### PR TITLE
Enable selection and hover highlight in 2D viewport

### DIFF
--- a/gui/layout2dviewdialog.cpp
+++ b/gui/layout2dviewdialog.cpp
@@ -18,7 +18,7 @@ Layout2DViewDialog::Layout2DViewDialog(wxWindow *parent)
   auto *mainSizer = new wxBoxSizer(wxVERTICAL);
   auto *contentSizer = new wxBoxSizer(wxHORIZONTAL);
 
-  viewerPanel = new Viewer2DPanel(this, false, false);
+  viewerPanel = new Viewer2DPanel(this, false, false, false);
   renderPanel = new Viewer2DRenderPanel(this);
   layerPanel = new LayerPanel(this, false);
 

--- a/viewer2d/viewer2doffscreenrenderer.cpp
+++ b/viewer2d/viewer2doffscreenrenderer.cpp
@@ -26,7 +26,7 @@ Viewer2DOffscreenRenderer::Viewer2DOffscreenRenderer(wxWindow *parent) {
   host_ = new wxPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(1, 1));
   host_->Hide();
 
-  panel_ = new Viewer2DPanel(host_, true, false);
+  panel_ = new Viewer2DPanel(host_, true, false, false);
   panel_->SetSize(wxSize(kDefaultViewportWidth, kDefaultViewportHeight));
   panel_->SetClientSize(wxSize(kDefaultViewportWidth, kDefaultViewportHeight));
   panel_->LoadViewFromConfig();

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -48,7 +48,8 @@ struct Viewer2DViewState {
 class Viewer2DPanel : public wxGLCanvas {
 public:
   explicit Viewer2DPanel(wxWindow *parent, bool allowOffscreenRender = false,
-                         bool persistViewState = true);
+                         bool persistViewState = true,
+                         bool enableSelection = true);
   ~Viewer2DPanel();
 
   static Viewer2DPanel *Instance();
@@ -127,11 +128,16 @@ private:
   void OnCaptureLost(wxMouseCaptureLostEvent &event);
 
   bool m_dragging = false;
+  bool m_draggedSincePress = false;
   wxPoint m_lastMousePos;
   float m_offsetX = 0.0f;
   float m_offsetY = 0.0f;
   float m_zoom = 1.0f;
   bool m_mouseInside = false;
+  bool m_mouseMoved = false;
+  bool m_hasHover = false;
+  bool m_enableSelection = true;
+  std::string m_hoverUuid;
 
   bool m_captureNextFrame = false;
   bool m_useSimplifiedFootprints = false;


### PR DESCRIPTION
### Motivation
- Bring the same selection and hover/highlight UX from the 3D viewport to the main 2D viewport so users can click/hover fixtures, trusses and scene objects in 2D as they do in 3D.
- Keep selection disabled for non-interactive 2D contexts (layout editor and offscreen capture) to avoid interfering with those workflows.

### Description
- Added an `enableSelection` constructor flag to `Viewer2DPanel` and instance state fields (`m_draggedSincePress`, `m_mouseMoved`, `m_hasHover`, `m_enableSelection`, `m_hoverUuid`) to manage hover and click interactions and to distinguish pan vs click.
- Implemented hit-testing and hover logic in `Viewer2DPanel::OnPaint` that queries the shared `Viewer3DController` (`GetFixtureLabelAt`, `GetTrussLabelAt`, `GetSceneObjectLabelAt`) and updates controller highlight with `SetHighlightUuid` and table panel highlights.
- Implemented click-selection in `Viewer2DPanel::OnMouseUp` mirroring 3D behavior: supports additive selection with Shift/Ctrl, updates `ConfigManager` selected lists, calls `m_controller.SetSelectedUuids(...)`, and updates the appropriate table panel (`SelectByUuid` / `ClearSelection`).
- Synced selection state on refresh by reading the `ConfigManager` selected lists in `Viewer2DPanel::UpdateScene` and calling `m_controller.SetSelectedUuids(...)`.
- Disabled selection when constructing non-interactive viewers by passing `false` at call-sites: `viewer2doffscreenrenderer.cpp` and `gui/layout2dviewdialog.cpp`.
- Minor UI glue: include headers for the table panels and ensure OpenGL context is current before hit-testing.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fdf90e63883248d65b6a5c504e332)