### PR TITLE
Enable 2D layout view edit workflow from layout viewer

### DIFF
--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -20,6 +20,8 @@
 #include <wx/wx.h>
 #include "layouts/LayoutCollection.h"
 
+wxDECLARE_EVENT(EVT_LAYOUT_VIEW_EDIT, wxCommandEvent);
+
 class LayoutViewerPanel : public wxPanel {
 public:
   explicit LayoutViewerPanel(wxWindow *parent);
@@ -33,9 +35,12 @@ private:
   void OnSize(wxSizeEvent &event);
   void OnLeftDown(wxMouseEvent &event);
   void OnLeftUp(wxMouseEvent &event);
+  void OnLeftDClick(wxMouseEvent &event);
   void OnMouseMove(wxMouseEvent &event);
   void OnMouseWheel(wxMouseEvent &event);
   void OnCaptureLost(wxMouseCaptureLostEvent &event);
+  void OnRightUp(wxMouseEvent &event);
+  void OnEditView(wxCommandEvent &event);
 
   void ResetViewToFit();
   wxRect GetPageRect() const;
@@ -43,6 +48,7 @@ private:
                     wxRect &rect) const;
   void UpdateFrame(const layouts::Layout2DViewFrame &frame,
                    bool updatePosition);
+  void EmitEditViewRequest();
 
   enum class FrameDragMode {
     None,

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -142,12 +142,14 @@ private:
   void OnLayoutAdd2DView(wxCommandEvent &event); // Layout 2D view creation
   void OnLayout2DViewOk(wxCommandEvent &event); // Confirm layout 2D view edit
   void OnLayout2DViewCancel(wxCommandEvent &event); // Cancel layout 2D edit
+  void OnLayoutViewEdit(wxCommandEvent &event);
 
   void OnPaneClose(wxAuiManagerEvent &event); // Keep View menu in sync
 
   void SaveCameraSettings();
   void ApplySavedLayout();
   void ApplyLayoutModePerspective();
+  void BeginLayout2DViewEdit();
   void UpdateViewMenuChecks();
   void OnLayoutSelected(wxCommandEvent &event);
   void ActivateLayoutView(const std::string &layoutName);
@@ -164,6 +166,7 @@ private:
   bool layout2DViewPrevViewportShown = false;
   bool layout2DViewPrevRenderShown = false;
   std::optional<viewer2d::Viewer2DState> layout2DViewSavedState;
+  std::string layout2DViewPrevPerspective;
 
   inline static MainWindow *s_instance = nullptr;
   wxDECLARE_EVENT_TABLE();

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -240,6 +240,11 @@ void Viewer2DPanel::CaptureFrameAsync(
   Refresh();
 }
 
+void Viewer2DPanel::SetLayoutEditOverlay(std::optional<float> aspectRatio) {
+  m_layoutEditAspect = aspectRatio;
+  Refresh();
+}
+
 Viewer2DViewState Viewer2DPanel::GetViewState() const {
   int w = 0;
   int h = 0;
@@ -348,6 +353,51 @@ void Viewer2DPanel::Render() {
   // top of geometry. Scale the label size with the current zoom so they behave
   // like regular scene objects instead of remaining a constant screen size.
   m_controller.DrawAllFixtureLabels(w, h, m_zoom);
+
+  if (m_layoutEditAspect && *m_layoutEditAspect > 0.0f) {
+    float aspect = *m_layoutEditAspect;
+    float padding = static_cast<float>(std::min(w, h)) * 0.1f;
+    float maxWidth = static_cast<float>(w) - padding * 2.0f;
+    float maxHeight = static_cast<float>(h) - padding * 2.0f;
+    float targetWidth = maxWidth;
+    float targetHeight = targetWidth / aspect;
+    if (targetHeight > maxHeight) {
+      targetHeight = maxHeight;
+      targetWidth = targetHeight * aspect;
+    }
+    float left = (static_cast<float>(w) - targetWidth) * 0.5f;
+    float bottom = (static_cast<float>(h) - targetHeight) * 0.5f;
+
+    GLboolean depthEnabled = glIsEnabled(GL_DEPTH_TEST);
+    if (depthEnabled)
+      glDisable(GL_DEPTH_TEST);
+
+    glMatrixMode(GL_PROJECTION);
+    glPushMatrix();
+    glLoadIdentity();
+    glOrtho(0.0f, static_cast<float>(w), 0.0f, static_cast<float>(h), -1.0f,
+            1.0f);
+    glMatrixMode(GL_MODELVIEW);
+    glPushMatrix();
+    glLoadIdentity();
+
+    glColor3f(1.0f, 0.0f, 0.0f);
+    glLineWidth(2.0f);
+    glBegin(GL_LINE_LOOP);
+    glVertex2f(left, bottom);
+    glVertex2f(left + targetWidth, bottom);
+    glVertex2f(left + targetWidth, bottom + targetHeight);
+    glVertex2f(left, bottom + targetHeight);
+    glEnd();
+
+    glPopMatrix();
+    glMatrixMode(GL_PROJECTION);
+    glPopMatrix();
+    glMatrixMode(GL_MODELVIEW);
+
+    if (depthEnabled)
+      glEnable(GL_DEPTH_TEST);
+  }
 
   if (recordingCanvas) {
     recordingCanvas->EndFrame();

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -30,6 +30,7 @@
 #include <wx/wx.h>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 
 // Current viewport information used to rebuild the same projection when
@@ -94,6 +95,8 @@ public:
   std::shared_ptr<const SymbolDefinitionSnapshot>
   GetBottomSymbolCacheSnapshot() const;
 
+  void SetLayoutEditOverlay(std::optional<float> aspectRatio);
+
 private:
   void InitGL();
   void Render();
@@ -128,6 +131,7 @@ private:
   Viewer3DController m_controller;
   Viewer2DRenderMode m_renderMode = Viewer2DRenderMode::White;
   Viewer2DView m_view = Viewer2DView::Top;
+  std::optional<float> m_layoutEditAspect;
 
   wxDECLARE_EVENT_TABLE();
 };


### PR DESCRIPTION
### Motivation
- Allow users to enter a focused 2D view editing workflow by double-clicking or using a context menu on a 2D view frame in the layout viewer.
- Transition to an editing UI that surfaces the 2D viewport plus render/layers controls and hides unrelated panels for an uncluttered editing experience.
- Provide an explicit OK/Cancel flow that restores previous viewport/pane state when editing finishes or is cancelled.
- Give visual feedback during editing by drawing a proportional red rectangle overlay in the 2D viewport representing the layout frame.

### Description
- Added a new event `EVT_LAYOUT_VIEW_EDIT` and handlers in `gui/layoutviewerpanel.*` including `OnLeftDClick`, right-click context menu, `OnEditView`, and `EmitEditViewRequest` to trigger edit requests.
- Implemented `BeginLayout2DViewEdit()` and `OnLayoutViewEdit()` in `gui/mainwindow.*` to save current 2D state (`layout2DViewSavedState`), save/restore the AUI perspective (`layout2DViewPrevPerspective`), show the `2DViewport`/`2DRenderOptions`/`LayerPanel`, hide unrelated panes, and enable `layout2DViewEditing` with OK/Cancel handling.
- Extended the 2D renderer (`viewer2d/viewer2dpanel.*`) with `SetLayoutEditOverlay(std::optional<float>)`, a member `m_layoutEditAspect`, and rendering code to draw a red proportional rectangle centered within the viewport when editing is active.
- Updated headers and event tables to wire the new handlers and added small UI/menu wiring (`kEditMenuId`) for the context menu edit action.

### Testing
- No automated tests were executed for this change.
- Changes were compiled and committed in the workspace (commit message: `Enable 2D layout view edit mode`).
- Manual runtime verification was not recorded in automated test output.
- Further unit/integration tests are recommended to cover the edit workflow and persistence of AUI perspectives.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949e85a01b48324ae74aa3cb5adbd5a)