### PR TITLE
Remove duplicate MainWindow::OnPrintTable definition

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1471,44 +1471,6 @@ void MainWindow::OnPrintTable(wxCommandEvent &WXUNUSED(event)) {
     TablePrinter::Print(this, ctrl, type);
 }
 
-void MainWindow::OnPrintTable(wxCommandEvent &WXUNUSED(event)) {
-  wxArrayString options;
-  if (fixturePanel)
-    options.Add("Fixtures");
-  if (trussPanel)
-    options.Add("Trusses");
-  if (hoistPanel)
-    options.Add("Hoists");
-  if (sceneObjPanel)
-    options.Add("Objects");
-  if (options.IsEmpty())
-    return;
-
-  wxSingleChoiceDialog dlg(this, "Select table", "Print Table", options);
-  if (dlg.ShowModal() != wxID_OK)
-    return;
-
-  wxString choice = dlg.GetStringSelection();
-  wxDataViewListCtrl *ctrl = nullptr;
-  TablePrinter::TableType type = TablePrinter::TableType::Fixtures;
-  if (choice == "Fixtures" && fixturePanel) {
-    ctrl = fixturePanel->GetTableCtrl();
-    type = TablePrinter::TableType::Fixtures;
-  } else if (choice == "Trusses" && trussPanel) {
-    ctrl = trussPanel->GetTableCtrl();
-    type = TablePrinter::TableType::Trusses;
-  } else if (choice == "Hoists" && hoistPanel) {
-    ctrl = hoistPanel->GetTableCtrl();
-    type = TablePrinter::TableType::Supports;
-  } else if (choice == "Objects" && sceneObjPanel) {
-    ctrl = sceneObjPanel->GetTableCtrl();
-    type = TablePrinter::TableType::SceneObjects;
-  }
-
-  if (ctrl)
-    TablePrinter::Print(this, ctrl, type);
-}
-
 void MainWindow::OnExportCSV(wxCommandEvent &WXUNUSED(event)) {
   wxArrayString options;
   if (fixturePanel)


### PR DESCRIPTION
### Motivation
- Fix compiler error C2084 caused by a duplicate definition of `MainWindow::OnPrintTable`.
- Ensure there is a single handler implementation to avoid redefinition and ODR issues.
- Preserve the existing table-printing behavior while removing redundant code.
- Prevent similar accidental duplication during merges and edits.

### Description
- Removed the duplicated implementation of `MainWindow::OnPrintTable` from `gui/mainwindow.cpp`.
- Deleted the redundant ~38-line block that repeated the same dialog and `TablePrinter::Print` logic.
- Left the original `OnPrintTable` implementation and the adjacent `OnExportCSV` function intact.
- Commit message: `Remove duplicate OnPrintTable definition`.

### Testing
- No automated tests or builds were run after this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948b03b85608324b6135e987545b9c9)