### PR TITLE
Peraviz: sync fixture lens glow with dimmer and beam color

### DIFF
--- a/peraviz/native/src/dmx/dmx_platform.cpp
+++ b/peraviz/native/src/dmx/dmx_platform.cpp
@@ -124,4 +124,31 @@ int get_last_socket_error() {
 #endif
 }
 
+
+std::string describe_socket_error(int error_code) {
+#ifdef _WIN32
+    switch (error_code) {
+    case WSAEADDRINUSE:
+        return "Address/port already in use (WSAEADDRINUSE)";
+    case WSAEACCES:
+        return "Permission denied to bind socket (WSAEACCES)";
+    case WSAEADDRNOTAVAIL:
+        return "Requested bind address is not available (WSAEADDRNOTAVAIL)";
+    default:
+        return "";
+    }
+#else
+    switch (error_code) {
+    case EADDRINUSE:
+        return "Address/port already in use (EADDRINUSE)";
+    case EACCES:
+        return "Permission denied to bind socket (EACCES)";
+    case EADDRNOTAVAIL:
+        return "Requested bind address is not available (EADDRNOTAVAIL)";
+    default:
+        return "";
+    }
+#endif
+}
+
 } // namespace peraviz::dmx

--- a/peraviz/native/src/dmx/dmx_platform.h
+++ b/peraviz/native/src/dmx/dmx_platform.h
@@ -33,5 +33,6 @@ bool set_socket_reuse_address(SocketHandle socket_handle, bool enabled, std::str
 void close_socket(SocketHandle socket_handle);
 bool is_would_block_error(int error_code);
 int get_last_socket_error();
+std::string describe_socket_error(int error_code);
 
 } // namespace peraviz::dmx

--- a/peraviz/native/src/dmx/udp_socket.cpp
+++ b/peraviz/native/src/dmx/udp_socket.cpp
@@ -51,8 +51,13 @@ bool UdpSocket::open_and_bind(const std::string &bind_ip, uint16_t port, std::st
     }
 
     if (::bind(socket_handle_, reinterpret_cast<sockaddr *>(&address), sizeof(address)) != 0) {
+        const int error_code = get_last_socket_error();
         error_message = "Failed to bind UDP socket on " + bind_ip + ":" + std::to_string(port) +
-                        ". Error=" + std::to_string(get_last_socket_error());
+                        ". Error=" + std::to_string(error_code);
+        const std::string error_detail = describe_socket_error(error_code);
+        if (!error_detail.empty()) {
+            error_message += " (" + error_detail + ")";
+        }
         close();
         return false;
     }

--- a/peraviz/native/src/gdtf_scene_builder.cpp
+++ b/peraviz/native/src/gdtf_scene_builder.cpp
@@ -33,11 +33,23 @@ bool looks_like_axis(const std::string &tag_name, const std::string &name) {
            n.find("head") != std::string::npos;
 }
 
-bool looks_like_emitter(const std::string &tag_name, const std::string &name) {
+bool looks_like_lens_geometry(const std::string &tag_name, const std::string &name,
+                              bool parent_is_lens) {
+    if (parent_is_lens) {
+        return true;
+    }
+    const std::string tag = lower_ascii(tag_name);
+    const std::string n = lower_ascii(name);
+    return tag == "beam" || n.find("lens") != std::string::npos ||
+           n.find("optic") != std::string::npos || n.find("glass") != std::string::npos;
+}
+
+bool looks_like_emitter(const std::string &tag_name, const std::string &name,
+                        bool is_lens_geometry) {
     const std::string tag = lower_ascii(tag_name);
     const std::string n = lower_ascii(name);
     return tag.find("beam") != std::string::npos || tag.find("laser") != std::string::npos ||
-           n.find("lens") != std::string::npos || n.find("emitter") != std::string::npos;
+           n.find("emitter") != std::string::npos || is_lens_geometry;
 }
 
 bool is_supported_geometry_tag(const std::string &tag_name) {
@@ -276,11 +288,11 @@ std::vector<SceneNode> build_fixture_geometry_nodes(const GdtfBuildRequest &requ
 
     int local_counter = 0;
     std::function<void(tinyxml2::XMLElement *, const std::string &, const Matrix &, const char *,
-                       const Matrix *)>
+                       const Matrix *, bool)>
         append_geometry;
     append_geometry = [&](tinyxml2::XMLElement *geometry, const std::string &geometry_parent_id,
                           const Matrix &geometry_parent_world, const char *override_model,
-                          const Matrix *prepend_local) {
+                          const Matrix *prepend_local, bool parent_is_lens) {
         const std::string geometry_tag = geometry->Name() ? geometry->Name() : "";
         Matrix local = parse_local_matrix(geometry);
         if (prepend_local) {
@@ -307,7 +319,7 @@ std::vector<SceneNode> build_fixture_geometry_nodes(const GdtfBuildRequest &requ
                 reference_model = geometry->Attribute("model");
             }
             append_geometry(referenced_it->second, geometry_parent_id, geometry_parent_world,
-                            reference_model ? reference_model : override_model, &local);
+                            reference_model ? reference_model : override_model, &local, parent_is_lens);
             return;
         }
 
@@ -323,7 +335,8 @@ std::vector<SceneNode> build_fixture_geometry_nodes(const GdtfBuildRequest &requ
         node.node_class = "fixture_geometry";
         node.is_fixture = true;
         node.is_axis = looks_like_axis(geometry->Name(), geometry_name);
-        node.is_emitter = looks_like_emitter(geometry->Name(), geometry_name);
+        node.is_lens = looks_like_lens_geometry(geometry_tag, geometry_name, parent_is_lens);
+        node.is_emitter = looks_like_emitter(geometry->Name(), geometry_name, node.is_lens);
         node.local_transform = peraviz::coordinate_mapper::to_godot_transform(local);
 
         if (geometry_tag == "Beam") {
@@ -378,11 +391,11 @@ std::vector<SceneNode> build_fixture_geometry_nodes(const GdtfBuildRequest &requ
             if (!is_supported_geometry_tag(child_tag)) {
                 continue;
             }
-            append_geometry(child, geometry_id, world, nullptr, nullptr);
+            append_geometry(child, geometry_id, world, nullptr, nullptr, node.is_lens);
         }
     };
 
-    append_geometry(root_geometry, parent_id, parent_world, nullptr, nullptr);
+    append_geometry(root_geometry, parent_id, parent_world, nullptr, nullptr, false);
     extracted_asset_count += gdtf_cache.extracted_assets();
     return nodes;
 }

--- a/peraviz/native/src/gdtf_scene_builder.cpp
+++ b/peraviz/native/src/gdtf_scene_builder.cpp
@@ -191,7 +191,14 @@ std::vector<SceneNode> build_fixture_geometry_nodes(const GdtfBuildRequest &requ
         return nodes;
     }
 
-    std::unordered_map<std::string, std::string> model_file_by_name;
+    struct GdtfModelVisual {
+        std::string file;
+        std::string primitive_type;
+        float size_x = 0.1F;
+        float size_y = 0.1F;
+        float size_z = 0.1F;
+    };
+    std::unordered_map<std::string, GdtfModelVisual> model_visual_by_name;
     std::unordered_map<std::string, float> emitter_wavelength_by_name;
     if (tinyxml2::XMLElement *models = fixture_type->FirstChildElement("Models")) {
         for (tinyxml2::XMLElement *model = models->FirstChildElement(); model;
@@ -200,14 +207,32 @@ std::vector<SceneNode> build_fixture_geometry_nodes(const GdtfBuildRequest &requ
             if (!name) {
                 name = model->Attribute("name");
             }
+            if (!name) {
+                continue;
+            }
+
+            GdtfModelVisual visual;
             const char *file = model->Attribute("File");
             if (!file) {
                 file = model->Attribute("file");
             }
-            if (!name || !file) {
-                continue;
+            if (file) {
+                visual.file = file;
             }
-            model_file_by_name[name] = file;
+
+            const char *primitive_type = model->Attribute("PrimitiveType");
+            if (!primitive_type) {
+                primitive_type = model->Attribute("primitivetype");
+            }
+            if (primitive_type) {
+                visual.primitive_type = primitive_type;
+            }
+
+            parse_float_attr(model, "Length", "length", visual.size_x);
+            parse_float_attr(model, "Width", "width", visual.size_y);
+            parse_float_attr(model, "Height", "height", visual.size_z);
+
+            model_visual_by_name[name] = visual;
         }
     }
 
@@ -376,12 +401,21 @@ std::vector<SceneNode> build_fixture_geometry_nodes(const GdtfBuildRequest &requ
             model_name = geometry->Attribute("model");
         }
         if (model_name) {
-            auto model_it = model_file_by_name.find(model_name);
-            if (model_it != model_file_by_name.end()) {
-                node.asset_path = gdtf_cache.ensure_gdtf_model_extracted(model_it->second);
+            auto model_it = model_visual_by_name.find(model_name);
+            if (model_it != model_visual_by_name.end()) {
+                if (!model_it->second.file.empty()) {
+                    node.asset_path = gdtf_cache.ensure_gdtf_model_extracted(model_it->second.file);
+                }
+                node.primitive_type = model_it->second.primitive_type;
+                node.primitive_size_x = std::max(model_it->second.size_x, 0.001F);
+                node.primitive_size_y = std::max(model_it->second.size_y, 0.001F);
+                node.primitive_size_z = std::max(model_it->second.size_z, 0.001F);
             }
         }
         node.asset_kind = infer_asset_kind_from_path(node.asset_path);
+        if (node.asset_kind == "none" && !node.primitive_type.empty()) {
+            node.asset_kind = "primitive";
+        }
 
         nodes.push_back(node);
 

--- a/peraviz/native/src/peraviz_dmx_receiver.cpp
+++ b/peraviz/native/src/peraviz_dmx_receiver.cpp
@@ -9,6 +9,7 @@ void PeravizDmxReceiver::_bind_methods() {
     ClassDB::bind_method(D_METHOD("start", "bind_ip", "port"), &PeravizDmxReceiver::start, DEFVAL(String("0.0.0.0")), DEFVAL(6454));
     ClassDB::bind_method(D_METHOD("stop"), &PeravizDmxReceiver::stop);
     ClassDB::bind_method(D_METHOD("is_running"), &PeravizDmxReceiver::is_running);
+    ClassDB::bind_method(D_METHOD("get_last_error"), &PeravizDmxReceiver::get_last_error);
     ClassDB::bind_method(D_METHOD("get_active_universes", "active_window_ms"), &PeravizDmxReceiver::get_active_universes, DEFVAL(2000));
     ClassDB::bind_method(D_METHOD("get_stats"), &PeravizDmxReceiver::get_stats);
     ClassDB::bind_method(D_METHOD("get_universe_data", "universe_id"), &PeravizDmxReceiver::get_universe_data);
@@ -33,6 +34,10 @@ void PeravizDmxReceiver::stop() {
 
 bool PeravizDmxReceiver::is_running() const {
     return receiver_->is_running();
+}
+
+String PeravizDmxReceiver::get_last_error() const {
+    return String(receiver_->get_last_error().c_str());
 }
 
 PackedInt32Array PeravizDmxReceiver::get_active_universes(int active_window_ms) const {

--- a/peraviz/native/src/peraviz_dmx_receiver.h
+++ b/peraviz/native/src/peraviz_dmx_receiver.h
@@ -26,6 +26,7 @@ public:
     bool start(const String &bind_ip = "0.0.0.0", int port = 6454);
     void stop();
     bool is_running() const;
+    String get_last_error() const;
 
     PackedInt32Array get_active_universes(int active_window_ms = 2000) const;
     Dictionary get_stats() const;

--- a/peraviz/native/src/peraviz_loader.cpp
+++ b/peraviz/native/src/peraviz_loader.cpp
@@ -76,6 +76,10 @@ Array PeravizLoader::load_mvr(const String &path, bool peraviz_debug_baseline,
         d["class"] = String(node.node_class.c_str());
         d["asset_kind"] = String(node.asset_kind.c_str());
         d["asset_path"] = String(node.asset_path.c_str());
+        d["primitive_type"] = String(node.primitive_type.c_str());
+        d["primitive_size_x"] = node.primitive_size_x;
+        d["primitive_size_y"] = node.primitive_size_y;
+        d["primitive_size_z"] = node.primitive_size_z;
         d["is_fixture"] = node.is_fixture;
         d["is_axis"] = node.is_axis;
         d["is_emitter"] = node.is_emitter;

--- a/peraviz/native/src/peraviz_loader.cpp
+++ b/peraviz/native/src/peraviz_loader.cpp
@@ -79,6 +79,7 @@ Array PeravizLoader::load_mvr(const String &path, bool peraviz_debug_baseline,
         d["is_fixture"] = node.is_fixture;
         d["is_axis"] = node.is_axis;
         d["is_emitter"] = node.is_emitter;
+        d["is_lens"] = node.is_lens;
         d["has_luminous_flux"] = node.has_luminous_flux;
         d["luminous_flux"] = node.luminous_flux;
         d["has_color_temperature"] = node.has_color_temperature;

--- a/peraviz/native/src/scene_model.h
+++ b/peraviz/native/src/scene_model.h
@@ -33,6 +33,7 @@ struct SceneNode {
     bool is_fixture = false;
     bool is_axis = false;
     bool is_emitter = false;
+    bool is_lens = false;
 
     bool has_luminous_flux = false;
     float luminous_flux = 10000.0F;

--- a/peraviz/native/src/scene_model.h
+++ b/peraviz/native/src/scene_model.h
@@ -29,6 +29,10 @@ struct SceneNode {
     std::string node_class;
     std::string asset_kind;
     std::string asset_path;
+    std::string primitive_type;
+    float primitive_size_x = 0.1F;
+    float primitive_size_y = 0.1F;
+    float primitive_size_z = 0.1F;
     SceneTransform local_transform;
     bool is_fixture = false;
     bool is_axis = false;

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -109,8 +109,6 @@ const DEFAULT_EMITTER_PHOTOMETRICS := {
 # (aligned with fixture lens output in runtime scenes) while still inheriting GDTF emitter transforms.
 const EMITTER_LIGHT_DIRECTION_FIX: Vector3 = Vector3(-90.0, 0.0, 0.0)
 const LENS_TINT_COLOR: Color = Color(0.72, 0.86, 1.0, 0.38)
-const LENS_GLOW_MIN_RADIUS_M: float = 0.012
-const LENS_GLOW_MAX_RADIUS_M: float = 0.08
 const DOUBLE_SIDED_NAME_HINTS: Array[String] = [
 	"lens", "glass", "visor", "shade", "shield", "fabric", "cloth", "curtain", "scrim", "flag", "plane", "card"
 ]
@@ -1386,6 +1384,7 @@ func _apply_dimmer_feedback_to_fixture(fixture_uuid: String, dimmer: float, cont
 		lens_nodes = emitter_nodes
 	var lens_materials: Array = _collect_fixture_lens_materials(fixture_uuid, lens_nodes, has_explicit_lens_nodes)
 	_apply_lens_feedback_materials(lens_materials, beam_color, normalized_dimmer)
+	_apply_lens_feedback_to_nodes(lens_nodes, beam_color, normalized_dimmer)
 
 	var emissive_materials: Array = _collect_fixture_emissive_materials(fixture_uuid, geometry_nodes)
 	var energy_multiplier: float = lerp(0.0, 4.0, normalized_dimmer)
@@ -1501,19 +1500,60 @@ func _apply_lens_feedback_materials(lens_materials: Array, beam_color: Color, no
 	for material in lens_materials:
 		if material is not BaseMaterial3D:
 			continue
-		var lens_material: BaseMaterial3D = material
-		lens_material.emission_enabled = true
-		lens_material.emission = beam_color
-		lens_material.emission_energy_multiplier = lerp(0.0, 4.5, dimmer_mix)
-		lens_material.disable_receive_shadows = true
-		lens_material.cull_mode = BaseMaterial3D.CULL_DISABLED
-		var alpha: float = lens_material.albedo_color.a
-		lens_material.albedo_color = Color(
-			lerp(LENS_TINT_COLOR.r, beam_color.r, dimmer_mix),
-			lerp(LENS_TINT_COLOR.g, beam_color.g, dimmer_mix),
-			lerp(LENS_TINT_COLOR.b, beam_color.b, dimmer_mix),
-			alpha
-		)
+		_apply_lens_feedback_to_material(material as BaseMaterial3D, beam_color, dimmer_mix)
+
+func _apply_lens_feedback_to_nodes(lens_nodes: Array, beam_color: Color, normalized_dimmer: float) -> void:
+	var dimmer_mix: float = clamp(normalized_dimmer, 0.0, 1.0)
+	for lens_root in lens_nodes:
+		_apply_lens_feedback_to_node_recursive(lens_root, beam_color, dimmer_mix)
+
+func _apply_lens_feedback_to_node_recursive(node: Node3D, beam_color: Color, dimmer_mix: float) -> void:
+	if node == null:
+		return
+	if node is MeshInstance3D:
+		var mesh_instance: MeshInstance3D = node
+		if mesh_instance.mesh != null:
+			for surface_index in range(mesh_instance.mesh.get_surface_count()):
+				var current_material: Material = mesh_instance.get_active_material(surface_index)
+				var target_material: BaseMaterial3D = _ensure_lens_surface_material(mesh_instance, surface_index, current_material)
+				if target_material != null:
+					_apply_lens_feedback_to_material(target_material, beam_color, dimmer_mix)
+	for child in node.get_children():
+		if child is Node3D:
+			_apply_lens_feedback_to_node_recursive(child, beam_color, dimmer_mix)
+
+func _ensure_lens_surface_material(mesh_instance: MeshInstance3D, surface_index: int, source_material: Material) -> BaseMaterial3D:
+	if source_material is BaseMaterial3D:
+		return source_material
+	var existing_override: Material = mesh_instance.get_surface_override_material(surface_index)
+	if existing_override is BaseMaterial3D and bool(existing_override.get_meta("peraviz_lens_runtime_override", false)):
+		return existing_override
+	var runtime_material := StandardMaterial3D.new()
+	runtime_material.set_meta("peraviz_lens_runtime_override", true)
+	runtime_material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
+	runtime_material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
+	runtime_material.blend_mode = BaseMaterial3D.BLEND_MODE_ADD
+	runtime_material.cull_mode = BaseMaterial3D.CULL_DISABLED
+	runtime_material.albedo_color = Color(LENS_TINT_COLOR.r, LENS_TINT_COLOR.g, LENS_TINT_COLOR.b, max(LENS_TINT_COLOR.a, 0.35))
+	runtime_material.emission_enabled = true
+	runtime_material.emission = Color.BLACK
+	runtime_material.emission_energy_multiplier = 0.0
+	mesh_instance.set_surface_override_material(surface_index, runtime_material)
+	return runtime_material
+
+func _apply_lens_feedback_to_material(lens_material: BaseMaterial3D, beam_color: Color, dimmer_mix: float) -> void:
+	lens_material.emission_enabled = true
+	lens_material.emission = beam_color
+	lens_material.emission_energy_multiplier = lerp(0.0, 4.5, dimmer_mix)
+	lens_material.disable_receive_shadows = true
+	lens_material.cull_mode = BaseMaterial3D.CULL_DISABLED
+	var alpha: float = lens_material.albedo_color.a
+	lens_material.albedo_color = Color(
+		lerp(LENS_TINT_COLOR.r, beam_color.r, dimmer_mix),
+		lerp(LENS_TINT_COLOR.g, beam_color.g, dimmer_mix),
+		lerp(LENS_TINT_COLOR.b, beam_color.b, dimmer_mix),
+		alpha
+	)
 
 func _find_or_create_emitter_light(emitter_node: Node3D) -> SpotLight3D:
 	var lens_radius: float = _estimate_emitter_lens_radius(emitter_node)
@@ -1525,7 +1565,6 @@ func _find_or_create_emitter_light(emitter_node: Node3D) -> SpotLight3D:
 			# Self/caster shadows from fixture geometry can clip the floor footprint.
 			child.shadow_enabled = false
 			child.set_meta("peraviz_lens_radius", lens_radius)
-			_ensure_emitter_lens_glow(emitter_node, lens_radius)
 			return child
 
 	var light := SpotLight3D.new()
@@ -1539,57 +1578,7 @@ func _find_or_create_emitter_light(emitter_node: Node3D) -> SpotLight3D:
 	light.spot_attenuation = 1.0
 	light.set_meta("peraviz_lens_radius", lens_radius)
 	emitter_node.add_child(light)
-	_ensure_emitter_lens_glow(emitter_node, lens_radius)
 	return light
-
-func _ensure_emitter_lens_glow(emitter_node: Node3D, lens_radius: float) -> void:
-	if emitter_node == null:
-		return
-	var glow_node: MeshInstance3D = null
-	for child in emitter_node.get_children():
-		if child is MeshInstance3D and child.name == "PeravizLensGlow":
-			glow_node = child
-			break
-	if glow_node == null:
-		glow_node = MeshInstance3D.new()
-		glow_node.name = "PeravizLensGlow"
-		glow_node.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
-		glow_node.position = Vector3.ZERO
-		glow_node.rotation_degrees = EMITTER_LIGHT_DIRECTION_FIX
-		var glow_mesh := SphereMesh.new()
-		glow_node.mesh = glow_mesh
-		var glow_material := StandardMaterial3D.new()
-		glow_material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
-		glow_material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
-		glow_material.blend_mode = BaseMaterial3D.BLEND_MODE_ADD
-		glow_material.cull_mode = BaseMaterial3D.CULL_DISABLED
-		glow_material.emission_enabled = true
-		glow_material.albedo_color = Color(1.0, 1.0, 1.0, 0.0)
-		glow_material.emission = Color.BLACK
-		glow_material.emission_energy_multiplier = 0.0
-		glow_node.material_override = glow_material
-		emitter_node.add_child(glow_node)
-
-	var effective_radius: float = clamp(lens_radius * 1.15, LENS_GLOW_MIN_RADIUS_M, LENS_GLOW_MAX_RADIUS_M)
-	if glow_node.mesh is SphereMesh:
-		var sphere_mesh: SphereMesh = glow_node.mesh
-		sphere_mesh.radius = effective_radius
-		sphere_mesh.height = effective_radius * 2.0
-
-func _update_emitter_lens_glow(emitter_node: Node3D, beam_color: Color, normalized_dimmer: float) -> void:
-	if emitter_node == null:
-		return
-	for child in emitter_node.get_children():
-		if child is MeshInstance3D and child.name == "PeravizLensGlow":
-			var glow_mesh: MeshInstance3D = child
-			glow_mesh.visible = normalized_dimmer > 0.0001
-			if glow_mesh.material_override is BaseMaterial3D:
-				var glow_material: BaseMaterial3D = glow_mesh.material_override
-				glow_material.emission_enabled = true
-				glow_material.emission = beam_color
-				glow_material.emission_energy_multiplier = lerp(0.0, 8.0, clamp(normalized_dimmer, 0.0, 1.0))
-				glow_material.albedo_color = Color(beam_color.r, beam_color.g, beam_color.b, lerp(0.0, 0.35, clamp(normalized_dimmer, 0.0, 1.0)))
-			return
 
 func _estimate_emitter_lens_radius(emitter_node: Node3D) -> float:
 	var default_radius: float = 0.03
@@ -1784,8 +1773,6 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 	# avoids early floor clipping on steep tilt while keeping cone visuals unchanged.
 	light.spot_range = clamp(cone_range * EMITTER_LIGHT_FOOTPRINT_RANGE_MULTIPLIER, EMITTER_LIGHT_MIN_EFFECTIVE_RANGE_M, EMITTER_LIGHT_MAX_RANGE_M)
 	light.light_color = _derive_emitter_color(photometric, controls)
-	var emitter_parent: Node3D = light.get_parent() as Node3D
-	_update_emitter_lens_glow(emitter_parent, light.light_color, normalized_dimmer)
 	var beam_radius_from_gdtf: bool = bool(photometric.get("beam_radius_from_gdtf", false))
 	var source_beam_radius: float = beam_radius_m if beam_radius_from_gdtf else -1.0
 	var lens_radius: float = max(float(light.get_meta("peraviz_lens_radius", 0.03)), 0.005)

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -1379,9 +1379,10 @@ func _apply_dimmer_feedback_to_fixture(fixture_uuid: String, dimmer: float, cont
 	var emitter_photometrics: Array = _get_fixture_emitter_photometrics(fixture_uuid)
 	var beam_color: Color = _resolve_fixture_beam_color(emitter_photometrics, controls)
 	var lens_nodes: Array = _to_node3d_array(_scene_registry.get_anchor(fixture_uuid, "lens"))
+	var has_explicit_lens_nodes: bool = not lens_nodes.is_empty()
 	if lens_nodes.is_empty():
 		lens_nodes = emitter_nodes
-	var lens_materials: Array = _collect_fixture_lens_materials(fixture_uuid, lens_nodes)
+	var lens_materials: Array = _collect_fixture_lens_materials(fixture_uuid, lens_nodes, has_explicit_lens_nodes)
 	_apply_lens_feedback_materials(lens_materials, beam_color, normalized_dimmer)
 
 	var emissive_materials: Array = _collect_fixture_emissive_materials(fixture_uuid, geometry_nodes)
@@ -1427,38 +1428,38 @@ func _collect_fixture_emitter_lights(fixture_uuid: String, emitter_nodes: Array)
 	_fixture_emitter_light_cache[fixture_uuid] = lights
 	return lights
 
-func _collect_fixture_lens_materials(fixture_uuid: String, emitter_nodes: Array) -> Array:
+func _collect_fixture_lens_materials(fixture_uuid: String, emitter_nodes: Array, include_all_materials: bool = false) -> Array:
 	if _fixture_lens_material_cache.has(fixture_uuid):
 		return _fixture_lens_material_cache.get(fixture_uuid, [])
 
 	var materials: Array = []
 	for emitter_node in emitter_nodes:
-		_collect_lens_materials_recursive(emitter_node, materials)
+		_collect_lens_materials_recursive(emitter_node, materials, include_all_materials)
 	_fixture_lens_material_cache[fixture_uuid] = materials
 	return materials
 
-func _collect_lens_materials_recursive(node: Node3D, output_materials: Array) -> void:
+func _collect_lens_materials_recursive(node: Node3D, output_materials: Array, include_all_materials: bool = false) -> void:
 	if node == null:
 		return
 	if node is MeshInstance3D:
 		var mesh_instance: MeshInstance3D = node
 		for surface_index in range(mesh_instance.get_surface_override_material_count()):
 			var override_material: Material = mesh_instance.get_surface_override_material(surface_index)
-			_maybe_add_gdtf_lens_material(mesh_instance, override_material, output_materials)
-		_maybe_add_gdtf_lens_material(mesh_instance, mesh_instance.material_override, output_materials)
+			_maybe_add_gdtf_lens_material(mesh_instance, override_material, output_materials, include_all_materials)
+		_maybe_add_gdtf_lens_material(mesh_instance, mesh_instance.material_override, output_materials, include_all_materials)
 		if mesh_instance.mesh != null:
 			for surface_index in range(mesh_instance.mesh.get_surface_count()):
 				var surface_material: Material = mesh_instance.mesh.surface_get_material(surface_index)
-				_maybe_add_gdtf_lens_material(mesh_instance, surface_material, output_materials)
+				_maybe_add_gdtf_lens_material(mesh_instance, surface_material, output_materials, include_all_materials)
 
 	for child in node.get_children():
 		if child is Node3D:
-			_collect_lens_materials_recursive(child, output_materials)
+			_collect_lens_materials_recursive(child, output_materials, include_all_materials)
 
-func _maybe_add_gdtf_lens_material(mesh_instance: MeshInstance3D, material: Material, output_materials: Array) -> void:
+func _maybe_add_gdtf_lens_material(mesh_instance: MeshInstance3D, material: Material, output_materials: Array, include_all_materials: bool = false) -> void:
 	if material == null or not (material is BaseMaterial3D):
 		return
-	if not _is_gdtf_beam_lens_material(mesh_instance, material):
+	if (not include_all_materials) and (not _is_gdtf_beam_lens_material(mesh_instance, material)):
 		return
 	if output_materials.has(material):
 		return
@@ -1504,14 +1505,13 @@ func _apply_lens_feedback_materials(lens_materials: Array, beam_color: Color, no
 		lens_material.emission_energy_multiplier = lerp(0.0, 4.5, dimmer_mix)
 		lens_material.disable_receive_shadows = true
 		lens_material.cull_mode = BaseMaterial3D.CULL_DISABLED
-		if lens_material.transparency != BaseMaterial3D.TRANSPARENCY_DISABLED:
-			var alpha: float = lens_material.albedo_color.a
-			lens_material.albedo_color = Color(
-				lerp(LENS_TINT_COLOR.r, beam_color.r, dimmer_mix),
-				lerp(LENS_TINT_COLOR.g, beam_color.g, dimmer_mix),
-				lerp(LENS_TINT_COLOR.b, beam_color.b, dimmer_mix),
-				alpha
-			)
+		var alpha: float = lens_material.albedo_color.a
+		lens_material.albedo_color = Color(
+			lerp(LENS_TINT_COLOR.r, beam_color.r, dimmer_mix),
+			lerp(LENS_TINT_COLOR.g, beam_color.g, dimmer_mix),
+			lerp(LENS_TINT_COLOR.b, beam_color.b, dimmer_mix),
+			alpha
+		)
 
 func _find_or_create_emitter_light(emitter_node: Node3D) -> SpotLight3D:
 	var lens_radius: float = _estimate_emitter_lens_radius(emitter_node)

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -589,6 +589,7 @@ func _create_scene_node(data: Dictionary) -> Node3D:
 	var is_fixture: bool = bool(data.get("is_fixture", false))
 	var is_axis: bool = bool(data.get("is_axis", false))
 	var is_emitter: bool = bool(data.get("is_emitter", false))
+	var is_lens: bool = bool(data.get("is_lens", false))
 	var node_name: String = str(data.get("name", item_type))
 
 	var root := Node3D.new()
@@ -596,6 +597,7 @@ func _create_scene_node(data: Dictionary) -> Node3D:
 	root.set_meta("peraviz_type", item_type)
 	root.set_meta("peraviz_is_axis", is_axis)
 	root.set_meta("peraviz_is_emitter", is_emitter)
+	root.set_meta("peraviz_is_lens", is_lens)
 	var node_position: Vector3 = _safe_position(data.get("pos", Vector3.ZERO), "create_scene_node:" + root.name)
 	if bool(data.get("has_basis", false)):
 		var node_basis: Basis = _safe_basis_from_data(data)
@@ -977,6 +979,7 @@ func _register_fixture_registry(nodes: Array) -> void:
 		fixture_anchors[node_id] = {
 			"axis": [],
 			"emitters": [],
+			"lens": [],
 			"geometry_nodes": [],
 		}
 
@@ -1011,6 +1014,10 @@ func _register_fixture_registry(nodes: Array) -> void:
 			var geometry_nodes: Array = anchors.get("geometry_nodes", [])
 			geometry_nodes.append(node)
 			anchors["geometry_nodes"] = geometry_nodes
+			if bool(item.get("is_lens", false)):
+				var lens_nodes: Array = anchors.get("lens", [])
+				lens_nodes.append(node)
+				anchors["lens"] = lens_nodes
 			if bool(item.get("is_emitter", false)):
 				var photometric_entries: Array = anchors.get("emitter_photometrics", [])
 				photometric_entries.append(_extract_emitter_photometrics(item))
@@ -1371,7 +1378,10 @@ func _apply_dimmer_feedback_to_fixture(fixture_uuid: String, dimmer: float, cont
 	var normalized_dimmer: float = dimmer_percent / 100.0
 	var emitter_photometrics: Array = _get_fixture_emitter_photometrics(fixture_uuid)
 	var beam_color: Color = _resolve_fixture_beam_color(emitter_photometrics, controls)
-	var lens_materials: Array = _collect_fixture_lens_materials(fixture_uuid, emitter_nodes)
+	var lens_nodes: Array = _to_node3d_array(_scene_registry.get_anchor(fixture_uuid, "lens"))
+	if lens_nodes.is_empty():
+		lens_nodes = emitter_nodes
+	var lens_materials: Array = _collect_fixture_lens_materials(fixture_uuid, lens_nodes)
 	_apply_lens_feedback_materials(lens_materials, beam_color, normalized_dimmer)
 
 	var emissive_materials: Array = _collect_fixture_emissive_materials(fixture_uuid, geometry_nodes)
@@ -1493,6 +1503,7 @@ func _apply_lens_feedback_materials(lens_materials: Array, beam_color: Color, no
 		lens_material.emission = beam_color
 		lens_material.emission_energy_multiplier = lerp(0.0, 4.5, dimmer_mix)
 		lens_material.disable_receive_shadows = true
+		lens_material.cull_mode = BaseMaterial3D.CULL_DISABLED
 		if lens_material.transparency != BaseMaterial3D.TRANSPARENCY_DISABLED:
 			var alpha: float = lens_material.albedo_color.a
 			lens_material.albedo_color = Color(

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -109,8 +109,6 @@ const DEFAULT_EMITTER_PHOTOMETRICS := {
 # (aligned with fixture lens output in runtime scenes) while still inheriting GDTF emitter transforms.
 const EMITTER_LIGHT_DIRECTION_FIX: Vector3 = Vector3(-90.0, 0.0, 0.0)
 const LENS_TINT_COLOR: Color = Color(0.72, 0.86, 1.0, 0.38)
-const LENS_GLOW_MIN_RADIUS_M: float = 0.014
-const LENS_GLOW_MAX_RADIUS_M: float = 0.09
 const DOUBLE_SIDED_NAME_HINTS: Array[String] = [
 	"lens", "glass", "visor", "shade", "shield", "fabric", "cloth", "curtain", "scrim", "flag", "plane", "card"
 ]
@@ -669,6 +667,8 @@ func _build_visual_node(data: Dictionary, item_type: String, item_class: String,
 		print("[Peraviz] Asset fallback for missing/invalid model: ", asset_path, " type=", item_type, " class=", item_class, " asset_kind=", asset_kind)
 
 	if item_type == "fixture" or item_type == "fixture_geometry":
+		if asset_kind == "primitive":
+			return _create_gdtf_primitive_mesh(data)
 		return null
 
 	return _create_dummy_mesh(is_fixture, visual_scale_hint)
@@ -942,6 +942,41 @@ func _create_dummy_mesh(is_fixture: bool, visual_scale_hint: float) -> Node3D:
 		base_material.albedo_color = Color(1.0, 0.5, 0.1) if is_fixture else Color(0.2, 0.8, 1.0)
 		_asset_cache.store_material(material_key, base_material)
 		material = _asset_cache.get_material(material_key, true)
+	mesh_instance.material_override = material
+	return mesh_instance
+
+func _create_gdtf_primitive_mesh(data: Dictionary) -> Node3D:
+	var primitive_type: String = str(data.get("primitive_type", "")).to_lower()
+	var sx: float = max(float(data.get("primitive_size_x", 0.1)), 0.001)
+	var sy: float = max(float(data.get("primitive_size_y", 0.1)), 0.001)
+	var sz: float = max(float(data.get("primitive_size_z", 0.1)), 0.001)
+	var mesh_instance := MeshInstance3D.new()
+	if primitive_type.contains("sphere"):
+		var sphere := SphereMesh.new()
+		sphere.radius = max(sx, max(sy, sz)) * 0.5
+		sphere.height = sphere.radius * 2.0
+		mesh_instance.mesh = sphere
+	elif primitive_type.contains("cylinder"):
+		var cylinder := CylinderMesh.new()
+		cylinder.top_radius = max(sx, sy) * 0.5
+		cylinder.bottom_radius = max(sx, sy) * 0.5
+		cylinder.height = sz
+		mesh_instance.mesh = cylinder
+	elif primitive_type.contains("cone"):
+		var cone := CylinderMesh.new()
+		cone.top_radius = 0.0
+		cone.bottom_radius = max(sx, sy) * 0.5
+		cone.height = sz
+		mesh_instance.mesh = cone
+	else:
+		var box := BoxMesh.new()
+		box.size = Vector3(sx, sy, sz)
+		mesh_instance.mesh = box
+
+	var material := StandardMaterial3D.new()
+	material.albedo_color = Color(0.2, 0.2, 0.22, 1.0)
+	material.roughness = 0.3
+	material.cull_mode = BaseMaterial3D.CULL_DISABLED
 	mesh_instance.material_override = material
 	return mesh_instance
 
@@ -1567,7 +1602,6 @@ func _find_or_create_emitter_light(emitter_node: Node3D) -> SpotLight3D:
 			# Self/caster shadows from fixture geometry can clip the floor footprint.
 			child.shadow_enabled = false
 			child.set_meta("peraviz_lens_radius", lens_radius)
-			_ensure_emitter_lens_glow(emitter_node, lens_radius)
 			return child
 
 	var light := SpotLight3D.new()
@@ -1581,58 +1615,7 @@ func _find_or_create_emitter_light(emitter_node: Node3D) -> SpotLight3D:
 	light.spot_attenuation = 1.0
 	light.set_meta("peraviz_lens_radius", lens_radius)
 	emitter_node.add_child(light)
-	_ensure_emitter_lens_glow(emitter_node, lens_radius)
 	return light
-
-func _ensure_emitter_lens_glow(emitter_node: Node3D, lens_radius: float) -> void:
-	if emitter_node == null:
-		return
-	var glow_node: MeshInstance3D = null
-	for child in emitter_node.get_children():
-		if child is MeshInstance3D and child.name == "PeravizLensGlow":
-			glow_node = child
-			break
-	if glow_node == null:
-		glow_node = MeshInstance3D.new()
-		glow_node.name = "PeravizLensGlow"
-		glow_node.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
-		glow_node.position = Vector3.ZERO
-		glow_node.rotation_degrees = EMITTER_LIGHT_DIRECTION_FIX
-		var glow_mesh := SphereMesh.new()
-		glow_node.mesh = glow_mesh
-		var glow_material := StandardMaterial3D.new()
-		glow_material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
-		glow_material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
-		glow_material.blend_mode = BaseMaterial3D.BLEND_MODE_ADD
-		glow_material.cull_mode = BaseMaterial3D.CULL_DISABLED
-		glow_material.emission_enabled = true
-		glow_material.albedo_color = Color(1.0, 1.0, 1.0, 0.0)
-		glow_material.emission = Color.BLACK
-		glow_material.emission_energy_multiplier = 0.0
-		glow_node.material_override = glow_material
-		emitter_node.add_child(glow_node)
-
-	# Slightly larger than the estimated lens to improve visibility without looking detached.
-	var effective_radius: float = clamp(lens_radius * 1.30, LENS_GLOW_MIN_RADIUS_M, LENS_GLOW_MAX_RADIUS_M)
-	if glow_node.mesh is SphereMesh:
-		var sphere_mesh: SphereMesh = glow_node.mesh
-		sphere_mesh.radius = effective_radius
-		sphere_mesh.height = effective_radius * 2.0
-
-func _update_emitter_lens_glow(emitter_node: Node3D, beam_color: Color, normalized_dimmer: float) -> void:
-	if emitter_node == null:
-		return
-	for child in emitter_node.get_children():
-		if child is MeshInstance3D and child.name == "PeravizLensGlow":
-			var glow_mesh: MeshInstance3D = child
-			glow_mesh.visible = normalized_dimmer > 0.0001
-			if glow_mesh.material_override is BaseMaterial3D:
-				var glow_material: BaseMaterial3D = glow_mesh.material_override
-				glow_material.emission_enabled = true
-				glow_material.emission = beam_color
-				glow_material.emission_energy_multiplier = lerp(0.0, 8.5, clamp(normalized_dimmer, 0.0, 1.0))
-				glow_material.albedo_color = Color(beam_color.r, beam_color.g, beam_color.b, lerp(0.0, 0.40, clamp(normalized_dimmer, 0.0, 1.0)))
-			return
 
 func _estimate_emitter_lens_radius(emitter_node: Node3D) -> float:
 	var default_radius: float = 0.03
@@ -1827,8 +1810,6 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 	# avoids early floor clipping on steep tilt while keeping cone visuals unchanged.
 	light.spot_range = clamp(cone_range * EMITTER_LIGHT_FOOTPRINT_RANGE_MULTIPLIER, EMITTER_LIGHT_MIN_EFFECTIVE_RANGE_M, EMITTER_LIGHT_MAX_RANGE_M)
 	light.light_color = _derive_emitter_color(photometric, controls)
-	var emitter_parent: Node3D = light.get_parent() as Node3D
-	_update_emitter_lens_glow(emitter_parent, light.light_color, normalized_dimmer)
 	var beam_radius_from_gdtf: bool = bool(photometric.get("beam_radius_from_gdtf", false))
 	var source_beam_radius: float = beam_radius_m if beam_radius_from_gdtf else -1.0
 	var lens_radius: float = max(float(light.get_meta("peraviz_lens_radius", 0.03)), 0.005)

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -2256,12 +2256,23 @@ func _on_dmx_toggle_pressed() -> void:
 		_dmx_toggle_button.button_pressed = false
 		return
 	if _dmx_toggle_button.button_pressed:
+		# Defensive restart: ensure stale sockets are released before retrying bind.
+		_dmx_receiver.stop()
 		var started: bool = _dmx_receiver.start("0.0.0.0", 6454)
+		if not started:
+			_dmx_receiver.stop()
+			started = _dmx_receiver.start("0.0.0.0", 6454)
 		if not started:
 			_dmx_toggle_button.button_pressed = false
 			_dmx_toggle_button.text = "DMX OFF"
 			_update_dmx_toggle_color(false, false)
-			_dmx_toggle_button.tooltip_text = "DMX failed to start"
+			var startup_error: String = ""
+			if _dmx_receiver.has_method("get_last_error"):
+				startup_error = str(_dmx_receiver.get_last_error())
+			if startup_error.is_empty():
+				_dmx_toggle_button.tooltip_text = "DMX failed to start"
+			else:
+				_dmx_toggle_button.tooltip_text = "DMX failed to start: %s" % startup_error
 			return
 		_dmx_toggle_button.text = "DMX ON"
 		_dmx_toggle_button.tooltip_text = ""

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -1437,17 +1437,24 @@ func _collect_lens_materials_recursive(node: Node3D, output_materials: Array) ->
 		var mesh_instance: MeshInstance3D = node
 		for surface_index in range(mesh_instance.get_surface_override_material_count()):
 			var override_material: Material = mesh_instance.get_surface_override_material(surface_index)
-			_maybe_add_lens_material(override_material, output_materials)
-		_maybe_add_lens_material(mesh_instance.material_override, output_materials)
+			_maybe_add_lens_material(mesh_instance, override_material, output_materials)
+		_maybe_add_lens_material(mesh_instance, mesh_instance.material_override, output_materials)
+		if mesh_instance.mesh != null:
+			for surface_index in range(mesh_instance.mesh.get_surface_count()):
+				var surface_material: Material = mesh_instance.mesh.surface_get_material(surface_index)
+				_maybe_add_lens_material(mesh_instance, surface_material, output_materials)
 
 	for child in node.get_children():
 		if child is Node3D:
 			_collect_lens_materials_recursive(child, output_materials)
 
-func _maybe_add_lens_material(material: Material, output_materials: Array) -> void:
+func _maybe_add_lens_material(mesh_instance: MeshInstance3D, material: Material, output_materials: Array) -> void:
 	if material == null or not (material is BaseMaterial3D):
 		return
-	if not bool(material.get_meta("peraviz_lens_material", false)):
+	var include_material: bool = bool(material.get_meta("peraviz_lens_material", false))
+	if not include_material:
+		include_material = _should_apply_lens_tint(mesh_instance, material)
+	if not include_material:
 		return
 	if output_materials.has(material):
 		return
@@ -1481,6 +1488,7 @@ func _apply_lens_feedback_materials(lens_materials: Array, beam_color: Color, no
 		var alpha: float = LENS_TINT_COLOR.a
 		if lens_material.has_meta("peraviz_lens_base_alpha"):
 			alpha = float(lens_material.get_meta("peraviz_lens_base_alpha", LENS_TINT_COLOR.a))
+		lens_material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
 		lens_material.albedo_color = Color(
 			lerp(LENS_TINT_COLOR.r, beam_color.r, dimmer_mix),
 			lerp(LENS_TINT_COLOR.g, beam_color.g, dimmer_mix),
@@ -1972,23 +1980,27 @@ func _tint_emitter_lens_recursive(node: Node3D) -> void:
 
 func _should_apply_lens_tint(mesh_instance: MeshInstance3D, material: Material) -> bool:
 	var name_hint: String = mesh_instance.name.to_lower()
-	if name_hint.contains("lens") or name_hint.contains("emitter") or name_hint.contains("beam"):
+	if name_hint.contains("lens") or name_hint.contains("glass"):
 		return true
 	if material is BaseMaterial3D:
 		var base_material: BaseMaterial3D = material
 		if base_material.transparency != BaseMaterial3D.TRANSPARENCY_DISABLED:
 			return true
-		if base_material.emission_enabled:
+		if base_material.emission_enabled and (name_hint.contains("lens") or name_hint.contains("glass")):
 			return true
 	return false
 
 func _build_lens_material_override(source: Material) -> StandardMaterial3D:
 	var material := StandardMaterial3D.new()
+	var source_alpha: float = LENS_TINT_COLOR.a
 	if source is BaseMaterial3D:
 		var base_source: BaseMaterial3D = source
 		material.albedo_color = base_source.albedo_color.lerp(LENS_TINT_COLOR, 0.65)
+		if base_source.transparency != BaseMaterial3D.TRANSPARENCY_DISABLED:
+			source_alpha = min(base_source.albedo_color.a, LENS_TINT_COLOR.a)
 	else:
 		material.albedo_color = LENS_TINT_COLOR
+	material.albedo_color.a = source_alpha
 	material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
 	material.roughness = 0.08
 	material.metallic = 0.0

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -44,7 +44,6 @@ var _fixture_emissive_cache: Dictionary = {}
 var _fixture_lens_material_cache: Dictionary = {}
 var _fixture_emitter_light_cache: Dictionary = {}
 var _fixture_emitter_photometrics: Dictionary = {}
-var _fixture_lens_tuned: Dictionary = {}
 var _updating_fixture_controls: bool = false
 var _visual_environment_baseline := {
 	"ambient_light_energy": 0.2,
@@ -953,7 +952,6 @@ func _clear_scene() -> void:
 	_fixture_lens_material_cache.clear()
 	_fixture_emitter_light_cache.clear()
 	_fixture_emitter_photometrics.clear()
-	_fixture_lens_tuned.clear()
 	_has_loaded_bounds = false
 	_clear_debug_gizmos()
 
@@ -1368,7 +1366,6 @@ func _apply_dimmer_feedback_to_fixture(fixture_uuid: String, dimmer: float, cont
 	var emitter_nodes: Array = _to_node3d_array(_scene_registry.get_anchor(fixture_uuid, "emitters"))
 	if geometry_nodes.is_empty() and emitter_nodes.is_empty():
 		return
-	_apply_fixture_lens_visual_tuning(fixture_uuid, emitter_nodes)
 
 	var dimmer_percent: float = clamp(dimmer, 0.0, 100.0)
 	var normalized_dimmer: float = dimmer_percent / 100.0
@@ -1437,28 +1434,38 @@ func _collect_lens_materials_recursive(node: Node3D, output_materials: Array) ->
 		var mesh_instance: MeshInstance3D = node
 		for surface_index in range(mesh_instance.get_surface_override_material_count()):
 			var override_material: Material = mesh_instance.get_surface_override_material(surface_index)
-			_maybe_add_lens_material(mesh_instance, override_material, output_materials)
-		_maybe_add_lens_material(mesh_instance, mesh_instance.material_override, output_materials)
+			_maybe_add_gdtf_lens_material(mesh_instance, override_material, output_materials)
+		_maybe_add_gdtf_lens_material(mesh_instance, mesh_instance.material_override, output_materials)
 		if mesh_instance.mesh != null:
 			for surface_index in range(mesh_instance.mesh.get_surface_count()):
 				var surface_material: Material = mesh_instance.mesh.surface_get_material(surface_index)
-				_maybe_add_lens_material(mesh_instance, surface_material, output_materials)
+				_maybe_add_gdtf_lens_material(mesh_instance, surface_material, output_materials)
 
 	for child in node.get_children():
 		if child is Node3D:
 			_collect_lens_materials_recursive(child, output_materials)
 
-func _maybe_add_lens_material(mesh_instance: MeshInstance3D, material: Material, output_materials: Array) -> void:
+func _maybe_add_gdtf_lens_material(mesh_instance: MeshInstance3D, material: Material, output_materials: Array) -> void:
 	if material == null or not (material is BaseMaterial3D):
 		return
-	var include_material: bool = bool(material.get_meta("peraviz_lens_material", false))
-	if not include_material:
-		include_material = _should_apply_lens_tint(mesh_instance, material)
-	if not include_material:
+	if not _is_gdtf_beam_lens_material(mesh_instance, material):
 		return
 	if output_materials.has(material):
 		return
 	output_materials.append(material)
+
+func _is_gdtf_beam_lens_material(mesh_instance: MeshInstance3D, material: Material) -> bool:
+	# GDTF beam geometry is already represented by emitter anchors.
+	# Inside those anchors, lens surfaces are usually transparent or explicitly named lens/glass.
+	var name_hint: String = mesh_instance.name.to_lower()
+	if name_hint.contains("lens") or name_hint.contains("glass"):
+		return true
+	if material.resource_name.to_lower().contains("lens") or material.resource_name.to_lower().contains("glass"):
+		return true
+	if material is BaseMaterial3D:
+		var base_material: BaseMaterial3D = material
+		return base_material.transparency != BaseMaterial3D.TRANSPARENCY_DISABLED
+	return false
 
 func _resolve_fixture_beam_color(emitter_photometrics: Array, controls: Dictionary) -> Color:
 	if emitter_photometrics.is_empty():
@@ -1485,16 +1492,15 @@ func _apply_lens_feedback_materials(lens_materials: Array, beam_color: Color, no
 		lens_material.emission_enabled = true
 		lens_material.emission = beam_color
 		lens_material.emission_energy_multiplier = lerp(0.0, 4.5, dimmer_mix)
-		var alpha: float = LENS_TINT_COLOR.a
-		if lens_material.has_meta("peraviz_lens_base_alpha"):
-			alpha = float(lens_material.get_meta("peraviz_lens_base_alpha", LENS_TINT_COLOR.a))
-		lens_material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
-		lens_material.albedo_color = Color(
-			lerp(LENS_TINT_COLOR.r, beam_color.r, dimmer_mix),
-			lerp(LENS_TINT_COLOR.g, beam_color.g, dimmer_mix),
-			lerp(LENS_TINT_COLOR.b, beam_color.b, dimmer_mix),
-			alpha
-		)
+		lens_material.disable_receive_shadows = true
+		if lens_material.transparency != BaseMaterial3D.TRANSPARENCY_DISABLED:
+			var alpha: float = lens_material.albedo_color.a
+			lens_material.albedo_color = Color(
+				lerp(LENS_TINT_COLOR.r, beam_color.r, dimmer_mix),
+				lerp(LENS_TINT_COLOR.g, beam_color.g, dimmer_mix),
+				lerp(LENS_TINT_COLOR.b, beam_color.b, dimmer_mix),
+				alpha
+			)
 
 func _find_or_create_emitter_light(emitter_node: Node3D) -> SpotLight3D:
 	var lens_radius: float = _estimate_emitter_lens_radius(emitter_node)
@@ -1956,63 +1962,6 @@ func _update_beam_cone_material(cone: MeshInstance3D, beam_color: Color, scaled_
 	material.set_shader_parameter("depth_feather_enabled", true)
 	material.set_shader_parameter("depth_fade_distance", 0.5)
 	material.set_shader_parameter("max_brightness", lerp(1.0, 10.0 * brightness_scale, scaled_intensity))
-
-func _apply_fixture_lens_visual_tuning(fixture_uuid: String, emitter_nodes: Array) -> void:
-	if _fixture_lens_tuned.get(fixture_uuid, false):
-		return
-	for emitter_node in emitter_nodes:
-		_tint_emitter_lens_recursive(emitter_node)
-	_fixture_lens_tuned[fixture_uuid] = true
-
-func _tint_emitter_lens_recursive(node: Node3D) -> void:
-	if node == null:
-		return
-	if node is MeshInstance3D:
-		var mesh_instance: MeshInstance3D = node
-		if mesh_instance.mesh != null:
-			for surface_index in range(mesh_instance.mesh.get_surface_count()):
-				var material: Material = mesh_instance.get_active_material(surface_index)
-				if _should_apply_lens_tint(mesh_instance, material):
-					mesh_instance.set_surface_override_material(surface_index, _build_lens_material_override(material))
-	for child in node.get_children():
-		if child is Node3D:
-			_tint_emitter_lens_recursive(child)
-
-func _should_apply_lens_tint(mesh_instance: MeshInstance3D, material: Material) -> bool:
-	var name_hint: String = mesh_instance.name.to_lower()
-	if name_hint.contains("lens") or name_hint.contains("glass"):
-		return true
-	if material is BaseMaterial3D:
-		var base_material: BaseMaterial3D = material
-		if base_material.transparency != BaseMaterial3D.TRANSPARENCY_DISABLED:
-			return true
-		if base_material.emission_enabled and (name_hint.contains("lens") or name_hint.contains("glass")):
-			return true
-	return false
-
-func _build_lens_material_override(source: Material) -> StandardMaterial3D:
-	var material := StandardMaterial3D.new()
-	var source_alpha: float = LENS_TINT_COLOR.a
-	if source is BaseMaterial3D:
-		var base_source: BaseMaterial3D = source
-		material.albedo_color = base_source.albedo_color.lerp(LENS_TINT_COLOR, 0.65)
-		if base_source.transparency != BaseMaterial3D.TRANSPARENCY_DISABLED:
-			source_alpha = min(base_source.albedo_color.a, LENS_TINT_COLOR.a)
-	else:
-		material.albedo_color = LENS_TINT_COLOR
-	material.albedo_color.a = source_alpha
-	material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
-	material.roughness = 0.08
-	material.metallic = 0.0
-	material.clearcoat_enabled = true
-	material.clearcoat = 0.75
-	material.specular = 1.0
-	material.emission_enabled = true
-	material.emission = material.albedo_color
-	material.emission_energy_multiplier = 0.35
-	material.set_meta("peraviz_lens_material", true)
-	material.set_meta("peraviz_lens_base_alpha", material.albedo_color.a)
-	return material
 
 func _derive_emitter_color(photometric: Dictionary, controls: Dictionary = {}) -> Color:
 	var base_color: Color

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -109,6 +109,8 @@ const DEFAULT_EMITTER_PHOTOMETRICS := {
 # (aligned with fixture lens output in runtime scenes) while still inheriting GDTF emitter transforms.
 const EMITTER_LIGHT_DIRECTION_FIX: Vector3 = Vector3(-90.0, 0.0, 0.0)
 const LENS_TINT_COLOR: Color = Color(0.72, 0.86, 1.0, 0.38)
+const LENS_GLOW_MIN_RADIUS_M: float = 0.012
+const LENS_GLOW_MAX_RADIUS_M: float = 0.08
 const DOUBLE_SIDED_NAME_HINTS: Array[String] = [
 	"lens", "glass", "visor", "shade", "shield", "fabric", "cloth", "curtain", "scrim", "flag", "plane", "card"
 ]
@@ -1523,6 +1525,7 @@ func _find_or_create_emitter_light(emitter_node: Node3D) -> SpotLight3D:
 			# Self/caster shadows from fixture geometry can clip the floor footprint.
 			child.shadow_enabled = false
 			child.set_meta("peraviz_lens_radius", lens_radius)
+			_ensure_emitter_lens_glow(emitter_node, lens_radius)
 			return child
 
 	var light := SpotLight3D.new()
@@ -1536,7 +1539,57 @@ func _find_or_create_emitter_light(emitter_node: Node3D) -> SpotLight3D:
 	light.spot_attenuation = 1.0
 	light.set_meta("peraviz_lens_radius", lens_radius)
 	emitter_node.add_child(light)
+	_ensure_emitter_lens_glow(emitter_node, lens_radius)
 	return light
+
+func _ensure_emitter_lens_glow(emitter_node: Node3D, lens_radius: float) -> void:
+	if emitter_node == null:
+		return
+	var glow_node: MeshInstance3D = null
+	for child in emitter_node.get_children():
+		if child is MeshInstance3D and child.name == "PeravizLensGlow":
+			glow_node = child
+			break
+	if glow_node == null:
+		glow_node = MeshInstance3D.new()
+		glow_node.name = "PeravizLensGlow"
+		glow_node.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
+		glow_node.position = Vector3.ZERO
+		glow_node.rotation_degrees = EMITTER_LIGHT_DIRECTION_FIX
+		var glow_mesh := SphereMesh.new()
+		glow_node.mesh = glow_mesh
+		var glow_material := StandardMaterial3D.new()
+		glow_material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
+		glow_material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
+		glow_material.blend_mode = BaseMaterial3D.BLEND_MODE_ADD
+		glow_material.cull_mode = BaseMaterial3D.CULL_DISABLED
+		glow_material.emission_enabled = true
+		glow_material.albedo_color = Color(1.0, 1.0, 1.0, 0.0)
+		glow_material.emission = Color.BLACK
+		glow_material.emission_energy_multiplier = 0.0
+		glow_node.material_override = glow_material
+		emitter_node.add_child(glow_node)
+
+	var effective_radius: float = clamp(lens_radius * 1.15, LENS_GLOW_MIN_RADIUS_M, LENS_GLOW_MAX_RADIUS_M)
+	if glow_node.mesh is SphereMesh:
+		var sphere_mesh: SphereMesh = glow_node.mesh
+		sphere_mesh.radius = effective_radius
+		sphere_mesh.height = effective_radius * 2.0
+
+func _update_emitter_lens_glow(emitter_node: Node3D, beam_color: Color, normalized_dimmer: float) -> void:
+	if emitter_node == null:
+		return
+	for child in emitter_node.get_children():
+		if child is MeshInstance3D and child.name == "PeravizLensGlow":
+			var glow_mesh: MeshInstance3D = child
+			glow_mesh.visible = normalized_dimmer > 0.0001
+			if glow_mesh.material_override is BaseMaterial3D:
+				var glow_material: BaseMaterial3D = glow_mesh.material_override
+				glow_material.emission_enabled = true
+				glow_material.emission = beam_color
+				glow_material.emission_energy_multiplier = lerp(0.0, 8.0, clamp(normalized_dimmer, 0.0, 1.0))
+				glow_material.albedo_color = Color(beam_color.r, beam_color.g, beam_color.b, lerp(0.0, 0.35, clamp(normalized_dimmer, 0.0, 1.0)))
+			return
 
 func _estimate_emitter_lens_radius(emitter_node: Node3D) -> float:
 	var default_radius: float = 0.03
@@ -1731,6 +1784,8 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 	# avoids early floor clipping on steep tilt while keeping cone visuals unchanged.
 	light.spot_range = clamp(cone_range * EMITTER_LIGHT_FOOTPRINT_RANGE_MULTIPLIER, EMITTER_LIGHT_MIN_EFFECTIVE_RANGE_M, EMITTER_LIGHT_MAX_RANGE_M)
 	light.light_color = _derive_emitter_color(photometric, controls)
+	var emitter_parent: Node3D = light.get_parent() as Node3D
+	_update_emitter_lens_glow(emitter_parent, light.light_color, normalized_dimmer)
 	var beam_radius_from_gdtf: bool = bool(photometric.get("beam_radius_from_gdtf", false))
 	var source_beam_radius: float = beam_radius_m if beam_radius_from_gdtf else -1.0
 	var lens_radius: float = max(float(light.get_meta("peraviz_lens_radius", 0.03)), 0.005)

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -41,6 +41,7 @@ var _manual_fixture_test_enabled: bool = false
 var _selected_fixture_uuid: String = ""
 var _fixture_manual_values: Dictionary = {}
 var _fixture_emissive_cache: Dictionary = {}
+var _fixture_lens_material_cache: Dictionary = {}
 var _fixture_emitter_light_cache: Dictionary = {}
 var _fixture_emitter_photometrics: Dictionary = {}
 var _fixture_lens_tuned: Dictionary = {}
@@ -949,6 +950,7 @@ func _clear_scene() -> void:
 	_node_index.clear()
 	_asset_cache.clear()
 	_fixture_emissive_cache.clear()
+	_fixture_lens_material_cache.clear()
 	_fixture_emitter_light_cache.clear()
 	_fixture_emitter_photometrics.clear()
 	_fixture_lens_tuned.clear()
@@ -1370,15 +1372,20 @@ func _apply_dimmer_feedback_to_fixture(fixture_uuid: String, dimmer: float, cont
 
 	var dimmer_percent: float = clamp(dimmer, 0.0, 100.0)
 	var normalized_dimmer: float = dimmer_percent / 100.0
+	var emitter_photometrics: Array = _get_fixture_emitter_photometrics(fixture_uuid)
+	var beam_color: Color = _resolve_fixture_beam_color(emitter_photometrics, controls)
+	var lens_materials: Array = _collect_fixture_lens_materials(fixture_uuid, emitter_nodes)
+	_apply_lens_feedback_materials(lens_materials, beam_color, normalized_dimmer)
+
 	var emissive_materials: Array = _collect_fixture_emissive_materials(fixture_uuid, geometry_nodes)
 	var energy_multiplier: float = lerp(0.0, 4.0, normalized_dimmer)
 	for material in emissive_materials:
 		if material is BaseMaterial3D:
 			material.emission_enabled = true
+			material.emission = beam_color
 			material.emission_energy_multiplier = energy_multiplier
 
 	var emitter_lights: Array = _collect_fixture_emitter_lights(fixture_uuid, emitter_nodes)
-	var emitter_photometrics: Array = _get_fixture_emitter_photometrics(fixture_uuid)
 	for index in range(emitter_lights.size()):
 		var light: SpotLight3D = emitter_lights[index]
 		if light == null or not is_instance_valid(light):
@@ -1412,6 +1419,74 @@ func _collect_fixture_emitter_lights(fixture_uuid: String, emitter_nodes: Array)
 
 	_fixture_emitter_light_cache[fixture_uuid] = lights
 	return lights
+
+func _collect_fixture_lens_materials(fixture_uuid: String, emitter_nodes: Array) -> Array:
+	if _fixture_lens_material_cache.has(fixture_uuid):
+		return _fixture_lens_material_cache.get(fixture_uuid, [])
+
+	var materials: Array = []
+	for emitter_node in emitter_nodes:
+		_collect_lens_materials_recursive(emitter_node, materials)
+	_fixture_lens_material_cache[fixture_uuid] = materials
+	return materials
+
+func _collect_lens_materials_recursive(node: Node3D, output_materials: Array) -> void:
+	if node == null:
+		return
+	if node is MeshInstance3D:
+		var mesh_instance: MeshInstance3D = node
+		for surface_index in range(mesh_instance.get_surface_override_material_count()):
+			var override_material: Material = mesh_instance.get_surface_override_material(surface_index)
+			_maybe_add_lens_material(override_material, output_materials)
+		_maybe_add_lens_material(mesh_instance.material_override, output_materials)
+
+	for child in node.get_children():
+		if child is Node3D:
+			_collect_lens_materials_recursive(child, output_materials)
+
+func _maybe_add_lens_material(material: Material, output_materials: Array) -> void:
+	if material == null or not (material is BaseMaterial3D):
+		return
+	if not bool(material.get_meta("peraviz_lens_material", false)):
+		return
+	if output_materials.has(material):
+		return
+	output_materials.append(material)
+
+func _resolve_fixture_beam_color(emitter_photometrics: Array, controls: Dictionary) -> Color:
+	if emitter_photometrics.is_empty():
+		return _derive_emitter_color(DEFAULT_EMITTER_PHOTOMETRICS, controls)
+
+	var accumulated_color: Color = Color.BLACK
+	var samples: int = 0
+	for entry in emitter_photometrics:
+		if entry is not Dictionary:
+			continue
+		accumulated_color += _derive_emitter_color(entry, controls)
+		samples += 1
+	if samples <= 0:
+		return _derive_emitter_color(DEFAULT_EMITTER_PHOTOMETRICS, controls)
+	var inverse_samples: float = 1.0 / float(samples)
+	return Color(accumulated_color.r * inverse_samples, accumulated_color.g * inverse_samples, accumulated_color.b * inverse_samples, 1.0)
+
+func _apply_lens_feedback_materials(lens_materials: Array, beam_color: Color, normalized_dimmer: float) -> void:
+	var dimmer_mix: float = clamp(normalized_dimmer, 0.0, 1.0)
+	for material in lens_materials:
+		if material is not BaseMaterial3D:
+			continue
+		var lens_material: BaseMaterial3D = material
+		lens_material.emission_enabled = true
+		lens_material.emission = beam_color
+		lens_material.emission_energy_multiplier = lerp(0.0, 4.5, dimmer_mix)
+		var alpha: float = LENS_TINT_COLOR.a
+		if lens_material.has_meta("peraviz_lens_base_alpha"):
+			alpha = float(lens_material.get_meta("peraviz_lens_base_alpha", LENS_TINT_COLOR.a))
+		lens_material.albedo_color = Color(
+			lerp(LENS_TINT_COLOR.r, beam_color.r, dimmer_mix),
+			lerp(LENS_TINT_COLOR.g, beam_color.g, dimmer_mix),
+			lerp(LENS_TINT_COLOR.b, beam_color.b, dimmer_mix),
+			alpha
+		)
 
 func _find_or_create_emitter_light(emitter_node: Node3D) -> SpotLight3D:
 	var lens_radius: float = _estimate_emitter_lens_radius(emitter_node)
@@ -1923,6 +1998,8 @@ func _build_lens_material_override(source: Material) -> StandardMaterial3D:
 	material.emission_enabled = true
 	material.emission = material.albedo_color
 	material.emission_energy_multiplier = 0.35
+	material.set_meta("peraviz_lens_material", true)
+	material.set_meta("peraviz_lens_base_alpha", material.albedo_color.a)
 	return material
 
 func _derive_emitter_color(photometric: Dictionary, controls: Dictionary = {}) -> Color:

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -109,6 +109,8 @@ const DEFAULT_EMITTER_PHOTOMETRICS := {
 # (aligned with fixture lens output in runtime scenes) while still inheriting GDTF emitter transforms.
 const EMITTER_LIGHT_DIRECTION_FIX: Vector3 = Vector3(-90.0, 0.0, 0.0)
 const LENS_TINT_COLOR: Color = Color(0.72, 0.86, 1.0, 0.38)
+const LENS_GLOW_MIN_RADIUS_M: float = 0.014
+const LENS_GLOW_MAX_RADIUS_M: float = 0.09
 const DOUBLE_SIDED_NAME_HINTS: Array[String] = [
 	"lens", "glass", "visor", "shade", "shield", "fabric", "cloth", "curtain", "scrim", "flag", "plane", "card"
 ]
@@ -1565,6 +1567,7 @@ func _find_or_create_emitter_light(emitter_node: Node3D) -> SpotLight3D:
 			# Self/caster shadows from fixture geometry can clip the floor footprint.
 			child.shadow_enabled = false
 			child.set_meta("peraviz_lens_radius", lens_radius)
+			_ensure_emitter_lens_glow(emitter_node, lens_radius)
 			return child
 
 	var light := SpotLight3D.new()
@@ -1578,7 +1581,58 @@ func _find_or_create_emitter_light(emitter_node: Node3D) -> SpotLight3D:
 	light.spot_attenuation = 1.0
 	light.set_meta("peraviz_lens_radius", lens_radius)
 	emitter_node.add_child(light)
+	_ensure_emitter_lens_glow(emitter_node, lens_radius)
 	return light
+
+func _ensure_emitter_lens_glow(emitter_node: Node3D, lens_radius: float) -> void:
+	if emitter_node == null:
+		return
+	var glow_node: MeshInstance3D = null
+	for child in emitter_node.get_children():
+		if child is MeshInstance3D and child.name == "PeravizLensGlow":
+			glow_node = child
+			break
+	if glow_node == null:
+		glow_node = MeshInstance3D.new()
+		glow_node.name = "PeravizLensGlow"
+		glow_node.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
+		glow_node.position = Vector3.ZERO
+		glow_node.rotation_degrees = EMITTER_LIGHT_DIRECTION_FIX
+		var glow_mesh := SphereMesh.new()
+		glow_node.mesh = glow_mesh
+		var glow_material := StandardMaterial3D.new()
+		glow_material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
+		glow_material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
+		glow_material.blend_mode = BaseMaterial3D.BLEND_MODE_ADD
+		glow_material.cull_mode = BaseMaterial3D.CULL_DISABLED
+		glow_material.emission_enabled = true
+		glow_material.albedo_color = Color(1.0, 1.0, 1.0, 0.0)
+		glow_material.emission = Color.BLACK
+		glow_material.emission_energy_multiplier = 0.0
+		glow_node.material_override = glow_material
+		emitter_node.add_child(glow_node)
+
+	# Slightly larger than the estimated lens to improve visibility without looking detached.
+	var effective_radius: float = clamp(lens_radius * 1.30, LENS_GLOW_MIN_RADIUS_M, LENS_GLOW_MAX_RADIUS_M)
+	if glow_node.mesh is SphereMesh:
+		var sphere_mesh: SphereMesh = glow_node.mesh
+		sphere_mesh.radius = effective_radius
+		sphere_mesh.height = effective_radius * 2.0
+
+func _update_emitter_lens_glow(emitter_node: Node3D, beam_color: Color, normalized_dimmer: float) -> void:
+	if emitter_node == null:
+		return
+	for child in emitter_node.get_children():
+		if child is MeshInstance3D and child.name == "PeravizLensGlow":
+			var glow_mesh: MeshInstance3D = child
+			glow_mesh.visible = normalized_dimmer > 0.0001
+			if glow_mesh.material_override is BaseMaterial3D:
+				var glow_material: BaseMaterial3D = glow_mesh.material_override
+				glow_material.emission_enabled = true
+				glow_material.emission = beam_color
+				glow_material.emission_energy_multiplier = lerp(0.0, 8.5, clamp(normalized_dimmer, 0.0, 1.0))
+				glow_material.albedo_color = Color(beam_color.r, beam_color.g, beam_color.b, lerp(0.0, 0.40, clamp(normalized_dimmer, 0.0, 1.0)))
+			return
 
 func _estimate_emitter_lens_radius(emitter_node: Node3D) -> float:
 	var default_radius: float = 0.03
@@ -1773,6 +1827,8 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 	# avoids early floor clipping on steep tilt while keeping cone visuals unchanged.
 	light.spot_range = clamp(cone_range * EMITTER_LIGHT_FOOTPRINT_RANGE_MULTIPLIER, EMITTER_LIGHT_MIN_EFFECTIVE_RANGE_M, EMITTER_LIGHT_MAX_RANGE_M)
 	light.light_color = _derive_emitter_color(photometric, controls)
+	var emitter_parent: Node3D = light.get_parent() as Node3D
+	_update_emitter_lens_glow(emitter_parent, light.light_color, normalized_dimmer)
 	var beam_radius_from_gdtf: bool = bool(photometric.get("beam_radius_from_gdtf", false))
 	var source_beam_radius: float = beam_radius_m if beam_radius_from_gdtf else -1.0
 	var lens_radius: float = max(float(light.get_meta("peraviz_lens_radius", 0.03)), 0.005)


### PR DESCRIPTION
### Motivation
- Fixtures' lenses should visibly light up (change color/intensity) when the fixture dimmer is turned on so the scene clearly shows a fixture is "on" and reflects beam color.

### Description
- Added per-fixture lens material caching and traversal helpers (`_collect_fixture_lens_materials`, `_collect_lens_materials_recursive`, `_maybe_add_lens_material`) to find lens materials under emitter nodes and avoid repeated scans.
- Derived a per-fixture `beam_color` from emitter photometrics and DMX color controls via `_resolve_fixture_beam_color` and applied it to both emissive geometry and lens materials when the dimmer changes.
- Implemented `_apply_lens_feedback_materials` to mix lens albedo and emission with `beam_color` based on normalized dimmer and to adjust emission energy accordingly.
- Marked generated lens override materials with metadata (`peraviz_lens_material`, `peraviz_lens_base_alpha`) and clear the new lens-material cache in `_clear_scene` to keep behavior consistent and limited to intended materials.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699747b6e5348324bc698c0d96d34cc7)