### PR TITLE
peraviz: add WorldEnvironment baseline with conservative grading defaults

### DIFF
--- a/peraviz/docs/ENVIRONMENT_TUNING.md
+++ b/peraviz/docs/ENVIRONMENT_TUNING.md
@@ -1,0 +1,23 @@
+# Viewer environment baseline (`test.tscn`)
+
+This document records the conservative default values configured in `Viewer/WorldEnvironment` for artistic iteration.
+
+## Current baseline
+
+- **Background**: neutral solid color (`background_mode = Color`), slightly cool dark gray.
+- **Ambient light**: low fill (`ambient_light_energy = 0.2`) with a neutral cool tint to soften hard shadows without flattening depth.
+- **Tonemapper**: **ACES** with `tonemap_exposure = 1.0` as a safe starting point.
+- **Image adjustment**: enabled with moderate values to avoid a washed-out look:
+  - `adjustment_contrast = 1.05`
+  - `adjustment_saturation = 1.05`
+
+## Suggested iteration ranges
+
+Use these ranges for look-dev passes while preserving a neutral baseline:
+
+- `ambient_light_energy`: `0.15` - `0.35`
+- `tonemap_exposure`: `0.9` - `1.2`
+- `adjustment_contrast`: `1.0` - `1.15`
+- `adjustment_saturation`: `1.0` - `1.15`
+
+Keep adjustments subtle at first and validate against representative MVR scenes before widening ranges.

--- a/peraviz/test.tscn
+++ b/peraviz/test.tscn
@@ -5,8 +5,23 @@
 
 [sub_resource type="PlaneMesh" id="PlaneMesh_ground"]
 
+[sub_resource type="Environment" id="Environment_viewer"]
+background_mode = 1
+background_color = Color(0.129412, 0.137255, 0.156863, 1)
+ambient_light_source = 2
+ambient_light_color = Color(0.176471, 0.188235, 0.211765, 1)
+ambient_light_energy = 0.2
+tonemap_mode = 3
+tonemap_exposure = 1.0
+adjustment_enabled = true
+adjustment_contrast = 1.05
+adjustment_saturation = 1.05
+
 [node name="Viewer" type="Node3D"]
 script = ExtResource("1_script")
+
+[node name="WorldEnvironment" type="WorldEnvironment" parent="."]
+environment = SubResource("Environment_viewer")
 
 [node name="Camera3D" type="Camera3D" parent="."]
 script = ExtResource("2_camera_script")


### PR DESCRIPTION
### Motivation
- Provide a conservative, artist-friendly default `WorldEnvironment` in the viewer to reduce harsh shadow contrast and avoid a washed-out look while keeping visuals neutral for MVR validation.
- Expose a documented baseline so look-dev can iterate safely without structural scene changes.

### Description
- Add a `WorldEnvironment` node as a child of `Viewer` in `peraviz/test.tscn` and link it to a new `Environment` sub-resource.
- Configure the `Environment` with a neutral background color, low ambient fill light (`ambient_light_energy = 0.2`) and a soft ambient tint.
- Set the tonemapper to ACES with a neutral exposure (`tonemap_exposure = 1.0`) and enable mild image adjustments (`adjustment_contrast = 1.05`, `adjustment_saturation = 1.05`).
- Add `peraviz/docs/ENVIRONMENT_TUNING.md` documenting the baseline parameters and suggested iteration ranges for future art-direction.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (`OK`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994a1cf8c248324a610788b22bf9c3b)