### PR TITLE
Guard viewer allocations and handle bad_alloc

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -21,6 +21,7 @@
 #include "projectutils.h"
 #include "splashscreen.h"
 #include <filesystem>
+#include <new>
 #include <thread>
 #include <wx/stackwalk.h>
 #include <wx/sysopt.h>
@@ -163,7 +164,10 @@ bool MyApp::OnExceptionInMainLoop() {
   try {
     throw;
   } catch (const std::exception &ex) {
-    Logger::Instance().Log(ex.what());
+    if (dynamic_cast<const std::bad_alloc *>(&ex)) {
+      Logger::Instance().Log("Unhandled exception in main loop: bad allocation.");
+      return true;
+    }
     LogExceptionWithStack(ex, "Unhandled exception in main loop: ");
     return true;
   } catch (...) {
@@ -176,7 +180,10 @@ void MyApp::OnUnhandledException() {
   try {
     throw;
   } catch (const std::exception &ex) {
-    Logger::Instance().Log(ex.what());
+    if (dynamic_cast<const std::bad_alloc *>(&ex)) {
+      Logger::Instance().Log("Unhandled exception: bad allocation.");
+      return;
+    }
     LogExceptionWithStack(ex, "Unhandled exception: ");
   } catch (...) {
     Logger::Instance().Log("Unhandled exception: unknown error.");


### PR DESCRIPTION
### Motivation
- The app crashed with `bad allocation` during large texture/capture allocations and the exception stack-walk path can allocate more memory during low-memory conditions, worsening the failure.
- Add lightweight guards and short-circuit handling to avoid attempting large allocations and to log `bad_alloc` without performing stack traces that may allocate.

### Description
- Short-circuit `std::bad_alloc` in the global exception hooks by detecting `bad_alloc` and logging a concise message instead of performing a stack walk (`MyApp::OnExceptionInMainLoop` and `MyApp::OnUnhandledException` in `main.cpp`).
- Add include of `<new>` where `bad_alloc` is caught (`main.cpp`, `gui/layoutviewerpanel.cpp`, `viewer2d/viewer2dpanel.cpp`).
- Add `TryAllocatePixelBuffer` in `gui/layoutviewerpanel.cpp` to enforce `kMaxRenderPixels`/`kMaxRenderBytes` limits and catch `bad_alloc`, and replace direct `pixels.resize(...)` calls for legend, event table, text and image caches with this guarded allocator.
- Add `TryAllocateCaptureBuffer` in `viewer2d/viewer2dpanel.cpp` and use it from `Viewer2DPanel::RenderToRGBA` to prevent oversized capture buffer allocations and log failures.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bb112ca748324a800b150c07b4370)