### PR TITLE
Expand symbol bounds to include stroke width to avoid clipped schematic outlines

### DIFF
--- a/viewer2d/planpdfexporter.cpp
+++ b/viewer2d/planpdfexporter.cpp
@@ -471,27 +471,39 @@ SymbolBounds ComputeSymbolBounds(const std::vector<CanvasCommand> &commands) {
     bounds.max.y = std::max(bounds.max.y, y);
   };
 
-  auto addPoints = [&](const std::vector<float> &points) {
-    for (size_t i = 0; i + 1 < points.size(); i += 2)
-      addPoint(points[i], points[i + 1]);
+  auto addPointWithPadding = [&](float x, float y, float padding) {
+    if (padding <= 0.0f) {
+      addPoint(x, y);
+      return;
+    }
+    addPoint(x - padding, y - padding);
+    addPoint(x + padding, y + padding);
   };
 
   for (const auto &cmd : commands) {
     if (const auto *line = std::get_if<LineCommand>(&cmd)) {
-      addPoint(line->x0, line->y0);
-      addPoint(line->x1, line->y1);
+      float pad = std::max(0.0f, line->stroke.width) * 0.5f;
+      addPointWithPadding(line->x0, line->y0, pad);
+      addPointWithPadding(line->x1, line->y1, pad);
     } else if (const auto *polyline = std::get_if<PolylineCommand>(&cmd)) {
-      addPoints(polyline->points);
+      float pad = std::max(0.0f, polyline->stroke.width) * 0.5f;
+      for (size_t i = 0; i + 1 < polyline->points.size(); i += 2)
+        addPointWithPadding(polyline->points[i], polyline->points[i + 1], pad);
     } else if (const auto *poly = std::get_if<PolygonCommand>(&cmd)) {
-      addPoints(poly->points);
+      float pad = std::max(0.0f, poly->stroke.width) * 0.5f;
+      for (size_t i = 0; i + 1 < poly->points.size(); i += 2)
+        addPointWithPadding(poly->points[i], poly->points[i + 1], pad);
     } else if (const auto *rect = std::get_if<RectangleCommand>(&cmd)) {
-      addPoint(rect->x, rect->y);
-      addPoint(rect->x + rect->w, rect->y);
-      addPoint(rect->x + rect->w, rect->y + rect->h);
-      addPoint(rect->x, rect->y + rect->h);
+      float pad = std::max(0.0f, rect->stroke.width) * 0.5f;
+      addPointWithPadding(rect->x, rect->y, pad);
+      addPointWithPadding(rect->x + rect->w, rect->y, pad);
+      addPointWithPadding(rect->x + rect->w, rect->y + rect->h, pad);
+      addPointWithPadding(rect->x, rect->y + rect->h, pad);
     } else if (const auto *circle = std::get_if<CircleCommand>(&cmd)) {
-      addPoint(circle->cx - circle->radius, circle->cy - circle->radius);
-      addPoint(circle->cx + circle->radius, circle->cy + circle->radius);
+      float pad = std::max(0.0f, circle->stroke.width) * 0.5f;
+      float radius = circle->radius + pad;
+      addPoint(circle->cx - radius, circle->cy - radius);
+      addPoint(circle->cx + radius, circle->cy + radius);
     }
   }
 

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -160,27 +160,39 @@ static SymbolBounds ComputeSymbolBounds(const CommandBuffer &buffer) {
     bounds.max.y = std::max(bounds.max.y, y);
   };
 
-  auto addPoints = [&](const std::vector<float> &points) {
-    for (size_t i = 0; i + 1 < points.size(); i += 2)
-      addPoint(points[i], points[i + 1]);
+  auto addPointWithPadding = [&](float x, float y, float padding) {
+    if (padding <= 0.0f) {
+      addPoint(x, y);
+      return;
+    }
+    addPoint(x - padding, y - padding);
+    addPoint(x + padding, y + padding);
   };
 
   for (const auto &cmd : buffer.commands) {
     if (const auto *line = std::get_if<LineCommand>(&cmd)) {
-      addPoint(line->x0, line->y0);
-      addPoint(line->x1, line->y1);
+      float pad = std::max(0.0f, line->stroke.width) * 0.5f;
+      addPointWithPadding(line->x0, line->y0, pad);
+      addPointWithPadding(line->x1, line->y1, pad);
     } else if (const auto *polyline = std::get_if<PolylineCommand>(&cmd)) {
-      addPoints(polyline->points);
+      float pad = std::max(0.0f, polyline->stroke.width) * 0.5f;
+      for (size_t i = 0; i + 1 < polyline->points.size(); i += 2)
+        addPointWithPadding(polyline->points[i], polyline->points[i + 1], pad);
     } else if (const auto *poly = std::get_if<PolygonCommand>(&cmd)) {
-      addPoints(poly->points);
+      float pad = std::max(0.0f, poly->stroke.width) * 0.5f;
+      for (size_t i = 0; i + 1 < poly->points.size(); i += 2)
+        addPointWithPadding(poly->points[i], poly->points[i + 1], pad);
     } else if (const auto *rect = std::get_if<RectangleCommand>(&cmd)) {
-      addPoint(rect->x, rect->y);
-      addPoint(rect->x + rect->w, rect->y);
-      addPoint(rect->x + rect->w, rect->y + rect->h);
-      addPoint(rect->x, rect->y + rect->h);
+      float pad = std::max(0.0f, rect->stroke.width) * 0.5f;
+      addPointWithPadding(rect->x, rect->y, pad);
+      addPointWithPadding(rect->x + rect->w, rect->y, pad);
+      addPointWithPadding(rect->x + rect->w, rect->y + rect->h, pad);
+      addPointWithPadding(rect->x, rect->y + rect->h, pad);
     } else if (const auto *circle = std::get_if<CircleCommand>(&cmd)) {
-      addPoint(circle->cx - circle->radius, circle->cy - circle->radius);
-      addPoint(circle->cx + circle->radius, circle->cy + circle->radius);
+      float pad = std::max(0.0f, circle->stroke.width) * 0.5f;
+      float radius = circle->radius + pad;
+      addPoint(circle->cx - radius, circle->cy - radius);
+      addPoint(circle->cx + radius, circle->cy + radius);
     }
   }
 


### PR DESCRIPTION
### Motivation
- When exporting in `Schematic` mode the simplified footprints are later rendered with a thicker outline; their computed symbol bounding box did not account for stroke thickness and the outline could be clipped.
- Ensure PDF XObject bounding boxes and cached symbol bounds include a small padding for stroke width so exports and snapshots don't cut off outlines.

### Description
- Add `addPointWithPadding` helper and use it when accumulating symbol bounds so points are padded by half the stroke width.
- Apply padding for all command types that contribute bounds: `LineCommand`, `PolylineCommand`, `PolygonCommand`, `RectangleCommand`, and `CircleCommand`.
- Changes made in `viewer2d/planpdfexporter.cpp` and mirrored for snapshot/bounds computation in `viewer3d/viewer3dcontroller.cpp`.
- Padding uses `std::max(0.0f, stroke.width) * 0.5f` to avoid negative widths and keep the expansion minimal (roughly a pixel-equivalent in world units).

### Testing
- No automated tests were run as part of this change.
- Performed static code inspection and repository searches to ensure the bounds computation sites were updated consistently.
- Manual smoke validation (not automated) was suggested to confirm PDF exports no longer clip schematic outlines.
- If desired, add a unit/integration test that renders a simple schematic symbol with a non-zero `stroke.width` and asserts exported symbol `BBox` is larger than unpadded bounds.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945a5c93db08324b90f1ead1e751a3d)