### PR TITLE
Include wxWidgets DLLs in Windows install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,23 @@ if(WIN32)
     include(InstallRequiredSystemLibraries)
     install(FILES $<TARGET_RUNTIME_DLLS:${PROJECT_NAME}> DESTINATION .)
     install(FILES $<TARGET_RUNTIME_DLLS:${PROJECT_NAME}> DESTINATION . COMPONENT Runtime)
+
+    set(PERASTAGE_WX_DLLS "")
+    foreach(wx_dir IN LISTS wxWidgets_LIBRARY_DIRS)
+        if(wx_dir)
+            list(APPEND PERASTAGE_WX_DLLS
+                "${wx_dir}/wxmsw*.dll"
+                "${wx_dir}/wxbase*.dll")
+            get_filename_component(wx_bin_dir "${wx_dir}/../bin" ABSOLUTE)
+            list(APPEND PERASTAGE_WX_DLLS
+                "${wx_bin_dir}/wxmsw*.dll"
+                "${wx_bin_dir}/wxbase*.dll")
+        endif()
+    endforeach()
+    file(GLOB PERASTAGE_WX_RUNTIME_DLLS CONFIGURE_DEPENDS ${PERASTAGE_WX_DLLS})
+    if(PERASTAGE_WX_RUNTIME_DLLS)
+        install(FILES ${PERASTAGE_WX_RUNTIME_DLLS} DESTINATION .)
+    endif()
 endif()
 
 if(CMAKE_CONFIGURATION_TYPES)


### PR DESCRIPTION
### Motivation
- Windows distributions were missing wxWidgets runtime DLLs (e.g. `wxmsw331u_*.dll`, `wxbase331u_*.dll`) causing the installed Perastage to fail to start. 
- Ensure the installer collects the minimal wxWidgets DLLs so the packaged `Perastage.exe` runs without requiring users to manually supply wx DLLs.

### Description
- Updated `CMakeLists.txt` to add logic that iterates `wxWidgets_LIBRARY_DIRS` and collects `wxmsw*.dll` and `wxbase*.dll` patterns from the library and the corresponding `../bin` directories. 
- Uses `file(GLOB ... CONFIGURE_DEPENDS ...)` to expand those patterns into `PERASTAGE_WX_RUNTIME_DLLS` and installs them next to the executable with `install(FILES ... DESTINATION .)`. 
- Keeps the existing usage of `$<TARGET_RUNTIME_DLLS:${PROJECT_NAME}>` and `InstallRequiredSystemLibraries`. 
- Modified file: `CMakeLists.txt`.

### Testing
- No automated tests were run.
- CMake/make build or install steps were not executed as part of this change.
- Manual verification of installed artifacts was not performed in this run.
- The change compiles as a CMake script edit only and was committed to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696173435620832482f58bcb25b91cbb)