### PR TITLE
Respect saved Summary/Rigging panel visibility

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1854,15 +1854,6 @@ void MainWindow::ApplySavedLayout() {
     if (view2dPane.IsOk())
         view2dPane.MinSize(wxSize(250, 600));
 
-    // Ensure always-visible panels
-    auto& summaryPane = auiManager->GetPane("SummaryPanel");
-    if (summaryPane.IsOk() && !summaryPane.IsShown())
-        summaryPane.Show();
-
-    auto& riggingPane = auiManager->GetPane("RiggingPanel");
-    if (riggingPane.IsOk() && !riggingPane.IsShown())
-        riggingPane.Show();
-
     auiManager->Update();
     UpdateViewMenuChecks();
 }


### PR DESCRIPTION
### Motivation
- The Summary and Rigging panes were being force-shown after loading a saved layout, preventing the stored visibility state from being restored.
- The intent is to make these two panes behave like the other panels that fully respect the saved `layout_perspective`.

### Description
- Removed the forced `Show()` calls for `SummaryPanel` and `RiggingPanel` in `MainWindow::ApplySavedLayout()` so their visibility is no longer overridden.
- The saved layout from `ConfigManager` continues to be applied via `auiManager->LoadPerspective()` and now determines those panes' visibility.
- Change made in `gui/mainwindow.cpp`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949745c83808324a2ea0053c2a5ea0d)