### PR TITLE
Add offscreen 2D renderer for print and layout capture

### DIFF
--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -36,6 +36,7 @@ class SceneObjectTablePanel;
 class Viewer3DPanel;
 class Viewer2DPanel;
 class Viewer2DRenderPanel;
+class Viewer2DOffscreenRenderer;
 class ConsolePanel;
 class LayerPanel;
 class LayoutPanel;
@@ -58,6 +59,7 @@ public:
   void EnableShortcuts(bool enable);
   void Ensure2DViewportAvailable();
   Viewer2DPanel *GetLayoutCapturePanel() const;
+  Viewer2DOffscreenRenderer *GetOffscreenRenderer();
   bool IsLayout2DViewEditing() const;
   void PersistLayout2DViewState();
   void RestoreLayout2DViewState(int viewIndex);
@@ -81,6 +83,7 @@ private:
   Viewer3DPanel *viewportPanel = nullptr;
   Viewer2DPanel *viewport2DPanel = nullptr;
   Viewer2DRenderPanel *viewport2DRenderPanel = nullptr;
+  std::unique_ptr<Viewer2DOffscreenRenderer> offscreenViewer2DRenderer;
   ConsolePanel *consolePanel = nullptr;
   LayerPanel *layerPanel = nullptr;
   LayoutPanel *layoutPanel = nullptr;

--- a/viewer2d/viewer2doffscreenrenderer.cpp
+++ b/viewer2d/viewer2doffscreenrenderer.cpp
@@ -1,0 +1,52 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "viewer2doffscreenrenderer.h"
+
+namespace {
+constexpr int kDefaultViewportWidth = 1600;
+constexpr int kDefaultViewportHeight = 900;
+}
+
+Viewer2DOffscreenRenderer::Viewer2DOffscreenRenderer(wxWindow *parent) {
+  host_ = new wxPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(1, 1));
+  host_->Hide();
+
+  panel_ = new Viewer2DPanel(host_, true);
+  panel_->SetSize(wxSize(kDefaultViewportWidth, kDefaultViewportHeight));
+  panel_->SetClientSize(wxSize(kDefaultViewportWidth, kDefaultViewportHeight));
+  panel_->LoadViewFromConfig();
+  panel_->UpdateScene(true);
+}
+
+Viewer2DOffscreenRenderer::~Viewer2DOffscreenRenderer() = default;
+
+void Viewer2DOffscreenRenderer::SetViewportSize(const wxSize &size) {
+  if (!panel_)
+    return;
+  if (size.GetWidth() <= 0 || size.GetHeight() <= 0)
+    return;
+  panel_->SetSize(size);
+  panel_->SetClientSize(size);
+}
+
+void Viewer2DOffscreenRenderer::PrepareForCapture() {
+  if (!panel_)
+    return;
+  panel_->LoadViewFromConfig();
+  panel_->UpdateScene(true);
+}

--- a/viewer2d/viewer2doffscreenrenderer.h
+++ b/viewer2d/viewer2doffscreenrenderer.h
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "viewer2dpanel.h"
+#include <wx/panel.h>
+#include <wx/window.h>
+
+class Viewer2DOffscreenRenderer {
+public:
+  explicit Viewer2DOffscreenRenderer(wxWindow *parent);
+  ~Viewer2DOffscreenRenderer();
+
+  Viewer2DPanel *GetPanel() const { return panel_; }
+  void SetViewportSize(const wxSize &size);
+  void PrepareForCapture();
+
+private:
+  wxPanel *host_ = nullptr;
+  Viewer2DPanel *panel_ = nullptr;
+};

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -46,7 +46,7 @@ struct Viewer2DViewState {
 
 class Viewer2DPanel : public wxGLCanvas {
 public:
-  explicit Viewer2DPanel(wxWindow *parent);
+  explicit Viewer2DPanel(wxWindow *parent, bool allowOffscreenRender = false);
   ~Viewer2DPanel();
 
   static Viewer2DPanel *Instance();
@@ -130,6 +130,7 @@ private:
   std::function<void(CommandBuffer, Viewer2DViewState)> m_captureCallback;
   std::string m_lastFixtureDebugReport;
   bool m_forceOffscreenRender = false;
+  bool m_allowOffscreenRender = false;
 
   wxGLContext *m_glContext = nullptr;
   bool m_glInitialized = false;


### PR DESCRIPTION
### Motivation
- Allow capturing the 2D view for printing and layout thumbnails without requiring the visible on-screen `Viewer2DPanel` or the user to open the “2D Viewport”.
- Avoid reliance on `IsShownOnScreen()` so captures can be performed from hidden/offscreen renderers.
- Use a dedicated offscreen renderer for `MainWindow::OnPrintViewer2D` and `LayoutViewerPanel::OnPaint` to produce reliable exports and layout previews.

### Description
- Add a new `Viewer2DOffscreenRenderer` class (files `viewer2d/viewer2doffscreenrenderer.{h,cpp}`) that hosts a hidden `Viewer2DPanel` and exposes `GetPanel()`, `SetViewportSize()` and `PrepareForCapture()` for offscreen captures.
- Extend `Viewer2DPanel` to accept an `allowOffscreenRender` flag, add `m_allowOffscreenRender`, and update `CaptureFrameNow`/`InitGL` so the panel can initialize and render while hidden when allowed (use `m_forceOffscreenRender`/`m_allowOffscreenRender`).
- Add `MainWindow::GetOffscreenRenderer()` and a `std::unique_ptr<Viewer2DOffscreenRenderer> offscreenViewer2DRenderer`, and switch `OnPrintViewer2D` to use the offscreen renderer (set viewport size, prepare, then call `CaptureFrameNow` on the offscreen `Viewer2DPanel`).
- Update `LayoutViewerPanel::OnPaint` to request captures from the offscreen renderer for layout view previews and use the appropriate panel for state capture (`statePanel`) while using the offscreen panel for actual rendering.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958343873d48324be2e6a2b75c7e4e5)