### PR TITLE
Fix RiderTextDialog source label construction using wxString::Format

### DIFF
--- a/gui/ridertextdialog.cpp
+++ b/gui/ridertextdialog.cpp
@@ -44,9 +44,10 @@ RiderTextDialog::RiderTextDialog(wxWindow *parent,
   wxBoxSizer *mainSizer = new wxBoxSizer(wxVERTICAL);
 
   wxBoxSizer *headerSizer = new wxBoxSizer(wxHORIZONTAL);
-  sourceText = new wxStaticText(
-      this, wxID_ANY,
-      sourceLabel.empty() ? "No source loaded." : "Loaded: " + sourceLabel);
+  const wxString sourceTextLabel =
+      sourceLabel.empty() ? wxString("No source loaded.")
+                          : wxString::Format("Loaded: %s", sourceLabel);
+  sourceText = new wxStaticText(this, wxID_ANY, sourceTextLabel);
   headerSizer->Add(sourceText, 1, wxALIGN_CENTER_VERTICAL | wxRIGHT, 8);
   wxButton *loadButton =
       new wxButton(this, ID_RiderText_Load, "Import rider...");
@@ -89,7 +90,7 @@ void RiderTextDialog::OnLoadFromFile(wxCommandEvent &WXUNUSED(event)) {
   }
   sourceLabel = dlg.GetFilename();
   if (sourceText)
-    sourceText->SetLabel("Loaded: " + sourceLabel);
+    sourceText->SetLabel(wxString::Format("Loaded: %s", sourceLabel));
   textCtrl->ChangeValue(wxString::FromUTF8(text));
 }
 


### PR DESCRIPTION
### Motivation
- The previous ternary used to construct the source label mixed C string literals and `wxString`, causing compiler errors (`C2661` and `C2445`) due to ambiguous overloads and conditional-expression result types.
- Ensure the `wxStaticText` is created with a proper `wxString` and that updating the label at runtime uses a consistent `wxString` API.

### Description
- Replace the inline ternary that mixed `const char[]` and `wxString` with a `const wxString sourceTextLabel` constructed via `wxString::Format`.
- Create the `wxStaticText` using `sourceTextLabel`: `sourceText = new wxStaticText(this, wxID_ANY, sourceTextLabel);`.
- Update the runtime label update to use `sourceText->SetLabel(wxString::Format("Loaded: %s", sourceLabel));`.
- Modified file: `gui/ridertextdialog.cpp`.

### Testing
- No automated tests were run for this change.
- (Build/CI was not executed as part of this change.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69457cf232fc8324bc28fba604ba9ce4)