### PR TITLE
Improve layout text rendering and export (font sizing, alpha handling, PDF text output)

### DIFF
--- a/gui/layouttextdialog.cpp
+++ b/gui/layouttextdialog.cpp
@@ -205,6 +205,7 @@ void LayoutTextDialog::ApplyFontSize(int size) {
     return;
   wxRichTextAttr attr;
   attr.SetFontSize(size);
+  attr.SetFlags(wxTEXT_ATTR_FONT_SIZE);
   wxRichTextRange range = textCtrl->GetSelectionRange();
   if (textCtrl->HasSelection() && range.GetLength() > 0) {
     textCtrl->SetStyleEx(range, attr);

--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1075,11 +1075,24 @@ void LayoutViewerPanel::RebuildCachedTexture() {
 
     std::vector<unsigned char> pixels;
     pixels.resize(static_cast<size_t>(width) * height * 4);
+    const bool needsUnpremultiply = !text.solidBackground && alpha;
     for (int i = 0; i < width * height; ++i) {
-      pixels[static_cast<size_t>(i) * 4] = rgb[i * 3];
-      pixels[static_cast<size_t>(i) * 4 + 1] = rgb[i * 3 + 1];
-      pixels[static_cast<size_t>(i) * 4 + 2] = rgb[i * 3 + 2];
-      pixels[static_cast<size_t>(i) * 4 + 3] = alpha ? alpha[i] : 255;
+      const unsigned char a = alpha ? alpha[i] : 255;
+      unsigned char r = rgb[i * 3];
+      unsigned char g = rgb[i * 3 + 1];
+      unsigned char b = rgb[i * 3 + 2];
+      if (needsUnpremultiply && a > 0 && a < 255) {
+        r = static_cast<unsigned char>(
+            std::min(255, static_cast<int>(r) * 255 / a));
+        g = static_cast<unsigned char>(
+            std::min(255, static_cast<int>(g) * 255 / a));
+        b = static_cast<unsigned char>(
+            std::min(255, static_cast<int>(b) * 255 / a));
+      }
+      pixels[static_cast<size_t>(i) * 4] = r;
+      pixels[static_cast<size_t>(i) * 4 + 1] = g;
+      pixels[static_cast<size_t>(i) * 4 + 2] = b;
+      pixels[static_cast<size_t>(i) * 4 + 3] = a;
     }
 
     InitGL();

--- a/gui/layoutviewerpanel_shared.h
+++ b/gui/layoutviewerpanel_shared.h
@@ -37,7 +37,7 @@ inline const std::vector<const char *> kSharedFontFaceNames = {
 #endif
 };
 
-constexpr double kTextRenderScale = 1.0;
+constexpr double kTextRenderScale = 96.0 / 72.0;
 constexpr int kTextDefaultFontSize = 12;
 
 inline wxString ResolveSharedFontFaceName() {

--- a/viewer2d/viewer2dpdfexporter.h
+++ b/viewer2d/viewer2dpdfexporter.h
@@ -83,9 +83,12 @@ struct LayoutTextExportData {
   int zIndex = 0;
   bool solidBackground = true;
   bool drawFrame = true;
-  int imageWidth = 0;
-  int imageHeight = 0;
-  std::vector<unsigned char> rgba;
+  enum class Alignment { Left, Center, Right, Justified };
+  Alignment alignment = Alignment::Left;
+  int fontSize = 12;
+  bool bold = false;
+  bool italic = false;
+  std::vector<std::string> lines;
 };
 
 // Writes the captured 2D drawing commands to a vector PDF that mirrors the


### PR DESCRIPTION
### Motivation
- Fix inconsistencies between the "Edit Text" dialog and the Layout Viewer where font size, bold/italic and multi-line text were not preserved or rendered correctly. 
- Remove rasterized text in exported PDFs for layout text boxes and emit proper vector text where possible to avoid pixelation and to respect alignment and basic font styles. 
- Eliminate unwanted black profiling/halo when text background is transparent by correcting alpha handling when building textures for the viewer.

### Description
- Ensure font size mutations in the editor take effect by setting the font-size flag in `LayoutTextDialog::ApplyFontSize` with `attr.SetFlags(wxTEXT_ATTR_FONT_SIZE)`.
- Adjust on-screen text render scaling to match display DPI by changing `layoutviewerpanel::detail::kTextRenderScale` from `1.0` to `96.0/72.0` so sizes are consistent between editor and viewer.
- Fix texture alpha artifacts in the Layout Viewer by changing how text bitmaps are converted to GL textures (handle alpha / premultiplication properly when building the RGBA pixel buffer) so transparent backgrounds do not produce black outlines.
- Populate structured text export data in `BuildLayoutTextExportData` by parsing `richText` when present and extracting basic style hints (font size, bold, italic, alignment) and splitting into lines instead of always rasterizing the text to an image.
- Replace the previous image-based layout-text export path in the PDF exporter with vector text emission in `viewer2d/viewer2dpdfexporter.cpp` by using the parsed `LayoutTextExportData` fields (background fill, alignment, font size, bold/italic) and emitting PDF `BT`/`Tj` text operators positioned inside the text frame (keep frame outline behavior when `drawFrame` is set).
- Update `LayoutTextExportData` (in `viewer2d/viewer2dpdfexporter.h`) to carry `alignment`, `fontSize`, `bold`, `italic` and `lines` instead of image RGBA blobs so PDF export can render text as vector text.

### Testing
- No automated tests were executed as part of this change; changes were implemented and committed locally (no test run was requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967fd1085fc8324b949c43142f26f46)