### PR TITLE
Use Lucide `layout-list` icon for Layout Legend toolbar button

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -603,7 +603,7 @@ void MainWindow::CreateToolBars() {
                                          wxART_MISSING_IMAGE),
                          "Add 2D View to Layout");
   layoutToolBar->AddTool(ID_View_Layout_Legend, "Añadir leyenda",
-                         loadToolbarIcon("list",
+                         loadToolbarIcon("layout-list",
                                          wxART_PLUS),
                          "Add fixture legend to layout");
   layoutToolBar->Realize();

--- a/resources/icons/icons-usage.json
+++ b/resources/icons/icons-usage.json
@@ -62,7 +62,7 @@
     },
     {
       "name": "Layout Legend",
-      "icon": "outline/list.svg",
+      "icon": "outline/layout-list.svg",
       "description": "Shows or hides the layout legend panel.",
       "group": "LayoutToolbar"
     }

--- a/resources/icons/outline/layout-list.svg
+++ b/resources/icons/outline/layout-list.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="4" width="18" height="16" rx="2" />
+  <line x1="7" y1="8" x2="17" y2="8" />
+  <line x1="7" y1="12" x2="17" y2="12" />
+  <line x1="7" y1="16" x2="17" y2="16" />
+</svg>


### PR DESCRIPTION
### Motivation

- Replace the current "Añadir leyenda" toolbar icon with the Lucide `layout-list` icon for visual consistency with the icon set.
- Ensure the icon usage manifest reflects the new SVG so tooling and documentation reference the correct icon.

### Description

- Change the toolbar icon load in `gui/mainwindow.cpp` to call `loadToolbarIcon("layout-list", ...)` for `ID_View_Layout_Legend`.
- Add the new SVG file at `resources/icons/outline/layout-list.svg` containing the Lucide `layout-list` glyph.
- Update `resources/icons/icons-usage.json` to reference `outline/layout-list.svg` for the "Layout Legend" entry.
- No functional behavior changes beyond the toolbar icon and icon metadata updates.

### Testing

- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696148e2bee083248740de494b8ac430)