### PR TITLE
Fix layout PDF export symbols and config capture

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1615,6 +1615,7 @@ void MainWindow::OnPrintLayout(wxCommandEvent &WXUNUSED(event)) {
   }
 
   ConfigManager &cfg = ConfigManager::Get();
+  ConfigManager *cfgPtr = &cfg;
   print::Viewer2DPrintSettings settings =
       print::Viewer2DPrintSettings::LoadFromConfig(cfg);
   settings.pageSize = layout->pageSetup.pageSize;

--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -1037,10 +1037,19 @@ Viewer2DExportResult ExportViewer2DToPdf(
 
   std::ostringstream resources;
   resources << "<< /Font << /F1 1 0 R >>";
-  if (!xObjectNameIds.empty()) {
+  if (!xObjectKeyIds.empty() || !xObjectIdIds.empty()) {
     resources << " /XObject << ";
-    for (const auto &entry : xObjectNameIds) {
-      resources << '/' << entry.first << ' ' << entry.second << " 0 R ";
+    for (const auto &entry : xObjectKeyIds) {
+      auto nameIt = xObjectKeyNames.find(entry.first);
+      if (nameIt == xObjectKeyNames.end())
+        continue;
+      resources << '/' << nameIt->second << ' ' << entry.second << " 0 R ";
+    }
+    for (const auto &entry : xObjectIdIds) {
+      auto nameIt = xObjectIdNames.find(entry.first);
+      if (nameIt == xObjectIdNames.end())
+        continue;
+      resources << '/' << nameIt->second << ' ' << entry.second << " 0 R ";
     }
     resources << ">>";
   }


### PR DESCRIPTION
### Motivation
- Resolve compiler errors in the layout print flow caused by an undefined config pointer and incorrect PDF XObject resource emission.
- Ensure symbols referenced in exported PDFs are actually declared in the PDF resources so generated files render correctly.

### Description
- Add `ConfigManager *cfgPtr = &cfg;` in `MainWindow::OnPrintLayout` so the capture lambda receives a valid config pointer.
- Update `viewer2d/viewer2dpdfexporter.cpp` to emit `/XObject` resources by iterating `xObjectKeyIds` and `xObjectIdIds` and mapping entries to names using `xObjectKeyNames` and `xObjectIdNames`.
- Guard XObject emission with `if (!xObjectKeyIds.empty() || !xObjectIdIds.empty())` to include the block only when needed.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69598a9aa5908324816304a234b70459)