### PR TITLE
Avoid exceptions from numeric parsing; add safe parsers and input validation

### DIFF
--- a/models/support.h
+++ b/models/support.h
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <charconv>
 #include <string>
 #include "types.h"
 
@@ -61,10 +62,13 @@ inline std::string NormalizeHoistFunction(const std::string &rawValue) {
     if (trimmed.empty())
         return "Lighting";
 
-    try {
-        if (std::stod(trimmed) == 0.0)
+    double parsed = 0.0;
+    auto begin = trimmed.data();
+    auto end = trimmed.data() + trimmed.size();
+    auto result = std::from_chars(begin, end, parsed);
+    if (result.ec == std::errc{} && result.ptr == end) {
+        if (parsed == 0.0)
             return "Lighting";
-    } catch (...) {
     }
 
     auto lower = trimmed;
@@ -81,4 +85,3 @@ inline std::string NormalizeHoistFunction(const std::string &rawValue) {
 
     return trimmed;
 }
-


### PR DESCRIPTION
### Motivation
- Prevent `std::invalid_argument` and other exception-driven control flow when parsing numbers from external data and user input. 
- Harden import/export/loader paths against malformed numeric values coming from GDTF, MVR, rider text and CLI commands. 
- Provide clear, non-crashing diagnostics for invalid numeric tokens instead of aborting flows. 
- Reduce repeated exception overhead in hot loops (e.g. 2D export / GDTF parsing).

### Description
- Added `TryParseInt` helpers (`std::from_chars`-based) and reused existing `TryParseFloat` to safely parse integers/floats without exceptions in `viewer3d/gdtfloader.cpp`, `core/riderimporter.cpp` and `mvr/mvrexporter.cpp`. 
- Replaced several `std::stoi`/`std::stod` usages with the safe parsers (examples: DMX offsets in `ParseModes`, rider importer quantity/indices, `ParseAddress` in `mvrexporter`, and `NormalizeHoistFunction` in `models/support.h`).
- Added controlled console warnings via `ConsolePanel::AppendMessage` when encountering malformed DMX offsets and invalid selection ids instead of throwing, and added `parseId` validation for CLI selection handling in `gui/consolepanel.cpp`.
- Kept behavior conservative: malformed numeric tokens are either skipped, defaulted, or produce a user-visible message but do not throw exceptions or abort the import/export flows.

### Testing
- No automated tests were executed as part of this change. 
- Static grep/inspection was used to locate `std::stoi`/`std::stod`/`std::from_chars` sites and verify replacements. 
- Recommend running the full build and the existing test suite (e.g. `ctest`) and exercising GDTF/MVR/rider import and console commands to validate runtime behavior. 
- Manual smoke tests are suggested for flows that previously flooded exceptions (e.g. 2D print export and GDTF parsing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d0dd3ba1883248836c5bee4b94d5f)