### PR TITLE
Tune DirectionalLight3D shadow cascades and bias in peraviz/test.tscn

### DIFF
--- a/peraviz/test.tscn
+++ b/peraviz/test.tscn
@@ -32,9 +32,16 @@ current = true
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
 rotation_degrees = Vector3(-45, 45, 0)
 shadow_enabled = true
-directional_shadow_max_distance = 120.0
-shadow_bias = 0.03
-shadow_normal_bias = 1.0
+directional_shadow_mode = 2
+directional_shadow_blend_splits = true
+directional_shadow_split_1 = 0.08
+directional_shadow_split_2 = 0.2
+directional_shadow_split_3 = 0.45
+directional_shadow_fade_start = 0.85
+directional_shadow_max_distance = 72.0
+shadow_bias = 0.015
+shadow_normal_bias = 0.7
+light_angular_distance = 0.35
 
 [node name="Ground" type="MeshInstance3D" parent="."]
 mesh = SubResource("PlaneMesh_ground")


### PR DESCRIPTION
### Motivation
- Improve shadow quality and stability in the peraviz test scene by using PSSM cascades, reducing unnecessary far-range shadow distance, and recalibrating bias to reduce acne and peter-panning.

### Description
- Updated `peraviz/test.tscn` `DirectionalLight3D` to enable 4-split PSSM (`directional_shadow_mode = 2`) and blended cascade transitions with tuned split distribution and `directional_shadow_fade_start`.
- Reduced `directional_shadow_max_distance` to `72.0` to match the practical camera/scene range used in the test scene.
- Recalibrated `shadow_bias` to `0.015` and `shadow_normal_bias` to `0.7` and enabled soft shadow edges via `light_angular_distance = 0.35`.
- This is a focused scene-only tweak (file changed: `peraviz/test.tscn`) with no module or architecture boundary changes.

### Testing
- Ran repository checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both succeeded.
- Attempted to run Godot for visual verification but `godot4`/`godot` is not available in this environment so visual validation was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994a425a7cc83249581aa7240731f55)