### PR TITLE
Fix frame scale persistence in 2D view editor

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -2207,6 +2207,25 @@ void MainWindow::OnLayout2DViewOk(wxCommandEvent &WXUNUSED(event)) {
       frame = view->frame;
   }
 
+  if (editPanel) {
+    if (auto overlaySize = editPanel->GetLayoutEditOverlaySize()) {
+      const int newWidth = overlaySize->GetWidth();
+      const int newHeight = overlaySize->GetHeight();
+      if (newWidth > 0 && newHeight > 0) {
+        if (frame.width > 0 || frame.height > 0) {
+          const double centerX = frame.x + frame.width / 2.0;
+          const double centerY = frame.y + frame.height / 2.0;
+          frame.x =
+              static_cast<int>(std::lround(centerX - newWidth / 2.0));
+          frame.y =
+              static_cast<int>(std::lround(centerY - newHeight / 2.0));
+        }
+        frame.width = newWidth;
+        frame.height = newHeight;
+      }
+    }
+  }
+
   // Ensure the stored viewport matches the layout frame size, not the popup.
   if (frame.width > 0 || frame.height > 0) {
     current.camera.viewportWidth = frame.width;


### PR DESCRIPTION
### Motivation

- The 2D View Editor scale overlay was not being applied when saving, so the stored layout frame size did not reflect the editor's `Frame scale` setting.
- The intent is to persist the overlay-scaled frame size into the layout definition so exported/printed views match what the user sees in the editor.

### Description

- Apply the overlay size from `GetLayoutEditOverlaySize()` when saving in `MainWindow::OnLayout2DViewOk` and update `frame.width` and `frame.height` accordingly.
- Preserve the existing frame center when resizing by recomputing `frame.x` and `frame.y` to keep the frame centered after scale changes.
- Ensure the stored viewport dimensions continue to match the adjusted `frame` and update the layout via `LayoutManager::UpdateLayout2DView`.
- Change made in `gui/mainwindow.cpp` to perform the overlay-to-frame conversion before creating the updated `Layout2DViewDefinition`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69597aa3ccc483248001589772c865fc)