### PR TITLE
Replace wx/size.h with wx/gdicmn.h to provide wxSize

### DIFF
--- a/gui/layouttextutils.h
+++ b/gui/layouttextutils.h
@@ -17,8 +17,8 @@
  */
 #pragma once
 
+#include <wx/gdicmn.h>
 #include <wx/image.h>
-#include <wx/size.h>
 
 #include "layouts/LayoutCollection.h"
 


### PR DESCRIPTION
### Motivation
- Some wxWidgets installations do not provide `wx/size.h`, while `wxSize` is available from `wx/gdicmn.h`, so the include needs to be updated to avoid missing-header errors.

### Description
- Replaced `#include <wx/size.h>` with `#include <wx/gdicmn.h>` in `gui/layouttextutils.h` to ensure `wxSize` is available.

### Testing
- No automated tests were run for this header-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967d03ac29c8324a2945903efbae2ad)