### PR TITLE
Fix default layout image aspect ratio on insert

### DIFF
--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -164,14 +164,21 @@ layouts::Layout2DViewFrame BuildDefaultLayoutImageFrame(
     width = height * ratio;
   }
 
-  int finalWidth = std::max(kMinFrameSize,
-                            static_cast<int>(std::lround(width)));
-  int finalHeight = std::max(kMinFrameSize,
-                             static_cast<int>(std::lround(height)));
+  if (width < kMinFrameSize || height < kMinFrameSize) {
+    const double scale =
+        std::max(kMinFrameSize / width, kMinFrameSize / height);
+    width *= scale;
+    height *= scale;
+  }
 
-  finalWidth = std::min(finalWidth, static_cast<int>(std::lround(pageWidth)));
-  finalHeight = std::min(finalHeight,
-                         static_cast<int>(std::lround(pageHeight)));
+  const double maxScale = std::min(pageWidth / width, pageHeight / height);
+  if (maxScale < 1.0) {
+    width *= maxScale;
+    height *= maxScale;
+  }
+
+  int finalWidth = static_cast<int>(std::lround(width));
+  int finalHeight = static_cast<int>(std::lround(height));
 
   int x = std::max(
       0, static_cast<int>(std::lround((pageWidth - finalWidth) / 2.0)));


### PR DESCRIPTION
### Motivation
- New images inserted into a layout were getting a fixed size and did not preserve their aspect ratio until manually scaled. 
- The intent is to compute the initial image frame so the image appears with correct proportions while still respecting minimum and page bounds.

### Description
- Update `BuildDefaultLayoutImageFrame` in `gui/mainwindow_layout.cpp` to change how default image frame sizes are computed.
- If the computed `width` or `height` is below `kMinFrameSize`, scale both dimensions up using a uniform `scale` to preserve the aspect ratio.
- Compute a `maxScale` based on `pageWidth`/`pageHeight` to ensure the frame fits the page and scale down if necessary, then round to `finalWidth`/`finalHeight`.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e1ca200cc8324ad0b57201bca46cf)