### PR TITLE
Restore default wxAUI toolbar sizing and docking behavior

### DIFF
--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -490,15 +490,6 @@ void MainWindow::ApplySavedLayout() {
       return;
     toolbar->Realize();
     toolbar->InvalidateBestSize();
-    auto &pane = auiManager->GetPane(paneName);
-    if (pane.IsOk()) {
-      const wxSize toolbarSize = toolbar->GetBestSize();
-      pane.BestSize(toolbarSize);
-      pane.MinSize(toolbarSize);
-      pane.MaxSize(toolbarSize);
-      toolbar->SetMinSize(toolbarSize);
-      toolbar->SetMaxSize(toolbarSize);
-    }
   };
 
   refreshToolbarLayout(fileToolBar, "FileToolbar");

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -135,7 +135,7 @@ std::string WrapHelpHtml(const std::string &body) {
 
 void MainWindow::CreateToolBars() {
   const long toolbarStyle =
-      (wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_HORIZONTAL) & ~wxAUI_TB_GRIPPER;
+      (wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_HORIZONTAL);
   fileToolBar = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition,
                                  wxDefaultSize, toolbarStyle);
   fileToolBar->SetToolBitmapSize(wxSize(16, 16));
@@ -173,9 +173,6 @@ void MainWindow::CreateToolBars() {
                        loadToolbarIcon("file-output", wxART_FILE_SAVE),
                        "Export the project to MVR");
   fileToolBar->Realize();
-  const wxSize fileToolbarSize = fileToolBar->GetBestSize();
-  fileToolBar->SetMinSize(fileToolbarSize);
-  fileToolBar->SetMaxSize(fileToolbarSize);
 
   auiManager->AddPane(
       fileToolBar, wxAuiPaneInfo()
@@ -183,14 +180,6 @@ void MainWindow::CreateToolBars() {
                        .Caption("File")
                        .ToolbarPane()
                        .Top()
-                       .LeftDockable(false)
-                       .RightDockable(false)
-                       .DockFixed()
-                       .Fixed()
-                       .BestSize(fileToolbarSize)
-                       .MinSize(fileToolbarSize)
-                       .MaxSize(fileToolbarSize)
-                       .Resizable(false)
                        .Row(0)
                        .Position(0));
 
@@ -211,30 +200,18 @@ void MainWindow::CreateToolBars() {
                                               wxART_MISSING_IMAGE),
                               "Switch to Layout Mode View");
   layoutViewsToolBar->Realize();
-  const wxSize layoutViewsToolbarSize = layoutViewsToolBar->GetBestSize();
-  layoutViewsToolBar->SetMinSize(layoutViewsToolbarSize);
-  layoutViewsToolBar->SetMaxSize(layoutViewsToolbarSize);
   auiManager->AddPane(
       layoutViewsToolBar, wxAuiPaneInfo()
                               .Name("LayoutViewsToolbar")
                               .Caption("Layout Views")
                               .ToolbarPane()
                               .Top()
-                              .LeftDockable(false)
-                              .RightDockable(false)
-                              .DockFixed()
-                              .Fixed()
-                              .BestSize(layoutViewsToolbarSize)
-                              .MinSize(layoutViewsToolbarSize)
-                              .MaxSize(layoutViewsToolbarSize)
-                              .Resizable(false)
                               .Row(0)
                               .Position(1));
 
   layoutToolBar = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition,
                                    wxDefaultSize, toolbarStyle);
   layoutToolBar->SetToolBitmapSize(wxSize(16, 16));
-  layoutToolBar->SetOverflowVisible(false);
   layoutToolBar->AddTool(ID_View_Layout_2DView, "Añadir vista 2D",
                          loadToolbarIcon("panel-top-bottom-dashed",
                                          wxART_MISSING_IMAGE),
@@ -253,23 +230,12 @@ void MainWindow::CreateToolBars() {
                          loadToolbarIcon("image-plus", wxART_MISSING_IMAGE),
                          "Add image to layout");
   layoutToolBar->Realize();
-  const wxSize layoutToolbarSize = layoutToolBar->GetBestSize();
-  layoutToolBar->SetMinSize(layoutToolbarSize);
-  layoutToolBar->SetMaxSize(layoutToolbarSize);
   auiManager->AddPane(
       layoutToolBar, wxAuiPaneInfo()
                          .Name("LayoutToolbar")
                          .Caption("Layout")
                          .ToolbarPane()
                          .Top()
-                         .LeftDockable(false)
-                         .RightDockable(false)
-                         .DockFixed()
-                         .Fixed()
-                         .BestSize(layoutToolbarSize)
-                         .MinSize(layoutToolbarSize)
-                         .MaxSize(layoutToolbarSize)
-                         .Resizable(false)
                          .Row(1)
                          .Position(0));
 }


### PR DESCRIPTION
### Motivation
- Toolbars were being forcibly constrained (fixed sizes and docking) which caused them to stretch, show separators and hide the last icon instead of using native wxWidgets toolbar behavior. 
- The intent is to let `wxAuiToolBar` manage its own sizing/overflow so toolbars display icons at their natural size and behave like the wxWidgets default.

### Description
- Removed forced toolbar size clamping and fixed pane flags in `gui/mainwindow_menu.cpp` so panes are no longer configured with `.DockFixed()/.Fixed()` and explicit `BestSize/MinSize/MaxSize` values. 
- Restored the default toolbar style by removing the `~wxAUI_TB_GRIPPER` mask and using `(wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_HORIZONTAL)` for `toolbarStyle` in `gui/mainwindow_menu.cpp`. 
- Re-enabled default overflow behavior by removing `SetOverflowVisible(false)` and removed explicit `SetMinSize`/`SetMaxSize` calls for toolbars. 
- Simplified the layout refresh in `gui/mainwindow_layout.cpp` by stopping the reapplication of fixed toolbar sizes in `refreshToolbarLayout`, leaving `Realize()` and `InvalidateBestSize()` so wxAUI can compute sizes itself.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c9c0d9020832480f390eef6123bd1)