### PR TITLE
Restore 2D mesh stroke colors and hover/selection highlights

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -2059,6 +2059,14 @@ void Viewer3DController::DrawMeshWithOutline(
     float lineWidth = (mode == Viewer2DRenderMode::Wireframe) ? 1.0f : 2.0f;
     const bool drawOutline =
         m_showSelectionOutline2D && (highlight || selected);
+    const bool monochromeWireframe = (mode == Viewer2DRenderMode::Wireframe);
+    std::array<float, 3> baseStrokeColor = {r, g, b};
+    if (highlight)
+      baseStrokeColor = {0.0f, 1.0f, 0.0f};
+    else if (selected)
+      baseStrokeColor = {0.0f, 1.0f, 1.0f};
+    else if (monochromeWireframe)
+      baseStrokeColor = {0.0f, 0.0f, 0.0f};
     if (!m_captureOnly) {
       if (drawOutline) {
         float glowWidth = lineWidth + 3.0f;
@@ -2070,10 +2078,11 @@ void Viewer3DController::DrawMeshWithOutline(
         DrawMeshWireframe(mesh, scale, captureTransform);
       }
       glLineWidth(lineWidth);
-      SetGLColor(0.0f, 0.0f, 0.0f);
+      SetGLColor(baseStrokeColor[0], baseStrokeColor[1], baseStrokeColor[2]);
     }
     CanvasStroke stroke;
-    stroke.color = {0.0f, 0.0f, 0.0f, 1.0f};
+    stroke.color = {baseStrokeColor[0], baseStrokeColor[1],
+                    baseStrokeColor[2], 1.0f};
     stroke.width = lineWidth;
     DrawMeshWireframe(mesh, scale, captureTransform);
     if (m_captureCanvas && mode != Viewer2DRenderMode::Wireframe) {


### PR DESCRIPTION
### Motivation
- The 2D viewers lost correct polygon stroke/fill colors after a change that scoped lens tinting to 3D, causing non-lens polygons to render as black and interaction outlines (hover/selected) to disappear.  
- The intent is to keep lens tinting limited to 3D while restoring per-fixture / per-layer color and the green/cyan highlights in 2D.

### Description
- Reintroduced per-wireframe stroke color logic in `DrawMeshWithOutline` so the base stroke color derives from the fixture color (`r,g,b`) and respects viewer color modes.  
- Restored explicit overrides so hover/highlight is painted green and selected is painted cyan in 2D, while pure `Wireframe` mode remains monochrome (black) when not highlighted/selected.  
- Changed the captured recording path to use the same `CanvasStroke` color so PDF/recording output matches on-screen 2D behavior; the edit is in `viewer3d/viewer3dcontroller.cpp` around the `DrawMeshWithOutline` implementation.

### Testing
- Ran `git diff --check` to ensure no whitespace/patch issues, which completed without errors.  
- Ran `git status --short` to confirm the working tree state after applying the fix, which showed no outstanding problems.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986345dd07c83249f18f8cacf149b11)