### PR TITLE
Improve GDTF lens detection and render lenses as unlit emitters

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1560,7 +1560,8 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
                   }
                   DrawMeshWithOutline(obj.mesh, partR, partG, partB,
                                       RENDER_SCALE, false, false, 0.0f, 0.0f,
-                                      0.0f, wireframe, mode, applyCapture);
+                                      0.0f, wireframe, mode, applyCapture,
+                                      obj.isLens);
                   ++partIndex;
                 }
               } else {
@@ -1623,7 +1624,7 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
           }
           DrawMeshWithOutline(obj.mesh, partR, partG, partB, RENDER_SCALE,
                               highlight, selected, cx, cy, cz, wireframe, mode,
-                              applyCapture);
+                              applyCapture, obj.isLens);
           glPopMatrix();
           ++partIndex;
         }
@@ -2047,7 +2048,8 @@ void Viewer3DController::DrawMeshWithOutline(
     bool selected, float cx, float cy, float cz, bool wireframe,
     Viewer2DRenderMode mode,
     const std::function<std::array<float, 3>(const std::array<float, 3> &)> &
-        captureTransform) {
+        captureTransform,
+    bool unlit) {
   (void)cx;
   (void)cy;
   (void)cz; // parameters kept for compatibility
@@ -2100,7 +2102,11 @@ void Viewer3DController::DrawMeshWithOutline(
         glEnable(GL_POLYGON_OFFSET_FILL);
         glPolygonOffset(-1.0f, -1.0f);
         SetGLColor(r, g, b);
+        if (unlit)
+          glDisable(GL_LIGHTING);
         DrawMesh(mesh, scale);
+        if (unlit)
+          glEnable(GL_LIGHTING);
         glDisable(GL_POLYGON_OFFSET_FILL);
       }
     }
@@ -2115,7 +2121,11 @@ void Viewer3DController::DrawMeshWithOutline(
     else
       SetGLColor(r, g, b);
 
+    if (unlit)
+      glDisable(GL_LIGHTING);
     DrawMesh(mesh, scale);
+    if (unlit)
+      glEnable(GL_LIGHTING);
   }
   if (m_captureCanvas) {
     CanvasStroke stroke;

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -176,7 +176,8 @@ private:
                            Viewer2DRenderMode mode = Viewer2DRenderMode::White,
                            const std::function<std::array<float, 3>(
                                const std::array<float, 3> &)> &captureTransform =
-                               {});
+                               {},
+                           bool unlit = false);
 
   // Draws only the mesh edges for wireframe rendering
   void DrawMeshWireframe(


### PR DESCRIPTION
### Motivation
- Many fixtures were not having their lens geometry detected (so they were not tinted as lenses) and lenses should be rendered as light emitters (not shaded by scene lighting). 

### Description
- Added heuristic detection functions in `viewer3d/gdtfloader.cpp` (`ContainsTokenInsensitive`, `IsBeamLikeNodeName`, `IsLikelyLensGeometry`) and replaced the previous simple check so geometry/model names and model file names containing optical keywords (`lens`, `optic`, `glass`) are treated as lens geometry and lens state is inherited to children. 
- When loading geometry the parser now marks more parts as `isLens` by calling `IsLikelyLensGeometry` and preserves recursive parent lens propagation. 
- Extended `DrawMeshWithOutline` (signature in `viewer3d/viewer3dcontroller.h` / implementation in `viewer3d/viewer3dcontroller.cpp`) with a `unlit` flag, propagated calls to pass `obj.isLens`, and temporarily disable `GL_LIGHTING` while drawing unlit meshes so lenses are drawn as emissive (keeping the warm lens tint). 
- Changes touch `viewer3d/gdtfloader.cpp`, `viewer3d/viewer3dcontroller.cpp`, and `viewer3d/viewer3dcontroller.h` to implement these behaviours.

### Testing
- Attempted build with `cmake -S . -B build && cmake --build build -j2` but configuration failed due to missing `wxWidgets` in the environment (build blocked). 
- Ran repository inspection/sanity scripts (example: Python scripts parsing `library/fixtures/*.gdtf` and comparing old vs new heuristics) which reported additional lens candidates in bundled fixtures (e.g. `Robin Spiider.gdtf`, `Robin iSpiiderX.gdtf`), indicating broader detection coverage. 
- No unit tests were added or available for this change in the repository; code was committed locally after verification of diffs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985bd33fdf8832482eaa9a0637df4a5)