### PR TITLE
Fix disappearing meshes after switching between 2D and 3D views

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -2131,6 +2131,25 @@ void Viewer3DController::SetupMeshBuffers(Mesh &mesh) {
   glBindBuffer(GL_ARRAY_BUFFER, 0);
   glBindVertexArray(0);
 
+  const bool gpuResourcesValid =
+      glIsVertexArray(mesh.vao) == GL_TRUE &&
+      glIsBuffer(mesh.vboVertices) == GL_TRUE &&
+      glIsBuffer(mesh.vboNormals) == GL_TRUE &&
+      glIsBuffer(mesh.eboTriangles) == GL_TRUE &&
+      glIsBuffer(mesh.eboLines) == GL_TRUE;
+
+  if (!gpuResourcesValid) {
+    mesh.vao = 0;
+    mesh.vboVertices = 0;
+    mesh.vboNormals = 0;
+    mesh.eboTriangles = 0;
+    mesh.eboLines = 0;
+    mesh.triangleIndexCount = 0;
+    mesh.lineIndexCount = 0;
+    mesh.buffersReady = false;
+    return;
+  }
+
   mesh.triangleIndexCount = static_cast<int>(mesh.indices.size());
   mesh.lineIndexCount = static_cast<int>(lineIndices.size());
   mesh.buffersReady = true;
@@ -2281,9 +2300,13 @@ void Viewer3DController::DrawMeshWireframe(
     const Mesh &mesh, float scale,
     const std::function<std::array<float, 3>(const std::array<float, 3> &)> &
         captureTransform) {
+  const bool gpuHandlesValid =
+      glIsBuffer(mesh.vboVertices) == GL_TRUE &&
+      glIsBuffer(mesh.eboLines) == GL_TRUE &&
+      glIsBuffer(mesh.eboTriangles) == GL_TRUE;
   const bool canUseGpuWireframe =
       mesh.buffersReady && mesh.vao != 0 && mesh.vboVertices != 0 &&
-      mesh.eboLines != 0 && mesh.eboTriangles != 0;
+      mesh.eboLines != 0 && mesh.eboTriangles != 0 && gpuHandlesValid;
 
   if (!m_captureOnly && canUseGpuWireframe) {
     glBindVertexArray(mesh.vao);
@@ -2360,9 +2383,13 @@ void Viewer3DController::DrawMeshWireframe(
 // Draws a mesh using GL triangles. The optional scale parameter allows
 // converting vertex units (e.g. millimeters) to meters.
 void Viewer3DController::DrawMesh(const Mesh &mesh, float scale) {
+  const bool gpuHandlesValid =
+      glIsBuffer(mesh.vboVertices) == GL_TRUE &&
+      glIsBuffer(mesh.vboNormals) == GL_TRUE &&
+      glIsBuffer(mesh.eboTriangles) == GL_TRUE;
   const bool canUseGpuTriangles =
       mesh.buffersReady && mesh.vao != 0 && mesh.vboVertices != 0 &&
-      mesh.vboNormals != 0 && mesh.eboTriangles != 0;
+      mesh.vboNormals != 0 && mesh.eboTriangles != 0 && gpuHandlesValid;
 
   if (!m_captureOnly && canUseGpuTriangles) {
     glBindVertexArray(mesh.vao);


### PR DESCRIPTION
### Motivation
- After introducing VBO/VAO/instancing, meshes could disappear when switching between 2D and 3D views because cached GL object IDs can become invalid across GL context lifecycle or pane/view switches.
- The renderer relied on non-zero handles and a `buffersReady` flag without verifying the handles are still valid in the current GL context.

### Description
- In `SetupMeshBuffers` added runtime validation using `glIsVertexArray` and `glIsBuffer` and clear mesh handles and `buffersReady` when validation fails to avoid marking invalid GPU resources as ready.
- In `DrawMeshWireframe` and `DrawMesh` added `glIsBuffer` checks and require those checks when deciding to take the GPU (VAO/VBO/EBO) fast path so stale handles are not used.
- When GPU validation fails the code now falls back to the existing CPU/immediate-mode rendering path, preserving visibility instead of attempting invalid GPU draws.

### Testing
- Attempted to run `cmake -S . -B build` to configure a build, but configuration failed due to a missing `wxWidgets` development package in this environment (CMake error reported). (failed)
- Performed local static verification by running repository searches and inspected diffs; changes were compiled into a commit in the repository (commit present). (inspection only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988acf7044083248f30c65b89a4d2bf)