### PR TITLE
Fix macOS Godot Variant ambiguity in Peraviz loader logging

### DIFF
--- a/peraviz/native/src/peraviz_loader.cpp
+++ b/peraviz/native/src/peraviz_loader.cpp
@@ -53,11 +53,11 @@ Array PeravizLoader::load_mvr(const String &path, bool peraviz_debug_baseline,
                                           peraviz_debug_baseline,
                                           peraviz_debug_coords);
 
-    UtilityFunctions::print("[PeravizNative] load_mvr nodes=", last_scene_model_.nodes.size(),
+    UtilityFunctions::print("[PeravizNative] load_mvr nodes=", static_cast<int64_t>(last_scene_model_.nodes.size()),
                             " baseline_debug=", peraviz_debug_baseline,
                             " coords_debug=", peraviz_debug_coords,
                             " fixtures=", last_scene_model_.fixture_count,
-                            " fixture_patches=", last_scene_model_.fixture_patches.size(),
+                            " fixture_patches=", static_cast<int64_t>(last_scene_model_.fixture_patches.size()),
                             " trusses=", last_scene_model_.truss_count,
                             " objects=", last_scene_model_.object_count,
                             " supports=", last_scene_model_.support_count,


### PR DESCRIPTION
### Motivation
- Avoid a compilation error on macOS/Clang caused by ambiguous `Variant` constructor resolution when passing `size_t` (`unsigned long`) values into `godot::UtilityFunctions::print` from `PeravizLoader::load_mvr` logging.

### Description
- Cast `last_scene_model_.nodes.size()` and `last_scene_model_.fixture_patches.size()` to `int64_t` in `peraviz/native/src/peraviz_loader.cpp` inside `PeravizLoader::load_mvr` so the `Variant` overload is unambiguous; functional behavior is unchanged.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69981856e2008324aad68e49997fd4e1)