### PR TITLE
Adjust layout 2D zoom for overlay scale

### DIFF
--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -806,6 +806,11 @@ void MainWindow::OnLayout2DViewOk(wxCommandEvent &WXUNUSED(event)) {
   viewer2d::Viewer2DState current =
       viewer2d::CaptureState(editPanel, cfg);
   viewer2d::ApplyEditorRenderOptions(current, cfg);
+  const float overlayScale =
+      editPanel ? editPanel->GetLayoutEditOverlayScale() : 1.0f;
+  if (overlayScale > 0.0f) {
+    current.camera.zoom /= overlayScale;
+  }
 
   layouts::Layout2DViewFrame frame{};
   int viewId = layout2DViewEditingId;


### PR DESCRIPTION
### Motivation
- When persisting a 2D layout view edited via the popup overlay, the captured camera zoom must be normalized by the overlay scale so the final layout shows the same visible content as the editor.

### Description
- Fetch the overlay scale with `editPanel->GetLayoutEditOverlayScale()` and divide `current.camera.zoom` by that scale before composing the stored view.
- Preserve existing `frame.width`/`frame.height` handling and keep `current.camera.viewportWidth/viewportHeight` assignment behavior unchanged.
- Change made in `gui/mainwindow_layout.cpp` inside `MainWindow::OnLayout2DViewOk` (added overlay scale normalization around the captured state).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978ecf9aacc8324a59e12385f9fdf57)