### PR TITLE
Fix loading overlay text texture reuse

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -578,8 +578,16 @@ void LayoutViewerPanel::DrawLoadingOverlay(const wxSize &size) {
 }
 
 void LayoutViewerPanel::EnsureLoadingTextTexture() {
-  if (loadingTextTexture_ != 0)
-    return;
+  if (loadingTextTexture_ != 0) {
+    if (!InitGL())
+      return;
+    if (!glIsTexture(loadingTextTexture_)) {
+      loadingTextTexture_ = 0;
+      loadingTextTextureSize_ = wxSize(0, 0);
+    } else {
+      return;
+    }
+  }
 
   const wxString label = wxString::FromUTF8("Loading layout...");
   wxFont font = wxFontInfo(14).Bold();


### PR DESCRIPTION
### Motivation
- The loading overlay could show a blank white rectangle after GL context changes because the cached texture was reused without verifying it was still valid in the current OpenGL context.

### Description
- Update `EnsureLoadingTextTexture()` to call `InitGL()` and validate the cached `loadingTextTexture_` with `glIsTexture`, resetting `loadingTextTexture_` and `loadingTextTextureSize_` when the texture is no longer valid so the text bitmap is regenerated.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e4f32f5a083249932382bc4cb9609)