### PR TITLE
Fix legend symbol stroke scaling

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -91,17 +91,16 @@ class LegendSymbolBackend : public viewer2d::IViewer2DCommandBackend {
 public:
   explicit LegendSymbolBackend(wxDC &dc) : dc_(dc) {}
 
-  static int StrokeWidthPx(const CanvasStroke &stroke) {
-    if (stroke.width <= 0.0f)
+  static int StrokeWidthPx(double strokeWidthPx) {
+    if (strokeWidthPx <= 0.0)
       return 0;
-    return std::max(1, static_cast<int>(std::lround(stroke.width)));
+    return std::max(1, static_cast<int>(std::lround(strokeWidthPx)));
   }
 
   void DrawLine(const viewer2d::Viewer2DRenderPoint &p0,
                 const viewer2d::Viewer2DRenderPoint &p1,
                 const CanvasStroke &stroke, double strokeWidthPx) override {
-    (void)strokeWidthPx;
-    int strokeWidth = StrokeWidthPx(stroke);
+    int strokeWidth = StrokeWidthPx(strokeWidthPx);
     if (strokeWidth <= 0)
       return;
     wxPen pen(ToWxColor(stroke.color), strokeWidth);
@@ -116,8 +115,7 @@ public:
                     double strokeWidthPx) override {
     if (points.empty())
       return;
-    (void)strokeWidthPx;
-    int strokeWidth = StrokeWidthPx(stroke);
+    int strokeWidth = StrokeWidthPx(strokeWidthPx);
     if (strokeWidth <= 0)
       return;
     wxPen pen(ToWxColor(stroke.color), strokeWidth);
@@ -136,8 +134,7 @@ public:
                    double strokeWidthPx) override {
     if (points.empty())
       return;
-    (void)strokeWidthPx;
-    int strokeWidth = StrokeWidthPx(stroke);
+    int strokeWidth = StrokeWidthPx(strokeWidthPx);
     if (strokeWidth > 0) {
       wxPen pen(ToWxColor(stroke.color), strokeWidth);
       dc_.SetPen(pen);
@@ -160,8 +157,7 @@ public:
   void DrawCircle(const viewer2d::Viewer2DRenderPoint &center, double radiusPx,
                   const CanvasStroke &stroke, const CanvasFill *fill,
                   double strokeWidthPx) override {
-    (void)strokeWidthPx;
-    int strokeWidth = StrokeWidthPx(stroke);
+    int strokeWidth = StrokeWidthPx(strokeWidthPx);
     if (strokeWidth > 0) {
       wxPen pen(ToWxColor(stroke.color), strokeWidth);
       dc_.SetPen(pen);


### PR DESCRIPTION
### Motivation
- Legend symbols in layout thumbnails were rendering as tiny dots or blobs instead of matching the 2D viewer output.
- The 2D renderer provides a pixel stroke width for commands which the legend backend was not using.
- Align legend drawing with the `viewer2d` rendering pipeline to produce clean, consistent symbols.

### Description
- Change `StrokeWidthPx` to accept the renderer-provided `double strokeWidthPx` instead of reading `CanvasStroke::width`.
- Update `LegendSymbolBackend` implementations of `DrawLine`, `DrawPolyline`, `DrawPolygon`, and `DrawCircle` to compute pen widths from the passed `strokeWidthPx` parameter.
- Keep color and fill handling unchanged while ensuring stroke scaling matches `viewer2d` output.
- Code changes are limited to `gui/layoutviewerpanel.cpp`.

### Testing
- No automated tests were executed for this change.
- The change was committed locally; no CI/test run was performed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d43c626d483249ff8230e9e41ea4b)