### PR TITLE
Tune Peraviz emitter beams to avoid oversized and overbright output

### DIFF
--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -91,6 +91,7 @@ const EMITTER_LIGHT_ENERGY_SCALE: float = 0.03
 const EMITTER_LIGHT_MAX_BEAM_ANGLE_DEG: float = 45.0
 const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 4.0
 const EMITTER_LIGHT_MAX_FOOTPRINT_RADIUS_M: float = EMITTER_CONE_MAX_BASE_RADIUS_M
+const EMITTER_LIGHT_MIN_EFFECTIVE_RANGE_M: float = 0.75
 const EMITTER_CONE_NEAR_ALPHA: float = 0.06
 const EMITTER_CONE_FAR_ALPHA: float = 0.004
 const EMITTER_CONE_NEAR_EMISSION: float = 0.45
@@ -1452,8 +1453,8 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 	var beam_half_angle_tan: float = tan(deg_to_rad(beam_angle * 0.5))
 	var max_spot_range_from_footprint: float = EMITTER_LIGHT_MAX_RANGE_M
 	if beam_half_angle_tan > 0.0001:
-		max_spot_range_from_footprint = max(EMITTER_LIGHT_MAX_FOOTPRINT_RADIUS_M / beam_half_angle_tan, EMITTER_LIGHT_MIN_RANGE_M)
-	light.spot_range = clamp(min(nominal_spot_range, max_spot_range_from_footprint), EMITTER_LIGHT_MIN_RANGE_M, EMITTER_LIGHT_MAX_RANGE_M)
+		max_spot_range_from_footprint = max(EMITTER_LIGHT_MAX_FOOTPRINT_RADIUS_M / beam_half_angle_tan, EMITTER_LIGHT_MIN_EFFECTIVE_RANGE_M)
+	light.spot_range = clamp(min(nominal_spot_range, max_spot_range_from_footprint), EMITTER_LIGHT_MIN_EFFECTIVE_RANGE_M, EMITTER_LIGHT_MAX_RANGE_M)
 	light.light_color = _derive_emitter_color(photometric)
 	var beam_radius_from_gdtf: bool = bool(photometric.get("beam_radius_from_gdtf", false))
 	var source_beam_radius: float = beam_radius_m if beam_radius_from_gdtf else -1.0
@@ -1522,10 +1523,10 @@ func _update_emitter_beam_cone(light: SpotLight3D, beam_angle: float, beam_range
 		var lens_radius: float = max(float(light.get_meta("peraviz_lens_radius", 0.03)), 0.005)
 		if gdtf_beam_radius > 0.0:
 			lens_radius = max(gdtf_beam_radius, 0.005)
-		cone_mesh.top_radius = clamp(radius, 0.03, EMITTER_CONE_MAX_BASE_RADIUS_M)
-		cone_mesh.bottom_radius = lens_radius
+		cone_mesh.top_radius = lens_radius
+		cone_mesh.bottom_radius = clamp(radius, 0.03, EMITTER_CONE_MAX_BASE_RADIUS_M)
 		cone_mesh.height = beam_range
-	cone.position = Vector3(0.0, 0.0, beam_range * 0.5)
+	cone.position = Vector3(0.0, 0.0, -beam_range * 0.5)
 
 	var material: ShaderMaterial = cone.material_override as ShaderMaterial
 	if material != null:

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -90,6 +90,7 @@ const EMITTER_LIGHT_RANGE_BEAM_RADIUS_MULTIPLIER: float = 320.0
 const EMITTER_LIGHT_ENERGY_SCALE: float = 0.03
 const EMITTER_LIGHT_MAX_BEAM_ANGLE_DEG: float = 45.0
 const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 4.0
+const EMITTER_LIGHT_MAX_FOOTPRINT_RADIUS_M: float = EMITTER_CONE_MAX_BASE_RADIUS_M
 const ENV_QUALITY_PRESET_SETTING: String = "peraviz_environment_quality"
 const ENV_QUALITY_PRESET_DEFAULT: String = "medium"
 const ENVIRONMENT_QUALITY_PRESETS := {
@@ -1443,7 +1444,12 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 	light.light_energy = luminous_flux * normalized_dimmer * EMITTER_LIGHT_ENERGY_SCALE
 	light.spot_angle = beam_angle
 	light.spot_attenuation = clamp(beam_angle / field_angle, 0.2, 1.0)
-	light.spot_range = clamp(beam_radius_m * EMITTER_LIGHT_RANGE_BEAM_RADIUS_MULTIPLIER, EMITTER_LIGHT_MIN_RANGE_M, EMITTER_LIGHT_MAX_RANGE_M)
+	var nominal_spot_range: float = clamp(beam_radius_m * EMITTER_LIGHT_RANGE_BEAM_RADIUS_MULTIPLIER, EMITTER_LIGHT_MIN_RANGE_M, EMITTER_LIGHT_MAX_RANGE_M)
+	var beam_half_angle_tan: float = tan(deg_to_rad(beam_angle * 0.5))
+	var max_spot_range_from_footprint: float = EMITTER_LIGHT_MAX_RANGE_M
+	if beam_half_angle_tan > 0.0001:
+		max_spot_range_from_footprint = max(EMITTER_LIGHT_MAX_FOOTPRINT_RADIUS_M / beam_half_angle_tan, EMITTER_LIGHT_MIN_RANGE_M)
+	light.spot_range = clamp(min(nominal_spot_range, max_spot_range_from_footprint), EMITTER_LIGHT_MIN_RANGE_M, EMITTER_LIGHT_MAX_RANGE_M)
 	light.light_color = _derive_emitter_color(photometric)
 	var beam_radius_from_gdtf: bool = bool(photometric.get("beam_radius_from_gdtf", false))
 	var source_beam_radius: float = beam_radius_m if beam_radius_from_gdtf else -1.0

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -1263,6 +1263,9 @@ func _find_or_create_emitter_light(emitter_node: Node3D) -> SpotLight3D:
 		if child is SpotLight3D and child.name == "PeravizEmitterLight":
 			if child.rotation_degrees != EMITTER_LIGHT_DIRECTION_FIX:
 				child.rotation_degrees = EMITTER_LIGHT_DIRECTION_FIX
+			# Keep spotlight footprint behavior stable while pan/tilt moves the fixture.
+			# Self/caster shadows from fixture geometry can clip the floor footprint.
+			child.shadow_enabled = false
 			child.set_meta("peraviz_lens_radius", lens_radius)
 			return child
 
@@ -1271,7 +1274,7 @@ func _find_or_create_emitter_light(emitter_node: Node3D) -> SpotLight3D:
 	light.position = Vector3.ZERO
 	light.rotation_degrees = EMITTER_LIGHT_DIRECTION_FIX
 	light.light_negative = false
-	light.shadow_enabled = true
+	light.shadow_enabled = false
 	light.spot_range = 60.0
 	light.spot_angle = 25.0
 	light.spot_attenuation = 1.0

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -93,6 +93,7 @@ const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 4.0
 const EMITTER_LIGHT_MAX_FOOTPRINT_RADIUS_M: float = EMITTER_CONE_MAX_BASE_RADIUS_M
 const EMITTER_LIGHT_MIN_EFFECTIVE_RANGE_M: float = 0.75
 const EMITTER_BEAM_LENGTH_SCALE: float = 2.0
+const EMITTER_LIGHT_FOOTPRINT_RANGE_MULTIPLIER: float = 2.0
 const EMITTER_CONE_FADE_END_RATIO: float = 0.82
 const EMITTER_CONE_NEAR_ALPHA: float = 0.06
 const EMITTER_CONE_FAR_ALPHA: float = 0.004
@@ -1459,11 +1460,14 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 	var max_spot_range_from_footprint: float = EMITTER_LIGHT_MAX_RANGE_M
 	if beam_slope > 0.0001:
 		max_spot_range_from_footprint = max(EMITTER_LIGHT_MAX_FOOTPRINT_RADIUS_M / beam_slope, EMITTER_LIGHT_MIN_EFFECTIVE_RANGE_M)
-	light.spot_range = clamp(min(nominal_spot_range, max_spot_range_from_footprint), EMITTER_LIGHT_MIN_EFFECTIVE_RANGE_M, EMITTER_LIGHT_MAX_RANGE_M)
+	var cone_range: float = clamp(min(nominal_spot_range, max_spot_range_from_footprint), EMITTER_LIGHT_MIN_EFFECTIVE_RANGE_M, EMITTER_LIGHT_MAX_RANGE_M)
+	# SpotLight3D footprint follows transform by default in Godot; this extension only
+	# avoids early floor clipping on steep tilt while keeping cone visuals unchanged.
+	light.spot_range = clamp(cone_range * EMITTER_LIGHT_FOOTPRINT_RANGE_MULTIPLIER, EMITTER_LIGHT_MIN_EFFECTIVE_RANGE_M, EMITTER_LIGHT_MAX_RANGE_M)
 	light.light_color = _derive_emitter_color(photometric)
 	var beam_radius_from_gdtf: bool = bool(photometric.get("beam_radius_from_gdtf", false))
 	var source_beam_radius: float = beam_radius_m if beam_radius_from_gdtf else -1.0
-	_update_emitter_beam_cone(light, beam_angle, light.spot_range, light.light_color, normalized_dimmer, source_beam_radius)
+	_update_emitter_beam_cone(light, beam_angle, cone_range, light.light_color, normalized_dimmer, source_beam_radius)
 
 func _create_emitter_beam_cone() -> MeshInstance3D:
 	var cone := MeshInstance3D.new()

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -1480,7 +1480,7 @@ func _create_emitter_beam_material() -> ShaderMaterial:
 	var shader := Shader.new()
 	shader.code = """
 shader_type spatial;
-render_mode unshaded, blend_add, cull_disabled, depth_draw_never, shadows_disabled;
+render_mode unshaded, blend_add, cull_disabled, depth_draw_never, depth_test_disabled, shadows_disabled;
 
 uniform vec4 beam_color : source_color = vec4(1.0, 0.85, 0.55, 1.0);
 uniform float near_alpha = 0.06;
@@ -1497,7 +1497,7 @@ void vertex() {
 }
 
 void fragment() {
-	float near_factor = 1.0 - beam_axial;
+	float near_factor = beam_axial;
 	ALBEDO = beam_color.rgb;
 	ALPHA = mix(far_alpha, near_alpha, near_factor);
 	EMISSION = beam_color.rgb * mix(far_emission, near_emission, near_factor);

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -92,6 +92,8 @@ const EMITTER_LIGHT_MAX_BEAM_ANGLE_DEG: float = 45.0
 const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 4.0
 const EMITTER_LIGHT_MAX_FOOTPRINT_RADIUS_M: float = EMITTER_CONE_MAX_BASE_RADIUS_M
 const EMITTER_LIGHT_MIN_EFFECTIVE_RANGE_M: float = 0.75
+const EMITTER_BEAM_LENGTH_SCALE: float = 2.0
+const EMITTER_CONE_FADE_END_RATIO: float = 0.82
 const EMITTER_CONE_NEAR_ALPHA: float = 0.06
 const EMITTER_CONE_FAR_ALPHA: float = 0.004
 const EMITTER_CONE_NEAR_EMISSION: float = 0.45
@@ -1449,11 +1451,11 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 	light.light_energy = luminous_flux * normalized_dimmer * EMITTER_LIGHT_ENERGY_SCALE
 	light.spot_angle = beam_angle
 	light.spot_attenuation = clamp(beam_angle / field_angle, 0.2, 1.0)
-	var nominal_spot_range: float = clamp(beam_radius_m * EMITTER_LIGHT_RANGE_BEAM_RADIUS_MULTIPLIER, EMITTER_LIGHT_MIN_RANGE_M, EMITTER_LIGHT_MAX_RANGE_M)
-	var beam_half_angle_tan: float = tan(deg_to_rad(beam_angle * 0.5))
+	var beam_slope: float = tan(deg_to_rad(beam_angle))
+	var nominal_spot_range: float = beam_radius_m * EMITTER_LIGHT_RANGE_BEAM_RADIUS_MULTIPLIER * EMITTER_BEAM_LENGTH_SCALE
 	var max_spot_range_from_footprint: float = EMITTER_LIGHT_MAX_RANGE_M
-	if beam_half_angle_tan > 0.0001:
-		max_spot_range_from_footprint = max(EMITTER_LIGHT_MAX_FOOTPRINT_RADIUS_M / beam_half_angle_tan, EMITTER_LIGHT_MIN_EFFECTIVE_RANGE_M)
+	if beam_slope > 0.0001:
+		max_spot_range_from_footprint = max(EMITTER_LIGHT_MAX_FOOTPRINT_RADIUS_M / beam_slope, EMITTER_LIGHT_MIN_EFFECTIVE_RANGE_M)
 	light.spot_range = clamp(min(nominal_spot_range, max_spot_range_from_footprint), EMITTER_LIGHT_MIN_EFFECTIVE_RANGE_M, EMITTER_LIGHT_MAX_RANGE_M)
 	light.light_color = _derive_emitter_color(photometric)
 	var beam_radius_from_gdtf: bool = bool(photometric.get("beam_radius_from_gdtf", false))
@@ -1488,6 +1490,7 @@ uniform float far_alpha = 0.004;
 uniform float near_emission = 0.45;
 uniform float far_emission = 0.04;
 uniform float cone_height = 1.0;
+uniform float fade_end_ratio = 0.82;
 
 varying float beam_axial;
 
@@ -1498,9 +1501,10 @@ void vertex() {
 
 void fragment() {
 	float near_factor = beam_axial;
+	float end_fade = 1.0 - smoothstep(clamp(fade_end_ratio, 0.0, 0.99), 1.0, beam_axial);
 	ALBEDO = beam_color.rgb;
-	ALPHA = mix(far_alpha, near_alpha, near_factor);
-	EMISSION = beam_color.rgb * mix(far_emission, near_emission, near_factor);
+	ALPHA = mix(far_alpha, near_alpha, near_factor) * end_fade;
+	EMISSION = beam_color.rgb * (mix(far_emission, near_emission, near_factor) * end_fade);
 }
 """
 	shader_material.shader = shader
@@ -1519,7 +1523,7 @@ func _update_emitter_beam_cone(light: SpotLight3D, beam_angle: float, beam_range
 	cone.visible = intensity > 0.015
 	var cone_mesh: CylinderMesh = cone.mesh as CylinderMesh
 	if cone_mesh != null:
-		var radius: float = tan(deg_to_rad(beam_angle * 0.5)) * beam_range
+		var radius: float = tan(deg_to_rad(beam_angle)) * beam_range
 		var lens_radius: float = max(float(light.get_meta("peraviz_lens_radius", 0.03)), 0.005)
 		if gdtf_beam_radius > 0.0:
 			lens_radius = max(gdtf_beam_radius, 0.005)
@@ -1536,6 +1540,7 @@ func _update_emitter_beam_cone(light: SpotLight3D, beam_angle: float, beam_range
 		material.set_shader_parameter("near_emission", lerp(0.0, EMITTER_CONE_NEAR_EMISSION, intensity))
 		material.set_shader_parameter("far_emission", lerp(0.0, EMITTER_CONE_FAR_EMISSION, intensity))
 		material.set_shader_parameter("cone_height", max(beam_range, 0.001))
+		material.set_shader_parameter("fade_end_ratio", EMITTER_CONE_FADE_END_RATIO)
 
 func _apply_fixture_lens_visual_tuning(fixture_uuid: String, emitter_nodes: Array) -> void:
 	if _fixture_lens_tuned.get(fixture_uuid, false):

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -1451,7 +1451,7 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 	light.light_energy = luminous_flux * normalized_dimmer * EMITTER_LIGHT_ENERGY_SCALE
 	light.spot_angle = beam_angle
 	light.spot_attenuation = clamp(beam_angle / field_angle, 0.2, 1.0)
-	var beam_slope: float = tan(deg_to_rad(beam_angle))
+	var beam_slope: float = tan(deg_to_rad(beam_angle * 0.5))
 	var nominal_spot_range: float = beam_radius_m * EMITTER_LIGHT_RANGE_BEAM_RADIUS_MULTIPLIER * EMITTER_BEAM_LENGTH_SCALE
 	var max_spot_range_from_footprint: float = EMITTER_LIGHT_MAX_RANGE_M
 	if beam_slope > 0.0001:
@@ -1501,7 +1501,8 @@ void vertex() {
 
 void fragment() {
 	float near_factor = beam_axial;
-	float end_fade = 1.0 - smoothstep(clamp(fade_end_ratio, 0.0, 0.99), 1.0, beam_axial);
+	float far_progress = 1.0 - beam_axial;
+	float end_fade = 1.0 - smoothstep(clamp(fade_end_ratio, 0.0, 0.99), 1.0, far_progress);
 	ALBEDO = beam_color.rgb;
 	ALPHA = mix(far_alpha, near_alpha, near_factor) * end_fade;
 	EMISSION = beam_color.rgb * (mix(far_emission, near_emission, near_factor) * end_fade);
@@ -1523,7 +1524,7 @@ func _update_emitter_beam_cone(light: SpotLight3D, beam_angle: float, beam_range
 	cone.visible = intensity > 0.015
 	var cone_mesh: CylinderMesh = cone.mesh as CylinderMesh
 	if cone_mesh != null:
-		var radius: float = tan(deg_to_rad(beam_angle)) * beam_range
+		var radius: float = tan(deg_to_rad(beam_angle * 0.5)) * beam_range
 		var lens_radius: float = max(float(light.get_meta("peraviz_lens_radius", 0.03)), 0.005)
 		if gdtf_beam_radius > 0.0:
 			lens_radius = max(gdtf_beam_radius, 0.005)

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -85,8 +85,11 @@ const DOUBLE_SIDED_MATERIAL_HINTS: Array[String] = [
 ]
 const IMPORTED_CONTENT_SCALE: float = 1.0
 const EMITTER_LIGHT_MIN_RANGE_M: float = 8.0
-const EMITTER_LIGHT_MAX_RANGE_M: float = 180.0
-const EMITTER_LIGHT_RANGE_BEAM_RADIUS_MULTIPLIER: float = 900.0
+const EMITTER_LIGHT_MAX_RANGE_M: float = 90.0
+const EMITTER_LIGHT_RANGE_BEAM_RADIUS_MULTIPLIER: float = 320.0
+const EMITTER_LIGHT_ENERGY_SCALE: float = 0.03
+const EMITTER_LIGHT_MAX_BEAM_ANGLE_DEG: float = 45.0
+const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 4.0
 const ENV_QUALITY_PRESET_SETTING: String = "peraviz_environment_quality"
 const ENV_QUALITY_PRESET_DEFAULT: String = "medium"
 const ENVIRONMENT_QUALITY_PRESETS := {
@@ -1432,12 +1435,12 @@ func _extract_emitter_photometrics(item: Dictionary) -> Dictionary:
 
 func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, normalized_dimmer: float) -> void:
 	var luminous_flux: float = max(float(photometric.get("luminous_flux", 10000.0)), 0.0)
-	var beam_angle: float = clamp(float(photometric.get("beam_angle", 25.0)), 0.1, 179.0)
-	var field_angle: float = clamp(float(photometric.get("field_angle", beam_angle)), beam_angle, 179.0)
+	var beam_angle: float = clamp(float(photometric.get("beam_angle", 25.0)), 0.1, EMITTER_LIGHT_MAX_BEAM_ANGLE_DEG)
+	var field_angle: float = clamp(float(photometric.get("field_angle", beam_angle)), beam_angle, EMITTER_LIGHT_MAX_BEAM_ANGLE_DEG)
 	var beam_radius_m: float = max(float(photometric.get("beam_radius", 0.05)), 0.001)
 
 	light.visible = normalized_dimmer > 0.0001
-	light.light_energy = luminous_flux * normalized_dimmer
+	light.light_energy = luminous_flux * normalized_dimmer * EMITTER_LIGHT_ENERGY_SCALE
 	light.spot_angle = beam_angle
 	light.spot_attenuation = clamp(beam_angle / field_angle, 0.2, 1.0)
 	light.spot_range = clamp(beam_radius_m * EMITTER_LIGHT_RANGE_BEAM_RADIUS_MULTIPLIER, EMITTER_LIGHT_MIN_RANGE_M, EMITTER_LIGHT_MAX_RANGE_M)
@@ -1490,15 +1493,15 @@ func _update_emitter_beam_cone(light: SpotLight3D, beam_angle: float, beam_range
 		if gdtf_beam_radius > 0.0:
 			top_radius = max(gdtf_beam_radius, 0.005)
 		cone_mesh.top_radius = top_radius
-		cone_mesh.bottom_radius = max(radius, 0.03)
+		cone_mesh.bottom_radius = clamp(radius, 0.03, EMITTER_CONE_MAX_BASE_RADIUS_M)
 		cone_mesh.height = beam_range
 	cone.position = Vector3(0.0, 0.0, -beam_range * 0.5)
 
 	var material: StandardMaterial3D = cone.material_override as StandardMaterial3D
 	if material != null:
-		material.albedo_color = Color(beam_color.r, beam_color.g, beam_color.b, lerp(0.01, 0.12, intensity))
+		material.albedo_color = Color(beam_color.r, beam_color.g, beam_color.b, lerp(0.008, 0.06, intensity))
 		material.emission = beam_color
-		material.emission_energy_multiplier = lerp(0.1, 1.1, intensity)
+		material.emission_energy_multiplier = lerp(0.06, 0.45, intensity)
 
 func _apply_fixture_lens_visual_tuning(fixture_uuid: String, emitter_nodes: Array) -> void:
 	if _fixture_lens_tuned.get(fixture_uuid, false):

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -91,6 +91,10 @@ const EMITTER_LIGHT_ENERGY_SCALE: float = 0.03
 const EMITTER_LIGHT_MAX_BEAM_ANGLE_DEG: float = 45.0
 const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 4.0
 const EMITTER_LIGHT_MAX_FOOTPRINT_RADIUS_M: float = EMITTER_CONE_MAX_BASE_RADIUS_M
+const EMITTER_CONE_NEAR_ALPHA: float = 0.06
+const EMITTER_CONE_FAR_ALPHA: float = 0.004
+const EMITTER_CONE_NEAR_EMISSION: float = 0.45
+const EMITTER_CONE_FAR_EMISSION: float = 0.04
 const ENV_QUALITY_PRESET_SETTING: String = "peraviz_environment_quality"
 const ENV_QUALITY_PRESET_DEFAULT: String = "medium"
 const ENVIRONMENT_QUALITY_PRESETS := {
@@ -1467,18 +1471,39 @@ func _create_emitter_beam_cone() -> MeshInstance3D:
 	cone.mesh = cone_mesh
 	cone.rotation_degrees.x = 90.0
 
-	var cone_material := StandardMaterial3D.new()
-	cone_material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
-	cone_material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
-	cone_material.blend_mode = BaseMaterial3D.BLEND_MODE_ADD
-	cone_material.no_depth_test = true
-	cone_material.cull_mode = BaseMaterial3D.CULL_DISABLED
-	cone_material.albedo_color = Color(1.0, 0.9, 0.7, 0.08)
-	cone_material.emission_enabled = true
-	cone_material.emission = Color(1.0, 0.85, 0.55)
-	cone_material.emission_energy_multiplier = 0.7
-	cone.material_override = cone_material
+	cone.material_override = _create_emitter_beam_material()
 	return cone
+
+func _create_emitter_beam_material() -> ShaderMaterial:
+	var shader_material := ShaderMaterial.new()
+	var shader := Shader.new()
+	shader.code = """
+shader_type spatial;
+render_mode unshaded, blend_add, cull_disabled, depth_draw_never, shadows_disabled;
+
+uniform vec4 beam_color : source_color = vec4(1.0, 0.85, 0.55, 1.0);
+uniform float near_alpha = 0.06;
+uniform float far_alpha = 0.004;
+uniform float near_emission = 0.45;
+uniform float far_emission = 0.04;
+uniform float cone_height = 1.0;
+
+varying float beam_axial;
+
+void vertex() {
+	float normalized_y = (VERTEX.y / max(cone_height, 0.0001)) + 0.5;
+	beam_axial = clamp(normalized_y, 0.0, 1.0);
+}
+
+void fragment() {
+	float near_factor = 1.0 - beam_axial;
+	ALBEDO = beam_color.rgb;
+	ALPHA = mix(far_alpha, near_alpha, near_factor);
+	EMISSION = beam_color.rgb * mix(far_emission, near_emission, near_factor);
+}
+"""
+	shader_material.shader = shader
+	return shader_material
 
 func _update_emitter_beam_cone(light: SpotLight3D, beam_angle: float, beam_range: float, beam_color: Color, normalized_dimmer: float, gdtf_beam_radius: float = -1.0) -> void:
 	if not light.has_meta("peraviz_beam_cone"):
@@ -1495,19 +1520,21 @@ func _update_emitter_beam_cone(light: SpotLight3D, beam_angle: float, beam_range
 	if cone_mesh != null:
 		var radius: float = tan(deg_to_rad(beam_angle * 0.5)) * beam_range
 		var lens_radius: float = max(float(light.get_meta("peraviz_lens_radius", 0.03)), 0.005)
-		var top_radius: float = lens_radius
 		if gdtf_beam_radius > 0.0:
-			top_radius = max(gdtf_beam_radius, 0.005)
-		cone_mesh.top_radius = top_radius
-		cone_mesh.bottom_radius = clamp(radius, 0.03, EMITTER_CONE_MAX_BASE_RADIUS_M)
+			lens_radius = max(gdtf_beam_radius, 0.005)
+		cone_mesh.top_radius = clamp(radius, 0.03, EMITTER_CONE_MAX_BASE_RADIUS_M)
+		cone_mesh.bottom_radius = lens_radius
 		cone_mesh.height = beam_range
-	cone.position = Vector3(0.0, 0.0, -beam_range * 0.5)
+	cone.position = Vector3(0.0, 0.0, beam_range * 0.5)
 
-	var material: StandardMaterial3D = cone.material_override as StandardMaterial3D
+	var material: ShaderMaterial = cone.material_override as ShaderMaterial
 	if material != null:
-		material.albedo_color = Color(beam_color.r, beam_color.g, beam_color.b, lerp(0.008, 0.06, intensity))
-		material.emission = beam_color
-		material.emission_energy_multiplier = lerp(0.06, 0.45, intensity)
+		material.set_shader_parameter("beam_color", Color(beam_color.r, beam_color.g, beam_color.b, 1.0))
+		material.set_shader_parameter("near_alpha", lerp(0.0, EMITTER_CONE_NEAR_ALPHA, intensity))
+		material.set_shader_parameter("far_alpha", lerp(0.0, EMITTER_CONE_FAR_ALPHA, intensity))
+		material.set_shader_parameter("near_emission", lerp(0.0, EMITTER_CONE_NEAR_EMISSION, intensity))
+		material.set_shader_parameter("far_emission", lerp(0.0, EMITTER_CONE_FAR_EMISSION, intensity))
+		material.set_shader_parameter("cone_height", max(beam_range, 0.001))
 
 func _apply_fixture_lens_visual_tuning(fixture_uuid: String, emitter_nodes: Array) -> void:
 	if _fixture_lens_tuned.get(fixture_uuid, false):


### PR DESCRIPTION
### Motivation
- Beam proxies in Peraviz could become visually excessive (very large cones, extreme intensity) when consuming wide photometric values, so runtime limits and scaling are needed to keep beams reasonable in the scene. 
- The change is focused on runtime visual tuning of emitter lights to reduce visual clutter without changing parsing or scene registry behavior.

### Description
- Updated `peraviz/scripts/load_scene.gd` to introduce and use new tuning constants: `EMITTER_LIGHT_ENERGY_SCALE`, `EMITTER_LIGHT_MAX_BEAM_ANGLE_DEG`, and `EMITTER_CONE_MAX_BASE_RADIUS_M`, and reduced `EMITTER_LIGHT_MAX_RANGE_M` and `EMITTER_LIGHT_RANGE_BEAM_RADIUS_MULTIPLIER`.
- Clamped `beam_angle`/`field_angle` to `EMITTER_LIGHT_MAX_BEAM_ANGLE_DEG` and scaled `light.light_energy` by `EMITTER_LIGHT_ENERGY_SCALE` to avoid over-intense spot lights.
- Capped the visual cone base radius using `clamp(radius, 0.03, EMITTER_CONE_MAX_BASE_RADIUS_M)` and reduced the cone material alpha and `emission_energy_multiplier` ranges to make beam meshes less visually aggressive.
- All changes are localized to `peraviz/scripts/load_scene.gd` and do not alter fixture parsing or scene registration logic.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (`OK`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994bb4d76808324a4e8f3972018b0c2)