### PR TITLE
peraviz: add visual settings popup with runtime lighting controls

### DIFF
--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -24,6 +24,8 @@ extends Node3D
 @onready var tilt_slider: HSlider = $HUD/FixtureDebugPanel/Margin/VBox/TiltSlider
 @onready var dimmer_slider: HSlider = $HUD/FixtureDebugPanel/Margin/VBox/DimmerSlider
 @onready var quick_reset_button: Button = $HUD/FixtureDebugPanel/Margin/VBox/QuickResetButton
+@onready var visual_settings_button: Button = $HUD/VisualSettingsButton
+@onready var visual_settings_window: VisualSettingsWindow = $HUD/VisualSettingsWindow
 
 var _loader := PeravizLoader.new()
 var _scene_registry := SceneRegistry.new()
@@ -42,6 +44,18 @@ var _fixture_emitter_light_cache: Dictionary = {}
 var _fixture_emitter_photometrics: Dictionary = {}
 var _fixture_lens_tuned: Dictionary = {}
 var _updating_fixture_controls: bool = false
+var _visual_environment_baseline := {
+	"ambient_light_energy": 0.2,
+	"glow_bloom": 0.05,
+	"background_color": Color(0.129412, 0.137255, 0.156863, 1.0),
+}
+var _visual_settings := {
+	"ambient_multiplier": 1.0,
+	"spot_multiplier": 1.0,
+	"beam_multiplier": 1.0,
+	"bloom_multiplier": 1.0,
+	"background_color": Color(0.129412, 0.137255, 0.156863, 1.0),
+}
 
 var _dmx_receiver = null
 var _dmx_toggle_button: Button
@@ -155,6 +169,8 @@ func _ready() -> void:
 	dimmer_min_input.value_changed.connect(_on_limit_changed)
 	dimmer_max_input.value_changed.connect(_on_limit_changed)
 	quick_reset_button.pressed.connect(_on_quick_reset_pressed)
+	visual_settings_button.pressed.connect(_on_visual_settings_pressed)
+	visual_settings_window.settings_changed.connect(_on_visual_settings_changed)
 	picker.access = FileDialog.ACCESS_FILESYSTEM
 	status_label.text = "Select a .mvr file"
 	_debug_coords_enabled = bool(ProjectSettings.get_setting("peraviz_debug_coords", false))
@@ -164,10 +180,14 @@ func _ready() -> void:
 	_asset_cache.configure_debug_logging(_debug_asset_cache_enabled, 100)
 	_ensure_debug_gizmo_root()
 	_update_debug_legend()
+	_refresh_emitter_visual_scalars()
 	_refresh_fixture_debug_panel()
 	_setup_dmx_controls()
 	_setup_dmx_fixture_runtime()
 	_apply_environment_quality_preset()
+	_capture_visual_environment_baseline()
+	visual_settings_window.configure(_visual_settings)
+	_apply_visual_settings(_visual_settings)
 
 
 func _apply_imported_content_scale() -> void:
@@ -184,6 +204,61 @@ func _apply_environment_quality_preset() -> void:
 	var preset_config: Dictionary = ENVIRONMENT_QUALITY_PRESETS.get(requested_preset, {})
 	for property_name in preset_config.keys():
 		world_environment.environment.set(property_name, preset_config[property_name])
+
+func _capture_visual_environment_baseline() -> void:
+	if world_environment == null or world_environment.environment == null:
+		return
+	_visual_environment_baseline["ambient_light_energy"] = float(world_environment.environment.ambient_light_energy)
+	_visual_environment_baseline["glow_bloom"] = float(world_environment.environment.glow_bloom)
+	_visual_environment_baseline["background_color"] = world_environment.environment.background_color
+	_visual_settings["background_color"] = _visual_environment_baseline["background_color"]
+
+func _apply_visual_settings(settings: Dictionary) -> void:
+	for key in _visual_settings.keys():
+		if settings.has(key):
+			_visual_settings[key] = settings[key]
+
+	if world_environment != null and world_environment.environment != null:
+		world_environment.environment.ambient_light_energy = float(_visual_environment_baseline.get("ambient_light_energy", 0.2)) * float(_visual_settings.get("ambient_multiplier", 1.0))
+		world_environment.environment.glow_bloom = float(_visual_environment_baseline.get("glow_bloom", 0.05)) * float(_visual_settings.get("bloom_multiplier", 1.0))
+		world_environment.environment.background_color = _visual_settings.get("background_color", _visual_environment_baseline.get("background_color", Color(0.129412, 0.137255, 0.156863, 1.0)))
+
+	_refresh_emitter_visual_scalars()
+
+func _refresh_emitter_visual_scalars() -> void:
+	for fixture_uuid in _fixture_emitter_light_cache.keys():
+		var lights: Array = _fixture_emitter_light_cache.get(fixture_uuid, [])
+		for light in lights:
+			if light is SpotLight3D and is_instance_valid(light):
+				_apply_visual_scalars_to_light(light)
+
+func _apply_visual_scalars_to_light(light: SpotLight3D) -> void:
+	var base_energy: float = float(light.get_meta("peraviz_base_light_energy", light.light_energy))
+	light.light_energy = base_energy * float(_visual_settings.get("spot_multiplier", 1.0))
+	_update_existing_beam_material_scalars(light)
+
+func _update_existing_beam_material_scalars(light: SpotLight3D) -> void:
+	if not light.has_meta("peraviz_beam_cone"):
+		return
+	var cone: MeshInstance3D = light.get_meta("peraviz_beam_cone") as MeshInstance3D
+	if cone == null:
+		return
+	var material: ShaderMaterial = cone.material_override as ShaderMaterial
+	if material == null:
+		return
+	var base_intensity: float = float(light.get_meta("peraviz_beam_base_intensity", 0.0))
+	var beam_multiplier: float = float(_visual_settings.get("beam_multiplier", 1.0))
+	var scaled_intensity: float = clamp(base_intensity * beam_multiplier, 0.0, 3.0)
+	material.set_shader_parameter("near_alpha", lerp(0.0, EMITTER_CONE_NEAR_ALPHA, scaled_intensity))
+	material.set_shader_parameter("far_alpha", lerp(0.0, EMITTER_CONE_FAR_ALPHA, scaled_intensity))
+	material.set_shader_parameter("near_emission", lerp(0.0, EMITTER_CONE_NEAR_EMISSION, scaled_intensity))
+	material.set_shader_parameter("far_emission", lerp(0.0, EMITTER_CONE_FAR_EMISSION, scaled_intensity))
+
+func _on_visual_settings_pressed() -> void:
+	visual_settings_window.popup_settings()
+
+func _on_visual_settings_changed(settings: Dictionary) -> void:
+	_apply_visual_settings(settings)
 
 func _on_load_pressed() -> void:
 	picker.popup_centered_ratio(0.7)
@@ -216,6 +291,7 @@ func _on_file_selected(path: String) -> void:
 			" material(hit/miss)=", hit_by_kind.get("material", 0), "/", miss_by_kind.get("material", 0))
 	status_label.text = "Nodes: %d (press F to focus, C debug coords)" % nodes.size()
 	_update_debug_legend()
+	_refresh_emitter_visual_scalars()
 
 func _on_manual_fixture_toggle(enabled: bool) -> void:
 	_manual_fixture_test_enabled = enabled
@@ -1456,7 +1532,9 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 	var beam_radius_m: float = max(float(photometric.get("beam_radius", 0.05)), 0.001)
 
 	light.visible = normalized_dimmer > 0.0001
-	light.light_energy = luminous_flux * normalized_dimmer * EMITTER_LIGHT_ENERGY_SCALE
+	var base_light_energy: float = luminous_flux * normalized_dimmer * EMITTER_LIGHT_ENERGY_SCALE
+	light.set_meta("peraviz_base_light_energy", base_light_energy)
+	light.light_energy = base_light_energy * float(_visual_settings.get("spot_multiplier", 1.0))
 	light.spot_angle = beam_angle
 	light.spot_attenuation = clamp(beam_angle / field_angle, 0.2, 1.0)
 	var beam_slope: float = tan(deg_to_rad(beam_angle * 0.5))
@@ -1532,7 +1610,10 @@ func _update_emitter_beam_cone(light: SpotLight3D, beam_angle: float, beam_range
 		light.add_child(cone)
 
 	var intensity: float = clamp(normalized_dimmer, 0.0, 1.0)
+	light.set_meta("peraviz_beam_base_intensity", intensity)
 	cone.visible = intensity > 0.015
+	var beam_multiplier: float = float(_visual_settings.get("beam_multiplier", 1.0))
+	var scaled_intensity: float = clamp(intensity * beam_multiplier, 0.0, 3.0)
 	var cone_mesh: CylinderMesh = cone.mesh as CylinderMesh
 	if cone_mesh != null:
 		var radius: float = tan(deg_to_rad(beam_angle * 0.5)) * beam_range
@@ -1547,10 +1628,10 @@ func _update_emitter_beam_cone(light: SpotLight3D, beam_angle: float, beam_range
 	var material: ShaderMaterial = cone.material_override as ShaderMaterial
 	if material != null:
 		material.set_shader_parameter("beam_color", Color(beam_color.r, beam_color.g, beam_color.b, 1.0))
-		material.set_shader_parameter("near_alpha", lerp(0.0, EMITTER_CONE_NEAR_ALPHA, intensity))
-		material.set_shader_parameter("far_alpha", lerp(0.0, EMITTER_CONE_FAR_ALPHA, intensity))
-		material.set_shader_parameter("near_emission", lerp(0.0, EMITTER_CONE_NEAR_EMISSION, intensity))
-		material.set_shader_parameter("far_emission", lerp(0.0, EMITTER_CONE_FAR_EMISSION, intensity))
+		material.set_shader_parameter("near_alpha", lerp(0.0, EMITTER_CONE_NEAR_ALPHA, scaled_intensity))
+		material.set_shader_parameter("far_alpha", lerp(0.0, EMITTER_CONE_FAR_ALPHA, scaled_intensity))
+		material.set_shader_parameter("near_emission", lerp(0.0, EMITTER_CONE_NEAR_EMISSION, scaled_intensity))
+		material.set_shader_parameter("far_emission", lerp(0.0, EMITTER_CONE_FAR_EMISSION, scaled_intensity))
 		material.set_shader_parameter("cone_height", max(beam_range, 0.001))
 		material.set_shader_parameter("fade_end_ratio", EMITTER_CONE_FADE_END_RATIO)
 

--- a/peraviz/scripts/visual_settings_window.gd
+++ b/peraviz/scripts/visual_settings_window.gd
@@ -1,0 +1,164 @@
+extends Window
+
+class_name VisualSettingsWindow
+
+signal settings_changed(settings: Dictionary)
+
+const DEFAULT_SETTINGS := {
+	"ambient_multiplier": 1.0,
+	"spot_multiplier": 1.0,
+	"beam_multiplier": 1.0,
+	"bloom_multiplier": 1.0,
+	"background_color": Color(0.129412, 0.137255, 0.156863, 1.0),
+}
+
+var _settings: Dictionary = DEFAULT_SETTINGS.duplicate(true)
+var _ambient_slider: HSlider
+var _ambient_value_label: Label
+var _spot_slider: HSlider
+var _spot_value_label: Label
+var _beam_slider: HSlider
+var _beam_value_label: Label
+var _bloom_slider: HSlider
+var _bloom_value_label: Label
+var _background_picker: ColorPickerButton
+
+func _init() -> void:
+	title = "Visual Settings"
+	size = Vector2i(420, 340)
+	unresizable = false
+
+func _ready() -> void:
+	close_requested.connect(_on_close_requested)
+	_build_ui()
+	_apply_settings_to_controls()
+
+func configure(initial_settings: Dictionary) -> void:
+	if initial_settings.is_empty():
+		return
+	for key in DEFAULT_SETTINGS.keys():
+		if initial_settings.has(key):
+			_settings[key] = initial_settings[key]
+	if is_node_ready():
+		_apply_settings_to_controls()
+
+func popup_settings() -> void:
+	popup_centered()
+	grab_focus()
+
+func _build_ui() -> void:
+	var root: MarginContainer = MarginContainer.new()
+	root.set_anchors_preset(Control.PRESET_FULL_RECT)
+	root.add_theme_constant_override("margin_left", 12)
+	root.add_theme_constant_override("margin_top", 12)
+	root.add_theme_constant_override("margin_right", 12)
+	root.add_theme_constant_override("margin_bottom", 12)
+	add_child(root)
+
+	var container: VBoxContainer = VBoxContainer.new()
+	container.add_theme_constant_override("separation", 10)
+	root.add_child(container)
+
+	_ambient_slider = _add_slider_row(container, "Ambient light", "ambient_multiplier", 0.0, 3.0, 0.01)
+	_spot_slider = _add_slider_row(container, "Spot intensity", "spot_multiplier", 0.0, 3.0, 0.01)
+	_beam_slider = _add_slider_row(container, "Beam intensity", "beam_multiplier", 0.0, 3.0, 0.01)
+	_bloom_slider = _add_slider_row(container, "Bloom", "bloom_multiplier", 0.0, 3.0, 0.01)
+
+	var background_row: HBoxContainer = HBoxContainer.new()
+	background_row.add_theme_constant_override("separation", 8)
+	container.add_child(background_row)
+
+	var background_label: Label = Label.new()
+	background_label.text = "Background color"
+	background_label.custom_minimum_size = Vector2(150, 0)
+	background_row.add_child(background_label)
+
+	_background_picker = ColorPickerButton.new()
+	_background_picker.custom_minimum_size = Vector2(180, 30)
+	_background_picker.color_changed.connect(_on_background_color_changed)
+	background_row.add_child(_background_picker)
+
+	var actions_row: HBoxContainer = HBoxContainer.new()
+	actions_row.alignment = BoxContainer.ALIGNMENT_END
+	container.add_child(actions_row)
+
+	var reset_button: Button = Button.new()
+	reset_button.text = "Reset"
+	reset_button.pressed.connect(_on_reset_pressed)
+	actions_row.add_child(reset_button)
+
+func _add_slider_row(parent: VBoxContainer,
+		label_text: String,
+		key: String,
+		min_value: float,
+		max_value: float,
+		step: float) -> HSlider:
+	var row: HBoxContainer = HBoxContainer.new()
+	row.add_theme_constant_override("separation", 8)
+	parent.add_child(row)
+
+	var setting_label: Label = Label.new()
+	setting_label.text = label_text
+	setting_label.custom_minimum_size = Vector2(150, 0)
+	row.add_child(setting_label)
+
+	var slider: HSlider = HSlider.new()
+	slider.min_value = min_value
+	slider.max_value = max_value
+	slider.step = step
+	slider.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	slider.value_changed.connect(func(value: float) -> void:
+		_on_slider_changed(key, value)
+	)
+	row.add_child(slider)
+
+	var value_label: Label = Label.new()
+	value_label.custom_minimum_size = Vector2(44, 0)
+	value_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+	row.add_child(value_label)
+
+	match key:
+		"ambient_multiplier":
+			_ambient_value_label = value_label
+		"spot_multiplier":
+			_spot_value_label = value_label
+		"beam_multiplier":
+			_beam_value_label = value_label
+		"bloom_multiplier":
+			_bloom_value_label = value_label
+
+	return slider
+
+func _apply_settings_to_controls() -> void:
+	_ambient_slider.value = float(_settings.get("ambient_multiplier", 1.0))
+	_spot_slider.value = float(_settings.get("spot_multiplier", 1.0))
+	_beam_slider.value = float(_settings.get("beam_multiplier", 1.0))
+	_bloom_slider.value = float(_settings.get("bloom_multiplier", 1.0))
+	_background_picker.color = _settings.get("background_color", DEFAULT_SETTINGS["background_color"])
+	_update_value_labels()
+
+func _on_slider_changed(key: String, value: float) -> void:
+	_settings[key] = value
+	_update_value_labels()
+	_emit_settings_changed()
+
+func _on_background_color_changed(color: Color) -> void:
+	_settings["background_color"] = color
+	_emit_settings_changed()
+
+func _on_reset_pressed() -> void:
+	_settings = DEFAULT_SETTINGS.duplicate(true)
+	_apply_settings_to_controls()
+	_emit_settings_changed()
+
+func _update_value_labels() -> void:
+	_ambient_value_label.text = "%.2f" % float(_settings.get("ambient_multiplier", 1.0))
+	_spot_value_label.text = "%.2f" % float(_settings.get("spot_multiplier", 1.0))
+	_beam_value_label.text = "%.2f" % float(_settings.get("beam_multiplier", 1.0))
+	_bloom_value_label.text = "%.2f" % float(_settings.get("bloom_multiplier", 1.0))
+
+func _emit_settings_changed() -> void:
+	settings_changed.emit(_settings.duplicate(true))
+
+func _on_close_requested() -> void:
+	hide()

--- a/peraviz/scripts/visual_settings_window.gd.uid
+++ b/peraviz/scripts/visual_settings_window.gd.uid
@@ -1,0 +1,1 @@
+uid://bq8n5oubm8j8u

--- a/peraviz/test.tscn
+++ b/peraviz/test.tscn
@@ -2,6 +2,7 @@
 
 [ext_resource type="Script" path="res://scripts/load_scene.gd" id="1_script"]
 [ext_resource type="Script" path="res://scripts/editor_camera.gd" id="2_camera_script"]
+[ext_resource type="Script" path="res://scripts/visual_settings_window.gd" id="3_visual_settings"]
 
 [sub_resource type="PlaneMesh" id="PlaneMesh_ground"]
 size = Vector2(100, 100)
@@ -92,6 +93,16 @@ offset_top = 12.0
 offset_right = 430.0
 offset_bottom = 44.0
 text = "Manual fixture test"
+
+[node name="VisualSettingsButton" type="Button" parent="HUD"]
+offset_left = 440.0
+offset_top = 12.0
+offset_right = 620.0
+offset_bottom = 44.0
+text = "Visual settings"
+
+[node name="VisualSettingsWindow" type="Window" parent="HUD"]
+script = ExtResource("3_visual_settings")
 
 [node name="FixtureDebugPanel" type="PanelContainer" parent="HUD"]
 visible = false


### PR DESCRIPTION
### Motivation
- Provide an in-viewer UI to tune visual rendering parameters (ambient light, spot intensity, beam intensity, bloom and background color) so designers can iterate quickly without rebuilding scenes.

### Description
- Added a new `VisualSettingsWindow` Godot script at `peraviz/scripts/visual_settings_window.gd` implementing sliders, a background color picker and a `settings_changed` signal.
- Added a HUD `VisualSettingsButton` and an instance of the window in `peraviz/test.tscn` to open the popup from the viewer HUD.
- Integrated the popup into the runtime in `peraviz/scripts/load_scene.gd` by wiring button / window signals, capturing an environment baseline from `WorldEnvironment`, applying live environment changes (`ambient_light_energy`, `glow_bloom`, background color) and applying spot/beam multipliers to emitter SpotLight3D instances by storing base values in light metadata and updating beam shader parameters.
- Technical note: `load_scene.gd` is a large, hotspot file and this change adds visual-settings responsibilities; recommend extracting the visual/settings application logic into a small dedicated module (e.g. `visual_settings_manager.gd`) in a follow-up to keep responsibilities modular.

### Testing
- `tests/check_perastage_tree_modules.sh` — OK.
- `tests/check_no_configmanager_get_in_gui.sh` — OK.
- Attempted an automated Playwright screenshot to visually validate the popup but it failed because there is no reachable HTTP endpoint for the Godot UI in this environment (expected limitation, not a runtime failure of the changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995a6215e38832485562745c56d5804)