### PR TITLE
Add missing layout legend toolbar icon

### DIFF
--- a/resources/icons/outline/square-chart-gantt.svg
+++ b/resources/icons/outline/square-chart-gantt.svg
@@ -1,0 +1,18 @@
+<!-- @license lucide-static v0.562.0 - ISC -->
+<svg
+  class="lucide lucide-square-chart-gantt"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect x="3" y="3" width="18" height="18" rx="2" />
+  <path d="M7 8h6" />
+  <path d="M7 12h10" />
+  <path d="M7 16h4" />
+</svg>


### PR DESCRIPTION
### Motivation
- The layout legend toolbar action calls `loadToolbarIcon("square-chart-gantt", ...)` but the corresponding SVG asset was absent, so the legend icon did not appear in the toolbar.
- The missing icon prevented users from discovering or clicking the Add Legend action when in the layout view.

### Description
- Added `resources/icons/outline/square-chart-gantt.svg` containing the Lucide `square-chart-gantt` SVG markup. 
- This supplies the asset used by `loadToolbarIcon` in `gui/mainwindow.cpp` so the toolbar can display the legend icon and tooltip.
- No code logic changes were made, only the icon asset was added and committed.

### Testing
- No automated tests were run for this asset-only change.
- No test failures were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d118443f083249c13eb94da1fd10e)