### PR TITLE
Preserve cached textures while rendering in layout viewer and add "Loading..." overlay

### DIFF
--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -136,6 +136,7 @@ private:
                        int activeTextId);
   void DrawImageElement(const layouts::LayoutImageDefinition &image,
                         int activeImageId);
+  void DrawLoadingOverlay(const wxRect &frameRect);
 
   void ResetViewToFit();
   wxRect GetPageRect() const;
@@ -264,6 +265,8 @@ private:
   std::unordered_map<int, EventTableCache> eventTableCaches_;
   std::unordered_map<int, TextCache> textCaches_;
   std::unordered_map<int, ImageCache> imageCaches_;
+  unsigned int loadingTexture_ = 0;
+  wxSize loadingTextureSize_{0, 0};
   std::vector<LegendItem> legendItems_;
   size_t legendDataHash = 0;
   bool pendingFitOnResize = true;

--- a/gui/layoutviewerpanel_eventtable.cpp
+++ b/gui/layoutviewerpanel_eventtable.cpp
@@ -178,8 +178,12 @@ void LayoutViewerPanel::DrawEventTableElement(
   const int frameBottom = frameRect.GetTop() + frameRect.GetHeight();
 
   const wxSize renderSize = GetFrameSizeForZoom(table.frame, cache.renderZoom);
-  if (cache.texture != 0 && renderSize.GetWidth() > 0 &&
-      renderSize.GetHeight() > 0 && cache.textureSize == renderSize) {
+  const bool hasCachedTexture =
+      cache.texture != 0 &&
+      (cache.renderDirty ||
+       (renderSize.GetWidth() > 0 && renderSize.GetHeight() > 0 &&
+        cache.textureSize == renderSize));
+  if (hasCachedTexture) {
     glEnable(GL_TEXTURE_2D);
     glBindTexture(GL_TEXTURE_2D, cache.texture);
     glColor4ub(255, 255, 255, 255);
@@ -210,6 +214,9 @@ void LayoutViewerPanel::DrawEventTableElement(
     glVertex2f(static_cast<float>(frameRect.GetLeft()),
                static_cast<float>(frameRect.GetBottom()));
     glEnd();
+    if (cache.texture == 0) {
+      DrawLoadingOverlay(frameRect);
+    }
   }
 
   if (table.id == selectedElementId &&

--- a/gui/layoutviewerpanel_image.cpp
+++ b/gui/layoutviewerpanel_image.cpp
@@ -202,8 +202,12 @@ void LayoutViewerPanel::DrawImageElement(
   const int frameBottom = frameRect.GetTop() + frameRect.GetHeight();
 
   const wxSize renderSize = GetFrameSizeForZoom(image.frame, cache.renderZoom);
-  if (cache.texture != 0 && renderSize.GetWidth() > 0 &&
-      renderSize.GetHeight() > 0 && cache.textureSize == renderSize) {
+  const bool hasCachedTexture =
+      cache.texture != 0 &&
+      (cache.renderDirty ||
+       (renderSize.GetWidth() > 0 && renderSize.GetHeight() > 0 &&
+        cache.textureSize == renderSize));
+  if (hasCachedTexture) {
     glEnable(GL_TEXTURE_2D);
     glBindTexture(GL_TEXTURE_2D, cache.texture);
     glColor4ub(255, 255, 255, 255);
@@ -234,6 +238,9 @@ void LayoutViewerPanel::DrawImageElement(
     glVertex2f(static_cast<float>(frameRect.GetLeft()),
                static_cast<float>(frameRect.GetBottom()));
     glEnd();
+    if (cache.texture == 0) {
+      DrawLoadingOverlay(frameRect);
+    }
   }
 
   if (image.id == activeImageId) {

--- a/gui/layoutviewerpanel_legend.cpp
+++ b/gui/layoutviewerpanel_legend.cpp
@@ -635,8 +635,12 @@ void LayoutViewerPanel::DrawLegendElement(
   const int frameBottom = frameRect.GetTop() + frameRect.GetHeight();
 
   const wxSize renderSize = GetFrameSizeForZoom(legend.frame, cache.renderZoom);
-  if (cache.texture != 0 && renderSize.GetWidth() > 0 &&
-      renderSize.GetHeight() > 0 && cache.textureSize == renderSize) {
+  const bool hasCachedTexture =
+      cache.texture != 0 &&
+      (cache.renderDirty ||
+       (renderSize.GetWidth() > 0 && renderSize.GetHeight() > 0 &&
+        cache.textureSize == renderSize));
+  if (hasCachedTexture) {
     glEnable(GL_TEXTURE_2D);
     glBindTexture(GL_TEXTURE_2D, cache.texture);
     glColor4ub(255, 255, 255, 255);
@@ -667,6 +671,9 @@ void LayoutViewerPanel::DrawLegendElement(
     glVertex2f(static_cast<float>(frameRect.GetLeft()),
                static_cast<float>(frameRect.GetBottom()));
     glEnd();
+    if (cache.texture == 0) {
+      DrawLoadingOverlay(frameRect);
+    }
   }
 
   if (legend.id == activeLegendId) {

--- a/gui/layoutviewerpanel_text.cpp
+++ b/gui/layoutviewerpanel_text.cpp
@@ -193,8 +193,12 @@ void LayoutViewerPanel::DrawTextElement(
   const int frameBottom = frameRect.GetTop() + frameRect.GetHeight();
 
   const wxSize renderSize = GetFrameSizeForZoom(text.frame, cache.renderZoom);
-  if (cache.texture != 0 && renderSize.GetWidth() > 0 &&
-      renderSize.GetHeight() > 0 && cache.textureSize == renderSize) {
+  const bool hasCachedTexture =
+      cache.texture != 0 &&
+      (cache.renderDirty ||
+       (renderSize.GetWidth() > 0 && renderSize.GetHeight() > 0 &&
+        cache.textureSize == renderSize));
+  if (hasCachedTexture) {
     glEnable(GL_TEXTURE_2D);
     glBindTexture(GL_TEXTURE_2D, cache.texture);
     glColor4ub(255, 255, 255, 255);
@@ -225,6 +229,9 @@ void LayoutViewerPanel::DrawTextElement(
     glVertex2f(static_cast<float>(frameRect.GetLeft()),
                static_cast<float>(frameRect.GetBottom()));
     glEnd();
+  }
+  if (!hasCachedTexture && cache.texture == 0) {
+    DrawLoadingOverlay(frameRect);
   }
 
   if (text.drawFrame || text.id == activeTextId) {


### PR DESCRIPTION
### Motivation
- Prevent flicker and data loss by keeping the previous cached texture visible while a new offscreen render is in progress or fails.
- Only update a cache entry's texture once a new render is successfully produced and copied into the GPU texture.
- Provide a minimal visual feedback when no previous texture exists by drawing a small "Loading..." overlay inside the element frame.

### Description
- Added a reusable `DrawLoadingOverlay(const wxRect &frameRect)` helper and GPU-backed `loadingTexture_` state to `LayoutViewerPanel` (changes in `gui/layoutviewerpanel.h` and `gui/layoutviewerpanel.cpp`).
- Changed element draw logic (`DrawViewElement`, `DrawLegendElement`, `DrawEventTableElement`, `DrawTextElement`, `DrawImageElement`) to compute `hasCachedTexture` and continue drawing the existing texture while `renderDirty` is true, and to show the loading overlay only when no cached texture is available (files under `gui/` including `_view.cpp`, `_legend.cpp`, `_eventtable.cpp`, `_text.cpp`, `_image.cpp`).
- Reworked `RebuildCachedTexture()` to avoid deleting/clearing existing textures on render failures or intermediate conditions; cache entries only have `renderDirty` cleared when the render and blit succeed, and `renderDirty`/`renderDirty` state is recomputed at the end with `renderDirty = HasDirtyCaches()` (changes in `gui/layoutviewerpanel.cpp`).
- Removed aggressive calls to `ClearCachedTexture(...)` when frame/capture conditions temporarily prevent a successful rebuild so prior textures remain visible until replaced; ensured proper cleanup of the `loadingTexture_` in the destructor (changes across `gui/layoutviewerpanel*.cpp` and header).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697736c4b49c8324b94ac3aad1385874)