### PR TITLE
Align legend symbols with text in layout viewer

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1845,12 +1845,12 @@ wxImage LayoutViewerPanel::BuildLegendImage(
     maxChWidth = std::max(maxChWidth, measureTextWidth(chText));
   }
 
-  int lineHeight = 0;
+  int textHeight = 0;
   int lineWidth = 0;
-  dc.GetTextExtent("Hg", &lineWidth, &lineHeight);
+  dc.GetTextExtent("Hg", &lineWidth, &textHeight);
   const int separatorGapPx =
       std::max(1, static_cast<int>(std::lround(separatorGap * renderZoom)));
-  lineHeight += separatorGapPx;
+  const int lineHeight = textHeight + separatorGapPx;
 
   const double rowHeight = totalRows > 0 ? availableHeight / totalRows : 0.0;
   const int baseRowHeightPx =
@@ -1892,10 +1892,12 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   };
 
   int y = paddingPx;
+  const int textOffset =
+      std::max(0, (rowHeightPx - textHeight) / 2);
   dc.SetFont(headerFont);
-  dc.DrawText("Count", xCount, y);
-  dc.DrawText("Type", xType, y);
-  dc.DrawText("Ch Count", xCh, y);
+  dc.DrawText("Count", xCount, y + textOffset);
+  dc.DrawText("Type", xType, y + textOffset);
+  dc.DrawText("Ch Count", xCh, y + textOffset);
 
   y += rowHeightPx;
   dc.SetPen(wxPen(wxColour(200, 200, 200)));
@@ -1945,9 +1947,9 @@ wxImage LayoutViewerPanel::BuildLegendImage(
         }
       }
     }
-    dc.DrawText(countText, xCount, y);
-    dc.DrawText(typeText, xType, y);
-    dc.DrawText(chText, xCh, y);
+    dc.DrawText(countText, xCount, y + textOffset);
+    dc.DrawText(typeText, xType, y + textOffset);
+    dc.DrawText(chText, xCh, y + textOffset);
     y += rowHeightPx;
   }
 


### PR DESCRIPTION
### Motivation

- Legend symbols were vertically misaligned relative to their row text and headers, making the legend look off-center.
- The legend rendering routine needed the text baseline to be centered within each row so symbols and text share the same visual center.

### Description

- Update `BuildLegendImage` in `gui/layoutviewerpanel.cpp` to measure text height using `dc.GetTextExtent` into `textHeight` and compute `lineHeight` as `textHeight + separatorGapPx`.
- Compute a `textOffset` as `std::max(0, (rowHeightPx - textHeight) / 2)` and use `y + textOffset` when drawing header and row text to vertically center text within each row.
- Keep symbol drawing centered in the row by using the existing calculation for `symbolDrawTop` based on `rowHeightPx`, so symbols and text share the same vertical alignment.

### Testing

- No automated tests were run for this change.
- The change modifies only `gui/layoutviewerpanel.cpp` and compiles locally as part of the normal workflow (no test suite executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d733f1ca08324b46be9c3e0cb66f3)