### PR TITLE
Add minimum widths to table columns

### DIFF
--- a/gui/columnutils.h
+++ b/gui/columnutils.h
@@ -1,0 +1,35 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <wx/dataview.h>
+
+namespace ColumnUtils {
+inline void EnforceMinColumnWidth(wxDataViewListCtrl *table,
+                                  int minWidth = 50) {
+  if (!table)
+    return;
+
+  const unsigned int count = table->GetColumnCount();
+  for (unsigned int i = 0; i < count; ++i) {
+    if (auto *col = table->GetColumn(i))
+      col->SetMinWidth(minWidth);
+  }
+}
+} // namespace ColumnUtils
+

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -17,6 +17,7 @@
  */
 #include "fixturetablepanel.h"
 #include "addressdialog.h"
+#include "columnutils.h"
 #include "configmanager.h"
 #include "consolepanel.h"
 #include "fixtureeditdialog.h"
@@ -141,6 +142,8 @@ void FixtureTablePanel::InitializeTable() {
                                            columnLabels.size() - 1,
                                            widths.back(), wxALIGN_LEFT, flags);
   table->AppendColumn(colorColumn);
+
+  ColumnUtils::EnforceMinColumnWidth(table);
 }
 
 void FixtureTablePanel::ReloadData() {

--- a/gui/gdtfsearchdialog.cpp
+++ b/gui/gdtfsearchdialog.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "gdtfsearchdialog.h"
+#include "columnutils.h"
 #include "consolepanel.h"
 #include <wx/datetime.h>
 
@@ -83,6 +84,7 @@ GdtfSearchDialog::GdtfSearchDialog(wxWindow* parent, const std::string& listData
                                   wxALIGN_LEFT, flags);
     resultTable->AppendTextColumn("Rating", wxDATAVIEW_CELL_INERT, 60,
                                   wxALIGN_LEFT, flags);
+    ColumnUtils::EnforceMinColumnWidth(resultTable);
     sizer->Add(resultTable, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 10);
 
     wxBoxSizer* btnSizer = new wxBoxSizer(wxHORIZONTAL);

--- a/gui/layerpanel.cpp
+++ b/gui/layerpanel.cpp
@@ -16,12 +16,13 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "layerpanel.h"
+#include "columnutils.h"
 #include "configmanager.h"
-#include "viewer3dpanel.h"
-#include "viewer2dpanel.h"
 #include "fixturetablepanel.h"
-#include "trusstablepanel.h"
 #include "sceneobjecttablepanel.h"
+#include "trusstablepanel.h"
+#include "viewer2dpanel.h"
+#include "viewer3dpanel.h"
 #include <set>
 #include <chrono>
 #include <algorithm>
@@ -38,6 +39,7 @@ LayerPanel::LayerPanel(wxWindow* parent)
     auto* colorRenderer = new wxDataViewIconTextRenderer();
     auto* colorColumn = new wxDataViewColumn("Color", colorRenderer, 2, 40, wxALIGN_CENTER);
     list->AppendColumn(colorColumn);
+    ColumnUtils::EnforceMinColumnWidth(list);
 
     wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
     sizer->Add(list, 1, wxEXPAND | wxALL, 5);

--- a/gui/riggingpanel.cpp
+++ b/gui/riggingpanel.cpp
@@ -21,6 +21,7 @@
 #include <string>
 
 #include "colorstore.h"
+#include "columnutils.h"
 #include "configmanager.h"
 
 namespace {
@@ -50,6 +51,8 @@ RiggingPanel::RiggingPanel(wxWindow *parent) : wxPanel(parent, wxID_ANY) {
   table->AppendTextColumn("Total Weight (kg)", wxDATAVIEW_CELL_INERT,
                           wxCOL_WIDTH_AUTOSIZE, wxALIGN_RIGHT,
                           wxDATAVIEW_COL_RESIZABLE);
+
+  ColumnUtils::EnforceMinColumnWidth(table);
 
   auto *sizer = new wxBoxSizer(wxVERTICAL);
   sizer->Add(table, 1, wxEXPAND | wxALL, 5);

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -16,13 +16,14 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "sceneobjecttablepanel.h"
+#include "columnutils.h"
 #include "configmanager.h"
-#include "matrixutils.h"
-#include "viewer3dpanel.h"
-#include "viewer2dpanel.h"
 #include "layerpanel.h"
-#include "summarypanel.h"
+#include "matrixutils.h"
 #include "stringutils.h"
+#include "summarypanel.h"
+#include "viewer2dpanel.h"
+#include "viewer3dpanel.h"
 #include <algorithm>
 #include <wx/notebook.h>
 #include <wx/choicdlg.h>
@@ -78,6 +79,7 @@ void SceneObjectTablePanel::InitializeTable()
         table->AppendTextColumn(
             columnLabels[i], wxDATAVIEW_CELL_INERT, widths[i], wxALIGN_LEFT,
             wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
+    ColumnUtils::EnforceMinColumnWidth(table);
 }
 
 void SceneObjectTablePanel::ReloadData()

--- a/gui/summarypanel.cpp
+++ b/gui/summarypanel.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "summarypanel.h"
+#include "columnutils.h"
 #include "configmanager.h"
 #include <map>
 
@@ -27,6 +28,7 @@ SummaryPanel::SummaryPanel(wxWindow* parent)
     table = new wxDataViewListCtrl(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxDV_ROW_LINES);
     table->AppendTextColumn("Count", wxDATAVIEW_CELL_INERT, 60, wxALIGN_LEFT, wxDATAVIEW_COL_RESIZABLE);
     table->AppendTextColumn("Type", wxDATAVIEW_CELL_INERT, 150, wxALIGN_LEFT, wxDATAVIEW_COL_RESIZABLE);
+    ColumnUtils::EnforceMinColumnWidth(table);
     wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
     sizer->Add(table, 1, wxEXPAND | wxALL, 5);
     SetSizer(sizer);

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -16,18 +16,19 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "trusstablepanel.h"
+#include "columnutils.h"
 #include "configmanager.h"
-#include "matrixutils.h"
-#include "viewer3dpanel.h"
-#include "viewer2dpanel.h"
+#include "consolepanel.h"
 #include "layerpanel.h"
-#include "riggingpanel.h"
-#include "summarypanel.h"
-#include "stringutils.h"
+#include "matrixutils.h"
 #include "projectutils.h"
+#include "riggingpanel.h"
+#include "stringutils.h"
+#include "summarypanel.h"
 #include "trussdictionary.h"
 #include "trussloader.h"
-#include "consolepanel.h"
+#include "viewer2dpanel.h"
+#include "viewer3dpanel.h"
 #include <filesystem>
 #include <wx/filedlg.h>
 #include <wx/filename.h>
@@ -92,6 +93,7 @@ void TrussTablePanel::InitializeTable()
         table->AppendTextColumn(
             columnLabels[i], wxDATAVIEW_CELL_INERT, widths[i], wxALIGN_LEFT,
             wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
+    ColumnUtils::EnforceMinColumnWidth(table);
 }
 
 void TrussTablePanel::ReloadData()


### PR DESCRIPTION
## Summary
- add a shared helper to enforce minimum widths on wxDataViewListCtrl columns
- apply the minimum width rule across fixture, truss, scene object, rigging, summary, layer, and GDTF search tables to prevent columns from being collapsed

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69375e2790548324a5be00cbf278320c)