### PR TITLE
Add axis‑locked dragging to 2D viewer for moving selected objects

### DIFF
--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -28,6 +28,7 @@
 #include "viewer3dcontroller.h"
 #include <wx/glcanvas.h>
 #include <wx/wx.h>
+#include <array>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -117,6 +118,10 @@ public:
   std::optional<wxSize> GetLayoutEditOverlaySize() const;
 
 private:
+  enum class DragMode { None, View, Selection };
+  enum class DragAxis { None, Horizontal, Vertical };
+  enum class DragTarget { None, Fixtures, Trusses, SceneObjects };
+
   void InitGL();
   void Render();
   void RenderInternal(bool swapBuffers);
@@ -132,7 +137,16 @@ private:
   void OnResize(wxSizeEvent &event);
   void OnCaptureLost(wxMouseCaptureLostEvent &event);
 
-  bool m_dragging = false;
+  std::array<float, 3> MapDragDelta(float dxMeters, float dyMeters) const;
+  void ApplySelectionDelta(const std::array<float, 3> &deltaMeters);
+  void FinalizeSelectionDrag();
+
+  DragMode m_dragMode = DragMode::None;
+  DragAxis m_dragAxis = DragAxis::None;
+  DragTarget m_dragTarget = DragTarget::None;
+  std::vector<std::string> m_dragSelectionUuids;
+  bool m_dragSelectionMoved = false;
+  bool m_dragSelectionPushedUndo = false;
   bool m_draggedSincePress = false;
   wxPoint m_lastMousePos;
   float m_offsetX = 0.0f;


### PR DESCRIPTION
### Motivation
- Users need to be able to drag objects or selections in the 2D view and have movement constrained to the axis where the drag started. 
- The new behavior must update scene data (positions) and reflect changes in the corresponding tables after the mouse is released.
- Movement should integrate with the existing selection model and undo stack so edits are recorded properly.

### Description
- Added drag state and helpers to `Viewer2DPanel` (`DragMode`, `DragAxis`, `DragTarget`, selection UUID tracking) and included `<array>` and `viewer3dpanel.h` where required.
- Implemented `MapDragDelta`, `ApplySelectionDelta` and `FinalizeSelectionDrag` to map screen deltas into scene coordinates, apply meter→mm conversion, push a single undo state (`"move selection"`), and update scene objects (`fixtures`, `trusses`, `sceneObjects`) accordingly.
- Updated mouse handling: `OnMouseDown` detects clicks on fixtures/trusses/scene objects and enters selection-drag mode when appropriate; `OnMouseMove` computes axis-locked movement (threshold ~3px) and applies deltas live; `OnMouseUp` finalizes the drag, refreshes tables (`ReloadData`/`SelectByUuid`) and triggers a 3D scene update/refresh.
- Movement respects current 2D view orientation by remapping X/Y drag into the correct world axes and refreshes both 2D and 3D views after completion.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69727eca02e08324a2211cb6b207f59e)