### PR TITLE
Guard scoped 2D state against destroyed panels

### DIFF
--- a/viewer2d/viewer2dstate.cpp
+++ b/viewer2d/viewer2dstate.cpp
@@ -158,8 +158,8 @@ ScopedViewer2DState::ScopedViewer2DState(Viewer2DPanel *applyPanel,
       applyRenderPanel_(applyRenderPanel), restorePanel_(restorePanel),
       restoreRenderPanel_(restoreRenderPanel),
       restored_(false) {
-  previousState_ = CaptureState(restorePanel_ ? restorePanel_ : applyPanel_, cfg);
-  ApplyState(applyPanel_, applyRenderPanel_, cfg, state);
+  previousState_ = CaptureState(restorePanel ? restorePanel : applyPanel, cfg);
+  ApplyState(applyPanel_.get(), applyRenderPanel_.get(), cfg, state);
 }
 
 ScopedViewer2DState::~ScopedViewer2DState() { Restore(); }
@@ -182,10 +182,10 @@ ScopedViewer2DState::operator=(ScopedViewer2DState &&other) noexcept {
   restored_ = other.restored_;
 
   other.cfg_ = nullptr;
-  other.applyPanel_ = nullptr;
-  other.applyRenderPanel_ = nullptr;
-  other.restorePanel_ = nullptr;
-  other.restoreRenderPanel_ = nullptr;
+  other.applyPanel_ = wxWeakRef<Viewer2DPanel>();
+  other.applyRenderPanel_ = wxWeakRef<Viewer2DRenderPanel>();
+  other.restorePanel_ = wxWeakRef<Viewer2DPanel>();
+  other.restoreRenderPanel_ = wxWeakRef<Viewer2DRenderPanel>();
   other.restored_ = true;
   return *this;
 }
@@ -195,9 +195,9 @@ void ScopedViewer2DState::Restore() {
     return;
 
   Viewer2DPanel *targetPanel =
-      restorePanel_ ? restorePanel_ : Viewer2DPanel::Instance();
+      restorePanel_ ? restorePanel_.get() : Viewer2DPanel::Instance();
   Viewer2DRenderPanel *targetRenderPanel =
-      restoreRenderPanel_ ? restoreRenderPanel_
+      restoreRenderPanel_ ? restoreRenderPanel_.get()
                           : Viewer2DRenderPanel::Instance();
 
   ApplyState(targetPanel, targetRenderPanel, *cfg_, previousState_);

--- a/viewer2d/viewer2dstate.h
+++ b/viewer2d/viewer2dstate.h
@@ -19,6 +19,8 @@
 
 #include "layouts/LayoutCollection.h"
 
+#include <wx/weakref.h>
+
 class ConfigManager;
 class Viewer2DPanel;
 class Viewer2DRenderPanel;
@@ -55,10 +57,10 @@ public:
 
 private:
   ConfigManager *cfg_ = nullptr;
-  Viewer2DPanel *applyPanel_ = nullptr;
-  Viewer2DRenderPanel *applyRenderPanel_ = nullptr;
-  Viewer2DPanel *restorePanel_ = nullptr;
-  Viewer2DRenderPanel *restoreRenderPanel_ = nullptr;
+  wxWeakRef<Viewer2DPanel> applyPanel_;
+  wxWeakRef<Viewer2DRenderPanel> applyRenderPanel_;
+  wxWeakRef<Viewer2DPanel> restorePanel_;
+  wxWeakRef<Viewer2DRenderPanel> restoreRenderPanel_;
   Viewer2DState previousState_;
   bool restored_ = true;
 };


### PR DESCRIPTION
### Motivation
- Prevent crashes caused by `ScopedViewer2DState::Restore()` dereferencing panels that have already been destroyed.
- The previous implementation stored raw `Viewer2DPanel*`/`Viewer2DRenderPanel*` and could produce dangling-pointer use during capture/restore or UI lifecycle races.
- Use weak references to avoid restoring state onto invalid UI objects during reentrant or multi-step UI operations.
- Improve robustness of 2D view capture/restore paths when panels are swapped or destroyed.

### Description
- Add `#include <wx/weakref.h>` and replace raw panel pointer members in `ScopedViewer2DState` with `wxWeakRef<Viewer2DPanel>` and `wxWeakRef<Viewer2DRenderPanel>`.
- Update constructor and restore logic to use the incoming raw parameters for initial state capture and to call `ApplyState`/`CaptureState` with `.get()` from the weak refs so destroyed panels are not dereferenced.
- Adjust move-assignment to clear moved-from weak refs by assigning default `wxWeakRef<>` values and preserve the `restored_` state correctly.
- Keep the public API unchanged while hardening internal lifetime handling in `viewer2d/viewer2dstate.h` and `viewer2d/viewer2dstate.cpp`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d03b578448324841b7733e2ac656c)