### PR TITLE
Add raster layout preview captures

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -243,6 +243,7 @@ void LayoutViewerPanel::SetLayoutDefinition(
   captureVersion = -1;
   hasCapture = false;
   cachedBitmap = wxBitmap();
+  cachedRasterBitmap = wxBitmap();
   cachedBitmapSize = wxSize(0, 0);
   renderDirty = true;
   ResetViewToFit();
@@ -337,10 +338,11 @@ void LayoutViewerPanel::OnPaint(wxPaintEvent &) {
       }
       auto stateGuard = std::make_shared<viewer2d::ScopedViewer2DState>(
           capturePanel, nullptr, cfg, layoutState);
-      capturePanel->CaptureFrameNow(
+      capturePanel->CaptureFrameNowWithBitmap(
           [this, stateGuard, fallbackViewportWidth, fallbackViewportHeight,
            capturePanel](
-              CommandBuffer buffer, Viewer2DViewState state) {
+              CommandBuffer buffer, Viewer2DViewState state,
+              wxBitmap bitmap) {
             cachedBuffer = std::move(buffer);
             cachedViewState = state;
             if (cachedViewState.viewportWidth <= 0 &&
@@ -355,6 +357,7 @@ void LayoutViewerPanel::OnPaint(wxPaintEvent &) {
             if (capturePanel) {
               cachedSymbols = capturePanel->GetBottomSymbolCacheSnapshot();
             }
+            cachedRasterBitmap = bitmap;
             hasCapture = !cachedBuffer.commands.empty();
             captureVersion = layoutVersion;
             captureInProgress = false;
@@ -666,6 +669,15 @@ void LayoutViewerPanel::RebuildCachedBitmap() {
       frameRect.GetWidth() <= 0 || frameRect.GetHeight() <= 0) {
     cachedBitmap = wxBitmap();
     cachedBitmapSize = wxSize(0, 0);
+    return;
+  }
+
+  if (cachedRasterBitmap.IsOk()) {
+    wxImage image = cachedRasterBitmap.ConvertToImage();
+    image.Rescale(frameRect.GetWidth(), frameRect.GetHeight(),
+                  wxIMAGE_QUALITY_HIGH);
+    cachedBitmap = wxBitmap(image);
+    cachedBitmapSize = frameRect.GetSize();
     return;
   }
 

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -86,6 +86,7 @@ private:
   CommandBuffer cachedBuffer;
   Viewer2DViewState cachedViewState;
   std::shared_ptr<const SymbolDefinitionSnapshot> cachedSymbols;
+  wxBitmap cachedRasterBitmap;
   wxBitmap cachedBitmap;
   wxSize cachedBitmapSize{0, 0};
   bool renderDirty = true;

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -268,6 +268,19 @@ void Viewer2DPanel::CaptureFrameNow(
   }
 }
 
+void Viewer2DPanel::CaptureFrameNowWithBitmap(
+    std::function<void(CommandBuffer, Viewer2DViewState, wxBitmap)> callback,
+    bool useSimplifiedFootprints, bool includeGridInCapture) {
+  CaptureFrameNow(
+      [this, callback = std::move(callback)](CommandBuffer buffer,
+                                             Viewer2DViewState state) mutable {
+        wxBitmap bitmap = ReadBackBitmap(state.viewportWidth,
+                                         state.viewportHeight);
+        callback(std::move(buffer), state, bitmap);
+      },
+      useSimplifiedFootprints, includeGridInCapture);
+}
+
 void Viewer2DPanel::SetLayoutEditOverlay(std::optional<float> aspectRatio) {
   m_layoutEditAspect = aspectRatio;
   Refresh();
@@ -463,6 +476,35 @@ void Viewer2DPanel::Render() {
 
   glFlush();
   SwapBuffers();
+}
+
+wxBitmap Viewer2DPanel::ReadBackBitmap(int width, int height) const {
+  if (width <= 0 || height <= 0)
+    return wxBitmap();
+  wxImage image(width, height, false);
+  std::vector<unsigned char> pixels(
+      static_cast<size_t>(width) * static_cast<size_t>(height) * 3);
+  glReadBuffer(GL_BACK);
+  glPixelStorei(GL_PACK_ALIGNMENT, 1);
+  glReadPixels(0, 0, width, height, GL_RGB, GL_UNSIGNED_BYTE,
+               pixels.data());
+  unsigned char *data = image.GetData();
+  for (int y = 0; y < height; ++y) {
+    for (int x = 0; x < width; ++x) {
+      size_t srcIndex =
+          (static_cast<size_t>(y) * static_cast<size_t>(width) +
+           static_cast<size_t>(x)) *
+          3;
+      size_t dstIndex =
+          (static_cast<size_t>(height - 1 - y) * static_cast<size_t>(width) +
+           static_cast<size_t>(x)) *
+          3;
+      data[dstIndex] = pixels[srcIndex];
+      data[dstIndex + 1] = pixels[srcIndex + 1];
+      data[dstIndex + 2] = pixels[srcIndex + 2];
+    }
+  }
+  return wxBitmap(image);
 }
 
 void Viewer2DPanel::OnPaint(wxPaintEvent &WXUNUSED(event)) {

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -83,6 +83,10 @@ public:
       std::function<void(CommandBuffer, Viewer2DViewState)> callback,
       bool useSimplifiedFootprints = false,
       bool includeGridInCapture = true);
+  void CaptureFrameNowWithBitmap(
+      std::function<void(CommandBuffer, Viewer2DViewState, wxBitmap)> callback,
+      bool useSimplifiedFootprints = false,
+      bool includeGridInCapture = true);
 
   // Accessor for the last recorded set of drawing commands. The buffer is
   // cleared and re-populated on every requested capture.
@@ -104,6 +108,7 @@ public:
 private:
   void InitGL();
   void Render();
+  wxBitmap ReadBackBitmap(int width, int height) const;
   void OnPaint(wxPaintEvent &event);
 
   void OnMouseDown(wxMouseEvent &event);


### PR DESCRIPTION
### Motivation
- Provide a raster capture path from the 2D OpenGL viewer so layout previews can be shown as bitmaps while keeping the vector command buffer available for printing/export.
- Allow the layout viewer to store and scale a raster snapshot for fast previews that match the on-screen GL rendering.
- Preserve existing vector re-rendering as a fallback when no raster snapshot is available.

### Description
- Added `CaptureFrameNowWithBitmap` to `Viewer2DPanel` which captures the `CommandBuffer` and view state and also produces a `wxBitmap` by reading back the GL back buffer using a new `ReadBackBitmap` helper.
- Implemented `ReadBackBitmap(int width, int height)` in `viewer2dpanel.cpp` which uses `glReadPixels` and converts the pixel data into a `wxBitmap`.
- Extended `LayoutViewerPanel` with a `cachedRasterBitmap` member and updated capture logic to call `CaptureFrameNowWithBitmap` and store the returned bitmap alongside the `CommandBuffer` and view state.
- Updated `RebuildCachedBitmap` to prefer the captured `cachedRasterBitmap` (rescaling it to the frame size) and fall back to the vector `Viewer2DCommandRenderer` path when no raster bitmap is present.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695905ff55148324b93f0a5d1531121a)