### PR TITLE
Guard pending event cleanup on shutdown

### DIFF
--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -86,7 +86,8 @@ void Viewer3DPanel::StopRefreshThread()
     m_threadRunning = false;
     if (m_refreshThread.joinable())
         m_refreshThread.join();
-    DeletePendingEvents();
+    if (Pending())
+        DeletePendingEvents();
 }
 
 // Initializes OpenGL basic settings


### PR DESCRIPTION
### Motivation
- Closing the app could trigger a wxWidgets assert in `ProcessPendingEvents()` when `DeletePendingEvents()` is called with no pending events.
- `Viewer3DPanel::StopRefreshThread()` can be invoked multiple times (from `MainWindow::OnCloseWindow` and the panel destructor), so the cleanup must be idempotent.
- The assert appeared during shutdown of the 3D/2D viewers and caused a debug break in `Perastage.exe`.

### Description
- Replace the unconditional call to `DeletePendingEvents()` with a guarded call: `if (Pending()) DeletePendingEvents();` in `viewer3d/viewer3dpanel.cpp`.
- The change makes `StopRefreshThread()` safe to call multiple times without triggering the wxWidgets pending-events assert.
- Only the `viewer3d/viewer3dpanel.cpp` file was modified.

### Testing
- No automated tests were executed for this change.
- Local code inspection and repository search were used to identify related event/thread usage sites.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fcdb6a21c8324875dff9c9f8fcad9)