### PR TITLE
Fix layout 2D edit zoom scaling

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -2148,7 +2148,11 @@ void MainWindow::BeginLayout2DViewEdit() {
   if (view->frame.height > 0 && layout2DViewEditPanel) {
     float aspect =
         static_cast<float>(view->frame.width) / view->frame.height;
-    layout2DViewEditPanel->SetLayoutEditOverlay(aspect);
+    std::optional<wxSize> viewportSize;
+    if (view->frame.width > 0) {
+      viewportSize = wxSize(view->frame.width, view->frame.height);
+    }
+    layout2DViewEditPanel->SetLayoutEditOverlay(aspect, viewportSize);
   } else if (layout2DViewEditPanel) {
     layout2DViewEditPanel->SetLayoutEditOverlay(std::nullopt);
   }

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -103,7 +103,8 @@ public:
   std::shared_ptr<const SymbolDefinitionSnapshot>
   GetBottomSymbolCacheSnapshot() const;
 
-  void SetLayoutEditOverlay(std::optional<float> aspectRatio);
+  void SetLayoutEditOverlay(std::optional<float> aspectRatio,
+                            std::optional<wxSize> viewportSize = std::nullopt);
   void SetLayoutEditOverlayScale(float scale);
   float GetLayoutEditOverlayScale() const { return m_layoutEditScale; }
   std::optional<wxSize> GetLayoutEditOverlaySize() const;
@@ -147,6 +148,7 @@ private:
   Viewer2DView m_view = Viewer2DView::Top;
   std::optional<float> m_layoutEditAspect;
   std::optional<wxSize> m_layoutEditBaseSize;
+  std::optional<wxSize> m_layoutEditViewportSize;
   float m_layoutEditScale = 1.0f;
 
   wxDECLARE_EVENT_TABLE();


### PR DESCRIPTION
### Motivation
- The 2D View Editor popup size was unintentionally affecting the camera zoom and projection because the on-screen widget size was used for viewport calculations.
- The layout frame's stored viewport dimensions should be used when editing a layout so the camera/zoom remain consistent with saved layout data.
- Preserve the layout edit overlay behavior while allowing a fixed viewport size to be applied for projection calculations.

### Description
- Added an optional `viewportSize` parameter to `Viewer2DPanel::SetLayoutEditOverlay` and a new member `m_layoutEditViewportSize` to track the layout frame size.
- When an overlay `viewportSize` is provided `m_layoutEditViewportSize` is set and used instead of the control's client size in `GetViewState` and in `RenderInternal` projection math (half-width/half-height computation).
- Updated `MainWindow::BeginLayout2DViewEdit` to pass the layout frame size into `SetLayoutEditOverlay` when available.
- Reset the stored layout viewport size when the overlay is cleared and keep existing scale/refresh semantics.

### Testing
- No automated tests were executed for this change (not requested).
- Changes were limited to the 2D viewer code paths that compute projection and view state and should be covered by existing rendering/capture logic in normal runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69596c7812648324a69ef92d9ac5ad1b)