### PR TITLE
Preserve layout frame size on 2D view save

### DIFF
--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -830,25 +830,6 @@ void MainWindow::OnLayout2DViewOk(wxCommandEvent &WXUNUSED(event)) {
     frame = editableView->frame;
   }
 
-  if (editPanel) {
-    if (auto overlaySize = editPanel->GetLayoutEditOverlaySize()) {
-      const int newWidth = overlaySize->GetWidth();
-      const int newHeight = overlaySize->GetHeight();
-      if (newWidth > 0 && newHeight > 0) {
-        if (frame.width > 0 || frame.height > 0) {
-          const double centerX = frame.x + frame.width / 2.0;
-          const double centerY = frame.y + frame.height / 2.0;
-          frame.x =
-              static_cast<int>(std::lround(centerX - newWidth / 2.0));
-          frame.y =
-              static_cast<int>(std::lround(centerY - newHeight / 2.0));
-        }
-        frame.width = newWidth;
-        frame.height = newHeight;
-      }
-    }
-  }
-
   // Ensure the stored viewport matches the layout frame size, not the popup.
   if (frame.width > 0 || frame.height > 0) {
     current.camera.viewportWidth = frame.width;


### PR DESCRIPTION
### Motivation
- Prevent the layout frame persisted in the layout from being overridden by the temporary edit-overlay size/scale when confirming a 2D view edit.

### Description
- Remove the code path that read `GetLayoutEditOverlaySize()` and assigned its width/height to the saved `frame` so the existing `frame` from `matchedView`/`editableView` is preserved.
- Keep the existing behavior that the stored viewport is set from `frame` (no change to `current.camera.viewportWidth/Height`).
- This change ensures the overlay scale/slider affects only the visual edit overlay (and zoom in the editor) and not the persisted layout dimensions.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978ea600f888324932011bba594a925)