### PR TITLE
Guard layout view filesystem path handling

### DIFF
--- a/gui/layoutviewerpanel_legend.cpp
+++ b/gui/layoutviewerpanel_legend.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <exception>
 #include <filesystem>
 #include <functional>
 #include <limits>
@@ -724,11 +725,16 @@ LayoutViewerPanel::BuildLegendItems() const {
     std::string typeName = fixture.typeName;
     std::string fullPath;
     if (!fixture.gdtfSpec.empty()) {
-      std::filesystem::path p = basePath.empty()
-                                    ? std::filesystem::path(fixture.gdtfSpec)
-                                    : std::filesystem::path(basePath) /
-                                          fixture.gdtfSpec;
-      fullPath = p.string();
+      try {
+        std::filesystem::path p =
+            basePath.empty()
+                ? std::filesystem::u8path(fixture.gdtfSpec)
+                : std::filesystem::u8path(basePath) /
+                      std::filesystem::u8path(fixture.gdtfSpec);
+        fullPath = p.string();
+      } catch (const std::exception &) {
+        fullPath.clear();
+      }
     }
     if (typeName.empty() && !fullPath.empty()) {
       wxFileName fn(fullPath);


### PR DESCRIPTION
### Motivation
- Prevent an unhandled exception/crash when opening the layouts view caused by constructing `std::filesystem::path` from invalid or non-UTF-8 layout resource paths (image and GDTF paths). 

### Description
- Wrap filesystem path construction for layout image hashing in a `try/catch` and use `std::filesystem::u8path` to avoid exceptions for invalid UTF-8 paths, returning the partial hash on failure. 
- Guard GDTF fixture path construction in the legend builder with `std::filesystem::u8path` inside a `try/catch` and clear `fullPath` on failure to avoid crashing when deriving names. 
- Add explicit `<exception>` includes where needed. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b3cf3b8a88324b3b9af62bfe4d060)