### PR TITLE
Preserve rich text formatting in Layout Viewer

### DIFF
--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -122,36 +122,34 @@ wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
     }
   }
 
-  wxRichTextAttr baseStyle = buffer.GetDefaultStyle();
-  wxString faceName = layoutviewerpanel::detail::ResolveSharedFontFaceName();
-  if (!faceName.empty())
-    baseStyle.SetFontFaceName(faceName);
-  baseStyle.SetTextColour(*wxBLACK);
-  baseStyle.SetParagraphSpacingBefore(0);
-  baseStyle.SetParagraphSpacingAfter(0);
   if (!loaded) {
+    wxRichTextAttr baseStyle = buffer.GetDefaultStyle();
+    wxString faceName = layoutviewerpanel::detail::ResolveSharedFontFaceName();
+    if (!faceName.empty())
+      baseStyle.SetFontFaceName(faceName);
+    baseStyle.SetTextColour(*wxBLACK);
+    baseStyle.SetParagraphSpacingBefore(0);
+    baseStyle.SetParagraphSpacingAfter(0);
     baseStyle.SetFontSize(layoutviewerpanel::detail::kTextDefaultFontSize);
-  }
-  buffer.SetDefaultStyle(baseStyle);
-  buffer.SetBasicStyle(baseStyle);
-  if (buffer.GetRange().GetLength() > 0) {
-    wxRichTextAttr overrideStyle;
-    long flags = wxTEXT_ATTR_TEXT_COLOUR |
-                 wxTEXT_ATTR_PARAGRAPH_SPACING_BEFORE |
-                 wxTEXT_ATTR_PARAGRAPH_SPACING_AFTER;
-    if (!faceName.empty()) {
-      overrideStyle.SetFontFaceName(faceName);
-      flags |= wxTEXT_ATTR_FONT_FACE;
-    }
-    overrideStyle.SetTextColour(*wxBLACK);
-    overrideStyle.SetParagraphSpacingBefore(0);
-    overrideStyle.SetParagraphSpacingAfter(0);
-    if (!loaded) {
+    buffer.SetDefaultStyle(baseStyle);
+    buffer.SetBasicStyle(baseStyle);
+    if (buffer.GetRange().GetLength() > 0) {
+      wxRichTextAttr overrideStyle;
+      long flags = wxTEXT_ATTR_TEXT_COLOUR |
+                   wxTEXT_ATTR_PARAGRAPH_SPACING_BEFORE |
+                   wxTEXT_ATTR_PARAGRAPH_SPACING_AFTER |
+                   wxTEXT_ATTR_FONT_SIZE;
+      if (!faceName.empty()) {
+        overrideStyle.SetFontFaceName(faceName);
+        flags |= wxTEXT_ATTR_FONT_FACE;
+      }
+      overrideStyle.SetTextColour(*wxBLACK);
+      overrideStyle.SetParagraphSpacingBefore(0);
+      overrideStyle.SetParagraphSpacingAfter(0);
       overrideStyle.SetFontSize(layoutviewerpanel::detail::kTextDefaultFontSize);
-      flags |= wxTEXT_ATTR_FONT_SIZE;
+      overrideStyle.SetFlags(flags);
+      buffer.SetStyle(buffer.GetRange(), overrideStyle);
     }
-    overrideStyle.SetFlags(flags);
-    buffer.SetStyle(buffer.GetRange(), overrideStyle);
   }
 
   const int padding = 4;


### PR DESCRIPTION
### Motivation

- Fix loss of rich text formatting and single-line rendering in the Layout Viewer by avoiding unconditional style overrides when rendering text elements so user edits (font, size, alignment, multiline content) are preserved.

### Description

- Apply the default/baseline rich text style only for plain-text fallbacks by moving `SetDefaultStyle`/`SetBasicStyle` and style override logic inside the `if (!loaded)` branch in `RenderTextImage`.
- Ensure default font size is explicitly set for fallback content and include `wxTEXT_ATTR_FONT_SIZE` in the override flags so plain-text paragraphs render with an intended default size.
- Only set face/name/paragraph spacing/font size overrides for the fallback path so already-loaded `richText` content keeps its own formatting when drawn.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696806f490a083249964f72ed48511cb)