### PR TITLE
Fix undefined addStr/addInt helpers in mvrexporter lambdas

### DIFF
--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -704,6 +704,13 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
         te->InsertEndChild(e);
       }
     };
+    auto addStr = [&](const char *n, const std::string &v) {
+      if (!v.empty()) {
+        tinyxml2::XMLElement *e = doc.NewElement(n);
+        e->SetText(v.c_str());
+        te->InsertEndChild(e);
+      }
+    };
     auto idIt = assignedIds.find(t.uuid);
     int fixtureNumericId = (idIt != assignedIds.end()) ? idIt->second.second : 0;
     std::string fixtureId =
@@ -838,6 +845,13 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
       if (!v.empty()) {
         tinyxml2::XMLElement *e = doc.NewElement(n);
         e->SetText(v.c_str());
+        se->InsertEndChild(e);
+      }
+    };
+    auto addInt = [&](const char *n, int v) {
+      if (v != 0) {
+        tinyxml2::XMLElement *e = doc.NewElement(n);
+        e->SetText(std::to_string(v).c_str());
         se->InsertEndChild(e);
       }
     };


### PR DESCRIPTION
### Motivation
- Resolve MSVC `error C3861` caused by missing helper lambdas referenced inside the `exportTruss` and `exportSupport` lambdas so Truss/Support XML fields can be emitted correctly.

### Description
- Added a local `addStr` lambda inside `exportTruss` to emit string child elements on the `Truss` node (`mvr/mvrexporter.cpp`).
- Added a local `addInt` lambda inside `exportSupport` to emit integer child elements on the `Support` node (`mvr/mvrexporter.cpp`).
- These helpers mirror existing patterns used in `exportFixture` and other export lambdas to keep element emission consistent.

### Testing
- Verified helper call sites resolve using `rg -n "addStr\\(|addInt\\(" mvr/mvrexporter.cpp`, which returned the updated usages; check succeeded.
- Committed the change (`git commit`) and confirmed the patch was applied; no full build was run in this environment because the original error was reported on MSVC/Windows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984e47b83708324bf45b3b5d496a96a)