### PR TITLE
Suavizado inercial para la cámara 3D del visor

### DIFF
--- a/viewer3d/viewer3dcamera.h
+++ b/viewer3d/viewer3dcamera.h
@@ -53,12 +53,26 @@ public:
     // Returns current distance
     float GetDistance() const;
 
+    // Smoothly interpolates current camera state toward target state
+    void Update(float dt);
+
     float GetYaw() const { return yaw; }
     float GetPitch() const { return pitch; }
     float GetTargetX() const { return targetX; }
     float GetTargetY() const { return targetY; }
     float GetTargetZ() const { return targetZ; }
-    void SetTarget(float x, float y, float z) { targetX = x; targetY = y; targetZ = z; }
+    void SetTarget(float x, float y, float z) {
+        targetX = x; targetY = y; targetZ = z;
+        targetTargetX = x; targetTargetY = y; targetTargetZ = z;
+    }
+
+    // Desired/orbital target state used for smooth interpolation.
+    float targetYaw;
+    float targetPitch;
+    float targetDistance;
+    float targetTargetX;
+    float targetTargetY;
+    float targetTargetZ;
 
     // Resets camera to default orientation and target
     void Reset();


### PR DESCRIPTION
### Motivation
- Mejorar la fluidez y la sensación inercial de la cámara 3D evitando cambios instantáneos del estado de la cámara ante la entrada del usuario. 
- Mantener la API pública existente (`Orbit`, `Pan`, `Zoom`, `SetOrientation`, `SetDistance`, `SetTarget`) y preservar la lógica de overshoot en `Zoom` para el `minDistance`.

### Description
- Añadidos campos objetivo en `Viewer3DCamera`: `targetYaw`, `targetPitch`, `targetDistance`, `targetTargetX/Y/Z`, y `Update(float dt)` que interpola el estado actual hacia dichos objetivos de forma suave; inicialización de objetivos en constructores y `Reset` para evitar saltos al arrancar (modificados `viewer3d/viewer3dcamera.h` y `viewer3d/viewer3dcamera.cpp`).
- `Orbit`, `Pan` y `Zoom` ahora actualizan los valores objetivo en lugar del estado actual; `Zoom` mantiene la lógica de overshoot pero aplica la traslación al objetivo (archivo `viewer3d/viewer3dcamera.cpp`).
- Integración en el ciclo de render: se calcula `dt` con `std::chrono::steady_clock` y se llama a `m_camera.Update(dt)` en `Viewer3DPanel::OnPaint` antes de `Render()` (archivo `viewer3d/viewer3dpanel.cpp`).
- Input actualizado para producir objetivos en vez de cambios instantáneos: arrastre de ratón y teclas modifican `targetYaw`/`targetPitch` (con `std::clamp` en pitch) y `Pan`/`Zoom` operan sobre objetivos; `SetTarget` sincroniza también los objetivos para evitar saltos al cargar configuración.

### Testing
- Intenté construir con `cmake -S . -B build && cmake --build build -j2` pero la configuración falla en este entorno por falta de dependencias de desarrollo de wxWidgets (`Could NOT find wxWidgets (missing: wxWidgets_LIBRARIES wxWidgets_INCLUDE_DIRS)`).
- No se modificaron pruebas automatizadas; no se pudieron ejecutar pruebas de integración/ejecución por la ausencia de bibliotecas gráficas en el entorno de CI local.
- Archivos modificados: `viewer3d/viewer3dcamera.h`, `viewer3d/viewer3dcamera.cpp`, `viewer3d/viewer3dpanel.cpp`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989fcdb09e48324b93136a7122b3fa9)