### PR TITLE
Update toolbar icons and add icon usage mapping

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -385,7 +385,7 @@ void MainWindow::CreateToolBars() {
                                           wxSize(24, 24));
   };
   fileToolBar->AddTool(ID_File_New, "New",
-                       loadToolbarIcon("file-plus", wxART_NEW),
+                       loadToolbarIcon("file", wxART_NEW),
                        "Create a new project");
   fileToolBar->AddTool(ID_File_Load, "Open",
                        loadToolbarIcon("folder-open", wxART_FILE_OPEN),
@@ -394,13 +394,13 @@ void MainWindow::CreateToolBars() {
                        loadToolbarIcon("save", wxART_FILE_SAVE),
                        "Save the current project");
   fileToolBar->AddTool(ID_File_SaveAs, "Save As",
-                       loadToolbarIcon("save", wxART_FILE_SAVE),
+                       loadToolbarIcon("save-all", wxART_FILE_SAVE),
                        "Save the current project with a new name");
   fileToolBar->AddTool(ID_File_ImportMVR, "Import MVR",
-                       loadToolbarIcon("folder-open", wxART_FILE_OPEN),
+                       loadToolbarIcon("file-input", wxART_FILE_OPEN),
                        "Import an MVR file");
   fileToolBar->AddTool(ID_File_ExportMVR, "Export MVR",
-                       loadToolbarIcon("save", wxART_FILE_SAVE),
+                       loadToolbarIcon("file-output", wxART_FILE_SAVE),
                        "Export the project to MVR");
   fileToolBar->AddSeparator();
   fileToolBar->Realize();

--- a/resources/icons/icons-usage.json
+++ b/resources/icons/icons-usage.json
@@ -1,0 +1,10 @@
+{
+  "toolbar": {
+    "New": "outline/file.svg",
+    "Load": "outline/folder-open.svg",
+    "Save": "outline/save.svg",
+    "Save As": "outline/save-all.svg",
+    "Import MVR": "outline/file-input.svg",
+    "Export MVR": "outline/file-output.svg"
+  }
+}

--- a/resources/icons/outline/file-input.svg
+++ b/resources/icons/outline/file-input.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M4 11V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.706.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-1" />
+  <path d="M14 2v5a1 1 0 0 0 1 1h5" />
+  <path d="M2 15h10" />
+  <path d="m9 18 3-3-3-3" />
+</svg>

--- a/resources/icons/outline/file-output.svg
+++ b/resources/icons/outline/file-output.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M4.226 20.925A2 2 0 0 0 6 22h12a2 2 0 0 0 2-2V8a2.4 2.4 0 0 0-.706-1.706l-3.588-3.588A2.4 2.4 0 0 0 14 2H6a2 2 0 0 0-2 2v3.127" />
+  <path d="M14 2v5a1 1 0 0 0 1 1h5" />
+  <path d="m5 11-3 3" />
+  <path d="m5 17-3-3h10" />
+</svg>

--- a/resources/icons/outline/file.svg
+++ b/resources/icons/outline/file.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z" />
+  <path d="M14 2v5a1 1 0 0 0 1 1h5" />
+</svg>

--- a/resources/icons/outline/save-all.svg
+++ b/resources/icons/outline/save-all.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M10 2v3a1 1 0 0 0 1 1h5" />
+  <path d="M18 18v-6a1 1 0 0 0-1-1h-6a1 1 0 0 0-1 1v6" />
+  <path d="M18 22H4a2 2 0 0 1-2-2V6" />
+  <path d="M8 18a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9.172a2 2 0 0 1 1.414.586l2.828 2.828A2 2 0 0 1 22 6.828V16a2 2 0 0 1-2.01 2z" />
+</svg>


### PR DESCRIPTION
### Motivation
- Standardize file-related toolbar icons to use Lucide outline assets and ensure consistent visuals for file operations.
- Provide the missing Lucide SVGs so toolbar actions have explicit icon files instead of fallbacks.
- Introduce a simple machine-readable mapping so icon usage is documented and can be kept up to date when UI icons change.

### Description
- Updated `MainWindow::CreateToolBars()` to use `file.svg` for New, `save-all.svg` for Save As, `file-input.svg` for Import MVR, and `file-output.svg` for Export MVR.
- Added new SVG assets under `resources/icons/outline/`: `file.svg`, `save-all.svg`, `file-input.svg`, and `file-output.svg`.
- Added `resources/icons/icons-usage.json` containing a `toolbar` mapping that documents which icons are used for each toolbar action.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949a4208660832496a325791dc36c7c)