### PR TITLE
Remove layout mode pane overrides for default AUI behavior

### DIFF
--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -385,19 +385,6 @@ void MainWindow::ApplyLayoutPreset(const LayoutViewPreset &preset,
   else
     auiManager->Update();
 
-  if (layoutMode) {
-    const int clientWidth = GetClientSize().GetWidth();
-    const int layoutPanelWidth = std::max(200, clientWidth / 6);
-    auto &layoutPane = auiManager->GetPane("LayoutPanel");
-    if (layoutPane.IsOk())
-      layoutPane.Left().BestSize(layoutPanelWidth, 600).MinSize(
-          wxSize(200, 300));
-
-    auto &layoutViewerPane = auiManager->GetPane("LayoutViewer");
-    if (layoutViewerPane.IsOk())
-      layoutViewerPane.Center().MinSize(wxSize(400, 300));
-  }
-
   auto applyPaneState = [this](const std::vector<std::string> &panes,
                                bool show) {
     for (const auto &name : panes) {


### PR DESCRIPTION
### Motivation
- Fix unexpected toolbar/pane sizing in "Layout Mode View" by removing manual pane sizing that altered the default wxWidgets/wxAUI behavior which caused toolbars to expand and cover content.

### Description
- Remove the layout-mode-specific pane size overrides in `MainWindow::ApplyLayoutPreset` (deleted manual `BestSize`/`MinSize` adjustments for `LayoutPanel` and `LayoutViewer`) in `gui/mainwindow_layout.cpp` so panes and toolbars follow the default AUI behavior.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ca1ef1ca08324b8433fe43c029320)