### PR TITLE
Use modern wxWidgets CONFIG targets in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,8 +35,7 @@ elseif(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
 endif()
 
 # Find required packages
-find_package(wxWidgets REQUIRED COMPONENTS core base aui gl html richtext)
-include(${wxWidgets_USE_FILE})
+find_package(wxWidgets CONFIG REQUIRED COMPONENTS core base aui gl html richtext)
 find_package(tinyxml2 CONFIG REQUIRED)
 find_package(OpenGL REQUIRED)
 find_package(CURL REQUIRED)
@@ -102,7 +101,12 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 
 # Link required libraries
 target_link_libraries(${PROJECT_NAME} PRIVATE
-    ${wxWidgets_LIBRARIES}
+    wx::core
+    wx::base
+    wx::aui
+    wx::gl
+    wx::html
+    wx::richtext
     tinyxml2::tinyxml2
     OpenGL::GL
     OpenGL::GLU


### PR DESCRIPTION
### Motivation
- Modernize wxWidgets discovery and linking to work with vcpkg/CMake `CONFIG` mode (improves macOS arm64 compatibility) while keeping existing Windows support and project structure intact.

### Description
- Replace legacy `find_package(wxWidgets REQUIRED ...)
  include(${wxWidgets_USE_FILE})` with `find_package(wxWidgets CONFIG REQUIRED COMPONENTS core base aui gl html richtext)`.
- Replace the legacy `${wxWidgets_LIBRARIES}` entry in `target_link_libraries` with explicit modern targets `wx::core`, `wx::base`, `wx::aui`, `wx::gl`, `wx::html`, and `wx::richtext`.
- Leave other `find_package` calls and the Windows-specific install/runtime handling unchanged.

### Testing
- No automated tests or build/configure steps were run on the modified CMake file in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bf3ad9f748324a3f99fd9d856e7ff)