### PR TITLE
Reduce legend font and symbol sizes; tighten legend line spacing

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -494,7 +494,8 @@ constexpr int kHandleSizePx = 10;
 constexpr int kHandleHalfPx = kHandleSizePx / 2;
 constexpr int kHandleHoverPadPx = 6;
 constexpr int kMinFrameSize = 24;
-constexpr int kLegendSymbolSizePx = 160;
+constexpr int kLegendSymbolSizePx = 106;
+constexpr double kLegendFontScale = 2.0 / 3.0;
 constexpr int kEditMenuId = wxID_HIGHEST + 490;
 constexpr int kDeleteMenuId = wxID_HIGHEST + 491;
 constexpr int kDeleteLegendMenuId = wxID_HIGHEST + 492;
@@ -1808,7 +1809,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
 
   const int padding = 8;
   const int columnGap = 8;
-  constexpr double kLegendLineSpacingScale = 0.9;
+  constexpr double kLegendLineSpacingScale = 0.8;
   const int totalRows = static_cast<int>(items.size()) + 1;
   const int baseHeight = logicalSize.GetHeight() > 0 ? logicalSize.GetHeight()
                                                      : size.GetHeight();
@@ -1819,6 +1820,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
       totalRows > 0 ? (static_cast<double>(availableHeight) / totalRows) - 2.0
                     : 10.0;
   fontSize = std::clamp(fontSize, 6.0, 14.0);
+  fontSize *= kLegendFontScale;
   const int fontSizePx =
       std::max(1, static_cast<int>(std::lround(fontSize * renderZoom)));
 

--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -50,7 +50,8 @@ constexpr float PDF_TEXT_ASCENT_FACTOR = 0.718f;
 // Complements the ascent factor using Helvetica's 207 unit descent as a
 // fallback for text that does not provide explicit metrics.
 constexpr float PDF_TEXT_DESCENT_FACTOR = 0.207f;
-constexpr double kLegendSymbolSize = 160.0;
+constexpr double kLegendSymbolSize = 160.0 * 2.0 / 3.0;
+constexpr double kLegendFontScale = 2.0 / 3.0;
 
 static bool ShouldTraceLabelOrder() {
   static const bool enabled = std::getenv("PERASTAGE_TRACE_LABELS") != nullptr;
@@ -1567,13 +1568,14 @@ Viewer2DExportResult ExportLayoutToPdf(
 
     const double padding = 8.0;
     const double columnGap = 8.0;
-    constexpr double kLegendLineSpacingScale = 0.9;
+    constexpr double kLegendLineSpacingScale = 0.8;
     const double separatorGap = 2.0;
     const size_t totalRows = legend.items.size() + 1;
     const double availableHeight = frameH - padding * 2.0 - separatorGap;
     double fontSize =
         totalRows > 0 ? (availableHeight / totalRows) - 2.0 : 10.0;
     fontSize = std::clamp(fontSize, 6.0, 14.0);
+    fontSize *= kLegendFontScale;
 
     double maxCountWidth = measureTextWidth("Count", fontSize);
     double maxChWidth = measureTextWidth("Ch Count", fontSize);


### PR DESCRIPTION
### Motivation
- The on-screen and PDF legend text and symbols were visually too large and line spacing was too loose. 
- The goal is to scale legend fonts and symbol slots to about two thirds of their previous size and reduce interline spacing for a more compact layout. 

### Description
- Scaled down the legend symbol pixel size in the layout viewer by changing `kLegendSymbolSizePx` from `160` to `106` in `gui/layoutviewerpanel.cpp`. 
- Added a `kLegendFontScale` (`2.0/3.0`) and apply it to computed `fontSize` in both `gui/layoutviewerpanel.cpp` and `viewer2d/viewer2dpdfexporter.cpp` so on-screen and exported PDFs match. 
- Reduced the legend line spacing by changing `kLegendLineSpacingScale` from `0.9` to `0.8` in both the viewer image builder and the PDF exporter. 
- Adjusted the PDF exporter symbol sizing by setting `kLegendSymbolSize` to `160.0 * 2.0 / 3.0` in `viewer2d/viewer2dpdfexporter.cpp` so exported PDFs reflect the same visual scale. 

### Testing
- No automated tests were executed for this change. 
- Changes were compiled/committed locally as code edits to `gui/layoutviewerpanel.cpp` and `viewer2d/viewer2dpdfexporter.cpp`. 
- Visual verification is recommended by generating a layout view and exporting to PDF to confirm on-screen and PDF legends match. 
- If desired, run the existing unit/integration tests (not run here) to ensure no regressions occurred.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d7f00106083248e6e28281efbd7c4)