### PR TITLE
Fix toolbar sizing and gripper lines

### DIFF
--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -134,9 +134,10 @@ std::string WrapHelpHtml(const std::string &body) {
 } // namespace
 
 void MainWindow::CreateToolBars() {
+  const long toolbarStyle =
+      (wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_HORIZONTAL) & ~wxAUI_TB_GRIPPER;
   fileToolBar = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition,
-                                 wxDefaultSize,
-                                 wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_HORIZONTAL);
+                                 wxDefaultSize, toolbarStyle);
   fileToolBar->SetToolBitmapSize(wxSize(16, 16));
 
   const auto loadToolbarIcon = [](const std::string &name,
@@ -184,6 +185,8 @@ void MainWindow::CreateToolBars() {
                        .Top()
                        .LeftDockable(false)
                        .RightDockable(false)
+                       .DockFixed()
+                       .Fixed()
                        .BestSize(fileToolbarSize)
                        .MinSize(fileToolbarSize)
                        .MaxSize(fileToolbarSize)
@@ -193,7 +196,7 @@ void MainWindow::CreateToolBars() {
 
   layoutViewsToolBar =
       new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
-                       wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_HORIZONTAL);
+                       toolbarStyle);
   layoutViewsToolBar->SetToolBitmapSize(wxSize(16, 16));
   layoutViewsToolBar->AddTool(ID_View_Layout_Default, "Vista layout 3D",
                               loadToolbarIcon("box",
@@ -219,6 +222,8 @@ void MainWindow::CreateToolBars() {
                               .Top()
                               .LeftDockable(false)
                               .RightDockable(false)
+                              .DockFixed()
+                              .Fixed()
                               .BestSize(layoutViewsToolbarSize)
                               .MinSize(layoutViewsToolbarSize)
                               .MaxSize(layoutViewsToolbarSize)
@@ -227,8 +232,7 @@ void MainWindow::CreateToolBars() {
                               .Position(1));
 
   layoutToolBar = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition,
-                                   wxDefaultSize,
-                                   wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_HORIZONTAL);
+                                   wxDefaultSize, toolbarStyle);
   layoutToolBar->SetToolBitmapSize(wxSize(16, 16));
   layoutToolBar->SetOverflowVisible(false);
   layoutToolBar->AddTool(ID_View_Layout_2DView, "Añadir vista 2D",
@@ -260,6 +264,8 @@ void MainWindow::CreateToolBars() {
                          .Top()
                          .LeftDockable(false)
                          .RightDockable(false)
+                         .DockFixed()
+                         .Fixed()
                          .BestSize(layoutToolbarSize)
                          .MinSize(layoutToolbarSize)
                          .MaxSize(layoutToolbarSize)


### PR DESCRIPTION
### Motivation
- Toolbars were stretching and showing vertical gripper lines when placed adjacent, causing icons to be clipped and panes to expand to full width instead of fitting their contents.

### Description
- Define a shared `toolbarStyle` that clears `wxAUI_TB_GRIPPER` and use it when constructing `wxAuiToolBar` instances to remove gripper visuals and behavior.
- Mark toolbar panes as fixed by adding `.DockFixed()` and `.Fixed()` to their `wxAuiPaneInfo` so the panes respect the toolbars' `GetBestSize()` and do not stretch horizontally.
- Changes are limited to `gui/mainwindow_menu.cpp` and preserve the existing `GetBestSize()`/`SetMinSize()`/`SetMaxSize()` sizing logic for each toolbar.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c9b0a9aec8324ad3e5f0df01a662f)