### PR TITLE
Handle Delete key in Layout Viewer to remove selected element

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1185,6 +1185,17 @@ void LayoutViewerPanel::OnLeftDClick(wxMouseEvent &event) {
 
 void LayoutViewerPanel::OnKeyDown(wxKeyEvent &event) {
   const int key = event.GetKeyCode();
+  if (key == WXK_DELETE || key == WXK_NUMPAD_DELETE) {
+    wxCommandEvent deleteEvent;
+    if (selectedElementType == SelectedElementType::View2D) {
+      OnDeleteView(deleteEvent);
+    } else if (selectedElementType == SelectedElementType::Legend) {
+      OnDeleteLegend(deleteEvent);
+    } else if (selectedElementType == SelectedElementType::EventTable) {
+      OnDeleteEventTable(deleteEvent);
+    }
+    return;
+  }
   if (key == 'Z' || key == 'z') {
     ResetViewToFit();
     RequestRenderRebuild();


### PR DESCRIPTION
### Motivation
- Allow pressing Delete (or NumPad Delete) while focused on the Layout Viewer to remove the currently selected layout element (2D view, legend, or event table) without requiring the context menu.

### Description
- Add handling in `LayoutViewerPanel::OnKeyDown` to detect `WXK_DELETE` and `WXK_NUMPAD_DELETE` and invoke `OnDeleteView`, `OnDeleteLegend`, or `OnDeleteEventTable` depending on the current selection in `gui/layoutviewerpanel.cpp`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967acbf1be0832498c6a0e623174ecc)