### PR TITLE
Fix 2D view editor projection on resize

### DIFF
--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -369,20 +369,14 @@ void Viewer2DPanel::Render() { RenderInternal(true); }
 void Viewer2DPanel::RenderInternal(bool swapBuffers) {
   int w, h;
   GetClientSize(&w, &h);
-  int viewportW = w;
-  int viewportH = h;
-  if (m_layoutEditViewportSize) {
-    viewportW = m_layoutEditViewportSize->GetWidth();
-    viewportH = m_layoutEditViewportSize->GetHeight();
-  }
 
   glViewport(0, 0, w, h);
 
   glMatrixMode(GL_PROJECTION);
   glLoadIdentity();
   float ppm = PIXELS_PER_METER * m_zoom;
-  float halfW = static_cast<float>(viewportW) / ppm * 0.5f;
-  float halfH = static_cast<float>(viewportH) / ppm * 0.5f;
+  float halfW = static_cast<float>(w) / ppm * 0.5f;
+  float halfH = static_cast<float>(h) / ppm * 0.5f;
   float offX = m_offsetX / PIXELS_PER_METER;
   float offY = m_offsetY / PIXELS_PER_METER;
   glOrtho(-halfW - offX, halfW - offX, -halfH - offY, halfH - offY, -100.0f,


### PR DESCRIPTION
### Motivation
- Resizing the "2D View Editor" window incorrectly changed the on-screen projection, stretching the scene and altering zoom/offset.
- The on-screen projection should always be based on the actual canvas size so that enlarging the window only reveals more content without changing zoom or deforming the image.

### Description
- Update `RenderInternal` in `viewer2d/viewer2dpanel.cpp` to stop using `m_layoutEditViewportSize` for the on-screen projection calculation.
- Compute `halfW` and `halfH` from the real client size (`w`, `h` from `GetClientSize`) instead of `viewportW/viewportH` derived from `m_layoutEditViewportSize`.
- Leave `m_layoutEditViewportSize` available for overlay/offscreen rendering logic but remove it from the on-screen `glOrtho` projection code.
- Modified file: `viewer2d/viewer2dpanel.cpp`.

### Testing
- No automated tests were run for this change.
- Manual runtime verification was not recorded in automated test logs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69596e8e97208324808930f37a7b8756)