### PR TITLE
Guard UTF-8 font selection to avoid startup prompt

### DIFF
--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -63,7 +63,9 @@ wxFont MakeRenderFont(int sizePx, bool bold, bool italic,
       font = wxFont(sizePx, wxFONTFAMILY_SWISS, style, weight);
     }
   }
-  font.SetEncoding(wxFONTENCODING_UTF8);
+  if (wxFontEnumerator::IsValidEncoding(wxFONTENCODING_UTF8)) {
+    font.SetEncoding(wxFONTENCODING_UTF8);
+  }
   return font;
 }
 

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -155,7 +155,9 @@ wxFont BuildDefaultUiFont() {
   if (!resolvedFaceName.empty()) {
     defaultFont.SetFaceName(resolvedFaceName);
   }
-  defaultFont.SetEncoding(wxFONTENCODING_UTF8);
+  if (wxFontEnumerator::IsValidEncoding(wxFONTENCODING_UTF8)) {
+    defaultFont.SetEncoding(wxFONTENCODING_UTF8);
+  }
   if (!defaultFont.IsOk()) {
     const int fallbackSize =
         defaultFont.IsOk() ? defaultFont.GetPointSize() : 10;
@@ -165,7 +167,9 @@ wxFont BuildDefaultUiFont() {
     defaultFont = wxFont(fallbackSize, wxFONTFAMILY_SWISS,
                          wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false,
                          fallbackFace);
-    defaultFont.SetEncoding(wxFONTENCODING_UTF8);
+    if (wxFontEnumerator::IsValidEncoding(wxFONTENCODING_UTF8)) {
+      defaultFont.SetEncoding(wxFONTENCODING_UTF8);
+    }
   }
   return defaultFont;
 }


### PR DESCRIPTION
### Motivation
- Avoid the startup warning about missing UTF‑8 font encoding by only applying `wxFONTENCODING_UTF8` when the platform reports it as available.

### Description
- Added checks using `wxFontEnumerator::IsValidEncoding(wxFONTENCODING_UTF8)` before calling `SetEncoding(wxFONTENCODING_UTF8)` in `BuildDefaultUiFont()` (`gui/mainwindow.cpp`) and `MakeRenderFont()` (`gui/layouttextutils.cpp`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d6359e1888324b14bb017d039ebeb)