### PR TITLE
Add toolbar group metadata to icons-usage.json

### DIFF
--- a/resources/icons/icons-usage.json
+++ b/resources/icons/icons-usage.json
@@ -3,42 +3,50 @@
     {
       "name": "New",
       "icon": "outline/file.svg",
-      "description": "Creates a new project or document."
+      "description": "Creates a new project or document.",
+      "group": "FileToolbar"
     },
     {
       "name": "Load",
       "icon": "outline/folder-open.svg",
-      "description": "Opens an existing project or file from disk."
+      "description": "Opens an existing project or file from disk.",
+      "group": "FileToolbar"
     },
     {
       "name": "Save",
       "icon": "outline/save.svg",
-      "description": "Saves the current project or document."
+      "description": "Saves the current project or document.",
+      "group": "FileToolbar"
     },
     {
       "name": "Save As",
       "icon": "outline/save-all.svg",
-      "description": "Saves the current project under a new name or location."
+      "description": "Saves the current project under a new name or location.",
+      "group": "FileToolbar"
     },
     {
       "name": "Import MVR",
       "icon": "outline/file-input.svg",
-      "description": "Imports an MVR file into the project."
+      "description": "Imports an MVR file into the project.",
+      "group": "FileToolbar"
     },
     {
       "name": "Export MVR",
       "icon": "outline/file-output.svg",
-      "description": "Exports the current project as an MVR file."
+      "description": "Exports the current project as an MVR file.",
+      "group": "FileToolbar"
     },
     {
       "name": "Layout 2D View",
       "icon": "outline/panel-top-bottom-dashed.svg",
-      "description": "Toggles or applies the 2D view layout."
+      "description": "Toggles or applies the 2D view layout.",
+      "group": "LayoutToolbar"
     },
     {
       "name": "Layout Legend",
       "icon": "outline/list.svg",
-      "description": "Shows or hides the layout legend panel."
+      "description": "Shows or hides the layout legend panel.",
+      "group": "LayoutToolbar"
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- Toolbar icons currently lacked information about which toolbar group they belong to, making organization and maintenance harder.
- The change documents whether each tool is part of the file-related or layout-related toolbar to aid discoverability and future automation.
- Keeping the data in JSON preserves machine-readability for tools that may consume this file.

### Description
- Added a `group` property to each toolbar entry in `resources/icons/icons-usage.json`.
- Assigned `FileToolbar` to file-related actions and `LayoutToolbar` to layout-related actions.
- Preserved existing `name`, `icon`, and `description` fields and JSON structure.
- Updated eight toolbar entries to include the new `group` metadata.

### Testing
- No automated tests were run for this change.
- Please run project CI or linters as needed to validate integration and formatting.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960f70b4ce4832490bef29315ffc972)