### PR TITLE
Add Helvetica-Bold PDF font object for legend headers

### DIFF
--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -961,6 +961,8 @@ Viewer2DExportResult ExportViewer2DToPdf(
   }
   std::vector<PdfObject> objects;
   objects.push_back({"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>"});
+  objects.push_back(
+      {"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>"});
 
   Mapping symbolMapping{};
   symbolMapping.scale = scale;


### PR DESCRIPTION
### Motivation
- The PDF legend code emits text using the resource name `F2` via `appendText(..., "F2", ...)`, so a second font object must exist to make `/F2` valid in the PDF resources.
- The resources string uses `/F1 1 0 R /F2 2 0 R`, so the `objects` order must contain two font objects so object indices match those resource references.

### Description
- Added a second font object entry in `viewer2d/viewer2dpdfexporter.cpp` by pushing a `Helvetica-Bold` font object with `objects.push_back(...)` so `/F2` resolves to `Helvetica-Bold`.
- Ensured the additional font object is inserted before building the page `Resources` so the existing `resources` string (`/F1 1 0 R /F2 2 0 R`) remains correct.

### Testing
- No automated tests were executed as part of this change.
- Static code inspection (searches) were used to verify the `F2` usage and the corresponding insertion site in `viewer2d/viewer2dpdfexporter.cpp`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d2dbaf364832491127866f2e4f370)