### PR TITLE
Fix wxString literal conversions in event filter

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -130,14 +130,14 @@ bool MyApp::OnInit() {
 int MyApp::FilterEvent(wxEvent &event) {
   const wxClassInfo *eventInfo = event.GetClassInfo();
   wxString eventClassName =
-      eventInfo ? eventInfo->GetClassName() : "UnknownEvent";
-  wxString objectClassName = "None";
+      eventInfo ? eventInfo->GetClassName() : wxT("UnknownEvent");
+  wxString objectClassName = wxT("None");
   if (event.GetEventObject()) {
     const wxClassInfo *objectInfo = event.GetEventObject()->GetClassInfo();
     if (objectInfo) {
       objectClassName = objectInfo->GetClassName();
     } else {
-      objectClassName = "UnknownObject";
+      objectClassName = wxT("UnknownObject");
     }
   }
   last_event_summary_ = wxString::Format(


### PR DESCRIPTION
### Motivation
- Resolve a Windows build conversion error (C2446) by ensuring default event/object class name literals are provided as `wxChar`-compatible strings.

### Description
- Replace narrow string literals with `wxT()` wrappers for the event filter defaults in `main.cpp`, changing `"UnknownEvent"`, `"None"`, and `"UnknownObject"` to `wxT("...")`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bef1adaa08324a967eb471d31cc90)