### PR TITLE
Guard 3D viewer refresh during shutdown

### DIFF
--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -115,6 +115,7 @@ private:
 
     Viewer3DController m_controller;
 
+    std::atomic<bool> m_shuttingDown{false};
     std::atomic<bool> m_threadRunning{false};
     std::thread m_refreshThread;
     void RefreshLoop();


### PR DESCRIPTION
### Motivation
- Prevent spurious background refresh events and render calls during application teardown that can race with object destruction and cause access violations. 
- Stop the refresh loop and drop pending paint/refresh events early in the viewer lifecycle to avoid use-after-free on UI/state objects. 
- Ensure scene updates and rendering no-ops when the 3D panel is tearing down. 

### Description
- Add an atomic shutdown flag `m_shuttingDown` to `Viewer3DPanel` and set it during destruction and thread stop via `m_shuttingDown = true`.
- Short-circuit `OnPaint`, `Render`, `UpdateScene`, and `OnThreadRefresh` with early returns when `m_shuttingDown` is set. 
- Stop the refresh loop by changing `RefreshLoop` to `while (m_threadRunning && !m_shuttingDown)` and call `DeletePendingEvents()` from `StopRefreshThread()` to clear queued refresh events. 
- Move `SetInstance(nullptr)` earlier in destructor to reduce window for events referencing the global instance. 

### Testing
- No automated tests were executed as part of this change. 
- Changes were compiled/committed locally (no test suite run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fc053e2f88324b9e37ae5c548decc)