### PR TITLE
Refine PDF rendering pipeline

### DIFF
--- a/viewer2d/planpdfexporter.h
+++ b/viewer2d/planpdfexporter.h
@@ -32,6 +32,7 @@ struct PlanPrintOptions {
   double marginPt = 36.0;       // Half an inch margin for readability
   bool landscape = false;
   bool compressStreams = true;
+  int floatPrecision = 3;
 };
 
 struct PlanExportResult {


### PR DESCRIPTION
## Summary
- add configurable float precision to plan print options and reuse a shared formatter when emitting PDF content
- introduce a PDF graphics state cache and revised polygon rendering with a separate outline pass to avoid unintended fills
- update shape and text emission to reuse cached state and consistent formatting for smaller, cleaner PDF streams

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b6ef8bce883248dcd73e8e8c90596)