### PR TITLE
Fix rich text dialog encoding and multiline plain-text fallback

### DIFF
--- a/gui/layouttextdialog.cpp
+++ b/gui/layouttextdialog.cpp
@@ -117,13 +117,16 @@ LayoutTextDialog::LayoutTextDialog(wxWindow *parent,
                                 wxTE_MULTILINE | wxTE_RICH2);
   wxFont sharedFont = layoutviewerpanel::detail::MakeSharedFont(
       layoutviewerpanel::detail::kTextDefaultFontSize, wxFONTWEIGHT_NORMAL);
+  wxRichTextAttr defaultStyle;
   if (sharedFont.IsOk()) {
     textCtrl->SetFont(sharedFont);
-    wxRichTextAttr defaultStyle;
     defaultStyle.SetFont(sharedFont);
-    defaultStyle.SetTextColour(*wxBLACK);
-    textCtrl->SetDefaultStyle(defaultStyle);
   }
+  defaultStyle.SetTextColour(*wxBLACK);
+  defaultStyle.SetFontEncoding(wxFONTENCODING_UTF8);
+  textCtrl->SetDefaultStyle(defaultStyle);
+  textCtrl->GetBuffer().SetDefaultStyle(defaultStyle);
+  textCtrl->GetBuffer().SetBasicStyle(defaultStyle);
   textCtrl->SetMinSize(wxSize(580, 280));
   mainSizer->Add(textCtrl, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 8);
 
@@ -148,7 +151,7 @@ wxString LayoutTextDialog::GetRichText() const {
 }
 
 wxString LayoutTextDialog::GetPlainText() const {
-  return textCtrl ? textCtrl->GetValue() : wxString();
+  return textCtrl ? textCtrl->GetBuffer().GetText() : wxString();
 }
 
 bool LayoutTextDialog::GetSolidBackground() const {

--- a/gui/layoutviewerpanel_text.cpp
+++ b/gui/layoutviewerpanel_text.cpp
@@ -22,6 +22,9 @@
 
 #include <GL/gl.h>
 
+#include <wx/richtext/richtextbuffer.h>
+#include <wx/tokenzr.h>
+
 #include "layouttextdialog.h"
 #include "layouttextutils.h"
 #include "layoutviewerpanel_shared.h"
@@ -89,6 +92,21 @@ void LayoutViewerPanel::UpdateTextFrame(const layouts::Layout2DViewFrame &frame,
   Refresh();
 }
 
+namespace {
+wxString BuildRichTextFromPlainText(const wxString &plainText) {
+  if (plainText.empty())
+    return wxEmptyString;
+  wxRichTextBuffer buffer;
+  wxStringTokenizer tokenizer(plainText, "\r\n", wxTOKEN_RET_EMPTY);
+  while (tokenizer.HasMoreTokens()) {
+    buffer.AddParagraph(tokenizer.GetNextToken());
+  }
+  if (buffer.GetParagraphCount() == 0)
+    buffer.AddParagraph(wxString());
+  return layouttext::SaveRichTextBufferToString(buffer);
+}
+} // namespace
+
 void LayoutViewerPanel::OnEditText(wxCommandEvent &) {
   if (selectedElementType != SelectedElementType::Text)
     return;
@@ -108,8 +126,7 @@ void LayoutViewerPanel::OnEditText(wxCommandEvent &) {
   wxString updatedRichText = dialog.GetRichText();
   wxString updatedPlainText = dialog.GetPlainText();
   if (updatedRichText.empty() && !updatedPlainText.empty()) {
-    updatedRichText = "<richtext><paragraph>" + updatedPlainText +
-                      "</paragraph></richtext>";
+    updatedRichText = BuildRichTextFromPlainText(updatedPlainText);
   }
   wxScopedCharBuffer richBuf = updatedRichText.ToUTF8();
   wxScopedCharBuffer plainBuf = updatedPlainText.ToUTF8();


### PR DESCRIPTION
### Motivation
- Preserve accented characters and other UTF-8 text entered in the text editor by ensuring the rich text buffer uses UTF-8 encoding.
- Keep paragraph breaks when a user edits a text box so the editor does not discard content after the first newline.
- Ensure font attributes and other styles applied in the editor are retained when the dialog is accepted by synchronizing default/basic styles with the buffer.

### Description
- Set a `wxRichTextAttr` default style with `wxFONTENCODING_UTF8` and apply it to the `wxRichTextCtrl` and its underlying `wxRichTextBuffer` using `SetDefaultStyle` and `SetBasicStyle` in `gui/layouttextdialog.cpp`.
- Read plain text from the underlying buffer via `GetBuffer().GetText()` in `LayoutTextDialog::GetPlainText()` to preserve newlines and full content.
- Add `BuildRichTextFromPlainText()` in `gui/layoutviewerpanel_text.cpp` that tokenizes multiline plain text into paragraphs using `wxStringTokenizer` and `wxRichTextBuffer`, and use it as the fallback when the dialog returns empty rich text.
- Add necessary includes (`<wx/richtext/richtextbuffer.h>`, `<wx/tokenzr.h>`) and adjust where `defaultStyle` is created/applied; changes touch `gui/layouttextdialog.cpp` and `gui/layoutviewerpanel_text.cpp`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696929be9f0c8324880039782f3061e7)