### PR TITLE
Update 2D view editor UI strings to English

### DIFF
--- a/gui/layout2dviewdialog.cpp
+++ b/gui/layout2dviewdialog.cpp
@@ -7,7 +7,7 @@
 #include <wx/sizer.h>
 
 Layout2DViewDialog::Layout2DViewDialog(wxWindow *parent)
-    : wxDialog(parent, wxID_ANY, "Editar vista 2D", wxDefaultPosition,
+    : wxDialog(parent, wxID_ANY, "2D View Editor", wxDefaultPosition,
                wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER) {
   auto *mainSizer = new wxBoxSizer(wxVERTICAL);
   auto *contentSizer = new wxBoxSizer(wxHORIZONTAL);

--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -262,7 +262,7 @@ void LayoutViewerPanel::OnRightUp(wxMouseEvent &event) {
   }
 
   wxMenu menu;
-  menu.Append(kEditMenuId, "Editar vista 2D");
+  menu.Append(kEditMenuId, "2D View Editor");
   PopupMenu(&menu, pos);
 }
 


### PR DESCRIPTION
### Motivation
- Replace Spanish UI strings for the 2D view editor with English to make the interface consistent.
- Ensure the dialog title and the context menu label match and are user-friendly in English.
- Reduce mixed-language labels that can confuse users interacting with 2D view editing features.

### Description
- Changed the dialog title in `gui/layout2dviewdialog.cpp` from the Spanish string to `"2D View Editor"`.
- Updated the context menu entry in `gui/layoutviewerpanel.cpp` to use `"2D View Editor"`.
- Performed a code search to locate and update the visible UI strings related to the 2D view editor.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949f69e08648324a45bc28e0edbb448)