### PR TITLE
Fix UTF-8 encoding checks for wx font setup

### DIFF
--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -24,6 +24,7 @@
 #include <wx/dcgraph.h>
 #include <wx/dcmemory.h>
 #include <wx/fontenum.h>
+#include <wx/fontmap.h>
 #include <wx/log.h>
 #include <wx/mstream.h>
 #include <wx/richtext/richtextbuffer.h>
@@ -63,7 +64,8 @@ wxFont MakeRenderFont(int sizePx, bool bold, bool italic,
       font = wxFont(sizePx, wxFONTFAMILY_SWISS, style, weight);
     }
   }
-  if (wxFontEnumerator::IsValidEncoding(wxFONTENCODING_UTF8)) {
+  if (wxFontMapper::Get() &&
+      wxFontMapper::Get()->IsEncodingAvailable(wxFONTENCODING_UTF8)) {
     font.SetEncoding(wxFONTENCODING_UTF8);
   }
   return font;

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -44,6 +44,7 @@
 #include <wx/filefn.h>
 #include <wx/filename.h>
 #include <wx/fontenum.h>
+#include <wx/fontmap.h>
 #include <wx/html/htmlwin.h>
 #include <wx/iconbndl.h>
 #include <wx/image.h>
@@ -155,7 +156,8 @@ wxFont BuildDefaultUiFont() {
   if (!resolvedFaceName.empty()) {
     defaultFont.SetFaceName(resolvedFaceName);
   }
-  if (wxFontEnumerator::IsValidEncoding(wxFONTENCODING_UTF8)) {
+  if (wxFontMapper::Get() &&
+      wxFontMapper::Get()->IsEncodingAvailable(wxFONTENCODING_UTF8)) {
     defaultFont.SetEncoding(wxFONTENCODING_UTF8);
   }
   if (!defaultFont.IsOk()) {
@@ -167,7 +169,8 @@ wxFont BuildDefaultUiFont() {
     defaultFont = wxFont(fallbackSize, wxFONTFAMILY_SWISS,
                          wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false,
                          fallbackFace);
-    if (wxFontEnumerator::IsValidEncoding(wxFONTENCODING_UTF8)) {
+    if (wxFontMapper::Get() &&
+        wxFontMapper::Get()->IsEncodingAvailable(wxFONTENCODING_UTF8)) {
       defaultFont.SetEncoding(wxFONTENCODING_UTF8);
     }
   }


### PR DESCRIPTION
### Motivation
- The code relied on `wxFontEnumerator::IsValidEncoding`, which is not present in newer wxWidgets versions and caused build errors and incorrect UTF-8 font setup, so a mapper-based check is needed.

### Description
- Added `#include <wx/fontmap.h>` and replaced calls to `wxFontEnumerator::IsValidEncoding(wxFONTENCODING_UTF8)` with `wxFontMapper::Get() && wxFontMapper::Get()->IsEncodingAvailable(wxFONTENCODING_UTF8)` in `gui/layouttextutils.cpp` and `gui/mainwindow.cpp`.
- This change ensures `SetEncoding(wxFONTENCODING_UTF8)` is only invoked when the `wxFontMapper` reports UTF-8 support.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d6544edb0832480417267c4706478)