### PR TITLE
Fix timer use-after-free in LayoutViewerPanel deferred callback

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1962,6 +1962,11 @@ void LayoutViewerPanel::RequestRenderRebuild() {
     panel->Update();
     if (wxTheApp && wxTheApp->IsMainLoopRunning())
       wxTheApp->Yield(true);
+    if (!weakThis)
+      return;
+    panel = weakThis.get();
+    if (!panel)
+      return;
     if (panel->renderDelayTimer_.IsRunning()) {
       panel->renderDelayTimer_.Stop();
     }


### PR DESCRIPTION
### Motivation
- A use-after-free risk was observed when the deferred callback in `LayoutViewerPanel::RequestRenderRebuild()` calls `wxTheApp->Yield(true)`, because yielding can process destroy events and leave the panel/timers invalid before the callback continues.

### Description
- Re-validate and re-acquire the `LayoutViewerPanel` instance from the existing `wxWeakRef` after the `Yield` call and before touching `renderDelayTimer_` to avoid dereferencing freed timer state (`gui/layoutviewerpanel.cpp`).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990986ab6108324b68f54231216d0ea)