### PR TITLE
Fix 3DS unit scaling mismatch in Peraviz loader

### DIFF
--- a/peraviz/native/src/mesh_3ds_loader.cpp
+++ b/peraviz/native/src/mesh_3ds_loader.cpp
@@ -11,6 +11,8 @@
 
 namespace {
 
+constexpr float kMillimetersToMeters = 0.001F;
+
 struct Chunk {
     uint16_t id = 0;
     uint32_t length = 0;
@@ -232,8 +234,10 @@ bool load_3ds_mesh_data(const godot::String &path,
 
     out_vertices.resize(static_cast<int64_t>(mesh.vertices.size() / 3));
     for (int64_t i = 0; i < out_vertices.size(); ++i) {
-        out_vertices.set(i, godot::Vector3(mesh.vertices[i * 3], mesh.vertices[i * 3 + 1],
-                                           mesh.vertices[i * 3 + 2]));
+        out_vertices.set(
+            i, godot::Vector3(mesh.vertices[i * 3] * kMillimetersToMeters,
+                              mesh.vertices[i * 3 + 1] * kMillimetersToMeters,
+                              mesh.vertices[i * 3 + 2] * kMillimetersToMeters));
     }
 
     out_normals.resize(static_cast<int64_t>(mesh.normals.size() / 3));


### PR DESCRIPTION
### Motivation
- Peraviz was uploading 3DS vertex positions in raw millimeters while node transforms were already converted to meters, producing visually oversized geometry compared to dummy placeholders and the viewer3D pipeline.

### Description
- Convert 3DS vertex coordinates from mm to meters in `peraviz/native/src/mesh_3ds_loader.cpp` by introducing `kMillimetersToMeters = 0.001F` and applying it when populating `out_vertices`.
- Leave normals and indices untouched and keep the existing transform-to-Godot mapping logic unchanged so node transforms remain consistent.
- The change aligns Peraviz mesh units with the `RENDER_SCALE` convention used by the Perastage 3D viewer.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991912a0ce08324a4f0bca2406cf47e)