### PR TITLE
Fix Layout Viewer text box multiline rendering

### DIFF
--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -18,6 +18,7 @@
 #include "layouttextutils.h"
 
 #include <algorithm>
+#include <cmath>
 
 #include <wx/dcgraph.h>
 #include <wx/dcmemory.h>
@@ -156,8 +157,14 @@ wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
   }
 
   const int padding = 4;
-  const int logicalWidth = std::max(0, logicalSize.GetWidth() - padding * 2);
-  const int logicalHeight = std::max(0, logicalSize.GetHeight() - padding * 2);
+  const double logicalScale = layoutviewerpanel::detail::kTextRenderScale;
+  const int logicalWidth = std::max(
+      0, static_cast<int>(std::lround(logicalSize.GetWidth() * logicalScale)) -
+             padding * 2);
+  const int logicalHeight =
+      std::max(0, static_cast<int>(std::lround(logicalSize.GetHeight() *
+                                               logicalScale)) -
+                     padding * 2);
   wxRect logicalRect(padding, padding, logicalWidth, logicalHeight);
 
   dc.SetUserScale(adjustedScale, adjustedScale);


### PR DESCRIPTION
### Motivation
- Layout text boxes were only showing the first line because the logical layout bounds used for text layout were not converted from points to screen pixels, causing `wxRichTextBuffer::Layout` to receive an undersized width and clip wrapped lines.

### Description
- Compute the logical rendering size using `layoutviewerpanel::detail::kTextRenderScale` and convert with `std::lround` to produce correctly scaled `logicalWidth` and `logicalHeight` values.
- Subtract the padding from the scaled dimensions and clamp to zero before building the `wxRect logicalRect` so the rich-text layout receives the intended width for multiline wrapping.
- Add `#include <cmath>` and update `gui/layouttextutils.cpp` to apply the change.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696810f72ed88324818ce791fc9606e3)