### PR TITLE
docs: add Windows IntelliSense C++20 troubleshooting guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,33 @@ incompatible link settings. Do a clean rebuild:
 3. If you keep the build directory, use `cmake --build . --config Debug --clean-first`
    (or the corresponding configuration) to force a clean rebuild.
 
+If Visual Studio shows many **`Error (inactive)`** diagnostics such as:
+
+- `std has no member filesystem / optional / variant / string_view / get_if / bit_cast`
+- structured-binding parse errors near `for (const auto& [a, b] : ...)`
+- follow-up parser errors (`expected ';'`, `expected ']'`, unknown identifiers)
+
+the active IntelliSense profile is usually not using C++20 yet (or is attached to
+an outdated CMake cache). This project requires **C++20**.
+
+Recommended fix sequence:
+
+1. Remove the current build directory (for example `out/build/x64-Debug`).
+2. Re-configure with CMake from a Developer PowerShell:
+   ```powershell
+   cmake -S . -B out/build/x64-Debug -G "Visual Studio 17 2022" -A x64
+   ```
+3. Build explicitly with that configured tree:
+   ```powershell
+   cmake --build out/build/x64-Debug --config Debug
+   ```
+4. In Visual Studio, open the CMake project/folder tied to that build directory
+   and wait for IntelliSense to finish reindexing.
+
+If the diagnostics are still marked as **inactive**, prioritize the real compiler
+output from `cmake --build`; inactive diagnostics alone do not necessarily mean
+the code fails to compile.
+
 ---
 
 ## macOS build troubleshooting (Apple Silicon)


### PR DESCRIPTION
### Motivation
- Visual Studio often reports many `Error (inactive)` IntelliSense diagnostics when the editor is not using C++20 or is attached to an outdated CMake cache, which confuses users even when the real compiler can build the project.

### Description
- Expanded `README.md` Windows troubleshooting with a short diagnosis and a recommended recovery sequence (clean build directory, reconfigure with `cmake -S . -B <build> -G "Visual Studio 17 2022" -A x64`, build with `cmake --build <build> --config Debug`, and reindex IntelliSense), and guidance to trust the actual `cmake --build` output over inactive diagnostics.

### Testing
- Ran the project checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both succeeded (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69981989dab483248eec4ab3e26ae2ba)