### PR TITLE
Refactor mesh rendering to VAO/VBO indexed drawing

### DIFF
--- a/viewer3d/mesh.h
+++ b/viewer3d/mesh.h
@@ -23,6 +23,16 @@ struct Mesh {
     std::vector<float> vertices; // x,y,z order in mm
     std::vector<unsigned short> indices; // 3 indices per triangle
     std::vector<float> normals;  // optional per-vertex normals
+
+    // GPU resources used by the 3D viewer render path.
+    mutable unsigned int vao = 0;
+    mutable unsigned int vboVertices = 0;
+    mutable unsigned int vboNormals = 0;
+    mutable unsigned int eboTriangles = 0;
+    mutable unsigned int eboLines = 0;
+    mutable bool gpuBuffersReady = false;
+    mutable size_t triangleIndexCount = 0;
+    mutable size_t lineIndexCount = 0;
 };
 
 // Compute smooth per-vertex normals based on the indexed triangles. The

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -168,6 +168,24 @@ static std::array<float, 3> HsvToRgb(float h, float s, float v) {
   return {r + m, g + m, b + m};
 }
 
+
+
+static std::vector<unsigned short> BuildWireframeIndices(const Mesh &mesh) {
+  std::vector<unsigned short> lines;
+  lines.reserve(mesh.indices.size() * 2);
+  for (size_t i = 0; i + 2 < mesh.indices.size(); i += 3) {
+    const unsigned short i0 = mesh.indices[i];
+    const unsigned short i1 = mesh.indices[i + 1];
+    const unsigned short i2 = mesh.indices[i + 2];
+    lines.push_back(i0);
+    lines.push_back(i1);
+    lines.push_back(i1);
+    lines.push_back(i2);
+    lines.push_back(i2);
+    lines.push_back(i0);
+  }
+  return lines;
+}
 static std::array<float, 3> MakeDeterministicColor(std::string_view key) {
   if (key.empty())
     key = "default";
@@ -611,6 +629,8 @@ Viewer3DController::Viewer3DController() {
 }
 
 Viewer3DController::~Viewer3DController() {
+  for (auto &[path, mesh] : m_loadedMeshes)
+    ReleaseMeshBuffers(mesh);
   if (m_vg)
     nvgDeleteGL2(m_vg);
 }
@@ -712,6 +732,87 @@ void Viewer3DController::SetSelectedUuids(
     m_selectedUuids.insert(u);
 }
 
+void Viewer3DController::SetupMeshBuffers(const Mesh &mesh) const {
+  if (mesh.gpuBuffersReady || mesh.vertices.empty() || mesh.indices.empty())
+    return;
+
+  if (mesh.normals.size() < mesh.vertices.size()) {
+    Mesh &mutableMesh = const_cast<Mesh &>(mesh);
+    ComputeNormals(mutableMesh);
+  }
+
+  glGenVertexArrays(1, &mesh.vao);
+  glBindVertexArray(mesh.vao);
+
+  glGenBuffers(1, &mesh.vboVertices);
+  glBindBuffer(GL_ARRAY_BUFFER, mesh.vboVertices);
+  glBufferData(GL_ARRAY_BUFFER,
+               static_cast<GLsizeiptr>(mesh.vertices.size() * sizeof(float)),
+               mesh.vertices.data(), GL_STATIC_DRAW);
+  glEnableClientState(GL_VERTEX_ARRAY);
+  glVertexPointer(3, GL_FLOAT, 0, nullptr);
+
+  if (!mesh.normals.empty()) {
+    glGenBuffers(1, &mesh.vboNormals);
+    glBindBuffer(GL_ARRAY_BUFFER, mesh.vboNormals);
+    glBufferData(GL_ARRAY_BUFFER,
+                 static_cast<GLsizeiptr>(mesh.normals.size() * sizeof(float)),
+                 mesh.normals.data(), GL_STATIC_DRAW);
+    glEnableClientState(GL_NORMAL_ARRAY);
+    glNormalPointer(GL_FLOAT, 0, nullptr);
+  }
+
+  glGenBuffers(1, &mesh.eboTriangles);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mesh.eboTriangles);
+  glBufferData(GL_ELEMENT_ARRAY_BUFFER,
+               static_cast<GLsizeiptr>(mesh.indices.size() *
+                                       sizeof(unsigned short)),
+               mesh.indices.data(), GL_STATIC_DRAW);
+  mesh.triangleIndexCount = mesh.indices.size();
+
+  std::vector<unsigned short> wireIndices = BuildWireframeIndices(mesh);
+  if (!wireIndices.empty()) {
+    glGenBuffers(1, &mesh.eboLines);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mesh.eboLines);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER,
+                 static_cast<GLsizeiptr>(wireIndices.size() *
+                                         sizeof(unsigned short)),
+                 wireIndices.data(), GL_STATIC_DRAW);
+    mesh.lineIndexCount = wireIndices.size();
+  }
+
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+  glBindVertexArray(0);
+  mesh.gpuBuffersReady = true;
+}
+
+void Viewer3DController::ReleaseMeshBuffers(Mesh &mesh) const {
+  if (mesh.eboLines != 0) {
+    glDeleteBuffers(1, &mesh.eboLines);
+    mesh.eboLines = 0;
+  }
+  if (mesh.eboTriangles != 0) {
+    glDeleteBuffers(1, &mesh.eboTriangles);
+    mesh.eboTriangles = 0;
+  }
+  if (mesh.vboNormals != 0) {
+    glDeleteBuffers(1, &mesh.vboNormals);
+    mesh.vboNormals = 0;
+  }
+  if (mesh.vboVertices != 0) {
+    glDeleteBuffers(1, &mesh.vboVertices);
+    mesh.vboVertices = 0;
+  }
+  if (mesh.vao != 0) {
+    glDeleteVertexArrays(1, &mesh.vao);
+    mesh.vao = 0;
+  }
+  mesh.gpuBuffersReady = false;
+  mesh.triangleIndexCount = 0;
+  mesh.lineIndexCount = 0;
+}
+
 // Loads meshes or GDTF models referenced by scene objects. Called when the
 // scene is updated.
 void Viewer3DController::Update() {
@@ -746,6 +847,7 @@ void Viewer3DController::Update() {
 
       if (loaded) {
         m_loadedMeshes[path] = std::move(mesh);
+        SetupMeshBuffers(m_loadedMeshes[path]);
       } else if (ConsolePanel::Instance()) {
         wxString msg = wxString::Format("Failed to load model: %s",
                                         wxString::FromUTF8(path));
@@ -774,6 +876,7 @@ void Viewer3DController::Update() {
 
       if (loaded) {
         m_loadedMeshes[path] = std::move(mesh);
+        SetupMeshBuffers(m_loadedMeshes[path]);
       } else if (ConsolePanel::Instance()) {
         wxString msg = wxString::Format("Failed to load model: %s",
                                         wxString::FromUTF8(path));
@@ -2182,34 +2285,18 @@ void Viewer3DController::DrawMeshWireframe(
     const std::function<std::array<float, 3>(const std::array<float, 3> &)> &
         captureTransform) {
   if (!m_captureOnly) {
-    glBegin(GL_LINES);
-    for (size_t i = 0; i + 2 < mesh.indices.size(); i += 3) {
-      unsigned short i0 = mesh.indices[i];
-      unsigned short i1 = mesh.indices[i + 1];
-      unsigned short i2 = mesh.indices[i + 2];
-
-      float v0x = mesh.vertices[i0 * 3] * scale;
-      float v0y = mesh.vertices[i0 * 3 + 1] * scale;
-      float v0z = mesh.vertices[i0 * 3 + 2] * scale;
-
-      float v1x = mesh.vertices[i1 * 3] * scale;
-      float v1y = mesh.vertices[i1 * 3 + 1] * scale;
-      float v1z = mesh.vertices[i1 * 3 + 2] * scale;
-
-      float v2x = mesh.vertices[i2 * 3] * scale;
-      float v2y = mesh.vertices[i2 * 3 + 1] * scale;
-      float v2z = mesh.vertices[i2 * 3 + 2] * scale;
-
-      glVertex3f(v0x, v0y, v0z);
-      glVertex3f(v1x, v1y, v1z);
-
-      glVertex3f(v1x, v1y, v1z);
-      glVertex3f(v2x, v2y, v2z);
-
-      glVertex3f(v2x, v2y, v2z);
-      glVertex3f(v0x, v0y, v0z);
+    SetupMeshBuffers(mesh);
+    if (mesh.gpuBuffersReady && mesh.vao != 0 && mesh.eboLines != 0 &&
+        mesh.lineIndexCount > 0) {
+      glPushMatrix();
+      glScalef(scale, scale, scale);
+      glBindVertexArray(mesh.vao);
+      glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mesh.eboLines);
+      glDrawElements(GL_LINES, static_cast<GLsizei>(mesh.lineIndexCount),
+                     GL_UNSIGNED_SHORT, nullptr);
+      glBindVertexArray(0);
+      glPopMatrix();
     }
-    glEnd();
   }
   if (m_captureCanvas) {
     CanvasStroke stroke;
@@ -2245,62 +2332,19 @@ void Viewer3DController::DrawMeshWireframe(
 // converting vertex units (e.g. millimeters) to meters.
 void Viewer3DController::DrawMesh(const Mesh &mesh, float scale) {
   if (!m_captureOnly) {
-    glBegin(GL_TRIANGLES);
-    bool hasNormals = mesh.normals.size() >= mesh.vertices.size();
-    for (size_t i = 0; i + 2 < mesh.indices.size(); i += 3) {
-      unsigned short i0 = mesh.indices[i];
-      unsigned short i1 = mesh.indices[i + 1];
-      unsigned short i2 = mesh.indices[i + 2];
-
-      float v0x = mesh.vertices[i0 * 3] * scale;
-      float v0y = mesh.vertices[i0 * 3 + 1] * scale;
-      float v0z = mesh.vertices[i0 * 3 + 2] * scale;
-
-      float v1x = mesh.vertices[i1 * 3] * scale;
-      float v1y = mesh.vertices[i1 * 3 + 1] * scale;
-      float v1z = mesh.vertices[i1 * 3 + 2] * scale;
-
-      float v2x = mesh.vertices[i2 * 3] * scale;
-      float v2y = mesh.vertices[i2 * 3 + 1] * scale;
-      float v2z = mesh.vertices[i2 * 3 + 2] * scale;
-
-      if (hasNormals) {
-        glNormal3f(mesh.normals[i0 * 3], mesh.normals[i0 * 3 + 1],
-                   mesh.normals[i0 * 3 + 2]);
-        glVertex3f(v0x, v0y, v0z);
-        glNormal3f(mesh.normals[i1 * 3], mesh.normals[i1 * 3 + 1],
-                   mesh.normals[i1 * 3 + 2]);
-        glVertex3f(v1x, v1y, v1z);
-        glNormal3f(mesh.normals[i2 * 3], mesh.normals[i2 * 3 + 1],
-                   mesh.normals[i2 * 3 + 2]);
-        glVertex3f(v2x, v2y, v2z);
-      } else {
-        float ux = v1x - v0x;
-        float uy = v1y - v0y;
-        float uz = v1z - v0z;
-
-        float vx = v2x - v0x;
-        float vy = v2y - v0y;
-        float vz = v2z - v0z;
-
-        float nx = uy * vz - uz * vy;
-        float ny = uz * vx - ux * vz;
-        float nz = ux * vy - uy * vx;
-
-        float len = std::sqrt(nx * nx + ny * ny + nz * nz);
-        if (len > 0.0f) {
-          nx /= len;
-          ny /= len;
-          nz /= len;
-        }
-
-        glNormal3f(nx, ny, nz);
-        glVertex3f(v0x, v0y, v0z);
-        glVertex3f(v1x, v1y, v1z);
-        glVertex3f(v2x, v2y, v2z);
-      }
+    SetupMeshBuffers(mesh);
+    if (mesh.gpuBuffersReady && mesh.vao != 0 && mesh.eboTriangles != 0 &&
+        mesh.triangleIndexCount > 0) {
+      glPushMatrix();
+      glScalef(scale, scale, scale);
+      glBindVertexArray(mesh.vao);
+      glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mesh.eboTriangles);
+      glDrawElements(GL_TRIANGLES,
+                     static_cast<GLsizei>(mesh.triangleIndexCount),
+                     GL_UNSIGNED_SHORT, nullptr);
+      glBindVertexArray(0);
+      glPopMatrix();
     }
-    glEnd();
   }
 }
 

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -232,6 +232,10 @@ private:
   // so they can use a scale of 1.0f
   void DrawMesh(const Mesh &mesh, float scale = RENDER_SCALE);
 
+  // Initializes and destroys GPU buffers associated with a mesh.
+  void SetupMeshBuffers(const Mesh &mesh) const;
+  void ReleaseMeshBuffers(Mesh &mesh) const;
+
   // Cache of already loaded meshes indexed by absolute file path
   std::unordered_map<std::string, Mesh> m_loadedMeshes;
 


### PR DESCRIPTION
### Motivation
- Reduce CPU overhead and prepare the renderer for efficient batching/instancing by replacing per-vertex immediate-mode submissions with GPU-side buffers. 
- Preserve current scene semantics, selection/highlight visuals and the `m_captureCanvas` export path while making the minimal safe changes to switch mesh submission to VAO/VBO/EBO.

### Description
- Added GPU handles and state to `Mesh` (`vao`, `vboVertices`, `vboNormals`, `eboTriangles`, `eboLines`, flags and index counts) so each mesh can be uploaded once to the GPU (`viewer3d/mesh.h`).
- Implemented `SetupMeshBuffers` and `ReleaseMeshBuffers` in `Viewer3DController` to create/destroy VAO/VBO/EBO resources and build a wireframe index buffer via `BuildWireframeIndices` (`viewer3d/viewer3dcontroller.cpp` and header). 
- Call `SetupMeshBuffers` when a mesh is loaded and free all mesh GPU resources in the destructor to avoid leaks (`Viewer3DController::Update` and `~Viewer3DController`).
- Rewrote `DrawMeshWireframe` and `DrawMesh` to bind the mesh VAO/EBO and call `glDrawElements` instead of emitting per-vertex `glBegin`/`glEnd` loops, while leaving `m_captureCanvas` recording code intact so 2D/PDF export behavior is preserved.

### Testing
- Ran `cmake -S . -B build` to validate configure, which failed due to a missing system dependency (`wxWidgetsConfig.cmake` not found) so a full build could not be completed in this environment. (failed)
- Performed automated source checks using `rg` to verify the old immediate-mode loops were replaced and that `glDrawElements`/buffer setup functions are present; these grep checks show the new calls and helper functions are in place. (succeeded)
- No automated unit tests exist in this patch; full compile/run validation should be performed in an environment with development dependencies (notably wxWidgets) before merging. (not run)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69889cc9fb908324a29eee154c0bb3b1)