### PR TITLE
Fix layout text rich text persistence

### DIFF
--- a/gui/layouttextdialog.cpp
+++ b/gui/layouttextdialog.cpp
@@ -117,6 +117,7 @@ LayoutTextDialog::LayoutTextDialog(wxWindow *parent,
                                 wxTE_MULTILINE | wxTE_RICH2);
   wxFont sharedFont = layoutviewerpanel::detail::MakeSharedFont(
       layoutviewerpanel::detail::kTextDefaultFontSize, wxFONTWEIGHT_NORMAL);
+  sharedFont.SetEncoding(wxFONTENCODING_UTF8);
   wxRichTextAttr defaultStyle;
   if (sharedFont.IsOk()) {
     textCtrl->SetFont(sharedFont);
@@ -124,6 +125,7 @@ LayoutTextDialog::LayoutTextDialog(wxWindow *parent,
   }
   defaultStyle.SetTextColour(*wxBLACK);
   defaultStyle.SetFontEncoding(wxFONTENCODING_UTF8);
+  defaultStyle.SetFlags(defaultStyle.GetFlags() | wxTEXT_ATTR_FONT_ENCODING);
   textCtrl->SetDefaultStyle(defaultStyle);
   textCtrl->GetBuffer().SetDefaultStyle(defaultStyle);
   textCtrl->GetBuffer().SetBasicStyle(defaultStyle);

--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -106,8 +106,6 @@ wxString SaveRichTextBufferToString(wxRichTextBuffer &buffer) {
     return output;
 #if defined(wxRICHTEXT_TYPE_RICHTEXT)
   output = SaveBufferToUtf8(buffer, wxRICHTEXT_TYPE_RICHTEXT);
-#else
-  output = SaveBufferToUtf8(buffer, wxRICHTEXT_TYPE_TEXT);
 #endif
   if (!output.empty())
     return output;

--- a/gui/layoutviewerpanel_text.cpp
+++ b/gui/layoutviewerpanel_text.cpp
@@ -23,7 +23,6 @@
 #include <GL/gl.h>
 
 #include <wx/richtext/richtextbuffer.h>
-#include <wx/tokenzr.h>
 
 #include "layouttextdialog.h"
 #include "layouttextutils.h"
@@ -92,21 +91,6 @@ void LayoutViewerPanel::UpdateTextFrame(const layouts::Layout2DViewFrame &frame,
   Refresh();
 }
 
-namespace {
-wxString BuildRichTextFromPlainText(const wxString &plainText) {
-  if (plainText.empty())
-    return wxEmptyString;
-  wxRichTextBuffer buffer;
-  wxStringTokenizer tokenizer(plainText, "\r\n", wxTOKEN_RET_EMPTY);
-  while (tokenizer.HasMoreTokens()) {
-    buffer.AddParagraph(tokenizer.GetNextToken());
-  }
-  if (buffer.GetParagraphCount() == 0)
-    buffer.AddParagraph(wxString());
-  return layouttext::SaveRichTextBufferToString(buffer);
-}
-} // namespace
-
 void LayoutViewerPanel::OnEditText(wxCommandEvent &) {
   if (selectedElementType != SelectedElementType::Text)
     return;
@@ -125,9 +109,6 @@ void LayoutViewerPanel::OnEditText(wxCommandEvent &) {
     return;
   wxString updatedRichText = dialog.GetRichText();
   wxString updatedPlainText = dialog.GetPlainText();
-  if (updatedRichText.empty() && !updatedPlainText.empty()) {
-    updatedRichText = BuildRichTextFromPlainText(updatedPlainText);
-  }
   wxScopedCharBuffer richBuf = updatedRichText.ToUTF8();
   wxScopedCharBuffer plainBuf = updatedPlainText.ToUTF8();
   text->richText.assign(richBuf.data() ? richBuf.data() : "",


### PR DESCRIPTION
### Motivation
- Rich text entered in the layout text editor could lose accented characters, paragraph breaks and font attributes when saved and rendered.  
- The editor did not force UTF-8 encoding on the font/style, causing diacritics to be mangled during buffer serialization.  
- The save/load pipeline fell back to plain text and rebuilt XML from plain text, which stripped style runs and collapsed multi-line content.

### Description
- Enforce UTF-8 on the editor font and default style in `gui/layouttextdialog.cpp` by calling `sharedFont.SetEncoding(wxFONTENCODING_UTF8)` and setting the default style encoding and flag.  
- Stop rebuilding rich text from plain text in `gui/layoutviewerpanel_text.cpp` by removing the `BuildRichTextFromPlainText` helper and the code path that wrapped plain text into a single `<paragraph>`.  
- Improve serialization in `gui/layouttextutils.cpp` by removing the final fallback to plain text and preferring `wxRICHTEXT_TYPE_RICHTEXT` when `wxRICHTEXT_TYPE_XML` fails, so style runs are preserved.  
- Minor cleanup: removed an unused include (`wx/tokenzr.h`) after deleting the plain-text tokenizer helper.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69692d6d1bac832480e0fdd198965ed0)