### PR TITLE
Add Layouts panel and wire layout selection to activate 2D/3D views

### DIFF
--- a/gui/layoutpanel.cpp
+++ b/gui/layoutpanel.cpp
@@ -1,0 +1,232 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "layoutpanel.h"
+
+#include "columnutils.h"
+#include "layouts/LayoutManager.h"
+#include <wx/choicdlg.h>
+
+namespace {
+std::string LayoutViewLabel(const std::string &viewId) {
+  if (viewId == "viewer2d")
+    return "2D View";
+  if (viewId == "viewer3d")
+    return "3D View";
+  return viewId;
+}
+
+std::string ChoiceToViewId(int selection) {
+  if (selection == 1)
+    return "viewer3d";
+  return "viewer2d";
+}
+} // namespace
+
+LayoutPanel *LayoutPanel::s_instance = nullptr;
+wxDEFINE_EVENT(EVT_LAYOUT_SELECTED, wxCommandEvent);
+
+LayoutPanel::LayoutPanel(wxWindow *parent) : wxPanel(parent, wxID_ANY) {
+  list = new wxDataViewListCtrl(this, wxID_ANY);
+  list->AppendTextColumn("Layout");
+  list->AppendTextColumn("View");
+  ColumnUtils::EnforceMinColumnWidth(list);
+
+  wxBoxSizer *sizer = new wxBoxSizer(wxVERTICAL);
+  sizer->Add(list, 1, wxEXPAND | wxALL, 5);
+
+  wxBoxSizer *btnSizer = new wxBoxSizer(wxHORIZONTAL);
+  auto *addBtn = new wxButton(this, wxID_ADD, "Add");
+  auto *renameBtn = new wxButton(this, wxID_EDIT, "Rename");
+  auto *delBtn = new wxButton(this, wxID_DELETE, "Delete");
+  btnSizer->Add(addBtn, 0, wxALL, 5);
+  btnSizer->Add(renameBtn, 0, wxALL, 5);
+  btnSizer->Add(delBtn, 0, wxALL, 5);
+  sizer->Add(btnSizer, 0, wxALIGN_LEFT);
+
+  SetSizer(sizer);
+
+  list->Bind(wxEVT_DATAVIEW_SELECTION_CHANGED, &LayoutPanel::OnSelect, this);
+  list->Bind(wxEVT_DATAVIEW_ITEM_ACTIVATED, &LayoutPanel::OnRenameLayout, this);
+  addBtn->Bind(wxEVT_BUTTON, &LayoutPanel::OnAddLayout, this);
+  renameBtn->Bind(wxEVT_BUTTON, &LayoutPanel::OnRenameLayout, this);
+  delBtn->Bind(wxEVT_BUTTON, &LayoutPanel::OnDeleteLayout, this);
+
+  ReloadLayouts();
+}
+
+LayoutPanel *LayoutPanel::Instance() { return s_instance; }
+
+void LayoutPanel::SetInstance(LayoutPanel *p) { s_instance = p; }
+
+void LayoutPanel::ReloadLayouts() {
+  if (!list)
+    return;
+
+  list->DeleteAllItems();
+
+  const auto &layouts = layouts::LayoutManager::Get().GetLayouts().Items();
+  int selectedRow = -1;
+  int row = 0;
+  for (const auto &layout : layouts) {
+    wxVector<wxVariant> cols;
+    cols.push_back(wxVariant(wxString::FromUTF8(layout.name)));
+    cols.push_back(wxVariant(wxString::FromUTF8(LayoutViewLabel(layout.viewId))));
+    list->AppendItem(cols);
+    if (!currentLayout.empty() && layout.name == currentLayout)
+      selectedRow = row;
+    ++row;
+  }
+
+  if (selectedRow < 0 && list->GetItemCount() > 0)
+    selectedRow = 0;
+
+  if (selectedRow >= 0) {
+    list->SelectRow(selectedRow);
+    wxString name = list->GetTextValue(selectedRow, 0);
+    currentLayout = name.ToStdString();
+    for (const auto &layout : layouts) {
+      if (layout.name == currentLayout) {
+        EmitLayoutSelected(layout.viewId);
+        break;
+      }
+    }
+  }
+}
+
+void LayoutPanel::OnSelect(wxDataViewEvent &evt) {
+  unsigned int idx = list->ItemToRow(evt.GetItem());
+  if (idx == wxNOT_FOUND)
+    return;
+  wxString name = list->GetTextValue(idx, 0);
+  currentLayout = name.ToStdString();
+  const auto &layouts = layouts::LayoutManager::Get().GetLayouts().Items();
+  for (const auto &layout : layouts) {
+    if (layout.name == currentLayout) {
+      EmitLayoutSelected(layout.viewId);
+      break;
+    }
+  }
+}
+
+void LayoutPanel::OnAddLayout(wxCommandEvent &) {
+  wxTextEntryDialog nameDlg(this, "Enter new layout name:", "Add Layout");
+  if (nameDlg.ShowModal() != wxID_OK)
+    return;
+  std::string name = nameDlg.GetValue().ToStdString();
+  if (name.empty())
+    return;
+
+  const auto &items = layouts::LayoutManager::Get().GetLayouts().Items();
+  for (const auto &layout : items) {
+    if (layout.name == name) {
+      wxMessageBox("Layout already exists.", "Add Layout",
+                   wxOK | wxICON_ERROR, this);
+      return;
+    }
+  }
+
+  wxArrayString choices;
+  choices.Add("2D View");
+  choices.Add("3D View");
+  wxSingleChoiceDialog viewDlg(this, "Select layout view:", "Layout View",
+                               choices);
+  viewDlg.SetSelection(0);
+  if (viewDlg.ShowModal() != wxID_OK)
+    return;
+
+  layouts::LayoutDefinition layout;
+  layout.name = name;
+  layout.pageSetup.pageSize = print::PageSize::A4;
+  layout.pageSetup.landscape = false;
+  layout.viewId = ChoiceToViewId(viewDlg.GetSelection());
+
+  if (!layouts::LayoutManager::Get().AddLayout(layout)) {
+    wxMessageBox("Could not add layout.", "Add Layout", wxOK | wxICON_ERROR,
+                 this);
+    return;
+  }
+
+  currentLayout = name;
+  ReloadLayouts();
+}
+
+void LayoutPanel::OnRenameLayout(wxCommandEvent &) {
+  if (!list)
+    return;
+  int sel = list->GetSelectedRow();
+  if (sel == wxNOT_FOUND)
+    return;
+
+  wxString currentName = list->GetTextValue(sel, 0);
+  wxTextEntryDialog dlg(this, "Enter new layout name:", "Rename Layout",
+                        currentName);
+  if (dlg.ShowModal() != wxID_OK)
+    return;
+
+  std::string newName = dlg.GetValue().ToStdString();
+  std::string oldName = currentName.ToStdString();
+  if (newName.empty() || newName == oldName)
+    return;
+
+  if (!layouts::LayoutManager::Get().RenameLayout(oldName, newName)) {
+    wxMessageBox("Layout name is not available.", "Rename Layout",
+                 wxOK | wxICON_ERROR, this);
+    return;
+  }
+
+  currentLayout = newName;
+  ReloadLayouts();
+}
+
+void LayoutPanel::OnDeleteLayout(wxCommandEvent &) {
+  if (!list)
+    return;
+  int sel = list->GetSelectedRow();
+  if (sel == wxNOT_FOUND)
+    return;
+
+  if (layouts::LayoutManager::Get().GetLayouts().Count() <= 1) {
+    wxMessageBox("Cannot delete the last layout.", "Delete Layout",
+                 wxOK | wxICON_ERROR, this);
+    return;
+  }
+
+  wxString name = list->GetTextValue(sel, 0);
+  std::string layoutName = name.ToStdString();
+  if (!layouts::LayoutManager::Get().RemoveLayout(layoutName)) {
+    wxMessageBox("Could not delete layout.", "Delete Layout",
+                 wxOK | wxICON_ERROR, this);
+    return;
+  }
+
+  if (layoutName == currentLayout)
+    currentLayout.clear();
+  ReloadLayouts();
+}
+
+void LayoutPanel::EmitLayoutSelected(const std::string &viewId) {
+  if (viewId.empty())
+    return;
+  wxCommandEvent event(EVT_LAYOUT_SELECTED);
+  event.SetEventObject(this);
+  event.SetString(wxString::FromUTF8(viewId));
+  if (GetParent())
+    wxPostEvent(GetParent(), event);
+  else
+    wxPostEvent(this, event);
+}

--- a/gui/layoutpanel.h
+++ b/gui/layoutpanel.h
@@ -1,0 +1,44 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <wx/dataview.h>
+#include <wx/wx.h>
+
+wxDECLARE_EVENT(EVT_LAYOUT_SELECTED, wxCommandEvent);
+
+class LayoutPanel : public wxPanel {
+public:
+  explicit LayoutPanel(wxWindow *parent);
+  void ReloadLayouts();
+
+  static LayoutPanel *Instance();
+  static void SetInstance(LayoutPanel *p);
+
+private:
+  void OnSelect(wxDataViewEvent &evt);
+  void OnAddLayout(wxCommandEvent &evt);
+  void OnRenameLayout(wxCommandEvent &evt);
+  void OnDeleteLayout(wxCommandEvent &evt);
+  void EmitLayoutSelected(const std::string &viewId);
+
+  wxDataViewListCtrl *list = nullptr;
+  std::string currentLayout;
+
+  static LayoutPanel *s_instance;
+};

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -34,6 +34,7 @@ class Viewer2DPanel;
 class Viewer2DRenderPanel;
 class ConsolePanel;
 class LayerPanel;
+class LayoutPanel;
 class SummaryPanel;
 class RiggingPanel;
 
@@ -71,6 +72,7 @@ private:
   Viewer2DRenderPanel *viewport2DRenderPanel = nullptr;
   ConsolePanel *consolePanel = nullptr;
   LayerPanel *layerPanel = nullptr;
+  LayoutPanel *layoutPanel = nullptr;
   SummaryPanel *summaryPanel = nullptr;
   RiggingPanel *riggingPanel = nullptr;
 
@@ -105,6 +107,7 @@ private:
   void OnToggleViewport2D(wxCommandEvent &event);     // Toggle 2D viewport
   void OnToggleRender2D(wxCommandEvent &event);       // Toggle 2D render panel
   void OnToggleLayers(wxCommandEvent &event);         // Toggle layer panel
+  void OnToggleLayouts(wxCommandEvent &event);        // Toggle layout panel
   void OnToggleSummary(wxCommandEvent &event);        // Toggle summary panel
   void OnToggleRigging(wxCommandEvent &event);        // Toggle rigging panel
   void OnShowHelp(wxCommandEvent &event);             // Show help dialog
@@ -133,6 +136,8 @@ private:
   void SaveCameraSettings();
   void ApplySavedLayout();
   void UpdateViewMenuChecks();
+  void OnLayoutSelected(wxCommandEvent &event);
+  void ActivateLayoutView(const std::string &viewId);
   void SyncSceneData();
   bool ConfirmSaveIfDirty(const wxString &actionLabel,
                           const wxString &dialogTitle);
@@ -162,6 +167,7 @@ enum {
   ID_View_ToggleViewport2D,
   ID_View_ToggleRender2D,
   ID_View_ToggleLayers,
+  ID_View_ToggleLayouts,
   ID_View_ToggleSummary,
   ID_View_ToggleRigging,
   ID_View_Layout_Default,


### PR DESCRIPTION
### Motivation
- Provide a GUI panel to list and manage saved layouts (create/rename/delete) and avoid calling `ConfigManager` directly for these operations. 
- Ensure UI validation prevents removing the last remaining layout. 
- Allow choosing a layout to activate the corresponding view (2D or 3D) so layout selection drives the main view. 
- Expose the new panel in the View menu and keep visibility state synchronized.

### Description
- Added `gui/layoutpanel.h` and `gui/layoutpanel.cpp` implementing a `LayoutPanel` that lists layouts and calls `layouts::LayoutManager` to `AddLayout`, `RenameLayout`, and `RemoveLayout` and emits `EVT_LAYOUT_SELECTED` on selection. 
- Integrated the panel into `MainWindow` by adding a `layoutPanel` member, wiring a `ID_View_ToggleLayouts` menu item, adding `OnToggleLayouts`, registering `EVT_LAYOUT_SELECTED`, and calling `layoutPanel->ReloadLayouts()` during setup. 
- Implemented `MainWindow::OnLayoutSelected` and `MainWindow::ActivateLayoutView` to ensure selecting a layout shows and refreshes the appropriate `2D` or `3D` panes (calls `Ensure2DViewport`/`Ensure3DViewport` and shows the panes). 
- Added UI validation to prevent deleting the last layout (`LayoutManager::Get().GetLayouts().Count() <= 1`) and show error dialogs when operations are invalid or fail.

### Testing
- No automated tests were executed for this change.
- The new sources were added and code was committed successfully to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69494502204083249ec21e5fcb5e9f57)