### PR TITLE
Prevent rider text import from mutating existing fixtures

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -132,6 +132,15 @@ bool TryParseInt(std::string_view text, int &out) {
   return false;
 }
 
+int ParseTrailingNumber(const std::string &text) {
+  const size_t space = text.find_last_of(' ');
+  if (space == std::string::npos || space + 1 >= text.size())
+    return 0;
+  int parsed = 0;
+  return TryParseInt(std::string_view(text).substr(space + 1), parsed) ? parsed
+                                                                        : 0;
+}
+
 bool IsRenderableTrussGeometry(const std::string &path) {
   if (path.empty())
     return false;
@@ -386,6 +395,7 @@ bool RiderImporter::ImportText(const std::string &text) {
   typeOrder.reserve(16);
   std::unordered_set<std::string> seenTypes;
   std::vector<std::string> importedTrussUuids;
+  std::vector<std::string> importedFixtureUuids;
   int pendingQuantity = 0;
   bool havePending = false;
 
@@ -430,6 +440,7 @@ bool RiderImporter::ImportText(const std::string &text) {
         f.transform.o[1] = getHangPos(currentHang);
         f.transform.o[2] = getHangHeight(currentHang);
         scene.fixtures[f.uuid] = f;
+        importedFixtureUuids.push_back(f.uuid);
         addToLayer(f.layer, f.uuid);
       }
     }
@@ -871,9 +882,13 @@ bool RiderImporter::ImportText(const std::string &text) {
   }
 
   std::unordered_map<std::string, std::vector<Fixture *>> fixturesByPos;
-  fixturesByPos.reserve(scene.fixtures.size());
-  for (auto &[uuid, f] : scene.fixtures)
-    fixturesByPos[f.positionName].push_back(&f);
+  fixturesByPos.reserve(importedFixtureUuids.size());
+  for (const std::string &uuid : importedFixtureUuids) {
+    auto fixtureIt = scene.fixtures.find(uuid);
+    if (fixtureIt == scene.fixtures.end())
+      continue;
+    fixturesByPos[fixtureIt->second.positionName].push_back(&fixtureIt->second);
+  }
 
   for (auto &[pos, fixturesVec] : fixturesByPos) {
     if (fixturesVec.empty())
@@ -955,12 +970,34 @@ bool RiderImporter::ImportText(const std::string &text) {
     }
   }
 
-  // Assign fixture IDs and instance names grouped by type, ordering fixtures
-  // from left to right within each hang position and front to back across
-  // positions. IDs start at 101, 201, ...
+  // Assign fixture IDs and instance names to imported fixtures only.
+  // Existing fixtures keep their IDs and transforms untouched.
   std::unordered_map<std::string, std::vector<Fixture *>> fixturesByType;
-  for (auto &[uuid, f] : scene.fixtures)
-    fixturesByType[f.typeName].push_back(&f);
+  fixturesByType.reserve(typeOrder.size());
+  for (const std::string &uuid : importedFixtureUuids) {
+    auto fixtureIt = scene.fixtures.find(uuid);
+    if (fixtureIt == scene.fixtures.end())
+      continue;
+    fixturesByType[fixtureIt->second.typeName].push_back(&fixtureIt->second);
+  }
+
+  std::unordered_set<std::string> importedFixtureIdSet(importedFixtureUuids.begin(),
+                                                       importedFixtureUuids.end());
+  int highestExistingFixtureId = 100;
+  std::unordered_map<std::string, int> nextUnitByType;
+  for (const auto &[uuid, fixture] : scene.fixtures) {
+    if (importedFixtureIdSet.count(uuid) != 0)
+      continue;
+    highestExistingFixtureId = std::max(highestExistingFixtureId, fixture.fixtureId);
+
+    int nextUnit = fixture.unitNumber;
+    if (nextUnit <= 0)
+      nextUnit = ParseTrailingNumber(fixture.instanceName);
+    if (nextUnit > 0) {
+      int &tracked = nextUnitByType[fixture.typeName];
+      tracked = std::max(tracked, nextUnit);
+    }
+  }
 
   auto baseName = [](const std::string &name) {
     size_t space = name.find_last_of(' ');
@@ -976,7 +1013,7 @@ bool RiderImporter::ImportText(const std::string &text) {
     return numeric ? name.substr(0, space) : name;
   };
 
-  int baseId = 101;
+  int baseId = ((highestExistingFixtureId + 99) / 100) * 100 + 1;
   for (const std::string &type : typeOrder) {
     auto it = fixturesByType.find(type);
     if (it == fixturesByType.end())
@@ -988,10 +1025,12 @@ bool RiderImporter::ImportText(const std::string &text) {
       return a->transform.o[1] < b->transform.o[1];
     });
     std::string prefix = vec.empty() ? type : baseName(vec.front()->instanceName);
+    int nextUnitNumber = nextUnitByType[type] + 1;
     for (size_t i = 0; i < vec.size(); ++i) {
       vec[i]->fixtureId = baseId + static_cast<int>(i);
-      vec[i]->unitNumber = static_cast<int>(i) + 1;
-      vec[i]->instanceName = prefix + " " + std::to_string(i + 1);
+      vec[i]->unitNumber = nextUnitNumber + static_cast<int>(i);
+      vec[i]->instanceName =
+          prefix + " " + std::to_string(nextUnitNumber + static_cast<int>(i));
     }
     baseId =
         ((baseId - 1 + static_cast<int>(vec.size()) + 99) / 100) * 100 + 1;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -308,6 +308,29 @@ add_test(NAME RiderImportOrder COMMAND rider_import_order_test
          ${CMAKE_CURRENT_SOURCE_DIR}/data/rider_fixture_order.txt)
 set_library_env(RiderImportOrder)
 
+add_executable(rider_import_preserve_existing_test rider_import_preserve_existing_test.cpp
+               riderimporter_stubs.cpp
+               gdtfloader_stub.cpp
+               ../core/riderimporter.cpp
+               ../core/uuidutils.cpp
+               ../core/autopatcher.cpp
+               ../core/patchmanager.cpp
+               ../core/configmanager.cpp
+               ../core/configservices.cpp
+               ../core/projectutils.cpp
+               ../core/logger.cpp
+               ../models/mvrscene.cpp
+               ../models/fixture.cpp
+               ../models/truss.cpp
+               ../models/sceneobject.cpp
+               ../models/layer.cpp
+               ${LAYOUT_SOURCES})
+target_include_directories(rider_import_preserve_existing_test PRIVATE
+                           . ../core ../models ../mvr ../gui ../third_party)
+target_link_libraries(rider_import_preserve_existing_test PRIVATE ${wxWidgets_LIBRARIES})
+add_test(NAME RiderImportPreserveExisting COMMAND rider_import_preserve_existing_test)
+set_library_env(RiderImportPreserveExisting)
+
 add_executable(rider_autopatch_test rider_autopatch_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_onech_stub.cpp

--- a/tests/rider_import_preserve_existing_test.cpp
+++ b/tests/rider_import_preserve_existing_test.cpp
@@ -1,0 +1,55 @@
+#include <cassert>
+#include <string>
+#include <wx/init.h>
+
+#include "configmanager.h"
+#include "fixture.h"
+#include "riderimporter.h"
+
+int main() {
+  wxInitializer initializer;
+  assert(initializer.IsOk());
+
+  auto &cfg = ConfigManager::Get();
+  cfg.Reset();
+
+  Fixture existing;
+  existing.uuid = "existing-fixture";
+  existing.typeName = "ExistingType";
+  existing.instanceName = "ExistingType 7";
+  existing.positionName = "LX1";
+  existing.fixtureId = 507;
+  existing.unitNumber = 7;
+  existing.transform.o[0] = 1234.0f;
+  existing.transform.o[1] = 5678.0f;
+  existing.transform.o[2] = 910.0f;
+  cfg.GetScene().fixtures.emplace(existing.uuid, existing);
+
+  const std::string riderText = "ilumin\n"
+                                "LX1\n"
+                                "2 Spot\n";
+  assert(RiderImporter::ImportText(riderText));
+
+  const auto &scene = cfg.GetScene();
+  auto existingIt = scene.fixtures.find(existing.uuid);
+  assert(existingIt != scene.fixtures.end());
+
+  const Fixture &preserved = existingIt->second;
+  assert(preserved.fixtureId == 507);
+  assert(preserved.unitNumber == 7);
+  assert(preserved.instanceName == "ExistingType 7");
+  assert(preserved.transform.o[0] == 1234.0f);
+  assert(preserved.transform.o[1] == 5678.0f);
+  assert(preserved.transform.o[2] == 910.0f);
+
+  int importedCount = 0;
+  for (const auto &[uuid, fixture] : scene.fixtures) {
+    if (uuid == existing.uuid)
+      continue;
+    ++importedCount;
+    assert(fixture.fixtureId >= 601);
+  }
+  assert(importedCount == 2);
+
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- Importing fixtures from rider text was reassigning positions/IDs of fixtures already present in the scene, causing unexpected shifts in existing data. The intent is to make text imports additive and non-destructive to pre-existing fixtures.

### Description
- Limit placement and renumbering logic to fixtures created during the current import by tracking `importedFixtureUuids` and using those when distributing positions and assigning IDs in `RiderImporter::ImportText` (`core/riderimporter.cpp`).
- Preserve transforms, `fixtureId`, `unitNumber` and `instanceName` for fixtures that already existed before the import by computing `highestExistingFixtureId` and per-type next unit numbers and starting imported blocks after existing IDs. (`core/riderimporter.cpp`).
- Add helper `ParseTrailingNumber` to extract numeric suffixes from existing instance names to continue per-type numbering when `unitNumber` is not set. (`core/riderimporter.cpp`).
- Add a regression test `rider_import_preserve_existing_test` which seeds an existing fixture, runs `RiderImporter::ImportText`, and asserts the existing fixture remains unchanged while imported fixtures receive IDs after the existing block. (`tests/rider_import_preserve_existing_test.cpp`).
- Register the new test in `tests/CMakeLists.txt` so it runs as part of the rider importer test suite.

### Testing
- Ran repository checks: `tests/check_perastage_tree_modules.sh` succeeded. 
- Ran GUI rule check: `tests/check_no_configmanager_get_in_gui.sh` succeeded. 
- Attempted to configure/build and run the new/related tests via CMake/CTest, but CMake configuration failed in this environment due to missing development packages for wxWidgets (missing `wxWidgets_LIBRARIES` and `wxWidgets_INCLUDE_DIRS`), so full test execution could not be completed here. All changes are covered by the added unit test `rider_import_preserve_existing_test` and the existing rider importer tests in `tests/` (registered in `tests/CMakeLists.txt`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699446d44db88324b16027ae56ce9d53)