### PR TITLE
Normalize truss model keys and use canonical keys during Rider import

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -540,28 +540,28 @@ bool RiderImporter::ImportText(const std::string &text) {
             t.name = "TRUSS " + sizeStr;
           else
             t.name = "TRUSS " + model + " " + sizeStr;
-          t.model = t.name;
+          t.model = TrussDictionary::NormalizeModelKey(t.name);
           if (auto dictPath = TrussDictionary::Get(t.model)) {
-          Truss parsed;
-          if (LoadTrussDefinition(*dictPath, parsed)) {
-            if (!parsed.symbolFile.empty())
-              t.symbolFile = parsed.symbolFile;
-            t.modelFile = parsed.modelFile.empty() ? *dictPath : parsed.modelFile;
-            t.gdtfSpec = parsed.gdtfSpec;
-            t.gdtfMode = parsed.gdtfMode;
-            t.manufacturer = parsed.manufacturer;
-            if (parsed.lengthMm > 0.0f)
-              t.lengthMm = parsed.lengthMm;
-            if (parsed.widthMm > 0.0f)
-              t.widthMm = parsed.widthMm;
-            if (parsed.heightMm > 0.0f)
-              t.heightMm = parsed.heightMm;
-            t.weightKg = parsed.weightKg;
-            t.crossSection = parsed.crossSection;
-          } else {
-            t.modelFile = *dictPath;
+            Truss parsed;
+            if (LoadTrussDefinition(*dictPath, parsed)) {
+              if (!parsed.symbolFile.empty())
+                t.symbolFile = parsed.symbolFile;
+              t.modelFile = parsed.modelFile.empty() ? *dictPath : parsed.modelFile;
+              t.gdtfSpec = parsed.gdtfSpec;
+              t.gdtfMode = parsed.gdtfMode;
+              t.manufacturer = parsed.manufacturer;
+              if (parsed.lengthMm > 0.0f)
+                t.lengthMm = parsed.lengthMm;
+              if (parsed.widthMm > 0.0f)
+                t.widthMm = parsed.widthMm;
+              if (parsed.heightMm > 0.0f)
+                t.heightMm = parsed.heightMm;
+              t.weightKg = parsed.weightKg;
+              t.crossSection = parsed.crossSection;
+            } else {
+              t.modelFile = *dictPath;
+            }
           }
-        }
           const std::string trussUuid = t.uuid;
           const std::string trussLayer = t.layer;
           scene.trusses.emplace(trussUuid, std::move(t));
@@ -629,7 +629,7 @@ bool RiderImporter::ImportText(const std::string &text) {
         t.transform.o[2] = getHangHeight(hang);
         std::string sizeStr = formatLength(s);
         t.name = "TRUSS " + sizeStr;
-        t.model = t.name;
+        t.model = TrussDictionary::NormalizeModelKey(t.name);
         if (auto dictPath = TrussDictionary::Get(t.model)) {
           Truss parsed;
           if (LoadTrussDefinition(*dictPath, parsed)) {
@@ -689,6 +689,7 @@ bool RiderImporter::ImportText(const std::string &text) {
     if (!resolved && !t.gdtfSpec.empty())
       resolved = LoadTrussDefinition(t.gdtfSpec, parsed);
     if (!resolved && !t.model.empty()) {
+      t.model = TrussDictionary::NormalizeModelKey(t.model);
       if (auto dictPath = TrussDictionary::Get(t.model)) {
         resolved = LoadTrussDefinition(*dictPath, parsed);
         if (resolved && t.modelFile.empty())

--- a/core/trussdictionary.cpp
+++ b/core/trussdictionary.cpp
@@ -25,6 +25,7 @@
 #include <cctype>
 #include <filesystem>
 #include <fstream>
+#include <regex>
 #include <vector>
 
 namespace fs = std::filesystem;
@@ -43,6 +44,31 @@ static std::string LowerExt(const fs::path &path) {
   std::transform(ext.begin(), ext.end(), ext.begin(),
                  [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
   return ext;
+}
+
+static std::string TrimAsciiWhitespace(const std::string &text) {
+  const size_t start = text.find_first_not_of(" \t\r\n");
+  if (start == std::string::npos)
+    return {};
+  const size_t end = text.find_last_not_of(" \t\r\n");
+  return text.substr(start, end - start + 1);
+}
+
+static std::string CollapseAsciiWhitespace(const std::string &text) {
+  std::string collapsed;
+  collapsed.reserve(text.size());
+  bool hadWhitespace = false;
+  for (unsigned char c : text) {
+    if (std::isspace(c)) {
+      hadWhitespace = true;
+      continue;
+    }
+    if (hadWhitespace && !collapsed.empty())
+      collapsed.push_back(' ');
+    collapsed.push_back(static_cast<char>(c));
+    hadWhitespace = false;
+  }
+  return collapsed;
 }
 
 static fs::path GetDictFile() {
@@ -87,6 +113,18 @@ static bool EnsureMigratedToGdtf(fs::path &pathInOut, std::string &error) {
 }
 
 } // namespace
+
+std::string NormalizeModelKey(const std::string &model) {
+  std::string normalized = CollapseAsciiWhitespace(TrimAsciiWhitespace(model));
+  std::transform(normalized.begin(), normalized.end(), normalized.begin(),
+                 [](unsigned char c) {
+                   return static_cast<char>(std::toupper(c));
+                 });
+
+  static const std::regex kDimensionSeparator("(\\d)\\s*[xX]\\s*(\\d)");
+  normalized = std::regex_replace(normalized, kDimensionSeparator, "$1X$2");
+  return normalized;
+}
 
 bool ImportTrussFile(const std::string &inputPath, std::string &storedPath,
                      std::string &error) {
@@ -161,6 +199,10 @@ std::optional<std::unordered_map<std::string, std::string>> Load() {
     if (!it.value().is_string())
       continue;
 
+    const std::string normalizedKey = NormalizeModelKey(it.key());
+    if (normalizedKey.empty())
+      continue;
+
     fs::path path = fs::u8path(it.value().get<std::string>());
     if (!path.is_absolute())
       path = dir / path;
@@ -172,9 +214,9 @@ std::optional<std::unordered_map<std::string, std::string>> Load() {
     if (!EnsureMigratedToGdtf(migrated, error))
       continue;
 
-    if (migrated != path)
+    if (migrated != path || normalizedKey != it.key())
       changed = true;
-    dict[it.key()] = ToUtf8String(migrated);
+    dict[normalizedKey] = ToUtf8String(migrated);
   }
 
   if (changed)
@@ -188,14 +230,22 @@ void Save(const std::unordered_map<std::string, std::string> &dict) {
     return;
 
   nlohmann::json j;
+  std::unordered_map<std::string, std::string> normalizedDict;
+  normalizedDict.reserve(dict.size());
+  for (const auto &[model, path] : dict) {
+    const std::string normalizedKey = NormalizeModelKey(model);
+    if (!normalizedKey.empty())
+      normalizedDict[normalizedKey] = path;
+  }
+
   std::vector<std::string> keys;
-  keys.reserve(dict.size());
-  for (const auto &[model, _] : dict)
+  keys.reserve(normalizedDict.size());
+  for (const auto &[model, _] : normalizedDict)
     keys.push_back(model);
   std::sort(keys.begin(), keys.end());
 
   for (const auto &model : keys) {
-    fs::path p = fs::u8path(dict.at(model));
+    fs::path p = fs::u8path(normalizedDict.at(model));
     fs::path forced = p;
     if (forced.extension() != ".gdtf")
       forced.replace_extension(".gdtf");
@@ -208,12 +258,16 @@ void Save(const std::unordered_map<std::string, std::string> &dict) {
 }
 
 std::optional<std::string> Get(const std::string &model) {
+  const std::string normalizedModel = NormalizeModelKey(model);
+  if (normalizedModel.empty())
+    return std::nullopt;
+
   auto dictOpt = Load();
   if (!dictOpt)
     return std::nullopt;
 
   auto &dict = *dictOpt;
-  auto it = dict.find(model);
+  auto it = dict.find(normalizedModel);
   if (it == dict.end())
     return std::nullopt;
 
@@ -227,7 +281,8 @@ std::optional<std::string> Get(const std::string &model) {
 }
 
 void Update(const std::string &model, const std::string &modelPath) {
-  if (model.empty() || modelPath.empty())
+  const std::string normalizedModel = NormalizeModelKey(model);
+  if (normalizedModel.empty() || modelPath.empty())
     return;
 
   std::string storedPath;
@@ -240,7 +295,7 @@ void Update(const std::string &model, const std::string &modelPath) {
     return;
 
   auto &dict = *dictOpt;
-  dict[model] = storedPath;
+  dict[normalizedModel] = storedPath;
   Save(dict);
 }
 

--- a/core/trussdictionary.h
+++ b/core/trussdictionary.h
@@ -22,6 +22,7 @@
 #include <unordered_map>
 
 namespace TrussDictionary {
+std::string NormalizeModelKey(const std::string &model);
 std::optional<std::unordered_map<std::string, std::string>> Load();
 void Save(const std::unordered_map<std::string, std::string> &dict);
 std::optional<std::string> Get(const std::string &model);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -144,6 +144,36 @@ target_link_libraries(truss_path_encoding_regression_test PRIVATE
                       ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
 add_test(NAME TrussPathEncodingRegression COMMAND truss_path_encoding_regression_test)
 
+add_executable(rider_truss_dictionary_normalization_test
+               rider_truss_dictionary_normalization_test.cpp
+               pdftext_stub.cpp
+               gdtfloader_stub.cpp
+               consolepanel_stub.cpp
+               ../core/riderimporter.cpp
+               ../core/uuidutils.cpp
+               ../core/autopatcher.cpp
+               ../core/patchmanager.cpp
+               ../core/configmanager.cpp
+               ../core/configservices.cpp
+               ../core/projectutils.cpp
+               ../core/gdtfdictionary.cpp
+               ../core/trussdictionary.cpp
+               ../core/trussloader.cpp
+               ../core/truss_gdtf_builder.cpp
+               ../mvr/mvrimporter.cpp
+               ../mvr/mvrexporter.cpp
+               ../core/logger.cpp
+               ../models/mvrscene.cpp
+               ../models/fixture.cpp
+               ../models/truss.cpp
+               ../models/sceneobject.cpp
+               ../models/layer.cpp
+               ${LAYOUT_SOURCES})
+target_include_directories(rider_truss_dictionary_normalization_test PRIVATE
+                           . ../core ../models ../mvr ../gui ../third_party)
+target_link_libraries(rider_truss_dictionary_normalization_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
+add_test(NAME RiderTrussDictionaryNormalization COMMAND rider_truss_dictionary_normalization_test)
+
 add_executable(mvr_dmx_address_test mvr_dmx_address_test.cpp
                ../mvr/mvrexporter.cpp
                ../core/configmanager.cpp

--- a/tests/rider_truss_dictionary_normalization_test.cpp
+++ b/tests/rider_truss_dictionary_normalization_test.cpp
@@ -1,0 +1,134 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <cassert>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include <wx/filename.h>
+#include <wx/init.h>
+#include <wx/wfstream.h>
+#include <wx/zipstrm.h>
+
+#include "configmanager.h"
+#include "riderimporter.h"
+#include "trussdictionary.h"
+
+namespace fs = std::filesystem;
+
+namespace {
+
+std::string ToUtf8String(const fs::path &path) {
+  std::u8string utf8 = path.u8string();
+  return std::string(utf8.begin(), utf8.end());
+}
+
+void SetLibraryPathEnv(const std::string &value) {
+#ifdef _WIN32
+  _putenv_s("PERASTAGE_LIBRARY_PATH", value.c_str());
+#else
+  setenv("PERASTAGE_LIBRARY_PATH", value.c_str(), 1);
+#endif
+}
+
+bool WriteArchive(const fs::path &archivePath) {
+  wxFileName::Mkdir(archivePath.parent_path().string(), wxS_DIR_DEFAULT,
+                    wxPATH_MKDIR_FULL);
+
+  wxFileOutputStream output(archivePath.string());
+  if (!output.IsOk())
+    return false;
+
+  wxZipOutputStream zip(output);
+  if (!zip.IsOk())
+    return false;
+
+  static const char *kDescriptionXml =
+      "<GDTF><FixtureType Manufacturer=\"Perastage\" Name=\"FK40Q\">"
+      "<Models><Model Name=\"main\" File=\"main\" Length=\"3.0\" Width=\"0.3\" Height=\"0.3\"/>"
+      "</Models></FixtureType></GDTF>";
+  static const char *kSvg =
+      "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"10\" height=\"10\"></svg>";
+
+  if (!zip.PutNextEntry("description.xml"))
+    return false;
+  zip.Write(kDescriptionXml, std::strlen(kDescriptionXml));
+
+  if (!zip.PutNextEntry("models/svg/main.svg"))
+    return false;
+  zip.Write(kSvg, std::strlen(kSvg));
+
+  zip.Close();
+  return output.IsOk();
+}
+
+void AssertTrussSymbolResolved(const std::string &textVariant) {
+  auto &cfg = ConfigManager::Get();
+  cfg.Reset();
+  assert(RiderImporter::ImportText(textVariant));
+
+  const auto &scene = cfg.GetScene();
+  assert(scene.trusses.size() == 1);
+  const auto &truss = scene.trusses.begin()->second;
+  assert(!truss.symbolFile.empty());
+  assert(fs::exists(fs::u8path(truss.symbolFile)));
+}
+
+} // namespace
+
+int main() {
+  wxInitializer initializer;
+  assert(initializer.IsOk());
+
+  const fs::path tempRoot =
+      fs::temp_directory_path() / fs::u8path("perastage_truss_model_normalization");
+  std::error_code ec;
+  fs::remove_all(tempRoot, ec);
+  fs::create_directories(tempRoot);
+
+  const fs::path libraryRoot = tempRoot / fs::u8path("library");
+  SetLibraryPathEnv(ToUtf8String(libraryRoot));
+
+  const fs::path archivePath = tempRoot / fs::u8path("FK40Q.gdtf");
+  assert(WriteArchive(archivePath));
+
+  TrussDictionary::Update("TRUSS 40X40 3M", ToUtf8String(archivePath));
+  const auto canonical = TrussDictionary::Get("TRUSS 40X40 3M");
+  assert(canonical.has_value());
+
+  const std::vector<std::string> variants = {
+      "TRUSS 40X40 3M",
+      "truss 40x40 3m",
+      "TRUSS   40X40   3M",
+  };
+  for (const std::string &variant : variants) {
+    const auto resolved = TrussDictionary::Get(variant);
+    assert(resolved.has_value());
+    assert(*resolved == *canonical);
+  }
+
+  AssertTrussSymbolResolved("1 truss 40X40 3M\n");
+  AssertTrussSymbolResolved("1 truss 40x40 3m\n");
+  AssertTrussSymbolResolved("1 truss   40X40   3M\n");
+
+  TrussDictionary::Save({});
+  fs::remove_all(tempRoot, ec);
+  return 0;
+}

--- a/tests/riderimporter_stubs.cpp
+++ b/tests/riderimporter_stubs.cpp
@@ -39,6 +39,7 @@ void Update(const std::string &, const std::string &, const std::string &) {}
 }
 
 namespace TrussDictionary {
+std::string NormalizeModelKey(const std::string &model) { return model; }
 std::optional<std::unordered_map<std::string, std::string>> Load() { return std::unordered_map<std::string, std::string>(); }
 void Save(const std::unordered_map<std::string, std::string> &) {}
 std::optional<std::string> Get(const std::string &) { return std::nullopt; }


### PR DESCRIPTION
### Motivation
- Ensure logically equivalent truss model strings resolve to the same dictionary entry regardless of casing, spacing or common separators so imports reliably find matching GDTF models. 
- Avoid missed matches during Rider text import caused by superficial differences such as extra spaces or `x`/`X` separators.

### Description
- Added a public helper `TrussDictionary::NormalizeModelKey(const std::string&)` that trims, collapses consecutive ASCII whitespace, uppercases the key and normalizes dimension separators (e.g. `40 x 40` → `40X40`) and declared it in `core/trussdictionary.h` and implemented it in `core/trussdictionary.cpp`.
- Applied normalization across the dictionary lifecycle: `Load()` now normalizes incoming keys and migrates if needed, `Save()` serializes normalized keys, `Get()` and `Update()` operate on normalized keys so lookups and inserts are canonicalized.
- Updated `core/riderimporter.cpp` to normalize `t.model` before any `TrussDictionary::Get(...)` lookup, including the deferred resolution pass after initial import, so Rider text variants resolve consistently.
- Added a regression test `tests/rider_truss_dictionary_normalization_test.cpp` and registered it in `tests/CMakeLists.txt` which (1) verifies variants `TRUSS 40X40 3M`, `truss 40x40 3m`, `TRUSS   40X40   3M` map to the same stored model and (2) verifies the Rider text import flow populates `t.symbolFile` on first load for those variants; also added a stub `NormalizeModelKey` implementation in `tests/riderimporter_stubs.cpp` to keep test builds working under the test harness.

### Testing
- Ran project checks `tests/check_perastage_tree_modules.sh` which passed (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed (`OK`).
- Attempted to configure a build with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` but configuration failed due to missing `wxWidgets` development libraries in the environment, so the new C++ test executable could not be compiled or executed here; the test was added and will run in CI or a dev environment with `wxWidgets` available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993714ecdac83249591f00bd0c4c6b8)