### PR TITLE
Fix 2D view editor viewport sizing

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -2145,12 +2145,19 @@ void MainWindow::BeginLayout2DViewEdit() {
       layout2DViewEditPanel, layout2DViewEditRenderPanel, cfg, state,
       viewport2DPanel, viewport2DRenderPanel);
 
-  if (view->frame.height > 0 && layout2DViewEditPanel) {
-    float aspect =
-        static_cast<float>(view->frame.width) / view->frame.height;
-    layout2DViewEditPanel->SetLayoutEditOverlay(aspect);
-  } else if (layout2DViewEditPanel) {
-    layout2DViewEditPanel->SetLayoutEditOverlay(std::nullopt);
+  if (layout2DViewEditPanel) {
+    std::optional<float> aspect;
+    if (view->frame.height > 0) {
+      aspect = static_cast<float>(view->frame.width) / view->frame.height;
+    }
+    std::optional<wxSize> viewportOverride;
+    if (view->camera.viewportWidth > 0 && view->camera.viewportHeight > 0) {
+      viewportOverride =
+          wxSize(view->camera.viewportWidth, view->camera.viewportHeight);
+    } else if (view->frame.width > 0 && view->frame.height > 0) {
+      viewportOverride = wxSize(view->frame.width, view->frame.height);
+    }
+    layout2DViewEditPanel->SetLayoutEditOverlay(aspect, viewportOverride);
   }
 
   layout2DViewEditing = true;

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -150,6 +150,58 @@ std::string BuildFixtureDebugReport(const CommandBuffer &buffer,
 
   return out.str();
 }
+
+struct LayoutEditViewport {
+  int x = 0;
+  int y = 0;
+  int width = 0;
+  int height = 0;
+  int virtualWidth = 0;
+  int virtualHeight = 0;
+};
+
+LayoutEditViewport ComputeLayoutEditViewport(
+    int panelWidth, int panelHeight, std::optional<float> aspectRatio,
+    std::optional<wxSize> viewportOverride) {
+  LayoutEditViewport result;
+  result.width = panelWidth;
+  result.height = panelHeight;
+  result.virtualWidth = panelWidth;
+  result.virtualHeight = panelHeight;
+
+  if (!aspectRatio || *aspectRatio <= 0.0f || panelWidth <= 0 ||
+      panelHeight <= 0) {
+    return result;
+  }
+
+  float padding = static_cast<float>(std::min(panelWidth, panelHeight)) * 0.1f;
+  float maxWidth = static_cast<float>(panelWidth) - padding * 2.0f;
+  float maxHeight = static_cast<float>(panelHeight) - padding * 2.0f;
+  float targetWidth = maxWidth;
+  float targetHeight = targetWidth / *aspectRatio;
+  if (targetHeight > maxHeight) {
+    targetHeight = maxHeight;
+    targetWidth = targetHeight * *aspectRatio;
+  }
+
+  result.x =
+      static_cast<int>(std::lround((panelWidth - targetWidth) * 0.5f));
+  result.y =
+      static_cast<int>(std::lround((panelHeight - targetHeight) * 0.5f));
+  result.width = std::max(1, static_cast<int>(std::lround(targetWidth)));
+  result.height = std::max(1, static_cast<int>(std::lround(targetHeight)));
+
+  if (viewportOverride && viewportOverride->GetWidth() > 0 &&
+      viewportOverride->GetHeight() > 0) {
+    result.virtualWidth = viewportOverride->GetWidth();
+    result.virtualHeight = viewportOverride->GetHeight();
+  } else {
+    result.virtualWidth = result.width;
+    result.virtualHeight = result.height;
+  }
+
+  return result;
+}
 } // namespace
 
 namespace {
@@ -268,8 +320,10 @@ void Viewer2DPanel::CaptureFrameNow(
   }
 }
 
-void Viewer2DPanel::SetLayoutEditOverlay(std::optional<float> aspectRatio) {
+void Viewer2DPanel::SetLayoutEditOverlay(
+    std::optional<float> aspectRatio, std::optional<wxSize> viewportSize) {
   m_layoutEditAspect = aspectRatio;
+  m_layoutEditViewport = viewportSize;
   Refresh();
 }
 
@@ -277,13 +331,15 @@ Viewer2DViewState Viewer2DPanel::GetViewState() const {
   int w = 0;
   int h = 0;
   const_cast<Viewer2DPanel *>(this)->GetClientSize(&w, &h);
+  const LayoutEditViewport viewport =
+      ComputeLayoutEditViewport(w, h, m_layoutEditAspect, m_layoutEditViewport);
 
   Viewer2DViewState state{};
   state.offsetPixelsX = m_offsetX;
   state.offsetPixelsY = m_offsetY;
   state.zoom = m_zoom;
-  state.viewportWidth = w;
-  state.viewportHeight = h;
+  state.viewportWidth = viewport.virtualWidth;
+  state.viewportHeight = viewport.virtualHeight;
   state.view = m_view;
   return state;
 }
@@ -315,13 +371,16 @@ void Viewer2DPanel::RenderInternal(bool swapBuffers) {
   int w, h;
   GetClientSize(&w, &h);
 
-  glViewport(0, 0, w, h);
+  const LayoutEditViewport viewport =
+      ComputeLayoutEditViewport(w, h, m_layoutEditAspect, m_layoutEditViewport);
+
+  glViewport(viewport.x, viewport.y, viewport.width, viewport.height);
 
   glMatrixMode(GL_PROJECTION);
   glLoadIdentity();
   float ppm = PIXELS_PER_METER * m_zoom;
-  float halfW = static_cast<float>(w) / ppm * 0.5f;
-  float halfH = static_cast<float>(h) / ppm * 0.5f;
+  float halfW = static_cast<float>(viewport.virtualWidth) / ppm * 0.5f;
+  float halfH = static_cast<float>(viewport.virtualHeight) / ppm * 0.5f;
   float offX = m_offsetX / PIXELS_PER_METER;
   float offY = m_offsetY / PIXELS_PER_METER;
   glOrtho(-halfW - offX, halfW - offX, -halfH - offY, halfH - offY, -100.0f,
@@ -386,21 +445,15 @@ void Viewer2DPanel::RenderInternal(bool swapBuffers) {
   // Draw labels for all fixtures after rendering the scene so they appear on
   // top of geometry. Scale the label size with the current zoom so they behave
   // like regular scene objects instead of remaining a constant screen size.
-  m_controller.DrawAllFixtureLabels(w, h, m_zoom);
+  m_controller.DrawAllFixtureLabels(viewport.virtualWidth,
+                                    viewport.virtualHeight, m_zoom);
 
   if (m_layoutEditAspect && *m_layoutEditAspect > 0.0f) {
-    float aspect = *m_layoutEditAspect;
-    float padding = static_cast<float>(std::min(w, h)) * 0.1f;
-    float maxWidth = static_cast<float>(w) - padding * 2.0f;
-    float maxHeight = static_cast<float>(h) - padding * 2.0f;
-    float targetWidth = maxWidth;
-    float targetHeight = targetWidth / aspect;
-    if (targetHeight > maxHeight) {
-      targetHeight = maxHeight;
-      targetWidth = targetHeight * aspect;
-    }
-    float left = (static_cast<float>(w) - targetWidth) * 0.5f;
-    float bottom = (static_cast<float>(h) - targetHeight) * 0.5f;
+    glViewport(0, 0, w, h);
+    float left = static_cast<float>(viewport.x);
+    float bottom = static_cast<float>(viewport.y);
+    float targetWidth = static_cast<float>(viewport.width);
+    float targetHeight = static_cast<float>(viewport.height);
 
     GLboolean depthEnabled = glIsEnabled(GL_DEPTH_TEST);
     if (depthEnabled)

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -103,7 +103,8 @@ public:
   std::shared_ptr<const SymbolDefinitionSnapshot>
   GetBottomSymbolCacheSnapshot() const;
 
-  void SetLayoutEditOverlay(std::optional<float> aspectRatio);
+  void SetLayoutEditOverlay(std::optional<float> aspectRatio,
+                            std::optional<wxSize> viewportSize = std::nullopt);
 
 private:
   void InitGL();
@@ -143,6 +144,7 @@ private:
   Viewer2DRenderMode m_renderMode = Viewer2DRenderMode::White;
   Viewer2DView m_view = Viewer2DView::Top;
   std::optional<float> m_layoutEditAspect;
+  std::optional<wxSize> m_layoutEditViewport;
 
   wxDECLARE_EVENT_TABLE();
 };


### PR DESCRIPTION
### Motivation
- The 2D layout editor previously tied the captured/rendered viewport to the editor window size so the visible content changed when the editor was resized instead of depending only on the configured layout zoom and stored viewport size.
- The intent is that layout captures and the editor framing are independent of the dialog window size and honor the stored layout viewport or an explicitly provided viewport size.

### Description
- Add a new `LayoutEditViewport` helper and `ComputeLayoutEditViewport` to compute a fixed virtual viewport and scaled on-screen rectangle for layout editing.
- Change `Viewer2DPanel::SetLayoutEditOverlay` to accept an optional `wxSize` `viewportSize` and store it in `m_layoutEditViewport` so the editor can preserve stored viewport dimensions.
- Use the computed virtual viewport in `Viewer2DPanel::RenderInternal` (call `glViewport` with the edit rectangle and build the orthographic projection using the virtual size) and in `GetViewState` so captures use the fixed virtual viewport.
- Update `MainWindow::BeginLayout2DViewEdit` to pass an aspect and a viewport override (from `view->camera.viewportWidth/viewportHeight` or the frame size) to the edit panel so editing preserves stored layout viewport sizes.

### Testing
- No automated tests were executed for this change.
- The change was implemented across `viewer2d/viewer2dpanel.cpp`, `viewer2d/viewer2dpanel.h`, and `gui/mainwindow.cpp` and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69594dc6439083248070ad88b20e1c45)