### PR TITLE
Add Helvetica-Bold font resource to PDF exporter to fix legend rendering

### DIFF
--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -967,6 +967,8 @@ Viewer2DExportResult ExportViewer2DToPdf(
       {"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>"});
   objects.push_back(
       {"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>"});
+  objects.push_back(
+      {"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>"});
 
   Mapping symbolMapping{};
   symbolMapping.scale = scale;


### PR DESCRIPTION
### Motivation
- Exported layout PDFs referenced a bold font for legend headers but the corresponding PDF font resource was missing, causing errors in generated PDFs.
- The layout legend header style needs a valid bold font resource so on-PDF rendering matches the UI and does not produce invalid font references.

### Description
- Added a `Helvetica-Bold` font object to the PDF font resources in `viewer2d/viewer2dpdfexporter.cpp` so the bold font key resolves during export.
- The change is limited to inserting an additional `objects.push_back(...)` entry for the `Helvetica-Bold` Type1 font.
- No other behavior or layout drawing logic was modified.

### Testing
- No automated tests were run after this change.
- The patch is a minimal resource registration fix and should be covered by existing PDF export tests if executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d295d14f88324a2780c58e2c581b2)