### PR TITLE
Fix circle stroke rendering in layout viewer

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -311,7 +311,8 @@ void RenderCommands(wxGraphicsContext &gc, const CommandBuffer &buffer,
       wxPen pen(ToWxColor(circle->stroke.color),
                 strokeWidth(circle->stroke.width));
       gc.SetPen(pen);
-      gc.StrokeEllipse(rect.m_x, rect.m_y, rect.m_width, rect.m_height);
+      gc.SetBrush(*wxTRANSPARENT_BRUSH);
+      gc.DrawEllipse(rect.m_x, rect.m_y, rect.m_width, rect.m_height);
     } else if (const auto *text = std::get_if<TextCommand>(&cmd)) {
       wxPoint2DDouble anchor =
           MapPoint(text->x, text->y, localTransform, currentTransform, mapping,


### PR DESCRIPTION
### Motivation
- A build error occurred because `StrokeEllipse` is not a member of `wxGraphicsContext`, so a supported API is required.
- The intent is to preserve circle stroke rendering while using `wxGraphicsContext` methods that exist.
- The change should not alter existing circle fill behavior when `hasFill` is true.

### Description
- Replace the unsupported call `gc.StrokeEllipse(...)` with `gc.SetBrush(*wxTRANSPARENT_BRUSH); gc.DrawEllipse(...)` to draw strokes using `DrawEllipse`.
- Keep the existing `wxPen` creation and `gc.SetPen(...)` so strokes are still applied.
- No other rendering code paths for rectangles, polygons, or text were modified.

### Testing
- No automated tests or CI were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694af1d7c8b48324b993eb9bd281698f)