### PR TITLE
Tighten legend symbol column width

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -2052,7 +2052,29 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   const int desiredSymbolSize =
       static_cast<int>(std::lround(kLegendSymbolSizePx * renderZoom));
   const int symbolSize = std::max(4, desiredSymbolSize);
-  const int symbolSlotSize = symbolSize;
+  double maxSymbolDrawWidth = 0.0;
+  if (symbols) {
+    for (const auto &item : items) {
+      if (item.symbolKey.empty())
+        continue;
+      const SymbolDefinition *symbol =
+          FindSymbolDefinition(symbols, item.symbolKey);
+      if (!symbol)
+        continue;
+      const float symbolW = symbol->bounds.max.x - symbol->bounds.min.x;
+      const float symbolH = symbol->bounds.max.y - symbol->bounds.min.y;
+      if (symbolW <= 0.0f || symbolH <= 0.0f)
+        continue;
+      double scale = std::min(static_cast<double>(symbolSize) / symbolW,
+                              static_cast<double>(symbolSize) / symbolH);
+      double drawW = symbolW * scale;
+      maxSymbolDrawWidth = std::max(maxSymbolDrawWidth, drawW);
+    }
+  }
+  const int symbolSlotSize =
+      maxSymbolDrawWidth > 0.0
+          ? std::max(4, static_cast<int>(std::ceil(maxSymbolDrawWidth)))
+          : symbolSize;
   const int rowHeightPx = baseRowHeightPx;
   const int paddingPx =
       std::max(0, static_cast<int>(std::lround(padding * renderZoom)));


### PR DESCRIPTION
### Motivation
- The legend symbol column left excessive horizontal whitespace even though the rendered symbol size should remain unchanged.
- The goal is to reduce that blank space while keeping the symbol drawing size identical and without altering other layout behavior.

### Description
- Change made in `gui/layoutviewerpanel.cpp` to compute the legend symbol column width from the actual drawn symbol widths instead of using the nominal slot size.
- The code iterates legend `items`, looks up each `SymbolDefinition` with `FindSymbolDefinition`, computes the per-symbol `scale` and resulting `drawW`, and retains the `maxSymbolDrawWidth`.
- `symbolSlotSize` is then set to `ceil(maxSymbolDrawWidth)` with a fallback to the original `symbolSize` and a minimum of 4 pixels, leaving symbol rendering unchanged.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eaa83d1b48324a8063ea7c34afcee)