### PR TITLE
Improve Peraviz default scene scale and fixture beam range

### DIFF
--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -84,6 +84,9 @@ const DOUBLE_SIDED_MATERIAL_HINTS: Array[String] = [
 	"lens", "glass", "visor", "fabric", "cloth", "curtain", "thin", "plane"
 ]
 const IMPORTED_CONTENT_SCALE: float = 10.0
+const EMITTER_LIGHT_MIN_RANGE_M: float = 8.0
+const EMITTER_LIGHT_MAX_RANGE_M: float = 180.0
+const EMITTER_LIGHT_RANGE_BEAM_RADIUS_MULTIPLIER: float = 900.0
 const ENV_QUALITY_PRESET_SETTING: String = "peraviz_environment_quality"
 const ENV_QUALITY_PRESET_DEFAULT: String = "medium"
 const ENVIRONMENT_QUALITY_PRESETS := {
@@ -1258,7 +1261,7 @@ func _find_or_create_emitter_light(emitter_node: Node3D) -> SpotLight3D:
 	light.rotation_degrees = EMITTER_LIGHT_DIRECTION_FIX
 	light.light_negative = false
 	light.shadow_enabled = true
-	light.spot_range = 20.0
+	light.spot_range = 60.0
 	light.spot_angle = 25.0
 	light.spot_attenuation = 1.0
 	light.set_meta("peraviz_beam_cone", _create_emitter_beam_cone())
@@ -1437,7 +1440,7 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 	light.light_energy = luminous_flux * normalized_dimmer
 	light.spot_angle = beam_angle
 	light.spot_attenuation = clamp(beam_angle / field_angle, 0.2, 1.0)
-	light.spot_range = clamp(beam_radius_m * 400.0, 0.5, 60.0)
+	light.spot_range = clamp(beam_radius_m * EMITTER_LIGHT_RANGE_BEAM_RADIUS_MULTIPLIER, EMITTER_LIGHT_MIN_RANGE_M, EMITTER_LIGHT_MAX_RANGE_M)
 	light.light_color = _derive_emitter_color(photometric)
 	var beam_radius_from_gdtf: bool = bool(photometric.get("beam_radius_from_gdtf", false))
 	var source_beam_radius: float = beam_radius_m if beam_radius_from_gdtf else -1.0

--- a/peraviz/test.tscn
+++ b/peraviz/test.tscn
@@ -4,12 +4,13 @@
 [ext_resource type="Script" path="res://scripts/editor_camera.gd" id="2_camera_script"]
 
 [sub_resource type="PlaneMesh" id="PlaneMesh_ground"]
+size = Vector2(100, 100)
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_ground"]
 albedo_color = Color(0.45, 0.45, 0.45, 1)
 metallic_specular = 0.45
 roughness = 0.78
-uv1_scale = Vector3(6, 6, 6)
+uv1_scale = Vector3(30, 30, 30)
 disable_receive_shadows = false
 
 [sub_resource type="Environment" id="Environment_viewer"]
@@ -43,12 +44,12 @@ environment = SubResource("Environment_viewer")
 
 [node name="Camera3D" type="Camera3D" parent="."]
 script = ExtResource("2_camera_script")
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3, 8)
-rotation_degrees = Vector3(-20, 0, 0)
+transform = Transform3D(0.788011, 0, -0.615661, -0.169148, 0.961262, -0.216548, 0.592149, 0.275637, 0.759504, 24, 18, 24)
+rotation_degrees = Vector3(-16, 39, 0)
 current = true
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
-rotation_degrees = Vector3(-45, 45, 0)
+rotation_degrees = Vector3(-52, 32, 0)
 shadow_enabled = true
 directional_shadow_mode = 2
 directional_shadow_blend_splits = true
@@ -65,7 +66,7 @@ light_angular_distance = 0.35
 mesh = SubResource("PlaneMesh_ground")
 material_override = SubResource("StandardMaterial3D_ground")
 cast_shadow = 1
-transform = Transform3D(12, 0, 0, 0, 1, 0, 0, 0, 12, 0, 0, 0)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 
 [node name="Proxies" type="Node3D" parent="."]
 


### PR DESCRIPTION
### Motivation
- The default Godot test scene used by Peraviz was too small and centered for the new real-world import scale, making ground tiles and initial view unhelpful. 
- Camera and directional light defaults need repositioning to give a better starting composition for larger scenes. 
- Fixture emitter beams were too short and did not reach the ground at realistic photometric sizes, so runtime beam distance logic needed widening.

### Description
- Enlarged the default ground `PlaneMesh` to `100x100` meters and increased `uv1_scale` to `Vector3(30, 30, 30)` so materials tile correctly at the new world scale, and removed the previous transform scaling on `Ground` in `peraviz/test.tscn`.
- Moved the default `Camera3D` away from the center and updated its `transform` and `rotation_degrees` to provide a more useful initial view in `peraviz/test.tscn`.
- Adjusted the `DirectionalLight3D` `rotation_degrees` to better illuminate the larger scene in `peraviz/test.tscn`.
- In `peraviz/scripts/load_scene.gd` added configurable constants `EMITTER_LIGHT_MIN_RANGE_M`, `EMITTER_LIGHT_MAX_RANGE_M`, and `EMITTER_LIGHT_RANGE_BEAM_RADIUS_MULTIPLIER`, raised the default `SpotLight3D.spot_range` for emitter lights to `60.0`, and changed the runtime `spot_range` calculation to `clamp(beam_radius_m * EMITTER_LIGHT_RANGE_BEAM_RADIUS_MULTIPLIER, EMITTER_LIGHT_MIN_RANGE_M, EMITTER_LIGHT_MAX_RANGE_M)` to allow beams to reach realistic distances.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994b775d7ac8324850269b6bc9eba36)