### PR TITLE
Add persistent ids for layout 2D views

### DIFF
--- a/core/layouts/LayoutCollection.cpp
+++ b/core/layouts/LayoutCollection.cpp
@@ -78,16 +78,24 @@ bool LayoutCollection::UpdateLayout2DView(const std::string &name,
                                           const Layout2DViewDefinition &view) {
   for (auto &layout : layouts) {
     if (layout.name == name) {
+      Layout2DViewDefinition updatedView = view;
+      int nextId = 1;
+      for (const auto &entry : layout.view2dViews) {
+        if (entry.id > 0)
+          nextId = std::max(nextId, entry.id + 1);
+      }
+      if (updatedView.id <= 0)
+        updatedView.id = nextId;
       bool replaced = false;
       for (auto &entry : layout.view2dViews) {
-        if (entry.camera.view == view.camera.view) {
-          entry = view;
+        if (entry.id == updatedView.id && updatedView.id > 0) {
+          entry = updatedView;
           replaced = true;
           break;
         }
       }
       if (!replaced)
-        layout.view2dViews.push_back(view);
+        layout.view2dViews.push_back(updatedView);
       return true;
     }
   }

--- a/core/layouts/LayoutCollection.h
+++ b/core/layouts/LayoutCollection.h
@@ -66,6 +66,7 @@ struct Layout2DViewLayers {
 };
 
 struct Layout2DViewDefinition {
+  int id = 0;
   Layout2DViewFrame frame;
   Layout2DViewCameraState camera;
   Layout2DViewRenderOptions renderOptions;

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -171,6 +171,7 @@ private:
   bool layoutModeActive = false;
   std::string activeLayoutName;
   bool layout2DViewEditing = false;
+  int layout2DViewEditingId = 0;
   std::unique_ptr<viewer2d::ScopedViewer2DState> layout2DViewStateGuard;
   Viewer2DPanel *layout2DViewEditPanel = nullptr;
   Viewer2DRenderPanel *layout2DViewEditRenderPanel = nullptr;


### PR DESCRIPTION
### Motivation
- Avoid replacing 2D layout views solely by `camera.view` because that can collide or lose the intended mapping when editing or persisting state.
- Provide a stable, persistent identifier for each `Layout2DViewDefinition` so edits and persisted captures reliably target the same view.
- Ensure existing saved layouts are normalized to unique ids on load to maintain backward compatibility.

### Description
- Add `int id` to `Layout2DViewDefinition` and switch `LayoutCollection::UpdateLayout2DView` to match/replace views by `id` and assign a new id when missing.
- Serialize and deserialize the new `id` in `ToJson` and `ParseLayout2DView`, and add `EnsureUniqueViewIds` during `LayoutManager::LoadFromConfig` to deduplicate and generate ids.
- Update GUI logic by adding `layout2DViewEditingId` to `MainWindow` and preserve/pass the view id through begin/edit/ok/cancel/persist flows so edits keep the same id.
- Add required headers (`<algorithm>`, `<unordered_set>`) and minor related adjustments to maintain behavior while introducing ids.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69597c42afcc8324a050ff449994e7e8)