### PR TITLE
Ensure layout toolbar shows event table icon and enables overflow

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -626,6 +626,7 @@ void MainWindow::CreateToolBars() {
                                    wxDefaultSize,
                                    wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_HORIZONTAL);
   layoutToolBar->SetToolBitmapSize(wxSize(16, 16));
+  layoutToolBar->SetOverflowVisible(true);
   layoutToolBar->AddTool(ID_View_Layout_2DView, "Añadir vista 2D",
                          loadToolbarIcon("panel-top-bottom-dashed",
                                          wxART_MISSING_IMAGE),
@@ -635,7 +636,7 @@ void MainWindow::CreateToolBars() {
                                          wxART_MISSING_IMAGE),
                          "Add fixture legend to layout");
   layoutToolBar->AddTool(ID_View_Layout_EventTable, "Añadir tabla de evento",
-                         loadToolbarIcon("table", wxART_MISSING_IMAGE),
+                         loadToolbarIcon("table", wxART_LIST_VIEW),
                          "Add event table to layout");
   layoutToolBar->Realize();
   auiManager->AddPane(


### PR DESCRIPTION
### Motivation
- Make the layout toolbar reliably expose the "Add event table" tool and provide a usable fallback icon when the SVG isn't available so users can trigger event-table creation in Layout Mode.

### Description
- Enabled overflow handling on the layout toolbar by calling `SetOverflowVisible(true)` and changed the fallback bitmap for the event table tool in `gui/mainwindow.cpp` to use `wxART_LIST_VIEW` when `table.svg` cannot be loaded.

### Testing
- No automated tests were executed for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69675f7e76d48324b2cc73cad9c299ae)