### PR TITLE
Improve layout viewer 2D zoom rendering

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -43,6 +43,7 @@ constexpr int kHandleSizePx = 10;
 constexpr int kHandleHalfPx = kHandleSizePx / 2;
 constexpr int kHandleHoverPadPx = 6;
 constexpr int kMinFrameSize = 24;
+constexpr int kMaxRenderTextureSize = 8192;
 constexpr int kEditMenuId = wxID_HIGHEST + 490;
 constexpr int kDeleteMenuId = wxID_HIGHEST + 491;
 }
@@ -563,7 +564,18 @@ wxSize LayoutViewerPanel::GetFrameSizeForZoom(
 }
 
 double LayoutViewerPanel::GetRenderZoom() const {
-  return 1.0;
+  double targetZoom = std::max(1.0, zoom);
+  const layouts::Layout2DViewDefinition *view = GetEditableView();
+  if (!view || view->frame.width <= 0 || view->frame.height <= 0)
+    return targetZoom;
+  const double maxZoomWidth =
+      static_cast<double>(kMaxRenderTextureSize) / view->frame.width;
+  const double maxZoomHeight =
+      static_cast<double>(kMaxRenderTextureSize) / view->frame.height;
+  const double maxZoom = std::min(maxZoomWidth, maxZoomHeight);
+  if (maxZoom > 0.0)
+    targetZoom = std::min(targetZoom, maxZoom);
+  return targetZoom;
 }
 
 layouts::Layout2DViewDefinition *LayoutViewerPanel::GetEditableView() {


### PR DESCRIPTION
### Motivation
- The `Layout Viewer` produced pixelated `2D view` captures when the user zoomed in, because offscreen captures were rendered at a fixed low resolution.
- The viewer should scale offscreen rendering with the display zoom so captured textures remain sharp.
- Creating arbitrarily large textures can exceed GPU/GL limits or cause excessive memory use, so the render size must be capped.
- Provide a sensible maximum texture size to avoid oversized textures while improving visual quality when zoomed.

### Description
- Added a new constant `kMaxRenderTextureSize` (8192) and updated `GetRenderZoom()` inside `gui/layoutviewerpanel.cpp`.
- `GetRenderZoom()` now computes a `targetZoom` from `std::max(1.0, zoom)` and caps it using `kMaxRenderTextureSize / view->frame.{width,height}` to prevent oversized textures.
- The offscreen render size calculation and texture generation now use this computed render zoom so captures scale with viewer zoom while respecting the cap.
- Change is confined to `gui/layoutviewerpanel.cpp` and does not alter external APIs.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695938525380832493fd57061cf5cbba)