### PR TITLE
Mantener vista 2D al cerrar/reabrir: aislar estado de layout

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -205,8 +205,8 @@ ConfigManager::ConfigManager() {
   RegisterVariable("label_offset_angle_front", "float", 180.0f, 0.0f, 360.0f);
   RegisterVariable("label_offset_distance_side", "float", 0.5f, 0.0f, 1.0f);
   RegisterVariable("label_offset_angle_side", "float", 180.0f, 0.0f, 360.0f);
-  RegisterVariable("view2d_offset_x", "float", 0.0f, -1000.0f, 1000.0f);
-  RegisterVariable("view2d_offset_y", "float", 0.0f, -1000.0f, 1000.0f);
+  RegisterVariable("view2d_offset_x", "float", 0.0f, -1000000.0f, 1000000.0f);
+  RegisterVariable("view2d_offset_y", "float", 0.0f, -1000000.0f, 1000000.0f);
   RegisterVariable("view2d_zoom", "float", 1.0f, 0.1f, 100.0f);
   RegisterVariable("view2d_render_mode", "float", 2.0f, 0.0f, 3.0f);
   RegisterVariable("view2d_view", "float", 0.0f, 0.0f, 2.0f);

--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1089,7 +1089,7 @@ void LayoutViewerPanel::RebuildCachedTexture() {
     renderState.camera.viewportHeight = renderSize.GetHeight();
 
     auto stateGuard = std::make_shared<viewer2d::ScopedViewer2DState>(
-        capturePanel, nullptr, cfg, renderState);
+        capturePanel, nullptr, cfg, renderState, nullptr, nullptr, false);
 
     std::vector<unsigned char> pixels;
     int width = 0;

--- a/gui/layoutviewerpanel_view.cpp
+++ b/gui/layoutviewerpanel_view.cpp
@@ -174,7 +174,7 @@ void LayoutViewerPanel::DrawViewElement(
       offscreenRenderer->PrepareForCapture();
     }
     auto stateGuard = std::make_shared<viewer2d::ScopedViewer2DState>(
-        capturePanel, nullptr, cfg, layoutState);
+        capturePanel, nullptr, cfg, layoutState, nullptr, nullptr, false);
     capturePanel->CaptureFrameNow(
         [this, viewId, stateGuard, fallbackViewportWidth, fallbackViewportHeight,
          capturePanel](CommandBuffer buffer, Viewer2DViewState state) {

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -535,22 +535,23 @@ void MainWindow::SaveCameraSettings() {
 void MainWindow::SaveUserConfigWithViewport2DState() {
   ConfigManager &cfg = ConfigManager::Get();
   std::optional<viewer2d::Viewer2DState> layoutState;
-  if (layoutModeActive && !standalone2DState) {
-    standalone2DState = viewer2d::CaptureState(nullptr, cfg);
-  }
   if (layoutModeActive && viewport2DPanel)
     layoutState = viewer2d::CaptureState(viewport2DPanel, cfg);
 
   SaveCameraSettings();
 
-  if (layoutModeActive && standalone2DState)
-    viewer2d::ApplyState(nullptr, nullptr, cfg, *standalone2DState);
+  if (layoutModeActive) {
+    if (!standalone2DState)
+      standalone2DState = viewer2d::CaptureState(nullptr, cfg);
+    if (standalone2DState)
+      viewer2d::ApplyState(nullptr, nullptr, cfg, *standalone2DState, true,
+                           false);
+  }
 
   cfg.SaveUserConfig();
 
   if (layoutModeActive && layoutState)
-    viewer2d::ApplyState(viewport2DPanel, viewport2DRenderPanel, cfg,
-                         *layoutState);
+    viewer2d::ApplyState(nullptr, nullptr, cfg, *layoutState, true, false);
 }
 
 void MainWindow::UpdateViewMenuChecks() {

--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -762,7 +762,7 @@ void MainWindow::BeginLayout2DViewEdit() {
   viewer2d::Viewer2DState state = viewer2d::FromLayoutDefinition(*view);
   layout2DViewStateGuard = std::make_unique<viewer2d::ScopedViewer2DState>(
       layout2DViewEditPanel, layout2DViewEditRenderPanel, cfg, state,
-      viewport2DPanel, viewport2DRenderPanel);
+      viewport2DPanel, viewport2DRenderPanel, false);
 
   if (view->frame.height > 0 && layout2DViewEditPanel) {
     float aspect =
@@ -979,5 +979,5 @@ void MainWindow::RestoreLayout2DViewState(int viewId) {
           : viewport2DRenderPanel;
   viewer2d::Viewer2DState state = viewer2d::FromLayoutDefinition(*match);
   state.renderOptions.darkMode = cfg.GetFloat("view2d_dark_mode") != 0.0f;
-  viewer2d::ApplyState(activePanel, activeRenderPanel, cfg, state);
+  viewer2d::ApplyState(activePanel, activeRenderPanel, cfg, state, false);
 }

--- a/gui/mainwindow_print.cpp
+++ b/gui/mainwindow_print.cpp
@@ -432,7 +432,8 @@ void MainWindow::OnPrintLayout(wxCommandEvent &WXUNUSED(event)) {
         }
 
         auto stateGuard = std::make_shared<viewer2d::ScopedViewer2DState>(
-            capturePanel, nullptr, *cfgPtr, layoutState);
+            capturePanel, nullptr, *cfgPtr, layoutState, nullptr, nullptr,
+            false);
         capturePanel->CaptureFrameNow(
             [captureNext, exportViews, view, viewportWidth, viewportHeight,
              capturePanel, scaleX, scaleY,

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -241,12 +241,24 @@ void Viewer2DPanel::LoadViewFromConfig() {
 }
 
 void Viewer2DPanel::SaveViewToConfig() const {
+  if (!m_persistViewState)
+    return;
   ConfigManager &cfg = ConfigManager::Get();
   cfg.SetFloat("view2d_offset_x", m_offsetX);
   cfg.SetFloat("view2d_offset_y", m_offsetY);
   cfg.SetFloat("view2d_zoom", m_zoom);
   cfg.SetFloat("view2d_render_mode", static_cast<float>(m_renderMode));
   cfg.SetFloat("view2d_view", static_cast<float>(m_view));
+}
+
+void Viewer2DPanel::ApplyViewState(float offsetX, float offsetY, float zoom,
+                                   Viewer2DView view,
+                                   Viewer2DRenderMode renderMode) {
+  m_offsetX = offsetX;
+  m_offsetY = offsetY;
+  m_zoom = zoom;
+  m_view = view;
+  m_renderMode = renderMode;
 }
 
 void Viewer2DPanel::RequestFrameCapture() { m_captureNextFrame = true; }

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -69,6 +69,8 @@ public:
 
   void LoadViewFromConfig();
   void SaveViewToConfig() const;
+  void ApplyViewState(float offsetX, float offsetY, float zoom,
+                      Viewer2DView view, Viewer2DRenderMode renderMode);
 
   // Request that the next paint pass stores every 2D drawing command in
   // m_lastCapturedFrame. The on-screen result is unchanged.

--- a/viewer2d/viewer2dstate.h
+++ b/viewer2d/viewer2dstate.h
@@ -36,7 +36,9 @@ struct Viewer2DState {
 Viewer2DState CaptureState(const Viewer2DPanel *panel,
                            const ConfigManager &cfg);
 void ApplyState(Viewer2DPanel *panel, Viewer2DRenderPanel *renderPanel,
-                ConfigManager &cfg, const Viewer2DState &state);
+                ConfigManager &cfg, const Viewer2DState &state,
+                bool persistCameraToConfig = true,
+                bool updatePanels = true);
 
 class ScopedViewer2DState {
 public:
@@ -44,7 +46,8 @@ public:
                       Viewer2DRenderPanel *applyRenderPanel,
                       ConfigManager &cfg, const Viewer2DState &state,
                       Viewer2DPanel *restorePanel = nullptr,
-                      Viewer2DRenderPanel *restoreRenderPanel = nullptr);
+                      Viewer2DRenderPanel *restoreRenderPanel = nullptr,
+                      bool persistCameraToConfig = true);
   ~ScopedViewer2DState();
 
   ScopedViewer2DState(const ScopedViewer2DState &) = delete;
@@ -63,6 +66,7 @@ private:
   wxWeakRef<Viewer2DRenderPanel> restoreRenderPanel_;
   Viewer2DState previousState_;
   bool restored_ = true;
+  bool persistCameraToConfig_ = true;
 };
 
 Viewer2DState FromLayoutDefinition(const layouts::Layout2DViewDefinition &view);


### PR DESCRIPTION
### Motivation
- Evitar que estados temporales de visores de layout u off‑screen sobrescriban la vista 2D principal guardada en `ConfigManager` (claves `view2d_offset_x`, `view2d_offset_y`, `view2d_zoom`).
- Asegurar que al guardar la configuración de usuario la cámara persistida provenga del estado standalone apropiado y no de estados usados sólo para edición/impresión.
- Permitir capturas/operaciones con visores secundarios sin escribir accidentalmente en la configuración global del usuario.

### Description
- Añadido `Viewer2DPanel::ApplyViewState(...)` y cambiado `Viewer2DPanel::SaveViewToConfig()` para respetar la bandera `m_persistViewState`, de forma que sólo los paneles con `persistViewState=true` escriban en `ConfigManager` (ficheros modificados: `viewer2d/viewer2dpanel.h`, `viewer2d/viewer2dpanel.cpp`).
- Modificada la API de estado 2D para soportar aplicar estados sin persistir la cámara en la configuración mediante nuevos parámetros `persistCameraToConfig` y `updatePanels` en `ApplyState()` y en `ScopedViewer2DState`, y aplicando el flujo apropiado cuando sea un visor secundario (ficheros modificados: `viewer2d/viewer2dstate.h`, `viewer2d/viewer2dstate.cpp`).
- Ajustada la lógica de guardado en `MainWindow::SaveUserConfigWithViewport2DState()` para capturar/usar el `standalone2DState` y escribir la configuración del usuario sin restaurar temporalmente la vista editable que provocaba sobreescrituras; después de guardar se vuelve a aplicar el estado de layout sin persistir (fichero modificado: `gui/mainwindow.cpp`).
- Cambiados los lugares que usan estados para capturas/edición/imprenta para no persistir la cámara (pasan `persist=false` a `ScopedViewer2DState`), incluyendo `gui/mainwindow_layout.cpp`, `gui/layoutviewerpanel.cpp`, `gui/layoutviewerpanel_view.cpp` y `gui/mainwindow_print.cpp`.
- Ampliado el rango registrado para `view2d_offset_x` y `view2d_offset_y` en `ConfigManager` de ±1000 a ±1e6 para evitar saturación/truncado de desplazamientos grandes (fichero modificado: `core/configmanager.cpp`).

### Testing
- No se ejecutaron tests automáticos en este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970072733508324b97eb5c1ee67e26d)