### PR TITLE
Guard row updates during table highlighting

### DIFF
--- a/gui/colorstore.h
+++ b/gui/colorstore.h
@@ -107,7 +107,8 @@ public:
     if (row >= rowAttrs.size())
       rowAttrs.resize(row + 1);
     rowAttrs[row].SetBackgroundColour(colour);
-    RowChanged(row);
+    if (row < GetItemCount())
+      RowChanged(row);
   }
 
   void ClearRowBackground(unsigned row) {
@@ -119,7 +120,8 @@ public:
       rowAttrs[row] = wxDataViewItemAttr();
       if (hasFg)
         rowAttrs[row].SetColour(fg);
-      RowChanged(row);
+      if (row < GetItemCount())
+        RowChanged(row);
     }
   }
 
@@ -127,7 +129,8 @@ public:
     if (row >= rowAttrs.size())
       rowAttrs.resize(row + 1);
     rowAttrs[row].SetColour(colour);
-    RowChanged(row);
+    if (row < GetItemCount())
+      RowChanged(row);
   }
 
   void ClearRowTextColour(unsigned row) {
@@ -139,7 +142,8 @@ public:
       rowAttrs[row] = wxDataViewItemAttr();
       if (hasBg)
         rowAttrs[row].SetBackgroundColour(bg);
-      RowChanged(row);
+      if (row < GetItemCount())
+        RowChanged(row);
     }
   }
 
@@ -149,14 +153,16 @@ public:
     if (col >= cellAttrs[row].size())
       cellAttrs[row].resize(col + 1);
     cellAttrs[row][col].SetColour(colour);
-    RowChanged(row);
+    if (row < GetItemCount())
+      RowChanged(row);
   }
 
   void ClearCellTextColour(unsigned row, unsigned col) {
     if (row >= cellAttrs.size() || col >= cellAttrs[row].size())
       return;
     cellAttrs[row][col] = wxDataViewItemAttr();
-    RowChanged(row);
+    if (row < GetItemCount())
+      RowChanged(row);
   }
 
   void SetSelectionColours(const wxColour &background,

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -903,7 +903,9 @@ bool FixtureTablePanel::IsActivePage() const {
 }
 
 void FixtureTablePanel::HighlightFixture(const std::string &uuid) {
-  for (size_t i = 0; i < rowUuids.size(); ++i) {
+  size_t count =
+      std::min(rowUuids.size(), static_cast<size_t>(table->GetItemCount()));
+  for (size_t i = 0; i < count; ++i) {
     if (!uuid.empty() && rowUuids[i] == uuid)
       store->SetRowBackgroundColour(i, wxColour(0, 200, 0));
     else

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -610,7 +610,9 @@ bool HoistTablePanel::IsActivePage() const {
 }
 
 void HoistTablePanel::HighlightHoist(const std::string &uuid) {
-  for (size_t i = 0; i < rowUuids.size(); ++i) {
+  size_t count =
+      std::min(rowUuids.size(), static_cast<size_t>(table->GetItemCount()));
+  for (size_t i = 0; i < count; ++i) {
     if (!uuid.empty() && rowUuids[i] == uuid)
       store->SetRowBackgroundColour(i, wxColour(0, 200, 0));
     else

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -609,7 +609,9 @@ bool SceneObjectTablePanel::IsActivePage() const
 
 void SceneObjectTablePanel::HighlightObject(const std::string& uuid)
 {
-    for (size_t i = 0; i < rowUuids.size(); ++i)
+    size_t count =
+        std::min(rowUuids.size(), static_cast<size_t>(table->GetItemCount()));
+    for (size_t i = 0; i < count; ++i)
     {
         if (!uuid.empty() && rowUuids[i] == uuid)
             store->SetRowBackgroundColour(i, wxColour(0, 200, 0));

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -905,7 +905,9 @@ bool TrussTablePanel::IsActivePage() const
 
 void TrussTablePanel::HighlightTruss(const std::string& uuid)
 {
-    for (size_t i = 0; i < rowUuids.size(); ++i)
+    size_t count =
+        std::min(rowUuids.size(), static_cast<size_t>(table->GetItemCount()));
+    for (size_t i = 0; i < count; ++i)
     {
         if (!uuid.empty() && rowUuids[i] == uuid)
             store->SetRowBackgroundColour(i, wxColour(0, 200, 0));


### PR DESCRIPTION
### Motivation
- Prevent an out-of-range `RowChanged` notification that causes an assertion/crash on macOS when `rowUuids` and the visible row count diverge during table reloads or updates.

### Description
- Added a guard `if (row < GetItemCount()) RowChanged(row);` to row/cell colour update methods in `ColorfulDataViewListStore` to avoid notifying the view about non-existent rows (file `gui/colorstore.h`).
- Limited highlight loops to `std::min(rowUuids.size(), static_cast<size_t>(table->GetItemCount()))` to avoid iterating past the current number of items in the view in `FixtureTablePanel::HighlightFixture`, `HoistTablePanel::HighlightHoist`, `TrussTablePanel::HighlightTruss` and `SceneObjectTablePanel::HighlightObject` (files `gui/fixturetablepanel.cpp`, `gui/hoisttablepanel.cpp`, `gui/trusstablepanel.cpp`, `gui/sceneobjecttablepanel.cpp`).
- Preserved existing behaviour of clearing internal attribute containers on `DeleteAllItems()`; changes are defensive checks to prevent transient desynchronization crashes.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cf9650d9c8324a79901eb1c77c0ff)