### PR TITLE
Remove unsupported selection color setters from DataView tables

### DIFF
--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -116,11 +116,6 @@ FixtureTablePanel::FixtureTablePanel(wxWindow *parent)
   const wxColour selectionBackground(0, 255, 255);
   const wxColour selectionForeground(0, 0, 0);
   store->SetSelectionColours(selectionBackground, selectionForeground);
-#if wxCHECK_VERSION(3, 1, 0)
-  table->SetSelectionBackground(selectionBackground);
-  table->SetSelectionForeground(selectionForeground);
-#endif
-
   table->Bind(wxEVT_LEFT_DOWN, &FixtureTablePanel::OnLeftDown, this);
   table->Bind(wxEVT_LEFT_UP, &FixtureTablePanel::OnLeftUp, this);
   table->Bind(wxEVT_MOTION, &FixtureTablePanel::OnMouseMove, this);

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -104,11 +104,6 @@ HoistTablePanel::HoistTablePanel(wxWindow *parent)
   const wxColour selectionBackground(0, 255, 255);
   const wxColour selectionForeground(0, 0, 0);
   store->SetSelectionColours(selectionBackground, selectionForeground);
-#if wxCHECK_VERSION(3, 1, 0)
-  table->SetSelectionBackground(selectionBackground);
-  table->SetSelectionForeground(selectionForeground);
-#endif
-
   table->Bind(wxEVT_LEFT_DOWN, &HoistTablePanel::OnLeftDown, this);
   table->Bind(wxEVT_LEFT_UP, &HoistTablePanel::OnLeftUp, this);
   table->Bind(wxEVT_MOTION, &HoistTablePanel::OnMouseMove, this);

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -108,11 +108,6 @@ SceneObjectTablePanel::SceneObjectTablePanel(wxWindow* parent)
   const wxColour selectionBackground(0, 255, 255);
   const wxColour selectionForeground(0, 0, 0);
   store->SetSelectionColours(selectionBackground, selectionForeground);
-#if wxCHECK_VERSION(3, 1, 0)
-  table->SetSelectionBackground(selectionBackground);
-  table->SetSelectionForeground(selectionForeground);
-#endif
-
     table->Bind(wxEVT_LEFT_DOWN, &SceneObjectTablePanel::OnLeftDown, this);
     table->Bind(wxEVT_LEFT_UP, &SceneObjectTablePanel::OnLeftUp, this);
     table->Bind(wxEVT_MOTION, &SceneObjectTablePanel::OnMouseMove, this);

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -118,12 +118,7 @@ TrussTablePanel::TrussTablePanel(wxWindow* parent)
   const wxColour selectionBackground(0, 255, 255);
   const wxColour selectionForeground(0, 0, 0);
   store->SetSelectionColours(selectionBackground, selectionForeground);
-#if wxCHECK_VERSION(3, 1, 0)
-  table->SetSelectionBackground(selectionBackground);
-  table->SetSelectionForeground(selectionForeground);
-#endif
-
-    table->Bind(wxEVT_LEFT_DOWN, &TrussTablePanel::OnLeftDown, this);
+  table->Bind(wxEVT_LEFT_DOWN, &TrussTablePanel::OnLeftDown, this);
     table->Bind(wxEVT_LEFT_UP, &TrussTablePanel::OnLeftUp, this);
     table->Bind(wxEVT_MOTION, &TrussTablePanel::OnMouseMove, this);
     table->Bind(wxEVT_DATAVIEW_SELECTION_CHANGED,


### PR DESCRIPTION
### Motivation
- The code called `wxDataViewListCtrl::SetSelectionBackground`/`SetSelectionForeground`, which is not available on the target wxWidgets version and caused compilation errors.
- Selection coloring is already provided by the custom `ColorfulDataViewListStore::SetSelectionColours`, so the explicit DataView calls are unnecessary.

### Description
- Removed conditional `#if wxCHECK_VERSION(3, 1, 0)` blocks that invoked `table->SetSelectionBackground(...)` and `table->SetSelectionForeground(...)` from the table panels.
- Updated the four panels `gui/sceneobjecttablepanel.cpp`, `gui/hoisttablepanel.cpp`, `gui/trusstablepanel.cpp`, and `gui/fixturetablepanel.cpp` to rely on `store->SetSelectionColours(...)` instead of calling `wxDataViewListCtrl` selection setters.
- No changes were made to the `ColorfulDataViewListStore` implementation, which continues to manage per-row/per-cell and selected-row coloring.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fd4dd09a883249bcbaf6b127e41cb)