### PR TITLE
Return true for std::exception in OnExceptionInMainLoop to allow wxWidgets continuation

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -164,6 +164,7 @@ bool MyApp::OnExceptionInMainLoop() {
     throw;
   } catch (const std::exception &ex) {
     LogExceptionWithStack(ex, "Unhandled exception in main loop: ");
+    return true;
   } catch (...) {
     Logger::Instance().Log("Unhandled exception in main loop: unknown error.");
   }


### PR DESCRIPTION
### Motivation
- Avoid immediate application exit on recoverable exceptions in the main loop and ensure the exception `what()` message is recorded for diagnostics.

### Description
- Log `std::exception::what()` via `LogExceptionWithStack` and return `true` in `MyApp::OnExceptionInMainLoop()` for caught `std::exception` so wxWidgets can attempt to continue, while unknown exceptions still fall through and return `false` to allow irreparable handling.

### Testing
- No automated tests or build steps were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bcb668030832485037e13d040e760)