### PR TITLE
Fix layout save before destroying AUI manager

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -220,11 +220,12 @@ wxBEGIN_EVENT_TABLE(MainWindow, wxFrame) EVT_MENU(
 }
 
 MainWindow::~MainWindow() {
+  SaveCameraSettings();
   if (auiManager) {
     auiManager->UnInit();
     delete auiManager;
+    auiManager = nullptr;
   }
-  SaveCameraSettings();
   ConfigManager::Get().SaveUserConfig();
   ProjectUtils::SaveLastProjectPath(currentProjectPath);
 }


### PR DESCRIPTION
## Summary
- save camera and layout settings before tearing down the AUI manager to avoid use-after-free
- clear the manager pointer after deletion for safety during shutdown

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69361bb3d7048324a4018e6e03107526)