### PR TITLE
Añadir menú de selección múltiple por click derecho en visores 2D y 3D

### DIFF
--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -135,6 +135,7 @@ private:
   void OnMouseUp(wxMouseEvent &event);
   void OnMouseMove(wxMouseEvent &event);
   void OnMouseWheel(wxMouseEvent &event);
+  void OnRightUp(wxMouseEvent &event);
   void OnKeyDown(wxKeyEvent &event);
   void OnMouseEnter(wxMouseEvent &event);
   void OnMouseLeave(wxMouseEvent &event);

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -95,6 +95,7 @@ private:
     void OnMouseUp(wxMouseEvent& event);
     void OnMouseMove(wxMouseEvent& event);
     void OnMouseWheel(wxMouseEvent& event);
+    void OnRightUp(wxMouseEvent& event);
     void OnMouseDClick(wxMouseEvent& event);
     void OnKeyDown(wxKeyEvent& event);
     void OnMouseEnter(wxMouseEvent& event);


### PR DESCRIPTION
### Motivation
- Permitir seleccionar múltiples fixtures desde los visores 2D y 3D haciendo click derecho en espacio vacío y elegir selección por "fixture type" o por "position". 
- Facilitar opciones rápidas con "All fixtures" (por tipo) y "No position" (por posición) y mantener la selección sincronizada con el estado global y la tabla de fixtures.

### Description
- Se añadió el handler `OnRightUp` y su declaración en `viewer2d/viewer2dpanel.h`/`.cpp` y en `viewer3d/viewer3dpanel.h`/`.cpp` para abrir el menú contextual cuando el click derecho ocurre sobre espacio vacío.  
- Implementadas utilidades `BuildFixtureSelectionByType`, `BuildFixtureSelectionByPosition` y `ApplyFixtureSelectionToUi` en ambos visores para construir la lista de UUIDs y aplicar la selección a `ConfigManager`, al controller del visor y a `FixtureTablePanel`.  
- El menú tiene submenús en inglés `Select by fixture type` y `Select by position` con las opciones `All fixtures` y `No position` respectivamente, y los elementos disponibles se generan dinámicamente desde la escena.  
- Se añadieron pequeños ajustes (incluye `#include <set>`) y se registraron los eventos en las tablas de eventos de los panels para integrar la nueva funcionalidad.

### Testing
- Se verificó la presencia de los nuevos handlers y cadenas con búsquedas `rg`/`nl` en los archivos modificados (búsquedas locales exitosas).  
- Se intentó construir el proyecto con `cmake -S . -B build && cmake --build build -j4`, pero la configuración falló por una dependencia de entorno ausente (`wxWidgetsConfig.cmake`), por lo que no se pudo compilar ni ejecutar tests de integración en este entorno.
- Se realizaron comprobaciones estáticas y de integración de símbolos/funciones en el árbol de código modificado y no se detectaron referencias rotas en las rutas editadas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69875c2cead483248990d8426a12e1b8)