### PR TITLE
Add configurable Truss geometry authority for MVR export (MVR vs GDTF)

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -123,6 +123,7 @@ ConfigManager::ConfigManager() {
   RegisterVariable("render_culling_min_pixels_2d", "float", 1.0f, 0.0f,
                    64.0f);
   RegisterVariable("mvr_import_detailed_log", "float", 0.0f, 0.0f, 1.0f);
+  RegisterVariable("mvr_truss_geometry_authority", "float", 0.0f, 0.0f, 1.0f);
   RegisterVariable("label_optimizations_enabled", "float", 1.0f, 0.0f,
                    1.0f);
   RegisterVariable("label_max_fixtures", "float", 250.0f, 0.0f, 5000.0f);

--- a/docs/mvr_truss_geometry_authority.md
+++ b/docs/mvr_truss_geometry_authority.md
@@ -1,0 +1,24 @@
+# MVR Truss Geometry Authority
+
+Perastage now exports truss objects with an explicit geometry authority policy controlled by the `mvr_truss_geometry_authority` configuration key.
+
+## Configuration
+
+- `mvr_truss_geometry_authority = 0` → `MVR_GEOMETRY` (default)
+- `mvr_truss_geometry_authority = 1` → `GDTF`
+
+## Export policy
+
+The exporter always keeps `GDTFSpec` for truss objects when a GDTF source is available (existing truss GDTF, `.gdtf` model file, or generated GDTF).
+
+To prevent duplicate meshes in downstream consumers, only one source is allowed to provide visible geometry per truss:
+
+- In `MVR_GEOMETRY`, visible geometry is written in the MVR `<Geometries>` node and the truss GDTF is rewritten as metadata-only (no renderable model).
+- In `GDTF`, no truss `<Geometries>` node is written and visible geometry is expected to come from the referenced GDTF.
+
+## Expected compatibility matrix
+
+| Mode (`mvr_truss_geometry_authority`) | `GDTFSpec` on Truss | `<Geometries>` on Truss | Visible geometry authority | Expected result in consumers that render GDTF by default |
+| --- | --- | --- | --- | --- |
+| `MVR_GEOMETRY` (`0`) | Yes | Yes (when symbol geometry is available) | MVR `<Geometry3D>` | No double mesh, truss identity/metadata remains via GDTF. |
+| `GDTF` (`1`) | Yes | No | GDTF model | No duplicate mesh from MVR truss geometry. |

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -67,6 +67,27 @@ static bool TryComputeAbsoluteDmx(int universe1Based, int address1Based,
 static constexpr const char *kMvrProvider = "Perastage";
 static constexpr const char *kMvrProviderVersion = "1.0";
 
+enum class TrussGeometryAuthority {
+  MvrGeometry = 0,
+  Gdtf = 1,
+};
+
+static TrussGeometryAuthority GetTrussGeometryAuthoritySetting() {
+  const float rawValue = ConfigManager::Get().GetFloat("mvr_truss_geometry_authority");
+  return rawValue >= 0.5f ? TrussGeometryAuthority::Gdtf : TrussGeometryAuthority::MvrGeometry;
+}
+
+static void RemoveModelAttributeRecursive(tinyxml2::XMLElement *element) {
+  if (!element)
+    return;
+  if (element->FindAttribute("Model"))
+    element->DeleteAttribute("Model");
+  for (tinyxml2::XMLElement *child = element->FirstChildElement(); child;
+       child = child->NextSiblingElement()) {
+    RemoveModelAttributeRecursive(child);
+  }
+}
+
 static std::string TrimAscii(std::string value) {
   auto isSpace = [](unsigned char c) { return std::isspace(c); };
   value.erase(value.begin(), std::find_if(value.begin(), value.end(),
@@ -634,8 +655,44 @@ static std::string CreatePatchedGdtf(const std::string &gdtfPath,
   return outPath;
 }
 
+static std::string CreateMetadataOnlyTrussGdtf(const std::string &gdtfPath) {
+  if (gdtfPath.empty())
+    return {};
+
+  std::string tempDir = CreateTempDir();
+  if (!ExtractZip(gdtfPath, tempDir))
+    return {};
+
+  std::string descPath = tempDir + "/description.xml";
+  tinyxml2::XMLDocument doc;
+  if (doc.LoadFile(descPath.c_str()) != tinyxml2::XML_SUCCESS)
+    return {};
+
+  tinyxml2::XMLElement *fixtureType = doc.FirstChildElement("GDTF");
+  if (fixtureType)
+    fixtureType = fixtureType->FirstChildElement("FixtureType");
+  else
+    fixtureType = doc.FirstChildElement("FixtureType");
+  if (!fixtureType)
+    return {};
+
+  if (tinyxml2::XMLElement *models = fixtureType->FirstChildElement("Models")) {
+    fixtureType->DeleteChild(models);
+  }
+  RemoveModelAttributeRecursive(fixtureType);
+
+  fs::remove_all(fs::path(tempDir) / "models");
+
+  doc.SaveFile(descPath.c_str());
+  std::string outPath = tempDir + ".gdtf";
+  if (!ZipDir(tempDir, outPath))
+    return {};
+  return outPath;
+}
+
 bool MvrExporter::ExportToFile(const std::string &filePath) {
   const auto &scene = ConfigManager::Get().GetScene();
+  const TrussGeometryAuthority trussGeometryAuthority = GetTrussGeometryAuthoritySetting();
   auto positions = scene.positions;
 
   std::unordered_map<std::string, std::string> positionByName;
@@ -1080,6 +1137,12 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
       }
     }
 
+    if (trussGeometryAuthority == TrussGeometryAuthority::MvrGeometry && !trussSourceGdtf.empty()) {
+      std::string metadataOnlyGdtf = CreateMetadataOnlyTrussGdtf(trussSourceGdtf);
+      if (!metadataOnlyGdtf.empty())
+        trussSourceGdtf = metadataOnlyGdtf;
+    }
+
     std::string trussSlug = SlugifyArchiveName(t.model.empty() ? t.name : t.model);
     std::string trussPreferredName = trussSlug.empty() ? "truss.gdtf" : (trussSlug + ".gdtf");
     std::string trussGdtfArchivePath = registerGdtfResource(t.uuid, trussSourceGdtf, trussPreferredName);
@@ -1112,7 +1175,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
       }
     }
 
-    if (!t.symbolFile.empty()) {
+    if (trussGeometryAuthority == TrussGeometryAuthority::MvrGeometry && !t.symbolFile.empty()) {
       std::string ext = fs::path(t.symbolFile).extension().string();
       std::transform(ext.begin(), ext.end(), ext.begin(),
                      [](unsigned char c) { return static_cast<char>(std::tolower(c)); });

--- a/tests/mvr_exporter_compliance_test.cpp
+++ b/tests/mvr_exporter_compliance_test.cpp
@@ -215,6 +215,11 @@ int main() {
           }
 
           if (std::string(cur->Name()) == "Truss") {
+            auto *gdtfSpec = cur->FirstChildElement("GDTFSpec");
+            assert(gdtfSpec != nullptr && gdtfSpec->GetText() != nullptr);
+            auto *geometries = cur->FirstChildElement("Geometries");
+            assert(geometries != nullptr);
+
             auto *userData = cur->FirstChildElement("UserData");
             assert(userData != nullptr);
             auto *data = userData->FirstChildElement("Data");
@@ -268,6 +273,58 @@ int main() {
   for (const auto &name : entries) {
     assert(name.rfind("gdtf/", 0) != 0);
   }
+
+
+  cfg.SetFloat("mvr_truss_geometry_authority", 1.0f);
+  fs::path mvrPathGdtfAuthority = tempDir / "Test2_GdtfAuthority.mvr";
+  assert(exporter.ExportToFile(mvrPathGdtfAuthority.generic_string()));
+
+  wxFileInputStream inputGdtfAuthority(mvrPathGdtfAuthority.generic_string());
+  assert(inputGdtfAuthority.IsOk());
+  wxZipInputStream zipGdtfAuthority(inputGdtfAuthority);
+
+  std::string xmlGdtfAuthority;
+  std::unique_ptr<wxZipEntry> entryGdtfAuthority;
+  while ((entryGdtfAuthority.reset(zipGdtfAuthority.GetNextEntry())), entryGdtfAuthority) {
+    if (entryGdtfAuthority->GetName().ToStdString() == "GeneralSceneDescription.xml") {
+      char buffer[4096];
+      while (true) {
+        zipGdtfAuthority.Read(buffer, sizeof(buffer));
+        size_t bytes = zipGdtfAuthority.LastRead();
+        if (bytes == 0)
+          break;
+        xmlGdtfAuthority.append(buffer, bytes);
+      }
+      break;
+    }
+  }
+
+  assert(!xmlGdtfAuthority.empty());
+  tinyxml2::XMLDocument docGdtfAuthority;
+  assert(docGdtfAuthority.Parse(xmlGdtfAuthority.c_str()) == tinyxml2::XML_SUCCESS);
+  tinyxml2::XMLElement *rootGdtfAuthority = docGdtfAuthority.FirstChildElement("GeneralSceneDescription");
+  assert(rootGdtfAuthority != nullptr);
+
+  bool sawTrussWithGdtfSpec = false;
+  for (tinyxml2::XMLElement *node = rootGdtfAuthority->FirstChildElement(); node;
+       node = node->NextSiblingElement()) {
+    std::vector<tinyxml2::XMLElement *> stack{node};
+    while (!stack.empty()) {
+      tinyxml2::XMLElement *cur = stack.back();
+      stack.pop_back();
+      if (std::string(cur->Name()) == "Truss") {
+        auto *gdtfSpec = cur->FirstChildElement("GDTFSpec");
+        assert(gdtfSpec != nullptr && gdtfSpec->GetText() != nullptr);
+        sawTrussWithGdtfSpec = true;
+        assert(cur->FirstChildElement("Geometries") == nullptr);
+      }
+      for (tinyxml2::XMLElement *child = cur->FirstChildElement(); child;
+           child = child->NextSiblingElement()) {
+        stack.push_back(child);
+      }
+    }
+  }
+  assert(sawTrussWithGdtfSpec);
   fs::remove_all(tempDir);
   return 0;
 }


### PR DESCRIPTION
### Motivation
- Prevent duplicate visible meshes for truss objects by making a single, explicit geometry authority choice between MVR `<Geometries>` and referenced GDTF content while preserving `GDTFSpec` identity/metadata.
- Provide a simple, opt-in configuration to support different consumer workflows that either prefer scene geometry in the MVR or the GDTF model.
- Keep changes local to the exporter logic and add a small test and documentation entry for the expected behaviors.

### Description
- Introduced a new configuration key `mvr_truss_geometry_authority` (registered in `core/configmanager.cpp`) with two modes: `MVR_GEOMETRY` (default = `0`) and `GDTF` (`1`).
- Added `TrussGeometryAuthority` enum and `GetTrussGeometryAuthoritySetting()` in `mvr/mvrexporter.cpp` to read the config and influence export behavior.
- Implemented `CreateMetadataOnlyTrussGdtf()` plus `RemoveModelAttributeRecursive()` to produce a metadata-only version of a truss GDTF (removes model entries and `models/` resources) so the GDTF can still provide identity/metadata without renderable geometry.
- Updated `exportTruss` logic in `mvr/mvrexporter.cpp` to:
  - Always keep `GDTFSpec` when a GDTF source exists (original identity preserved).
  - In `MVR_GEOMETRY` mode, register and include a metadata-only GDTF and write `<Geometries>` for visible geometry (from `symbolFile` / model lookup) so consumers that render MVR geometry get the visible mesh while avoiding duplicate GDTF meshes.
  - In `GDTF` mode, do not emit `<Geometries>` for trusses so visible geometry authority remains the GDTF model.
- Added documentation `docs/mvr_truss_geometry_authority.md` describing configuration, export policy, and a compatibility matrix.
- Extended `tests/mvr_exporter_compliance_test.cpp` to assert both the default/export behavior (GDTFSpec + Geometries present) and the `GDTF`-authority behavior (GDTFSpec present, Geometries omitted).
- Technical note: `mvr/mvrexporter.cpp` is an existing hotspot; the new helpers are intentionally local for this change, but the GDTF patching logic is a good candidate for extraction to a dedicated helper file in a follow-up PR if further growth occurs.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed successfully.
- Attempted a local CMake configure (`cmake -S . -B build-local -G Ninja`) to enable building the new/modified test binary but configure failed due to missing system `wxWidgets` development packages in the environment, so the updated `mvr_exporter_compliance_test` was added but not executed here.
- All changes are committed; unit-test scaffolding for the exported behaviors was added to the test suite and will run in CI or when the build environment has `wxWidgets` available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69937586cf1c832490769ccfe9f46a15)