### PR TITLE
Move 2D drag table updates to worker thread (queue UUIDs, build snapshots in worker)

### DIFF
--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -160,7 +160,7 @@ private:
   BuildDragTablePositionSnapshots(DragTarget target,
                                   const std::vector<std::string> &uuids);
   void QueueDragTableUpdate(DragTarget target,
-                            std::vector<DragTablePositionSnapshot> snapshots);
+                            std::vector<std::string> uuids);
 
   static constexpr long kSelectionDragDelayMs = 150;
   static constexpr int kDragTableUpdateIntervalMs = 50;
@@ -202,7 +202,8 @@ private:
   bool m_dragTableWorkerStop = false;
   bool m_dragTableUpdateQueued = false;
   DragTarget m_dragTableUpdateWorkerTarget = DragTarget::None;
-  std::vector<DragTablePositionSnapshot> m_dragTableUpdateSnapshots;
+  std::vector<std::string> m_dragTableUpdateUuids;
+  std::mutex m_dragTableUpdateSceneMutex;
 
   wxGLContext *m_glContext = nullptr;
   bool m_glInitialized = false;


### PR DESCRIPTION
### Motivation
- Keep table position values updating in real time while dragging without blocking the UI by moving snapshot building out of the UI/timer context and into the worker thread.
- Avoid data races between the drag worker and the main thread when reading scene object positions.

### Description
- Change `QueueDragTableUpdate` to accept a vector of UUIDs instead of pre-built `DragTablePositionSnapshot` objects and defer snapshot construction to the worker thread; updated `viewer2d/viewer2dpanel.h` and `viewer2d/viewer2dpanel.cpp` accordingly.
- Build snapshots inside the worker by calling `BuildDragTablePositionSnapshots(target, uuids)` in the worker loop, and early-return when there are no UUIDs or snapshots.
- Add `m_dragTableUpdateSceneMutex` and lock it in `ApplySelectionDelta` and `BuildDragTablePositionSnapshots` to protect scene access while deltas are applied and snapshots are built.
- Ensure queued UUID state is cleared when stopping updates and when the timer hands work to the worker (use `std::move` + clear pending vector).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697295c18b1883249ae3f059e617690d)