### PR TITLE
Log stack trace for std::bad_alloc in main loop

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -166,6 +166,7 @@ bool MyApp::OnExceptionInMainLoop() {
   } catch (const std::exception &ex) {
     if (dynamic_cast<const std::bad_alloc *>(&ex)) {
       Logger::Instance().Log("Unhandled exception in main loop: bad allocation.");
+      LogExceptionWithStack(ex, "Unhandled exception in main loop: ");
       return true;
     }
     LogExceptionWithStack(ex, "Unhandled exception in main loop: ");


### PR DESCRIPTION
### Motivation
- Ensure `std::bad_alloc` thrown inside the main loop is recorded with a full stack trace while keeping the existing specific "bad allocation" message.

### Description
- Update `MyApp::OnExceptionInMainLoop()` in `main.cpp` to call `LogExceptionWithStack(ex, "Unhandled exception in main loop: ")` in the `std::bad_alloc` branch so the stack trace is logged in addition to the specific log message; no other control flow changes were made.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bda7233c08324a7242a2018f895bb)