### PR TITLE
Fix Godot parse error in peraviz test scene

### DIFF
--- a/peraviz/test.tscn
+++ b/peraviz/test.tscn
@@ -3,6 +3,8 @@
 [ext_resource type="Script" path="res://scripts/load_scene.gd" id="1_script"]
 [ext_resource type="Script" path="res://scripts/editor_camera.gd" id="2_camera_script"]
 
+[sub_resource type="PlaneMesh" id="PlaneMesh_ground"]
+
 [node name="Viewer" type="Node3D"]
 script = ExtResource("1_script")
 
@@ -20,7 +22,7 @@ shadow_bias = 0.03
 shadow_normal_bias = 1.0
 
 [node name="Ground" type="MeshInstance3D" parent="."]
-mesh = PlaneMesh.new()
+mesh = SubResource("PlaneMesh_ground")
 transform = Transform3D(12, 0, 0, 0, 1, 0, 0, 12, 0, 0, 0, 0)
 
 [node name="Proxies" type="Node3D" parent="."]


### PR DESCRIPTION
### Motivation
- The text-format Godot scene `peraviz/test.tscn` used an invalid inline `PlaneMesh.new()` expression which caused a parse error when Godot tried to load `res://test.tscn`.

### Description
- Add a `[sub_resource type="PlaneMesh" id="PlaneMesh_ground"]` declaration and update the `Ground` node to use `mesh = SubResource("PlaneMesh_ground")` instead of `PlaneMesh.new()` in `peraviz/test.tscn`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both returned OK; attempted `godot --headless --path peraviz --quit` but the `godot` binary is not available in this environment so runtime load verification was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699097a66c208324af76cb7e55fd0e13)