### PR TITLE
Fix logger include path for 2D PDF exporter

### DIFF
--- a/viewer2d/planpdfexporter.cpp
+++ b/viewer2d/planpdfexporter.cpp
@@ -35,7 +35,7 @@
 
 #include <zlib.h>
 
-#include "core/logger.h"
+#include "logger.h"
 
 namespace {
 


### PR DESCRIPTION
## Summary
- update the logger include in the 2D PDF exporter to match configured include paths

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f192bf2208324988c52c8451f7c6c)