### PR TITLE
Rename Layout menu to "Layout Views" and update 2D/3D item labels

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -497,9 +497,9 @@ void MainWindow::CreateMenuBar() {
   viewMenu->AppendCheckItem(ID_View_ToggleRigging, "Rigging");
 
   wxMenu *layoutMenu = new wxMenu();
-  layoutMenu->Append(ID_View_Layout_Default, "3D Layout");
-  layoutMenu->Append(ID_View_Layout_2D, "2D Layout");
-  viewMenu->AppendSubMenu(layoutMenu, "Layout");
+  layoutMenu->Append(ID_View_Layout_Default, "3D Layout View");
+  layoutMenu->Append(ID_View_Layout_2D, "2D Layout View");
+  viewMenu->AppendSubMenu(layoutMenu, "Layout Views");
 
   menuBar->Append(viewMenu, "&View");
 


### PR DESCRIPTION
### Motivation
- Make the View menu wording clearer by explicitly indicating these entries control layout views rather than other layout concepts.
- Standardize the labels for the 2D and 3D layout menu items to include the word "View" for clarity.
- Keep the change limited to UI text so there is no change in behavior.

### Description
- Updated the menu labels in `gui/mainwindow.cpp` to rename the submenu from `"Layout"` to `"Layout Views"` and the entries from `"3D Layout"`/`"2D Layout"` to `"3D Layout View"`/`"2D Layout View"`.
- This is a purely textual UI change and does not modify any program logic or event handlers.
- Only `gui/mainwindow.cpp` was modified.

### Testing
- No automated tests were run for this change.
- No compilation or CI runs were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694942bc6bc4832483d1140ea8080c3b)