### PR TITLE
Add layout text tool and rich text editor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ elseif(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
 endif()
 
 # Find required packages
-find_package(wxWidgets REQUIRED COMPONENTS core base aui gl html)
+find_package(wxWidgets REQUIRED COMPONENTS core base aui gl html richtext)
 include(${wxWidgets_USE_FILE})
 find_package(tinyxml2 CONFIG REQUIRED)
 find_package(OpenGL REQUIRED)

--- a/core/layouts/LayoutCollection.h
+++ b/core/layouts/LayoutCollection.h
@@ -88,12 +88,21 @@ struct LayoutEventTableDefinition {
   std::array<std::string, 7> fields;
 };
 
+struct LayoutTextDefinition {
+  int id = 0;
+  int zIndex = 0;
+  Layout2DViewFrame frame;
+  std::string text;
+  std::string richText;
+};
+
 struct LayoutDefinition {
   std::string name;
   print::PageSetup pageSetup;
   std::vector<Layout2DViewDefinition> view2dViews;
   std::vector<LayoutLegendDefinition> legendViews;
   std::vector<LayoutEventTableDefinition> eventTables;
+  std::vector<LayoutTextDefinition> textViews;
 };
 
 class LayoutCollection {
@@ -121,6 +130,10 @@ public:
   bool RemoveLayoutEventTable(const std::string &name, int tableId);
   bool MoveLayoutEventTable(const std::string &name, int tableId,
                             bool toFront);
+  bool UpdateLayoutText(const std::string &name,
+                        const LayoutTextDefinition &text);
+  bool RemoveLayoutText(const std::string &name, int textId);
+  bool MoveLayoutText(const std::string &name, int textId, bool toFront);
 
   void ReplaceAll(std::vector<LayoutDefinition> layouts);
 

--- a/core/layouts/LayoutManager.h
+++ b/core/layouts/LayoutManager.h
@@ -46,6 +46,10 @@ public:
                               const LayoutEventTableDefinition &table);
   bool RemoveLayoutEventTable(const std::string &name, int tableId);
   bool MoveLayoutEventTable(const std::string &name, int tableId, bool toFront);
+  bool UpdateLayoutText(const std::string &name,
+                        const LayoutTextDefinition &text);
+  bool RemoveLayoutText(const std::string &name, int textId);
+  bool MoveLayoutText(const std::string &name, int textId, bool toFront);
 
   void LoadFromConfig(ConfigManager &cfg);
   void SaveToConfig(ConfigManager &cfg) const;

--- a/gui/layouttextdialog.cpp
+++ b/gui/layouttextdialog.cpp
@@ -1,0 +1,185 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "layouttextdialog.h"
+
+#include <algorithm>
+#include <filesystem>
+#include <functional>
+
+#include <wx/artprov.h>
+#include <wx/bmpbuttn.h>
+#include <wx/button.h>
+#include <wx/richtext/richtextctrl.h>
+#include <wx/sizer.h>
+#include <wx/spinctrl.h>
+#include <wx/sstream.h>
+
+#include "projectutils.h"
+
+namespace {
+constexpr int kToolbarIconSizePx = 16;
+constexpr int kDefaultFontSize = 12;
+constexpr int kMinFontSize = 6;
+constexpr int kMaxFontSize = 72;
+} // namespace
+
+LayoutTextDialog::LayoutTextDialog(wxWindow *parent,
+                                   const wxString &initialRichText,
+                                   const wxString &fallbackText)
+    : wxDialog(parent, wxID_ANY, "Edit Text", wxDefaultPosition,
+               wxSize(640, 420),
+               wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER) {
+  wxBoxSizer *mainSizer = new wxBoxSizer(wxVERTICAL);
+  wxBoxSizer *toolbarSizer = new wxBoxSizer(wxHORIZONTAL);
+
+  auto addToolButton = [&](const std::string &iconName,
+                           const wxString &tooltip,
+                           const std::function<void()> &handler) {
+    wxBitmapBundle bundle = LoadIcon(iconName);
+    wxBitmap bitmap = bundle.GetBitmap(wxSize(kToolbarIconSizePx,
+                                              kToolbarIconSizePx));
+    wxBitmapButton *button = new wxBitmapButton(
+        this, wxID_ANY, bitmap, wxDefaultPosition,
+        wxSize(kToolbarIconSizePx + 6, kToolbarIconSizePx + 6));
+    button->SetToolTip(tooltip);
+    button->Bind(wxEVT_BUTTON, [handler](wxCommandEvent &) { handler(); });
+    toolbarSizer->Add(button, 0, wxRIGHT, 4);
+  };
+
+  addToolButton("bold", "Bold", [this]() { ApplyBold(); });
+  addToolButton("italic", "Italic", [this]() { ApplyItalic(); });
+  addToolButton("a-arrow-down", "Decrease font size",
+                [this]() { AdjustFontSize(-1); });
+  addToolButton("a-arrow-up", "Increase font size",
+                [this]() { AdjustFontSize(1); });
+
+  fontSizeCtrl = new wxSpinCtrl(this, wxID_ANY, wxEmptyString,
+                                wxDefaultPosition, wxSize(64, -1),
+                                wxSP_ARROW_KEYS, kMinFontSize, kMaxFontSize,
+                                kDefaultFontSize);
+  fontSizeCtrl->Bind(wxEVT_SPINCTRL, [this](wxCommandEvent &) {
+    ApplyFontSize(fontSizeCtrl->GetValue());
+  });
+  fontSizeCtrl->Bind(wxEVT_TEXT, [this](wxCommandEvent &) {
+    ApplyFontSize(fontSizeCtrl->GetValue());
+  });
+  toolbarSizer->Add(fontSizeCtrl, 0, wxRIGHT, 8);
+
+  addToolButton("align-horizontal-justify-start", "Align start",
+                [this]() { ApplyAlignment(wxTEXT_ALIGNMENT_LEFT); });
+  addToolButton("align-horizontal-justify-center", "Align center",
+                [this]() { ApplyAlignment(wxTEXT_ALIGNMENT_CENTRE); });
+  addToolButton("align-horizontal-justify-end", "Align end",
+                [this]() { ApplyAlignment(wxTEXT_ALIGNMENT_RIGHT); });
+  addToolButton("align-horizontal-space-between", "Justify",
+                [this]() { ApplyAlignment(wxTEXT_ALIGNMENT_JUSTIFIED); });
+
+  mainSizer->Add(toolbarSizer, 0, wxEXPAND | wxALL, 8);
+
+  textCtrl = new wxRichTextCtrl(this, wxID_ANY, wxEmptyString,
+                                wxDefaultPosition, wxDefaultSize,
+                                wxTE_MULTILINE | wxTE_RICH2);
+  textCtrl->SetMinSize(wxSize(580, 280));
+  mainSizer->Add(textCtrl, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 8);
+
+  wxBoxSizer *buttonSizer = new wxBoxSizer(wxHORIZONTAL);
+  wxButton *okButton = new wxButton(this, wxID_OK, "Ok");
+  wxButton *cancelButton = new wxButton(this, wxID_CANCEL, "Cancel");
+  buttonSizer->AddStretchSpacer();
+  buttonSizer->Add(okButton, 0, wxRIGHT, 8);
+  buttonSizer->Add(cancelButton, 0);
+  mainSizer->Add(buttonSizer, 0, wxEXPAND | wxALL, 8);
+
+  SetSizer(mainSizer);
+  LoadInitialContent(initialRichText, fallbackText);
+  Layout();
+  Centre();
+}
+
+wxString LayoutTextDialog::GetRichText() const {
+  if (!textCtrl)
+    return wxEmptyString;
+  wxStringOutputStream output;
+  if (textCtrl->GetBuffer().SaveFile(output, wxRICHTEXT_TYPE_XML))
+    return output.GetString();
+  return textCtrl->GetValue();
+}
+
+wxString LayoutTextDialog::GetPlainText() const {
+  return textCtrl ? textCtrl->GetValue() : wxEmptyString;
+}
+
+wxBitmapBundle LayoutTextDialog::LoadIcon(const std::string &name) const {
+  auto svgPath = ProjectUtils::GetResourceRoot() / "icons" / "outline" /
+                 (name + ".svg");
+  if (std::filesystem::exists(svgPath)) {
+    wxBitmapBundle bundle =
+        wxBitmapBundle::FromSVGFile(svgPath.string(),
+                                    wxSize(kToolbarIconSizePx,
+                                           kToolbarIconSizePx));
+    if (bundle.IsOk())
+      return bundle;
+  }
+  return wxArtProvider::GetBitmapBundle(wxART_MISSING_IMAGE, wxART_TOOLBAR,
+                                        wxSize(kToolbarIconSizePx,
+                                               kToolbarIconSizePx));
+}
+
+void LayoutTextDialog::LoadInitialContent(const wxString &initialRichText,
+                                          const wxString &fallbackText) {
+  if (!textCtrl)
+    return;
+  if (!initialRichText.empty()) {
+    wxStringInputStream input(initialRichText);
+    if (textCtrl->GetBuffer().LoadFile(input, wxRICHTEXT_TYPE_XML)) {
+      return;
+    }
+  }
+  textCtrl->SetValue(fallbackText);
+}
+
+void LayoutTextDialog::ApplyBold() {
+  if (textCtrl)
+    textCtrl->ApplyBoldToSelection();
+}
+
+void LayoutTextDialog::ApplyItalic() {
+  if (textCtrl)
+    textCtrl->ApplyItalicToSelection();
+}
+
+void LayoutTextDialog::ApplyFontSize(int size) {
+  if (textCtrl)
+    textCtrl->ApplyFontSizeToSelection(size);
+}
+
+void LayoutTextDialog::AdjustFontSize(int delta) {
+  if (!fontSizeCtrl)
+    return;
+  int size = fontSizeCtrl->GetValue() + delta;
+  size = std::clamp(size, kMinFontSize, kMaxFontSize);
+  fontSizeCtrl->SetValue(size);
+  ApplyFontSize(size);
+}
+
+void LayoutTextDialog::ApplyAlignment(int alignment) {
+  if (!textCtrl)
+    return;
+  textCtrl->ApplyAlignmentToSelection(
+      static_cast<wxTextAttrAlignment>(alignment));
+}

--- a/gui/layouttextdialog.h
+++ b/gui/layouttextdialog.h
@@ -1,0 +1,46 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <wx/dialog.h>
+
+class wxBitmapBundle;
+class wxRichTextCtrl;
+class wxSpinCtrl;
+
+class LayoutTextDialog : public wxDialog {
+public:
+  LayoutTextDialog(wxWindow *parent, const wxString &initialRichText,
+                   const wxString &fallbackText);
+
+  wxString GetRichText() const;
+  wxString GetPlainText() const;
+
+private:
+  wxBitmapBundle LoadIcon(const std::string &name) const;
+  void LoadInitialContent(const wxString &initialRichText,
+                          const wxString &fallbackText);
+  void ApplyBold();
+  void ApplyItalic();
+  void ApplyFontSize(int size);
+  void AdjustFontSize(int delta);
+  void ApplyAlignment(int alignment);
+
+  wxRichTextCtrl *textCtrl = nullptr;
+  wxSpinCtrl *fontSizeCtrl = nullptr;
+};

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -81,6 +81,14 @@ private:
     size_t contentHash = 0;
   };
 
+  struct TextCache {
+    unsigned int texture = 0;
+    wxSize textureSize{0, 0};
+    double renderZoom = 0.0;
+    bool renderDirty = true;
+    size_t contentHash = 0;
+  };
+
   void OnPaint(wxPaintEvent &event);
   void OnSize(wxSizeEvent &event);
   void OnLeftDown(wxMouseEvent &event);
@@ -96,6 +104,8 @@ private:
   void OnDeleteLegend(wxCommandEvent &event);
   void OnEditEventTable(wxCommandEvent &event);
   void OnDeleteEventTable(wxCommandEvent &event);
+  void OnEditText(wxCommandEvent &event);
+  void OnDeleteText(wxCommandEvent &event);
   void OnBringToFront(wxCommandEvent &event);
   void OnSendToBack(wxCommandEvent &event);
 
@@ -112,12 +122,15 @@ private:
                          bool updatePosition);
   void UpdateEventTableFrame(const layouts::Layout2DViewFrame &frame,
                              bool updatePosition);
+  void UpdateTextFrame(const layouts::Layout2DViewFrame &frame,
+                       bool updatePosition);
   void InitGL();
   void RebuildCachedTexture();
   void ClearCachedTexture();
   void ClearCachedTexture(ViewCache &cache);
   void ClearCachedTexture(LegendCache &cache);
   void ClearCachedTexture(EventTableCache &cache);
+  void ClearCachedTexture(TextCache &cache);
   void RequestRenderRebuild();
   void InvalidateRenderIfFrameChanged();
   void EmitEditViewRequest();
@@ -126,14 +139,18 @@ private:
                           layouts::Layout2DViewFrame &frame) const;
   bool GetEventTableFrameById(int tableId,
                               layouts::Layout2DViewFrame &frame) const;
+  bool GetTextFrameById(int textId, layouts::Layout2DViewFrame &frame) const;
   const layouts::LayoutLegendDefinition *GetSelectedLegend() const;
   layouts::LayoutLegendDefinition *GetSelectedLegend();
   const layouts::LayoutEventTableDefinition *GetSelectedEventTable() const;
   layouts::LayoutEventTableDefinition *GetSelectedEventTable();
+  const layouts::LayoutTextDefinition *GetSelectedText() const;
+  layouts::LayoutTextDefinition *GetSelectedText();
   bool GetSelectedFrame(layouts::Layout2DViewFrame &frame) const;
   ViewCache &GetViewCache(int viewId);
   LegendCache &GetLegendCache(int legendId);
   EventTableCache &GetEventTableCache(int tableId);
+  TextCache &GetTextCache(int textId);
   std::vector<LegendItem> BuildLegendItems() const;
   size_t HashLegendItems(const std::vector<LegendItem> &items) const;
   wxImage BuildLegendImage(const wxSize &size, const wxSize &logicalSize,
@@ -145,6 +162,10 @@ private:
   wxImage BuildEventTableImage(
       const wxSize &size, const wxSize &logicalSize, double renderZoom,
       const layouts::LayoutEventTableDefinition &table) const;
+  size_t HashTextContent(const layouts::LayoutTextDefinition &text) const;
+  wxImage BuildTextImage(const wxSize &size, const wxSize &logicalSize,
+                         double renderZoom,
+                         const layouts::LayoutTextDefinition &text) const;
 
   enum class FrameDragMode {
     None,
@@ -161,7 +182,8 @@ private:
     None,
     View2D,
     Legend,
-    EventTable
+    EventTable,
+    Text
   };
 
   struct ZOrderedElement {
@@ -194,6 +216,7 @@ private:
   std::unordered_map<int, ViewCache> viewCaches_;
   std::unordered_map<int, LegendCache> legendCaches_;
   std::unordered_map<int, EventTableCache> eventTableCaches_;
+  std::unordered_map<int, TextCache> textCaches_;
   std::vector<LegendItem> legendItems_;
   size_t legendDataHash = 0;
 

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -154,6 +154,7 @@ private:
   void OnLayoutAdd2DView(wxCommandEvent &event); // Layout 2D view creation
   void OnLayoutAddLegend(wxCommandEvent &event); // Layout legend creation
   void OnLayoutAddEventTable(wxCommandEvent &event); // Layout event table
+  void OnLayoutAddText(wxCommandEvent &event); // Layout text creation
   void OnLayout2DViewOk(wxCommandEvent &event); // Confirm layout 2D view edit
   void OnLayout2DViewCancel(wxCommandEvent &event); // Cancel layout 2D edit
   void OnLayoutViewEdit(wxCommandEvent &event);
@@ -217,6 +218,7 @@ enum {
   ID_View_Layout_2DView,
   ID_View_Layout_Legend,
   ID_View_Layout_EventTable,
+  ID_View_Layout_Text,
   ID_Tools_DownloadGdtf,
   ID_Tools_EditDictionaries,
   ID_Tools_ImportRiderText,

--- a/resources/icons/icons-usage.json
+++ b/resources/icons/icons-usage.json
@@ -65,6 +65,12 @@
       "icon": "outline/layout-list.svg",
       "description": "Shows or hides the layout legend panel.",
       "group": "LayoutToolbar"
+    },
+    {
+      "name": "Layout Text",
+      "icon": "outline/text-select.svg",
+      "description": "Adds a text box to the layout.",
+      "group": "LayoutToolbar"
     }
   ]
 }

--- a/resources/icons/outline/a-arrow-down.svg
+++ b/resources/icons/outline/a-arrow-down.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m14 12 4 4 4-4" />
+  <path d="M18 16V7" />
+  <path d="m2 16 4.039-9.69a.5.5 0 0 1 .923 0L11 16" />
+  <path d="M3.304 13h6.392" />
+</svg>

--- a/resources/icons/outline/a-arrow-up.svg
+++ b/resources/icons/outline/a-arrow-up.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m14 11 4-4 4 4" />
+  <path d="M18 16V7" />
+  <path d="m2 16 4.039-9.69a.5.5 0 0 1 .923 0L11 16" />
+  <path d="M3.304 13h6.392" />
+</svg>

--- a/resources/icons/outline/align-horizontal-justify-center.svg
+++ b/resources/icons/outline/align-horizontal-justify-center.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="6" height="14" x="2" y="5" rx="2" />
+  <rect width="6" height="10" x="16" y="7" rx="2" />
+  <path d="M12 2v20" />
+</svg>

--- a/resources/icons/outline/align-horizontal-justify-end.svg
+++ b/resources/icons/outline/align-horizontal-justify-end.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="6" height="14" x="2" y="5" rx="2" />
+  <rect width="6" height="10" x="12" y="7" rx="2" />
+  <path d="M22 2v20" />
+</svg>

--- a/resources/icons/outline/align-horizontal-justify-start.svg
+++ b/resources/icons/outline/align-horizontal-justify-start.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="6" height="14" x="6" y="5" rx="2" />
+  <rect width="6" height="10" x="16" y="7" rx="2" />
+  <path d="M2 2v20" />
+</svg>

--- a/resources/icons/outline/align-horizontal-space-between.svg
+++ b/resources/icons/outline/align-horizontal-space-between.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="6" height="14" x="3" y="5" rx="2" />
+  <rect width="6" height="10" x="15" y="7" rx="2" />
+  <path d="M3 2v20" />
+  <path d="M21 2v20" />
+</svg>

--- a/resources/icons/outline/bold.svg
+++ b/resources/icons/outline/bold.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M6 12h9a4 4 0 0 1 0 8H7a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1h7a4 4 0 0 1 0 8" />
+</svg>

--- a/resources/icons/outline/italic.svg
+++ b/resources/icons/outline/italic.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <line x1="19" x2="10" y1="4" y2="4" />
+  <line x1="14" x2="5" y1="20" y2="20" />
+  <line x1="15" x2="9" y1="4" y2="20" />
+</svg>

--- a/resources/icons/outline/text-select.svg
+++ b/resources/icons/outline/text-select.svg
@@ -1,0 +1,27 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M14 21h1" />
+  <path d="M14 3h1" />
+  <path d="M19 3a2 2 0 0 1 2 2" />
+  <path d="M21 14v1" />
+  <path d="M21 19a2 2 0 0 1-2 2" />
+  <path d="M21 9v1" />
+  <path d="M3 14v1" />
+  <path d="M3 9v1" />
+  <path d="M5 21a2 2 0 0 1-2-2" />
+  <path d="M5 3a2 2 0 0 0-2 2" />
+  <path d="M7 12h10" />
+  <path d="M7 16h6" />
+  <path d="M7 8h8" />
+  <path d="M9 21h1" />
+  <path d="M9 3h1" />
+</svg>


### PR DESCRIPTION
### Motivation
- Provide a new resizable text element for Layout Mode so users can add and edit text boxes on layouts without scaling internal font when frame size changes.
- Reuse existing layout serialization and rendering pipelines so text boxes persist in config and participate in z-order, context actions and PDF/export workflows.

### Description
- Added a `LayoutTextDefinition` to layout models and full manager support for create/update/remove/move plus JSON serialization/deserialization; relevant files: `core/layouts/LayoutCollection.*`, `core/layouts/LayoutManager.*`.
- Added a toolbar/menu action and handler to create a default text box (`"Light Plot"`) in Layout Mode and updated UI ids and toolbar: `gui/mainwindow.{h,cpp}` and `resources/icons/icons-usage.json`.
- Integrated text rendering, interaction and caching into the layout viewer with selection, hit-testing, resize/move, context menu (edit/delete/bring to front/send to back) and texture caching: `gui/layoutviewerpanel.{h,cpp}`.
- Implemented a floating rich text editor dialog with bold/italic/font size/alignment controls and Lucide icons, plus loading/saving rich XML content and extracting plain text: `gui/layouttextdialog.{h,cpp}`, added icons under `resources/icons/outline/` and enabled `richtext` in `CMakeLists.txt`.

### Testing
- No automated tests were executed for this change; build and runtime verification were not performed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967ba257d1483248490c485ed1f2893)