### PR TITLE
Fix 2D layout editor resize behavior

### DIFF
--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -271,11 +271,13 @@ void Viewer2DPanel::CaptureFrameNow(
 void Viewer2DPanel::SetLayoutEditOverlay(std::optional<float> aspectRatio,
                                          std::optional<wxSize> viewportSize) {
   m_layoutEditAspect = aspectRatio;
-  m_layoutEditBaseSize.reset();
   m_layoutEditViewportSize.reset();
   if (viewportSize && viewportSize->GetWidth() > 0 &&
       viewportSize->GetHeight() > 0) {
     m_layoutEditViewportSize = viewportSize;
+    m_layoutEditBaseSize = viewportSize;
+  } else {
+    m_layoutEditBaseSize.reset();
   }
   m_layoutEditScale = 1.0f;
   Refresh();
@@ -671,7 +673,7 @@ void Viewer2DPanel::OnMouseLeave(wxMouseEvent &event) {
 }
 
 void Viewer2DPanel::OnResize(wxSizeEvent &event) {
-  if (m_layoutEditAspect) {
+  if (m_layoutEditAspect && !m_layoutEditViewportSize) {
     m_layoutEditBaseSize.reset();
   }
   Refresh();


### PR DESCRIPTION
### Motivation
- Ensure the 2D view editor overlay remains tied to the frame dimensions so resizing the window does not rescale or shift the editable frame.
- When a fixed viewport/frame size is supplied for layout editing, avoid recomputing the overlay base size on normal window resizes.
- Prevent the red layout rectangle and the captured layout viewport from being affected by host window size changes.

### Description
- In `viewer2d/viewer2dpanel.cpp` `SetLayoutEditOverlay` now assigns `m_layoutEditBaseSize` from the provided `viewportSize` when present, and only resets it when no fixed viewport is supplied.
- `OnResize` was changed to clear `m_layoutEditBaseSize` only if an overlay aspect is active and there is no fixed `m_layoutEditViewportSize`.
- Kept the existing refresh behavior by calling `Refresh()` after overlay changes so the UI updates consistently.

### Testing
- No automated tests were executed for this change.
- The change was implemented and committed to the local branch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959778906c48324a79153cc02c1fcca)