### PR TITLE
Add Layout Views toolbar (visible by default)

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -566,6 +566,33 @@ void MainWindow::CreateToolBars() {
                        .Row(0)
                        .Position(0));
 
+  layoutViewsToolBar =
+      new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
+                       wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_HORIZONTAL);
+  layoutViewsToolBar->SetToolBitmapSize(wxSize(16, 16));
+  layoutViewsToolBar->AddTool(ID_View_Layout_Default, "Vista layout 3D",
+                              loadToolbarIcon("square-chart-gantt",
+                                              wxART_MISSING_IMAGE),
+                              "Switch to 3D Layout View");
+  layoutViewsToolBar->AddTool(ID_View_Layout_2D, "Vista layout 2D",
+                              loadToolbarIcon("panel-top-bottom-dashed",
+                                              wxART_MISSING_IMAGE),
+                              "Switch to 2D Layout View");
+  layoutViewsToolBar->AddTool(ID_View_Layout_Mode, "Modo layout",
+                              loadToolbarIcon("list", wxART_MISSING_IMAGE),
+                              "Switch to Layout Mode View");
+  layoutViewsToolBar->Realize();
+  auiManager->AddPane(
+      layoutViewsToolBar, wxAuiPaneInfo()
+                              .Name("LayoutViewsToolbar")
+                              .Caption("Layout Views")
+                              .ToolbarPane()
+                              .Top()
+                              .LeftDockable(false)
+                              .RightDockable(false)
+                              .Row(0)
+                              .Position(1));
+
   layoutToolBar = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition,
                                    wxDefaultSize,
                                    wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_HORIZONTAL);
@@ -2123,6 +2150,9 @@ void MainWindow::OnApplyDefaultLayout(wxCommandEvent &WXUNUSED(event)) {
   auto &fileToolbarPane = auiManager->GetPane("FileToolbar");
   if (fileToolbarPane.IsOk())
     fileToolbarPane.Show();
+  auto &layoutViewsToolbarPane = auiManager->GetPane("LayoutViewsToolbar");
+  if (layoutViewsToolbarPane.IsOk())
+    layoutViewsToolbarPane.Show();
   auiManager->Update();
 
   cfg.SetValue("layout_perspective", perspective);
@@ -2149,6 +2179,9 @@ void MainWindow::OnApply2DLayout(wxCommandEvent &WXUNUSED(event)) {
   auto &fileToolbarPane = auiManager->GetPane("FileToolbar");
   if (fileToolbarPane.IsOk())
     fileToolbarPane.Show();
+  auto &layoutViewsToolbarPane = auiManager->GetPane("LayoutViewsToolbar");
+  if (layoutViewsToolbarPane.IsOk())
+    layoutViewsToolbarPane.Show();
   auiManager->Update();
 
   ConfigManager &cfg = ConfigManager::Get();
@@ -2376,6 +2409,7 @@ void MainWindow::ApplyLayoutModePerspective() {
   showPane("LayoutViewer");
   showPane("FileToolbar");
   showPane("LayoutToolbar");
+  showPane("LayoutViewsToolbar");
 
   hidePane("3DViewport");
   hidePane("2DViewport");

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -92,6 +92,7 @@ private:
   RiggingPanel *riggingPanel = nullptr;
   wxAuiToolBar *fileToolBar = nullptr;
   wxAuiToolBar *layoutToolBar = nullptr;
+  wxAuiToolBar *layoutViewsToolBar = nullptr;
 
   wxAcceleratorTable m_accel;
 


### PR DESCRIPTION
### Motivation
- Provide a new toolbar with quick access to the layout view actions so users can switch between 3D/2D/Layout Mode more easily.
- Make the toolbar visible by default alongside the existing File toolbar in standard, 2D, and layout-mode perspectives. 

### Description
- Added a new member `layoutViewsToolBar` to `gui/mainwindow.h` and created the toolbar in `MainWindow::CreateToolBars()` in `gui/mainwindow.cpp`. 
- Added three tools to the toolbar using the existing `loadToolbarIcon` helper with Lucide SVG icons `square-chart-gantt`, `panel-top-bottom-dashed`, and `list` mapped to `ID_View_Layout_Default`, `ID_View_Layout_2D`, and `ID_View_Layout_Mode` respectively. 
- Registered the toolbar with the `wxAuiManager` as `LayoutViewsToolbar` and positioned it on the top row next to the File toolbar. 
- Ensured the new toolbar is shown in `OnApplyDefaultLayout`, `OnApply2DLayout`, and `ApplyLayoutModePerspective` so it remains visible in default, 2D, and layout-mode perspectives. 

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960f9ad311c83248a1977c4a4a7ea75)