### PR TITLE
Do not abort layout cache rebuild when capture panel is missing

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1215,55 +1215,22 @@ void LayoutViewerPanel::RebuildCachedTexture() {
     }
     capturePanel = legendRenderer ? legendRenderer->GetPanel() : nullptr;
   }
-  if (!capturePanel) {
-    return;
-  }
 
-  std::shared_ptr<const SymbolDefinitionSnapshot> legendSymbols =
-      capturePanel->GetBottomSymbolCacheSnapshot();
+  std::shared_ptr<const SymbolDefinitionSnapshot> legendSymbols;
   bool legendReady = true;
   if (!currentLayout.legendViews.empty()) {
-    if (!legendSymbols || legendSymbols->empty()) {
+    if (!capturePanel) {
       legendReady = false;
-      if (!legendCaptureInProgress) {
-        legendCaptureInProgress = true;
-        ConfigManager &cfg = ConfigManager::Get();
-        viewer2d::Viewer2DState state =
-            viewer2d::CaptureState(capturePanel, cfg);
-        state.camera.view = static_cast<int>(Viewer2DView::Top);
-        state.renderOptions.darkMode = false;
-        auto stateGuard = std::make_shared<viewer2d::ScopedViewer2DState>(
-            capturePanel, nullptr, cfg, state, nullptr, nullptr, false);
-        capturePanel->CaptureFrameAsync(
-            [this, stateGuard](CommandBuffer, Viewer2DViewState) {
-              legendCaptureInProgress = false;
-              renderDirty = true;
-              RequestRenderRebuild();
-              Refresh();
-            },
-            true, false);
-      }
     } else {
-      bool hasTop = false;
-      bool hasFront = false;
-      for (const auto &entry : *legendSymbols) {
-        if (entry.second.key.viewKind == SymbolViewKind::Top)
-          hasTop = true;
-        else if (entry.second.key.viewKind == SymbolViewKind::Front)
-          hasFront = true;
-        if (hasTop && hasFront)
-          break;
-      }
-      if (!hasTop || !hasFront) {
+      legendSymbols = capturePanel->GetBottomSymbolCacheSnapshot();
+      if (!legendSymbols || legendSymbols->empty()) {
         legendReady = false;
         if (!legendCaptureInProgress) {
           legendCaptureInProgress = true;
-          const Viewer2DView targetView =
-              hasTop ? Viewer2DView::Front : Viewer2DView::Top;
           ConfigManager &cfg = ConfigManager::Get();
           viewer2d::Viewer2DState state =
               viewer2d::CaptureState(capturePanel, cfg);
-          state.camera.view = static_cast<int>(targetView);
+          state.camera.view = static_cast<int>(Viewer2DView::Top);
           state.renderOptions.darkMode = false;
           auto stateGuard = std::make_shared<viewer2d::ScopedViewer2DState>(
               capturePanel, nullptr, cfg, state, nullptr, nullptr, false);
@@ -1275,6 +1242,40 @@ void LayoutViewerPanel::RebuildCachedTexture() {
                 Refresh();
               },
               true, false);
+        }
+      } else {
+        bool hasTop = false;
+        bool hasFront = false;
+        for (const auto &entry : *legendSymbols) {
+          if (entry.second.key.viewKind == SymbolViewKind::Top)
+            hasTop = true;
+          else if (entry.second.key.viewKind == SymbolViewKind::Front)
+            hasFront = true;
+          if (hasTop && hasFront)
+            break;
+        }
+        if (!hasTop || !hasFront) {
+          legendReady = false;
+          if (!legendCaptureInProgress) {
+            legendCaptureInProgress = true;
+            const Viewer2DView targetView =
+                hasTop ? Viewer2DView::Front : Viewer2DView::Top;
+            ConfigManager &cfg = ConfigManager::Get();
+            viewer2d::Viewer2DState state =
+                viewer2d::CaptureState(capturePanel, cfg);
+            state.camera.view = static_cast<int>(targetView);
+            state.renderOptions.darkMode = false;
+            auto stateGuard = std::make_shared<viewer2d::ScopedViewer2DState>(
+                capturePanel, nullptr, cfg, state, nullptr, nullptr, false);
+            capturePanel->CaptureFrameAsync(
+                [this, stateGuard](CommandBuffer, Viewer2DViewState) {
+                  legendCaptureInProgress = false;
+                  renderDirty = true;
+                  RequestRenderRebuild();
+                  Refresh();
+                },
+                true, false);
+          }
         }
       }
     }


### PR DESCRIPTION
### Motivation
- `RebuildCachedTexture` previously returned early if the offscreen `capturePanel` was not available, causing layout elements to remain showing the "Loading..." overlay indefinitely because text/image/table caches could not be rebuilt.

### Description
- Stop returning early when `capturePanel` is missing and instead only disable legend-specific capture work by setting `legendReady` to `false` when `capturePanel` is unavailable.
- Delay reading `legendSymbols` until after checking `capturePanel` and only run legend capture logic when `capturePanel` exists, keeping the rest of the cache rebuild flow for views, text, images and event tables intact.
- Keep existing asynchronous capture requests and `legendCaptureInProgress` handling but guard them behind the `capturePanel` availability check so non-legend caches can still be generated.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69774a1f04a8832481cc1c9577be6cd7)