### PR TITLE
Fix layout view render rebuild scheduling

### DIFF
--- a/gui/layoutviewerpanel_view.cpp
+++ b/gui/layoutviewerpanel_view.cpp
@@ -158,6 +158,7 @@ void LayoutViewerPanel::DrawViewElement(
     cache.hasRenderState = true;
     cache.renderDirty = true;
     renderDirty = true;
+    RequestRenderRebuild();
   }
   if (cache.captureInProgress) {
     if (cache.captureVersion != layoutVersion)


### PR DESCRIPTION
### Motivation
- Prevent layout elements from remaining stuck on "Loading..." by ensuring a render rebuild is scheduled when a 2D view initializes its render state.

### Description
- Call `RequestRenderRebuild()` after initializing `ViewCache::renderState` in `LayoutViewerPanel::DrawViewElement` in `gui/layoutviewerpanel_view.cpp` so the offscreen capture and texture build are triggered.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69774e812f2c8324a258fc0a4efced64)