### PR TITLE
Skip loading overlay for empty layouts

### DIFF
--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -239,6 +239,7 @@ private:
 
   std::vector<ZOrderedElement> BuildZOrderedElements() const;
   std::pair<int, int> GetZIndexRange() const;
+  bool IsLayoutEmpty() const;
 
   static constexpr double kLegendContentScale = 0.7;
   static constexpr double kLegendFontScale =

--- a/gui/layoutviewerpanel_legend.cpp
+++ b/gui/layoutviewerpanel_legend.cpp
@@ -694,12 +694,18 @@ void LayoutViewerPanel::DrawLegendElement(
 }
 
 void LayoutViewerPanel::RefreshLegendData() {
+  if (currentLayout.legendViews.empty())
+    return;
   std::vector<LegendItem> items = BuildLegendItems();
   size_t newHash = HashLegendItems(items);
   if (newHash == legendDataHash)
     return;
   legendItems_ = std::move(items);
   legendDataHash = newHash;
+  if (legendItems_.size() == 1 &&
+      legendItems_.front().typeName == "No fixtures") {
+    return;
+  }
   for (auto &entry : legendCaches_) {
     entry.second.renderDirty = true;
   }


### PR DESCRIPTION
### Motivation
- Avoid showing the "Loading layout..." overlay and creating render/legend textures when switching to a layout that contains no elements to improve perceived responsiveness.
- Prevent unnecessary legend regeneration when there are no legend views or when the legend only contains the placeholder "No fixtures" entry.

### Description
- Added helper `IsLayoutEmpty()` to `LayoutViewerPanel` (`gui/layoutviewerpanel.h` / `gui/layoutviewerpanel.cpp`) which returns true when `view2dViews`, `legendViews`, `eventTables`, `textViews` and `imageViews` are all empty.
- Updated `SetLayoutDefinition()` in `gui/layoutviewerpanel.cpp` to early-return for empty layouts after clearing selection/caches, disabling `renderDirty`/`loadingRequested`/`isLoading`, clearing legend data, calling `ResetViewToFit()` and `Refresh()` without calling `RefreshLegendData()` or `RequestRenderRebuild()`.
- Guarded `RequestRenderRebuild()` in `gui/layoutviewerpanel.cpp` to immediately clear pending/loading state and return when `IsLayoutEmpty()` is true so no loading timers or render delay timers are started for empty layouts.
- Modified `RefreshLegendData()` in `gui/layoutviewerpanel_legend.cpp` to return immediately when there are no `legendViews`, and to avoid marking renders dirty or calling `RequestRenderRebuild()` when the built legend items are the single placeholder item with `typeName == "No fixtures"`.
- Files changed: `gui/layoutviewerpanel.h`, `gui/layoutviewerpanel.cpp`, `gui/layoutviewerpanel_legend.cpp`.

### Testing
- No automated tests were run as part of this change.
- Manual validation notes were not included in this PR description (only automated test results belong here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b5c792cc083248a067811f8e1f021)