### PR TITLE
Fix PDF legend text escaping

### DIFF
--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -22,6 +22,7 @@
 #include <array>
 #include <cmath>
 #include <cctype>
+#include <cstdio>
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
@@ -1288,10 +1289,39 @@ Viewer2DExportResult ExportLayoutToPdf(
   auto escapeText = [](const std::string &text) {
     std::string escaped;
     escaped.reserve(text.size());
-    for (char ch : text) {
-      if (ch == '(' || ch == ')' || ch == '\\')
+    for (unsigned char ch : text) {
+      switch (ch) {
+      case '(':
+      case ')':
+      case '\\':
         escaped.push_back('\\');
-      escaped.push_back(ch);
+        escaped.push_back(static_cast<char>(ch));
+        break;
+      case '\n':
+        escaped.append("\\n");
+        break;
+      case '\r':
+        escaped.append("\\r");
+        break;
+      case '\t':
+        escaped.append("\\t");
+        break;
+      case '\b':
+        escaped.append("\\b");
+        break;
+      case '\f':
+        escaped.append("\\f");
+        break;
+      default:
+        if (ch < 0x20 || ch > 0x7e) {
+          char buffer[5] = {};
+          std::snprintf(buffer, sizeof(buffer), "\\%03o", ch);
+          escaped.append(buffer);
+        } else {
+          escaped.push_back(static_cast<char>(ch));
+        }
+        break;
+      }
     }
     return escaped;
   };


### PR DESCRIPTION
### Motivation
- PDF exports could become malformed or fail when legend text contained control characters or non-ASCII bytes, causing printing/export errors.
- The previous `escapeText` only escaped `(`, `)` and `\\` and did not translate newlines, tabs, or non-printable characters.
- The change also requires `snprintf` for octal escapes, so the C header needed to be included.

### Description
- Replace the `escapeText` lambda in `viewer2d/viewer2dpdfexporter.cpp` with a robust implementation that escapes `(`, `)`, and `\\`, encodes control characters (`\n`, `\r`, `\t`, `\b`, `\f`) and octal-encodes bytes outside the printable ASCII range.
- Add `#include <cstdio>` to support `std::snprintf` used for octal escapes.
- The change is localized to `viewer2d/viewer2dpdfexporter.cpp` and does not alter PDF layout logic.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d2582b428832486ee2ef2202facfe)