### PR TITLE
Fix layout 2D view label scaling in cached renders

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1328,9 +1328,6 @@ void LayoutViewerPanel::RebuildCachedTexture() {
 
     ConfigManager &cfg = ConfigManager::Get();
     viewer2d::Viewer2DState renderState = cache.renderState;
-    if (renderZoom != 1.0) {
-      renderState.camera.zoom *= static_cast<float>(renderZoom);
-    }
     renderState.camera.viewportWidth = renderSize.GetWidth();
     renderState.camera.viewportHeight = renderSize.GetHeight();
 


### PR DESCRIPTION
### Motivation
- Prevent the layout panel zoom from affecting the camera zoom used when rebuilding cached 2D view textures so fixture labels keep their intended size.

### Description
- Stop multiplying `renderState.camera.zoom` by `renderZoom` in `LayoutViewerPanel::RebuildCachedTexture()` (file `gui/layoutviewerpanel.cpp`) so cached renders use the layout view's camera zoom only.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69777546861c83249b5ab5a658eafe76)