### PR TITLE
Populate legend symbol cache before rebuilding legend textures

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1016,6 +1016,12 @@ void LayoutViewerPanel::RebuildCachedTexture() {
 
   std::shared_ptr<const SymbolDefinitionSnapshot> legendSymbols =
       capturePanel->GetBottomSymbolCacheSnapshot();
+  if ((!legendSymbols || legendSymbols->empty()) &&
+      !currentLayout.legendViews.empty()) {
+    capturePanel->CaptureFrameNow(
+        [](CommandBuffer, Viewer2DViewState) {}, true, false);
+    legendSymbols = capturePanel->GetBottomSymbolCacheSnapshot();
+  }
   const double renderZoom = GetRenderZoom();
   for (const auto &view : currentLayout.view2dViews) {
     ViewCache &cache = GetViewCache(view.id);


### PR DESCRIPTION
### Motivation
- Legend symbols in layout legends were not appearing because the symbol snapshot could be empty when rebuilding legend textures.
- The texture rebuild path needs a populated bottom symbol cache so `BuildLegendImage` can render per-item symbols.
- Avoid missing legend symbols when a layout contains legend views but no prior symbol capture has occurred.

### Description
- In `LayoutViewerPanel::RebuildCachedTexture` call `CaptureFrameNow` when `GetBottomSymbolCacheSnapshot()` returns empty and `currentLayout.legendViews` is not empty to force a 2D frame capture.
- After the capture, refresh the `legendSymbols` snapshot by calling `GetBottomSymbolCacheSnapshot()` again so subsequent legend rendering uses the newly populated cache.
- The change touches `gui/layoutviewerpanel.cpp` and guards the capture behind the presence of legend views to minimize unnecessary captures.

### Testing
- No automated tests were run for this change.
- Change was compiled and committed locally (no test suite executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d3542645483248ea4a283b221cb74)