### PR TITLE
viewer3d: invalidation-driven rendering with active-interaction refresh

### DIFF
--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -31,6 +31,8 @@
 #include <string>
 #include <thread>
 #include <atomic>
+#include <chrono>
+#include <cstdint>
 #include <wx/thread.h>
 #include <vector>
 
@@ -122,7 +124,14 @@ private:
     Viewer3DController m_controller;
 
     std::atomic<bool> m_threadRunning{false};
+    std::atomic<bool> m_needsRender{true};
+    std::atomic<bool> m_activeInteraction{false};
+    std::atomic<std::int64_t> m_interactionUntilMs{0};
+    std::vector<std::string> m_selectedUuids;
     std::thread m_refreshThread;
+    void MarkRenderDirty();
+    void SetInteractionActive(bool active);
+    void ExtendInteractionWindow(std::chrono::milliseconds duration);
     void RefreshLoop();
     void OnThreadRefresh(wxThreadEvent& event);
 


### PR DESCRIPTION
### Motivation
- Reemplazar el repintado periódico fijo por una estrategia basada en invalidación para reducir repintes innecesarios y preservar fluidez durante interacción (drag/zoom) mientras el visor está inactivo.

### Description
- Añadidos flags y helpers: `m_needsRender`, `m_activeInteraction`, `m_interactionUntilMs`, y funciones `MarkRenderDirty()`, `SetInteractionActive()` y `ExtendInteractionWindow()` en `Viewer3DPanel` para controlar cuándo se requiere repintado.
- `RefreshLoop()` y `OnThreadRefresh()` ahora respetan `m_needsRender`/`m_activeInteraction` y usan sleeps más largos en inactividad; el refresco continuo solo corre durante interacción activa o cuando la vista está marcada como sucia.
- Reemplazados llamados directos a `Refresh()` por `MarkRenderDirty()` y/o activación temporal de interacción en eventos relevantes (`OnResize`, `OnMouseDown/Up/Move/Wheel`, `OnKeyDown`, `OnMouseLeave`, `UpdateScene`, menú de selección), y `SetSelectedFixtures()` evita repintar si la selección no cambió comparando con `m_selectedUuids`.
- Archivos modificados: `viewer3d/viewer3dpanel.h` y `viewer3d/viewer3dpanel.cpp` (implementación de la lógica de invalidación e interacción activa y actualización de lugares que antes llamaban a `Refresh()` directamente).

### Testing
- Intenté una compilación local con `cmake -S . -B build && cmake --build build -j2`; la configuración falla en este entorno por falta del paquete CMake de `wxWidgets` (no se pudo localizar `wxWidgetsConfig.cmake`), por lo que no se pudo completar el build aquí.
- No se ejecutaron tests unitarios adicionales automáticos en este entorno debido a la dependencia ausente; los cambios están limitados a la gestión de refresco/invalidez y deben ser verificables manualmente integrándolos en un entorno con `wxWidgets` instalado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698852ca516483248da0ed9b383aa2ae)