### PR TITLE
Fix layout 2D view cache initialization

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1283,10 +1283,19 @@ void LayoutViewerPanel::RebuildCachedTexture() {
   const double renderZoom = GetRenderZoom();
   for (const auto &view : currentLayout.view2dViews) {
     ViewCache &cache = GetViewCache(view.id);
+    if (!cache.hasRenderState) {
+      viewer2d::Viewer2DState layoutState =
+          viewer2d::FromLayoutDefinition(view);
+      layoutState.renderOptions.darkMode = false;
+      cache.renderState = layoutState;
+      cache.hasRenderState = true;
+      cache.renderDirty = true;
+      renderDirty = true;
+    }
     if (!cache.renderDirty)
       continue;
     wxRect frameRect;
-    if (!cache.hasRenderState || !GetFrameRect(view.frame, frameRect)) {
+    if (!GetFrameRect(view.frame, frameRect)) {
       continue;
     }
 


### PR DESCRIPTION
### Motivation
- 2D view elements remained stuck showing the "Loading..." overlay because their `ViewCache` entries lacked an initialized `renderState` when `RebuildCachedTexture()` ran.

### Description
- Initialize the view render state inside `RebuildCachedTexture()` by populating `cache.renderState` from `viewer2d::FromLayoutDefinition(view)` and setting `cache.hasRenderState = true`.
- Force the cache to be considered dirty after initialization by setting `cache.renderDirty = true` and `renderDirty = true` so offscreen rendering proceeds without waiting for a paint pass.
- Tighten the frame-rect check so the loop only continues on an invalid frame by using `if (!GetFrameRect(...))` after ensuring the cache has been initialized in the function (`gui/layoutviewerpanel.cpp`, `RebuildCachedTexture`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697755d4848c83249ca3c82687a1ae1c)