### PR TITLE
Add support and motor summaries to rigging views

### DIFF
--- a/gui/motortablepanel.cpp
+++ b/gui/motortablepanel.cpp
@@ -151,7 +151,7 @@ void MotorTablePanel::ReloadData() {
   if (LayerPanel::Instance())
     LayerPanel::Instance()->ReloadLayers();
   if (SummaryPanel::Instance() && IsActivePage())
-    SummaryPanel::Instance()->ShowFixtureSummary();
+    SummaryPanel::Instance()->ShowSupportSummary();
 }
 
 void MotorTablePanel::OnContextMenu(wxDataViewEvent &event) {
@@ -453,7 +453,7 @@ void MotorTablePanel::UpdateSceneData() {
   }
 
   if (SummaryPanel::Instance() && IsActivePage())
-    SummaryPanel::Instance()->ShowFixtureSummary();
+    SummaryPanel::Instance()->ShowSupportSummary();
 }
 
 MotorTablePanel *MotorTablePanel::Instance() { return s_instance; }
@@ -527,7 +527,7 @@ void MotorTablePanel::DeleteSelected() {
   }
 
   if (SummaryPanel::Instance())
-    SummaryPanel::Instance()->ShowFixtureSummary();
+    SummaryPanel::Instance()->ShowSupportSummary();
 
   if (Viewer3DPanel::Instance()) {
     Viewer3DPanel::Instance()->UpdateScene();

--- a/gui/summarypanel.h
+++ b/gui/summarypanel.h
@@ -20,19 +20,23 @@
 #include <wx/wx.h>
 #include <wx/dataview.h>
 
+#include <vector>
+
 // Panel that shows a summary count of items by type/model/name
 class SummaryPanel : public wxPanel {
 public:
     explicit SummaryPanel(wxWindow* parent);
 
-    void ShowFixtureSummary();
-    void ShowTrussSummary();
-    void ShowSceneObjectSummary();
+  void ShowFixtureSummary();
+  void ShowTrussSummary();
+  void ShowSceneObjectSummary();
+  void ShowSupportSummary();
 
     static SummaryPanel* Instance();
-    static void SetInstance(SummaryPanel* panel);
+  static void SetInstance(SummaryPanel* panel);
 
 private:
-    wxDataViewListCtrl* table = nullptr;
-    void ShowSummary(const std::vector<std::pair<std::string,int>>& items);
+  wxDataViewListCtrl* table = nullptr;
+  void ResetColumns(const std::vector<wxString>& headers);
+  void ShowSummary(const std::vector<std::pair<std::string,int>>& items);
 };


### PR DESCRIPTION
## Summary
- add supports count and weight columns to rigging panel totals and red flagging
- extend summary panel to show support totals including weight and capacity
- update motor table interactions to trigger the new support summary

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69376f25f8fc8324b6e152a15b4358db)