### PR TITLE
Adjust help dialog size and enable maximize box

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -2431,8 +2431,13 @@ void MainWindow::OnShowHelp(wxCommandEvent &WXUNUSED(event)) {
 
     // Create a resizable dialog containing a wxHtmlWindow to render the
     // generated HTML.
+    const wxSize parentSize = GetSize();
+    const wxSize dialogSize(
+        std::max(900, static_cast<int>(parentSize.x * 0.85)),
+        std::max(700, static_cast<int>(parentSize.y * 0.85)));
     wxDialog dlg(this, wxID_ANY, "Perastage Help", wxDefaultPosition,
-                 wxSize(800, 600), wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER);
+                 dialogSize,
+                 wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxMAXIMIZE_BOX);
     wxBoxSizer *sizer = new wxBoxSizer(wxVERTICAL);
     wxHtmlWindow *htmlWin = new wxHtmlWindow(
         &dlg, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxHW_SCROLLBAR_AUTO);


### PR DESCRIPTION
### Motivation
- Make the help dialog more readable by increasing its initial size relative to the main window.
- Provide maximize/restore controls by enabling `wxMAXIMIZE_BOX` so users can expand the help when needed.
- Preserve resizable behavior and modal blocking so the dialog remains modal and adjustable.
- Ensure the dialog has sensible minimum dimensions to avoid too-small windows.

### Description
- Use `GetSize()` to obtain the main window size and compute `dialogSize` as the greater of `900x700` and `85%` of the parent dimensions.
- Construct the `wxDialog` with the computed `dialogSize` and add `wxMAXIMIZE_BOX` while keeping `wxRESIZE_BORDER` in the style.
- The change is localized to `gui/mainwindow.cpp` in the `OnShowHelp` handler and leaves the `wxHtmlWindow` rendering and `ShowModal()` call intact.
- No other functionality was modified.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a8baba884832493aa46cd3dcf5f4d)