### PR TITLE
Always normalize line breaks when rendering text

### DIFF
--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -122,9 +122,8 @@ wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
   }
 
   wxString plainText = buffer.GetText();
-  if (buffer.GetParagraphCount() <= 1 &&
-      (plainText.Find('\n') != wxNOT_FOUND ||
-       plainText.Find('\r') != wxNOT_FOUND)) {
+  if (plainText.Find('\n') != wxNOT_FOUND ||
+      plainText.Find('\r') != wxNOT_FOUND) {
     for (long i = static_cast<long>(plainText.length()) - 1; i >= 0; --i) {
       if (plainText[i] == '\n') {
         long deleteStart = i;


### PR DESCRIPTION
### Motivation
- Ensure the viewer renders multi-line text correctly by converting raw `\n`/`\r` into rich-text paragraph breaks during `layouttext::RenderTextImage` instead of skipping normalization based on paragraph count.

### Description
- Remove the `buffer.GetParagraphCount()` guard so that when `buffer.GetText()` contains `\n` or `\r`, the code always iterates the text and calls `InsertNewlineWithUndo` to normalize line breaks; the change is in `gui/layouttextutils.cpp` inside `RenderTextImage`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968d55f03448324be5f707ff6843601)