### PR TITLE
Widen legend symbol column to fit top/front symbol pairs

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -2493,7 +2493,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   const int symbolColumnGap = 2;
   const int symbolPairGap = 0;
   constexpr double kLegendLineSpacingScale = 0.8;
-  constexpr double kLegendSymbolColumnScale = 0.8;
+  constexpr double kLegendSymbolColumnScale = 1.0;
   const int totalRows = static_cast<int>(items.size()) + 1;
   const int baseHeight = logicalSize.GetHeight() > 0 ? logicalSize.GetHeight()
                                                      : size.GetHeight();

--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -2114,7 +2114,7 @@ Viewer2DExportResult ExportLayoutToPdf(
     const double symbolColumnGap = 2.0;
     const double symbolPairGap = 0.0;
     constexpr double kLegendLineSpacingScale = 0.8;
-    constexpr double kLegendSymbolColumnScale = 0.8;
+    constexpr double kLegendSymbolColumnScale = 1.0;
     const double separatorGap = 2.0;
     const size_t totalRows = legend.items.size() + 1;
     const double availableHeight =


### PR DESCRIPTION
### Motivation
- Legend entries that include both top and front symbols could not fit side-by-side because the symbol column width was too small, causing the front symbol to be hidden or overlap the text.
- The intent is to make on-screen legend rendering and exported PDF legends consistent by giving the symbol column enough space for paired symbols.

### Description
- Changed `kLegendSymbolColumnScale` from `0.8` to `1.0` in `gui/layoutviewerpanel.cpp` to widen the on-screen legend symbol column.
- Applied the same change to `kLegendSymbolColumnScale` in `viewer2d/viewer2dpdfexporter.cpp` so PDF export uses the same wider symbol column.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696774ea5c148324ae40bf66b69ec044)