### PR TITLE
Persist 2D viewport view state for printing

### DIFF
--- a/gui/layout2dviewdialog.cpp
+++ b/gui/layout2dviewdialog.cpp
@@ -18,7 +18,7 @@ Layout2DViewDialog::Layout2DViewDialog(wxWindow *parent)
   auto *mainSizer = new wxBoxSizer(wxVERTICAL);
   auto *contentSizer = new wxBoxSizer(wxHORIZONTAL);
 
-  viewerPanel = new Viewer2DPanel(this);
+  viewerPanel = new Viewer2DPanel(this, false, false);
   renderPanel = new Viewer2DRenderPanel(this);
   layerPanel = new LayerPanel(this, false);
 

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1699,6 +1699,8 @@ void MainWindow::OnPrintViewer2D(wxCommandEvent &WXUNUSED(event)) {
   if (captureSize.GetWidth() <= 0 || captureSize.GetHeight() <= 0) {
     captureSize = wxSize(1600, 900);
   }
+  if (viewport2DPanel)
+    viewport2DPanel->SaveViewToConfig();
   offscreenRenderer->SetViewportSize(captureSize);
   offscreenRenderer->PrepareForCapture();
 

--- a/viewer2d/viewer2doffscreenrenderer.cpp
+++ b/viewer2d/viewer2doffscreenrenderer.cpp
@@ -26,7 +26,7 @@ Viewer2DOffscreenRenderer::Viewer2DOffscreenRenderer(wxWindow *parent) {
   host_ = new wxPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(1, 1));
   host_->Hide();
 
-  panel_ = new Viewer2DPanel(host_, true);
+  panel_ = new Viewer2DPanel(host_, true, false);
   panel_->SetSize(wxSize(kDefaultViewportWidth, kDefaultViewportHeight));
   panel_->SetClientSize(wxSize(kDefaultViewportWidth, kDefaultViewportHeight));
   panel_->LoadViewFromConfig();

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -166,11 +166,12 @@ wxBEGIN_EVENT_TABLE(Viewer2DPanel, wxGLCanvas) EVT_PAINT(Viewer2DPanel::OnPaint)
                         EVT_MOUSE_CAPTURE_LOST(Viewer2DPanel::OnCaptureLost)
                             EVT_SIZE(Viewer2DPanel::OnResize) wxEND_EVENT_TABLE()
 
-                            Viewer2DPanel::Viewer2DPanel(wxWindow *parent,
-                                                         bool allowOffscreenRender)
+Viewer2DPanel::Viewer2DPanel(wxWindow *parent, bool allowOffscreenRender,
+                             bool persistViewState)
     : wxGLCanvas(parent, wxID_ANY, nullptr, wxDefaultPosition, wxDefaultSize,
                  wxFULL_REPAINT_ON_RESIZE),
-      m_allowOffscreenRender(allowOffscreenRender) {
+      m_allowOffscreenRender(allowOffscreenRender),
+      m_persistViewState(persistViewState) {
   SetBackgroundStyle(wxBG_STYLE_CUSTOM);
   m_glContext = new wxGLContext(this);
 }
@@ -600,6 +601,8 @@ void Viewer2DPanel::OnMouseMove(wxMouseEvent &event) {
     m_offsetX += dx / m_zoom;
     m_offsetY += dy / m_zoom;
     m_lastMousePos = pos;
+    if (m_persistViewState)
+      SaveViewToConfig();
     Refresh();
   }
 }
@@ -614,6 +617,8 @@ void Viewer2DPanel::OnMouseWheel(wxMouseEvent &event) {
   m_zoom *= factor;
   if (m_zoom < 0.1f)
     m_zoom = 0.1f;
+  if (m_persistViewState)
+    SaveViewToConfig();
   Refresh();
 }
 
@@ -658,6 +663,8 @@ void Viewer2DPanel::OnKeyDown(wxKeyEvent &event) {
 
   if (m_zoom < 0.1f)
     m_zoom = 0.1f;
+  if (m_persistViewState)
+    SaveViewToConfig();
   Refresh();
 }
 

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -47,7 +47,8 @@ struct Viewer2DViewState {
 
 class Viewer2DPanel : public wxGLCanvas {
 public:
-  explicit Viewer2DPanel(wxWindow *parent, bool allowOffscreenRender = false);
+  explicit Viewer2DPanel(wxWindow *parent, bool allowOffscreenRender = false,
+                         bool persistViewState = true);
   ~Viewer2DPanel();
 
   static Viewer2DPanel *Instance();
@@ -140,6 +141,7 @@ private:
   std::string m_lastFixtureDebugReport;
   bool m_forceOffscreenRender = false;
   bool m_allowOffscreenRender = false;
+  bool m_persistViewState = true;
 
   wxGLContext *m_glContext = nullptr;
   bool m_glInitialized = false;


### PR DESCRIPTION
### Motivation
- Ensure the 2D viewport pan/zoom/view used for on-screen inspection is preserved and used for PDF/print captures without letting layout editor or offscreen renderers overwrite the global saved view.

### Description
- Add a `persistViewState` flag to `Viewer2DPanel` (constructor and `m_persistViewState`) so panels can opt out of writing viewport state to config. 
- Persist view state during user interactions (`OnMouseMove`, `OnMouseWheel`, `OnKeyDown`) only when `m_persistViewState` is true by calling `SaveViewToConfig()`.
- Create layout editor `Viewer2DPanel` and offscreen renderer `Viewer2DPanel` instances with `persistViewState=false` to keep the editor/offscreen captures independent. 
- Force a `SaveViewToConfig()` on the visible `viewport2DPanel` before preparing the offscreen capture in `MainWindow::OnPrintViewer2D` so the printed/exported PDF matches the on-screen view.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967a4da907c8324a2764ac24125dba7)