### PR TITLE
Translate layout toolbar tooltips

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -456,16 +456,16 @@ void MainWindow::CreateToolBars() {
   layoutToolBar->AddTool(ID_View_Layout_2DView, "Añadir vista 2D",
                          loadToolbarIcon("panel-top-bottom-dashed",
                                          wxART_MISSING_IMAGE),
-                         "Añadir vista 2D en layout");
+                         "Add 2D View to Layout");
   layoutToolBar->AddSeparator();
   layoutToolBar->AddTool(ID_View_Layout_2DView_Ok, "OK",
                          wxArtProvider::GetBitmapBundle(
                              wxART_TICK_MARK, wxART_TOOLBAR, wxSize(24, 24)),
-                         "Guardar vista 2D");
+                         "Save 2D View");
   layoutToolBar->AddTool(ID_View_Layout_2DView_Cancel, "Cancelar",
                          wxArtProvider::GetBitmapBundle(
                              wxART_CROSS_MARK, wxART_TOOLBAR, wxSize(24, 24)),
-                         "Cancelar edición de vista 2D");
+                         "Cancel 2D View Edit");
   layoutToolBar->Realize();
   auiManager->AddPane(
       layoutToolBar, wxAuiPaneInfo()


### PR DESCRIPTION
### Motivation

- Ensure toolbar tooltips are in English for consistency with the rest of the UI.
- Target the layout toolbar 2D view actions which previously had Spanish tooltips in `gui/mainwindow.cpp`.
- Improve clarity for users interacting with layout editing controls.

### Description

- Changed the tooltip for `ID_View_Layout_2DView` to "Add 2D View to Layout" in `gui/mainwindow.cpp`.
- Changed the tooltip for `ID_View_Layout_2DView_Ok` to "Save 2D View" in `gui/mainwindow.cpp`.
- Changed the tooltip for `ID_View_Layout_2DView_Cancel` to "Cancel 2D View Edit" in `gui/mainwindow.cpp`.
- No other labels or icon wiring were modified; only the tooltip strings were updated.

### Testing

- No automated tests were run against this change.
- The change was committed to the repository as `gui/mainwindow.cpp`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949f05d2fa0832492e97d8f4e800e10)