### PR TITLE
Enable symbol instancing for Top/Front/Side capture views

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1155,7 +1155,11 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
 
     bool suppressCapture = false;
     const bool useSymbolInstancing =
-        (m_captureView == Viewer2DView::Bottom && !highlight && !selected);
+        ((m_captureView == Viewer2DView::Bottom ||
+          m_captureView == Viewer2DView::Top ||
+          m_captureView == Viewer2DView::Front ||
+          m_captureView == Viewer2DView::Side) &&
+         !highlight && !selected);
     bool placedInstance = false;
     if (useSymbolInstancing && m_captureCanvas) {
       std::string modelKey = NormalizeModelKey(gdtfPath);


### PR DESCRIPTION
### Motivation

- Allow symbol instancing in additional 2D capture orientations so captured fixtures can reuse symbol definitions for Top/Front/Side views (previously only Bottom used instancing).
- Reduce duplicate capture rendering and improve reuse of recorded symbol geometry across different view orientations.

### Description

- Broadened the `useSymbolInstancing` condition in `viewer3d/viewer3dcontroller.cpp` to enable instancing when `m_captureView` is `Top`, `Front`, or `Side` in addition to `Bottom` (while still skipping when `highlight` or `selected` are set).
- Kept the existing `SymbolKey` usage which already sets `symbolKey.viewKind`, ensuring the `SymbolCache` keys remain distinct per view orientation and preventing cross-view symbol mixing.
- Did not change the `PlaceSymbolInstance` flow or the symbol creation callback — symbol recording and placement logic remain unchanged.

### Testing

- No automated tests were run as part of this change.
- No build or runtime validation was performed in this rollout (compile/run not executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69459c0726a083248a4c5a5ebb2dc8f7)