### PR TITLE
Remove `HasPendingEvents` guard and always clear pending events on Viewer3DPanel shutdown

### DIFF
--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -86,8 +86,7 @@ void Viewer3DPanel::StopRefreshThread()
     m_threadRunning = false;
     if (m_refreshThread.joinable())
         m_refreshThread.join();
-    if (HasPendingEvents())
-        DeletePendingEvents();
+    DeletePendingEvents();
 }
 
 // Initializes OpenGL basic settings


### PR DESCRIPTION
### Motivation
- Fix a compile error caused by the missing `HasPendingEvents` identifier reported during build. 
- Ensure pending events are cleared during panel shutdown to avoid leaving stale events in the queue. 
- Simplify shutdown logic in the refresh thread cleanup path. 

### Description
- Removed the conditional `if (HasPendingEvents())` and now call `DeletePendingEvents()` unconditionally in `Viewer3DPanel::StopRefreshThread()`. 
- The change was applied to `viewer3d/viewer3dpanel.cpp` and affects the `Viewer3DPanel::StopRefreshThread()` shutdown sequence. 
- This directly addresses the `C3861: 'HasPendingEvents': identifier not found` build error by eliminating the reference. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fcf120db08324ba792fb95af37f54)