### PR TITLE
Sync layout 2D elements with editor render options

### DIFF
--- a/gui/layoutviewerpanel_view.cpp
+++ b/gui/layoutviewerpanel_view.cpp
@@ -164,6 +164,7 @@ void LayoutViewerPanel::DrawViewElement(
     ConfigManager &cfg = ConfigManager::Get();
     viewer2d::Viewer2DState layoutState =
         viewer2d::FromLayoutDefinition(view);
+    viewer2d::ApplyEditorRenderOptions(layoutState, cfg);
     layoutState.renderOptions.darkMode = false;
     cache.renderState = layoutState;
     cache.hasRenderState = true;

--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -760,6 +760,7 @@ void MainWindow::BeginLayout2DViewEdit() {
   Viewer2DRenderPanel::SetInstance(layout2DViewEditRenderPanel);
 
   viewer2d::Viewer2DState state = viewer2d::FromLayoutDefinition(*view);
+  viewer2d::ApplyEditorRenderOptions(state, cfg);
   layout2DViewStateGuard = std::make_unique<viewer2d::ScopedViewer2DState>(
       layout2DViewEditPanel, layout2DViewEditRenderPanel, cfg, state,
       viewport2DPanel, viewport2DRenderPanel, true);

--- a/gui/mainwindow_print.cpp
+++ b/gui/mainwindow_print.cpp
@@ -412,6 +412,7 @@ void MainWindow::OnPrintLayout(wxCommandEvent &WXUNUSED(event)) {
         const auto &view = layoutViews[index];
         viewer2d::Viewer2DState layoutState =
             viewer2d::FromLayoutDefinition(view);
+        viewer2d::ApplyEditorRenderOptions(layoutState, *cfgPtr);
         layoutState.renderOptions.darkMode = false;
 
         const int fallbackViewportWidth = view.camera.viewportWidth > 0

--- a/viewer2d/viewer2dstate.cpp
+++ b/viewer2d/viewer2dstate.cpp
@@ -227,6 +227,12 @@ Viewer2DState FromLayoutDefinition(const layouts::Layout2DViewDefinition &view) 
   return state;
 }
 
+void ApplyEditorRenderOptions(Viewer2DState &state, const ConfigManager &cfg) {
+  Viewer2DState editorState = CaptureState(nullptr, cfg);
+  state.renderOptions = editorState.renderOptions;
+  state.layers = editorState.layers;
+}
+
 layouts::Layout2DViewDefinition ToLayoutDefinition(
     const Viewer2DState &state, const layouts::Layout2DViewFrame &frame) {
   layouts::Layout2DViewDefinition view;

--- a/viewer2d/viewer2dstate.h
+++ b/viewer2d/viewer2dstate.h
@@ -70,6 +70,7 @@ private:
 };
 
 Viewer2DState FromLayoutDefinition(const layouts::Layout2DViewDefinition &view);
+void ApplyEditorRenderOptions(Viewer2DState &state, const ConfigManager &cfg);
 layouts::Layout2DViewDefinition ToLayoutDefinition(
     const Viewer2DState &state, const layouts::Layout2DViewFrame &frame = {});
 layouts::Layout2DViewDefinition CaptureLayoutDefinition(


### PR DESCRIPTION
### Motivation
- Layout 2D elements (views, legends, text, images, tables) must inherit label positioning and other render settings from the editor so their on-page preview, editing, and exported PDFs match the editor view.

### Description
- Add `ApplyEditorRenderOptions(Viewer2DState &, const ConfigManager &)` to `viewer2d::` to copy the editor's render options and hidden-layer state into a layout-derived `Viewer2DState` (`viewer2d/viewer2dstate.h` and `.cpp`).
- Use the new helper when rendering layout previews so captured 2D view textures respect the editor's label/label-offset and layer visibility settings (`gui/layoutviewerpanel_view.cpp`).
- Apply the editor render options when opening the 2D view editor so the editable popup starts with the editor's render and layer configuration (`gui/mainwindow_layout.cpp`).
- Apply the editor render options when exporting layout PDF pages so exported captures match the editor's label placement (`gui/mainwindow_print.cpp`).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972b38a34048324a457590e5770db04)