### PR TITLE
Add initial MVR proxy loading path to Peraviz GDExtension

### DIFF
--- a/peraviz/docs/NATIVE_BUILD.md
+++ b/peraviz/docs/NATIVE_BUILD.md
@@ -1,64 +1,64 @@
-# Compilación nativa (GDExtension) para Peraviz
+# Native build (GDExtension) for Peraviz
 
-Este documento describe cómo compilar la extensión nativa C++ (`peraviz_native`) para el proyecto Godot `peraviz/`, incluyendo la carga inicial de escenas MVR con proxies.
+This document explains how to build the C++ native extension (`peraviz_native`) for the Godot project in `peraviz/`, including the initial MVR proxy loading workflow.
 
-## Versiones soportadas
+## Supported versions
 
 - **Godot**: `4.2+`.
 - **godot-cpp**: `godot-4.2.2-stable`.
 
-## Dependencias nuevas para el cargador MVR
+## New dependencies for the MVR loader
 
-Además de `godot-cpp`, el target nativo ahora enlaza:
+In addition to `godot-cpp`, the native target now links:
 
-- `tinyxml2`: parseo de `GeneralSceneDescription.xml`.
-- `wxWidgets (core/base)`: lectura del contenedor ZIP `.mvr` mediante `wxZipInputStream`.
-- Cabeceras compartidas de Perastage (`models/types.h`, `models/matrixutils.h`) para matrices y composición de transformaciones.
+- `tinyxml2`: parsing `GeneralSceneDescription.xml`.
+- `wxWidgets (core/base)`: reading `.mvr` ZIP containers through `wxZipInputStream`.
+- Shared Perastage headers (`models/types.h`, `models/matrixutils.h`) for matrix handling and transform composition.
 
-## Conversión de coordenadas (MVR/GDTF -> Godot)
+## Coordinate conversion (MVR/GDTF -> Godot)
 
-La conversión se hace en C++ antes de exponer datos a GDScript:
+The conversion is performed in C++ before exposing data to GDScript:
 
-- MVR trabaja típicamente en mm con convención Z-up.
-- Godot usa metros con convención Y-up.
-- Se aplica mapeo de ejes y escala de unidades en `mvr_scene_loader.cpp`, y se exporta a GDScript como `Vector3` para posición/rotación/escala.
+- MVR typically uses millimeters with a Z-up convention.
+- Godot uses meters with a Y-up convention.
+- Axis mapping and unit scaling are applied in `mvr_scene_loader.cpp`, and values are exported to GDScript as `Vector3` for position/rotation/scale.
 
-## Compilación standalone
+## Standalone build
 
-Desde la raíz del repositorio:
+From the repository root:
 
 ```bash
 cmake -S peraviz/native -B peraviz/native/build -DCMAKE_BUILD_TYPE=Debug
 cmake --build peraviz/native/build --config Debug
 ```
 
-La librería resultante se copia automáticamente a `peraviz/bin/`.
+The resulting library is copied automatically to `peraviz/bin/`.
 
-## Integración con CMake raíz
+## Root CMake integration
 
-La raíz incluye el subproyecto con:
+The root CMake includes this subproject with:
 
-- `-DPERAVIZ_ENABLE_NATIVE=ON` (por defecto).
+- `-DPERAVIZ_ENABLE_NATIVE=ON` (default).
 
-Para desactivar:
+To disable it:
 
 ```bash
 cmake -S . -B build -DPERAVIZ_ENABLE_NATIVE=OFF
 ```
 
-## Uso desde Godot
+## Usage from Godot
 
-La clase nativa `PeravizLoader` expone:
+The native class `PeravizLoader` exposes:
 
 - `load_mvr(path: String) -> Array`
 
-Cada elemento del array es un `Dictionary` con:
+Each array element is a `Dictionary` with:
 
 - `id: String`
 - `type: String` (`fixture`, `truss`, `support`, `scene_object`)
 - `is_fixture: bool`
 - `pos: Vector3`
-- `rot: Vector3` (grados)
+- `rot: Vector3` (degrees)
 - `scale: Vector3`
 
-El script `res://scripts/load_scene.gd` usa estos datos para instanciar proxies (`ConeMesh` / `BoxMesh`) en la escena de prueba.
+The script `res://scripts/load_scene.gd` consumes this data to instantiate proxy meshes (`ConeMesh` / `BoxMesh`) in the test scene.

--- a/peraviz/docs/USED_LIBS.md
+++ b/peraviz/docs/USED_LIBS.md
@@ -1,13 +1,13 @@
-# Peraviz: módulos de Perastage reutilizados
+# Peraviz: reused Perastage modules
 
-## Librerías / módulos usados en el hito de proxies MVR
+## Modules used in the MVR proxy milestone
 
-- `models/types.h` y `models/matrixutils.h`  
-  Se usan para parsear matrices MVR (`MatrixUtils::ParseMatrix`), componer transformaciones jerárquicas (`MatrixUtils::Multiply`) y extraer euler para proxy placement.
+- `models/types.h` and `models/matrixutils.h`  
+  Used to parse MVR matrices (`MatrixUtils::ParseMatrix`), compose hierarchical transforms (`MatrixUtils::Multiply`), and extract Euler angles for proxy placement.
 
-- Esquema MVR de `mvr/` (compatibilidad de estructura XML)  
-  El cargador nativo de Peraviz sigue la misma estructura de nodos de Perastage (`GeneralSceneDescription -> Scene -> Layers -> ChildList`) para fixtures, trusses, supports y scene objects.
+- MVR schema compatibility from `mvr/`  
+  The native Peraviz loader follows the same node structure used by Perastage (`GeneralSceneDescription -> Scene -> Layers -> ChildList`) for fixtures, trusses, supports, and scene objects.
 
-## Notas
+## Notes
 
-- En este hito todavía no se reutiliza la tubería completa de geometría/materiales; solamente se comparte la base de transformaciones y parsing espacial para validar ejes/unidades.
+- This milestone still does not reuse the full geometry/material pipeline. It reuses the transformation and spatial parsing foundation to validate axis and unit conversion first.

--- a/peraviz/docs/USED_LIBS.md
+++ b/peraviz/docs/USED_LIBS.md
@@ -1,11 +1,13 @@
-# Peraviz: módulos de Perastage a reutilizar
+# Peraviz: módulos de Perastage reutilizados
 
-> Estado inicial (hito 1): sin integración funcional todavía.
+## Librerías / módulos usados en el hito de proxies MVR
 
-## Lista preliminar
+- `models/types.h` y `models/matrixutils.h`  
+  Se usan para parsear matrices MVR (`MatrixUtils::ParseMatrix`), componer transformaciones jerárquicas (`MatrixUtils::Multiply`) y extraer euler para proxy placement.
 
-- *(vacío por ahora)*
+- Esquema MVR de `mvr/` (compatibilidad de estructura XML)  
+  El cargador nativo de Peraviz sigue la misma estructura de nodos de Perastage (`GeneralSceneDescription -> Scene -> Layers -> ChildList`) para fixtures, trusses, supports y scene objects.
 
 ## Notas
 
-- Este archivo documentará, por etapas, qué módulos/librerías de Perastage se exponen como librerías reutilizables para Peraviz.
+- En este hito todavía no se reutiliza la tubería completa de geometría/materiales; solamente se comparte la base de transformaciones y parsing espacial para validar ejes/unidades.

--- a/peraviz/native/CMakeLists.txt
+++ b/peraviz/native/CMakeLists.txt
@@ -31,17 +31,61 @@ if(NOT TARGET godot-cpp)
     endif()
 endif()
 
+
+if(EXISTS "${CMAKE_SOURCE_DIR}/models/matrixutils.h")
+    set(PERASTAGE_ROOT_DIR "${CMAKE_SOURCE_DIR}")
+elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../../models/matrixutils.h")
+    get_filename_component(PERASTAGE_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." ABSOLUTE)
+else()
+    message(FATAL_ERROR "Cannot locate Perastage root (models/matrixutils.h not found).")
+endif()
+
+if(NOT tinyxml2_FOUND)
+    find_package(tinyxml2 CONFIG QUIET)
+endif()
+if(NOT TARGET tinyxml2::tinyxml2)
+    find_path(TINYXML2_INCLUDE_DIR tinyxml2.h)
+    find_library(TINYXML2_LIBRARY tinyxml2)
+    if(NOT TINYXML2_INCLUDE_DIR OR NOT TINYXML2_LIBRARY)
+        message(FATAL_ERROR "tinyxml2 not found. Install development package or provide tinyxml2Config.cmake")
+    endif()
+    add_library(tinyxml2::tinyxml2 UNKNOWN IMPORTED)
+    set_target_properties(tinyxml2::tinyxml2 PROPERTIES
+        IMPORTED_LOCATION "${TINYXML2_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${TINYXML2_INCLUDE_DIR}"
+    )
+endif()
+
+if(NOT wxWidgets_FOUND)
+    find_package(wxWidgets REQUIRED COMPONENTS core base)
+    include(${wxWidgets_USE_FILE})
+    set(_peraviz_wx_libs ${wxWidgets_LIBRARIES})
+else()
+    if(TARGET wx::core)
+        set(_peraviz_wx_libs wx::core wx::base)
+    else()
+        set(_peraviz_wx_libs ${wxWidgets_LIBRARIES})
+    endif()
+endif()
+
 add_library(peraviz_native SHARED
     src/hello_world.cpp
+    src/mvr_scene_loader.cpp
+    src/peraviz_loader.cpp
     src/register_types.cpp
     src/entry.cpp
 )
 
 target_include_directories(peraviz_native PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/src"
+    "${PERASTAGE_ROOT_DIR}/models"
 )
 
-target_link_libraries(peraviz_native PRIVATE godot-cpp)
+target_link_libraries(peraviz_native PRIVATE
+    godot-cpp
+    tinyxml2::tinyxml2
+    ${_peraviz_wx_libs}
+)
 
 set_target_properties(peraviz_native PROPERTIES
     OUTPUT_NAME "peraviz_native"

--- a/peraviz/native/src/mvr_scene_loader.cpp
+++ b/peraviz/native/src/mvr_scene_loader.cpp
@@ -1,0 +1,214 @@
+#include "mvr_scene_loader.h"
+
+#include "matrixutils.h"
+#include "types.h"
+
+#include <cmath>
+#include <memory>
+#include <cctype>
+#include <filesystem>
+#include <functional>
+#include <string>
+
+#include <tinyxml2.h>
+#include <wx/wfstream.h>
+#include <wx/zipstrm.h>
+
+namespace {
+
+using peraviz::SceneInstance;
+using peraviz::SceneModel;
+using peraviz::Vec3;
+
+Vec3 map_position(const std::array<float, 3> &source_mm) {
+    return Vec3{source_mm[0] / 1000.0F, source_mm[2] / 1000.0F,
+                -source_mm[1] / 1000.0F};
+}
+
+std::array<float, 3> map_axis(const std::array<float, 3> &v) {
+    return {v[0], v[2], -v[1]};
+}
+
+Matrix to_godot_basis_matrix(const Matrix &source) {
+    Matrix out;
+    out.u = map_axis(source.u);
+    out.v = map_axis(source.v);
+    out.w = map_axis(source.w);
+    out.o = {0.0F, 0.0F, 0.0F};
+    return out;
+}
+
+std::array<float, 3> extract_scale(const Matrix &m) {
+    auto len = [](const std::array<float, 3> &v) {
+        return std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
+    };
+    return {len(m.u), len(m.v), len(m.w)};
+}
+
+Matrix normalize_basis(const Matrix &m, const std::array<float, 3> &scale) {
+    Matrix out = m;
+    auto safe_div = [](float value, float s) {
+        return (std::abs(s) > 1e-6F) ? value / s : value;
+    };
+    for (int i = 0; i < 3; ++i) {
+        out.u[i] = safe_div(out.u[i], scale[0]);
+        out.v[i] = safe_div(out.v[i], scale[1]);
+        out.w[i] = safe_div(out.w[i], scale[2]);
+    }
+    return out;
+}
+
+std::string read_xml_from_mvr(const std::string &path) {
+    wxFileInputStream input(wxString::FromUTF8(path.c_str()));
+    if (!input.IsOk()) {
+        return {};
+    }
+
+    wxZipInputStream zip(input);
+    std::unique_ptr<wxZipEntry> entry;
+    while ((entry.reset(zip.GetNextEntry())), entry) {
+        std::string file_name = entry->GetName().ToUTF8().data();
+        std::string lower = file_name;
+        for (char &c : lower) {
+            c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+        }
+        if (lower.find("generalscenedescription.xml") == std::string::npos) {
+            continue;
+        }
+
+        std::string xml;
+        char buffer[4096];
+        while (!zip.Eof()) {
+            zip.Read(buffer, sizeof(buffer));
+            size_t n = zip.LastRead();
+            if (n == 0) {
+                break;
+            }
+            xml.append(buffer, n);
+        }
+        return xml;
+    }
+
+    return {};
+}
+
+void append_instance(SceneModel &scene, const std::string &type, bool is_fixture,
+                     const std::string &id, const Matrix &world) {
+    SceneInstance instance;
+    instance.type = type;
+    instance.is_fixture = is_fixture;
+    instance.id = id.empty() ? type : id;
+
+    instance.transform.position = map_position(world.o);
+
+    Matrix basis = to_godot_basis_matrix(world);
+    const auto scale = extract_scale(basis);
+    instance.transform.scale = {scale[0], scale[1], scale[2]};
+
+    Matrix rotation_only = normalize_basis(basis, scale);
+    const auto euler = MatrixUtils::MatrixToEuler(rotation_only);
+    instance.transform.rotation_degrees = {euler[0], euler[1], euler[2]};
+
+    scene.instances.push_back(instance);
+    if (type == "fixture") {
+        ++scene.fixture_count;
+    } else if (type == "truss") {
+        ++scene.truss_count;
+    } else if (type == "support") {
+        ++scene.support_count;
+    } else {
+        ++scene.object_count;
+    }
+}
+
+std::string node_id(tinyxml2::XMLElement *node) {
+    if (const char *uuid = node->Attribute("uuid")) {
+        return uuid;
+    }
+    if (const char *name = node->Attribute("name")) {
+        return name;
+    }
+    return node->Name();
+}
+
+Matrix parse_matrix_node(tinyxml2::XMLElement *node) {
+    Matrix m = MatrixUtils::Identity();
+    if (tinyxml2::XMLElement *matrix_node = node->FirstChildElement("Matrix")) {
+        if (const char *text = matrix_node->GetText()) {
+            MatrixUtils::ParseMatrix(text, m);
+        }
+    }
+    return m;
+}
+
+} // namespace
+
+namespace peraviz {
+
+SceneModel load_mvr(const std::string &path) {
+    SceneModel model;
+    if (!std::filesystem::exists(std::filesystem::u8path(path))) {
+        return model;
+    }
+
+    const std::string xml_content = read_xml_from_mvr(path);
+    if (xml_content.empty()) {
+        return model;
+    }
+
+    tinyxml2::XMLDocument doc;
+    if (doc.Parse(xml_content.c_str()) != tinyxml2::XML_SUCCESS) {
+        return model;
+    }
+
+    auto *root = doc.FirstChildElement("GeneralSceneDescription");
+    if (!root) {
+        return model;
+    }
+    auto *scene = root->FirstChildElement("Scene");
+    if (!scene) {
+        return model;
+    }
+    auto *layers = scene->FirstChildElement("Layers");
+    if (!layers) {
+        return model;
+    }
+
+    std::function<void(tinyxml2::XMLElement *, const Matrix &)> parse_child_list;
+    parse_child_list = [&](tinyxml2::XMLElement *child_list, const Matrix &parent) {
+        for (tinyxml2::XMLElement *child = child_list->FirstChildElement(); child;
+             child = child->NextSiblingElement()) {
+            Matrix node_transform = MatrixUtils::Multiply(parent, parse_matrix_node(child));
+            const std::string node_name = child->Name();
+            if (node_name == "Fixture") {
+                append_instance(model, "fixture", true, node_id(child), node_transform);
+            } else if (node_name == "Truss") {
+                append_instance(model, "truss", false, node_id(child), node_transform);
+            } else if (node_name == "Support") {
+                append_instance(model, "support", false, node_id(child), node_transform);
+            } else if (node_name == "SceneObject") {
+                append_instance(model, "scene_object", false, node_id(child), node_transform);
+            }
+
+            if (tinyxml2::XMLElement *nested = child->FirstChildElement("ChildList")) {
+                parse_child_list(nested, node_transform);
+            }
+        }
+    };
+
+    for (tinyxml2::XMLElement *root_list = layers->FirstChildElement("ChildList"); root_list;
+         root_list = root_list->NextSiblingElement("ChildList")) {
+        parse_child_list(root_list, MatrixUtils::Identity());
+    }
+
+    for (tinyxml2::XMLElement *layer = layers->FirstChildElement("Layer"); layer;
+         layer = layer->NextSiblingElement("Layer")) {
+        if (tinyxml2::XMLElement *child_list = layer->FirstChildElement("ChildList")) {
+            parse_child_list(child_list, parse_matrix_node(layer));
+        }
+    }
+
+    return model;
+}
+
+} // namespace peraviz

--- a/peraviz/native/src/mvr_scene_loader.h
+++ b/peraviz/native/src/mvr_scene_loader.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <string>
+
+#include "scene_model.h"
+
+namespace peraviz {
+
+SceneModel load_mvr(const std::string &path);
+
+} // namespace peraviz

--- a/peraviz/native/src/peraviz_loader.cpp
+++ b/peraviz/native/src/peraviz_loader.cpp
@@ -1,0 +1,52 @@
+#include "peraviz_loader.h"
+
+#include "mvr_scene_loader.h"
+
+#include <godot_cpp/variant/array.hpp>
+#include <godot_cpp/variant/dictionary.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+#include <godot_cpp/variant/vector3.hpp>
+
+namespace godot {
+
+void PeravizLoader::_bind_methods() {
+    ClassDB::bind_method(D_METHOD("load_mvr", "path"), &PeravizLoader::load_mvr);
+}
+
+Array PeravizLoader::load_mvr(const String &path) const {
+    const peraviz::SceneModel model = peraviz::load_mvr(std::string(path.utf8().get_data()));
+
+    UtilityFunctions::print("[PeravizNative] load_mvr instances=", model.instances.size(),
+                            " fixtures=", model.fixture_count,
+                            " trusses=", model.truss_count,
+                            " objects=", model.object_count,
+                            " supports=", model.support_count);
+
+    for (int i = 0; i < 3 && i < static_cast<int>(model.instances.size()); ++i) {
+        const auto &inst = model.instances[static_cast<size_t>(i)];
+        UtilityFunctions::print("[PeravizNative] sample[", i, "] ", inst.type, " ", inst.id,
+                                " pos=", inst.transform.position.x, ",",
+                                inst.transform.position.y, ",", inst.transform.position.z);
+    }
+
+    Array out;
+    out.resize(static_cast<int64_t>(model.instances.size()));
+    int index = 0;
+    for (const auto &inst : model.instances) {
+        Dictionary d;
+        d["id"] = String(inst.id.c_str());
+        d["type"] = String(inst.type.c_str());
+        d["is_fixture"] = inst.is_fixture;
+        d["pos"] = Vector3(inst.transform.position.x, inst.transform.position.y,
+                            inst.transform.position.z);
+        d["rot"] = Vector3(inst.transform.rotation_degrees.x,
+                            inst.transform.rotation_degrees.y,
+                            inst.transform.rotation_degrees.z);
+        d["scale"] = Vector3(inst.transform.scale.x, inst.transform.scale.y,
+                              inst.transform.scale.z);
+        out[index++] = d;
+    }
+    return out;
+}
+
+} // namespace godot

--- a/peraviz/native/src/peraviz_loader.h
+++ b/peraviz/native/src/peraviz_loader.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <godot_cpp/classes/object.hpp>
+#include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/variant/array.hpp>
+#include <godot_cpp/variant/string.hpp>
+
+namespace godot {
+
+class PeravizLoader : public Object {
+    GDCLASS(PeravizLoader, Object)
+
+protected:
+    static void _bind_methods();
+
+public:
+    Array load_mvr(const String &path) const;
+};
+
+} // namespace godot

--- a/peraviz/native/src/register_types.cpp
+++ b/peraviz/native/src/register_types.cpp
@@ -1,6 +1,7 @@
 #include "register_types.h"
 
 #include "hello_world.h"
+#include "peraviz_loader.h"
 
 void initialize_peraviz_module(godot::ModuleInitializationLevel p_level) {
     if (p_level != godot::MODULE_INITIALIZATION_LEVEL_SCENE) {
@@ -8,6 +9,7 @@ void initialize_peraviz_module(godot::ModuleInitializationLevel p_level) {
     }
 
     godot::ClassDB::register_class<godot::HelloWorld>();
+    godot::ClassDB::register_class<godot::PeravizLoader>();
 }
 
 void uninitialize_peraviz_module(godot::ModuleInitializationLevel p_level) {

--- a/peraviz/native/src/scene_model.h
+++ b/peraviz/native/src/scene_model.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace peraviz {
+
+struct Vec3 {
+    float x = 0.0F;
+    float y = 0.0F;
+    float z = 0.0F;
+};
+
+struct SceneTransform {
+    Vec3 position;
+    Vec3 rotation_degrees;
+    Vec3 scale{1.0F, 1.0F, 1.0F};
+};
+
+struct SceneInstance {
+    std::string id;
+    std::string type;
+    SceneTransform transform;
+    bool is_fixture = false;
+};
+
+struct SceneModel {
+    std::vector<SceneInstance> instances;
+    int fixture_count = 0;
+    int truss_count = 0;
+    int object_count = 0;
+    int support_count = 0;
+};
+
+} // namespace peraviz

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -9,7 +9,7 @@ var _loader := PeravizLoader.new()
 func _ready() -> void:
 	$HUD/LoadButton.pressed.connect(_on_load_pressed)
 	picker.file_selected.connect(_on_file_selected)
-	status_label.text = "Selecciona un archivo .mvr"
+	status_label.text = "Select a .mvr file"
 
 func _on_load_pressed() -> void:
 	picker.popup_centered_ratio(0.7)
@@ -17,13 +17,13 @@ func _on_load_pressed() -> void:
 func _on_file_selected(path: String) -> void:
 	_clear_scene()
 	var instances: Array = _loader.load_mvr(path)
-	print("[Peraviz] Instancias cargadas: ", instances.size())
+	print("[Peraviz] Loaded instances: ", instances.size())
 
 	for item in instances:
 		if item is Dictionary:
 			_create_proxy(item)
 
-	status_label.text = "Instancias: %d" % instances.size()
+	status_label.text = "Instances: %d" % instances.size()
 
 func _create_proxy(data: Dictionary) -> void:
 	var is_fixture: bool = bool(data.get("is_fixture", false))

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -1,0 +1,56 @@
+extends Node3D
+
+@onready var proxies_root: Node3D = $Proxies
+@onready var status_label: Label = $HUD/StatusLabel
+@onready var picker: FileDialog = $HUD/FileDialog
+
+var _loader := PeravizLoader.new()
+
+func _ready() -> void:
+	$HUD/LoadButton.pressed.connect(_on_load_pressed)
+	picker.file_selected.connect(_on_file_selected)
+	status_label.text = "Selecciona un archivo .mvr"
+
+func _on_load_pressed() -> void:
+	picker.popup_centered_ratio(0.7)
+
+func _on_file_selected(path: String) -> void:
+	_clear_scene()
+	var instances: Array = _loader.load_mvr(path)
+	print("[Peraviz] Instancias cargadas: ", instances.size())
+
+	for item in instances:
+		if item is Dictionary:
+			_create_proxy(item)
+
+	status_label.text = "Instancias: %d" % instances.size()
+
+func _create_proxy(data: Dictionary) -> void:
+	var is_fixture: bool = bool(data.get("is_fixture", false))
+	var item_type: String = str(data.get("type", "scene_object"))
+
+	var mesh_instance := MeshInstance3D.new()
+	if is_fixture:
+		var cone := ConeMesh.new()
+		cone.bottom_radius = 0.15
+		cone.height = 0.4
+		mesh_instance.mesh = cone
+	else:
+		var box := BoxMesh.new()
+		box.size = Vector3(0.3, 0.3, 0.3)
+		mesh_instance.mesh = box
+
+	mesh_instance.position = data.get("pos", Vector3.ZERO)
+	mesh_instance.rotation_degrees = data.get("rot", Vector3.ZERO)
+	mesh_instance.scale = data.get("scale", Vector3.ONE)
+
+	var material := StandardMaterial3D.new()
+	material.albedo_color = Color(1.0, 0.5, 0.1) if is_fixture else Color(0.2, 0.8, 1.0)
+	mesh_instance.material_override = material
+	mesh_instance.name = "%s_%s" % [item_type, str(data.get("id", "item"))]
+
+	proxies_root.add_child(mesh_instance)
+
+func _clear_scene() -> void:
+	for child in proxies_root.get_children():
+		child.queue_free()

--- a/peraviz/test.tscn
+++ b/peraviz/test.tscn
@@ -22,14 +22,14 @@ offset_left = 12.0
 offset_top = 12.0
 offset_right = 160.0
 offset_bottom = 44.0
-text = "Cargar MVR"
+text = "Load MVR"
 
 [node name="StatusLabel" type="Label" parent="HUD"]
 offset_left = 12.0
 offset_top = 52.0
 offset_right = 600.0
 offset_bottom = 80.0
-text = "Estado"
+text = "Status"
 
 [node name="FileDialog" type="FileDialog" parent="HUD"]
 file_mode = 0

--- a/peraviz/test.tscn
+++ b/peraviz/test.tscn
@@ -1,16 +1,36 @@
 [gd_scene format=3]
 
-[ext_resource type="Script" path="res://test.gd" id="1_test"]
+[ext_resource type="Script" path="res://scripts/load_scene.gd" id="1_script"]
 
-[node name="PeravizTest" type="Node"]
-script = ExtResource("1_test")
+[node name="Viewer" type="Node3D"]
+script = ExtResource("1_script")
+
+[node name="Camera3D" type="Camera3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3, 8)
+rotation_degrees = Vector3(-20, 0, 0)
+current = true
+
+[node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
+rotation_degrees = Vector3(-45, 45, 0)
+
+[node name="Proxies" type="Node3D" parent="."]
 
 [node name="HUD" type="CanvasLayer" parent="."]
 
-[node name="PingLabel" type="Label" parent="HUD"]
-offset_left = 10.0
-offset_top = 10.0
-offset_right = 510.0
-offset_bottom = 48.0
-theme_override_font_sizes/font_size = 24
-text = "Waiting..."
+[node name="LoadButton" type="Button" parent="HUD"]
+offset_left = 12.0
+offset_top = 12.0
+offset_right = 160.0
+offset_bottom = 44.0
+text = "Cargar MVR"
+
+[node name="StatusLabel" type="Label" parent="HUD"]
+offset_left = 12.0
+offset_top = 52.0
+offset_right = 600.0
+offset_bottom = 80.0
+text = "Estado"
+
+[node name="FileDialog" type="FileDialog" parent="HUD"]
+file_mode = 0
+filters = PackedStringArray("*.mvr ; MVR")


### PR DESCRIPTION
### Motivation

- Proveer un primer pipeline nativo para Peraviz que permita cargar `.mvr` y visualizar proxies 3D básicos en Godot para validar ejes/unidades antes de integrar geometría real.
- Mantener el parsing y la conversión de coordenadas en C++ reutilizando las librerías de Perastage en vez de duplicar lógica en GDScript.

### Description

- Añadidas estructuras motor-agnósticas en `peraviz/native/src/scene_model.h` para describir `SceneInstance`, `SceneTransform` y `SceneModel` y transportar instancias MVR en C++.
- Implementado el importador nativo `peraviz::load_mvr(const std::string&)` en `peraviz/native/src/mvr_scene_loader.cpp` que extrae `GeneralSceneDescription.xml` del `.mvr`, recorre `Layers/ChildList`, compone transformaciones jerárquicas y genera `SceneInstance` por `Fixture/Truss/Support/SceneObject`.
- Conversión de coordenadas/units en C++: MVR (mm, Z‑up RH) -> Godot (m, Y‑up LH) aplicando `mm -> m` y mapeo de ejes `{x, y, z} (mm)` -> `{x, z, -y} (m)` y la misma permuta para las bases (implementado en `mvr_scene_loader.cpp`).
- Expuesta la carga a Godot con la nueva clase GDExtension `PeravizLoader` (`peraviz/native/src/peraviz_loader.h/.cpp`) que implementa `load_mvr(path: String) -> Array` y devuelve un `Array` de `Dictionary` por instancia con claves `id`, `type`, `is_fixture`, `pos`, `rot`, `scale`.
- Registrada la clase nativa en `peraviz/native/src/register_types.cpp` y actualizado `peraviz/native/CMakeLists.txt` para compilar los nuevos ficheros y enlazar con `tinyxml2`, `wxWidgets` y las cabeceras de Perastage (`models`).
- Escena/script de prueba actualizados: `peraviz/test.tscn` y `peraviz/scripts/load_scene.gd` para seleccionar un `.mvr` con `FileDialog` y crear proxies (`ConeMesh` para fixtures, `BoxMesh` para otros) aplicando posición/rotación/escala devueltas por la extensión nativa.
- Documentación actualizada en `peraviz/docs/USED_LIBS.md` y `peraviz/docs/NATIVE_BUILD.md` describiendo módulos reutilizados y nuevas dependencias/build notes.

### Testing

- Ejecutado configure de la extensión con `cmake -S peraviz/native -B peraviz/native/build -DCMAKE_BUILD_TYPE=Debug`, la configuración falló en este entorno por falta de metapackages/devel: `tinyxml2` no se encontró (CMake error indicando ausencia de `tinyxml2Config.cmake`).
- Ejecutado configure del proyecto raíz con `cmake -S . -B build -DPERAVIZ_ENABLE_NATIVE=ON`, la configuración falló por falta de dependencias del sistema: `wxWidgets` development files no disponibles (error de `FindwxWidgets`).
- Debido a los fallos de configuración en este entorno no se construyó `peraviz_native` ni se probó la ejecución en Godot automáticamente; el código incluye logs para validación (el loader imprime conteo de instancias y las primeras 3 posiciones) para facilitar la verificación manual una vez instaladas las dependencias del sistema.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f6bc52400832481c8c5d3ede83ffc)