### PR TITLE
Fix: set linker language unconditionally for imported libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,19 +54,12 @@ function(perastage_ensure_linker_language target_name language)
         else()
             set(perastage_link_target ${target_name})
         endif()
-        get_target_property(perastage_linker_language ${perastage_link_target} LINKER_LANGUAGE)
-        if(NOT perastage_linker_language)
-            set_target_properties(${perastage_link_target} PROPERTIES LINKER_LANGUAGE ${language})
-        endif()
-        get_target_property(perastage_imported_link_langs
-            ${perastage_link_target} IMPORTED_LINK_INTERFACE_LANGUAGES
+        set_target_properties(
+            ${perastage_link_target}
+            PROPERTIES
+                LINKER_LANGUAGE ${language}
+                IMPORTED_LINK_INTERFACE_LANGUAGES ${language}
         )
-        if(NOT perastage_imported_link_langs)
-            set_target_properties(
-                ${perastage_link_target}
-                PROPERTIES IMPORTED_LINK_INTERFACE_LANGUAGES ${language}
-            )
-        endif()
     endif()
 endfunction()
 


### PR DESCRIPTION
### Motivation
- CMake can fail with “CMake can not determine linker language” when imported targets have an empty or invalid `LINKER_LANGUAGE` or `IMPORTED_LINK_INTERFACE_LANGUAGES` property. 
- The intent is to ensure CMake always has a valid linker language for imported dependency targets so link rules can be generated. 
- The fix must run after `find_package` so the imported targets exist before properties are applied. 
- Do not change any DLL installation or resource-copying logic as those were fixed previously.

### Description
- Updated `perastage_ensure_linker_language` to always call `set_target_properties` and unconditionally set `LINKER_LANGUAGE` and `IMPORTED_LINK_INTERFACE_LANGUAGES` on the resolved target (handling `ALIASED_TARGET`).
- The function still resolves the real link target via the `ALIASED_TARGET` property and applies properties to `perastage_link_target` when the target exists.
- Kept calls to `perastage_ensure_linker_language` for `CURL::libcurl`, `CURL::libcurl_shared`, `GLEW::GLEW`, `podofo::podofo`, `podofo::podofo_shared`, `tinyxml2::tinyxml2`, `nanovg::nanovg`, and `ZLIB::ZLIB` immediately after `find_package` invocations. 
- No other build or install logic was modified.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696193b8f5c0832483c3e6465cb5606b)