### PR TITLE
Render layout 2D view with OpenGL and offscreen texture capture

### DIFF
--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -19,17 +19,20 @@
 
 #include <memory>
 #include <optional>
+#include <wx/glcanvas.h>
 #include <wx/wx.h>
 #include "layouts/LayoutCollection.h"
 #include "canvas2d.h"
 #include "symbolcache.h"
 #include "viewer2dpanel.h"
+#include "viewer2dstate.h"
 
 wxDECLARE_EVENT(EVT_LAYOUT_VIEW_EDIT, wxCommandEvent);
 
-class LayoutViewerPanel : public wxPanel {
+class LayoutViewerPanel : public wxGLCanvas {
 public:
   explicit LayoutViewerPanel(wxWindow *parent);
+  ~LayoutViewerPanel();
 
   void SetLayoutDefinition(const layouts::LayoutDefinition &layout);
   layouts::Layout2DViewDefinition *GetEditableView();
@@ -54,7 +57,9 @@ private:
                     wxRect &rect) const;
   void UpdateFrame(const layouts::Layout2DViewFrame &frame,
                    bool updatePosition);
-  void RebuildCachedBitmap();
+  void InitGL();
+  void RebuildCachedTexture();
+  void ClearCachedTexture();
   void RequestRenderRebuild();
   void InvalidateRenderIfFrameChanged();
   void EmitEditViewRequest();
@@ -85,9 +90,13 @@ private:
   bool hasCapture = false;
   CommandBuffer cachedBuffer;
   Viewer2DViewState cachedViewState;
+  viewer2d::Viewer2DState cachedRenderState;
+  bool hasRenderState = false;
   std::shared_ptr<const SymbolDefinitionSnapshot> cachedSymbols;
-  wxBitmap cachedBitmap;
-  wxSize cachedBitmapSize{0, 0};
+  wxGLContext *glContext_ = nullptr;
+  bool glInitialized_ = false;
+  unsigned int cachedTexture_ = 0;
+  wxSize cachedTextureSize{0, 0};
   bool renderDirty = true;
   bool renderPending = false;
 

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -32,6 +32,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <vector>
 
 // Current viewport information used to rebuild the same projection when
 // exporting or printing the 2D view.
@@ -84,6 +85,9 @@ public:
       bool useSimplifiedFootprints = false,
       bool includeGridInCapture = true);
 
+  bool RenderToRGBA(std::vector<unsigned char> &pixels, int &width,
+                    int &height);
+
   // Accessor for the last recorded set of drawing commands. The buffer is
   // cleared and re-populated on every requested capture.
   const CommandBuffer &GetLastCapturedFrame() const { return m_lastCapturedFrame; }
@@ -104,6 +108,7 @@ public:
 private:
   void InitGL();
   void Render();
+  void RenderInternal(bool swapBuffers);
   void OnPaint(wxPaintEvent &event);
 
   void OnMouseDown(wxMouseEvent &event);


### PR DESCRIPTION
### Motivation
- Replace the CPU/wxGraphics-based on-screen layout preview with an OpenGL-backed presentation to match the 2D viewer renderer and allow GPU-accelerated display. 
- Keep the existing `CommandBuffer` capture flow for PDF/export while switching the interactive presentation to an OpenGL texture so the visual result matches the OpenGL renderer. 
- Reuse the existing offscreen 2D renderer to produce RGBA frames and avoid duplicating rendering logic. 
- Prepare the layout preview for future context-sharing or zero-copy texture presentation between renderers.

### Description
- Convert `LayoutViewerPanel` from a `wxPanel` to a `wxGLCanvas` and add an OpenGL context via `glContext_`, plus lifecycle handling in a new destructor. 
- Replace the cached `wxBitmap` path with an OpenGL texture (`cachedTexture_`) and implement `InitGL()`, `RebuildCachedTexture()` and `ClearCachedTexture()` to manage texture creation, upload and cleanup. 
- Use the offscreen renderer to produce RGBA pixels and upload them into the GL texture by adding `Viewer2DPanel::RenderToRGBA` and `RenderInternal(bool)` to support offscreen rendering + readback without swapping buffers. 
- Change painting logic in `LayoutViewerPanel::OnPaint` to draw the page background, frame handles and the uploaded 2D view texture with OpenGL primitives, and update `RequestRenderRebuild()` to call `RebuildCachedTexture()`.

### Testing
- No automated tests were executed as part of this change. 
- The changes compile-commit cycle was performed locally (no CI results included). 
- Manual runtime validation is expected (not included in this PR). 
- Further integration testing and platform runtime checks are recommended, especially for GL context interactions and platforms without GL support.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69590b2bb3748324abb77001f1fc7048)