### PR TITLE
Reduce noisy loader logs

### DIFF
--- a/viewer3d/loader3ds.cpp
+++ b/viewer3d/loader3ds.cpp
@@ -21,6 +21,8 @@
 #include "consolepanel.h"
 #include <wx/wx.h>
 
+constexpr bool kLog3dsMessages = false;
+
 struct Chunk {
     uint16_t id;
     uint32_t length;
@@ -126,7 +128,7 @@ bool Load3DS(const std::string& path, Mesh& outMesh)
     bool ok = !outMesh.vertices.empty() && !outMesh.indices.empty();
     if (ok)
         ComputeNormals(outMesh);
-    if (ConsolePanel::Instance()) {
+    if (kLog3dsMessages && ConsolePanel::Instance()) {
         if (ok) {
             wxString msg = wxString::Format("3DS: %s -> v=%zu i=%zu",
                                            wxString::FromUTF8(path),

--- a/viewer3d/loaderglb.cpp
+++ b/viewer3d/loaderglb.cpp
@@ -26,6 +26,8 @@
 #include <wx/wx.h>
 #include <optional>
 
+constexpr bool kLogGlbMessages = false;
+
 using json = nlohmann::json;
 
 // glTF specification defines distances in meters whereas MVR expects
@@ -131,7 +133,7 @@ bool LoadGLB(const std::string& path, Mesh& outMesh)
     std::string parseError;
     auto glbFile = ParseGLBFile(path, parseError);
     if (!glbFile) {
-        if (ConsolePanel::Instance()) {
+        if (kLogGlbMessages && ConsolePanel::Instance()) {
             ConsolePanel::Instance()->AppendMessage(
                 wxString::Format("GLB: %s (se omite carga - %s)",
                                  wxString::FromUTF8(path),
@@ -440,7 +442,7 @@ bool LoadGLB(const std::string& path, Mesh& outMesh)
     if (ok)
         ComputeNormals(outMesh);
 
-    if(ConsolePanel::Instance()) {
+    if(kLogGlbMessages && ConsolePanel::Instance()) {
         wxString msg;
         if(ok) {
             msg = wxString::Format("GLB: %s -> v=%zu i=%zu",


### PR DESCRIPTION
## Summary
- avoid repeated GDTF load failure logs by remembering previously failed files
- add switches to silence verbose 3DS and GLB loader output by default while keeping the messages available

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936316fe57c8324aab3b49d8a5a06d8)