### PR TITLE
Fix PDF symbol instance scaling for 2D/3D exports

### DIFF
--- a/viewer2d/pdf/layout_pdf_exporter.cpp
+++ b/viewer2d/pdf/layout_pdf_exporter.cpp
@@ -517,7 +517,7 @@ Viewer2DExportResult ExportViewer2DToPdf(
   }
 
   Mapping symbolMapping{};
-  symbolMapping.scale = scale;
+  symbolMapping.scale = 1.0;
   symbolMapping.flipY = false;
 
   auto appendSymbolObject = [&](const std::string &name,
@@ -539,10 +539,10 @@ Viewer2DExportResult ExportViewer2DToPdf(
     }
     const std::string &symbolStream =
         compressed ? compressedSymbol : symbolContent;
-    double minX = bounds.min.x * scale;
-    double minY = bounds.min.y * scale;
-    double maxX = bounds.max.x * scale;
-    double maxY = bounds.max.y * scale;
+    double minX = bounds.min.x * symbolMapping.scale;
+    double minY = bounds.min.y * symbolMapping.scale;
+    double maxX = bounds.max.x * symbolMapping.scale;
+    double maxY = bounds.max.y * symbolMapping.scale;
     if (minX > maxX)
       std::swap(minX, maxX);
     if (minY > maxY)
@@ -1064,7 +1064,7 @@ Viewer2DExportResult ExportLayoutToPdf(
       xObjectNameIds[entry.second] =
           appendSymbolObject(entry.second, defIt->second.commands,
                              defIt->second.metadata, defIt->second.sources,
-                             group.mapping.scale, group.strokeScale, bounds);
+                             1.0, group.strokeScale, bounds);
     }
 
     if (symbolSnapshot) {
@@ -1077,7 +1077,7 @@ Viewer2DExportResult ExportLayoutToPdf(
                                defIt->second.localCommands.commands,
                                defIt->second.localCommands.metadata,
                                defIt->second.localCommands.sources,
-                               group.mapping.scale, group.strokeScale,
+                               1.0, group.strokeScale,
                                defIt->second.bounds);
       }
     }

--- a/viewer2d/pdf/pdf_draw_commands.cpp
+++ b/viewer2d/pdf/pdf_draw_commands.cpp
@@ -340,12 +340,15 @@ void AppendSymbolInstance(std::ostringstream &out, const FloatFormatter &fmt,
                           const Mapping &mapping,
                           const Transform2D &transform,
                           const std::string &name) {
+  const double linearScale = mapping.scale;
   double translateX = mapping.scale * transform.tx +
                       mapping.offsetX - mapping.minX * mapping.scale;
   double translateY = mapping.scale * transform.ty +
                       mapping.offsetY - mapping.minY * mapping.scale;
-  out << "q\n" << fmt.Format(transform.a) << ' ' << fmt.Format(transform.b)
-      << ' ' << fmt.Format(transform.c) << ' ' << fmt.Format(transform.d)
+  out << "q\n" << fmt.Format(transform.a * linearScale) << ' '
+      << fmt.Format(transform.b * linearScale) << ' '
+      << fmt.Format(transform.c * linearScale) << ' '
+      << fmt.Format(transform.d * linearScale)
       << ' ' << fmt.Format(translateX) << ' ' << fmt.Format(translateY)
       << " cm\n/" << name << " Do\nQ\n";
 }

--- a/viewer3d/render/opaque_object_pass.cpp
+++ b/viewer3d/render/opaque_object_pass.cpp
@@ -146,6 +146,15 @@ void OpaqueObjectPass::Render(
                 return TransformPoint(partCaptureMatrix, p);
               };
 
+              Matrix localCaptureMatrix = part.localTransform;
+              localCaptureMatrix.o[0] *= RENDER_SCALE;
+              localCaptureMatrix.o[1] *= RENDER_SCALE;
+              localCaptureMatrix.o[2] *= RENDER_SCALE;
+              auto localPartCapture =
+                  [localCaptureMatrix](const std::array<float, 3> &p) {
+                    return TransformPoint(localCaptureMatrix, p);
+                  };
+
               float localMatrix[16];
               MatrixToArray(part.localTransform, localMatrix);
               glPushMatrix();
@@ -153,6 +162,8 @@ void OpaqueObjectPass::Render(
               auto partCaptureTransform = captureTransformFn;
               if (captureTransformFn)
                 partCaptureTransform = partCapture;
+              else
+                partCaptureTransform = localPartCapture;
 
               controller.DrawMeshWithOutline(*part.mesh, r, g, b, RENDER_SCALE,
                                              isHighlighted, isSelected, cx, cy,


### PR DESCRIPTION
### Motivation
- PDF exports were losing MVR/model instance scaling: symbol XObjects were pre-scaled and instance transforms did not include the viewport/page mapping linear scale, causing oversized objects in printed PDFs.

### Description
- Apply the view/page mapping scale directly to the symbol instance affine matrix by multiplying the instance `a,b,c,d` terms when emitting the `cm` operator in `AppendSymbolInstance` (`viewer2d/pdf/pdf_draw_commands.cpp`).
- Stop pre-scaling symbol Form XObjects and keep them in local units by setting `symbolMapping.scale = 1.0` and using that for symbol BBox calculations in both single-view and layout exporters (`viewer2d/pdf/layout_pdf_exporter.cpp`).
- Ensure the layout exporter also creates symbol XObjects at unit scale and relies on the instance transform to produce the final on-page size, making single-view and multi-view exports consistent (changes affect both `ExportViewer2DToPdf` and `ExportLayoutToPdf`).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (`OK`).
- Attempted a local build but no `build` directory was present in the environment so a full compile/test run was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f703f7ebc8324ad63a0b6a1d621b8)