### PR TITLE
Introduce lightweight viewer3d interfaces and decouple systems from Viewer3DController

### DIFF
--- a/viewer3d/culling/visibilitysystem.h
+++ b/viewer3d/culling/visibilitysystem.h
@@ -1,26 +1,27 @@
 #pragma once
 
-#include "../viewer3dcontroller.h"
+#include "../interfaces/ivisibilitycontext.h"
 
 class VisibilitySystem {
 public:
-  explicit VisibilitySystem(Viewer3DController &controller) : m_controller(controller) {}
+  explicit VisibilitySystem(IVisibilityContext &controller)
+      : m_controller(controller) {}
 
-  bool EnsureBoundsComputed(const std::string &uuid, Viewer3DController::ItemType type,
+  bool EnsureBoundsComputed(const std::string &uuid, IVisibilityContext::ItemType type,
                             const std::unordered_set<std::string> &hiddenLayers);
-  bool TryBuildVisibleSet(const Viewer3DController::ViewFrustumSnapshot &frustum,
+  bool TryBuildVisibleSet(const IVisibilityContext::ViewFrustumSnapshot &frustum,
                           bool useFrustumCulling, float minPixels,
-                          const Viewer3DController::VisibleSet &layerVisibleCandidates,
-                          Viewer3DController::VisibleSet &out) const;
+                          const IVisibilityContext::VisibleSet &layerVisibleCandidates,
+                          IVisibilityContext::VisibleSet &out) const;
   bool TryBuildLayerVisibleCandidates(
       const std::unordered_set<std::string> &hiddenLayers,
-      Viewer3DController::VisibleSet &out) const;
-  const Viewer3DController::VisibleSet &
-  GetVisibleSet(const Viewer3DController::ViewFrustumSnapshot &frustum,
+      IVisibilityContext::VisibleSet &out) const;
+  const IVisibilityContext::VisibleSet &
+  GetVisibleSet(const IVisibilityContext::ViewFrustumSnapshot &frustum,
                 const std::unordered_set<std::string> &hiddenLayers,
                 bool useFrustumCulling, float minPixels) const;
   void RebuildVisibleSetCache();
 
 private:
-  Viewer3DController &m_controller;
+  IVisibilityContext &m_controller;
 };

--- a/viewer3d/interfaces/irendercontext.h
+++ b/viewer3d/interfaces/irendercontext.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../canvas2d.h"
+#include "../../viewer2d/canvas2d.h"
 
 class IRenderContext {
 public:

--- a/viewer3d/interfaces/irendercontext.h
+++ b/viewer3d/interfaces/irendercontext.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "../canvas2d.h"
+
+class IRenderContext {
+public:
+  virtual ~IRenderContext() = default;
+
+  virtual bool IsInteracting() const = 0;
+  virtual bool UseAdaptiveLineProfile() const = 0;
+  virtual bool SkipOutlinesForCurrentFrame() const = 0;
+  virtual bool IsSelectionOutlineEnabled2D() const = 0;
+  virtual bool IsCaptureOnly() const = 0;
+  virtual ICanvas2D *GetCaptureCanvas() const = 0;
+  virtual bool CaptureIncludesGrid() const = 0;
+
+  virtual void SetGLColor(float r, float g, float b) const = 0;
+  virtual void RecordLine(const std::array<float, 3> &a,
+                          const std::array<float, 3> &b,
+                          const CanvasStroke &stroke) const = 0;
+  virtual void RecordPolygon(const std::vector<std::array<float, 3>> &points,
+                             const CanvasStroke &stroke,
+                             const CanvasFill *fill) const = 0;
+};

--- a/viewer3d/interfaces/iselectioncontext.h
+++ b/viewer3d/interfaces/iselectioncontext.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../viewer3d_types.h"
-#include "../canvas2d.h"
+#include "../../viewer2d/canvas2d.h"
 #include <string>
 #include <unordered_map>
 #include <unordered_set>

--- a/viewer3d/interfaces/iselectioncontext.h
+++ b/viewer3d/interfaces/iselectioncontext.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "../viewer3d_types.h"
+#include "../canvas2d.h"
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+struct NVGcontext;
+
+class ISelectionContext {
+public:
+  using BoundingBox = Viewer3DBoundingBox;
+  using VisibleSet = Viewer3DVisibleSet;
+  using ViewFrustumSnapshot = Viewer3DViewFrustumSnapshot;
+
+  virtual ~ISelectionContext() = default;
+
+  virtual void ApplyHighlightUuid(const std::string &uuid) = 0;
+  virtual void ReplaceSelectedUuids(const std::vector<std::string> &uuids) = 0;
+  virtual bool IsCameraMoving() const = 0;
+
+  virtual const BoundingBox *FindFixtureBounds(const std::string &uuid) const = 0;
+  virtual const BoundingBox *FindTrussBounds(const std::string &uuid) const = 0;
+  virtual const BoundingBox *FindObjectBounds(const std::string &uuid) const = 0;
+
+  virtual const VisibleSet &
+  GetVisibleSet(const ViewFrustumSnapshot &frustum,
+                const std::unordered_set<std::string> &hiddenLayers,
+                bool useFrustumCulling, float minPixels) const = 0;
+
+  virtual const std::string &GetHighlightUuid() const = 0;
+  virtual const std::unordered_map<std::string, BoundingBox> &
+  GetFixtureBoundsMap() const = 0;
+  virtual const std::unordered_map<std::string, BoundingBox> &
+  GetTrussBoundsMap() const = 0;
+  virtual const std::unordered_map<std::string, BoundingBox> &
+  GetObjectBoundsMap() const = 0;
+  virtual NVGcontext *GetNanoVGContext() const = 0;
+  virtual int GetLabelFont() const = 0;
+  virtual int GetLabelBoldFont() const = 0;
+  virtual bool IsDarkMode() const = 0;
+  virtual ICanvas2D *GetCaptureCanvas() const = 0;
+  virtual void RecordText(float x, float y, const std::string &text,
+                          const CanvasTextStyle &style) const = 0;
+};

--- a/viewer3d/interfaces/ivisibilitycontext.h
+++ b/viewer3d/interfaces/ivisibilitycontext.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../resources/resource_sync_system.h"
-#include "../scenedatamanager.h"
+#include "../../core/scenedatamanager.h"
 #include "../viewer3d_types.h"
 #include <array>
 #include <mutex>

--- a/viewer3d/interfaces/ivisibilitycontext.h
+++ b/viewer3d/interfaces/ivisibilitycontext.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "../resources/resource_sync_system.h"
+#include "../scenedatamanager.h"
+#include "../viewer3d_types.h"
+#include <array>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+class IVisibilityContext {
+public:
+  using ItemType = Viewer3DItemType;
+  using VisibleSet = Viewer3DVisibleSet;
+  using ViewFrustumSnapshot = Viewer3DViewFrustumSnapshot;
+  using BoundingBox = Viewer3DBoundingBox;
+
+  virtual ~IVisibilityContext() = default;
+
+  virtual ResourceSyncState &GetResourceSyncState() = 0;
+  virtual std::unordered_map<std::string, BoundingBox> &GetModelBounds() = 0;
+  virtual std::unordered_map<std::string, BoundingBox> &GetFixtureBounds() = 0;
+  virtual std::unordered_map<std::string, BoundingBox> &GetTrussBounds() = 0;
+  virtual std::unordered_map<std::string, BoundingBox> &GetObjectBounds() = 0;
+
+  virtual size_t GetSceneVersion() const = 0;
+  virtual const std::vector<const std::pair<const std::string, Fixture> *> &
+  GetSortedFixtures() const = 0;
+  virtual const std::vector<const std::pair<const std::string, Truss> *> &
+  GetSortedTrusses() const = 0;
+  virtual const std::vector<const std::pair<const std::string, SceneObject> *> &
+  GetSortedObjects() const = 0;
+  virtual std::mutex &GetSortedListsMutex() const = 0;
+
+  virtual VisibleSet &GetCachedVisibleSet() const = 0;
+  virtual VisibleSet &GetCachedLayerVisibleCandidates() const = 0;
+  virtual size_t &GetLayerVisibleCandidatesSceneVersion() const = 0;
+  virtual std::unordered_set<std::string> &
+  GetLayerVisibleCandidatesHiddenLayers() const = 0;
+  virtual size_t &GetLayerVisibleCandidatesRevision() const = 0;
+  virtual size_t &GetVisibleSetLayerCandidatesRevision() const = 0;
+  virtual bool &GetVisibleSetFrustumCulling() const = 0;
+  virtual float &GetVisibleSetMinPixels() const = 0;
+  virtual std::array<int, 4> &GetVisibleSetViewport() const = 0;
+  virtual std::array<double, 16> &GetVisibleSetModel() const = 0;
+  virtual std::array<double, 16> &GetVisibleSetProjection() const = 0;
+};

--- a/viewer3d/labels/label_render_system.h
+++ b/viewer3d/labels/label_render_system.h
@@ -1,10 +1,11 @@
 #pragma once
 
-#include "../viewer3dcontroller.h"
+#include "../interfaces/iselectioncontext.h"
+#include "../viewer3d_types.h"
 
 class LabelRenderSystem {
 public:
-  explicit LabelRenderSystem(Viewer3DController &controller)
+  explicit LabelRenderSystem(ISelectionContext &controller)
       : m_controller(controller) {}
 
   void DrawFixtureLabels(int width, int height);
@@ -14,5 +15,5 @@ public:
                             float zoom);
 
 private:
-  Viewer3DController &m_controller;
+  ISelectionContext &m_controller;
 };

--- a/viewer3d/picking/selectionsystem.cpp
+++ b/viewer3d/picking/selectionsystem.cpp
@@ -92,12 +92,12 @@ bool SelectionSystem::GetFixtureLabelAt(int mouseX, int mouseY, int width,
   for (const auto &[uuid, f] : fixtures) {
     if (!IsLayerVisibleCached(hiddenLayers, f.layer))
       continue;
-    const Viewer3DController::BoundingBox *bbPtr =
+    const ISelectionContext::BoundingBox *bbPtr =
         m_controller.FindFixtureBounds(uuid);
     if (!bbPtr)
       continue;
 
-    const Viewer3DController::BoundingBox &bb = *bbPtr;
+    const ISelectionContext::BoundingBox &bb = *bbPtr;
     std::array<std::array<float, 3>, 8> corners = {
         std::array<float, 3>{bb.min[0], bb.min[1], bb.min[2]},
         {bb.max[0], bb.min[1], bb.min[2]},
@@ -193,12 +193,12 @@ bool SelectionSystem::GetTrussLabelAt(int mouseX, int mouseY, int width,
   for (const auto &[uuid, t] : trusses) {
     if (!IsLayerVisibleCached(hiddenLayers, t.layer))
       continue;
-    const Viewer3DController::BoundingBox *bbPtr =
+    const ISelectionContext::BoundingBox *bbPtr =
         m_controller.FindTrussBounds(uuid);
     if (!bbPtr)
       continue;
 
-    const Viewer3DController::BoundingBox &bb = *bbPtr;
+    const ISelectionContext::BoundingBox &bb = *bbPtr;
     std::array<std::array<float, 3>, 8> corners = {
         std::array<float, 3>{bb.min[0], bb.min[1], bb.min[2]},
         {bb.max[0], bb.min[1], bb.min[2]},
@@ -282,12 +282,12 @@ bool SelectionSystem::GetSceneObjectLabelAt(int mouseX, int mouseY, int width,
   for (const auto &[uuid, o] : objs) {
     if (!IsLayerVisibleCached(hiddenLayers, o.layer))
       continue;
-    const Viewer3DController::BoundingBox *bbPtr =
+    const ISelectionContext::BoundingBox *bbPtr =
         m_controller.FindObjectBounds(uuid);
     if (!bbPtr)
       continue;
 
-    const Viewer3DController::BoundingBox &bb = *bbPtr;
+    const ISelectionContext::BoundingBox &bb = *bbPtr;
     std::array<std::array<float, 3>, 8> corners = {
         std::array<float, 3>{bb.min[0], bb.min[1], bb.min[2]},
         {bb.max[0], bb.min[1], bb.min[2]},
@@ -366,7 +366,7 @@ std::vector<std::string> SelectionSystem::GetFixturesInScreenRect(
              rect.maxY < selectionRect.minY || rect.minY > selectionRect.maxY);
   };
 
-  auto projectBounds = [&](const Viewer3DController::BoundingBox &bb, ScreenRect &rect) {
+  auto projectBounds = [&](const ISelectionContext::BoundingBox &bb, ScreenRect &rect) {
     rect = ScreenRect{};
     bool visible = false;
     std::array<std::array<float, 3>, 8> corners = {
@@ -395,14 +395,14 @@ std::vector<std::string> SelectionSystem::GetFixturesInScreenRect(
   };
 
   std::vector<std::string> selection;
-  Viewer3DController::ViewFrustumSnapshot frustum{};
+  ISelectionContext::ViewFrustumSnapshot frustum{};
   std::copy(std::begin(viewport), std::end(viewport), std::begin(frustum.viewport));
   std::copy(std::begin(model), std::end(model), std::begin(frustum.model));
   std::copy(std::begin(proj), std::end(proj), std::begin(frustum.projection));
-  const Viewer3DController::VisibleSet &visibleSet =
+  const ISelectionContext::VisibleSet &visibleSet =
       m_controller.GetVisibleSet(frustum, hiddenLayers, true, 0.0f);
   for (const auto &uuid : visibleSet.fixtureUuids) {
-    const Viewer3DController::BoundingBox *bbPtr =
+    const ISelectionContext::BoundingBox *bbPtr =
         m_controller.FindFixtureBounds(uuid);
     if (!bbPtr)
       continue;
@@ -439,7 +439,7 @@ std::vector<std::string> SelectionSystem::GetTrussesInScreenRect(
              rect.maxY < selectionRect.minY || rect.minY > selectionRect.maxY);
   };
 
-  auto projectBounds = [&](const Viewer3DController::BoundingBox &bb, ScreenRect &rect) {
+  auto projectBounds = [&](const ISelectionContext::BoundingBox &bb, ScreenRect &rect) {
     rect = ScreenRect{};
     bool visible = false;
     std::array<std::array<float, 3>, 8> corners = {
@@ -468,14 +468,14 @@ std::vector<std::string> SelectionSystem::GetTrussesInScreenRect(
   };
 
   std::vector<std::string> selection;
-  Viewer3DController::ViewFrustumSnapshot frustum{};
+  ISelectionContext::ViewFrustumSnapshot frustum{};
   std::copy(std::begin(viewport), std::end(viewport), std::begin(frustum.viewport));
   std::copy(std::begin(model), std::end(model), std::begin(frustum.model));
   std::copy(std::begin(proj), std::end(proj), std::begin(frustum.projection));
-  const Viewer3DController::VisibleSet &visibleSet =
+  const ISelectionContext::VisibleSet &visibleSet =
       m_controller.GetVisibleSet(frustum, hiddenLayers, true, 0.0f);
   for (const auto &uuid : visibleSet.trussUuids) {
-    const Viewer3DController::BoundingBox *bbPtr =
+    const ISelectionContext::BoundingBox *bbPtr =
         m_controller.FindTrussBounds(uuid);
     if (!bbPtr)
       continue;
@@ -512,7 +512,7 @@ std::vector<std::string> SelectionSystem::GetSceneObjectsInScreenRect(
              rect.maxY < selectionRect.minY || rect.minY > selectionRect.maxY);
   };
 
-  auto projectBounds = [&](const Viewer3DController::BoundingBox &bb, ScreenRect &rect) {
+  auto projectBounds = [&](const ISelectionContext::BoundingBox &bb, ScreenRect &rect) {
     rect = ScreenRect{};
     bool visible = false;
     std::array<std::array<float, 3>, 8> corners = {
@@ -541,14 +541,14 @@ std::vector<std::string> SelectionSystem::GetSceneObjectsInScreenRect(
   };
 
   std::vector<std::string> selection;
-  Viewer3DController::ViewFrustumSnapshot frustum{};
+  ISelectionContext::ViewFrustumSnapshot frustum{};
   std::copy(std::begin(viewport), std::end(viewport), std::begin(frustum.viewport));
   std::copy(std::begin(model), std::end(model), std::begin(frustum.model));
   std::copy(std::begin(proj), std::end(proj), std::begin(frustum.projection));
-  const Viewer3DController::VisibleSet &visibleSet =
+  const ISelectionContext::VisibleSet &visibleSet =
       m_controller.GetVisibleSet(frustum, hiddenLayers, true, 0.0f);
   for (const auto &uuid : visibleSet.objectUuids) {
-    const Viewer3DController::BoundingBox *bbPtr =
+    const ISelectionContext::BoundingBox *bbPtr =
         m_controller.FindObjectBounds(uuid);
     if (!bbPtr)
       continue;

--- a/viewer3d/picking/selectionsystem.cpp
+++ b/viewer3d/picking/selectionsystem.cpp
@@ -17,9 +17,12 @@
 #endif
 
 #include "../../core/configmanager.h"
+#include "../../core/scenedatamanager.h"
 #include <algorithm>
+#include <array>
 #include <cfloat>
 #include <cstdio>
+#include <unordered_set>
 
 namespace {
 

--- a/viewer3d/picking/selectionsystem.h
+++ b/viewer3d/picking/selectionsystem.h
@@ -1,10 +1,14 @@
 #pragma once
 
-#include "../viewer3dcontroller.h"
+#include "../interfaces/iselectioncontext.h"
+#include <string>
+#include <vector>
+#include <wx/gdicmn.h>
+#include <wx/string.h>
 
 class SelectionSystem {
 public:
-  explicit SelectionSystem(Viewer3DController &controller) : m_controller(controller) {}
+  explicit SelectionSystem(ISelectionContext &controller) : m_controller(controller) {}
 
   void SetHighlightUuid(const std::string &uuid);
   void SetSelectedUuids(const std::vector<std::string> &uuids);
@@ -29,5 +33,5 @@ public:
                                                        int height) const;
 
 private:
-  Viewer3DController &m_controller;
+  ISelectionContext &m_controller;
 };

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -45,14 +45,14 @@ void SceneRenderer::DrawMeshWithOutline(
 
   if (wireframe) {
     float lineWidth =
-        GetLineRenderProfile(m_controller.m_isInteracting,
+        GetLineRenderProfile(m_controller.IsInteracting(),
                              mode == Viewer2DRenderMode::Wireframe,
-                             m_controller.m_useAdaptiveLineProfile)
+                             m_controller.UseAdaptiveLineProfile())
             .lineWidth;
     const bool drawOutline =
-        !m_controller.m_skipOutlinesForCurrentFrame &&
-        m_controller.m_showSelectionOutline2D && (highlight || selected);
-    if (!m_controller.m_captureOnly) {
+        !m_controller.SkipOutlinesForCurrentFrame() &&
+        m_controller.IsSelectionOutlineEnabled2D() && (highlight || selected);
+    if (!m_controller.IsCaptureOnly()) {
       if (drawOutline) {
         float glowWidth = lineWidth + 3.0f;
         glLineWidth(glowWidth);
@@ -69,7 +69,7 @@ void SceneRenderer::DrawMeshWithOutline(
     stroke.color = {0.0f, 0.0f, 0.0f, 1.0f};
     stroke.width = lineWidth;
     DrawMeshWireframe(mesh, scale, captureTransform);
-    if (m_controller.m_captureCanvas && mode != Viewer2DRenderMode::Wireframe) {
+    if (m_controller.GetCaptureCanvas() && mode != Viewer2DRenderMode::Wireframe) {
       CanvasFill fill;
       fill.color = {r, g, b, 1.0f};
       for (size_t i = 0; i + 2 < mesh.indices.size(); i += 3) {
@@ -90,7 +90,7 @@ void SceneRenderer::DrawMeshWithOutline(
         m_controller.RecordPolygon(pts, stroke, &fill);
       }
     }
-    if (!m_controller.m_captureOnly) {
+    if (!m_controller.IsCaptureOnly()) {
       glLineWidth(1.0f);
       if (mode != Viewer2DRenderMode::Wireframe) {
         glEnable(GL_POLYGON_OFFSET_FILL);
@@ -107,7 +107,7 @@ void SceneRenderer::DrawMeshWithOutline(
     return;
   }
 
-  if (!m_controller.m_captureOnly) {
+  if (!m_controller.IsCaptureOnly()) {
     if (highlight)
       m_controller.SetGLColor(0.0f, 1.0f, 0.0f);
     else if (selected)
@@ -121,7 +121,7 @@ void SceneRenderer::DrawMeshWithOutline(
     if (unlit)
       glEnable(GL_LIGHTING);
   }
-  if (m_controller.m_captureCanvas) {
+  if (m_controller.GetCaptureCanvas()) {
     CanvasStroke stroke;
     stroke.color = {r, g, b, 1.0f};
     stroke.width = 0.0f;
@@ -158,7 +158,7 @@ void SceneRenderer::DrawMeshWireframe(
       mesh.buffersReady && mesh.vao != 0 && mesh.vboVertices != 0 &&
       mesh.eboLines != 0 && mesh.eboTriangles != 0 && gpuHandlesValid;
 
-  if (!m_controller.m_captureOnly && canUseGpuWireframe) {
+  if (!m_controller.IsCaptureOnly() && canUseGpuWireframe) {
     glBindVertexArray(mesh.vao);
     glPushMatrix();
     glScalef(scale, scale, scale);
@@ -175,7 +175,7 @@ void SceneRenderer::DrawMeshWireframe(
     glDisableClientState(GL_VERTEX_ARRAY);
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     glPopMatrix();
-  } else if (!m_controller.m_captureOnly) {
+  } else if (!m_controller.IsCaptureOnly()) {
     glBegin(GL_LINES);
     for (size_t i = 0; i + 2 < mesh.indices.size(); i += 3) {
       const unsigned short i0 = mesh.indices[i];
@@ -199,7 +199,7 @@ void SceneRenderer::DrawMeshWireframe(
     }
     glEnd();
   }
-  if (m_controller.m_captureCanvas) {
+  if (m_controller.GetCaptureCanvas()) {
     CanvasStroke stroke;
     stroke.color = {0.0f, 0.0f, 0.0f, 1.0f};
     stroke.width = 1.0f;
@@ -277,7 +277,7 @@ void SceneRenderer::DrawMesh(const Mesh &mesh, float scale, const float *modelMa
       mesh.vboNormals != 0 && mesh.eboTriangles != 0 && gpuHandlesValid &&
       !requiresCpuDrawPath;
 
-  if (!m_controller.m_captureOnly && canUseGpuTriangles) {
+  if (!m_controller.IsCaptureOnly() && canUseGpuTriangles) {
     glBindVertexArray(mesh.vao);
     glPushMatrix();
     glScalef(scale, scale, scale);
@@ -298,7 +298,7 @@ void SceneRenderer::DrawMesh(const Mesh &mesh, float scale, const float *modelMa
     glDisableClientState(GL_VERTEX_ARRAY);
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     glPopMatrix();
-  } else if (!m_controller.m_captureOnly) {
+  } else if (!m_controller.IsCaptureOnly()) {
     GLint shadeModel = GL_SMOOTH;
     glGetIntegerv(GL_SHADE_MODEL, &shadeModel);
     const bool useFaceNormals = (shadeModel == GL_FLAT);
@@ -393,8 +393,8 @@ void SceneRenderer::DrawGrid(int style, float r, float g, float b,
   const float step = 1.0f;
 
   const LineRenderProfile profile =
-      GetLineRenderProfile(m_controller.m_isInteracting, true,
-                           m_controller.m_useAdaptiveLineProfile);
+      GetLineRenderProfile(m_controller.IsInteracting(), true,
+                           m_controller.UseAdaptiveLineProfile());
   CanvasStroke stroke;
   stroke.color = {r, g, b, 1.0f};
   stroke.width = profile.lineWidth;
@@ -417,7 +417,7 @@ void SceneRenderer::DrawGrid(int style, float r, float g, float b,
         glVertex3f(i, size, 0.0f);
         glVertex3f(-size, i, 0.0f);
         glVertex3f(size, i, 0.0f);
-        if (m_controller.m_captureCanvas && m_controller.m_captureIncludeGrid) {
+        if (m_controller.GetCaptureCanvas() && m_controller.CaptureIncludesGrid()) {
           m_controller.RecordLine({i, -size, 0.0f}, {i, size, 0.0f}, stroke);
           m_controller.RecordLine({-size, i, 0.0f}, {size, i, 0.0f}, stroke);
         }
@@ -427,7 +427,7 @@ void SceneRenderer::DrawGrid(int style, float r, float g, float b,
         glVertex3f(i, 0.0f, size);
         glVertex3f(-size, 0.0f, i);
         glVertex3f(size, 0.0f, i);
-        if (m_controller.m_captureCanvas && m_controller.m_captureIncludeGrid) {
+        if (m_controller.GetCaptureCanvas() && m_controller.CaptureIncludesGrid()) {
           m_controller.RecordLine({i, 0.0f, -size}, {i, 0.0f, size}, stroke);
           m_controller.RecordLine({-size, 0.0f, i}, {size, 0.0f, i}, stroke);
         }
@@ -437,7 +437,7 @@ void SceneRenderer::DrawGrid(int style, float r, float g, float b,
         glVertex3f(0.0f, i, size);
         glVertex3f(0.0f, -size, i);
         glVertex3f(0.0f, size, i);
-        if (m_controller.m_captureCanvas && m_controller.m_captureIncludeGrid) {
+        if (m_controller.GetCaptureCanvas() && m_controller.CaptureIncludesGrid()) {
           m_controller.RecordLine({0.0f, i, -size}, {0.0f, i, size}, stroke);
           m_controller.RecordLine({0.0f, -size, i}, {0.0f, size, i}, stroke);
         }
@@ -456,17 +456,17 @@ void SceneRenderer::DrawGrid(int style, float r, float g, float b,
         case Viewer2DView::Top:
         case Viewer2DView::Bottom:
           glVertex3f(x, y, 0.0f);
-          if (m_controller.m_captureCanvas && m_controller.m_captureIncludeGrid)
+          if (m_controller.GetCaptureCanvas() && m_controller.CaptureIncludesGrid())
             m_controller.RecordLine({x, y, 0.0f}, {x, y, 0.0f}, stroke);
           break;
         case Viewer2DView::Front:
           glVertex3f(x, 0.0f, y);
-          if (m_controller.m_captureCanvas && m_controller.m_captureIncludeGrid)
+          if (m_controller.GetCaptureCanvas() && m_controller.CaptureIncludesGrid())
             m_controller.RecordLine({x, 0.0f, y}, {x, 0.0f, y}, stroke);
           break;
         case Viewer2DView::Side:
           glVertex3f(0.0f, x, y);
-          if (m_controller.m_captureCanvas && m_controller.m_captureIncludeGrid)
+          if (m_controller.GetCaptureCanvas() && m_controller.CaptureIncludesGrid())
             m_controller.RecordLine({0.0f, x, y}, {0.0f, x, y}, stroke);
           break;
         }
@@ -488,7 +488,7 @@ void SceneRenderer::DrawGrid(int style, float r, float g, float b,
           glVertex3f(x + half, y, 0.0f);
           glVertex3f(x, y - half, 0.0f);
           glVertex3f(x, y + half, 0.0f);
-          if (m_controller.m_captureCanvas && m_controller.m_captureIncludeGrid) {
+          if (m_controller.GetCaptureCanvas() && m_controller.CaptureIncludesGrid()) {
             m_controller.RecordLine({x - half, y, 0.0f}, {x + half, y, 0.0f}, stroke);
             m_controller.RecordLine({x, y - half, 0.0f}, {x, y + half, 0.0f}, stroke);
           }
@@ -498,7 +498,7 @@ void SceneRenderer::DrawGrid(int style, float r, float g, float b,
           glVertex3f(x + half, 0.0f, y);
           glVertex3f(x, 0.0f, y - half);
           glVertex3f(x, 0.0f, y + half);
-          if (m_controller.m_captureCanvas && m_controller.m_captureIncludeGrid) {
+          if (m_controller.GetCaptureCanvas() && m_controller.CaptureIncludesGrid()) {
             m_controller.RecordLine({x - half, 0.0f, y}, {x + half, 0.0f, y}, stroke);
             m_controller.RecordLine({x, 0.0f, y - half}, {x, 0.0f, y + half}, stroke);
           }
@@ -508,7 +508,7 @@ void SceneRenderer::DrawGrid(int style, float r, float g, float b,
           glVertex3f(0.0f, x + half, y);
           glVertex3f(0.0f, x, y - half);
           glVertex3f(0.0f, x, y + half);
-          if (m_controller.m_captureCanvas && m_controller.m_captureIncludeGrid) {
+          if (m_controller.GetCaptureCanvas() && m_controller.CaptureIncludesGrid()) {
             m_controller.RecordLine({0.0f, x - half, y}, {0.0f, x + half, y}, stroke);
             m_controller.RecordLine({0.0f, x, y - half}, {0.0f, x, y + half}, stroke);
           }

--- a/viewer3d/render/scenerenderer.h
+++ b/viewer3d/render/scenerenderer.h
@@ -1,10 +1,13 @@
 #pragma once
 
-#include "../viewer3dcontroller.h"
+#include "../interfaces/irendercontext.h"
+#include "../mesh.h"
+#include "../viewer3d_types.h"
+#include <functional>
 
 class SceneRenderer {
 public:
-  explicit SceneRenderer(Viewer3DController &controller) : m_controller(controller) {}
+  explicit SceneRenderer(IRenderContext &controller) : m_controller(controller) {}
 
   void DrawMeshWithOutline(
       const Mesh &mesh, float r, float g, float b, float scale, bool highlight,
@@ -20,5 +23,5 @@ public:
   void SetupMaterialFromRGB(float r, float g, float b);
 
 private:
-  Viewer3DController &m_controller;
+  IRenderContext &m_controller;
 };

--- a/viewer3d/viewer3d_types.h
+++ b/viewer3d/viewer3d_types.h
@@ -43,6 +43,11 @@ struct Viewer3DViewFrustumSnapshot {
   double projection[16] = {0.0};
 };
 
+struct Viewer3DBoundingBox {
+  std::array<float, 3> min;
+  std::array<float, 3> max;
+};
+
 struct RenderFrameContext {
   Viewer2DRenderMode mode = Viewer2DRenderMode::White;
   Viewer2DView view = Viewer2DView::Top;


### PR DESCRIPTION
### Motivation
- Reduce tight coupling between viewer systems and `Viewer3DController` so subsystem headers do not depend on `viewer3dcontroller.h`.
- Provide small context contracts so rendering, visibility and selection code can access only the state they need without friend access to controller internals.
- Move shared types out of the controller header to avoid unnecessary includes across modules.

### Description
- Added lightweight interfaces under `viewer3d/interfaces/`: `IRenderContext`, `IVisibilityContext`, and `ISelectionContext` that declare the minimal API used by systems.
- Moved the shared bounding-box type into `viewer3d/viewer3d_types.h` as `Viewer3DBoundingBox` and replaced the controller-local type with `Viewer3DBoundingBox`.
- Made `Viewer3DController` implement the three interfaces and exposed the required getters and helpers so systems use the interface methods rather than private member access.
- Updated subsystem headers and implementations to accept interface references and consume interface methods instead of including `viewer3dcontroller.h`; examples include `SceneRenderer`, `VisibilitySystem`, `SelectionSystem`, and `LabelRenderSystem` refactors; removed the now-unnecessary `friend class SceneRenderer` and `friend class VisibilitySystem` declarations.

### Testing
- Ran ``cmake --list-presets`` successfully to validate environment presets.
- Attempted to configure a local build with ``cmake -S . -B build`` and the configuration step failed due to a missing system dependency (`wxWidgets`), so a full compile was not validated in this environment.
- Performed local source-level updates and textual refactors across the affected files and ensured the new interfaces are used consistently by the modified subsystems.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dbe3adcf08324b99e28308a49375d)