### PR TITLE
Use cyan selection highlight in data tables

### DIFF
--- a/gui/colorstore.h
+++ b/gui/colorstore.h
@@ -222,3 +222,18 @@ public:
     return wxDataViewListStore::Compare(item1, item2, column, ascending);
   }
 };
+
+inline void ApplyDataViewSelectionColours(wxDataViewCtrl *ctrl,
+                                          const wxColour &background,
+                                          const wxColour &foreground) {
+#if wxCHECK_VERSION(3, 1, 0)
+  if (ctrl) {
+    ctrl->SetSelectionBackground(background);
+    ctrl->SetSelectionForeground(foreground);
+  }
+#else
+  (void)ctrl;
+  (void)background;
+  (void)foreground;
+#endif
+}

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -112,7 +112,11 @@ FixtureTablePanel::FixtureTablePanel(wxWindow *parent)
   store->DecRef();
 
   table->SetAlternateRowColour(wxColour(40, 40, 40));
-  store->SetSelectionColours(wxColour(0, 255, 255), wxColour(0, 0, 0));
+  const wxColour selectionBackground(0, 255, 255);
+  const wxColour selectionForeground(0, 0, 0);
+  store->SetSelectionColours(selectionBackground, selectionForeground);
+  ApplyDataViewSelectionColours(table, selectionBackground,
+                                selectionForeground);
 
   table->Bind(wxEVT_LEFT_DOWN, &FixtureTablePanel::OnLeftDown, this);
   table->Bind(wxEVT_LEFT_UP, &FixtureTablePanel::OnLeftUp, this);

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -100,7 +100,11 @@ HoistTablePanel::HoistTablePanel(wxWindow *parent)
   store->DecRef();
 
   table->SetAlternateRowColour(wxColour(40, 40, 40));
-  store->SetSelectionColours(wxColour(0, 255, 255), wxColour(0, 0, 0));
+  const wxColour selectionBackground(0, 255, 255);
+  const wxColour selectionForeground(0, 0, 0);
+  store->SetSelectionColours(selectionBackground, selectionForeground);
+  ApplyDataViewSelectionColours(table, selectionBackground,
+                                selectionForeground);
 
   table->Bind(wxEVT_LEFT_DOWN, &HoistTablePanel::OnLeftDown, this);
   table->Bind(wxEVT_LEFT_UP, &HoistTablePanel::OnLeftUp, this);

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -104,7 +104,11 @@ SceneObjectTablePanel::SceneObjectTablePanel(wxWindow* parent)
   store->DecRef();
 
   table->SetAlternateRowColour(wxColour(40, 40, 40));
-  store->SetSelectionColours(wxColour(0, 255, 255), wxColour(0, 0, 0));
+  const wxColour selectionBackground(0, 255, 255);
+  const wxColour selectionForeground(0, 0, 0);
+  store->SetSelectionColours(selectionBackground, selectionForeground);
+  ApplyDataViewSelectionColours(table, selectionBackground,
+                                selectionForeground);
 
     table->Bind(wxEVT_LEFT_DOWN, &SceneObjectTablePanel::OnLeftDown, this);
     table->Bind(wxEVT_LEFT_UP, &SceneObjectTablePanel::OnLeftUp, this);

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -114,7 +114,11 @@ TrussTablePanel::TrussTablePanel(wxWindow* parent)
   store->DecRef();
 
   table->SetAlternateRowColour(wxColour(40, 40, 40));
-  store->SetSelectionColours(wxColour(0, 255, 255), wxColour(0, 0, 0));
+  const wxColour selectionBackground(0, 255, 255);
+  const wxColour selectionForeground(0, 0, 0);
+  store->SetSelectionColours(selectionBackground, selectionForeground);
+  ApplyDataViewSelectionColours(table, selectionBackground,
+                                selectionForeground);
 
     table->Bind(wxEVT_LEFT_DOWN, &TrussTablePanel::OnLeftDown, this);
     table->Bind(wxEVT_LEFT_UP, &TrussTablePanel::OnLeftUp, this);


### PR DESCRIPTION
### Motivation

- Make the selection colouring in the data tables match the cyan tint used for selections in the 3D view so selected rows stand out more. 
- Ensure the change is applied in the main tables for fixtures, trusses, hoists and scene objects for a consistent UX.

### Description

- Add helper `ApplyDataViewSelectionColours` in `gui/colorstore.h` that sets `wxDataViewCtrl` selection background/foreground when supported by the wxWidgets version. 
- Use a cyan background `wxColour(0, 255, 255)` and black foreground `wxColour(0, 0, 0)` and propagate them to the model via `SetSelectionColours` and to the view via `ApplyDataViewSelectionColours`. 
- Apply the new selection colouring in the four table panels `gui/fixturetablepanel.cpp`, `gui/trusstablepanel.cpp`, `gui/hoisttablepanel.cpp` and `gui/sceneobjecttablepanel.cpp`. 
- Guard calls to the view API with `#if wxCHECK_VERSION(3, 1, 0)` so older wxWidgets releases remain unaffected.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fcbb3439883249469cdea24d0a3e7)