### PR TITLE
Add DMX Zoom support with GDTF zoom range parsing in Peraviz

### DIFF
--- a/peraviz/native/src/dmx/fixture_dmx_binding.cpp
+++ b/peraviz/native/src/dmx/fixture_dmx_binding.cpp
@@ -72,11 +72,21 @@ FixtureBindingBuildResult build_dimmer_bindings(
             to_channel_index_0(patch, offsets.tilt_fine_offset_1_based);
         binding.tilt.ultra_fine_dmx_channel_index_0 =
             to_channel_index_0(patch, offsets.tilt_ultra_fine_offset_1_based);
+        binding.zoom.coarse_dmx_channel_index_0 =
+            to_channel_index_0(patch, offsets.zoom_coarse_offset_1_based);
+        binding.zoom.fine_dmx_channel_index_0 =
+            to_channel_index_0(patch, offsets.zoom_fine_offset_1_based);
+        binding.zoom.ultra_fine_dmx_channel_index_0 =
+            to_channel_index_0(patch, offsets.zoom_ultra_fine_offset_1_based);
+        binding.has_zoom_physical_limits = offsets.has_zoom_physical_limits;
+        binding.zoom_physical_min_degrees = offsets.zoom_physical_min_degrees;
+        binding.zoom_physical_max_degrees = offsets.zoom_physical_max_degrees;
 
         const bool has_dimmer = is_valid_channel_index(binding.dimmer.coarse_dmx_channel_index_0);
         const bool has_pan = is_valid_channel_index(binding.pan.coarse_dmx_channel_index_0);
         const bool has_tilt = is_valid_channel_index(binding.tilt.coarse_dmx_channel_index_0);
-        if (!has_dimmer && !has_pan && !has_tilt) {
+        const bool has_zoom = is_valid_channel_index(binding.zoom.coarse_dmx_channel_index_0);
+        if (!has_dimmer && !has_pan && !has_tilt && !has_zoom) {
             result.unbound.push_back({patch.fixture_uuid,
                                       "resolved DMX channels are out of 0..511 range"});
             continue;
@@ -105,6 +115,14 @@ FixtureBindingBuildResult build_dimmer_bindings(
         if (binding.tilt.ultra_fine_dmx_channel_index_0 >= 0 &&
             !is_valid_channel_index(binding.tilt.ultra_fine_dmx_channel_index_0)) {
             binding.tilt.ultra_fine_dmx_channel_index_0 = -1;
+        }
+        if (binding.zoom.fine_dmx_channel_index_0 >= 0 &&
+            !is_valid_channel_index(binding.zoom.fine_dmx_channel_index_0)) {
+            binding.zoom.fine_dmx_channel_index_0 = -1;
+        }
+        if (binding.zoom.ultra_fine_dmx_channel_index_0 >= 0 &&
+            !is_valid_channel_index(binding.zoom.ultra_fine_dmx_channel_index_0)) {
+            binding.zoom.ultra_fine_dmx_channel_index_0 = -1;
         }
 
         result.bindings.push_back(binding);

--- a/peraviz/native/src/dmx/fixture_dmx_binding.h
+++ b/peraviz/native/src/dmx/fixture_dmx_binding.h
@@ -26,6 +26,10 @@ struct FixtureControlBinding {
     FixtureAttributeChannel dimmer;
     FixtureAttributeChannel pan;
     FixtureAttributeChannel tilt;
+    FixtureAttributeChannel zoom;
+    bool has_zoom_physical_limits = false;
+    float zoom_physical_min_degrees = -1.0F;
+    float zoom_physical_max_degrees = -1.0F;
     float scale = 1.0F;
 };
 
@@ -49,10 +53,16 @@ struct FixtureControlOffsets {
     int tilt_coarse_offset_1_based = -1;
     int tilt_fine_offset_1_based = -1;
     int tilt_ultra_fine_offset_1_based = -1;
+    int zoom_coarse_offset_1_based = -1;
+    int zoom_fine_offset_1_based = -1;
+    int zoom_ultra_fine_offset_1_based = -1;
+    bool has_zoom_physical_limits = false;
+    float zoom_physical_min_degrees = -1.0F;
+    float zoom_physical_max_degrees = -1.0F;
 
     bool has_any() const {
         return dimmer_coarse_offset_1_based > 0 || pan_coarse_offset_1_based > 0 ||
-               tilt_coarse_offset_1_based > 0;
+               tilt_coarse_offset_1_based > 0 || zoom_coarse_offset_1_based > 0;
     }
 };
 

--- a/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
@@ -130,6 +130,7 @@ enum class AttributeRole {
     kDimmer,
     kPan,
     kTilt,
+    kZoom,
 };
 
 struct ParsedAttribute {
@@ -242,6 +243,10 @@ ParsedAttribute parse_attribute_name(const std::string &raw_attribute) {
     } else if (starts_with_role_token(leaf, "tilt", byte_index)) {
         parsed.role = AttributeRole::kTilt;
         parsed.byte_index = byte_index;
+    } else if (starts_with_role_token(leaf, "zoom", byte_index) ||
+               starts_with_role_token(leaf, "digitalzoom", byte_index)) {
+        parsed.role = AttributeRole::kZoom;
+        parsed.byte_index = byte_index;
     }
 
     if (parsed.role == AttributeRole::kUnknown) {
@@ -253,6 +258,55 @@ ParsedAttribute parse_attribute_name(const std::string &raw_attribute) {
     }
 
     return parsed;
+}
+
+void consume_zoom_physical_range(tinyxml2::XMLElement *channel_function,
+                                 peraviz::dmx::FixtureControlOffsets &out_offsets);
+
+bool parse_float_attr_ci(tinyxml2::XMLElement *node,
+                         const char *attr_name,
+                         const char *attr_name_alt,
+                         float &out_value) {
+    if (!node) {
+        return false;
+    }
+
+    if (node->QueryFloatAttribute(attr_name, &out_value) == tinyxml2::XML_SUCCESS) {
+        return true;
+    }
+    if (node->QueryFloatAttribute(attr_name_alt, &out_value) == tinyxml2::XML_SUCCESS) {
+        return true;
+    }
+    return false;
+}
+
+void consume_zoom_physical_range(tinyxml2::XMLElement *channel_function,
+                                 peraviz::dmx::FixtureControlOffsets &out_offsets) {
+    float physical_from = 0.0F;
+    float physical_to = 0.0F;
+    const bool has_physical_from = parse_float_attr_ci(channel_function, "PhysicalFrom", "physicalfrom", physical_from);
+    const bool has_physical_to = parse_float_attr_ci(channel_function, "PhysicalTo", "physicalto", physical_to);
+    if (!has_physical_from || !has_physical_to) {
+        return;
+    }
+
+    const float min_value = std::min(physical_from, physical_to);
+    const float max_value = std::max(physical_from, physical_to);
+    if (max_value <= min_value || max_value <= 0.0F) {
+        return;
+    }
+
+    if (!out_offsets.has_zoom_physical_limits) {
+        out_offsets.zoom_physical_min_degrees = min_value;
+        out_offsets.zoom_physical_max_degrees = max_value;
+        out_offsets.has_zoom_physical_limits = true;
+        return;
+    }
+
+    out_offsets.zoom_physical_min_degrees =
+        std::min(out_offsets.zoom_physical_min_degrees, min_value);
+    out_offsets.zoom_physical_max_degrees =
+        std::max(out_offsets.zoom_physical_max_degrees, max_value);
 }
 
 void consume_offsets(const std::vector<int> &offsets,
@@ -352,6 +406,13 @@ void consume_channel_offsets(tinyxml2::XMLElement *dmx_channel,
                 break;
             case AttributeRole::kUnknown:
                 break;
+            case AttributeRole::kZoom:
+                consume_offsets(offsets, parsed_attribute.is_fine, parsed_attribute.byte_index,
+                                out_offsets.zoom_coarse_offset_1_based,
+                                out_offsets.zoom_fine_offset_1_based,
+                                out_offsets.zoom_ultra_fine_offset_1_based);
+                consume_zoom_physical_range(channel_function, out_offsets);
+                break;
             }
         }
     }
@@ -427,7 +488,7 @@ DimmerResolveCacheEntry resolve_uncached(const std::string &gdtf_path,
     }
 
     if (!out.offsets.has_any()) {
-        out.reason = "No Dimmer/Pan/Tilt attributes found in mode DMX channels";
+        out.reason = "No Dimmer/Pan/Tilt/Zoom attributes found in mode DMX channels";
         return out;
     }
 

--- a/peraviz/native/src/peraviz_loader.cpp
+++ b/peraviz/native/src/peraviz_loader.cpp
@@ -171,6 +171,12 @@ Dictionary PeravizLoader::build_fixture_dimmer_bindings(int universe_offset) con
         item["tilt_channel_index_0"] = binding.tilt.coarse_dmx_channel_index_0;
         item["tilt_fine_channel_index_0"] = binding.tilt.fine_dmx_channel_index_0;
         item["tilt_ultra_fine_channel_index_0"] = binding.tilt.ultra_fine_dmx_channel_index_0;
+        item["zoom_channel_index_0"] = binding.zoom.coarse_dmx_channel_index_0;
+        item["zoom_fine_channel_index_0"] = binding.zoom.fine_dmx_channel_index_0;
+        item["zoom_ultra_fine_channel_index_0"] = binding.zoom.ultra_fine_dmx_channel_index_0;
+        item["has_zoom_physical_limits"] = binding.has_zoom_physical_limits;
+        item["zoom_physical_min_degrees"] = binding.zoom_physical_min_degrees;
+        item["zoom_physical_max_degrees"] = binding.zoom_physical_max_degrees;
         item["scale"] = binding.scale;
         bindings[binding_index++] = item;
     }

--- a/peraviz/scripts/dmx_fixture_runtime.gd
+++ b/peraviz/scripts/dmx_fixture_runtime.gd
@@ -85,13 +85,21 @@ func apply_dmx(receiver, apply_fixture_callback: Callable) -> void:
 			"pan_norm": 0.0,
 			"has_tilt": false,
 			"tilt_norm": 0.0,
+			"has_zoom": false,
+			"zoom_norm": 0.0,
 		}
 
 		_read_control(binding, frame, "dimmer_channel_index_0", "dimmer_fine_channel_index_0", "dimmer_ultra_fine_channel_index_0", controls, "has_dimmer", "dimmer_norm")
 		_read_control(binding, frame, "pan_channel_index_0", "pan_fine_channel_index_0", "pan_ultra_fine_channel_index_0", controls, "has_pan", "pan_norm")
 		_read_control(binding, frame, "tilt_channel_index_0", "tilt_fine_channel_index_0", "tilt_ultra_fine_channel_index_0", controls, "has_tilt", "tilt_norm")
+		_read_control(binding, frame, "zoom_channel_index_0", "zoom_fine_channel_index_0", "zoom_ultra_fine_channel_index_0", controls, "has_zoom", "zoom_norm")
 
-		if not controls["has_dimmer"] and not controls["has_pan"] and not controls["has_tilt"]:
+		if controls["has_zoom"]:
+			controls["has_zoom_physical_limits"] = bool(binding.get("has_zoom_physical_limits", false))
+			controls["zoom_physical_min_degrees"] = float(binding.get("zoom_physical_min_degrees", -1.0))
+			controls["zoom_physical_max_degrees"] = float(binding.get("zoom_physical_max_degrees", -1.0))
+
+		if not controls["has_dimmer"] and not controls["has_pan"] and not controls["has_tilt"] and not controls["has_zoom"]:
 			continue
 		apply_fixture_callback.call(fixture_uuid, controls)
 

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -105,6 +105,9 @@ const EMITTER_LIGHT_MAX_RANGE_M: float = 90.0
 const EMITTER_LIGHT_RANGE_BEAM_RADIUS_MULTIPLIER: float = 320.0
 const EMITTER_LIGHT_ENERGY_SCALE: float = 0.03
 const EMITTER_LIGHT_MAX_BEAM_ANGLE_DEG: float = 45.0
+const EMITTER_ZOOM_DEFAULT_MIN_BEAM_ANGLE_DEG: float = 4.0
+const EMITTER_ZOOM_DEFAULT_MAX_BEAM_ANGLE_DEG: float = EMITTER_LIGHT_MAX_BEAM_ANGLE_DEG
+const EMITTER_ZOOM_LENS_RANGE_REFERENCE_M: float = 12.0
 const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 4.0
 const EMITTER_LIGHT_MAX_FOOTPRINT_RADIUS_M: float = EMITTER_CONE_MAX_BASE_RADIUS_M
 const EMITTER_LIGHT_MIN_EFFECTIVE_RANGE_M: float = 0.75
@@ -1282,11 +1285,13 @@ func _apply_dmx_controls_to_fixture(fixture_uuid: String, controls: Dictionary) 
 		var tilt_degrees: float = lerp(tilt_min, tilt_max, clamp(float(controls.get("tilt_norm", 0.0)), 0.0, 1.0))
 		_apply_pan_tilt_components_to_fixture(fixture_uuid, has_pan, pan_degrees, has_tilt, tilt_degrees)
 
-	if controls.get("has_dimmer", false):
-		var dimmer_percent: float = clamp(float(controls.get("dimmer_norm", 0.0)), 0.0, 1.0) * 100.0
-		_apply_dimmer_feedback_to_fixture(fixture_uuid, dimmer_percent)
+	if controls.get("has_dimmer", false) or controls.get("has_zoom", false):
+		var dimmer_percent: float = float(MANUAL_DEFAULTS["dimmer"])
+		if controls.get("has_dimmer", false):
+			dimmer_percent = clamp(float(controls.get("dimmer_norm", 0.0)), 0.0, 1.0) * 100.0
+		_apply_dimmer_feedback_to_fixture(fixture_uuid, dimmer_percent, controls)
 
-func _apply_dimmer_feedback_to_fixture(fixture_uuid: String, dimmer: float) -> void:
+func _apply_dimmer_feedback_to_fixture(fixture_uuid: String, dimmer: float, controls: Dictionary = {}) -> void:
 	var geometry_nodes: Array = _to_node3d_array(_scene_registry.get_anchor(fixture_uuid, "geometry_nodes"))
 	var emitter_nodes: Array = _to_node3d_array(_scene_registry.get_anchor(fixture_uuid, "emitters"))
 	if geometry_nodes.is_empty() and emitter_nodes.is_empty():
@@ -1311,7 +1316,7 @@ func _apply_dimmer_feedback_to_fixture(fixture_uuid: String, dimmer: float) -> v
 		var photometric: Dictionary = DEFAULT_EMITTER_PHOTOMETRICS.duplicate(true)
 		if index < emitter_photometrics.size() and emitter_photometrics[index] is Dictionary:
 			photometric.merge(emitter_photometrics[index], true)
-		_apply_emitter_light_state(light, photometric, normalized_dimmer)
+		_apply_emitter_light_state(light, photometric, normalized_dimmer, controls)
 
 func _collect_fixture_emissive_materials(fixture_uuid: String, geometry_nodes: Array) -> Array:
 	if _fixture_emissive_cache.has(fixture_uuid):
@@ -1525,10 +1530,17 @@ func _extract_emitter_photometrics(item: Dictionary) -> Dictionary:
 		data["dominant_wavelength"] = float(item.get("dominant_wavelength", 0.0))
 	return data
 
-func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, normalized_dimmer: float) -> void:
+func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, normalized_dimmer: float, controls: Dictionary = {}) -> void:
 	var luminous_flux: float = max(float(photometric.get("luminous_flux", 10000.0)), 0.0)
 	var beam_angle: float = clamp(float(photometric.get("beam_angle", 25.0)), 0.1, EMITTER_LIGHT_MAX_BEAM_ANGLE_DEG)
 	var field_angle: float = clamp(float(photometric.get("field_angle", beam_angle)), beam_angle, EMITTER_LIGHT_MAX_BEAM_ANGLE_DEG)
+	if bool(controls.get("has_zoom", false)):
+		var zoom_norm: float = clamp(float(controls.get("zoom_norm", 0.0)), 0.0, 1.0)
+		var zoom_limits: Dictionary = _resolve_zoom_beam_limits(light, controls)
+		var zoom_min_angle: float = float(zoom_limits.get("min_beam_angle", EMITTER_ZOOM_DEFAULT_MIN_BEAM_ANGLE_DEG))
+		var zoom_max_angle: float = float(zoom_limits.get("max_beam_angle", EMITTER_ZOOM_DEFAULT_MAX_BEAM_ANGLE_DEG))
+		beam_angle = lerp(zoom_min_angle, zoom_max_angle, zoom_norm)
+		field_angle = max(field_angle, beam_angle)
 	var beam_radius_m: float = max(float(photometric.get("beam_radius", 0.05)), 0.001)
 
 	light.visible = normalized_dimmer > 0.0001
@@ -1550,6 +1562,31 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 	var beam_radius_from_gdtf: bool = bool(photometric.get("beam_radius_from_gdtf", false))
 	var source_beam_radius: float = beam_radius_m if beam_radius_from_gdtf else -1.0
 	_update_emitter_beam_cone(light, beam_angle, cone_range, light.light_color, normalized_dimmer, source_beam_radius)
+
+func _resolve_zoom_beam_limits(light: SpotLight3D, controls: Dictionary) -> Dictionary:
+	var min_beam_angle: float = EMITTER_ZOOM_DEFAULT_MIN_BEAM_ANGLE_DEG
+	var max_beam_angle: float = EMITTER_ZOOM_DEFAULT_MAX_BEAM_ANGLE_DEG
+
+	if bool(controls.get("has_zoom_physical_limits", false)):
+		min_beam_angle = float(controls.get("zoom_physical_min_degrees", min_beam_angle))
+		max_beam_angle = float(controls.get("zoom_physical_max_degrees", max_beam_angle))
+	else:
+		var lens_radius: float = max(float(light.get_meta("peraviz_lens_radius", 0.0)), 0.0)
+		if lens_radius > 0.0:
+			var lens_angle: float = rad_to_deg(2.0 * atan(lens_radius / EMITTER_ZOOM_LENS_RANGE_REFERENCE_M))
+			min_beam_angle = max(lens_angle, 0.1)
+
+	if max_beam_angle < min_beam_angle:
+		var swap_value: float = min_beam_angle
+		min_beam_angle = max_beam_angle
+		max_beam_angle = swap_value
+
+	min_beam_angle = clamp(min_beam_angle, 0.1, EMITTER_LIGHT_MAX_BEAM_ANGLE_DEG)
+	max_beam_angle = clamp(max_beam_angle, min_beam_angle, EMITTER_LIGHT_MAX_BEAM_ANGLE_DEG)
+	return {
+		"min_beam_angle": min_beam_angle,
+		"max_beam_angle": max_beam_angle,
+	}
 
 func _create_emitter_beam_cone() -> MeshInstance3D:
 	var cone := MeshInstance3D.new()


### PR DESCRIPTION
### Motivation

- Parity with existing DMX controls: Peraviz already resolves Pan/Tilt/Dimmer from GDTF and the scene runtime; Zoom should be treated similarly so fixtures exposing only Zoom are usable. 
- Respect GDTF metadata: If a GDTF provides `PhysicalFrom`/`PhysicalTo` for Zoom, surface those as physical zoom limits to drive beam-angle mapping; otherwise provide sensible fallbacks (lens-width-derived minimum or configurable defaults).

### Description

- Added Zoom fields to the binding and offsets types: `FixtureAttributeChannel zoom` and physical limit fields were added to `peraviz/native/src/dmx/fixture_dmx_binding.h` and corresponding offset fields for zoom were added to `FixtureControlOffsets`.
- GDTF parser extended to detect `Zoom`/`DigitalZoom` channel functions and to read `PhysicalFrom`/`PhysicalTo` into `FixtureControlOffsets` via `gdtf_dimmer_resolver.cpp` so parsed zoom min/max (degrees) are available when present.
- Binding pipeline and loader serialization updated so zoom channel indexes and parsed physical limits are exposed to Godot: `fixture_dmx_binding.cpp` maps zoom offsets into bindings and `peraviz_loader.cpp` now includes `zoom_channel_index_*` and zoom limits in the returned `bindings` dictionary.
- Runtime changes to read and apply Zoom: `peraviz/scripts/dmx_fixture_runtime.gd` reads zoom channels into controls, propagates optional `has_zoom_physical_limits` / `zoom_physical_min_degrees` / `zoom_physical_max_degrees` into fixture controls, and `peraviz/scripts/load_scene.gd` applies zoom by adjusting the emitter `beam_angle` when `has_zoom` is present.
- Beam-angle resolution strategy: `_resolve_zoom_beam_limits` returns min/max beam angles using (in order) GDTF-provided physical limits, a lens-width-derived minimum when a lens meta is present, or default min/max constants; `_apply_emitter_light_state` lerps `beam_angle` between those limits using the DMX zoom norm.

### Testing

- Ran `tests/check_perastage_tree_modules.sh` and it passed (OK). 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (OK). 
- Ran `git diff --check` and there were no whitespace or diff-check issues (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995bbcffe1c83248c8b1ea0297e5d9b)