### PR TITLE
Add FBO-backed offscreen rendering for 2D viewer

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1165,7 +1165,6 @@ void LayoutViewerPanel::RebuildCachedTexture() {
     }
 
     offscreenRenderer->SetViewportSize(renderSize);
-    offscreenRenderer->PrepareForCapture();
 
     ConfigManager &cfg = ConfigManager::Get();
     viewer2d::Viewer2DState renderState = cache.renderState;
@@ -1191,16 +1190,16 @@ void LayoutViewerPanel::RebuildCachedTexture() {
     if (!IsShownOnScreen())
       return;
     const wxSize renderSizeWx(width, height);
-    if (!offscreenRenderer->RenderToTexture(renderSizeWx) ||
-        offscreenRenderer->GetRenderedTexture() == 0 ||
+    offscreenRenderer->PrepareForCapture(renderSizeWx);
+    const GLuint renderedTexture = offscreenRenderer->GetRenderedTexture();
+    if (renderedTexture == 0 ||
         offscreenRenderer->GetRenderedTextureSize() != renderSizeWx) {
       ClearCachedTexture(cache);
       cache.textureSize = wxSize(0, 0);
       cache.renderZoom = 0.0;
       continue;
     }
-    if (!BlitTextureToCache(offscreenRenderer->GetRenderedTexture(),
-                            renderSizeWx, cache)) {
+    if (!BlitTextureToCache(renderedTexture, renderSizeWx, cache)) {
       ClearCachedTexture(cache);
       cache.textureSize = wxSize(0, 0);
       cache.renderZoom = 0.0;

--- a/gui/layoutviewerpanel_view.cpp
+++ b/gui/layoutviewerpanel_view.cpp
@@ -172,10 +172,14 @@ void LayoutViewerPanel::DrawViewElement(
         fallbackViewportHeight > 0) {
       offscreenRenderer->SetViewportSize(
           wxSize(fallbackViewportWidth, fallbackViewportHeight));
-      offscreenRenderer->PrepareForCapture();
     }
     auto stateGuard = std::make_shared<viewer2d::ScopedViewer2DState>(
         capturePanel, nullptr, cfg, layoutState, nullptr, nullptr, false);
+    if (offscreenRenderer && fallbackViewportWidth > 0 &&
+        fallbackViewportHeight > 0) {
+      offscreenRenderer->PrepareForCapture(
+          wxSize(fallbackViewportWidth, fallbackViewportHeight));
+    }
     capturePanel->CaptureFrameNow(
         [this, viewId, stateGuard, fallbackViewportWidth, fallbackViewportHeight,
          capturePanel](CommandBuffer buffer, Viewer2DViewState state) {

--- a/gui/mainwindow_print.cpp
+++ b/gui/mainwindow_print.cpp
@@ -172,7 +172,7 @@ void MainWindow::OnPrintViewer2D(wxCommandEvent &WXUNUSED(event)) {
   if (viewport2DPanel)
     viewport2DPanel->SaveViewToConfig();
   offscreenRenderer->SetViewportSize(captureSize);
-  offscreenRenderer->PrepareForCapture();
+  offscreenRenderer->PrepareForCapture(captureSize);
 
   capturePanel->CaptureFrameNow(
       [this, capturePanel, opts, outputPath, outputPathDisplay](
@@ -426,15 +426,15 @@ void MainWindow::OnPrintLayout(wxCommandEvent &WXUNUSED(event)) {
         const int viewportHeight =
             fallbackViewportHeight > 0 ? fallbackViewportHeight : 900;
 
-        if (offscreenRenderer && viewportWidth > 0 && viewportHeight > 0) {
-          offscreenRenderer->SetViewportSize(
-              wxSize(viewportWidth, viewportHeight));
-          offscreenRenderer->PrepareForCapture();
-        }
-
         auto stateGuard = std::make_shared<viewer2d::ScopedViewer2DState>(
             capturePanel, nullptr, *cfgPtr, layoutState, nullptr, nullptr,
             false);
+        if (offscreenRenderer && viewportWidth > 0 && viewportHeight > 0) {
+          offscreenRenderer->SetViewportSize(
+              wxSize(viewportWidth, viewportHeight));
+          offscreenRenderer->PrepareForCapture(
+              wxSize(viewportWidth, viewportHeight));
+        }
         capturePanel->CaptureFrameNow(
             [captureNext, exportViews, view, viewportWidth, viewportHeight,
              capturePanel, scaleX, scaleY,

--- a/viewer2d/viewer2doffscreenrenderer.h
+++ b/viewer2d/viewer2doffscreenrenderer.h
@@ -29,22 +29,22 @@ public:
   Viewer2DPanel *GetPanel() const { return panel_; }
   void SetSharedContext(wxGLContext *sharedContext);
   void SetViewportSize(const wxSize &size);
-  void PrepareForCapture();
+  void PrepareForCapture(const wxSize &size);
   bool RenderToTexture(const wxSize &size);
-  unsigned int GetRenderedTexture() const { return renderedTexture_; }
-  wxSize GetRenderedTextureSize() const { return renderedTextureSize_; }
+  unsigned int GetRenderedTexture() const { return colorTex_; }
+  wxSize GetRenderedTextureSize() const { return renderSize_; }
 
 private:
   void CreatePanel();
   void DestroyPanel();
-  void EnsureOffscreenTarget(const wxSize &size);
-  void DestroyOffscreenTarget();
+  void EnsureRenderTarget(const wxSize &size);
+  void DestroyRenderTarget();
   wxWindow *parent_ = nullptr;
   wxPanel *host_ = nullptr;
   Viewer2DPanel *panel_ = nullptr;
   wxGLContext *sharedContext_ = nullptr;
-  unsigned int renderedTexture_ = 0;
-  unsigned int renderedFbo_ = 0;
-  unsigned int renderedDepthRbo_ = 0;
-  wxSize renderedTextureSize_{0, 0};
+  unsigned int fbo_ = 0;
+  unsigned int colorTex_ = 0;
+  unsigned int depthRb_ = 0;
+  wxSize renderSize_{0, 0};
 };

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -646,6 +646,31 @@ bool Viewer2DPanel::RenderToTexture(unsigned int &texture,
   return true;
 }
 
+bool Viewer2DPanel::RenderToTexture(unsigned int framebuffer,
+                                    const wxSize &size) {
+  if (size.GetWidth() <= 0 || size.GetHeight() <= 0)
+    return false;
+
+  bool previousForce = m_forceOffscreenRender;
+  m_forceOffscreenRender = true;
+  InitGL();
+
+  GLint previousFbo = 0;
+  glGetIntegerv(GL_FRAMEBUFFER_BINDING, &previousFbo);
+  GLint previousViewport[4] = {0, 0, 0, 0};
+  glGetIntegerv(GL_VIEWPORT, previousViewport);
+
+  glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
+  glViewport(0, 0, size.GetWidth(), size.GetHeight());
+  RenderInternal(false);
+  glBindFramebuffer(GL_FRAMEBUFFER, static_cast<GLuint>(previousFbo));
+  glViewport(previousViewport[0], previousViewport[1], previousViewport[2],
+             previousViewport[3]);
+
+  m_forceOffscreenRender = previousForce;
+  return true;
+}
+
 bool Viewer2DPanel::RenderToFramebuffer(unsigned int framebuffer) {
   int w = 0;
   int h = 0;

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -103,6 +103,7 @@ public:
 
   bool RenderToTexture(unsigned int &texture, unsigned int &framebuffer,
                        int &width, int &height);
+  bool RenderToTexture(unsigned int framebuffer, const wxSize &size);
   bool RenderToFramebuffer(unsigned int framebuffer);
 
   // Accessor for the last recorded set of drawing commands. The buffer is


### PR DESCRIPTION
### Motivation
- Replace the previous ad-hoc offscreen flow with an explicit FBO/color texture/depth renderbuffer so offscreen 2D rendering can be reused and bound directly for cache/blit operations.
- Ensure stable size tracking for offscreen targets so rendered textures can be read or drawn without re-uploading pixels.

### Description
- Added FBO, color texture and depth renderbuffer members and size tracking to `Viewer2DOffscreenRenderer` (`fbo_`, `colorTex_`, `depthRb_`, `renderSize_`) and replaced the old names and helpers with `EnsureRenderTarget(const wxSize&)` and `DestroyRenderTarget()` in `viewer2d/viewer2doffscreenrenderer.*`.
- Changed `PrepareForCapture` to accept a `wxSize` and to call `SetViewportSize`, `EnsureRenderTarget(size)` and the panel helper to render into the FBO (`panel_->RenderToTexture(fbo_, size)`).
- Added `Viewer2DPanel::RenderToTexture(unsigned int framebuffer, const wxSize &size)` which binds the provided FBO, sets the viewport to `size`, calls `RenderInternal(false)` and restores GL state.
- Updated capture and cache call sites to use the new API: `LayoutViewerPanel` now calls `offscreenRenderer->PrepareForCapture(renderSizeWx)`, reads the texture via `GetRenderedTexture()` / `GetRenderedTextureSize()` and blits that texture to the cache; call sites in `gui/layoutviewerpanel_view.cpp` and `gui/mainwindow_print.cpp` were updated to pass sizes into `PrepareForCapture` and to reorder preparation where needed.

### Testing
- No automated tests were executed in this change; compilation and visual verification were not run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69772e573a44832486d7d7f3ca1d73c0)