### PR TITLE
Add log levels and opt-in detailed MVR import logging; fix default min level

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -218,6 +218,7 @@ ConfigManager::ConfigManager() {
                    64.0f);
   RegisterVariable("render_culling_min_pixels_2d", "float", 1.0f, 0.0f,
                    64.0f);
+  RegisterVariable("mvr_import_detailed_log", "float", 0.0f, 0.0f, 1.0f);
   LoadUserConfig();
   if (!HasKey("rider_autopatch"))
     SetValue("rider_autopatch", "1");

--- a/core/logger.cpp
+++ b/core/logger.cpp
@@ -19,8 +19,31 @@
 #include <algorithm>
 #include <filesystem>
 #include <iostream>
+#include <sstream>
 #include <vector>
 #include <wx/stdpaths.h>
+
+namespace {
+const char *LevelToString(Logger::Level level) {
+  switch (level) {
+  case Logger::Level::Error:
+    return "ERROR";
+  case Logger::Level::Warn:
+    return "WARN";
+  case Logger::Level::Info:
+    return "INFO";
+  case Logger::Level::Debug:
+    return "DEBUG";
+  }
+  return "INFO";
+}
+
+std::string FormatLogLine(Logger::Level level, const std::string &msg) {
+  std::ostringstream oss;
+  oss << '[' << LevelToString(level) << "] " << msg;
+  return oss.str();
+}
+} // namespace
 
 Logger &Logger::Instance() {
   static Logger instance;
@@ -65,12 +88,26 @@ Logger::~Logger() {
     file_.close();
 }
 
-void Logger::Log(std::string msg) {
+void Logger::Log(std::string msg) { Log(Level::Info, std::move(msg)); }
+
+void Logger::Log(Level level, std::string msg) {
   {
     std::lock_guard<std::mutex> lock(mutex_);
-    queue_.push(std::move(msg));
+    if (static_cast<int>(level) > static_cast<int>(min_level_))
+      return;
+    queue_.push({level, std::move(msg)});
   }
   cv_.notify_one();
+}
+
+void Logger::SetMinLevel(Level level) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  min_level_ = level;
+}
+
+Logger::Level Logger::GetMinLevel() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return min_level_;
 }
 
 void Logger::Worker() {
@@ -84,23 +121,24 @@ void Logger::Worker() {
     while (!queue_.empty()) {
       const std::size_t batch_size =
           std::min(queue_.size(), kMaxBatchSize);
-      std::vector<std::string> batch;
+      std::vector<Entry> batch;
       batch.reserve(batch_size);
       for (std::size_t i = 0; i < batch_size; ++i) {
         batch.emplace_back(std::move(queue_.front()));
         queue_.pop();
       }
       lock.unlock();
-      for (const auto &msg : batch) {
+      for (const auto &entry : batch) {
+        std::string formatted = FormatLogLine(entry.level, entry.msg);
         if (file_.is_open()) {
-          file_ << msg << '\n';
+          file_ << formatted << '\n';
           ++messages_since_flush;
           if (messages_since_flush >= kFlushInterval) {
             file_.flush();
             messages_since_flush = 0;
           }
         }
-        std::cerr << msg << '\n';
+        std::cerr << formatted << '\n';
       }
       lock.lock();
     }


### PR DESCRIPTION
### Motivation
- Reduce noisy per-object MVR import messages by making detailed import logs opt-in and introducing log levels. 
- Provide a simple, extensible logger API so callers can emit `Error`/`Warn`/`Info`/`Debug` messages and filter them at runtime. 
- Fix a regression where `Debug` logs were suppressed by default so MVR detailed diagnostics could never be seen even when enabled. 

### Description
- Add `Logger::Level` (`Error`, `Warn`, `Info`, `Debug`), `Log(Level, std::string)` overload, and `SetMinLevel`/`GetMinLevel` API in `core/logger.h` and implement them in `core/logger.cpp`. 
- Replace the string-only queue with `Entry { Level, msg }`, add `FormatLogLine` to prefix messages with the level, and write formatted lines to stderr and the log file in `core/logger.cpp`. 
- Change `min_level_` default to `Debug` so filtering is opt-in and provide runtime level filtering in the logger implementation. 
- Register the persistent preference `mvr_import_detailed_log` in `core/configmanager.cpp` and update `mvr/mvrimporter.cpp` to use a gated `LogMessage(Level, ...)` helper that only emits `Debug`-level per-object import messages when `mvr_import_detailed_log` is enabled. 

### Testing
- Performed static repository inspections and file content/diff checks to validate the code changes and internal consistency, which succeeded. 
- Attempted to configure and build with `cmake -S . -B build && cmake --build build -j2`, which failed due to missing `wxWidgets` development packages in this environment. 
- No automated unit tests were executed; logging and gating behavior were validated by code review and targeted file checks only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a0c626724832481f4c4ed09eed9b6)