### PR TITLE
Add LayoutManager sources to test targets to fix linker errors

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,10 @@ function(set_library_env TEST_NAME)
     set_tests_properties(${TEST_NAME} PROPERTIES ENVIRONMENT "PERASTAGE_LIBRARY_PATH=${CMAKE_SOURCE_DIR}/library")
 endfunction()
 
+set(LAYOUT_SOURCES
+    ../core/layouts/LayoutManager.cpp
+    ../core/layouts/LayoutCollection.cpp)
+
 if(TARGET podofo::podofo)
     add_executable(pdf_text_test pdf_text_test.cpp ../core/pdftext.cpp)
     target_link_libraries(pdf_text_test PRIVATE podofo::podofo ${wxWidgets_LIBRARIES})
@@ -61,7 +65,8 @@ add_executable(save_load_roundtrip_test save_load_roundtrip_test.cpp
                ../models/fixture.cpp
                ../models/truss.cpp
                ../models/sceneobject.cpp
-               ../models/layer.cpp)
+               ../models/layer.cpp
+               ${LAYOUT_SOURCES})
 target_include_directories(save_load_roundtrip_test PRIVATE
                            . ../core ../models ../mvr ../gui ../external)
 target_link_libraries(save_load_roundtrip_test PRIVATE
@@ -89,7 +94,8 @@ add_executable(rider_save_roundtrip_test rider_save_roundtrip_test.cpp
                ../models/fixture.cpp
                ../models/truss.cpp
                ../models/sceneobject.cpp
-               ../models/layer.cpp)
+               ../models/layer.cpp
+               ${LAYOUT_SOURCES})
 target_include_directories(rider_save_roundtrip_test PRIVATE
                            . ../core ../models ../mvr ../gui ../external)
 target_link_libraries(rider_save_roundtrip_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
@@ -110,7 +116,8 @@ add_executable(riderimporter_fixtureid_test rider_import_fixtureid_test.cpp
                ../models/fixture.cpp
                ../models/truss.cpp
                ../models/sceneobject.cpp
-               ../models/layer.cpp)
+               ../models/layer.cpp
+               ${LAYOUT_SOURCES})
 target_include_directories(riderimporter_fixtureid_test PRIVATE
                            . ../core ../models ../mvr ../gui ../external)
 target_link_libraries(riderimporter_fixtureid_test PRIVATE ${wxWidgets_LIBRARIES})
@@ -132,7 +139,8 @@ add_executable(rider_import_order_test rider_import_order_test.cpp
                ../models/fixture.cpp
                ../models/truss.cpp
                ../models/sceneobject.cpp
-               ../models/layer.cpp)
+               ../models/layer.cpp
+               ${LAYOUT_SOURCES})
 target_include_directories(rider_import_order_test PRIVATE
                            . ../core ../models ../mvr ../gui ../external)
 target_link_libraries(rider_import_order_test PRIVATE ${wxWidgets_LIBRARIES})
@@ -153,7 +161,8 @@ add_executable(rider_autopatch_test rider_autopatch_test.cpp
                ../models/fixture.cpp
                ../models/truss.cpp
                ../models/sceneobject.cpp
-               ../models/layer.cpp)
+               ../models/layer.cpp
+               ${LAYOUT_SOURCES})
 target_include_directories(rider_autopatch_test PRIVATE
                            . ../core ../models ../mvr ../gui ../external)
 target_link_libraries(rider_autopatch_test PRIVATE ${wxWidgets_LIBRARIES})
@@ -174,7 +183,8 @@ add_executable(rider_layer_mode_test rider_layer_mode_test.cpp
                ../models/fixture.cpp
                ../models/truss.cpp
                ../models/sceneobject.cpp
-               ../models/layer.cpp)
+               ../models/layer.cpp
+               ${LAYOUT_SOURCES})
 target_include_directories(rider_layer_mode_test PRIVATE
                            . ../core ../models ../mvr ../gui ../external)
 target_link_libraries(rider_layer_mode_test PRIVATE ${wxWidgets_LIBRARIES})
@@ -195,7 +205,8 @@ add_executable(rider_import_benchmark rider_import_benchmark.cpp
                ../models/fixture.cpp
                ../models/truss.cpp
                ../models/sceneobject.cpp
-               ../models/layer.cpp)
+               ../models/layer.cpp
+               ${LAYOUT_SOURCES})
 target_include_directories(rider_import_benchmark PRIVATE
                            . ../core ../models ../mvr ../gui ../external)
 target_link_libraries(rider_import_benchmark PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)


### PR DESCRIPTION
### Motivation
- Several test executables that compile `ConfigManager` failed with LNK2019 unresolved externals referencing `layouts::LayoutManager` because the layout implementation files were not included in those targets.
- The tests build individual executables (not the main target) so they must provide the needed `LayoutManager` symbols directly.

### Description
- Introduce a `LAYOUT_SOURCES` variable that lists `../core/layouts/LayoutManager.cpp` and `../core/layouts/LayoutCollection.cpp`.
- Append `${LAYOUT_SOURCES}` to all test targets that include `../core/configmanager.cpp` or otherwise require layout symbols so the linker can find `LayoutManager` implementations.
- Centralize layout-related sources for consistency across test targets in `tests/CMakeLists.txt`.

### Testing
- No automated tests were executed as part of this change.
- Manual compilation was not recorded here, so automated build/test status is unknown.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d0c2d04088324af0801049813f150)