### PR TITLE
Replicate 3D double-click fixture edit behavior in 2D viewer

### DIFF
--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -131,6 +131,7 @@ private:
   void OnPaint(wxPaintEvent &event);
 
   void OnMouseDown(wxMouseEvent &event);
+  void OnMouseDClick(wxMouseEvent &event);
   void OnMouseUp(wxMouseEvent &event);
   void OnMouseMove(wxMouseEvent &event);
   void OnMouseWheel(wxMouseEvent &event);


### PR DESCRIPTION
### Motivation
- Make the 2D viewer match the 3D viewer UX by opening the existing fixture patch popup when the user double-clicks a fixture in the 2D view so users can edit patch values consistently across views.

### Description
- Declared a new `OnMouseDClick` handler in `viewer2d/viewer2dpanel.h` and registered it in the 2D panel event table with `EVT_LEFT_DCLICK`.
- Added `#include "fixturepatchdialog.h"` to `viewer2d/viewer2dpanel.cpp` and implemented `Viewer2DPanel::OnMouseDClick` to perform fixture hit-testing using `m_controller.GetFixtureLabelAt` and open `FixturePatchDialog` when a fixture is found.
- Applied edits back to the fixture (sets `fixtureId` and computes `address` from universe/channel), reloads the fixture table via `FixtureTablePanel::Instance()->ReloadData()` and refreshes the 2D scene with `UpdateScene(false)` and `Refresh()`.
- Changes are limited to the 2D viewer interaction logic and reuse the existing dialog/logic already used by the 3D viewer.

### Testing
- Ran `rg -n "OnMouseDClick|EVT_LEFT_DCLICK|fixturepatchdialog" viewer2d/viewer2dpanel.*` to verify the new handler, event binding and include are present, and it succeeded.
- Ran `cmake -S . -B build` to validate project configuration which failed in this environment due to a missing `wxWidgets` CMake package (`wxWidgetsConfig.cmake` not found).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987587954688324afbcbae7fb065f12)