### PR TITLE
Optimize viewer rendering by caching sort order and throttling labels

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -218,6 +218,11 @@ ConfigManager::ConfigManager() {
                    64.0f);
   RegisterVariable("render_culling_min_pixels_2d", "float", 1.0f, 0.0f,
                    64.0f);
+  RegisterVariable("label_optimizations_enabled", "float", 1.0f, 0.0f,
+                   1.0f);
+  RegisterVariable("label_max_fixtures", "float", 250.0f, 0.0f, 5000.0f);
+  RegisterVariable("label_max_trusses", "float", 150.0f, 0.0f, 5000.0f);
+  RegisterVariable("label_max_objects", "float", 150.0f, 0.0f, 5000.0f);
   LoadUserConfig();
   if (!HasKey("rider_autopatch"))
     SetValue("rider_autopatch", "1");

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -519,6 +519,7 @@ void Viewer2DPanel::RenderInternal(bool swapBuffers) {
   if (!m_glInitialized) {
     return;
   }
+  const bool pauseHeavyTasks = ShouldPauseHeavyTasks();
   int w, h;
   GetClientSize(&w, &h);
 

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -593,7 +593,8 @@ void Viewer2DPanel::RenderInternal(bool swapBuffers) {
   // Draw labels for all fixtures after rendering the scene so they appear on
   // top of geometry. Scale the label size with the current zoom so they behave
   // like regular scene objects instead of remaining a constant screen size.
-  m_controller.DrawAllFixtureLabels(w, h, m_view, m_zoom);
+  if (!pauseHeavyTasks)
+    m_controller.DrawAllFixtureLabels(w, h, m_view, m_zoom);
 
   if (m_layoutEditAspect && *m_layoutEditAspect > 0.0f) {
     if (!m_layoutEditBaseSize || m_layoutEditBaseSize->GetWidth() <= 0 ||

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -264,6 +264,7 @@ wxBEGIN_EVENT_TABLE(Viewer2DPanel, wxGLCanvas) EVT_PAINT(Viewer2DPanel::OnPaint)
                 EVT_ENTER_WINDOW(Viewer2DPanel::OnMouseEnter)
                     EVT_LEAVE_WINDOW(Viewer2DPanel::OnMouseLeave)
                         EVT_MOUSE_CAPTURE_LOST(Viewer2DPanel::OnCaptureLost)
+                            EVT_TIMER(wxID_ANY, Viewer2DPanel::OnInteractionPauseTimer)
                             EVT_SIZE(Viewer2DPanel::OnResize) wxEND_EVENT_TABLE()
 
 Viewer2DPanel::Viewer2DPanel(wxWindow *parent, bool allowOffscreenRender,
@@ -271,6 +272,7 @@ Viewer2DPanel::Viewer2DPanel(wxWindow *parent, bool allowOffscreenRender,
     : wxGLCanvas(parent, wxID_ANY, nullptr, wxDefaultPosition, wxDefaultSize,
                  wxFULL_REPAINT_ON_RESIZE),
       m_allowOffscreenRender(allowOffscreenRender),
+      m_interactionResumeTimer(this),
       m_persistViewState(persistViewState),
       m_enableSelection(enableSelection) {
   SetBackgroundStyle(wxBG_STYLE_CUSTOM);
@@ -284,6 +286,7 @@ Viewer2DPanel::Viewer2DPanel(wxWindow *parent, bool allowOffscreenRender,
 Viewer2DPanel::~Viewer2DPanel() {
   if (g_instance == this)
     g_instance = nullptr;
+  m_interactionResumeTimer.Stop();
   StopDragTableUpdateWorker();
   delete m_glContext;
 }
@@ -1208,6 +1211,18 @@ bool Viewer2DPanel::ShouldPauseHeavyTasks() {
   return false;
 }
 
+void Viewer2DPanel::MarkInteractionActivity() {
+  m_isInteracting = true;
+  m_lastInteractionTime = std::chrono::steady_clock::now();
+  m_interactionResumeTimer.StartOnce(
+      static_cast<int>(kPauseDelay.count()) + 10);
+}
+
+void Viewer2DPanel::OnInteractionPauseTimer(wxTimerEvent &WXUNUSED(event)) {
+  if (!ShouldPauseHeavyTasks())
+    Refresh(false);
+}
+
 void Viewer2DPanel::OnMouseDown(wxMouseEvent &event) {
   if (event.LeftDown()) {
     CaptureMouse();
@@ -1220,8 +1235,7 @@ void Viewer2DPanel::OnMouseDown(wxMouseEvent &event) {
     m_dragSelectionMoved = false;
     m_dragSelectionPushedUndo = false;
     m_lastMousePos = event.GetPosition();
-    m_isInteracting = true;
-    m_lastInteractionTime = std::chrono::steady_clock::now();
+    MarkInteractionActivity();
 
     if (!m_enableSelection || !IsShownOnScreen())
       return;
@@ -1620,8 +1634,7 @@ void Viewer2DPanel::OnMouseMove(wxMouseEvent &event) {
   if (m_dragMode == DragMode::RectSelection && event.Dragging()) {
     m_rectSelectEnd = pos;
     m_draggedSincePress = true;
-    m_isInteracting = true;
-    m_lastInteractionTime = std::chrono::steady_clock::now();
+    MarkInteractionActivity();
     Refresh();
     return;
   }
@@ -1658,8 +1671,7 @@ void Viewer2DPanel::OnMouseMove(wxMouseEvent &event) {
           float dyMeters = static_cast<float>(-dy) / ppm;
           ApplySelectionDelta(MapDragDelta(dxMeters, dyMeters));
           m_draggedSincePress = true;
-          m_isInteracting = true;
-          m_lastInteractionTime = std::chrono::steady_clock::now();
+          MarkInteractionActivity();
           m_dragSelectionMoved = true;
           Refresh();
         }
@@ -1677,8 +1689,7 @@ void Viewer2DPanel::OnMouseMove(wxMouseEvent &event) {
     m_offsetY += dy / m_zoom;
     m_lastMousePos = pos;
     m_draggedSincePress = true;
-    m_isInteracting = true;
-    m_lastInteractionTime = std::chrono::steady_clock::now();
+    MarkInteractionActivity();
     if (m_persistViewState)
       SaveViewToConfig();
     Refresh();
@@ -1693,8 +1704,7 @@ void Viewer2DPanel::OnMouseMove(wxMouseEvent &event) {
 }
 
 void Viewer2DPanel::OnMouseWheel(wxMouseEvent &event) {
-  m_isInteracting = true;
-  m_lastInteractionTime = std::chrono::steady_clock::now();
+  MarkInteractionActivity();
 
   int rotation = event.GetWheelRotation();
   int deltaWheel = event.GetWheelDelta();

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -153,6 +153,8 @@ private:
   void StartDragTableUpdateWorker();
   void StopDragTableUpdateWorker();
   bool ShouldPauseHeavyTasks();
+  void MarkInteractionActivity();
+  void OnInteractionPauseTimer(wxTimerEvent &event);
 
   struct DragTablePositionSnapshot {
     std::string uuid;
@@ -191,6 +193,7 @@ private:
   bool m_hasHover = false;
   std::chrono::steady_clock::time_point m_lastInteractionTime{};
   bool m_isInteracting = false;
+  wxTimer m_interactionResumeTimer;
   bool m_enableSelection = true;
   std::string m_hoverUuid;
 

--- a/viewer3d/mesh.h
+++ b/viewer3d/mesh.h
@@ -36,6 +36,8 @@ struct Mesh {
     int triangleIndexCount = 0;
     int lineIndexCount = 0;
     bool buffersReady = false;
+    // Optional cached triangle index order for mirrored instances.
+    mutable std::vector<unsigned short> flippedIndicesCache;
     // True once we have evaluated/fixed triangle winding for compatibility
     // with assets coming from heterogeneous DCC/export pipelines.
     bool windingChecked = false;

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -30,6 +30,7 @@
 #include "canvas2d.h"
 #include "symbolcache.h"
 #include <array>
+#include <mutex>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -275,6 +276,14 @@ private:
   std::unordered_map<std::string, BoundingBox> m_fixtureBounds;
   std::unordered_map<std::string, BoundingBox> m_trussBounds;
   std::unordered_map<std::string, BoundingBox> m_objectBounds;
+
+  // Cached draw order to avoid re-sorting unchanged scenes every frame.
+  std::vector<const std::pair<const std::string, Fixture> *> m_sortedFixtures;
+  std::vector<const std::pair<const std::string, Truss> *> m_sortedTrusses;
+  std::vector<const std::pair<const std::string, SceneObject> *>
+      m_sortedObjects;
+  bool m_sortedListsDirty = true;
+  mutable std::mutex m_sortedListsMutex;
 
   // Cached deterministic colors for fixture types and layers in 2D view
   std::unordered_map<std::string, std::array<float, 3>> m_typeColors;

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -325,13 +325,15 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
     }
     m_mouseMoved = false;
 
-    // Draw labels before swapping buffers to avoid losing them
-    if (FixtureTablePanel::Instance() && FixtureTablePanel::Instance()->IsActivePage())
-        m_controller.DrawFixtureLabels(w, h);
-    else if (TrussTablePanel::Instance() && TrussTablePanel::Instance()->IsActivePage())
-        m_controller.DrawTrussLabels(w, h);
-    else if (SceneObjectTablePanel::Instance() && SceneObjectTablePanel::Instance()->IsActivePage())
-        m_controller.DrawSceneObjectLabels(w, h);
+    // Draw labels before swapping buffers to avoid losing them.
+    if (!pauseHeavyTasks) {
+        if (FixtureTablePanel::Instance() && FixtureTablePanel::Instance()->IsActivePage())
+            m_controller.DrawFixtureLabels(w, h);
+        else if (TrussTablePanel::Instance() && TrussTablePanel::Instance()->IsActivePage())
+            m_controller.DrawTrussLabels(w, h);
+        else if (SceneObjectTablePanel::Instance() && SceneObjectTablePanel::Instance()->IsActivePage())
+            m_controller.DrawSceneObjectLabels(w, h);
+    }
 
     if (m_rectSelecting)
         DrawSelectionRectangle(w, h);


### PR DESCRIPTION
### Motivation
- Avoid paying `O(n log n)` per-frame cost re-sorting scene lists when the scene hasn't changed. 
- Cut expensive label work (projection + NanoVG draws) in large scenes and during camera interaction to reduce CPU usage. 
- Minimize per-frame CPU mesh work when mirrored transforms or per-instance normal transforms force immediate-mode drawing.

### Description
- Added cached sorted draw lists in `Viewer3DController` (`m_sortedObjects`, `m_sortedTrusses`, `m_sortedFixtures`) with a `m_sortedListsDirty` flag and `m_sortedListsMutex`, and mark them dirty when the scene signature changes in `Update()` so `RenderScene()` only re-sorts when needed.  
- Reworked `RenderScene()` to snapshot the cached lists and iterate the snapshot (no per-frame allocations/sorts) and kept layer visibility checks and existing culling logic. 
- Added label optimizations: new config keys in `ConfigManager` (`label_optimizations_enabled`, `label_max_fixtures`, `label_max_trusses`, `label_max_objects`), per-label culling using `ProjectBoundingBoxToScreen` + `ShouldCullByScreenRect`, and a top-N selection for 2D fixture labels using projected area + `std::partial_sort`.  
- Skip drawing heavy labels while the UI indicates `pauseHeavyTasks` (hooks added in `viewer3dpanel.cpp` and `viewer2dpanel.cpp`) to avoid expensive projection/NanoVG work during interaction. 
- Reduce CPU mesh work for mirrored instances by caching a flipped triangle index buffer in `Mesh` (`flippedIndicesCache`) and reusing it in `DrawMesh()` instead of swapping indices per-frame. 

### Testing
- Attempted to configure the project with `cmake --preset default`, which failed because the preset does not exist in this repository.  
- Attempted to configure a local build with `cmake -S . -B build`, which failed due to missing `wxWidgets` development libraries in the environment so a full build/test run could not be completed.  
- All changes are committed (see commit message: "Optimize viewer rendering by caching sort order and label workload") and static edits were validated by the repository `git` operations performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a03099918832492309b1071d74c79)