### PR TITLE
Adjust layout mode pane sizing for Layout Mode view

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1880,13 +1880,16 @@ void MainWindow::ApplyLayoutModePerspective() {
   if (!layoutModePerspective.empty())
     auiManager->LoadPerspective(layoutModePerspective, true);
 
+  const int clientWidth = GetClientSize().GetWidth();
+  const int layoutPanelWidth = std::max(480, clientWidth / 3);
   auto &layoutPane = auiManager->GetPane("LayoutPanel");
   if (layoutPane.IsOk())
-    layoutPane.Left();
+    layoutPane.Left().BestSize(layoutPanelWidth, 600).MinSize(
+        wxSize(std::max(360, layoutPanelWidth - 120), 300));
 
   auto &layoutViewerPane = auiManager->GetPane("LayoutViewer");
   if (layoutViewerPane.IsOk())
-    layoutViewerPane.Right();
+    layoutViewerPane.Center().MinSize(wxSize(400, 300));
 
   auto showPane = [this](const char *name) {
     auto &pane = auiManager->GetPane(name);


### PR DESCRIPTION
### Motivation
- The Layout Mode view showed the `LayoutViewer` squashed into a narrow right-side panel instead of filling the remaining central space. 
- The initial `LayoutPanel` width was too small and should be increased relative to the main window width so the viewer has more room. 
- The change aims to prevent cramped layouts when switching to Layout Mode and produce a more usable default sizing. 

### Description
- In `ApplyLayoutModePerspective()` compute `clientWidth` from `GetClientSize()` and derive `layoutPanelWidth = std::max(480, clientWidth / 3)` to increase the left panel width. 
- Apply `.BestSize(layoutPanelWidth, 600)` and a `.MinSize(wxSize(std::max(360, layoutPanelWidth - 120), 300))` to the `LayoutPanel` pane obtained via `auiManager->GetPane("LayoutPanel")`. 
- Dock the `LayoutViewer` pane in the center using `.Center()` and set a minimum size with `.MinSize(wxSize(400, 300))` so it occupies the remaining space. 
- Changes are implemented in `gui/mainwindow.cpp` and preserve existing show/hide and perspective save logic. 

### Testing
- No automated tests were executed for this change. 
- The change is limited to UI pane layout adjustments in `ApplyLayoutModePerspective()`, so visual/manual verification is recommended after building.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694972afb00883248955a0093c88dbd9)