### PR TITLE
Make plan PDF symbol instancing depend on Detailed/Schematic print mode

### DIFF
--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -311,8 +311,7 @@ void Viewer2DPanel::Render() {
   std::unique_ptr<ICanvas2D> recordingCanvas;
   if (m_captureNextFrame) {
     m_lastCapturedFrame.Clear();
-    recordingCanvas =
-        CreateRecordingCanvas(m_lastCapturedFrame, m_useSimplifiedFootprints);
+    recordingCanvas = CreateRecordingCanvas(m_lastCapturedFrame, false);
     // The recorded commands operate in the same world-space coordinates used by
     // the OpenGL renderer. We keep the transform identity so the exporter can
     // apply the viewport offsets/zoom exactly once using the captured
@@ -324,7 +323,8 @@ void Viewer2DPanel::Render() {
     recordingCanvas->BeginFrame();
     recordingCanvas->SetTransform(transform);
     m_controller.SetCaptureCanvas(recordingCanvas.get(), m_view,
-                                  m_captureIncludeGrid);
+                                  m_captureIncludeGrid,
+                                  m_useSimplifiedFootprints);
   } else {
     m_controller.SetCaptureCanvas(nullptr, m_view);
   }

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1155,7 +1155,8 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
 
     bool suppressCapture = false;
     const bool useSymbolInstancing =
-        ((m_captureView == Viewer2DView::Bottom ||
+        (m_captureUseSymbols &&
+         (m_captureView == Viewer2DView::Bottom ||
           m_captureView == Viewer2DView::Top ||
           m_captureView == Viewer2DView::Front ||
           m_captureView == Viewer2DView::Side) &&

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -254,6 +254,7 @@ private:
   Viewer2DView m_captureView = Viewer2DView::Top;
   bool m_captureIncludeGrid = true;
   bool m_captureOnly = false;
+  bool m_captureUseSymbols = false;
   SymbolCache m_bottomSymbolCache;
 
 public:
@@ -262,9 +263,11 @@ public:
   // BeginFrame/EndFrame. Recording is disabled automatically after each
   // render pass by resetting the canvas to nullptr.
   void SetCaptureCanvas(ICanvas2D *canvas, Viewer2DView view,
-                        bool includeGrid = true) {
+                        bool includeGrid = true,
+                        bool useSymbolInstancing = false) {
     m_captureCanvas = canvas;
     m_captureView = view;
     m_captureIncludeGrid = includeGrid;
+    m_captureUseSymbols = canvas ? useSymbolInstancing : false;
   }
 };


### PR DESCRIPTION
### Motivation
- Restore the previous behavior where the `Detailed` plan export writes full captured geometry (no placed symbol instances) so the PDF matches the 2D viewer output.
- Enable symbol instancing for the `Schematic` export so schematic prints reuse generated symbol instances (lighter PDF) instead of writing raw 3D geometry.
- Provide a simple capture-time switch to choose whether symbol instancing is used during the 2D capture.
- Keep the on-screen viewer unchanged while changing only how the capture exports are recorded.

### Description
- Added a capture-time flag to the 3D controller: `m_captureUseSymbols` and extended `Viewer3DController::SetCaptureCanvas` to accept `useSymbolInstancing` and set the new flag.
- Gate symbol instancing in the capture path by the new flag: the `useSymbolInstancing` condition in `RenderScene` now requires `m_captureUseSymbols` in addition to the existing view/selection checks.
- Force the recording canvas to capture full geometry (no simplification) by creating the recording canvas with `simplifyFootprints = false` during plan capture; the detailed vs schematic behavior is controlled by passing `m_useSimplifiedFootprints` as the `useSymbolInstancing` argument to `SetCaptureCanvas`.
- Files changed:
  - `viewer3d/viewer3dcontroller.h` — add `m_captureUseSymbols`, extend `SetCaptureCanvas` signature.
  - `viewer3d/viewer3dcontroller.cpp` — conditionally gate symbol instancing with `m_captureUseSymbols`.
  - `viewer2d/viewer2dpanel.cpp` — create recording canvas with `false` (detailed geometry) and forward `m_useSimplifiedFootprints` into `SetCaptureCanvas` to enable symbol instancing for schematic mode.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69459db399448324a2d8cad28f4c0753)