### PR TITLE
Add plan printing preferences page

### DIFF
--- a/gui/preferencesdialog.h
+++ b/gui/preferencesdialog.h
@@ -20,6 +20,10 @@
 #include <array>
 #include <wx/wx.h>
 
+namespace print {
+class PlanPrintSettings;
+}
+
 class PreferencesDialog : public wxDialog {
 public:
   PreferencesDialog(wxWindow *parent);
@@ -31,4 +35,14 @@ private:
   wxCheckBox *autopatchCheck = nullptr;
   wxRadioButton *layerPosRadio = nullptr;
   wxRadioButton *layerTypeRadio = nullptr;
+  wxRadioButton *pageSizeA3Radio = nullptr;
+  wxRadioButton *pageSizeA4Radio = nullptr;
+  wxRadioButton *portraitRadio = nullptr;
+  wxRadioButton *landscapeRadio = nullptr;
+  wxCheckBox *includeGridCheck = nullptr;
+  wxRadioButton *detailedRadio = nullptr;
+  wxRadioButton *schematicRadio = nullptr;
+
+  void LoadPlanPrintSettings(const print::PlanPrintSettings &settings);
+  void SavePlanPrintSettings(print::PlanPrintSettings &settings);
 };


### PR DESCRIPTION
## Summary
- add a Plan Printing page to the preferences dialog with page size, orientation, grid, and element detail controls
- load and save plan print settings through PlanPrintSettings and ConfigManager for immediate reuse
- add Apply handling so printing settings take effect without restarting

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c495c27a48324a9209d4560c8b788)