### PR TITLE
Use dedicated offscreen Viewer2DPanel for layout captures

### DIFF
--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -32,6 +32,7 @@ public:
   explicit LayoutViewerPanel(wxWindow *parent);
 
   void SetLayoutDefinition(const layouts::LayoutDefinition &layout);
+  void SetCapturePanel(Viewer2DPanel *panel);
   layouts::Layout2DViewDefinition *GetEditableView();
   const layouts::Layout2DViewDefinition *GetEditableView() const;
 
@@ -83,6 +84,7 @@ private:
   CommandBuffer cachedBuffer;
   Viewer2DViewState cachedViewState;
   std::shared_ptr<const SymbolDefinitionSnapshot> cachedSymbols;
+  Viewer2DPanel *capturePanel = nullptr;
 
   wxDECLARE_EVENT_TABLE();
 };

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -78,6 +78,7 @@ private:
   Viewer3DPanel *viewportPanel = nullptr;
   Viewer2DPanel *viewport2DPanel = nullptr;
   Viewer2DRenderPanel *viewport2DRenderPanel = nullptr;
+  Viewer2DPanel *layoutCapture2DPanel = nullptr;
   ConsolePanel *consolePanel = nullptr;
   LayerPanel *layerPanel = nullptr;
   LayoutPanel *layoutPanel = nullptr;


### PR DESCRIPTION
### Motivation
- Avoid relying on the hidden singleton `Viewer2DPanel::Instance()` for layout snapshots because the visible viewport can be hidden and lack a valid GL context for capture.  
- Ensure layout viewer captures are produced reliably even when the main 2D viewport is not visible by providing a dedicated capture panel with a valid GL context.  
- Keep layout-mode initialization and project load/reset in sync so captured frames and symbol caches remain up to date.  

### Description
- Added `LayoutViewerPanel::SetCapturePanel(Viewer2DPanel*)` and a `capturePanel` member so the layout viewer uses an explicit 2D panel for frame capture instead of `Viewer2DPanel::Instance()`.  
- Created and maintain a hidden/offscreen `layoutCapture2DPanel` in `MainWindow::Ensure2DViewport()` and wired it into layout mode via `layoutViewerPanel->SetCapturePanel(...)`.  
- Updated `LayoutViewerPanel::OnPaint` to call `CaptureFrameAsync` on the specified capture panel and to `Refresh()`/`Update()` the capture panel to trigger a paint with a valid GL context before using the buffer.  
- Propagated capture-panel lifecycle handling to project load/reset and ensured `Ensure2DViewport()` is called when applying layout-mode perspective.  

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fb1eb5934832492fc3247bf670a78)