### PR TITLE
Avoid loading overlay for empty layouts

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -471,7 +471,8 @@ void LayoutViewerPanel::OnPaint(wxPaintEvent &) {
       activeElementHasTexture = hasTexture(imageCaches_, activeImageId);
     }
   }
-  const bool showLoadingOverlay = !texturesReady || !activeElementHasTexture;
+  const bool showLoadingOverlay =
+      !IsLayoutEmpty() && (!texturesReady || !activeElementHasTexture);
   if (showLoadingOverlay && isReadyToRender_) {
     DrawLoadingOverlay(size);
   }


### PR DESCRIPTION
### Motivation
- Prevent the Layout Viewer from remaining stuck on the "Loading layout..." overlay when the current layout contains no elements.

### Description
- In `gui/layoutviewerpanel.cpp` change the `showLoadingOverlay` condition to `!IsLayoutEmpty() && (!texturesReady || !activeElementHasTexture)` so `DrawLoadingOverlay` is not called for empty layouts.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b5f59577c8324b271215af1c10a47)