### PR TITLE
Ensure PDF label outlines are always white and thinner

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -2561,10 +2561,8 @@ void Viewer3DController::DrawAllFixtureLabels(int width, int height,
         style.lineHeight = lineHeightsWorld[i];
         style.extraLineSpacing = lineSpacingWorld;
         style.color = {0.0f, 0.0f, 0.0f, 1.0f};
-        if (!m_darkMode) {
-          style.outlineColor = {1.0f, 1.0f, 1.0f, 1.0f};
-          style.outlineWidth = pxToWorld;
-        }
+        style.outlineColor = {1.0f, 1.0f, 1.0f, 1.0f};
+        style.outlineWidth = pxToWorld * 0.5f;
         style.hAlign = CanvasTextStyle::HorizontalAlign::Center;
         style.vAlign = CanvasTextStyle::VerticalAlign::Baseline;
         float baseline = currentY - style.ascent;


### PR DESCRIPTION
### Motivation
- Make captured fixture label outlines visible in PDF exports regardless of UI color theme so white outlines are always applied.
- Reduce the outline thickness used for PDF labels so the printed outline is visually finer.

### Description
- Removed the `m_darkMode` conditional and always set `style.outlineColor = {1.0f, 1.0f, 1.0f, 1.0f}` for captured labels.
- Reduced the outline width by setting `style.outlineWidth = pxToWorld * 0.5f` when recording fixture label styles.
- Change is implemented in `viewer3d/viewer3dcontroller.cpp` where label capture `CanvasTextStyle` is populated.

### Testing
- No automated tests were run for this change.
- A commit was created with the change to `viewer3d/viewer3dcontroller.cpp` and is ready for CI/build verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948a13696588324be9b6412ebf23dd2)