### PR TITLE
Corregir persistencia del estado del Viewer 2D al guardar

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -521,7 +521,7 @@ void MainWindow::SaveCameraSettings() {
     ConfigManager::Get().SetFloat("camera_target_y", cam.GetTargetY());
     ConfigManager::Get().SetFloat("camera_target_z", cam.GetTargetZ());
   }
-  if (viewport2DPanel && !layoutModeActive)
+  if (viewport2DPanel)
     viewport2DPanel->SaveViewToConfig();
   if (auiManager) {
     const std::string perspective =
@@ -537,6 +537,9 @@ void MainWindow::SaveUserConfigWithViewport2DState() {
   std::optional<viewer2d::Viewer2DState> layoutState;
   if (layoutModeActive && viewport2DPanel)
     layoutState = viewer2d::CaptureState(viewport2DPanel, cfg);
+
+  SaveCameraSettings();
+
   if (layoutModeActive && !standalone2DState) {
     Viewer2DPanel *capturePanel = viewport2DPanel;
     standalone2DState = viewer2d::CaptureState(capturePanel, cfg);
@@ -544,13 +547,11 @@ void MainWindow::SaveUserConfigWithViewport2DState() {
   if (layoutModeActive && standalone2DState)
     viewer2d::ApplyState(nullptr, nullptr, cfg, *standalone2DState);
 
-  SaveCameraSettings();
   cfg.SaveUserConfig();
 
-  if (layoutModeActive && layoutState) {
+  if (layoutModeActive && layoutState)
     viewer2d::ApplyState(viewport2DPanel, viewport2DRenderPanel, cfg,
                          *layoutState);
-  }
 }
 
 void MainWindow::UpdateViewMenuChecks() {


### PR DESCRIPTION
### Motivation
- Evitar que los valores de posición/zoom del `Viewer2D` se sobrescriban al guardar la configuración de usuario, lo que provocaba que la vista 2D se reseteara al reabrir el programa.

### Description
- Hacer que `SaveCameraSettings()` siempre persista el estado del 2D viewport llamando a `viewport2DPanel->SaveViewToConfig()` independientemente de `layoutModeActive`.
- Reordenar `SaveUserConfigWithViewport2DState()` para llamar a `SaveCameraSettings()` antes de capturar/aplicar el `standalone2DState` y antes de `cfg.SaveUserConfig()`, evitando así que un estado temporal sobrescriba los valores guardados.
- Mantener la captura/restauración del `layoutState` alrededor de la escritura de configuración para preservar el comportamiento anterior de modo layout.

### Testing
- No se ejecutaron pruebas automáticas durante este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970009c67048324b59bdb5b75790895)