### PR TITLE
Add MainWindow::RefreshAfterSceneChange helper and use it in import/auto actions

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -630,6 +630,28 @@ void MainWindow::SyncSceneData() {
     sceneObjPanel->UpdateSceneData();
 }
 
+void MainWindow::RefreshAfterSceneChange(bool refreshViewport) {
+  if (fixturePanel)
+    fixturePanel->ReloadData();
+  if (trussPanel)
+    trussPanel->ReloadData();
+  if (hoistPanel)
+    hoistPanel->ReloadData();
+  if (sceneObjPanel)
+    sceneObjPanel->ReloadData();
+  RefreshSummary();
+  if (refreshViewport) {
+    if (viewportPanel) {
+      viewportPanel->UpdateScene();
+      viewportPanel->Refresh();
+    }
+    if (viewport2DPanel) {
+      viewport2DPanel->UpdateScene();
+      viewport2DPanel->Refresh();
+    }
+  }
+}
+
 void MainWindow::OnProjectLoaded(wxCommandEvent &event) {
   bool loaded = event.GetInt() != 0;
   std::string path = event.GetString().ToStdString();

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -138,6 +138,7 @@ private:
   void OnSelectObjects(wxCommandEvent &event);        // Switch to objects tab
   void OnNotebookPageChanged(wxBookCtrlEvent &event); // Update summary panel
   void RefreshSummary();                              // Refresh summary counts
+  void RefreshAfterSceneChange(bool refreshViewport = true);
   void RefreshRigging();                              // Refresh rigging summary
 
   void OnPreferences(wxCommandEvent &event);        // Show preferences dialog

--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -148,17 +148,7 @@ void MainWindow::OnImportRider(wxCommandEvent &event) {
     wxMessageBox("Rider imported successfully.", "Success", wxICON_INFORMATION);
     if (consolePanel)
       consolePanel->AppendMessage("Imported " + dlg.GetPath());
-    if (fixturePanel)
-      fixturePanel->ReloadData();
-    if (trussPanel)
-      trussPanel->ReloadData();
-    if (hoistPanel)
-      hoistPanel->ReloadData();
-    if (viewportPanel) {
-      viewportPanel->UpdateScene();
-      viewportPanel->Refresh();
-    }
-    RefreshSummary();
+    RefreshAfterSceneChange();
   }
 }
 
@@ -169,17 +159,7 @@ void MainWindow::OnImportRiderText(wxCommandEvent &WXUNUSED(event)) {
 
   if (consolePanel)
     consolePanel->AppendMessage("Imported rider from text.");
-  if (fixturePanel)
-    fixturePanel->ReloadData();
-  if (trussPanel)
-    trussPanel->ReloadData();
-  if (hoistPanel)
-    hoistPanel->ReloadData();
-  if (viewportPanel) {
-    viewportPanel->UpdateScene();
-    viewportPanel->Refresh();
-  }
-  RefreshSummary();
+  RefreshAfterSceneChange();
 }
 
 // Handles MVR file selection, import, and updates fixture/truss panels
@@ -205,19 +185,7 @@ void MainWindow::OnImportMVR(wxCommandEvent &event) {
                  wxICON_INFORMATION);
     if (consolePanel)
       consolePanel->AppendMessage("Imported " + filePath);
-    if (fixturePanel)
-      fixturePanel->ReloadData();
-    if (trussPanel)
-      trussPanel->ReloadData();
-    if (hoistPanel)
-      hoistPanel->ReloadData();
-    if (sceneObjPanel)
-      sceneObjPanel->ReloadData();
-    RefreshSummary();
-    if (viewportPanel) {
-      viewportPanel->UpdateScene();
-      viewportPanel->Refresh();
-    }
+    RefreshAfterSceneChange();
   }
 }
 

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -386,8 +386,7 @@ void MainWindow::OnAutoPatch(wxCommandEvent &WXUNUSED(event)) {
   ConfigManager &cfg = ConfigManager::Get();
   cfg.PushUndoState("auto patch");
   AutoPatcher::AutoPatch(cfg.GetScene());
-  if (fixturePanel)
-    fixturePanel->ReloadData();
+  RefreshAfterSceneChange();
 }
 
 void MainWindow::OnAutoColor(wxCommandEvent &WXUNUSED(event)) {
@@ -461,14 +460,9 @@ void MainWindow::OnAutoColor(wxCommandEvent &WXUNUSED(event)) {
     SetGdtfModelColor(gdtfPath, color);
   }
 
-  if (fixturePanel)
-    fixturePanel->ReloadData();
   if (layerPanel)
     layerPanel->ReloadLayers();
-  if (Viewer3DPanel::Instance()) {
-    Viewer3DPanel::Instance()->UpdateScene();
-    Viewer3DPanel::Instance()->Refresh();
-  }
+  RefreshAfterSceneChange();
 }
 
 void MainWindow::OnConvertToHoist(wxCommandEvent &WXUNUSED(event)) {


### PR DESCRIPTION
### Motivation
- Reduce repeated panel/viewport refresh code after scene modifications and centralize the logic in one helper.
- Make import handlers and auto actions (`auto-patch`/`auto-color`) call a single function to ensure consistent UI updates.

### Description
- Add `void MainWindow::RefreshAfterSceneChange(bool refreshViewport = true)` declaration in `gui/mainwindow.h` and implement it in `gui/mainwindow.cpp` to reload `fixturePanel`, `trussPanel`, `hoistPanel`, `sceneObjPanel`, call `RefreshSummary()` and optionally update/refresh 3D/2D viewports using `UpdateScene()/Refresh()`.
- Replace duplicated reload/update blocks in import handlers inside `gui/mainwindow_io.cpp` (rider, rider text and MVR imports) to call `RefreshAfterSceneChange()`.
- Replace duplicated reload/update calls in `gui/mainwindow_menu.cpp` for `OnAutoPatch` and `OnAutoColor` to call `RefreshAfterSceneChange()` and keep layer updates and model color adjustments intact.
- Changes touch `gui/mainwindow.h`, `gui/mainwindow.cpp`, `gui/mainwindow_io.cpp`, and `gui/mainwindow_menu.cpp` to centralize UI refresh behavior.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e0cec19408324b7946b750430016d)