### PR TITLE
Refresh 2D view when toggling dark mode

### DIFF
--- a/viewer2d/viewer2drenderpanel.cpp
+++ b/viewer2d/viewer2drenderpanel.cpp
@@ -299,7 +299,7 @@ void Viewer2DRenderPanel::OnDarkMode(wxCommandEvent &evt) {
   ConfigManager::Get().SetFloat("view2d_dark_mode",
                                 m_darkMode->GetValue() ? 1.0f : 0.0f);
   if (auto *vp = Viewer2DPanel::Instance()) {
-    vp->UpdateScene(false);
+    vp->UpdateScene(true);
     vp->Update();
   }
   evt.Skip();


### PR DESCRIPTION
### Motivation
- Toggling the dark mode option should apply immediately in the 2D viewer instead of waiting for a later reload. 
- The renderer needs a full scene reload so the controller's dark mode setting takes effect for all drawn primitives. 

### Description
- Change `Viewer2DRenderPanel::OnDarkMode` to call `vp->UpdateScene(true)` instead of `vp->UpdateScene(false)` so the scene is reloaded. 
- The `OnDarkMode` handler still updates the config and calls `vp->Update()` to refresh the window. 
- Modified file: `viewer2d/viewer2drenderpanel.cpp` with a one-line behavioral change. 

### Testing
- No automated tests were run for this change. 
- The change is minimal (single-line) and scoped to the 2D render options handler.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69484d801e6883248339ba1d00cb3483)