### PR TITLE
Remove 2D view edit toolbar actions and unused IDs

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -185,8 +185,6 @@ EVT_MENU(ID_View_Layout_Default, MainWindow::OnApplyDefaultLayout)
 EVT_MENU(ID_View_Layout_2D, MainWindow::OnApply2DLayout)
 EVT_MENU(ID_View_Layout_Mode, MainWindow::OnApplyLayoutModeLayout)
 EVT_MENU(ID_View_Layout_2DView, MainWindow::OnLayoutAdd2DView)
-EVT_MENU(ID_View_Layout_2DView_Ok, MainWindow::OnLayout2DViewOk)
-EVT_MENU(ID_View_Layout_2DView_Cancel, MainWindow::OnLayout2DViewCancel)
 EVT_MENU(ID_Tools_DownloadGdtf, MainWindow::OnDownloadGdtf)
 EVT_MENU(ID_Tools_EditDictionaries, MainWindow::OnEditDictionaries)
 EVT_MENU(ID_Tools_ExportFixture, MainWindow::OnExportFixture)
@@ -458,15 +456,6 @@ void MainWindow::CreateToolBars() {
                          loadToolbarIcon("panel-top-bottom-dashed",
                                          wxART_MISSING_IMAGE),
                          "Add 2D View to Layout");
-  layoutToolBar->AddSeparator();
-  layoutToolBar->AddTool(ID_View_Layout_2DView_Ok, "OK",
-                         wxArtProvider::GetBitmapBundle(
-                             wxART_TICK_MARK, wxART_TOOLBAR, wxSize(24, 24)),
-                         "Save 2D View");
-  layoutToolBar->AddTool(ID_View_Layout_2DView_Cancel, "Cancelar",
-                         wxArtProvider::GetBitmapBundle(
-                             wxART_CROSS_MARK, wxART_TOOLBAR, wxSize(24, 24)),
-                         "Cancel 2D View Edit");
   layoutToolBar->Realize();
   auiManager->AddPane(
       layoutToolBar, wxAuiPaneInfo()

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -198,8 +198,6 @@ enum {
   ID_View_Layout_2D,
   ID_View_Layout_Mode,
   ID_View_Layout_2DView,
-  ID_View_Layout_2DView_Ok,
-  ID_View_Layout_2DView_Cancel,
   ID_Tools_DownloadGdtf,
   ID_Tools_EditDictionaries,
   ID_Tools_ImportRiderText,


### PR DESCRIPTION
### Motivation
- Remove the inline 2D view edit toolbar controls that provided `OK`/`Cancel` actions to simplify the layout toolbar UI.
- Eliminate now-unused identifiers and event bindings related to the removed toolbar buttons to avoid dead code.
- Prevent a visual gap by removing the separator that preceded the deleted buttons.
- Keep the rest of the layout toolbar behavior intact and avoid changing pane placement.

### Description
- Deleted the `AddSeparator()` and `AddTool()` calls that added `ID_View_Layout_2DView_Ok` and `ID_View_Layout_2DView_Cancel` to the layout toolbar in `gui/mainwindow.cpp`.
- Removed the corresponding `EVT_MENU(ID_View_Layout_2DView_Ok, ...)` and `EVT_MENU(ID_View_Layout_2DView_Cancel, ...)` entries from the event table in `gui/mainwindow.cpp`.
- Removed the `ID_View_Layout_2DView_Ok` and `ID_View_Layout_2DView_Cancel` enum entries from `gui/mainwindow.h`.
- Kept the `ID_View_Layout_2DView` action and overall toolbar/pane setup unchanged.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a8e7ed9a48324aa9f80e6394a7dc8)