### PR TITLE
Fix legend font sizing across zoom levels

### DIFF
--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -114,7 +114,8 @@ private:
   LegendCache &GetLegendCache(int legendId);
   std::vector<LegendItem> BuildLegendItems() const;
   size_t HashLegendItems(const std::vector<LegendItem> &items) const;
-  wxImage BuildLegendImage(const wxSize &size,
+  wxImage BuildLegendImage(const wxSize &size, const wxSize &logicalSize,
+                           double renderZoom,
                            const std::vector<LegendItem> &items,
                            const SymbolDefinitionSnapshot *symbols) const;
 


### PR DESCRIPTION
### Motivation
- Legends on layouts changed their visible font size when the viewer zoom level changed, causing inconsistent and incorrect rendering.
- The goal is to render legend text in logical frame units and scale layout metrics by the render zoom so typography remains stable across zoom levels.

### Description
- Change the signature of `BuildLegendImage` to accept a logical size and `renderZoom` (`wxImage BuildLegendImage(const wxSize &size, const wxSize &logicalSize, double renderZoom, ...)`).
- Update the call site in `RebuildCachedTexture` to pass `wxSize(legend.frame.width, legend.frame.height)` and the current `renderZoom` to `BuildLegendImage`.
- Compute font sizes and spacing from the logical frame height and then scale to pixels using `renderZoom` (introduce `fontSizePx`, `paddingPx`, `columnGapPx`, and scale line spacing accordingly) and guard against invalid `renderZoom`.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d403ccd8c8324a9888dc0c0384e30)