### PR TITLE
Include layout legends in PDF export

### DIFF
--- a/viewer2d/viewer2dpdfexporter.h
+++ b/viewer2d/viewer2dpdfexporter.h
@@ -24,7 +24,9 @@
 #include "viewer2dpanel.h"
 #include <filesystem>
 #include <memory>
+#include <optional>
 #include <string>
+#include <vector>
 
 constexpr double kMmToPt = 72.0 / 25.4;
 
@@ -54,6 +56,17 @@ struct LayoutViewExportData {
   std::shared_ptr<const SymbolDefinitionSnapshot> symbolSnapshot;
 };
 
+struct LayoutLegendItem {
+  std::string typeName;
+  int count = 0;
+  std::optional<int> channelCount;
+};
+
+struct LayoutLegendExportData {
+  layouts::Layout2DViewFrame frame;
+  std::vector<LayoutLegendItem> items;
+};
+
 // Writes the captured 2D drawing commands to a vector PDF that mirrors the
 // current viewport state. Returns structured information so callers can surface
 // meaningful errors to the user.
@@ -66,5 +79,6 @@ Viewer2DExportResult ExportViewer2DToPdf(
 // Writes multiple 2D views into a single vector PDF layout.
 Viewer2DExportResult ExportLayoutToPdf(
     const std::vector<LayoutViewExportData> &views,
+    const std::vector<LayoutLegendExportData> &legends,
     const Viewer2DPrintOptions &options,
     const std::filesystem::path &outputPath);


### PR DESCRIPTION
### Motivation
- Layout print/export should include any legend elements placed on the layout so PDFs match what the user sees.
- Exported PDFs must render legend boxes, headers and per-item rows alongside the 2D views.
- Reuse the existing scene fixture data to build legend contents so printed legends reflect the current scene.
- Keep layout export pipeline consistent with existing `ExportLayoutToPdf` flow.

### Description
- Added `LayoutLegendItem` and `LayoutLegendExportData` types and extended `ExportLayoutToPdf` to accept a `legends` vector (`viewer2d/viewer2dpdfexporter.h`).
- Implemented PDF rendering of legend frames and text rows inside `ExportLayoutToPdf`, including simple text escaping, measurement and trimming helpers (`viewer2d/viewer2dpdfexporter.cpp`).
- Built legend item data from the current scene with `BuildLayoutLegendItems()` and hooked it into the layout capture/export flow in `MainWindow::OnPrintLayout` so legends are scaled and passed to the exporter (`gui/mainwindow.cpp`).
- Wired the threading closure to pass the legend payload into the background export thread so PDF generation includes legend content.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d16eebb0c83248e78b31f3a50d95b)