### PR TITLE
Disable shortcuts while editing label values

### DIFF
--- a/viewer2d/viewer2drenderpanel.cpp
+++ b/viewer2d/viewer2drenderpanel.cpp
@@ -104,6 +104,7 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
                         this);
   m_labelNameSize->Bind(wxEVT_KILL_FOCUS, &Viewer2DRenderPanel::OnEndTextEdit,
                         this);
+  m_labelNameSize->Bind(wxEVT_TEXT, &Viewer2DRenderPanel::OnTextChange, this);
   m_labelNameSize->Bind(wxEVT_TEXT_ENTER, &Viewer2DRenderPanel::OnTextEnter,
                         this);
 
@@ -123,6 +124,7 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
                       this);
   m_labelIdSize->Bind(wxEVT_KILL_FOCUS, &Viewer2DRenderPanel::OnEndTextEdit,
                       this);
+  m_labelIdSize->Bind(wxEVT_TEXT, &Viewer2DRenderPanel::OnTextChange, this);
   m_labelIdSize->Bind(wxEVT_TEXT_ENTER, &Viewer2DRenderPanel::OnTextEnter,
                       this);
 
@@ -144,6 +146,8 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
                            &Viewer2DRenderPanel::OnBeginTextEdit, this);
   m_labelAddressSize->Bind(wxEVT_KILL_FOCUS,
                            &Viewer2DRenderPanel::OnEndTextEdit, this);
+  m_labelAddressSize->Bind(wxEVT_TEXT, &Viewer2DRenderPanel::OnTextChange,
+                           this);
   m_labelAddressSize->Bind(wxEVT_TEXT_ENTER,
                            &Viewer2DRenderPanel::OnTextEnter, this);
 
@@ -161,6 +165,8 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
                               &Viewer2DRenderPanel::OnBeginTextEdit, this);
   m_labelOffsetDistance->Bind(wxEVT_KILL_FOCUS,
                               &Viewer2DRenderPanel::OnEndTextEdit, this);
+  m_labelOffsetDistance->Bind(wxEVT_TEXT, &Viewer2DRenderPanel::OnTextChange,
+                              this);
   m_labelOffsetDistance->Bind(wxEVT_TEXT_ENTER,
                               &Viewer2DRenderPanel::OnTextEnter, this);
 
@@ -176,6 +182,8 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
                            &Viewer2DRenderPanel::OnBeginTextEdit, this);
   m_labelOffsetAngle->Bind(wxEVT_KILL_FOCUS,
                            &Viewer2DRenderPanel::OnEndTextEdit, this);
+  m_labelOffsetAngle->Bind(wxEVT_TEXT, &Viewer2DRenderPanel::OnTextChange,
+                           this);
   m_labelOffsetAngle->Bind(wxEVT_TEXT_ENTER, &Viewer2DRenderPanel::OnTextEnter,
                            this);
 
@@ -411,6 +419,12 @@ void Viewer2DRenderPanel::OnBeginTextEdit(wxFocusEvent &evt) {
 void Viewer2DRenderPanel::OnEndTextEdit(wxFocusEvent &evt) {
   if (auto *mw = MainWindow::Instance())
     mw->EnableShortcuts(true);
+  evt.Skip();
+}
+
+void Viewer2DRenderPanel::OnTextChange(wxCommandEvent &evt) {
+  if (auto *mw = MainWindow::Instance())
+    mw->EnableShortcuts(false);
   evt.Skip();
 }
 

--- a/viewer2d/viewer2drenderpanel.h
+++ b/viewer2d/viewer2drenderpanel.h
@@ -49,6 +49,7 @@ private:
   void OnView(wxCommandEvent &evt);
   void OnBeginTextEdit(wxFocusEvent &evt);
   void OnEndTextEdit(wxFocusEvent &evt);
+  void OnTextChange(wxCommandEvent &evt);
   void OnTextEnter(wxCommandEvent &evt);
 
   wxRadioBox *m_radio = nullptr;


### PR DESCRIPTION
## Summary
- keep application shortcuts disabled whenever label numeric fields are being edited
- reapply label value changes on Enter and restore shortcuts afterward

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944478611748324a67314f831f0b961)