### PR TITLE
Align PDF plan drawing order with viewer

### DIFF
--- a/viewer2d/planpdfexporter.cpp
+++ b/viewer2d/planpdfexporter.cpp
@@ -408,19 +408,13 @@ std::string RenderCommandsToStream(
       return;
 
     for (size_t idx : group) {
-      if (metadata[idx].hasStroke)
-        EmitCommandStroke(content, stateCache, formatter, mapping, current,
-                          commands[idx]);
-    }
-
-    for (size_t idx : group) {
       if (metadata[idx].hasFill)
         EmitCommandFill(content, stateCache, formatter, mapping, current,
                         commands[idx]);
     }
 
     for (size_t idx : group) {
-      if (metadata[idx].hasStroke && !metadata[idx].hasFill)
+      if (metadata[idx].hasStroke)
         EmitCommandStroke(content, stateCache, formatter, mapping, current,
                           commands[idx]);
     }


### PR DESCRIPTION
## Summary
- adjust PDF export command grouping to draw fills before strokes
- ensure wireframes are rendered below planar fills to match 2D viewer appearance

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c7737443483249d5cc848349271d3)