### PR TITLE
Preserve legend symbol stroke width in PDF export

### DIFF
--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -1529,12 +1529,21 @@ Viewer2DExportResult ExportLayoutToPdf(
       auto defIt = symbolSnapshot->find(entry.first);
       if (defIt == symbolSnapshot->end())
         continue;
+      const double symbolW =
+          defIt->second.bounds.max.x - defIt->second.bounds.min.x;
+      const double symbolH =
+          defIt->second.bounds.max.y - defIt->second.bounds.min.y;
+      double symbolScale = 1.0;
+      if (symbolW > 0.0 && symbolH > 0.0) {
+        symbolScale =
+            std::min(kLegendSymbolSize / symbolW, kLegendSymbolSize / symbolH);
+      }
       xObjectNameIds[entry.second] =
           appendSymbolObject(entry.second,
                              defIt->second.localCommands.commands,
                              defIt->second.localCommands.metadata,
                              defIt->second.localCommands.sources,
-                             1.0, defIt->second.bounds);
+                             symbolScale, defIt->second.bounds);
     }
   }
 
@@ -1649,11 +1658,8 @@ Viewer2DExportResult ExportLayoutToPdf(
               double symbolOffsetY =
                   symbolBoxY + (symbolSize - drawH) * 0.5 -
                   symbol->bounds.min.y * scale;
-              contentStream << "q\n"
-                            << formatter.Format(scale) << " 0 0 "
-                            << formatter.Format(scale) << ' '
-                            << formatter.Format(symbolOffsetX) << ' '
-                            << formatter.Format(symbolOffsetY) << " cm\n/"
+              contentStream << "q\n1 0 0 1 " << formatter.Format(symbolOffsetX)
+                            << ' ' << formatter.Format(symbolOffsetY) << " cm\n/"
                             << nameIt->second << " Do\nQ\n";
             }
           }


### PR DESCRIPTION
### Motivation

- Legend symbols exported to PDF had exaggerated stroke widths because placement scaling affected their outlines compared to the 2D viewer.
- The 2D viewer renders legend symbols at the correct visual stroke thickness; the PDF exporter should match that behavior.
- Make legend symbol generation in the PDF use a fixed, final-scale representation so placement no longer rescales strokes.

### Description

- Compute and apply a `symbolScale` when creating legend symbol XObjects in `viewer2d/viewer2dpdfexporter.cpp` so symbols are stored already scaled to `kLegendSymbolSize` instead of scaling at placement time.
- When placing legend XObjects in the PDF content stream, use a translation-only transform (`1 0 0 1 tx ty cm`) so stroke widths are preserved and not multiplied by placement scaling.
- Replace the previous placement-by-scaling approach and pass the computed `symbolScale` into `appendSymbolObject` for legend symbols.

### Testing

- No automated unit tests or CI jobs were executed for this change.
- The change was committed locally and the modified file is `viewer2d/viewer2dpdfexporter.cpp`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d773cdb0c8324bd5bdeaf46420391)