### PR TITLE
Fix label capture baseline computation

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -2071,7 +2071,7 @@ void Viewer3DController::DrawAllFixtureLabels(int width, int height,
         style.color = {0.0f, 0.0f, 0.0f, 1.0f};
         style.hAlign = CanvasTextStyle::HorizontalAlign::Center;
         style.vAlign = CanvasTextStyle::VerticalAlign::Baseline;
-        float baseline = currentTop - style.ascent;
+        float baseline = currentY - lineHeightsWorld[i] + style.ascent;
         if (ShouldTraceLabelOrder()) {
           std::ostringstream trace;
           trace << "[label-capture] fixture=" << uuid << " source="
@@ -2080,8 +2080,7 @@ void Viewer3DController::DrawAllFixtureLabels(int width, int height,
                 << " size=" << style.fontSize << " vAlign=Baseline";
           Logger::Instance().Log(trace.str());
         }
-        RecordText(anchor[0], currentY - lineHeightsWorld[i] + style.ascent,
-                   lines[i].text, style);
+        RecordText(anchor[0], baseline, lines[i].text, style);
         if (i + 1 < lines.size())
           currentY += lineHeightsWorld[i] + lineSpacingWorld;
       }


### PR DESCRIPTION
## Summary
- compute the baseline from the current capture cursor instead of referencing an undefined variable
- reuse the baseline for both tracing and recording label text to keep capture and logs aligned

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69445f1c8ed48324a0a083c50615aed8)