### PR TITLE
Reset toolbar docking in Layout Mode View

### DIFF
--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -410,6 +410,20 @@ void MainWindow::ApplyLayoutPreset(const LayoutViewPreset &preset,
   applyPaneState(preset.showPanes, true);
   applyPaneState(preset.hidePanes, false);
 
+  if (layoutMode) {
+    auto resetToolbarPane = [this](const std::string &paneName, int row,
+                                   int position) {
+      auto &pane = auiManager->GetPane(paneName);
+      if (!pane.IsOk())
+        return;
+      pane.ToolbarPane().Top().Row(row).Position(position);
+    };
+
+    resetToolbarPane("FileToolbar", 0, 0);
+    resetToolbarPane("LayoutViewsToolbar", 0, 1);
+    resetToolbarPane("LayoutToolbar", 1, 0);
+  }
+
   auiManager->Update();
 
   layoutModeActive = layoutMode;


### PR DESCRIPTION
### Motivation
- Restaurar el anclaje por defecto de las barras de herramientas al entrar en "Layout Mode View" para evitar el comportamiento anómalo de las toolbars.

### Description
- En `gui/mainwindow_layout.cpp` se añadió un bloque que, cuando `layoutMode` es true, reajusta las posiciones de `FileToolbar`, `LayoutViewsToolbar` y `LayoutToolbar` mediante `pane.ToolbarPane().Top().Row(...).Position(...)` antes de llamar a `auiManager->Update()`.

### Testing
- No se ejecutaron pruebas automatizadas para este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c9e240210832490e5474ccfad5830)