### PR TITLE
Add zoom-bucketed render cache for LayoutViewerPanel

### DIFF
--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -55,6 +55,9 @@ private:
   wxRect GetPageRect() const;
   bool GetFrameRect(const layouts::Layout2DViewFrame &frame,
                     wxRect &rect) const;
+  wxSize GetFrameSizeForZoom(const layouts::Layout2DViewFrame &frame,
+                             double targetZoom) const;
+  double GetRenderZoom() const;
   void UpdateFrame(const layouts::Layout2DViewFrame &frame,
                    bool updatePosition);
   void InitGL();
@@ -97,6 +100,7 @@ private:
   bool glInitialized_ = false;
   unsigned int cachedTexture_ = 0;
   wxSize cachedTextureSize{0, 0};
+  double cachedRenderZoom = 0.0;
   bool renderDirty = true;
   bool renderPending = false;
 


### PR DESCRIPTION
### Motivation

- Avoid re-rasterizing the whole captured `CommandBuffer` on small zoom/pan changes by separating capture from presentation and reusing cached renders. 
- Reduce GPU/CPU work when the user performs small zoom steps by grouping zoom into cache buckets so nearby zooms reuse the same texture. 
- Keep offscreen capture and on-screen presentation responsibilities distinct so captures are not needlessly repeated on view transforms.

### Description

- Add `cachedRenderZoom` and `kZoomCacheStepsPerLevel` and compute a bucketed render zoom via the new `GetRenderZoom()` helper so renders are produced at discrete zoom levels. 
- Add `GetFrameSizeForZoom()` helper and use it to decide cached texture sizes and to set the offscreen renderer viewport (`RebuildCachedTexture()` now renders at the bucketed zoom and stores `cachedRenderZoom`).
- Update presentation logic in `OnPaint()` to reuse the cached texture when `cachedRenderZoom` and `cachedTextureSize` match the required render size, and update invalidation logic in `InvalidateRenderIfFrameChanged()` to consider `cachedRenderZoom` changes.
- Initialize and reset `cachedRenderZoom` alongside other capture/cache state when layouts or captures change so cache reuse is safe across operations.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69590faff3e48324a903107aca5e8439)