### PR TITLE
Fix toolbar stretching in AUI layout

### DIFF
--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -495,7 +495,9 @@ void MainWindow::ApplySavedLayout() {
       const wxSize toolbarSize = toolbar->GetBestSize();
       pane.BestSize(toolbarSize);
       pane.MinSize(toolbarSize);
+      pane.MaxSize(toolbarSize);
       toolbar->SetMinSize(toolbarSize);
+      toolbar->SetMaxSize(toolbarSize);
     }
   };
 

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -174,6 +174,7 @@ void MainWindow::CreateToolBars() {
   fileToolBar->Realize();
   const wxSize fileToolbarSize = fileToolBar->GetBestSize();
   fileToolBar->SetMinSize(fileToolbarSize);
+  fileToolBar->SetMaxSize(fileToolbarSize);
 
   auiManager->AddPane(
       fileToolBar, wxAuiPaneInfo()
@@ -185,6 +186,7 @@ void MainWindow::CreateToolBars() {
                        .RightDockable(false)
                        .BestSize(fileToolbarSize)
                        .MinSize(fileToolbarSize)
+                       .MaxSize(fileToolbarSize)
                        .Resizable(false)
                        .Row(0)
                        .Position(0));
@@ -208,6 +210,7 @@ void MainWindow::CreateToolBars() {
   layoutViewsToolBar->Realize();
   const wxSize layoutViewsToolbarSize = layoutViewsToolBar->GetBestSize();
   layoutViewsToolBar->SetMinSize(layoutViewsToolbarSize);
+  layoutViewsToolBar->SetMaxSize(layoutViewsToolbarSize);
   auiManager->AddPane(
       layoutViewsToolBar, wxAuiPaneInfo()
                               .Name("LayoutViewsToolbar")
@@ -218,6 +221,7 @@ void MainWindow::CreateToolBars() {
                               .RightDockable(false)
                               .BestSize(layoutViewsToolbarSize)
                               .MinSize(layoutViewsToolbarSize)
+                              .MaxSize(layoutViewsToolbarSize)
                               .Resizable(false)
                               .Row(0)
                               .Position(1));
@@ -247,6 +251,7 @@ void MainWindow::CreateToolBars() {
   layoutToolBar->Realize();
   const wxSize layoutToolbarSize = layoutToolBar->GetBestSize();
   layoutToolBar->SetMinSize(layoutToolbarSize);
+  layoutToolBar->SetMaxSize(layoutToolbarSize);
   auiManager->AddPane(
       layoutToolBar, wxAuiPaneInfo()
                          .Name("LayoutToolbar")
@@ -257,6 +262,7 @@ void MainWindow::CreateToolBars() {
                          .RightDockable(false)
                          .BestSize(layoutToolbarSize)
                          .MinSize(layoutToolbarSize)
+                         .MaxSize(layoutToolbarSize)
                          .Resizable(false)
                          .Row(1)
                          .Position(0));


### PR DESCRIPTION
### Motivation
- Toolbars were stretching to fill available width when placed side-by-side, producing gaps and widths larger than the icons they contain.  
- The goal is to keep each toolbar at its optimal width so it only shows its icons without expanding to fill the row.

### Description
- Cap each toolbar widget to its best size by calling `SetMaxSize` with the `GetBestSize()` value for `fileToolBar`, `layoutViewsToolBar`, and `layoutToolBar` in `MainWindow::CreateToolBars()` (`gui/mainwindow_menu.cpp`).
- Ensure the AUI pane configurations match the toolbar constraints by setting `.MaxSize(...)` on the corresponding `wxAuiPaneInfo` entries for the toolbar panes in `gui/mainwindow_menu.cpp`.
- Keep size constraints in sync when refreshing the layout by setting `pane.MaxSize(...)` and `toolbar->SetMaxSize(...)` inside `refreshToolbarLayout` in `gui/mainwindow_layout.cpp`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c99e9685c8324ab11cdf12d55b4a6)