### PR TITLE
Enable dictionary application during MVR import

### DIFF
--- a/mvr/mvrimporter.h
+++ b/mvr/mvrimporter.h
@@ -28,14 +28,14 @@ public:
     // Set applyDictionary=true to resolve GDTF conflicts using the dictionary
     bool ImportFromFile(const std::string& filePath,
                         bool promptConflicts = true,
-                        bool applyDictionary = false);
+                        bool applyDictionary = true);
 
     // Static interface for use outside the import module (e.g. GUI)
     // Allows the caller to decide whether dictionary conflicts should prompt
     // or whether the dictionary should be applied at all
     static bool ImportAndRegister(const std::string& filePath,
                                   bool promptConflicts = true,
-                                  bool applyDictionary = false);
+                                  bool applyDictionary = true);
 
 private:
     // Creates a temporary directory for extracting the contents of the MVR archive


### PR DESCRIPTION
## Summary
- default MVR imports now apply the GDTF dictionary automatically when available

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69362d791884832493f85213cc94fbf1)