### PR TITLE
Fix PDF fill for placeholder fixtures in 2D capture

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1594,6 +1594,32 @@ void Viewer3DController::DrawCubeWithOutline(
       return;
     }
     DrawWireframeCube(size, 0.0f, 0.0f, 0.0f, mode, captureTransform);
+    if (m_captureCanvas) {
+      float half = size / 2.0f;
+      float x0 = -half, x1 = half;
+      float y0 = -half, y1 = half;
+      float z0 = -half, z1 = half;
+      std::vector<std::array<float, 3>> verts = {
+          {x0, y0, z0}, {x1, y0, z0}, {x0, y1, z0}, {x1, y1, z0},
+          {x0, y0, z1}, {x1, y0, z1}, {x0, y1, z1}, {x1, y1, z1}};
+      if (captureTransform) {
+        for (auto &p : verts)
+          p = captureTransform(p);
+      }
+      float lineWidth = (mode == Viewer2DRenderMode::Wireframe) ? 1.0f : 2.0f;
+      CanvasStroke stroke;
+      stroke.color = {0.0f, 0.0f, 0.0f, 1.0f};
+      stroke.width = lineWidth;
+      CanvasFill fill;
+      fill.color = {r, g, b, 1.0f};
+      const int faces[6][4] = {{0, 1, 3, 2}, {4, 5, 7, 6}, {0, 1, 5, 4},
+                               {2, 3, 7, 6}, {0, 2, 6, 4}, {1, 3, 7, 5}};
+      for (const auto &face : faces) {
+        std::vector<std::array<float, 3>> pts = {
+            verts[face[0]], verts[face[1]], verts[face[2]], verts[face[3]]};
+        RecordPolygon(pts, stroke, &fill);
+      }
+    }
     if (!m_captureOnly) {
       glEnable(GL_POLYGON_OFFSET_FILL);
       glPolygonOffset(-1.0f, -1.0f);


### PR DESCRIPTION
### Motivation
- Placeholder fixtures (those lacking valid 3D/GDTF geometry) are captured as wireframe cubes in the 2D viewer but when exporting to PDF the color/filled pass was missing — PDFs showed only the thick black outline instead of the colored fill seen on-screen.
- Ensure the capture pipeline records the same stroke+fill passes sent to the PDF exporter so PDF output matches the 2D viewer.

### Description
- In `viewer3d/viewer3dcontroller.cpp` updated `Viewer3DController::DrawCubeWithOutline` to record filled cube faces into the capture canvas when in the wireframe capture path:
  - When `m_captureCanvas` is set and `wireframe` handling is active the code now constructs the cube vertices, applies the `captureTransform`, and calls `RecordPolygon` for each face with a black stroke and a `CanvasFill` using the cube color `(r,g,b)`.
  - This produces both stroke and fill drawing commands in the `CommandBuffer`, matching the on-screen two-pass rendering (stroke pass then fill pass) used by the PDF exporter.
- The change is narrowly scoped to the wireframe placeholder capture path and does not affect normal GL rendering.

### Testing
- Automated tests: none were executed for this change.
- Manual/functional intent: the change is intended to make the capture buffer include filled faces so existing PDF export logic (`viewer2d/planpdfexporter.cpp`) replays both stroke and fill layers and produces PDFs visually equivalent to the 2D view.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945a05b5a308324b6bc4d60b3baa1d6)