### PR TITLE
Avoid persisting layout 2D view state from hidden 2D viewport

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -2245,6 +2245,8 @@ void MainWindow::OnLayout2DViewCancel(wxCommandEvent &WXUNUSED(event)) {
 void MainWindow::PersistLayout2DViewState() {
   if (activeLayoutName.empty())
     return;
+  if (layoutModeActive && !layout2DViewEditing)
+    return;
   ConfigManager &cfg = ConfigManager::Get();
   Viewer2DPanel *activePanel =
       (layout2DViewEditing && layout2DViewEditPanel) ? layout2DViewEditPanel


### PR DESCRIPTION
### Motivation
- Prevent layout mode from overwriting per-layout `2D view` settings (zoom/offset) with stale data coming from a hidden main viewport when switching layouts.
- Ensure that layout view state is only saved when the user is actively editing a layout view so per-layout camera state remains stable.

### Description
- Add an early return in `PersistLayout2DViewState` to skip persisting when `layoutModeActive` is true and `layout2DViewEditing` is false.
- Change applied in `gui/mainwindow.cpp` to avoid writing layout `2D view` state from the possibly-hidden `viewport2DPanel` unless the layout view is being edited.
- Preserves existing behavior when a layout view is actively being edited, so edits are still captured and saved.

### Testing
- No automated tests were run for this change.
- The change is limited to an early-return guard and should be low-risk to compile and verify in a normal build/test cycle.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695947bd0f5c83249392f5d2f981ca04)