### PR TITLE
Guard GL texture cleanup on hidden canvas

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -696,6 +696,10 @@ void LayoutViewerPanel::RebuildCachedTexture() {
 void LayoutViewerPanel::ClearCachedTexture() {
   if (cachedTexture_ == 0 || !glContext_)
     return;
+  if (!IsShown()) {
+    cachedTexture_ = 0;
+    return;
+  }
   SetCurrent(*glContext_);
   glDeleteTextures(1, &cachedTexture_);
   cachedTexture_ = 0;


### PR DESCRIPTION
### Motivation
- Deleting GL textures by calling `SetCurrent` on a hidden `wxGLCanvas` triggers a wxWidgets assertion during application teardown.
- The destructor calls `ClearCachedTexture`, which could attempt to make a hidden GL canvas current and delete textures.
- Prevent crashes and debug assertions when windows are being destroyed while hidden.

### Description
- Added a visibility guard in `LayoutViewerPanel::ClearCachedTexture` to skip calling `SetCurrent` and `glDeleteTextures` when `IsShown()` is false.
- When the canvas is hidden the code now clears the `cachedTexture_` handle without touching the GL context.
- No other logic or lifetime changes were made to `glContext_` or texture creation in `RebuildCachedTexture`.

### Testing
- No automated tests were run for this change.
- The change is a small defensive check intended to avoid a wxWidgets assertion observed at shutdown.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69593f694eec8324b83f9cf0cc409d97)