### PR TITLE
Guard std::max usage in gui/colorstore.h to avoid macro collision

### DIFF
--- a/gui/colorstore.h
+++ b/gui/colorstore.h
@@ -173,7 +173,7 @@ public:
     selectionRows.assign(rows.begin(), rows.end());
     if (rowAttrs.size() > selectionRows.size())
       selectionRows.resize(rowAttrs.size(), false);
-    size_t notifyCount = std::max(oldSize, selectionRows.size());
+    size_t notifyCount = (std::max)(oldSize, selectionRows.size());
     for (size_t i = 0; i < notifyCount; ++i) {
       bool oldVal = i < oldSize ? oldRows[i] : false;
       bool newVal = i < selectionRows.size() ? selectionRows[i] : false;


### PR DESCRIPTION
### Motivation
- Fix compile errors on Windows caused by a `max` macro colliding with the `std::max` call in `SetSelectedRows` of `gui/colorstore.h`.

### Description
- Replace `std::max(oldSize, selectionRows.size())` with `(std::max)(oldSize, selectionRows.size())` in `gui/colorstore.h` to prevent macro expansion and restore correct overload resolution.

### Testing
- No automated tests were run for this trivial fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fc7ec9f9c8324bda1fbc77c4ccf82)