### PR TITLE
Refresh hoist tables after loading and imports

### DIFF
--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -21,6 +21,7 @@
 #include "configmanager.h"
 #include "layerpanel.h"
 #include "matrixutils.h"
+#include "riggingpanel.h"
 #include "stringutils.h"
 #include "summarypanel.h"
 #include "support.h"
@@ -151,8 +152,10 @@ void HoistTablePanel::ReloadData() {
 
   if (LayerPanel::Instance())
     LayerPanel::Instance()->ReloadLayers();
-  if (SummaryPanel::Instance() && IsActivePage())
+  if (SummaryPanel::Instance())
     SummaryPanel::Instance()->ShowFixtureSummary();
+  if (RiggingPanel::Instance())
+    RiggingPanel::Instance()->RefreshData();
 }
 
 void HoistTablePanel::OnContextMenu(wxDataViewEvent &event) {
@@ -483,8 +486,10 @@ void HoistTablePanel::UpdateSceneData() {
     it->second.weightKg = static_cast<float>(weight);
   }
 
-  if (SummaryPanel::Instance() && IsActivePage())
+  if (SummaryPanel::Instance())
     SummaryPanel::Instance()->ShowFixtureSummary();
+  if (RiggingPanel::Instance())
+    RiggingPanel::Instance()->RefreshData();
 }
 
 HoistTablePanel *HoistTablePanel::Instance() { return s_instance; }

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -638,10 +638,13 @@ void MainWindow::OnImportRider(wxCommandEvent &event) {
       fixturePanel->ReloadData();
     if (trussPanel)
       trussPanel->ReloadData();
+    if (hoistPanel)
+      hoistPanel->ReloadData();
     if (viewportPanel) {
       viewportPanel->UpdateScene();
       viewportPanel->Refresh();
     }
+    RefreshSummary();
   }
 }
 
@@ -672,9 +675,11 @@ void MainWindow::OnImportMVR(wxCommandEvent &event) {
       fixturePanel->ReloadData();
     if (trussPanel)
       trussPanel->ReloadData();
+    if (hoistPanel)
+      hoistPanel->ReloadData();
     if (sceneObjPanel)
       sceneObjPanel->ReloadData();
-    RefreshRigging();
+    RefreshSummary();
     if (viewportPanel) {
       viewportPanel->UpdateScene();
       viewportPanel->Refresh();
@@ -1517,6 +1522,8 @@ bool MainWindow::LoadProjectFromPath(const std::string &path) {
     fixturePanel->ReloadData();
   if (trussPanel)
     trussPanel->ReloadData();
+  if (hoistPanel)
+    hoistPanel->ReloadData();
   if (sceneObjPanel)
     sceneObjPanel->ReloadData();
   if (viewportPanel) {
@@ -1540,6 +1547,8 @@ bool MainWindow::LoadProjectFromPath(const std::string &path) {
     viewport2DRenderPanel->ApplyConfig();
   if (layerPanel)
     layerPanel->ReloadLayers();
+  RefreshSummary();
+  RefreshRigging();
   ConfigManager::Get().MarkSaved();
   UpdateTitle();
   return true;
@@ -1553,6 +1562,8 @@ void MainWindow::ResetProject() {
     fixturePanel->ReloadData();
   if (trussPanel)
     trussPanel->ReloadData();
+  if (hoistPanel)
+    hoistPanel->ReloadData();
   if (sceneObjPanel)
     sceneObjPanel->ReloadData();
   if (viewportPanel) {
@@ -1568,6 +1579,8 @@ void MainWindow::ResetProject() {
     viewport2DRenderPanel->ApplyConfig();
   if (layerPanel)
     layerPanel->ReloadLayers();
+  RefreshSummary();
+  RefreshRigging();
   UpdateTitle();
 }
 


### PR DESCRIPTION
## Summary
- refresh hoist table and rigging/summary panels after importing riders or MVR files
- reload hoists and regenerate summaries when loading or resetting projects
- keep summary and rigging data in sync when editing hoist table rows

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69398c2ad2d48324824473e5b98fe022)