### PR TITLE
Fix crash when selecting fixtures by type/position from 2D context menu

### DIFF
--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -1499,36 +1499,36 @@ void Viewer2DPanel::OnRightUp(wxMouseEvent &event) {
   }
 
   wxMenu filterMenu;
-  wxMenu typeSubmenu;
-  wxMenu positionSubmenu;
+  auto typeSubmenu = std::make_unique<wxMenu>();
+  auto positionSubmenu = std::make_unique<wxMenu>();
 
   constexpr int kSelectTypeAllId = wxID_HIGHEST + 600;
   constexpr int kSelectTypeBaseId = wxID_HIGHEST + 601;
   constexpr int kSelectPositionNoneId = wxID_HIGHEST + 800;
   constexpr int kSelectPositionBaseId = wxID_HIGHEST + 801;
 
-  typeSubmenu.Append(kSelectTypeAllId, "All fixtures");
+  typeSubmenu->Append(kSelectTypeAllId, "All fixtures");
 
   std::vector<std::string> orderedTypes;
   orderedTypes.reserve(typeNames.size());
   int nextTypeId = kSelectTypeBaseId;
   for (const auto &name : typeNames) {
     orderedTypes.push_back(name);
-    typeSubmenu.Append(nextTypeId++, wxString::FromUTF8(name));
+    typeSubmenu->Append(nextTypeId++, wxString::FromUTF8(name));
   }
 
-  positionSubmenu.Append(kSelectPositionNoneId, "No position");
+  positionSubmenu->Append(kSelectPositionNoneId, "No position");
 
   std::vector<std::string> orderedPositions;
   orderedPositions.reserve(positionNames.size());
   int nextPositionId = kSelectPositionBaseId;
   for (const auto &name : positionNames) {
     orderedPositions.push_back(name);
-    positionSubmenu.Append(nextPositionId++, wxString::FromUTF8(name));
+    positionSubmenu->Append(nextPositionId++, wxString::FromUTF8(name));
   }
 
-  filterMenu.AppendSubMenu(&typeSubmenu, "Select by fixture type");
-  filterMenu.AppendSubMenu(&positionSubmenu, "Select by position");
+  filterMenu.AppendSubMenu(typeSubmenu.release(), "Select by fixture type");
+  filterMenu.AppendSubMenu(positionSubmenu.release(), "Select by position");
 
   const int selectedId =
       GetPopupMenuSelectionFromUser(filterMenu, event.GetPosition());


### PR DESCRIPTION
### Motivation
- The 2D right-click "Select by" popup could crash because submenus were created on the stack and their addresses were passed to `wxMenu::AppendSubMenu`, which takes ownership and leads to invalid lifetime/double-free issues.

### Description
- Replaced stack-allocated `wxMenu` locals with heap-allocated menus managed by `std::unique_ptr` and transferred ownership via `release()` when calling `AppendSubMenu`.
- Change is localized to `Viewer2DPanel::OnRightUp` in `viewer2d/viewer2dpanel.cpp` and only affects construction/attachment of the type/position submenus for the selection popup.
- Kept the existing selection-building and application logic (`BuildFixtureSelectionByType`, `BuildFixtureSelectionByPosition`, `ApplyFixtureSelectionToUi`) unchanged.

### Testing
- Attempted an automated build with `cmake -S . -B build && cmake --build build -j2`, which could not complete due to missing `wxWidgets` CMake package files in the environment (build blocked). 
- Verified source-level change, ran basic repository checks (`git status`, commit succeeded) and inspected the modified region with `nl`/`sed` to confirm correct edits; no unit tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69877248582c8324966e1d00ce0f4d76)