### PR TITLE
Sync CLI 'clear' with 2D viewer selection

### DIFF
--- a/gui/consolepanel.cpp
+++ b/gui/consolepanel.cpp
@@ -549,6 +549,8 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
           Viewer3DPanel::Instance()->SetSelectedFixtures({});
           Viewer3DPanel::Instance()->Refresh();
         }
+        if (Viewer2DPanel::Instance())
+          Viewer2DPanel::Instance()->SetSelectedUuids({});
       } else if (lw == "pos" || lw == "rot") {
         bool isRot = (lw == "rot");
         cfg.PushUndoState(std::string("cli ") + lw);


### PR DESCRIPTION
### Motivation
- Fix desynchronization between table/3D selection state and the 2D viewer so running the CLI `clear` command also clears highlights in the 2D view.

### Description
- When processing the `clear` CLI command in `gui/consolepanel.cpp` call `Viewer2DPanel::Instance()->SetSelectedUuids({})` to clear the 2D selection.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970999f4d688324bb7205329a3eeb86)