### PR TITLE
Guard 2D view state restore after layout mode transitions

### DIFF
--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -360,6 +360,17 @@ void MainWindow::ApplyLayoutPreset(const LayoutViewPreset &preset,
     if (standalone2DState) {
       ConfigManager &cfg = ConfigManager::Get();
       if (viewport2DPanel) {
+        const auto viewState = viewport2DPanel->GetViewState();
+        standalone2DState->camera.offsetPixelsX = viewState.offsetPixelsX;
+        standalone2DState->camera.offsetPixelsY = viewState.offsetPixelsY;
+        standalone2DState->camera.zoom = viewState.zoom;
+        standalone2DState->camera.viewportWidth = viewState.viewportWidth;
+        standalone2DState->camera.viewportHeight = viewState.viewportHeight;
+        standalone2DState->camera.view = static_cast<int>(viewState.view);
+      } else {
+        standalone2DState->camera = viewer2d::CaptureState(nullptr, cfg).camera;
+      }
+      if (viewport2DPanel) {
         viewer2d::ApplyState(viewport2DPanel, viewport2DRenderPanel, cfg,
                              *standalone2DState);
       } else {


### PR DESCRIPTION
### Motivation
- Prevent `viewer2d::ApplyState` from overwriting a restored 2D zoom when leaving layout mode or during startup by ensuring the saved `standalone2DState` camera matches the current/loaded `Viewer2DPanel` view before applying it.

### Description
- Update `ApplyLayoutPreset` in `gui/mainwindow_layout.cpp` to sync `standalone2DState->camera` from `viewport2DPanel->GetViewState()` when exiting layout mode so the restored zoom/offset are preserved.
- Add a fallback to load camera values from `viewer2d::CaptureState(nullptr, cfg)` when the 2D panel is not available.
- Preserve the existing behavior of calling `viewer2d::ApplyState(...)` and then clearing `standalone2DState` after applying.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bb9ab3ec08324a975c18b322e8b76)