### PR TITLE
Handle 2D view cleanup on close

### DIFF
--- a/gui/layout2dviewdialog.cpp
+++ b/gui/layout2dviewdialog.cpp
@@ -32,6 +32,7 @@ Layout2DViewDialog::Layout2DViewDialog(wxWindow *parent)
   auto *cancelButton = new wxButton(this, wxID_CANCEL, "Cancel");
   okButton->Bind(wxEVT_BUTTON, &Layout2DViewDialog::OnOk, this);
   cancelButton->Bind(wxEVT_BUTTON, &Layout2DViewDialog::OnCancel, this);
+  Bind(wxEVT_CLOSE_WINDOW, &Layout2DViewDialog::OnClose, this);
   buttonSizer->AddButton(okButton);
   buttonSizer->AddButton(cancelButton);
   buttonSizer->Realize();
@@ -52,5 +53,14 @@ void Layout2DViewDialog::OnOk(wxCommandEvent &event) {
 
 void Layout2DViewDialog::OnCancel(wxCommandEvent &event) {
   EndModal(wxID_CANCEL);
+  event.Skip();
+}
+
+void Layout2DViewDialog::OnClose(wxCloseEvent &event) {
+  if (IsModal()) {
+    EndModal(wxID_CANCEL);
+  } else {
+    Destroy();
+  }
   event.Skip();
 }

--- a/gui/layout2dviewdialog.h
+++ b/gui/layout2dviewdialog.h
@@ -16,6 +16,7 @@ public:
 private:
   void OnOk(wxCommandEvent &event);
   void OnCancel(wxCommandEvent &event);
+  void OnClose(wxCloseEvent &event);
 
   Viewer2DPanel *viewerPanel = nullptr;
   Viewer2DRenderPanel *renderPanel = nullptr;

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1643,6 +1643,13 @@ void MainWindow::OnCloseWindow(wxCloseEvent &event) {
     layoutViewerPanel->SetCapturePanel(nullptr);
   }
 
+  if (layout2DViewEditing) {
+    layout2DViewEditing = false;
+    layout2DViewStateGuard.reset();
+    Viewer2DPanel::SetInstance(viewport2DPanel);
+    Viewer2DRenderPanel::SetInstance(viewport2DRenderPanel);
+  }
+
   if (auiManager) {
     auiManager->UnInit();
     delete auiManager;

--- a/viewer2d/viewer2dstate.cpp
+++ b/viewer2d/viewer2dstate.cpp
@@ -138,7 +138,7 @@ void ApplyState(Viewer2DPanel *panel, Viewer2DRenderPanel *renderPanel,
                                          state.layers.hiddenLayers.end());
   cfg.SetHiddenLayers(hidden);
 
-  if (panel) {
+  if (panel && !panel->IsBeingDeleted() && panel->IsShownOnScreen()) {
     panel->LoadViewFromConfig();
     panel->UpdateScene(true);
     panel->Refresh();


### PR DESCRIPTION
### Motivation
- Prevent asserts/crashes during application shutdown when the 2D view editor is open by ensuring edit state and singletons are cleaned up before UI teardown.
- Avoid applying/view updates to panels that are being destroyed or are not visible during state restore.
- Ensure closing the 2D view editor from the main window properly terminates the modal dialog and releases its resources.

### Description
- In `MainWindow::OnCloseWindow` cancel the 2D edit by setting `layout2DViewEditing = false`, calling `layout2DViewStateGuard.reset()`, and restoring viewer singletons via `Viewer2DPanel::SetInstance(viewport2DPanel)` and `Viewer2DRenderPanel::SetInstance(viewport2DRenderPanel)` before `auiManager->UnInit()`.
- In `viewer2d::ApplyState` add a guard `if (panel && !panel->IsBeingDeleted() && panel->IsShownOnScreen())` to avoid calling `LoadViewFromConfig()`, `UpdateScene()` and `Refresh()` on panels that are being destroyed or hidden.
- Add a close handler to `Layout2DViewDialog` by declaring `OnClose` in the header and binding `wxEVT_CLOSE_WINDOW` in the dialog to call `EndModal(wxID_CANCEL)` when modal or `Destroy()` when not.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69526d8e2704832494765bddc37ff68c)