### PR TITLE
Fix layer visibility synchronization in 2D/3D viewers

### DIFF
--- a/gui/layerpanel.cpp
+++ b/gui/layerpanel.cpp
@@ -146,7 +146,9 @@ void LayerPanel::ReloadLayers()
 
 void LayerPanel::OnCheck(wxDataViewEvent& evt)
 {
-    unsigned int idx = list->ItemToRow(evt.GetItem());
+    int idx = static_cast<int>(list->ItemToRow(evt.GetItem()));
+    if (idx == wxNOT_FOUND || idx < 0 || idx >= static_cast<int>(list->GetItemCount()))
+        return;
     wxString wname = list->GetTextValue(idx,1);
     std::string name = wname.ToStdString();
     wxVariant v;
@@ -159,9 +161,9 @@ void LayerPanel::OnCheck(wxDataViewEvent& evt)
         hidden.insert(name);
     ConfigManager::Get().SetHiddenLayers(hidden);
     if (Viewer3DPanel::Instance())
-        Viewer3DPanel::Instance()->Refresh();
+        Viewer3DPanel::Instance()->UpdateScene();
     if (Viewer2DPanel::Instance())
-        Viewer2DPanel::Instance()->Refresh();
+        Viewer2DPanel::Instance()->UpdateScene(true);
 }
 
 void LayerPanel::OnSelect(wxDataViewEvent& evt)


### PR DESCRIPTION
### Motivation
- Layer visibility toggles were only triggering repaints, which could leave cached visible sets stale and cause the Layers panel state to diverge from what the 2D/3D viewers render.

### Description
- Add a safety check in `LayerPanel::OnCheck` to ignore invalid list rows before reading values, preventing out-of-range access in the layers list (`gui/layerpanel.cpp`).
- Replace calls to `Refresh()` with `Viewer3DPanel::UpdateScene()` and `Viewer2DPanel::UpdateScene(true)` so viewers recompute scene/visibility state (not just repaint) after a layer visibility change.

### Testing
- Attempted to configure the project with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`, but configuration failed due to missing `wxWidgets` development libraries in the environment (configuration failed).
- No automated unit tests were executed; changes were validated by code inspection and a compile/configure attempt limited by the missing GUI dependency.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b8efcde688324b55c502423766f76)