### PR TITLE
Split visible-set caching into layer and frustum phases

### DIFF
--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -383,8 +383,8 @@ private:
   mutable VisibleSet m_cachedLayerVisibleCandidates;
   mutable size_t m_layerVisibleCandidatesSceneVersion = static_cast<size_t>(-1);
   mutable std::unordered_set<std::string> m_layerVisibleCandidatesHiddenLayers;
-  mutable size_t m_visibleSetSceneVersion = static_cast<size_t>(-1);
-  mutable std::unordered_set<std::string> m_visibleSetHiddenLayers;
+  mutable size_t m_layerVisibleCandidatesRevision = 0;
+  mutable size_t m_visibleSetLayerCandidatesRevision = static_cast<size_t>(-1);
   mutable bool m_visibleSetFrustumCulling = false;
   mutable float m_visibleSetMinPixels = -1.0f;
   mutable std::array<int, 4> m_visibleSetViewport = {0, 0, 0, 0};


### PR DESCRIPTION
### Motivation
- Camera movement was causing the entire visibility cache to be invalidated because the cache mixed camera-dependent state (frustum/model/projection) with scene/layer-dependent state, forcing expensive layer filtering on every camera update.

### Description
- Introduced a separate revision counter `m_layerVisibleCandidatesRevision` and a tracking field `m_visibleSetLayerCandidatesRevision` to decouple the layer-candidates cache from the frustum-visible cache and only advance the revision when layer candidates are rebuilt.
- Moved the `TryBuildLayerVisibleCandidates` check to run before frustum comparisons and increment the layer-candidates revision when it is rebuilt, and updated the frustum cache validity to depend on the layer-candidates revision instead of scene/layer keys directly.
- Kept `TryBuildVisibleSet` behaviour unchanged so frustum culling iterates only over the already-filtered layer candidates (`m_cachedLayerVisibleCandidates`) rather than the full scene map.
- Modified files: `viewer3d/viewer3dcontroller.h` and `viewer3d/viewer3dcontroller.cpp` to add revision fields and update `GetVisibleSet` logic.

### Testing
- Ran a local configure attempt with `cmake -S . -B build`, which failed in this environment due to missing system dependency `wxWidgets` so a full build/test run could not be executed.
- Changes were committed (`Split visible set cache into layer and frustum phases`) and a PR description was prepared; no automated unit tests were executed in this container due to the missing dependency.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b98823c248324965b5061b64f9112)