### PR TITLE
Fix missing wxMemoryDC include for layout text rendering

### DIFF
--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 
 #include <wx/dcgraph.h>
+#include <wx/dcmemory.h>
 #include <wx/richtext/richtextbuffer.h>
 #include <wx/sstream.h>
 


### PR DESCRIPTION
### Motivation
- Resolve compilation errors where `wxMemoryDC` and `wxGCDC` were undefined by adding the required `<wx/dcmemory.h>` include.

### Description
- Add `#include <wx/dcmemory.h>` to `gui/layouttextutils.cpp` so `wxMemoryDC` and `wxGCDC` construct correctly.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967d8d8ddfc83248dbaf0ef5aae4394)