### PR TITLE
Reset layout edit overlay base size on Viewer2DPanel resize

### DIFF
--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -661,6 +661,9 @@ void Viewer2DPanel::OnMouseLeave(wxMouseEvent &event) {
 }
 
 void Viewer2DPanel::OnResize(wxSizeEvent &event) {
+  if (m_layoutEditAspect) {
+    m_layoutEditBaseSize.reset();
+  }
   Refresh();
   event.Skip();
 }


### PR DESCRIPTION
### Motivation
- The 2D View Editor overlay could become misaligned with the Layout Viewer after the window was resized, producing offset/scale discrepancies.
- The overlay uses a cached base size in `m_layoutEditBaseSize` that was not invalidated on panel resize.
- Failing to clear the cached base size prevented `GetLayoutEditOverlaySize()` from recomputing a correct size for the new viewport.
- Invalidate the cached base size on resize so the overlay is recalculated and remains synchronized with the layout rendering.

### Description
- Clear `m_layoutEditBaseSize` when `m_layoutEditAspect` is set inside `Viewer2DPanel::OnResize` in `viewer2d/viewer2dpanel.cpp`.
- This forces the overlay base size to be recomputed on the next paint, keeping editor and layout viewer alignment.
- The change is minimal (a conditional reset) and preserves existing refresh behavior by still calling `Refresh()`.
- No other logic or state is modified.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959651595108324ae15959f4e87503f)