### PR TITLE
Handle Unicode paths when exporting plan PDF

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1316,20 +1316,22 @@ void MainWindow::OnPrintPlan(wxCommandEvent &WXUNUSED(event)) {
 
   Viewer2DViewState state = viewport2DPanel->GetViewState();
   PlanPrintOptions opts; // Defaults to A3 portrait.
-  std::string outputPath = dlg.GetPath().ToStdString();
 
   // Run the PDF generation off the UI thread to avoid freezing the window while
   // writing potentially large plans to disk.
-  std::thread([this, buffer = std::move(buffer), state, opts, outputPath]() {
+  wxString outputPathWx = dlg.GetPath();
+  std::thread([this, buffer = std::move(buffer), state, opts, outputPathWx]() {
+    std::filesystem::path outputPath =
+        std::filesystem::path(outputPathWx.ToStdWstring());
     bool ok = ExportPlanToPdf(buffer, state, opts, outputPath);
 
-    wxTheApp->CallAfter([this, ok, outputPath]() {
+    wxTheApp->CallAfter([this, ok, outputPathWx]() {
       if (!ok) {
         wxMessageBox("Failed to generate PDF plan.", "Print Plan",
                      wxOK | wxICON_ERROR, this);
       } else {
         wxMessageBox(wxString::Format("Plan saved to %s",
-                                      wxString::FromUTF8(outputPath)),
+                                      outputPathWx),
                      "Print Plan", wxOK | wxICON_INFORMATION, this);
       }
     });

--- a/viewer2d/planpdfexporter.cpp
+++ b/viewer2d/planpdfexporter.cpp
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <filesystem>
 #include <fstream>
 #include <iomanip>
 #include <sstream>
@@ -205,7 +206,7 @@ void AppendText(std::ostringstream &out, const Point &pos, const TextCommand &cm
 bool ExportPlanToPdf(const CommandBuffer &buffer,
                     const Viewer2DViewState &viewState,
                     const PlanPrintOptions &options,
-                    const std::string &outputPath) {
+                    const std::filesystem::path &outputPath) {
   if (buffer.commands.empty())
     return false;
 

--- a/viewer2d/planpdfexporter.h
+++ b/viewer2d/planpdfexporter.h
@@ -20,6 +20,7 @@
 
 #include "canvas2d.h"
 #include "viewer2dpanel.h"
+#include <filesystem>
 #include <string>
 
 // Options describing the paper size and orientation for the PDF export. A3
@@ -37,5 +38,5 @@ struct PlanPrintOptions {
 bool ExportPlanToPdf(const CommandBuffer &buffer,
                     const Viewer2DViewState &viewState,
                     const PlanPrintOptions &options,
-                    const std::string &outputPath);
+                    const std::filesystem::path &outputPath);
 


### PR DESCRIPTION
## Summary
- ensure plan PDF export uses filesystem paths so PDF export works with Unicode file names
- capture the save path as a wxString for messaging while passing a wide-compatible path to the exporter

## Testing
- not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ac997118483248b9568709eb4a1be)