### PR TITLE
Fix async 2D capture on UI thread

### DIFF
--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -156,12 +156,6 @@ private:
   void StopDragTableUpdates();
   void StartDragTableUpdateWorker();
   void StopDragTableUpdateWorker();
-  void StartAsyncCaptureWorker();
-  void StopAsyncCaptureWorker();
-  void ProcessAsyncCaptureRequests();
-  void PerformAsyncCapture(
-      const std::function<void(CommandBuffer, Viewer2DViewState)> &callback,
-      bool useSimplifiedFootprints, bool includeGridInCapture);
   void EnsureOffscreenTarget(int width, int height);
   void DestroyOffscreenTarget();
 
@@ -219,15 +213,6 @@ private:
   DragTarget m_dragTableUpdateWorkerTarget = DragTarget::None;
   std::vector<std::string> m_dragTableUpdateUuids;
   std::mutex m_dragTableUpdateSceneMutex;
-  std::thread m_asyncCaptureWorker;
-  std::mutex m_asyncCaptureMutex;
-  std::condition_variable m_asyncCaptureCv;
-  bool m_asyncCaptureWorkerStop = false;
-  bool m_asyncCaptureQueued = false;
-  bool m_asyncCaptureUseSimplifiedFootprints = false;
-  bool m_asyncCaptureIncludeGrid = true;
-  std::function<void(CommandBuffer, Viewer2DViewState)>
-      m_asyncCaptureCallback;
   std::recursive_mutex m_renderMutex;
 
   wxGLContext *m_glContext = nullptr;


### PR DESCRIPTION
### Motivation
- The background async capture worker performed OpenGL rendering off the UI thread which can use an invalid GL context and left 2D layout views stuck at "Loading..." and increased some load latencies.
- The goal is to ensure 2D frame capture runs safely on the GUI thread and remove the fragile off-thread capture path.

### Description
- Rewrote `Viewer2DPanel::CaptureFrameAsync` to schedule the capture on the UI thread using `wxTheApp->CallAfter` and delegate to the existing, safe `CaptureFrameNow` path.
- Removed the background async capture worker and its helpers (`StartAsyncCaptureWorker`, `StopAsyncCaptureWorker`, `ProcessAsyncCaptureRequests`, `PerformAsyncCapture`) and the associated synchronization members from `viewer2d/viewer2dpanel.cpp` and `viewer2d/viewer2dpanel.h`.
- Stopped starting/stopping the removed worker in the constructor/destructor and cleaned up unused member variables (mutexes, condition variables, worker thread, and queued state).
- Kept capture logic identical when executed synchronously via `CaptureFrameNow` to preserve behavior for offscreen and on-screen renders.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977727ff4a08324b362c6a68817898f)