### PR TITLE
Fix layout mode persistence and panel sizing

### DIFF
--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -148,6 +148,7 @@ private:
   std::string defaultLayoutPerspective;
   std::string default2DLayoutPerspective;
   std::string layoutModePerspective;
+  bool layoutModeActive = false;
 
   static MainWindow *s_instance;
   wxDECLARE_EVENT_TABLE();


### PR DESCRIPTION
### Motivation
- Prevent the "Layouts" and "Layout Viewer" panes from briefly showing (flashing) at startup before the saved perspective is applied.
- Ensure the custom "layout mode" perspective is tracked and persisted when the application is closed so it is restored correctly on next launch.
- Reduce the default width of the `LayoutPanel` in layout mode to avoid an overly wide sidebar.

### Description
- Add a `layoutModeActive` flag to `MainWindow` and use it to track whether the UI is currently in layout mode and to control persistence of the `layout_layout_mode` perspective.
- Stop showing the `LayoutPanel` and `LayoutViewer` by default during `SetupLayout` by adding `.Hide()` so the saved perspective can be applied without an initial flash.
- In `ApplySavedLayout` determine whether the loaded `layout_perspective` equals the stored `layout_layout_mode` and set `layoutModeActive` accordingly, hiding the layout panes when not in layout mode.
- Save `layout_layout_mode` only when `layoutModeActive` and reduce the layout-mode sidebar width calculation from `std::max(260, clientWidth/4)` to `std::max(200, clientWidth/6)` in `ApplyLayoutModePerspective`.

### Testing
- No automated tests were run against these changes.
- Manual inspection covered the code paths for `ApplySavedLayout`, `ApplyLayoutModePerspective`, and `SaveCameraSettings` during the rollout but no test suite was executed.
- The change compiles and the patch was committed successfully in the development branch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694979730fec83249fb35afea2420c3d)