### PR TITLE
Ensure linker language for imported targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,24 +54,18 @@ function(perastage_ensure_linker_language target_name language)
         else()
             set(perastage_link_target ${target_name})
         endif()
-        get_target_property(perastage_target_type ${perastage_link_target} TYPE)
-        if(NOT perastage_target_type STREQUAL "INTERFACE_LIBRARY")
-            get_target_property(perastage_linker_language ${perastage_link_target} LINKER_LANGUAGE)
-            if(NOT perastage_linker_language)
-                set_target_properties(${perastage_link_target} PROPERTIES LINKER_LANGUAGE ${language})
-            endif()
-            if(perastage_target_type STREQUAL "UNKNOWN_LIBRARY")
-                get_target_property(perastage_imported_link_langs
-                    ${perastage_link_target}
-                    IMPORTED_LINK_INTERFACE_LANGUAGES
-                )
-                if(NOT perastage_imported_link_langs)
-                    set_target_properties(
-                        ${perastage_link_target}
-                        PROPERTIES IMPORTED_LINK_INTERFACE_LANGUAGES ${language}
-                    )
-                endif()
-            endif()
+        get_target_property(perastage_linker_language ${perastage_link_target} LINKER_LANGUAGE)
+        if(NOT perastage_linker_language)
+            set_target_properties(${perastage_link_target} PROPERTIES LINKER_LANGUAGE ${language})
+        endif()
+        get_target_property(perastage_imported_link_langs
+            ${perastage_link_target} IMPORTED_LINK_INTERFACE_LANGUAGES
+        )
+        if(NOT perastage_imported_link_langs)
+            set_target_properties(
+                ${perastage_link_target}
+                PROPERTIES IMPORTED_LINK_INTERFACE_LANGUAGES ${language}
+            )
         endif()
     endif()
 endfunction()
@@ -84,6 +78,8 @@ perastage_ensure_linker_language(GLEW::GLEW C)
 perastage_ensure_linker_language(podofo::podofo CXX)
 perastage_ensure_linker_language(podofo::podofo_shared CXX)
 perastage_ensure_linker_language(tinyxml2::tinyxml2 CXX)
+perastage_ensure_linker_language(nanovg::nanovg C)
+perastage_ensure_linker_language(ZLIB::ZLIB C)
 
 # Gather source files
 file(GLOB_RECURSE SRC_FILES CONFIGURE_DEPENDS


### PR DESCRIPTION
### Motivation
- Resolver errores de CMake "CMake can not determine linker language for target …" al asegurar que los objetivos importados tengan información de lenguaje de enlace.
- Algunas configuraciones de paquetes exportan targets importados sin `LINKER_LANGUAGE` ni `IMPORTED_LINK_INTERFACE_LANGUAGES`, lo que impide que CMake genere reglas de enlace.
- Mantener intacta la lógica existente de instalación de DLLs y recolección de dependencias mientras se corrige la detección del lenguaje.

### Description
- Se actualizó la función `perastage_ensure_linker_language` en `CMakeLists.txt` para siempre establecer `LINKER_LANGUAGE` e `IMPORTED_LINK_INTERFACE_LANGUAGES` si no existen, sin descartar `INTERFACE_LIBRARY` ni depender del tipo `UNKNOWN_LIBRARY`.
- Se añadió la comprobación explícita de lenguaje para los targets de bajo nivel `nanovg::nanovg` y `ZLIB::ZLIB` además de los ya existentes (`CURL::libcurl`, `CURL::libcurl_shared`, `GLEW::GLEW`, `podofo::podofo`, `podofo::podofo_shared`, `tinyxml2::tinyxml2`).
- Las llamadas a `perastage_ensure_linker_language` se ejecutan después de los `find_package(...)` existentes para asegurar que los targets importados ya existan.
- No se modificó la lógica de instalación de DLLs ni la recolección de dependencias en `CMakeLists.txt`.

### Testing
- No se ejecutaron pruebas automatizadas durante este cambio.
- No se realizó una configuración/build de `cmake` en el rollout automatizado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69619199308c8324bf498db86fead589)