### PR TITLE
Handle missing or unwritable user data dir for last project path

### DIFF
--- a/core/projectutils.cpp
+++ b/core/projectutils.cpp
@@ -93,15 +93,23 @@ fs::path GetResourceRoot()
 std::string GetLastProjectPathFile()
 {
     wxString dir = wxStandardPaths::Get().GetUserDataDir();
+    if (dir.empty())
+        return {};
     fs::path p = fs::path(dir.ToStdString());
-    fs::create_directories(p);
+    std::error_code ec;
+    fs::create_directories(p, ec);
+    if (ec)
+        return {};
     p /= "last_project.txt";
     return p.string();
 }
 
 bool SaveLastProjectPath(const std::string& path)
 {
-    std::ofstream out(GetLastProjectPathFile());
+    const std::string pathFile = GetLastProjectPathFile();
+    if (pathFile.empty())
+        return false;
+    std::ofstream out(pathFile);
     if (!out.is_open())
         return false;
     out << path;
@@ -110,7 +118,10 @@ bool SaveLastProjectPath(const std::string& path)
 
 std::optional<std::string> LoadLastProjectPath()
 {
-    std::ifstream in(GetLastProjectPathFile());
+    const std::string pathFile = GetLastProjectPathFile();
+    if (pathFile.empty())
+        return std::nullopt;
+    std::ifstream in(pathFile);
     if (!in.is_open())
         return std::nullopt;
     std::string path;


### PR DESCRIPTION
### Motivation
- Prevent the app from blocking when loading the "last project" if `wxStandardPaths::Get().GetUserDataDir()` is empty or not writable, which left the splash screen showing "Loading last project..." and the 3D viewport not appearing.

### Description
- Return an empty path from `GetLastProjectPathFile()` if `wxStandardPaths::Get().GetUserDataDir()` is empty.
- Use `std::error_code` with `fs::create_directories()` and return an empty path if directory creation fails to avoid throwing or creating invalid paths.
- Make `SaveLastProjectPath()` and `LoadLastProjectPath()` check the returned path from `GetLastProjectPathFile()` and fail early if it is empty to avoid attempting file I/O on an invalid path.
- Small refactor to centralize the `last_project.txt` path into a local `pathFile` variable in save/load functions.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e3f7247688324891235f92537e9ca)