### PR TITLE
Fix runtime DLL collection for imported dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,22 @@ set(PERASTAGE_IMPORT_DEPS
     ZLIB::ZLIB
 )
 
+function(perastage_append_runtime_dlls out_var target_name)
+    if(NOT TARGET ${target_name})
+        return()
+    endif()
+    get_target_property(perastage_target_type ${target_name} TYPE)
+    if(NOT perastage_target_type)
+        return()
+    endif()
+    if(perastage_target_type STREQUAL "SHARED_LIBRARY"
+        OR perastage_target_type STREQUAL "MODULE_LIBRARY"
+        OR perastage_target_type STREQUAL "EXECUTABLE")
+        list(APPEND ${out_var} $<TARGET_RUNTIME_DLLS:${target_name}>)
+        set(${out_var} "${${out_var}}" PARENT_SCOPE)
+    endif()
+endfunction()
+
 if(BUILD_TESTING)
     add_subdirectory(tests)
 endif()
@@ -221,7 +237,7 @@ if(WIN32)
     # libraries in Windows distributions (e.g. zlib, pcre2, jpeg).
     set(PERASTAGE_DEP_RUNTIME_DLLS "")
     foreach(dep IN LISTS PERASTAGE_IMPORT_DEPS)
-        list(APPEND PERASTAGE_DEP_RUNTIME_DLLS $<TARGET_RUNTIME_DLLS:${dep}>)
+        perastage_append_runtime_dlls(PERASTAGE_DEP_RUNTIME_DLLS ${dep})
     endforeach()
     list(REMOVE_DUPLICATES PERASTAGE_DEP_RUNTIME_DLLS)
 


### PR DESCRIPTION
### Motivation
- Avoid CMake generator-expression failures when collecting runtime DLLs from imported dependency targets that are interface/static or lack a linker language.
- Prevent errors like `CMake can not determine linker language for target` and invalid `$<TARGET_RUNTIME_DLLS:...>` evaluations.

### Description
- Added a helper function `perastage_append_runtime_dlls` that checks `TARGET` existence and the target `TYPE` before appending `$<TARGET_RUNTIME_DLLS:...>`.
- The helper only appends runtime DLLs for targets of type `SHARED_LIBRARY`, `MODULE_LIBRARY`, or `EXECUTABLE` to avoid invalid generator expressions.
- Replaced direct `list(APPEND PERASTAGE_DEP_RUNTIME_DLLS $<TARGET_RUNTIME_DLLS:${dep}>)` with calls to `perastage_append_runtime_dlls` while iterating `PERASTAGE_IMPORT_DEPS`.

### Testing
- No automated tests were executed as part of this change.
- The repository changes were committed successfully and the new function was added to `CMakeLists.txt` without further runtime verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69618972337c8324b6646d9742bfdc49)