### PR TITLE
Add layout legend element for fixture counts (Layout Mode)

### DIFF
--- a/core/layouts/LayoutCollection.h
+++ b/core/layouts/LayoutCollection.h
@@ -73,10 +73,16 @@ struct Layout2DViewDefinition {
   Layout2DViewLayers layers;
 };
 
+struct LayoutLegendDefinition {
+  int id = 0;
+  Layout2DViewFrame frame;
+};
+
 struct LayoutDefinition {
   std::string name;
   print::PageSetup pageSetup;
   std::vector<Layout2DViewDefinition> view2dViews;
+  std::vector<LayoutLegendDefinition> legendViews;
 };
 
 class LayoutCollection {
@@ -94,6 +100,9 @@ public:
   bool UpdateLayout2DView(const std::string &name,
                           const Layout2DViewDefinition &view);
   bool RemoveLayout2DView(const std::string &name, int viewId);
+  bool UpdateLayoutLegend(const std::string &name,
+                          const LayoutLegendDefinition &legend);
+  bool RemoveLayoutLegend(const std::string &name, int legendId);
 
   void ReplaceAll(std::vector<LayoutDefinition> layouts);
 

--- a/core/layouts/LayoutManager.h
+++ b/core/layouts/LayoutManager.h
@@ -37,6 +37,9 @@ public:
   bool UpdateLayout2DView(const std::string &name,
                           const Layout2DViewDefinition &view);
   bool RemoveLayout2DView(const std::string &name, int viewId);
+  bool UpdateLayoutLegend(const std::string &name,
+                          const LayoutLegendDefinition &legend);
+  bool RemoveLayoutLegend(const std::string &name, int legendId);
 
   void LoadFromConfig(ConfigManager &cfg);
   void SaveToConfig(ConfigManager &cfg) const;

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -150,6 +150,7 @@ private:
   void OnAddSceneObject(wxCommandEvent &event); // Add generic scene object
   void OnDelete(wxCommandEvent &event);         // Delete selected items
   void OnLayoutAdd2DView(wxCommandEvent &event); // Layout 2D view creation
+  void OnLayoutAddLegend(wxCommandEvent &event); // Layout legend creation
   void OnLayout2DViewOk(wxCommandEvent &event); // Confirm layout 2D view edit
   void OnLayout2DViewCancel(wxCommandEvent &event); // Cancel layout 2D edit
   void OnLayoutViewEdit(wxCommandEvent &event);
@@ -208,6 +209,7 @@ enum {
   ID_View_Layout_2D,
   ID_View_Layout_Mode,
   ID_View_Layout_2DView,
+  ID_View_Layout_Legend,
   ID_Tools_DownloadGdtf,
   ID_Tools_EditDictionaries,
   ID_Tools_ImportRiderText,


### PR DESCRIPTION
### Motivation
- Provide a scalable, dockable legend element in Layout Mode that shows fixture counts by type and channel counts similar to the existing Summary panel. 
- Make legends persistent with the layout collection so they can be added/edited/removed like 2D views.
- Ensure legend visuals are renderable and cacheable as textures for performant layout rendering.
- Keep legend data in sync with scene changes (refresh alongside the summary updates).

### Description
- Add a new model `LayoutLegendDefinition` and `legendViews` to layout definitions and extend `LayoutCollection`/`LayoutManager` with `UpdateLayoutLegend` and `RemoveLayoutLegend` for persistence and JSON (de)serialization.
- Add a toolbar action and menu id `ID_View_Layout_Legend` and `OnLayoutAddLegend` to insert a default legend frame into the active layout.
- Implement legend rendering, caching and selection in `LayoutViewerPanel`, including `RefreshLegendData`, `BuildLegendItems`, `BuildLegendImage`, per-legend `LegendCache`, hit-testing, resize/move handles, and delete via context menu (`OnDeleteLegend`).
- Compute legend contents by aggregating fixtures from `ConfigManager` and calling `GetGdtfModeChannelCount` to show optional per-type channel counts, and refresh legend data when the Summary is refreshed via `RefreshLegendData`.

### Testing
- No automated tests were executed for this change (new UI behavior was implemented but unit/integration tests were not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d0852ef308324b6131bb9bfebaaa9)