### PR TITLE
Optimize 3D viewer during camera motion and skip hidden-layer processing

### DIFF
--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -285,7 +285,8 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
 
     const bool skipLabelsWhenMoving =
         ConfigManager::Get().GetFloat("viewer3d_skip_labels_when_moving") >= 0.5f;
-    const bool skipLabelWork = m_cameraMoving && IsFastInteractionModeEnabled() && skipLabelsWhenMoving;
+    const bool skipLabelWork = m_cameraMoving &&
+        (IsFastInteractionModeEnabled() || skipLabelsWhenMoving);
 
     if (!skipLabelWork && FixtureTablePanel::Instance() && FixtureTablePanel::Instance()->IsActivePage()) {
         found = m_controller.GetFixtureLabelAt(m_lastMousePos.x, m_lastMousePos.y,
@@ -331,7 +332,7 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
         else if (SceneObjectTablePanel::Instance() && SceneObjectTablePanel::Instance()->IsActivePage())
             SceneObjectTablePanel::Instance()->HighlightObject(std::string(m_hoverUuid));
     }
-    else if (!m_hasHover || m_mouseMoved) {
+    else if (!skipLabelWork && (!m_hasHover || m_mouseMoved)) {
         m_hasHover = false;
         m_controller.SetHighlightUuid("");
         if (FixtureTablePanel::Instance())
@@ -340,6 +341,11 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
             TrussTablePanel::Instance()->HighlightTruss(std::string());
         if (SceneObjectTablePanel::Instance())
             SceneObjectTablePanel::Instance()->HighlightObject(std::string());
+    } else if (skipLabelWork) {
+        m_hasHover = false;
+        m_hoverUuid.clear();
+        m_hoverText.clear();
+        m_controller.SetHighlightUuid("");
     }
     m_mouseMoved = false;
 


### PR DESCRIPTION
### Motivation
- Large scenes cause the 3D viewer to do excessive per-frame work (label lookups, table highlight updates, model/GDTF resolution and loads), slowing interaction. 
- While the user is moving the camera those expensive ops should be deferred to keep interaction smooth. 
- Items in hidden/disabled layers (layouts) must not be processed because they do not affect the visible scene.

### Description
- Skip per-frame label/hover lookups and related table highlight updates while the camera is moving by tightening the `skipLabelWork` logic in `Viewer3DPanel::OnPaint` (`viewer3d/viewer3dpanel.cpp`) and add an explicit hover reset when label work is skipped. 
- Restrict work in `Viewer3DController::UpdateResourcesIfDirty` (`viewer3d/viewer3dcontroller.cpp`) to only the elements on visible layers by building `visibleTrusses`, `visibleObjects` and `visibleFixtures` lists and iterating those for path resolution, mesh loading, GDTF loading and error counting instead of iterating the entire scene containers. 
- Preserve the existing scene signature invalidation semantics while moving heavy work to the filtered visible subsets so caches still invalidate correctly when content changes.

### Testing
- Attempted an automated build with `cmake -S . -B build && cmake --build build`, but configuration failed due to missing `wxWidgets` development libraries (`wxWidgets_LIBRARIES` / `wxWidgets_INCLUDE_DIRS`), so a full compile/test could not be performed in this environment. 
- No other automated tests were run in this environment; changes were validated by code inspection and local compile attempt only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ba5ff4be8832490f9fddfa4a55fe6)