### PR TITLE
Reload layouts after project load/reset

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1846,6 +1846,8 @@ bool MainWindow::LoadProjectFromPath(const std::string &path) {
   ProjectUtils::SaveLastProjectPath(currentProjectPath);
 
   ApplySavedLayout();
+  if (layoutPanel)
+    layoutPanel->ReloadLayouts();
 
   if (consolePanel)
     consolePanel->AppendMessage("Loaded " + wxString::FromUTF8(path));
@@ -1889,6 +1891,8 @@ void MainWindow::ResetProject() {
   ConfigManager::Get().Reset();
   ConfigManager::Get().MarkSaved();
   currentProjectPath.clear();
+  if (layoutPanel)
+    layoutPanel->ReloadLayouts();
   if (fixturePanel)
     fixturePanel->ReloadData();
   if (trussPanel)


### PR DESCRIPTION
### Motivation
- 2D views added to a layout were not reflected in the UI after saving and re-opening a project because the layout panel was not being refreshed from the loaded configuration.
- Keep the layout list in sync with the persisted `LayoutManager` state after project load and after a project reset.

### Description
- Call `layoutPanel->ReloadLayouts()` from `MainWindow::LoadProjectFromPath` after `ApplySavedLayout()` to refresh the layout list after loading a project.
- Call `layoutPanel->ReloadLayouts()` from `MainWindow::ResetProject` after clearing project state to refresh the layout list when resetting.
- Changes were made in `gui/mainwindow.cpp` and only affect the UI refresh of the layout panel, leaving persistence logic intact.

### Testing
- No automated tests were executed for this change.
- N/A

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69594083903c8324893e452c7fc19490)