### PR TITLE
Align Peraviz camera controls with Viewer3D behavior

### DIFF
--- a/peraviz/scripts/editor_camera.gd
+++ b/peraviz/scripts/editor_camera.gd
@@ -1,7 +1,7 @@
 extends Camera3D
 
 @export var orbit_sensitivity: float = 0.01
-@export var pan_sensitivity: float = 0.002
+@export var pan_sensitivity: float = 0.01
 @export var zoom_step_factor: float = 1.1
 @export var min_distance: float = 0.5
 @export var max_distance: float = 500.0
@@ -16,8 +16,16 @@ var current_yaw: float = 0.0
 var current_pitch: float = -0.3
 var current_distance: float = 8.0
 
-var _orbiting: bool = false
-var _panning: bool = false
+enum DragMode {
+	NONE,
+	ORBIT,
+	PAN,
+}
+
+var _left_down: bool = false
+var _right_down: bool = false
+var _middle_down: bool = false
+var _drag_mode: DragMode = DragMode.NONE
 
 func focus_on_aabb(bounds: AABB) -> void:
 	if bounds.size.length_squared() <= 0.0:
@@ -39,6 +47,8 @@ func _unhandled_input(event: InputEvent) -> void:
 		_handle_mouse_button(event)
 	elif event is InputEventMouseMotion:
 		_handle_mouse_motion(event)
+	elif event is InputEventKey:
+		_handle_key_input(event)
 
 func _process(delta: float) -> void:
 	var alpha: float = clamp(delta * smoothing_speed, 0.0, 1.0)
@@ -65,15 +75,25 @@ func _initialize_from_transform() -> void:
 	current_pitch = target_pitch
 
 func _handle_mouse_button(event: InputEventMouseButton) -> void:
+	if event.button_index == MOUSE_BUTTON_LEFT:
+		_left_down = event.pressed
+		_update_drag_mode(event.shift_pressed)
+		_set_mouse_mode(_is_dragging())
+		if event.pressed:
+			get_viewport().set_input_as_handled()
+		return
+
 	if event.button_index == MOUSE_BUTTON_RIGHT:
-		_orbiting = event.pressed
-		_set_mouse_mode(_orbiting or _panning)
+		_right_down = event.pressed
+		_update_drag_mode(event.shift_pressed)
+		_set_mouse_mode(_is_dragging())
 		get_viewport().set_input_as_handled()
 		return
 
 	if event.button_index == MOUSE_BUTTON_MIDDLE:
-		_panning = event.pressed
-		_set_mouse_mode(_orbiting or _panning)
+		_middle_down = event.pressed
+		_update_drag_mode(event.shift_pressed)
+		_set_mouse_mode(_is_dragging())
 		get_viewport().set_input_as_handled()
 		return
 
@@ -87,23 +107,126 @@ func _handle_mouse_button(event: InputEventMouseButton) -> void:
 		get_viewport().set_input_as_handled()
 
 func _handle_mouse_motion(event: InputEventMouseMotion) -> void:
-	if _orbiting:
+	_update_drag_mode(Input.is_key_pressed(KEY_SHIFT))
+
+	if _drag_mode == DragMode.ORBIT:
 		target_yaw -= event.relative.x * orbit_sensitivity
 		target_pitch -= event.relative.y * orbit_sensitivity
 		target_pitch = clamp(target_pitch, deg_to_rad(-89.0), deg_to_rad(89.0))
 		get_viewport().set_input_as_handled()
 		return
 
-	if _panning:
-		var distance_scale: float = max(current_distance, min_distance)
-		var movement: Vector3 = (-global_transform.basis.x * event.relative.x + global_transform.basis.y * event.relative.y)
-		target_position += movement * (pan_sensitivity * distance_scale)
+	if _drag_mode == DragMode.PAN:
+		_apply_pan(-event.relative.x * pan_sensitivity, event.relative.y * pan_sensitivity)
 		get_viewport().set_input_as_handled()
 
 func _apply_zoom(steps: float) -> void:
 	var adaptive_base: float = zoom_step_factor + 0.1 * clamp(target_distance / 200.0, 0.0, 1.0)
 	var zoom_factor: float = pow(adaptive_base, steps)
-	target_distance = clamp(target_distance * zoom_factor, min_distance, max_distance)
+	var new_distance: float = target_distance * zoom_factor
+
+	if new_distance < min_distance:
+		var forward: Vector3 = _forward_direction(target_yaw, target_pitch)
+		var overshoot: float = min_distance - new_distance
+		target_position += forward * overshoot
+		target_distance = min_distance
+	else:
+		target_distance = clamp(new_distance, min_distance, max_distance)
+
+func _apply_pan(delta_x: float, delta_y: float) -> void:
+	var right: Vector3 = Vector3(cos(target_yaw), 0.0, -sin(target_yaw))
+	target_position += right * delta_x
+	target_position += Vector3.UP * delta_y
+
+func _forward_direction(yaw: float, pitch: float) -> Vector3:
+	var cos_pitch: float = cos(pitch)
+	return Vector3(
+		-cos_pitch * sin(yaw),
+		-sin(pitch),
+		-cos_pitch * cos(yaw)
+	)
+
+func _handle_key_input(event: InputEventKey) -> void:
+	if not event.pressed or event.echo:
+		return
+
+	if event.keycode == KEY_LEFT:
+		if event.shift_pressed:
+			_apply_pan(-0.1, 0.0)
+		elif event.alt_pressed:
+			_apply_zoom(-1.0)
+		else:
+			target_yaw -= deg_to_rad(5.0)
+		get_viewport().set_input_as_handled()
+		return
+
+	if event.keycode == KEY_RIGHT:
+		if event.shift_pressed:
+			_apply_pan(0.1, 0.0)
+		elif event.alt_pressed:
+			_apply_zoom(1.0)
+		else:
+			target_yaw += deg_to_rad(5.0)
+		get_viewport().set_input_as_handled()
+		return
+
+	if event.keycode == KEY_UP:
+		if event.shift_pressed:
+			_apply_pan(0.0, 0.1)
+		elif event.alt_pressed:
+			_apply_zoom(-1.0)
+		else:
+			target_pitch = clamp(target_pitch + deg_to_rad(5.0), deg_to_rad(-89.0), deg_to_rad(89.0))
+		get_viewport().set_input_as_handled()
+		return
+
+	if event.keycode == KEY_DOWN:
+		if event.shift_pressed:
+			_apply_pan(0.0, -0.1)
+		elif event.alt_pressed:
+			_apply_zoom(1.0)
+		else:
+			target_pitch = clamp(target_pitch - deg_to_rad(5.0), deg_to_rad(-89.0), deg_to_rad(89.0))
+		get_viewport().set_input_as_handled()
+		return
+
+	if event.keycode == KEY_KP_1:
+		target_yaw = 0.0
+		target_pitch = 0.0
+		get_viewport().set_input_as_handled()
+		return
+
+	if event.keycode == KEY_KP_3:
+		target_yaw = deg_to_rad(90.0)
+		target_pitch = 0.0
+		get_viewport().set_input_as_handled()
+		return
+
+	if event.keycode == KEY_KP_7:
+		target_yaw = 0.0
+		target_pitch = deg_to_rad(89.0)
+		get_viewport().set_input_as_handled()
+		return
+
+	if event.keycode == KEY_KP_5:
+		target_position = Vector3.ZERO
+		target_yaw = deg_to_rad(45.0)
+		target_pitch = deg_to_rad(30.0)
+		target_distance = 15.0
+		get_viewport().set_input_as_handled()
+
+func _update_drag_mode(shift_down: bool) -> void:
+	if not _is_dragging():
+		_drag_mode = DragMode.NONE
+		return
+
+	if shift_down or _middle_down:
+		_drag_mode = DragMode.PAN
+	else:
+		_drag_mode = DragMode.ORBIT
+
+func _is_dragging() -> bool:
+	return _left_down or _right_down or _middle_down
 
 func _update_camera_transform() -> void:
 	var cos_pitch: float = cos(current_pitch)


### PR DESCRIPTION
### Motivation
- Make Peraviz camera interaction match the Viewer3D panel so users get consistent orbit/pan/zoom semantics across tools.
- Preserve existing modular boundaries by only updating the Peraviz camera script and keeping logic localized to `peraviz/scripts/editor_camera.gd`.

### Description
- Increased `pan_sensitivity` and added a `DragMode` enum with explicit `_left_down`, `_right_down`, `_middle_down` and `_drag_mode` state to mirror Viewer3D drag semantics and mode switching in `peraviz/scripts/editor_camera.gd`.
- Implemented orbit-on-drag (left/right mouse), pan-on-drag (middle mouse or Shift+drag), and unified mouse capture handling via `_update_drag_mode` and `_set_mouse_mode` helpers.
- Reworked pan math to use yaw-based lateral movement and vertical movement on `Vector3.UP`, and updated zoom to apply the same overshoot behavior (translate `target_position` forward when zooming past `min_distance`).
- Added keyboard parity with Viewer3D including arrow keys (orbit), `Shift`+arrow (pan), `Alt`+arrow (zoom), and numpad `1/3/7/5` for preset views and reset.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990b44552a083249dbd81d064c07ec7)