### PR TITLE
Add Layout toolbar with 2D View button and icon

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -154,6 +154,7 @@ EVT_MENU(ID_View_ToggleRigging, MainWindow::OnToggleRigging)
 EVT_MENU(ID_View_Layout_Default, MainWindow::OnApplyDefaultLayout)
 EVT_MENU(ID_View_Layout_2D, MainWindow::OnApply2DLayout)
 EVT_MENU(ID_View_Layout_Mode, MainWindow::OnApplyLayoutModeLayout)
+EVT_MENU(ID_View_Layout_2DView, MainWindow::OnLayout2DView)
 EVT_MENU(ID_Tools_DownloadGdtf, MainWindow::OnDownloadGdtf)
 EVT_MENU(ID_Tools_EditDictionaries, MainWindow::OnEditDictionaries)
 EVT_MENU(ID_Tools_ExportFixture, MainWindow::OnExportFixture)
@@ -415,6 +416,26 @@ void MainWindow::CreateToolBars() {
                        .RightDockable(false)
                        .Row(0)
                        .Position(0));
+
+  layoutToolBar = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition,
+                                   wxDefaultSize,
+                                   wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_HORIZONTAL);
+  layoutToolBar->SetToolBitmapSize(wxSize(24, 24));
+  layoutToolBar->AddTool(ID_View_Layout_2DView, "Vista 2D",
+                         loadToolbarIcon("panel-top-bottom-dashed",
+                                         wxART_MISSING_IMAGE),
+                         "Vista 2D en layout");
+  layoutToolBar->Realize();
+  auiManager->AddPane(
+      layoutToolBar, wxAuiPaneInfo()
+                         .Name("LayoutToolbar")
+                         .Caption("Layout")
+                         .ToolbarPane()
+                         .Top()
+                         .LeftDockable(false)
+                         .RightDockable(false)
+                         .Row(1)
+                         .Position(0));
 }
 
 void MainWindow::Ensure3DViewport() {
@@ -1706,6 +1727,12 @@ void MainWindow::OnApplyDefaultLayout(wxCommandEvent &WXUNUSED(event)) {
   auto &layoutViewerPane = auiManager->GetPane("LayoutViewer");
   if (layoutViewerPane.IsOk())
     layoutViewerPane.Hide();
+  auto &layoutToolbarPane = auiManager->GetPane("LayoutToolbar");
+  if (layoutToolbarPane.IsOk())
+    layoutToolbarPane.Hide();
+  auto &fileToolbarPane = auiManager->GetPane("FileToolbar");
+  if (fileToolbarPane.IsOk())
+    fileToolbarPane.Show();
   auiManager->Update();
 
   cfg.SetValue("layout_perspective", perspective);
@@ -1724,6 +1751,12 @@ void MainWindow::OnApply2DLayout(wxCommandEvent &WXUNUSED(event)) {
   auto &layoutViewerPane = auiManager->GetPane("LayoutViewer");
   if (layoutViewerPane.IsOk())
     layoutViewerPane.Hide();
+  auto &layoutToolbarPane = auiManager->GetPane("LayoutToolbar");
+  if (layoutToolbarPane.IsOk())
+    layoutToolbarPane.Hide();
+  auto &fileToolbarPane = auiManager->GetPane("FileToolbar");
+  if (fileToolbarPane.IsOk())
+    fileToolbarPane.Show();
   auiManager->Update();
 
   ConfigManager &cfg = ConfigManager::Get();
@@ -1939,6 +1972,8 @@ void MainWindow::ApplyLayoutModePerspective() {
 
   showPane("LayoutPanel");
   showPane("LayoutViewer");
+  showPane("FileToolbar");
+  showPane("LayoutToolbar");
 
   hidePane("3DViewport");
   hidePane("2DViewport");
@@ -1957,6 +1992,8 @@ void MainWindow::ApplyLayoutModePerspective() {
   layoutModeActive = true;
   UpdateViewMenuChecks();
 }
+
+void MainWindow::OnLayout2DView(wxCommandEvent &WXUNUSED(event)) {}
 
 void MainWindow::UpdateViewMenuChecks() {
   if (!auiManager || !GetMenuBar())

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -79,6 +79,7 @@ private:
   SummaryPanel *summaryPanel = nullptr;
   RiggingPanel *riggingPanel = nullptr;
   wxAuiToolBar *fileToolBar = nullptr;
+  wxAuiToolBar *layoutToolBar = nullptr;
 
   wxAcceleratorTable m_accel;
 
@@ -135,6 +136,7 @@ private:
   void OnAddTruss(wxCommandEvent &event);       // Add truss from library
   void OnAddSceneObject(wxCommandEvent &event); // Add generic scene object
   void OnDelete(wxCommandEvent &event);         // Delete selected items
+  void OnLayout2DView(wxCommandEvent &event);   // Layout 2D view placeholder
 
   void OnPaneClose(wxAuiManagerEvent &event); // Keep View menu in sync
 
@@ -181,6 +183,7 @@ enum {
   ID_View_Layout_Default,
   ID_View_Layout_2D,
   ID_View_Layout_Mode,
+  ID_View_Layout_2DView,
   ID_Tools_DownloadGdtf,
   ID_Tools_EditDictionaries,
   ID_Tools_ImportRiderText,

--- a/resources/icons/icons-usage.json
+++ b/resources/icons/icons-usage.json
@@ -5,6 +5,7 @@
     "Save": "outline/save.svg",
     "Save As": "outline/save-all.svg",
     "Import MVR": "outline/file-input.svg",
-    "Export MVR": "outline/file-output.svg"
+    "Export MVR": "outline/file-output.svg",
+    "Layout 2D View": "outline/panel-top-bottom-dashed.svg"
   }
 }

--- a/resources/icons/outline/panel-top-bottom-dashed.svg
+++ b/resources/icons/outline/panel-top-bottom-dashed.svg
@@ -1,0 +1,23 @@
+<!-- @license lucide-static v0.562.0 - ISC -->
+<svg
+  class="lucide lucide-panel-top-bottom-dashed"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M14 15h1" />
+  <path d="M14 9h1" />
+  <path d="M19 15h2" />
+  <path d="M19 9h2" />
+  <path d="M3 15h2" />
+  <path d="M3 9h2" />
+  <path d="M9 15h1" />
+  <path d="M9 9h1" />
+  <rect x="3" y="3" width="18" height="18" rx="2" />
+</svg>


### PR DESCRIPTION
### Motivation
- Provide a separate toolbar for layout editing with a dedicated "2D view" control so layout mode has its own UI group.
- Ensure the File toolbar remains available when switching to layout mode and that the layout toolbar only appears in layout-editing perspective.
- Include a Lucide SVG icon for the new toolbar button and register its usage for packaging/resource tracking.

### Description
- Added a new `wxAuiToolBar *layoutToolBar` member and a new ID `ID_View_Layout_2DView`, plus an empty handler `OnLayout2DView` and `EVT_MENU` binding.
- Created the `LayoutToolbar` in `MainWindow::CreateToolBars` with a single `Vista 2D` button using `loadToolbarIcon("panel-top-bottom-dashed", wxART_MISSING_IMAGE)` and registered it as an AUI pane named `LayoutToolbar` on row 1.
- Made layout mode always show `FileToolbar` and `LayoutToolbar` in `ApplyLayoutModePerspective`, and hid `LayoutToolbar` (while ensuring `FileToolbar` is shown) in `OnApplyDefaultLayout` and `OnApply2DLayout`.
- Added the icon file `resources/icons/outline/panel-top-bottom-dashed.svg` and updated `resources/icons/icons-usage.json` with the entry `"Layout 2D View": "outline/panel-top-bottom-dashed.svg"`.

### Testing
- No automated tests were executed for this change.
- Changes were compiled and committed locally (manual verification steps used during development).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949a88782ec8324a96e9befc9c2e345)