### PR TITLE
Corregir tracking de capas ocultas para evitar `m_visibilityChangedDirty` recurrente

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1277,8 +1277,10 @@ void Viewer3DController::Update() {
 void Viewer3DController::UpdateFrameStateLightweight() {
   ConfigManager &cfg = ConfigManager::Get();
   const auto hiddenLayers = SnapshotHiddenLayers(cfg);
-  if (hiddenLayers != m_lastHiddenLayers)
+  if (hiddenLayers != m_lastHiddenLayers) {
+    Logger::Instance().Log("visibility dirty reason: hidden layers changed vs last frame snapshot");
     m_visibilityChangedDirty = true;
+  }
 }
 
 void Viewer3DController::ResetDebugPerFrameCounters() {
@@ -1538,8 +1540,10 @@ void Viewer3DController::UpdateResourcesIfDirty() {
     }
   }
 
-  if (hiddenLayers != m_boundsHiddenLayers)
+  if (hiddenLayers != m_boundsHiddenLayers) {
+    Logger::Instance().Log("visibility dirty reason: hidden layers changed vs bounds cache");
     m_visibilityChangedDirty = true;
+  }
 
   if (!(m_sceneChangedDirty || m_assetsChangedDirty || m_visibilityChangedDirty) &&
       m_cachedVersion == m_sceneVersion)
@@ -1871,6 +1875,7 @@ void Viewer3DController::UpdateResourcesIfDirty() {
   m_sceneChangedDirty = false;
   m_assetsChangedDirty = false;
   m_visibilityChangedDirty = false;
+  m_lastHiddenLayers = hiddenLayers;
 }
 
 


### PR DESCRIPTION
### Motivation
- Evitar que la comparación de capas ocultas provoque invalidaciones de visibilidad cada frame cuando no hubo cambio real en las capas.
- Sincronizar el snapshot procesado de capas (`m_lastHiddenLayers`) tras el ciclo de actualización para que las siguientes comprobaciones comparen contra el estado ya procesado.
- Añadir trazas temporales para identificar la razón por la que se marca `m_visibilityChangedDirty` durante la verificación.

### Description
- En `UpdateFrameStateLightweight()` se mantiene la comprobación `hiddenLayers != m_lastHiddenLayers` y ahora se registra un `Logger::Instance().Log("visibility dirty reason: hidden layers changed vs last frame snapshot")` antes de setear `m_visibilityChangedDirty`.
- En `UpdateResourcesIfDirty()` la comprobación `hiddenLayers != m_boundsHiddenLayers` también registra `Logger::Instance().Log("visibility dirty reason: hidden layers changed vs bounds cache")` antes de marcar `m_visibilityChangedDirty`.
- Al final de `UpdateResourcesIfDirty()` se asigna `m_lastHiddenLayers = hiddenLayers` para sincronizar el estado procesado y evitar reprocesos innecesarios en frames siguientes.
- Cambios aplicados en `viewer3d/viewer3dcontroller.cpp` y commit realizado con el mensaje `Fix visibility dirty tracking for hidden layers`.

### Testing
- Intento de configuración local con `cmake -S . -B build` falló en este entorno por dependencias faltantes de `wxWidgets` (error esperado en CI/laptop sin dev packages), por lo que no se compiló aquí.
- Verificación de cambios en el árbol y commit exitoso (`git status` y `git commit`), y se agregó el logging temporal para depuración manual en ejecución; sin compilación automatizada local por la razón anterior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b940cfcf0832489936ce92beb3607)