### PR TITLE
Introduce shared `PageSetup` and reuse in layouts and print settings

### DIFF
--- a/core/layouts/LayoutCollection.cpp
+++ b/core/layouts/LayoutCollection.cpp
@@ -70,7 +70,12 @@ void LayoutCollection::ReplaceAll(std::vector<LayoutDefinition> updated) {
 }
 
 LayoutDefinition LayoutCollection::DefaultLayout() {
-  return {"Layout 1", PageSize::A4, false, "viewer2d"};
+  LayoutDefinition layout;
+  layout.name = "Layout 1";
+  layout.pageSetup.pageSize = print::PageSize::A4;
+  layout.pageSetup.landscape = false;
+  layout.viewId = "viewer2d";
+  return layout;
 }
 
 bool LayoutCollection::NameExists(const std::string &name,

--- a/core/layouts/LayoutCollection.h
+++ b/core/layouts/LayoutCollection.h
@@ -20,14 +20,13 @@
 #include <string>
 #include <vector>
 
-namespace layouts {
+#include "../print/PageSetup.h"
 
-enum class PageSize { A3 = 0, A4 = 1 };
+namespace layouts {
 
 struct LayoutDefinition {
   std::string name;
-  PageSize pageSize = PageSize::A4;
-  bool landscape = false;
+  print::PageSetup pageSetup;
   std::string viewId;
 };
 

--- a/core/layouts/LayoutManager.cpp
+++ b/core/layouts/LayoutManager.cpp
@@ -24,26 +24,26 @@ namespace layouts {
 namespace {
 constexpr const char *kLayoutsConfigKey = "layouts_collection";
 
-std::string PageSizeToString(PageSize size) {
+std::string PageSizeToString(print::PageSize size) {
   switch (size) {
-  case PageSize::A3:
+  case print::PageSize::A3:
     return "A3";
-  case PageSize::A4:
+  case print::PageSize::A4:
   default:
     return "A4";
   }
 }
 
-PageSize PageSizeFromString(const std::string &value) {
+print::PageSize PageSizeFromString(const std::string &value) {
   if (value == "A3")
-    return PageSize::A3;
-  return PageSize::A4;
+    return print::PageSize::A3;
+  return print::PageSize::A4;
 }
 
 nlohmann::json ToJson(const LayoutDefinition &layout) {
   return nlohmann::json{{"name", layout.name},
-                        {"pageSize", PageSizeToString(layout.pageSize)},
-                        {"landscape", layout.landscape},
+                        {"pageSize", PageSizeToString(layout.pageSetup.pageSize)},
+                        {"landscape", layout.pageSetup.landscape},
                         {"viewId", layout.viewId}};
 }
 
@@ -59,12 +59,12 @@ bool ParseLayout(const nlohmann::json &value, LayoutDefinition &out) {
 
   const auto sizeIt = value.find("pageSize");
   if (sizeIt != value.end() && sizeIt->is_string())
-    out.pageSize = PageSizeFromString(sizeIt->get<std::string>());
+    out.pageSetup.pageSize = PageSizeFromString(sizeIt->get<std::string>());
   else
-    out.pageSize = PageSize::A4;
+    out.pageSetup.pageSize = print::PageSize::A4;
 
   const auto landscapeIt = value.find("landscape");
-  out.landscape =
+  out.pageSetup.landscape =
       landscapeIt != value.end() && landscapeIt->is_boolean()
           ? landscapeIt->get<bool>()
           : false;

--- a/core/print/PageSetup.cpp
+++ b/core/print/PageSetup.cpp
@@ -15,21 +15,34 @@
  * You should have received a copy of the GNU General Public License
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
-#pragma once
-
 #include "PageSetup.h"
 
-class ConfigManager;
+namespace {
+constexpr double kMmToPoints = 72.0 / 25.4;
+} // namespace
 
 namespace print {
 
-struct Viewer2DPrintSettings : public PageSetup {
-  Viewer2DPrintSettings() { pageSize = PageSize::A3; }
-  bool includeGrid = true;
-  bool detailedFootprints = false;
+std::pair<double, double> PageSetup::BasePageSizeMm() const {
+  switch (pageSize) {
+  case PageSize::A4:
+    return {210.0, 297.0};
+  case PageSize::A3:
+  default:
+    return {297.0, 420.0};
+  }
+}
 
-  static Viewer2DPrintSettings LoadFromConfig(ConfigManager &cfg);
-  void SaveToConfig(ConfigManager &cfg) const;
-};
+double PageSetup::PageWidthPt() const {
+  auto [portraitW, portraitH] = BasePageSizeMm();
+  const double mm = landscape ? portraitH : portraitW;
+  return mm * kMmToPoints;
+}
+
+double PageSetup::PageHeightPt() const {
+  auto [portraitW, portraitH] = BasePageSizeMm();
+  const double mm = landscape ? portraitW : portraitH;
+  return mm * kMmToPoints;
+}
 
 } // namespace print

--- a/core/print/PageSetup.h
+++ b/core/print/PageSetup.h
@@ -17,19 +17,21 @@
  */
 #pragma once
 
-#include "PageSetup.h"
-
-class ConfigManager;
+#include <utility>
 
 namespace print {
 
-struct Viewer2DPrintSettings : public PageSetup {
-  Viewer2DPrintSettings() { pageSize = PageSize::A3; }
-  bool includeGrid = true;
-  bool detailedFootprints = false;
+enum class PageSize { A3 = 0, A4 = 1 };
 
-  static Viewer2DPrintSettings LoadFromConfig(ConfigManager &cfg);
-  void SaveToConfig(ConfigManager &cfg) const;
+struct PageSetup {
+  PageSize pageSize = PageSize::A4;
+  bool landscape = false;
+
+  double PageWidthPt() const;
+  double PageHeightPt() const;
+
+private:
+  std::pair<double, double> BasePageSizeMm() const;
 };
 
 } // namespace print

--- a/core/print/Viewer2DPrintSettings.cpp
+++ b/core/print/Viewer2DPrintSettings.cpp
@@ -19,10 +19,6 @@
 
 #include "configmanager.h"
 
-namespace {
-constexpr double kMmToPoints = 72.0 / 25.4;
-} // namespace
-
 namespace print {
 
 Viewer2DPrintSettings Viewer2DPrintSettings::LoadFromConfig(
@@ -45,28 +41,6 @@ void Viewer2DPrintSettings::SaveToConfig(ConfigManager &cfg) const {
   cfg.SetFloat("print_include_grid", includeGrid ? 1.0f : 0.0f);
   cfg.SetFloat("print_use_simplified_footprints",
                detailedFootprints ? 0.0f : 1.0f);
-}
-
-std::pair<double, double> Viewer2DPrintSettings::BasePageSizeMm() const {
-  switch (pageSize) {
-  case PageSize::A4:
-    return {210.0, 297.0};
-  case PageSize::A3:
-  default:
-    return {297.0, 420.0};
-  }
-}
-
-double Viewer2DPrintSettings::PageWidthPt() const {
-  auto [portraitW, portraitH] = BasePageSizeMm();
-  const double mm = landscape ? portraitH : portraitW;
-  return mm * kMmToPoints;
-}
-
-double Viewer2DPrintSettings::PageHeightPt() const {
-  auto [portraitW, portraitH] = BasePageSizeMm();
-  const double mm = landscape ? portraitW : portraitH;
-  return mm * kMmToPoints;
 }
 
 } // namespace print


### PR DESCRIPTION
### Motivation
- Centralize page size/orientation conversion and defaults to avoid duplicated logic across printing and layout code.
- Prevent adding redundant configuration keys by having layouts reference the same page setup structure used by the viewer print settings.

### Description
- Add a new `PageSetup` type in `core/print/PageSetup.h`/`PageSetup.cpp` containing `pageSize`, `landscape` and the `PageWidthPt`/`PageHeightPt` helpers.
- Make `Viewer2DPrintSettings` inherit from `print::PageSetup` and remove its local page-size conversion helpers, while retaining the previous default of `A3` for the viewer settings.
- Replace `LayoutDefinition` fields `pageSize` and `landscape` with a `print::PageSetup pageSetup` member and update `LayoutManager` serialization/parsing to read/write `pageSize` and `landscape` from `pageSetup`.
- Update `LayoutCollection::DefaultLayout` to initialize the new `pageSetup` member and preserve the `viewId` default of `"viewer2d"`.

### Testing
- No automated tests were executed as part of this change.
- Repository build or unit test runs were not performed in this rollout.
- Manual compilation was not reported in the change log.
- Configuration key `layouts_collection` and existing JSON schema for `pageSize`/`landscape` are preserved by the updated serializer.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69494396f5b883249a4f666eb0a0b83f)