### PR TITLE
Refresh 2D editor when Layout 2D View dialog is shown

### DIFF
--- a/gui/layout2dviewdialog.cpp
+++ b/gui/layout2dviewdialog.cpp
@@ -43,6 +43,8 @@ Layout2DViewDialog::Layout2DViewDialog(wxWindow *parent)
   SetMinSize(wxSize(1000, 700));
   Layout();
   CentreOnParent();
+
+  Bind(wxEVT_SHOW, &Layout2DViewDialog::OnShow, this);
 }
 
 void Layout2DViewDialog::OnOk(wxCommandEvent &event) {
@@ -52,5 +54,13 @@ void Layout2DViewDialog::OnOk(wxCommandEvent &event) {
 
 void Layout2DViewDialog::OnCancel(wxCommandEvent &event) {
   EndModal(wxID_CANCEL);
+  event.Skip();
+}
+
+void Layout2DViewDialog::OnShow(wxShowEvent &event) {
+  if (event.IsShown() && viewerPanel) {
+    viewerPanel->UpdateScene(true);
+    viewerPanel->Update();
+  }
   event.Skip();
 }

--- a/gui/layout2dviewdialog.h
+++ b/gui/layout2dviewdialog.h
@@ -16,6 +16,7 @@ public:
 private:
   void OnOk(wxCommandEvent &event);
   void OnCancel(wxCommandEvent &event);
+  void OnShow(wxShowEvent &event);
 
   Viewer2DPanel *viewerPanel = nullptr;
   Viewer2DRenderPanel *renderPanel = nullptr;


### PR DESCRIPTION
### Motivation
- The 2D View Editor could display missing/occluded elements on first open while subsequent pan/zoom caused a correct refresh. 
- The initial dialog show path did not force the editor to reload the scene and repaint with the same sequence used by later refreshes. 
- Ensuring the editor's scene is updated when the dialog becomes visible makes the on-screen result match the 2D viewport. 

### Description
- Added an `OnShow` event handler to `Layout2DViewDialog` and declared it in the header as `void OnShow(wxShowEvent &event)`. 
- Bound `wxEVT_SHOW` in the dialog constructor to call the new `OnShow` handler. 
- The handler calls `viewerPanel->UpdateScene(true)` and `viewerPanel->Update()` to force a full reload and repaint of the 2D editor when the dialog is shown. 
- No other functional changes were made. 

### Testing
- No automated tests were run for this change. 
- The change is limited to dialog show handling and forces the existing `Viewer2DPanel` update pathway to run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953af42a4a483249198d935df9f37db)