### PR TITLE
Fix wxDataView model ownership for tables

### DIFF
--- a/gui/fixturetablepanel.h
+++ b/gui/fixturetablepanel.h
@@ -48,7 +48,7 @@ public:
 private:
     friend class FixtureEditDialog; // allow dialog to access internals
 
-    ColorfulDataViewListStore store;
+    ColorfulDataViewListStore* store;
     wxDataViewListCtrl* table;
     std::vector<wxString> columnLabels;
     std::vector<wxString> gdtfPaths; // Stores full GDTF paths per row

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -32,10 +32,12 @@ static SceneObjectTablePanel* s_instance = nullptr;
 SceneObjectTablePanel::SceneObjectTablePanel(wxWindow* parent)
     : wxPanel(parent, wxID_ANY)
 {
+    store = new ColorfulDataViewListStore();
     wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
     table = new wxDataViewListCtrl(this, wxID_ANY, wxDefaultPosition,
                                    wxDefaultSize, wxDV_MULTIPLE | wxDV_ROW_LINES);
-    table->AssociateModel(&store);
+    table->AssociateModel(store);
+    store->DecRef();
 
     table->SetAlternateRowColour(wxColour(40, 40, 40));
 
@@ -61,6 +63,7 @@ SceneObjectTablePanel::SceneObjectTablePanel(wxWindow* parent)
 
 SceneObjectTablePanel::~SceneObjectTablePanel()
 {
+    store = nullptr;
 }
 
 void SceneObjectTablePanel::InitializeTable()
@@ -123,7 +126,7 @@ void SceneObjectTablePanel::ReloadData()
         row.push_back(pitch);
         row.push_back(yaw);
 
-        store.AppendItem(row, rowUuids.size());
+        store->AppendItem(row, rowUuids.size());
         rowUuids.push_back(uuid);
     }
 
@@ -452,9 +455,9 @@ void SceneObjectTablePanel::HighlightObject(const std::string& uuid)
     for (size_t i = 0; i < rowUuids.size(); ++i)
     {
         if (!uuid.empty() && rowUuids[i] == uuid)
-            store.SetRowBackgroundColour(i, wxColour(0, 200, 0));
+            store->SetRowBackgroundColour(i, wxColour(0, 200, 0));
         else
-            store.ClearRowBackground(i);
+            store->ClearRowBackground(i);
     }
     table->Refresh();
 }
@@ -536,10 +539,10 @@ void SceneObjectTablePanel::ResyncRows(const std::vector<std::string>& oldOrder,
     for (unsigned int i = 0; i < count; ++i)
     {
         wxDataViewItem it = table->RowToItem(i);
-        unsigned long idx = store.GetItemData(it);
+        unsigned long idx = store->GetItemData(it);
         if (idx < oldOrder.size())
             newOrder[i] = oldOrder[idx];
-        store.SetItemData(it, i);
+        store->SetItemData(it, i);
     }
     rowUuids.swap(newOrder);
 

--- a/gui/sceneobjecttablepanel.h
+++ b/gui/sceneobjecttablepanel.h
@@ -44,7 +44,7 @@ public:
     void UpdateSceneData();
 
 private:
-    ColorfulDataViewListStore store;
+    ColorfulDataViewListStore* store;
     wxDataViewListCtrl* table;
     std::vector<wxString> columnLabels;
     std::vector<std::string> rowUuids;

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -41,10 +41,12 @@ namespace fs = std::filesystem;
 TrussTablePanel::TrussTablePanel(wxWindow* parent)
     : wxPanel(parent, wxID_ANY)
 {
+    store = new ColorfulDataViewListStore();
     wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
     table = new wxDataViewListCtrl(this, wxID_ANY, wxDefaultPosition,
                                    wxDefaultSize, wxDV_MULTIPLE | wxDV_ROW_LINES);
-    table->AssociateModel(&store);
+    table->AssociateModel(store);
+    store->DecRef();
 
     table->SetAlternateRowColour(wxColour(40, 40, 40));
 
@@ -70,6 +72,7 @@ TrussTablePanel::TrussTablePanel(wxWindow* parent)
 
 TrussTablePanel::~TrussTablePanel()
 {
+    store = nullptr;
 }
 
 void TrussTablePanel::InitializeTable()
@@ -182,7 +185,7 @@ void TrussTablePanel::ReloadData()
         row.push_back(hei);
         row.push_back(weight);
 
-        store.AppendItem(row, rowUuids.size());
+        store->AppendItem(row, rowUuids.size());
         rowUuids.push_back(uuid);
     }
 
@@ -742,9 +745,9 @@ void TrussTablePanel::HighlightTruss(const std::string& uuid)
     for (size_t i = 0; i < rowUuids.size(); ++i)
     {
         if (!uuid.empty() && rowUuids[i] == uuid)
-            store.SetRowBackgroundColour(i, wxColour(0, 200, 0));
+            store->SetRowBackgroundColour(i, wxColour(0, 200, 0));
         else
-            store.ClearRowBackground(i);
+            store->ClearRowBackground(i);
     }
     table->Refresh();
 }
@@ -832,7 +835,7 @@ void TrussTablePanel::ResyncRows(const std::vector<std::string>& oldOrder,
     for (unsigned int i = 0; i < count; ++i)
     {
         wxDataViewItem it = table->RowToItem(i);
-        unsigned long idx = store.GetItemData(it);
+        unsigned long idx = store->GetItemData(it);
         if (idx < oldOrder.size()) {
             newOrder[i] = oldOrder[idx];
             if (idx < modelPaths.size())
@@ -840,7 +843,7 @@ void TrussTablePanel::ResyncRows(const std::vector<std::string>& oldOrder,
             if (idx < symbolPaths.size())
                 newSymPaths[i] = symbolPaths[idx];
         }
-        store.SetItemData(it, i);
+        store->SetItemData(it, i);
     }
     rowUuids.swap(newOrder);
     modelPaths.swap(newPaths);

--- a/gui/trusstablepanel.h
+++ b/gui/trusstablepanel.h
@@ -44,7 +44,7 @@ public:
     void UpdateSceneData();
 
 private:
-    ColorfulDataViewListStore store;
+    ColorfulDataViewListStore* store;
     wxDataViewListCtrl* table;
     std::vector<wxString> columnLabels;
     std::vector<std::string> rowUuids;


### PR DESCRIPTION
## Summary
- allocate dataview list store models dynamically for fixture, truss, and scene object tables
- hand off ownership to the corresponding wxDataViewListCtrl instances to avoid notifier issues during teardown

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69361e44d0148324b65dc60f347a69d1)