### PR TITLE
Persist layout data when saving projects

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -577,6 +577,8 @@ bool ConfigManager::SaveProject(const std::string &path) {
   if (!tempDir.Valid())
     return false;
 
+  layouts::LayoutManager::Get().SaveToConfig(*this);
+
   fs::path configPath = tempDir.Path() / "config.json";
   fs::path scenePath = tempDir.Path() / "scene.mvr";
 


### PR DESCRIPTION
### Motivation
- Users reported that adding a 2D view to a layout, saving the project and reopening would lose the 2D view.  
- Investigation showed layouts are loaded from `config.json` via `LayoutManager::LoadFromConfig`, but layouts weren't being synced into `ConfigManager` before the project save bundle was written.  
- The intent is to ensure layout definitions (including 2D views) are serialized into the saved project so they persist across sessions.  

### Description
- Call `layouts::LayoutManager::Get().SaveToConfig(*this)` from `ConfigManager::SaveProject` to write current layout data into `ConfigManager` before creating `config.json` in the project ZIP.  
- This ensures `configData` contains the `layouts_collection` key when `SaveToFile` writes `config.json`.  
- Change is localized to `core/configmanager.cpp` and does not alter the layout serialization logic in `core/layouts/LayoutManager`.  

### Testing
- No automated tests were executed for this change.  
- The change is a single-line call insertion and should be covered by existing load/save behavior exercised by manual save/load flows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695941e477088324a7e5f48c6994b3ff)