### PR TITLE
Relax Peraviz Godot ignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -373,9 +373,9 @@ FodyWeavers.xsd
 # Godot / Peraviz
 # ---------------------------------------------------------------------------
 
-# Godot imported assets cache (generated)
-.peraviz/.godot/
-peraviz/.godot/
+# Godot generated cache folders (keep project files versioned)
+peraviz/.godot/imported/
+peraviz/.godot/shader_cache/
 
 # Godot export presets can be kept (optional). If you don't want them versioned, uncomment:
 # peraviz/export_presets.cfg

--- a/peraviz/.gitignore
+++ b/peraviz/.gitignore
@@ -1,6 +1,6 @@
-# Godot 4+ specific ignores
-.godot/
-/android/
+# Godot generated cache folders (keep project files versioned)
+.godot/imported/
+.godot/shader_cache/
 
 # Example MVR
 *.mvr


### PR DESCRIPTION
### Motivation
- Make the Peraviz Godot project files shareable and consistent across machines by removing an overly-broad ignore that prevented important Godot project files from being tracked while still excluding generated caches and exported builds.

### Description
- Updated the root `.gitignore` and `peraviz/.gitignore` to stop ignoring the entire `peraviz/.godot` tree and instead ignore only generated cache folders (`peraviz/.godot/imported/` and `peraviz/.godot/shader_cache/`), removed the broad `/android/` ignore in `peraviz/.gitignore`, and kept `*.mvr` ignored for test MVR files.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995761f60ac8324ad2e5cafee4e3c97)