### PR TITLE
Adjust Layouts panel size and dock positions in Layout Mode

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -344,7 +344,8 @@ void MainWindow::SetupLayout() {
                                        .Right()
                                        .Row(0)
                                        .Position(1)
-                                       .BestSize(200, 260)
+                                       .BestSize(260, 260)
+                                       .MinSize(wxSize(240, 200))
                                        .CloseButton(true)
                                        .MaximizeButton(true)
                                        .PaneBorder(true));
@@ -1878,6 +1879,14 @@ void MainWindow::ApplyLayoutModePerspective() {
 
   if (!layoutModePerspective.empty())
     auiManager->LoadPerspective(layoutModePerspective, true);
+
+  auto &layoutPane = auiManager->GetPane("LayoutPanel");
+  if (layoutPane.IsOk())
+    layoutPane.Left();
+
+  auto &layoutViewerPane = auiManager->GetPane("LayoutViewer");
+  if (layoutViewerPane.IsOk())
+    layoutViewerPane.Right();
 
   auto showPane = [this](const char *name) {
     auto &pane = auiManager->GetPane(name);


### PR DESCRIPTION
### Motivation
- The `Layouts` panel was too narrow to show the bottom buttons clearly, and its minimum width was insufficient.
- When entering Layout Mode it’s more intuitive to place the `Layouts` list on the left and the `Layout Viewer` on the right.

### Description
- Increased the default width for the `LayoutPanel` by changing its `BestSize` from `200` to `260` in `gui/mainwindow.cpp`.
- Added a `MinSize` of `wxSize(240, 200)` for the `LayoutPanel` to prevent it from collapsing below a usable width.
- In `ApplyLayoutModePerspective()` the `LayoutPanel` is now set to `.Left()` and the `LayoutViewer` is set to `.Right()` before showing panes.
- All changes are contained in `gui/mainwindow.cpp` and preserve existing show/hide logic and perspective persistence.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949711fe008832489f25b6950fdbaa7)