### PR TITLE
Guard layout render sizes to avoid oversized allocations

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -44,6 +44,9 @@ constexpr int kHandleHalfPx = kHandleSizePx / 2;
 constexpr int kHandleHoverPadPx = 6;
 constexpr int kMinFrameSize = 24;
 constexpr int kLayoutGridStep = 5;
+constexpr int kMaxRenderDimension = 8192;
+constexpr size_t kMaxRenderPixels =
+    static_cast<size_t>(kMaxRenderDimension) * kMaxRenderDimension;
 constexpr int kEditMenuId = wxID_HIGHEST + 490;
 constexpr int kDeleteMenuId = wxID_HIGHEST + 491;
 constexpr int kDeleteLegendMenuId = wxID_HIGHEST + 492;
@@ -1084,10 +1087,21 @@ wxSize LayoutViewerPanel::GetFrameSizeForZoom(
     const layouts::Layout2DViewFrame &frame, double targetZoom) const {
   if (frame.width <= 0 || frame.height <= 0 || targetZoom <= 0.0)
     return wxSize(0, 0);
-  const int scaledWidth =
-      static_cast<int>(std::lround(frame.width * targetZoom));
-  const int scaledHeight =
-      static_cast<int>(std::lround(frame.height * targetZoom));
+  const double scaledWidthValue = frame.width * targetZoom;
+  const double scaledHeightValue = frame.height * targetZoom;
+  if (scaledWidthValue > kMaxRenderDimension ||
+      scaledHeightValue > kMaxRenderDimension)
+    return wxSize(0, 0);
+  const int scaledWidth = static_cast<int>(std::lround(scaledWidthValue));
+  const int scaledHeight = static_cast<int>(std::lround(scaledHeightValue));
+  if (scaledWidth <= 0 || scaledHeight <= 0)
+    return wxSize(0, 0);
+  if (scaledWidth > kMaxRenderDimension ||
+      scaledHeight > kMaxRenderDimension)
+    return wxSize(0, 0);
+  if (static_cast<size_t>(scaledWidth) >
+      kMaxRenderPixels / static_cast<size_t>(scaledHeight))
+    return wxSize(0, 0);
   return wxSize(scaledWidth, scaledHeight);
 }
 


### PR DESCRIPTION
### Motivation
- Prevent crashes and huge memory allocations when layout frame sizes or zoom values produce excessively large render targets by validating scaled dimensions before creating pixel buffers or textures.
- Avoid triggering GPU/GL texture limits or integer overflows when loading corrupted or very large layout images.

### Description
- Added `kMaxRenderDimension` and `kMaxRenderPixels` constants and used them to bound render sizes in `gui/layoutviewerpanel.cpp`.
- Updated `GetFrameSizeForZoom` to compute scaled width/height as doubles, check against `kMaxRenderDimension`/`kMaxRenderPixels`, and return `wxSize(0, 0)` when sizes are out of bounds to skip rendering.
- This change prevents downstream large allocations of pixel buffers and texture creation when a frame at the target zoom would exceed safe limits.

### Testing
- No automated tests were run for this change.
- The patch is limited to defensive checks and returns early when limits are exceeded so normal rendering paths are unchanged when sizes are within bounds.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977cf85e8c483248aef00368d18ec10)