### PR TITLE
Expand fixture symbol bounds to include stroke width

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -160,27 +160,42 @@ static SymbolBounds ComputeSymbolBounds(const CommandBuffer &buffer) {
     bounds.max.y = std::max(bounds.max.y, y);
   };
 
-  auto addPoints = [&](const std::vector<float> &points) {
+  auto addPointWithPadding = [&](float x, float y, float padding) {
+    if (padding <= 0.0f) {
+      addPoint(x, y);
+      return;
+    }
+    addPoint(x - padding, y - padding);
+    addPoint(x + padding, y + padding);
+  };
+
+  auto addPoints = [&](const std::vector<float> &points, float padding) {
     for (size_t i = 0; i + 1 < points.size(); i += 2)
-      addPoint(points[i], points[i + 1]);
+      addPointWithPadding(points[i], points[i + 1], padding);
   };
 
   for (const auto &cmd : buffer.commands) {
     if (const auto *line = std::get_if<LineCommand>(&cmd)) {
-      addPoint(line->x0, line->y0);
-      addPoint(line->x1, line->y1);
+      float padding = line->stroke.width * 0.5f;
+      addPointWithPadding(line->x0, line->y0, padding);
+      addPointWithPadding(line->x1, line->y1, padding);
     } else if (const auto *polyline = std::get_if<PolylineCommand>(&cmd)) {
-      addPoints(polyline->points);
+      float padding = polyline->stroke.width * 0.5f;
+      addPoints(polyline->points, padding);
     } else if (const auto *poly = std::get_if<PolygonCommand>(&cmd)) {
-      addPoints(poly->points);
+      float padding = poly->stroke.width * 0.5f;
+      addPoints(poly->points, padding);
     } else if (const auto *rect = std::get_if<RectangleCommand>(&cmd)) {
-      addPoint(rect->x, rect->y);
-      addPoint(rect->x + rect->w, rect->y);
-      addPoint(rect->x + rect->w, rect->y + rect->h);
-      addPoint(rect->x, rect->y + rect->h);
+      float padding = rect->stroke.width * 0.5f;
+      addPoint(rect->x - padding, rect->y - padding);
+      addPoint(rect->x + rect->w + padding, rect->y - padding);
+      addPoint(rect->x + rect->w + padding, rect->y + rect->h + padding);
+      addPoint(rect->x - padding, rect->y + rect->h + padding);
     } else if (const auto *circle = std::get_if<CircleCommand>(&cmd)) {
-      addPoint(circle->cx - circle->radius, circle->cy - circle->radius);
-      addPoint(circle->cx + circle->radius, circle->cy + circle->radius);
+      float padding = circle->stroke.width * 0.5f;
+      float radius = circle->radius + padding;
+      addPoint(circle->cx - radius, circle->cy - radius);
+      addPoint(circle->cx + radius, circle->cy + radius);
     }
   }
 


### PR DESCRIPTION
### Motivation
- When exporting fixture symbols (e.g. Schematic/print plan) the outer outline could be clipped because symbol bounding boxes ignored stroke thickness.
- The exporter builds cached symbol bounding boxes from recorded 2D drawing commands; those bounds must include stroke width so PDF/XObject BBox and plan layout reserve enough space.

### Description
- Update `ComputeSymbolBounds` in `viewer3d/viewer3dcontroller.cpp` to account for stroke width when computing symbol bounds.
- Add helper `addPointWithPadding` and change `addPoints` to accept a `padding` parameter derived from `stroke.width * 0.5f` for `LineCommand`, `PolylineCommand`, `PolygonCommand`, `RectangleCommand` and `CircleCommand`.
- This expands the computed `SymbolBounds` so outlines placed by the 3D capture/2D recorder are not clipped in exported PDF XObjects.

### Testing
- No automated tests were executed as part of this change.
- The change is localized to `viewer3d/viewer3dcontroller.cpp` and purely affects symbol bound computation used by PDF/plan export.
- Recommend running the existing plan export / PDF generation workflow and visual regression/manual checks for Schematic export to verify outlines are no longer clipped.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945af81350c83248cc3154fc8869dde)