### PR TITLE
Refine layout render dirty tracking

### DIFF
--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -259,6 +259,9 @@ private:
   wxGLContext *glContext_ = nullptr;
   bool glInitialized_ = false;
   bool renderDirty = true;
+  double lastRenderZoom = 0.0;
+  double lastPageWidthPt = 0.0;
+  double lastPageHeightPt = 0.0;
   bool renderPending = false;
   bool isLoading = false;
   bool loadingRequested = false;


### PR DESCRIPTION
### Motivation
- Avoid triggering a global render rebuild for single-element frame edits so other element textures remain cached and are not unnecessarily re-rendered.
- Ensure zoom or page-size changes still force a global rebuild when required.
- Make per-element invalidation explicit so only the affected element's `cache.renderDirty` is set for point changes.

### Description
- Added tracking fields `lastRenderZoom`, `lastPageWidthPt` and `lastPageHeightPt` to `LayoutViewerPanel` to detect zoom/page changes. 
- Rewrote `InvalidateRenderIfFrameChanged()` to compute `zoomChanged` and `pageChanged`, count dirty elements with `dirtyElementCount`, and mark individual caches via `cache.renderDirty` without immediately setting the global `renderDirty` flag. 
- Only set the global `renderDirty` when zoom or page size changed or when multiple elements were invalidated (`dirtyElementCount > 1`), keeping single-element edits local to that element's cache. 
- Kept the existing behavior of clearing textures for frames that are no longer valid, but now use the refined dirty-tracking logic to avoid unnecessary global rebuilds.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978faa11b7083248ae7afecf6ba542c)