### PR TITLE
Clamp selection notifications to existing rows in ColorfulDataViewListStore

### DIFF
--- a/gui/colorstore.h
+++ b/gui/colorstore.h
@@ -173,7 +173,9 @@ public:
     selectionRows.assign(rows.begin(), rows.end());
     if (rowAttrs.size() > selectionRows.size())
       selectionRows.resize(rowAttrs.size(), false);
-    size_t notifyCount = (std::max)(oldSize, selectionRows.size());
+    size_t currentCount = rowAttrs.size();
+    size_t notifyCount = (std::min)((std::max)(oldSize, selectionRows.size()),
+                                    currentCount);
     for (size_t i = 0; i < notifyCount; ++i) {
       bool oldVal = i < oldSize ? oldRows[i] : false;
       bool newVal = i < selectionRows.size() ? selectionRows[i] : false;


### PR DESCRIPTION
### Motivation
- Deleting fixtures could shrink the list store while `SetSelectedRows` still notifies up to the previous selection size, causing `RowChanged` calls for non-existent rows and triggering an assert in wxDataView (`GetItem` invalid index).

### Description
- In `gui/colorstore.h` update `SetSelectedRows` to compute `notifyCount` as `min(max(oldSize, selectionRows.size()), currentCount)` where `currentCount` is `rowAttrs.size()`, so notifications are clamped to existing rows.
- This change prevents out-of-bounds `RowChanged` notifications after item deletions and keeps `selectionRows` aligned with `rowAttrs`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69755c03b698832480f92a59e3ac4578)