### PR TITLE
Add Layout Mode perspective and menu entry for layout viewer

### DIFF
--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -125,6 +125,7 @@ private:
   void OnPreferences(wxCommandEvent &event);        // Show preferences dialog
   void OnApplyDefaultLayout(wxCommandEvent &event); // Reset to default layout
   void OnApply2DLayout(wxCommandEvent &event);      // Apply 2D layout
+  void OnApplyLayoutModeLayout(wxCommandEvent &event); // Apply layout mode
 
   void OnUndo(wxCommandEvent &event);           // Undo action placeholder
   void OnRedo(wxCommandEvent &event);           // Redo action placeholder
@@ -137,6 +138,7 @@ private:
 
   void SaveCameraSettings();
   void ApplySavedLayout();
+  void ApplyLayoutModePerspective();
   void UpdateViewMenuChecks();
   void OnLayoutSelected(wxCommandEvent &event);
   void ActivateLayoutView(const std::string &layoutName);
@@ -145,6 +147,7 @@ private:
                           const wxString &dialogTitle);
   std::string defaultLayoutPerspective;
   std::string default2DLayoutPerspective;
+  std::string layoutModePerspective;
 
   static MainWindow *s_instance;
   wxDECLARE_EVENT_TABLE();
@@ -174,6 +177,7 @@ enum {
   ID_View_ToggleRigging,
   ID_View_Layout_Default,
   ID_View_Layout_2D,
+  ID_View_Layout_Mode,
   ID_Tools_DownloadGdtf,
   ID_Tools_EditDictionaries,
   ID_Tools_ImportRiderText,


### PR DESCRIPTION
### Motivation
- Provide a dedicated layout-focused view that hides unrelated panels and surfaces the layout list and viewer for easier layout inspection.
- Expose the new mode in the existing `Layout Views` menu so users can switch to the layout-only workspace.
- Ensure selecting a layout uses the new focused perspective instead of the generic 2D layout arrangement.

### Description
- Added a new menu item `ID_View_Layout_Mode` labeled "Layout Mode View" under the `Layout Views` submenu and wired it to `OnApplyLayoutModeLayout`.
- Introduced `ApplyLayoutModePerspective()` which loads/saves a `layout_layout_mode` perspective, shows `LayoutPanel` and `LayoutViewer`, and hides `3DViewport`, `2DViewport`, `2DRenderOptions` and other non-relevant panes before updating the AUI manager.
- Updated `ActivateLayoutView()` to call `ApplyLayoutModePerspective()` so activating a layout opens the new layout-mode perspective and set the layout definition on the `LayoutViewerPanel`.
- Added declarations and a `layoutModePerspective` member in `mainwindow.h` and updated the header with `OnApplyLayoutModeLayout` and `ApplyLayoutModePerspective` prototypes.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69496f223d308324bdc7b15a2806afe2)