### PR TITLE
Preserve 2D view state when saving in layout mode

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -537,8 +537,10 @@ void MainWindow::SaveUserConfigWithViewport2DState() {
   std::optional<viewer2d::Viewer2DState> layoutState;
   if (layoutModeActive && viewport2DPanel)
     layoutState = viewer2d::CaptureState(viewport2DPanel, cfg);
-  if (layoutModeActive && !standalone2DState)
-    standalone2DState = viewer2d::CaptureState(nullptr, cfg);
+  if (layoutModeActive && !standalone2DState) {
+    Viewer2DPanel *capturePanel = viewport2DPanel;
+    standalone2DState = viewer2d::CaptureState(capturePanel, cfg);
+  }
   if (layoutModeActive && standalone2DState)
     viewer2d::ApplyState(nullptr, nullptr, cfg, *standalone2DState);
 


### PR DESCRIPTION
### Motivation
- Saving the user config while in layout mode could overwrite the live 2D viewport state because the standalone state was captured from `ConfigManager` (`nullptr`) instead of the live `Viewer2DPanel`, causing offsets/zoom to be reset on reopen.

### Description
- In `MainWindow::SaveUserConfigWithViewport2DState` the code now captures the current panel state by passing `viewport2DPanel` into `viewer2d::CaptureState` when initializing `standalone2DState` instead of calling `CaptureState(nullptr, cfg)`; this change is in `gui/mainwindow.cpp` and preserves the live 2D view (offset/zoom/render) when saving in layout mode.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ffee4bf74832487c4191b95a74850)