### PR TITLE
Fix linker language for imported CMake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,16 @@ function(perastage_ensure_linker_language target_name language)
         else()
             set(perastage_link_target ${target_name})
         endif()
+        get_target_property(perastage_import_configs ${perastage_link_target} IMPORTED_CONFIGURATIONS)
+        if(perastage_import_configs)
+            foreach(perastage_config IN LISTS perastage_import_configs)
+                set_target_properties(
+                    ${perastage_link_target}
+                    PROPERTIES
+                        IMPORTED_LINK_INTERFACE_LANGUAGES_${perastage_config} ${language}
+                )
+            endforeach()
+        endif()
         set_target_properties(
             ${perastage_link_target}
             PROPERTIES


### PR DESCRIPTION
### Motivation
- CMake reported "cannot determine linker language" for several imported dependency targets because some package configs define imported targets without explicit linker language.
- Packaging and multi-config generators can define per-configuration imported targets that need configuration-specific linker language properties.

### Description
- Enhance `perastage_ensure_linker_language` to read `IMPORTED_CONFIGURATIONS` for a target and set `IMPORTED_LINK_INTERFACE_LANGUAGES_<config>` for each configuration.
- Preserve existing behavior by still setting the generic `LINKER_LANGUAGE` and `IMPORTED_LINK_INTERFACE_LANGUAGES` properties for the target.
- Apply the helper to the same dependency targets (`CURL::libcurl[_shared]`, `GLEW::GLEW`, `podofo::podofo[_shared]`, `tinyxml2::tinyxml2`, `nanovg::nanovg`, `ZLIB::ZLIB`) to ensure link rules are generated.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961955729908324b13b471745fad3ca)