### PR TITLE
Fix text rendering scale and transparency in Layout Viewer

### DIFF
--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -85,6 +85,12 @@ wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
     return wxImage();
   }
 
+  const double adjustedScale =
+      renderScale / layoutviewerpanel::detail::kTextRenderScale;
+  if (adjustedScale <= 0.0) {
+    return wxImage();
+  }
+
   wxBitmap bitmap(renderSize.GetWidth(), renderSize.GetHeight(), 32);
   bitmap.UseAlpha();
   wxMemoryDC memoryDc(bitmap);
@@ -129,7 +135,8 @@ wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
   baseStyle.SetTextColour(*wxBLACK);
   baseStyle.SetParagraphSpacingBefore(0);
   baseStyle.SetParagraphSpacingAfter(0);
-  baseStyle.SetFontSize(layoutviewerpanel::detail::kTextDefaultFontSize);
+  if (!loaded)
+    baseStyle.SetFontSize(layoutviewerpanel::detail::kTextDefaultFontSize);
   buffer.SetDefaultStyle(baseStyle);
   buffer.SetBasicStyle(baseStyle);
   if (buffer.GetRange().GetLength() > 0) {
@@ -153,7 +160,7 @@ wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
   const int logicalHeight = std::max(0, logicalSize.GetHeight() - padding * 2);
   wxRect logicalRect(padding, padding, logicalWidth, logicalHeight);
 
-  dc.SetUserScale(renderScale, renderScale);
+  dc.SetUserScale(adjustedScale, adjustedScale);
   wxRichTextDrawingContext context(&buffer);
   wxRichTextSelection selection;
   buffer.Layout(dc, context, logicalRect, logicalRect, wxRICHTEXT_FIXED_WIDTH);

--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1157,11 +1157,24 @@ void LayoutViewerPanel::RebuildCachedTexture() {
 
     std::vector<unsigned char> pixels;
     pixels.resize(static_cast<size_t>(width) * height * 4);
+    const bool needsUnpremultiply = !text.solidBackground;
     for (int i = 0; i < width * height; ++i) {
-      pixels[static_cast<size_t>(i) * 4] = rgb[i * 3];
-      pixels[static_cast<size_t>(i) * 4 + 1] = rgb[i * 3 + 1];
-      pixels[static_cast<size_t>(i) * 4 + 2] = rgb[i * 3 + 2];
-      pixels[static_cast<size_t>(i) * 4 + 3] = alpha ? alpha[i] : 255;
+      const unsigned char a = alpha ? alpha[i] : 255;
+      unsigned char r = rgb[i * 3];
+      unsigned char g = rgb[i * 3 + 1];
+      unsigned char b = rgb[i * 3 + 2];
+      if (needsUnpremultiply && a > 0 && a < 255) {
+        r = static_cast<unsigned char>(
+            std::min(255, static_cast<int>(r) * 255 / a));
+        g = static_cast<unsigned char>(
+            std::min(255, static_cast<int>(g) * 255 / a));
+        b = static_cast<unsigned char>(
+            std::min(255, static_cast<int>(b) * 255 / a));
+      }
+      pixels[static_cast<size_t>(i) * 4] = r;
+      pixels[static_cast<size_t>(i) * 4 + 1] = g;
+      pixels[static_cast<size_t>(i) * 4 + 2] = b;
+      pixels[static_cast<size_t>(i) * 4 + 3] = a;
     }
 
     InitGL();


### PR DESCRIPTION
### Motivation
- Rich text in layout text boxes was rendered at an incorrect scale and lost formatted font sizes when displayed in the Layout Viewer, and transparent backgrounds produced visible halo/outline artifacts.
- The viewer must display WYSIWYG text (matching exported PDF and the editor) and avoid visual artifacts when switching between opaque and transparent backgrounds.

### Description
- Adjusted the rich text rendering scale in `RenderTextImage` so on-screen rendering respects layout units by dividing the incoming `renderScale` by `layoutviewerpanel::detail::kTextRenderScale` and using that value for `dc.SetUserScale`.
- Only apply the default font size (`kTextDefaultFontSize`) when no rich text was loaded, preserving explicit font sizes from saved rich text content.
- When building/uploading text textures in the viewer, unpremultiply color channels for text images that have a transparent background to avoid dark outlining around glyphs before creating the GL texture.
- Changes made in `gui/layouttextutils.cpp` (`RenderTextImage`) and `gui/layoutviewerpanel.cpp` (text image alpha handling and texture upload path).

### Testing
- No automated tests were executed for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69680dbcb36c8324bc25c6866ade1a37)