### PR TITLE
Skip bounding-box updates for hidden layers and add lazy bounds computation

### DIFF
--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -278,6 +278,7 @@ private:
   std::unordered_map<std::string, BoundingBox> m_fixtureBounds;
   std::unordered_map<std::string, BoundingBox> m_trussBounds;
   std::unordered_map<std::string, BoundingBox> m_objectBounds;
+  std::unordered_set<std::string> m_boundsHiddenLayers;
 
   // Cached draw order to avoid re-sorting unchanged scenes every frame.
   std::vector<const std::pair<const std::string, Fixture> *> m_sortedFixtures;
@@ -327,6 +328,10 @@ private:
   bool m_cameraMoving = false;
   bool m_useAdaptiveLineProfile = true;
   bool m_skipOutlinesForCurrentFrame = false;
+
+  enum class ItemType { Fixture, Truss, SceneObject };
+  bool EnsureBoundsComputed(const std::string &uuid, ItemType type,
+                            const std::unordered_set<std::string> &hiddenLayers);
 
 public:
   // Enables recording of all primitives drawn during the next RenderScene


### PR DESCRIPTION
### Motivation
- Avoid wasted CPU and memory work recomputing and storing world-space bounding boxes for fixtures, trusses and scene objects that are on layers currently hidden. 
- Improve responsiveness for large scenes with many hidden layers by computing bounds only for visible items or on-demand when an item becomes visible or interacted with.

### Description
- Add `m_boundsHiddenLayers` and an `ItemType` enum to `Viewer3DController` and declare `EnsureBoundsComputed(...)` to support lazy bounds generation (file: `viewer3d/viewer3dcontroller.h`).
- Implement `EnsureBoundsComputed(...)` which computes and inserts a world-space bounding box into the appropriate map only when the item’s layer is visible, reusing cached local model bounds and falling back to primitive boxes when necessary (file: `viewer3d/viewer3dcontroller.cpp`).
- Snapshot hidden layers at the start of `Update()`, skip precomputing bounds for items on hidden layers, and clear/evict stale bounds when hidden-layer visibility changes to free memory and mark sorted lists dirty.
- Call `EnsureBoundsComputed(...)` from `RenderScene()` before any culling/center calculations for scene objects, trusses and fixtures so bounds are computed lazily when required.

### Testing
- Ran `cmake --preset default` which failed because the repository has no `default` preset in this environment (expected preset mismatch).
- Ran `cmake -S . -B build-local` to validate configuration wiring and this failed because the environment lacks required `wxWidgets` development packages, so a full build could not be completed.
- No unit tests were executed in this environment due to missing platform dependencies; behavior was validated by static inspection and localized manual verification of inserted calls and guard conditions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a26ef7e3083249b6eb82f50cbc525)