### PR TITLE
Preserve imported model scale when exporting MVR (always emit Geometry3D)

### DIFF
--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -987,24 +987,12 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
 
     if (!t.symbolFile.empty()) {
       tinyxml2::XMLElement *geos = doc.NewElement("Geometries");
-      bool usedSym = false;
-      for (const auto &[sUuid, file] : scene.symdefFiles) {
-        if (file == t.symbolFile) {
-          tinyxml2::XMLElement *sym = doc.NewElement("Symbol");
-          sym->SetAttribute("symdef", sUuid.c_str());
-          geos->InsertEndChild(sym);
-          usedSym = true;
-          break;
-        }
-      }
-      if (!usedSym) {
-        tinyxml2::XMLElement *g3d = doc.NewElement("Geometry3D");
-        std::string symbolArchivePath = registerResource(
-            t.symbolFile,
-            SanitizeArchiveFileName(t.symbolFile, "truss.3ds"));
-        g3d->SetAttribute("fileName", symbolArchivePath.c_str());
-        geos->InsertEndChild(g3d);
-      }
+      tinyxml2::XMLElement *g3d = doc.NewElement("Geometry3D");
+      std::string symbolArchivePath = registerResource(
+          t.symbolFile,
+          SanitizeArchiveFileName(t.symbolFile, "truss.3ds"));
+      g3d->SetAttribute("fileName", symbolArchivePath.c_str());
+      geos->InsertEndChild(g3d);
       te->InsertEndChild(geos);
       registerResource(
           t.symbolFile,
@@ -1172,24 +1160,12 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
 
     if (!obj.modelFile.empty()) {
       tinyxml2::XMLElement *geos = doc.NewElement("Geometries");
-      bool usedSym = false;
-      for (const auto &[sUuid, file] : scene.symdefFiles) {
-        if (file == obj.modelFile) {
-          tinyxml2::XMLElement *sym = doc.NewElement("Symbol");
-          sym->SetAttribute("symdef", sUuid.c_str());
-          geos->InsertEndChild(sym);
-          usedSym = true;
-          break;
-        }
-      }
-      if (!usedSym) {
-        tinyxml2::XMLElement *g3d = doc.NewElement("Geometry3D");
-        std::string modelArchivePath = registerResource(
-            obj.modelFile,
-            SanitizeArchiveFileName(obj.modelFile, "object.3ds"));
-        g3d->SetAttribute("fileName", modelArchivePath.c_str());
-        geos->InsertEndChild(g3d);
-      }
+      tinyxml2::XMLElement *g3d = doc.NewElement("Geometry3D");
+      std::string modelArchivePath = registerResource(
+          obj.modelFile,
+          SanitizeArchiveFileName(obj.modelFile, "object.3ds"));
+      g3d->SetAttribute("fileName", modelArchivePath.c_str());
+      geos->InsertEndChild(g3d);
       oe->InsertEndChild(geos);
       registerResource(
           obj.modelFile,


### PR DESCRIPTION
### Motivation
- Import composes symdef geometry matrices into per-object `transform` so the effective scale/transform is stored on `obj.transform` / `t.transform` and must be preserved on export.
- The exporter previously tried to convert matching resource files back into `<Symbol symdef="...">` entries which reintroduced symdef semantics on load and caused scale/transform to be lost or misapplied.

### Description
- Always emit a `<Geometry3D fileName="...">` element for truss symbols (`t.symbolFile`) instead of attempting to re-link to a `<Symbol>`; the exporter now writes the resource and a `Geometry3D` node. (file: `mvr/mvrexporter.cpp`)
- Apply the same change for generic scene objects (`obj.modelFile`) so scene objects are exported as `Geometries/Geometry3D` with the registered archive path. (file: `mvr/mvrexporter.cpp`)
- This ensures the already-composed object matrices are the single source of truth and prevents reapplying symdef matrices on reload.

### Testing
- Attempted to configure and build with `cmake -S . -B build && cmake --build build -j2`, but the process failed because the environment is missing the `wxWidgets` CMake package (`wxWidgetsConfig.cmake`), so a full compile could not be completed (failure).
- No additional automated tests were present or executed in this environment; change is limited to MVR export code paths in `mvr/mvrexporter.cpp`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69885a4ebfc8832499cebd01b3aff4b7)