### PR TITLE
Guard 2D GL capture when canvas is hidden

### DIFF
--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -252,8 +252,7 @@ void Viewer2DPanel::CaptureFrameNow(
   if (IsShownOnScreen()) {
     Update();
   } else {
-    InitGL();
-    Render();
+    return;
   }
 }
 
@@ -283,6 +282,9 @@ Viewer2DPanel::GetBottomSymbolCacheSnapshot() const {
 }
 
 void Viewer2DPanel::InitGL() {
+  if (!IsShownOnScreen()) {
+    return;
+  }
   SetCurrent(*m_glContext);
   if (!m_glInitialized) {
     glewExperimental = GL_TRUE;


### PR DESCRIPTION
### Motivation
- Prevent `SetCurrent`/GL operations from being invoked when the 2D canvas is not visible to avoid asserts/crashes.
- Avoid attempting to render a GL frame during a capture when the canvas is hidden since the context may not be current.

### Description
- Early-return from `CaptureFrameNow` when `IsShownOnScreen()` is false to skip `InitGL()` and `Render()` calls.
- Add an `IsShownOnScreen()` guard at the start of `InitGL()` to skip calling `SetCurrent(*m_glContext)` for hidden canvases.
- Keep capture plumbing (`CaptureFrameAsync`, `RequestFrameCapture`, etc.) unchanged so visible captures still proceed normally.

### Testing
- No automated tests were run for this change.
- Build and runtime tests were not executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69582f7ecc448324942bfc1422710998)