### PR TITLE
Fix rich text fallback parsing for layout text rendering

### DIFF
--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -57,10 +57,11 @@ bool LoadRichTextBufferFromString(wxRichTextBuffer &buffer,
     return true;
   wxStringInputStream richInput(content);
 #if defined(wxRICHTEXT_TYPE_RICHTEXT)
-  return buffer.LoadFile(richInput, wxRICHTEXT_TYPE_RICHTEXT);
-#else
-  return buffer.LoadFile(richInput, wxRICHTEXT_TYPE_TEXT);
+  if (buffer.LoadFile(richInput, wxRICHTEXT_TYPE_RICHTEXT))
+    return true;
 #endif
+  wxStringInputStream textInput(content);
+  return buffer.LoadFile(textInput, wxRICHTEXT_TYPE_TEXT);
 }
 
 wxString SaveRichTextBufferToString(wxRichTextBuffer &buffer) {
@@ -75,7 +76,7 @@ wxString SaveRichTextBufferToString(wxRichTextBuffer &buffer) {
   if (buffer.SaveFile(richOutput, wxRICHTEXT_TYPE_TEXT))
 #endif
     return richOutput.GetString();
-  return buffer.GetText();
+  return wxEmptyString;
 }
 
 wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,


### PR DESCRIPTION
### Motivation
- Fix cases where rich-text parsing for layout text would fail and leave the viewer with incomplete or corrupted content and prevent invalid rich-text payloads from being persisted.

### Description
- Update `gui/layouttextutils.cpp` so `LoadRichTextBufferFromString` will try XML, then rich-text, and finally a plain-`wxTEXT` fallback, and change `SaveRichTextBufferToString` to return `wxEmptyString` instead of `buffer.GetText()` when serialization to XML/RICHTEXT/TEXT fails.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968c7a8255c83248ae8fdbec1501989)