### PR TITLE
Fix multiline layout text rendering

### DIFF
--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -156,23 +156,6 @@ wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
     buffer.AddParagraph(fallback);
   }
 
-  wxString plainText = buffer.GetText();
-  if (buffer.GetParagraphCount() <= 1 &&
-      (plainText.Find('\n') != wxNOT_FOUND ||
-       plainText.Find('\r') != wxNOT_FOUND)) {
-    plainText.Replace("\r\n", "\n");
-    plainText.Replace("\r", "\n");
-    buffer.Clear();
-    if (plainText.empty()) {
-      buffer.AddParagraph(wxString());
-    } else {
-      wxStringTokenizer tokenizer(plainText, "\n", wxTOKEN_RET_EMPTY_ALL);
-      while (tokenizer.HasMoreTokens()) {
-        buffer.AddParagraph(tokenizer.GetNextToken());
-      }
-    }
-  }
-
   wxRichTextAttr baseStyle = buffer.GetDefaultStyle();
   wxString faceName = layoutviewerpanel::detail::ResolveSharedFontFaceName();
   if (!faceName.empty())
@@ -186,6 +169,25 @@ wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
     baseStyle.SetFontSize(layoutviewerpanel::detail::kTextDefaultFontSize);
   buffer.SetDefaultStyle(baseStyle);
   buffer.SetBasicStyle(baseStyle);
+
+  wxString plainText = buffer.GetText();
+  if (buffer.GetParagraphCount() <= 1 &&
+      (plainText.Find('\n') != wxNOT_FOUND ||
+       plainText.Find('\r') != wxNOT_FOUND)) {
+    plainText.Replace("\r\n", "\n");
+    plainText.Replace("\r", "\n");
+    buffer.Clear();
+    buffer.SetDefaultStyle(baseStyle);
+    buffer.SetBasicStyle(baseStyle);
+    if (plainText.empty()) {
+      buffer.AddParagraph(wxString());
+    } else {
+      wxStringTokenizer tokenizer(plainText, "\n", wxTOKEN_RET_EMPTY_ALL);
+      while (tokenizer.HasMoreTokens()) {
+        buffer.AddParagraph(tokenizer.GetNextToken());
+      }
+    }
+  }
   if (buffer.GetRange().GetLength() > 0) {
     wxRichTextAttr overrideStyle;
     long flags = wxTEXT_ATTR_TEXT_COLOUR |


### PR DESCRIPTION
### Motivation
- The layout viewer was only drawing the first line of multi-line text even though the content existed and printed correctly, due to paragraph reconstruction that lost the rich-text base style.
- Previously an edit to remove extra spaces on line breaks caused the buffer to be rebuilt without reapplying default styles, which prevented further lines from being rendered.

### Description
- Reordered logic in `RenderTextImage` so the `baseStyle` is computed and applied before checking and splitting `\n`/`\r` line breaks. 
- After calling `buffer.Clear()` to rebuild paragraphs from plain text, reapply `buffer.SetDefaultStyle(baseStyle)` and `buffer.SetBasicStyle(baseStyle)` so rebuilt paragraphs keep the correct font and paragraph attributes.
- No other rendering or layout algorithms were changed; the fix only ensures rich-text styles persist across the paragraph-rebuild path in `gui/layouttextutils.cpp`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969458f8c8c8324823099f7a2ace552)