### PR TITLE
Clear selection when deleting fixtures, trusses, scene objects and supports

### DIFF
--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -1009,6 +1009,7 @@ void FixtureTablePanel::DeleteSelected() {
 
   ConfigManager &cfg = ConfigManager::Get();
   cfg.PushUndoState("delete fixture");
+  cfg.SetSelectedFixtures({});
 
   std::vector<std::string> oldOrder = rowUuids;
   std::vector<wxString> oldPaths = gdtfPaths;
@@ -1046,9 +1047,11 @@ void FixtureTablePanel::DeleteSelected() {
   HighlightDuplicateFixtureIds();
 
   if (Viewer3DPanel::Instance()) {
+    Viewer3DPanel::Instance()->SetSelectedFixtures({});
     Viewer3DPanel::Instance()->UpdateScene();
     Viewer3DPanel::Instance()->Refresh();
   } else if (Viewer2DPanel::Instance()) {
+    Viewer2DPanel::Instance()->SetSelectedUuids({});
     Viewer2DPanel::Instance()->UpdateScene();
   }
 

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -660,6 +660,7 @@ void HoistTablePanel::DeleteSelected() {
 
   ConfigManager &cfg = ConfigManager::Get();
   cfg.PushUndoState("delete support");
+  cfg.SetSelectedSupports({});
 
   std::vector<int> rows;
   rows.reserve(selections.size());
@@ -683,9 +684,11 @@ void HoistTablePanel::DeleteSelected() {
     SummaryPanel::Instance()->ShowHoistSummary();
 
   if (Viewer3DPanel::Instance()) {
+    Viewer3DPanel::Instance()->SetSelectedFixtures({});
     Viewer3DPanel::Instance()->UpdateScene();
     Viewer3DPanel::Instance()->Refresh();
   } else if (Viewer2DPanel::Instance()) {
+    Viewer2DPanel::Instance()->SetSelectedUuids({});
     Viewer2DPanel::Instance()->UpdateScene();
   }
 

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -661,6 +661,7 @@ void SceneObjectTablePanel::DeleteSelected()
 
     ConfigManager& cfg = ConfigManager::Get();
     cfg.PushUndoState("delete scene object");
+    cfg.SetSelectedSceneObjects({});
 
     std::vector<int> rows;
     rows.reserve(selections.size());
@@ -681,10 +682,12 @@ void SceneObjectTablePanel::DeleteSelected()
     }
 
     if (Viewer3DPanel::Instance()) {
+        Viewer3DPanel::Instance()->SetSelectedFixtures({});
         Viewer3DPanel::Instance()->UpdateScene();
         Viewer3DPanel::Instance()->Refresh();
     }
     else if (Viewer2DPanel::Instance()) {
+        Viewer2DPanel::Instance()->SetSelectedUuids({});
         Viewer2DPanel::Instance()->UpdateScene();
     }
 

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -957,6 +957,7 @@ void TrussTablePanel::DeleteSelected()
 
     ConfigManager& cfg = ConfigManager::Get();
     cfg.PushUndoState("delete truss");
+    cfg.SetSelectedTrusses({});
 
     std::vector<int> rows;
     rows.reserve(selections.size());
@@ -981,10 +982,12 @@ void TrussTablePanel::DeleteSelected()
     }
 
     if (Viewer3DPanel::Instance()) {
+        Viewer3DPanel::Instance()->SetSelectedFixtures({});
         Viewer3DPanel::Instance()->UpdateScene();
         Viewer3DPanel::Instance()->Refresh();
     }
     else if (Viewer2DPanel::Instance()) {
+        Viewer2DPanel::Instance()->SetSelectedUuids({});
         Viewer2DPanel::Instance()->UpdateScene();
     }
 


### PR DESCRIPTION
### Motivation
- Deleting items left selection state in the config and viewers, producing stale highlights and inconsistent UI state.
- The UI should clear selection when the user deletes the currently selected items so viewers and tables stay in sync.

### Description
- Clear the ConfigManager selection vectors by calling `SetSelectedFixtures({})`, `SetSelectedTrusses({})`, `SetSelectedSceneObjects({})`, or `SetSelectedSupports({})` at the start of the respective delete handlers.
- Reset viewer selection state after deletions by calling `Viewer3DPanel::SetSelectedFixtures({})` and `Viewer2DPanel::SetSelectedUuids({})` where appropriate so the 3D/2D views no longer highlight deleted items.
- Changes applied to `gui/fixturetablepanel.cpp`, `gui/trusstablepanel.cpp`, `gui/sceneobjecttablepanel.cpp`, and `gui/hoisttablepanel.cpp` to ensure deletion handlers clear selections and update viewers.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69729f86d99483249d3304281c54f173)