### PR TITLE
Tighten legend table padding and shorten channel header to `Ch`

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1996,7 +1996,10 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   dc.SetTextForeground(wxColour(20, 20, 20));
   dc.SetPen(*wxTRANSPARENT_PEN);
 
-  const int padding = 8;
+  const int paddingLeft = 4;
+  const int paddingRight = 4;
+  const int paddingTop = 6;
+  const int paddingBottom = 2;
   const int columnGap = 8;
   const int symbolColumnGap = 2;
   constexpr double kLegendLineSpacingScale = 0.8;
@@ -2005,8 +2008,8 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   const int baseHeight = logicalSize.GetHeight() > 0 ? logicalSize.GetHeight()
                                                      : size.GetHeight();
   const double separatorGap = 2.0;
-  const double availableHeight =
-      static_cast<double>(baseHeight) - padding * 2 - separatorGap;
+  const double availableHeight = static_cast<double>(baseHeight) -
+                                 paddingTop - paddingBottom - separatorGap;
   double fontSize =
       totalRows > 0 ? (static_cast<double>(availableHeight) / totalRows) - 2.0
                     : 10.0;
@@ -2029,7 +2032,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
 
   dc.SetFont(baseFont);
   int maxCountWidth = measureTextWidth("Count");
-  int maxChWidth = measureTextWidth("Ch Count");
+  int maxChWidth = measureTextWidth("Ch");
   for (const auto &item : items) {
     maxCountWidth =
         std::max(maxCountWidth, measureTextWidth(wxString::Format("%d", item.count)));
@@ -2079,16 +2082,22 @@ wxImage LayoutViewerPanel::BuildLegendImage(
           (maxSymbolDrawWidth > 0.0 ? maxSymbolDrawWidth : symbolSize) *
           kLegendSymbolColumnScale)));
   const int rowHeightPx = baseRowHeightPx;
-  const int paddingPx =
-      std::max(0, static_cast<int>(std::lround(padding * renderZoom)));
+  const int paddingLeftPx =
+      std::max(0, static_cast<int>(std::lround(paddingLeft * renderZoom)));
+  const int paddingRightPx =
+      std::max(0, static_cast<int>(std::lround(paddingRight * renderZoom)));
+  const int paddingTopPx =
+      std::max(0, static_cast<int>(std::lround(paddingTop * renderZoom)));
+  const int paddingBottomPx =
+      std::max(0, static_cast<int>(std::lround(paddingBottom * renderZoom)));
   const int columnGapPx =
       std::max(0, static_cast<int>(std::lround(columnGap * renderZoom)));
   const int symbolColumnGapPx =
       std::max(0, static_cast<int>(std::lround(symbolColumnGap * renderZoom)));
-  int xSymbol = paddingPx;
+  int xSymbol = paddingLeftPx;
   int xCount = xSymbol + symbolSlotSize + symbolColumnGapPx;
   int xType = xCount + maxCountWidth + columnGapPx;
-  int xCh = size.GetWidth() - paddingPx - maxChWidth;
+  int xCh = size.GetWidth() - paddingRightPx - maxChWidth;
   if (xCh < xType + columnGapPx)
     xCh = xType + columnGapPx;
   int typeWidth = std::max(0, xCh - xType - columnGapPx);
@@ -2111,23 +2120,23 @@ wxImage LayoutViewerPanel::BuildLegendImage(
     return trimmed + ellipsis;
   };
 
-  int y = paddingPx;
+  int y = paddingTopPx;
   const int textOffset =
       std::max(0, (rowHeightPx - textHeight) / 2);
   dc.SetFont(headerFont);
   dc.DrawText("Count", xCount, y + textOffset);
   dc.DrawText("Type", xType, y + textOffset);
-  dc.DrawText("Ch Count", xCh, y + textOffset);
+  dc.DrawText("Ch", xCh, y + textOffset);
 
   y += rowHeightPx;
   dc.SetPen(wxPen(wxColour(200, 200, 200)));
-  dc.DrawLine(paddingPx, y, size.GetWidth() - paddingPx, y);
+  dc.DrawLine(paddingLeftPx, y, size.GetWidth() - paddingRightPx, y);
   y += separatorGapPx;
 
   dc.SetFont(baseFont);
   LegendSymbolBackend backend(dc);
   for (const auto &item : items) {
-    if (y + rowHeightPx > size.GetHeight() - paddingPx)
+    if (y + rowHeightPx > size.GetHeight() - paddingBottomPx)
       break;
     wxString countText = wxString::Format("%d", item.count);
     wxString typeText =

--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -2060,14 +2060,18 @@ Viewer2DExportResult ExportLayoutToPdf(
                   << formatter.Format(frameW) << ' '
                   << formatter.Format(frameH) << " re f\n";
 
-    const double padding = 8.0;
+    const double paddingLeft = 4.0;
+    const double paddingRight = 4.0;
+    const double paddingTop = 6.0;
+    const double paddingBottom = 2.0;
     const double columnGap = 8.0;
     const double symbolColumnGap = 2.0;
     constexpr double kLegendLineSpacingScale = 0.8;
     constexpr double kLegendSymbolColumnScale = 0.8;
     const double separatorGap = 2.0;
     const size_t totalRows = legend.items.size() + 1;
-    const double availableHeight = frameH - padding * 2.0 - separatorGap;
+    const double availableHeight =
+        frameH - paddingTop - paddingBottom - separatorGap;
     double fontSize =
         totalRows > 0 ? (availableHeight / totalRows) - 2.0 : 10.0;
     fontSize = std::clamp(fontSize, 6.0, 14.0);
@@ -2076,7 +2080,7 @@ Viewer2DExportResult ExportLayoutToPdf(
     double maxCountWidth =
         MeasureTextWidth("Count", fontSize, fontCatalog.bold);
     double maxChWidth =
-        MeasureTextWidth("Ch Count", fontSize, fontCatalog.bold);
+        MeasureTextWidth("Ch", fontSize, fontCatalog.bold);
     for (const auto &item : legend.items) {
       maxCountWidth = std::max(
           maxCountWidth,
@@ -2120,10 +2124,10 @@ Viewer2DExportResult ExportLayoutToPdf(
         std::max(rowHeightCandidate * kLegendLineSpacingScale, lineHeight);
     const double textOffset =
         std::max(0.0, (rowHeight - textHeightEstimate) * 0.5);
-    double xSymbol = frameX + padding;
+    double xSymbol = frameX + paddingLeft;
     double xCount = xSymbol + symbolSlotSize + symbolColumnGap;
     double xType = xCount + maxCountWidth + columnGap;
-    double xCh = frameX + frameW - padding - maxChWidth;
+    double xCh = frameX + frameW - paddingRight - maxChWidth;
     if (xCh < xType + columnGap)
       xCh = xType + columnGap;
     double typeWidth = std::max(0.0, xCh - xType - columnGap);
@@ -2139,27 +2143,27 @@ Viewer2DExportResult ExportLayoutToPdf(
                     << escapeText(text) << ") Tj\nET\n";
     };
 
-    double rowTop = frameY + frameH - padding;
+    double rowTop = frameY + frameH - paddingTop;
     // Use a bold PDF font for legend headers to keep emphasis consistent with
     // the UI and avoid diverging header styling between PDF and on-screen views.
     appendText(xCount, rowTop - textOffset - fontSize, "Count", "F2", 0.08,
                0.08, 0.08);
     appendText(xType, rowTop - textOffset - fontSize, "Type", "F2", 0.08, 0.08,
                0.08);
-    appendText(xCh, rowTop - textOffset - fontSize, "Ch Count", "F2", 0.08,
+    appendText(xCh, rowTop - textOffset - fontSize, "Ch", "F2", 0.08,
                0.08, 0.08);
 
     const double separatorY = rowTop - rowHeight;
     contentStream << formatter.Format(0.78) << ' ' << formatter.Format(0.78)
                   << ' ' << formatter.Format(0.78) << " RG 0.5 w "
-                  << formatter.Format(frameX + padding) << ' '
+                  << formatter.Format(frameX + paddingLeft) << ' '
                   << formatter.Format(separatorY) << " m "
-                  << formatter.Format(frameX + frameW - padding) << ' '
+                  << formatter.Format(frameX + frameW - paddingRight) << ' '
                   << formatter.Format(separatorY) << " l S\n";
 
     rowTop = separatorY - separatorGap;
     for (const auto &item : legend.items) {
-      if (rowTop - rowHeight < frameY + padding)
+      if (rowTop - rowHeight < frameY + paddingBottom)
         break;
       const std::string countText = std::to_string(item.count);
       std::string typeText =


### PR DESCRIPTION
### Motivation
- Reduce excessive left whitespace in legend tables while keeping overall layout intact.
- Remove extra blank space after the last legend row so the table height better matches content.
- Shorten the long `Ch Count` header to `Ch` because the values are at most three characters.

### Description
- Replaced a single `padding` value with `paddingLeft`, `paddingRight`, `paddingTop`, and `paddingBottom` in `LayoutViewerPanel::BuildLegendImage` to tighten left and bottom spacing and recalc available height and positions.
- Shortened the channel header text and width calculation from `"Ch Count"` to `"Ch"` and adjusted column x positions and measurements in `gui/layoutviewerpanel.cpp`.
- Mirrored the same padding and header changes in the PDF renderer by adding per-side padding and changing `"Ch Count"` to `"Ch"` in `viewer2d/viewer2dpdfexporter.cpp` so exported PDFs match on-screen rendering.
- Adjusted separator line drawing and row clipping to use the new left/right/top/bottom padding values to eliminate the extra top/ bottom whitespace.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eb9271ae883248c24a84b8ae9ef51)