### PR TITLE
Fix resource fallbacks and last-project path resolution

### DIFF
--- a/gui/splashscreen.cpp
+++ b/gui/splashscreen.cpp
@@ -14,15 +14,7 @@ wxFrame *g_splash = nullptr;
 wxStaticText *g_label = nullptr;
 
 void LogMissingIcon(const std::filesystem::path &path) {
-#ifndef NDEBUG
-  wxLogDebug("Splash icon not found at '%s'", path.string().c_str());
-  wxASSERT_MSG(
-      false,
-      wxString::Format("Splash icon not found at '%s'",
-                       wxString::FromUTF8(path.string()).c_str()));
-#else
   wxLogWarning("Splash icon not found at '%s'", path.string().c_str());
-#endif
 }
 }
 
@@ -38,13 +30,17 @@ void SplashScreen::Show() {
 
   wxBitmap logoBmp;
   wxIconBundle bundle;
-  std::filesystem::path iconPath =
-      ProjectUtils::GetResourceRoot() / "Perastage.ico";
+  const std::filesystem::path resourceRoot = ProjectUtils::GetResourceRoot();
+  std::filesystem::path iconPath;
+  if (!resourceRoot.empty())
+    iconPath = resourceRoot / "Perastage.ico";
   std::error_code ec;
-  if (std::filesystem::exists(iconPath, ec)) {
+  if (!iconPath.empty() && std::filesystem::exists(iconPath, ec)) {
     bundle.AddIcon(iconPath.string(), wxBITMAP_TYPE_ICO);
   } else {
-    LogMissingIcon(iconPath);
+    LogMissingIcon(
+        iconPath.empty() ? std::filesystem::path("resources/Perastage.ico")
+                         : iconPath);
   }
   wxIcon icon = bundle.GetIcon(wxSize(256, 256));
   if (icon.IsOk())

--- a/main.cpp
+++ b/main.cpp
@@ -35,7 +35,7 @@ wxIMPLEMENT_APP(MyApp);
 
 bool MyApp::OnInit() {
   SetAppName("Perastage");
-  SetVendorName("Perastage");
+  SetVendorName("Perasoft");
 
   // Enable support for common image formats used by the app
   wxInitAllImageHandlers();
@@ -71,7 +71,11 @@ bool MyApp::OnInit() {
       namespace fs = std::filesystem;
       path = *last;
       std::error_code ec;
-      fs::path lastPath = fs::u8path(path);
+      fs::path lastPath = fs::absolute(fs::u8path(path), ec);
+      if (!ec) {
+        std::u8string u8Path = lastPath.u8string();
+        path.assign(u8Path.begin(), u8Path.end());
+      }
       bool isFile = fs::is_regular_file(lastPath, ec);
       if (ec || !isFile) {
         ProjectUtils::SaveLastProjectPath("");


### PR DESCRIPTION
### Motivation
- Prevent startup from blocking when icon/resource files are missing by removing assertion dialogs that can hang the splash screen. 
- Make resource discovery more robust so the app can find its `resources` directory when launched from different locations. 
- Ensure the saved "last project" path is valid regardless of the current working directory by storing and resolving absolute paths. 
- Make `wxStandardPaths::Get().GetUserDataDir()` stable between builds by setting explicit application and vendor names in `OnInit()`.

### Description
- Replace assertion-based handling in `LogMissingIcon()` with a `wxLogWarning()` and add safe fallbacks for missing icons in `gui/splashscreen.cpp` and `gui/mainwindow.cpp` so the splash logo uses `wxArtProvider::GetBitmap(wxART_MISSING_IMAGE, ...)` and the main window uses `wxArtProvider::GetIcon(wxART_MISSING_IMAGE)` when `Perastage.ico` is unavailable. 
- Change callers to tolerate an empty resource root returned by `ProjectUtils::GetResourceRoot()` and pass a sensible diagnostic path to `LogMissingIcon()` when none is found. 
- Update `core/projectutils.cpp` `GetResourceRoot()` to fall back to `wxStandardPaths::Get().GetResourcesDir()` (with existence checks) and return an empty path if no resource directory can be found. 
- Persist and load last-project paths as absolute UTF-8 paths by using `std::filesystem::absolute(fs::u8path(...))` in `ProjectUtils::SaveLastProjectPath()` and `ProjectUtils::LoadLastProjectPath()`, and adjust `main.cpp` loader thread to call `std::filesystem::absolute()` on the loaded path before checking `is_regular_file()`. 
- Set a stable vendor name in `MyApp::OnInit()` via `SetAppName("Perastage")` and `SetVendorName("Perasoft")` to keep `GetUserDataDir()` stable between debug/release runs. 
- No changes to CMake install scripts were required in this patch (verify that existing CMake copy commands are used when packaging).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e447aa89c8324a386618f31440310)