### PR TITLE
Preserve fixture IDs on MVR project roundtrip

### DIFF
--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -217,14 +217,7 @@ static bool ValidateMvr16Export(
   }
 
   std::unordered_set<int> numericIds;
-  std::unordered_set<int> fixtureNumericIds;
   std::vector<std::string> referencedFiles;
-
-  auto isDigitsOnly = [](const std::string &value) {
-    return !value.empty() && std::all_of(value.begin(), value.end(), [](unsigned char c) {
-      return std::isdigit(c) != 0;
-    });
-  };
 
   std::vector<tinyxml2::XMLElement *> stack;
   for (tinyxml2::XMLElement *node = root->FirstChildElement(); node;
@@ -250,18 +243,11 @@ static bool ValidateMvr16Export(
             numNode && numNode->GetText() ? TrimAscii(numNode->GetText()) : "";
         int fixtureNumeric = 0;
 
-        if (!isDigitsOnly(fixtureId) || !TryParseInt(fixtureNumericText, fixtureNumeric) ||
-            fixtureNumeric <= 0 || fixtureId != std::to_string(fixtureNumeric)) {
+        if (fixtureId.empty() || !TryParseInt(fixtureNumericText, fixtureNumeric) ||
+            fixtureNumeric <= 0) {
           wxLogError(
-              "MVR export validation failed: Fixture '%s' (uuid=%s) must have a digits-only FixtureID that equals FixtureIDNumeric",
+              "MVR export validation failed: Fixture '%s' (uuid=%s) must have a non-empty FixtureID and a positive integer FixtureIDNumeric",
               fixtureName, fixtureUuid);
-          return false;
-        }
-
-        if (!fixtureNumericIds.insert(fixtureNumeric).second) {
-          wxLogError(
-              "MVR export validation failed: duplicate FixtureIDNumeric %d found on Fixture '%s' (uuid=%s)",
-              fixtureNumeric, fixtureName, fixtureUuid);
           return false;
         }
 
@@ -341,7 +327,7 @@ static bool ValidateMvr16Export(
       stack.push_back(child);
   }
 
-  for (const char *tagName : {"Fixture", "Truss", "Support", "VideoScreen", "Projector"}) {
+  for (const char *tagName : {"Truss", "Support", "VideoScreen", "Projector"}) {
     for (tinyxml2::XMLElement *node = root->FirstChildElement(); node;
          node = node->NextSiblingElement()) {
       std::vector<tinyxml2::XMLElement *> stack;
@@ -743,7 +729,6 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
   auto assignIds = [&]() {
     int nextNumericId = 1;
     std::unordered_set<int> usedIds;
-    std::unordered_map<int, int> numericCounts;
 
     auto reserveId = [&](int candidate) {
       if (candidate > 0)
@@ -752,8 +737,6 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
     for (const auto &[uid, f] : scene.fixtures) {
       int existing = f.fixtureIdNumeric > 0 ? f.fixtureIdNumeric : f.fixtureId;
       reserveId(existing);
-      if (existing > 0)
-        ++numericCounts[existing];
     }
 
     auto allocId = [&]() {
@@ -766,10 +749,10 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
     std::unordered_map<std::string, std::pair<std::string, int>> result;
     for (const auto &[uid, f] : scene.fixtures) {
       int numeric = f.fixtureIdNumeric > 0 ? f.fixtureIdNumeric : f.fixtureId;
-      if (numeric <= 0 || numericCounts[numeric] > 1) {
+      if (numeric <= 0) {
         numeric = allocId();
       }
-      std::string stringId = f.instanceName.empty() ? std::to_string(numeric) : TrimAscii(f.instanceName);
+      std::string stringId = TrimAscii(f.fixtureIdText);
       if (stringId.empty())
         stringId = std::to_string(numeric);
       result[uid] = {stringId, numeric};
@@ -935,10 +918,14 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
     };
 
     auto idIt = assignedIds.find(f.uuid);
-    int fixtureNumericId = (idIt != assignedIds.end()) ? idIt->second.second : 0;
+    int fixtureNumericId = f.fixtureIdNumeric > 0 ? f.fixtureIdNumeric : f.fixtureId;
+    if (fixtureNumericId <= 0 && idIt != assignedIds.end())
+      fixtureNumericId = idIt->second.second;
     if (fixtureNumericId <= 0)
       fixtureNumericId = 1;
-    std::string fixtureId = std::to_string(fixtureNumericId);
+    std::string fixtureId = TrimAscii(f.fixtureIdText);
+    if (fixtureId.empty())
+      fixtureId = std::to_string(fixtureNumericId);
     addStr("FixtureID", fixtureId);
     addInt("FixtureIDNumeric", fixtureNumericId);
     if (f.unitNumber != 0 && f.unitNumber != fixtureNumericId)

--- a/tests/save_load_roundtrip_test.cpp
+++ b/tests/save_load_roundtrip_test.cpp
@@ -50,6 +50,7 @@ int main() {
     GdtfDictionary::Update("FixtureType", (tempDir / "dict.gdtf").string(), "");
 
     Fixture f; f.uuid = "fx1"; f.instanceName = "Fixture"; f.layer = layer.name; f.typeName = "FixtureType"; f.gdtfSpec = "orig.gdtf"; f.color = "#445566"; f.fixtureIdText = "S101A"; f.fixtureIdNumeric = 101; f.fixtureId = 101; scene.fixtures[f.uuid] = f;
+    Fixture f2; f2.uuid = "fx2"; f2.instanceName = "Fixture 2"; f2.layer = layer.name; f2.typeName = "FixtureType"; f2.gdtfSpec = "orig.gdtf"; f2.fixtureIdText = "S101B"; f2.fixtureIdNumeric = 101; f2.fixtureId = 101; scene.fixtures[f2.uuid] = f2;
     Truss t; t.uuid = "tr1"; t.name = "Truss"; t.layer = layer.name; scene.trusses[t.uuid] = t;
     SceneObject o; o.uuid = "obj1"; o.name = "Object"; o.layer = layer.name; scene.sceneObjects[o.uuid] = o;
 
@@ -61,7 +62,7 @@ int main() {
     assert(cfg.LoadProject(temp.string()));
 
     const auto &scene2 = cfg.GetScene();
-    assert(scene2.fixtures.size() == 1);
+    assert(scene2.fixtures.size() == 2);
     assert(scene2.trusses.size() == 1);
     assert(scene2.sceneObjects.size() == 1);
     assert(scene2.fixtures.at("fx1").instanceName == "Fixture");
@@ -70,6 +71,8 @@ int main() {
     assert(scene2.fixtures.at("fx1").color == "#445566");
     assert(scene2.fixtures.at("fx1").fixtureIdText == "S101A");
     assert(scene2.fixtures.at("fx1").fixtureIdNumeric == 101);
+    assert(scene2.fixtures.at("fx2").fixtureIdText == "S101B");
+    assert(scene2.fixtures.at("fx2").fixtureIdNumeric == 101);
     assert(scene2.layers.at("layer1").color == "#112233");
 
     const auto &loaded = scene2.fixtures.at("fx1");


### PR DESCRIPTION
### Motivation
- Prevent the importer/exporter from silently renumbering fixtures so user-assigned fixture identifiers are preserved across save/load cycles.
- Avoid treating fixture ID collisions or non-numeric `FixtureID` strings as an export-time correction opportunity that mutates the project.
- Keep MVR export validation strict where it matters while allowing non-numeric textual IDs to survive roundtrip.

### Description
- Relaxed MVR export validation in `mvr/mvrexporter.cpp` so a fixture must have a non-empty `FixtureID` and a positive integer `FixtureIDNumeric` but `FixtureID` is no longer required to be digits-only and equal to `FixtureIDNumeric`.
- Changed MVR export ID assignment in `mvr/mvrexporter.cpp` to prefer preserving `fixtureIdText` and `fixtureIdNumeric` from the scene and only generate numeric fallbacks when values are missing or invalid, instead of renumbering conflicted IDs.
- Removed duplicate-enforcement logic that previously forced global uniqueness during export for fixtures in order to keep conflict state visible to the user rather than hiding it via automatic renumbering.
- Added regression coverage in `tests/save_load_roundtrip_test.cpp` to assert that two fixtures sharing the same numeric ID but different text IDs are preserved after `SaveProject`/`LoadProject` roundtrip.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded.
- Attempted `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug` which failed in this environment due to missing `wxWidgets` development packages (environment limitation, not a code regression).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998353ea05c832480faae80445f1e2c)