### PR TITLE
Fix macOS data view ellipsizing measurement

### DIFF
--- a/gui/colorfulrenderers.h
+++ b/gui/colorfulrenderers.h
@@ -88,15 +88,6 @@ inline void DrawTextValue(wxDataViewCustomRenderer *renderer,
     return;
 
   auto measureText = [&](const wxString &value) {
-    wxDataViewColumn *column = renderer->GetOwner();
-    wxDataViewCtrl *ctrl = column ? column->GetOwner() : nullptr;
-    wxFont font = dc->GetFont();
-    if (ctrl) {
-      int width = 0;
-      int height = 0;
-      ctrl->GetTextExtent(value, &width, &height, nullptr, nullptr, &font);
-      return wxSize(width, height);
-    }
     return dc->GetTextExtent(value);
   };
 


### PR DESCRIPTION
### Motivation
- On macOS the previous code used `wxDataViewCtrl::GetTextExtent` with an explicit font which could over-report text widths and cause unnecessary ellipsizing in data view cells, so measurement must match the active `wxDC` used for drawing.

### Description
- Replace the `measureText` lambda in `DrawTextValue` to always use `dc->GetTextExtent(value)` and remove the `wxDataViewCtrl`-specific text extent path in `gui/colorfulrenderers.h` so displayed text is measured consistently with the drawing context.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d0f910f5083248a01f2692ea6743e)