### PR TITLE
Preserve UTF-8 rider text input

### DIFF
--- a/gui/ridertextdialog.cpp
+++ b/gui/ridertextdialog.cpp
@@ -22,6 +22,7 @@
 #include <wx/msgdlg.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
+#include <wx/strconv.h>
 #include <wx/textctrl.h>
 
 #include "projectutils.h"
@@ -132,7 +133,10 @@ void RiderTextDialog::OnLoadExample(wxCommandEvent &WXUNUSED(event)) {
 }
 
 void RiderTextDialog::OnApply(wxCommandEvent &WXUNUSED(event)) {
-  std::string text = textCtrl->GetValue().ToStdString();
+  wxScopedCharBuffer utf8Text = textCtrl->GetValue().ToUTF8();
+  std::string text = utf8Text.data()
+                         ? std::string(utf8Text.data(), utf8Text.length())
+                         : std::string();
   if (!RiderImporter::ImportText(text)) {
     wxMessageBox("Failed to import rider text.", "Error", wxICON_ERROR);
     return;


### PR DESCRIPTION
### Motivation
- Ensure text taken from the rider text editor is preserved as UTF-8 so accented characters (tildes) are not corrupted when passed to the importer.

### Description
- Use `textCtrl->GetValue().ToUTF8()` with `wxScopedCharBuffer` to build an explicit `std::string` in `RiderTextDialog::OnApply`, and add `#include <wx/strconv.h>` to support the conversion.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968d8b4c33883248f49de38d5a22cff)