### PR TITLE
Add interactive 2D frame editing to LayoutViewerPanel

### DIFF
--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -36,12 +36,34 @@ private:
   void OnCaptureLost(wxMouseCaptureLostEvent &event);
 
   void ResetViewToFit();
+  wxRect GetPageRect() const;
+  bool GetFrameRect(const layouts::Layout2DViewFrame &frame,
+                    wxRect &rect) const;
+  layouts::Layout2DViewDefinition *GetEditableView();
+  const layouts::Layout2DViewDefinition *GetEditableView() const;
+  void UpdateFrame(const layouts::Layout2DViewFrame &frame,
+                   bool updatePosition);
+
+  enum class FrameDragMode {
+    None,
+    Move,
+    ResizeRight,
+    ResizeBottom,
+    ResizeCorner
+  };
+
+  FrameDragMode HitTestFrame(const wxPoint &pos, const wxRect &frameRect) const;
+  wxCursor CursorForMode(FrameDragMode mode) const;
 
   layouts::LayoutDefinition currentLayout;
   double zoom = 1.0;
   wxPoint panOffset{0, 0};
   bool isPanning = false;
   wxPoint lastMousePos{0, 0};
+  FrameDragMode dragMode = FrameDragMode::None;
+  FrameDragMode hoverMode = FrameDragMode::None;
+  wxPoint dragStartPos{0, 0};
+  layouts::Layout2DViewFrame dragStartFrame;
 
   wxDECLARE_EVENT_TABLE();
 };


### PR DESCRIPTION
### Motivation
- Provide an interaction mode to select, move and resize the 2D frame shown in the layout viewer so users can adjust the viewport frame visually.
- Persist frame size/position back into the layout definition while only modifying dimensions during resize operations.
- Prevent accidental zoom/pan while the user is actively manipulating the frame.
- Give clear visual feedback (handles and cursor changes) to distinguish editing vs navigation.

### Description
- Added new API and state to `LayoutViewerPanel` (`GetPageRect`, `GetFrameRect`, `GetEditableView`, `UpdateFrame`, `FrameDragMode` and related members) and constants for handle sizing and minimum frame size.
- Draw frame outline and three resize handles in `OnPaint`, plus cursor feedback via `CursorForMode`, and hit-testing with `HitTestFrame` to detect `Move`, `ResizeRight`, `ResizeBottom`, and `ResizeCorner` operations.
- Implemented drag handling in `OnLeftDown`/`OnMouseMove`/`OnLeftUp` to move/resize the frame and call `layouts::LayoutManager::Get().UpdateLayout2DView` to persist edits when the layout has a name.
- Blocked navigation while editing by skipping wheel zoom when a drag is active and preventing panning during frame manipulation.

### Testing
- No automated tests were executed for this change.
- The change was compiled and committed as part of the local development workflow (no CI run recorded).
- Manual runtime verification was not recorded in automated test logs.
- Further unit/integration tests and UI tests are recommended to validate edge cases and persistence across layouts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949b0cfa71c8324ae6e8597570c0fb0)