### PR TITLE
Add hover tooltips for red warning cells in Data Views and Rigging panels

### DIFF
--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -61,6 +61,29 @@ public:
 
   MvrScene &GetScene() override { return GetDefaultGuiConfigServices().LegacyConfigManager().GetScene(); }
 };
+
+bool IsRedCell(const ColorfulDataViewListStore *store, int row, int col) {
+  if (!store || row < 0 || col < 0)
+    return false;
+
+  const size_t rowIndex = static_cast<size_t>(row);
+  const size_t colIndex = static_cast<size_t>(col);
+  if (rowIndex >= store->cellAttrs.size())
+    return false;
+  if (colIndex >= store->cellAttrs[rowIndex].size())
+    return false;
+
+  const wxDataViewItemAttr &attr = store->cellAttrs[rowIndex][colIndex];
+  return attr.HasColour() && attr.GetColour() == *wxRED;
+}
+
+wxString BuildFixtureTooltipForColumn(int modelColumn) {
+  if (modelColumn == 0)
+    return "Duplicate Fixture ID. Each fixture must have a unique ID.";
+  if (modelColumn == 5 || modelColumn == 6)
+    return "DMX patch conflict detected. Universe and channel overlap with another fixture.";
+  return wxString();
+}
 } // namespace
 
 FixtureTablePanel::FixtureTablePanel(wxWindow *parent, IGuiConfigServices *services)
@@ -80,6 +103,7 @@ FixtureTablePanel::FixtureTablePanel(wxWindow *parent, IGuiConfigServices *servi
   table->Bind(wxEVT_LEFT_DOWN, &FixtureTablePanel::OnLeftDown, this);
   table->Bind(wxEVT_LEFT_UP, &FixtureTablePanel::OnLeftUp, this);
   table->Bind(wxEVT_MOTION, &FixtureTablePanel::OnMouseMove, this);
+  table->Bind(wxEVT_LEAVE_WINDOW, &FixtureTablePanel::OnMouseLeave, this);
   table->Bind(wxEVT_DATAVIEW_SELECTION_CHANGED,
               &FixtureTablePanel::OnSelectionChanged, this);
 
@@ -958,6 +982,8 @@ void FixtureTablePanel::OnCaptureLost(wxMouseCaptureLostEvent &WXUNUSED(evt)) {
 }
 
 void FixtureTablePanel::OnMouseMove(wxMouseEvent &evt) {
+  UpdateHoverTooltip(evt.GetPosition());
+
   if (!dragSelecting || !evt.Dragging()) {
     evt.Skip();
     return;
@@ -975,6 +1001,34 @@ void FixtureTablePanel::OnMouseMove(wxMouseEvent &evt) {
       table->SelectRow(r);
   }
   evt.Skip();
+}
+
+void FixtureTablePanel::OnMouseLeave(wxMouseEvent &evt) {
+  if (!activeHoverTooltip.IsEmpty()) {
+    table->SetToolTip(wxString());
+    activeHoverTooltip.clear();
+  }
+  evt.Skip();
+}
+
+void FixtureTablePanel::UpdateHoverTooltip(const wxPoint &position) {
+  wxDataViewItem item;
+  wxDataViewColumn *column = nullptr;
+  table->HitTest(position, item, column);
+
+  wxString tooltip;
+  if (item.IsOk() && column) {
+    int row = table->ItemToRow(item);
+    int modelColumn = column->GetModelColumn();
+    if (IsRedCell(store, row, modelColumn))
+      tooltip = BuildFixtureTooltipForColumn(modelColumn);
+  }
+
+  if (tooltip == activeHoverTooltip)
+    return;
+
+  table->SetToolTip(tooltip);
+  activeHoverTooltip = tooltip;
 }
 
 void FixtureTablePanel::OnSelectionChanged(wxDataViewEvent &evt) {

--- a/gui/fixturetablepanel.h
+++ b/gui/fixturetablepanel.h
@@ -73,11 +73,15 @@ private:
     void OnLeftDown(wxMouseEvent& evt);
     void OnLeftUp(wxMouseEvent& evt);
     void OnMouseMove(wxMouseEvent& evt);
+    void OnMouseLeave(wxMouseEvent& evt);
     void OnCaptureLost(wxMouseCaptureLostEvent& evt);
     void OnSelectionChanged(wxDataViewEvent& evt);
+    void UpdateHoverTooltip(const wxPoint& position);
     void UpdateSelectionHighlight();
     void PropagateTypeValues(const wxDataViewItemArray& selections, int col);
     void ApplyModeForGdtf(const wxString& path, const wxString& preferredMode = wxString());
     void HighlightDuplicateFixtureIds();
     void HighlightPatchConflicts();
+
+    wxString activeHoverTooltip;
 };

--- a/gui/riggingpanel.cpp
+++ b/gui/riggingpanel.cpp
@@ -32,6 +32,37 @@ constexpr const char *UNASSIGNED_POSITION = "Unassigned";
 float CeilToNearestTens(float value) {
   return std::ceil(value / 10.0f) * 10.0f;
 }
+
+bool IsRedCell(const ColorfulDataViewListStore *store, int row, int col) {
+  if (!store || row < 0 || col < 0)
+    return false;
+
+  const size_t rowIndex = static_cast<size_t>(row);
+  const size_t colIndex = static_cast<size_t>(col);
+  if (rowIndex >= store->cellAttrs.size())
+    return false;
+  if (colIndex >= store->cellAttrs[rowIndex].size())
+    return false;
+
+  const wxDataViewItemAttr &attr = store->cellAttrs[rowIndex][colIndex];
+  return attr.HasColour() && attr.GetColour() == *wxRED;
+}
+
+wxString BuildRiggingTooltipForColumn(int modelColumn) {
+  switch (modelColumn) {
+  case 4:
+    return "Fixture weight includes zero or missing values in this position.";
+  case 5:
+    return "Truss weight includes zero or missing values in this position.";
+  case 6:
+    return "Hoist weight includes zero or missing values in this position.";
+  case 7:
+  case 8:
+    return "Total weight includes items with zero or missing weight.";
+  default:
+    return wxString();
+  }
+}
 }
 
 static RiggingPanel *s_instance = nullptr;
@@ -42,6 +73,8 @@ RiggingPanel::RiggingPanel(wxWindow *parent) : wxPanel(parent, wxID_ANY) {
                                  wxDV_ROW_LINES | wxDV_VERT_RULES);
   table->AssociateModel(store);
   store->DecRef();
+  table->Bind(wxEVT_MOTION, &RiggingPanel::OnMouseMove, this);
+  table->Bind(wxEVT_LEAVE_WINDOW, &RiggingPanel::OnMouseLeave, this);
   table->AppendTextColumn("Position", wxDATAVIEW_CELL_INERT, wxCOL_WIDTH_AUTOSIZE,
                           wxALIGN_LEFT, wxDATAVIEW_COL_RESIZABLE);
   table->AppendTextColumn("Fixtures", wxDATAVIEW_CELL_INERT, wxCOL_WIDTH_AUTOSIZE,
@@ -182,4 +215,38 @@ void RiggingPanel::RefreshData() {
   // refresh is triggered (e.g. after loading/importing data or editing
   // weights in the tables).
   table->Refresh();
+}
+
+
+void RiggingPanel::OnMouseMove(wxMouseEvent &event) {
+  UpdateHoverTooltip(event.GetPosition());
+  event.Skip();
+}
+
+void RiggingPanel::OnMouseLeave(wxMouseEvent &event) {
+  if (!activeHoverTooltip.IsEmpty()) {
+    table->SetToolTip(wxString());
+    activeHoverTooltip.clear();
+  }
+  event.Skip();
+}
+
+void RiggingPanel::UpdateHoverTooltip(const wxPoint &position) {
+  wxDataViewItem item;
+  wxDataViewColumn *column = nullptr;
+  table->HitTest(position, item, column);
+
+  wxString tooltip;
+  if (item.IsOk() && column) {
+    int row = table->ItemToRow(item);
+    int modelColumn = column->GetModelColumn();
+    if (IsRedCell(store, row, modelColumn))
+      tooltip = BuildRiggingTooltipForColumn(modelColumn);
+  }
+
+  if (tooltip == activeHoverTooltip)
+    return;
+
+  table->SetToolTip(tooltip);
+  activeHoverTooltip = tooltip;
 }

--- a/gui/riggingpanel.h
+++ b/gui/riggingpanel.h
@@ -33,6 +33,11 @@ public:
   static void SetInstance(RiggingPanel *panel);
 
 private:
+  void OnMouseMove(wxMouseEvent &event);
+  void OnMouseLeave(wxMouseEvent &event);
+  void UpdateHoverTooltip(const wxPoint &position);
+
   wxDataViewListCtrl *table = nullptr;
   ColorfulDataViewListStore *store = nullptr;
+  wxString activeHoverTooltip;
 };


### PR DESCRIPTION
### Motivation
- Improve user clarity by showing contextual tooltips when hovering over cells that are highlighted in red (duplicate IDs, DMX patch conflicts, zero/missing weights).
- Keep the change localized to GUI panels and reuse existing per-cell colour state from `ColorfulDataViewListStore` to avoid duplicating logic.

### Description
- Add tooltip support to the Fixtures Data Views by updating `gui/fixturetablepanel.h/.cpp` with `IsRedCell`, `BuildFixtureTooltipForColumn`, `UpdateHoverTooltip`, `OnMouseLeave` and binding `wxEVT_MOTION`/`wxEVT_LEAVE_WINDOW` so the tooltip appears for red cells in Fixture ID (model column 0) and DMX patch columns (model columns 5 and 6).
- Add tooltip support to the Rigging panel by updating `gui/riggingpanel.h/.cpp` with `IsRedCell`, `BuildRiggingTooltipForColumn`, `UpdateHoverTooltip`, `OnMouseLeave` and binding `wxEVT_MOTION`/`wxEVT_LEAVE_WINDOW` so the tooltip appears for red weight and total columns (model columns 4–8).
- Implement lightweight helpers that read the existing `cellAttrs` in `ColorfulDataViewListStore` to detect red cells and return concise explanatory messages per column, and store the last active tooltip (`activeHoverTooltip`) to avoid redundant updates.
- Keep UI behaviour unchanged except for the on-hover explanatory tooltips which are cleared when the cursor leaves the control.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it completed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69982f03a1588324a25f03a0b280597d)