### PR TITLE
Guard use of install(RUNTIME_DEPENDENCIES) by CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,32 +159,48 @@ if(WIN32)
     list(REMOVE_DUPLICATES PERASTAGE_VCPKG_BIN_DIRS)
     list(REMOVE_DUPLICATES PERASTAGE_VCPKG_DEBUG_BIN_DIRS)
 
+    set(PERASTAGE_INSTALL_SUPPORTS_RUNTIME_DEPS TRUE)
+    if(CMAKE_VERSION VERSION_LESS "3.21")
+        set(PERASTAGE_INSTALL_SUPPORTS_RUNTIME_DEPS FALSE)
+    endif()
+
     if(CMAKE_CONFIGURATION_TYPES)
-        install(TARGETS ${PROJECT_NAME}
-            RUNTIME DESTINATION .
-            CONFIGURATIONS Release RelWithDebInfo MinSizeRel
-            RUNTIME_DEPENDENCIES
-                DIRECTORIES ${PERASTAGE_VCPKG_BIN_DIRS}
-                PRE_EXCLUDE_REGEXES
-                    "api-ms-.*"
-                    "ext-ms-.*"
-                POST_EXCLUDE_REGEXES
-                    ".*[Ww]indows[\\/].*"
-                    ".*[Ss]ystem32[\\/].*"
-        )
+        if(PERASTAGE_INSTALL_SUPPORTS_RUNTIME_DEPS)
+            install(TARGETS ${PROJECT_NAME}
+                RUNTIME DESTINATION .
+                CONFIGURATIONS Release RelWithDebInfo MinSizeRel
+                RUNTIME_DEPENDENCIES
+                    DIRECTORIES ${PERASTAGE_VCPKG_BIN_DIRS}
+                    PRE_EXCLUDE_REGEXES
+                        "api-ms-.*"
+                        "ext-ms-.*"
+                    POST_EXCLUDE_REGEXES
+                        ".*[Ww]indows[\\/].*"
+                        ".*[Ss]ystem32[\\/].*"
+            )
+        else()
+            install(TARGETS ${PROJECT_NAME}
+                RUNTIME DESTINATION .
+                CONFIGURATIONS Release RelWithDebInfo MinSizeRel
+            )
+        endif()
         install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION . CONFIGURATIONS Debug)
     elseif(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-        install(TARGETS ${PROJECT_NAME}
-            RUNTIME DESTINATION .
-            RUNTIME_DEPENDENCIES
-                DIRECTORIES ${PERASTAGE_VCPKG_BIN_DIRS}
-                PRE_EXCLUDE_REGEXES
-                    "api-ms-.*"
-                    "ext-ms-.*"
-                POST_EXCLUDE_REGEXES
-                    ".*[Ww]indows[\\/].*"
-                    ".*[Ss]ystem32[\\/].*"
-        )
+        if(PERASTAGE_INSTALL_SUPPORTS_RUNTIME_DEPS)
+            install(TARGETS ${PROJECT_NAME}
+                RUNTIME DESTINATION .
+                RUNTIME_DEPENDENCIES
+                    DIRECTORIES ${PERASTAGE_VCPKG_BIN_DIRS}
+                    PRE_EXCLUDE_REGEXES
+                        "api-ms-.*"
+                        "ext-ms-.*"
+                    POST_EXCLUDE_REGEXES
+                        ".*[Ww]indows[\\/].*"
+                        ".*[Ss]ystem32[\\/].*"
+            )
+        else()
+            install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION .)
+        endif()
     else()
         install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION .)
     endif()


### PR DESCRIPTION
### Motivation
- Release installs failed on older CMake with an error about the unknown `RUNTIME_DEPENDENCIES` argument to `install`.
- Preserve `RUNTIME_DEPENDENCIES` behavior when the installed CMake supports it while allowing builds on older CMake versions.
- Keep Debug install behavior and existing install layout unchanged.

### Description
- Add `PERASTAGE_INSTALL_SUPPORTS_RUNTIME_DEPS` set from `CMAKE_VERSION` and disable it when `CMAKE_VERSION` is less than `3.21`.
- Condition the `install(... RUNTIME_DEPENDENCIES ...)` usage on that variable and provide a fallback `install` without runtime dependencies for older CMake.
- Apply the guarded logic for both multi-config (`CMAKE_CONFIGURATION_TYPES`) and single-config (`CMAKE_BUILD_TYPE`) code paths in `CMakeLists.txt`.
- Maintain the same install configurations for `Release`, `RelWithDebInfo`, `MinSizeRel`, and `Debug` where appropriate.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696295b694e08324ab67c20f4291c2ff)