### PR TITLE
Avoid !is_inside_tree() warnings when creating debug gizmos

### DIFF
--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -166,9 +166,9 @@ func _add_debug_gizmo_for_target(target: Node3D, kind: String, origin_color: Col
 		return
 	var holder := Node3D.new()
 	holder.name = "Gizmo_%s" % kind
+	_debug_gizmos_root.add_child(holder)
 	holder.global_position = _safe_target_global_position(target)
 	holder.add_child(_create_axes_gizmo_node(origin_color, length))
-	_debug_gizmos_root.add_child(holder)
 
 func _create_axes_gizmo_node(origin_color: Color, length: float) -> Node3D:
 	var immediate := ImmediateMesh.new()


### PR DESCRIPTION
### Motivation
- Godot emits repeated `!is_inside_tree()` warnings when `global_position` is accessed on a `Node3D` before it is attached to the scene tree, causing spam during debug-gizmo creation.

### Description
- In `_add_debug_gizmo_for_target` in `peraviz/scripts/load_scene.gd` the newly created gizmo `holder` is now attached to `_debug_gizmos_root` before `holder.global_position` is assigned, while keeping naming, null checks, and gizmo mesh/marker creation behavior unchanged.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both completed successfully (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69937c82a5ec83249e4529d81879730a)