### PR TITLE
Force status bar repaint before layout rendering

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -636,6 +636,10 @@ void MainWindow::ActivateLayoutView(const std::string &layoutName) {
       selectedLayout = &layout;
       if (layoutViewerPanel) {
         ShowLayoutLoadingIndicator("Rendering layout...");
+        if (GetStatusBar())
+          GetStatusBar()->Update();
+        else
+          Update();
         layoutViewerPanel->SetLayoutDefinition(layout);
         appliedLayout = true;
       }


### PR DESCRIPTION
### Motivation
- Ensure the status bar text set by `ShowLayoutLoadingIndicator` repaints immediately so the loading indicator is visible before the heavy `SetLayoutDefinition` work begins.

### Description
- In `MainWindow::ActivateLayoutView` call `GetStatusBar()->Update()` if available, otherwise call `Update()`, immediately after `ShowLayoutLoadingIndicator(...)` and before `layoutViewerPanel->SetLayoutDefinition(layout)`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977c8d2843483249cc54126a8876141)