### PR TITLE
Sync 2D viewer highlights for CLI selections

### DIFF
--- a/gui/consolepanel.cpp
+++ b/gui/consolepanel.cpp
@@ -22,6 +22,7 @@
 #include "matrixutils.h"
 #include "sceneobjecttablepanel.h"
 #include "trusstablepanel.h"
+#include "viewer2dpanel.h"
 #include "viewer3dpanel.h"
 #include <algorithm>
 #include <charconv>
@@ -387,6 +388,8 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
         if (TrussTablePanel::Instance())
           TrussTablePanel::Instance()->SelectByUuid(current);
       }
+      if (Viewer2DPanel::Instance())
+        Viewer2DPanel::Instance()->SetSelectedUuids(current);
       if (Viewer3DPanel::Instance()) {
         Viewer3DPanel::Instance()->SetSelectedFixtures(current);
         Viewer3DPanel::Instance()->Refresh();


### PR DESCRIPTION
### Motivation
- Ensure selections made from the CLI also update the 2D viewer highlight, matching the behavior already present for table selections and the 3D viewer.

### Description
- Add `#include "viewer2dpanel.h"` and invoke `Viewer2DPanel::Instance()->SetSelectedUuids(current)` in `ConsolePanel::ProcessCommand` so CLI selection changes propagate to the 2D view.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697097ce3b9883248bd0ba1296413c2f)