### PR TITLE
Invalidate layout 2D view caches when camera or render options change

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1294,15 +1294,7 @@ void LayoutViewerPanel::RebuildCachedTexture() {
   const double renderZoom = GetRenderZoom();
   for (const auto &view : currentLayout.view2dViews) {
     ViewCache &cache = GetViewCache(view.id);
-    if (!cache.hasRenderState) {
-      viewer2d::Viewer2DState layoutState =
-          viewer2d::FromLayoutDefinition(view);
-      layoutState.renderOptions.darkMode = false;
-      cache.renderState = layoutState;
-      cache.hasRenderState = true;
-      cache.renderDirty = true;
-      renderDirty = true;
-    }
+    UpdateViewCacheState(view, cache);
     if (!cache.renderDirty)
       continue;
     wxRect frameRect;

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -60,6 +60,7 @@ private:
     Viewer2DViewState viewState;
     viewer2d::Viewer2DState renderState;
     bool hasRenderState = false;
+    size_t renderStateHash = 0;
     std::shared_ptr<const SymbolDefinitionSnapshot> symbols;
     unsigned int texture = 0;
     wxSize textureSize{0, 0};
@@ -136,6 +137,8 @@ private:
   void DrawImageElement(const layouts::LayoutImageDefinition &image,
                         int activeImageId);
   void DrawLoadingOverlay(const wxRect &frameRect);
+  bool UpdateViewCacheState(const layouts::Layout2DViewDefinition &view,
+                            ViewCache &cache);
 
   void ResetViewToFit();
   wxRect GetPageRect() const;


### PR DESCRIPTION
### Motivation
- Editing a layout 2D view could leave an offscreen render cache stale so zoom/render option changes (and label visibility) were not applied consistently, causing incorrect zoom or missing fixture labels in layout previews.

### Description
- Added a `renderStateHash` to `ViewCache` and a `HashLayoutViewRenderState` helper that hashes the camera, render options and hidden layers to detect meaningful view changes.
- Implemented `UpdateViewCacheState(const Layout2DViewDefinition&, ViewCache&)` to refresh `cache.renderState`, mark `renderDirty`, invalidate `captureVersion` and set `captureDirty` if a capture is in progress.
- Call `UpdateViewCacheState` from `RebuildCachedTexture` and `DrawViewElement` so cached textures and offscreen captures are re-requested when the view’s camera/options/labels change.
- Adjusted render rebuild and capture logic so a changed render state triggers `RequestRenderRebuild()` and forces re-capture when needed to avoid stale zoom/label renders.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977ab554f3883248a3f3255ca1b871a)