### PR TITLE
Fix revision suppression guard access

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -29,22 +29,14 @@ class wxZipStreamLink;
 #include <wx/stdpaths.h>
 #include <wx/zipstrm.h>
 
-namespace {
+ConfigManager::RevisionGuard::RevisionGuard(ConfigManager &cfg)
+    : cfg(cfg), previous(cfg.suppressRevision) {
+  cfg.suppressRevision = true;
+}
 
-class RevisionGuard {
-public:
-  explicit RevisionGuard(ConfigManager &cfg)
-      : cfg(cfg), previous(cfg.suppressRevision) {
-    cfg.suppressRevision = true;
-  }
-  ~RevisionGuard() { cfg.suppressRevision = previous; }
-
-private:
-  ConfigManager &cfg;
-  bool previous;
-};
-
-} // namespace
+ConfigManager::RevisionGuard::~RevisionGuard() {
+  cfg.suppressRevision = previous;
+}
 
 static std::vector<std::string> SplitCSV(const std::string &s) {
   std::vector<std::string> result;

--- a/core/configmanager.h
+++ b/core/configmanager.h
@@ -116,6 +116,16 @@ public:
     void MarkSaved();
 
 private:
+    class RevisionGuard {
+    public:
+        explicit RevisionGuard(ConfigManager &cfg);
+        ~RevisionGuard();
+
+    private:
+        ConfigManager &cfg;
+        bool previous;
+    };
+
     ConfigManager();
     ConfigManager(const ConfigManager&) = delete;
     ConfigManager& operator=(const ConfigManager&) = delete;


### PR DESCRIPTION
## Summary
- move RevisionGuard inside ConfigManager so it can access the suppression flag
- keep revision suppression state changes encapsulated within ConfigManager

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937126ab624832490b6b9d26b16a3a7)