### PR TITLE
Scope lens tinting to 3D viewer only and restore 2D color behavior

### DIFF
--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -536,7 +536,7 @@ void Viewer2DPanel::RenderInternal(bool swapBuffers) {
   }
 
   m_controller.RenderScene(true, m_renderMode, m_view, showGrid, gridStyle,
-                           gridR, gridG, gridB, drawAbove);
+                           gridR, gridG, gridB, drawAbove, true);
 
   // Draw labels for all fixtures after rendering the scene so they appear on
   // top of geometry. Scale the label size with the current zoom so they behave

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1025,7 +1025,8 @@ void Viewer3DController::Update() {
 void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
                                      Viewer2DView view, bool showGrid,
                                      int gridStyle, float gridR, float gridG,
-                                     float gridB, bool gridOnTop) {
+                                     float gridB, bool gridOnTop,
+                                     bool is2DViewer) {
   if (wireframe)
     glDisable(GL_LIGHTING);
   else
@@ -1553,7 +1554,7 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
                   float partR = r;
                   float partG = g;
                   float partB = b;
-                  if (obj.isLens) {
+                  if (!is2DViewer && obj.isLens) {
                     partR = 1.0f;
                     partG = 0.78f;
                     partB = 0.35f;
@@ -1617,7 +1618,7 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
           float partR = r;
           float partG = g;
           float partB = b;
-          if (obj.isLens) {
+          if (!is2DViewer && obj.isLens) {
             partR = 1.0f;
             partG = 0.78f;
             partB = 0.35f;

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -87,7 +87,8 @@ public:
                    float gridR = 0.35f,
                    float gridG = 0.35f,
                    float gridB = 0.35f,
-                   bool gridOnTop = false);
+                   bool gridOnTop = false,
+                   bool is2DViewer = false);
 
   // Enables color tweaks for dark mode in the 2D viewer only.
   void SetDarkMode(bool enabled);


### PR DESCRIPTION
### Motivation
- A previous change tied lens tinting to `wireframe`, which regressed 2D viewer coloring because the 2D viewer is a distinct context, not just wireframe mode. 
- The 2D viewer must always respect `Render Options` and legacy 2D coloring across its modes, while the lens tint behavior should remain in the 3D viewer only. 
- Restore the expected UX so fixture lenses are not tinted in any 2D view while preserving existing 3D tinting.

### Description
- Added a new `bool is2DViewer` parameter to `Viewer3DController::RenderScene` (default `false`) to model viewer context. 
- Replaced checks of `!wireframe && obj.isLens` with `!is2DViewer && obj.isLens` in both fixture render paths so lens tinting is applied only in non-2D contexts. 
- Updated the 2D call site in `viewer2d/viewer2dpanel.cpp` to call `RenderScene(..., true)` with `is2DViewer = true` so the 2D panel preserves classic coloring. 
- Kept all existing 3D rendering behavior unchanged except for scoping the lens tint to 3D-only.

### Testing
- Attempted to configure the build with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`, which failed due to the environment missing the system dependency `wxWidgets` (configuration incomplete).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986274c0e9c832489e16ef5dbadb818)