### PR TITLE
Guard LayoutViewerPanel capture panel with weak reference

### DIFF
--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <optional>
+#include <wx/weakref.h>
 #include <wx/wx.h>
 #include "layouts/LayoutCollection.h"
 #include "canvas2d.h"
@@ -84,7 +85,7 @@ private:
   CommandBuffer cachedBuffer;
   Viewer2DViewState cachedViewState;
   std::shared_ptr<const SymbolDefinitionSnapshot> cachedSymbols;
-  Viewer2DPanel *capturePanel = nullptr;
+  wxWeakRef<Viewer2DPanel> capturePanel;
 
   wxDECLARE_EVENT_TABLE();
 };


### PR DESCRIPTION
### Motivation
- Closing the application could trigger a breakpoint from the wxWidgets assert handler caused by an asynchronous capture callback accessing a destroyed `Viewer2DPanel` instance used by the layout viewer. 
- The layout viewer stores a raw `Viewer2DPanel *` and starts async captures via `CaptureFrameAsync`, which allowed use-after-destruction during shutdown or panel replacement. 

### Description
- Replace the raw `capturePanel` pointer with a `wxWeakRef<Viewer2DPanel>` and include `<wx/weakref.h>` in `gui/layoutviewerpanel.h`. 
- Use `capturePanel.get()` for comparisons and to obtain a safe pointer where needed in `SetCapturePanel` and `OnPaint`. 
- When starting an async capture, create a `wxWeakRef` (`panelRef`) and capture it into the lambda; the callback calls `panelRef.get()` and early-returns if the panel was destroyed, and resets `captureInProgress` to keep state consistent. 

### Testing
- No automated tests were executed for this change. 
- The change is limited to safety around lifetime of the capture panel and does not alter capture logic when the panel is alive.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fc68f5798832492d7dcb49121f8e8)