### PR TITLE
Add CMY DMX channel support for Peraviz fixture beams

### DIFF
--- a/peraviz/native/src/dmx/fixture_dmx_binding.cpp
+++ b/peraviz/native/src/dmx/fixture_dmx_binding.cpp
@@ -78,6 +78,24 @@ FixtureBindingBuildResult build_dimmer_bindings(
             to_channel_index_0(patch, offsets.zoom_fine_offset_1_based);
         binding.zoom.ultra_fine_dmx_channel_index_0 =
             to_channel_index_0(patch, offsets.zoom_ultra_fine_offset_1_based);
+        binding.cyan.coarse_dmx_channel_index_0 =
+            to_channel_index_0(patch, offsets.cyan_coarse_offset_1_based);
+        binding.cyan.fine_dmx_channel_index_0 =
+            to_channel_index_0(patch, offsets.cyan_fine_offset_1_based);
+        binding.cyan.ultra_fine_dmx_channel_index_0 =
+            to_channel_index_0(patch, offsets.cyan_ultra_fine_offset_1_based);
+        binding.magenta.coarse_dmx_channel_index_0 =
+            to_channel_index_0(patch, offsets.magenta_coarse_offset_1_based);
+        binding.magenta.fine_dmx_channel_index_0 =
+            to_channel_index_0(patch, offsets.magenta_fine_offset_1_based);
+        binding.magenta.ultra_fine_dmx_channel_index_0 =
+            to_channel_index_0(patch, offsets.magenta_ultra_fine_offset_1_based);
+        binding.yellow.coarse_dmx_channel_index_0 =
+            to_channel_index_0(patch, offsets.yellow_coarse_offset_1_based);
+        binding.yellow.fine_dmx_channel_index_0 =
+            to_channel_index_0(patch, offsets.yellow_fine_offset_1_based);
+        binding.yellow.ultra_fine_dmx_channel_index_0 =
+            to_channel_index_0(patch, offsets.yellow_ultra_fine_offset_1_based);
         binding.has_zoom_physical_limits = offsets.has_zoom_physical_limits;
         binding.zoom_physical_min_degrees = offsets.zoom_physical_min_degrees;
         binding.zoom_physical_max_degrees = offsets.zoom_physical_max_degrees;
@@ -86,7 +104,10 @@ FixtureBindingBuildResult build_dimmer_bindings(
         const bool has_pan = is_valid_channel_index(binding.pan.coarse_dmx_channel_index_0);
         const bool has_tilt = is_valid_channel_index(binding.tilt.coarse_dmx_channel_index_0);
         const bool has_zoom = is_valid_channel_index(binding.zoom.coarse_dmx_channel_index_0);
-        if (!has_dimmer && !has_pan && !has_tilt && !has_zoom) {
+        const bool has_cyan = is_valid_channel_index(binding.cyan.coarse_dmx_channel_index_0);
+        const bool has_magenta = is_valid_channel_index(binding.magenta.coarse_dmx_channel_index_0);
+        const bool has_yellow = is_valid_channel_index(binding.yellow.coarse_dmx_channel_index_0);
+        if (!has_dimmer && !has_pan && !has_tilt && !has_zoom && !has_cyan && !has_magenta && !has_yellow) {
             result.unbound.push_back({patch.fixture_uuid,
                                       "resolved DMX channels are out of 0..511 range"});
             continue;
@@ -123,6 +144,30 @@ FixtureBindingBuildResult build_dimmer_bindings(
         if (binding.zoom.ultra_fine_dmx_channel_index_0 >= 0 &&
             !is_valid_channel_index(binding.zoom.ultra_fine_dmx_channel_index_0)) {
             binding.zoom.ultra_fine_dmx_channel_index_0 = -1;
+        }
+        if (binding.cyan.fine_dmx_channel_index_0 >= 0 &&
+            !is_valid_channel_index(binding.cyan.fine_dmx_channel_index_0)) {
+            binding.cyan.fine_dmx_channel_index_0 = -1;
+        }
+        if (binding.cyan.ultra_fine_dmx_channel_index_0 >= 0 &&
+            !is_valid_channel_index(binding.cyan.ultra_fine_dmx_channel_index_0)) {
+            binding.cyan.ultra_fine_dmx_channel_index_0 = -1;
+        }
+        if (binding.magenta.fine_dmx_channel_index_0 >= 0 &&
+            !is_valid_channel_index(binding.magenta.fine_dmx_channel_index_0)) {
+            binding.magenta.fine_dmx_channel_index_0 = -1;
+        }
+        if (binding.magenta.ultra_fine_dmx_channel_index_0 >= 0 &&
+            !is_valid_channel_index(binding.magenta.ultra_fine_dmx_channel_index_0)) {
+            binding.magenta.ultra_fine_dmx_channel_index_0 = -1;
+        }
+        if (binding.yellow.fine_dmx_channel_index_0 >= 0 &&
+            !is_valid_channel_index(binding.yellow.fine_dmx_channel_index_0)) {
+            binding.yellow.fine_dmx_channel_index_0 = -1;
+        }
+        if (binding.yellow.ultra_fine_dmx_channel_index_0 >= 0 &&
+            !is_valid_channel_index(binding.yellow.ultra_fine_dmx_channel_index_0)) {
+            binding.yellow.ultra_fine_dmx_channel_index_0 = -1;
         }
 
         result.bindings.push_back(binding);

--- a/peraviz/native/src/dmx/fixture_dmx_binding.h
+++ b/peraviz/native/src/dmx/fixture_dmx_binding.h
@@ -27,6 +27,9 @@ struct FixtureControlBinding {
     FixtureAttributeChannel pan;
     FixtureAttributeChannel tilt;
     FixtureAttributeChannel zoom;
+    FixtureAttributeChannel cyan;
+    FixtureAttributeChannel magenta;
+    FixtureAttributeChannel yellow;
     bool has_zoom_physical_limits = false;
     float zoom_physical_min_degrees = -1.0F;
     float zoom_physical_max_degrees = -1.0F;
@@ -56,13 +59,24 @@ struct FixtureControlOffsets {
     int zoom_coarse_offset_1_based = -1;
     int zoom_fine_offset_1_based = -1;
     int zoom_ultra_fine_offset_1_based = -1;
+    int cyan_coarse_offset_1_based = -1;
+    int cyan_fine_offset_1_based = -1;
+    int cyan_ultra_fine_offset_1_based = -1;
+    int magenta_coarse_offset_1_based = -1;
+    int magenta_fine_offset_1_based = -1;
+    int magenta_ultra_fine_offset_1_based = -1;
+    int yellow_coarse_offset_1_based = -1;
+    int yellow_fine_offset_1_based = -1;
+    int yellow_ultra_fine_offset_1_based = -1;
     bool has_zoom_physical_limits = false;
     float zoom_physical_min_degrees = -1.0F;
     float zoom_physical_max_degrees = -1.0F;
 
     bool has_any() const {
         return dimmer_coarse_offset_1_based > 0 || pan_coarse_offset_1_based > 0 ||
-               tilt_coarse_offset_1_based > 0 || zoom_coarse_offset_1_based > 0;
+               tilt_coarse_offset_1_based > 0 || zoom_coarse_offset_1_based > 0 ||
+               cyan_coarse_offset_1_based > 0 || magenta_coarse_offset_1_based > 0 ||
+               yellow_coarse_offset_1_based > 0;
     }
 };
 

--- a/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
@@ -253,8 +253,10 @@ ParsedAttribute parse_attribute_name(const std::string &raw_attribute) {
     } else if (starts_with_role_token(leaf, "cyan", byte_index) ||
                starts_with_role_token(leaf, "coloradd_c", byte_index) ||
                starts_with_role_token(leaf, "coloradd_cyan", byte_index) ||
+               starts_with_role_token(leaf, "coloradd_coarse", byte_index) ||
                starts_with_role_token(leaf, "colorsub_c", byte_index) ||
                starts_with_role_token(leaf, "colorsub_cyan", byte_index) ||
+               starts_with_role_token(leaf, "colorsub_coarse", byte_index) ||
                starts_with_role_token(leaf, "colorrgb_c", byte_index) ||
                starts_with_role_token(leaf, "colorrgb_cyan", byte_index)) {
         parsed.role = AttributeRole::kCyan;

--- a/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
@@ -252,19 +252,28 @@ ParsedAttribute parse_attribute_name(const std::string &raw_attribute) {
         parsed.byte_index = byte_index;
     } else if (starts_with_role_token(leaf, "cyan", byte_index) ||
                starts_with_role_token(leaf, "coloradd_c", byte_index) ||
+               starts_with_role_token(leaf, "coloradd_cyan", byte_index) ||
                starts_with_role_token(leaf, "colorsub_c", byte_index) ||
+               starts_with_role_token(leaf, "colorsub_cyan", byte_index) ||
+               starts_with_role_token(leaf, "colorrgb_c", byte_index) ||
                starts_with_role_token(leaf, "colorrgb_cyan", byte_index)) {
         parsed.role = AttributeRole::kCyan;
         parsed.byte_index = byte_index;
     } else if (starts_with_role_token(leaf, "magenta", byte_index) ||
                starts_with_role_token(leaf, "coloradd_m", byte_index) ||
+               starts_with_role_token(leaf, "coloradd_magenta", byte_index) ||
                starts_with_role_token(leaf, "colorsub_m", byte_index) ||
+               starts_with_role_token(leaf, "colorsub_magenta", byte_index) ||
+               starts_with_role_token(leaf, "colorrgb_m", byte_index) ||
                starts_with_role_token(leaf, "colorrgb_magenta", byte_index)) {
         parsed.role = AttributeRole::kMagenta;
         parsed.byte_index = byte_index;
     } else if (starts_with_role_token(leaf, "yellow", byte_index) ||
                starts_with_role_token(leaf, "coloradd_y", byte_index) ||
+               starts_with_role_token(leaf, "coloradd_yellow", byte_index) ||
                starts_with_role_token(leaf, "colorsub_y", byte_index) ||
+               starts_with_role_token(leaf, "colorsub_yellow", byte_index) ||
+               starts_with_role_token(leaf, "colorrgb_y", byte_index) ||
                starts_with_role_token(leaf, "colorrgb_yellow", byte_index)) {
         parsed.role = AttributeRole::kYellow;
         parsed.byte_index = byte_index;

--- a/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
@@ -251,15 +251,21 @@ ParsedAttribute parse_attribute_name(const std::string &raw_attribute) {
         parsed.role = AttributeRole::kZoom;
         parsed.byte_index = byte_index;
     } else if (starts_with_role_token(leaf, "cyan", byte_index) ||
-               starts_with_role_token(leaf, "coloradd_c", byte_index)) {
+               starts_with_role_token(leaf, "coloradd_c", byte_index) ||
+               starts_with_role_token(leaf, "colorsub_c", byte_index) ||
+               starts_with_role_token(leaf, "colorrgb_cyan", byte_index)) {
         parsed.role = AttributeRole::kCyan;
         parsed.byte_index = byte_index;
     } else if (starts_with_role_token(leaf, "magenta", byte_index) ||
-               starts_with_role_token(leaf, "coloradd_m", byte_index)) {
+               starts_with_role_token(leaf, "coloradd_m", byte_index) ||
+               starts_with_role_token(leaf, "colorsub_m", byte_index) ||
+               starts_with_role_token(leaf, "colorrgb_magenta", byte_index)) {
         parsed.role = AttributeRole::kMagenta;
         parsed.byte_index = byte_index;
     } else if (starts_with_role_token(leaf, "yellow", byte_index) ||
-               starts_with_role_token(leaf, "coloradd_y", byte_index)) {
+               starts_with_role_token(leaf, "coloradd_y", byte_index) ||
+               starts_with_role_token(leaf, "colorsub_y", byte_index) ||
+               starts_with_role_token(leaf, "colorrgb_yellow", byte_index)) {
         parsed.role = AttributeRole::kYellow;
         parsed.byte_index = byte_index;
     }

--- a/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
@@ -131,6 +131,9 @@ enum class AttributeRole {
     kPan,
     kTilt,
     kZoom,
+    kCyan,
+    kMagenta,
+    kYellow,
 };
 
 struct ParsedAttribute {
@@ -246,6 +249,18 @@ ParsedAttribute parse_attribute_name(const std::string &raw_attribute) {
     } else if (starts_with_role_token(leaf, "zoom", byte_index) ||
                starts_with_role_token(leaf, "digitalzoom", byte_index)) {
         parsed.role = AttributeRole::kZoom;
+        parsed.byte_index = byte_index;
+    } else if (starts_with_role_token(leaf, "cyan", byte_index) ||
+               starts_with_role_token(leaf, "coloradd_c", byte_index)) {
+        parsed.role = AttributeRole::kCyan;
+        parsed.byte_index = byte_index;
+    } else if (starts_with_role_token(leaf, "magenta", byte_index) ||
+               starts_with_role_token(leaf, "coloradd_m", byte_index)) {
+        parsed.role = AttributeRole::kMagenta;
+        parsed.byte_index = byte_index;
+    } else if (starts_with_role_token(leaf, "yellow", byte_index) ||
+               starts_with_role_token(leaf, "coloradd_y", byte_index)) {
+        parsed.role = AttributeRole::kYellow;
         parsed.byte_index = byte_index;
     }
 
@@ -413,6 +428,24 @@ void consume_channel_offsets(tinyxml2::XMLElement *dmx_channel,
                                 out_offsets.zoom_ultra_fine_offset_1_based);
                 consume_zoom_physical_range(channel_function, out_offsets);
                 break;
+            case AttributeRole::kCyan:
+                consume_offsets(offsets, parsed_attribute.is_fine, parsed_attribute.byte_index,
+                                out_offsets.cyan_coarse_offset_1_based,
+                                out_offsets.cyan_fine_offset_1_based,
+                                out_offsets.cyan_ultra_fine_offset_1_based);
+                break;
+            case AttributeRole::kMagenta:
+                consume_offsets(offsets, parsed_attribute.is_fine, parsed_attribute.byte_index,
+                                out_offsets.magenta_coarse_offset_1_based,
+                                out_offsets.magenta_fine_offset_1_based,
+                                out_offsets.magenta_ultra_fine_offset_1_based);
+                break;
+            case AttributeRole::kYellow:
+                consume_offsets(offsets, parsed_attribute.is_fine, parsed_attribute.byte_index,
+                                out_offsets.yellow_coarse_offset_1_based,
+                                out_offsets.yellow_fine_offset_1_based,
+                                out_offsets.yellow_ultra_fine_offset_1_based);
+                break;
             }
         }
     }
@@ -488,7 +521,7 @@ DimmerResolveCacheEntry resolve_uncached(const std::string &gdtf_path,
     }
 
     if (!out.offsets.has_any()) {
-        out.reason = "No Dimmer/Pan/Tilt/Zoom attributes found in mode DMX channels";
+        out.reason = "No Dimmer/Pan/Tilt/Zoom/CMY attributes found in mode DMX channels";
         return out;
     }
 

--- a/peraviz/native/src/peraviz_loader.cpp
+++ b/peraviz/native/src/peraviz_loader.cpp
@@ -174,6 +174,15 @@ Dictionary PeravizLoader::build_fixture_dimmer_bindings(int universe_offset) con
         item["zoom_channel_index_0"] = binding.zoom.coarse_dmx_channel_index_0;
         item["zoom_fine_channel_index_0"] = binding.zoom.fine_dmx_channel_index_0;
         item["zoom_ultra_fine_channel_index_0"] = binding.zoom.ultra_fine_dmx_channel_index_0;
+        item["cyan_channel_index_0"] = binding.cyan.coarse_dmx_channel_index_0;
+        item["cyan_fine_channel_index_0"] = binding.cyan.fine_dmx_channel_index_0;
+        item["cyan_ultra_fine_channel_index_0"] = binding.cyan.ultra_fine_dmx_channel_index_0;
+        item["magenta_channel_index_0"] = binding.magenta.coarse_dmx_channel_index_0;
+        item["magenta_fine_channel_index_0"] = binding.magenta.fine_dmx_channel_index_0;
+        item["magenta_ultra_fine_channel_index_0"] = binding.magenta.ultra_fine_dmx_channel_index_0;
+        item["yellow_channel_index_0"] = binding.yellow.coarse_dmx_channel_index_0;
+        item["yellow_fine_channel_index_0"] = binding.yellow.fine_dmx_channel_index_0;
+        item["yellow_ultra_fine_channel_index_0"] = binding.yellow.ultra_fine_dmx_channel_index_0;
         item["has_zoom_physical_limits"] = binding.has_zoom_physical_limits;
         item["zoom_physical_min_degrees"] = binding.zoom_physical_min_degrees;
         item["zoom_physical_max_degrees"] = binding.zoom_physical_max_degrees;

--- a/peraviz/scripts/dmx_fixture_runtime.gd
+++ b/peraviz/scripts/dmx_fixture_runtime.gd
@@ -87,19 +87,28 @@ func apply_dmx(receiver, apply_fixture_callback: Callable) -> void:
 			"tilt_norm": 0.0,
 			"has_zoom": false,
 			"zoom_norm": 0.0,
+			"has_cyan": false,
+			"cyan_norm": 0.0,
+			"has_magenta": false,
+			"magenta_norm": 0.0,
+			"has_yellow": false,
+			"yellow_norm": 0.0,
 		}
 
 		_read_control(binding, frame, "dimmer_channel_index_0", "dimmer_fine_channel_index_0", "dimmer_ultra_fine_channel_index_0", controls, "has_dimmer", "dimmer_norm")
 		_read_control(binding, frame, "pan_channel_index_0", "pan_fine_channel_index_0", "pan_ultra_fine_channel_index_0", controls, "has_pan", "pan_norm")
 		_read_control(binding, frame, "tilt_channel_index_0", "tilt_fine_channel_index_0", "tilt_ultra_fine_channel_index_0", controls, "has_tilt", "tilt_norm")
 		_read_control(binding, frame, "zoom_channel_index_0", "zoom_fine_channel_index_0", "zoom_ultra_fine_channel_index_0", controls, "has_zoom", "zoom_norm")
+		_read_control(binding, frame, "cyan_channel_index_0", "cyan_fine_channel_index_0", "cyan_ultra_fine_channel_index_0", controls, "has_cyan", "cyan_norm")
+		_read_control(binding, frame, "magenta_channel_index_0", "magenta_fine_channel_index_0", "magenta_ultra_fine_channel_index_0", controls, "has_magenta", "magenta_norm")
+		_read_control(binding, frame, "yellow_channel_index_0", "yellow_fine_channel_index_0", "yellow_ultra_fine_channel_index_0", controls, "has_yellow", "yellow_norm")
 
 		if controls["has_zoom"]:
 			controls["has_zoom_physical_limits"] = bool(binding.get("has_zoom_physical_limits", false))
 			controls["zoom_physical_min_degrees"] = float(binding.get("zoom_physical_min_degrees", -1.0))
 			controls["zoom_physical_max_degrees"] = float(binding.get("zoom_physical_max_degrees", -1.0))
 
-		if not controls["has_dimmer"] and not controls["has_pan"] and not controls["has_tilt"] and not controls["has_zoom"]:
+		if not controls["has_dimmer"] and not controls["has_pan"] and not controls["has_tilt"] and not controls["has_zoom"] and not controls["has_cyan"] and not controls["has_magenta"] and not controls["has_yellow"]:
 			continue
 		apply_fixture_callback.call(fixture_uuid, controls)
 

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -1544,9 +1544,7 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 	var beam_radius_m: float = max(float(photometric.get("beam_radius", 0.05)), 0.001)
 
 	light.visible = normalized_dimmer > 0.0001
-	var cmy_filter: Dictionary = _resolve_cmy_filter(controls)
-	var cmy_transmission: float = float(cmy_filter.get("transmission", 1.0))
-	var base_light_energy: float = luminous_flux * normalized_dimmer * EMITTER_LIGHT_ENERGY_SCALE * cmy_transmission
+	var base_light_energy: float = luminous_flux * normalized_dimmer * EMITTER_LIGHT_ENERGY_SCALE
 	light.set_meta("peraviz_base_light_energy", base_light_energy)
 	light.light_energy = base_light_energy * float(_visual_settings.get("spot_multiplier", 1.0))
 	light.spot_angle = beam_angle
@@ -1727,14 +1725,20 @@ func _build_lens_material_override(source: Material) -> StandardMaterial3D:
 
 func _derive_emitter_color(photometric: Dictionary, controls: Dictionary = {}) -> Color:
 	var base_color: Color
-	var wavelength: float = float(photometric.get("dominant_wavelength", 0.0))
-	if wavelength > 0.0:
-		base_color = _wavelength_to_rgb(wavelength)
-	else:
-		var temperature_kelvin: float = clamp(float(photometric.get("color_temperature", 6000.0)), 1000.0, 40000.0)
-		base_color = _color_temperature_to_rgb(temperature_kelvin)
-
 	var cmy_filter: Dictionary = _resolve_cmy_filter(controls)
+	if bool(cmy_filter.get("has_cmy", false)):
+		# CMY color-mixing fixtures are expected to start from an approximately
+		# white source. Using photometric color temperature as the base here can
+		# bias the mix (e.g. weak red output on cool bases).
+		base_color = Color.WHITE
+	else:
+		var wavelength: float = float(photometric.get("dominant_wavelength", 0.0))
+		if wavelength > 0.0:
+			base_color = _wavelength_to_rgb(wavelength)
+		else:
+			var temperature_kelvin: float = clamp(float(photometric.get("color_temperature", 6000.0)), 1000.0, 40000.0)
+			base_color = _color_temperature_to_rgb(temperature_kelvin)
+
 	var filter_color: Color = cmy_filter.get("color", Color.WHITE)
 	return Color(base_color.r * filter_color.r, base_color.g * filter_color.g, base_color.b * filter_color.b, 1.0)
 
@@ -1743,14 +1747,10 @@ func _resolve_cmy_filter(controls: Dictionary) -> Dictionary:
 	var magenta: float = clamp(float(controls.get("magenta_norm", 0.0)), 0.0, 1.0)
 	var yellow: float = clamp(float(controls.get("yellow_norm", 0.0)), 0.0, 1.0)
 	var filter_color := Color(1.0 - cyan, 1.0 - magenta, 1.0 - yellow, 1.0)
-	var transmission: float = clamp(_color_luminance(filter_color), 0.0, 1.0)
 	return {
 		"color": filter_color,
-		"transmission": transmission,
+		"has_cmy": cyan > 0.0001 or magenta > 0.0001 or yellow > 0.0001,
 	}
-
-func _color_luminance(color: Color) -> float:
-	return (0.2126 * color.r) + (0.7152 * color.g) + (0.0722 * color.b)
 
 func _color_temperature_to_rgb(temperature_kelvin: float) -> Color:
 	var t: float = temperature_kelvin / 100.0

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -1544,7 +1544,9 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 	var beam_radius_m: float = max(float(photometric.get("beam_radius", 0.05)), 0.001)
 
 	light.visible = normalized_dimmer > 0.0001
-	var base_light_energy: float = luminous_flux * normalized_dimmer * EMITTER_LIGHT_ENERGY_SCALE
+	var cmy_filter: Dictionary = _resolve_cmy_filter(controls)
+	var cmy_transmission: float = float(cmy_filter.get("transmission", 1.0))
+	var base_light_energy: float = luminous_flux * normalized_dimmer * EMITTER_LIGHT_ENERGY_SCALE * cmy_transmission
 	light.set_meta("peraviz_base_light_energy", base_light_energy)
 	light.light_energy = base_light_energy * float(_visual_settings.get("spot_multiplier", 1.0))
 	light.spot_angle = beam_angle
@@ -1732,10 +1734,23 @@ func _derive_emitter_color(photometric: Dictionary, controls: Dictionary = {}) -
 		var temperature_kelvin: float = clamp(float(photometric.get("color_temperature", 6000.0)), 1000.0, 40000.0)
 		base_color = _color_temperature_to_rgb(temperature_kelvin)
 
+	var cmy_filter: Dictionary = _resolve_cmy_filter(controls)
+	var filter_color: Color = cmy_filter.get("color", Color.WHITE)
+	return Color(base_color.r * filter_color.r, base_color.g * filter_color.g, base_color.b * filter_color.b, 1.0)
+
+func _resolve_cmy_filter(controls: Dictionary) -> Dictionary:
 	var cyan: float = clamp(float(controls.get("cyan_norm", 0.0)), 0.0, 1.0)
 	var magenta: float = clamp(float(controls.get("magenta_norm", 0.0)), 0.0, 1.0)
 	var yellow: float = clamp(float(controls.get("yellow_norm", 0.0)), 0.0, 1.0)
-	return Color(base_color.r * (1.0 - cyan), base_color.g * (1.0 - magenta), base_color.b * (1.0 - yellow), 1.0)
+	var filter_color := Color(1.0 - cyan, 1.0 - magenta, 1.0 - yellow, 1.0)
+	var transmission: float = clamp(_color_luminance(filter_color), 0.0, 1.0)
+	return {
+		"color": filter_color,
+		"transmission": transmission,
+	}
+
+func _color_luminance(color: Color) -> float:
+	return (0.2126 * color.r) + (0.7152 * color.g) + (0.0722 * color.b)
 
 func _color_temperature_to_rgb(temperature_kelvin: float) -> Color:
 	var t: float = temperature_kelvin / 100.0

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -1285,7 +1285,7 @@ func _apply_dmx_controls_to_fixture(fixture_uuid: String, controls: Dictionary) 
 		var tilt_degrees: float = lerp(tilt_min, tilt_max, clamp(float(controls.get("tilt_norm", 0.0)), 0.0, 1.0))
 		_apply_pan_tilt_components_to_fixture(fixture_uuid, has_pan, pan_degrees, has_tilt, tilt_degrees)
 
-	if controls.get("has_dimmer", false) or controls.get("has_zoom", false):
+	if controls.get("has_dimmer", false) or controls.get("has_zoom", false) or controls.get("has_cyan", false) or controls.get("has_magenta", false) or controls.get("has_yellow", false):
 		var dimmer_percent: float = float(MANUAL_DEFAULTS["dimmer"])
 		if controls.get("has_dimmer", false):
 			dimmer_percent = clamp(float(controls.get("dimmer_norm", 0.0)), 0.0, 1.0) * 100.0
@@ -1558,7 +1558,7 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 	# SpotLight3D footprint follows transform by default in Godot; this extension only
 	# avoids early floor clipping on steep tilt while keeping cone visuals unchanged.
 	light.spot_range = clamp(cone_range * EMITTER_LIGHT_FOOTPRINT_RANGE_MULTIPLIER, EMITTER_LIGHT_MIN_EFFECTIVE_RANGE_M, EMITTER_LIGHT_MAX_RANGE_M)
-	light.light_color = _derive_emitter_color(photometric)
+	light.light_color = _derive_emitter_color(photometric, controls)
 	var beam_radius_from_gdtf: bool = bool(photometric.get("beam_radius_from_gdtf", false))
 	var source_beam_radius: float = beam_radius_m if beam_radius_from_gdtf else -1.0
 	_update_emitter_beam_cone(light, beam_angle, cone_range, light.light_color, normalized_dimmer, source_beam_radius)
@@ -1723,12 +1723,19 @@ func _build_lens_material_override(source: Material) -> StandardMaterial3D:
 	material.emission_energy_multiplier = 0.35
 	return material
 
-func _derive_emitter_color(photometric: Dictionary) -> Color:
+func _derive_emitter_color(photometric: Dictionary, controls: Dictionary = {}) -> Color:
+	var base_color: Color
 	var wavelength: float = float(photometric.get("dominant_wavelength", 0.0))
 	if wavelength > 0.0:
-		return _wavelength_to_rgb(wavelength)
-	var temperature_kelvin: float = clamp(float(photometric.get("color_temperature", 6000.0)), 1000.0, 40000.0)
-	return _color_temperature_to_rgb(temperature_kelvin)
+		base_color = _wavelength_to_rgb(wavelength)
+	else:
+		var temperature_kelvin: float = clamp(float(photometric.get("color_temperature", 6000.0)), 1000.0, 40000.0)
+		base_color = _color_temperature_to_rgb(temperature_kelvin)
+
+	var cyan: float = clamp(float(controls.get("cyan_norm", 0.0)), 0.0, 1.0)
+	var magenta: float = clamp(float(controls.get("magenta_norm", 0.0)), 0.0, 1.0)
+	var yellow: float = clamp(float(controls.get("yellow_norm", 0.0)), 0.0, 1.0)
+	return Color(base_color.r * (1.0 - cyan), base_color.g * (1.0 - magenta), base_color.b * (1.0 - yellow), 1.0)
 
 func _color_temperature_to_rgb(temperature_kelvin: float) -> Color:
 	var t: float = temperature_kelvin / 100.0


### PR DESCRIPTION
### Motivation
- Add support for CMY (Cyan/Magenta/Yellow) DMX channels so fixture beams can be colored via DMX the same way pan/tilt/dimmer/zoom are handled.

### Description
- Extend native DMX binding data structures to include `cyan`, `magenta`, and `yellow` coarse/fine/ultra-fine channels and offsets (files updated under `peraviz/native/src/dmx`).
- Update the GDTF DMX attribute resolver to detect CMY attributes (`cyan`, `magenta`, `yellow`, `coloradd_c/m/y`) and populate offsets used when building bindings (`gdtf_dimmer_resolver.cpp`).
- Serialize CMY channel indices from the native loader into the Godot runtime binding dictionary so runtime code can read them (`peraviz/native/src/peraviz_loader.cpp`).
- Read CMY channels in the runtime DMX path and expose normalized `cyan_norm`, `magenta_norm`, `yellow_norm` in the fixture `controls` dictionary (`peraviz/scripts/dmx_fixture_runtime.gd`).
- Apply a subtractive CMY filter to the emitter beam color when updating emitters so incoming CMY DMX values affect visible beam color (`peraviz/scripts/load_scene.gd`).
- Files changed: `peraviz/native/src/dmx/fixture_dmx_binding.h|.cpp`, `peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp`, `peraviz/native/src/peraviz_loader.cpp`, `peraviz/scripts/dmx_fixture_runtime.gd`, `peraviz/scripts/load_scene.gd`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both passed.
- Ran `git diff --check` to detect whitespace/merge issues, which reported no errors.
- All changes were committed locally with the message "Add CMY DMX channel support for Peraviz fixture beams".

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995c3df026c832491ac22424197da96)