### PR TITLE
Shift legend content left and expand 'Ch' column spacing

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -2041,6 +2041,9 @@ wxImage LayoutViewerPanel::BuildLegendImage(
                           : wxString("-");
     maxChWidth = std::max(maxChWidth, measureTextWidth(chText));
   }
+  const int leftTrimPx = measureTextWidth("000");
+  const int chExtraWidthPx = measureTextWidth("0");
+  maxChWidth += chExtraWidthPx;
 
   int textHeight = 0;
   int lineWidth = 0;
@@ -2094,7 +2097,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
       std::max(0, static_cast<int>(std::lround(columnGap * renderZoom)));
   const int symbolColumnGapPx =
       std::max(0, static_cast<int>(std::lround(symbolColumnGap * renderZoom)));
-  int xSymbol = paddingLeftPx;
+  int xSymbol = paddingLeftPx - leftTrimPx;
   int xCount = xSymbol + symbolSlotSize + symbolColumnGapPx;
   int xType = xCount + maxCountWidth + columnGapPx;
   int xCh = size.GetWidth() - paddingRightPx - maxChWidth;
@@ -2130,7 +2133,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
 
   y += rowHeightPx;
   dc.SetPen(wxPen(wxColour(200, 200, 200)));
-  dc.DrawLine(paddingLeftPx, y, size.GetWidth() - paddingRightPx, y);
+  dc.DrawLine(xSymbol, y, size.GetWidth() - paddingRightPx, y);
   y += separatorGapPx;
 
   dc.SetFont(baseFont);

--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -2092,6 +2092,10 @@ Viewer2DExportResult ExportLayoutToPdf(
           maxChWidth,
           MeasureTextWidth(chText, fontSize, fontCatalog.regular));
     }
+    const double leftTrim = MeasureTextWidth("000", fontSize, fontCatalog.regular);
+    const double chExtraWidth =
+        MeasureTextWidth("0", fontSize, fontCatalog.regular);
+    maxChWidth += chExtraWidth;
 
     const double rowHeightCandidate =
         totalRows > 0 ? (availableHeight / totalRows) : 0.0;
@@ -2124,7 +2128,7 @@ Viewer2DExportResult ExportLayoutToPdf(
         std::max(rowHeightCandidate * kLegendLineSpacingScale, lineHeight);
     const double textOffset =
         std::max(0.0, (rowHeight - textHeightEstimate) * 0.5);
-    double xSymbol = frameX + paddingLeft;
+    double xSymbol = frameX + paddingLeft - leftTrim;
     double xCount = xSymbol + symbolSlotSize + symbolColumnGap;
     double xType = xCount + maxCountWidth + columnGap;
     double xCh = frameX + frameW - paddingRight - maxChWidth;
@@ -2156,7 +2160,7 @@ Viewer2DExportResult ExportLayoutToPdf(
     const double separatorY = rowTop - rowHeight;
     contentStream << formatter.Format(0.78) << ' ' << formatter.Format(0.78)
                   << ' ' << formatter.Format(0.78) << " RG 0.5 w "
-                  << formatter.Format(frameX + paddingLeft) << ' '
+                  << formatter.Format(xSymbol) << ' '
                   << formatter.Format(separatorY) << " m "
                   << formatter.Format(frameX + frameW - paddingRight) << ' '
                   << formatter.Format(separatorY) << " l S\n";


### PR DESCRIPTION
### Motivation
- Reduce the large empty margin left of legend symbols by shifting legend content left by roughly three character widths. 
- Ensure the `Ch` (channel count) column has a bit more room so single-digit channel counts don't crowd the column. 
- Keep PDF exports visually consistent with the on-screen legend layout. 

### Description
- In `gui/layoutviewerpanel.cpp` computed a `leftTrimPx` (`measureTextWidth("000")`) and subtract it from the symbol X origin (`xSymbol`) to shift the legend content left. 
- Increased `maxChWidth` by one character width (`measureTextWidth("0")`) so the `Ch` column is slightly wider. 
- Mirrored the same adjustments in `viewer2d/viewer2dpdfexporter.cpp` using `leftTrim` and `chExtraWidth`, and updated the legend separator line to use the adjusted `xSymbol`. 

### Testing
- No automated tests were run for this change. 
- Visual verification is implied by the change (on-screen and PDF alignment adjustments) but not executed as part of automated tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eba9e83608324b2b38c70559ab778)