### PR TITLE
Enforce hoist symbol selection

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -239,7 +239,7 @@ void ConfigManager::ApplyColumnDefaults() {
     SetValue("truss_print_columns", "Name,Layer,Hang Pos,Manufacturer,Model");
   if (!HasKey("support_print_columns"))
     SetValue("support_print_columns",
-             "Hoist ID,Name,Type,Rigging Point,Layer,Hang Pos,Pos X,Pos Y,Pos Z,Roll (X),Pitch (Y),Yaw (Z),Chain Length (m),Capacity (kg),Weight (kg)");
+             "Hoist ID,Name,Type,Symbol,Layer,Hang Pos,Pos X,Pos Y,Pos Z,Roll (X),Pitch (Y),Yaw (Z),Chain Length (m),Capacity (kg),Weight (kg)");
   if (!HasKey("sceneobject_print_columns"))
     SetValue("sceneobject_print_columns", "Name,Layer");
 }

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -582,7 +582,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
     se->InsertEndChild(mat);
 
     bool hasMeta = s.capacityKg != 0.0f || s.weightKg != 0.0f ||
-                   !s.riggingPoint.empty();
+                   !s.symbol.empty();
     if (hasMeta) {
       tinyxml2::XMLElement *ud = doc.NewElement("UserData");
       tinyxml2::XMLElement *data = doc.NewElement("Data");
@@ -603,9 +603,10 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
       addNum("Capacity", s.capacityKg, "kg");
       addNum("Weight", s.weightKg, "kg");
 
-      if (!s.riggingPoint.empty()) {
+      if (!s.symbol.empty()) {
         tinyxml2::XMLElement *rp = doc.NewElement("RiggingPoint");
-        rp->SetText(s.riggingPoint.c_str());
+        std::string symbol = NormalizeHoistSymbol(s.symbol);
+        rp->SetText(symbol.c_str());
         info->InsertEndChild(rp);
       }
 

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -663,7 +663,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
               if (tinyxml2::XMLElement *rp =
                       info->FirstChildElement("RiggingPoint")) {
                 if (const char *txt = rp->GetText())
-                  support.riggingPoint = Trim(txt);
+                  support.symbol = NormalizeHoistSymbol(Trim(txt));
               }
             }
           }


### PR DESCRIPTION
## Summary
- rename the hoist rigging point column to Symbol and normalize the stored value
- add allowed hoist symbol options with defaults to Lighting and fallback to Extra when unknown
- update MVR import/export and table editing to use the constrained symbol list

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693802859dcc8324a12ba7b7ac9738f3)