### PR TITLE
Fix logger header include path in bounds_cache_system

### DIFF
--- a/viewer3d/culling/bounds_cache_system.cpp
+++ b/viewer3d/culling/bounds_cache_system.cpp
@@ -2,7 +2,7 @@
 
 #include "../../core/projectutils.h"
 #include "../../models/types.h"
-#include "../logger.h"
+#include "../../core/logger.h"
 #include "../matrixutils.h"
 
 #include <algorithm>


### PR DESCRIPTION
### Motivation
- Fix an incorrect relative include in `viewer3d/culling/bounds_cache_system.cpp` so it uses the existing `core/logger.h` location and avoids MSVC include errors (C1083).

### Description
- Replaced `#include "../logger.h"` with `#include "../../core/logger.h"` in `viewer3d/culling/bounds_cache_system.cpp`.

### Testing
- Verified the updated include via `rg` and file preview, and attempted to build the Visual Studio `Perastage` target but the Windows CMake preset could not be executed on this non-Windows host so MSVC/C1083 verification was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698de356b6588324ac7e557c24b868e8)