### PR TITLE
Handle config parse errors and clean up dataview models safely

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -376,8 +376,14 @@ bool ConfigManager::LoadFromFile(const std::string &path) {
   } catch (...) {
     return false;
   }
+  if (!j.is_object())
+    return false;
 
-  configData = j.get<std::unordered_map<std::string, std::string>>();
+  try {
+    configData = j.get<std::unordered_map<std::string, std::string>>();
+  } catch (...) {
+    return false;
+  }
   ApplyColumnDefaults();
   ApplyDefaults();
   return true;

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -76,8 +76,6 @@ FixtureTablePanel::FixtureTablePanel(wxWindow *parent)
 }
 
 FixtureTablePanel::~FixtureTablePanel() {
-  if (table)
-    table->AssociateModel(nullptr);
 }
 
 void FixtureTablePanel::InitializeTable() {

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -61,8 +61,6 @@ SceneObjectTablePanel::SceneObjectTablePanel(wxWindow* parent)
 
 SceneObjectTablePanel::~SceneObjectTablePanel()
 {
-    if (table)
-        table->AssociateModel(nullptr);
 }
 
 void SceneObjectTablePanel::InitializeTable()

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -70,8 +70,6 @@ TrussTablePanel::TrussTablePanel(wxWindow* parent)
 
 TrussTablePanel::~TrussTablePanel()
 {
-    if (table)
-        table->AssociateModel(nullptr);
 }
 
 void TrussTablePanel::InitializeTable()


### PR DESCRIPTION
## Summary
- guard configuration loading against invalid JSON shapes to prevent unhandled exceptions
- rely on wxDataViewListCtrl cleanup instead of manual disassociation to avoid double notifier removal

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935caa5a2508324a6ba737af9e869a7)