### PR TITLE
Add LayoutViewerPanel: centered A4/A3 paper preview with pan/zoom and AUI integration

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1,0 +1,161 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "layoutviewerpanel.h"
+
+#include <algorithm>
+#include <cmath>
+#include <wx/dcbuffer.h>
+
+namespace {
+constexpr double kMinZoom = 0.1;
+constexpr double kMaxZoom = 10.0;
+constexpr double kZoomStep = 1.1;
+constexpr int kFitMarginPx = 40;
+}
+
+wxBEGIN_EVENT_TABLE(LayoutViewerPanel, wxPanel)
+    EVT_PAINT(LayoutViewerPanel::OnPaint)
+    EVT_SIZE(LayoutViewerPanel::OnSize)
+    EVT_LEFT_DOWN(LayoutViewerPanel::OnLeftDown)
+    EVT_LEFT_UP(LayoutViewerPanel::OnLeftUp)
+    EVT_MOTION(LayoutViewerPanel::OnMouseMove)
+    EVT_MOUSEWHEEL(LayoutViewerPanel::OnMouseWheel)
+    EVT_MOUSE_CAPTURE_LOST(LayoutViewerPanel::OnCaptureLost)
+wxEND_EVENT_TABLE()
+
+LayoutViewerPanel::LayoutViewerPanel(wxWindow *parent)
+    : wxPanel(parent, wxID_ANY) {
+  SetBackgroundStyle(wxBG_STYLE_PAINT);
+  currentLayout.pageSetup.pageSize = print::PageSize::A4;
+  currentLayout.pageSetup.landscape = false;
+  ResetViewToFit();
+}
+
+void LayoutViewerPanel::SetLayoutDefinition(
+    const layouts::LayoutDefinition &layout) {
+  currentLayout = layout;
+  ResetViewToFit();
+  Refresh();
+}
+
+void LayoutViewerPanel::OnPaint(wxPaintEvent &) {
+  wxAutoBufferedPaintDC dc(this);
+  dc.Clear();
+
+  wxSize size = GetClientSize();
+  dc.SetBrush(wxBrush(wxColour(90, 90, 90)));
+  dc.SetPen(*wxTRANSPARENT_PEN);
+  dc.DrawRectangle(0, 0, size.GetWidth(), size.GetHeight());
+
+  const double pageWidth = currentLayout.pageSetup.PageWidthPt();
+  const double pageHeight = currentLayout.pageSetup.PageHeightPt();
+
+  const double scaledWidth = pageWidth * zoom;
+  const double scaledHeight = pageHeight * zoom;
+
+  const wxPoint center(size.GetWidth() / 2, size.GetHeight() / 2);
+  const wxPoint topLeft(center.x - static_cast<int>(scaledWidth / 2.0) +
+                            panOffset.x,
+                        center.y - static_cast<int>(scaledHeight / 2.0) +
+                            panOffset.y);
+
+  dc.SetBrush(wxBrush(wxColour(255, 255, 255)));
+  dc.SetPen(wxPen(wxColour(200, 200, 200)));
+  dc.DrawRectangle(topLeft.x, topLeft.y, static_cast<int>(scaledWidth),
+                   static_cast<int>(scaledHeight));
+}
+
+void LayoutViewerPanel::OnSize(wxSizeEvent &) {
+  Refresh();
+}
+
+void LayoutViewerPanel::OnLeftDown(wxMouseEvent &event) {
+  isPanning = true;
+  lastMousePos = event.GetPosition();
+  CaptureMouse();
+}
+
+void LayoutViewerPanel::OnLeftUp(wxMouseEvent &) {
+  if (isPanning) {
+    isPanning = false;
+    if (HasCapture())
+      ReleaseMouse();
+  }
+}
+
+void LayoutViewerPanel::OnMouseMove(wxMouseEvent &event) {
+  if (!isPanning || !event.Dragging())
+    return;
+
+  wxPoint currentPos = event.GetPosition();
+  wxPoint delta = currentPos - lastMousePos;
+  panOffset += delta;
+  lastMousePos = currentPos;
+  Refresh();
+}
+
+void LayoutViewerPanel::OnMouseWheel(wxMouseEvent &event) {
+  const int rotation = event.GetWheelRotation();
+  const int delta = event.GetWheelDelta();
+  if (delta == 0 || rotation == 0)
+    return;
+
+  const double steps = static_cast<double>(rotation) /
+                       static_cast<double>(delta);
+  const double factor = std::pow(kZoomStep, steps);
+  const double newZoom = std::clamp(zoom * factor, kMinZoom, kMaxZoom);
+  if (std::abs(newZoom - zoom) < 1e-6)
+    return;
+
+  wxSize size = GetClientSize();
+  wxPoint center(size.GetWidth() / 2, size.GetHeight() / 2);
+  wxPoint mousePos = event.GetPosition();
+
+  wxPoint relative = mousePos - center - panOffset;
+  const double scale = newZoom / zoom;
+  wxPoint newRelative(static_cast<int>(relative.x * scale),
+                      static_cast<int>(relative.y * scale));
+
+  panOffset += relative - newRelative;
+  zoom = newZoom;
+  Refresh();
+}
+
+void LayoutViewerPanel::OnCaptureLost(wxMouseCaptureLostEvent &) {
+  isPanning = false;
+}
+
+void LayoutViewerPanel::ResetViewToFit() {
+  wxSize size = GetClientSize();
+  const double pageWidth = currentLayout.pageSetup.PageWidthPt();
+  const double pageHeight = currentLayout.pageSetup.PageHeightPt();
+
+  if (pageWidth <= 0.0 || pageHeight <= 0.0 || size.GetWidth() <= 0 ||
+      size.GetHeight() <= 0) {
+    zoom = 1.0;
+    panOffset = wxPoint(0, 0);
+    return;
+  }
+
+  const double fitWidth =
+      static_cast<double>(size.GetWidth() - kFitMarginPx) / pageWidth;
+  const double fitHeight =
+      static_cast<double>(size.GetHeight() - kFitMarginPx) / pageHeight;
+  zoom = std::clamp(std::min(fitWidth, fitHeight), kMinZoom, kMaxZoom);
+  panOffset = wxPoint(0, 0);
+}

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <wx/wx.h>
+#include "layouts/LayoutCollection.h"
+
+class LayoutViewerPanel : public wxPanel {
+public:
+  explicit LayoutViewerPanel(wxWindow *parent);
+
+  void SetLayoutDefinition(const layouts::LayoutDefinition &layout);
+
+private:
+  void OnPaint(wxPaintEvent &event);
+  void OnSize(wxSizeEvent &event);
+  void OnLeftDown(wxMouseEvent &event);
+  void OnLeftUp(wxMouseEvent &event);
+  void OnMouseMove(wxMouseEvent &event);
+  void OnMouseWheel(wxMouseEvent &event);
+  void OnCaptureLost(wxMouseCaptureLostEvent &event);
+
+  void ResetViewToFit();
+
+  layouts::LayoutDefinition currentLayout;
+  double zoom = 1.0;
+  wxPoint panOffset{0, 0};
+  bool isPanning = false;
+  wxPoint lastMousePos{0, 0};
+
+  wxDECLARE_EVENT_TABLE();
+};

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -35,6 +35,7 @@ class Viewer2DRenderPanel;
 class ConsolePanel;
 class LayerPanel;
 class LayoutPanel;
+class LayoutViewerPanel;
 class SummaryPanel;
 class RiggingPanel;
 
@@ -73,6 +74,7 @@ private:
   ConsolePanel *consolePanel = nullptr;
   LayerPanel *layerPanel = nullptr;
   LayoutPanel *layoutPanel = nullptr;
+  LayoutViewerPanel *layoutViewerPanel = nullptr;
   SummaryPanel *summaryPanel = nullptr;
   RiggingPanel *riggingPanel = nullptr;
 


### PR DESCRIPTION
### Motivation
- Provide an interactive preview of layout pages (A4/A3) inside the GUI so users can see a paper representation of a selected layout. 
- Use the existing `layouts::LayoutDefinition` `pageSetup` (size/orientation) to render correct page dimensions. 
- Allow basic navigation of the preview by implementing zoom and pan for better inspection. 
- Expose the viewer as a dockable AUI pane to control visibility and integrate with existing layout selection.

### Description
- Added `gui/layoutviewerpanel.h` and `gui/layoutviewerpanel.cpp`, implementing `LayoutViewerPanel` which draws a centered white page on a grey background using `currentLayout.pageSetup.PageWidthPt()`/`PageHeightPt()` and implements mouse-wheel zoom and drag pan. 
- Wire up the new panel in `MainWindow`: include `layoutviewerpanel.h`, add `LayoutViewerPanel *layoutViewerPanel` member, instantiate it in `SetupLayout()` and register it with `wxAuiManager` as a pane named `"LayoutViewer"` (hidden by default). 
- On layout activation (`ActivateLayoutView`) the code looks up the matching `layouts::LayoutDefinition` from `layouts::LayoutManager` and calls `SetLayoutDefinition` on the viewer, then shows the `LayoutViewer` pane and updates the AUI layout. 
- Implemented view fit logic (`ResetViewToFit`) and constraints for zoom (`kMinZoom`/`kMaxZoom`) to ensure reasonable scaling and behavior.

### Testing
- No automated tests were run for these UI changes. 
- The new files were compiled and committed as part of the change set (no test-suite execution performed). 
- Manual interaction is expected to validate pan (mouse drag) and zoom (mouse wheel) behavior in the running application. 
- Integration relies on `layouts::LayoutManager` providing `LayoutDefinition` items; no additional unit tests were added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69496d7fe7b48324ade276147d2a1102)