### PR TITLE
Rebuild rich text buffer for multiline plain text

### DIFF
--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -270,18 +270,23 @@ wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
           normalizeNewlines(wxString::FromUTF8(text.text.data(),
                                                text.text.size()));
     }
-    wxString candidatePlain = bufferPlain;
-    if (candidatePlain.Find('\n') == wxNOT_FOUND &&
-        fallbackPlain.Find('\n') != wxNOT_FOUND) {
-      candidatePlain = fallbackPlain;
-    }
-    if (candidatePlain.Find('\n') != wxNOT_FOUND &&
-        (buffer.GetParagraphCount() <= 1 || candidatePlain != bufferPlain)) {
-      wxRichTextAttr firstStyle;
-      const bool hasStyle = buffer.GetRange().GetLength() > 0 &&
-                            buffer.GetStyle(0, firstStyle);
-      rebuildBufferFromPlainText(candidatePlain,
+    wxRichTextAttr firstStyle;
+    const bool hasStyle =
+        buffer.GetRange().GetLength() > 0 && buffer.GetStyle(0, firstStyle);
+    if (!fallbackPlain.empty() && fallbackPlain.Find('\n') != wxNOT_FOUND) {
+      rebuildBufferFromPlainText(fallbackPlain,
                                  hasStyle ? &firstStyle : nullptr);
+    } else {
+      wxString candidatePlain = bufferPlain;
+      if (candidatePlain.Find('\n') == wxNOT_FOUND &&
+          fallbackPlain.Find('\n') != wxNOT_FOUND) {
+        candidatePlain = fallbackPlain;
+      }
+      if (candidatePlain.Find('\n') != wxNOT_FOUND &&
+          (buffer.GetParagraphCount() <= 1 || candidatePlain != bufferPlain)) {
+        rebuildBufferFromPlainText(candidatePlain,
+                                   hasStyle ? &firstStyle : nullptr);
+      }
     }
   }
 


### PR DESCRIPTION
### Motivation
- Ensure multiline plain text (containing `\n`) is rendered correctly by rebuilding the `wxRichTextBuffer` from normalized plain text even when `richText` successfully loaded, and preserve basic formatting.

### Description
- Modify `RenderTextImage` in `gui/layouttextutils.cpp` to prefer rebuilding from `fallbackPlain` if it contains newlines, otherwise keep previous candidate logic, and reuse the first buffer style via `buffer.GetStyle(0, firstStyle)` when available before calling `rebuildBufferFromPlainText`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d33bef0c88324a212a962a178560e)