### PR TITLE
Reduce legend symbol column spacing

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1998,9 +1998,9 @@ wxImage LayoutViewerPanel::BuildLegendImage(
 
   const int padding = 8;
   const int columnGap = 8;
-  const int symbolColumnGap = 4;
+  const int symbolColumnGap = 2;
   constexpr double kLegendLineSpacingScale = 0.8;
-  constexpr double kLegendSymbolColumnScale = 1.0;
+  constexpr double kLegendSymbolColumnScale = 0.8;
   const int totalRows = static_cast<int>(items.size()) + 1;
   const int baseHeight = logicalSize.GetHeight() > 0 ? logicalSize.GetHeight()
                                                      : size.GetHeight();

--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -2062,9 +2062,9 @@ Viewer2DExportResult ExportLayoutToPdf(
 
     const double padding = 8.0;
     const double columnGap = 8.0;
-    const double symbolColumnGap = 4.0;
+    const double symbolColumnGap = 2.0;
     constexpr double kLegendLineSpacingScale = 0.8;
-    constexpr double kLegendSymbolColumnScale = 1.0;
+    constexpr double kLegendSymbolColumnScale = 0.8;
     const double separatorGap = 2.0;
     const size_t totalRows = legend.items.size() + 1;
     const double availableHeight = frameH - padding * 2.0 - separatorGap;


### PR DESCRIPTION
### Motivation
- Reducir el espacio en blanco a ambos lados de los símbolos dentro de las leyendas para evitar columnas excesivamente anchas en la UI.
- Alinear el espaciado visual entre la vista en pantalla y la exportación a PDF para obtener resultados consistentes.

### Description
- Disminuye `symbolColumnGap` de `4` a `2` en `gui/layoutviewerpanel.cpp` para compactar la columna de símbolos en la vista de UI.
- Reduce la escala de columna de símbolo (`kLegendSymbolColumnScale`) de `1.0` a `0.8` en `gui/layoutviewerpanel.cpp` para ajustar el ancho reservado al símbolo.
- Aplica los mismos cambios en `viewer2d/viewer2dpdfexporter.cpp` para que las leyendas exportadas a PDF usen el mismo espaciado.
- Los cambios afectan al cálculo de `symbolSlotSize`, `xCount`, `xType` y `xCh` usados para posicionar texto y símbolos en las leyendas.

### Testing
- No se ejecutaron pruebas automatizadas como parte de este cambio.
- Ninguna suite de pruebas informó resultados (no solicitadas ni ejecutadas).
- Se generó y confirmó el commit local que contiene los cambios en `gui/layoutviewerpanel.cpp` y `viewer2d/viewer2dpdfexporter.cpp`.
- Recomendado: ejecutar la suite de UI y la exportación a PDF en CI para verificar el ajuste visual en pantallas y PDF.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eb73ccadc83249859e801779862b8)