### PR TITLE
Fix stale 3D sorted entry pointers after scene deletions

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -823,6 +823,12 @@ void Viewer3DController::UpdateResourcesIfDirty() {
     ++m_impl->sceneVersion;
     m_impl->sceneChangedDirty = true;
     std::lock_guard<std::mutex> lock(m_impl->sortedListsMutex);
+    // Scene removals invalidate pointers stored in the sorted entry caches.
+    // Clear them immediately so fast-interaction frames (which may defer the
+    // rebuild) never dereference stale entries.
+    m_impl->sortedObjects.clear();
+    m_impl->sortedTrusses.clear();
+    m_impl->sortedFixtures.clear();
     m_impl->sortedListsDirty = true;
   }
   if (syncResult.assetsChanged) {


### PR DESCRIPTION
### Motivation
- Deleting scene items could leave dangling pointers in the controller's sorted-entry caches which, when read later (e.g. during fast-interaction frames that defer rebuilds), produced read-access violations while hashing/comparing UUIDs; the sorted caches must be invalidated immediately on scene changes.

### Description
- In `viewer3d/viewer3dcontroller.cpp` inside `UpdateResourcesIfDirty()` clear `m_impl->sortedObjects`, `m_impl->sortedTrusses`, and `m_impl->sortedFixtures` (under the `sortedListsMutex`) when `ResourceSyncSystem::Sync` reports `sceneChanged`, and keep `sortedListsDirty = true` so the full rebuild occurs later.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which succeeded, and `tests/check_no_configmanager_get_in_gui.sh` which also succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998111de7908324abfc4629c04c6c9b)