### PR TITLE
Añadir componente `wx::xml` a wxWidgets en todas las plataformas y ajustar orden de enlace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 
 # Find required packages
 if(WIN32)
-    find_package(wxWidgets CONFIG REQUIRED COMPONENTS core base aui gl html richtext)
+    find_package(wxWidgets CONFIG REQUIRED COMPONENTS core base aui gl html richtext xml)
     set(_wx_libs
         wx::core
         wx::base
@@ -45,10 +45,13 @@ if(WIN32)
         wx::html
         wx::richtext
     )
+    if(TARGET wx::xml)
+        list(APPEND _wx_libs wx::xml)
+    endif()
     set(_wx_includes "")
     find_package(tinyxml2 CONFIG REQUIRED)
 else()
-    find_package(wxWidgets REQUIRED COMPONENTS core base aui gl html richtext)
+    find_package(wxWidgets REQUIRED COMPONENTS core base aui gl html richtext xml)
     include(${wxWidgets_USE_FILE})
     set(_wx_libs ${wxWidgets_LIBRARIES})
     set(_wx_includes ${wxWidgets_INCLUDE_DIRS})
@@ -149,7 +152,6 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 
 # Link required libraries
 target_link_libraries(${PROJECT_NAME} PRIVATE
-    ${_wx_libs}
     tinyxml2::tinyxml2
     OpenGL::GL
     OpenGL::GLU
@@ -158,6 +160,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     nanovg::nanovg
     podofo::podofo
     ZLIB::ZLIB
+    ${_wx_libs}
 )
 
 


### PR DESCRIPTION
### Motivation
- Resolver errores de símbolos indefinidos relacionados con `wxXmlDocument`/`wxXmlNode` añadiendo el componente XML de wxWidgets a la detección de paquetes. 
- Mantener paridad entre Windows (modo `CONFIG`) y no-Windows para que el componente `xml` esté siempre solicitado por `find_package(wxWidgets ...)`. 
- Mitigar problemas de orden de enlace en enlaces estáticos asegurando que las bibliotecas de wxWidgets se pasen al final de `target_link_libraries`. 

### Description
- En la rama `WIN32` de `CMakeLists.txt` se añadió `xml` a `find_package(wxWidgets CONFIG REQUIRED COMPONENTS ...)`. 
- En la rama no-Windows se añadió `xml` a `find_package(wxWidgets REQUIRED COMPONENTS ...)` y se mantiene la inclusión de `wxWidgets_USE_FILE`. 
- Se agregó un bloque condicional `if(TARGET wx::xml) list(APPEND _wx_libs wx::xml) endif()` para añadir `wx::xml` al listado explícito `_wx_libs` en Windows cuando el target existe. 
- Se movió `${_wx_libs}` al final de `target_link_libraries(${PROJECT_NAME} PRIVATE ...)` para mejorar la resolución de símbolos en enlace estático. 

### Testing
- Ejecuté `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` para regenerar desde cero, y la configuración falló por ausencia de las librerías de desarrollo de wxWidgets (`wxWidgets_LIBRARIES` / `wxWidgets_INCLUDE_DIRS` faltantes). 
- No fue posible completar la compilación/enlace en este entorno debido a la falta de dependencias del sistema, por lo que no se ejecutaron pruebas de enlace o binarios compilados automatizados.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c737278488324a4180bb09121075c)