### PR TITLE
Use CMake 3.21 runtime dependency sets for Release install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,48 +159,39 @@ if(WIN32)
     list(REMOVE_DUPLICATES PERASTAGE_VCPKG_BIN_DIRS)
     list(REMOVE_DUPLICATES PERASTAGE_VCPKG_DEBUG_BIN_DIRS)
 
-    set(PERASTAGE_INSTALL_SUPPORTS_RUNTIME_DEPS TRUE)
-    if(CMAKE_VERSION VERSION_LESS "3.21")
-        set(PERASTAGE_INSTALL_SUPPORTS_RUNTIME_DEPS FALSE)
-    endif()
-
     if(CMAKE_CONFIGURATION_TYPES)
-        if(PERASTAGE_INSTALL_SUPPORTS_RUNTIME_DEPS)
-            install(TARGETS ${PROJECT_NAME}
-                RUNTIME DESTINATION .
-                CONFIGURATIONS Release RelWithDebInfo MinSizeRel
-                RUNTIME_DEPENDENCIES
-                    DIRECTORIES ${PERASTAGE_VCPKG_BIN_DIRS}
-                    PRE_EXCLUDE_REGEXES
-                        "api-ms-.*"
-                        "ext-ms-.*"
-                    POST_EXCLUDE_REGEXES
-                        ".*[Ww]indows[\\/].*"
-                        ".*[Ss]ystem32[\\/].*"
-            )
-        else()
-            install(TARGETS ${PROJECT_NAME}
-                RUNTIME DESTINATION .
-                CONFIGURATIONS Release RelWithDebInfo MinSizeRel
-            )
-        endif()
+        install(TARGETS ${PROJECT_NAME}
+            RUNTIME DESTINATION .
+            CONFIGURATIONS Release RelWithDebInfo MinSizeRel
+            RUNTIME_DEPENDENCY_SET perastage_runtime_deps_release
+        )
         install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION . CONFIGURATIONS Debug)
+        install(RUNTIME_DEPENDENCY_SET perastage_runtime_deps_release
+            DESTINATION .
+            CONFIGURATIONS Release RelWithDebInfo MinSizeRel
+            DIRECTORIES ${PERASTAGE_VCPKG_BIN_DIRS}
+            PRE_EXCLUDE_REGEXES
+                "api-ms-.*"
+                "ext-ms-.*"
+            POST_EXCLUDE_REGEXES
+                ".*[Ww]indows[\\/].*"
+                ".*[Ss]ystem32[\\/].*"
+        )
     elseif(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-        if(PERASTAGE_INSTALL_SUPPORTS_RUNTIME_DEPS)
-            install(TARGETS ${PROJECT_NAME}
-                RUNTIME DESTINATION .
-                RUNTIME_DEPENDENCIES
-                    DIRECTORIES ${PERASTAGE_VCPKG_BIN_DIRS}
-                    PRE_EXCLUDE_REGEXES
-                        "api-ms-.*"
-                        "ext-ms-.*"
-                    POST_EXCLUDE_REGEXES
-                        ".*[Ww]indows[\\/].*"
-                        ".*[Ss]ystem32[\\/].*"
-            )
-        else()
-            install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION .)
-        endif()
+        install(TARGETS ${PROJECT_NAME}
+            RUNTIME DESTINATION .
+            RUNTIME_DEPENDENCY_SET perastage_runtime_deps_release
+        )
+        install(RUNTIME_DEPENDENCY_SET perastage_runtime_deps_release
+            DESTINATION .
+            DIRECTORIES ${PERASTAGE_VCPKG_BIN_DIRS}
+            PRE_EXCLUDE_REGEXES
+                "api-ms-.*"
+                "ext-ms-.*"
+            POST_EXCLUDE_REGEXES
+                ".*[Ww]indows[\\/].*"
+                ".*[Ss]ystem32[\\/].*"
+        )
     else()
         install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION .)
     endif()


### PR DESCRIPTION
### Motivation
- Restore `cmake_minimum_required(VERSION 3.21)` so the project can be built with CMake 3.21 while using modern install primitives.
- Replace the previous generated install-time script approach with updated CMake commands to reliably collect and copy missing DLLs for Release installs on Windows.
- Keep the same runtime dependency filtering and vcpkg / wxWidgets lookup behavior while using a cleaner, supported API.

### Description
- Bumped `cmake_minimum_required` to `3.21` and updated `CMakeLists.txt` accordingly.
- Replaced the `file(GET_RUNTIME_DEPENDENCIES)` + generated `install(SCRIPT ...)` approach with `install(TARGETS ... RUNTIME_DEPENDENCY_SET ...)` and `install(RUNTIME_DEPENDENCY_SET ...)` for Release (and multi-config Release variants).
- Preserved the `PERASTAGE_VCPKG_BIN_DIRS` handling and the `PRE_EXCLUDE_REGEXES` / `POST_EXCLUDE_REGEXES` rules used to filter system and Windows API shims.
- Kept Debug installs unchanged and removed the older compatibility guard used to choose between the two approaches.

### Testing
- No automated tests were run for this change.
- The change was applied to `CMakeLists.txt` and committed locally without running build or install tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696297112c088324bc2c2d258a4fdfcf)