### PR TITLE
Add forward declaration for TryParseFloat

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -34,6 +34,8 @@ class wxZipStreamLink;
 #include <wx/zipstrm.h>
 
 namespace {
+bool TryParseFloat(const std::string &text, float &out);
+
 class TempDir {
 public:
   explicit TempDir(const std::string &prefix) {


### PR DESCRIPTION
## Summary
- declare TryParseFloat before its first use in ConfigManager

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c45a6ba308324ada24fe218e55954)