### PR TITLE
Restore mouse orbit controls in Edit Fixture preview

### DIFF
--- a/gui/fixturepreviewpanel.cpp
+++ b/gui/fixturepreviewpanel.cpp
@@ -149,6 +149,8 @@ wxBEGIN_EVENT_TABLE(FixturePreviewPanel, wxGLCanvas)
     EVT_SIZE(FixturePreviewPanel::OnResize)
     EVT_LEFT_DOWN(FixturePreviewPanel::OnMouseDown)
     EVT_LEFT_UP(FixturePreviewPanel::OnMouseUp)
+    EVT_RIGHT_DOWN(FixturePreviewPanel::OnMouseDown)
+    EVT_RIGHT_UP(FixturePreviewPanel::OnMouseUp)
     EVT_MOTION(FixturePreviewPanel::OnMouseMove)
     EVT_MOUSEWHEEL(FixturePreviewPanel::OnMouseWheel)
     EVT_MOUSE_CAPTURE_LOST(FixturePreviewPanel::OnCaptureLost)
@@ -283,7 +285,9 @@ void FixturePreviewPanel::OnMouseDown(wxMouseEvent& evt)
 {
     m_dragging = true;
     m_lastMousePos = evt.GetPosition();
-    CaptureMouse();
+    if(!HasCapture()){
+        CaptureMouse();
+    }
 }
 
 void FixturePreviewPanel::OnMouseUp(wxMouseEvent&)
@@ -301,13 +305,18 @@ void FixturePreviewPanel::OnCaptureLost(wxMouseCaptureLostEvent& WXUNUSED(evt))
 
 void FixturePreviewPanel::OnMouseMove(wxMouseEvent& evt)
 {
-    if(m_dragging){
+    if(m_dragging && (evt.LeftIsDown() || evt.RightIsDown())){
         wxPoint pos = evt.GetPosition();
         int dx = pos.x - m_lastMousePos.x;
         int dy = pos.y - m_lastMousePos.y;
         m_camera.Orbit(dx * 0.5f, dy * 0.5f);
         m_lastMousePos = pos;
         Refresh();
+    } else if(m_dragging) {
+        m_dragging = false;
+        if(HasCapture()){
+            ReleaseMouse();
+        }
     }
 }
 


### PR DESCRIPTION
### Motivation
- The 3D preview in the `Edit Fixture` dialog lost reliable orbit drag interaction, preventing users from rotating the fixture with the mouse.
- Interaction should support typical workflows using either left or right mouse button and must not leave mouse capture in an inconsistent state.

### Description
- Re-enabled drag-orbit interaction for both left and right mouse buttons by wiring `EVT_RIGHT_DOWN` and `EVT_RIGHT_UP` to the same handlers in `gui/fixturepreviewpanel.cpp`.
- Made mouse capture safer by calling `CaptureMouse()` only when `HasCapture()` is false to avoid duplicate captures.
- Updated `OnMouseMove` to perform `m_camera.Orbit(...)` only when `evt.LeftIsDown()` or `evt.RightIsDown()` are true and to reset `m_dragging` and release capture when the drag button is no longer pressed.
- Changes are confined to `gui/fixturepreviewpanel.cpp` and keep the change small and focused on input handling.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed successfully.
- Verified that the GUI preview code path compiles and the orbit/zoom handlers behave as expected in the `Edit Fixture` preview (mouse wheel zoom unchanged).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996f35a92688324b69ec3a68b470f2a)