### PR TITLE
Refactor layout selection: remove `viewId`, apply layout-mode perspective

### DIFF
--- a/core/layouts/LayoutCollection.cpp
+++ b/core/layouts/LayoutCollection.cpp
@@ -74,7 +74,6 @@ LayoutDefinition LayoutCollection::DefaultLayout() {
   layout.name = "Layout 1";
   layout.pageSetup.pageSize = print::PageSize::A4;
   layout.pageSetup.landscape = false;
-  layout.viewId = "viewer2d";
   return layout;
 }
 

--- a/core/layouts/LayoutCollection.h
+++ b/core/layouts/LayoutCollection.h
@@ -27,7 +27,6 @@ namespace layouts {
 struct LayoutDefinition {
   std::string name;
   print::PageSetup pageSetup;
-  std::string viewId;
 };
 
 class LayoutCollection {

--- a/core/layouts/LayoutManager.cpp
+++ b/core/layouts/LayoutManager.cpp
@@ -43,8 +43,7 @@ print::PageSize PageSizeFromString(const std::string &value) {
 nlohmann::json ToJson(const LayoutDefinition &layout) {
   return nlohmann::json{{"name", layout.name},
                         {"pageSize", PageSizeToString(layout.pageSetup.pageSize)},
-                        {"landscape", layout.pageSetup.landscape},
-                        {"viewId", layout.viewId}};
+                        {"landscape", layout.pageSetup.landscape}};
 }
 
 bool ParseLayout(const nlohmann::json &value, LayoutDefinition &out) {
@@ -69,10 +68,6 @@ bool ParseLayout(const nlohmann::json &value, LayoutDefinition &out) {
           ? landscapeIt->get<bool>()
           : false;
 
-  const auto viewIdIt = value.find("viewId");
-  out.viewId = viewIdIt != value.end() && viewIdIt->is_string()
-                   ? viewIdIt->get<std::string>()
-                   : std::string{};
   return true;
 }
 } // namespace

--- a/gui/layoutpanel.h
+++ b/gui/layoutpanel.h
@@ -35,7 +35,7 @@ private:
   void OnAddLayout(wxCommandEvent &evt);
   void OnRenameLayout(wxCommandEvent &evt);
   void OnDeleteLayout(wxCommandEvent &evt);
-  void EmitLayoutSelected(const std::string &viewId);
+  void EmitLayoutSelected(const std::string &layoutName);
 
   wxDataViewListCtrl *list = nullptr;
   std::string currentLayout;

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1885,31 +1885,16 @@ void MainWindow::OnLayoutSelected(wxCommandEvent &event) {
   ActivateLayoutView(event.GetString().ToStdString());
 }
 
-void MainWindow::ActivateLayoutView(const std::string &viewId) {
-  if (!auiManager)
+void MainWindow::ActivateLayoutView(const std::string &layoutName) {
+  if (!auiManager || layoutName.empty())
     return;
 
-  if (viewId == "viewer2d") {
-    Ensure2DViewport();
-    auto &pane2d = auiManager->GetPane("2DViewport");
-    if (pane2d.IsOk())
-      pane2d.Show();
-    auto &renderPane = auiManager->GetPane("2DRenderOptions");
-    if (renderPane.IsOk())
-      renderPane.Show();
-    auiManager->Update();
-    if (pane2d.IsShown() && Viewer2DPanel::Instance())
-      Viewer2DPanel::Instance()->Refresh();
-  } else if (viewId == "viewer3d") {
-    Ensure3DViewport();
-    auto &pane3d = auiManager->GetPane("3DViewport");
-    if (pane3d.IsOk())
-      pane3d.Show();
-    auiManager->Update();
-    if (pane3d.IsShown() && Viewer3DPanel::Instance())
-      Viewer3DPanel::Instance()->Refresh();
-  }
+  Ensure2DViewport();
+  auiManager->LoadPerspective(default2DLayoutPerspective, true);
+  auiManager->Update();
 
+  ConfigManager::Get().SetValue("layout_perspective",
+                                default2DLayoutPerspective);
   UpdateViewMenuChecks();
 }
 

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -137,7 +137,7 @@ private:
   void ApplySavedLayout();
   void UpdateViewMenuChecks();
   void OnLayoutSelected(wxCommandEvent &event);
-  void ActivateLayoutView(const std::string &viewId);
+  void ActivateLayoutView(const std::string &layoutName);
   void SyncSceneData();
   bool ConfirmSaveIfDirty(const wxString &actionLabel,
                           const wxString &dialogTitle);


### PR DESCRIPTION
### Motivation
- Stop using `viewId` as a viewer selector and treat layouts only as an active layout choice.
- Prevent layout selection from directly showing/hiding `2DViewport`/`3DViewport` and move to a single "layout mode" activation.
- Simplify layout storage and serialization by removing the per-layout viewer selector.
- Make `ActivateLayoutView` apply the saved layout perspective instead of toggling viewer panes.

### Description
- Removed the `viewId` field from `LayoutDefinition` and from `core/layouts/LayoutCollection.h` and its default value in `LayoutCollection::DefaultLayout()`.
- Stopped serializing/parsing `viewId` in `core/layouts/LayoutManager.cpp` so layout JSON no longer contains a viewer selector.
- Simplified the layouts UI in `gui/layoutpanel.cpp` by removing the `View` column and the 2D/3D choice when creating layouts, and changed the event payload to emit the selected layout name instead of a `viewId`.
- Reworked `MainWindow::ActivateLayoutView` (and related declarations) to accept a layout name and to activate the layout mode by ensuring the 2D viewport exists and loading `default2DLayoutPerspective`, and to set the `layout_perspective` config value rather than toggling specific viewport panes.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69496c03e62083249aa42d48d8a1e4d9)