### PR TITLE
Fix table hover highlight on selected rows

### DIFF
--- a/gui/colorfulrenderers.h
+++ b/gui/colorfulrenderers.h
@@ -61,14 +61,14 @@ inline bool ResolveBackgroundColour(const wxDataViewCustomRenderer *renderer,
                                     int state,
                                     const wxDataViewItemAttr &attr,
                                     wxColour &colour) {
+  if (attr.HasBackgroundColour()) {
+    colour = attr.GetBackgroundColour();
+    return true;
+  }
   const auto *store = GetColorfulStore(renderer);
   if ((state & wxDATAVIEW_CELL_SELECTED) && store &&
       store->selectionBackgroundEnabled) {
     colour = store->selectionBackground;
-    return true;
-  }
-  if (attr.HasBackgroundColour()) {
-    colour = attr.GetBackgroundColour();
     return true;
   }
   return false;


### PR DESCRIPTION
### Motivation
- The green hover highlight applied to a row (used for object hover) was not visible in data tables when the row was already selected and tinted with the selection background, causing inconsistent behavior versus the 2D/3D viewers.

### Description
- Change the background resolution order in `ResolveBackgroundColour` so that `attr.HasBackgroundColour()` (row/cell background like hover) is checked before the selection background, ensuring row-specific backgrounds take precedence.
- The change is implemented in `gui/colorfulrenderers.h` by moving the `attr.HasBackgroundColour()` branch above the selection background logic.
- This modifies the rendering behavior used by `ColorfulTextRenderer` and `ColorfulIconTextRenderer` so hover highlights show even for selected rows.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69726a0510a0832482d7a043bfcb0dc0)