### PR TITLE
Merge row background into cell attributes

### DIFF
--- a/gui/colorstore.h
+++ b/gui/colorstore.h
@@ -41,10 +41,15 @@ public:
       hasTextColour = attr.HasColour();
     }
 
-    if (!hasAttr && row < rowAttrs.size() && !rowAttrs[row].IsDefault()) {
-      attr = rowAttrs[row];
-      hasAttr = true;
-      hasTextColour = attr.HasColour();
+    if (row < rowAttrs.size() && !rowAttrs[row].IsDefault()) {
+      if (!hasAttr) {
+        attr = rowAttrs[row];
+        hasAttr = true;
+        hasTextColour = attr.HasColour();
+      } else if (rowAttrs[row].HasBackgroundColour() &&
+                 !attr.HasBackgroundColour()) {
+        attr.SetBackgroundColour(rowAttrs[row].GetBackgroundColour());
+      }
     }
 
     bool isSelected =


### PR DESCRIPTION
### Motivation
- Ensure a row-level background (selection background) is visible in all columns even when individual cells have text attributes.
- Avoid overwriting existing cell attributes when combining row and cell styles.
- Preserve per-cell text color while allowing the row background to fill missing cell backgrounds.

### Description
- Update `GetAttrByRow` in `gui/colorstore.h` to avoid replacing a cell attribute when it exists and instead merge the row background when the cell has no background.
- When a cell attribute is present and the corresponding `rowAttrs[row]` has a background and the cell lacks one, copy the row background into the cell attribute via `SetBackgroundColour`.
- Keep the previous behavior of using the row attribute when no cell attribute exists, and retain existing selection color logic and text-color precedence.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972706c7068832485d6468754ce210e)