### PR TITLE
Fix newline paragraph splitting in text rendering

### DIFF
--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -413,8 +413,7 @@ wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
           fallbackPlain.Find('\n') != wxNOT_FOUND) {
         candidatePlain = fallbackPlain;
       }
-      if (candidatePlain.Find('\n') != wxNOT_FOUND &&
-          (buffer.GetParagraphCount() <= 1 || candidatePlain != bufferPlain)) {
+      if (candidatePlain.Find('\n') != wxNOT_FOUND) {
         wxRichTextAttr firstStyle;
         const bool hasStyle = buffer.GetRange().GetLength() > 0 &&
                               buffer.GetStyle(0, firstStyle);


### PR DESCRIPTION
### Motivation
- Ensure multi-line text boxes render all lines on-screen by splitting plain text on newline characters before rebuilding the rich-text buffer, because relying on `wxRichTextBuffer::GetParagraphCount()` prevented paragraph splitting and caused only the first line to be drawn.

### Description
- In `gui/layouttextutils.cpp` inside `RenderTextImage`, remove the paragraph-count gating and always rebuild the buffer from `candidatePlain` when it contains `\n` (i.e. replace the conditional that checked `buffer.GetParagraphCount()` with an unconditional `candidatePlain.Find('\n')` check), so each newline becomes its own paragraph for on-screen rendering.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d4b0fc8f08324b42bce87e34f8d3c)