### PR TITLE
Avoid repeating GDTF failure logs in viewer

### DIFF
--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -195,6 +195,10 @@ private:
   // Cache of failed GDTF loads with their failure reason, indexed by absolute
   // file path
   std::unordered_map<std::string, std::string> m_failedGdtfReasons;
+  // Tracks the last reported fixture counts per failed GDTF path to avoid
+  // repeating identical console messages every update
+  std::unordered_map<std::string, size_t> m_reportedGdtfFailureCounts;
+  std::unordered_map<std::string, std::string> m_reportedGdtfFailureReasons;
   std::string m_lastSceneBasePath;
 
   struct BoundingBox {


### PR DESCRIPTION
## Summary
- avoid logging the same GDTF load failure on every scene update
- track the last reported reason and fixture count per failed GDTF to suppress duplicates

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693707ded50c832484ed2f1bcea05937)