### PR TITLE
Debounce layout viewer cache rebuilds

### DIFF
--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -23,6 +23,7 @@
 #include <unordered_map>
 #include <utility>
 #include <wx/glcanvas.h>
+#include <wx/timer.h>
 #include <wx/wx.h>
 #include "layouts/LayoutCollection.h"
 #include "canvas2d.h"
@@ -121,6 +122,7 @@ private:
   void OnDeleteImage(wxCommandEvent &event);
   void OnBringToFront(wxCommandEvent &event);
   void OnSendToBack(wxCommandEvent &event);
+  void OnRenderDebounceTimer(wxTimerEvent &event);
 
   void DrawSelectionHandles(const wxRect &frameRect) const;
   void DrawViewElement(const layouts::Layout2DViewDefinition &view,
@@ -163,6 +165,7 @@ private:
   void ClearCachedTexture(TextCache &cache);
   void ClearCachedTexture(ImageCache &cache);
   void RequestRenderRebuild();
+  bool HasDirtyCaches() const;
   void InvalidateRenderIfFrameChanged();
   void EmitEditViewRequest();
   bool SelectElementAtPosition(const wxPoint &pos);
@@ -255,6 +258,7 @@ private:
   unsigned int textureCopyFbo_ = 0;
   bool renderDirty = true;
   bool renderPending = false;
+  wxTimer renderDebounceTimer_;
   std::unordered_map<int, ViewCache> viewCaches_;
   std::unordered_map<int, LegendCache> legendCaches_;
   std::unordered_map<int, EventTableCache> eventTableCaches_;


### PR DESCRIPTION
### Motivation
- Avoid performing a full global cache rebuild when nothing in the layout actually needs updating by ensuring only caches with `cache.renderDirty == true` are processed.  
- Reduce redundant work and GPU texture churn caused by many rapid UI updates by grouping rebuild requests with a short debounce (within the requested 16–50ms range).  
- Prevent multiple rebuilds being triggered from the same frame when the 2D view emits several quick changes.  

### Description
- Added constants `kRenderDebounceTimerId` and `kRenderDebounceDelayMs` (set to `32` ms) and hooked `EVT_TIMER` to a new `OnRenderDebounceTimer` handler.  
- Introduced a `wxTimer renderDebounceTimer_` member and initialized it in the constructor with `renderDebounceTimer_(this, kRenderDebounceTimerId)`.  
- Implemented `bool HasDirtyCaches() const` to detect whether any view/legend/event-table/text/image cache is missing or has `renderDirty == true`.  
- Short-circuited work paths by using `HasDirtyCaches()` in both `RequestRenderRebuild()` and `RebuildCachedTexture()` so rebuilds are skipped when no caches are dirty, and changed `RequestRenderRebuild()` to start a debounce via `renderDebounceTimer_.StartOnce(kRenderDebounceDelayMs)` instead of immediate `CallAfter` execution.  

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697733cbdb588324b3cde6ad81fdd6fb)