### PR TITLE
Sanitize scene node transforms for editor selection stability and add coordinate debug logging

### DIFF
--- a/peraviz/native/src/gdtf_scene_builder.cpp
+++ b/peraviz/native/src/gdtf_scene_builder.cpp
@@ -284,6 +284,13 @@ std::vector<SceneNode> build_fixture_geometry_nodes(const GdtfBuildRequest &requ
         node.is_emitter = looks_like_emitter(geometry->Name(), geometry_name);
         node.local_transform = peraviz::coordinate_mapper::to_godot_transform(local);
 
+        if (node.is_emitter) {
+            peraviz::debug_runtime::log_coordinate_debug_event(
+                "emitter_reference", request.fixture_name,
+                "geometry_id=" + geometry_id +
+                    " expected_beam_direction_local=-Z (GDTF reference)");
+        }
+
         const char *model_name = override_model ? override_model : geometry->Attribute("Model");
         if (!model_name) {
             model_name = geometry->Attribute("model");

--- a/peraviz/native/src/mvr_scene_loader.cpp
+++ b/peraviz/native/src/mvr_scene_loader.cpp
@@ -269,8 +269,11 @@ void append_geometry_children(SceneModel &scene, tinyxml2::XMLElement *node, con
 
 namespace peraviz {
 
-SceneModel load_mvr(const std::string &path, bool peraviz_debug_baseline) {
+SceneModel load_mvr(const std::string &path, bool peraviz_debug_baseline,
+                    bool peraviz_debug_coords) {
     peraviz::debug_runtime::set_baseline_debug_enabled(peraviz_debug_baseline);
+    peraviz::debug_runtime::set_coordinate_debug_enabled(peraviz_debug_coords);
+    peraviz::debug_runtime::log_coordinate_mapping_metadata();
 
     SceneModel model;
     if (!std::filesystem::exists(std::filesystem::u8path(path))) {
@@ -321,6 +324,10 @@ SceneModel load_mvr(const std::string &path, bool peraviz_debug_baseline) {
             node.parent_id = parent_id;
             node.name = parse_name(child, node_name);
             node.local_transform = peraviz::coordinate_mapper::to_godot_transform(local_transform);
+
+            peraviz::debug_runtime::log_coordinate_debug_event(
+                "instantiate_node", node_name,
+                "node_id=" + id + " parent_id=" + parent_id + " name=" + node.name);
 
             if (node_name == "Fixture") {
                 node.type = "fixture";

--- a/peraviz/native/src/mvr_scene_loader.h
+++ b/peraviz/native/src/mvr_scene_loader.h
@@ -6,6 +6,7 @@
 
 namespace peraviz {
 
-SceneModel load_mvr(const std::string &path, bool peraviz_debug_baseline = false);
+SceneModel load_mvr(const std::string &path, bool peraviz_debug_baseline = false,
+                    bool peraviz_debug_coords = false);
 
 } // namespace peraviz

--- a/peraviz/native/src/peraviz_debug_runtime.cpp
+++ b/peraviz/native/src/peraviz_debug_runtime.cpp
@@ -8,6 +8,7 @@ namespace peraviz::debug_runtime {
 namespace {
 
 bool g_baseline_debug_enabled = false;
+bool g_coordinate_debug_enabled = false;
 
 godot::String vec_to_string(const std::array<float, 3> &v) {
     godot::String out("(");
@@ -69,6 +70,41 @@ bool is_baseline_debug_enabled() {
     return g_baseline_debug_enabled;
 }
 
+void set_coordinate_debug_enabled(bool enabled) {
+    g_coordinate_debug_enabled = enabled;
+}
+
+bool is_coordinate_debug_enabled() {
+    return g_coordinate_debug_enabled;
+}
+
+void log_coordinate_mapping_metadata() {
+    if (!g_coordinate_debug_enabled) {
+        return;
+    }
+
+    godot::UtilityFunctions::print(
+        "[PeravizCoordDebug] event=coordinate_mapping_metadata"
+        " scale_global=mm_to_m(0.001)"
+        " godot_up=+Y"
+        " godot_forward=-Z"
+        " godot_handedness=right_handed"
+        " source_to_godot=(x,y,z)->(x,z,-y)"
+        " beam_reference_local_direction=-Z");
+}
+
+void log_coordinate_debug_event(const std::string &event,
+                                const std::string &scope,
+                                const std::string &detail) {
+    if (!g_coordinate_debug_enabled) {
+        return;
+    }
+
+    godot::UtilityFunctions::print("[PeravizCoordDebug] event=", godot::String(event.c_str()),
+                                   " scope=", godot::String(scope.c_str()),
+                                   " detail=", godot::String(detail.c_str()));
+}
+
 void log_baseline_transform_comparison(const std::string &context,
                                        const Matrix &source_local,
                                        const SceneTransform &mapped_transform) {
@@ -85,11 +121,16 @@ void log_transform_adjustment(const std::string &context,
                               const std::string &reason,
                               const Matrix &before,
                               const Matrix &after) {
-    godot::UtilityFunctions::print("[PeravizTransformAdjustment] context=",
-                                   godot::String(context.c_str()),
-                                   " reason=", godot::String(reason.c_str()),
-                                   " before=", matrix_to_string(before),
-                                   " after=", matrix_to_string(after));
+    if (!g_coordinate_debug_enabled) {
+        return;
+    }
+
+    godot::UtilityFunctions::print(
+        "[PeravizCoordDebug] event=transform_adjustment"
+        " context=", godot::String(context.c_str()),
+        " reason=", godot::String(reason.c_str()),
+        " before=", matrix_to_string(before),
+        " after=", matrix_to_string(after));
 }
 
 } // namespace peraviz::debug_runtime

--- a/peraviz/native/src/peraviz_debug_runtime.h
+++ b/peraviz/native/src/peraviz_debug_runtime.h
@@ -10,6 +10,15 @@ namespace peraviz::debug_runtime {
 void set_baseline_debug_enabled(bool enabled);
 bool is_baseline_debug_enabled();
 
+void set_coordinate_debug_enabled(bool enabled);
+bool is_coordinate_debug_enabled();
+
+void log_coordinate_mapping_metadata();
+
+void log_coordinate_debug_event(const std::string &event,
+                                const std::string &scope,
+                                const std::string &detail);
+
 void log_baseline_transform_comparison(const std::string &context,
                                        const Matrix &source_local,
                                        const SceneTransform &mapped_transform);
@@ -20,4 +29,3 @@ void log_transform_adjustment(const std::string &context,
                               const Matrix &after);
 
 } // namespace peraviz::debug_runtime
-

--- a/peraviz/native/src/peraviz_loader.cpp
+++ b/peraviz/native/src/peraviz_loader.cpp
@@ -13,16 +13,19 @@
 namespace godot {
 
 void PeravizLoader::_bind_methods() {
-    ClassDB::bind_method(D_METHOD("load_mvr", "path", "peraviz_debug_baseline"), &PeravizLoader::load_mvr);
+    ClassDB::bind_method(D_METHOD("load_mvr", "path", "peraviz_debug_baseline", "peraviz_debug_coords"), &PeravizLoader::load_mvr);
     ClassDB::bind_method(D_METHOD("load_3ds_mesh_data", "path"), &PeravizLoader::load_3ds_mesh_data);
 }
 
-Array PeravizLoader::load_mvr(const String &path, bool peraviz_debug_baseline) const {
+Array PeravizLoader::load_mvr(const String &path, bool peraviz_debug_baseline,
+                              bool peraviz_debug_coords) const {
     const peraviz::SceneModel model = peraviz::load_mvr(std::string(path.utf8().get_data()),
-                                                        peraviz_debug_baseline);
+                                                        peraviz_debug_baseline,
+                                                        peraviz_debug_coords);
 
     UtilityFunctions::print("[PeravizNative] load_mvr nodes=", model.nodes.size(),
                             " baseline_debug=", peraviz_debug_baseline,
+                            " coords_debug=", peraviz_debug_coords,
                             " fixtures=", model.fixture_count,
                             " trusses=", model.truss_count,
                             " objects=", model.object_count,

--- a/peraviz/native/src/peraviz_loader.h
+++ b/peraviz/native/src/peraviz_loader.h
@@ -15,7 +15,8 @@ protected:
     static void _bind_methods();
 
 public:
-    Array load_mvr(const String &path, bool peraviz_debug_baseline = false) const;
+    Array load_mvr(const String &path, bool peraviz_debug_baseline = false,
+                   bool peraviz_debug_coords = false) const;
     Dictionary load_3ds_mesh_data(const String &path) const;
 };
 

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -10,12 +10,19 @@ var _loaded_bounds: AABB
 var _has_loaded_bounds: bool = false
 var _node_index: Dictionary = {}
 var _asset_cache: Dictionary = {}
+var _debug_coords_enabled: bool = false
+var _debug_gizmos_root: Node3D
+
+const DEBUG_TOGGLE_KEY: Key = KEY_C
 
 func _ready() -> void:
 	$HUD/LoadButton.pressed.connect(_on_load_pressed)
 	picker.file_selected.connect(_on_file_selected)
 	picker.access = FileDialog.ACCESS_FILESYSTEM
 	status_label.text = "Select a .mvr file"
+	_debug_coords_enabled = bool(ProjectSettings.get_setting("peraviz_debug_coords", false))
+	_ensure_debug_gizmo_root()
+	_update_debug_legend()
 
 func _on_load_pressed() -> void:
 	picker.popup_centered_ratio(0.7)
@@ -24,18 +31,171 @@ func _on_file_selected(path: String) -> void:
 	_clear_scene()
 	var native_path: String = ProjectSettings.globalize_path(path)
 	var peraviz_debug_baseline: bool = bool(ProjectSettings.get_setting("peraviz_debug_baseline", false))
-	var nodes: Array = _loader.load_mvr(native_path, peraviz_debug_baseline)
-	print("[Peraviz] Loaded render nodes: ", nodes.size(), " baseline_debug=", peraviz_debug_baseline)
+	var nodes: Array = _loader.load_mvr(native_path, peraviz_debug_baseline, _debug_coords_enabled)
+	print("[Peraviz] Loaded render nodes: ", nodes.size(), " baseline_debug=", peraviz_debug_baseline, " coords_debug=", _debug_coords_enabled)
 	_has_loaded_bounds = false
+	_clear_debug_gizmos()
 
 	_build_node_tree(nodes)
+	_rebuild_debug_gizmos()
 	_focus_loaded_scene()
-	status_label.text = "Nodes: %d (press F to focus)" % nodes.size()
+	status_label.text = "Nodes: %d (press F to focus, C debug coords)" % nodes.size()
+	_update_debug_legend()
 
 func _unhandled_input(event: InputEvent) -> void:
 	if event is InputEventKey and event.pressed and not event.echo and event.keycode == KEY_F:
 		_focus_loaded_scene()
 		get_viewport().set_input_as_handled()
+		return
+
+	if event is InputEventKey and event.pressed and not event.echo and event.keycode == DEBUG_TOGGLE_KEY:
+		_debug_coords_enabled = not _debug_coords_enabled
+		ProjectSettings.set_setting("peraviz_debug_coords", _debug_coords_enabled)
+		print("[PeravizCoordDebug] event=toggle coords_debug=", _debug_coords_enabled)
+		_rebuild_debug_gizmos()
+		_update_debug_legend()
+		get_viewport().set_input_as_handled()
+
+
+func _ensure_debug_gizmo_root() -> void:
+	if _debug_gizmos_root != null and is_instance_valid(_debug_gizmos_root):
+		return
+	_debug_gizmos_root = Node3D.new()
+	_debug_gizmos_root.name = "DebugGizmos"
+	_debug_gizmos_root.top_level = true
+	add_child(_debug_gizmos_root)
+
+func _clear_debug_gizmos() -> void:
+	_ensure_debug_gizmo_root()
+	for child in _debug_gizmos_root.get_children():
+		child.queue_free()
+
+func _rebuild_debug_gizmos() -> void:
+	_clear_debug_gizmos()
+	if not _debug_coords_enabled:
+		return
+
+	_add_debug_gizmo_for_target(proxies_root, "scene_root", Color(1.0, 0.25, 1.0), 0.75)
+	for node in _node_index.values():
+		if node is not Node3D:
+			continue
+		var node3d: Node3D = node
+		var metadata_type: String = str(node3d.get_meta("peraviz_type", ""))
+		var is_axis: bool = bool(node3d.get_meta("peraviz_is_axis", false))
+		var is_emitter: bool = bool(node3d.get_meta("peraviz_is_emitter", false))
+
+		if metadata_type in ["fixture", "truss", "support", "scene_object"]:
+			_add_debug_gizmo_for_target(node3d, "mvr_instance_root", Color(1.0, 0.9, 0.2), 0.55)
+		if is_axis:
+			_add_debug_gizmo_for_target(node3d, "gdtf_axis", Color(0.0, 1.0, 1.0), 0.35)
+		if is_emitter:
+			_add_debug_gizmo_for_target(node3d, "emitter", Color(1.0, 0.55, 0.15), 0.30)
+
+
+func _is_basis_valid(basis: Basis) -> bool:
+	var determinant: float = basis.determinant()
+	if is_zero_approx(determinant):
+		return false
+	return is_finite(determinant)
+
+func _safe_basis_from_data(data: Dictionary) -> Basis:
+	var basis_x: Vector3 = data.get("basis_x", Vector3.RIGHT)
+	var basis_y: Vector3 = data.get("basis_y", Vector3.UP)
+	var basis_z: Vector3 = data.get("basis_z", Vector3.BACK)
+	var basis := Basis(basis_x, basis_y, basis_z)
+	if _is_basis_valid(basis):
+		return basis
+
+	print("[PeravizCoordDebug] event=invalid_basis_fallback basis_x=", basis_x, " basis_y=", basis_y, " basis_z=", basis_z)
+	return Basis.IDENTITY
+
+func _safe_position(value: Vector3, context: String) -> Vector3:
+	if is_finite(value.x) and is_finite(value.y) and is_finite(value.z):
+		return value
+	print("[PeravizCoordDebug] event=invalid_position_fallback context=", context, " pos=", value)
+	return Vector3.ZERO
+
+func _safe_scale_from_data(data: Dictionary, context: String) -> Vector3:
+	var raw_scale: Vector3 = data.get("scale", Vector3.ONE)
+	if not is_finite(raw_scale.x) or not is_finite(raw_scale.y) or not is_finite(raw_scale.z):
+		print("[PeravizCoordDebug] event=invalid_scale_fallback context=", context, " scale=", raw_scale)
+		return Vector3.ONE
+
+	var min_axis: float = 0.0001
+	var sx: float = raw_scale.x
+	var sy: float = raw_scale.y
+	var sz: float = raw_scale.z
+	if is_zero_approx(sx):
+		sx = min_axis
+	if is_zero_approx(sy):
+		sy = min_axis
+	if is_zero_approx(sz):
+		sz = min_axis
+
+	if not is_equal_approx(sx, raw_scale.x) or not is_equal_approx(sy, raw_scale.y) or not is_equal_approx(sz, raw_scale.z):
+		print("[PeravizCoordDebug] event=zero_scale_sanitized context=", context, " raw_scale=", raw_scale, " sanitized_scale=", Vector3(sx, sy, sz))
+	return Vector3(sx, sy, sz)
+
+func _safe_target_global_position(target: Node3D) -> Vector3:
+	if target == null:
+		return Vector3.ZERO
+	var origin: Vector3 = target.global_position
+	if not is_finite(origin.x) or not is_finite(origin.y) or not is_finite(origin.z):
+		print("[PeravizCoordDebug] event=invalid_target_origin_fallback node=", target.name, " origin=", origin)
+		return Vector3.ZERO
+	return origin
+
+func _add_debug_gizmo_for_target(target: Node3D, kind: String, origin_color: Color, length: float) -> void:
+	if target == null:
+		return
+	var holder := Node3D.new()
+	holder.name = "Gizmo_%s" % kind
+	holder.global_position = _safe_target_global_position(target)
+	holder.add_child(_create_axes_gizmo_node(origin_color, length))
+	_debug_gizmos_root.add_child(holder)
+
+func _create_axes_gizmo_node(origin_color: Color, length: float) -> Node3D:
+	var immediate := ImmediateMesh.new()
+	var line_material := ORMMaterial3D.new()
+	line_material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
+	line_material.vertex_color_use_as_albedo = true
+	immediate.surface_begin(Mesh.PRIMITIVE_LINES, line_material)
+	immediate.surface_set_color(Color(1, 0, 0))
+	immediate.surface_add_vertex(Vector3.ZERO)
+	immediate.surface_add_vertex(Vector3.RIGHT * length)
+	immediate.surface_set_color(Color(0, 1, 0))
+	immediate.surface_add_vertex(Vector3.ZERO)
+	immediate.surface_add_vertex(Vector3.UP * length)
+	immediate.surface_set_color(Color(0, 0.4, 1))
+	immediate.surface_add_vertex(Vector3.ZERO)
+	immediate.surface_add_vertex(Vector3.BACK * length)
+	immediate.surface_end()
+
+	var axes_instance := MeshInstance3D.new()
+	axes_instance.mesh = immediate
+	axes_instance.material_override = line_material
+
+	var marker := SphereMesh.new()
+	marker.radius = max(length * 0.08, 0.01)
+	marker.height = marker.radius * 2.0
+	var marker_material := StandardMaterial3D.new()
+	marker_material.albedo_color = origin_color
+	marker_material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
+	var marker_instance := MeshInstance3D.new()
+	marker_instance.mesh = marker
+	marker_instance.material_override = marker_material
+
+	var container := Node3D.new()
+	container.add_child(axes_instance)
+	container.add_child(marker_instance)
+	return container
+
+func _update_debug_legend() -> void:
+	if not _debug_coords_enabled:
+		print("[PeravizCoordDebugLegend] disabled (press C to enable)")
+		return
+
+	print("[PeravizCoordDebugLegend] X=Red Y=Green Z=Blue scene_root_origin=Magenta mvr_instance_root_origin=Yellow gdtf_axis_origin=Cyan emitter_origin=Orange beam_expected_local=-Z")
 
 func _build_node_tree(nodes: Array) -> void:
 	_node_index.clear()
@@ -69,16 +229,22 @@ func _create_scene_node(data: Dictionary) -> Node3D:
 
 	var root := Node3D.new()
 	root.name = "%s_%s" % [item_class, node_name]
-	var position: Vector3 = data.get("pos", Vector3.ZERO)
+	root.set_meta("peraviz_type", item_type)
+	root.set_meta("peraviz_is_axis", is_axis)
+	root.set_meta("peraviz_is_emitter", is_emitter)
+	var position: Vector3 = _safe_position(data.get("pos", Vector3.ZERO), "create_scene_node:" + root.name)
 	if bool(data.get("has_basis", false)):
-		var basis_x: Vector3 = data.get("basis_x", Vector3.RIGHT)
-		var basis_y: Vector3 = data.get("basis_y", Vector3.UP)
-		var basis_z: Vector3 = data.get("basis_z", Vector3.BACK)
-		root.transform = Transform3D(Basis(basis_x, basis_y, basis_z), position)
+		var basis: Basis = _safe_basis_from_data(data)
+		var safe_scale: Vector3 = _safe_scale_from_data(data, "create_scene_node_basis:" + root.name)
+		basis = basis.scaled(safe_scale)
+		if not _is_basis_valid(basis):
+			print("[PeravizCoordDebug] event=scaled_basis_invalid_fallback node=", root.name, " scale=", safe_scale)
+			basis = Basis.IDENTITY.scaled(safe_scale)
+		root.transform = Transform3D(basis, position)
 	else:
 		root.position = position
 		root.rotation_degrees = data.get("rot", Vector3.ZERO)
-		root.scale = data.get("scale", Vector3.ONE)
+		root.scale = _safe_scale_from_data(data, "create_scene_node_euler:" + root.name)
 
 	if is_axis:
 		var pivot := Node3D.new()
@@ -121,6 +287,8 @@ func _extract_visual_scale_hint(data: Dictionary) -> float:
 
 	var scale: Vector3 = data.get("scale", Vector3.ONE)
 	var average_scale: float = (abs(scale.x) + abs(scale.y) + abs(scale.z)) / 3.0
+	if not is_finite(average_scale):
+		return 1.0
 	return max(average_scale, 0.0001)
 
 func _load_3d_asset(asset_path: String, asset_kind_hint: String = "") -> Variant:
@@ -248,6 +416,7 @@ func _clear_scene() -> void:
 	_node_index.clear()
 	_asset_cache.clear()
 	_has_loaded_bounds = false
+	_clear_debug_gizmos()
 
 func _expand_loaded_bounds_from_node(node: Node3D) -> void:
 	if node is MeshInstance3D:


### PR DESCRIPTION
### Motivation
- Prevent Godot editor assertions `core/math/basis.cpp:47 - Condition "det == 0" is true.` caused by singular or non-finite transforms when clicking/selecting nodes in the editor. 
- Provide opt-in, gated coordinate debug logs and events to aid diagnosing source-to-Godot mapping without polluting normal runtime.

### Description
- Hardened Godot-side scene ingestion in `peraviz/scripts/load_scene.gd` by adding `_safe_position(...)` and `_safe_scale_from_data(...)`, applying sanitized scale when constructing a `Basis`, revalidating determinants with `_is_basis_valid(...)`, and falling back to `Basis.IDENTITY.scaled(...)` if necessary to avoid singular transforms. 
- Made debug gizmos non-invasive by using `_safe_target_global_position(...)` for gizmo placement and added an opt-in toggle for coordinate gizmos stored in `ProjectSettings.peraviz_debug_coords` (toggle `C`), with helpers to build/clear gizmos. 
- Propagated a new `peraviz_debug_coords` flag through the native loader stack (`PeravizLoader`, `peraviz::load_mvr`, `mvr_scene_loader`) and emitted structured coordinate events from native loaders (`instantiate_node` and `emitter_reference`). 
- Added coordinate debug runtime API in `peraviz/native/src/peraviz_debug_runtime.{h,cpp}`: `set_coordinate_debug_enabled`, `is_coordinate_debug_enabled`, `log_coordinate_mapping_metadata`, and `log_coordinate_debug_event`, and gated the coordinate transform adjustment logs behind this flag. 

### Testing
- Ran `./tests/check_perastage_tree_modules.sh` and it passed (OK). 
- Ran `./tests/check_no_configmanager_get_in_gui.sh` and it passed (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69930c1b49348324865aa995cbec2887)