### PR TITLE
Prompt to save unsaved changes before closing or replacing projects

### DIFF
--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -123,6 +123,8 @@ private:
   void ApplySavedLayout();
   void UpdateViewMenuChecks();
   void SyncSceneData();
+  bool ConfirmSaveIfDirty(const wxString &actionLabel,
+                          const wxString &dialogTitle);
   std::string defaultLayoutPerspective;
   std::string default2DLayoutPerspective;
 


### PR DESCRIPTION
## Summary
- centralize unsaved-change confirmations into a reusable helper
- ensure projects mark a clean state after loading or resetting for accurate change tracking
- reuse the confirmation flow when creating, loading, or exiting projects

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69370ecbbb8c8324a5c2b222fc552d91)