### PR TITLE
Update 2D drag to refresh position columns in tables

### DIFF
--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -1168,6 +1168,36 @@ void FixtureTablePanel::UpdateSelectionHighlight() {
   store->SetSelectedRows(selectedRows);
 }
 
+void FixtureTablePanel::UpdatePositionValues(
+    const std::vector<std::string> &uuids) {
+  if (!table)
+    return;
+
+  ConfigManager &cfg = ConfigManager::Get();
+  auto &scene = cfg.GetScene();
+  wxWindowUpdateLocker locker(table);
+
+  for (const auto &uuid : uuids) {
+    auto it = scene.fixtures.find(uuid);
+    if (it == scene.fixtures.end())
+      continue;
+
+    auto posArr = it->second.GetPosition();
+    wxString posX = wxString::Format("%.3f", posArr[0] / 1000.0f);
+    wxString posY = wxString::Format("%.3f", posArr[1] / 1000.0f);
+    wxString posZ = wxString::Format("%.3f", posArr[2] / 1000.0f);
+
+    auto pos = std::find(rowUuids.begin(), rowUuids.end(), uuid);
+    if (pos == rowUuids.end())
+      continue;
+
+    int row = static_cast<int>(pos - rowUuids.begin());
+    table->SetValue(wxVariant(posX), row, 10);
+    table->SetValue(wxVariant(posY), row, 11);
+    table->SetValue(wxVariant(posZ), row, 12);
+  }
+}
+
 void FixtureTablePanel::PropagateTypeValues(
     const wxDataViewItemArray &selections, int col) {
   if (col != 16 && col != 17 && col != 18)

--- a/gui/fixturetablepanel.h
+++ b/gui/fixturetablepanel.h
@@ -38,6 +38,7 @@ public:
     void SelectByUuid(const std::vector<std::string>& uuids);
     bool IsActivePage() const;
     void DeleteSelected();
+    void UpdatePositionValues(const std::vector<std::string>& uuids);
     wxDataViewListCtrl* GetTableCtrl() const { return table; }
 
     static FixtureTablePanel* Instance();

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -495,6 +495,36 @@ void SceneObjectTablePanel::UpdateSelectionHighlight()
     store->SetSelectedRows(selectedRows);
 }
 
+void SceneObjectTablePanel::UpdatePositionValues(
+    const std::vector<std::string>& uuids) {
+    if (!table)
+        return;
+
+    ConfigManager& cfg = ConfigManager::Get();
+    auto& scene = cfg.GetScene();
+    wxWindowUpdateLocker locker(table);
+
+    for (const auto& uuid : uuids) {
+        auto it = scene.sceneObjects.find(uuid);
+        if (it == scene.sceneObjects.end())
+            continue;
+
+        auto posArr = it->second.transform.o;
+        wxString posX = wxString::Format("%.3f", posArr[0] / 1000.0f);
+        wxString posY = wxString::Format("%.3f", posArr[1] / 1000.0f);
+        wxString posZ = wxString::Format("%.3f", posArr[2] / 1000.0f);
+
+        auto pos = std::find(rowUuids.begin(), rowUuids.end(), uuid);
+        if (pos == rowUuids.end())
+            continue;
+
+        int row = static_cast<int>(pos - rowUuids.begin());
+        table->SetValue(wxVariant(posX), row, 3);
+        table->SetValue(wxVariant(posY), row, 4);
+        table->SetValue(wxVariant(posZ), row, 5);
+    }
+}
+
 void SceneObjectTablePanel::UpdateSceneData()
 {
     ConfigManager& cfg = ConfigManager::Get();

--- a/gui/sceneobjecttablepanel.h
+++ b/gui/sceneobjecttablepanel.h
@@ -36,6 +36,7 @@ public:
     void SelectByUuid(const std::vector<std::string>& uuids);
     bool IsActivePage() const;
     void DeleteSelected();
+    void UpdatePositionValues(const std::vector<std::string>& uuids);
     wxDataViewListCtrl* GetTableCtrl() const { return table; }
 
     static SceneObjectTablePanel* Instance();

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -662,6 +662,36 @@ void TrussTablePanel::UpdateSelectionHighlight()
     store->SetSelectedRows(selectedRows);
 }
 
+void TrussTablePanel::UpdatePositionValues(
+    const std::vector<std::string>& uuids) {
+    if (!table)
+        return;
+
+    ConfigManager& cfg = ConfigManager::Get();
+    auto& scene = cfg.GetScene();
+    wxWindowUpdateLocker locker(table);
+
+    for (const auto& uuid : uuids) {
+        auto it = scene.trusses.find(uuid);
+        if (it == scene.trusses.end())
+            continue;
+
+        auto posArr = it->second.transform.o;
+        wxString posX = wxString::Format("%.3f", posArr[0] / 1000.0f);
+        wxString posY = wxString::Format("%.3f", posArr[1] / 1000.0f);
+        wxString posZ = wxString::Format("%.3f", posArr[2] / 1000.0f);
+
+        auto pos = std::find(rowUuids.begin(), rowUuids.end(), uuid);
+        if (pos == rowUuids.end())
+            continue;
+
+        int row = static_cast<int>(pos - rowUuids.begin());
+        table->SetValue(wxVariant(posX), row, 4);
+        table->SetValue(wxVariant(posY), row, 5);
+        table->SetValue(wxVariant(posZ), row, 6);
+    }
+}
+
 void TrussTablePanel::UpdateSceneData()
 {
     ConfigManager& cfg = ConfigManager::Get();

--- a/gui/trusstablepanel.h
+++ b/gui/trusstablepanel.h
@@ -36,6 +36,7 @@ public:
     void SelectByUuid(const std::vector<std::string>& uuids);
     bool IsActivePage() const;
     void DeleteSelected();
+    void UpdatePositionValues(const std::vector<std::string>& uuids);
     wxDataViewListCtrl* GetTableCtrl() const { return table; }
 
     static TrussTablePanel* Instance();

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -740,12 +740,19 @@ void Viewer2DPanel::ApplySelectionDelta(
   switch (m_dragTarget) {
   case DragTarget::Fixtures:
     applyDelta(scene.fixtures);
+    if (FixtureTablePanel::Instance())
+      FixtureTablePanel::Instance()->UpdatePositionValues(m_dragSelectionUuids);
     break;
   case DragTarget::Trusses:
     applyDelta(scene.trusses);
+    if (TrussTablePanel::Instance())
+      TrussTablePanel::Instance()->UpdatePositionValues(m_dragSelectionUuids);
     break;
   case DragTarget::SceneObjects:
     applyDelta(scene.sceneObjects);
+    if (SceneObjectTablePanel::Instance())
+      SceneObjectTablePanel::Instance()->UpdatePositionValues(
+          m_dragSelectionUuids);
     break;
   default:
     break;


### PR DESCRIPTION
### Motivation
- Make table position columns reflect object movement while dragging in the 2D viewer so users see live updates without a full table reload.

### Description
- Added `UpdatePositionValues(const std::vector<std::string>&)` helpers to `FixtureTablePanel`, `TrussTablePanel`, and `SceneObjectTablePanel` to update only the position columns from scene data.
- Hooked the 2D drag path in `viewer2d::Viewer2DPanel::ApplySelectionDelta` to call the new `UpdatePositionValues` methods for the currently dragged UUIDs for fixtures, trusses and scene objects.
- Implementations use `ConfigManager::Get().GetScene()` and `wxWindowUpdateLocker` to update the appropriate row cells (`posX/posY/posZ`) without rebuilding the whole table.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69728e0518ec832494c3273fe99b2673)