### PR TITLE
Fix multi-line text rendering in layout viewer

### DIFF
--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -296,6 +296,7 @@ wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
     baseStyle.SetFontFaceName(faceName);
   baseStyle.SetTextColour(*wxBLACK);
   baseStyle.SetFontFamily(wxFONTFAMILY_SWISS);
+  baseStyle.SetFontEncoding(wxFONTENCODING_UTF8);
   baseStyle.SetParagraphSpacingBefore(0);
   baseStyle.SetParagraphSpacingAfter(0);
   if (!loaded || baseStyle.GetFontSize() <= 0)
@@ -434,6 +435,8 @@ wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
       overrideStyle.SetFontFaceName(faceName);
       flags |= wxTEXT_ATTR_FONT_FACE;
     }
+    overrideStyle.SetFontEncoding(wxFONTENCODING_UTF8);
+    flags |= wxTEXT_ATTR_FONT_ENCODING;
     overrideStyle.SetTextColour(*wxBLACK);
     overrideStyle.SetFlags(flags);
     buffer.SetStyle(buffer.GetRange(), overrideStyle);
@@ -453,10 +456,9 @@ wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
   dc.SetUserScale(adjustedScale, adjustedScale);
   wxRichTextDrawingContext context(&buffer);
   wxRichTextSelection selection;
-  buffer.Layout(dc, context, logicalRect, logicalRect, wxRICHTEXT_FIXED_WIDTH);
-  dc.SetClippingRegion(logicalRect);
+  buffer.Layout(dc, context, logicalRect, logicalRect,
+                wxRICHTEXT_FIXED_WIDTH | wxRICHTEXT_FIXED_HEIGHT);
   buffer.Draw(dc, context, buffer.GetRange(), selection, logicalRect, 0, 0);
-  dc.DestroyClippingRegion();
 
   memoryDc.SelectObject(wxNullBitmap);
   wxImage image = bitmap.ConvertToImage();


### PR DESCRIPTION
### Motivation
- The layout viewer was only drawing the first line of multi-line rich text because `wxRichTextBuffer::Layout` was constrained by width but not height and the code then clipped the DC, preventing additional lines from being rendered. 
- Accented characters could be mis-encoded because the base and override font styles did not explicitly set UTF-8 encoding.

### Description
- Constrain rich text layout to both width and height by calling `buffer.Layout(..., wxRICHTEXT_FIXED_WIDTH | wxRICHTEXT_FIXED_HEIGHT)` in `gui/layouttextutils.cpp`. 
- Remove use of DC clipping (`SetClippingRegion` / `DestroyClippingRegion`) and draw directly after the fixed-size layout. 
- Set the base and override styles to UTF-8 encoding via `baseStyle.SetFontEncoding(wxFONTENCODING_UTF8)` and `overrideStyle.SetFontEncoding(wxFONTENCODING_UTF8)` and include `wxTEXT_ATTR_FONT_ENCODING` in the override flags.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d4e2338f48324b17f63401b0cb2c8)