### PR TITLE
Fix summary panel contents based on active tab

### DIFF
--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -153,7 +153,7 @@ void HoistTablePanel::ReloadData() {
   if (LayerPanel::Instance())
     LayerPanel::Instance()->ReloadLayers();
   if (SummaryPanel::Instance())
-    SummaryPanel::Instance()->ShowFixtureSummary();
+    SummaryPanel::Instance()->ShowHoistSummary();
   if (RiggingPanel::Instance())
     RiggingPanel::Instance()->RefreshData();
 }
@@ -487,7 +487,7 @@ void HoistTablePanel::UpdateSceneData() {
   }
 
   if (SummaryPanel::Instance())
-    SummaryPanel::Instance()->ShowFixtureSummary();
+    SummaryPanel::Instance()->ShowHoistSummary();
   if (RiggingPanel::Instance())
     RiggingPanel::Instance()->RefreshData();
 }
@@ -563,7 +563,7 @@ void HoistTablePanel::DeleteSelected() {
   }
 
   if (SummaryPanel::Instance())
-    SummaryPanel::Instance()->ShowFixtureSummary();
+    SummaryPanel::Instance()->ShowHoistSummary();
 
   if (Viewer3DPanel::Instance()) {
     Viewer3DPanel::Instance()->UpdateScene();

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1849,7 +1849,7 @@ void MainWindow::RefreshSummary() {
     else if (notebook->GetPage(sel) == trussPanel)
       summaryPanel->ShowTrussSummary();
     else if (notebook->GetPage(sel) == hoistPanel)
-      summaryPanel->ShowFixtureSummary();
+      summaryPanel->ShowHoistSummary();
     else if (notebook->GetPage(sel) == sceneObjPanel)
       summaryPanel->ShowSceneObjectSummary();
   }

--- a/gui/summarypanel.cpp
+++ b/gui/summarypanel.cpp
@@ -61,21 +61,6 @@ void SummaryPanel::ShowFixtureSummary()
 {
     if (!table) return;
 
-    auto addSection = [&](const std::string& title,
-                          const std::vector<std::pair<std::string, int>>& items) {
-        wxVector<wxVariant> header;
-        header.push_back(wxVariant());
-        header.push_back(wxString::FromUTF8(title));
-        table->AppendItem(header);
-
-        for (const auto& [name, count] : items) {
-            wxVector<wxVariant> row;
-            row.push_back(wxString::Format("%d", count));
-            row.push_back(wxString::FromUTF8(name));
-            table->AppendItem(row);
-        }
-    };
-
     table->DeleteAllItems();
 
     std::map<std::string, int> fixtureCounts;
@@ -84,22 +69,7 @@ void SummaryPanel::ShowFixtureSummary()
         fixtureCounts[fix.typeName]++;
     std::vector<std::pair<std::string, int>> fixtureItems(fixtureCounts.begin(), fixtureCounts.end());
 
-    addSection("Fixtures", fixtureItems);
-
-    wxVector<wxVariant> spacer;
-    spacer.push_back(wxVariant());
-    spacer.push_back(wxVariant());
-    table->AppendItem(spacer);
-
-    std::map<std::string, int> hoistCounts;
-    const auto& supports = ConfigManager::Get().GetScene().supports;
-    for (const auto& [uuid, support] : supports) {
-        std::string type = support.function.empty() ? "Hoist" : support.function;
-        hoistCounts[type]++;
-    }
-    std::vector<std::pair<std::string, int>> hoistItems(hoistCounts.begin(), hoistCounts.end());
-
-    addSection("Hoists", hoistItems);
+    ShowSummary(fixtureItems);
 }
 
 void SummaryPanel::ShowTrussSummary()
@@ -110,6 +80,21 @@ void SummaryPanel::ShowTrussSummary()
         counts[truss.model]++;
     std::vector<std::pair<std::string,int>> items(counts.begin(), counts.end());
     ShowSummary(items);
+}
+
+void SummaryPanel::ShowHoistSummary()
+{
+    if (!table) return;
+
+    std::map<std::string, int> hoistCounts;
+    const auto& supports = ConfigManager::Get().GetScene().supports;
+    for (const auto& [uuid, support] : supports) {
+        std::string type = support.function.empty() ? "Hoist" : support.function;
+        hoistCounts[type]++;
+    }
+    std::vector<std::pair<std::string, int>> hoistItems(hoistCounts.begin(), hoistCounts.end());
+
+    ShowSummary(hoistItems);
 }
 
 void SummaryPanel::ShowSceneObjectSummary()

--- a/gui/summarypanel.h
+++ b/gui/summarypanel.h
@@ -27,6 +27,7 @@ public:
 
     void ShowFixtureSummary();
     void ShowTrussSummary();
+    void ShowHoistSummary();
     void ShowSceneObjectSummary();
 
     static SummaryPanel* Instance();


### PR DESCRIPTION
## Summary
- add dedicated hoist summary rendering and remove hoist data from fixture summaries
- update hoist table actions and page selection to use the hoist summary view

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69398d84632c8324bb9ccf373e172935)