### PR TITLE
Preserve UTF-8 in layout text serialization

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -198,7 +198,8 @@ LayoutTextExportData BuildLayoutTextExportData(
   wxStringTokenizer tokenizer(plainText, "\n", wxTOKEN_RET_EMPTY_ALL);
   bool wroteLine = false;
   while (tokenizer.HasMoreTokens()) {
-    data.lines.push_back(tokenizer.GetNextToken().ToStdString());
+    wxCharBuffer utf8 = tokenizer.GetNextToken().ToUTF8();
+    data.lines.emplace_back(utf8.data() ? utf8.data() : "");
     wroteLine = true;
   }
   if (!wroteLine)


### PR DESCRIPTION
### Motivation
- Evitar pérdidas o transformaciones de caracteres (por ejemplo tildes) durante el ciclo de edición/guardado/lectura de los cuadros de texto asegurando que se preserve UTF-8 en todo el pipeline.

### Description
- Añadidas las funciones `LoadBufferFromUtf8` y `SaveBufferToUtf8` que usan `wxMemoryInputStream`/`wxMemoryOutputStream` para cargar y guardar `wxRichTextBuffer` sin conversiones de locale en `gui/layouttextutils.cpp`.
- Reemplazada la lectura/escritura previa basada en `wxStringInputStream`/`wxStringOutputStream` por las nuevas funciones en `LoadRichTextBufferFromString` y `SaveRichTextBufferToString` para forzar manejo UTF-8.
- En `BuildLayoutTextExportData` se cambió la serialización de líneas para usar `ToUTF8()` y `wxCharBuffer` en lugar de `ToStdString()` para garantizar que las líneas exportadas se codifiquen en UTF-8.
- Incluidos `wx/mstream.h` y `cstring` y mínimos ajustes en `gui/layouttextutils.cpp` y `gui/mainwindow.cpp` para soportar los cambios anteriores.

### Testing
- No se ejecutaron pruebas automatizadas durante este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968db4509f4832487ba82adc1fe259c)