### PR TITLE
Delay layout render rebuild to show loading overlay before heavy rendering

### DIFF
--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -166,6 +166,7 @@ private:
   void RequestRenderRebuild();
   void InvalidateRenderIfFrameChanged();
   void OnLoadingTimer(wxTimerEvent &event);
+  void OnRenderDelayTimer(wxTimerEvent &event);
   bool AreTexturesReady() const;
   void EmitEditViewRequest();
   bool SelectElementAtPosition(const wxPoint &pos);
@@ -260,6 +261,7 @@ private:
   bool isLoading = false;
   bool loadingRequested = false;
   wxTimer loadingTimer_;
+  wxTimer renderDelayTimer_;
   unsigned int loadingTextTexture_ = 0;
   wxSize loadingTextTextureSize_{0, 0};
   std::unordered_map<int, ViewCache> viewCaches_;


### PR DESCRIPTION
### Motivation
- Ensure the loading overlay becomes visible before starting the heavy `RebuildCachedTexture()` work so the UI does not appear frozen. 
- Avoid performing the render rebuild immediately inside the `CallAfter` that triggers the overlay, which could prevent the overlay from being presented. 
- Provide at least a `150ms` window for the overlay (the existing `kLoadingOverlayDelayMs`) to be visible before the expensive render starts.

### Description
- Added timer IDs `kLoadingTimerId` and `kRenderDelayTimerId` and a new `wxTimer renderDelayTimer_`, and bound `OnRenderDelayTimer` to the render-delay timer. 
- Changed `RequestRenderRebuild()` to set `isLoading`, call `Refresh()`/`Update()`, call `wxTheApp->Yield(true)` to allow a UI frame, and start `renderDelayTimer_` instead of calling `RebuildCachedTexture()` immediately. 
- Implemented `OnRenderDelayTimer()` which verifies pending state and then calls `RebuildCachedTexture()` via `CallAfter()` and finishes with a `Refresh()`, and ensured timers are started/stopped appropriately.

### Testing
- No automated tests were run on this change. 
- The change was compiled/committed in the working tree (no test-suite execution was requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977c6107a108324ad98b9d977c1cf80)