### PR TITLE
Fix PDF label top alignment offset

### DIFF
--- a/viewer2d/planpdfexporter.cpp
+++ b/viewer2d/planpdfexporter.cpp
@@ -373,7 +373,7 @@ void AppendText(std::ostringstream &out, const FloatFormatter &fmt,
 
   double verticalOffset = 0.0;
   if (style.vAlign == CanvasTextStyle::VerticalAlign::Top)
-    verticalOffset = scaledFontSize * PDF_TEXT_ASCENT_FACTOR;
+    verticalOffset = -scaledFontSize * PDF_TEXT_ASCENT_FACTOR;
 
   // Always advance downward for successive lines to mirror the on-screen
   // rendering, even if upstream metrics change sign conventions.


### PR DESCRIPTION
## Summary
- adjust PDF text vertical offset for top-aligned labels to match 2D viewer positioning

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f24eaad30832489dbf7623023d992)