### PR TITLE
Ensure uuid utility source always builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ find_package(nanovg CONFIG REQUIRED)
 find_package(podofo CONFIG REQUIRED)
 
 # Gather source files
-file(GLOB_RECURSE SRC_FILES
+file(GLOB_RECURSE SRC_FILES CONFIGURE_DEPENDS
     ${CMAKE_SOURCE_DIR}/main.cpp
     ${CMAKE_SOURCE_DIR}/gui/*.cpp
     ${CMAKE_SOURCE_DIR}/models/*.cpp
@@ -29,6 +29,7 @@ file(GLOB_RECURSE SRC_FILES
 
 # Explicitly ensure markdown conversion source is included
 list(APPEND SRC_FILES ${CMAKE_SOURCE_DIR}/core/markdown.cpp)
+list(APPEND SRC_FILES ${CMAKE_SOURCE_DIR}/core/uuidutils.cpp)
 
 # On Windows, include application icon resources
 if (WIN32)


### PR DESCRIPTION
## Summary
- add CONFIGURE_DEPENDS to source globs so new files are picked up on reconfigure
- explicitly append core/uuidutils.cpp to the executable sources to resolve missing symbol errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693730046a548324b8723ab56b2de181)