### PR TITLE
Add wx/wupdlock.h include to FixtureTablePanel

### DIFF
--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -45,6 +45,7 @@
 #include <wx/filename.h>
 #include <wx/notebook.h>
 #include <wx/tokenzr.h>
+#include <wx/wupdlock.h>
 #include <wx/version.h>
 
 namespace fs = std::filesystem;


### PR DESCRIPTION
### Motivation
- Add the missing include `wx/wupdlock.h` so `wxWindowUpdateLocker` is available in `gui/fixturetablepanel.cpp` and to resolve the related compile errors.

### Description
- Inserted `#include <wx/wupdlock.h>` into `gui/fixturetablepanel.cpp` alongside other wx includes.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69728ff9d2d883249c10b8bbc0178e52)