### PR TITLE
Pause heavy 2D/3D updates during user interaction

### DIFF
--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -29,6 +29,7 @@
 #include <wx/glcanvas.h>
 #include <wx/wx.h>
 #include <array>
+#include <chrono>
 #include <condition_variable>
 #include <functional>
 #include <memory>
@@ -151,6 +152,7 @@ private:
   void StopDragTableUpdates();
   void StartDragTableUpdateWorker();
   void StopDragTableUpdateWorker();
+  bool ShouldPauseHeavyTasks();
 
   struct DragTablePositionSnapshot {
     std::string uuid;
@@ -167,6 +169,7 @@ private:
 
   static constexpr long kSelectionDragDelayMs = 150;
   static constexpr int kDragTableUpdateIntervalMs = 50;
+  static constexpr std::chrono::milliseconds kPauseDelay{200};
 
   DragMode m_dragMode = DragMode::None;
   DragAxis m_dragAxis = DragAxis::None;
@@ -186,6 +189,8 @@ private:
   bool m_mouseInside = false;
   bool m_mouseMoved = false;
   bool m_hasHover = false;
+  std::chrono::steady_clock::time_point m_lastInteractionTime{};
+  bool m_isInteracting = false;
   bool m_enableSelection = true;
   std::string m_hoverUuid;
 

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -31,6 +31,7 @@
 #include <string>
 #include <thread>
 #include <atomic>
+#include <chrono>
 #include <wx/thread.h>
 #include <vector>
 
@@ -63,6 +64,7 @@ public:
 
     Viewer3DCamera& GetCamera() { return m_camera; }
     const Viewer3DCamera& GetCamera() const { return m_camera; }
+    bool ShouldPauseHeavyTasks();
 
 private:
     wxGLContext* m_glContext;
@@ -80,6 +82,8 @@ private:
     // Type of interaction currently active (Orbit or Pan)
     enum class InteractionMode { None, Orbit, Pan };
     InteractionMode m_mode = InteractionMode::None;
+    std::chrono::steady_clock::time_point m_lastInteractionTime{};
+    bool m_isInteracting = false;
 
     // Initializes OpenGL settings
     void InitGL();


### PR DESCRIPTION
### Motivation
- Minimize UI jank and CPU churn by temporarily suspending expensive scene/table updates while the user is actively manipulating the view (orbit/pan/zoom or dragging).
- Resume heavy work shortly after interactions stop to keep scene and tables consistent without interfering with navigation.

### Description
- Added interaction tracking fields `m_lastInteractionTime` and `m_isInteracting` and a `ShouldPauseHeavyTasks()` helper to both `Viewer3DPanel` and `Viewer2DPanel`, and introduced a `kPauseDelay` of `200ms` to control the pause window.
- Mark interaction start from input paths (`OnMouseDown`, `OnMouseMove`, `OnMouseWheel` and drag flows) by updating `m_lastInteractionTime` and setting `m_isInteracting = true` so the pause window is extended while the user manipulates the view.
- Guarded heavy work: `Viewer3DPanel::UpdateScene()` and `Viewer2DPanel::UpdateScene(true)` return early when `ShouldPauseHeavyTasks()` indicates active interaction, and `Viewer2DPanel::ScheduleDragTableUpdate()` skips enqueuing table updates during the pause window to reduce worker churn.
- Implemented automatic resume checks in paint/update flows so the controller `Update()` is invoked once when the interaction window elapses (implemented in `OnPaint` for 2D/3D), and respected the pause in `FinalizeSelectionDrag()` to avoid immediate heavy recompute on mouse-up.
- Files changed: `viewer3d/viewer3dpanel.h/.cpp` and `viewer2d/viewer2dpanel.h/.cpp` (interaction tracking, pause logic and guards added).

### Testing
- Attempted a local configure with `cmake -S . -B build`; configuration failed because the environment is missing `wxWidgets` development libraries, so a full build/test could not be completed in this environment.
- Basic static verification done by running repository searches and inspecting modified files to ensure `ShouldPauseHeavyTasks()` is consulted from the intended code paths; no unit/integration tests were executed due to missing GUI dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989cb5c02248324942249b404f78577)