### PR TITLE
Add layout event table element

### DIFF
--- a/core/layouts/LayoutCollection.h
+++ b/core/layouts/LayoutCollection.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <array>
+#include <array>
 #include <string>
 #include <vector>
 
@@ -80,11 +81,19 @@ struct LayoutLegendDefinition {
   Layout2DViewFrame frame;
 };
 
+struct LayoutEventTableDefinition {
+  int id = 0;
+  int zIndex = 0;
+  Layout2DViewFrame frame;
+  std::array<std::string, 7> fields;
+};
+
 struct LayoutDefinition {
   std::string name;
   print::PageSetup pageSetup;
   std::vector<Layout2DViewDefinition> view2dViews;
   std::vector<LayoutLegendDefinition> legendViews;
+  std::vector<LayoutEventTableDefinition> eventTables;
 };
 
 class LayoutCollection {
@@ -107,6 +116,11 @@ public:
                           const LayoutLegendDefinition &legend);
   bool RemoveLayoutLegend(const std::string &name, int legendId);
   bool MoveLayoutLegend(const std::string &name, int legendId, bool toFront);
+  bool UpdateLayoutEventTable(const std::string &name,
+                              const LayoutEventTableDefinition &table);
+  bool RemoveLayoutEventTable(const std::string &name, int tableId);
+  bool MoveLayoutEventTable(const std::string &name, int tableId,
+                            bool toFront);
 
   void ReplaceAll(std::vector<LayoutDefinition> layouts);
 

--- a/core/layouts/LayoutManager.h
+++ b/core/layouts/LayoutManager.h
@@ -42,6 +42,10 @@ public:
                           const LayoutLegendDefinition &legend);
   bool RemoveLayoutLegend(const std::string &name, int legendId);
   bool MoveLayoutLegend(const std::string &name, int legendId, bool toFront);
+  bool UpdateLayoutEventTable(const std::string &name,
+                              const LayoutEventTableDefinition &table);
+  bool RemoveLayoutEventTable(const std::string &name, int tableId);
+  bool MoveLayoutEventTable(const std::string &name, int tableId, bool toFront);
 
   void LoadFromConfig(ConfigManager &cfg);
   void SaveToConfig(ConfigManager &cfg) const;

--- a/gui/layouteventtabledialog.cpp
+++ b/gui/layouteventtabledialog.cpp
@@ -1,0 +1,65 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "layouteventtabledialog.h"
+
+namespace {
+constexpr std::array<const char *, 7> kEventTableLabels = {
+    "Venue:", "Location:", "Date:", "Stage:",
+    "Version:", "Design:", "Mail:"};
+}
+
+LayoutEventTableDialog::LayoutEventTableDialog(
+    wxWindow *parent, const layouts::LayoutEventTableDefinition &table)
+    : wxDialog(parent, wxID_ANY, "Edit Event Table", wxDefaultPosition,
+               wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER) {
+  wxBoxSizer *mainSizer = new wxBoxSizer(wxVERTICAL);
+  wxFlexGridSizer *grid = new wxFlexGridSizer(2, 8, 10);
+  grid->AddGrowableCol(1, 1);
+
+  for (size_t idx = 0; idx < kEventTableLabels.size(); ++idx) {
+    wxStaticText *label =
+        new wxStaticText(this, wxID_ANY, kEventTableLabels[idx]);
+    grid->Add(label, 0, wxALIGN_CENTER_VERTICAL | wxLEFT | wxRIGHT, 5);
+
+    wxTextCtrl *field = new wxTextCtrl(this, wxID_ANY);
+    if (idx < table.fields.size()) {
+      field->SetValue(wxString::FromUTF8(table.fields[idx]));
+    }
+    fieldControls_[idx] = field;
+    grid->Add(field, 1, wxEXPAND | wxLEFT | wxRIGHT, 5);
+  }
+
+  mainSizer->Add(grid, 1, wxEXPAND | wxALL, 12);
+  mainSizer->Add(CreateStdDialogButtonSizer(wxOK | wxCANCEL), 0,
+                 wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 12);
+
+  SetSizerAndFit(mainSizer);
+  CentreOnParent();
+}
+
+std::array<std::string, 7> LayoutEventTableDialog::GetFields() const {
+  std::array<std::string, 7> fields{};
+  for (size_t idx = 0; idx < fieldControls_.size(); ++idx) {
+    if (fieldControls_[idx]) {
+      wxString value = fieldControls_[idx]->GetValue();
+      value.Trim(true).Trim(false);
+      fields[idx] = value.ToStdString();
+    }
+  }
+  return fields;
+}

--- a/gui/layouteventtabledialog.h
+++ b/gui/layouteventtabledialog.h
@@ -1,0 +1,34 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <array>
+#include <string>
+#include <wx/wx.h>
+#include "layouts/LayoutCollection.h"
+
+class LayoutEventTableDialog : public wxDialog {
+public:
+  LayoutEventTableDialog(wxWindow *parent,
+                         const layouts::LayoutEventTableDefinition &table);
+
+  std::array<std::string, 7> GetFields() const;
+
+private:
+  std::array<wxTextCtrl *, 7> fieldControls_{};
+};

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -73,6 +73,14 @@ private:
     std::shared_ptr<const SymbolDefinitionSnapshot> symbols;
   };
 
+  struct EventTableCache {
+    unsigned int texture = 0;
+    wxSize textureSize{0, 0};
+    double renderZoom = 0.0;
+    bool renderDirty = true;
+    size_t contentHash = 0;
+  };
+
   void OnPaint(wxPaintEvent &event);
   void OnSize(wxSizeEvent &event);
   void OnLeftDown(wxMouseEvent &event);
@@ -85,6 +93,8 @@ private:
   void OnEditView(wxCommandEvent &event);
   void OnDeleteView(wxCommandEvent &event);
   void OnDeleteLegend(wxCommandEvent &event);
+  void OnEditEventTable(wxCommandEvent &event);
+  void OnDeleteEventTable(wxCommandEvent &event);
   void OnBringToFront(wxCommandEvent &event);
   void OnSendToBack(wxCommandEvent &event);
 
@@ -99,28 +109,41 @@ private:
                    bool updatePosition);
   void UpdateLegendFrame(const layouts::Layout2DViewFrame &frame,
                          bool updatePosition);
+  void UpdateEventTableFrame(const layouts::Layout2DViewFrame &frame,
+                             bool updatePosition);
   void InitGL();
   void RebuildCachedTexture();
   void ClearCachedTexture();
   void ClearCachedTexture(ViewCache &cache);
   void ClearCachedTexture(LegendCache &cache);
+  void ClearCachedTexture(EventTableCache &cache);
   void RequestRenderRebuild();
   void InvalidateRenderIfFrameChanged();
   void EmitEditViewRequest();
   bool SelectElementAtPosition(const wxPoint &pos);
   bool GetLegendFrameById(int legendId,
                           layouts::Layout2DViewFrame &frame) const;
+  bool GetEventTableFrameById(int tableId,
+                              layouts::Layout2DViewFrame &frame) const;
   const layouts::LayoutLegendDefinition *GetSelectedLegend() const;
   layouts::LayoutLegendDefinition *GetSelectedLegend();
+  const layouts::LayoutEventTableDefinition *GetSelectedEventTable() const;
+  layouts::LayoutEventTableDefinition *GetSelectedEventTable();
   bool GetSelectedFrame(layouts::Layout2DViewFrame &frame) const;
   ViewCache &GetViewCache(int viewId);
   LegendCache &GetLegendCache(int legendId);
+  EventTableCache &GetEventTableCache(int tableId);
   std::vector<LegendItem> BuildLegendItems() const;
   size_t HashLegendItems(const std::vector<LegendItem> &items) const;
   wxImage BuildLegendImage(const wxSize &size, const wxSize &logicalSize,
                            double renderZoom,
                            const std::vector<LegendItem> &items,
                            const SymbolDefinitionSnapshot *symbols) const;
+  size_t HashEventTableFields(
+      const layouts::LayoutEventTableDefinition &table) const;
+  wxImage BuildEventTableImage(
+      const wxSize &size, const wxSize &logicalSize, double renderZoom,
+      const layouts::LayoutEventTableDefinition &table) const;
 
   enum class FrameDragMode {
     None,
@@ -136,7 +159,8 @@ private:
   enum class SelectedElementType {
     None,
     View2D,
-    Legend
+    Legend,
+    EventTable
   };
 
   struct ZOrderedElement {
@@ -168,6 +192,7 @@ private:
   bool renderPending = false;
   std::unordered_map<int, ViewCache> viewCaches_;
   std::unordered_map<int, LegendCache> legendCaches_;
+  std::unordered_map<int, EventTableCache> eventTableCaches_;
   std::vector<LegendItem> legendItems_;
   size_t legendDataHash = 0;
 

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -153,6 +153,7 @@ private:
   void OnDelete(wxCommandEvent &event);         // Delete selected items
   void OnLayoutAdd2DView(wxCommandEvent &event); // Layout 2D view creation
   void OnLayoutAddLegend(wxCommandEvent &event); // Layout legend creation
+  void OnLayoutAddEventTable(wxCommandEvent &event); // Layout event table
   void OnLayout2DViewOk(wxCommandEvent &event); // Confirm layout 2D view edit
   void OnLayout2DViewCancel(wxCommandEvent &event); // Cancel layout 2D edit
   void OnLayoutViewEdit(wxCommandEvent &event);
@@ -215,6 +216,7 @@ enum {
   ID_View_Layout_Mode,
   ID_View_Layout_2DView,
   ID_View_Layout_Legend,
+  ID_View_Layout_EventTable,
   ID_Tools_DownloadGdtf,
   ID_Tools_EditDictionaries,
   ID_Tools_ImportRiderText,

--- a/resources/icons/outline/table.svg
+++ b/resources/icons/outline/table.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-table">
+  <path d="M12 3v18" />
+  <path d="M3 9h18" />
+  <path d="M3 15h18" />
+  <rect width="18" height="18" x="3" y="3" rx="2" />
+</svg>

--- a/viewer2d/viewer2dpdfexporter.h
+++ b/viewer2d/viewer2dpdfexporter.h
@@ -22,6 +22,7 @@
 #include "symbolcache.h"
 #include "layouts/LayoutCollection.h"
 #include "viewer2dpanel.h"
+#include <array>
 #include <filesystem>
 #include <memory>
 #include <optional>
@@ -71,6 +72,12 @@ struct LayoutLegendExportData {
   std::shared_ptr<const SymbolDefinitionSnapshot> symbolSnapshot = nullptr;
 };
 
+struct LayoutEventTableExportData {
+  layouts::Layout2DViewFrame frame;
+  std::array<std::string, 7> fields;
+  int zIndex = 0;
+};
+
 // Writes the captured 2D drawing commands to a vector PDF that mirrors the
 // current viewport state. Returns structured information so callers can surface
 // meaningful errors to the user.
@@ -84,5 +91,6 @@ Viewer2DExportResult ExportViewer2DToPdf(
 Viewer2DExportResult ExportLayoutToPdf(
     const std::vector<LayoutViewExportData> &views,
     const std::vector<LayoutLegendExportData> &legends,
+    const std::vector<LayoutEventTableExportData> &tables,
     const Viewer2DPrintOptions &options,
     const std::filesystem::path &outputPath);


### PR DESCRIPTION
### Motivation
- Provide a reusable event information table element for layout-mode so users can place an editable event metadata block on layouts. 
- Integrate the new element with existing layout editing workflow so it supports selection, move/resize, z-order and persistence like other layout elements. 
- Include the event table in layout PDF export so printed layouts can contain the same metadata visible on-screen. 

### Description
- Added a new `LayoutEventTableDefinition` (fields, id, zIndex, frame) and storage in `layouts::LayoutDefinition` and `LayoutCollection` and added management functions `UpdateLayoutEventTable`, `RemoveLayoutEventTable`, `MoveLayoutEventTable` in `LayoutCollection` and `LayoutManager` and corresponding JSON (de)serialization in `LayoutManager.cpp` using keys `eventTables` and field names `venue`, `location`, `date`, `stage`, `version`, `design`, `mail`.
- Implemented editor UI and rendering: new dialog `gui/layouteventtabledialog.{h,cpp}` for editing fields, rendering and caching in `gui/layoutviewerpanel.*` (`EventTableCache`, drawing, texture rebuild, hit-testing, selection, move/resize, context menu entries, edit/delete handlers), and added image-building with emphasized first field and same base font sizing as legends (`BuildEventTableImage`, `HashEventTableFields`).
- Hooked insertion and toolbar integration: added Lucide `table` icon `resources/icons/outline/table.svg`, toolbar action `ID_View_Layout_EventTable` and `MainWindow::OnLayoutAddEventTable` to create default-positioned event tables (`BuildDefaultLayoutEventTableFrame`) while in layout mode.
- Export support: extended `viewer2d::LayoutEventTableExportData` and updated `viewer2d/viewer2dpdfexporter.{h,cpp}` and `MainWindow::OnPrintLayout` flow to include event tables in layout PDF export with proper layout placement and font styling.
- Updated various UI glue points and enums/IDs: `gui/layoutviewerpanel.h`, `gui/mainwindow.h/cpp` and layout manager headers to wire up events, menu IDs and persistence sync so event tables behave like existing legend/view elements.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696759fc81808324af586d61ac036fd7)