### PR TITLE
Considerar capturas 2D completadas válidas aunque estén vacías

### DIFF
--- a/gui/layoutviewerpanel_view.cpp
+++ b/gui/layoutviewerpanel_view.cpp
@@ -191,7 +191,7 @@ void LayoutViewerPanel::DrawViewElement(
           if (capturePanel) {
             cache.symbols = capturePanel->GetBottomSymbolCacheSnapshot();
           }
-          cache.hasCapture = !cache.buffer.commands.empty();
+          cache.hasCapture = true;
           cache.captureVersion = captureVersion;
           cache.captureInProgress = false;
           cache.renderDirty = true;


### PR DESCRIPTION
### Motivation
- Evitar que los elementos del visor 2D queden en el estado "Loading" indefinidamente cuando una captura asíncrona se completa pero el buffer de comandos resultante está vacío.

### Description
- En `gui/layoutviewerpanel_view.cpp` se marca `cache.hasCapture = true` tras recibir la devolución de `CaptureFrameAsync`, en lugar de depender de `!cache.buffer.commands.empty()`, de modo que una captura completada (aunque vacía) se trate como válida y permita renderizar la vista en el layout.

### Testing
- No se ejecutaron pruebas automáticas para este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977441c960c83249140f1e08467dadf)