### PR TITLE
Align layout 2D stroke widths with viewer/PDF logic

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -56,9 +56,10 @@ public:
   void DrawLine(const viewer2d::Viewer2DRenderPoint &p0,
                 const viewer2d::Viewer2DRenderPoint &p1,
                 const CanvasStroke &stroke, double strokeWidthPx) override {
+    (void)strokeWidthPx;
     wxGraphicsPen pen =
         gc_.CreatePen(wxGraphicsPenInfo(ToWxColor(stroke.color))
-                          .Width(strokeWidthPx));
+                          .Width(stroke.width));
     gc_.SetPen(pen);
     gc_.StrokeLine(p0.x, p0.y, p1.x, p1.y);
   }
@@ -66,6 +67,7 @@ public:
   void DrawPolyline(const std::vector<viewer2d::Viewer2DRenderPoint> &points,
                     const CanvasStroke &stroke,
                     double strokeWidthPx) override {
+    (void)strokeWidthPx;
     if (points.size() < 2)
       return;
     wxGraphicsPath path = gc_.CreatePath();
@@ -75,7 +77,7 @@ public:
     }
     wxGraphicsPen pen =
         gc_.CreatePen(wxGraphicsPenInfo(ToWxColor(stroke.color))
-                          .Width(strokeWidthPx));
+                          .Width(stroke.width));
     gc_.SetPen(pen);
     gc_.StrokePath(path);
   }
@@ -83,6 +85,7 @@ public:
   void DrawPolygon(const std::vector<viewer2d::Viewer2DRenderPoint> &points,
                    const CanvasStroke &stroke, const CanvasFill *fill,
                    double strokeWidthPx) override {
+    (void)strokeWidthPx;
     if (points.size() < 3)
       return;
     wxGraphicsPath path = gc_.CreatePath();
@@ -97,7 +100,7 @@ public:
     }
     wxGraphicsPen pen =
         gc_.CreatePen(wxGraphicsPenInfo(ToWxColor(stroke.color))
-                          .Width(strokeWidthPx));
+                          .Width(stroke.width));
     gc_.SetPen(pen);
     gc_.StrokePath(path);
   }
@@ -105,6 +108,7 @@ public:
   void DrawCircle(const viewer2d::Viewer2DRenderPoint &center, double radiusPx,
                   const CanvasStroke &stroke, const CanvasFill *fill,
                   double strokeWidthPx) override {
+    (void)strokeWidthPx;
     wxRect2DDouble rect(center.x - radiusPx, center.y - radiusPx,
                         radiusPx * 2.0, radiusPx * 2.0);
     if (fill) {
@@ -113,7 +117,7 @@ public:
     }
     wxGraphicsPen pen =
         gc_.CreatePen(wxGraphicsPenInfo(ToWxColor(stroke.color))
-                          .Width(strokeWidthPx));
+                          .Width(stroke.width));
     gc_.SetPen(pen);
     gc_.SetBrush(*wxTRANSPARENT_BRUSH);
     gc_.DrawEllipse(rect.m_x, rect.m_y, rect.m_width, rect.m_height);


### PR DESCRIPTION
### Motivation
- Make layout 2D rendering reuse the same logical stroke width semantics used by the viewer and PDF pipeline to keep line weights consistent.
- Avoid double-scaling strokes by the layout render mapping which produced exaggerated line widths in layouts.
- Preserve the existing `viewer2d` and PDF behavior while changing only the layout rendering backend to match it.

### Description
- `WxGraphicsCommandBackend` in `gui/layoutviewerpanel.cpp` now uses `stroke.width` instead of the mapped `strokeWidthPx` in `DrawLine`, `DrawPolyline`, `DrawPolygon`, and `DrawCircle` so layouts receive logical stroke widths.
- Added `(void)strokeWidthPx;` in the affected functions to silence unused-parameter warnings.
- No changes were made to the viewer2d rendering or PDF exporter code paths in this change.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695272d75554832488b1aa01d11d4fc8)