### PR TITLE
Add compatibility fallbacks for wx paragraph spacing flags

### DIFF
--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -27,6 +27,14 @@
 
 #include "layoutviewerpanel_shared.h"
 
+#ifndef wxTEXT_ATTR_PARAGRAPH_SPACING_BEFORE
+#define wxTEXT_ATTR_PARAGRAPH_SPACING_BEFORE 0
+#endif
+
+#ifndef wxTEXT_ATTR_PARAGRAPH_SPACING_AFTER
+#define wxTEXT_ATTR_PARAGRAPH_SPACING_AFTER 0
+#endif
+
 namespace layouttext {
 namespace {
 void EnsureRichTextHandlers() {


### PR DESCRIPTION
### Motivation
- Provide fallback definitions for paragraph spacing attribute flags to avoid `undeclared identifier` build errors with older wxWidgets versions.

### Description
- Add `#ifndef` guards that define `wxTEXT_ATTR_PARAGRAPH_SPACING_BEFORE` and `wxTEXT_ATTR_PARAGRAPH_SPACING_AFTER` to `0` when missing in `gui/layouttextutils.cpp` so existing flag usage compiles.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967f7a2e16c83248ae461e716781e2b)