### PR TITLE
Inherit editor render options for layout 2D views

### DIFF
--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -575,6 +575,7 @@ void MainWindow::OnLayoutAdd2DView(wxCommandEvent &WXUNUSED(event)) {
   ConfigManager &cfg = ConfigManager::Get();
   viewer2d::Viewer2DState baseState =
       viewer2d::CaptureState(viewport2DPanel, cfg);
+  viewer2d::ApplyEditorRenderOptions(baseState, cfg);
   layouts::Layout2DViewFrame frame = BuildDefaultLayout2DFrame(*layout);
   layouts::Layout2DViewDefinition view =
       viewer2d::ToLayoutDefinition(baseState, frame);
@@ -804,6 +805,7 @@ void MainWindow::OnLayout2DViewOk(wxCommandEvent &WXUNUSED(event)) {
       layout2DViewEditPanel ? layout2DViewEditPanel : viewport2DPanel;
   viewer2d::Viewer2DState current =
       viewer2d::CaptureState(editPanel, cfg);
+  viewer2d::ApplyEditorRenderOptions(current, cfg);
 
   layouts::Layout2DViewFrame frame{};
   int viewId = layout2DViewEditingId;

--- a/viewer2d/viewer2dstate.cpp
+++ b/viewer2d/viewer2dstate.cpp
@@ -258,7 +258,9 @@ layouts::Layout2DViewDefinition CaptureLayoutDefinition(
     resolvedFrame.width = viewState.viewportWidth;
     resolvedFrame.height = viewState.viewportHeight;
   }
-  return ToLayoutDefinition(CaptureState(panel, cfg), resolvedFrame);
+  Viewer2DState state = CaptureState(panel, cfg);
+  ApplyEditorRenderOptions(state, cfg);
+  return ToLayoutDefinition(state, resolvedFrame);
 }
 
 } // namespace viewer2d


### PR DESCRIPTION
### Motivation
- Make layout 2D elements inherit label positions and other editor render/layer settings so views added or saved from the editor preserve the editor's label placement and related configuration.

### Description
- Ensure captured layout definitions apply editor render options by calling `ApplyEditorRenderOptions(state, cfg)` inside `viewer2d::CaptureLayoutDefinition` in `viewer2d/viewer2dstate.cpp`.
- Apply `viewer2d::ApplyEditorRenderOptions` to the captured state used when creating a new layout view in `MainWindow::OnLayoutAdd2DView` in `gui/mainwindow_layout.cpp` so newly added views inherit editor settings.
- Apply `viewer2d::ApplyEditorRenderOptions` to the captured state before persisting edits in `MainWindow::OnLayout2DViewOk` in `gui/mainwindow_layout.cpp` so saved updates inherit editor settings.
- Modified files: `viewer2d/viewer2dstate.cpp`, `gui/mainwindow_layout.cpp`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69755a8b588c8324ab8813447583894a)