### PR TITLE
Fix layout 2D view mapping for offscreen capture

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -303,12 +303,10 @@ void LayoutViewerPanel::OnPaint(wxPaintEvent &) {
               CommandBuffer buffer, Viewer2DViewState state) {
             cachedBuffer = std::move(buffer);
             cachedViewState = state;
-            if (cachedViewState.viewportWidth <= 0 &&
-                fallbackViewportWidth > 0) {
+            if (fallbackViewportWidth > 0) {
               cachedViewState.viewportWidth = fallbackViewportWidth;
             }
-            if (cachedViewState.viewportHeight <= 0 &&
-                fallbackViewportHeight > 0) {
+            if (fallbackViewportHeight > 0) {
               cachedViewState.viewportHeight = fallbackViewportHeight;
             }
             cachedSymbols.reset();


### PR DESCRIPTION
### Motivation
- Layout preview images were rendering blank because the offscreen capture panel reported a tiny viewport (e.g. 1×1) which caused `BuildViewMapping` to compute invalid mapping extents.
- The capture-to-render flow must use the layout view/frame dimensions rather than trusting the offscreen panel's reported size to avoid geometry mapping outside the target frame.
- The change must be minimal and avoid duplicating mapping logic or adding runtime overhead.

### Description
- Force the captured `Viewer2DViewState` `viewportWidth` and `viewportHeight` to the layout frame/fallback size when receiving the async capture in `LayoutViewerPanel::OnPaint` so previews use the intended extents. 
- This removes reliance on the offscreen panel's reported viewport (which can be 1×1) while preserving the existing `renderState` fallback logic used for final mapping with `BuildViewMapping`.
- Only a small conditional update in `gui/layoutviewerpanel.cpp` was made; no rendering algorithm or mapping math was changed.

### Testing
- No automated unit or integration tests were executed for this change.
- CI / automated pipelines were not run as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fb0dd0f208324ada848c179ba381e)