### PR TITLE
Guard selection updates against stale row counts

### DIFF
--- a/gui/colorstore.h
+++ b/gui/colorstore.h
@@ -177,11 +177,13 @@ public:
     std::vector<bool> oldRows = selectionRows;
     size_t oldSize = oldRows.size();
     selectionRows.assign(rows.begin(), rows.end());
-    if (rowAttrs.size() > selectionRows.size())
-      selectionRows.resize(rowAttrs.size(), false);
-    size_t currentCount = rowAttrs.size();
-    size_t notifyCount = (std::min)((std::max)(oldSize, selectionRows.size()),
-                                    currentCount);
+    size_t itemCount = GetItemCount();
+    if (itemCount > selectionRows.size())
+      selectionRows.resize(itemCount, false);
+    if (selectionRows.size() > itemCount)
+      selectionRows.resize(itemCount);
+    size_t notifyCount =
+        (std::min)((std::max)(oldSize, selectionRows.size()), itemCount);
     for (size_t i = 0; i < notifyCount; ++i) {
       bool oldVal = i < oldSize ? oldRows[i] : false;
       bool newVal = i < selectionRows.size() ? selectionRows[i] : false;


### PR DESCRIPTION
### Motivation
- Fix a crash observed on macOS where selection updates could notify `RowChanged` for indices outside the current model size (wxWidgets assert in `wxDataViewIndexListModel::GetItem`), by keeping selection state aligned with the underlying data view item count.

### Description
- In `gui/colorstore.h` updated `SetSelectedRows` to use `GetItemCount()` instead of `rowAttrs.size()` when sizing and clamping `selectionRows` so the selection vector always matches the model size.
- Ensure `selectionRows` is resized both up and down to `itemCount` and compute the notification range against the actual `itemCount` to avoid invalid `RowChanged` notifications.
- The change avoids generating out-of-range row notifications that could trigger the wxWidgets assertion on selection updates.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cfe54474083248aa83e611ebc5671)