### PR TITLE
Ensure Windows installs include wxWidgets runtime DLLs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,22 @@ if(BUILD_TESTING)
     add_subdirectory(tests)
 endif()
 
-install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION .)
+if(WIN32)
+    set(PERASTAGE_RUNTIME_DEPENDENCY_DIRS)
+    if(wxWidgets_LIBRARY_DIRS)
+        foreach(wx_dir IN LISTS wxWidgets_LIBRARY_DIRS)
+            list(APPEND PERASTAGE_RUNTIME_DEPENDENCY_DIRS "${wx_dir}")
+            get_filename_component(wx_parent_dir "${wx_dir}" DIRECTORY)
+            list(APPEND PERASTAGE_RUNTIME_DEPENDENCY_DIRS "${wx_parent_dir}/bin")
+        endforeach()
+    endif()
+    list(REMOVE_DUPLICATES PERASTAGE_RUNTIME_DEPENDENCY_DIRS)
+    install(TARGETS ${PROJECT_NAME}
+        RUNTIME DESTINATION .
+        RUNTIME_DEPENDENCY_SET perastage_runtime_deps)
+else()
+    install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION .)
+endif()
 
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/resources DESTINATION .)
 if(EXISTS "${CMAKE_SOURCE_DIR}/library")
@@ -111,6 +126,11 @@ if(WIN32)
     include(InstallRequiredSystemLibraries)
     install(FILES $<TARGET_RUNTIME_DLLS:${PROJECT_NAME}> DESTINATION .)
     install(FILES $<TARGET_RUNTIME_DLLS:${PROJECT_NAME}> DESTINATION . COMPONENT Runtime)
+    install(RUNTIME_DEPENDENCY_SET perastage_runtime_deps
+        DESTINATION .
+        DIRECTORIES ${PERASTAGE_RUNTIME_DEPENDENCY_DIRS}
+        PRE_EXCLUDE_REGEXES "api-ms-win-.*" "ext-ms-win-.*"
+        POST_EXCLUDE_REGEXES ".*system32/.*")
 endif()
 
 if(CMAKE_CONFIGURATION_TYPES)


### PR DESCRIPTION
### Motivation
- Ensure the Windows installer stage includes wxWidgets runtime DLLs that were previously not being collected by the default install rules.
- Collect runtime dependency directories from the discovered wxWidgets installation so bundled executables have their required DLLs next to them.
- Avoid shipping system DLLs by excluding known system patterns during dependency collection.

### Description
- Add a Windows-only `if(WIN32)` block that collects `wxWidgets_LIBRARY_DIRS` and their parent `bin` directories into `PERASTAGE_RUNTIME_DEPENDENCY_DIRS` and removes duplicates.
- Install the main target with a `RUNTIME_DEPENDENCY_SET perastage_runtime_deps` on Windows and keep the original `install(TARGETS ...)` on non-Windows platforms.
- Add `install(RUNTIME_DEPENDENCY_SET perastage_runtime_deps ...)` with `DIRECTORIES ${PERASTAGE_RUNTIME_DEPENDENCY_DIRS}` and `PRE_EXCLUDE_REGEXES`/`POST_EXCLUDE_REGEXES` to avoid copying API/system runtime DLLs.
- Preserve existing non-Windows install behavior and other install rules (resources, licenses, etc.).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961702af22483248302414d347042dc)