### PR TITLE
Add layout view presets registry and centralize layout application in MainWindow

### DIFF
--- a/core/layoutviewpresets.cpp
+++ b/core/layoutviewpresets.cpp
@@ -1,0 +1,83 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "layoutviewpresets.h"
+
+#include <algorithm>
+
+namespace {
+const std::vector<LayoutViewPreset> kLayoutViewPresets = {
+    {
+        "3d_layout_view",
+        {
+            "FileToolbar",
+            "LayoutViewsToolbar",
+        },
+        {
+            "LayoutPanel",
+            "LayoutViewer",
+            "LayoutToolbar",
+        },
+    },
+    {
+        "2d_layout_view",
+        {
+            "FileToolbar",
+            "LayoutViewsToolbar",
+        },
+        {
+            "LayoutPanel",
+            "LayoutViewer",
+            "LayoutToolbar",
+        },
+    },
+    {
+        "layout_mode_view",
+        {
+            "LayoutPanel",
+            "LayoutViewer",
+            "FileToolbar",
+            "LayoutToolbar",
+            "LayoutViewsToolbar",
+        },
+        {
+            "3DViewport",
+            "2DViewport",
+            "2DRenderOptions",
+            "DataNotebook",
+            "Console",
+            "LayerPanel",
+            "SummaryPanel",
+            "RiggingPanel",
+        },
+    },
+};
+} // namespace
+
+const LayoutViewPreset *LayoutViewPresetRegistry::GetPreset(
+    const std::string &name) {
+  auto it = std::find_if(
+      kLayoutViewPresets.begin(), kLayoutViewPresets.end(),
+      [&name](const LayoutViewPreset &preset) { return preset.name == name; });
+  if (it == kLayoutViewPresets.end())
+    return nullptr;
+  return &(*it);
+}
+
+const std::vector<LayoutViewPreset> &LayoutViewPresetRegistry::GetPresets() {
+  return kLayoutViewPresets;
+}

--- a/core/layoutviewpresets.h
+++ b/core/layoutviewpresets.h
@@ -1,0 +1,33 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <string>
+#include <vector>
+
+struct LayoutViewPreset {
+  std::string name;
+  std::vector<std::string> showPanes;
+  std::vector<std::string> hidePanes;
+};
+
+class LayoutViewPresetRegistry {
+public:
+  static const LayoutViewPreset *GetPreset(const std::string &name);
+  static const std::vector<LayoutViewPreset> &GetPresets();
+};

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -43,6 +43,7 @@ class LayoutPanel;
 class LayoutViewerPanel;
 class SummaryPanel;
 class RiggingPanel;
+struct LayoutViewPreset;
 
 // Main application window for GUI components
 class MainWindow : public wxFrame {
@@ -160,6 +161,9 @@ private:
 
   void SaveCameraSettings();
   void ApplySavedLayout();
+  void ApplyLayoutPreset(const LayoutViewPreset &preset,
+                         const std::optional<std::string> &perspective,
+                         bool layoutMode, bool persistPerspective);
   void ApplyLayoutModePerspective();
   void BeginLayout2DViewEdit();
   void UpdateViewMenuChecks();


### PR DESCRIPTION
### Motivation
- Introduce a reusable definition for common layout/pane combinations so the same layout logic can be applied from multiple places.
- Centralize the logic that applies saved/default/2D/layout-mode perspectives to avoid duplication and ensure consistent behavior.
- Ensure the `layout_perspective` and `layout_layout_mode` config values are correctly updated after applying a preset.

### Description
- Add `LayoutViewPreset` and `LayoutViewPresetRegistry` in `core/layoutviewpresets.h` and `core/layoutviewpresets.cpp` with three initial presets: `3d_layout_view`, `2d_layout_view`, and `layout_mode_view`.
- Add `MainWindow::ApplyLayoutPreset(const LayoutViewPreset&, const std::optional<std::string>&, bool, bool)` and use it from `OnApplyDefaultLayout`, `OnApply2DLayout`, `ApplyLayoutModePerspective`, and `ApplySavedLayout` to apply presets and update panes via `auiManager->GetPane(...)` and `auiManager->Update()`.
- Update `gui/mainwindow.h` to forward-declare `LayoutViewPreset` and declare the new `ApplyLayoutPreset` method, and include `layoutviewpresets.h` where needed.
- Persist `layout_perspective` and `layout_layout_mode` when requested by the preset application flow so saved perspectives remain consistent.

### Testing
- No automated tests were run as part of this change.
- Changes were committed locally with `git commit` and the new files `core/layoutviewpresets.*` plus modified `gui/mainwindow.*` were added to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962b6c519fc8324b943a76f6c8adb48)