### PR TITLE
Include viewer2dcommandrenderer.h in layoutviewerpanel.cpp

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -35,6 +35,7 @@
 #include "legendutils.h"
 #include "layouts/LayoutManager.h"
 #include "mainwindow.h"
+#include "viewer2dcommandrenderer.h"
 #include "viewer2doffscreenrenderer.h"
 #include "viewer2dstate.h"
 #include <wx/dcgraph.h>


### PR DESCRIPTION
### Motivation

- Resolve compiler errors in `gui/layoutviewerpanel.cpp` caused by missing declarations for legend rendering types such as `viewer2d::Viewer2DRenderPoint`, `viewer2d::Viewer2DRenderMapping`, and `viewer2d::IViewer2DCommandBackend`.
- Ensure the legend rendering implementation in this file has the proper type and interface definitions available.

### Description

- Add `#include "viewer2dcommandrenderer.h"` to `gui/layoutviewerpanel.cpp` so the viewer2d rendering types and backend interface are defined.
- No other source changes were made.

### Testing

- No automated tests were run after this change.
- The change is targeted to fix the compilation failures caused by missing type declarations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d5d66b99c8324a8d80b0b4eac1d5c)