### PR TITLE
Fix rider text import conversion and empty-input validation

### DIFF
--- a/gui/ridertextdialog.cpp
+++ b/gui/ridertextdialog.cpp
@@ -133,10 +133,15 @@ void RiderTextDialog::OnLoadExample(wxCommandEvent &WXUNUSED(event)) {
 }
 
 void RiderTextDialog::OnApply(wxCommandEvent &WXUNUSED(event)) {
-  wxScopedCharBuffer utf8Text = textCtrl->GetValue().ToUTF8();
-  std::string text = utf8Text.data()
-                         ? std::string(utf8Text.data(), utf8Text.length())
-                         : std::string();
+  wxString value = textCtrl->GetValue();
+  std::string text = value.ToStdString(wxConvUTF8);
+  if (text.empty() && !value.empty()) {
+    text = value.ToStdString();
+  }
+  if (text.empty()) {
+    wxMessageBox("Rider text is empty.", "Error", wxICON_ERROR);
+    return;
+  }
   if (!RiderImporter::ImportText(text)) {
     wxMessageBox("Failed to import rider text.", "Error", wxICON_ERROR);
     return;


### PR DESCRIPTION
### Motivation
- Importing riders from the text dialog could silently fail because the dialog conversion produced an empty or incorrectly encoded `std::string`, so `RiderImporter::ImportText` received no data and no fixtures/trusses were created.
- The dialog also lacked an explicit check for empty input, causing a silent no-op when the user clicked `Apply` with no content.

### Description
- Replace the previous `ToUTF8`/`wxScopedCharBuffer` conversion with a robust conversion using `value.ToStdString(wxConvUTF8)` and a fallback to `value.ToStdString()` to preserve UTF-8 input accurately.
- Add an explicit empty-input validation that shows `wxMessageBox("Rider text is empty.")` and aborts the import when no text is present.
- Change implemented in `gui/ridertextdialog.cpp` inside `RiderTextDialog::OnApply`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e27a34bf4832484b88189735aa4c0)