### PR TITLE
Throttle 2D drag table updates in background worker

### DIFF
--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -139,7 +139,6 @@ private:
   void OnMouseLeave(wxMouseEvent &event);
   void OnResize(wxSizeEvent &event);
   void OnCaptureLost(wxMouseCaptureLostEvent &event);
-  void OnDragTableUpdateTimer(wxTimerEvent &event);
 
   std::array<float, 3> MapDragDelta(float dxMeters, float dyMeters) const;
   void ApplySelectionDelta(const std::array<float, 3> &deltaMeters);
@@ -192,10 +191,6 @@ private:
   bool m_forceOffscreenRender = false;
   bool m_allowOffscreenRender = false;
   bool m_persistViewState = true;
-  wxTimer m_dragTableUpdateTimer;
-  bool m_pendingTableUpdate = false;
-  DragTarget m_pendingTableUpdateTarget = DragTarget::None;
-  std::vector<std::string> m_pendingTableUpdateUuids;
   std::thread m_dragTableUpdateWorker;
   std::mutex m_dragTableUpdateMutex;
   std::condition_variable m_dragTableUpdateCv;


### PR DESCRIPTION
### Motivation
- Keep position values in fixture/truss/object tables updating during 2D drag without blocking the UI by moving updates off the UI timer and into the background worker. 

### Description
- Removed the wxTimer and pending-queue fields used for throttled UI-timer driven updates and the `OnDragTableUpdateTimer` handler, and stopped binding the timer in the constructor. 
- Schedule drag updates now enqueues the current drag target/uuids directly via `QueueDragTableUpdate` from `ScheduleDragTableUpdate`. 
- The background worker (`StartDragTableUpdateWorker`) was extended to perform throttling using `std::chrono` so it emits updates at most once per `kDragTableUpdateIntervalMs` (50 ms) while keeping updates off the UI thread. 
- Simplified `StopDragTableUpdates` to clear worker-side queued state under the worker mutex. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972971e5e7083248324077eeb83b1cf)