### PR TITLE
Embed NanoVG-equivalent TTF fonts in PDF export and use TTF metrics

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -587,6 +587,9 @@ void Viewer3DController::InitializeGL() {
 
   m_vg = nvgCreateGL2(NVG_ANTIALIAS | NVG_STENCIL_STROKES);
   if (m_vg) {
+    // Windows uses Arial (C:/Windows/Fonts/arial.ttf); Linux uses
+    // DejaVuSans (/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf) for NanoVG
+    // labels.
     const char *fontPaths[] = {
 #ifdef _WIN32
         "C:/Windows/Fonts/arial.ttf",


### PR DESCRIPTION
### Motivation
- Ensure PDF exported labels match the on-screen NanoVG rendering by using the same TrueType fonts and actual font metrics instead of hardcoded Helvetica approximations.
- Replace the previous fixed Type1 Helvetica usage and ascent/descent heuristics with embedded TTF data and per-glyph advance widths when available.  
- Allow the exporter to respect the captured `CanvasTextStyle::fontFamily` to choose the appropriate PDF font when different families are used at capture time.  
- Provide safe fallbacks to standard Type1 Helvetica/Helvetica-Bold when embedded TTFs are not available.

### Description
- Documented which TTF files NanoVG uses for labels in `viewer3d/viewer3dcontroller.cpp` (Windows: Arial, Linux: DejaVuSans).  
- Implemented TTF parsing and metric extraction in `viewer2d/viewer2dpdfexporter.cpp` (parsing `head`, `hhea`, `maxp`, `hmtx`, `cmap`, optional `OS/2`) and added `TtfFontMetrics`, `PdfFontDefinition` and `PdfFontCatalog` structures.  
- Embed fonts into generated PDFs using `/FontFile2` and a `FontDescriptor`, populate per-character widths and use those widths to measure and layout text in `AppendText`, replacing the previous hardcoded Helvetica width table and ascent/descent factors.  
- Threaded a `PdfFontCatalog` through `RenderOptions` so exporters can resolve `CanvasTextStyle::fontFamily`, updated legend width measuring/trim logic to use the embedded metrics, and keep Type1 fallbacks when embedding or font files are missing.

### Testing
- No automated tests were executed for this change in the current environment.  
- The changes were committed locally and the repository state reflects the updated files `viewer2d/viewer2dpdfexporter.cpp` and `viewer3d/viewer3dcontroller.cpp`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d84ade71483249a77cc6507dade79)