### PR TITLE
Simplify project persistence for layer visibility checks

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -29,6 +29,35 @@
 #include <algorithm>
 #include <wx/stdpaths.h>
 
+
+namespace {
+constexpr const char *kHiddenLayersConfigKey = "view_hidden_layers";
+
+std::string SerializeHiddenLayerChecks(
+    const std::unordered_set<std::string> &hiddenLayers) {
+  std::vector<std::string> sorted(hiddenLayers.begin(), hiddenLayers.end());
+  std::sort(sorted.begin(), sorted.end());
+  return nlohmann::json(sorted).dump();
+}
+
+std::unordered_set<std::string>
+DeserializeHiddenLayerChecks(const std::optional<std::string> &serialized) {
+  std::unordered_set<std::string> hiddenLayers;
+  if (!serialized || serialized->empty())
+    return hiddenLayers;
+
+  nlohmann::json parsed = nlohmann::json::parse(*serialized, nullptr, false);
+  if (!parsed.is_array())
+    return hiddenLayers;
+
+  for (const auto &entry : parsed) {
+    if (entry.is_string())
+      hiddenLayers.insert(entry.get<std::string>());
+  }
+  return hiddenLayers;
+}
+} // namespace
+
 ConfigManager::RevisionGuard::RevisionGuard(ConfigManager &cfg)
     : cfg(cfg), previous(cfg.suppressRevision) {
   cfg.suppressRevision = true;
@@ -343,6 +372,8 @@ bool ConfigManager::SaveToFile(const std::string &path) const {
 
 bool ConfigManager::SaveProject(const std::string &path) {
   layouts::LayoutManager::Get().SaveToConfig(*this);
+  SetValue(kHiddenLayersConfigKey,
+           SerializeHiddenLayerChecks(layerVisibilityState.GetHiddenLayers()));
   bool ok = projectSession.SaveProject(
       path, [this](const std::string &configPath) {
         return SaveToFile(configPath);
@@ -376,6 +407,8 @@ bool ConfigManager::LoadProject(const std::string &path) {
       });
 
   if (ok) {
+    layerVisibilityState.SetHiddenLayers(
+        DeserializeHiddenLayerChecks(GetValue(kHiddenLayersConfigKey)));
     restoreUserPreferences();
     ClearHistory();
     selectionState.Clear();


### PR DESCRIPTION
### Motivation
- Persist the per-project layout visibility "checks" (hidden layers) so viewers restore the same visibility when reopening a project and fall back to showing everything on error. 
- Keep `LayerVisibilityState` focused on runtime visibility responsibilities and avoid expanding its API for project-specific persistence. 
- Follow reviewer feedback to keep persistence logic local to the project save/load flow and provide a tolerant restore path for older/malformed projects. 

### Description
- Added JSON helpers `SerializeHiddenLayerChecks()` and `DeserializeHiddenLayerChecks()` in an anonymous namespace inside `core/configmanager.cpp` to encode/decode the hidden-layer set as a stable JSON array under the key `"view_hidden_layers"`. 
- `SaveProject()` now writes `layerVisibilityState.GetHiddenLayers()` via `SerializeHiddenLayerChecks()` into the project config. 
- `LoadProject()` now restores hidden layers with `DeserializeHiddenLayerChecks(GetValue(kHiddenLayersConfigKey))` and sets the visibility state, with tolerant parsing that yields an empty hidden set on missing/invalid data (resulting in all layers visible). 
- Removed the previously added `SerializeHiddenLayers()`/`DeserializeHiddenLayers()` methods from `LayerVisibilityState` (`core/configservices.h` / `core/configservices.cpp`) and simplified the `LayerVisibilityState` unit test to keep the test focused on runtime behavior rather than project persistence. 

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which succeeded. 
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which succeeded. 
- Full CMake/CTest unit-test build was not executed in this environment due to missing `wxWidgets` development dependencies, so integration/build tests could not be run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69944b423c888324b9595ab236d0fee5)