### PR TITLE
Add tool action to convert fixtures to hoists

### DIFF
--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -89,6 +89,7 @@ private:
   void OnExportSceneObject(wxCommandEvent &event); // Export scene object model
   void OnAutoPatch(wxCommandEvent &event);         // Auto patch fixtures
   void OnAutoColor(wxCommandEvent &event);         // Auto assign colors
+  void OnConvertToHoist(wxCommandEvent &event);    // Convert fixtures to hoists
   void OnPrintTable(wxCommandEvent &event);        // Print selected table
   void OnExportCSV(wxCommandEvent &event);         // Export table to CSV
   void
@@ -167,6 +168,7 @@ enum {
   ID_Tools_ExportSceneObject,
   ID_Tools_AutoPatch,
   ID_Tools_AutoColor,
+  ID_Tools_ConvertToHoist,
   ID_Help_Help,
   ID_Help_About,
   ID_Select_Fixtures,


### PR DESCRIPTION
## Summary
- add a Tools menu action to convert selected fixtures into hoist supports
- copy fixture attributes into new supports with generated UUIDs and refresh UI selections and panels

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939887637408324acc3be2b8d2dc9e6)