### PR TITLE
Preserve standalone 2D viewer camera state on save

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -276,13 +276,12 @@ wxEND_EVENT_TABLE()
 }
 
 MainWindow::~MainWindow() {
-  SaveCameraSettings();
+  SaveUserConfigWithViewport2DState();
   if (auiManager) {
     auiManager->UnInit();
     delete auiManager;
     auiManager = nullptr;
   }
-  ConfigManager::Get().SaveUserConfig();
   ProjectUtils::SaveLastProjectPath(currentProjectPath);
 }
 
@@ -530,6 +529,22 @@ void MainWindow::SaveCameraSettings() {
     ConfigManager::Get().SetValue("layout_perspective", perspective);
     if (layoutModeActive)
       ConfigManager::Get().SetValue("layout_layout_mode", perspective);
+  }
+}
+
+void MainWindow::SaveUserConfigWithViewport2DState() {
+  ConfigManager &cfg = ConfigManager::Get();
+  std::optional<viewer2d::Viewer2DState> guardState;
+  if (layoutModeActive && viewport2DPanel) {
+    guardState = viewer2d::CaptureState(viewport2DPanel, cfg);
+  }
+
+  SaveCameraSettings();
+  cfg.SaveUserConfig();
+
+  if (guardState) {
+    viewer2d::ApplyState(viewport2DPanel, viewport2DRenderPanel, cfg,
+                         *guardState);
   }
 }
 

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -164,6 +164,7 @@ private:
   void OnPaneClose(wxAuiManagerEvent &event); // Keep View menu in sync
 
   void SaveCameraSettings();
+  void SaveUserConfigWithViewport2DState();
   void ApplySavedLayout();
   void ApplyLayoutPreset(const LayoutViewPreset &preset,
                          const std::optional<std::string> &perspective,

--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -84,8 +84,7 @@ void MainWindow::OnSave(wxCommandEvent &event) {
     return;
   }
   SyncSceneData();
-  SaveCameraSettings();
-  ConfigManager::Get().SaveUserConfig();
+  SaveUserConfigWithViewport2DState();
   if (!ConfigManager::Get().SaveProject(currentProjectPath))
     wxMessageBox("Failed to save project.", "Error", wxICON_ERROR);
   else {
@@ -117,8 +116,7 @@ void MainWindow::OnSaveAs(wxCommandEvent &event) {
 
   currentProjectPath = dlg.GetPath().ToStdString();
   SyncSceneData();
-  SaveCameraSettings();
-  ConfigManager::Get().SaveUserConfig();
+  SaveUserConfigWithViewport2DState();
   if (!ConfigManager::Get().SaveProject(currentProjectPath))
     wxMessageBox("Failed to save project.", "Error", wxICON_ERROR);
   else {

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -543,8 +543,7 @@ void MainWindow::OnClose(wxCommandEvent &event) {
 }
 
 void MainWindow::OnCloseWindow(wxCloseEvent &event) {
-  SaveCameraSettings();
-  ConfigManager::Get().SaveUserConfig();
+  SaveUserConfigWithViewport2DState();
   if (!ConfirmSaveIfDirty("exiting", "Exit")) {
     event.Veto();
     return;


### PR DESCRIPTION
### Motivation
- The standalone 2D viewport camera (offset/zoom/view) was being overwritten by layout-mode view state when saving or closing, causing the user's on-screen 2D pan/zoom to reset.
- The 2D viewer configuration must remain independent from layout view definitions and be saved/restored without being stomped by other parts of the application.

### Description
- Added `MainWindow::SaveUserConfigWithViewport2DState()` which captures the 2D viewport state when layout mode is active, calls the existing `SaveCameraSettings()`, saves the user config, and then reapplies the captured 2D state to keep the standalone viewport unchanged.
- Replaced direct calls to `SaveCameraSettings()`/`ConfigManager::Get().SaveUserConfig()` with `SaveUserConfigWithViewport2DState()` in the close/save flows (`MainWindow` destructor, `OnCloseWindow`, `OnSave`, and `OnSaveAs`).
- Updated declarations in `gui/mainwindow.h` and modified implementations in `gui/mainwindow.cpp`, `gui/mainwindow_io.cpp`, and `gui/mainwindow_menu.cpp` to wire the new helper and remove the redundant explicit `SaveUserConfig()` call from the destructor.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ff8415d94832484fda26706a8ae92)