### PR TITLE
Remove fixed toolbar row positioning

### DIFF
--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -179,9 +179,7 @@ void MainWindow::CreateToolBars() {
                        .Name("FileToolbar")
                        .Caption("File")
                        .ToolbarPane()
-                       .Top()
-                       .Row(0)
-                       .Position(0));
+                       .Top());
 
   layoutViewsToolBar =
       new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
@@ -205,9 +203,7 @@ void MainWindow::CreateToolBars() {
                               .Name("LayoutViewsToolbar")
                               .Caption("Layout Views")
                               .ToolbarPane()
-                              .Top()
-                              .Row(0)
-                              .Position(1));
+                              .Top());
 
   layoutToolBar = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition,
                                    wxDefaultSize, toolbarStyle);


### PR DESCRIPTION
### Motivation
- Revert explicit AUI row/position overrides so toolbars use the default wxWidgets docking behavior and avoid forced spacing/positioning artifacts that caused the icon toolbars to separate and resize incorrectly.

### Description
- Remove `.Row(...)` and `.Position(...)` calls from the `auiManager->AddPane` invocations for the `FileToolbar` and `LayoutViewsToolbar` in `gui/mainwindow_menu.cpp` so they dock with default placement (`.Top()` left intact).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ca41bed308324852fc997f121ca14)