### PR TITLE
Improve layout 2D view render resolution

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -563,7 +563,7 @@ wxSize LayoutViewerPanel::GetFrameSizeForZoom(
 }
 
 double LayoutViewerPanel::GetRenderZoom() const {
-  return 1.0;
+  return zoom;
 }
 
 layouts::Layout2DViewDefinition *LayoutViewerPanel::GetEditableView() {
@@ -653,8 +653,17 @@ void LayoutViewerPanel::RebuildCachedTexture() {
   offscreenRenderer->PrepareForCapture();
 
   ConfigManager &cfg = ConfigManager::Get();
+  viewer2d::Viewer2DState renderState = cachedRenderState;
+  if (renderZoom != 1.0) {
+    renderState.camera.zoom *= static_cast<float>(renderZoom);
+    renderState.camera.offsetPixelsX *= static_cast<float>(renderZoom);
+    renderState.camera.offsetPixelsY *= static_cast<float>(renderZoom);
+  }
+  renderState.camera.viewportWidth = renderSize.GetWidth();
+  renderState.camera.viewportHeight = renderSize.GetHeight();
+
   auto stateGuard = std::make_shared<viewer2d::ScopedViewer2DState>(
-      capturePanel, nullptr, cfg, cachedRenderState);
+      capturePanel, nullptr, cfg, renderState);
 
   std::vector<unsigned char> pixels;
   int width = 0;


### PR DESCRIPTION
### Motivation
- Layout "2D view" frames became pixelated when zooming the layout because the offscreen capture used a fixed render scale, producing low-resolution textures.
- The layout zoom should increase the rendered texture resolution without changing the actual 2D view content (camera offset/zoom) seen inside the frame.
- Previous attempts changed the captured view content when zooming the layout, which is incorrect because layout zoom should act like moving the camera further/closer to the page only.

### Description
- Make `GetRenderZoom` return the current layout `zoom` so offscreen captures are produced at layout zoom instead of a fixed scale.
- In `RebuildCachedTexture`, build a `viewer2d::Viewer2DState` copy and scale `camera.zoom` and `camera.offsetPixelsX/Y` by the `renderZoom` so the captured image increases resolution but preserves the same visible content.
- Set `camera.viewportWidth` and `camera.viewportHeight` in the render state to match the offscreen `renderSize` used for capture and pass the adjusted state to `ScopedViewer2DState` before rendering.
- Preserve existing texture upload/GL code and only change the capture scale and state applied to the offscreen renderer.

### Testing
- No automated tests were run for this change.
- The change compiles and was committed locally (no CI results available in this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69593a35cb7083248990a8c0dc726268)