### PR TITLE
Fix PDF export vertical orientation

### DIFF
--- a/viewer2d/planpdfexporter.cpp
+++ b/viewer2d/planpdfexporter.cpp
@@ -62,8 +62,10 @@ Point MapToPage(double x, double y, double minX, double minY, double scale,
                 double offsetX, double offsetY, double pageHeight) {
   double px = offsetX + (x - minX) * scale;
   double py = offsetY + (y - minY) * scale;
-  // Flip Y because PDF origin is at the bottom-left.
-  return {px, pageHeight - py};
+  // Keep the same top-left origin as the 2D viewer so the PDF matches the
+  // on-screen layout.
+  (void)pageHeight; // Retained for future layout tweaks.
+  return {px, py};
 }
 
 void AppendStroke(std::ostringstream &out, const CanvasStroke &stroke) {


### PR DESCRIPTION
## Summary
- maintain the 2D viewer's top-left origin when mapping coordinates into PDF space
- prevent truss and fixture geometry from being flipped vertically in exported plans

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b5ba7bb6083248f12d696aac6628f)