### PR TITLE
Fix summary refresh on tab shortcuts (use SetSelection)

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1944,22 +1944,22 @@ void MainWindow::OnShowAbout(wxCommandEvent &WXUNUSED(event)) {
 
 void MainWindow::OnSelectFixtures(wxCommandEvent &WXUNUSED(event)) {
   if (notebook)
-    notebook->ChangeSelection(0);
+    notebook->SetSelection(0);
 }
 
 void MainWindow::OnSelectTrusses(wxCommandEvent &WXUNUSED(event)) {
   if (notebook)
-    notebook->ChangeSelection(1);
+    notebook->SetSelection(1);
 }
 
 void MainWindow::OnSelectSupports(wxCommandEvent &WXUNUSED(event)) {
   if (notebook)
-    notebook->ChangeSelection(2);
+    notebook->SetSelection(2);
 }
 
 void MainWindow::OnSelectObjects(wxCommandEvent &WXUNUSED(event)) {
   if (notebook)
-    notebook->ChangeSelection(3);
+    notebook->SetSelection(3);
 }
 
 void MainWindow::OnNotebookPageChanged(wxBookCtrlEvent &event) {


### PR DESCRIPTION
### Motivation
- The summary panel sometimes did not update when switching tables via keyboard shortcuts because the notebook page-change event was not being emitted.
- The change aims to ensure `OnNotebookPageChanged` runs when tabs are changed programmatically so the summary stays in sync.

### Description
- Replaced `notebook->ChangeSelection(...)` with `notebook->SetSelection(...)` in `MainWindow::OnSelectFixtures`, `OnSelectTrusses`, `OnSelectSupports`, and `OnSelectObjects`.
- This causes the notebook to emit page-change events and triggers `RefreshSummary()` via `OnNotebookPageChanged`.
- The single modified file is `gui/mainwindow.cpp`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694843ff4a848324ba8d1693ff4964b9)