### PR TITLE
Tint GDTF lens geometries amber in the 3D viewer

### DIFF
--- a/viewer3d/gdtfloader.h
+++ b/viewer3d/gdtfloader.h
@@ -26,6 +26,7 @@
 struct GdtfObject {
     Mesh mesh;
     Matrix transform; // local transform relative to fixture
+    bool isLens = false;
 };
 
 // Metadata for a GDTF model definition. Length/Width/Height correspond

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1550,9 +1550,17 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
                           const std::array<float, 3> &p) {
                         return TransformPoint(objTransform, p);
                       };
-                  DrawMeshWithOutline(obj.mesh, r, g, b, RENDER_SCALE, false,
-                                      false, 0.0f, 0.0f, 0.0f, wireframe, mode,
-                                      applyCapture);
+                  float partR = r;
+                  float partG = g;
+                  float partB = b;
+                  if (obj.isLens) {
+                    partR = 1.0f;
+                    partG = 0.78f;
+                    partB = 0.35f;
+                  }
+                  DrawMeshWithOutline(obj.mesh, partR, partG, partB,
+                                      RENDER_SCALE, false, false, 0.0f, 0.0f,
+                                      0.0f, wireframe, mode, applyCapture);
                   ++partIndex;
                 }
               } else {
@@ -1605,8 +1613,16 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
                 auto local = TransformPoint(objTransform, p);
                 return TransformPoint(fixtureTransform, local);
               };
-          DrawMeshWithOutline(obj.mesh, r, g, b, RENDER_SCALE, highlight,
-                              selected, cx, cy, cz, wireframe, mode,
+          float partR = r;
+          float partG = g;
+          float partB = b;
+          if (obj.isLens) {
+            partR = 1.0f;
+            partG = 0.78f;
+            partB = 0.35f;
+          }
+          DrawMeshWithOutline(obj.mesh, partR, partG, partB, RENDER_SCALE,
+                              highlight, selected, cx, cy, cz, wireframe, mode,
                               applyCapture);
           glPopMatrix();
           ++partIndex;


### PR DESCRIPTION
### Motivation
- Make lens parts in imported GDTF fixtures visually distinct in the 3D viewer by rendering them with a soft amber (yellow/orange) tint, matching behavior observed in other viewers.

### Description
- Added a boolean `isLens` field to `GdtfObject` so loaded sub-meshes can be marked as lens geometry (`viewer3d/gdtfloader.h`).
- Extended `ParseGeometry` to propagate a `parentIsLens` flag, mark geometry as lens when the node is a `Beam`, when an ancestor is lens-marked, or when the geometry `Name` contains the substring `lens`, and store that flag on the produced `GdtfObject` (`viewer3d/gdtfloader.cpp`).
- Updated the 3D rendering paths that draw GDTF parts (both capture and live draw) to tint lens-marked parts with RGB `(1.0, 0.78, 0.35)` while preserving existing selection/highlight behavior (`viewer3d/viewer3dcontroller.cpp`).

### Testing
- Ran a quick inspection script over `library/fixtures/*.gdtf` to confirm `Beam`/geometry tags are present and that the new detection heuristics will find lens-like geometries; the script ran successfully.
- Attempted to configure and build with CMake (`cmake -S . -B build` and `cmake --build build`) to validate compilation, but configuration failed due to the environment missing the `wxWidgets` development package, so a full build/test could not be completed in this environment.
- Performed repository searches (`rg`) to verify modified call sites and ensure the `isLens` flag is used where geometry parts are rendered; those checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985b9714a488324ab75af6569ea1903)