### PR TITLE
Fix dictionary editor column handling

### DIFF
--- a/gui/dictionaryeditdialog.cpp
+++ b/gui/dictionaryeditdialog.cpp
@@ -28,6 +28,8 @@
 #include <filesystem>
 #include <vector>
 
+#include <wx/filename.h>
+
 namespace {
 struct FixtureRow {
   std::string name;
@@ -397,9 +399,7 @@ void DictionaryEditDialog::OnItemActivated(wxDataViewEvent &event) {
   int row = table->ItemToRow(item);
   if (row == wxNOT_FOUND)
     return;
-  int col = -1;
-  if (auto *column = event.GetColumn())
-    col = column->GetModelColumn();
+  int col = event.GetColumn();
   if (IsFixturesPage()) {
     if (col == 2) {
       if (static_cast<size_t>(row) >= fixturePaths.size())


### PR DESCRIPTION
### Motivation
- Resolve compiler errors caused by missing `wxFileName` header and incorrect use of the column API in the dictionary editor.
- Prevent the conversion issues where a pointer was expected but an integer was provided by `wxDataViewEvent::GetColumn()` usage.
- Ensure the item-activated handling for fixture/truss tables correctly reads the selected column index.

### Description
- Added `#include <wx/filename.h>` to provide `wxFileName` declarations used when extracting file names.
- Replaced the previous pointer-based column handling with the integer column index returned by `event.GetColumn()` by changing `int col = -1; if (auto *column = event.GetColumn()) col = column->GetModelColumn();` to `int col = event.GetColumn();`.
- Adjusted related logic to use the integer `col` value when deciding cell behavior in `OnItemActivated`.

### Testing
- No automated tests were run for this change.
- The change is small and targeted at resolving build-time type/identifier errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948552da7f48324b9ca290eee6486b4)