### PR TITLE
Add text-based Rider import dialog and support in RiderImporter

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -213,17 +213,27 @@ std::vector<float> SplitTrussSymmetric(float total) {
 // ExtractPdfText moved to pdftext.cpp
 } // namespace
 
+std::string RiderImporter::LoadText(const std::string &path) {
+  if (path.size() < 4)
+    return {};
+  std::string ext = path.substr(path.size() - 4);
+  for (auto &c : ext)
+    c = static_cast<char>(std::tolower(c));
+  if (ext == ".txt")
+    return ReadTextFile(path);
+  if (ext == ".pdf")
+    return ExtractPdfText(path);
+  return {};
+}
+
 bool RiderImporter::Import(const std::string &path) {
-  std::string text;
-  if (path.size() >= 4) {
-    std::string ext = path.substr(path.size() - 4);
-    for (auto &c : ext)
-      c = static_cast<char>(std::tolower(c));
-    if (ext == ".txt")
-      text = ReadTextFile(path);
-    else if (ext == ".pdf")
-      text = ExtractPdfText(path);
-  }
+  std::string text = LoadText(path);
+  if (text.empty())
+    return false;
+  return ImportText(text);
+}
+
+bool RiderImporter::ImportText(const std::string &text) {
   if (text.empty())
     return false;
 

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -75,6 +75,7 @@ using json = nlohmann::json;
 #include "projectutils.h"
 #include "riggingpanel.h"
 #include "riderimporter.h"
+#include "ridertextdialog.h"
 #include "sceneobjecttablepanel.h"
 #include "selectfixturetypedialog.h"
 #include "selectnamedialog.h"
@@ -171,13 +172,15 @@ wxBEGIN_EVENT_TABLE(MainWindow, wxFrame) EVT_MENU(
                                     EVT_MENU(
                                         ID_Tools_ExportSceneObject,
                                         MainWindow::
-                                    OnExportSceneObject) EVT_MENU(ID_Tools_AutoPatch,
+                                      OnExportSceneObject) EVT_MENU(ID_Tools_AutoPatch,
                                                                           MainWindow::
                                                                               OnAutoPatch) EVT_MENU(ID_Tools_AutoColor,
                                                                           MainWindow::
                                                                               OnAutoColor) EVT_MENU(ID_Tools_ConvertToHoist,
                                                                           MainWindow::
                                                                               OnConvertToHoist)
+                                        EVT_MENU(ID_Tools_ImportRiderText,
+                                                 MainWindow::OnImportRiderText)
                                         EVT_MENU(ID_Help_Help, MainWindow::OnShowHelp) EVT_MENU(
                                             ID_Help_About, MainWindow::
                                                                OnShowAbout)
@@ -501,6 +504,7 @@ void MainWindow::CreateMenuBar() {
   // Tools menu
   wxMenu *toolsMenu = new wxMenu();
   toolsMenu->Append(ID_Tools_DownloadGdtf, "Download GDTF fixture...");
+  toolsMenu->Append(ID_Tools_ImportRiderText, "Import rider from text...");
   toolsMenu->Append(ID_Tools_ExportFixture, "Export Fixture...");
   toolsMenu->Append(ID_Tools_ExportTruss, "Export Truss...");
   toolsMenu->Append(ID_Tools_ExportSceneObject, "Export Scene Object...");
@@ -655,6 +659,27 @@ void MainWindow::OnImportRider(wxCommandEvent &event) {
     }
     RefreshSummary();
   }
+}
+
+void MainWindow::OnImportRiderText(wxCommandEvent &WXUNUSED(event)) {
+  RiderTextDialog dlg(this);
+  if (dlg.ShowModal() != wxID_OK)
+    return;
+
+  wxMessageBox("Rider imported successfully.", "Success", wxICON_INFORMATION);
+  if (consolePanel)
+    consolePanel->AppendMessage("Imported rider from text.");
+  if (fixturePanel)
+    fixturePanel->ReloadData();
+  if (trussPanel)
+    trussPanel->ReloadData();
+  if (hoistPanel)
+    hoistPanel->ReloadData();
+  if (viewportPanel) {
+    viewportPanel->UpdateScene();
+    viewportPanel->Refresh();
+  }
+  RefreshSummary();
 }
 
 // Handles MVR file selection, import, and updates fixture/truss panels

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -82,6 +82,7 @@ private:
   void OnSaveAs(wxCommandEvent &event); // Save project as
   void
   OnImportRider(wxCommandEvent &event);    // Import fixtures/trusses from rider
+  void OnImportRiderText(wxCommandEvent &event); // Import rider from text editor
   void OnImportMVR(wxCommandEvent &event); // Handle the Import MVR action
   void OnExportMVR(wxCommandEvent &event); // Handle the Export MVR action
   void OnExportTruss(wxCommandEvent &event);       // Export truss metadata
@@ -165,6 +166,7 @@ enum {
   ID_View_Layout_Default,
   ID_View_Layout_2D,
   ID_Tools_DownloadGdtf,
+  ID_Tools_ImportRiderText,
   ID_Tools_ExportFixture,
   ID_Tools_ExportTruss,
   ID_Tools_ExportSceneObject,

--- a/gui/ridertextdialog.cpp
+++ b/gui/ridertextdialog.cpp
@@ -1,0 +1,103 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "ridertextdialog.h"
+
+#include <wx/button.h>
+#include <wx/filedlg.h>
+#include <wx/msgdlg.h>
+#include <wx/sizer.h>
+#include <wx/stattext.h>
+#include <wx/textctrl.h>
+
+#include "projectutils.h"
+#include "riderimporter.h"
+
+enum { ID_RiderText_Load = wxID_HIGHEST + 4200, ID_RiderText_Apply };
+
+wxBEGIN_EVENT_TABLE(RiderTextDialog, wxDialog)
+EVT_BUTTON(ID_RiderText_Load, RiderTextDialog::OnLoadFromFile)
+EVT_BUTTON(ID_RiderText_Apply, RiderTextDialog::OnApply)
+wxEND_EVENT_TABLE()
+
+RiderTextDialog::RiderTextDialog(wxWindow *parent,
+                                 const wxString &initialText,
+                                 const wxString &initialSource)
+    : wxDialog(parent, wxID_ANY, "Import rider from text",
+               wxDefaultPosition, wxSize(720, 520),
+               wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
+      sourceLabel(initialSource) {
+  wxBoxSizer *mainSizer = new wxBoxSizer(wxVERTICAL);
+
+  wxBoxSizer *headerSizer = new wxBoxSizer(wxHORIZONTAL);
+  sourceText = new wxStaticText(
+      this, wxID_ANY,
+      sourceLabel.empty() ? "No source loaded." : "Loaded: " + sourceLabel);
+  headerSizer->Add(sourceText, 1, wxALIGN_CENTER_VERTICAL | wxRIGHT, 8);
+  wxButton *loadButton =
+      new wxButton(this, ID_RiderText_Load, "Import rider...");
+  headerSizer->Add(loadButton, 0);
+  mainSizer->Add(headerSizer, 0, wxEXPAND | wxALL, 8);
+
+  textCtrl = new wxTextCtrl(this, wxID_ANY, initialText,
+                            wxDefaultPosition, wxDefaultSize,
+                            wxTE_MULTILINE | wxTE_RICH2);
+  textCtrl->SetMinSize(wxSize(680, 360));
+  mainSizer->Add(textCtrl, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 8);
+
+  wxBoxSizer *buttonSizer = new wxBoxSizer(wxHORIZONTAL);
+  wxButton *applyButton = new wxButton(this, ID_RiderText_Apply, "Apply");
+  wxButton *cancelButton = new wxButton(this, wxID_CANCEL, "Cancel");
+  buttonSizer->AddStretchSpacer();
+  buttonSizer->Add(applyButton, 0, wxRIGHT, 8);
+  buttonSizer->Add(cancelButton, 0);
+  mainSizer->Add(buttonSizer, 0, wxEXPAND | wxALL, 8);
+
+  SetSizer(mainSizer);
+  Layout();
+  Centre();
+}
+
+void RiderTextDialog::OnLoadFromFile(wxCommandEvent &WXUNUSED(event)) {
+  wxString miscDir =
+      wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("misc"));
+  wxFileDialog dlg(this, "Import Rider", miscDir, "",
+                   "Rider files (*.txt;*.pdf)|*.txt;*.pdf",
+                   wxFD_OPEN | wxFD_FILE_MUST_EXIST);
+  if (dlg.ShowModal() == wxID_CANCEL)
+    return;
+
+  std::string pathUtf8 = dlg.GetPath().ToStdString();
+  std::string text = RiderImporter::LoadText(pathUtf8);
+  if (text.empty()) {
+    wxMessageBox("Failed to import rider.", "Error", wxICON_ERROR);
+    return;
+  }
+  sourceLabel = dlg.GetFilename();
+  if (sourceText)
+    sourceText->SetLabel("Loaded: " + sourceLabel);
+  textCtrl->ChangeValue(wxString::FromUTF8(text));
+}
+
+void RiderTextDialog::OnApply(wxCommandEvent &WXUNUSED(event)) {
+  std::string text = textCtrl->GetValue().ToStdString();
+  if (!RiderImporter::ImportText(text)) {
+    wxMessageBox("Failed to import rider text.", "Error", wxICON_ERROR);
+    return;
+  }
+  EndModal(wxID_OK);
+}

--- a/gui/ridertextdialog.h
+++ b/gui/ridertextdialog.h
@@ -17,15 +17,24 @@
  */
 #pragma once
 
-#include <string>
+#include <wx/dialog.h>
 
-// Parses simple rider files (.txt/.pdf) to create dummy fixtures and trusses
-class RiderImporter {
+class wxTextCtrl;
+class wxStaticText;
+
+class RiderTextDialog : public wxDialog {
 public:
-    // Import rider located at path. Returns true on success.
-    static bool Import(const std::string& path);
-    // Load rider file into text. Returns empty string on failure.
-    static std::string LoadText(const std::string& path);
-    // Import from raw rider text. Returns true on success.
-    static bool ImportText(const std::string& text);
+  explicit RiderTextDialog(wxWindow *parent,
+                           const wxString &initialText = wxEmptyString,
+                           const wxString &initialSource = wxEmptyString);
+
+private:
+  void OnLoadFromFile(wxCommandEvent &event);
+  void OnApply(wxCommandEvent &event);
+
+  wxTextCtrl *textCtrl = nullptr;
+  wxStaticText *sourceText = nullptr;
+  wxString sourceLabel;
+
+  wxDECLARE_EVENT_TABLE();
 };


### PR DESCRIPTION
### Motivation
- Provide a way to create scene fixtures/trusses by pasting or editing rider text instead of only selecting a file.
- Allow users to load a `.txt`/`.pdf` rider into an editor, edit the text, and apply the same import logic used by the file-based `Import Rider` flow.
- Keep the existing file import behaviour while exposing helpers so the same parser can be invoked on arbitrary text.

### Description
- Added a new dialog `RiderTextDialog` (`gui/ridertextdialog.h` / `.cpp`) that contains a multi-line text editor, a `Load` button to load a rider file into the editor, an `Apply` button to perform the import from the edited text, and `Cancel`.
- Extended `RiderImporter` API (`core/riderimporter.h`) with two helpers: `LoadText(const std::string &path)` to extract text from `.txt`/`.pdf`, and `ImportText(const std::string &text)` to import from raw text.
- Refactored `RiderImporter::Import` to reuse `LoadText` and `ImportText` so file-based and text-based imports share the same parsing/import logic (`core/riderimporter.cpp`).
- Integrated the dialog into the UI: added a new Tools menu item `Import rider from text...` and handler `MainWindow::OnImportRiderText` that opens the dialog and refreshes panels/view after a successful import (`gui/mainwindow.h` / `.cpp`).

### Testing
- No automated tests were run as part of this change.
- Existing unit/test files for rider importer remain in place (no test execution was requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69457b53407483249351fd3ffeb8f6d7)