### PR TITLE
Preserve layout render options when capturing 2D view (fix label offset persistence)

### DIFF
--- a/gui/layoutviewerpanel_view.cpp
+++ b/gui/layoutviewerpanel_view.cpp
@@ -164,7 +164,6 @@ void LayoutViewerPanel::DrawViewElement(
     ConfigManager &cfg = ConfigManager::Get();
     viewer2d::Viewer2DState layoutState =
         viewer2d::FromLayoutDefinition(view);
-    viewer2d::ApplyEditorRenderOptions(layoutState, cfg);
     layoutState.renderOptions.darkMode = false;
     cache.renderState = layoutState;
     cache.hasRenderState = true;


### PR DESCRIPTION
### Motivation
- Prevent the editor from overwriting layout-specific render options when building 2D view previews so changes like label offset distance made in the layout editor are actually persisted.

### Description
- Remove the call to `viewer2d::ApplyEditorRenderOptions(layoutState, cfg)` in `gui/layoutviewerpanel_view.cpp` so the captured `layoutState` preserves the layout's `renderOptions` (fixes label offset and related settings remaining applied).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975624efdf883249b2e53ea10876265)