### PR TITLE
peraviz: map MVR patch + GDTF mode dimmer to Art-Net DMX input

### DIFF
--- a/docs/DMX_PATCH_MVR_GDTF.md
+++ b/docs/DMX_PATCH_MVR_GDTF.md
@@ -1,0 +1,55 @@
+# DMX patch from MVR + Dimmer mapping from GDTF
+
+## Overview
+
+Peraviz now resolves fixture dimmer control directly from loaded MVR and GDTF data:
+
+1. Fixture patch is read from MVR (universe + address, or absolute address).
+2. Fixture selected DMX mode is read from MVR (`GDTFMode`).
+3. The dimmer channel offset is resolved from the fixture GDTF mode.
+4. Art-Net DMX values are applied to fixture dimmer in the Godot runtime.
+
+## Universe offset
+
+MVR universes are often authored as 1-based, while many Art-Net senders expose universe IDs as 0-based.
+
+Peraviz adds a `universe_offset` mapping:
+
+- `artnet_universe_id = mvr_universe + universe_offset`
+- Default: `-1` (maps MVR universe 1 to Art-Net universe 0)
+
+You can change this value in the Peraviz DMX control bar at runtime.
+
+## Supported in this implementation
+
+- Art-Net receiver input.
+- Fixture patch extraction from MVR.
+- Fixture DMX mode extraction from MVR.
+- Dimmer channel lookup in GDTF mode.
+- Dimmer application to fixtures (existing fixture dimmer pathway).
+- Bound and unbound fixture debug summary.
+
+## Not supported yet
+
+- Non-dimmer channel families (color, gobo, shutter/strobe, wheels, prisms, focus, zoom, etc.).
+- Multi-attribute fixture playback from GDTF.
+- sACN.
+
+## Validation workflow
+
+1. Build Peraviz native with DMX enabled.
+2. Load the target MVR that references fixture GDTF files.
+3. Enable DMX in Peraviz.
+4. Confirm DMX status shows non-zero bound fixtures.
+5. Send Art-Net DMX on patched universe/address.
+6. Verify fixture intensity responds to DMX dimmer values.
+
+## Notes on unbound fixtures
+
+Fixtures are listed as unbound when one of these happens:
+
+- Missing or invalid patch in MVR.
+- Missing selected DMX mode in MVR.
+- Missing GDTF reference/path.
+- Dimmer attribute not found for the selected mode.
+- Resolved dimmer channel index outside the 1..512 frame.

--- a/peraviz/native/CMakeLists.txt
+++ b/peraviz/native/CMakeLists.txt
@@ -90,6 +90,8 @@ if(PERAVIZ_ENABLE_DMX)
         src/dmx/artnet_dmx_parser.cpp
         src/dmx/dmx_universe_cache.cpp
         src/dmx/artnet_receiver.cpp
+        src/dmx/gdtf_dimmer_resolver.cpp
+        src/dmx/fixture_dmx_binding.cpp
         src/peraviz_dmx_receiver.cpp
     )
     target_compile_definitions(peraviz_native PRIVATE PERAVIZ_ENABLE_DMX=1)

--- a/peraviz/native/src/dmx/fixture_dmx_binding.cpp
+++ b/peraviz/native/src/dmx/fixture_dmx_binding.cpp
@@ -1,0 +1,70 @@
+#include "dmx/fixture_dmx_binding.h"
+
+#include <algorithm>
+#include <cctype>
+
+namespace {
+
+std::string lower_ascii(std::string text) {
+    std::transform(text.begin(), text.end(), text.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    return text;
+}
+
+} // namespace
+
+namespace peraviz::dmx {
+
+FixtureBindingBuildResult build_dimmer_bindings(
+    const std::vector<FixturePatch> &patches,
+    int universe_offset,
+    std::unordered_map<std::string, FixtureDimmerBinding> &fixture_lookup) {
+    FixtureBindingBuildResult result;
+    fixture_lookup.clear();
+
+    for (const FixturePatch &patch : patches) {
+        if (patch.fixture_uuid.empty()) {
+            continue;
+        }
+        if (patch.mvr_universe <= 0 || patch.mvr_address <= 0 || patch.mvr_address > 512) {
+            result.unbound.push_back({patch.fixture_uuid, "missing or invalid MVR patch (universe/address)"});
+            continue;
+        }
+        if (patch.dmx_mode.empty()) {
+            result.unbound.push_back({patch.fixture_uuid, "missing DMX mode in MVR fixture"});
+            continue;
+        }
+        if (patch.gdtf_path.empty()) {
+            result.unbound.push_back({patch.fixture_uuid, "missing resolved GDTF path"});
+            continue;
+        }
+
+        int dimmer_offset_1_based = -1;
+        std::string debug_reason;
+        if (!resolve_dimmer_channel_offset(patch.gdtf_path, patch.dmx_mode,
+                                           dimmer_offset_1_based, debug_reason)) {
+            result.unbound.push_back({patch.fixture_uuid, debug_reason});
+            continue;
+        }
+
+        const int dmx_channel_index_0 = (patch.mvr_address - 1) + (dimmer_offset_1_based - 1);
+        if (dmx_channel_index_0 < 0 || dmx_channel_index_0 >= 512) {
+            result.unbound.push_back({patch.fixture_uuid, "resolved dimmer channel index out of 0..511 range"});
+            continue;
+        }
+
+        FixtureDimmerBinding binding;
+        binding.fixture_uuid = patch.fixture_uuid;
+        binding.artnet_universe_id = patch.mvr_universe + universe_offset;
+        binding.dmx_channel_index_0 = dmx_channel_index_0;
+        binding.scale = 1.0F;
+
+        result.bindings.push_back(binding);
+        fixture_lookup[binding.fixture_uuid] = binding;
+    }
+
+    return result;
+}
+
+} // namespace peraviz::dmx

--- a/peraviz/native/src/dmx/fixture_dmx_binding.h
+++ b/peraviz/native/src/dmx/fixture_dmx_binding.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace peraviz::dmx {
+
+struct FixturePatch {
+    std::string fixture_uuid;
+    int mvr_universe = -1;
+    int mvr_address = -1;
+    std::string dmx_mode;
+    std::string gdtf_path;
+};
+
+struct FixtureDimmerBinding {
+    std::string fixture_uuid;
+    int artnet_universe_id = -1;
+    int dmx_channel_index_0 = -1;
+    float scale = 1.0F;
+};
+
+struct FixtureUnboundReason {
+    std::string fixture_uuid;
+    std::string reason;
+};
+
+struct FixtureBindingBuildResult {
+    std::vector<FixtureDimmerBinding> bindings;
+    std::vector<FixtureUnboundReason> unbound;
+};
+
+bool resolve_dimmer_channel_offset(const std::string &gdtf_path,
+                                   const std::string &dmx_mode_name,
+                                   int &out_offset_1_based,
+                                   std::string &out_debug_reason);
+
+FixtureBindingBuildResult build_dimmer_bindings(
+    const std::vector<FixturePatch> &patches,
+    int universe_offset,
+    std::unordered_map<std::string, FixtureDimmerBinding> &fixture_lookup);
+
+} // namespace peraviz::dmx

--- a/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
@@ -1,0 +1,281 @@
+#include "dmx/fixture_dmx_binding.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <mutex>
+#include <sstream>
+#include <unordered_map>
+
+#include <tinyxml2.h>
+#include <wx/wfstream.h>
+#include <wx/zipstrm.h>
+
+namespace {
+
+struct DimmerResolveCacheEntry {
+    bool ok = false;
+    int offset = -1;
+    std::string reason;
+};
+
+std::mutex g_cache_mutex;
+std::unordered_map<std::string, DimmerResolveCacheEntry> g_cache;
+
+std::string lower_ascii(std::string text) {
+    std::transform(text.begin(), text.end(), text.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    return text;
+}
+
+std::string trim_ascii(std::string text) {
+    const auto is_space = [](unsigned char c) { return std::isspace(c) != 0; };
+    text.erase(text.begin(), std::find_if(text.begin(), text.end(), [&](unsigned char c) { return !is_space(c); }));
+    text.erase(std::find_if(text.rbegin(), text.rend(), [&](unsigned char c) { return !is_space(c); }).base(), text.end());
+    return text;
+}
+
+std::string make_cache_key(const std::string &gdtf_path, const std::string &dmx_mode_name) {
+    return gdtf_path + "\n" + dmx_mode_name;
+}
+
+std::string read_gdtf_description_xml(const std::string &gdtf_path) {
+    wxFileInputStream input(wxString::FromUTF8(gdtf_path.c_str()));
+    if (!input.IsOk()) {
+        return {};
+    }
+
+    wxZipInputStream zip(input);
+    std::unique_ptr<wxZipEntry> entry;
+    while ((entry.reset(zip.GetNextEntry())), entry) {
+        const std::string file_name = lower_ascii(entry->GetName().ToUTF8().data());
+        if (file_name != "description.xml" && file_name.find("/description.xml") == std::string::npos) {
+            continue;
+        }
+
+        std::string xml;
+        char buffer[4096];
+        while (!zip.Eof()) {
+            zip.Read(buffer, sizeof(buffer));
+            const size_t n = zip.LastRead();
+            if (n == 0) {
+                break;
+            }
+            xml.append(buffer, n);
+        }
+        return xml;
+    }
+
+    return {};
+}
+
+std::vector<tinyxml2::XMLElement *> collect_elements_by_name(tinyxml2::XMLElement *root, const std::string &name_lower) {
+    std::vector<tinyxml2::XMLElement *> result;
+    std::vector<tinyxml2::XMLElement *> stack;
+    if (root) {
+        stack.push_back(root);
+    }
+
+    while (!stack.empty()) {
+        tinyxml2::XMLElement *node = stack.back();
+        stack.pop_back();
+
+        if (lower_ascii(node->Name()) == name_lower) {
+            result.push_back(node);
+        }
+
+        for (tinyxml2::XMLElement *child = node->FirstChildElement(); child;
+             child = child->NextSiblingElement()) {
+            stack.push_back(child);
+        }
+    }
+    return result;
+}
+
+int parse_offset_first_component(const char *raw_offset) {
+    if (!raw_offset) {
+        return -1;
+    }
+
+    std::string offset_text = raw_offset;
+    offset_text = trim_ascii(offset_text);
+    for (char &ch : offset_text) {
+        if (ch == ';') {
+            ch = ',';
+        }
+    }
+
+    std::stringstream ss(offset_text);
+    std::string first;
+    if (!std::getline(ss, first, ',')) {
+        return -1;
+    }
+    first = trim_ascii(first);
+    if (first.empty()) {
+        return -1;
+    }
+
+    char *end = nullptr;
+    const long parsed = std::strtol(first.c_str(), &end, 10);
+    if (end == first.c_str() || parsed <= 0L) {
+        return -1;
+    }
+
+    return static_cast<int>(parsed);
+}
+
+bool channel_has_dimmer_attribute(tinyxml2::XMLElement *dmx_channel) {
+    if (!dmx_channel) {
+        return false;
+    }
+
+    const std::vector<tinyxml2::XMLElement *> logical_channels = collect_elements_by_name(dmx_channel, "logicalchannel");
+    for (tinyxml2::XMLElement *logical_channel : logical_channels) {
+        const std::vector<tinyxml2::XMLElement *> channel_functions = collect_elements_by_name(logical_channel, "channelfunction");
+        for (tinyxml2::XMLElement *channel_function : channel_functions) {
+            const char *attribute = channel_function->Attribute("Attribute");
+            if (!attribute) {
+                attribute = channel_function->Attribute("attribute");
+            }
+            if (!attribute) {
+                continue;
+            }
+            if (lower_ascii(attribute) == "dimmer") {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+DimmerResolveCacheEntry resolve_uncached(const std::string &gdtf_path,
+                                         const std::string &dmx_mode_name) {
+    DimmerResolveCacheEntry out;
+
+    const std::string xml_content = read_gdtf_description_xml(gdtf_path);
+    if (xml_content.empty()) {
+        out.reason = "GDTF description.xml not found";
+        return out;
+    }
+
+    tinyxml2::XMLDocument doc;
+    if (doc.Parse(xml_content.c_str()) != tinyxml2::XML_SUCCESS) {
+        out.reason = "GDTF description.xml parse failure";
+        return out;
+    }
+
+    tinyxml2::XMLElement *root = doc.RootElement();
+    if (!root) {
+        out.reason = "GDTF XML root missing";
+        return out;
+    }
+
+    std::vector<tinyxml2::XMLElement *> modes = collect_elements_by_name(root, "dmxmode");
+    if (modes.empty()) {
+        out.reason = "GDTF DMXMode list is empty";
+        return out;
+    }
+
+    tinyxml2::XMLElement *selected_mode = nullptr;
+    for (tinyxml2::XMLElement *mode : modes) {
+        const char *name = mode->Attribute("Name");
+        if (!name) {
+            name = mode->Attribute("name");
+        }
+        if (name && dmx_mode_name == name) {
+            selected_mode = mode;
+            break;
+        }
+    }
+
+    if (!selected_mode) {
+        const std::string expected = lower_ascii(dmx_mode_name);
+        for (tinyxml2::XMLElement *mode : modes) {
+            const char *name = mode->Attribute("Name");
+            if (!name) {
+                name = mode->Attribute("name");
+            }
+            if (name && expected == lower_ascii(name)) {
+                selected_mode = mode;
+                break;
+            }
+        }
+    }
+
+    if (!selected_mode) {
+        out.reason = "DMX mode not found in GDTF: " + dmx_mode_name;
+        return out;
+    }
+
+    std::vector<tinyxml2::XMLElement *> dmx_channels = collect_elements_by_name(selected_mode, "dmxchannel");
+    if (dmx_channels.empty()) {
+        out.reason = "DMX mode has no DMXChannel entries";
+        return out;
+    }
+
+    int found_count = 0;
+    for (tinyxml2::XMLElement *dmx_channel : dmx_channels) {
+        if (!channel_has_dimmer_attribute(dmx_channel)) {
+            continue;
+        }
+
+        const int offset = parse_offset_first_component(dmx_channel->Attribute("Offset"));
+        if (offset <= 0) {
+            continue;
+        }
+
+        ++found_count;
+        if (!out.ok) {
+            out.ok = true;
+            out.offset = offset;
+            out.reason.clear();
+        }
+    }
+
+    if (!out.ok) {
+        out.reason = "Dimmer attribute not found in mode DMX channels";
+        return out;
+    }
+
+    if (found_count > 1) {
+        out.reason = "multiple dimmer channels found; using first";
+    }
+
+    return out;
+}
+
+} // namespace
+
+namespace peraviz::dmx {
+
+bool resolve_dimmer_channel_offset(const std::string &gdtf_path,
+                                   const std::string &dmx_mode_name,
+                                   int &out_offset_1_based,
+                                   std::string &out_debug_reason) {
+    const std::string cache_key = make_cache_key(gdtf_path, dmx_mode_name);
+
+    {
+        const std::scoped_lock lock(g_cache_mutex);
+        auto it = g_cache.find(cache_key);
+        if (it != g_cache.end()) {
+            out_offset_1_based = it->second.offset;
+            out_debug_reason = it->second.reason;
+            return it->second.ok;
+        }
+    }
+
+    const DimmerResolveCacheEntry resolved = resolve_uncached(gdtf_path, dmx_mode_name);
+
+    {
+        const std::scoped_lock lock(g_cache_mutex);
+        g_cache[cache_key] = resolved;
+    }
+
+    out_offset_1_based = resolved.offset;
+    out_debug_reason = resolved.reason;
+    return resolved.ok;
+}
+
+} // namespace peraviz::dmx

--- a/peraviz/native/src/mvr_scene_loader.cpp
+++ b/peraviz/native/src/mvr_scene_loader.cpp
@@ -193,7 +193,7 @@ int read_int_child_value(tinyxml2::XMLElement *node, std::initializer_list<const
 
 SceneModel::FixturePatch parse_fixture_patch(tinyxml2::XMLElement *fixture_node,
                                              const std::string &fixture_uuid,
-                                             ZipAssetCache &mvr_cache) {
+                                             peraviz::ZipAssetCache &mvr_cache) {
     SceneModel::FixturePatch patch;
     patch.fixture_uuid = fixture_uuid;
 

--- a/peraviz/native/src/mvr_scene_loader.cpp
+++ b/peraviz/native/src/mvr_scene_loader.cpp
@@ -136,16 +136,74 @@ std::string parse_name(tinyxml2::XMLElement *node, const std::string &fallback) 
     return fallback;
 }
 
+std::string trim_ascii(std::string value) {
+    const auto is_space = [](unsigned char c) {
+        return std::isspace(c) != 0;
+    };
+
+    while (!value.empty() && is_space(static_cast<unsigned char>(value.front()))) {
+        value.erase(value.begin());
+    }
+    while (!value.empty() && is_space(static_cast<unsigned char>(value.back()))) {
+        value.pop_back();
+    }
+    return value;
+}
+
 int parse_int_text(const char *value) {
     if (!value) {
         return -1;
     }
+
+    const std::string trimmed = trim_ascii(value);
+    if (trimmed.empty()) {
+        return -1;
+    }
+
     char *end = nullptr;
-    const long parsed = std::strtol(value, &end, 10);
-    if (end == value || parsed <= 0L) {
+    const long parsed = std::strtol(trimmed.c_str(), &end, 10);
+    if (end == trimmed.c_str() || parsed <= 0L) {
         return -1;
     }
     return static_cast<int>(parsed);
+}
+
+bool try_parse_fixture_address_text(const std::string &text,
+                                    int break_index_zero_based,
+                                    int &out_universe,
+                                    int &out_address) {
+    const std::string trimmed = trim_ascii(text);
+    if (trimmed.empty()) {
+        return false;
+    }
+
+    const std::size_t dot = trimmed.find('.');
+    if (dot != std::string::npos) {
+        const int universe = parse_int_text(trimmed.substr(0, dot).c_str());
+        const int address = parse_int_text(trimmed.substr(dot + 1).c_str());
+        if (universe > 0 && address >= 1 && address <= 512) {
+            out_universe = universe;
+            out_address = address;
+            return true;
+        }
+        return false;
+    }
+
+    const int absolute_or_channel = parse_int_text(trimmed.c_str());
+    if (absolute_or_channel <= 0) {
+        return false;
+    }
+
+    if (absolute_or_channel <= 512) {
+        out_universe = std::max(1, break_index_zero_based + 1);
+        out_address = absolute_or_channel;
+        return true;
+    }
+
+    const int base_universe = std::max(1, break_index_zero_based + 1);
+    out_universe = base_universe + ((absolute_or_channel - 1) / 512);
+    out_address = ((absolute_or_channel - 1) % 512) + 1;
+    return true;
 }
 
 int read_int_attribute(tinyxml2::XMLElement *node, std::initializer_list<const char *> names) {
@@ -220,7 +278,8 @@ SceneModel::FixturePatch parse_fixture_patch(tinyxml2::XMLElement *fixture_node,
                            : read_int_child_value(fixture_node, {"AbsoluteAddress", "AbsDMXAddress", "DMXAbsoluteAddress"});
 
     if (tinyxml2::XMLElement *addresses = fixture_node->FirstChildElement("Addresses"); addresses) {
-        if (tinyxml2::XMLElement *address_node = addresses->FirstChildElement("Address")) {
+        for (tinyxml2::XMLElement *address_node = addresses->FirstChildElement("Address"); address_node;
+             address_node = address_node->NextSiblingElement("Address")) {
             if (universe <= 0) {
                 universe = read_int_attribute(address_node, {"Universe", "universe", "DMXUniverse"});
             }
@@ -229,6 +288,28 @@ SceneModel::FixturePatch parse_fixture_patch(tinyxml2::XMLElement *fixture_node,
             }
             if (absolute_address <= 0) {
                 absolute_address = read_int_attribute(address_node, {"AbsoluteAddress", "absoluteAddress", "DMXAbsoluteAddress"});
+            }
+
+            int parsed_universe = -1;
+            int parsed_address = -1;
+            const int break_index = std::max(0, read_int_attribute(address_node, {"break", "Break"}));
+            if (try_parse_fixture_address_text(address_node->GetText() ? address_node->GetText() : "",
+                                               break_index,
+                                               parsed_universe,
+                                               parsed_address)) {
+                if (universe <= 0) {
+                    universe = parsed_universe;
+                }
+                if (address <= 0) {
+                    address = parsed_address;
+                }
+                if (absolute_address <= 0 && parsed_universe > 0 && parsed_address > 0) {
+                    absolute_address = ((parsed_universe - 1) * 512) + parsed_address;
+                }
+            }
+
+            if (universe > 0 && address > 0) {
+                break;
             }
         }
     }

--- a/peraviz/native/src/mvr_scene_loader.cpp
+++ b/peraviz/native/src/mvr_scene_loader.cpp
@@ -11,6 +11,7 @@
 #include <array>
 #include <cctype>
 #include <cmath>
+#include <cstdlib>
 #include <filesystem>
 #include <functional>
 #include <memory>
@@ -133,6 +134,113 @@ std::string parse_name(tinyxml2::XMLElement *node, const std::string &fallback) 
         return name;
     }
     return fallback;
+}
+
+int parse_int_text(const char *value) {
+    if (!value) {
+        return -1;
+    }
+    char *end = nullptr;
+    const long parsed = std::strtol(value, &end, 10);
+    if (end == value || parsed <= 0L) {
+        return -1;
+    }
+    return static_cast<int>(parsed);
+}
+
+int read_int_attribute(tinyxml2::XMLElement *node, std::initializer_list<const char *> names) {
+    if (!node) {
+        return -1;
+    }
+    for (const char *name : names) {
+        const int parsed = parse_int_text(node->Attribute(name));
+        if (parsed > 0) {
+            return parsed;
+        }
+    }
+    return -1;
+}
+
+int read_int_child_value(tinyxml2::XMLElement *node, std::initializer_list<const char *> names) {
+    if (!node) {
+        return -1;
+    }
+    for (const char *name : names) {
+        if (tinyxml2::XMLElement *child = node->FirstChildElement(name)) {
+            const int parsed = parse_int_text(child->GetText());
+            if (parsed > 0) {
+                return parsed;
+            }
+        }
+    }
+
+    for (tinyxml2::XMLElement *child = node->FirstChildElement(); child;
+         child = child->NextSiblingElement()) {
+        const std::string child_name = lower_ascii(child->Name());
+        for (const char *name : names) {
+            const std::string expected_name = lower_ascii(name);
+            if (child_name != expected_name) {
+                continue;
+            }
+            const int parsed = parse_int_text(child->GetText());
+            if (parsed > 0) {
+                return parsed;
+            }
+        }
+    }
+    return -1;
+}
+
+SceneModel::FixturePatch parse_fixture_patch(tinyxml2::XMLElement *fixture_node,
+                                             const std::string &fixture_uuid,
+                                             ZipAssetCache &mvr_cache) {
+    SceneModel::FixturePatch patch;
+    patch.fixture_uuid = fixture_uuid;
+
+    std::string gdtf_spec;
+    if (tinyxml2::XMLElement *gdtf = fixture_node->FirstChildElement("GDTFSpec"); gdtf && gdtf->GetText()) {
+        gdtf_spec = gdtf->GetText();
+    }
+    if (!gdtf_spec.empty()) {
+        patch.gdtf_path = mvr_cache.ensure_extracted(gdtf_spec);
+    }
+
+    if (tinyxml2::XMLElement *mode = fixture_node->FirstChildElement("GDTFMode"); mode && mode->GetText()) {
+        patch.dmx_mode = mode->GetText();
+    }
+
+    int universe = read_int_attribute(fixture_node, {"Universe", "universe", "DMXUniverse", "dmxUniverse"});
+    int address = read_int_attribute(fixture_node, {"Address", "address", "DMXAddress", "dmxAddress"});
+    int absolute_address = read_int_attribute(fixture_node, {"AbsoluteAddress", "absoluteAddress", "AbsDMXAddress", "absDmxAddress"});
+
+    universe = universe > 0 ? universe : read_int_child_value(fixture_node, {"Universe", "DMXUniverse"});
+    address = address > 0 ? address : read_int_child_value(fixture_node, {"Address", "DMXAddress"});
+    absolute_address = absolute_address > 0
+                           ? absolute_address
+                           : read_int_child_value(fixture_node, {"AbsoluteAddress", "AbsDMXAddress", "DMXAbsoluteAddress"});
+
+    if (tinyxml2::XMLElement *addresses = fixture_node->FirstChildElement("Addresses"); addresses) {
+        if (tinyxml2::XMLElement *address_node = addresses->FirstChildElement("Address")) {
+            if (universe <= 0) {
+                universe = read_int_attribute(address_node, {"Universe", "universe", "DMXUniverse"});
+            }
+            if (address <= 0) {
+                address = read_int_attribute(address_node, {"Address", "address", "DMXAddress"});
+            }
+            if (absolute_address <= 0) {
+                absolute_address = read_int_attribute(address_node, {"AbsoluteAddress", "absoluteAddress", "DMXAbsoluteAddress"});
+            }
+        }
+    }
+
+    if (absolute_address > 0 && (universe <= 0 || address <= 0)) {
+        universe = ((absolute_address - 1) / 512) + 1;
+        address = ((absolute_address - 1) % 512) + 1;
+    }
+
+    patch.mvr_universe = universe;
+    patch.mvr_address = address;
+    return patch;
 }
 
 std::unordered_map<std::string, std::vector<SymdefGeometry>> parse_symdefs(tinyxml2::XMLElement *root) {
@@ -336,23 +444,17 @@ SceneModel load_mvr(const std::string &path, bool peraviz_debug_baseline,
                 node.is_fixture = true;
                 append_scene_node(model, node);
 
-                std::string gdtf_spec;
-                if (tinyxml2::XMLElement *gdtf = child->FirstChildElement("GDTFSpec"); gdtf && gdtf->GetText()) {
-                    gdtf_spec = gdtf->GetText();
-                }
-                std::string gdtf_mode;
-                if (tinyxml2::XMLElement *mode = child->FirstChildElement("GDTFMode"); mode && mode->GetText()) {
-                    gdtf_mode = mode->GetText();
-                }
+                const SceneModel::FixturePatch fixture_patch = parse_fixture_patch(child, id, mvr_cache);
+                model.fixture_patches.push_back(fixture_patch);
 
-                if (!gdtf_spec.empty()) {
-                    const std::string gdtf_path = mvr_cache.ensure_extracted(gdtf_spec);
-                    if (!gdtf_path.empty()) {
-                        const GdtfBuildRequest request{gdtf_path, gdtf_mode, id, node.name};
-                        auto fixture_nodes = build_fixture_geometry_nodes(request, id, node_world,
-                                                                          model.extracted_asset_count);
-                        model.nodes.insert(model.nodes.end(), fixture_nodes.begin(), fixture_nodes.end());
-                    }
+                const std::string gdtf_mode = fixture_patch.dmx_mode;
+                const std::string gdtf_path = fixture_patch.gdtf_path;
+
+                if (!gdtf_path.empty()) {
+                    const GdtfBuildRequest request{gdtf_path, gdtf_mode, id, node.name};
+                    auto fixture_nodes = build_fixture_geometry_nodes(request, id, node_world,
+                                                                      model.extracted_asset_count);
+                    model.nodes.insert(model.nodes.end(), fixture_nodes.begin(), fixture_nodes.end());
                 }
             } else if (node_name == "Truss") {
                 node.type = "truss";

--- a/peraviz/native/src/peraviz_loader.cpp
+++ b/peraviz/native/src/peraviz_loader.cpp
@@ -3,6 +3,10 @@
 #include "mvr_scene_loader.h"
 #include "mesh_3ds_loader.h"
 
+#ifdef PERAVIZ_ENABLE_DMX
+#include "dmx/fixture_dmx_binding.h"
+#endif
+
 #include <godot_cpp/variant/array.hpp>
 #include <godot_cpp/variant/dictionary.hpp>
 #include <godot_cpp/variant/packed_int32_array.hpp>
@@ -10,33 +14,60 @@
 #include <godot_cpp/variant/utility_functions.hpp>
 #include <godot_cpp/variant/vector3.hpp>
 
+#include <unordered_map>
+
+namespace {
+
+godot::Array serialize_fixture_patches(const peraviz::SceneModel &model) {
+    godot::Array out;
+    out.resize(static_cast<int64_t>(model.fixture_patches.size()));
+    int64_t index = 0;
+    for (const auto &patch : model.fixture_patches) {
+        godot::Dictionary d;
+        d["fixture_uuid"] = godot::String(patch.fixture_uuid.c_str());
+        d["mvr_universe"] = patch.mvr_universe;
+        d["mvr_address"] = patch.mvr_address;
+        d["dmx_mode"] = godot::String(patch.dmx_mode.c_str());
+        d["gdtf_path"] = godot::String(patch.gdtf_path.c_str());
+        out[index++] = d;
+    }
+    return out;
+}
+
+} // namespace
+
 namespace godot {
 
 void PeravizLoader::_bind_methods() {
     ClassDB::bind_method(D_METHOD("load_mvr", "path", "peraviz_debug_baseline", "peraviz_debug_coords"), &PeravizLoader::load_mvr);
     ClassDB::bind_method(D_METHOD("load_3ds_mesh_data", "path"), &PeravizLoader::load_3ds_mesh_data);
+    ClassDB::bind_method(D_METHOD("get_fixtures_patch"), &PeravizLoader::get_fixtures_patch);
+    ClassDB::bind_method(D_METHOD("build_fixture_dimmer_bindings", "universe_offset"),
+                         &PeravizLoader::build_fixture_dimmer_bindings,
+                         DEFVAL(-1));
 }
 
 Array PeravizLoader::load_mvr(const String &path, bool peraviz_debug_baseline,
-                              bool peraviz_debug_coords) const {
-    const peraviz::SceneModel model = peraviz::load_mvr(std::string(path.utf8().get_data()),
-                                                        peraviz_debug_baseline,
-                                                        peraviz_debug_coords);
+                              bool peraviz_debug_coords) {
+    last_scene_model_ = peraviz::load_mvr(std::string(path.utf8().get_data()),
+                                          peraviz_debug_baseline,
+                                          peraviz_debug_coords);
 
-    UtilityFunctions::print("[PeravizNative] load_mvr nodes=", model.nodes.size(),
+    UtilityFunctions::print("[PeravizNative] load_mvr nodes=", last_scene_model_.nodes.size(),
                             " baseline_debug=", peraviz_debug_baseline,
                             " coords_debug=", peraviz_debug_coords,
-                            " fixtures=", model.fixture_count,
-                            " trusses=", model.truss_count,
-                            " objects=", model.object_count,
-                            " supports=", model.support_count,
-                            " extracted_assets=", model.extracted_asset_count,
-                            " cache=", String(model.cache_path.c_str()));
+                            " fixtures=", last_scene_model_.fixture_count,
+                            " fixture_patches=", last_scene_model_.fixture_patches.size(),
+                            " trusses=", last_scene_model_.truss_count,
+                            " objects=", last_scene_model_.object_count,
+                            " supports=", last_scene_model_.support_count,
+                            " extracted_assets=", last_scene_model_.extracted_asset_count,
+                            " cache=", String(last_scene_model_.cache_path.c_str()));
 
     Array out;
-    out.resize(static_cast<int64_t>(model.nodes.size()));
+    out.resize(static_cast<int64_t>(last_scene_model_.nodes.size()));
     int index = 0;
-    for (const auto &node : model.nodes) {
+    for (const auto &node : last_scene_model_.nodes) {
         Dictionary d;
         d["node_id"] = String(node.node_id.c_str());
         d["parent_id"] = String(node.parent_id.c_str());
@@ -68,11 +99,11 @@ Array PeravizLoader::load_mvr(const String &path, bool peraviz_debug_baseline,
         d["scale"] = Vector3(node.local_transform.scale.x, node.local_transform.scale.y,
                               node.local_transform.scale.z);
         d["basis_x"] = Vector3(node.local_transform.basis_x.x, node.local_transform.basis_x.y,
-                                 node.local_transform.basis_x.z);
+                                node.local_transform.basis_x.z);
         d["basis_y"] = Vector3(node.local_transform.basis_y.x, node.local_transform.basis_y.y,
-                                 node.local_transform.basis_y.z);
+                                node.local_transform.basis_y.z);
         d["basis_z"] = Vector3(node.local_transform.basis_z.x, node.local_transform.basis_z.y,
-                                 node.local_transform.basis_z.z);
+                                node.local_transform.basis_z.z);
         d["has_basis"] = node.local_transform.has_basis;
         out[index++] = d;
     }
@@ -96,6 +127,62 @@ Dictionary PeravizLoader::load_3ds_mesh_data(const String &path) const {
     out["vertices"] = vertices;
     out["normals"] = normals;
     out["indices"] = indices;
+    return out;
+}
+
+Array PeravizLoader::get_fixtures_patch() const {
+    return serialize_fixture_patches(last_scene_model_);
+}
+
+Dictionary PeravizLoader::build_fixture_dimmer_bindings(int universe_offset) const {
+    Dictionary out;
+    out["universe_offset"] = universe_offset;
+
+#ifdef PERAVIZ_ENABLE_DMX
+    std::vector<peraviz::dmx::FixturePatch> patches;
+    patches.reserve(last_scene_model_.fixture_patches.size());
+    for (const auto &patch : last_scene_model_.fixture_patches) {
+        peraviz::dmx::FixturePatch copy;
+        copy.fixture_uuid = patch.fixture_uuid;
+        copy.mvr_universe = patch.mvr_universe;
+        copy.mvr_address = patch.mvr_address;
+        copy.dmx_mode = patch.dmx_mode;
+        copy.gdtf_path = patch.gdtf_path;
+        patches.push_back(copy);
+    }
+
+    std::unordered_map<std::string, peraviz::dmx::FixtureDimmerBinding> lookup;
+    const peraviz::dmx::FixtureBindingBuildResult result =
+        peraviz::dmx::build_dimmer_bindings(patches, universe_offset, lookup);
+
+    Array bindings;
+    bindings.resize(static_cast<int64_t>(result.bindings.size()));
+    int64_t binding_index = 0;
+    for (const auto &binding : result.bindings) {
+        Dictionary item;
+        item["fixture_uuid"] = String(binding.fixture_uuid.c_str());
+        item["artnet_universe_id"] = binding.artnet_universe_id;
+        item["dmx_channel_index_0"] = binding.dmx_channel_index_0;
+        item["scale"] = binding.scale;
+        bindings[binding_index++] = item;
+    }
+
+    Array unbound;
+    unbound.resize(static_cast<int64_t>(result.unbound.size()));
+    int64_t unbound_index = 0;
+    for (const auto &item : result.unbound) {
+        Dictionary d;
+        d["fixture_uuid"] = String(item.fixture_uuid.c_str());
+        d["reason"] = String(item.reason.c_str());
+        unbound[unbound_index++] = d;
+    }
+
+    out["bindings"] = bindings;
+    out["unbound"] = unbound;
+#else
+    out["bindings"] = Array();
+    out["unbound"] = Array();
+#endif
     return out;
 }
 

--- a/peraviz/native/src/peraviz_loader.h
+++ b/peraviz/native/src/peraviz_loader.h
@@ -6,6 +6,8 @@
 #include <godot_cpp/variant/dictionary.hpp>
 #include <godot_cpp/variant/string.hpp>
 
+#include "scene_model.h"
+
 namespace godot {
 
 class PeravizLoader : public Object {
@@ -16,8 +18,13 @@ protected:
 
 public:
     Array load_mvr(const String &path, bool peraviz_debug_baseline = false,
-                   bool peraviz_debug_coords = false) const;
+                   bool peraviz_debug_coords = false);
     Dictionary load_3ds_mesh_data(const String &path) const;
+    Array get_fixtures_patch() const;
+    Dictionary build_fixture_dimmer_bindings(int universe_offset = -1) const;
+
+private:
+    peraviz::SceneModel last_scene_model_;
 };
 
 } // namespace godot

--- a/peraviz/native/src/scene_model.h
+++ b/peraviz/native/src/scene_model.h
@@ -55,12 +55,21 @@ struct SceneNode {
 
 struct SceneModel {
     std::vector<SceneNode> nodes;
+    struct FixturePatch {
+        std::string fixture_uuid;
+        int mvr_universe = -1;
+        int mvr_address = -1;
+        std::string dmx_mode;
+        std::string gdtf_path;
+    };
+
     int fixture_count = 0;
     int truss_count = 0;
     int object_count = 0;
     int support_count = 0;
     int extracted_asset_count = 0;
     std::string cache_path;
+    std::vector<FixturePatch> fixture_patches;
 };
 
 } // namespace peraviz

--- a/peraviz/scripts/dmx_fixture_runtime.gd
+++ b/peraviz/scripts/dmx_fixture_runtime.gd
@@ -1,0 +1,100 @@
+extends RefCounted
+class_name DmxFixtureRuntime
+
+const MAX_UNBOUND_PREVIEW: int = 8
+
+var _loader = null
+var _scene_registry: SceneRegistry = null
+var _bindings: Array = []
+var _unbound: Array = []
+var _fixture_nodes: Dictionary = {}
+var _used_universes: Dictionary = {}
+
+func configure(loader, scene_registry: SceneRegistry) -> void:
+	_loader = loader
+	_scene_registry = scene_registry
+
+func rebuild(universe_offset: int) -> Dictionary:
+	_bindings.clear()
+	_unbound.clear()
+	_fixture_nodes.clear()
+	_used_universes.clear()
+
+	if _loader == null or _scene_registry == null:
+		return {
+			"bound": 0,
+			"unbound": 0,
+			"unbound_preview": PackedStringArray(),
+		}
+
+	var result: Dictionary = _loader.build_fixture_dimmer_bindings(universe_offset)
+	_bindings = result.get("bindings", [])
+	_unbound = result.get("unbound", [])
+
+	for binding in _bindings:
+		if binding is not Dictionary:
+			continue
+		var fixture_uuid: String = str(binding.get("fixture_uuid", ""))
+		if fixture_uuid.is_empty():
+			continue
+		var fixture_node: Node = _scene_registry.get_fixture(fixture_uuid)
+		if fixture_node == null:
+			_unbound.append({
+				"fixture_uuid": fixture_uuid,
+				"reason": "fixture node not found in loaded scene",
+			})
+			continue
+		_fixture_nodes[fixture_uuid] = fixture_node
+		var universe_id: int = int(binding.get("artnet_universe_id", -1))
+		if universe_id >= 0:
+			_used_universes[universe_id] = true
+
+	return _build_summary(universe_offset)
+
+func apply_dmx(receiver, apply_dimmer_callback: Callable) -> void:
+	if receiver == null or not receiver.is_running():
+		return
+	if apply_dimmer_callback.is_null():
+		return
+
+	var universe_frames: Dictionary = {}
+	for universe_key in _used_universes.keys():
+		var universe_id: int = int(universe_key)
+		universe_frames[universe_id] = receiver.get_universe_data(universe_id)
+
+	for binding in _bindings:
+		if binding is not Dictionary:
+			continue
+		var fixture_uuid: String = str(binding.get("fixture_uuid", ""))
+		if fixture_uuid.is_empty() or not _fixture_nodes.has(fixture_uuid):
+			continue
+		var universe_id: int = int(binding.get("artnet_universe_id", -1))
+		var channel_index: int = int(binding.get("dmx_channel_index_0", -1))
+		if channel_index < 0 or channel_index >= 512:
+			continue
+		var frame: PackedByteArray = universe_frames.get(universe_id, PackedByteArray())
+		if channel_index >= frame.size():
+			continue
+		var normalized_value: float = float(frame[channel_index]) / 255.0
+		apply_dimmer_callback.call(fixture_uuid, normalized_value * 100.0)
+
+func get_bound_count() -> int:
+	return _fixture_nodes.size()
+
+func get_unbound_count() -> int:
+	return _unbound.size()
+
+func get_unbound_preview() -> PackedStringArray:
+	var lines := PackedStringArray()
+	for index in range(min(MAX_UNBOUND_PREVIEW, _unbound.size())):
+		var row: Dictionary = _unbound[index]
+		lines.append("%s: %s" % [str(row.get("fixture_uuid", "<unknown>")), str(row.get("reason", "unspecified"))])
+	return lines
+
+func _build_summary(universe_offset: int) -> Dictionary:
+	return {
+		"bound": get_bound_count(),
+		"unbound": get_unbound_count(),
+		"unbound_preview": get_unbound_preview(),
+		"universe_offset": universe_offset,
+	}

--- a/peraviz/scripts/dmx_fixture_runtime.gd.uid
+++ b/peraviz/scripts/dmx_fixture_runtime.gd.uid
@@ -1,0 +1,1 @@
+uid://kim3vmhheqqg

--- a/peraviz/scripts/dmx_monitor_window.gd.uid
+++ b/peraviz/scripts/dmx_monitor_window.gd.uid
@@ -1,0 +1,1 @@
+uid://5urht3xrhy0x

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -1608,19 +1608,6 @@ func _on_dmx_timer_timeout() -> void:
 	_update_dmx_toggle_color(true, receiving)
 	_refresh_dmx_monitor_window(true)
 
-	var bound_count: int = 0
-	var unbound_count: int = 0
-	if _dmx_fixture_runtime != null:
-		bound_count = int(_dmx_fixture_runtime.get_bound_count())
-		unbound_count = int(_dmx_fixture_runtime.get_unbound_count())
-	status_label.text = "DMX pps=%d uni=%d last=%dms bound_fixtures=%d unbound=%d universe_offset=%d" % [
-		int(stats.get("packets_per_sec", 0)),
-		active_universes.size(),
-		last_ms,
-		bound_count,
-		unbound_count,
-		int(_dmx_universe_offset_input.value),
-	]
 
 func _update_dmx_toggle_color(enabled: bool, receiving_signal: bool) -> void:
 	if _dmx_toggle_button == null:

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -47,8 +47,12 @@ var _dmx_toggle_button: Button
 var _dmx_monitor_button: Button
 var _dmx_monitor_window: Window
 var _dmx_timer: Timer
+var _dmx_universe_offset_input: SpinBox
+var _dmx_unbound_preview_label: Label
+var _dmx_fixture_runtime = null
 
 const DmxMonitorWindowScript = preload("res://scripts/dmx_monitor_window.gd")
+const DmxFixtureRuntimeScript = preload("res://scripts/dmx_fixture_runtime.gd")
 
 const DEBUG_TOGGLE_KEY: Key = KEY_C
 const MANUAL_TEST_FLAG: String = "--peraviz_manual_fixture_test"
@@ -103,6 +107,7 @@ func _ready() -> void:
 	_update_debug_legend()
 	_refresh_fixture_debug_panel()
 	_setup_dmx_controls()
+	_setup_dmx_fixture_runtime()
 
 func _on_load_pressed() -> void:
 	picker.popup_centered_ratio(0.7)
@@ -118,6 +123,7 @@ func _on_file_selected(path: String) -> void:
 
 	_build_node_tree(nodes)
 	_register_fixture_registry(nodes)
+	_refresh_dmx_fixture_bindings()
 	_populate_fixture_list()
 	_sync_selection_state("scene_reload")
 	_rebuild_debug_gizmos()
@@ -1508,8 +1514,25 @@ func _setup_dmx_controls() -> void:
 	hud_root.add_child(_dmx_monitor_button)
 	_dmx_monitor_button.pressed.connect(_on_dmx_monitor_pressed)
 
+	_dmx_universe_offset_input = SpinBox.new()
+	_dmx_universe_offset_input.position = Vector2(770, 20)
+	_dmx_universe_offset_input.custom_minimum_size = Vector2(90, 24)
+	_dmx_universe_offset_input.min_value = -32
+	_dmx_universe_offset_input.max_value = 32
+	_dmx_universe_offset_input.step = 1
+	_dmx_universe_offset_input.value = -1
+	hud_root.add_child(_dmx_universe_offset_input)
+	_dmx_universe_offset_input.value_changed.connect(_on_dmx_universe_offset_changed)
+
+	_dmx_unbound_preview_label = Label.new()
+	_dmx_unbound_preview_label.position = Vector2(540, 50)
+	_dmx_unbound_preview_label.size = Vector2(500, 120)
+	_dmx_unbound_preview_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_dmx_unbound_preview_label.visible = false
+	hud_root.add_child(_dmx_unbound_preview_label)
+
 	_dmx_timer = Timer.new()
-	_dmx_timer.wait_time = 0.2
+	_dmx_timer.wait_time = 0.03
 	_dmx_timer.autostart = true
 	hud_root.add_child(_dmx_timer)
 	_dmx_timer.timeout.connect(_on_dmx_timer_timeout)
@@ -1520,6 +1543,21 @@ func _setup_dmx_controls() -> void:
 	else:
 		_dmx_toggle_button.disabled = true
 		_dmx_toggle_button.tooltip_text = "DMX unavailable (build without PERAVIZ_ENABLE_DMX)"
+
+func _setup_dmx_fixture_runtime() -> void:
+	_dmx_fixture_runtime = DmxFixtureRuntimeScript.new()
+	_dmx_fixture_runtime.configure(_loader, _scene_registry)
+
+func _refresh_dmx_fixture_bindings() -> void:
+	if _dmx_fixture_runtime == null:
+		return
+	var summary: Dictionary = _dmx_fixture_runtime.rebuild(int(_dmx_universe_offset_input.value))
+	var unbound_preview: PackedStringArray = summary.get("unbound_preview", PackedStringArray())
+	_dmx_unbound_preview_label.visible = unbound_preview.size() > 0
+	_dmx_unbound_preview_label.text = "Unbound fixtures:\n" + "\n".join(unbound_preview)
+
+func _on_dmx_universe_offset_changed(_value: float) -> void:
+	_refresh_dmx_fixture_bindings()
 
 func _on_dmx_toggle_pressed() -> void:
 	if _dmx_receiver == null:
@@ -1560,12 +1598,29 @@ func _on_dmx_timer_timeout() -> void:
 		_refresh_dmx_monitor_window(false)
 		return
 
+	if _dmx_fixture_runtime != null:
+		_dmx_fixture_runtime.apply_dmx(_dmx_receiver, Callable(self, "_apply_dimmer_feedback_to_fixture"))
+
 	var stats: Dictionary = _dmx_receiver.get_stats()
 	var active_universes: PackedInt32Array = _dmx_receiver.get_active_universes(2000)
 	var last_ms: int = int(stats.get("last_packet_ms_ago", -1))
 	var receiving: bool = active_universes.size() > 0 and last_ms >= 0 and last_ms <= 2000
 	_update_dmx_toggle_color(true, receiving)
 	_refresh_dmx_monitor_window(true)
+
+	var bound_count: int = 0
+	var unbound_count: int = 0
+	if _dmx_fixture_runtime != null:
+		bound_count = int(_dmx_fixture_runtime.get_bound_count())
+		unbound_count = int(_dmx_fixture_runtime.get_unbound_count())
+	status_label.text = "DMX pps=%d uni=%d last=%dms bound_fixtures=%d unbound=%d universe_offset=%d" % [
+		int(stats.get("packets_per_sec", 0)),
+		active_universes.size(),
+		last_ms,
+		bound_count,
+		unbound_count,
+		int(_dmx_universe_offset_input.value),
+	]
 
 func _update_dmx_toggle_color(enabled: bool, receiving_signal: bool) -> void:
 	if _dmx_toggle_button == null:


### PR DESCRIPTION
### Motivation
- Enable Peraviz to discover fixture DMX patch (universe/address) and selected DMX mode from an MVR and resolve the Dimmer channel from the referenced GDTF so incoming Art-Net DMX dimmer values can drive fixtures in the Godot scene while keeping scope limited to Dimmer only.
- Keep changes isolated under `peraviz/` and `peraviz/native/` so Perastage build/runtime are unaffected and the native core is engine-agnostic.
- Provide a small, efficient runtime pathway that avoids per-tick scene traversal and supports multiple universes and many fixtures.

### Description
- Added MVR-level fixture patch capture and persistence in the native model (`SceneModel::fixture_patches`) and extended the MVR loader to extract UUID, universe/address (including absolute-address fallback), selected `GDTFMode`, and resolved GDTF path at load time (`peraviz/native/src/mvr_scene_loader.cpp` and `peraviz/native/src/scene_model.h`).
- Implemented a minimal, cached GDTF dimmer resolver that reads `description.xml` inside the GDTF zip, finds the named DMX mode (case-sensitive then case-insensitive), locates `ChannelFunction Attribute="Dimmer"`, and returns the first DMXChannel offset; results are cached per `(gdtf_path, mode)` (`peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp`).
- Added engine-agnostic binding core to build `FixtureDimmerBinding` entries (mapping MVR universe/address + resolved dimmer offset -> Art-Net universe/id + 0-based channel index) with validation and unbound reasons, and exposed builder via native `PeravizLoader` (`get_fixtures_patch()` and `build_fixture_dimmer_bindings(universe_offset)`) so Godot can consume bindings (`peraviz/native/src/dmx/fixture_dmx_binding.*`, `peraviz/native/src/peraviz_loader.*`).
- Integrated a small Godot runtime helper `DmxFixtureRuntime` that caches Node references and used universes, applies DMX dimmer values efficiently at timer rate via the existing fixture dimmer pathway, and added minimal UI controls (universe offset SpinBox, bound/unbound counts and unbound preview) to `load_scene.gd`; added `docs/DMX_PATCH_MVR_GDTF.md` describing behavior and test flow.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which succeeded. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which succeeded. 
- Ran `git diff --check` to ensure no whitespace/index issues, which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69945e939d108324b9b4636af7525ed9)