### PR TITLE
Sync layout text scale with editor and fix background/alpha

### DIFF
--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -51,9 +51,9 @@ wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
   wxGCDC dc(memoryDc);
 
   if (text.solidBackground) {
-    dc.SetBackground(wxBrush(wxColour(255, 255, 255)));
+    dc.SetBackground(wxBrush(wxColour(255, 255, 255, 255)));
   } else {
-    dc.SetBackground(wxBrush(wxColour(255, 255, 255, 0)));
+    dc.SetBackground(wxBrush(wxColour(0, 0, 0, 0)));
   }
   dc.Clear();
   dc.SetTextForeground(wxColour(0, 0, 0));
@@ -91,7 +91,19 @@ wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
   buffer.Draw(dc, context, buffer.GetRange(), selection, logicalRect, 0, 0);
 
   memoryDc.SelectObject(wxNullBitmap);
-  return bitmap.ConvertToImage();
+  wxImage image = bitmap.ConvertToImage();
+  if (!image.HasAlpha())
+    image.InitAlpha();
+  if (text.solidBackground) {
+    unsigned char *alpha = image.GetAlpha();
+    if (alpha) {
+      const size_t pixelCount =
+          static_cast<size_t>(image.GetWidth()) *
+          static_cast<size_t>(image.GetHeight());
+      std::fill(alpha, alpha + pixelCount, 255);
+    }
+  }
+  return image;
 }
 
 } // namespace layouttext

--- a/gui/layoutviewerpanel_shared.h
+++ b/gui/layoutviewerpanel_shared.h
@@ -37,7 +37,7 @@ inline const std::vector<const char *> kSharedFontFaceNames = {
 #endif
 };
 
-constexpr double kTextRenderScale = 0.8;
+constexpr double kTextRenderScale = 1.0;
 
 inline wxString ResolveSharedFontFaceName() {
   static wxString faceName;


### PR DESCRIPTION
### Motivation
- The font size chosen in the "Edit Text" dialog was not reflected in the Layout Viewer because the viewer used a different render scale, causing visual mismatch between editor and viewer.
- Text in the Layout Viewer and exported PDFs could appear gray or outlined when backgrounds were transparent or opaque due to incorrect alpha/brush handling.

### Description
- Set the text render scale used by the layout viewer to `1.0` to match the editor scale by updating `kTextRenderScale` in `gui/layoutviewerpanel_shared.h`.
- Ensure text rendering uses correct opaque/transparent backgrounds and preserves alpha by changing background brush usage and initializing the image alpha channel in `gui/layouttextutils.cpp`, and explicitly filling alpha to `255` for solid backgrounds.
- Affected files: `gui/layoutviewerpanel_shared.h` and `gui/layouttextutils.cpp`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967e1ba8c4c832498e47edc4eb42663)