### PR TITLE
Fix undo for rider text import

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -238,6 +238,7 @@ bool RiderImporter::ImportText(const std::string &text) {
     return false;
 
   ConfigManager &cfg = ConfigManager::Get();
+  cfg.PushUndoState("import rider");
   auto &scene = cfg.GetScene();
   std::string defaultLayer = cfg.GetCurrentLayer();
   auto modeVal = cfg.GetValue("rider_layer_mode");
@@ -803,6 +804,5 @@ bool RiderImporter::ImportText(const std::string &text) {
   auto autoPref = cfg.GetValue("rider_autopatch");
   if (!autoPref || *autoPref != "0")
     AutoPatcher::AutoPatch(scene);
-  cfg.PushUndoState("import rider");
   return true;
 }


### PR DESCRIPTION
### Motivation
- Undo did not restore the pre-import state when creating a rider from text because the undo snapshot was taken after scene mutations.
- The intent is to capture the previous scene snapshot before any modifications so `Undo` restores the state prior to the import.

### Description
- Move the `cfg.PushUndoState("import rider")` call to the start of `RiderImporter::ImportText` so the undo snapshot is taken before scene changes.
- Remove the duplicated `cfg.PushUndoState("import rider")` at the end of `ImportText` to avoid capturing the post-import state.
- Modified file: `core/riderimporter.cpp`.

### Testing
- No automated tests were run as part of this change.
- A commit with the change was created and staged in the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69483f7a687083249d3da5f8d7bde334)