### PR TITLE
Draw fills before strokes in PDF export

### DIFF
--- a/viewer2d/planpdfexporter.cpp
+++ b/viewer2d/planpdfexporter.cpp
@@ -479,12 +479,12 @@ std::string RenderCommandsToStream(
 
     for (size_t idx : run) {
       auto meta = getMeta(idx);
-      if (meta.hasStroke)
-        EmitCommandStroke(content, stateCache, formatter, mapping, current,
-                          commands[idx]);
       if (meta.hasFill)
         EmitCommandFill(content, stateCache, formatter, mapping, current,
                         commands[idx]);
+      if (meta.hasStroke)
+        EmitCommandStroke(content, stateCache, formatter, mapping, current,
+                          commands[idx]);
     }
   }
 


### PR DESCRIPTION
## Summary
- render PDF export fills before strokes to mirror 2D viewer draw order
- preserve existing depth sorting and command sequencing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c64862d248324a5538f83dd4f54c8)