### PR TITLE
Use offscreen FBO textures for layout 2D view caching

### DIFF
--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -154,6 +154,8 @@ private:
                         bool updatePosition);
   void InitGL();
   void RebuildCachedTexture();
+  bool BlitTextureToCache(unsigned int sourceTexture, const wxSize &sourceSize,
+                          ViewCache &cache);
   void ClearCachedTexture();
   void ClearCachedTexture(ViewCache &cache);
   void ClearCachedTexture(LegendCache &cache);
@@ -250,6 +252,7 @@ private:
   int selectedElementId = -1;
   wxGLContext *glContext_ = nullptr;
   bool glInitialized_ = false;
+  unsigned int textureCopyFbo_ = 0;
   bool renderDirty = true;
   bool renderPending = false;
   std::unordered_map<int, ViewCache> viewCaches_;

--- a/viewer2d/viewer2doffscreenrenderer.h
+++ b/viewer2d/viewer2doffscreenrenderer.h
@@ -30,12 +30,21 @@ public:
   void SetSharedContext(wxGLContext *sharedContext);
   void SetViewportSize(const wxSize &size);
   void PrepareForCapture();
+  bool RenderToTexture(const wxSize &size);
+  unsigned int GetRenderedTexture() const { return renderedTexture_; }
+  wxSize GetRenderedTextureSize() const { return renderedTextureSize_; }
 
 private:
   void CreatePanel();
   void DestroyPanel();
+  void EnsureOffscreenTarget(const wxSize &size);
+  void DestroyOffscreenTarget();
   wxWindow *parent_ = nullptr;
   wxPanel *host_ = nullptr;
   Viewer2DPanel *panel_ = nullptr;
   wxGLContext *sharedContext_ = nullptr;
+  unsigned int renderedTexture_ = 0;
+  unsigned int renderedFbo_ = 0;
+  unsigned int renderedDepthRbo_ = 0;
+  wxSize renderedTextureSize_{0, 0};
 };

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -408,6 +408,8 @@ Viewer2DPanel::GetBottomSymbolCacheSnapshot() const {
   return m_controller.GetBottomSymbolCacheSnapshot();
 }
 
+void Viewer2DPanel::EnsureGLReady() { InitGL(); }
+
 void Viewer2DPanel::InitGL() {
   if (!IsShownOnScreen() && !m_forceOffscreenRender &&
       !m_allowOffscreenRender) {
@@ -639,6 +641,27 @@ bool Viewer2DPanel::RenderToTexture(unsigned int &texture,
   if (!useExternalTexture)
     texture = targetTexture;
   framebuffer = m_offscreenFbo;
+
+  m_forceOffscreenRender = previousForce;
+  return true;
+}
+
+bool Viewer2DPanel::RenderToFramebuffer(unsigned int framebuffer) {
+  int w = 0;
+  int h = 0;
+  GetClientSize(&w, &h);
+  if (w <= 0 || h <= 0)
+    return false;
+
+  bool previousForce = m_forceOffscreenRender;
+  m_forceOffscreenRender = true;
+  InitGL();
+
+  GLint previousFbo = 0;
+  glGetIntegerv(GL_FRAMEBUFFER_BINDING, &previousFbo);
+  glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
+  RenderInternal(false);
+  glBindFramebuffer(GL_FRAMEBUFFER, static_cast<GLuint>(previousFbo));
 
   m_forceOffscreenRender = previousForce;
   return true;

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -99,8 +99,11 @@ public:
       bool useSimplifiedFootprints = false,
       bool includeGridInCapture = true);
 
+  void EnsureGLReady();
+
   bool RenderToTexture(unsigned int &texture, unsigned int &framebuffer,
                        int &width, int &height);
+  bool RenderToFramebuffer(unsigned int framebuffer);
 
   // Accessor for the last recorded set of drawing commands. The buffer is
   // cleared and re-populated on every requested capture.


### PR DESCRIPTION
### Motivation
- Avoid CPU readback and `glTexImage2D` uploads when composing layout view caches by rendering the 2D view directly into a GPU texture (FBO) and copying on-GPU to the layout cache.

### Description
- Add FBO-based offscreen rendering to `Viewer2DOffscreenRenderer`, introducing `RenderToTexture(const wxSize&)`, `GetRenderedTexture()` and `GetRenderedTextureSize()` plus FBO/texture/depth RBO lifecycle management.
- Expose helpers on the panel with `Viewer2DPanel::EnsureGLReady()` and `Viewer2DPanel::RenderToFramebuffer()` so the viewer can render into an externally-managed FBO without reading pixels back to the CPU.
- Replace the previous `RenderToTexture + glTexImage2D` pipeline inside `LayoutViewerPanel::RebuildCachedTexture()` by calling the offscreen renderer and then GPU-blitting the offscreen texture into the view cache via the new `BlitTextureToCache()` routine that binds the source texture and draws a quad into a cache texture attached to an internal `textureCopyFbo_`.
- Add cleanup for the copy FBO and ensure offscreen targets are created/destroyed safely (changes in `DestroyOffscreenTarget` and destructor cleanup), while preserving the capture/export code paths on the viewer panel.

### Testing
- No automated tests were executed for this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69772a8050248324a97223035f3a81da)