### PR TITLE
viewer2d: drag moves entire selection when multiple items selected

### DIFF
--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -848,7 +848,7 @@ void Viewer2DPanel::OnMouseDown(wxMouseEvent &event) {
       }
 
       auto it = std::find(selection.begin(), selection.end(), uuid);
-      if (it != selection.end())
+      if (selection.size() > 1 || it != selection.end())
         m_dragSelectionUuids = selection;
       else
         m_dragSelectionUuids = {uuid};


### PR DESCRIPTION
### Motivation
- Ensure dragging in the 2D viewer moves the full current selection when multiple items are selected instead of only the clicked item.

### Description
- Update selection logic in `Viewer2DPanel::OnMouseDown` so `m_dragSelectionUuids` is set to the whole `selection` when `selection.size() > 1` or the clicked `uuid` is already in the selection, otherwise use `{uuid}` (change in `viewer2d/viewer2dpanel.cpp`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697282b723bc83248189d42da21e5fe5)