### PR TITLE
Agrandar símbolos de la leyenda sin mover el texto

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1856,18 +1856,17 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   const int baseRowHeightPx =
       std::max(lineHeight,
                static_cast<int>(std::lround(rowHeight * renderZoom)));
+  const int symbolSlotSize = baseRowHeightPx;
   const int desiredSymbolSize =
       static_cast<int>(std::lround(baseRowHeightPx * kLegendSymbolScale));
-  const int maxSymbolSize = std::max(4, baseRowHeightPx);
-  const int symbolSize =
-      std::clamp(desiredSymbolSize, 4, maxSymbolSize);
+  const int symbolSize = std::max(4, desiredSymbolSize);
   const int rowHeightPx = baseRowHeightPx;
   const int paddingPx =
       std::max(0, static_cast<int>(std::lround(padding * renderZoom)));
   const int columnGapPx =
       std::max(0, static_cast<int>(std::lround(columnGap * renderZoom)));
   int xSymbol = paddingPx;
-  int xCount = xSymbol + symbolSize + columnGapPx;
+  int xCount = xSymbol + symbolSlotSize + columnGapPx;
   int xType = xCount + maxCountWidth + columnGapPx;
   int xCh = size.GetWidth() - paddingPx - maxChWidth;
   if (xCh < xType + columnGapPx)
@@ -1927,7 +1926,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
           double drawW = symbolW * scale;
           double drawH = symbolH * scale;
           double symbolDrawLeft =
-              xSymbol + (static_cast<double>(symbolSize) - drawW) * 0.5;
+              xSymbol + (static_cast<double>(symbolSlotSize) - drawW) * 0.5;
           double symbolDrawTop =
               y + (static_cast<double>(rowHeightPx) - drawH) * 0.5;
 

--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -1577,11 +1577,11 @@ Viewer2DExportResult ExportLayoutToPdf(
     }
 
     const double lineHeight = fontSize + 2.0;
-    const double maxSymbolSize = std::max(4.0, lineHeight);
-    const double symbolSize = std::clamp(lineHeight * kLegendSymbolScale, 4.0,
-                                         maxSymbolSize);
+    const double symbolSlotSize = lineHeight;
+    const double symbolSize =
+        std::max(4.0, lineHeight * kLegendSymbolScale);
     double xSymbol = frameX + padding;
-    double xCount = xSymbol + symbolSize + columnGap;
+    double xCount = xSymbol + symbolSlotSize + columnGap;
     double xType = xCount + maxCountWidth + columnGap;
     double xCh = frameX + frameW - padding - maxChWidth;
     if (xCh < xType + columnGap)
@@ -1645,7 +1645,7 @@ Viewer2DExportResult ExportLayoutToPdf(
               double symbolBoxY =
                   rowBottom + (lineHeight - symbolSize) * 0.5;
               double symbolOffsetX =
-                  xSymbol + (symbolSize - drawW) * 0.5 -
+                  xSymbol + (symbolSlotSize - drawW) * 0.5 -
                   symbol->bounds.min.x * scale;
               double symbolOffsetY =
                   symbolBoxY + (symbolSize - drawH) * 0.5 -


### PR DESCRIPTION
### Motivation
- Allow legend symbols to be rendered larger (using `kLegendSymbolScale`) without changing line spacing or moving the text columns. 
- Keep header and row text size and interlineado unchanged while enabling symbol drawing to exceed the reserved slot. 
- Apply the same behavior both for on-screen UI rendering and for PDF export. 

### Description
- Introduced a separate `symbolSlotSize` (set to the row height) and kept `symbolSize` computed from `kLegendSymbolScale` so symbols can draw larger than their reserved column. 
- Updated text column layout to use `symbolSlotSize` when computing `xCount` so text positions are stable and unaffected by symbol scale. 
- Adjusted symbol centering math to place the (potentially oversized) symbol inside the fixed slot by using `symbolSlotSize` for offsets. 
- Changes applied in `gui/layoutviewerpanel.cpp` and `viewer2d/viewer2dpdfexporter.cpp`. 

### Testing
- No automated tests were run on this change. 
- A local commit was created including the two modified files `gui/layoutviewerpanel.cpp` and `viewer2d/viewer2dpdfexporter.cpp`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d6428c8148324a2129634b4b50e71)