### PR TITLE
Apply capture transform during PDF mesh export

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1421,6 +1421,10 @@ void Viewer3DController::DrawMeshWithOutline(
            mesh.vertices[i1 * 3 + 2] * scale},
           {mesh.vertices[i2 * 3] * scale, mesh.vertices[i2 * 3 + 1] * scale,
            mesh.vertices[i2 * 3 + 2] * scale}};
+      if (captureTransform) {
+        for (auto &p : pts)
+          p = captureTransform(p);
+      }
       RecordPolygon(pts, stroke, &fill);
     }
   }


### PR DESCRIPTION
## Summary
- apply the world capture transform to mesh triangles when recording filled polygons for PDF export
- ensure fixture meshes render in their correct positions instead of collapsing at the origin

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b60d019b8832480990abb9c8ddac6)