### PR TITLE
Improve library path handling for debug and release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@
 *.userosscache
 *.sln.docstates
 
+# Perastage user data outside the repository
+Perastage/library/
+*/Perastage/library/
+
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 

--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -32,9 +32,16 @@ static fs::path GetDictFile() {
   fs::create_directories(dir);
   fs::path file = dir / "gdtf_dictionary.json";
   if (!fs::exists(file)) {
-    std::ofstream create(file);
-    if (create.is_open())
-      create << "{}";
+    fs::path baseLib = ProjectUtils::GetBaseLibraryPath("fixtures");
+    fs::path baseFile = baseLib / "gdtf_dictionary.json";
+    std::error_code ec;
+    if (fs::exists(baseFile))
+      fs::copy_file(baseFile, file, fs::copy_options::overwrite_existing, ec);
+    if (!fs::exists(file)) {
+      std::ofstream create(file);
+      if (create.is_open())
+        create << "{}";
+    }
   }
   return file;
 }

--- a/core/projectutils.h
+++ b/core/projectutils.h
@@ -17,8 +17,9 @@
  */
 #pragma once
 
-#include <string>
+#include <filesystem>
 #include <optional>
+#include <string>
 
 namespace ProjectUtils {
     inline constexpr const char* PROJECT_EXTENSION = ".pstg";
@@ -26,6 +27,9 @@ namespace ProjectUtils {
     std::string GetLastProjectPathFile();
     bool SaveLastProjectPath(const std::string& path);
     std::optional<std::string> LoadLastProjectPath();
+
+    // Path containing the built-in library shipped with the executable.
+    std::filesystem::path GetBaseLibraryPath(const std::string& subdir);
 
     // Returns the path to a library subdirectory if it exists, otherwise empty.
     std::string GetDefaultLibraryPath(const std::string& subdir);

--- a/core/trussdictionary.cpp
+++ b/core/trussdictionary.cpp
@@ -32,9 +32,16 @@ static fs::path GetDictFile() {
   fs::create_directories(dir);
   fs::path file = dir / "truss_dictionary.json";
   if (!fs::exists(file)) {
-    std::ofstream create(file);
-    if (create.is_open())
-      create << "{}";
+    fs::path baseLib = ProjectUtils::GetBaseLibraryPath("trusses");
+    fs::path baseFile = baseLib / "truss_dictionary.json";
+    std::error_code ec;
+    if (fs::exists(baseFile))
+      fs::copy_file(baseFile, file, fs::copy_options::overwrite_existing, ec);
+    if (!fs::exists(file)) {
+      std::ofstream create(file);
+      if (create.is_open())
+        create << "{}";
+    }
   }
   return file;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,10 @@ find_package(tinyxml2 CONFIG REQUIRED)
 
 enable_testing()
 
+function(set_library_env TEST_NAME)
+    set_tests_properties(${TEST_NAME} PROPERTIES ENVIRONMENT "PERASTAGE_LIBRARY_PATH=${CMAKE_SOURCE_DIR}/library")
+endfunction()
+
 if(TARGET podofo::podofo)
     add_executable(pdf_text_test pdf_text_test.cpp ../core/pdftext.cpp)
     target_link_libraries(pdf_text_test PRIVATE podofo::podofo ${wxWidgets_LIBRARIES})
@@ -18,6 +22,7 @@ if(TARGET podofo::podofo)
              COMMAND pdf_text_test
              ${CMAKE_CURRENT_SOURCE_DIR}/data/simple.pdf
              ${CMAKE_CURRENT_SOURCE_DIR}/data/translated.pdf)
+    set_library_env(PdfTextComparison)
 endif()
 
 add_executable(autopatcher_test autopatcher_test.cpp
@@ -25,12 +30,14 @@ add_executable(autopatcher_test autopatcher_test.cpp
                ../core/patchmanager.cpp)
 target_include_directories(autopatcher_test PRIVATE ../core ../models ../viewer3d)
 add_test(NAME AutoPatchTypeGrouping COMMAND autopatcher_test)
+set_library_env(AutoPatchTypeGrouping)
 
 add_executable(autopatcher_grouping_test autopatcher_grouping_test.cpp
                ../core/autopatcher.cpp
                ../core/patchmanager.cpp)
 target_include_directories(autopatcher_grouping_test PRIVATE ../core ../models ../viewer3d)
 add_test(NAME AutoPatchGroupIntegrity COMMAND autopatcher_grouping_test)
+set_library_env(AutoPatchGroupIntegrity)
 
 add_executable(save_load_roundtrip_test save_load_roundtrip_test.cpp
                ../core/configmanager.cpp
@@ -52,6 +59,7 @@ target_include_directories(save_load_roundtrip_test PRIVATE
 target_link_libraries(save_load_roundtrip_test PRIVATE
                       ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
 add_test(NAME SaveLoadRoundtrip COMMAND save_load_roundtrip_test)
+set_library_env(SaveLoadRoundtrip)
 
 add_executable(rider_save_roundtrip_test rider_save_roundtrip_test.cpp
                pdftext_stub.cpp
@@ -79,6 +87,7 @@ target_include_directories(rider_save_roundtrip_test PRIVATE
 target_link_libraries(rider_save_roundtrip_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
 add_test(NAME RiderSaveRoundtrip COMMAND rider_save_roundtrip_test
          ${CMAKE_CURRENT_SOURCE_DIR}/data/rider_fixtureid_basic.txt)
+set_library_env(RiderSaveRoundtrip)
 
 add_executable(riderimporter_fixtureid_test rider_import_fixtureid_test.cpp
                riderimporter_stubs.cpp
@@ -100,6 +109,7 @@ target_link_libraries(riderimporter_fixtureid_test PRIVATE ${wxWidgets_LIBRARIES
 add_test(NAME RiderImporterFixtureIds COMMAND riderimporter_fixtureid_test
          ${CMAKE_CURRENT_SOURCE_DIR}/data/rider_fixtureid_basic.txt
          ${CMAKE_CURRENT_SOURCE_DIR}/data/rider_fixtureid_over100.txt)
+set_library_env(RiderImporterFixtureIds)
 
 add_executable(rider_import_order_test rider_import_order_test.cpp
                riderimporter_stubs.cpp
@@ -120,6 +130,7 @@ target_include_directories(rider_import_order_test PRIVATE
 target_link_libraries(rider_import_order_test PRIVATE ${wxWidgets_LIBRARIES})
 add_test(NAME RiderImportOrder COMMAND rider_import_order_test
          ${CMAKE_CURRENT_SOURCE_DIR}/data/rider_fixture_order.txt)
+set_library_env(RiderImportOrder)
 
 add_executable(rider_autopatch_test rider_autopatch_test.cpp
                riderimporter_stubs.cpp
@@ -140,6 +151,7 @@ target_include_directories(rider_autopatch_test PRIVATE
 target_link_libraries(rider_autopatch_test PRIVATE ${wxWidgets_LIBRARIES})
 add_test(NAME RiderAutoPatch COMMAND rider_autopatch_test
          ${CMAKE_CURRENT_SOURCE_DIR}/data/rider_fixtureid_basic.txt)
+set_library_env(RiderAutoPatch)
 
 add_executable(rider_layer_mode_test rider_layer_mode_test.cpp
                riderimporter_stubs.cpp
@@ -160,3 +172,4 @@ target_include_directories(rider_layer_mode_test PRIVATE
 target_link_libraries(rider_layer_mode_test PRIVATE ${wxWidgets_LIBRARIES})
 add_test(NAME RiderLayerMode COMMAND rider_layer_mode_test
          ${CMAKE_CURRENT_SOURCE_DIR}/data/rider_layer_mode.txt)
+set_library_env(RiderLayerMode)


### PR DESCRIPTION
## Summary
- add environment override and release/user-copy behavior for library paths
- seed fixture and truss dictionaries from bundled library when missing
- configure tests to use repository library path and ignore user library copies

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69374421012483248099ae153da282ea)