### PR TITLE
Disable ellipsizing on data view renderers

### DIFF
--- a/gui/columnutils.h
+++ b/gui/columnutils.h
@@ -42,6 +42,9 @@ inline void EnforceMinColumnWidth(wxDataViewListCtrl *table,
     if (auto *col = table->GetColumn(i)) {
       col->SetMinWidth(minWidth);
       detail::SetEllipsizeModeIfSupported(col, wxELLIPSIZE_NONE);
+      if (auto *renderer = col->GetRenderer()) {
+        detail::SetEllipsizeModeIfSupported(renderer, wxELLIPSIZE_NONE);
+      }
     }
   }
 }


### PR DESCRIPTION
### Motivation
- On macOS table cell text was still being ellipsized even when there was enough space, likely because column renderers retained an ellipsize mode in addition to the column itself; the change aims to stop renderers from forcing truncation when space is available.

### Description
- Call `GetRenderer()` for each column inside `ColumnUtils::EnforceMinColumnWidth` and disable ellipsizing on the renderer as well by invoking `detail::SetEllipsizeModeIfSupported(renderer, wxELLIPSIZE_NONE)`, in `gui/columnutils.h`.

### Testing
- No automated tests were run for this small UI adjustment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d09163dc88324845ff422fef19631)