### PR TITLE
Add hoist summaries to UI panels

### DIFF
--- a/gui/riggingpanel.cpp
+++ b/gui/riggingpanel.cpp
@@ -42,10 +42,15 @@ RiggingPanel::RiggingPanel(wxWindow *parent) : wxPanel(parent, wxID_ANY) {
                           wxALIGN_RIGHT, wxDATAVIEW_COL_RESIZABLE);
   table->AppendTextColumn("Trusses", wxDATAVIEW_CELL_INERT, wxCOL_WIDTH_AUTOSIZE,
                           wxALIGN_RIGHT, wxDATAVIEW_COL_RESIZABLE);
+  table->AppendTextColumn("Hoists", wxDATAVIEW_CELL_INERT, wxCOL_WIDTH_AUTOSIZE,
+                          wxALIGN_RIGHT, wxDATAVIEW_COL_RESIZABLE);
   table->AppendTextColumn("Fixture Weight (kg)", wxDATAVIEW_CELL_INERT,
                           wxCOL_WIDTH_AUTOSIZE, wxALIGN_RIGHT,
                           wxDATAVIEW_COL_RESIZABLE);
   table->AppendTextColumn("Truss Weight (kg)", wxDATAVIEW_CELL_INERT,
+                          wxCOL_WIDTH_AUTOSIZE, wxALIGN_RIGHT,
+                          wxDATAVIEW_COL_RESIZABLE);
+  table->AppendTextColumn("Hoists Weight (kg)", wxDATAVIEW_CELL_INERT,
                           wxCOL_WIDTH_AUTOSIZE, wxALIGN_RIGHT,
                           wxDATAVIEW_COL_RESIZABLE);
   table->AppendTextColumn("Total Weight (kg)", wxDATAVIEW_CELL_INERT,
@@ -81,10 +86,13 @@ void RiggingPanel::RefreshData() {
   struct Totals {
     int fixtures = 0;
     int trusses = 0;
+    int hoists = 0;
     float fixtureWeight = 0.0f;
     float trussWeight = 0.0f;
+    float hoistWeight = 0.0f;
     bool hasZeroWeightFixture = false;
     bool hasZeroWeightTruss = false;
+    bool hasZeroWeightHoist = false;
   };
 
   std::map<std::string, Totals> rows;
@@ -109,41 +117,61 @@ void RiggingPanel::RefreshData() {
       entry.hasZeroWeightTruss = true;
   }
 
+  for (const auto &[uuid, support] : scene.supports) {
+    std::string pos = support.positionName.empty() ? UNASSIGNED_POSITION
+                                                   : support.positionName;
+    auto &entry = rows[pos];
+    entry.hoists++;
+    entry.hoistWeight += support.weightKg;
+    if (support.weightKg <= 0.0f)
+      entry.hasZeroWeightHoist = true;
+  }
+
   // Ensure both the view and the custom store start from a clean state so
   // text colours get recalculated on every refresh.
   store->DeleteAllItems();
   table->DeleteAllItems();
   for (const auto &[position, totals] : rows) {
-    float totalWeight = totals.fixtureWeight + totals.trussWeight;
+    float totalWeight =
+        totals.fixtureWeight + totals.trussWeight + totals.hoistWeight;
     wxVector<wxVariant> row;
     row.push_back(wxString::FromUTF8(position));
     row.push_back(wxString::Format("%d", totals.fixtures));
     row.push_back(wxString::Format("%d", totals.trusses));
+    row.push_back(wxString::Format("%d", totals.hoists));
     row.push_back(wxString::Format("%.2f", totals.fixtureWeight));
     row.push_back(wxString::Format("%.2f", totals.trussWeight));
+    row.push_back(wxString::Format("%.2f", totals.hoistWeight));
     row.push_back(wxString::Format("%.2f", totalWeight));
     unsigned int rowIndex = table->GetItemCount();
     table->AppendItem(row);
 
     const bool fixtureCountZero = totals.fixtures == 0;
     const bool trussCountZero = totals.trusses == 0;
+    const bool hoistCountZero = totals.hoists == 0;
     const bool fixtureWeightZero =
         totals.fixtureWeight <= 0.0f || totals.hasZeroWeightFixture;
     const bool trussWeightZero =
         totals.trussWeight <= 0.0f || totals.hasZeroWeightTruss;
+    const bool hoistWeightZero =
+        totals.hoistWeight <= 0.0f || totals.hasZeroWeightHoist;
 
     if (fixtureCountZero)
       store->SetCellTextColour(rowIndex, 1, *wxRED);
     if (trussCountZero)
       store->SetCellTextColour(rowIndex, 2, *wxRED);
-    if (fixtureWeightZero)
+    if (hoistCountZero)
       store->SetCellTextColour(rowIndex, 3, *wxRED);
-    if (trussWeightZero)
+    if (fixtureWeightZero)
       store->SetCellTextColour(rowIndex, 4, *wxRED);
-
-    if (fixtureCountZero || trussCountZero || fixtureWeightZero ||
-        trussWeightZero)
+    if (trussWeightZero)
       store->SetCellTextColour(rowIndex, 5, *wxRED);
+    if (hoistWeightZero)
+      store->SetCellTextColour(rowIndex, 6, *wxRED);
+
+    if (fixtureCountZero || trussCountZero || hoistCountZero ||
+        fixtureWeightZero || trussWeightZero || hoistWeightZero)
+      store->SetCellTextColour(rowIndex, 7, *wxRED);
   }
 
   AutoSizeColumns(table);

--- a/gui/summarypanel.cpp
+++ b/gui/summarypanel.cpp
@@ -59,12 +59,47 @@ void SummaryPanel::ShowSummary(const std::vector<std::pair<std::string,int>>& it
 
 void SummaryPanel::ShowFixtureSummary()
 {
-    std::map<std::string,int> counts;
+    if (!table) return;
+
+    auto addSection = [&](const std::string& title,
+                          const std::vector<std::pair<std::string, int>>& items) {
+        wxVector<wxVariant> header;
+        header.push_back(wxVariant());
+        header.push_back(wxString::FromUTF8(title));
+        table->AppendItem(header);
+
+        for (const auto& [name, count] : items) {
+            wxVector<wxVariant> row;
+            row.push_back(wxString::Format("%d", count));
+            row.push_back(wxString::FromUTF8(name));
+            table->AppendItem(row);
+        }
+    };
+
+    table->DeleteAllItems();
+
+    std::map<std::string, int> fixtureCounts;
     const auto& fixtures = ConfigManager::Get().GetScene().fixtures;
     for (const auto& [uuid, fix] : fixtures)
-        counts[fix.typeName]++;
-    std::vector<std::pair<std::string,int>> items(counts.begin(), counts.end());
-    ShowSummary(items);
+        fixtureCounts[fix.typeName]++;
+    std::vector<std::pair<std::string, int>> fixtureItems(fixtureCounts.begin(), fixtureCounts.end());
+
+    addSection("Fixtures", fixtureItems);
+
+    wxVector<wxVariant> spacer;
+    spacer.push_back(wxVariant());
+    spacer.push_back(wxVariant());
+    table->AppendItem(spacer);
+
+    std::map<std::string, int> hoistCounts;
+    const auto& supports = ConfigManager::Get().GetScene().supports;
+    for (const auto& [uuid, support] : supports) {
+        std::string type = support.function.empty() ? "Hoist" : support.function;
+        hoistCounts[type]++;
+    }
+    std::vector<std::pair<std::string, int>> hoistItems(hoistCounts.begin(), hoistCounts.end());
+
+    addSection("Hoists", hoistItems);
 }
 
 void SummaryPanel::ShowTrussSummary()


### PR DESCRIPTION
## Summary
- show fixtures and hoists as separate sections in the summary panel, aggregating hoist types from Motors data
- extend rigging panel with hoist count and weight columns and include them in totals
- apply consistent zero-value highlighting for the new rigging columns

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937f64c45cc8324801ac41292d3c312)