### PR TITLE
Fix GDTF fixture piece offsets in Peraviz Godot loader

### DIFF
--- a/peraviz/native/src/gdtf_scene_builder.cpp
+++ b/peraviz/native/src/gdtf_scene_builder.cpp
@@ -47,6 +47,12 @@ bool is_supported_geometry_tag(const std::string &tag_name) {
            tag_name == "MediaServerMaster" || tag_name.rfind("Filter", 0) == 0;
 }
 
+void convert_translation_m_to_mm(Matrix &matrix) {
+    matrix.o[0] *= 1000.0F;
+    matrix.o[1] *= 1000.0F;
+    matrix.o[2] *= 1000.0F;
+}
+
 Matrix parse_local_matrix(tinyxml2::XMLElement *node) {
     Matrix out = MatrixUtils::Identity();
 
@@ -56,6 +62,11 @@ Matrix parse_local_matrix(tinyxml2::XMLElement *node) {
     }
     if (position) {
         MatrixUtils::ParseMatrix(position, out);
+        // GDTF geometry transforms are authored in meters. The Peraviz scene
+        // graph uses the same matrix utilities as MVR parsing, where
+        // translations are represented in millimeters before conversion to
+        // Godot meters.
+        convert_translation_m_to_mm(out);
         return out;
     }
 
@@ -65,6 +76,7 @@ Matrix parse_local_matrix(tinyxml2::XMLElement *node) {
     }
     if (matrix_attr) {
         MatrixUtils::ParseMatrix(matrix_attr, out);
+        convert_translation_m_to_mm(out);
         return out;
     }
 
@@ -75,6 +87,7 @@ Matrix parse_local_matrix(tinyxml2::XMLElement *node) {
     if (matrix) {
         if (const char *text = matrix->GetText()) {
             MatrixUtils::ParseMatrix(text, out);
+            convert_translation_m_to_mm(out);
         }
     }
     return out;


### PR DESCRIPTION
### Motivation
- Peraviz was assembling GDTF fixture submodels with incorrect offsets so all pieces collapsed near the fixture insertion point due to a units mismatch between GDTF (meters) and the internal MVR pipeline (millimetres). 
- The change aligns GDTF local transforms with the existing MVR -> Godot conversion path so per-piece translations, relative distances and axes are preserved.

### Description
- Update `peraviz/native/src/gdtf_scene_builder.cpp` to convert parsed GDTF translation components from meters to millimetres before composing hierarchy by adding a helper `convert_translation_m_to_mm` and calling it from `parse_local_matrix` after reading `Position`/`Matrix` attributes/text. 
- Keep all other geometry parsing and model extraction logic unchanged and localize the unit conversion to the Peraviz native GDTF assembler.
- The change is scoped to the Peraviz native loader and does not modify Perastage viewer rendering logic or module boundaries.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed. 
- Attempted to build the native Peraviz target with `cmake -S peraviz/native -B peraviz/native/build -DCMAKE_BUILD_TYPE=Debug && cmake --build peraviz/native/build --config Debug` but the build was blocked in this environment due to a missing development package (`tinyxml2`), so compilation could not be verified here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992eac0819c83249b15bfa80663bb66)