### PR TITLE
Use fixed-width timestamp for image content hash

### DIFF
--- a/gui/layoutviewerpanel_image.cpp
+++ b/gui/layoutviewerpanel_image.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <filesystem>
 #include <functional>
 
@@ -268,9 +269,10 @@ size_t LayoutViewerPanel::HashImageContent(
         HashCombine(seed, std::hash<uintmax_t>{}(fileSize));
       const auto writeTime = std::filesystem::last_write_time(path, ec);
       if (!ec) {
-        const auto stamp = writeTime.time_since_epoch().count();
-        HashCombine(seed,
-                    std::hash<decltype(stamp)>{}(stamp));
+        auto stamp = writeTime.time_since_epoch().count();
+        HashCombine(
+            seed,
+            std::hash<std::int64_t>{}(static_cast<std::int64_t>(stamp)));
       }
     }
   }


### PR DESCRIPTION
### Motivation
- Fix hashing of file write time that caused template/constructor errors by ensuring a stable integer type is passed to `std::hash`.

### Description
- Add `#include <cstdint>` to provide fixed-width integer types.
- Cast the filesystem timestamp count to `std::int64_t` and use `std::hash<std::int64_t>` when calling `HashCombine`.
- Change the timestamp variable to a non-const `auto` to allow the explicit cast before hashing.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e173112388324996f3d4b5b4df919)