### PR TITLE
Sync cyan selection highlight for fixture/truss/hoist/scene-object tables

### DIFF
--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -957,6 +957,7 @@ void FixtureTablePanel::HighlightPatchConflicts() {
 void FixtureTablePanel::ClearSelection() {
   table->UnselectAll();
   selectionOrder.clear();
+  UpdateSelectionHighlight();
 }
 
 std::vector<std::string> FixtureTablePanel::GetSelectedUuids() const {
@@ -983,6 +984,7 @@ void FixtureTablePanel::SelectByUuid(const std::vector<std::string> &uuids) {
       selectionOrder.push_back(row);
     }
   }
+  UpdateSelectionHighlight();
 }
 
 void FixtureTablePanel::DeleteSelected() {

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -614,7 +614,10 @@ void HoistTablePanel::HighlightHoist(const std::string &uuid) {
   table->Refresh();
 }
 
-void HoistTablePanel::ClearSelection() { table->UnselectAll(); }
+void HoistTablePanel::ClearSelection() {
+  table->UnselectAll();
+  UpdateSelectionHighlight();
+}
 
 std::vector<std::string> HoistTablePanel::GetSelectedUuids() const {
   wxDataViewItemArray selections;
@@ -636,6 +639,7 @@ void HoistTablePanel::SelectByUuid(const std::vector<std::string> &uuids) {
     if (pos != rowUuids.end())
       table->SelectRow(static_cast<int>(pos - rowUuids.begin()));
   }
+  UpdateSelectionHighlight();
 }
 
 void HoistTablePanel::DeleteSelected() {

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -566,6 +566,7 @@ void SceneObjectTablePanel::HighlightObject(const std::string& uuid)
 
 void SceneObjectTablePanel::ClearSelection() {
     table->UnselectAll();
+    UpdateSelectionHighlight();
 }
 
 std::vector<std::string> SceneObjectTablePanel::GetSelectedUuids() const {
@@ -588,6 +589,7 @@ void SceneObjectTablePanel::SelectByUuid(const std::vector<std::string>& uuids) 
         if (pos != rowUuids.end())
             table->SelectRow(static_cast<int>(pos - rowUuids.begin()));
     }
+    UpdateSelectionHighlight();
 }
 
 void SceneObjectTablePanel::DeleteSelected()

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -862,6 +862,7 @@ void TrussTablePanel::HighlightTruss(const std::string& uuid)
 
 void TrussTablePanel::ClearSelection() {
     table->UnselectAll();
+    UpdateSelectionHighlight();
 }
 
 std::vector<std::string> TrussTablePanel::GetSelectedUuids() const {
@@ -884,6 +885,7 @@ void TrussTablePanel::SelectByUuid(const std::vector<std::string>& uuids) {
         if (pos != rowUuids.end())
             table->SelectRow(static_cast<int>(pos - rowUuids.begin()));
     }
+    UpdateSelectionHighlight();
 }
 
 void TrussTablePanel::DeleteSelected()


### PR DESCRIPTION
### Motivation
- The previous change applied cyan selection highlighting to the summary/rigging tables, but the visual sync needs to happen on the object tables (Fixtures, Trusses, Hoists, Scene Objects).
- Programmatic selection changes (e.g. `SelectByUuid`, clearing selection) must update the custom store so the cyan highlight remains correct after selections are changed by code.
- Revert the incorrect summary/rigging modifications and apply the highlight synchronization where it belongs.

### Description
- Call `UpdateSelectionHighlight()` after programmatic selection changes in `FixtureTablePanel`, `TrussTablePanel`, `HoistTablePanel`, and `SceneObjectTablePanel` by adding the call at the end of `SelectByUuid()` and after `ClearSelection()` where appropriate (files changed: `gui/fixturetablepanel.cpp`, `gui/trusstablepanel.cpp`, `gui/hoisttablepanel.cpp`, `gui/sceneobjecttablepanel.cpp`).
- Ensure `ClearSelection()` implementations invoke `UpdateSelectionHighlight()` so unselecting also clears the custom selection highlight.
- Reverted the earlier modifications to the summary/rigging panels so the selection highlighting changes are applied only to the object tables (summary/rigging files were restored to their prior state).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fc8f0d9b483248c24887d656da6f4)