### PR TITLE
Ensure toolbars keep visible size after layout restore

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -2483,6 +2483,21 @@ void MainWindow::ApplySavedLayout() {
     if (view2dPane.IsOk())
         view2dPane.MinSize(wxSize(250, 600));
 
+    auto applyToolbarMinSize = [this](wxAuiToolBar *toolbar,
+                                      const std::string &paneName) {
+        if (!toolbar)
+            return;
+        const wxSize bestSize = toolbar->GetBestSize();
+        toolbar->SetMinSize(bestSize);
+        auto &pane = auiManager->GetPane(paneName);
+        if (pane.IsOk())
+            pane.BestSize(bestSize).MinSize(bestSize);
+    };
+
+    applyToolbarMinSize(fileToolBar, "FileToolbar");
+    applyToolbarMinSize(layoutViewsToolBar, "LayoutViewsToolbar");
+    applyToolbarMinSize(layoutToolBar, "LayoutToolbar");
+
     auiManager->Update();
     UpdateViewMenuChecks();
 }


### PR DESCRIPTION
### Motivation
- Restoring a saved AUI perspective could leave toolbar panes with sizes overridden, causing toolbar icons to be hidden on first launch for new users.
- Ensure toolbars retain a visible size after loading saved layouts so the UI shows icons correctly without user interaction.

### Description
- Added an `applyToolbarMinSize` lambda in `MainWindow::ApplySavedLayout()` that queries each toolbar's `GetBestSize()` and applies it via `SetMinSize()` and the corresponding pane `BestSize()`/`MinSize()`.
- Applied this fix to `fileToolBar`, `layoutViewsToolBar`, and `layoutToolBar` and kept the final `auiManager->Update()` call to reflow the layout.
- Change is in `gui/mainwindow.cpp` (around `ApplySavedLayout`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967c6dd44508324b2999181faed8a8e)