### PR TITLE
Update layout view toolbar icons

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -571,15 +571,16 @@ void MainWindow::CreateToolBars() {
                        wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_HORIZONTAL);
   layoutViewsToolBar->SetToolBitmapSize(wxSize(16, 16));
   layoutViewsToolBar->AddTool(ID_View_Layout_Default, "Vista layout 3D",
-                              loadToolbarIcon("square-chart-gantt",
+                              loadToolbarIcon("box",
                                               wxART_MISSING_IMAGE),
                               "Switch to 3D Layout View");
   layoutViewsToolBar->AddTool(ID_View_Layout_2D, "Vista layout 2D",
-                              loadToolbarIcon("panel-top-bottom-dashed",
+                              loadToolbarIcon("square-asterisk",
                                               wxART_MISSING_IMAGE),
                               "Switch to 2D Layout View");
   layoutViewsToolBar->AddTool(ID_View_Layout_Mode, "Modo layout",
-                              loadToolbarIcon("list", wxART_MISSING_IMAGE),
+                              loadToolbarIcon("panels-right-bottom",
+                                              wxART_MISSING_IMAGE),
                               "Switch to Layout Mode View");
   layoutViewsToolBar->Realize();
   auiManager->AddPane(

--- a/resources/icons/icons-usage.json
+++ b/resources/icons/icons-usage.json
@@ -37,6 +37,24 @@
       "group": "FileToolbar"
     },
     {
+      "name": "Layout 3D View",
+      "icon": "outline/box.svg",
+      "description": "Switches to the 3D layout view preset.",
+      "group": "LayoutViewsToolbar"
+    },
+    {
+      "name": "Layout 2D View",
+      "icon": "outline/square-asterisk.svg",
+      "description": "Switches to the 2D layout view preset.",
+      "group": "LayoutViewsToolbar"
+    },
+    {
+      "name": "Layout Mode View",
+      "icon": "outline/panels-right-bottom.svg",
+      "description": "Switches to the layout mode view for editing.",
+      "group": "LayoutViewsToolbar"
+    },
+    {
       "name": "Layout 2D View",
       "icon": "outline/panel-top-bottom-dashed.svg",
       "description": "Toggles or applies the 2D view layout.",

--- a/resources/icons/outline/box.svg
+++ b/resources/icons/outline/box.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z" />
+  <path d="m3.3 7 8.7 5 8.7-5" />
+  <path d="M12 22V12" />
+</svg>

--- a/resources/icons/outline/panels-right-bottom.svg
+++ b/resources/icons/outline/panels-right-bottom.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="18" height="18" x="3" y="3" rx="2" />
+  <path d="M3 15h12" />
+  <path d="M15 3v18" />
+</svg>

--- a/resources/icons/outline/square-asterisk.svg
+++ b/resources/icons/outline/square-asterisk.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="18" height="18" x="3" y="3" rx="2" />
+  <path d="M12 8v8" />
+  <path d="m8.5 14 7-4" />
+  <path d="m8.5 10 7 4" />
+</svg>


### PR DESCRIPTION
### Motivation

- Replace the existing layout toolbar icons with the requested pictograms for clearer semantics: use `box` for 3D layout, `square-asterisk` for 2D layout and `panels-right-bottom` for layout mode view.
- Ensure the application has the corresponding SVG assets so `loadToolbarIcon` can find and render the icons from resources.
- Keep the icon usage documentation in sync with the code so tooling and designers can find which icons are used for each toolbar.

### Description

- Update `MainWindow::CreateToolBars` in `gui/mainwindow.cpp` to load `box`, `square-asterisk` and `panels-right-bottom` for the layout views toolbar instead of the previous icons.
- Add SVG assets `resources/icons/outline/box.svg`, `resources/icons/outline/square-asterisk.svg`, and `resources/icons/outline/panels-right-bottom.svg` to the resources bundle.
- Update `resources/icons/icons-usage.json` to document the new `Layout 3D View`, `Layout 2D View` and `Layout Mode View` toolbar icons and their groups.
- SVG assets were sourced from the Lucide icon set and placed under the existing `outline` directory so `loadToolbarIcon` can load them via the existing code path.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960fd011ea88324be02d0c33ae449fb)