### PR TITLE
Preserve 2D layout frames when persisting view state

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -2220,8 +2220,29 @@ void MainWindow::PersistLayout2DViewState() {
   Viewer2DPanel *activePanel =
       (layout2DViewEditing && layout2DViewEditPanel) ? layout2DViewEditPanel
                                                      : viewport2DPanel;
+  layouts::Layout2DViewFrame frame{};
+  const layouts::LayoutDefinition *layout = nullptr;
+  for (const auto &entry : layouts::LayoutManager::Get().GetLayouts().Items()) {
+    if (entry.name == activeLayoutName) {
+      layout = &entry;
+      break;
+    }
+  }
+  if (layout) {
+    viewer2d::Viewer2DState state = viewer2d::CaptureState(activePanel, cfg);
+    for (const auto &entry : layout->view2dViews) {
+      if (entry.camera.view == state.camera.view) {
+        frame = entry.frame;
+        break;
+      }
+    }
+  }
+  if (frame.width == 0 && frame.height == 0 && layoutViewerPanel) {
+    if (const auto *view = layoutViewerPanel->GetEditableView())
+      frame = view->frame;
+  }
   layouts::Layout2DViewDefinition view =
-      viewer2d::CaptureLayoutDefinition(activePanel, cfg);
+      viewer2d::CaptureLayoutDefinition(activePanel, cfg, frame);
   layouts::LayoutManager::Get().UpdateLayout2DView(activeLayoutName, view);
 }
 

--- a/viewer2d/viewer2dstate.cpp
+++ b/viewer2d/viewer2dstate.cpp
@@ -165,15 +165,15 @@ layouts::Layout2DViewDefinition ToLayoutDefinition(
 }
 
 layouts::Layout2DViewDefinition CaptureLayoutDefinition(
-    const Viewer2DPanel *panel, const ConfigManager &cfg) {
-  layouts::Layout2DViewDefinition view =
-      ToLayoutDefinition(CaptureState(panel, cfg));
-  if (panel) {
+    const Viewer2DPanel *panel, const ConfigManager &cfg,
+    const layouts::Layout2DViewFrame &frame) {
+  layouts::Layout2DViewFrame resolvedFrame = frame;
+  if (panel && (resolvedFrame.width <= 0 || resolvedFrame.height <= 0)) {
     const auto viewState = panel->GetViewState();
-    view.frame.width = viewState.viewportWidth;
-    view.frame.height = viewState.viewportHeight;
+    resolvedFrame.width = viewState.viewportWidth;
+    resolvedFrame.height = viewState.viewportHeight;
   }
-  return view;
+  return ToLayoutDefinition(CaptureState(panel, cfg), resolvedFrame);
 }
 
 } // namespace viewer2d

--- a/viewer2d/viewer2dstate.h
+++ b/viewer2d/viewer2dstate.h
@@ -40,6 +40,7 @@ Viewer2DState FromLayoutDefinition(const layouts::Layout2DViewDefinition &view);
 layouts::Layout2DViewDefinition ToLayoutDefinition(
     const Viewer2DState &state, const layouts::Layout2DViewFrame &frame = {});
 layouts::Layout2DViewDefinition CaptureLayoutDefinition(
-    const Viewer2DPanel *panel, const ConfigManager &cfg);
+    const Viewer2DPanel *panel, const ConfigManager &cfg,
+    const layouts::Layout2DViewFrame &frame = {});
 
 } // namespace viewer2d


### PR DESCRIPTION
### Motivation
- Ensure `CaptureLayoutDefinition` can reuse an existing `Layout2DViewFrame` instead of always starting from an empty/default frame. 
- Prevent persisting from overwriting an edited layout frame with the current viewport size when a frame was already defined. 
- Make `PersistLayout2DViewState` reuse the active layout’s stored frame so edited frames in the `LayoutViewerPanel` are preserved. 
- Ensure moves/resizes performed in `LayoutViewerPanel::UpdateFrame` are reflected in the persistent layout stored via `UpdateLayout2DView`.

### Description
- Changed `viewer2d::CaptureLayoutDefinition` signature to accept an optional `layouts::Layout2DViewFrame` and updated the implementation to use the provided frame unless its width/height are unset, in which case it falls back to the panel viewport size. 
- Updated `MainWindow::PersistLayout2DViewState` to look up the active layout, pick the stored `frame` for the current `camera.view` when present, fall back to `layoutViewerPanel->GetEditableView()` if needed, and pass that `frame` into `CaptureLayoutDefinition` before calling `UpdateLayout2DView`. 
- Updated header `viewer2d/viewer2dstate.h` to reflect the new `CaptureLayoutDefinition` signature and kept `ToLayoutDefinition` behavior consistent by accepting an explicit `frame`. 
- Changes touch `viewer2d/viewer2dstate.h`, `viewer2d/viewer2dstate.cpp`, and `gui/mainwindow.cpp` and rely on existing `LayoutViewerPanel::UpdateFrame` which already calls `UpdateLayout2DView` to persist edits.

### Testing
- No automated tests were run for this change. 
- The change is limited to function signatures and call sites and should be covered by existing unit/integration tests when run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aecdee04c832486655aa7cbea364b)