### PR TITLE
Guard 2D rendering when GL context is unavailable

### DIFF
--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -411,7 +411,9 @@ void Viewer2DPanel::InitGL() {
       !m_allowOffscreenRender) {
     return;
   }
-  SetCurrent(*m_glContext);
+  if (!SetCurrent(*m_glContext)) {
+    return;
+  }
   if (!m_glInitialized) {
     glewExperimental = GL_TRUE;
     glewInit();
@@ -425,6 +427,9 @@ void Viewer2DPanel::InitGL() {
 void Viewer2DPanel::Render() { RenderInternal(true); }
 
 void Viewer2DPanel::RenderInternal(bool swapBuffers) {
+  if (!m_glInitialized) {
+    return;
+  }
   int w, h;
   GetClientSize(&w, &h);
 
@@ -615,6 +620,10 @@ bool Viewer2DPanel::RenderToRGBA(std::vector<unsigned char> &pixels, int &width,
   bool previousForce = m_forceOffscreenRender;
   m_forceOffscreenRender = true;
   InitGL();
+  if (!m_glInitialized) {
+    m_forceOffscreenRender = previousForce;
+    return false;
+  }
   RenderInternal(false);
 
   glReadBuffer(GL_BACK);


### PR DESCRIPTION
### Motivation
- Prevent an unhandled exception when opening the Layouts view caused by attempting OpenGL operations before the GL context is current or initialized, and make offscreen captures fail gracefully instead of invoking GL with an invalid context.

### Description
- In `viewer2d/viewer2dpanel.cpp` make `InitGL()` return early if `SetCurrent(*m_glContext)` fails so the GL context is not assumed available.
- Add an early return in `RenderInternal()` when `m_glInitialized` is false to avoid issuing GL calls before initialization.
- In `RenderToRGBA()` call `InitGL()` and return `false` if GL initialization did not complete, so offscreen capture bails out safely.
- Changes are limited to `viewer2d/viewer2dpanel.cpp` and committed with a concise message.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b3fe2da788324ae7a65a33e7c54bf)