### PR TITLE
Extract viewer3d shared types and decouple subsystem headers

### DIFF
--- a/viewer3d/culling/visibilitysystem.cpp
+++ b/viewer3d/culling/visibilitysystem.cpp
@@ -1,16 +1,17 @@
 #include "visibilitysystem.h"
+#include "../viewer3dcontroller.h"
 
 bool VisibilitySystem::EnsureBoundsComputed(
-    const std::string &uuid, Viewer3DController::ItemType type,
+    const std::string &uuid, ViewerItemType type,
     const std::unordered_set<std::string> &hiddenLayers) {
   return m_controller.EnsureBoundsComputedImpl(uuid, type, hiddenLayers);
 }
 
 bool VisibilitySystem::TryBuildVisibleSet(
-    const Viewer3DController::ViewFrustumSnapshot &frustum,
+    const ViewerViewFrustumSnapshot &frustum,
     bool useFrustumCulling, float minPixels,
-    const Viewer3DController::VisibleSet &layerVisibleCandidates,
-    Viewer3DController::VisibleSet &out) const {
+    const ViewerVisibleSet &layerVisibleCandidates,
+    ViewerVisibleSet &out) const {
   return m_controller.TryBuildVisibleSetImpl(frustum, useFrustumCulling,
                                              minPixels, layerVisibleCandidates,
                                              out);

--- a/viewer3d/culling/visibilitysystem.h
+++ b/viewer3d/culling/visibilitysystem.h
@@ -1,17 +1,22 @@
 #pragma once
 
-#include "../viewer3dcontroller.h"
+#include "../viewer3d_types.h"
+
+#include <string>
+#include <unordered_set>
+
+class Viewer3DController;
 
 class VisibilitySystem {
 public:
   explicit VisibilitySystem(Viewer3DController &controller) : m_controller(controller) {}
 
-  bool EnsureBoundsComputed(const std::string &uuid, Viewer3DController::ItemType type,
+  bool EnsureBoundsComputed(const std::string &uuid, ViewerItemType type,
                             const std::unordered_set<std::string> &hiddenLayers);
-  bool TryBuildVisibleSet(const Viewer3DController::ViewFrustumSnapshot &frustum,
+  bool TryBuildVisibleSet(const ViewerViewFrustumSnapshot &frustum,
                           bool useFrustumCulling, float minPixels,
-                          const Viewer3DController::VisibleSet &layerVisibleCandidates,
-                          Viewer3DController::VisibleSet &out) const;
+                          const ViewerVisibleSet &layerVisibleCandidates,
+                          ViewerVisibleSet &out) const;
   void RebuildVisibleSetCache();
 
 private:

--- a/viewer3d/picking/selectionsystem.cpp
+++ b/viewer3d/picking/selectionsystem.cpp
@@ -1,4 +1,5 @@
 #include "selectionsystem.h"
+#include "../viewer3dcontroller.h"
 
 void SelectionSystem::SetHighlightUuid(const std::string &uuid) {
   m_controller.SetHighlightUuidImpl(uuid);

--- a/viewer3d/picking/selectionsystem.h
+++ b/viewer3d/picking/selectionsystem.h
@@ -1,6 +1,12 @@
 #pragma once
 
-#include "../viewer3dcontroller.h"
+#include <string>
+#include <vector>
+
+#include <wx/gdicmn.h>
+#include <wx/string.h>
+
+class Viewer3DController;
 
 class SelectionSystem {
 public:

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -1,4 +1,5 @@
 #include "scenerenderer.h"
+#include "../viewer3dcontroller.h"
 
 void SceneRenderer::DrawMeshWithOutline(
     const Mesh &mesh, float r, float g, float b, float scale, bool highlight,

--- a/viewer3d/render/scenerenderer.h
+++ b/viewer3d/render/scenerenderer.h
@@ -1,6 +1,9 @@
 #pragma once
 
-#include "../viewer3dcontroller.h"
+#include "../mesh.h"
+#include "../viewer3d_types.h"
+
+class Viewer3DController;
 
 class SceneRenderer {
 public:

--- a/viewer3d/viewer3d_types.h
+++ b/viewer3d/viewer3d_types.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <array>
+#include <string>
+#include <vector>
+
+// MVR coordinates are defined in millimeters. This constant converts
+// them to meters when rendering.
+static constexpr float RENDER_SCALE = 0.001f;
+
+// Rendering options for the simplified 2D top-down view
+enum class Viewer2DRenderMode {
+  Wireframe = 0,
+  White,
+  ByFixtureType,
+  ByLayer
+};
+
+// Available orientations for the 2D viewer
+enum class Viewer2DView {
+  Top = 0,
+  Front,
+  Side,
+  Bottom
+};
+
+enum class ViewerItemType : int { Fixture, Truss, SceneObject };
+
+struct ViewerVisibleSet {
+  std::vector<std::string> fixtureUuids;
+  std::vector<std::string> trussUuids;
+  std::vector<std::string> objectUuids;
+
+  bool Empty() const {
+    return fixtureUuids.empty() && trussUuids.empty() && objectUuids.empty();
+  }
+};
+
+struct ViewerViewFrustumSnapshot {
+  int viewport[4] = {0, 0, 0, 0};
+  double model[16] = {0.0};
+  double projection[16] = {0.0};
+};


### PR DESCRIPTION
### Motivation
- Reduce header coupling between `Viewer3DController` and renderer/visibility/selection subsystems and prepare for migrating `*Impl` logic into dedicated subsystem classes. 
- Centralize small shared viewer types (2D modes, view enums, render scale and visibility structs) so subsystems can depend on a minimal header instead of the full controller header. 

### Description
- Added `viewer3d/viewer3d_types.h` containing `RENDER_SCALE`, `Viewer2DRenderMode`, `Viewer2DView`, `ViewerItemType`, `ViewerVisibleSet`, and `ViewerViewFrustumSnapshot` and moved those definitions out of the controller header. 
- Updated `viewer3d/viewer3dcontroller.h/.cpp` to consume the new shared types and to replace internal `ItemType`/`VisibleSet`/`ViewFrustumSnapshot` usages with the shared `Viewer*` types and signatures. 
- Refactored subsystem headers `viewer3d/render/scenerenderer.h`, `viewer3d/culling/visibilitysystem.h`, and `viewer3d/picking/selectionsystem.h` to avoid including `viewer3dcontroller.h` (they now forward-declare `Viewer3DController` and include only minimal headers such as `viewer3d_types.h`/`mesh.h`/wx types). 
- Updated subsystem implementations (`*.cpp`) to include `viewer3dcontroller.h` and to adapt calls/signatures to the shared types, and wired subsystem facade calls to current `*Impl` controller methods while keeping actual `Impl` logic in the controller (preparation step for later migration). 

### Testing
- Attempted an out-of-tree CMake configure (`cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`) to validate configuration, but it failed due to missing system/development dependencies for `wxWidgets` in the current environment (configuration did not complete).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cbfa6441c8324bedf45a8076b8e84)