### PR TITLE
Sync 2D selection highlights with table selections

### DIFF
--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -1149,6 +1149,8 @@ void FixtureTablePanel::OnSelectionChanged(wxDataViewEvent &evt) {
   }
   if (Viewer3DPanel::Instance())
     Viewer3DPanel::Instance()->SetSelectedFixtures(uuids);
+  if (Viewer2DPanel::Instance())
+    Viewer2DPanel::Instance()->SetSelectedUuids(uuids);
   UpdateSelectionHighlight();
   evt.Skip();
 }

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -474,6 +474,8 @@ void SceneObjectTablePanel::OnSelectionChanged(wxDataViewEvent& evt)
     }
     if (Viewer3DPanel::Instance())
         Viewer3DPanel::Instance()->SetSelectedFixtures(uuids);
+    if (Viewer2DPanel::Instance())
+        Viewer2DPanel::Instance()->SetSelectedUuids(uuids);
     UpdateSelectionHighlight();
     evt.Skip();
 }

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -641,6 +641,8 @@ void TrussTablePanel::OnSelectionChanged(wxDataViewEvent& evt)
     }
     if (Viewer3DPanel::Instance())
         Viewer3DPanel::Instance()->SetSelectedFixtures(uuids);
+    if (Viewer2DPanel::Instance())
+        Viewer2DPanel::Instance()->SetSelectedUuids(uuids);
     UpdateSelectionHighlight();
     evt.Skip();
 }

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -222,6 +222,14 @@ void Viewer2DPanel::SetView(Viewer2DView view) {
   Refresh();
 }
 
+void Viewer2DPanel::SetSelectedUuids(
+    const std::vector<std::string> &selection) {
+  if (!m_enableSelection)
+    return;
+  m_controller.SetSelectedUuids(selection);
+  Refresh();
+}
+
 void Viewer2DPanel::SetLayerColor(const std::string &layer,
                                   const std::string &hex) {
   // Forward the updated color to the shared controller so the 2D view

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -63,6 +63,9 @@ public:
   void SetView(Viewer2DView view);
   Viewer2DView GetView() const { return m_view; }
 
+  // Synchronize the highlighted selection from external sources (tables/3D).
+  void SetSelectedUuids(const std::vector<std::string> &selection);
+
   // Update cached color for a specific layer so user selections are applied
   // immediately to the 2D renderer.
   void SetLayerColor(const std::string &layer, const std::string &hex);


### PR DESCRIPTION
### Motivation
- Ensure the 2D viewer shows the same cyan highlight when rows are selected in the fixtures/trusses/scene objects tables so selection feels consistent between list views and visualizers. 
- Make the 2D view respond to external selection changes (tables and 3D) without requiring the user to click inside the 2D canvas.

### Description
- Added a public API `Viewer2DPanel::SetSelectedUuids(const std::vector<std::string>&)` to `viewer2d/viewer2dpanel.h` and implemented it in `viewer2d/viewer2dpanel.cpp` to forward selections to the shared `Viewer3DController` and refresh the 2D view. 
- Wired table selection handlers to call the new API so table selections propagate to the 2D view by adding calls to `Viewer2DPanel::Instance()->SetSelectedUuids(uuids)` in `gui/fixturetablepanel.cpp`, `gui/trusstablepanel.cpp`, and `gui/sceneobjecttablepanel.cpp`. 
- The 2D setter respects the panel's `m_enableSelection` flag and triggers a `Refresh()` after updating controller state so the highlight is updated immediately.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970937e9b1883249d191c551703b1ad)