### PR TITLE
Preserve MVR geometry scale across save/load and transform edits

### DIFF
--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -1357,9 +1357,10 @@ void FixtureTablePanel::UpdateSceneData() {
     Matrix rot = MatrixUtils::EulerToMatrix(
         static_cast<float>(yaw), static_cast<float>(pitch),
         static_cast<float>(roll));
-    rot.o = {static_cast<float>(x * 1000.0), static_cast<float>(y * 1000.0),
-             static_cast<float>(z * 1000.0)};
-    it->second.transform = rot;
+    it->second.transform = MatrixUtils::ApplyRotationPreservingScale(
+        it->second.transform, rot,
+        {static_cast<float>(x * 1000.0), static_cast<float>(y * 1000.0),
+         static_cast<float>(z * 1000.0)});
 
     table->GetValue(v, i, 16);
     double pw = 0.0;

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -574,9 +574,10 @@ void HoistTablePanel::UpdateSceneData() {
     Matrix rot = MatrixUtils::EulerToMatrix(static_cast<float>(yaw),
                                             static_cast<float>(pitch),
                                             static_cast<float>(roll));
-    rot.o = {static_cast<float>(x * 1000.0), static_cast<float>(y * 1000.0),
-             static_cast<float>(z * 1000.0)};
-    it->second.transform = rot;
+    it->second.transform = MatrixUtils::ApplyRotationPreservingScale(
+        it->second.transform, rot,
+        {static_cast<float>(x * 1000.0), static_cast<float>(y * 1000.0),
+         static_cast<float>(z * 1000.0)});
 
     table->GetValue(v, i, 12);
     double chainLen = 0.0;

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -581,10 +581,11 @@ void SceneObjectTablePanel::UpdateSceneData()
         Matrix rot = MatrixUtils::EulerToMatrix(static_cast<float>(yaw),
                                                 static_cast<float>(pitch),
                                                 static_cast<float>(roll));
-        rot.o = {static_cast<float>(x * 1000.0),
-                  static_cast<float>(y * 1000.0),
-                  static_cast<float>(z * 1000.0)};
-        it->second.transform = rot;
+        it->second.transform = MatrixUtils::ApplyRotationPreservingScale(
+            it->second.transform, rot,
+            {static_cast<float>(x * 1000.0),
+             static_cast<float>(y * 1000.0),
+             static_cast<float>(z * 1000.0)});
     }
 
     if (SummaryPanel::Instance() && IsActivePage())

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -787,10 +787,11 @@ void TrussTablePanel::UpdateSceneData()
         Matrix rot = MatrixUtils::EulerToMatrix(static_cast<float>(yaw),
                                                 static_cast<float>(pitch),
                                                 static_cast<float>(roll));
-        rot.o = {static_cast<float>(x * 1000.0),
-                 static_cast<float>(y * 1000.0),
-                 static_cast<float>(z * 1000.0)};
-        it->second.transform = rot;
+        it->second.transform = MatrixUtils::ApplyRotationPreservingScale(
+            it->second.transform, rot,
+            {static_cast<float>(x * 1000.0),
+             static_cast<float>(y * 1000.0),
+             static_cast<float>(z * 1000.0)});
 
         table->GetValue(v, i, 10);
         it->second.manufacturer = std::string(v.GetString().mb_str());

--- a/models/matrixutils.h
+++ b/models/matrixutils.h
@@ -33,6 +33,30 @@
 // Utility functions for handling 4x3 transformation matrices
 namespace MatrixUtils {
 
+    inline std::array<float, 3> ExtractScale(const Matrix& m)
+    {
+        auto norm = [](const std::array<float, 3>& v) {
+            return std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
+        };
+        return {norm(m.u), norm(m.v), norm(m.w)};
+    }
+
+    inline Matrix ApplyRotationPreservingScale(const Matrix& source,
+                                               const Matrix& rotation,
+                                               const std::array<float, 3>& translation)
+    {
+        Matrix out = rotation;
+        const auto scales = ExtractScale(source);
+
+        for (int i = 0; i < 3; ++i) {
+            out.u[i] *= scales[0];
+            out.v[i] *= scales[1];
+            out.w[i] *= scales[2];
+        }
+        out.o = translation;
+        return out;
+    }
+
     // Parse a matrix string which can be either the MVR 4x3 format
     // "{a,b,c}{d,e,f}{g,h,i}{j,k,l}" or the GDTF 4x4 format
     // "{a,b,c,d}{e,f,g,h}{i,j,k,l}{m,n,o,p}". Both are stored row-major

--- a/tests/matrixutils_test.cpp
+++ b/tests/matrixutils_test.cpp
@@ -40,5 +40,23 @@ int main() {
     }
   }
 
+
+  {
+    Matrix source;
+    MatrixUtils::ParseMatrix("{0.0254,0,0}{0,0.0508,0}{0,0,0.1016}{100,200,300}", source);
+
+    Matrix rotation = MatrixUtils::EulerToMatrix(90.0f, 0.0f, 0.0f);
+    Matrix updated = MatrixUtils::ApplyRotationPreservingScale(source, rotation,
+                                                               {400.0f, 500.0f, 600.0f});
+
+    auto scales = MatrixUtils::ExtractScale(updated);
+    if (!Near(scales[0], 0.0254f) || !Near(scales[1], 0.0508f) ||
+        !Near(scales[2], 0.1016f) || !Near(updated.o[0], 400.0f) ||
+        !Near(updated.o[1], 500.0f) || !Near(updated.o[2], 600.0f)) {
+      std::cerr << "ApplyRotationPreservingScale did not keep source scale\n";
+      return 1;
+    }
+  }
+
   return 0;
 }


### PR DESCRIPTION
### Motivation
- Imported MVR objects can carry non‑uniform scale in their basis vectors and rebuilding transforms from unit rotation + translation was losing that scale, producing incorrectly sized models after save/load or table edits.
- The change aims to preserve any axis scale baked into `Matrix.u/v/w` when applying user edits to rotation/position so exported `scene.mvr` keeps original geometry scale.

### Description
- Added `MatrixUtils::ExtractScale` and `MatrixUtils::ApplyRotationPreservingScale` to `models/matrixutils.h` to extract per-axis scale and rebuild a transform with a new rotation while preserving scale and setting translation.
- Replaced code paths that previously overwrote transforms with unit rotation + translation in `UpdateSceneData()` for fixtures, trusses, hoists and scene objects so they now call `ApplyRotationPreservingScale` instead of assigning a pure rotation matrix; files modified: `gui/fixturetablepanel.cpp`, `gui/trusstablepanel.cpp`, `gui/hoisttablepanel.cpp`, `gui/sceneobjecttablepanel.cpp`.
- Added a unit check in `tests/matrixutils_test.cpp` that verifies the new helper preserves original axis scale and applies translation correctly.

### Testing
- Built and executed the matrix unit test with `g++ -std=c++20 tests/matrixutils_test.cpp -I models -o /tmp/matrixutils_test && /tmp/matrixutils_test`, which succeeded.
- Ran `git diff --check` to ensure no trailing whitespace or patch issues, which reported no problems.
- Changes were reviewed via a local commit and diff confirming modifications to the matrix utilities, four GUI table panels, and the test.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69885ca93ce08324b7b37e5d4e3e44ae)