### PR TITLE
Improve truss import diagnostics and explicit dummy-box fallback logging

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -43,6 +43,7 @@
 #include "gdtfdictionary.h"
 #include "gdtfloader.h"
 #include "layer.h"
+#include "logger.h"
 #include "truss.h"
 #include "trussdictionary.h"
 #include "trussloader.h"
@@ -139,6 +140,15 @@ bool IsRenderableTrussGeometry(const std::string &path) {
                    return static_cast<char>(std::tolower(c));
                  });
   return ext == ".3ds" || ext == ".glb";
+}
+
+std::string DescribeTrussForLog(const Truss &truss) {
+  const std::string displayName = truss.name.empty() ? "(unnamed)" : truss.name;
+  std::ostringstream oss;
+  oss << "uuid='" << truss.uuid << "', name='" << displayName << "', model='"
+      << truss.model << "', modelFile='" << truss.modelFile << "', gdtfSpec='"
+      << truss.gdtfSpec << "', symbolFile='" << truss.symbolFile << "'";
+  return oss.str();
 }
 
 std::vector<std::string> SplitPlus(const std::string &s) {
@@ -683,22 +693,53 @@ bool RiderImporter::ImportText(const std::string &text) {
 
     Truss parsed;
     bool resolved = false;
+    bool modelDefinitionFailed = false;
+    bool gdtfDefinitionFailed = false;
+    bool dictionaryDefinitionFailed = false;
 
-    if (!t.modelFile.empty())
+    if (!t.modelFile.empty()) {
       resolved = LoadTrussDefinition(t.modelFile, parsed);
-    if (!resolved && !t.gdtfSpec.empty())
+      if (!resolved)
+        modelDefinitionFailed = true;
+    }
+    if (!resolved && !t.gdtfSpec.empty()) {
       resolved = LoadTrussDefinition(t.gdtfSpec, parsed);
+      if (!resolved)
+        gdtfDefinitionFailed = true;
+    }
     if (!resolved && !t.model.empty()) {
       t.model = TrussDictionary::NormalizeModelKey(t.model);
       if (auto dictPath = TrussDictionary::Get(t.model)) {
         resolved = LoadTrussDefinition(*dictPath, parsed);
+        if (!resolved)
+          dictionaryDefinitionFailed = true;
         if (resolved && t.modelFile.empty())
           t.modelFile = *dictPath;
       }
     }
 
-    if (!resolved)
+    if (!resolved) {
+      std::vector<std::string> reasons;
+      if (modelDefinitionFailed)
+        reasons.emplace_back("LoadTrussDefinition(modelFile) returned false");
+      if (gdtfDefinitionFailed)
+        reasons.emplace_back("LoadTrussDefinition(gdtfSpec) returned false");
+      if (dictionaryDefinitionFailed)
+        reasons.emplace_back("LoadTrussDefinition(dictionary model) returned false");
+      if (reasons.empty())
+        reasons.emplace_back("missing or non-renderable symbolFile");
+
+      std::ostringstream oss;
+      oss << "Rider import truss fallback to dummy box: "
+          << DescribeTrussForLog(t) << ". Reason: ";
+      for (size_t i = 0; i < reasons.size(); ++i) {
+        if (i > 0)
+          oss << "; ";
+        oss << reasons[i];
+      }
+      Logger::Instance().Log(Logger::Level::Warn, oss.str());
       continue;
+    }
 
     if (!parsed.symbolFile.empty())
       t.symbolFile = parsed.symbolFile;
@@ -710,6 +751,24 @@ bool RiderImporter::ImportText(const std::string &text) {
       t.gdtfMode = parsed.gdtfMode;
     if (t.manufacturer.empty() && !parsed.manufacturer.empty())
       t.manufacturer = parsed.manufacturer;
+
+    bool symbolLooksRenderable = IsRenderableTrussGeometry(t.symbolFile);
+    bool symbolExists =
+        symbolLooksRenderable && std::filesystem::exists(std::filesystem::u8path(t.symbolFile));
+    if (!symbolExists) {
+      std::ostringstream reason;
+      if (t.symbolFile.empty()) {
+        reason << "symbolFile is empty";
+      } else if (!symbolLooksRenderable) {
+        reason << "symbolFile extension is not .3ds/.glb";
+      } else {
+        reason << "symbolFile does not exist on disk";
+      }
+      std::ostringstream oss;
+      oss << "Rider import truss fallback to dummy box: "
+          << DescribeTrussForLog(t) << ". Reason: " << reason.str();
+      Logger::Instance().Log(Logger::Level::Warn, oss.str());
+    }
   }
 
   // Distribute fixtures along their hang positions using available truss

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -101,6 +101,26 @@ static bool TryParseFloat(const std::string &text, float &out) {
   return false;
 }
 
+static bool IsRenderableTrussGeometry(const std::string &path) {
+  if (path.empty())
+    return false;
+
+  std::string ext = fs::path(path).extension().string();
+  std::transform(ext.begin(), ext.end(), ext.begin(), [](unsigned char c) {
+    return static_cast<char>(std::tolower(c));
+  });
+  return ext == ".3ds" || ext == ".glb";
+}
+
+static std::string DescribeTrussForLog(const Truss &truss) {
+  const std::string displayName = truss.name.empty() ? "(unnamed)" : truss.name;
+  std::ostringstream oss;
+  oss << "uuid='" << truss.uuid << "', name='" << displayName << "', model='"
+      << truss.model << "', modelFile='" << truss.modelFile << "', gdtfSpec='"
+      << truss.gdtfSpec << "', symbolFile='" << truss.symbolFile << "'";
+  return oss.str();
+}
+
 static std::string CieToHex(const std::string &cie) {
   std::string t = cie;
   std::replace(t.begin(), t.end(), ',', ' ');
@@ -788,6 +808,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         truss.position = textOf(node, "Position");
         truss.positionName = ensurePositionEntry(truss.position);
 
+        bool gdtfLoadFailed = false;
         if (!truss.gdtfSpec.empty()) {
           fs::path gdtfPath = scene.basePath.empty()
                                   ? fs::u8path(truss.gdtfSpec)
@@ -814,6 +835,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
               truss.weightKg = gdtfTruss.weightKg;
             if (truss.gdtfMode.empty())
               truss.gdtfMode = gdtfTruss.gdtfMode.empty() ? "Default" : gdtfTruss.gdtfMode;
+          } else {
+            gdtfLoadFailed = true;
           }
         }
 
@@ -897,6 +920,27 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
               break;
             }
           }
+        }
+
+        const bool symbolRenderable = IsRenderableTrussGeometry(truss.symbolFile);
+        const bool symbolExists =
+            symbolRenderable && fs::exists(fs::u8path(truss.symbolFile));
+        if (!symbolExists) {
+          std::ostringstream reason;
+          if (truss.symbolFile.empty()) {
+            reason << "symbolFile is empty";
+          } else if (!symbolRenderable) {
+            reason << "symbolFile extension is not .3ds/.glb";
+          } else {
+            reason << "symbolFile does not exist on disk";
+          }
+          if (gdtfLoadFailed)
+            reason << "; LoadTrussDefinition(gdtfSpec) returned false";
+
+          std::ostringstream msg;
+          msg << "MVR import truss fallback to dummy box: "
+              << DescribeTrussForLog(truss) << ". Reason: " << reason.str();
+          LogMessage(Logger::Level::Warn, msg.str());
         }
 
         scene.trusses[truss.uuid] = truss;


### PR DESCRIPTION
### Motivation
- Improve user and developer visibility when imported trusses fall back to a simple box by reporting why model geometry was not used.
- Provide parity between the Rider and MVR import flows so diagnostics are consistent across importers.

### Description
- In `core/riderimporter.cpp` added `#include "logger.h"`, a `DescribeTrussForLog` helper, tracking flags for failed `LoadTrussDefinition` attempts (`modelFile`, `gdtfSpec`, dictionary) and explicit warning logs that include `uuid`, `name`, `model`, `modelFile`, `gdtfSpec`, `symbolFile` and the reason including the phrase "fallback to dummy box" when resolution fails or the `symbolFile` is not a renderable `.3ds/.glb` or does not exist on disk.
- In `mvr/mvrimporter.cpp` added `IsRenderableTrussGeometry` and `DescribeTrussForLog` helpers, a `gdtfLoadFailed` flag, and equivalent warning logging via `LogMessage` when `symbolFile` is invalid/missing, including the same explicit "fallback to dummy box" wording.
- Kept changes localized to importer flows and reused existing `Logger` / `LogMessage` plumbing for console + log file delivery.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993769958288324ab6fd696d2d74eb7)