### PR TITLE
Scale layout 2D editor camera offsets when applying overlay zoom

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -2234,8 +2234,11 @@ void MainWindow::OnLayout2DViewOk(wxCommandEvent &WXUNUSED(event)) {
       const double scale =
           static_cast<double>(frame.width) /
           static_cast<double>(overlaySize->GetWidth());
-      if (scale > 0.0)
+      if (scale > 0.0) {
         current.camera.zoom *= static_cast<float>(scale);
+        current.camera.offsetPixelsX *= static_cast<float>(scale);
+        current.camera.offsetPixelsY *= static_cast<float>(scale);
+      }
     }
   }
 


### PR DESCRIPTION
### Motivation

- Fix a mismatch between the 2D view editor and the saved layout 2D view where objects drift after editing with an overlay scale applied.  
- The editor previously scaled only `camera.zoom` when converting from the popup overlay to the stored viewport, leaving `offsetPixelsX`/`offsetPixelsY` unscaled.  
- This could cause the viewport to appear shifted (objects moving up/down or left/right) after closing or re-opening the editor.  
- The change keeps the edited view aligned with the layout frame when overlay scaling is used.

### Description

- In `gui/mainwindow.cpp` when computing the scale between the layout frame and the editor overlay, also multiply `current.camera.offsetPixelsX` and `current.camera.offsetPixelsY` by the same `scale` used for `current.camera.zoom`.  
- Ensures camera offsets are correctly adjusted for overlay size so the stored `Layout2DViewDefinition` matches the edited appearance.  
- The edit is localized to the `OnLayout2DViewOk` flow that applies popup overlay scaling before saving the view.  
- No other behavior or config keys were modified.

### Testing

- No automated tests were run for this change.  
- A compile and lightweight manual verification were performed during development (editor overlay zoom now preserves object positions when saving).  
- No unit or integration test failures to report because test suite was not executed.  
- Further automated tests are recommended to cover overlay scaling of `camera.offsetPixelsX/Y` in the layout editor.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69595d5b105483248d39ff9ef2518ed1)