### PR TITLE
Aggregate GDTF load errors for fixtures

### DIFF
--- a/tests/gdtfloader.h
+++ b/tests/gdtfloader.h
@@ -21,7 +21,7 @@
 #include "../viewer3d/mesh.h"
 #include "../models/types.h"
 struct GdtfObject { Mesh mesh; Matrix transform; };
-bool LoadGdtf(const std::string&, std::vector<GdtfObject>&);
+bool LoadGdtf(const std::string&, std::vector<GdtfObject>&, std::string* outError = nullptr);
 int GetGdtfModeChannelCount(const std::string&, const std::string&);
 std::string GetGdtfFixtureName(const std::string& gdtfPath);
 std::string GetGdtfModelColor(const std::string& gdtfPath);

--- a/tests/gdtfloader_onech_stub.cpp
+++ b/tests/gdtfloader_onech_stub.cpp
@@ -22,6 +22,8 @@
 
 struct GdtfObject { Mesh mesh; Matrix transform; };
 
-bool LoadGdtf(const std::string&, std::vector<GdtfObject>&) { return false; }
+bool LoadGdtf(const std::string&, std::vector<GdtfObject>&, std::string*) {
+    return false;
+}
 int GetGdtfModeChannelCount(const std::string&, const std::string&) { return 1; }
 std::string GetGdtfFixtureName(const std::string& gdtfPath) { return gdtfPath; }

--- a/tests/gdtfloader_stub.cpp
+++ b/tests/gdtfloader_stub.cpp
@@ -22,7 +22,9 @@
 
 struct GdtfObject { Mesh mesh; Matrix transform; };
 
-bool LoadGdtf(const std::string&, std::vector<GdtfObject>&) { return false; }
+bool LoadGdtf(const std::string&, std::vector<GdtfObject>&, std::string*) {
+    return false;
+}
 int GetGdtfModeChannelCount(const std::string&, const std::string&) { return 0; }
 std::string GetGdtfFixtureName(const std::string& gdtfPath) { return gdtfPath; }
 std::string GetGdtfModelColor(const std::string& gdtfPath) { return "#000000"; }

--- a/viewer3d/gdtfloader.h
+++ b/viewer3d/gdtfloader.h
@@ -45,7 +45,9 @@ struct GdtfChannelInfo {
 };
 
 // Loads the models defined in a GDTF file. Returns true on success.
-bool LoadGdtf(const std::string& gdtfPath, std::vector<GdtfObject>& outObjects);
+bool LoadGdtf(const std::string& gdtfPath,
+              std::vector<GdtfObject>& outObjects,
+              std::string* outError = nullptr);
 
 // Returns the number of DMX addresses used by the given mode in a GDTF file.
 // Channels using more than one byte contribute multiple addresses to this


### PR DESCRIPTION
## Summary
- expose optional error details from LoadGdtf instead of logging failures directly
- collect fixture GDTF loading errors before logging and aggregate duplicates
- maintain cached failure reasons for reuse and consolidated reporting

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693702fc05d48324986d2521b6bf8cd6)