### PR TITLE
Adjust toolbar icon size to 16x16

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -400,7 +400,7 @@ void MainWindow::CreateToolBars() {
   fileToolBar = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition,
                                  wxDefaultSize,
                                  wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_HORIZONTAL);
-  fileToolBar->SetToolBitmapSize(wxSize(24, 24));
+  fileToolBar->SetToolBitmapSize(wxSize(16, 16));
 
   const auto loadToolbarIcon = [](const std::string &name,
                                   const wxArtID &fallbackArtId) {
@@ -408,13 +408,13 @@ void MainWindow::CreateToolBars() {
                    (name + ".svg");
     if (std::filesystem::exists(svgPath)) {
       wxBitmapBundle bundle =
-          wxBitmapBundle::FromSVGFile(svgPath.string(), wxSize(24, 24));
+          wxBitmapBundle::FromSVGFile(svgPath.string(), wxSize(16, 16));
       if (bundle.IsOk()) {
         return bundle;
       }
     }
     return wxArtProvider::GetBitmapBundle(fallbackArtId, wxART_TOOLBAR,
-                                          wxSize(24, 24));
+                                          wxSize(16, 16));
   };
   fileToolBar->AddTool(ID_File_New, "New",
                        loadToolbarIcon("file", wxART_NEW),
@@ -451,7 +451,7 @@ void MainWindow::CreateToolBars() {
   layoutToolBar = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition,
                                    wxDefaultSize,
                                    wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_HORIZONTAL);
-  layoutToolBar->SetToolBitmapSize(wxSize(24, 24));
+  layoutToolBar->SetToolBitmapSize(wxSize(16, 16));
   layoutToolBar->AddTool(ID_View_Layout_2DView, "Añadir vista 2D",
                          loadToolbarIcon("panel-top-bottom-dashed",
                                          wxART_MISSING_IMAGE),


### PR DESCRIPTION
### Motivation
- Reduce visual footprint of toolbar icons by changing them from 24x24 to 16x16 to better match the UI design.
- Ensure SVG icon loading and fallback bitmaps use the same size to avoid scaling artifacts.

### Description
- Changed `fileToolBar->SetToolBitmapSize(wxSize(24, 24))` to `wxSize(16, 16)` for the File toolbar in `CreateToolBars`.
- Changed `layoutToolBar->SetToolBitmapSize(wxSize(24, 24))` to `wxSize(16, 16)` for the Layout toolbar in `CreateToolBars`.
- Updated `wxBitmapBundle::FromSVGFile(..., wxSize(24, 24))` to `wxSize(16, 16)` and `wxArtProvider::GetBitmapBundle(..., wxSize(24, 24))` to `wxSize(16, 16)` so loaded SVGs and fallback bitmaps match the toolbar size.

### Testing
- No automated tests were run against this change.
- The change is limited to UI bitmap sizing and should not affect non-UI logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a9538294483248f4123f192d0c3ed)