### PR TITLE
Guard GL canvas SetCurrent calls when panels are hidden

### DIFF
--- a/gui/fixturepreviewpanel.cpp
+++ b/gui/fixturepreviewpanel.cpp
@@ -166,6 +166,9 @@ FixturePreviewPanel::~FixturePreviewPanel()
 
 void FixturePreviewPanel::InitGL()
 {
+    if(!IsShownOnScreen()){
+        return;
+    }
     SetCurrent(*m_glContext);
     if(!m_glInitialized){
         glewExperimental = GL_TRUE;
@@ -256,6 +259,9 @@ void FixturePreviewPanel::Render()
 void FixturePreviewPanel::OnPaint(wxPaintEvent&)
 {
     wxPaintDC dc(this);
+    if(!IsShownOnScreen()){
+        return;
+    }
     InitGL();
     Render();
     SwapBuffers();
@@ -305,4 +311,3 @@ void FixturePreviewPanel::OnMouseWheel(wxMouseEvent& evt)
     m_camera.Zoom(-(float)rot/delta);
     Refresh();
 }
-

--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -612,6 +612,9 @@ std::pair<int, int> LayoutViewerPanel::GetZIndexRange() const {
 
 void LayoutViewerPanel::OnPaint(wxPaintEvent &) {
   wxPaintDC dc(this);
+  if (!IsShownOnScreen()) {
+    return;
+  }
   InitGL();
   SetCurrent(*glContext_);
   RefreshLegendData();
@@ -1486,6 +1489,8 @@ void LayoutViewerPanel::UpdateLegendFrame(const layouts::Layout2DViewFrame &fram
 void LayoutViewerPanel::InitGL() {
   if (!glContext_)
     return;
+  if (!IsShownOnScreen())
+    return;
   SetCurrent(*glContext_);
   if (!glInitialized_) {
     glDisable(GL_DEPTH_TEST);
@@ -1497,6 +1502,8 @@ void LayoutViewerPanel::InitGL() {
 
 void LayoutViewerPanel::RebuildCachedTexture() {
   if (!renderDirty)
+    return;
+  if (!IsShownOnScreen())
     return;
 
   renderDirty = false;
@@ -1569,6 +1576,8 @@ void LayoutViewerPanel::RebuildCachedTexture() {
     }
 
     InitGL();
+    if (!IsShownOnScreen())
+      return;
     SetCurrent(*glContext_);
     if (cache.texture == 0) {
       glGenTextures(1, &cache.texture);
@@ -1639,6 +1648,8 @@ void LayoutViewerPanel::RebuildCachedTexture() {
     }
 
     InitGL();
+    if (!IsShownOnScreen())
+      return;
     SetCurrent(*glContext_);
     if (cache.texture == 0) {
       glGenTextures(1, &cache.texture);

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -89,6 +89,9 @@ void Viewer3DPanel::StopRefreshThread()
 // Initializes OpenGL basic settings
 void Viewer3DPanel::InitGL()
 {
+    if (!IsShownOnScreen()) {
+        return;
+    }
     SetCurrent(*m_glContext);
     if (!m_glInitialized) {
         glewExperimental = GL_TRUE;
@@ -109,6 +112,9 @@ void Viewer3DPanel::InitGL()
 void Viewer3DPanel::OnPaint(wxPaintEvent& event)
 {
     wxPaintDC dc(this);
+    if (!IsShownOnScreen()) {
+        return;
+    }
     InitGL();
     Render();
 
@@ -199,6 +205,9 @@ void Viewer3DPanel::OnResize(wxSizeEvent& event)
 // Renders the full 3D scene
 void Viewer3DPanel::Render()
 {
+    if (!IsShownOnScreen()) {
+        return;
+    }
     SetCurrent(*m_glContext);
 
     int width, height;
@@ -251,6 +260,9 @@ void Viewer3DPanel::OnMouseUp(wxMouseEvent& event)
     {
         int w, h;
         GetClientSize(&w, &h);
+        if (!IsShownOnScreen()) {
+            return;
+        }
         SetCurrent(*m_glContext);
         wxString label;
         wxPoint pos;


### PR DESCRIPTION
### Motivation

- Prevent wxWidgets assertions and crashes caused by calling OpenGL `SetCurrent` on hidden GL canvases.
- Avoid performing GL initialization, rendering, or texture uploads when a panel is not visible on screen.
- Ensure background/offscreen work that touches GL respects widget visibility to avoid invalid context usage.
- Reduce chances of race/visibility-related failures in `FixturePreviewPanel`, `Viewer3DPanel`, and `LayoutViewerPanel`.

### Description

- Add `IsShownOnScreen()` guards to `FixturePreviewPanel::InitGL` and `FixturePreviewPanel::OnPaint` to skip GL work when hidden. 
- Add `IsShownOnScreen()` checks to `Viewer3DPanel::InitGL`, `Viewer3DPanel::OnPaint`, `Viewer3DPanel::Render`, and the `OnMouseUp` path to avoid making the GL context current while hidden. 
- Add visibility checks in `LayoutViewerPanel::OnPaint`, `LayoutViewerPanel::InitGL`, and `LayoutViewerPanel::RebuildCachedTexture` to bail out before `SetCurrent` and texture uploads when not visible. 
- Overall change: early-return when panel is not shown to prevent calling `SetCurrent(*glContext_)` on invisible canvases.

### Testing

- No automated tests were executed for these changes.
- Changes were committed and contain only defensive early-return guards; no runtime test run was requested.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965808ae6948324accaefb4133c6383)