### PR TITLE
Sync layout textbox rendering with PDF layout logic

### DIFF
--- a/gui/layouttextutils.h
+++ b/gui/layouttextutils.h
@@ -22,11 +22,15 @@
 #include <wx/richtext/richtextbuffer.h>
 
 #include "layouts/LayoutCollection.h"
+#include "viewer2d/viewer2dpdfexporter.h"
 
 namespace layouttext {
 bool LoadRichTextBufferFromString(wxRichTextBuffer &buffer,
                                   const wxString &content);
 wxString SaveRichTextBufferToString(wxRichTextBuffer &buffer);
+
+LayoutTextExportData BuildLayoutTextExportData(
+    const layouts::LayoutTextDefinition &text, double scaleX, double scaleY);
 
 wxImage RenderTextImage(const layouts::LayoutTextDefinition &text,
                         const wxSize &renderSize, const wxSize &logicalSize,


### PR DESCRIPTION
### Motivation
- Text boxes in the layout view only rendered the first line on-screen while the PDF export showed the full text, so the PDF text layout process was reused to make on-screen textboxes render the same content.

### Description
- Added `BuildLayoutTextExportData` to `layouttext` and declared it in `gui/layouttextutils.h` so the PDF builder logic is reusable from the UI layer.
- Moved the text line/run parsing and style extraction into `gui/layouttextutils.cpp` and added `MakeRenderFont` plus per-run drawing so `RenderTextImage` now draws the same lines/runs used by the PDF exporter instead of relying on `wxRichTextBuffer::Layout`.
- Replaced the local builder in `mainwindow.cpp` with calls to `layouttext::BuildLayoutTextExportData` so the PDF export still uses the shared logic.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d5a05fbe483248247f030b79830fb)