### PR TITLE
Guard layout viewer against missing OpenGL context

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -257,6 +257,9 @@ void LayoutViewerPanel::OnPaint(wxPaintEvent &) {
   if (!IsShownOnScreen()) {
     return;
   }
+  if (!glContext_) {
+    return;
+  }
   InitGL();
   SetCurrent(*glContext_);
   RefreshLegendData();
@@ -536,6 +539,8 @@ void LayoutViewerPanel::EnsureLoadingTextTexture() {
     pixels[static_cast<size_t>(i) * 4 + 3] = intensity;
   }
 
+  if (!glContext_)
+    return;
   InitGL();
   if (!IsShownOnScreen())
     return;


### PR DESCRIPTION
### Motivation
- Fix a crash when opening the program in layout mode caused by the layout viewer attempting GL operations when its `wxGLContext` (`glContext_`) is not available.

### Description
- Add early-return checks for `glContext_` in `LayoutViewerPanel::OnPaint` and `LayoutViewerPanel::EnsureLoadingTextTexture` to avoid performing OpenGL calls or creating textures when the GL context is missing.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b24302b988324bb1f1d8ee5ba1757)