### PR TITLE
Fix renderer ellipsize mode compatibility

### DIFF
--- a/gui/colorfulrenderers.h
+++ b/gui/colorfulrenderers.h
@@ -25,6 +25,16 @@
 #include "colorstore.h"
 
 namespace {
+template <typename Renderer>
+auto SetEllipsizeModeIfSupported(Renderer *renderer, wxEllipsizeMode mode)
+    -> decltype(renderer->SetEllipsizeMode(mode), void()) {
+  if (!renderer)
+    return;
+  renderer->SetEllipsizeMode(mode);
+}
+
+inline void SetEllipsizeModeIfSupported(...) {}
+
 inline const ColorfulDataViewListStore *GetColorfulStore(
     const wxDataViewCustomRenderer *renderer) {
   if (!renderer)
@@ -128,9 +138,7 @@ public:
   ColorfulTextRenderer(wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT,
                        int align = wxDVR_DEFAULT_ALIGNMENT)
       : wxDataViewCustomRenderer("string", mode, align) {
-#ifdef __WXMAC__
-    SetEllipsizeMode(wxELLIPSIZE_NONE);
-#endif
+    SetEllipsizeModeIfSupported(this, wxELLIPSIZE_NONE);
   }
 
   bool Render(wxRect rect, wxDC *dc, int state) override {
@@ -176,9 +184,7 @@ public:
   ColorfulIconTextRenderer(wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT,
                            int align = wxDVR_DEFAULT_ALIGNMENT)
       : wxDataViewCustomRenderer("wxDataViewIconText", mode, align) {
-#ifdef __WXMAC__
-    SetEllipsizeMode(wxELLIPSIZE_NONE);
-#endif
+    SetEllipsizeModeIfSupported(this, wxELLIPSIZE_NONE);
   }
 
   bool Render(wxRect rect, wxDC *dc, int state) override {


### PR DESCRIPTION
### Motivation
- Avoid macOS build failures where `SetEllipsizeMode` is not available on some `wxDataViewCustomRenderer` implementations by calling it only when supported.

### Description
- Add a SFINAE-based helper `SetEllipsizeModeIfSupported` in `gui/colorfulrenderers.h` that invokes `SetEllipsizeMode` if the renderer exposes it, and replace the previous guarded calls with `SetEllipsizeModeIfSupported(this, wxELLIPSIZE_NONE)` in the custom renderers.

### Testing
- No automated tests or builds were run on the modified code in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d0380ca8c83249a5552b81344e4e8)