### PR TITLE
Guard UTF-8 font encoding selection to avoid startup prompt

### DIFF
--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -23,6 +23,7 @@
 
 #include <wx/dcgraph.h>
 #include <wx/dcmemory.h>
+#include <wx/fontenum.h>
 #include <wx/log.h>
 #include <wx/mstream.h>
 #include <wx/richtext/richtextbuffer.h>
@@ -55,7 +56,9 @@ wxFont MakeRenderFont(int sizePx, bool bold, bool italic,
   } else {
     font = wxFont(sizePx, wxFONTFAMILY_SWISS, style, weight);
   }
-  font.SetEncoding(wxFONTENCODING_UTF8);
+  if (wxFontEnumerator::IsValidEncoding(wxFONTENCODING_UTF8)) {
+    font.SetEncoding(wxFONTENCODING_UTF8);
+  }
   return font;
 }
 

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -43,6 +43,7 @@
 #include <wx/event.h>
 #include <wx/filefn.h>
 #include <wx/filename.h>
+#include <wx/fontenum.h>
 #include <wx/html/htmlwin.h>
 #include <wx/iconbndl.h>
 #include <wx/image.h>
@@ -145,7 +146,9 @@ wxFont BuildDefaultUiFont() {
   if (!faceName.empty()) {
     defaultFont.SetFaceName(faceName);
   }
-  defaultFont.SetEncoding(wxFONTENCODING_UTF8);
+  if (wxFontEnumerator::IsValidEncoding(wxFONTENCODING_UTF8)) {
+    defaultFont.SetEncoding(wxFONTENCODING_UTF8);
+  }
   if (!defaultFont.IsOk()) {
     const int fallbackSize =
         defaultFont.IsOk() ? defaultFont.GetPointSize() : 10;
@@ -154,7 +157,9 @@ wxFont BuildDefaultUiFont() {
     defaultFont = wxFont(fallbackSize, wxFONTFAMILY_SWISS,
                          wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false,
                          fallbackFace);
-    defaultFont.SetEncoding(wxFONTENCODING_UTF8);
+    if (wxFontEnumerator::IsValidEncoding(wxFONTENCODING_UTF8)) {
+      defaultFont.SetEncoding(wxFONTENCODING_UTF8);
+    }
   }
   return defaultFont;
 }


### PR DESCRIPTION
### Motivation
- Prevent the runtime font-encoding dialog "No font for displaying text in encoding 'Unicode 8 bit (UTF-8)' found" by avoiding forcing UTF-8 encoding when the platform does not advertise that encoding.

### Description
- In `gui/mainwindow.cpp` and `gui/layouttextutils.cpp` add `#include <wx/fontenum.h>` and guard calls to `SetEncoding(wxFONTENCODING_UTF8)` with `wxFontEnumerator::IsValidEncoding(wxFONTENCODING_UTF8)` so UTF-8 is only set when supported.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d5eb14aa88324b9b9d7c127307b8b)