### PR TITLE
Add scalable fixed overlay for 2D View Editor

### DIFF
--- a/gui/layout2dviewdialog.h
+++ b/gui/layout2dviewdialog.h
@@ -5,6 +5,8 @@
 class Viewer2DPanel;
 class Viewer2DRenderPanel;
 class LayerPanel;
+class wxSlider;
+class wxStaticText;
 
 class Layout2DViewDialog : public wxDialog {
 public:
@@ -17,8 +19,12 @@ private:
   void OnOk(wxCommandEvent &event);
   void OnCancel(wxCommandEvent &event);
   void OnShow(wxShowEvent &event);
+  void OnScaleChanged(wxCommandEvent &event);
+  void UpdateScaleLabel();
 
   Viewer2DPanel *viewerPanel = nullptr;
   Viewer2DRenderPanel *renderPanel = nullptr;
   LayerPanel *layerPanel = nullptr;
+  wxSlider *scaleSlider = nullptr;
+  wxStaticText *scaleValueLabel = nullptr;
 };

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -2203,6 +2203,18 @@ void MainWindow::OnLayout2DViewOk(wxCommandEvent &WXUNUSED(event)) {
       frame = view->frame;
   }
 
+  if (frame.width > 0 && frame.height > 0 && editPanel) {
+    auto overlaySize = editPanel->GetLayoutEditOverlaySize();
+    if (overlaySize && overlaySize->GetWidth() > 0 &&
+        overlaySize->GetHeight() > 0) {
+      const double scale =
+          static_cast<double>(frame.width) /
+          static_cast<double>(overlaySize->GetWidth());
+      if (scale > 0.0)
+        current.camera.zoom *= static_cast<float>(scale);
+    }
+  }
+
   // Ensure the stored viewport matches the layout frame size, not the popup.
   if (frame.width > 0 || frame.height > 0) {
     current.camera.viewportWidth = frame.width;

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -104,6 +104,9 @@ public:
   GetBottomSymbolCacheSnapshot() const;
 
   void SetLayoutEditOverlay(std::optional<float> aspectRatio);
+  void SetLayoutEditOverlayScale(float scale);
+  float GetLayoutEditOverlayScale() const { return m_layoutEditScale; }
+  std::optional<wxSize> GetLayoutEditOverlaySize() const;
 
 private:
   void InitGL();
@@ -143,6 +146,8 @@ private:
   Viewer2DRenderMode m_renderMode = Viewer2DRenderMode::White;
   Viewer2DView m_view = Viewer2DView::Top;
   std::optional<float> m_layoutEditAspect;
+  std::optional<wxSize> m_layoutEditBaseSize;
+  float m_layoutEditScale = 1.0f;
 
   wxDECLARE_EVENT_TABLE();
 };


### PR DESCRIPTION
### Motivation
- Decouple the red framing rectangle in the "2D View Editor" from the dialog size so the captured area does not change when the popup is resized.
- Provide interactive controls to scale the fixed overlay so users can choose the framing size without changing the overlay aspect.
- Ensure that accepting the editor stores a viewport that matches exactly what was inside the red rectangle.

### Description
- Added overlay sizing and scaling state to `Viewer2DPanel` (`m_layoutEditBaseSize`, `m_layoutEditScale`) and implemented `SetLayoutEditOverlayScale`, `GetLayoutEditOverlayScale`, and `GetLayoutEditOverlaySize` to compute and return a stable, scaled overlay size.
- Modified rendering in `Viewer2DPanel::RenderInternal` to compute the base overlay size once and reuse it, and to draw the red fixed overlay using the current scale rather than recomputing from dialog size each frame.
- Extended `Layout2DViewDialog` to add a scale slider and label, plus handlers `OnScaleChanged` and `UpdateScaleLabel`, that call `Viewer2DPanel::SetLayoutEditOverlayScale` to let users adjust the overlay scale interactively.
- When confirming edits, `MainWindow::OnLayout2DViewOk` now queries `GetLayoutEditOverlaySize` and adjusts the captured `camera.zoom` to ensure the stored layout viewport matches what was visible inside the fixed overlay.

### Testing
- No automated tests were executed as part of this change.
- Manual/run-time verification was intended but not recorded by the automated rollout steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695955b133bc83249746851a8d2da445)