### PR TITLE
Ensure dummy legend symbols match plan fallback

### DIFF
--- a/gui/legendutils.cpp
+++ b/gui/legendutils.cpp
@@ -71,5 +71,7 @@ std::string BuildFixtureSymbolKey(const Fixture &fixture,
     modelKey = NormalizeModelKey(fixture.gdtfSpec);
   if (modelKey.empty() && !fixture.typeName.empty())
     modelKey = fixture.typeName;
+  if (modelKey.empty())
+    modelKey = "unknown";
   return modelKey;
 }

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1434,6 +1434,8 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
         modelKey = NormalizeModelKey(f.gdtfSpec);
       if (modelKey.empty() && !f.typeName.empty())
         modelKey = f.typeName;
+      if (modelKey.empty())
+        modelKey = "unknown";
 
       if (!modelKey.empty()) {
         SymbolKey symbolKey;


### PR DESCRIPTION
### Motivation
- Legend items must render the same square "dummy" symbol used in plan captures when a fixture has no valid model.
- When fixtures lack a GDTF/model and `typeName` is empty, the symbol lookup was returning an empty key causing inconsistent legend rendering.

### Description
- Set a shared fallback model key `"unknown"` in `BuildFixtureSymbolKey` (`gui/legendutils.cpp`) when no model, spec or type name is available.
- Apply the same `"unknown"` fallback in the capture path before creating symbol instances in `RenderScene` (`viewer3d/viewer3dcontroller.cpp`) so captured symbols are created for fixtures without models.
- This aligns legend symbol lookup with the plan capture fallback and ensures the same dummy square symbol, colors and rendering dynamics are used.

### Testing
- No automated tests were run for this change.
- The patch is limited to two files: `gui/legendutils.cpp` and `viewer3d/viewer3dcontroller.cpp` and compiles as part of the normal build (commit created).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696640f0a0288324b968321ee4165cf9)