### PR TITLE
Preserve rich text when serialization fails

### DIFF
--- a/gui/layoutviewerpanel_text.cpp
+++ b/gui/layoutviewerpanel_text.cpp
@@ -22,6 +22,7 @@
 
 #include <GL/gl.h>
 
+#include <wx/log.h>
 #include <wx/richtext/richtextbuffer.h>
 
 #include "layouttextdialog.h"
@@ -109,10 +110,17 @@ void LayoutViewerPanel::OnEditText(wxCommandEvent &) {
     return;
   wxString updatedRichText = dialog.GetRichText();
   wxString updatedPlainText = dialog.GetPlainText();
+  const bool hadRichText = !text->richText.empty();
   wxScopedCharBuffer richBuf = updatedRichText.ToUTF8();
   wxScopedCharBuffer plainBuf = updatedPlainText.ToUTF8();
-  text->richText.assign(richBuf.data() ? richBuf.data() : "",
-                        richBuf.length());
+  if (updatedRichText.IsEmpty() && hadRichText) {
+    wxLogWarning(
+        "LayoutViewerPanel::OnEditText received empty rich text, "
+        "preserving previous rich text to avoid losing formatting.");
+  } else {
+    text->richText.assign(richBuf.data() ? richBuf.data() : "",
+                          richBuf.length());
+  }
   text->text.assign(plainBuf.data() ? plainBuf.data() : "",
                     plainBuf.length());
   text->solidBackground = dialog.GetSolidBackground();


### PR DESCRIPTION
### Motivation
- Prevent accidental loss of rich-text formatting when the editor dialog returns an empty rich-text serialization (e.g. from `SaveRichTextBufferToString`) by keeping the previous `richText` and emitting a warning to aid debugging.

### Description
- In `gui/layoutviewerpanel_text.cpp` add `#include <wx/log.h>`, record whether the text previously had rich text, and only overwrite `text->richText` when the dialog returns non-empty content; otherwise log a `wxLogWarning` and preserve the existing rich text while still updating plain text, background/frame flags, layout storage and marking render caches dirty.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69694ce077ac832489f1c7e25516bc98)