### PR TITLE
Increase layout legend symbol size and align rendering with 2D viewer

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1609,7 +1609,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   const int rowHeightPx =
       std::max(lineHeight,
                static_cast<int>(std::lround(rowHeight * renderZoom)));
-  int symbolSize = std::max(4, rowHeightPx - 2);
+  int symbolSize = std::max(4, rowHeightPx);
   const int paddingPx =
       std::max(0, static_cast<int>(std::lround(padding * renderZoom)));
   const int columnGapPx =
@@ -1690,9 +1690,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
           double strokeScale =
               mapping.scale > 0.0 ? (renderZoom / mapping.scale) : renderZoom;
           backend.SetStrokeScale(strokeScale);
-          backend.SetRenderMode(true, false);
-          renderer.Render(symbol->localCommands);
-          backend.SetRenderMode(false, true);
+          backend.SetRenderMode(true, true);
           renderer.Render(symbol->localCommands);
         }
       }

--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -1576,7 +1576,7 @@ Viewer2DExportResult ExportLayoutToPdf(
     }
 
     const double lineHeight = fontSize + 2.0;
-    const double symbolSize = std::max(4.0, lineHeight - 2.0);
+    const double symbolSize = std::max(4.0, lineHeight);
     double xSymbol = frameX + padding;
     double xCount = xSymbol + symbolSize + columnGap;
     double xType = xCount + maxCountWidth + columnGap;


### PR DESCRIPTION
### Motivation
- Legend symbols in layout exports were too small and were rendered using a different process than the 2D viewer, producing inconsistent visuals.
- The intended goal is to reuse the same rendering logic and increase symbol size without changing text or line metrics.

### Description
- Increased on-screen legend symbol size by using `rowHeightPx` instead of `rowHeightPx - 2` in `LayoutViewerPanel::BuildLegendImage` to make symbols larger while preserving text sizing.
- Rendered symbol fills and strokes together for legend icons by calling `backend.SetRenderMode(true, true)` before `Viewer2DCommandRenderer::Render` to match the 2D viewer behavior.
- Kept PDF export symbol sizing in sync by changing `symbolSize` calculation in `viewer2d/viewer2dpdfexporter.cpp` to use `std::max(4.0, lineHeight)`.

### Testing
- No automated tests were run for this change.
- Affected files: `gui/layoutviewerpanel.cpp` and `viewer2d/viewer2dpdfexporter.cpp` were modified and committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d5498879483248977789670f29444)