### PR TITLE
Sync 2D editor overlay with layout resize

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -2153,6 +2153,30 @@ void MainWindow::BeginLayout2DViewEdit() {
     layout2DViewEditPanel->SetLayoutEditOverlay(std::nullopt);
   }
 
+  if (layout2DViewEditPanel) {
+    auto overlaySize = layout2DViewEditPanel->GetLayoutEditOverlaySize();
+    int viewportWidth = view->camera.viewportWidth;
+    int viewportHeight = view->camera.viewportHeight;
+    if (viewportWidth <= 0 || viewportHeight <= 0) {
+      viewportWidth = view->frame.width;
+      viewportHeight = view->frame.height;
+    }
+    if (overlaySize && overlaySize->GetWidth() > 0 &&
+        overlaySize->GetHeight() > 0 && viewportWidth > 0 &&
+        viewportHeight > 0) {
+      const float scaleX = static_cast<float>(overlaySize->GetWidth()) /
+                           static_cast<float>(viewportWidth);
+      const float scaleY = static_cast<float>(overlaySize->GetHeight()) /
+                           static_cast<float>(viewportHeight);
+      const float scale = std::min(scaleX, scaleY);
+      if (scale > 0.0f) {
+        cfg.SetFloat("view2d_zoom", state.camera.zoom * scale);
+        cfg.SetFloat("view2d_offset_x", state.camera.offsetPixelsX * scale);
+        cfg.SetFloat("view2d_offset_y", state.camera.offsetPixelsY * scale);
+      }
+    }
+  }
+
   layout2DViewEditing = true;
   UpdateViewMenuChecks();
 


### PR DESCRIPTION
### Motivation
- Reopen of the 2D View editor after resizing a layout frame produced a mismatch between the red overlay rectangle and the actual editor content because the editor camera zoom/offsets were not adjusted to the resized overlay.
- The change aims to make the editor immediately reflect layout frame resizing so the content visible inside the overlay matches what was in the layout.

### Description
- Added code in `MainWindow::BeginLayout2DViewEdit()` (in `gui/mainwindow.cpp`) to query `GetLayoutEditOverlaySize()` from the editor panel and compute the overlay-to-viewport scale.
- If the stored `view.camera.viewportWidth/viewportHeight` are not set, the code falls back to the layout frame `width/height` to compute a reliable scale.
- The computed scale is applied to the editor camera state by updating `ConfigManager` floats `view2d_zoom`, `view2d_offset_x`, and `view2d_offset_y` using the captured `state.camera` values multiplied by the scale.
- This adjustment runs before showing the `Layout2DViewDialog`, ensuring the popup editor's overlay and camera match the resized layout frame.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695958db2c508324956bc1c7e8e7a350)