### PR TITLE
Add outline for 2D fixture labels in dark mode

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -356,7 +356,8 @@ struct LabelLine2D {
 
 static void
 DrawLabelLines2D(NVGcontext *vg, const std::vector<LabelLine2D> &lines, int x,
-                 int y, NVGcolor textColor = nvgRGBAf(1.f, 1.f, 1.f, 1.f)) {
+                 int y, NVGcolor textColor = nvgRGBAf(1.f, 1.f, 1.f, 1.f),
+                 bool outline = false) {
   if (!vg || lines.empty())
     return;
 
@@ -388,6 +389,18 @@ DrawLabelLines2D(NVGcontext *vg, const std::vector<LabelLine2D> &lines, int x,
     nvgFontSize(vg, lines[i].size);
     nvgFontFaceId(vg, lines[i].font);
     nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_TOP);
+    if (outline) {
+      nvgFillColor(vg, nvgRGBAf(0.f, 0.f, 0.f, 1.f));
+      const std::array<std::array<float, 2>, 8> offsets = {
+          std::array<float, 2>{-1.f, 0.f}, std::array<float, 2>{1.f, 0.f},
+          std::array<float, 2>{0.f, -1.f}, std::array<float, 2>{0.f, 1.f},
+          std::array<float, 2>{-1.f, -1.f}, std::array<float, 2>{1.f, -1.f},
+          std::array<float, 2>{-1.f, 1.f}, std::array<float, 2>{1.f, 1.f}};
+      for (const auto &offset : offsets) {
+        nvgText(vg, static_cast<float>(x) + offset[0], currentY + offset[1],
+                lines[i].text.c_str(), nullptr);
+      }
+    }
     nvgFillColor(vg, textColor);
     nvgText(vg, (float)x, currentY, lines[i].text.c_str(), nullptr);
     currentY += heights[i] + lineSpacing;
@@ -2567,7 +2580,7 @@ void Viewer3DController::DrawAllFixtureLabels(int width, int height,
     NVGcolor textColor =
         m_darkMode ? nvgRGBAf(1.f, 1.f, 1.f, 1.f)
                    : nvgRGBAf(0.f, 0.f, 0.f, 1.f);
-    DrawLabelLines2D(m_vg, lines, x, y, textColor);
+    DrawLabelLines2D(m_vg, lines, x, y, textColor, m_darkMode);
   }
 }
 


### PR DESCRIPTION
### Motivation
- Improve label readability when `m_darkMode` is enabled by giving highlighted/foreground text a dark outline under the white text.
- Keep existing appearance in light mode unchanged.
- Provide an easy opt-in parameter to enable outlines for other callers if needed.

### Description
- Added an optional `bool outline` parameter to `DrawLabelLines2D` (default `false`).
- When `outline` is true, the function first renders the label text in black multiple times using small offsets (±1px horizontally, vertically and on diagonals) to create an outline, then draws the main text in the provided `textColor`.
- Updated the caller `Viewer3DController::DrawAllFixtureLabels` to pass `m_darkMode` as the `outline` flag so labels are outlined when dark mode is active.
- Change is confined to `viewer3d/viewer3dcontroller.cpp` and preserves all existing layout, sizing and PDF/canvas capture behavior for light mode.

### Testing
- No automated tests were executed for this change.
- The change is limited to rendering code; light-mode rendering behavior is preserved by default (`outline` defaults to `false`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945c985a7f08324928d1467f4a183ab)