### PR TITLE
DPI-aware supersampled rendering for layout viewer

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -182,6 +182,7 @@ ConfigManager::ConfigManager() {
   RegisterVariable("view2d_render_mode", "float", 2.0f, 0.0f, 3.0f);
   RegisterVariable("view2d_view", "float", 0.0f, 0.0f, 2.0f);
   RegisterVariable("view2d_dark_mode", "float", 1.0f, 0.0f, 1.0f);
+  RegisterVariable("layout_viewer_supersample", "float", 1.0f, 1.0f, 4.0f);
   LoadUserConfig();
   if (!HasKey("rider_autopatch"))
     SetValue("rider_autopatch", "1");

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -63,6 +63,7 @@ private:
   void RequestRenderRebuild();
   void InvalidateRenderIfFrameChanged();
   void EmitEditViewRequest();
+  double GetRenderScaleFactor() const;
 
   enum class FrameDragMode {
     None,
@@ -96,7 +97,9 @@ private:
   wxGLContext *glContext_ = nullptr;
   bool glInitialized_ = false;
   unsigned int cachedTexture_ = 0;
-  wxSize cachedTextureSize{0, 0};
+  wxSize cachedTextureTargetSize{0, 0};
+  wxSize cachedTextureRenderSize{0, 0};
+  double cachedRenderScale = 1.0;
   bool renderDirty = true;
   bool renderPending = false;
 


### PR DESCRIPTION
### Motivation
- Improve visual sharpness of 2D layout captures by rendering the `CommandBuffer` at higher resolution and scaling down, without changing layout logic.
- Take into account display DPI so captures are crisp on high-DPI screens by using `GetContentScaleFactor`.
- Allow users to control extra supersampling via configuration to balance quality and performance.

### Description
- Added a new configuration variable `layout_viewer_supersample` in `ConfigManager` to expose a supersample factor.
- Implemented `GetRenderScaleFactor()` in `LayoutViewerPanel` that multiplies `GetContentScaleFactor()` by the configured supersample factor.
- Reworked cached texture handling to track `cachedTextureTargetSize`, `cachedTextureRenderSize`, and `cachedRenderScale`, and render the offscreen viewport at `frameSize * renderScale` before storing the high-resolution texture.
- Invalidate and rebuild cached textures when the frame size or computed render scale changes, and draw the stored texture scaled to the final frame rectangle.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69590eb0538c8324860a6724adee5bd7)