### PR TITLE
Remove trailing separator from File toolbar

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -552,7 +552,6 @@ void MainWindow::CreateToolBars() {
   fileToolBar->AddTool(ID_File_ExportMVR, "Export MVR",
                        loadToolbarIcon("file-output", wxART_FILE_SAVE),
                        "Export the project to MVR");
-  fileToolBar->AddSeparator();
   fileToolBar->Realize();
 
   auiManager->AddPane(


### PR DESCRIPTION
### Motivation
- The `File` toolbar ended with a separator but there were no tools after it, leaving an unnecessary empty gap.
- The trailing separator provided no functional separation and affected the toolbar appearance.

### Description
- Removed the call to `fileToolBar->AddSeparator();` in `gui/mainwindow.cpp` so the toolbar no longer ends with an extraneous separator.
- The toolbar is now realized immediately after the last file tool with `fileToolBar->Realize();`.
- One source file was modified: `gui/mainwindow.cpp`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69614c933a2c8324bbfa787e3ddbdffb)