### PR TITLE
Scale legend fixture symbols with row height

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -2057,9 +2057,11 @@ wxImage LayoutViewerPanel::BuildLegendImage(
       std::max(lineHeight,
                static_cast<int>(std::lround(rowHeight * renderZoom *
                                             kLegendLineSpacingScale)));
+  const int rowHeightPx = baseRowHeightPx;
   const int desiredSymbolSize =
       static_cast<int>(std::lround(kLegendSymbolSizePx * renderZoom));
-  const int symbolSize = std::max(4, desiredSymbolSize);
+  const int symbolSize =
+      std::max(4, std::min(desiredSymbolSize, rowHeightPx));
   double maxSymbolDrawWidth = 0.0;
   if (symbols) {
     for (const auto &item : items) {
@@ -2084,7 +2086,6 @@ wxImage LayoutViewerPanel::BuildLegendImage(
       static_cast<int>(std::ceil(
           (maxSymbolDrawWidth > 0.0 ? maxSymbolDrawWidth : symbolSize) *
           kLegendSymbolColumnScale)));
-  const int rowHeightPx = baseRowHeightPx;
   const int paddingLeftPx =
       std::max(0, static_cast<int>(std::lround(paddingLeft * renderZoom)));
   const int paddingRightPx =


### PR DESCRIPTION
### Motivation
- Legend text scales down when the legend box is reduced but fixture symbols did not, causing visual mismatch and clipping.
- Symbols should scale together with the text so icons remain proportional and fit inside the row height.

### Description
- Modified `BuildLegendImage` in `gui/layoutviewerpanel.cpp` to clamp `symbolSize` to the legend `rowHeightPx` using `std::min(desiredSymbolSize, rowHeightPx)` so symbols never exceed the row height.
- Moved the `rowHeightPx` binding earlier in the function so it can be used when computing `symbolSize` and `symbolSlotSize`.
- Kept a minimum symbol size (`std::max(4, ...)`) to avoid rendering invisible icons.
- Changes only affect legend image construction and rendering paths that use `BuildLegendImage` (on-screen legend cache and exported legends).

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69657c43e8ac8324b3b44648dad465c9)