### PR TITLE
Avoid creating layout 2D views on selection

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -2320,24 +2320,7 @@ void MainWindow::ActivateLayoutView(const std::string &layoutName) {
     const auto &layouts = layouts::LayoutManager::Get().GetLayouts().Items();
     for (const auto &layout : layouts) {
       if (layout.name == layoutName) {
-        ConfigManager &cfg = ConfigManager::Get();
-        layouts::Layout2DViewDefinition view =
-            viewer2d::CaptureLayoutDefinition(viewport2DPanel, cfg);
-        bool hasMatchingView = false;
-        for (const auto &entry : layout.view2dViews) {
-          if (entry.camera.view == view.camera.view) {
-            hasMatchingView = true;
-            break;
-          }
-        }
-        if (!hasMatchingView) {
-          layouts::LayoutManager::Get().UpdateLayout2DView(layoutName, view);
-          layouts::LayoutDefinition updated = layout;
-          updated.view2dViews.push_back(std::move(view));
-          layoutViewerPanel->SetLayoutDefinition(updated);
-        } else {
-          layoutViewerPanel->SetLayoutDefinition(layout);
-        }
+        layoutViewerPanel->SetLayoutDefinition(layout);
         break;
       }
     }


### PR DESCRIPTION
### Motivation
- Prevent implicitly capturing and inserting a new 2D view when a user only selects a layout, so selection is non-destructive.
- Ensure `layoutViewerPanel->SetLayoutDefinition(...)` is invoked without adding views when the selected layout has none.
- Stop layout selection from modifying the stored layouts collection unless the user explicitly adds a 2D view.
- Keep `OnLayoutAdd2DView` as the only code path that creates or updates layout 2D views.

### Description
- Removed the block in `MainWindow::ActivateLayoutView` that called `viewer2d::CaptureLayoutDefinition`, compared views, and invoked `layouts::LayoutManager::Get().UpdateLayout2DView`.
- Changed `MainWindow::ActivateLayoutView` to always call `layoutViewerPanel->SetLayoutDefinition(layout)` for the selected layout without inserting a new view.
- Left `OnLayoutAdd2DView` as the explicit handler that creates and updates 2D views via `UpdateLayout2DView`.
- Implemented the change in `gui/mainwindow.cpp` (reduced code paths that mutate layouts on selection).

### Testing
- No automated tests were run against this change.
- No CI or unit-test results are available for this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a99a100cc8324a5588c59adabb34d)