### PR TITLE
Fix scene object deletion crash by stabilizing UUID erasure

### DIFF
--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -692,11 +692,21 @@ void SceneObjectTablePanel::DeleteSelected()
             rows.push_back(r);
     }
     std::sort(rows.begin(), rows.end(), std::greater<int>());
+    rows.erase(std::unique(rows.begin(), rows.end()), rows.end());
+
+    std::vector<std::string> uuidsToDelete;
+    uuidsToDelete.reserve(rows.size());
+    for (int r : rows) {
+        if (r >= 0 && static_cast<size_t>(r) < rowUuids.size())
+            uuidsToDelete.push_back(rowUuids[r]);
+    }
 
     auto& scene = guiConfigServices->LegacyConfigManager().GetScene();
+    for (const auto& uuid : uuidsToDelete)
+        scene.sceneObjects.erase(uuid);
+
     for (int r : rows) {
         if ((size_t)r < rowUuids.size()) {
-            scene.sceneObjects.erase(rowUuids[r]);
             rowUuids.erase(rowUuids.begin() + r);
             table->DeleteItem(r);
         }


### PR DESCRIPTION
### Motivation
- Deleting scene objects could trigger a read-access/hashing crash because the code erased map keys while still relying on row-index-backed UUIDs during iteration. 
- The intent is to make deletion robust by avoiding use-after-modify access to row/UUID state while mutating the scene and UI structures.

### Description
- Deduplicate selected row indices before processing to avoid repeated work and index conflicts.
- Snapshot the UUIDs to delete into a stable `uuidsToDelete` vector and erase `scene.sceneObjects` from that stable list before modifying `rowUuids` or the UI table.
- Remove the previous in-loop erasure of `scene.sceneObjects` that read UUIDs from a structure being mutated while rows were removed.
- Changed file: `gui/sceneobjecttablepanel.cpp` (updates are localized to `SceneObjectTablePanel::DeleteSelected()`).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995b4ff97908324bdd572564478edf0)