### PR TITLE
Fix include path for config manager

### DIFF
--- a/core/print/PlanPrintSettings.cpp
+++ b/core/print/PlanPrintSettings.cpp
@@ -17,7 +17,7 @@
  */
 #include "PlanPrintSettings.h"
 
-#include "core/configmanager.h"
+#include "configmanager.h"
 
 namespace {
 constexpr double kMmToPoints = 72.0 / 25.4;


### PR DESCRIPTION
## Summary
- adjust PlanPrintSettings include to use existing configmanager header path

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c48341ed88324829581209cc250ac)