### PR TITLE
Avoid GL offscreen teardown on hidden canvas

### DIFF
--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -701,6 +701,8 @@ void Viewer2DPanel::EnsureOffscreenTarget(int width, int height) {
 void Viewer2DPanel::DestroyOffscreenTarget() {
   if (!m_glContext)
     return;
+  if (!IsShownOnScreen())
+    return;
   SetCurrent(*m_glContext);
   if (m_offscreenDepthRbo != 0) {
     glDeleteRenderbuffers(1, &m_offscreenDepthRbo);


### PR DESCRIPTION
### Motivation
- Prevent a wxWidgets assert triggered by calling `SetCurrent` on a hidden `wxGLCanvas` during offscreen GL resource teardown when closing the application or switching layouts.

### Description
- Add an early return in `Viewer2DPanel::DestroyOffscreenTarget` (in `viewer2d/viewer2dpanel.cpp`) that checks `IsShownOnScreen()` and skips `SetCurrent` and GL resource deletions when the canvas is not shown.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697725fa15e483249eeb55b58eafd943)