### PR TITLE
Fix legend symbol column width

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -2000,7 +2000,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   const int columnGap = 8;
   const int symbolColumnGap = 4;
   constexpr double kLegendLineSpacingScale = 0.8;
-  constexpr double kLegendSymbolColumnScale = 1.0 / 3.0;
+  constexpr double kLegendSymbolColumnScale = 1.0;
   const int totalRows = static_cast<int>(items.size()) + 1;
   const int baseHeight = logicalSize.GetHeight() > 0 ? logicalSize.GetHeight()
                                                      : size.GetHeight();

--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -2064,7 +2064,7 @@ Viewer2DExportResult ExportLayoutToPdf(
     const double columnGap = 8.0;
     const double symbolColumnGap = 4.0;
     constexpr double kLegendLineSpacingScale = 0.8;
-    constexpr double kLegendSymbolColumnScale = 1.0 / 3.0;
+    constexpr double kLegendSymbolColumnScale = 1.0;
     const double separatorGap = 2.0;
     const size_t totalRows = legend.items.size() + 1;
     const double availableHeight = frameH - padding * 2.0 - separatorGap;


### PR DESCRIPTION
### Motivation
- Legend symbols were being drawn too far to the right and overlapping the next column after prior adjustments, so the column allocation needs to be widened to keep symbols centered.
- The goal is to make legend symbol layout consistent between on-screen rendering and PDF export.

### Description
- Increase the legend symbol column scale by changing `kLegendSymbolColumnScale` from `1.0/3.0` to `1.0` in `gui/layoutviewerpanel.cpp` to allocate full-width symbol slots.
- Apply the same change to `viewer2d/viewer2dpdfexporter.cpp` so PDF export uses the same symbol column sizing.
- The change affects only the computed `symbolSlotSize` used for symbol placement and does not alter textual columns or other layout logic.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eb51d1aa88324b0f84b87449a268b)