### PR TITLE
Ensure synced table selections use cyan highlight

### DIFF
--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -978,15 +978,18 @@ std::vector<std::string> FixtureTablePanel::GetSelectedUuids() const {
 void FixtureTablePanel::SelectByUuid(const std::vector<std::string> &uuids) {
   table->UnselectAll();
   selectionOrder.clear();
+  std::vector<bool> selectedRows(table->GetItemCount(), false);
   for (const auto &u : uuids) {
     auto pos = std::find(rowUuids.begin(), rowUuids.end(), u);
     if (pos != rowUuids.end()) {
       int row = static_cast<int>(pos - rowUuids.begin());
       table->SelectRow(row);
       selectionOrder.push_back(row);
+      if (row >= 0 && static_cast<size_t>(row) < selectedRows.size())
+        selectedRows[row] = true;
     }
   }
-  UpdateSelectionHighlight();
+  store->SetSelectedRows(selectedRows);
 }
 
 void FixtureTablePanel::DeleteSelected() {

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -636,12 +636,17 @@ std::vector<std::string> HoistTablePanel::GetSelectedUuids() const {
 
 void HoistTablePanel::SelectByUuid(const std::vector<std::string> &uuids) {
   table->UnselectAll();
+  std::vector<bool> selectedRows(table->GetItemCount(), false);
   for (const auto &u : uuids) {
     auto pos = std::find(rowUuids.begin(), rowUuids.end(), u);
-    if (pos != rowUuids.end())
-      table->SelectRow(static_cast<int>(pos - rowUuids.begin()));
+    if (pos != rowUuids.end()) {
+      int row = static_cast<int>(pos - rowUuids.begin());
+      table->SelectRow(row);
+      if (row >= 0 && static_cast<size_t>(row) < selectedRows.size())
+        selectedRows[row] = true;
+    }
   }
-  UpdateSelectionHighlight();
+  store->SetSelectedRows(selectedRows);
 }
 
 void HoistTablePanel::DeleteSelected() {

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -586,12 +586,17 @@ std::vector<std::string> SceneObjectTablePanel::GetSelectedUuids() const {
 
 void SceneObjectTablePanel::SelectByUuid(const std::vector<std::string>& uuids) {
     table->UnselectAll();
+    std::vector<bool> selectedRows(table->GetItemCount(), false);
     for (const auto& u : uuids) {
         auto pos = std::find(rowUuids.begin(), rowUuids.end(), u);
-        if (pos != rowUuids.end())
-            table->SelectRow(static_cast<int>(pos - rowUuids.begin()));
+        if (pos != rowUuids.end()) {
+            int row = static_cast<int>(pos - rowUuids.begin());
+            table->SelectRow(row);
+            if (row >= 0 && static_cast<size_t>(row) < selectedRows.size())
+                selectedRows[row] = true;
+        }
     }
-    UpdateSelectionHighlight();
+    store->SetSelectedRows(selectedRows);
 }
 
 void SceneObjectTablePanel::DeleteSelected()

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -882,12 +882,17 @@ std::vector<std::string> TrussTablePanel::GetSelectedUuids() const {
 
 void TrussTablePanel::SelectByUuid(const std::vector<std::string>& uuids) {
     table->UnselectAll();
+    std::vector<bool> selectedRows(table->GetItemCount(), false);
     for (const auto& u : uuids) {
         auto pos = std::find(rowUuids.begin(), rowUuids.end(), u);
-        if (pos != rowUuids.end())
-            table->SelectRow(static_cast<int>(pos - rowUuids.begin()));
+        if (pos != rowUuids.end()) {
+            int row = static_cast<int>(pos - rowUuids.begin());
+            table->SelectRow(row);
+            if (row >= 0 && static_cast<size_t>(row) < selectedRows.size())
+                selectedRows[row] = true;
+        }
     }
-    UpdateSelectionHighlight();
+    store->SetSelectedRows(selectedRows);
 }
 
 void TrussTablePanel::DeleteSelected()


### PR DESCRIPTION
### Motivation
- Selecting objects in the 3D view tints them cyan, but programmatic selections in the corresponding tables were highlighted with a dark gray that was hard to see. 
- The change aims to make programmatic selections (from 3D) render using the same cyan selection colours provided by the table `ColorfulDataViewListStore`.

### Description
- Update `SelectByUuid` in `gui/fixturetablepanel.cpp`, `gui/trusstablepanel.cpp`, `gui/hoisttablepanel.cpp` and `gui/sceneobjecttablepanel.cpp` to compute a `std::vector<bool>` sized from `table->GetItemCount()` and mark selected rows. 
- Call `store->SetSelectedRows(selectedRows)` directly so the `ColorfulDataViewListStore` applies the cyan background/foreground instead of relying on `UpdateSelectionHighlight()`. 
- Add bounds checks when setting per-row flags and preserve the existing `selectionOrder` behavior in the fixture panel. 
- Modified files: `gui/fixturetablepanel.cpp`, `gui/trusstablepanel.cpp`, `gui/hoisttablepanel.cpp`, `gui/sceneobjecttablepanel.cpp`.

### Testing
- No automated tests were run for these changes. 
- Changes are limited to UI selection state propagation and expect to be validated by visual/manual UI checks or CI GUI tests if available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fcfbb9f4c8324a902c737c13d6c58)