### PR TITLE
Avoid asserts when app icon is missing

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -115,15 +115,7 @@ void MainWindow::SetInstance(MainWindow *inst) { s_instance = inst; }
 
 namespace {
 void LogMissingIcon(const std::filesystem::path &path) {
-#ifndef NDEBUG
-  wxLogDebug("Main window icon not found at '%s'", path.string().c_str());
-  wxASSERT_MSG(
-      false,
-      wxString::Format("Main window icon not found at '%s'",
-                       wxString::FromUTF8(path.string()).c_str()));
-#else
   wxLogWarning("Main window icon not found at '%s'", path.string().c_str());
-#endif
 }
 
 layouts::Layout2DViewFrame BuildDefaultLayout2DFrame(

--- a/gui/splashscreen.cpp
+++ b/gui/splashscreen.cpp
@@ -14,15 +14,7 @@ wxFrame *g_splash = nullptr;
 wxStaticText *g_label = nullptr;
 
 void LogMissingIcon(const std::filesystem::path &path) {
-#ifndef NDEBUG
-  wxLogDebug("Splash icon not found at '%s'", path.string().c_str());
-  wxASSERT_MSG(
-      false,
-      wxString::Format("Splash icon not found at '%s'",
-                       wxString::FromUTF8(path.string()).c_str()));
-#else
   wxLogWarning("Splash icon not found at '%s'", path.string().c_str());
-#endif
 }
 }
 


### PR DESCRIPTION
### Motivation
- Prevent the application from breaking into the debugger when the splash or main window icon file is missing by removing debug-only assertions that triggered a trap.
- Keep a user-facing diagnostic so missing resources are still reported without halting execution.

### Description
- Replace the debug assertion and `wxLogDebug` in `LogMissingIcon` with a single `wxLogWarning` in `gui/mainwindow.cpp`.
- Make the same change in `gui/splashscreen.cpp` so both splash and main window icon missing cases only emit a warning and do not call `wxASSERT_MSG`.
- The change removes `#ifndef NDEBUG` guarded assertion code paths and ensures the app continues running when icons are not present.

### Testing
- No automated tests were executed for this change.
- The change is limited to logging behavior and does not alter application control flow beyond removing assertions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fc79a8ee483248112cb99e4877479)