### PR TITLE
Increase legend font size cap to allow larger legend symbols

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1571,7 +1571,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   double fontSize =
       totalRows > 0 ? (static_cast<double>(availableHeight) / totalRows) - 2.0
                     : 10.0;
-  fontSize = std::clamp(fontSize, 6.0, 14.0);
+  fontSize = std::clamp(fontSize, 6.0, 72.0);
   const int fontSizePx =
       std::max(1, static_cast<int>(std::lround(fontSize * renderZoom)));
 

--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -1561,7 +1561,7 @@ Viewer2DExportResult ExportLayoutToPdf(
     const double availableHeight = frameH - padding * 2.0;
     double fontSize =
         totalRows > 0 ? (availableHeight / totalRows) - 2.0 : 10.0;
-    fontSize = std::clamp(fontSize, 6.0, 14.0);
+    fontSize = std::clamp(fontSize, 6.0, 72.0);
 
     double maxCountWidth = measureTextWidth("Count", fontSize);
     double maxChWidth = measureTextWidth("Ch Count", fontSize);


### PR DESCRIPTION
### Motivation
- Legend symbols in layout views and exported PDFs were rendered too small because the font-size cap limited scaling. 
- The UI and PDF export used a very low maximum font size which prevented legend symbols from growing with zoom. 
- The intent is to allow larger legend text so symbol graphics scale up to a visually appropriate size. 
- Keep rendering behavior consistent between on-screen legend bitmaps and PDF exports. 

### Description
- Raised the upper bound of the computed legend `fontSize` from `14.0` to `72.0` in `gui/layoutviewerpanel.cpp` within `BuildLegendImage`. 
- Made the matching change in `viewer2d/viewer2dpdfexporter.cpp` inside `ExportLayoutToPdf` so PDF legend export uses the same cap. 
- This increases the derived `fontSize` used to calculate line height and `symbolSize`, allowing larger symbol renders. 
- No other layout or rendering logic was modified, preserving existing layout math and clamping lower bound. 

### Testing
- No automated tests were executed for this change. 
- The patch only adjusts numeric caps and does not add new test cases. 
- A build and manual UI/PDF verification are recommended to confirm visual results. 
- No regressions were detected by automated checks because none were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d4f4955e483249eb7bc423c107f2f)