### PR TITLE
Increase legend symbol size and adjust row height for UI and PDF export

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1604,12 +1604,16 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   dc.GetTextExtent("Hg", &lineWidth, &lineHeight);
   lineHeight += std::max(1, static_cast<int>(std::lround(2.0 * renderZoom)));
 
+  constexpr double kLegendSymbolScale = 4.0;
+  const int symbolRowPadding =
+      std::max(1, static_cast<int>(std::lround(2.0 * renderZoom)));
   const double rowHeight =
       totalRows > 0 ? static_cast<double>(availableHeight) / totalRows : 0.0;
-  const int rowHeightPx =
-      std::max(lineHeight,
-               static_cast<int>(std::lround(rowHeight * renderZoom)));
-  int symbolSize = std::max(4, rowHeightPx - 2);
+  int rowHeightPx = std::max(
+      lineHeight, static_cast<int>(std::lround(rowHeight * renderZoom)));
+  int symbolSize = std::max(
+      4, static_cast<int>(std::lround(lineHeight * kLegendSymbolScale)));
+  rowHeightPx = std::max(rowHeightPx, symbolSize + symbolRowPadding);
   const int paddingPx =
       std::max(0, static_cast<int>(std::lround(padding * renderZoom)));
   const int columnGapPx =

--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -1575,8 +1575,10 @@ Viewer2DExportResult ExportLayoutToPdf(
                             measureTextWidth(chText, fontSize));
     }
 
-    const double lineHeight = fontSize + 2.0;
-    const double symbolSize = std::max(4.0, lineHeight - 2.0);
+    constexpr double kLegendSymbolScale = 4.0;
+    const double baseLineHeight = fontSize + 2.0;
+    const double symbolSize = std::max(4.0, baseLineHeight * kLegendSymbolScale);
+    const double lineHeight = std::max(baseLineHeight, symbolSize + 2.0);
     double xSymbol = frameX + padding;
     double xCount = xSymbol + symbolSize + columnGap;
     double xType = xCount + maxCountWidth + columnGap;


### PR DESCRIPTION
### Motivation
- Legend symbols in layout legends were visually too small compared to the text because symbol sizing was derived from a row height that didn't scale the symbol relative to the text baseline. 
- The PDF exporter used a different sizing heuristic, so exported legends could diverge from the on-screen appearance.

### Description
- Introduce a scale constant `kLegendSymbolScale` and compute `symbolSize` from the text `lineHeight` in `BuildLegendImage` to increase symbol size relative to text. 
- Ensure `rowHeightPx` is at least `symbolSize + symbolRowPadding` so rows accommodate the larger symbols without clipping. 
- Mirror the same sizing approach in the PDF exporter by computing `symbolSize` from a `baseLineHeight` and clamping `lineHeight` to fit the symbol. 
- Changes applied to `gui/layoutviewerpanel.cpp` and `viewer2d/viewer2dpdfexporter.cpp`.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d50744a248324b763f6ae728f828d)