### PR TITLE
Add loading overlay to LayoutViewerPanel

### DIFF
--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -133,6 +133,9 @@ private:
                        int activeTextId);
   void DrawImageElement(const layouts::LayoutImageDefinition &image,
                         int activeImageId);
+  void DrawLoadingOverlay(const wxSize &size);
+  void EnsureLoadingTextTexture();
+  void ClearLoadingTextTexture();
 
   void ResetViewToFit();
   wxRect GetPageRect() const;
@@ -161,6 +164,8 @@ private:
   void ClearCachedTexture(ImageCache &cache);
   void RequestRenderRebuild();
   void InvalidateRenderIfFrameChanged();
+  void OnLoadingTimer(wxTimerEvent &event);
+  bool AreTexturesReady() const;
   void EmitEditViewRequest();
   bool SelectElementAtPosition(const wxPoint &pos);
   bool GetLegendFrameById(int legendId,
@@ -251,6 +256,11 @@ private:
   bool glInitialized_ = false;
   bool renderDirty = true;
   bool renderPending = false;
+  bool isLoading = false;
+  bool loadingRequested = false;
+  wxTimer loadingTimer_;
+  unsigned int loadingTextTexture_ = 0;
+  wxSize loadingTextTextureSize_{0, 0};
   std::unordered_map<int, ViewCache> viewCaches_;
   std::unordered_map<int, LegendCache> legendCaches_;
   std::unordered_map<int, EventTableCache> eventTableCaches_;


### PR DESCRIPTION
### Motivation
- Avoid flicker and provide user feedback when layout textures are being (re)built by showing an explicit loading state and delaying the overlay for short renders.
- Mark loading when `RequestRenderRebuild()` or `SetLayoutDefinition()` trigger a `RebuildCachedTexture()` and clear it when the rebuild finishes or is interrupted.
- Ensure the overlay only appears when textures are not ready or a rebuild is pending, and does not interfere with already-rendered content.

### Description
- Added loading state fields and helpers to `LayoutViewerPanel` (`isLoading`, `loadingRequested`, `loadingTimer_`, `loadingTextTexture_`, `loadingTextTextureSize_`) and a `kLoadingOverlayDelayMs` constant to avoid flicker.
- Marked `loadingRequested = true` from `SetLayoutDefinition()` and `RequestRenderRebuild()` and start a single-shot timer (`StartOnce`) to show the overlay after the delay; implemented `OnLoadingTimer()` to set `isLoading` and `Refresh()`.
- Implemented `DrawLoadingOverlay()` which draws a semi-transparent quad and a centered "Cargando layout..." texture; added `EnsureLoadingTextTexture()` to create the GL texture from a `wxBitmap` and `ClearLoadingTextTexture()` to free it.
- Cleared loading state on completion/early exit inside `RebuildCachedTexture()` and added `AreTexturesReady()` to check if all caches already have textures so overlay can be suppressed when unnecessary.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977b24d3f9883249e4ff344b4acd0f8)