### PR TITLE
Avoid background wxStandardPaths access during startup

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -653,8 +653,11 @@ void MainWindow::RefreshAfterSceneChange(bool refreshViewport) {
 
 void MainWindow::OnProjectLoaded(wxCommandEvent &event) {
   bool loaded = event.GetInt() != 0;
+  bool clearLastProject = event.GetExtraLong() != 0;
   std::string path = event.GetString().ToStdString();
   Ensure3DViewport();
+  if (clearLastProject)
+    ProjectUtils::SaveLastProjectPath("");
   if (loaded && !path.empty()) {
     currentProjectPath = path;
     ProjectUtils::SaveLastProjectPath(currentProjectPath);


### PR DESCRIPTION
### Motivation
- Startup could hang when the app runs outside IDEs because `wxStandardPaths` was being accessed from a background thread while loading the "last project", leaving the splash stuck on "Loading last project...". 
- The code also attempted to clear invalid last-project paths from the worker thread which can race with UI APIs and cause inconsistent state.

### Description
- Move the `ProjectUtils::LoadLastProjectPath()` lookup to the main thread and pass the resolved path into the loader worker so background work avoids calling `wxStandardPaths` or other UI APIs (`main.cpp`).
- Change the loader thread to resolve the filesystem path with `std::filesystem` and signal the UI with `EVT_PROJECT_LOADED` including an `ExtraLong` flag (via `SetExtraLong`) that indicates the last-project entry should be cleared; `MainWindow::OnProjectLoaded` now clears the saved last-project on the UI thread when that flag is set (`gui/mainwindow.cpp`).
- Ensure a `EVT_PROJECT_LOADED` event is always queued at startup even when there is no recent file, so the splash screen is dismissed reliably.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e479c22d08324831fab3310f894f9)