### PR TITLE
Fix 2D dark mode persistence in layout view state

### DIFF
--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -785,7 +785,6 @@ void MainWindow::OnLayout2DViewOk(wxCommandEvent &WXUNUSED(event)) {
       layout2DViewEditPanel ? layout2DViewEditPanel : viewport2DPanel;
   viewer2d::Viewer2DState current =
       viewer2d::CaptureState(editPanel, cfg);
-  current.renderOptions.darkMode = false;
 
   layouts::Layout2DViewFrame frame{};
   int viewId = layout2DViewEditingId;
@@ -922,7 +921,6 @@ void MainWindow::PersistLayout2DViewState() {
   }
   layouts::Layout2DViewDefinition view =
       viewer2d::CaptureLayoutDefinition(activePanel, cfg, frame);
-  view.renderOptions.darkMode = false;
   view.id = viewId;
   if (matchedView) {
     view.zIndex = matchedView->zIndex;
@@ -959,6 +957,7 @@ void MainWindow::RestoreLayout2DViewState(int viewId) {
       (layout2DViewEditing && layout2DViewEditRenderPanel)
           ? layout2DViewEditRenderPanel
           : viewport2DRenderPanel;
-  viewer2d::ApplyState(activePanel, activeRenderPanel, cfg,
-                       viewer2d::FromLayoutDefinition(*match));
+  viewer2d::Viewer2DState state = viewer2d::FromLayoutDefinition(*match);
+  state.renderOptions.darkMode = cfg.GetFloat("view2d_dark_mode") != 0.0f;
+  viewer2d::ApplyState(activePanel, activeRenderPanel, cfg, state);
 }


### PR DESCRIPTION
### Motivation
- Editing or restoring saved 2D layout views was forcing `renderOptions.darkMode = false`, which could overwrite the user's `view2d_dark_mode` preference and cause the UI to revert from dark mode after reloads or refreshes.

### Description
- Removed the hard-coded `darkMode = false` when capturing/persisting layout view state so saved layout entries no longer clear the user's dark-mode choice.
- When restoring a layout view state, the restored `Viewer2DState` now sets `state.renderOptions.darkMode` from `ConfigManager::Get().GetFloat("view2d_dark_mode")` so the active user preference is preserved.
- Changes made in `gui/mainwindow_layout.cpp` to `OnLayout2DViewOk`, `PersistLayout2DViewState`, and `RestoreLayout2DViewState`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ff60940648324af1679e891a4f1a1)