### PR TITLE
Fix wxWidgets DLL install globs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,20 +121,30 @@ if(WIN32)
         if(wx_dir)
             list(APPEND PERASTAGE_WX_DLLS
                 "${wx_dir}/wxmsw*.dll"
-                "${wx_dir}/wxbase*.dll")
+                "${wx_dir}/wxbase*.dll"
+                "${wx_dir}/nwxmsw*.dll"
+                "${wx_dir}/nwxbase*.dll")
             get_filename_component(wx_bin_dir "${wx_dir}/../bin" ABSOLUTE)
             list(APPEND PERASTAGE_WX_DLLS
                 "${wx_bin_dir}/wxmsw*.dll"
-                "${wx_bin_dir}/wxbase*.dll")
+                "${wx_bin_dir}/wxbase*.dll"
+                "${wx_bin_dir}/nwxmsw*.dll"
+                "${wx_bin_dir}/nwxbase*.dll")
         endif()
     endforeach()
     list(REMOVE_ITEM PERASTAGE_WX_DLLS "")
     list(FILTER PERASTAGE_WX_DLLS INCLUDE REGEX ".+\\.dll$")
     list(REMOVE_DUPLICATES PERASTAGE_WX_DLLS)
     if(PERASTAGE_WX_DLLS)
-        file(GLOB PERASTAGE_WX_RUNTIME_DLLS CONFIGURE_DEPENDS ${PERASTAGE_WX_DLLS})
+        set(PERASTAGE_WX_RUNTIME_DLLS "")
+        foreach(wx_pattern IN LISTS PERASTAGE_WX_DLLS)
+            if(NOT wx_pattern STREQUAL "")
+                file(GLOB PERASTAGE_WX_GLOB CONFIGURE_DEPENDS "${wx_pattern}")
+                list(APPEND PERASTAGE_WX_RUNTIME_DLLS ${PERASTAGE_WX_GLOB})
+            endif()
+        endforeach()
+        list(REMOVE_DUPLICATES PERASTAGE_WX_RUNTIME_DLLS)
         if(PERASTAGE_WX_RUNTIME_DLLS)
-            list(REMOVE_DUPLICATES PERASTAGE_WX_RUNTIME_DLLS)
             install(FILES ${PERASTAGE_WX_RUNTIME_DLLS} DESTINATION .)
         endif()
     endif()


### PR DESCRIPTION
### Motivation
- The Windows installer was missing wxWidgets runtime DLLs (e.g. `nwxmsw331u_aui_vc_x64_custom.dll`) because the glob patterns did not include `nwx*` variants.
- Using a single `file(GLOB ... CONFIGURE_DEPENDS ${PERASTAGE_WX_DLLS})` could produce empty-glob or configuration errors such as `file GLOB requires a glob expression after CONFIGURE_DEPENDS`.

### Description
- Added `nwxmsw*.dll` and `nwxbase*.dll` patterns alongside the existing `wxmsw*`/`wxbase*` patterns for both library and `bin` directories.
- Replaced the single multi-pattern `file(GLOB ...)` call with a loop that calls `file(GLOB ... "${wx_pattern}")` per pattern and aggregates results into `PERASTAGE_WX_RUNTIME_DLLS`.
- Removed empty-patterns and duplicate entries using `list(REMOVE_ITEM ...)` and `list(REMOVE_DUPLICATES ...)` before calling `install(FILES ...)`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69617aee80908324966db1c5cc801098)