### PR TITLE
Add delay before 2D selection drag

### DIFF
--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -39,6 +39,7 @@
 #include "sceneobjecttablepanel.h"
 #include "trusstablepanel.h"
 #include "viewer3dpanel.h"
+#include <wx/utils.h>
 #include <algorithm>
 #include <cmath>
 #include <map>
@@ -791,6 +792,7 @@ void Viewer2DPanel::OnMouseDown(wxMouseEvent &event) {
   if (event.LeftDown()) {
     CaptureMouse();
     m_draggedSincePress = false;
+    m_dragPressTime = wxGetLocalTimeMillis();
     m_dragMode = DragMode::View;
     m_dragAxis = DragAxis::None;
     m_dragTarget = DragTarget::None;
@@ -1009,6 +1011,12 @@ void Viewer2DPanel::OnMouseMove(wxMouseEvent &event) {
   wxPoint pos = event.GetPosition();
 
   if (m_dragMode == DragMode::Selection && event.Dragging()) {
+    if ((wxGetLocalTimeMillis() - m_dragPressTime).ToLong() <
+        kSelectionDragDelayMs) {
+      m_lastMousePos = pos;
+      return;
+    }
+
     int dx = pos.x - m_lastMousePos.x;
     int dy = pos.y - m_lastMousePos.y;
 

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -141,6 +141,8 @@ private:
   void ApplySelectionDelta(const std::array<float, 3> &deltaMeters);
   void FinalizeSelectionDrag();
 
+  static constexpr long kSelectionDragDelayMs = 150;
+
   DragMode m_dragMode = DragMode::None;
   DragAxis m_dragAxis = DragAxis::None;
   DragTarget m_dragTarget = DragTarget::None;
@@ -148,6 +150,7 @@ private:
   bool m_dragSelectionMoved = false;
   bool m_dragSelectionPushedUndo = false;
   bool m_draggedSincePress = false;
+  wxLongLong m_dragPressTime = 0;
   wxPoint m_lastMousePos;
   float m_offsetX = 0.0f;
   float m_offsetY = 0.0f;


### PR DESCRIPTION
### Motivation
- Prevent accidental immediate moves when holding the left mouse button in the 2D viewer by requiring a short press time before selection dragging begins.

### Description
- Introduce `kSelectionDragDelayMs = 150` and a `wxLongLong m_dragPressTime` field in `Viewer2DPanel` to track press time.  
- Record the press time with `wxGetLocalTimeMillis()` during `OnMouseDown`.  
- In `OnMouseMove`, skip applying selection deltas while the elapsed time since press is less than the threshold, deferring selection drag start until the delay has passed.  
- Add `#include <wx/utils.h>` and small type conversion (`.ToLong()`) to compare the elapsed time.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972861128e883248866e96468153cf2)