### PR TITLE
Fix console fixture selection parsing for hyphen ranges

### DIFF
--- a/gui/consolepanel.cpp
+++ b/gui/consolepanel.cpp
@@ -275,6 +275,17 @@ NormalizeRangeTokens(const std::vector<std::string> &tokens) {
         continue;
       }
     }
+    size_t dashPos = token.find('-');
+    if (dashPos != std::string::npos && dashPos > 0 &&
+        dashPos + 1 < token.size() && token.find('-', dashPos + 1) == std::string::npos) {
+      std::string before = token.substr(0, dashPos);
+      std::string after = token.substr(dashPos + 1);
+      if (isNumberToken(before) && isNumberToken(after)) {
+        out.push_back(before);
+        out.push_back(after);
+        continue;
+      }
+    }
     out.push_back(token);
   }
   return out;
@@ -311,9 +322,8 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
         auto end = token.data() + token.size();
         auto result = std::from_chars(begin, end, value);
         if (result.ec != std::errc{} || result.ptr != end) {
-          AppendMessage(
-              wxString::Format("Invalid selection id: %s",
-                               wxString::FromUTF8(token)));
+          AppendMessage(wxString::Format("Invalid selection id: %s",
+                                         wxString::FromUTF8(token).c_str()));
           return false;
         }
         return true;


### PR DESCRIPTION
### Motivation
- Compact hyphen ranges used in console selection commands (for example `f 1-5`) were not normalized by the tokeniser, causing range selections to fail and leading to inconsistent selection behaviour when choosing fixtures/trusses by ID.

### Description
- Added detection of a single hyphen range inside `NormalizeRangeTokens` in `gui/consolepanel.cpp` so tokens like `1-5` are expanded into `"1","5"` after verifying both sides with `isNumberToken`.
- Kept existing `t` / `thru` normalization logic intact and guarded the hyphen handling to avoid splitting tokens that contain multiple hyphens.
- Fixed the invalid-token error formatting in `parseId` by passing `c_str()` into `wxString::Format` to avoid using a temporary `wxString` as the format argument.
- All code changes are localized to `gui/consolepanel.cpp`.

### Testing
- Attempted to run a CMake configure step with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`, but configuration failed because the environment is missing `wxWidgets` development config files (`wxWidgetsConfig.cmake`), so no build or automated tests were executed.
- No automated test suite ran due to the missing dependency.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69875fe43cd08324aef831b6b90ba9be)