### PR TITLE
Handle invalid GLB accessor data

### DIFF
--- a/viewer3d/loaderglb.cpp
+++ b/viewer3d/loaderglb.cpp
@@ -110,11 +110,17 @@ bool LoadGLB(const std::string& path, Mesh& outMesh)
         const auto& accs = doc["accessors"];
         if(idx >= accs.size()) return false;
         const auto& acc = accs[idx];
+        if(!acc.contains("componentType") || !acc["componentType"].is_number_integer())
+            return false;
+        if(!acc.contains("type") || !acc["type"].is_string())
+            return false;
+        if(!acc.contains("count") || !acc["count"].is_number_integer())
+            return false;
         compType = acc["componentType"].get<int>();
         type = acc["type"].get<std::string>();
         count = acc["count"].get<size_t>();
         size_t accOffset = acc.value("byteOffset", 0);
-        if(!acc.contains("bufferView")) return false;
+        if(!acc.contains("bufferView") || !acc["bufferView"].is_number_integer()) return false;
         size_t viewIdx = acc["bufferView"].get<size_t>();
         if(!doc.contains("bufferViews")) return false;
         const auto& views = doc["bufferViews"];


### PR DESCRIPTION
## Summary
- validate GLB accessor fields before reading to prevent crashes when types are unexpected

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935c4db81d88324a6a691f8d194335b)