### PR TITLE
Support `thru`/`t` as range separators in table numeric inputs

### DIFF
--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -25,11 +25,63 @@
 #include "viewer2dpanel.h"
 #include "viewer3dpanel.h"
 #include <algorithm>
+#include <cctype>
 #include <wx/notebook.h>
 #include <wx/choicdlg.h>
 #include <wx/wupdlock.h> // freeze/thaw UI during batch edits
 
 static SceneObjectTablePanel* s_instance = nullptr;
+
+namespace {
+struct RangeParts {
+    wxArrayString parts;
+    bool usedSeparator = false;
+};
+
+bool IsNumChar(char c)
+{
+    return std::isdigit(static_cast<unsigned char>(c)) || c == '.' || c == '-' ||
+           c == '+';
+}
+
+RangeParts SplitRangeParts(const wxString& value)
+{
+    std::string lower = value.Lower().ToStdString();
+    std::string normalized;
+    normalized.reserve(lower.size() + 4);
+    bool usedSeparator = false;
+    for (size_t i = 0; i < lower.size();)
+    {
+        if (lower.compare(i, 4, "thru") == 0)
+        {
+            normalized.push_back(' ');
+            usedSeparator = true;
+            i += 4;
+            continue;
+        }
+        if (lower[i] == 't')
+        {
+            char prev = (i > 0) ? lower[i - 1] : '\0';
+            char next = (i + 1 < lower.size()) ? lower[i + 1] : '\0';
+            if (IsNumChar(prev) || IsNumChar(next))
+            {
+                normalized.push_back(' ');
+                usedSeparator = true;
+                i += 1;
+                continue;
+            }
+        }
+        normalized.push_back(lower[i]);
+        i += 1;
+    }
+    wxArrayString rawParts = wxSplit(wxString(normalized), ' ');
+    wxArrayString parts;
+    for (const auto& part : rawParts)
+        if (!part.IsEmpty())
+            parts.push_back(part);
+    return {parts, usedSeparator};
+}
+} // namespace
 
 SceneObjectTablePanel::SceneObjectTablePanel(wxWindow* parent)
     : wxPanel(parent, wxID_ANY)
@@ -253,8 +305,14 @@ void SceneObjectTablePanel::OnContextMenu(wxDataViewEvent& event)
         }
         else
         {
-            wxArrayString parts = wxSplit(value, ' ');
+            RangeParts range = SplitRangeParts(value);
+            wxArrayString parts = range.parts;
             if (parts.size() == 0 || parts.size() > 2)
+            {
+                wxMessageBox("Invalid numeric value", "Error", wxOK | wxICON_ERROR);
+                return;
+            }
+            if (range.usedSeparator && parts.size() != 2)
             {
                 wxMessageBox("Invalid numeric value", "Error", wxOK | wxICON_ERROR);
                 return;

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -29,6 +29,7 @@
 #include "trussloader.h"
 #include "viewer2dpanel.h"
 #include "viewer3dpanel.h"
+#include <cctype>
 #include <filesystem>
 #include <wx/filedlg.h>
 #include <wx/filename.h>
@@ -40,6 +41,57 @@
 
 static TrussTablePanel* s_instance = nullptr;
 namespace fs = std::filesystem;
+
+namespace {
+struct RangeParts {
+    wxArrayString parts;
+    bool usedSeparator = false;
+};
+
+bool IsNumChar(char c)
+{
+    return std::isdigit(static_cast<unsigned char>(c)) || c == '.' || c == '-' ||
+           c == '+';
+}
+
+RangeParts SplitRangeParts(const wxString& value)
+{
+    std::string lower = value.Lower().ToStdString();
+    std::string normalized;
+    normalized.reserve(lower.size() + 4);
+    bool usedSeparator = false;
+    for (size_t i = 0; i < lower.size();)
+    {
+        if (lower.compare(i, 4, "thru") == 0)
+        {
+            normalized.push_back(' ');
+            usedSeparator = true;
+            i += 4;
+            continue;
+        }
+        if (lower[i] == 't')
+        {
+            char prev = (i > 0) ? lower[i - 1] : '\0';
+            char next = (i + 1 < lower.size()) ? lower[i + 1] : '\0';
+            if (IsNumChar(prev) || IsNumChar(next))
+            {
+                normalized.push_back(' ');
+                usedSeparator = true;
+                i += 1;
+                continue;
+            }
+        }
+        normalized.push_back(lower[i]);
+        i += 1;
+    }
+    wxArrayString rawParts = wxSplit(wxString(normalized), ' ');
+    wxArrayString parts;
+    for (const auto& part : rawParts)
+        if (!part.IsEmpty())
+            parts.push_back(part);
+    return {parts, usedSeparator};
+}
+} // namespace
 
 TrussTablePanel::TrussTablePanel(wxWindow* parent)
     : wxPanel(parent, wxID_ANY)
@@ -421,8 +473,14 @@ void TrussTablePanel::OnContextMenu(wxDataViewEvent& event)
         }
         else
         {
-            wxArrayString parts = wxSplit(value, ' ');
+            RangeParts range = SplitRangeParts(value);
+            wxArrayString parts = range.parts;
             if (parts.size() == 0 || parts.size() > 2)
+            {
+                wxMessageBox("Invalid numeric value", "Error", wxOK | wxICON_ERROR);
+                return;
+            }
+            if (range.usedSeparator && parts.size() != 2)
             {
                 wxMessageBox("Invalid numeric value", "Error", wxOK | wxICON_ERROR);
                 return;


### PR DESCRIPTION
### Motivation
- Improve data entry in table cells so ranges like `123 thru 160`, `123t160`, or `123 t 160` are parsed the same as space-separated pairs.
- Preserve existing behaviors: single-value entry, two-value interpolation, and trailing-space sequential numbering.
- Apply consistent parsing across fixture, truss, hoist and scene-object tables.

### Description
- Added a small parsing helper (`RangeParts`, `IsNumChar`, `SplitRangeParts`) in an anonymous namespace to each modified panel to normalize and split input values recognizing `thru` and single-letter `t` separators (with or without spaces).
- Replaced direct `wxSplit(value, ' ')` usage with `SplitRangeParts(value)` and use the returned `parts` and `usedSeparator` flag to:
  - enforce that explicit separators produce exactly two numeric parts,
  - ensure trailing-space sequential behavior only applies when the separator was not used.
- Files modified: `gui/fixturetablepanel.cpp`, `gui/trusstablepanel.cpp`, `gui/hoisttablepanel.cpp`, `gui/sceneobjecttablepanel.cpp`.
- Key symbols added: `SplitRangeParts`, `RangeParts`, `IsNumChar` (all internal helpers); existing numeric/integers parsing and interpolation logic is preserved.

### Testing
- No automated tests were executed as part of this change.
- Manual validation was not recorded in automated output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945c26e5c008324a903154bc10c82ee)