### PR TITLE
Add rigging panel summarizing positions

### DIFF
--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -34,6 +34,7 @@ class Viewer2DRenderPanel;
 class ConsolePanel;
 class LayerPanel;
 class SummaryPanel;
+class RiggingPanel;
 
 // Main application window for GUI components
 class MainWindow : public wxFrame {
@@ -69,6 +70,7 @@ private:
   ConsolePanel *consolePanel = nullptr;
   LayerPanel *layerPanel = nullptr;
   SummaryPanel *summaryPanel = nullptr;
+  RiggingPanel *riggingPanel = nullptr;
 
   wxAcceleratorTable m_accel;
 
@@ -98,6 +100,7 @@ private:
   void OnToggleRender2D(wxCommandEvent &event);       // Toggle 2D render panel
   void OnToggleLayers(wxCommandEvent &event);         // Toggle layer panel
   void OnToggleSummary(wxCommandEvent &event);        // Toggle summary panel
+  void OnToggleRigging(wxCommandEvent &event);        // Toggle rigging panel
   void OnShowHelp(wxCommandEvent &event);             // Show help dialog
   void OnShowAbout(wxCommandEvent &event);            // Show about dialog
   void OnSelectFixtures(wxCommandEvent &event);       // Switch to fixtures tab
@@ -105,6 +108,7 @@ private:
   void OnSelectObjects(wxCommandEvent &event);        // Switch to objects tab
   void OnNotebookPageChanged(wxBookCtrlEvent &event); // Update summary panel
   void RefreshSummary();                              // Refresh summary counts
+  void RefreshRigging();                              // Refresh rigging summary
 
   void OnPreferences(wxCommandEvent &event);        // Show preferences dialog
   void OnApplyDefaultLayout(wxCommandEvent &event); // Reset to default layout
@@ -151,6 +155,7 @@ enum {
   ID_View_ToggleRender2D,
   ID_View_ToggleLayers,
   ID_View_ToggleSummary,
+  ID_View_ToggleRigging,
   ID_View_Layout_Default,
   ID_View_Layout_2D,
   ID_Tools_DownloadGdtf,

--- a/gui/riggingpanel.cpp
+++ b/gui/riggingpanel.cpp
@@ -1,0 +1,97 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "riggingpanel.h"
+
+#include <map>
+#include <string>
+
+#include "configmanager.h"
+
+namespace {
+constexpr const char *UNASSIGNED_POSITION = "Unassigned";
+}
+
+static RiggingPanel *s_instance = nullptr;
+
+RiggingPanel::RiggingPanel(wxWindow *parent) : wxPanel(parent, wxID_ANY) {
+  table = new wxDataViewListCtrl(this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
+                                 wxDV_ROW_LINES | wxDV_VERT_RULES);
+  table->AppendTextColumn("Position", wxDATAVIEW_CELL_INERT, 160, wxALIGN_LEFT,
+                          wxDATAVIEW_COL_RESIZABLE);
+  table->AppendTextColumn("Fixtures", wxDATAVIEW_CELL_INERT, 80, wxALIGN_RIGHT,
+                          wxDATAVIEW_COL_RESIZABLE);
+  table->AppendTextColumn("Trusses", wxDATAVIEW_CELL_INERT, 80, wxALIGN_RIGHT,
+                          wxDATAVIEW_COL_RESIZABLE);
+  table->AppendTextColumn("Fixture Weight (kg)", wxDATAVIEW_CELL_INERT, 150,
+                          wxALIGN_RIGHT, wxDATAVIEW_COL_RESIZABLE);
+  table->AppendTextColumn("Truss Weight (kg)", wxDATAVIEW_CELL_INERT, 150,
+                          wxALIGN_RIGHT, wxDATAVIEW_COL_RESIZABLE);
+  table->AppendTextColumn("Total Weight (kg)", wxDATAVIEW_CELL_INERT, 150,
+                          wxALIGN_RIGHT, wxDATAVIEW_COL_RESIZABLE);
+
+  auto *sizer = new wxBoxSizer(wxVERTICAL);
+  sizer->Add(table, 1, wxEXPAND | wxALL, 5);
+  SetSizer(sizer);
+}
+
+RiggingPanel *RiggingPanel::Instance() { return s_instance; }
+
+void RiggingPanel::SetInstance(RiggingPanel *panel) { s_instance = panel; }
+
+void RiggingPanel::RefreshData() {
+  if (!table)
+    return;
+
+  struct Totals {
+    int fixtures = 0;
+    int trusses = 0;
+    float fixtureWeight = 0.0f;
+    float trussWeight = 0.0f;
+  };
+
+  std::map<std::string, Totals> rows;
+  const auto &scene = ConfigManager::Get().GetScene();
+  for (const auto &[uuid, fixture] : scene.fixtures) {
+    std::string pos = fixture.positionName.empty() ? UNASSIGNED_POSITION
+                                                   : fixture.positionName;
+    auto &entry = rows[pos];
+    entry.fixtures++;
+    entry.fixtureWeight += fixture.weightKg;
+  }
+
+  for (const auto &[uuid, truss] : scene.trusses) {
+    std::string pos = truss.positionName.empty() ? UNASSIGNED_POSITION
+                                                 : truss.positionName;
+    auto &entry = rows[pos];
+    entry.trusses++;
+    entry.trussWeight += truss.weightKg;
+  }
+
+  table->DeleteAllItems();
+  for (const auto &[position, totals] : rows) {
+    float totalWeight = totals.fixtureWeight + totals.trussWeight;
+    wxVector<wxVariant> row;
+    row.push_back(wxString::FromUTF8(position));
+    row.push_back(wxString::Format("%d", totals.fixtures));
+    row.push_back(wxString::Format("%d", totals.trusses));
+    row.push_back(wxString::Format("%.2f", totals.fixtureWeight));
+    row.push_back(wxString::Format("%.2f", totals.trussWeight));
+    row.push_back(wxString::Format("%.2f", totalWeight));
+    table->AppendItem(row);
+  }
+}

--- a/gui/riggingpanel.h
+++ b/gui/riggingpanel.h
@@ -1,0 +1,35 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <wx/dataview.h>
+#include <wx/wx.h>
+
+// Panel that summarizes rigging information grouped by position
+class RiggingPanel : public wxPanel {
+public:
+  explicit RiggingPanel(wxWindow *parent);
+
+  void RefreshData();
+
+  static RiggingPanel *Instance();
+  static void SetInstance(RiggingPanel *panel);
+
+private:
+  wxDataViewListCtrl *table = nullptr;
+};


### PR DESCRIPTION
## Summary
- add a Rigging panel that groups fixtures and trusses by position with counts and weight totals
- integrate the new panel into the View menu and default layouts with saved state
- refresh rigging data alongside existing summary updates

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69374ebbb27c8324b411e4f452e4a147)