### PR TITLE
Refactor Viewer3D update flow to avoid heavy per-frame refresh

### DIFF
--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -71,6 +71,8 @@ public:
 
   // Updates the internal logic if needed (e.g. animation, camera)
   void Update();
+  void UpdateResourcesIfDirty();
+  void UpdateFrameStateLightweight();
 
   // Renders all scene objects. When wireframe is true lighting is disabled
   // and geometry is drawn using black lines only. The optional mode controls
@@ -273,6 +275,9 @@ private:
   size_t m_cachedVersion = static_cast<size_t>(-1);
   size_t m_lastSceneSignature = 0;
   bool m_hasSceneSignature = false;
+  bool m_sceneChangedDirty = true;
+  bool m_assetsChangedDirty = true;
+  bool m_visibilityChangedDirty = true;
 
   // Precomputed world-space bounds for each fixture by UUID
   std::unordered_map<std::string, BoundingBox> m_fixtureBounds;

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -245,10 +245,10 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
     }
     InitGL();
 
-    const bool wasCameraMoving = m_cameraMoving;
     const bool pauseHeavyTasks = ShouldPauseHeavyTasks();
-    if (!pauseHeavyTasks && (!m_cameraMoving || wasCameraMoving))
-        m_controller.Update();
+    m_controller.UpdateFrameStateLightweight();
+    if (!pauseHeavyTasks && !m_cameraMoving)
+        m_controller.UpdateResourcesIfDirty();
 
     static auto s_lastCameraUpdate = std::chrono::steady_clock::now();
     const auto now = std::chrono::steady_clock::now();
@@ -971,7 +971,7 @@ void Viewer3DPanel::UpdateScene()
     if (ShouldPauseHeavyTasks() || m_cameraMoving)
         return;
 
-    m_controller.Update();
+    m_controller.UpdateResourcesIfDirty();
     if (Viewer2DPanel::Instance())
         Viewer2DPanel::Instance()->UpdateScene();
 }


### PR DESCRIPTION
### Motivation
- Avoid performing expensive scene/resource work every paint frame to keep interaction and rendering responsive.
- Make heavy resource loading/bounds computation triggerable only when necessary by using explicit dirty flags.

### Description
- Split `Viewer3DController::Update()` into `UpdateFrameStateLightweight()` (called every frame) and `UpdateResourcesIfDirty()` (heavy work run conditionally). (files: `viewer3d/viewer3dcontroller.h/.cpp`)
- Added explicit dirty flags: `m_sceneChangedDirty`, `m_assetsChangedDirty`, and `m_visibilityChangedDirty`, and set them when scene signature, base path, cache changes, or visibility changes occur. (file: `viewer3d/viewer3dcontroller.h`)
- Changed `Viewer3DPanel::OnPaint` to call the lightweight per-frame path each frame and only call the heavy `UpdateResourcesIfDirty()` when not pausing heavy tasks and the camera is not moving; `UpdateScene()` now invokes the heavy path directly when appropriate. (file: `viewer3d/viewer3dpanel.cpp`)
- Trigger a deferred heavy refresh when interaction ends by invoking `UpdateResourcesIfDirty()` from `SetInteracting(false)`. (file: `viewer3d/viewer3dcontroller.cpp`)

### Testing
- Ran `cmake -S . -B build` to validate project configuration, which failed in this environment due to missing `wxWidgets` development dependencies (configuration failure unrelated to the code changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a34bd16e483249bf0d5035f43ffa2)