### PR TITLE
Freeze data view table updates during batch edits

### DIFF
--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <wx/notebook.h>
 #include <wx/choicdlg.h>
+#include <wx/wupdlock.h> // freeze/thaw UI during batch edits
 
 static SceneObjectTablePanel* s_instance = nullptr;
 
@@ -145,6 +146,12 @@ void SceneObjectTablePanel::OnContextMenu(wxDataViewEvent& event)
     int col = event.GetColumn();
     if (!item.IsOk() || col < 0)
         return;
+
+    // Freeze UI updates while performing bulk table modifications. Without
+    // freezing, the control repaints after each SetValue call or resort,
+    // causing noticeable lag when updating multiple rows. The locker
+    // automatically unfreezes the table when it goes out of scope.
+    wxWindowUpdateLocker locker(table);
 
     wxDataViewItemArray selections;
     table->GetSelections(selections);

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -36,6 +36,7 @@
 #include <unordered_map>
 #include <wx/notebook.h>
 #include <wx/choicdlg.h>
+#include <wx/wupdlock.h> // freeze/thaw UI during batch edits
 
 static TrussTablePanel* s_instance = nullptr;
 namespace fs = std::filesystem;
@@ -205,6 +206,12 @@ void TrussTablePanel::OnContextMenu(wxDataViewEvent& event)
     int col = event.GetColumn();
     if (!item.IsOk() || col < 0)
         return;
+
+    // Freeze UI updates while performing bulk table modifications to avoid
+    // excessive repaints. This RAII locker calls Freeze() on the table and
+    // Thaw() automatically when it is destroyed at the end of the function,
+    // improving responsiveness during edits.
+    wxWindowUpdateLocker locker(table);
 
     wxDataViewItemArray selections;
     table->GetSelections(selections);


### PR DESCRIPTION
## Summary
- include wxWindowUpdateLocker in each table panel context menu to freeze updates during batch edits
- prevent repeated repaints while editing hoist, truss, and scene object tables

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693999e514348324bada4aceb9e14e4b)