### PR TITLE
Avoid UTF-8 font prompt in text editor

### DIFF
--- a/gui/layouttextdialog.cpp
+++ b/gui/layouttextdialog.cpp
@@ -191,8 +191,6 @@ void LayoutTextDialog::ApplyDefaultFontStyle() {
                         wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL,
                         wxFONTWEIGHT_NORMAL, false, "Arial");
   }
-  sharedFont.SetEncoding(wxFONTENCODING_UTF8);
-
   wxRichTextAttr defaultStyle = textCtrl->GetDefaultStyle();
   if (sharedFont.IsOk()) {
     textCtrl->SetFont(sharedFont);
@@ -200,10 +198,8 @@ void LayoutTextDialog::ApplyDefaultFontStyle() {
     defaultStyle.SetFontFaceName(sharedFont.GetFaceName());
   }
   defaultStyle.SetTextColour(*wxBLACK);
-  defaultStyle.SetFontEncoding(wxFONTENCODING_UTF8);
   defaultStyle.SetFontFamily(wxFONTFAMILY_SWISS);
-  defaultStyle.SetFlags(defaultStyle.GetFlags() | wxTEXT_ATTR_FONT_ENCODING |
-                        wxTEXT_ATTR_FONT_FAMILY);
+  defaultStyle.SetFlags(defaultStyle.GetFlags() | wxTEXT_ATTR_FONT_FAMILY);
   if (sharedFont.IsOk()) {
     defaultStyle.SetFlags(defaultStyle.GetFlags() | wxTEXT_ATTR_FONT_FACE);
   }
@@ -216,10 +212,8 @@ void LayoutTextDialog::ApplyDefaultFontStyle() {
     return;
   wxRichTextAttr overrideStyle;
   overrideStyle.SetTextColour(*wxBLACK);
-  overrideStyle.SetFontEncoding(wxFONTENCODING_UTF8);
   overrideStyle.SetFontFamily(wxFONTFAMILY_SWISS);
-  long flags = wxTEXT_ATTR_TEXT_COLOUR | wxTEXT_ATTR_FONT_ENCODING |
-               wxTEXT_ATTR_FONT_FAMILY;
+  long flags = wxTEXT_ATTR_TEXT_COLOUR | wxTEXT_ATTR_FONT_FAMILY;
   if (sharedFont.IsOk()) {
     overrideStyle.SetFont(sharedFont);
     overrideStyle.SetFontFaceName(sharedFont.GetFaceName());


### PR DESCRIPTION
### Motivation
- Prevent the recurring "No font for displaying text in encoding Unicode 8 bit (UTF-8) found" prompt when first editing a text box by not forcing UTF-8 font encoding while still preferring a shared/default face (e.g. Arial fallback).

### Description
- Stop calling `SetEncoding(wxFONTENCODING_UTF8)` and remove `wxTEXT_ATTR_FONT_ENCODING` from default/override style flags in `LayoutTextDialog::ApplyDefaultFontStyle()` so the shared font face/family (via `MakeSharedFont(...)`) is applied without forcing an encoding.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969337a2480832487025fd1f17e89b9)