### PR TITLE
Apply selection background per-cell in table panels and add cell background APIs

### DIFF
--- a/gui/colorstore.h
+++ b/gui/colorstore.h
@@ -157,10 +157,33 @@ public:
     RowChanged(row);
   }
 
+  void SetCellBackgroundColour(unsigned row, unsigned col,
+                               const wxColour &colour) {
+    if (row >= cellAttrs.size())
+      cellAttrs.resize(row + 1);
+    if (col >= cellAttrs[row].size())
+      cellAttrs[row].resize(col + 1);
+    cellAttrs[row][col].SetBackgroundColour(colour);
+    RowChanged(row);
+  }
+
   void ClearCellTextColour(unsigned row, unsigned col) {
     if (row >= cellAttrs.size() || col >= cellAttrs[row].size())
       return;
     cellAttrs[row][col] = wxDataViewItemAttr();
+    RowChanged(row);
+  }
+
+  void ClearCellBackgroundColour(unsigned row, unsigned col) {
+    if (row >= cellAttrs.size() || col >= cellAttrs[row].size())
+      return;
+    wxColour fg;
+    bool hasFg = cellAttrs[row][col].HasColour();
+    if (hasFg)
+      fg = cellAttrs[row][col].GetColour();
+    cellAttrs[row][col] = wxDataViewItemAttr();
+    if (hasFg)
+      cellAttrs[row][col].SetColour(fg);
     RowChanged(row);
   }
 

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -1167,21 +1167,23 @@ void FixtureTablePanel::UpdateSelectionHighlight() {
   }
   const wxColour selectionColor = store->selectionBackground;
   const wxColour highlightColor(0, 200, 0);
+  const unsigned int columnCount = table->GetColumnCount();
   for (size_t row = 0; row < rowCount; ++row) {
-    bool hasBackground = row < store->rowAttrs.size() &&
-                         store->rowAttrs[row].HasBackgroundColour();
-    wxColour currentBackground;
-    if (hasBackground)
-      currentBackground = store->rowAttrs[row].GetBackgroundColour();
     bool isHighlight =
-        hasBackground && currentBackground == highlightColor;
-    if (selectedRows[row]) {
-      if (!hasBackground || currentBackground == selectionColor) {
-        if (!isHighlight)
-          store->SetRowBackgroundColour(row, selectionColor);
-      }
-    } else if (hasBackground && currentBackground == selectionColor) {
+        row < store->rowAttrs.size() &&
+        store->rowAttrs[row].HasBackgroundColour() &&
+        store->rowAttrs[row].GetBackgroundColour() == highlightColor;
+    if (!isHighlight && row < store->rowAttrs.size() &&
+        store->rowAttrs[row].HasBackgroundColour() &&
+        store->rowAttrs[row].GetBackgroundColour() == selectionColor)
       store->ClearRowBackground(row);
+    for (unsigned int col = 0; col < columnCount; ++col) {
+      if (isHighlight)
+        store->SetCellBackgroundColour(row, col, highlightColor);
+      else if (selectedRows[row])
+        store->SetCellBackgroundColour(row, col, selectionColor);
+      else
+        store->ClearCellBackgroundColour(row, col);
     }
   }
   store->SetSelectedRows(selectedRows);

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -509,20 +509,23 @@ void HoistTablePanel::UpdateSelectionHighlight() {
   }
   const wxColour selectionColor = store->selectionBackground;
   const wxColour highlightColor(0, 200, 0);
+  const unsigned int columnCount = table->GetColumnCount();
   for (size_t row = 0; row < rowCount; ++row) {
-    bool hasBackground = row < store->rowAttrs.size() &&
-                         store->rowAttrs[row].HasBackgroundColour();
-    wxColour currentBackground;
-    if (hasBackground)
-      currentBackground = store->rowAttrs[row].GetBackgroundColour();
-    bool isHighlight = hasBackground && currentBackground == highlightColor;
-    if (selectedRows[row]) {
-      if (!hasBackground || currentBackground == selectionColor) {
-        if (!isHighlight)
-          store->SetRowBackgroundColour(row, selectionColor);
-      }
-    } else if (hasBackground && currentBackground == selectionColor) {
+    bool isHighlight =
+        row < store->rowAttrs.size() &&
+        store->rowAttrs[row].HasBackgroundColour() &&
+        store->rowAttrs[row].GetBackgroundColour() == highlightColor;
+    if (!isHighlight && row < store->rowAttrs.size() &&
+        store->rowAttrs[row].HasBackgroundColour() &&
+        store->rowAttrs[row].GetBackgroundColour() == selectionColor)
       store->ClearRowBackground(row);
+    for (unsigned int col = 0; col < columnCount; ++col) {
+      if (isHighlight)
+        store->SetCellBackgroundColour(row, col, highlightColor);
+      else if (selectedRows[row])
+        store->SetCellBackgroundColour(row, col, selectionColor);
+      else
+        store->ClearCellBackgroundColour(row, col);
     }
   }
   store->SetSelectedRows(selectedRows);

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -494,25 +494,25 @@ void SceneObjectTablePanel::UpdateSelectionHighlight()
     }
     const wxColour selectionColor = store->selectionBackground;
     const wxColour highlightColor(0, 200, 0);
+    const unsigned int columnCount = table->GetColumnCount();
     for (size_t row = 0; row < rowCount; ++row)
     {
-        bool hasBackground = row < store->rowAttrs.size() &&
-                             store->rowAttrs[row].HasBackgroundColour();
-        wxColour currentBackground;
-        if (hasBackground)
-            currentBackground = store->rowAttrs[row].GetBackgroundColour();
-        bool isHighlight = hasBackground && currentBackground == highlightColor;
-        if (selectedRows[row])
-        {
-            if (!hasBackground || currentBackground == selectionColor)
-            {
-                if (!isHighlight)
-                    store->SetRowBackgroundColour(row, selectionColor);
-            }
-        }
-        else if (hasBackground && currentBackground == selectionColor)
-        {
+        bool isHighlight =
+            row < store->rowAttrs.size() &&
+            store->rowAttrs[row].HasBackgroundColour() &&
+            store->rowAttrs[row].GetBackgroundColour() == highlightColor;
+        if (!isHighlight && row < store->rowAttrs.size() &&
+            store->rowAttrs[row].HasBackgroundColour() &&
+            store->rowAttrs[row].GetBackgroundColour() == selectionColor)
             store->ClearRowBackground(row);
+        for (unsigned int col = 0; col < columnCount; ++col)
+        {
+            if (isHighlight)
+                store->SetCellBackgroundColour(row, col, highlightColor);
+            else if (selectedRows[row])
+                store->SetCellBackgroundColour(row, col, selectionColor);
+            else
+                store->ClearCellBackgroundColour(row, col);
         }
     }
     store->SetSelectedRows(selectedRows);

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -661,25 +661,25 @@ void TrussTablePanel::UpdateSelectionHighlight()
     }
     const wxColour selectionColor = store->selectionBackground;
     const wxColour highlightColor(0, 200, 0);
+    const unsigned int columnCount = table->GetColumnCount();
     for (size_t row = 0; row < rowCount; ++row)
     {
-        bool hasBackground = row < store->rowAttrs.size() &&
-                             store->rowAttrs[row].HasBackgroundColour();
-        wxColour currentBackground;
-        if (hasBackground)
-            currentBackground = store->rowAttrs[row].GetBackgroundColour();
-        bool isHighlight = hasBackground && currentBackground == highlightColor;
-        if (selectedRows[row])
-        {
-            if (!hasBackground || currentBackground == selectionColor)
-            {
-                if (!isHighlight)
-                    store->SetRowBackgroundColour(row, selectionColor);
-            }
-        }
-        else if (hasBackground && currentBackground == selectionColor)
-        {
+        bool isHighlight =
+            row < store->rowAttrs.size() &&
+            store->rowAttrs[row].HasBackgroundColour() &&
+            store->rowAttrs[row].GetBackgroundColour() == highlightColor;
+        if (!isHighlight && row < store->rowAttrs.size() &&
+            store->rowAttrs[row].HasBackgroundColour() &&
+            store->rowAttrs[row].GetBackgroundColour() == selectionColor)
             store->ClearRowBackground(row);
+        for (unsigned int col = 0; col < columnCount; ++col)
+        {
+            if (isHighlight)
+                store->SetCellBackgroundColour(row, col, highlightColor);
+            else if (selectedRows[row])
+                store->SetCellBackgroundColour(row, col, selectionColor);
+            else
+                store->ClearCellBackgroundColour(row, col);
         }
     }
     store->SetSelectedRows(selectedRows);


### PR DESCRIPTION
### Motivation
- Selection highlighting should fill each cell in a selected row instead of only setting a row attribute so selection appears consistently across all columns. 
- Existing store supported per-cell text colour but not per-cell background, so APIs were needed to control individual cell backgrounds. 
- Green highlights applied by `Highlight*` must take priority over the cyan selection background to avoid being overwritten. 

### Description
- Added `SetCellBackgroundColour` and `ClearCellBackgroundColour` to `ColorfulDataViewListStore` to set/clear per-cell background colours while preserving any per-cell text colour. 
- Updated `UpdateSelectionHighlight()` in `gui/fixturetablepanel.cpp`, `gui/hoisttablepanel.cpp`, `gui/trusstablepanel.cpp`, and `gui/sceneobjecttablepanel.cpp` to iterate columns using `table->GetColumnCount()` and apply the selection or highlight background to every cell in the row via the new cell background APIs. 
- For non-selected rows the code now clears per-cell backgrounds with `ClearCellBackgroundColour`. 
- Kept the existing green highlight behaviour as highest priority by detecting highlight rows and applying the highlight colour to cells so it overrides the cyan selection fill. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697273ce577883248add56cd7adcedf8)