### PR TITLE
Preserve standalone 2D viewer state when saving in layout mode

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -535,15 +535,14 @@ void MainWindow::SaveCameraSettings() {
 void MainWindow::SaveUserConfigWithViewport2DState() {
   ConfigManager &cfg = ConfigManager::Get();
   std::optional<viewer2d::Viewer2DState> layoutState;
+  if (layoutModeActive && !standalone2DState) {
+    standalone2DState = viewer2d::CaptureState(nullptr, cfg);
+  }
   if (layoutModeActive && viewport2DPanel)
     layoutState = viewer2d::CaptureState(viewport2DPanel, cfg);
 
   SaveCameraSettings();
 
-  if (layoutModeActive && !standalone2DState) {
-    Viewer2DPanel *capturePanel = viewport2DPanel;
-    standalone2DState = viewer2d::CaptureState(capturePanel, cfg);
-  }
   if (layoutModeActive && standalone2DState)
     viewer2d::ApplyState(nullptr, nullptr, cfg, *standalone2DState);
 


### PR DESCRIPTION
### Motivation
- Saving while in layout mode could overwrite or reset the standalone 2D viewer camera/view settings because the standalone state was captured too late in the save flow, causing the user-modified 2D view to be lost on reopen.

### Description
- Capture the standalone 2D viewer state earlier inside `SaveUserConfigWithViewport2DState()` by calling `standalone2DState = viewer2d::CaptureState(nullptr, cfg);` when `layoutModeActive` and `standalone2DState` is not already present, and remove the previous redundant capture; change applied in `gui/mainwindow.cpp`.
- This ensures `viewer2d::ApplyState(nullptr, nullptr, cfg, *standalone2DState)` writes the preserved standalone 2D view into the config before `cfg.SaveUserConfig()` is called.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697003738e2483248a31734133f0548d)