### PR TITLE
Capture 2D commands without duplicating viewport offsets

### DIFF
--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -244,10 +244,14 @@ void Viewer2DPanel::Render() {
   if (m_captureNextFrame) {
     m_lastCapturedFrame.Clear();
     recordingCanvas = CreateRecordingCanvas(m_lastCapturedFrame);
+    // The recorded commands operate in the same world-space coordinates used by
+    // the OpenGL renderer. We keep the transform identity so the exporter can
+    // apply the viewport offsets/zoom exactly once using the captured
+    // ViewState, matching the 2D on-screen projection.
     CanvasTransform transform{};
     transform.scale = 1.0f;
-    transform.offsetX = -offX;
-    transform.offsetY = -offY;
+    transform.offsetX = 0.0f;
+    transform.offsetY = 0.0f;
     recordingCanvas->BeginFrame();
     recordingCanvas->SetTransform(transform);
     m_controller.SetCaptureCanvas(recordingCanvas.get(), m_view);


### PR DESCRIPTION
## Summary
- keep the recorded 2D commands in world coordinates when capturing frames
- allow the PDF exporter to apply viewport offsets and zoom exactly once for consistent geometry

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b69e27dd08324802506afa2aa095c)