### PR TITLE
Fix PDF fixture label alignment

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -2066,13 +2066,13 @@ void Viewer3DController::DrawAllFixtureLabels(int width, int height,
         style.lineHeight = ascentsWorld[i] + descentsWorld[i];
         style.color = {0.0f, 0.0f, 0.0f, 1.0f};
         style.hAlign = CanvasTextStyle::HorizontalAlign::Center;
-        style.vAlign = CanvasTextStyle::VerticalAlign::Middle;
+        style.vAlign = CanvasTextStyle::VerticalAlign::Baseline;
         if (ShouldTraceLabelOrder()) {
           std::ostringstream trace;
           trace << "[label-capture] fixture=" << uuid << " source="
                 << labelSourceKey << " text=\"" << lines[i].text << "\" x="
                 << anchor[0] << " y=" << currentY << " size=" << style.fontSize
-                << " vAlign=Middle";
+                << " vAlign=Baseline";
           Logger::Instance().Log(trace.str());
         }
         RecordText(anchor[0], currentY + style.ascent, lines[i].text, style);


### PR DESCRIPTION
## Summary
- align captured fixture label text using baseline positioning so the PDF export matches the 2D viewer
- preserve the measured spacing when exporting labels to PDF to avoid overlapping lines

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694450372fe48324a6b63352fede5b60)