### PR TITLE
Restore per-view 2D layout state when switching views

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -2283,6 +2283,35 @@ void MainWindow::PersistLayout2DViewState() {
   layouts::LayoutManager::Get().UpdateLayout2DView(activeLayoutName, view);
 }
 
+void MainWindow::RestoreLayout2DViewState(int viewIndex) {
+  if (activeLayoutName.empty())
+    return;
+
+  const layouts::LayoutDefinition *layout = nullptr;
+  for (const auto &entry : layouts::LayoutManager::Get().GetLayouts().Items()) {
+    if (entry.name == activeLayoutName) {
+      layout = &entry;
+      break;
+    }
+  }
+  if (!layout)
+    return;
+
+  const layouts::Layout2DViewDefinition *match = nullptr;
+  for (const auto &view : layout->view2dViews) {
+    if (view.camera.view == viewIndex) {
+      match = &view;
+      break;
+    }
+  }
+  if (!match)
+    return;
+
+  ConfigManager &cfg = ConfigManager::Get();
+  viewer2d::ApplyState(viewport2DPanel, viewport2DRenderPanel, cfg,
+                       viewer2d::FromLayoutDefinition(*match));
+}
+
 void MainWindow::UpdateViewMenuChecks() {
   if (!auiManager || !GetMenuBar())
     return;

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -55,6 +55,8 @@ public:
   static void SetInstance(MainWindow *inst);
 
   void EnableShortcuts(bool enable);
+  void PersistLayout2DViewState();
+  void RestoreLayout2DViewState(int viewIndex);
 
 private:
   void SetupLayout();   // Set up main window layout
@@ -153,7 +155,6 @@ private:
   void UpdateViewMenuChecks();
   void OnLayoutSelected(wxCommandEvent &event);
   void ActivateLayoutView(const std::string &layoutName);
-  void PersistLayout2DViewState();
   void SyncSceneData();
   bool ConfirmSaveIfDirty(const wxString &actionLabel,
                           const wxString &dialogTitle);

--- a/viewer2d/viewer2drenderpanel.cpp
+++ b/viewer2d/viewer2drenderpanel.cpp
@@ -411,14 +411,18 @@ void Viewer2DRenderPanel::OnLabelOffsetAngle(wxSpinEvent &evt) {
 }
 
 void Viewer2DRenderPanel::OnView(wxCommandEvent &evt) {
-  int sel = m_view->GetSelection();
   ConfigManager &cfg = ConfigManager::Get();
+  if (auto *mw = MainWindow::Instance())
+    mw->PersistLayout2DViewState();
+  int sel = m_view->GetSelection();
   cfg.SetFloat("view2d_view", static_cast<float>(sel));
   m_labelOffsetDistance->SetValue(cfg.GetFloat(DIST_KEYS[sel]));
   m_labelOffsetAngle->SetValue(static_cast<int>(cfg.GetFloat(ANGLE_KEYS[sel])));
   m_showLabelName->SetValue(cfg.GetFloat(NAME_KEYS[sel]) != 0.0f);
   m_showLabelId->SetValue(cfg.GetFloat(ID_KEYS[sel]) != 0.0f);
   m_showLabelAddress->SetValue(cfg.GetFloat(DMX_KEYS[sel]) != 0.0f);
+  if (auto *mw = MainWindow::Instance())
+    mw->RestoreLayout2DViewState(sel);
   if (auto *vp = Viewer2DPanel::Instance()) {
     vp->SetView(static_cast<Viewer2DView>(sel));
     vp->UpdateScene(false);


### PR DESCRIPTION
### Motivation
- Persist and restore per-layout 2D viewer state so each saved layout keeps its own `view2d` offset/zoom/render options/layers for each 2D view (Top/Front/Side).
- Ensure the UI applies the saved 2D view state when the user switches the active 2D view or activates a layout.

### Description
- Added `MainWindow::RestoreLayout2DViewState(int)` which looks up the active layout and applies a matching `Layout2DViewDefinition` via `viewer2d::ApplyState`.
- Exposed `PersistLayout2DViewState()` in `MainWindow` header and ensured it is called before changing the selected 2D view so the previous view is saved via `viewer2d::CaptureLayoutDefinition` and `LayoutManager::UpdateLayout2DView`.
- Updated `Viewer2DRenderPanel::OnView` to call `PersistLayout2DViewState()` before changing the view index and `RestoreLayout2DViewState(sel)` after updating config so layout-specific settings are re-applied.
- Minor header/source reorganization to declare and implement the new functions and wire them into the existing layout/view switching flow.

### Testing
- No automated tests were executed for this change.
- The changes were committed locally (3 files modified) and are ready for build and runtime verification to confirm per-view layout states are saved and restored when switching views and activating layouts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949eb965d8083248269621fa2a0f0b6)