### PR TITLE
Soporte de fondo/perfil para textos en Layouts y exportación a PDF

### DIFF
--- a/core/layouts/LayoutCollection.h
+++ b/core/layouts/LayoutCollection.h
@@ -94,6 +94,8 @@ struct LayoutTextDefinition {
   Layout2DViewFrame frame;
   std::string text;
   std::string richText;
+  bool solidBackground = true;
+  bool drawFrame = true;
 };
 
 struct LayoutDefinition {

--- a/core/layouts/LayoutManager.cpp
+++ b/core/layouts/LayoutManager.cpp
@@ -117,8 +117,13 @@ nlohmann::json ToJson(const LayoutTextDefinition &text) {
       {"id", text.id},
       {"zIndex", text.zIndex},
       {"frame",
-       {{"x", frame.x}, {"y", frame.y}, {"width", frame.width}, {"height", frame.height}}},
-      {"text", text.text}};
+       {{"x", frame.x},
+        {"y", frame.y},
+        {"width", frame.width},
+        {"height", frame.height}}},
+      {"text", text.text},
+      {"solidBackground", text.solidBackground},
+      {"drawFrame", text.drawFrame}};
   if (!text.richText.empty())
     data["richText"] = text.richText;
   return data;
@@ -337,6 +342,12 @@ bool ParseLayoutText(const nlohmann::json &value,
   if (auto richIt = value.find("richText");
       richIt != value.end() && richIt->is_string())
     out.richText = richIt->get<std::string>();
+  if (auto bgIt = value.find("solidBackground");
+      bgIt != value.end() && bgIt->is_boolean())
+    out.solidBackground = bgIt->get<bool>();
+  if (auto frameIt = value.find("drawFrame");
+      frameIt != value.end() && frameIt->is_boolean())
+    out.drawFrame = frameIt->get<bool>();
   return true;
 }
 

--- a/gui/layouttextdialog.cpp
+++ b/gui/layouttextdialog.cpp
@@ -24,6 +24,7 @@
 #include <wx/artprov.h>
 #include <wx/bmpbuttn.h>
 #include <wx/button.h>
+#include <wx/checkbox.h>
 #include <wx/richtext/richtextctrl.h>
 #include <wx/sizer.h>
 #include <wx/spinctrl.h>
@@ -40,7 +41,8 @@ constexpr int kMaxFontSize = 72;
 
 LayoutTextDialog::LayoutTextDialog(wxWindow *parent,
                                    const wxString &initialRichText,
-                                   const wxString &fallbackText)
+                                   const wxString &fallbackText,
+                                   bool solidBackground, bool drawFrame)
     : wxDialog(parent, wxID_ANY, "Edit Text", wxDefaultPosition,
                wxSize(640, 420),
                wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER) {
@@ -91,6 +93,15 @@ LayoutTextDialog::LayoutTextDialog(wxWindow *parent,
 
   mainSizer->Add(toolbarSizer, 0, wxEXPAND | wxALL, 8);
 
+  wxBoxSizer *optionsSizer = new wxBoxSizer(wxHORIZONTAL);
+  solidBackgroundCtrl = new wxCheckBox(this, wxID_ANY, "Solid background");
+  solidBackgroundCtrl->SetValue(solidBackground);
+  optionsSizer->Add(solidBackgroundCtrl, 0, wxRIGHT, 12);
+  drawFrameCtrl = new wxCheckBox(this, wxID_ANY, "Show outline");
+  drawFrameCtrl->SetValue(drawFrame);
+  optionsSizer->Add(drawFrameCtrl, 0, wxRIGHT, 8);
+  mainSizer->Add(optionsSizer, 0, wxLEFT | wxRIGHT | wxBOTTOM, 8);
+
   textCtrl = new wxRichTextCtrl(this, wxID_ANY, wxEmptyString,
                                 wxDefaultPosition, wxDefaultSize,
                                 wxTE_MULTILINE | wxTE_RICH2);
@@ -122,6 +133,14 @@ wxString LayoutTextDialog::GetRichText() const {
 
 wxString LayoutTextDialog::GetPlainText() const {
   return textCtrl ? textCtrl->GetValue() : wxString();
+}
+
+bool LayoutTextDialog::GetSolidBackground() const {
+  return solidBackgroundCtrl ? solidBackgroundCtrl->GetValue() : true;
+}
+
+bool LayoutTextDialog::GetDrawFrame() const {
+  return drawFrameCtrl ? drawFrameCtrl->GetValue() : true;
 }
 
 wxBitmapBundle LayoutTextDialog::LoadIcon(const std::string &name) const {
@@ -172,6 +191,9 @@ void LayoutTextDialog::ApplyFontSize(int size) {
   if (textCtrl->HasSelection() && range.GetLength() > 0) {
     textCtrl->SetStyleEx(range, attr);
   } else {
+    wxRichTextRange all(0, textCtrl->GetLastPosition());
+    if (all.GetLength() > 0)
+      textCtrl->SetStyleEx(all, attr);
     textCtrl->SetDefaultStyle(attr);
   }
 }

--- a/gui/layouttextdialog.h
+++ b/gui/layouttextdialog.h
@@ -20,16 +20,20 @@
 #include <wx/dialog.h>
 
 class wxBitmapBundle;
+class wxCheckBox;
 class wxRichTextCtrl;
 class wxSpinCtrl;
 
 class LayoutTextDialog : public wxDialog {
 public:
   LayoutTextDialog(wxWindow *parent, const wxString &initialRichText,
-                   const wxString &fallbackText);
+                   const wxString &fallbackText, bool solidBackground,
+                   bool drawFrame);
 
   wxString GetRichText() const;
   wxString GetPlainText() const;
+  bool GetSolidBackground() const;
+  bool GetDrawFrame() const;
 
 private:
   wxBitmapBundle LoadIcon(const std::string &name) const;
@@ -43,4 +47,6 @@ private:
 
   wxRichTextCtrl *textCtrl = nullptr;
   wxSpinCtrl *fontSizeCtrl = nullptr;
+  wxCheckBox *solidBackgroundCtrl = nullptr;
+  wxCheckBox *drawFrameCtrl = nullptr;
 };

--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -1,0 +1,86 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "layouttextutils.h"
+
+#include <algorithm>
+
+#include <wx/dcgraph.h>
+#include <wx/richtext/richtextbuffer.h>
+#include <wx/sstream.h>
+
+#include "layoutviewerpanel_shared.h"
+
+namespace layouttext {
+
+wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
+                        const wxSize &renderSize, const wxSize &logicalSize,
+                        double renderScale) {
+  if (renderSize.GetWidth() <= 0 || renderSize.GetHeight() <= 0 ||
+      renderScale <= 0.0) {
+    return wxImage();
+  }
+
+  wxBitmap bitmap(renderSize.GetWidth(), renderSize.GetHeight(), 32);
+  bitmap.UseAlpha();
+  wxMemoryDC memoryDc(bitmap);
+  wxGCDC dc(memoryDc);
+
+  if (text.solidBackground) {
+    dc.SetBackground(wxBrush(wxColour(255, 255, 255)));
+  } else {
+    dc.SetBackground(wxBrush(wxColour(255, 255, 255, 0)));
+  }
+  dc.Clear();
+  dc.SetTextForeground(wxColour(20, 20, 20));
+
+  wxRichTextBuffer buffer;
+  bool loaded = false;
+  if (!text.richText.empty()) {
+    wxStringInputStream input(wxString::FromUTF8(text.richText));
+    loaded = buffer.LoadFile(input, wxRICHTEXT_TYPE_XML);
+  }
+  if (!loaded) {
+    wxString fallback =
+        text.text.empty() ? wxString("Light Plot")
+                          : wxString::FromUTF8(text.text);
+    buffer.AddParagraph(fallback);
+  }
+
+  wxRichTextAttr baseStyle = buffer.GetDefaultStyle();
+  wxString faceName = layoutviewerpanel::detail::ResolveSharedFontFaceName();
+  if (!faceName.empty()) {
+    baseStyle.SetFontFaceName(faceName);
+    buffer.SetDefaultStyle(baseStyle);
+  }
+
+  const int padding = 4;
+  const int logicalWidth = std::max(0, logicalSize.GetWidth() - padding * 2);
+  const int logicalHeight = std::max(0, logicalSize.GetHeight() - padding * 2);
+  wxRect logicalRect(padding, padding, logicalWidth, logicalHeight);
+
+  dc.SetUserScale(renderScale, renderScale);
+  wxRichTextDrawingContext context(&buffer);
+  wxRichTextSelection selection;
+  buffer.Layout(dc, context, logicalRect, logicalRect, wxRICHTEXT_FIXED_WIDTH);
+  buffer.Draw(dc, context, buffer.GetRange(), selection, logicalRect, 0, 0);
+
+  memoryDc.SelectObject(wxNullBitmap);
+  return bitmap.ConvertToImage();
+}
+
+} // namespace layouttext

--- a/gui/layouttextutils.h
+++ b/gui/layouttextutils.h
@@ -1,0 +1,29 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <wx/image.h>
+#include <wx/size.h>
+
+#include "layouts/LayoutCollection.h"
+
+namespace layouttext {
+wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
+                        const wxSize &renderSize, const wxSize &logicalSize,
+                        double renderScale);
+} // namespace layouttext

--- a/gui/layoutviewerpanel_shared.h
+++ b/gui/layoutviewerpanel_shared.h
@@ -37,6 +37,8 @@ inline const std::vector<const char *> kSharedFontFaceNames = {
 #endif
 };
 
+constexpr double kTextRenderScale = 0.9;
+
 inline wxString ResolveSharedFontFaceName() {
   static wxString faceName;
   static bool initialized = false;

--- a/viewer2d/viewer2dpdfexporter.h
+++ b/viewer2d/viewer2dpdfexporter.h
@@ -78,6 +78,16 @@ struct LayoutEventTableExportData {
   int zIndex = 0;
 };
 
+struct LayoutTextExportData {
+  layouts::Layout2DViewFrame frame;
+  int zIndex = 0;
+  bool solidBackground = true;
+  bool drawFrame = true;
+  int imageWidth = 0;
+  int imageHeight = 0;
+  std::vector<unsigned char> rgba;
+};
+
 // Writes the captured 2D drawing commands to a vector PDF that mirrors the
 // current viewport state. Returns structured information so callers can surface
 // meaningful errors to the user.
@@ -92,5 +102,6 @@ Viewer2DExportResult ExportLayoutToPdf(
     const std::vector<LayoutViewExportData> &views,
     const std::vector<LayoutLegendExportData> &legends,
     const std::vector<LayoutEventTableExportData> &tables,
+    const std::vector<LayoutTextExportData> &texts,
     const Viewer2DPrintOptions &options,
     const std::filesystem::path &outputPath);


### PR DESCRIPTION
### Motivation
- Habilitar control sobre si los cuadros de texto tienen fondo sólido o son transparentes y si muestran un borde (perfil). 
- Asegurar que cambios de tamaño de fuente en el editor se apliquen consistentemente y que la vista de Layout muestre el texto con escala coherente. 
- Incluir los cuadros de texto en las exportaciones a PDF conservando contenido, formato, tamaño y transparencia.

### Description
- Añadidos los flags `solidBackground` y `drawFrame` a `layouts::LayoutTextDefinition` y persistencia en JSON mediante `core/layouts/LayoutManager.cpp` (lectura/escritura). 
- Extendido el diálogo `LayoutTextDialog` con dos `wxCheckBox` para `Solid background` y `Show outline`, y se aplica el tamaño de fuente a todo el contenido si no hay selección; la información se guarda/recupera desde el diálogo (`gui/layouttextdialog.*`). 
- Centralizada la generación de imágenes rasterizadas de texto en `gui/layouttextutils.*` usando `wxRichTextBuffer` y una escala compartida (`layoutviewerpanel_shared.h::kTextRenderScale`), y usada por el `LayoutViewerPanel` para renderizar y cachear texturas (`gui/layoutviewerpanel_text.cpp`). 
- El render en pantalla ahora respeta `solidBackground` y `drawFrame`, y `HashTextContent` incluye la información de fondo para invalidar cachés correctamente (`gui/layoutviewerpanel_text.cpp`). 
- Añadido soporte de exportación a PDF para textos: nuevo `LayoutTextExportData` y flujo en `MainWindow::OnPrintLayout` para renderizar imágenes de texto, y en `viewer2d/viewer2dpdfexporter.cpp` para incrustar las imágenes como XObject (con máscara alpha cuando procede) y dibujarlas en el PDF respetando posición, tamaño, fondo y borde.

### Testing
- Ninguna prueba automatizada fue ejecutada como parte de este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967cc98badc83249c0756fdf008f3f0)