### PR TITLE
Fix fixture symbol transforms for front/side schematic prints

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -419,16 +419,16 @@ static Transform2D BuildInstanceTransform2D(const Matrix &m, Viewer2DView view) 
   case Viewer2DView::Front:
     t.a = m.u[0];
     t.b = m.u[2];
-    t.c = m.v[0];
-    t.d = m.v[2];
+    t.c = m.w[0];
+    t.d = m.w[2];
     t.tx = m.o[0];
     t.ty = m.o[2];
     break;
   case Viewer2DView::Side:
-    t.a = -m.u[1];
-    t.b = m.u[2];
-    t.c = -m.v[1];
-    t.d = m.v[2];
+    t.a = -m.v[1];
+    t.b = m.v[2];
+    t.c = -m.w[1];
+    t.d = m.w[2];
     t.tx = -m.o[1];
     t.ty = m.o[2];
     break;


### PR DESCRIPTION
### Motivation
- Schematic (simplified) printouts in Front/Side views showed missing or misplaced fixtures because symbol instance transforms used incorrect matrix components.
- The top view already created and reused cached symbols with the correct transform; Front/Side needed equivalent per-view transforms so symbols render and can be instanced for PDF export.
- Ensure fixture symbols for front/side are generated and applied the same way as for Top so schematic prints include fixtures.

### Description
- Adjusted the 2D instance transform calculation in `BuildInstanceTransform2D` (in `viewer3d/viewer3dcontroller.cpp`):
  - For `Viewer2DView::Front` now use `m.w[0]` / `m.w[2]` for the second column components (`t.c`, `t.d`) so the vertical axis comes from the correct matrix row.
  - For `Viewer2DView::Side` updated the mapping to use `m.v`/`m.w` components (and preserved sign/mirroring) so the side view instance transform matches the on-screen projection.
- This makes `PlaceSymbolInstance` receive correct `Transform2D` values for Front/Side, allowing cached `SymbolDefinition`s to be reused and rendered correctly in schematic exports.

### Testing
- No automated tests were executed for this change.
- Manual validation (via running the application and printing schematic Top/Front/Side) is recommended to confirm fixtures now appear in Front and Side schematic exports.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945b461673483249b322cb2ee66933e)