### PR TITLE
Add shared viewer2d/render2d_common module and unify PDF mapping/stroke rules

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -26,7 +26,8 @@
 
 #include "configmanager.h"
 #include "layouts/LayoutManager.h"
-#include "viewer2dcommandrenderer.h"
+#include "render2d_common.h"
+#include "viewer2dpdfexporter.h"
 #include "viewer2dstate.h"
 
 namespace {
@@ -625,21 +626,7 @@ void LayoutViewerPanel::RebuildCachedBitmap() {
     return;
   }
 
-  Viewer2DViewState renderState = cachedViewState;
-  if (renderState.viewportWidth <= 0) {
-    if (view->camera.viewportWidth > 0) {
-      renderState.viewportWidth = view->camera.viewportWidth;
-    } else {
-      renderState.viewportWidth = view->frame.width;
-    }
-  }
-  if (renderState.viewportHeight <= 0) {
-    if (view->camera.viewportHeight > 0) {
-      renderState.viewportHeight = view->camera.viewportHeight;
-    } else {
-      renderState.viewportHeight = view->frame.height;
-    }
-  }
+  Viewer2DViewState renderState = ResolveRenderViewState(*view);
 
   wxBitmap bufferBitmap(frameRect.GetWidth(), frameRect.GetHeight());
   wxMemoryDC memDC(bufferBitmap);
@@ -660,6 +647,40 @@ void LayoutViewerPanel::RebuildCachedBitmap() {
   memDC.SelectObject(wxNullBitmap);
   cachedBitmap = bufferBitmap;
   cachedBitmapSize = frameRect.GetSize();
+}
+
+Viewer2DExportResult LayoutViewerPanel::ExportLayoutToPdf(
+    const Viewer2DPrintOptions &options,
+    const std::filesystem::path &outputPath) const {
+  Viewer2DExportResult result{};
+  const layouts::Layout2DViewDefinition *view = GetEditableView();
+  if (!view || !hasCapture) {
+    result.message = "The layout view is not ready for export.";
+    return result;
+  }
+  Viewer2DViewState renderState = ResolveRenderViewState(*view);
+  return ExportViewer2DToPdf(cachedBuffer, renderState, options, outputPath,
+                             cachedSymbols);
+}
+
+Viewer2DViewState LayoutViewerPanel::ResolveRenderViewState(
+    const layouts::Layout2DViewDefinition &view) const {
+  Viewer2DViewState renderState = cachedViewState;
+  if (renderState.viewportWidth <= 0) {
+    if (view.camera.viewportWidth > 0) {
+      renderState.viewportWidth = view.camera.viewportWidth;
+    } else {
+      renderState.viewportWidth = view.frame.width;
+    }
+  }
+  if (renderState.viewportHeight <= 0) {
+    if (view.camera.viewportHeight > 0) {
+      renderState.viewportHeight = view.camera.viewportHeight;
+    } else {
+      renderState.viewportHeight = view.frame.height;
+    }
+  }
+  return renderState;
 }
 
 void LayoutViewerPanel::RequestRenderRebuild() {

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -20,12 +20,16 @@
 #include <memory>
 #include <optional>
 #include <wx/wx.h>
+#include <filesystem>
 #include "layouts/LayoutCollection.h"
 #include "canvas2d.h"
 #include "symbolcache.h"
 #include "viewer2dpanel.h"
 
 wxDECLARE_EVENT(EVT_LAYOUT_VIEW_EDIT, wxCommandEvent);
+
+struct Viewer2DExportResult;
+struct Viewer2DPrintOptions;
 
 class LayoutViewerPanel : public wxPanel {
 public:
@@ -34,6 +38,9 @@ public:
   void SetLayoutDefinition(const layouts::LayoutDefinition &layout);
   layouts::Layout2DViewDefinition *GetEditableView();
   const layouts::Layout2DViewDefinition *GetEditableView() const;
+  Viewer2DExportResult ExportLayoutToPdf(
+      const Viewer2DPrintOptions &options,
+      const std::filesystem::path &outputPath) const;
 
 private:
   void OnPaint(wxPaintEvent &event);
@@ -58,6 +65,8 @@ private:
   void RequestRenderRebuild();
   void InvalidateRenderIfFrameChanged();
   void EmitEditViewRequest();
+  Viewer2DViewState ResolveRenderViewState(
+      const layouts::Layout2DViewDefinition &view) const;
 
   enum class FrameDragMode {
     None,

--- a/viewer2d/render2d_common.cpp
+++ b/viewer2d/render2d_common.cpp
@@ -16,12 +16,12 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "viewer2dcommandrenderer.h"
+#include "render2d_common.h"
+
+#include "viewer2dpanel.h"
 
 #include <algorithm>
 #include <cmath>
-
-#include "viewer2dpanel.h"
 
 namespace viewer2d {
 namespace {
@@ -103,6 +103,7 @@ bool BuildViewMapping(const Viewer2DViewState &viewState, double targetWidth,
   mapping.offsetX = offsetX;
   mapping.offsetY = offsetY;
   mapping.drawHeight = bounds.height * scale;
+  mapping.flipY = true;
   return true;
 }
 
@@ -135,8 +136,11 @@ void Viewer2DCommandRenderer::RenderInternal(const CommandBuffer &buffer,
     double ty = transformed.y * currentTransform.scale +
                 currentTransform.offsetY;
     double mappedX = mapping_.offsetX + (tx - mapping_.minX) * mapping_.scale;
-    double mappedY = mapping_.offsetY + mapping_.drawHeight -
-                     (ty - mapping_.minY) * mapping_.scale;
+    double mappedY = mapping_.offsetY + (ty - mapping_.minY) * mapping_.scale;
+    if (mapping_.flipY) {
+      mappedY = mapping_.offsetY + mapping_.drawHeight -
+                (ty - mapping_.minY) * mapping_.scale;
+    }
     return Viewer2DRenderPoint{mappedX, mappedY};
   };
 

--- a/viewer2d/render2d_common.h
+++ b/viewer2d/render2d_common.h
@@ -45,6 +45,7 @@ struct Viewer2DRenderMapping {
   double offsetX = 0.0;
   double offsetY = 0.0;
   double drawHeight = 0.0;
+  bool flipY = true;
 };
 
 struct Viewer2DRenderPoint {


### PR DESCRIPTION
### Motivation
- Remove duplicated 2D mapping and command-rendering logic that existed in multiple places and provide a single reusable module. 
- Ensure the same view mapping and stroke scaling are used for on-screen raster rendering and PDF (vector) export. 
- Make it straightforward to print layout views by passing the captured `CommandBuffer` and `Viewer2DViewState` directly to the PDF exporter. 
- Keep on-screen rendering as raster for performance while reproducing identical mapping and stroke rules in PDF output.

### Description
- Add a shared module `viewer2d/render2d_common.h` and `viewer2d/render2d_common.cpp` (renamed from the old `viewer2dcommandrenderer`), exposing `Viewer2DRenderMapping`, `BuildViewMapping`, `ComputeViewBounds`, `Viewer2DCommandRenderer`, and the `IViewer2DCommandBackend` interface. 
- Update the PDF exporter to use `viewer2d::Viewer2DRenderMapping`, pass mapping scale into stroke/fill append functions, and set `viewMapping.flipY = false` for PDF so vector output uses the same mapping and stroke widths as the on-screen renderer. 
- Replace local renderer usage in the GUI with the new common API by including `render2d_common.h` and implementing `WxGraphicsCommandBackend : IViewer2DCommandBackend` for on-screen drawing. 
- Add layout export helpers to `LayoutViewerPanel` (`ExportLayoutToPdf` and `ResolveRenderViewState`) so the captured `CommandBuffer` + `Viewer2DViewState` for a layout can be sent directly to `ExportViewer2DToPdf`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952798d28a48324aa7906eb6e09165b)