### PR TITLE
Fix layout text rendering styles and sizing

### DIFF
--- a/gui/layouttextdialog.cpp
+++ b/gui/layouttextdialog.cpp
@@ -31,11 +31,11 @@
 #include <wx/spinctrl.h>
 #include <wx/sstream.h>
 
+#include "layoutviewerpanel_shared.h"
 #include "projectutils.h"
 
 namespace {
 constexpr int kToolbarIconSizePx = 16;
-constexpr int kDefaultFontSize = 12;
 constexpr int kMinFontSize = 6;
 constexpr int kMaxFontSize = 72;
 
@@ -83,7 +83,7 @@ LayoutTextDialog::LayoutTextDialog(wxWindow *parent,
   fontSizeCtrl = new wxSpinCtrl(this, wxID_ANY, wxEmptyString,
                                 wxDefaultPosition, wxSize(64, -1),
                                 wxSP_ARROW_KEYS, kMinFontSize, kMaxFontSize,
-                                kDefaultFontSize);
+                                layoutviewerpanel::detail::kTextDefaultFontSize);
   fontSizeCtrl->Bind(wxEVT_SPINCTRL, [this](wxCommandEvent &) {
     ApplyFontSize(fontSizeCtrl->GetValue());
   });
@@ -115,6 +115,14 @@ LayoutTextDialog::LayoutTextDialog(wxWindow *parent,
   textCtrl = new wxRichTextCtrl(this, wxID_ANY, wxEmptyString,
                                 wxDefaultPosition, wxDefaultSize,
                                 wxTE_MULTILINE | wxTE_RICH2);
+  wxFont sharedFont = layoutviewerpanel::detail::MakeSharedFont(
+      layoutviewerpanel::detail::kTextDefaultFontSize, wxFONTWEIGHT_NORMAL);
+  if (sharedFont.IsOk()) {
+    textCtrl->SetFont(sharedFont);
+    wxRichTextAttr defaultStyle;
+    defaultStyle.SetFont(sharedFont);
+    textCtrl->SetDefaultStyle(defaultStyle);
+  }
   textCtrl->SetMinSize(wxSize(580, 280));
   mainSizer->Add(textCtrl, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 8);
 

--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -76,7 +76,15 @@ wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
   wxString faceName = layoutviewerpanel::detail::ResolveSharedFontFaceName();
   if (!faceName.empty()) {
     baseStyle.SetFontFaceName(faceName);
-    buffer.SetDefaultStyle(baseStyle);
+  }
+  baseStyle.SetTextColour(*wxBLACK);
+  if (!loaded) {
+    baseStyle.SetFontSize(layoutviewerpanel::detail::kTextDefaultFontSize);
+  }
+  buffer.SetDefaultStyle(baseStyle);
+  buffer.SetBasicStyle(baseStyle);
+  if (buffer.GetRange().GetLength() > 0) {
+    buffer.SetStyle(buffer.GetRange(), baseStyle);
   }
 
   const int padding = 4;

--- a/gui/layoutviewerpanel_shared.h
+++ b/gui/layoutviewerpanel_shared.h
@@ -37,7 +37,8 @@ inline const std::vector<const char *> kSharedFontFaceNames = {
 #endif
 };
 
-constexpr double kTextRenderScale = 1.0;
+constexpr double kTextRenderScale = 0.85;
+constexpr int kTextDefaultFontSize = 12;
 
 inline wxString ResolveSharedFontFaceName() {
   static wxString faceName;


### PR DESCRIPTION
### Motivation
- Make text appearance consistent between the `Edit Text` dialog and the `Layout Viewer` so font size and style changes in the editor are reflected in the viewer and exported PDF.
- Ensure bold/italic/font-size changes are preserved and rendered, and improve visual match by scaling the viewer render pipeline.
- Force rendered text color to solid black for both opaque and transparent backgrounds so viewer and PDF output show black text.

### Description
- Added use of the shared font utilities by including `layoutviewerpanel_shared.h` in the editor and applying a shared font to the `wxRichTextCtrl` default style with `SetDefaultStyle`.
- Introduced `kTextDefaultFontSize` and reduced `kTextRenderScale` from `1.0` to `0.85` in `gui/layoutviewerpanel_shared.h` to better align on-screen viewer sizing with the editor.
- Updated the font size spin control to use `layoutviewerpanel::detail::kTextDefaultFontSize` in `LayoutTextDialog`.
- In `layouttextutils.cpp` enforced a base `wxRichTextAttr` (font face, black text color, and default font size when no rich text) and applied it via `SetDefaultStyle`, `SetBasicStyle` and `SetStyle` so the rendered text image respects the editor settings and is solid black.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967f17638508324acedceb716775c44)