### PR TITLE
Adjust polygon PDF drawing sequence

### DIFF
--- a/viewer2d/planpdfexporter.cpp
+++ b/viewer2d/planpdfexporter.cpp
@@ -202,28 +202,15 @@ void AppendPolygon(std::ostringstream &out, GraphicsStateCache &cache,
   };
 
   if (stroke.width > 0.0f) {
-    CanvasStroke outlineStroke = stroke;
-    outlineStroke.color = {0.0f, 0.0f, 0.0f, 1.0f};
-    outlineStroke.width = 2.0f;
-    cache.SetStroke(out, outlineStroke, fmt);
+    cache.SetStroke(out, stroke, fmt);
     emitPath();
     out << "S\n";
   }
 
   if (fill) {
     cache.SetFill(out, *fill, fmt);
-    if (stroke.width > 0.0f) {
-      cache.SetStroke(out, stroke, fmt);
-      emitPath();
-      out << "B\n";
-    } else {
-      emitPath();
-      out << "f\n";
-    }
-  } else if (stroke.width > 0.0f) {
-    cache.SetStroke(out, stroke, fmt);
     emitPath();
-    out << "S\n";
+    out << "f\n";
   }
 }
 


### PR DESCRIPTION
## Summary
- remove the artificial outline stroke in polygon rendering
- separate stroke and fill rendering so strokes use the original stroke and fills overlay with `f`

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c4f96cea48324b99ca543ef8e0c16)