### PR TITLE
Align layout viewports with frame size

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -2203,6 +2203,15 @@ void MainWindow::OnLayout2DViewOk(wxCommandEvent &WXUNUSED(event)) {
       frame = view->frame;
   }
 
+  // Ensure the stored viewport matches the layout frame size, not the popup.
+  if (frame.width > 0 || frame.height > 0) {
+    current.camera.viewportWidth = frame.width;
+    current.camera.viewportHeight = frame.height;
+  } else {
+    current.camera.viewportWidth = 0;
+    current.camera.viewportHeight = 0;
+  }
+
   layouts::Layout2DViewDefinition updatedView =
       viewer2d::ToLayoutDefinition(current, frame);
   layouts::LayoutManager::Get().UpdateLayout2DView(activeLayoutName,

--- a/viewer2d/viewer2dstate.cpp
+++ b/viewer2d/viewer2dstate.cpp
@@ -217,10 +217,10 @@ layouts::Layout2DViewDefinition ToLayoutDefinition(
   layouts::Layout2DViewDefinition view;
   view.frame = frame;
   view.camera = state.camera;
-  if (view.camera.viewportWidth <= 0 && frame.width > 0) {
+  if (frame.width > 0) {
     view.camera.viewportWidth = frame.width;
   }
-  if (view.camera.viewportHeight <= 0 && frame.height > 0) {
+  if (frame.height > 0) {
     view.camera.viewportHeight = frame.height;
   }
   view.renderOptions = state.renderOptions;


### PR DESCRIPTION
### Motivation
- Prevent the layout's saved camera viewport from reflecting the popup editor size instead of the layout frame size.
- Ensure persisted layout view definitions use the intended frame dimensions so cached renders and saved layouts remain consistent.

### Description
- In `MainWindow::OnLayout2DViewOk` overwrite `current.camera.viewportWidth` and `current.camera.viewportHeight` to `frame.width`/`frame.height` (or set to `0` to force fallback) and add a brief comment documenting the intent.
- In `viewer2d::ToLayoutDefinition` prefer the provided `frame.width`/`frame.height` unconditionally when > 0 so frame dimensions take precedence over the panel viewport.
- No changes were made to `LayoutViewerPanel::RebuildCachedTexture` because it already uses the layout frame size for `offscreenRenderer->SetViewportSize` and sets the `renderState.camera` dimensions accordingly.

### Testing
- No automated tests were executed for this change.
- The modified files were staged and committed locally without running a test suite.
- Manual runtime verification was not performed as part of this PR.
- Reviewers should verify that saving a 2D layout now records the frame size rather than the popup viewport size during integration testing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959522cad6083248ede41c90d45d75e)