### PR TITLE
Fix MVR 1.6 export FileName references and duplicate ZIP entries

### DIFF
--- a/tests/mvr_exporter_compliance_test.cpp
+++ b/tests/mvr_exporter_compliance_test.cpp
@@ -134,6 +134,7 @@ int main() {
             std::string spec = gdtf->GetText();
             assert(spec.find(':') == std::string::npos);
             assert(spec.find('\\') == std::string::npos);
+            assert(spec.find('/') == std::string::npos);
             assert(!spec.empty() && spec.front() != '/');
             assert(entries.count(spec) == 1);
             ++gdtfCount[spec];
@@ -148,6 +149,10 @@ int main() {
   }
 
   assert(gdtfCount.size() >= 2);
+
+  for (const auto &name : entries) {
+    assert(name.rfind("gdtf/", 0) != 0);
+  }
   fs::remove_all(tempDir);
   return 0;
 }


### PR DESCRIPTION
### Motivation
- Prevent CAST Wysiwyg from generating placeholder `gdtf/fixture*.gdtf` files by ensuring `GDTFSpec` values are archive-root FileName values (no absolute paths or path separators). 
- Eliminate duplicate ZIP entries that cause inconsistent archive consumers and ensure MVR 1.6 root attributes (`verMajor=1`, `verMinor=6`, `provider`, `providerVersion`) remain present and correct. 
- Add automated validation to fail exports that would produce broken MVR archives rather than silently emitting placeholders or duplicates.

### Description
- Added `IsValidMvrFileName` to enforce FileName rules (no `:`, `/`, `\\`, control chars or other reserved characters) and updated `ValidateMvr16Export` to scan XML for all `GDTFSpec` and `fileName` references and require each referenced file to appear exactly once in the archive. 
- Switched `registerGdtfResource` to use a sanitized root-level base filename (no `gdtf/` prefix) and changed geometry/model registrations to use sanitized root filenames so all resources are archive-root FileNames. 
- Made archive-name collision suffixes deterministic and safe by changing `EnsureUniqueArchivePath` to produce `_2`, `_3`, ... style suffixes instead of parentheses, and kept a `sourceToArchivePath` mapping so the same source maps to the same archive filename. 
- Built a `plannedArchiveEntries` frequency map used by validation and added a runtime duplicate-write guard `writtenArchiveEntries` when emitting ZIP entries to prevent duplicate writes and to fail the export with a clear error if duplicates would be written. 
- Updated the compliance test `tests/mvr_exporter_compliance_test.cpp` to assert `GDTFSpec` contains no path separators and that no archive entry begins with `gdtf/`.
- Files modified: `mvr/mvrexporter.cpp`, `tests/mvr_exporter_compliance_test.cpp`.

### Testing
- Updated unit test: modified `tests/mvr_exporter_compliance_test.cpp` to validate the new FileName constraints and absence of `gdtf/` entries (test source changed but not executed here). 
- Attempted to configure and build the targeted test executable (`mvr_exporter_compliance_test`) with `cmake`/`cmake --build`, but the build failed in this environment due to a missing `wxWidgets` CMake package, so the updated test was not executed. 
- No other automated tests were run in this environment; changes were committed after local edits and test updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984fb48066083249352ca95b135e9c8)