### PR TITLE
Fix plan PDF landscape orientation

### DIFF
--- a/viewer2d/planpdfexporter.cpp
+++ b/viewer2d/planpdfexporter.cpp
@@ -838,8 +838,8 @@ PlanExportResult ExportPlanToPdf(const CommandBuffer &buffer,
 
   (void)viewState.view; // Orientation reserved for future layout tweaks.
 
-  double pageW = options.landscape ? options.pageHeightPt : options.pageWidthPt;
-  double pageH = options.landscape ? options.pageWidthPt : options.pageHeightPt;
+  double pageW = options.pageWidthPt;
+  double pageH = options.pageHeightPt;
   double margin = options.marginPt;
   double drawW = pageW - margin * 2.0;
   double drawH = pageH - margin * 2.0;


### PR DESCRIPTION
### Motivation
- Exported plan PDFs were still produced in portrait even when `landscape` was selected in preferences, causing user-facing incorrect output.
- The root cause was that `PlanPrintSettings::PageWidthPt()`/`PageHeightPt()` already return dimensions adjusted for landscape, and the exporter was swapping them again.

### Description
- Stop double-swapping page dimensions in `ExportPlanToPdf` by using `options.pageWidthPt` and `options.pageHeightPt` directly instead of conditionally swapping them.
- Change applied to `viewer2d/planpdfexporter.cpp` where the `pageW`/`pageH` initialization previously flipped width/height for `options.landscape`.
- This aligns the exporter with `PlanPrintSettings` which performs the orientation-aware sizing in `PageWidthPt()`/`PageHeightPt()`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948aa207ae083248c9459746ca8bd0f)