### PR TITLE
Fix Windows build issues in 3D selection code

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -3095,15 +3095,15 @@ Viewer3DController::GetFixturesInScreenRect(int x1, int y1, int x2, int y2,
   glGetDoublev(GL_PROJECTION_MATRIX, proj);
   glGetIntegerv(GL_VIEWPORT, viewport);
 
-  ScreenRect selection;
-  selection.minX = std::max(0, std::min(x1, x2));
-  selection.maxX = std::min(width, std::max(x1, x2));
-  selection.minY = std::max(0, std::min(y1, y2));
-  selection.maxY = std::min(height, std::max(y1, y2));
+  ScreenRect selectionRect;
+  selectionRect.minX = std::max(0, std::min(x1, x2));
+  selectionRect.maxX = std::min(width, std::max(x1, x2));
+  selectionRect.minY = std::max(0, std::min(y1, y2));
+  selectionRect.maxY = std::min(height, std::max(y1, y2));
 
   auto intersects = [&](const ScreenRect &rect) {
-    return !(rect.maxX < selection.minX || rect.minX > selection.maxX ||
-             rect.maxY < selection.minY || rect.minY > selection.maxY);
+    return !(rect.maxX < selectionRect.minX || rect.minX > selectionRect.maxX ||
+             rect.maxY < selectionRect.minY || rect.minY > selectionRect.maxY);
   };
 
   auto projectBounds = [&](const BoundingBox &bb, ScreenRect &rect) {
@@ -3163,15 +3163,15 @@ Viewer3DController::GetTrussesInScreenRect(int x1, int y1, int x2, int y2,
   glGetDoublev(GL_PROJECTION_MATRIX, proj);
   glGetIntegerv(GL_VIEWPORT, viewport);
 
-  ScreenRect selection;
-  selection.minX = std::max(0, std::min(x1, x2));
-  selection.maxX = std::min(width, std::max(x1, x2));
-  selection.minY = std::max(0, std::min(y1, y2));
-  selection.maxY = std::min(height, std::max(y1, y2));
+  ScreenRect selectionRect;
+  selectionRect.minX = std::max(0, std::min(x1, x2));
+  selectionRect.maxX = std::min(width, std::max(x1, x2));
+  selectionRect.minY = std::max(0, std::min(y1, y2));
+  selectionRect.maxY = std::min(height, std::max(y1, y2));
 
   auto intersects = [&](const ScreenRect &rect) {
-    return !(rect.maxX < selection.minX || rect.minX > selection.maxX ||
-             rect.maxY < selection.minY || rect.minY > selection.maxY);
+    return !(rect.maxX < selectionRect.minX || rect.minX > selectionRect.maxX ||
+             rect.maxY < selectionRect.minY || rect.minY > selectionRect.maxY);
   };
 
   auto projectBounds = [&](const BoundingBox &bb, ScreenRect &rect) {
@@ -3230,15 +3230,15 @@ Viewer3DController::GetSceneObjectsInScreenRect(int x1, int y1, int x2, int y2,
   glGetDoublev(GL_PROJECTION_MATRIX, proj);
   glGetIntegerv(GL_VIEWPORT, viewport);
 
-  ScreenRect selection;
-  selection.minX = std::max(0, std::min(x1, x2));
-  selection.maxX = std::min(width, std::max(x1, x2));
-  selection.minY = std::max(0, std::min(y1, y2));
-  selection.maxY = std::min(height, std::max(y1, y2));
+  ScreenRect selectionRect;
+  selectionRect.minX = std::max(0, std::min(x1, x2));
+  selectionRect.maxX = std::min(width, std::max(x1, x2));
+  selectionRect.minY = std::max(0, std::min(y1, y2));
+  selectionRect.maxY = std::min(height, std::max(y1, y2));
 
   auto intersects = [&](const ScreenRect &rect) {
-    return !(rect.maxX < selection.minX || rect.minX > selection.maxX ||
-             rect.maxY < selection.minY || rect.minY > selection.maxY);
+    return !(rect.maxX < selectionRect.minX || rect.minX > selectionRect.maxX ||
+             rect.maxY < selectionRect.minY || rect.minY > selectionRect.maxY);
   };
 
   auto projectBounds = [&](const BoundingBox &bb, ScreenRect &rect) {

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -24,6 +24,7 @@
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
 #include <windows.h>
 #endif
 #include <GL/glew.h>


### PR DESCRIPTION
### Motivation
- Resolve Windows build errors caused by `min`/`max` macro collisions and name collisions in selection helpers that produced syntax and redefinition errors during compilation.

### Description
- Define `NOMINMAX` in `viewer3d/viewer3dpanel.cpp` to prevent Windows headers from defining `min`/`max` macros that conflict with `std::min`/`std::max`.
- Rename local `ScreenRect` variables from `selection` to `selectionRect` in `viewer3d/viewer3dcontroller.cpp` and update related lambdas to avoid shadowing and type redefinition conflicts with vector `selection` variables.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69729d9ad8288324b785672d10952f6a)