### PR TITLE
Improve Visual Studio IntelliSense C++20 configuration

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -7,7 +7,7 @@
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "buildRoot": "${projectDir}\\out\\build\\${name}",
       "installRoot": "${projectDir}\\out\\install\\${name}",
-      "cmakeCommandArgs": "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows",
+      "cmakeCommandArgs": "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows -DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_STANDARD_REQUIRED=ON -DCMAKE_CXX_EXTENSIONS=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
       "buildCommandArgs": "",
       "ctestCommandArgs": "",
       "variables": [
@@ -23,7 +23,7 @@
       "configurationType": "RelWithDebInfo",
       "buildRoot": "${projectDir}\\out\\build\\${name}",
       "installRoot": "${projectDir}\\out\\install\\${name}",
-      "cmakeCommandArgs": "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows",
+      "cmakeCommandArgs": "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows -DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_STANDARD_REQUIRED=ON -DCMAKE_CXX_EXTENSIONS=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
       "buildCommandArgs": "",
       "ctestCommandArgs": "",
       "inheritEnvironments": [ "msvc_x64_x64" ],

--- a/CppProperties.json
+++ b/CppProperties.json
@@ -18,7 +18,8 @@
         "_UNICODE"
       ],
       "intelliSenseMode": "windows-msvc-x64",
-      "cppStandard": "c++20"
+      "cppStandard": "c++20",
+      "compileCommands": "${workspaceRoot}\\out\\build\\x64-Debug\\compile_commands.json"
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- IntelliSense was reporting cascading `Error (inactive)` diagnostics (missing `std::filesystem`, `std::optional`, structured-binding/`std::get_if`, etc.) because the editor/profile was not consistently using the project C++20 compile settings. This change makes the IDE consume explicit C++20 flags and exported compile commands so parsing matches the real CMake configuration.

### Description
- Added explicit C++20 flags and `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON` to the Visual Studio CMake settings in `CMakeSettings.json` for Debug and Release so CMake invocations from the IDE include `-DCMAKE_CXX_STANDARD=20`, `-DCMAKE_CXX_STANDARD_REQUIRED=ON` and `-DCMAKE_CXX_EXTENSIONS=OFF`.
- Added `"compileCommands": "${workspaceRoot}\\out\\build\\x64-Debug\\compile_commands.json"` to the `x64-Debug` IntelliSense profile in `CppProperties.json` so the editor can read the real `compile_commands.json` produced by CMake.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded (OK).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69981fabfb648324a9d5580086b39c35)