### PR TITLE
Stabilize last-project loading across launch contexts

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -34,6 +34,9 @@ public:
 wxIMPLEMENT_APP(MyApp);
 
 bool MyApp::OnInit() {
+  SetAppName("Perastage");
+  SetVendorName("Perastage");
+
   // Enable support for common image formats used by the app
   wxInitAllImageHandlers();
 


### PR DESCRIPTION
### Motivation
- The app could show `Untitled` or fail to open the last project when launched outside of VS Code because user-data paths and stored project paths were resolved relative to different bases. 
- Persisting stable absolute paths and a consistent application name ensures `wxStandardPaths::Get().GetUserDataDir()` and the saved last-project path behave the same across launch contexts.

### Description
- Call `SetAppName("Perastage")` and `SetVendorName("Perastage")` in `main.cpp` so `wxStandardPaths` returns a stable user data directory across different launch contexts. 
- Update `SaveLastProjectPath` in `core/projectutils.cpp` to always persist an absolute path when possible and correctly write empty values. 
- Update `LoadLastProjectPath` in `core/projectutils.cpp` to read the raw saved value and resolve it robustly by accepting absolute paths, trying the current working directory, and falling back to resolving relative paths against the executable directory before returning the candidate path. 
- Keep legacy and error fallbacks so invalid or non-existent stored paths do not block startup and can be cleared.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e41e622e0832487a0b4bd2ef1dbf6)