### PR TITLE
Preserve hang position edits

### DIFF
--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -1144,6 +1144,11 @@ void FixtureTablePanel::UpdateSceneData() {
     else
       it->second.layer = layerStr;
 
+    table->GetValue(v, i, 4);
+    it->second.positionName = std::string(v.GetString().ToUTF8());
+    if (!it->second.position.empty())
+      scene.positions[it->second.position] = it->second.positionName;
+
     table->GetValue(v, i, 5);
     long uni = v.GetLong();
 

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -607,6 +607,8 @@ void TrussTablePanel::UpdateSceneData()
         }
         table->GetValue(v, i, 3);
         it->second.positionName = std::string(v.GetString().mb_str());
+        if (!it->second.position.empty())
+            scene.positions[it->second.position] = it->second.positionName;
 
         double x=0, y=0, z=0;
         table->GetValue(v, i, 4); v.GetString().ToDouble(&x);


### PR DESCRIPTION
## Summary
- read hang position changes from the fixture table and propagate them to the scene positions map
- sync truss hang position edits with stored positions so exports keep the updated names

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69373623eae08324a17e94e65b217c1b)