### PR TITLE
Fix persistence of layout text formatting

### DIFF
--- a/gui/layouttextdialog.cpp
+++ b/gui/layouttextdialog.cpp
@@ -29,8 +29,8 @@
 #include <wx/richtext/richtextctrl.h>
 #include <wx/sizer.h>
 #include <wx/spinctrl.h>
-#include <wx/sstream.h>
 
+#include "layouttextutils.h"
 #include "layoutviewerpanel_shared.h"
 #include "projectutils.h"
 
@@ -143,10 +143,7 @@ LayoutTextDialog::LayoutTextDialog(wxWindow *parent,
 wxString LayoutTextDialog::GetRichText() const {
   if (!textCtrl)
     return wxEmptyString;
-  wxStringOutputStream output;
-  if (textCtrl->GetBuffer().SaveFile(output, wxRICHTEXT_TYPE_XML))
-    return output.GetString();
-  return textCtrl->GetValue();
+  return layouttext::SaveRichTextBufferToString(textCtrl->GetBuffer());
 }
 
 wxString LayoutTextDialog::GetPlainText() const {
@@ -182,8 +179,8 @@ void LayoutTextDialog::LoadInitialContent(const wxString &initialRichText,
   if (!textCtrl)
     return;
   if (!initialRichText.empty()) {
-    wxStringInputStream input(initialRichText);
-    if (textCtrl->GetBuffer().LoadFile(input, wxRICHTEXT_TYPE_XML)) {
+    if (layouttext::LoadRichTextBufferFromString(textCtrl->GetBuffer(),
+                                                 initialRichText)) {
       return;
     }
   }

--- a/gui/layouttextutils.h
+++ b/gui/layouttextutils.h
@@ -19,10 +19,15 @@
 
 #include <wx/gdicmn.h>
 #include <wx/image.h>
+#include <wx/richtext/richtextbuffer.h>
 
 #include "layouts/LayoutCollection.h"
 
 namespace layouttext {
+bool LoadRichTextBufferFromString(wxRichTextBuffer &buffer,
+                                  const wxString &content);
+wxString SaveRichTextBufferToString(wxRichTextBuffer &buffer);
+
 wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
                         const wxSize &renderSize, const wxSize &logicalSize,
                         double renderScale);

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -50,7 +50,6 @@
 #include <wx/numdlg.h>
 #include <wx/statbmp.h>
 #include <wx/stdpaths.h>
-#include <wx/sstream.h>
 #include <wx/textctrl.h>
 #include <wx/tokenzr.h>
 #include <wx/wfstream.h>
@@ -80,6 +79,7 @@ using json = nlohmann::json;
 #include "layoutviewpresets.h"
 #include "layoutpanel.h"
 #include "layoutviewerpanel.h"
+#include "layouttextutils.h"
 #include "layoutviewerpanel_shared.h"
 #include "legendutils.h"
 #include "layerpanel.h"
@@ -137,14 +137,6 @@ void LogMissingIcon(const std::filesystem::path &path) {
 #endif
 }
 
-void EnsureRichTextHandlers() {
-  static bool initialized = false;
-  if (initialized)
-    return;
-  wxRichTextBuffer::InitStandardHandlers();
-  initialized = true;
-}
-
 LayoutTextExportData BuildLayoutTextExportData(
     const layouts::LayoutTextDefinition &text, double scaleX, double scaleY) {
   LayoutTextExportData data;
@@ -158,12 +150,11 @@ LayoutTextExportData BuildLayoutTextExportData(
   data.solidBackground = text.solidBackground;
   data.drawFrame = text.drawFrame;
 
-  EnsureRichTextHandlers();
   wxRichTextBuffer buffer;
   bool loaded = false;
   if (!text.richText.empty()) {
-    wxStringInputStream input(wxString::FromUTF8(text.richText));
-    loaded = buffer.LoadFile(input, wxRICHTEXT_TYPE_XML);
+    loaded = layouttext::LoadRichTextBufferFromString(
+        buffer, wxString::FromUTF8(text.richText));
   }
 
   wxString plainText;


### PR DESCRIPTION
### Motivation
- The layout text editor was not reliably preserving rich-text formatting (font size, bold/italic, alignment) when editing, exporting or rendering text boxes.
- The previous code attempted to load/save XML rich text directly and duplicated handler initialization, which caused formatting to be lost when XML handlers were not available.

### Description
- Add shared helpers `LoadRichTextBufferFromString` and `SaveRichTextBufferToString` in `gui/layouttextutils.{h,cpp}` to load/save rich text with XML first and an RTF fallback. 
- Use the new helpers from the editor by replacing the manual `wxRichTextBuffer` load/save logic in `LayoutTextDialog::LoadInitialContent` and `LayoutTextDialog::GetRichText`.
- Use the new loader from the renderer and export path by replacing direct buffer XML loads in `gui/layouttextutils.cpp` (`RenderTextImage`) and `gui/mainwindow.cpp` (`BuildLayoutTextExportData`).
- Remove duplicated `EnsureRichTextHandlers` usages and centralize rich-text handler initialization via the new helpers, and add the header include `layouttextutils.h` where needed.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696801b6fb388324b0e465a37e1fe344)