### PR TITLE
Fix layout text rendering persistence and scaling

### DIFF
--- a/gui/layoutviewerpanel_shared.h
+++ b/gui/layoutviewerpanel_shared.h
@@ -37,7 +37,7 @@ inline const std::vector<const char *> kSharedFontFaceNames = {
 #endif
 };
 
-constexpr double kTextRenderScale = 0.85;
+constexpr double kTextRenderScale = 1.0;
 constexpr int kTextDefaultFontSize = 12;
 
 inline wxString ResolveSharedFontFaceName() {


### PR DESCRIPTION
### Motivation
- Make text box rendering consistent between the `Edit Text` dialog and the `Layout Viewer` so font sizes set in the editor appear correctly in the viewer and are not lost.
- Avoid the visual artifact where text looks outlined when the text box background is transparent and keep rendering identical except for the background. 
- Prevent extra blank spacing being introduced when a user inserts line breaks in the text editor.

### Description
- Aligned on-screen text sizing by changing `layoutviewerpanel::detail::kTextRenderScale` from `0.85` to `1.0` in `gui/layoutviewerpanel_shared.h` so rendered text size matches the editor.
- Improved the text image renderer in `gui/layouttextutils.cpp` by switching transparent background painting to a white-with-alpha brush (fixes outlined appearance), adding `#include <wx/tokenzr.h>`, normalizing line endings and tokenizing fallback plain text into individual paragraphs to avoid added spacing, and ensuring empty paragraphs are handled.
- Enforced consistent paragraph metrics and style overrides by zeroing paragraph spacing and applying an explicit `wxRichTextAttr` with controlled flags (text colour, paragraph spacing, font face and font size when applicable) so font face/size and paragraph spacing are preserved during rendering.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967f5cc84708324aaf2a3071028bea8)