### PR TITLE
Add 'Delete 2D View' context action and backend support

### DIFF
--- a/core/layouts/LayoutCollection.cpp
+++ b/core/layouts/LayoutCollection.cpp
@@ -17,6 +17,8 @@
  */
 #include "LayoutCollection.h"
 
+#include <algorithm>
+
 namespace layouts {
 
 LayoutCollection::LayoutCollection() { layouts.push_back(DefaultLayout()); }
@@ -86,6 +88,24 @@ bool LayoutCollection::UpdateLayout2DView(const std::string &name,
       }
       if (!replaced)
         layout.view2dViews.push_back(view);
+      return true;
+    }
+  }
+  return false;
+}
+
+bool LayoutCollection::RemoveLayout2DView(const std::string &name,
+                                          int viewIndex) {
+  for (auto &layout : layouts) {
+    if (layout.name == name) {
+      auto &views = layout.view2dViews;
+      auto it = std::remove_if(
+          views.begin(), views.end(), [viewIndex](const auto &entry) {
+            return entry.camera.view == viewIndex;
+          });
+      if (it == views.end())
+        return false;
+      views.erase(it, views.end());
       return true;
     }
   }

--- a/core/layouts/LayoutCollection.h
+++ b/core/layouts/LayoutCollection.h
@@ -92,6 +92,7 @@ public:
   bool SetLayoutOrientation(const std::string &name, bool landscape);
   bool UpdateLayout2DView(const std::string &name,
                           const Layout2DViewDefinition &view);
+  bool RemoveLayout2DView(const std::string &name, int viewIndex);
 
   void ReplaceAll(std::vector<LayoutDefinition> layouts);
 

--- a/core/layouts/LayoutManager.cpp
+++ b/core/layouts/LayoutManager.cpp
@@ -381,6 +381,14 @@ bool LayoutManager::UpdateLayout2DView(const std::string &name,
   return true;
 }
 
+bool LayoutManager::RemoveLayout2DView(const std::string &name,
+                                       int viewIndex) {
+  if (!layouts.RemoveLayout2DView(name, viewIndex))
+    return false;
+  SyncToConfig();
+  return true;
+}
+
 void LayoutManager::LoadFromConfig(ConfigManager &cfg) {
   auto value = cfg.GetValue(kLayoutsConfigKey);
   if (!value.has_value()) {

--- a/core/layouts/LayoutManager.h
+++ b/core/layouts/LayoutManager.h
@@ -36,6 +36,7 @@ public:
   bool SetLayoutOrientation(const std::string &name, bool landscape);
   bool UpdateLayout2DView(const std::string &name,
                           const Layout2DViewDefinition &view);
+  bool RemoveLayout2DView(const std::string &name, int viewIndex);
 
   void LoadFromConfig(ConfigManager &cfg);
   void SaveToConfig(ConfigManager &cfg) const;

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -41,6 +41,7 @@ private:
   void OnCaptureLost(wxMouseCaptureLostEvent &event);
   void OnRightUp(wxMouseEvent &event);
   void OnEditView(wxCommandEvent &event);
+  void OnDeleteView(wxCommandEvent &event);
 
   void ResetViewToFit();
   wxRect GetPageRect() const;


### PR DESCRIPTION
### Motivation
- Allow users to remove a layout's 2D view from the Layout viewer right-click context menu instead of only being able to edit it.
- Persist changes to the stored layout configuration when a 2D view is removed.

### Description
- Added `RemoveLayout2DView` to `LayoutCollection` and `LayoutManager` and implemented removal using `std::remove_if` to drop views whose `camera.view` matches the target index.
- Exposed the new API via `LayoutManager::RemoveLayout2DView` which calls `SyncToConfig()` to persist the change.
- Extended `LayoutViewerPanel` by adding `kDeleteMenuId`, a `Delete 2D View` entry to the right-click menu, and a handler `OnDeleteView` that calls `LayoutManager::RemoveLayout2DView` and updates `currentLayout.view2dViews` then calls `Refresh()`.

### Testing
- No automated tests were executed for this change.
- No CI/build steps were run as part of this PR preparation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a959d96dc8324b804b89955c12a25)