### PR TITLE
Align SpotLight footprint with visual cone and soften beam edges

### DIFF
--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -112,7 +112,7 @@ const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 4.0
 const EMITTER_LIGHT_MAX_FOOTPRINT_RADIUS_M: float = EMITTER_CONE_MAX_BASE_RADIUS_M
 const EMITTER_LIGHT_MIN_EFFECTIVE_RANGE_M: float = 0.75
 const EMITTER_BEAM_LENGTH_SCALE: float = 2.0
-const EMITTER_LIGHT_FOOTPRINT_RANGE_MULTIPLIER: float = 1.08
+const EMITTER_LIGHT_FOOTPRINT_RANGE_MULTIPLIER: float = 1.0
 const EMITTER_LIGHT_SPOT_ATTENUATION_FLOOR: float = 0.08
 const EMITTER_LIGHT_SPOT_ATTENUATION_CEIL: float = 0.65
 const EMITTER_CONE_FADE_END_RATIO: float = 0.82
@@ -1619,6 +1619,8 @@ uniform float near_emission = 0.45;
 uniform float far_emission = 0.04;
 uniform float cone_height = 1.0;
 uniform float fade_end_ratio = 0.82;
+uniform float lateral_softness = 0.18;
+uniform float lateral_emission_boost = 0.2;
 
 varying float beam_axial;
 
@@ -1631,9 +1633,12 @@ void fragment() {
 	float near_factor = beam_axial;
 	float far_progress = 1.0 - beam_axial;
 	float end_fade = 1.0 - smoothstep(clamp(fade_end_ratio, 0.0, 0.99), 1.0, far_progress);
+	float view_alignment = abs(dot(normalize(NORMAL), normalize(VIEW)));
+	float lateral_fade = smoothstep(0.0, clamp(lateral_softness, 0.02, 1.0), view_alignment);
+	float center_boost = 1.0 + (lateral_emission_boost * lateral_fade);
 	ALBEDO = beam_color.rgb;
-	ALPHA = mix(far_alpha, near_alpha, near_factor) * end_fade;
-	EMISSION = beam_color.rgb * (mix(far_emission, near_emission, near_factor) * end_fade);
+	ALPHA = mix(far_alpha, near_alpha, near_factor) * end_fade * lateral_fade;
+	EMISSION = beam_color.rgb * (mix(far_emission, near_emission, near_factor) * end_fade * center_boost);
 }
 """
 	shader_material.shader = shader
@@ -1673,6 +1678,8 @@ func _update_emitter_beam_cone(light: SpotLight3D, beam_angle: float, beam_range
 		material.set_shader_parameter("far_emission", lerp(0.0, EMITTER_CONE_FAR_EMISSION, scaled_intensity))
 		material.set_shader_parameter("cone_height", max(beam_range, 0.001))
 		material.set_shader_parameter("fade_end_ratio", EMITTER_CONE_FADE_END_RATIO)
+		material.set_shader_parameter("lateral_softness", 0.18)
+		material.set_shader_parameter("lateral_emission_boost", 0.2)
 
 func _apply_fixture_lens_visual_tuning(fixture_uuid: String, emitter_nodes: Array) -> void:
 	if _fixture_lens_tuned.get(fixture_uuid, false):


### PR DESCRIPTION
### Motivation

- Ensure the SpotLight3D projected footprint matches the rendered beam cone so the gobo/footprint cut aligns exactly with the cone geometry.
- Reduce the hard lateral edge of the beam by introducing a view-aligned lateral falloff while keeping the beam core visually stronger.

### Description

- Updated `peraviz/scripts/load_scene.gd` to set `EMITTER_LIGHT_FOOTPRINT_RANGE_MULTIPLIER` to `1.0` so `SpotLight3D.spot_range` matches the visual cone range.
- Extended the emitter cone shader with two new uniforms `lateral_softness` and `lateral_emission_boost` and computed a `view_alignment`-based `lateral_fade` to soften side edges.
- Applied `lateral_fade` to `ALPHA` and used `center_boost` (derived from `lateral_emission_boost`) to keep the beam core brighter while edges decay.
- Wired the new shader parameters from `_update_emitter_beam_cone` so the effect is applied at runtime alongside existing intensity and color parameters.

### Testing

- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995dccd43a483248a66eabedf7cddb5)