### PR TITLE
Refresh toolbar sizes after restoring layout/perspective

### DIFF
--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -140,6 +140,7 @@ private:
   void RefreshSummary();                              // Refresh summary counts
   void RefreshAfterSceneChange(bool refreshViewport = true);
   void RefreshRigging();                              // Refresh rigging summary
+  void RefreshToolbarPaneSizes();
 
   void OnPreferences(wxCommandEvent &event);        // Show preferences dialog
   void OnApplyDefaultLayout(wxCommandEvent &event); // Reset to default layout

--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -375,6 +375,8 @@ void MainWindow::ApplyLayoutPreset(const LayoutViewPreset &preset,
   applyPaneState(preset.hidePanes, false);
 
   auiManager->Update();
+  RefreshToolbarPaneSizes();
+  auiManager->Update();
 
   layoutModeActive = layoutMode;
 
@@ -390,6 +392,28 @@ void MainWindow::ApplyLayoutPreset(const LayoutViewPreset &preset,
   }
 
   UpdateViewMenuChecks();
+}
+
+void MainWindow::RefreshToolbarPaneSizes() {
+  if (!auiManager)
+    return;
+
+  auto refreshToolbarLayout = [this](wxAuiToolBar *toolbar,
+                                     const std::string &paneName) {
+    if (!toolbar)
+      return;
+    toolbar->Realize();
+    toolbar->InvalidateBestSize();
+    const wxSize bestSize = toolbar->GetBestSize();
+    toolbar->SetMinSize(bestSize);
+    auto &pane = auiManager->GetPane(paneName);
+    if (pane.IsOk())
+      pane.BestSize(bestSize).MinSize(bestSize);
+  };
+
+  refreshToolbarLayout(fileToolBar, "FileToolbar");
+  refreshToolbarLayout(layoutViewsToolBar, "LayoutViewsToolbar");
+  refreshToolbarLayout(layoutToolBar, "LayoutToolbar");
 }
 
 void MainWindow::ApplySavedLayout() {
@@ -448,20 +472,7 @@ void MainWindow::ApplySavedLayout() {
   if (view2dPane.IsOk())
     view2dPane.MinSize(wxSize(250, 600));
 
-  auto refreshToolbarLayout = [this](wxAuiToolBar *toolbar,
-                                     const std::string &paneName) {
-    if (!toolbar)
-      return;
-    toolbar->Realize();
-    toolbar->InvalidateBestSize();
-    auto &pane = auiManager->GetPane(paneName);
-    if (pane.IsOk())
-      pane.BestSize(toolbar->GetBestSize());
-  };
-
-  refreshToolbarLayout(fileToolBar, "FileToolbar");
-  refreshToolbarLayout(layoutViewsToolBar, "LayoutViewsToolbar");
-  refreshToolbarLayout(layoutToolBar, "LayoutToolbar");
+  RefreshToolbarPaneSizes();
 
   auiManager->Update();
   SendSizeEvent();


### PR DESCRIPTION
### Motivation

- Saved layout perspectives can leave toolbar panes with stale/shrunken sizes which hides newly added toolbar icons until the user moves the pane. 
- Ensure toolbar best/min sizes are recalculated and re-applied after perspective/load/preset changes so toolbars display correctly immediately.

### Description

- Added a new `MainWindow::RefreshToolbarPaneSizes()` declaration in `gui/mainwindow.h` to centralize toolbar resizing logic.  
- Implemented `RefreshToolbarPaneSizes()` in `gui/mainwindow_layout.cpp` to call `Realize()`, `InvalidateBestSize()`, compute `GetBestSize()`, call `SetMinSize()` on the toolbar and apply `BestSize(...).MinSize(...)` to the corresponding AUI panes.  
- Replaced the previous inline toolbar sizing lambda in `ApplySavedLayout()` with the shared `RefreshToolbarPaneSizes()` helper and wired the helper into `ApplyLayoutPreset()` so toolbar sizes are revalidated surrounding `auiManager->Update()` calls.  

### Testing

- No automated tests were run for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e1a72b8e88324b9569e91cf9f3fad)