### PR TITLE
Avoid dangling layout pointer by copying selected layout

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -628,12 +628,12 @@ void MainWindow::ActivateLayoutView(const std::string &layoutName) {
   }
   activeLayoutName = layoutName;
 
-  const layouts::LayoutDefinition *selectedLayout = nullptr;
+  std::optional<layouts::LayoutDefinition> selectedLayout;
   bool appliedLayout = false;
   const auto &layouts = layouts::LayoutManager::Get().GetLayouts().Items();
   for (const auto &layout : layouts) {
     if (layout.name == layoutName) {
-      selectedLayout = &layout;
+      selectedLayout = layout;
       if (layoutViewerPanel) {
         ShowLayoutLoadingIndicator("Rendering layout...");
         if (GetStatusBar())


### PR DESCRIPTION
### Motivation
- Prevent a `read access violation` caused by holding a pointer into the layout collection when the collection can change while restoring a 2D view, which triggered a `front()` access on an invalid/vector element.

### Description
- Replace a raw pointer to a `layouts::LayoutDefinition` with `std::optional<layouts::LayoutDefinition>` and store the selected layout by value instead of keeping a pointer into the `LayoutManager` collection in `gui/mainwindow.cpp`.
- Use the copied layout when falling back to the first 2D view (`view2dViews.front()`) so the fallback does not reference an invalidated object.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b3be3a80c83248199a52afca84e2a)