### PR TITLE
Align PDF label text with viewer metrics

### DIFF
--- a/viewer2d/canvas2d.h
+++ b/viewer2d/canvas2d.h
@@ -56,6 +56,7 @@ struct CanvasTextStyle {
   float ascent = 0.0f;
   float descent = 0.0f;
   float lineHeight = 0.0f;
+  float extraLineSpacing = 0.0f;
   CanvasColor color{};
   enum class HorizontalAlign { Left, Center, Right } hAlign =
       HorizontalAlign::Left;

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -2068,6 +2068,7 @@ void Viewer3DController::DrawAllFixtureLabels(int width, int height,
         style.ascent = ascentsWorld[i];
         style.descent = descentsWorld[i];
         style.lineHeight = ascentsWorld[i] + descentsWorld[i];
+        style.extraLineSpacing = lineSpacingWorld;
         style.color = {0.0f, 0.0f, 0.0f, 1.0f};
         style.hAlign = CanvasTextStyle::HorizontalAlign::Center;
         style.vAlign = CanvasTextStyle::VerticalAlign::Baseline;


### PR DESCRIPTION
## Summary
- capture label line spacing in CanvasTextStyle and carry it through text recording
- update PDF text rendering to use recorded ascent, descent, line height, and extra spacing instead of hardcoded factors
- keep metric-based fallbacks while removing the ad-hoc line height factor for PDF text layout

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944624b880c83248d3eef6624290594)