### PR TITLE
Fix loading overlay text and texture orientation

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -446,7 +446,7 @@ void LayoutViewerPanel::EnsureLoadingTextTexture() {
   if (loadingTextTexture_ != 0)
     return;
 
-  const wxString label = wxString::FromUTF8("Cargando layout...");
+  const wxString label = wxString::FromUTF8("Loading layout...");
   wxFont font = wxFontInfo(14).Bold();
   int textWidth = 0;
   int textHeight = 0;
@@ -475,6 +475,7 @@ void LayoutViewerPanel::EnsureLoadingTextTexture() {
   wxImage image = bitmap.ConvertToImage();
   if (!image.IsOk())
     return;
+  image = image.Mirror(true).Mirror(false);
 
   const unsigned char *rgb = image.GetData();
   if (!rgb)


### PR DESCRIPTION
### Motivation
- The loading overlay used a Spanish label and the generated text texture was mirrored both vertically and horizontally, causing the overlay to display reversed text.

### Description
- Replace `wxString::FromUTF8("Cargando layout...")` with `wxString::FromUTF8("Loading layout...")` and apply `image = image.Mirror(true).Mirror(false);` before extracting pixel data so the text texture renders with the correct orientation.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977b17d41fc8324ba945efdea4c3811)