### PR TITLE
Render layout legend symbols with wxGraphicsContext (fallback to wxDC)

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -38,6 +38,7 @@
 #include "viewer2dcommandrenderer.h"
 #include "viewer2doffscreenrenderer.h"
 #include "viewer2dstate.h"
+#include <wx/graphics.h>
 #include <wx/filename.h>
 
 namespace {
@@ -88,7 +89,85 @@ wxColour ToWxColor(const CanvasColor &color) {
 
 class LegendSymbolBackend : public viewer2d::IViewer2DCommandBackend {
 public:
-  explicit LegendSymbolBackend(wxDC &dc) : dc_(dc) {}
+  explicit LegendSymbolBackend(wxGraphicsContext &gc) : gc_(gc) {}
+
+  void DrawLine(const viewer2d::Viewer2DRenderPoint &p0,
+                const viewer2d::Viewer2DRenderPoint &p1,
+                const CanvasStroke &stroke, double strokeWidthPx) override {
+    if (strokeWidthPx <= 0.0)
+      return;
+    gc_.SetPen(gc_.CreatePen(
+        wxGraphicsPenInfo(ToWxColor(stroke.color)).Width(strokeWidthPx)));
+    gc_.StrokeLine(p0.x, p0.y, p1.x, p1.y);
+  }
+
+  void DrawPolyline(const std::vector<viewer2d::Viewer2DRenderPoint> &points,
+                    const CanvasStroke &stroke,
+                    double strokeWidthPx) override {
+    if (points.empty())
+      return;
+    if (strokeWidthPx <= 0.0)
+      return;
+    wxGraphicsPath path = gc_.CreatePath();
+    path.MoveToPoint(points.front().x, points.front().y);
+    for (size_t i = 1; i < points.size(); ++i) {
+      path.AddLineToPoint(points[i].x, points[i].y);
+    }
+    gc_.SetPen(gc_.CreatePen(
+        wxGraphicsPenInfo(ToWxColor(stroke.color)).Width(strokeWidthPx)));
+    gc_.StrokePath(path);
+  }
+
+  void DrawPolygon(const std::vector<viewer2d::Viewer2DRenderPoint> &points,
+                   const CanvasStroke &stroke, const CanvasFill *fill,
+                   double strokeWidthPx) override {
+    if (points.empty())
+      return;
+    wxGraphicsPath path = gc_.CreatePath();
+    path.MoveToPoint(points.front().x, points.front().y);
+    for (size_t i = 1; i < points.size(); ++i) {
+      path.AddLineToPoint(points[i].x, points[i].y);
+    }
+    path.CloseSubpath();
+    if (fill) {
+      gc_.SetBrush(gc_.CreateBrush(wxBrush(ToWxColor(fill->color))));
+      gc_.FillPath(path);
+    }
+    if (strokeWidthPx > 0.0) {
+      gc_.SetPen(gc_.CreatePen(
+          wxGraphicsPenInfo(ToWxColor(stroke.color)).Width(strokeWidthPx)));
+      gc_.StrokePath(path);
+    }
+  }
+
+  void DrawCircle(const viewer2d::Viewer2DRenderPoint &center, double radiusPx,
+                  const CanvasStroke &stroke, const CanvasFill *fill,
+                  double strokeWidthPx) override {
+    if (!fill && strokeWidthPx <= 0.0)
+      return;
+    if (fill) {
+      gc_.SetBrush(gc_.CreateBrush(wxBrush(ToWxColor(fill->color))));
+    }
+    if (strokeWidthPx > 0.0) {
+      gc_.SetPen(gc_.CreatePen(
+          wxGraphicsPenInfo(ToWxColor(stroke.color)).Width(strokeWidthPx)));
+    }
+    const double diameter = radiusPx * 2.0;
+    gc_.DrawEllipse(center.x - radiusPx, center.y - radiusPx, diameter,
+                    diameter);
+  }
+
+  void DrawText(const viewer2d::Viewer2DRenderText &text) override {
+    (void)text;
+  }
+
+private:
+  wxGraphicsContext &gc_;
+};
+
+class LegendSymbolFallbackBackend : public viewer2d::IViewer2DCommandBackend {
+public:
+  explicit LegendSymbolFallbackBackend(wxDC &dc) : dc_(dc) {}
 
   void DrawLine(const viewer2d::Viewer2DRenderPoint &p0,
                 const viewer2d::Viewer2DRenderPoint &p1,
@@ -1566,7 +1645,16 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   y += 2;
 
   dc.SetFont(baseFont);
-  LegendSymbolBackend backend(dc);
+  std::unique_ptr<wxGraphicsContext> graphics(wxGraphicsContext::Create(dc));
+  if (graphics) {
+    graphics->SetAntialiasMode(wxANTIALIAS_DEFAULT);
+  }
+  std::unique_ptr<viewer2d::IViewer2DCommandBackend> backend;
+  if (graphics) {
+    backend = std::make_unique<LegendSymbolBackend>(*graphics);
+  } else {
+    backend = std::make_unique<LegendSymbolFallbackBackend>(dc);
+  }
   for (const auto &item : items) {
     if (y + lineHeight > size.GetHeight() - padding)
       break;
@@ -1600,7 +1688,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
           mapping.offsetX = symbolDrawLeft;
           mapping.offsetY = symbolDrawTop;
           mapping.drawHeight = drawH;
-          viewer2d::Viewer2DCommandRenderer renderer(mapping, backend, symbols);
+          viewer2d::Viewer2DCommandRenderer renderer(mapping, *backend, symbols);
           renderer.Render(symbol->localCommands);
         }
       }


### PR DESCRIPTION
### Motivation
- Legend symbols rendered in the layout view appeared as solid/incorrect shapes because the previous `wxDC` drawing path did not preserve symbol stroke widths and alpha at the small legend sizes. 
- The symbols used for schematics are available as viewer symbol definitions, so the legend should render the same symbol commands to keep visual parity. 
- Use the same 2D command rendering pipeline (`Viewer2DCommandRenderer`) but drive it with a backend that preserves vector stroke/alpha semantics at small scales. 
- Provide a safe fallback to the original `wxDC` drawing path when a `wxGraphicsContext` cannot be created. 

### Description
- Added `#include <wx/graphics.h>` and replaced the legend backend to prefer a `wxGraphicsContext`-based implementation by introducing `LegendSymbolBackend` that draws lines, polylines, polygons and circles using `wxGraphicsContext` APIs. 
- Added `LegendSymbolFallbackBackend` which preserves the previous `wxDC` drawing behavior and is used when `wxGraphicsContext::Create(dc)` returns `nullptr`. 
- When building legend images in `BuildLegendImage`, create a `wxGraphicsContext` and choose between the `LegendSymbolBackend` and `LegendSymbolFallbackBackend`, then pass the chosen backend to `Viewer2DCommandRenderer` as `*backend` so symbol command rendering is reused unchanged. 
- Kept symbol measurement/scale and mapping logic unchanged so exported PDFs and existing layouts keep consistent symbol placement. 

### Testing
- No automated tests were executed for this change. 
- The patch only touches `gui/layoutviewerpanel.cpp` and wiring for legend rendering backends. 
- No compile or CI results are included in this rollout. 
- Manual runtime verification was not recorded by the automated rollout steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d39da3aec8324ac0f2c36ede4304f)