### PR TITLE
Fix Mac data view text measurement for ellipsis

### DIFF
--- a/gui/colorfulrenderers.h
+++ b/gui/colorfulrenderers.h
@@ -97,6 +97,19 @@ inline void DrawTextValue(wxDataViewCustomRenderer *renderer,
   if (!renderer || !dc)
     return;
 
+  auto measureText = [&](const wxString &value) {
+    wxDataViewColumn *column = renderer->GetOwner();
+    wxDataViewCtrl *ctrl = column ? column->GetOwner() : nullptr;
+    wxFont font = dc->GetFont();
+    if (ctrl) {
+      int width = 0;
+      int height = 0;
+      ctrl->GetTextExtent(value, &width, &height, nullptr, nullptr, &font);
+      return wxSize(width, height);
+    }
+    return dc->GetTextExtent(value);
+  };
+
   wxDCClipper clip(*dc, rect);
   const wxDataViewItemAttr &attr = renderer->GetAttr();
   ApplyAttributeFont(dc, attr);
@@ -107,7 +120,7 @@ inline void DrawTextValue(wxDataViewCustomRenderer *renderer,
   const int availableWidth =
       std::max(0, rect.GetWidth() - horizontalPadding * 2);
   if (renderer->GetEllipsizeMode() != wxELLIPSIZE_NONE) {
-    wxSize rawSize = dc->GetTextExtent(displayText);
+    wxSize rawSize = measureText(displayText);
     if (rawSize.x > availableWidth) {
       displayText = wxControl::Ellipsize(displayText, *dc,
                                          renderer->GetEllipsizeMode(),
@@ -115,7 +128,7 @@ inline void DrawTextValue(wxDataViewCustomRenderer *renderer,
     }
   }
 
-  wxSize textSize = dc->GetTextExtent(displayText);
+  wxSize textSize = measureText(displayText);
   int align = renderer->GetEffectiveAlignment();
   int x = rect.x + horizontalPadding;
   if (align & wxALIGN_RIGHT)


### PR DESCRIPTION
### Motivation
- On macOS/HiDPI the data view cell text was being ellipsized prematurely because text extents were measured from the `wxDC` instead of using the owning control's metrics, producing inconsistent width calculations for trimming and alignment.

### Description
- Added a `measureText` lambda in `gui/colorfulrenderers.h` that uses the owning `wxDataViewCtrl::GetTextExtent` with the current font when available and falls back to `dc->GetTextExtent`.
- Replaced direct `dc->GetTextExtent` calls with `measureText` for ellipsize checks and final layout so trimming and alignment use the same measurement.

### Testing
- No automated tests were run because this is a UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d0b137bf48324a40a7a48c65c0261)