### PR TITLE
Use layout view camera state in 2D view editor

### DIFF
--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -762,7 +762,7 @@ void MainWindow::BeginLayout2DViewEdit() {
   viewer2d::Viewer2DState state = viewer2d::FromLayoutDefinition(*view);
   layout2DViewStateGuard = std::make_unique<viewer2d::ScopedViewer2DState>(
       layout2DViewEditPanel, layout2DViewEditRenderPanel, cfg, state,
-      viewport2DPanel, viewport2DRenderPanel, false);
+      viewport2DPanel, viewport2DRenderPanel, true);
 
   if (view->frame.height > 0 && layout2DViewEditPanel) {
     float aspect =


### PR DESCRIPTION
### Motivation
- Ensure the 2D view editor shows exactly the same camera (zoom/offset/view) as the layout element being edited by applying the element's camera state into the configuration while the editor is open.

### Description
- In `gui/mainwindow_layout.cpp` the `ScopedViewer2DState` ctor call was changed to pass `true` for the `persistCameraToConfig` flag so the layout view camera state is written to `ConfigManager` and loaded by the editor (`ScopedViewer2DState(..., true)`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972b044f86c83248c34e7a4b0efa05c)