### PR TITLE
Lower minimum CMake version to 3.20 to avoid install errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.20)
 cmake_policy(SET CMP0074 NEW)
 
 project(Perastage VERSION 1.0 LANGUAGES CXX)


### PR DESCRIPTION
### Motivation
- The build fails on older generators with `install TARGETS` when the `RUNTIME_DEPENDENCIES` argument is not supported, producing the error about unknown argument `RUNTIME_DEPENDENCIES`.
- The project previously guarded runtime-deps support based on `CMAKE_VERSION` and wants to allow configuration on older CMake installations.

### Description
- Updated `cmake_minimum_required` from `3.21` to `3.20` in `CMakeLists.txt` to permit use with slightly older CMake versions.
- This change ensures the existing runtime-dependencies conditional logic (which disables `RUNTIME_DEPENDENCIES` for older CMake) can be used without preventing configuration.

### Testing
- No automated tests were run as part of this change.
- A local commit was created updating `CMakeLists.txt` and the repository state was updated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696297112c088324bc2c2d258a4fdfcf)