### PR TITLE
Parent fixture visual meshes under geometry nodes while preserving world transforms

### DIFF
--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -288,16 +288,18 @@ func _reparent_fixture_visual_children(geometry_node: Node3D, model_root: Node3D
 	if model_root is MeshInstance3D:
 		return
 
+	var model_root_local: Transform3D = model_root.transform
 	var moved_any_child: bool = false
 	for child in model_root.get_children():
 		if child is not Node3D:
 			continue
 
 		var child_node: Node3D = child
-		var world_before: Transform3D = child_node.global_transform
+		var child_local_before: Transform3D = child_node.transform
+		var child_local_after: Transform3D = model_root_local * child_local_before
 		model_root.remove_child(child_node)
 		geometry_node.add_child(child_node)
-		child_node.global_transform = world_before
+		child_node.transform = child_local_after
 		moved_any_child = true
 
 	if moved_any_child:

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -276,8 +276,32 @@ func _create_scene_node(data: Dictionary) -> Node3D:
 	var model_node: Node3D = _build_visual_node(data, item_type, item_class, is_fixture, visual_scale_hint)
 	if model_node != null:
 		root.add_child(model_node)
+		if item_type == "fixture_geometry":
+			_reparent_fixture_visual_children(root, model_node)
 
 	return root
+
+func _reparent_fixture_visual_children(geometry_node: Node3D, model_root: Node3D) -> void:
+	if geometry_node == null or model_root == null:
+		return
+
+	if model_root is MeshInstance3D:
+		return
+
+	var moved_any_child: bool = false
+	for child in model_root.get_children():
+		if child is not Node3D:
+			continue
+
+		var child_node: Node3D = child
+		var world_before: Transform3D = child_node.global_transform
+		model_root.remove_child(child_node)
+		geometry_node.add_child(child_node)
+		child_node.global_transform = world_before
+		moved_any_child = true
+
+	if moved_any_child:
+		model_root.queue_free()
 
 func _build_visual_node(data: Dictionary, item_type: String, item_class: String, is_fixture: bool, visual_scale_hint: float) -> Node3D:
 	var asset_path: String = str(data.get("asset_path", ""))


### PR DESCRIPTION
### Motivation
- The final fixture visual node is instantiated in `_create_scene_node` (after `_build_visual_node`) and was being left under an intermediate model root instead of the logical Geometry node, causing a flat root in the scene graph.  
- Reparenting the imported visual children into the corresponding `fixture_geometry` node preserves intended hierarchy and makes axis/emitter anchors and downstream logic operate on the canonical geometry node.

### Description
- Call `_reparent_fixture_visual_children(root, model_node)` in `_create_scene_node` for items of type `fixture_geometry` so visuals are moved into the Geometry Node after the model is added.  
- Add helper function `func _reparent_fixture_visual_children(geometry_node: Node3D, model_root: Node3D)` which iterates `model_root` children, captures each child's `global_transform` before detach, reattaches the child under the geometry node, and restores `global_transform` to avoid visual jumps.  
- The helper guards the common simple case by skipping reparenting when `model_root` is already a `MeshInstance3D`, and when any children were moved it frees the now-empty `model_root` container.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it returned `OK`.  
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it returned `OK`.  
- Attempted baseline visual validation but could not run Godot (`godot`/`godot4` not available in this environment), so per-run visual baseline comparison (`peraviz_debug_baseline`) was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69939c0301a08324a98d846672c2a8dd)