### PR TITLE
Fix LayoutViewerPanel InitGL return paths

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1214,9 +1214,9 @@ bool LayoutViewerPanel::InitGL() {
   if (!glContext_)
     return false;
   if (!IsShownOnScreen())
-    return;
+    return false;
   if (!SetCurrent(*glContext_))
-    return;
+    return false;
   if (!glInitialized_) {
     glDisable(GL_DEPTH_TEST);
     glEnable(GL_BLEND);
@@ -1224,6 +1224,7 @@ bool LayoutViewerPanel::InitGL() {
     glInitialized_ = true;
   }
   isReadyToRender_ = true;
+  return true;
 }
 
 void LayoutViewerPanel::RebuildCachedTexture() {


### PR DESCRIPTION
### Motivation
- Resolve compiler error C2561 by ensuring `LayoutViewerPanel::InitGL` returns a boolean on all control paths.

### Description
- Return `false` for early exits when `IsShownOnScreen()` or `SetCurrent(*glContext_)` fail and return `true` on successful initialization.
- Preserve the existing GL initialization sequence and `isReadyToRender_` assignment.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b3b2ee4888324a663aaf58614b190)