### PR TITLE
peraviz: add SceneRegistry for fixture registration and anchor lookup

### DIFF
--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -6,6 +6,7 @@ extends Node3D
 @onready var camera: Camera3D = $Camera3D
 
 var _loader := PeravizLoader.new()
+var _scene_registry := SceneRegistry.new()
 var _loaded_bounds: AABB
 var _has_loaded_bounds: bool = false
 var _node_index: Dictionary = {}
@@ -16,6 +17,7 @@ var _debug_gizmos_root: Node3D
 const DEBUG_TOGGLE_KEY: Key = KEY_C
 
 func _ready() -> void:
+	_scene_registry.configure(proxies_root)
 	$HUD/LoadButton.pressed.connect(_on_load_pressed)
 	picker.file_selected.connect(_on_file_selected)
 	picker.access = FileDialog.ACCESS_FILESYSTEM
@@ -37,6 +39,7 @@ func _on_file_selected(path: String) -> void:
 	_clear_debug_gizmos()
 
 	_build_node_tree(nodes)
+	_register_fixture_registry(nodes)
 	_rebuild_debug_gizmos()
 	_focus_loaded_scene()
 	status_label.text = "Nodes: %d (press F to focus, C debug coords)" % nodes.size()
@@ -411,12 +414,96 @@ func _create_dummy_mesh(is_fixture: bool, visual_scale_hint: float) -> Node3D:
 	return mesh_instance
 
 func _clear_scene() -> void:
+	_scene_registry.clear("scene_reload")
 	for child in proxies_root.get_children():
 		child.queue_free()
 	_node_index.clear()
 	_asset_cache.clear()
 	_has_loaded_bounds = false
 	_clear_debug_gizmos()
+
+func _register_fixture_registry(nodes: Array) -> void:
+	if nodes.is_empty():
+		return
+
+	var parent_lookup: Dictionary = {}
+	var type_lookup: Dictionary = {}
+	for item in nodes:
+		if item is not Dictionary:
+			continue
+		var node_id: String = str(item.get("node_id", ""))
+		if node_id.is_empty():
+			continue
+		parent_lookup[node_id] = str(item.get("parent_id", ""))
+		type_lookup[node_id] = str(item.get("type", ""))
+
+	var fixture_anchors: Dictionary = {}
+	for node_id in type_lookup.keys():
+		if str(type_lookup.get(node_id, "")) != "fixture":
+			continue
+		fixture_anchors[node_id] = {
+			"axis": [],
+			"emitters": [],
+			"geometry_nodes": [],
+		}
+
+	for item in nodes:
+		if item is not Dictionary:
+			continue
+		var node_id: String = str(item.get("node_id", ""))
+		if node_id.is_empty():
+			continue
+
+		var fixture_uuid: String = _resolve_fixture_uuid(node_id, parent_lookup, type_lookup, {})
+		if fixture_uuid.is_empty() or not fixture_anchors.has(fixture_uuid):
+			continue
+
+		if node_id == fixture_uuid:
+			continue
+
+		var node: Node3D = _node_index.get(node_id)
+		if node == null:
+			continue
+
+		var anchors: Dictionary = fixture_anchors[fixture_uuid]
+		if bool(item.get("is_axis", false)):
+			var axis_nodes: Array = anchors.get("axis", [])
+			axis_nodes.append(node)
+			anchors["axis"] = axis_nodes
+		if bool(item.get("is_emitter", false)):
+			var emitter_nodes: Array = anchors.get("emitters", [])
+			emitter_nodes.append(node)
+			anchors["emitters"] = emitter_nodes
+		if str(item.get("type", "")) == "fixture_geometry":
+			var geometry_nodes: Array = anchors.get("geometry_nodes", [])
+			geometry_nodes.append(node)
+			anchors["geometry_nodes"] = geometry_nodes
+
+	for fixture_uuid in fixture_anchors.keys():
+		var fixture_node: Node3D = _node_index.get(fixture_uuid)
+		if fixture_node == null:
+			print("[PeravizSceneRegistry] register_fixture skipped: fixture node missing uuid=", fixture_uuid)
+			continue
+		var anchors: Dictionary = fixture_anchors[fixture_uuid]
+		_scene_registry.register_fixture(fixture_uuid, fixture_node, anchors)
+
+func _resolve_fixture_uuid(node_id: String, parent_lookup: Dictionary, type_lookup: Dictionary, cache: Dictionary) -> String:
+	if cache.has(node_id):
+		return str(cache.get(node_id, ""))
+
+	var node_type: String = str(type_lookup.get(node_id, ""))
+	if node_type == "fixture":
+		cache[node_id] = node_id
+		return node_id
+
+	var parent_id: String = str(parent_lookup.get(node_id, ""))
+	if parent_id.is_empty() or parent_id == node_id:
+		cache[node_id] = ""
+		return ""
+
+	var fixture_uuid: String = _resolve_fixture_uuid(parent_id, parent_lookup, type_lookup, cache)
+	cache[node_id] = fixture_uuid
+	return fixture_uuid
 
 func _expand_loaded_bounds_from_node(node: Node3D) -> void:
 	if node is MeshInstance3D:

--- a/peraviz/scripts/scene_registry.gd
+++ b/peraviz/scripts/scene_registry.gd
@@ -1,0 +1,117 @@
+extends RefCounted
+class_name SceneRegistry
+
+var _owner_root: Node
+var _fixture_entries: Dictionary = {}
+
+func configure(owner_root: Node) -> void:
+	_owner_root = owner_root
+	_debug_log("configure owner=%s" % [_describe_node(owner_root)])
+
+func register_fixture(uuid: String, root_node: Node, anchors: Dictionary = {}) -> void:
+	if uuid.is_empty():
+		_debug_log("register_fixture skipped: empty uuid")
+		return
+	if root_node == null:
+		_debug_log("register_fixture skipped: null root uuid=%s" % uuid)
+		return
+
+	var conflict: bool = _fixture_entries.has(uuid)
+	if conflict:
+		_debug_log("register_fixture conflict: replacing existing entry uuid=%s" % uuid)
+
+	var normalized_anchors: Dictionary = _normalize_anchor_dictionary(anchors)
+	var entry: Dictionary = {
+		"path": root_node.get_path(),
+		"weak": weakref(root_node),
+		"anchors": normalized_anchors,
+	}
+	_fixture_entries[uuid] = entry
+
+	if not root_node.tree_exited.is_connected(_on_fixture_tree_exited.bind(uuid)):
+		root_node.tree_exited.connect(_on_fixture_tree_exited.bind(uuid), CONNECT_ONE_SHOT)
+
+	_debug_log("register_fixture uuid=%s anchors=%d total=%d" % [uuid, normalized_anchors.size(), _fixture_entries.size()])
+
+func unregister_fixture(uuid: String, reason: String = "") -> void:
+	if not _fixture_entries.erase(uuid):
+		return
+	_debug_log("unregister_fixture uuid=%s reason=%s total=%d" % [uuid, reason, _fixture_entries.size()])
+
+func clear(reason: String = "") -> void:
+	if _fixture_entries.is_empty():
+		return
+	var previous_total: int = _fixture_entries.size()
+	_fixture_entries.clear()
+	_debug_log("clear reason=%s removed=%d total=0" % [reason, previous_total])
+
+func get_fixture(uuid: String) -> Node:
+	var entry: Dictionary = _fixture_entries.get(uuid, {})
+	if entry.is_empty():
+		return null
+
+	var weak_ref: WeakRef = entry.get("weak")
+	if weak_ref != null:
+		var weak_node: Variant = weak_ref.get_ref()
+		if weak_node is Node and is_instance_valid(weak_node):
+			return weak_node
+
+	var node_path: NodePath = entry.get("path", NodePath(""))
+	if _owner_root == null or node_path.is_empty():
+		return null
+	return _owner_root.get_node_or_null(node_path)
+
+func get_anchor(uuid: String, anchor_name_or_id: Variant) -> Variant:
+	var entry: Dictionary = _fixture_entries.get(uuid, {})
+	if entry.is_empty():
+		return null
+
+	var anchors: Dictionary = entry.get("anchors", {})
+	if anchors.is_empty():
+		return null
+
+	var key: String = str(anchor_name_or_id)
+	if anchors.has(key):
+		return _resolve_anchor_value(anchors.get(key))
+	return null
+
+func _normalize_anchor_dictionary(anchors: Dictionary) -> Dictionary:
+	var normalized: Dictionary = {}
+	for key in anchors.keys():
+		var anchor_name: String = str(key)
+		normalized[anchor_name] = _normalize_anchor_value(anchors.get(key))
+	return normalized
+
+func _normalize_anchor_value(anchor_value: Variant) -> Variant:
+	if anchor_value is Node:
+		var node: Node = anchor_value
+		return node.get_path()
+	if anchor_value is Array:
+		var normalized_list: Array = []
+		for entry in anchor_value:
+			normalized_list.append(_normalize_anchor_value(entry))
+		return normalized_list
+	return anchor_value
+
+func _resolve_anchor_value(anchor_value: Variant) -> Variant:
+	if anchor_value is NodePath:
+		if _owner_root == null:
+			return null
+		return _owner_root.get_node_or_null(anchor_value)
+	if anchor_value is Array:
+		var resolved_nodes: Array = []
+		for entry in anchor_value:
+			resolved_nodes.append(_resolve_anchor_value(entry))
+		return resolved_nodes
+	return anchor_value
+
+func _on_fixture_tree_exited(uuid: String) -> void:
+	unregister_fixture(uuid, "tree_exited")
+
+func _debug_log(message: String) -> void:
+	print("[PeravizSceneRegistry] %s" % message)
+
+func _describe_node(node: Node) -> String:
+	if node == null:
+		return "<null>"
+	return "%s@%s" % [node.name, node.get_path()]

--- a/peraviz/scripts/scene_registry.gd.uid
+++ b/peraviz/scripts/scene_registry.gd.uid
@@ -1,0 +1,1 @@
+uid://dgmsuxtl6sbdu


### PR DESCRIPTION
### Motivation

- Provide a single, lightweight place to register and look up fixture instances by UUID so other Peraviz code can reliably resolve fixtures and their key anchor subnodes. 
- Expose a minimal API for register/get operations and anchor resolution to avoid duplicated traversal logic across scene loading and visualization code. 
- Improve lifecycle handling and debugging by tracking weak refs/paths and auto-unregistering when nodes exit the tree.

### Description

- Added a new module `peraviz/scripts/scene_registry.gd` implementing `class_name SceneRegistry` with the API `register_fixture(uuid, root_node, anchors)`, `get_fixture(uuid)`, and `get_anchor(uuid, anchor_name_or_id)`, storing entries as both `NodePath` and `WeakRef` and normalizing/ resolving anchor values. 
- Integrated the registry into `peraviz/scripts/load_scene.gd` by creating `_scene_registry := SceneRegistry.new()` and calling `_scene_registry.configure(proxies_root)` in `_ready()` and `_scene_registry.clear("scene_reload")` in `_clear_scene()`. 
- Added `_register_fixture_registry(nodes)` and helper `_resolve_fixture_uuid(...)` to populate the registry after building the node tree; this groups anchors (`axis`, `emitters`, `geometry_nodes`) per fixture UUID and registers each fixture with its anchors. 
- The registry wires `tree_exited` on registered root nodes to auto-unregister and emits debug logs for configure/register/conflicts/unregister/clear and skip cases for easier troubleshooting.

### Testing

- Ran `tests/check_perastage_tree_modules.sh` which passed: `OK: perastage_tree.md keeps module sections and scope note aligned.`
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed: `OK: no direct ConfigManager::Get() usages in gui/.`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69933620d614832484a6d28c40368c79)