### PR TITLE
Remove File 'Import Rider' entry and rename rider-text UI to 'Create from text'

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -457,7 +457,6 @@ void MainWindow::CreateMenuBar() {
   fileMenu->Append(ID_File_Save, "Save\tCtrl+S");
   fileMenu->Append(ID_File_SaveAs, "Save As...");
   fileMenu->AppendSeparator();
-  fileMenu->Append(ID_File_ImportRider, "Import Rider...");
   fileMenu->Append(ID_File_ImportMVR, "Import MVR...");
   fileMenu->Append(ID_File_ExportMVR, "Export MVR...");
   fileMenu->Append(ID_File_PrintPlan, "Print Plan...");
@@ -504,7 +503,7 @@ void MainWindow::CreateMenuBar() {
   // Tools menu
   wxMenu *toolsMenu = new wxMenu();
   toolsMenu->Append(ID_Tools_DownloadGdtf, "Download GDTF fixture...");
-  toolsMenu->Append(ID_Tools_ImportRiderText, "Import rider from text...");
+  toolsMenu->Append(ID_Tools_ImportRiderText, "Create from text...");
   toolsMenu->Append(ID_Tools_ExportFixture, "Export Fixture...");
   toolsMenu->Append(ID_Tools_ExportTruss, "Export Truss...");
   toolsMenu->Append(ID_Tools_ExportSceneObject, "Export Scene Object...");

--- a/gui/ridertextdialog.cpp
+++ b/gui/ridertextdialog.cpp
@@ -37,7 +37,7 @@ wxEND_EVENT_TABLE()
 RiderTextDialog::RiderTextDialog(wxWindow *parent,
                                  const wxString &initialText,
                                  const wxString &initialSource)
-    : wxDialog(parent, wxID_ANY, "Import rider from text",
+    : wxDialog(parent, wxID_ANY, "Create rider from text",
                wxDefaultPosition, wxSize(720, 520),
                wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
       sourceLabel(initialSource) {
@@ -49,8 +49,7 @@ RiderTextDialog::RiderTextDialog(wxWindow *parent,
                           : wxString::Format("Loaded: %s", sourceLabel);
   sourceText = new wxStaticText(this, wxID_ANY, sourceTextLabel);
   headerSizer->Add(sourceText, 1, wxALIGN_CENTER_VERTICAL | wxRIGHT, 8);
-  wxButton *loadButton =
-      new wxButton(this, ID_RiderText_Load, "Import rider...");
+  wxButton *loadButton = new wxButton(this, ID_RiderText_Load, "Load rider...");
   headerSizer->Add(loadButton, 0);
   mainSizer->Add(headerSizer, 0, wxEXPAND | wxALL, 8);
 


### PR DESCRIPTION
### Motivation
- Align UI wording with the intent to create riders from pasted/loaded text rather than import terminology.
- Remove duplicate/confusing `Import Rider` entry from the `File` menu and prefer the Tools-based workflow for creating riders from text.

### Description
- Removed the `File` menu entry for `Import Rider` in `gui/mainwindow.cpp` (no longer appended to the File menu).
- Renamed the Tools menu item `ID_Tools_ImportRiderText` label from `"Import rider from text..."` to `"Create from text..."` in `gui/mainwindow.cpp`.
- Updated the rider text dialog title from `"Import rider from text"` to `"Create rider from text"` in `gui/ridertextdialog.cpp`.
- Changed the dialog load button text from `"Import rider..."` to `"Load rider..."` in `gui/ridertextdialog.cpp`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69457ed3456483248938817c93423e33)