### PR TITLE
cmake: enforce C++20 feature flags for better MSVC IntelliSense

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,12 @@ add_executable(${PROJECT_NAME} main.cpp
     mvr/mvrexporter.cpp
 )
 
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
+
+if(MSVC)
+    target_compile_options(${PROJECT_NAME} PRIVATE /Zc:__cplusplus)
+endif()
+
 add_subdirectory(core)
 add_subdirectory(gui)
 add_subdirectory(viewer2d)


### PR DESCRIPTION
### Motivation
- Visual Studio/IntelliSense reports many "inactive" errors for C++20 library features (e.g. `std::variant`, `std::filesystem`, `std::optional`) even though the project compiles, so the build settings need to make the language level explicit at the target level for correct IDE/tooling diagnostics.

### Description
- Updated `CMakeLists.txt` to add `target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)` and, for MSVC, `target_compile_options(${PROJECT_NAME} PRIVATE /Zc:__cplusplus)`, which improves `__cplusplus` reporting and reduces false-positive IntelliSense diagnostics without changing runtime behavior.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both tests completed successfully (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69981db65b108324b12495822dfc30b4)