### PR TITLE
Fix MVR 1.6 exporter: provider/providerVersion, GDTFSpec packaging, ZIP dedupe and FixtureID allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@
   - A built‑in fixture dictionary maps textual fixture descriptions to GDTF files stored in the `library/` directory.
   - Geometry loaders parse embedded GDTF models for preview and rendering in the 3D viewer.
   - Online lookup: download fixtures from **GDTF‑Share** via the *Tools → Download GDTF fixture* dialog.
+  - Exported MVR packages store referenced GDTFs under `gdtf/` inside the archive and `GDTFSpec` always uses archive‑relative forward‑slash paths.
+  - If two different GDTF files share the same filename, export auto‑renames collisions deterministically (`name (1).gdtf`, etc.) and updates each `GDTFSpec` reference.
+  - Parametric objects exported as Fixture/Truss/Support receive non-empty `FixtureID` + globally unique `FixtureIDNumeric` values across the scene.
 
 ### Rider import from text or PDF
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -74,6 +74,30 @@ target_link_libraries(save_load_roundtrip_test PRIVATE
 add_test(NAME SaveLoadRoundtrip COMMAND save_load_roundtrip_test)
 set_library_env(SaveLoadRoundtrip)
 
+add_executable(mvr_exporter_compliance_test mvr_exporter_compliance_test.cpp
+               ../core/configmanager.cpp
+               ../core/projectutils.cpp
+               ../core/gdtfdictionary.cpp
+               ../core/trussdictionary.cpp
+               ../core/uuidutils.cpp
+               ../mvr/mvrimporter.cpp
+               ../mvr/mvrexporter.cpp
+               ../core/logger.cpp
+               gdtfloader_stub.cpp
+               consolepanel_stub.cpp
+               ../models/mvrscene.cpp
+               ../models/fixture.cpp
+               ../models/truss.cpp
+               ../models/sceneobject.cpp
+               ../models/layer.cpp
+               ${LAYOUT_SOURCES})
+target_include_directories(mvr_exporter_compliance_test PRIVATE
+                           . ../core ../models ../mvr ../gui ../external)
+target_link_libraries(mvr_exporter_compliance_test PRIVATE
+                      ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
+add_test(NAME MvrExporterCompliance COMMAND mvr_exporter_compliance_test)
+set_library_env(MvrExporterCompliance)
+
 add_executable(rider_save_roundtrip_test rider_save_roundtrip_test.cpp
                pdftext_stub.cpp
                gdtfloader_stub.cpp

--- a/tests/mvr_exporter_compliance_test.cpp
+++ b/tests/mvr_exporter_compliance_test.cpp
@@ -1,0 +1,153 @@
+/*
+ * This file is part of Perastage.
+ */
+#include <cassert>
+#include <filesystem>
+#include <fstream>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <tinyxml2.h>
+#include <wx/init.h>
+#include <wx/wfstream.h>
+#include <wx/zipstrm.h>
+
+#include "../core/configmanager.h"
+#include "../mvr/mvrexporter.h"
+#include "../models/fixture.h"
+#include "../models/truss.h"
+#include "../models/support.h"
+
+namespace fs = std::filesystem;
+
+int main() {
+  wxInitializer initializer;
+  assert(initializer.IsOk());
+
+  auto &cfg = ConfigManager::Get();
+  cfg.Reset();
+  MvrScene &scene = cfg.GetScene();
+
+  fs::path tempDir = fs::temp_directory_path() / "mvr_exporter_compliance_test";
+  fs::remove_all(tempDir);
+  fs::create_directories(tempDir / "A");
+  fs::create_directories(tempDir / "B");
+
+  std::ofstream(tempDir / "A" / "Same.gdtf") << "A";
+  std::ofstream(tempDir / "B" / "Same.gdtf") << "B";
+  std::ofstream(tempDir / "mesh.3ds") << "mesh";
+
+  scene.basePath = tempDir.generic_string();
+  scene.provider.clear();
+  scene.providerVersion.clear();
+  scene.versionMajor = 1;
+  scene.versionMinor = 6;
+
+  Fixture f1;
+  f1.uuid = "fx-1";
+  f1.instanceName = "Front Key";
+  f1.gdtfSpec = (tempDir / "A" / "Same.gdtf").generic_string();
+  f1.fixtureId = 0;
+  f1.fixtureIdNumeric = 0;
+  scene.fixtures[f1.uuid] = f1;
+
+  Fixture f2;
+  f2.uuid = "fx-2";
+  f2.instanceName = "Back Key";
+  f2.gdtfSpec = (tempDir / "B" / "Same.gdtf").generic_string();
+  f2.fixtureId = 0;
+  f2.fixtureIdNumeric = 0;
+  scene.fixtures[f2.uuid] = f2;
+
+  Truss tr;
+  tr.uuid = "tr-1";
+  tr.name = "Main Truss";
+  tr.symbolFile = "mesh.3ds";
+  tr.modelFile = "mesh.3ds";
+  scene.trusses[tr.uuid] = tr;
+
+  Support sup;
+  sup.uuid = "sup-1";
+  sup.name = "Hoist 1";
+  sup.gdtfSpec = (tempDir / "A" / "Same.gdtf").generic_string();
+  scene.supports[sup.uuid] = sup;
+
+  MvrExporter exporter;
+  fs::path mvrPath = tempDir / "Test1.mvr";
+  assert(exporter.ExportToFile(mvrPath.generic_string()));
+
+  wxFileInputStream input(mvrPath.generic_string());
+  assert(input.IsOk());
+  wxZipInputStream zip(input);
+
+  std::unordered_set<std::string> entries;
+  std::string xml;
+  std::unique_ptr<wxZipEntry> entry;
+  while ((entry.reset(zip.GetNextEntry())), entry) {
+    const std::string name = entry->GetName().ToStdString();
+    assert(entries.insert(name).second);
+
+    if (name == "GeneralSceneDescription.xml") {
+      char buffer[4096];
+      while (true) {
+        zip.Read(buffer, sizeof(buffer));
+        size_t bytes = zip.LastRead();
+        if (bytes == 0)
+          break;
+        xml.append(buffer, bytes);
+      }
+    }
+  }
+
+  assert(!xml.empty());
+  tinyxml2::XMLDocument doc;
+  assert(doc.Parse(xml.c_str()) == tinyxml2::XML_SUCCESS);
+  tinyxml2::XMLElement *root = doc.FirstChildElement("GeneralSceneDescription");
+  assert(root != nullptr);
+  assert(root->IntAttribute("verMajor") == 1);
+  assert(root->IntAttribute("verMinor") == 6);
+  assert(std::string(root->Attribute("provider")) == "Perastage");
+  assert(std::string(root->Attribute("providerVersion")) == "1.0");
+
+  std::unordered_set<int> numericIds;
+  std::unordered_map<std::string, int> gdtfCount;
+  for (const char *tagName : {"Fixture", "Truss", "Support"}) {
+    for (tinyxml2::XMLElement *node = root->FirstChildElement(); node;
+         node = node->NextSiblingElement()) {
+      std::vector<tinyxml2::XMLElement *> stack{node};
+      while (!stack.empty()) {
+        tinyxml2::XMLElement *cur = stack.back();
+        stack.pop_back();
+        if (std::string(cur->Name()) == tagName) {
+          auto *idNode = cur->FirstChildElement("FixtureID");
+          auto *numNode = cur->FirstChildElement("FixtureIDNumeric");
+          assert(idNode && idNode->GetText() && std::string(idNode->GetText()).size() > 0);
+          assert(numNode && numNode->GetText());
+          int value = std::stoi(numNode->GetText());
+          assert(value > 0);
+          assert(numericIds.insert(value).second);
+
+          if (auto *gdtf = cur->FirstChildElement("GDTFSpec"); gdtf && gdtf->GetText()) {
+            std::string spec = gdtf->GetText();
+            assert(spec.find(':') == std::string::npos);
+            assert(spec.find('\\') == std::string::npos);
+            assert(!spec.empty() && spec.front() != '/');
+            assert(entries.count(spec) == 1);
+            ++gdtfCount[spec];
+          }
+        }
+        for (tinyxml2::XMLElement *child = cur->FirstChildElement(); child;
+             child = child->NextSiblingElement()) {
+          stack.push_back(child);
+        }
+      }
+    }
+  }
+
+  assert(gdtfCount.size() >= 2);
+  fs::remove_all(tempDir);
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- The exporter produced MVRs that lacked required MVR 1.6 root attributes (`provider` / `providerVersion`) and emitted filesystem paths in `GDTFSpec`, breaking importers (e.g. CAST Wysiwyg). 
- Parametric objects were sometimes missing `FixtureID`/`FixtureIDNumeric` or emitting empty tags, and `FixtureIDNumeric` could collide across objects. 
- The ZIP writer could add duplicate internal entries (same internal filename), producing invalid/buggy archives. 
- Add a validation pass and a regression test to guarantee exported MVR 1.6 invariants are preserved.

### Description
- Enforce MVR 1.6 root metadata and UTF-8 declaration in `mvr/mvrexporter.cpp` by writing `verMajor=1`, `verMinor=6`, `provider` and `providerVersion` (defaults to `Perastage` / `1.0` when missing) and an explicit `<?xml ... encoding="UTF-8"?>` declaration.  See `ValidateMvr16Export`. 
- Replace raw resource collection with a deduplicating resource registry that computes archive-relative paths, sanitizes file names, and ensures deterministic collision handling (helper functions: `SanitizeArchiveFileName`, `EnsureUniqueArchivePath`, `registerResource`, `registerGdtfResource`). GDTFs are stored as archive-relative names (recommended `gdtf/...`) and `GDTFSpec` now references only archive paths. 
- Allocate stable, non-empty `FixtureID` strings and globally unique positive `FixtureIDNumeric` values across `Fixture`, `Truss`, and `Support` exports with fallback allocation to avoid collisions; multipatch children handling preserved by omitting IDs when appropriate. 
- Prevent duplicate internal ZIP entries by tracking `resourceEntries` and writing each archive path once; patched GDTFs are injected only when needed (`CreatePatchedGdtf`) and the ZIP entries are written with the computed archive paths. 
- Add exporter-side validation (`ValidateMvr16Export`) that checks root attributes, required object IDs (except multipatch children), GDTFSpec format (no ':' or backslashes, no leading '/'), and that each referenced GDTF is present in the archive before writing the ZIP. 
- Documentation and test: added `tests/mvr_exporter_compliance_test.cpp`, registered in `tests/CMakeLists.txt`, and documented packaging rules in `README.md`.

### Testing
- A new regression test `MvrExporterCompliance` (`tests/mvr_exporter_compliance_test.cpp`) was added that generates `Test1.mvr` and asserts the following invariants in the produced archive: `GeneralSceneDescription` has `verMajor=1`/`verMinor=6` and `provider`/`providerVersion`; there are no duplicate internal ZIP entry names; `GDTFSpec` values are archive-relative (no `:` or `\` or leading `/`) and match included entries; `FixtureIDNumeric` values are globally unique and > 0. 
- Attempted to configure the tests with `cmake -S tests -B build/tests -DCMAKE_BUILD_TYPE=Release` in this environment, but configuration failed because the system is missing the `wxWidgets` development packages (so the regression test was not executed here). To run locally: `cmake -S tests -B build/tests -DCMAKE_BUILD_TYPE=Release && cmake --build build/tests && ctest --test-dir build/tests`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984e15b455483249c237b67215d46b4)