### PR TITLE
Fix include path for viewer2dpdfexporter in layouttextutils.h

### DIFF
--- a/gui/layouttextutils.h
+++ b/gui/layouttextutils.h
@@ -22,7 +22,7 @@
 #include <wx/richtext/richtextbuffer.h>
 
 #include "layouts/LayoutCollection.h"
-#include "viewer2d/viewer2dpdfexporter.h"
+#include "viewer2dpdfexporter.h"
 
 namespace layouttext {
 bool LoadRichTextBufferFromString(wxRichTextBuffer &buffer,


### PR DESCRIPTION
### Motivation
- Fix Windows build failures caused by `viewer2d/viewer2dpdfexporter.h` not being found by using the project's configured include path.

### Description
- Replace `#include "viewer2d/viewer2dpdfexporter.h"` with `#include "viewer2dpdfexporter.h"` in `gui/layouttextutils.h`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d5b92c40883249a8c57ebba5dbc3b)