### PR TITLE
Add project root include path for viewer2d headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES WIN32_EXECUTABLE TRUE)
 
 # Include project directories
 target_include_directories(${PROJECT_NAME} PRIVATE
+    ${CMAKE_SOURCE_DIR}
     ${CMAKE_SOURCE_DIR}/gui
     ${CMAKE_SOURCE_DIR}/models
     ${CMAKE_SOURCE_DIR}/core


### PR DESCRIPTION
## Summary
- add the project root directory to target include paths so prefixed viewer2d headers resolve correctly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69364509f80c832485286807894d49a7)