### PR TITLE
Ensure rich text editor uses system text colour for entire buffer

### DIFF
--- a/gui/layouttextdialog.cpp
+++ b/gui/layouttextdialog.cpp
@@ -222,7 +222,8 @@ void LayoutTextDialog::ApplyDefaultFontStyle() {
     defaultStyle.SetFont(sharedFont);
     defaultStyle.SetFontFaceName(sharedFont.GetFaceName());
   }
-  defaultStyle.SetTextColour(GetEditorTextColour());
+  wxColour editorColour = GetEditorTextColour();
+  defaultStyle.SetTextColour(editorColour);
   defaultStyle.SetFontFamily(wxFONTFAMILY_SWISS);
   defaultStyle.SetFlags(defaultStyle.GetFlags() | wxTEXT_ATTR_FONT_FAMILY);
   if (sharedFont.IsOk()) {
@@ -232,11 +233,11 @@ void LayoutTextDialog::ApplyDefaultFontStyle() {
   textCtrl->GetBuffer().SetDefaultStyle(defaultStyle);
   textCtrl->GetBuffer().SetBasicStyle(defaultStyle);
 
-  wxRichTextRange range = textCtrl->GetBuffer().GetRange();
+  wxRichTextRange range(0, textCtrl->GetLastPosition());
   if (range.GetLength() <= 0)
     return;
   wxRichTextAttr overrideStyle;
-  overrideStyle.SetTextColour(GetEditorTextColour());
+  overrideStyle.SetTextColour(editorColour);
   overrideStyle.SetFontFamily(wxFONTFAMILY_SWISS);
   long flags = wxTEXT_ATTR_TEXT_COLOUR | wxTEXT_ATTR_FONT_FAMILY;
   if (sharedFont.IsOk()) {
@@ -245,7 +246,7 @@ void LayoutTextDialog::ApplyDefaultFontStyle() {
     flags |= wxTEXT_ATTR_FONT_FACE;
   }
   overrideStyle.SetFlags(flags);
-  textCtrl->GetBuffer().SetStyle(range, overrideStyle);
+  textCtrl->SetStyleEx(range, overrideStyle, wxRICHTEXT_SETSTYLE_REPLACE);
 }
 
 void LayoutTextDialog::ApplyBold() {


### PR DESCRIPTION
### Motivation
- The rich text editor sometimes displays lines in the wrong colour when loading content, so the editor view should always use the system text colour (e.g. white on dark backgrounds) even if saved content uses a different colour.

### Description
- Updated `gui/layouttextdialog.cpp` in `ApplyDefaultFontStyle()` to capture the system colour once via `GetEditorTextColour()` and use it for the editor default style.
- Applied the editor colour to the buffer default/basic style and forced the entire buffer range `wxRichTextRange(0, textCtrl->GetLastPosition())` to use that colour.
- Replaced the previous `SetStyle` usage with `textCtrl->SetStyleEx(range, overrideStyle, wxRICHTEXT_SETSTYLE_REPLACE)` to ensure the editor view overrides loaded text colours across the whole buffer.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dfc90056c8324aa28f64caae8e41a)