### PR TITLE
Use SVG toolbar icons when available

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -370,31 +370,37 @@ void MainWindow::CreateToolBars() {
                                  wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_HORIZONTAL);
   fileToolBar->SetToolBitmapSize(wxSize(24, 24));
 
-  // TODO: Replace wxArtProvider icons with Tabler SVGs via
-  // wxBitmapBundle::FromSVGFile() when icon assets are available.
+  const auto loadToolbarIcon = [](const std::string &name,
+                                  const wxArtID &fallbackArtId) {
+    auto svgPath = ProjectUtils::GetResourceRoot() / "icons" / "outline" /
+                   (name + ".svg");
+    if (std::filesystem::exists(svgPath)) {
+      wxBitmapBundle bundle =
+          wxBitmapBundle::FromSVGFile(svgPath.string(), wxSize(24, 24));
+      if (bundle.IsOk()) {
+        return bundle;
+      }
+    }
+    return wxArtProvider::GetBitmapBundle(fallbackArtId, wxART_TOOLBAR,
+                                          wxSize(24, 24));
+  };
   fileToolBar->AddTool(ID_File_New, "New",
-                       wxArtProvider::GetBitmapBundle(wxART_NEW,
-                                                      wxART_TOOLBAR),
+                       loadToolbarIcon("file-plus", wxART_NEW),
                        "Create a new project");
   fileToolBar->AddTool(ID_File_Load, "Open",
-                       wxArtProvider::GetBitmapBundle(wxART_FILE_OPEN,
-                                                      wxART_TOOLBAR),
+                       loadToolbarIcon("folder-open", wxART_FILE_OPEN),
                        "Open an existing project");
   fileToolBar->AddTool(ID_File_Save, "Save",
-                       wxArtProvider::GetBitmapBundle(wxART_FILE_SAVE,
-                                                      wxART_TOOLBAR),
+                       loadToolbarIcon("save", wxART_FILE_SAVE),
                        "Save the current project");
   fileToolBar->AddTool(ID_File_SaveAs, "Save As",
-                       wxArtProvider::GetBitmapBundle(wxART_FILE_SAVE,
-                                                      wxART_TOOLBAR),
+                       loadToolbarIcon("save", wxART_FILE_SAVE),
                        "Save the current project with a new name");
   fileToolBar->AddTool(ID_File_ImportMVR, "Import MVR",
-                       wxArtProvider::GetBitmapBundle(wxART_FILE_OPEN,
-                                                      wxART_TOOLBAR),
+                       loadToolbarIcon("folder-open", wxART_FILE_OPEN),
                        "Import an MVR file");
   fileToolBar->AddTool(ID_File_ExportMVR, "Export MVR",
-                       wxArtProvider::GetBitmapBundle(wxART_FILE_SAVE,
-                                                      wxART_TOOLBAR),
+                       loadToolbarIcon("save", wxART_FILE_SAVE),
                        "Export the project to MVR");
   fileToolBar->AddSeparator();
   fileToolBar->Realize();


### PR DESCRIPTION
### Motivation
- Prefer vector Tabler outline icons from the resources when available to improve toolbar visuals.
- Keep DPI-independent icon sizing consistent by using a 24 DIP size for both SVG bundles and fallbacks.
- Provide a fallback to the existing `wxArtProvider` icons to preserve behavior when SVG assets are missing.

### Description
- Added a local helper `loadToolbarIcon` in `gui/mainwindow.cpp` that builds the path from `ProjectUtils::GetResourceRoot()` and tries `wxBitmapBundle::FromSVGFile` with `wxSize(24,24)`.
- The helper falls back to `wxArtProvider::GetBitmapBundle(fallbackArtId, wxART_TOOLBAR, wxSize(24,24))` if the SVG file is missing or the bundle is invalid.
- Replaced `AddTool` icon arguments for the file toolbar (`New`, `Open`, `Save`, `Save As`, `Import MVR`, `Export MVR`) to call `loadToolbarIcon(...)` with appropriate icon names and fallback art IDs.
- The only modified file is `gui/mainwindow.cpp` and the toolbar continues to use `SetToolBitmapSize(wxSize(24, 24))` for consistent sizing.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949a06d9cc883248591b07dc18d4e4e)