### PR TITLE
Fix wxWidgets debug/release linkage and install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,32 @@
-﻿cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.21)
 cmake_policy(SET CMP0074 NEW)
 
 project(Perastage VERSION 1.0 LANGUAGES CXX)
 
+# wxWidgets chooses different binary sets based on wxWidgets_USE_DEBUG, so we
+# force it to match the active build configuration to avoid mixing runtime DLLs.
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(CTest)
+
+# Force wxWidgets release libs when not debugging.
+if(CMAKE_CONFIGURATION_TYPES)
+    set(wxWidgets_USE_DEBUG "$<CONFIG:Debug>" CACHE BOOL "" FORCE)
+else()
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+        set(wxWidgets_USE_DEBUG ON CACHE BOOL "" FORCE)
+    else()
+        set(wxWidgets_USE_DEBUG OFF CACHE BOOL "" FORCE)
+    endif()
+endif()
+set(wxWidgets_USE_UNICODE ON CACHE BOOL "" FORCE)
+
+if(CMAKE_CONFIGURATION_TYPES)
+    set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
+elseif(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
+endif()
 
 # Find required packages
 find_package(wxWidgets REQUIRED COMPONENTS core base aui gl html)
@@ -116,6 +136,8 @@ if(WIN32)
     install(FILES $<TARGET_RUNTIME_DLLS:${PROJECT_NAME}> DESTINATION .)
     install(FILES $<TARGET_RUNTIME_DLLS:${PROJECT_NAME}> DESTINATION . COMPONENT Runtime)
 
+    # wxWidgets libraries may not appear in TARGET_RUNTIME_DLLS when discovered
+    # via wxWidgets_USE_FILE, so collect and install them explicitly.
     set(PERASTAGE_WX_DLLS "")
     foreach(wx_dir IN LISTS wxWidgets_LIBRARY_DIRS)
         if(wx_dir)
@@ -144,6 +166,9 @@ if(WIN32)
             endif()
         endforeach()
         list(REMOVE_DUPLICATES PERASTAGE_WX_RUNTIME_DLLS)
+        if(NOT wxWidgets_USE_DEBUG)
+            list(FILTER PERASTAGE_WX_RUNTIME_DLLS EXCLUDE REGEX ".*d_vc_.*\\.dll$")
+        endif()
         if(PERASTAGE_WX_RUNTIME_DLLS)
             install(FILES ${PERASTAGE_WX_RUNTIME_DLLS} DESTINATION .)
         endif()


### PR DESCRIPTION
### Motivation
- Ensure Release builds link against wxWidgets Release libraries and do not mix Debug DLLs with Release binaries.
- Prevent tests from being built/installed in non-Debug configurations to avoid shipping test artifacts.
- Make the runtime DLL installation for wxWidgets deterministic and avoid installing debug-suffixed DLLs into Release outputs.
- Document why wxWidgets debug/release selection is forced so package discovery yields the correct runtime files.

### Description
- Added a header comment and logic before package discovery to set `wxWidgets_USE_DEBUG` based on `CMAKE_BUILD_TYPE` or multi-config `CONFIG`, and forced `wxWidgets_USE_UNICODE` to `ON` using `CACHE ... FORCE`.
- Disabled testing in non-Debug configurations by setting `BUILD_TESTING` to `OFF` when appropriate, retaining the existing `if(BUILD_TESTING)` guard around `add_subdirectory(tests)`.
- Kept the existing `install(FILES $<TARGET_RUNTIME_DLLS:${PROJECT_NAME}> ...)` and also collected wxWidgets DLL globs into `PERASTAGE_WX_RUNTIME_DLLS`, then filtered out debug variants when `wxWidgets_USE_DEBUG` is `OFF` via `list(FILTER ... EXCLUDE REGEX ...)` before installing.
- Added a comment explaining why wxWidgets DLLs are collected/installed explicitly (they may not appear in `TARGET_RUNTIME_DLLS` when discovered via `wxWidgets_USE_FILE`).

### Testing
- No automated tests were run for this change.
- Manual build verification was not performed as part of this PR.
- CI/build jobs were not triggered from this change in the current environment.
- Recommend running a Release build and invoking the `perastage_stage` target to validate `out/install/x64-Release` contains `Perastage.exe` and only Release wxWidgets DLLs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69617f55cedc832495f1f4df20338085)