### PR TITLE
Transform per-instance normals and fix mirrored winding for MVR meshes

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,20 @@ Run tests from the build directory with `ctest` to execute unit tests.
 
 ---
 
+
+## Manual shading verification (MVR)
+
+To verify flat-shading consistency after importing MVR scenes:
+
+1. Build and run the app, then import an `.mvr` file that contains repeated sloped surfaces (for example roof planes).
+2. In the 3D viewer, keep solid rendering enabled and inspect surfaces with the same tilt angle.
+3. Confirm they receive consistent grayscale shading (no random white/gray mismatch on equally oriented planes).
+4. Load a representative GDTF fixture and confirm rendering is unchanged compared to previous behavior.
+
+These checks validate that per-instance normal transformation and mirrored-transform winding correction are working as expected.
+
+---
+
 ## Windows packaging
 
 1. Build the Release configuration.

--- a/viewer3d/mesh.h
+++ b/viewer3d/mesh.h
@@ -220,9 +220,10 @@ TransformNormal(const std::array<float, 3>& normal, const float model[16])
         return normal;
 
     const float invDet = 1.0f / det;
-    const float nx = (c00 * normal[0] + c10 * normal[1] + c20 * normal[2]) * invDet;
-    const float ny = (c01 * normal[0] + c11 * normal[1] + c21 * normal[2]) * invDet;
-    const float nz = (c02 * normal[0] + c12 * normal[1] + c22 * normal[2]) * invDet;
+    // inverse-transpose(A) equals the cofactor matrix divided by det(A).
+    const float nx = (c00 * normal[0] + c01 * normal[1] + c02 * normal[2]) * invDet;
+    const float ny = (c10 * normal[0] + c11 * normal[1] + c12 * normal[2]) * invDet;
+    const float nz = (c20 * normal[0] + c21 * normal[1] + c22 * normal[2]) * invDet;
 
     const float len = std::sqrt(nx * nx + ny * ny + nz * nz);
     if (len <= 1e-8f)

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -2490,39 +2490,34 @@ void Viewer3DController::DrawMesh(const Mesh &mesh, float scale,
           transformInstanceNormals ? transformedNormals : mesh.normals;
 
       if (useFaceNormals) {
-        float nx = (v1y - v0y) * (v2z - v0z) - (v1z - v0z) * (v2y - v0y);
-        float ny = (v1z - v0z) * (v2x - v0x) - (v1x - v0x) * (v2z - v0z);
-        float nz = (v1x - v0x) * (v2y - v0y) - (v1y - v0y) * (v2x - v0x);
-        const float len = std::sqrt(nx * nx + ny * ny + nz * nz);
-        if (len > 0.0f) {
-          nx /= len;
-          ny /= len;
-          nz /= len;
-        }
-
         if (hasNormals) {
-          // Some imported assets contain triangles with inconsistent local
-          // winding. Align face normals with averaged vertex normals to avoid
-          // alternating bright/dark patches on coplanar surfaces.
-          float ax = normalData[i0 * 3] + normalData[i1 * 3] + normalData[i2 * 3];
+          // In flat mode use one normal per triangle, but derive it from the
+          // triangle's transformed vertex normals when available. This avoids
+          // checkerboard artifacts from provoking-vertex changes without
+          // introducing extra winding-dependent flips.
+          float ax = normalData[i0 * 3] + normalData[i1 * 3] +
+                     normalData[i2 * 3];
           float ay = normalData[i0 * 3 + 1] + normalData[i1 * 3 + 1] +
                      normalData[i2 * 3 + 1];
           float az = normalData[i0 * 3 + 2] + normalData[i1 * 3 + 2] +
                      normalData[i2 * 3 + 2];
           const float alen = std::sqrt(ax * ax + ay * ay + az * az);
           if (alen > 0.0f) {
-            ax /= alen;
-            ay /= alen;
-            az /= alen;
-            if (nx * ax + ny * ay + nz * az < 0.0f) {
-              nx = -nx;
-              ny = -ny;
-              nz = -nz;
-            }
+            glNormal3f(ax / alen, ay / alen, az / alen);
+          } else {
+            glNormal3f(0.0f, 0.0f, 1.0f);
           }
+        } else {
+          float nx = (v1y - v0y) * (v2z - v0z) - (v1z - v0z) * (v2y - v0y);
+          float ny = (v1z - v0z) * (v2x - v0x) - (v1x - v0x) * (v2z - v0z);
+          float nz = (v1x - v0x) * (v2y - v0y) - (v1y - v0y) * (v2x - v0x);
+          const float len = std::sqrt(nx * nx + ny * ny + nz * nz);
+          if (len > 0.0f)
+            glNormal3f(nx / len, ny / len, nz / len);
+          else
+            glNormal3f(0.0f, 0.0f, 1.0f);
         }
 
-        glNormal3f(nx, ny, nz);
         glVertex3f(v0x, v0y, v0z);
         glVertex3f(v1x, v1y, v1z);
         glVertex3f(v2x, v2y, v2z);

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -178,7 +178,8 @@ private:
                            const std::function<std::array<float, 3>(
                                const std::array<float, 3> &)> &captureTransform =
                                {},
-                           bool unlit = false);
+                           bool unlit = false,
+                           const float *modelMatrix = nullptr);
 
   // Draws only the mesh edges for wireframe rendering
   void DrawMeshWireframe(
@@ -237,7 +238,8 @@ private:
   // Draws a mesh loaded from a 3DS file using the given scale factor
   // for vertex positions. GDTF models may already be defined in meters
   // so they can use a scale of 1.0f
-  void DrawMesh(const Mesh &mesh, float scale = RENDER_SCALE);
+  void DrawMesh(const Mesh &mesh, float scale = RENDER_SCALE,
+                const float *modelMatrix = nullptr);
 
   // Cache of already loaded meshes indexed by absolute file path
   std::unordered_map<std::string, Mesh> m_loadedMeshes;


### PR DESCRIPTION
### Motivation

- MVR-imported instances were shaded inconsistently because normals computed in local space were never transformed by the instance model matrix and negative-scale/mirrored transforms produced inverted winding and flipped lighting.
- The fixed-function pipeline did not normalize normals after model-space transforms, causing lighting to depend on transform scale.

### Description

- Add `TransformNormal(...)` and `TransformDeterminant(...)` helpers in `viewer3d/mesh.h` to compute inverse-transpose normal transforms and detect mirrored (negative determinant) instance matrices.
- Extend `DrawMeshWithOutline` and `DrawMesh` signatures to accept an optional `modelMatrix` pointer and pass instance matrices for scene objects and trusses so only transformed instances use per-draw normal correction.
- Generate a temporary `transformedNormals` buffer at draw time (leaving `mesh.normals` unchanged), apply `TransformNormal` to each normal, invert normals when the determinant is negative, and swap triangle winding in a temporary index array prior to drawing so faces keep correct front-facing orientation.
- Support both VAO/VBO (GPU) and immediate-mode paths by feeding `transformedNormals.data()` to `glNormalPointer` when per-instance transformation is used, and enable `GL_NORMALIZE` in `SetupBasicLighting()` to keep normals correct under scaling.
- Add a short README section `Manual shading verification (MVR)` describing manual checks to validate the fix on `.mvr` scenes and a GDTF sanity check.

### Testing

- Attempted to configure the project with `cmake -S . -B build`, which failed in this environment due to missing `wxWidgets` development packages (so no full build or unit tests were executed).
- No automated `ctest` runs were performed here because the build step could not complete; changes were verified by code inspection and local edits and then committed (`git commit`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988e8a96cac83248dda2354c9b0e2ae)