### PR TITLE
Refresh layout viewer after saving 2D view state

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -2185,19 +2185,14 @@ void MainWindow::OnLayout2DViewOk(wxCommandEvent &WXUNUSED(event)) {
   layouts::LayoutManager::Get().UpdateLayout2DView(activeLayoutName,
                                                    updatedView);
 
-  if (layout && layoutViewerPanel) {
-    layouts::LayoutDefinition updatedLayout = *layout;
-    bool replaced = false;
-    for (auto &entry : updatedLayout.view2dViews) {
-      if (entry.camera.view == updatedView.camera.view) {
-        entry = updatedView;
-        replaced = true;
+  if (layoutViewerPanel) {
+    for (const auto &entry :
+         layouts::LayoutManager::Get().GetLayouts().Items()) {
+      if (entry.name == activeLayoutName) {
+        layoutViewerPanel->SetLayoutDefinition(entry);
         break;
       }
     }
-    if (!replaced)
-      updatedLayout.view2dViews.push_back(updatedView);
-    layoutViewerPanel->SetLayoutDefinition(updatedLayout);
   }
 
   viewer2d::ApplyState(viewport2DPanel, viewport2DRenderPanel, cfg,


### PR DESCRIPTION
### Motivation
- Ensure the layout viewer panel reflects the changes made in the 2D view editor immediately after the dialog is accepted.  
- Avoid maintaining a separate local update path and instead use the canonical layout data stored by `LayoutManager`.  
- Keep the layout viewer in sync with the persisted layout definition so edits are visible when returning to normal mode.  

### Description
- Replaced the previous manual in-place `updatedLayout` modification with reloading the active layout from `layouts::LayoutManager::Get().GetLayouts().Items()` and calling `layoutViewerPanel->SetLayoutDefinition(entry)` in `gui/mainwindow.cpp`.  
- Continued to call `layouts::LayoutManager::Get().UpdateLayout2DView(activeLayoutName, updatedView)` to persist the modified view.  
- Retained restoring the editor viewport state via `viewer2d::ApplyState(...)` and clearing `layout2DViewSavedState`.  

### Testing
- No automated tests were executed for this change.  
- The change is limited to `MainWindow::OnLayout2DViewOk` in `gui/mainwindow.cpp` and does not alter `LayoutManager` serialization logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949f44708b083248ddef9e75406f540)