### PR TITLE
Fix GLEW include order in OpenGL panels

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -22,6 +22,7 @@
 #include <memory>
 #include <vector>
 
+#include <GL/glew.h>
 #include <GL/gl.h>
 #ifndef GL_CLAMP_TO_EDGE
 #define GL_CLAMP_TO_EDGE 0x812F

--- a/gui/layoutviewerpanel_eventtable.cpp
+++ b/gui/layoutviewerpanel_eventtable.cpp
@@ -21,6 +21,7 @@
 #include <array>
 #include <functional>
 
+#include <GL/glew.h>
 #include <GL/gl.h>
 
 #include "layouteventtabledialog.h"

--- a/gui/layoutviewerpanel_image.cpp
+++ b/gui/layoutviewerpanel_image.cpp
@@ -23,6 +23,7 @@
 #include <filesystem>
 #include <functional>
 
+#include <GL/glew.h>
 #include <GL/gl.h>
 
 #include "layoutimageutils.h"

--- a/gui/layoutviewerpanel_legend.cpp
+++ b/gui/layoutviewerpanel_legend.cpp
@@ -25,6 +25,7 @@
 #include <map>
 #include <vector>
 
+#include <GL/glew.h>
 #include <GL/gl.h>
 
 #include "configmanager.h"

--- a/gui/layoutviewerpanel_text.cpp
+++ b/gui/layoutviewerpanel_text.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <functional>
 
+#include <GL/glew.h>
 #include <GL/gl.h>
 
 #include <wx/log.h>

--- a/gui/layoutviewerpanel_view.cpp
+++ b/gui/layoutviewerpanel_view.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <memory>
 
+#include <GL/glew.h>
 #include <GL/gl.h>
 
 #include "configmanager.h"

--- a/viewer2d/canvas2d.cpp
+++ b/viewer2d/canvas2d.cpp
@@ -26,6 +26,7 @@
 #include <windows.h>
 #endif
 
+#include <GL/glew.h>
 #include <GL/gl.h>
 #include <wx/glcanvas.h>
 #include <algorithm>


### PR DESCRIPTION
### Motivation
- Several source files included `<GL/gl.h>` before GLEW which causes `glew.h` to emit errors and leaves GL types undefined on some platforms, producing build failures. 
- Normalizing the include order ensures GLEW's definitions are available before `gl.h` and avoids header-order dependent compilation errors.

### Description
- Updated the include order in seven files to ensure `glew.h` is included before `gl.h`: `viewer2d/canvas2d.cpp`, `gui/layoutviewerpanel.cpp`, `gui/layoutviewerpanel_eventtable.cpp`, `gui/layoutviewerpanel_image.cpp`, `gui/layoutviewerpanel_legend.cpp`, `gui/layoutviewerpanel_text.cpp`, and `gui/layoutviewerpanel_view.cpp`.
- Each modified file now prepends `#include <GL/glew.h>` immediately before `#include <GL/gl.h>`.
- No runtime or API changes were made; this is strictly a header-order fix to prevent compile-time errors.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978e4badf388324b720d084230c1802)