### PR TITLE
Normalize layout cache rebuild loading flags

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1219,19 +1219,22 @@ void LayoutViewerPanel::RebuildCachedTexture() {
       wxPostEvent(this, event);
     });
   };
-  auto clearLoadingState = [this]() {
+  auto stopLoadingRequest = [this]() {
     loadingRequested = false;
     if (loadingTimer_.IsRunning())
       loadingTimer_.Stop();
+  };
+  auto clearLoadingState = [this]() {
+    stopLoadingRequest();
     isLoading = false;
   };
+  renderDirty = false;
+  stopLoadingRequest();
   if (!IsShownOnScreen()) {
     clearLoadingState();
     notifyRenderReady();
     return;
   }
-
-  renderDirty = false;
 
   Viewer2DOffscreenRenderer *offscreenRenderer = nullptr;
   Viewer2DPanel *capturePanel = nullptr;


### PR DESCRIPTION
### Motivation
- Ensure cache-only invalidations (e.g. per-element `cache.renderDirty = true`) can rebuild textures without leaving a persistent loading overlay or referencing missing textures by normalizing loading flags and render state at the start of the rebuild flow.

### Description
- Add a `stopLoadingRequest` helper and make `clearLoadingState` call it to centralize stopping the loading overlay behavior (`loadingRequested` / `loadingTimer_`).
- Clear `renderDirty` and call `stopLoadingRequest()` at the start of `RebuildCachedTexture()` so the global render flag and loading request are consistent even when only per-cache entries are dirty.
- Remove the duplicated `renderDirty = false` and keep existing early-return behavior guarded by `NeedsRenderRebuild()`; all changes are in `gui/layoutviewerpanel.cpp`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b2f5dc0a88324a87da3cc8ca520c9)