### PR TITLE
Add print include grid flag for 2D plan export

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -145,6 +145,7 @@ ConfigManager::ConfigManager() {
   RegisterVariable("grid_color_g", "float", 0.35f, 0.0f, 1.0f);
   RegisterVariable("grid_color_b", "float", 0.35f, 0.0f, 1.0f);
   RegisterVariable("grid_draw_above", "float", 0.0f, 0.0f, 1.0f);
+  RegisterVariable("print_include_grid", "float", 1.0f, 0.0f, 1.0f);
   RegisterVariable("label_show_name", "float", 1.0f, 0.0f, 1.0f);
   RegisterVariable("label_show_id", "float", 1.0f, 0.0f, 1.0f);
   RegisterVariable("label_show_dmx", "float", 1.0f, 0.0f, 1.0f);

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1313,6 +1313,8 @@ void MainWindow::OnPrintPlan(wxCommandEvent &WXUNUSED(event)) {
   }
 
   PlanPrintOptions opts; // Defaults to A3 portrait.
+  opts.printIncludeGrid =
+      ConfigManager::Get().GetFloat("print_include_grid") != 0.0f;
   std::filesystem::path outputPath(
       std::filesystem::path(outputPathWx.ToStdWstring()));
   wxString outputPathDisplay = outputPathWx;
@@ -1368,7 +1370,7 @@ void MainWindow::OnPrintPlan(wxCommandEvent &WXUNUSED(event)) {
           });
         }).detach();
       },
-      opts.useSimplifiedFootprints);
+      opts.useSimplifiedFootprints, opts.printIncludeGrid);
 }
 
 void MainWindow::OnPrintTable(wxCommandEvent &WXUNUSED(event)) {

--- a/viewer2d/planpdfexporter.h
+++ b/viewer2d/planpdfexporter.h
@@ -34,6 +34,7 @@ struct PlanPrintOptions {
   bool compressStreams = true;
   int floatPrecision = 3;
   bool useSimplifiedFootprints = true;
+  bool printIncludeGrid = true;
 };
 
 struct PlanExportResult {

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -225,9 +225,10 @@ void Viewer2DPanel::RequestFrameCapture() { m_captureNextFrame = true; }
 
 void Viewer2DPanel::CaptureFrameAsync(
     std::function<void(CommandBuffer, Viewer2DViewState)> callback,
-    bool useSimplifiedFootprints) {
+    bool useSimplifiedFootprints, bool includeGridInCapture) {
   m_captureCallback = std::move(callback);
   m_useSimplifiedFootprints = useSimplifiedFootprints;
+  m_captureIncludeGrid = includeGridInCapture;
   RequestFrameCapture();
   Refresh();
 }
@@ -313,7 +314,8 @@ void Viewer2DPanel::Render() {
     transform.offsetY = 0.0f;
     recordingCanvas->BeginFrame();
     recordingCanvas->SetTransform(transform);
-    m_controller.SetCaptureCanvas(recordingCanvas.get(), m_view);
+    m_controller.SetCaptureCanvas(recordingCanvas.get(), m_view,
+                                  m_captureIncludeGrid);
   } else {
     m_controller.SetCaptureCanvas(nullptr, m_view);
   }

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -75,7 +75,8 @@ public:
   // the callback is invoked immediately afterwards.
   void CaptureFrameAsync(
       std::function<void(CommandBuffer, Viewer2DViewState)> callback,
-      bool useSimplifiedFootprints = false);
+      bool useSimplifiedFootprints = false,
+      bool includeGridInCapture = true);
 
   // Accessor for the last recorded set of drawing commands. The buffer is
   // cleared and re-populated on every requested capture.
@@ -113,6 +114,7 @@ private:
 
   bool m_captureNextFrame = false;
   bool m_useSimplifiedFootprints = false;
+  bool m_captureIncludeGrid = true;
   CommandBuffer m_lastCapturedFrame;
   std::function<void(CommandBuffer, Viewer2DViewState)> m_captureCallback;
   std::string m_lastFixtureDebugReport;

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1604,24 +1604,30 @@ void Viewer3DController::DrawGrid(int style, float r, float g, float b,
         glVertex3f(i, size, 0.0f);
         glVertex3f(-size, i, 0.0f);
         glVertex3f(size, i, 0.0f);
-        RecordLine({i, -size, 0.0f}, {i, size, 0.0f}, stroke);
-        RecordLine({-size, i, 0.0f}, {size, i, 0.0f}, stroke);
+        if (m_captureCanvas && m_captureIncludeGrid) {
+          RecordLine({i, -size, 0.0f}, {i, size, 0.0f}, stroke);
+          RecordLine({-size, i, 0.0f}, {size, i, 0.0f}, stroke);
+        }
         break;
       case Viewer2DView::Front:
         glVertex3f(i, 0.0f, -size);
         glVertex3f(i, 0.0f, size);
         glVertex3f(-size, 0.0f, i);
         glVertex3f(size, 0.0f, i);
-        RecordLine({i, 0.0f, -size}, {i, 0.0f, size}, stroke);
-        RecordLine({-size, 0.0f, i}, {size, 0.0f, i}, stroke);
+        if (m_captureCanvas && m_captureIncludeGrid) {
+          RecordLine({i, 0.0f, -size}, {i, 0.0f, size}, stroke);
+          RecordLine({-size, 0.0f, i}, {size, 0.0f, i}, stroke);
+        }
         break;
       case Viewer2DView::Side:
         glVertex3f(0.0f, i, -size);
         glVertex3f(0.0f, i, size);
         glVertex3f(0.0f, -size, i);
         glVertex3f(0.0f, size, i);
-        RecordLine({0.0f, i, -size}, {0.0f, i, size}, stroke);
-        RecordLine({0.0f, -size, i}, {0.0f, size, i}, stroke);
+        if (m_captureCanvas && m_captureIncludeGrid) {
+          RecordLine({0.0f, i, -size}, {0.0f, i, size}, stroke);
+          RecordLine({0.0f, -size, i}, {0.0f, size, i}, stroke);
+        }
         break;
       }
     }
@@ -1636,15 +1642,18 @@ void Viewer3DController::DrawGrid(int style, float r, float g, float b,
         switch (view) {
         case Viewer2DView::Top:
           glVertex3f(x, y, 0.0f);
-          RecordLine({x, y, 0.0f}, {x, y, 0.0f}, stroke);
+          if (m_captureCanvas && m_captureIncludeGrid)
+            RecordLine({x, y, 0.0f}, {x, y, 0.0f}, stroke);
           break;
         case Viewer2DView::Front:
           glVertex3f(x, 0.0f, y);
-          RecordLine({x, 0.0f, y}, {x, 0.0f, y}, stroke);
+          if (m_captureCanvas && m_captureIncludeGrid)
+            RecordLine({x, 0.0f, y}, {x, 0.0f, y}, stroke);
           break;
         case Viewer2DView::Side:
           glVertex3f(0.0f, x, y);
-          RecordLine({0.0f, x, y}, {0.0f, x, y}, stroke);
+          if (m_captureCanvas && m_captureIncludeGrid)
+            RecordLine({0.0f, x, y}, {0.0f, x, y}, stroke);
           break;
         }
       }
@@ -1664,24 +1673,30 @@ void Viewer3DController::DrawGrid(int style, float r, float g, float b,
           glVertex3f(x + half, y, 0.0f);
           glVertex3f(x, y - half, 0.0f);
           glVertex3f(x, y + half, 0.0f);
-          RecordLine({x - half, y, 0.0f}, {x + half, y, 0.0f}, stroke);
-          RecordLine({x, y - half, 0.0f}, {x, y + half, 0.0f}, stroke);
+          if (m_captureCanvas && m_captureIncludeGrid) {
+            RecordLine({x - half, y, 0.0f}, {x + half, y, 0.0f}, stroke);
+            RecordLine({x, y - half, 0.0f}, {x, y + half, 0.0f}, stroke);
+          }
           break;
         case Viewer2DView::Front:
           glVertex3f(x - half, 0.0f, y);
           glVertex3f(x + half, 0.0f, y);
           glVertex3f(x, 0.0f, y - half);
           glVertex3f(x, 0.0f, y + half);
-          RecordLine({x - half, 0.0f, y}, {x + half, 0.0f, y}, stroke);
-          RecordLine({x, 0.0f, y - half}, {x, 0.0f, y + half}, stroke);
+          if (m_captureCanvas && m_captureIncludeGrid) {
+            RecordLine({x - half, 0.0f, y}, {x + half, 0.0f, y}, stroke);
+            RecordLine({x, 0.0f, y - half}, {x, 0.0f, y + half}, stroke);
+          }
           break;
         case Viewer2DView::Side:
           glVertex3f(0.0f, x - half, y);
           glVertex3f(0.0f, x + half, y);
           glVertex3f(0.0f, x, y - half);
           glVertex3f(0.0f, x, y + half);
-          RecordLine({0.0f, x - half, y}, {0.0f, x + half, y}, stroke);
-          RecordLine({0.0f, x, y - half}, {0.0f, x, y + half}, stroke);
+          if (m_captureCanvas && m_captureIncludeGrid) {
+            RecordLine({0.0f, x - half, y}, {0.0f, x + half, y}, stroke);
+            RecordLine({0.0f, x, y - half}, {0.0f, x, y + half}, stroke);
+          }
           break;
         }
       }

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -245,14 +245,17 @@ private:
   // takes place and the render path behaves as before.
   ICanvas2D *m_captureCanvas = nullptr;
   Viewer2DView m_captureView = Viewer2DView::Top;
+  bool m_captureIncludeGrid = true;
 
 public:
   // Enables recording of all primitives drawn during the next RenderScene
   // call. The caller owns the canvas lifetime and is responsible for calling
   // BeginFrame/EndFrame. Recording is disabled automatically after each
   // render pass by resetting the canvas to nullptr.
-  void SetCaptureCanvas(ICanvas2D *canvas, Viewer2DView view) {
+  void SetCaptureCanvas(ICanvas2D *canvas, Viewer2DView view,
+                        bool includeGrid = true) {
     m_captureCanvas = canvas;
     m_captureView = view;
+    m_captureIncludeGrid = includeGrid;
   }
 };


### PR DESCRIPTION
## Summary
- add a print include grid option to plan print settings and persist it through the UI
- allow 2D capture to drop grid primitives while keeping on-screen rendering unchanged
- register a configuration toggle to control whether grids are recorded during plan export

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c380dac6483248b72fa822684f52d)