### PR TITLE
Add PDF text descent factor constant

### DIFF
--- a/viewer2d/planpdfexporter.cpp
+++ b/viewer2d/planpdfexporter.cpp
@@ -46,6 +46,9 @@ constexpr float PDF_TEXT_LINE_HEIGHT_FACTOR = 0.78f;
 // on-screen NanoVG rendering that places text relative to its bounding box top
 // edge.
 constexpr float PDF_TEXT_ASCENT_FACTOR = 0.718f;
+// Complements the ascent factor using Helvetica's 207 unit descent to align the
+// PDF export's baseline with the on-screen text metrics.
+constexpr float PDF_TEXT_DESCENT_FACTOR = 0.207f;
 
 double ComputeTextLineAdvance(const CanvasTextStyle &style) {
   // Negative because PDF moves the text cursor downward with a negative y


### PR DESCRIPTION
## Summary
- add a Helvetica-based descent factor constant used by the PDF exporter
- ensure text line advance calculations have both ascent and descent metrics defined

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693efdfb36cc8324b260960cfe9f696d)