### PR TITLE
Update legend toolbar icon to Lucide `list`

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -561,7 +561,7 @@ void MainWindow::CreateToolBars() {
                                          wxART_MISSING_IMAGE),
                          "Add 2D View to Layout");
   layoutToolBar->AddTool(ID_View_Layout_Legend, "Añadir leyenda",
-                         loadToolbarIcon("square-chart-gantt",
+                         loadToolbarIcon("list",
                                          wxART_PLUS),
                          "Add fixture legend to layout");
   layoutToolBar->Realize();

--- a/resources/icons/outline/list.svg
+++ b/resources/icons/outline/list.svg
@@ -1,0 +1,20 @@
+<!-- @license lucide-static v0.562.0 - ISC -->
+<svg
+  class="lucide lucide-list"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M3 5h.01" />
+  <path d="M3 12h.01" />
+  <path d="M3 19h.01" />
+  <path d="M8 5h13" />
+  <path d="M8 12h13" />
+  <path d="M8 19h13" />
+</svg>


### PR DESCRIPTION
### Motivation
- Replace the previous Gantt-like icon with a clearer "list" icon to better represent a fixture legend in the layout toolbar.
- Use a Lucide icon so the asset matches other outline icons already in `resources/icons/outline`.

### Description
- Switched the toolbar call from `loadToolbarIcon("square-chart-gantt", wxART_PLUS)` to `loadToolbarIcon("list", wxART_PLUS)` in `gui/mainwindow.cpp` for the `ID_View_Layout_Legend` button.
- Added the Lucide `list` SVG asset at `resources/icons/outline/list.svg` (Lucide v0.562.0).
- The change affects only the layout toolbar icon used for the "Añadir leyenda" action.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d20a9cb60832491695985017b39f8)