### PR TITLE
Cull hidden polygons in schematic symbol capture

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -55,6 +55,7 @@
 #include <filesystem>
 #include <iomanip>
 #include <iostream>
+#include <limits>
 #include <nanovg.h>
 #include <nanovg_gl.h>
 #include <random>
@@ -511,11 +512,205 @@ void Viewer3DController::RecordPolygon(
   m_captureCanvas->DrawPolygon(flat, stroke, fill);
 }
 
+void Viewer3DController::RecordPolygonsWithOptionalCull(
+    const std::vector<std::vector<std::array<float, 3>>> &polygons,
+    const CanvasStroke &stroke, const CanvasFill *fill) const {
+  if (!m_captureCanvas)
+    return;
+  if (!m_captureOnly) {
+    for (const auto &poly : polygons)
+      RecordPolygon(poly, stroke, fill);
+    return;
+  }
+  auto keep = CullHiddenPolygons(polygons);
+  for (size_t i = 0; i < polygons.size(); ++i) {
+    if (i < keep.size() && keep[i])
+      RecordPolygon(polygons[i], stroke, fill);
+  }
+}
+
 void Viewer3DController::RecordText(float x, float y, const std::string &text,
                                     const CanvasTextStyle &style) const {
   if (!m_captureCanvas)
     return;
   m_captureCanvas->DrawText(x, y, text, style);
+}
+
+float Viewer3DController::CaptureDepth(const std::array<float, 3> &p) const {
+  switch (m_captureView) {
+  case Viewer2DView::Top:
+    return p[2];
+  case Viewer2DView::Bottom:
+    return -p[2];
+  case Viewer2DView::Front:
+    return p[1];
+  case Viewer2DView::Side:
+    return p[0];
+  }
+  return p[2];
+}
+
+std::vector<bool> Viewer3DController::CullHiddenPolygons(
+    const std::vector<std::vector<std::array<float, 3>>> &polygons) const {
+  struct CaptureTriangle {
+    std::array<float, 2> p0;
+    std::array<float, 2> p1;
+    std::array<float, 2> p2;
+    float d0 = 0.0f;
+    float d1 = 0.0f;
+    float d2 = 0.0f;
+    size_t polygonIndex = 0;
+  };
+
+  std::vector<CaptureTriangle> triangles;
+  triangles.reserve(polygons.size() * 2);
+
+  float minX = std::numeric_limits<float>::infinity();
+  float minY = std::numeric_limits<float>::infinity();
+  float maxX = -std::numeric_limits<float>::infinity();
+  float maxY = -std::numeric_limits<float>::infinity();
+
+  for (size_t polyIndex = 0; polyIndex < polygons.size(); ++polyIndex) {
+    const auto &poly = polygons[polyIndex];
+    if (poly.size() < 3)
+      continue;
+    for (size_t i = 1; i + 1 < poly.size(); ++i) {
+      CaptureTriangle tri;
+      tri.polygonIndex = polyIndex;
+      tri.p0 = ProjectToCanvas(poly[0]);
+      tri.p1 = ProjectToCanvas(poly[i]);
+      tri.p2 = ProjectToCanvas(poly[i + 1]);
+      tri.d0 = CaptureDepth(poly[0]);
+      tri.d1 = CaptureDepth(poly[i]);
+      tri.d2 = CaptureDepth(poly[i + 1]);
+
+      minX = std::min(minX, std::min({tri.p0[0], tri.p1[0], tri.p2[0]}));
+      minY = std::min(minY, std::min({tri.p0[1], tri.p1[1], tri.p2[1]}));
+      maxX = std::max(maxX, std::max({tri.p0[0], tri.p1[0], tri.p2[0]}));
+      maxY = std::max(maxY, std::max({tri.p0[1], tri.p1[1], tri.p2[1]}));
+      triangles.push_back(tri);
+    }
+  }
+
+  std::vector<bool> keep(polygons.size(), true);
+  if (triangles.empty())
+    return keep;
+
+  const float width = maxX - minX;
+  const float height = maxY - minY;
+  if (width <= 1e-6f || height <= 1e-6f)
+    return keep;
+
+  int gridW = 128;
+  int gridH = 128;
+  if (width > height) {
+    gridH = std::max(16, static_cast<int>(gridW * (height / width)));
+  } else {
+    gridW = std::max(16, static_cast<int>(gridH * (width / height)));
+  }
+
+  const float invW = 1.0f / width;
+  const float invH = 1.0f / height;
+  const float cellW = width / static_cast<float>(gridW);
+  const float cellH = height / static_cast<float>(gridH);
+
+  std::vector<float> depthBuffer(
+      static_cast<size_t>(gridW * gridH),
+      -std::numeric_limits<float>::infinity());
+
+  auto barycentric = [](const std::array<float, 2> &p,
+                        const std::array<float, 2> &a,
+                        const std::array<float, 2> &b,
+                        const std::array<float, 2> &c, float &w0, float &w1,
+                        float &w2) -> bool {
+    float denom = (b[1] - c[1]) * (a[0] - c[0]) +
+                  (c[0] - b[0]) * (a[1] - c[1]);
+    if (std::abs(denom) < 1e-8f)
+      return false;
+    w0 = ((b[1] - c[1]) * (p[0] - c[0]) +
+          (c[0] - b[0]) * (p[1] - c[1])) /
+         denom;
+    w1 = ((c[1] - a[1]) * (p[0] - c[0]) +
+          (a[0] - c[0]) * (p[1] - c[1])) /
+         denom;
+    w2 = 1.0f - w0 - w1;
+    return w0 >= -1e-4f && w1 >= -1e-4f && w2 >= -1e-4f;
+  };
+
+  for (const auto &tri : triangles) {
+    float triMinX = std::min({tri.p0[0], tri.p1[0], tri.p2[0]});
+    float triMinY = std::min({tri.p0[1], tri.p1[1], tri.p2[1]});
+    float triMaxX = std::max({tri.p0[0], tri.p1[0], tri.p2[0]});
+    float triMaxY = std::max({tri.p0[1], tri.p1[1], tri.p2[1]});
+
+    int minXi = std::clamp(static_cast<int>((triMinX - minX) * invW * gridW), 0,
+                           gridW - 1);
+    int maxXi = std::clamp(static_cast<int>((triMaxX - minX) * invW * gridW), 0,
+                           gridW - 1);
+    int minYi = std::clamp(static_cast<int>((triMinY - minY) * invH * gridH), 0,
+                           gridH - 1);
+    int maxYi = std::clamp(static_cast<int>((triMaxY - minY) * invH * gridH), 0,
+                           gridH - 1);
+
+    for (int y = minYi; y <= maxYi; ++y) {
+      float py = minY + (static_cast<float>(y) + 0.5f) * cellH;
+      for (int x = minXi; x <= maxXi; ++x) {
+        float px = minX + (static_cast<float>(x) + 0.5f) * cellW;
+        float w0 = 0.0f, w1 = 0.0f, w2 = 0.0f;
+        if (!barycentric({px, py}, tri.p0, tri.p1, tri.p2, w0, w1, w2))
+          continue;
+        float depth = w0 * tri.d0 + w1 * tri.d1 + w2 * tri.d2;
+        size_t idx = static_cast<size_t>(y * gridW + x);
+        if (depth > depthBuffer[idx])
+          depthBuffer[idx] = depth;
+      }
+    }
+  }
+
+  const float epsilon = 1e-4f;
+  std::vector<bool> visible(polygons.size(), false);
+
+  for (const auto &tri : triangles) {
+    if (visible[tri.polygonIndex])
+      continue;
+    float triMinX = std::min({tri.p0[0], tri.p1[0], tri.p2[0]});
+    float triMinY = std::min({tri.p0[1], tri.p1[1], tri.p2[1]});
+    float triMaxX = std::max({tri.p0[0], tri.p1[0], tri.p2[0]});
+    float triMaxY = std::max({tri.p0[1], tri.p1[1], tri.p2[1]});
+
+    int minXi = std::clamp(static_cast<int>((triMinX - minX) * invW * gridW), 0,
+                           gridW - 1);
+    int maxXi = std::clamp(static_cast<int>((triMaxX - minX) * invW * gridW), 0,
+                           gridW - 1);
+    int minYi = std::clamp(static_cast<int>((triMinY - minY) * invH * gridH), 0,
+                           gridH - 1);
+    int maxYi = std::clamp(static_cast<int>((triMaxY - minY) * invH * gridH), 0,
+                           gridH - 1);
+
+    bool sampled = false;
+    for (int y = minYi; y <= maxYi && !visible[tri.polygonIndex]; ++y) {
+      float py = minY + (static_cast<float>(y) + 0.5f) * cellH;
+      for (int x = minXi; x <= maxXi; ++x) {
+        float px = minX + (static_cast<float>(x) + 0.5f) * cellW;
+        float w0 = 0.0f, w1 = 0.0f, w2 = 0.0f;
+        if (!barycentric({px, py}, tri.p0, tri.p1, tri.p2, w0, w1, w2))
+          continue;
+        sampled = true;
+        float depth = w0 * tri.d0 + w1 * tri.d1 + w2 * tri.d2;
+        size_t idx = static_cast<size_t>(y * gridW + x);
+        if (depthBuffer[idx] <= depth + epsilon) {
+          visible[tri.polygonIndex] = true;
+          break;
+        }
+      }
+    }
+    if (!sampled)
+      visible[tri.polygonIndex] = true;
+  }
+
+  for (size_t i = 0; i < keep.size(); ++i)
+    keep[i] = visible[i];
+  return keep;
 }
 
 Viewer3DController::Viewer3DController() {
@@ -1827,11 +2022,14 @@ void Viewer3DController::DrawCubeWithOutline(
       fill.color = {r, g, b, 1.0f};
       const int faces[6][4] = {{0, 1, 3, 2}, {4, 5, 7, 6}, {0, 1, 5, 4},
                                {2, 3, 7, 6}, {0, 2, 6, 4}, {1, 3, 7, 5}};
+      std::vector<std::vector<std::array<float, 3>>> polygons;
+      polygons.reserve(6);
       for (const auto &face : faces) {
         std::vector<std::array<float, 3>> pts = {
             verts[face[0]], verts[face[1]], verts[face[2]], verts[face[3]]};
-        RecordPolygon(pts, stroke, &fill);
+        polygons.push_back(std::move(pts));
       }
+      RecordPolygonsWithOptionalCull(polygons, stroke, &fill);
     }
     if (!m_captureOnly) {
       glEnable(GL_POLYGON_OFFSET_FILL);
@@ -1876,6 +2074,8 @@ void Viewer3DController::DrawMeshWithOutline(
     if (m_captureCanvas && mode != Viewer2DRenderMode::Wireframe) {
       CanvasFill fill;
       fill.color = {r, g, b, 1.0f};
+      std::vector<std::vector<std::array<float, 3>>> polygons;
+      polygons.reserve(mesh.indices.size() / 3);
       for (size_t i = 0; i + 2 < mesh.indices.size(); i += 3) {
         unsigned short i0 = mesh.indices[i];
         unsigned short i1 = mesh.indices[i + 1];
@@ -1891,8 +2091,9 @@ void Viewer3DController::DrawMeshWithOutline(
           for (auto &p : pts)
             p = captureTransform(p);
         }
-        RecordPolygon(pts, stroke, &fill);
+        polygons.push_back(std::move(pts));
       }
+      RecordPolygonsWithOptionalCull(polygons, stroke, &fill);
     }
     if (!m_captureOnly) {
       glLineWidth(1.0f);
@@ -1923,6 +2124,8 @@ void Viewer3DController::DrawMeshWithOutline(
     stroke.width = 0.0f;
     CanvasFill fill;
     fill.color = {r, g, b, 1.0f};
+    std::vector<std::vector<std::array<float, 3>>> polygons;
+    polygons.reserve(mesh.indices.size() / 3);
     for (size_t i = 0; i + 2 < mesh.indices.size(); i += 3) {
       unsigned short i0 = mesh.indices[i];
       unsigned short i1 = mesh.indices[i + 1];
@@ -1938,8 +2141,9 @@ void Viewer3DController::DrawMeshWithOutline(
         for (auto &p : pts)
           p = captureTransform(p);
       }
-      RecordPolygon(pts, stroke, &fill);
+      polygons.push_back(std::move(pts));
     }
+    RecordPolygonsWithOptionalCull(polygons, stroke, &fill);
   }
 }
 

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -206,8 +206,14 @@ private:
                       const CanvasStroke &stroke) const;
   void RecordPolygon(const std::vector<std::array<float, 3>> &points,
                      const CanvasStroke &stroke, const CanvasFill *fill) const;
+  void RecordPolygonsWithOptionalCull(
+      const std::vector<std::vector<std::array<float, 3>>> &polygons,
+      const CanvasStroke &stroke, const CanvasFill *fill) const;
   void RecordText(float x, float y, const std::string &text,
                   const CanvasTextStyle &style) const;
+  float CaptureDepth(const std::array<float, 3> &p) const;
+  std::vector<bool> CullHiddenPolygons(
+      const std::vector<std::vector<std::array<float, 3>>> &polygons) const;
 
   // Draws a mesh loaded from a 3DS file using the given scale factor
   // for vertex positions. GDTF models may already be defined in meters


### PR DESCRIPTION
### Motivation
- Al generar símbolos para impresión muchos polígonos 3D quedan totalmente tapados pero aún se registran en el símbolo, aumentando tamaño y ruido visual.
- Se necesita un pase adicional que detecte y elimine polígonos completamente ocultos antes de serializar el símbolo 2D.
- El filtrado debe ejecutarse solo durante la captura de símbolos para no alterar el renderizado en pantalla (`m_captureOnly`).

### Description
- Añade las rutinas `RecordPolygonsWithOptionalCull`, `CaptureDepth` y `CullHiddenPolygons` para soportar el pase de eliminación de polígonos ocultos.
- Agrupa triángulos desde `DrawMeshWithOutline` y los cubos antes de grabar y reemplaza llamadas directas a `RecordPolygon` por `RecordPolygonsWithOptionalCull`.
- `CullHiddenPolygons` proyecta triángulos con `ProjectToCanvas`, construye un buffer de profundidad en una rejilla de baja resolución y usa muestreo baricéntrico para decidir qué polígonos están totalmente ocultos.
- Cuando `m_captureOnly` es falso se omite el culling y el comportamiento previo se preserva completamente.

### Testing
- No se ejecutaron pruebas automáticas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69488ae864448324be6cbfb5f7a84425)