### PR TITLE
Clean staging install outputs: single root exe and filter debug DLLs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,8 @@ add_executable(${PROJECT_NAME} ${SRC_FILES} ${HEADER_FILES})
 # Mark as GUI application (no console)
 set_target_properties(${PROJECT_NAME} PROPERTIES WIN32_EXECUTABLE TRUE)
 
+install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION .)
+
 # Include project directories
 target_include_directories(${PROJECT_NAME} PRIVATE
     ${CMAKE_SOURCE_DIR}/gui
@@ -109,10 +111,6 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
 
 if(BUILD_TESTING)
     add_subdirectory(tests)
-endif()
-
-if(NOT WIN32)
-    install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION .)
 endif()
 
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/resources DESTINATION .)
@@ -161,14 +159,9 @@ if(WIN32)
 
     if(CMAKE_CONFIGURATION_TYPES)
         install(TARGETS ${PROJECT_NAME}
-            RUNTIME DESTINATION .
-            CONFIGURATIONS Release RelWithDebInfo MinSizeRel
-        )
-        install(TARGETS ${PROJECT_NAME}
             RUNTIME_DEPENDENCY_SET perastage_runtime_deps_release
             CONFIGURATIONS Release RelWithDebInfo MinSizeRel
         )
-        install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION . CONFIGURATIONS Debug)
         install(RUNTIME_DEPENDENCY_SET perastage_runtime_deps_release
             DESTINATION .
             CONFIGURATIONS Release RelWithDebInfo MinSizeRel
@@ -179,12 +172,12 @@ if(WIN32)
             POST_EXCLUDE_REGEXES
                 ".*[Ww]indows[\\/].*"
                 ".*[Ss]ystem32[\\/].*"
+                ".*ud_.*\\.dll$"
+                ".*d_.*\\.dll$"
+                ".*d\\.dll$"
         )
     elseif(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
         install(TARGETS ${PROJECT_NAME}
-            RUNTIME DESTINATION .
-        )
-        install(TARGETS ${PROJECT_NAME}
             RUNTIME_DEPENDENCY_SET perastage_runtime_deps_release
         )
         install(RUNTIME_DEPENDENCY_SET perastage_runtime_deps_release
@@ -196,9 +189,10 @@ if(WIN32)
             POST_EXCLUDE_REGEXES
                 ".*[Ww]indows[\\/].*"
                 ".*[Ss]ystem32[\\/].*"
+                ".*ud_.*\\.dll$"
+                ".*d_.*\\.dll$"
+                ".*d\\.dll$"
         )
-    else()
-        install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION .)
     endif()
 
     # wxWidgets libraries may not appear in TARGET_RUNTIME_DLLS when discovered
@@ -248,6 +242,9 @@ if(WIN32)
         set(PERASTAGE_WX_RELEASE_DLLS ${PERASTAGE_WX_RUNTIME_DLLS})
         list(FILTER PERASTAGE_WX_DEBUG_DLLS INCLUDE REGEX ".*(d_vc_|ud_vc_).*\\.dll$")
         list(FILTER PERASTAGE_WX_RELEASE_DLLS EXCLUDE REGEX ".*(d_vc_|ud_vc_).*\\.dll$")
+        list(FILTER PERASTAGE_WX_RELEASE_DLLS EXCLUDE REGEX ".*ud_.*\\.dll$")
+        list(FILTER PERASTAGE_WX_RELEASE_DLLS EXCLUDE REGEX ".*d_.*\\.dll$")
+        list(FILTER PERASTAGE_WX_RELEASE_DLLS EXCLUDE REGEX ".*d\\.dll$")
 
         if(CMAKE_CONFIGURATION_TYPES)
             install(FILES ${PERASTAGE_WX_DEBUG_DLLS} DESTINATION . CONFIGURATIONS Debug)


### PR DESCRIPTION
### Motivation
- Ensure the install staging tree (`out/install/<config>`) produces a clean Release package without debug DLLs and without a `bin/` folder or duplicate `Perastage.exe`.
- Keep runtime resources (`resources/`, `library/`, `licenses/`, `LICENSE.txt`, `THIRD_PARTY_LICENSES.md`) next to the executable in the package root.
- Prevent shipping generated runtime artifacts such as `perastage.log` (no install rule is added for logs).
- Filter runtime dependency collection so debug wxWidgets and other debug DLLs are excluded from Release/RelWithDebInfo installs.

### Description
- Add a single unconditional install rule `install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION .)` to place `Perastage.exe` only at the package root and remove redundant per-configuration exe installs.
- Remove other `install(TARGETS ... RUNTIME DESTINATION .)` occurrences that caused duplicate placement (including `bin/` copies) so no `bin/Perastage.exe` is produced.
- Add exclusion regexes to runtime dependency installation to filter debug DLLs by patterns `.*ud_.*\.dll$`, `.*d_.*\.dll$` and `.*d\.dll$` for Release/RelWithDebInfo/MinSizeRel installs.
- Apply the same DLL filters to the `PERASTAGE_WX_RELEASE_DLLS` selection so wxWidgets debug/Unicode-debug DLLs are not installed in Release packages while keeping the Unicode Release libraries.

### Testing
- No automated tests were run as part of this change.
- Manual verification was not included in the automated rollout steps.
- The patch was compiled into the repository and committed successfully.
- Users should run `cmake --install <build-dir> --prefix out/install/Release --config Release` and verify the `out/install/Release` directory contains a single `Perastage.exe`, no `bin/` folder, and no `*ud*`/`*d*` debug DLLs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962a129d178832499c7691d748bc53c)