### PR TITLE
Increase legend symbol size without affecting spacing

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -494,7 +494,7 @@ constexpr int kHandleSizePx = 10;
 constexpr int kHandleHalfPx = kHandleSizePx / 2;
 constexpr int kHandleHoverPadPx = 6;
 constexpr int kMinFrameSize = 24;
-constexpr int kLegendSymbolSizePx = 20;
+constexpr int kLegendSymbolSizePx = 24;
 constexpr int kEditMenuId = wxID_HIGHEST + 490;
 constexpr int kDeleteMenuId = wxID_HIGHEST + 491;
 constexpr int kDeleteLegendMenuId = wxID_HIGHEST + 492;
@@ -1860,7 +1860,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
       static_cast<int>(std::lround(kLegendSymbolSizePx * renderZoom));
   const int symbolSize = std::max(4, desiredSymbolSize);
   const int symbolSlotSize = symbolSize;
-  const int rowHeightPx = std::max(baseRowHeightPx, symbolSize);
+  const int rowHeightPx = baseRowHeightPx;
   const int paddingPx =
       std::max(0, static_cast<int>(std::lround(padding * renderZoom)));
   const int columnGapPx =

--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -50,7 +50,7 @@ constexpr float PDF_TEXT_ASCENT_FACTOR = 0.718f;
 // Complements the ascent factor using Helvetica's 207 unit descent as a
 // fallback for text that does not provide explicit metrics.
 constexpr float PDF_TEXT_DESCENT_FACTOR = 0.207f;
-constexpr double kLegendSymbolSize = 20.0;
+constexpr double kLegendSymbolSize = 24.0;
 
 static bool ShouldTraceLabelOrder() {
   static const bool enabled = std::getenv("PERASTAGE_TRACE_LABELS") != nullptr;
@@ -1579,7 +1579,7 @@ Viewer2DExportResult ExportLayoutToPdf(
     const double lineHeight = fontSize + 2.0;
     const double symbolSize = std::max(4.0, kLegendSymbolSize);
     const double symbolSlotSize = symbolSize;
-    const double rowHeight = std::max(lineHeight, symbolSize);
+    const double rowHeight = lineHeight;
     double xSymbol = frameX + padding;
     double xCount = xSymbol + symbolSlotSize + columnGap;
     double xType = xCount + maxCountWidth + columnGap;


### PR DESCRIPTION
### Motivation
- Make legend symbols larger in layout legends while keeping text line spacing and font sizes unchanged.
- Ensure the PDF export matches the on-screen viewer appearance for symbol sizing.

### Description
- Increased the on-screen legend symbol constant from `kLegendSymbolSizePx = 20` to `24` in `gui/layoutviewerpanel.cpp`.
- Prevented larger symbols from increasing row spacing by changing the row height calculation to use the text-derived base row height (`rowHeightPx = baseRowHeightPx`) instead of `max(baseRowHeightPx, symbolSize)` in `gui/layoutviewerpanel.cpp`.
- Increased the PDF legend symbol constant from `kLegendSymbolSize = 20.0` to `24.0` in `viewer2d/viewer2dpdfexporter.cpp` and made the PDF row height follow the text line height (`rowHeight = lineHeight`) instead of `max(lineHeight, symbolSize)`.

### Testing
- No automated tests were run for this change.
- Visual/manual verification is recommended to confirm larger symbols render correctly without affecting interline spacing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d6d2942808324a059c13489ba80d1)