### PR TITLE
Add motor data view panel and integrate printing

### DIFF
--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -27,6 +27,7 @@ wxDECLARE_EVENT(EVT_PROJECT_LOADED, wxCommandEvent);
 class wxNotebook;
 class FixtureTablePanel;
 class TrussTablePanel;
+class MotorTablePanel;
 class SceneObjectTablePanel;
 class Viewer3DPanel;
 class Viewer2DPanel;
@@ -62,6 +63,7 @@ private:
   wxNotebook *notebook = nullptr;
   FixtureTablePanel *fixturePanel = nullptr;
   TrussTablePanel *trussPanel = nullptr;
+  MotorTablePanel *motorPanel = nullptr;
   SceneObjectTablePanel *sceneObjPanel = nullptr;
   wxAuiManager *auiManager = nullptr;
   Viewer3DPanel *viewportPanel = nullptr;
@@ -105,6 +107,7 @@ private:
   void OnShowAbout(wxCommandEvent &event);            // Show about dialog
   void OnSelectFixtures(wxCommandEvent &event);       // Switch to fixtures tab
   void OnSelectTrusses(wxCommandEvent &event);        // Switch to trusses tab
+  void OnSelectSupports(wxCommandEvent &event);       // Switch to supports tab
   void OnSelectObjects(wxCommandEvent &event);        // Switch to objects tab
   void OnNotebookPageChanged(wxBookCtrlEvent &event); // Update summary panel
   void RefreshSummary();                              // Refresh summary counts
@@ -168,6 +171,7 @@ enum {
   ID_Help_About,
   ID_Select_Fixtures,
   ID_Select_Trusses,
+  ID_Select_Supports,
   ID_Select_Objects,
   ID_Edit_Undo,
   ID_Edit_Redo,

--- a/gui/motortablepanel.cpp
+++ b/gui/motortablepanel.cpp
@@ -1,0 +1,576 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "motortablepanel.h"
+
+#include "columnutils.h"
+#include "configmanager.h"
+#include "layerpanel.h"
+#include "matrixutils.h"
+#include "stringutils.h"
+#include "summarypanel.h"
+#include "support.h"
+#include "viewer2dpanel.h"
+#include "viewer3dpanel.h"
+#include <algorithm>
+#include <wx/choicdlg.h>
+#include <wx/notebook.h>
+
+static MotorTablePanel *s_instance = nullptr;
+
+MotorTablePanel::MotorTablePanel(wxWindow *parent)
+    : wxPanel(parent, wxID_ANY) {
+  store = new ColorfulDataViewListStore();
+  wxBoxSizer *sizer = new wxBoxSizer(wxVERTICAL);
+  table = new wxDataViewListCtrl(this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
+                                 wxDV_MULTIPLE | wxDV_ROW_LINES);
+  table->AssociateModel(store);
+  store->DecRef();
+
+  table->SetAlternateRowColour(wxColour(40, 40, 40));
+
+  table->Bind(wxEVT_LEFT_DOWN, &MotorTablePanel::OnLeftDown, this);
+  table->Bind(wxEVT_LEFT_UP, &MotorTablePanel::OnLeftUp, this);
+  table->Bind(wxEVT_MOTION, &MotorTablePanel::OnMouseMove, this);
+  table->Bind(wxEVT_DATAVIEW_SELECTION_CHANGED,
+              &MotorTablePanel::OnSelectionChanged, this);
+
+  table->Bind(wxEVT_DATAVIEW_ITEM_CONTEXT_MENU, &MotorTablePanel::OnContextMenu,
+              this);
+  table->Bind(wxEVT_DATAVIEW_COLUMN_SORTED, &MotorTablePanel::OnColumnSorted,
+              this);
+
+  Bind(wxEVT_MOUSE_CAPTURE_LOST, &MotorTablePanel::OnCaptureLost, this);
+
+  InitializeTable();
+  ReloadData();
+
+  sizer->Add(table, 1, wxEXPAND | wxALL, 5);
+  SetSizer(sizer);
+}
+
+MotorTablePanel::~MotorTablePanel() { store = nullptr; }
+
+void MotorTablePanel::InitializeTable() {
+  columnLabels = {"Motor ID",    "Name",       "Type",       "Rigging Point",
+                  "Layer",       "Hang Pos",   "Pos X",      "Pos Y",
+                  "Pos Z",       "Roll (X)",   "Pitch (Y)",  "Yaw (Z)",
+                  "Chain Length (m)", "Capacity (kg)", "Weight (kg)"};
+  std::vector<int> widths = {70,  150, 120, 120, 100, 120, 80,  80,
+                             80,  80,  80,  80,  110, 110, 100};
+  for (size_t i = 0; i < columnLabels.size(); ++i)
+    table->AppendTextColumn(columnLabels[i], wxDATAVIEW_CELL_INERT, widths[i],
+                            wxALIGN_LEFT,
+                            wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
+  ColumnUtils::EnforceMinColumnWidth(table);
+}
+
+void MotorTablePanel::ReloadData() {
+  table->DeleteAllItems();
+  rowUuids.clear();
+  const auto &supports = ConfigManager::Get().GetScene().supports;
+
+  std::vector<std::pair<std::string, const Support *>> sorted;
+  sorted.reserve(supports.size());
+  for (const auto &[uuid, support] : supports)
+    sorted.emplace_back(uuid, &support);
+
+  std::sort(sorted.begin(), sorted.end(), [](const auto &A, const auto &B) {
+    const Support *a = A.second;
+    const Support *b = B.second;
+    if (a->layer != b->layer)
+      return StringUtils::NaturalLess(a->layer, b->layer);
+    if (a->positionName != b->positionName)
+      return StringUtils::NaturalLess(a->positionName, b->positionName);
+    return StringUtils::NaturalLess(a->name, b->name);
+  });
+
+  int motorId = 1;
+  for (const auto &pair : sorted) {
+    const std::string &uuid = pair.first;
+    const Support &support = *pair.second;
+    wxVector<wxVariant> row;
+
+    row.push_back(wxVariant(motorId));
+    wxString name = wxString::FromUTF8(support.name);
+    wxString type = wxString::FromUTF8(support.function);
+    wxString rigging = wxString::FromUTF8(support.riggingPoint);
+    wxString layer = support.layer == DEFAULT_LAYER_NAME
+                         ? wxString()
+                         : wxString::FromUTF8(support.layer);
+    wxString posName = wxString::FromUTF8(support.positionName);
+
+    auto posArr = support.transform.o;
+    wxString posX = wxString::Format("%.3f", posArr[0] / 1000.0f);
+    wxString posY = wxString::Format("%.3f", posArr[1] / 1000.0f);
+    wxString posZ = wxString::Format("%.3f", posArr[2] / 1000.0f);
+
+    auto euler = MatrixUtils::MatrixToEuler(support.transform);
+    wxString roll = wxString::Format("%.1f\u00B0", euler[2]);
+    wxString pitch = wxString::Format("%.1f\u00B0", euler[1]);
+    wxString yaw = wxString::Format("%.1f\u00B0", euler[0]);
+
+    wxString chainLen = wxString::Format("%.2f", support.chainLength);
+    wxString capacity = wxString::Format("%.2f", support.capacityKg);
+    wxString weight = wxString::Format("%.2f", support.weightKg);
+
+    row.push_back(name);
+    row.push_back(type);
+    row.push_back(rigging);
+    row.push_back(layer);
+    row.push_back(posName);
+    row.push_back(posX);
+    row.push_back(posY);
+    row.push_back(posZ);
+    row.push_back(roll);
+    row.push_back(pitch);
+    row.push_back(yaw);
+    row.push_back(chainLen);
+    row.push_back(capacity);
+    row.push_back(weight);
+
+    store->AppendItem(row, rowUuids.size());
+    rowUuids.push_back(uuid);
+    ++motorId;
+  }
+
+  if (LayerPanel::Instance())
+    LayerPanel::Instance()->ReloadLayers();
+  if (SummaryPanel::Instance() && IsActivePage())
+    SummaryPanel::Instance()->ShowFixtureSummary();
+}
+
+void MotorTablePanel::OnContextMenu(wxDataViewEvent &event) {
+  wxDataViewItem item = event.GetItem();
+  int col = event.GetColumn();
+  if (!item.IsOk() || col < 0)
+    return;
+
+  wxDataViewItemArray selections;
+  table->GetSelections(selections);
+  if (selections.empty())
+    selections.push_back(item);
+
+  std::vector<std::string> selectedUuids;
+  for (const auto &it : selections) {
+    int r = table->ItemToRow(it);
+    if (r != wxNOT_FOUND && (size_t)r < rowUuids.size())
+      selectedUuids.push_back(rowUuids[r]);
+  }
+  std::vector<std::string> oldOrder = rowUuids;
+
+  int row = table->ItemToRow(item);
+  if (row == wxNOT_FOUND)
+    return;
+
+  wxVariant current;
+  table->GetValue(current, row, col);
+
+  if (col == 4) {
+    auto layers = ConfigManager::Get().GetLayerNames();
+    wxArrayString choices;
+    for (const auto &n : layers)
+      choices.push_back(wxString::FromUTF8(n));
+    wxSingleChoiceDialog sdlg(this, "Select layer", "Layer", choices);
+    if (sdlg.ShowModal() != wxID_OK)
+      return;
+    wxString sel = sdlg.GetStringSelection();
+    wxString val = sel == wxString::FromUTF8(DEFAULT_LAYER_NAME) ? wxString()
+                                                                 : sel;
+    for (const auto &itSel : selections) {
+      int r = table->ItemToRow(itSel);
+      if (r != wxNOT_FOUND)
+        table->SetValue(wxVariant(val), r, col);
+    }
+    ResyncRows(oldOrder, selectedUuids);
+    UpdateSceneData();
+    if (Viewer3DPanel::Instance()) {
+      Viewer3DPanel::Instance()->UpdateScene();
+      Viewer3DPanel::Instance()->Refresh();
+    } else if (Viewer2DPanel::Instance()) {
+      Viewer2DPanel::Instance()->UpdateScene();
+    }
+    return;
+  }
+
+  wxTextEntryDialog dlg(this, "Edit value:", columnLabels[col],
+                        current.GetString());
+  if (dlg.ShowModal() != wxID_OK)
+    return;
+
+  wxString value = dlg.GetValue().Trim(true).Trim(false);
+
+  bool numericCol = (col >= 6);
+  bool relative = false;
+  double delta = 0.0;
+  if (numericCol && col <= 14 &&
+      (value.StartsWith("++") || value.StartsWith("--"))) {
+    wxString numStr = value.Mid(2);
+    if (numStr.ToDouble(&delta)) {
+      if (value.StartsWith("--"))
+        delta = -delta;
+      relative = true;
+    }
+  }
+
+  if (numericCol) {
+    if (relative) {
+      for (const auto &it : selections) {
+        int r = table->ItemToRow(it);
+        if (r == wxNOT_FOUND)
+          continue;
+        wxVariant cv;
+        table->GetValue(cv, r, col);
+        wxString cur = cv.GetString();
+        if (col >= 9 && col <= 11)
+          cur.Replace("\u00B0", "");
+        double curVal = 0.0;
+        cur.ToDouble(&curVal);
+        double newVal = curVal + delta;
+        wxString out;
+        if (col >= 9 && col <= 11)
+          out = wxString::Format("%.1f\u00B0", newVal);
+        else
+          out = wxString::Format((col == 12) ? "%.2f" : "%.3f", newVal);
+        table->SetValue(wxVariant(out), r, col);
+      }
+    } else {
+      wxArrayString parts = wxSplit(value, ' ');
+      if (parts.size() == 0 || parts.size() > 2) {
+        wxMessageBox("Invalid numeric value", "Error", wxOK | wxICON_ERROR);
+        return;
+      }
+
+      double v1, v2 = 0.0;
+      if (!parts[0].ToDouble(&v1)) {
+        wxMessageBox("Invalid value", "Error", wxOK | wxICON_ERROR);
+        return;
+      }
+      bool interp = false;
+      if (parts.size() == 2) {
+        if (!parts[1].ToDouble(&v2)) {
+          wxMessageBox("Invalid value", "Error", wxOK | wxICON_ERROR);
+          return;
+        }
+        interp = selections.size() > 1;
+      }
+
+      for (size_t i = 0; i < selections.size(); ++i) {
+        double val = v1;
+        if (interp)
+          val = v1 + (v2 - v1) * i / (selections.size() - 1);
+
+        wxString out;
+        if (col >= 9 && col <= 11)
+          out = wxString::Format("%.1f\u00B0", val);
+        else
+          out = wxString::Format((col == 12) ? "%.2f" : "%.3f", val);
+
+        int r = table->ItemToRow(selections[i]);
+        if (r != wxNOT_FOUND)
+          table->SetValue(wxVariant(out), r, col);
+      }
+    }
+  } else {
+    for (const auto &it : selections) {
+      int r = table->ItemToRow(it);
+      if (r != wxNOT_FOUND)
+        table->SetValue(wxVariant(value), r, col);
+    }
+  }
+
+  ResyncRows(oldOrder, selectedUuids);
+
+  UpdateSceneData();
+  if (Viewer3DPanel::Instance()) {
+    Viewer3DPanel::Instance()->UpdateScene();
+    Viewer3DPanel::Instance()->Refresh();
+  } else if (Viewer2DPanel::Instance()) {
+    Viewer2DPanel::Instance()->UpdateScene();
+  }
+}
+
+void MotorTablePanel::OnLeftDown(wxMouseEvent &evt) {
+  wxDataViewItem item;
+  wxDataViewColumn *col;
+  table->HitTest(evt.GetPosition(), item, col);
+  startRow = table->ItemToRow(item);
+  if (startRow != wxNOT_FOUND) {
+    dragSelecting = true;
+    table->UnselectAll();
+    table->SelectRow(startRow);
+    CaptureMouse();
+  }
+  evt.Skip();
+}
+
+void MotorTablePanel::OnLeftUp(wxMouseEvent &evt) {
+  if (dragSelecting) {
+    dragSelecting = false;
+    ReleaseMouse();
+  }
+  evt.Skip();
+}
+
+void MotorTablePanel::OnCaptureLost(wxMouseCaptureLostEvent &WXUNUSED(evt)) {
+  dragSelecting = false;
+}
+
+void MotorTablePanel::OnMouseMove(wxMouseEvent &evt) {
+  if (!dragSelecting || !evt.Dragging()) {
+    evt.Skip();
+    return;
+  }
+  wxDataViewItem item;
+  wxDataViewColumn *col;
+  table->HitTest(evt.GetPosition(), item, col);
+  int row = table->ItemToRow(item);
+  if (row != wxNOT_FOUND) {
+    int minRow = std::min(startRow, row);
+    int maxRow = std::max(startRow, row);
+    table->UnselectAll();
+    for (int r = minRow; r <= maxRow; ++r)
+      table->SelectRow(r);
+  }
+  evt.Skip();
+}
+
+void MotorTablePanel::OnSelectionChanged(wxDataViewEvent &evt) {
+  wxDataViewItemArray selections;
+  table->GetSelections(selections);
+  std::vector<std::string> uuids;
+  uuids.reserve(selections.size());
+  for (const auto &it : selections) {
+    int r = table->ItemToRow(it);
+    if (r != wxNOT_FOUND && (size_t)r < rowUuids.size())
+      uuids.push_back(rowUuids[r]);
+  }
+  ConfigManager &cfg = ConfigManager::Get();
+  if (uuids != cfg.GetSelectedSupports()) {
+    cfg.PushUndoState("support selection");
+    cfg.SetSelectedSupports(uuids);
+  }
+  if (Viewer3DPanel::Instance())
+    Viewer3DPanel::Instance()->SetSelectedFixtures(uuids);
+  evt.Skip();
+}
+
+void MotorTablePanel::UpdateSceneData() {
+  ConfigManager &cfg = ConfigManager::Get();
+  cfg.PushUndoState("edit support");
+  auto &scene = cfg.GetScene();
+  size_t count = std::min((size_t)table->GetItemCount(), rowUuids.size());
+  for (size_t i = 0; i < count; ++i) {
+    auto it = scene.supports.find(rowUuids[i]);
+    if (it == scene.supports.end())
+      continue;
+
+    wxVariant v;
+    table->GetValue(v, i, 1);
+    it->second.name = std::string(v.GetString().ToUTF8());
+
+    table->GetValue(v, i, 2);
+    it->second.function = std::string(v.GetString().ToUTF8());
+
+    table->GetValue(v, i, 3);
+    it->second.riggingPoint = std::string(v.GetString().ToUTF8());
+
+    table->GetValue(v, i, 4);
+    std::string layerStr = std::string(v.GetString().ToUTF8());
+    if (layerStr.empty())
+      it->second.layer.clear();
+    else
+      it->second.layer = layerStr;
+
+    table->GetValue(v, i, 5);
+    it->second.positionName = std::string(v.GetString().ToUTF8());
+    if (!it->second.position.empty())
+      scene.positions[it->second.position] = it->second.positionName;
+
+    double x = 0, y = 0, z = 0;
+    table->GetValue(v, i, 6);
+    v.GetString().ToDouble(&x);
+    table->GetValue(v, i, 7);
+    v.GetString().ToDouble(&y);
+    table->GetValue(v, i, 8);
+    v.GetString().ToDouble(&z);
+
+    double roll = 0, pitch = 0, yaw = 0;
+    table->GetValue(v, i, 9);
+    {
+      wxString s = v.GetString();
+      s.Replace("\u00B0", "");
+      s.ToDouble(&roll);
+    }
+    table->GetValue(v, i, 10);
+    {
+      wxString s = v.GetString();
+      s.Replace("\u00B0", "");
+      s.ToDouble(&pitch);
+    }
+    table->GetValue(v, i, 11);
+    {
+      wxString s = v.GetString();
+      s.Replace("\u00B0", "");
+      s.ToDouble(&yaw);
+    }
+
+    Matrix rot = MatrixUtils::EulerToMatrix(static_cast<float>(yaw),
+                                            static_cast<float>(pitch),
+                                            static_cast<float>(roll));
+    rot.o = {static_cast<float>(x * 1000.0), static_cast<float>(y * 1000.0),
+             static_cast<float>(z * 1000.0)};
+    it->second.transform = rot;
+
+    table->GetValue(v, i, 12);
+    double chainLen = 0.0;
+    v.GetString().ToDouble(&chainLen);
+    it->second.chainLength = static_cast<float>(chainLen);
+
+    table->GetValue(v, i, 13);
+    double capacity = 0.0;
+    v.GetString().ToDouble(&capacity);
+    it->second.capacityKg = static_cast<float>(capacity);
+
+    table->GetValue(v, i, 14);
+    double weight = 0.0;
+    v.GetString().ToDouble(&weight);
+    it->second.weightKg = static_cast<float>(weight);
+  }
+
+  if (SummaryPanel::Instance() && IsActivePage())
+    SummaryPanel::Instance()->ShowFixtureSummary();
+}
+
+MotorTablePanel *MotorTablePanel::Instance() { return s_instance; }
+
+void MotorTablePanel::SetInstance(MotorTablePanel *panel) { s_instance = panel; }
+
+bool MotorTablePanel::IsActivePage() const {
+  auto *nb = dynamic_cast<wxNotebook *>(GetParent());
+  return nb && nb->GetPage(nb->GetSelection()) == this;
+}
+
+void MotorTablePanel::HighlightMotor(const std::string &uuid) {
+  for (size_t i = 0; i < rowUuids.size(); ++i) {
+    if (!uuid.empty() && rowUuids[i] == uuid)
+      store->SetRowBackgroundColour(i, wxColour(0, 200, 0));
+    else
+      store->ClearRowBackground(i);
+  }
+  table->Refresh();
+}
+
+void MotorTablePanel::ClearSelection() { table->UnselectAll(); }
+
+std::vector<std::string> MotorTablePanel::GetSelectedUuids() const {
+  wxDataViewItemArray selections;
+  table->GetSelections(selections);
+  std::vector<std::string> uuids;
+  uuids.reserve(selections.size());
+  for (const auto &it : selections) {
+    int r = table->ItemToRow(it);
+    if (r != wxNOT_FOUND && (size_t)r < rowUuids.size())
+      uuids.push_back(rowUuids[r]);
+  }
+  return uuids;
+}
+
+void MotorTablePanel::SelectByUuid(const std::vector<std::string> &uuids) {
+  table->UnselectAll();
+  for (const auto &u : uuids) {
+    auto pos = std::find(rowUuids.begin(), rowUuids.end(), u);
+    if (pos != rowUuids.end())
+      table->SelectRow(static_cast<int>(pos - rowUuids.begin()));
+  }
+}
+
+void MotorTablePanel::DeleteSelected() {
+  wxDataViewItemArray selections;
+  table->GetSelections(selections);
+  if (selections.empty())
+    return;
+
+  ConfigManager &cfg = ConfigManager::Get();
+  cfg.PushUndoState("delete support");
+
+  std::vector<int> rows;
+  rows.reserve(selections.size());
+  for (const auto &it : selections) {
+    int r = table->ItemToRow(it);
+    if (r != wxNOT_FOUND)
+      rows.push_back(r);
+  }
+  std::sort(rows.begin(), rows.end(), std::greater<int>());
+
+  auto &scene = cfg.GetScene();
+  for (int r : rows) {
+    if ((size_t)r < rowUuids.size()) {
+      scene.supports.erase(rowUuids[r]);
+      rowUuids.erase(rowUuids.begin() + r);
+      table->DeleteItem(r);
+    }
+  }
+
+  if (SummaryPanel::Instance())
+    SummaryPanel::Instance()->ShowFixtureSummary();
+
+  if (Viewer3DPanel::Instance()) {
+    Viewer3DPanel::Instance()->UpdateScene();
+    Viewer3DPanel::Instance()->Refresh();
+  } else if (Viewer2DPanel::Instance()) {
+    Viewer2DPanel::Instance()->UpdateScene();
+  }
+
+  std::vector<std::string> order = rowUuids;
+  ResyncRows(order, {});
+}
+
+void MotorTablePanel::ResyncRows(const std::vector<std::string> &oldOrder,
+                                 const std::vector<std::string> &selectedUuids) {
+  unsigned int count = table->GetItemCount();
+  std::vector<std::string> newOrder(count);
+  for (unsigned int i = 0; i < count; ++i) {
+    wxDataViewItem it = table->RowToItem(i);
+    unsigned long idx = store->GetItemData(it);
+    if (idx < oldOrder.size())
+      newOrder[i] = oldOrder[idx];
+    store->SetItemData(it, i);
+  }
+  rowUuids.swap(newOrder);
+
+  table->UnselectAll();
+  for (const auto &uuid : selectedUuids) {
+    auto pos = std::find(rowUuids.begin(), rowUuids.end(), uuid);
+    if (pos != rowUuids.end())
+      table->SelectRow(static_cast<int>(pos - rowUuids.begin()));
+  }
+}
+
+void MotorTablePanel::OnColumnSorted(wxDataViewEvent &event) {
+  wxDataViewItemArray selections;
+  table->GetSelections(selections);
+  std::vector<std::string> selectedUuids;
+  for (const auto &it : selections) {
+    int r = table->ItemToRow(it);
+    if (r != wxNOT_FOUND && (size_t)r < rowUuids.size())
+      selectedUuids.push_back(rowUuids[r]);
+  }
+  std::vector<std::string> oldOrder = rowUuids;
+  ResyncRows(oldOrder, selectedUuids);
+  event.Skip();
+}

--- a/gui/motortablepanel.h
+++ b/gui/motortablepanel.h
@@ -1,0 +1,63 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <wx/dataview.h>
+#include <wx/wx.h>
+#include <string>
+#include <vector>
+#include "colorstore.h"
+
+class MotorTablePanel : public wxPanel {
+public:
+  explicit MotorTablePanel(wxWindow *parent);
+  ~MotorTablePanel();
+
+  void ReloadData();
+  void HighlightMotor(const std::string &uuid);
+  void ClearSelection();
+  std::vector<std::string> GetSelectedUuids() const;
+  void SelectByUuid(const std::vector<std::string> &uuids);
+  bool IsActivePage() const;
+  void DeleteSelected();
+  wxDataViewListCtrl *GetTableCtrl() const { return table; }
+
+  static MotorTablePanel *Instance();
+  static void SetInstance(MotorTablePanel *panel);
+
+  void UpdateSceneData();
+
+private:
+  ColorfulDataViewListStore *store;
+  wxDataViewListCtrl *table;
+  std::vector<wxString> columnLabels;
+  std::vector<std::string> rowUuids;
+  bool dragSelecting = false;
+  int startRow = -1;
+
+  void InitializeTable();
+  void OnSelectionChanged(wxDataViewEvent &evt);
+  void OnContextMenu(wxDataViewEvent &event);
+  void OnColumnSorted(wxDataViewEvent &event);
+  void ResyncRows(const std::vector<std::string> &oldOrder,
+                  const std::vector<std::string> &selectedUuids);
+  void OnLeftDown(wxMouseEvent &evt);
+  void OnLeftUp(wxMouseEvent &evt);
+  void OnMouseMove(wxMouseEvent &evt);
+  void OnCaptureLost(wxMouseCaptureLostEvent &evt);
+};

--- a/gui/tableprinter.cpp
+++ b/gui/tableprinter.cpp
@@ -37,12 +37,13 @@ void Print(wxWindow* parent, wxDataViewListCtrl* table, TableType type)
         cols.push_back(std::string(table->GetColumn(i)->GetTitle().ToUTF8()));
 
     std::vector<std::string> saved;
-    switch (type)
-    {
-    case TableType::Fixtures: saved = ConfigManager::Get().GetFixturePrintColumns(); break;
-    case TableType::Trusses: saved = ConfigManager::Get().GetTrussPrintColumns(); break;
-    case TableType::SceneObjects: saved = ConfigManager::Get().GetSceneObjectPrintColumns(); break;
-    }
+  switch (type)
+  {
+  case TableType::Fixtures: saved = ConfigManager::Get().GetFixturePrintColumns(); break;
+  case TableType::Trusses: saved = ConfigManager::Get().GetTrussPrintColumns(); break;
+  case TableType::Supports: saved = ConfigManager::Get().GetSupportPrintColumns(); break;
+  case TableType::SceneObjects: saved = ConfigManager::Get().GetSceneObjectPrintColumns(); break;
+  }
 
     std::vector<int> defaultIdx;
     for (const auto& name : saved)
@@ -64,12 +65,13 @@ void Print(wxWindow* parent, wxDataViewListCtrl* table, TableType type)
     for (int c : selCols)
         toSave.push_back(cols[c]);
 
-    switch (type)
-    {
-    case TableType::Fixtures: ConfigManager::Get().SetFixturePrintColumns(toSave); break;
-    case TableType::Trusses: ConfigManager::Get().SetTrussPrintColumns(toSave); break;
-    case TableType::SceneObjects: ConfigManager::Get().SetSceneObjectPrintColumns(toSave); break;
-    }
+  switch (type)
+  {
+  case TableType::Fixtures: ConfigManager::Get().SetFixturePrintColumns(toSave); break;
+  case TableType::Trusses: ConfigManager::Get().SetTrussPrintColumns(toSave); break;
+  case TableType::Supports: ConfigManager::Get().SetSupportPrintColumns(toSave); break;
+  case TableType::SceneObjects: ConfigManager::Get().SetSceneObjectPrintColumns(toSave); break;
+  }
 
     static wxHtmlEasyPrinting printer("Table Printer", parent);
     printer.SetParentWindow(parent);
@@ -121,12 +123,13 @@ void ExportCSV(wxWindow* parent, wxDataViewListCtrl* table, TableType type)
         cols.push_back(std::string(table->GetColumn(i)->GetTitle().ToUTF8()));
 
     std::vector<std::string> saved;
-    switch (type)
-    {
-    case TableType::Fixtures: saved = ConfigManager::Get().GetFixturePrintColumns(); break;
-    case TableType::Trusses: saved = ConfigManager::Get().GetTrussPrintColumns(); break;
-    case TableType::SceneObjects: saved = ConfigManager::Get().GetSceneObjectPrintColumns(); break;
-    }
+  switch (type)
+  {
+  case TableType::Fixtures: saved = ConfigManager::Get().GetFixturePrintColumns(); break;
+  case TableType::Trusses: saved = ConfigManager::Get().GetTrussPrintColumns(); break;
+  case TableType::Supports: saved = ConfigManager::Get().GetSupportPrintColumns(); break;
+  case TableType::SceneObjects: saved = ConfigManager::Get().GetSceneObjectPrintColumns(); break;
+  }
 
     std::vector<int> defaultIdx;
     for (const auto& name : saved)
@@ -148,12 +151,13 @@ void ExportCSV(wxWindow* parent, wxDataViewListCtrl* table, TableType type)
     for (int c : selCols)
         toSave.push_back(cols[c]);
 
-    switch (type)
-    {
-    case TableType::Fixtures: ConfigManager::Get().SetFixturePrintColumns(toSave); break;
-    case TableType::Trusses: ConfigManager::Get().SetTrussPrintColumns(toSave); break;
-    case TableType::SceneObjects: ConfigManager::Get().SetSceneObjectPrintColumns(toSave); break;
-    }
+  switch (type)
+  {
+  case TableType::Fixtures: ConfigManager::Get().SetFixturePrintColumns(toSave); break;
+  case TableType::Trusses: ConfigManager::Get().SetTrussPrintColumns(toSave); break;
+  case TableType::Supports: ConfigManager::Get().SetSupportPrintColumns(toSave); break;
+  case TableType::SceneObjects: ConfigManager::Get().SetSceneObjectPrintColumns(toSave); break;
+  }
 
     wxFileDialog saveDlg(parent, "Export CSV", "", "", "CSV files (*.csv)|*.csv|All files (*.*)|*.*",
                          wxFD_SAVE | wxFD_OVERWRITE_PROMPT);

--- a/gui/tableprinter.h
+++ b/gui/tableprinter.h
@@ -24,7 +24,7 @@ class wxWindow;
 class wxDataViewListCtrl;
 
 namespace TablePrinter {
-enum class TableType { Fixtures, Trusses, SceneObjects };
+enum class TableType { Fixtures, Trusses, Supports, SceneObjects };
 void Print(wxWindow* parent, wxDataViewListCtrl* table, TableType type);
 void ExportCSV(wxWindow* parent, wxDataViewListCtrl* table, TableType type);
 }


### PR DESCRIPTION
## Summary
- add MotorTablePanel to display and edit supports in the Data Views notebook
- hook motor selection into undo/redo, deletion, and navigation shortcuts
- extend table printing/CSV export support to motor tables

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69376c469ac483249f1f2bc3e094af6e)