### PR TITLE
Fix 2D view restore in non-layout mode

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -676,7 +676,7 @@ void MainWindow::ActivateLayoutView(const std::string &layoutName) {
     ClearLayoutLoadingIndicator();
   }
 
-  if (viewport2DPanel) {
+  if (viewport2DPanel && layoutModeActive) {
     int viewId = 0;
     bool hasViewId = false;
     if (layoutViewerPanel) {


### PR DESCRIPTION
### Motivation
- The application was overwriting the saved 2D viewport zoom/position on startup because layout-specific 2D view restoration was being applied even when not in layout mode, causing an unwanted reset after the initial restored view.

### Description
- Added a guard in `ActivateLayoutView` so the layout view restoration block only runs when `layoutModeActive`, modifying `gui/mainwindow.cpp` to avoid calling `RestoreLayout2DViewState` in non-layout mode.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698399f146e08324808099b9aabec7fe)