### PR TITLE
Fix 2D layout view offset scaling

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -670,8 +670,6 @@ void LayoutViewerPanel::RebuildCachedTexture() {
   viewer2d::Viewer2DState renderState = cachedRenderState;
   if (renderZoom != 1.0) {
     renderState.camera.zoom *= static_cast<float>(renderZoom);
-    renderState.camera.offsetPixelsX *= static_cast<float>(renderZoom);
-    renderState.camera.offsetPixelsY *= static_cast<float>(renderZoom);
   }
   renderState.camera.viewportWidth = renderSize.GetWidth();
   renderState.camera.viewportHeight = renderSize.GetHeight();


### PR DESCRIPTION
### Motivation
- The layout preview shown by the layout panel did not match the "2D View editor" because the view offset was being rescaled during cached texture rendering.
- Multiplying `offsetPixelsX`/`offsetPixelsY` by the render zoom produced a displaced image even when the zoom looked correct, so the preview contents were shifted relative to the editor.

### Description
- Stop scaling `renderState.camera.offsetPixelsX` and `renderState.camera.offsetPixelsY` in `LayoutViewerPanel::RebuildCachedTexture` so offsets remain in editor pixel units.  
- The change is implemented in `gui/layoutviewerpanel.cpp` and preserves the existing `camera.zoom` scaling and viewport size adjustments.  
- This ensures the cached texture rendered for the layout preview aligns with the editor view after confirmation.

### Testing
- No automated tests were run for this change.
- No CI/test results are available for this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959796315dc8324b4e838991116ba81)