### PR TITLE
Reduce layout legend line spacing in UI and PDF export

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1808,6 +1808,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
 
   const int padding = 8;
   const int columnGap = 8;
+  constexpr double kLegendLineSpacingScale = 0.9;
   const int totalRows = static_cast<int>(items.size()) + 1;
   const int baseHeight = logicalSize.GetHeight() > 0 ? logicalSize.GetHeight()
                                                      : size.GetHeight();
@@ -1855,7 +1856,8 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   const double rowHeight = totalRows > 0 ? availableHeight / totalRows : 0.0;
   const int baseRowHeightPx =
       std::max(lineHeight,
-               static_cast<int>(std::lround(rowHeight * renderZoom)));
+               static_cast<int>(std::lround(rowHeight * renderZoom *
+                                            kLegendLineSpacingScale)));
   const int desiredSymbolSize =
       static_cast<int>(std::lround(kLegendSymbolSizePx * renderZoom));
   const int symbolSize = std::max(4, desiredSymbolSize);

--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -1567,6 +1567,7 @@ Viewer2DExportResult ExportLayoutToPdf(
 
     const double padding = 8.0;
     const double columnGap = 8.0;
+    constexpr double kLegendLineSpacingScale = 0.9;
     const double separatorGap = 2.0;
     const size_t totalRows = legend.items.size() + 1;
     const double availableHeight = frameH - padding * 2.0 - separatorGap;
@@ -1592,7 +1593,8 @@ Viewer2DExportResult ExportLayoutToPdf(
     const double lineHeight = textHeightEstimate + separatorGap;
     const double symbolSize = std::max(4.0, kLegendSymbolSize);
     const double symbolSlotSize = symbolSize;
-    const double rowHeight = std::max(rowHeightCandidate, lineHeight);
+    const double rowHeight =
+        std::max(rowHeightCandidate * kLegendLineSpacingScale, lineHeight);
     const double textOffset =
         std::max(0.0, (rowHeight - textHeightEstimate) * 0.5);
     double xSymbol = frameX + padding;


### PR DESCRIPTION
### Motivation
- Decrease the interlineado (line spacing) for layout legend rows to improve compactness of on-screen legends.
- Ensure the same tighter spacing is applied when exporting layouts to PDF so printed output matches the UI.
- Provide a single tweakable scale factor so the spacing change is consistent and easy to adjust.

### Description
- Added `constexpr double kLegendLineSpacingScale = 0.9` and applied it to legend row height calculations in `gui/layoutviewerpanel.cpp` and `viewer2d/viewer2dpdfexporter.cpp`.
- In `BuildLegendImage` adjusted the base row height computation to multiply `rowHeight * renderZoom` by the scale factor before rounding.
- In the PDF exporter adjusted the computed `rowHeight` to use `rowHeightCandidate * kLegendLineSpacingScale` when determining row layout.
- Modified files: `gui/layoutviewerpanel.cpp` and `viewer2d/viewer2dpdfexporter.cpp` and committed the change with the message `Adjust layout legend line spacing`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d7d04161883248ada3fd4df459f1f)