### PR TITLE
Mirror PDF Y axis to match 2D view

### DIFF
--- a/viewer2d/planpdfexporter.cpp
+++ b/viewer2d/planpdfexporter.cpp
@@ -62,9 +62,10 @@ Point MapToPage(double x, double y, double minX, double minY, double scale,
                 double offsetX, double offsetY, double pageHeight) {
   double px = offsetX + (x - minX) * scale;
   double py = offsetY + (y - minY) * scale;
-  // Keep the same top-left origin as the 2D viewer so the PDF matches the
-  // on-screen layout.
-  (void)pageHeight; // Retained for future layout tweaks.
+  // Mirror the Y axis so the PDF uses the same top-left origin as the 2D
+  // viewer. The OpenGL canvas grows upwards, while the PDF coordinate space
+  // grows upwards from the bottom-left corner.
+  py = pageHeight - py;
   return {px, py};
 }
 


### PR DESCRIPTION
## Summary
- mirror the PDF export Y axis so recorded 2D commands keep the same top-left origin as the viewer
- ensure polygon and shape coordinates are mapped using the same orientation as the on-screen 2D view

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b66cc91dc8324be74e44dfe25446a)