### PR TITLE
Fix 2D dark mode background refresh timing

### DIFF
--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -277,7 +277,6 @@ void Viewer2DPanel::Render() {
   GetClientSize(&w, &h);
 
   glViewport(0, 0, w, h);
-  glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
   glMatrixMode(GL_PROJECTION);
   glLoadIdentity();
@@ -313,6 +312,7 @@ void Viewer2DPanel::Render() {
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
   else
     glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
+  glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
   bool showGrid = cfg.GetFloat("grid_show") != 0.0f;
   int gridStyle = static_cast<int>(cfg.GetFloat("grid_style"));
   float gridR = cfg.GetFloat("grid_color_r");


### PR DESCRIPTION
### Motivation
- Toggling Dark mode did not immediately change the 2D view background because the framebuffer was being cleared before the clear color was updated.
- The intent is to have background color changes (dark/light) appear immediately without requiring a user interaction like pan or zoom.

### Description
- Moved the `glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)` call to occur after `m_controller.SetDarkMode(darkMode)` and the `glClearColor(...)` call in `viewer2d/viewer2dpanel.cpp`.
- Ensures the new clear color is applied for the current frame so background updates are visible immediately.
- Change is a single-line reorder in the `Render()` path of the 2D viewer.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69484f4cd82883248655b8160e433e59)