### PR TITLE
Enable symbol instancing during plan captures (PDF export)

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1155,8 +1155,8 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
 
     bool suppressCapture = false;
     const bool useSymbolInstancing =
-        m_captureCanvas && m_captureView == Viewer2DView::Bottom && !highlight &&
-        !selected;
+        m_captureCanvas != nullptr ||
+        (m_captureView == Viewer2DView::Bottom && !highlight && !selected);
     if (useSymbolInstancing) {
       std::string modelKey = NormalizeModelKey(gdtfPath);
       if (modelKey.empty() && !f.gdtfSpec.empty())
@@ -1165,9 +1165,23 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
         modelKey = f.typeName;
 
       if (!modelKey.empty()) {
+        auto resolveSymbolView = [](Viewer2DView viewKind) {
+          switch (viewKind) {
+          case Viewer2DView::Top:
+            return SymbolViewKind::Top;
+          case Viewer2DView::Front:
+            return SymbolViewKind::Front;
+          case Viewer2DView::Side:
+            return SymbolViewKind::Left;
+          case Viewer2DView::Bottom:
+          default:
+            return SymbolViewKind::Bottom;
+          }
+        };
+
         SymbolKey symbolKey;
         symbolKey.modelKey = modelKey;
-        symbolKey.viewKind = SymbolViewKind::Bottom;
+        symbolKey.viewKind = resolveSymbolView(m_captureView);
         symbolKey.styleVersion = 1;
 
         const auto &symbol =


### PR DESCRIPTION
### Motivation
- Ensure PDF/plan exports use symbol instancing (`SymbolInstanceCommand`) for repeated fixtures when capturing a plan, even if there are selected or highlighted objects or when the view is `Top`.
- Previously `useSymbolInstancing` was only enabled for `Viewer2DView::Bottom` and when no selection/highlight existed, causing duplicated geometry and large PDF outputs.

### Description
- Updated `RenderScene` in `viewer3d/viewer3dcontroller.cpp` to enable symbol instancing when `m_captureCanvas != nullptr` (i.e. during a plan capture), regardless of `m_captureView`, selection or highlight state.
- Added a small `resolveSymbolView` mapping so the `SymbolKey.viewKind` reflects the active capture view (`m_captureView`) instead of hardcoding `Bottom`.
- Continued to use the existing symbol cache (`m_bottomSymbolCache.GetOrCreate(...)`) to create/lookup `SymbolDefinition` and to build the local recording canvas; symbol generation and placement logic remains unchanged.
- Preserved current behavior for text/labels — they are still emitted individually and not included inside symbols.

### Testing
- No automated tests were executed as part of this change.
- Local build/run verification was not performed in this rollout (recommend building the app and generating a PDF with many identical fixtures to validate reduced PDF size and correctness).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694587a0d6dc8324a37aaef07ef06de3)