### PR TITLE
Render rich-text runs in layout PDF (preserve bold/italic, sizes and all lines)

### DIFF
--- a/viewer2d/viewer2dpdfexporter.h
+++ b/viewer2d/viewer2dpdfexporter.h
@@ -88,7 +88,16 @@ struct LayoutTextExportData {
   int fontSize = 12;
   bool bold = false;
   bool italic = false;
-  std::vector<std::string> lines;
+  struct Run {
+    std::string text;
+    int fontSize = 12;
+    bool bold = false;
+    bool italic = false;
+  };
+  struct Line {
+    std::vector<Run> runs;
+  };
+  std::vector<Line> lines;
 };
 
 // Writes the captured 2D drawing commands to a vector PDF that mirrors the


### PR DESCRIPTION
### Motivation
- Preserve rich-text appearance for layout text in PDF without rasterizing, applying bold/italic/size per styled run and ensuring all lines of a text box are exported.
- Avoid previous bitmap fallback for rich text and ensure characters are encoded properly for PDF text output.

### Description
- Reworked `LayoutTextExportData` to represent text as lines of styled runs (`Run`/`Line`) instead of a single string per line (`viewer2d/viewer2dpdfexporter.h`).
- Updated `BuildLayoutTextExportData` to extract per-character styles from `wxRichTextBuffer` and build lines and runs with `fontSize`, `bold`, `italic` and UTF-8 text (`gui/mainwindow.cpp`).
- Removed the image/XObject text-image registration paths and bitmap fallback for layout text, and changed PDF export to render vector text runs directly while choosing bold/regular fonts from the catalog (`viewer2d/viewer2dpdfexporter.cpp`).
- Added `EncodeWinAnsiCodepoint`/`EncodeWinAnsi` and applied WinAnsi encoding for PDF text emission and measurement, and updated `AppendText` to measure and emit encoded text so special characters map correctly in PDFs (`viewer2d/viewer2dpdfexporter.cpp`).
- Implemented per-run rendering in `ExportLayoutToPdf::renderText`, computing run widths, choosing font keys (`F1`/`F2`), applying run sizes and italics (via text matrix skew), and ensuring all lines are visible within the frame.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69695173d0b48324963c27d3199af6ea)