### PR TITLE
Fix loading overlay blending in layout viewer

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -538,6 +538,8 @@ void LayoutViewerPanel::DrawLoadingOverlay(const wxSize &size) {
     return;
   if (size.GetWidth() <= 0 || size.GetHeight() <= 0)
     return;
+  glEnable(GL_BLEND);
+  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
   glColor4ub(0, 0, 0, 150);
   glBegin(GL_QUADS);
   glVertex2f(0.0f, 0.0f);


### PR DESCRIPTION
### Motivation
- Subsequent draws of the `Loading layout...` overlay showed a white rectangle instead of alpha text because blending was not enabled when rendering the overlay texture.

### Description
- Enable OpenGL blending and set `glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)` at the start of `DrawLoadingOverlay` so the text texture alpha is applied correctly.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e4d5f6d3483249c83fef921e41baa)