### PR TITLE
Fix layout view rebuild when shown

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -72,6 +72,7 @@ wxDEFINE_EVENT(EVT_LAYOUT_VIEW_EDIT, wxCommandEvent);
 
 wxBEGIN_EVENT_TABLE(LayoutViewerPanel, wxGLCanvas)
     EVT_PAINT(LayoutViewerPanel::OnPaint)
+    EVT_SHOW(LayoutViewerPanel::OnShow)
     EVT_SIZE(LayoutViewerPanel::OnSize)
     EVT_LEFT_DOWN(LayoutViewerPanel::OnLeftDown)
     EVT_LEFT_UP(LayoutViewerPanel::OnLeftUp)
@@ -258,6 +259,9 @@ void LayoutViewerPanel::OnPaint(wxPaintEvent &) {
   if (!IsShownOnScreen()) {
     return;
   }
+  if (renderDirty && !renderPending) {
+    RequestRenderRebuild();
+  }
   InitGL();
   SetCurrent(*glContext_);
   RefreshLegendData();
@@ -402,6 +406,13 @@ void LayoutViewerPanel::OnPaint(wxPaintEvent &) {
 
   glFlush();
   SwapBuffers();
+}
+
+void LayoutViewerPanel::OnShow(wxShowEvent &event) {
+  if (event.IsShown() && renderDirty) {
+    RequestRenderRebuild();
+  }
+  event.Skip();
 }
 
 void LayoutViewerPanel::DrawSelectionHandles(const wxRect &frameRect) const {

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -101,6 +101,7 @@ private:
   };
 
   void OnPaint(wxPaintEvent &event);
+  void OnShow(wxShowEvent &event);
   void OnSize(wxSizeEvent &event);
   void OnLeftDown(wxMouseEvent &event);
   void OnLeftUp(wxMouseEvent &event);


### PR DESCRIPTION
### Motivation

- Ensure layout view caches are rebuilt when the panel becomes visible or when painting occurs while caches are dirty, to avoid the UI getting stuck showing a "Loading…" state after asynchronous layout changes.

### Description

- Add `OnShow` event handler declaration in `LayoutViewerPanel` and register `EVT_SHOW` in the event table to trigger rebuilds when the panel is shown (`gui/layoutviewerpanel.h` and `gui/layoutviewerpanel.cpp`).
- Implement `LayoutViewerPanel::OnShow(wxShowEvent &event)` to call `RequestRenderRebuild()` when `event.IsShown()` and `renderDirty` is true.
- During `OnPaint`, request a render rebuild if `renderDirty` is true and no `renderPending` debounce is active by calling `RequestRenderRebuild()` before initializing GL (`gui/layoutviewerpanel.cpp`).

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697757543b6483248eeb4eca7930c7a2)