### PR TITLE
Enable fixture symbol instancing for front/side print captures

### DIFF
--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -229,6 +229,12 @@ void Viewer2DPanel::CaptureFrameAsync(
     bool useSimplifiedFootprints, bool includeGridInCapture) {
   m_captureCallback = std::move(callback);
   m_useSimplifiedFootprints = useSimplifiedFootprints;
+  if (!m_useSimplifiedFootprints &&
+      (m_view == Viewer2DView::Front || m_view == Viewer2DView::Side)) {
+    // Front/side printouts should still use cached fixture symbols so repeated
+    // fixtures are emitted as reusable PDF symbols like in top/bottom views.
+    m_useSimplifiedFootprints = true;
+  }
   m_captureIncludeGrid = includeGridInCapture;
   RequestFrameCapture();
   Refresh();


### PR DESCRIPTION
### Motivation
- Printing front or side 2D views did not reuse cached fixture symbols, which prevented repeated fixtures from being emitted as reusable PDF symbols.
- Ensure print/export output for `Front`/`Side` views matches `Top`/`Bottom` behavior so PDFs can reuse symbol XObjects and keep outlines/fills correct.
- Keep the on-screen rendering unchanged while altering only the capture behavior used for printing/exporting.

### Description
- Adjusted `Viewer2DPanel::CaptureFrameAsync` in `viewer2d/viewer2dpanel.cpp` to force `m_useSimplifiedFootprints = true` when capturing a `Front` or `Side` view and simplified footprints were not explicitly requested.
- This makes `CaptureFrameAsync` treat front/side captures like top/bottom captures with respect to symbol instancing, letting the `SymbolCache` produce reusable symbol definitions for PDF export.
- One file modified: `viewer2d/viewer2dpanel.cpp` (change is confined to `CaptureFrameAsync`).

### Testing
- No automated tests were run as part of this change.
- Manual validation not included in this PR (none requested).
- Change is small and localized to the capture path (`Viewer2DPanel::CaptureFrameAsync`).
- Recommend running existing PDF export/print flow and verifying front/side exports reuse symbol XObjects in generated PDFs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945b1e492c88324b6ab966be673fe89)