### PR TITLE
Embed LayerPanel in 2D layout dialog and add optional button visibility

### DIFF
--- a/gui/layerpanel.cpp
+++ b/gui/layerpanel.cpp
@@ -30,7 +30,7 @@
 
 LayerPanel* LayerPanel::s_instance = nullptr;
 
-LayerPanel::LayerPanel(wxWindow* parent)
+LayerPanel::LayerPanel(wxWindow* parent, bool showButtons)
     : wxPanel(parent, wxID_ANY)
 {
     list = new wxDataViewListCtrl(this, wxID_ANY);
@@ -44,12 +44,16 @@ LayerPanel::LayerPanel(wxWindow* parent)
     wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
     sizer->Add(list, 1, wxEXPAND | wxALL, 5);
 
-    wxBoxSizer* btnSizer = new wxBoxSizer(wxHORIZONTAL);
-    auto* addBtn = new wxButton(this, wxID_ADD, "Add");
-    auto* delBtn = new wxButton(this, wxID_DELETE, "Delete");
-    btnSizer->Add(addBtn, 0, wxALL, 5);
-    btnSizer->Add(delBtn, 0, wxALL, 5);
-    sizer->Add(btnSizer, 0, wxALIGN_LEFT);
+    wxButton* addBtn = nullptr;
+    wxButton* delBtn = nullptr;
+    if (showButtons) {
+        wxBoxSizer* btnSizer = new wxBoxSizer(wxHORIZONTAL);
+        addBtn = new wxButton(this, wxID_ADD, "Add");
+        delBtn = new wxButton(this, wxID_DELETE, "Delete");
+        btnSizer->Add(addBtn, 0, wxALL, 5);
+        btnSizer->Add(delBtn, 0, wxALL, 5);
+        sizer->Add(btnSizer, 0, wxALIGN_LEFT);
+    }
 
     SetSizer(sizer);
 
@@ -57,8 +61,10 @@ LayerPanel::LayerPanel(wxWindow* parent)
     list->Bind(wxEVT_DATAVIEW_SELECTION_CHANGED, &LayerPanel::OnSelect, this);
     list->Bind(wxEVT_DATAVIEW_ITEM_CONTEXT_MENU, &LayerPanel::OnContext, this);
     list->Bind(wxEVT_DATAVIEW_ITEM_ACTIVATED, &LayerPanel::OnRenameLayer, this);
-    addBtn->Bind(wxEVT_BUTTON, &LayerPanel::OnAddLayer, this);
-    delBtn->Bind(wxEVT_BUTTON, &LayerPanel::OnDeleteLayer, this);
+    if (addBtn)
+        addBtn->Bind(wxEVT_BUTTON, &LayerPanel::OnAddLayer, this);
+    if (delBtn)
+        delBtn->Bind(wxEVT_BUTTON, &LayerPanel::OnDeleteLayer, this);
 
     ReloadLayers();
 }
@@ -406,4 +412,3 @@ void LayerPanel::OnRenameLayer(wxDataViewEvent& evt)
         Viewer3DPanel::Instance()->Refresh();
     }
 }
-

--- a/gui/layerpanel.h
+++ b/gui/layerpanel.h
@@ -24,7 +24,7 @@
 class LayerPanel : public wxPanel
 {
 public:
-    explicit LayerPanel(wxWindow* parent);
+    explicit LayerPanel(wxWindow* parent, bool showButtons = true);
     void ReloadLayers();
 
     static LayerPanel* Instance();
@@ -40,4 +40,3 @@ private:
     wxDataViewListCtrl* list = nullptr;
     static LayerPanel* s_instance;
 };
-

--- a/gui/layout2dviewdialog.cpp
+++ b/gui/layout2dviewdialog.cpp
@@ -1,5 +1,6 @@
 #include "layout2dviewdialog.h"
 
+#include "layerpanel.h"
 #include "viewer2dpanel.h"
 #include "viewer2drenderpanel.h"
 
@@ -15,9 +16,11 @@ Layout2DViewDialog::Layout2DViewDialog(wxWindow *parent)
 
   viewerPanel = new Viewer2DPanel(this);
   renderPanel = new Viewer2DRenderPanel(this);
+  layerPanel = new LayerPanel(this, false);
 
   contentSizer->Add(viewerPanel, 1, wxEXPAND | wxALL, 8);
   contentSizer->Add(renderPanel, 0, wxEXPAND | wxTOP | wxBOTTOM | wxRIGHT, 8);
+  contentSizer->Add(layerPanel, 0, wxEXPAND | wxTOP | wxBOTTOM | wxRIGHT, 8);
 
   mainSizer->Add(contentSizer, 1, wxEXPAND);
 

--- a/gui/layout2dviewdialog.h
+++ b/gui/layout2dviewdialog.h
@@ -4,6 +4,7 @@
 
 class Viewer2DPanel;
 class Viewer2DRenderPanel;
+class LayerPanel;
 
 class Layout2DViewDialog : public wxDialog {
 public:
@@ -18,4 +19,5 @@ private:
 
   Viewer2DPanel *viewerPanel = nullptr;
   Viewer2DRenderPanel *renderPanel = nullptr;
+  LayerPanel *layerPanel = nullptr;
 };


### PR DESCRIPTION
### Motivation
- Allow embedding the layer list inside the 2D view dialog without the Add/Delete controls for a compact layout.
- Reuse the existing `LayerPanel` inside `Layout2DViewDialog` so layers appear alongside the 2D viewer and render panels.
- Provide a simple constructor flag to toggle the presence of layer management buttons when the panel is used in different contexts.

### Description
- Changed `LayerPanel` constructor to `LayerPanel(wxWindow* parent, bool showButtons = true)` to make Add/Delete buttons optional.
- Updated `gui/layerpanel.cpp` to only create and bind the Add/Delete buttons when `showButtons` is true.
- Added a `LayerPanel* layerPanel` member to `Layout2DViewDialog` and instantiated it with `new LayerPanel(this, false)` in `gui/layout2dviewdialog.cpp`.
- Added `layerPanel` to the dialog `contentSizer` so it appears alongside `viewerPanel` and `renderPanel`.

### Testing
- No automated tests were executed for this change.
- No test failures reported because no tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a930bd14c832498ec87750f4d169f)