### PR TITLE
Refactor Viewer3D render flow into explicit pipeline phases

### DIFF
--- a/viewer3d/render/render_pipeline.cpp
+++ b/viewer3d/render/render_pipeline.cpp
@@ -1,0 +1,25 @@
+#include "render_pipeline.h"
+
+#include "../viewer3dcontroller.h"
+
+RenderPipeline::RenderPipeline(Viewer3DController &controller)
+    : m_controller(controller) {}
+
+void RenderPipeline::PrepareFrame(const RenderFrameContext &context) {
+  m_context = context;
+  m_visibleSet = &m_controller.PrepareRenderFrame(m_context, m_frustum);
+}
+
+void RenderPipeline::RenderOpaque() {
+  if (!m_visibleSet)
+    return;
+  m_controller.RenderOpaqueFrame(m_context, *m_visibleSet);
+}
+
+void RenderPipeline::RenderOverlays() {
+  if (!m_visibleSet)
+    return;
+  m_controller.RenderOverlayFrame(m_context, *m_visibleSet);
+}
+
+void RenderPipeline::FinalizeFrame() { m_visibleSet = nullptr; }

--- a/viewer3d/render/render_pipeline.h
+++ b/viewer3d/render/render_pipeline.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "../viewer3d_types.h"
+
+class Viewer3DController;
+
+class RenderPipeline {
+public:
+  explicit RenderPipeline(Viewer3DController &controller);
+
+  void PrepareFrame(const RenderFrameContext &context);
+  void RenderOpaque();
+  void RenderOverlays();
+  void FinalizeFrame();
+
+private:
+  Viewer3DController &m_controller;
+  RenderFrameContext m_context;
+  Viewer3DViewFrustumSnapshot m_frustum{};
+  const Viewer3DVisibleSet *m_visibleSet = nullptr;
+};

--- a/viewer3d/viewer3d_types.h
+++ b/viewer3d/viewer3d_types.h
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 // MVR coordinates are defined in millimeters. This constant converts
@@ -40,4 +41,33 @@ struct Viewer3DViewFrustumSnapshot {
   int viewport[4] = {0, 0, 0, 0};
   double model[16] = {0.0};
   double projection[16] = {0.0};
+};
+
+struct RenderFrameContext {
+  Viewer2DRenderMode mode = Viewer2DRenderMode::White;
+  Viewer2DView view = Viewer2DView::Top;
+  bool wireframe = false;
+  bool showGrid = true;
+  int gridStyle = 0;
+  float gridR = 0.35f;
+  float gridG = 0.35f;
+  float gridB = 0.35f;
+  bool gridOnTop = false;
+  bool is2DViewer = false;
+
+  bool useLighting = true;
+  bool drawGridBeforeScene = false;
+  bool drawGridAfterScene = false;
+  bool useFrustumCulling = false;
+  float minCullingPixels = 0.0f;
+
+  bool fastInteractionMode = false;
+  bool skipOptionalWork = false;
+  bool skipCapture = false;
+  bool skipOutlinesForCurrentFrame = false;
+
+  bool colorByFixtureType = false;
+  bool colorByLayer = false;
+
+  std::unordered_set<std::string> hiddenLayers;
 };

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -45,6 +45,7 @@ struct NVGcontext;
 class SceneRenderer;
 class VisibilitySystem;
 class SelectionSystem;
+class RenderPipeline;
 
 class Viewer3DController {
 public:
@@ -157,7 +158,14 @@ public:
 private:
   friend class SceneRenderer;
   friend class VisibilitySystem;
+  friend class RenderPipeline;
 
+  const VisibleSet &PrepareRenderFrame(const RenderFrameContext &context,
+                                       ViewFrustumSnapshot &frustum);
+  void RenderOpaqueFrame(const RenderFrameContext &context,
+                         const VisibleSet &visibleSet);
+  void RenderOverlayFrame(const RenderFrameContext &context,
+                          const VisibleSet &visibleSet);
   // Draws a solid cube centered at origin with given size and color
   void DrawCube(float size = 0.2f, float r = 1.0f, float g = 1.0f,
                 float b = 1.0f);


### PR DESCRIPTION
### Motivation
- Remove heavy branching inside `RenderScene` by centralizing per-frame mode/state into a single `RenderFrameContext` to simplify reasoning about rendering behavior.
- Encapsulate frame orchestration into explicit phases (`PrepareFrame`, `RenderOpaque`, `RenderOverlays`, `FinalizeFrame`) to improve readability and enable future pipeline extensions.
- Keep public API and behavior unchanged while reducing `RenderScene` complexity to the requested size and separating concerns.
- Preserve existing rendering semantics (2D/3D, wireframe, capture/symbol instancing, culling) by moving logic rather than changing it.

### Description
- Added `RenderFrameContext` in `viewer3d/viewer3d_types.h` to collect per-frame flags and cached state such as mode/view/wireframe, culling params, grid placement, fast-interaction flags and `hiddenLayers`.
- Introduced a new orchestration class `RenderPipeline` in `viewer3d/render/render_pipeline.h` and `viewer3d/render/render_pipeline.cpp` exposing `PrepareFrame`, `RenderOpaque`, `RenderOverlays`, and `FinalizeFrame` phases which call into the controller helpers.
- Refactored `Viewer3DController` to add private helpers `PrepareRenderFrame`, `RenderOpaqueFrame`, and `RenderOverlayFrame`, declared `RenderPipeline` as `friend`, and moved the original branching/drawing work into these helpers while keeping public signatures unchanged.
- Reworked `Viewer3DController::RenderScene` to only build a `RenderFrameContext`, instantiate and run the `RenderPipeline` phases, and clear capture state at the end; no public API changes were made and behavior is preserved via the new wrappers.

### Testing
- Ran an automated configure step with `cmake -S . -B build` to validate project wiring, which failed during configure due to missing system development dependencies (`wxWidgets_LIBRARIES` / `wxWidgets_INCLUDE_DIRS`) in the execution environment, so a full build/run could not be performed.
- No other automated tests were available or executed in this environment; the change is structural and intended to be build-compatible with the existing interfaces.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cff17cf7883248d5736c11aa5f946)