### PR TITLE
Decouple layout viewer render zoom from page zoom

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -563,12 +563,7 @@ wxSize LayoutViewerPanel::GetFrameSizeForZoom(
 }
 
 double LayoutViewerPanel::GetRenderZoom() const {
-  if (zoom <= 0.0)
-    return 1.0;
-  const double logZoom = std::log(zoom) / std::log(kZoomStep);
-  const double bucket =
-      std::round(logZoom / kZoomCacheStepsPerLevel) * kZoomCacheStepsPerLevel;
-  return std::clamp(std::pow(kZoomStep, bucket), kMinZoom, kMaxZoom);
+  return 1.0;
 }
 
 layouts::Layout2DViewDefinition *LayoutViewerPanel::GetEditableView() {


### PR DESCRIPTION
### Motivation
- Zooming the layout viewer currently changes the apparent content of 2D view elements because the render zoom was derived from the page zoom and bucketed for caching. 
- The layout viewer zoom should only change how far away the layout is viewed, and must not modify the captured/rendered content of embedded 2D views.

### Description
- Change `LayoutViewerPanel::GetRenderZoom()` to return a fixed `1.0` instead of computing a bucketed render zoom from the layout `zoom` value.
- This ensures captures and cached textures are generated at a stable 1:1 render zoom so layout panning/zooming no longer affects 2D view content.
- The change is implemented in `gui/layoutviewerpanel.cpp` (replace the previous log/bucket logic with `return 1.0;`).

### Testing
- No automated tests were run for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69591104c6548324a5a07893840f823b)