### PR TITLE
Fix rich text rendering and font sizing

### DIFF
--- a/gui/layouttextdialog.cpp
+++ b/gui/layouttextdialog.cpp
@@ -121,7 +121,7 @@ wxString LayoutTextDialog::GetRichText() const {
 }
 
 wxString LayoutTextDialog::GetPlainText() const {
-  return textCtrl ? textCtrl->GetValue() : wxEmptyString;
+  return textCtrl ? textCtrl->GetValue() : wxString();
 }
 
 wxBitmapBundle LayoutTextDialog::LoadIcon(const std::string &name) const {
@@ -164,8 +164,16 @@ void LayoutTextDialog::ApplyItalic() {
 }
 
 void LayoutTextDialog::ApplyFontSize(int size) {
-  if (textCtrl)
-    textCtrl->ApplyFontSizeToSelection(size);
+  if (!textCtrl)
+    return;
+  wxRichTextAttr attr;
+  attr.SetFontSize(size);
+  wxRichTextRange range = textCtrl->GetSelectionRange();
+  if (range.IsValid() && range.GetLength() > 0) {
+    textCtrl->SetStyleEx(range, attr);
+  } else {
+    textCtrl->SetDefaultStyle(attr);
+  }
 }
 
 void LayoutTextDialog::AdjustFontSize(int delta) {

--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -3433,9 +3433,10 @@ wxImage LayoutViewerPanel::BuildTextImage(
   wxRect logicalRect(padding, padding, logicalWidth, logicalHeight);
 
   dc.SetUserScale(renderZoom, renderZoom);
-  buffer.Layout(dc, logicalRect, wxRICHTEXT_FIXED_WIDTH);
-  buffer.Draw(dc, wxRichTextRange(0, buffer.GetLastPosition()), logicalRect,
-              0, 0);
+  wxRichTextDrawingContext context(&buffer);
+  wxRichTextSelection selection;
+  buffer.Layout(dc, context, logicalRect, logicalRect, wxRICHTEXT_FIXED_WIDTH);
+  buffer.Draw(dc, context, buffer.GetRange(), selection, logicalRect, 0, 0);
 
   memoryDc.SelectObject(wxNullBitmap);
   return bitmap.ConvertToImage();


### PR DESCRIPTION
### Motivation
- Update code to match the current wxRichText API signatures so rich text can be laid out and drawn into images without type/signature errors.
- Replace removed/unsupported convenience calls for font sizing with explicit rich-text style operations to reliably apply sizes in the editor dialog.

### Description
- In `BuildTextImage` create a `wxRichTextDrawingContext` and a `wxRichTextSelection`, and replace the old `buffer.Layout(dc, logicalRect, ...)` and `buffer.Draw(dc, ...)` calls with `buffer.Layout(dc, context, logicalRect, logicalRect, wxRICHTEXT_FIXED_WIDTH)` and `buffer.Draw(dc, context, buffer.GetRange(), selection, logicalRect, 0, 0)` to match current `wxRichTextBuffer`/`wxRichTextParagraphLayoutBox` APIs.
- In `LayoutTextDialog` change `GetPlainText` to return `wxString()` as the empty fallback and implement `ApplyFontSize` by constructing a `wxRichTextAttr` with `SetFontSize(size)` and applying it with `SetStyleEx` for a selection or `SetDefaultStyle` when there is no selection, replacing the removed `ApplyFontSizeToSelection` call.
- Minor API adaptations to avoid ambiguous/invalid overloads and to ensure correct types are passed into the rich text layout/draw routines.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967c2008738832486c49c8d79d8d81e)