### PR TITLE
Apply per-row selection background and preserve green highlights

### DIFF
--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -1165,6 +1165,25 @@ void FixtureTablePanel::UpdateSelectionHighlight() {
     if (r != wxNOT_FOUND && static_cast<size_t>(r) < rowCount)
       selectedRows[r] = true;
   }
+  const wxColour selectionColor = store->selectionBackground;
+  const wxColour highlightColor(0, 200, 0);
+  for (size_t row = 0; row < rowCount; ++row) {
+    bool hasBackground = row < store->rowAttrs.size() &&
+                         store->rowAttrs[row].HasBackgroundColour();
+    wxColour currentBackground;
+    if (hasBackground)
+      currentBackground = store->rowAttrs[row].GetBackgroundColour();
+    bool isHighlight =
+        hasBackground && currentBackground == highlightColor;
+    if (selectedRows[row]) {
+      if (!hasBackground || currentBackground == selectionColor) {
+        if (!isHighlight)
+          store->SetRowBackgroundColour(row, selectionColor);
+      }
+    } else if (hasBackground && currentBackground == selectionColor) {
+      store->ClearRowBackground(row);
+    }
+  }
   store->SetSelectedRows(selectedRows);
 }
 

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -507,6 +507,24 @@ void HoistTablePanel::UpdateSelectionHighlight() {
     if (r != wxNOT_FOUND && static_cast<size_t>(r) < rowCount)
       selectedRows[r] = true;
   }
+  const wxColour selectionColor = store->selectionBackground;
+  const wxColour highlightColor(0, 200, 0);
+  for (size_t row = 0; row < rowCount; ++row) {
+    bool hasBackground = row < store->rowAttrs.size() &&
+                         store->rowAttrs[row].HasBackgroundColour();
+    wxColour currentBackground;
+    if (hasBackground)
+      currentBackground = store->rowAttrs[row].GetBackgroundColour();
+    bool isHighlight = hasBackground && currentBackground == highlightColor;
+    if (selectedRows[row]) {
+      if (!hasBackground || currentBackground == selectionColor) {
+        if (!isHighlight)
+          store->SetRowBackgroundColour(row, selectionColor);
+      }
+    } else if (hasBackground && currentBackground == selectionColor) {
+      store->ClearRowBackground(row);
+    }
+  }
   store->SetSelectedRows(selectedRows);
 }
 

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -492,6 +492,29 @@ void SceneObjectTablePanel::UpdateSelectionHighlight()
         if (r != wxNOT_FOUND && static_cast<size_t>(r) < rowCount)
             selectedRows[r] = true;
     }
+    const wxColour selectionColor = store->selectionBackground;
+    const wxColour highlightColor(0, 200, 0);
+    for (size_t row = 0; row < rowCount; ++row)
+    {
+        bool hasBackground = row < store->rowAttrs.size() &&
+                             store->rowAttrs[row].HasBackgroundColour();
+        wxColour currentBackground;
+        if (hasBackground)
+            currentBackground = store->rowAttrs[row].GetBackgroundColour();
+        bool isHighlight = hasBackground && currentBackground == highlightColor;
+        if (selectedRows[row])
+        {
+            if (!hasBackground || currentBackground == selectionColor)
+            {
+                if (!isHighlight)
+                    store->SetRowBackgroundColour(row, selectionColor);
+            }
+        }
+        else if (hasBackground && currentBackground == selectionColor)
+        {
+            store->ClearRowBackground(row);
+        }
+    }
     store->SetSelectedRows(selectedRows);
 }
 

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -659,6 +659,29 @@ void TrussTablePanel::UpdateSelectionHighlight()
         if (r != wxNOT_FOUND && static_cast<size_t>(r) < rowCount)
             selectedRows[r] = true;
     }
+    const wxColour selectionColor = store->selectionBackground;
+    const wxColour highlightColor(0, 200, 0);
+    for (size_t row = 0; row < rowCount; ++row)
+    {
+        bool hasBackground = row < store->rowAttrs.size() &&
+                             store->rowAttrs[row].HasBackgroundColour();
+        wxColour currentBackground;
+        if (hasBackground)
+            currentBackground = store->rowAttrs[row].GetBackgroundColour();
+        bool isHighlight = hasBackground && currentBackground == highlightColor;
+        if (selectedRows[row])
+        {
+            if (!hasBackground || currentBackground == selectionColor)
+            {
+                if (!isHighlight)
+                    store->SetRowBackgroundColour(row, selectionColor);
+            }
+        }
+        else if (hasBackground && currentBackground == selectionColor)
+        {
+            store->ClearRowBackground(row);
+        }
+    }
     store->SetSelectedRows(selectedRows);
 }
 


### PR DESCRIPTION
### Motivation
- Make row selection visuals explicit by applying the selection color to the row background instead of relying only on renderer selection state by modifying `UpdateSelectionHighlight` behavior. 
- Ensure critical highlights (green used by `HighlightFixture` / `HighlightObject`) are not overridden by selection color. 
- Clear selection background when rows are deselected while continuing to track selected rows via the store.

### Description
- Updated `UpdateSelectionHighlight` in `gui/fixturetablepanel.cpp`, `gui/sceneobjecttablepanel.cpp`, `gui/hoisttablepanel.cpp` and `gui/trusstablepanel.cpp` to compute `selectionColor` and `highlightColor` and apply per-row background changes. 
- For each row, added logic to check existing row background via `store->rowAttrs[row].HasBackgroundColour()` and `GetBackgroundColour()` and only call `SetRowBackgroundColour(row, selectionColor)` when it will not overwrite the green highlight (`wxColour(0,200,0)`). 
- On deselect, rows whose background matches the selection color are cleared with `store->ClearRowBackground(row)`. 
- Selection bookkeeping remains via `store->SetSelectedRows(selectedRows)` at the end of the function.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69726d6511ec83248a36b2df0dae0557)