### PR TITLE
Guard viewer2d state changes during layout capture/editing

### DIFF
--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -22,6 +22,7 @@
 #include <wx/aui/aui.h>
 #include <wx/wx.h>
 
+#include <memory>
 #include <optional>
 
 wxDECLARE_EVENT(EVT_PROJECT_LOADED, wxCommandEvent);
@@ -164,7 +165,7 @@ private:
   bool layoutModeActive = false;
   std::string activeLayoutName;
   bool layout2DViewEditing = false;
-  std::optional<viewer2d::Viewer2DState> layout2DViewSavedState;
+  std::unique_ptr<viewer2d::ScopedViewer2DState> layout2DViewStateGuard;
   Viewer2DPanel *layout2DViewEditPanel = nullptr;
   Viewer2DRenderPanel *layout2DViewEditRenderPanel = nullptr;
 

--- a/viewer2d/viewer2dstate.h
+++ b/viewer2d/viewer2dstate.h
@@ -36,6 +36,33 @@ Viewer2DState CaptureState(const Viewer2DPanel *panel,
 void ApplyState(Viewer2DPanel *panel, Viewer2DRenderPanel *renderPanel,
                 ConfigManager &cfg, const Viewer2DState &state);
 
+class ScopedViewer2DState {
+public:
+  ScopedViewer2DState(Viewer2DPanel *applyPanel,
+                      Viewer2DRenderPanel *applyRenderPanel,
+                      ConfigManager &cfg, const Viewer2DState &state,
+                      Viewer2DPanel *restorePanel = nullptr,
+                      Viewer2DRenderPanel *restoreRenderPanel = nullptr);
+  ~ScopedViewer2DState();
+
+  ScopedViewer2DState(const ScopedViewer2DState &) = delete;
+  ScopedViewer2DState &operator=(const ScopedViewer2DState &) = delete;
+  ScopedViewer2DState(ScopedViewer2DState &&other) noexcept;
+  ScopedViewer2DState &operator=(ScopedViewer2DState &&other) noexcept;
+
+  void Restore();
+  bool IsActive() const { return cfg_ != nullptr && !restored_; }
+
+private:
+  ConfigManager *cfg_ = nullptr;
+  Viewer2DPanel *applyPanel_ = nullptr;
+  Viewer2DRenderPanel *applyRenderPanel_ = nullptr;
+  Viewer2DPanel *restorePanel_ = nullptr;
+  Viewer2DRenderPanel *restoreRenderPanel_ = nullptr;
+  Viewer2DState previousState_;
+  bool restored_ = true;
+};
+
 Viewer2DState FromLayoutDefinition(const layouts::Layout2DViewDefinition &view);
 layouts::Layout2DViewDefinition ToLayoutDefinition(
     const Viewer2DState &state, const layouts::Layout2DViewFrame &frame = {});


### PR DESCRIPTION
### Motivation
- Prevent temporary changes to `ConfigManager` when applying a `Viewer2DState` for layout captures or editing so the main 2D viewer preferences are not overwritten.
- Ensure layout capture and layout view editing can operate on separate viewer instances without producing global side effects.
- Provide a safe RAII mechanism to always restore the previous viewer state on all exit paths.

### Description
- Add `ScopedViewer2DState` in `viewer2d/viewer2dstate.{h,cpp}` which captures the previous state via `CaptureState`, applies a new state via `ApplyState`, and restores the previous state on destruction, including move semantics.
- Replace direct temporary `ApplyState`/manual restore in `gui/layoutviewerpanel.cpp` with a `std::shared_ptr<viewer2d::ScopedViewer2DState>` so the applied state persists for the async capture callback and is restored afterwards.
- Replace the ad-hoc saved-state approach in `gui/mainwindow.{h,cpp}` with a `std::unique_ptr<viewer2d::ScopedViewer2DState>` to scope layout view edits and automatically restore the primary viewer state when editing finishes or is canceled.
- Keep existing `CaptureState`, `ApplyState`, `FromLayoutDefinition`, and `ToLayoutDefinition` APIs intact and add minimal includes (`<memory>`, `<utility>`) where required.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fac3f328c8324bf3474ea99ab4070)