### PR TITLE
Fix PDF export axis orientation

### DIFF
--- a/viewer2d/planpdfexporter.cpp
+++ b/viewer2d/planpdfexporter.cpp
@@ -506,7 +506,7 @@ PlanExportResult ExportPlanToPdf(const CommandBuffer &buffer,
     mainCommands.push_back(cmd);
   }
 
-  Mapping pageMapping{minX, minY, scale, offsetX, offsetY, pageH, true};
+  Mapping pageMapping{minX, minY, scale, offsetX, offsetY, pageH, false};
   std::string contentStr = RenderCommandsToStream(mainCommands, pageMapping,
                                                  formatter);
 
@@ -526,9 +526,9 @@ PlanExportResult ExportPlanToPdf(const CommandBuffer &buffer,
       continue;
 
     double a = placement.transform.scale * scale;
-    double d = -placement.transform.scale * scale;
+    double d = placement.transform.scale * scale;
     double e = scale * (placement.transform.offsetX - minX) + offsetX;
-    double f = pageH - offsetY - scale * (placement.transform.offsetY - minY);
+    double f = offsetY + scale * (placement.transform.offsetY - minY);
 
     placementStream << "q\n" << formatter.Format(a) << " 0 0 "
                     << formatter.Format(d) << ' ' << formatter.Format(e) << ' '


### PR DESCRIPTION
## Summary
- stop flipping the Y axis when mapping captured 2D commands to PDF pages
- adjust symbol placement transforms to preserve the on-screen orientation in exports

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c3ed63c688324a172452e1653edf1)