### PR TITLE
Fix compilation errors in viewer3d projection prefilter

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -376,10 +376,10 @@ static bool PrefilterBoundsForProjection(const std::array<float, 3> &minBound,
     minEyeZ = std::min(minEyeZ, ez); maxEyeZ = std::max(maxEyeZ, ez);
   }
 
-  const double near = proj[14] / (proj[10] - 1.0);
-  const double far = proj[14] / (proj[10] + 1.0);
-  const double nearPos = std::abs(near);
-  const double farPos = std::abs(far);
+  const double nearPlane = proj[14] / (proj[10] - 1.0);
+  const double farPlane = proj[14] / (proj[10] + 1.0);
+  const double nearPos = std::abs(nearPlane);
+  const double farPos = std::abs(farPlane);
 
   if (maxEyeZ > -nearPos || minEyeZ < -farPos)
     return false;


### PR DESCRIPTION
### Motivation
- Avoid name collisions with platform macros (notably MSVC/Windows) that caused parse errors and downstream `abs` overload failures in `PrefilterBoundsForProjection`.

### Description
- Rename local variables `near` -> `nearPlane` and `far` -> `farPlane` in `viewer3d/viewer3dcontroller.cpp` and update dependent expressions so behavior is unchanged.

### Testing
- Attempted automated builds: `cmake --preset win-x64-debug` failed because the preset is disabled in this environment, and `cmake --build --preset win-debug-build` failed because the Windows build directory is not present, so no Windows build could be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69878b02c1208324836149878c27b0f2)