### PR TITLE
Fix capture transform handling in viewer3d

### DIFF
--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -153,7 +153,10 @@ private:
                                {});
 
   // Draws only the mesh edges for wireframe rendering
-  void DrawMeshWireframe(const Mesh &mesh, float scale = RENDER_SCALE);
+  void DrawMeshWireframe(
+      const Mesh &mesh, float scale = RENDER_SCALE,
+      const std::function<std::array<float, 3>(
+          const std::array<float, 3> &)> &captureTransform = {});
 
   // Draws a colored cube tinted when selected or highlighted. The optional
   // center offset parameters are unused and kept for compatibility.


### PR DESCRIPTION
## Summary
- ensure capture transforms are passed into wireframe mesh rendering for capture logging
- provide fixture-level capture transform when drawing fallback cubes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b5992ac208324bdefca615bc17003)