### PR TITLE
Unify 2D color assignments across viewers

### DIFF
--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -238,7 +238,7 @@ private:
   std::unordered_map<std::string, BoundingBox> m_trussBounds;
   std::unordered_map<std::string, BoundingBox> m_objectBounds;
 
-  // Randomly assigned colors for fixture types and layers in 2D view
+  // Cached deterministic colors for fixture types and layers in 2D view
   std::unordered_map<std::string, std::array<float, 3>> m_typeColors;
   std::unordered_map<std::string, std::array<float, 3>> m_layerColors;
 


### PR DESCRIPTION
### Motivation
- Make 2D colors consistent across the 2D viewer, 3D simplified 2D rendering and layout captures so the same layer/type shows the same color everywhere.
- Replace non-deterministic random color assignment with a stable algorithm so colors do not change across runs or when opening editors.
- Always respect user-configured layer colors from `ConfigManager` before applying defaults so user choices propagate everywhere.
- Reduce visual mismatch between view editors, the `Viewer2D`/`Viewer3D` renderers and layout exports.

### Description
- Added a deterministic color generator by introducing `HashString`, `HsvToRgb` and `MakeDeterministicColor` helper functions in `viewer3d/viewer3dcontroller.cpp` and included `<cstdint>` and `<string_view>`.
- Replaced RNG-based color selection with deterministic defaults in `Viewer3DController::RenderScene` for both fixture types and layers and preserved any configured hex colors via `ConfigManager::GetLayerColor`/`HexToRGB`.
- Updated the field comment in `viewer3d/viewer3dcontroller.h` to reflect that cached colors are deterministic rather than random.
- Modified `getTypeColor`/`getLayerColor` logic to populate `m_typeColors`/`m_layerColors` with deterministic values when no user color is present.

### Testing
- No automated tests were run for this change.
- Local build and runtime verification were not recorded in automated test logs.
- Recommend running the UI and validating that colors remain stable across reopening editors and across `Viewer2D`, `Viewer3D` and layout captures.
- Consider adding unit tests around `HashString`/`MakeDeterministicColor` in follow-up work.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69593cf2fc2c8324a9dfdf1c8fd8a6c3)