### PR TITLE
Fix macOS font path conversion in NanoVG loader

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -648,7 +648,7 @@ void Viewer3DController::InitializeGL() {
         if (path.empty())
           continue;
         if (fs::exists(path, ec)) {
-          std::string pathString = path.u8string();
+          std::string pathString = path.string();
           target = nvgCreateFont(m_vg, name, pathString.c_str());
           if (target >= 0)
             return true;


### PR DESCRIPTION
### Motivation
- Building on macOS failed with a conversion error from `std::u8string` to `std::string` when passing font paths to NanoVG, causing compilation to fail in `viewer3d/viewer3dcontroller.cpp`.

### Description
- Replace `path.u8string()` with `path.string()` before calling `nvgCreateFont` to ensure a `std::string` is passed, updating `viewer3d/viewer3dcontroller.cpp` accordingly.

### Testing
- No automated tests or CI builds were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c71db0af08324b240e8e4a54b1e46)