### PR TITLE
Register print plan config defaults with legacy fallback

### DIFF
--- a/core/configmanager.h
+++ b/core/configmanager.h
@@ -70,10 +70,12 @@ public:
         float value = 0.0f;
         float minValue = 0.0f;
         float maxValue = 0.0f;
+        std::vector<std::string> legacyNames;
     };
 
     void RegisterVariable(const std::string& name, const std::string& type,
-                          float defVal, float minVal, float maxVal);
+                          float defVal, float minVal, float maxVal,
+                          std::vector<std::string> legacyNames = {});
     float GetFloat(const std::string& name) const;
     void SetFloat(const std::string& name, float v);
     void ApplyDefaults();


### PR DESCRIPTION
## Summary
- register new print plan configuration variables with defaults, ranges, and legacy fallbacks
- clamp configuration values when setting and loading registered floats to keep them within bounds

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c446e00408324989ae59dc8d6e5fc)