### PR TITLE
Prevent layout 2D view updates outside editor

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -2668,7 +2668,7 @@ void MainWindow::OnLayout2DViewCancel(wxCommandEvent &WXUNUSED(event)) {
 void MainWindow::PersistLayout2DViewState() {
   if (activeLayoutName.empty())
     return;
-  if (layoutModeActive && !layout2DViewEditing)
+  if (!layout2DViewEditing)
     return;
   ConfigManager &cfg = ConfigManager::Get();
   Viewer2DPanel *activePanel =

--- a/viewer2d/viewer2drenderpanel.cpp
+++ b/viewer2d/viewer2drenderpanel.cpp
@@ -417,7 +417,7 @@ void Viewer2DRenderPanel::OnLabelOffsetAngle(wxSpinEvent &evt) {
 
 void Viewer2DRenderPanel::OnView(wxCommandEvent &evt) {
   ConfigManager &cfg = ConfigManager::Get();
-  if (auto *mw = MainWindow::Instance())
+  if (auto *mw = MainWindow::Instance(); mw && mw->IsLayout2DViewEditing())
     mw->PersistLayout2DViewState();
   int sel = m_view->GetSelection();
   cfg.SetFloat("view2d_view", static_cast<float>(sel));
@@ -426,7 +426,7 @@ void Viewer2DRenderPanel::OnView(wxCommandEvent &evt) {
   m_showLabelName->SetValue(cfg.GetFloat(NAME_KEYS[sel]) != 0.0f);
   m_showLabelId->SetValue(cfg.GetFloat(ID_KEYS[sel]) != 0.0f);
   m_showLabelAddress->SetValue(cfg.GetFloat(DMX_KEYS[sel]) != 0.0f);
-  if (auto *mw = MainWindow::Instance())
+  if (auto *mw = MainWindow::Instance(); mw && mw->IsLayout2DViewEditing())
     mw->RestoreLayout2DViewState(sel);
   if (auto *vp = Viewer2DPanel::Instance()) {
     vp->SetView(static_cast<Viewer2DView>(sel));


### PR DESCRIPTION
### Motivation
- Switching the global 2D viewer between `Top`/`Front`/`Side` was incorrectly mutating saved layout 2D views used by Layout Mode View, which should remain independent. 
- The layout 2D view definitions must only be updated when the user explicitly edits a layout 2D view in the dedicated editor (to avoid surprising changes to layout mode).

### Description
- Changed `MainWindow::PersistLayout2DViewState` to skip persisting unless a layout 2D view edit is active by returning early if `layout2DViewEditing` is false. 
- Updated `Viewer2DRenderPanel::OnView` to call `PersistLayout2DViewState` and `RestoreLayout2DViewState` only when `MainWindow::IsLayout2DViewEditing()` is true, preventing view switches in the general 2D viewport from affecting layout view definitions. 
- Modified files: `gui/mainwindow.cpp` and `viewer2d/viewer2drenderpanel.cpp`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696753d2750083248c0a969796f60fcb)