### PR TITLE
Adjust layout views toolbar width to fit all icons

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -611,6 +611,9 @@ void MainWindow::CreateToolBars() {
                                               wxART_MISSING_IMAGE),
                               "Switch to Layout Mode View");
   layoutViewsToolBar->Realize();
+  const wxSize layoutViewsToolbarSize = layoutViewsToolBar->GetBestSize();
+  layoutViewsToolBar->SetMinSize(layoutViewsToolbarSize);
+  layoutViewsToolBar->SetMaxSize(layoutViewsToolbarSize);
   auiManager->AddPane(
       layoutViewsToolBar, wxAuiPaneInfo()
                               .Name("LayoutViewsToolbar")


### PR DESCRIPTION
### Motivation
- The Layout Views toolbar was too narrow in Layout Mode and only showed two of three icons instead of adapting to its contents. 
- The toolbar should size itself to the number of tools so all layout view icons remain visible.

### Description
- After calling `Realize()` on `layoutViewsToolBar`, obtain its best size via `GetBestSize()` and apply it. 
- Set both `SetMinSize()` and `SetMaxSize()` on `layoutViewsToolBar` to the computed best size to prevent clipping. 
- Changes are localized to `gui/mainwindow.cpp` around the toolbar creation for `LayoutViewsToolbar`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967628fd88083249e9a9f37bb7d8762)