### PR TITLE
Add DMX monitor window and DMX signal indicator

### DIFF
--- a/peraviz/scripts/dmx_monitor_window.gd
+++ b/peraviz/scripts/dmx_monitor_window.gd
@@ -1,0 +1,153 @@
+extends Window
+
+class_name DmxMonitorWindow
+
+const CHANNEL_COUNT: int = 512
+
+var _receiver = null
+var _selected_universe: int = -1
+var _universe_buttons: Dictionary = {}
+var _channel_panels: Array[PanelContainer] = []
+var _channel_labels: Array[Label] = []
+
+var _state_label: Label
+var _universes_flow: FlowContainer
+
+func _init() -> void:
+	title = "DMX Monitor"
+	size = Vector2i(1040, 680)
+	unresizable = false
+
+func _ready() -> void:
+	var root: VBoxContainer = VBoxContainer.new()
+	root.set_anchors_preset(Control.PRESET_FULL_RECT)
+	root.offset_left = 12
+	root.offset_top = 12
+	root.offset_right = -12
+	root.offset_bottom = -12
+	add_child(root)
+
+	_state_label = Label.new()
+	_state_label.text = "DMX monitor inactive"
+	root.add_child(_state_label)
+
+	var universe_scroll: ScrollContainer = ScrollContainer.new()
+	universe_scroll.custom_minimum_size = Vector2(0, 100)
+	universe_scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	universe_scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
+	root.add_child(universe_scroll)
+
+	_universes_flow = FlowContainer.new()
+	_universes_flow.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_universes_flow.add_theme_constant_override("h_separation", 6)
+	_universes_flow.add_theme_constant_override("v_separation", 6)
+	universe_scroll.add_child(_universes_flow)
+
+	var channels_scroll: ScrollContainer = ScrollContainer.new()
+	channels_scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	channels_scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	root.add_child(channels_scroll)
+
+	var channels_grid: GridContainer = GridContainer.new()
+	channels_grid.columns = 16
+	channels_grid.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	channels_grid.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	channels_grid.add_theme_constant_override("h_separation", 4)
+	channels_grid.add_theme_constant_override("v_separation", 4)
+	channels_scroll.add_child(channels_grid)
+
+	for channel_idx in range(CHANNEL_COUNT):
+		var panel: PanelContainer = PanelContainer.new()
+		panel.custom_minimum_size = Vector2(58, 24)
+		channels_grid.add_child(panel)
+
+		var label: Label = Label.new()
+		label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+		label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+		label.text = "%03d" % (channel_idx + 1)
+		panel.add_child(label)
+
+		_channel_panels.append(panel)
+		_channel_labels.append(label)
+
+		_update_channel_cell(channel_idx, 0)
+
+func configure(receiver) -> void:
+	_receiver = receiver
+
+func refresh(running: bool) -> void:
+	if _receiver == null:
+		_state_label.text = "DMX unavailable"
+		return
+
+	if not running:
+		_state_label.text = "DMX OFF"
+		_update_universe_buttons([])
+		for channel_idx in range(CHANNEL_COUNT):
+			_update_channel_cell(channel_idx, 0)
+		return
+
+	var active_universes: PackedInt32Array = _receiver.get_active_universes(2000)
+	_update_universe_buttons(active_universes)
+
+	if _selected_universe < 0 and active_universes.size() > 0:
+		_selected_universe = int(active_universes[0])
+
+	var selected_text: String = "none"
+	if _selected_universe >= 0:
+		selected_text = str(_selected_universe)
+	_state_label.text = "Active universes: %d | Selected universe: %s" % [active_universes.size(), selected_text]
+
+	var data: PackedByteArray = PackedByteArray()
+	if _selected_universe >= 0:
+		data = _receiver.get_universe_data(_selected_universe)
+
+	for channel_idx in range(CHANNEL_COUNT):
+		var channel_value: int = 0
+		if channel_idx < data.size():
+			channel_value = int(data[channel_idx])
+		_update_channel_cell(channel_idx, channel_value)
+
+func _update_universe_buttons(active_universes: PackedInt32Array) -> void:
+	var active_map: Dictionary = {}
+	for universe in active_universes:
+		active_map[int(universe)] = true
+
+	for universe_id in _universe_buttons.keys():
+		var button: Button = _universe_buttons[universe_id]
+		var is_active: bool = active_map.has(universe_id)
+		button.modulate = Color(0.35, 1.0, 0.35) if is_active else Color(0.35, 0.35, 0.35)
+		button.button_pressed = (int(universe_id) == _selected_universe)
+
+	for universe in active_universes:
+		var uni_id: int = int(universe)
+		if _universe_buttons.has(uni_id):
+			continue
+		var button: Button = Button.new()
+		button.toggle_mode = true
+		button.text = "U%d" % uni_id
+		button.custom_minimum_size = Vector2(74, 34)
+		button.modulate = Color(0.35, 1.0, 0.35)
+		button.pressed.connect(func() -> void:
+			_selected_universe = uni_id
+			for btn_uni in _universe_buttons.keys():
+				var btn: Button = _universe_buttons[btn_uni]
+				btn.button_pressed = (int(btn_uni) == _selected_universe)
+		)
+		_universe_buttons[uni_id] = button
+		_universes_flow.add_child(button)
+
+func _update_channel_cell(channel_idx: int, channel_value: int) -> void:
+	var normalized: float = clamp(float(channel_value) / 255.0, 0.0, 1.0)
+	var color: Color = Color(0.08, 0.16 + (0.84 * normalized), 0.08)
+
+	var style: StyleBoxFlat = StyleBoxFlat.new()
+	style.bg_color = color
+	style.border_color = Color(0.05, 0.05, 0.05)
+	style.border_width_left = 1
+	style.border_width_right = 1
+	style.border_width_top = 1
+	style.border_width_bottom = 1
+
+	_channel_panels[channel_idx].add_theme_stylebox_override("panel", style)
+	_channel_labels[channel_idx].text = "%03d:%03d" % [channel_idx + 1, channel_value]

--- a/peraviz/scripts/dmx_monitor_window.gd
+++ b/peraviz/scripts/dmx_monitor_window.gd
@@ -19,6 +19,7 @@ func _init() -> void:
 	unresizable = false
 
 func _ready() -> void:
+	close_requested.connect(_on_close_requested)
 	var root: VBoxContainer = VBoxContainer.new()
 	root.set_anchors_preset(Control.PRESET_FULL_RECT)
 	root.offset_left = 12
@@ -151,3 +152,7 @@ func _update_channel_cell(channel_idx: int, channel_value: int) -> void:
 
 	_channel_panels[channel_idx].add_theme_stylebox_override("panel", style)
 	_channel_labels[channel_idx].text = "%03d:%03d" % [channel_idx + 1, channel_value]
+
+
+func _on_close_requested() -> void:
+	hide()

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -44,8 +44,11 @@ var _updating_fixture_controls: bool = false
 
 var _dmx_receiver = null
 var _dmx_toggle_button: Button
-var _dmx_status_label: Label
+var _dmx_monitor_button: Button
+var _dmx_monitor_window: Window
 var _dmx_timer: Timer
+
+const DmxMonitorWindowScript = preload("res://scripts/dmx_monitor_window.gd")
 
 const DEBUG_TOGGLE_KEY: Key = KEY_C
 const MANUAL_TEST_FLAG: String = "--peraviz_manual_fixture_test"
@@ -1496,11 +1499,14 @@ func _setup_dmx_controls() -> void:
 	_dmx_toggle_button.position = Vector2(540, 20)
 	hud_root.add_child(_dmx_toggle_button)
 	_dmx_toggle_button.pressed.connect(_on_dmx_toggle_pressed)
+	_update_dmx_toggle_color(false, false)
 
-	_dmx_status_label = Label.new()
-	_dmx_status_label.position = Vector2(650, 25)
-	_dmx_status_label.text = "DMX: OFF"
-	hud_root.add_child(_dmx_status_label)
+	_dmx_monitor_button = Button.new()
+	_dmx_monitor_button.text = "DMX Monitor"
+	_dmx_monitor_button.position = Vector2(650, 20)
+	_dmx_monitor_button.disabled = true
+	hud_root.add_child(_dmx_monitor_button)
+	_dmx_monitor_button.pressed.connect(_on_dmx_monitor_pressed)
 
 	_dmx_timer = Timer.new()
 	_dmx_timer.wait_time = 0.2
@@ -1510,9 +1516,10 @@ func _setup_dmx_controls() -> void:
 
 	if ClassDB.class_exists("PeravizDmxReceiver"):
 		_dmx_receiver = ClassDB.instantiate("PeravizDmxReceiver")
+		_dmx_monitor_button.disabled = false
 	else:
 		_dmx_toggle_button.disabled = true
-		_dmx_status_label.text = "DMX: unavailable (build without PERAVIZ_ENABLE_DMX)"
+		_dmx_toggle_button.tooltip_text = "DMX unavailable (build without PERAVIZ_ENABLE_DMX)"
 
 func _on_dmx_toggle_pressed() -> void:
 	if _dmx_receiver == null:
@@ -1523,27 +1530,55 @@ func _on_dmx_toggle_pressed() -> void:
 		if not started:
 			_dmx_toggle_button.button_pressed = false
 			_dmx_toggle_button.text = "DMX OFF"
-			_dmx_status_label.text = "DMX: failed to start"
+			_update_dmx_toggle_color(false, false)
+			_dmx_toggle_button.tooltip_text = "DMX failed to start"
 			return
 		_dmx_toggle_button.text = "DMX ON"
+		_dmx_toggle_button.tooltip_text = ""
 	else:
 		_dmx_receiver.stop()
 		_dmx_toggle_button.text = "DMX OFF"
-		_dmx_status_label.text = "DMX: OFF"
+		_update_dmx_toggle_color(false, false)
+		_refresh_dmx_monitor_window(false)
+
+func _on_dmx_monitor_pressed() -> void:
+	if _dmx_receiver == null:
+		return
+	if _dmx_monitor_window == null or not is_instance_valid(_dmx_monitor_window):
+		_dmx_monitor_window = DmxMonitorWindowScript.new()
+		add_child(_dmx_monitor_window)
+		_dmx_monitor_window.configure(_dmx_receiver)
+	_dmx_monitor_window.popup_centered_ratio(0.75)
+	_refresh_dmx_monitor_window(_dmx_receiver.is_running())
 
 func _on_dmx_timer_timeout() -> void:
 	if _dmx_receiver == null:
 		return
 	if not _dmx_receiver.is_running():
 		if _dmx_toggle_button != null and not _dmx_toggle_button.button_pressed:
-			_dmx_status_label.text = "DMX: OFF"
+			_update_dmx_toggle_color(false, false)
+		_refresh_dmx_monitor_window(false)
 		return
 
 	var stats: Dictionary = _dmx_receiver.get_stats()
 	var active_universes: PackedInt32Array = _dmx_receiver.get_active_universes(2000)
-	var pps: int = int(stats.get("packets_per_sec", 0))
 	var last_ms: int = int(stats.get("last_packet_ms_ago", -1))
-	_dmx_status_label.text = "DMX: pps=%d active_universes=%d last=%dms" % [pps, active_universes.size(), last_ms]
+	var receiving: bool = active_universes.size() > 0 and last_ms >= 0 and last_ms <= 2000
+	_update_dmx_toggle_color(true, receiving)
+	_refresh_dmx_monitor_window(true)
+
+func _update_dmx_toggle_color(enabled: bool, receiving_signal: bool) -> void:
+	if _dmx_toggle_button == null:
+		return
+	if not enabled:
+		_dmx_toggle_button.modulate = Color(0.75, 0.75, 0.75)
+		return
+	_dmx_toggle_button.modulate = Color(0.25, 0.95, 0.25) if receiving_signal else Color(0.95, 0.25, 0.25)
+
+func _refresh_dmx_monitor_window(running: bool) -> void:
+	if _dmx_monitor_window == null or not is_instance_valid(_dmx_monitor_window):
+		return
+	_dmx_monitor_window.refresh(running)
 
 func _exit_tree() -> void:
 	if _dmx_receiver != null:


### PR DESCRIPTION
### Motivation
- Provide clear DMX receive feedback on the main HUD and a dedicated monitor for inspecting universes and channel values. 
- Replace verbose textual DMX status in HUD with immediate color feedback on the `DMX ON` toggle so users can see signal presence at a glance. 
- Offer an interactive window to visualize active universes and the 512 channel values for a selected universe for debugging and inspection.

### Description
- Added a new Godot window script `peraviz/scripts/dmx_monitor_window.gd` that displays active universes as selectable tiles and a 512-channel grid where each channel cell background maps intensity to a green ramp. 
- Updated `peraviz/scripts/load_scene.gd` to add and wire a `DMX Monitor` HUD button, to preload and create the monitor window, and to refresh it from the DMX receiver. 
- Replaced the HUD textual DMX status label with color feedback on the `DMX ON` toggle: gray when disabled, red when enabled but no signal, and green when enabled and receiving. 
- Technical note: this change touches `peraviz/scripts/load_scene.gd` (≈1550 LOC); recommended follow-up is to extract DMX HUD/controller logic into a small adjacent script (e.g. `peraviz/scripts/dmx_hud.gd`) to keep `load_scene.gd` smaller and responsibilities separated.

### Testing
- Automated checks run: `tests/check_perastage_tree_modules.sh` — OK. 
- Automated checks run: `tests/check_no_configmanager_get_in_gui.sh` — OK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994583859d88324a2e3f418f54b0f29)