### PR TITLE
Fix rich text handler lookup in layouttextutils.cpp

### DIFF
--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -49,7 +49,7 @@ bool LoadBufferFromUtf8(wxRichTextBuffer &buffer, const wxString &content,
   const size_t size = std::strlen(data);
   wxMemoryInputStream input(data, size);
   wxRichTextFileHandler *handler =
-      wxRichTextBuffer::GetHandler(static_cast<wxRichTextFileType>(format));
+      wxRichTextBuffer::FindHandler(static_cast<wxRichTextFileType>(format));
   if (!handler)
     return false;
   return handler->LoadFile(&buffer, input);
@@ -58,7 +58,7 @@ bool LoadBufferFromUtf8(wxRichTextBuffer &buffer, const wxString &content,
 wxString SaveBufferToUtf8(wxRichTextBuffer &buffer, int format) {
   wxMemoryOutputStream output;
   wxRichTextFileHandler *handler =
-      wxRichTextBuffer::GetHandler(static_cast<wxRichTextFileType>(format));
+      wxRichTextBuffer::FindHandler(static_cast<wxRichTextFileType>(format));
   if (!handler)
     return wxEmptyString;
   if (!handler->SaveFile(&buffer, output))


### PR DESCRIPTION
### Motivation
- Replace use of `wxRichTextBuffer::GetHandler` because some wxWidgets versions do not provide it, which caused build errors when looking up rich text file handlers.

### Description
- Replace `wxRichTextBuffer::GetHandler(...)` with `wxRichTextBuffer::FindHandler(...)` in `LoadBufferFromUtf8` and `SaveBufferToUtf8` in `gui/layouttextutils.cpp`.

### Testing
- No automated tests were run after this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968eaf7bcf4832491572c8c700fd12a)