### PR TITLE
Guard layout render allocations to avoid std::bad_alloc

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -48,6 +48,7 @@ constexpr int kLayoutGridStep = 5;
 constexpr int kMaxRenderDimension = 8192;
 constexpr size_t kMaxRenderPixels =
     static_cast<size_t>(kMaxRenderDimension) * kMaxRenderDimension;
+constexpr size_t kMaxRenderBytes = 64 * 1024 * 1024;
 constexpr int kEditMenuId = wxID_HIGHEST + 490;
 constexpr int kDeleteMenuId = wxID_HIGHEST + 491;
 constexpr int kDeleteLegendMenuId = wxID_HIGHEST + 492;
@@ -1205,6 +1206,12 @@ wxSize LayoutViewerPanel::GetFrameSizeForZoom(
     return wxSize(0, 0);
   if (static_cast<size_t>(scaledWidth) >
       kMaxRenderPixels / static_cast<size_t>(scaledHeight))
+    return wxSize(0, 0);
+  const size_t pixelCount =
+      static_cast<size_t>(scaledWidth) * static_cast<size_t>(scaledHeight);
+  if (pixelCount > kMaxRenderPixels)
+    return wxSize(0, 0);
+  if (pixelCount > kMaxRenderBytes / 4)
     return wxSize(0, 0);
   return wxSize(scaledWidth, scaledHeight);
 }


### PR DESCRIPTION
### Motivation
- Prevent crashes observed when opening layouts due to oversized RGBA allocations during offscreen rendering and text/image texture uploads.

### Description
- Added a byte-size cap `kMaxRenderBytes` and extra checks in `GetFrameSizeForZoom` to early-reject frame sizes that would exceed pixel or memory limits.
- The guard enforces both per-dimension (`kMaxRenderDimension`) and total pixel/byte limits before allocating RGBA buffers to avoid `std::bad_alloc` during capture/texture creation in `gui/layoutviewerpanel.cpp`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ba40868ec8324b00736774ef7a528)