### PR TITLE
Add modal dialog for layout 2D view editing

### DIFF
--- a/gui/layout2dviewdialog.cpp
+++ b/gui/layout2dviewdialog.cpp
@@ -1,0 +1,47 @@
+#include "layout2dviewdialog.h"
+
+#include "viewer2dpanel.h"
+#include "viewer2drenderpanel.h"
+
+#include <wx/button.h>
+#include <wx/sizer.h>
+
+Layout2DViewDialog::Layout2DViewDialog(wxWindow *parent)
+    : wxDialog(parent, wxID_ANY, "Editar vista 2D", wxDefaultPosition,
+               wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER) {
+  auto *mainSizer = new wxBoxSizer(wxVERTICAL);
+  auto *contentSizer = new wxBoxSizer(wxHORIZONTAL);
+
+  viewerPanel = new Viewer2DPanel(this);
+  renderPanel = new Viewer2DRenderPanel(this);
+
+  contentSizer->Add(viewerPanel, 1, wxEXPAND | wxALL, 8);
+  contentSizer->Add(renderPanel, 0, wxEXPAND | wxTOP | wxBOTTOM | wxRIGHT, 8);
+
+  mainSizer->Add(contentSizer, 1, wxEXPAND);
+
+  auto *buttonSizer = new wxStdDialogButtonSizer();
+  auto *okButton = new wxButton(this, wxID_OK, "OK");
+  auto *cancelButton = new wxButton(this, wxID_CANCEL, "Cancel");
+  okButton->Bind(wxEVT_BUTTON, &Layout2DViewDialog::OnOk, this);
+  cancelButton->Bind(wxEVT_BUTTON, &Layout2DViewDialog::OnCancel, this);
+  buttonSizer->AddButton(okButton);
+  buttonSizer->AddButton(cancelButton);
+  buttonSizer->Realize();
+
+  mainSizer->Add(buttonSizer, 0, wxEXPAND | wxALL, 8);
+
+  SetSizerAndFit(mainSizer);
+  SetMinSize(wxSize(900, 600));
+  CentreOnParent();
+}
+
+void Layout2DViewDialog::OnOk(wxCommandEvent &event) {
+  EndModal(wxID_OK);
+  event.Skip();
+}
+
+void Layout2DViewDialog::OnCancel(wxCommandEvent &event) {
+  EndModal(wxID_CANCEL);
+  event.Skip();
+}

--- a/gui/layout2dviewdialog.h
+++ b/gui/layout2dviewdialog.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <wx/dialog.h>
+
+class Viewer2DPanel;
+class Viewer2DRenderPanel;
+
+class Layout2DViewDialog : public wxDialog {
+public:
+  explicit Layout2DViewDialog(wxWindow *parent);
+
+  Viewer2DPanel *GetViewerPanel() const { return viewerPanel; }
+  Viewer2DRenderPanel *GetRenderPanel() const { return renderPanel; }
+
+private:
+  void OnOk(wxCommandEvent &event);
+  void OnCancel(wxCommandEvent &event);
+
+  Viewer2DPanel *viewerPanel = nullptr;
+  Viewer2DRenderPanel *renderPanel = nullptr;
+};

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -164,10 +164,9 @@ private:
   bool layoutModeActive = false;
   std::string activeLayoutName;
   bool layout2DViewEditing = false;
-  bool layout2DViewPrevViewportShown = false;
-  bool layout2DViewPrevRenderShown = false;
   std::optional<viewer2d::Viewer2DState> layout2DViewSavedState;
-  std::string layout2DViewPrevPerspective;
+  Viewer2DPanel *layout2DViewEditPanel = nullptr;
+  Viewer2DRenderPanel *layout2DViewEditRenderPanel = nullptr;
 
   inline static MainWindow *s_instance = nullptr;
   wxDECLARE_EVENT_TABLE();


### PR DESCRIPTION
### Motivation

- Provide a dedicated modal editor for 2D layout views instead of reusing the main 2D frame so edits can be isolated and reviewed before saving.
- Embed both the 2D viewport and the 2D render options inside the modal so users can tweak rendering and camera together while editing a layout view.
- Support an explicit OK/Cancel lifecycle so changes are committed to the layout only on `OK` and the global viewer state is restored on `Cancel`.
- Preserve layout capture/persistence semantics (capture/restore state, layout frame overlay) when editing inside the dialog.

### Description

- Added `gui/layout2dviewdialog.h` and `gui/layout2dviewdialog.cpp` implementing `Layout2DViewDialog` that creates a `Viewer2DPanel` and `Viewer2DRenderPanel` and exposes `OK`/`Cancel` handlers that call `EndModal(wxID_OK)` / `EndModal(wxID_CANCEL)`.
- Updated `MainWindow::BeginLayout2DViewEdit` to instantiate the dialog, temporarily replace the global `Viewer2DPanel::Instance()` and `Viewer2DRenderPanel::Instance()` with the dialog panels, apply the layout view state to the dialog panels, show the dialog with `ShowModal()`, and restore the previous global instances after the dialog closes.
- Adjusted `OnLayout2DViewOk`, `OnLayout2DViewCancel`, `PersistLayout2DViewState`, and `RestoreLayout2DViewState` to operate on the dialog edit panels when layout editing is active so captures/persistence work correctly, and to clear the layout edit overlay via `SetLayoutEditOverlay(std::nullopt)` on close.
- Removed the previous AUI perspective/pane show/hide logic for the inline edit flow and routed OK/Cancel handling through the dialog result calls to commit or revert changes to the layout.

### Testing

- No automated tests were run as part of this change.
- Code changes were compiled and committed in the repository (no CI/test results included in this PR description).
- Manual verification performed while wiring the dialog ensured `ShowModal()` returns and `OnLayout2DViewOk/Cancel` are invoked based on dialog result (no automated checks).
- Existing layout capture/restore code paths were reused for the dialog panels so layout state persistence remains unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949f212e29883249af9d066d085b7af)