### PR TITLE
Guard selection color setters for older wxWidgets (pre-3.3)

### DIFF
--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -112,8 +112,10 @@ FixtureTablePanel::FixtureTablePanel(wxWindow *parent)
   store->DecRef();
 
   table->SetAlternateRowColour(wxColour(40, 40, 40));
+#if wxCHECK_VERSION(3, 3, 0)
   table->SetSelectionBackground(wxColour(0, 255, 255));
   table->SetSelectionForeground(wxColour(0, 0, 0));
+#endif
 
   table->Bind(wxEVT_LEFT_DOWN, &FixtureTablePanel::OnLeftDown, this);
   table->Bind(wxEVT_LEFT_UP, &FixtureTablePanel::OnLeftUp, this);

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -100,8 +100,10 @@ HoistTablePanel::HoistTablePanel(wxWindow *parent)
   store->DecRef();
 
   table->SetAlternateRowColour(wxColour(40, 40, 40));
+#if wxCHECK_VERSION(3, 3, 0)
   table->SetSelectionBackground(wxColour(0, 255, 255));
   table->SetSelectionForeground(wxColour(0, 0, 0));
+#endif
 
   table->Bind(wxEVT_LEFT_DOWN, &HoistTablePanel::OnLeftDown, this);
   table->Bind(wxEVT_LEFT_UP, &HoistTablePanel::OnLeftUp, this);

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -104,8 +104,10 @@ SceneObjectTablePanel::SceneObjectTablePanel(wxWindow* parent)
   store->DecRef();
 
   table->SetAlternateRowColour(wxColour(40, 40, 40));
+#if wxCHECK_VERSION(3, 3, 0)
   table->SetSelectionBackground(wxColour(0, 255, 255));
   table->SetSelectionForeground(wxColour(0, 0, 0));
+#endif
 
     table->Bind(wxEVT_LEFT_DOWN, &SceneObjectTablePanel::OnLeftDown, this);
     table->Bind(wxEVT_LEFT_UP, &SceneObjectTablePanel::OnLeftUp, this);

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -114,8 +114,10 @@ TrussTablePanel::TrussTablePanel(wxWindow* parent)
   store->DecRef();
 
   table->SetAlternateRowColour(wxColour(40, 40, 40));
+#if wxCHECK_VERSION(3, 3, 0)
   table->SetSelectionBackground(wxColour(0, 255, 255));
   table->SetSelectionForeground(wxColour(0, 0, 0));
+#endif
 
     table->Bind(wxEVT_LEFT_DOWN, &TrussTablePanel::OnLeftDown, this);
     table->Bind(wxEVT_LEFT_UP, &TrussTablePanel::OnLeftUp, this);


### PR DESCRIPTION
### Motivation
- Recent builds failed with errors indicating `SetSelectionBackground` and `SetSelectionForeground` are not members of `wxDataViewListCtrl` on older wxWidgets versions, so the selection color setters need to be disabled when the API is unavailable.

### Description
- Wrap calls to `SetSelectionBackground` and `SetSelectionForeground` with `#if wxCHECK_VERSION(3, 3, 0)` to only enable them on wxWidgets 3.3.0 and newer.
- Applied the change to the four data view panels: `TrussTablePanel`, `FixtureTablePanel`, `HoistTablePanel`, and `SceneObjectTablePanel` in the `gui/` directory.
- Kept the alternate row color call (`SetAlternateRowColour`) unchanged since it is available across supported wx versions.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fc4367df083249264ef291fb9d75f)