### PR TITLE
Preserve standalone 2D viewer state during layout mode and saves

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -534,17 +534,20 @@ void MainWindow::SaveCameraSettings() {
 
 void MainWindow::SaveUserConfigWithViewport2DState() {
   ConfigManager &cfg = ConfigManager::Get();
-  std::optional<viewer2d::Viewer2DState> guardState;
-  if (layoutModeActive && viewport2DPanel) {
-    guardState = viewer2d::CaptureState(viewport2DPanel, cfg);
-  }
+  std::optional<viewer2d::Viewer2DState> layoutState;
+  if (layoutModeActive && viewport2DPanel)
+    layoutState = viewer2d::CaptureState(viewport2DPanel, cfg);
+  if (layoutModeActive && !standalone2DState)
+    standalone2DState = viewer2d::CaptureState(nullptr, cfg);
+  if (layoutModeActive && standalone2DState)
+    viewer2d::ApplyState(nullptr, nullptr, cfg, *standalone2DState);
 
   SaveCameraSettings();
   cfg.SaveUserConfig();
 
-  if (guardState) {
+  if (layoutModeActive && layoutState) {
     viewer2d::ApplyState(viewport2DPanel, viewport2DRenderPanel, cfg,
-                         *guardState);
+                         *layoutState);
   }
 }
 

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -187,6 +187,7 @@ private:
   std::unique_ptr<viewer2d::ScopedViewer2DState> layout2DViewStateGuard;
   Viewer2DPanel *layout2DViewEditPanel = nullptr;
   Viewer2DRenderPanel *layout2DViewEditRenderPanel = nullptr;
+  std::optional<viewer2d::Viewer2DState> standalone2DState;
 
   inline static MainWindow *s_instance = nullptr;
   wxDECLARE_EVENT_TABLE();

--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -351,6 +351,24 @@ void MainWindow::ApplyLayoutPreset(const LayoutViewPreset &preset,
   if (!auiManager)
     return;
 
+  const bool wasLayoutMode = layoutModeActive;
+  if (layoutMode && !wasLayoutMode) {
+    ConfigManager &cfg = ConfigManager::Get();
+    if (!standalone2DState)
+      standalone2DState = viewer2d::CaptureState(viewport2DPanel, cfg);
+  } else if (!layoutMode && wasLayoutMode) {
+    if (standalone2DState) {
+      ConfigManager &cfg = ConfigManager::Get();
+      if (viewport2DPanel) {
+        viewer2d::ApplyState(viewport2DPanel, viewport2DRenderPanel, cfg,
+                             *standalone2DState);
+      } else {
+        viewer2d::ApplyState(nullptr, nullptr, cfg, *standalone2DState);
+      }
+      standalone2DState.reset();
+    }
+  }
+
   if (perspective && !perspective->empty())
     auiManager->LoadPerspective(*perspective, true);
   else
@@ -950,6 +968,8 @@ void MainWindow::RestoreLayout2DViewState(int viewId) {
     return;
 
   ConfigManager &cfg = ConfigManager::Get();
+  if (layoutModeActive && !standalone2DState)
+    standalone2DState = viewer2d::CaptureState(nullptr, cfg);
   Viewer2DPanel *activePanel =
       (layout2DViewEditing && layout2DViewEditPanel) ? layout2DViewEditPanel
                                                      : viewport2DPanel;


### PR DESCRIPTION
### Motivation
- The standalone 2D viewport camera/render state must remain independent from layout-edit 2D views and must not be overwritten when switching layout modes or when saving the project.
- Current flows saved layout view parameters during layout edits which could overwrite the user's standalone 2D view position/zoom when config is persisted.

### Description
- Added `std::optional<viewer2d::Viewer2DState> standalone2DState` to `MainWindow` to hold the standalone 2D viewer state independently (`gui/mainwindow.h`).
- When applying layout presets `ApplyLayoutPreset(...)` now captures the standalone 2D state when entering layout mode and restores & clears it when leaving layout mode (`gui/mainwindow_layout.cpp`).
- `RestoreLayout2DViewState(...)` ensures the standalone state is captured before applying a layout 2D view so the standalone viewport can be restored later (`gui/mainwindow_layout.cpp`).
- `SaveUserConfigWithViewport2DState()` now captures the layout-edit view state and the standalone 2D state separately, temporarily applies the standalone state into the config before calling `cfg.SaveUserConfig()`, then re-applies the layout view state to the active panel after saving so saves don’t clobber the standalone 2D settings (`gui/mainwindow.cpp`).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ffb9107088324b19d59bee81cb309)