### PR TITLE
Fix UTF-8 font encoding setup in GUI

### DIFF
--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -56,9 +56,7 @@ wxFont MakeRenderFont(int sizePx, bool bold, bool italic,
   } else {
     font = wxFont(sizePx, wxFONTFAMILY_SWISS, style, weight);
   }
-  if (wxFontEnumerator::IsValidEncoding(wxFONTENCODING_UTF8)) {
-    font.SetEncoding(wxFONTENCODING_UTF8);
-  }
+  font.SetEncoding(wxFONTENCODING_UTF8);
   return font;
 }
 

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -146,9 +146,7 @@ wxFont BuildDefaultUiFont() {
   if (!faceName.empty()) {
     defaultFont.SetFaceName(faceName);
   }
-  if (wxFontEnumerator::IsValidEncoding(wxFONTENCODING_UTF8)) {
-    defaultFont.SetEncoding(wxFONTENCODING_UTF8);
-  }
+  defaultFont.SetEncoding(wxFONTENCODING_UTF8);
   if (!defaultFont.IsOk()) {
     const int fallbackSize =
         defaultFont.IsOk() ? defaultFont.GetPointSize() : 10;
@@ -157,9 +155,7 @@ wxFont BuildDefaultUiFont() {
     defaultFont = wxFont(fallbackSize, wxFONTFAMILY_SWISS,
                          wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false,
                          fallbackFace);
-    if (wxFontEnumerator::IsValidEncoding(wxFONTENCODING_UTF8)) {
-      defaultFont.SetEncoding(wxFONTENCODING_UTF8);
-    }
+    defaultFont.SetEncoding(wxFONTENCODING_UTF8);
   }
   return defaultFont;
 }


### PR DESCRIPTION
### Motivation
- Calls to `wxFontEnumerator::IsValidEncoding` were removed/absent and caused build errors, so fonts need a consistent way to be set to UTF-8 encoding.

### Description
- Remove `wxFontEnumerator::IsValidEncoding(...)` checks and call `SetEncoding(wxFONTENCODING_UTF8)` unconditionally in `MakeRenderFont` in `gui/layouttextutils.cpp` and in `BuildDefaultUiFont` in `gui/mainwindow.cpp`.
- Apply UTF-8 encoding to both the primary and fallback/default UI fonts to ensure consistent rendering across platforms.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d60138e548324867c5cf5bc08ae8f)