### PR TITLE
Add initial support entity handling

### DIFF
--- a/core/configmanager.h
+++ b/core/configmanager.h
@@ -59,6 +59,8 @@ public:
     void SetSelectedFixtures(const std::vector<std::string>& uuids);
     const std::vector<std::string>& GetSelectedTrusses() const;
     void SetSelectedTrusses(const std::vector<std::string>& uuids);
+    const std::vector<std::string>& GetSelectedSupports() const;
+    void SetSelectedSupports(const std::vector<std::string>& uuids);
     const std::vector<std::string>& GetSelectedSceneObjects() const;
     void SetSelectedSceneObjects(const std::vector<std::string>& uuids);
 
@@ -81,6 +83,8 @@ public:
     void SetFixturePrintColumns(const std::vector<std::string>& cols);
     std::vector<std::string> GetTrussPrintColumns() const;
     void SetTrussPrintColumns(const std::vector<std::string>& cols);
+    std::vector<std::string> GetSupportPrintColumns() const;
+    void SetSupportPrintColumns(const std::vector<std::string>& cols);
     std::vector<std::string> GetSceneObjectPrintColumns() const;
     void SetSceneObjectPrintColumns(const std::vector<std::string>& cols);
 
@@ -139,12 +143,14 @@ private:
     // Selection state
     std::vector<std::string> selectedFixtures;
     std::vector<std::string> selectedTrusses;
+    std::vector<std::string> selectedSupports;
     std::vector<std::string> selectedSceneObjects;
 
     struct Snapshot {
         MvrScene scene;
         std::vector<std::string> selFixtures;
         std::vector<std::string> selTrusses;
+        std::vector<std::string> selSupports;
         std::vector<std::string> selSceneObjects;
         std::string description;
     };

--- a/models/mvrscene.h
+++ b/models/mvrscene.h
@@ -22,6 +22,7 @@
 #include "fixture.h"
 #include "truss.h"
 #include "sceneobject.h"
+#include "support.h"
 #include "layer.h"
 
 // Represents the full scene structure from an MVR file
@@ -35,6 +36,7 @@ public:
 
     std::unordered_map<std::string, Fixture> fixtures;
     std::unordered_map<std::string, Truss> trusses;
+    std::unordered_map<std::string, Support> supports;
     std::unordered_map<std::string, SceneObject> sceneObjects;
     std::unordered_map<std::string, Layer> layers;
     // Lookup tables for additional references

--- a/models/support.h
+++ b/models/support.h
@@ -15,19 +15,27 @@
  * You should have received a copy of the GNU General Public License
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
-#include "mvrscene.h"
+#pragma once
 
-void MvrScene::Clear() {
-    fixtures.clear();
-    trusses.clear();
-    supports.clear();
-    sceneObjects.clear();
-    layers.clear();
-    positions.clear();
-    symdefFiles.clear();
-    provider.clear();
-    providerVersion.clear();
-    basePath.clear();
-    versionMajor = 1;
-    versionMinor = 6;
-}
+#include <string>
+#include "types.h"
+
+// Represents a rigging support/hoist parsed from MVR
+struct Support {
+    std::string uuid;
+    std::string name;
+    std::string gdtfSpec;
+    std::string gdtfMode;
+    std::string function;
+    float chainLength = 0.0f;
+    std::string position;
+    std::string positionName;
+    std::string layer;
+
+    float capacityKg = 0.0f;
+    float weightKg = 0.0f;
+    std::string riggingPoint;
+
+    Matrix transform;
+};
+


### PR DESCRIPTION
## Summary
- add Support data model and selection helpers in the config manager
- parse and export MVR Support nodes with Perastage motor metadata
- include supports in position bookkeeping and scene summaries

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69376a19ddb483248d31d18924b09490)