### PR TITLE
Refactor ConfigManager into extracted config subservices

### DIFF
--- a/core/configmanager.h
+++ b/core/configmanager.h
@@ -22,9 +22,7 @@
 #include <unordered_set>
 #include <optional>
 #include <vector>
-#include "mvrscene.h"
-
-inline constexpr const char* DEFAULT_LAYER_NAME = "No Layer";
+#include "configservices.h"
 
 // Singleton to manage configuration and MVR scene data globally
 class ConfigManager
@@ -63,15 +61,6 @@ public:
     void SetSelectedSupports(const std::vector<std::string>& uuids);
     const std::vector<std::string>& GetSelectedSceneObjects() const;
     void SetSelectedSceneObjects(const std::vector<std::string>& uuids);
-
-    struct VariableInfo {
-        std::string type;
-        float defaultValue = 0.0f;
-        float value = 0.0f;
-        float minValue = 0.0f;
-        float maxValue = 0.0f;
-        std::vector<std::string> legacyNames;
-    };
 
     void RegisterVariable(const std::string& name, const std::string& type,
                           float defVal, float minVal, float maxVal,
@@ -136,35 +125,11 @@ private:
     ConfigManager(const ConfigManager&) = delete;
     ConfigManager& operator=(const ConfigManager&) = delete;
 
-    void ApplyColumnDefaults();
-
-    std::unordered_map<std::string, std::string> configData;
-    std::unordered_map<std::string, VariableInfo> variables;
-    MvrScene scene;
-
-    // Selection state
-    std::vector<std::string> selectedFixtures;
-    std::vector<std::string> selectedTrusses;
-    std::vector<std::string> selectedSupports;
-    std::vector<std::string> selectedSceneObjects;
-
-    struct Snapshot {
-        MvrScene scene;
-        std::vector<std::string> selFixtures;
-        std::vector<std::string> selTrusses;
-        std::vector<std::string> selSupports;
-        std::vector<std::string> selSceneObjects;
-        std::string description;
-    };
-
-    std::vector<Snapshot> undoStack;
-    std::vector<Snapshot> redoStack;
-    size_t maxHistory = 20;
-
-    size_t revision = 0;
-    size_t savedRevision = 0;
+    UserPreferencesStore preferencesStore;
+    ProjectSession projectSession;
+    SelectionState selectionState;
+    HistoryManager historyManager;
+    LayerVisibilityState layerVisibilityState;
 
     bool suppressRevision = false;
-
-    std::string currentLayer = DEFAULT_LAYER_NAME;
 };

--- a/core/configservices.cpp
+++ b/core/configservices.cpp
@@ -1,0 +1,466 @@
+#include "configservices.h"
+
+#include "json.hpp"
+
+#include <algorithm>
+#include <charconv>
+#include <cctype>
+#include <filesystem>
+#include <fstream>
+#include <set>
+#include <sstream>
+#include <string_view>
+
+#include <wx/stdpaths.h>
+
+namespace {
+std::vector<std::string> SplitCSV(const std::string &s) {
+  std::vector<std::string> result;
+  std::stringstream ss(s);
+  std::string item;
+  while (std::getline(ss, item, ',')) {
+    size_t start = item.find_first_not_of(" \t");
+    size_t end = item.find_last_not_of(" \t");
+    if (start != std::string::npos)
+      result.push_back(item.substr(start, end - start + 1));
+  }
+  return result;
+}
+
+std::string JoinCSV(const std::vector<std::string> &items) {
+  std::string out;
+  for (size_t i = 0; i < items.size(); ++i) {
+    if (i > 0)
+      out += ',';
+    out += items[i];
+  }
+  return out;
+}
+
+bool TryParseFloat(const std::string &text, float &out) {
+  if (text.empty())
+    return false;
+
+  const auto first =
+      std::find_if_not(text.begin(), text.end(), [](unsigned char c) {
+        return std::isspace(c);
+      });
+  if (first == text.end())
+    return false;
+  const auto last =
+      std::find_if_not(text.rbegin(), text.rend(), [](unsigned char c) {
+        return std::isspace(c);
+      }).base();
+  std::string_view trimmed(&(*first), static_cast<size_t>(last - first));
+
+  auto *begin = trimmed.data();
+  auto *end = trimmed.data() + trimmed.size();
+
+  auto result = std::from_chars(begin, end, out);
+  return result.ec == std::errc{} && result.ptr == end;
+}
+} // namespace
+
+void UserPreferencesStore::SetValue(const std::string &key,
+                                    const std::string &value) {
+  std::string newValue = value;
+
+  auto var = variables.find(key);
+  if (var != variables.end() && var->second.type == "float") {
+    float parsed = 0.0f;
+    if (TryParseFloat(value, parsed)) {
+      parsed = std::clamp(parsed, var->second.minValue, var->second.maxValue);
+      var->second.value = parsed;
+      newValue = std::to_string(parsed);
+    }
+  }
+
+  configData[key] = newValue;
+}
+
+std::optional<std::string>
+UserPreferencesStore::GetValue(const std::string &key) const {
+  auto it = configData.find(key);
+  if (it != configData.end())
+    return it->second;
+  return std::nullopt;
+}
+
+bool UserPreferencesStore::HasKey(const std::string &key) const {
+  return configData.find(key) != configData.end();
+}
+
+void UserPreferencesStore::RemoveKey(const std::string &key) {
+  configData.erase(key);
+}
+
+void UserPreferencesStore::ClearValues() { configData.clear(); }
+
+void UserPreferencesStore::RegisterVariable(const std::string &name,
+                                            const std::string &type,
+                                            float defVal, float minVal,
+                                            float maxVal,
+                                            std::vector<std::string> legacyNames) {
+  VariableInfo info;
+  info.type = type;
+  info.defaultValue = defVal;
+  info.value = defVal;
+  info.minValue = minVal;
+  info.maxValue = maxVal;
+  info.legacyNames = std::move(legacyNames);
+  variables[name] = info;
+}
+
+float UserPreferencesStore::GetFloat(const std::string &name) const {
+  auto it = variables.find(name);
+  float defVal = 0.0f;
+  if (it != variables.end())
+    defVal = it->second.defaultValue;
+
+  auto valStr = GetValue(name);
+  if (valStr) {
+    float parsed = 0.0f;
+    if (TryParseFloat(*valStr, parsed))
+      return parsed;
+    return defVal;
+  }
+  return defVal;
+}
+
+void UserPreferencesStore::SetFloat(const std::string &name, float v) {
+  auto it = variables.find(name);
+  if (it != variables.end()) {
+    v = std::clamp(v, it->second.minValue, it->second.maxValue);
+    it->second.value = v;
+  }
+  SetValue(name, std::to_string(v));
+}
+
+void UserPreferencesStore::ApplyDefaults() {
+  for (const auto &[name, info] : variables) {
+    float value = info.defaultValue;
+    auto raw = GetValue(name);
+    if (raw) {
+      float parsed = 0.0f;
+      if (TryParseFloat(*raw, parsed))
+        value = std::clamp(parsed, info.minValue, info.maxValue);
+    } else {
+      for (const auto &legacy : info.legacyNames) {
+        auto legacyRaw = GetValue(legacy);
+        if (!legacyRaw)
+          continue;
+        float parsed = 0.0f;
+        if (TryParseFloat(*legacyRaw, parsed)) {
+          value = std::clamp(parsed, info.minValue, info.maxValue);
+          break;
+        }
+      }
+    }
+    SetValue(name, std::to_string(value));
+  }
+}
+
+void UserPreferencesStore::ApplyColumnDefaults() {
+  if (!HasKey("fixture_print_columns"))
+    SetValue("fixture_print_columns", "position,id,type");
+  if (!HasKey("truss_print_columns"))
+    SetValue("truss_print_columns", "position,type,length");
+  if (!HasKey("support_print_columns"))
+    SetValue("support_print_columns", "position,type,height");
+  if (!HasKey("sceneobject_print_columns"))
+    SetValue("sceneobject_print_columns", "position,name,type");
+}
+
+std::vector<std::string> UserPreferencesStore::GetFixturePrintColumns() const {
+  auto val = GetValue("fixture_print_columns");
+  if (val)
+    return SplitCSV(*val);
+  return {};
+}
+
+void UserPreferencesStore::SetFixturePrintColumns(
+    const std::vector<std::string> &cols) {
+  SetValue("fixture_print_columns", JoinCSV(cols));
+}
+
+std::vector<std::string> UserPreferencesStore::GetTrussPrintColumns() const {
+  auto val = GetValue("truss_print_columns");
+  if (val)
+    return SplitCSV(*val);
+  return {};
+}
+
+void UserPreferencesStore::SetTrussPrintColumns(
+    const std::vector<std::string> &cols) {
+  SetValue("truss_print_columns", JoinCSV(cols));
+}
+
+std::vector<std::string> UserPreferencesStore::GetSupportPrintColumns() const {
+  auto val = GetValue("support_print_columns");
+  if (val)
+    return SplitCSV(*val);
+  return {};
+}
+
+void UserPreferencesStore::SetSupportPrintColumns(
+    const std::vector<std::string> &cols) {
+  SetValue("support_print_columns", JoinCSV(cols));
+}
+
+std::vector<std::string>
+UserPreferencesStore::GetSceneObjectPrintColumns() const {
+  auto val = GetValue("sceneobject_print_columns");
+  if (val)
+    return SplitCSV(*val);
+  return {};
+}
+
+void UserPreferencesStore::SetSceneObjectPrintColumns(
+    const std::vector<std::string> &cols) {
+  SetValue("sceneobject_print_columns", JoinCSV(cols));
+}
+
+bool UserPreferencesStore::LoadFromFile(const std::string &path) {
+  std::ifstream file(path, std::ios::binary);
+  if (!file.is_open())
+    return false;
+
+  nlohmann::json j;
+  try {
+    file >> j;
+  } catch (...) {
+    return false;
+  }
+  if (!j.is_object())
+    return false;
+
+  try {
+    configData = j.get<std::unordered_map<std::string, std::string>>();
+  } catch (...) {
+    return false;
+  }
+  ApplyColumnDefaults();
+  ApplyDefaults();
+  return true;
+}
+
+bool UserPreferencesStore::SaveToFile(const std::string &path) const {
+  std::ofstream file(path, std::ios::binary);
+  if (!file.is_open())
+    return false;
+
+  nlohmann::json j(configData);
+  file << j.dump(4);
+  return true;
+}
+
+std::string UserPreferencesStore::GetUserConfigFile() {
+  wxString dir = wxStandardPaths::Get().GetUserDataDir();
+  std::filesystem::path p = std::filesystem::path(dir.ToStdString());
+  std::filesystem::create_directories(p);
+  p /= "user_config.json";
+  return p.string();
+}
+
+bool UserPreferencesStore::LoadUserConfig() {
+  return LoadFromFile(GetUserConfigFile());
+}
+
+bool UserPreferencesStore::SaveUserConfig() const {
+  return SaveToFile(GetUserConfigFile());
+}
+
+const std::vector<std::string> &SelectionState::GetSelectedFixtures() const {
+  return selectedFixtures;
+}
+
+void SelectionState::SetSelectedFixtures(const std::vector<std::string> &uuids) {
+  selectedFixtures = uuids;
+}
+
+const std::vector<std::string> &SelectionState::GetSelectedTrusses() const {
+  return selectedTrusses;
+}
+
+void SelectionState::SetSelectedTrusses(const std::vector<std::string> &uuids) {
+  selectedTrusses = uuids;
+}
+
+const std::vector<std::string> &SelectionState::GetSelectedSupports() const {
+  return selectedSupports;
+}
+
+void SelectionState::SetSelectedSupports(const std::vector<std::string> &uuids) {
+  selectedSupports = uuids;
+}
+
+const std::vector<std::string> &SelectionState::GetSelectedSceneObjects() const {
+  return selectedSceneObjects;
+}
+
+void SelectionState::SetSelectedSceneObjects(
+    const std::vector<std::string> &uuids) {
+  selectedSceneObjects = uuids;
+}
+
+void SelectionState::Clear() {
+  selectedFixtures.clear();
+  selectedTrusses.clear();
+  selectedSupports.clear();
+  selectedSceneObjects.clear();
+}
+
+void HistoryManager::PushUndoState(const MvrScene &scene,
+                                   const SelectionState &selection,
+                                   const std::string &description) {
+  Snapshot snap{scene,
+                selection.GetSelectedFixtures(),
+                selection.GetSelectedTrusses(),
+                selection.GetSelectedSupports(),
+                selection.GetSelectedSceneObjects(),
+                description};
+  undoStack.push_back(std::move(snap));
+  if (undoStack.size() > maxHistory)
+    undoStack.erase(undoStack.begin());
+  redoStack.clear();
+}
+
+bool HistoryManager::CanUndo() const { return !undoStack.empty(); }
+
+bool HistoryManager::CanRedo() const { return !redoStack.empty(); }
+
+std::string HistoryManager::Undo(MvrScene &scene, SelectionState &selection) {
+  if (undoStack.empty())
+    return {};
+  const Snapshot snap = undoStack.back();
+  redoStack.push_back({scene,
+                       selection.GetSelectedFixtures(),
+                       selection.GetSelectedTrusses(),
+                       selection.GetSelectedSupports(),
+                       selection.GetSelectedSceneObjects(),
+                       snap.description});
+  scene = snap.scene;
+  selection.SetSelectedFixtures(snap.selFixtures);
+  selection.SetSelectedTrusses(snap.selTrusses);
+  selection.SetSelectedSupports(snap.selSupports);
+  selection.SetSelectedSceneObjects(snap.selSceneObjects);
+  undoStack.pop_back();
+  return snap.description;
+}
+
+std::string HistoryManager::Redo(MvrScene &scene, SelectionState &selection) {
+  if (redoStack.empty())
+    return {};
+  const Snapshot snap = redoStack.back();
+  undoStack.push_back({scene,
+                       selection.GetSelectedFixtures(),
+                       selection.GetSelectedTrusses(),
+                       selection.GetSelectedSupports(),
+                       selection.GetSelectedSceneObjects(),
+                       snap.description});
+  scene = snap.scene;
+  selection.SetSelectedFixtures(snap.selFixtures);
+  selection.SetSelectedTrusses(snap.selTrusses);
+  selection.SetSelectedSupports(snap.selSupports);
+  selection.SetSelectedSceneObjects(snap.selSceneObjects);
+  redoStack.pop_back();
+  return snap.description;
+}
+
+void HistoryManager::ClearHistory() {
+  undoStack.clear();
+  redoStack.clear();
+}
+
+std::unordered_set<std::string> LayerVisibilityState::GetHiddenLayers() const {
+  return hiddenLayers;
+}
+
+void LayerVisibilityState::SetHiddenLayers(
+    const std::unordered_set<std::string> &layers) {
+  hiddenLayers = layers;
+}
+
+bool LayerVisibilityState::IsLayerVisible(const std::string &layer) const {
+  std::string name = layer.empty() ? DEFAULT_LAYER_NAME : layer;
+  return hiddenLayers.find(name) == hiddenLayers.end();
+}
+
+void LayerVisibilityState::SetLayerColor(MvrScene &scene, const std::string &layer,
+                                         const std::string &color) {
+  std::string name = layer.empty() ? DEFAULT_LAYER_NAME : layer;
+  std::string layerUuid;
+  for (auto &[uuid, l] : scene.layers) {
+    if (l.name == name) {
+      layerUuid = uuid;
+      break;
+    }
+  }
+  if (layerUuid.empty()) {
+    Layer l;
+    l.name = name;
+    l.color = color;
+    l.uuid = "layer_" + std::to_string(scene.layers.size() + 1);
+    scene.layers[l.uuid] = l;
+  } else {
+    scene.layers[layerUuid].color = color;
+  }
+}
+
+std::optional<std::string>
+LayerVisibilityState::GetLayerColor(const MvrScene &scene,
+                                    const std::string &layer) const {
+  std::string name = layer.empty() ? DEFAULT_LAYER_NAME : layer;
+  for (const auto &[uuid, l] : scene.layers) {
+    if (l.name == name && !l.color.empty())
+      return l.color;
+  }
+  return std::nullopt;
+}
+
+std::vector<std::string>
+LayerVisibilityState::GetLayerNames(const MvrScene &scene) const {
+  std::set<std::string> names;
+  for (const auto &[uuid, layer] : scene.layers)
+    names.insert(layer.name);
+  auto collect = [&](const std::string &ln) {
+    if (!ln.empty())
+      names.insert(ln);
+  };
+  for (const auto &[u, f] : scene.fixtures)
+    collect(f.layer);
+  for (const auto &[u, t] : scene.trusses)
+    collect(t.layer);
+  for (const auto &[u, s] : scene.supports)
+    collect(s.layer);
+  for (const auto &[u, o] : scene.sceneObjects)
+    collect(o.layer);
+  names.insert(DEFAULT_LAYER_NAME);
+  return {names.begin(), names.end()};
+}
+
+const std::string &LayerVisibilityState::GetCurrentLayer() const {
+  return currentLayer;
+}
+
+void LayerVisibilityState::SetCurrentLayer(const std::string &name) {
+  if (name.empty())
+    currentLayer = DEFAULT_LAYER_NAME;
+  else
+    currentLayer = name;
+}
+
+MvrScene &ProjectSession::GetScene() { return scene; }
+
+const MvrScene &ProjectSession::GetScene() const { return scene; }
+
+bool ProjectSession::IsDirty() const { return revision != savedRevision; }
+
+void ProjectSession::Touch() { ++revision; }
+
+void ProjectSession::MarkSaved() { savedRevision = revision; }
+
+void ProjectSession::ResetDirty() {
+  revision = 0;
+  savedRevision = 0;
+}

--- a/core/configservices.h
+++ b/core/configservices.h
@@ -1,0 +1,136 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+#include "mvrscene.h"
+
+inline constexpr const char *DEFAULT_LAYER_NAME = "No Layer";
+
+class UserPreferencesStore {
+public:
+  struct VariableInfo {
+    std::string type;
+    float defaultValue = 0.0f;
+    float value = 0.0f;
+    float minValue = 0.0f;
+    float maxValue = 0.0f;
+    std::vector<std::string> legacyNames;
+  };
+
+  void SetValue(const std::string &key, const std::string &value);
+  std::optional<std::string> GetValue(const std::string &key) const;
+  bool HasKey(const std::string &key) const;
+  void RemoveKey(const std::string &key);
+  void ClearValues();
+
+  bool LoadFromFile(const std::string &path);
+  bool SaveToFile(const std::string &path) const;
+  static std::string GetUserConfigFile();
+  bool LoadUserConfig();
+  bool SaveUserConfig() const;
+
+  void RegisterVariable(const std::string &name, const std::string &type,
+                        float defVal, float minVal, float maxVal,
+                        std::vector<std::string> legacyNames = {});
+  float GetFloat(const std::string &name) const;
+  void SetFloat(const std::string &name, float v);
+  void ApplyDefaults();
+
+  std::vector<std::string> GetFixturePrintColumns() const;
+  void SetFixturePrintColumns(const std::vector<std::string> &cols);
+  std::vector<std::string> GetTrussPrintColumns() const;
+  void SetTrussPrintColumns(const std::vector<std::string> &cols);
+  std::vector<std::string> GetSupportPrintColumns() const;
+  void SetSupportPrintColumns(const std::vector<std::string> &cols);
+  std::vector<std::string> GetSceneObjectPrintColumns() const;
+  void SetSceneObjectPrintColumns(const std::vector<std::string> &cols);
+
+private:
+  void ApplyColumnDefaults();
+
+  std::unordered_map<std::string, std::string> configData;
+  std::unordered_map<std::string, VariableInfo> variables;
+};
+
+class SelectionState {
+public:
+  const std::vector<std::string> &GetSelectedFixtures() const;
+  void SetSelectedFixtures(const std::vector<std::string> &uuids);
+  const std::vector<std::string> &GetSelectedTrusses() const;
+  void SetSelectedTrusses(const std::vector<std::string> &uuids);
+  const std::vector<std::string> &GetSelectedSupports() const;
+  void SetSelectedSupports(const std::vector<std::string> &uuids);
+  const std::vector<std::string> &GetSelectedSceneObjects() const;
+  void SetSelectedSceneObjects(const std::vector<std::string> &uuids);
+  void Clear();
+
+private:
+  std::vector<std::string> selectedFixtures;
+  std::vector<std::string> selectedTrusses;
+  std::vector<std::string> selectedSupports;
+  std::vector<std::string> selectedSceneObjects;
+};
+
+class HistoryManager {
+public:
+  struct Snapshot {
+    MvrScene scene;
+    std::vector<std::string> selFixtures;
+    std::vector<std::string> selTrusses;
+    std::vector<std::string> selSupports;
+    std::vector<std::string> selSceneObjects;
+    std::string description;
+  };
+
+  void PushUndoState(const MvrScene &scene, const SelectionState &selection,
+                     const std::string &description = "");
+  bool CanUndo() const;
+  bool CanRedo() const;
+  std::string Undo(MvrScene &scene, SelectionState &selection);
+  std::string Redo(MvrScene &scene, SelectionState &selection);
+  void ClearHistory();
+
+private:
+  std::vector<Snapshot> undoStack;
+  std::vector<Snapshot> redoStack;
+  size_t maxHistory = 20;
+};
+
+class LayerVisibilityState {
+public:
+  std::unordered_set<std::string> GetHiddenLayers() const;
+  void SetHiddenLayers(const std::unordered_set<std::string> &layers);
+  bool IsLayerVisible(const std::string &layer) const;
+
+  void SetLayerColor(MvrScene &scene, const std::string &layer,
+                     const std::string &color);
+  std::optional<std::string> GetLayerColor(const MvrScene &scene,
+                                           const std::string &layer) const;
+  std::vector<std::string> GetLayerNames(const MvrScene &scene) const;
+
+  const std::string &GetCurrentLayer() const;
+  void SetCurrentLayer(const std::string &name);
+
+private:
+  std::unordered_set<std::string> hiddenLayers;
+  std::string currentLayer = DEFAULT_LAYER_NAME;
+};
+
+class ProjectSession {
+public:
+  MvrScene &GetScene();
+  const MvrScene &GetScene() const;
+
+  bool IsDirty() const;
+  void Touch();
+  void MarkSaved();
+  void ResetDirty();
+
+private:
+  MvrScene scene;
+  size_t revision = 0;
+  size_t savedRevision = 0;
+};

--- a/gui/layerpanel.h
+++ b/gui/layerpanel.h
@@ -21,10 +21,12 @@
 #include <wx/dataview.h>
 #include <wx/colordlg.h>
 
+class ConfigManager;
+
 class LayerPanel : public wxPanel
 {
 public:
-    explicit LayerPanel(wxWindow* parent, bool showButtons = true);
+    explicit LayerPanel(wxWindow* parent, bool showButtons = true, ConfigManager* config = nullptr);
     void ReloadLayers();
 
     static LayerPanel* Instance();
@@ -39,4 +41,5 @@ private:
     void OnRenameLayer(wxDataViewEvent& evt);
     wxDataViewListCtrl* list = nullptr;
     static LayerPanel* s_instance;
+    ConfigManager* configManager = nullptr;
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -315,3 +315,54 @@ target_include_directories(gdtfloader_primitive_test PRIVATE
 target_link_libraries(gdtfloader_primitive_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
 add_test(NAME GdtfLoaderPrimitiveFallback COMMAND gdtfloader_primitive_test)
 set_library_env(GdtfLoaderPrimitiveFallback)
+
+
+add_executable(user_preferences_store_test
+               user_preferences_store_test.cpp
+               ../core/configservices.cpp)
+target_include_directories(user_preferences_store_test PRIVATE ../core ../external ../models)
+target_link_libraries(user_preferences_store_test PRIVATE ${wxWidgets_LIBRARIES})
+add_test(NAME UserPreferencesStore COMMAND user_preferences_store_test)
+
+add_executable(project_session_test
+               project_session_test.cpp
+               ../core/configservices.cpp
+               ../models/mvrscene.cpp
+               ../models/fixture.cpp
+               ../models/truss.cpp
+               ../models/sceneobject.cpp
+               ../models/layer.cpp)
+target_include_directories(project_session_test PRIVATE ../core ../models ../external)
+target_link_libraries(project_session_test PRIVATE ${wxWidgets_LIBRARIES})
+add_test(NAME ProjectSession COMMAND project_session_test)
+
+add_executable(selection_state_test
+               selection_state_test.cpp
+               ../core/configservices.cpp)
+target_include_directories(selection_state_test PRIVATE ../core ../external ../models)
+target_link_libraries(selection_state_test PRIVATE ${wxWidgets_LIBRARIES})
+add_test(NAME SelectionState COMMAND selection_state_test)
+
+add_executable(history_manager_test
+               history_manager_test.cpp
+               ../core/configservices.cpp
+               ../models/mvrscene.cpp
+               ../models/fixture.cpp
+               ../models/truss.cpp
+               ../models/sceneobject.cpp
+               ../models/layer.cpp)
+target_include_directories(history_manager_test PRIVATE ../core ../models ../external)
+target_link_libraries(history_manager_test PRIVATE ${wxWidgets_LIBRARIES})
+add_test(NAME HistoryManager COMMAND history_manager_test)
+
+add_executable(layer_visibility_state_test
+               layer_visibility_state_test.cpp
+               ../core/configservices.cpp
+               ../models/mvrscene.cpp
+               ../models/fixture.cpp
+               ../models/truss.cpp
+               ../models/sceneobject.cpp
+               ../models/layer.cpp)
+target_include_directories(layer_visibility_state_test PRIVATE ../core ../models ../external)
+target_link_libraries(layer_visibility_state_test PRIVATE ${wxWidgets_LIBRARIES})
+add_test(NAME LayerVisibilityState COMMAND layer_visibility_state_test)

--- a/tests/history_manager_test.cpp
+++ b/tests/history_manager_test.cpp
@@ -1,0 +1,27 @@
+#include "configservices.h"
+
+#include <cassert>
+
+int main() {
+  HistoryManager history;
+  SelectionState selection;
+  ProjectSession session;
+
+  Fixture f;
+  f.uuid = "f1";
+  session.GetScene().fixtures[f.uuid] = f;
+  selection.SetSelectedFixtures({"f1"});
+
+  history.PushUndoState(session.GetScene(), selection, "add fixture");
+  session.GetScene().fixtures.clear();
+  selection.Clear();
+
+  assert(history.CanUndo());
+  assert(history.Undo(session.GetScene(), selection) == "add fixture");
+  assert(session.GetScene().fixtures.size() == 1);
+  assert(selection.GetSelectedFixtures().size() == 1);
+  assert(history.CanRedo());
+
+  assert(history.Redo(session.GetScene(), selection) == "add fixture");
+  return 0;
+}

--- a/tests/layer_visibility_state_test.cpp
+++ b/tests/layer_visibility_state_test.cpp
@@ -1,0 +1,22 @@
+#include "configservices.h"
+
+#include <cassert>
+
+int main() {
+  LayerVisibilityState layers;
+  MvrScene scene;
+
+  layers.SetHiddenLayers({"Layer A"});
+  assert(!layers.IsLayerVisible("Layer A"));
+  assert(layers.IsLayerVisible("Layer B"));
+
+  layers.SetLayerColor(scene, "Layer A", "#ff0000");
+  assert(layers.GetLayerColor(scene, "Layer A").value() == "#ff0000");
+
+  layers.SetCurrentLayer("Layer B");
+  assert(layers.GetCurrentLayer() == "Layer B");
+
+  auto names = layers.GetLayerNames(scene);
+  assert(!names.empty());
+  return 0;
+}

--- a/tests/project_session_test.cpp
+++ b/tests/project_session_test.cpp
@@ -1,0 +1,21 @@
+#include "configservices.h"
+
+#include <cassert>
+
+int main() {
+  ProjectSession session;
+  assert(!session.IsDirty());
+  session.Touch();
+  assert(session.IsDirty());
+  session.MarkSaved();
+  assert(!session.IsDirty());
+
+  Fixture f;
+  f.uuid = "fixture-1";
+  session.GetScene().fixtures[f.uuid] = f;
+  assert(session.GetScene().fixtures.size() == 1);
+
+  session.ResetDirty();
+  assert(!session.IsDirty());
+  return 0;
+}

--- a/tests/selection_state_test.cpp
+++ b/tests/selection_state_test.cpp
@@ -1,0 +1,23 @@
+#include "configservices.h"
+
+#include <cassert>
+
+int main() {
+  SelectionState state;
+  state.SetSelectedFixtures({"f1", "f2"});
+  state.SetSelectedTrusses({"t1"});
+  state.SetSelectedSupports({"s1"});
+  state.SetSelectedSceneObjects({"o1"});
+
+  assert(state.GetSelectedFixtures().size() == 2);
+  assert(state.GetSelectedTrusses().size() == 1);
+  assert(state.GetSelectedSupports().size() == 1);
+  assert(state.GetSelectedSceneObjects().size() == 1);
+
+  state.Clear();
+  assert(state.GetSelectedFixtures().empty());
+  assert(state.GetSelectedTrusses().empty());
+  assert(state.GetSelectedSupports().empty());
+  assert(state.GetSelectedSceneObjects().empty());
+  return 0;
+}

--- a/tests/user_preferences_store_test.cpp
+++ b/tests/user_preferences_store_test.cpp
@@ -1,0 +1,23 @@
+#include "configservices.h"
+
+#include <cassert>
+#include <filesystem>
+
+int main() {
+  UserPreferencesStore store;
+  store.RegisterVariable("zoom", "float", 1.0f, 0.5f, 2.0f);
+  store.SetValue("zoom", "4.0");
+  assert(store.GetFloat("zoom") == 2.0f);
+
+  const std::filesystem::path out = std::filesystem::temp_directory_path() /
+                                    "perastage_user_preferences_store_test.json";
+  assert(store.SaveToFile(out.string()));
+
+  UserPreferencesStore loaded;
+  loaded.RegisterVariable("zoom", "float", 1.0f, 0.5f, 2.0f);
+  assert(loaded.LoadFromFile(out.string()));
+  assert(loaded.GetFloat("zoom") == 2.0f);
+  std::error_code ec;
+  std::filesystem::remove(out, ec);
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- Separar responsabilidades y permitir inyección de dependencias extrayendo la lógica de configuración/estado del singleton monolítico `ConfigManager` en servicios más pequeños y testeables.
- Mantener compatibilidad hacia atrás mientras se habilita una migración gradual de la GUI para reducir accesos globales a `ConfigManager::Get()`.

### Description
- Añadidos los nuevos subservicios `UserPreferencesStore`, `ProjectSession`, `SelectionState`, `HistoryManager` y `LayerVisibilityState` en `core/configservices.h` y `core/configservices.cpp` y se movió la lógica correspondiente desde `core/configmanager.*` a esos archivos.
- `ConfigManager` se conserva como fachada de compatibilidad y ahora delega operaciones a las instancias miembro `preferencesStore`, `projectSession`, `selectionState`, `historyManager` y `layerVisibilityState` sin cambiar su API pública (`core/configmanager.h` / `core/configmanager.cpp`).
- Inicio de migración en GUI: `LayerPanel` acepta ahora una dependencia inyectable `ConfigManager*` (con fallback a la instancia singleton) y se actualizó su código para usar la dependencia en lugar de llamadas directas a `ConfigManager::Get()` (`gui/layerpanel.h`, `gui/layerpanel.cpp`).
- Añadidos tests unitarios por subservicio y los ficheros de prueba a `tests/` (`user_preferences_store_test.cpp`, `project_session_test.cpp`, `selection_state_test.cpp`, `history_manager_test.cpp`, `layer_visibility_state_test.cpp`) y se registraron en `tests/CMakeLists.txt`.

### Testing
- Intenté configurar el proyecto con `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`, pero la configuración falló en este entorno por no poder localizar `wxWidgets` (`wxWidgets_LIBRARIES`/`wxWidgets_INCLUDE_DIRS`).
- Se añadieron pruebas unitarias en `tests/` para cada subservicio (no se ejecutaron aquí debido al fallo de configuración de CMake en este entorno); los tests están listados en `tests/CMakeLists.txt` y pueden ejecutarse una vez que las dependencias (p. ej. `wxWidgets`) estén disponibles.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e196b3d70832480e71146e1ea34a3)