### PR TITLE
mvr: export GDTF files at archive root

### DIFF
--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -692,7 +692,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
     std::string fileName = preferredName;
     if (fileName.empty())
       fileName = SanitizeArchiveFileName(rawGdtfPath, "fixture.gdtf");
-    std::string archivePath = registerResource(rawGdtfPath, "gdtf/" + fileName);
+    std::string archivePath = registerResource(rawGdtfPath, fileName);
     if (!objectUuid.empty() && !archivePath.empty())
       gdtfArchiveByObjectUuid[objectUuid] = archivePath;
     return archivePath;


### PR DESCRIPTION
### Motivation
- External tools and some importers expect `.gdtf` entries at the archive root, so `GDTFSpec` should be a simple archive-relative filename rather than a path under `gdtf/`.

### Description
- In `mvr/mvrexporter.cpp` updated `registerGdtfResource` to call `registerResource(rawGdtfPath, fileName)` instead of `registerResource(rawGdtfPath, "gdtf/" + fileName)`, so exported `.gdtf` files are placed at the archive root.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed.
- Confirmed with `rg -n "gdtf/" mvr/mvrexporter.cpp tests/mvr_exporter_compliance_test.cpp` that the exporter no longer prefers the `gdtf/` prefix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69936b7720a083248f60dc7abb5e1204)