### PR TITLE
Adjust emitter beam shader depth mode for occlusion

### DIFF
--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -1493,7 +1493,7 @@ func _create_emitter_beam_material() -> ShaderMaterial:
 	var shader := Shader.new()
 	shader.code = """
 shader_type spatial;
-render_mode unshaded, blend_add, cull_disabled, depth_draw_never, depth_test_disabled, shadows_disabled;
+render_mode unshaded, blend_add, cull_disabled, depth_prepass_alpha, shadows_disabled;
 
 uniform vec4 beam_color : source_color = vec4(1.0, 0.85, 0.55, 1.0);
 uniform float near_alpha = 0.06;


### PR DESCRIPTION
### Motivation
- Prevent the emitter beam cone from rendering through opaque fixture geometry by enabling depth testing while retaining the additive volumetric look in the beam shader.

### Description
- In `peraviz/scripts/load_scene.gd` update `_create_emitter_beam_material()` by replacing `render_mode unshaded, blend_add, cull_disabled, depth_draw_never, depth_test_disabled, shadows_disabled;` with `render_mode unshaded, blend_add, cull_disabled, depth_prepass_alpha, shadows_disabled;` to use a depth prepass for alpha while keeping `unshaded`/`blend_add` behavior.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995a11099f0832492bd0b218ed5f04a)