### PR TITLE
Avoid starting drag update worker for offscreen 2D panels

### DIFF
--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -192,7 +192,9 @@ Viewer2DPanel::Viewer2DPanel(wxWindow *parent, bool allowOffscreenRender,
   SetBackgroundStyle(wxBG_STYLE_CUSTOM);
   m_controller.SetSelectionOutlineEnabled(m_enableSelection);
   m_glContext = new wxGLContext(this);
-  StartDragTableUpdateWorker();
+  if (m_enableSelection) {
+    StartDragTableUpdateWorker();
+  }
 }
 
 Viewer2DPanel::~Viewer2DPanel() {


### PR DESCRIPTION
### Motivation
- Prevent a background drag-update worker from running for offscreen 2D panels (which disable selection), avoiding work and potential exceptions when opening the Layouts view.

### Description
- Call `StartDragTableUpdateWorker()` in `Viewer2DPanel` constructor only when `m_enableSelection` is true; change made in `viewer2d/viewer2dpanel.cpp` to skip the worker for panels used by the offscreen layout renderer.

### Testing
- No automated tests were run for this change (`not run`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b62b79dc48324aecd1f6505f4da5e)