### PR TITLE
Cache layout viewer render bitmap

### DIFF
--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -54,6 +54,9 @@ private:
                     wxRect &rect) const;
   void UpdateFrame(const layouts::Layout2DViewFrame &frame,
                    bool updatePosition);
+  void RebuildCachedBitmap();
+  void RequestRenderRebuild();
+  void InvalidateRenderIfFrameChanged();
   void EmitEditViewRequest();
 
   enum class FrameDragMode {
@@ -83,6 +86,10 @@ private:
   CommandBuffer cachedBuffer;
   Viewer2DViewState cachedViewState;
   std::shared_ptr<const SymbolDefinitionSnapshot> cachedSymbols;
+  wxBitmap cachedBitmap;
+  wxSize cachedBitmapSize{0, 0};
+  bool renderDirty = true;
+  bool renderPending = false;
 
   wxDECLARE_EVENT_TABLE();
 };


### PR DESCRIPTION
### Motivation
- Reduce UI jank by separating the expensive `CommandBuffer` render pass from the lightweight paint path.
- Avoid re-rendering when nothing has changed by caching the rendered output for the current frame size and capture version.
- Make rendering resilient to asynchronous captures and large renders by scheduling rebuilds off the immediate paint path.

### Description
- Added cached state (`cachedBitmap`, `cachedBitmapSize`, `renderDirty`, `renderPending`) and new methods `RebuildCachedBitmap()`, `RequestRenderRebuild()`, and `InvalidateRenderIfFrameChanged()` in `LayoutViewerPanel`.
- Moved the heavy `viewer2d::Viewer2DCommandRenderer` rendering logic into `RebuildCachedBitmap()` and made `OnPaint()` draw the cached bitmap or a placeholder message if the bitmap is not ready.
- Marked the cached bitmap dirty and call `RequestRenderRebuild()` from capture callback, `SetLayoutDefinition()`, `OnSize()`, `UpdateFrame()`, zoom/pan changes and other frame-changing paths; rebuilds are scheduled via `CallAfter()` to avoid blocking UI interaction.
- `InvalidateRenderIfFrameChanged()` invalidates the cache when the view/frame size changes and `RebuildCachedBitmap()` recalculates view mapping and re-renders into the cached bitmap.

### Testing
- No automated tests were run for this change.
- The change was committed locally with the message `Cache layout viewer render bitmap`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695276502a2c8324b67df60270d6ae63)