### PR TITLE
Corregir lenguaje del enlazador para dependencias importadas

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,30 +47,35 @@ find_package(podofo CONFIG REQUIRED)
 find_package(ZLIB REQUIRED)
 
 function(perastage_ensure_linker_language target_name language)
-    if(TARGET ${target_name})
-        get_target_property(perastage_aliased_target ${target_name} ALIASED_TARGET)
-        if(perastage_aliased_target)
-            set(perastage_link_target ${perastage_aliased_target})
-        else()
-            set(perastage_link_target ${target_name})
-        endif()
-        get_target_property(perastage_import_configs ${perastage_link_target} IMPORTED_CONFIGURATIONS)
-        if(perastage_import_configs)
-            foreach(perastage_config IN LISTS perastage_import_configs)
-                set_target_properties(
-                    ${perastage_link_target}
-                    PROPERTIES
-                        IMPORTED_LINK_INTERFACE_LANGUAGES_${perastage_config} ${language}
-                )
-            endforeach()
-        endif()
-        set_target_properties(
-            ${perastage_link_target}
-            PROPERTIES
-                LINKER_LANGUAGE ${language}
-                IMPORTED_LINK_INTERFACE_LANGUAGES ${language}
-        )
+    if(NOT TARGET ${target_name})
+        return()
     endif()
+
+    get_target_property(perastage_aliased_target ${target_name} ALIASED_TARGET)
+    if(perastage_aliased_target)
+        set(perastage_link_target ${perastage_aliased_target})
+    else()
+        set(perastage_link_target ${target_name})
+    endif()
+
+    get_target_property(perastage_is_imported ${perastage_link_target} IMPORTED)
+    if(NOT perastage_is_imported)
+        return()
+    endif()
+
+    get_target_property(perastage_import_configs ${perastage_link_target} IMPORTED_CONFIGURATIONS)
+    if(perastage_import_configs)
+        foreach(perastage_config IN LISTS perastage_import_configs)
+            set_property(
+                TARGET ${perastage_link_target}
+                PROPERTY IMPORTED_LINK_INTERFACE_LANGUAGES_${perastage_config} ${language}
+            )
+        endforeach()
+    endif()
+    set_property(
+        TARGET ${perastage_link_target}
+        PROPERTY IMPORTED_LINK_INTERFACE_LANGUAGES ${language}
+    )
 endfunction()
 
 # Some package configs define imported targets without explicit linker language.


### PR DESCRIPTION
### Motivation
- Resolver los errores de CMake del tipo `CMake can not determine linker language for target: ...` al configurar Debug/Release. 
- Mantener el comportamiento existente para `Debug` y aplicar correctamente las configuraciones para `Release` y multi-config. 
- Evitar modificar propiedades de objetivos que no son importados para no romper objetivos locales o alias.

### Description
- Se reescribió la función `perastage_ensure_linker_language` para devolver temprano si el objetivo no existe mediante `if(NOT TARGET ...)` y así evitar acciones innecesarias. 
- La función ahora comprueba que el objetivo sea `IMPORTED` antes de aplicar cambios y usa `set_property` para establecer `IMPORTED_LINK_INTERFACE_LANGUAGES` por configuración en lugar de forzar `LINKER_LANGUAGE` en objetivos no importados. 
- Se preserva la aplicación por-configuración usando `IMPORTED_CONFIGURATIONS` y se sigue llamando la función para las dependencias externas relevantes como `CURL::libcurl_shared`, `podofo::podofo_shared`, `tinyxml2::tinyxml2`, `GLEW::GLEW` y `ZLIB::ZLIB`.

### Testing
- No se ejecutaron pruebas automatizadas sobre el cambio (ninguna prueba corrida).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69628ae760688324975d21b1138a6d59)