### PR TITLE
Fix layout 2D view editing access

### DIFF
--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -25,6 +25,8 @@ public:
   explicit LayoutViewerPanel(wxWindow *parent);
 
   void SetLayoutDefinition(const layouts::LayoutDefinition &layout);
+  layouts::Layout2DViewDefinition *GetEditableView();
+  const layouts::Layout2DViewDefinition *GetEditableView() const;
 
 private:
   void OnPaint(wxPaintEvent &event);
@@ -39,8 +41,6 @@ private:
   wxRect GetPageRect() const;
   bool GetFrameRect(const layouts::Layout2DViewFrame &frame,
                     wxRect &rect) const;
-  layouts::Layout2DViewDefinition *GetEditableView();
-  const layouts::Layout2DViewDefinition *GetEditableView() const;
   void UpdateFrame(const layouts::Layout2DViewFrame &frame,
                    bool updatePosition);
 

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -2151,10 +2151,6 @@ void MainWindow::OnLayout2DViewCancel(wxCommandEvent &WXUNUSED(event)) {
   layout2DViewEditing = false;
 }
 
-void MainWindow::OnLayout2DViewOk(wxCommandEvent &WXUNUSED(event)) {}
-
-void MainWindow::OnLayout2DViewCancel(wxCommandEvent &WXUNUSED(event)) {}
-
 void MainWindow::PersistLayout2DViewState() {
   if (!layoutModeActive || activeLayoutName.empty())
     return;


### PR DESCRIPTION
### Motivation
- Resolve compile-time errors caused by `MainWindow` needing access to the editable 2D view while `LayoutViewerPanel::GetEditableView()` was private. 
- Remove duplicate empty handler definitions for layout 2D view OK/Cancel that caused multiple-definition build errors. 
- Make the viewer panel API usable from other GUI code to allow reading/updating the editable view. 

### Description
- Made `GetEditableView()` and its `const` overload public in `gui/layoutviewerpanel.h` so external callers can access the editable view. 
- Removed duplicate empty implementations of `MainWindow::OnLayout2DViewOk` and `MainWindow::OnLayout2DViewCancel` from `gui/mainwindow.cpp`. 
- Kept existing behavior for updating and persisting layout 2D views; no logic changes beyond visibility and duplicate removal. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949e639a1d08324805315ffdd85095e)