### PR TITLE
peraviz: show native ping result in HUD PingLabel

### DIFF
--- a/peraviz/test.gd
+++ b/peraviz/test.gd
@@ -4,3 +4,9 @@ func _ready() -> void:
 	var hello_world = HelloWorld.new()
 	var message = hello_world.ping()
 	print("[PeravizTest] " + str(message))
+
+	var ping_label := get_node_or_null("HUD/PingLabel") as Label
+	if ping_label:
+		ping_label.text = str(message)
+	else:
+		push_warning("[PeravizTest] HUD/PingLabel is missing; cannot display ping result")

--- a/peraviz/test.tscn
+++ b/peraviz/test.tscn
@@ -4,3 +4,13 @@
 
 [node name="PeravizTest" type="Node"]
 script = ExtResource("1_test")
+
+[node name="HUD" type="CanvasLayer" parent="."]
+
+[node name="PingLabel" type="Label" parent="HUD"]
+offset_left = 10.0
+offset_top = 10.0
+offset_right = 510.0
+offset_bottom = 48.0
+theme_override_font_sizes/font_size = 24
+text = "Waiting..."


### PR DESCRIPTION
### Motivation
- Make the native extension ping result visible in the running scene so the returned string from `HelloWorld.ping()` is shown on-screen in addition to the existing console logs.
- Do this entirely within `peraviz/` without touching native C++ or Perastage code and keep startup robust if the HUD node is missing.

### Description
- Added a `CanvasLayer` node `HUD` and a `Label` node `PingLabel` to the main scene `peraviz/test.tscn`, positioned top-left with 10px-style offsets and `theme_override_font_sizes/font_size = 24`, default text `"Waiting..."`.
- Updated `peraviz/test.gd` to preserve the existing behavior (`HelloWorld.new()`, `ping()`, and `print("[PeravizTest] ...")`) and then set `$HUD/PingLabel.text` to the returned `ping()` message.
- Use `get_node_or_null("HUD/PingLabel")` and `push_warning(...)` as a safe fallback so the game does not crash if the label is absent.

### Testing
- Attempted to run Godot headless with `godot --headless --path peraviz --quit`, but the `godot` command is not available in this environment so runtime execution could not be validated (failed).
- Repository operations and patches were applied successfully and the two modified files (`peraviz/test.tscn`, `peraviz/test.gd`) were committed to the repo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f64d1ff54832485aec01d6ea79a4a)