### PR TITLE
Fix rich text buffer stream handling

### DIFF
--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -48,12 +48,20 @@ bool LoadBufferFromUtf8(wxRichTextBuffer &buffer, const wxString &content,
     return false;
   const size_t size = std::strlen(data);
   wxMemoryInputStream input(data, size);
-  return buffer.LoadFile(input, format);
+  wxRichTextFileHandler *handler =
+      wxRichTextBuffer::GetHandler(static_cast<wxRichTextFileType>(format));
+  if (!handler)
+    return false;
+  return handler->LoadFile(&buffer, input);
 }
 
 wxString SaveBufferToUtf8(wxRichTextBuffer &buffer, int format) {
   wxMemoryOutputStream output;
-  if (!buffer.SaveFile(output, format))
+  wxRichTextFileHandler *handler =
+      wxRichTextBuffer::GetHandler(static_cast<wxRichTextFileType>(format));
+  if (!handler)
+    return wxEmptyString;
+  if (!handler->SaveFile(&buffer, output))
     return wxEmptyString;
   const size_t size = output.GetSize();
   if (size == 0)


### PR DESCRIPTION
### Motivation
- Resolve compilation errors from incompatible overloads of `wxRichTextBuffer::LoadFile`/`SaveFile` by using the explicit file handler API. 
- Improve compatibility with wxWidgets stream-based rich text handlers while keeping the existing UTF-8 conversion logic.

### Description
- Replace direct calls to `buffer.LoadFile(input, format)` and `buffer.SaveFile(output, format)` with handler-based calls using `wxRichTextBuffer::GetHandler(static_cast<wxRichTextFileType>(format))`.
- Call `handler->LoadFile(&buffer, input)` and `handler->SaveFile(&buffer, output)` to perform stream IO and add null checks for missing handlers.
- Preserve existing `wxMemoryInputStream`/`wxMemoryOutputStream` usage and UTF-8 conversion and maintain the existing early-return behavior on empty results.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968ea1f15388324a35005842f712f8b)