### PR TITLE
Separate view render version to avoid unnecessary recaptures

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -146,6 +146,7 @@ void LayoutViewerPanel::SetLayoutDefinition(
     selectedElementId = -1;
   }
   layoutVersion++;
+  viewRenderVersion++;
   captureInProgress = false;
   ClearCachedTexture();
   renderDirty = true;

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -253,6 +253,7 @@ private:
   wxPoint dragStartPos{0, 0};
   layouts::Layout2DViewFrame dragStartFrame;
   int layoutVersion = 0;
+  int viewRenderVersion = 0;
   bool captureInProgress = false;
   SelectedElementType selectedElementType = SelectedElementType::None;
   int selectedElementId = -1;

--- a/gui/layoutviewerpanel_view.cpp
+++ b/gui/layoutviewerpanel_view.cpp
@@ -136,6 +136,7 @@ void LayoutViewerPanel::UpdateFrame(const layouts::Layout2DViewFrame &frame,
     } else {
       view->camera.viewportHeight = 0;
     }
+    viewRenderVersion++;
   }
   if (!currentLayout.name.empty()) {
     layouts::LayoutManager::Get().UpdateLayout2DView(currentLayout.name,
@@ -153,7 +154,7 @@ void LayoutViewerPanel::DrawViewElement(
     Viewer2DOffscreenRenderer *offscreenRenderer, int activeViewId) {
   ViewCache &cache = GetViewCache(view.id);
   if (!captureInProgress && !cache.captureInProgress &&
-      cache.captureVersion != layoutVersion && capturePanel) {
+      cache.captureVersion != viewRenderVersion && capturePanel) {
     captureInProgress = true;
     cache.captureInProgress = true;
     const int viewId = view.id;
@@ -196,7 +197,7 @@ void LayoutViewerPanel::DrawViewElement(
             cache.symbols = capturePanel->GetBottomSymbolCacheSnapshot();
           }
           cache.hasCapture = !cache.buffer.commands.empty();
-          cache.captureVersion = layoutVersion;
+          cache.captureVersion = viewRenderVersion;
           cache.captureInProgress = false;
           captureInProgress = false;
           cache.renderDirty = true;


### PR DESCRIPTION
### Motivation
- Prevent view recapture when only the visual ordering (z-index) of elements changes by decoupling capture invalidation from layout ordering updates.
- Ensure captures are only triggered for changes that affect rendering (camera, viewport size, render options, layers).

### Description
- Added a dedicated `int viewRenderVersion` counter in `LayoutViewerPanel` to track render-affecting changes (`gui/layoutviewerpanel.h`).
- Bumped `viewRenderVersion` in `SetLayoutDefinition` and when a view frame size changes in `UpdateFrame` (`gui/layoutviewerpanel.cpp`, `gui/layoutviewerpanel_view.cpp`).
- Switched view capture checks and assignments in `DrawViewElement` to compare and set `cache.captureVersion` against `viewRenderVersion` instead of `layoutVersion` so z-order updates do not force recapture (`gui/layoutviewerpanel_view.cpp`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b2c510c1483248a7ae8b8fc997cb5)