### PR TITLE
Update text alignment toolbar icons

### DIFF
--- a/gui/layouttextdialog.cpp
+++ b/gui/layouttextdialog.cpp
@@ -111,13 +111,13 @@ LayoutTextDialog::LayoutTextDialog(wxWindow *parent,
   });
   toolbarSizer->Add(fontSizeCtrl, 0, wxRIGHT, 8);
 
-  addToolButton("align-horizontal-justify-start", "Align start",
+  addToolButton("text-align-start", "Align start",
                 [this]() { ApplyAlignment(wxTEXT_ALIGNMENT_LEFT); });
-  addToolButton("align-horizontal-justify-center", "Align center",
+  addToolButton("text-align-center", "Align center",
                 [this]() { ApplyAlignment(wxTEXT_ALIGNMENT_CENTRE); });
-  addToolButton("align-horizontal-justify-end", "Align end",
+  addToolButton("text-align-end", "Align end",
                 [this]() { ApplyAlignment(wxTEXT_ALIGNMENT_RIGHT); });
-  addToolButton("align-horizontal-space-between", "Justify",
+  addToolButton("text-align-center", "Justify",
                 [this]() { ApplyAlignment(wxTEXT_ALIGNMENT_JUSTIFIED); });
 
   mainSizer->Add(toolbarSizer, 0, wxEXPAND | wxALL, 8);

--- a/resources/icons/outline/text-align-center.svg
+++ b/resources/icons/outline/text-align-center.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <line x1="6" y1="6" x2="18" y2="6" />
+  <line x1="4" y1="12" x2="20" y2="12" />
+  <line x1="8" y1="18" x2="16" y2="18" />
+</svg>

--- a/resources/icons/outline/text-align-end.svg
+++ b/resources/icons/outline/text-align-end.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <line x1="8" y1="6" x2="20" y2="6" />
+  <line x1="4" y1="12" x2="20" y2="12" />
+  <line x1="10" y1="18" x2="20" y2="18" />
+</svg>

--- a/resources/icons/outline/text-align-start.svg
+++ b/resources/icons/outline/text-align-start.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <line x1="4" y1="6" x2="16" y2="6" />
+  <line x1="4" y1="12" x2="20" y2="12" />
+  <line x1="4" y1="18" x2="14" y2="18" />
+</svg>


### PR DESCRIPTION
### Motivation
- Replace legacy Lucide alignment icons used in the layout text editor toolbar with project-local `text-align-*` icons to match the requested icon set.
- Provide the matching SVG assets so the toolbar can load the new icons directly from `resources/icons/outline`.

### Description
- Updated `gui/layouttextdialog.cpp` to use `text-align-start`, `text-align-center`, and `text-align-end` for the left/center/right alignment buttons and `text-align-center` for the justify button.
- Added three new SVG icon files: `resources/icons/outline/text-align-start.svg`, `resources/icons/outline/text-align-center.svg`, and `resources/icons/outline/text-align-end.svg`.
- Kept the existing icon loading mechanism (`LoadIcon`) unchanged so the new SVGs are discovered from the resource path.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e047ba50c8324a345dc8edd0ee44a)