### PR TITLE
Sanitize exported TrussInfo ModelFile paths in MVR exporter

### DIFF
--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -116,6 +116,37 @@ static std::string SanitizeArchiveFileName(const std::string &input,
   return fs::path(candidate).filename().generic_string();
 }
 
+static std::string ExportSafeTrussModelFile(const std::string &modelFile) {
+  std::string candidate = TrimAscii(modelFile);
+  if (candidate.empty())
+    return {};
+
+  const bool hasDriveLetter = candidate.size() >= 2 && std::isalpha(candidate[0]) != 0 &&
+                              candidate[1] == ':';
+  const bool hasAbsolutePrefix = candidate.front() == '/' || candidate.front() == '\\' ||
+                                 candidate.rfind("//", 0) == 0 ||
+                                 candidate.rfind("\\\\", 0) == 0;
+  const bool isAbsolutePath = hasAbsolutePrefix || fs::path(candidate).is_absolute();
+
+  if (isAbsolutePath || hasDriveLetter) {
+    std::replace(candidate.begin(), candidate.end(), '\\', '/');
+    while (!candidate.empty() && candidate.back() == '/')
+      candidate.pop_back();
+    const size_t sep = candidate.find_last_of('/');
+    candidate = sep == std::string::npos ? candidate : candidate.substr(sep + 1);
+  }
+
+  candidate = TrimAscii(candidate);
+  if (candidate.empty() || candidate.find(':') != std::string::npos)
+    return {};
+
+  if (candidate.front() == '/' || candidate.front() == '\\' ||
+      candidate.rfind("//", 0) == 0 || candidate.rfind("\\\\", 0) == 0)
+    return {};
+
+  return candidate;
+}
+
 
 static std::string SlugifyArchiveName(const std::string &input) {
   std::string out;
@@ -1136,7 +1167,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
       addNum("Height", t.heightMm, "mm");
       addNum("Weight", t.weightKg, "kg");
       addTxt("CrossSection", t.crossSection);
-      addTxt("ModelFile", t.modelFile);
+      addTxt("ModelFile", ExportSafeTrussModelFile(t.modelFile));
       addTxt("HangPos", t.positionName);
       data->InsertEndChild(info);
       ud->InsertEndChild(data);

--- a/tests/mvr_exporter_compliance_test.cpp
+++ b/tests/mvr_exporter_compliance_test.cpp
@@ -36,10 +36,12 @@ int main() {
   fs::remove_all(tempDir);
   fs::create_directories(tempDir / "A");
   fs::create_directories(tempDir / "B");
+  fs::create_directories(tempDir / "models");
 
   std::ofstream(tempDir / "A" / "Same.gdtf") << "A";
   std::ofstream(tempDir / "B" / "Same.gdtf") << "B";
   std::ofstream(tempDir / "mesh.3ds") << "mesh";
+  std::ofstream(tempDir / "models" / "truss_model.3ds") << "truss";
 
   scene.basePath = tempDir.generic_string();
   scene.provider.clear();
@@ -78,7 +80,7 @@ int main() {
   tr.uuid = "tr-1";
   tr.name = "Main Truss";
   tr.symbolFile = "mesh.3ds";
-  tr.modelFile = "mesh.3ds";
+  tr.modelFile = (tempDir / "models" / "truss_model.3ds").string();
   scene.trusses[tr.uuid] = tr;
 
   Support sup;
@@ -131,6 +133,7 @@ int main() {
   bool sawAddress1 = false;
   bool sawAddress1025 = false;
   bool sawAddress2681 = false;
+  bool sawSafeModelFile = false;
   for (const char *tagName : {"Fixture", "Truss", "Support"}) {
     for (tinyxml2::XMLElement *node = root->FirstChildElement(); node;
          node = node->NextSiblingElement()) {
@@ -203,6 +206,25 @@ int main() {
             ++fixtureAddressCount;
           }
 
+          if (std::string(cur->Name()) == "Truss") {
+            auto *userData = cur->FirstChildElement("UserData");
+            assert(userData != nullptr);
+            auto *data = userData->FirstChildElement("Data");
+            assert(data != nullptr);
+            auto *trussInfo = data->FirstChildElement("TrussInfo");
+            assert(trussInfo != nullptr);
+            auto *modelFile = trussInfo->FirstChildElement("ModelFile");
+            assert(modelFile != nullptr);
+            assert(modelFile->GetText() != nullptr);
+
+            const std::string modelFileText = modelFile->GetText();
+            assert(!modelFileText.empty());
+            assert(modelFileText.find(':') == std::string::npos);
+            assert(modelFileText.front() != '/');
+            assert(modelFileText.front() != '\\');
+            sawSafeModelFile = true;
+          }
+
           if (auto *gdtf = cur->FirstChildElement("GDTFSpec"); gdtf && gdtf->GetText()) {
             std::string spec = gdtf->GetText();
             assert(spec.find(':') == std::string::npos);
@@ -226,6 +248,7 @@ int main() {
   assert(sawAddress1);
   assert(sawAddress1025);
   assert(sawAddress2681);
+  assert(sawSafeModelFile);
 
   for (const auto &name : entries) {
     assert(name.rfind("gdtf/", 0) != 0);


### PR DESCRIPTION
### Motivation
- Prevent exporting host-specific absolute paths or drive-letter prefixed paths in `TrussInfo/ModelFile`, which can leak local filesystem layout or break cross-platform imports. 
- Preserve existing `TrussInfo` compatibility for fields that are already safe.

### Description
- Added `ExportSafeTrussModelFile` to `mvr/mvrexporter.cpp`, which detects absolute paths and drive-letter prefixes, extracts a safe basename when possible, and returns empty to omit `ModelFile` when the result remains unsafe. 
- Updated `exportTruss` to call `ExportSafeTrussModelFile(t.modelFile)` instead of exporting `t.modelFile` verbatim. 
- Extended `tests/mvr_exporter_compliance_test.cpp` to create a truss with an absolute `modelFile` and assert the exported `ModelFile` element contains no `:` and has no absolute prefix.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed. 
- Attempted to run `cmake -S . -B build` to build tests, but configuration failed in this environment due to missing `wxWidgets` development packages, so full test build/run was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993727103d883248adcdeb934b05d3d)