### PR TITLE
Fix 2D View Editor panel sizing

### DIFF
--- a/gui/layout2dviewdialog.cpp
+++ b/gui/layout2dviewdialog.cpp
@@ -18,6 +18,9 @@ Layout2DViewDialog::Layout2DViewDialog(wxWindow *parent)
   renderPanel = new Viewer2DRenderPanel(this);
   layerPanel = new LayerPanel(this, false);
 
+  renderPanel->SetMinSize(wxSize(260, -1));
+  layerPanel->SetMinSize(wxSize(220, -1));
+
   contentSizer->Add(viewerPanel, 1, wxEXPAND | wxALL, 8);
   contentSizer->Add(renderPanel, 0, wxEXPAND | wxTOP | wxBOTTOM | wxRIGHT, 8);
   contentSizer->Add(layerPanel, 0, wxEXPAND | wxTOP | wxBOTTOM | wxRIGHT, 8);


### PR DESCRIPTION
### Motivation
- The Layer panel in the `2D View Editor` could shrink to a thin line due to sizer distribution and lack of minimum widths.
- Ensure the render options and layer panels remain usable and visible when the dialog is resized.

### Description
- Set minimum widths on the render and layer panels in `Layout2DViewDialog` by calling `SetMinSize(wxSize(260, -1))` on the render panel and `SetMinSize(wxSize(220, -1))` on the layer panel.
- Change applied in `gui/layout2dviewdialog.cpp` so the existing sizer layout and behavior are preserved while preventing collapse.

### Testing
- No automated tests were executed because this is a GUI-only sizing adjustment.
- Manual visual verification is recommended after building the application to confirm panels no longer collapse.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a96b8d23c83249a77dba038768dad)