### PR TITLE
Add 2D viewer state capture and restore for layout 2D view editing

### DIFF
--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -18,8 +18,11 @@
 #pragma once
 
 #include "projectutils.h"
+#include "viewer2dstate.h"
 #include <wx/aui/aui.h>
 #include <wx/wx.h>
+
+#include <optional>
 
 wxDECLARE_EVENT(EVT_PROJECT_LOADED, wxCommandEvent);
 
@@ -137,6 +140,8 @@ private:
   void OnAddSceneObject(wxCommandEvent &event); // Add generic scene object
   void OnDelete(wxCommandEvent &event);         // Delete selected items
   void OnLayout2DView(wxCommandEvent &event);   // Layout 2D view placeholder
+  void OnLayout2DViewOk(wxCommandEvent &event); // Confirm layout 2D view edit
+  void OnLayout2DViewCancel(wxCommandEvent &event); // Cancel layout 2D edit
 
   void OnPaneClose(wxAuiManagerEvent &event); // Keep View menu in sync
 
@@ -155,6 +160,10 @@ private:
   std::string layoutModePerspective;
   bool layoutModeActive = false;
   std::string activeLayoutName;
+  bool layout2DViewEditing = false;
+  bool layout2DViewPrevViewportShown = false;
+  bool layout2DViewPrevRenderShown = false;
+  std::optional<viewer2d::Viewer2DState> layout2DViewSavedState;
 
   inline static MainWindow *s_instance = nullptr;
   wxDECLARE_EVENT_TABLE();
@@ -186,6 +195,8 @@ enum {
   ID_View_Layout_2D,
   ID_View_Layout_Mode,
   ID_View_Layout_2DView,
+  ID_View_Layout_2DView_Ok,
+  ID_View_Layout_2DView_Cancel,
   ID_Tools_DownloadGdtf,
   ID_Tools_EditDictionaries,
   ID_Tools_ImportRiderText,

--- a/viewer2d/viewer2dstate.cpp
+++ b/viewer2d/viewer2dstate.cpp
@@ -1,0 +1,179 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "viewer2dstate.h"
+
+#include "configmanager.h"
+#include "viewer2dpanel.h"
+#include "viewer2drenderpanel.h"
+
+#include <algorithm>
+#include <array>
+#include <unordered_set>
+
+namespace viewer2d {
+namespace {
+const std::array<const char *, 3> kLabelNameKeys = {"label_show_name_top",
+                                                    "label_show_name_front",
+                                                    "label_show_name_side"};
+const std::array<const char *, 3> kLabelIdKeys = {"label_show_id_top",
+                                                  "label_show_id_front",
+                                                  "label_show_id_side"};
+const std::array<const char *, 3> kLabelDmxKeys = {"label_show_dmx_top",
+                                                   "label_show_dmx_front",
+                                                   "label_show_dmx_side"};
+const std::array<const char *, 3> kLabelOffsetDistanceKeys = {
+    "label_offset_distance_top", "label_offset_distance_front",
+    "label_offset_distance_side"};
+const std::array<const char *, 3> kLabelOffsetAngleKeys = {
+    "label_offset_angle_top", "label_offset_angle_front",
+    "label_offset_angle_side"};
+} // namespace
+
+Viewer2DState CaptureState(const Viewer2DPanel *panel,
+                           const ConfigManager &cfg) {
+  Viewer2DState state;
+  if (panel) {
+    const auto viewState = panel->GetViewState();
+    state.camera.offsetPixelsX = viewState.offsetPixelsX;
+    state.camera.offsetPixelsY = viewState.offsetPixelsY;
+    state.camera.zoom = viewState.zoom;
+    state.camera.viewportWidth = viewState.viewportWidth;
+    state.camera.viewportHeight = viewState.viewportHeight;
+    state.camera.view = static_cast<int>(viewState.view);
+  } else {
+    state.camera.offsetPixelsX = cfg.GetFloat("view2d_offset_x");
+    state.camera.offsetPixelsY = cfg.GetFloat("view2d_offset_y");
+    state.camera.zoom = cfg.GetFloat("view2d_zoom");
+    state.camera.view = static_cast<int>(cfg.GetFloat("view2d_view"));
+  }
+
+  state.renderOptions.renderMode =
+      static_cast<int>(cfg.GetFloat("view2d_render_mode"));
+  state.renderOptions.darkMode = cfg.GetFloat("view2d_dark_mode") != 0.0f;
+  state.renderOptions.showGrid = cfg.GetFloat("grid_show") != 0.0f;
+  state.renderOptions.gridStyle =
+      static_cast<int>(cfg.GetFloat("grid_style"));
+  state.renderOptions.gridColorR = cfg.GetFloat("grid_color_r");
+  state.renderOptions.gridColorG = cfg.GetFloat("grid_color_g");
+  state.renderOptions.gridColorB = cfg.GetFloat("grid_color_b");
+  state.renderOptions.gridDrawAbove = cfg.GetFloat("grid_draw_above") != 0.0f;
+
+  for (size_t i = 0; i < state.renderOptions.showLabelName.size(); ++i) {
+    state.renderOptions.showLabelName[i] =
+        cfg.GetFloat(kLabelNameKeys[i]) != 0.0f;
+    state.renderOptions.showLabelId[i] =
+        cfg.GetFloat(kLabelIdKeys[i]) != 0.0f;
+    state.renderOptions.showLabelDmx[i] =
+        cfg.GetFloat(kLabelDmxKeys[i]) != 0.0f;
+    state.renderOptions.labelOffsetDistance[i] =
+        cfg.GetFloat(kLabelOffsetDistanceKeys[i]);
+    state.renderOptions.labelOffsetAngle[i] =
+        cfg.GetFloat(kLabelOffsetAngleKeys[i]);
+  }
+  state.renderOptions.labelFontSizeName = cfg.GetFloat("label_font_size_name");
+  state.renderOptions.labelFontSizeId = cfg.GetFloat("label_font_size_id");
+  state.renderOptions.labelFontSizeDmx = cfg.GetFloat("label_font_size_dmx");
+
+  state.layers.hiddenLayers.clear();
+  auto hidden = cfg.GetHiddenLayers();
+  state.layers.hiddenLayers.insert(state.layers.hiddenLayers.end(),
+                                   hidden.begin(), hidden.end());
+  std::sort(state.layers.hiddenLayers.begin(), state.layers.hiddenLayers.end());
+
+  return state;
+}
+
+void ApplyState(Viewer2DPanel *panel, Viewer2DRenderPanel *renderPanel,
+                ConfigManager &cfg, const Viewer2DState &state) {
+  cfg.SetFloat("view2d_offset_x", state.camera.offsetPixelsX);
+  cfg.SetFloat("view2d_offset_y", state.camera.offsetPixelsY);
+  cfg.SetFloat("view2d_zoom", state.camera.zoom);
+  cfg.SetFloat("view2d_view", static_cast<float>(state.camera.view));
+
+  cfg.SetFloat("view2d_render_mode",
+               static_cast<float>(state.renderOptions.renderMode));
+  cfg.SetFloat("view2d_dark_mode", state.renderOptions.darkMode ? 1.0f : 0.0f);
+  cfg.SetFloat("grid_show", state.renderOptions.showGrid ? 1.0f : 0.0f);
+  cfg.SetFloat("grid_style", static_cast<float>(state.renderOptions.gridStyle));
+  cfg.SetFloat("grid_color_r", state.renderOptions.gridColorR);
+  cfg.SetFloat("grid_color_g", state.renderOptions.gridColorG);
+  cfg.SetFloat("grid_color_b", state.renderOptions.gridColorB);
+  cfg.SetFloat("grid_draw_above",
+               state.renderOptions.gridDrawAbove ? 1.0f : 0.0f);
+
+  for (size_t i = 0; i < state.renderOptions.showLabelName.size(); ++i) {
+    cfg.SetFloat(kLabelNameKeys[i],
+                 state.renderOptions.showLabelName[i] ? 1.0f : 0.0f);
+    cfg.SetFloat(kLabelIdKeys[i],
+                 state.renderOptions.showLabelId[i] ? 1.0f : 0.0f);
+    cfg.SetFloat(kLabelDmxKeys[i],
+                 state.renderOptions.showLabelDmx[i] ? 1.0f : 0.0f);
+    cfg.SetFloat(kLabelOffsetDistanceKeys[i],
+                 state.renderOptions.labelOffsetDistance[i]);
+    cfg.SetFloat(kLabelOffsetAngleKeys[i],
+                 state.renderOptions.labelOffsetAngle[i]);
+  }
+  cfg.SetFloat("label_font_size_name",
+               state.renderOptions.labelFontSizeName);
+  cfg.SetFloat("label_font_size_id", state.renderOptions.labelFontSizeId);
+  cfg.SetFloat("label_font_size_dmx", state.renderOptions.labelFontSizeDmx);
+
+  std::unordered_set<std::string> hidden(state.layers.hiddenLayers.begin(),
+                                         state.layers.hiddenLayers.end());
+  cfg.SetHiddenLayers(hidden);
+
+  if (panel) {
+    panel->LoadViewFromConfig();
+    panel->UpdateScene(true);
+    panel->Refresh();
+  }
+  if (renderPanel)
+    renderPanel->ApplyConfig();
+}
+
+Viewer2DState FromLayoutDefinition(const layouts::Layout2DViewDefinition &view) {
+  Viewer2DState state;
+  state.camera = view.camera;
+  state.renderOptions = view.renderOptions;
+  state.layers = view.layers;
+  return state;
+}
+
+layouts::Layout2DViewDefinition ToLayoutDefinition(
+    const Viewer2DState &state, const layouts::Layout2DViewFrame &frame) {
+  layouts::Layout2DViewDefinition view;
+  view.frame = frame;
+  view.camera = state.camera;
+  view.renderOptions = state.renderOptions;
+  view.layers = state.layers;
+  return view;
+}
+
+layouts::Layout2DViewDefinition CaptureLayoutDefinition(
+    const Viewer2DPanel *panel, const ConfigManager &cfg) {
+  layouts::Layout2DViewDefinition view =
+      ToLayoutDefinition(CaptureState(panel, cfg));
+  if (panel) {
+    const auto viewState = panel->GetViewState();
+    view.frame.width = viewState.viewportWidth;
+    view.frame.height = viewState.viewportHeight;
+  }
+  return view;
+}
+
+} // namespace viewer2d

--- a/viewer2d/viewer2dstate.h
+++ b/viewer2d/viewer2dstate.h
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "layouts/LayoutCollection.h"
+
+class ConfigManager;
+class Viewer2DPanel;
+class Viewer2DRenderPanel;
+
+namespace viewer2d {
+
+struct Viewer2DState {
+  layouts::Layout2DViewCameraState camera;
+  layouts::Layout2DViewRenderOptions renderOptions;
+  layouts::Layout2DViewLayers layers;
+};
+
+Viewer2DState CaptureState(const Viewer2DPanel *panel,
+                           const ConfigManager &cfg);
+void ApplyState(Viewer2DPanel *panel, Viewer2DRenderPanel *renderPanel,
+                ConfigManager &cfg, const Viewer2DState &state);
+
+Viewer2DState FromLayoutDefinition(const layouts::Layout2DViewDefinition &view);
+layouts::Layout2DViewDefinition ToLayoutDefinition(
+    const Viewer2DState &state, const layouts::Layout2DViewFrame &frame = {});
+layouts::Layout2DViewDefinition CaptureLayoutDefinition(
+    const Viewer2DPanel *panel, const ConfigManager &cfg);
+
+} // namespace viewer2d


### PR DESCRIPTION
### Motivation
- Provide a serializable representation of the global 2D viewer state (camera, render options, layers) so layout views can be applied and stored reliably.
- Preserve the user’s global 2D viewport while allowing editing of layout-specific 2D views and avoid losing the global configuration when entering layout edit mode.
- Allow the layout editing flow to apply a saved layout view for preview and then either commit the changes into the layout or revert back to the original global state.

### Description
- Added `viewer2d/viewer2dstate.h` and `viewer2d/viewer2dstate.cpp` implementing `viewer2d::Viewer2DState` plus `CaptureState()`, `ApplyState()`, conversion helpers `FromLayoutDefinition()` / `ToLayoutDefinition()` and `CaptureLayoutDefinition()`.
- Integrated state helpers into `gui/mainwindow.*` by including `viewer2dstate.h`, adding toolbar actions and event IDs for layout OK/Cancel, and implementing `OnLayout2DView()`, `OnLayout2DViewOk()` and `OnLayout2DViewCancel()` to save the global state, apply the selected layout view, and restore or persist state on Cancel/OK respectively.
- Switched existing layout capture calls to use `viewer2d::CaptureLayoutDefinition()` and updated `PersistLayout2DViewState()` to use the new capture helper.
- Introduced temporary state fields in `MainWindow` to track whether layout 2D view edit is active and to store the saved `viewer2d::Viewer2DState` for restoration.

### Testing
- No automated tests were executed for this change (no CI or unit tests were run as part of this rollout).
- Manual compilation and runtime verification were not executed by the automated rollout process and should be performed locally or in CI before merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949e2a1fc608324ac3e4ca15cbf9481)