### PR TITLE
Restore default ellipsize behavior in data view columns and renderers

### DIFF
--- a/gui/colorfulrenderers.h
+++ b/gui/colorfulrenderers.h
@@ -25,16 +25,6 @@
 #include "colorstore.h"
 
 namespace {
-template <typename Renderer>
-auto SetEllipsizeModeIfSupported(Renderer *renderer, wxEllipsizeMode mode)
-    -> decltype(renderer->SetEllipsizeMode(mode), void()) {
-  if (!renderer)
-    return;
-  renderer->SetEllipsizeMode(mode);
-}
-
-inline void SetEllipsizeModeIfSupported(...) {}
-
 inline const ColorfulDataViewListStore *GetColorfulStore(
     const wxDataViewCustomRenderer *renderer) {
   if (!renderer)
@@ -150,9 +140,7 @@ class ColorfulTextRenderer : public wxDataViewCustomRenderer {
 public:
   ColorfulTextRenderer(wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT,
                        int align = wxDVR_DEFAULT_ALIGNMENT)
-      : wxDataViewCustomRenderer("string", mode, align) {
-    SetEllipsizeModeIfSupported(this, wxELLIPSIZE_NONE);
-  }
+      : wxDataViewCustomRenderer("string", mode, align) {}
 
   bool Render(wxRect rect, wxDC *dc, int state) override {
     wxColour background;
@@ -196,9 +184,7 @@ class ColorfulIconTextRenderer : public wxDataViewCustomRenderer {
 public:
   ColorfulIconTextRenderer(wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT,
                            int align = wxDVR_DEFAULT_ALIGNMENT)
-      : wxDataViewCustomRenderer("wxDataViewIconText", mode, align) {
-    SetEllipsizeModeIfSupported(this, wxELLIPSIZE_NONE);
-  }
+      : wxDataViewCustomRenderer("wxDataViewIconText", mode, align) {}
 
   bool Render(wxRect rect, wxDC *dc, int state) override {
     wxColour background;

--- a/gui/columnutils.h
+++ b/gui/columnutils.h
@@ -20,18 +20,6 @@
 #include <wx/dataview.h>
 
 namespace ColumnUtils {
-namespace detail {
-template <typename Column>
-auto SetEllipsizeModeIfSupported(Column *column, wxEllipsizeMode mode)
-    -> decltype(column->SetEllipsizeMode(mode), void()) {
-  if (!column)
-    return;
-  column->SetEllipsizeMode(mode);
-}
-
-inline void SetEllipsizeModeIfSupported(...) {}
-} // namespace detail
-
 inline void EnforceMinColumnWidth(wxDataViewListCtrl *table,
                                   int minWidth = 50) {
   if (!table)
@@ -41,10 +29,6 @@ inline void EnforceMinColumnWidth(wxDataViewListCtrl *table,
   for (unsigned int i = 0; i < count; ++i) {
     if (auto *col = table->GetColumn(i)) {
       col->SetMinWidth(minWidth);
-      detail::SetEllipsizeModeIfSupported(col, wxELLIPSIZE_NONE);
-      if (auto *renderer = col->GetRenderer()) {
-        detail::SetEllipsizeModeIfSupported(renderer, wxELLIPSIZE_NONE);
-      }
     }
   }
 }


### PR DESCRIPTION
### Motivation
- macOS was seeing inappropriate ellipsizing in table cells because code forced an ellipsize mode override, making text appear compressed even when there was room.
- The intent is to revert to the wxWidgets default ellipsize behavior so text is truncated only when it actually doesn't fit, while keeping minimum column width enforcement.

### Description
- Removed the `SetEllipsizeModeIfSupported` helper and its usages that forced `wxELLIPSIZE_NONE` for data view columns in `gui/columnutils.h` and for custom renderers in `gui/colorfulrenderers.h`.
- Left `EnforceMinColumnWidth` intact so minimum column widths are still applied via `EnforceMinColumnWidth`.
- Removed calls in `ColorfulTextRenderer` and `ColorfulIconTextRenderer` constructors that previously attempted to set the ellipsize mode, restoring renderer defaults.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d0dea3d7883249d514838de0755e5)