### PR TITLE
Stabilize cross-platform CMake IntelliSense settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,6 @@
 {
-  "cmake.configureSettings": {
-    "CMAKE_TOOLCHAIN_FILE": "/Users/arenasaudio/vcpkg/scripts/buildsystems/vcpkg.cmake",
-    "VCPKG_TARGET_TRIPLET": "arm64-osx",
-    "CMAKE_OSX_ARCHITECTURES": "arm64"
-  },
-  "cmake.generator": "Unix Makefiles"
+  "cmake.useCMakePresets": "always",
+  "cmake.configureOnOpen": true,
+  "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools",
+  "C_Cpp.default.cppStandard": "c++20"
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -62,7 +62,8 @@
         "VCPKG_TARGET_TRIPLET": "x64-windows",
         "CMAKE_CXX_STANDARD": "20",
         "CMAKE_CXX_STANDARD_REQUIRED": "ON",
-        "CMAKE_CXX_EXTENSIONS": "OFF"
+        "CMAKE_CXX_EXTENSIONS": "OFF",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       },
       "condition": {
         "type": "equals",
@@ -82,7 +83,8 @@
         "VCPKG_TARGET_TRIPLET": "x64-windows",
         "CMAKE_CXX_STANDARD": "20",
         "CMAKE_CXX_STANDARD_REQUIRED": "ON",
-        "CMAKE_CXX_EXTENSIONS": "OFF"
+        "CMAKE_CXX_EXTENSIONS": "OFF",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       },
       "condition": {
         "type": "equals",

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,13 +1,15 @@
-﻿{
+{
   "configurations": [
     {
       "name": "x64-Debug",
       "generator": "Visual Studio 17 2022",
       "configurationType": "Debug",
-      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "inheritEnvironments": [
+        "msvc_x64_x64"
+      ],
       "buildRoot": "${projectDir}\\out\\build\\${name}",
       "installRoot": "${projectDir}\\out\\install\\${name}",
-      "cmakeCommandArgs": "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows",
+      "cmakeCommandArgs": "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows -DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_STANDARD_REQUIRED=ON -DCMAKE_CXX_EXTENSIONS=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
       "buildCommandArgs": "",
       "ctestCommandArgs": "",
       "variables": [
@@ -23,10 +25,12 @@
       "configurationType": "RelWithDebInfo",
       "buildRoot": "${projectDir}\\out\\build\\${name}",
       "installRoot": "${projectDir}\\out\\install\\${name}",
-      "cmakeCommandArgs": "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows",
+      "cmakeCommandArgs": "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows -DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_STANDARD_REQUIRED=ON -DCMAKE_CXX_EXTENSIONS=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
       "buildCommandArgs": "",
       "ctestCommandArgs": "",
-      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "inheritEnvironments": [
+        "msvc_x64_x64"
+      ],
       "variables": [
         {
           "name": "BUILD_TESTING",


### PR DESCRIPTION
### Motivation
- Fix false/inactive IntelliSense diagnostics on macOS and Windows by aligning editor configuration with the real CMake build settings and ensuring C++20 and `compile_commands` are exported.

### Description
- Update editor/build presets and settings: switch `.vscode/settings.json` to use `cmake.useCMakePresets` and `ms-vscode.cmake-tools`, enable `CMAKE_EXPORT_COMPILE_COMMANDS=ON` for Windows configure presets in `CMakePresets.json`, and add explicit C++20 and `CMAKE_EXPORT_COMPILE_COMMANDS=ON` flags to the Windows entries in `CMakeSettings.json`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh` and validated JSON syntax with `python -m json.tool CMakePresets.json CMakeSettings.json .vscode/settings.json`, all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69981b36204c8324a357149b3de29a65)