### PR TITLE
Set linker language for imported CMake dependency targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,24 @@ find_package(nanovg CONFIG REQUIRED)
 find_package(podofo CONFIG REQUIRED)
 find_package(ZLIB REQUIRED)
 
+function(perastage_ensure_linker_language target_name language)
+    if(TARGET ${target_name})
+        get_target_property(perastage_linker_language ${target_name} LINKER_LANGUAGE)
+        if(NOT perastage_linker_language)
+            set_target_properties(${target_name} PROPERTIES LINKER_LANGUAGE ${language})
+        endif()
+    endif()
+endfunction()
+
+# Some package configs define imported targets without explicit linker language.
+# Ensure CMake can generate link rules for these dependency targets.
+perastage_ensure_linker_language(CURL::libcurl C)
+perastage_ensure_linker_language(CURL::libcurl_shared C)
+perastage_ensure_linker_language(GLEW::GLEW C)
+perastage_ensure_linker_language(podofo::podofo CXX)
+perastage_ensure_linker_language(podofo::podofo_shared CXX)
+perastage_ensure_linker_language(tinyxml2::tinyxml2 CXX)
+
 # Gather source files
 file(GLOB_RECURSE SRC_FILES CONFIGURE_DEPENDS
     ${CMAKE_SOURCE_DIR}/main.cpp


### PR DESCRIPTION
### Motivation
- Fix CMake generator errors where CMake cannot determine linker language for some imported targets (e.g., curl, GLEW, podofo, tinyxml2).
- Ensure CMake can generate correct link rules for imported dependency targets so Windows runtime DLL collection and install rules work reliably.

### Description
- Add a `perastage_ensure_linker_language` helper in `CMakeLists.txt` that sets the `LINKER_LANGUAGE` property on a target when missing.
- Invoke the helper for `CURL::libcurl`, `CURL::libcurl_shared`, `GLEW::GLEW`, `podofo::podofo`, `podofo::podofo_shared`, and `tinyxml2::tinyxml2` after the `find_package` calls.
- Insert the helper into `CMakeLists.txt` so imported dependency targets have an explicit linker language prior to generating link rules and installs.

### Testing
- No automated tests or CMake configure were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69618e158fa48324a1039a11d95a367f)