### PR TITLE
Fix layout text font persistence, render scale and color

### DIFF
--- a/gui/layouttextdialog.cpp
+++ b/gui/layouttextdialog.cpp
@@ -25,6 +25,7 @@
 #include <wx/bmpbuttn.h>
 #include <wx/button.h>
 #include <wx/checkbox.h>
+#include <wx/richtext/richtextbuffer.h>
 #include <wx/richtext/richtextctrl.h>
 #include <wx/sizer.h>
 #include <wx/spinctrl.h>
@@ -37,6 +38,14 @@ constexpr int kToolbarIconSizePx = 16;
 constexpr int kDefaultFontSize = 12;
 constexpr int kMinFontSize = 6;
 constexpr int kMaxFontSize = 72;
+
+void EnsureRichTextHandlers() {
+  static bool initialized = false;
+  if (initialized)
+    return;
+  wxRichTextBuffer::InitStandardHandlers();
+  initialized = true;
+}
 } // namespace
 
 LayoutTextDialog::LayoutTextDialog(wxWindow *parent,
@@ -46,6 +55,7 @@ LayoutTextDialog::LayoutTextDialog(wxWindow *parent,
     : wxDialog(parent, wxID_ANY, "Edit Text", wxDefaultPosition,
                wxSize(640, 420),
                wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER) {
+  EnsureRichTextHandlers();
   wxBoxSizer *mainSizer = new wxBoxSizer(wxVERTICAL);
   wxBoxSizer *toolbarSizer = new wxBoxSizer(wxHORIZONTAL);
 

--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -27,6 +27,15 @@
 #include "layoutviewerpanel_shared.h"
 
 namespace layouttext {
+namespace {
+void EnsureRichTextHandlers() {
+  static bool initialized = false;
+  if (initialized)
+    return;
+  wxRichTextBuffer::InitStandardHandlers();
+  initialized = true;
+}
+} // namespace
 
 wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
                         const wxSize &renderSize, const wxSize &logicalSize,
@@ -47,8 +56,9 @@ wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
     dc.SetBackground(wxBrush(wxColour(255, 255, 255, 0)));
   }
   dc.Clear();
-  dc.SetTextForeground(wxColour(20, 20, 20));
+  dc.SetTextForeground(wxColour(0, 0, 0));
 
+  EnsureRichTextHandlers();
   wxRichTextBuffer buffer;
   bool loaded = false;
   if (!text.richText.empty()) {

--- a/gui/layoutviewerpanel_shared.h
+++ b/gui/layoutviewerpanel_shared.h
@@ -37,7 +37,7 @@ inline const std::vector<const char *> kSharedFontFaceNames = {
 #endif
 };
 
-constexpr double kTextRenderScale = 0.9;
+constexpr double kTextRenderScale = 0.8;
 
 inline wxString ResolveSharedFontFaceName() {
   static wxString faceName;


### PR DESCRIPTION
### Motivation
- The layout text editor changes (font size and rich text) were not reliably applied or visible in the Layout Viewer, text was rendered in a gray color, and the on-screen rendered size did not match the editor.

### Description
- Initialize rich text XML handlers by calling `wxRichTextBuffer::InitStandardHandlers()` from `LayoutTextDialog` and the layout text renderer so rich text/font size changes persist and can be loaded.
- Change the layout text renderer foreground to pure black by using `dc.SetTextForeground(wxColour(0, 0, 0))` in `layouttext::RenderTextImage` so on-screen text appears black.
- Adjust the text render scale constant from `kTextRenderScale = 0.9` to `0.8` in `layoutviewerpanel::detail` to better match editor sizing when converting logical to rendered pixels.
- Add necessary `#include <wx/richtext/richtextbuffer.h>` and small refactors to ensure the handlers initialization is available where needed.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967dd8dcf00832486527b065e99072c)