### PR TITLE
Revert "Lower minimum CMake version to 3.20 to avoid install errors"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 cmake_policy(SET CMP0074 NEW)
 
 project(Perastage VERSION 1.0 LANGUAGES CXX)


### PR DESCRIPTION
Reverts PeramatoG/Perastage#461