### PR TITLE
Auto-fix mesh winding and enable backface culling in 3D viewer

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -2094,6 +2094,8 @@ void Viewer3DController::SetupMeshBuffers(Mesh &mesh) {
   if (mesh.buffersReady)
     ReleaseMeshBuffers(mesh);
 
+  EnsureOutwardWinding(mesh);
+
   if (mesh.normals.size() < mesh.vertices.size())
     ComputeNormals(mesh);
 
@@ -2637,6 +2639,9 @@ void Viewer3DController::ApplyTransform(const float matrix[16],
 void Viewer3DController::SetupBasicLighting() {
   glEnable(GL_LIGHTING);
   glEnable(GL_LIGHT0);
+  glEnable(GL_CULL_FACE);
+  glCullFace(GL_BACK);
+  glFrontFace(GL_CCW);
 
   GLfloat ambient[] = {0.2f, 0.2f, 0.2f, 1.0f};
   GLfloat diffuse[] = {0.8f, 0.8f, 0.8f, 1.0f};


### PR DESCRIPTION
### Motivation
- Imported MVR/3D assets can come from many DCC tools with inconsistent triangle winding, producing shading/visibility artifacts.  
- Fixing winding at load time avoids incorrect lighting and inconsistent backface behavior across assets.  
- The fix must avoid per-frame overhead so viewer performance is not degraded.

### Description
- Added a per-mesh flag `windingChecked` to `Mesh` to ensure compatibility checks run only once per mesh.  
- Implemented `EnsureOutwardWinding(Mesh&)` in `viewer3d/mesh.h`, a one-time heuristic pass that scores triangle orientations against the mesh centroid and flips triangle index order and inverts normals when a clear inverted-winding signal is detected.  
- Integrated the compatibility pass into `Viewer3DController::SetupMeshBuffers` by calling `EnsureOutwardWinding(mesh)` before `ComputeNormals`, so corrected winding is used when generating normals and uploading buffers.  
- Enabled backface culling in `Viewer3DController::SetupBasicLighting` with `glEnable(GL_CULL_FACE)`, `glCullFace(GL_BACK)` and `glFrontFace(GL_CCW)` to improve visual robustness and reduce fragment work.

### Testing
- Attempted an automated build with `cmake -S . -B build`, but the build could not be completed in this environment because the `wxWidgets` development package / `wxWidgetsConfig.cmake` was not available (configuration failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988aefd2cdc8324a49dc661e81277ea)