### PR TITLE
Fix GDTF loader zip extraction build errors

### DIFF
--- a/viewer3d/gdtfloader.cpp
+++ b/viewer3d/gdtfloader.cpp
@@ -63,6 +63,8 @@ struct GdtfCacheEntry
 
 static std::unordered_map<std::string, GdtfCacheEntry> g_gdtfCache;
 
+static bool ExtractZip(const std::string& zipPath, const std::string& destDir);
+
 static std::string ToLower(const std::string& s)
 {
     std::string t = s;
@@ -138,8 +140,10 @@ struct TempExtraction
 
     ~TempExtraction()
     {
-        if (!dir.empty())
-            fs::remove_all(dir, std::error_code());
+        if (!dir.empty()) {
+            std::error_code ec;
+            fs::remove_all(dir, ec);
+        }
     }
 
     bool IsValid() const { return extracted; }


### PR DESCRIPTION
## Summary
- add forward declaration for ExtractZip before use in TempExtraction
- fix temporary directory cleanup to use reusable error_code when removing files

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693626a8353883248a9f958d1e2cc6f2)