### PR TITLE
Fix volumetric beam gradient and add modular beam renderer + UI settings

### DIFF
--- a/peraviz/docs/BEAM_RENDERING_MODES.md
+++ b/peraviz/docs/BEAM_RENDERING_MODES.md
@@ -1,0 +1,31 @@
+# Beam rendering modes
+
+Peraviz now provides two beam rendering modes in **Visual Settings**:
+
+- **Volumetric (default)**: realistic haze shaft rendering with distance attenuation, view-dependent scattering, soft end fade and quality presets.
+- **Lightweight (legacy)**: previous cone-based beam rendering for low-resource systems.
+
+## Performance guidance
+
+- Use **Volumetric + Low** on integrated GPUs.
+- Use **Volumetric + Medium/High** on desktop GPUs for better smoothness and turbulence detail.
+- Switch to **Lightweight (legacy)** at runtime when you need maximum FPS.
+
+## Quality presets
+
+- **Low**: fewer raymarch steps, no turbulence noise.
+- **Medium**: balanced cost and visual quality.
+- **High**: highest step count and full turbulence contribution.
+
+## Beam axis conventions
+
+The volumetric and legacy cone meshes follow the same axis convention:
+
+- Cone geometry is authored along **local +Y/-Y** (`CylinderMesh.height` axis).
+- Runtime rotates the beam mesh by **+90° on X** so the cone projects along fixture **local -Z** (same direction as `SpotLight3D`).
+- Runtime places the beam center at `position = Vector3(0, 0, -beam_range * 0.5)` so the cone starts near the lens and extends forward.
+
+Shader shaping uses:
+
+- **Axial factor** from local mesh Y to control near-lens intensity and far-end fade.
+- **Radial factor** from local XZ distance to keep the center denser than edges.

--- a/peraviz/scripts/beam_renderers/beam_renderer_base.gd
+++ b/peraviz/scripts/beam_renderers/beam_renderer_base.gd
@@ -1,0 +1,15 @@
+extends RefCounted
+
+class_name BeamRendererBase
+
+func configure(_view_camera: Camera3D, _settings: Dictionary) -> void:
+	pass
+
+func ensure_beam(_light: SpotLight3D) -> void:
+	pass
+
+func update_beam(_light: SpotLight3D, _params: Dictionary) -> void:
+	pass
+
+func cleanup_beam(_light: SpotLight3D) -> void:
+	pass

--- a/peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd
@@ -1,0 +1,123 @@
+extends BeamRendererBase
+
+class_name LegacyConeBeamRenderer
+
+const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 10.0
+const EMITTER_CONE_FADE_END_RATIO: float = 0.82
+const EMITTER_CONE_NEAR_ALPHA: float = 0.16
+const EMITTER_CONE_FAR_ALPHA: float = 0.004
+const EMITTER_CONE_NEAR_EMISSION: float = 0.45
+const EMITTER_CONE_FAR_EMISSION: float = 0.04
+
+const MAIN_KEY: String = "peraviz_beam_cone"
+const MID_KEY: String = "peraviz_beam_cone_mid"
+const CORE_KEY: String = "peraviz_beam_cone_core"
+
+var _shared_material: ShaderMaterial
+
+func _init() -> void:
+	_shared_material = ShaderMaterial.new()
+	_shared_material.shader = load("res://scripts/shaders/legacy_beam_cone.gdshader")
+
+func ensure_beam(light: SpotLight3D) -> void:
+	if not light.has_meta(MAIN_KEY):
+		light.set_meta(MAIN_KEY, _create_cone("PeravizBeamCone"))
+	if not light.has_meta(MID_KEY):
+		light.set_meta(MID_KEY, _create_cone("PeravizBeamMidCone"))
+	if not light.has_meta(CORE_KEY):
+		light.set_meta(CORE_KEY, _create_cone("PeravizBeamCoreCone"))
+
+func update_beam(light: SpotLight3D, params: Dictionary) -> void:
+	ensure_beam(light)
+	var cone: MeshInstance3D = light.get_meta(MAIN_KEY) as MeshInstance3D
+	var mid_cone: MeshInstance3D = light.get_meta(MID_KEY) as MeshInstance3D
+	var core_cone: MeshInstance3D = light.get_meta(CORE_KEY) as MeshInstance3D
+	if cone == null and mid_cone == null and core_cone == null:
+		return
+	_attach_if_needed(light, cone)
+	_attach_if_needed(light, mid_cone)
+	_attach_if_needed(light, core_cone)
+
+	var intensity: float = clamp(float(params.get("normalized_dimmer", 0.0)), 0.0, 1.0)
+	var scaled_intensity: float = clamp(float(params.get("scaled_intensity", 0.0)), 0.0, 3.0)
+	var beam_range: float = max(float(params.get("beam_range", 0.1)), 0.01)
+	var beam_angle: float = max(float(params.get("beam_angle", 1.0)), 0.1)
+	var beam_color: Color = params.get("beam_color", Color.WHITE)
+	var lens_radius: float = max(float(params.get("lens_radius", 0.03)), 0.005)
+	var is_visible: bool = bool(params.get("is_visible", true)) and intensity > 0.015
+
+	if cone != null:
+		cone.visible = is_visible
+	if mid_cone != null:
+		mid_cone.visible = is_visible
+	if core_cone != null:
+		core_cone.visible = is_visible
+	if not is_visible:
+		return
+
+	var beam_half_angle_deg: float = beam_angle * 0.5
+	var radius: float = tan(deg_to_rad(beam_half_angle_deg)) * beam_range
+	var bottom_radius: float = clamp(radius, 0.03, EMITTER_CONE_MAX_BASE_RADIUS_M)
+
+	_update_cone_geometry(cone, lens_radius, bottom_radius, beam_range, 1.0)
+	_update_cone_geometry(mid_cone, lens_radius, bottom_radius, beam_range, 0.7)
+	_update_cone_geometry(core_cone, lens_radius, bottom_radius, beam_range, 0.45)
+
+	var color_alpha := Color(beam_color.r, beam_color.g, beam_color.b, 1.0)
+	_update_cone_material(cone, color_alpha, scaled_intensity, beam_range, 0.35, 0.16, 0.06, 1.0, 1.0)
+	_update_cone_material(mid_cone, color_alpha, scaled_intensity, beam_range, 0.18, 0.26, 0.04, 1.35, 1.25)
+	_update_cone_material(core_cone, color_alpha, scaled_intensity, beam_range, 0.09, 0.35, 0.02, 1.7, 1.5)
+
+func cleanup_beam(light: SpotLight3D) -> void:
+	for meta_key in [MAIN_KEY, MID_KEY, CORE_KEY]:
+		if not light.has_meta(meta_key):
+			continue
+		var cone: MeshInstance3D = light.get_meta(meta_key) as MeshInstance3D
+		if cone != null and is_instance_valid(cone):
+			cone.queue_free()
+		light.remove_meta(meta_key)
+
+func _attach_if_needed(light: SpotLight3D, cone: MeshInstance3D) -> void:
+	if cone != null and cone.get_parent() == null:
+		light.add_child(cone)
+
+func _create_cone(cone_name: String) -> MeshInstance3D:
+	var cone_mesh := CylinderMesh.new()
+	cone_mesh.radial_segments = 40
+	cone_mesh.rings = 6
+	cone_mesh.top_radius = 0.02
+	cone_mesh.bottom_radius = 0.6
+	cone_mesh.height = 8.0
+	var cone := MeshInstance3D.new()
+	cone.name = cone_name
+	cone.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
+	cone.mesh = cone_mesh
+	cone.material_override = _shared_material
+	cone.rotation_degrees.x = 90.0
+	cone.visible = false
+	return cone
+
+func _update_cone_geometry(cone: MeshInstance3D, lens_radius: float, bottom_radius: float, beam_range: float, radius_scale: float) -> void:
+	if cone == null:
+		return
+	var cone_mesh: CylinderMesh = cone.mesh as CylinderMesh
+	if cone_mesh == null:
+		return
+	cone_mesh.top_radius = max(lens_radius * radius_scale, 0.003)
+	cone_mesh.bottom_radius = clamp(bottom_radius * radius_scale, 0.02, EMITTER_CONE_MAX_BASE_RADIUS_M)
+	cone_mesh.height = beam_range
+	cone.position = Vector3(0.0, 0.0, -beam_range * 0.5)
+
+func _update_cone_material(cone: MeshInstance3D, beam_color: Color, scaled_intensity: float, beam_range: float, lateral_softness: float, lateral_emission_boost: float, noise_strength: float, alpha_scale: float, emission_scale: float) -> void:
+	if cone == null:
+		return
+	cone.set_instance_shader_parameter("beam_color", beam_color)
+	cone.set_instance_shader_parameter("near_alpha", lerp(0.0, EMITTER_CONE_NEAR_ALPHA * alpha_scale, scaled_intensity))
+	cone.set_instance_shader_parameter("far_alpha", lerp(0.0, EMITTER_CONE_FAR_ALPHA * alpha_scale, scaled_intensity))
+	cone.set_instance_shader_parameter("near_emission", lerp(0.0, EMITTER_CONE_NEAR_EMISSION * emission_scale, scaled_intensity))
+	cone.set_instance_shader_parameter("far_emission", lerp(0.0, EMITTER_CONE_FAR_EMISSION * emission_scale, scaled_intensity))
+	cone.set_instance_shader_parameter("cone_height", max(beam_range, 0.001))
+	cone.set_instance_shader_parameter("fade_end_ratio", EMITTER_CONE_FADE_END_RATIO)
+	cone.set_instance_shader_parameter("lateral_softness", lateral_softness)
+	cone.set_instance_shader_parameter("lateral_emission_boost", lateral_emission_boost)
+	cone.set_instance_shader_parameter("volumetric_noise_strength", noise_strength)

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -1,0 +1,106 @@
+extends BeamRendererBase
+
+class_name VolumetricBeamRenderer
+
+const BEAM_META_KEY: String = "peraviz_volumetric_beam"
+const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 10.0
+
+const QUALITY_PRESETS := {
+	0: {"steps": 14.0, "noise_multiplier": 0.0},
+	1: {"steps": 28.0, "noise_multiplier": 0.65},
+	2: {"steps": 56.0, "noise_multiplier": 1.0},
+}
+
+var _shared_material: ShaderMaterial
+var _camera: Camera3D
+var _settings: Dictionary = {}
+
+func _init() -> void:
+	_shared_material = ShaderMaterial.new()
+	_shared_material.shader = load("res://scripts/shaders/volumetric_beam.gdshader")
+
+func configure(view_camera: Camera3D, settings: Dictionary) -> void:
+	_camera = view_camera
+	_settings = settings.duplicate(true)
+
+func ensure_beam(light: SpotLight3D) -> void:
+	if light.has_meta(BEAM_META_KEY):
+		return
+	var cone_mesh := CylinderMesh.new()
+	cone_mesh.radial_segments = 48
+	cone_mesh.rings = 12
+	cone_mesh.top_radius = 0.02
+	cone_mesh.bottom_radius = 0.8
+	cone_mesh.height = 8.0
+	var cone := MeshInstance3D.new()
+	cone.name = "PeravizVolumetricBeam"
+	cone.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
+	cone.mesh = cone_mesh
+	cone.material_override = _shared_material
+	cone.rotation_degrees.x = 90.0
+	cone.visible = false
+	light.add_child(cone)
+	light.set_meta(BEAM_META_KEY, cone)
+
+func update_beam(light: SpotLight3D, params: Dictionary) -> void:
+	ensure_beam(light)
+	var cone: MeshInstance3D = light.get_meta(BEAM_META_KEY) as MeshInstance3D
+	if cone == null:
+		return
+
+	var intensity: float = clamp(float(params.get("scaled_intensity", 0.0)), 0.0, 3.0)
+	var threshold: float = float(params.get("intensity_visibility_threshold", 0.015))
+	if intensity <= threshold or not bool(params.get("is_visible", true)):
+		cone.visible = false
+		return
+
+	var beam_range: float = max(float(params.get("beam_range", 0.1)), 0.01)
+	var beam_angle: float = max(float(params.get("beam_angle", 1.0)), 0.1)
+	var beam_color: Color = params.get("beam_color", Color.WHITE)
+	var lens_radius: float = max(float(params.get("lens_radius", 0.03)), 0.005)
+	var distance_limit: float = float(params.get("distance_cull_m", 180.0))
+
+	if _camera != null:
+		var cam_distance: float = _camera.global_position.distance_to(light.global_position)
+		if cam_distance > distance_limit or _camera.is_position_behind(light.global_position):
+			cone.visible = false
+			return
+
+	var half_angle_deg: float = beam_angle * 0.5
+	var radius: float = tan(deg_to_rad(half_angle_deg)) * beam_range
+	var bottom_radius: float = clamp(radius, 0.03, EMITTER_CONE_MAX_BASE_RADIUS_M)
+	var cone_mesh: CylinderMesh = cone.mesh as CylinderMesh
+	if cone_mesh != null:
+		cone_mesh.top_radius = max(lens_radius, 0.003)
+		cone_mesh.bottom_radius = bottom_radius
+		cone_mesh.height = beam_range
+	cone.position = Vector3(0.0, 0.0, -beam_range * 0.5)
+	cone.visible = true
+
+	var quality: int = int(_settings.get("beam_quality", 1))
+	var quality_preset: Dictionary = QUALITY_PRESETS.get(quality, QUALITY_PRESETS[1])
+	var haze_density: float = float(_settings.get("beam_haze_density", 0.22))
+	var anisotropy: float = float(_settings.get("beam_anisotropy", 0.62))
+	var noise_amount: float = float(_settings.get("beam_noise_amount", 0.06)) * float(quality_preset.get("noise_multiplier", 1.0))
+
+	cone.set_instance_shader_parameter("beam_color", Color(beam_color.r, beam_color.g, beam_color.b, 1.0))
+	cone.set_instance_shader_parameter("beam_intensity", intensity)
+	cone.set_instance_shader_parameter("cone_height", beam_range)
+	cone.set_instance_shader_parameter("top_radius", max(lens_radius, 0.003))
+	cone.set_instance_shader_parameter("bottom_radius", bottom_radius)
+	cone.set_instance_shader_parameter("haze_density", haze_density)
+	cone.set_instance_shader_parameter("anisotropy", anisotropy)
+	cone.set_instance_shader_parameter("noise_amount", noise_amount)
+	cone.set_instance_shader_parameter("noise_scale", float(_settings.get("beam_noise_scale", 1.4)))
+	cone.set_instance_shader_parameter("end_fade_ratio", float(params.get("fade_end_ratio", 0.82)))
+	cone.set_instance_shader_parameter("step_count", float(quality_preset.get("steps", 28.0)))
+	cone.set_instance_shader_parameter("beam_range", beam_range)
+	cone.set_instance_shader_parameter("camera_inside_dimmer", 0.6)
+
+func cleanup_beam(light: SpotLight3D) -> void:
+	if not light.has_meta(BEAM_META_KEY):
+		return
+	var cone: MeshInstance3D = light.get_meta(BEAM_META_KEY) as MeshInstance3D
+	if cone != null and is_instance_valid(cone):
+		cone.queue_free()
+	light.remove_meta(BEAM_META_KEY)

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -55,6 +55,12 @@ var _visual_settings := {
 	"spot_multiplier": 1.0,
 	"beam_multiplier": 1.0,
 	"bloom_multiplier": 1.0,
+	"beam_render_mode": 0,
+	"beam_quality": 1,
+	"beam_haze_density": 0.17,
+	"beam_anisotropy": 0.62,
+	"beam_noise_amount": 0.06,
+	"beam_noise_scale": 1.4,
 	"background_color": Color(0.129412, 0.137255, 0.156863, 1.0),
 }
 
@@ -67,8 +73,17 @@ var _dmx_universe_offset_input: SpinBox
 var _dmx_unbound_preview_label: Label
 var _dmx_fixture_runtime = null
 
+var _beam_renderers: Dictionary = {}
+var _active_beam_renderer: BeamRendererBase
+var _active_beam_mode: int = -1
+
+
 const DmxMonitorWindowScript = preload("res://scripts/dmx_monitor_window.gd")
 const DmxFixtureRuntimeScript = preload("res://scripts/dmx_fixture_runtime.gd")
+
+const BeamRendererBaseScript = preload("res://scripts/beam_renderers/beam_renderer_base.gd")
+const LegacyConeBeamRendererScript = preload("res://scripts/beam_renderers/legacy_cone_beam_renderer.gd")
+const VolumetricBeamRendererScript = preload("res://scripts/beam_renderers/volumetric_beam_renderer.gd")
 
 const DEBUG_TOGGLE_KEY: Key = KEY_C
 const MANUAL_TEST_FLAG: String = "--peraviz_manual_fixture_test"
@@ -121,6 +136,12 @@ const EMITTER_CONE_NEAR_ALPHA: float = 0.16
 const EMITTER_CONE_FAR_ALPHA: float = 0.004
 const EMITTER_CONE_NEAR_EMISSION: float = 0.45
 const EMITTER_CONE_FAR_EMISSION: float = 0.04
+const VISUAL_SETTINGS_PROJECT_KEY: String = "peraviz_visual_settings"
+const BEAM_RENDER_MODE_VOLUMETRIC: int = 0
+const BEAM_RENDER_MODE_LEGACY: int = 1
+const BEAM_INTENSITY_VISIBILITY_THRESHOLD: float = 0.015
+const BEAM_DISTANCE_CULL_M: float = 180.0
+
 const ENV_QUALITY_PRESET_SETTING: String = "peraviz_environment_quality"
 const ENV_QUALITY_PRESET_DEFAULT: String = "medium"
 const ENVIRONMENT_QUALITY_PRESETS := {
@@ -192,6 +213,8 @@ func _ready() -> void:
 	_setup_dmx_fixture_runtime()
 	_apply_environment_quality_preset()
 	_capture_visual_environment_baseline()
+	_load_visual_settings_from_project()
+	_initialize_beam_renderers()
 	visual_settings_window.configure(_visual_settings)
 	_apply_visual_settings(_visual_settings)
 
@@ -219,6 +242,21 @@ func _capture_visual_environment_baseline() -> void:
 	_visual_environment_baseline["background_color"] = world_environment.environment.background_color
 	_visual_settings["background_color"] = _visual_environment_baseline["background_color"]
 
+func _load_visual_settings_from_project() -> void:
+	var stored_settings: Variant = ProjectSettings.get_setting(VISUAL_SETTINGS_PROJECT_KEY, {})
+	if stored_settings is Dictionary:
+		for key in _visual_settings.keys():
+			if stored_settings.has(key):
+				_visual_settings[key] = stored_settings[key]
+
+func _save_visual_settings_to_project() -> void:
+	ProjectSettings.set_setting(VISUAL_SETTINGS_PROJECT_KEY, _visual_settings.duplicate(true))
+
+func _initialize_beam_renderers() -> void:
+	_beam_renderers[BEAM_RENDER_MODE_LEGACY] = LegacyConeBeamRendererScript.new()
+	_beam_renderers[BEAM_RENDER_MODE_VOLUMETRIC] = VolumetricBeamRendererScript.new()
+	_update_beam_renderer_mode(true)
+
 func _apply_visual_settings(settings: Dictionary) -> void:
 	for key in _visual_settings.keys():
 		if settings.has(key):
@@ -229,7 +267,36 @@ func _apply_visual_settings(settings: Dictionary) -> void:
 		world_environment.environment.glow_bloom = float(_visual_environment_baseline.get("glow_bloom", 0.05)) * float(_visual_settings.get("bloom_multiplier", 1.0))
 		world_environment.environment.background_color = _visual_settings.get("background_color", _visual_environment_baseline.get("background_color", Color(0.129412, 0.137255, 0.156863, 1.0)))
 
+	_update_beam_renderer_mode(false)
+	_save_visual_settings_to_project()
 	_refresh_emitter_visual_scalars()
+
+func _update_beam_renderer_mode(force_refresh: bool) -> void:
+	var requested_mode: int = int(clamp(int(_visual_settings.get("beam_render_mode", BEAM_RENDER_MODE_VOLUMETRIC)), BEAM_RENDER_MODE_VOLUMETRIC, BEAM_RENDER_MODE_LEGACY))
+	var requested_renderer: BeamRendererBase = _beam_renderers.get(requested_mode, null)
+	if requested_renderer == null:
+		requested_mode = BEAM_RENDER_MODE_LEGACY
+		requested_renderer = _beam_renderers.get(requested_mode, null)
+	if requested_renderer == null:
+		return
+
+	if force_refresh or requested_mode != _active_beam_mode:
+		for fixture_uuid in _fixture_emitter_light_cache.keys():
+			var lights: Array = _fixture_emitter_light_cache.get(fixture_uuid, [])
+			for light_node in lights:
+				if light_node is SpotLight3D and is_instance_valid(light_node):
+					_cleanup_light_beam_renderers(light_node)
+
+	_active_beam_mode = requested_mode
+	_active_beam_renderer = requested_renderer
+	for renderer in _beam_renderers.values():
+		if renderer is BeamRendererBase:
+			renderer.configure(camera, _visual_settings)
+
+func _cleanup_light_beam_renderers(light: SpotLight3D) -> void:
+	for renderer in _beam_renderers.values():
+		if renderer is BeamRendererBase:
+			renderer.cleanup_beam(light)
 
 func _refresh_emitter_visual_scalars() -> void:
 	for fixture_uuid in _fixture_emitter_light_cache.keys():
@@ -245,33 +312,20 @@ func _apply_visual_scalars_to_light(light: SpotLight3D) -> void:
 
 func _update_existing_beam_material_scalars(light: SpotLight3D) -> void:
 	var base_intensity: float = float(light.get_meta("peraviz_beam_base_intensity", 0.0))
+	var beam_params: Dictionary = light.get_meta("peraviz_beam_last_params", {}) if light.has_meta("peraviz_beam_last_params") else {}
+	if beam_params.is_empty():
+		return
 	var beam_multiplier: float = float(_visual_settings.get("beam_multiplier", 1.0))
-	var scaled_intensity: float = clamp(base_intensity * beam_multiplier, 0.0, 3.0)
-	_update_beam_material_scalars_for_meta(light, "peraviz_beam_cone", scaled_intensity)
-	_update_beam_material_scalars_for_meta(light, "peraviz_beam_cone_mid", scaled_intensity)
-	_update_beam_material_scalars_for_meta(light, "peraviz_beam_cone_core", scaled_intensity)
+	beam_params["scaled_intensity"] = clamp(base_intensity * beam_multiplier, 0.0, 3.0)
+	beam_params["beam_quality"] = int(_visual_settings.get("beam_quality", 1))
+	_update_beam_for_light(light, beam_params)
 
-func _update_beam_material_scalars_for_meta(light: SpotLight3D, cone_meta_key: String, scaled_intensity: float) -> void:
-	if not light.has_meta(cone_meta_key):
+func _update_beam_for_light(light: SpotLight3D, beam_params: Dictionary) -> void:
+	if _active_beam_renderer == null:
 		return
-	var cone: MeshInstance3D = light.get_meta(cone_meta_key) as MeshInstance3D
-	if cone == null:
-		return
-	var material: ShaderMaterial = cone.material_override as ShaderMaterial
-	if material == null:
-		return
-	var alpha_scale: float = 1.0
-	var emission_scale: float = 1.0
-	if cone_meta_key == "peraviz_beam_cone_mid":
-		alpha_scale = 1.35
-		emission_scale = 1.25
-	elif cone_meta_key == "peraviz_beam_cone_core":
-		alpha_scale = 1.7
-		emission_scale = 1.5
-	material.set_shader_parameter("near_alpha", lerp(0.0, EMITTER_CONE_NEAR_ALPHA * alpha_scale, scaled_intensity))
-	material.set_shader_parameter("far_alpha", lerp(0.0, EMITTER_CONE_FAR_ALPHA * alpha_scale, scaled_intensity))
-	material.set_shader_parameter("near_emission", lerp(0.0, EMITTER_CONE_NEAR_EMISSION * emission_scale, scaled_intensity))
-	material.set_shader_parameter("far_emission", lerp(0.0, EMITTER_CONE_FAR_EMISSION * emission_scale, scaled_intensity))
+	light.set_meta("peraviz_beam_last_params", beam_params.duplicate(true))
+	_active_beam_renderer.ensure_beam(light)
+	_active_beam_renderer.update_beam(light, beam_params)
 
 func _on_visual_settings_pressed() -> void:
 	visual_settings_window.popup_settings()
@@ -1380,9 +1434,6 @@ func _find_or_create_emitter_light(emitter_node: Node3D) -> SpotLight3D:
 	light.spot_range = 60.0
 	light.spot_angle = 25.0
 	light.spot_attenuation = 1.0
-	light.set_meta("peraviz_beam_cone", _create_emitter_beam_cone())
-	light.set_meta("peraviz_beam_cone_mid", _create_emitter_beam_mid_cone())
-	light.set_meta("peraviz_beam_cone_core", _create_emitter_beam_core_cone())
 	light.set_meta("peraviz_lens_radius", lens_radius)
 	emitter_node.add_child(light)
 	return light
@@ -1582,7 +1633,23 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 	light.light_color = _derive_emitter_color(photometric, controls)
 	var beam_radius_from_gdtf: bool = bool(photometric.get("beam_radius_from_gdtf", false))
 	var source_beam_radius: float = beam_radius_m if beam_radius_from_gdtf else -1.0
-	_update_emitter_beam_cone(light, beam_angle, cone_range, light.light_color, normalized_dimmer, source_beam_radius)
+	var lens_radius: float = max(float(light.get_meta("peraviz_lens_radius", 0.03)), 0.005)
+	if source_beam_radius > 0.0:
+		lens_radius = max(source_beam_radius, 0.005)
+	light.set_meta("peraviz_beam_base_intensity", clamp(normalized_dimmer, 0.0, 1.0))
+	var beam_params := {
+		"beam_angle": beam_angle,
+		"beam_range": cone_range,
+		"beam_color": light.light_color,
+		"normalized_dimmer": clamp(normalized_dimmer, 0.0, 1.0),
+		"scaled_intensity": clamp(normalized_dimmer * float(_visual_settings.get("beam_multiplier", 1.0)), 0.0, 3.0),
+		"lens_radius": lens_radius,
+		"is_visible": light.visible,
+		"fade_end_ratio": EMITTER_CONE_FADE_END_RATIO,
+		"intensity_visibility_threshold": BEAM_INTENSITY_VISIBILITY_THRESHOLD,
+		"distance_cull_m": BEAM_DISTANCE_CULL_M,
+	}
+	_update_beam_for_light(light, beam_params)
 
 func _resolve_zoom_beam_limits(light: SpotLight3D, controls: Dictionary) -> Dictionary:
 	# min/max beam angles are kept as full GDTF beam apertures (not half-angle).

--- a/peraviz/scripts/shaders/legacy_beam_cone.gdshader
+++ b/peraviz/scripts/shaders/legacy_beam_cone.gdshader
@@ -1,0 +1,35 @@
+shader_type spatial;
+render_mode unshaded, blend_add, cull_disabled, depth_prepass_alpha, shadows_disabled;
+
+instance uniform vec4 beam_color : source_color = vec4(1.0, 0.85, 0.55, 1.0);
+instance uniform float near_alpha = 0.16;
+instance uniform float far_alpha = 0.004;
+instance uniform float near_emission = 0.45;
+instance uniform float far_emission = 0.04;
+instance uniform float cone_height = 15.0;
+instance uniform float fade_end_ratio = 0.82;
+instance uniform float lateral_softness = 0.35;
+instance uniform float lateral_emission_boost = 0.16;
+instance uniform float volumetric_noise_strength = 0.06;
+instance uniform float volumetric_noise_scale = 14.0;
+
+varying float beam_axial;
+
+void vertex() {
+	float normalized_y = (VERTEX.y / max(cone_height, 0.0001)) + 0.5;
+	beam_axial = clamp(normalized_y, 0.0, 1.0);
+}
+
+void fragment() {
+	float near_factor = beam_axial;
+	float far_progress = 1.0 - beam_axial;
+	float end_fade = 1.0 - smoothstep(clamp(fade_end_ratio, 0.0, 0.99), 1.0, far_progress);
+	float view_alignment = abs(dot(normalize(NORMAL), normalize(VIEW)));
+	float lateral_fade = smoothstep(0.0, clamp(lateral_softness, 0.02, 1.0), view_alignment);
+	float axial_noise = sin((beam_axial * volumetric_noise_scale) + (TIME * 0.9));
+	float beam_noise = 1.0 + (axial_noise * volumetric_noise_strength);
+	float center_boost = (1.0 + (lateral_emission_boost * lateral_fade)) * beam_noise;
+	ALBEDO = beam_color.rgb;
+	ALPHA = mix(far_alpha, near_alpha, near_factor) * end_fade * lateral_fade;
+	EMISSION = beam_color.rgb * (mix(far_emission, near_emission, near_factor) * end_fade * center_boost);
+}

--- a/peraviz/scripts/shaders/volumetric_beam.gdshader
+++ b/peraviz/scripts/shaders/volumetric_beam.gdshader
@@ -1,0 +1,102 @@
+shader_type spatial;
+render_mode unshaded, blend_add, cull_disabled, depth_prepass_alpha, shadows_disabled;
+
+instance uniform vec4 beam_color : source_color = vec4(1.0, 0.85, 0.55, 1.0);
+instance uniform float beam_intensity = 1.0;
+instance uniform float cone_height = 20.0;
+instance uniform float top_radius = 0.02;
+instance uniform float bottom_radius = 0.8;
+instance uniform float haze_density = 0.22;
+instance uniform float anisotropy = 0.62;
+instance uniform float noise_amount = 0.05;
+instance uniform float noise_scale = 1.4;
+instance uniform float end_fade_ratio = 0.82;
+instance uniform float step_count = 24.0;
+instance uniform float beam_range = 20.0;
+instance uniform float camera_inside_dimmer = 0.6;
+
+varying float beam_axial;
+varying vec3 local_position;
+
+float hash31(vec3 p) {
+	p = fract(p * 0.1031);
+	p += dot(p, p.yzx + 33.33);
+	return fract((p.x + p.y) * p.z);
+}
+
+float value_noise(vec3 p) {
+	vec3 ip = floor(p);
+	vec3 fp = fract(p);
+	fp = fp * fp * (3.0 - 2.0 * fp);
+	float n000 = hash31(ip + vec3(0.0, 0.0, 0.0));
+	float n100 = hash31(ip + vec3(1.0, 0.0, 0.0));
+	float n010 = hash31(ip + vec3(0.0, 1.0, 0.0));
+	float n110 = hash31(ip + vec3(1.0, 1.0, 0.0));
+	float n001 = hash31(ip + vec3(0.0, 0.0, 1.0));
+	float n101 = hash31(ip + vec3(1.0, 0.0, 1.0));
+	float n011 = hash31(ip + vec3(0.0, 1.0, 1.0));
+	float n111 = hash31(ip + vec3(1.0, 1.0, 1.0));
+	float nx00 = mix(n000, n100, fp.x);
+	float nx10 = mix(n010, n110, fp.x);
+	float nx01 = mix(n001, n101, fp.x);
+	float nx11 = mix(n011, n111, fp.x);
+	float nxy0 = mix(nx00, nx10, fp.y);
+	float nxy1 = mix(nx01, nx11, fp.y);
+	return mix(nxy0, nxy1, fp.z);
+}
+
+void vertex() {
+	float normalized_y = (VERTEX.y / max(cone_height, 0.0001)) + 0.5;
+	beam_axial = clamp(normalized_y, 0.0, 1.0);
+	local_position = VERTEX;
+}
+
+void fragment() {
+	float near_factor = beam_axial;
+	float far_progress = 1.0 - beam_axial;
+	float end_fade = 1.0 - smoothstep(clamp(end_fade_ratio, 0.0, 0.99), 1.0, far_progress);
+	float current_radius = mix(top_radius, bottom_radius, beam_axial);
+	float radial = length(vec2(local_position.x, local_position.z));
+	float radial_ratio = clamp(radial / max(current_radius, 0.0001), 0.0, 1.0);
+	float radial_density = 1.0 - smoothstep(0.35, 1.0, radial_ratio);
+	float axial_density = mix(0.28, 1.25, near_factor);
+
+	float view_alignment = abs(dot(normalize(NORMAL), normalize(VIEW)));
+	float side_visibility = 1.0 - view_alignment;
+	float phase = 0.35 + (0.65 * side_visibility);
+
+	float steps = clamp(step_count, 8.0, 64.0);
+	float step_length = beam_range / steps;
+	float sigma_t = haze_density;
+	float sigma_s = haze_density * 0.8;
+	float transmittance = 1.0;
+	float radiance = 0.0;
+
+	for (float i = 0.0; i < 64.0; i += 1.0) {
+		if (i >= steps) {
+			break;
+		}
+		float t = (i + 0.5) / steps;
+		float sample_far_progress = clamp(mix(far_progress, 1.0, t * 0.9), 0.0, 1.0);
+		float sample_near_factor = 1.0 - sample_far_progress;
+		float sample_end_fade = 1.0 - smoothstep(clamp(end_fade_ratio, 0.0, 0.99), 1.0, sample_far_progress);
+		float sample_axial_density = mix(0.28, 1.25, sample_near_factor);
+		float sample_noise = 1.0;
+		if (noise_amount > 0.001) {
+			sample_noise += (value_noise(vec3(local_position.xz * noise_scale, sample_far_progress + TIME * 0.08)) - 0.5) * noise_amount;
+		}
+		float density = max(radial_density * sample_axial_density * sample_end_fade * sample_noise, 0.0);
+		transmittance *= exp(-sigma_t * density * step_length);
+		radiance += transmittance * sigma_s * density * phase * step_length;
+		if (transmittance < 0.02) {
+			break;
+		}
+	}
+
+	float inside_dimmer = mix(1.0, camera_inside_dimmer, smoothstep(0.0, 0.25, radial_ratio));
+	float alpha = clamp(radiance * beam_intensity * inside_dimmer * 18.0, 0.0, 1.0) * end_fade;
+
+	ALBEDO = beam_color.rgb;
+	EMISSION = beam_color.rgb * alpha * 2.8;
+	ALPHA = alpha;
+}

--- a/peraviz/scripts/visual_settings_window.gd
+++ b/peraviz/scripts/visual_settings_window.gd
@@ -9,6 +9,12 @@ const DEFAULT_SETTINGS := {
 	"spot_multiplier": 1.0,
 	"beam_multiplier": 1.0,
 	"bloom_multiplier": 1.0,
+	"beam_render_mode": 0,
+	"beam_quality": 1,
+	"beam_haze_density": 0.17,
+	"beam_anisotropy": 0.62,
+	"beam_noise_amount": 0.06,
+	"beam_noise_scale": 1.4,
 	"background_color": Color(0.129412, 0.137255, 0.156863, 1.0),
 }
 
@@ -22,10 +28,12 @@ var _beam_value_label: Label
 var _bloom_slider: HSlider
 var _bloom_value_label: Label
 var _background_picker: ColorPickerButton
+var _beam_render_mode_option: OptionButton
+var _beam_quality_option: OptionButton
 
 func _init() -> void:
 	title = "Visual Settings"
-	size = Vector2i(420, 340)
+	size = Vector2i(460, 400)
 	unresizable = false
 
 func _ready() -> void:
@@ -63,6 +71,8 @@ func _build_ui() -> void:
 	_spot_slider = _add_slider_row(container, "Spot intensity", "spot_multiplier", 0.0, 3.0, 0.01)
 	_beam_slider = _add_slider_row(container, "Beam intensity", "beam_multiplier", 0.0, 3.0, 0.01)
 	_bloom_slider = _add_slider_row(container, "Bloom", "bloom_multiplier", 0.0, 3.0, 0.01)
+	_beam_render_mode_option = _add_option_row(container, "Beam rendering", ["Volumetric (default)", "Lightweight (legacy)"], _on_beam_render_mode_selected)
+	_beam_quality_option = _add_option_row(container, "Beam quality", ["Low", "Medium", "High"], _on_beam_quality_selected)
 
 	var background_row: HBoxContainer = HBoxContainer.new()
 	background_row.add_theme_constant_override("separation", 8)
@@ -129,11 +139,32 @@ func _add_slider_row(parent: VBoxContainer,
 
 	return slider
 
+func _add_option_row(parent: VBoxContainer, label_text: String, options: Array[String], on_selected: Callable) -> OptionButton:
+	var row: HBoxContainer = HBoxContainer.new()
+	row.add_theme_constant_override("separation", 8)
+	parent.add_child(row)
+
+	var setting_label: Label = Label.new()
+	setting_label.text = label_text
+	setting_label.custom_minimum_size = Vector2(150, 0)
+	row.add_child(setting_label)
+
+	var option_button: OptionButton = OptionButton.new()
+	option_button.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	for option_text in options:
+		option_button.add_item(option_text)
+	option_button.item_selected.connect(on_selected)
+	row.add_child(option_button)
+
+	return option_button
+
 func _apply_settings_to_controls() -> void:
 	_ambient_slider.value = float(_settings.get("ambient_multiplier", 1.0))
 	_spot_slider.value = float(_settings.get("spot_multiplier", 1.0))
 	_beam_slider.value = float(_settings.get("beam_multiplier", 1.0))
 	_bloom_slider.value = float(_settings.get("bloom_multiplier", 1.0))
+	_beam_render_mode_option.select(clamp(int(_settings.get("beam_render_mode", 0)), 0, 1))
+	_beam_quality_option.select(clamp(int(_settings.get("beam_quality", 1)), 0, 2))
 	_background_picker.color = _settings.get("background_color", DEFAULT_SETTINGS["background_color"])
 	_update_value_labels()
 
@@ -149,6 +180,14 @@ func _on_background_color_changed(color: Color) -> void:
 func _on_reset_pressed() -> void:
 	_settings = DEFAULT_SETTINGS.duplicate(true)
 	_apply_settings_to_controls()
+	_emit_settings_changed()
+
+func _on_beam_render_mode_selected(index: int) -> void:
+	_settings["beam_render_mode"] = clamp(index, 0, 1)
+	_emit_settings_changed()
+
+func _on_beam_quality_selected(index: int) -> void:
+	_settings["beam_quality"] = clamp(index, 0, 2)
 	_emit_settings_changed()
 
 func _update_value_labels() -> void:


### PR DESCRIPTION
### Motivation
- Correct an inverted volumetric cone gradient so the beam is brightest near the lens and fades toward the far end.
- Restore correct center-vs-edge weighting so cone cores remain denser than lateral edges and avoid view-dependent edge over-brightening.
- Introduce a small renderer abstraction so volumetric and legacy cone renderers can coexist and be selected from Visual Settings.

### Description
- Adjusted `peraviz/scripts/shaders/volumetric_beam.gdshader` to use `near_factor = beam_axial`, invert axial density mapping to favor the lens, compute radial density in local space, simplify the view-side phase term, and ensure per-step sampling follows the corrected near/far progression.
- Added a lightweight legacy cone shader `peraviz/scripts/shaders/legacy_beam_cone.gdshader` and moved cone logic into two renderer implementations: `peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd` and `peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd`, plus a `BeamRendererBase` interface for modularity.
- Updated scene bootstrap and beam plumbing in `peraviz/scripts/load_scene.gd` to initialize selectable beam renderers, persist visual beam settings, centralize beam parameter updates via `_update_beam_for_light`, and apply distance/visibility culling.
- Exposed beam mode/quality controls in the UI by extending `peraviz/scripts/visual_settings_window.gd` and added documentation `peraviz/docs/BEAM_RENDERING_MODES.md` describing mesh/shader axis conventions and quality guidance.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.
- Ran `git diff --check` / whitespace checks and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996196e8a3483249a6462cde9e15133)