### PR TITLE
Fix multiline text rendering in layout viewer

### DIFF
--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -160,18 +160,16 @@ wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
   if (buffer.GetParagraphCount() <= 1 &&
       (plainText.Find('\n') != wxNOT_FOUND ||
        plainText.Find('\r') != wxNOT_FOUND)) {
-    wxArrayString lines;
-    if (plainText.empty()) {
-      lines.Add(wxString());
-    } else {
-      wxStringTokenizer tokenizer(plainText, "\r\n", wxTOKEN_RET_EMPTY);
-      while (tokenizer.HasMoreTokens()) {
-        lines.Add(tokenizer.GetNextToken());
-      }
-    }
+    plainText.Replace("\r\n", "\n");
+    plainText.Replace("\r", "\n");
     buffer.Clear();
-    for (const auto &line : lines) {
-      buffer.AddParagraph(line);
+    if (plainText.empty()) {
+      buffer.AddParagraph(wxString());
+    } else {
+      wxStringTokenizer tokenizer(plainText, "\n", wxTOKEN_RET_EMPTY_ALL);
+      while (tokenizer.HasMoreTokens()) {
+        buffer.AddParagraph(tokenizer.GetNextToken());
+      }
     }
   }
 


### PR DESCRIPTION
### Motivation
- The layout viewer only rendered the first line of multi-line text due to incorrect newline splitting and token retention in `RenderTextImage`.
- The previous tokenizer split on `"\r"` and `"\n"` separately and discarded empty tokens, causing blank-line handling issues and lost lines.
- The goal is to normalize newline sequences and split on `"\n"` while preserving empty lines so each logical line becomes a paragraph for rendering.

### Description
- Normalize newline sequences in `RenderTextImage` by calling `plainText.Replace("\r\n", "\n"); plainText.Replace("\r", "\n");` before splitting.
- Replace the old tokenizer with `wxStringTokenizer tokenizer(plainText, "\n", wxTOKEN_RET_EMPTY_ALL)` and add each token as a paragraph directly to the `wxRichTextBuffer` so every line (including blank ones) is represented.
- Remove the intermediate `wxArrayString` and the previous `"\r\n"` tokenizer usage; update `gui/layouttextutils.cpp` accordingly.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69693e5c0b3c83249b27f576e5f00d84)