### PR TITLE
Fix rich text rendering and UTF-8 persistence

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -537,7 +537,7 @@ void ConfigManager::SetSelectedSceneObjects(
 
 bool ConfigManager::LoadFromFile(const std::string &path) {
   RevisionGuard guard(*this);
-  std::ifstream file(path);
+  std::ifstream file(path, std::ios::binary);
   if (!file.is_open())
     return false;
 
@@ -562,7 +562,7 @@ bool ConfigManager::LoadFromFile(const std::string &path) {
 }
 
 bool ConfigManager::SaveToFile(const std::string &path) const {
-  std::ofstream file(path);
+  std::ofstream file(path, std::ios::binary);
   if (!file.is_open())
     return false;
 

--- a/gui/layoutviewerpanel_text.cpp
+++ b/gui/layoutviewerpanel_text.cpp
@@ -103,8 +103,14 @@ void LayoutViewerPanel::OnEditText(wxCommandEvent &) {
                           text->drawFrame);
   if (dialog.ShowModal() != wxID_OK)
     return;
-  text->richText = dialog.GetRichText().ToUTF8().data();
-  text->text = dialog.GetPlainText().ToUTF8().data();
+  wxString updatedRichText = dialog.GetRichText();
+  wxString updatedPlainText = dialog.GetPlainText();
+  if (updatedRichText.empty() && !updatedPlainText.empty()) {
+    updatedRichText = "<richtext><paragraph>" + updatedPlainText +
+                      "</paragraph></richtext>";
+  }
+  text->richText = updatedRichText.ToUTF8().data();
+  text->text = updatedPlainText.ToUTF8().data();
   text->solidBackground = dialog.GetSolidBackground();
   text->drawFrame = dialog.GetDrawFrame();
   if (!currentLayout.name.empty()) {


### PR DESCRIPTION
### Motivation
- Ensure multi-line text in rich text buffers is rendered correctly by inserting paragraph breaks at actual '\n' positions instead of reconstructing buffers manually.
- Stop forcing `wxFONTENCODING_UTF8` on font attributes so wxWidgets can handle Unicode correctly by default.
- Preserve exact UTF-8 bytes when saving and loading configuration JSON files to avoid corruption of accented characters.
- Preserve formatted output when the text editor returns no rich content but plain text was edited.

### Description
- Call `EnsureRichTextHandlers()` early in `RenderTextImage` to guarantee rich text handlers are initialized.
- Replace manual tokenization/normalization of fallback text with a single `buffer.AddParagraph(fallback)` and remove the old normalized-buffer block.
- When the buffer contains embedded CR/LF or LF sequences, iterate over `plainText` and insert paragraph/newline boundaries in-place using `DeleteRange` and `InsertNewlineWithUndo` so paragraph counts match actual lines.
- Change font encoding usage from `wxFONTENCODING_UTF8` to `wxFONTENCODING_DEFAULT` for both `baseStyle` and `overrideStyle` to rely on default Unicode handling.
- In `LayoutViewerPanel::OnEditText`, if `dialog.GetRichText()` is empty but `GetPlainText()` is not, wrap the plain text into a minimal rich-text XML string before storing to `text->richText` so style-preserving code paths are used.
- Open config JSON files in binary mode in `ConfigManager::LoadFromFile` and `ConfigManager::SaveToFile` by using `std::ifstream(path, std::ios::binary)` and `std::ofstream(path, std::ios::binary)` to avoid newline/encoding transformations.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968d0f0548083249db7fcf5b1157fad)