### PR TITLE
Strip .gdtf extension from fixture type names

### DIFF
--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -281,7 +281,7 @@ void FixtureTablePanel::ReloadData() {
     wxString gdtf = wxFileName(gdtfFull).GetFullName();
     wxString type = wxString::FromUTF8(fixture->typeName);
     if (type.empty())
-      type = gdtf;
+      type = wxFileName(gdtfFull).GetName();
     wxString mode = wxString::FromUTF8(fixture->gdtfMode);
 
     int chCount = GetGdtfModeChannelCount(std::string(gdtfFull.ToUTF8()),
@@ -389,7 +389,7 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
       GetGdtfProperties(pathUtf8, w, p);
       wxString typeName = wxString::FromUTF8(GetGdtfFixtureName(pathUtf8));
       if (typeName.empty())
-        typeName = fdlg.GetFilename();
+        typeName = wxFileName(path).GetName();
       wxString fileName = fdlg.GetFilename();
 
       std::vector<std::string> prevTypes;


### PR DESCRIPTION
### Motivation
- When a GDTF file is selected for a fixture the derived fixture `type` should not include the `.gdtf` extension so types are cleaner and consistent.

### Description
- Use `wxFileName(...).GetName()` instead of the full filename when deriving default fixture `typeName` in `gui/fixturetablepanel.cpp` for both reload display and when selecting a GDTF via the context menu.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69679321208483248339b5a8d1386494)