### PR TITLE
Remove print diagnostics popup logging

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1381,7 +1381,6 @@ void MainWindow::OnPrintPlan(wxCommandEvent &WXUNUSED(event)) {
         }
 
         std::string diagnostics = BuildPrintDiagnostics(buffer);
-        wxLogMessage("%s", wxString::FromUTF8(diagnostics));
         if (ConsolePanel::Instance()) {
           ConsolePanel::Instance()->AppendMessage(
               wxString::FromUTF8(diagnostics));


### PR DESCRIPTION
### Motivation
- Suppress modal pop-ups caused by print diagnostics so diagnostics are only visible in the application console.
- Keep diagnostic information available to users without interrupting the UI or requiring dismissal of a dialog.

### Description
- Removed the `wxLogMessage` call that displayed `BuildPrintDiagnostics` output as a popup in `gui/mainwindow.cpp`.
- Retained sending diagnostics to the in-app console via `ConsolePanel::Instance()->AppendMessage`.
- Change is limited to `MainWindow::OnPrintPlan` and does not alter how fixture reports are handled.

### Testing
- No automated tests were run for this change.
- Local compile or runtime verification was not executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948a6114044832490204093156cc7e9)