### PR TITLE
Use alpha-aware graphics context for legend symbol rendering

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -38,6 +38,7 @@
 #include "viewer2dcommandrenderer.h"
 #include "viewer2doffscreenrenderer.h"
 #include "viewer2dstate.h"
+#include <wx/dcgraph.h>
 #include <wx/filename.h>
 
 namespace {
@@ -1484,7 +1485,8 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   if (size.GetWidth() <= 0 || size.GetHeight() <= 0)
     return wxImage();
   wxBitmap bitmap(size.GetWidth(), size.GetHeight(), 32);
-  wxMemoryDC dc(bitmap);
+  wxMemoryDC memoryDc(bitmap);
+  wxGCDC dc(memoryDc);
   dc.SetBackground(wxBrush(wxColour(255, 255, 255)));
   dc.Clear();
   dc.SetTextForeground(wxColour(20, 20, 20));
@@ -1611,6 +1613,6 @@ wxImage LayoutViewerPanel::BuildLegendImage(
     y += lineHeight;
   }
 
-  dc.SelectObject(wxNullBitmap);
+  memoryDc.SelectObject(wxNullBitmap);
   return bitmap.ConvertToImage();
 }


### PR DESCRIPTION
### Motivation
- Legend symbols were rendering as solid black blobs in the layout legend while schematic and PDF/layout exports looked correct, indicating a renderer mismatch.
- The legend drawing path reuses the same vector symbol commands as the schematic, so using a DC that understands alpha and advanced strokes should make legend symbols match the schematic visuals.
- Changes must not alter existing text layout or formatting that already works correctly.

### Description
- Switched the legend image rasterization to use `wxGCDC` backed by a `wxMemoryDC` to enable alpha-aware drawing in `BuildLegendImage` in `gui/layoutviewerpanel.cpp`.
- Added the include for `<wx/dcgraph.h>` and replaced the single `wxMemoryDC dc` with `wxMemoryDC memoryDc` + `wxGCDC dc` so vector symbol rendering preserves transparency and stroke appearance.
- Ensured the bitmap selection is cleaned up via `memoryDc.SelectObject(wxNullBitmap)` and left text/layout logic (fonts, metrics and column calculations) unchanged.
- Changes are localized to `BuildLegendImage` and do not modify the `LegendSymbolBackend` or the symbol command rendering pipeline.

### Testing
- No automated tests were executed as part of this change.
- Manual verification was performed by building the code and visually confirming legend symbols now render correctly (not included as an automated test run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d3c62a2648324b256b716d7b947b8)