### PR TITLE
Add layout toolbar action to create 2D views

### DIFF
--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -139,7 +139,7 @@ private:
   void OnAddTruss(wxCommandEvent &event);       // Add truss from library
   void OnAddSceneObject(wxCommandEvent &event); // Add generic scene object
   void OnDelete(wxCommandEvent &event);         // Delete selected items
-  void OnLayout2DView(wxCommandEvent &event);   // Layout 2D view placeholder
+  void OnLayoutAdd2DView(wxCommandEvent &event); // Layout 2D view creation
   void OnLayout2DViewOk(wxCommandEvent &event); // Confirm layout 2D view edit
   void OnLayout2DViewCancel(wxCommandEvent &event); // Cancel layout 2D edit
 


### PR DESCRIPTION
### Motivation
- Provide a toolbar action that creates a new visible 2D view frame in the active layout instead of opening the editor. 
- Seed the newly created layout view with the current global 2D viewer state so the frame matches the user viewport (offset/zoom/render options/layers). 
- Create a sensible default frame sized and centered on the page when inserting a new 2D view. 

### Description
- Renamed the handler and menu binding from `OnLayout2DView` to `OnLayoutAdd2DView` and updated the toolbar label to `"Añadir vista 2D"` in `gui/mainwindow.cpp` and `gui/mainwindow.h`.
- Added helper `BuildDefaultLayout2DFrame` to compute a centered default `Layout2DViewFrame` based on the layout page size and minimum size in `gui/mainwindow.cpp`.
- Implemented `OnLayoutAdd2DView` to `CaptureState` from the global 2D viewer, build a `Layout2DViewDefinition` with `viewer2d::ToLayoutDefinition`, insert it via `layouts::LayoutManager::Get().UpdateLayout2DView`, and refresh the active `layoutViewerPanel`.
- Minor include and formatting updates (`<cmath>` added) and removed the previous edit-mode flow so the editor is not opened on add.

### Testing
- No automated tests were executed as part of this change.
- Project files were updated and the changes were committed locally using the repository workflow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949e72dc24c832496c4ce206a18bb49)