### PR TITLE
Corregir crash en menú flotante de selección 3D (submenús)

### DIFF
--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -51,6 +51,7 @@
 #include <wx/log.h>
 #include <chrono>
 #include <algorithm>
+#include <memory>
 #include <set>
 
 wxDEFINE_EVENT(wxEVT_VIEWER_REFRESH, wxThreadEvent);
@@ -506,34 +507,34 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent& event)
     }
 
     wxMenu rootMenu;
-    wxMenu typeSubmenu;
-    wxMenu positionSubmenu;
+    auto typeSubmenu = std::make_unique<wxMenu>();
+    auto positionSubmenu = std::make_unique<wxMenu>();
 
     constexpr int kSelectTypeAllId = wxID_HIGHEST + 900;
     constexpr int kSelectTypeBaseId = wxID_HIGHEST + 901;
     constexpr int kSelectPositionNoneId = wxID_HIGHEST + 1100;
     constexpr int kSelectPositionBaseId = wxID_HIGHEST + 1101;
 
-    typeSubmenu.Append(kSelectTypeAllId, "All fixtures");
+    typeSubmenu->Append(kSelectTypeAllId, "All fixtures");
     std::vector<std::string> orderedTypes;
     orderedTypes.reserve(typeNames.size());
     int nextTypeId = kSelectTypeBaseId;
     for (const auto& typeName : typeNames) {
         orderedTypes.push_back(typeName);
-        typeSubmenu.Append(nextTypeId++, wxString::FromUTF8(typeName));
+        typeSubmenu->Append(nextTypeId++, wxString::FromUTF8(typeName));
     }
 
-    positionSubmenu.Append(kSelectPositionNoneId, "No position");
+    positionSubmenu->Append(kSelectPositionNoneId, "No position");
     std::vector<std::string> orderedPositions;
     orderedPositions.reserve(positionNames.size());
     int nextPositionId = kSelectPositionBaseId;
     for (const auto& positionName : positionNames) {
         orderedPositions.push_back(positionName);
-        positionSubmenu.Append(nextPositionId++, wxString::FromUTF8(positionName));
+        positionSubmenu->Append(nextPositionId++, wxString::FromUTF8(positionName));
     }
 
-    rootMenu.AppendSubMenu(&typeSubmenu, "Select by fixture type");
-    rootMenu.AppendSubMenu(&positionSubmenu, "Select by position");
+    rootMenu.AppendSubMenu(typeSubmenu.release(), "Select by fixture type");
+    rootMenu.AppendSubMenu(positionSubmenu.release(), "Select by position");
 
     const int selectedId = GetPopupMenuSelectionFromUser(rootMenu, event.GetPosition());
     if (selectedId == wxID_NONE)


### PR DESCRIPTION
### Motivation
- El menú contextual del visor 3D se cerraba con crash al seleccionar "Select by fixture type" o "Select by position" por ownership/lifetime incorrecto de los submenús.
- El visor 2D ya tenía la solución creando los submenús en heap y transfiriendo ownership; se aplica la misma corrección en 3D para evitar el mismo fallo.

### Description
- Modificado `viewer3d/viewer3dpanel.cpp` para incluir `<memory>` y crear los submenús con `std::make_unique<wxMenu>()` en lugar de instancias en stack.
- Transfiero ownership a `AppendSubMenu` usando `typeSubmenu.release()` y `positionSubmenu.release()`, y uso `->Append()` para añadir entradas a los submenús.
- Se mantiene intacta la lógica de construcción de la selección y el refresco UI (`BuildFixtureSelectionByType/Position`, `ApplyFixtureSelectionToUi`, `Refresh()`), el cambio sólo estabiliza la creación/cierre del popup.

### Testing
- Ejecutada búsqueda estática para comparar con la implementación 2D y verificar rutas afectadas (`rg`), y la comprobación tuvo éxito.
- Verificado el diff con `git diff` y el archivo modificado es `viewer3d/viewer3dpanel.cpp`, y el cambio fue commiteado correctamente.
- Intenté construir con `cmake --build` pero el directorio `build` no existía en este entorno, por lo que no se realizó compilación automática aquí.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987742e45708324ad920f7e7b76db6f)