### PR TITLE
Tighten legend symbol column spacing

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1998,6 +1998,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
 
   const int padding = 8;
   const int columnGap = 8;
+  const int symbolColumnGap = 4;
   constexpr double kLegendLineSpacingScale = 0.8;
   const int totalRows = static_cast<int>(items.size()) + 1;
   const int baseHeight = logicalSize.GetHeight() > 0 ? logicalSize.GetHeight()
@@ -2080,8 +2081,10 @@ wxImage LayoutViewerPanel::BuildLegendImage(
       std::max(0, static_cast<int>(std::lround(padding * renderZoom)));
   const int columnGapPx =
       std::max(0, static_cast<int>(std::lround(columnGap * renderZoom)));
+  const int symbolColumnGapPx =
+      std::max(0, static_cast<int>(std::lround(symbolColumnGap * renderZoom)));
   int xSymbol = paddingPx;
-  int xCount = xSymbol + symbolSlotSize + columnGapPx;
+  int xCount = xSymbol + symbolSlotSize + symbolColumnGapPx;
   int xType = xCount + maxCountWidth + columnGapPx;
   int xCh = size.GetWidth() - paddingPx - maxChWidth;
   if (xCh < xType + columnGapPx)

--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -2062,6 +2062,7 @@ Viewer2DExportResult ExportLayoutToPdf(
 
     const double padding = 8.0;
     const double columnGap = 8.0;
+    const double symbolColumnGap = 4.0;
     constexpr double kLegendLineSpacingScale = 0.8;
     const double separatorGap = 2.0;
     const size_t totalRows = legend.items.size() + 1;
@@ -2098,7 +2099,7 @@ Viewer2DExportResult ExportLayoutToPdf(
     const double textOffset =
         std::max(0.0, (rowHeight - textHeightEstimate) * 0.5);
     double xSymbol = frameX + padding;
-    double xCount = xSymbol + symbolSlotSize + columnGap;
+    double xCount = xSymbol + symbolSlotSize + symbolColumnGap;
     double xType = xCount + maxCountWidth + columnGap;
     double xCh = frameX + frameW - padding - maxChWidth;
     if (xCh < xType + columnGap)


### PR DESCRIPTION
### Motivation
- Reduce wasted horizontal space to the sides of legend symbols without changing symbol or text sizes.
- Make on-screen legend and exported PDF legend use the same, tighter spacing for consistency.

### Description
- Introduce a new `symbolColumnGap` (value `4`) in `gui/layoutviewerpanel.cpp` and `viewer2d/viewer2dpdfexporter.cpp` to tighten the gap between the symbol column and the count column.
- Use `symbolColumnGapPx` in the UI rendering code and `symbolColumnGap` in the PDF exporter when computing `xCount`, replacing the previous use of the larger `columnGap` for that spacing.
- Only spacing logic was changed; symbol sizing (`symbolSlotSize`, `symbolSize`) and all text measurements remain unchanged.

### Testing
- No automated tests were run for this change.
- A commit was created containing updates to `gui/layoutviewerpanel.cpp` and `viewer2d/viewer2dpdfexporter.cpp` and reported as successful in the local repo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ead8705648324ae0b7cde28b4c28b)