### PR TITLE
Ensure /F2 references a real font: add Helvetica-Bold in layout export and remove duplicate

### DIFF
--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -961,8 +961,6 @@ Viewer2DExportResult ExportViewer2DToPdf(
   }
   std::vector<PdfObject> objects;
   objects.push_back({"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>"});
-  objects.push_back(
-      {"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>"});
 
   Mapping symbolMapping{};
   symbolMapping.scale = scale;
@@ -1353,6 +1351,8 @@ Viewer2DExportResult ExportLayoutToPdf(
 
   std::vector<PdfObject> objects;
   objects.push_back({"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>"});
+  objects.push_back(
+      {"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>"});
 
   auto appendSymbolObject = [&](const std::string &name,
                                 const std::vector<CanvasCommand> &commands,


### PR DESCRIPTION
### Motivation
- PDF pages declared `/F2` in `/Resources` but previously `/F2` pointed to a non-font XObject, which produced invalid PDFs or viewer warnings.
- Legend header text uses `/F2 ... Tf`, so the exporter must emit a real Type1 font object for `/F2` so viewers (Acrobat, Ghostscript) do not substitute or error.
- A duplicated `Helvetica-Bold` object was present in the viewer export path, which does not fix resource pointers and only creates redundant objects.

### Description
- Updated `viewer2d/viewer2dpdfexporter.cpp` to remove the duplicate `Helvetica-Bold` `objects.push_back(...)` in the viewer export path.
- Added a single `Helvetica-Bold` font object in the layout export path so the page resource `/Font << /F1 1 0 R /F2 2 0 R >>` has `2 0 R` pointing to a real font.
- The change uses the standard PDF Type1 font `Helvetica-Bold` (one of the 14 base fonts) so embedding is not required and viewers will render legend headers correctly.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d2ee205f48324b91f089f85152076)