### PR TITLE
Use layout view ids when syncing 2D view state

### DIFF
--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -62,7 +62,7 @@ public:
   Viewer2DOffscreenRenderer *GetOffscreenRenderer();
   bool IsLayout2DViewEditing() const;
   void PersistLayout2DViewState();
-  void RestoreLayout2DViewState(int viewIndex);
+  void RestoreLayout2DViewState(int viewId);
 
 private:
   void SetupLayout();   // Set up main window layout


### PR DESCRIPTION
### Motivation

- The previous code located layout 2D views by `camera.view` (a runtime index) which could match the wrong entry when persisting or restoring state.
- The goal is to reliably identify the exact `view2dViews` entry to update so changes don't affect other views.
- Use the explicit layout view `id` (or the selected view from `LayoutViewerPanel`) to resolve which view is being edited or saved.

### Description

- Added a helper `FindLayout2DViewById` to look up a `layouts::Layout2DViewDefinition` by its `id`.
- Updated `OnLayout2DViewOk`, `PersistLayout2DViewState`, and `RestoreLayout2DViewState` to resolve views by `id` and fall back to `layoutViewerPanel->GetEditableView()` when appropriate.
- Changed the `RestoreLayout2DViewState` parameter name to `viewId` and modified `ActivateLayoutView` to prefer the viewer-selected view id or the first view id from the layout definition.
- All updates use `UpdateLayout2DView` with the resolved `id` so the correct layout entry is replaced or appended without unintentionally modifying other views.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695981d3fe208324997fe78197ca8435)