### PR TITLE
Fix unnecessary 2D view reset right after startup project load

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -767,8 +767,9 @@ void MainWindow::OnProjectLoaded(wxCommandEvent &event) {
       viewportPanel->Refresh();
     }
     if (viewport2DPanel) {
-      if (!HasActiveLayout2DView())
-        viewport2DPanel->LoadViewFromConfig();
+      // During startup the panel has already loaded the persisted standalone
+      // camera state once (in Ensure2DViewport). Re-loading here can cause a
+      // second camera jump right after launch.
       viewport2DPanel->UpdateScene();
       viewport2DPanel->Refresh();
     }


### PR DESCRIPTION
### Motivation
- Prevent a visual jump where the 2D viewport camera is reapplied after startup because the panel already loads persisted camera state in `Ensure2DViewport` and re-loading it again in the async project-load path causes an unnecessary reset.

### Description
- Remove the redundant `LoadViewFromConfig()` call in `MainWindow::OnProjectLoaded` for `viewport2DPanel`, retain `UpdateScene()`/`Refresh()`, and add a clarifying comment in `gui/mainwindow.cpp` explaining why the extra reload is skipped.

### Testing
- Attempted to run a configure step with `cmake -S . -B build`, but configuration failed in this environment due to a missing `wxWidgets` development package (`wxWidgetsConfig.cmake` not found), so no full build/test could be performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69846cc0df508324906abbf2589785d8)