### PR TITLE
Refresh toolbar layout after saved perspective load

### DIFF
--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -448,22 +448,23 @@ void MainWindow::ApplySavedLayout() {
   if (view2dPane.IsOk())
     view2dPane.MinSize(wxSize(250, 600));
 
-  auto applyToolbarMinSize = [this](wxAuiToolBar *toolbar,
-                                    const std::string &paneName) {
+  auto refreshToolbarLayout = [this](wxAuiToolBar *toolbar,
+                                     const std::string &paneName) {
     if (!toolbar)
       return;
-    const wxSize bestSize = toolbar->GetBestSize();
-    toolbar->SetMinSize(bestSize);
+    toolbar->Realize();
+    toolbar->InvalidateBestSize();
     auto &pane = auiManager->GetPane(paneName);
     if (pane.IsOk())
-      pane.BestSize(bestSize).MinSize(bestSize);
+      pane.BestSize(toolbar->GetBestSize());
   };
 
-  applyToolbarMinSize(fileToolBar, "FileToolbar");
-  applyToolbarMinSize(layoutViewsToolBar, "LayoutViewsToolbar");
-  applyToolbarMinSize(layoutToolBar, "LayoutToolbar");
+  refreshToolbarLayout(fileToolBar, "FileToolbar");
+  refreshToolbarLayout(layoutViewsToolBar, "LayoutViewsToolbar");
+  refreshToolbarLayout(layoutToolBar, "LayoutToolbar");
 
   auiManager->Update();
+  SendSizeEvent();
   UpdateViewMenuChecks();
 }
 


### PR DESCRIPTION
### Motivation
- The previous workaround that expanded and shrank toolbars to force new icons to appear did not reliably show newly added toolbar SVG icons after loading a saved perspective. 
- The goal is to recalculate toolbar sizes and refresh the UI layout in a more robust way without performing an explicit resize hack.

### Description
- Replace the old `applyToolbarMinSize` logic with a `refreshToolbarLayout` lambda that calls `Realize()` and `InvalidateBestSize()` on each toolbar and updates the pane `BestSize` from `toolbar->GetBestSize()`.
- Update the three toolbar refresh calls to use the new `refreshToolbarLayout` for `FileToolbar`, `LayoutViewsToolbar`, and `LayoutToolbar`.
- After applying the AUI manager update the code now triggers a `SendSizeEvent()` to force a layout refresh and then calls `UpdateViewMenuChecks()`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e18d59dac8324b01c46686225820c)