### PR TITLE
Fix layout viewer text rendering and UTF-8 accents

### DIFF
--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -131,7 +131,8 @@ wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
 
   wxString plainText = buffer.GetText();
   if (loaded && buffer.GetParagraphCount() <= 1 &&
-      plainText.Find('\n') != wxNOT_FOUND) {
+      (plainText.Find('\n') != wxNOT_FOUND ||
+       plainText.Find('\r') != wxNOT_FOUND)) {
     wxRichTextBuffer normalized;
     normalized.SetDefaultStyle(buffer.GetDefaultStyle());
     wxString normalizedText = plainText;
@@ -154,15 +155,18 @@ wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
   if (!faceName.empty())
     baseStyle.SetFontFaceName(faceName);
   baseStyle.SetTextColour(*wxBLACK);
+  baseStyle.SetFontEncoding(wxFONTENCODING_UTF8);
+  baseStyle.SetFontFamily(wxFONTFAMILY_SWISS);
   baseStyle.SetParagraphSpacingBefore(0);
   baseStyle.SetParagraphSpacingAfter(0);
-  if (!loaded)
+  if (!loaded || baseStyle.GetFontSize() <= 0)
     baseStyle.SetFontSize(layoutviewerpanel::detail::kTextDefaultFontSize);
   buffer.SetDefaultStyle(baseStyle);
   buffer.SetBasicStyle(baseStyle);
   if (buffer.GetRange().GetLength() > 0) {
     wxRichTextAttr overrideStyle;
     long flags = wxTEXT_ATTR_TEXT_COLOUR |
+                 wxTEXT_ATTR_FONT_ENCODING |
                  wxTEXT_ATTR_PARAGRAPH_SPACING_BEFORE |
                  wxTEXT_ATTR_PARAGRAPH_SPACING_AFTER;
     if (!faceName.empty()) {
@@ -170,6 +174,7 @@ wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
       flags |= wxTEXT_ATTR_FONT_FACE;
     }
     overrideStyle.SetTextColour(*wxBLACK);
+    overrideStyle.SetFontEncoding(wxFONTENCODING_UTF8);
     overrideStyle.SetParagraphSpacingBefore(0);
     overrideStyle.SetParagraphSpacingAfter(0);
     overrideStyle.SetFlags(flags);


### PR DESCRIPTION
### Motivation
- The Layout Viewer was only drawing the first line of multi-line text boxes when the rich text buffer contained embedded carriage returns or mixed newline characters.  
- Accented characters were rendered incorrectly (e.g. "Línea" -> "L_nea") due to missing UTF-8 encoding and font hints in the rich text attributes.

### Description
- Normalize rich-text paragraph splitting to treat both `\n` and `\r` when converting a single-buffer text into paragraphs so all lines are rendered (changes in `gui/layouttextutils.cpp`).
- When a loaded buffer has one paragraph but contains `\n` or `\r`, split into multiple paragraphs using `wxStringTokenizer` to preserve line breaks for layout drawing.
- Set the rich-text base and override attributes to use `wxFONTENCODING_UTF8` and a Swiss font family and include `wxTEXT_ATTR_FONT_ENCODING` in the override flags so accents are rendered correctly.
- Ensure a default font size is applied when the buffer lacks a font size by checking `baseStyle.GetFontSize()` and applying `layoutviewerpanel::detail::kTextDefaultFontSize`.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968c526f0108324ba601632a6c538f3)