### PR TITLE
Ensure TryParseFloat validates full token

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -231,7 +231,9 @@ bool TryParseFloat(const std::string &text, float &out) {
   auto *end = trimmed.data() + trimmed.size();
 
   auto result = std::from_chars(begin, end, out);
-  return result.ec == std::errc{};
+  // Success requires the conversion to finish without errors and consume the
+  // entire trimmed token so trailing garbage is rejected.
+  return result.ec == std::errc{} && result.ptr == end;
 }
 } // namespace
 


### PR DESCRIPTION
## Summary
- ensure TryParseFloat uses from_chars result to require the entire value to parse
- reject numeric configuration values with trailing garbage more safely

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693afbe4ffe08324ab9f5ee42e3d13bf)