### PR TITLE
Peraviz: auto-focus camera after loading MVR proxies

### DIFF
--- a/peraviz/scripts/editor_camera.gd
+++ b/peraviz/scripts/editor_camera.gd
@@ -19,6 +19,17 @@ var current_distance: float = 8.0
 var _orbiting: bool = false
 var _panning: bool = false
 
+func focus_on_aabb(bounds: AABB) -> void:
+	if bounds.size.length_squared() <= 0.0:
+		return
+
+	target_position = bounds.get_center()
+
+	var radius: float = max(bounds.size.length() * 0.5, min_distance)
+	var half_fov: float = deg_to_rad(fov) * 0.5
+	var fit_distance: float = radius / max(tan(half_fov), 0.01)
+	target_distance = clamp(fit_distance * 1.2, min_distance, max_distance)
+
 func _ready() -> void:
 	_initialize_from_transform()
 	_set_mouse_mode(false)


### PR DESCRIPTION
### Motivation
- Improve Peraviz UX by automatically framing the 3D view after an `load_mvr()` import so the loaded proxies are centered and visible, and provide a quick `F` key to re-focus.
- Keep responsibilities separated so the scene loader computes bounds while the camera script performs framing math.

### Description
- Added `focus_on_aabb(bounds)` to `peraviz/scripts/editor_camera.gd` which recenters `target_position` and computes a fitting `target_distance` from the camera FOV with padding and min/max clamps.
- Updated `peraviz/scripts/load_scene.gd` to track a world-space AABB while creating proxy `MeshInstance3D` nodes via `_expand_loaded_bounds(mesh_instance)` and to call `_focus_loaded_scene()` after `load_mvr()` completes.
- Added `_unhandled_input` handling in `peraviz/scripts/load_scene.gd` to let the user press `F` to re-focus on the last loaded bounds, and a `_has_loaded_bounds` flag to guard focus calls.
- Changes are scoped to Peraviz scripts and preserve modular separation (loader computes bounds, camera performs framing).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded (`OK: perastage_tree.md keeps module sections and scope note aligned`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded (`OK: no direct ConfigManager::Get() usages in gui/`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69908e1e83088324afaf8a901c12dd2a)