### PR TITLE
Restore layout-specific 2D view state on switch

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -2377,6 +2377,22 @@ void MainWindow::ActivateLayoutView(const std::string &layoutName) {
     }
   }
 
+  if (layoutModeActive && viewport2DPanel) {
+    int viewIndex = 0;
+    bool hasViewIndex = false;
+    if (layoutViewerPanel) {
+      if (const auto *view = layoutViewerPanel->GetEditableView()) {
+        viewIndex = view->camera.view;
+        hasViewIndex = true;
+      }
+    }
+    if (!hasViewIndex) {
+      const auto viewState = viewport2DPanel->GetViewState();
+      viewIndex = static_cast<int>(viewState.view);
+    }
+    RestoreLayout2DViewState(viewIndex);
+  }
+
   ApplyLayoutModePerspective();
 }
 


### PR DESCRIPTION
### Motivation
- Fix incorrect 2D view/zoom when switching between layouts in layout mode so each layout restores its saved 2D view state.
- Ensure the source of the view index is the layout viewer selection when available, falling back to the active 2D viewport.

### Description
- Added logic in `ActivateLayoutView` (file `gui/mainwindow.cpp`) to call `RestoreLayout2DViewState(viewIndex)` when activating a layout in layout mode.
- Determine `viewIndex` by preferring `layoutViewerPanel->GetEditableView()` and its `camera.view`, and falling back to `viewport2DPanel->GetViewState()` when no editable view is present.
- Preserves the existing `PersistLayout2DViewState()` call when switching away from an active layout so state is saved before switching.

### Testing
- No automated tests were run for this change.
- The change was compiled and committed as a single-file update (`gui/mainwindow.cpp`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959444efb408324abaffa59ca90a5d7)