### PR TITLE
Fix viewport dimension calculation in plan PDF exporter

### DIFF
--- a/viewer2d/planpdfexporter.cpp
+++ b/viewer2d/planpdfexporter.cpp
@@ -568,6 +568,8 @@ PlanExportResult ExportPlanToPdf(const CommandBuffer &buffer,
   double maxX = halfW - offX;
   double minY = -halfH - offY;
   double maxY = halfH - offY;
+  double width = maxX - minX;
+  double height = maxY - minY;
   if (width <= 0.0 || height <= 0.0) {
     result.message = "Viewport dimensions are invalid for export.";
     return result;


### PR DESCRIPTION
## Summary
- define viewport width and height when exporting plan PDFs
- ensure invalid viewport dimensions are detected before scaling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c6daa2c64832482a14289ff760aae)