### PR TITLE
Fix Windows OpenGL includes for 2D canvas

### DIFF
--- a/viewer2d/canvas2d.cpp
+++ b/viewer2d/canvas2d.cpp
@@ -18,6 +18,12 @@
 
 #include "canvas2d.h"
 
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#endif
+
 #include <GL/gl.h>
 #include <wx/glcanvas.h>
 #include <cmath>


### PR DESCRIPTION
## Summary
- include Windows headers before OpenGL headers in the 2D canvas to provide APIENTRY definitions on Windows

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936476cbc788324a2de64e4636a9bfd)