### PR TITLE
Fix cyan selection rendering in data views

### DIFF
--- a/gui/colorfulrenderers.h
+++ b/gui/colorfulrenderers.h
@@ -1,0 +1,228 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <wx/control.h>
+#include <wx/dataview.h>
+#include <wx/dc.h>
+#include <wx/settings.h>
+
+#include "colorstore.h"
+
+namespace {
+inline const ColorfulDataViewListStore *GetColorfulStore(
+    const wxDataViewCustomRenderer *renderer) {
+  if (!renderer)
+    return nullptr;
+  wxDataViewColumn *column = renderer->GetOwner();
+  if (!column)
+    return nullptr;
+  wxDataViewCtrl *ctrl = column->GetOwner();
+  if (!ctrl)
+    return nullptr;
+  return dynamic_cast<const ColorfulDataViewListStore *>(ctrl->GetModel());
+}
+
+inline wxColour ResolveTextColour(const wxDataViewCustomRenderer *renderer,
+                                  int state,
+                                  const wxDataViewItemAttr &attr) {
+  wxDataViewColumn *column = renderer ? renderer->GetOwner() : nullptr;
+  wxDataViewCtrl *ctrl = column ? column->GetOwner() : nullptr;
+  wxColour colour =
+      ctrl ? ctrl->GetForegroundColour()
+           : wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
+  if (attr.HasColour())
+    colour = attr.GetColour();
+  const auto *store = GetColorfulStore(renderer);
+  if ((state & wxDATAVIEW_CELL_SELECTED) && store &&
+      store->selectionForegroundEnabled && !attr.HasColour())
+    colour = store->selectionForeground;
+  if (ctrl && !ctrl->IsEnabled())
+    colour = wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT);
+  return colour;
+}
+
+inline bool ResolveBackgroundColour(const wxDataViewCustomRenderer *renderer,
+                                    int state,
+                                    const wxDataViewItemAttr &attr,
+                                    wxColour &colour) {
+  const auto *store = GetColorfulStore(renderer);
+  if ((state & wxDATAVIEW_CELL_SELECTED) && store &&
+      store->selectionBackgroundEnabled) {
+    colour = store->selectionBackground;
+    return true;
+  }
+  if (attr.HasBackgroundColour()) {
+    colour = attr.GetBackgroundColour();
+    return true;
+  }
+  return false;
+}
+
+inline void ApplyAttributeFont(wxDC *dc, const wxDataViewItemAttr &attr) {
+  if (!dc)
+    return;
+  if (attr.HasFont())
+    dc->SetFont(attr.GetEffectiveFont(dc->GetFont()));
+}
+
+inline void DrawTextValue(wxDataViewCustomRenderer *renderer,
+                          const wxString &text, wxRect rect, wxDC *dc,
+                          int state) {
+  if (!renderer || !dc)
+    return;
+
+  wxDCClipper clip(*dc, rect);
+  const wxDataViewItemAttr &attr = renderer->GetAttr();
+  ApplyAttributeFont(dc, attr);
+  dc->SetTextForeground(ResolveTextColour(renderer, state, attr));
+
+  wxString displayText = text;
+  if (renderer->GetEllipsizeMode() != wxELLIPSIZE_NONE) {
+    displayText = wxControl::Ellipsize(displayText, *dc,
+                                       renderer->GetEllipsizeMode(),
+                                       rect.GetWidth());
+  }
+
+  wxSize textSize = dc->GetTextExtent(displayText);
+  int align = renderer->GetEffectiveAlignment();
+  int x = rect.x + 2;
+  if (align & wxALIGN_RIGHT)
+    x = rect.x + rect.width - textSize.x - 2;
+  else if (align & wxALIGN_CENTER_HORIZONTAL)
+    x = rect.x + (rect.width - textSize.x) / 2;
+
+  int y = rect.y + 1;
+  if (align & wxALIGN_BOTTOM)
+    y = rect.y + rect.height - textSize.y - 1;
+  else if (align & wxALIGN_CENTER_VERTICAL)
+    y = rect.y + (rect.height - textSize.y) / 2;
+
+  dc->DrawText(displayText, x, y);
+}
+} // namespace
+
+class ColorfulTextRenderer : public wxDataViewCustomRenderer {
+public:
+  ColorfulTextRenderer(wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT,
+                       int align = wxDVR_DEFAULT_ALIGNMENT)
+      : wxDataViewCustomRenderer("string", mode, align) {}
+
+  bool Render(wxRect rect, wxDC *dc, int state) override {
+    wxColour background;
+    if (ResolveBackgroundColour(this, state, GetAttr(), background)) {
+      dc->SetBrush(wxBrush(background));
+      dc->SetPen(*wxTRANSPARENT_PEN);
+      dc->DrawRectangle(rect);
+    }
+    DrawTextValue(this, m_text, rect, dc, state);
+    return true;
+  }
+
+  wxSize GetSize() const override { return GetTextExtent(m_text); }
+
+  bool SetValue(const wxVariant &value) override {
+    m_text = value.MakeString();
+    return true;
+  }
+
+  bool GetValue(wxVariant &value) const override {
+    value = m_text;
+    return true;
+  }
+
+  bool IsCompatibleVariantType(const wxString &WXUNUSED(type)) const override {
+    return true;
+  }
+
+#if wxUSE_ACCESSIBILITY
+  wxString GetAccessibleDescription() const override { return m_text; }
+#endif
+
+private:
+  wxString m_text;
+};
+
+class ColorfulIconTextRenderer : public wxDataViewCustomRenderer {
+public:
+  ColorfulIconTextRenderer(wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT,
+                           int align = wxDVR_DEFAULT_ALIGNMENT)
+      : wxDataViewCustomRenderer("wxDataViewIconText", mode, align) {}
+
+  bool Render(wxRect rect, wxDC *dc, int state) override {
+    wxColour background;
+    if (ResolveBackgroundColour(this, state, GetAttr(), background)) {
+      dc->SetBrush(wxBrush(background));
+      dc->SetPen(*wxTRANSPARENT_PEN);
+      dc->DrawRectangle(rect);
+    }
+
+    wxRect drawRect = rect;
+    wxBitmapBundle bundle = m_value.GetBitmapBundle();
+    if (bundle.IsOk()) {
+      wxBitmap bmp = bundle.GetBitmap(wxDefaultSize);
+      if (bmp.IsOk()) {
+        int bmpX = drawRect.x + 2;
+        int bmpY = drawRect.y + (drawRect.height - bmp.GetHeight()) / 2;
+        dc->DrawBitmap(bmp, bmpX, bmpY, true);
+        drawRect.x = bmpX + bmp.GetWidth() + 4;
+        drawRect.width =
+            std::max(0, rect.width - (drawRect.x - rect.x));
+      }
+    }
+
+    DrawTextValue(this, m_value.GetText(), drawRect, dc, state);
+    return true;
+  }
+
+  wxSize GetSize() const override {
+    wxSize textSize = GetTextExtent(m_value.GetText());
+    wxBitmapBundle bundle = m_value.GetBitmapBundle();
+    if (!bundle.IsOk())
+      return textSize;
+    wxBitmap bmp = bundle.GetBitmap(wxDefaultSize);
+    if (!bmp.IsOk())
+      return textSize;
+    int width = textSize.x + bmp.GetWidth() + 6;
+    int height = std::max(textSize.y, bmp.GetHeight());
+    return wxSize(width, height);
+  }
+
+  bool SetValue(const wxVariant &value) override {
+    if (value.GetType() == "wxDataViewIconText") {
+      m_value << value;
+      return true;
+    }
+    m_value = wxDataViewIconText(value.MakeString());
+    return true;
+  }
+
+  bool GetValue(wxVariant &value) const override {
+    value << m_value;
+    return true;
+  }
+
+#if wxUSE_ACCESSIBILITY
+  wxString GetAccessibleDescription() const override {
+    return m_value.GetText();
+  }
+#endif
+
+private:
+  wxDataViewIconText m_value;
+};

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -20,6 +20,7 @@
 #include "columnutils.h"
 #include "configmanager.h"
 #include "consolepanel.h"
+#include "colorfulrenderers.h"
 #include "fixtureeditdialog.h"
 #include "gdtfdictionary.h"
 #include "gdtfloader.h"
@@ -155,52 +156,59 @@ void FixtureTablePanel::InitializeTable() {
 
   // Column 0: Fixture ID (numeric for proper sorting)
   auto *idRenderer =
-      new wxDataViewTextRenderer("long", wxDATAVIEW_CELL_INERT, wxALIGN_LEFT);
-  auto *idColumn = new wxDataViewColumn(columnLabels[0], idRenderer, 0,
-                                        widths[0], wxALIGN_LEFT, flags);
-  table->AppendColumn(idColumn);
+      new ColorfulTextRenderer(wxDATAVIEW_CELL_INERT, wxALIGN_LEFT);
+  table->AppendColumn(new wxDataViewColumn(columnLabels[0], idRenderer, 0,
+                                           widths[0], wxALIGN_LEFT, flags));
 
   // Column 1: Name (string)
-  table->AppendTextColumn(columnLabels[1], wxDATAVIEW_CELL_INERT, widths[1],
-                          wxALIGN_LEFT, flags);
+  table->AppendColumn(new wxDataViewColumn(
+      columnLabels[1], new ColorfulTextRenderer(wxDATAVIEW_CELL_INERT,
+                                                wxALIGN_LEFT),
+      1, widths[1], wxALIGN_LEFT, flags));
 
   // Column 2: Type (string)
-  table->AppendTextColumn(columnLabels[2], wxDATAVIEW_CELL_INERT, widths[2],
-                          wxALIGN_LEFT, flags);
+  table->AppendColumn(new wxDataViewColumn(
+      columnLabels[2], new ColorfulTextRenderer(wxDATAVIEW_CELL_INERT,
+                                                wxALIGN_LEFT),
+      2, widths[2], wxALIGN_LEFT, flags));
 
   // Column 3: Layer (string)
-  table->AppendTextColumn(columnLabels[3], wxDATAVIEW_CELL_INERT, widths[3],
-                          wxALIGN_LEFT, flags);
+  table->AppendColumn(new wxDataViewColumn(
+      columnLabels[3], new ColorfulTextRenderer(wxDATAVIEW_CELL_INERT,
+                                                wxALIGN_LEFT),
+      3, widths[3], wxALIGN_LEFT, flags));
 
   // Column 4: Hang Pos (string)
-  table->AppendTextColumn(columnLabels[4], wxDATAVIEW_CELL_INERT, widths[4],
-                          wxALIGN_LEFT, flags);
+  table->AppendColumn(new wxDataViewColumn(
+      columnLabels[4], new ColorfulTextRenderer(wxDATAVIEW_CELL_INERT,
+                                                wxALIGN_LEFT),
+      4, widths[4], wxALIGN_LEFT, flags));
 
   // Column 5: Universe (numeric)
-  auto *uniRenderer =
-      new wxDataViewTextRenderer("long", wxDATAVIEW_CELL_INERT, wxALIGN_LEFT);
-  auto *uniColumn = new wxDataViewColumn(columnLabels[5], uniRenderer, 5,
-                                         widths[5], wxALIGN_LEFT, flags);
-  table->AppendColumn(uniColumn);
+  table->AppendColumn(new wxDataViewColumn(
+      columnLabels[5], new ColorfulTextRenderer(wxDATAVIEW_CELL_INERT,
+                                                wxALIGN_LEFT),
+      5, widths[5], wxALIGN_LEFT, flags));
 
   // Column 6: Channel (numeric)
-  auto *chRenderer =
-      new wxDataViewTextRenderer("long", wxDATAVIEW_CELL_INERT, wxALIGN_LEFT);
-  auto *chColumn = new wxDataViewColumn(columnLabels[6], chRenderer, 6,
-                                        widths[6], wxALIGN_LEFT, flags);
-  table->AppendColumn(chColumn);
+  table->AppendColumn(new wxDataViewColumn(
+      columnLabels[6], new ColorfulTextRenderer(wxDATAVIEW_CELL_INERT,
+                                                wxALIGN_LEFT),
+      6, widths[6], wxALIGN_LEFT, flags));
 
   // Columns 7 to second last as regular text
   for (size_t i = 7; i < columnLabels.size() - 1; ++i)
-    table->AppendTextColumn(columnLabels[i], wxDATAVIEW_CELL_INERT, widths[i],
-                            wxALIGN_LEFT, flags);
+    table->AppendColumn(new wxDataViewColumn(
+        columnLabels[i], new ColorfulTextRenderer(wxDATAVIEW_CELL_INERT,
+                                                  wxALIGN_LEFT),
+        i, widths[i], wxALIGN_LEFT, flags));
 
   // Last column (Color) uses icon+text to show a colored square
-  auto *colorRenderer = new wxDataViewIconTextRenderer();
-  auto *colorColumn = new wxDataViewColumn(columnLabels.back(), colorRenderer,
-                                           columnLabels.size() - 1,
-                                           widths.back(), wxALIGN_LEFT, flags);
-  table->AppendColumn(colorColumn);
+  auto *colorRenderer =
+      new ColorfulIconTextRenderer(wxDATAVIEW_CELL_INERT, wxALIGN_LEFT);
+  table->AppendColumn(new wxDataViewColumn(
+      columnLabels.back(), colorRenderer, columnLabels.size() - 1,
+      widths.back(), wxALIGN_LEFT, flags));
 
   ColumnUtils::EnforceMinColumnWidth(table);
 }

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -18,6 +18,7 @@
 #include "hoisttablepanel.h"
 
 #include "columnutils.h"
+#include "colorfulrenderers.h"
 #include "configmanager.h"
 #include "layerpanel.h"
 #include "matrixutils.h"
@@ -134,9 +135,11 @@ void HoistTablePanel::InitializeTable() {
   std::vector<int> widths = {70,  150, 120, 120, 100, 120, 80,  80,
                              80,  80,  80,  80,  110, 110, 100};
   for (size_t i = 0; i < columnLabels.size(); ++i)
-    table->AppendTextColumn(columnLabels[i], wxDATAVIEW_CELL_INERT, widths[i],
-                            wxALIGN_LEFT,
-                            wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
+    table->AppendColumn(new wxDataViewColumn(
+        columnLabels[i], new ColorfulTextRenderer(wxDATAVIEW_CELL_INERT,
+                                                  wxALIGN_LEFT),
+        i, widths[i], wxALIGN_LEFT,
+        wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE));
   ColumnUtils::EnforceMinColumnWidth(table);
 }
 

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -17,6 +17,7 @@
  */
 #include "sceneobjecttablepanel.h"
 #include "columnutils.h"
+#include "colorfulrenderers.h"
 #include "configmanager.h"
 #include "layerpanel.h"
 #include "matrixutils.h"
@@ -142,9 +143,11 @@ void SceneObjectTablePanel::InitializeTable()
                                80, 80, 80,
                                80, 80, 80};
     for (size_t i = 0; i < columnLabels.size(); ++i)
-        table->AppendTextColumn(
-            columnLabels[i], wxDATAVIEW_CELL_INERT, widths[i], wxALIGN_LEFT,
-            wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
+        table->AppendColumn(new wxDataViewColumn(
+            columnLabels[i], new ColorfulTextRenderer(wxDATAVIEW_CELL_INERT,
+                                                      wxALIGN_LEFT),
+            i, widths[i], wxALIGN_LEFT,
+            wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE));
     ColumnUtils::EnforceMinColumnWidth(table);
 }
 

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -17,6 +17,7 @@
  */
 #include "trusstablepanel.h"
 #include "columnutils.h"
+#include "colorfulrenderers.h"
 #include "configmanager.h"
 #include "consolepanel.h"
 #include "layerpanel.h"
@@ -156,9 +157,11 @@ void TrussTablePanel::InitializeTable()
                                120, 120,
                                90, 90, 90, 90};
     for (size_t i = 0; i < columnLabels.size(); ++i)
-        table->AppendTextColumn(
-            columnLabels[i], wxDATAVIEW_CELL_INERT, widths[i], wxALIGN_LEFT,
-            wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
+        table->AppendColumn(new wxDataViewColumn(
+            columnLabels[i], new ColorfulTextRenderer(wxDATAVIEW_CELL_INERT,
+                                                      wxALIGN_LEFT),
+            i, widths[i], wxALIGN_LEFT,
+            wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE));
     ColumnUtils::EnforceMinColumnWidth(table);
 }
 


### PR DESCRIPTION
### Motivation
- Selection colours set in `ColorfulDataViewListStore` were being ignored by the default data-view renderers so selected rows appeared with a dull gray instead of the configured cyan; custom renderers are needed to honor the store's selection foreground/background and other per-cell attributes.

### Description
- Add `gui/colorfulrenderers.h` providing `ColorfulTextRenderer` and `ColorfulIconTextRenderer` (both `wxDataViewCustomRenderer`) that consult `ColorfulDataViewListStore` to resolve selection background/foreground, per-row/per-cell attributes, fonts and ellipsizing when painting cells.
- Replace `AppendTextColumn`/`wxDataViewTextRenderer` and `wxDataViewIconTextRenderer` uses in `FixtureTablePanel`, `HoistTablePanel`, `TrussTablePanel` and `SceneObjectTablePanel` so all table columns (including the color icon column) use the new renderers and therefore respect the cyan selection colours.
- Renderers handle background painting, text colour resolution (including disabled state), font application, ellipsizing, and icon drawing while keeping existing `ColorfulDataViewListStore` behaviour unchanged.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fd7e013d483249101583e013ab524)