### PR TITLE
Keep selection when applying CLI position/rotation transforms

### DIFF
--- a/gui/consolepanel.cpp
+++ b/gui/consolepanel.cpp
@@ -508,6 +508,28 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
       return vals;
     };
 
+    auto refreshSelectionAfterTransform =
+        [&](const std::vector<std::string> &sel, bool fixtures) {
+          if (fixtures) {
+            if (FixtureTablePanel::Instance()) {
+              FixtureTablePanel::Instance()->ReloadData();
+              FixtureTablePanel::Instance()->SelectByUuid(sel);
+            }
+          } else {
+            if (TrussTablePanel::Instance()) {
+              TrussTablePanel::Instance()->ReloadData();
+              TrussTablePanel::Instance()->SelectByUuid(sel);
+            }
+          }
+          if (Viewer3DPanel::Instance()) {
+            Viewer3DPanel::Instance()->SetSelectedFixtures(sel);
+            Viewer3DPanel::Instance()->UpdateScene();
+            Viewer3DPanel::Instance()->Refresh();
+          }
+          if (Viewer2DPanel::Instance())
+            Viewer2DPanel::Instance()->SetSelectedUuids(sel);
+        };
+
     auto isCmd = [](const std::string &tok, bool allowAxis,
                     bool allowRangeSeparator) {
       if (tok.empty())
@@ -609,17 +631,7 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
           else
             applyPos(sel, fixtures, axis, vals, rel);
         }
-        if (fixtures) {
-          if (FixtureTablePanel::Instance())
-            FixtureTablePanel::Instance()->ReloadData();
-        } else {
-          if (TrussTablePanel::Instance())
-            TrussTablePanel::Instance()->ReloadData();
-        }
-        if (Viewer3DPanel::Instance()) {
-          Viewer3DPanel::Instance()->UpdateScene();
-          Viewer3DPanel::Instance()->Refresh();
-        }
+        refreshSelectionAfterTransform(sel, fixtures);
       } else if (lw == "x" || lw == "y" || lw == "z") {
         cfg.PushUndoState("cli pos");
         std::string rest;
@@ -636,17 +648,7 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
         bool rel = false;
         auto vals = parseVals(rest, rel);
         applyPos(sel, fixtures, axis, vals, rel);
-        if (fixtures) {
-          if (FixtureTablePanel::Instance())
-            FixtureTablePanel::Instance()->ReloadData();
-        } else {
-          if (TrussTablePanel::Instance())
-            TrussTablePanel::Instance()->ReloadData();
-        }
-        if (Viewer3DPanel::Instance()) {
-          Viewer3DPanel::Instance()->UpdateScene();
-          Viewer3DPanel::Instance()->Refresh();
-        }
+        refreshSelectionAfterTransform(sel, fixtures);
       } else if (!lw.empty() && (std::isdigit(lw[0]) || lw[0] == '-' ||
                                  lw[0] == '+') &&
                  word.find(',') != std::string::npos) {
@@ -661,17 +663,7 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
           auto vals = parseVals(parts[idx], rel);
           applyPos(sel, fixtures, (int)idx, vals, rel);
         }
-        if (fixtures) {
-          if (FixtureTablePanel::Instance())
-            FixtureTablePanel::Instance()->ReloadData();
-        } else {
-          if (TrussTablePanel::Instance())
-            TrussTablePanel::Instance()->ReloadData();
-        }
-        if (Viewer3DPanel::Instance()) {
-          Viewer3DPanel::Instance()->UpdateScene();
-          Viewer3DPanel::Instance()->Refresh();
-        }
+        refreshSelectionAfterTransform(sel, fixtures);
       } else if (!lw.empty() && lw[0] == 'f') {
         std::vector<std::string> sub(tokens.begin() + i + 1,
                                      tokens.begin() + j);


### PR DESCRIPTION
### Motivation
- CLI transform commands (`pos`, `rot`, axis `x|y|z`, and comma-vector forms) reloaded the fixture/truss tables and caused the current selection to be lost. 
- The most efficient and robust fix is to preserve the current selected UUIDs and reapply them after the table reload instead of recomputing selection from scene state.

### Description
- Added a helper `refreshSelectionAfterTransform` inside `ConsolePanel::ProcessCommand` that reloads the appropriate table, calls `SelectByUuid(sel)`, and synchronizes selection with `Viewer3D` and `Viewer2D`.
- Replaced repeated manual `ReloadData`/`UpdateScene`/`Refresh` calls in the CLI transform code paths with calls to `refreshSelectionAfterTransform(sel, fixtures)` for `pos`/`rot`, axis-only (`x|y|z`), and comma-vector forms.
- The change modifies `gui/consolepanel.cpp` to preserve and reapply selection by UUID after CLI-applied transforms.

### Testing
- Ran `git diff --check` to validate the patch and it reported no issues. 
- Staged and committed the change with `git add gui/consolepanel.cpp` and `git commit -m "Keep CLI transform selection after table reload"`; no automated build or runtime tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69847e8cfce08324bae8b25a072dfb2d)