### PR TITLE
Fix print plan Y mapping to preserve margins

### DIFF
--- a/viewer2d/planpdfexporter.cpp
+++ b/viewer2d/planpdfexporter.cpp
@@ -112,7 +112,8 @@ Point MapWithMapping(double x, double y, const Mapping &mapping) {
   double px = mapping.offsetX + (x - mapping.minX) * mapping.scale;
   double py = mapping.offsetY + (y - mapping.minY) * mapping.scale;
   if (mapping.flipY)
-    py = mapping.pageHeight - py;
+    py = mapping.pageHeight - mapping.offsetY -
+         (y - mapping.minY) * mapping.scale;
   return {px, py};
 }
 


### PR DESCRIPTION
## Summary
- adjust Y-axis mapping when flipping coordinates so page margins are preserved when exporting plans

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c3cdb2ff483249e669ed562e0ab3b)