### PR TITLE
Center legend symbols within symbol column (UI and PDF export)

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -2147,8 +2147,10 @@ wxImage LayoutViewerPanel::BuildLegendImage(
                        static_cast<double>(symbolSize) / symbolH);
           double drawW = symbolW * scale;
           double drawH = symbolH * scale;
-          double symbolDrawLeft =
-              xSymbol + (static_cast<double>(symbolSlotSize) - drawW);
+          double symbolInset =
+              std::max(0.0,
+                       (static_cast<double>(symbolSlotSize) - drawW) * 0.5);
+          double symbolDrawLeft = xSymbol + symbolInset;
           double symbolDrawTop =
               y + (static_cast<double>(rowHeightPx) - drawH) * 0.5;
 

--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -2187,9 +2187,10 @@ Viewer2DExportResult ExportLayoutToPdf(
               double drawH = symbolH * scale;
               double rowBottom = rowTop - rowHeight;
               double symbolBoxY = rowBottom + (rowHeight - symbolSize) * 0.5;
+              double symbolInset =
+                  std::max(0.0, (symbolSlotSize - drawW) * 0.5);
               double symbolOffsetX =
-                  xSymbol + (symbolSlotSize - drawW) -
-                  symbol->bounds.min.x * scale;
+                  xSymbol + symbolInset - symbol->bounds.min.x * scale;
               double symbolOffsetY =
                   symbolBoxY + (symbolSize - drawH) * 0.5 -
                   symbol->bounds.min.y * scale;


### PR DESCRIPTION
### Motivation
- Legend symbol drawings were left-aligned inside a narrow symbol column and could be visually clipped or sit outside the table. 
- The UI legend renderer and the PDF export used different placement logic, causing inconsistent appearance. 
- Centering symbols in the available slot improves readability for small columns. 
- Keep symbol scaling and slot sizing behavior unchanged while adjusting horizontal placement. 

### Description
- Update `gui/layoutviewerpanel.cpp` to compute a `symbolInset` and set `symbolDrawLeft = xSymbol + symbolInset` so symbols are centered within the `symbolSlotSize` when rendering the legend bitmap. 
- Apply the same centering calculation in `viewer2d/viewer2dpdfexporter.cpp` by computing `symbolInset` and using it when composing the PDF content stream's symbol offset. 
- The centering uses `std::max(0.0, (symbolSlotSize - drawW) * 0.5)` to avoid negative insets and preserve existing scaling logic. 
- No other layout, scaling, or column width changes were made. 

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eb0a0e44083248592e17338e270a7)