### PR TITLE
Improve rigging panel column sizing and highlighting

### DIFF
--- a/gui/riggingpanel.cpp
+++ b/gui/riggingpanel.cpp
@@ -20,6 +20,7 @@
 #include <map>
 #include <string>
 
+#include "colorstore.h"
 #include "configmanager.h"
 
 namespace {
@@ -29,20 +30,26 @@ constexpr const char *UNASSIGNED_POSITION = "Unassigned";
 static RiggingPanel *s_instance = nullptr;
 
 RiggingPanel::RiggingPanel(wxWindow *parent) : wxPanel(parent, wxID_ANY) {
+  store = new ColorfulDataViewListStore();
   table = new wxDataViewListCtrl(this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
                                  wxDV_ROW_LINES | wxDV_VERT_RULES);
-  table->AppendTextColumn("Position", wxDATAVIEW_CELL_INERT, 160, wxALIGN_LEFT,
-                          wxDATAVIEW_COL_RESIZABLE);
-  table->AppendTextColumn("Fixtures", wxDATAVIEW_CELL_INERT, 80, wxALIGN_RIGHT,
-                          wxDATAVIEW_COL_RESIZABLE);
-  table->AppendTextColumn("Trusses", wxDATAVIEW_CELL_INERT, 80, wxALIGN_RIGHT,
-                          wxDATAVIEW_COL_RESIZABLE);
-  table->AppendTextColumn("Fixture Weight (kg)", wxDATAVIEW_CELL_INERT, 150,
+  table->AssociateModel(store);
+  store->DecRef();
+  table->AppendTextColumn("Position", wxDATAVIEW_CELL_INERT, wxCOL_WIDTH_AUTOSIZE,
+                          wxALIGN_LEFT, wxDATAVIEW_COL_RESIZABLE);
+  table->AppendTextColumn("Fixtures", wxDATAVIEW_CELL_INERT, wxCOL_WIDTH_AUTOSIZE,
                           wxALIGN_RIGHT, wxDATAVIEW_COL_RESIZABLE);
-  table->AppendTextColumn("Truss Weight (kg)", wxDATAVIEW_CELL_INERT, 150,
+  table->AppendTextColumn("Trusses", wxDATAVIEW_CELL_INERT, wxCOL_WIDTH_AUTOSIZE,
                           wxALIGN_RIGHT, wxDATAVIEW_COL_RESIZABLE);
-  table->AppendTextColumn("Total Weight (kg)", wxDATAVIEW_CELL_INERT, 150,
-                          wxALIGN_RIGHT, wxDATAVIEW_COL_RESIZABLE);
+  table->AppendTextColumn("Fixture Weight (kg)", wxDATAVIEW_CELL_INERT,
+                          wxCOL_WIDTH_AUTOSIZE, wxALIGN_RIGHT,
+                          wxDATAVIEW_COL_RESIZABLE);
+  table->AppendTextColumn("Truss Weight (kg)", wxDATAVIEW_CELL_INERT,
+                          wxCOL_WIDTH_AUTOSIZE, wxALIGN_RIGHT,
+                          wxDATAVIEW_COL_RESIZABLE);
+  table->AppendTextColumn("Total Weight (kg)", wxDATAVIEW_CELL_INERT,
+                          wxCOL_WIDTH_AUTOSIZE, wxALIGN_RIGHT,
+                          wxDATAVIEW_COL_RESIZABLE);
 
   auto *sizer = new wxBoxSizer(wxVERTICAL);
   sizer->Add(table, 1, wxEXPAND | wxALL, 5);
@@ -53,8 +60,19 @@ RiggingPanel *RiggingPanel::Instance() { return s_instance; }
 
 void RiggingPanel::SetInstance(RiggingPanel *panel) { s_instance = panel; }
 
-void RiggingPanel::RefreshData() {
+namespace {
+void AutoSizeColumns(wxDataViewListCtrl *table) {
   if (!table)
+    return;
+
+  const unsigned int columnCount = table->GetColumnCount();
+  for (unsigned int i = 0; i < columnCount; ++i)
+    table->GetColumn(i)->SetWidth(wxCOL_WIDTH_AUTOSIZE);
+}
+} // namespace
+
+void RiggingPanel::RefreshData() {
+  if (!table || !store)
     return;
 
   struct Totals {
@@ -92,6 +110,27 @@ void RiggingPanel::RefreshData() {
     row.push_back(wxString::Format("%.2f", totals.fixtureWeight));
     row.push_back(wxString::Format("%.2f", totals.trussWeight));
     row.push_back(wxString::Format("%.2f", totalWeight));
+    unsigned int rowIndex = table->GetItemCount();
     table->AppendItem(row);
+
+    const bool fixtureCountZero = totals.fixtures == 0;
+    const bool trussCountZero = totals.trusses == 0;
+    const bool fixtureWeightZero = totals.fixtureWeight <= 0.0f;
+    const bool trussWeightZero = totals.trussWeight <= 0.0f;
+
+    if (fixtureCountZero)
+      store->SetCellTextColour(rowIndex, 1, *wxRED);
+    if (trussCountZero)
+      store->SetCellTextColour(rowIndex, 2, *wxRED);
+    if (fixtureWeightZero)
+      store->SetCellTextColour(rowIndex, 3, *wxRED);
+    if (trussWeightZero)
+      store->SetCellTextColour(rowIndex, 4, *wxRED);
+
+    if (fixtureCountZero || trussCountZero || fixtureWeightZero ||
+        trussWeightZero)
+      store->SetCellTextColour(rowIndex, 5, *wxRED);
   }
+
+  AutoSizeColumns(table);
 }

--- a/gui/riggingpanel.h
+++ b/gui/riggingpanel.h
@@ -20,6 +20,8 @@
 #include <wx/dataview.h>
 #include <wx/wx.h>
 
+class ColorfulDataViewListStore;
+
 // Panel that summarizes rigging information grouped by position
 class RiggingPanel : public wxPanel {
 public:
@@ -32,4 +34,5 @@ public:
 
 private:
   wxDataViewListCtrl *table = nullptr;
+  ColorfulDataViewListStore *store = nullptr;
 };


### PR DESCRIPTION
## Summary
- switch rigging table to use the colorful data view store so we can apply cell-level highlighting
- automatically auto-size rigging columns to fit their content after refreshes
- highlight zero counts and weights in red and propagate the state to the total weight column

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69375215b5ac832488c9aee72da9ce53)