### PR TITLE
Restore cyan selection highlighting without wxWidgets 3.3 APIs

### DIFF
--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -112,10 +112,7 @@ FixtureTablePanel::FixtureTablePanel(wxWindow *parent)
   store->DecRef();
 
   table->SetAlternateRowColour(wxColour(40, 40, 40));
-#if wxCHECK_VERSION(3, 3, 0)
-  table->SetSelectionBackground(wxColour(0, 255, 255));
-  table->SetSelectionForeground(wxColour(0, 0, 0));
-#endif
+  store->SetSelectionColours(wxColour(0, 255, 255), wxColour(0, 0, 0));
 
   table->Bind(wxEVT_LEFT_DOWN, &FixtureTablePanel::OnLeftDown, this);
   table->Bind(wxEVT_LEFT_UP, &FixtureTablePanel::OnLeftUp, this);
@@ -1137,7 +1134,21 @@ void FixtureTablePanel::OnSelectionChanged(wxDataViewEvent &evt) {
   }
   if (Viewer3DPanel::Instance())
     Viewer3DPanel::Instance()->SetSelectedFixtures(uuids);
+  UpdateSelectionHighlight();
   evt.Skip();
+}
+
+void FixtureTablePanel::UpdateSelectionHighlight() {
+  size_t rowCount = table->GetItemCount();
+  std::vector<bool> selectedRows(rowCount, false);
+  wxDataViewItemArray selections;
+  table->GetSelections(selections);
+  for (const auto &it : selections) {
+    int r = table->ItemToRow(it);
+    if (r != wxNOT_FOUND && static_cast<size_t>(r) < rowCount)
+      selectedRows[r] = true;
+  }
+  store->SetSelectedRows(selectedRows);
 }
 
 void FixtureTablePanel::PropagateTypeValues(

--- a/gui/fixturetablepanel.h
+++ b/gui/fixturetablepanel.h
@@ -70,6 +70,7 @@ private:
     void OnMouseMove(wxMouseEvent& evt);
     void OnCaptureLost(wxMouseCaptureLostEvent& evt);
     void OnSelectionChanged(wxDataViewEvent& evt);
+    void UpdateSelectionHighlight();
     void PropagateTypeValues(const wxDataViewItemArray& selections, int col);
     void ApplyModeForGdtf(const wxString& path, const wxString& preferredMode = wxString());
     void HighlightDuplicateFixtureIds();

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -100,10 +100,7 @@ HoistTablePanel::HoistTablePanel(wxWindow *parent)
   store->DecRef();
 
   table->SetAlternateRowColour(wxColour(40, 40, 40));
-#if wxCHECK_VERSION(3, 3, 0)
-  table->SetSelectionBackground(wxColour(0, 255, 255));
-  table->SetSelectionForeground(wxColour(0, 0, 0));
-#endif
+  store->SetSelectionColours(wxColour(0, 255, 255), wxColour(0, 0, 0));
 
   table->Bind(wxEVT_LEFT_DOWN, &HoistTablePanel::OnLeftDown, this);
   table->Bind(wxEVT_LEFT_UP, &HoistTablePanel::OnLeftUp, this);
@@ -491,7 +488,21 @@ void HoistTablePanel::OnSelectionChanged(wxDataViewEvent &evt) {
   }
   if (Viewer3DPanel::Instance())
     Viewer3DPanel::Instance()->SetSelectedFixtures(uuids);
+  UpdateSelectionHighlight();
   evt.Skip();
+}
+
+void HoistTablePanel::UpdateSelectionHighlight() {
+  size_t rowCount = table->GetItemCount();
+  std::vector<bool> selectedRows(rowCount, false);
+  wxDataViewItemArray selections;
+  table->GetSelections(selections);
+  for (const auto &it : selections) {
+    int r = table->ItemToRow(it);
+    if (r != wxNOT_FOUND && static_cast<size_t>(r) < rowCount)
+      selectedRows[r] = true;
+  }
+  store->SetSelectedRows(selectedRows);
 }
 
 void HoistTablePanel::UpdateSceneData() {

--- a/gui/hoisttablepanel.h
+++ b/gui/hoisttablepanel.h
@@ -60,4 +60,5 @@ private:
   void OnLeftUp(wxMouseEvent &evt);
   void OnMouseMove(wxMouseEvent &evt);
   void OnCaptureLost(wxMouseCaptureLostEvent &evt);
+  void UpdateSelectionHighlight();
 };

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -104,10 +104,7 @@ SceneObjectTablePanel::SceneObjectTablePanel(wxWindow* parent)
   store->DecRef();
 
   table->SetAlternateRowColour(wxColour(40, 40, 40));
-#if wxCHECK_VERSION(3, 3, 0)
-  table->SetSelectionBackground(wxColour(0, 255, 255));
-  table->SetSelectionForeground(wxColour(0, 0, 0));
-#endif
+  store->SetSelectionColours(wxColour(0, 255, 255), wxColour(0, 0, 0));
 
     table->Bind(wxEVT_LEFT_DOWN, &SceneObjectTablePanel::OnLeftDown, this);
     table->Bind(wxEVT_LEFT_UP, &SceneObjectTablePanel::OnLeftUp, this);
@@ -472,7 +469,23 @@ void SceneObjectTablePanel::OnSelectionChanged(wxDataViewEvent& evt)
     }
     if (Viewer3DPanel::Instance())
         Viewer3DPanel::Instance()->SetSelectedFixtures(uuids);
+    UpdateSelectionHighlight();
     evt.Skip();
+}
+
+void SceneObjectTablePanel::UpdateSelectionHighlight()
+{
+    size_t rowCount = table->GetItemCount();
+    std::vector<bool> selectedRows(rowCount, false);
+    wxDataViewItemArray selections;
+    table->GetSelections(selections);
+    for (const auto& it : selections)
+    {
+        int r = table->ItemToRow(it);
+        if (r != wxNOT_FOUND && static_cast<size_t>(r) < rowCount)
+            selectedRows[r] = true;
+    }
+    store->SetSelectedRows(selectedRows);
 }
 
 void SceneObjectTablePanel::UpdateSceneData()

--- a/gui/sceneobjecttablepanel.h
+++ b/gui/sceneobjecttablepanel.h
@@ -60,4 +60,5 @@ private:
     void OnLeftUp(wxMouseEvent& evt);
     void OnMouseMove(wxMouseEvent& evt);
     void OnCaptureLost(wxMouseCaptureLostEvent& evt);
+    void UpdateSelectionHighlight();
 };

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -114,10 +114,7 @@ TrussTablePanel::TrussTablePanel(wxWindow* parent)
   store->DecRef();
 
   table->SetAlternateRowColour(wxColour(40, 40, 40));
-#if wxCHECK_VERSION(3, 3, 0)
-  table->SetSelectionBackground(wxColour(0, 255, 255));
-  table->SetSelectionForeground(wxColour(0, 0, 0));
-#endif
+  store->SetSelectionColours(wxColour(0, 255, 255), wxColour(0, 0, 0));
 
     table->Bind(wxEVT_LEFT_DOWN, &TrussTablePanel::OnLeftDown, this);
     table->Bind(wxEVT_LEFT_UP, &TrussTablePanel::OnLeftUp, this);
@@ -639,7 +636,23 @@ void TrussTablePanel::OnSelectionChanged(wxDataViewEvent& evt)
     }
     if (Viewer3DPanel::Instance())
         Viewer3DPanel::Instance()->SetSelectedFixtures(uuids);
+    UpdateSelectionHighlight();
     evt.Skip();
+}
+
+void TrussTablePanel::UpdateSelectionHighlight()
+{
+    size_t rowCount = table->GetItemCount();
+    std::vector<bool> selectedRows(rowCount, false);
+    wxDataViewItemArray selections;
+    table->GetSelections(selections);
+    for (const auto& it : selections)
+    {
+        int r = table->ItemToRow(it);
+        if (r != wxNOT_FOUND && static_cast<size_t>(r) < rowCount)
+            selectedRows[r] = true;
+    }
+    store->SetSelectedRows(selectedRows);
 }
 
 void TrussTablePanel::UpdateSceneData()

--- a/gui/trusstablepanel.h
+++ b/gui/trusstablepanel.h
@@ -62,4 +62,5 @@ private:
     void OnLeftUp(wxMouseEvent& evt);
     void OnMouseMove(wxMouseEvent& evt);
     void OnCaptureLost(wxMouseCaptureLostEvent& evt);
+    void UpdateSelectionHighlight();
 };


### PR DESCRIPTION
### Motivation
- wxWidgets 3.3+ APIs like `SetSelectionBackground`/`SetSelectionForeground` are not available on all targets, so selection coloring must be implemented without relying on those members.
- The goal is to keep the visual cyan selection (and black text) behavior while preserving existing per-row/per-cell styling such as green row highlights and red cell text.

### Description
- Added selection-tracking and color state to the model by extending `ColorfulDataViewListStore` with `selectionRows`, `selectionBackground`, `selectionForeground`, `SetSelectionColours`, and `SetSelectedRows`, and updated `GetAttrByRow` to merge selection colors with existing row/cell attributes.
- Replaced `SetSelectionBackground`/`SetSelectionForeground` usage in the table panels with `store->SetSelectionColours(...)` in `gui/hoisttablepanel.cpp`, `gui/sceneobjecttablepanel.cpp`, `gui/trusstablepanel.cpp`, and `gui/fixturetablepanel.cpp`.
- Added `UpdateSelectionHighlight` helper to each table panel header and implementation to compute selected rows and call `store->SetSelectedRows(...)` when selections change.
- Preserved existing alternate-row coloring and per-cell text/row background behavior while applying selection background and only applying selection foreground when a row/cell does not already specify text color.

### Testing
- No automated tests were run against these changes.
- Manual verification is recommended to confirm selection rendering in UI configurations that previously relied on `wxDataViewListCtrl` selection APIs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fc4f9b5388324aaaaadb0d14558af)