### PR TITLE
Cachear visibilidad de capas ocultas y usarlo en rutas de render 3D

### DIFF
--- a/core/configmanager.h
+++ b/core/configmanager.h
@@ -92,6 +92,7 @@ public:
 
     // Layer visibility management
     std::unordered_set<std::string> GetHiddenLayers() const;
+    const std::unordered_set<std::string>& GetHiddenLayersCached() const;
     void SetHiddenLayers(const std::unordered_set<std::string>& layers);
     bool IsLayerVisible(const std::string& layer) const;
 
@@ -165,6 +166,9 @@ private:
     size_t savedRevision = 0;
 
     bool suppressRevision = false;
+
+    mutable std::unordered_set<std::string> hiddenLayersCache;
+    mutable bool hiddenLayersCacheValid = false;
 
     std::string currentLayer = DEFAULT_LAYER_NAME;
 };

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1027,6 +1027,13 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
                                      int gridStyle, float gridR, float gridG,
                                      float gridB, bool gridOnTop,
                                      bool is2DViewer) {
+  ConfigManager &cfg = ConfigManager::Get();
+  const auto &hiddenLayers = cfg.GetHiddenLayersCached();
+  auto isLayerVisibleInFrame = [&hiddenLayers](const std::string &layer) {
+    const std::string name = layer.empty() ? DEFAULT_LAYER_NAME : layer;
+    return hiddenLayers.find(name) == hiddenLayers.end();
+  };
+
   if (wireframe)
     glDisable(GL_LIGHTING);
   else
@@ -1044,7 +1051,7 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
   };
   auto getLayerColor = [&](const std::string &key) {
     std::array<float, 3> c;
-    auto opt = ConfigManager::Get().GetLayerColor(key);
+    auto opt = cfg.GetLayerColor(key);
     if (opt && HexToRGB(*opt, c[0], c[1], c[2])) {
       m_layerColors[key] = c;
       return c;
@@ -1055,7 +1062,7 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
   };
   if (showGrid && !gridOnTop)
     DrawGrid(gridStyle, gridR, gridG, gridB, view);
-  const std::string &base = ConfigManager::Get().GetScene().basePath;
+  const std::string &base = cfg.GetScene().basePath;
   auto resolveSymbolView = [](Viewer2DView viewKind) {
     switch (viewKind) {
     case Viewer2DView::Top:
@@ -1084,7 +1091,7 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
   for (const auto *entry : sortedObjs) {
     const auto &uuid = entry->first;
     const auto &m = entry->second;
-    if (!ConfigManager::Get().IsLayerVisible(m.layer))
+    if (!isLayerVisibleInFrame(m.layer))
       continue;
     glPushMatrix();
 
@@ -1250,7 +1257,7 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
   for (const auto *entry : sortedTrusses) {
     const auto &uuid = entry->first;
     const auto &t = entry->second;
-    if (!ConfigManager::Get().IsLayerVisible(t.layer))
+    if (!isLayerVisibleInFrame(t.layer))
       continue;
     glPushMatrix();
 
@@ -1437,7 +1444,7 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
   for (const auto *entry : sortedFixtures) {
     const auto &uuid = entry->first;
     const auto &f = entry->second;
-    if (!ConfigManager::Get().IsLayerVisible(f.layer))
+    if (!isLayerVisibleInFrame(f.layer))
       continue;
     glPushMatrix();
 
@@ -2483,6 +2490,11 @@ void Viewer3DController::DrawFixtureLabels(int width, int height) {
   glGetIntegerv(GL_VIEWPORT, viewport);
 
   ConfigManager &cfg = ConfigManager::Get();
+  const auto &hiddenLayers = cfg.GetHiddenLayersCached();
+  auto isLayerVisibleInFrame = [&hiddenLayers](const std::string &layer) {
+    const std::string name = layer.empty() ? DEFAULT_LAYER_NAME : layer;
+    return hiddenLayers.find(name) == hiddenLayers.end();
+  };
   bool showName = cfg.GetFloat("label_show_name") != 0.0f;
   bool showId = cfg.GetFloat("label_show_id") != 0.0f;
   bool showDmx = cfg.GetFloat("label_show_dmx") != 0.0f;
@@ -2497,7 +2509,7 @@ void Viewer3DController::DrawFixtureLabels(int width, int height) {
 
   const auto &fixtures = SceneDataManager::Instance().GetFixtures();
   for (const auto &[uuid, f] : fixtures) {
-    if (!cfg.IsLayerVisible(f.layer))
+    if (!isLayerVisibleInFrame(f.layer))
       continue;
     if (uuid != m_highlightUuid)
       continue;
@@ -2563,6 +2575,11 @@ void Viewer3DController::DrawAllFixtureLabels(int width, int height,
   glGetIntegerv(GL_VIEWPORT, viewport);
 
   ConfigManager &cfg = ConfigManager::Get();
+  const auto &hiddenLayers = cfg.GetHiddenLayersCached();
+  auto isLayerVisibleInFrame = [&hiddenLayers](const std::string &layer) {
+    const std::string name = layer.empty() ? DEFAULT_LAYER_NAME : layer;
+    return hiddenLayers.find(name) == hiddenLayers.end();
+  };
   const std::array<const char *, 4> nameKeys = {"label_show_name_top",
                                                "label_show_name_front",
                                                "label_show_name_side",
@@ -2618,7 +2635,7 @@ void Viewer3DController::DrawAllFixtureLabels(int width, int height,
 
   const auto &fixtures = SceneDataManager::Instance().GetFixtures();
   for (const auto &[uuid, f] : fixtures) {
-    if (!cfg.IsLayerVisible(f.layer))
+    if (!isLayerVisibleInFrame(f.layer))
       continue;
 
     double wx, wy, wz;


### PR DESCRIPTION
### Motivation
- Evitar que `IsLayerVisible()` reconstruya el `std::unordered_set` de `hidden_layers` en cada llamada porque esa operación (CSV split + inserciones) es costosa en rutas de render de alto volumen.
- Mejorar el rendimiento en bucles frecuentes del viewer 3D (`RenderScene`, `DrawFixtureLabels`, `DrawAllFixtureLabels`).
- Mantener la semántica existente: las capas vacías se normalizan a `DEFAULT_LAYER_NAME`.

### Description
- Añadido cache mutable en `ConfigManager`: `hiddenLayersCache` y `hiddenLayersCacheValid`, más el nuevo método `GetHiddenLayersCached()` que devuelve la referencia a la caché y la rellena si está inválida.
- `IsLayerVisible()` ahora consulta la caché (`GetHiddenLayersCached()`) y `GetHiddenLayers()` delega en ella para compatibilidad.
- Se asegura la invalidación/actualización de la caché en todos los puntos de cambio de `hidden_layers`: `SetValue` (si la clave es `hidden_layers`), `RemoveKey`, `ClearValues` y `SetHiddenLayers` (este último hidrata la caché con nombres normalizados `DEFAULT_LAYER_NAME`).
- Rutas de render calientes en `viewer3d/viewer3dcontroller.cpp` (`RenderScene`, `DrawFixtureLabels`, `DrawAllFixtureLabels`) resuelven la lista de capas ocultas una vez por llamada (`cfg.GetHiddenLayersCached()`), crean una lambda local de visibilidad y reemplazan las comprobaciones repetidas por búsquedas O(1) en la caché.

### Testing
- Ejecuté `cmake -S . -B build && cmake --build build -j2` para verificar compilación; la configuración falló por falta del paquete `wxWidgets` en el entorno (`wxWidgetsConfig.cmake` no encontrado). (Build no completado.)
- Realicé comprobaciones estáticas locales mediante búsquedas/patches (`rg`/`sed`) y verifiqué las rutas de llamadas reemplazadas en el código fuente; no se ejecutaron tests unitarios automatizados adicionales en este entorno.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698783d0f700832491af6462f8cfbe80)