### PR TITLE
Persist layout 2D view state when switching layouts

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -2243,12 +2243,14 @@ void MainWindow::OnLayout2DViewCancel(wxCommandEvent &WXUNUSED(event)) {
 }
 
 void MainWindow::PersistLayout2DViewState() {
-  if (!layoutModeActive || activeLayoutName.empty())
+  if (activeLayoutName.empty())
     return;
   ConfigManager &cfg = ConfigManager::Get();
   Viewer2DPanel *activePanel =
       (layout2DViewEditing && layout2DViewEditPanel) ? layout2DViewEditPanel
                                                      : viewport2DPanel;
+  if (!activePanel)
+    return;
   layouts::Layout2DViewFrame frame{};
   const layouts::LayoutDefinition *layout = nullptr;
   for (const auto &entry : layouts::LayoutManager::Get().GetLayouts().Items()) {
@@ -2361,8 +2363,7 @@ void MainWindow::ActivateLayoutView(const std::string &layoutName) {
   if (!auiManager || layoutName.empty())
     return;
 
-  if (layoutModeActive && !activeLayoutName.empty() &&
-      activeLayoutName != layoutName) {
+  if (!activeLayoutName.empty() && activeLayoutName != layoutName) {
     PersistLayout2DViewState();
   }
   activeLayoutName = layoutName;
@@ -2377,7 +2378,7 @@ void MainWindow::ActivateLayoutView(const std::string &layoutName) {
     }
   }
 
-  if (layoutModeActive && viewport2DPanel) {
+  if (viewport2DPanel) {
     int viewIndex = 0;
     bool hasViewIndex = false;
     if (layoutViewerPanel) {


### PR DESCRIPTION
### Motivation
- Per-layout 2D camera settings (zoom/offset) were not always being stored/restored when switching layouts, causing the 2D view to jump back to defaults.
- The intent is to persist the 2D view state for each layout whenever the active layout changes, not only while in layout-edit mode.
- Also ensure we don't attempt to capture state when no 2D panel is available to avoid null dereferences.

### Description
- Relaxed the `layoutModeActive` checks so `PersistLayout2DViewState` is invoked when switching away from the current layout regardless of layout mode by updating `ActivateLayoutView`.
- Removed the early return on `PersistLayout2DViewState` that required `layoutModeActive` and added a guard to return if there is no `activePanel` to capture from.
- As a result, layout-specific `view2d` entries (camera, zoom, offsets, render options, layers) are captured via `viewer2d::CaptureLayoutDefinition` and saved with `LayoutManager::UpdateLayout2DView` on every layout switch.
- Changes are implemented in `gui/mainwindow.cpp` (adjustments to `PersistLayout2DViewState` and `ActivateLayoutView`).

### Testing
- No automated tests were executed for this change.
- Manual runtime verification (developer testing) was not recorded in automated test logs.
- No test failures reported because no tests were run.
- Recommend adding an automated unit/integration test to exercise layout switch persistence for future changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695945e6595c8324b64af53d90d0736b)