### PR TITLE
Limit symbol instancing to Bottom view and only suppress capture when an instance is placed

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1155,9 +1155,9 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
 
     bool suppressCapture = false;
     const bool useSymbolInstancing =
-        m_captureCanvas != nullptr ||
         (m_captureView == Viewer2DView::Bottom && !highlight && !selected);
-    if (useSymbolInstancing) {
+    bool placedInstance = false;
+    if (useSymbolInstancing && m_captureCanvas) {
       std::string modelKey = NormalizeModelKey(gdtfPath);
       if (modelKey.empty() && !f.gdtfSpec.empty())
         modelKey = NormalizeModelKey(f.gdtfSpec);
@@ -1242,9 +1242,10 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
             BuildInstanceTransform2D(fixtureTransform, m_captureView);
         m_captureCanvas->PlaceSymbolInstance(symbol.symbolId,
                                              instanceTransform);
-        suppressCapture = true;
+        placedInstance = true;
       }
     }
+    suppressCapture = placedInstance;
 
     auto drawFixtureGeometry = [&]() {
       if (itg != m_loadedGdtf.end()) {


### PR DESCRIPTION
### Motivation

- Fix missing luminaires in exported PDFs caused by forcing symbol instancing whenever `m_captureCanvas != nullptr`.
- Ensure non-Bottom views (e.g., Top) capture real geometry so fixtures appear in prints.
- Keep instancing optimization for Bottom view where symbol caching is available.

### Description

- In `Viewer3DController::RenderScene` changed the `useSymbolInstancing` condition to only enable instancing for Bottom view: ` (m_captureView == Viewer2DView::Bottom && !highlight && !selected)`.
- Prevent attempting to insert `SymbolInstanceCommand`s unless `m_captureCanvas` is present by gating the instancing logic with `if (useSymbolInstancing && m_captureCanvas) { ... }`.
- Added a `placedInstance` flag and set `suppressCapture = placedInstance;` so capture suppression only occurs when a symbol instance was actually placed into the capture canvas.
- File modified: `viewer3d/viewer3dcontroller.cpp`.

### Testing

- No automated tests were executed as part of this change.
- Manual validation recommended: capture Top view to verify luminaires appear in PDF; capture Bottom to verify instancing and lighter PDF output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69458f682c10832499ea0d23c046e59c)