### PR TITLE
Fix CMake RUNTIME_DEPENDENCY_SET parsing in install() calls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,10 @@ if(WIN32)
         install(TARGETS ${PROJECT_NAME}
             RUNTIME DESTINATION .
             CONFIGURATIONS Release RelWithDebInfo MinSizeRel
+        )
+        install(TARGETS ${PROJECT_NAME}
             RUNTIME_DEPENDENCY_SET perastage_runtime_deps_release
+            CONFIGURATIONS Release RelWithDebInfo MinSizeRel
         )
         install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION . CONFIGURATIONS Debug)
         install(RUNTIME_DEPENDENCY_SET perastage_runtime_deps_release
@@ -180,6 +183,8 @@ if(WIN32)
     elseif(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
         install(TARGETS ${PROJECT_NAME}
             RUNTIME DESTINATION .
+        )
+        install(TARGETS ${PROJECT_NAME}
             RUNTIME_DEPENDENCY_SET perastage_runtime_deps_release
         )
         install(RUNTIME_DEPENDENCY_SET perastage_runtime_deps_release


### PR DESCRIPTION
### Motivation

- CMake 3.21 can mis-parse `install(TARGETS ...)` when `RUNTIME_DEPENDENCY_SET` is mixed with other target types, producing the error `install TARGETS given unknown argument "RUNTIME_DEPENDENCY_SET"`.
- The change aims to avoid the parser bug while preserving existing install destinations and configuration behavior.
- The fix must work for both multi-config generators (Visual Studio) and single-config builds.
- Keep existing runtime dependency installation and exclusion rules unchanged.

### Description

- Split the combined `install(TARGETS ...)` call into separate `install(TARGETS ...)` invocations so `RUNTIME_DEPENDENCY_SET` is not passed alongside other target type arguments in the same call.
- Added a dedicated `install(TARGETS ${PROJECT_NAME} RUNTIME_DEPENDENCY_SET perastage_runtime_deps_release ...)` call in both the multi-config and single-config branches.
- Kept the existing `install(RUNTIME_DEPENDENCY_SET perastage_runtime_deps_release ...)` call with its `DESTINATION`, `DIRECTORIES`, and exclude regexes intact.
- Modified file: `CMakeLists.txt`.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69629ba4b47083248c6a66282d693ac4)