### PR TITLE
Show layout render status and clear on ready

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -92,6 +92,8 @@ wxBEGIN_EVENT_TABLE(LayoutViewerPanel, wxGLCanvas)
     EVT_MENU(kSendToBackMenuId, LayoutViewerPanel::OnSendToBack)
 wxEND_EVENT_TABLE()
 
+wxDEFINE_EVENT(EVT_LAYOUT_RENDER_READY, wxCommandEvent);
+
 LayoutViewerPanel::LayoutViewerPanel(wxWindow *parent)
     : wxGLCanvas(parent, wxID_ANY, nullptr, wxDefaultPosition,
                  wxDefaultSize,
@@ -1142,6 +1144,13 @@ void LayoutViewerPanel::InitGL() {
 void LayoutViewerPanel::RebuildCachedTexture() {
   if (!renderDirty)
     return;
+  auto notifyRenderReady = [this]() {
+    CallAfter([this]() {
+      wxCommandEvent event(EVT_LAYOUT_RENDER_READY);
+      event.SetEventObject(this);
+      wxPostEvent(this, event);
+    });
+  };
   auto clearLoadingState = [this]() {
     loadingRequested = false;
     if (loadingTimer_.IsRunning())
@@ -1150,6 +1159,7 @@ void LayoutViewerPanel::RebuildCachedTexture() {
   };
   if (!IsShownOnScreen()) {
     clearLoadingState();
+    notifyRenderReady();
     return;
   }
 
@@ -1164,6 +1174,7 @@ void LayoutViewerPanel::RebuildCachedTexture() {
   if (!capturePanel || !offscreenRenderer) {
     ClearCachedTexture();
     clearLoadingState();
+    notifyRenderReady();
     return;
   }
 
@@ -1253,6 +1264,7 @@ void LayoutViewerPanel::RebuildCachedTexture() {
     InitGL();
     if (!IsShownOnScreen()) {
       clearLoadingState();
+      notifyRenderReady();
       return;
     }
     SetCurrent(*glContext_);
@@ -1327,6 +1339,7 @@ void LayoutViewerPanel::RebuildCachedTexture() {
     InitGL();
     if (!IsShownOnScreen()) {
       clearLoadingState();
+      notifyRenderReady();
       return;
     }
     SetCurrent(*glContext_);
@@ -1412,6 +1425,7 @@ void LayoutViewerPanel::RebuildCachedTexture() {
     InitGL();
     if (!IsShownOnScreen()) {
       clearLoadingState();
+      notifyRenderReady();
       return;
     }
     SetCurrent(*glContext_);
@@ -1496,6 +1510,7 @@ void LayoutViewerPanel::RebuildCachedTexture() {
     InitGL();
     if (!IsShownOnScreen()) {
       clearLoadingState();
+      notifyRenderReady();
       return;
     }
     SetCurrent(*glContext_);
@@ -1586,6 +1601,7 @@ void LayoutViewerPanel::RebuildCachedTexture() {
     InitGL();
     if (!IsShownOnScreen()) {
       clearLoadingState();
+      notifyRenderReady();
       return;
     }
     SetCurrent(*glContext_);
@@ -1606,6 +1622,7 @@ void LayoutViewerPanel::RebuildCachedTexture() {
   }
 
   clearLoadingState();
+  notifyRenderReady();
 }
 
 void LayoutViewerPanel::ClearCachedTexture() {

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -30,6 +30,7 @@
 #include "viewer2dstate.h"
 
 wxDECLARE_EVENT(EVT_LAYOUT_VIEW_EDIT, wxCommandEvent);
+wxDECLARE_EVENT(EVT_LAYOUT_RENDER_READY, wxCommandEvent);
 
 class Viewer2DOffscreenRenderer;
 

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -160,6 +160,7 @@ private:
   void OnLayout2DViewOk(wxCommandEvent &event); // Confirm layout 2D view edit
   void OnLayout2DViewCancel(wxCommandEvent &event); // Cancel layout 2D edit
   void OnLayoutViewEdit(wxCommandEvent &event);
+  void OnLayoutRenderReady(wxCommandEvent &event);
 
   void OnPaneClose(wxAuiManagerEvent &event); // Keep View menu in sync
 
@@ -174,6 +175,8 @@ private:
   void UpdateViewMenuChecks();
   void OnLayoutSelected(wxCommandEvent &event);
   void ActivateLayoutView(const std::string &layoutName);
+  void ShowLayoutLoadingIndicator(const wxString &message);
+  void ClearLayoutLoadingIndicator();
   void SyncSceneData();
   bool ConfirmSaveIfDirty(const wxString &actionLabel,
                           const wxString &dialogTitle);
@@ -188,6 +191,7 @@ private:
   Viewer2DPanel *layout2DViewEditPanel = nullptr;
   Viewer2DRenderPanel *layout2DViewEditRenderPanel = nullptr;
   std::optional<viewer2d::Viewer2DState> standalone2DState;
+  std::unique_ptr<wxBusyCursor> layoutRenderCursor;
 
   inline static MainWindow *s_instance = nullptr;
   wxDECLARE_EVENT_TABLE();


### PR DESCRIPTION
### Motivation
- Provide immediate user feedback when a layout is activated by showing a status message or busy cursor while cached textures are rebuilt.  
- Ensure the feedback is cleared once the render is actually ready or if no valid layout/panel is available.  
- Avoid leaving the UI in a loading state on early-return paths during the render pipeline.

### Description
- Added a new event `EVT_LAYOUT_RENDER_READY` in `gui/layoutviewerpanel.h` and defined it in `gui/layoutviewerpanel.cpp`.  
- Emit `EVT_LAYOUT_RENDER_READY` from `LayoutViewerPanel::RebuildCachedTexture()` via a `CallAfter` wrapper (`notifyRenderReady`) at all early-return points and after the final rebuild to notify the UI when textures are ready.  
- Added `ShowLayoutLoadingIndicator`, `ClearLayoutLoadingIndicator`, and `OnLayoutRenderReady` handlers in `gui/mainwindow.cpp`, bound the new event, and updated `ActivateLayoutView` to show a status message / `wxBusyCursor` before calling `layoutViewerPanel->SetLayoutDefinition(layout)`.  
- Ensure the loading indicator is cleared when there is no valid layout, no panel, or when the render-ready event fires; introduced a `layoutRenderCursor` member in `gui/mainwindow.h` to manage the busy cursor lifecycle.  

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977c1d837d48324ae5d74a8565c812a)