### PR TITLE
Add Lucide outline icons for file actions

### DIFF
--- a/resources/icons/outline/file-plus.svg
+++ b/resources/icons/outline/file-plus.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z" />
+  <path d="M14 2v5a1 1 0 0 0 1 1h5" />
+  <path d="M9 15h6" />
+  <path d="M12 18v-6" />
+</svg>

--- a/resources/icons/outline/folder-open.svg
+++ b/resources/icons/outline/folder-open.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m6 14 1.5-2.9A2 2 0 0 1 9.24 10H20a2 2 0 0 1 1.94 2.5l-1.54 6a2 2 0 0 1-1.95 1.5H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h3.9a2 2 0 0 1 1.69.9l.81 1.2a2 2 0 0 0 1.67.9H18a2 2 0 0 1 2 2v2" />
+</svg>

--- a/resources/icons/outline/save.svg
+++ b/resources/icons/outline/save.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M15.2 3a2 2 0 0 1 1.4.6l3.8 3.8a2 2 0 0 1 .6 1.4V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z" />
+  <path d="M17 21v-7a1 1 0 0 0-1-1H8a1 1 0 0 0-1 1v7" />
+  <path d="M7 3v4a1 1 0 0 0 1 1h7" />
+</svg>


### PR DESCRIPTION
### Motivation
- Provide SVG icon assets so the UI can replace `wxArtProvider` placeholders with real icons.
- Use a simple, provider-agnostic naming scheme (`lowercase-with-dashes`) to make mapping straightforward.
- Add common file-action icons needed by the toolbar (`file-plus`, `folder-open`, `save`).

### Description
- Create the `resources/icons/outline` directory and add `file-plus.svg`, `folder-open.svg`, and `save.svg` sourced from Lucide.
- Files are outline SVGs and follow the `lowercase-with-dashes` naming convention for predictable access.
- Assets are prepared to be consumed by code such as `wxBitmapBundle::FromSVGFile()` when the toolbar is switched from `wxArtProvider` to SVG assets.

### Testing
- No automated tests were run because this is an asset-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69499225b6088324a1e09e0db2d90d40)