### PR TITLE
Limit UTF-8 font setup to layout text dialog

### DIFF
--- a/gui/layouttextdialog.h
+++ b/gui/layouttextdialog.h
@@ -39,6 +39,7 @@ private:
   wxBitmapBundle LoadIcon(const std::string &name) const;
   void LoadInitialContent(const wxString &initialRichText,
                           const wxString &fallbackText);
+  void ApplyDefaultFontStyle();
   void ApplyBold();
   void ApplyItalic();
   void ApplyFontSize(int size);

--- a/gui/layoutviewerpanel_shared.h
+++ b/gui/layoutviewerpanel_shared.h
@@ -67,5 +67,6 @@ inline wxFont MakeSharedFont(int sizePx, wxFontWeight weight) {
   }
   return wxFont(sizePx, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL, weight);
 }
+
 } // namespace detail
 } // namespace layoutviewerpanel


### PR DESCRIPTION
### Motivation
- Avoid changing global UI fonts and encodings while ensuring text boxes in layouts consistently use a shared UTF-8 font to prevent font prompts and mismatches.

### Description
- Remove the previous global UI font/encoding setup and the `MakeDefaultUIFont()` usage so the rest of the application UI remains unchanged.
- Add `ApplyDefaultFontStyle()` to `LayoutTextDialog` and declare it in `gui/layouttextdialog.h` to centralize font/encoding logic for layout text editing.
- `ApplyDefaultFontStyle()` uses `layoutviewerpanel::detail::MakeSharedFont()` with an `Arial` fallback, forces `wxFONTENCODING_UTF8`, sets the `wxRichTextAttr` default style on the control and applies an override style to the buffer range so existing content adopts the shared font/UTF-8 encoding.
- Call `ApplyDefaultFontStyle()` when creating the `wxRichTextCtrl` and after loading initial content so layout text boxes consistently use the shared font/UTF-8 without touching splash/main window/startup code.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69692efacb8483249476443bbadcd6ec)