### PR TITLE
Add per-layout 2D view state storage and avoid mutating global Viewer2D config in layout mode

### DIFF
--- a/core/layouts/LayoutCollection.cpp
+++ b/core/layouts/LayoutCollection.cpp
@@ -72,6 +72,18 @@ bool LayoutCollection::SetLayoutOrientation(const std::string &name,
   return false;
 }
 
+bool LayoutCollection::UpdateLayout2DViewState(const std::string &name,
+                                               const Layout2DViewState &state) {
+  for (auto &layout : layouts) {
+    if (layout.name == name) {
+      layout.view2dState = state;
+      layout.hasView2dState = true;
+      return true;
+    }
+  }
+  return false;
+}
+
 void LayoutCollection::ReplaceAll(std::vector<LayoutDefinition> updated) {
   if (updated.empty()) {
     layouts = {DefaultLayout()};
@@ -85,6 +97,7 @@ LayoutDefinition LayoutCollection::DefaultLayout() {
   layout.name = "Layout 1";
   layout.pageSetup.pageSize = print::PageSize::A4;
   layout.pageSetup.landscape = false;
+  layout.hasView2dState = false;
   return layout;
 }
 

--- a/core/layouts/LayoutCollection.h
+++ b/core/layouts/LayoutCollection.h
@@ -17,6 +17,7 @@
  */
 #pragma once
 
+#include <array>
 #include <string>
 #include <vector>
 
@@ -24,9 +25,43 @@
 
 namespace layouts {
 
+struct Layout2DViewState {
+  float offsetPixelsX = 0.0f;
+  float offsetPixelsY = 0.0f;
+  float zoom = 1.0f;
+  int viewportWidth = 0;
+  int viewportHeight = 0;
+  int view = 0;
+
+  int renderMode = 2;
+  bool darkMode = true;
+  bool showGrid = true;
+  int gridStyle = 0;
+  float gridColorR = 0.35f;
+  float gridColorG = 0.35f;
+  float gridColorB = 0.35f;
+  bool gridDrawAbove = false;
+
+  std::array<bool, 3> showLabelName = {true, true, true};
+  std::array<bool, 3> showLabelId = {true, true, true};
+  std::array<bool, 3> showLabelDmx = {true, true, true};
+  float labelFontSizeName = 3.0f;
+  float labelFontSizeId = 2.0f;
+  float labelFontSizeDmx = 4.0f;
+  std::array<float, 3> labelOffsetDistance = {0.5f, 0.5f, 0.5f};
+  std::array<float, 3> labelOffsetAngle = {180.0f, 180.0f, 180.0f};
+
+  std::vector<std::string> hiddenLayers;
+
+  int frameWidth = 0;
+  int frameHeight = 0;
+};
+
 struct LayoutDefinition {
   std::string name;
   print::PageSetup pageSetup;
+  Layout2DViewState view2dState;
+  bool hasView2dState = false;
 };
 
 class LayoutCollection {
@@ -41,6 +76,8 @@ public:
                     const std::string &newName);
   bool RemoveLayout(const std::string &name);
   bool SetLayoutOrientation(const std::string &name, bool landscape);
+  bool UpdateLayout2DViewState(const std::string &name,
+                               const Layout2DViewState &state);
 
   void ReplaceAll(std::vector<LayoutDefinition> layouts);
 

--- a/core/layouts/LayoutManager.h
+++ b/core/layouts/LayoutManager.h
@@ -34,6 +34,8 @@ public:
                     const std::string &newName);
   bool RemoveLayout(const std::string &name);
   bool SetLayoutOrientation(const std::string &name, bool landscape);
+  bool UpdateLayout2DViewState(const std::string &name,
+                               const Layout2DViewState &state);
 
   void LoadFromConfig(ConfigManager &cfg);
   void SaveToConfig(ConfigManager &cfg) const;

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -146,6 +146,7 @@ private:
   void UpdateViewMenuChecks();
   void OnLayoutSelected(wxCommandEvent &event);
   void ActivateLayoutView(const std::string &layoutName);
+  void PersistLayout2DViewState();
   void SyncSceneData();
   bool ConfirmSaveIfDirty(const wxString &actionLabel,
                           const wxString &dialogTitle);
@@ -153,6 +154,7 @@ private:
   std::string default2DLayoutPerspective;
   std::string layoutModePerspective;
   bool layoutModeActive = false;
+  std::string activeLayoutName;
 
   inline static MainWindow *s_instance = nullptr;
   wxDECLARE_EVENT_TABLE();


### PR DESCRIPTION
### Motivation
- Provide a dedicated, per-layout snapshot for the 2D viewer so each layout can store its own camera, render and layer settings.
- Capture the Viewer2D state by value when entering/activating a layout so the layout keeps an independent copy instead of sharing references.
- Ensure that layout-mode edits are persisted to the `LayoutDefinition` and not written back into the global `Viewer2D` config.
- Avoid corrupting or mixing global viewer state while switching between normal and layout-edit modes.

### Description
- Added a new `layouts::Layout2DViewState` structure and extended `LayoutDefinition` with `view2dState` and `hasView2dState` in `core/layouts/LayoutCollection.h` and implemented update logic in `LayoutCollection.cpp`.
- Extended `LayoutManager` with `UpdateLayout2DViewState` and updated JSON serialization/parsing in `core/layouts/LayoutManager.cpp` to persist/restore the `view2dState` block.
- Added capture and persistence helpers in `gui/mainwindow.cpp`: `CaptureViewer2DState`, `PersistLayout2DViewState`, and logic in `ActivateLayoutView` and `SaveCameraSettings` to copy state by value into the active `LayoutDefinition` and to avoid writing layout-mode 2D state back to the global viewer config.
- Kept existing `Viewer2DPanel` behavior unchanged so the global viewer continues to read/write only its own config keys (save path gated by `layoutModeActive`).

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949ac486ad48324936f3fd83df93bdd)