### PR TITLE
Use unique view IDs for layout 2D view selection and caching

### DIFF
--- a/core/layouts/LayoutCollection.cpp
+++ b/core/layouts/LayoutCollection.cpp
@@ -103,13 +103,13 @@ bool LayoutCollection::UpdateLayout2DView(const std::string &name,
 }
 
 bool LayoutCollection::RemoveLayout2DView(const std::string &name,
-                                          int viewIndex) {
+                                          int viewId) {
   for (auto &layout : layouts) {
     if (layout.name == name) {
       auto &views = layout.view2dViews;
       auto it = std::remove_if(
-          views.begin(), views.end(), [viewIndex](const auto &entry) {
-            return entry.camera.view == viewIndex;
+          views.begin(), views.end(), [viewId](const auto &entry) {
+            return entry.id == viewId;
           });
       if (it == views.end())
         return false;

--- a/core/layouts/LayoutCollection.h
+++ b/core/layouts/LayoutCollection.h
@@ -93,7 +93,7 @@ public:
   bool SetLayoutOrientation(const std::string &name, bool landscape);
   bool UpdateLayout2DView(const std::string &name,
                           const Layout2DViewDefinition &view);
-  bool RemoveLayout2DView(const std::string &name, int viewIndex);
+  bool RemoveLayout2DView(const std::string &name, int viewId);
 
   void ReplaceAll(std::vector<LayoutDefinition> layouts);
 

--- a/core/layouts/LayoutManager.cpp
+++ b/core/layouts/LayoutManager.cpp
@@ -262,11 +262,13 @@ bool ParseLayout(const nlohmann::json &value, LayoutDefinition &out) {
       if (!ParseLayout2DView(entry, view))
         continue;
       bool replaced = false;
-      for (auto &existing : out.view2dViews) {
-        if (existing.camera.view == view.camera.view) {
-          existing = view;
-          replaced = true;
-          break;
+      if (view.id > 0) {
+        for (auto &existing : out.view2dViews) {
+          if (existing.id == view.id) {
+            existing = view;
+            replaced = true;
+            break;
+          }
         }
       }
       if (!replaced)
@@ -410,9 +412,8 @@ bool LayoutManager::UpdateLayout2DView(const std::string &name,
   return true;
 }
 
-bool LayoutManager::RemoveLayout2DView(const std::string &name,
-                                       int viewIndex) {
-  if (!layouts.RemoveLayout2DView(name, viewIndex))
+bool LayoutManager::RemoveLayout2DView(const std::string &name, int viewId) {
+  if (!layouts.RemoveLayout2DView(name, viewId))
     return false;
   SyncToConfig();
   return true;

--- a/core/layouts/LayoutManager.h
+++ b/core/layouts/LayoutManager.h
@@ -36,7 +36,7 @@ public:
   bool SetLayoutOrientation(const std::string &name, bool landscape);
   bool UpdateLayout2DView(const std::string &name,
                           const Layout2DViewDefinition &view);
-  bool RemoveLayout2DView(const std::string &name, int viewIndex);
+  bool RemoveLayout2DView(const std::string &name, int viewId);
 
   void LoadFromConfig(ConfigManager &cfg);
   void SaveToConfig(ConfigManager &cfg) const;


### PR DESCRIPTION
### Motivation
- The layout viewer keyed selection and cached textures by `camera.view`, which is not unique and caused a second 2D view to appear grey/unselectable when multiple views shared the same camera orientation.
- The code needs a stable per-view identifier so multiple 2D views can coexist even if they use the same camera/view setting.

### Description
- Key layout viewer selection, caching and render logic by `Layout2DViewDefinition::id` instead of `camera.view` in `gui/layoutviewerpanel.cpp` so each view is addressed by its unique `id`.
- Update deletion and cache cleanup to use the view `id` and keep `selectedViewId` in sync with `id` when views are removed or selected in `gui/layoutviewerpanel.cpp`.
- Change `RemoveLayout2DView` to take a `viewId` and update parsing/replace logic to match views by `id` in `core/layouts/LayoutCollection.*` and `core/layouts/LayoutManager.*` so persisted layouts preserve and use unique view identifiers.
- Adjusted `ParseLayout` to replace existing views by `id` when present and preserved the automatic id assignment logic in `UpdateLayout2DView`.

### Testing
- No automated tests were executed against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695983af5cb08324acb5ddaa93509053)