### PR TITLE
Limit global render dirtiness to page or zoom changes

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1820,12 +1820,10 @@ void LayoutViewerPanel::InvalidateRenderIfFrameChanged() {
   const bool zoomChanged = lastRenderZoom != renderZoom;
   const bool pageChanged =
       lastPageWidthPt != pageWidth || lastPageHeightPt != pageHeight;
-  int dirtyElementCount = 0;
   auto markDirty = [&](bool &cacheDirty) {
     if (cacheDirty)
       return;
     cacheDirty = true;
-    dirtyElementCount++;
   };
 
   for (const auto &view : currentLayout.view2dViews) {
@@ -1923,7 +1921,7 @@ void LayoutViewerPanel::InvalidateRenderIfFrameChanged() {
     }
   }
 
-  if (zoomChanged || pageChanged || dirtyElementCount > 1) {
+  if (zoomChanged || pageChanged) {
     renderDirty = true;
   }
   lastRenderZoom = renderZoom;


### PR DESCRIPTION
### Motivation
- Avoid triggering a full rebuild for local frame edits so only the affected element's cache is re-rendered, and reserve global rebuilds for zoom or page size changes that impact all elements.

### Description
- Change `LayoutViewerPanel::InvalidateRenderIfFrameChanged()` so the `markDirty` lambda only sets the individual `cache.renderDirty` flag and remove the `dirtyElementCount` logic, and only set the global `renderDirty` when zoom or page size changed; modified file: `gui/layoutviewerpanel.cpp`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b27f1fc9c8324867b322b7c127242)