### PR TITLE
Ensure 2D viewport is available for layout activation

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -603,6 +603,8 @@ void MainWindow::ActivateLayoutView(const std::string &layoutName) {
   if (!auiManager || layoutName.empty())
     return;
 
+  Ensure2DViewportAvailable();
+
   if (!activeLayoutName.empty() && activeLayoutName != layoutName) {
     PersistLayout2DViewState();
   }


### PR DESCRIPTION
### Motivation
- Layout 2D elements remained stuck showing the `Loading...` overlay because the layout capture path requires a valid `Viewer2DPanel` (capture panel) and the 2D viewport could be uninitialized when a layout is activated.

### Description
- Call `Ensure2DViewportAvailable()` at the start of `MainWindow::ActivateLayoutView` so the 2D viewport/panels are initialized before the layout is applied and captures/rendering can proceed.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697769f3a6708324805718a48b673440)