### PR TITLE
Render layout view textures directly in offscreen FBO (remove CPU readback)

### DIFF
--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -99,8 +99,6 @@ public:
       bool useSimplifiedFootprints = false,
       bool includeGridInCapture = true);
 
-  bool RenderToRGBA(std::vector<unsigned char> &pixels, int &width,
-                    int &height);
   bool RenderToTexture(unsigned int &texture, unsigned int &framebuffer,
                        int &width, int &height);
 


### PR DESCRIPTION
### Motivation
- Replace the CPU readback path (`glReadPixels`/CPU `glTexImage2D` uploads) with a GPU-only flow that renders 2D views directly into textures attached to an FBO to avoid expensive readbacks and copies. 
- Keep the same shading/render path so the final image pixels remain identical to the current pipeline (preserve print/export fidelity). 
- Allow offscreen renders to target externally-provided textures so cached layout view textures can be written directly into shared GPU textures. 

### Description
- Removed the CPU readback capture path by deleting the `RenderToRGBA` usage and readback logic and instead routing offscreen renders to a texture-backed FBO. 
- Updated `Viewer2DPanel::RenderToTexture` to accept an optional external `texture` (if non-zero) and bind that texture to the panel offscreen FBO with `glFramebufferTexture2D` before calling `RenderInternal`, so rendering happens directly into the GPU texture. 
- Adjusted `EnsureOffscreenTarget` usage and added guards so `RenderToTexture` reports failure if no valid target texture exists. 
- Modified `LayoutViewerPanel::RebuildCachedTexture` to allocate/prepare `cache.texture` on the GPU and call `capturePanel->RenderToTexture(cache.texture, sourceFbo, width, height)` to render directly into the `cache.texture`, removing the previous `glCopyTexSubImage2D`-based copy/readback path. 

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697727c69e7c83248417ea7807374f97)