### PR TITLE
Fix CLI range separator parsing

### DIFF
--- a/gui/consolepanel.cpp
+++ b/gui/consolepanel.cpp
@@ -494,12 +494,15 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
       return vals;
     };
 
-    auto isCmd = [](const std::string &tok, bool allowAxis) {
+    auto isCmd = [](const std::string &tok, bool allowAxis,
+                    bool allowRangeSeparator) {
       if (tok.empty())
         return false;
       std::string l = tok;
       std::transform(l.begin(), l.end(), l.begin(),
                      [](unsigned char c) { return std::tolower(c); });
+      if (allowRangeSeparator && (l == "t" || l == "thru"))
+        return false;
       if (l == "clear" || l == "pos" || l == "rot" || l[0] == 'f' ||
           l[0] == 't')
         return true;
@@ -522,7 +525,10 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
                      [](unsigned char c) { return std::tolower(c); });
       size_t j = i + 1;
       bool allowAxis = (lw != "pos" && lw != "rot");
-      while (j < tokens.size() && !isCmd(tokens[j], allowAxis))
+      bool allowRangeSeparator =
+          (!lw.empty() && (lw[0] == 'f' || lw[0] == 't'));
+      while (j < tokens.size() &&
+             !isCmd(tokens[j], allowAxis, allowRangeSeparator))
         ++j;
 
       if (lw == "clear") {


### PR DESCRIPTION
### Motivation
- Range separators `t`/`thru` inside fixture/truss selection arguments were being treated as command tokens and prematurely splitting selection arguments, breaking inputs like `f 1 t1000`.

### Description
- Update `gui/consolepanel.cpp` to extend `isCmd` with an `allowRangeSeparator` flag and avoid treating `t`/`thru` as command boundaries when they appear inside `f`/`t` selection arguments.
- Add `allowRangeSeparator` detection where tokens for a command are collected so range separators remain inside selection argument tokens instead of ending the argument list.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fec043e5483249b28239c6fee55ab)