### PR TITLE
Fix GDTF lens rendering regression in 2D viewers

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1562,7 +1562,7 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
                   DrawMeshWithOutline(obj.mesh, partR, partG, partB,
                                       RENDER_SCALE, false, false, 0.0f, 0.0f,
                                       0.0f, wireframe, mode, applyCapture,
-                                      obj.isLens);
+                                      false);
                   ++partIndex;
                 }
               } else {
@@ -1623,9 +1623,10 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
             partG = 0.78f;
             partB = 0.35f;
           }
+          const bool drawUnlit = !is2DViewer && obj.isLens;
           DrawMeshWithOutline(obj.mesh, partR, partG, partB, RENDER_SCALE,
-                              highlight, selected, cx, cy, cz, wireframe, mode,
-                              applyCapture, obj.isLens);
+                              highlight, selected, cx, cy, cz, wireframe,
+                              mode, applyCapture, drawUnlit);
           glPopMatrix();
           ++partIndex;
         }


### PR DESCRIPTION
### Motivation
- A recent change marked GDTF lens parts with `isLens` and passed that flag into rendering as `unlit`, which unintentionally altered the 2D symbol/capture rendering; the goal is to restrict the unlit/lens shading behavior to the true 3D viewer and keep 2D viewers identical to previous behavior.

### Description
- In `viewer3d/viewer3dcontroller.cpp` the symbol-capture path now calls `DrawMeshWithOutline(..., unlit)` with `unlit = false` to preserve prior 2D capture appearance (always lit).
- The runtime scene draw path now computes `drawUnlit = !is2DViewer && obj.isLens` and passes that as the `unlit` argument to `DrawMeshWithOutline`, so unlit rendering only occurs in 3D views.
- Change is limited to `RenderScene`/symbol-capture code paths and does not modify other rendering modes or `DrawMeshWithOutline` signature.

### Testing
- Performed static site checks and code inspection using `rg 'DrawMeshWithOutline'` and reviewed the surrounding logic with `sed`/`nl`; inspection succeeded and call sites were updated as intended.
- Applied the patch with `apply_patch` and committed the change (`git commit`); these operations completed successfully.
- No automated renderer/unit tests were present for this code path, so no runtime render tests were executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69864b56ba6c832481eafa8b355a4668)