### PR TITLE
Fix viewport fallback for layout captures

### DIFF
--- a/viewer2d/viewer2dstate.cpp
+++ b/viewer2d/viewer2dstate.cpp
@@ -159,6 +159,12 @@ layouts::Layout2DViewDefinition ToLayoutDefinition(
   layouts::Layout2DViewDefinition view;
   view.frame = frame;
   view.camera = state.camera;
+  if (view.camera.viewportWidth <= 0 && frame.width > 0) {
+    view.camera.viewportWidth = frame.width;
+  }
+  if (view.camera.viewportHeight <= 0 && frame.height > 0) {
+    view.camera.viewportHeight = frame.height;
+  }
   view.renderOptions = state.renderOptions;
   view.layers = state.layers;
   return view;


### PR DESCRIPTION
### Motivation
- Prevent rendered thumbnails from getting a zero scale when captured view states have `viewportWidth`/`viewportHeight` <= 0.
- Ensure layout definitions persist valid viewport sizes so saved views can be restored reliably.
- Make sure `RenderCommands` always receives a `Viewer2DViewState` with valid viewport sizes to avoid `BuildMapping` returning scale zero.

### Description
- In `gui/layoutviewerpanel.cpp` compute `fallbackViewportWidth`/`fallbackViewportHeight` from `view->camera` or `view->frame` before calling `CaptureFrameAsync` and populate `cachedViewState` with those fallbacks when the captured state has non-positive sizes.
- In the paint path create a local `renderState` copied from `cachedViewState` and apply camera/frame fallbacks before calling `RenderCommands` so drawing never uses zero-sized viewports.
- In `viewer2d/viewer2dstate.cpp` update `ToLayoutDefinition` to fill `view.camera.viewportWidth`/`viewportHeight` from `frame.width`/`frame.height` when the camera values are missing, so saved layout defs contain valid viewport sizes.
- These changes together ensure mapping scale calculation has non-zero dimensions and avoid empty/invalid thumbnails.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ecd4e739083248d56965c567a251c)