### PR TITLE
Fix pending events check in Viewer3DPanel

### DIFF
--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -86,7 +86,7 @@ void Viewer3DPanel::StopRefreshThread()
     m_threadRunning = false;
     if (m_refreshThread.joinable())
         m_refreshThread.join();
-    if (Pending())
+    if (HasPendingEvents())
         DeletePendingEvents();
 }
 


### PR DESCRIPTION
### Motivation
- Fix a compiler error (C3861) caused by the undefined identifier `Pending` in `viewer3d/viewer3dpanel.cpp` when shutting down the refresh thread.
- Ensure the correct wxWidgets API is used to detect queued events before calling `DeletePendingEvents()`.

### Description
- Replace `if (Pending())` with `if (HasPendingEvents())` inside `Viewer3DPanel::StopRefreshThread()` in `viewer3d/viewer3dpanel.cpp`.
- Update is a single-line change to use the proper event-query function before clearing pending events.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fce88996083249142fc4109c77616)