### PR TITLE
Fijar ancho del toolbar de Layout y eliminar desbordamiento

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -626,7 +626,7 @@ void MainWindow::CreateToolBars() {
                                    wxDefaultSize,
                                    wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_HORIZONTAL);
   layoutToolBar->SetToolBitmapSize(wxSize(16, 16));
-  layoutToolBar->SetOverflowVisible(true);
+  layoutToolBar->SetOverflowVisible(false);
   layoutToolBar->AddTool(ID_View_Layout_2DView, "Añadir vista 2D",
                          loadToolbarIcon("panel-top-bottom-dashed",
                                          wxART_MISSING_IMAGE),
@@ -639,6 +639,9 @@ void MainWindow::CreateToolBars() {
                          loadToolbarIcon("table", wxART_LIST_VIEW),
                          "Add event table to layout");
   layoutToolBar->Realize();
+  const wxSize layoutToolbarSize = layoutToolBar->GetBestSize();
+  layoutToolBar->SetMinSize(layoutToolbarSize);
+  layoutToolBar->SetMaxSize(layoutToolbarSize);
   auiManager->AddPane(
       layoutToolBar, wxAuiPaneInfo()
                          .Name("LayoutToolbar")


### PR DESCRIPTION
### Motivation
- Evitar que el toolbar "Layout" muestre un menú de desbordamiento y que cambie de tamaño, haciendo que su anchura refleje exactamente los iconos disponibles.

### Description
- Se desactiva el overflow con `layoutToolBar->SetOverflowVisible(false);` y se fija la anchura al tamaño óptimo obtenido por `GetBestSize()` aplicando `SetMinSize()` y `SetMaxSize()` en `gui/mainwindow.cpp`.

### Testing
- No se ejecutaron pruebas automatizadas sobre el cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696760fdd9bc8324b0dbefd911897c24)