### PR TITLE
Fix PDF label alignment

### DIFF
--- a/viewer2d/planpdfexporter.cpp
+++ b/viewer2d/planpdfexporter.cpp
@@ -365,7 +365,7 @@ void AppendText(std::ostringstream &out, const FloatFormatter &fmt,
 
   double verticalOffset = 0.0;
   if (style.vAlign == CanvasTextStyle::VerticalAlign::Top)
-    verticalOffset = -scaledFontSize * PDF_TEXT_ASCENT_FACTOR;
+    verticalOffset = scaledFontSize * PDF_TEXT_ASCENT_FACTOR;
 
   const double lineAdvance = ComputeTextLineAdvance(scaledFontSize);
   out << "BT\n/F1 " << fmt.Format(scaledFontSize) << " Tf\n";


### PR DESCRIPTION
## Summary
- adjust PDF text vertical alignment to match the 2D viewer's top-anchored labels

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f09a74c6c83248c4c3bc51bfdd474)