### PR TITLE
Use format-based wxRichTextBuffer LoadFile/SaveFile to avoid handler lookup errors

### DIFF
--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -48,18 +48,12 @@ bool LoadBufferFromUtf8(wxRichTextBuffer &buffer, const wxString &content,
     return false;
   const size_t size = std::strlen(data);
   wxMemoryInputStream input(data, size);
-  wxRichTextFileHandler *handler = wxRichTextBuffer::FindHandler(format);
-  if (!handler)
-    return false;
-  return buffer.LoadFile(input, handler);
+  return buffer.LoadFile(input, format);
 }
 
 wxString SaveBufferToUtf8(wxRichTextBuffer &buffer, int format) {
   wxMemoryOutputStream output;
-  wxRichTextFileHandler *handler = wxRichTextBuffer::FindHandler(format);
-  if (!handler)
-    return wxEmptyString;
-  if (!buffer.SaveFile(output, handler))
+  if (!buffer.SaveFile(output, format))
     return wxEmptyString;
   const size_t size = output.GetSize();
   if (size == 0)


### PR DESCRIPTION
### Motivation
- Fix build/runtime issues caused by using `wxRichTextBuffer::FindHandler` and handler pointers when loading/saving rich text streams by switching to the format-based stream overloads.

### Description
- Replace handler lookup and handler-based calls with `buffer.LoadFile(input, format)` and `buffer.SaveFile(output, format)` in `gui/layouttextutils.cpp` to simplify UTF-8 serialization path.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968e99094248324a955dce356d651dc)