### PR TITLE
Add compatibility fallback for wxRICHTEXT_SETSTYLE_REPLACE

### DIFF
--- a/gui/layouttextdialog.cpp
+++ b/gui/layouttextdialog.cpp
@@ -32,6 +32,10 @@
 #include <wx/sizer.h>
 #include <wx/spinctrl.h>
 
+#ifndef wxRICHTEXT_SETSTYLE_REPLACE
+#define wxRICHTEXT_SETSTYLE_REPLACE wxRICHTEXT_SETSTYLE_RESET
+#endif
+
 #include "layouttextutils.h"
 #include "layoutviewerpanel_shared.h"
 #include "projectutils.h"


### PR DESCRIPTION
### Motivation
- Resolve build failures on environments where `wxRICHTEXT_SETSTYLE_REPLACE` is not defined by providing a compatibility mapping to the older `wxRICHTEXT_SETSTYLE_RESET` flag.

### Description
- Add a preprocessor guard in `gui/layouttextdialog.cpp` that defines `wxRICHTEXT_SETSTYLE_REPLACE` as `wxRICHTEXT_SETSTYLE_RESET` when the former is not available.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dfe6f6e2083249e6db14b42b547dc)