### PR TITLE
Fix transform drift when saving unchanged scene rows

### DIFF
--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -1354,13 +1354,27 @@ void FixtureTablePanel::UpdateSceneData() {
       s.ToDouble(&yaw);
     }
 
-    Matrix rot = MatrixUtils::EulerToMatrix(
-        static_cast<float>(yaw), static_cast<float>(pitch),
-        static_cast<float>(roll));
-    it->second.transform = MatrixUtils::ApplyRotationPreservingScale(
-        it->second.transform, rot,
-        {static_cast<float>(x * 1000.0), static_cast<float>(y * 1000.0),
-         static_cast<float>(z * 1000.0)});
+    const auto currentEuler = MatrixUtils::MatrixToEuler(it->second.transform);
+    const bool transformChanged =
+        wxString::Format("%.3f", it->second.transform.o[0] / 1000.0f) !=
+            wxString::Format("%.3f", x) ||
+        wxString::Format("%.3f", it->second.transform.o[1] / 1000.0f) !=
+            wxString::Format("%.3f", y) ||
+        wxString::Format("%.3f", it->second.transform.o[2] / 1000.0f) !=
+            wxString::Format("%.3f", z) ||
+        wxString::Format("%.1f", currentEuler[2]) != wxString::Format("%.1f", roll) ||
+        wxString::Format("%.1f", currentEuler[1]) != wxString::Format("%.1f", pitch) ||
+        wxString::Format("%.1f", currentEuler[0]) != wxString::Format("%.1f", yaw);
+
+    if (transformChanged) {
+      Matrix rot = MatrixUtils::EulerToMatrix(
+          static_cast<float>(yaw), static_cast<float>(pitch),
+          static_cast<float>(roll));
+      it->second.transform = MatrixUtils::ApplyRotationPreservingScale(
+          it->second.transform, rot,
+          {static_cast<float>(x * 1000.0), static_cast<float>(y * 1000.0),
+           static_cast<float>(z * 1000.0)});
+    }
 
     table->GetValue(v, i, 16);
     double pw = 0.0;

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -571,13 +571,27 @@ void HoistTablePanel::UpdateSceneData() {
       s.ToDouble(&yaw);
     }
 
-    Matrix rot = MatrixUtils::EulerToMatrix(static_cast<float>(yaw),
-                                            static_cast<float>(pitch),
-                                            static_cast<float>(roll));
-    it->second.transform = MatrixUtils::ApplyRotationPreservingScale(
-        it->second.transform, rot,
-        {static_cast<float>(x * 1000.0), static_cast<float>(y * 1000.0),
-         static_cast<float>(z * 1000.0)});
+    const auto currentEuler = MatrixUtils::MatrixToEuler(it->second.transform);
+    const bool transformChanged =
+        wxString::Format("%.3f", it->second.transform.o[0] / 1000.0f) !=
+            wxString::Format("%.3f", x) ||
+        wxString::Format("%.3f", it->second.transform.o[1] / 1000.0f) !=
+            wxString::Format("%.3f", y) ||
+        wxString::Format("%.3f", it->second.transform.o[2] / 1000.0f) !=
+            wxString::Format("%.3f", z) ||
+        wxString::Format("%.1f", currentEuler[2]) != wxString::Format("%.1f", roll) ||
+        wxString::Format("%.1f", currentEuler[1]) != wxString::Format("%.1f", pitch) ||
+        wxString::Format("%.1f", currentEuler[0]) != wxString::Format("%.1f", yaw);
+
+    if (transformChanged) {
+      Matrix rot = MatrixUtils::EulerToMatrix(static_cast<float>(yaw),
+                                              static_cast<float>(pitch),
+                                              static_cast<float>(roll));
+      it->second.transform = MatrixUtils::ApplyRotationPreservingScale(
+          it->second.transform, rot,
+          {static_cast<float>(x * 1000.0), static_cast<float>(y * 1000.0),
+           static_cast<float>(z * 1000.0)});
+    }
 
     table->GetValue(v, i, 12);
     double chainLen = 0.0;

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -578,14 +578,31 @@ void SceneObjectTablePanel::UpdateSceneData()
             wxString s = v.GetString(); s.Replace("\u00B0", ""); s.ToDouble(&yaw);
         }
 
-        Matrix rot = MatrixUtils::EulerToMatrix(static_cast<float>(yaw),
-                                                static_cast<float>(pitch),
-                                                static_cast<float>(roll));
-        it->second.transform = MatrixUtils::ApplyRotationPreservingScale(
-            it->second.transform, rot,
-            {static_cast<float>(x * 1000.0),
-             static_cast<float>(y * 1000.0),
-             static_cast<float>(z * 1000.0)});
+        const auto currentEuler = MatrixUtils::MatrixToEuler(it->second.transform);
+        const bool transformChanged =
+            wxString::Format("%.3f", it->second.transform.o[0] / 1000.0f) !=
+                wxString::Format("%.3f", x) ||
+            wxString::Format("%.3f", it->second.transform.o[1] / 1000.0f) !=
+                wxString::Format("%.3f", y) ||
+            wxString::Format("%.3f", it->second.transform.o[2] / 1000.0f) !=
+                wxString::Format("%.3f", z) ||
+            wxString::Format("%.1f", currentEuler[2]) !=
+                wxString::Format("%.1f", roll) ||
+            wxString::Format("%.1f", currentEuler[1]) !=
+                wxString::Format("%.1f", pitch) ||
+            wxString::Format("%.1f", currentEuler[0]) !=
+                wxString::Format("%.1f", yaw);
+
+        if (transformChanged) {
+            Matrix rot = MatrixUtils::EulerToMatrix(static_cast<float>(yaw),
+                                                    static_cast<float>(pitch),
+                                                    static_cast<float>(roll));
+            it->second.transform = MatrixUtils::ApplyRotationPreservingScale(
+                it->second.transform, rot,
+                {static_cast<float>(x * 1000.0),
+                 static_cast<float>(y * 1000.0),
+                 static_cast<float>(z * 1000.0)});
+        }
     }
 
     if (SummaryPanel::Instance() && IsActivePage())

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -784,14 +784,31 @@ void TrussTablePanel::UpdateSceneData()
             wxString s = v.GetString(); s.Replace("\u00B0", ""); s.ToDouble(&yaw);
         }
 
-        Matrix rot = MatrixUtils::EulerToMatrix(static_cast<float>(yaw),
-                                                static_cast<float>(pitch),
-                                                static_cast<float>(roll));
-        it->second.transform = MatrixUtils::ApplyRotationPreservingScale(
-            it->second.transform, rot,
-            {static_cast<float>(x * 1000.0),
-             static_cast<float>(y * 1000.0),
-             static_cast<float>(z * 1000.0)});
+        const auto currentEuler = MatrixUtils::MatrixToEuler(it->second.transform);
+        const bool transformChanged =
+            wxString::Format("%.3f", it->second.transform.o[0] / 1000.0f) !=
+                wxString::Format("%.3f", x) ||
+            wxString::Format("%.3f", it->second.transform.o[1] / 1000.0f) !=
+                wxString::Format("%.3f", y) ||
+            wxString::Format("%.3f", it->second.transform.o[2] / 1000.0f) !=
+                wxString::Format("%.3f", z) ||
+            wxString::Format("%.1f", currentEuler[2]) !=
+                wxString::Format("%.1f", roll) ||
+            wxString::Format("%.1f", currentEuler[1]) !=
+                wxString::Format("%.1f", pitch) ||
+            wxString::Format("%.1f", currentEuler[0]) !=
+                wxString::Format("%.1f", yaw);
+
+        if (transformChanged) {
+            Matrix rot = MatrixUtils::EulerToMatrix(static_cast<float>(yaw),
+                                                    static_cast<float>(pitch),
+                                                    static_cast<float>(roll));
+            it->second.transform = MatrixUtils::ApplyRotationPreservingScale(
+                it->second.transform, rot,
+                {static_cast<float>(x * 1000.0),
+                 static_cast<float>(y * 1000.0),
+                 static_cast<float>(z * 1000.0)});
+        }
 
         table->GetValue(v, i, 10);
         it->second.manufacturer = std::string(v.GetString().mb_str());


### PR DESCRIPTION
### Motivation
- Saving a project caused some 3D elements to change rotation/position because table sync always rebuilt transforms from the displayed (rounded) position/angle values, introducing reconstruction drift.
- The intent is to preserve the original `transform` unless the user actually changed the visible position/rotation cells.

### Description
- Added change-detection guards that compare the current `transform` (using `MatrixUtils::MatrixToEuler` and formatted position strings) against the table's displayed values and only rebuild the matrix when values differ. 
- Only apply `MatrixUtils::ApplyRotationPreservingScale` when a real change is detected to avoid silent transform mutation.
- Modified files: `gui/fixturetablepanel.cpp`, `gui/trusstablepanel.cpp`, `gui/hoisttablepanel.cpp`, and `gui/sceneobjecttablepanel.cpp`.

### Testing
- Ran a CMake configuration check with `cmake -S . -B build` to validate project setup; the configure failed due to missing `wxWidgets` package in the environment, so a full build and unit tests could not be executed (environment limitation).
- No automated unit tests were run in this environment; changes were committed locally (`Fix transform drift when saving unchanged scene rows`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69885ed41ba4832489a1f150a370b9a9)