### PR TITLE
Fix DataView renderer padding to avoid clipped cell text

### DIFF
--- a/gui/colorfulrenderers.h
+++ b/gui/colorfulrenderers.h
@@ -134,7 +134,10 @@ public:
     return true;
   }
 
-  wxSize GetSize() const override { return GetTextExtent(m_text); }
+  wxSize GetSize() const override {
+    wxSize textSize = GetTextExtent(m_text);
+    return wxSize(textSize.x + 4, textSize.y + 2);
+  }
 
   bool SetValue(const wxVariant &value) override {
     m_text = value.MakeString();
@@ -198,8 +201,8 @@ public:
     wxBitmap bmp = bundle.GetBitmap(wxDefaultSize);
     if (!bmp.IsOk())
       return textSize;
-    int width = textSize.x + bmp.GetWidth() + 6;
-    int height = std::max(textSize.y, bmp.GetHeight());
+    int width = textSize.x + bmp.GetWidth() + 8;
+    int height = std::max(textSize.y + 2, bmp.GetHeight());
     return wxSize(width, height);
   }
 


### PR DESCRIPTION
### Motivation
- Custom `wxDataView` renderers that were added to support selection colors caused cell text to be visually clipped at the end, so size calculations need to include drawing offsets and padding to avoid truncation.

### Description
- Update `GetSize()` in `ColorfulTextRenderer` and `ColorfulIconTextRenderer` (`gui/colorfulrenderers.h`) to add horizontal and vertical padding and to account for the icon bitmap spacing when measuring width and height.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fddc4b53083248259d387e827d6f4)