### PR TITLE
Refresh layouts after project load

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -2418,6 +2418,8 @@ void MainWindow::OnProjectLoaded(wxCommandEvent &event) {
     currentProjectPath = path;
     ProjectUtils::SaveLastProjectPath(currentProjectPath);
     ApplySavedLayout();
+    if (layoutPanel)
+      layoutPanel->ReloadLayouts();
     if (consolePanel)
       consolePanel->AppendMessage("Loaded " + wxString::FromUTF8(path));
     if (fixturePanel)


### PR DESCRIPTION
### Motivation
- The layout viewer sometimes did not display the active layout when a project was loaded because the `LayoutPanel` was not refreshed after the saved perspective was applied.
- It appears the saved layout perspective is applied before the layouts list is reloaded, so the `LayoutViewerPanel` could miss the active layout selection.

### Description
- Add a call to `layoutPanel->ReloadLayouts()` in `MainWindow::OnProjectLoaded` immediately after `ApplySavedLayout()`.
- The change ensures the `LayoutPanel` emits the active layout selection so the `LayoutViewerPanel` receives and displays the correct layout definition.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69594a70061c832484004025cdaf7fb7)