### PR TITLE
Translate AGENTS guidance to English and add language policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# AGENTS.md (global)
+
+## Objective
+Keep Perastage clean and modular while continuing to deliver new features, following `docs/code_health_review_2026-02-13.md`.
+
+## Mandatory global rules
+
+1. **Modularity before growing large files**
+   - Avoid adding large logic blocks to hotspot files.
+   - If a change introduces a new responsibility, create/use adjacent files organized by responsibility.
+
+2. **File-size guardrail (soft limit)**
+   - When touching a file near **1200–1500 LOC**, prioritize extraction before adding major features.
+   - If extraction is not feasible in the same PR, include a short technical note in the PR description with the next recommended split.
+
+3. **Architecture and build conventions**
+   - Keep explicit source ownership in CMake (no `GLOB_RECURSE` for project source registration).
+   - Respect module boundaries described in `docs/architecture.md` and `perastage_tree.md`.
+
+4. **Mandatory checks before closing changes**
+   - Run and keep green:
+     - `tests/check_perastage_tree_modules.sh`
+     - `tests/check_no_configmanager_get_in_gui.sh`
+   - If a new architectural boundary is introduced, add a small `tests/check_*.sh` script in the same PR.
+
+5. **Refactoring strategy**
+   - Refactor incrementally around touched code paths.
+   - Avoid big-bang rewrites.
+
+6. **Language policy for contributions**
+   - All new/updated code must be written in English.
+   - All code comments and documentation updates should be written in English.
+
+## Current hotspots (watch for growth)
+- `gui/layoutviewerpanel.cpp`
+- `viewer2d/viewer2dpanel.cpp`
+- `viewer2d/pdf/layout_pdf_exporter.cpp`
+- `viewer3d/viewer3dcontroller.cpp`
+- `mvr/mvrexporter.cpp`
+- `gui/mainwindow_menu.cpp`
+- `gui/fixturetablepanel.cpp`
+
+## Change quality
+- Keep changes small, focused, and explicit in responsibility naming.
+- Before introducing cross-module coupling, prefer an interface/helper in the module that owns the responsibility.

--- a/gui/AGENTS.md
+++ b/gui/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS.md (gui)
+
+## Scope
+These rules apply to everything under `gui/`.
+
+## Rules
+1. **Do not grow UI hotspots without prior extraction**
+   - Priority files to contain growth:
+     - `layoutviewerpanel.cpp`
+     - `mainwindow_menu.cpp`
+     - `fixturetablepanel.cpp`
+   - New menu logic, routing, or complex behavior should go into specialized files (`*_menu*`, `*_controller*`, `*_layout*`, etc.).
+
+2. **UI responsibility separation**
+   - Keep these concerns separated:
+     - widget/layout construction,
+     - event wiring,
+     - command/action logic,
+     - UI IO/import/export.
+
+3. **Large changes in hotspots**
+   - For large hotspot changes, add tests/regressions (or available integration checks) for touched behavior first, then extract.
+
+4. **Dependencies**
+   - Avoid introducing GUI dependencies on internal details of other modules when a public API or helper exists in the owning module.

--- a/mvr/AGENTS.md
+++ b/mvr/AGENTS.md
@@ -1,0 +1,17 @@
+# AGENTS.md (mvr)
+
+## Scope
+These rules apply to everything under `mvr/`.
+
+## Rules
+1. **Primary hotspot**
+   - `mvrexporter.cpp` should evolve through responsibility extraction.
+
+2. **Recommended separation when extending exporter logic**
+   - Keep decoupled:
+     - data normalization/preparation,
+     - XML serialization,
+     - package/file writing.
+
+3. **Change strategy**
+   - Refactor opportunistically around touched paths; avoid massive one-PR changes.

--- a/viewer2d/AGENTS.md
+++ b/viewer2d/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS.md (viewer2d)
+
+## Scope
+These rules apply to everything under `viewer2d/`.
+
+## Rules
+1. **Contain hotspots**
+   - Files to monitor:
+     - `viewer2dpanel.cpp`
+     - `pdf/layout_pdf_exporter.cpp`
+   - Add new capabilities using responsibility-focused components (e.g., camera, grid/overlay, page composition, element renderers).
+
+2. **Suggested split direction when touching hotspots**
+   - `viewer2dpanel.cpp`: separate camera/grid/overlay logic from draw submission.
+   - `layout_pdf_exporter.cpp`: separate page composition from element rendering.
+
+3. **Incremental refactoring**
+   - Do not attempt full rewrites; extract only around the modified flow.

--- a/viewer3d/AGENTS.md
+++ b/viewer3d/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md (viewer3d)
+
+## Scope
+These rules apply to everything under `viewer3d/`.
+
+## Rules
+1. **Primary hotspot**
+   - `viewer3dcontroller.cpp` should be kept contained.
+
+2. **Design direction when extending controller logic**
+   - Separate command/interaction handling from scene/resource synchronization.
+   - If a new responsibility is added, create a dedicated unit in submodules (`render/`, `resources/`, `picking/`, etc.) before growing the controller.
+
+3. **Safe changes**
+   - For significant splits, cover current touched behavior first with available tests/regression checks.


### PR DESCRIPTION
### Motivation
- Convert the previously Spanish project governance files to English to align documentation and in-repo guidance with the repository standard and the user's request.  
- Preserve the code-health guardrails from `docs/code_health_review_2026-02-13.md` (hotspot tracking, extraction guidance, and mandatory checks) while adding an explicit language policy for contributions.

### Description
- Translated and replaced AGENTS guidance into English for the root and module scopes by updating `AGENTS.md`, `gui/AGENTS.md`, `viewer2d/AGENTS.md`, `viewer3d/AGENTS.md`, and `mvr/AGENTS.md`, keeping existing hotspot and refactor rules intact.  
- Added a global language policy requiring that all new/updated code, comments, and documentation be written in English (new rule in `AGENTS.md`).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which reported `OK`.  
- Ran `tests/check_no_configmanager_get_in_gui.sh` which reported `OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f6c6cc3b4832496ca95a8a0fe32f6)