### PR TITLE
Fix shutdown cleanup for AUI manager

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1639,6 +1639,12 @@ void MainWindow::OnCloseWindow(wxCloseEvent &event) {
   if (viewportPanel)
     viewportPanel->StopRefreshThread();
 
+  if (auiManager) {
+    auiManager->UnInit();
+    delete auiManager;
+    auiManager = nullptr;
+  }
+
   Destroy();
 }
 


### PR DESCRIPTION
### Motivation
- Closing the application triggered a breakpoint/assert in the wxWidgets default assert handler during shutdown, indicating incorrect teardown ordering.
- The AUI manager was still initialized when the frame was destroyed, which could lead to double cleanup or use-after-free when the destructor also uninitialized and deleted it.
- Properly uninitializing UI subsystems before destroying the frame prevents asserts and race conditions with background threads.

### Description
- Added explicit uninitialization and deletion of `auiManager` in `MainWindow::OnCloseWindow` by calling `auiManager->UnInit()`, `delete auiManager`, and setting `auiManager = nullptr`.
- Ensured the viewport refresh thread is stopped before AUI manager teardown by keeping the existing `viewportPanel->StopRefreshThread()` call.
- This prevents double cleanup in the destructor and avoids leaving `auiManager` in an invalid state when `Destroy()` is called.

### Testing
- No automated tests were run for this change.
- The change is narrowly scoped to shutdown sequence modifications and does not add new public APIs.
- Manual verification is recommended to confirm the assert no longer occurs during application exit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fc3889840832490c7b2d79f3ee9f4)