### PR TITLE
Prefer Arial for UTF-8 UI fonts

### DIFF
--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -54,7 +54,14 @@ wxFont MakeRenderFont(int sizePx, bool bold, bool italic,
   if (!faceName.empty()) {
     font = wxFont(sizePx, wxFONTFAMILY_SWISS, style, weight, false, faceName);
   } else {
-    font = wxFont(sizePx, wxFONTFAMILY_SWISS, style, weight);
+    wxFont testFont(sizePx, wxFONTFAMILY_SWISS, style, weight, false,
+                    wxString::FromUTF8("Arial"));
+    if (testFont.IsOk() &&
+        testFont.GetFaceName().CmpNoCase("Arial") == 0) {
+      font = testFont;
+    } else {
+      font = wxFont(sizePx, wxFONTFAMILY_SWISS, style, weight);
+    }
   }
   font.SetEncoding(wxFONTENCODING_UTF8);
   return font;

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -143,15 +143,25 @@ wxFont BuildDefaultUiFont() {
   wxFont defaultFont = wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT);
   const wxString faceName =
       layoutviewerpanel::detail::ResolveSharedFontFaceName();
-  if (!faceName.empty()) {
-    defaultFont.SetFaceName(faceName);
+  wxString resolvedFaceName = faceName;
+  if (resolvedFaceName.empty()) {
+    wxFont testFont(10, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL,
+                    wxFONTWEIGHT_NORMAL, false, wxString::FromUTF8("Arial"));
+    if (testFont.IsOk() &&
+        testFont.GetFaceName().CmpNoCase("Arial") == 0) {
+      resolvedFaceName = testFont.GetFaceName();
+    }
+  }
+  if (!resolvedFaceName.empty()) {
+    defaultFont.SetFaceName(resolvedFaceName);
   }
   defaultFont.SetEncoding(wxFONTENCODING_UTF8);
   if (!defaultFont.IsOk()) {
     const int fallbackSize =
         defaultFont.IsOk() ? defaultFont.GetPointSize() : 10;
     wxString fallbackFace =
-        faceName.empty() ? wxString::FromUTF8("Arial") : faceName;
+        resolvedFaceName.empty() ? wxString::FromUTF8("Arial")
+                                 : resolvedFaceName;
     defaultFont = wxFont(fallbackSize, wxFONTFAMILY_SWISS,
                          wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false,
                          fallbackFace);


### PR DESCRIPTION
### Motivation
- Ensure accented characters (tildes) render correctly by keeping `wxFONTENCODING_UTF8` while avoiding the startup font-selection prompt when shared face names are not available.

### Description
- In `BuildDefaultUiFont()` prefer a resolved face name by attempting an `Arial` probe via `wxString::FromUTF8("Arial")` and use that face before calling `SetEncoding(wxFONTENCODING_UTF8)`.
- Use the resolved face (or `Arial`) as the fallback when constructing the default font and call `SetEncoding(wxFONTENCODING_UTF8)` on the fallback font as well.
- In `MakeRenderFont()` attempt to construct a `testFont` using `Arial` when `faceName` is empty and use it if present, otherwise fall back to the prior constructor, then call `SetEncoding(wxFONTENCODING_UTF8)` on the returned font.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d60d511688324af2243fe96a8c27a)