### PR TITLE
Fix toolbar sizing in AUI layout panes

### DIFF
--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -491,8 +491,12 @@ void MainWindow::ApplySavedLayout() {
     toolbar->Realize();
     toolbar->InvalidateBestSize();
     auto &pane = auiManager->GetPane(paneName);
-    if (pane.IsOk())
-      pane.BestSize(toolbar->GetBestSize());
+    if (pane.IsOk()) {
+      const wxSize toolbarSize = toolbar->GetBestSize();
+      pane.BestSize(toolbarSize);
+      pane.MinSize(toolbarSize);
+      toolbar->SetMinSize(toolbarSize);
+    }
   };
 
   refreshToolbarLayout(fileToolBar, "FileToolbar");

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -172,6 +172,8 @@ void MainWindow::CreateToolBars() {
                        loadToolbarIcon("file-output", wxART_FILE_SAVE),
                        "Export the project to MVR");
   fileToolBar->Realize();
+  const wxSize fileToolbarSize = fileToolBar->GetBestSize();
+  fileToolBar->SetMinSize(fileToolbarSize);
 
   auiManager->AddPane(
       fileToolBar, wxAuiPaneInfo()
@@ -181,6 +183,9 @@ void MainWindow::CreateToolBars() {
                        .Top()
                        .LeftDockable(false)
                        .RightDockable(false)
+                       .BestSize(fileToolbarSize)
+                       .MinSize(fileToolbarSize)
+                       .Resizable(false)
                        .Row(0)
                        .Position(0));
 
@@ -213,6 +218,7 @@ void MainWindow::CreateToolBars() {
                               .RightDockable(false)
                               .BestSize(layoutViewsToolbarSize)
                               .MinSize(layoutViewsToolbarSize)
+                              .Resizable(false)
                               .Row(0)
                               .Position(1));
 
@@ -251,6 +257,7 @@ void MainWindow::CreateToolBars() {
                          .RightDockable(false)
                          .BestSize(layoutToolbarSize)
                          .MinSize(layoutToolbarSize)
+                         .Resizable(false)
                          .Row(1)
                          .Position(0));
 }


### PR DESCRIPTION
### Motivation
- Toolbars were stretching to fill available width when placed side-by-side, causing visual/layout issues instead of using the natural width needed for icons.

### Description
- Set each toolbar's best and minimum size after `Realize()` via `GetBestSize()` and `SetMinSize()` so toolbars request their natural width.
- Mark the corresponding `wxAuiPaneInfo` entries with `.BestSize(...).MinSize(...).Resizable(false)` for `FileToolbar`, `LayoutViewsToolbar` and `LayoutToolbar` to prevent automatic horizontal resizing.
- When restoring a saved layout, re-apply the toolbar `BestSize`/`MinSize` and call `toolbar->SetMinSize()` inside `ApplySavedLayout()` to keep sizes consistent after layout restore.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c92ed5f788324b263e706fe749d0a)