### PR TITLE
Enable editing of event tables via double-click in layout viewer

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1095,12 +1095,19 @@ void LayoutViewerPanel::OnLeftUp(wxMouseEvent &) {
 void LayoutViewerPanel::OnLeftDClick(wxMouseEvent &event) {
   const wxPoint pos = event.GetPosition();
   SelectElementAtPosition(pos);
-  const layouts::Layout2DViewDefinition *view = GetEditableView();
+  layouts::Layout2DViewFrame selectedFrame;
   wxRect frameRect;
-  if (view && GetFrameRect(view->frame, frameRect) && frameRect.Contains(pos) &&
-      selectedElementType == SelectedElementType::View2D) {
-    EmitEditViewRequest();
-    return;
+  if (GetSelectedFrame(selectedFrame) &&
+      GetFrameRect(selectedFrame, frameRect) && frameRect.Contains(pos)) {
+    if (selectedElementType == SelectedElementType::View2D) {
+      EmitEditViewRequest();
+      return;
+    }
+    if (selectedElementType == SelectedElementType::EventTable) {
+      wxCommandEvent editEvent;
+      OnEditEventTable(editEvent);
+      return;
+    }
   }
   event.Skip();
 }


### PR DESCRIPTION
### Motivation
- Double-clicking a layout element currently only opened the 2D view editor, and the change makes double-clicking an Event Table behave like selecting "Edit Event Table" to improve UX.

### Description
- In `gui/layoutviewerpanel.cpp` updated `OnLeftDClick` to use `GetSelectedFrame`/`GetFrameRect` and call `EmitEditViewRequest()` for `View2D` or invoke `OnEditEventTable()` for `EventTable` when the double-click occurs inside the element frame.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967657bd5488324bd50232ed64c94ce)