### PR TITLE
Remove unused PDF font objects

### DIFF
--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -961,16 +961,6 @@ Viewer2DExportResult ExportViewer2DToPdf(
   }
   std::vector<PdfObject> objects;
   objects.push_back({"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>"});
-  objects.push_back(
-      {"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>"});
-  objects.push_back(
-      {"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>"});
-  objects.push_back(
-      {"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>"});
-  objects.push_back(
-      {"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>"});
-  objects.push_back(
-      {"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>"});
 
   Mapping symbolMapping{};
   symbolMapping.scale = scale;


### PR DESCRIPTION
### Motivation
- Ensure the PDF page resources only reference fonts that are actually defined so `/F1` maps to the correct object index.
- Remove repeated `Helvetica-Bold` font objects that were never referenced by the page `resources` entry.
- Prevent stale references to deleted font objects and reduce unnecessary PDF object bloat.

### Description
- Deleted multiple `objects.push_back` entries that added `Helvetica-Bold` font `PdfObject`s and left only the `Helvetica` font object.
- Kept the single `<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>` entry so `/F1` corresponds to the first font object.
- Changes are limited to `viewer2d/viewer2dpdfexporter.cpp` around the PDF objects construction block.
- No other export logic was modified, only removal of unused font objects.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d2ced06cc8324b15a99e24fc7ba8e)