### PR TITLE
Fix GLEW include order for wxGLCanvas headers

### DIFF
--- a/gui/fixturepreviewpanel.h
+++ b/gui/fixturepreviewpanel.h
@@ -17,6 +17,7 @@
  */
 #pragma once
 
+#include <GL/glew.h>
 #include <wx/glcanvas.h>
 #include <vector>
 #include <string>
@@ -59,4 +60,3 @@ private:
 
     wxDECLARE_EVENT_TABLE();
 };
-

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -17,6 +17,7 @@
  */
 #pragma once
 
+#include <GL/glew.h>
 #include <memory>
 #include <optional>
 #include <unordered_map>

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -24,6 +24,8 @@
 
 #pragma once
 
+#include <GL/glew.h>
+
 #include "canvas2d.h"
 #include "viewer3dcontroller.h"
 #include <wx/glcanvas.h>

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <GL/glew.h>
 #include <wx/glcanvas.h>
 #include "viewer3dcamera.h"
 #include "viewer3dcontroller.h"


### PR DESCRIPTION
### Motivation
- Building on Windows produced `#error:  gl.h included before glew.h` because `wx/glcanvas.h` can pull in `gl.h` before `glew.h` is included.
- Ensuring GLEW is included before wx's GL headers prevents header ordering conflicts and runtime GL symbol issues.

### Description
- Add `#include <GL/glew.h>` before `#include <wx/glcanvas.h>` in the following headers: `viewer3d/viewer3dpanel.h`, `viewer2d/viewer2dpanel.h`, `gui/fixturepreviewpanel.h`, and `gui/layoutviewerpanel.h`.
- The change standardizes OpenGL header ordering across 2D/3D viewers and layout/fixture preview panels to avoid the `gl.h` vs `glew.h` include error.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697723fba1b48324a811b6706e83e7d4)