### PR TITLE
Respect depth ordering in 2D PDF export

### DIFF
--- a/viewer2d/canvas2d.h
+++ b/viewer2d/canvas2d.h
@@ -80,6 +80,7 @@ public:
   virtual void Save() = 0;
   virtual void Restore() = 0;
   virtual void SetTransform(const CanvasTransform &transform) = 0;
+  virtual void SetDepthHint(float depth) = 0;
   virtual void SetSourceKey(const std::string &key) = 0;
   virtual void BeginSymbol(const std::string &key) = 0;
   virtual void EndSymbol(const std::string &key) = 0;
@@ -156,6 +157,8 @@ struct TextCommand {
 struct CommandMetadata {
   bool hasStroke = false;
   bool hasFill = false;
+  bool hasDepth = false;
+  float depth = 0.0f;
 };
 
 struct SaveCommand {};

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -188,6 +188,8 @@ private:
 
   // Helpers used only when recording the 2D view to a canvas command buffer.
   std::array<float, 2> ProjectToCanvas(const std::array<float, 3> &p) const;
+  float DepthForPoint(const std::array<float, 3> &p) const;
+  float AverageDepth(const std::vector<std::array<float, 3>> &points) const;
   void RecordLine(const std::array<float, 3> &a, const std::array<float, 3> &b,
                   const CanvasStroke &stroke) const;
   void RecordPolyline(const std::vector<std::array<float, 3>> &points,


### PR DESCRIPTION
## Summary
- capture per-command depth hints when recording 2D viewer geometry
- sort drawable commands by depth during PDF export to mirror on-screen occlusion

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c5e171c9c832489d6e744aa201f4a)