### PR TITLE
Fix unnecessary ellipsis in table cell rendering on macOS

### DIFF
--- a/gui/colorfulrenderers.h
+++ b/gui/colorfulrenderers.h
@@ -93,17 +93,23 @@ inline void DrawTextValue(wxDataViewCustomRenderer *renderer,
   dc->SetTextForeground(ResolveTextColour(renderer, state, attr));
 
   wxString displayText = text;
+  const int horizontalPadding = 2;
+  const int availableWidth =
+      std::max(0, rect.GetWidth() - horizontalPadding * 2);
   if (renderer->GetEllipsizeMode() != wxELLIPSIZE_NONE) {
-    displayText = wxControl::Ellipsize(displayText, *dc,
-                                       renderer->GetEllipsizeMode(),
-                                       rect.GetWidth());
+    wxSize rawSize = dc->GetTextExtent(displayText);
+    if (rawSize.x > availableWidth) {
+      displayText = wxControl::Ellipsize(displayText, *dc,
+                                         renderer->GetEllipsizeMode(),
+                                         availableWidth);
+    }
   }
 
   wxSize textSize = dc->GetTextExtent(displayText);
   int align = renderer->GetEffectiveAlignment();
-  int x = rect.x + 2;
+  int x = rect.x + horizontalPadding;
   if (align & wxALIGN_RIGHT)
-    x = rect.x + rect.width - textSize.x - 2;
+    x = rect.x + rect.width - textSize.x - horizontalPadding;
   else if (align & wxALIGN_CENTER_HORIZONTAL)
     x = rect.x + (rect.width - textSize.x) / 2;
 


### PR DESCRIPTION
### Motivation
- Prevent table cell text from being truncated with `...` on macOS by only ellipsizing when the rendered text actually exceeds the usable cell width and by using consistent horizontal padding when positioning text.

### Description
- Adjusted `DrawTextValue` in `gui/colorfulrenderers.h` to compute an `availableWidth` that subtracts `horizontalPadding`, measure the raw text with `dc->GetTextExtent`, and only call `wxControl::Ellipsize` when `rawSize.x > availableWidth`, and reused the same `horizontalPadding` when calculating the text `x` position.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d00e7b208832486018745066ad167)