### PR TITLE
Fix font size application selection check

### DIFF
--- a/gui/layouttextdialog.cpp
+++ b/gui/layouttextdialog.cpp
@@ -169,7 +169,7 @@ void LayoutTextDialog::ApplyFontSize(int size) {
   wxRichTextAttr attr;
   attr.SetFontSize(size);
   wxRichTextRange range = textCtrl->GetSelectionRange();
-  if (range.IsValid() && range.GetLength() > 0) {
+  if (textCtrl->HasSelection() && range.GetLength() > 0) {
     textCtrl->SetStyleEx(range, attr);
   } else {
     textCtrl->SetDefaultStyle(attr);


### PR DESCRIPTION
### Motivation
- Replace use of `wxRichTextRange::IsValid()` which is not available and caused a compile error with a correct selection check on the control.

### Description
- In `LayoutTextDialog::ApplyFontSize` use `textCtrl->HasSelection()` combined with `range.GetLength() > 0` instead of `range.IsValid()` to choose between `SetStyleEx` and `SetDefaultStyle`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967c39fafa48324958cc66753cc2f46)