### PR TITLE
Fix Print Plan offset scaling

### DIFF
--- a/viewer2d/planpdfexporter.cpp
+++ b/viewer2d/planpdfexporter.cpp
@@ -448,8 +448,12 @@ PlanExportResult ExportPlanToPdf(const CommandBuffer &buffer,
   double ppm = PIXELS_PER_METER * static_cast<double>(viewState.zoom);
   double halfW = static_cast<double>(viewState.viewportWidth) / ppm * 0.5;
   double halfH = static_cast<double>(viewState.viewportHeight) / ppm * 0.5;
-  double offX = static_cast<double>(viewState.offsetPixelsX) / PIXELS_PER_METER;
-  double offY = static_cast<double>(viewState.offsetPixelsY) / PIXELS_PER_METER;
+  // The stored offsets are expressed in screen pixels normalized by the zoom
+  // factor (see Viewer2DPanel::OnMouseMove). Convert them back to world-space
+  // meters by accounting for both the pixel density and the current zoom so the
+  // printed plan covers exactly the same region shown on screen.
+  double offX = static_cast<double>(viewState.offsetPixelsX) / ppm;
+  double offY = static_cast<double>(viewState.offsetPixelsY) / ppm;
   double minX = -halfW - offX;
   double maxX = halfW - offX;
   double minY = -halfH - offY;


### PR DESCRIPTION
## Summary
- adjust print-plan offset conversion to account for zoomed pixel values
- ensure printed plan covers the same region shown in the 2D viewport

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c4160b1308324b3e4007d9a9ae2d0)