### PR TITLE
Fix Windows CMake install configuration errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,18 +89,7 @@ if(BUILD_TESTING)
 endif()
 
 if(WIN32)
-    set(PERASTAGE_RUNTIME_DEPENDENCY_DIRS)
-    if(wxWidgets_LIBRARY_DIRS)
-        foreach(wx_dir IN LISTS wxWidgets_LIBRARY_DIRS)
-            list(APPEND PERASTAGE_RUNTIME_DEPENDENCY_DIRS "${wx_dir}")
-            get_filename_component(wx_parent_dir "${wx_dir}" DIRECTORY)
-            list(APPEND PERASTAGE_RUNTIME_DEPENDENCY_DIRS "${wx_parent_dir}/bin")
-        endforeach()
-    endif()
-    list(REMOVE_DUPLICATES PERASTAGE_RUNTIME_DEPENDENCY_DIRS)
-    install(TARGETS ${PROJECT_NAME}
-        RUNTIME DESTINATION .
-        RUNTIME_DEPENDENCY_SET perastage_runtime_deps)
+    install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION .)
 else()
     install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION .)
 endif()
@@ -126,11 +115,6 @@ if(WIN32)
     include(InstallRequiredSystemLibraries)
     install(FILES $<TARGET_RUNTIME_DLLS:${PROJECT_NAME}> DESTINATION .)
     install(FILES $<TARGET_RUNTIME_DLLS:${PROJECT_NAME}> DESTINATION . COMPONENT Runtime)
-    install(RUNTIME_DEPENDENCY_SET perastage_runtime_deps
-        DESTINATION .
-        DIRECTORIES ${PERASTAGE_RUNTIME_DEPENDENCY_DIRS}
-        PRE_EXCLUDE_REGEXES "api-ms-win-.*" "ext-ms-win-.*"
-        POST_EXCLUDE_REGEXES ".*system32/.*")
 endif()
 
 if(CMAKE_CONFIGURATION_TYPES)

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -14,10 +14,6 @@
         {
           "name": "BUILD_TESTING",
           "value": "ON"
-        },
-        {
-          "name": "CMAKE_INSTALL_PREFIX",
-          "value": "${projectDir}\\out\\install\\${name}"
         }
       ]
     },
@@ -35,10 +31,6 @@
         {
           "name": "BUILD_TESTING",
           "value": "OFF"
-        },
-        {
-          "name": "CMAKE_INSTALL_PREFIX",
-          "value": "${projectDir}\\out\\install\\${name}"
         }
       ]
     }


### PR DESCRIPTION
### Motivation

- CMake configuration failed on Windows due to the unsupported `RUNTIME_DEPENDENCY_SET` argument in an `install(TARGETS ...)` call.
- Visual Studio CMake settings raised duplicate variable warnings for `CMAKE_INSTALL_PREFIX`.
- The Windows install logic needed simplification to rely on supported runtime DLL handling.
- Reduce platform-specific complexity to improve Windows/MSVC/Ninja configuration stability.

### Description

- Removed the `PERASTAGE_RUNTIME_DEPENDENCY_DIRS` construction and the `RUNTIME_DEPENDENCY_SET perastage_runtime_deps` usage from `CMakeLists.txt`.
- Standardized the target installation to use `install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION .)` for Windows and other platforms.
- Kept the `install(FILES $<TARGET_RUNTIME_DLLS:${PROJECT_NAME}> ...)` DLL bundling for Windows and removed the unsupported `install(RUNTIME_DEPENDENCY_SET ...)` block and its exclude regexes.
- Deleted duplicate `CMAKE_INSTALL_PREFIX` variable entries from both configurations in `CMakeSettings.json` to avoid redefinition warnings.

### Testing

- No automated tests (such as `ctest`) were run for this change.
- The project files `CMakeLists.txt` and `CMakeSettings.json` were updated and committed locally without running a configure or build step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961714d1d188324b70bb65c7f61a703)