### PR TITLE
Document table multi-edit ranges and 2D render defaults in help/README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ The application is built with **wxWidgets** for the user interface and **OpenGL*
 
 - **GUI helpers**
   - Tables for fixtures, trusses and scene objects.
+  - Multi-edit shortcuts in tables, including range interpolation (`1 10`,
+    `1 thru 10`) and sequential fills with trailing separators.
   - Summary and console panels.
   - Dialogs for preferences, login, fixture type selection, GDTF search, export options, etc.
 

--- a/help.md
+++ b/help.md
@@ -77,6 +77,28 @@ Perastage is a high-performance, cross-platform viewer for MVR (My Virtual Rig) 
 ### Summary Panel
 - Provides counts and basic statistics for fixtures, trusses and objects.
 
+### 2D Render Options Panel
+- Controls the 2D viewport render mode, grid appearance, and label visibility.
+- Default settings (from current configuration defaults):
+  - Render mode: **By device type**
+  - Dark mode: **On**
+  - View: **Top**
+  - Grid: **Shown**, style **Lines**, color **35% gray**, draw-above **Off**
+  - Labels: **Name/ID/DMX shown**, sizes **3/2/4**, offset distance **0.5**,
+    offset angle **180°**
+
+### Table Editing Shortcuts
+- **Apply one value to all selected rows:** enter a single number (or text).
+- **Interpolate across selections:** enter a start and end value (for example
+  `1 12` or `1 thru 12`) to spread values across the selection.
+- **Sequential values:** end with a trailing space (for example `100␠`) or a
+  trailing range token (for example `100 t`) to increment values by 1 across
+  the selection.
+- **Range separators:** `t` or `thru` can be used with or without spaces (for
+  example `1t10`, `1 t 10`, `1 thru 10`).
+- **Relative edits (position/rotation columns):** use `++` or `--` prefixes
+  (for example `++0.5` or `--15`) to add or subtract from existing values.
+
 ## File Menu Options
 
 | Menu Option   | Description                                |


### PR DESCRIPTION
### Motivation
- Recent UI code added flexible table multi-edit parsing (range separators like `t`/`thru`, trailing-separator sequential fills, interpolation) and updated 2D render options in the viewer UI.
- The user-facing documentation and README did not reflect these behaviors or the current default 2D render settings.
- Improve discoverability so users can reliably use table multi-edit shortcuts and understand 2D render defaults.

### Description
- Updated `help.md` to add a **2D Render Options Panel** section listing current defaults (render mode, dark mode, view, grid settings, label visibility/size/offsets).
- Added a **Table Editing Shortcuts** subsection in `help.md` documenting:
  - range interpolation using start/end (`1 12`) and `t`/`thru` separators (examples: `1t10`, `1 thru 10`),
  - sequential fills by ending input with a trailing space or range token (e.g. `100 ` or `100 t`), and
  - relative edits for position/rotation using `++`/`--` (e.g. `++0.5`, `--15`).
- Updated `README.md` to note the table multi-edit shortcuts (range interpolation and sequential fills).
- Files changed: `help.md`, `README.md`.

### Testing
- Documentation-only changes; no code paths were modified.
- No automated tests were run for these edits (not required for doc updates).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945c71939708324894a44a8974fbc4d)