### PR TITLE
Reduce legend symbol pair spacing

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -2518,7 +2518,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   const int paddingBottom = 2;
   const int columnGap = 8;
   const int symbolColumnGap = 2;
-  const int symbolPairGap = 0;
+  const int symbolPairGap = -2;
   constexpr double kLegendLineSpacingScale = 0.8;
   constexpr double kLegendSymbolColumnScale = 1.0;
   const int totalRows = static_cast<int>(items.size()) + 1;
@@ -2580,7 +2580,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
       kLegendSymbolSizePx * renderZoom * fontScale));
   const int symbolSize = std::max(4, desiredSymbolSize);
   const int symbolPairGapPx =
-      std::max(0, static_cast<int>(std::lround(symbolPairGap * renderZoom)));
+      static_cast<int>(std::lround(symbolPairGap * renderZoom));
   auto symbolDrawWidth = [&](const SymbolDefinition *symbol) -> double {
     if (!symbol)
       return 0.0;

--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -2112,7 +2112,7 @@ Viewer2DExportResult ExportLayoutToPdf(
     const double paddingBottom = 2.0;
     const double columnGap = 8.0;
     const double symbolColumnGap = 2.0;
-    const double symbolPairGap = 0.0;
+    const double symbolPairGap = -2.0;
     constexpr double kLegendLineSpacingScale = 0.8;
     constexpr double kLegendSymbolColumnScale = 1.0;
     const double separatorGap = 2.0;
@@ -2152,7 +2152,7 @@ Viewer2DExportResult ExportLayoutToPdf(
     const double lineHeight = textHeightEstimate + separatorGap;
     const double symbolSize =
         std::max(4.0, kLegendSymbolSize * fontScale);
-    const double symbolPairGapSize = std::max(0.0, symbolPairGap);
+    const double symbolPairGapSize = symbolPairGap;
     auto symbolDrawWidth = [&](const SymbolDefinition *symbol) -> double {
       if (!symbol)
         return 0.0;


### PR DESCRIPTION
### Motivation
- Tighten the horizontal gap between the two symbols in each legend row so the pair appears closer while keeping symbol sizes and row heights unchanged.

### Description
- Set `symbolPairGap` to `-2` in `gui/layoutviewerpanel.cpp` and `viewer2d/viewer2dpdfexporter.cpp` and removed the `std::max(..., 0)` clamps so the computed `symbolPairGapPx`/`symbolPairGapSize` allow a small negative offset when rounding to pixels.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69678568c3848324860ec4c2812afb1b)