### PR TITLE
Fix viewer2d includes in layout viewer panel

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -25,7 +25,7 @@
 
 #include "configmanager.h"
 #include "layouts/LayoutManager.h"
-#include "viewer2d/viewer2dstate.h"
+#include "viewer2dstate.h"
 
 namespace {
 constexpr double kMinZoom = 0.1;

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -21,9 +21,9 @@
 #include <optional>
 #include <wx/wx.h>
 #include "layouts/LayoutCollection.h"
-#include "viewer2d/canvas2d.h"
-#include "viewer2d/symbolcache.h"
-#include "viewer2d/viewer2dpanel.h"
+#include "canvas2d.h"
+#include "symbolcache.h"
+#include "viewer2dpanel.h"
 
 wxDECLARE_EVENT(EVT_LAYOUT_VIEW_EDIT, wxCommandEvent);
 


### PR DESCRIPTION
### Motivation
- Resolve build errors caused by header includes that reference `viewer2d/` prefixed paths which are not found by the configured include directories.
- Make include usage consistent with other `viewer2d` headers and the project's `target_include_directories` configuration.

### Description
- Replaced `#include "viewer2d/canvas2d.h"`, `#include "viewer2d/symbolcache.h"`, and `#include "viewer2d/viewer2dpanel.h"` with `#include "canvas2d.h"`, `#include "symbolcache.h"`, and `#include "viewer2dpanel.h"` in `gui/layoutviewerpanel.h`.
- Replaced `#include "viewer2d/viewer2dstate.h"` with `#include "viewer2dstate.h"` in `gui/layoutviewerpanel.cpp` to match other `viewer2d` header includes.
- These changes align the layout viewer headers with the project's include path layout so the compiler can locate the `viewer2d` headers.

### Testing
- No automated tests were run as part of this change.
- CI should validate compilation and run the test suite after this PR is submitted.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694af13576388324978843d5b94bd81b)