### PR TITLE
Log exception messages in MyApp exception handlers

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -163,6 +163,7 @@ bool MyApp::OnExceptionInMainLoop() {
   try {
     throw;
   } catch (const std::exception &ex) {
+    Logger::Instance().Log(ex.what());
     LogExceptionWithStack(ex, "Unhandled exception in main loop: ");
     return true;
   } catch (...) {
@@ -175,6 +176,7 @@ void MyApp::OnUnhandledException() {
   try {
     throw;
   } catch (const std::exception &ex) {
+    Logger::Instance().Log(ex.what());
     LogExceptionWithStack(ex, "Unhandled exception: ");
   } catch (...) {
     Logger::Instance().Log("Unhandled exception: unknown error.");


### PR DESCRIPTION
### Motivation
- Ensure `perastage.log` records the exact exception reason by logging `std::exception::what()` when exceptions occur in the app's main loop and global handler.

### Description
- In `main.cpp` (class `MyApp`) add `Logger::Instance().Log(ex.what());` to `OnExceptionInMainLoop()` and `OnUnhandledException()` before the existing `LogExceptionWithStack(...)` calls, preserving stack-trace logging.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bcf6667dc832488800736c9fd5c92)