### PR TITLE
Fix rich text stream handler selection

### DIFF
--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -48,12 +48,18 @@ bool LoadBufferFromUtf8(wxRichTextBuffer &buffer, const wxString &content,
     return false;
   const size_t size = std::strlen(data);
   wxMemoryInputStream input(data, size);
-  return buffer.LoadFile(input, format);
+  wxRichTextFileHandler *handler = wxRichTextBuffer::FindHandler(format);
+  if (!handler)
+    return false;
+  return buffer.LoadFile(input, handler);
 }
 
 wxString SaveBufferToUtf8(wxRichTextBuffer &buffer, int format) {
   wxMemoryOutputStream output;
-  if (!buffer.SaveFile(output, format))
+  wxRichTextFileHandler *handler = wxRichTextBuffer::FindHandler(format);
+  if (!handler)
+    return wxEmptyString;
+  if (!buffer.SaveFile(output, handler))
     return wxEmptyString;
   const size_t size = output.GetSize();
   if (size == 0)


### PR DESCRIPTION
### Motivation
- Address compilation errors (C2665) caused by calling the stream overloads of `wxRichTextBuffer::LoadFile`/`SaveFile` with integer format constants by resolving and using the appropriate `wxRichTextFileHandler` for the requested format.

### Description
- Update `LoadBufferFromUtf8` and `SaveBufferToUtf8` to call `wxRichTextBuffer::FindHandler(format)` and pass the resulting `wxRichTextFileHandler*` to `buffer.LoadFile`/`buffer.SaveFile`, returning early if no handler is found.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968e4b15e00832496a614283a2270c4)