### PR TITLE
Restore layout capture viewer state on layout panel

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -296,7 +296,7 @@ void LayoutViewerPanel::OnPaint(wxPaintEvent &) {
       viewer2d::Viewer2DState layoutState =
           viewer2d::FromLayoutDefinition(*view);
       auto stateGuard = std::make_shared<viewer2d::ScopedViewer2DState>(
-          panel, nullptr, cfg, layoutState);
+          panel, nullptr, cfg, layoutState, panel, nullptr);
       panel->CaptureFrameAsync(
           [this, panel, stateGuard, fallbackViewportWidth,
            fallbackViewportHeight](


### PR DESCRIPTION
### Motivation
- The layout 2D viewer could be blank because the camera state (offset/zoom) was being restored on the wrong instance, leaving the layout capture panel without the correct transform.
- The intent is to ensure the viewer state used during layout capture is applied to the layout panel that performs the capture so the rendered content matches the saved camera.
- Preserve modular behavior without duplicating state management logic already present in `PersistLayout2DViewState`/`RestoreLayout2DViewState`.
- Fixing the restore target ensures each view’s offset/zoom are saved and restored per-panel.

### Description
- In `LayoutViewerPanel::OnPaint` the construction of `viewer2d::ScopedViewer2DState` was changed to explicitly pass the layout capture panel as the restore target by replacing the call with `std::make_shared<viewer2d::ScopedViewer2DState>(panel, nullptr, cfg, layoutState, panel, nullptr)`.
- The single-line change was applied in `gui/layoutviewerpanel.cpp` so the panel used to capture the frame also receives the restored state.
- No other source files were modified and no changes were made to `PersistLayout2DViewState` or `RestoreLayout2DViewState` logic.
- This ensures the viewer’s offset/zoom are restored on the layout capture panel rather than on a global instance.

### Testing
- No automated tests were executed as part of this change.
- The patch is minimal and limited to a single file change (`gui/layoutviewerpanel.cpp`).
- Manual validation is recommended to confirm that layout captures render correctly and that per-view camera state persists.
- No test failures to report.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fbab038248324904ad9f69e84d6f5)