### PR TITLE
Ensure PDF multiline text advances downward

### DIFF
--- a/viewer2d/planpdfexporter.cpp
+++ b/viewer2d/planpdfexporter.cpp
@@ -365,9 +365,12 @@ void AppendText(std::ostringstream &out, const FloatFormatter &fmt,
 
   double verticalOffset = 0.0;
   if (style.vAlign == CanvasTextStyle::VerticalAlign::Top)
-    verticalOffset = -scaledFontSize * PDF_TEXT_ASCENT_FACTOR;
+    verticalOffset = scaledFontSize * PDF_TEXT_ASCENT_FACTOR;
 
-  const double lineAdvance = ComputeTextLineAdvance(scaledFontSize);
+  // Always advance downward for successive lines to mirror the on-screen
+  // rendering, even if upstream metrics change sign conventions.
+  const double lineAdvance =
+      -std::abs(ComputeTextLineAdvance(scaledFontSize));
   out << "BT\n/F1 " << fmt.Format(scaledFontSize) << " Tf\n";
   out << fmt.Format(style.color.r) << ' ' << fmt.Format(style.color.g) << ' '
       << fmt.Format(style.color.b) << " rg\n";


### PR DESCRIPTION
## Summary
- force PDF text line advancement to always move downward, matching the on-screen label order

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f09a74c6c83248c4c3bc51bfdd474)