### PR TITLE
Refactor Viewer3DController into SceneRenderer / VisibilitySystem / SelectionSystem

### DIFF
--- a/viewer3d/culling/visibilitysystem.cpp
+++ b/viewer3d/culling/visibilitysystem.cpp
@@ -1,0 +1,21 @@
+#include "visibilitysystem.h"
+
+bool VisibilitySystem::EnsureBoundsComputed(
+    const std::string &uuid, Viewer3DController::ItemType type,
+    const std::unordered_set<std::string> &hiddenLayers) {
+  return m_controller.EnsureBoundsComputedImpl(uuid, type, hiddenLayers);
+}
+
+bool VisibilitySystem::TryBuildVisibleSet(
+    const Viewer3DController::ViewFrustumSnapshot &frustum,
+    bool useFrustumCulling, float minPixels,
+    const Viewer3DController::VisibleSet &layerVisibleCandidates,
+    Viewer3DController::VisibleSet &out) const {
+  return m_controller.TryBuildVisibleSetImpl(frustum, useFrustumCulling,
+                                             minPixels, layerVisibleCandidates,
+                                             out);
+}
+
+void VisibilitySystem::RebuildVisibleSetCache() {
+  m_controller.RebuildVisibleSetCacheImpl();
+}

--- a/viewer3d/culling/visibilitysystem.h
+++ b/viewer3d/culling/visibilitysystem.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "../viewer3dcontroller.h"
+
+class VisibilitySystem {
+public:
+  explicit VisibilitySystem(Viewer3DController &controller) : m_controller(controller) {}
+
+  bool EnsureBoundsComputed(const std::string &uuid, Viewer3DController::ItemType type,
+                            const std::unordered_set<std::string> &hiddenLayers);
+  bool TryBuildVisibleSet(const Viewer3DController::ViewFrustumSnapshot &frustum,
+                          bool useFrustumCulling, float minPixels,
+                          const Viewer3DController::VisibleSet &layerVisibleCandidates,
+                          Viewer3DController::VisibleSet &out) const;
+  void RebuildVisibleSetCache();
+
+private:
+  Viewer3DController &m_controller;
+};

--- a/viewer3d/picking/selectionsystem.cpp
+++ b/viewer3d/picking/selectionsystem.cpp
@@ -1,0 +1,51 @@
+#include "selectionsystem.h"
+
+void SelectionSystem::SetHighlightUuid(const std::string &uuid) {
+  m_controller.SetHighlightUuidImpl(uuid);
+}
+
+void SelectionSystem::SetSelectedUuids(const std::vector<std::string> &uuids) {
+  m_controller.SetSelectedUuidsImpl(uuids);
+}
+
+bool SelectionSystem::GetFixtureLabelAt(int mouseX, int mouseY, int width,
+                                        int height, wxString &outLabel,
+                                        wxPoint &outPos,
+                                        std::string *outUuid) {
+  return m_controller.GetFixtureLabelAtImpl(mouseX, mouseY, width, height,
+                                            outLabel, outPos, outUuid);
+}
+
+bool SelectionSystem::GetTrussLabelAt(int mouseX, int mouseY, int width,
+                                      int height, wxString &outLabel,
+                                      wxPoint &outPos,
+                                      std::string *outUuid) {
+  return m_controller.GetTrussLabelAtImpl(mouseX, mouseY, width, height,
+                                          outLabel, outPos, outUuid);
+}
+
+bool SelectionSystem::GetSceneObjectLabelAt(int mouseX, int mouseY, int width,
+                                            int height, wxString &outLabel,
+                                            wxPoint &outPos,
+                                            std::string *outUuid) {
+  return m_controller.GetSceneObjectLabelAtImpl(mouseX, mouseY, width, height,
+                                                outLabel, outPos, outUuid);
+}
+
+std::vector<std::string> SelectionSystem::GetFixturesInScreenRect(
+    int x1, int y1, int x2, int y2, int width, int height) const {
+  return m_controller.GetFixturesInScreenRectImpl(x1, y1, x2, y2, width,
+                                                  height);
+}
+
+std::vector<std::string> SelectionSystem::GetTrussesInScreenRect(
+    int x1, int y1, int x2, int y2, int width, int height) const {
+  return m_controller.GetTrussesInScreenRectImpl(x1, y1, x2, y2, width,
+                                                 height);
+}
+
+std::vector<std::string> SelectionSystem::GetSceneObjectsInScreenRect(
+    int x1, int y1, int x2, int y2, int width, int height) const {
+  return m_controller.GetSceneObjectsInScreenRectImpl(x1, y1, x2, y2, width,
+                                                      height);
+}

--- a/viewer3d/picking/selectionsystem.h
+++ b/viewer3d/picking/selectionsystem.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "../viewer3dcontroller.h"
+
+class SelectionSystem {
+public:
+  explicit SelectionSystem(Viewer3DController &controller) : m_controller(controller) {}
+
+  void SetHighlightUuid(const std::string &uuid);
+  void SetSelectedUuids(const std::vector<std::string> &uuids);
+  bool GetFixtureLabelAt(int mouseX, int mouseY, int width, int height,
+                         wxString &outLabel, wxPoint &outPos,
+                         std::string *outUuid = nullptr);
+  bool GetTrussLabelAt(int mouseX, int mouseY, int width, int height,
+                       wxString &outLabel, wxPoint &outPos,
+                       std::string *outUuid = nullptr);
+  bool GetSceneObjectLabelAt(int mouseX, int mouseY, int width, int height,
+                             wxString &outLabel, wxPoint &outPos,
+                             std::string *outUuid = nullptr);
+  std::vector<std::string> GetFixturesInScreenRect(int x1, int y1, int x2,
+                                                   int y2, int width,
+                                                   int height) const;
+  std::vector<std::string> GetTrussesInScreenRect(int x1, int y1, int x2,
+                                                  int y2, int width,
+                                                  int height) const;
+  std::vector<std::string> GetSceneObjectsInScreenRect(int x1, int y1,
+                                                       int x2, int y2,
+                                                       int width,
+                                                       int height) const;
+
+private:
+  Viewer3DController &m_controller;
+};

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -1,0 +1,30 @@
+#include "scenerenderer.h"
+
+void SceneRenderer::DrawMeshWithOutline(
+    const Mesh &mesh, float r, float g, float b, float scale, bool highlight,
+    bool selected, float cx, float cy, float cz, bool wireframe,
+    Viewer2DRenderMode mode,
+    const std::function<std::array<float, 3>(const std::array<float, 3> &)> &captureTransform,
+    bool unlit, const float *modelMatrix) {
+  m_controller.DrawMeshWithOutlineImpl(mesh, r, g, b, scale, highlight, selected,
+                                       cx, cy, cz, wireframe, mode,
+                                       captureTransform, unlit, modelMatrix);
+}
+
+void SceneRenderer::DrawMeshWireframe(
+    const Mesh &mesh, float scale,
+    const std::function<std::array<float, 3>(const std::array<float, 3> &)> &captureTransform) {
+  m_controller.DrawMeshWireframeImpl(mesh, scale, captureTransform);
+}
+
+void SceneRenderer::DrawMesh(const Mesh &mesh, float scale, const float *modelMatrix) {
+  m_controller.DrawMeshImpl(mesh, scale, modelMatrix);
+}
+
+void SceneRenderer::DrawGrid(int style, float r, float g, float b, Viewer2DView view) {
+  m_controller.DrawGridImpl(style, r, g, b, view);
+}
+
+void SceneRenderer::SetupMaterialFromRGB(float r, float g, float b) {
+  m_controller.SetupMaterialFromRGBImpl(r, g, b);
+}

--- a/viewer3d/render/scenerenderer.h
+++ b/viewer3d/render/scenerenderer.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "../viewer3dcontroller.h"
+
+class SceneRenderer {
+public:
+  explicit SceneRenderer(Viewer3DController &controller) : m_controller(controller) {}
+
+  void DrawMeshWithOutline(
+      const Mesh &mesh, float r, float g, float b, float scale, bool highlight,
+      bool selected, float cx, float cy, float cz, bool wireframe,
+      Viewer2DRenderMode mode,
+      const std::function<std::array<float, 3>(const std::array<float, 3> &)> &captureTransform,
+      bool unlit, const float *modelMatrix);
+  void DrawMeshWireframe(
+      const Mesh &mesh, float scale,
+      const std::function<std::array<float, 3>(const std::array<float, 3> &)> &captureTransform);
+  void DrawMesh(const Mesh &mesh, float scale, const float *modelMatrix);
+  void DrawGrid(int style, float r, float g, float b, Viewer2DView view);
+  void SetupMaterialFromRGB(float r, float g, float b);
+
+private:
+  Viewer3DController &m_controller;
+};


### PR DESCRIPTION
### Motivation
- Modularize `viewer3d/` by splitting rendering, culling and picking responsibilities into separate subsystems to improve maintainability and prepare for further refactors.
- Move low-level drawing and material helpers out of the controller and isolate visibility and selection logic to make `Viewer3DController` an orchestrator by composition.
- Preserve the existing public API so callers (e.g. `viewer3dpanel.cpp`) keep working in the short term while the internal structure evolves.

### Description
- Added new submodules and files: `viewer3d/render/SceneRenderer` (`scenerenderer.h/.cpp`), `viewer3d/culling/VisibilitySystem` (`visibilitysystem.h/.cpp`) and `viewer3d/picking/SelectionSystem` (`selectionsystem.h/.cpp`).
- Introduced `*Impl` methods in `Viewer3DController` (e.g. `DrawMeshWithOutlineImpl`, `TryBuildVisibleSetImpl`, `EnsureBoundsComputedImpl`, `Get*LabelAtImpl`, `Get*InScreenRectImpl`, `SetupMaterialFromRGBImpl`) and moved existing implementations there.
- Kept original public methods (e.g. `DrawMeshWithOutline`, `GetFixtureLabelAt`, `RebuildVisibleSetCache`, `GetFixturesInScreenRect`, `SetHighlightUuid`, etc.) as wrappers that delegate to the new subsystem instances (`m_sceneRenderer`, `m_visibilitySystem`, `m_selectionSystem`).
- Wired `Viewer3DController` to compose the new systems with `std::unique_ptr` members and added `friend` declarations so the subsystems can call the `*Impl` functions when needed.

### Testing
- Attempted to configure the project with `cmake -S . -B build`, but configuration failed due to missing system development dependencies: `wxWidgets_LIBRARIES` / `wxWidgets_INCLUDE_DIRS` were not found in this environment (no successful build verification).
- No unit tests were executed in this environment after the refactor because the build could not be configured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ca9826104832497c498065d9f309c)