### PR TITLE
RiderImporter: accept multiple meter unit spellings when parsing trusses

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -54,10 +54,11 @@ namespace {
 // the compilation cost on every import call and makes keyword matching cheap
 // even when processing large riders.
 static const std::regex kTrussLineRe(
-    "^\\s*(?:[-*]\\s*)?(\\d+)\\s+(?:truss)\\s+([^\\n]*?)\\s+(\\d+(?:\\.\\d+)?)\\s*m(?:\\s+para\\s+(.+))?",
+    "^\\s*(?:[-*]\\s*)?(\\d+)\\s+(?:truss)\\s+([^\\n]*?)\\s+(\\d+(?:\\.\\d+)?)\\s*(?:m|metros?|meters?)\\b(?:\\s+para\\s+(.+))?",
     std::regex::icase);
 static const std::regex kTrussRe(
-    "(?:truss)[^\\n]*?(\\d+(?:\\.\\d+)?)\\s*m", std::regex::icase);
+    "(?:truss)[^\\n]*?(\\d+(?:\\.\\d+)?)\\s*(?:m|metros?|meters?)\\b",
+    std::regex::icase);
 static const std::regex kFixtureLineRe("^\\s*(?:[-*]\\s*)?(\\d+)\\s+(.+)$",
                                        std::regex::icase);
 static const std::regex kQuantityOnlyRe("^\\s*(?:[-*]\\s*)?(\\d+)\\s*$");


### PR DESCRIPTION
### Motivation
- Rider truss parsing previously only matched a bare `m` token, causing imports to fail when riders used `metros`/`meters` or different capitalization.
- The change ensures truss length detection accepts common English and Spanish unit spellings and is case-insensitive.

### Description
- Updated the truss parsing regular expressions in `core/riderimporter.cpp` by modifying `kTrussLineRe` and `kTrussRe` to match `(?:m|metros?|meters?)\b` with `std::regex::icase`.
- The new patterns allow optional whitespace before the unit and enforce a word boundary to avoid false positives, while leaving the rest of the parsing logic unchanged.
- Only `core/riderimporter.cpp` was modified.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696577152fac832494f5687572f84b06)