### PR TITLE
Use English truncation suffix for console messages

### DIFF
--- a/gui/consolepanel.cpp
+++ b/gui/consolepanel.cpp
@@ -66,7 +66,7 @@ void ConsolePanel::AppendMessage(const wxString &msg) {
     return;
 
   constexpr size_t kMaxConsoleMessageLength = 8 * 1024;
-  const wxString suffix = "... (truncado)";
+  const wxString suffix = "... (truncated)";
   wxString safeMsg = msg;
   if (safeMsg.length() > kMaxConsoleMessageLength) {
     size_t keepLength =

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -137,7 +137,7 @@ static void LogMessage(const std::string &msg) {
   Logger::Instance().Log(msg);
   if (ConsolePanel::Instance() && wxTheApp) {
     constexpr size_t kMaxConsoleMessageLength = 8 * 1024;
-    const std::string suffix = "... (truncado)";
+    const std::string suffix = "... (truncated)";
     std::string panelMsg = msg;
     if (panelMsg.size() > kMaxConsoleMessageLength) {
       size_t keepLength =


### PR DESCRIPTION
### Motivation
- Align console truncation messaging to English and keep truncation performed before `wxString::FromUTF8` in the MVR importer.

### Description
- Replaced the Spanish suffix `"... (truncado)"` with the English `"... (truncated)"` in `mvr/mvrimporter.cpp` and `gui/consolepanel.cpp`, preserving the existing truncation logic and the `8 * 1024` max length.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697be39786fc8324bbeaf45ae3a218db)