### PR TITLE
Keep DataView store and control in sync when clearing/deleting rows

### DIFF
--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -215,7 +215,7 @@ void FixtureTablePanel::InitializeTable() {
 }
 
 void FixtureTablePanel::ReloadData() {
-  table->DeleteAllItems();
+  store->DeleteAllItems();
   gdtfPaths.clear();
   rowUuids.clear();
 
@@ -1030,7 +1030,7 @@ void FixtureTablePanel::DeleteSelected() {
       rowUuids.erase(rowUuids.begin() + r);
       if ((size_t)r < gdtfPaths.size())
         gdtfPaths.erase(gdtfPaths.begin() + r);
-      table->DeleteItem(r);
+      store->DeleteItem(r);
       for (auto itSel = selectionOrder.begin();
            itSel != selectionOrder.end();) {
         if (*itSel == r)


### PR DESCRIPTION
### Motivation
- Deleting fixture rows or clearing the table previously used the view control APIs and left the custom `ColorfulDataViewListStore` internal arrays out-of-sync, which could trigger wxWidgets assertions like `row < m_hash.GetCount()` when selection/highlighting code ran.

### Description
- Use `store->DeleteAllItems()` instead of `table->DeleteAllItems()` in `FixtureTablePanel::ReloadData()` to clear the model and store state together.
- Use `store->DeleteItem(r)` instead of `table->DeleteItem(r)` in `FixtureTablePanel::DeleteSelected()` so per-row attributes and selection state in `ColorfulDataViewListStore` stay synchronized with deletions.
- These changes keep the custom store's `rowAttrs`, `cellAttrs` and `selectionRows` aligned with the DataView items and avoid invalid index accesses.

### Testing
- No automated tests were run for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69755e5186448324b2a88d86afc74e16)