### PR TITLE
Defer layout config syncs during drag operations

### DIFF
--- a/core/layouts/LayoutManager.h
+++ b/core/layouts/LayoutManager.h
@@ -55,6 +55,9 @@ public:
   bool RemoveLayoutImage(const std::string &name, int imageId);
   bool MoveLayoutImage(const std::string &name, int imageId, bool toFront);
 
+  void BeginBatchUpdate();
+  void EndBatchUpdate();
+
   void LoadFromConfig(ConfigManager &cfg);
   void SaveToConfig(ConfigManager &cfg) const;
   void ResetToDefault(ConfigManager &cfg);
@@ -64,6 +67,8 @@ private:
   void SyncToConfig();
 
   LayoutCollection layouts;
+  int batchDepth = 0;
+  bool pendingSync = false;
 };
 
 } // namespace layouts

--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -422,6 +422,9 @@ void LayoutViewerPanel::OnLeftDown(wxMouseEvent &event) {
       dragStartPos = pos;
       dragStartFrame = selectedFrame;
       CaptureMouse();
+      if (!currentLayout.name.empty()) {
+        layouts::LayoutManager::Get().BeginBatchUpdate();
+      }
       return;
     }
   }
@@ -434,6 +437,7 @@ void LayoutViewerPanel::OnLeftDown(wxMouseEvent &event) {
 void LayoutViewerPanel::OnLeftUp(wxMouseEvent &) {
   if (dragMode != FrameDragMode::None) {
     dragMode = FrameDragMode::None;
+    layouts::LayoutManager::Get().EndBatchUpdate();
     if (HasCapture())
       ReleaseMouse();
     return;
@@ -635,6 +639,9 @@ void LayoutViewerPanel::OnMouseWheel(wxMouseEvent &event) {
 
 void LayoutViewerPanel::OnCaptureLost(wxMouseCaptureLostEvent &) {
   isPanning = false;
+  if (dragMode != FrameDragMode::None) {
+    layouts::LayoutManager::Get().EndBatchUpdate();
+  }
   dragMode = FrameDragMode::None;
 }
 


### PR DESCRIPTION
### Motivation
- Prevent frequent config writes while the user is dragging/resizing layout elements by deferring syncs until the drag finishes.
- Ensure a robust end-of-drag path that still performs a single sync if capture is lost during a drag.

### Description
- Added `BeginBatchUpdate()` and `EndBatchUpdate()` to `layouts::LayoutManager` and internal state `batchDepth`/`pendingSync` to track batches.
- Modified `SyncToConfig()` to set `pendingSync` while `batchDepth > 0` and to call `SaveToConfig()` only when the batch completes.
- Implemented `EndBatchUpdate()` to trigger `SaveToConfig()` when leaving the outermost batch and a sync is pending.
- Started a batch on drag start and ended it on drag end and capture loss by calling `BeginBatchUpdate()`/`EndBatchUpdate()` from `LayoutViewerPanel::OnLeftDown`, `OnLeftUp`, and `OnCaptureLost`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e1e9572008324b92a0287d7094a0c)