### PR TITLE
Rewrite NaturalLess to use std::string_view with manual numeric parsing and add tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,11 @@ if(TARGET podofo::podofo)
     set_library_env(PdfTextComparison)
 endif()
 
+add_executable(stringutils_test stringutils_test.cpp)
+target_include_directories(stringutils_test PRIVATE ../core)
+add_test(NAME StringUtilsNaturalLess COMMAND stringutils_test)
+set_library_env(StringUtilsNaturalLess)
+
 add_executable(autopatcher_test autopatcher_test.cpp
                ../core/autopatcher.cpp
                ../core/patchmanager.cpp)

--- a/tests/stringutils_test.cpp
+++ b/tests/stringutils_test.cpp
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "../core/stringutils.h"
+#include <cassert>
+#include <string>
+
+int main() {
+  using StringUtils::NaturalLess;
+
+  assert(NaturalLess("item2", "item10"));
+  assert(!NaturalLess("item10", "item2"));
+
+  assert(NaturalLess("item", "item2"));
+  assert(!NaturalLess("item2", "item"));
+
+  assert(NaturalLess("item2", "item02"));
+  assert(!NaturalLess("item02", "item2"));
+
+  assert(NaturalLess("alpha", "beta"));
+  assert(!NaturalLess("beta", "alpha"));
+
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- Replace allocations and `strtol` usage in `NaturalLess` to improve performance and reduce temporaries by using `std::string_view` and index-based traversal.
- Preserve existing natural-sort semantics (compare common prefix, then numeric suffix, breaking ties by length) while avoiding `substr` and `strtol`.
- Add unit coverage to ensure the new implementation matches the previous behavior.

### Description
- Change signature of `NaturalLess` to `inline bool NaturalLess(std::string_view a, std::string_view b)` and remove the `<cstdlib>` dependency in `core/stringutils.h`.
- Implement `extract` to walk backwards to find a numeric suffix and accumulate the numeric value manually with a `long` instead of calling `strtol` or creating substrings.
- Keep the same comparison logic: if prefixes match and either side had a numeric suffix compare numeric values, otherwise compare sizes to break ties, and fallback to lexicographical compare of the whole `string_view`.
- Add `tests/stringutils_test.cpp` with assertions covering the natural comparisons and register the new `StringUtilsNaturalLess` test in `tests/CMakeLists.txt`.

### Testing
- Added an automated test target `StringUtilsNaturalLess` that runs `tests/stringutils_test.cpp` and is registered in `tests/CMakeLists.txt`.
- No automated tests were executed as part of this change (the new test was added but not run in this rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e244cdcc883248887d89fff1dc1d4)