### PR TITLE
Adjust table selection highlighting

### DIFF
--- a/gui/colorfulrenderers.h
+++ b/gui/colorfulrenderers.h
@@ -61,14 +61,9 @@ inline bool ResolveBackgroundColour(const wxDataViewCustomRenderer *renderer,
                                     int state,
                                     const wxDataViewItemAttr &attr,
                                     wxColour &colour) {
+  (void)state;
   if (attr.HasBackgroundColour()) {
     colour = attr.GetBackgroundColour();
-    return true;
-  }
-  const auto *store = GetColorfulStore(renderer);
-  if ((state & wxDATAVIEW_CELL_SELECTED) && store &&
-      store->selectionBackgroundEnabled) {
-    colour = store->selectionBackground;
     return true;
   }
   return false;

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -110,7 +110,7 @@ FixtureTablePanel::FixtureTablePanel(wxWindow *parent)
   wxBoxSizer *sizer = new wxBoxSizer(wxVERTICAL);
   table = new wxDataViewListCtrl(
       this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
-      wxDV_MULTIPLE | wxDV_ROW_LINES | wxDV_NO_HIGHLIGHT);
+      wxDV_MULTIPLE | wxDV_ROW_LINES);
   table->AssociateModel(store);
   store->DecRef();
 

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -98,7 +98,7 @@ HoistTablePanel::HoistTablePanel(wxWindow *parent)
   wxBoxSizer *sizer = new wxBoxSizer(wxVERTICAL);
   table = new wxDataViewListCtrl(
       this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
-      wxDV_MULTIPLE | wxDV_ROW_LINES | wxDV_NO_HIGHLIGHT);
+      wxDV_MULTIPLE | wxDV_ROW_LINES);
   table->AssociateModel(store);
   store->DecRef();
 

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -102,7 +102,7 @@ SceneObjectTablePanel::SceneObjectTablePanel(wxWindow* parent)
     wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
     table = new wxDataViewListCtrl(
         this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
-        wxDV_MULTIPLE | wxDV_ROW_LINES | wxDV_NO_HIGHLIGHT);
+        wxDV_MULTIPLE | wxDV_ROW_LINES);
   table->AssociateModel(store);
   store->DecRef();
 

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -112,7 +112,7 @@ TrussTablePanel::TrussTablePanel(wxWindow* parent)
     wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
     table = new wxDataViewListCtrl(
         this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
-        wxDV_MULTIPLE | wxDV_ROW_LINES | wxDV_NO_HIGHLIGHT);
+        wxDV_MULTIPLE | wxDV_ROW_LINES);
   table->AssociateModel(store);
   store->DecRef();
 


### PR DESCRIPTION
### Motivation
- Unify selection highlighting so the selection color is applied at the row level instead of per-cell to avoid native cell highlight painting interfering with custom colors.
- Prevent per-cell renderers from painting the native selected-cell background and let `UpdateSelectionHighlight` drive the cyan selection as a full-row background.
- Preserve existing green/highlighted row coloring as higher priority so it is not overridden by selection coloring.

### Description
- In `gui/colorfulrenderers.h` removed the code that applied the selection background when `wxDATAVIEW_CELL_SELECTED` is set in `ResolveBackgroundColour`, and made `state` unused there via `(void)state` so renderers no longer paint per-cell selection backgrounds.
- In `gui/fixturetablepanel.cpp`, `gui/hoisttablepanel.cpp`, `gui/sceneobjecttablepanel.cpp`, and `gui/trusstablepanel.cpp` removed the `wxDV_NO_HIGHLIGHT` flag from the `wxDataViewListCtrl` constructor calls so row-level background coloring can be shown consistently.
- The row-level selection behavior remains driven by existing `UpdateSelectionHighlight`, which uses `SetRowBackgroundColour` for the cyan selection and checks for the green `highlightColor` to avoid overriding it.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69727924b3d08324a0114f5c1196e27c)