### PR TITLE
Consolidate frame orchestration into RenderPipeline

### DIFF
--- a/viewer3d/render/render_pipeline.cpp
+++ b/viewer3d/render/render_pipeline.cpp
@@ -2,24 +2,58 @@
 
 #include "viewer3dcontroller.h"
 
+#include <cassert>
+
 RenderPipeline::RenderPipeline(Viewer3DController &controller)
     : m_controller(controller) {}
 
+RenderPipeline::~RenderPipeline() {
+  if (m_framePrepared) {
+    assert(false && "RenderPipeline invariant violated: FinalizeFrame() must be called");
+    FinalizeFrame();
+  }
+}
+
+void RenderPipeline::Execute(const RenderFrameContext &context) {
+  PrepareFrame(context);
+
+  struct FinalizeGuard {
+    RenderPipeline &pipeline;
+    ~FinalizeGuard() { pipeline.FinalizeFrame(); }
+  } guard{*this};
+
+  RenderOpaque();
+  RenderOverlays();
+}
+
 void RenderPipeline::PrepareFrame(const RenderFrameContext &context) {
+  assert(!m_framePrepared && "RenderPipeline invariant violated: frame already prepared");
   m_context = context;
   m_visibleSet = &m_controller.PrepareRenderFrame(m_context, m_frustum);
+  m_framePrepared = true;
 }
 
 void RenderPipeline::RenderOpaque() {
-  if (!m_visibleSet)
-    return;
+  EnsureVisibleSetPrepared("RenderOpaque");
   m_controller.RenderOpaqueFrame(m_context, *m_visibleSet);
 }
 
 void RenderPipeline::RenderOverlays() {
-  if (!m_visibleSet)
-    return;
+  EnsureVisibleSetPrepared("RenderOverlays");
   m_controller.RenderOverlayFrame(m_context, *m_visibleSet);
 }
 
-void RenderPipeline::FinalizeFrame() { m_visibleSet = nullptr; }
+void RenderPipeline::FinalizeFrame() {
+  if (!m_framePrepared)
+    return;
+
+  m_controller.FinalizeRenderFrame();
+  m_visibleSet = nullptr;
+  m_framePrepared = false;
+}
+
+void RenderPipeline::EnsureVisibleSetPrepared(const char *phase) const {
+  (void)phase;
+  assert(m_framePrepared && "RenderPipeline invariant violated: frame not prepared");
+  assert(m_visibleSet && "RenderPipeline invariant violated: visible set must be prepared");
+}

--- a/viewer3d/render/render_pipeline.h
+++ b/viewer3d/render/render_pipeline.h
@@ -7,6 +7,9 @@ class Viewer3DController;
 class RenderPipeline {
 public:
   explicit RenderPipeline(Viewer3DController &controller);
+  ~RenderPipeline();
+
+  void Execute(const RenderFrameContext &context);
 
   void PrepareFrame(const RenderFrameContext &context);
   void RenderOpaque();
@@ -14,8 +17,11 @@ public:
   void FinalizeFrame();
 
 private:
+  void EnsureVisibleSetPrepared(const char *phase) const;
+
   Viewer3DController &m_controller;
   RenderFrameContext m_context;
   Viewer3DViewFrustumSnapshot m_frustum{};
   const Viewer3DVisibleSet *m_visibleSet = nullptr;
+  bool m_framePrepared = false;
 };

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -886,18 +886,8 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
   const auto hiddenLayers = SnapshotHiddenLayers(cfg);
   context.hiddenLayers = hiddenLayers;
 
-  // Execute the explicit render pipeline phases.
-  // 1) PrepareFrame: gather visibility and per-frame cached state.
-  // 2) RenderOpaque: draw scene geometry.
-  // 3) RenderOverlays: draw overlays such as grid-on-top/axes.
   RenderPipeline pipeline(*this);
-  pipeline.PrepareFrame(context);
-  pipeline.RenderOpaque();
-  pipeline.RenderOverlays();
-  pipeline.FinalizeFrame();
-
-  if (m_captureCanvas)
-    m_captureCanvas->SetSourceKey("unknown");
+  pipeline.Execute(context);
 }
 
 const Viewer3DController::VisibleSet &Viewer3DController::PrepareRenderFrame(
@@ -1029,6 +1019,13 @@ void Viewer3DController::RenderOverlayFrame(const RenderFrameContext &context,
 
   DrawAxes();
 }
+
+void Viewer3DController::FinalizeRenderFrame() {
+  m_skipOutlinesForCurrentFrame = false;
+  if (m_captureCanvas)
+    m_captureCanvas->SetSourceKey("unknown");
+}
+
 
 void Viewer3DController::SetDarkMode(bool enabled) { m_darkMode = enabled; }
 

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -168,6 +168,7 @@ public:
                          const VisibleSet &visibleSet);
   void RenderOverlayFrame(const RenderFrameContext &context,
                           const VisibleSet &visibleSet);
+  void FinalizeRenderFrame();
 
   // Enables recording of all primitives drawn during the next RenderScene
   // call. The caller owns the canvas lifetime and is responsible for calling


### PR DESCRIPTION
### Motivation
- Move the per-frame execution flow out of the controller so `RenderScene` only configures the frame context and delegates execution. 
- Centralize the full render sequence (`prepare -> opaque -> overlays -> finalize`) into the pipeline to reduce controller logic surface and make invariants explicit.
- Add runtime invariants to catch misuse (double-prepare / missing-finalize) and ensure `visibleSet` is available during rendering.

### Description
- Added `RenderPipeline::Execute(const RenderFrameContext &)` to run the full frame flow (`PrepareFrame`, `RenderOpaque`, `RenderOverlays`) and use an RAII guard to always call `FinalizeFrame` at scope exit. 
- Introduced a destructor check and `m_framePrepared` flag in `RenderPipeline` to assert if a frame was left finalized incorrectly, and added `EnsureVisibleSetPrepared()` to validate invariants before render phases. 
- Updated `PrepareFrame` to set `m_framePrepared` and added asserts to prevent double prepare. 
- Moved per-frame finalization responsibilities into the controller via `Viewer3DController::FinalizeRenderFrame()` and call it from `RenderPipeline::FinalizeFrame()`. 
- Replaced the explicit pipeline sequence in `Viewer3DController::RenderScene` with a single `pipeline.Execute(context)` call. 
- Modified files: `viewer3d/render/render_pipeline.h`, `viewer3d/render/render_pipeline.cpp`, `viewer3d/viewer3dcontroller.h`, and `viewer3d/viewer3dcontroller.cpp`.

### Testing
- Ran `git diff --check` to validate no whitespace conflicts and it succeeded. 
- Ran `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` to configure a build; configuration failed in this environment due to missing system development libraries for `wxWidgets` (`wxWidgets_LIBRARIES` / `wxWidgets_INCLUDE_DIRS`), so a full build could not be completed here. 
- No unit tests were modified or added as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698df8a607548324816de17d10257d7a)