### PR TITLE
Fix truss path UTF-8 serialization and add regression test

### DIFF
--- a/core/trussdictionary.cpp
+++ b/core/trussdictionary.cpp
@@ -33,6 +33,11 @@ namespace TrussDictionary {
 
 namespace {
 
+static std::string ToUtf8String(const fs::path &path) {
+  std::u8string utf8 = path.u8string();
+  return std::string(utf8.begin(), utf8.end());
+}
+
 static std::string LowerExt(const fs::path &path) {
   std::string ext = path.extension().string();
   std::transform(ext.begin(), ext.end(), ext.begin(),
@@ -111,7 +116,7 @@ bool ImportTrussFile(const std::string &inputPath, std::string &storedPath,
     return false;
   }
 
-  storedPath = dest.string();
+  storedPath = ToUtf8String(dest);
   return true;
 }
 
@@ -169,7 +174,7 @@ std::optional<std::unordered_map<std::string, std::string>> Load() {
 
     if (migrated != path)
       changed = true;
-    dict[it.key()] = migrated.string();
+    dict[it.key()] = ToUtf8String(migrated);
   }
 
   if (changed)
@@ -212,7 +217,7 @@ std::optional<std::string> Get(const std::string &model) {
   if (it == dict.end())
     return std::nullopt;
 
-  if (!fs::exists(it->second)) {
+  if (!fs::exists(fs::u8path(it->second))) {
     dict.erase(it);
     Save(dict);
     return std::nullopt;

--- a/core/trussloader.cpp
+++ b/core/trussloader.cpp
@@ -35,6 +35,11 @@ namespace fs = std::filesystem;
 
 namespace {
 
+static std::string ToUtf8String(const fs::path &path) {
+  std::u8string utf8 = path.u8string();
+  return std::string(utf8.begin(), utf8.end());
+}
+
 static std::string LowerExt(fs::path path) {
   std::string ext = path.extension().string();
   std::transform(ext.begin(), ext.end(), ext.begin(),
@@ -122,8 +127,8 @@ bool LoadTrussGdtf(const std::string &gdtfPath, Truss &outTruss) {
     return false;
 
   outTruss = Truss{};
-  outTruss.modelFile = inputPath.string();
-  outTruss.gdtfSpec = inputPath.string();
+  outTruss.modelFile = ToUtf8String(inputPath);
+  outTruss.gdtfSpec = ToUtf8String(inputPath);
 
   fs::path baseDir = BuildGdtfExtractionCacheDir(inputPath);
   std::error_code ec;
@@ -174,11 +179,11 @@ bool LoadTrussGdtf(const std::string &gdtfPath, Truss &outTruss) {
         {fs::path("models/gltf") / (fileBase + ".glb"),
          fs::path("models/3ds") / (fileBase + ".3ds")});
     if (!modelPath.empty())
-      outTruss.symbolFile = modelPath.string();
+      outTruss.symbolFile = ToUtf8String(modelPath);
 
     fs::path symbolPath = FindFirstExisting(baseDir, {fs::path("models/svg") / (fileBase + ".svg")});
     if (!symbolPath.empty() && outTruss.symbolFile.empty())
-      outTruss.symbolFile = symbolPath.string();
+      outTruss.symbolFile = ToUtf8String(symbolPath);
   }
 
   tinyxml2::XMLElement *phys = fixtureType->FirstChildElement("PhysicalDescriptions");
@@ -206,7 +211,7 @@ bool LoadTrussDefinition(const std::string &path, Truss &outTruss) {
   fs::path inputPath = fs::u8path(path);
   std::string ext = LowerExt(inputPath);
   if (ext == ".gdtf")
-    return LoadTrussGdtf(path, outTruss);
+    return LoadTrussGdtf(ToUtf8String(inputPath), outTruss);
 
   if (ext == ".gtruss") {
     fs::path migratedPath = inputPath;
@@ -216,11 +221,11 @@ bool LoadTrussDefinition(const std::string &path, Truss &outTruss) {
         !ConvertLegacyGtrussToGdtf(inputPath, migratedPath, &error)) {
       return false;
     }
-    return LoadTrussGdtf(migratedPath.string(), outTruss);
+    return LoadTrussGdtf(ToUtf8String(migratedPath), outTruss);
   }
 
   outTruss = Truss{};
-  outTruss.symbolFile = path;
-  outTruss.modelFile = path;
+  outTruss.symbolFile = ToUtf8String(inputPath);
+  outTruss.modelFile = ToUtf8String(inputPath);
   return true;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -130,6 +130,20 @@ target_link_libraries(save_load_roundtrip_test PRIVATE
 add_test(NAME SaveLoadRoundtrip COMMAND save_load_roundtrip_test)
 set_library_env(SaveLoadRoundtrip)
 
+add_executable(truss_path_encoding_regression_test
+               truss_path_encoding_regression_test.cpp
+               ../core/projectutils.cpp
+               ../core/trussdictionary.cpp
+               ../core/trussloader.cpp
+               ../core/truss_gdtf_builder.cpp
+               ../core/logger.cpp
+               ../models/truss.cpp)
+target_include_directories(truss_path_encoding_regression_test PRIVATE
+                           . ../core ../models ../third_party)
+target_link_libraries(truss_path_encoding_regression_test PRIVATE
+                      ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
+add_test(NAME TrussPathEncodingRegression COMMAND truss_path_encoding_regression_test)
+
 add_executable(mvr_dmx_address_test mvr_dmx_address_test.cpp
                ../mvr/mvrexporter.cpp
                ../core/configmanager.cpp

--- a/tests/truss_path_encoding_regression_test.cpp
+++ b/tests/truss_path_encoding_regression_test.cpp
@@ -1,0 +1,122 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <cassert>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include <wx/filename.h>
+#include <wx/init.h>
+#include <wx/wfstream.h>
+#include <wx/zipstrm.h>
+
+#include "trussdictionary.h"
+#include "trussloader.h"
+
+namespace fs = std::filesystem;
+
+namespace {
+
+std::string ToUtf8String(const fs::path &path) {
+  std::u8string utf8 = path.u8string();
+  return std::string(utf8.begin(), utf8.end());
+}
+
+void SetLibraryPathEnv(const std::string &value) {
+#ifdef _WIN32
+  _putenv_s("PERASTAGE_LIBRARY_PATH", value.c_str());
+#else
+  setenv("PERASTAGE_LIBRARY_PATH", value.c_str(), 1);
+#endif
+}
+
+bool WriteArchive(const fs::path &archivePath) {
+  wxFileName::Mkdir(archivePath.parent_path().string(), wxS_DIR_DEFAULT,
+                    wxPATH_MKDIR_FULL);
+
+  wxFileOutputStream output(archivePath.string());
+  if (!output.IsOk())
+    return false;
+
+  wxZipOutputStream zip(output);
+  if (!zip.IsOk())
+    return false;
+
+  static const char *kDescriptionXml =
+      "<GDTF><FixtureType Manufacturer=\"Perastage\" Name=\"FK40Q\">"
+      "<Models><Model Name=\"main\" File=\"main\" Length=\"3.0\" Width=\"0.3\" Height=\"0.3\"/>"
+      "</Models></FixtureType></GDTF>";
+  static const char *kSvg =
+      "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"10\" height=\"10\"></svg>";
+
+  if (!zip.PutNextEntry("description.xml"))
+    return false;
+  zip.Write(kDescriptionXml, std::strlen(kDescriptionXml));
+
+  if (!zip.PutNextEntry("models/svg/main.svg"))
+    return false;
+  zip.Write(kSvg, std::strlen(kSvg));
+
+  zip.Close();
+  return output.IsOk();
+}
+
+void RunPathCase(const fs::path &sourceDir, const std::string &modelName,
+                 const std::string &fileName) {
+  fs::create_directories(sourceDir);
+  const fs::path archivePath = sourceDir / fs::u8path(fileName);
+  assert(WriteArchive(archivePath));
+
+  TrussDictionary::Update(modelName, ToUtf8String(archivePath));
+  const auto storedPath = TrussDictionary::Get(modelName);
+  assert(storedPath.has_value());
+
+  Truss truss;
+  assert(LoadTrussDefinition(*storedPath, truss));
+  assert(!truss.symbolFile.empty());
+  assert(fs::exists(fs::u8path(truss.symbolFile)));
+  assert(fs::path(fs::u8path(truss.symbolFile)).filename() == "main.svg");
+  assert(truss.symbolFile != *storedPath);
+}
+
+} // namespace
+
+int main() {
+  wxInitializer initializer;
+  assert(initializer.IsOk());
+
+  const fs::path tempRoot =
+      fs::temp_directory_path() / fs::u8path("perastage_truss_diccionario_ñ");
+  std::error_code ec;
+  fs::remove_all(tempRoot, ec);
+  fs::create_directories(tempRoot);
+
+  const fs::path libraryRoot = tempRoot / fs::u8path("librería prueba");
+  SetLibraryPathEnv(ToUtf8String(libraryRoot));
+
+  RunPathCase(tempRoot / fs::u8path("origen ñ"), "FK40Q-Unicode",
+              "Tramo_áéíóú.gdtf");
+  RunPathCase(tempRoot / fs::u8path("source with spaces"), "FK40Q-Spaces",
+              "FK40Q H-300.gdtf");
+
+  TrussDictionary::Save({});
+  fs::remove_all(tempRoot, ec);
+  return 0;
+}


### PR DESCRIPTION
### Motivation

- Ensure a single, consistent encoding convention for persisting and loading truss file paths to avoid double reinterpretation between native system strings and UTF-8, which caused failures for non-ASCII paths and filenames with spaces.

### Description

- Introduce a `ToUtf8String(const fs::path&)` helper and use it in `core/trussdictionary.cpp` to persist `storedPath` and loaded dictionary values as UTF-8 strings and to validate entries via `fs::u8path(...)`.
- Apply the same UTF-8 convention in `core/trussloader.cpp` so `LoadTrussGdtf`/`LoadTrussDefinition` set `Truss::modelFile`, `Truss::gdtfSpec` and `Truss::symbolFile` using UTF-8 strings and receive UTF-8 arguments from callers.
- Add a regression test `tests/truss_path_encoding_regression_test.cpp` that creates `.gdtf` archives under temporary folders with non-ASCII characters and spaces and asserts that `TrussDictionary::Update`/`Get` + `LoadTrussDefinition` resolve a valid `symbolFile` (`main.svg`) and do not fall back to dummy values.
- Register the new test in `tests/CMakeLists.txt` so it will be built and run by the test suite when dependencies are available.

### Testing

- Ran `tests/check_perastage_tree_modules.sh` and it passed (OK). 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (OK).
- Attempted full build with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`, but configuration failed in this environment due to missing `wxWidgets` CMake package, so the new test binary could not be compiled or executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69936e3b76e08324ae3758264127ac64)