### PR TITLE
Evita doble ejecución de UpdateResourcesIfDirty por frame

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1279,12 +1279,19 @@ void Viewer3DController::UpdateFrameStateLightweight() {
   const auto hiddenLayers = SnapshotHiddenLayers(cfg);
   if (hiddenLayers != m_lastHiddenLayers)
     m_visibilityChangedDirty = true;
+}
 
-  if (!m_isInteracting)
-    UpdateResourcesIfDirty();
+void Viewer3DController::ResetDebugPerFrameCounters() {
+  m_updateResourcesCallsPerFrame = 0;
+}
+
+int Viewer3DController::GetDebugUpdateResourcesCallsPerFrame() const {
+  return m_updateResourcesCallsPerFrame;
 }
 
 void Viewer3DController::UpdateResourcesIfDirty() {
+  ++m_updateResourcesCallsPerFrame;
+
   ConfigManager &cfg = ConfigManager::Get();
   const auto hiddenLayers = SnapshotHiddenLayers(cfg);
   const std::string &base = cfg.GetScene().basePath;

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -73,6 +73,8 @@ public:
   void Update();
   void UpdateResourcesIfDirty();
   void UpdateFrameStateLightweight();
+  void ResetDebugPerFrameCounters();
+  int GetDebugUpdateResourcesCallsPerFrame() const;
 
   // Renders all scene objects. When wireframe is true lighting is disabled
   // and geometry is drawn using black lines only. The optional mode controls
@@ -345,6 +347,7 @@ private:
   bool m_cameraMoving = false;
   bool m_useAdaptiveLineProfile = true;
   bool m_skipOutlinesForCurrentFrame = false;
+  int m_updateResourcesCallsPerFrame = 0;
 
   enum class ItemType { Fixture, Truss, SceneObject };
   struct VisibleSet {

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -251,9 +251,18 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
     InitGL();
 
     const bool pauseHeavyTasks = ShouldPauseHeavyTasks();
+    m_controller.ResetDebugPerFrameCounters();
     m_controller.UpdateFrameStateLightweight();
     if (!pauseHeavyTasks && !m_cameraMoving)
         m_controller.UpdateResourcesIfDirty();
+
+    const int updateResourcesCallsPerFrame =
+        m_controller.GetDebugUpdateResourcesCallsPerFrame();
+    if (updateResourcesCallsPerFrame > 1) {
+        wxLogTrace("viewer3d_perf",
+                   "UpdateResourcesIfDirty called %d times in a frame",
+                   updateResourcesCallsPerFrame);
+    }
 
     static auto s_lastCameraUpdate = std::chrono::steady_clock::now();
     const auto now = std::chrono::steady_clock::now();


### PR DESCRIPTION
### Motivation
- `OnPaint()` podía provocar dos rutas hacia la carga pesada porque `UpdateFrameStateLightweight()` también llamaba internamente a `UpdateResourcesIfDirty()`, generando trabajo pesado duplicado en el mismo frame y alto consumo CPU en escenas grandes.
- Objetivo: mantener `UpdateFrameStateLightweight()` como una ruta liviana y dejar una sola llamada explícita a la ruta pesada por frame, además de añadir telemetría debug para verificar el comportamiento.

### Description
- Eliminada la invocación pesada desde `Viewer3DController::UpdateFrameStateLightweight()` para que sólo actualice estado liviano (detección de capas ocultas/flags dirty). (modificado `viewer3d/viewer3dcontroller.cpp`).
- Añadido contador por frame `m_updateResourcesCallsPerFrame` con API `ResetDebugPerFrameCounters()` y `GetDebugUpdateResourcesCallsPerFrame()` para reset y lectura (cabecera `viewer3d/viewer3dcontroller.h` y definición en `viewer3d/viewer3dcontroller.cpp`).
- Incremento del contador al inicio de `UpdateResourcesIfDirty()` y reset al comienzo de `OnPaint()`, dejando la única llamada pesada desde `Viewer3DPanel::OnPaint()` cuando no están pausadas las tareas (modificado `viewer3d/viewer3dpanel.cpp`).
- Añadida traza debug con `wxLogTrace("viewer3d_perf", ...)` en `OnPaint()` cuando se detectan más de una llamada pesada por frame para facilitar la verificación en ejecución.

### Testing
- Intenté configurar la build con `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` como prueba automatizada de integración, pero la configuración falló debido a la dependencia ausente `wxWidgets` (`wxWidgets_LIBRARIES` / `wxWidgets_INCLUDE_DIRS`), por lo que no se pudo completar una compilación automática en este entorno.
- No se ejecutaron tests unitarios automatizados porque la compilación no pudo completarse en el entorno de integración actual por la dependencia faltante.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b8d4997b88324bf23f6a39e0b2564)