### PR TITLE
Ajustar escala de símbolos en leyendas

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -494,7 +494,7 @@ constexpr int kHandleSizePx = 10;
 constexpr int kHandleHalfPx = kHandleSizePx / 2;
 constexpr int kHandleHoverPadPx = 6;
 constexpr int kMinFrameSize = 24;
-constexpr double kLegendSymbolScale = 1.4;
+constexpr double kLegendSymbolScale = 5.0;
 constexpr int kEditMenuId = wxID_HIGHEST + 490;
 constexpr int kDeleteMenuId = wxID_HIGHEST + 491;
 constexpr int kDeleteLegendMenuId = wxID_HIGHEST + 492;
@@ -1856,10 +1856,9 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   const int baseRowHeightPx =
       std::max(lineHeight,
                static_cast<int>(std::lround(rowHeight * renderZoom)));
-  const int desiredSymbolSize = std::max(
+  const int symbolSize = std::max(
       4, static_cast<int>(std::lround(baseRowHeightPx * kLegendSymbolScale)));
-  const int symbolSize = std::min(baseRowHeightPx, desiredSymbolSize);
-  const int rowHeightPx = baseRowHeightPx;
+  const int rowHeightPx = std::max(baseRowHeightPx, symbolSize);
   const int paddingPx =
       std::max(0, static_cast<int>(std::lround(padding * renderZoom)));
   const int columnGapPx =

--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -50,6 +50,7 @@ constexpr float PDF_TEXT_ASCENT_FACTOR = 0.718f;
 // Complements the ascent factor using Helvetica's 207 unit descent as a
 // fallback for text that does not provide explicit metrics.
 constexpr float PDF_TEXT_DESCENT_FACTOR = 0.207f;
+constexpr double kLegendSymbolScale = 5.0;
 
 static bool ShouldTraceLabelOrder() {
   static const bool enabled = std::getenv("PERASTAGE_TRACE_LABELS") != nullptr;
@@ -1575,8 +1576,9 @@ Viewer2DExportResult ExportLayoutToPdf(
                             measureTextWidth(chText, fontSize));
     }
 
-    const double lineHeight = fontSize + 2.0;
-    const double symbolSize = std::max(4.0, lineHeight);
+    double lineHeight = fontSize + 2.0;
+    const double symbolSize = std::max(4.0, lineHeight * kLegendSymbolScale);
+    lineHeight = std::max(lineHeight, symbolSize);
     double xSymbol = frameX + padding;
     double xCount = xSymbol + symbolSize + columnGap;
     double xType = xCount + maxCountWidth + columnGap;


### PR DESCRIPTION
### Motivation
- Layout legend symbols were rendered much smaller than expected because a legend-specific scale factor was too small or not applied consistently. 
- The PDF exporter and on-screen legend rendering used different sizing heuristics causing inconsistent symbol sizes between UI and exports. 
- The goal is to apply a larger, consistent scale to legend symbols so icons in legends are visually appropriate without changing other behavior. 

### Description
- Increased the legend symbol scale constant from `1.4` to `5.0` and added `kLegendSymbolScale` to `viewer2d/viewer2dpdfexporter.cpp` to align PDF exports with the UI. 
- In `gui/layoutviewerpanel.cpp` changed symbol sizing to compute `symbolSize = std::max(4, round(baseRowHeightPx * kLegendSymbolScale))` and made the row height `rowHeightPx = std::max(baseRowHeightPx, symbolSize)` so rows accommodate the enlarged symbols. 
- In `viewer2d/viewer2dpdfexporter.cpp` changed the legend PDF sizing to compute `symbolSize = std::max(4.0, lineHeight * kLegendSymbolScale)` and then `lineHeight = std::max(lineHeight, symbolSize)` so PDF legend symbols match on-screen size. 
- Only the legend symbol sizing/row-height computations were modified; no other rendering logic was changed. 

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d5f26a28c83249408477e13b6abbe)