### PR TITLE
Fix GLEW include order in OpenGL sources

### DIFF
--- a/gui/layoutviewerpanel_eventtable.cpp
+++ b/gui/layoutviewerpanel_eventtable.cpp
@@ -21,6 +21,7 @@
 #include <array>
 #include <functional>
 
+#include <GL/glew.h>
 #include <GL/gl.h>
 
 #include "layouteventtabledialog.h"

--- a/gui/layoutviewerpanel_image.cpp
+++ b/gui/layoutviewerpanel_image.cpp
@@ -23,6 +23,7 @@
 #include <filesystem>
 #include <functional>
 
+#include <GL/glew.h>
 #include <GL/gl.h>
 
 #include "layoutimageutils.h"

--- a/gui/layoutviewerpanel_legend.cpp
+++ b/gui/layoutviewerpanel_legend.cpp
@@ -25,6 +25,7 @@
 #include <map>
 #include <vector>
 
+#include <GL/glew.h>
 #include <GL/gl.h>
 
 #include "configmanager.h"

--- a/gui/layoutviewerpanel_text.cpp
+++ b/gui/layoutviewerpanel_text.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <functional>
 
+#include <GL/glew.h>
 #include <GL/gl.h>
 
 #include <wx/log.h>

--- a/gui/layoutviewerpanel_view.cpp
+++ b/gui/layoutviewerpanel_view.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <memory>
 
+#include <GL/glew.h>
 #include <GL/gl.h>
 
 #include "configmanager.h"

--- a/viewer2d/canvas2d.cpp
+++ b/viewer2d/canvas2d.cpp
@@ -26,6 +26,7 @@
 #include <windows.h>
 #endif
 
+#include <GL/glew.h>
 #include <GL/gl.h>
 #include <wx/glcanvas.h>
 #include <algorithm>


### PR DESCRIPTION
### Motivation
- Fix build and Intellisense errors caused by `GL/gl.h` being included before `GL/glew.h`, which produces `#error` and undefined GL type issues in the GLEW header.

### Description
- Inserted `#include <GL/glew.h>` before `#include <GL/gl.h>` in multiple GUI and 2D viewer sources to ensure the correct include order for GLEW.
- Files changed: `gui/layoutviewerpanel_eventtable.cpp`, `gui/layoutviewerpanel_image.cpp`, `gui/layoutviewerpanel_legend.cpp`, `gui/layoutviewerpanel_text.cpp`, `gui/layoutviewerpanel_view.cpp`, and `viewer2d/canvas2d.cpp`.
- No other code or behavioral changes were made beyond adjusting the include order.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69756a88944c83248bb1c0e2139bd5c8)