### PR TITLE
Restore mouse orbit in Edit Fixture 3D preview

### DIFF
--- a/gui/fixturepreviewpanel.cpp
+++ b/gui/fixturepreviewpanel.cpp
@@ -244,6 +244,7 @@ void FixturePreviewPanel::Render()
     gluPerspective(45.0,(double)w/h,0.1,100.0);
     glMatrixMode(GL_MODELVIEW);
     glLoadIdentity();
+    m_camera.Update(0.0f);
     m_camera.Apply();
     float lightPos[4] = {0.f, 0.f, 1.f, 0.f};
     float lightDiffuse[4] = {1.f,1.f,1.f,1.f};

--- a/gui/fixturepreviewpanel.cpp
+++ b/gui/fixturepreviewpanel.cpp
@@ -149,6 +149,8 @@ wxBEGIN_EVENT_TABLE(FixturePreviewPanel, wxGLCanvas)
     EVT_SIZE(FixturePreviewPanel::OnResize)
     EVT_LEFT_DOWN(FixturePreviewPanel::OnMouseDown)
     EVT_LEFT_UP(FixturePreviewPanel::OnMouseUp)
+    EVT_MIDDLE_DOWN(FixturePreviewPanel::OnMouseDown)
+    EVT_MIDDLE_UP(FixturePreviewPanel::OnMouseUp)
     EVT_RIGHT_DOWN(FixturePreviewPanel::OnMouseDown)
     EVT_RIGHT_UP(FixturePreviewPanel::OnMouseUp)
     EVT_MOTION(FixturePreviewPanel::OnMouseMove)
@@ -283,6 +285,7 @@ void FixturePreviewPanel::OnResize(wxSizeEvent&)
 
 void FixturePreviewPanel::OnMouseDown(wxMouseEvent& evt)
 {
+    SetFocus();
     m_dragging = true;
     m_lastMousePos = evt.GetPosition();
     if(!HasCapture()){
@@ -305,7 +308,7 @@ void FixturePreviewPanel::OnCaptureLost(wxMouseCaptureLostEvent& WXUNUSED(evt))
 
 void FixturePreviewPanel::OnMouseMove(wxMouseEvent& evt)
 {
-    if(m_dragging && (evt.LeftIsDown() || evt.RightIsDown())){
+    if(m_dragging && (evt.LeftIsDown() || evt.MiddleIsDown() || evt.RightIsDown())){
         wxPoint pos = evt.GetPosition();
         int dx = pos.x - m_lastMousePos.x;
         int dy = pos.y - m_lastMousePos.y;


### PR DESCRIPTION
### Motivation
- The 3D preview in the "Edit Fixture" dialog stopped reliably orbiting when dragging, likely due to missing middle-button handling and focus not being set on the preview canvas.

### Description
- Added middle mouse button handlers to the preview event table (`EVT_MIDDLE_DOWN` / `EVT_MIDDLE_UP`).
- Call `SetFocus()` at drag start in `OnMouseDown` so the preview receives input reliably while interacting.
- Updated movement detection in `OnMouseMove` to consider `MiddleIsDown()` in addition to `LeftIsDown()` and `RightIsDown()`.
- Change is localized to `gui/fixturepreviewpanel.cpp`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996fe8c0d908324a356a3ef5e255a5e)