### PR TITLE
Fix const buffer access in rich text layout rebuild

### DIFF
--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -263,7 +263,7 @@ wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
   };
 
   auto rebuildBufferWithLineBreaks =
-      [&](const wxString &sourceText, const wxRichTextBuffer &sourceBuffer) {
+      [&](const wxString &sourceText, wxRichTextBuffer &sourceBuffer) {
     buffer.Clear();
     buffer.SetDefaultStyle(baseStyle);
     buffer.SetBasicStyle(baseStyle);


### PR DESCRIPTION
### Motivation
- Resolve a compilation error when `GetStyle` was called on a `const wxRichTextBuffer` during the line-break buffer rebuild by allowing the helper to accept a mutable buffer.

### Description
- Change the `rebuildBufferWithLineBreaks` lambda parameter from `const wxRichTextBuffer &sourceBuffer` to `wxRichTextBuffer &sourceBuffer` so non-const methods like `GetStyle` can be called.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d432ab3f8832485ab1411303f4f6c)