### PR TITLE
Adjust PDF label line spacing to match 2D viewer

### DIFF
--- a/viewer2d/planpdfexporter.cpp
+++ b/viewer2d/planpdfexporter.cpp
@@ -37,8 +37,9 @@ namespace {
 
 constexpr float PIXELS_PER_METER = 25.0f;
 // Matches the tighter line spacing used by the on-screen 2D viewer when
-// rendering multi-line text labels.
-constexpr float PDF_TEXT_LINE_HEIGHT_FACTOR = 0.8f;
+// rendering multi-line text labels. Slightly below 1.0 to mirror the compact
+// leading applied in the live view.
+constexpr float PDF_TEXT_LINE_HEIGHT_FACTOR = 0.78f;
 
 double ComputeTextLineAdvance(const CanvasTextStyle &style) {
   // Negative because PDF moves the text cursor downward with a negative y


### PR DESCRIPTION
## Summary
- tune the PDF text line height factor to better match the compact spacing used in the 2D viewer
- keep the line advance calculation centralized to preserve alignment for multi-line labels

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c93b5d4a48324a59053c6b5bae979)