### PR TITLE
Guard layout capture state restoration on shutdown

### DIFF
--- a/viewer2d/viewer2dstate.h
+++ b/viewer2d/viewer2dstate.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "layouts/LayoutCollection.h"
+#include <wx/weakref.h>
 
 class ConfigManager;
 class Viewer2DPanel;
@@ -57,8 +58,10 @@ private:
   ConfigManager *cfg_ = nullptr;
   Viewer2DPanel *applyPanel_ = nullptr;
   Viewer2DRenderPanel *applyRenderPanel_ = nullptr;
-  Viewer2DPanel *restorePanel_ = nullptr;
-  Viewer2DRenderPanel *restoreRenderPanel_ = nullptr;
+  wxWeakRef<Viewer2DPanel> restorePanel_;
+  wxWeakRef<Viewer2DRenderPanel> restoreRenderPanel_;
+  bool hasRestorePanelTarget_ = false;
+  bool hasRestoreRenderPanelTarget_ = false;
   Viewer2DState previousState_;
   bool restored_ = true;
 };


### PR DESCRIPTION
### Motivation
- Restoring a captured 2D view state could try to apply state to panels that were destroyed during shutdown, causing exceptions.
- The layout viewer capture path creates a `ScopedViewer2DState` with explicit restore targets, so we must avoid use-after-free when those targets no longer exist.
- Preserve existing fallback behavior when callers do not provide explicit restore targets.
- Make capture/restore decisions deterministic and safe when panels are destroyed.

### Description
- Use `wxWeakRef` for `restorePanel_` and `restoreRenderPanel_` in `viewer2d::ScopedViewer2DState` to avoid strong references to UI panels. 
- Add `hasRestorePanelTarget_` and `hasRestoreRenderPanelTarget_` flags and set them in the constructor to track whether an explicit restore target was provided.
- Capture the previous state from the weak restore panel when available, otherwise from the apply panel, via `restorePanel_.get()` fallback logic in the constructor.
- In `Restore()` choose the restore targets based on the flags and the weak refs (calling `.get()` only when an explicit target was used), falling back to `Viewer2DPanel::Instance()` and `Viewer2DRenderPanel::Instance()` when appropriate.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fbcdf8e70832493084e8b1a510eca)