### PR TITLE
Escribir mensajes de log incrementalmente en Logger::Worker

### DIFF
--- a/core/logger.cpp
+++ b/core/logger.cpp
@@ -87,20 +87,21 @@ void Logger::Worker() {
       queue_.pop();
     }
     lock.unlock();
-    std::string buffer;
     for (const auto &msg : batch) {
-      buffer.append(msg);
-      buffer.push_back('\n');
-    }
-    if (file_.is_open()) {
-      file_ << buffer;
-      messages_since_flush += batch.size();
-      if (shutting_down || messages_since_flush >= kFlushInterval) {
-        file_.flush();
-        messages_since_flush = 0;
+      if (file_.is_open()) {
+        file_ << msg << '\n';
+        ++messages_since_flush;
+        if (messages_since_flush >= kFlushInterval) {
+          file_.flush();
+          messages_since_flush = 0;
+        }
       }
+      std::cerr << msg << '\n';
     }
-    std::cerr << buffer;
+    if (file_.is_open() && shutting_down && messages_since_flush > 0) {
+      file_.flush();
+      messages_since_flush = 0;
+    }
     lock.lock();
   }
 }


### PR DESCRIPTION
### Motivation
- Evitar la construcción de un único buffer grande que puede crecer sin límite y reducir latencia escribiendo cada mensaje al archivo y a stderr, manteniendo flush periódico y sin bloquear el hilo de logging.

### Description
- Reemplaza la acumulación en `buffer` por escritura incremental: `file_ << msg << '\n'` y `std::cerr << msg << '\n'` dentro del bucle del worker.
- Mantiene el contador `messages_since_flush` y realiza `file_.flush()` cuando alcanza `kFlushInterval` o en shutdown para asegurar que no se pierdan mensajes.
- Conserva la lógica de desbloqueo del `mutex_` alrededor de las operaciones de E/S para evitar bloquear el hilo de log.

### Testing
- No se ejecutaron pruebas automatizadas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bd621e2308324ab4864e9e20ddd02)