### PR TITLE
Reduce legend symbol pair spacing

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -2518,9 +2518,9 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   const int paddingBottom = 2;
   const int columnGap = 8;
   const int symbolColumnGap = 2;
-  const int symbolPairGap = -2;
   constexpr double kLegendLineSpacingScale = 0.8;
   constexpr double kLegendSymbolColumnScale = 1.0;
+  constexpr double kLegendSymbolPairOverlapScale = 0.35;
   const int totalRows = static_cast<int>(items.size()) + 1;
   const int baseHeight = logicalSize.GetHeight() > 0 ? logicalSize.GetHeight()
                                                      : size.GetHeight();
@@ -2579,8 +2579,9 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   const int desiredSymbolSize = static_cast<int>(std::lround(
       kLegendSymbolSizePx * renderZoom * fontScale));
   const int symbolSize = std::max(4, desiredSymbolSize);
-  const int symbolPairGapPx =
-      static_cast<int>(std::lround(symbolPairGap * renderZoom));
+  const double symbolPairGapPx =
+      -std::max(1.0, static_cast<double>(symbolSize) *
+                         kLegendSymbolPairOverlapScale);
   auto symbolDrawWidth = [&](const SymbolDefinition *symbol) -> double {
     if (!symbol)
       return 0.0;

--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -2112,9 +2112,9 @@ Viewer2DExportResult ExportLayoutToPdf(
     const double paddingBottom = 2.0;
     const double columnGap = 8.0;
     const double symbolColumnGap = 2.0;
-    const double symbolPairGap = -2.0;
     constexpr double kLegendLineSpacingScale = 0.8;
     constexpr double kLegendSymbolColumnScale = 1.0;
+    constexpr double kLegendSymbolPairOverlapScale = 0.35;
     const double separatorGap = 2.0;
     const size_t totalRows = legend.items.size() + 1;
     const double availableHeight =
@@ -2152,7 +2152,8 @@ Viewer2DExportResult ExportLayoutToPdf(
     const double lineHeight = textHeightEstimate + separatorGap;
     const double symbolSize =
         std::max(4.0, kLegendSymbolSize * fontScale);
-    const double symbolPairGapSize = symbolPairGap;
+    const double symbolPairGapSize =
+        -std::max(1.0, symbolSize * kLegendSymbolPairOverlapScale);
     auto symbolDrawWidth = [&](const SymbolDefinition *symbol) -> double {
       if (!symbol)
         return 0.0;


### PR DESCRIPTION
### Motivation
- The legend pair gap was fixed (`symbolPairGap = -2`) and did not respond to `renderZoom` or symbol size, so pairs could not be tightened without changing symbol size or row height.
- The goal is to minimize horizontal spacing between the two symbols on a legend row while preserving row height and symbol size and to keep UI and PDF output consistent.

### Description
- Replace the fixed `symbolPairGap` with a scale-based overlap factor `kLegendSymbolPairOverlapScale` in `gui/layoutviewerpanel.cpp` and `viewer2d/viewer2dpdfexporter.cpp`.
- Compute the pair gap as a negative overlap based on symbol size using `-std::max(1.0, symbolSize * kLegendSymbolPairOverlapScale)` for the UI and PDF paths so gap shrinks proportionally to the rendered symbol size.
- Change the pair-gap storage to floating point (`double`) to support fractional overlap and remove the previous `-2` magic constant while leaving row heights and symbol sizes unchanged.
- Keep all other legend layout and rendering logic intact and ensure the same spacing policy is used for on-screen rendering and PDF export.

### Testing
- No automated tests were run for this change.
- The change was compiled and committed locally (no test suite executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696786bd9054832491b80821c5552e26)