### PR TITLE
Refine layout render invalidation for single-element updates

### DIFF
--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -163,6 +163,8 @@ private:
   void ClearCachedTexture(EventTableCache &cache);
   void ClearCachedTexture(TextCache &cache);
   void ClearCachedTexture(ImageCache &cache);
+  bool HasDirtyRenderCaches() const;
+  bool NeedsRenderRebuild() const;
   void RequestRenderRebuild();
   void InvalidateRenderIfFrameChanged();
   void OnLoadingTimer(wxTimerEvent &event);

--- a/gui/layoutviewerpanel_eventtable.cpp
+++ b/gui/layoutviewerpanel_eventtable.cpp
@@ -95,7 +95,9 @@ void LayoutViewerPanel::UpdateEventTableFrame(
                                                          *table);
   }
   InvalidateRenderIfFrameChanged();
-  RequestRenderRebuild();
+  if (NeedsRenderRebuild()) {
+    RequestRenderRebuild();
+  }
   Refresh();
 }
 

--- a/gui/layoutviewerpanel_image.cpp
+++ b/gui/layoutviewerpanel_image.cpp
@@ -95,7 +95,9 @@ void LayoutViewerPanel::UpdateImageFrame(const layouts::Layout2DViewFrame &frame
     layouts::LayoutManager::Get().UpdateLayoutImage(currentLayout.name, *image);
   }
   InvalidateRenderIfFrameChanged();
-  RequestRenderRebuild();
+  if (NeedsRenderRebuild()) {
+    RequestRenderRebuild();
+  }
   Refresh();
 }
 

--- a/gui/layoutviewerpanel_legend.cpp
+++ b/gui/layoutviewerpanel_legend.cpp
@@ -573,7 +573,9 @@ void LayoutViewerPanel::UpdateLegendFrame(const layouts::Layout2DViewFrame &fram
                                                      *legend);
   }
   InvalidateRenderIfFrameChanged();
-  RequestRenderRebuild();
+  if (NeedsRenderRebuild()) {
+    RequestRenderRebuild();
+  }
   Refresh();
 }
 

--- a/gui/layoutviewerpanel_text.cpp
+++ b/gui/layoutviewerpanel_text.cpp
@@ -88,7 +88,9 @@ void LayoutViewerPanel::UpdateTextFrame(const layouts::Layout2DViewFrame &frame,
     layouts::LayoutManager::Get().UpdateLayoutText(currentLayout.name, *text);
   }
   InvalidateRenderIfFrameChanged();
-  RequestRenderRebuild();
+  if (NeedsRenderRebuild()) {
+    RequestRenderRebuild();
+  }
   Refresh();
 }
 

--- a/gui/layoutviewerpanel_view.cpp
+++ b/gui/layoutviewerpanel_view.cpp
@@ -142,7 +142,9 @@ void LayoutViewerPanel::UpdateFrame(const layouts::Layout2DViewFrame &frame,
                                                      *view);
   }
   InvalidateRenderIfFrameChanged();
-  RequestRenderRebuild();
+  if (NeedsRenderRebuild()) {
+    RequestRenderRebuild();
+  }
   Refresh();
 }
 


### PR DESCRIPTION
### Motivation
- Avoid global `renderDirty` being set when only the active element changes but its cached texture remains valid, to prevent unnecessary full rebuilds and visual flicker.
- Make render rebuild scheduling conditional so `RequestRenderRebuild()` is only queued when there is actual work to do (global dirty state or per-element caches flagged).
- Keep existing behavior intact for layout-wide changes (zoom, page size, layers) that must trigger full rebuilds.

### Description
- Added two helpers in `LayoutViewerPanel`: `HasDirtyRenderCaches()` and `NeedsRenderRebuild()` and exported them via the header, to centralize whether a rebuild is required.
- Updated `RequestRenderRebuild()`, `RebuildCachedTexture()`, `OnLoadingTimer()` and `OnRenderDelayTimer()` to use `NeedsRenderRebuild()` instead of the previous `renderDirty` checks so pending per-cache dirty flags are respected.
- Modified `InvalidateRenderIfFrameChanged()` so it marks the specific element cache (`cache.renderDirty = true`) and only sets global `renderDirty = true` when non-selected elements were affected; switching the selected element alone will not force a full rebuild if the selected element texture remains valid.
- Changed frame-update handlers in `gui/layoutviewerpanel_view.cpp`, `..._legend.cpp`, `..._text.cpp`, `..._image.cpp`, and `..._eventtable.cpp` to call `RequestRenderRebuild()` only when `NeedsRenderRebuild()` indicates work is required.
- Files changed: `gui/layoutviewerpanel.cpp`, `gui/layoutviewerpanel.h`, `gui/layoutviewerpanel_view.cpp`, `gui/layoutviewerpanel_legend.cpp`, `gui/layoutviewerpanel_text.cpp`, `gui/layoutviewerpanel_image.cpp`, and `gui/layoutviewerpanel_eventtable.cpp`.

### Testing
- No automated tests were executed as part of this change (no unit/integration tests run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978f05069408324a874884a5a50f289)