### PR TITLE
Include wx/event header for wxCallAfter

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -33,6 +33,7 @@
 #include <tinyxml2.h>
 #include <wx/aboutdlg.h>
 #include <wx/app.h>
+#include <wx/event.h>
 #include <wx/filefn.h>
 #include <wx/filename.h>
 #include <wx/html/htmlwin.h>


### PR DESCRIPTION
## Summary
- add the wx/event header in mainwindow.cpp so wxCallAfter is available

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ac715a27483249c8c48231e3cdc4f)