### PR TITLE
Enable offscreen FBO texture path for 2D layout capture

### DIFF
--- a/viewer2d/viewer2doffscreenrenderer.cpp
+++ b/viewer2d/viewer2doffscreenrenderer.cpp
@@ -23,17 +23,19 @@ constexpr int kDefaultViewportHeight = 900;
 }
 
 Viewer2DOffscreenRenderer::Viewer2DOffscreenRenderer(wxWindow *parent) {
-  host_ = new wxPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(1, 1));
-  host_->Hide();
-
-  panel_ = new Viewer2DPanel(host_, true, false, false);
-  panel_->SetSize(wxSize(kDefaultViewportWidth, kDefaultViewportHeight));
-  panel_->SetClientSize(wxSize(kDefaultViewportWidth, kDefaultViewportHeight));
-  panel_->LoadViewFromConfig();
-  panel_->UpdateScene(true);
+  parent_ = parent;
+  CreatePanel();
 }
 
-Viewer2DOffscreenRenderer::~Viewer2DOffscreenRenderer() = default;
+Viewer2DOffscreenRenderer::~Viewer2DOffscreenRenderer() { DestroyPanel(); }
+
+void Viewer2DOffscreenRenderer::SetSharedContext(wxGLContext *sharedContext) {
+  if (sharedContext_ == sharedContext)
+    return;
+  sharedContext_ = sharedContext;
+  DestroyPanel();
+  CreatePanel();
+}
 
 void Viewer2DOffscreenRenderer::SetViewportSize(const wxSize &size) {
   if (!panel_)
@@ -49,4 +51,28 @@ void Viewer2DOffscreenRenderer::PrepareForCapture() {
     return;
   panel_->LoadViewFromConfig();
   panel_->UpdateScene(true);
+}
+
+void Viewer2DOffscreenRenderer::CreatePanel() {
+  if (!parent_)
+    return;
+  host_ = new wxPanel(parent_, wxID_ANY, wxDefaultPosition, wxSize(1, 1));
+  host_->Hide();
+
+  panel_ = new Viewer2DPanel(host_, true, false, false, sharedContext_);
+  panel_->SetSize(wxSize(kDefaultViewportWidth, kDefaultViewportHeight));
+  panel_->SetClientSize(wxSize(kDefaultViewportWidth, kDefaultViewportHeight));
+  panel_->LoadViewFromConfig();
+  panel_->UpdateScene(true);
+}
+
+void Viewer2DOffscreenRenderer::DestroyPanel() {
+  if (panel_) {
+    panel_->Destroy();
+    panel_ = nullptr;
+  }
+  if (host_) {
+    host_->Destroy();
+    host_ = nullptr;
+  }
 }

--- a/viewer2d/viewer2doffscreenrenderer.h
+++ b/viewer2d/viewer2doffscreenrenderer.h
@@ -27,10 +27,15 @@ public:
   ~Viewer2DOffscreenRenderer();
 
   Viewer2DPanel *GetPanel() const { return panel_; }
+  void SetSharedContext(wxGLContext *sharedContext);
   void SetViewportSize(const wxSize &size);
   void PrepareForCapture();
 
 private:
+  void CreatePanel();
+  void DestroyPanel();
+  wxWindow *parent_ = nullptr;
   wxPanel *host_ = nullptr;
   Viewer2DPanel *panel_ = nullptr;
+  wxGLContext *sharedContext_ = nullptr;
 };

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -53,7 +53,8 @@ class Viewer2DPanel : public wxGLCanvas {
 public:
   explicit Viewer2DPanel(wxWindow *parent, bool allowOffscreenRender = false,
                          bool persistViewState = true,
-                         bool enableSelection = true);
+                         bool enableSelection = true,
+                         wxGLContext *sharedContext = nullptr);
   ~Viewer2DPanel();
 
   static Viewer2DPanel *Instance();
@@ -98,6 +99,8 @@ public:
 
   bool RenderToRGBA(std::vector<unsigned char> &pixels, int &width,
                     int &height);
+  bool RenderToTexture(unsigned int &texture, unsigned int &framebuffer,
+                       int &width, int &height);
 
   // Accessor for the last recorded set of drawing commands. The buffer is
   // cleared and re-populated on every requested capture.
@@ -149,6 +152,8 @@ private:
   void StopDragTableUpdates();
   void StartDragTableUpdateWorker();
   void StopDragTableUpdateWorker();
+  void EnsureOffscreenTarget(int width, int height);
+  void DestroyOffscreenTarget();
 
   struct DragTablePositionSnapshot {
     std::string uuid;
@@ -207,6 +212,11 @@ private:
 
   wxGLContext *m_glContext = nullptr;
   bool m_glInitialized = false;
+  unsigned int m_offscreenTexture = 0;
+  unsigned int m_offscreenFbo = 0;
+  unsigned int m_offscreenDepthRbo = 0;
+  int m_offscreenWidth = 0;
+  int m_offscreenHeight = 0;
   Viewer3DController m_controller;
   Viewer2DRenderMode m_renderMode = Viewer2DRenderMode::White;
   Viewer2DView m_view = Viewer2DView::Top;


### PR DESCRIPTION
### Motivation
- Eliminate CPU readback and CPU-side `glTexImage2D` uploads when capturing 2D views by rendering directly to an OpenGL texture (FBO) and copying on-GPU into the layout cache. 
- Share GL context between the visible `Viewer2DPanel` and the offscreen renderer so an offscreen `Viewer2DPanel` can produce a texture without breaking GL resource ownership.
- Reduce capture latency and preserve pixel fidelity by using GPU-side `glCopyTexSubImage2D` / FBO copies instead of `glReadPixels`.

### Description
- Added a new FBO-backed capture API `Viewer2DPanel::RenderToTexture(unsigned int &texture, unsigned int &framebuffer, int &width, int &height)` that renders the panel into an offscreen FBO and returns the texture and FBO handles. 
- Implemented offscreen target management in `Viewer2DPanel` with `EnsureOffscreenTarget` and `DestroyOffscreenTarget`, and new member fields `m_offscreenTexture`, `m_offscreenFbo`, `m_offscreenDepthRbo`, `m_offscreenWidth`, and `m_offscreenHeight`. 
- Extended `Viewer2DPanel` constructor to accept a shared `wxGLContext*` so offscreen panels can be created with a shared GL context; updated `Viewer2DOffscreenRenderer` to support `SetSharedContext`, create/destroy its offscreen `Viewer2DPanel` using the shared context, and avoid creating an independent context. 
- Updated `LayoutViewerPanel::InitGL` to initialize GLEW and set the shared context on the offscreen renderer, and modified `RebuildCachedTexture` to call `capturePanel->RenderToTexture(...)` and copy the offscreen FBO into the layout cache texture using `glCopyTexSubImage2D` (preserving the texture entirely on the GPU) instead of reading pixels to CPU and re-uploading with `glTexImage2D`. 
- Added/updated `#include <GL/glew.h>` where needed and preserved previous behavior for legends/event tables that still use CPU `wxImage` paths. 

### Testing
- No automated tests were run as part of this change (no test execution requested in this rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975672382c08324af8751c38d629c77)