### PR TITLE
Fix PDF fixture label vertical alignment

### DIFF
--- a/viewer2d/planpdfexporter.cpp
+++ b/viewer2d/planpdfexporter.cpp
@@ -372,8 +372,12 @@ void AppendText(std::ostringstream &out, const FloatFormatter &fmt,
     horizontalOffset = -maxLineWidth;
 
   double verticalOffset = 0.0;
+  // Recorded fixture labels provide the text's top edge as the anchor. To keep
+  // the PDF export aligned with the on-screen 2D view, place the PDF text
+  // baseline at that same anchor instead of offsetting by the font ascent.
+  // This avoids shifting the entire label downward relative to its fixture.
   if (style.vAlign == CanvasTextStyle::VerticalAlign::Top)
-    verticalOffset = -scaledFontSize * PDF_TEXT_ASCENT_FACTOR;
+    verticalOffset = 0.0;
 
   // Always advance downward for successive lines to mirror the on-screen
   // rendering, even if upstream metrics change sign conventions.


### PR DESCRIPTION
## Summary
- stop offsetting top-anchored PDF text so fixture labels align with their captured anchor

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f26cb78cc832498ce5c492fe497cc)