### PR TITLE
Add fallback when wxRICHTEXT_TYPE_RICHTEXT is unavailable

### DIFF
--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -55,7 +55,11 @@ bool LoadRichTextBufferFromString(wxRichTextBuffer &buffer,
   if (buffer.LoadFile(xmlInput, wxRICHTEXT_TYPE_XML))
     return true;
   wxStringInputStream richInput(content);
+#if defined(wxRICHTEXT_TYPE_RICHTEXT)
   return buffer.LoadFile(richInput, wxRICHTEXT_TYPE_RICHTEXT);
+#else
+  return buffer.LoadFile(richInput, wxRICHTEXT_TYPE_TEXT);
+#endif
 }
 
 wxString SaveRichTextBufferToString(wxRichTextBuffer &buffer) {
@@ -64,7 +68,11 @@ wxString SaveRichTextBufferToString(wxRichTextBuffer &buffer) {
   if (buffer.SaveFile(output, wxRICHTEXT_TYPE_XML))
     return output.GetString();
   wxStringOutputStream richOutput;
+#if defined(wxRICHTEXT_TYPE_RICHTEXT)
   if (buffer.SaveFile(richOutput, wxRICHTEXT_TYPE_RICHTEXT))
+#else
+  if (buffer.SaveFile(richOutput, wxRICHTEXT_TYPE_TEXT))
+#endif
     return richOutput.GetString();
   return buffer.GetText();
 }


### PR DESCRIPTION
### Motivation
- Some wxWidgets configurations do not define `wxRICHTEXT_TYPE_RICHTEXT`, causing builds and rich-text load/save to fail, so a safe fallback is needed.

### Description
- Updated `gui/layouttextutils.cpp` to conditionally compile usage of `wxRICHTEXT_TYPE_RICHTEXT` and fall back to `wxRICHTEXT_TYPE_TEXT` for `LoadFile` and `SaveFile`, while keeping existing XML handling with `wxRICHTEXT_TYPE_XML` unchanged.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69680340b1d88324934f857ec60bae21)