### PR TITLE
Avoid showing layout busy cursor when layout viewer is hidden

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -601,6 +601,13 @@ void MainWindow::OnLayoutSelected(wxCommandEvent &event) {
 }
 
 void MainWindow::ShowLayoutLoadingIndicator(const wxString &message) {
+  if (auiManager) {
+    auto &layoutPane = auiManager->GetPane("LayoutViewer");
+    if (layoutPane.IsOk() && !layoutPane.IsShown())
+      return;
+  }
+  if (layoutViewerPanel && !layoutViewerPanel->IsShownOnScreen())
+    return;
   if (GetStatusBar())
     SetStatusText(message);
   if (!layoutRenderCursor)


### PR DESCRIPTION
### Motivation
- Prevent the UI from showing a persistent busy cursor/status when the application renders a layout while the layout viewer is hidden or off-screen.

### Description
- Add early-return guards in `MainWindow::ShowLayoutLoadingIndicator` (in `gui/mainwindow.cpp`) to skip setting the status text and creating a `wxBusyCursor` when the AUI pane `LayoutViewer` is hidden or when `layoutViewerPanel->IsShownOnScreen()` is false.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ba938c1988324b1a52cc3061d2f2b)