### PR TITLE
Align PDF plan drawing order with 2D viewer

### DIFF
--- a/viewer2d/planpdfexporter.cpp
+++ b/viewer2d/planpdfexporter.cpp
@@ -442,12 +442,16 @@ std::string RenderCommandsToStream(
       continue;
     }
 
-    if (metadata[i].hasFill)
-      EmitCommandFill(content, stateCache, formatter, mapping, current,
-                      commands[i]);
+    // The on-screen 2D renderer draws outlines before filling the geometry in
+    // wireframe-derived modes (see Viewer3DController::DrawMeshWithOutline). To
+    // reproduce the same visual result in the PDF export we must respect that
+    // order so fills can intentionally cover strokes when required.
     if (metadata[i].hasStroke)
       EmitCommandStroke(content, stateCache, formatter, mapping, current,
                         commands[i]);
+    if (metadata[i].hasFill)
+      EmitCommandFill(content, stateCache, formatter, mapping, current,
+                      commands[i]);
   }
 
   return content.str();


### PR DESCRIPTION
## Summary
- emit PDF stroke commands before fill commands to mirror the on-screen 2D rendering order
- ensure plan exports let fills cover outlines the same way as the viewer

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c595baad8832491d87d55f4e21af0)