### PR TITLE
Keep 3D element profiles black in Dark mode and force immediate 2D refresh

### DIFF
--- a/viewer2d/viewer2drenderpanel.cpp
+++ b/viewer2d/viewer2drenderpanel.cpp
@@ -298,8 +298,10 @@ void Viewer2DRenderPanel::OnRadio(wxCommandEvent &evt) {
 void Viewer2DRenderPanel::OnDarkMode(wxCommandEvent &evt) {
   ConfigManager::Get().SetFloat("view2d_dark_mode",
                                 m_darkMode->GetValue() ? 1.0f : 0.0f);
-  if (auto *vp = Viewer2DPanel::Instance())
+  if (auto *vp = Viewer2DPanel::Instance()) {
     vp->UpdateScene(false);
+    vp->Update();
+  }
   evt.Skip();
 }
 

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1511,8 +1511,6 @@ std::array<float, 3> Viewer3DController::AdjustColor(float r, float g,
                                                      float b) const {
   if (!m_darkMode)
     return {r, g, b};
-  if (r == 0.0f && g == 0.0f && b == 0.0f)
-    return {1.0f, 1.0f, 1.0f};
   return {r, g, b};
 }
 


### PR DESCRIPTION
### Motivation
- Dark mode should not invert the black profile lines of 3D elements; black outlines must remain black to preserve visual cues.
- Toggling the `Dark mode` option in the 2D Render Options must refresh the view immediately so the change is visible without extra user interaction.

### Description
- Stop changing pure-black colors to white in dark mode by removing the special-case flip in `Viewer3DController::AdjustColor` (`viewer3d/viewer3dcontroller.cpp`).
- Force an immediate repaint when toggling Dark mode in the 2D render panel by calling `vp->Update()` in `Viewer2DRenderPanel::OnDarkMode` in `viewer2d/viewer2drenderpanel.cpp` (in addition to the existing `vp->UpdateScene(false)`).
- Affects `Viewer3DController::AdjustColor` and `Viewer2DRenderPanel::OnDarkMode`.

### Testing
- No automated tests were executed as part of this change.
- Change is limited and localized to rendering behavior and UI refresh logic; manual verification was the intended step (not performed by automated test suite here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945bcc293608324a5af850517114cd3)