### PR TITLE
peraviz: add runtime asset cache manager keyed by asset_path

### DIFF
--- a/peraviz/scripts/asset_runtime_cache.gd
+++ b/peraviz/scripts/asset_runtime_cache.gd
@@ -1,0 +1,93 @@
+extends RefCounted
+class_name PeravizRuntimeAssetCache
+
+var _mesh_cache: Dictionary = {}
+var _scene_cache: Dictionary = {}
+var _material_cache: Dictionary = {}
+var _failed_paths: Dictionary = {}
+
+var _hit_count: int = 0
+var _miss_count: int = 0
+
+func clear() -> void:
+	_mesh_cache.clear()
+	_scene_cache.clear()
+	_material_cache.clear()
+	_failed_paths.clear()
+	_hit_count = 0
+	_miss_count = 0
+
+func get_mesh(asset_path: String) -> Mesh:
+	if _failed_paths.has(asset_path):
+		_register_miss("mesh", asset_path)
+		return null
+	var cached: Variant = _mesh_cache.get(asset_path)
+	if cached is Mesh:
+		_register_hit("mesh", asset_path)
+		return cached
+	_register_miss("mesh", asset_path)
+	return null
+
+func store_mesh(asset_path: String, mesh: Mesh) -> void:
+	if asset_path.is_empty() or mesh == null:
+		return
+	_mesh_cache[asset_path] = mesh
+
+func instantiate_scene(asset_path: String) -> Node3D:
+	if _failed_paths.has(asset_path):
+		_register_miss("scene", asset_path)
+		return null
+	var cached: Variant = _scene_cache.get(asset_path)
+	if cached is PackedScene:
+		_register_hit("scene", asset_path)
+		var instance: Node = cached.instantiate()
+		if instance is Node3D:
+			return instance
+	_register_miss("scene", asset_path)
+	return null
+
+func store_scene(asset_path: String, packed_scene: PackedScene) -> void:
+	if asset_path.is_empty() or packed_scene == null:
+		return
+	_scene_cache[asset_path] = packed_scene
+
+func get_material(asset_path: String, clone_for_instance: bool = true) -> Material:
+	if _failed_paths.has(asset_path):
+		_register_miss("material", asset_path)
+		return null
+	var cached: Variant = _material_cache.get(asset_path)
+	if cached is Material:
+		_register_hit("material", asset_path)
+		if clone_for_instance:
+			return cached.duplicate(true)
+		return cached
+	_register_miss("material", asset_path)
+	return null
+
+func store_material(asset_path: String, material: Material) -> void:
+	if asset_path.is_empty() or material == null:
+		return
+	_material_cache[asset_path] = material
+
+func mark_failed(asset_path: String) -> void:
+	if asset_path.is_empty():
+		return
+	_failed_paths[asset_path] = true
+
+func debug_summary() -> Dictionary:
+	return {
+		"hits": _hit_count,
+		"misses": _miss_count,
+		"unique_resources": _mesh_cache.size() + _scene_cache.size() + _material_cache.size(),
+		"mesh_unique": _mesh_cache.size(),
+		"scene_unique": _scene_cache.size(),
+		"material_unique": _material_cache.size(),
+	}
+
+func _register_hit(kind: String, asset_path: String) -> void:
+	_hit_count += 1
+	print("[PeravizAssetCache] hit kind=", kind, " key=", asset_path, " hits=", _hit_count, " misses=", _miss_count)
+
+func _register_miss(kind: String, asset_path: String) -> void:
+	_miss_count += 1
+	print("[PeravizAssetCache] miss kind=", kind, " key=", asset_path, " hits=", _hit_count, " misses=", _miss_count)

--- a/peraviz/scripts/asset_runtime_cache.gd
+++ b/peraviz/scripts/asset_runtime_cache.gd
@@ -9,6 +9,24 @@ var _failed_paths: Dictionary = {}
 var _hit_count: int = 0
 var _miss_count: int = 0
 
+var _hit_by_kind: Dictionary = {
+	"mesh": 0,
+	"scene": 0,
+	"material": 0,
+}
+var _miss_by_kind: Dictionary = {
+	"mesh": 0,
+	"scene": 0,
+	"material": 0,
+}
+
+var _debug_logging_enabled: bool = false
+var _debug_log_interval: int = 50
+
+func configure_debug_logging(enabled: bool, log_interval: int = 50) -> void:
+	_debug_logging_enabled = enabled
+	_debug_log_interval = max(log_interval, 1)
+
 func clear() -> void:
 	_mesh_cache.clear()
 	_scene_cache.clear()
@@ -16,6 +34,10 @@ func clear() -> void:
 	_failed_paths.clear()
 	_hit_count = 0
 	_miss_count = 0
+	for kind in _hit_by_kind.keys():
+		_hit_by_kind[kind] = 0
+	for kind in _miss_by_kind.keys():
+		_miss_by_kind[kind] = 0
 
 func get_mesh(asset_path: String) -> Mesh:
 	if _failed_paths.has(asset_path):
@@ -78,6 +100,8 @@ func debug_summary() -> Dictionary:
 	return {
 		"hits": _hit_count,
 		"misses": _miss_count,
+		"hits_by_kind": _hit_by_kind.duplicate(true),
+		"misses_by_kind": _miss_by_kind.duplicate(true),
 		"unique_resources": _mesh_cache.size() + _scene_cache.size() + _material_cache.size(),
 		"mesh_unique": _mesh_cache.size(),
 		"scene_unique": _scene_cache.size(),
@@ -86,8 +110,27 @@ func debug_summary() -> Dictionary:
 
 func _register_hit(kind: String, asset_path: String) -> void:
 	_hit_count += 1
-	print("[PeravizAssetCache] hit kind=", kind, " key=", asset_path, " hits=", _hit_count, " misses=", _miss_count)
+	_hit_by_kind[kind] = int(_hit_by_kind.get(kind, 0)) + 1
+	_log_lookup_event("hit", kind, asset_path)
 
 func _register_miss(kind: String, asset_path: String) -> void:
 	_miss_count += 1
-	print("[PeravizAssetCache] miss kind=", kind, " key=", asset_path, " hits=", _hit_count, " misses=", _miss_count)
+	_miss_by_kind[kind] = int(_miss_by_kind.get(kind, 0)) + 1
+	_log_lookup_event("miss", kind, asset_path)
+
+func _log_lookup_event(event_kind: String, asset_kind: String, asset_path: String) -> void:
+	if not _debug_logging_enabled:
+		return
+
+	var should_log: bool = (_hit_count + _miss_count) % _debug_log_interval == 0
+	if not should_log and _failed_paths.has(asset_path):
+		should_log = true
+	if not should_log:
+		return
+
+	print("[PeravizAssetCache] event=", event_kind,
+		" kind=", asset_kind,
+		" key=", asset_path,
+		" hits=", _hit_count,
+		" misses=", _miss_count,
+		" interval=", _debug_log_interval)

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -12,6 +12,7 @@ var _has_loaded_bounds: bool = false
 var _node_index: Dictionary = {}
 var _asset_cache := PeravizRuntimeAssetCache.new()
 var _debug_coords_enabled: bool = false
+var _debug_asset_cache_enabled: bool = false
 var _debug_gizmos_root: Node3D
 
 const DEBUG_TOGGLE_KEY: Key = KEY_C
@@ -23,6 +24,8 @@ func _ready() -> void:
 	picker.access = FileDialog.ACCESS_FILESYSTEM
 	status_label.text = "Select a .mvr file"
 	_debug_coords_enabled = bool(ProjectSettings.get_setting("peraviz_debug_coords", false))
+	_debug_asset_cache_enabled = bool(ProjectSettings.get_setting("peraviz_debug_asset_cache", false))
+	_asset_cache.configure_debug_logging(_debug_asset_cache_enabled, 100)
 	_ensure_debug_gizmo_root()
 	_update_debug_legend()
 
@@ -42,8 +45,16 @@ func _on_file_selected(path: String) -> void:
 	_register_fixture_registry(nodes)
 	_rebuild_debug_gizmos()
 	_focus_loaded_scene()
-	var cache_summary: Dictionary = _asset_cache.debug_summary()
-	print("[PeravizAssetCache] summary hits=", cache_summary.get("hits", 0), " misses=", cache_summary.get("misses", 0), " unique=", cache_summary.get("unique_resources", 0), " mesh=", cache_summary.get("mesh_unique", 0), " scenes=", cache_summary.get("scene_unique", 0), " materials=", cache_summary.get("material_unique", 0))
+	if _debug_asset_cache_enabled:
+		var cache_summary: Dictionary = _asset_cache.debug_summary()
+		var hit_by_kind: Dictionary = cache_summary.get("hits_by_kind", {})
+		var miss_by_kind: Dictionary = cache_summary.get("misses_by_kind", {})
+		print("[PeravizAssetCache] summary hits=", cache_summary.get("hits", 0),
+			" misses=", cache_summary.get("misses", 0),
+			" unique=", cache_summary.get("unique_resources", 0),
+			" mesh(hit/miss)=", hit_by_kind.get("mesh", 0), "/", miss_by_kind.get("mesh", 0),
+			" scene(hit/miss)=", hit_by_kind.get("scene", 0), "/", miss_by_kind.get("scene", 0),
+			" material(hit/miss)=", hit_by_kind.get("material", 0), "/", miss_by_kind.get("material", 0))
 	status_label.text = "Nodes: %d (press F to focus, C debug coords)" % nodes.size()
 	_update_debug_legend()
 

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -10,7 +10,7 @@ var _scene_registry := SceneRegistry.new()
 var _loaded_bounds: AABB
 var _has_loaded_bounds: bool = false
 var _node_index: Dictionary = {}
-var _asset_cache: Dictionary = {}
+var _asset_cache := PeravizRuntimeAssetCache.new()
 var _debug_coords_enabled: bool = false
 var _debug_gizmos_root: Node3D
 
@@ -42,6 +42,8 @@ func _on_file_selected(path: String) -> void:
 	_register_fixture_registry(nodes)
 	_rebuild_debug_gizmos()
 	_focus_loaded_scene()
+	var cache_summary: Dictionary = _asset_cache.debug_summary()
+	print("[PeravizAssetCache] summary hits=", cache_summary.get("hits", 0), " misses=", cache_summary.get("misses", 0), " unique=", cache_summary.get("unique_resources", 0), " mesh=", cache_summary.get("mesh_unique", 0), " scenes=", cache_summary.get("scene_unique", 0), " materials=", cache_summary.get("material_unique", 0))
 	status_label.text = "Nodes: %d (press F to focus, C debug coords)" % nodes.size()
 	_update_debug_legend()
 
@@ -295,61 +297,64 @@ func _extract_visual_scale_hint(data: Dictionary) -> float:
 	return max(average_scale, 0.0001)
 
 func _load_3d_asset(asset_path: String, asset_kind_hint: String = "") -> Variant:
-	if _asset_cache.has(asset_path):
-		var cached: Variant = _asset_cache[asset_path]
-		if cached is Mesh:
-			var cached_mesh_instance := MeshInstance3D.new()
-			cached_mesh_instance.mesh = cached
-			return cached_mesh_instance
-		if cached is PackedScene:
-			var packed_instance: Node = cached.instantiate()
-			if packed_instance is Node3D:
-				return packed_instance
-		if cached is Node3D:
-			return cached.duplicate(DUPLICATE_USE_INSTANTIATION)
-		return null
-
 	var resolved_asset_kind: String = asset_kind_hint.to_lower()
 	if resolved_asset_kind.is_empty() or resolved_asset_kind == "none":
 		resolved_asset_kind = _infer_asset_kind_from_extension(asset_path)
 
 	var extension: String = asset_path.get_extension().to_lower()
 	if resolved_asset_kind == "mesh" or extension == "3ds":
+		var cached_mesh: Mesh = _asset_cache.get_mesh(asset_path)
+		if cached_mesh != null:
+			var cached_mesh_instance := MeshInstance3D.new()
+			cached_mesh_instance.mesh = cached_mesh
+			return cached_mesh_instance
+
 		var mesh_data: Dictionary = _loader.load_3ds_mesh_data(asset_path)
 		if not bool(mesh_data.get("ok", false)):
-			_asset_cache[asset_path] = null
+			_asset_cache.mark_failed(asset_path)
 			return null
 		var mesh: ArrayMesh = _build_3ds_mesh(mesh_data)
 		if mesh == null:
-			_asset_cache[asset_path] = null
+			_asset_cache.mark_failed(asset_path)
 			return null
-		_asset_cache[asset_path] = mesh
+		_asset_cache.store_mesh(asset_path, mesh)
 		var mesh_instance := MeshInstance3D.new()
 		mesh_instance.mesh = mesh
 		return mesh_instance
 
 	if resolved_asset_kind == "scene" or extension == "glb" or extension == "gltf":
+		var cached_scene_instance: Node3D = _asset_cache.instantiate_scene(asset_path)
+		if cached_scene_instance != null:
+			return cached_scene_instance
+
 		var gltf := GLTFDocument.new()
 		var state := GLTFState.new()
 		var err: int = gltf.append_from_file(asset_path, state)
 		if err != OK:
-			_asset_cache[asset_path] = null
+			_asset_cache.mark_failed(asset_path)
 			return null
 		var generated: Node = gltf.generate_scene(state)
 		if generated is Node3D:
-			_asset_cache[asset_path] = generated
-			return generated.duplicate(DUPLICATE_USE_INSTANTIATION)
-		_asset_cache[asset_path] = null
+			var packed_scene := PackedScene.new()
+			if packed_scene.pack(generated) == OK:
+				_asset_cache.store_scene(asset_path, packed_scene)
+				generated.free()
+				return _asset_cache.instantiate_scene(asset_path)
+		if generated != null:
+			generated.free()
+		_asset_cache.mark_failed(asset_path)
 		return null
+
+	var scene_instance: Node3D = _asset_cache.instantiate_scene(asset_path)
+	if scene_instance != null:
+		return scene_instance
 
 	var resource: Resource = load(asset_path)
 	if resource is PackedScene:
-		_asset_cache[asset_path] = resource
-		var scene_instance: Node = resource.instantiate()
-		if scene_instance is Node3D:
-			return scene_instance
+		_asset_cache.store_scene(asset_path, resource)
+		return _asset_cache.instantiate_scene(asset_path)
 
-	_asset_cache[asset_path] = null
+	_asset_cache.mark_failed(asset_path)
 	return null
 
 
@@ -408,8 +413,13 @@ func _create_dummy_mesh(is_fixture: bool, visual_scale_hint: float) -> Node3D:
 		box.size = Vector3.ONE * (0.3 * local_size_multiplier)
 		mesh_instance.mesh = box
 
-	var material := StandardMaterial3D.new()
-	material.albedo_color = Color(1.0, 0.5, 0.1) if is_fixture else Color(0.2, 0.8, 1.0)
+	var material_key: String = "builtin://material/dummy_fixture" if is_fixture else "builtin://material/dummy_object"
+	var material: Material = _asset_cache.get_material(material_key, true)
+	if material == null:
+		var base_material := StandardMaterial3D.new()
+		base_material.albedo_color = Color(1.0, 0.5, 0.1) if is_fixture else Color(0.2, 0.8, 1.0)
+		_asset_cache.store_material(material_key, base_material)
+		material = _asset_cache.get_material(material_key, true)
 	mesh_instance.material_override = material
 	return mesh_instance
 


### PR DESCRIPTION
### Motivation
- Reduce repeated runtime loads/imports by centralizing asset caching keyed by `asset_path` so assets are loaded once and reused. 
- Cache common runtime resources used by the Peraviz loader (`Mesh`, `PackedScene`, `Material`) to improve load performance and avoid duplicated work. 
- Provide lightweight debug metrics (hit/miss counts and unique resource counts) and protect against repeated failing loads.

### Description
- Added `peraviz/scripts/asset_runtime_cache.gd` implementing `PeravizRuntimeAssetCache` with typed stores for meshes, scenes and materials, failure tracking, and `hit/miss` logging. 
- Replaced the ad-hoc `_asset_cache` dictionary in `peraviz/scripts/load_scene.gd` with a `PeravizRuntimeAssetCache` instance and updated the asset loading flow to consult the cache before importing/loading. 
- Caching behavior implemented for: native `3ds` meshes (store `ArrayMesh`), `glb/gltf` generated scenes (pack once to `PackedScene` and reuse), and generic `PackedScene` loads (store + instantiate). 
- Added allocation safety for materials by storing a base material and returning a cloned instance for per-node overrides (`duplicate(true)`) to avoid shared mutable state. 
- Added a cache summary print after scene load that reports `hits`, `misses`, and per-type unique resource counts via `debug_summary()`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed (`OK`).
- Ran both checks together (`tests/check_perastage_tree_modules.sh && tests/check_no_configmanager_get_in_gui.sh`) which also passed (`OK`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69933b11c3dc8324acbf29aaf214a7d9)