### PR TITLE
Fix 2D layout editing actions when starting in layout mode

### DIFF
--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -443,10 +443,11 @@ void MainWindow::ApplySavedLayout() {
   }
   if (!preset)
     preset = LayoutViewPresetRegistry::GetPreset("3d_layout_view");
+  const bool savedLayoutMode = preset && preset->name == "layout_mode_view";
   if (preset && perspective)
-    ApplyLayoutPreset(*preset, perspective, false, false);
+    ApplyLayoutPreset(*preset, perspective, savedLayoutMode, false);
   else if (preset)
-    ApplyLayoutPreset(*preset, std::nullopt, false, false);
+    ApplyLayoutPreset(*preset, std::nullopt, savedLayoutMode, false);
 
   // Re-apply hard-coded minimum sizes so they are not overridden by the saved perspective
   auto &dataPane = auiManager->GetPane("DataNotebook");


### PR DESCRIPTION
### Motivation
- Starting the app with a saved `layout_mode_view` perspective showed the layout UI but did not set the internal `layoutModeActive` flag, which prevented layout-mode gated 2D editing actions from working until the layout mode was re-applied manually.

### Description
- Compute `savedLayoutMode = preset && preset->name == "layout_mode_view"` and pass it to `ApplyLayoutPreset()` instead of using a hard-coded `false`, so the internal `layoutModeActive` state matches the restored visual preset in `gui/mainwindow_layout.cpp`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990a6cb34748324b7cf850d061f27e0)