### PR TITLE
Add selection handling for layout views

### DIFF
--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -66,6 +66,8 @@ private:
   void RequestRenderRebuild();
   void InvalidateRenderIfFrameChanged();
   void EmitEditViewRequest();
+  bool SelectViewAtPosition(const wxPoint &pos);
+  int GetViewIndexAtPosition(const wxPoint &pos) const;
 
   enum class FrameDragMode {
     None,
@@ -91,6 +93,7 @@ private:
   int captureVersion = -1;
   bool captureInProgress = false;
   bool hasCapture = false;
+  int selectedViewId = -1;
   CommandBuffer cachedBuffer;
   Viewer2DViewState cachedViewState;
   viewer2d::Viewer2DState cachedRenderState;


### PR DESCRIPTION
### Motivation
- Allow selecting the specific 2D view under the mouse so the user can edit or delete a particular view instead of always operating on the first view.  
- Make `GetEditableView()` return the currently selected view so editing flows target the active selection.  
- Ensure context menu actions (`Edit` / `Delete`) operate on the view under the cursor.  
- Visually distinguish the active view to avoid confusion when multiple frames overlap.  

### Description
- Added an `int selectedViewId` member and initialized it from the first view in `SetLayoutDefinition`.  
- Implemented `SelectViewAtPosition(const wxPoint &pos)` and `GetViewIndexAtPosition(const wxPoint &pos) const` to perform per-frame hit-testing and update selection.  
- Changed `GetEditableView()` / const overload to return the selected view when present, and updated code paths in `OnPaint`, capture logic, and render-size calculations to work with the active view (`activeView`).  
- Hooked selection into mouse handlers by calling `SelectViewAtPosition` from `OnLeftDown`, `OnLeftDClick`, `OnMouseMove`, and `OnRightUp`, updated context menu handling to require selection, and adjusted `OnDeleteView` to update `selectedViewId` after removal.  
- Added rendering of non-selected frames as subtle outlines and kept the active frame highlighted with the existing thicker outline and resize handles to improve visual clarity.  

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69597df712c08324bc4717c4b1475315)