### PR TITLE
Add primitive mesh fallback for GDTF models without file assets

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -237,3 +237,16 @@ target_link_libraries(rider_import_benchmark PRIVATE ${wxWidgets_LIBRARIES} tiny
 add_test(NAME RiderImportBenchmark COMMAND rider_import_benchmark
          ${CMAKE_CURRENT_SOURCE_DIR}/data/rider_large.txt 1)
 set_library_env(RiderImportBenchmark)
+
+
+add_executable(gdtfloader_primitive_test gdtfloader_primitive_test.cpp
+               ../viewer3d/gdtfloader.cpp
+               ../viewer3d/loader3ds.cpp
+               ../viewer3d/loaderglb.cpp
+               ../viewer3d/meshprimitives.cpp
+               consolepanel_stub.cpp)
+target_include_directories(gdtfloader_primitive_test PRIVATE
+                           . ../viewer3d ../models ../gui ../external)
+target_link_libraries(gdtfloader_primitive_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
+add_test(NAME GdtfLoaderPrimitiveFallback COMMAND gdtfloader_primitive_test)
+set_library_env(GdtfLoaderPrimitiveFallback)

--- a/tests/gdtfloader_primitive_test.cpp
+++ b/tests/gdtfloader_primitive_test.cpp
@@ -1,0 +1,90 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "../viewer3d/gdtfloader.h"
+
+#include <cassert>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include <wx/filename.h>
+#include <wx/wfstream.h>
+class wxZipStreamLink;
+#include <wx/zipstrm.h>
+
+namespace {
+std::string MakeGdtf(const std::string& primitiveType)
+{
+    wxFileName tempName(wxFileName::CreateTempFileName("gdtf_primitive_"));
+    const std::string outPath = tempName.GetFullPath().ToStdString() + ".gdtf";
+    wxRemoveFile(tempName.GetFullPath());
+
+    wxFFileOutputStream fileOut(outPath);
+    assert(fileOut.IsOk());
+    wxZipOutputStream zipOut(fileOut);
+
+    zipOut.PutNextEntry("description.xml");
+    std::string xml =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        "<GDTF DataVersion=\"1.2\">"
+        "<FixtureType Name=\"Test\">"
+        "<Models>"
+        "<Model Name=\"Body\" File=\"\" PrimitiveType=\"" + primitiveType + "\" "
+        "Length=\"1.0\" Width=\"1.0\" Height=\"1.0\"/>"
+        "</Models>"
+        "<Geometries>"
+        "<Geometry Name=\"Root\" Model=\"Body\"/>"
+        "</Geometries>"
+        "</FixtureType>"
+        "</GDTF>";
+    zipOut.Write(xml.data(), xml.size());
+    zipOut.Close();
+
+    return outPath;
+}
+}
+
+int main()
+{
+    {
+        const std::string gdtfPath = MakeGdtf("Cube");
+        std::vector<GdtfObject> objects;
+        std::string error;
+        const bool ok = LoadGdtf(gdtfPath, objects, &error);
+        assert(ok);
+        assert(error.empty());
+        assert(!objects.empty());
+        std::error_code ec;
+        std::filesystem::remove(gdtfPath, ec);
+    }
+
+    {
+        const std::string gdtfPath = MakeGdtf("Undefined");
+        std::vector<GdtfObject> objects;
+        std::string error;
+        const bool ok = LoadGdtf(gdtfPath, objects, &error);
+        assert(!ok);
+        assert(objects.empty());
+        assert(!error.empty());
+        std::error_code ec;
+        std::filesystem::remove(gdtfPath, ec);
+    }
+
+    return 0;
+}

--- a/viewer3d/gdtfloader.h
+++ b/viewer3d/gdtfloader.h
@@ -34,6 +34,7 @@ struct GdtfObject {
 // GDTF file. When any of these are zero the raw mesh size is used.
 struct GdtfModelInfo {
     std::string file;
+    std::string primitiveType;
     float length = 0.0f; // meters
     float width  = 0.0f; // meters
     float height = 0.0f; // meters

--- a/viewer3d/meshprimitives.cpp
+++ b/viewer3d/meshprimitives.cpp
@@ -1,0 +1,180 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "meshprimitives.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+
+namespace {
+constexpr float kPi = 3.14159265358979323846f;
+
+std::string ToLower(std::string value)
+{
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    return value;
+}
+
+void AddVertex(Mesh& mesh, float x, float y, float z)
+{
+    mesh.vertices.push_back(x);
+    mesh.vertices.push_back(y);
+    mesh.vertices.push_back(z);
+}
+}
+
+Mesh BuildCubeMesh(float sizeX, float sizeY, float sizeZ)
+{
+    Mesh mesh;
+    const float hx = sizeX * 0.5f;
+    const float hy = sizeY * 0.5f;
+    const float hz = sizeZ * 0.5f;
+
+    mesh.vertices = {
+        -hx, -hy, -hz,
+         hx, -hy, -hz,
+         hx,  hy, -hz,
+        -hx,  hy, -hz,
+        -hx, -hy,  hz,
+         hx, -hy,  hz,
+         hx,  hy,  hz,
+        -hx,  hy,  hz,
+    };
+
+    mesh.indices = {
+        0, 1, 2, 0, 2, 3,
+        4, 6, 5, 4, 7, 6,
+        0, 4, 5, 0, 5, 1,
+        1, 5, 6, 1, 6, 2,
+        2, 6, 7, 2, 7, 3,
+        3, 7, 4, 3, 4, 0,
+    };
+
+    ComputeNormals(mesh);
+    return mesh;
+}
+
+Mesh BuildCylinderMesh(float radius, float height, int segments)
+{
+    Mesh mesh;
+    segments = std::max(segments, 3);
+
+    const float halfH = height * 0.5f;
+    const unsigned short topCenter = 0;
+    const unsigned short bottomCenter = 1;
+    AddVertex(mesh, 0.0f, 0.0f, halfH);
+    AddVertex(mesh, 0.0f, 0.0f, -halfH);
+
+    for (int i = 0; i < segments; ++i) {
+        float a = (2.0f * kPi * static_cast<float>(i)) / static_cast<float>(segments);
+        float x = std::cos(a) * radius;
+        float y = std::sin(a) * radius;
+        AddVertex(mesh, x, y, halfH);
+        AddVertex(mesh, x, y, -halfH);
+    }
+
+    for (int i = 0; i < segments; ++i) {
+        unsigned short top0 = static_cast<unsigned short>(2 + i * 2);
+        unsigned short bot0 = static_cast<unsigned short>(top0 + 1);
+        unsigned short top1 = static_cast<unsigned short>(2 + ((i + 1) % segments) * 2);
+        unsigned short bot1 = static_cast<unsigned short>(top1 + 1);
+
+        mesh.indices.push_back(topCenter);
+        mesh.indices.push_back(top0);
+        mesh.indices.push_back(top1);
+
+        mesh.indices.push_back(bottomCenter);
+        mesh.indices.push_back(bot1);
+        mesh.indices.push_back(bot0);
+
+        mesh.indices.push_back(top0);
+        mesh.indices.push_back(bot0);
+        mesh.indices.push_back(top1);
+
+        mesh.indices.push_back(top1);
+        mesh.indices.push_back(bot0);
+        mesh.indices.push_back(bot1);
+    }
+
+    ComputeNormals(mesh);
+    return mesh;
+}
+
+Mesh BuildSphereMesh(float radius, int rings, int segments)
+{
+    Mesh mesh;
+    rings = std::max(rings, 3);
+    segments = std::max(segments, 3);
+
+    for (int r = 0; r <= rings; ++r) {
+        float v = static_cast<float>(r) / static_cast<float>(rings);
+        float phi = v * kPi;
+        float z = std::cos(phi) * radius;
+        float rr = std::sin(phi) * radius;
+        for (int s = 0; s <= segments; ++s) {
+            float u = static_cast<float>(s) / static_cast<float>(segments);
+            float theta = u * 2.0f * kPi;
+            AddVertex(mesh, std::cos(theta) * rr, std::sin(theta) * rr, z);
+        }
+    }
+
+    for (int r = 0; r < rings; ++r) {
+        for (int s = 0; s < segments; ++s) {
+            unsigned short i0 = static_cast<unsigned short>(r * (segments + 1) + s);
+            unsigned short i1 = static_cast<unsigned short>(i0 + segments + 1);
+            unsigned short i2 = static_cast<unsigned short>(i0 + 1);
+            unsigned short i3 = static_cast<unsigned short>(i1 + 1);
+
+            mesh.indices.push_back(i0);
+            mesh.indices.push_back(i1);
+            mesh.indices.push_back(i2);
+            mesh.indices.push_back(i2);
+            mesh.indices.push_back(i1);
+            mesh.indices.push_back(i3);
+        }
+    }
+
+    ComputeNormals(mesh);
+    return mesh;
+}
+
+bool BuildPrimitiveMesh(const std::string& primitiveType, Mesh& outMesh)
+{
+    const std::string type = ToLower(primitiveType);
+
+    if (type == "cube" || type == "base" || type == "base1_1" ||
+        type == "conventional" || type == "conventional1_1") {
+        outMesh = BuildCubeMesh(1000.0f, 1000.0f, 1000.0f);
+        return true;
+    }
+
+    if (type == "cylinder" || type == "yoke" || type == "scanner" ||
+        type == "scanner1_1" || type == "pigtail") {
+        outMesh = BuildCylinderMesh(500.0f, 1000.0f);
+        return true;
+    }
+
+    if (type == "sphere" || type == "head") {
+        outMesh = BuildSphereMesh(500.0f);
+        return true;
+    }
+
+    return false;
+}

--- a/viewer3d/meshprimitives.h
+++ b/viewer3d/meshprimitives.h
@@ -1,0 +1,34 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <string>
+#include "mesh.h"
+
+// Builds a cube centered at origin with the given dimensions in millimeters.
+Mesh BuildCubeMesh(float sizeX, float sizeY, float sizeZ);
+
+// Builds a cylinder centered at origin, axis aligned on Z, dimensions in mm.
+Mesh BuildCylinderMesh(float radius, float height, int segments = 24);
+
+// Builds a UV sphere centered at origin, dimensions in mm.
+Mesh BuildSphereMesh(float radius, int rings = 12, int segments = 24);
+
+// Builds a mesh from a GDTF PrimitiveType string. Returns false when the
+// primitive type is not representable.
+bool BuildPrimitiveMesh(const std::string& primitiveType, Mesh& outMesh);


### PR DESCRIPTION
### Motivation
- Some GDTF fixtures specify a `PrimitiveType` but have an empty `File` attribute; those are valid by spec and should not be discarded or produce spurious warnings. 
- Provide a minimal, deterministic visual representation for those fixtures by generating simple meshes (cube/cylinder/sphere) and apply the existing `Length/Width/Height` scaling.

### Description
- Extend `GdtfModelInfo` to store `primitiveType` in addition to `file`, `length`, `width`, `height` (file: `viewer3d/gdtfloader.h`).
- Update model parsing in `LoadGdtf` to read `PrimitiveType` and only emit a warning when `File` is empty *and* `PrimitiveType` is absent or `Undefined` (file: `viewer3d/gdtfloader.cpp`).
- Add `viewer3d/meshprimitives.h` / `viewer3d/meshprimitives.cpp` implementing parametric primitive builders: `BuildCubeMesh`, `BuildCylinderMesh`, `BuildSphereMesh` and `BuildPrimitiveMesh` with an initial mapping of GDTF primitive names (`Base`, `Yoke`, `Head`, `Scanner`, `Conventional`, `Pigtail`, `Base1_1`, `Scanner1_1`, `Conventional1_1`) to reasonable primitives.
- Change `ParseGeometry` flow to try loading a file model first (existing behavior), and when no file is resolvable or load fails, attempt to build a primitive mesh from `primitiveType`; in either case apply dimension scaling via a new helper `ApplyModelDimensions` so `Length/Width/Height` affect primitives and file meshes consistently (file: `viewer3d/gdtfloader.cpp`).
- Add `IsPrimitiveTypeDefined` helper to detect non-`Undefined` primitive types and avoid false positives.
- Add unit test `tests/gdtfloader_primitive_test.cpp` that creates minimal `.gdtf` packages and validates: `File=""` + `PrimitiveType="Cube"` loads objects successfully, and `File=""` + `PrimitiveType="Undefined"` fails with an error; register the test in `tests/CMakeLists.txt`.

### Testing
- Added an automated unit test target `GdtfLoaderPrimitiveFallback` (`tests/gdtfloader_primitive_test.cpp`) and updated `tests/CMakeLists.txt` so it can be built by the test suite.
- Attempted to configure the project with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`, but configuration failed in this environment due to a missing `wxWidgets` development config (`wxWidgetsConfig.cmake`), so the new test could not be built or executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986202c8a488324b41070e0f281053f)