### PR TITLE
Restore 2D wireframe & highlight colors; avoid duplicate capture strokes

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -2059,6 +2059,14 @@ void Viewer3DController::DrawMeshWithOutline(
     float lineWidth = (mode == Viewer2DRenderMode::Wireframe) ? 1.0f : 2.0f;
     const bool drawOutline =
         m_showSelectionOutline2D && (highlight || selected);
+    const bool monochromeWireframe = (mode == Viewer2DRenderMode::Wireframe);
+    std::array<float, 3> baseStrokeColor = {r, g, b};
+    if (highlight)
+      baseStrokeColor = {0.0f, 1.0f, 0.0f};
+    else if (selected)
+      baseStrokeColor = {0.0f, 1.0f, 1.0f};
+    else if (monochromeWireframe)
+      baseStrokeColor = {0.0f, 0.0f, 0.0f};
     if (!m_captureOnly) {
       if (drawOutline) {
         float glowWidth = lineWidth + 3.0f;
@@ -2067,15 +2075,16 @@ void Viewer3DController::DrawMeshWithOutline(
           SetGLColor(0.0f, 1.0f, 0.0f);
         else if (selected)
           SetGLColor(0.0f, 1.0f, 1.0f);
-        DrawMeshWireframe(mesh, scale, captureTransform);
+        DrawMeshWireframe(mesh, scale, captureTransform, false);
       }
       glLineWidth(lineWidth);
-      SetGLColor(0.0f, 0.0f, 0.0f);
+      SetGLColor(baseStrokeColor[0], baseStrokeColor[1], baseStrokeColor[2]);
     }
     CanvasStroke stroke;
-    stroke.color = {0.0f, 0.0f, 0.0f, 1.0f};
+    stroke.color = {baseStrokeColor[0], baseStrokeColor[1],
+                    baseStrokeColor[2], 1.0f};
     stroke.width = lineWidth;
-    DrawMeshWireframe(mesh, scale, captureTransform);
+    DrawMeshWireframe(mesh, scale, captureTransform, true);
     if (m_captureCanvas && mode != Viewer2DRenderMode::Wireframe) {
       CanvasFill fill;
       fill.color = {r, g, b, 1.0f};
@@ -2159,7 +2168,8 @@ void Viewer3DController::DrawMeshWithOutline(
 void Viewer3DController::DrawMeshWireframe(
     const Mesh &mesh, float scale,
     const std::function<std::array<float, 3>(const std::array<float, 3> &)> &
-        captureTransform) {
+        captureTransform,
+    bool captureLines) {
   if (!m_captureOnly) {
     glBegin(GL_LINES);
     for (size_t i = 0; i + 2 < mesh.indices.size(); i += 3) {
@@ -2190,7 +2200,7 @@ void Viewer3DController::DrawMeshWireframe(
     }
     glEnd();
   }
-  if (m_captureCanvas) {
+  if (m_captureCanvas && captureLines) {
     CanvasStroke stroke;
     stroke.color = {0.0f, 0.0f, 0.0f, 1.0f};
     stroke.width = 1.0f;

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -184,7 +184,8 @@ private:
   void DrawMeshWireframe(
       const Mesh &mesh, float scale = RENDER_SCALE,
       const std::function<std::array<float, 3>(
-          const std::array<float, 3> &)> &captureTransform = {});
+          const std::array<float, 3> &)> &captureTransform = {},
+      bool captureLines = true);
 
   // Draws a colored cube tinted when selected or highlighted. The optional
   // center offset parameters are unused and kept for compatibility.


### PR DESCRIPTION
### Motivation
- Recover prior 2D viewer behavior where fixture fill/stroke colors depend on selection, fixture type or layer and hover/selection outlines are green/cyan instead of rendering black for non-lens polygons.
- Preserve the existing 3D lens tinting behavior while preventing the 2D-only lens capture path from altering the color treatment of other polygons.
- Prevent duplicate recording of outline lines into the 2D capture buffer caused by the highlight glow pass.

### Description
- Restores stroke color selection for 2D wireframe rendering by computing a `baseStrokeColor` that uses fixture/layer color unless the object is hovered (green), selected (cyan) or in pure `Wireframe` mode (black).
- Extends `DrawMeshWireframe` signature with a `bool captureLines = true` parameter and uses `captureLines=false` for the highlight glow pass so the glow is drawn to GL but not double-recorded into the capture command buffer.
- Updates all internal call sites in `viewer3d/viewer3dcontroller.cpp` to pass the new `captureLines` flag appropriately and adjusts the capture recording branch to respect the flag.
- Declares the new parameter in `viewer3d/viewer3dcontroller.h` to keep header/implementation consistent.

### Testing
- Ran targeted static searches for the relevant symbols and keywords (`DrawMeshWireframe`, `wireframe`, `highlight`, `selected`) to confirm call sites were updated and no other call sites are left with the old signature, which succeeded.
- Inspected the source diffs to verify the changes are limited to `viewer3d/viewer3dcontroller.cpp` and `viewer3d/viewer3dcontroller.h`, which succeeded.
- Queried available CMake presets (`cmake --list-presets=all`) and attempted to use a disabled macOS preset, which failed due to the preset being disabled in this environment; no full build was executed in this environment.}

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698635e717248324a723124817ca7af5)