### PR TITLE
Add plan print settings and page size handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ file(GLOB_RECURSE SRC_FILES CONFIGURE_DEPENDS
     ${CMAKE_SOURCE_DIR}/gui/*.cpp
     ${CMAKE_SOURCE_DIR}/models/*.cpp
     ${CMAKE_SOURCE_DIR}/core/*.cpp
+    ${CMAKE_SOURCE_DIR}/core/print/*.cpp
     ${CMAKE_SOURCE_DIR}/mvr/*.cpp
     ${CMAKE_SOURCE_DIR}/viewer3d/*.cpp
     ${CMAKE_SOURCE_DIR}/viewer2d/*.cpp
@@ -42,6 +43,7 @@ file(GLOB_RECURSE HEADER_FILES
     ${CMAKE_SOURCE_DIR}/gui/*.h
     ${CMAKE_SOURCE_DIR}/models/*.h
     ${CMAKE_SOURCE_DIR}/core/*.h
+    ${CMAKE_SOURCE_DIR}/core/print/*.h
     ${CMAKE_SOURCE_DIR}/mvr/*.h
     ${CMAKE_SOURCE_DIR}/viewer3d/*.h
     ${CMAKE_SOURCE_DIR}/viewer2d/*.h

--- a/core/print/PlanPrintSettings.cpp
+++ b/core/print/PlanPrintSettings.cpp
@@ -1,0 +1,70 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "PlanPrintSettings.h"
+
+#include "core/configmanager.h"
+
+namespace {
+constexpr double kMmToPoints = 72.0 / 25.4;
+} // namespace
+
+namespace print {
+
+PlanPrintSettings PlanPrintSettings::LoadFromConfig(ConfigManager &cfg) {
+  PlanPrintSettings settings;
+  settings.pageSize = cfg.GetFloat("print_plan_page_size") >= 0.5f
+                          ? PageSize::A4
+                          : PageSize::A3;
+  settings.landscape = cfg.GetFloat("print_plan_landscape") != 0.0f;
+  settings.includeGrid = cfg.GetFloat("print_include_grid") != 0.0f;
+  settings.detailedFootprints =
+      cfg.GetFloat("print_use_simplified_footprints") == 0.0f;
+  return settings;
+}
+
+void PlanPrintSettings::SaveToConfig(ConfigManager &cfg) const {
+  cfg.SetFloat("print_plan_page_size", pageSize == PageSize::A4 ? 1.0f : 0.0f);
+  cfg.SetFloat("print_plan_landscape", landscape ? 1.0f : 0.0f);
+  cfg.SetFloat("print_include_grid", includeGrid ? 1.0f : 0.0f);
+  cfg.SetFloat("print_use_simplified_footprints",
+               detailedFootprints ? 0.0f : 1.0f);
+}
+
+std::pair<double, double> PlanPrintSettings::BasePageSizeMm() const {
+  switch (pageSize) {
+  case PageSize::A4:
+    return {210.0, 297.0};
+  case PageSize::A3:
+  default:
+    return {297.0, 420.0};
+  }
+}
+
+double PlanPrintSettings::PageWidthPt() const {
+  auto [portraitW, portraitH] = BasePageSizeMm();
+  const double mm = landscape ? portraitH : portraitW;
+  return mm * kMmToPoints;
+}
+
+double PlanPrintSettings::PageHeightPt() const {
+  auto [portraitW, portraitH] = BasePageSizeMm();
+  const double mm = landscape ? portraitW : portraitH;
+  return mm * kMmToPoints;
+}
+
+} // namespace print

--- a/core/print/PlanPrintSettings.h
+++ b/core/print/PlanPrintSettings.h
@@ -1,0 +1,44 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <utility>
+
+class ConfigManager;
+
+namespace print {
+
+enum class PageSize { A3 = 0, A4 = 1 };
+
+struct PlanPrintSettings {
+  PageSize pageSize = PageSize::A3;
+  bool landscape = false;
+  bool includeGrid = true;
+  bool detailedFootprints = false;
+
+  static PlanPrintSettings LoadFromConfig(ConfigManager &cfg);
+  void SaveToConfig(ConfigManager &cfg) const;
+
+  double PageWidthPt() const;
+  double PageHeightPt() const;
+
+private:
+  std::pair<double, double> BasePageSizeMm() const;
+};
+
+} // namespace print

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -81,6 +81,7 @@ using json = nlohmann::json;
 #include "splashscreen.h"
 #include "summarypanel.h"
 #include "tableprinter.h"
+#include "print/PlanPrintSettings.h"
 #include "planpdfexporter.h"
 #include "print_diagnostics.h"
 #include "support.h"
@@ -1312,9 +1313,15 @@ void MainWindow::OnPrintPlan(wxCommandEvent &WXUNUSED(event)) {
     return;
   }
 
+  print::PlanPrintSettings settings =
+      print::PlanPrintSettings::LoadFromConfig(ConfigManager::Get());
+
   PlanPrintOptions opts; // Defaults to A3 portrait.
-  opts.printIncludeGrid =
-      ConfigManager::Get().GetFloat("print_include_grid") != 0.0f;
+  opts.landscape = settings.landscape;
+  opts.printIncludeGrid = settings.includeGrid;
+  opts.useSimplifiedFootprints = !settings.detailedFootprints;
+  opts.pageWidthPt = settings.PageWidthPt();
+  opts.pageHeightPt = settings.PageHeightPt();
   std::filesystem::path outputPath(
       std::filesystem::path(outputPathWx.ToStdWstring()));
   wxString outputPathDisplay = outputPathWx;

--- a/viewer2d/planpdfexporter.h
+++ b/viewer2d/planpdfexporter.h
@@ -23,13 +23,15 @@
 #include <filesystem>
 #include <string>
 
+constexpr double kMmToPt = 72.0 / 25.4;
+
 // Options describing the paper size and orientation for the PDF export. A3
 // portrait is used by default but callers can override the values to support
 // additional formats and orientations later on.
 struct PlanPrintOptions {
-  double pageWidthPt = 842.0;  // 297 mm in PostScript points
-  double pageHeightPt = 1191.0; // 420 mm in PostScript points
-  double marginPt = 36.0;       // Half an inch margin for readability
+  double pageWidthPt = 297.0 * kMmToPt;  // A3 portrait width
+  double pageHeightPt = 420.0 * kMmToPt; // A3 portrait height
+  double marginPt = 36.0;                // Half an inch margin for readability
   bool landscape = false;
   bool compressStreams = true;
   int floatPrecision = 3;


### PR DESCRIPTION
## Summary
- add reusable plan print settings helper to load/save paper options and compute page dimensions
- expose configurable page dimensions in PDF export defaults using A3 portrait conversion
- wire MainWindow print flow to apply stored settings for orientation, grid visibility, and footprint detail

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c46e3fe3483249221d083df2cd539)