### PR TITLE
Avoid reloading failed GDTF files

### DIFF
--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -192,6 +192,10 @@ private:
 
   // Cache of loaded GDTF models indexed by absolute file path
   std::unordered_map<std::string, std::vector<GdtfObject>> m_loadedGdtf;
+  // Cache of failed GDTF loads with their failure reason, indexed by absolute
+  // file path
+  std::unordered_map<std::string, std::string> m_failedGdtfReasons;
+  std::string m_lastSceneBasePath;
 
   struct BoundingBox {
     std::array<float, 3> min;


### PR DESCRIPTION
## Summary
- add a cache for failed GDTF loads with the reported reason
- skip fixtures whose GDTF already failed to load in the current session
- reset the failed cache when the scene base path changes alongside loaded GDTFs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937009ebfcc8324989a8dcfaf5862bc)