### PR TITLE
Show rider import success popup when loading text (not on Apply)

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -665,7 +665,6 @@ void MainWindow::OnImportRiderText(wxCommandEvent &WXUNUSED(event)) {
   if (dlg.ShowModal() != wxID_OK)
     return;
 
-  wxMessageBox("Rider imported successfully.", "Success", wxICON_INFORMATION);
   if (consolePanel)
     consolePanel->AppendMessage("Imported rider from text.");
   if (fixturePanel)

--- a/gui/ridertextdialog.cpp
+++ b/gui/ridertextdialog.cpp
@@ -91,6 +91,7 @@ void RiderTextDialog::OnLoadFromFile(wxCommandEvent &WXUNUSED(event)) {
   if (sourceText)
     sourceText->SetLabel(wxString::Format("Loaded: %s", sourceLabel));
   textCtrl->ChangeValue(wxString::FromUTF8(text));
+  wxMessageBox("Rider imported successfully.", "Success", wxICON_INFORMATION);
 }
 
 void RiderTextDialog::OnApply(wxCommandEvent &WXUNUSED(event)) {


### PR DESCRIPTION
### Motivation
- Improve UX: the success popup should appear when a rider file is loaded into the rider text dialog, not when the user clicks `Apply` to import the text into the scene.
- Avoid showing a success message before the actual import step completes.

### Description
- Removed the success message from `MainWindow::OnImportRiderText` in `gui/mainwindow.cpp`.
- Added the success message to `RiderTextDialog::OnLoadFromFile` in `gui/ridertextdialog.cpp` so it is shown immediately after loading text from a file.
- Files modified: `gui/mainwindow.cpp`, `gui/ridertextdialog.cpp`.

### Testing
- No automated tests were executed for this change.
- Code changes compiled and committed in the working branch (no CI/test results included).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945851d10808324be2c1cb3c2c0480e)