### PR TITLE
Use wxTheApp CallAfter for plan export

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1323,7 +1323,7 @@ void MainWindow::OnPrintPlan(wxCommandEvent &WXUNUSED(event)) {
   std::thread([this, buffer = std::move(buffer), state, opts, outputPath]() {
     bool ok = ExportPlanToPdf(buffer, state, opts, outputPath);
 
-    wxCallAfter([this, ok, outputPath]() {
+    wxTheApp->CallAfter([this, ok, outputPath]() {
       if (!ok) {
         wxMessageBox("Failed to generate PDF plan.", "Print Plan",
                      wxOK | wxICON_ERROR, this);


### PR DESCRIPTION
## Summary
- invoke CallAfter via wxTheApp to post PDF export results safely back to the UI thread

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ac863de1c83248d3c03d904703741)