### PR TITLE
Guard layout-mode re-application to avoid unwanted view switch on restore

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -2826,7 +2826,8 @@ void MainWindow::ActivateLayoutView(const std::string &layoutName) {
       RestoreLayout2DViewState(viewId);
   }
 
-  ApplyLayoutModePerspective();
+  if (layoutModeActive)
+    ApplyLayoutModePerspective();
 }
 
 void MainWindow::SyncSceneData() {


### PR DESCRIPTION
### Motivation
- Restoring a saved workspace could unexpectedly switch the UI into layout mode even when the prior session was in the 3D view, causing an extra view flip on startup.
- The root cause was an unconditional re-application of the layout-mode perspective when activating a layout view.
- The expected behavior is to only re-apply the layout-mode perspective when layout mode is already active, preserving the exact view users had when they closed the app.

### Description
- Changed `gui/mainwindow.cpp` to conditionally call `ApplyLayoutModePerspective()` only when `layoutModeActive` is true in `ActivateLayoutView`.
- This replaces the previous unconditional call to `ApplyLayoutModePerspective()` so layout selection no longer forces layout mode on startup.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696540fea700832486df9c9d012764a4)