### PR TITLE
Disable ellipsis truncation on data view columns

### DIFF
--- a/gui/columnutils.h
+++ b/gui/columnutils.h
@@ -20,6 +20,18 @@
 #include <wx/dataview.h>
 
 namespace ColumnUtils {
+namespace detail {
+template <typename Column>
+auto SetEllipsizeModeIfSupported(Column *column, wxEllipsizeMode mode)
+    -> decltype(column->SetEllipsizeMode(mode), void()) {
+  if (!column)
+    return;
+  column->SetEllipsizeMode(mode);
+}
+
+inline void SetEllipsizeModeIfSupported(...) {}
+} // namespace detail
+
 inline void EnforceMinColumnWidth(wxDataViewListCtrl *table,
                                   int minWidth = 50) {
   if (!table)
@@ -27,9 +39,10 @@ inline void EnforceMinColumnWidth(wxDataViewListCtrl *table,
 
   const unsigned int count = table->GetColumnCount();
   for (unsigned int i = 0; i < count; ++i) {
-    if (auto *col = table->GetColumn(i))
+    if (auto *col = table->GetColumn(i)) {
       col->SetMinWidth(minWidth);
+      detail::SetEllipsizeModeIfSupported(col, wxELLIPSIZE_NONE);
+    }
   }
 }
 } // namespace ColumnUtils
-


### PR DESCRIPTION
### Motivation
- Prevent wxDataView columns from eliding cell text on platforms that enable per-column ellipsizing so full names can be shown when there is room.

### Description
- Add a small `detail::SetEllipsizeModeIfSupported` helper in `gui/columnutils.h` and call it from `EnforceMinColumnWidth` to set `wxELLIPSIZE_NONE` on each `wxDataViewColumn` when the column type supports `SetEllipsizeMode`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d072d1f1483249e0954612401b2e1)