### PR TITLE
Fix sizer assertion by removing alignment flag from GDTF Share login help button

### DIFF
--- a/gui/logindialog.cpp
+++ b/gui/logindialog.cpp
@@ -25,8 +25,8 @@ GdtfLoginDialog::GdtfLoginDialog(wxWindow* parent, const std::string& user, cons
     wxBoxSizer* headerSizer = new wxBoxSizer(wxHORIZONTAL);
     headerSizer->AddStretchSpacer(1);
     wxButton* helpButton = new wxButton(this, wxID_ANY, "?", wxDefaultPosition, wxSize(22, 22), wxBU_EXACTFIT);
-    helpButton->SetToolTip("Debes estar registrado en https://gdtf-share.com/");
-    headerSizer->Add(helpButton, 0, wxALIGN_RIGHT);
+    helpButton->SetToolTip("You must be registered at https://gdtf-share.com/ to download GDTF files.");
+    headerSizer->Add(helpButton, 0);
     sizer->Add(headerSizer, 0, wxLEFT | wxRIGHT | wxTOP | wxEXPAND, 10);
 
     wxFlexGridSizer* grid = new wxFlexGridSizer(2, 5, 5);


### PR DESCRIPTION
### Motivation
- Prevent a wxWidgets sizer assertion caused by passing a horizontal sizer an invalid alignment flag for the help button while keeping the login help text in English.

### Description
- Replace the `headerSizer->Add(helpButton, 0, ...)` call with `headerSizer->Add(helpButton, 0)` to remove the alignment flag and avoid the sizer check; the tooltip remains set to `"You must be registered at https://gdtf-share.com/ to download GDTF files."`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fd7a54510832497ff871283b4618e)