### PR TITLE
Fix multi-line layout text rendering in layout preview

### DIFF
--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -262,23 +262,26 @@ wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
     }
   };
 
-  if (loaded && buffer.GetParagraphCount() == 1) {
-    wxString plainText = normalizeNewlines(buffer.GetText());
+  if (loaded) {
+    wxString bufferPlain = normalizeNewlines(buffer.GetText());
     wxString fallbackPlain;
     if (!text.text.empty()) {
       fallbackPlain =
           normalizeNewlines(wxString::FromUTF8(text.text.data(),
                                                text.text.size()));
     }
-    if (plainText.Find('\n') == wxNOT_FOUND &&
+    wxString candidatePlain = bufferPlain;
+    if (candidatePlain.Find('\n') == wxNOT_FOUND &&
         fallbackPlain.Find('\n') != wxNOT_FOUND) {
-      plainText = fallbackPlain;
+      candidatePlain = fallbackPlain;
     }
-    if (plainText.Find('\n') != wxNOT_FOUND) {
+    if (candidatePlain.Find('\n') != wxNOT_FOUND &&
+        (buffer.GetParagraphCount() <= 1 || candidatePlain != bufferPlain)) {
       wxRichTextAttr firstStyle;
       const bool hasStyle = buffer.GetRange().GetLength() > 0 &&
                             buffer.GetStyle(0, firstStyle);
-      rebuildBufferFromPlainText(plainText, hasStyle ? &firstStyle : nullptr);
+      rebuildBufferFromPlainText(candidatePlain,
+                                 hasStyle ? &firstStyle : nullptr);
     }
   }
 


### PR DESCRIPTION
### Motivation
- The layout text preview could show only the first line on-screen when a `richText` buffer had a single paragraph but the stored plain `text` contained `\n` line breaks, so the rich-text buffer must be rebuilt from the plain text when appropriate and newlines normalized.

### Description
- Update `gui/layouttextutils.cpp` to normalize CR/LF sequences and choose a `candidatePlain` string (from the buffer or fallback plain text) and call `rebuildBufferFromPlainText` when `candidatePlain` contains newlines and the buffer has one or fewer paragraphs or the candidate differs from the buffer.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a00dc03c083248c69d863fdb0ef58)