### PR TITLE
Adapt Viewer3D line rendering based on interaction state

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -212,6 +212,7 @@ ConfigManager::ConfigManager() {
   RegisterVariable("view2d_view", "float", 0.0f, 0.0f, 2.0f);
   RegisterVariable("view2d_dark_mode", "float", 1.0f, 0.0f, 1.0f);
   RegisterVariable("viewer3d_aa_quality", "float", 1.0f, 0.0f, 2.0f);
+  RegisterVariable("viewer3d_adaptive_line_profile", "float", 1.0f, 0.0f, 1.0f);
   LoadUserConfig();
   if (!HasKey("rider_autopatch"))
     SetValue("rider_autopatch", "1");

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -92,6 +92,7 @@ public:
 
   // Enables color tweaks for dark mode in the 2D viewer only.
   void SetDarkMode(bool enabled);
+  void SetInteracting(bool interacting);
   void SetSelectionOutlineEnabled(bool enabled) {
     m_showSelectionOutline2D = enabled;
   }
@@ -291,6 +292,8 @@ private:
   SymbolCache m_bottomSymbolCache;
   bool m_darkMode = false;
   bool m_showSelectionOutline2D = false;
+  bool m_isInteracting = false;
+  bool m_useAdaptiveLineProfile = true;
 
 public:
   // Enables recording of all primitives drawn during the next RenderScene

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -365,6 +365,7 @@ void Viewer3DPanel::OnMouseDown(wxMouseEvent& event)
     {
         if (event.LeftDown() && event.ControlDown()) {
             m_rectSelecting = true;
+            m_controller.SetInteracting(true);
             m_rectSelectStart = event.GetPosition();
             m_rectSelectEnd = m_rectSelectStart;
             m_draggedSincePress = false;
@@ -378,6 +379,7 @@ void Viewer3DPanel::OnMouseDown(wxMouseEvent& event)
             m_mode = InteractionMode::Orbit;
 
         m_dragging = true;
+        m_controller.SetInteracting(true);
         m_draggedSincePress = false;
         m_lastMousePos = event.GetPosition();
         CaptureMouse();
@@ -394,6 +396,7 @@ void Viewer3DPanel::OnMouseUp(wxMouseEvent& event)
         ApplyRectangleSelection(m_rectSelectStart, m_rectSelectEnd);
         m_rectSelecting = false;
         m_dragging = false;
+        m_controller.SetInteracting(false);
         m_mode = InteractionMode::None;
         m_draggedSincePress = false;
         Refresh();
@@ -403,6 +406,7 @@ void Viewer3DPanel::OnMouseUp(wxMouseEvent& event)
     if (m_dragging && (event.LeftUp() || event.MiddleUp()))
     {
         m_dragging = false;
+        m_controller.SetInteracting(false);
         m_mode = InteractionMode::None;
         ReleaseMouse();
     }
@@ -646,6 +650,7 @@ void Viewer3DPanel::OnCaptureLost(wxMouseCaptureLostEvent& WXUNUSED(event))
     m_dragging = false;
     m_mode = InteractionMode::None;
     m_rectSelecting = false;
+    m_controller.SetInteracting(false);
 }
 
 void Viewer3DPanel::ApplyRectangleSelection(const wxPoint& start,
@@ -800,7 +805,9 @@ void Viewer3DPanel::OnMouseWheel(wxMouseEvent& event)
     float steps = 0.0f;
     if (deltaWheel != 0)
         steps = -static_cast<float>(rotation) / static_cast<float>(deltaWheel);
+    m_controller.SetInteracting(true);
     m_camera.Zoom(steps);
+    m_controller.SetInteracting(false);
     Refresh();
 }
 


### PR DESCRIPTION
### Motivation

- Reduce visual noise and stabilize the rendered image when the camera is idle while preserving responsiveness and fluidity during user interaction (orbit/pan/zoom/rectangle selection).
- Provide an opt-out so users can disable this adaptive behavior via configuration if they prefer the original rendering.

### Description

- Propagated interaction state from `Viewer3DPanel` to `Viewer3DController` by adding `SetInteracting(bool)` and calling it from drag/rectangle selection, mouse-wheel zoom and capture-loss code paths in `viewer3d/viewer3dpanel.cpp`.
- Introduced a `LineRenderProfile` and helper `GetLineRenderProfile(...)` plus flags `m_isInteracting` and `m_useAdaptiveLineProfile` in `viewer3d/viewer3dcontroller.*` to choose between an "interaction" profile (thinner lines, no smoothing) and a "rest" profile (normal width + line smoothing).
- Applied the adaptive profile to the requested rendering paths: `DrawGrid`, `DrawAxes`, `DrawMeshWithOutline` (wireframe), `DrawWireframeCube` / `DrawWireframeBox` and related capture strokes so on-screen lines reduce thickness while interacting and enable smoothing when idle.
- Added a configuration toggle `viewer3d_adaptive_line_profile` (default enabled) in `core/configmanager.cpp` so adaptation can be disabled by setting the config variable.

### Testing

- Attempted a full configure/build with `cmake -S . -B build && cmake --build build -j2`, but the CMake configure step failed in this environment due to missing `wxWidgets` development libraries, so a full compile/run validation could not be performed.
- Performed local static checks (code search/inspection) to verify new symbols and call sites were wired (`SetInteracting`, `m_isInteracting`, `viewer3d_adaptive_line_profile`) and adjusted rendering code paths accordingly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989c8bc22ac8324879d824e0d25ad38)