### PR TITLE
Fix MSVC C2679 in DrawWireframeBox by using CanvasColor assignments

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -2084,7 +2084,15 @@ void Viewer3DController::DrawWireframeBox(
     std::vector<std::array<float, 3>> vv = {{x0,y0,z0},{x1,y0,z0},{x0,y1,z0},{x1,y1,z0},{x0,y0,z1},{x1,y0,z1},{x0,y1,z1},{x1,y1,z1}};
     if (captureTransform) for (auto &p: vv) p = captureTransform(p);
     CanvasStroke stroke; stroke.width=wireframe?baseWidth:1.0f;
-    stroke.color = wireframe ? std::array<float,4>{0,0,0,1} : (highlight?std::array<float,4>{0,1,0,1}:(selected?std::array<float,4>{0,1,1,1}:std::array<float,4>{1,1,0,1}));
+    if (wireframe) {
+      stroke.color = {0.0f, 0.0f, 0.0f, 1.0f};
+    } else if (highlight) {
+      stroke.color = {0.0f, 1.0f, 0.0f, 1.0f};
+    } else if (selected) {
+      stroke.color = {0.0f, 1.0f, 1.0f, 1.0f};
+    } else {
+      stroke.color = {1.0f, 1.0f, 0.0f, 1.0f};
+    }
     const int e[12][2]={{0,1},{2,3},{4,5},{6,7},{0,2},{1,3},{4,6},{5,7},{0,4},{1,5},{2,6},{3,7}};
     for (auto &k:e) RecordLine(vv[k[0]], vv[k[1]], stroke);
   }


### PR DESCRIPTION
### Motivation

- A ternary expression constructed `std::array<float,4>` values and assigned them to `CanvasStroke::color` (type `CanvasColor`), which triggers MSVC error C2679 because no suitable conversion/operator exists.

### Description

- Replace the ternary `std::array<float,4>{...}` assignment in `Viewer3DController::DrawWireframeBox` with explicit `CanvasColor` assignments using braced float initializers.
- Preserve the original color logic for `wireframe`, `highlight`, `selected`, and default cases.
- The change is localized to `viewer3d/viewer3dcontroller.cpp` at the canvas capture stroke assignment.

### Testing

- Ran `git diff --check` which returned without issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69878fdea544832482526cf45135fb9e)