### PR TITLE
Fix bounds cache compile errors on Windows

### DIFF
--- a/viewer3d/culling/bounds_cache_system.cpp
+++ b/viewer3d/culling/bounds_cache_system.cpp
@@ -1,5 +1,12 @@
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#endif
+
 #include "bounds_cache_system.h"
 
+#include "configmanager.h"
 #include "projectutils.h"
 #include "types.h"
 #include "logger.h"
@@ -30,6 +37,13 @@ static bool IsLayerVisibleCached(const std::unordered_set<std::string> &hidden,
   if (layer.empty())
     return hidden.find(DEFAULT_LAYER_NAME) == hidden.end();
   return hidden.find(layer) == hidden.end();
+}
+
+static std::array<float, 3> TransformPoint(const Matrix &m,
+                                           const std::array<float, 3> &p) {
+  return {m.u[0] * p[0] + m.v[0] * p[1] + m.w[0] * p[2] + m.o[0],
+          m.u[1] * p[0] + m.v[1] * p[1] + m.w[1] * p[2] + m.o[1],
+          m.u[2] * p[0] + m.v[2] * p[1] + m.w[2] * p[2] + m.o[2]};
 }
 
 static Viewer3DBoundingBox TransformBounds(const Viewer3DBoundingBox &local,


### PR DESCRIPTION
### Motivation
- Resolve multiple Windows build errors in `viewer3d/culling/bounds_cache_system.cpp` caused by macro collisions, missing declarations, and a missing helper used to transform points.

### Description
- Define `NOMINMAX` under `#ifdef _WIN32` at the top of `bounds_cache_system.cpp` to avoid Windows `min`/`max` macros colliding with `std::min`/`std::max`.
- Add `#include "configmanager.h"` so `DEFAULT_LAYER_NAME` is available in this translation unit.
- Add a local `TransformPoint` helper function to provide the missing identifier used to transform bounding-box corner points.
- All changes are in `viewer3d/culling/bounds_cache_system.cpp` and were committed.

### Testing
- Attempted to run the build with `cmake --build build -j2`, which failed because the configured build directory `build` does not exist in this environment (no successful build verification).
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698de653fab48324a7b51684f5589855)