### PR TITLE
Fix standalone Peraviz native CMake root detection

### DIFF
--- a/peraviz/native/CMakeLists.txt
+++ b/peraviz/native/CMakeLists.txt
@@ -6,9 +6,18 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-set(PERAVIZ_GODOT_PROJECT_DIR "${CMAKE_SOURCE_DIR}/peraviz" CACHE PATH "Path to the Peraviz Godot project")
 set(GODOT_CPP_DIR "" CACHE PATH "Path to a local godot-cpp checkout")
 option(PERAVIZ_FETCH_GODOT_CPP "Fetch godot-cpp automatically when GODOT_CPP_DIR is not provided" ON)
+
+if(EXISTS "${CMAKE_SOURCE_DIR}/models/matrixutils.h")
+    set(PERASTAGE_ROOT_DIR "${CMAKE_SOURCE_DIR}")
+elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../../models/matrixutils.h")
+    get_filename_component(PERASTAGE_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." ABSOLUTE)
+else()
+    message(FATAL_ERROR "Cannot locate Perastage root (models/matrixutils.h not found).")
+endif()
+
+set(PERAVIZ_GODOT_PROJECT_DIR "${PERASTAGE_ROOT_DIR}/peraviz" CACHE PATH "Path to the Peraviz Godot project")
 
 if(NOT TARGET godot-cpp)
     if(GODOT_CPP_DIR)
@@ -31,14 +40,6 @@ if(NOT TARGET godot-cpp)
     endif()
 endif()
 
-
-if(EXISTS "${CMAKE_SOURCE_DIR}/models/matrixutils.h")
-    set(PERASTAGE_ROOT_DIR "${CMAKE_SOURCE_DIR}")
-elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../../models/matrixutils.h")
-    get_filename_component(PERASTAGE_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." ABSOLUTE)
-else()
-    message(FATAL_ERROR "Cannot locate Perastage root (models/matrixutils.h not found).")
-endif()
 
 if(NOT tinyxml2_FOUND)
     find_package(tinyxml2 CONFIG QUIET)


### PR DESCRIPTION
### Motivation
- When configuring `peraviz/native` directly, `CMAKE_SOURCE_DIR` pointed at the subfolder which made the default `PERAVIZ_GODOT_PROJECT_DIR` expand to an incorrect path and prevented the built extension from being copied to the real `peraviz/bin`, which can surface as Godot reporting `Identifier "PeravizLoader" not declared in the current scope`.
- The change ensures the project root is detected once and used to derive the Godot project path so standalone CMake invocations behave like the root-integrated flow.

### Description
- Move root detection so `PERASTAGE_ROOT_DIR` is resolved early in `peraviz/native/CMakeLists.txt` and use it to set the default `PERAVIZ_GODOT_PROJECT_DIR` to `${PERASTAGE_ROOT_DIR}/peraviz` instead of `${CMAKE_SOURCE_DIR}/peraviz`.
- Remove the duplicated `PERASTAGE_ROOT_DIR` detection block further down in the same file so the resolution has a single source of truth.
- Keep existing behaviour for `godot-cpp` handling and FetchContent fallback unchanged, but now outputs and post-build copy target point to the correct `peraviz/bin` when configured standalone.
- Modified file: `peraviz/native/CMakeLists.txt`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded (`OK`).
- Performed a CMake configure check with `cmake -S peraviz/native -B /tmp/peraviz-native-cmake-check -DPERAVIZ_FETCH_GODOT_CPP=OFF -DGODOT_CPP_DIR=/tmp/nonexistent` and CMake returned the expected error when `GODOT_CPP_DIR` points to a non-existent path, indicating the guard remains functional.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f7241adcc8324abe82ed5c2119e1c)