### PR TITLE
Fix layout text newline handling and UTF-8 encoding

### DIFF
--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -162,19 +162,18 @@ wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
   if (buffer.GetParagraphCount() <= 1 &&
       (plainText.Find('\n') != wxNOT_FOUND ||
        plainText.Find('\r') != wxNOT_FOUND)) {
-    for (long i = static_cast<long>(plainText.length()) - 1; i >= 0; --i) {
-      if (plainText[i] == '\n') {
-        long deleteStart = i;
-        if (i > 0 && plainText[i - 1] == '\r') {
-          deleteStart = i - 1;
-          --i;
-        }
-        buffer.DeleteRange(wxRichTextRange(deleteStart, i));
-        buffer.InsertNewlineWithUndo(deleteStart, nullptr);
-      } else if (plainText[i] == '\r') {
-        buffer.DeleteRange(wxRichTextRange(i, i));
-        buffer.InsertNewlineWithUndo(i, nullptr);
+    wxArrayString lines;
+    if (plainText.empty()) {
+      lines.Add(wxString());
+    } else {
+      wxStringTokenizer tokenizer(plainText, "\r\n", wxTOKEN_RET_EMPTY);
+      while (tokenizer.HasMoreTokens()) {
+        lines.Add(tokenizer.GetNextToken());
       }
+    }
+    buffer.Clear();
+    for (const auto &line : lines) {
+      buffer.AddParagraph(line);
     }
   }
 
@@ -183,7 +182,7 @@ wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
   if (!faceName.empty())
     baseStyle.SetFontFaceName(faceName);
   baseStyle.SetTextColour(*wxBLACK);
-  baseStyle.SetFontEncoding(wxFONTENCODING_DEFAULT);
+  baseStyle.SetFontEncoding(wxFONTENCODING_UTF8);
   baseStyle.SetFontFamily(wxFONTFAMILY_SWISS);
   baseStyle.SetParagraphSpacingBefore(0);
   baseStyle.SetParagraphSpacingAfter(0);
@@ -202,7 +201,7 @@ wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
       flags |= wxTEXT_ATTR_FONT_FACE;
     }
     overrideStyle.SetTextColour(*wxBLACK);
-    overrideStyle.SetFontEncoding(wxFONTENCODING_DEFAULT);
+    overrideStyle.SetFontEncoding(wxFONTENCODING_UTF8);
     overrideStyle.SetParagraphSpacingBefore(0);
     overrideStyle.SetParagraphSpacingAfter(0);
     overrideStyle.SetFlags(flags);


### PR DESCRIPTION
### Motivation

- The previous `RenderTextImage` logic attempted to correct embedded line breaks by mutating the `wxRichTextBuffer` with index-based `DeleteRange()`/`InsertNewlineWithUndo()` which dropped lines when there were multiple breaks. 
- The rich text styles were using `wxFONTENCODING_DEFAULT`, causing non-ASCII characters (e.g. accented letters) to render incorrectly when loading XML-rich text.

### Description

- Replaced the fragile index-based newline fix in `RenderTextImage` with a stable approach that reads `buffer.GetText()`, tokenizes by `\r`/`\n` via `wxStringTokenizer`, clears the buffer and rebuilds paragraphs using `buffer.AddParagraph()` so every line becomes its own paragraph.
- Set the rich text base and override styles to `SetFontEncoding(wxFONTENCODING_UTF8)` so text loaded via the rich text XML handler preserves UTF-8 characters.
- Kept the override style flags limited to `wxTEXT_ATTR_TEXT_COLOUR`, `wxTEXT_ATTR_FONT_ENCODING`, `wxTEXT_ATTR_PARAGRAPH_SPACING_BEFORE`, `wxTEXT_ATTR_PARAGRAPH_SPACING_AFTER`, and optionally `wxTEXT_ATTR_FONT_FACE`, to preserve user-chosen font attributes instead of forcing weight/style.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969250c8de08324939ca885255e20f9)