### PR TITLE
Bold patch values in 2D fixture labels

### DIFF
--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -251,6 +251,7 @@ private:
   NVGcontext *m_vg = nullptr;
   // Font handle for label rendering
   int m_font = -1;
+  int m_fontBold = -1;
 
   // Optional capture target used by the 2D viewer to record drawing commands
   // without altering the OpenGL on-screen output. When null, no recording


### PR DESCRIPTION
### Motivation
- Hacer que el valor de patch (línea DMX) en las etiquetas de fixtures 2D aparezca en negrita tanto en el visor on‑screen como en las capturas usadas por layouts/PDFs para mejorar la legibilidad.

### Description
- Añadido un manejador de fuente bold `m_fontBold` y carga de rutas de fuentes bold en `viewer3d/viewer3dcontroller.cpp` y declarado en `viewer3d/viewer3dcontroller.h`.
- Extendida la representación de línea de etiqueta con `font` y `fontFamily` y se selecciona `m_fontBold` para la línea de dirección DMX mientras el resto de líneas usan la fuente regular.
- Al capturar etiquetas para exportación se rellena `CanvasTextStyle.fontFamily` con `"sans"` o `"sans-bold"` por línea para que el exportador PDF (`viewer2d/viewer2dpdfexporter.cpp`) pueda resolver la variante bold automáticamente.

### Testing
- No se ejecutaron pruebas automatizadas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69679c64837483248e72b739d27e0c00)