### PR TITLE
Fix wxWidgets DLL install for multi-config and use generator expression for wxWidgets_USE_DEBUG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,8 @@ if(PERASTAGE_FORCE_WXDEBUG)
     set(wxWidgets_USE_DEBUG ON CACHE BOOL "" FORCE)
 else()
     if(CMAKE_CONFIGURATION_TYPES)
-        set(wxWidgets_USE_DEBUG OFF CACHE BOOL "" FORCE)
+        # Multi-config generators must select debug libs per configuration.
+        set(wxWidgets_USE_DEBUG "$<CONFIG:Debug>" CACHE BOOL "" FORCE)
     else()
         if(CMAKE_BUILD_TYPE STREQUAL "Debug")
             set(wxWidgets_USE_DEBUG ON CACHE BOOL "" FORCE)
@@ -141,48 +142,67 @@ if(WIN32)
     include(InstallRequiredSystemLibraries)
     # Filter out debug DLLs in release installs to avoid missing DLL issues.
     set(PERASTAGE_RUNTIME_DLLS $<TARGET_RUNTIME_DLLS:${PROJECT_NAME}>)
-    if(NOT wxWidgets_USE_DEBUG)
+    if(NOT CMAKE_CONFIGURATION_TYPES AND NOT wxWidgets_USE_DEBUG)
         list(FILTER PERASTAGE_RUNTIME_DLLS EXCLUDE REGEX ".*(d_vc_|ud_vc_).*\\.dll$")
     endif()
     install(FILES ${PERASTAGE_RUNTIME_DLLS} DESTINATION .)
     install(FILES ${PERASTAGE_RUNTIME_DLLS} DESTINATION . COMPONENT Runtime)
 
     # wxWidgets libraries may not appear in TARGET_RUNTIME_DLLS when discovered
-    # via wxWidgets_USE_FILE, so collect and install them explicitly.
-    set(PERASTAGE_WX_DLLS "")
+    # via wxWidgets_USE_FILE, so derive DLL locations from linked libraries too.
+    set(PERASTAGE_WX_SEARCH_DIRS "")
     foreach(wx_dir IN LISTS wxWidgets_LIBRARY_DIRS)
-        if(wx_dir)
-            list(APPEND PERASTAGE_WX_DLLS
-                "${wx_dir}/wxmsw*.dll"
-                "${wx_dir}/wxbase*.dll"
-                "${wx_dir}/nwxmsw*.dll"
-                "${wx_dir}/nwxbase*.dll")
-            get_filename_component(wx_bin_dir "${wx_dir}/../bin" ABSOLUTE)
-            list(APPEND PERASTAGE_WX_DLLS
-                "${wx_bin_dir}/wxmsw*.dll"
-                "${wx_bin_dir}/wxbase*.dll"
-                "${wx_bin_dir}/nwxmsw*.dll"
-                "${wx_bin_dir}/nwxbase*.dll")
+        if(wx_dir AND IS_DIRECTORY "${wx_dir}")
+            list(APPEND PERASTAGE_WX_SEARCH_DIRS "${wx_dir}")
         endif()
     endforeach()
-    list(REMOVE_ITEM PERASTAGE_WX_DLLS "")
-    list(FILTER PERASTAGE_WX_DLLS INCLUDE REGEX ".+\\.dll$")
-    list(REMOVE_DUPLICATES PERASTAGE_WX_DLLS)
-    if(PERASTAGE_WX_DLLS)
-        set(PERASTAGE_WX_RUNTIME_DLLS "")
-        foreach(wx_pattern IN LISTS PERASTAGE_WX_DLLS)
-            if(NOT wx_pattern STREQUAL "")
-                file(GLOB PERASTAGE_WX_GLOB CONFIGURE_DEPENDS "${wx_pattern}")
-                list(APPEND PERASTAGE_WX_RUNTIME_DLLS ${PERASTAGE_WX_GLOB})
+    foreach(wx_lib IN LISTS wxWidgets_LIBRARIES)
+        if(EXISTS "${wx_lib}")
+            get_filename_component(wx_lib_dir "${wx_lib}" DIRECTORY)
+            if(IS_DIRECTORY "${wx_lib_dir}")
+                list(APPEND PERASTAGE_WX_SEARCH_DIRS "${wx_lib_dir}")
             endif()
-        endforeach()
-        list(REMOVE_DUPLICATES PERASTAGE_WX_RUNTIME_DLLS)
-        if(NOT wxWidgets_USE_DEBUG)
-            # Exclude wxWidgets debug DLLs to avoid release installer failures.
-            list(FILTER PERASTAGE_WX_RUNTIME_DLLS EXCLUDE REGEX ".*(d_vc_|ud_vc_).*\\.dll$")
         endif()
-        if(PERASTAGE_WX_RUNTIME_DLLS)
-            install(FILES ${PERASTAGE_WX_RUNTIME_DLLS} DESTINATION .)
+    endforeach()
+    list(REMOVE_DUPLICATES PERASTAGE_WX_SEARCH_DIRS)
+
+    set(PERASTAGE_WX_DLL_PATTERNS "")
+    foreach(wx_dir IN LISTS PERASTAGE_WX_SEARCH_DIRS)
+        list(APPEND PERASTAGE_WX_DLL_PATTERNS
+            "${wx_dir}/wxmsw*.dll"
+            "${wx_dir}/wxbase*.dll"
+            "${wx_dir}/nwxmsw*.dll"
+            "${wx_dir}/nwxbase*.dll")
+        get_filename_component(wx_bin_dir "${wx_dir}/../bin" ABSOLUTE)
+        list(APPEND PERASTAGE_WX_DLL_PATTERNS
+            "${wx_bin_dir}/wxmsw*.dll"
+            "${wx_bin_dir}/wxbase*.dll"
+            "${wx_bin_dir}/nwxmsw*.dll"
+            "${wx_bin_dir}/nwxbase*.dll")
+    endforeach()
+    list(REMOVE_ITEM PERASTAGE_WX_DLL_PATTERNS "")
+    list(REMOVE_DUPLICATES PERASTAGE_WX_DLL_PATTERNS)
+
+    set(PERASTAGE_WX_RUNTIME_DLLS "")
+    foreach(wx_pattern IN LISTS PERASTAGE_WX_DLL_PATTERNS)
+        file(GLOB PERASTAGE_WX_GLOB CONFIGURE_DEPENDS "${wx_pattern}")
+        list(APPEND PERASTAGE_WX_RUNTIME_DLLS ${PERASTAGE_WX_GLOB})
+    endforeach()
+    list(REMOVE_DUPLICATES PERASTAGE_WX_RUNTIME_DLLS)
+
+    if(PERASTAGE_WX_RUNTIME_DLLS)
+        set(PERASTAGE_WX_DEBUG_DLLS ${PERASTAGE_WX_RUNTIME_DLLS})
+        set(PERASTAGE_WX_RELEASE_DLLS ${PERASTAGE_WX_RUNTIME_DLLS})
+        list(FILTER PERASTAGE_WX_DEBUG_DLLS INCLUDE REGEX ".*(d_vc_|ud_vc_).*\\.dll$")
+        list(FILTER PERASTAGE_WX_RELEASE_DLLS EXCLUDE REGEX ".*(d_vc_|ud_vc_).*\\.dll$")
+        if(CMAKE_CONFIGURATION_TYPES)
+            # Install debug DLLs only for Debug and release DLLs for other configs.
+            install(FILES ${PERASTAGE_WX_DEBUG_DLLS} DESTINATION . CONFIGURATIONS Debug)
+            install(FILES ${PERASTAGE_WX_RELEASE_DLLS} DESTINATION . CONFIGURATIONS Release RelWithDebInfo MinSizeRel)
+        elseif(wxWidgets_USE_DEBUG)
+            install(FILES ${PERASTAGE_WX_DEBUG_DLLS} DESTINATION .)
+        else()
+            install(FILES ${PERASTAGE_WX_RELEASE_DLLS} DESTINATION .)
         endif()
     endif()
 endif()


### PR DESCRIPTION
### Motivation
- The Release executable was missing Unicode wxWidgets DLLs (e.g. `wxmsw331u_core_vc_x64_custom.dll`) because the install script only scanned a limited set of directories and `wxWidgets_USE_DEBUG` was forced OFF for multi-config generators.  
- The build must select debug vs release wxWidgets libraries per active configuration for multi-config generators (Visual Studio) so the installer includes the correct DLL set.  
- DLL discovery must derive paths from the actual linked libraries so custom wxWidgets layouts (e.g. `vc_x64_custom`) are handled.  

### Description
- Use a generator expression for multi-config builds by setting `wxWidgets_USE_DEBUG` to `"$<CONFIG:Debug>"` when `CMAKE_CONFIGURATION_TYPES` is present, while keeping single-config logic for `CMAKE_BUILD_TYPE` in `CMakeLists.txt`.  
- Enhance wxWidgets DLL discovery by collecting directories from `wxWidgets_LIBRARY_DIRS` and by iterating `wxWidgets_LIBRARIES` to derive library directories, building glob patterns for those dirs and their `../bin` sibling, expanding them with `file(GLOB ...)`, removing duplicates, and splitting debug vs release DLLs for installation.  
- Preserve the existing `install(FILES $<TARGET_RUNTIME_DLLS:${PROJECT_NAME}> ...)` usage for runtime DLLs that CMake can detect automatically and adjust debug-filtering to only apply in the single-config code path.  
- Add explanatory comments in `CMakeLists.txt` describing the generator expression rationale and the reason for deriving search directories from `wxWidgets_LIBRARIES`.  

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696185ecbcb88324be13900637651ff7)