### PR TITLE
Add macOS OpenGL header guards and deprecation silencing

### DIFF
--- a/gui/fixturepreviewpanel.cpp
+++ b/gui/fixturepreviewpanel.cpp
@@ -22,13 +22,14 @@
 #endif
 
 #include <GL/glew.h>
-// Include GLEW or other OpenGL loader first if present
+// macOS ships OpenGL headers via the framework; use conditional includes for portability.
 #ifdef __APPLE__
-#  include <OpenGL/gl.h>
-#  include <OpenGL/glu.h>
+#define GL_SILENCE_DEPRECATION
+#include <OpenGL/gl.h>
+#include <OpenGL/glu.h>
 #else
-#  include <GL/gl.h>
-#  include <GL/glu.h>
+#include <GL/gl.h>
+#include <GL/glu.h>
 #endif
 
 #include <wx/wx.h>

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -29,13 +29,14 @@
 #endif
 
 #include <GL/glew.h>
-// Include GLEW or other OpenGL loader first if present
+// macOS uses the OpenGL framework headers; guard includes for cross-platform builds.
 #ifdef __APPLE__
-#  include <OpenGL/gl.h>
-#  include <OpenGL/glu.h>
+#define GL_SILENCE_DEPRECATION
+#include <OpenGL/gl.h>
+#include <OpenGL/glu.h>
 #else
-#  include <GL/gl.h>
-#  include <GL/glu.h>
+#include <GL/gl.h>
+#include <GL/glu.h>
 #endif
 
 #include "viewer2dpanel.h"

--- a/viewer3d/viewer3dcamera.cpp
+++ b/viewer3d/viewer3dcamera.cpp
@@ -30,7 +30,13 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif
+// macOS uses the OpenGL framework headers; choose the correct GLU header by platform.
+#ifdef __APPLE__
+#define GL_SILENCE_DEPRECATION
+#include <OpenGL/glu.h>
+#else
 #include <GL/glu.h>
+#endif
 
 Viewer3DCamera::Viewer3DCamera()
     : yaw(0.0f), pitch(20.0f), distance(30.0f),

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -30,13 +30,14 @@
 #endif
 
 #include <GL/glew.h>
-// Include GLEW or other OpenGL loader first if present
+// macOS provides OpenGL via the framework, so choose headers by platform.
 #ifdef __APPLE__
-#  include <OpenGL/gl.h>
-#  include <OpenGL/glu.h>
+#define GL_SILENCE_DEPRECATION
+#include <OpenGL/gl.h>
+#include <OpenGL/glu.h>
 #else
-#  include <GL/gl.h>
-#  include <GL/glu.h>
+#include <GL/gl.h>
+#include <GL/glu.h>
 #endif
 #include <cstdlib>
 #include <numeric>

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -28,13 +28,14 @@
 #include <windows.h>
 #endif
 #include <GL/glew.h>
-// Include GLEW or other OpenGL loader first if present
+// macOS ships OpenGL headers in the framework; include them conditionally.
 #ifdef __APPLE__
-#  include <OpenGL/gl.h>
-#  include <OpenGL/glu.h>
+#define GL_SILENCE_DEPRECATION
+#include <OpenGL/gl.h>
+#include <OpenGL/glu.h>
 #else
-#  include <GL/gl.h>
-#  include <GL/glu.h>
+#include <GL/gl.h>
+#include <GL/glu.h>
 #endif
 
 #include "viewer3dpanel.h"


### PR DESCRIPTION
### Motivation
- Ensure the project compiles cleanly on macOS by using the platform's OpenGL framework headers instead of hard-coded `<GL/...>` includes.
- Silence macOS OpenGL deprecation warnings via `GL_SILENCE_DEPRECATION` while preserving existing behavior on Windows/Linux.

### Description
- Replace unconditional OpenGL includes with platform-guarded includes and an explanatory comment in `gui/fixturepreviewpanel.cpp`, keeping the existing `GLEW` include where present.
- Add the same conditional include pattern and `GL_SILENCE_DEPRECATION` in `viewer2d/viewer2dpanel.cpp`, preserving `GLEW` usage and adding a short portability comment.
- Make the `glu.h` include platform-aware in `viewer3d/viewer3dcamera.cpp` to ensure `gluLookAt` is available on macOS.
- Add macOS framework guards and deprecation silencing to `viewer3d/viewer3dcontroller.cpp` and `viewer3d/viewer3dpanel.cpp`, keeping non-Apple code paths unchanged.

### Testing
- No automated build or test runs were executed as part of this change; only the source files were updated and committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697be272896c8324838812174990507c)