### PR TITLE
Cache resolved model/GDTF paths and avoid recursive lookups per frame

### DIFF
--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -270,6 +270,17 @@ private:
   // Cache of local-space model bounds keyed by resolved source path.
   std::unordered_map<std::string, BoundingBox> m_modelBounds;
 
+  struct PathResolutionEntry {
+    std::string resolvedPath;
+    bool attempted = false;
+  };
+
+  // Cached path resolution for raw GDTF specs and model references.
+  // When attempted=true and resolvedPath is empty, the lookup failed and we
+  // skip re-trying on every frame.
+  std::unordered_map<std::string, PathResolutionEntry> m_resolvedGdtfSpecs;
+  std::unordered_map<std::string, PathResolutionEntry> m_resolvedModelRefs;
+
   // Scene versioning used to skip expensive bounds recomputation when only
   // the camera changes.
   size_t m_sceneVersion = 0;


### PR DESCRIPTION
### Motivation
- Prevent expensive `std::filesystem::recursive_directory_iterator` traversals on every render/frame by resolving ambiguous asset references once when the scene is dirty. 
- Avoid repeated work by storing both successful and failed resolutions (negative caching) so failed lookups are not retried every frame.
- Improve frame-time predictability by ensuring the render/path/bounds code uses only previously resolved paths.

### Description
- Added `PathResolutionEntry` and per-controller caches `m_resolvedGdtfSpecs` and `m_resolvedModelRefs` to store `resolvedPath` + `attempted` flags in `Viewer3DController`.
- Extended `ResolveGdtfPath` and `ResolveModelPath` with an `allowRecursiveSearch` parameter and added `ResolveCacheKey` helper; recursive filename search is only performed when `allowRecursiveSearch=true`.
- Moved recursive/expensive resolution into `UpdateResourcesIfDirty()` where the code now walks the scene and populates the resolution caches (including negative results), and clears those caches when the scene base path changes.
- Updated bounds/precompute and render code paths (`EnsureBoundsComputed`, `RenderScene`, mesh/GDTF load loops) to read resolved paths from the caches and skip on-the-fly resolution, using cached empty results when a previous attempt failed.

### Testing
- Ran source verification commands (searches/edits) to confirm resolution call sites were updated and caches are used instead of per-frame lookups; these checks completed successfully.
- Attempted a full local configure/build with `cmake -S . -B build && cmake --build build -j2`, which failed during CMake configuration due to missing system development dependency `wxWidgets` in this environment (no build artifacts produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b888fe5cc832483c67190807b59a0)