### PR TITLE
Normalize GDTF offset parsing in ParseModes

### DIFF
--- a/viewer3d/gdtfloader.cpp
+++ b/viewer3d/gdtfloader.cpp
@@ -336,14 +336,24 @@ static void ParseModes(tinyxml2::XMLElement* ft,
                 GdtfChannelInfo info;
                 if (const char* offset = c->Attribute("Offset"))
                 {
+                    auto trim = [](std::string& value) {
+                        value.erase(0, value.find_first_not_of(" \t\r\n"));
+                        value.erase(value.find_last_not_of(" \t\r\n") + 1);
+                    };
                     std::string offStr = offset;
-                    size_t comma = offStr.find(',');
-                    std::string first = offStr.substr(0, comma);
-                    if (!TryParseInt(first, info.channel) && ConsolePanel::Instance()) {
-                        wxString msg = wxString::Format(
-                            "GDTF: invalid DMX channel offset '%s'",
-                            wxString::FromUTF8(first));
-                        ConsolePanel::Instance()->AppendMessage(msg);
+                    trim(offStr);
+                    if (!offStr.empty() && offStr != "None") {
+                        size_t comma = offStr.find(',');
+                        std::string first = offStr.substr(0, comma);
+                        trim(first);
+                        if (!first.empty() && first != "None") {
+                            if (!TryParseInt(first, info.channel) && ConsolePanel::Instance()) {
+                                wxString msg = wxString::Format(
+                                    "GDTF: invalid DMX channel offset '%s'",
+                                    wxString::FromUTF8(first));
+                                ConsolePanel::Instance()->AppendMessage(msg);
+                            }
+                        }
                     }
                 }
                 if (info.channel == 0)
@@ -358,24 +368,28 @@ static void ParseModes(tinyxml2::XMLElement* ft,
                 channelsVec.push_back(info);
 
                 if (const char* offset = c->Attribute("Offset")) {
+                    auto trim = [](std::string& value) {
+                        value.erase(0, value.find_first_not_of(" \t\r\n"));
+                        value.erase(value.find_last_not_of(" \t\r\n") + 1);
+                    };
                     std::string offStr = offset;
-                    if (!offStr.empty() && offStr != "None") {
-                        std::stringstream ss(offStr);
-                        std::string token;
-                        while (std::getline(ss, token, ',')) {
-                            token.erase(0, token.find_first_not_of(" \t\r\n"));
-                            token.erase(token.find_last_not_of(" \t\r\n") + 1);
-                            if (token.empty())
-                                continue;
-                            int parsed = 0;
-                            if (TryParseInt(token, parsed)) {
-                                ++count;
-                            } else if (ConsolePanel::Instance()) {
-                                wxString msg = wxString::Format(
-                                    "GDTF: invalid DMX channel offset '%s'",
-                                    wxString::FromUTF8(token));
-                                ConsolePanel::Instance()->AppendMessage(msg);
-                            }
+                    trim(offStr);
+                    if (offStr.empty() || offStr == "None")
+                        continue;
+                    std::stringstream ss(offStr);
+                    std::string token;
+                    while (std::getline(ss, token, ',')) {
+                        trim(token);
+                        if (token.empty() || token == "None")
+                            continue;
+                        int parsed = 0;
+                        if (TryParseInt(token, parsed)) {
+                            ++count;
+                        } else if (ConsolePanel::Instance()) {
+                            wxString msg = wxString::Format(
+                                "GDTF: invalid DMX channel offset '%s'",
+                                wxString::FromUTF8(token));
+                            ConsolePanel::Instance()->AppendMessage(msg);
                         }
                     }
                 }


### PR DESCRIPTION
### Motivation
- Prevent spurious error logs when DMX `Offset` attributes are empty or set to `"None"` and ensure offsets are normalized before parsing.

### Description
- Add a local `trim` lambda and use it to normalize `offStr` and the first token before attempting `TryParseInt` on the first offset token.
- Skip parsing and avoid logging when `offStr` or a token is empty or equals `"None"` so logs only appear for actual parse failures.
- Apply the same trimming and filtering to the loop that iterates comma-separated offset tokens and increments the channel `count` only for successfully parsed tokens.
- Changes are confined to `ParseModes` in `viewer3d/gdtfloader.cpp` and do not alter other logic.

### Testing
- No automated tests were run on the modified code in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bb486f6fc8324baf06dfa0a96f1aa)