### PR TITLE
Register missing bold PDF font for layout legend (fix PDF generation)

### DIFF
--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -969,6 +969,8 @@ Viewer2DExportResult ExportViewer2DToPdf(
       {"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>"});
   objects.push_back(
       {"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>"});
+  objects.push_back(
+      {"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>"});
 
   Mapping symbolMapping{};
   symbolMapping.scale = scale;


### PR DESCRIPTION
### Motivation
- Generated PDF plans were failing when layout legends referenced a second font object (`F2`) for bold headers because that font object was not registered.
- The legend rendering code emits font resources like `F1`/`F2`, so the PDF must contain matching font objects to avoid invalid references in output files.
- Using built-in PDF Type1 fonts such as `Helvetica`/`Helvetica-Bold` avoids relying on platform font files on Windows and provides a reliable fallback.

### Description
- Added an extra `Helvetica-Bold` font object to the PDF object list in `viewer2d/viewer2dpdfexporter.cpp` so the bold font index used for legend headers (`F2`) points to a valid object.
- The change ensures `ExportViewer2DToPdf` registers the bold font used by layout legend headers and prevents invalid font references in the generated PDF.

### Testing
- No automated tests were executed for this change.
- The change is limited to the PDF font registration in `viewer2d/viewer2dpdfexporter.cpp` and is low-risk, but please run the existing PDF export tests or a build verification in CI to confirm output correctness.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d2a61e9f88324b6e5011317e7bc14)