### PR TITLE
Cull hidden mesh edges in schematic PDF capture

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1900,6 +1900,10 @@ void Viewer3DController::DrawWireframeBox(
                                                  {x0, y1, z0}, {x1, y1, z0},
                                                  {x0, y0, z1}, {x1, y0, z1},
                                                  {x0, y1, z1}, {x1, y1, z1}};
+      if (captureTransform) {
+        for (auto &p : verts)
+          p = captureTransform(p);
+      }
       const int edges[12][2] = {{0, 1}, {2, 3}, {4, 5}, {6, 7}, {0, 2},
                                 {1, 3}, {4, 6}, {5, 7}, {0, 4}, {1, 5},
                                 {2, 6}, {3, 7}};
@@ -2070,11 +2074,11 @@ void Viewer3DController::DrawMeshWithOutline(
     CanvasStroke stroke;
     stroke.color = {0.0f, 0.0f, 0.0f, 1.0f};
     stroke.width = lineWidth;
-    DrawMeshWireframe(mesh, scale, captureTransform);
-    if (m_captureCanvas && mode != Viewer2DRenderMode::Wireframe) {
-      CanvasFill fill;
-      fill.color = {r, g, b, 1.0f};
-      std::vector<std::vector<std::array<float, 3>>> polygons;
+    const bool shouldCullCapture =
+        m_captureCanvas && (m_captureOnly || m_captureCullHidden);
+    std::vector<std::vector<std::array<float, 3>>> polygons;
+    std::vector<bool> visible;
+    if (shouldCullCapture) {
       polygons.reserve(mesh.indices.size() / 3);
       for (size_t i = 0; i + 2 < mesh.indices.size(); i += 3) {
         unsigned short i0 = mesh.indices[i];
@@ -2093,7 +2097,55 @@ void Viewer3DController::DrawMeshWithOutline(
         }
         polygons.push_back(std::move(pts));
       }
-      RecordPolygonsWithOptionalCull(polygons, stroke, &fill);
+      visible = CullHiddenPolygons(polygons);
+    }
+
+    DrawMeshWireframe(mesh, scale, captureTransform, !shouldCullCapture);
+
+    if (m_captureCanvas) {
+      if (shouldCullCapture) {
+        for (size_t i = 0; i < polygons.size(); ++i) {
+          if (i < visible.size() && !visible[i])
+            continue;
+          const auto &tri = polygons[i];
+          if (tri.size() < 3)
+            continue;
+          RecordLine(tri[0], tri[1], stroke);
+          RecordLine(tri[1], tri[2], stroke);
+          RecordLine(tri[2], tri[0], stroke);
+        }
+        if (mode != Viewer2DRenderMode::Wireframe) {
+          CanvasFill fill;
+          fill.color = {r, g, b, 1.0f};
+          for (size_t i = 0; i < polygons.size(); ++i) {
+            if (i < visible.size() && !visible[i])
+              continue;
+            RecordPolygon(polygons[i], stroke, &fill);
+          }
+        }
+      } else if (mode != Viewer2DRenderMode::Wireframe) {
+        CanvasFill fill;
+        fill.color = {r, g, b, 1.0f};
+        polygons.reserve(mesh.indices.size() / 3);
+        for (size_t i = 0; i + 2 < mesh.indices.size(); i += 3) {
+          unsigned short i0 = mesh.indices[i];
+          unsigned short i1 = mesh.indices[i + 1];
+          unsigned short i2 = mesh.indices[i + 2];
+          std::vector<std::array<float, 3>> pts = {
+              {mesh.vertices[i0 * 3] * scale, mesh.vertices[i0 * 3 + 1] * scale,
+               mesh.vertices[i0 * 3 + 2] * scale},
+              {mesh.vertices[i1 * 3] * scale, mesh.vertices[i1 * 3 + 1] * scale,
+               mesh.vertices[i1 * 3 + 2] * scale},
+              {mesh.vertices[i2 * 3] * scale, mesh.vertices[i2 * 3 + 1] * scale,
+               mesh.vertices[i2 * 3 + 2] * scale}};
+          if (captureTransform) {
+            for (auto &p : pts)
+              p = captureTransform(p);
+          }
+          polygons.push_back(std::move(pts));
+        }
+        RecordPolygonsWithOptionalCull(polygons, stroke, &fill);
+      }
     }
     if (!m_captureOnly) {
       glLineWidth(1.0f);
@@ -2152,7 +2204,8 @@ void Viewer3DController::DrawMeshWithOutline(
 void Viewer3DController::DrawMeshWireframe(
     const Mesh &mesh, float scale,
     const std::function<std::array<float, 3>(const std::array<float, 3> &)> &
-        captureTransform) {
+        captureTransform,
+    bool captureLines) {
   if (!m_captureOnly) {
     glBegin(GL_LINES);
     for (size_t i = 0; i + 2 < mesh.indices.size(); i += 3) {
@@ -2183,7 +2236,7 @@ void Viewer3DController::DrawMeshWireframe(
     }
     glEnd();
   }
-  if (m_captureCanvas) {
+  if (m_captureCanvas && captureLines) {
     CanvasStroke stroke;
     stroke.color = {0.0f, 0.0f, 0.0f, 1.0f};
     stroke.width = 1.0f;

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -166,7 +166,8 @@ private:
   void DrawMeshWireframe(
       const Mesh &mesh, float scale = RENDER_SCALE,
       const std::function<std::array<float, 3>(
-          const std::array<float, 3> &)> &captureTransform = {});
+          const std::array<float, 3> &)> &captureTransform = {},
+      bool captureLines = true);
 
   // Draws a colored cube tinted when selected or highlighted. The optional
   // center offset parameters are unused and kept for compatibility.


### PR DESCRIPTION
### Motivation
- Reduce PDF size in schematic (simplified) export by avoiding recording occluded mesh geometry.
- Ensure captured 2D coordinates used for PDF symbols are consistent with the applied capture transforms.
- Reuse triangle visibility when emitting fills so occluded polygons are not written to the PDF.

### Description
- When capturing mesh geometry for schematic export, build per-triangle polygons and call `CullHiddenPolygons` to compute visibility and skip occluded triangles during recording.
- Make `DrawMeshWireframe` accept an extra `captureLines` flag and only emit captured edge lines when appropriate to avoid duplicating culled geometry.
- Use the previously computed visibility to avoid recording occluded fills (polygons) as well as wireframe edges for schematic captures.
- Apply `captureTransform` to truss/wireframe box vertex lists before recording their edges so recorded coordinates match transformed output, and update the corresponding header signature in `viewer3d/viewer3dcontroller.h`.

### Testing
- No automated tests were run for this change.
- The change was compiled and committed locally (manual verification only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948965c48d88324800939b63cb202b8)