### PR TITLE
Fallback library storage to user data when base dir is not writable

### DIFF
--- a/core/projectutils.cpp
+++ b/core/projectutils.cpp
@@ -203,6 +203,13 @@ std::string GetDefaultLibraryPath(const std::string& subdir)
     if (!ec)
         return baseLib.string();
 
+    fs::path userLib = fs::path(wxStandardPaths::Get().GetUserDataDir().ToStdString()) /
+                      "library" / subdir;
+    ec.clear();
+    fs::create_directories(userLib, ec);
+    if (!ec)
+        return fs::absolute(userLib).string();
+
     return {};
 #endif
 }


### PR DESCRIPTION
### Motivation
- Avoid failing to locate or create the global library directory when the base library path is not writable by falling back to a per-user `library/<subdir>` location so the application can still store and load resources.

### Description
- In `core/projectutils.cpp` add an attempt to create and return `wxStandardPaths::Get().GetUserDataDir()/library/<subdir>` when creating `baseLib` fails in the non-`NDEBUG` (debug) code path.

### Testing
- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e55c865b083248f69fe64c2986744)