### PR TITLE
Fix layout legend selection and rendering

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -159,7 +159,8 @@ void LayoutViewerPanel::OnPaint(wxPaintEvent &) {
              static_cast<float>(topLeft.y + scaledHeight));
   glEnd();
 
-  const layouts::Layout2DViewDefinition *activeView = GetEditableView();
+  const layouts::Layout2DViewDefinition *activeView =
+      static_cast<const LayoutViewerPanel *>(this)->GetEditableView();
   const int activeViewId =
       selectedElementType == SelectedElementType::View2D && activeView
           ? activeView->id
@@ -983,6 +984,7 @@ void LayoutViewerPanel::RebuildCachedTexture() {
       cache.renderZoom = 0.0;
       continue;
     }
+    image = image.Mirror(false);
     if (!image.HasAlpha())
       image.InitAlpha();
     const int width = image.GetWidth();

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -500,7 +500,7 @@ void MainWindow::CreateToolBars() {
                          "Add 2D View to Layout");
   layoutToolBar->AddTool(ID_View_Layout_Legend, "Añadir leyenda",
                          loadToolbarIcon("square-chart-gantt",
-                                         wxART_MISSING_IMAGE),
+                                         wxART_PLUS),
                          "Add fixture legend to layout");
   layoutToolBar->Realize();
   auiManager->AddPane(


### PR DESCRIPTION
### Motivation
- The layout legend toolbar button used an invisible fallback icon which hid the add-legend control in some environments.
- Legend bitmaps were rendered upside-down, causing text to appear mirrored vertically in the layout view.
- Retrieving the active 2D view during paint could call a non-const accessor which might modify selection state and cause legend focus/selection to be lost, preventing expected interactions.
- Ensure legend textures and selection/focus behave consistently so delete/focus work reliably.

### Description
- Use the `const` overload of `GetEditableView()` by calling `static_cast<const LayoutViewerPanel*>(this)->GetEditableView()` so retrieving the active view does not mutate selection state. 
- Flip legend images before uploading to GL with `image = image.Mirror(false)` to correct vertical mirroring of text.
- Change the toolbar fallback icon for the legend add tool from `wxART_MISSING_IMAGE` to `wxART_PLUS` so the button is visible if the SVG cannot be loaded.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d1494a3588324ab1f20a911115026)