### PR TITLE
Add symbol instance command placeholder to CommandBuffer

### DIFF
--- a/viewer2d/canvas2d.h
+++ b/viewer2d/canvas2d.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <variant>
@@ -72,6 +73,20 @@ struct CanvasTransform {
   float scale = 1.0f;  // Uniform scale applied after the camera zoom
   float offsetX = 0.0f; // Translation applied after scaling
   float offsetY = 0.0f;
+};
+
+// Simple 2D affine transform expressed as a 2x3 matrix. This is intended to be
+// reusable by commands that need full control over rotation, scaling and
+// translation in a single structure.
+struct Transform2D {
+  float a = 1.0f;
+  float b = 0.0f;
+  float c = 0.0f;
+  float d = 1.0f;
+  float tx = 0.0f;
+  float ty = 0.0f;
+
+  static Transform2D Identity() { return Transform2D{}; }
 };
 
 // Abstract interface representing a 2D drawing surface. The coordinate space
@@ -179,12 +194,17 @@ struct PlaceSymbolCommand {
   std::string key;
   CanvasTransform transform{};
 };
+struct SymbolInstanceCommand {
+  uint32_t symbolId = 0;
+  Transform2D transform = Transform2D::Identity();
+  // TODO: Add style overrides when cached symbol instances need them.
+};
 
 using CanvasCommand =
     std::variant<LineCommand, PolylineCommand, PolygonCommand,
                  RectangleCommand, CircleCommand, TextCommand, SaveCommand,
                  RestoreCommand, TransformCommand, BeginSymbolCommand,
-                 EndSymbolCommand, PlaceSymbolCommand>;
+                 EndSymbolCommand, PlaceSymbolCommand, SymbolInstanceCommand>;
 
 // Container preserving the order of issued drawing commands. It is deliberately
 // lightweight so it can be handed over to future SVG/PDF/printing code without

--- a/viewer2d/planpdfexporter.cpp
+++ b/viewer2d/planpdfexporter.cpp
@@ -595,6 +595,8 @@ std::string RenderCommandsToStream(
         Logger::Instance().Log(trace.str());
       }
       AppendText(content, formatter, pos, cmd, cmd.style, mapping.scale);
+    } else if constexpr (std::is_same_v<T, SymbolInstanceCommand>) {
+      // TODO: Replay cached symbol instances once exporters understand them.
     } else {
       // Symbol control commands are handled at a higher level but must preserve
       // ordering relative to drawing commands.
@@ -612,6 +614,7 @@ std::string RenderCommandsToStream(
                  std::is_same_v<T, BeginSymbolCommand> ||
                  std::is_same_v<T, EndSymbolCommand> ||
                  std::is_same_v<T, PlaceSymbolCommand> ||
+                 std::is_same_v<T, SymbolInstanceCommand> ||
                  std::is_same_v<T, TextCommand>;
         },
         cmd);

--- a/viewer2d/print_diagnostics.cpp
+++ b/viewer2d/print_diagnostics.cpp
@@ -158,6 +158,8 @@ std::string CommandName(const CanvasCommand &cmd) {
           return "Restore";
         else if constexpr (std::is_same_v<T, TransformCommand>)
           return "Transform";
+        else if constexpr (std::is_same_v<T, SymbolInstanceCommand>)
+          return "SymbolInstance";
         else
           return "Unknown";
       },
@@ -180,6 +182,8 @@ size_t EstimateBytes(const CanvasCommand &cmd) {
           return EstimateCircleBytes(value);
         else if constexpr (std::is_same_v<T, TextCommand>)
           return EstimateTextBytes(value);
+        else if constexpr (std::is_same_v<T, SymbolInstanceCommand>)
+          return static_cast<size_t>(0);
         else
           return static_cast<size_t>(0);
       },


### PR DESCRIPTION
## Summary
- add a reusable Transform2D helper and SymbolInstanceCommand payload to the 2D command buffer
- extend diagnostics and PDF export visitors to recognize the new command type without changing behavior

## Testing
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug *(fails: missing wxWidgets libraries in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944849fe3348324934e1aaae580ea07)