### PR TITLE
Fix layout label offsets to respect active view

### DIFF
--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -499,7 +499,7 @@ void Viewer2DPanel::RenderInternal(bool swapBuffers) {
   // Draw labels for all fixtures after rendering the scene so they appear on
   // top of geometry. Scale the label size with the current zoom so they behave
   // like regular scene objects instead of remaining a constant screen size.
-  m_controller.DrawAllFixtureLabels(w, h, m_zoom);
+  m_controller.DrawAllFixtureLabels(w, h, m_view, m_zoom);
 
   if (m_layoutEditAspect && *m_layoutEditAspect > 0.0f) {
     if (!m_layoutEditBaseSize || m_layoutEditBaseSize->GetWidth() <= 0 ||

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -2477,7 +2477,7 @@ void Viewer3DController::DrawFixtureLabels(int width, int height) {
 // drawn tag roughly matches the fixture size, and the optional zoom parameter
 // scales the label like regular geometry when zooming the 2D view.
 void Viewer3DController::DrawAllFixtureLabels(int width, int height,
-                                              float zoom) {
+                                              Viewer2DView view, float zoom) {
   double model[16];
   double proj[16];
   int viewport[4];
@@ -2506,7 +2506,7 @@ void Viewer3DController::DrawAllFixtureLabels(int width, int height,
                                                  "label_offset_angle_front",
                                                  "label_offset_angle_side",
                                                  "label_offset_angle_top"};
-  int viewIdx = static_cast<int>(cfg.GetFloat("view2d_view"));
+  int viewIdx = static_cast<int>(view);
   bool showName = cfg.GetFloat(nameKeys[viewIdx]) != 0.0f;
   bool showId = cfg.GetFloat(idKeys[viewIdx]) != 0.0f;
   bool showDmx = cfg.GetFloat(dmxKeys[viewIdx]) != 0.0f;

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -106,7 +106,8 @@ public:
   // Renders labels for all fixtures with a uniform font size that scales
   // with the provided zoom factor. Labels have no outline and always show
   // name, ID and DMX address on three separate lines.
-  void DrawAllFixtureLabels(int width, int height, float zoom = 1.0f);
+  void DrawAllFixtureLabels(int width, int height, Viewer2DView view,
+                            float zoom = 1.0f);
 
   // Returns true and outputs label and screen position of the fixture
   // under the given mouse coordinates (if any)


### PR DESCRIPTION
### Motivation
- Labels in 2D layouts used the global config view index when computing offsets, causing offsets to be applied on the wrong axis for some views (e.g. top vs front) which made layout label placement inconsistent.
- The goal is to ensure label offset distance/angle are applied relative to the actual active 2D view so layouts render correctly for top/front/side.

### Description
- Changed `DrawAllFixtureLabels` to accept the active view as a parameter by updating its signature to `void DrawAllFixtureLabels(int width, int height, Viewer2DView view, float zoom = 1.0f)` in `viewer3d/viewer3dcontroller.h` and `viewer3d/viewer3dcontroller.cpp`.
- Replace reading the view index from the config with the passed `view` parameter (`int viewIdx = static_cast<int>(view);`) so label offset keys (`label_offset_distance_*` / `label_offset_angle_*`) are selected using the active view.
- Updated the caller in `viewer2d/viewer2dpanel.cpp` to pass the current view (`m_view`) into `DrawAllFixtureLabels` so the runtime view is used when computing offsets.
- Modified only the function signature and the call site; label offset math and keys remain unchanged but are now indexed by the active view.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69756023bb14832493e8476e8ca0c91c)