### PR TITLE
Fix MVR fixture ID persistence for fixture/spot roundtrips

### DIFF
--- a/models/fixture.h
+++ b/models/fixture.h
@@ -39,7 +39,8 @@ struct Fixture {
 
     std::string color;            // Hex RGB color (e.g., "#RRGGBB")
 
-    int fixtureId = 0;            // FixtureID (numeric ID from XML)
+    std::string fixtureIdText;    // FixtureID (free-form string identifier from XML)
+    int fixtureId = 0;            // Numeric FixtureID fallback used internally
     int fixtureIdNumeric = 0;     // Optional numeric ID field (if distinct)
     int unitNumber = 0;           // Unit number (if available)
     int customId = 0;             // Custom ID field

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -672,8 +672,11 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
 
     auto idIt = assignedIds.find(f.uuid);
     int fixtureNumericId = (idIt != assignedIds.end()) ? idIt->second.second : 0;
-    std::string fixtureId =
-        (idIt != assignedIds.end()) ? idIt->second.first : std::to_string(fixtureNumericId);
+    std::string fixtureId = TrimAscii(f.fixtureIdText);
+    if (fixtureId.empty()) {
+      fixtureId =
+          (idIt != assignedIds.end()) ? idIt->second.first : std::to_string(fixtureNumericId);
+    }
     if (fixtureId.empty())
       fixtureId = std::to_string(fixtureNumericId);
     if (fixtureNumericId <= 0)

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -383,6 +383,15 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
       out = std::atoi(n->GetText());
   };
 
+  auto fixtureIdOf = [&](tinyxml2::XMLElement *parent,
+                         std::string &textOut,
+                         int &numericOut) {
+    textOut = textOf(parent, "FixtureID");
+    intOf(parent, "FixtureIDNumeric", numericOut);
+    if (numericOut <= 0 && !textOut.empty())
+      numericOut = std::atoi(textOut.c_str());
+  };
+
   // ---- Parse AUXData for Symdefs and Positions ----
   if (tinyxml2::XMLElement *auxNode = sceneNode->FirstChildElement("AUXData")) {
     for (tinyxml2::XMLElement *pos = auxNode->FirstChildElement("Position");
@@ -449,8 +458,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         if (const char *nameAttr = node->Attribute("name"))
           fixture.instanceName = nameAttr;
 
-        intOf(node, "FixtureID", fixture.fixtureId);
-        intOf(node, "FixtureIDNumeric", fixture.fixtureIdNumeric);
+        fixtureIdOf(node, fixture.fixtureIdText, fixture.fixtureIdNumeric);
+        fixture.fixtureId = fixture.fixtureIdNumeric;
         intOf(node, "UnitNumber", fixture.unitNumber);
         intOf(node, "CustomId", fixture.customId);
         intOf(node, "CustomIdType", fixture.customIdType);

--- a/tests/save_load_roundtrip_test.cpp
+++ b/tests/save_load_roundtrip_test.cpp
@@ -49,7 +49,7 @@ int main() {
     // Dictionary entry that should NOT be applied on load
     GdtfDictionary::Update("FixtureType", (tempDir / "dict.gdtf").string(), "");
 
-    Fixture f; f.uuid = "fx1"; f.instanceName = "Fixture"; f.layer = layer.name; f.typeName = "FixtureType"; f.gdtfSpec = "orig.gdtf"; f.color = "#445566"; scene.fixtures[f.uuid] = f;
+    Fixture f; f.uuid = "fx1"; f.instanceName = "Fixture"; f.layer = layer.name; f.typeName = "FixtureType"; f.gdtfSpec = "orig.gdtf"; f.color = "#445566"; f.fixtureIdText = "S101A"; f.fixtureIdNumeric = 101; f.fixtureId = 101; scene.fixtures[f.uuid] = f;
     Truss t; t.uuid = "tr1"; t.name = "Truss"; t.layer = layer.name; scene.trusses[t.uuid] = t;
     SceneObject o; o.uuid = "obj1"; o.name = "Object"; o.layer = layer.name; scene.sceneObjects[o.uuid] = o;
 
@@ -68,6 +68,8 @@ int main() {
     assert(scene2.trusses.at("tr1").name == "Truss");
     assert(scene2.sceneObjects.at("obj1").name == "Object");
     assert(scene2.fixtures.at("fx1").color == "#445566");
+    assert(scene2.fixtures.at("fx1").fixtureIdText == "S101A");
+    assert(scene2.fixtures.at("fx1").fixtureIdNumeric == 101);
     assert(scene2.layers.at("layer1").color == "#112233");
 
     const auto &loaded = scene2.fixtures.at("fx1");


### PR DESCRIPTION
### Motivation
- The MVR spec allows `<FixtureID>` to be a free-form string while selection/range logic relies on `<FixtureIDNumeric>`, so parsing `FixtureID` as an integer can lose alphanumeric spot IDs. 
- Preserve the original textual ID on import/export so roundtrips (save/load, MVR export/import) do not drop or mangle non-numeric fixture/spot identifiers.

### Description
- Add a new `fixtureIdText` field to `Fixture` to store the raw `<FixtureID>` string from MVR and keep `fixtureIdNumeric` as the numeric selection ID; retain `fixtureId` as a numeric fallback. (`models/fixture.h`)
- Update MVR importer to read both `<FixtureID>` (as text) and `<FixtureIDNumeric>` (as integer) and to derive the numeric fallback from the textual ID only when `FixtureIDNumeric` is absent or non-positive. (`mvr/mvrimporter.cpp`)
- Update MVR exporter to prioritize the preserved `fixtureIdText` when writing `<FixtureID>`, while still emitting a valid `<FixtureIDNumeric>` for interoperability. (`mvr/mvrexporter.cpp`)
- Extend the save/load roundtrip test to set an alphanumeric fixture ID (`S101A`) and assert that both `fixtureIdText` and `fixtureIdNumeric` are preserved through save/load. (`tests/save_load_roundtrip_test.cpp`)

### Testing
- The `tests/save_load_roundtrip_test.cpp` was updated to exercise an alphanumeric `FixtureID` and asserts it survives project save/load; this test was added/updated in the change set. 
- An attempt to configure the project with `cmake -S . -B build` was performed, but configuration failed in this environment because the `wxWidgets` development package (e.g. `wxWidgetsConfig.cmake`) is not available, so a full build and test run could not be executed here. 
- Changes were kept focused and unit-test-friendly so they should compile and pass in a CI/build environment with the project dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985a64ba464832481fd3216cd28f38f)