### PR TITLE
Async 2D capture worker and offscreen renderer pool

### DIFF
--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -33,8 +33,6 @@
 
 wxDECLARE_EVENT(EVT_LAYOUT_VIEW_EDIT, wxCommandEvent);
 
-class Viewer2DOffscreenRenderer;
-
 class LayoutViewerPanel : public wxGLCanvas {
 public:
   explicit LayoutViewerPanel(wxWindow *parent);
@@ -56,6 +54,7 @@ private:
   struct ViewCache {
     int captureVersion = -1;
     bool captureInProgress = false;
+    bool captureDirty = false;
     bool hasCapture = false;
     CommandBuffer buffer;
     Viewer2DViewState viewState;
@@ -127,7 +126,6 @@ private:
   void DrawSelectionHandles(const wxRect &frameRect) const;
   void DrawViewElement(const layouts::Layout2DViewDefinition &view,
                        Viewer2DPanel *capturePanel,
-                       Viewer2DOffscreenRenderer *offscreenRenderer,
                        int activeViewId);
   void DrawLegendElement(const layouts::LayoutLegendDefinition &legend,
                          int activeLegendId);
@@ -251,7 +249,6 @@ private:
   wxPoint dragStartPos{0, 0};
   layouts::Layout2DViewFrame dragStartFrame;
   int layoutVersion = 0;
-  bool captureInProgress = false;
   SelectedElementType selectedElementType = SelectedElementType::None;
   int selectedElementId = -1;
   wxGLContext *glContext_ = nullptr;
@@ -259,6 +256,7 @@ private:
   unsigned int textureCopyFbo_ = 0;
   bool renderDirty = true;
   bool renderPending = false;
+  bool legendCaptureInProgress = false;
   wxTimer renderDebounceTimer_;
   std::unordered_map<int, ViewCache> viewCaches_;
   std::unordered_map<int, LegendCache> legendCaches_;

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -375,12 +375,12 @@ Viewer2DPanel *MainWindow::GetLayoutCapturePanel() const {
   return viewport2DPanel;
 }
 
-Viewer2DOffscreenRenderer *MainWindow::GetOffscreenRenderer() {
-  if (!offscreenViewer2DRenderer) {
-    offscreenViewer2DRenderer =
-        std::make_unique<Viewer2DOffscreenRenderer>(this);
+Viewer2DOffscreenRenderer *MainWindow::GetOffscreenRendererForView(int viewId) {
+  if (!offscreenViewer2DRendererPool) {
+    offscreenViewer2DRendererPool =
+        std::make_unique<Viewer2DOffscreenRendererPool>(this);
   }
-  return offscreenViewer2DRenderer.get();
+  return offscreenViewer2DRendererPool->GetRendererForView(viewId);
 }
 
 bool MainWindow::IsLayout2DViewEditing() const { return layout2DViewEditing; }

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -37,6 +37,7 @@ class Viewer3DPanel;
 class Viewer2DPanel;
 class Viewer2DRenderPanel;
 class Viewer2DOffscreenRenderer;
+class Viewer2DOffscreenRendererPool;
 class ConsolePanel;
 class LayerPanel;
 class LayoutPanel;
@@ -60,7 +61,7 @@ public:
   void EnableShortcuts(bool enable);
   void Ensure2DViewportAvailable();
   Viewer2DPanel *GetLayoutCapturePanel() const;
-  Viewer2DOffscreenRenderer *GetOffscreenRenderer();
+  Viewer2DOffscreenRenderer *GetOffscreenRendererForView(int viewId);
   bool IsLayout2DViewEditing() const;
   void PersistLayout2DViewState();
   void RestoreLayout2DViewState(int viewId);
@@ -84,7 +85,7 @@ private:
   Viewer3DPanel *viewportPanel = nullptr;
   Viewer2DPanel *viewport2DPanel = nullptr;
   Viewer2DRenderPanel *viewport2DRenderPanel = nullptr;
-  std::unique_ptr<Viewer2DOffscreenRenderer> offscreenViewer2DRenderer;
+  std::unique_ptr<Viewer2DOffscreenRendererPool> offscreenViewer2DRendererPool;
   ConsolePanel *consolePanel = nullptr;
   LayerPanel *layerPanel = nullptr;
   LayoutPanel *layoutPanel = nullptr;

--- a/gui/mainwindow_print.cpp
+++ b/gui/mainwindow_print.cpp
@@ -120,7 +120,8 @@ std::vector<LayoutLegendItem> BuildLayoutLegendItems() {
 }
 
 void MainWindow::OnPrintViewer2D(wxCommandEvent &WXUNUSED(event)) {
-  Viewer2DOffscreenRenderer *offscreenRenderer = GetOffscreenRenderer();
+  Viewer2DOffscreenRenderer *offscreenRenderer =
+      GetOffscreenRendererForView(-1);
   Viewer2DPanel *capturePanel =
       offscreenRenderer ? offscreenRenderer->GetPanel() : nullptr;
   if (!capturePanel) {
@@ -256,7 +257,8 @@ void MainWindow::OnPrintLayout(wxCommandEvent &WXUNUSED(event)) {
     return;
   }
 
-  Viewer2DOffscreenRenderer *offscreenRenderer = GetOffscreenRenderer();
+  Viewer2DOffscreenRenderer *offscreenRenderer =
+      GetOffscreenRendererForView(-1);
   Viewer2DPanel *capturePanel =
       offscreenRenderer ? offscreenRenderer->GetPanel() : nullptr;
   if (!capturePanel) {

--- a/viewer2d/viewer2doffscreenrenderer.h
+++ b/viewer2d/viewer2doffscreenrenderer.h
@@ -18,6 +18,9 @@
 #pragma once
 
 #include "viewer2dpanel.h"
+#include <memory>
+#include <unordered_map>
+#include <vector>
 #include <wx/panel.h>
 #include <wx/window.h>
 
@@ -48,4 +51,18 @@ private:
   unsigned int depthRb_ = 0;
   wxSize renderSize_{0, 0};
   size_t lastStateHash_ = 0;
+};
+
+class Viewer2DOffscreenRendererPool {
+public:
+  explicit Viewer2DOffscreenRendererPool(wxWindow *parent);
+
+  Viewer2DOffscreenRenderer *GetRendererForView(int viewId);
+  void SetSharedContext(wxGLContext *sharedContext);
+
+private:
+  wxWindow *parent_ = nullptr;
+  wxGLContext *sharedContext_ = nullptr;
+  std::vector<std::unique_ptr<Viewer2DOffscreenRenderer>> renderers_;
+  std::unordered_map<int, size_t> rendererIndexByView_;
 };

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -194,12 +194,14 @@ Viewer2DPanel::Viewer2DPanel(wxWindow *parent, bool allowOffscreenRender,
   m_controller.SetSelectionOutlineEnabled(m_enableSelection);
   m_glContext = new wxGLContext(this, sharedContext);
   StartDragTableUpdateWorker();
+  StartAsyncCaptureWorker();
 }
 
 Viewer2DPanel::~Viewer2DPanel() {
   if (g_instance == this)
     g_instance = nullptr;
   StopDragTableUpdateWorker();
+  StopAsyncCaptureWorker();
   DestroyOffscreenTarget();
   delete m_glContext;
 }
@@ -291,6 +293,21 @@ void Viewer2DPanel::RequestFrameCapture() { m_captureNextFrame = true; }
 void Viewer2DPanel::CaptureFrameAsync(
     std::function<void(CommandBuffer, Viewer2DViewState)> callback,
     bool useSimplifiedFootprints, bool includeGridInCapture) {
+  if (!callback)
+    return;
+  {
+    std::lock_guard<std::mutex> lock(m_asyncCaptureMutex);
+    m_asyncCaptureCallback = std::move(callback);
+    m_asyncCaptureUseSimplifiedFootprints = useSimplifiedFootprints;
+    m_asyncCaptureIncludeGrid = includeGridInCapture;
+    m_asyncCaptureQueued = true;
+  }
+  m_asyncCaptureCv.notify_one();
+}
+
+void Viewer2DPanel::CaptureFrameNow(
+    std::function<void(CommandBuffer, Viewer2DViewState)> callback,
+    bool useSimplifiedFootprints, bool includeGridInCapture) {
   m_captureCallback = std::move(callback);
   m_useSimplifiedFootprints = useSimplifiedFootprints;
   if (!m_useSimplifiedFootprints &&
@@ -301,14 +318,6 @@ void Viewer2DPanel::CaptureFrameAsync(
   }
   m_captureIncludeGrid = includeGridInCapture;
   RequestFrameCapture();
-  Refresh();
-}
-
-void Viewer2DPanel::CaptureFrameNow(
-    std::function<void(CommandBuffer, Viewer2DViewState)> callback,
-    bool useSimplifiedFootprints, bool includeGridInCapture) {
-  CaptureFrameAsync(std::move(callback), useSimplifiedFootprints,
-                    includeGridInCapture);
   if (m_allowOffscreenRender) {
     m_forceOffscreenRender = true;
     InitGL();
@@ -429,6 +438,14 @@ void Viewer2DPanel::InitGL() {
 void Viewer2DPanel::Render() { RenderInternal(true); }
 
 void Viewer2DPanel::RenderInternal(bool swapBuffers) {
+  std::unique_lock<std::recursive_mutex> renderLock(m_renderMutex,
+                                                    std::defer_lock);
+  if (swapBuffers) {
+    if (!renderLock.try_lock())
+      return;
+  } else {
+    renderLock.lock();
+  }
   int w, h;
   GetClientSize(&w, &h);
 
@@ -607,6 +624,7 @@ void Viewer2DPanel::RenderInternal(bool swapBuffers) {
 bool Viewer2DPanel::RenderToTexture(unsigned int &texture,
                                     unsigned int &framebuffer, int &width,
                                     int &height) {
+  std::lock_guard<std::recursive_mutex> renderLock(m_renderMutex);
   int w = 0;
   int h = 0;
   GetClientSize(&w, &h);
@@ -648,6 +666,7 @@ bool Viewer2DPanel::RenderToTexture(unsigned int &texture,
 
 bool Viewer2DPanel::RenderToTexture(unsigned int framebuffer,
                                     const wxSize &size) {
+  std::lock_guard<std::recursive_mutex> renderLock(m_renderMutex);
   if (size.GetWidth() <= 0 || size.GetHeight() <= 0)
     return false;
 
@@ -672,6 +691,7 @@ bool Viewer2DPanel::RenderToTexture(unsigned int framebuffer,
 }
 
 bool Viewer2DPanel::RenderToFramebuffer(unsigned int framebuffer) {
+  std::lock_guard<std::recursive_mutex> renderLock(m_renderMutex);
   int w = 0;
   int h = 0;
   GetClientSize(&w, &h);
@@ -1152,6 +1172,108 @@ void Viewer2DPanel::StopDragTableUpdateWorker() {
   m_dragTableUpdateCv.notify_one();
   if (m_dragTableUpdateWorker.joinable())
     m_dragTableUpdateWorker.join();
+}
+
+void Viewer2DPanel::StartAsyncCaptureWorker() {
+  m_asyncCaptureWorker = std::thread([this]() { ProcessAsyncCaptureRequests(); });
+}
+
+void Viewer2DPanel::StopAsyncCaptureWorker() {
+  {
+    std::lock_guard<std::mutex> lock(m_asyncCaptureMutex);
+    m_asyncCaptureWorkerStop = true;
+    m_asyncCaptureQueued = true;
+  }
+  m_asyncCaptureCv.notify_one();
+  if (m_asyncCaptureWorker.joinable())
+    m_asyncCaptureWorker.join();
+}
+
+void Viewer2DPanel::ProcessAsyncCaptureRequests() {
+  while (true) {
+    std::function<void(CommandBuffer, Viewer2DViewState)> callback;
+    bool useSimplifiedFootprints = false;
+    bool includeGridInCapture = true;
+    {
+      std::unique_lock<std::mutex> lock(m_asyncCaptureMutex);
+      m_asyncCaptureCv.wait(lock, [this]() {
+        return m_asyncCaptureWorkerStop || m_asyncCaptureQueued;
+      });
+      if (m_asyncCaptureWorkerStop)
+        break;
+      callback = m_asyncCaptureCallback;
+      useSimplifiedFootprints = m_asyncCaptureUseSimplifiedFootprints;
+      includeGridInCapture = m_asyncCaptureIncludeGrid;
+      m_asyncCaptureQueued = false;
+    }
+
+    if (callback) {
+      PerformAsyncCapture(callback, useSimplifiedFootprints,
+                          includeGridInCapture);
+    }
+
+  }
+}
+
+void Viewer2DPanel::PerformAsyncCapture(
+    const std::function<void(CommandBuffer, Viewer2DViewState)> &callback,
+    bool useSimplifiedFootprints, bool includeGridInCapture) {
+  if (!callback)
+    return;
+
+  std::lock_guard<std::recursive_mutex> renderLock(m_renderMutex);
+  bool previousForce = m_forceOffscreenRender;
+  m_forceOffscreenRender = true;
+  InitGL();
+
+  int w = 0;
+  int h = 0;
+  GetClientSize(&w, &h);
+  if (w <= 0 || h <= 0) {
+    m_forceOffscreenRender = previousForce;
+    return;
+  }
+  EnsureOffscreenTarget(w, h);
+
+  CommandBuffer capturedBuffer;
+  Viewer2DViewState capturedState;
+  auto previousCallback = std::move(m_captureCallback);
+
+  m_captureCallback =
+      [&capturedBuffer, &capturedState](CommandBuffer buffer,
+                                        Viewer2DViewState state) {
+        capturedBuffer = std::move(buffer);
+        capturedState = state;
+      };
+  m_useSimplifiedFootprints = useSimplifiedFootprints;
+  if (!m_useSimplifiedFootprints &&
+      (m_view == Viewer2DView::Front || m_view == Viewer2DView::Side)) {
+    m_useSimplifiedFootprints = true;
+  }
+  m_captureIncludeGrid = includeGridInCapture;
+  m_captureNextFrame = true;
+
+  GLint previousFbo = 0;
+  glGetIntegerv(GL_FRAMEBUFFER_BINDING, &previousFbo);
+  glBindFramebuffer(GL_FRAMEBUFFER, m_offscreenFbo);
+  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+                         m_offscreenTexture, 0);
+  glDrawBuffer(GL_COLOR_ATTACHMENT0);
+  RenderInternal(false);
+  glBindFramebuffer(GL_FRAMEBUFFER, static_cast<GLuint>(previousFbo));
+
+  m_captureCallback = std::move(previousCallback);
+  m_forceOffscreenRender = previousForce;
+
+  if (!wxTheApp)
+    return;
+
+  auto bufferPtr =
+      std::make_shared<CommandBuffer>(std::move(capturedBuffer));
+  wxTheApp->CallAfter([callback, bufferPtr,
+                       capturedState]() mutable {
+    callback(std::move(*bufferPtr), capturedState);
+  });
 }
 
 std::vector<Viewer2DPanel::DragTablePositionSnapshot>

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -156,6 +156,12 @@ private:
   void StopDragTableUpdates();
   void StartDragTableUpdateWorker();
   void StopDragTableUpdateWorker();
+  void StartAsyncCaptureWorker();
+  void StopAsyncCaptureWorker();
+  void ProcessAsyncCaptureRequests();
+  void PerformAsyncCapture(
+      const std::function<void(CommandBuffer, Viewer2DViewState)> &callback,
+      bool useSimplifiedFootprints, bool includeGridInCapture);
   void EnsureOffscreenTarget(int width, int height);
   void DestroyOffscreenTarget();
 
@@ -213,6 +219,16 @@ private:
   DragTarget m_dragTableUpdateWorkerTarget = DragTarget::None;
   std::vector<std::string> m_dragTableUpdateUuids;
   std::mutex m_dragTableUpdateSceneMutex;
+  std::thread m_asyncCaptureWorker;
+  std::mutex m_asyncCaptureMutex;
+  std::condition_variable m_asyncCaptureCv;
+  bool m_asyncCaptureWorkerStop = false;
+  bool m_asyncCaptureQueued = false;
+  bool m_asyncCaptureUseSimplifiedFootprints = false;
+  bool m_asyncCaptureIncludeGrid = true;
+  std::function<void(CommandBuffer, Viewer2DViewState)>
+      m_asyncCaptureCallback;
+  std::recursive_mutex m_renderMutex;
 
   wxGLContext *m_glContext = nullptr;
   bool m_glInitialized = false;


### PR DESCRIPTION
### Motivation
- Avoid blocking the UI thread during large 2D frame captures by performing real captures on a worker thread that renders into an FBO and posts results back to the UI thread.
- Allow multiple simultaneous captures by providing per-view offscreen renderer instances (a pool keyed by view id) to remove the single shared renderer bottleneck.
- Prevent overlapping captures for the same view by marking in-progress captures as "dirty" and re-scheduling them when the first finishes.
- Preserve `CaptureFrameNow` for explicit synchronous usages (e.g. printing) while making normal captures asynchronous.

### Description
- Implemented an async capture pipeline in `Viewer2DPanel` by adding `StartAsyncCaptureWorker`, `ProcessAsyncCaptureRequests`, and `PerformAsyncCapture`, plus associated state and synchronization members (`m_asyncCapture*`, `m_asyncCaptureCv`, `m_renderMutex`) and a worker thread that renders to the panel's offscreen FBO and posts the `CommandBuffer` back to the UI thread with `wxTheApp->CallAfter`.
- Changed `CaptureFrameAsync` to enqueue capture requests to the async worker, while `CaptureFrameNow` retains synchronous behavior and still forces an immediate offscreen render when required.
- Added a recursive `m_renderMutex` and guarded `RenderInternal`/`RenderToTexture`/`RenderToFramebuffer` to avoid concurrent GL usage and to keep the UI responsive while background captures run.
- Introduced `Viewer2DOffscreenRendererPool` in `viewer2doffscreenrenderer.h/.cpp` to create and manage multiple `Viewer2DOffscreenRenderer` instances and allow setting a shared GL context across them.
- Updated `MainWindow` to own a `Viewer2DOffscreenRendererPool` and expose `GetOffscreenRendererForView(int viewId)`, and migrated calls that previously used the single renderer to request a renderer per view id (including print paths in `mainwindow_print.cpp`).
- Reworked layout capture flow in `LayoutViewerPanel` to use per-view renderers from the pool, to call `CaptureFrameAsync` for non-blocking captures, and to add `captureDirty` tracking in `ViewCache` so captures already in progress are not duplicated but are re-run after completion.
- Implemented asynchronous legend/symbol capture logic in `LayoutViewerPanel::RebuildCachedTexture` so legend symbol generation is performed asynchronously when missing or incomplete.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69773fb95c688324b1a0f1cadcb7c538)