### PR TITLE
Add 2D symbol instancing cache scaffolding

### DIFF
--- a/viewer2d/symbolcache.cpp
+++ b/viewer2d/symbolcache.cpp
@@ -1,0 +1,38 @@
+#include "symbolcache.h"
+
+#include <utility>
+
+const SymbolDefinition &SymbolCache::GetOrCreate(const SymbolKey &key,
+                                                 const BuilderFn &builder) {
+  auto it = definitions_.find(key);
+  if (it != definitions_.end()) {
+    ++hits_;
+    return it->second;
+  }
+
+  ++misses_;
+  const uint32_t symbolId = nextSymbolId_++;
+  SymbolDefinition definition = builder ? builder(key, symbolId) : SymbolDefinition{};
+  if (definition.symbolId == 0) {
+    definition.symbolId = symbolId;
+  }
+
+  auto inserted = definitions_.emplace(key, std::move(definition));
+  idToKey_.emplace(inserted.first->second.symbolId, key);
+  return inserted.first->second;
+}
+
+const SymbolDefinition *SymbolCache::GetById(uint32_t id) const {
+  auto keyIt = idToKey_.find(id);
+  if (keyIt == idToKey_.end()) {
+    return nullptr;
+  }
+
+  auto defIt = definitions_.find(keyIt->second);
+  if (defIt == definitions_.end()) {
+    return nullptr;
+  }
+
+  return &defIt->second;
+}
+

--- a/viewer2d/symbolcache.h
+++ b/viewer2d/symbolcache.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <unordered_map>
+
+#include "canvas2d.h"
+
+// Describes the orientation used when capturing or instancing a 2D symbol.
+enum class SymbolViewKind {
+  Top,
+  Bottom,
+  Left,
+  Right,
+  Front,
+  Back,
+};
+
+struct SymbolPoint {
+  float x = 0.0f;
+  float y = 0.0f;
+};
+
+struct SymbolBounds {
+  SymbolPoint min{};
+  SymbolPoint max{};
+};
+
+struct SymbolKey {
+  std::string modelKey;
+  SymbolViewKind viewKind = SymbolViewKind::Top;
+  uint32_t styleVersion = 1;
+
+  bool operator==(const SymbolKey &other) const {
+    return modelKey == other.modelKey && viewKind == other.viewKind &&
+           styleVersion == other.styleVersion;
+  }
+};
+
+namespace std {
+template <> struct hash<SymbolKey> {
+  size_t operator()(const SymbolKey &key) const noexcept {
+    size_t h1 = hash<string>{}(key.modelKey);
+    size_t h2 = hash<int>{}(static_cast<int>(key.viewKind));
+    size_t h3 = hash<uint32_t>{}(key.styleVersion);
+
+    size_t seed = h1;
+    seed ^= h2 + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+    seed ^= h3 + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+    return seed;
+  }
+};
+} // namespace std
+
+struct SymbolDefinition {
+  uint32_t symbolId = 0;
+  SymbolBounds bounds{};
+  CommandBuffer localCommands{};
+};
+
+class SymbolCache {
+public:
+  using BuilderFn = std::function<SymbolDefinition(const SymbolKey &, uint32_t)>;
+
+  const SymbolDefinition &GetOrCreate(const SymbolKey &key,
+                                      const BuilderFn &builder);
+  const SymbolDefinition *GetById(uint32_t id) const;
+
+  uint64_t HitCount() const { return hits_; }
+  uint64_t MissCount() const { return misses_; }
+
+private:
+  std::unordered_map<SymbolKey, SymbolDefinition> definitions_;
+  std::unordered_map<uint32_t, SymbolKey> idToKey_;
+  uint32_t nextSymbolId_ = 1;
+  uint64_t hits_ = 0;
+  uint64_t misses_ = 0;
+};
+


### PR DESCRIPTION
## Summary
- add extensible symbol view kind and key structures for 2D symbols
- define symbol bounds, definitions, and storage for recorded commands
- implement a symbol cache with builder-based creation, lookup, and optional hit/miss tracking

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694483278098832497ea76e8299994a5)