### PR TITLE
Fix legend row height when scaling symbols

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1856,9 +1856,12 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   const int baseRowHeightPx =
       std::max(lineHeight,
                static_cast<int>(std::lround(rowHeight * renderZoom)));
-  const int symbolSize = std::max(
-      4, static_cast<int>(std::lround(baseRowHeightPx * kLegendSymbolScale)));
-  const int rowHeightPx = std::max(baseRowHeightPx, symbolSize);
+  const int desiredSymbolSize =
+      static_cast<int>(std::lround(baseRowHeightPx * kLegendSymbolScale));
+  const int maxSymbolSize = std::max(4, baseRowHeightPx);
+  const int symbolSize =
+      std::clamp(desiredSymbolSize, 4, maxSymbolSize);
+  const int rowHeightPx = baseRowHeightPx;
   const int paddingPx =
       std::max(0, static_cast<int>(std::lround(padding * renderZoom)));
   const int columnGapPx =

--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -1576,9 +1576,10 @@ Viewer2DExportResult ExportLayoutToPdf(
                             measureTextWidth(chText, fontSize));
     }
 
-    double lineHeight = fontSize + 2.0;
-    const double symbolSize = std::max(4.0, lineHeight * kLegendSymbolScale);
-    lineHeight = std::max(lineHeight, symbolSize);
+    const double lineHeight = fontSize + 2.0;
+    const double maxSymbolSize = std::max(4.0, lineHeight);
+    const double symbolSize = std::clamp(lineHeight * kLegendSymbolScale, 4.0,
+                                         maxSymbolSize);
     double xSymbol = frameX + padding;
     double xCount = xSymbol + symbolSize + columnGap;
     double xType = xCount + maxCountWidth + columnGap;


### PR DESCRIPTION
### Motivation
- Increasing legend symbol scale could inflate row height and break legend interline spacing so items were not displayed correctly.
- Symbols must be limited so they do not force larger row heights and cause clipping of legend content.
- PDF exports should match on-screen legend spacing to keep exported legends readable.

### Description
- In `gui/layoutviewerpanel.cpp` compute `desiredSymbolSize` and clamp `symbolSize` to the range `[4, baseRowHeightPx]`, and keep `rowHeightPx` equal to `baseRowHeightPx` so symbols no longer increase row height.
- In `viewer2d/viewer2dpdfexporter.cpp` apply an equivalent clamp so `symbolSize` is limited to `[4.0, lineHeight]` while preserving `lineHeight` for PDF rendering.
- Small refactor to make the symbol-size cap explicit and consistent between UI and PDF code paths.

### Testing
- No automated tests were run on this change.
- Changes were limited to symbol-size calculations in legend rendering for UI and PDF exporter, and verified via code inspection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d62a130708324a7ab17704f44a3cf)