### PR TITLE
Refresh rigging panel after data updates

### DIFF
--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -26,6 +26,7 @@
 #include "matrixutils.h"
 #include "patchmanager.h"
 #include "projectutils.h"
+#include "riggingpanel.h"
 #include "stringutils.h"
 #include "summarypanel.h"
 #include "viewer2dpanel.h"
@@ -1254,6 +1255,9 @@ void FixtureTablePanel::UpdateSceneData() {
   }
 
   HighlightDuplicateFixtureIds();
+
+  if (RiggingPanel::Instance())
+    RiggingPanel::Instance()->RefreshData();
 
   if (SummaryPanel::Instance() && IsActivePage())
     SummaryPanel::Instance()->ShowFixtureSummary();

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -661,6 +661,7 @@ void MainWindow::OnImportMVR(wxCommandEvent &event) {
       trussPanel->ReloadData();
     if (sceneObjPanel)
       sceneObjPanel->ReloadData();
+    RefreshRigging();
     if (viewportPanel) {
       viewportPanel->UpdateScene();
       viewportPanel->Refresh();
@@ -1622,6 +1623,7 @@ void MainWindow::OnProjectLoaded(wxCommandEvent &event) {
     if (layerPanel)
       layerPanel->ReloadLayers();
     RefreshSummary();
+    RefreshRigging();
     ConfigManager::Get().MarkSaved();
     UpdateTitle();
   } else {

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -21,6 +21,7 @@
 #include "viewer3dpanel.h"
 #include "viewer2dpanel.h"
 #include "layerpanel.h"
+#include "riggingpanel.h"
 #include "summarypanel.h"
 #include "stringutils.h"
 #include "projectutils.h"
@@ -724,6 +725,9 @@ void TrussTablePanel::UpdateSceneData()
 
     if (SummaryPanel::Instance() && IsActivePage())
         SummaryPanel::Instance()->ShowTrussSummary();
+
+    if (RiggingPanel::Instance())
+        RiggingPanel::Instance()->RefreshData();
 }
 
 TrussTablePanel* TrussTablePanel::Instance()


### PR DESCRIPTION
## Summary
- refresh the rigging panel after importing MVR files and when a project finishes loading
- trigger rigging panel updates when fixture or truss table edits (including weight changes) are saved

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69375861c35883248813b78bbc11ba90)