### PR TITLE
Set new layouts to landscape by default

### DIFF
--- a/core/layouts/LayoutCollection.cpp
+++ b/core/layouts/LayoutCollection.cpp
@@ -276,7 +276,7 @@ LayoutDefinition LayoutCollection::DefaultLayout() {
   LayoutDefinition layout;
   layout.name = "Layout 1";
   layout.pageSetup.pageSize = print::PageSize::A4;
-  layout.pageSetup.landscape = false;
+  layout.pageSetup.landscape = true;
   layout.view2dViews.clear();
   layout.legendViews.clear();
   return layout;

--- a/gui/layoutpanel.cpp
+++ b/gui/layoutpanel.cpp
@@ -184,7 +184,7 @@ void LayoutPanel::OnAddLayout(wxCommandEvent &) {
   layouts::LayoutDefinition layout;
   layout.name = name;
   layout.pageSetup.pageSize = print::PageSize::A4;
-  layout.pageSetup.landscape = false;
+  layout.pageSetup.landscape = true;
 
   if (!layouts::LayoutManager::Get().AddLayout(layout)) {
     wxMessageBox("Could not add layout.", "Add Layout", wxOK | wxICON_ERROR,

--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -528,7 +528,7 @@ LayoutViewerPanel::LayoutViewerPanel(wxWindow *parent)
   SetBackgroundStyle(wxBG_STYLE_CUSTOM);
   glContext_ = new wxGLContext(this);
   currentLayout.pageSetup.pageSize = print::PageSize::A4;
-  currentLayout.pageSetup.landscape = false;
+  currentLayout.pageSetup.landscape = true;
   ResetViewToFit();
 }
 


### PR DESCRIPTION
### Motivation
- New layouts should default to a landscape orientation instead of portrait for expected printing and viewing behavior.
- Make the default in the core collection consistent with the UI creation paths to avoid mismatches.
- Ensure the layout viewer starts with the same default orientation as newly created layouts.

### Description
- Set `pageSetup.landscape = true` in `layouts::LayoutCollection::DefaultLayout()` in `core/layouts/LayoutCollection.cpp`.
- Set `pageSetup.landscape = true` when creating a new layout in `LayoutPanel::OnAddLayout` (`gui/layoutpanel.cpp`).
- Initialize `currentLayout.pageSetup.landscape = true` in `LayoutViewerPanel` constructor (`gui/layoutviewerpanel.cpp`).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960e82620048324a5855be15b05d485)