### PR TITLE
Apply cyan selection color to fixtures/trusses/hoists/scene object tables

### DIFF
--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -44,6 +44,7 @@
 #include <wx/filename.h>
 #include <wx/notebook.h>
 #include <wx/tokenzr.h>
+#include <wx/version.h>
 
 namespace fs = std::filesystem;
 
@@ -115,6 +116,10 @@ FixtureTablePanel::FixtureTablePanel(wxWindow *parent)
   const wxColour selectionBackground(0, 255, 255);
   const wxColour selectionForeground(0, 0, 0);
   store->SetSelectionColours(selectionBackground, selectionForeground);
+#if wxCHECK_VERSION(3, 1, 0)
+  table->SetSelectionBackground(selectionBackground);
+  table->SetSelectionForeground(selectionForeground);
+#endif
 
   table->Bind(wxEVT_LEFT_DOWN, &FixtureTablePanel::OnLeftDown, this);
   table->Bind(wxEVT_LEFT_UP, &FixtureTablePanel::OnLeftUp, this);

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -32,6 +32,7 @@
 #include <wx/choicdlg.h>
 #include <wx/notebook.h>
 #include <wx/wupdlock.h> // freeze/thaw UI during batch edits
+#include <wx/version.h>
 
 static HoistTablePanel *s_instance = nullptr;
 
@@ -103,6 +104,10 @@ HoistTablePanel::HoistTablePanel(wxWindow *parent)
   const wxColour selectionBackground(0, 255, 255);
   const wxColour selectionForeground(0, 0, 0);
   store->SetSelectionColours(selectionBackground, selectionForeground);
+#if wxCHECK_VERSION(3, 1, 0)
+  table->SetSelectionBackground(selectionBackground);
+  table->SetSelectionForeground(selectionForeground);
+#endif
 
   table->Bind(wxEVT_LEFT_DOWN, &HoistTablePanel::OnLeftDown, this);
   table->Bind(wxEVT_LEFT_UP, &HoistTablePanel::OnLeftUp, this);

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -29,6 +29,7 @@
 #include <wx/notebook.h>
 #include <wx/choicdlg.h>
 #include <wx/wupdlock.h> // freeze/thaw UI during batch edits
+#include <wx/version.h>
 
 static SceneObjectTablePanel* s_instance = nullptr;
 
@@ -107,6 +108,10 @@ SceneObjectTablePanel::SceneObjectTablePanel(wxWindow* parent)
   const wxColour selectionBackground(0, 255, 255);
   const wxColour selectionForeground(0, 0, 0);
   store->SetSelectionColours(selectionBackground, selectionForeground);
+#if wxCHECK_VERSION(3, 1, 0)
+  table->SetSelectionBackground(selectionBackground);
+  table->SetSelectionForeground(selectionForeground);
+#endif
 
     table->Bind(wxEVT_LEFT_DOWN, &SceneObjectTablePanel::OnLeftDown, this);
     table->Bind(wxEVT_LEFT_UP, &SceneObjectTablePanel::OnLeftUp, this);

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -38,6 +38,7 @@
 #include <wx/notebook.h>
 #include <wx/choicdlg.h>
 #include <wx/wupdlock.h> // freeze/thaw UI during batch edits
+#include <wx/version.h>
 
 static TrussTablePanel* s_instance = nullptr;
 namespace fs = std::filesystem;
@@ -117,6 +118,10 @@ TrussTablePanel::TrussTablePanel(wxWindow* parent)
   const wxColour selectionBackground(0, 255, 255);
   const wxColour selectionForeground(0, 0, 0);
   store->SetSelectionColours(selectionBackground, selectionForeground);
+#if wxCHECK_VERSION(3, 1, 0)
+  table->SetSelectionBackground(selectionBackground);
+  table->SetSelectionForeground(selectionForeground);
+#endif
 
     table->Bind(wxEVT_LEFT_DOWN, &TrussTablePanel::OnLeftDown, this);
     table->Bind(wxEVT_LEFT_UP, &TrussTablePanel::OnLeftUp, this);


### PR DESCRIPTION
### Motivation
- Table rows selected in the 3D view are highlighted in cyan but the corresponding rows in the data tables used a dark gray that did not match, making selections hard to see.
- The change applies the same cyan foreground/background at the `wxDataViewListCtrl` level while guarding new API usage to avoid incompatibilities with older wxWidgets versions.

### Description
- For `FixtureTablePanel`, `TrussTablePanel`, `HoistTablePanel` and `SceneObjectTablePanel` add `#include <wx/version.h>` and call `table->SetSelectionBackground(...)` and `table->SetSelectionForeground(...)` to set cyan selection colors in addition to the existing `store->SetSelectionColours(...)` call.
- Guard the new calls with `#if wxCHECK_VERSION(3, 1, 0)` so the code only uses `SetSelectionBackground`/`SetSelectionForeground` when the wxWidgets API is available.
- Keep the existing `ColorfulDataViewListStore::SetSelectionColours` behavior so older wx versions still receive selection color information via the custom store.

### Testing
- No automated tests were executed for this change.
- The patch was compiled locally via the repository workflow (changes committed) but no CI/build artifacts were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fd2bfd8e88324ac41af9164ed1619)