### PR TITLE
Limit console panel log message length

### DIFF
--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -136,7 +136,17 @@ static std::string CieToHex(const std::string &cie) {
 static void LogMessage(const std::string &msg) {
   Logger::Instance().Log(msg);
   if (ConsolePanel::Instance() && wxTheApp) {
-    wxString wmsg = wxString::FromUTF8(msg.c_str());
+    static constexpr size_t kMaxPanelMessageBytes = 8192;
+    static constexpr std::string_view kTruncatedSuffix = "... (truncado)";
+    std::string panelMessage = msg;
+    if (panelMessage.size() > kMaxPanelMessageBytes) {
+      size_t trimSize = kMaxPanelMessageBytes > kTruncatedSuffix.size()
+                            ? kMaxPanelMessageBytes - kTruncatedSuffix.size()
+                            : 0;
+      panelMessage = panelMessage.substr(0, trimSize);
+      panelMessage.append(kTruncatedSuffix);
+    }
+    wxString wmsg = wxString::FromUTF8(panelMessage.c_str());
     wxTheApp->CallAfter([wmsg]() {
       if (ConsolePanel::Instance())
         ConsolePanel::Instance()->AppendMessage(wmsg);


### PR DESCRIPTION
### Motivation
- Evitar que mensajes muy largos enviados al panel de consola provoquen sobrecarga o errores en el hilo GUI restringiendo su longitud antes de append.

### Description
- En `mvr/mvrimporter.cpp` se preserva el log completo con `Logger::Instance().Log(msg)` y se limita lo enviado al panel a `kMaxPanelMessageBytes` (8192 bytes), truncando y añadiendo el sufijo `"... (truncado)"` cuando corresponde.
- En `gui/consolepanel.cpp` se añade una defensa adicional que recorta mensajes mayores que `kMaxConsoleMessageChars` (16384 caracteres) y usa el mismo sufijo antes de llamar a `AppendText`, asegurando también que la lógica de mensajes repetidos compare y almacene la versión recortada.
- Se añadió la inclusión de `<string_view>` y se introdujeron las constantes `kTruncatedSuffix`, `kMaxPanelMessageBytes` y `kMaxConsoleMessageChars` para claridad.
- El comportamiento de logging en fichero no cambia porque el mensaje original se sigue enviando a `Logger::Instance()`.

### Testing
- No se ejecutaron pruebas automáticas durante este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bd6da5c708324bf6ee6147e1479cb)