### PR TITLE
Add z-order controls for Layout Viewer items

### DIFF
--- a/core/layouts/LayoutCollection.cpp
+++ b/core/layouts/LayoutCollection.cpp
@@ -120,6 +120,36 @@ bool LayoutCollection::RemoveLayout2DView(const std::string &name,
   return false;
 }
 
+bool LayoutCollection::MoveLayout2DView(const std::string &name, int viewId,
+                                        bool toFront) {
+  for (auto &layout : layouts) {
+    if (layout.name == name) {
+      auto &views = layout.view2dViews;
+      auto it = std::find_if(views.begin(), views.end(),
+                             [viewId](const auto &entry) {
+                               return entry.id == viewId;
+                             });
+      if (it == views.end())
+        return false;
+      if (toFront) {
+        if (std::next(it) != views.end()) {
+          auto moved = std::move(*it);
+          views.erase(it);
+          views.push_back(std::move(moved));
+        }
+      } else {
+        if (it != views.begin()) {
+          auto moved = std::move(*it);
+          views.erase(it);
+          views.insert(views.begin(), std::move(moved));
+        }
+      }
+      return true;
+    }
+  }
+  return false;
+}
+
 bool LayoutCollection::UpdateLayoutLegend(
     const std::string &name, const LayoutLegendDefinition &legend) {
   for (auto &layout : layouts) {
@@ -161,6 +191,36 @@ bool LayoutCollection::RemoveLayoutLegend(const std::string &name,
       if (it == legends.end())
         return false;
       legends.erase(it, legends.end());
+      return true;
+    }
+  }
+  return false;
+}
+
+bool LayoutCollection::MoveLayoutLegend(const std::string &name, int legendId,
+                                        bool toFront) {
+  for (auto &layout : layouts) {
+    if (layout.name == name) {
+      auto &legends = layout.legendViews;
+      auto it = std::find_if(legends.begin(), legends.end(),
+                             [legendId](const auto &entry) {
+                               return entry.id == legendId;
+                             });
+      if (it == legends.end())
+        return false;
+      if (toFront) {
+        if (std::next(it) != legends.end()) {
+          auto moved = std::move(*it);
+          legends.erase(it);
+          legends.push_back(std::move(moved));
+        }
+      } else {
+        if (it != legends.begin()) {
+          auto moved = std::move(*it);
+          legends.erase(it);
+          legends.insert(legends.begin(), std::move(moved));
+        }
+      }
       return true;
     }
   }

--- a/core/layouts/LayoutCollection.h
+++ b/core/layouts/LayoutCollection.h
@@ -100,9 +100,11 @@ public:
   bool UpdateLayout2DView(const std::string &name,
                           const Layout2DViewDefinition &view);
   bool RemoveLayout2DView(const std::string &name, int viewId);
+  bool MoveLayout2DView(const std::string &name, int viewId, bool toFront);
   bool UpdateLayoutLegend(const std::string &name,
                           const LayoutLegendDefinition &legend);
   bool RemoveLayoutLegend(const std::string &name, int legendId);
+  bool MoveLayoutLegend(const std::string &name, int legendId, bool toFront);
 
   void ReplaceAll(std::vector<LayoutDefinition> layouts);
 

--- a/core/layouts/LayoutManager.cpp
+++ b/core/layouts/LayoutManager.cpp
@@ -491,6 +491,14 @@ bool LayoutManager::RemoveLayout2DView(const std::string &name, int viewId) {
   return true;
 }
 
+bool LayoutManager::MoveLayout2DView(const std::string &name, int viewId,
+                                     bool toFront) {
+  if (!layouts.MoveLayout2DView(name, viewId, toFront))
+    return false;
+  SyncToConfig();
+  return true;
+}
+
 bool LayoutManager::UpdateLayoutLegend(const std::string &name,
                                        const LayoutLegendDefinition &legend) {
   if (!layouts.UpdateLayoutLegend(name, legend))
@@ -501,6 +509,14 @@ bool LayoutManager::UpdateLayoutLegend(const std::string &name,
 
 bool LayoutManager::RemoveLayoutLegend(const std::string &name, int legendId) {
   if (!layouts.RemoveLayoutLegend(name, legendId))
+    return false;
+  SyncToConfig();
+  return true;
+}
+
+bool LayoutManager::MoveLayoutLegend(const std::string &name, int legendId,
+                                     bool toFront) {
+  if (!layouts.MoveLayoutLegend(name, legendId, toFront))
     return false;
   SyncToConfig();
   return true;

--- a/core/layouts/LayoutManager.h
+++ b/core/layouts/LayoutManager.h
@@ -37,9 +37,11 @@ public:
   bool UpdateLayout2DView(const std::string &name,
                           const Layout2DViewDefinition &view);
   bool RemoveLayout2DView(const std::string &name, int viewId);
+  bool MoveLayout2DView(const std::string &name, int viewId, bool toFront);
   bool UpdateLayoutLegend(const std::string &name,
                           const LayoutLegendDefinition &legend);
   bool RemoveLayoutLegend(const std::string &name, int legendId);
+  bool MoveLayoutLegend(const std::string &name, int legendId, bool toFront);
 
   void LoadFromConfig(ConfigManager &cfg);
   void SaveToConfig(ConfigManager &cfg) const;

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -84,6 +84,8 @@ private:
   void OnEditView(wxCommandEvent &event);
   void OnDeleteView(wxCommandEvent &event);
   void OnDeleteLegend(wxCommandEvent &event);
+  void OnBringToFront(wxCommandEvent &event);
+  void OnSendToBack(wxCommandEvent &event);
 
   void ResetViewToFit();
   wxRect GetPageRect() const;


### PR DESCRIPTION
### Motivation
- Allow users to control which `view2d` or `legend` overlays appear above others from the Layout Viewer context menu.
- Persist ordering changes so reordering survives across sessions and configuration saves using the layouts backend.
- Update the viewer UI to immediately reflect z-order changes so overlaps render as expected.

### Description
- Added `MoveLayout2DView` and `MoveLayoutLegend` to `core/layouts/LayoutCollection` and exposed them via `core/layouts/LayoutManager` as `MoveLayout2DView` and `MoveLayoutLegend` to persist ordering changes.
- Introduced context menu items `kBringToFrontMenuId` and `kSendToBackMenuId` and a helper template `MoveElementById` in `gui/layoutviewerpanel.cpp` to reorder in-memory layout lists.
- Implemented `LayoutViewerPanel::OnBringToFront` and `LayoutViewerPanel::OnSendToBack` that update the local `currentLayout`, call the corresponding `layouts::LayoutManager::Get().MoveLayout...` APIs, then call `RequestRenderRebuild()` and `Refresh()` to update rendering.
- Updated headers and event table wiring in `gui/layoutviewerpanel.h`/`.cpp` to register the new handlers and menu commands.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d8c9c47b8832497a9a951d3dce7dd)