### PR TITLE
Add 2D viewport hover/selection outlines

### DIFF
--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -177,6 +177,7 @@ Viewer2DPanel::Viewer2DPanel(wxWindow *parent, bool allowOffscreenRender,
       m_persistViewState(persistViewState),
       m_enableSelection(enableSelection) {
   SetBackgroundStyle(wxBG_STYLE_CUSTOM);
+  m_controller.SetSelectionOutlineEnabled(m_enableSelection);
   m_glContext = new wxGLContext(this);
 }
 

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -90,6 +90,9 @@ public:
 
   // Enables color tweaks for dark mode in the 2D viewer only.
   void SetDarkMode(bool enabled);
+  void SetSelectionOutlineEnabled(bool enabled) {
+    m_showSelectionOutline2D = enabled;
+  }
 
   // Fixture UUID currently highlighted (hovered)
   void SetHighlightUuid(const std::string &uuid);
@@ -135,7 +138,9 @@ private:
                          Viewer2DRenderMode mode = Viewer2DRenderMode::White,
                          const std::function<std::array<float, 3>(
                              const std::array<float, 3> &)> &captureTransform =
-                             {});
+                             {},
+                         float lineWidthOverride = -1.0f,
+                         bool recordCapture = true);
 
   // Draws a wireframe box with independent dimensions. Length corresponds
   // to the X axis, width to Y and height to Z. The box's origin is at the
@@ -263,6 +268,7 @@ private:
   bool m_captureUseSymbols = false;
   SymbolCache m_bottomSymbolCache;
   bool m_darkMode = false;
+  bool m_showSelectionOutline2D = false;
 
 public:
   // Enables recording of all primitives drawn during the next RenderScene


### PR DESCRIPTION
### Motivation
- Make the 2D viewport provide the same intuitive hover/selection feedback available in the 3D view by adding a colored outline/glow for hovered and selected objects without changing layout viewports.

### Description
- Added a 2D-only selection-outline toggle to the controller via `SetSelectionOutlineEnabled` and a backing `m_showSelectionOutline2D` flag in `viewer3d/viewer3dcontroller.h`.
- Extended `DrawWireframeCube` to accept a `lineWidthOverride` and `recordCapture` so we can render thicker glow passes separately from the normal capture path in `viewer3d/viewer3dcontroller.cpp`.
- Implemented a glow/outline pass for hovered (green) and selected (cyan) objects by drawing a thicker colored wireframe before the regular black wireframe for meshes, boxes and cubes in the 2D rendering paths in `viewer3d/viewer3dcontroller.cpp`.
- Hooked the 2D panel to enable the outline behavior when selection is enabled by calling `m_controller.SetSelectionOutlineEnabled(m_enableSelection)` in `viewer2d/viewer2dpanel.cpp`.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fe22ee9708324930927f7fc988321)