### PR TITLE
Include uuid utils in save-load roundtrip test build

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,6 +51,7 @@ add_executable(save_load_roundtrip_test save_load_roundtrip_test.cpp
                ../core/projectutils.cpp
                ../core/gdtfdictionary.cpp
                ../core/trussdictionary.cpp
+               ../core/uuidutils.cpp
                ../mvr/mvrimporter.cpp
                ../mvr/mvrexporter.cpp
                ../core/logger.cpp


### PR DESCRIPTION
## Summary
- include the uuid utilities source in the save_load_roundtrip_test target so GenerateUuid links correctly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69446acdfc9083249b65425b82353b4e)