### PR TITLE
Enable Bottom-view 2D symbol instancing via SymbolCache (runtime only)

### DIFF
--- a/viewer2d/canvas2d.h
+++ b/viewer2d/canvas2d.h
@@ -89,6 +89,8 @@ struct Transform2D {
   static Transform2D Identity() { return Transform2D{}; }
 };
 
+class SymbolCache;
+
 // Abstract interface representing a 2D drawing surface. The coordinate space
 // is always the logical world space used by the 2D viewer after applying the
 // active view orientation and camera transform. Implementations may draw on
@@ -108,6 +110,8 @@ public:
   virtual void EndSymbol(const std::string &key) = 0;
   virtual void PlaceSymbol(const std::string &key,
                            const CanvasTransform &transform) = 0;
+  virtual void PlaceSymbolInstance(uint32_t symbolId,
+                                   const Transform2D &transform) = 0;
 
   virtual void DrawLine(float x0, float y0, float x1, float y1,
                         const CanvasStroke &stroke) = 0;
@@ -232,3 +236,6 @@ std::unique_ptr<ICanvas2D> CreateRecordingCanvas(CommandBuffer &buffer,
                                                      false);
 std::unique_ptr<ICanvas2D> CreateMultiCanvas(
     const std::vector<ICanvas2D *> &canvases);
+
+void ReplayCommandBuffer(const CommandBuffer &buffer, ICanvas2D &canvas,
+                         const SymbolCache *symbolCache = nullptr);

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -65,6 +65,7 @@ void EmitGrid(ICanvas2D &canvas, int style, Viewer2DView view, float r, float g,
     for (float i = -size; i <= size; i += step) {
       switch (view) {
       case Viewer2DView::Top:
+      case Viewer2DView::Bottom:
         canvas.DrawLine(i, -size, i, size, stroke);
         canvas.DrawLine(-size, i, size, i, stroke);
         break;
@@ -282,6 +283,9 @@ void Viewer2DPanel::Render() {
   switch (m_view) {
   case Viewer2DView::Top:
     gluLookAt(0.0, 0.0, 10.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0);
+    break;
+  case Viewer2DView::Bottom:
+    gluLookAt(0.0, 0.0, -10.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0);
     break;
   case Viewer2DView::Front:
     gluLookAt(0.0, -10.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0);

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -28,6 +28,7 @@
 #include "mesh.h"
 #include "scenedatamanager.h"
 #include "canvas2d.h"
+#include "symbolcache.h"
 #include <array>
 #include <string>
 #include <unordered_map>
@@ -53,7 +54,8 @@ enum class Viewer2DRenderMode {
 enum class Viewer2DView {
   Top = 0,
   Front,
-  Side
+  Side,
+  Bottom
 };
 
 class Viewer3DController {
@@ -112,6 +114,8 @@ public:
 
   // Update cached layer color for rendering
   void SetLayerColor(const std::string &layer, const std::string &hex);
+  const SymbolCache &GetBottomSymbolCache() const { return m_bottomSymbolCache; }
+  SymbolCache &GetBottomSymbolCache() { return m_bottomSymbolCache; }
 
 private:
   // Draws a solid cube centered at origin with given size and color
@@ -246,6 +250,8 @@ private:
   ICanvas2D *m_captureCanvas = nullptr;
   Viewer2DView m_captureView = Viewer2DView::Top;
   bool m_captureIncludeGrid = true;
+  bool m_captureOnly = false;
+  SymbolCache m_bottomSymbolCache;
 
 public:
   // Enables recording of all primitives drawn during the next RenderScene


### PR DESCRIPTION
### Motivation
- Reduce repeated geometry emitted for identical fixtures in the Bottom 2D view by caching per-model 2D command lists and emitting lightweight instances instead of re-recording geometry each frame.
- Keep label/text drawing per-instance (not baked into symbols) and avoid changing PDF/export behavior in this change.
- Make symbol replay available at runtime so the recording/rendering path can replay cached definitions efficiently.

### Description
- New Canvas2D API and replay support
  - Added `PlaceSymbolInstance(uint32_t symbolId, const Transform2D&)` to `ICanvas2D` and implemented it for `RasterCanvas`, `RecordingCanvas` and `MultiCanvas`.
  - Implemented `ReplayCommandBuffer(const CommandBuffer&, ICanvas2D&, const SymbolCache*)` and internal replay helpers in `viewer2d/canvas2d.cpp` that handle `SymbolInstanceCommand` by fetching a `SymbolDefinition` and replaying its `localCommands` with the composed transform.
- Symbol instancing in Bottom view capture path
  - Added a persistent `SymbolCache m_bottomSymbolCache` to `Viewer3DController` (lifetime across frames) and helpers to build a stable `modelKey` (`NormalizeModelKey`) and symbol bounds (`ComputeSymbolBounds`).
  - During capture for Bottom view, when eligible, the controller calls `GetOrCreate` on the cache to build a `SymbolDefinition` by recording the per-model geometry into a local `CommandBuffer` (using a temporary `RecordingCanvas`) and stores `localCommands` and bounds. The builder uses viewKind = `Bottom` and `styleVersion = 1`.
  - The main capture emits `SymbolInstanceCommand` via `PlaceSymbolInstance(symbolId, instanceTransform)` instead of re-emitting full geometry for repeated fixtures; labels/text are still emitted per-instance as before.
- Capture-only and rendering adjustments
  - Added `m_captureOnly` flag to `Viewer3DController` so symbol-building recording can disable GL draw calls while recording symbol content (prevents duplicate on-screen drawing during symbol capture).
  - Updated mesh/cube/wireframe/drawing helpers to skip on-screen GL drawing when `m_captureOnly` is set, while still recording capture commands for PDF/export.
- Bottom view orientation and label/grid handling
  - Added `Viewer2DView::Bottom` handling in grid drawing and label placement helpers so captured coordinates/orientation match the Bottom view.

Files changed (high level):
- viewer2d/canvas2d.h / viewer2d/canvas2d.cpp: new PlaceSymbolInstance, replay implementation, helper ReplayCommandBuffer
- viewer2d/viewer2dpanel.cpp: Bottom view camera position in 2D panel
- viewer3d/viewer3dcontroller.h / viewer3d/viewer3dcontroller.cpp: SymbolCache member, model key normalization, symbol builder callback, capture-only rendering adjustments, Bottom view handling for projection/labels and instancing logic

Constraints respected: only Bottom 2D capture path is affected; PDF exporter was not changed to instantiate XObjects (it still ignores SymbolInstanceCommand for export as before).

### Testing
- Automated tests: none executed in this rollout — no unit/integration test runs or CI jobs were invoked.
- Manual verification steps performed during the change (development only): code was compiled and committed locally after changes; runtime/visual verification and PDF exporter regression testing were not performed as part of this automated step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69453477a8d88324b2725c1694cdaf62)