### PR TITLE
Group repeated console logs

### DIFF
--- a/gui/consolepanel.cpp
+++ b/gui/consolepanel.cpp
@@ -62,7 +62,21 @@ ConsolePanel::ConsolePanel(wxWindow *parent) : wxPanel(parent, wxID_ANY) {
 void ConsolePanel::AppendMessage(const wxString &msg) {
   if (!m_textCtrl)
     return;
-  m_textCtrl->AppendText(msg + "\n");
+
+  if (msg == m_lastMessage) {
+    m_repeatCount++;
+    wxString combined = wxString::Format("%s (repeated %zu times)", msg,
+                                        m_repeatCount);
+    long endPos = m_textCtrl->GetLastPosition();
+    if (m_lastLineStart < endPos)
+      m_textCtrl->Remove(m_lastLineStart, endPos);
+    m_textCtrl->AppendText(combined + "\n");
+  } else {
+    m_lastMessage = msg;
+    m_repeatCount = 1;
+    m_lastLineStart = m_textCtrl->GetLastPosition();
+    m_textCtrl->AppendText(msg + "\n");
+  }
   if (m_autoScroll)
     m_textCtrl->ShowPosition(m_textCtrl->GetLastPosition());
 }

--- a/gui/consolepanel.h
+++ b/gui/consolepanel.h
@@ -38,6 +38,9 @@ private:
     wxTextCtrl* m_textCtrl = nullptr;
     wxTextCtrl* m_inputCtrl = nullptr;
     bool m_autoScroll = true;
+    wxString m_lastMessage;
+    size_t m_repeatCount = 0;
+    long m_lastLineStart = 0;
     std::vector<wxString> m_history;
     size_t m_historyIndex = 0;
     void OnScroll(wxScrollWinEvent& event);


### PR DESCRIPTION
## Summary
- track the last console message and count repeats
- replace repeated lines with a single entry indicating the number of occurrences to reduce spam

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69363b6ece848324891f820a914488b4)