### PR TITLE
Reapply OpenGL blend/depth state in InitGL to fix loading text transparency

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1297,12 +1297,10 @@ bool LayoutViewerPanel::InitGL() {
     return false;
   if (!SetCurrent(*glContext_))
     return false;
-  if (!glInitialized_) {
-    glDisable(GL_DEPTH_TEST);
-    glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    glInitialized_ = true;
-  }
+  glDisable(GL_DEPTH_TEST);
+  glEnable(GL_BLEND);
+  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+  glInitialized_ = true;
   isReadyToRender_ = true;
   return true;
 }


### PR DESCRIPTION
### Motivation
- Fix a rendering bug where the "Loading layout..." text appears as a white rectangle on subsequent displays because OpenGL blend/depth state was not re-applied when the GL context is re-used.

### Description
- Always call `glDisable(GL_DEPTH_TEST)`, `glEnable(GL_BLEND)` and `glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)` inside `LayoutViewerPanel::InitGL()` so the GL state required for alpha text rendering is restored each time the context is initialized.
- Set `glInitialized_ = true` after applying the state; no other behavioral changes were made.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e4987a15883248bc201853c4bf6ad)