### PR TITLE
Fix MainWindow singleton, tidy event table and add ConsolePanel test stub

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -103,128 +103,62 @@ using json = nlohmann::json;
 #define pclose _pclose
 #endif
 
-MainWindow *MainWindow::s_instance = nullptr;
 wxDEFINE_EVENT(EVT_PROJECT_LOADED, wxCommandEvent);
 
 MainWindow *MainWindow::Instance() { return s_instance; }
 
 void MainWindow::SetInstance(MainWindow *inst) { s_instance = inst; }
 
-wxBEGIN_EVENT_TABLE(MainWindow, wxFrame) EVT_MENU(
-    ID_File_New,
-    MainWindow::
-        OnNew) EVT_MENU(ID_File_Load,
-                        MainWindow::
-                            OnLoad) EVT_MENU(ID_File_Save,
-                                             MainWindow::
-                                                 OnSave) EVT_MENU(ID_File_SaveAs,
-                                                                  MainWindow::
-                                                                      OnSaveAs)
-    EVT_MENU(ID_File_ImportRider, MainWindow::OnImportRider) EVT_MENU(
-        ID_File_ImportMVR,
-        MainWindow::
-            OnImportMVR) EVT_MENU(ID_File_ExportMVR,
-                                  MainWindow::
-                                      OnExportMVR)
-    EVT_MENU(ID_File_PrintViewer2D, MainWindow::OnPrintViewer2D)
-        EVT_MENU(ID_File_PrintTable, MainWindow::OnPrintTable) EVT_MENU(
-            ID_File_ExportCSV, MainWindow::OnExportCSV) EVT_MENU(
-            ID_File_Close,
-            MainWindow::
-                OnClose) EVT_CLOSE(MainWindow::
-                                       OnCloseWindow) EVT_MENU(ID_Edit_Undo,
-                                                               MainWindow::
-                                                                   OnUndo)
-            EVT_MENU(ID_Edit_Redo, MainWindow::OnRedo) EVT_MENU(
-                ID_Edit_AddFixture,
-                MainWindow::
-                    OnAddFixture) EVT_MENU(ID_Edit_AddTruss,
-                                           MainWindow::
-                                               OnAddTruss) EVT_MENU(ID_Edit_AddSceneObject,
-                                                                    MainWindow::
-                                                                        OnAddSceneObject)
-                EVT_MENU(ID_Edit_Delete, MainWindow::OnDelete) EVT_MENU(
-                    ID_View_ToggleConsole,
-                    MainWindow::
-                        OnToggleConsole) EVT_MENU(ID_View_ToggleFixtures,
-                                                  MainWindow::OnToggleFixtures)
-                    EVT_MENU(ID_View_ToggleViewport, MainWindow::OnToggleViewport) EVT_MENU(
-                        ID_View_ToggleViewport2D,
-                        MainWindow::
-                            OnToggleViewport2D) EVT_MENU(ID_View_ToggleRender2D,
-                                                         MainWindow::
-                                                             OnToggleRender2D)
-                        EVT_MENU(ID_View_ToggleLayers, MainWindow::OnToggleLayers) EVT_MENU(
-                            ID_View_ToggleLayouts, MainWindow::OnToggleLayouts) EVT_MENU(
-                            ID_View_ToggleSummary,
-                            MainWindow::
-                                OnToggleSummary) EVT_MENU(ID_View_ToggleRigging,
-                                                          MainWindow::OnToggleRigging) EVT_MENU(
-                            ID_View_Layout_Default,
-                                                      MainWindow::
-                                                          OnApplyDefaultLayout)
-                            EVT_MENU(
-                                ID_View_Layout_2D,
-                                MainWindow::
-                                    OnApply2DLayout)
-                                EVT_MENU(
-                                    ID_View_Layout_Mode,
-                                    MainWindow::
-                                        OnApplyLayoutModeLayout)
-                                    EVT_MENU(ID_Tools_DownloadGdtf,
-                                                              MainWindow::
-                                                                  OnDownloadGdtf)
-                                EVT_MENU(ID_Tools_EditDictionaries,
-                                         MainWindow::OnEditDictionaries)
-                                EVT_MENU(
-                                    ID_Tools_ExportFixture,
-                                    MainWindow::
-                                        OnExportFixture) EVT_MENU(ID_Tools_ExportTruss,
-                                                                  MainWindow::
-                                                                      OnExportTruss)
-                                    EVT_MENU(
-                                        ID_Tools_ExportSceneObject,
-                                        MainWindow::
-                                      OnExportSceneObject) EVT_MENU(ID_Tools_AutoPatch,
-                                                                          MainWindow::
-                                                                              OnAutoPatch) EVT_MENU(ID_Tools_AutoColor,
-                                                                          MainWindow::
-                                                                              OnAutoColor) EVT_MENU(ID_Tools_ConvertToHoist,
-                                                                          MainWindow::
-                                                                              OnConvertToHoist)
-                                        EVT_MENU(ID_Tools_ImportRiderText,
-                                                 MainWindow::OnImportRiderText)
-                                        EVT_MENU(ID_Help_Help, MainWindow::OnShowHelp) EVT_MENU(
-                                            ID_Help_About, MainWindow::
-                                                               OnShowAbout)
-                                            EVT_MENU(ID_Select_Fixtures,
-                                                     MainWindow::
-                                                         OnSelectFixtures)
-                                                EVT_MENU(ID_Select_Trusses,
-                                                         MainWindow::
-                                                             OnSelectTrusses)
-                                                    EVT_MENU(ID_Select_Supports,
-                                                             MainWindow::
-                                                                 OnSelectSupports)
-                                                        EVT_MENU(
-                                                            ID_Select_Objects,
-                                                            MainWindow::
-                                                                OnSelectObjects)
-                                                        EVT_MENU(
-                                                            ID_Edit_Preferences,
-                                                            MainWindow::
-                                                                OnPreferences)
-                                                            EVT_COMMAND(
-                                                                wxID_ANY,
-                                                                EVT_PROJECT_LOADED,
-                                                                MainWindow::
-                                                                    OnProjectLoaded)
-                                                            EVT_COMMAND(
-                                                                wxID_ANY,
-                                                                EVT_LAYOUT_SELECTED,
-                                                                MainWindow::
-                                                                    OnLayoutSelected)
-                                                                wxEND_EVENT_TABLE()
+wxBEGIN_EVENT_TABLE(MainWindow, wxFrame)
+EVT_MENU(ID_File_New, MainWindow::OnNew)
+EVT_MENU(ID_File_Load, MainWindow::OnLoad)
+EVT_MENU(ID_File_Save, MainWindow::OnSave)
+EVT_MENU(ID_File_SaveAs, MainWindow::OnSaveAs)
+EVT_MENU(ID_File_ImportRider, MainWindow::OnImportRider)
+EVT_MENU(ID_File_ImportMVR, MainWindow::OnImportMVR)
+EVT_MENU(ID_File_ExportMVR, MainWindow::OnExportMVR)
+EVT_MENU(ID_File_PrintViewer2D, MainWindow::OnPrintViewer2D)
+EVT_MENU(ID_File_PrintTable, MainWindow::OnPrintTable)
+EVT_MENU(ID_File_ExportCSV, MainWindow::OnExportCSV)
+EVT_MENU(ID_File_Close, MainWindow::OnClose)
+EVT_CLOSE(MainWindow::OnCloseWindow)
+EVT_MENU(ID_Edit_Undo, MainWindow::OnUndo)
+EVT_MENU(ID_Edit_Redo, MainWindow::OnRedo)
+EVT_MENU(ID_Edit_AddFixture, MainWindow::OnAddFixture)
+EVT_MENU(ID_Edit_AddTruss, MainWindow::OnAddTruss)
+EVT_MENU(ID_Edit_AddSceneObject, MainWindow::OnAddSceneObject)
+EVT_MENU(ID_Edit_Delete, MainWindow::OnDelete)
+EVT_MENU(ID_View_ToggleConsole, MainWindow::OnToggleConsole)
+EVT_MENU(ID_View_ToggleFixtures, MainWindow::OnToggleFixtures)
+EVT_MENU(ID_View_ToggleViewport, MainWindow::OnToggleViewport)
+EVT_MENU(ID_View_ToggleViewport2D, MainWindow::OnToggleViewport2D)
+EVT_MENU(ID_View_ToggleRender2D, MainWindow::OnToggleRender2D)
+EVT_MENU(ID_View_ToggleLayers, MainWindow::OnToggleLayers)
+EVT_MENU(ID_View_ToggleLayouts, MainWindow::OnToggleLayouts)
+EVT_MENU(ID_View_ToggleSummary, MainWindow::OnToggleSummary)
+EVT_MENU(ID_View_ToggleRigging, MainWindow::OnToggleRigging)
+EVT_MENU(ID_View_Layout_Default, MainWindow::OnApplyDefaultLayout)
+EVT_MENU(ID_View_Layout_2D, MainWindow::OnApply2DLayout)
+EVT_MENU(ID_View_Layout_Mode, MainWindow::OnApplyLayoutModeLayout)
+EVT_MENU(ID_Tools_DownloadGdtf, MainWindow::OnDownloadGdtf)
+EVT_MENU(ID_Tools_EditDictionaries, MainWindow::OnEditDictionaries)
+EVT_MENU(ID_Tools_ExportFixture, MainWindow::OnExportFixture)
+EVT_MENU(ID_Tools_ExportTruss, MainWindow::OnExportTruss)
+EVT_MENU(ID_Tools_ExportSceneObject, MainWindow::OnExportSceneObject)
+EVT_MENU(ID_Tools_AutoPatch, MainWindow::OnAutoPatch)
+EVT_MENU(ID_Tools_AutoColor, MainWindow::OnAutoColor)
+EVT_MENU(ID_Tools_ConvertToHoist, MainWindow::OnConvertToHoist)
+EVT_MENU(ID_Tools_ImportRiderText, MainWindow::OnImportRiderText)
+EVT_MENU(ID_Help_Help, MainWindow::OnShowHelp)
+EVT_MENU(ID_Help_About, MainWindow::OnShowAbout)
+EVT_MENU(ID_Select_Fixtures, MainWindow::OnSelectFixtures)
+EVT_MENU(ID_Select_Trusses, MainWindow::OnSelectTrusses)
+EVT_MENU(ID_Select_Supports, MainWindow::OnSelectSupports)
+EVT_MENU(ID_Select_Objects, MainWindow::OnSelectObjects)
+EVT_MENU(ID_Edit_Preferences, MainWindow::OnPreferences)
+EVT_COMMAND(wxID_ANY, EVT_PROJECT_LOADED, MainWindow::OnProjectLoaded)
+EVT_COMMAND(wxID_ANY, EVT_LAYOUT_SELECTED, MainWindow::OnLayoutSelected)
+wxEND_EVENT_TABLE()
 
                                                                     MainWindow::
                                                                         MainWindow(

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -152,7 +152,7 @@ private:
   std::string layoutModePerspective;
   bool layoutModeActive = false;
 
-  static MainWindow *s_instance;
+  inline static MainWindow *s_instance = nullptr;
   wxDECLARE_EVENT_TABLE();
 };
 

--- a/tests/consolepanel_stub.cpp
+++ b/tests/consolepanel_stub.cpp
@@ -19,3 +19,4 @@
 
 ConsolePanel* ConsolePanel::Instance() { return nullptr; }
 void ConsolePanel::AppendMessage(const wxString&) {}
+void ConsolePanel::SetInstance(ConsolePanel*) {}


### PR DESCRIPTION
### Motivation
- Fix linker / MSVC errors caused by the out-of-class storage definition of `MainWindow::s_instance` (can conflict with `dllimport`).
- Ensure unit tests link correctly by supplying the missing `ConsolePanel::SetInstance` stub referenced from GUI code.
- Improve clarity and reliability of the `wxBEGIN_EVENT_TABLE` macro expansion by using explicit `EVT_MENU`/`EVT_COMMAND` lines.

### Description
- Change the singleton storage to an inline static by declaring `inline static MainWindow *s_instance = nullptr;` in `gui/mainwindow.h` and remove the out-of-class definition from `gui/mainwindow.cpp`.
- Reformat the `wxBEGIN_EVENT_TABLE` block in `gui/mainwindow.cpp` into explicit `EVT_MENU` / `EVT_COMMAND` entries for clearer macro expansion.
- Add a `ConsolePanel::SetInstance` stub in `tests/consolepanel_stub.cpp` so test binaries can link without the full GUI.
- Modified files: `gui/mainwindow.h`, `gui/mainwindow.cpp`, and `tests/consolepanel_stub.cpp`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694989112f4c832490f65cd5f4f6c7bc)