### PR TITLE
Log print plan diagnostics to GUI console and remove popup dialogs

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1382,12 +1382,9 @@ void MainWindow::OnPrintPlan(wxCommandEvent &WXUNUSED(event)) {
 
         std::string diagnostics = BuildPrintDiagnostics(buffer);
         wxLogMessage("%s", wxString::FromUTF8(diagnostics));
-        bool showDiagnosticsBox =
-            ConfigManager::Get().GetFloat("print_plan_diagnostics_popup") !=
-            0.0f;
-        if (showDiagnosticsBox) {
-          wxMessageBox(wxString::FromUTF8(diagnostics), "Print Plan diagnostics",
-                       wxOK | wxICON_INFORMATION, this);
+        if (ConsolePanel::Instance()) {
+          ConsolePanel::Instance()->AppendMessage(
+              wxString::FromUTF8(diagnostics));
         }
 
         std::string fixtureReport;
@@ -1395,10 +1392,9 @@ void MainWindow::OnPrintPlan(wxCommandEvent &WXUNUSED(event)) {
           fixtureReport = viewport2DPanel->GetLastFixtureDebugReport();
         if (!fixtureReport.empty()) {
           wxLogMessage("%s", wxString::FromUTF8(fixtureReport));
-          if (showDiagnosticsBox) {
-            wxMessageBox(wxString::FromUTF8(fixtureReport),
-                         "Print Plan fixture debug", wxOK | wxICON_INFORMATION,
-                         this);
+          if (ConsolePanel::Instance()) {
+            ConsolePanel::Instance()->AppendMessage(
+                wxString::FromUTF8(fixtureReport));
           }
         }
 


### PR DESCRIPTION
### Motivation
- Avoid modal pop-ups for print diagnostics so diagnostic text appears in the GUI console instead of blocking the user. 
- Ensure both the textual diagnostics produced by `BuildPrintDiagnostics` and fixture debug reports are visible in the in-application console. 
- Keep the existing `wxLogMessage` logging path while surfacing messages to the `ConsolePanel` UI for easier user access. 

### Description
- Removed modal `wxMessageBox` calls that displayed print plan diagnostics and fixture debug messages inside `MainWindow::OnPrintPlan` in `gui/mainwindow.cpp`. 
- Added calls to `ConsolePanel::Instance()->AppendMessage(wxString::FromUTF8(...))` to append the `diagnostics` and `fixtureReport` text to the GUI console. 
- Left `wxLogMessage` logging and the PDF export modal feedback intact so non-diagnostic export errors/success messages remain unchanged. 

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948a3b3a6608324a32983141892be44)