### PR TITLE
Skip zero-width strokes when rendering legend symbols

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -93,7 +93,10 @@ public:
   void DrawLine(const viewer2d::Viewer2DRenderPoint &p0,
                 const viewer2d::Viewer2DRenderPoint &p1,
                 const CanvasStroke &stroke, double strokeWidthPx) override {
-    wxPen pen(ToWxColor(stroke.color), std::max(1, (int)std::lround(strokeWidthPx)));
+    if (strokeWidthPx <= 0.0)
+      return;
+    wxPen pen(ToWxColor(stroke.color),
+              std::max(1, (int)std::lround(strokeWidthPx)));
     dc_.SetPen(pen);
     dc_.SetBrush(*wxTRANSPARENT_BRUSH);
     dc_.DrawLine(wxPoint(std::lround(p0.x), std::lround(p0.y)),
@@ -105,7 +108,10 @@ public:
                     double strokeWidthPx) override {
     if (points.empty())
       return;
-    wxPen pen(ToWxColor(stroke.color), std::max(1, (int)std::lround(strokeWidthPx)));
+    if (strokeWidthPx <= 0.0)
+      return;
+    wxPen pen(ToWxColor(stroke.color),
+              std::max(1, (int)std::lround(strokeWidthPx)));
     dc_.SetPen(pen);
     dc_.SetBrush(*wxTRANSPARENT_BRUSH);
     std::vector<wxPoint> wxPoints;
@@ -121,8 +127,13 @@ public:
                    double strokeWidthPx) override {
     if (points.empty())
       return;
-    wxPen pen(ToWxColor(stroke.color), std::max(1, (int)std::lround(strokeWidthPx)));
-    dc_.SetPen(pen);
+    if (strokeWidthPx > 0.0) {
+      wxPen pen(ToWxColor(stroke.color),
+                std::max(1, (int)std::lround(strokeWidthPx)));
+      dc_.SetPen(pen);
+    } else {
+      dc_.SetPen(*wxTRANSPARENT_PEN);
+    }
     if (fill) {
       dc_.SetBrush(wxBrush(ToWxColor(fill->color)));
     } else {
@@ -139,8 +150,13 @@ public:
   void DrawCircle(const viewer2d::Viewer2DRenderPoint &center, double radiusPx,
                   const CanvasStroke &stroke, const CanvasFill *fill,
                   double strokeWidthPx) override {
-    wxPen pen(ToWxColor(stroke.color), std::max(1, (int)std::lround(strokeWidthPx)));
-    dc_.SetPen(pen);
+    if (strokeWidthPx > 0.0) {
+      wxPen pen(ToWxColor(stroke.color),
+                std::max(1, (int)std::lround(strokeWidthPx)));
+      dc_.SetPen(pen);
+    } else {
+      dc_.SetPen(*wxTRANSPARENT_PEN);
+    }
     if (fill) {
       dc_.SetBrush(wxBrush(ToWxColor(fill->color)));
     } else {


### PR DESCRIPTION
### Motivation
- Legend symbols rendered in layout legends appeared as solid black blobs because zero-width strokes were still drawn with a minimum pen width.
- The legend rendering reuses the 2D command backend but must respect zero-width strokes (no outline) while preserving fills.

### Description
- Update `LegendSymbolBackend` in `gui/layoutviewerpanel.cpp` to ignore stroke drawing when `strokeWidthPx <= 0.0` in `DrawLine` and `DrawPolyline` by early returning. 
- For `DrawPolygon` and `DrawCircle` the code now selects `wxTRANSPARENT_PEN` when `strokeWidthPx <= 0.0` so fills remain visible but outlines are not drawn. 
- Kept existing behavior for non-zero strokes by constructing a `wxPen` with the rounded pixel width as before.

### Testing
- No automated tests were executed for this change. 
- Manual visual verification is expected to be used to confirm legend symbols no longer show solid outlines when strokes are zero.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d36f64fe083248f4af75b8ea258bc)