### PR TITLE
Auto color: override white fixture colors when assigning type colors

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1200,6 +1200,17 @@ void MainWindow::OnAutoColor(wxCommandEvent &WXUNUSED(event)) {
     return wxString::Format("#%02X%02X%02X", dist(rng), dist(rng), dist(rng))
         .ToStdString();
   };
+  auto isWhiteColor = [](const std::string &color) {
+    if (color.empty())
+      return false;
+    std::string normalized = color;
+    std::transform(normalized.begin(), normalized.end(), normalized.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    if (normalized.rfind('#', 0) == 0)
+      normalized.erase(0, 1);
+    return normalized == "fff" || normalized == "ffffff" ||
+           normalized == "white";
+  };
   const std::string trussColor = "#D3D3D3";
 
   std::set<std::string> layerNames;
@@ -1231,7 +1242,8 @@ void MainWindow::OnAutoColor(wxCommandEvent &WXUNUSED(event)) {
     if (!f.gdtfSpec.empty()) {
       auto it = typeColors.find(f.gdtfSpec);
       if (it == typeColors.end()) {
-        std::string c = f.color.empty() ? randHex() : f.color;
+        std::string c =
+            (f.color.empty() || isWhiteColor(f.color)) ? randHex() : f.color;
         typeColors[f.gdtfSpec] = c;
         f.color = c;
       } else {


### PR DESCRIPTION
### Motivation
- Keep the existing `Auto color` behavior but allow fixtures that are effectively white to be replaced with a new type-based color.
- Users expect blank/white-looking fixture colors to be refreshed by the auto-color operation while preserving other explicit colors.
- Layer color logic (truss -> light gray, preserve non-empty layer colors) must remain unchanged.

### Description
- Added an `isWhiteColor` lambda in `gui/mainwindow.cpp` to detect `"#fff"`, `"#ffffff"`, and `"white"` color values.
- Modified `OnAutoColor` so that when computing per-type colors, a fixture's color is considered unassigned if `f.color` is empty or `isWhiteColor(f.color)`, and in that case `randHex` is used.
- Existing behavior for non-white fixture colors, layer color assignment, and calls to `SetGdtfModelColor` are preserved.
- Changes are localized to the `OnAutoColor` function in `gui/mainwindow.cpp`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69488badbe8c83249d8ff2e7ef886348)