### PR TITLE
Reduce legend symbol size to narrow legend column

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -530,7 +530,7 @@ constexpr int kHandleHoverPadPx = 6;
 constexpr int kMinFrameSize = 24;
 constexpr double kLegendContentScale = 0.7;
 constexpr int kLegendSymbolSizePx =
-    static_cast<int>(106 * kLegendContentScale);
+    static_cast<int>(64 * kLegendContentScale);
 constexpr double kLegendFontScale =
     (2.0 / 3.0) * kLegendContentScale;
 constexpr int kEditMenuId = wxID_HIGHEST + 490;

--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -45,7 +45,7 @@
 namespace {
 constexpr double kLegendContentScale = 0.7;
 constexpr double kLegendSymbolSize =
-    160.0 * 2.0 / 3.0 * kLegendContentScale;
+    96.0 * 2.0 / 3.0 * kLegendContentScale;
 constexpr double kLegendFontScale =
     (2.0 / 3.0) * kLegendContentScale;
 constexpr std::array<const char *, 7> kEventTableLabels = {


### PR DESCRIPTION
### Motivation
- Narrow the legend symbol column and make top/front symbol pair appear closer together in layout legends by reducing the base symbol size and keep PDF exports visually consistent with the on-screen view.

### Description
- Decreased the on-screen legend base symbol size by changing `kLegendSymbolSizePx` in `gui/layoutviewerpanel.cpp` and updated the PDF exporter `kLegendSymbolSize` in `viewer2d/viewer2dpdfexporter.cpp` to match the new sizing.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967795457748324a91e91a9edcb974e)