### PR TITLE
Fix VS IntelliSense profile to match Windows x64 C++20 build settings

### DIFF
--- a/CppProperties.json
+++ b/CppProperties.json
@@ -2,10 +2,11 @@
   "configurations": [
     {
       "inheritEnvironments": [
-        "msvc_x86"
+        "msvc_x64_x64"
       ],
-      "name": "x86-Debug",
+      "name": "x64-Debug",
       "includePath": [
+        "C:/vcpkg/installed/x64-windows/include",
         "${env.VCPKG_ROOT}\\installed\\x64-windows\\include",
         "${env.INCLUDE}",
         "${workspaceRoot}\\**"
@@ -16,7 +17,8 @@
         "UNICODE",
         "_UNICODE"
       ],
-      "intelliSenseMode": "windows-msvc-x86"
+      "intelliSenseMode": "windows-msvc-x64",
+      "cppStandard": "c++20"
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- Editor (IntelliSense) reported many false-positive/inactive errors because the VS/VSCode IntelliSense profile did not match the actual Windows x64 + C++20 build configuration and could not resolve vcpkg includes.

### Description
- Updated `CppProperties.json` to align IntelliSense with the real toolchain by changing `inheritEnvironments` from `msvc_x86` to `msvc_x64_x64`, renaming the profile to `x64-Debug`, adding `C:/vcpkg/installed/x64-windows/include` to `includePath`, setting `intelliSenseMode` to `windows-msvc-x64`, and adding `cppStandard: "c++20"`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both checks passed (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699589abc008832499db941f11c5952b)