### PR TITLE
Use exact front-view symbols for legends and reduce symbol pair gap

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -99,6 +99,20 @@ const SymbolDefinition *FindSymbolDefinitionPreferred(
   return FindSymbolDefinition(symbols, modelKey);
 }
 
+const SymbolDefinition *FindSymbolDefinitionExact(
+    const SymbolDefinitionSnapshot *symbols, const std::string &modelKey,
+    SymbolViewKind view) {
+  if (!symbols || modelKey.empty())
+    return nullptr;
+  for (const auto &entry : *symbols) {
+    if (entry.second.key.modelKey == modelKey &&
+        entry.second.key.viewKind == view) {
+      return &entry.second;
+    }
+  }
+  return nullptr;
+}
+
 struct LegendRenderState {
   CanvasTransform current{};
   std::vector<CanvasTransform> stack;
@@ -2477,7 +2491,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   const int paddingBottom = 2;
   const int columnGap = 8;
   const int symbolColumnGap = 2;
-  const int symbolPairGap = 2;
+  const int symbolPairGap = 0;
   constexpr double kLegendLineSpacingScale = 0.8;
   constexpr double kLegendSymbolColumnScale = 0.8;
   const int totalRows = static_cast<int>(items.size()) + 1;
@@ -2558,7 +2572,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
         continue;
       const SymbolDefinition *topSymbol = FindSymbolDefinitionPreferred(
           symbols, item.symbolKey, SymbolViewKind::Top);
-      const SymbolDefinition *frontSymbol = FindSymbolDefinitionPreferred(
+      const SymbolDefinition *frontSymbol = FindSymbolDefinitionExact(
           symbols, item.symbolKey, SymbolViewKind::Front);
       double topDrawW = symbolDrawWidth(topSymbol);
       double frontDrawW = symbolDrawWidth(frontSymbol);
@@ -2644,7 +2658,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
     if (symbols && !item.symbolKey.empty()) {
       const SymbolDefinition *topSymbol = FindSymbolDefinitionPreferred(
           symbols, item.symbolKey, SymbolViewKind::Top);
-      const SymbolDefinition *frontSymbol = FindSymbolDefinitionPreferred(
+      const SymbolDefinition *frontSymbol = FindSymbolDefinitionExact(
           symbols, item.symbolKey, SymbolViewKind::Front);
       auto drawSymbol = [&](const SymbolDefinition *symbol, double drawLeft,
                             double drawTop) {

--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -905,6 +905,20 @@ const SymbolDefinition *FindSymbolDefinitionPreferred(
   return FindSymbolDefinition(symbols, modelKey);
 }
 
+const SymbolDefinition *FindSymbolDefinitionExact(
+    const SymbolDefinitionSnapshot *symbols, const std::string &modelKey,
+    SymbolViewKind view) {
+  if (!symbols || modelKey.empty())
+    return nullptr;
+  for (const auto &entry : *symbols) {
+    if (entry.second.key.modelKey == modelKey &&
+        entry.second.key.viewKind == view) {
+      return &entry.second;
+    }
+  }
+  return nullptr;
+}
+
 SymbolBounds ComputeSymbolBounds(const std::vector<CanvasCommand> &commands) {
   SymbolBounds bounds{};
   bool hasPoint = false;
@@ -1782,7 +1796,7 @@ Viewer2DExportResult ExportLayoutToPdf(
         continue;
       const SymbolDefinition *topSymbol = FindSymbolDefinitionPreferred(
           legendSymbols, item.symbolKey, SymbolViewKind::Top);
-      const SymbolDefinition *frontSymbol = FindSymbolDefinitionPreferred(
+      const SymbolDefinition *frontSymbol = FindSymbolDefinitionExact(
           legendSymbols, item.symbolKey, SymbolViewKind::Front);
       addLegendSymbol(topSymbol);
       addLegendSymbol(frontSymbol);
@@ -2098,7 +2112,7 @@ Viewer2DExportResult ExportLayoutToPdf(
     const double paddingBottom = 2.0;
     const double columnGap = 8.0;
     const double symbolColumnGap = 2.0;
-    const double symbolPairGap = 2.0;
+    const double symbolPairGap = 0.0;
     constexpr double kLegendLineSpacingScale = 0.8;
     constexpr double kLegendSymbolColumnScale = 0.8;
     const double separatorGap = 2.0;
@@ -2168,7 +2182,7 @@ Viewer2DExportResult ExportLayoutToPdf(
                                 : symbolSnapshot.get();
       const SymbolDefinition *topSymbol = FindSymbolDefinitionPreferred(
           legendSymbols, item.symbolKey, SymbolViewKind::Top);
-      const SymbolDefinition *frontSymbol = FindSymbolDefinitionPreferred(
+      const SymbolDefinition *frontSymbol = FindSymbolDefinitionExact(
           legendSymbols, item.symbolKey, SymbolViewKind::Front);
       double topDrawW = symbolDrawWidth(topSymbol);
       double frontDrawW = symbolDrawWidth(frontSymbol);
@@ -2242,7 +2256,7 @@ Viewer2DExportResult ExportLayoutToPdf(
                                   : symbolSnapshot.get();
         const SymbolDefinition *topSymbol = FindSymbolDefinitionPreferred(
             legendSymbols, item.symbolKey, SymbolViewKind::Top);
-        const SymbolDefinition *frontSymbol = FindSymbolDefinitionPreferred(
+        const SymbolDefinition *frontSymbol = FindSymbolDefinitionExact(
             legendSymbols, item.symbolKey, SymbolViewKind::Front);
         const double topDrawW = symbolDrawWidth(topSymbol);
         const double frontDrawW = symbolDrawWidth(frontSymbol);


### PR DESCRIPTION
### Motivation

- Legend entries were rendering both symbols from the same preferred view (often duplicating the top view) and had an unnecessarily large gap between paired symbols.  
- The intent is to show the top and front views distinctly in the legend and place the two symbols almost adjacent.

### Description

- Added a helper `FindSymbolDefinitionExact` to both `gui/layoutviewerpanel.cpp` and `viewer2d/viewer2dpdfexporter.cpp` to fetch symbols for a specific view without falling back to other views.  
- Replaced front-view lookups to use `FindSymbolDefinitionExact(..., SymbolViewKind::Front)` so the front symbol is not substituted by the top view.  
- Reduced the pairing gap by setting `symbolPairGap` to `0` in `gui/layoutviewerpanel.cpp` and `symbolPairGap` to `0.0` in `viewer2d/viewer2dpdfexporter.cpp` so paired legend symbols are drawn closely together.  
- Changes apply both to on-screen legend rendering and PDF export so visuals are consistent across UI and exports.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69676fd0e0c48324a38a2b50c4c3c208)