### PR TITLE
Fix DrawText macro conflict on Windows

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -26,6 +26,7 @@
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #include <windows.h>
+#undef DrawText // Avoid conflict with Windows GDI macro of the same name
 #endif
 
 #include <GL/glew.h>


### PR DESCRIPTION
## Summary
- undefine the Windows GDI DrawText macro to avoid conflicts with the ICanvas2D interface

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69364814d99c8324a3fa735a22056e85)