### PR TITLE
Fix Peraviz MVR loading by resolving FileDialog paths to filesystem

### DIFF
--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -9,6 +9,7 @@ var _loader := PeravizLoader.new()
 func _ready() -> void:
 	$HUD/LoadButton.pressed.connect(_on_load_pressed)
 	picker.file_selected.connect(_on_file_selected)
+	picker.access = FileDialog.ACCESS_FILESYSTEM
 	status_label.text = "Select a .mvr file"
 
 func _on_load_pressed() -> void:
@@ -16,7 +17,8 @@ func _on_load_pressed() -> void:
 
 func _on_file_selected(path: String) -> void:
 	_clear_scene()
-	var instances: Array = _loader.load_mvr(path)
+	var native_path: String = ProjectSettings.globalize_path(path)
+	var instances: Array = _loader.load_mvr(native_path)
 	print("[Peraviz] Loaded instances: ", instances.size())
 
 	for item in instances:


### PR DESCRIPTION
### Motivation
- The native Peraviz MVR loader was receiving Godot resource paths (e.g. `res://...`) which are not direct filesystem paths, causing the C++ loader to return zero instances; the UI should supply a real filesystem path.

### Description
- Set the file picker to filesystem mode with `picker.access = FileDialog.ACCESS_FILESYSTEM` and convert the selected path using `ProjectSettings.globalize_path(path)` before calling `PeravizLoader::load_mvr` in `peraviz/scripts/load_scene.gd`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69907309c6b483248dfd9363000f934e)