### PR TITLE
Include wx/event for custom event definition

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -28,6 +28,7 @@
 #include <fstream>
 #include <functional>
 #include <iterator>
+#include <wx/event.h>
 #include <map>
 #include <memory>
 #include <optional>


### PR DESCRIPTION
### Motivation
- `gui/mainwindow.cpp` uses the `wxDEFINE_EVENT(EVT_PROJECT_LOADED, wxCommandEvent)` macro but static analysis reported the definition was not found, indicating a missing event header. 
- Adding the wxWidgets event header ensures the custom event macro resolves and avoids warnings or potential build issues.
- This change is limited and intended to fix the missing-symbol warning without altering runtime behavior.

### Description
- Add an explicit `#include <wx/event.h>` to `gui/mainwindow.cpp` so `wxDEFINE_EVENT` is available.
- No other code or event handling logic was modified.
- The only file changed is `gui/mainwindow.cpp`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d5c0243888324b39c21a61a7b0fe7)