### PR TITLE
Allow hover highlight over selected table rows

### DIFF
--- a/gui/colorstore.h
+++ b/gui/colorstore.h
@@ -53,7 +53,7 @@ public:
     if (isSelected) {
       if (!hasAttr)
         attr = wxDataViewItemAttr();
-      if (selectionBackgroundEnabled)
+      if (selectionBackgroundEnabled && !attr.HasBackgroundColour())
         attr.SetBackgroundColour(selectionBackground);
       if (selectionForegroundEnabled && !hasTextColour)
         attr.SetColour(selectionForeground);


### PR DESCRIPTION
### Motivation
- Table row hover (green) was not visible when a row was already selected (cyan) because the selection background unconditionally overwrote any per-row/background hover highlight, making hover behavior inconsistent with the 2D/3D viewers.

### Description
- Change `GetAttrByRow` in `gui/colorstore.h` to only apply the selection background when `selectionBackgroundEnabled` is true and `attr` does not already have a background color, i.e. use `selectionBackgroundEnabled && !attr.HasBackgroundColour()` so existing hover/background highlights are preserved.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697268da7dd483248b443ff55a2df0ef)