### PR TITLE
Add initial File toolbar group with placeholder icons and tooltips

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -34,6 +34,7 @@
 #include <tinyxml2.h>
 #include <wx/aboutdlg.h>
 #include <wx/app.h>
+#include <wx/artprov.h>
 #include <wx/event.h>
 #include <wx/filefn.h>
 #include <wx/filename.h>
@@ -277,6 +278,8 @@ void MainWindow::SetupLayout() {
   auiManager = new wxAuiManager(this);
   Bind(wxEVT_AUI_PANE_CLOSE, &MainWindow::OnPaneClose, this);
 
+  CreateToolBars();
+
   // Create notebook with data panels
   notebook = new wxNotebook(this, wxID_ANY);
   notebook->Bind(wxEVT_NOTEBOOK_PAGE_CHANGED,
@@ -410,6 +413,53 @@ void MainWindow::SetupLayout() {
 
   // Ensure the View menu reflects the actual pane visibility
   UpdateViewMenuChecks();
+}
+
+void MainWindow::CreateToolBars() {
+  fileToolBar = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition,
+                                 wxDefaultSize,
+                                 wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_HORIZONTAL);
+  fileToolBar->SetToolBitmapSize(wxSize(24, 24));
+
+  // TODO: Replace wxArtProvider icons with Tabler SVGs via
+  // wxBitmapBundle::FromSVGFile() when icon assets are available.
+  fileToolBar->AddTool(ID_File_New, "New",
+                       wxArtProvider::GetBitmapBundle(wxART_NEW,
+                                                      wxART_TOOLBAR),
+                       "Create a new project");
+  fileToolBar->AddTool(ID_File_Load, "Open",
+                       wxArtProvider::GetBitmapBundle(wxART_FILE_OPEN,
+                                                      wxART_TOOLBAR),
+                       "Open an existing project");
+  fileToolBar->AddTool(ID_File_Save, "Save",
+                       wxArtProvider::GetBitmapBundle(wxART_FILE_SAVE,
+                                                      wxART_TOOLBAR),
+                       "Save the current project");
+  fileToolBar->AddTool(ID_File_SaveAs, "Save As",
+                       wxArtProvider::GetBitmapBundle(wxART_FILE_SAVE,
+                                                      wxART_TOOLBAR),
+                       "Save the current project with a new name");
+  fileToolBar->AddTool(ID_File_ImportMVR, "Import MVR",
+                       wxArtProvider::GetBitmapBundle(wxART_FILE_OPEN,
+                                                      wxART_TOOLBAR),
+                       "Import an MVR file");
+  fileToolBar->AddTool(ID_File_ExportMVR, "Export MVR",
+                       wxArtProvider::GetBitmapBundle(wxART_FILE_SAVE,
+                                                      wxART_TOOLBAR),
+                       "Export the project to MVR");
+  fileToolBar->AddSeparator();
+  fileToolBar->Realize();
+
+  auiManager->AddPane(
+      fileToolBar, wxAuiPaneInfo()
+                       .Name("FileToolbar")
+                       .Caption("File")
+                       .ToolbarPane()
+                       .Top()
+                       .LeftDockable(false)
+                       .RightDockable(false)
+                       .Row(0)
+                       .Position(0));
 }
 
 void MainWindow::Ensure3DViewport() {

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -56,6 +56,7 @@ public:
 private:
   void SetupLayout();   // Set up main window layout
   void CreateMenuBar(); // Create menus
+  void CreateToolBars(); // Create toolbars
   void UpdateTitle();   // Refresh window title
   void Ensure3DViewport();
   void Ensure2DViewport();
@@ -77,6 +78,7 @@ private:
   LayoutViewerPanel *layoutViewerPanel = nullptr;
   SummaryPanel *summaryPanel = nullptr;
   RiggingPanel *riggingPanel = nullptr;
+  wxAuiToolBar *fileToolBar = nullptr;
 
   wxAcceleratorTable m_accel;
 


### PR DESCRIPTION
### Motivation
- Provide a first toolbar group that mirrors the existing `File` menu so the UI can be validated before adding icons. 
- Prepare the code structure to later swap in Tabler SVG icons via `wxBitmapBundle::FromSVGFile()` without changing layout logic. 
- Include tooltips from the start to improve discoverability even with placeholder icons. 
- Create a reusable toolbar area to allow adding/hiding grouped tools per context in future work.

### Description
- Added a new method declaration `CreateToolBars()` and a `wxAuiToolBar *fileToolBar` member to `gui/mainwindow.h` and wired `CreateToolBars()` into `SetupLayout()` in `gui/mainwindow.cpp`.
- Implemented `MainWindow::CreateToolBars()` which constructs a `wxAuiToolBar`, sets `SetToolBitmapSize`, adds `File`-related tools (`ID_File_New`, `ID_File_Load`, `ID_File_Save`, `ID_File_SaveAs`, `ID_File_ImportMVR`, `ID_File_ExportMVR`) with placeholder bitmaps from `wxArtProvider::GetBitmapBundle(...)` and tooltips, calls `Realize()`, and registers the toolbar as a top `auiManager` pane.
- Added `#include <wx/artprov.h>` and left a `TODO` comment to replace `wxArtProvider` placeholders with Tabler SVGs via `wxBitmapBundle::FromSVGFile()` when assets are available.
- Constrained the toolbar pane to the top row and disabled left/right docking to keep the initial layout stable.

### Testing
- No automated tests were run for this UI change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694971b545a88324abbdcc1f30cdb7ff)