### PR TITLE
Apply hidden polygon culling during schematic capture

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -517,7 +517,7 @@ void Viewer3DController::RecordPolygonsWithOptionalCull(
     const CanvasStroke &stroke, const CanvasFill *fill) const {
   if (!m_captureCanvas)
     return;
-  if (!m_captureOnly) {
+  if (!m_captureOnly && !m_captureCullHidden) {
     for (const auto &poly : polygons)
       RecordPolygon(poly, stroke, fill);
     return;

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -266,6 +266,7 @@ private:
   bool m_captureIncludeGrid = true;
   bool m_captureOnly = false;
   bool m_captureUseSymbols = false;
+  bool m_captureCullHidden = false;
   SymbolCache m_bottomSymbolCache;
   bool m_darkMode = false;
 
@@ -281,5 +282,6 @@ public:
     m_captureView = view;
     m_captureIncludeGrid = includeGrid;
     m_captureUseSymbols = canvas ? useSymbolInstancing : false;
+    m_captureCullHidden = canvas ? useSymbolInstancing : false;
   }
 };


### PR DESCRIPTION
### Motivation
- The code previously performed hidden-polygon culling when capturing individual symbol definitions but did not consistently apply that culling when recording the full 2D schematic for PDF export.  
- This caused PDF output to include many occluded polygons and larger-than-expected files.  
- The intent is to enable the same depth-based hidden-polygon filtering used for symbols during schematic capture when appropriate.  

### Description
- Added a new capture flag `m_captureCullHidden` to `Viewer3DController` to track whether hidden-polygon culling should be applied during capture.  
- Set `m_captureCullHidden` in `SetCaptureCanvas(...)` from the `useSymbolInstancing` parameter so schematic captures that use symbol instancing enable culling.  
- Updated `RecordPolygonsWithOptionalCull(...)` to respect `m_captureCullHidden` and run `CullHiddenPolygons(...)` even when not in `m_captureOnly` mode if culling is requested.  
- Modified files: `viewer3d/viewer3dcontroller.h` and `viewer3d/viewer3dcontroller.cpp` (small, focused change).  

### Testing
- No automated tests were executed for this change.  
- Change is limited and compiled/committed in the tree (manual CI/test not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948902f9cc483248c7f44706c21b597)