### PR TITLE
Add missing layout legend icon (square-chart-gantt)

### DIFF
--- a/resources/icons/icons-usage.json
+++ b/resources/icons/icons-usage.json
@@ -6,6 +6,7 @@
     "Save As": "outline/save-all.svg",
     "Import MVR": "outline/file-input.svg",
     "Export MVR": "outline/file-output.svg",
-    "Layout 2D View": "outline/panel-top-bottom-dashed.svg"
+    "Layout 2D View": "outline/panel-top-bottom-dashed.svg",
+    "Layout Legend": "outline/square-chart-gantt.svg"
   }
 }

--- a/resources/icons/outline/square-chart-gantt.svg
+++ b/resources/icons/outline/square-chart-gantt.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="18" height="18" x="3" y="3" rx="2" />
+  <path d="M9 8h7" />
+  <path d="M8 12h6" />
+  <path d="M11 16h5" />
+</svg>


### PR DESCRIPTION
### Motivation
- The toolbar lacked an icon for the "Layout Legend" action, so the legend button showed no icon.
- Icons are bundled under `resources/icons/outline` and referenced from `resources/icons/icons-usage.json`, so the missing icon needs to be added and mapped consistently with other toolbar icons.

### Description
- Added the SVG file `resources/icons/outline/square-chart-gantt.svg` containing the Lucide outline SVG for the layout legend.
- Updated `resources/icons/icons-usage.json` to include the mapping `"Layout Legend": "outline/square-chart-gantt.svg"`.
- The new icon follows the same outline style and placement as the other toolbar icons.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d12711f2883249ba203759b859d34)