### PR TITLE
Reduce legend content scale by ~30%

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -494,8 +494,11 @@ constexpr int kHandleSizePx = 10;
 constexpr int kHandleHalfPx = kHandleSizePx / 2;
 constexpr int kHandleHoverPadPx = 6;
 constexpr int kMinFrameSize = 24;
-constexpr int kLegendSymbolSizePx = 106;
-constexpr double kLegendFontScale = 2.0 / 3.0;
+constexpr double kLegendContentScale = 0.7;
+constexpr int kLegendSymbolSizePx =
+    static_cast<int>(106 * kLegendContentScale);
+constexpr double kLegendFontScale =
+    (2.0 / 3.0) * kLegendContentScale;
 constexpr int kEditMenuId = wxID_HIGHEST + 490;
 constexpr int kDeleteMenuId = wxID_HIGHEST + 491;
 constexpr int kDeleteLegendMenuId = wxID_HIGHEST + 492;

--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -43,8 +43,11 @@
 #include "viewer2dcommandrenderer.h"
 
 namespace {
-constexpr double kLegendSymbolSize = 160.0 * 2.0 / 3.0;
-constexpr double kLegendFontScale = 2.0 / 3.0;
+constexpr double kLegendContentScale = 0.7;
+constexpr double kLegendSymbolSize =
+    160.0 * 2.0 / 3.0 * kLegendContentScale;
+constexpr double kLegendFontScale =
+    (2.0 / 3.0) * kLegendContentScale;
 
 static bool ShouldTraceLabelOrder() {
   static const bool enabled = std::getenv("PERASTAGE_TRACE_LABELS") != nullptr;


### PR DESCRIPTION
### Motivation
- Legend text and symbols were visually too large and need to be slightly reduced without changing behavior. 
- The reduction should be consistent between the on-screen layout viewer and exported PDFs. 

### Description
- Introduce a new scale constant `kLegendContentScale = 0.7` and apply it to legend sizing. 
- In `gui/layoutviewerpanel.cpp` adjust `kLegendSymbolSizePx` and `kLegendFontScale` to multiply the previous values by `kLegendContentScale`. 
- In `viewer2d/viewer2dpdfexporter.cpp` apply the same `kLegendContentScale` to `kLegendSymbolSize` and `kLegendFontScale` used for PDF legend rendering. 

### Testing
- No automated tests were run for this change. 
- The change is limited to constant adjustments and does not modify rendering algorithms or public APIs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69664415ae1083248773590089991611)