### PR TITLE
Clear table selection after deletions

### DIFF
--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -1058,6 +1058,7 @@ void FixtureTablePanel::DeleteSelected() {
   if (SummaryPanel::Instance())
     SummaryPanel::Instance()->ShowFixtureSummary();
 
+  selectionOrder.clear();
   ResyncRows(oldOrder, {}, &oldPaths);
 }
 
@@ -1532,6 +1533,7 @@ void FixtureTablePanel::ResyncRows(
     if (pos != rowUuids.end())
       table->SelectRow(static_cast<int>(pos - rowUuids.begin()));
   }
+  UpdateSelectionHighlight();
 }
 
 void FixtureTablePanel::OnColumnSorted(wxDataViewEvent &event) {

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -715,6 +715,7 @@ void HoistTablePanel::ResyncRows(const std::vector<std::string> &oldOrder,
     if (pos != rowUuids.end())
       table->SelectRow(static_cast<int>(pos - rowUuids.begin()));
   }
+  UpdateSelectionHighlight();
 }
 
 void HoistTablePanel::OnColumnSorted(wxDataViewEvent &event) {

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -720,6 +720,7 @@ void SceneObjectTablePanel::ResyncRows(const std::vector<std::string>& oldOrder,
         if (pos != rowUuids.end())
             table->SelectRow(static_cast<int>(pos - rowUuids.begin()));
     }
+    UpdateSelectionHighlight();
 }
 
 void SceneObjectTablePanel::OnColumnSorted(wxDataViewEvent& event)

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -1029,6 +1029,7 @@ void TrussTablePanel::ResyncRows(const std::vector<std::string>& oldOrder,
         if (pos != rowUuids.end())
             table->SelectRow(static_cast<int>(pos - rowUuids.begin()));
     }
+    UpdateSelectionHighlight();
 }
 
 void TrussTablePanel::OnColumnSorted(wxDataViewEvent& event)


### PR DESCRIPTION
### Motivation
- When items are deleted from tables the UI selection could remain highlighted even though the underlying selection state had been cleared, so the table selection/highlight must be explicitly updated after deletions and row resyncs.

### Description
- Clear fixture selection order in `FixtureTablePanel::DeleteSelected()` by calling `selectionOrder.clear()` after deleting rows and updating scene state.
- Ensure selection highlight state is refreshed after row reordering/resync in `ResyncRows()` by calling `UpdateSelectionHighlight()` in `gui/fixturetablepanel.cpp`, `gui/trusstablepanel.cpp`, `gui/hoisttablepanel.cpp`, and `gui/sceneobjecttablepanel.cpp`.
- This makes table visuals consistent with the cleared selection state sent to 2D/3D viewers and summary panels.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972a13cbaec832483e3a4a00d01c08d)