### PR TITLE
Guard layout viewer capture callbacks and cancel on shutdown

### DIFF
--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -31,6 +31,7 @@ wxDECLARE_EVENT(EVT_LAYOUT_VIEW_EDIT, wxCommandEvent);
 class LayoutViewerPanel : public wxPanel {
 public:
   explicit LayoutViewerPanel(wxWindow *parent);
+  ~LayoutViewerPanel() override;
 
   void SetLayoutDefinition(const layouts::LayoutDefinition &layout);
   void SetCapturePanel(Viewer2DPanel *panel);
@@ -82,6 +83,7 @@ private:
   int captureVersion = -1;
   bool captureInProgress = false;
   bool hasCapture = false;
+  bool shutdown = false;
   CommandBuffer cachedBuffer;
   Viewer2DViewState cachedViewState;
   std::shared_ptr<const SymbolDefinitionSnapshot> cachedSymbols;

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1639,6 +1639,10 @@ void MainWindow::OnCloseWindow(wxCloseEvent &event) {
   if (viewportPanel)
     viewportPanel->StopRefreshThread();
 
+  if (layoutViewerPanel) {
+    layoutViewerPanel->SetCapturePanel(nullptr);
+  }
+
   if (auiManager) {
     auiManager->UnInit();
     delete auiManager;


### PR DESCRIPTION
### Motivation
- Prevent async `CaptureFrameAsync` callbacks from accessing `LayoutViewerPanel` or `Viewer2DPanel` after they have been destroyed to avoid use-after-free or invalid repaint calls.
- Avoid triggering `Refresh()`/`Update()` on panes that are hidden or in the process of being deleted.
- Ensure capture is cancelled/cleaned up when the main window is closing to stop background capture flow.

### Description
- Add `~LayoutViewerPanel()` to set a `shutdown` flag, clear `capturePanel`, and stop in-progress capture bookkeeping.
- Guard capture start and `SetCapturePanel()` so no new capture is initiated when `shutdown` is true and return early from `SetCapturePanel` when shutting down.
- Protect the async callback by capturing a `wxWeakRef<LayoutViewerPanel>` (`selfRef`) and `wxWeakRef<Viewer2DPanel>` (`panelRef`), and check `IsBeingDeleted()`/`IsShownOnScreen()`/`shutdown` before touching members or calling `Refresh()`.
- Call `layoutViewerPanel->SetCapturePanel(nullptr)` from `MainWindow::OnCloseWindow` and avoid `Refresh()`/`Update()` on the capture source if it is being deleted or not shown.

### Testing
- No automated tests were executed for this change.
- Changes were limited to guarding lifetime and callback behavior and do not add new public APIs requiring tests.
- Manual runtime validation is recommended to confirm no repaint/callbacks occur during window shutdown (not performed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69526b2aa330832495bc43e545379204)