### PR TITLE
Capture stopLoadingRequest in clearLoadingState

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1224,7 +1224,7 @@ void LayoutViewerPanel::RebuildCachedTexture() {
     if (loadingTimer_.IsRunning())
       loadingTimer_.Stop();
   };
-  auto clearLoadingState = [this]() {
+  auto clearLoadingState = [this, stopLoadingRequest]() {
     stopLoadingRequest();
     isLoading = false;
   };


### PR DESCRIPTION
### Motivation
- Prevent implicit use of the local lambda `stopLoadingRequest` from within `clearLoadingState` in `LayoutViewerPanel::RebuildCachedTexture()` to avoid accidental dangling/unspecified captures.

### Description
- Update the `clearLoadingState` lambda capture in `gui/layoutviewerpanel.cpp` to explicitly capture `stopLoadingRequest` (now `auto clearLoadingState = [this, stopLoadingRequest]() { ... };`).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b341f3f78832492f64d0a7f5a00b0)