### PR TITLE
Fix Godot Variant conversion in PeravizLoader sample logging

### DIFF
--- a/peraviz/native/src/peraviz_loader.cpp
+++ b/peraviz/native/src/peraviz_loader.cpp
@@ -24,7 +24,8 @@ Array PeravizLoader::load_mvr(const String &path) const {
 
     for (int i = 0; i < 3 && i < static_cast<int>(model.instances.size()); ++i) {
         const auto &inst = model.instances[static_cast<size_t>(i)];
-        UtilityFunctions::print("[PeravizNative] sample[", i, "] ", inst.type, " ", inst.id,
+        UtilityFunctions::print("[PeravizNative] sample[", i, "] ", String(inst.type.c_str()),
+                                " ", String(inst.id.c_str()),
                                 " pos=", inst.transform.position.x, ",",
                                 inst.transform.position.y, ",", inst.transform.position.z);
     }


### PR DESCRIPTION
### Motivation
- Fix a Windows/MSVC build error where passing `std::string` values to `godot::UtilityFunctions::print` failed to convert to `godot::Variant` (C2440).

### Description
- Convert `inst.type` and `inst.id` to `godot::String` before logging in `PeravizLoader::load_mvr` (`peraviz/native/src/peraviz_loader.cpp`) so the arguments are compatible with `UtilityFunctions::print`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both reported OK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f8a6c375083248722c2a8fb4333db)