### PR TITLE
Fix degenerate basis in Godot test scene ground transform

### DIFF
--- a/peraviz/test.tscn
+++ b/peraviz/test.tscn
@@ -23,7 +23,7 @@ shadow_normal_bias = 1.0
 
 [node name="Ground" type="MeshInstance3D" parent="."]
 mesh = SubResource("PlaneMesh_ground")
-transform = Transform3D(12, 0, 0, 0, 1, 0, 0, 12, 0, 0, 0, 0)
+transform = Transform3D(12, 0, 0, 0, 1, 0, 0, 0, 12, 0, 0, 0)
 
 [node name="Proxies" type="Node3D" parent="."]
 


### PR DESCRIPTION
### Motivation
- The Godot test scene had a singular (determinant==0) basis on the `Ground` node transform which caused repeated runtime errors from `core/math/basis.cpp` when interacting with the 3D editor, so the scene must use a valid, non-degenerate basis to avoid crashes and noisy logs.

### Description
- Corrected the `Ground` node `transform` in `peraviz/test.tscn` by fixing the Z basis column from `(0, 12, 0)` to `(0, 0, 12)` so the basis vectors are orthogonal and the transform determinant is non-zero.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69932b91f5e0832491bcf4376270f258)