### PR TITLE
Fix legend symbol stroke scaling

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -98,7 +98,12 @@ public:
     drawFills_ = drawFills;
   }
 
-  static int StrokeWidthPx(double strokeWidthPx) {
+  void SetStrokeScale(double scale) {
+    strokeScale_ = scale;
+  }
+
+  int StrokeWidthPx(double strokeWidthPx) const {
+    strokeWidthPx *= strokeScale_;
     if (strokeWidthPx <= 0.0)
       return 0;
     return std::max(1, static_cast<int>(std::lround(strokeWidthPx)));
@@ -235,6 +240,7 @@ private:
   wxGraphicsContext *gc_ = nullptr;
   bool drawStrokes_ = true;
   bool drawFills_ = true;
+  double strokeScale_ = 1.0;
 };
 constexpr double kMinZoom = 0.1;
 constexpr double kMaxZoom = 10.0;
@@ -1676,6 +1682,9 @@ wxImage LayoutViewerPanel::BuildLegendImage(
           mapping.offsetY = symbolDrawTop;
           mapping.drawHeight = drawH;
           viewer2d::Viewer2DCommandRenderer renderer(mapping, backend, symbols);
+          double strokeScale =
+              mapping.scale > 0.0 ? (renderZoom / mapping.scale) : renderZoom;
+          backend.SetStrokeScale(strokeScale);
           backend.SetRenderMode(true, false);
           renderer.Render(symbol->localCommands);
           backend.SetRenderMode(false, true);


### PR DESCRIPTION
### Motivation
- Legend symbol strokes were rendering too thick because stroke widths were not adjusted to account for the icon scaling used when drawing symbols in legends.
- The legend rendering path scales symbol geometry independently of stroke widths, producing visually oversized strokes at small or large icon scales.
- The intent is to apply a scale factor to stroke widths so strokes keep consistent visual thickness when symbols are scaled for legend thumbnails.

### Description
- Add a `strokeScale_` member and `SetStrokeScale()` to `LegendSymbolBackend` and change `StrokeWidthPx()` to multiply the incoming width by this scale.
- Before rendering each symbol, compute `strokeScale` as `mapping.scale > 0.0 ? (renderZoom / mapping.scale) : renderZoom` and call `backend.SetStrokeScale(strokeScale)` so strokes are adjusted to the legend rendering zoom.
- Keep the rest of the symbol rendering flow intact, only adjusting the stroke width calculation used to create `wxPen` instances.

### Testing
- No automated tests were executed for this change.
- The change is limited to `gui/layoutviewerpanel.cpp` and compiles as part of the project build in local commits (no CI results included).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d4b29181c8324bf12a6e23b267cda)