### PR TITLE
Refresh symbol snapshot after 2D capture for print plan export

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1346,16 +1346,12 @@ void MainWindow::OnPrintPlan(wxCommandEvent &WXUNUSED(event)) {
   opts.useSimplifiedFootprints = !settings.detailedFootprints;
   opts.pageWidthPt = settings.PageWidthPt();
   opts.pageHeightPt = settings.PageHeightPt();
-  std::shared_ptr<const SymbolDefinitionSnapshot> symbolSnapshot = nullptr;
-  if (viewport2DPanel) {
-    symbolSnapshot = viewport2DPanel->GetBottomSymbolCacheSnapshot();
-  }
   std::filesystem::path outputPath(
       std::filesystem::path(outputPathWx.ToStdWstring()));
   wxString outputPathDisplay = outputPathWx;
 
   viewport2DPanel->CaptureFrameAsync(
-      [this, opts, outputPath, outputPathDisplay, symbolSnapshot](
+      [this, opts, outputPath, outputPathDisplay](
           CommandBuffer buffer, Viewer2DViewState state) {
         if (buffer.commands.empty()) {
           wxMessageBox("Unable to capture the 2D view for printing.",
@@ -1383,6 +1379,11 @@ void MainWindow::OnPrintPlan(wxCommandEvent &WXUNUSED(event)) {
                          "Print Plan fixture debug", wxOK | wxICON_INFORMATION,
                          this);
           }
+        }
+
+        std::shared_ptr<const SymbolDefinitionSnapshot> symbolSnapshot = nullptr;
+        if (viewport2DPanel) {
+          symbolSnapshot = viewport2DPanel->GetBottomSymbolCacheSnapshot();
         }
 
         // Run the PDF generation off the UI thread to avoid freezing the


### PR DESCRIPTION
### Motivation
- Exported PDF plans could miss fixture symbol instances because the symbol cache snapshot was captured before the 2D frame capture completed.
- Symbol definitions can be created during the capture pass (symbol instancing), so the snapshot must be refreshed after capture to include them.

### Description
- Stop taking the `SymbolDefinitionSnapshot` before requesting the 2D capture; instead obtain it after the capture completes.
- After the capture callback finishes diagnostic/logging, call `viewport2DPanel->GetBottomSymbolCacheSnapshot()` and pass the resulting `symbolSnapshot` into the background worker that calls `ExportPlanToPdf`.
- Adjusted the lambda captures in `MainWindow::OnPrintPlan` to remove the early snapshot and include the refreshed `symbolSnapshot` when launching the export thread.
- Modified file: `gui/mainwindow.cpp` (updates to the capture callback and thread capture list).

### Testing
- Automated tests: none were run for this change.
- No CI/build output included in this change; the patch is limited to the `OnPrintPlan` flow to ensure symbol definitions produced during capture are visible to the PDF exporter.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945ab90a1488324b6522a92d007bc5a)