### PR TITLE
Fix crash when formatting console exception messages

### DIFF
--- a/gui/consolepanel.cpp
+++ b/gui/consolepanel.cpp
@@ -691,6 +691,6 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
 
     AppendMessage("OK");
   } catch (const std::exception &e) {
-    AppendMessage(wxString::Format("Error: %s", e.what()));
+    AppendMessage("Error: " + wxString::FromUTF8(e.what()));
   }
 }


### PR DESCRIPTION
### Motivation
- Prevent a crash triggered by using `wxString::Format("Error: %s", e.what())` when reporting exceptions in the console, which can cause varargs/type-mismatch issues on some MSVC CRT builds.

### Description
- Replace the unsafe format call with safe UTF-8 concatenation: `AppendMessage("Error: " + wxString::FromUTF8(e.what()))` in `ConsolePanel::ProcessCommand` (`gui/consolepanel.cpp`).

### Testing
- Ran `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug` which failed due to missing `wxWidgets` development packages in the environment, and verified the source change with `git diff` and `git status` to confirm the intended edit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69876132f16c8324923ac1abc8acb064)