### PR TITLE
Include LayoutManager sources in test targets to fix linker errors

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,10 @@ function(set_library_env TEST_NAME)
     set_tests_properties(${TEST_NAME} PROPERTIES ENVIRONMENT "PERASTAGE_LIBRARY_PATH=${CMAKE_SOURCE_DIR}/library")
 endfunction()
 
+set(LAYOUT_SOURCES
+    ../core/layouts/LayoutManager.cpp
+    ../core/layouts/LayoutCollection.cpp)
+
 if(TARGET podofo::podofo)
     add_executable(pdf_text_test pdf_text_test.cpp ../core/pdftext.cpp)
     target_link_libraries(pdf_text_test PRIVATE podofo::podofo ${wxWidgets_LIBRARIES})
@@ -47,6 +51,7 @@ add_test(NAME AutoPatchUniverseWrap COMMAND autopatcher_universe_wrap_test)
 set_library_env(AutoPatchUniverseWrap)
 
 add_executable(save_load_roundtrip_test save_load_roundtrip_test.cpp
+               ${LAYOUT_SOURCES}
                ../core/configmanager.cpp
                ../core/projectutils.cpp
                ../core/gdtfdictionary.cpp
@@ -74,6 +79,7 @@ add_executable(rider_save_roundtrip_test rider_save_roundtrip_test.cpp
                gdtfloader_stub.cpp
                consolepanel_stub.cpp
                trussloader_stub.cpp
+               ${LAYOUT_SOURCES}
                ../core/riderimporter.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -100,6 +106,7 @@ set_library_env(RiderSaveRoundtrip)
 add_executable(riderimporter_fixtureid_test rider_import_fixtureid_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
+               ${LAYOUT_SOURCES}
                ../core/riderimporter.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -122,6 +129,7 @@ set_library_env(RiderImporterFixtureIds)
 add_executable(rider_import_order_test rider_import_order_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
+               ${LAYOUT_SOURCES}
                ../core/riderimporter.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -143,6 +151,7 @@ set_library_env(RiderImportOrder)
 add_executable(rider_autopatch_test rider_autopatch_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_onech_stub.cpp
+               ${LAYOUT_SOURCES}
                ../core/riderimporter.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -164,6 +173,7 @@ set_library_env(RiderAutoPatch)
 add_executable(rider_layer_mode_test rider_layer_mode_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
+               ${LAYOUT_SOURCES}
                ../core/riderimporter.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -185,6 +195,7 @@ set_library_env(RiderLayerMode)
 add_executable(rider_import_benchmark rider_import_benchmark.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
+               ${LAYOUT_SOURCES}
                ../core/riderimporter.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp


### PR DESCRIPTION
### Motivation
- Tests that compile `ConfigManager` were failing with LNK2019 unresolved externals for `layouts::LayoutManager` (`Get`, `LoadFromConfig`, `ResetToDefault`).
- The test executables referenced `LayoutManager` symbols but did not compile the corresponding `.cpp` files into the test binaries.
- Centralizing the layout source list makes it straightforward to add/remove layout implementation files for all tests that need them.

### Description
- Added a `LAYOUT_SOURCES` variable to `tests/CMakeLists.txt` containing `../core/layouts/LayoutManager.cpp` and `../core/layouts/LayoutCollection.cpp`.
- Appended `${LAYOUT_SOURCES}` to all test executables that include `ConfigManager` or otherwise reference layout manager functionality (e.g. `save_load_roundtrip_test`, `rider_save_roundtrip_test`, `riderimporter_fixtureid_test`, `rider_import_order_test`, `rider_autopatch_test`, `rider_layer_mode_test`, `rider_import_benchmark`).
- This ensures `LayoutManager` and `LayoutCollection` are compiled/linked into those test binaries and removes the unresolved externals without changing production targets.
- Change is localized to the tests `CMakeLists.txt` and does not alter runtime linkage for the main executable.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fc4d0dc908324a3365a224215b024)