### PR TITLE
Remove extra top gap in layout legend rendering

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -2572,14 +2572,10 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   const int lineHeight = textHeight + separatorGapPx;
 
   const double rowHeight = totalRows > 0 ? availableHeight / totalRows : 0.0;
-  const int availableHeightPx = std::max(
-      0, static_cast<int>(std::lround(availableHeight * renderZoom)));
   const int baseRowHeightPx =
       std::max(lineHeight,
                static_cast<int>(std::lround(rowHeight * renderZoom *
                                             kLegendLineSpacingScale)));
-  const int contentGapPx =
-      std::max(0, availableHeightPx - baseRowHeightPx * totalRows);
   const int desiredSymbolSize = static_cast<int>(std::lround(
       kLegendSymbolSizePx * renderZoom * fontScale));
   const int symbolSize = std::max(4, desiredSymbolSize);
@@ -2669,7 +2665,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
     return trimmed + ellipsis;
   };
 
-  int y = paddingTopPx + contentGapPx;
+  int y = paddingTopPx;
   const int textOffset =
       std::max(0, (rowHeightPx - textHeight) / 2);
   dc.SetFont(headerFont);


### PR DESCRIPTION
### Motivation
- The legend header rendered with an unnecessary blank gap at the top of the legend frame, visually adding an empty line above the header without changing inter-line spacing.
- The goal is to remove that unused vertical offset so the header aligns with the configured top padding while keeping line spacing intact.

### Description
- In `BuildLegendImage` (`gui/layoutviewerpanel.cpp`) removed the unused `availableHeightPx` / `contentGapPx` calculation and the extra offset when computing the initial row `y` position. 
- The initial header `y` now starts at `paddingTopPx` instead of `paddingTopPx + contentGapPx`, preserving `baseRowHeightPx` and other layout math.
- Only `gui/layoutviewerpanel.cpp` was modified to eliminate the extra top gap while leaving row sizing and spacing logic unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696791b8dba48324873a6ff39c2817a2)