### PR TITLE
Fix layout viewer multiline text rendering

### DIFF
--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -218,9 +218,10 @@ wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
   dc.SetUserScale(adjustedScale, adjustedScale);
   wxRichTextDrawingContext context(&buffer);
   wxRichTextSelection selection;
-  buffer.Layout(dc, context, logicalRect, logicalRect,
-                wxRICHTEXT_FIXED_WIDTH | wxRICHTEXT_FIXED_HEIGHT);
+  buffer.Layout(dc, context, logicalRect, logicalRect, wxRICHTEXT_FIXED_WIDTH);
+  dc.SetClippingRegion(logicalRect);
   buffer.Draw(dc, context, buffer.GetRange(), selection, logicalRect, 0, 0);
+  dc.DestroyClippingRegion();
 
   memoryDc.SelectObject(wxNullBitmap);
   wxImage image = bitmap.ConvertToImage();


### PR DESCRIPTION
### Motivation
- The layout viewer was only showing the first line of multi-line text because rich-text layout was constrained and drawing could overflow the text frame without proper clipping.

### Description
- Change `buffer.Layout` to use `wxRICHTEXT_FIXED_WIDTH` only and add a drawing clip by calling `dc.SetClippingRegion(logicalRect)` before `buffer.Draw` and `dc.DestroyClippingRegion()` after, in `gui/layouttextutils.cpp` so full multi-line content is laid out and rendered clipped to the frame.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969436e841083249d61e276efb43115)