### PR TITLE
Fix fixture color table update after editor apply

### DIFF
--- a/gui/fixtureeditdialog.cpp
+++ b/gui/fixtureeditdialog.cpp
@@ -235,8 +235,19 @@ void FixtureEditDialog::ApplyChanges() {
     } else if (i == 18) {
       auto *picker = wxDynamicCast(ctrls[i], wxColourPickerCtrl);
       if (picker) {
-        wxString col = picker->GetColour().GetAsString(wxC2S_HTML_SYNTAX);
-        table->SetValue(wxVariant(col), row, i);
+        wxColour selectedColor = picker->GetColour();
+        wxString colorText = selectedColor.GetAsString(wxC2S_HTML_SYNTAX);
+        wxBitmap colorSwatch(16, 16);
+        {
+          wxMemoryDC dc(colorSwatch);
+          dc.SetPen(*wxTRANSPARENT_PEN);
+          dc.SetBrush(wxBrush(selectedColor));
+          dc.DrawRectangle(0, 0, 16, 16);
+          dc.SelectObject(wxNullBitmap);
+        }
+        wxVariant colorValue;
+        colorValue << wxDataViewIconText(colorText, colorSwatch);
+        table->SetValue(colorValue, row, i);
       }
     } else {
       wxTextCtrl *tc = wxDynamicCast(ctrls[i], wxTextCtrl);

--- a/gui/fixturetable/fixture_table_columns.cpp
+++ b/gui/fixturetable/fixture_table_columns.cpp
@@ -62,6 +62,7 @@ void ConfigureColumns(wxDataViewListCtrl *table,
 
   auto *colorRenderer =
       new ColorfulIconTextRenderer(wxDATAVIEW_CELL_INERT, wxALIGN_LEFT);
+  colorRenderer->EnableEllipsize(wxELLIPSIZE_NONE);
   table->AppendColumn(new wxDataViewColumn(
       columnLabels.back(), colorRenderer, columnLabels.size() - 1,
       widths.back(), wxALIGN_LEFT, flags));


### PR DESCRIPTION
### Motivation
- Ensure that color changes made in the Fixture Editor are immediately visible in the Fixtures table and that full color codes are not elided when there is space available.

### Description
- Write the color column value as a `wxDataViewIconText` (text + 16x16 swatch bitmap) from `FixtureEditDialog::ApplyChanges()` so the table receives the same value type it uses when populating rows (file changed: `gui/fixtureeditdialog.cpp`).
- Disable ellipsizing on the color column renderer by calling `EnableEllipsize(wxELLIPSIZE_NONE)` on the `ColorfulIconTextRenderer` so color hex strings are not forced into a middle-ellipsis (file changed: `gui/fixturetable/fixture_table_columns.cpp`).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (OK).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69982d67f5d88324a16e629852d89c08)