### PR TITLE
Fix std::atomic<bool> assignment in Viewer3DPanel

### DIFF
--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -962,7 +962,7 @@ void Viewer3DPanel::OnThreadRefresh(wxThreadEvent& event)
         return;
 
     Refresh();
-    m_needsRender = m_activeInteraction;
+    m_needsRender = m_activeInteraction.load();
 }
 
 void Viewer3DPanel::LoadCameraFromConfig()


### PR DESCRIPTION
### Motivation
- Fix a Windows/MSVC compile error (deleted copy-assignment for `std::atomic<bool>`) by avoiding direct assignment between atomics in the refresh handler.

### Description
- Replace the invalid assignment `m_needsRender = m_activeInteraction;` with `m_needsRender = m_activeInteraction.load();` in `viewer3d/viewer3dpanel.cpp` to read the atomic value explicitly and preserve behavior.

### Testing
- Ran `cmake -S . -B build` to validate the build setup, which failed due to a missing `wxWidgets` development package so a full compile could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698854c2e4d48324b14646a971ffafc0)