### PR TITLE
Persist and restore Layout Mode view on restart

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -537,21 +537,10 @@ void MainWindow::SaveCameraSettings() {
   if (viewport2DPanel)
     viewport2DPanel->SaveViewToConfig();
 
-  if (layoutModeActive) {
-    cfg.SetValue("layout_view_mode", "layout_mode_view");
-  }
-
   if (auiManager) {
     const std::string perspective =
         auiManager->SavePerspective().ToStdString();
-    if (!layoutModeActive) {
-      cfg.SetValue("layout_perspective", perspective);
-      const bool is2DLayout =
-          perspective.find("2DViewport") != std::string::npos ||
-          perspective.find("2DRenderOptions") != std::string::npos;
-      cfg.SetValue("layout_view_mode",
-                   is2DLayout ? "2d_layout_view" : "3d_layout_view");
-    }
+    cfg.SetValue("layout_perspective", perspective);
   }
 }
 

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -522,24 +522,36 @@ void MainWindow::UpdateTitle() {
 }
 
 void MainWindow::SaveCameraSettings() {
+  ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
   if (layoutModeActive)
     PersistLayout2DViewState();
   if (viewportPanel) {
     Viewer3DCamera &cam = viewportPanel->GetCamera();
-    GetDefaultGuiConfigServices().LegacyConfigManager().SetFloat("camera_yaw", cam.GetYaw());
-    GetDefaultGuiConfigServices().LegacyConfigManager().SetFloat("camera_pitch", cam.GetPitch());
-    GetDefaultGuiConfigServices().LegacyConfigManager().SetFloat("camera_distance", cam.GetDistance());
-    GetDefaultGuiConfigServices().LegacyConfigManager().SetFloat("camera_target_x", cam.GetTargetX());
-    GetDefaultGuiConfigServices().LegacyConfigManager().SetFloat("camera_target_y", cam.GetTargetY());
-    GetDefaultGuiConfigServices().LegacyConfigManager().SetFloat("camera_target_z", cam.GetTargetZ());
+    cfg.SetFloat("camera_yaw", cam.GetYaw());
+    cfg.SetFloat("camera_pitch", cam.GetPitch());
+    cfg.SetFloat("camera_distance", cam.GetDistance());
+    cfg.SetFloat("camera_target_x", cam.GetTargetX());
+    cfg.SetFloat("camera_target_y", cam.GetTargetY());
+    cfg.SetFloat("camera_target_z", cam.GetTargetZ());
   }
   if (viewport2DPanel)
     viewport2DPanel->SaveViewToConfig();
+
+  if (layoutModeActive) {
+    cfg.SetValue("layout_view_mode", "layout_mode_view");
+  }
+
   if (auiManager) {
     const std::string perspective =
         auiManager->SavePerspective().ToStdString();
-    if (!layoutModeActive)
-      GetDefaultGuiConfigServices().LegacyConfigManager().SetValue("layout_perspective", perspective);
+    if (!layoutModeActive) {
+      cfg.SetValue("layout_perspective", perspective);
+      const bool is2DLayout =
+          perspective.find("2DViewport") != std::string::npos ||
+          perspective.find("2DRenderOptions") != std::string::npos;
+      cfg.SetValue("layout_view_mode",
+                   is2DLayout ? "2d_layout_view" : "3d_layout_view");
+    }
   }
 }
 

--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -404,8 +404,10 @@ void MainWindow::ApplyLayoutPreset(const LayoutViewPreset &preset,
 
   if (persistPerspective) {
     ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
-    if (!layoutMode && perspective) {
-      cfg.SetValue("layout_perspective", *perspective);
+    cfg.SetValue("layout_view_mode", preset.name);
+    if (auiManager) {
+      cfg.SetValue("layout_perspective",
+                   auiManager->SavePerspective().ToStdString());
     }
   }
 
@@ -419,21 +421,11 @@ void MainWindow::ApplySavedLayout() {
   if (!auiManager)
     return;
 
-  std::optional<std::string> perspective;
-  const std::string viewMode =
-      GetDefaultGuiConfigServices().LegacyConfigManager()
-          .GetValue("layout_view_mode")
-          .value_or("");
+  ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+  const std::string viewMode = cfg.GetValue("layout_view_mode").value_or("");
+  std::optional<std::string> perspective = cfg.GetValue("layout_perspective");
 
-  if (viewMode == "layout_mode_view") {
-    ApplyLayoutModePerspective();
-    return;
-  }
-
-  // Load stored layout perspective if it exists
-  if (auto val = GetDefaultGuiConfigServices().LegacyConfigManager().GetValue("layout_perspective")) {
-    perspective = *val;
-
+  if (perspective) {
     // Ensure viewports exist before loading the saved perspective
     if (perspective->find("3DViewport") != std::string::npos)
       Ensure3DViewport();
@@ -442,18 +434,15 @@ void MainWindow::ApplySavedLayout() {
       Ensure2DViewport();
   }
 
-  const LayoutViewPreset *preset = nullptr;
-  if (viewMode == "2d_layout_view") {
+  const LayoutViewPreset *preset = LayoutViewPresetRegistry::GetPreset(viewMode);
+  if (!preset && perspective &&
+      (perspective->find("2DViewport") != std::string::npos ||
+       perspective->find("2DRenderOptions") != std::string::npos)) {
+    // Backward compatibility for configs without layout_view_mode.
     preset = LayoutViewPresetRegistry::GetPreset("2d_layout_view");
-  } else if (viewMode == "3d_layout_view") {
-    preset = LayoutViewPresetRegistry::GetPreset("3d_layout_view");
-  } else if (perspective &&
-             (perspective->find("2DViewport") != std::string::npos ||
-              perspective->find("2DRenderOptions") != std::string::npos)) {
-    preset = LayoutViewPresetRegistry::GetPreset("2d_layout_view");
-  } else {
-    preset = LayoutViewPresetRegistry::GetPreset("3d_layout_view");
   }
+  if (!preset)
+    preset = LayoutViewPresetRegistry::GetPreset("3d_layout_view");
   if (preset && perspective)
     ApplyLayoutPreset(*preset, perspective, false, false);
   else if (preset)

--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -420,6 +420,15 @@ void MainWindow::ApplySavedLayout() {
     return;
 
   std::optional<std::string> perspective;
+  const std::string viewMode =
+      GetDefaultGuiConfigServices().LegacyConfigManager()
+          .GetValue("layout_view_mode")
+          .value_or("");
+
+  if (viewMode == "layout_mode_view") {
+    ApplyLayoutModePerspective();
+    return;
+  }
 
   // Load stored layout perspective if it exists
   if (auto val = GetDefaultGuiConfigServices().LegacyConfigManager().GetValue("layout_perspective")) {
@@ -434,7 +443,11 @@ void MainWindow::ApplySavedLayout() {
   }
 
   const LayoutViewPreset *preset = nullptr;
-  if (perspective &&
+  if (viewMode == "2d_layout_view") {
+    preset = LayoutViewPresetRegistry::GetPreset("2d_layout_view");
+  } else if (viewMode == "3d_layout_view") {
+    preset = LayoutViewPresetRegistry::GetPreset("3d_layout_view");
+  } else if (perspective &&
              (perspective->find("2DViewport") != std::string::npos ||
               perspective->find("2DRenderOptions") != std::string::npos)) {
     preset = LayoutViewPresetRegistry::GetPreset("2d_layout_view");


### PR DESCRIPTION
### Motivation
- Restore the application to the same view mode it had when closed so Layout Mode reopens like 2D/3D views did previously.

### Description
- Added persistence of an explicit `layout_view_mode` config key (`layout_mode_view`, `2d_layout_view`, `3d_layout_view`) when saving user settings in `MainWindow::SaveCameraSettings` in `gui/mainwindow.cpp`.
- When not in Layout Mode the code continues to save `layout_perspective` and now also infers and stores `layout_view_mode` as `2d_layout_view` or `3d_layout_view` based on the saved perspective in `MainWindow::SaveCameraSettings`.
- Updated startup restoration in `MainWindow::ApplySavedLayout` in `gui/mainwindow_layout.cpp` to read `layout_view_mode` first and immediately reapply Layout Mode by calling `ApplyLayoutModePerspective()` when `layout_view_mode == "layout_mode_view"`, with backward-compatible fallback to the previous `layout_perspective`-based detection for 2D/3D.
- Minor refactor to use a local `ConfigManager &cfg` reference in `SaveCameraSettings` for clearer and consolidated config writes.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (OK). 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (OK).
- Ran `git diff --check` and it reported no issues (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69909c9e7218832496cde4770073bae3)