### PR TITLE
Stop 3D refresh thread before shutdown

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1267,6 +1267,9 @@ void MainWindow::OnCloseWindow(wxCloseEvent &event) {
     }
   }
 
+  if (viewportPanel)
+    viewportPanel->StopRefreshThread();
+
   Destroy();
 }
 

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -74,10 +74,16 @@ Viewer3DPanel::~Viewer3DPanel()
 {
     if (HasCapture())
         ReleaseMouse();
+    StopRefreshThread();
+    delete m_glContext;
+    SetInstance(nullptr);
+}
+
+void Viewer3DPanel::StopRefreshThread()
+{
     m_threadRunning = false;
     if (m_refreshThread.joinable())
         m_refreshThread.join();
-    delete m_glContext;
 }
 
 // Initializes OpenGL basic settings

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -41,6 +41,9 @@ public:
     Viewer3DPanel(wxWindow* parent);
     ~Viewer3DPanel();
 
+    // Stop the refresh thread. Safe to call multiple times.
+    void StopRefreshThread();
+
     // Loads camera parameters from ConfigManager (delayed initialization)
     void LoadCameraFromConfig();
 


### PR DESCRIPTION
## Summary
- add an explicit stop helper for the 3D viewer refresh thread
- stop the refresh loop during shutdown and clear the panel singleton pointer

## Testing
- cmake -S . -B build *(fails: missing wxWidgets dependencies)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69361c7a58fc83248c40361670a02b2b)