### PR TITLE
Logger: batch messages and add flush policy

### DIFF
--- a/core/logger.h
+++ b/core/logger.h
@@ -17,6 +17,7 @@
  */
 #pragma once
 #include <condition_variable>
+#include <cstddef>
 #include <fstream>
 #include <mutex>
 #include <queue>
@@ -30,7 +31,7 @@ public:
   static Logger &Instance();
 
   // Queue a message to be logged.
-  void Log(const std::string &msg);
+  void Log(std::string msg);
 
 private:
   Logger();
@@ -39,6 +40,9 @@ private:
   Logger &operator=(const Logger &) = delete;
 
   void Worker();
+
+  // Flush policy: flush after every kFlushInterval messages or during shutdown.
+  static constexpr std::size_t kFlushInterval = 32;
 
   std::ofstream file_;
   std::mutex mutex_;


### PR DESCRIPTION
### Motivation
- Reduce per-message I/O overhead and avoid flushing on every log write by batching messages before writing to disk.
- Allow move semantics to avoid extra string copies when queuing log messages via `queue_.push(std::move(msg))`.
- Make flush behavior explicit and configurable by documenting a `kFlushInterval` policy.

### Description
- Change `Logger::Log` signature to `void Log(std::string msg)` and push messages with `std::move(msg)` into the queue.
- Batch all available queued messages in `Worker()` into a `std::vector<std::string>`, concatenate them into a single `buffer`, and write the buffer to the log file and `std::cerr` in one operation.
- Replace per-message `file_.flush()` with a `messages_since_flush` counter and a compile-time `kFlushInterval` that triggers `file_.flush()` every N messages or on shutdown.
- Add `#include <cstddef>` and `#include <vector>` and document the flush policy in the header.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e23bd84888324b22441b51b26b186)