### PR TITLE
Fix multiline layout text rendering in viewer

### DIFF
--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -242,6 +242,14 @@ wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
     wxString plainText = buffer.GetText();
     plainText.Replace("\r\n", "\n");
     plainText.Replace("\r", "\n");
+    if (plainText.Find('\n') == wxNOT_FOUND && !text.text.empty()) {
+      wxString fallbackPlain =
+          wxString::FromUTF8(text.text.data(), text.text.size());
+      fallbackPlain.Replace("\r\n", "\n");
+      fallbackPlain.Replace("\r", "\n");
+      if (fallbackPlain.Find('\n') != wxNOT_FOUND)
+        plainText = fallbackPlain;
+    }
     if (plainText.Find('\n') != wxNOT_FOUND) {
       wxRichTextAttr firstStyle;
       if (buffer.GetRange().GetLength() > 0) {


### PR DESCRIPTION
### Motivation
- Text elements in layout text boxes only displayed the first line on-screen despite PDFs and the editor showing the full content, indicating a rendering/parsing mismatch for multiline rich/plain text.
- The loaded rich-text buffer sometimes contained a single paragraph while the plain `text.text` field had embedded newlines, so line breaks were lost when rendering the on-screen widget.

### Description
- Update `gui/layouttextutils.cpp` to detect when a loaded rich-text buffer has a single paragraph and no newline markers, and to fall back to the plain `text.text` content if that plain text contains line breaks.
- Normalize line endings and rebuild the `wxRichTextBuffer` into multiple paragraphs using the detected newline-separated content so the on-screen rendering preserves all lines.
- Preserve the original paragraph style when reconstructing paragraphs and leave existing behavior unchanged for other cases.

### Testing
- No automated tests were run for this change (no test invocation was requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969f79dbc848324b80586c104488440)