### PR TITLE
Add async offscreen rendering worker for layout view captures

### DIFF
--- a/gui/fixturepreviewpanel.h
+++ b/gui/fixturepreviewpanel.h
@@ -17,6 +17,7 @@
  */
 #pragma once
 
+#include <GL/glew.h>
 #include <wx/glcanvas.h>
 #include <vector>
 #include <string>
@@ -59,4 +60,3 @@ private:
 
     wxDECLARE_EVENT_TABLE();
 };
-

--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1165,7 +1165,6 @@ void LayoutViewerPanel::RebuildCachedTexture() {
     }
 
     offscreenRenderer->SetViewportSize(renderSize);
-    offscreenRenderer->PrepareForCapture();
 
     ConfigManager &cfg = ConfigManager::Get();
     viewer2d::Viewer2DState renderState = cache.renderState;
@@ -1191,16 +1190,16 @@ void LayoutViewerPanel::RebuildCachedTexture() {
     if (!IsShownOnScreen())
       return;
     const wxSize renderSizeWx(width, height);
-    if (!offscreenRenderer->RenderToTexture(renderSizeWx) ||
-        offscreenRenderer->GetRenderedTexture() == 0 ||
+    offscreenRenderer->PrepareForCapture(renderSizeWx);
+    const GLuint renderedTexture = offscreenRenderer->GetRenderedTexture();
+    if (renderedTexture == 0 ||
         offscreenRenderer->GetRenderedTextureSize() != renderSizeWx) {
       ClearCachedTexture(cache);
       cache.textureSize = wxSize(0, 0);
       cache.renderZoom = 0.0;
       continue;
     }
-    if (!BlitTextureToCache(offscreenRenderer->GetRenderedTexture(),
-                            renderSizeWx, cache)) {
+    if (!BlitTextureToCache(renderedTexture, renderSizeWx, cache)) {
       ClearCachedTexture(cache);
       cache.textureSize = wxSize(0, 0);
       cache.renderZoom = 0.0;

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -154,6 +154,8 @@ private:
                         bool updatePosition);
   void InitGL();
   void RebuildCachedTexture();
+  bool BlitTextureToCache(unsigned int sourceTexture, const wxSize &sourceSize,
+                          ViewCache &cache);
   void ClearCachedTexture();
   void ClearCachedTexture(ViewCache &cache);
   void ClearCachedTexture(LegendCache &cache);
@@ -250,6 +252,7 @@ private:
   int selectedElementId = -1;
   wxGLContext *glContext_ = nullptr;
   bool glInitialized_ = false;
+  unsigned int textureCopyFbo_ = 0;
   bool renderDirty = true;
   bool renderPending = false;
   std::unordered_map<int, ViewCache> viewCaches_;

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -17,6 +17,7 @@
  */
 #pragma once
 
+#include <GL/glew.h>
 #include <memory>
 #include <optional>
 #include <unordered_map>

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -23,6 +23,7 @@
 #include <unordered_map>
 #include <utility>
 #include <wx/glcanvas.h>
+#include <wx/timer.h>
 #include <wx/wx.h>
 #include "layouts/LayoutCollection.h"
 #include "canvas2d.h"
@@ -121,6 +122,7 @@ private:
   void OnDeleteImage(wxCommandEvent &event);
   void OnBringToFront(wxCommandEvent &event);
   void OnSendToBack(wxCommandEvent &event);
+  void OnRenderDebounceTimer(wxTimerEvent &event);
 
   void DrawSelectionHandles(const wxRect &frameRect) const;
   void DrawViewElement(const layouts::Layout2DViewDefinition &view,
@@ -163,6 +165,7 @@ private:
   void ClearCachedTexture(TextCache &cache);
   void ClearCachedTexture(ImageCache &cache);
   void RequestRenderRebuild();
+  bool HasDirtyCaches() const;
   void InvalidateRenderIfFrameChanged();
   void EmitEditViewRequest();
   bool SelectElementAtPosition(const wxPoint &pos);
@@ -255,6 +258,7 @@ private:
   unsigned int textureCopyFbo_ = 0;
   bool renderDirty = true;
   bool renderPending = false;
+  wxTimer renderDebounceTimer_;
   std::unordered_map<int, ViewCache> viewCaches_;
   std::unordered_map<int, LegendCache> legendCaches_;
   std::unordered_map<int, EventTableCache> eventTableCaches_;

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -66,6 +66,8 @@ private:
     wxSize textureSize{0, 0};
     double renderZoom = 0.0;
     bool renderDirty = true;
+    bool renderPending = false;
+    size_t renderRequestToken = 0;
   };
 
   struct LegendCache {
@@ -156,6 +158,10 @@ private:
                         bool updatePosition);
   void InitGL();
   void RebuildCachedTexture();
+  size_t BuildViewRenderToken(int viewId, int version, double renderZoom,
+                              const wxSize &size) const;
+  void OnViewRenderReady(int viewId, size_t renderToken, unsigned int texture,
+                         const wxSize &size, double renderZoom);
   bool BlitTextureToCache(unsigned int sourceTexture, const wxSize &sourceSize,
                           ViewCache &cache);
   void ClearCachedTexture();

--- a/gui/layoutviewerpanel_eventtable.cpp
+++ b/gui/layoutviewerpanel_eventtable.cpp
@@ -21,6 +21,7 @@
 #include <array>
 #include <functional>
 
+#include <GL/glew.h>
 #include <GL/gl.h>
 
 #include "layouteventtabledialog.h"

--- a/gui/layoutviewerpanel_image.cpp
+++ b/gui/layoutviewerpanel_image.cpp
@@ -23,6 +23,7 @@
 #include <filesystem>
 #include <functional>
 
+#include <GL/glew.h>
 #include <GL/gl.h>
 
 #include "layoutimageutils.h"

--- a/gui/layoutviewerpanel_legend.cpp
+++ b/gui/layoutviewerpanel_legend.cpp
@@ -25,6 +25,7 @@
 #include <map>
 #include <vector>
 
+#include <GL/glew.h>
 #include <GL/gl.h>
 
 #include "configmanager.h"

--- a/gui/layoutviewerpanel_text.cpp
+++ b/gui/layoutviewerpanel_text.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <functional>
 
+#include <GL/glew.h>
 #include <GL/gl.h>
 
 #include <wx/log.h>

--- a/gui/layoutviewerpanel_view.cpp
+++ b/gui/layoutviewerpanel_view.cpp
@@ -172,10 +172,14 @@ void LayoutViewerPanel::DrawViewElement(
         fallbackViewportHeight > 0) {
       offscreenRenderer->SetViewportSize(
           wxSize(fallbackViewportWidth, fallbackViewportHeight));
-      offscreenRenderer->PrepareForCapture();
     }
     auto stateGuard = std::make_shared<viewer2d::ScopedViewer2DState>(
         capturePanel, nullptr, cfg, layoutState, nullptr, nullptr, false);
+    if (offscreenRenderer && fallbackViewportWidth > 0 &&
+        fallbackViewportHeight > 0) {
+      offscreenRenderer->PrepareForCapture(
+          wxSize(fallbackViewportWidth, fallbackViewportHeight));
+    }
     capturePanel->CaptureFrameNow(
         [this, viewId, stateGuard, fallbackViewportWidth, fallbackViewportHeight,
          capturePanel](CommandBuffer buffer, Viewer2DViewState state) {

--- a/gui/layoutviewerpanel_view.cpp
+++ b/gui/layoutviewerpanel_view.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <memory>
 
+#include <GL/glew.h>
 #include <GL/gl.h>
 
 #include "configmanager.h"

--- a/gui/mainwindow_print.cpp
+++ b/gui/mainwindow_print.cpp
@@ -172,7 +172,7 @@ void MainWindow::OnPrintViewer2D(wxCommandEvent &WXUNUSED(event)) {
   if (viewport2DPanel)
     viewport2DPanel->SaveViewToConfig();
   offscreenRenderer->SetViewportSize(captureSize);
-  offscreenRenderer->PrepareForCapture();
+  offscreenRenderer->PrepareForCapture(captureSize);
 
   capturePanel->CaptureFrameNow(
       [this, capturePanel, opts, outputPath, outputPathDisplay](
@@ -426,15 +426,15 @@ void MainWindow::OnPrintLayout(wxCommandEvent &WXUNUSED(event)) {
         const int viewportHeight =
             fallbackViewportHeight > 0 ? fallbackViewportHeight : 900;
 
-        if (offscreenRenderer && viewportWidth > 0 && viewportHeight > 0) {
-          offscreenRenderer->SetViewportSize(
-              wxSize(viewportWidth, viewportHeight));
-          offscreenRenderer->PrepareForCapture();
-        }
-
         auto stateGuard = std::make_shared<viewer2d::ScopedViewer2DState>(
             capturePanel, nullptr, *cfgPtr, layoutState, nullptr, nullptr,
             false);
+        if (offscreenRenderer && viewportWidth > 0 && viewportHeight > 0) {
+          offscreenRenderer->SetViewportSize(
+              wxSize(viewportWidth, viewportHeight));
+          offscreenRenderer->PrepareForCapture(
+              wxSize(viewportWidth, viewportHeight));
+        }
         capturePanel->CaptureFrameNow(
             [captureNext, exportViews, view, viewportWidth, viewportHeight,
              capturePanel, scaleX, scaleY,

--- a/viewer2d/canvas2d.cpp
+++ b/viewer2d/canvas2d.cpp
@@ -26,6 +26,7 @@
 #include <windows.h>
 #endif
 
+#include <GL/glew.h>
 #include <GL/gl.h>
 #include <wx/glcanvas.h>
 #include <algorithm>

--- a/viewer2d/viewer2doffscreenrenderer.cpp
+++ b/viewer2d/viewer2doffscreenrenderer.cpp
@@ -23,17 +23,19 @@ constexpr int kDefaultViewportHeight = 900;
 }
 
 Viewer2DOffscreenRenderer::Viewer2DOffscreenRenderer(wxWindow *parent) {
-  host_ = new wxPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(1, 1));
-  host_->Hide();
-
-  panel_ = new Viewer2DPanel(host_, true, false, false);
-  panel_->SetSize(wxSize(kDefaultViewportWidth, kDefaultViewportHeight));
-  panel_->SetClientSize(wxSize(kDefaultViewportWidth, kDefaultViewportHeight));
-  panel_->LoadViewFromConfig();
-  panel_->UpdateScene(true);
+  parent_ = parent;
+  CreatePanel();
 }
 
-Viewer2DOffscreenRenderer::~Viewer2DOffscreenRenderer() = default;
+Viewer2DOffscreenRenderer::~Viewer2DOffscreenRenderer() { DestroyPanel(); }
+
+void Viewer2DOffscreenRenderer::SetSharedContext(wxGLContext *sharedContext) {
+  if (sharedContext_ == sharedContext)
+    return;
+  sharedContext_ = sharedContext;
+  DestroyPanel();
+  CreatePanel();
+}
 
 void Viewer2DOffscreenRenderer::SetViewportSize(const wxSize &size) {
   if (!panel_)
@@ -49,4 +51,28 @@ void Viewer2DOffscreenRenderer::PrepareForCapture() {
     return;
   panel_->LoadViewFromConfig();
   panel_->UpdateScene(true);
+}
+
+void Viewer2DOffscreenRenderer::CreatePanel() {
+  if (!parent_)
+    return;
+  host_ = new wxPanel(parent_, wxID_ANY, wxDefaultPosition, wxSize(1, 1));
+  host_->Hide();
+
+  panel_ = new Viewer2DPanel(host_, true, false, false, sharedContext_);
+  panel_->SetSize(wxSize(kDefaultViewportWidth, kDefaultViewportHeight));
+  panel_->SetClientSize(wxSize(kDefaultViewportWidth, kDefaultViewportHeight));
+  panel_->LoadViewFromConfig();
+  panel_->UpdateScene(true);
+}
+
+void Viewer2DOffscreenRenderer::DestroyPanel() {
+  if (panel_) {
+    panel_->Destroy();
+    panel_ = nullptr;
+  }
+  if (host_) {
+    host_->Destroy();
+    host_ = nullptr;
+  }
 }

--- a/viewer2d/viewer2doffscreenrenderer.h
+++ b/viewer2d/viewer2doffscreenrenderer.h
@@ -27,10 +27,15 @@ public:
   ~Viewer2DOffscreenRenderer();
 
   Viewer2DPanel *GetPanel() const { return panel_; }
+  void SetSharedContext(wxGLContext *sharedContext);
   void SetViewportSize(const wxSize &size);
   void PrepareForCapture();
 
 private:
+  void CreatePanel();
+  void DestroyPanel();
+  wxWindow *parent_ = nullptr;
   wxPanel *host_ = nullptr;
   Viewer2DPanel *panel_ = nullptr;
+  wxGLContext *sharedContext_ = nullptr;
 };

--- a/viewer2d/viewer2doffscreenrenderer.h
+++ b/viewer2d/viewer2doffscreenrenderer.h
@@ -30,12 +30,21 @@ public:
   void SetSharedContext(wxGLContext *sharedContext);
   void SetViewportSize(const wxSize &size);
   void PrepareForCapture();
+  bool RenderToTexture(const wxSize &size);
+  unsigned int GetRenderedTexture() const { return renderedTexture_; }
+  wxSize GetRenderedTextureSize() const { return renderedTextureSize_; }
 
 private:
   void CreatePanel();
   void DestroyPanel();
+  void EnsureOffscreenTarget(const wxSize &size);
+  void DestroyOffscreenTarget();
   wxWindow *parent_ = nullptr;
   wxPanel *host_ = nullptr;
   Viewer2DPanel *panel_ = nullptr;
   wxGLContext *sharedContext_ = nullptr;
+  unsigned int renderedTexture_ = 0;
+  unsigned int renderedFbo_ = 0;
+  unsigned int renderedDepthRbo_ = 0;
+  wxSize renderedTextureSize_{0, 0};
 };

--- a/viewer2d/viewer2doffscreenrenderer.h
+++ b/viewer2d/viewer2doffscreenrenderer.h
@@ -29,22 +29,22 @@ public:
   Viewer2DPanel *GetPanel() const { return panel_; }
   void SetSharedContext(wxGLContext *sharedContext);
   void SetViewportSize(const wxSize &size);
-  void PrepareForCapture();
+  void PrepareForCapture(const wxSize &size);
   bool RenderToTexture(const wxSize &size);
-  unsigned int GetRenderedTexture() const { return renderedTexture_; }
-  wxSize GetRenderedTextureSize() const { return renderedTextureSize_; }
+  unsigned int GetRenderedTexture() const { return colorTex_; }
+  wxSize GetRenderedTextureSize() const { return renderSize_; }
 
 private:
   void CreatePanel();
   void DestroyPanel();
-  void EnsureOffscreenTarget(const wxSize &size);
-  void DestroyOffscreenTarget();
+  void EnsureRenderTarget(const wxSize &size);
+  void DestroyRenderTarget();
   wxWindow *parent_ = nullptr;
   wxPanel *host_ = nullptr;
   Viewer2DPanel *panel_ = nullptr;
   wxGLContext *sharedContext_ = nullptr;
-  unsigned int renderedTexture_ = 0;
-  unsigned int renderedFbo_ = 0;
-  unsigned int renderedDepthRbo_ = 0;
-  wxSize renderedTextureSize_{0, 0};
+  unsigned int fbo_ = 0;
+  unsigned int colorTex_ = 0;
+  unsigned int depthRb_ = 0;
+  wxSize renderSize_{0, 0};
 };

--- a/viewer2d/viewer2doffscreenrenderer.h
+++ b/viewer2d/viewer2doffscreenrenderer.h
@@ -18,6 +18,13 @@
 #pragma once
 
 #include "viewer2dpanel.h"
+#include <condition_variable>
+#include <deque>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <unordered_map>
 #include <wx/panel.h>
 #include <wx/window.h>
 
@@ -26,23 +33,66 @@ public:
   explicit Viewer2DOffscreenRenderer(wxWindow *parent);
   ~Viewer2DOffscreenRenderer();
 
+  struct PanelLock {
+    std::unique_lock<std::mutex> lock;
+    Viewer2DPanel *panel = nullptr;
+  };
+
+  struct RenderResult {
+    int viewId = -1;
+    size_t renderToken = 0;
+    double renderZoom = 0.0;
+    wxSize size{0, 0};
+    unsigned int texture = 0;
+    bool success = false;
+  };
+
   Viewer2DPanel *GetPanel() const { return panel_; }
+  PanelLock AcquirePanel();
   void SetSharedContext(wxGLContext *sharedContext);
   void SetViewportSize(const wxSize &size);
   void PrepareForCapture(const wxSize &size);
   bool RenderToTexture(const wxSize &size);
   unsigned int GetRenderedTexture() const { return colorTex_; }
   wxSize GetRenderedTextureSize() const { return renderSize_; }
+  void EnqueueViewRender(
+      int viewId, const viewer2d::Viewer2DState &renderState,
+      const wxSize &size, size_t renderToken, double renderZoom,
+      std::function<void(const RenderResult &)> callback);
 
 private:
+  struct RenderJob {
+    int viewId = -1;
+    viewer2d::Viewer2DState renderState;
+    wxSize size{0, 0};
+    size_t renderToken = 0;
+    double renderZoom = 0.0;
+    std::function<void(const RenderResult &)> callback;
+  };
+
   void CreatePanel();
   void DestroyPanel();
+  void StartWorker();
+  void StopWorker();
+  void WorkerLoop();
+  void EnsureWorkerContext();
+  RenderResult RenderJobToTexture(const RenderJob &job);
+  void PrepareForCaptureLocked(const wxSize &size);
   void EnsureRenderTarget(const wxSize &size);
   void DestroyRenderTarget();
   wxWindow *parent_ = nullptr;
   wxPanel *host_ = nullptr;
   Viewer2DPanel *panel_ = nullptr;
   wxGLContext *sharedContext_ = nullptr;
+  wxGLContext *workerSharedContext_ = nullptr;
+  std::unique_ptr<wxGLContext> workerContext_;
+  std::mutex panelMutex_;
+  std::mutex jobMutex_;
+  std::condition_variable jobCv_;
+  std::unordered_map<int, RenderJob> jobQueue_;
+  std::deque<int> jobOrder_;
+  bool workerStop_ = false;
+  std::thread workerThread_;
   unsigned int fbo_ = 0;
   unsigned int colorTex_ = 0;
   unsigned int depthRb_ = 0;

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -408,6 +408,8 @@ Viewer2DPanel::GetBottomSymbolCacheSnapshot() const {
   return m_controller.GetBottomSymbolCacheSnapshot();
 }
 
+void Viewer2DPanel::EnsureGLReady() { InitGL(); }
+
 void Viewer2DPanel::InitGL() {
   if (!IsShownOnScreen() && !m_forceOffscreenRender &&
       !m_allowOffscreenRender) {
@@ -639,6 +641,27 @@ bool Viewer2DPanel::RenderToTexture(unsigned int &texture,
   if (!useExternalTexture)
     texture = targetTexture;
   framebuffer = m_offscreenFbo;
+
+  m_forceOffscreenRender = previousForce;
+  return true;
+}
+
+bool Viewer2DPanel::RenderToFramebuffer(unsigned int framebuffer) {
+  int w = 0;
+  int h = 0;
+  GetClientSize(&w, &h);
+  if (w <= 0 || h <= 0)
+    return false;
+
+  bool previousForce = m_forceOffscreenRender;
+  m_forceOffscreenRender = true;
+  InitGL();
+
+  GLint previousFbo = 0;
+  glGetIntegerv(GL_FRAMEBUFFER_BINDING, &previousFbo);
+  glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
+  RenderInternal(false);
+  glBindFramebuffer(GL_FRAMEBUFFER, static_cast<GLuint>(previousFbo));
 
   m_forceOffscreenRender = previousForce;
   return true;

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -701,6 +701,8 @@ void Viewer2DPanel::EnsureOffscreenTarget(int width, int height) {
 void Viewer2DPanel::DestroyOffscreenTarget() {
   if (!m_glContext)
     return;
+  if (!IsShownOnScreen())
+    return;
   SetCurrent(*m_glContext);
   if (m_offscreenDepthRbo != 0) {
     glDeleteRenderbuffers(1, &m_offscreenDepthRbo);

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -646,6 +646,31 @@ bool Viewer2DPanel::RenderToTexture(unsigned int &texture,
   return true;
 }
 
+bool Viewer2DPanel::RenderToTexture(unsigned int framebuffer,
+                                    const wxSize &size) {
+  if (size.GetWidth() <= 0 || size.GetHeight() <= 0)
+    return false;
+
+  bool previousForce = m_forceOffscreenRender;
+  m_forceOffscreenRender = true;
+  InitGL();
+
+  GLint previousFbo = 0;
+  glGetIntegerv(GL_FRAMEBUFFER_BINDING, &previousFbo);
+  GLint previousViewport[4] = {0, 0, 0, 0};
+  glGetIntegerv(GL_VIEWPORT, previousViewport);
+
+  glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
+  glViewport(0, 0, size.GetWidth(), size.GetHeight());
+  RenderInternal(false);
+  glBindFramebuffer(GL_FRAMEBUFFER, static_cast<GLuint>(previousFbo));
+  glViewport(previousViewport[0], previousViewport[1], previousViewport[2],
+             previousViewport[3]);
+
+  m_forceOffscreenRender = previousForce;
+  return true;
+}
+
 bool Viewer2DPanel::RenderToFramebuffer(unsigned int framebuffer) {
   int w = 0;
   int h = 0;

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -103,6 +103,7 @@ public:
 
   bool RenderToTexture(unsigned int &texture, unsigned int &framebuffer,
                        int &width, int &height);
+  bool RenderToTexture(unsigned int framebuffer, const wxSize &size);
   bool RenderToFramebuffer(unsigned int framebuffer);
 
   // Accessor for the last recorded set of drawing commands. The buffer is

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -99,8 +99,6 @@ public:
       bool useSimplifiedFootprints = false,
       bool includeGridInCapture = true);
 
-  bool RenderToRGBA(std::vector<unsigned char> &pixels, int &width,
-                    int &height);
   bool RenderToTexture(unsigned int &texture, unsigned int &framebuffer,
                        int &width, int &height);
 

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -24,6 +24,8 @@
 
 #pragma once
 
+#include <GL/glew.h>
+
 #include "canvas2d.h"
 #include "viewer3dcontroller.h"
 #include <wx/glcanvas.h>

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -100,6 +100,8 @@ public:
       bool includeGridInCapture = true);
 
   void EnsureGLReady();
+  void SetExternalContext(wxGLContext *context);
+  void SetRenderViewportOverride(std::optional<wxSize> size);
 
   bool RenderToTexture(unsigned int &texture, unsigned int &framebuffer,
                        int &width, int &height);
@@ -195,6 +197,8 @@ private:
   bool m_hasHover = false;
   bool m_enableSelection = true;
   std::string m_hoverUuid;
+  wxGLContext *m_externalContext = nullptr;
+  std::optional<wxSize> m_renderViewportOverride;
 
   bool m_captureNextFrame = false;
   bool m_useSimplifiedFootprints = false;

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -53,7 +53,8 @@ class Viewer2DPanel : public wxGLCanvas {
 public:
   explicit Viewer2DPanel(wxWindow *parent, bool allowOffscreenRender = false,
                          bool persistViewState = true,
-                         bool enableSelection = true);
+                         bool enableSelection = true,
+                         wxGLContext *sharedContext = nullptr);
   ~Viewer2DPanel();
 
   static Viewer2DPanel *Instance();
@@ -98,6 +99,8 @@ public:
 
   bool RenderToRGBA(std::vector<unsigned char> &pixels, int &width,
                     int &height);
+  bool RenderToTexture(unsigned int &texture, unsigned int &framebuffer,
+                       int &width, int &height);
 
   // Accessor for the last recorded set of drawing commands. The buffer is
   // cleared and re-populated on every requested capture.
@@ -149,6 +152,8 @@ private:
   void StopDragTableUpdates();
   void StartDragTableUpdateWorker();
   void StopDragTableUpdateWorker();
+  void EnsureOffscreenTarget(int width, int height);
+  void DestroyOffscreenTarget();
 
   struct DragTablePositionSnapshot {
     std::string uuid;
@@ -207,6 +212,11 @@ private:
 
   wxGLContext *m_glContext = nullptr;
   bool m_glInitialized = false;
+  unsigned int m_offscreenTexture = 0;
+  unsigned int m_offscreenFbo = 0;
+  unsigned int m_offscreenDepthRbo = 0;
+  int m_offscreenWidth = 0;
+  int m_offscreenHeight = 0;
   Viewer3DController m_controller;
   Viewer2DRenderMode m_renderMode = Viewer2DRenderMode::White;
   Viewer2DView m_view = Viewer2DView::Top;

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -99,8 +99,11 @@ public:
       bool useSimplifiedFootprints = false,
       bool includeGridInCapture = true);
 
+  void EnsureGLReady();
+
   bool RenderToTexture(unsigned int &texture, unsigned int &framebuffer,
                        int &width, int &height);
+  bool RenderToFramebuffer(unsigned int framebuffer);
 
   // Accessor for the last recorded set of drawing commands. The buffer is
   // cleared and re-populated on every requested capture.

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <GL/glew.h>
 #include <wx/glcanvas.h>
 #include "viewer3dcamera.h"
 #include "viewer3dcontroller.h"


### PR DESCRIPTION
### Motivation
- Create a shared OpenGL context on a worker thread to perform offscreen captures without blocking the UI and allow per-view capture queuing. 
- Ensure layout view captures can be requested concurrently per-view (by id) and notify the UI when textures are ready so cached textures can be updated without visual regressions.

### Description
- Add `SetExternalContext` and `SetRenderViewportOverride` to `Viewer2DPanel` and make `InitGL` / `RenderInternal` respect an externally provided GL context and viewport override so a worker can drive the panel offscreen. 
- Implement `Viewer2DOffscreenRenderer` worker thread, per-view `RenderJob` queue, `PanelLock` for synchronized panel access, `EnqueueViewRender`, `RenderJobToTexture` and worker context management to render captures on a separate thread and report `RenderResult` back to the UI. 
- Update `LayoutViewerPanel` to build per-view render tokens (`BuildViewRenderToken`), enqueue view renders in `RebuildCachedTexture`, track `renderPending`/request tokens and apply incoming textures in `OnViewRenderReady`. 
- Synchronize offscreen panel access across layout and print capture flows (use `AcquirePanel`/`PanelLock`), and adjust `LayoutViewerPanel::DrawViewElement` and printing paths to use the offscreen panel safely.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697738c93f808324af5cc09683e1ea14)