### PR TITLE
Fix linker language metadata for imported libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,9 +54,24 @@ function(perastage_ensure_linker_language target_name language)
         else()
             set(perastage_link_target ${target_name})
         endif()
-        get_target_property(perastage_linker_language ${perastage_link_target} LINKER_LANGUAGE)
-        if(NOT perastage_linker_language)
-            set_target_properties(${perastage_link_target} PROPERTIES LINKER_LANGUAGE ${language})
+        get_target_property(perastage_target_type ${perastage_link_target} TYPE)
+        if(NOT perastage_target_type STREQUAL "INTERFACE_LIBRARY")
+            get_target_property(perastage_linker_language ${perastage_link_target} LINKER_LANGUAGE)
+            if(NOT perastage_linker_language)
+                set_target_properties(${perastage_link_target} PROPERTIES LINKER_LANGUAGE ${language})
+            endif()
+            if(perastage_target_type STREQUAL "UNKNOWN_LIBRARY")
+                get_target_property(perastage_imported_link_langs
+                    ${perastage_link_target}
+                    IMPORTED_LINK_INTERFACE_LANGUAGES
+                )
+                if(NOT perastage_imported_link_langs)
+                    set_target_properties(
+                        ${perastage_link_target}
+                        PROPERTIES IMPORTED_LINK_INTERFACE_LANGUAGES ${language}
+                    )
+                endif()
+            endif()
         endif()
     endif()
 endfunction()


### PR DESCRIPTION
### Motivation
- CMake reported "cannot determine linker language" for several imported targets such as `tinyxml2::tinyxml2`, `CURL::libcurl`, `GLEW::GLEW`, and `podofo::podofo` during configure.
- Some package configs create imported targets without explicit `LINKER_LANGUAGE` or `IMPORTED_LINK_INTERFACE_LANGUAGES`, preventing CMake from generating proper link rules.
- The helper needed to avoid touching `INTERFACE_LIBRARY` targets and to populate imported link interface languages when targets are unknown.

### Description
- Extend `perastage_ensure_linker_language` to query the target `TYPE` before acting and skip `INTERFACE_LIBRARY` targets.
- Only set the `LINKER_LANGUAGE` property when it is not already defined for the target.
- When a target has type `UNKNOWN_LIBRARY`, set `IMPORTED_LINK_INTERFACE_LANGUAGES` to the requested language if that property is missing.
- Keep the helper calls for `CURL::libcurl`, `CURL::libcurl_shared`, `GLEW::GLEW`, `podofo::podofo`, `podofo::podofo_shared`, and `tinyxml2::tinyxml2` unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69618fa75ed48324b9090525efd1ea37)