### PR TITLE
Add missing `SetInstance` declaration to ConsolePanel test stub

### DIFF
--- a/tests/consolepanel.h
+++ b/tests/consolepanel.h
@@ -20,5 +20,6 @@
 class ConsolePanel {
 public:
     static ConsolePanel* Instance();
+    static void SetInstance(ConsolePanel*);
     void AppendMessage(const wxString&);
 };


### PR DESCRIPTION
### Motivation
- A build error reported `C2039 'SetInstance': is not a member of 'ConsolePanel'` because the test stub header did not declare a `SetInstance` method that the stub implementation and production code use.
- The test header needed to match the real `ConsolePanel` API to allow tests and compilation to proceed.

### Description
- Added the declaration `static void SetInstance(ConsolePanel*);` to `tests/consolepanel.h`.
- Left the existing `Instance()` and `AppendMessage()` declarations unchanged to preserve the stub API.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a8ac6259c8324b3c51aae1f43a221)