### PR TITLE
Ensure truss FixtureID always mirrors FixtureIDNumeric

### DIFF
--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -1058,10 +1058,9 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
     };
     auto idIt = assignedIds.find(t.uuid);
     int fixtureNumericId = (idIt != assignedIds.end()) ? idIt->second.second : 0;
-    std::string fixtureId =
-        (idIt != assignedIds.end()) ? idIt->second.first : std::to_string(fixtureNumericId);
-    if (fixtureId.empty())
-      fixtureId = std::to_string(fixtureNumericId);
+    if (fixtureNumericId <= 0)
+      fixtureNumericId = 1;
+    std::string fixtureId = std::to_string(fixtureNumericId);
     addStr("FixtureID", fixtureId);
     addInt("FixtureIDNumeric", fixtureNumericId);
     addInt("UnitNumber", t.unitNumber);

--- a/tests/mvr_exporter_compliance_test.cpp
+++ b/tests/mvr_exporter_compliance_test.cpp
@@ -83,6 +83,13 @@ int main() {
   tr.modelFile = (tempDir / "models" / "truss_model.3ds").string();
   scene.trusses[tr.uuid] = tr;
 
+  Truss trNonNumeric;
+  trNonNumeric.uuid = "tr-2";
+  trNonNumeric.name = "TRUSS 2M";
+  trNonNumeric.symbolFile = "mesh.3ds";
+  trNonNumeric.modelFile = (tempDir / "models" / "truss_model.3ds").string();
+  scene.trusses[trNonNumeric.uuid] = trNonNumeric;
+
   Support sup;
   sup.uuid = "sup-1";
   sup.name = "Hoist 1";
@@ -134,6 +141,7 @@ int main() {
   bool sawAddress1025 = false;
   bool sawAddress2681 = false;
   bool sawSafeModelFile = false;
+  bool sawNonNumericTrussNameFixtureIdConsistency = false;
   for (const char *tagName : {"Fixture", "Truss", "Support"}) {
     for (tinyxml2::XMLElement *node = root->FirstChildElement(); node;
          node = node->NextSiblingElement()) {
@@ -223,6 +231,12 @@ int main() {
             assert(modelFileText.front() != '/');
             assert(modelFileText.front() != '\\');
             sawSafeModelFile = true;
+
+            const char *trussUuid = cur->Attribute("uuid");
+            if (trussUuid != nullptr && std::string(trussUuid) == trNonNumeric.uuid) {
+              sawNonNumericTrussNameFixtureIdConsistency =
+                  fixtureIdText == std::to_string(value);
+            }
           }
 
           if (auto *gdtf = cur->FirstChildElement("GDTFSpec"); gdtf && gdtf->GetText()) {
@@ -249,6 +263,7 @@ int main() {
   assert(sawAddress1025);
   assert(sawAddress2681);
   assert(sawSafeModelFile);
+  assert(sawNonNumericTrussNameFixtureIdConsistency);
 
   for (const auto &name : entries) {
     assert(name.rfind("gdtf/", 0) != 0);


### PR DESCRIPTION
### Motivation
- Prevent non-numeric truss names from being emitted into `<FixtureID>` and ensure exported `FixtureID` is always a numeric text matching `FixtureIDNumeric` for trusses.
- Keep MVR output consistent with validation rules that require `FixtureID` to be digits-only and equal to `FixtureIDNumeric`.

### Description
- Changed `exportTruss` in `mvr/mvrexporter.cpp` to always emit `FixtureID` as `std::to_string(FixtureIDNumeric)` and to enforce a minimum positive `FixtureIDNumeric` value.
- Removed logic that could use a truss name (or other free text) as the exported `FixtureID` value.
- Added a test truss with a non-numeric name (`TRUSS 2M`) in `tests/mvr_exporter_compliance_test.cpp` and a check that the exported `<FixtureID>` equals `std::to_string(FixtureIDNumeric)` for that truss.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which succeeded.
- Attempted `cmake -S . -B build` to build and run the compliance test, but configuration failed in this environment due to missing `wxWidgets` development packages, so the updated compliance test executable could not be compiled/executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993738afb3483249f994196d5c4a97d)