### PR TITLE
Fix PdfObject declaration order in PDF exporter

### DIFF
--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -364,6 +364,10 @@ bool LoadPdfFontMetrics(PdfFontDefinition &font, bool bold) {
   return LoadTtfFontMetrics(path, font.metrics);
 }
 
+struct PdfObject {
+  std::string body;
+};
+
 bool AppendEmbeddedFontObjects(std::vector<PdfObject> &objects,
                                PdfFontDefinition &font) {
   if (!font.metrics.valid || font.metrics.data.empty())
@@ -431,10 +435,6 @@ void AppendFallbackType1Font(std::vector<PdfObject> &objects,
   font.embedded = false;
   font.baseName = baseFont;
 }
-
-struct PdfObject {
-  std::string body;
-};
 
 class FloatFormatter {
 public:


### PR DESCRIPTION
### Motivation
- Resolve compilation errors where `PdfObject` was referenced before being declared, causing template and member-function resolution failures.
- Ensure helper functions that manipulate PDF objects can use `std::vector<PdfObject>` without type-visibility issues.

### Description
- Move the `struct PdfObject { std::string body; };` definition above helper functions such as `AppendEmbeddedFontObjects` and `AppendFallbackType1Font` that use it.
- Adjust the surrounding code order in `viewer2d/viewer2dpdfexporter.cpp` accordingly (4 insertions, 4 deletions).
- No functional logic was changed aside from the declaration order, preserving existing formatting and behavior.

### Testing
- No automated tests were run on this change.
- A local commit was created after the edit to record the fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d87d6d484832498defd436c0d0d3d)