### PR TITLE
Añadir símbolos de fixtures en las leyendas de layout

### DIFF
--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -45,6 +45,7 @@ private:
     std::string typeName;
     int count = 0;
     std::optional<int> channelCount;
+    std::string symbolKey;
   };
 
   struct ViewCache {
@@ -68,6 +69,7 @@ private:
     double renderZoom = 0.0;
     bool renderDirty = true;
     size_t contentHash = 0;
+    std::shared_ptr<const SymbolDefinitionSnapshot> symbols;
   };
 
   void OnPaint(wxPaintEvent &event);
@@ -113,7 +115,8 @@ private:
   std::vector<LegendItem> BuildLegendItems() const;
   size_t HashLegendItems(const std::vector<LegendItem> &items) const;
   wxImage BuildLegendImage(const wxSize &size,
-                           const std::vector<LegendItem> &items) const;
+                           const std::vector<LegendItem> &items,
+                           const SymbolDefinitionSnapshot *symbols) const;
 
   enum class FrameDragMode {
     None,

--- a/gui/legendutils.cpp
+++ b/gui/legendutils.cpp
@@ -1,0 +1,75 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "legendutils.h"
+
+#include <algorithm>
+#include <filesystem>
+
+namespace fs = std::filesystem;
+
+namespace {
+std::string FindFileRecursive(const std::string &baseDir,
+                              const std::string &fileName) {
+  if (baseDir.empty())
+    return {};
+  for (auto &p : fs::recursive_directory_iterator(baseDir)) {
+    if (!p.is_regular_file())
+      continue;
+    if (p.path().filename() == fileName)
+      return p.path().string();
+  }
+  return {};
+}
+
+std::string NormalizePath(const std::string &path) {
+  std::string out = path;
+  char sep = static_cast<char>(fs::path::preferred_separator);
+  std::replace(out.begin(), out.end(), '\\', sep);
+  return out;
+}
+
+std::string NormalizeModelKey(const std::string &path) {
+  if (path.empty())
+    return {};
+  fs::path p(path);
+  p = p.lexically_normal();
+  return NormalizePath(p.string());
+}
+
+std::string ResolveGdtfPath(const std::string &base,
+                            const std::string &spec) {
+  if (spec.empty())
+    return {};
+  std::string norm = NormalizePath(spec);
+  fs::path p = base.empty() ? fs::path(norm) : fs::path(base) / norm;
+  if (fs::exists(p))
+    return p.string();
+  return FindFileRecursive(base, fs::path(norm).filename().string());
+}
+} // namespace
+
+std::string BuildFixtureSymbolKey(const Fixture &fixture,
+                                  const std::string &basePath) {
+  std::string gdtfPath = ResolveGdtfPath(basePath, fixture.gdtfSpec);
+  std::string modelKey = NormalizeModelKey(gdtfPath);
+  if (modelKey.empty() && !fixture.gdtfSpec.empty())
+    modelKey = NormalizeModelKey(fixture.gdtfSpec);
+  if (modelKey.empty() && !fixture.typeName.empty())
+    modelKey = fixture.typeName;
+  return modelKey;
+}

--- a/gui/legendutils.h
+++ b/gui/legendutils.h
@@ -1,0 +1,25 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <string>
+
+#include "fixture.h"
+
+std::string BuildFixtureSymbolKey(const Fixture &fixture,
+                                  const std::string &basePath);

--- a/viewer2d/symbolcache.cpp
+++ b/viewer2d/symbolcache.cpp
@@ -13,6 +13,7 @@ const SymbolDefinition &SymbolCache::GetOrCreate(const SymbolKey &key,
   ++misses_;
   const uint32_t symbolId = nextSymbolId_++;
   SymbolDefinition definition = builder ? builder(key, symbolId) : SymbolDefinition{};
+  definition.key = key;
   if (definition.symbolId == 0) {
     definition.symbolId = symbolId;
   }

--- a/viewer2d/symbolcache.h
+++ b/viewer2d/symbolcache.h
@@ -55,6 +55,7 @@ template <> struct hash<SymbolKey> {
 } // namespace std
 
 struct SymbolDefinition {
+  SymbolKey key{};
   uint32_t symbolId = 0;
   SymbolBounds bounds{};
   CommandBuffer localCommands{};

--- a/viewer2d/viewer2dpdfexporter.h
+++ b/viewer2d/viewer2dpdfexporter.h
@@ -60,11 +60,13 @@ struct LayoutLegendItem {
   std::string typeName;
   int count = 0;
   std::optional<int> channelCount;
+  std::string symbolKey;
 };
 
 struct LayoutLegendExportData {
   layouts::Layout2DViewFrame frame;
   std::vector<LayoutLegendItem> items;
+  std::shared_ptr<const SymbolDefinitionSnapshot> symbolSnapshot = nullptr;
 };
 
 // Writes the captured 2D drawing commands to a vector PDF that mirrors the


### PR DESCRIPTION
### Motivation
- Mostrar en las leyendas un símbolo reducido que represente cada tipo de objeto para mejorar la identificación visual. 
- Reutilizar los símbolos que ya se generan para la exportación/impresión en `viewer2d` para mantener consistencia entre vistas y PDF. 
- Incluir los símbolos también en la exportación a PDF de layouts para que las leyendas impresas muestren la misma iconografía. 

### Description
- Se añadió la clave de símbolo (`symbolKey`) a los elementos de leyenda y se rastrean símbolos por tipo; se creó `gui/legendutils.{h,cpp}` con `BuildFixtureSymbolKey` para resolver la clave desde `Fixture` y `basePath`. 
- El caché de símbolos ahora guarda la `SymbolKey` en `SymbolDefinition` y `SymbolCache::GetOrCreate` asigna esa clave para poder buscar la definición más adecuada por orientación. 
- En la UI se renderizan los símbolos en la columna inicial de la leyenda mediante `LayoutViewerPanel::BuildLegendImage` usando un backend ligerо (`LegendSymbolBackend`) y `viewer2d::Viewer2DCommandRenderer` para reproducir los comandos del símbolo a escala de línea de texto. 
- La exportación a PDF (`viewer2d/viewer2dpdfexporter.cpp`) incorpora los símbolos de leyenda: se capturan nombres XObject para símbolos usados por leyenda y se insertan en el flujo PDF con la escala y offset adecuados; además `LayoutLegendExportData` puede llevar un `symbolSnapshot`. 

### Testing
- No se ejecutaron pruebas automatizadas durante este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d3155bcf083248f37cfb37f5b63c4)