### PR TITLE
Use fixed legend symbol size in UI and PDF export

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -494,7 +494,7 @@ constexpr int kHandleSizePx = 10;
 constexpr int kHandleHalfPx = kHandleSizePx / 2;
 constexpr int kHandleHoverPadPx = 6;
 constexpr int kMinFrameSize = 24;
-constexpr double kLegendSymbolScale = 5.0;
+constexpr int kLegendSymbolSizePx = 20;
 constexpr int kEditMenuId = wxID_HIGHEST + 490;
 constexpr int kDeleteMenuId = wxID_HIGHEST + 491;
 constexpr int kDeleteLegendMenuId = wxID_HIGHEST + 492;
@@ -1856,11 +1856,11 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   const int baseRowHeightPx =
       std::max(lineHeight,
                static_cast<int>(std::lround(rowHeight * renderZoom)));
-  const int symbolSlotSize = baseRowHeightPx;
   const int desiredSymbolSize =
-      static_cast<int>(std::lround(baseRowHeightPx * kLegendSymbolScale));
+      static_cast<int>(std::lround(kLegendSymbolSizePx * renderZoom));
   const int symbolSize = std::max(4, desiredSymbolSize);
-  const int rowHeightPx = baseRowHeightPx;
+  const int symbolSlotSize = symbolSize;
+  const int rowHeightPx = std::max(baseRowHeightPx, symbolSize);
   const int paddingPx =
       std::max(0, static_cast<int>(std::lround(padding * renderZoom)));
   const int columnGapPx =

--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -50,7 +50,7 @@ constexpr float PDF_TEXT_ASCENT_FACTOR = 0.718f;
 // Complements the ascent factor using Helvetica's 207 unit descent as a
 // fallback for text that does not provide explicit metrics.
 constexpr float PDF_TEXT_DESCENT_FACTOR = 0.207f;
-constexpr double kLegendSymbolScale = 5.0;
+constexpr double kLegendSymbolSize = 20.0;
 
 static bool ShouldTraceLabelOrder() {
   static const bool enabled = std::getenv("PERASTAGE_TRACE_LABELS") != nullptr;
@@ -1577,9 +1577,9 @@ Viewer2DExportResult ExportLayoutToPdf(
     }
 
     const double lineHeight = fontSize + 2.0;
-    const double symbolSlotSize = lineHeight;
-    const double symbolSize =
-        std::max(4.0, lineHeight * kLegendSymbolScale);
+    const double symbolSize = std::max(4.0, kLegendSymbolSize);
+    const double symbolSlotSize = symbolSize;
+    const double rowHeight = std::max(lineHeight, symbolSize);
     double xSymbol = frameX + padding;
     double xCount = xSymbol + symbolSlotSize + columnGap;
     double xType = xCount + maxCountWidth + columnGap;
@@ -1614,7 +1614,7 @@ Viewer2DExportResult ExportLayoutToPdf(
                   << formatter.Format(frameX + frameW - padding) << ' '
                   << formatter.Format(separatorY) << " l S\n";
 
-    y -= lineHeight;
+    y -= rowHeight;
     for (const auto &item : legend.items) {
       if (y < frameY + padding)
         break;
@@ -1641,9 +1641,8 @@ Viewer2DExportResult ExportLayoutToPdf(
               double drawW = symbolW * scale;
               double drawH = symbolH * scale;
               double rowTop = y + fontSize * 0.7;
-              double rowBottom = rowTop - lineHeight;
-              double symbolBoxY =
-                  rowBottom + (lineHeight - symbolSize) * 0.5;
+              double rowBottom = rowTop - rowHeight;
+              double symbolBoxY = rowBottom + (rowHeight - symbolSize) * 0.5;
               double symbolOffsetX =
                   xSymbol + (symbolSlotSize - drawW) * 0.5 -
                   symbol->bounds.min.x * scale;
@@ -1663,7 +1662,7 @@ Viewer2DExportResult ExportLayoutToPdf(
       appendText(xCount, y, countText, "F1", 0.08, 0.08, 0.08);
       appendText(xType, y, typeText, "F1", 0.08, 0.08, 0.08);
       appendText(xCh, y, chText, "F1", 0.08, 0.08, 0.08);
-      y -= lineHeight;
+      y -= rowHeight;
     }
 
     contentStream << "Q\n";


### PR DESCRIPTION
### Motivation
- Legend symbol geometry was being scaled according to the legend font/row height causing symbol sizes to vary with legend size. 
- Symbols in legends should appear at a consistent, fixed pixel size for readability and consistent rendering across UI and exported PDF. 

### Description
- Replace the scaling-based `kLegendSymbolScale` with a fixed size constant (`kLegendSymbolSizePx` in `gui/layoutviewerpanel.cpp` and `kLegendSymbolSize` in `viewer2d/viewer2dpdfexporter.cpp`).
- In the layout viewer, compute `desiredSymbolSize` from the fixed size constant and set `symbolSlotSize` and `rowHeightPx` so rows accommodate the fixed symbol size. 
- In the PDF exporter, compute `symbolSize`, `symbolSlotSize`, and `rowHeight` from the fixed size constant and adjust row stepping and `symbolBoxY`/offset calculations to align symbols with rows. 
- Changes are limited to `gui/layoutviewerpanel.cpp` and `viewer2d/viewer2dpdfexporter.cpp` to keep UI and PDF legend symbol sizing consistent. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d66b436fc8324a5dcf982e2ee5b43)