### PR TITLE
Ensure layout 2D views initialize and ignore dark mode

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -26,6 +26,7 @@
 
 #include "configmanager.h"
 #include "layouts/LayoutManager.h"
+#include "mainwindow.h"
 #include "viewer2dcommandrenderer.h"
 #include "viewer2dstate.h"
 
@@ -284,6 +285,11 @@ void LayoutViewerPanel::OnPaint(wxPaintEvent &) {
 
   if (!captureInProgress && captureVersion != layoutVersion) {
     Viewer2DPanel *panel = Viewer2DPanel::Instance();
+    if (!panel) {
+      if (auto *mw = MainWindow::Instance())
+        mw->Ensure2DViewportAvailable();
+      panel = Viewer2DPanel::Instance();
+    }
     if (panel) {
       captureInProgress = true;
       const int fallbackViewportWidth =
@@ -295,6 +301,7 @@ void LayoutViewerPanel::OnPaint(wxPaintEvent &) {
       ConfigManager &cfg = ConfigManager::Get();
       viewer2d::Viewer2DState layoutState =
           viewer2d::FromLayoutDefinition(*view);
+      layoutState.renderOptions.darkMode = false;
       auto stateGuard = std::make_shared<viewer2d::ScopedViewer2DState>(
           panel, nullptr, cfg, layoutState);
       panel->CaptureFrameAsync(

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -551,6 +551,8 @@ void MainWindow::Ensure2DViewport() {
   }
 }
 
+void MainWindow::Ensure2DViewportAvailable() { Ensure2DViewport(); }
+
 void MainWindow::CreateMenuBar() {
   wxMenuBar *menuBar = new wxMenuBar();
 
@@ -2147,6 +2149,7 @@ void MainWindow::OnLayout2DViewOk(wxCommandEvent &WXUNUSED(event)) {
       layout2DViewEditPanel ? layout2DViewEditPanel : viewport2DPanel;
   viewer2d::Viewer2DState current =
       viewer2d::CaptureState(editPanel, cfg);
+  current.renderOptions.darkMode = false;
 
   layouts::Layout2DViewFrame frame{};
   const layouts::LayoutDefinition *layout = nullptr;
@@ -2238,6 +2241,7 @@ void MainWindow::PersistLayout2DViewState() {
   }
   layouts::Layout2DViewDefinition view =
       viewer2d::CaptureLayoutDefinition(activePanel, cfg, frame);
+  view.renderOptions.darkMode = false;
   layouts::LayoutManager::Get().UpdateLayout2DView(activeLayoutName, view);
 }
 

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -56,6 +56,7 @@ public:
   static void SetInstance(MainWindow *inst);
 
   void EnableShortcuts(bool enable);
+  void Ensure2DViewportAvailable();
   void PersistLayout2DViewState();
   void RestoreLayout2DViewState(int viewIndex);
 


### PR DESCRIPTION
### Motivation
- Layout preview captures were not available until the standalone 2D viewer was created, causing layout thumbnails/previews to remain empty.
- Saved/previewed layout 2D views could pick up the application dark mode which made printed/layout previews inconsistent with the intended light output.
- Provide a small API surface to ensure the 2D viewport can be created on-demand for other UI components.
- Keep layout editing/capture independent of the on-screen 2D viewer instance to avoid surprising side effects.

### Description
- Added `MainWindow::Ensure2DViewportAvailable()` which calls `Ensure2DViewport()` to allow other code to create the 2D viewport on demand.
- `LayoutViewerPanel` now attempts to initialize the shared `Viewer2DPanel` before requesting a capture by calling `MainWindow::Ensure2DViewportAvailable()` and re-checking `Viewer2DPanel::Instance()`.
- Forces layout-related captures and saved layout definitions to use light mode by setting `renderOptions.darkMode = false` in the captured/updated `Viewer2DState` and `Layout2DViewDefinition` paths (`LayoutViewerPanel` capture, `MainWindow::OnLayout2DViewOk`, and `MainWindow::PersistLayout2DViewState`).
- Small header/cpp updates: added declaration in `gui/mainwindow.h`, implementation in `gui/mainwindow.cpp`, and included `mainwindow.h` in `gui/layoutviewerpanel.cpp`.

### Testing
- No automated tests were executed for this change.
- Manual validation was implied by commit but no CI/test run was performed (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953a9cf54dc8324a7cf32ebaba96104)