### PR TITLE
Increase legend symbol size and align legend drawing with 2D renderer

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -251,6 +251,7 @@ constexpr int kHandleSizePx = 10;
 constexpr int kHandleHalfPx = kHandleSizePx / 2;
 constexpr int kHandleHoverPadPx = 6;
 constexpr int kMinFrameSize = 24;
+constexpr double kLegendSymbolScale = 1.4;
 constexpr int kEditMenuId = wxID_HIGHEST + 490;
 constexpr int kDeleteMenuId = wxID_HIGHEST + 491;
 constexpr int kDeleteLegendMenuId = wxID_HIGHEST + 492;
@@ -1606,10 +1607,12 @@ wxImage LayoutViewerPanel::BuildLegendImage(
 
   const double rowHeight =
       totalRows > 0 ? static_cast<double>(availableHeight) / totalRows : 0.0;
-  const int rowHeightPx =
+  const int baseRowHeightPx =
       std::max(lineHeight,
                static_cast<int>(std::lround(rowHeight * renderZoom)));
-  int symbolSize = std::max(4, rowHeightPx);
+  const int symbolSize = std::max(
+      4, static_cast<int>(std::lround(baseRowHeightPx * kLegendSymbolScale)));
+  const int rowHeightPx = std::max(baseRowHeightPx, symbolSize);
   const int paddingPx =
       std::max(0, static_cast<int>(std::lround(padding * renderZoom)));
   const int columnGapPx =
@@ -1687,9 +1690,6 @@ wxImage LayoutViewerPanel::BuildLegendImage(
           mapping.offsetY = symbolDrawTop;
           mapping.drawHeight = drawH;
           viewer2d::Viewer2DCommandRenderer renderer(mapping, backend, symbols);
-          double strokeScale =
-              mapping.scale > 0.0 ? (renderZoom / mapping.scale) : renderZoom;
-          backend.SetStrokeScale(strokeScale);
           backend.SetRenderMode(true, true);
           renderer.Render(symbol->localCommands);
         }


### PR DESCRIPTION
### Motivation
- Legend symbols in layout exports were rendered smaller than in the 2D viewers and used a different scaling approach, producing inconsistent visuals. 
- The intent is to reuse the same drawing code/behavior as the 2D viewer so symbols in layout legends match on-screen symbols.

### Description
- Added a new constant `kLegendSymbolScale` and increased the computed legend symbol size in `gui/layoutviewerpanel.cpp` so symbols are larger without changing text metrics. 
- Changed the row/symbol sizing logic in `BuildLegendImage` to compute a `baseRowHeightPx`, scale the symbol by `kLegendSymbolScale`, and ensure `rowHeightPx` accommodates the larger symbol. 
- Removed the custom stroke scaling previously applied to the legend symbol backend so rendering now follows the same stroke behavior as the 2D viewer command renderer. 
- All changes are localized to `gui/layoutviewerpanel.cpp` (legend image building and layout constants).

### Testing
- No automated tests were run for this change. 
- A minimal compile/commit cycle was performed locally (no test suite execution requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d55f9aa74832489107e42aa825a93)