### PR TITLE
Validate fixture color before initializing colour picker

### DIFF
--- a/gui/fixtureeditdialog.cpp
+++ b/gui/fixtureeditdialog.cpp
@@ -78,7 +78,17 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
       ctrls[i] = modelCtrl;
       grid->Add(hs, 1, wxEXPAND);
     } else if (i == 18) {
-      wxColour initial(v.GetString());
+      wxString colorString;
+      if (v.GetType() == "wxDataViewIconText") {
+        wxDataViewIconText icon;
+        icon << v;
+        colorString = icon.GetText();
+      } else {
+        colorString = v.GetString();
+      }
+      wxColour initial(colorString);
+      if (colorString.IsEmpty() || !initial.IsOk())
+        initial = *wxWHITE;
       auto *picker = new wxColourPickerCtrl(this, wxID_ANY, initial);
       ctrls[i] = picker;
       grid->Add(picker, 1, wxEXPAND);


### PR DESCRIPTION
### Motivation
- Prevent passing invalid or empty color values to the colour picker in `FixtureEditDialog::FixtureEditDialog` to avoid assertions on macOS when the table cell has no valid color.

### Description
- In `gui/fixtureeditdialog.cpp` (the `i == 18` branch of `FixtureEditDialog::FixtureEditDialog`) extract the color text from the `wxVariant` safely by checking for `wxDataViewIconText` and falling back to `v.GetString()`, construct `wxColour initial(colorString)`, and if the string is empty or `initial.IsOk()` is false, fall back to `*wxWHITE` before creating the `wxColourPickerCtrl`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d0c5685508324af1ceca69c808149)