### PR TITLE
Añadir MSAA configurable con fallback para canvas GL del visor 3D

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -211,6 +211,7 @@ ConfigManager::ConfigManager() {
   RegisterVariable("view2d_render_mode", "float", 2.0f, 0.0f, 3.0f);
   RegisterVariable("view2d_view", "float", 0.0f, 0.0f, 2.0f);
   RegisterVariable("view2d_dark_mode", "float", 1.0f, 0.0f, 1.0f);
+  RegisterVariable("viewer3d_aa_quality", "float", 1.0f, 0.0f, 2.0f);
   LoadUserConfig();
   if (!HasKey("rider_autopatch"))
     SetValue("rider_autopatch", "1");

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -119,6 +119,9 @@ private:
     // True once OpenGL/GLEW initialization has been performed
     bool m_glInitialized = false;
 
+    // Multisample anti-aliasing availability negotiated at context creation.
+    bool m_hasSampleBuffers = false;
+
     Viewer3DController m_controller;
 
     std::atomic<bool> m_threadRunning{false};


### PR DESCRIPTION
### Motivation
- Permitir que el visor 3D negocie un formato de contexto GL que pida doble buffer, profundidad adecuada y MSAA según la configuración para evitar imponer coste fijo en hardware modestos.
- Proveer una ruta segura de degradado cuando la plataforma no soporte la calidad de AA solicitada para mantener compatibilidad.

### Description
- Reemplacé la creación del `wxGLCanvas` que usaba `nullptr` por una selección explícita de atributos (`SelectGlCanvasAttributes()`) que solicita `WX_GL_DOUBLEBUFFER`, `WX_GL_DEPTH_SIZE`=24 y, opcionalmente, `WX_GL_SAMPLE_BUFFERS`/`WX_GL_SAMPLES` para 2x/4x MSAA en `viewer3d/viewer3dpanel.cpp` y `viewer3d/viewer3dpanel.h`.
- Implementé negociación de atributos usando `wxGLCanvas::IsDisplaySupported(...)` con degradado `4x -> 2x -> sin multisample` según la preferencia leída de configuración en `GetRequestedViewerAASamples()`.
- Añadí la bandera miembro `m_hasSampleBuffers` y en `InitGL()` comprobé `GL_SAMPLE_BUFFERS` con `glGetIntegerv` para habilitar/deshabilitar explícitamente `GL_MULTISAMPLE` sólo si el contexto tiene sample buffers activos.
- Registré la nueva clave de configuración `viewer3d_aa_quality` en `core/configmanager.cpp` (valores `0..2` mapeados a `Off/2x/4x`) y la lectura se utiliza durante la negociación del canvas para decidir la calidad solicitada.

### Testing
- Intenté configurar el build con `cmake -S . -B build` para validar la generación de proyecto, pero la configuración falló por falta de las librerías de desarrollo de wxWidgets en el entorno (`Could NOT find wxWidgets (missing: wxWidgets_LIBRARIES wxWidgets_INCLUDE_DIRS)`), por lo que no se pudo compilar aquí.
- No se ejecutaron tests unitarios automáticos adicionales debido a la ausencia de un entorno de compilación completo; la lógica de negociación usa la API `wxGLCanvas::IsDisplaySupported` y la consulta `GL_SAMPLE_BUFFERS` para comportamiento runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989c4b406e48324978b1d16c1a6c0d5)