### PR TITLE
Keep cyan selection backgrounds in data tables

### DIFF
--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -1167,22 +1167,22 @@ void FixtureTablePanel::UpdateSelectionHighlight() {
     if (r != wxNOT_FOUND && static_cast<size_t>(r) < rowCount)
       selectedRows[r] = true;
   }
-  const wxColour selectionColor = store->selectionBackground;
+  const wxColour selectionBackground = store->selectionBackground;
   const wxColour highlightColor(0, 200, 0);
   for (size_t row = 0; row < rowCount; ++row) {
     bool isHighlight =
         row < store->rowAttrs.size() &&
         store->rowAttrs[row].HasBackgroundColour() &&
         store->rowAttrs[row].GetBackgroundColour() == highlightColor;
-    if (selectedRows[row] && !isHighlight)
-      store->SetRowBackgroundColour(row, selectionColor);
-    else if (!selectedRows[row] && !isHighlight)
+    if (selectedRows[row])
+      store->SetRowBackgroundColour(row, selectionBackground);
+    else if (!isHighlight)
       store->ClearRowBackground(row);
     if (row < store->cellAttrs.size()) {
       for (unsigned int col = 0; col < store->cellAttrs[row].size(); ++col) {
         if (store->cellAttrs[row][col].HasBackgroundColour()) {
           wxColour bg = store->cellAttrs[row][col].GetBackgroundColour();
-          if (bg == selectionColor || bg == highlightColor)
+          if (bg == selectionBackground || bg == highlightColor)
             store->ClearCellBackgroundColour(row, col);
         }
       }

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -509,22 +509,22 @@ void HoistTablePanel::UpdateSelectionHighlight() {
     if (r != wxNOT_FOUND && static_cast<size_t>(r) < rowCount)
       selectedRows[r] = true;
   }
-  const wxColour selectionColor = store->selectionBackground;
+  const wxColour selectionBackground = store->selectionBackground;
   const wxColour highlightColor(0, 200, 0);
   for (size_t row = 0; row < rowCount; ++row) {
     bool isHighlight =
         row < store->rowAttrs.size() &&
         store->rowAttrs[row].HasBackgroundColour() &&
         store->rowAttrs[row].GetBackgroundColour() == highlightColor;
-    if (selectedRows[row] && !isHighlight)
-      store->SetRowBackgroundColour(row, selectionColor);
-    else if (!selectedRows[row] && !isHighlight)
+    if (selectedRows[row])
+      store->SetRowBackgroundColour(row, selectionBackground);
+    else if (!isHighlight)
       store->ClearRowBackground(row);
     if (row < store->cellAttrs.size()) {
       for (unsigned int col = 0; col < store->cellAttrs[row].size(); ++col) {
         if (store->cellAttrs[row][col].HasBackgroundColour()) {
           wxColour bg = store->cellAttrs[row][col].GetBackgroundColour();
-          if (bg == selectionColor || bg == highlightColor)
+          if (bg == selectionBackground || bg == highlightColor)
             store->ClearCellBackgroundColour(row, col);
         }
       }

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -494,7 +494,7 @@ void SceneObjectTablePanel::UpdateSelectionHighlight()
         if (r != wxNOT_FOUND && static_cast<size_t>(r) < rowCount)
             selectedRows[r] = true;
     }
-    const wxColour selectionColor = store->selectionBackground;
+    const wxColour selectionBackground = store->selectionBackground;
     const wxColour highlightColor(0, 200, 0);
     for (size_t row = 0; row < rowCount; ++row)
     {
@@ -502,9 +502,9 @@ void SceneObjectTablePanel::UpdateSelectionHighlight()
             row < store->rowAttrs.size() &&
             store->rowAttrs[row].HasBackgroundColour() &&
             store->rowAttrs[row].GetBackgroundColour() == highlightColor;
-        if (selectedRows[row] && !isHighlight)
-            store->SetRowBackgroundColour(row, selectionColor);
-        else if (!selectedRows[row] && !isHighlight)
+        if (selectedRows[row])
+            store->SetRowBackgroundColour(row, selectionBackground);
+        else if (!isHighlight)
             store->ClearRowBackground(row);
         if (row < store->cellAttrs.size())
         {
@@ -513,7 +513,7 @@ void SceneObjectTablePanel::UpdateSelectionHighlight()
                 if (store->cellAttrs[row][col].HasBackgroundColour())
                 {
                     wxColour bg = store->cellAttrs[row][col].GetBackgroundColour();
-                    if (bg == selectionColor || bg == highlightColor)
+                    if (bg == selectionBackground || bg == highlightColor)
                         store->ClearCellBackgroundColour(row, col);
                 }
             }

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -661,7 +661,7 @@ void TrussTablePanel::UpdateSelectionHighlight()
         if (r != wxNOT_FOUND && static_cast<size_t>(r) < rowCount)
             selectedRows[r] = true;
     }
-    const wxColour selectionColor = store->selectionBackground;
+    const wxColour selectionBackground = store->selectionBackground;
     const wxColour highlightColor(0, 200, 0);
     for (size_t row = 0; row < rowCount; ++row)
     {
@@ -669,9 +669,9 @@ void TrussTablePanel::UpdateSelectionHighlight()
             row < store->rowAttrs.size() &&
             store->rowAttrs[row].HasBackgroundColour() &&
             store->rowAttrs[row].GetBackgroundColour() == highlightColor;
-        if (selectedRows[row] && !isHighlight)
-            store->SetRowBackgroundColour(row, selectionColor);
-        else if (!selectedRows[row] && !isHighlight)
+        if (selectedRows[row])
+            store->SetRowBackgroundColour(row, selectionBackground);
+        else if (!isHighlight)
             store->ClearRowBackground(row);
         if (row < store->cellAttrs.size())
         {
@@ -680,7 +680,7 @@ void TrussTablePanel::UpdateSelectionHighlight()
                 if (store->cellAttrs[row][col].HasBackgroundColour())
                 {
                     wxColour bg = store->cellAttrs[row][col].GetBackgroundColour();
-                    if (bg == selectionColor || bg == highlightColor)
+                    if (bg == selectionBackground || bg == highlightColor)
                         store->ClearCellBackgroundColour(row, col);
                 }
             }


### PR DESCRIPTION
### Motivation
- Ensure the cyan selection background is reapplied for selected rows in the main data tables and avoid accidentally clearing row backgrounds when a green highlight is present.
- Keep the custom renderers from overriding row background highlights so the row-level cyan/green highlights remain the single source of truth for selection/highlight visuals.

### Description
- Updated `UpdateSelectionHighlight()` in `gui/fixturetablepanel.cpp`, `gui/hoisttablepanel.cpp`, `gui/trusstablepanel.cpp`, and `gui/sceneobjecttablepanel.cpp` to always call `store->SetRowBackgroundColour(row, selectionBackground)` for selected rows and to call `store->ClearRowBackground(row)` for unselected rows only when the row is not the green highlight.
- Renamed the local variable to `selectionBackground` and used it when clearing cell backgrounds so comparisons now check against the selection colour consistently (`selectionBackground` and the green `wxColour(0, 200, 0)`).
- Confirmed the cyan selection colour is defined as `wxColour(0, 255, 255)` in the table setup and left the renderer behavior in `gui/colorfulrenderers.h` unchanged because it already defers background drawing to row/cell attributes (it ignores `wxDATAVIEW_CELL_SELECTED` so the row background remains authoritative).

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69727ab9627c8324a4e3631c42b03c3d)