### PR TITLE
Translate high-level flow comments to English

### DIFF
--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -359,6 +359,9 @@ void MainWindow::ApplyLayoutPreset(const LayoutViewPreset &preset,
 }
 
 void MainWindow::ApplySavedLayout() {
+  // Flow overview: choose which perspective to apply (layout mode/2D/3D) from
+  // saved config, ensuring viewports exist before restoring; then re-apply
+  // minimum sizes so the saved perspective cannot degrade the UI.
   if (!auiManager)
     return;
 

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -273,6 +273,10 @@ void MainWindow::OnNew(wxCommandEvent &WXUNUSED(event)) {
 }
 
 void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
+  // Flow overview: reuse stored credentials to reduce friction, authenticate,
+  // and persist the session before requesting the list and downloading.
+  // The order matters because the list needs a valid cookie; we also save
+  // credentials early so a later network failure doesn't discard user input.
   std::string savedUser;
   std::string savedPass;
   if (auto creds = CredentialStore::Load()) {

--- a/gui/mainwindow_print.cpp
+++ b/gui/mainwindow_print.cpp
@@ -229,6 +229,9 @@ void MainWindow::OnPrintViewer2D(wxCommandEvent &WXUNUSED(event)) {
 }
 
 void MainWindow::OnPrintLayout(wxCommandEvent &WXUNUSED(event)) {
+  // Flow overview: validate selection and 2D resources, collect settings/file,
+  // scale frames to the output, and capture views sequentially before exporting
+  // to PDF (ordering guarantees consistent renderer/caches during export).
   if (activeLayoutName.empty()) {
     wxMessageBox("No layout is selected.", "Print Layout", wxOK | wxICON_WARNING,
                  this);


### PR DESCRIPTION
### Motivation
- Convert Spanish high-level flow comments to English to improve readability and maintainability in the GDTF download, layout restore, and layout print handlers.

### Description
- Replaced Spanish comments with English explanations in `gui/mainwindow_menu.cpp` (`MainWindow::OnDownloadGdtf`), `gui/mainwindow_layout.cpp` (`MainWindow::ApplySavedLayout`), and `gui/mainwindow_print.cpp` (`MainWindow::OnPrintLayout`) without changing logic.

### Testing
- No automated tests were run because these are comment-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e0df3a1588324b38b37293341e71e)