### PR TITLE
Rename hoist symbol to function and allow custom values

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -239,7 +239,7 @@ void ConfigManager::ApplyColumnDefaults() {
     SetValue("truss_print_columns", "Name,Layer,Hang Pos,Manufacturer,Model");
   if (!HasKey("support_print_columns"))
     SetValue("support_print_columns",
-             "Hoist ID,Name,Type,Symbol,Layer,Hang Pos,Pos X,Pos Y,Pos Z,Roll (X),Pitch (Y),Yaw (Z),Chain Length (m),Capacity (kg),Weight (kg)");
+             "Hoist ID,Name,Type,Function,Layer,Hang Pos,Pos X,Pos Y,Pos Z,Roll (X),Pitch (Y),Yaw (Z),Chain Length (m),Capacity (kg),Weight (kg)");
   if (!HasKey("sceneobject_print_columns"))
     SetValue("sceneobject_print_columns", "Name,Layer");
 }

--- a/models/support.h
+++ b/models/support.h
@@ -37,19 +37,19 @@ struct Support {
 
     float capacityKg = 0.0f;
     float weightKg = 0.0f;
-    // Hoist symbol/category. Limited to values returned by GetHoistSymbolOptions().
-    std::string symbol = "Lighting";
+    // Hoist function/category. Defaults to values returned by GetHoistFunctionOptions().
+    std::string hoistFunction = "Lighting";
 
     Matrix transform;
 };
 
-inline const std::array<std::string, 5> &GetHoistSymbolOptions() {
+inline const std::array<std::string, 5> &GetHoistFunctionOptions() {
     static const std::array<std::string, 5> options = {
         "Lighting", "Audio", "Video", "Scenic", "Extra"};
     return options;
 }
 
-inline std::string NormalizeHoistSymbol(const std::string &rawValue) {
+inline std::string NormalizeHoistFunction(const std::string &rawValue) {
     auto trimmed = rawValue;
     auto trimSpaces = [](std::string &s) {
         auto notSpace = [](unsigned char ch) { return !std::isspace(ch); };
@@ -71,7 +71,7 @@ inline std::string NormalizeHoistSymbol(const std::string &rawValue) {
     std::transform(lower.begin(), lower.end(), lower.begin(),
                    [](unsigned char c) { return std::tolower(c); });
 
-    for (const auto &opt : GetHoistSymbolOptions()) {
+    for (const auto &opt : GetHoistFunctionOptions()) {
         auto optLower = opt;
         std::transform(optLower.begin(), optLower.end(), optLower.begin(),
                        [](unsigned char c) { return std::tolower(c); });
@@ -79,6 +79,6 @@ inline std::string NormalizeHoistSymbol(const std::string &rawValue) {
             return opt;
     }
 
-    return "Extra";
+    return trimmed;
 }
 

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -559,7 +559,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
       resourceFiles.insert(s.gdtfSpec);
     }
     addStr("GDTFMode", s.gdtfMode);
-    addStr("Function", s.function);
+    std::string functionValue = s.hoistFunction.empty() ? s.function : s.hoistFunction;
+    addStr("Function", functionValue);
 
     if (s.chainLength > 0.0f) {
       tinyxml2::XMLElement *len = doc.NewElement("ChainLength");
@@ -585,7 +586,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
     se->InsertEndChild(mat);
 
     bool hasMeta = s.capacityKg != 0.0f || s.weightKg != 0.0f ||
-                   !s.symbol.empty();
+                   !s.hoistFunction.empty();
     if (hasMeta) {
       tinyxml2::XMLElement *ud = doc.NewElement("UserData");
       tinyxml2::XMLElement *data = doc.NewElement("Data");
@@ -606,10 +607,10 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
       addNum("Capacity", s.capacityKg, "kg");
       addNum("Weight", s.weightKg, "kg");
 
-      if (!s.symbol.empty()) {
+      if (!s.hoistFunction.empty()) {
         tinyxml2::XMLElement *rp = doc.NewElement("RiggingPoint");
-        std::string symbol = NormalizeHoistSymbol(s.symbol);
-        rp->SetText(symbol.c_str());
+        std::string hoistFunction = NormalizeHoistFunction(s.hoistFunction);
+        rp->SetText(hoistFunction.c_str());
         info->InsertEndChild(rp);
       }
 

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -626,6 +626,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         support.gdtfSpec = readText("GDTFSpec");
         support.gdtfMode = readText("GDTFMode");
         support.function = readText("Function");
+        support.hoistFunction = NormalizeHoistFunction(support.function);
         std::string chainText = readText("ChainLength");
         if (!chainText.empty()) {
           try {
@@ -667,12 +668,17 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
               if (tinyxml2::XMLElement *rp =
                       info->FirstChildElement("RiggingPoint")) {
                 if (const char *txt = rp->GetText())
-                  support.symbol = NormalizeHoistSymbol(Trim(txt));
+                  support.hoistFunction = NormalizeHoistFunction(Trim(txt));
               }
             }
           }
         }
 
+        if (support.hoistFunction.empty())
+          support.hoistFunction = NormalizeHoistFunction(support.function);
+
+        if (support.function.empty())
+          support.function = support.hoistFunction;
         auto posIt = scene.positions.find(support.position);
         if (posIt != scene.positions.end())
           support.positionName = posIt->second;


### PR DESCRIPTION
## Summary
- Rename the Hoist table column and related fields from Symbol to Function to reduce confusion
- Allow selecting predefined hoist functions or entering custom values, including during context menu edits
- Load and persist hoist function values from and to MVR files, including user data rigging points

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69399571b9308324a6b52f18023e441a)