### PR TITLE
Add rectangular selection (Ctrl+drag) to 2D and 3D viewers

### DIFF
--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -562,6 +562,9 @@ void Viewer2DPanel::RenderInternal(bool swapBuffers) {
     }
   }
 
+  if (swapBuffers && m_enableSelection && m_rectSelecting)
+    DrawSelectionRectangle(w, h, darkMode);
+
   if (recordingCanvas) {
     recordingCanvas->EndFrame();
     m_captureNextFrame = false;
@@ -806,6 +809,120 @@ void Viewer2DPanel::FinalizeSelectionDrag() {
   }
 }
 
+void Viewer2DPanel::ApplyRectangleSelection(const wxPoint &start,
+                                            const wxPoint &end) {
+  if (!m_enableSelection)
+    return;
+  if (!IsShownOnScreen())
+    return;
+
+  int w = 0;
+  int h = 0;
+  GetClientSize(&w, &h);
+  if (w <= 0 || h <= 0)
+    return;
+
+  SetCurrent(*m_glContext);
+
+  ConfigManager &cfg = ConfigManager::Get();
+  if (FixtureTablePanel::Instance() &&
+      FixtureTablePanel::Instance()->IsActivePage()) {
+    auto selection = m_controller.GetFixturesInScreenRect(
+        start.x, start.y, end.x, end.y, w, h);
+    if (selection != cfg.GetSelectedFixtures()) {
+      cfg.PushUndoState("fixture selection");
+      cfg.SetSelectedFixtures(selection);
+    }
+    m_controller.SetSelectedUuids(selection);
+    if (selection.empty())
+      FixtureTablePanel::Instance()->ClearSelection();
+    else
+      FixtureTablePanel::Instance()->SelectByUuid(selection);
+  } else if (TrussTablePanel::Instance() &&
+             TrussTablePanel::Instance()->IsActivePage()) {
+    auto selection =
+        m_controller.GetTrussesInScreenRect(start.x, start.y, end.x, end.y, w,
+                                            h);
+    if (selection != cfg.GetSelectedTrusses()) {
+      cfg.PushUndoState("truss selection");
+      cfg.SetSelectedTrusses(selection);
+    }
+    m_controller.SetSelectedUuids(selection);
+    if (selection.empty())
+      TrussTablePanel::Instance()->ClearSelection();
+    else
+      TrussTablePanel::Instance()->SelectByUuid(selection);
+  } else if (SceneObjectTablePanel::Instance() &&
+             SceneObjectTablePanel::Instance()->IsActivePage()) {
+    auto selection = m_controller.GetSceneObjectsInScreenRect(
+        start.x, start.y, end.x, end.y, w, h);
+    if (selection != cfg.GetSelectedSceneObjects()) {
+      cfg.PushUndoState("scene object selection");
+      cfg.SetSelectedSceneObjects(selection);
+    }
+    m_controller.SetSelectedUuids(selection);
+    if (selection.empty())
+      SceneObjectTablePanel::Instance()->ClearSelection();
+    else
+      SceneObjectTablePanel::Instance()->SelectByUuid(selection);
+  }
+}
+
+void Viewer2DPanel::DrawSelectionRectangle(int width, int height,
+                                           bool darkMode) {
+  if (!m_rectSelecting)
+    return;
+
+  int left = std::min(m_rectSelectStart.x, m_rectSelectEnd.x);
+  int right = std::max(m_rectSelectStart.x, m_rectSelectEnd.x);
+  int top = std::min(m_rectSelectStart.y, m_rectSelectEnd.y);
+  int bottom = std::max(m_rectSelectStart.y, m_rectSelectEnd.y);
+
+  float glLeft = static_cast<float>(left);
+  float glRight = static_cast<float>(right);
+  float glBottom = static_cast<float>(height - bottom);
+  float glTop = static_cast<float>(height - top);
+
+  GLboolean depthEnabled = glIsEnabled(GL_DEPTH_TEST);
+  if (depthEnabled)
+    glDisable(GL_DEPTH_TEST);
+
+  GLboolean stippleEnabled = glIsEnabled(GL_LINE_STIPPLE);
+  glEnable(GL_LINE_STIPPLE);
+  glLineStipple(1, 0x00FF);
+
+  glMatrixMode(GL_PROJECTION);
+  glPushMatrix();
+  glLoadIdentity();
+  glOrtho(0.0f, static_cast<float>(width), 0.0f,
+          static_cast<float>(height), -1.0f, 1.0f);
+  glMatrixMode(GL_MODELVIEW);
+  glPushMatrix();
+  glLoadIdentity();
+
+  if (darkMode)
+    glColor3f(1.0f, 1.0f, 1.0f);
+  else
+    glColor3f(0.0f, 0.0f, 0.0f);
+  glLineWidth(1.5f);
+  glBegin(GL_LINE_LOOP);
+  glVertex2f(glLeft, glBottom);
+  glVertex2f(glRight, glBottom);
+  glVertex2f(glRight, glTop);
+  glVertex2f(glLeft, glTop);
+  glEnd();
+
+  glPopMatrix();
+  glMatrixMode(GL_PROJECTION);
+  glPopMatrix();
+  glMatrixMode(GL_MODELVIEW);
+
+  if (!stippleEnabled)
+    glDisable(GL_LINE_STIPPLE);
+  if (depthEnabled)
+    glEnable(GL_DEPTH_TEST);
+}
+
 void Viewer2DPanel::ScheduleDragTableUpdate() {
   if (m_dragSelectionUuids.empty())
     return;
@@ -983,6 +1100,14 @@ void Viewer2DPanel::OnMouseDown(wxMouseEvent &event) {
     if (!m_enableSelection || !IsShownOnScreen())
       return;
 
+    if (event.ControlDown()) {
+      m_dragMode = DragMode::RectSelection;
+      m_rectSelecting = true;
+      m_rectSelectStart = m_lastMousePos;
+      m_rectSelectEnd = m_lastMousePos;
+      return;
+    }
+
     int w, h;
     GetClientSize(&w, &h);
     if (w <= 0 || h <= 0)
@@ -1041,6 +1166,22 @@ void Viewer2DPanel::OnMouseDown(wxMouseEvent &event) {
 }
 
 void Viewer2DPanel::OnMouseUp(wxMouseEvent &event) {
+  if (event.LeftUp() && m_dragMode == DragMode::RectSelection) {
+    if (HasCapture())
+      ReleaseMouse();
+    if (m_rectSelecting)
+      ApplyRectangleSelection(m_rectSelectStart, m_rectSelectEnd);
+    m_rectSelecting = false;
+    m_dragMode = DragMode::None;
+    m_dragAxis = DragAxis::None;
+    m_dragTarget = DragTarget::None;
+    m_dragSelectionUuids.clear();
+    m_dragSelectionMoved = false;
+    m_draggedSincePress = false;
+    Refresh();
+    return;
+  }
+
   if (event.LeftUp() && m_dragMode != DragMode::None) {
     if (HasCapture())
       ReleaseMouse();
@@ -1184,10 +1325,18 @@ void Viewer2DPanel::OnCaptureLost(wxMouseCaptureLostEvent &WXUNUSED(event)) {
   m_dragTarget = DragTarget::None;
   m_dragSelectionUuids.clear();
   m_dragSelectionMoved = false;
+  m_rectSelecting = false;
 }
 
 void Viewer2DPanel::OnMouseMove(wxMouseEvent &event) {
   wxPoint pos = event.GetPosition();
+
+  if (m_dragMode == DragMode::RectSelection && event.Dragging()) {
+    m_rectSelectEnd = pos;
+    m_draggedSincePress = true;
+    Refresh();
+    return;
+  }
 
   if (m_dragMode == DragMode::Selection && event.Dragging()) {
     if ((wxGetLocalTimeMillis() - m_dragPressTime).ToLong() <

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -121,7 +121,7 @@ public:
   std::optional<wxSize> GetLayoutEditOverlaySize() const;
 
 private:
-  enum class DragMode { None, View, Selection };
+  enum class DragMode { None, View, Selection, RectSelection };
   enum class DragAxis { None, Horizontal, Vertical };
   enum class DragTarget { None, Fixtures, Trusses, SceneObjects };
 
@@ -143,6 +143,8 @@ private:
   std::array<float, 3> MapDragDelta(float dxMeters, float dyMeters) const;
   void ApplySelectionDelta(const std::array<float, 3> &deltaMeters);
   void FinalizeSelectionDrag();
+  void ApplyRectangleSelection(const wxPoint &start, const wxPoint &end);
+  void DrawSelectionRectangle(int width, int height, bool darkMode);
   void ScheduleDragTableUpdate();
   void StopDragTableUpdates();
   void StartDragTableUpdateWorker();
@@ -172,6 +174,9 @@ private:
   bool m_dragSelectionPushedUndo = false;
   bool m_draggedSincePress = false;
   wxLongLong m_dragPressTime = 0;
+  bool m_rectSelecting = false;
+  wxPoint m_rectSelectStart;
+  wxPoint m_rectSelectEnd;
   wxPoint m_lastMousePos;
   float m_offsetX = 0.0f;
   float m_offsetY = 0.0f;

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -34,6 +34,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 #include <wx/gdicmn.h>
 #include <wx/string.h>
 
@@ -118,6 +119,15 @@ public:
   bool GetSceneObjectLabelAt(int mouseX, int mouseY, int width, int height,
                              wxString &outLabel, wxPoint &outPos,
                              std::string *outUuid = nullptr);
+  std::vector<std::string> GetFixturesInScreenRect(int x1, int y1, int x2,
+                                                   int y2, int width,
+                                                   int height) const;
+  std::vector<std::string> GetTrussesInScreenRect(int x1, int y1, int x2,
+                                                  int y2, int width,
+                                                  int height) const;
+  std::vector<std::string> GetSceneObjectsInScreenRect(int x1, int y1, int x2,
+                                                       int y2, int width,
+                                                       int height) const;
 
   // Update cached layer color for rendering
   void SetLayerColor(const std::string &layer, const std::string &hex);

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -73,6 +73,9 @@ private:
     bool m_draggedSincePress = false;
     bool m_mouseInside = false;
     wxPoint m_lastMousePos;
+    bool m_rectSelecting = false;
+    wxPoint m_rectSelectStart;
+    wxPoint m_rectSelectEnd;
 
     // Type of interaction currently active (Orbit or Pan)
     enum class InteractionMode { None, Orbit, Pan };
@@ -97,6 +100,8 @@ private:
     void OnMouseEnter(wxMouseEvent& event);
     void OnMouseLeave(wxMouseEvent& event);
     void OnCaptureLost(wxMouseCaptureLostEvent& event);
+    void ApplyRectangleSelection(const wxPoint& start, const wxPoint& end);
+    void DrawSelectionRectangle(int width, int height);
 
     // Renders the full scene
     void Render();


### PR DESCRIPTION
### Motivation
- Provide a rectangle-selection tool in both the 2D and 3D viewers that allows selecting multiple fixtures/trusses/scene objects by holding Ctrl and dragging with the left mouse button.
- Visual feedback is required: draw a dashed rectangle overlay while dragging and select any table items that are fully or partially inside the rectangle when the mouse is released.

### Description
- Implemented controller helpers in `Viewer3DController` to collect fixtures/trusses/scene objects whose precomputed screen-space bounding boxes intersect a given screen rectangle: `GetFixturesInScreenRect`, `GetTrussesInScreenRect`, `GetSceneObjectsInScreenRect`.
- Added rectangular selection support to the 2D viewer (`viewer2d/viewer2dpanel.*`): new `RectSelection` drag mode, mouse handlers for Ctrl+LeftDown/drag/LeftUp, `ApplyRectangleSelection` to query the controller and update `ConfigManager` and the corresponding table panel, and `DrawSelectionRectangle` to render a dashed rectangle overlay (respecting dark mode for color).
- Added analogous rectangular selection support to the 3D viewer (`viewer3d/viewer3dpanel.*`): Ctrl+LeftDown/drag/LeftUp handlers, `ApplyRectangleSelection` to apply results from the controller to selection state, and `DrawSelectionRectangle` to render the overlay in the 3D view.
- Added necessary state variables (start/end points, bool flags) and viewport clamping for rectangle coordinates so selection is constrained to the visible viewport, and ensured rendering state (depth/test and stipple) is preserved when drawing the overlay.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69729af3a61083249e131d84b241217b)