### PR TITLE
Fix hover tooltips for red cells in data and rigging tables

### DIFF
--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -102,6 +102,28 @@ wxPoint NormalizeMousePositionForTable(wxDataViewListCtrl *table,
   return table->ScreenToClient(sourceWindow->ClientToScreen(position));
 }
 
+template <typename Owner>
+void BindTableHoverEvents(wxDataViewListCtrl *table, Owner *owner,
+                          void (Owner::*onMouseMove)(wxMouseEvent &),
+                          void (Owner::*onMouseLeave)(wxMouseEvent &)) {
+  if (!table || !owner)
+    return;
+
+  auto bindEvents = [&](wxWindow *window) {
+    if (!window)
+      return;
+    window->Bind(wxEVT_MOTION, onMouseMove, owner);
+    window->Bind(wxEVT_LEAVE_WINDOW, onMouseLeave, owner);
+  };
+
+  bindEvents(table);
+  wxWindowList &children = table->GetChildren();
+  for (wxWindowList::compatibility_iterator it = children.GetFirst(); it;
+       it = it->GetNext()) {
+    bindEvents(it->GetData());
+  }
+}
+
 wxString BuildFixtureTooltipForColumn(int modelColumn) {
   if (modelColumn == 0)
     return "Duplicate Fixture ID. Each fixture must have a unique ID.";
@@ -127,8 +149,12 @@ FixtureTablePanel::FixtureTablePanel(wxWindow *parent, IGuiConfigServices *servi
   store->SetSelectionColours(selectionBackground, selectionForeground);
   table->Bind(wxEVT_LEFT_DOWN, &FixtureTablePanel::OnLeftDown, this);
   table->Bind(wxEVT_LEFT_UP, &FixtureTablePanel::OnLeftUp, this);
-  table->Bind(wxEVT_MOTION, &FixtureTablePanel::OnMouseMove, this);
-  table->Bind(wxEVT_LEAVE_WINDOW, &FixtureTablePanel::OnMouseLeave, this);
+  BindTableHoverEvents(table, this, &FixtureTablePanel::OnMouseMove,
+                       &FixtureTablePanel::OnMouseLeave);
+  table->CallAfter([this]() {
+    BindTableHoverEvents(table, this, &FixtureTablePanel::OnMouseMove,
+                         &FixtureTablePanel::OnMouseLeave);
+  });
   table->Bind(wxEVT_DATAVIEW_SELECTION_CHANGED,
               &FixtureTablePanel::OnSelectionChanged, this);
 

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -91,6 +91,17 @@ void SetTableAndChildTooltips(wxDataViewListCtrl *table,
   }
 }
 
+wxPoint NormalizeMousePositionForTable(wxDataViewListCtrl *table,
+                                       const wxMouseEvent &event) {
+  wxPoint position = event.GetPosition();
+  wxWindow *sourceWindow =
+      dynamic_cast<wxWindow *>(event.GetEventObject());
+  if (!table || !sourceWindow || sourceWindow == table)
+    return position;
+
+  return table->ScreenToClient(sourceWindow->ClientToScreen(position));
+}
+
 wxString BuildFixtureTooltipForColumn(int modelColumn) {
   if (modelColumn == 0)
     return "Duplicate Fixture ID. Each fixture must have a unique ID.";
@@ -996,7 +1007,7 @@ void FixtureTablePanel::OnCaptureLost(wxMouseCaptureLostEvent &WXUNUSED(evt)) {
 }
 
 void FixtureTablePanel::OnMouseMove(wxMouseEvent &evt) {
-  UpdateHoverTooltip(evt.GetPosition());
+  UpdateHoverTooltip(NormalizeMousePositionForTable(table, evt));
 
   if (!dragSelecting || !evt.Dragging()) {
     evt.Skip();

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -77,6 +77,20 @@ bool IsRedCell(const ColorfulDataViewListStore *store, int row, int col) {
   return attr.HasColour() && attr.GetColour() == *wxRED;
 }
 
+void SetTableAndChildTooltips(wxDataViewListCtrl *table,
+                              const wxString &tooltip) {
+  if (!table)
+    return;
+
+  table->SetToolTip(tooltip);
+  wxWindowList &children = table->GetChildren();
+  for (wxWindowList::compatibility_iterator it = children.GetFirst(); it;
+       it = it->GetNext()) {
+    if (wxWindow *child = it->GetData())
+      child->SetToolTip(tooltip);
+  }
+}
+
 wxString BuildFixtureTooltipForColumn(int modelColumn) {
   if (modelColumn == 0)
     return "Duplicate Fixture ID. Each fixture must have a unique ID.";
@@ -1005,7 +1019,7 @@ void FixtureTablePanel::OnMouseMove(wxMouseEvent &evt) {
 
 void FixtureTablePanel::OnMouseLeave(wxMouseEvent &evt) {
   if (!activeHoverTooltip.IsEmpty()) {
-    table->SetToolTip(wxString());
+    SetTableAndChildTooltips(table, wxString());
     activeHoverTooltip.clear();
   }
   evt.Skip();
@@ -1027,7 +1041,7 @@ void FixtureTablePanel::UpdateHoverTooltip(const wxPoint &position) {
   if (tooltip == activeHoverTooltip)
     return;
 
-  table->SetToolTip(tooltip);
+  SetTableAndChildTooltips(table, tooltip);
   activeHoverTooltip = tooltip;
 }
 

--- a/gui/riggingpanel.cpp
+++ b/gui/riggingpanel.cpp
@@ -77,6 +77,17 @@ void SetTableAndChildTooltips(wxDataViewListCtrl *table,
       child->SetToolTip(tooltip);
   }
 }
+
+wxPoint NormalizeMousePositionForTable(wxDataViewListCtrl *table,
+                                       const wxMouseEvent &event) {
+  wxPoint position = event.GetPosition();
+  wxWindow *sourceWindow =
+      dynamic_cast<wxWindow *>(event.GetEventObject());
+  if (!table || !sourceWindow || sourceWindow == table)
+    return position;
+
+  return table->ScreenToClient(sourceWindow->ClientToScreen(position));
+}
 }
 
 static RiggingPanel *s_instance = nullptr;
@@ -233,7 +244,7 @@ void RiggingPanel::RefreshData() {
 
 
 void RiggingPanel::OnMouseMove(wxMouseEvent &event) {
-  UpdateHoverTooltip(event.GetPosition());
+  UpdateHoverTooltip(NormalizeMousePositionForTable(table, event));
   event.Skip();
 }
 

--- a/gui/riggingpanel.cpp
+++ b/gui/riggingpanel.cpp
@@ -63,6 +63,20 @@ wxString BuildRiggingTooltipForColumn(int modelColumn) {
     return wxString();
   }
 }
+
+void SetTableAndChildTooltips(wxDataViewListCtrl *table,
+                              const wxString &tooltip) {
+  if (!table)
+    return;
+
+  table->SetToolTip(tooltip);
+  wxWindowList &children = table->GetChildren();
+  for (wxWindowList::compatibility_iterator it = children.GetFirst(); it;
+       it = it->GetNext()) {
+    if (wxWindow *child = it->GetData())
+      child->SetToolTip(tooltip);
+  }
+}
 }
 
 static RiggingPanel *s_instance = nullptr;
@@ -225,7 +239,7 @@ void RiggingPanel::OnMouseMove(wxMouseEvent &event) {
 
 void RiggingPanel::OnMouseLeave(wxMouseEvent &event) {
   if (!activeHoverTooltip.IsEmpty()) {
-    table->SetToolTip(wxString());
+    SetTableAndChildTooltips(table, wxString());
     activeHoverTooltip.clear();
   }
   event.Skip();
@@ -247,6 +261,6 @@ void RiggingPanel::UpdateHoverTooltip(const wxPoint &position) {
   if (tooltip == activeHoverTooltip)
     return;
 
-  table->SetToolTip(tooltip);
+  SetTableAndChildTooltips(table, tooltip);
   activeHoverTooltip = tooltip;
 }

--- a/gui/riggingpanel.cpp
+++ b/gui/riggingpanel.cpp
@@ -88,6 +88,28 @@ wxPoint NormalizeMousePositionForTable(wxDataViewListCtrl *table,
 
   return table->ScreenToClient(sourceWindow->ClientToScreen(position));
 }
+
+template <typename Owner>
+void BindTableHoverEvents(wxDataViewListCtrl *table, Owner *owner,
+                          void (Owner::*onMouseMove)(wxMouseEvent &),
+                          void (Owner::*onMouseLeave)(wxMouseEvent &)) {
+  if (!table || !owner)
+    return;
+
+  auto bindEvents = [&](wxWindow *window) {
+    if (!window)
+      return;
+    window->Bind(wxEVT_MOTION, onMouseMove, owner);
+    window->Bind(wxEVT_LEAVE_WINDOW, onMouseLeave, owner);
+  };
+
+  bindEvents(table);
+  wxWindowList &children = table->GetChildren();
+  for (wxWindowList::compatibility_iterator it = children.GetFirst(); it;
+       it = it->GetNext()) {
+    bindEvents(it->GetData());
+  }
+}
 }
 
 static RiggingPanel *s_instance = nullptr;
@@ -98,8 +120,12 @@ RiggingPanel::RiggingPanel(wxWindow *parent) : wxPanel(parent, wxID_ANY) {
                                  wxDV_ROW_LINES | wxDV_VERT_RULES);
   table->AssociateModel(store);
   store->DecRef();
-  table->Bind(wxEVT_MOTION, &RiggingPanel::OnMouseMove, this);
-  table->Bind(wxEVT_LEAVE_WINDOW, &RiggingPanel::OnMouseLeave, this);
+  BindTableHoverEvents(table, this, &RiggingPanel::OnMouseMove,
+                       &RiggingPanel::OnMouseLeave);
+  table->CallAfter([this]() {
+    BindTableHoverEvents(table, this, &RiggingPanel::OnMouseMove,
+                         &RiggingPanel::OnMouseLeave);
+  });
   table->AppendTextColumn("Position", wxDATAVIEW_CELL_INERT, wxCOL_WIDTH_AUTOSIZE,
                           wxALIGN_LEFT, wxDATAVIEW_COL_RESIZABLE);
   table->AppendTextColumn("Fixtures", wxDATAVIEW_CELL_INERT, wxCOL_WIDTH_AUTOSIZE,


### PR DESCRIPTION
### Motivation
- Hover tooltips for cells marked in red were not reliably visible because the tooltip was only set on the `wxDataViewListCtrl` and not propagated to its internal child windows.  
- The change ensures the red-cell warning messages are shown consistently when the user moves the mouse over affected cells.

### Description
- Added a small helper `SetTableAndChildTooltips(wxDataViewListCtrl*, const wxString&)` to `gui/fixturetablepanel.cpp` and `gui/riggingpanel.cpp` that sets the tooltip on the `wxDataViewListCtrl` and iterates its `wxWindowList` children to set the same tooltip on each child.  
- Replaced direct `table->SetToolTip(...)` calls in `OnMouseLeave` and `UpdateHoverTooltip` with `SetTableAndChildTooltips(...)` in both panels, preserving existing `IsRedCell(...)` detection and tooltip text.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.  
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69983178044883249502189858f54e31)