### PR TITLE
Show loading overlay before render rebuild

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1718,6 +1718,9 @@ void LayoutViewerPanel::RequestRenderRebuild() {
   }
   CallAfter([this]() {
     renderPending = false;
+    isLoading = true;
+    Refresh();
+    Update();
     RebuildCachedTexture();
     Refresh();
   });


### PR DESCRIPTION
### Motivation
- Ensure the UI shows the loading overlay immediately before the expensive texture rebuild so the user gets visual feedback and the `OnPaint` path runs prior to the heavy work.

### Description
- In `LayoutViewerPanel::RequestRenderRebuild()` set `isLoading = true` and call `Refresh()` and `Update()` before invoking `RebuildCachedTexture()` so the overlay is painted immediately.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977c530b6588324a085d002fcb02dc1)