### PR TITLE
Move plan printing options into Print Plan dialog

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -152,7 +152,7 @@ ConfigManager::ConfigManager() {
                    {"print_page_size"});
   RegisterVariable("print_plan_landscape", "float", 0.0f, 0.0f, 1.0f,
                    {"print_landscape"});
-  RegisterVariable("print_use_simplified_footprints", "float", 0.0f, 0.0f,
+  RegisterVariable("print_use_simplified_footprints", "float", 1.0f, 0.0f,
                    1.0f, {"use_simplified_footprints"});
   RegisterVariable("label_show_name", "float", 1.0f, 0.0f, 1.0f);
   RegisterVariable("label_show_id", "float", 1.0f, 0.0f, 1.0f);

--- a/gui/planprintdialog.cpp
+++ b/gui/planprintdialog.cpp
@@ -1,0 +1,94 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "planprintdialog.h"
+
+PlanPrintDialog::PlanPrintDialog(wxWindow *parent,
+                                 const print::PlanPrintSettings &settings)
+    : wxDialog(parent, wxID_ANY, "Print Plan", wxDefaultPosition,
+               wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER) {
+  wxBoxSizer *topSizer = new wxBoxSizer(wxVERTICAL);
+
+  wxStaticBoxSizer *pageSizeSizer =
+      new wxStaticBoxSizer(wxVERTICAL, this, "Page size");
+  pageSizeA3Radio =
+      new wxRadioButton(this, wxID_ANY, "A3", wxDefaultPosition,
+                        wxDefaultSize, wxRB_GROUP);
+  pageSizeA4Radio = new wxRadioButton(this, wxID_ANY, "A4");
+  pageSizeSizer->Add(pageSizeA3Radio, 0, wxALL, 5);
+  pageSizeSizer->Add(pageSizeA4Radio, 0, wxALL, 5);
+  topSizer->Add(pageSizeSizer, 0, wxEXPAND | wxALL, 10);
+
+  wxStaticBoxSizer *orientationSizer =
+      new wxStaticBoxSizer(wxVERTICAL, this, "Orientation");
+  portraitRadio = new wxRadioButton(this, wxID_ANY, "Portrait",
+                                    wxDefaultPosition, wxDefaultSize,
+                                    wxRB_GROUP);
+  landscapeRadio = new wxRadioButton(this, wxID_ANY, "Landscape");
+  orientationSizer->Add(portraitRadio, 0, wxALL, 5);
+  orientationSizer->Add(landscapeRadio, 0, wxALL, 5);
+  topSizer->Add(orientationSizer, 0,
+                wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 10);
+
+  includeGridCheck = new wxCheckBox(this, wxID_ANY, "Include grid");
+  topSizer->Add(includeGridCheck, 0, wxLEFT | wxRIGHT | wxBOTTOM, 10);
+
+  wxStaticBoxSizer *elementsSizer =
+      new wxStaticBoxSizer(wxVERTICAL, this, "Elements detail");
+  detailedRadio = new wxRadioButton(this, wxID_ANY, "Detailed",
+                                    wxDefaultPosition, wxDefaultSize,
+                                    wxRB_GROUP);
+  schematicRadio = new wxRadioButton(this, wxID_ANY, "Schematic");
+  elementsSizer->Add(detailedRadio, 0, wxALL, 5);
+  elementsSizer->Add(schematicRadio, 0, wxALL, 5);
+  topSizer->Add(elementsSizer, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 10);
+
+  pageSizeA3Radio->SetValue(settings.pageSize == print::PageSize::A3);
+  pageSizeA4Radio->SetValue(settings.pageSize == print::PageSize::A4);
+  landscapeRadio->SetValue(settings.landscape);
+  portraitRadio->SetValue(!settings.landscape);
+  includeGridCheck->SetValue(settings.includeGrid);
+  detailedRadio->SetValue(settings.detailedFootprints);
+  schematicRadio->SetValue(!settings.detailedFootprints);
+
+  detailedRadio->Bind(wxEVT_RADIOBUTTON,
+                      [this](wxCommandEvent &event) {
+                        if (event.IsChecked())
+                          ShowDetailedWarning();
+                      });
+
+  topSizer->Add(CreateSeparatedButtonSizer(wxOK | wxCANCEL), 0,
+                wxALL | wxEXPAND, 10);
+  SetSizerAndFit(topSizer);
+}
+
+print::PlanPrintSettings PlanPrintDialog::GetSettings() const {
+  print::PlanPrintSettings settings;
+  settings.pageSize = pageSizeA4Radio->GetValue() ? print::PageSize::A4
+                                                  : print::PageSize::A3;
+  settings.landscape = landscapeRadio->GetValue();
+  settings.includeGrid = includeGridCheck->GetValue();
+  settings.detailedFootprints = detailedRadio->GetValue();
+  return settings;
+}
+
+void PlanPrintDialog::ShowDetailedWarning() {
+  wxMessageBox(
+      "El modo Detailed tarda mucho más y genera archivos más pesados.\n"
+      "De momento solo lo mantengo para pruebas.",
+      "Print Plan", wxOK | wxICON_WARNING, this);
+}

--- a/gui/planprintdialog.h
+++ b/gui/planprintdialog.h
@@ -17,18 +17,25 @@
  */
 #pragma once
 
-#include <array>
+#include "print/PlanPrintSettings.h"
+
 #include <wx/wx.h>
 
-class PreferencesDialog : public wxDialog {
+class PlanPrintDialog : public wxDialog {
 public:
-  PreferencesDialog(wxWindow *parent);
+  PlanPrintDialog(wxWindow *parent,
+                  const print::PlanPrintSettings &settings);
+
+  print::PlanPrintSettings GetSettings() const;
 
 private:
-  std::array<wxTextCtrl *, 6> lxHeightCtrls{};
-  std::array<wxTextCtrl *, 6> lxPosCtrls{};
-  std::array<wxTextCtrl *, 6> lxMarginCtrls{};
-  wxCheckBox *autopatchCheck = nullptr;
-  wxRadioButton *layerPosRadio = nullptr;
-  wxRadioButton *layerTypeRadio = nullptr;
+  void ShowDetailedWarning();
+
+  wxRadioButton *pageSizeA3Radio = nullptr;
+  wxRadioButton *pageSizeA4Radio = nullptr;
+  wxRadioButton *portraitRadio = nullptr;
+  wxRadioButton *landscapeRadio = nullptr;
+  wxCheckBox *includeGridCheck = nullptr;
+  wxRadioButton *detailedRadio = nullptr;
+  wxRadioButton *schematicRadio = nullptr;
 };

--- a/gui/preferencesdialog.cpp
+++ b/gui/preferencesdialog.cpp
@@ -17,8 +17,6 @@
  */
 #include "preferencesdialog.h"
 #include "configmanager.h"
-#include "print/PlanPrintSettings.h"
-
 #include <wx/notebook.h>
 #include <wx/checkbox.h>
 #include <wx/radiobut.h>
@@ -86,48 +84,6 @@ PreferencesDialog::PreferencesDialog(wxWindow *parent)
 
   book->AddPage(riderPanel, "Rider Import");
 
-  // Plan printing page
-  wxPanel *planPanel = new wxPanel(book);
-  wxBoxSizer *planSizer = new wxBoxSizer(wxVERTICAL);
-
-  wxStaticBoxSizer *pageSizeSizer =
-      new wxStaticBoxSizer(wxVERTICAL, planPanel, "Page size");
-  pageSizeA3Radio = new wxRadioButton(planPanel, wxID_ANY, "A3", wxDefaultPosition,
-                                      wxDefaultSize, wxRB_GROUP);
-  pageSizeA4Radio = new wxRadioButton(planPanel, wxID_ANY, "A4");
-  pageSizeSizer->Add(pageSizeA3Radio, 0, wxALL, 5);
-  pageSizeSizer->Add(pageSizeA4Radio, 0, wxALL, 5);
-  planSizer->Add(pageSizeSizer, 0, wxEXPAND | wxALL, 10);
-
-  wxStaticBoxSizer *orientationSizer = new wxStaticBoxSizer(
-      wxVERTICAL, planPanel, "Orientation");
-  portraitRadio = new wxRadioButton(planPanel, wxID_ANY, "Portrait",
-                                    wxDefaultPosition, wxDefaultSize,
-                                    wxRB_GROUP);
-  landscapeRadio = new wxRadioButton(planPanel, wxID_ANY, "Landscape");
-  orientationSizer->Add(portraitRadio, 0, wxALL, 5);
-  orientationSizer->Add(landscapeRadio, 0, wxALL, 5);
-  planSizer->Add(orientationSizer, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM,
-                 10);
-
-  includeGridCheck = new wxCheckBox(planPanel, wxID_ANY, "Include grid");
-  planSizer->Add(includeGridCheck, 0, wxLEFT | wxRIGHT | wxBOTTOM, 10);
-
-  wxStaticBoxSizer *elementsSizer =
-      new wxStaticBoxSizer(wxVERTICAL, planPanel, "Elements detail");
-  detailedRadio = new wxRadioButton(planPanel, wxID_ANY, "Detailed",
-                                    wxDefaultPosition, wxDefaultSize,
-                                    wxRB_GROUP);
-  schematicRadio = new wxRadioButton(planPanel, wxID_ANY, "Schematic");
-  elementsSizer->Add(detailedRadio, 0, wxALL, 5);
-  elementsSizer->Add(schematicRadio, 0, wxALL, 5);
-  planSizer->Add(elementsSizer, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 10);
-
-  LoadPlanPrintSettings(print::PlanPrintSettings::LoadFromConfig(cfg));
-
-  planPanel->SetSizer(planSizer);
-  book->AddPage(planPanel, "Plan Printing");
-
   topSizer->Add(book, 1, wxEXPAND | wxALL, 5);
   topSizer->Add(CreateSeparatedButtonSizer(wxOK | wxCANCEL | wxAPPLY), 0,
                 wxALL | wxEXPAND, 5);
@@ -155,30 +111,7 @@ PreferencesDialog::PreferencesDialog(wxWindow *parent)
       cfg.SetValue("rider_layer_mode",
                    layerTypeRadio->GetValue() ? "type" : "position");
 
-      print::PlanPrintSettings planSettings;
-      SavePlanPrintSettings(planSettings);
-      planSettings.SaveToConfig(cfg);
     }
     evt.Skip();
   });
-}
-
-void PreferencesDialog::LoadPlanPrintSettings(
-    const print::PlanPrintSettings &settings) {
-  pageSizeA3Radio->SetValue(settings.pageSize == print::PageSize::A3);
-  pageSizeA4Radio->SetValue(settings.pageSize == print::PageSize::A4);
-  landscapeRadio->SetValue(settings.landscape);
-  portraitRadio->SetValue(!settings.landscape);
-  includeGridCheck->SetValue(settings.includeGrid);
-  detailedRadio->SetValue(settings.detailedFootprints);
-  schematicRadio->SetValue(!settings.detailedFootprints);
-}
-
-void PreferencesDialog::SavePlanPrintSettings(
-    print::PlanPrintSettings &settings) {
-  settings.pageSize = pageSizeA4Radio->GetValue() ? print::PageSize::A4
-                                                  : print::PageSize::A3;
-  settings.landscape = landscapeRadio->GetValue();
-  settings.includeGrid = includeGridCheck->GetValue();
-  settings.detailedFootprints = detailedRadio->GetValue();
 }


### PR DESCRIPTION
### Motivation
- Remove the Plan Printing page from Preferences and present print options at the time of printing so the Preferences UI is simpler.
- Provide an explicit warning when the user selects the heavier `Detailed` element detail mode because it produces larger files and takes longer.
- Persist the chosen print options when the user prints so the values survive between runs.
- Ensure sensible defaults for new projects / empty configs: A3, Portrait and Schematic.

### Description
- Removed the Plan Printing tab from `PreferencesDialog` and deleted its related controls and helper methods in `gui/preferencesdialog.*`.
- Added a new `PlanPrintDialog` (`gui/planprintdialog.h` / `gui/planprintdialog.cpp`) that exposes page size, orientation, grid inclusion and element detail, and shows a warning when `Detailed` is selected.
- Updated `MainWindow::OnPrintPlan` to open `PlanPrintDialog`, apply the returned `print::PlanPrintSettings`, save them to the config via `SaveToConfig`, and then proceed to export the PDF using the selected options.
- Changed the default for `print_use_simplified_footprints` in `core/configmanager.cpp` to `1.0f` so the default behavior is schematic (and combined with existing defaults for `print_plan_page_size` and `print_plan_landscape` this yields A3 + Portrait + Schematic for new/empty configs.

### Testing
- No automated tests were executed as part of this change.
- Changes compiled and were committed in the branch (manual compilation/run not recorded here).
- Manual runtime checks (dialog opening and warning) were not recorded by automated test runs.
- No unit tests were added or modified in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948ad1ea17083249a416e77ac7adffd)