### PR TITLE
Optimize Viewer3DController::Update by caching model bounds and scene-versioning

### DIFF
--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -261,6 +261,16 @@ private:
     std::array<float, 3> max;
   };
 
+  // Cache of local-space model bounds keyed by resolved source path.
+  std::unordered_map<std::string, BoundingBox> m_modelBounds;
+
+  // Scene versioning used to skip expensive bounds recomputation when only
+  // the camera changes.
+  size_t m_sceneVersion = 0;
+  size_t m_cachedVersion = static_cast<size_t>(-1);
+  size_t m_lastSceneSignature = 0;
+  bool m_hasSceneSignature = false;
+
   // Precomputed world-space bounds for each fixture by UUID
   std::unordered_map<std::string, BoundingBox> m_fixtureBounds;
   std::unordered_map<std::string, BoundingBox> m_trussBounds;


### PR DESCRIPTION
### Motivation
- Avoid recomputing per-vertex bounding boxes for every `Update()` which causes CPU spikes on large scenes when camera-only changes occur. 
- Reuse deterministic local model bounds and only transform them per-instance to keep visual/functional behavior identical while lowering CPU cost.

### Description
- Added a local-space model bounds cache `m_modelBounds` and scene-versioning fields (`m_sceneVersion`, `m_cachedVersion`, `m_lastSceneSignature`, `m_hasSceneSignature`) to `Viewer3DController`. (changes in `viewer3d/viewer3dcontroller.h`).
- Implemented scene-signature hashing (`HashCombine`, `HashFloat`, `HashString`, `HashMatrix`) and increment `m_sceneVersion` only when actors/transforms/models change, computed at the start of `Update()`. (changes in `viewer3d/viewer3dcontroller.cpp`).
- Short-circuit the heavy bounds recomputation when `m_cachedVersion == m_sceneVersion`; otherwise update `m_cachedVersion` and recompute. 
- Replace per-vertex world AABB walks by: compute and cache a model local AABB once per model/GDTF resource, then transform the 8 local corners to world-space to obtain instance/world AABBs for fixtures, trusses and scene objects; clear the model bounds cache when the scene base path changes. (changes in `viewer3d/viewer3dcontroller.cpp`).

### Testing
- Attempted an incremental build with `cmake --build build -j2`, which failed because the `build/` directory did not exist in this environment. (failed)
- Configured the project with `cmake -S . -B build`, which failed in this environment due to missing `wxWidgets` development packages reported by CMake, so a full build/run was not possible here. (failed)
- No additional automated unit tests were present or executed as part of this change in the current environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989f8c483588324ab008ff5f54a42d4)