### PR TITLE
Fix layout viewer z-order refresh after reorder

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1157,6 +1157,8 @@ void LayoutViewerPanel::OnBringToFront(wxCommandEvent &) {
   } else {
     return;
   }
+  layoutVersion++;
+  renderDirty = true;
   RequestRenderRebuild();
   Refresh();
 }
@@ -1181,6 +1183,8 @@ void LayoutViewerPanel::OnSendToBack(wxCommandEvent &) {
   } else {
     return;
   }
+  layoutVersion++;
+  renderDirty = true;
   RequestRenderRebuild();
   Refresh();
 }


### PR DESCRIPTION
### Motivation
- The `Bring to Front`/`Send to Back` actions in the Layout Viewer did not always update the rendered display after changing an element's z-order. 
- The change ensures z-order modifications mark the layout as changed so cached renders are rebuilt.

### Description
- In `gui/layoutviewerpanel.cpp` added `layoutVersion++` and `renderDirty = true` after successful moves in `LayoutViewerPanel::OnBringToFront` and `LayoutViewerPanel::OnSendToBack` to mark the layout changed and force re-renders. 
- The code still calls `RequestRenderRebuild()` and `Refresh()` to trigger texture rebuild and UI refresh. 
- This update makes reordering update caches and offscreen captures consistently without altering the existing move logic in `MoveElementById` or the layout manager calls.

### Testing
- No automated tests were executed for this change. 
- The change is limited to `gui/layoutviewerpanel.cpp` and is a minimal update to state flags used by the render pipeline. 
- Manual verification is recommended by exercising `Bring to Front` and `Send to Back` in the Layout Viewer to confirm visual updates. 
- No unit or integration test failures were reported because none were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d8edcbbb88324955c17257cd94058)