### PR TITLE
LayoutViewer: reset view to fit on 'Z' key

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -595,6 +595,7 @@ wxBEGIN_EVENT_TABLE(LayoutViewerPanel, wxGLCanvas)
     EVT_MOUSEWHEEL(LayoutViewerPanel::OnMouseWheel)
     EVT_MOUSE_CAPTURE_LOST(LayoutViewerPanel::OnCaptureLost)
     EVT_RIGHT_UP(LayoutViewerPanel::OnRightUp)
+    EVT_KEY_DOWN(LayoutViewerPanel::OnKeyDown)
     EVT_MENU(kEditMenuId, LayoutViewerPanel::OnEditView)
     EVT_MENU(kDeleteMenuId, LayoutViewerPanel::OnDeleteView)
     EVT_MENU(kDeleteLegendMenuId, LayoutViewerPanel::OnDeleteLegend)
@@ -1126,6 +1127,7 @@ void LayoutViewerPanel::OnSize(wxSizeEvent &) {
 }
 
 void LayoutViewerPanel::OnLeftDown(wxMouseEvent &event) {
+  SetFocus();
   const wxPoint pos = event.GetPosition();
   SelectElementAtPosition(pos);
   layouts::Layout2DViewFrame selectedFrame;
@@ -1177,6 +1179,17 @@ void LayoutViewerPanel::OnLeftDClick(wxMouseEvent &event) {
       OnEditEventTable(editEvent);
       return;
     }
+  }
+  event.Skip();
+}
+
+void LayoutViewerPanel::OnKeyDown(wxKeyEvent &event) {
+  const int key = event.GetKeyCode();
+  if (key == 'Z' || key == 'z') {
+    ResetViewToFit();
+    RequestRenderRebuild();
+    Refresh();
+    return;
   }
   event.Skip();
 }

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -90,6 +90,7 @@ private:
   void OnMouseWheel(wxMouseEvent &event);
   void OnCaptureLost(wxMouseCaptureLostEvent &event);
   void OnRightUp(wxMouseEvent &event);
+  void OnKeyDown(wxKeyEvent &event);
   void OnEditView(wxCommandEvent &event);
   void OnDeleteView(wxCommandEvent &event);
   void OnDeleteLegend(wxCommandEvent &event);


### PR DESCRIPTION
### Motivation
- Enable a keyboard shortcut so that when the Layout Viewer is focused and the user presses `z` (or `Z`), the layout page is reset to fit the maximum available window area, matching existing behavior when editing a 2D view.
- Ensure the Layout Viewer reliably receives keyboard input by focusing the panel on mouse click.

### Description
- Added an `OnKeyDown` handler to `LayoutViewerPanel` that checks for `'z'`/`'Z'` and calls `ResetViewToFit()`, `RequestRenderRebuild()`, and `Refresh()` to reset and redraw the view.
- Registered the handler in the event table with `EVT_KEY_DOWN(LayoutViewerPanel::OnKeyDown)` and declared `OnKeyDown` in `gui/layoutviewerpanel.h`.
- Call `SetFocus()` in `LayoutViewerPanel::OnLeftDown` so the panel receives key events after clicking.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967ab102c308324823a0e486c6449d5)