### PR TITLE
Stop persisting layout-mode toolbar perspective

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -527,9 +527,8 @@ void MainWindow::SaveCameraSettings() {
   if (auiManager) {
     const std::string perspective =
         auiManager->SavePerspective().ToStdString();
-    ConfigManager::Get().SetValue("layout_perspective", perspective);
-    if (layoutModeActive)
-      ConfigManager::Get().SetValue("layout_layout_mode", perspective);
+    if (!layoutModeActive)
+      ConfigManager::Get().SetValue("layout_perspective", perspective);
   }
 }
 

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -182,7 +182,6 @@ private:
                           const wxString &dialogTitle);
   std::string defaultLayoutPerspective;
   std::string default2DLayoutPerspective;
-  std::string layoutModePerspective;
   bool layoutModeActive = false;
   std::string activeLayoutName;
   bool layout2DViewEditing = false;

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -182,6 +182,7 @@ private:
                           const wxString &dialogTitle);
   std::string defaultLayoutPerspective;
   std::string default2DLayoutPerspective;
+  std::string defaultLayoutModePerspective;
   bool layoutModeActive = false;
   std::string activeLayoutName;
   bool layout2DViewEditing = false;

--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -403,11 +403,7 @@ void MainWindow::ApplyLayoutPreset(const LayoutViewPreset &preset,
 
   if (persistPerspective) {
     ConfigManager &cfg = ConfigManager::Get();
-    if (layoutMode) {
-      layoutModePerspective = auiManager->SavePerspective().ToStdString();
-      cfg.SetValue("layout_layout_mode", layoutModePerspective);
-      cfg.SetValue("layout_perspective", layoutModePerspective);
-    } else if (perspective) {
+    if (!layoutMode && perspective) {
       cfg.SetValue("layout_perspective", *perspective);
     }
   }
@@ -422,18 +418,11 @@ void MainWindow::ApplySavedLayout() {
   if (!auiManager)
     return;
 
-  bool didLoadLayoutMode = false;
   std::optional<std::string> perspective;
 
   // Load stored layout perspective if it exists
   if (auto val = ConfigManager::Get().GetValue("layout_perspective")) {
     perspective = *val;
-    if (layoutModePerspective.empty()) {
-      if (auto layoutVal = ConfigManager::Get().GetValue("layout_layout_mode"))
-        layoutModePerspective = *layoutVal;
-    }
-    didLoadLayoutMode =
-        !layoutModePerspective.empty() && *perspective == layoutModePerspective;
 
     // Ensure viewports exist before loading the saved perspective
     if (perspective->find("3DViewport") != std::string::npos)
@@ -444,9 +433,7 @@ void MainWindow::ApplySavedLayout() {
   }
 
   const LayoutViewPreset *preset = nullptr;
-  if (didLoadLayoutMode) {
-    preset = LayoutViewPresetRegistry::GetPreset("layout_mode_view");
-  } else if (perspective &&
+  if (perspective &&
              (perspective->find("2DViewport") != std::string::npos ||
               perspective->find("2DRenderOptions") != std::string::npos)) {
     preset = LayoutViewPresetRegistry::GetPreset("2d_layout_view");
@@ -454,9 +441,9 @@ void MainWindow::ApplySavedLayout() {
     preset = LayoutViewPresetRegistry::GetPreset("3d_layout_view");
   }
   if (preset && perspective)
-    ApplyLayoutPreset(*preset, perspective, didLoadLayoutMode, false);
+    ApplyLayoutPreset(*preset, perspective, false, false);
   else if (preset)
-    ApplyLayoutPreset(*preset, std::nullopt, didLoadLayoutMode, false);
+    ApplyLayoutPreset(*preset, std::nullopt, false, false);
 
   // Re-apply hard-coded minimum sizes so they are not overridden by the saved perspective
   auto &dataPane = auiManager->GetPane("DataNotebook");
@@ -480,21 +467,12 @@ void MainWindow::ApplyLayoutModePerspective() {
   if (!auiManager)
     return;
 
-  if (layoutModePerspective.empty()) {
-    if (auto val = ConfigManager::Get().GetValue("layout_layout_mode"))
-      layoutModePerspective = *val;
-  }
-
   const auto *preset =
       LayoutViewPresetRegistry::GetPreset("layout_mode_view");
   if (!preset)
     return;
 
-  if (layoutModePerspective.empty())
-    ApplyLayoutPreset(*preset, std::nullopt, true, true);
-  else
-    ApplyLayoutPreset(*preset, std::make_optional(layoutModePerspective), true,
-                      true);
+  ApplyLayoutPreset(*preset, std::nullopt, true, true);
 }
 
 void MainWindow::OnApplyDefaultLayout(wxCommandEvent &WXUNUSED(event)) {

--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -472,7 +472,32 @@ void MainWindow::ApplyLayoutModePerspective() {
   if (!preset)
     return;
 
-  ApplyLayoutPreset(*preset, std::nullopt, true, true);
+  if (defaultLayoutModePerspective.empty()) {
+    const std::string previousPerspective =
+        auiManager->SavePerspective().ToStdString();
+
+    auto applyPaneState = [this](const std::vector<std::string> &panes,
+                                 bool show) {
+      for (const auto &name : panes) {
+        auto &pane = auiManager->GetPane(name);
+        if (pane.IsOk())
+          pane.Show(show);
+      }
+    };
+
+    applyPaneState(preset->showPanes, true);
+    applyPaneState(preset->hidePanes, false);
+    auiManager->Update();
+    defaultLayoutModePerspective = auiManager->SavePerspective().ToStdString();
+    auiManager->LoadPerspective(previousPerspective, true);
+    auiManager->Update();
+  }
+
+  if (defaultLayoutModePerspective.empty())
+    ApplyLayoutPreset(*preset, std::nullopt, true, true);
+  else
+    ApplyLayoutPreset(*preset, std::make_optional(defaultLayoutModePerspective),
+                      true, true);
 }
 
 void MainWindow::OnApplyDefaultLayout(wxCommandEvent &WXUNUSED(event)) {


### PR DESCRIPTION
### Motivation
- Layout Mode caused toolbar groups to change size because a separate saved "layout mode" perspective was being persisted and restored, altering toolbar pane state when entering/exiting layout mode.

### Description
- Removed the `layoutModePerspective` member and all logic that saved/restored the `layout_layout_mode` config key.
- Changed `SaveCameraSettings()` / perspective saving to only call `ConfigManager::SetValue("layout_perspective", ...)` when not in layout mode (`layoutModeActive == false`).
- Updated `ApplyLayoutPreset()` so it no longer persists a perspective when `layoutMode == true`, and only writes the `layout_perspective` key for non-layout-mode perspectives.
- Simplified `ApplySavedLayout()` and `ApplyLayoutModePerspective()` so layout mode always applies the `layout_mode_view` preset without attempting to restore a special saved layout-mode perspective.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ca8165c90832495659813896568cc)