### PR TITLE
Introduce Viewer3DController facade and migrate SelectionSystem off friend access

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -958,6 +958,35 @@ void Viewer3DController::SetSelectedUuids(
   m_selectionSystem->SetSelectedUuids(uuids);
 }
 
+void Viewer3DController::ApplyHighlightUuid(const std::string &uuid) {
+  m_highlightUuid = uuid;
+}
+
+void Viewer3DController::ReplaceSelectedUuids(
+    const std::vector<std::string> &uuids) {
+  m_selectedUuids.clear();
+  for (const auto &u : uuids)
+    m_selectedUuids.insert(u);
+}
+
+const Viewer3DController::BoundingBox *
+Viewer3DController::FindFixtureBounds(const std::string &uuid) const {
+  auto it = m_fixtureBounds.find(uuid);
+  return it == m_fixtureBounds.end() ? nullptr : &it->second;
+}
+
+const Viewer3DController::BoundingBox *
+Viewer3DController::FindTrussBounds(const std::string &uuid) const {
+  auto it = m_trussBounds.find(uuid);
+  return it == m_trussBounds.end() ? nullptr : &it->second;
+}
+
+const Viewer3DController::BoundingBox *
+Viewer3DController::FindObjectBounds(const std::string &uuid) const {
+  auto it = m_objectBounds.find(uuid);
+  return it == m_objectBounds.end() ? nullptr : &it->second;
+}
+
 
 bool Viewer3DController::EnsureBoundsComputed(
     const std::string &uuid, ItemType type,


### PR DESCRIPTION
### Motivation
- Reduce coupling by turning `Viewer3DController` into a façade/orchestrator for selection and culling logic instead of exposing internals via `friend` access.
- Make `SelectionSystem` consume a stable, public query API so the subsystem can be migrated out of the controller implementation block safely.

### Description
- Promoted `BoundingBox` to a public type in `Viewer3DController` and added façade methods: `ApplyHighlightUuid`, `ReplaceSelectedUuids`, `FindFixtureBounds`, `FindTrussBounds`, `FindObjectBounds`, and a public `GetVisibleSet` query.
- Removed `friend class SelectionSystem` and implemented the façade helpers in `viewer3d/viewer3dcontroller.cpp`.
- Updated `viewer3d/picking/selectionsystem.cpp` to use the new public APIs and stop directly accessing controller internals (bounds, selected/highlight uuids and camera-moving flag).
- Committed changes that modify `viewer3d/viewer3dcontroller.h`, `viewer3d/viewer3dcontroller.cpp`, and `viewer3d/picking/selectionsystem.cpp`.

### Testing
- Ran the CMake configure step with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`, which failed in this environment due to missing system dependency `wxWidgets` (`wxWidgets_LIBRARIES` and `wxWidgets_INCLUDE_DIRS` not found), so a full build/test could not be completed.
- No other automated tests were available/run in this sandbox; changes were committed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ce7c6a6688324a90f475e7af69a71)