### PR TITLE
Prefer GDTF metadata for trusses and keep truss geometry embedded in exported GDTFs

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -594,15 +594,20 @@ bool RiderImporter::ImportText(const std::string &text) {
               t.modelFile = parsed.modelFile.empty() ? *dictPath : parsed.modelFile;
               t.gdtfSpec = parsed.gdtfSpec;
               t.gdtfMode = parsed.gdtfMode;
-              t.manufacturer = parsed.manufacturer;
+              if (!parsed.manufacturer.empty())
+                t.manufacturer = parsed.manufacturer;
+              if (!parsed.model.empty())
+                t.model = TrussDictionary::NormalizeModelKey(parsed.model);
               if (parsed.lengthMm > 0.0f)
                 t.lengthMm = parsed.lengthMm;
               if (parsed.widthMm > 0.0f)
                 t.widthMm = parsed.widthMm;
               if (parsed.heightMm > 0.0f)
                 t.heightMm = parsed.heightMm;
-              t.weightKg = parsed.weightKg;
-              t.crossSection = parsed.crossSection;
+              if (parsed.weightKg > 0.0f)
+                t.weightKg = parsed.weightKg;
+              if (!parsed.crossSection.empty())
+                t.crossSection = parsed.crossSection;
             } else {
               t.modelFile = *dictPath;
             }
@@ -802,6 +807,18 @@ bool RiderImporter::ImportText(const std::string &text) {
       t.gdtfMode = parsed.gdtfMode;
     if (t.manufacturer.empty() && !parsed.manufacturer.empty())
       t.manufacturer = parsed.manufacturer;
+    if (!parsed.model.empty())
+      t.model = TrussDictionary::NormalizeModelKey(parsed.model);
+    if (parsed.lengthMm > 0.0f)
+      t.lengthMm = parsed.lengthMm;
+    if (parsed.widthMm > 0.0f)
+      t.widthMm = parsed.widthMm;
+    if (parsed.heightMm > 0.0f)
+      t.heightMm = parsed.heightMm;
+    if (parsed.weightKg > 0.0f)
+      t.weightKg = parsed.weightKg;
+    if (!parsed.crossSection.empty())
+      t.crossSection = parsed.crossSection;
 
     bool symbolLooksRenderable = IsRenderableTrussGeometry(t.symbolFile);
     bool symbolExists =

--- a/core/trussdictionary.cpp
+++ b/core/trussdictionary.cpp
@@ -20,6 +20,7 @@
 #include "json.hpp"
 #include "projectutils.h"
 #include "truss_gdtf_builder.h"
+#include "truss.h"
 
 #include <algorithm>
 #include <cctype>
@@ -103,6 +104,20 @@ static bool EnsureMigratedToGdtf(fs::path &pathInOut, std::string &error) {
     if (!fs::exists(converted) &&
         !ConvertLegacyGtrussToGdtf(pathInOut, converted, &error)) {
       return false;
+    }
+    pathInOut = converted;
+    return true;
+  }
+
+  if (ext == ".glb" || ext == ".3ds") {
+    fs::path converted = pathInOut;
+    converted.replace_extension(".gdtf");
+    if (!fs::exists(converted)) {
+      Truss truss;
+      truss.modelFile = ToUtf8String(pathInOut);
+      truss.model = pathInOut.stem().string();
+      if (!BuildTrussGdtfFromInstance(truss, converted, &error))
+        return false;
     }
     pathInOut = converted;
     return true;

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -77,17 +77,6 @@ static TrussGeometryAuthority GetTrussGeometryAuthoritySetting() {
   return rawValue >= 0.5f ? TrussGeometryAuthority::Gdtf : TrussGeometryAuthority::MvrGeometry;
 }
 
-static void RemoveModelAttributeRecursive(tinyxml2::XMLElement *element) {
-  if (!element)
-    return;
-  if (element->FindAttribute("Model"))
-    element->DeleteAttribute("Model");
-  for (tinyxml2::XMLElement *child = element->FirstChildElement(); child;
-       child = child->NextSiblingElement()) {
-    RemoveModelAttributeRecursive(child);
-  }
-}
-
 static std::string TrimAscii(std::string value) {
   auto isSpace = [](unsigned char c) { return std::isspace(c); };
   value.erase(value.begin(), std::find_if(value.begin(), value.end(),
@@ -655,41 +644,6 @@ static std::string CreatePatchedGdtf(const std::string &gdtfPath,
   return outPath;
 }
 
-static std::string CreateMetadataOnlyTrussGdtf(const std::string &gdtfPath) {
-  if (gdtfPath.empty())
-    return {};
-
-  std::string tempDir = CreateTempDir();
-  if (!ExtractZip(gdtfPath, tempDir))
-    return {};
-
-  std::string descPath = tempDir + "/description.xml";
-  tinyxml2::XMLDocument doc;
-  if (doc.LoadFile(descPath.c_str()) != tinyxml2::XML_SUCCESS)
-    return {};
-
-  tinyxml2::XMLElement *fixtureType = doc.FirstChildElement("GDTF");
-  if (fixtureType)
-    fixtureType = fixtureType->FirstChildElement("FixtureType");
-  else
-    fixtureType = doc.FirstChildElement("FixtureType");
-  if (!fixtureType)
-    return {};
-
-  if (tinyxml2::XMLElement *models = fixtureType->FirstChildElement("Models")) {
-    fixtureType->DeleteChild(models);
-  }
-  RemoveModelAttributeRecursive(fixtureType);
-
-  fs::remove_all(fs::path(tempDir) / "models");
-
-  doc.SaveFile(descPath.c_str());
-  std::string outPath = tempDir + ".gdtf";
-  if (!ZipDir(tempDir, outPath))
-    return {};
-  return outPath;
-}
-
 bool MvrExporter::ExportToFile(const std::string &filePath) {
   const auto &scene = ConfigManager::Get().GetScene();
   const TrussGeometryAuthority trussGeometryAuthority = GetTrussGeometryAuthoritySetting();
@@ -1137,12 +1091,6 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
       }
     }
 
-    if (trussGeometryAuthority == TrussGeometryAuthority::MvrGeometry && !trussSourceGdtf.empty()) {
-      std::string metadataOnlyGdtf = CreateMetadataOnlyTrussGdtf(trussSourceGdtf);
-      if (!metadataOnlyGdtf.empty())
-        trussSourceGdtf = metadataOnlyGdtf;
-    }
-
     std::string trussSlug = SlugifyArchiveName(t.model.empty() ? t.name : t.model);
     std::string trussPreferredName = trussSlug.empty() ? "truss.gdtf" : (trussSlug + ".gdtf");
     std::string trussGdtfArchivePath = registerGdtfResource(t.uuid, trussSourceGdtf, trussPreferredName);
@@ -1195,11 +1143,13 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
     mat->SetText(mstr.c_str());
     te->InsertEndChild(mat);
 
-    bool hasMeta = !t.manufacturer.empty() || !t.model.empty() ||
-                   t.lengthMm != 0.0f || t.widthMm != 0.0f ||
-                   t.heightMm != 0.0f || t.weightKg != 0.0f ||
-                   !t.crossSection.empty() || !t.modelFile.empty() ||
-                   !t.positionName.empty();
+    const bool shouldWriteMvrTrussMetadata = trussGdtfArchivePath.empty();
+    bool hasMeta = shouldWriteMvrTrussMetadata &&
+                   (!t.manufacturer.empty() || !t.model.empty() ||
+                    t.lengthMm != 0.0f || t.widthMm != 0.0f ||
+                    t.heightMm != 0.0f || t.weightKg != 0.0f ||
+                    !t.crossSection.empty() || !t.modelFile.empty() ||
+                    !t.positionName.empty());
     if (hasMeta) {
       tinyxml2::XMLElement *ud = doc.NewElement("UserData");
       tinyxml2::XMLElement *data = doc.NewElement("Data");

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -866,50 +866,54 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
           }
         }
 
+        const bool hasGdtfMetadataAuthority = !truss.gdtfSpec.empty() && !gdtfLoadFailed;
+
         if (tinyxml2::XMLElement *ud = node->FirstChildElement("UserData")) {
           for (tinyxml2::XMLElement *data = ud->FirstChildElement("Data"); data;
                data = data->NextSiblingElement("Data")) {
             if (tinyxml2::XMLElement *info =
                     data->FirstChildElement("TrussInfo")) {
-              if (tinyxml2::XMLElement *m =
-                      info->FirstChildElement("Manufacturer"))
-                if (m->GetText())
-                  truss.manufacturer = Trim(m->GetText());
-              if (tinyxml2::XMLElement *mo = info->FirstChildElement("Model"))
-                if (mo->GetText())
-                  truss.model = Trim(mo->GetText());
-              if (tinyxml2::XMLElement *len = info->FirstChildElement("Length"))
-                if (len->GetText()) {
-                  float parsed = 0.0f;
-                  if (TryParseFloat(len->GetText(), parsed))
-                    truss.lengthMm = parsed;
-                }
-              if (tinyxml2::XMLElement *wid = info->FirstChildElement("Width"))
-                if (wid->GetText()) {
-                  float parsed = 0.0f;
-                  if (TryParseFloat(wid->GetText(), parsed))
-                    truss.widthMm = parsed;
-                  else
-                    truss.widthMm = 400.0f;
-                }
-              if (tinyxml2::XMLElement *hei = info->FirstChildElement("Height"))
-                if (hei->GetText()) {
-                  float parsed = 0.0f;
-                  if (TryParseFloat(hei->GetText(), parsed))
-                    truss.heightMm = parsed;
-                  else
-                    truss.heightMm = 400.0f;
-                }
-              if (tinyxml2::XMLElement *wei = info->FirstChildElement("Weight"))
-                if (wei->GetText()) {
-                  float parsed = 0.0f;
-                  if (TryParseFloat(wei->GetText(), parsed))
-                    truss.weightKg = parsed;
-                }
-              if (tinyxml2::XMLElement *cs =
-                      info->FirstChildElement("CrossSection"))
-                if (cs->GetText())
-                  truss.crossSection = Trim(cs->GetText());
+              if (!hasGdtfMetadataAuthority) {
+                if (tinyxml2::XMLElement *m =
+                        info->FirstChildElement("Manufacturer"))
+                  if (m->GetText())
+                    truss.manufacturer = Trim(m->GetText());
+                if (tinyxml2::XMLElement *mo = info->FirstChildElement("Model"))
+                  if (mo->GetText())
+                    truss.model = Trim(mo->GetText());
+                if (tinyxml2::XMLElement *len = info->FirstChildElement("Length"))
+                  if (len->GetText()) {
+                    float parsed = 0.0f;
+                    if (TryParseFloat(len->GetText(), parsed))
+                      truss.lengthMm = parsed;
+                  }
+                if (tinyxml2::XMLElement *wid = info->FirstChildElement("Width"))
+                  if (wid->GetText()) {
+                    float parsed = 0.0f;
+                    if (TryParseFloat(wid->GetText(), parsed))
+                      truss.widthMm = parsed;
+                    else
+                      truss.widthMm = 400.0f;
+                  }
+                if (tinyxml2::XMLElement *hei = info->FirstChildElement("Height"))
+                  if (hei->GetText()) {
+                    float parsed = 0.0f;
+                    if (TryParseFloat(hei->GetText(), parsed))
+                      truss.heightMm = parsed;
+                    else
+                      truss.heightMm = 400.0f;
+                  }
+                if (tinyxml2::XMLElement *wei = info->FirstChildElement("Weight"))
+                  if (wei->GetText()) {
+                    float parsed = 0.0f;
+                    if (TryParseFloat(wei->GetText(), parsed))
+                      truss.weightKg = parsed;
+                  }
+                if (tinyxml2::XMLElement *cs =
+                        info->FirstChildElement("CrossSection"))
+                  if (cs->GetText())
+                    truss.crossSection = Trim(cs->GetText());
+              }
               if (tinyxml2::XMLElement *mf =
                       info->FirstChildElement("ModelFile"))
                 if (mf->GetText())

--- a/tests/mvr_exporter_compliance_test.cpp
+++ b/tests/mvr_exporter_compliance_test.cpp
@@ -214,7 +214,6 @@ int main() {
   bool sawAddress1 = false;
   bool sawAddress1025 = false;
   bool sawAddress2681 = false;
-  bool sawSafeModelFile = false;
   bool sawNonNumericTrussNameFixtureIdConsistency = false;
   int mvrGeometryTrussCount = 0;
   int mvrGeometryTrussesWithGeometry3d = 0;
@@ -307,28 +306,10 @@ int main() {
             assert(gdtfOut.is_open());
             gdtfOut << mvrGeometryEntries.at(trussGdtfSpec);
             gdtfOut.close();
-
             const bool hasRenderableGdtf = GdtfHasRenderable3DModel(trussGdtfPath);
-            assert(!hasRenderableGdtf);
+            assert(hasRenderableGdtf);
             if (hasRenderableGdtf)
               ++mvrGeometryTrussesWithRenderableGdtf;
-
-            auto *userData = cur->FirstChildElement("UserData");
-            assert(userData != nullptr);
-            auto *data = userData->FirstChildElement("Data");
-            assert(data != nullptr);
-            auto *trussInfo = data->FirstChildElement("TrussInfo");
-            assert(trussInfo != nullptr);
-            auto *modelFile = trussInfo->FirstChildElement("ModelFile");
-            assert(modelFile != nullptr);
-            assert(modelFile->GetText() != nullptr);
-
-            const std::string modelFileText = modelFile->GetText();
-            assert(!modelFileText.empty());
-            assert(modelFileText.find(':') == std::string::npos);
-            assert(modelFileText.front() != '/');
-            assert(modelFileText.front() != '\\');
-            sawSafeModelFile = true;
 
             const char *trussUuid = cur->Attribute("uuid");
             if (trussUuid != nullptr && std::string(trussUuid) == trNonNumeric.uuid) {
@@ -360,11 +341,10 @@ int main() {
   assert(sawAddress1);
   assert(sawAddress1025);
   assert(sawAddress2681);
-  assert(sawSafeModelFile);
   assert(sawNonNumericTrussNameFixtureIdConsistency);
   assert(mvrGeometryTrussCount == static_cast<int>(scene.trusses.size()));
   assert(mvrGeometryTrussesWithGeometry3d == mvrGeometryTrussCount);
-  assert(mvrGeometryTrussesWithRenderableGdtf == 0);
+  assert(mvrGeometryTrussesWithRenderableGdtf == mvrGeometryTrussCount);
 
   for (const auto &name : entries) {
     assert(name.rfind("gdtf/", 0) != 0);


### PR DESCRIPTION
### Motivation
- Avoid duplicated truss metadata between GDTF and MVR by making GDTF the authoritative source when available and only emitting per-truss `UserData/TrussInfo` in the MVR as a fallback.  
- Preserve embedded 3D geometry inside truss GDTFs produced/registered during MVR export so the GDTF always contains the model (the MVR can still keep geometry for convenience).  
- Ensure rider/dictionary imports and library migration yield trusses that carry full metadata (manufacturer, model, dims, weight, etc.) coming from the GDTF.  
- Make dictionary entries that point at raw `.glb`/`.3ds` resolve to `.gdtf` archives so library lookups consistently return GDTFs with metadata + geometry.

### Description
- MVR export: changed `mvr/mvrexporter.cpp` so exported truss GDTFs are not stripped of their `models/` content and the MVR `UserData/TrussInfo` block is only written when there is no exported `GDTFSpec` for that truss (avoids metadata duplication).  
- MVR import: updated `mvr/mvrimporter.cpp` so if a truss `GDTFSpec` loads successfully then its parsed metadata takes precedence and `UserData/TrussInfo` fields are only used as fallback, while still reading `ModelFile`/`HangPos`.  
- Truss dictionary migration: extended `core/trussdictionary.cpp` to auto-convert `.glb`/`.3ds` entries into `.gdtf` (via `BuildTrussGdtfFromInstance`) so dictionary lookups resolve to GDTFs with embedded geometry.  
- Rider/dictionary hydration: updated `core/riderimporter.cpp` to apply parsed GDTF/dictionary fields more conservatively and normalize `model` keys, copying manufacturer, model, dimensions, weight and cross-section from parsed definitions when available.  
- Test expectations: adjusted `tests/mvr_exporter_compliance_test.cpp` to expect renderable truss GDTFs in both geometry authority modes and removed assertions that relied on previously-stripped metadata.

Files changed (high-level): `mvr/mvrexporter.cpp`, `mvr/mvrimporter.cpp`, `core/trussdictionary.cpp`, `core/riderimporter.cpp`, `tests/mvr_exporter_compliance_test.cpp`.

Technical note: `mvr/mvrexporter.cpp` is still a hotspot; consider extracting truss export logic into a small helper (selection/building, XML serialization, archive registration) in a follow-up PR.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (`OK: perastage_tree.md keeps module sections and scope note aligned`).  
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (`OK: no direct ConfigManager::Get() usages in gui/`).  
- Attempted to configure a build with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` but configuration failed in this environment due to missing `wxWidgets` development files, so a full build/test run was not possible here.  
- Updated unit test `tests/mvr_exporter_compliance_test.cpp` to reflect the new expectations (renderable GDTFs present for exported trusses) and these test changes are included in the PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993977a5df88324a2af067d3f8625cc)