### PR TITLE
Guard `wxTheApp->Yield` during layout render rebuild

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1739,7 +1739,8 @@ void LayoutViewerPanel::RequestRenderRebuild() {
     isLoading = true;
     Refresh();
     Update();
-    wxTheApp->Yield(true);
+    if (wxTheApp && wxTheApp->IsMainLoopRunning())
+      wxTheApp->Yield(true);
     if (renderDelayTimer_.IsRunning()) {
       renderDelayTimer_.Stop();
     }


### PR DESCRIPTION
### Motivation
- Starting the app in "Layout mode view" could trigger an unhandled exception because `LayoutViewerPanel::RequestRenderRebuild` called `wxTheApp->Yield()` before the main loop was running; this change prevents that startup crash.

### Description
- Add a runtime guard in `gui/layoutviewerpanel.cpp` so `wxTheApp->Yield(true)` is only called when `wxTheApp` is present and `IsMainLoopRunning()` returns true, protecting `LayoutViewerPanel::RequestRenderRebuild` from invoking the yield prematurely.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977d1110c4c8324a515a4ab208a1345)