### PR TITLE
Fix 2D viewer layer visibility sync by refreshing controller resources before render

### DIFF
--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -556,6 +556,12 @@ void Viewer2DPanel::RenderInternal(bool swapBuffers) {
   }
 
   ConfigManager &cfg = ConfigManager::Get();
+  // Keep controller resources/cache in sync in the 2D viewer as well.
+  // The 3D panel triggers this from its own render loop, but the 2D panel
+  // renders directly through the shared controller and otherwise misses
+  // scene/layer visibility refreshes.
+  if (!pauseHeavyTasks)
+    m_controller.UpdateResourcesIfDirty();
   bool darkMode = cfg.GetFloat("view2d_dark_mode") != 0.0f;
   m_controller.SetDarkMode(darkMode);
   if (darkMode)


### PR DESCRIPTION
### Motivation
- The 2D viewer was rendering stale layer/scene visibility because it did not refresh the shared controller's resources/caches before drawing, causing the Layers panel state to differ from what is shown on-screen.

### Description
- Added a guarded call to `m_controller.UpdateResourcesIfDirty()` in `Viewer2DPanel::RenderInternal` so the 2D render path refreshes controller resources/caches when heavy tasks are not paused, with a short comment explaining why this is necessary.

### Testing
- Ran `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` to validate configuration; configure failed due to missing `wxWidgets` development dependencies in the environment (no build performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b915f048c8324b1f6f2388600e786)