### PR TITLE
Preserve layout 2D view state on project load/reset

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -452,7 +452,8 @@ bool MainWindow::LoadProjectFromPath(const std::string &path) {
     viewportPanel->Refresh();
   }
   if (viewport2DPanel) {
-    viewport2DPanel->LoadViewFromConfig();
+    if (!HasActiveLayout2DView())
+      viewport2DPanel->LoadViewFromConfig();
     viewport2DPanel->UpdateScene();
     viewport2DPanel->Refresh();
   }
@@ -486,7 +487,8 @@ void MainWindow::ResetProject() {
     viewportPanel->Refresh();
   }
   if (viewport2DPanel) {
-    viewport2DPanel->LoadViewFromConfig();
+    if (!HasActiveLayout2DView())
+      viewport2DPanel->LoadViewFromConfig();
     viewport2DPanel->UpdateScene();
     viewport2DPanel->Refresh();
   }
@@ -597,6 +599,23 @@ void MainWindow::UpdateViewMenuChecks() {
 
 void MainWindow::OnLayoutSelected(wxCommandEvent &event) {
   ActivateLayoutView(event.GetString().ToStdString());
+}
+
+bool MainWindow::HasActiveLayout2DView() const {
+  if (activeLayoutName.empty())
+    return false;
+
+  const auto &layouts = layouts::LayoutManager::Get().GetLayouts().Items();
+  for (const auto &layout : layouts) {
+    if (layout.name != activeLayoutName)
+      continue;
+    for (const auto &view : layout.view2dViews) {
+      if (view.id > 0)
+        return true;
+    }
+    return false;
+  }
+  return false;
 }
 
 void MainWindow::ShowLayoutLoadingIndicator(const wxString &message) {
@@ -748,7 +767,8 @@ void MainWindow::OnProjectLoaded(wxCommandEvent &event) {
       viewportPanel->Refresh();
     }
     if (viewport2DPanel) {
-      viewport2DPanel->LoadViewFromConfig();
+      if (!HasActiveLayout2DView())
+        viewport2DPanel->LoadViewFromConfig();
       viewport2DPanel->UpdateScene();
       viewport2DPanel->Refresh();
     }

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -177,6 +177,7 @@ private:
   void ActivateLayoutView(const std::string &layoutName);
   void ShowLayoutLoadingIndicator(const wxString &message);
   void ClearLayoutLoadingIndicator();
+  bool HasActiveLayout2DView() const;
   void SyncSceneData();
   bool ConfirmSaveIfDirty(const wxString &actionLabel,
                           const wxString &dialogTitle);


### PR DESCRIPTION
### Motivation
- Fix a bug where a 2D view the user recorded for a layout would briefly appear after reopening a project but then get overwritten by the default/configured 2D viewport state, losing the saved zoom/position.

### Description
- Add `HasActiveLayout2DView()` to `MainWindow` to detect when the active layout contains a saved 2D view (checks `activeLayoutName` and `view.id > 0`).
- Use the helper to avoid calling `viewport2DPanel->LoadViewFromConfig()` when a layout 2D view is active, in `LoadProjectFromPath()`, `OnProjectLoaded()` and `ResetProject()` so the recorded layout view is not overwritten.
- Add the new method declaration to `gui/mainwindow.h` and implement it in `gui/mainwindow.cpp`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e50a3bf74832498725227b60200a4)