### PR TITLE
Fix Viewer2D view assignment for layout captures

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1227,7 +1227,7 @@ void LayoutViewerPanel::RebuildCachedTexture() {
       legendCaptureInProgress = true;
       ConfigManager &cfg = ConfigManager::Get();
       viewer2d::Viewer2DState state = viewer2d::CaptureState(capturePanel, cfg);
-      state.camera.view = Viewer2DView::Top;
+      state.camera.view = static_cast<int>(Viewer2DView::Top);
       state.renderOptions.darkMode = false;
       auto stateGuard = std::make_shared<viewer2d::ScopedViewer2DState>(
           capturePanel, nullptr, cfg, state, nullptr, nullptr, false);
@@ -1262,7 +1262,7 @@ void LayoutViewerPanel::RebuildCachedTexture() {
         ConfigManager &cfg = ConfigManager::Get();
         viewer2d::Viewer2DState state =
             viewer2d::CaptureState(capturePanel, cfg);
-        state.camera.view = targetView;
+        state.camera.view = static_cast<int>(targetView);
         state.renderOptions.darkMode = false;
         auto stateGuard = std::make_shared<viewer2d::ScopedViewer2DState>(
             capturePanel, nullptr, cfg, state, nullptr, nullptr, false);


### PR DESCRIPTION
### Motivation
- Fix compile-time conversion errors when assigning `Viewer2DView` enum values to the integer `camera.view` field during legend capture and target view selection.

### Description
- Replace direct assignments with explicit casts using `static_cast<int>(...)` in `gui/layoutviewerpanel.cpp` where `state.camera.view` is set.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697742f766208324ac9ebd9b9b4fde70)