### PR TITLE
Add Dark Mode toggle to 2D Render Options (affects on‑screen 2D only)

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -180,6 +180,7 @@ ConfigManager::ConfigManager() {
   RegisterVariable("view2d_zoom", "float", 1.0f, 0.1f, 100.0f);
   RegisterVariable("view2d_render_mode", "float", 1.0f, 0.0f, 3.0f);
   RegisterVariable("view2d_view", "float", 0.0f, 0.0f, 2.0f);
+  RegisterVariable("view2d_dark_mode", "float", 0.0f, 0.0f, 1.0f);
   LoadUserConfig();
   if (!HasKey("rider_autopatch"))
     SetValue("rider_autopatch", "1");

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -307,6 +307,12 @@ void Viewer2DPanel::Render() {
   }
 
   ConfigManager &cfg = ConfigManager::Get();
+  bool darkMode = cfg.GetFloat("view2d_dark_mode") != 0.0f;
+  m_controller.SetDarkMode(darkMode);
+  if (darkMode)
+    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+  else
+    glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
   bool showGrid = cfg.GetFloat("grid_show") != 0.0f;
   int gridStyle = static_cast<int>(cfg.GetFloat("grid_style"));
   float gridR = cfg.GetFloat("grid_color_r");

--- a/viewer2d/viewer2drenderpanel.cpp
+++ b/viewer2d/viewer2drenderpanel.cpp
@@ -52,6 +52,10 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
   m_radio->SetSelection(static_cast<int>(cfg.GetFloat("view2d_render_mode")));
   m_radio->Bind(wxEVT_RADIOBOX, &Viewer2DRenderPanel::OnRadio, this);
 
+  m_darkMode = new wxCheckBox(this, wxID_ANY, "Dark mode");
+  m_darkMode->SetValue(cfg.GetFloat("view2d_dark_mode") != 0.0f);
+  m_darkMode->Bind(wxEVT_CHECKBOX, &Viewer2DRenderPanel::OnDarkMode, this);
+
   wxString viewChoices[] = {"Top", "Front", "Side"};
   m_view = new wxRadioBox(this, wxID_ANY, "View", wxDefaultPosition,
                           wxDefaultSize, 3, viewChoices, 1, wxRA_SPECIFY_COLS);
@@ -189,6 +193,7 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
 
   auto *sizer = new wxBoxSizer(wxVERTICAL);
   sizer->Add(m_radio, 0, wxALL, 5);
+  sizer->Add(m_darkMode, 0, wxALL, 5);
   sizer->Add(m_view, 0, wxALL, 5);
 
   gridBox->Add(m_showGrid, 0, wxALL, 5);
@@ -252,6 +257,7 @@ void Viewer2DRenderPanel::SetInstance(Viewer2DRenderPanel *p) {
 void Viewer2DRenderPanel::ApplyConfig() {
   ConfigManager &cfg = ConfigManager::Get();
   m_radio->SetSelection(static_cast<int>(cfg.GetFloat("view2d_render_mode")));
+  m_darkMode->SetValue(cfg.GetFloat("view2d_dark_mode") != 0.0f);
   m_view->SetSelection(static_cast<int>(cfg.GetFloat("view2d_view")));
   m_showGrid->SetValue(cfg.GetFloat("grid_show") != 0.0f);
   m_gridStyle->SetSelection(static_cast<int>(cfg.GetFloat("grid_style")));
@@ -286,6 +292,14 @@ void Viewer2DRenderPanel::OnRadio(wxCommandEvent &evt) {
     vp->SetRenderMode(static_cast<Viewer2DRenderMode>(m_radio->GetSelection()));
     vp->UpdateScene(false);
   }
+  evt.Skip();
+}
+
+void Viewer2DRenderPanel::OnDarkMode(wxCommandEvent &evt) {
+  ConfigManager::Get().SetFloat("view2d_dark_mode",
+                                m_darkMode->GetValue() ? 1.0f : 0.0f);
+  if (auto *vp = Viewer2DPanel::Instance())
+    vp->UpdateScene(false);
   evt.Skip();
 }
 

--- a/viewer2d/viewer2drenderpanel.h
+++ b/viewer2d/viewer2drenderpanel.h
@@ -34,6 +34,7 @@ public:
 
 private:
   void OnRadio(wxCommandEvent &evt);
+  void OnDarkMode(wxCommandEvent &evt);
   void OnShowGrid(wxCommandEvent &evt);
   void OnGridStyle(wxCommandEvent &evt);
   void OnGridColor(wxColourPickerEvent &evt);
@@ -53,6 +54,7 @@ private:
   void OnTextEnter(wxCommandEvent &evt);
 
   wxRadioBox *m_radio = nullptr;
+  wxCheckBox *m_darkMode = nullptr;
   wxRadioBox *m_view = nullptr;
   wxCheckBox *m_showGrid = nullptr;
   wxRadioBox *m_gridStyle = nullptr;

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1505,6 +1505,22 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
   DrawAxes();
 }
 
+void Viewer3DController::SetDarkMode(bool enabled) { m_darkMode = enabled; }
+
+std::array<float, 3> Viewer3DController::AdjustColor(float r, float g,
+                                                     float b) const {
+  if (!m_darkMode)
+    return {r, g, b};
+  if (r == 0.0f && g == 0.0f && b == 0.0f)
+    return {1.0f, 1.0f, 1.0f};
+  return {r, g, b};
+}
+
+void Viewer3DController::SetGLColor(float r, float g, float b) const {
+  auto adjusted = AdjustColor(r, g, b);
+  glColor3f(adjusted[0], adjusted[1], adjusted[2]);
+}
+
 // Draws a solid cube centered at origin with given size and color
 void Viewer3DController::DrawCube(float size, float r, float g, float b) {
   float half = size / 2.0f;
@@ -1513,7 +1529,7 @@ void Viewer3DController::DrawCube(float size, float r, float g, float b) {
   float z0 = -half, z1 = half;
 
   if (!m_captureOnly) {
-    glColor3f(r, g, b);
+    SetGLColor(r, g, b);
     glBegin(GL_QUADS);
     glNormal3f(0.0f, 0.0f, 1.0f);
     glVertex3f(x0, y0, z1);
@@ -1562,7 +1578,7 @@ void Viewer3DController::DrawWireframeCube(
   float lineWidth = (mode == Viewer2DRenderMode::Wireframe) ? 1.0f : 2.0f;
   if (!m_captureOnly) {
     glLineWidth(lineWidth);
-    glColor3f(r, g, b);
+    SetGLColor(r, g, b);
   }
   CanvasStroke stroke;
   stroke.color = {r, g, b, 1.0f};
@@ -1614,7 +1630,7 @@ void Viewer3DController::DrawWireframeCube(
   if (mode != Viewer2DRenderMode::Wireframe) {
     glEnable(GL_POLYGON_OFFSET_FILL);
     glPolygonOffset(1.0f, 1.0f);
-    glColor3f(1.0f, 1.0f, 1.0f);
+    SetGLColor(1.0f, 1.0f, 1.0f);
     glBegin(GL_QUADS);
     glVertex3f(x0, y0, z1);
     glVertex3f(x1, y0, z1);
@@ -1640,7 +1656,7 @@ void Viewer3DController::DrawWireframeBox(
     float lineWidth = (mode == Viewer2DRenderMode::Wireframe) ? 1.0f : 2.0f;
     if (!m_captureOnly) {
       glLineWidth(lineWidth);
-      glColor3f(0.0f, 0.0f, 0.0f);
+      SetGLColor(0.0f, 0.0f, 0.0f);
     }
     CanvasStroke stroke;
     stroke.color = {0.0f, 0.0f, 0.0f, 1.0f};
@@ -1689,7 +1705,7 @@ void Viewer3DController::DrawWireframeBox(
       if (mode != Viewer2DRenderMode::Wireframe) {
         glEnable(GL_POLYGON_OFFSET_FILL);
         glPolygonOffset(1.0f, 1.0f);
-        glColor3f(1.0f, 1.0f, 1.0f);
+        SetGLColor(1.0f, 1.0f, 1.0f);
         glBegin(GL_QUADS);
         glVertex3f(x0, y0, z1);
         glVertex3f(x1, y0, z1);
@@ -1702,11 +1718,11 @@ void Viewer3DController::DrawWireframeBox(
     return;
   } else if (!m_captureOnly) {
     if (selected)
-      glColor3f(0.0f, 1.0f, 1.0f);
+      SetGLColor(0.0f, 1.0f, 1.0f);
     else if (highlight)
-      glColor3f(0.0f, 1.0f, 0.0f);
+      SetGLColor(0.0f, 1.0f, 0.0f);
     else
-      glColor3f(1.0f, 1.0f, 0.0f);
+      SetGLColor(1.0f, 1.0f, 0.0f);
   }
 
   CanvasStroke stroke;
@@ -1809,7 +1825,7 @@ void Viewer3DController::DrawCubeWithOutline(
     if (!m_captureOnly) {
       glEnable(GL_POLYGON_OFFSET_FILL);
       glPolygonOffset(-1.0f, -1.0f);
-      glColor3f(r, g, b);
+      SetGLColor(r, g, b);
       DrawCube(size, r, g, b);
       glDisable(GL_POLYGON_OFFSET_FILL);
     }
@@ -1840,7 +1856,7 @@ void Viewer3DController::DrawMeshWithOutline(
     float lineWidth = (mode == Viewer2DRenderMode::Wireframe) ? 1.0f : 2.0f;
     if (!m_captureOnly) {
       glLineWidth(lineWidth);
-      glColor3f(0.0f, 0.0f, 0.0f);
+      SetGLColor(0.0f, 0.0f, 0.0f);
     }
     CanvasStroke stroke;
     stroke.color = {0.0f, 0.0f, 0.0f, 1.0f};
@@ -1872,7 +1888,7 @@ void Viewer3DController::DrawMeshWithOutline(
       if (mode != Viewer2DRenderMode::Wireframe) {
         glEnable(GL_POLYGON_OFFSET_FILL);
         glPolygonOffset(-1.0f, -1.0f);
-        glColor3f(r, g, b);
+        SetGLColor(r, g, b);
         DrawMesh(mesh, scale);
         glDisable(GL_POLYGON_OFFSET_FILL);
       }
@@ -1882,11 +1898,11 @@ void Viewer3DController::DrawMeshWithOutline(
 
   if (!m_captureOnly) {
     if (selected)
-      glColor3f(0.0f, 1.0f, 1.0f);
+      SetGLColor(0.0f, 1.0f, 1.0f);
     else if (highlight)
-      glColor3f(0.0f, 1.0f, 0.0f);
+      SetGLColor(0.0f, 1.0f, 0.0f);
     else
-      glColor3f(r, g, b);
+      SetGLColor(r, g, b);
 
     DrawMesh(mesh, scale);
   }
@@ -2055,7 +2071,7 @@ void Viewer3DController::DrawGrid(int style, float r, float g, float b,
   stroke.color = {r, g, b, 1.0f};
   stroke.width = 1.0f;
 
-  glColor3f(r, g, b);
+  SetGLColor(r, g, b);
   if (style == 0) {
     glLineWidth(1.0f);
     glBegin(GL_LINES);
@@ -2174,13 +2190,13 @@ void Viewer3DController::DrawGrid(int style, float r, float g, float b,
 void Viewer3DController::DrawAxes() {
   glLineWidth(2.0f);
   glBegin(GL_LINES);
-  glColor3f(1.0f, 0.0f, 0.0f);
+  SetGLColor(1.0f, 0.0f, 0.0f);
   glVertex3f(0.0f, 0.0f, 0.0f);
   glVertex3f(1.0f, 0.0f, 0.0f); // X
-  glColor3f(0.0f, 1.0f, 0.0f);
+  SetGLColor(0.0f, 1.0f, 0.0f);
   glVertex3f(0.0f, 0.0f, 0.0f);
   glVertex3f(0.0f, 1.0f, 0.0f); // Y
-  glColor3f(0.0f, 0.0f, 1.0f);
+  SetGLColor(0.0f, 0.0f, 1.0f);
   glVertex3f(0.0f, 0.0f, 0.0f);
   glVertex3f(0.0f, 0.0f, 1.0f); // Z
   glEnd();
@@ -2232,7 +2248,7 @@ void Viewer3DController::SetupBasicLighting() {
 }
 
 void Viewer3DController::SetupMaterialFromRGB(float r, float g, float b) {
-  glColor3f(r, g, b);
+  SetGLColor(r, g, b);
 }
 
 void Viewer3DController::DrawFixtureLabels(int width, int height) {
@@ -2550,7 +2566,10 @@ void Viewer3DController::DrawAllFixtureLabels(int width, int height,
       }
     }
 
-    DrawLabelLines2D(m_vg, lines, x, y, nvgRGBAf(0.f, 0.f, 0.f, 1.f));
+    NVGcolor textColor =
+        m_darkMode ? nvgRGBAf(1.f, 1.f, 1.f, 1.f)
+                   : nvgRGBAf(0.f, 0.f, 0.f, 1.f);
+    DrawLabelLines2D(m_vg, lines, x, y, textColor);
   }
 }
 

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -88,6 +88,9 @@ public:
                    float gridB = 0.35f,
                    bool gridOnTop = false);
 
+  // Enables color tweaks for dark mode in the 2D viewer only.
+  void SetDarkMode(bool enabled);
+
   // Fixture UUID currently highlighted (hovered)
   void SetHighlightUuid(const std::string &uuid);
   void SetSelectedUuids(const std::vector<std::string> &uuids);
@@ -192,6 +195,8 @@ private:
   // Initializes simple lighting for the scene
   void SetupBasicLighting();
   void SetupMaterialFromRGB(float r, float g, float b);
+  void SetGLColor(float r, float g, float b) const;
+  std::array<float, 3> AdjustColor(float r, float g, float b) const;
 
   // Helpers used only when recording the 2D view to a canvas command buffer.
   std::array<float, 2> ProjectToCanvas(const std::array<float, 3> &p) const;
@@ -256,6 +261,7 @@ private:
   bool m_captureOnly = false;
   bool m_captureUseSymbols = false;
   SymbolCache m_bottomSymbolCache;
+  bool m_darkMode = false;
 
 public:
   // Enables recording of all primitives drawn during the next RenderScene


### PR DESCRIPTION
### Motivation

- Provide a user-controllable dark mode for the 2D viewer so the on-screen view can invert white/black for better visibility at night.
- The inversion must only affect the 2D on-screen viewer and must not change PDF/export captures.
- Persist the preference in configuration so it survives restarts via a new `view2d_dark_mode` config key.

### Description

- Added a new config variable `view2d_dark_mode` in `core/configmanager.cpp`.
- Added a `Dark mode` checkbox to the Render options UI in `viewer2d/viewer2drenderpanel.*` and hooked it to `OnDarkMode` to update the config and trigger a scene refresh.
- Propagated the dark mode state to the 2D rendering pipeline:
  - `viewer2d/viewer2dpanel.cpp` reads `view2d_dark_mode`, calls `m_controller.SetDarkMode(...)` and sets `glClearColor()` to black/white accordingly.
  - `viewer3d/viewer3dcontroller.*` now contains `SetDarkMode`, `AdjustColor` and `SetGLColor` to apply color tweaks when dark mode is active; many `glColor3f` calls were replaced with `SetGLColor` so black stroke/text can be drawn as white on-screen.
  - Label rendering in `DrawAllFixtureLabels` now chooses white/black text color (NanoVG) based on `m_darkMode`.
- The capture/export path remains unchanged: recording to `m_captureCanvas` and PDF export still record original colors (the capture APIs are left intact), so prints/PDFs are not affected by the on-screen dark mode.
- Minor header updates to expose the new methods/fields (`SetDarkMode`, `SetGLColor`, `AdjustColor`, `m_darkMode`).

### Testing

- No automated tests were executed as part of this change.
- Manual smoke testing recommendation: toggle `Render options -> Dark mode` and verify the 2D viewport background, stroke and label colors switch for on-screen rendering while PDF/export captures remain with original colors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945ba0bef84832483865723df8a65cd)