### PR TITLE
Fix layout 2D view rendering when captures lag

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1284,8 +1284,7 @@ void LayoutViewerPanel::RebuildCachedTexture() {
     if (!cache.renderDirty)
       continue;
     wxRect frameRect;
-    if (!cache.hasCapture || !cache.hasRenderState ||
-        !GetFrameRect(view.frame, frameRect)) {
+    if (!cache.hasRenderState || !GetFrameRect(view.frame, frameRect)) {
       continue;
     }
 


### PR DESCRIPTION
### Motivation
- Avoid leaving layout 2D elements stuck on a "Loading" overlay when an asynchronous capture is still pending by allowing rendering when a valid `renderState` is present.

### Description
- Update `RebuildCachedTexture()` in `gui/layoutviewerpanel.cpp` to remove the `cache.hasCapture` requirement so that views with a stored `cache.renderState` are processed and rendered even if a capture has not yet completed.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697745ba12f08324808e70b976e66736)