### PR TITLE
Force offscreen 2D captures for printing/layouts

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1492,7 +1492,7 @@ void MainWindow::OnPrintViewer2D(wxCommandEvent &WXUNUSED(event)) {
       std::filesystem::path(outputPathWx.ToStdWstring()));
   wxString outputPathDisplay = outputPathWx;
 
-  viewport2DPanel->CaptureFrameAsync(
+  viewport2DPanel->CaptureFrameNow(
       [this, opts, outputPath, outputPathDisplay](
           CommandBuffer buffer, Viewer2DViewState state) {
         if (buffer.commands.empty()) {

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -252,7 +252,10 @@ void Viewer2DPanel::CaptureFrameNow(
   if (IsShownOnScreen()) {
     Update();
   } else {
-    return;
+    m_forceOffscreenRender = true;
+    InitGL();
+    Render();
+    m_forceOffscreenRender = false;
   }
 }
 
@@ -282,7 +285,7 @@ Viewer2DPanel::GetBottomSymbolCacheSnapshot() const {
 }
 
 void Viewer2DPanel::InitGL() {
-  if (!IsShownOnScreen()) {
+  if (!IsShownOnScreen() && !m_forceOffscreenRender) {
     return;
   }
   SetCurrent(*m_glContext);

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -129,6 +129,7 @@ private:
   CommandBuffer m_lastCapturedFrame;
   std::function<void(CommandBuffer, Viewer2DViewState)> m_captureCallback;
   std::string m_lastFixtureDebugReport;
+  bool m_forceOffscreenRender = false;
 
   wxGLContext *m_glContext = nullptr;
   bool m_glInitialized = false;


### PR DESCRIPTION
### Motivation
- Allow the 2D viewer to initialize its GL context and render when it is hidden so captures for printing/layout generation succeed.
- Make the print/export path use the forced capture path to ensure PDF generation can capture the scene even if the panel is not visible.

### Description
- Added a boolean flag `m_forceOffscreenRender` to `Viewer2DPanel` to indicate a forced offscreen render.
- Updated `Viewer2DPanel::CaptureFrameNow` to set `m_forceOffscreenRender`, call `InitGL()` and `Render()` when `IsShownOnScreen()` is false, and then clear the flag.
- Modified `Viewer2DPanel::InitGL()` to initialize GL when `m_forceOffscreenRender` is true even if the panel is hidden.
- Switched the print code in `MainWindow::OnPrintViewer2D` to call `CaptureFrameNow` instead of `CaptureFrameAsync` so printing uses the forced capture path.

### Testing
- No automated tests were run for this change.
- (If desired) recommend running the application print-to-PDF flow and layout capture code paths to validate offscreen captures produce expected command buffers and PDFs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695832f0b35883248257594d281b1b97)