### PR TITLE
Include runtime DLLs from imported targets in Windows installer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,17 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     ZLIB::ZLIB
 )
 
+# List of imported dependency targets whose runtime DLLs must be installed.
+# Add new external targets here to ensure their DLLs ship with Windows builds.
+set(PERASTAGE_IMPORT_DEPS
+    tinyxml2::tinyxml2
+    GLEW::GLEW
+    CURL::libcurl
+    nanovg::nanovg
+    podofo::podofo
+    ZLIB::ZLIB
+)
+
 if(BUILD_TESTING)
     add_subdirectory(tests)
 endif()
@@ -204,6 +215,29 @@ if(WIN32)
         else()
             install(FILES ${PERASTAGE_WX_RELEASE_DLLS} DESTINATION .)
         endif()
+    endif()
+
+    # Gather runtime DLLs from imported dependencies to avoid missing third-party
+    # libraries in Windows distributions (e.g. zlib, pcre2, jpeg).
+    set(PERASTAGE_DEP_RUNTIME_DLLS "")
+    foreach(dep IN LISTS PERASTAGE_IMPORT_DEPS)
+        list(APPEND PERASTAGE_DEP_RUNTIME_DLLS $<TARGET_RUNTIME_DLLS:${dep}>)
+    endforeach()
+    list(REMOVE_DUPLICATES PERASTAGE_DEP_RUNTIME_DLLS)
+
+    # Filter debug DLLs by configuration when using multi-config generators or
+    # by suffix for single-config Release-style builds.
+    if(CMAKE_CONFIGURATION_TYPES)
+        install(FILES ${PERASTAGE_DEP_RUNTIME_DLLS} DESTINATION .
+            CONFIGURATIONS Release RelWithDebInfo MinSizeRel)
+        install(FILES ${PERASTAGE_DEP_RUNTIME_DLLS} DESTINATION .
+            CONFIGURATIONS Debug)
+    else()
+        if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+            list(FILTER PERASTAGE_DEP_RUNTIME_DLLS EXCLUDE
+                REGEX ".*(d_vc_|ud_vc_).*\\.dll$|.*d\\.dll$")
+        endif()
+        install(FILES ${PERASTAGE_DEP_RUNTIME_DLLS} DESTINATION .)
     endif()
 endif()
 


### PR DESCRIPTION
### Motivation
- The installer omitted runtime DLLs (e.g. `zlib1.dll`, `pcre2-16.dll`, `jpeg62.dll`) brought in by imported targets, causing missing-library errors on Windows.
- The goal is to automatically stage runtime DLLs for all linked imported libraries so staged distributions are runnable on clean machines.
- Maintain the existing, specialized handling for `Perastage` and `wxWidgets` while making the mechanism scalable for future dependencies.

### Description
- Added a new list `PERASTAGE_IMPORT_DEPS` that enumerates imported targets whose runtime DLLs must be installed (e.g. `tinyxml2::tinyxml2`, `GLEW::GLEW`, `CURL::libcurl`, `nanovg::nanovg`, `podofo::podofo`, `ZLIB::ZLIB`).
- Collects runtime DLLs from each listed target using the generator expression `$<TARGET_RUNTIME_DLLS:...>` and deduplicates the resulting list into `PERASTAGE_DEP_RUNTIME_DLLS`.
- Installs those DLLs into the Windows package and filters out debug-suffixed DLLs for non-Debug single-config builds while using `CONFIGURATIONS` to separate Debug vs Release in multi-config generators.
- Kept existing installation logic for `$<TARGET_RUNTIME_DLLS:${PROJECT_NAME}>` and the wxWidgets-specific discovery/installation intact and added inline comments documenting how to add more imported targets.

### Testing
- No automated tests were executed as part of this change.
- The change was limited to `CMakeLists.txt` and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69618826870483249bc2348efa348832)