### PR TITLE
Add macOS OpenGL include guards

### DIFF
--- a/gui/fixturepreviewpanel.cpp
+++ b/gui/fixturepreviewpanel.cpp
@@ -22,8 +22,14 @@
 #endif
 
 #include <GL/glew.h>
-#include <GL/gl.h>
-#include <GL/glu.h>
+// Include GLEW or other OpenGL loader first if present
+#ifdef __APPLE__
+#  include <OpenGL/gl.h>
+#  include <OpenGL/glu.h>
+#else
+#  include <GL/gl.h>
+#  include <GL/glu.h>
+#endif
 
 #include <wx/wx.h>
 #include "fixturepreviewpanel.h"

--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -23,7 +23,14 @@
 #include <new>
 #include <vector>
 
-#include <GL/gl.h>
+// Include GLEW or other OpenGL loader first if present
+#ifdef __APPLE__
+#  include <OpenGL/gl.h>
+#  include <OpenGL/glu.h>
+#else
+#  include <GL/gl.h>
+#  include <GL/glu.h>
+#endif
 #ifndef GL_CLAMP_TO_EDGE
 #define GL_CLAMP_TO_EDGE 0x812F
 #endif

--- a/gui/layoutviewerpanel_eventtable.cpp
+++ b/gui/layoutviewerpanel_eventtable.cpp
@@ -21,7 +21,14 @@
 #include <array>
 #include <functional>
 
-#include <GL/gl.h>
+// Include GLEW or other OpenGL loader first if present
+#ifdef __APPLE__
+#  include <OpenGL/gl.h>
+#  include <OpenGL/glu.h>
+#else
+#  include <GL/gl.h>
+#  include <GL/glu.h>
+#endif
 
 #include "layouteventtabledialog.h"
 #include "layoutviewerpanel_shared.h"

--- a/gui/layoutviewerpanel_image.cpp
+++ b/gui/layoutviewerpanel_image.cpp
@@ -24,7 +24,14 @@
 #include <filesystem>
 #include <functional>
 
-#include <GL/gl.h>
+// Include GLEW or other OpenGL loader first if present
+#ifdef __APPLE__
+#  include <OpenGL/gl.h>
+#  include <OpenGL/glu.h>
+#else
+#  include <GL/gl.h>
+#  include <GL/glu.h>
+#endif
 
 #include "layoutimageutils.h"
 #include "layouts/LayoutManager.h"

--- a/gui/layoutviewerpanel_legend.cpp
+++ b/gui/layoutviewerpanel_legend.cpp
@@ -26,7 +26,14 @@
 #include <map>
 #include <vector>
 
-#include <GL/gl.h>
+// Include GLEW or other OpenGL loader first if present
+#ifdef __APPLE__
+#  include <OpenGL/gl.h>
+#  include <OpenGL/glu.h>
+#else
+#  include <GL/gl.h>
+#  include <GL/glu.h>
+#endif
 
 #include "configmanager.h"
 #include "gdtfloader.h"

--- a/gui/layoutviewerpanel_text.cpp
+++ b/gui/layoutviewerpanel_text.cpp
@@ -20,7 +20,14 @@
 #include <algorithm>
 #include <functional>
 
-#include <GL/gl.h>
+// Include GLEW or other OpenGL loader first if present
+#ifdef __APPLE__
+#  include <OpenGL/gl.h>
+#  include <OpenGL/glu.h>
+#else
+#  include <GL/gl.h>
+#  include <GL/glu.h>
+#endif
 
 #include <wx/log.h>
 #include <wx/richtext/richtextbuffer.h>

--- a/gui/layoutviewerpanel_view.cpp
+++ b/gui/layoutviewerpanel_view.cpp
@@ -20,7 +20,14 @@
 #include <algorithm>
 #include <memory>
 
-#include <GL/gl.h>
+// Include GLEW or other OpenGL loader first if present
+#ifdef __APPLE__
+#  include <OpenGL/gl.h>
+#  include <OpenGL/glu.h>
+#else
+#  include <GL/gl.h>
+#  include <GL/glu.h>
+#endif
 
 #include "configmanager.h"
 #include "layouts/LayoutManager.h"

--- a/viewer2d/canvas2d.cpp
+++ b/viewer2d/canvas2d.cpp
@@ -26,7 +26,14 @@
 #include <windows.h>
 #endif
 
-#include <GL/gl.h>
+// Include GLEW or other OpenGL loader first if present
+#ifdef __APPLE__
+#  include <OpenGL/gl.h>
+#  include <OpenGL/glu.h>
+#else
+#  include <GL/gl.h>
+#  include <GL/glu.h>
+#endif
 #include <wx/glcanvas.h>
 #include <algorithm>
 #include <array>

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -29,8 +29,14 @@
 #endif
 
 #include <GL/glew.h>
-#include <GL/gl.h>
-#include <GL/glu.h>
+// Include GLEW or other OpenGL loader first if present
+#ifdef __APPLE__
+#  include <OpenGL/gl.h>
+#  include <OpenGL/glu.h>
+#else
+#  include <GL/gl.h>
+#  include <GL/glu.h>
+#endif
 
 #include "viewer2dpanel.h"
 #include "configmanager.h"

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -30,8 +30,14 @@
 #endif
 
 #include <GL/glew.h>
-#include <GL/gl.h>
-#include <GL/glu.h>
+// Include GLEW or other OpenGL loader first if present
+#ifdef __APPLE__
+#  include <OpenGL/gl.h>
+#  include <OpenGL/glu.h>
+#else
+#  include <GL/gl.h>
+#  include <GL/glu.h>
+#endif
 #include <cstdlib>
 #include <numeric>
 

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -28,8 +28,14 @@
 #include <windows.h>
 #endif
 #include <GL/glew.h>
-#include <GL/gl.h>
-#include <GL/glu.h>
+// Include GLEW or other OpenGL loader first if present
+#ifdef __APPLE__
+#  include <OpenGL/gl.h>
+#  include <OpenGL/glu.h>
+#else
+#  include <GL/gl.h>
+#  include <GL/glu.h>
+#endif
 
 #include "viewer3dpanel.h"
 #include "consolepanel.h"


### PR DESCRIPTION
### Motivation
- macOS provides OpenGL headers via the `OpenGL` framework rather than `GL`, causing `fatal error: 'GL/gl.h' file not found` when building on Apple platforms.  
- The change keeps existing behavior on Windows and Linux while selecting the correct headers on macOS via `__APPLE__` so no logic or build linkage is altered.

### Description
- Replaced direct `#include <GL/gl.h>`/`#include <GL/glu.h>` with a conditional block using `#ifdef __APPLE__` to include `<OpenGL/gl.h>` and `<OpenGL/glu.h>` on macOS and the original headers elsewhere.  
- Preserved any existing `#include <GL/glew.h>` lines and their ordering (GLEW remains included before the conditional block).  
- Applied the change to the following files: `gui/fixturepreviewpanel.cpp`, `viewer2d/canvas2d.cpp`, `gui/layoutviewerpanel.cpp`, `gui/layoutviewerpanel_image.cpp`, `gui/layoutviewerpanel_text.cpp`, `gui/layoutviewerpanel_eventtable.cpp`, `gui/layoutviewerpanel_legend.cpp`, `gui/layoutviewerpanel_view.cpp`, `viewer3d/viewer3dcontroller.cpp`, `viewer3d/viewer3dpanel.cpp`, and `viewer2d/viewer2dpanel.cpp` (11 files total).  

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bd93881d48324abf6318a2784bbcb)