### PR TITLE
Sync layout 2D view camera viewport with frame size

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -584,11 +584,25 @@ void LayoutViewerPanel::UpdateFrame(const layouts::Layout2DViewFrame &frame,
   layouts::Layout2DViewDefinition *view = GetEditableView();
   if (!view)
     return;
+  const bool sizeChanged =
+      view->frame.width != frame.width || view->frame.height != frame.height;
   view->frame.width = frame.width;
   view->frame.height = frame.height;
   if (updatePosition) {
     view->frame.x = frame.x;
     view->frame.y = frame.y;
+  }
+  if (sizeChanged) {
+    if (frame.width > 0) {
+      view->camera.viewportWidth = frame.width;
+    } else {
+      view->camera.viewportWidth = 0;
+    }
+    if (frame.height > 0) {
+      view->camera.viewportHeight = frame.height;
+    } else {
+      view->camera.viewportHeight = 0;
+    }
   }
   if (!currentLayout.name.empty()) {
     layouts::LayoutManager::Get().UpdateLayout2DView(currentLayout.name,


### PR DESCRIPTION
### Motivation
- Resizing a layout 2D view frame did not update the stored camera viewport dimensions, which could produce incorrect zoom when opening the 2D view editor.
- The layout edit UX needed the layout definition to reflect frame size changes so captured/edited views match what is shown in the layout.

### Description
- Modify `LayoutViewerPanel::UpdateFrame` in `gui/layoutviewerpanel.cpp` to detect when the frame size changes and synchronize `view.camera.viewportWidth` and `view.camera.viewportHeight` with the new `frame` values.
- Clear viewport dimensions to `0` when the frame width/height are not set, and leave viewport values unchanged when only the position changes.
- The change preserves the existing call to `LayoutManager::UpdateLayout2DView` and still calls `InvalidateRenderIfFrameChanged`, `RequestRenderRebuild`, and `Refresh` to update the UI.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69595a864fbc8324b9bf445025111340)