### PR TITLE
Fix UTF-8 handling for layout text boxes

### DIFF
--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -46,7 +46,9 @@ bool LoadBufferFromUtf8(wxRichTextBuffer &buffer, const wxString &content,
   const char *data = utf8.data();
   if (!data)
     return false;
-  const size_t size = std::strlen(data);
+  const size_t size = utf8.length();
+  if (size == 0)
+    return false;
   wxMemoryInputStream input(data, size);
   wxRichTextFileHandler *handler =
       wxRichTextBuffer::FindHandler(static_cast<wxRichTextFileType>(format));
@@ -145,12 +147,14 @@ wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
   bool loaded = false;
   if (!text.richText.empty()) {
     loaded = LoadRichTextBufferFromString(
-        buffer, wxString::FromUTF8(text.richText));
+        buffer, wxString::FromUTF8(text.richText.data(),
+                                   text.richText.size()));
   }
   if (!loaded) {
     wxString fallback =
         text.text.empty() ? wxString("Light Plot")
-                          : wxString::FromUTF8(text.text);
+                          : wxString::FromUTF8(text.text.data(),
+                                               text.text.size());
     buffer.AddParagraph(fallback);
   }
 

--- a/gui/layoutviewerpanel_text.cpp
+++ b/gui/layoutviewerpanel_text.cpp
@@ -95,10 +95,12 @@ void LayoutViewerPanel::OnEditText(wxCommandEvent &) {
   layouts::LayoutTextDefinition *text = GetSelectedText();
   if (!text)
     return;
-  const wxString richText = wxString::FromUTF8(text->richText);
+  const wxString richText =
+      wxString::FromUTF8(text->richText.data(), text->richText.size());
   const wxString fallbackText =
       text->text.empty() ? wxString("Light Plot")
-                         : wxString::FromUTF8(text->text);
+                         : wxString::FromUTF8(text->text.data(),
+                                              text->text.size());
   LayoutTextDialog dialog(this, richText, fallbackText, text->solidBackground,
                           text->drawFrame);
   if (dialog.ShowModal() != wxID_OK)
@@ -109,8 +111,12 @@ void LayoutViewerPanel::OnEditText(wxCommandEvent &) {
     updatedRichText = "<richtext><paragraph>" + updatedPlainText +
                       "</paragraph></richtext>";
   }
-  text->richText = updatedRichText.ToUTF8().data();
-  text->text = updatedPlainText.ToUTF8().data();
+  wxScopedCharBuffer richBuf = updatedRichText.ToUTF8();
+  wxScopedCharBuffer plainBuf = updatedPlainText.ToUTF8();
+  text->richText.assign(richBuf.data() ? richBuf.data() : "",
+                        richBuf.length());
+  text->text.assign(plainBuf.data() ? plainBuf.data() : "",
+                    plainBuf.length());
   text->solidBackground = dialog.GetSolidBackground();
   text->drawFrame = dialog.GetDrawFrame();
   if (!currentLayout.name.empty()) {

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -154,7 +154,8 @@ LayoutTextExportData BuildLayoutTextExportData(
   bool loaded = false;
   if (!text.richText.empty()) {
     loaded = layouttext::LoadRichTextBufferFromString(
-        buffer, wxString::FromUTF8(text.richText));
+        buffer, wxString::FromUTF8(text.richText.data(),
+                                   text.richText.size()));
   }
 
   wxString plainText;
@@ -163,7 +164,8 @@ LayoutTextExportData BuildLayoutTextExportData(
   }
   if (plainText.empty()) {
     plainText = text.text.empty() ? wxString("Light Plot")
-                                  : wxString::FromUTF8(text.text);
+                                  : wxString::FromUTF8(text.text.data(),
+                                                       text.text.size());
   }
   plainText.Replace("\r\n", "\n");
   plainText.Replace("\r", "\n");


### PR DESCRIPTION
### Motivation
- Prevent loss or replacement of accented characters when editing, rendering or exporting layout text by ensuring UTF-8 byte sequences are handled with explicit lengths instead of relying on C-string termination or implicit conversions.
- Ensure the text shown in the rich text editor is stored and exported exactly as edited (round-trip preservation of UTF-8 rich/plain text).

### Description
- Use the full `wxCharBuffer::length()` instead of `strlen()` when constructing input streams for rich text handlers and return early on zero-length to avoid passing an incorrect size (`gui/layouttextutils.cpp`).
- Load rich text and fallback plain text using `wxString::FromUTF8(data, size)` with explicit data/size to avoid truncation or incorrect conversion (`gui/layouttextutils.cpp`, `gui/mainwindow.cpp`, `gui/layoutviewerpanel_text.cpp`).
- When saving edited text from the dialog, obtain UTF-8 buffers via `ToUTF8()` and assign to `std::string` with the explicit buffer length to preserve all bytes (`gui/layoutviewerpanel_text.cpp`).
- Changes applied to `gui/layouttextutils.cpp`, `gui/layoutviewerpanel_text.cpp` and `gui/mainwindow.cpp` to centralize and fix UTF-8 handling for layout text flows.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968ec1d5fb88324adb1a3f7dc627eb3)