### PR TITLE
Show loading overlay when textures not ready or active element lacks texture

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -442,7 +442,7 @@ void LayoutViewerPanel::OnPaint(wxPaintEvent &) {
       activeElementHasTexture = hasTexture(imageCaches_, activeImageId);
     }
   }
-  const bool showLoadingOverlay = !texturesReady && !activeElementHasTexture;
+  const bool showLoadingOverlay = !texturesReady || !activeElementHasTexture;
   if (showLoadingOverlay) {
     DrawLoadingOverlay(size);
   }


### PR DESCRIPTION
### Motivation
- Ensure the loading overlay is shown when textures are still being prepared or when the currently selected element has no ready texture so users get feedback on the initial render.

### Description
- Update `LayoutViewerPanel::OnPaint` to use `const bool showLoadingOverlay = !texturesReady || !activeElementHasTexture;` so the overlay is displayed if textures are not ready or the active element lacks a texture while keeping existing textures rendered during background rebuilds.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b262090a083248dfd615d29935df9)