### PR TITLE
Adjust Layouts panel width and hide column header

### DIFF
--- a/gui/layoutpanel.cpp
+++ b/gui/layoutpanel.cpp
@@ -25,7 +25,8 @@ LayoutPanel *LayoutPanel::s_instance = nullptr;
 wxDEFINE_EVENT(EVT_LAYOUT_SELECTED, wxCommandEvent);
 
 LayoutPanel::LayoutPanel(wxWindow *parent) : wxPanel(parent, wxID_ANY) {
-  list = new wxDataViewListCtrl(this, wxID_ANY);
+  list = new wxDataViewListCtrl(this, wxID_ANY, wxDefaultPosition,
+                                wxDefaultSize, wxDV_NO_HEADER);
   list->AppendTextColumn("Layout");
   ColumnUtils::EnforceMinColumnWidth(list);
 

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -344,8 +344,8 @@ void MainWindow::SetupLayout() {
                                        .Right()
                                        .Row(0)
                                        .Position(1)
-                                       .BestSize(260, 260)
-                                       .MinSize(wxSize(240, 200))
+                                       .BestSize(130, 260)
+                                       .MinSize(wxSize(120, 200))
                                        .CloseButton(true)
                                        .MaximizeButton(true)
                                        .PaneBorder(true));


### PR DESCRIPTION
### Motivation
- Reduce the default and minimum width of the "Layouts" side panel so it occupies half the current width by default and can be slightly smaller at its minimum size. 
- Remove the redundant column header in the layouts list because the panel already shows the panel title "Layouts" making the column header repetitive.

### Description
- Change the `LayoutPanel` list construction to hide the header by passing `wxDV_NO_HEADER` to `wxDataViewListCtrl` in `gui/layoutpanel.cpp` while keeping the list column (`AppendTextColumn("Layout")`).
- Reduce the layouts pane default width and minimum width by updating `.BestSize` and `.MinSize` for the `LayoutPanel` pane in `gui/mainwindow.cpp` from `260/240` to `130/120` respectively.
- Keep existing selection, add/rename/delete behavior and `ColumnUtils::EnforceMinColumnWidth` unchanged so list functionality is preserved.

### Testing
- No automated tests were executed for this change. 
- The modified files are `gui/layoutpanel.cpp` and `gui/mainwindow.cpp` and were compiled locally as part of the patch application (no test suite run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694975e9c7848324849b49cf1c249057)