### PR TITLE
Rename motors to hoists

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -239,7 +239,7 @@ void ConfigManager::ApplyColumnDefaults() {
     SetValue("truss_print_columns", "Name,Layer,Hang Pos,Manufacturer,Model");
   if (!HasKey("support_print_columns"))
     SetValue("support_print_columns",
-             "Motor ID,Name,Type,Rigging Point,Layer,Hang Pos,Pos X,Pos Y,Pos Z,Roll (X),Pitch (Y),Yaw (Z),Chain Length (m),Capacity (kg),Weight (kg)");
+             "Hoist ID,Name,Type,Rigging Point,Layer,Hang Pos,Pos X,Pos Y,Pos Z,Roll (X),Pitch (Y),Yaw (Z),Chain Length (m),Capacity (kg),Weight (kg)");
   if (!HasKey("sceneobject_print_columns"))
     SetValue("sceneobject_print_columns", "Name,Layer");
 }

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
-#include "motortablepanel.h"
+#include "hoisttablepanel.h"
 
 #include "columnutils.h"
 #include "configmanager.h"
@@ -30,9 +30,9 @@
 #include <wx/choicdlg.h>
 #include <wx/notebook.h>
 
-static MotorTablePanel *s_instance = nullptr;
+static HoistTablePanel *s_instance = nullptr;
 
-MotorTablePanel::MotorTablePanel(wxWindow *parent)
+HoistTablePanel::HoistTablePanel(wxWindow *parent)
     : wxPanel(parent, wxID_ANY) {
   store = new ColorfulDataViewListStore();
   wxBoxSizer *sizer = new wxBoxSizer(wxVERTICAL);
@@ -43,18 +43,18 @@ MotorTablePanel::MotorTablePanel(wxWindow *parent)
 
   table->SetAlternateRowColour(wxColour(40, 40, 40));
 
-  table->Bind(wxEVT_LEFT_DOWN, &MotorTablePanel::OnLeftDown, this);
-  table->Bind(wxEVT_LEFT_UP, &MotorTablePanel::OnLeftUp, this);
-  table->Bind(wxEVT_MOTION, &MotorTablePanel::OnMouseMove, this);
+  table->Bind(wxEVT_LEFT_DOWN, &HoistTablePanel::OnLeftDown, this);
+  table->Bind(wxEVT_LEFT_UP, &HoistTablePanel::OnLeftUp, this);
+  table->Bind(wxEVT_MOTION, &HoistTablePanel::OnMouseMove, this);
   table->Bind(wxEVT_DATAVIEW_SELECTION_CHANGED,
-              &MotorTablePanel::OnSelectionChanged, this);
+              &HoistTablePanel::OnSelectionChanged, this);
 
-  table->Bind(wxEVT_DATAVIEW_ITEM_CONTEXT_MENU, &MotorTablePanel::OnContextMenu,
+  table->Bind(wxEVT_DATAVIEW_ITEM_CONTEXT_MENU, &HoistTablePanel::OnContextMenu,
               this);
-  table->Bind(wxEVT_DATAVIEW_COLUMN_SORTED, &MotorTablePanel::OnColumnSorted,
+  table->Bind(wxEVT_DATAVIEW_COLUMN_SORTED, &HoistTablePanel::OnColumnSorted,
               this);
 
-  Bind(wxEVT_MOUSE_CAPTURE_LOST, &MotorTablePanel::OnCaptureLost, this);
+  Bind(wxEVT_MOUSE_CAPTURE_LOST, &HoistTablePanel::OnCaptureLost, this);
 
   InitializeTable();
   ReloadData();
@@ -63,10 +63,10 @@ MotorTablePanel::MotorTablePanel(wxWindow *parent)
   SetSizer(sizer);
 }
 
-MotorTablePanel::~MotorTablePanel() { store = nullptr; }
+HoistTablePanel::~HoistTablePanel() { store = nullptr; }
 
-void MotorTablePanel::InitializeTable() {
-  columnLabels = {"Motor ID",    "Name",       "Type",       "Rigging Point",
+void HoistTablePanel::InitializeTable() {
+  columnLabels = {"Hoist ID",    "Name",       "Type",       "Rigging Point",
                   "Layer",       "Hang Pos",   "Pos X",      "Pos Y",
                   "Pos Z",       "Roll (X)",   "Pitch (Y)",  "Yaw (Z)",
                   "Chain Length (m)", "Capacity (kg)", "Weight (kg)"};
@@ -79,7 +79,7 @@ void MotorTablePanel::InitializeTable() {
   ColumnUtils::EnforceMinColumnWidth(table);
 }
 
-void MotorTablePanel::ReloadData() {
+void HoistTablePanel::ReloadData() {
   table->DeleteAllItems();
   rowUuids.clear();
   const auto &supports = ConfigManager::Get().GetScene().supports;
@@ -99,13 +99,13 @@ void MotorTablePanel::ReloadData() {
     return StringUtils::NaturalLess(a->name, b->name);
   });
 
-  int motorId = 1;
+  int hoistId = 1;
   for (const auto &pair : sorted) {
     const std::string &uuid = pair.first;
     const Support &support = *pair.second;
     wxVector<wxVariant> row;
 
-    row.push_back(wxVariant(motorId));
+    row.push_back(wxVariant(hoistId));
     wxString name = wxString::FromUTF8(support.name);
     wxString type = wxString::FromUTF8(support.function);
     wxString rigging = wxString::FromUTF8(support.riggingPoint);
@@ -145,7 +145,7 @@ void MotorTablePanel::ReloadData() {
 
     store->AppendItem(row, rowUuids.size());
     rowUuids.push_back(uuid);
-    ++motorId;
+    ++hoistId;
   }
 
   if (LayerPanel::Instance())
@@ -154,7 +154,7 @@ void MotorTablePanel::ReloadData() {
     SummaryPanel::Instance()->ShowFixtureSummary();
 }
 
-void MotorTablePanel::OnContextMenu(wxDataViewEvent &event) {
+void HoistTablePanel::OnContextMenu(wxDataViewEvent &event) {
   wxDataViewItem item = event.GetItem();
   int col = event.GetColumn();
   if (!item.IsOk() || col < 0)
@@ -304,7 +304,7 @@ void MotorTablePanel::OnContextMenu(wxDataViewEvent &event) {
   }
 }
 
-void MotorTablePanel::OnLeftDown(wxMouseEvent &evt) {
+void HoistTablePanel::OnLeftDown(wxMouseEvent &evt) {
   wxDataViewItem item;
   wxDataViewColumn *col;
   table->HitTest(evt.GetPosition(), item, col);
@@ -318,7 +318,7 @@ void MotorTablePanel::OnLeftDown(wxMouseEvent &evt) {
   evt.Skip();
 }
 
-void MotorTablePanel::OnLeftUp(wxMouseEvent &evt) {
+void HoistTablePanel::OnLeftUp(wxMouseEvent &evt) {
   if (dragSelecting) {
     dragSelecting = false;
     ReleaseMouse();
@@ -326,11 +326,11 @@ void MotorTablePanel::OnLeftUp(wxMouseEvent &evt) {
   evt.Skip();
 }
 
-void MotorTablePanel::OnCaptureLost(wxMouseCaptureLostEvent &WXUNUSED(evt)) {
+void HoistTablePanel::OnCaptureLost(wxMouseCaptureLostEvent &WXUNUSED(evt)) {
   dragSelecting = false;
 }
 
-void MotorTablePanel::OnMouseMove(wxMouseEvent &evt) {
+void HoistTablePanel::OnMouseMove(wxMouseEvent &evt) {
   if (!dragSelecting || !evt.Dragging()) {
     evt.Skip();
     return;
@@ -349,7 +349,7 @@ void MotorTablePanel::OnMouseMove(wxMouseEvent &evt) {
   evt.Skip();
 }
 
-void MotorTablePanel::OnSelectionChanged(wxDataViewEvent &evt) {
+void HoistTablePanel::OnSelectionChanged(wxDataViewEvent &evt) {
   wxDataViewItemArray selections;
   table->GetSelections(selections);
   std::vector<std::string> uuids;
@@ -369,7 +369,7 @@ void MotorTablePanel::OnSelectionChanged(wxDataViewEvent &evt) {
   evt.Skip();
 }
 
-void MotorTablePanel::UpdateSceneData() {
+void HoistTablePanel::UpdateSceneData() {
   ConfigManager &cfg = ConfigManager::Get();
   cfg.PushUndoState("edit support");
   auto &scene = cfg.GetScene();
@@ -456,16 +456,16 @@ void MotorTablePanel::UpdateSceneData() {
     SummaryPanel::Instance()->ShowFixtureSummary();
 }
 
-MotorTablePanel *MotorTablePanel::Instance() { return s_instance; }
+HoistTablePanel *HoistTablePanel::Instance() { return s_instance; }
 
-void MotorTablePanel::SetInstance(MotorTablePanel *panel) { s_instance = panel; }
+void HoistTablePanel::SetInstance(HoistTablePanel *panel) { s_instance = panel; }
 
-bool MotorTablePanel::IsActivePage() const {
+bool HoistTablePanel::IsActivePage() const {
   auto *nb = dynamic_cast<wxNotebook *>(GetParent());
   return nb && nb->GetPage(nb->GetSelection()) == this;
 }
 
-void MotorTablePanel::HighlightMotor(const std::string &uuid) {
+void HoistTablePanel::HighlightHoist(const std::string &uuid) {
   for (size_t i = 0; i < rowUuids.size(); ++i) {
     if (!uuid.empty() && rowUuids[i] == uuid)
       store->SetRowBackgroundColour(i, wxColour(0, 200, 0));
@@ -475,9 +475,9 @@ void MotorTablePanel::HighlightMotor(const std::string &uuid) {
   table->Refresh();
 }
 
-void MotorTablePanel::ClearSelection() { table->UnselectAll(); }
+void HoistTablePanel::ClearSelection() { table->UnselectAll(); }
 
-std::vector<std::string> MotorTablePanel::GetSelectedUuids() const {
+std::vector<std::string> HoistTablePanel::GetSelectedUuids() const {
   wxDataViewItemArray selections;
   table->GetSelections(selections);
   std::vector<std::string> uuids;
@@ -490,7 +490,7 @@ std::vector<std::string> MotorTablePanel::GetSelectedUuids() const {
   return uuids;
 }
 
-void MotorTablePanel::SelectByUuid(const std::vector<std::string> &uuids) {
+void HoistTablePanel::SelectByUuid(const std::vector<std::string> &uuids) {
   table->UnselectAll();
   for (const auto &u : uuids) {
     auto pos = std::find(rowUuids.begin(), rowUuids.end(), u);
@@ -499,7 +499,7 @@ void MotorTablePanel::SelectByUuid(const std::vector<std::string> &uuids) {
   }
 }
 
-void MotorTablePanel::DeleteSelected() {
+void HoistTablePanel::DeleteSelected() {
   wxDataViewItemArray selections;
   table->GetSelections(selections);
   if (selections.empty())
@@ -540,7 +540,7 @@ void MotorTablePanel::DeleteSelected() {
   ResyncRows(order, {});
 }
 
-void MotorTablePanel::ResyncRows(const std::vector<std::string> &oldOrder,
+void HoistTablePanel::ResyncRows(const std::vector<std::string> &oldOrder,
                                  const std::vector<std::string> &selectedUuids) {
   unsigned int count = table->GetItemCount();
   std::vector<std::string> newOrder(count);
@@ -561,7 +561,7 @@ void MotorTablePanel::ResyncRows(const std::vector<std::string> &oldOrder,
   }
 }
 
-void MotorTablePanel::OnColumnSorted(wxDataViewEvent &event) {
+void HoistTablePanel::OnColumnSorted(wxDataViewEvent &event) {
   wxDataViewItemArray selections;
   table->GetSelections(selections);
   std::vector<std::string> selectedUuids;

--- a/gui/hoisttablepanel.h
+++ b/gui/hoisttablepanel.h
@@ -23,13 +23,13 @@
 #include <vector>
 #include "colorstore.h"
 
-class MotorTablePanel : public wxPanel {
+class HoistTablePanel : public wxPanel {
 public:
-  explicit MotorTablePanel(wxWindow *parent);
-  ~MotorTablePanel();
+  explicit HoistTablePanel(wxWindow *parent);
+  ~HoistTablePanel();
 
   void ReloadData();
-  void HighlightMotor(const std::string &uuid);
+  void HighlightHoist(const std::string &uuid);
   void ClearSelection();
   std::vector<std::string> GetSelectedUuids() const;
   void SelectByUuid(const std::vector<std::string> &uuids);
@@ -37,8 +37,8 @@ public:
   void DeleteSelected();
   wxDataViewListCtrl *GetTableCtrl() const { return table; }
 
-  static MotorTablePanel *Instance();
-  static void SetInstance(MotorTablePanel *panel);
+  static HoistTablePanel *Instance();
+  static void SetInstance(HoistTablePanel *panel);
 
   void UpdateSceneData();
 

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -64,7 +64,7 @@ using json = nlohmann::json;
 #include "layerpanel.h"
 #include "logindialog.h"
 #include "markdown.h"
-#include "motortablepanel.h"
+#include "hoisttablepanel.h"
 #include "mvrexporter.h"
 #include "mvrimporter.h"
 #include "preferencesdialog.h"
@@ -257,9 +257,9 @@ void MainWindow::SetupLayout() {
   TrussTablePanel::SetInstance(trussPanel);
   notebook->AddPage(trussPanel, "Trusses");
 
-  motorPanel = new MotorTablePanel(notebook);
-  MotorTablePanel::SetInstance(motorPanel);
-  notebook->AddPage(motorPanel, "Motors");
+  hoistPanel = new HoistTablePanel(notebook);
+  HoistTablePanel::SetInstance(hoistPanel);
+  notebook->AddPage(hoistPanel, "Hoists");
 
   sceneObjPanel = new SceneObjectTablePanel(notebook);
   SceneObjectTablePanel::SetInstance(sceneObjPanel);
@@ -1215,8 +1215,8 @@ void MainWindow::OnPrintTable(wxCommandEvent &WXUNUSED(event)) {
     options.Add("Fixtures");
   if (trussPanel)
     options.Add("Trusses");
-  if (motorPanel)
-    options.Add("Motors");
+  if (hoistPanel)
+    options.Add("Hoists");
   if (sceneObjPanel)
     options.Add("Objects");
   if (options.IsEmpty())
@@ -1235,8 +1235,8 @@ void MainWindow::OnPrintTable(wxCommandEvent &WXUNUSED(event)) {
   } else if (choice == "Trusses" && trussPanel) {
     ctrl = trussPanel->GetTableCtrl();
     type = TablePrinter::TableType::Trusses;
-  } else if (choice == "Motors" && motorPanel) {
-    ctrl = motorPanel->GetTableCtrl();
+  } else if (choice == "Hoists" && hoistPanel) {
+    ctrl = hoistPanel->GetTableCtrl();
     type = TablePrinter::TableType::Supports;
   } else if (choice == "Objects" && sceneObjPanel) {
     ctrl = sceneObjPanel->GetTableCtrl();
@@ -1253,8 +1253,8 @@ void MainWindow::OnExportCSV(wxCommandEvent &WXUNUSED(event)) {
     options.Add("Fixtures");
   if (trussPanel)
     options.Add("Trusses");
-  if (motorPanel)
-    options.Add("Motors");
+  if (hoistPanel)
+    options.Add("Hoists");
   if (sceneObjPanel)
     options.Add("Objects");
   if (options.IsEmpty())
@@ -1273,8 +1273,8 @@ void MainWindow::OnExportCSV(wxCommandEvent &WXUNUSED(event)) {
   } else if (choice == "Trusses" && trussPanel) {
     ctrl = trussPanel->GetTableCtrl();
     type = TablePrinter::TableType::Trusses;
-  } else if (choice == "Motors" && motorPanel) {
-    ctrl = motorPanel->GetTableCtrl();
+  } else if (choice == "Hoists" && hoistPanel) {
+    ctrl = hoistPanel->GetTableCtrl();
     type = TablePrinter::TableType::Supports;
   } else if (choice == "Objects" && sceneObjPanel) {
     ctrl = sceneObjPanel->GetTableCtrl();
@@ -1600,8 +1600,8 @@ void MainWindow::SyncSceneData() {
     fixturePanel->UpdateSceneData();
   if (trussPanel)
     trussPanel->UpdateSceneData();
-  if (motorPanel)
-    motorPanel->UpdateSceneData();
+  if (hoistPanel)
+    hoistPanel->UpdateSceneData();
   if (sceneObjPanel)
     sceneObjPanel->UpdateSceneData();
 }
@@ -1620,8 +1620,8 @@ void MainWindow::OnProjectLoaded(wxCommandEvent &event) {
       fixturePanel->ReloadData();
     if (trussPanel)
       trussPanel->ReloadData();
-    if (motorPanel)
-      motorPanel->ReloadData();
+    if (hoistPanel)
+      hoistPanel->ReloadData();
     if (sceneObjPanel)
       sceneObjPanel->ReloadData();
     if (viewportPanel) {
@@ -1749,7 +1749,7 @@ void MainWindow::RefreshSummary() {
       summaryPanel->ShowFixtureSummary();
     else if (notebook->GetPage(sel) == trussPanel)
       summaryPanel->ShowTrussSummary();
-    else if (notebook->GetPage(sel) == motorPanel)
+    else if (notebook->GetPage(sel) == hoistPanel)
       summaryPanel->ShowFixtureSummary();
     else if (notebook->GetPage(sel) == sceneObjPanel)
       summaryPanel->ShowSceneObjectSummary();
@@ -1785,9 +1785,9 @@ void MainWindow::OnUndo(wxCommandEvent &WXUNUSED(event)) {
     trussPanel->ReloadData();
     trussPanel->SelectByUuid(cfg.GetSelectedTrusses());
   }
-  if (motorPanel) {
-    motorPanel->ReloadData();
-    motorPanel->SelectByUuid(cfg.GetSelectedSupports());
+  if (hoistPanel) {
+    hoistPanel->ReloadData();
+    hoistPanel->SelectByUuid(cfg.GetSelectedSupports());
   }
   if (sceneObjPanel) {
     sceneObjPanel->ReloadData();
@@ -1799,7 +1799,7 @@ void MainWindow::OnUndo(wxCommandEvent &WXUNUSED(event)) {
       viewportPanel->SetSelectedFixtures(cfg.GetSelectedFixtures());
     else if (trussPanel && trussPanel->IsActivePage())
       viewportPanel->SetSelectedFixtures(cfg.GetSelectedTrusses());
-    else if (motorPanel && motorPanel->IsActivePage())
+    else if (hoistPanel && hoistPanel->IsActivePage())
       viewportPanel->SetSelectedFixtures(cfg.GetSelectedSupports());
     else if (sceneObjPanel && sceneObjPanel->IsActivePage())
       viewportPanel->SetSelectedFixtures(cfg.GetSelectedSceneObjects());
@@ -1825,9 +1825,9 @@ void MainWindow::OnRedo(wxCommandEvent &WXUNUSED(event)) {
     trussPanel->ReloadData();
     trussPanel->SelectByUuid(cfg.GetSelectedTrusses());
   }
-  if (motorPanel) {
-    motorPanel->ReloadData();
-    motorPanel->SelectByUuid(cfg.GetSelectedSupports());
+  if (hoistPanel) {
+    hoistPanel->ReloadData();
+    hoistPanel->SelectByUuid(cfg.GetSelectedSupports());
   }
   if (sceneObjPanel) {
     sceneObjPanel->ReloadData();
@@ -1839,7 +1839,7 @@ void MainWindow::OnRedo(wxCommandEvent &WXUNUSED(event)) {
       viewportPanel->SetSelectedFixtures(cfg.GetSelectedFixtures());
     else if (trussPanel && trussPanel->IsActivePage())
       viewportPanel->SetSelectedFixtures(cfg.GetSelectedTrusses());
-    else if (motorPanel && motorPanel->IsActivePage())
+    else if (hoistPanel && hoistPanel->IsActivePage())
       viewportPanel->SetSelectedFixtures(cfg.GetSelectedSupports());
     else if (sceneObjPanel && sceneObjPanel->IsActivePage())
       viewportPanel->SetSelectedFixtures(cfg.GetSelectedSceneObjects());
@@ -2222,8 +2222,8 @@ void MainWindow::OnDelete(wxCommandEvent &WXUNUSED(event)) {
     fixturePanel->DeleteSelected();
   else if (trussPanel && trussPanel->IsActivePage())
     trussPanel->DeleteSelected();
-  else if (motorPanel && motorPanel->IsActivePage())
-    motorPanel->DeleteSelected();
+  else if (hoistPanel && hoistPanel->IsActivePage())
+    hoistPanel->DeleteSelected();
   else if (sceneObjPanel && sceneObjPanel->IsActivePage())
     sceneObjPanel->DeleteSelected();
 }

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -27,7 +27,7 @@ wxDECLARE_EVENT(EVT_PROJECT_LOADED, wxCommandEvent);
 class wxNotebook;
 class FixtureTablePanel;
 class TrussTablePanel;
-class MotorTablePanel;
+class HoistTablePanel;
 class SceneObjectTablePanel;
 class Viewer3DPanel;
 class Viewer2DPanel;
@@ -63,7 +63,7 @@ private:
   wxNotebook *notebook = nullptr;
   FixtureTablePanel *fixturePanel = nullptr;
   TrussTablePanel *trussPanel = nullptr;
-  MotorTablePanel *motorPanel = nullptr;
+  HoistTablePanel *hoistPanel = nullptr;
   SceneObjectTablePanel *sceneObjPanel = nullptr;
   wxAuiManager *auiManager = nullptr;
   Viewer3DPanel *viewportPanel = nullptr;

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -588,7 +588,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
       tinyxml2::XMLElement *data = doc.NewElement("Data");
       data->SetAttribute("provider", "Perastage");
       data->SetAttribute("ver", "1.0");
-      tinyxml2::XMLElement *info = doc.NewElement("MotorInfo");
+      tinyxml2::XMLElement *info = doc.NewElement("HoistInfo");
       info->SetAttribute("uuid", s.uuid.c_str());
 
       auto addNum = [&](const char *n, float v, const char *unit) {

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -644,8 +644,10 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         if (tinyxml2::XMLElement *ud = node->FirstChildElement("UserData")) {
           for (tinyxml2::XMLElement *data = ud->FirstChildElement("Data"); data;
                data = data->NextSiblingElement("Data")) {
-            if (tinyxml2::XMLElement *info =
-                    data->FirstChildElement("MotorInfo")) {
+            tinyxml2::XMLElement *info = data->FirstChildElement("HoistInfo");
+            if (!info)
+              info = data->FirstChildElement("MotorInfo"); // Legacy name
+            if (info) {
               auto readFloat = [&](const char *name, float &out) {
                 if (tinyxml2::XMLElement *e = info->FirstChildElement(name)) {
                   if (const char *txt = e->GetText()) {


### PR DESCRIPTION
## Summary
- rename motor table panel to hoist terminology and update UI labels
- update default support column headers and MVR metadata tags to use Hoist naming while parsing legacy Motor entries

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937f31b02f483248beadee14aa4bd33)