### PR TITLE
Avoid redundant 2D offscreen reloads by hashing config+scene

### DIFF
--- a/viewer2d/viewer2doffscreenrenderer.h
+++ b/viewer2d/viewer2doffscreenrenderer.h
@@ -47,4 +47,5 @@ private:
   unsigned int colorTex_ = 0;
   unsigned int depthRb_ = 0;
   wxSize renderSize_{0, 0};
+  size_t lastStateHash_ = 0;
 };


### PR DESCRIPTION
### Motivation
- Reduce unnecessary work during offscreen 2D captures by avoiding repeated calls to `LoadViewFromConfig`/`UpdateScene` when the view/config/scene haven't changed.
- Keep the visual output identical to the current flow while improving performance for repeated captures.

### Description
- Added deterministic hashing of viewer state and scene contents by implementing `HashViewer2DState`, `HashScene`, `HashViewer2DStateWithScene`, `HashMatrix`, `SortedEntries` and helper hash combiners in `viewer2doffscreenrenderer.cpp` to capture meaningful state changes.
- Use `viewer2d::CaptureState(nullptr, cfg)` + `ConfigManager::Get().GetScene()` as the source of truth for the computed hash and compare it against a stored `lastStateHash_` member added to `Viewer2DOffscreenRenderer` (field in `viewer2doffscreenrenderer.h`).
- Only call `panel_->LoadViewFromConfig()` and `panel_->UpdateScene(true)` inside `PrepareForCapture` when the newly computed hash differs from `lastStateHash_`, and update `lastStateHash_` accordingly; also initialize/reset `lastStateHash_` in `CreatePanel`/`DestroyPanel`.
- Hashing uses sorted map entries and includes relevant fields (camera, render options, layers and scene objects/fixtures/trusses/supports/layers/positions/symdefs) to ensure deterministic detection of meaningful changes.

### Testing
- No automated tests were run as part of this change (no test suite executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69773d0f74fc8324b15b9014ffe1077b)