### PR TITLE
Fix text measurement for data view renderers on macOS

### DIFF
--- a/gui/colorfulrenderers.h
+++ b/gui/colorfulrenderers.h
@@ -74,9 +74,12 @@ inline bool ResolveBackgroundColour(const wxDataViewCustomRenderer *renderer,
   return false;
 }
 
-inline void ApplyAttributeFont(wxDC *dc, const wxDataViewItemAttr &attr) {
+inline void ApplyAttributeFont(wxDC *dc, const wxDataViewItemAttr &attr,
+                               const wxWindow *ctrl) {
   if (!dc)
     return;
+  if (ctrl)
+    dc->SetFont(ctrl->GetFont());
   if (attr.HasFont())
     dc->SetFont(attr.GetEffectiveFont(dc->GetFont()));
 }
@@ -87,13 +90,17 @@ inline void DrawTextValue(wxDataViewCustomRenderer *renderer,
   if (!renderer || !dc)
     return;
 
+  wxDataViewCtrl *ctrl = nullptr;
+  if (auto *column = renderer->GetOwner())
+    ctrl = column->GetOwner();
+
   auto measureText = [&](const wxString &value) {
-    return dc->GetTextExtent(value);
+    return ctrl ? ctrl->GetTextExtent(value) : dc->GetTextExtent(value);
   };
 
   wxDCClipper clip(*dc, rect);
   const wxDataViewItemAttr &attr = renderer->GetAttr();
-  ApplyAttributeFont(dc, attr);
+  ApplyAttributeFont(dc, attr, ctrl);
   dc->SetTextForeground(ResolveTextColour(renderer, state, attr));
 
   wxString displayText = text;


### PR DESCRIPTION
### Motivation
- Data view cells on macOS were being ellipsized prematurely in the "Data Views" tables because text measurement used the DC font instead of the owning control font, causing text to appear compressed even when space was available.

### Description
- Change `ApplyAttributeFont` to accept the owning control pointer and apply `ctrl->GetFont()` to the DC before applying per-cell font attributes.
- In `DrawTextValue` obtain the owning `wxDataViewCtrl` from the renderer and use `ctrl->GetTextExtent()` for width measurements when available, falling back to `dc->GetTextExtent()` otherwise.
- Update the text measurement and font application logic in `gui/colorfulrenderers.h` to prevent premature ellipsizing while preserving existing ellipsize behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d1116a1348324bb02ecac754b7786)