### PR TITLE
Track unsaved changes when configuration updates

### DIFF
--- a/core/configmanager.h
+++ b/core/configmanager.h
@@ -146,5 +146,7 @@ private:
     size_t revision = 0;
     size_t savedRevision = 0;
 
+    bool suppressRevision = false;
+
     std::string currentLayer = DEFAULT_LAYER_NAME;
 };


### PR DESCRIPTION
## Summary
- guard initialization and loading so default configuration changes do not affect the dirty state
- bump the revision counter when configuration values change, are removed, or cleared to ensure unsaved prompts appear

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937113e6c20832492a37ee5d6ade852)