### PR TITLE
Fix layout viewer z-ordering (Bring to Front / Send to Back)

### DIFF
--- a/core/layouts/LayoutCollection.cpp
+++ b/core/layouts/LayoutCollection.cpp
@@ -20,6 +20,29 @@
 #include <algorithm>
 
 namespace layouts {
+namespace {
+int MaxZIndex(const LayoutDefinition &layout) {
+  bool hasValue = false;
+  int maxZ = 0;
+  for (const auto &view : layout.view2dViews) {
+    if (!hasValue) {
+      maxZ = view.zIndex;
+      hasValue = true;
+    } else {
+      maxZ = std::max(maxZ, view.zIndex);
+    }
+  }
+  for (const auto &legend : layout.legendViews) {
+    if (!hasValue) {
+      maxZ = legend.zIndex;
+      hasValue = true;
+    } else {
+      maxZ = std::max(maxZ, legend.zIndex);
+    }
+  }
+  return hasValue ? maxZ : 0;
+}
+} // namespace
 
 LayoutCollection::LayoutCollection() { layouts.push_back(DefaultLayout()); }
 
@@ -89,13 +112,20 @@ bool LayoutCollection::UpdateLayout2DView(const std::string &name,
       bool replaced = false;
       for (auto &entry : layout.view2dViews) {
         if (entry.id == updatedView.id && updatedView.id > 0) {
+          if (updatedView.zIndex == 0 && entry.zIndex != 0)
+            updatedView.zIndex = entry.zIndex;
           entry = updatedView;
           replaced = true;
           break;
         }
       }
-      if (!replaced)
+      if (!replaced) {
+        if (updatedView.zIndex == 0 &&
+            (!layout.view2dViews.empty() || !layout.legendViews.empty())) {
+          updatedView.zIndex = MaxZIndex(layout) + 1;
+        }
         layout.view2dViews.push_back(updatedView);
+      }
       return true;
     }
   }
@@ -165,13 +195,20 @@ bool LayoutCollection::UpdateLayoutLegend(
       bool replaced = false;
       for (auto &entry : layout.legendViews) {
         if (entry.id == updatedLegend.id && updatedLegend.id > 0) {
+          if (updatedLegend.zIndex == 0 && entry.zIndex != 0)
+            updatedLegend.zIndex = entry.zIndex;
           entry = updatedLegend;
           replaced = true;
           break;
         }
       }
-      if (!replaced)
+      if (!replaced) {
+        if (updatedLegend.zIndex == 0 &&
+            (!layout.view2dViews.empty() || !layout.legendViews.empty())) {
+          updatedLegend.zIndex = MaxZIndex(layout) + 1;
+        }
         layout.legendViews.push_back(updatedLegend);
+      }
       return true;
     }
   }

--- a/core/layouts/LayoutCollection.h
+++ b/core/layouts/LayoutCollection.h
@@ -67,6 +67,7 @@ struct Layout2DViewLayers {
 
 struct Layout2DViewDefinition {
   int id = 0;
+  int zIndex = 0;
   Layout2DViewFrame frame;
   Layout2DViewCameraState camera;
   Layout2DViewRenderOptions renderOptions;
@@ -75,6 +76,7 @@ struct Layout2DViewDefinition {
 
 struct LayoutLegendDefinition {
   int id = 0;
+  int zIndex = 0;
   Layout2DViewFrame frame;
 };
 

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -20,6 +20,7 @@
 #include <memory>
 #include <optional>
 #include <unordered_map>
+#include <utility>
 #include <wx/glcanvas.h>
 #include <wx/wx.h>
 #include "layouts/LayoutCollection.h"
@@ -137,6 +138,16 @@ private:
     View2D,
     Legend
   };
+
+  struct ZOrderedElement {
+    SelectedElementType type = SelectedElementType::None;
+    int id = -1;
+    int zIndex = 0;
+    size_t order = 0;
+  };
+
+  std::vector<ZOrderedElement> BuildZOrderedElements() const;
+  std::pair<int, int> GetZIndexRange() const;
 
   layouts::LayoutDefinition currentLayout;
   double zoom = 1.0;

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1772,6 +1772,7 @@ void MainWindow::OnPrintLayout(wxCommandEvent &WXUNUSED(event)) {
   for (const auto &legend : layout->legendViews) {
     LayoutLegendExportData legendData;
     legendData.items = legendItems;
+    legendData.zIndex = legend.zIndex;
     layouts::Layout2DViewFrame frame = legend.frame;
     frame.x = static_cast<int>(std::lround(frame.x * scaleX));
     frame.y = static_cast<int>(std::lround(frame.y * scaleY));
@@ -1879,6 +1880,7 @@ void MainWindow::OnPrintLayout(wxCommandEvent &WXUNUSED(event)) {
               frame.height =
                   static_cast<int>(std::lround(frame.height * scaleY));
               data.frame = frame;
+              data.zIndex = view.zIndex;
               if (capturePanel)
                 data.symbolSnapshot =
                     capturePanel->GetBottomSymbolCacheSnapshot();
@@ -2598,6 +2600,11 @@ void MainWindow::OnLayout2DViewOk(wxCommandEvent &WXUNUSED(event)) {
   layouts::Layout2DViewDefinition updatedView =
       viewer2d::ToLayoutDefinition(current, frame);
   updatedView.id = viewId;
+  if (matchedView) {
+    updatedView.zIndex = matchedView->zIndex;
+  } else if (editableView) {
+    updatedView.zIndex = editableView->zIndex;
+  }
   layouts::LayoutManager::Get().UpdateLayout2DView(activeLayoutName,
                                                    updatedView);
 
@@ -2676,6 +2683,11 @@ void MainWindow::PersistLayout2DViewState() {
       viewer2d::CaptureLayoutDefinition(activePanel, cfg, frame);
   view.renderOptions.darkMode = false;
   view.id = viewId;
+  if (matchedView) {
+    view.zIndex = matchedView->zIndex;
+  } else if (editableView) {
+    view.zIndex = editableView->zIndex;
+  }
   layouts::LayoutManager::Get().UpdateLayout2DView(activeLayoutName, view);
 }
 

--- a/viewer2d/viewer2dpdfexporter.h
+++ b/viewer2d/viewer2dpdfexporter.h
@@ -53,6 +53,7 @@ struct LayoutViewExportData {
   CommandBuffer buffer;
   Viewer2DViewState viewState;
   layouts::Layout2DViewFrame frame;
+  int zIndex = 0;
   std::shared_ptr<const SymbolDefinitionSnapshot> symbolSnapshot;
 };
 
@@ -66,6 +67,7 @@ struct LayoutLegendItem {
 struct LayoutLegendExportData {
   layouts::Layout2DViewFrame frame;
   std::vector<LayoutLegendItem> items;
+  int zIndex = 0;
   std::shared_ptr<const SymbolDefinitionSnapshot> symbolSnapshot = nullptr;
 };
 


### PR DESCRIPTION
### Motivation
- The `Bring to Front`/`Send to Back` actions in the Layout Viewer did not reorder elements reliably across types (2D views vs legends). 
- Legends must be orderable relative to 2D views so they can appear behind or in front of other elements. 
- The z-order needs to be persistent in layout data so edits and exports preserve visual stacking.

### Description
- Add a persistent `zIndex` field to `Layout2DViewDefinition` and `LayoutLegendDefinition` and include it in JSON serialization/parsing (`ToJson` / `ParseLayout`), assigning sensible defaults when missing. 
- Update `LayoutCollection` to preserve and auto-assign `zIndex` on `UpdateLayout2DView` / `UpdateLayoutLegend` using a `MaxZIndex` helper. 
- Change `LayoutViewerPanel` to build a combined z-ordered list (`BuildZOrderedElements`), render elements in z-order, perform hit-testing in z-order, and make `OnBringToFront` / `OnSendToBack` modify `zIndex` and call the corresponding `LayoutManager` update. 
- Propagate `zIndex` into export and edit paths by extending `LayoutViewExportData` / `LayoutLegendExportData`, updating PDF exporter render order to respect `zIndex`, and preserving `zIndex` during view edits in `MainWindow`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d91b612308324812313042eee9561)