### PR TITLE
Enable C language in CMake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.21)
 cmake_policy(SET CMP0074 NEW)
 
-project(Perastage VERSION 1.0 LANGUAGES CXX)
+project(Perastage VERSION 1.0 LANGUAGES C CXX)
 
 # wxWidgets chooses different binary sets based on wxWidgets_USE_DEBUG, so we
 # force it to match the active build configuration and expose

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.21)
-project(PerastageTests LANGUAGES CXX)
+project(PerastageTests LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
### Motivation
- CMake reported "CMake can not determine linker language" for several imported targets which require C linker rules. 
- The project and test CMake configurations only declared `CXX`, preventing C-based dependency targets from getting proper linker language. 
- Adding the `C` language lets CMake generate correct link rules for C-style imported targets like `CURL::libcurl` and `GLEW::GLEW`.

### Description
- Update the top-level `project(...)` in `CMakeLists.txt` to `LANGUAGES C CXX` to enable C language support. 
- Update the test project `project(...)` in `tests/CMakeLists.txt` to `LANGUAGES C CXX` for consistent language handling in tests. 
- No other source or build logic was changed; only the declared project languages were extended.

### Testing
- No automated tests were executed as part of this change. 
- A CMake configure/build should be attempted in CI or locally to verify linker-language resolution for the previously failing imported targets.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696194649890832492a8fe949a2ef89d)