### PR TITLE
Fix GDScript parse error in peraviz test script

### DIFF
--- a/peraviz/test.gd
+++ b/peraviz/test.gd
@@ -1,6 +1,6 @@
 extends Node
 
 func _ready() -> void:
-	var native := HelloWorld.new()
-	var message := native.ping()
-	print("[PeravizTest] %s" % message)
+	var hello_world = HelloWorld.new()
+	var message = hello_world.ping()
+	print("[PeravizTest] " + str(message))


### PR DESCRIPTION
### Motivation
- Corregir un posible `Parse error` en GDScript evitando sintaxis que puede fallar en algunas versiones/configuraciones de Godot renombrando la variable local y simplificando la asignación e impresión.

### Description
- Actualiza `peraviz/test.gd` para usar `var hello_world = HelloWorld.new()` en lugar de `var native := ...` y reemplaza `print("[PeravizTest] %s" % message)` por `print("[PeravizTest] " + str(message))`, manteniendo la misma lógica de instanciación y llamada a `ping()`.

### Testing
- Intenté ejecutar `godot --headless --path peraviz --check-only` pero `godot` no está disponible en este entorno, por lo que no se pudo validar con el comprobador de Godot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e1ce6cccc8324b659ab9691cb1eca)