### PR TITLE
Scale legend symbols with text size

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -2026,6 +2026,8 @@ wxImage LayoutViewerPanel::BuildLegendImage(
                     : 10.0;
   fontSize = std::clamp(fontSize, 6.0, 14.0);
   fontSize *= kLegendFontScale;
+  const double fontScale =
+      std::clamp(fontSize / (14.0 * kLegendFontScale), 0.0, 1.0);
   const int fontSizePx =
       std::max(1, static_cast<int>(std::lround(fontSize * renderZoom)));
 
@@ -2068,8 +2070,8 @@ wxImage LayoutViewerPanel::BuildLegendImage(
       std::max(lineHeight,
                static_cast<int>(std::lround(rowHeight * renderZoom *
                                             kLegendLineSpacingScale)));
-  const int desiredSymbolSize =
-      static_cast<int>(std::lround(kLegendSymbolSizePx * renderZoom));
+  const int desiredSymbolSize = static_cast<int>(std::lround(
+      kLegendSymbolSizePx * renderZoom * fontScale));
   const int symbolSize = std::max(4, desiredSymbolSize);
   double maxSymbolDrawWidth = 0.0;
   if (symbols) {

--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -2076,6 +2076,8 @@ Viewer2DExportResult ExportLayoutToPdf(
         totalRows > 0 ? (availableHeight / totalRows) - 2.0 : 10.0;
     fontSize = std::clamp(fontSize, 6.0, 14.0);
     fontSize *= kLegendFontScale;
+    const double fontScale =
+        std::clamp(fontSize / (14.0 * kLegendFontScale), 0.0, 1.0);
 
     double maxCountWidth =
         MeasureTextWidth("Count", fontSize, fontCatalog.bold);
@@ -2101,7 +2103,8 @@ Viewer2DExportResult ExportLayoutToPdf(
         totalRows > 0 ? (availableHeight / totalRows) : 0.0;
     const double textHeightEstimate = fontSize * 1.2;
     const double lineHeight = textHeightEstimate + separatorGap;
-    const double symbolSize = std::max(4.0, kLegendSymbolSize);
+    const double symbolSize =
+        std::max(4.0, kLegendSymbolSize * fontScale);
     double maxSymbolDrawWidth = 0.0;
     for (const auto &item : legend.items) {
       if (item.symbolKey.empty())


### PR DESCRIPTION
### Motivation
- Cuando la caja de la leyenda se reduce, las letras se escalan y los símbolos de fixtures deben seguir el mismo escalado para mantener proporciones y legibilidad.
- Aplicar el mismo comportamiento tanto en el visor de layouts (`gui/layoutviewerpanel.cpp`) como en la exportación a PDF (`viewer2d/viewer2dpdfexporter.cpp`).

### Description
- Se calcula un `fontScale` a partir del tamaño de fuente efectivo y se clampa entre `0.0` y `1.0` para representar el factor de reducción relativo a la fuente máxima.
- En `LayoutViewerPanel::BuildLegendImage` se usa `fontScale` para reducir `desiredSymbolSize` antes de calcular el tamaño final del símbolo y la casilla de símbolo.
- En `ExportLayoutToPdf` se aplica `fontScale` para ajustar `symbolSize` en la lógica de renderizado de leyendas PDF y mantener la consistencia con el visor.
- Se preserva un tamaño mínimo de símbolo (`>= 4`) y no se cambian las demás métricas de layout.

### Testing
- No se ejecutaron pruebas automatizadas durante este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69663e1e3e0883249bb655816405520d)