### PR TITLE
Guard layout viewer rendering until GL is ready

### DIFF
--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -110,6 +110,7 @@ private:
   void OnCaptureLost(wxMouseCaptureLostEvent &event);
   void OnRightUp(wxMouseEvent &event);
   void OnKeyDown(wxKeyEvent &event);
+  void OnShow(wxShowEvent &event);
   void OnEditView(wxCommandEvent &event);
   void OnDeleteView(wxCommandEvent &event);
   void OnDeleteLegend(wxCommandEvent &event);
@@ -259,6 +260,7 @@ private:
   int selectedElementId = -1;
   wxGLContext *glContext_ = nullptr;
   bool glInitialized_ = false;
+  bool isReadyToRender_ = false;
   bool renderDirty = true;
   double lastRenderZoom = 0.0;
   double lastPageWidthPt = 0.0;


### PR DESCRIPTION
### Motivation
- Prevent expensive GL rebuilds and drawing of the loading overlay before the panel has a valid GL context or the offscreen renderer is available.
- Avoid race conditions and redundant global invalidation while preserving existing partial-cache / versioning behavior.

### Description
- Added `isReadyToRender_` flag to `LayoutViewerPanel` and an `OnShow(wxShowEvent)` handler bound to `EVT_SHOW` to initialize GL when the panel becomes visible and to request rebuilds once ready.
- Hardened `InitGL()` to check `SetCurrent()` success and set `isReadyToRender_` only when GL is correctly initialized.
- Prevented `RequestRenderRebuild()` from running unless `isReadyToRender_`, a GL context and a valid offscreen renderer/panel are present.
- Added early-returns in `RebuildCachedTexture()` when not ready or when `MainWindow::Instance()` / `offscreenRenderer` / capture panel are not available so caches and overlay are not touched prematurely.
- Guarded `OnPaint()` and `DrawLoadingOverlay()` to avoid drawing the loading overlay or performing paint work before `isReadyToRender_`, and trigger a deferred `RequestRenderRebuild()` from paint when the panel becomes ready.
- Kept existing partial cache logic, cache invalidation rules and view-versioning intact (no rollback of previous cache/version behavior).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b361b389c8324aa17f59f5c34862d)