### PR TITLE
Add Lucide MIT license text

### DIFF
--- a/licenses/Lucide-MIT.txt
+++ b/licenses/Lucide-MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Lucide Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
### Motivation
- Add the Lucide MIT license text so bundled Lucide icons are properly attributed and licensed.
- Keep third-party license tracking consistent inside the `licenses/` directory.
- Reserve the intent to provide a separate internal license file for project-created icons (for example `licenses/Perastage-Icons.txt`).

### Description
- Add `licenses/Lucide-MIT.txt` containing the full MIT license text with Lucide attribution.
- No source code or build files were modified outside the `licenses/` directory.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949a24ec5bc8324afc53f12a2fa5c00)