### PR TITLE
Normalize layout mode toolbar docking

### DIFF
--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -484,18 +484,6 @@ void MainWindow::ApplySavedLayout() {
   if (view2dPane.IsOk())
     view2dPane.MinSize(wxSize(250, 600));
 
-  auto refreshToolbarLayout = [this](wxAuiToolBar *toolbar,
-                                     const std::string &paneName) {
-    if (!toolbar)
-      return;
-    toolbar->Realize();
-    toolbar->InvalidateBestSize();
-  };
-
-  refreshToolbarLayout(fileToolBar, "FileToolbar");
-  refreshToolbarLayout(layoutViewsToolBar, "LayoutViewsToolbar");
-  refreshToolbarLayout(layoutToolBar, "LayoutToolbar");
-
   auiManager->Update();
   SendSizeEvent();
   UpdateViewMenuChecks();

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -235,9 +235,7 @@ void MainWindow::CreateToolBars() {
                          .Name("LayoutToolbar")
                          .Caption("Layout")
                          .ToolbarPane()
-                         .Top()
-                         .Row(1)
-                         .Position(0));
+                         .Top());
 }
 
 void MainWindow::CreateMenuBar() {


### PR DESCRIPTION
### Motivation
- Layout Mode View showed abnormal toolbar behavior because extra code forced toolbar re-layout and explicit pane positioning, which overrides default wxWidgets/AUI behavior and causes toolbars to size/cover panels incorrectly.

### Description
- Removed explicit toolbar `Realize()`/`InvalidateBestSize()` relayout calls from `MainWindow::ApplySavedLayout` to let AUI manage toolbar sizing (`gui/mainwindow_layout.cpp`).
- Removed forced `.Row(1).Position(0)` placement of the `LayoutToolbar` pane and left it to dock at the top with `.Top()` in `CreateToolBars` (`gui/mainwindow_menu.cpp`).
- Changes keep toolbar docking and sizing consistent with the default wxWidgets/AUI behavior across layout modes and affect `ApplySavedLayout` and `CreateToolBars` only.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c9fd1ab0c8324a6c9899c07b256d2)