### PR TITLE
Fill layout view backgrounds in PDF export

### DIFF
--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -2024,6 +2024,10 @@ Viewer2DExportResult ExportLayoutToPdf(
                   << formatter.Format(group.frameY) << ' '
                   << formatter.Format(group.frameW) << ' '
                   << formatter.Format(group.frameH) << " re W n\n";
+    contentStream << "1 1 1 rg " << formatter.Format(group.frameX) << ' '
+                  << formatter.Format(group.frameY) << ' '
+                  << formatter.Format(group.frameW) << ' '
+                  << formatter.Format(group.frameH) << " re f\n";
     contentStream << RenderCommandsToStream(group.commands.commands,
                                             group.commands.metadata,
                                             group.commands.sources,


### PR DESCRIPTION
### Motivation
- Layout exports to PDF could show elements out of expected front/back order because view frames were rendered with transparent backgrounds. 
- The PDF output needs an opaque background for each layout view so stacking in the PDF matches the on-screen layout z-order. 

### Description
- In `ExportLayoutToPdf` (in `viewer2d/viewer2dpdfexporter.cpp`) paint each layout view frame white before emitting the view drawing commands by writing a filled rectangle PDF operator. 
- This adds a `1 1 1 rg ... re f` fill call into the content stream just prior to `RenderCommandsToStream` for each view group. 
- No other rendering logic or ordering code was changed; the existing `renderOrder` stable sort by `zIndex` is still used. 

### Testing
- No automated tests were run for this change. 
- Manual validation was not recorded in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d958643a08324b6ed465c9d497786)