### PR TITLE
Adjust legend symbol column width

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -2051,9 +2051,10 @@ wxImage LayoutViewerPanel::BuildLegendImage(
                                             kLegendLineSpacingScale)));
   const int desiredSymbolSize =
       static_cast<int>(std::lround(kLegendSymbolSizePx * renderZoom));
-  const int symbolSize = std::max(4, desiredSymbolSize);
-  const int symbolSlotSize = symbolSize;
   const int rowHeightPx = baseRowHeightPx;
+  const int symbolSlotSize = rowHeightPx;
+  const int symbolSize =
+      std::max(4, std::min(desiredSymbolSize, symbolSlotSize));
   const int paddingPx =
       std::max(0, static_cast<int>(std::lround(padding * renderZoom)));
   const int columnGapPx =

--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -2091,10 +2091,11 @@ Viewer2DExportResult ExportLayoutToPdf(
         totalRows > 0 ? (availableHeight / totalRows) : 0.0;
     const double textHeightEstimate = fontSize * 1.2;
     const double lineHeight = textHeightEstimate + separatorGap;
-    const double symbolSize = std::max(4.0, kLegendSymbolSize);
-    const double symbolSlotSize = symbolSize;
     const double rowHeight =
         std::max(rowHeightCandidate * kLegendLineSpacingScale, lineHeight);
+    const double symbolSlotSize = rowHeight;
+    const double symbolSize =
+        std::max(4.0, std::min(kLegendSymbolSize, symbolSlotSize));
     const double textOffset =
         std::max(0.0, (rowHeight - textHeightEstimate) * 0.5);
     double xSymbol = frameX + padding;


### PR DESCRIPTION
### Motivation
- Legend symbol column was visually too wide compared to the row height, making legends look unbalanced.
- The goal is to make the symbol slot track the row height so the column width is approximately the same as the symbol height.

### Description
- In `gui/layoutviewerpanel.cpp` set `symbolSlotSize` to the computed `rowHeightPx` and clamp `symbolSize` to `min(desiredSymbolSize, symbolSlotSize)` with a minimum of `4` pixels.
- In `viewer2d/viewer2dpdfexporter.cpp` set `symbolSlotSize` to the computed `rowHeight` and clamp `symbolSize` to `min(kLegendSymbolSize, symbolSlotSize)` with a minimum of `4.0` units.
- This keeps the on-screen legend symbol column and PDF legend symbol column aligned to the row height and prevents excessive horizontal space.
- Files changed: `gui/layoutviewerpanel.cpp`, `viewer2d/viewer2dpdfexporter.cpp`.

### Testing
- No automated tests were run for this change.
- The change is a small layout adjustment; please run the application UI and PDF export to visually verify the legend symbol sizing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ea8633cb08324862a4be309bb6085)