### PR TITLE
Clear 2D viewer singletons on teardown

### DIFF
--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -173,7 +173,11 @@ wxBEGIN_EVENT_TABLE(Viewer2DPanel, wxGLCanvas) EVT_PAINT(Viewer2DPanel::OnPaint)
   m_glContext = new wxGLContext(this);
 }
 
-Viewer2DPanel::~Viewer2DPanel() { delete m_glContext; }
+Viewer2DPanel::~Viewer2DPanel() {
+  if (g_instance == this)
+    g_instance = nullptr;
+  delete m_glContext;
+}
 
 Viewer2DPanel *Viewer2DPanel::Instance() { return g_instance; }
 

--- a/viewer2d/viewer2drenderpanel.cpp
+++ b/viewer2d/viewer2drenderpanel.cpp
@@ -248,6 +248,11 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
   ApplyConfig();
 }
 
+Viewer2DRenderPanel::~Viewer2DRenderPanel() {
+  if (s_instance == this)
+    s_instance = nullptr;
+}
+
 Viewer2DRenderPanel *Viewer2DRenderPanel::Instance() { return s_instance; }
 
 void Viewer2DRenderPanel::SetInstance(Viewer2DRenderPanel *p) {

--- a/viewer2d/viewer2drenderpanel.h
+++ b/viewer2d/viewer2drenderpanel.h
@@ -26,6 +26,7 @@
 class Viewer2DRenderPanel : public wxScrolledWindow {
 public:
   explicit Viewer2DRenderPanel(wxWindow *parent);
+  ~Viewer2DRenderPanel() override;
 
   void ApplyConfig();
 


### PR DESCRIPTION
### Motivation
- Prevent an access violation on shutdown caused by dangling singleton pointers to destroyed 2D viewer panels.
- Avoid stale `Viewer2DPanel::Instance()` / `Viewer2DRenderPanel::Instance()` returning freed objects during teardown or asynchronous capture flows.
- Make lifetime semantics explicit so helpers like `ScopedViewer2DState` and capture callbacks cannot observe freed singletons.

### Description
- Clear the `g_instance` singleton inside `Viewer2DPanel::~Viewer2DPanel()` when it points to `this`.
- Add a virtual destructor declaration `~Viewer2DRenderPanel()` to `viewer2d/viewer2drenderpanel.h` and implement it to clear `s_instance` in `viewer2d/viewer2drenderpanel.cpp`.
- Files modified: `viewer2d/viewer2dpanel.cpp`, `viewer2d/viewer2drenderpanel.h`, and `viewer2d/viewer2drenderpanel.cpp`.
- No other behavioral changes; these changes only reset singleton pointers on panel destruction.

### Testing
- No automated tests were run on this change.
- The change is limited to teardown behavior and intended to eliminate dangling pointers observed during shutdown.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694faedab1348324b0ca9b70326d22f1)