### PR TITLE
Avoid reloading global 2D viewer config in 2D View Editor

### DIFF
--- a/gui/layout2dviewdialog.cpp
+++ b/gui/layout2dviewdialog.cpp
@@ -74,7 +74,6 @@ void Layout2DViewDialog::OnCancel(wxCommandEvent &event) {
 
 void Layout2DViewDialog::OnShow(wxShowEvent &event) {
   if (event.IsShown() && viewerPanel) {
-    viewerPanel->LoadViewFromConfig();
     viewerPanel->UpdateScene(true);
     viewerPanel->Update();
   }


### PR DESCRIPTION
### Motivation
- When opening the 2D view editor it previously reloaded the global viewer2D config via `viewerPanel->LoadViewFromConfig()`, which could overwrite the camera/zoom/offset that should come from the edited layout element.

### Description
- Remove the call to `viewerPanel->LoadViewFromConfig()` in `Layout2DViewDialog::OnShow` so the editor preserves the element's stored camera state and only refreshes the scene with `UpdateScene`/`Update`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972ae9e58008324994b3ba09e2c9eb4)