### PR TITLE
Tighten legend symbol spacing

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -2520,7 +2520,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   const int symbolColumnGap = 2;
   constexpr double kLegendLineSpacingScale = 0.8;
   constexpr double kLegendSymbolColumnScale = 1.0;
-  constexpr double kLegendSymbolPairOverlapScale = 0.35;
+  constexpr double kLegendSymbolPairOverlapScale = 0.75;
   const int totalRows = static_cast<int>(items.size()) + 1;
   const int baseHeight = logicalSize.GetHeight() > 0 ? logicalSize.GetHeight()
                                                      : size.GetHeight();

--- a/viewer2d/viewer2dpdfexporter.cpp
+++ b/viewer2d/viewer2dpdfexporter.cpp
@@ -2114,7 +2114,7 @@ Viewer2DExportResult ExportLayoutToPdf(
     const double symbolColumnGap = 2.0;
     constexpr double kLegendLineSpacingScale = 0.8;
     constexpr double kLegendSymbolColumnScale = 1.0;
-    constexpr double kLegendSymbolPairOverlapScale = 0.35;
+    constexpr double kLegendSymbolPairOverlapScale = 0.75;
     const double separatorGap = 2.0;
     const size_t totalRows = legend.items.size() + 1;
     const double availableHeight =


### PR DESCRIPTION
### Motivation
- Reduce the horizontal gap between the two symbols shown on each legend row so the pair appears much closer while keeping row height and symbol sizes unchanged.

### Description
- Increase the pair overlap factor by changing `kLegendSymbolPairOverlapScale` from `0.35` to `0.75` in `gui/layoutviewerpanel.cpp` to tighten symbol spacing in the on-screen legend.
- Apply the same constant update in `viewer2d/viewer2dpdfexporter.cpp` so exported PDF legends use the same tighter spacing.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69678821c5088324b9f1f0a5423288e6)