### PR TITLE
Update toolbar icon mapping and help/README for layouts, hoists and rigging

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ The application is built with **wxWidgets** for the user interface and **OpenGL*
 - **Project management**
   - Open and save Perastage projects.
   - Keep fixtures, trusses and scene objects grouped in layers.
+  - Manage multiple printable layouts with stored page settings.
   - Central configuration management for paths and user preferences.
 
-- **Fixture and truss model**
-  - Internal data model for fixtures, trusses and generic scene objects.
+- **Fixture, truss, and hoist model**
+  - Internal data model for fixtures, trusses, hoists, and generic scene objects.
   - Layer support (visibility and selection per layer).
   - Basic geometry and transform helpers for positioning elements in the scene.
 
@@ -45,12 +46,14 @@ The application is built with **wxWidgets** for the user interface and **OpenGL*
     axes and labels) are preserved in draw order so an exporter can reproduce the
     exact frame the user saw on screen.
   - Camera and navigation helpers in the 3D viewer.
+  - Layout mode with printable 2D view frames and fixture legends.
 
 - **GUI helpers**
-  - Tables for fixtures, trusses and scene objects.
+  - Tables for fixtures, trusses, hoists, and scene objects.
   - Multi-edit shortcuts in tables, including range interpolation (`1 10`,
     `1 thru 10`) and sequential fills with trailing separators.
-  - Summary and console panels.
+  - Layout list and layout preview panels for print layout composition.
+  - Summary, rigging, and console panels.
   - Dialogs for preferences, login, fixture type selection, GDTF search, export options, etc.
 
 ---

--- a/help.md
+++ b/help.md
@@ -9,6 +9,7 @@ Perastage is a high-performance, cross-platform viewer for MVR (My Virtual Rig) 
 3. Navigate through the 3D viewport and explore scene elements via:
    - Fixtures Table
    - Trusses Table
+   - Hoists Table
    - Objects Table
 4. Use the **View** menu to toggle visibility of side panels and tables.
 
@@ -18,14 +19,14 @@ Perastage is a high-performance, cross-platform viewer for MVR (My Virtual Rig) 
 
 | Key Combination | Function             |
 |-----------------|----------------------|
-| Ctrl+N          | New project          |
-| Ctrl+L          | Load project         |
-| Ctrl+S          | Save project         |
-| Ctrl+Q          | Close application    |
-| Ctrl+Z / Ctrl+Y | Undo / Redo          |
-| Del             | Delete selection     |
-| F1              | Open help            |
-| 1 / 2 / 3       | Switch between tables|
+| Ctrl+N          | New project               |
+| Ctrl+L          | Load project              |
+| Ctrl+S          | Save project              |
+| Ctrl+Q          | Close application         |
+| Ctrl+Z / Ctrl+Y | Undo / Redo               |
+| Del             | Delete selection          |
+| F1              | Open help                 |
+| 1 / 2 / 3 / 4   | Fixtures / Trusses / Hoists / Objects |
 
 ### 3D Viewer
 
@@ -63,6 +64,11 @@ Perastage is a high-performance, cross-platform viewer for MVR (My Virtual Rig) 
 - Rotation columns are labeled **Roll (X)**, **Pitch (Y)** and **Yaw (Z)**.
 - Export functionality provided by `ExportTrussDialog`.
 
+### Hoists Table
+- Displays imported hoists (supports) with position, load, and metadata.
+- Function values are normalized using built-in hoist function presets.
+- Convert fixtures to hoists using **Tools → Convert to Hoist**.
+
 ### Objects Table
 - Lists generic scene objects and their transforms.
 - Rotation columns are labeled **Roll (X)**, **Pitch (Y)** and **Yaw (Z)**.
@@ -74,8 +80,16 @@ Perastage is a high-performance, cross-platform viewer for MVR (My Virtual Rig) 
 ### Layer Panel
 - Lists scene layers and lets you choose the active layer for new objects.
 
+### Layouts Panel
+- Lists available layout pages and lets you add, rename, or delete layouts.
+- Activate a layout to view and edit its 2D views and legends in layout mode.
+
 ### Summary Panel
-- Provides counts and basic statistics for fixtures, trusses and objects.
+- Provides counts and basic statistics for fixtures, trusses, hoists, and objects.
+
+### Rigging Panel
+- Summarizes fixture/truss/hoist counts and total weights per position.
+- Highlights rows with missing weights for quick validation.
 
 ### 2D Render Options Panel
 - Controls the 2D viewport render mode, grid appearance, and label visibility.
@@ -107,12 +121,12 @@ Perastage is a high-performance, cross-platform viewer for MVR (My Virtual Rig) 
 | Load          | Open an existing project (`Ctrl+L`)        |
 | Save          | Save the current project (`Ctrl+S`)        |
 | Save As       | Save project under a new name              |
-| Import Rider  | Load fixture/truss info from `.txt`/`.pdf` |
 | Import MVR    | Load an `.mvr` scene file                  |
 | Export MVR    | Write current scene to MVR                 |
+| Print Viewer 2D | Print the current 2D view                |
+| Print Layout  | Print the active layout to PDF             |
 | Print Table   | Print one of the data tables               |
 | Export CSV    | Export table data to CSV                   |
-| Recent Files  | Access previously opened scenes            |
 | Close         | Close the application (`Ctrl+Q`)           |
 
 ## Edit Menu
@@ -132,25 +146,31 @@ Perastage is a high-performance, cross-platform viewer for MVR (My Virtual Rig) 
 | Menu Option        | Description                                  |
 |--------------------|----------------------------------------------|
 | Console            | Show/hide console output                     |
-| Fixtures           | Toggle table notebook (Fixtures/Trusses/Objects) |
+| Fixtures           | Toggle table notebook (Fixtures/Trusses/Hoists/Objects) |
 | 3D Viewport        | Enable or disable 3D rendering               |
 | 2D Viewport        | Enable or disable top-down view              |
 | 2D Render Options  | Show/hide render options for 2D view          |
 | Layers             | Toggle layer panel                           |
+| Layouts            | Toggle layout list panel                     |
 | Summary            | Toggle summary panel                         |
-| Layout → Default   | Restore default panel layout                 |
-| Layout → 2D        | Activate preset 2D layout                    |
+| Rigging            | Toggle rigging weight summary panel          |
+| Layout Views → 3D Layout View | Restore default panel layout       |
+| Layout Views → 2D Layout View | Activate preset 2D layout        |
+| Layout Views → Layout Mode View | Enter layout editing mode       |
 
 ## Tools Menu
 
 | Menu Option           | Description                                   |
 |-----------------------|-----------------------------------------------|
 | Download GDTF fixture | Fetch a fixture from GDTF‑Share               |
+| Edit dictionaries     | Edit fixture dictionaries and metadata        |
+| Create from text      | Build fixtures from a text rider              |
 | Export Fixture        | Export selected fixtures to GDTF              |
 | Export Truss          | Export selected trusses                       |
 | Export Scene Object   | Export selected scene object model            |
 | Auto patch            | Assign addresses automatically to fixtures   |
 | Auto color            | Assign colors by fixture type; truss layers become light gray |
+| Convert to Hoist      | Convert selected fixtures into hoists         |
 
 ## Console Commands
 
@@ -192,7 +212,7 @@ Values are in meters for position and degrees for rotation.
    fixtures 1–4 by one meter.
 4. Choose **Tools → Auto patch** to assign DMX addresses.
 5. Choose **Tools → Auto color** to color fixtures by type and set truss layers to light gray.
-6. Enable **View → Summary** to review fixture counts.
+6. Enable **View → Summary** or **View → Rigging** to review counts and weights.
 7. Export data with **File → Export CSV**.
 
 ## Configuration Management

--- a/resources/icons/icons-usage.json
+++ b/resources/icons/icons-usage.json
@@ -7,6 +7,6 @@
     "Import MVR": "outline/file-input.svg",
     "Export MVR": "outline/file-output.svg",
     "Layout 2D View": "outline/panel-top-bottom-dashed.svg",
-    "Layout Legend": "outline/square-chart-gantt.svg"
+    "Layout Legend": "outline/list.svg"
   }
 }


### PR DESCRIPTION
### Motivation
- Align the toolbar icon mapping with the actual icon used for the layout legend in the resources.
- Bring the help and README documentation in sync with the current UI: add hoists (supports), layout tooling and the rigging summary panel.
- Remove or adjust outdated entries and reflect current menu items and keyboard shortcuts.
- Ensure users can find and use features such as layout printing, layout mode and hoist conversion from the docs.

### Description
- Changed the toolbar icon mapping: in `resources/icons/icons-usage.json` the `"Layout Legend"` entry now points to `"outline/list.svg"` instead of `"outline/square-chart-gantt.svg"`.
- Updated user help in `help.md` to document the Hoists table, Layouts panel, Rigging panel, updated View/Tools/File menu options (including `Print Viewer 2D`, `Print Layout`, `Layout Views` submenu) and the expanded keyboard shortcut table (`1 / 2 / 3 / 4`).
- Updated the top-level project overview in `README.md` to mention layouts, hoists and the rigging summary and to list the layout-related UI pieces.
- Commit message: `Update icon usage and help docs` (changes are limited to icons and documentation files).

### Testing
- No automated tests were run (`ctest` not executed) because this PR only updates documentation and an icon mapping.
- Manual verification: updated JSON and markdown files were committed and reviewed for consistency in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960e9ac67948324863d01cb8b603124)