### PR TITLE
Add layout collection module with config persistence

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ file(GLOB_RECURSE SRC_FILES CONFIGURE_DEPENDS
     ${CMAKE_SOURCE_DIR}/gui/*.cpp
     ${CMAKE_SOURCE_DIR}/models/*.cpp
     ${CMAKE_SOURCE_DIR}/core/*.cpp
+    ${CMAKE_SOURCE_DIR}/core/layouts/*.cpp
     ${CMAKE_SOURCE_DIR}/core/print/*.cpp
     ${CMAKE_SOURCE_DIR}/mvr/*.cpp
     ${CMAKE_SOURCE_DIR}/viewer3d/*.cpp
@@ -43,6 +44,7 @@ file(GLOB_RECURSE HEADER_FILES
     ${CMAKE_SOURCE_DIR}/gui/*.h
     ${CMAKE_SOURCE_DIR}/models/*.h
     ${CMAKE_SOURCE_DIR}/core/*.h
+    ${CMAKE_SOURCE_DIR}/core/layouts/*.h
     ${CMAKE_SOURCE_DIR}/core/print/*.h
     ${CMAKE_SOURCE_DIR}/mvr/*.h
     ${CMAKE_SOURCE_DIR}/viewer3d/*.h

--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -17,6 +17,7 @@
  */
 #include "configmanager.h"
 #include "../external/json.hpp"
+#include "layouts/LayoutManager.h"
 #include "mvrexporter.h"
 #include "mvrimporter.h"
 #include <chrono>
@@ -188,6 +189,7 @@ ConfigManager::ConfigManager() {
     SetValue("rider_layer_mode", "position");
   ApplyColumnDefaults();
   ApplyDefaults();
+  layouts::LayoutManager::Get().LoadFromConfig(*this);
   currentLayer = DEFAULT_LAYER_NAME;
 }
 
@@ -555,6 +557,7 @@ bool ConfigManager::LoadFromFile(const std::string &path) {
   }
   ApplyColumnDefaults();
   ApplyDefaults();
+  layouts::LayoutManager::Get().LoadFromConfig(*this);
   return true;
 }
 
@@ -685,6 +688,7 @@ void ConfigManager::Reset() {
   if (!HasKey("rider_autopatch"))
     SetValue("rider_autopatch", "1");
   ApplyDefaults();
+  layouts::LayoutManager::Get().ResetToDefault(*this);
   selectedFixtures.clear();
   selectedTrusses.clear();
   selectedSupports.clear();

--- a/core/layouts/LayoutCollection.cpp
+++ b/core/layouts/LayoutCollection.cpp
@@ -1,0 +1,85 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "LayoutCollection.h"
+
+namespace layouts {
+
+LayoutCollection::LayoutCollection() { layouts.push_back(DefaultLayout()); }
+
+const std::vector<LayoutDefinition> &LayoutCollection::Items() const {
+  return layouts;
+}
+
+std::size_t LayoutCollection::Count() const { return layouts.size(); }
+
+bool LayoutCollection::AddLayout(const LayoutDefinition &layout) {
+  if (layout.name.empty() || NameExists(layout.name))
+    return false;
+  layouts.push_back(layout);
+  return true;
+}
+
+bool LayoutCollection::RenameLayout(const std::string &currentName,
+                                    const std::string &newName) {
+  if (newName.empty())
+    return false;
+  if (NameExists(newName, currentName))
+    return false;
+  for (auto &layout : layouts) {
+    if (layout.name == currentName) {
+      layout.name = newName;
+      return true;
+    }
+  }
+  return false;
+}
+
+bool LayoutCollection::RemoveLayout(const std::string &name) {
+  if (layouts.size() <= 1)
+    return false;
+  for (auto it = layouts.begin(); it != layouts.end(); ++it) {
+    if (it->name == name) {
+      layouts.erase(it);
+      return true;
+    }
+  }
+  return false;
+}
+
+void LayoutCollection::ReplaceAll(std::vector<LayoutDefinition> updated) {
+  if (updated.empty()) {
+    layouts = {DefaultLayout()};
+    return;
+  }
+  layouts = std::move(updated);
+}
+
+LayoutDefinition LayoutCollection::DefaultLayout() {
+  return {"Layout 1", PageSize::A4, false, "viewer2d"};
+}
+
+bool LayoutCollection::NameExists(const std::string &name,
+                                  const std::string &ignoreName) const {
+  for (const auto &layout : layouts) {
+    if (layout.name == name && layout.name != ignoreName)
+      return true;
+  }
+  return false;
+}
+
+} // namespace layouts

--- a/core/layouts/LayoutCollection.h
+++ b/core/layouts/LayoutCollection.h
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace layouts {
+
+enum class PageSize { A3 = 0, A4 = 1 };
+
+struct LayoutDefinition {
+  std::string name;
+  PageSize pageSize = PageSize::A4;
+  bool landscape = false;
+  std::string viewId;
+};
+
+class LayoutCollection {
+public:
+  LayoutCollection();
+
+  const std::vector<LayoutDefinition> &Items() const;
+  std::size_t Count() const;
+
+  bool AddLayout(const LayoutDefinition &layout);
+  bool RenameLayout(const std::string &currentName,
+                    const std::string &newName);
+  bool RemoveLayout(const std::string &name);
+
+  void ReplaceAll(std::vector<LayoutDefinition> layouts);
+
+private:
+  static LayoutDefinition DefaultLayout();
+  bool NameExists(const std::string &name,
+                  const std::string &ignoreName = {}) const;
+
+  std::vector<LayoutDefinition> layouts;
+};
+
+} // namespace layouts

--- a/core/layouts/LayoutManager.cpp
+++ b/core/layouts/LayoutManager.cpp
@@ -1,0 +1,160 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "LayoutManager.h"
+
+#include "../configmanager.h"
+#include "../../external/json.hpp"
+
+namespace layouts {
+namespace {
+constexpr const char *kLayoutsConfigKey = "layouts_collection";
+
+std::string PageSizeToString(PageSize size) {
+  switch (size) {
+  case PageSize::A3:
+    return "A3";
+  case PageSize::A4:
+  default:
+    return "A4";
+  }
+}
+
+PageSize PageSizeFromString(const std::string &value) {
+  if (value == "A3")
+    return PageSize::A3;
+  return PageSize::A4;
+}
+
+nlohmann::json ToJson(const LayoutDefinition &layout) {
+  return nlohmann::json{{"name", layout.name},
+                        {"pageSize", PageSizeToString(layout.pageSize)},
+                        {"landscape", layout.landscape},
+                        {"viewId", layout.viewId}};
+}
+
+bool ParseLayout(const nlohmann::json &value, LayoutDefinition &out) {
+  if (!value.is_object())
+    return false;
+  const auto nameIt = value.find("name");
+  if (nameIt == value.end() || !nameIt->is_string())
+    return false;
+  out.name = nameIt->get<std::string>();
+  if (out.name.empty())
+    return false;
+
+  const auto sizeIt = value.find("pageSize");
+  if (sizeIt != value.end() && sizeIt->is_string())
+    out.pageSize = PageSizeFromString(sizeIt->get<std::string>());
+  else
+    out.pageSize = PageSize::A4;
+
+  const auto landscapeIt = value.find("landscape");
+  out.landscape =
+      landscapeIt != value.end() && landscapeIt->is_boolean()
+          ? landscapeIt->get<bool>()
+          : false;
+
+  const auto viewIdIt = value.find("viewId");
+  out.viewId = viewIdIt != value.end() && viewIdIt->is_string()
+                   ? viewIdIt->get<std::string>()
+                   : std::string{};
+  return true;
+}
+} // namespace
+
+LayoutManager::LayoutManager() = default;
+
+LayoutManager &LayoutManager::Get() {
+  static LayoutManager instance;
+  return instance;
+}
+
+const LayoutCollection &LayoutManager::GetLayouts() const { return layouts; }
+
+bool LayoutManager::AddLayout(const LayoutDefinition &layout) {
+  if (!layouts.AddLayout(layout))
+    return false;
+  SyncToConfig();
+  return true;
+}
+
+bool LayoutManager::RenameLayout(const std::string &currentName,
+                                 const std::string &newName) {
+  if (!layouts.RenameLayout(currentName, newName))
+    return false;
+  SyncToConfig();
+  return true;
+}
+
+bool LayoutManager::RemoveLayout(const std::string &name) {
+  if (!layouts.RemoveLayout(name))
+    return false;
+  SyncToConfig();
+  return true;
+}
+
+void LayoutManager::LoadFromConfig(ConfigManager &cfg) {
+  auto value = cfg.GetValue(kLayoutsConfigKey);
+  if (!value.has_value()) {
+    SaveToConfig(cfg);
+    return;
+  }
+  nlohmann::json parsed;
+  try {
+    parsed = nlohmann::json::parse(*value);
+  } catch (...) {
+    return;
+  }
+  if (!parsed.is_array())
+    return;
+
+  std::vector<LayoutDefinition> loaded;
+  for (const auto &entry : parsed) {
+    LayoutDefinition layout;
+    if (!ParseLayout(entry, layout))
+      continue;
+    bool duplicate = false;
+    for (const auto &existing : loaded) {
+      if (existing.name == layout.name) {
+        duplicate = true;
+        break;
+      }
+    }
+    if (duplicate)
+      continue;
+    loaded.push_back(std::move(layout));
+  }
+
+  layouts.ReplaceAll(std::move(loaded));
+}
+
+void LayoutManager::SaveToConfig(ConfigManager &cfg) const {
+  nlohmann::json data = nlohmann::json::array();
+  for (const auto &layout : layouts.Items())
+    data.push_back(ToJson(layout));
+  cfg.SetValue(kLayoutsConfigKey, data.dump());
+}
+
+void LayoutManager::ResetToDefault(ConfigManager &cfg) {
+  layouts = LayoutCollection();
+  SaveToConfig(cfg);
+}
+
+void LayoutManager::SyncToConfig() { SaveToConfig(ConfigManager::Get()); }
+
+} // namespace layouts

--- a/core/layouts/LayoutManager.h
+++ b/core/layouts/LayoutManager.h
@@ -1,0 +1,48 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "LayoutCollection.h"
+
+class ConfigManager;
+
+namespace layouts {
+
+class LayoutManager {
+public:
+  static LayoutManager &Get();
+
+  const LayoutCollection &GetLayouts() const;
+
+  bool AddLayout(const LayoutDefinition &layout);
+  bool RenameLayout(const std::string &currentName,
+                    const std::string &newName);
+  bool RemoveLayout(const std::string &name);
+
+  void LoadFromConfig(ConfigManager &cfg);
+  void SaveToConfig(ConfigManager &cfg) const;
+  void ResetToDefault(ConfigManager &cfg);
+
+private:
+  LayoutManager();
+  void SyncToConfig();
+
+  LayoutCollection layouts;
+};
+
+} // namespace layouts


### PR DESCRIPTION
### Motivation

- Provide a UI-agnostic representation for printable layouts (name, A3/A4 size, orientation, associated view id) and ensure the app always has at least one layout.
- Expose a simple API so the UI can add/rename/remove layouts without knowing the persistence layer.
- Persist user/project layout lists in the existing configuration storage so layouts survive save/load.
- Integrate layout lifecycle with global configuration resets and project loading.

### Description

- Added a new `core/layouts` module containing `LayoutDefinition`, `LayoutCollection` (with `AddLayout`, `RenameLayout`, `RemoveLayout`, `ReplaceAll`) and validation that prevents empty or duplicate names and disallows removing the last layout.
- Implemented a `LayoutManager` singleton API (`GetLayouts`, `AddLayout`, `RenameLayout`, `RemoveLayout`, `LoadFromConfig`, `SaveToConfig`, `ResetToDefault`) that serializes layouts to JSON and stores them in the config key `layouts_collection`.
- Integrated with `ConfigManager` so layouts are loaded after user/project config is applied and `LayoutManager::ResetToDefault` is invoked from `ConfigManager::Reset()`; loading will write a default value if the key is missing.
- Updated `CMakeLists.txt` to include the new `core/layouts` sources and headers.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69494059b8f08324adc5e1b24b27a036)