### PR TITLE
Adjust legend row height and symbol sizing

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1604,7 +1604,12 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   dc.GetTextExtent("Hg", &lineWidth, &lineHeight);
   lineHeight += std::max(1, static_cast<int>(std::lround(2.0 * renderZoom)));
 
-  int symbolSize = std::max(4, lineHeight - 2);
+  const double rowHeight =
+      totalRows > 0 ? static_cast<double>(availableHeight) / totalRows : 0.0;
+  const int rowHeightPx =
+      std::max(lineHeight,
+               static_cast<int>(std::lround(rowHeight * renderZoom)));
+  int symbolSize = std::max(4, rowHeightPx - 2);
   const int paddingPx =
       std::max(0, static_cast<int>(std::lround(padding * renderZoom)));
   const int columnGapPx =
@@ -1641,7 +1646,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   dc.DrawText("Type", xType, y);
   dc.DrawText("Ch Count", xCh, y);
 
-  y += lineHeight;
+  y += rowHeightPx;
   dc.SetPen(wxPen(wxColour(200, 200, 200)));
   dc.DrawLine(paddingPx, y, size.GetWidth() - paddingPx, y);
   y += std::max(1, static_cast<int>(std::lround(2.0 * renderZoom)));
@@ -1649,7 +1654,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   dc.SetFont(baseFont);
   LegendSymbolBackend backend(dc);
   for (const auto &item : items) {
-    if (y + lineHeight > size.GetHeight() - paddingPx)
+    if (y + rowHeightPx > size.GetHeight() - paddingPx)
       break;
     wxString countText = wxString::Format("%d", item.count);
     wxString typeText =
@@ -1672,7 +1677,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
           double symbolDrawLeft =
               xSymbol + (static_cast<double>(symbolSize) - drawW) * 0.5;
           double symbolDrawTop =
-              y + (static_cast<double>(lineHeight) - drawH) * 0.5;
+              y + (static_cast<double>(rowHeightPx) - drawH) * 0.5;
 
           viewer2d::Viewer2DRenderMapping mapping{};
           mapping.minX = symbol->bounds.min.x;
@@ -1695,7 +1700,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
     dc.DrawText(countText, xCount, y);
     dc.DrawText(typeText, xType, y);
     dc.DrawText(chText, xCh, y);
-    y += lineHeight;
+    y += rowHeightPx;
   }
 
   memoryDc.SelectObject(wxNullBitmap);


### PR DESCRIPTION
### Motivation
- Legend symbols and rows were rendering too small because the symbol size used text line height instead of the available frame row height. 
- The goal is to compute each legend row height from the available frame height so symbols scale to fit the legend area while preserving text layout.

### Description
- Compute `rowHeight` from `availableHeight / totalRows` and convert to pixels as `rowHeightPx` inside `LayoutViewerPanel::BuildLegendImage` in `gui/layoutviewerpanel.cpp`.
- Use `rowHeightPx` when deriving `symbolSize`, advancing the `y` position between rows, and when testing row bounds to ensure symbols and text align vertically within each row.
- Adjust symbol vertical centering to use `rowHeightPx` instead of the previous `lineHeight` so symbols occupy the full row height when space allows.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d4d20dba0832482e692c1761c522d)