### PR TITLE
Fix narrowing conversion in PDF export layout grouping

### DIFF
--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -1260,7 +1260,7 @@ Viewer2DExportResult ExportLayoutToPdf(
     captureCommands(view.buffer, mainCommands, viewSymbolKeys, viewSymbolIds);
     layoutGroups.push_back({std::move(mainCommands),
                             mapping,
-                            view.frame.x,
+                            static_cast<double>(view.frame.x),
                             frameOriginY,
                             static_cast<double>(view.frame.width),
                             static_cast<double>(view.frame.height),


### PR DESCRIPTION
### Motivation
- Fix a compile-time narrowing conversion error (C2397) occurring when building layout command groups for PDF export due to an integer-to-double conversion in list-initialization. 
- Ensure `LayoutCommandGroup.frameX` receives a proper `double` value when pushing view groups into `layoutGroups` to avoid build failures.

### Description
- Cast `view.frame.x` to `double` in the `layoutGroups.push_back` initializer to avoid narrowing during aggregate/list-initialization. 
- Change applied in `viewer2d/viewer2dpdfexporter.cpp` near the `layoutGroups.push_back` call that constructs `LayoutCommandGroup`.
- This is a single-line, backwards-compatible change that preserves the existing layout logic.

### Testing
- No automated tests were executed as part of this change. 
- The change is minimal and intended to resolve a compile-time error without altering runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69598deb72408324b52e31ef6d9689ed)