### PR TITLE
Optimiza hit-testing 3D: caché de hover, prefiltrado y métricas

### DIFF
--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -114,13 +114,19 @@ public:
   // under the given mouse coordinates (if any)
   bool GetFixtureLabelAt(int mouseX, int mouseY, int width, int height,
                          wxString &outLabel, wxPoint &outPos,
-                         std::string *outUuid = nullptr);
+                         std::string *outUuid = nullptr,
+                         wxRect *outProjectedRect = nullptr,
+                         double *outDepth = nullptr);
   bool GetTrussLabelAt(int mouseX, int mouseY, int width, int height,
                        wxString &outLabel, wxPoint &outPos,
-                       std::string *outUuid = nullptr);
+                       std::string *outUuid = nullptr,
+                       wxRect *outProjectedRect = nullptr,
+                       double *outDepth = nullptr);
   bool GetSceneObjectLabelAt(int mouseX, int mouseY, int width, int height,
                              wxString &outLabel, wxPoint &outPos,
-                             std::string *outUuid = nullptr);
+                             std::string *outUuid = nullptr,
+                             wxRect *outProjectedRect = nullptr,
+                             double *outDepth = nullptr);
   std::vector<std::string> GetFixturesInScreenRect(int x1, int y1, int x2,
                                                    int y2, int width,
                                                    int height) const;

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -33,6 +33,7 @@
 #include <atomic>
 #include <wx/thread.h>
 #include <vector>
+#include <array>
 
 wxDECLARE_EVENT(wxEVT_VIEWER_REFRESH, wxThreadEvent);
 
@@ -106,12 +107,28 @@ private:
 
     // Renders the full scene
     void Render();
+    std::array<float, 6> GetCameraState() const;
+    bool CanReuseHoverCache(int width, int height) const;
+    void InvalidateHoverCache();
+
+    struct HoverCache {
+        bool valid = false;
+        wxPoint mousePos;
+        wxSize viewport;
+        std::array<float, 6> cameraState{};
+        wxString label;
+        wxPoint pos;
+        std::string uuid;
+        wxRect projectedRect;
+        double depth = 0.0;
+    };
 
     // Hovered fixture label state
     bool m_hasHover = false;
     wxPoint m_hoverPos;
     wxString m_hoverText;
     std::string m_hoverUuid;
+    HoverCache m_hoverCache;
 
     // True when the mouse moved since the last paint
     bool m_mouseMoved = false;


### PR DESCRIPTION
### Motivation
- Reducir el coste de hit-testing por frame evitando llamar `Get*LabelAt` en cada `OnPaint` cuando no cambian el ratón, la cámara o el viewport. 
- Evitar proyectar las 8 esquinas de todas las AABB siempre, añadiendo un prefiltrado frustum/depth temprano para descartar candidatos rápido. 
- Instrumentar la ruta de hit-testing con métricas para medir y validar la mejora y preparar futura optimización espacial (grid/octree).

### Description
- `Viewer3DPanel`: se añadió `HoverCache` y métodos `GetCameraState()`, `CanReuseHoverCache()` e `InvalidateHoverCache()` para reutilizar resultados (uuid, label, posición, rect proyectado y depth) y sólo recalcular cuando cambian mouse/cámara/viewport; `OnPaint` ahora usa la caché en lugar de consultar siempre al controller. 
- `Viewer3DController`: se ampliaron las firmas de `GetFixtureLabelAt/GetTrussLabelAt/GetSceneObjectLabelAt` para devolver opcionalmente el `wxRect` proyectado y la `depth`, y se añadió `PrefilterBoundsForProjection` (frustum + depth estimate) para descartar AABB antes de llamar a `gluProject` en las 8 esquinas. 
- Métricas/telemetría: se introdujo `HitTestPerfStats`, logging periódico con `LogHitTestStats` y medición en microsegundos de cada llamada para promedios de tiempo, candidatos, proyectados y prefiltrados. 
- Invalidez de caché: puntos de invalidación añadidos/ajustados en resize, orbit/pan/zoom (mouse), movimiento de mouse, salida del panel, `UpdateScene()` y `LoadCameraFromConfig()` para mantener coherencia del hover cacheado; la estructura espacial (grid/octree) no se implementó (opcional).

### Testing
- `git diff --check` se ejecutó y no reportó errores en el diff (OK). 
- Intenté configurar una compilación con `cmake -S . -B build-linux -DCMAKE_BUILD_TYPE=Debug`, pero la configuración falló por falta de la dependencia del entorno `wxWidgets` en este contenedor (no se pudo completar la build end-to-end).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69878840013883248d5b93fbdb1e9845)