### PR TITLE
Unify Peraviz coordinate conversion to fix 3D placement/rotation

### DIFF
--- a/peraviz/native/CMakeLists.txt
+++ b/peraviz/native/CMakeLists.txt
@@ -72,6 +72,7 @@ endif()
 add_library(peraviz_native SHARED
     src/hello_world.cpp
     src/asset_cache.cpp
+    src/coordinate_mapper.cpp
     src/mesh_3ds_loader.cpp
     src/gdtf_scene_builder.cpp
     src/mvr_scene_loader.cpp

--- a/peraviz/native/src/coordinate_mapper.cpp
+++ b/peraviz/native/src/coordinate_mapper.cpp
@@ -1,0 +1,79 @@
+#include "coordinate_mapper.h"
+
+#include <cmath>
+
+namespace {
+
+std::array<float, 3> scale_axis(const std::array<float, 3> &v, float factor) {
+    return {v[0] * factor, v[1] * factor, v[2] * factor};
+}
+
+std::array<float, 3> extract_scale(const Matrix &m) {
+    auto len = [](const std::array<float, 3> &v) {
+        return std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
+    };
+    return {len(m.u), len(m.v), len(m.w)};
+}
+
+Matrix normalize_basis(const Matrix &m, const std::array<float, 3> &scale) {
+    Matrix out = m;
+    auto safe_div = [](float value, float s) {
+        return (std::abs(s) > 1e-6F) ? value / s : value;
+    };
+    for (int i = 0; i < 3; ++i) {
+        out.u[i] = safe_div(out.u[i], scale[0]);
+        out.v[i] = safe_div(out.v[i], scale[1]);
+        out.w[i] = safe_div(out.w[i], scale[2]);
+    }
+    return out;
+}
+
+} // namespace
+
+namespace peraviz::coordinate_mapper {
+
+Vec3 map_position_mm_to_m(const std::array<float, 3> &source_mm) {
+    return Vec3{source_mm[0] / 1000.0F, source_mm[2] / 1000.0F,
+                -source_mm[1] / 1000.0F};
+}
+
+std::array<float, 3> map_source_vector_to_godot(const std::array<float, 3> &source) {
+    return {source[0], source[2], -source[1]};
+}
+
+Matrix to_godot_local_basis(const Matrix &source_local) {
+    Matrix out;
+
+    const auto mapped_u = map_source_vector_to_godot(source_local.u);
+    const auto mapped_v = map_source_vector_to_godot(source_local.v);
+    const auto mapped_w = map_source_vector_to_godot(source_local.w);
+
+    // Convert local basis with C * R * C^-1 so parent/child composition remains correct.
+    out.u = mapped_u;
+    out.v = mapped_w;
+    out.w = scale_axis(mapped_v, -1.0F);
+    out.o = {0.0F, 0.0F, 0.0F};
+    return out;
+}
+
+SceneTransform to_godot_transform(const Matrix &source_local) {
+    SceneTransform transform;
+    transform.position = map_position_mm_to_m(source_local.o);
+
+    Matrix basis = to_godot_local_basis(source_local);
+    transform.basis_x = {basis.u[0], basis.u[1], basis.u[2]};
+    transform.basis_y = {basis.v[0], basis.v[1], basis.v[2]};
+    transform.basis_z = {basis.w[0], basis.w[1], basis.w[2]};
+    transform.has_basis = true;
+
+    const auto scale = extract_scale(basis);
+    transform.scale = {scale[0], scale[1], scale[2]};
+
+    Matrix rotation_only = normalize_basis(basis, scale);
+    const auto euler = MatrixUtils::MatrixToEuler(rotation_only);
+    transform.rotation_degrees = {euler[0], euler[1], euler[2]};
+    return transform;
+}
+
+} // namespace peraviz::coordinate_mapper
+

--- a/peraviz/native/src/coordinate_mapper.h
+++ b/peraviz/native/src/coordinate_mapper.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "matrixutils.h"
+#include "scene_model.h"
+
+#include <array>
+
+namespace peraviz::coordinate_mapper {
+
+Vec3 map_position_mm_to_m(const std::array<float, 3> &source_mm);
+
+std::array<float, 3> map_source_vector_to_godot(const std::array<float, 3> &source);
+
+Matrix to_godot_local_basis(const Matrix &source_local);
+
+SceneTransform to_godot_transform(const Matrix &source_local);
+
+} // namespace peraviz::coordinate_mapper
+

--- a/peraviz/native/src/gdtf_scene_builder.cpp
+++ b/peraviz/native/src/gdtf_scene_builder.cpp
@@ -1,6 +1,7 @@
 #include "gdtf_scene_builder.h"
 
 #include "asset_cache.h"
+#include "coordinate_mapper.h"
 #include "matrixutils.h"
 
 #include <algorithm>
@@ -15,65 +16,6 @@
 namespace {
 
 using peraviz::SceneNode;
-using peraviz::Vec3;
-
-Vec3 map_position(const std::array<float, 3> &source_mm) {
-    return Vec3{source_mm[0] / 1000.0F, source_mm[2] / 1000.0F,
-                -source_mm[1] / 1000.0F};
-}
-
-std::array<float, 3> map_axis(const std::array<float, 3> &v) {
-    return {v[0], v[2], -v[1]};
-}
-
-Matrix to_godot_basis_matrix(const Matrix &source) {
-    Matrix out;
-    out.u = map_axis(source.u);
-    out.v = map_axis(source.v);
-    out.w = map_axis(source.w);
-    out.o = {0.0F, 0.0F, 0.0F};
-    return out;
-}
-
-std::array<float, 3> extract_scale(const Matrix &m) {
-    auto len = [](const std::array<float, 3> &v) {
-        return std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
-    };
-    return {len(m.u), len(m.v), len(m.w)};
-}
-
-Matrix normalize_basis(const Matrix &m, const std::array<float, 3> &scale) {
-    Matrix out = m;
-    auto safe_div = [](float value, float s) {
-        return (std::abs(s) > 1e-6F) ? value / s : value;
-    };
-    for (int i = 0; i < 3; ++i) {
-        out.u[i] = safe_div(out.u[i], scale[0]);
-        out.v[i] = safe_div(out.v[i], scale[1]);
-        out.w[i] = safe_div(out.w[i], scale[2]);
-    }
-    return out;
-}
-
-peraviz::SceneTransform to_godot_transform(const Matrix &local_transform) {
-    peraviz::SceneTransform transform;
-    transform.position = map_position(local_transform.o);
-
-    Matrix basis = to_godot_basis_matrix(local_transform);
-    transform.basis_x = {basis.u[0], basis.u[1], basis.u[2]};
-    transform.basis_y = {basis.v[0], basis.v[1], basis.v[2]};
-    transform.basis_z = {basis.w[0], basis.w[1], basis.w[2]};
-    transform.has_basis = true;
-
-    const auto scale = extract_scale(basis);
-    transform.scale = {scale[0], scale[1], scale[2]};
-
-    Matrix rotation_only = normalize_basis(basis, scale);
-    const auto euler = MatrixUtils::MatrixToEuler(rotation_only);
-    transform.rotation_degrees = {euler[0], euler[1], euler[2]};
-    return transform;
-}
-
 std::string lower_ascii(std::string text) {
     std::transform(text.begin(), text.end(), text.begin(), [](unsigned char c) {
         return static_cast<char>(std::tolower(c));
@@ -218,7 +160,7 @@ std::vector<SceneNode> build_fixture_geometry_nodes(const GdtfBuildRequest &requ
         node.is_fixture = true;
         node.is_axis = looks_like_axis(geometry->Name(), geometry_name);
         node.is_emitter = looks_like_emitter(geometry->Name(), geometry_name);
-        node.local_transform = to_godot_transform(local);
+        node.local_transform = peraviz::coordinate_mapper::to_godot_transform(local);
 
         if (const char *model_name = geometry->Attribute("Model")) {
             auto model_it = model_file_by_name.find(model_name);

--- a/peraviz/native/src/mesh_3ds_loader.cpp
+++ b/peraviz/native/src/mesh_3ds_loader.cpp
@@ -1,5 +1,7 @@
 #include "mesh_3ds_loader.h"
 
+#include "coordinate_mapper.h"
+
 #include <godot_cpp/variant/vector3.hpp>
 
 #include <array>
@@ -234,16 +236,24 @@ bool load_3ds_mesh_data(const godot::String &path,
 
     out_vertices.resize(static_cast<int64_t>(mesh.vertices.size() / 3));
     for (int64_t i = 0; i < out_vertices.size(); ++i) {
-        out_vertices.set(
-            i, godot::Vector3(mesh.vertices[i * 3] * kMillimetersToMeters,
-                              mesh.vertices[i * 3 + 1] * kMillimetersToMeters,
-                              mesh.vertices[i * 3 + 2] * kMillimetersToMeters));
+        const std::array<float, 3> source_vertex = {
+            mesh.vertices[i * 3] * kMillimetersToMeters,
+            mesh.vertices[i * 3 + 1] * kMillimetersToMeters,
+            mesh.vertices[i * 3 + 2] * kMillimetersToMeters,
+        };
+        const auto mapped = coordinate_mapper::map_source_vector_to_godot(source_vertex);
+        out_vertices.set(i, godot::Vector3(mapped[0], mapped[1], mapped[2]));
     }
 
     out_normals.resize(static_cast<int64_t>(mesh.normals.size() / 3));
     for (int64_t i = 0; i < out_normals.size(); ++i) {
-        out_normals.set(i, godot::Vector3(mesh.normals[i * 3], mesh.normals[i * 3 + 1],
-                                          mesh.normals[i * 3 + 2]));
+        const std::array<float, 3> source_normal = {
+            mesh.normals[i * 3],
+            mesh.normals[i * 3 + 1],
+            mesh.normals[i * 3 + 2],
+        };
+        const auto mapped = coordinate_mapper::map_source_vector_to_godot(source_normal);
+        out_normals.set(i, godot::Vector3(mapped[0], mapped[1], mapped[2]));
     }
 
     out_indices.resize(static_cast<int64_t>(mesh.indices.size()));

--- a/peraviz/native/src/mvr_scene_loader.cpp
+++ b/peraviz/native/src/mvr_scene_loader.cpp
@@ -1,6 +1,7 @@
 #include "mvr_scene_loader.h"
 
 #include "asset_cache.h"
+#include "coordinate_mapper.h"
 #include "gdtf_scene_builder.h"
 #include "matrixutils.h"
 #include "types.h"
@@ -23,69 +24,11 @@ namespace {
 
 using peraviz::SceneModel;
 using peraviz::SceneNode;
-using peraviz::Vec3;
 
 struct SymdefGeometry {
     std::string file_name;
     Matrix transform = MatrixUtils::Identity();
 };
-
-Vec3 map_position(const std::array<float, 3> &source_mm) {
-    return Vec3{source_mm[0] / 1000.0F, source_mm[2] / 1000.0F,
-                -source_mm[1] / 1000.0F};
-}
-
-std::array<float, 3> map_axis(const std::array<float, 3> &v) {
-    return {v[0], v[2], -v[1]};
-}
-
-Matrix to_godot_basis_matrix(const Matrix &source) {
-    Matrix out;
-    out.u = map_axis(source.u);
-    out.v = map_axis(source.v);
-    out.w = map_axis(source.w);
-    out.o = {0.0F, 0.0F, 0.0F};
-    return out;
-}
-
-std::array<float, 3> extract_scale(const Matrix &m) {
-    auto len = [](const std::array<float, 3> &v) {
-        return std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
-    };
-    return {len(m.u), len(m.v), len(m.w)};
-}
-
-Matrix normalize_basis(const Matrix &m, const std::array<float, 3> &scale) {
-    Matrix out = m;
-    auto safe_div = [](float value, float s) {
-        return (std::abs(s) > 1e-6F) ? value / s : value;
-    };
-    for (int i = 0; i < 3; ++i) {
-        out.u[i] = safe_div(out.u[i], scale[0]);
-        out.v[i] = safe_div(out.v[i], scale[1]);
-        out.w[i] = safe_div(out.w[i], scale[2]);
-    }
-    return out;
-}
-
-peraviz::SceneTransform to_godot_transform(const Matrix &local_transform) {
-    peraviz::SceneTransform transform;
-    transform.position = map_position(local_transform.o);
-
-    Matrix basis = to_godot_basis_matrix(local_transform);
-    transform.basis_x = {basis.u[0], basis.u[1], basis.u[2]};
-    transform.basis_y = {basis.v[0], basis.v[1], basis.v[2]};
-    transform.basis_z = {basis.w[0], basis.w[1], basis.w[2]};
-    transform.has_basis = true;
-
-    const auto scale = extract_scale(basis);
-    transform.scale = {scale[0], scale[1], scale[2]};
-
-    Matrix rotation_only = normalize_basis(basis, scale);
-    const auto euler = MatrixUtils::MatrixToEuler(rotation_only);
-    transform.rotation_degrees = {euler[0], euler[1], euler[2]};
-    return transform;
-}
 
 std::string lower_ascii(std::string text) {
     std::transform(text.begin(), text.end(), text.begin(), [](unsigned char c) {
@@ -260,7 +203,7 @@ void append_geometry_children(SceneModel &scene, tinyxml2::XMLElement *node, con
         geo_node.parent_id = parent_id;
         geo_node.name = parse_name(geo, "Geometry3D");
         geo_node.type = "model_part";
-        geo_node.local_transform = to_godot_transform(local);
+        geo_node.local_transform = peraviz::coordinate_mapper::to_godot_transform(local);
         const std::string model_name = normalize_geometry_file_name(parse_model_filename(geo));
         if (!model_name.empty()) {
             geo_node.asset_path = mvr_cache.ensure_extracted(model_name);
@@ -291,7 +234,7 @@ void append_geometry_children(SceneModel &scene, tinyxml2::XMLElement *node, con
             symbol_node.type = "model_part";
 
             Matrix local = MatrixUtils::Multiply(symbol_local, sym_geo.transform);
-            symbol_node.local_transform = to_godot_transform(local);
+            symbol_node.local_transform = peraviz::coordinate_mapper::to_godot_transform(local);
 
             if (!sym_geo.file_name.empty()) {
                 symbol_node.asset_path = mvr_cache.ensure_extracted(sym_geo.file_name);
@@ -354,7 +297,7 @@ SceneModel load_mvr(const std::string &path) {
             node.node_id = id;
             node.parent_id = parent_id;
             node.name = parse_name(child, node_name);
-            node.local_transform = to_godot_transform(local_transform);
+            node.local_transform = peraviz::coordinate_mapper::to_godot_transform(local_transform);
 
             if (node_name == "Fixture") {
                 node.type = "fixture";
@@ -407,7 +350,7 @@ SceneModel load_mvr(const std::string &path) {
     for (tinyxml2::XMLElement *layer = layers->FirstChildElement("Layer"); layer;
          layer = layer->NextSiblingElement("Layer")) {
         if (tinyxml2::XMLElement *child_list = layer->FirstChildElement("ChildList")) {
-            parse_child_list(child_list, parse_matrix_node(layer), "");
+            parse_child_list(child_list, MatrixUtils::Identity(), "");
         }
     }
 


### PR DESCRIPTION
### Motivation
- Peraviz showed many 3D models placed with incorrect rotation/axis vs Perastage because the axis/transform conversion logic diverged between loaders. 
- The goal is to align Peraviz node/matrix mapping with Perastage’s scene-graph composition so nested geometry preserves correct axes and rotations.

### Description
- Added a new module `peraviz/native/src/coordinate_mapper.{h,cpp}` that centralizes source-to-Godot coordinate/axis mapping and produces a `SceneTransform` suitable for Godot/Peraviz use via `peraviz::coordinate_mapper::to_godot_transform`.
- Replaced ad-hoc conversions with the shared mapper in `peraviz/native/src/mvr_scene_loader.cpp` and `peraviz/native/src/gdtf_scene_builder.cpp` so MVR and GDTF geometry use exactly the same transform rules.
- Applied axis conversion to mesh data in the native 3DS loader (`peraviz/native/src/mesh_3ds_loader.cpp`) so vertices and normals are oriented consistently with node transforms.
- Adjusted MVR layer parsing to match Perastage behavior by parsing `Layer/ChildList` using an identity parent transform (avoids unintended layer-level offsets).
- Registered the new source file in `peraviz/native/CMakeLists.txt` (`src/coordinate_mapper.cpp`).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.
- Attempted a native build with `cmake -S peraviz/native -B /tmp/peraviz-native-build -DCMAKE_BUILD_TYPE=Debug && cmake --build /tmp/peraviz-native-build -j2`, which failed in the container due to a missing system dependency (`tinyxml2` development package / config), not because of code errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991934d4a7c8324b891a3c1c1080a2a)