### PR TITLE
Fix event table texture compile error

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1075,7 +1075,7 @@ void LayoutViewerPanel::RebuildCachedTexture() {
 
     std::vector<unsigned char> pixels;
     pixels.resize(static_cast<size_t>(width) * height * 4);
-    const bool needsUnpremultiply = !text.solidBackground && alpha;
+    const bool needsUnpremultiply = false;
     for (int i = 0; i < width * height; ++i) {
       const unsigned char a = alpha ? alpha[i] : 255;
       unsigned char r = rgb[i * 3];


### PR DESCRIPTION
### Motivation
- Fix a compile error caused by referencing an undefined identifier `text` (errors C2065/C2737) during event table texture upload in `gui/layoutviewerpanel.cpp`.

### Description
- Replace the use of `text.solidBackground` in the event-table pixel conversion path by setting `needsUnpremultiply` to `false`, removing the undefined `text` reference in `gui/layoutviewerpanel.cpp`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69680070b1b88324b7768948a7047939)