### PR TITLE
Add help button to GDTF login dialog

### DIFF
--- a/gui/logindialog.cpp
+++ b/gui/logindialog.cpp
@@ -22,6 +22,13 @@ GdtfLoginDialog::GdtfLoginDialog(wxWindow* parent, const std::string& user, cons
 {
     wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
 
+    wxBoxSizer* headerSizer = new wxBoxSizer(wxHORIZONTAL);
+    headerSizer->AddStretchSpacer(1);
+    wxButton* helpButton = new wxButton(this, wxID_ANY, "?", wxDefaultPosition, wxSize(22, 22), wxBU_EXACTFIT);
+    helpButton->SetToolTip("Debes estar registrado en https://gdtf-share.com/");
+    headerSizer->Add(helpButton, 0, wxALIGN_RIGHT);
+    sizer->Add(headerSizer, 0, wxLEFT | wxRIGHT | wxTOP | wxEXPAND, 10);
+
     wxFlexGridSizer* grid = new wxFlexGridSizer(2, 5, 5);
     grid->Add(new wxStaticText(this, wxID_ANY, "Username:"), 0, wxALIGN_CENTER_VERTICAL);
     userCtrl = new wxTextCtrl(this, wxID_ANY, wxString::FromUTF8(user),


### PR DESCRIPTION
### Motivation
- Provide an inline help affordance in the GDTF login dialog to point users to the registration site and clarify they must be registered at `https://gdtf-share.com/`.
- Place the help control near the dialog header without disturbing the credentials grid or the OK/Cancel button layout.

### Description
- Inserted a `headerSizer` (`wxBoxSizer` horizontal) at the top of the dialog and added a small help `wxButton` labeled `"?"` to it so it sits above the form fields.
- Created the help button with `wxSize(22, 22)` and `wxBU_EXACTFIT` and set its tooltip via `SetToolTip("Debes estar registrado en https://gdtf-share.com/")`.
- Added the header sizer to the main vertical sizer with `wxLEFT | wxRIGHT | wxTOP | wxEXPAND` so the grid and `CreateSeparatedButtonSizer(wxOK | wxCANCEL)` remain unaffected; changes are in `gui/logindialog.cpp`.

### Testing
- No automated tests were run for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fd533199883248f9d0091fffe9c36)