### PR TITLE
Force fixtures to render on top in 2D (disable depth during fixture pass)

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1295,6 +1295,13 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
 
   // Fixtures last
   glShadeModel(GL_FLAT);
+  const bool forceFixturesOnTop = wireframe;
+  GLboolean depthEnabled = GL_FALSE;
+  if (forceFixturesOnTop) {
+    depthEnabled = glIsEnabled(GL_DEPTH_TEST);
+    if (depthEnabled)
+      glDisable(GL_DEPTH_TEST);
+  }
   const auto &fixtures = SceneDataManager::Instance().GetFixtures();
   std::vector<const std::pair<const std::string, Fixture> *> sortedFixtures;
   sortedFixtures.reserve(fixtures.size());
@@ -1503,6 +1510,8 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
     if (m_captureCanvas)
       m_captureCanvas->SetSourceKey("unknown");
   }
+  if (forceFixturesOnTop && depthEnabled)
+    glEnable(GL_DEPTH_TEST);
 
   const auto &groups = SceneDataManager::Instance().GetGroupObjects();
   for (const auto &[uuid, g] : groups) {


### PR DESCRIPTION
### Motivation
- The 2D view editor could show incorrect occlusion because fixtures were rendered with the GL depth test enabled, so their intended "on-top" ordering for 2D/wireframe views was not preserved.
- The goal is to make the layout editor render match the on-screen 2D viewport by forcing fixtures to draw above other geometry in the 2D/wireframe pass.

### Description
- When rendering the fixture pass in `viewer3d/viewer3dcontroller.cpp`, add a `forceFixturesOnTop` flag derived from the `wireframe` parameter to control the behavior.
- Query and save the existing depth test state with `glIsEnabled(GL_DEPTH_TEST)` and call `glDisable(GL_DEPTH_TEST)` while drawing fixtures when `forceFixturesOnTop` is set.
- Restore the previous depth test state after fixture rendering by calling `glEnable(GL_DEPTH_TEST)` only if it was enabled before.
- Change is limited to the fixtures rendering section so other parts of `RenderScene` keep their previous behaviour.

### Testing
- No automated tests were run for this change.
- Manual runs / runtime verification are not reported here as only automated test results should be listed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953acf791748324ba7c41366f0b91ec)