### PR TITLE
Auto-fit layout view on initial resize

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -99,6 +99,7 @@ LayoutViewerPanel::LayoutViewerPanel(wxWindow *parent)
   glContext_ = new wxGLContext(this);
   currentLayout.pageSetup.pageSize = print::PageSize::A4;
   currentLayout.pageSetup.landscape = true;
+  pendingFitOnResize = true;
   ResetViewToFit();
 }
 
@@ -134,6 +135,7 @@ void LayoutViewerPanel::SetLayoutDefinition(
   ClearCachedTexture();
   renderDirty = true;
   RefreshLegendData();
+  pendingFitOnResize = true;
   ResetViewToFit();
   RequestRenderRebuild();
   Refresh();
@@ -412,7 +414,13 @@ void LayoutViewerPanel::DrawSelectionHandles(const wxRect &frameRect) const {
 }
 
 void LayoutViewerPanel::OnSize(wxSizeEvent &) {
-  InvalidateRenderIfFrameChanged();
+  wxSize size = GetClientSize();
+  if (pendingFitOnResize && size.GetWidth() > 0 && size.GetHeight() > 0) {
+    ResetViewToFit();
+    pendingFitOnResize = false;
+  } else {
+    InvalidateRenderIfFrameChanged();
+  }
   RequestRenderRebuild();
   Refresh();
 }

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -258,6 +258,7 @@ private:
   std::unordered_map<int, ImageCache> imageCaches_;
   std::vector<LegendItem> legendItems_;
   size_t legendDataHash = 0;
+  bool pendingFitOnResize = true;
 
   wxDECLARE_EVENT_TABLE();
 };


### PR DESCRIPTION
### Motivation
- The layout appears zoomed out the first time the Layout Mode is opened; the change ensures the viewer auto-fits the page the same way as pressing `z` (which calls `ResetViewToFit`).

### Description
- Add a `pendingFitOnResize` flag to `LayoutViewerPanel`, set it in the constructor and in `SetLayoutDefinition`, and update `OnSize` to call `ResetViewToFit` on the first valid resize (clearing the flag), otherwise preserve the previous `InvalidateRenderIfFrameChanged` behavior.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69708fae7fe48324815870601b674dfe)