### PR TITLE
Fix toolbar pane sizing to show all icons

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -613,7 +613,6 @@ void MainWindow::CreateToolBars() {
   layoutViewsToolBar->Realize();
   const wxSize layoutViewsToolbarSize = layoutViewsToolBar->GetBestSize();
   layoutViewsToolBar->SetMinSize(layoutViewsToolbarSize);
-  layoutViewsToolBar->SetMaxSize(layoutViewsToolbarSize);
   auiManager->AddPane(
       layoutViewsToolBar, wxAuiPaneInfo()
                               .Name("LayoutViewsToolbar")
@@ -622,6 +621,8 @@ void MainWindow::CreateToolBars() {
                               .Top()
                               .LeftDockable(false)
                               .RightDockable(false)
+                              .BestSize(layoutViewsToolbarSize)
+                              .MinSize(layoutViewsToolbarSize)
                               .Row(0)
                               .Position(1));
 
@@ -644,7 +645,6 @@ void MainWindow::CreateToolBars() {
   layoutToolBar->Realize();
   const wxSize layoutToolbarSize = layoutToolBar->GetBestSize();
   layoutToolBar->SetMinSize(layoutToolbarSize);
-  layoutToolBar->SetMaxSize(layoutToolbarSize);
   auiManager->AddPane(
       layoutToolBar, wxAuiPaneInfo()
                          .Name("LayoutToolbar")
@@ -653,6 +653,8 @@ void MainWindow::CreateToolBars() {
                          .Top()
                          .LeftDockable(false)
                          .RightDockable(false)
+                         .BestSize(layoutToolbarSize)
+                         .MinSize(layoutToolbarSize)
                          .Row(1)
                          .Position(0));
 }


### PR DESCRIPTION
### Motivation
- Toolbars created with `GetBestSize()` were being constrained in a way that caused some toolbar icons to be clipped and hidden instead of displayed, so the pane layout needs to receive the correct sizing hints to ensure all icons are visible.

### Description
- Stop calling `SetMaxSize()` on the toolbar controls in `gui/mainwindow.cpp` so the toolbar widgets are not artificially constrained.
- Apply the realized best size to the pane instead by adding `.BestSize(layout...ToolbarSize)` and `.MinSize(layout...ToolbarSize)` to the corresponding `wxAuiPaneInfo()` for both `LayoutViewsToolbar` and `LayoutToolbar` in `CreateToolBars()`.
- Keep the toolbar `SetMinSize()` calls so the toolbars still advertise their minimum required size after `Realize()`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69676394e9f483248ff2f9661d937d63)