### PR TITLE
Fix Layout Viewer text UTF-8 preservation and rendering scale

### DIFF
--- a/gui/layoutviewerpanel_text.cpp
+++ b/gui/layoutviewerpanel_text.cpp
@@ -103,8 +103,8 @@ void LayoutViewerPanel::OnEditText(wxCommandEvent &) {
                           text->drawFrame);
   if (dialog.ShowModal() != wxID_OK)
     return;
-  text->richText = dialog.GetRichText().ToStdString();
-  text->text = dialog.GetPlainText().ToStdString();
+  text->richText = dialog.GetRichText().ToUTF8().data();
+  text->text = dialog.GetPlainText().ToUTF8().data();
   text->solidBackground = dialog.GetSolidBackground();
   text->drawFrame = dialog.GetDrawFrame();
   if (!currentLayout.name.empty()) {
@@ -242,7 +242,5 @@ wxImage LayoutViewerPanel::BuildTextImage(
     const layouts::LayoutTextDefinition &text) const {
   if (size.GetWidth() <= 0 || size.GetHeight() <= 0 || renderZoom <= 0.0)
     return wxImage();
-  return layouttext::RenderTextImage(
-      text, size, logicalSize,
-      renderZoom * layoutviewerpanel::detail::kTextRenderScale);
+  return layouttext::RenderTextImage(text, size, logicalSize, renderZoom);
 }


### PR DESCRIPTION
### Motivation
- The Layout Viewer lost rich-text formatting and reverted sizes after editing, and on-screen text appeared as a single (larger) line compared to the editor/PDF output.
- The intent is to preserve rich text content and make on-screen rendering match the editor/exported PDF sizing.

### Description
- Save edited text using UTF-8 when storing values from the edit dialog by using `GetRichText().ToUTF8().data()` and `GetPlainText().ToUTF8().data()` so rich formatting is preserved on reopen.
- Stop applying the extra text render scale in the viewer by passing the raw `renderZoom` into `BuildTextImage`/`RenderTextImage` instead of multiplying by `layoutviewerpanel::detail::kTextRenderScale`, so on-screen font size matches the editor.
- Changes applied to `gui/layoutviewerpanel_text.cpp` to implement the above.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696804983bc083249b963695dd9013a0)