### PR TITLE
Restore 2D wireframe highlight and full-object color behavior

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -2059,6 +2059,14 @@ void Viewer3DController::DrawMeshWithOutline(
     float lineWidth = (mode == Viewer2DRenderMode::Wireframe) ? 1.0f : 2.0f;
     const bool drawOutline =
         m_showSelectionOutline2D && (highlight || selected);
+    const bool monochromeWireframe = (mode == Viewer2DRenderMode::Wireframe);
+    std::array<float, 3> baseStrokeColor = {r, g, b};
+    if (highlight)
+      baseStrokeColor = {0.0f, 1.0f, 0.0f};
+    else if (selected)
+      baseStrokeColor = {0.0f, 1.0f, 1.0f};
+    else if (monochromeWireframe)
+      baseStrokeColor = {0.0f, 0.0f, 0.0f};
     if (!m_captureOnly) {
       if (drawOutline) {
         float glowWidth = lineWidth + 3.0f;
@@ -2070,10 +2078,11 @@ void Viewer3DController::DrawMeshWithOutline(
         DrawMeshWireframe(mesh, scale, captureTransform);
       }
       glLineWidth(lineWidth);
-      SetGLColor(0.0f, 0.0f, 0.0f);
+      SetGLColor(baseStrokeColor[0], baseStrokeColor[1], baseStrokeColor[2]);
     }
     CanvasStroke stroke;
-    stroke.color = {0.0f, 0.0f, 0.0f, 1.0f};
+    stroke.color = {baseStrokeColor[0], baseStrokeColor[1],
+                    baseStrokeColor[2], 1.0f};
     stroke.width = lineWidth;
     DrawMeshWireframe(mesh, scale, captureTransform);
     if (m_captureCanvas && mode != Viewer2DRenderMode::Wireframe) {


### PR DESCRIPTION
### Motivation
- Recent changes made 2D simplified fixture geometry and mesh wireframes render their stroke color as black and caused hover/selection outlines to disappear in the 2D viewers.  This broke the expected 2D behavior where color comes from selection (white), fixture type, or layer and where hover/selection strokes appear as green/cyan. 
- Lens tinting should remain limited to the 3D context and should not force the fill/stroke handling for the rest of 2D polygons. 
- The changes recover the previous 2D visual semantics so fills are used for symbol extraction and strokes are colored appropriately depending on mode/selection.

### Description
- Prefer filled primitives when extracting a footprint style in `viewer2d/canvas2d.cpp::ExtractStyles` so recorded fixture symbols pick up polygon fills instead of picking an initial wireframe line-only style that produced black simplified symbols. 
- Restore correct wireframe stroke coloring in `viewer3d/viewer3dcontroller.cpp::DrawMeshWithOutline` by computing a `baseStrokeColor` that follows the object's render color (or layer/type color) and overrides it to green/cyan when hovered/selected, while keeping pure `Wireframe` mode monochrome black for non-highlighted objects. 
- Ensure the same `baseStrokeColor` is used for both on-screen GL stroke and for the recorded `CanvasStroke` emitted to the capture canvas so exported/captured 2D commands match on-screen coloring.

### Testing
- Ran `git diff --check` to ensure there were no whitespace / diff issues and it succeeded. 
- Verified repository status with `git status --short` to confirm staged changes. 
- Committed the fix with `git commit` which completed successfully and included the updated `viewer3d/viewer3dcontroller.cpp` (and earlier `viewer2d/canvas2d.cpp` change) files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698631dadd9883249d70e072a51863cc)