### PR TITLE
Throttle 2D drag table updates

### DIFF
--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -136,12 +136,16 @@ private:
   void OnMouseLeave(wxMouseEvent &event);
   void OnResize(wxSizeEvent &event);
   void OnCaptureLost(wxMouseCaptureLostEvent &event);
+  void OnDragTableUpdateTimer(wxTimerEvent &event);
 
   std::array<float, 3> MapDragDelta(float dxMeters, float dyMeters) const;
   void ApplySelectionDelta(const std::array<float, 3> &deltaMeters);
   void FinalizeSelectionDrag();
+  void ScheduleDragTableUpdate();
+  void StopDragTableUpdates();
 
   static constexpr long kSelectionDragDelayMs = 150;
+  static constexpr int kDragTableUpdateIntervalMs = 50;
 
   DragMode m_dragMode = DragMode::None;
   DragAxis m_dragAxis = DragAxis::None;
@@ -170,6 +174,10 @@ private:
   bool m_forceOffscreenRender = false;
   bool m_allowOffscreenRender = false;
   bool m_persistViewState = true;
+  wxTimer m_dragTableUpdateTimer;
+  bool m_pendingTableUpdate = false;
+  DragTarget m_pendingTableUpdateTarget = DragTarget::None;
+  std::vector<std::string> m_pendingTableUpdateUuids;
 
   wxGLContext *m_glContext = nullptr;
   bool m_glInitialized = false;


### PR DESCRIPTION
### Motivation
- Per-mouse-move updates to fixture/truss/scene-object tables during 2D drag cause stutter in movement and must be throttled. 
- Updates should be grouped and executed safely on the UI thread without reloading whole tables every frame. 

### Description
- Replace immediate per-mouse-move calls to `UpdatePositionValues` with a scheduled update mechanism using a `wxTimer` and `ScheduleDragTableUpdate`/`StopDragTableUpdates` helpers. 
- Add `OnDragTableUpdateTimer` to perform throttled table updates for `Fixtures`, `Trusses`, and `SceneObjects` and introduce `m_dragTableUpdateTimer`, pending flags, and `m_pendingTableUpdateUuids`. 
- Call `ScheduleDragTableUpdate()` from `ApplySelectionDelta()` instead of direct table updates and call `StopDragTableUpdates()` in `FinalizeSelectionDrag()`, and bind `wxEVT_TIMER` in the constructor. 
- Changes made in `viewer2d/viewer2dpanel.h` and `viewer2d/viewer2dpanel.cpp` (added timer, state fields, interval constant `kDragTableUpdateIntervalMs = 50`, and the new methods/handler). 

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69729163154c832481b10b18df6d6931)