### PR TITLE
Disable ellipsize in data view renderers on macOS

### DIFF
--- a/gui/colorfulrenderers.h
+++ b/gui/colorfulrenderers.h
@@ -127,7 +127,11 @@ class ColorfulTextRenderer : public wxDataViewCustomRenderer {
 public:
   ColorfulTextRenderer(wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT,
                        int align = wxDVR_DEFAULT_ALIGNMENT)
-      : wxDataViewCustomRenderer("string", mode, align) {}
+      : wxDataViewCustomRenderer("string", mode, align) {
+#ifdef __WXMAC__
+    SetEllipsizeMode(wxELLIPSIZE_NONE);
+#endif
+  }
 
   bool Render(wxRect rect, wxDC *dc, int state) override {
     wxColour background;
@@ -171,7 +175,11 @@ class ColorfulIconTextRenderer : public wxDataViewCustomRenderer {
 public:
   ColorfulIconTextRenderer(wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT,
                            int align = wxDVR_DEFAULT_ALIGNMENT)
-      : wxDataViewCustomRenderer("wxDataViewIconText", mode, align) {}
+      : wxDataViewCustomRenderer("wxDataViewIconText", mode, align) {
+#ifdef __WXMAC__
+    SetEllipsizeMode(wxELLIPSIZE_NONE);
+#endif
+  }
 
   bool Render(wxRect rect, wxDC *dc, int state) override {
     wxColour background;


### PR DESCRIPTION
### Motivation
- On macOS data view cell text was always truncated with an ellipsis even when there was space to display the full string, so the UI shows compressed labels.

### Description
- In `gui/colorfulrenderers.h` set `SetEllipsizeMode(wxELLIPSIZE_NONE)` under `__WXMAC__` in the `ColorfulTextRenderer` constructor to disable ellipsizing on macOS.
- Apply the same `SetEllipsizeMode(wxELLIPSIZE_NONE)` change in the `ColorfulIconTextRenderer` constructor to cover icon+text cells.
- This targets wxWidgets macOS behavior only by gating the change with the `__WXMAC__` macro and does not affect other platforms.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d029e69348324bf913d5d1063a486)