### PR TITLE
Add per-view 2D layout serialization

### DIFF
--- a/core/layouts/LayoutCollection.cpp
+++ b/core/layouts/LayoutCollection.cpp
@@ -72,12 +72,20 @@ bool LayoutCollection::SetLayoutOrientation(const std::string &name,
   return false;
 }
 
-bool LayoutCollection::UpdateLayout2DViewState(const std::string &name,
-                                               const Layout2DViewState &state) {
+bool LayoutCollection::UpdateLayout2DView(const std::string &name,
+                                          const Layout2DViewDefinition &view) {
   for (auto &layout : layouts) {
     if (layout.name == name) {
-      layout.view2dState = state;
-      layout.hasView2dState = true;
+      bool replaced = false;
+      for (auto &entry : layout.view2dViews) {
+        if (entry.camera.view == view.camera.view) {
+          entry = view;
+          replaced = true;
+          break;
+        }
+      }
+      if (!replaced)
+        layout.view2dViews.push_back(view);
       return true;
     }
   }
@@ -97,7 +105,7 @@ LayoutDefinition LayoutCollection::DefaultLayout() {
   layout.name = "Layout 1";
   layout.pageSetup.pageSize = print::PageSize::A4;
   layout.pageSetup.landscape = false;
-  layout.hasView2dState = false;
+  layout.view2dViews.clear();
   return layout;
 }
 

--- a/core/layouts/LayoutCollection.h
+++ b/core/layouts/LayoutCollection.h
@@ -25,14 +25,23 @@
 
 namespace layouts {
 
-struct Layout2DViewState {
+struct Layout2DViewFrame {
+  int x = 0;
+  int y = 0;
+  int width = 0;
+  int height = 0;
+};
+
+struct Layout2DViewCameraState {
   float offsetPixelsX = 0.0f;
   float offsetPixelsY = 0.0f;
   float zoom = 1.0f;
   int viewportWidth = 0;
   int viewportHeight = 0;
   int view = 0;
+};
 
+struct Layout2DViewRenderOptions {
   int renderMode = 2;
   bool darkMode = true;
   bool showGrid = true;
@@ -50,18 +59,23 @@ struct Layout2DViewState {
   float labelFontSizeDmx = 4.0f;
   std::array<float, 3> labelOffsetDistance = {0.5f, 0.5f, 0.5f};
   std::array<float, 3> labelOffsetAngle = {180.0f, 180.0f, 180.0f};
+};
 
+struct Layout2DViewLayers {
   std::vector<std::string> hiddenLayers;
+};
 
-  int frameWidth = 0;
-  int frameHeight = 0;
+struct Layout2DViewDefinition {
+  Layout2DViewFrame frame;
+  Layout2DViewCameraState camera;
+  Layout2DViewRenderOptions renderOptions;
+  Layout2DViewLayers layers;
 };
 
 struct LayoutDefinition {
   std::string name;
   print::PageSetup pageSetup;
-  Layout2DViewState view2dState;
-  bool hasView2dState = false;
+  std::vector<Layout2DViewDefinition> view2dViews;
 };
 
 class LayoutCollection {
@@ -76,8 +90,8 @@ public:
                     const std::string &newName);
   bool RemoveLayout(const std::string &name);
   bool SetLayoutOrientation(const std::string &name, bool landscape);
-  bool UpdateLayout2DViewState(const std::string &name,
-                               const Layout2DViewState &state);
+  bool UpdateLayout2DView(const std::string &name,
+                          const Layout2DViewDefinition &view);
 
   void ReplaceAll(std::vector<LayoutDefinition> layouts);
 

--- a/core/layouts/LayoutManager.h
+++ b/core/layouts/LayoutManager.h
@@ -34,8 +34,8 @@ public:
                     const std::string &newName);
   bool RemoveLayout(const std::string &name);
   bool SetLayoutOrientation(const std::string &name, bool landscape);
-  bool UpdateLayout2DViewState(const std::string &name,
-                               const Layout2DViewState &state);
+  bool UpdateLayout2DView(const std::string &name,
+                          const Layout2DViewDefinition &view);
 
   void LoadFromConfig(ConfigManager &cfg);
   void SaveToConfig(ConfigManager &cfg) const;


### PR DESCRIPTION
### Motivation
- Provide structured, per-view 2D state on each layout so multiple 2D view configurations can be stored independently. 
- Allow the layout system to persist camera, frame, render options and layer visibility per 2D view. 
- Keep compatibility with the legacy single `view2dState` JSON while migrating to a `view2dViews` array. 

### Description
- Introduce `Layout2DViewFrame`, `Layout2DViewCameraState`, `Layout2DViewRenderOptions`, `Layout2DViewLayers` and `Layout2DViewDefinition` and replace the single `Layout2DViewState` with a `std::vector<Layout2DViewDefinition>` in `LayoutDefinition` (`core/layouts/LayoutCollection.h`).
- Add `UpdateLayout2DView` to `LayoutCollection` and `LayoutManager` and implement per-view replace-or-append semantics based on the view index (`camera.view`) (`core/layouts/LayoutCollection.cpp`, `core/layouts/LayoutManager.cpp`, `core/layouts/LayoutManager.h`).
- Extend JSON serialization and parsing to emit/consume a `view2dViews` array, and add helpers to read/write `frame`, `camera`, `renderOptions` and `layers`; keep backward compatibility by parsing legacy `view2dState` into a single `view2dViews` entry when present (`core/layouts/LayoutManager.cpp`).
- Update GUI code to capture and persist the new per-view definition via `CaptureViewer2DViewDefinition` and to use `LayoutManager::UpdateLayout2DView` when switching or saving layouts, ensuring each view index maintains its own state (`gui/mainwindow.cpp`).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949af3fa2a48324929c48e05857d0bd)