### PR TITLE
Adjust rigging panel red highlight logic

### DIFF
--- a/gui/riggingpanel.cpp
+++ b/gui/riggingpanel.cpp
@@ -158,22 +158,10 @@ void RiggingPanel::RefreshData() {
     unsigned int rowIndex = table->GetItemCount();
     table->AppendItem(row);
 
-    const bool fixtureCountZero = totals.fixtures == 0;
-    const bool trussCountZero = totals.trusses == 0;
-    const bool hoistCountZero = totals.hoists == 0;
-    const bool fixtureWeightZero =
-        totals.fixtureWeight <= 0.0f || totals.hasZeroWeightFixture;
-    const bool trussWeightZero =
-        totals.trussWeight <= 0.0f || totals.hasZeroWeightTruss;
-    const bool hoistWeightZero =
-        totals.hoistWeight <= 0.0f || totals.hasZeroWeightHoist;
+    const bool fixtureWeightZero = totals.hasZeroWeightFixture;
+    const bool trussWeightZero = totals.hasZeroWeightTruss;
+    const bool hoistWeightZero = totals.hasZeroWeightHoist;
 
-    if (fixtureCountZero)
-      store->SetCellTextColour(rowIndex, 1, *wxRED);
-    if (trussCountZero)
-      store->SetCellTextColour(rowIndex, 2, *wxRED);
-    if (hoistCountZero)
-      store->SetCellTextColour(rowIndex, 3, *wxRED);
     if (fixtureWeightZero)
       store->SetCellTextColour(rowIndex, 4, *wxRED);
     if (trussWeightZero)
@@ -181,8 +169,7 @@ void RiggingPanel::RefreshData() {
     if (hoistWeightZero)
       store->SetCellTextColour(rowIndex, 6, *wxRED);
 
-    if (fixtureCountZero || trussCountZero || hoistCountZero ||
-        fixtureWeightZero || trussWeightZero || hoistWeightZero) {
+    if (fixtureWeightZero || trussWeightZero || hoistWeightZero) {
       store->SetCellTextColour(rowIndex, 7, *wxRED);
       store->SetCellTextColour(rowIndex, 8, *wxRED);
     }


### PR DESCRIPTION
### Motivation

- The rigging plan UI marked count columns (Fixtures/Trusses/Hoists) in red when their count was zero; this was noisy and incorrect for the intended meaning.
- The red highlight should indicate missing weight data (zero-weight elements), not merely an absence of items.
- Make the visual error indication consistent: only weight-related columns should turn red when a zero-weight element exists.

### Description

- Updated `gui/riggingpanel.cpp` in `RiggingPanel::RefreshData()` to change highlight logic.
- Removed checks that turned the count columns red when counts were zero; the code no longer computes `fixtureCountZero`, `trussCountZero`, or `hoistCountZero`.
- Now uses the existing `totals.hasZeroWeightFixture`, `totals.hasZeroWeightTruss`, and `totals.hasZeroWeightHoist` flags to mark weight columns red.
- Total columns (`Total Weight (kg)` and `Total Weight +5% (kg)`) are only marked red when one of the category weight flags is set.

### Testing

- No automated tests were run for this change.
- The patch was kept minimal and localized to `RiggingPanel::RefreshData()` to limit regression surface.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694577248af48324acca5155e8a6666e)