### PR TITLE
Enable minimize/maximize and increase initial size for Layout 2D View dialog

### DIFF
--- a/gui/layout2dviewdialog.cpp
+++ b/gui/layout2dviewdialog.cpp
@@ -8,7 +8,8 @@
 
 Layout2DViewDialog::Layout2DViewDialog(wxWindow *parent)
     : wxDialog(parent, wxID_ANY, "2D View Editor", wxDefaultPosition,
-               wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER) {
+               wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER |
+                                   wxMAXIMIZE_BOX | wxMINIMIZE_BOX) {
   auto *mainSizer = new wxBoxSizer(wxVERTICAL);
   auto *contentSizer = new wxBoxSizer(wxHORIZONTAL);
 
@@ -31,8 +32,10 @@ Layout2DViewDialog::Layout2DViewDialog(wxWindow *parent)
 
   mainSizer->Add(buttonSizer, 0, wxEXPAND | wxALL, 8);
 
-  SetSizerAndFit(mainSizer);
-  SetMinSize(wxSize(900, 600));
+  SetSizer(mainSizer);
+  SetSize(wxSize(1200, 800));
+  SetMinSize(wxSize(1000, 700));
+  Layout();
   CentreOnParent();
 }
 


### PR DESCRIPTION
### Motivation
- Allow the 2D view dialog to show minimize and maximize controls by adding the appropriate window style flags.
- Prevent the sizer from forcing an undesirably small initial size by avoiding `SetSizerAndFit` before sizing.
- Provide a more usable default size for the dialog so the embedded viewers are comfortably visible.

### Description
- Added `wxMAXIMIZE_BOX` and `wxMINIMIZE_BOX` to the `wxDialog` style in `gui/layout2dviewdialog.cpp`.
- Replaced `SetSizerAndFit(mainSizer)` with `SetSizer(mainSizer)`, then called `SetSize(wxSize(1200, 800))` and `SetMinSize(wxSize(1000, 700))` followed by `Layout()` to preserve the chosen initial size.
- Left dialog centering via `CentreOnParent()` intact and did not change control wiring for the OK/Cancel buttons.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a8f746dec8324ba5368491b7a6dcf)