### PR TITLE
Fix 3D double-click reliability and apply interaction hover-skip optimization to 2D

### DIFF
--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -761,8 +761,10 @@ void Viewer2DPanel::OnPaint(wxPaintEvent &WXUNUSED(event)) {
   wxPoint newPos;
   std::string newUuid;
   bool found = false;
+  const bool skipLabelWork =
+      wasInteracting && (m_dragMode == DragMode::View || m_dragMode == DragMode::None);
 
-  if (FixtureTablePanel::Instance() &&
+  if (!skipLabelWork && FixtureTablePanel::Instance() &&
       FixtureTablePanel::Instance()->IsActivePage()) {
     found = m_controller.GetFixtureLabelAt(m_lastMousePos.x, m_lastMousePos.y,
                                            w, h, newLabel, newPos, &newUuid);
@@ -772,7 +774,7 @@ void Viewer2DPanel::OnPaint(wxPaintEvent &WXUNUSED(event)) {
       if (SceneObjectTablePanel::Instance())
         SceneObjectTablePanel::Instance()->HighlightObject(std::string());
     }
-  } else if (TrussTablePanel::Instance() &&
+  } else if (!skipLabelWork && TrussTablePanel::Instance() &&
              TrussTablePanel::Instance()->IsActivePage()) {
     found = m_controller.GetTrussLabelAt(m_lastMousePos.x, m_lastMousePos.y, w,
                                          h, newLabel, newPos, &newUuid);
@@ -782,7 +784,7 @@ void Viewer2DPanel::OnPaint(wxPaintEvent &WXUNUSED(event)) {
       if (SceneObjectTablePanel::Instance())
         SceneObjectTablePanel::Instance()->HighlightObject(std::string());
     }
-  } else if (SceneObjectTablePanel::Instance() &&
+  } else if (!skipLabelWork && SceneObjectTablePanel::Instance() &&
              SceneObjectTablePanel::Instance()->IsActivePage()) {
     found = m_controller.GetSceneObjectLabelAt(m_lastMousePos.x,
                                                m_lastMousePos.y, w, h, newLabel,
@@ -810,7 +812,7 @@ void Viewer2DPanel::OnPaint(wxPaintEvent &WXUNUSED(event)) {
     else if (SceneObjectTablePanel::Instance() &&
              SceneObjectTablePanel::Instance()->IsActivePage())
       SceneObjectTablePanel::Instance()->HighlightObject(std::string(m_hoverUuid));
-  } else if (!m_hasHover || m_mouseMoved) {
+  } else if (!skipLabelWork && (!m_hasHover || m_mouseMoved)) {
     highlightChanged = m_hasHover;
     m_hasHover = false;
     m_hoverUuid.clear();
@@ -821,6 +823,11 @@ void Viewer2DPanel::OnPaint(wxPaintEvent &WXUNUSED(event)) {
       TrussTablePanel::Instance()->HighlightTruss(std::string());
     if (SceneObjectTablePanel::Instance())
       SceneObjectTablePanel::Instance()->HighlightObject(std::string());
+  } else if (skipLabelWork) {
+    highlightChanged = m_hasHover;
+    m_hasHover = false;
+    m_hoverUuid.clear();
+    m_controller.SetHighlightUuid("");
   }
   m_mouseMoved = false;
 

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -875,7 +875,20 @@ void Viewer3DPanel::OnMouseDClick(wxMouseEvent& event)
     wxString label;
     wxPoint pos;
     std::string uuid;
-    if (!m_controller.GetFixtureLabelAt(event.GetX(), event.GetY(), w, h, label, pos, &uuid))
+    const bool cameraWasMoving = m_cameraMoving;
+    if (cameraWasMoving)
+        m_controller.SetCameraMoving(false);
+
+    const bool found =
+        m_controller.GetFixtureLabelAt(event.GetX(), event.GetY(), w, h, label,
+                                       pos, &uuid);
+
+    if (cameraWasMoving)
+        m_controller.SetCameraMoving(true);
+
+    if (!found && !m_hoverUuid.empty())
+        uuid = m_hoverUuid;
+    if (uuid.empty())
         return;
 
     auto& scene = ConfigManager::Get().GetScene();


### PR DESCRIPTION
### Motivation

- El doble click sobre un fixture en la vista 3D a veces no abría el popup de edición porque el pick estaba bloqueado por la bandera de `cameraMoving` usada para optimizaciones de interacción.  
- Se quería extender la misma estrategia de reducir trabajo por frame durante interacción (saltar hit-tests/labels) que funcionó en 3D también a la vista 2D.

### Description

- En `Viewer3DPanel::OnMouseDClick` se desactiva temporalmente `cameraMoving` en el controlador durante el hit-test explícito del doble click y se restaura después, para evitar que el modo rápido impida la detección del fixture.  
- Se añadió un fallback que usa `m_hoverUuid` cuando el hit-test directo no devuelve fixture válido, mejorando la robustez del doble click.  
- En `Viewer2DPanel::OnPaint` se añade un `skipLabelWork` condicionado al estado de interacción para saltarse la comprobación de labels/hovers durante paneo/zoom y se limpia explícitamente el estado de hover/highlight cuando se opta por saltarlo.

### Testing

- Se ejecutó la comprobación estática `git diff --check` y se confirmó que no hay problemas reportados.  
- Se aplicaron y registraron los cambios con `git commit` (commit creado), no se ejecutaron compilaciones o suites de tests automatizados en este PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698baff3a8d88324a5c4b4858a4dba51)