### PR TITLE
Limit console panel log message length

### DIFF
--- a/gui/consolepanel.cpp
+++ b/gui/consolepanel.cpp
@@ -65,19 +65,30 @@ void ConsolePanel::AppendMessage(const wxString &msg) {
   if (!m_textCtrl)
     return;
 
-  if (msg == m_lastMessage) {
+  constexpr size_t kMaxConsoleMessageLength = 8 * 1024;
+  const wxString suffix = "... (truncado)";
+  wxString safeMsg = msg;
+  if (safeMsg.length() > kMaxConsoleMessageLength) {
+    size_t keepLength =
+        kMaxConsoleMessageLength > suffix.length()
+            ? kMaxConsoleMessageLength - suffix.length()
+            : 0;
+    safeMsg = safeMsg.Left(keepLength) + suffix;
+  }
+
+  if (safeMsg == m_lastMessage) {
     m_repeatCount++;
-    wxString combined = wxString::Format("%s (repeated %zu times)", msg,
+    wxString combined = wxString::Format("%s (repeated %zu times)", safeMsg,
                                         m_repeatCount);
     long endPos = m_textCtrl->GetLastPosition();
     if (m_lastLineStart < endPos)
       m_textCtrl->Remove(m_lastLineStart, endPos);
     m_textCtrl->AppendText(combined + "\n");
   } else {
-    m_lastMessage = msg;
+    m_lastMessage = safeMsg;
     m_repeatCount = 1;
     m_lastLineStart = m_textCtrl->GetLastPosition();
-    m_textCtrl->AppendText(msg + "\n");
+    m_textCtrl->AppendText(safeMsg + "\n");
   }
   if (m_autoScroll)
     m_textCtrl->ShowPosition(m_textCtrl->GetLastPosition());

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -136,7 +136,17 @@ static std::string CieToHex(const std::string &cie) {
 static void LogMessage(const std::string &msg) {
   Logger::Instance().Log(msg);
   if (ConsolePanel::Instance() && wxTheApp) {
-    wxString wmsg = wxString::FromUTF8(msg.c_str());
+    constexpr size_t kMaxConsoleMessageLength = 8 * 1024;
+    const std::string suffix = "... (truncado)";
+    std::string panelMsg = msg;
+    if (panelMsg.size() > kMaxConsoleMessageLength) {
+      size_t keepLength =
+          kMaxConsoleMessageLength > suffix.size()
+              ? kMaxConsoleMessageLength - suffix.size()
+              : 0;
+      panelMsg = panelMsg.substr(0, keepLength) + suffix;
+    }
+    wxString wmsg = wxString::FromUTF8(panelMsg.c_str());
     wxTheApp->CallAfter([wmsg]() {
       if (ConsolePanel::Instance())
         ConsolePanel::Instance()->AppendMessage(wmsg);


### PR DESCRIPTION
### Motivation
- Evitar que mensajes muy largos provoquen bloqueos o errores al enviar texto al panel de consola y proteger el hilo GUI de cadenas excesivas.
- Aplicar un límite razonable a los mensajes que se envían desde el importador y añadir una defensa adicional en el propio `ConsolePanel`.

### Description
- En `mvr/mvrimporter.cpp` se trunca el mensaje antes de enviarlo al panel con un límite de `kMaxConsoleMessageLength = 8 * 1024` y se añade el sufijo `"... (truncado)"` cuando procede.
- En `gui/consolepanel.cpp` se añade una comprobación defensiva que recorta entradas mayores que `kMaxConsoleMessageLength`, manteniendo la lógica de detección de mensajes repetidos y la etiqueta de repetición.
- Ambos cambios usan constantes locales y preservan la codificación UTF-8 al convertir a `wxString` antes de llamar a `AppendMessage`.
- Se actualizó el texto que se escribe en el control para usar la versión truncada (`safeMsg`) en lugar del mensaje original.

### Testing
- No se ejecutaron pruebas automatizadas sobre los cambios.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bd727e4bc8324a8ed70bf1595bcf9)