### PR TITLE
Export symbol definitions as PDF Form XObjects and replay instances with Do

### DIFF
--- a/viewer2d/planpdfexporter.h
+++ b/viewer2d/planpdfexporter.h
@@ -19,9 +19,12 @@
 #pragma once
 
 #include "canvas2d.h"
+#include "symbolcache.h"
 #include "viewer2dpanel.h"
 #include <filesystem>
+#include <memory>
 #include <string>
+#include <unordered_map>
 
 constexpr double kMmToPt = 72.0 / 25.4;
 
@@ -44,11 +47,15 @@ struct PlanExportResult {
   std::string message;
 };
 
+using SymbolDefinitionSnapshot =
+    std::unordered_map<uint32_t, SymbolDefinition>;
+
 // Writes the captured 2D drawing commands to a vector PDF that mirrors the
 // current viewport state. Returns structured information so callers can surface
 // meaningful errors to the user.
 PlanExportResult ExportPlanToPdf(const CommandBuffer &buffer,
                                  const Viewer2DViewState &viewState,
                                  const PlanPrintOptions &options,
-                                 const std::filesystem::path &outputPath);
-
+                                 const std::filesystem::path &outputPath,
+                                 std::shared_ptr<const SymbolDefinitionSnapshot>
+                                     symbolSnapshot = nullptr);


### PR DESCRIPTION
### Motivation

- Reduce PDF size and export time by emitting each cached symbol definition once as a PDF Form XObject and drawing instances with `/Do` instead of re-emitting geometry per instance.
- Avoid reading mutable live caches during background export by allowing callers to pass an immutable snapshot of symbol definitions.
- Preserve identical visual output and drawing order; ensure symbol streams do not leak graphics state and exclude label/text from symbol XObjects.

### Description

- Add snapshot support and API change: `ExportPlanToPdf` now accepts an optional `std::shared_ptr<const SymbolDefinitionSnapshot>` and a new `SymbolDefinitionSnapshot` alias (`std::unordered_map<uint32_t, SymbolDefinition>`) to provide an immutable symbol table at export time.
- Implement Form XObject generation and instance drawing:
  - Compute symbol bounds with `ComputeSymbolBounds` and build per-symbol XObject content streams (symbol streams are rendered with `includeText = false`).
  - Register XObjects in the page `/Resources` with stable names for both symbol keys and symbol IDs (`MakeSymbolKeyName` / `MakeSymbolIdName`).
  - Emit instances in the main content stream using `q`, `cm`, `/S<id> Do`, `Q` via `AppendSymbolInstance` so the instance transform is applied correctly.
- Extend the renderer plumbing:
  - `RenderCommandsToStream` gains a `RenderOptions` parameter to optionally skip text inside symbols and to map symbol key/ID -> PDF name when encountering `PlaceSymbolCommand` and `SymbolInstanceCommand`.
  - Added `TransformFromCanvas` helper for converting `CanvasTransform` into `Transform2D` for instance placement math.
- Keep existing non-symbol command export behavior intact (strokes/fills/text unchanged), keep compression handling and content object layout.

### Testing

- No automated tests were executed as part of this change.
- Recommendation: run the existing PDF export smoke tests and capture/export scenarios (scene with many identical fixtures) to validate file-size savings and visual parity.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69454d77e7248324b2383a53c16b0b94)