### PR TITLE
Fix layout view offscreen render state handling

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1314,8 +1314,13 @@ void LayoutViewerPanel::RebuildCachedTexture() {
     renderState.camera.viewportWidth = renderSize.GetWidth();
     renderState.camera.viewportHeight = renderSize.GetHeight();
 
+    Viewer2DPanel *renderPanel =
+        offscreenRenderer ? offscreenRenderer->GetPanel() : nullptr;
+    if (!renderPanel)
+      continue;
+
     auto stateGuard = std::make_shared<viewer2d::ScopedViewer2DState>(
-        capturePanel, nullptr, cfg, renderState, nullptr, nullptr, false);
+        renderPanel, nullptr, cfg, renderState, nullptr, nullptr, false);
 
     int width = renderSize.GetWidth();
     int height = renderSize.GetHeight();


### PR DESCRIPTION
### Motivation
- Layout view 2D elements were stuck on the "Loading..." overlay because the captured render state was being applied to the wrong panel context when building cached textures for offscreen rendering. 
- The offscreen renderer's `Viewer2DPanel` may be missing when rendering; we need to avoid applying state or attempting a capture when that panel is not available.

### Description
- In `gui/layoutviewerpanel.cpp` inside `RebuildCachedTexture()`, obtain the offscreen renderer panel via `offscreenRenderer->GetPanel()` and store it in `renderPanel` before applying state. 
- Use `renderPanel` when creating the `ScopedViewer2DState` (`std::make_shared<viewer2d::ScopedViewer2DState>(renderPanel, ...)`) so the render state is applied to the actual panel that will be used for capture. 
- Add a null-check for `renderPanel` and `continue` the loop if it is not present to avoid attempting to apply state or capture with a missing panel.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69774fab5b9c8324b551e5916f25133b)