### PR TITLE
Reduce legend symbol pair spacing

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -2518,7 +2518,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   const int paddingBottom = 2;
   const int columnGap = 8;
   const int symbolColumnGap = 2;
-  const int symbolPairGap = 2;
+  const int symbolPairGap = 0;
   constexpr double kLegendLineSpacingScale = 0.8;
   constexpr double kLegendSymbolColumnScale = 1.0;
   const int totalRows = static_cast<int>(items.size()) + 1;

--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -2112,7 +2112,7 @@ Viewer2DExportResult ExportLayoutToPdf(
     const double paddingBottom = 2.0;
     const double columnGap = 8.0;
     const double symbolColumnGap = 2.0;
-    const double symbolPairGap = 2.0;
+    const double symbolPairGap = 0.0;
     constexpr double kLegendLineSpacingScale = 0.8;
     constexpr double kLegendSymbolColumnScale = 1.0;
     const double separatorGap = 2.0;


### PR DESCRIPTION
### Motivation
- Reduce the horizontal gap between paired symbols in legend rows so the two symbols on the same line sit almost adjacent while keeping row heights unchanged.

### Description
- Set `symbolPairGap = 0` in `gui/layoutviewerpanel.cpp` and `viewer2d/viewer2dpdfexporter.cpp` to tighten the spacing between paired legend symbols.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696782d159488324b525cce2f1f0adcb)