### PR TITLE
Use 2D symbol snapshot when exporting print plans

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1347,8 +1347,10 @@ void MainWindow::OnPrintPlan(wxCommandEvent &WXUNUSED(event)) {
   opts.useSimplifiedFootprints = !settings.detailedFootprints;
   opts.pageWidthPt = settings.PageWidthPt();
   opts.pageHeightPt = settings.PageHeightPt();
-  std::shared_ptr<const SymbolDefinitionSnapshot> symbolSnapshot =
-      viewportPanel ? viewportPanel->GetBottomSymbolCacheSnapshot() : nullptr;
+  std::shared_ptr<const SymbolDefinitionSnapshot> symbolSnapshot = nullptr;
+  if (viewport2DPanel) {
+    symbolSnapshot = viewport2DPanel->GetBottomSymbolCacheSnapshot();
+  }
   std::filesystem::path outputPath(
       std::filesystem::path(outputPathWx.ToStdWstring()));
   wxString outputPathDisplay = outputPathWx;

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -249,6 +249,11 @@ Viewer2DViewState Viewer2DPanel::GetViewState() const {
   return state;
 }
 
+std::shared_ptr<const SymbolDefinitionSnapshot>
+Viewer2DPanel::GetBottomSymbolCacheSnapshot() const {
+  return m_controller.GetBottomSymbolCacheSnapshot();
+}
+
 void Viewer2DPanel::InitGL() {
   SetCurrent(*m_glContext);
   if (!m_glInitialized) {

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -29,6 +29,7 @@
 #include <wx/glcanvas.h>
 #include <wx/wx.h>
 #include <functional>
+#include <memory>
 #include <string>
 
 // Current viewport information used to rebuild the same projection when
@@ -89,6 +90,9 @@ public:
   // Accessor for the current viewport state so exporters can match what the
   // user is seeing on screen.
   Viewer2DViewState GetViewState() const;
+
+  std::shared_ptr<const SymbolDefinitionSnapshot>
+  GetBottomSymbolCacheSnapshot() const;
 
 private:
   void InitGL();


### PR DESCRIPTION
### Motivation
- When printing a plan the PDF exporter should reuse 2D symbol instances (Bottom view) to reduce file size and speed up generation.
- The exporter was receiving a snapshot from the 3D viewport which does not contain the 2D-captured symbol definitions.
- Provide access to the bottom symbol cache from the 2D viewer and use it when invoking the PDF export.

### Description
- Exposed a new accessor on `Viewer2DPanel`: `std::shared_ptr<const SymbolDefinitionSnapshot> GetBottomSymbolCacheSnapshot() const;` (declared in `viewer2d/viewer2dpanel.h`, implemented in `viewer2d/viewer2dpanel.cpp`).
- The new accessor forwards to the existing controller: `m_controller.GetBottomSymbolCacheSnapshot()`.
- Updated `MainWindow::OnPrintPlan` (`gui/mainwindow.cpp`) to obtain the snapshot from the 2D panel (`viewport2DPanel`) and pass it through to `ExportPlanToPdf` via the existing `symbolSnapshot` parameter.
- Files modified: `viewer2d/viewer2dpanel.h`, `viewer2d/viewer2dpanel.cpp`, `gui/mainwindow.cpp`.

### Testing
- No automated tests or CI jobs were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694580ffec048324aacaa94e60d145b5)