### PR TITLE
Preserve logical 2D stroke widths and use float-width wxGraphicsPen

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -56,8 +56,9 @@ public:
   void DrawLine(const viewer2d::Viewer2DRenderPoint &p0,
                 const viewer2d::Viewer2DRenderPoint &p1,
                 const CanvasStroke &stroke, double strokeWidthPx) override {
-    wxPen pen(ToWxColor(stroke.color),
-              std::max(1, static_cast<int>(std::lround(strokeWidthPx))));
+    wxGraphicsPen pen =
+        gc_.CreatePen(wxGraphicsPenInfo(ToWxColor(stroke.color))
+                          .Width(strokeWidthPx));
     gc_.SetPen(pen);
     gc_.StrokeLine(p0.x, p0.y, p1.x, p1.y);
   }
@@ -72,8 +73,9 @@ public:
     for (size_t i = 1; i < points.size(); ++i) {
       path.AddLineToPoint(points[i].x, points[i].y);
     }
-    wxPen pen(ToWxColor(stroke.color),
-              std::max(1, static_cast<int>(std::lround(strokeWidthPx))));
+    wxGraphicsPen pen =
+        gc_.CreatePen(wxGraphicsPenInfo(ToWxColor(stroke.color))
+                          .Width(strokeWidthPx));
     gc_.SetPen(pen);
     gc_.StrokePath(path);
   }
@@ -93,8 +95,9 @@ public:
       gc_.SetBrush(wxBrush(ToWxColor(fill->color)));
       gc_.FillPath(path);
     }
-    wxPen pen(ToWxColor(stroke.color),
-              std::max(1, static_cast<int>(std::lround(strokeWidthPx))));
+    wxGraphicsPen pen =
+        gc_.CreatePen(wxGraphicsPenInfo(ToWxColor(stroke.color))
+                          .Width(strokeWidthPx));
     gc_.SetPen(pen);
     gc_.StrokePath(path);
   }
@@ -108,8 +111,9 @@ public:
       gc_.SetBrush(wxBrush(ToWxColor(fill->color)));
       gc_.DrawEllipse(rect.m_x, rect.m_y, rect.m_width, rect.m_height);
     }
-    wxPen pen(ToWxColor(stroke.color),
-              std::max(1, static_cast<int>(std::lround(strokeWidthPx))));
+    wxGraphicsPen pen =
+        gc_.CreatePen(wxGraphicsPenInfo(ToWxColor(stroke.color))
+                          .Width(strokeWidthPx));
     gc_.SetPen(pen);
     gc_.SetBrush(*wxTRANSPARENT_BRUSH);
     gc_.DrawEllipse(rect.m_x, rect.m_y, rect.m_width, rect.m_height);

--- a/viewer2d/canvas2d.h
+++ b/viewer2d/canvas2d.h
@@ -35,7 +35,8 @@ struct CanvasColor {
 // Basic line style description shared by commands that involve strokes.
 struct CanvasStroke {
   CanvasColor color{};
-  float width = 1.0f; // Width expressed in the same logical units as the scene
+  float width = 1.0f; // Width in logical scene units (raster backends convert to
+                      // device pixels while vector exporters keep logical units).
 };
 
 // Fill style used by polygons, rectangles and circles.

--- a/viewer2d/viewer2dcommandrenderer.cpp
+++ b/viewer2d/viewer2dcommandrenderer.cpp
@@ -125,7 +125,7 @@ void Viewer2DCommandRenderer::RenderInternal(const CommandBuffer &buffer,
   std::vector<CanvasTransform> stack;
 
   auto strokeWidth = [&](float width) {
-    return std::max(1.0, std::round(width * mapping_.scale));
+    return width * mapping_.scale;
   };
 
   auto mapPoint = [&](float x, float y) {


### PR DESCRIPTION
### Motivation
- Align on-screen stroke width handling with the PDF exporter by keeping widths in logical scene units instead of forcing integer pixel radii.
- Avoid aggressive rounding/clamping that forces a minimum 1px stroke and distorts relative thickness when zooming.
- Ensure the layout backend can render non-integer stroke widths by using a floating-point pen in the wxGraphics pipeline.
- Document the expected units for `CanvasStroke::width` so raster and vector backends behave consistently.

### Description
- Return logical stroke width from the renderer by changing the stroke width computation to `width * mapping_.scale` (removed `std::round` and `std::max(1.0, ...)`) in `viewer2d/viewer2dcommandrenderer.cpp`.
- Replace integer `wxPen` creation with `wxGraphicsPen` via `gc_.CreatePen(wxGraphicsPenInfo(...).Width(strokeWidthPx))` in `gui/layoutviewerpanel.cpp` for `DrawLine`, `DrawPolyline`, `DrawPolygon` and `DrawCircle` to accept float widths.
- Clarify `CanvasStroke::width` units in `viewer2d/canvas2d.h` comment to state that widths are in logical scene units and raster backends convert to device pixels while vector exporters retain logical units.

### Testing
- No automated tests were executed as part of this change.
- The change compiles locally (manual confirmation during development) but no CI/test run is attached to this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695277e510008324a4ed70470d0dda38)