### PR TITLE
Fix Layout Viewer text styling and defaults

### DIFF
--- a/gui/layouttextdialog.cpp
+++ b/gui/layouttextdialog.cpp
@@ -121,6 +121,7 @@ LayoutTextDialog::LayoutTextDialog(wxWindow *parent,
     textCtrl->SetFont(sharedFont);
     wxRichTextAttr defaultStyle;
     defaultStyle.SetFont(sharedFont);
+    defaultStyle.SetTextColour(*wxBLACK);
     textCtrl->SetDefaultStyle(defaultStyle);
   }
   textCtrl->SetMinSize(wxSize(580, 280));
@@ -210,7 +211,10 @@ void LayoutTextDialog::ApplyFontSize(int size) {
     wxRichTextRange all(0, textCtrl->GetLastPosition());
     if (all.GetLength() > 0)
       textCtrl->SetStyleEx(all, attr);
-    textCtrl->SetDefaultStyle(attr);
+    wxRichTextAttr defaultStyle = textCtrl->GetDefaultStyle();
+    defaultStyle.SetFontSize(size);
+    defaultStyle.SetFlags(defaultStyle.GetFlags() | wxTEXT_ATTR_FONT_SIZE);
+    textCtrl->SetDefaultStyle(defaultStyle);
   }
 }
 

--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -122,34 +122,30 @@ wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
     }
   }
 
-  if (!loaded) {
-    wxRichTextAttr baseStyle = buffer.GetDefaultStyle();
-    wxString faceName = layoutviewerpanel::detail::ResolveSharedFontFaceName();
-    if (!faceName.empty())
-      baseStyle.SetFontFaceName(faceName);
-    baseStyle.SetTextColour(*wxBLACK);
-    baseStyle.SetParagraphSpacingBefore(0);
-    baseStyle.SetParagraphSpacingAfter(0);
-    baseStyle.SetFontSize(layoutviewerpanel::detail::kTextDefaultFontSize);
-    buffer.SetDefaultStyle(baseStyle);
-    buffer.SetBasicStyle(baseStyle);
-    if (buffer.GetRange().GetLength() > 0) {
-      wxRichTextAttr overrideStyle;
-      long flags = wxTEXT_ATTR_TEXT_COLOUR |
-                   wxTEXT_ATTR_PARAGRAPH_SPACING_BEFORE |
-                   wxTEXT_ATTR_PARAGRAPH_SPACING_AFTER |
-                   wxTEXT_ATTR_FONT_SIZE;
-      if (!faceName.empty()) {
-        overrideStyle.SetFontFaceName(faceName);
-        flags |= wxTEXT_ATTR_FONT_FACE;
-      }
-      overrideStyle.SetTextColour(*wxBLACK);
-      overrideStyle.SetParagraphSpacingBefore(0);
-      overrideStyle.SetParagraphSpacingAfter(0);
-      overrideStyle.SetFontSize(layoutviewerpanel::detail::kTextDefaultFontSize);
-      overrideStyle.SetFlags(flags);
-      buffer.SetStyle(buffer.GetRange(), overrideStyle);
+  wxRichTextAttr baseStyle = buffer.GetDefaultStyle();
+  wxString faceName = layoutviewerpanel::detail::ResolveSharedFontFaceName();
+  if (!faceName.empty())
+    baseStyle.SetFontFaceName(faceName);
+  baseStyle.SetTextColour(*wxBLACK);
+  baseStyle.SetParagraphSpacingBefore(0);
+  baseStyle.SetParagraphSpacingAfter(0);
+  baseStyle.SetFontSize(layoutviewerpanel::detail::kTextDefaultFontSize);
+  buffer.SetDefaultStyle(baseStyle);
+  buffer.SetBasicStyle(baseStyle);
+  if (buffer.GetRange().GetLength() > 0) {
+    wxRichTextAttr overrideStyle;
+    long flags = wxTEXT_ATTR_TEXT_COLOUR |
+                 wxTEXT_ATTR_PARAGRAPH_SPACING_BEFORE |
+                 wxTEXT_ATTR_PARAGRAPH_SPACING_AFTER;
+    if (!faceName.empty()) {
+      overrideStyle.SetFontFaceName(faceName);
+      flags |= wxTEXT_ATTR_FONT_FACE;
     }
+    overrideStyle.SetTextColour(*wxBLACK);
+    overrideStyle.SetParagraphSpacingBefore(0);
+    overrideStyle.SetParagraphSpacingAfter(0);
+    overrideStyle.SetFlags(flags);
+    buffer.SetStyle(buffer.GetRange(), overrideStyle);
   }
 
   const int padding = 4;


### PR DESCRIPTION
### Motivation
- Layout text edited in the `LayoutTextDialog` lost formatting and font-size changes when applied and reopened, and viewer rendering showed incorrect color/outline and sizing compared to the editor and PDF export. 
- The viewer sometimes displayed only the first line or used a larger font than the editor because rendering defaults were not consistently applied. 
- A consistent shared font, black text color, and preservation of per-paragraph font sizes are required so on-screen rendering matches the editor and exported PDFs.

### Description
- Always apply a consistent base style (shared font face, black text color, paragraph spacing) to the `wxRichTextBuffer` used by `RenderTextImage` in `gui/layouttextutils.cpp` so rendered images use the same defaults for loaded and fallback text. 
- Remove the unconditional font-size override when applying the post-load `overrideStyle` so per-paragraph/font-size information in rich text is preserved during rendering. 
- Set the rich text editor default color to black in `LayoutTextDialog` (`gui/layouttextdialog.cpp`) and preserve the editor default style when `ApplyFontSize` is used so changing font size does not reset color or other attributes. 
- Changes touch `gui/layouttextutils.cpp` and `gui/layouttextdialog.cpp` to align editor defaults and image rendering behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69680a8240ec8324bad597465054e477)