### PR TITLE
Peraviz: drive fixture emitters from manual dimmer using GDTF beam photometrics

### DIFF
--- a/peraviz/native/src/gdtf_scene_builder.cpp
+++ b/peraviz/native/src/gdtf_scene_builder.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdlib>
 #include <filesystem>
 #include <functional>
 #include <unordered_map>
@@ -127,6 +128,25 @@ std::string safe_name(tinyxml2::XMLElement *node, const std::string &fallback) {
     return fallback;
 }
 
+bool parse_float_attr(tinyxml2::XMLElement *node, const char *name,
+                      const char *alt_name, float &out_value) {
+    const char *raw = node->Attribute(name);
+    if (!raw && alt_name) {
+        raw = node->Attribute(alt_name);
+    }
+    if (!raw) {
+        return false;
+    }
+
+    char *end = nullptr;
+    const float parsed = std::strtof(raw, &end);
+    if (end == raw) {
+        return false;
+    }
+    out_value = parsed;
+    return true;
+}
+
 } // namespace
 
 namespace peraviz {
@@ -160,6 +180,7 @@ std::vector<SceneNode> build_fixture_geometry_nodes(const GdtfBuildRequest &requ
     }
 
     std::unordered_map<std::string, std::string> model_file_by_name;
+    std::unordered_map<std::string, float> emitter_wavelength_by_name;
     if (tinyxml2::XMLElement *models = fixture_type->FirstChildElement("Models")) {
         for (tinyxml2::XMLElement *model = models->FirstChildElement(); model;
              model = model->NextSiblingElement()) {
@@ -175,6 +196,27 @@ std::vector<SceneNode> build_fixture_geometry_nodes(const GdtfBuildRequest &requ
                 continue;
             }
             model_file_by_name[name] = file;
+        }
+    }
+
+    if (tinyxml2::XMLElement *physical_descriptions = fixture_type->FirstChildElement("PhysicalDescriptions")) {
+        if (tinyxml2::XMLElement *emitters = physical_descriptions->FirstChildElement("Emitters")) {
+            for (tinyxml2::XMLElement *emitter = emitters->FirstChildElement("Emitter"); emitter;
+                 emitter = emitter->NextSiblingElement("Emitter")) {
+                const char *emitter_name = emitter->Attribute("Name");
+                if (!emitter_name) {
+                    emitter_name = emitter->Attribute("name");
+                }
+                if (!emitter_name) {
+                    continue;
+                }
+
+                float dominant_wavelength = 0.0F;
+                if (parse_float_attr(emitter, "DominantWaveLength", "dominantwavelength",
+                                     dominant_wavelength)) {
+                    emitter_wavelength_by_name[emitter_name] = dominant_wavelength;
+                }
+            }
         }
     }
 
@@ -283,6 +325,31 @@ std::vector<SceneNode> build_fixture_geometry_nodes(const GdtfBuildRequest &requ
         node.is_axis = looks_like_axis(geometry->Name(), geometry_name);
         node.is_emitter = looks_like_emitter(geometry->Name(), geometry_name);
         node.local_transform = peraviz::coordinate_mapper::to_godot_transform(local);
+
+        if (geometry_tag == "Beam") {
+            node.has_luminous_flux = parse_float_attr(geometry, "LuminousFlux", "luminousflux",
+                                                      node.luminous_flux);
+            node.has_color_temperature = parse_float_attr(
+                geometry, "ColorTemperature", "colortemperature", node.color_temperature);
+            node.has_beam_angle = parse_float_attr(geometry, "BeamAngle", "beamangle",
+                                                   node.beam_angle);
+            node.has_field_angle = parse_float_attr(geometry, "FieldAngle", "fieldangle",
+                                                    node.field_angle);
+            node.has_beam_radius = parse_float_attr(geometry, "BeamRadius", "beamradius",
+                                                    node.beam_radius);
+
+            const char *emitter_spectrum = geometry->Attribute("EmitterSpectrum");
+            if (!emitter_spectrum) {
+                emitter_spectrum = geometry->Attribute("emitterspectrum");
+            }
+            if (emitter_spectrum) {
+                auto emitter_it = emitter_wavelength_by_name.find(emitter_spectrum);
+                if (emitter_it != emitter_wavelength_by_name.end()) {
+                    node.has_dominant_wavelength = true;
+                    node.dominant_wavelength = emitter_it->second;
+                }
+            }
+        }
 
         if (node.is_emitter) {
             peraviz::debug_runtime::log_coordinate_debug_event(

--- a/peraviz/native/src/peraviz_loader.cpp
+++ b/peraviz/native/src/peraviz_loader.cpp
@@ -48,6 +48,18 @@ Array PeravizLoader::load_mvr(const String &path, bool peraviz_debug_baseline,
         d["is_fixture"] = node.is_fixture;
         d["is_axis"] = node.is_axis;
         d["is_emitter"] = node.is_emitter;
+        d["has_luminous_flux"] = node.has_luminous_flux;
+        d["luminous_flux"] = node.luminous_flux;
+        d["has_color_temperature"] = node.has_color_temperature;
+        d["color_temperature"] = node.color_temperature;
+        d["has_beam_angle"] = node.has_beam_angle;
+        d["beam_angle"] = node.beam_angle;
+        d["has_field_angle"] = node.has_field_angle;
+        d["field_angle"] = node.field_angle;
+        d["has_beam_radius"] = node.has_beam_radius;
+        d["beam_radius"] = node.beam_radius;
+        d["has_dominant_wavelength"] = node.has_dominant_wavelength;
+        d["dominant_wavelength"] = node.dominant_wavelength;
         d["pos"] = Vector3(node.local_transform.position.x, node.local_transform.position.y,
                             node.local_transform.position.z);
         d["rot"] = Vector3(node.local_transform.rotation_degrees.x,

--- a/peraviz/native/src/scene_model.h
+++ b/peraviz/native/src/scene_model.h
@@ -33,6 +33,24 @@ struct SceneNode {
     bool is_fixture = false;
     bool is_axis = false;
     bool is_emitter = false;
+
+    bool has_luminous_flux = false;
+    float luminous_flux = 10000.0F;
+
+    bool has_color_temperature = false;
+    float color_temperature = 6000.0F;
+
+    bool has_beam_angle = false;
+    float beam_angle = 25.0F;
+
+    bool has_field_angle = false;
+    float field_angle = 25.0F;
+
+    bool has_beam_radius = false;
+    float beam_radius = 0.05F;
+
+    bool has_dominant_wavelength = false;
+    float dominant_wavelength = 0.0F;
 };
 
 struct SceneModel {

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -1015,7 +1015,6 @@ func _find_or_create_emitter_light(emitter_node: Node3D) -> SpotLight3D:
 	light.rotation_degrees = Vector3.ZERO
 	light.light_negative = false
 	light.shadow_enabled = true
-	light.omni_range = 20.0
 	light.spot_range = 20.0
 	light.spot_angle = 25.0
 	light.spot_attenuation = 1.0

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -37,6 +37,8 @@ var _manual_fixture_test_enabled: bool = false
 var _selected_fixture_uuid: String = ""
 var _fixture_manual_values: Dictionary = {}
 var _fixture_emissive_cache: Dictionary = {}
+var _fixture_emitter_light_cache: Dictionary = {}
+var _fixture_emitter_photometrics: Dictionary = {}
 var _updating_fixture_controls: bool = false
 
 const DEBUG_TOGGLE_KEY: Key = KEY_C
@@ -44,7 +46,16 @@ const MANUAL_TEST_FLAG: String = "--peraviz_manual_fixture_test"
 const MANUAL_DEFAULTS := {
 	"pan": 0.0,
 	"tilt": 0.0,
-	"dimmer": 1.0,
+	"dimmer": 100.0,
+}
+
+const DEFAULT_EMITTER_PHOTOMETRICS := {
+	"luminous_flux": 10000.0,
+	"color_temperature": 6000.0,
+	"beam_angle": 25.0,
+	"field_angle": 25.0,
+	"beam_radius": 0.05,
+	"dominant_wavelength": 0.0,
 }
 
 func _ready() -> void:
@@ -558,6 +569,8 @@ func _clear_scene() -> void:
 	_node_index.clear()
 	_asset_cache.clear()
 	_fixture_emissive_cache.clear()
+	_fixture_emitter_light_cache.clear()
+	_fixture_emitter_photometrics.clear()
 	_has_loaded_bounds = false
 	_clear_debug_gizmos()
 
@@ -617,6 +630,10 @@ func _register_fixture_registry(nodes: Array) -> void:
 			var geometry_nodes: Array = anchors.get("geometry_nodes", [])
 			geometry_nodes.append(node)
 			anchors["geometry_nodes"] = geometry_nodes
+			if bool(item.get("is_emitter", false)):
+				var photometric_entries: Array = anchors.get("emitter_photometrics", [])
+				photometric_entries.append(_extract_emitter_photometrics(item))
+				anchors["emitter_photometrics"] = photometric_entries
 
 	for fixture_uuid in fixture_anchors.keys():
 		var fixture_node: Node3D = _node_index.get(fixture_uuid)
@@ -938,17 +955,29 @@ func _find_axis_for_role(axis_nodes: Array, role: String) -> Node3D:
 
 func _apply_dimmer_feedback_to_fixture(fixture_uuid: String, dimmer: float) -> void:
 	var geometry_nodes: Array = _to_node3d_array(_scene_registry.get_anchor(fixture_uuid, "geometry_nodes"))
-	if geometry_nodes.is_empty():
-		return
-	var emissive_materials: Array = _collect_fixture_emissive_materials(fixture_uuid, geometry_nodes)
-	if emissive_materials.is_empty():
+	var emitter_nodes: Array = _to_node3d_array(_scene_registry.get_anchor(fixture_uuid, "emitters"))
+	if geometry_nodes.is_empty() and emitter_nodes.is_empty():
 		return
 
-	var energy_multiplier: float = lerp(0.05, 4.0, clamp(dimmer, 0.0, 1.0))
+	var dimmer_percent: float = clamp(dimmer, 0.0, 100.0)
+	var normalized_dimmer: float = dimmer_percent / 100.0
+	var emissive_materials: Array = _collect_fixture_emissive_materials(fixture_uuid, geometry_nodes)
+	var energy_multiplier: float = lerp(0.0, 4.0, normalized_dimmer)
 	for material in emissive_materials:
 		if material is BaseMaterial3D:
 			material.emission_enabled = true
 			material.emission_energy_multiplier = energy_multiplier
+
+	var emitter_lights: Array = _collect_fixture_emitter_lights(fixture_uuid, emitter_nodes)
+	var emitter_photometrics: Array = _get_fixture_emitter_photometrics(fixture_uuid)
+	for index in range(emitter_lights.size()):
+		var light: SpotLight3D = emitter_lights[index]
+		if light == null or not is_instance_valid(light):
+			continue
+		var photometric: Dictionary = DEFAULT_EMITTER_PHOTOMETRICS.duplicate(true)
+		if index < emitter_photometrics.size() and emitter_photometrics[index] is Dictionary:
+			photometric.merge(emitter_photometrics[index], true)
+		_apply_emitter_light_state(light, photometric, normalized_dimmer)
 
 func _collect_fixture_emissive_materials(fixture_uuid: String, geometry_nodes: Array) -> Array:
 	if _fixture_emissive_cache.has(fixture_uuid):
@@ -959,6 +988,134 @@ func _collect_fixture_emissive_materials(fixture_uuid: String, geometry_nodes: A
 		_collect_emissive_materials_recursive(geometry, materials)
 	_fixture_emissive_cache[fixture_uuid] = materials
 	return materials
+
+func _collect_fixture_emitter_lights(fixture_uuid: String, emitter_nodes: Array) -> Array:
+	if _fixture_emitter_light_cache.has(fixture_uuid):
+		return _fixture_emitter_light_cache.get(fixture_uuid, [])
+
+	var lights: Array = []
+	for emitter_node in emitter_nodes:
+		if emitter_node == null:
+			continue
+		var light: SpotLight3D = _find_or_create_emitter_light(emitter_node)
+		if light != null:
+			lights.append(light)
+
+	_fixture_emitter_light_cache[fixture_uuid] = lights
+	return lights
+
+func _find_or_create_emitter_light(emitter_node: Node3D) -> SpotLight3D:
+	for child in emitter_node.get_children():
+		if child is SpotLight3D and child.name == "PeravizEmitterLight":
+			return child
+
+	var light := SpotLight3D.new()
+	light.name = "PeravizEmitterLight"
+	light.position = Vector3.ZERO
+	light.rotation_degrees = Vector3.ZERO
+	light.light_negative = false
+	light.shadow_enabled = true
+	light.omni_range = 20.0
+	light.spot_range = 20.0
+	light.spot_angle = 25.0
+	light.spot_attenuation = 1.0
+	emitter_node.add_child(light)
+	return light
+
+func _get_fixture_emitter_photometrics(fixture_uuid: String) -> Array:
+	if _fixture_emitter_photometrics.has(fixture_uuid):
+		return _fixture_emitter_photometrics.get(fixture_uuid, [])
+	var entries: Variant = _scene_registry.get_anchor(fixture_uuid, "emitter_photometrics")
+	if entries is Array:
+		_fixture_emitter_photometrics[fixture_uuid] = entries
+		return entries
+	var empty: Array = []
+	_fixture_emitter_photometrics[fixture_uuid] = empty
+	return empty
+
+func _extract_emitter_photometrics(item: Dictionary) -> Dictionary:
+	var data: Dictionary = DEFAULT_EMITTER_PHOTOMETRICS.duplicate(true)
+	if bool(item.get("has_luminous_flux", false)):
+		data["luminous_flux"] = float(item.get("luminous_flux", data["luminous_flux"]))
+	if bool(item.get("has_color_temperature", false)):
+		data["color_temperature"] = float(item.get("color_temperature", data["color_temperature"]))
+	if bool(item.get("has_beam_angle", false)):
+		data["beam_angle"] = float(item.get("beam_angle", data["beam_angle"]))
+	if bool(item.get("has_field_angle", false)):
+		data["field_angle"] = float(item.get("field_angle", data["field_angle"]))
+	if bool(item.get("has_beam_radius", false)):
+		data["beam_radius"] = float(item.get("beam_radius", data["beam_radius"]))
+	if bool(item.get("has_dominant_wavelength", false)):
+		data["dominant_wavelength"] = float(item.get("dominant_wavelength", 0.0))
+	return data
+
+func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, normalized_dimmer: float) -> void:
+	var luminous_flux: float = max(float(photometric.get("luminous_flux", 10000.0)), 0.0)
+	var beam_angle: float = clamp(float(photometric.get("beam_angle", 25.0)), 0.1, 179.0)
+	var field_angle: float = clamp(float(photometric.get("field_angle", beam_angle)), beam_angle, 179.0)
+	var beam_radius_m: float = max(float(photometric.get("beam_radius", 0.05)), 0.001)
+
+	light.visible = normalized_dimmer > 0.0001
+	light.light_energy = luminous_flux * normalized_dimmer
+	light.spot_angle = beam_angle
+	light.spot_attenuation = clamp(beam_angle / field_angle, 0.2, 1.0)
+	light.spot_range = clamp(beam_radius_m * 400.0, 0.5, 60.0)
+	light.light_color = _derive_emitter_color(photometric)
+
+func _derive_emitter_color(photometric: Dictionary) -> Color:
+	var wavelength: float = float(photometric.get("dominant_wavelength", 0.0))
+	if wavelength > 0.0:
+		return _wavelength_to_rgb(wavelength)
+	var temperature_kelvin: float = clamp(float(photometric.get("color_temperature", 6000.0)), 1000.0, 40000.0)
+	return _color_temperature_to_rgb(temperature_kelvin)
+
+func _color_temperature_to_rgb(temperature_kelvin: float) -> Color:
+	var t: float = temperature_kelvin / 100.0
+	var red: float
+	var green: float
+	var blue: float
+	if t <= 66.0:
+		red = 255.0
+		green = 99.4708025861 * log(t) - 161.1195681661
+		if t <= 19.0:
+			blue = 0.0
+		else:
+			blue = 138.5177312231 * log(t - 10.0) - 305.0447927307
+	else:
+		red = 329.698727446 * pow(t - 60.0, -0.1332047592)
+		green = 288.1221695283 * pow(t - 60.0, -0.0755148492)
+		blue = 255.0
+	return Color(clamp(red / 255.0, 0.0, 1.0), clamp(green / 255.0, 0.0, 1.0), clamp(blue / 255.0, 0.0, 1.0))
+
+func _wavelength_to_rgb(wavelength_nm: float) -> Color:
+	var wavelength: float = clamp(wavelength_nm, 380.0, 780.0)
+	var red: float = 0.0
+	var green: float = 0.0
+	var blue: float = 0.0
+	if wavelength < 440.0:
+		red = -(wavelength - 440.0) / (440.0 - 380.0)
+		blue = 1.0
+	elif wavelength < 490.0:
+		green = (wavelength - 440.0) / (490.0 - 440.0)
+		blue = 1.0
+	elif wavelength < 510.0:
+		green = 1.0
+		blue = -(wavelength - 510.0) / (510.0 - 490.0)
+	elif wavelength < 580.0:
+		red = (wavelength - 510.0) / (580.0 - 510.0)
+		green = 1.0
+	elif wavelength < 645.0:
+		red = 1.0
+		green = -(wavelength - 645.0) / (645.0 - 580.0)
+	else:
+		red = 1.0
+
+	var factor: float = 1.0
+	if wavelength < 420.0:
+		factor = 0.3 + 0.7 * ((wavelength - 380.0) / (420.0 - 380.0))
+	elif wavelength > 700.0:
+		factor = 0.3 + 0.7 * ((780.0 - wavelength) / (780.0 - 700.0))
+	return Color(clamp(red * factor, 0.0, 1.0), clamp(green * factor, 0.0, 1.0), clamp(blue * factor, 0.0, 1.0))
 
 func _collect_emissive_materials_recursive(node: Node3D, output_materials: Array) -> void:
 	if node == null:

--- a/peraviz/test.tscn
+++ b/peraviz/test.tscn
@@ -128,23 +128,23 @@ suffix = "°"
 [node name="DimmerMin" type="SpinBox" parent="HUD/FixtureDebugPanel/Margin/VBox/LimitsGrid"]
 custom_minimum_size = Vector2(80, 0)
 min_value = 0.0
-max_value = 1.0
+max_value = 100.0
 value = 0.0
-step = 0.01
+step = 1.0
 
 [node name="DimmerMax" type="SpinBox" parent="HUD/FixtureDebugPanel/Margin/VBox/LimitsGrid"]
 custom_minimum_size = Vector2(80, 0)
 min_value = 0.0
-max_value = 1.0
-value = 1.0
-step = 0.01
+max_value = 100.0
+value = 100.0
+step = 1.0
 
 [node name="DimmerValue" type="SpinBox" parent="HUD/FixtureDebugPanel/Margin/VBox/LimitsGrid"]
 custom_minimum_size = Vector2(80, 0)
 min_value = 0.0
-max_value = 1.0
-value = 1.0
-step = 0.01
+max_value = 100.0
+value = 100.0
+step = 1.0
 
 [node name="PanSlider" type="HSlider" parent="HUD/FixtureDebugPanel/Margin/VBox"]
 min_value = -270.0
@@ -158,9 +158,9 @@ value = 0.0
 
 [node name="DimmerSlider" type="HSlider" parent="HUD/FixtureDebugPanel/Margin/VBox"]
 min_value = 0.0
-max_value = 1.0
-value = 1.0
-step = 0.01
+max_value = 100.0
+value = 100.0
+step = 1.0
 
 [node name="QuickResetButton" type="Button" parent="HUD/FixtureDebugPanel/Margin/VBox"]
 text = "Reset Pan/Tilt/Dimmer"


### PR DESCRIPTION
### Motivation
- The manual fixture dimmer in Peraviz test mode had no visible lighting effect when meshes lacked emissive materials, so the fixture lens/beam needs to act as a real light emitter driven by the dimmer.
- When available, use the GDTF beam/emitter photometric fields (luminous flux, wavelength, color temperature, beam angles, radius) as the authoritative source and fall back to sensible defaults otherwise.

### Description
- Native: extended `SceneNode` with photometric fields (`LuminousFlux`, `ColorTemperature`, `BeamAngle`, `FieldAngle`, `BeamRadius`, `DominantWaveLength`) and added parsing in `gdtf_scene_builder.cpp` (including `PhysicalDescriptions/Emitters` parsing and `parse_float_attr` helper) to populate them.
- Native: exposed the new photometric fields in `PeravizLoader::load_mvr` dictionary so runtime GDScript can read them from nodes.
- GDScript: changed manual dimmer controls to operate 0–100 (percentage) and normalize to 0..1 for output, updated `peraviz/test.tscn` slider/spinbox ranges and defaults accordingly.
- GDScript: added caching and runtime emitter support that creates/uses a `SpotLight3D` per emitter anchor, applies photometrics to light state (energy, spot angle, range, attenuation) and derives color from dominant wavelength or color temperature; existing emissive materials are still driven as before.
- GDScript: added helper functions to derive color from wavelength and color temperature and a small photometrics extraction flow with sensible GDTF-aligned defaults.

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which passed OK.
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which passed OK.
- Attempted `cmake -S peraviz/native -B peraviz/native/build -DCMAKE_BUILD_TYPE=Debug`, which failed in the environment due to missing `tinyxml2` development package (this is an external environment limitation, not a code regression).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993a94cc9248324a5c7da5da11b72e2)