### PR TITLE
Define GL_CLAMP_TO_EDGE when missing to fix Windows build

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -23,6 +23,9 @@
 #include <vector>
 
 #include <GL/gl.h>
+#ifndef GL_CLAMP_TO_EDGE
+#define GL_CLAMP_TO_EDGE 0x812F
+#endif
 
 #include "configmanager.h"
 #include "layouts/LayoutManager.h"


### PR DESCRIPTION
### Motivation
- The Windows MSVC build failed to compile with error C2065 because `GL_CLAMP_TO_EDGE` was not defined in `layoutviewerpanel.cpp`.
- Some GL headers provided on Windows do not include newer/extension texture wrap enum values unless an extension loader like GLEW is used, causing missing-symbol compile errors.
- Provide a small, local compatibility shim so the file can compile without requiring global header changes.

### Description
- Added a guarded preprocessor definition for `GL_CLAMP_TO_EDGE` with the value `0x812F` in `gui/layoutviewerpanel.cpp` after including `<GL/gl.h>`.
- The define is enclosed in `#ifndef`/`#endif` so it only applies when the constant is missing and remains local to the translation unit.
- No other changes to runtime logic or texture handling were made.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69590d66c938832486401f671d6ac3de)