### PR TITLE
Fix layout render-ready for empty layouts

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -162,6 +162,7 @@ void LayoutViewerPanel::SetLayoutDefinition(
     pendingFitOnResize = true;
     ResetViewToFit();
     Refresh();
+    NotifyRenderReady();
     return;
   }
   renderDirty = true;
@@ -171,6 +172,14 @@ void LayoutViewerPanel::SetLayoutDefinition(
   ResetViewToFit();
   RequestRenderRebuild();
   Refresh();
+}
+
+void LayoutViewerPanel::NotifyRenderReady() {
+  CallAfter([this]() {
+    wxCommandEvent event(EVT_LAYOUT_RENDER_READY);
+    event.SetEventObject(this);
+    wxPostEvent(this, event);
+  });
 }
 
 std::vector<LayoutViewerPanel::ZOrderedElement>
@@ -1263,13 +1272,6 @@ void LayoutViewerPanel::RebuildCachedTexture() {
   if (!capturePanel || !offscreenRenderer) {
     return;
   }
-  auto notifyRenderReady = [this]() {
-    CallAfter([this]() {
-      wxCommandEvent event(EVT_LAYOUT_RENDER_READY);
-      event.SetEventObject(this);
-      wxPostEvent(this, event);
-    });
-  };
   auto stopLoadingRequest = [this]() {
     loadingRequested = false;
     if (loadingTimer_.IsRunning())
@@ -1367,7 +1369,7 @@ void LayoutViewerPanel::RebuildCachedTexture() {
 
     if (!InitGL()) {
       clearLoadingState();
-      notifyRenderReady();
+      NotifyRenderReady();
       return;
     }
     if (cache.texture == 0) {
@@ -1440,7 +1442,7 @@ void LayoutViewerPanel::RebuildCachedTexture() {
 
     if (!InitGL()) {
       clearLoadingState();
-      notifyRenderReady();
+      NotifyRenderReady();
       return;
     }
     if (cache.texture == 0) {
@@ -1524,7 +1526,7 @@ void LayoutViewerPanel::RebuildCachedTexture() {
 
     if (!InitGL()) {
       clearLoadingState();
-      notifyRenderReady();
+      NotifyRenderReady();
       return;
     }
     if (cache.texture == 0) {
@@ -1607,7 +1609,7 @@ void LayoutViewerPanel::RebuildCachedTexture() {
 
     if (!InitGL()) {
       clearLoadingState();
-      notifyRenderReady();
+      NotifyRenderReady();
       return;
     }
     if (cache.texture == 0) {
@@ -1696,7 +1698,7 @@ void LayoutViewerPanel::RebuildCachedTexture() {
 
     if (!InitGL()) {
       clearLoadingState();
-      notifyRenderReady();
+      NotifyRenderReady();
       return;
     }
     if (cache.texture == 0) {
@@ -1716,7 +1718,7 @@ void LayoutViewerPanel::RebuildCachedTexture() {
   }
 
   clearLoadingState();
-  notifyRenderReady();
+  NotifyRenderReady();
 }
 
 void LayoutViewerPanel::ClearCachedTexture() {

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -100,6 +100,7 @@ private:
     size_t contentHash = 0;
   };
 
+  void NotifyRenderReady();
   void OnPaint(wxPaintEvent &event);
   void OnSize(wxSizeEvent &event);
   void OnLeftDown(wxMouseEvent &event);


### PR DESCRIPTION
### Motivation
- Switching to an empty layout could leave the UI in a loading state (busy cursor) because no render-ready event was emitted. 
- Render-ready notification logic was duplicated in a lambda and not always invoked on early-return code paths. 

### Description
- Added `NotifyRenderReady()` to `gui/layoutviewerpanel.h` and implemented it in `gui/layoutviewerpanel.cpp` to centralize posting of `EVT_LAYOUT_RENDER_READY` via `CallAfter`/`wxPostEvent`. 
- Call `NotifyRenderReady()` when switching to an empty layout in `SetLayoutDefinition` so the main window clears the busy cursor. 
- Removed the local `notifyRenderReady` lambda in `RebuildCachedTexture()` and replaced all calls to it (including early-return paths when `InitGL()` fails) with the new helper, and call it at the end of the render rebuild. 
- Modified only `gui/layoutviewerpanel.h` and `gui/layoutviewerpanel.cpp`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b6067a2cc83248c7411a14cdcd7b8)