### PR TITLE
Fix delete key handling in Layout Viewer

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -607,7 +607,8 @@ wxEND_EVENT_TABLE()
 
 LayoutViewerPanel::LayoutViewerPanel(wxWindow *parent)
     : wxGLCanvas(parent, wxID_ANY, nullptr, wxDefaultPosition,
-                 wxDefaultSize, wxFULL_REPAINT_ON_RESIZE) {
+                 wxDefaultSize,
+                 wxFULL_REPAINT_ON_RESIZE | wxWANTS_CHARS) {
   SetBackgroundStyle(wxBG_STYLE_CUSTOM);
   glContext_ = new wxGLContext(this);
   currentLayout.pageSetup.pageSize = print::PageSize::A4;
@@ -1298,6 +1299,7 @@ void LayoutViewerPanel::OnCaptureLost(wxMouseCaptureLostEvent &) {
 }
 
 void LayoutViewerPanel::OnRightUp(wxMouseEvent &event) {
+  SetFocus();
   const wxPoint pos = event.GetPosition();
   if (!SelectElementAtPosition(pos)) {
     event.Skip();


### PR DESCRIPTION
### Motivation
- Ensure pressing Delete removes the currently selected element in the Layout Viewer by making the viewer canvas accept key events and receive focus when a selection is made via right-click.

### Description
- Add `wxWANTS_CHARS` to the `LayoutViewerPanel` constructor and call `SetFocus()` in `OnRightUp` so the GL canvas receives keyboard events (enabling Delete handling) and is focused when the context menu is opened; change applied in `gui/layoutviewerpanel.cpp`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967b6c57344832494559f3d575afde2)