### PR TITLE
Remove default outline from layout images

### DIFF
--- a/gui/layoutviewerpanel_image.cpp
+++ b/gui/layoutviewerpanel_image.cpp
@@ -238,23 +238,18 @@ void LayoutViewerPanel::DrawImageElement(
   if (image.id == activeImageId) {
     glColor4ub(60, 160, 240, 255);
     glLineWidth(2.0f);
-  } else {
-    glColor4ub(160, 160, 160, 255);
-    glLineWidth(1.0f);
-  }
-  glBegin(GL_LINE_LOOP);
-  glVertex2f(static_cast<float>(frameRect.GetLeft()),
-             static_cast<float>(frameRect.GetTop()));
-  glVertex2f(static_cast<float>(frameRight),
-             static_cast<float>(frameRect.GetTop()));
-  glVertex2f(static_cast<float>(frameRight),
-             static_cast<float>(frameBottom));
-  glVertex2f(static_cast<float>(frameRect.GetLeft()),
-             static_cast<float>(frameRect.GetBottom()));
-  glEnd();
-
-  if (image.id == activeImageId)
+    glBegin(GL_LINE_LOOP);
+    glVertex2f(static_cast<float>(frameRect.GetLeft()),
+               static_cast<float>(frameRect.GetTop()));
+    glVertex2f(static_cast<float>(frameRight),
+               static_cast<float>(frameRect.GetTop()));
+    glVertex2f(static_cast<float>(frameRight),
+               static_cast<float>(frameBottom));
+    glVertex2f(static_cast<float>(frameRect.GetLeft()),
+               static_cast<float>(frameRect.GetBottom()));
+    glEnd();
     DrawSelectionHandles(frameRect);
+  }
 }
 
 size_t LayoutViewerPanel::HashImageContent(


### PR DESCRIPTION
### Motivation
- Inserted layout images were drawn with a default outline even when not selected, producing an unwanted visible border; only the active image should show a selection outline.

### Description
- Update `LayoutViewerPanel::DrawImageElement` in `gui/layoutviewerpanel_image.cpp` to only draw the line loop and selection handles when `image.id == activeImageId`, removing the default outline for non-active images.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e1db786cc8324819af313e3b81d68)