### PR TITLE
Ensure layout 2D editor loads view config on show

### DIFF
--- a/gui/layout2dviewdialog.cpp
+++ b/gui/layout2dviewdialog.cpp
@@ -59,6 +59,7 @@ void Layout2DViewDialog::OnCancel(wxCommandEvent &event) {
 
 void Layout2DViewDialog::OnShow(wxShowEvent &event) {
   if (event.IsShown() && viewerPanel) {
+    viewerPanel->LoadViewFromConfig();
     viewerPanel->UpdateScene(true);
     viewerPanel->Update();
   }


### PR DESCRIPTION
### Motivation
- The layout 2D editor initially rendered with a different viewport state than the main 2D viewer, causing some elements to appear hidden until the user panned/zoomed. 
- The inconsistency was caused by the editor's `Viewer2DPanel` not loading the saved view configuration before the first render. 
- Aligning the editor's startup behavior with the main 2D viewport prevents the transient visual mismatch. 
- This is a small, targeted fix to ensure the initial render matches the stored offsets/zoom/render options.

### Description
- Call `viewerPanel->LoadViewFromConfig()` in `Layout2DViewDialog::OnShow` so the editor reloads the saved 2D view state when first shown. 
- Change applied in `gui/layout2dviewdialog.cpp` (single-line insertion). 
- The `UpdateScene(true)` / `Update()` sequence now runs after the view config is applied so the first paint uses the correct state. 
- No other behavioral changes were made and the edit is intentionally low-risk.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953b1484ea08324aa6dd70581da1c57)