### PR TITLE
Implement GDTF gobo parsing and projection support in Peraviz

### DIFF
--- a/peraviz/README_gobos.md
+++ b/peraviz/README_gobos.md
@@ -18,13 +18,14 @@ This document summarizes how Peraviz reads and applies gobos from GDTF fixtures.
 
 - Gobo binding focuses on selector channels (`Gobo1`, `Gobo1Pos`, etc.).
 - Non-selector channels are ignored for projection (`Spin`, `Shake`, `Time`, `Speed`, `Rotate`, etc.).
-- If multiple gobo wheels exist, wheel `1` is preferred for the runtime projector binding.
+- Per-fixture bindings now include all discovered gobo selector wheels (`gobo_wheels`) and keep wheel `1` mirrored as compatibility keys (`gobo1_*` / `gobo_*`).
 
 ## Runtime projection in Godot
 
 - Gobo textures are assigned to `SpotLight3D.light_projector`.
 - `SpotLight3D.shadow_enabled` must be `true`; otherwise projector textures are not visible.
 - For fixtures with malformed/missing media, a temporary fake gobo texture can be generated for DMX/debug validation.
+- When multiple gobo wheels are active, Peraviz composes them into a single projector texture by multiplying wheel masks (gobo composition).
 
 ## Notes
 

--- a/peraviz/README_gobos.md
+++ b/peraviz/README_gobos.md
@@ -1,0 +1,32 @@
+# Peraviz gobo support
+
+This document summarizes how Peraviz reads and applies gobos from GDTF fixtures.
+
+## Parsing flow
+
+- Peraviz reads `description.xml` from each `.gdtf` archive.
+- Wheel images are discovered from `FixtureType/Wheels/Wheel/Slot` (and exporter variant `WheelSlot`).
+- `Slot/@MediaFileName` is resolved as a resource stem and loaded from the archive, preferring:
+  - `wheels/<MediaFileName>.png`
+  - plus compatible fallback paths (`wheels/images/...` and stem-based archive lookup).
+- DMX-to-slot mapping is parsed from `ChannelFunction/ChannelSet` using:
+  - `ChannelSet/@DMXFrom`
+  - `ChannelSet/@DMXTo` (optional, inferred from next range when missing)
+  - `ChannelSet/@WheelSlotIndex`
+
+## DMX binding rules
+
+- Gobo binding focuses on selector channels (`Gobo1`, `Gobo1Pos`, etc.).
+- Non-selector channels are ignored for projection (`Spin`, `Shake`, `Time`, `Speed`, `Rotate`, etc.).
+- If multiple gobo wheels exist, wheel `1` is preferred for the runtime projector binding.
+
+## Runtime projection in Godot
+
+- Gobo textures are assigned to `SpotLight3D.light_projector`.
+- `SpotLight3D.shadow_enabled` must be `true`; otherwise projector textures are not visible.
+- For fixtures with malformed/missing media, a temporary fake gobo texture can be generated for DMX/debug validation.
+
+## Notes
+
+- Compatibility renderer (`gl_compatibility`) does not support projector behavior reliably.
+- Forward+ / Mobile renderers are required for predictable gobo projection.

--- a/peraviz/native/src/dmx/fixture_dmx_binding.cpp
+++ b/peraviz/native/src/dmx/fixture_dmx_binding.cpp
@@ -96,6 +96,14 @@ FixtureBindingBuildResult build_dimmer_bindings(
             to_channel_index_0(patch, offsets.yellow_fine_offset_1_based);
         binding.yellow.ultra_fine_dmx_channel_index_0 =
             to_channel_index_0(patch, offsets.yellow_ultra_fine_offset_1_based);
+        binding.gobo.coarse_dmx_channel_index_0 =
+            to_channel_index_0(patch, offsets.gobo_coarse_offset_1_based);
+        binding.gobo.fine_dmx_channel_index_0 =
+            to_channel_index_0(patch, offsets.gobo_fine_offset_1_based);
+        binding.gobo.ultra_fine_dmx_channel_index_0 =
+            to_channel_index_0(patch, offsets.gobo_ultra_fine_offset_1_based);
+        binding.gobo_slots = offsets.gobo_slots;
+        binding.gobo_ranges = offsets.gobo_ranges;
         binding.has_zoom_physical_limits = offsets.has_zoom_physical_limits;
         binding.zoom_physical_min_degrees = offsets.zoom_physical_min_degrees;
         binding.zoom_physical_max_degrees = offsets.zoom_physical_max_degrees;
@@ -107,7 +115,8 @@ FixtureBindingBuildResult build_dimmer_bindings(
         const bool has_cyan = is_valid_channel_index(binding.cyan.coarse_dmx_channel_index_0);
         const bool has_magenta = is_valid_channel_index(binding.magenta.coarse_dmx_channel_index_0);
         const bool has_yellow = is_valid_channel_index(binding.yellow.coarse_dmx_channel_index_0);
-        if (!has_dimmer && !has_pan && !has_tilt && !has_zoom && !has_cyan && !has_magenta && !has_yellow) {
+        const bool has_gobo = is_valid_channel_index(binding.gobo.coarse_dmx_channel_index_0);
+        if (!has_dimmer && !has_pan && !has_tilt && !has_zoom && !has_cyan && !has_magenta && !has_yellow && !has_gobo) {
             result.unbound.push_back({patch.fixture_uuid,
                                       "resolved DMX channels are out of 0..511 range"});
             continue;
@@ -168,6 +177,14 @@ FixtureBindingBuildResult build_dimmer_bindings(
         if (binding.yellow.ultra_fine_dmx_channel_index_0 >= 0 &&
             !is_valid_channel_index(binding.yellow.ultra_fine_dmx_channel_index_0)) {
             binding.yellow.ultra_fine_dmx_channel_index_0 = -1;
+        }
+        if (binding.gobo.fine_dmx_channel_index_0 >= 0 &&
+            !is_valid_channel_index(binding.gobo.fine_dmx_channel_index_0)) {
+            binding.gobo.fine_dmx_channel_index_0 = -1;
+        }
+        if (binding.gobo.ultra_fine_dmx_channel_index_0 >= 0 &&
+            !is_valid_channel_index(binding.gobo.ultra_fine_dmx_channel_index_0)) {
+            binding.gobo.ultra_fine_dmx_channel_index_0 = -1;
         }
 
         result.bindings.push_back(binding);

--- a/peraviz/native/src/dmx/fixture_dmx_binding.cpp
+++ b/peraviz/native/src/dmx/fixture_dmx_binding.cpp
@@ -102,6 +102,8 @@ FixtureBindingBuildResult build_dimmer_bindings(
             to_channel_index_0(patch, offsets.gobo_fine_offset_1_based);
         binding.gobo.ultra_fine_dmx_channel_index_0 =
             to_channel_index_0(patch, offsets.gobo_ultra_fine_offset_1_based);
+        binding.gobo_wheel_number = offsets.gobo_wheel_number;
+        binding.gobo_wheel_name = offsets.gobo_wheel_name;
         binding.gobo_slots = offsets.gobo_slots;
         binding.gobo_ranges = offsets.gobo_ranges;
         binding.has_zoom_physical_limits = offsets.has_zoom_physical_limits;

--- a/peraviz/native/src/dmx/fixture_dmx_binding.cpp
+++ b/peraviz/native/src/dmx/fixture_dmx_binding.cpp
@@ -1,5 +1,7 @@
 #include "dmx/fixture_dmx_binding.h"
 
+#include <utility>
+
 namespace peraviz::dmx {
 
 namespace {
@@ -13,6 +15,28 @@ int to_channel_index_0(const FixturePatch &patch, int offset_1_based) {
 
 bool is_valid_channel_index(int index_0) {
     return index_0 >= 0 && index_0 < 512;
+}
+
+
+FixtureAttributeChannel to_channel_binding(const FixturePatch &patch,
+                                          int coarse_1_based,
+                                          int fine_1_based,
+                                          int ultra_1_based) {
+    FixtureAttributeChannel out;
+    out.coarse_dmx_channel_index_0 = to_channel_index_0(patch, coarse_1_based);
+    out.fine_dmx_channel_index_0 = to_channel_index_0(patch, fine_1_based);
+    out.ultra_fine_dmx_channel_index_0 = to_channel_index_0(patch, ultra_1_based);
+    return out;
+}
+
+void sanitize_channel_binding(FixtureAttributeChannel &channel) {
+    if (channel.fine_dmx_channel_index_0 >= 0 && !is_valid_channel_index(channel.fine_dmx_channel_index_0)) {
+        channel.fine_dmx_channel_index_0 = -1;
+    }
+    if (channel.ultra_fine_dmx_channel_index_0 >= 0 &&
+        !is_valid_channel_index(channel.ultra_fine_dmx_channel_index_0)) {
+        channel.ultra_fine_dmx_channel_index_0 = -1;
+    }
 }
 
 } // namespace
@@ -106,6 +130,19 @@ FixtureBindingBuildResult build_dimmer_bindings(
         binding.gobo_wheel_name = offsets.gobo_wheel_name;
         binding.gobo_slots = offsets.gobo_slots;
         binding.gobo_ranges = offsets.gobo_ranges;
+        binding.gobo_wheels.reserve(offsets.gobo_wheels.size());
+        for (const FixtureGoboWheelOffset &wheel : offsets.gobo_wheels) {
+            FixtureGoboWheelBinding wheel_binding;
+            wheel_binding.channel = to_channel_binding(patch,
+                                                       wheel.coarse_offset_1_based,
+                                                       wheel.fine_offset_1_based,
+                                                       wheel.ultra_fine_offset_1_based);
+            wheel_binding.wheel_number = wheel.wheel_number;
+            wheel_binding.wheel_name = wheel.wheel_name;
+            wheel_binding.slots = wheel.slots;
+            wheel_binding.ranges = wheel.ranges;
+            binding.gobo_wheels.push_back(std::move(wheel_binding));
+        }
         binding.has_zoom_physical_limits = offsets.has_zoom_physical_limits;
         binding.zoom_physical_min_degrees = offsets.zoom_physical_min_degrees;
         binding.zoom_physical_max_degrees = offsets.zoom_physical_max_degrees;
@@ -117,7 +154,13 @@ FixtureBindingBuildResult build_dimmer_bindings(
         const bool has_cyan = is_valid_channel_index(binding.cyan.coarse_dmx_channel_index_0);
         const bool has_magenta = is_valid_channel_index(binding.magenta.coarse_dmx_channel_index_0);
         const bool has_yellow = is_valid_channel_index(binding.yellow.coarse_dmx_channel_index_0);
-        const bool has_gobo = is_valid_channel_index(binding.gobo.coarse_dmx_channel_index_0);
+        bool has_gobo = is_valid_channel_index(binding.gobo.coarse_dmx_channel_index_0);
+        for (const FixtureGoboWheelBinding &wheel_binding : binding.gobo_wheels) {
+            if (is_valid_channel_index(wheel_binding.channel.coarse_dmx_channel_index_0)) {
+                has_gobo = true;
+                break;
+            }
+        }
         if (!has_dimmer && !has_pan && !has_tilt && !has_zoom && !has_cyan && !has_magenta && !has_yellow && !has_gobo) {
             result.unbound.push_back({patch.fixture_uuid,
                                       "resolved DMX channels are out of 0..511 range"});
@@ -180,13 +223,9 @@ FixtureBindingBuildResult build_dimmer_bindings(
             !is_valid_channel_index(binding.yellow.ultra_fine_dmx_channel_index_0)) {
             binding.yellow.ultra_fine_dmx_channel_index_0 = -1;
         }
-        if (binding.gobo.fine_dmx_channel_index_0 >= 0 &&
-            !is_valid_channel_index(binding.gobo.fine_dmx_channel_index_0)) {
-            binding.gobo.fine_dmx_channel_index_0 = -1;
-        }
-        if (binding.gobo.ultra_fine_dmx_channel_index_0 >= 0 &&
-            !is_valid_channel_index(binding.gobo.ultra_fine_dmx_channel_index_0)) {
-            binding.gobo.ultra_fine_dmx_channel_index_0 = -1;
+        sanitize_channel_binding(binding.gobo);
+        for (FixtureGoboWheelBinding &wheel_binding : binding.gobo_wheels) {
+            sanitize_channel_binding(wheel_binding.channel);
         }
 
         result.bindings.push_back(binding);

--- a/peraviz/native/src/dmx/fixture_dmx_binding.h
+++ b/peraviz/native/src/dmx/fixture_dmx_binding.h
@@ -42,6 +42,8 @@ struct FixtureControlBinding {
     FixtureAttributeChannel magenta;
     FixtureAttributeChannel yellow;
     FixtureAttributeChannel gobo;
+    int gobo_wheel_number = 0;
+    std::string gobo_wheel_name;
     std::vector<FixtureGoboSlot> gobo_slots;
     std::vector<FixtureGoboRange> gobo_ranges;
     bool has_zoom_physical_limits = false;
@@ -85,6 +87,8 @@ struct FixtureControlOffsets {
     int gobo_coarse_offset_1_based = -1;
     int gobo_fine_offset_1_based = -1;
     int gobo_ultra_fine_offset_1_based = -1;
+    int gobo_wheel_number = 0;
+    std::string gobo_wheel_name;
     std::vector<FixtureGoboSlot> gobo_slots;
     std::vector<FixtureGoboRange> gobo_ranges;
     bool has_zoom_physical_limits = false;

--- a/peraviz/native/src/dmx/fixture_dmx_binding.h
+++ b/peraviz/native/src/dmx/fixture_dmx_binding.h
@@ -31,6 +31,14 @@ struct FixtureGoboRange {
     int slot_index = -1;
 };
 
+struct FixtureGoboWheelBinding {
+    FixtureAttributeChannel channel;
+    int wheel_number = 0;
+    std::string wheel_name;
+    std::vector<FixtureGoboSlot> slots;
+    std::vector<FixtureGoboRange> ranges;
+};
+
 struct FixtureControlBinding {
     std::string fixture_uuid;
     int artnet_universe_id = -1;
@@ -46,6 +54,7 @@ struct FixtureControlBinding {
     std::string gobo_wheel_name;
     std::vector<FixtureGoboSlot> gobo_slots;
     std::vector<FixtureGoboRange> gobo_ranges;
+    std::vector<FixtureGoboWheelBinding> gobo_wheels;
     bool has_zoom_physical_limits = false;
     float zoom_physical_min_degrees = -1.0F;
     float zoom_physical_max_degrees = -1.0F;
@@ -60,6 +69,16 @@ struct FixtureUnboundReason {
 struct FixtureBindingBuildResult {
     std::vector<FixtureControlBinding> bindings;
     std::vector<FixtureUnboundReason> unbound;
+};
+
+struct FixtureGoboWheelOffset {
+    int coarse_offset_1_based = -1;
+    int fine_offset_1_based = -1;
+    int ultra_fine_offset_1_based = -1;
+    int wheel_number = 0;
+    std::string wheel_name;
+    std::vector<FixtureGoboSlot> slots;
+    std::vector<FixtureGoboRange> ranges;
 };
 
 struct FixtureControlOffsets {
@@ -91,6 +110,7 @@ struct FixtureControlOffsets {
     std::string gobo_wheel_name;
     std::vector<FixtureGoboSlot> gobo_slots;
     std::vector<FixtureGoboRange> gobo_ranges;
+    std::vector<FixtureGoboWheelOffset> gobo_wheels;
     bool has_zoom_physical_limits = false;
     float zoom_physical_min_degrees = -1.0F;
     float zoom_physical_max_degrees = -1.0F;
@@ -99,8 +119,8 @@ struct FixtureControlOffsets {
         return dimmer_coarse_offset_1_based > 0 || pan_coarse_offset_1_based > 0 ||
                tilt_coarse_offset_1_based > 0 || zoom_coarse_offset_1_based > 0 ||
                cyan_coarse_offset_1_based > 0 || magenta_coarse_offset_1_based > 0 ||
-               gobo_coarse_offset_1_based > 0 ||
-               yellow_coarse_offset_1_based > 0;
+               gobo_coarse_offset_1_based > 0 || yellow_coarse_offset_1_based > 0 ||
+               !gobo_wheels.empty();
     }
 };
 

--- a/peraviz/native/src/dmx/fixture_dmx_binding.h
+++ b/peraviz/native/src/dmx/fixture_dmx_binding.h
@@ -20,6 +20,17 @@ struct FixtureAttributeChannel {
     int ultra_fine_dmx_channel_index_0 = -1;
 };
 
+struct FixtureGoboSlot {
+    int slot_index = -1;
+    std::string image_path;
+};
+
+struct FixtureGoboRange {
+    int dmx_from = 0;
+    int dmx_to = 255;
+    int slot_index = -1;
+};
+
 struct FixtureControlBinding {
     std::string fixture_uuid;
     int artnet_universe_id = -1;
@@ -30,6 +41,9 @@ struct FixtureControlBinding {
     FixtureAttributeChannel cyan;
     FixtureAttributeChannel magenta;
     FixtureAttributeChannel yellow;
+    FixtureAttributeChannel gobo;
+    std::vector<FixtureGoboSlot> gobo_slots;
+    std::vector<FixtureGoboRange> gobo_ranges;
     bool has_zoom_physical_limits = false;
     float zoom_physical_min_degrees = -1.0F;
     float zoom_physical_max_degrees = -1.0F;
@@ -68,6 +82,11 @@ struct FixtureControlOffsets {
     int yellow_coarse_offset_1_based = -1;
     int yellow_fine_offset_1_based = -1;
     int yellow_ultra_fine_offset_1_based = -1;
+    int gobo_coarse_offset_1_based = -1;
+    int gobo_fine_offset_1_based = -1;
+    int gobo_ultra_fine_offset_1_based = -1;
+    std::vector<FixtureGoboSlot> gobo_slots;
+    std::vector<FixtureGoboRange> gobo_ranges;
     bool has_zoom_physical_limits = false;
     float zoom_physical_min_degrees = -1.0F;
     float zoom_physical_max_degrees = -1.0F;
@@ -76,6 +95,7 @@ struct FixtureControlOffsets {
         return dimmer_coarse_offset_1_based > 0 || pan_coarse_offset_1_based > 0 ||
                tilt_coarse_offset_1_based > 0 || zoom_coarse_offset_1_based > 0 ||
                cyan_coarse_offset_1_based > 0 || magenta_coarse_offset_1_based > 0 ||
+               gobo_coarse_offset_1_based > 0 ||
                yellow_coarse_offset_1_based > 0;
     }
 };

--- a/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
@@ -1,4 +1,5 @@
 #include "dmx/fixture_dmx_binding.h"
+#include "asset_cache.h"
 
 #include <algorithm>
 #include <cctype>
@@ -7,6 +8,7 @@
 #include <sstream>
 #include <unordered_map>
 #include <vector>
+#include <unordered_set>
 
 #include <tinyxml2.h>
 #include <wx/wfstream.h>
@@ -134,6 +136,7 @@ enum class AttributeRole {
     kCyan,
     kMagenta,
     kYellow,
+    kGobo,
 };
 
 struct ParsedAttribute {
@@ -226,6 +229,22 @@ bool starts_with_role_token(const std::string &attribute,
     return false;
 }
 
+bool matches_gobo_attribute(const std::string &leaf) {
+    int byte_index = 1;
+    if (starts_with_role_token(leaf, "gobo", byte_index) ||
+        starts_with_role_token(leaf, "gobowheel", byte_index) ||
+        starts_with_role_token(leaf, "goboindex", byte_index) ||
+        starts_with_role_token(leaf, "goboselect", byte_index)) {
+        return true;
+    }
+
+    const bool references_wheel = leaf.find("wheel") != std::string::npos;
+    const bool references_selector =
+        leaf.find("slot") != std::string::npos || leaf.find("index") != std::string::npos ||
+        leaf.find("select") != std::string::npos;
+    return references_wheel && references_selector;
+}
+
 ParsedAttribute parse_attribute_name(const std::string &raw_attribute) {
     ParsedAttribute parsed;
     const std::string lower = lower_ascii(trim_ascii(raw_attribute));
@@ -278,6 +297,9 @@ ParsedAttribute parse_attribute_name(const std::string &raw_attribute) {
                starts_with_role_token(leaf, "colorrgb_y", byte_index) ||
                starts_with_role_token(leaf, "colorrgb_yellow", byte_index)) {
         parsed.role = AttributeRole::kYellow;
+        parsed.byte_index = byte_index;
+    } else if (matches_gobo_attribute(leaf)) {
+        parsed.role = AttributeRole::kGobo;
         parsed.byte_index = byte_index;
     }
 
@@ -383,7 +405,210 @@ void consume_offsets(const std::vector<int> &offsets,
     }
 }
 
+int parse_positive_int(const char *raw) {
+    if (!raw) {
+        return -1;
+    }
+
+    std::string value = trim_ascii(raw);
+    if (value.empty()) {
+        return -1;
+    }
+
+    size_t length = 0;
+    while (length < value.size() && std::isdigit(static_cast<unsigned char>(value[length])) != 0) {
+        ++length;
+    }
+    if (length == 0) {
+        return -1;
+    }
+
+    const long parsed = std::strtol(value.substr(0, length).c_str(), nullptr, 10);
+    if (parsed <= 0L) {
+        return -1;
+    }
+    return static_cast<int>(parsed);
+}
+
+int parse_dmx_value_8bit(const char *raw_value) {
+    if (!raw_value) {
+        return -1;
+    }
+
+    std::string value = trim_ascii(raw_value);
+    if (value.empty()) {
+        return -1;
+    }
+
+    size_t slash = value.find('/');
+    if (slash != std::string::npos) {
+        value = value.substr(0, slash);
+    }
+    value = trim_ascii(value);
+
+    char *end = nullptr;
+    const long parsed = std::strtol(value.c_str(), &end, 10);
+    if (end == value.c_str()) {
+        return -1;
+    }
+    return static_cast<int>(std::clamp(parsed, 0L, 255L));
+}
+
+std::string read_attr_ci(tinyxml2::XMLElement *node, const char *name_a, const char *name_b) {
+    if (!node) {
+        return {};
+    }
+    const char *value = node->Attribute(name_a);
+    if (!value) {
+        value = node->Attribute(name_b);
+    }
+    return value ? trim_ascii(value) : std::string();
+}
+
+std::string ensure_gobo_media_extracted(peraviz::ZipAssetCache &cache, const std::string &media_reference) {
+    if (media_reference.empty()) {
+        return {};
+    }
+
+    const std::string normalized = trim_ascii(media_reference);
+    std::vector<std::string> candidates;
+    candidates.push_back(normalized);
+    candidates.push_back("wheels/" + normalized);
+    candidates.push_back("wheels/images/" + normalized);
+
+    const std::string lower = lower_ascii(normalized);
+    const bool has_ext = lower.find('.') != std::string::npos;
+    if (!has_ext) {
+        candidates.push_back("wheels/" + normalized + ".png");
+        candidates.push_back("wheels/" + normalized + ".jpg");
+        candidates.push_back("wheels/" + normalized + ".jpeg");
+        candidates.push_back("wheels/images/" + normalized + ".png");
+        candidates.push_back("wheels/images/" + normalized + ".jpg");
+        candidates.push_back("wheels/images/" + normalized + ".jpeg");
+    }
+
+    for (const std::string &candidate : candidates) {
+        const std::string extracted = cache.ensure_extracted(candidate);
+        if (!extracted.empty()) {
+            return extracted;
+        }
+    }
+
+    return {};
+}
+
+typedef std::unordered_map<std::string, std::unordered_map<int, std::string>> GoboWheelCatalog;
+
+GoboWheelCatalog build_gobo_wheel_catalog(const std::string &gdtf_path, tinyxml2::XMLElement *root) {
+    GoboWheelCatalog out;
+    if (!root) {
+        return out;
+    }
+
+    peraviz::ZipAssetCache cache(gdtf_path);
+    const std::vector<tinyxml2::XMLElement *> wheels = collect_elements_by_name(root, "wheel");
+    for (tinyxml2::XMLElement *wheel : wheels) {
+        const std::string wheel_name = lower_ascii(read_attr_ci(wheel, "Name", "name"));
+        if (wheel_name.empty()) {
+            continue;
+        }
+
+        int implicit_index = 1;
+        for (tinyxml2::XMLElement *wheel_slot = wheel->FirstChildElement(); wheel_slot;
+             wheel_slot = wheel_slot->NextSiblingElement()) {
+            if (lower_ascii(wheel_slot->Name()) != "wheelslot") {
+                continue;
+            }
+
+            int slot_index = parse_positive_int(wheel_slot->Attribute("WheelSlotIndex"));
+            if (slot_index <= 0) {
+                slot_index = parse_positive_int(wheel_slot->Attribute("wheelslotindex"));
+            }
+            if (slot_index <= 0) {
+                slot_index = implicit_index;
+            }
+            implicit_index = std::max(implicit_index, slot_index + 1);
+
+            const std::string media_file = read_attr_ci(wheel_slot, "MediaFileName", "mediafilename");
+            if (media_file.empty()) {
+                continue;
+            }
+
+            const std::string extracted = ensure_gobo_media_extracted(cache, media_file);
+            if (!extracted.empty()) {
+                out[wheel_name][slot_index] = extracted;
+            }
+        }
+    }
+
+    return out;
+}
+
+void consume_gobo_channel_sets(tinyxml2::XMLElement *channel_function,
+                               const GoboWheelCatalog &wheel_catalog,
+                               peraviz::dmx::FixtureControlOffsets &out_offsets) {
+    if (!channel_function) {
+        return;
+    }
+
+    const std::string wheel_name = lower_ascii(read_attr_ci(channel_function, "Wheel", "wheel"));
+    if (wheel_name.empty()) {
+        return;
+    }
+
+    auto wheel_it = wheel_catalog.find(wheel_name);
+    if (wheel_it == wheel_catalog.end()) {
+        return;
+    }
+
+    std::unordered_set<int> known_slots;
+    for (const auto &[slot_index, image_path] : wheel_it->second) {
+        if (slot_index <= 0 || image_path.empty()) {
+            continue;
+        }
+        known_slots.insert(slot_index);
+        out_offsets.gobo_slots.push_back({slot_index, image_path});
+    }
+
+    for (tinyxml2::XMLElement *channel_set = channel_function->FirstChildElement(); channel_set;
+         channel_set = channel_set->NextSiblingElement()) {
+        if (lower_ascii(channel_set->Name()) != "channelset") {
+            continue;
+        }
+
+        int slot_index = parse_positive_int(channel_set->Attribute("WheelSlotIndex"));
+        if (slot_index <= 0) {
+            slot_index = parse_positive_int(channel_set->Attribute("wheelslotindex"));
+        }
+        if (slot_index <= 0 || known_slots.find(slot_index) == known_slots.end()) {
+            continue;
+        }
+
+        int dmx_from = parse_dmx_value_8bit(channel_set->Attribute("DMXFrom"));
+        if (dmx_from < 0) {
+            dmx_from = parse_dmx_value_8bit(channel_set->Attribute("dmxfrom"));
+        }
+        if (dmx_from < 0) {
+            dmx_from = 0;
+        }
+
+        int dmx_to = parse_dmx_value_8bit(channel_set->Attribute("DMXTo"));
+        if (dmx_to < 0) {
+            dmx_to = parse_dmx_value_8bit(channel_set->Attribute("dmxto"));
+        }
+        if (dmx_to < 0) {
+            dmx_to = dmx_from;
+        }
+        if (dmx_to < dmx_from) {
+            std::swap(dmx_from, dmx_to);
+        }
+
+        out_offsets.gobo_ranges.push_back({dmx_from, dmx_to, slot_index});
+    }
+}
+
 void consume_channel_offsets(tinyxml2::XMLElement *dmx_channel,
+                             const GoboWheelCatalog &wheel_catalog,
                              peraviz::dmx::FixtureControlOffsets &out_offsets) {
     if (!dmx_channel) {
         return;
@@ -463,6 +688,13 @@ void consume_channel_offsets(tinyxml2::XMLElement *dmx_channel,
                                 out_offsets.yellow_fine_offset_1_based,
                                 out_offsets.yellow_ultra_fine_offset_1_based);
                 break;
+            case AttributeRole::kGobo:
+                consume_offsets(offsets, parsed_attribute.is_fine, parsed_attribute.byte_index,
+                                out_offsets.gobo_coarse_offset_1_based,
+                                out_offsets.gobo_fine_offset_1_based,
+                                out_offsets.gobo_ultra_fine_offset_1_based);
+                consume_gobo_channel_sets(channel_function, wheel_catalog, out_offsets);
+                break;
             }
         }
     }
@@ -527,6 +759,8 @@ DimmerResolveCacheEntry resolve_uncached(const std::string &gdtf_path,
         return out;
     }
 
+    const GoboWheelCatalog wheel_catalog = build_gobo_wheel_catalog(gdtf_path, root);
+
     std::vector<tinyxml2::XMLElement *> dmx_channels = collect_elements_by_name(selected_mode, "dmxchannel");
     if (dmx_channels.empty()) {
         out.reason = "DMX mode has no DMXChannel entries";
@@ -534,11 +768,47 @@ DimmerResolveCacheEntry resolve_uncached(const std::string &gdtf_path,
     }
 
     for (tinyxml2::XMLElement *dmx_channel : dmx_channels) {
-        consume_channel_offsets(dmx_channel, out.offsets);
+        consume_channel_offsets(dmx_channel, wheel_catalog, out.offsets);
     }
 
+    std::sort(out.offsets.gobo_slots.begin(), out.offsets.gobo_slots.end(),
+              [](const peraviz::dmx::FixtureGoboSlot &a,
+                 const peraviz::dmx::FixtureGoboSlot &b) {
+                  if (a.slot_index != b.slot_index) {
+                      return a.slot_index < b.slot_index;
+                  }
+                  return a.image_path < b.image_path;
+              });
+    out.offsets.gobo_slots.erase(
+        std::unique(out.offsets.gobo_slots.begin(), out.offsets.gobo_slots.end(),
+                    [](const peraviz::dmx::FixtureGoboSlot &a,
+                       const peraviz::dmx::FixtureGoboSlot &b) {
+                        return a.slot_index == b.slot_index && a.image_path == b.image_path;
+                    }),
+        out.offsets.gobo_slots.end());
+
+    std::sort(out.offsets.gobo_ranges.begin(), out.offsets.gobo_ranges.end(),
+              [](const peraviz::dmx::FixtureGoboRange &a,
+                 const peraviz::dmx::FixtureGoboRange &b) {
+                  if (a.dmx_from != b.dmx_from) {
+                      return a.dmx_from < b.dmx_from;
+                  }
+                  if (a.dmx_to != b.dmx_to) {
+                      return a.dmx_to < b.dmx_to;
+                  }
+                  return a.slot_index < b.slot_index;
+              });
+    out.offsets.gobo_ranges.erase(
+        std::unique(out.offsets.gobo_ranges.begin(), out.offsets.gobo_ranges.end(),
+                    [](const peraviz::dmx::FixtureGoboRange &a,
+                       const peraviz::dmx::FixtureGoboRange &b) {
+                        return a.dmx_from == b.dmx_from && a.dmx_to == b.dmx_to &&
+                               a.slot_index == b.slot_index;
+                    }),
+        out.offsets.gobo_ranges.end());
+
     if (!out.offsets.has_any()) {
-        out.reason = "No Dimmer/Pan/Tilt/Zoom/CMY attributes found in mode DMX channels";
+        out.reason = "No Dimmer/Pan/Tilt/Zoom/CMY/Gobo attributes found in mode DMX channels";
         return out;
     }
 

--- a/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
@@ -514,22 +514,24 @@ GoboWheelCatalog build_gobo_wheel_catalog(const std::string &gdtf_path, tinyxml2
         }
 
         int implicit_index = 1;
-        for (tinyxml2::XMLElement *wheel_slot = wheel->FirstChildElement(); wheel_slot;
-             wheel_slot = wheel_slot->NextSiblingElement()) {
-            if (lower_ascii(wheel_slot->Name()) != "wheelslot") {
+        for (tinyxml2::XMLElement *slot_node = wheel->FirstChildElement(); slot_node;
+             slot_node = slot_node->NextSiblingElement()) {
+            const std::string slot_tag = lower_ascii(slot_node->Name());
+            // GDTF 1.0/1.1/1.2 commonly uses <Slot>, while some exporters emit <WheelSlot>.
+            if (slot_tag != "slot" && slot_tag != "wheelslot") {
                 continue;
             }
 
-            int slot_index = parse_positive_int(wheel_slot->Attribute("WheelSlotIndex"));
+            int slot_index = parse_positive_int(slot_node->Attribute("WheelSlotIndex"));
             if (slot_index <= 0) {
-                slot_index = parse_positive_int(wheel_slot->Attribute("wheelslotindex"));
+                slot_index = parse_positive_int(slot_node->Attribute("wheelslotindex"));
             }
             if (slot_index <= 0) {
                 slot_index = implicit_index;
             }
             implicit_index = std::max(implicit_index, slot_index + 1);
 
-            const std::string media_file = read_attr_ci(wheel_slot, "MediaFileName", "mediafilename");
+            const std::string media_file = read_attr_ci(slot_node, "MediaFileName", "mediafilename");
             if (media_file.empty()) {
                 continue;
             }
@@ -570,6 +572,13 @@ void consume_gobo_channel_sets(tinyxml2::XMLElement *channel_function,
         out_offsets.gobo_slots.push_back({slot_index, image_path});
     }
 
+    struct ParsedGoboSet {
+        int dmx_from = 0;
+        int dmx_to = -1;
+        int slot_index = -1;
+    };
+    std::vector<ParsedGoboSet> parsed_sets;
+
     for (tinyxml2::XMLElement *channel_set = channel_function->FirstChildElement(); channel_set;
          channel_set = channel_set->NextSiblingElement()) {
         if (lower_ascii(channel_set->Name()) != "channelset") {
@@ -596,14 +605,37 @@ void consume_gobo_channel_sets(tinyxml2::XMLElement *channel_function,
         if (dmx_to < 0) {
             dmx_to = parse_dmx_value_8bit(channel_set->Attribute("dmxto"));
         }
-        if (dmx_to < 0) {
-            dmx_to = dmx_from;
+        parsed_sets.push_back({dmx_from, dmx_to, slot_index});
+    }
+
+    if (parsed_sets.empty()) {
+        return;
+    }
+
+    std::sort(parsed_sets.begin(), parsed_sets.end(),
+              [](const ParsedGoboSet &a, const ParsedGoboSet &b) {
+                  if (a.dmx_from != b.dmx_from) {
+                      return a.dmx_from < b.dmx_from;
+                  }
+                  return a.slot_index < b.slot_index;
+              });
+
+    for (size_t i = 0; i < parsed_sets.size(); ++i) {
+        ParsedGoboSet &row = parsed_sets[i];
+        if (row.dmx_to < 0) {
+            if (i + 1 < parsed_sets.size()) {
+                row.dmx_to = std::max(row.dmx_from, parsed_sets[i + 1].dmx_from - 1);
+            } else {
+                row.dmx_to = 255;
+            }
         }
-        if (dmx_to < dmx_from) {
-            std::swap(dmx_from, dmx_to);
+        row.dmx_from = std::clamp(row.dmx_from, 0, 255);
+        row.dmx_to = std::clamp(row.dmx_to, 0, 255);
+        if (row.dmx_to < row.dmx_from) {
+            std::swap(row.dmx_from, row.dmx_to);
         }
 
-        out_offsets.gobo_ranges.push_back({dmx_from, dmx_to, slot_index});
+        out_offsets.gobo_ranges.push_back({row.dmx_from, row.dmx_to, row.slot_index});
     }
 }
 

--- a/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
@@ -2,6 +2,7 @@
 #include "asset_cache.h"
 
 #include <algorithm>
+#include <array>
 #include <cctype>
 #include <filesystem>
 #include <cstdlib>
@@ -231,9 +232,19 @@ bool starts_with_role_token(const std::string &attribute,
 }
 
 bool matches_gobo_attribute(const std::string &leaf) {
+    const std::array<std::string, 9> non_projector_tokens = {
+        "spin", "shake", "audio", "random", "time", "mspeed", "speed", "reset", "rotate"};
+    for (const std::string &token : non_projector_tokens) {
+        if (leaf.find(token) != std::string::npos) {
+            return false;
+        }
+    }
+
     int byte_index = 1;
-    if (starts_with_role_token(leaf, "gobo", byte_index) ||
-        starts_with_role_token(leaf, "gobowheel", byte_index) ||
+    if (starts_with_role_token(leaf, "gobo", byte_index)) {
+        return true;
+    }
+    if (starts_with_role_token(leaf, "gobowheel", byte_index) ||
         starts_with_role_token(leaf, "goboindex", byte_index) ||
         starts_with_role_token(leaf, "goboselect", byte_index)) {
         return true;
@@ -242,7 +253,7 @@ bool matches_gobo_attribute(const std::string &leaf) {
     const bool references_wheel = leaf.find("wheel") != std::string::npos;
     const bool references_selector =
         leaf.find("slot") != std::string::npos || leaf.find("index") != std::string::npos ||
-        leaf.find("select") != std::string::npos;
+        leaf.find("select") != std::string::npos || leaf.find("pos") != std::string::npos;
     return references_wheel && references_selector;
 }
 

--- a/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
@@ -11,6 +11,7 @@
 #include <unordered_map>
 #include <vector>
 #include <unordered_set>
+#include <utility>
 
 #include <tinyxml2.h>
 #include <wx/wfstream.h>
@@ -168,24 +169,6 @@ int parse_gobo_wheel_number(const std::string &leaf) {
     return static_cast<int>(parsed);
 }
 
-bool should_replace_gobo_binding(int current_wheel_number, int candidate_wheel_number) {
-    if (current_wheel_number <= 0) {
-        return true;
-    }
-    if (candidate_wheel_number <= 0) {
-        return false;
-    }
-    if (candidate_wheel_number == current_wheel_number) {
-        return true;
-    }
-    if (candidate_wheel_number == 1) {
-        return true;
-    }
-    if (current_wheel_number == 1) {
-        return false;
-    }
-    return candidate_wheel_number < current_wheel_number;
-}
 
 bool has_explicit_fine_marker(const std::string &lower) {
     return lower.find("fine") != std::string::npos ||
@@ -650,7 +633,7 @@ GoboWheelCatalog build_gobo_wheel_catalog(const std::string &gdtf_path, tinyxml2
 
 void consume_gobo_channel_sets(tinyxml2::XMLElement *channel_function,
                                const GoboWheelCatalog &wheel_catalog,
-                               peraviz::dmx::FixtureControlOffsets &out_offsets) {
+                               peraviz::dmx::FixtureGoboWheelOffset &out_wheel) {
     if (!channel_function) {
         return;
     }
@@ -665,7 +648,7 @@ void consume_gobo_channel_sets(tinyxml2::XMLElement *channel_function,
         return;
     }
 
-    out_offsets.gobo_wheel_name = wheel_name;
+    out_wheel.wheel_name = wheel_name;
 
     std::unordered_set<int> known_slots;
     for (const auto &[slot_index, image_path] : wheel_it->second) {
@@ -673,7 +656,7 @@ void consume_gobo_channel_sets(tinyxml2::XMLElement *channel_function,
             continue;
         }
         known_slots.insert(slot_index);
-        out_offsets.gobo_slots.push_back({slot_index, image_path});
+        out_wheel.slots.push_back({slot_index, image_path});
     }
 
     struct ParsedGoboSet {
@@ -739,8 +722,98 @@ void consume_gobo_channel_sets(tinyxml2::XMLElement *channel_function,
             std::swap(row.dmx_from, row.dmx_to);
         }
 
-        out_offsets.gobo_ranges.push_back({row.dmx_from, row.dmx_to, row.slot_index});
+        out_wheel.ranges.push_back({row.dmx_from, row.dmx_to, row.slot_index});
     }
+}
+
+
+int parse_last_number_token(const std::string &text) {
+    int value = 0;
+    bool found = false;
+    int current = 0;
+    bool in_digits = false;
+    for (char ch : text) {
+        if (std::isdigit(static_cast<unsigned char>(ch)) != 0) {
+            in_digits = true;
+            current = (current * 10) + (ch - '0');
+            continue;
+        }
+        if (in_digits) {
+            value = current;
+            found = true;
+            current = 0;
+            in_digits = false;
+        }
+    }
+    if (in_digits) {
+        value = current;
+        found = true;
+    }
+    return found ? value : 0;
+}
+
+peraviz::dmx::FixtureGoboWheelOffset *find_or_create_gobo_wheel_offset(
+    peraviz::dmx::FixtureControlOffsets &out_offsets,
+    int wheel_number,
+    const std::string &wheel_name) {
+    for (auto &wheel : out_offsets.gobo_wheels) {
+        if (!wheel_name.empty() && !wheel.wheel_name.empty() && wheel.wheel_name == wheel_name) {
+            if (wheel.wheel_number <= 0 && wheel_number > 0) {
+                wheel.wheel_number = wheel_number;
+            }
+            return &wheel;
+        }
+        if (wheel_number > 0 && wheel.wheel_number == wheel_number) {
+            if (wheel.wheel_name.empty() && !wheel_name.empty()) {
+                wheel.wheel_name = wheel_name;
+            }
+            return &wheel;
+        }
+    }
+
+    peraviz::dmx::FixtureGoboWheelOffset wheel;
+    wheel.wheel_number = wheel_number;
+    wheel.wheel_name = wheel_name;
+    out_offsets.gobo_wheels.push_back(std::move(wheel));
+    return &out_offsets.gobo_wheels.back();
+}
+
+void dedupe_and_sort_gobo_wheel(peraviz::dmx::FixtureGoboWheelOffset &wheel) {
+    std::sort(wheel.slots.begin(), wheel.slots.end(),
+              [](const peraviz::dmx::FixtureGoboSlot &a,
+                 const peraviz::dmx::FixtureGoboSlot &b) {
+                  if (a.slot_index != b.slot_index) {
+                      return a.slot_index < b.slot_index;
+                  }
+                  return a.image_path < b.image_path;
+              });
+    wheel.slots.erase(
+        std::unique(wheel.slots.begin(), wheel.slots.end(),
+                    [](const peraviz::dmx::FixtureGoboSlot &a,
+                       const peraviz::dmx::FixtureGoboSlot &b) {
+                        return a.slot_index == b.slot_index && a.image_path == b.image_path;
+                    }),
+        wheel.slots.end());
+
+    std::sort(wheel.ranges.begin(), wheel.ranges.end(),
+              [](const peraviz::dmx::FixtureGoboRange &a,
+                 const peraviz::dmx::FixtureGoboRange &b) {
+                  if (a.dmx_from != b.dmx_from) {
+                      return a.dmx_from < b.dmx_from;
+                  }
+                  if (a.dmx_to != b.dmx_to) {
+                      return a.dmx_to < b.dmx_to;
+                  }
+                  return a.slot_index < b.slot_index;
+              });
+    wheel.ranges.erase(
+        std::unique(wheel.ranges.begin(), wheel.ranges.end(),
+                    [](const peraviz::dmx::FixtureGoboRange &a,
+                       const peraviz::dmx::FixtureGoboRange &b) {
+                        return a.dmx_from == b.dmx_from && a.dmx_to == b.dmx_to &&
+                               a.slot_index == b.slot_index;
+                    }),
+        wheel.ranges.end());
 }
 
 void consume_channel_offsets(tinyxml2::XMLElement *dmx_channel,
@@ -825,21 +898,21 @@ void consume_channel_offsets(tinyxml2::XMLElement *dmx_channel,
                                 out_offsets.yellow_ultra_fine_offset_1_based);
                 break;
             case AttributeRole::kGobo: {
-                if (should_replace_gobo_binding(out_offsets.gobo_wheel_number,
-                                                parsed_attribute.gobo_wheel_number)) {
-                    const bool changed_wheel = out_offsets.gobo_wheel_number != parsed_attribute.gobo_wheel_number;
-                    out_offsets.gobo_wheel_number = parsed_attribute.gobo_wheel_number;
-                    if (changed_wheel) {
-                        out_offsets.gobo_slots.clear();
-                        out_offsets.gobo_ranges.clear();
-                        out_offsets.gobo_wheel_name.clear();
-                    }
-                    consume_offsets(offsets, parsed_attribute.is_fine, parsed_attribute.byte_index,
-                                    out_offsets.gobo_coarse_offset_1_based,
-                                    out_offsets.gobo_fine_offset_1_based,
-                                    out_offsets.gobo_ultra_fine_offset_1_based);
-                    consume_gobo_channel_sets(channel_function, wheel_catalog, out_offsets);
+                const std::string wheel_name = lower_ascii(read_attr_ci(channel_function, "Wheel", "wheel"));
+                int wheel_number = parsed_attribute.gobo_wheel_number;
+                if (wheel_number <= 0) {
+                    wheel_number = parse_last_number_token(wheel_name);
                 }
+                peraviz::dmx::FixtureGoboWheelOffset *wheel =
+                    find_or_create_gobo_wheel_offset(out_offsets, wheel_number, wheel_name);
+                if (!wheel) {
+                    break;
+                }
+                consume_offsets(offsets, parsed_attribute.is_fine, parsed_attribute.byte_index,
+                                wheel->coarse_offset_1_based,
+                                wheel->fine_offset_1_based,
+                                wheel->ultra_fine_offset_1_based);
+                consume_gobo_channel_sets(channel_function, wheel_catalog, *wheel);
                 break;
             }
             }
@@ -918,41 +991,47 @@ DimmerResolveCacheEntry resolve_uncached(const std::string &gdtf_path,
         consume_channel_offsets(dmx_channel, wheel_catalog, out.offsets);
     }
 
-    std::sort(out.offsets.gobo_slots.begin(), out.offsets.gobo_slots.end(),
-              [](const peraviz::dmx::FixtureGoboSlot &a,
-                 const peraviz::dmx::FixtureGoboSlot &b) {
-                  if (a.slot_index != b.slot_index) {
-                      return a.slot_index < b.slot_index;
-                  }
-                  return a.image_path < b.image_path;
-              });
-    out.offsets.gobo_slots.erase(
-        std::unique(out.offsets.gobo_slots.begin(), out.offsets.gobo_slots.end(),
-                    [](const peraviz::dmx::FixtureGoboSlot &a,
-                       const peraviz::dmx::FixtureGoboSlot &b) {
-                        return a.slot_index == b.slot_index && a.image_path == b.image_path;
-                    }),
-        out.offsets.gobo_slots.end());
+    for (auto &wheel : out.offsets.gobo_wheels) {
+        dedupe_and_sort_gobo_wheel(wheel);
+    }
+    out.offsets.gobo_wheels.erase(
+        std::remove_if(out.offsets.gobo_wheels.begin(), out.offsets.gobo_wheels.end(),
+                       [](const peraviz::dmx::FixtureGoboWheelOffset &wheel) {
+                           return wheel.coarse_offset_1_based <= 0;
+                       }),
+        out.offsets.gobo_wheels.end());
 
-    std::sort(out.offsets.gobo_ranges.begin(), out.offsets.gobo_ranges.end(),
-              [](const peraviz::dmx::FixtureGoboRange &a,
-                 const peraviz::dmx::FixtureGoboRange &b) {
-                  if (a.dmx_from != b.dmx_from) {
-                      return a.dmx_from < b.dmx_from;
+    std::sort(out.offsets.gobo_wheels.begin(), out.offsets.gobo_wheels.end(),
+              [](const peraviz::dmx::FixtureGoboWheelOffset &a,
+                 const peraviz::dmx::FixtureGoboWheelOffset &b) {
+                  if (a.wheel_number > 0 && b.wheel_number > 0 && a.wheel_number != b.wheel_number) {
+                      return a.wheel_number < b.wheel_number;
                   }
-                  if (a.dmx_to != b.dmx_to) {
-                      return a.dmx_to < b.dmx_to;
+                  if (a.wheel_name != b.wheel_name) {
+                      return a.wheel_name < b.wheel_name;
                   }
-                  return a.slot_index < b.slot_index;
+                  return a.coarse_offset_1_based < b.coarse_offset_1_based;
               });
-    out.offsets.gobo_ranges.erase(
-        std::unique(out.offsets.gobo_ranges.begin(), out.offsets.gobo_ranges.end(),
-                    [](const peraviz::dmx::FixtureGoboRange &a,
-                       const peraviz::dmx::FixtureGoboRange &b) {
-                        return a.dmx_from == b.dmx_from && a.dmx_to == b.dmx_to &&
-                               a.slot_index == b.slot_index;
-                    }),
-        out.offsets.gobo_ranges.end());
+
+    const peraviz::dmx::FixtureGoboWheelOffset *primary_wheel = nullptr;
+    for (const auto &wheel : out.offsets.gobo_wheels) {
+        if (wheel.wheel_number == 1) {
+            primary_wheel = &wheel;
+            break;
+        }
+    }
+    if (!primary_wheel && !out.offsets.gobo_wheels.empty()) {
+        primary_wheel = &out.offsets.gobo_wheels.front();
+    }
+    if (primary_wheel) {
+        out.offsets.gobo_coarse_offset_1_based = primary_wheel->coarse_offset_1_based;
+        out.offsets.gobo_fine_offset_1_based = primary_wheel->fine_offset_1_based;
+        out.offsets.gobo_ultra_fine_offset_1_based = primary_wheel->ultra_fine_offset_1_based;
+        out.offsets.gobo_wheel_number = primary_wheel->wheel_number;
+        out.offsets.gobo_wheel_name = primary_wheel->wheel_name;
+        out.offsets.gobo_slots = primary_wheel->slots;
+        out.offsets.gobo_ranges = primary_wheel->ranges;
+    }
 
     if (!out.offsets.has_any()) {
         out.reason = "No Dimmer/Pan/Tilt/Zoom/CMY/Gobo attributes found in mode DMX channels";

--- a/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
@@ -145,7 +145,47 @@ struct ParsedAttribute {
     AttributeRole role = AttributeRole::kUnknown;
     bool is_fine = false;
     int byte_index = 1;
+    int gobo_wheel_number = 0;
 };
+
+
+int parse_gobo_wheel_number(const std::string &leaf) {
+    if (leaf.rfind("gobo", 0) != 0 || leaf.size() <= 4) {
+        return 0;
+    }
+    size_t index = 4;
+    size_t digits_end = index;
+    while (digits_end < leaf.size() && std::isdigit(static_cast<unsigned char>(leaf[digits_end])) != 0) {
+        ++digits_end;
+    }
+    if (digits_end == index) {
+        return 0;
+    }
+    const long parsed = std::strtol(leaf.substr(index, digits_end - index).c_str(), nullptr, 10);
+    if (parsed <= 0L) {
+        return 0;
+    }
+    return static_cast<int>(parsed);
+}
+
+bool should_replace_gobo_binding(int current_wheel_number, int candidate_wheel_number) {
+    if (current_wheel_number <= 0) {
+        return true;
+    }
+    if (candidate_wheel_number <= 0) {
+        return false;
+    }
+    if (candidate_wheel_number == current_wheel_number) {
+        return true;
+    }
+    if (candidate_wheel_number == 1) {
+        return true;
+    }
+    if (current_wheel_number == 1) {
+        return false;
+    }
+    return candidate_wheel_number < current_wheel_number;
+}
 
 bool has_explicit_fine_marker(const std::string &lower) {
     return lower.find("fine") != std::string::npos ||
@@ -313,6 +353,7 @@ ParsedAttribute parse_attribute_name(const std::string &raw_attribute) {
     } else if (matches_gobo_attribute(leaf)) {
         parsed.role = AttributeRole::kGobo;
         parsed.byte_index = byte_index;
+        parsed.gobo_wheel_number = parse_gobo_wheel_number(leaf);
     }
 
     if (parsed.role == AttributeRole::kUnknown) {
@@ -624,6 +665,8 @@ void consume_gobo_channel_sets(tinyxml2::XMLElement *channel_function,
         return;
     }
 
+    out_offsets.gobo_wheel_name = wheel_name;
+
     std::unordered_set<int> known_slots;
     for (const auto &[slot_index, image_path] : wheel_it->second) {
         if (slot_index <= 0 || image_path.empty()) {
@@ -781,13 +824,24 @@ void consume_channel_offsets(tinyxml2::XMLElement *dmx_channel,
                                 out_offsets.yellow_fine_offset_1_based,
                                 out_offsets.yellow_ultra_fine_offset_1_based);
                 break;
-            case AttributeRole::kGobo:
-                consume_offsets(offsets, parsed_attribute.is_fine, parsed_attribute.byte_index,
-                                out_offsets.gobo_coarse_offset_1_based,
-                                out_offsets.gobo_fine_offset_1_based,
-                                out_offsets.gobo_ultra_fine_offset_1_based);
-                consume_gobo_channel_sets(channel_function, wheel_catalog, out_offsets);
+            case AttributeRole::kGobo: {
+                if (should_replace_gobo_binding(out_offsets.gobo_wheel_number,
+                                                parsed_attribute.gobo_wheel_number)) {
+                    const bool changed_wheel = out_offsets.gobo_wheel_number != parsed_attribute.gobo_wheel_number;
+                    out_offsets.gobo_wheel_number = parsed_attribute.gobo_wheel_number;
+                    if (changed_wheel) {
+                        out_offsets.gobo_slots.clear();
+                        out_offsets.gobo_ranges.clear();
+                        out_offsets.gobo_wheel_name.clear();
+                    }
+                    consume_offsets(offsets, parsed_attribute.is_fine, parsed_attribute.byte_index,
+                                    out_offsets.gobo_coarse_offset_1_based,
+                                    out_offsets.gobo_fine_offset_1_based,
+                                    out_offsets.gobo_ultra_fine_offset_1_based);
+                    consume_gobo_channel_sets(channel_function, wheel_catalog, out_offsets);
+                }
                 break;
+            }
             }
         }
     }

--- a/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <filesystem>
 #include <cstdlib>
 #include <mutex>
 #include <sstream>
@@ -465,7 +466,51 @@ std::string read_attr_ci(tinyxml2::XMLElement *node, const char *name_a, const c
     return value ? trim_ascii(value) : std::string();
 }
 
-std::string ensure_gobo_media_extracted(peraviz::ZipAssetCache &cache, const std::string &media_reference) {
+std::string find_archive_media_by_stem(const std::string &gdtf_path,
+                                       const std::string &media_reference) {
+    const std::filesystem::path ref_path = std::filesystem::u8path(trim_ascii(media_reference));
+    const std::string wanted_stem = lower_ascii(ref_path.stem().u8string());
+    if (wanted_stem.empty()) {
+        return {};
+    }
+
+    wxFileInputStream input(wxString::FromUTF8(gdtf_path.c_str()));
+    if (!input.IsOk()) {
+        return {};
+    }
+
+    std::string best_match;
+    wxZipInputStream zip(input);
+    std::unique_ptr<wxZipEntry> entry;
+    while ((entry.reset(zip.GetNextEntry())), entry) {
+        std::string entry_name = entry->GetName().ToUTF8().data();
+        std::replace(entry_name.begin(), entry_name.end(), '\\', '/');
+        const std::string entry_lower = lower_ascii(entry_name);
+        const std::filesystem::path entry_path = std::filesystem::u8path(entry_name);
+        const std::string entry_ext = lower_ascii(entry_path.extension().u8string());
+        if (entry_ext != ".png" && entry_ext != ".jpg" && entry_ext != ".jpeg") {
+            continue;
+        }
+        const std::string entry_stem = lower_ascii(entry_path.stem().u8string());
+        if (entry_stem != wanted_stem) {
+            continue;
+        }
+
+        const bool in_wheels_folder = entry_lower.find("wheels/") != std::string::npos;
+        if (in_wheels_folder) {
+            return entry_name;
+        }
+        if (best_match.empty()) {
+            best_match = entry_name;
+        }
+    }
+
+    return best_match;
+}
+
+std::string ensure_gobo_media_extracted(const std::string &gdtf_path,
+                                        peraviz::ZipAssetCache &cache,
+                                        const std::string &media_reference) {
     if (media_reference.empty()) {
         return {};
     }
@@ -492,6 +537,11 @@ std::string ensure_gobo_media_extracted(peraviz::ZipAssetCache &cache, const std
         if (!extracted.empty()) {
             return extracted;
         }
+    }
+
+    const std::string archive_match = find_archive_media_by_stem(gdtf_path, normalized);
+    if (!archive_match.empty()) {
+        return cache.ensure_extracted(archive_match);
     }
 
     return {};
@@ -536,7 +586,7 @@ GoboWheelCatalog build_gobo_wheel_catalog(const std::string &gdtf_path, tinyxml2
                 continue;
             }
 
-            const std::string extracted = ensure_gobo_media_extracted(cache, media_file);
+            const std::string extracted = ensure_gobo_media_extracted(gdtf_path, cache, media_file);
             if (!extracted.empty()) {
                 out[wheel_name][slot_index] = extracted;
             }

--- a/peraviz/native/src/peraviz_loader.cpp
+++ b/peraviz/native/src/peraviz_loader.cpp
@@ -224,6 +224,43 @@ Dictionary PeravizLoader::build_fixture_dimmer_bindings(int universe_offset) con
         item["gobo_ranges"] = gobo_ranges;
         item["gobo1_ranges"] = gobo_ranges;
 
+        Array gobo_wheels;
+        gobo_wheels.resize(static_cast<int64_t>(binding.gobo_wheels.size()));
+        for (int64_t wheel_index = 0; wheel_index < static_cast<int64_t>(binding.gobo_wheels.size()); ++wheel_index) {
+            const auto &wheel = binding.gobo_wheels[static_cast<size_t>(wheel_index)];
+            Dictionary wheel_item;
+            wheel_item["wheel_number"] = wheel.wheel_number;
+            wheel_item["wheel_name"] = String(wheel.wheel_name.c_str());
+            wheel_item["channel_index_0"] = wheel.channel.coarse_dmx_channel_index_0;
+            wheel_item["fine_channel_index_0"] = wheel.channel.fine_dmx_channel_index_0;
+            wheel_item["ultra_fine_channel_index_0"] = wheel.channel.ultra_fine_dmx_channel_index_0;
+
+            Array wheel_slots;
+            wheel_slots.resize(static_cast<int64_t>(wheel.slots.size()));
+            for (int64_t slot_index = 0; slot_index < static_cast<int64_t>(wheel.slots.size()); ++slot_index) {
+                const auto &slot = wheel.slots[static_cast<size_t>(slot_index)];
+                Dictionary slot_item;
+                slot_item["slot_index"] = slot.slot_index;
+                slot_item["image_path"] = String(slot.image_path.c_str());
+                wheel_slots[slot_index] = slot_item;
+            }
+            wheel_item["slots"] = wheel_slots;
+
+            Array wheel_ranges;
+            wheel_ranges.resize(static_cast<int64_t>(wheel.ranges.size()));
+            for (int64_t range_index = 0; range_index < static_cast<int64_t>(wheel.ranges.size()); ++range_index) {
+                const auto &range = wheel.ranges[static_cast<size_t>(range_index)];
+                Dictionary range_item;
+                range_item["dmx_from"] = range.dmx_from;
+                range_item["dmx_to"] = range.dmx_to;
+                range_item["slot_index"] = range.slot_index;
+                wheel_ranges[range_index] = range_item;
+            }
+            wheel_item["ranges"] = wheel_ranges;
+            gobo_wheels[wheel_index] = wheel_item;
+        }
+        item["gobo_wheels"] = gobo_wheels;
+
         item["has_zoom_physical_limits"] = binding.has_zoom_physical_limits;
         item["zoom_physical_min_degrees"] = binding.zoom_physical_min_degrees;
         item["zoom_physical_max_degrees"] = binding.zoom_physical_max_degrees;

--- a/peraviz/native/src/peraviz_loader.cpp
+++ b/peraviz/native/src/peraviz_loader.cpp
@@ -191,6 +191,13 @@ Dictionary PeravizLoader::build_fixture_dimmer_bindings(int universe_offset) con
         item["gobo_channel_index_0"] = binding.gobo.coarse_dmx_channel_index_0;
         item["gobo_fine_channel_index_0"] = binding.gobo.fine_dmx_channel_index_0;
         item["gobo_ultra_fine_channel_index_0"] = binding.gobo.ultra_fine_dmx_channel_index_0;
+        item["gobo_wheel_number"] = binding.gobo_wheel_number;
+        item["gobo_wheel_name"] = String(binding.gobo_wheel_name.c_str());
+
+        item["gobo1_channel_index_0"] = binding.gobo.coarse_dmx_channel_index_0;
+        item["gobo1_fine_channel_index_0"] = binding.gobo.fine_dmx_channel_index_0;
+        item["gobo1_ultra_fine_channel_index_0"] = binding.gobo.ultra_fine_dmx_channel_index_0;
+        item["gobo1_wheel_name"] = String(binding.gobo_wheel_name.c_str());
 
         Array gobo_slots;
         gobo_slots.resize(static_cast<int64_t>(binding.gobo_slots.size()));
@@ -202,6 +209,7 @@ Dictionary PeravizLoader::build_fixture_dimmer_bindings(int universe_offset) con
             gobo_slots[slot_index] = slot_item;
         }
         item["gobo_slots"] = gobo_slots;
+        item["gobo1_slots"] = gobo_slots;
 
         Array gobo_ranges;
         gobo_ranges.resize(static_cast<int64_t>(binding.gobo_ranges.size()));
@@ -214,6 +222,7 @@ Dictionary PeravizLoader::build_fixture_dimmer_bindings(int universe_offset) con
             gobo_ranges[range_index] = range_item;
         }
         item["gobo_ranges"] = gobo_ranges;
+        item["gobo1_ranges"] = gobo_ranges;
 
         item["has_zoom_physical_limits"] = binding.has_zoom_physical_limits;
         item["zoom_physical_min_degrees"] = binding.zoom_physical_min_degrees;

--- a/peraviz/native/src/peraviz_loader.cpp
+++ b/peraviz/native/src/peraviz_loader.cpp
@@ -188,6 +188,33 @@ Dictionary PeravizLoader::build_fixture_dimmer_bindings(int universe_offset) con
         item["yellow_channel_index_0"] = binding.yellow.coarse_dmx_channel_index_0;
         item["yellow_fine_channel_index_0"] = binding.yellow.fine_dmx_channel_index_0;
         item["yellow_ultra_fine_channel_index_0"] = binding.yellow.ultra_fine_dmx_channel_index_0;
+        item["gobo_channel_index_0"] = binding.gobo.coarse_dmx_channel_index_0;
+        item["gobo_fine_channel_index_0"] = binding.gobo.fine_dmx_channel_index_0;
+        item["gobo_ultra_fine_channel_index_0"] = binding.gobo.ultra_fine_dmx_channel_index_0;
+
+        Array gobo_slots;
+        gobo_slots.resize(static_cast<int64_t>(binding.gobo_slots.size()));
+        for (int64_t slot_index = 0; slot_index < static_cast<int64_t>(binding.gobo_slots.size()); ++slot_index) {
+            const auto &slot = binding.gobo_slots[static_cast<size_t>(slot_index)];
+            Dictionary slot_item;
+            slot_item["slot_index"] = slot.slot_index;
+            slot_item["image_path"] = String(slot.image_path.c_str());
+            gobo_slots[slot_index] = slot_item;
+        }
+        item["gobo_slots"] = gobo_slots;
+
+        Array gobo_ranges;
+        gobo_ranges.resize(static_cast<int64_t>(binding.gobo_ranges.size()));
+        for (int64_t range_index = 0; range_index < static_cast<int64_t>(binding.gobo_ranges.size()); ++range_index) {
+            const auto &range = binding.gobo_ranges[static_cast<size_t>(range_index)];
+            Dictionary range_item;
+            range_item["dmx_from"] = range.dmx_from;
+            range_item["dmx_to"] = range.dmx_to;
+            range_item["slot_index"] = range.slot_index;
+            gobo_ranges[range_index] = range_item;
+        }
+        item["gobo_ranges"] = gobo_ranges;
+
         item["has_zoom_physical_limits"] = binding.has_zoom_physical_limits;
         item["zoom_physical_min_degrees"] = binding.zoom_physical_min_degrees;
         item["zoom_physical_max_degrees"] = binding.zoom_physical_max_degrees;

--- a/peraviz/scripts/dmx_fixture_runtime.gd
+++ b/peraviz/scripts/dmx_fixture_runtime.gd
@@ -93,6 +93,8 @@ func apply_dmx(receiver, apply_fixture_callback: Callable) -> void:
 			"magenta_norm": 0.0,
 			"has_yellow": false,
 			"yellow_norm": 0.0,
+			"has_gobo": false,
+			"gobo_norm": 0.0,
 		}
 
 		_read_control(binding, frame, "dimmer_channel_index_0", "dimmer_fine_channel_index_0", "dimmer_ultra_fine_channel_index_0", controls, "has_dimmer", "dimmer_norm")
@@ -102,13 +104,18 @@ func apply_dmx(receiver, apply_fixture_callback: Callable) -> void:
 		_read_control(binding, frame, "cyan_channel_index_0", "cyan_fine_channel_index_0", "cyan_ultra_fine_channel_index_0", controls, "has_cyan", "cyan_norm")
 		_read_control(binding, frame, "magenta_channel_index_0", "magenta_fine_channel_index_0", "magenta_ultra_fine_channel_index_0", controls, "has_magenta", "magenta_norm")
 		_read_control(binding, frame, "yellow_channel_index_0", "yellow_fine_channel_index_0", "yellow_ultra_fine_channel_index_0", controls, "has_yellow", "yellow_norm")
+		_read_control(binding, frame, "gobo_channel_index_0", "gobo_fine_channel_index_0", "gobo_ultra_fine_channel_index_0", controls, "has_gobo", "gobo_norm")
 
 		if controls["has_zoom"]:
 			controls["has_zoom_physical_limits"] = bool(binding.get("has_zoom_physical_limits", false))
 			controls["zoom_physical_min_degrees"] = float(binding.get("zoom_physical_min_degrees", -1.0))
 			controls["zoom_physical_max_degrees"] = float(binding.get("zoom_physical_max_degrees", -1.0))
 
-		if not controls["has_dimmer"] and not controls["has_pan"] and not controls["has_tilt"] and not controls["has_zoom"] and not controls["has_cyan"] and not controls["has_magenta"] and not controls["has_yellow"]:
+		if controls["has_gobo"]:
+			controls["gobo_slots"] = binding.get("gobo_slots", [])
+			controls["gobo_ranges"] = binding.get("gobo_ranges", [])
+
+		if not controls["has_dimmer"] and not controls["has_pan"] and not controls["has_tilt"] and not controls["has_zoom"] and not controls["has_cyan"] and not controls["has_magenta"] and not controls["has_yellow"] and not controls["has_gobo"]:
 			continue
 		apply_fixture_callback.call(fixture_uuid, controls)
 

--- a/peraviz/scripts/dmx_fixture_runtime.gd
+++ b/peraviz/scripts/dmx_fixture_runtime.gd
@@ -119,6 +119,11 @@ func apply_dmx(receiver, apply_fixture_callback: Callable) -> void:
 			controls["gobo_wheel_name"] = str(binding.get("gobo1_wheel_name", binding.get("gobo_wheel_name", "")))
 			controls["gobo_wheel_number"] = int(binding.get("gobo_wheel_number", 0))
 
+		var gobo_runtime_bindings: Array = _build_runtime_gobo_bindings(binding, frame)
+		if not gobo_runtime_bindings.is_empty():
+			controls["has_gobo"] = true
+			controls["gobo_runtime_bindings"] = gobo_runtime_bindings
+
 		if not controls["has_dimmer"] and not controls["has_pan"] and not controls["has_tilt"] and not controls["has_zoom"] and not controls["has_cyan"] and not controls["has_magenta"] and not controls["has_yellow"] and not controls["has_gobo"]:
 			continue
 		apply_fixture_callback.call(fixture_uuid, controls)
@@ -223,3 +228,45 @@ func _build_summary(universe_offset: int) -> Dictionary:
 		"unbound_preview": get_unbound_preview(),
 		"universe_offset": universe_offset,
 	}
+
+func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -> Array:
+	var runtime_bindings: Array = []
+	var raw_wheels: Array = binding.get("gobo_wheels", [])
+	for item in raw_wheels:
+		if item is not Dictionary:
+			continue
+		var coarse_index: int = int(item.get("channel_index_0", -1))
+		if not _is_valid_channel_index(frame, coarse_index):
+			continue
+		var value: Dictionary = _read_control_value(frame, coarse_index, int(item.get("fine_channel_index_0", -1)), int(item.get("ultra_fine_channel_index_0", -1)))
+		var raw_8bit: int = _resolve_raw_to_8bit(int(value.get("raw", 0)), int(value.get("resolution_bits", 8)))
+		runtime_bindings.append({
+			"wheel_number": int(item.get("wheel_number", 0)),
+			"wheel_name": str(item.get("wheel_name", "")),
+			"raw_8bit": raw_8bit,
+			"slot_index": _resolve_gobo_slot_from_ranges(raw_8bit, item.get("ranges", [])),
+			"slots": item.get("slots", []),
+			"ranges": item.get("ranges", []),
+		})
+	return runtime_bindings
+
+func _resolve_raw_to_8bit(raw_value: int, resolution_bits: int) -> int:
+	if resolution_bits >= 24:
+		return clampi(raw_value >> 16, 0, 255)
+	if resolution_bits >= 16:
+		return clampi(raw_value >> 8, 0, 255)
+	return clampi(raw_value, 0, 255)
+
+func _resolve_gobo_slot_from_ranges(raw_8bit: int, ranges: Array) -> int:
+	for item in ranges:
+		if item is not Dictionary:
+			continue
+		var dmx_from: int = int(item.get("dmx_from", 0))
+		var dmx_to: int = int(item.get("dmx_to", dmx_from))
+		if dmx_to < dmx_from:
+			var temp: int = dmx_from
+			dmx_from = dmx_to
+			dmx_to = temp
+		if raw_8bit >= dmx_from and raw_8bit <= dmx_to:
+			return int(item.get("slot_index", 0))
+	return 0

--- a/peraviz/scripts/dmx_fixture_runtime.gd
+++ b/peraviz/scripts/dmx_fixture_runtime.gd
@@ -104,7 +104,9 @@ func apply_dmx(receiver, apply_fixture_callback: Callable) -> void:
 		_read_control(binding, frame, "cyan_channel_index_0", "cyan_fine_channel_index_0", "cyan_ultra_fine_channel_index_0", controls, "has_cyan", "cyan_norm")
 		_read_control(binding, frame, "magenta_channel_index_0", "magenta_fine_channel_index_0", "magenta_ultra_fine_channel_index_0", controls, "has_magenta", "magenta_norm")
 		_read_control(binding, frame, "yellow_channel_index_0", "yellow_fine_channel_index_0", "yellow_ultra_fine_channel_index_0", controls, "has_yellow", "yellow_norm")
-		_read_control(binding, frame, "gobo_channel_index_0", "gobo_fine_channel_index_0", "gobo_ultra_fine_channel_index_0", controls, "has_gobo", "gobo_norm")
+		_read_control(binding, frame, "gobo1_channel_index_0", "gobo1_fine_channel_index_0", "gobo1_ultra_fine_channel_index_0", controls, "has_gobo", "gobo_norm")
+		if not controls["has_gobo"]:
+			_read_control(binding, frame, "gobo_channel_index_0", "gobo_fine_channel_index_0", "gobo_ultra_fine_channel_index_0", controls, "has_gobo", "gobo_norm")
 
 		if controls["has_zoom"]:
 			controls["has_zoom_physical_limits"] = bool(binding.get("has_zoom_physical_limits", false))
@@ -112,8 +114,10 @@ func apply_dmx(receiver, apply_fixture_callback: Callable) -> void:
 			controls["zoom_physical_max_degrees"] = float(binding.get("zoom_physical_max_degrees", -1.0))
 
 		if controls["has_gobo"]:
-			controls["gobo_slots"] = binding.get("gobo_slots", [])
-			controls["gobo_ranges"] = binding.get("gobo_ranges", [])
+			controls["gobo_slots"] = binding.get("gobo1_slots", binding.get("gobo_slots", []))
+			controls["gobo_ranges"] = binding.get("gobo1_ranges", binding.get("gobo_ranges", []))
+			controls["gobo_wheel_name"] = str(binding.get("gobo1_wheel_name", binding.get("gobo_wheel_name", "")))
+			controls["gobo_wheel_number"] = int(binding.get("gobo_wheel_number", 0))
 
 		if not controls["has_dimmer"] and not controls["has_pan"] and not controls["has_tilt"] and not controls["has_zoom"] and not controls["has_cyan"] and not controls["has_magenta"] and not controls["has_yellow"] and not controls["has_gobo"]:
 			continue

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -1,0 +1,71 @@
+extends RefCounted
+class_name FixtureGoboProjector
+
+var _texture_cache: Dictionary = {}
+
+func clear_cache() -> void:
+	_texture_cache.clear()
+
+func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> void:
+	if light == null or not is_instance_valid(light):
+		return
+	if not bool(controls.get("has_gobo", false)):
+		light.light_projector = null
+		return
+
+	var active_slot_index: int = _resolve_active_gobo_slot_index(controls)
+	if active_slot_index <= 0:
+		light.light_projector = null
+		return
+
+	var gobo_texture: Texture2D = _resolve_gobo_texture_for_slot(controls, active_slot_index)
+	light.light_projector = gobo_texture
+
+func _resolve_active_gobo_slot_index(controls: Dictionary) -> int:
+	var gobo_ranges: Array = controls.get("gobo_ranges", [])
+	if gobo_ranges.is_empty():
+		return -1
+	var gobo_raw: int = int(round(clamp(float(controls.get("gobo_norm", 0.0)), 0.0, 1.0) * 255.0))
+	if controls.has("gobo_raw_value") and controls.has("gobo_resolution_bits"):
+		var raw_value: int = int(controls.get("gobo_raw_value", gobo_raw))
+		var resolution_bits: int = int(controls.get("gobo_resolution_bits", 8))
+		if resolution_bits > 8:
+			var shift_bits: int = max(0, resolution_bits - 8)
+			gobo_raw = raw_value >> shift_bits
+		else:
+			gobo_raw = raw_value
+	gobo_raw = clampi(gobo_raw, 0, 255)
+
+	for item in gobo_ranges:
+		if item is not Dictionary:
+			continue
+		var dmx_from: int = int(item.get("dmx_from", 0))
+		var dmx_to: int = int(item.get("dmx_to", dmx_from))
+		if dmx_to < dmx_from:
+			var swap_value: int = dmx_from
+			dmx_from = dmx_to
+			dmx_to = swap_value
+		if gobo_raw >= dmx_from and gobo_raw <= dmx_to:
+			return int(item.get("slot_index", -1))
+	return -1
+
+func _resolve_gobo_texture_for_slot(controls: Dictionary, slot_index: int) -> Texture2D:
+	var gobo_slots: Array = controls.get("gobo_slots", [])
+	for item in gobo_slots:
+		if item is not Dictionary:
+			continue
+		if int(item.get("slot_index", -1)) != slot_index:
+			continue
+		var image_path: String = str(item.get("image_path", ""))
+		if image_path.is_empty():
+			return null
+		if _texture_cache.has(image_path):
+			return _texture_cache[image_path] as Texture2D
+		var image := Image.new()
+		var load_error: Error = image.load(image_path)
+		if load_error != OK:
+			return null
+		var texture: ImageTexture = ImageTexture.create_from_image(image)
+		_texture_cache[image_path] = texture
+		return texture
+	return null

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -1,6 +1,8 @@
 extends RefCounted
 class_name FixtureGoboProjector
 
+const FAKE_GOBO_TEXTURE_SIZE: int = 128
+
 var _texture_cache: Dictionary = {}
 
 func clear_cache() -> void:
@@ -13,18 +15,19 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> void:
 		light.light_projector = null
 		return
 
-	var active_slot_index: int = _resolve_active_gobo_slot_index(controls)
+	var gobo_raw_8bit: int = _resolve_gobo_raw_8bit(controls)
+	var active_slot_index: int = _resolve_active_gobo_slot_index(controls, gobo_raw_8bit)
 	if active_slot_index <= 0:
-		light.light_projector = null
+		light.light_projector = _resolve_fake_gobo_texture(gobo_raw_8bit)
 		return
 
 	var gobo_texture: Texture2D = _resolve_gobo_texture_for_slot(controls, active_slot_index)
+	if gobo_texture == null:
+		light.light_projector = _resolve_fake_gobo_texture(gobo_raw_8bit)
+		return
 	light.light_projector = gobo_texture
 
-func _resolve_active_gobo_slot_index(controls: Dictionary) -> int:
-	var gobo_ranges: Array = controls.get("gobo_ranges", [])
-	if gobo_ranges.is_empty():
-		return -1
+func _resolve_gobo_raw_8bit(controls: Dictionary) -> int:
 	var gobo_raw: int = int(round(clamp(float(controls.get("gobo_norm", 0.0)), 0.0, 1.0) * 255.0))
 	if controls.has("gobo_raw_value") and controls.has("gobo_resolution_bits"):
 		var raw_value: int = int(controls.get("gobo_raw_value", gobo_raw))
@@ -34,7 +37,12 @@ func _resolve_active_gobo_slot_index(controls: Dictionary) -> int:
 			gobo_raw = raw_value >> shift_bits
 		else:
 			gobo_raw = raw_value
-	gobo_raw = clampi(gobo_raw, 0, 255)
+	return clampi(gobo_raw, 0, 255)
+
+func _resolve_active_gobo_slot_index(controls: Dictionary, gobo_raw_8bit: int) -> int:
+	var gobo_ranges: Array = controls.get("gobo_ranges", [])
+	if gobo_ranges.is_empty():
+		return -1
 
 	for item in gobo_ranges:
 		if item is not Dictionary:
@@ -45,7 +53,7 @@ func _resolve_active_gobo_slot_index(controls: Dictionary) -> int:
 			var swap_value: int = dmx_from
 			dmx_from = dmx_to
 			dmx_to = swap_value
-		if gobo_raw >= dmx_from and gobo_raw <= dmx_to:
+		if gobo_raw_8bit >= dmx_from and gobo_raw_8bit <= dmx_to:
 			return int(item.get("slot_index", -1))
 	return -1
 
@@ -69,3 +77,27 @@ func _resolve_gobo_texture_for_slot(controls: Dictionary, slot_index: int) -> Te
 		_texture_cache[image_path] = texture
 		return texture
 	return null
+
+func _resolve_fake_gobo_texture(gobo_raw_8bit: int) -> Texture2D:
+	var fake_bucket: int = gobo_raw_8bit / 8
+	var cache_key: String = "__fake_gobo_%d" % fake_bucket
+	if _texture_cache.has(cache_key):
+		return _texture_cache[cache_key] as Texture2D
+
+	var image := Image.create(FAKE_GOBO_TEXTURE_SIZE, FAKE_GOBO_TEXTURE_SIZE, false, Image.FORMAT_RGBA8)
+	image.fill(Color(0.0, 0.0, 0.0, 1.0))
+
+	var stripe_step: int = max(4, int(4 + (fake_bucket % 12) * 2))
+	var radius: float = float(FAKE_GOBO_TEXTURE_SIZE) * (0.18 + 0.015 * float(fake_bucket % 10))
+	var center: Vector2 = Vector2(FAKE_GOBO_TEXTURE_SIZE, FAKE_GOBO_TEXTURE_SIZE) * 0.5
+	for y in range(FAKE_GOBO_TEXTURE_SIZE):
+		for x in range(FAKE_GOBO_TEXTURE_SIZE):
+			var uv: Vector2 = Vector2(float(x), float(y)) - center
+			var dist: float = uv.length()
+			var stripe: bool = ((x + y + fake_bucket) % stripe_step) < (stripe_step / 2)
+			if dist < radius and stripe:
+				image.set_pixel(x, y, Color(1.0, 1.0, 1.0, 1.0))
+
+	var texture: ImageTexture = ImageTexture.create_from_image(image)
+	_texture_cache[cache_key] = texture
+	return texture

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -13,7 +13,12 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> void:
 		return
 	if not bool(controls.get("has_gobo", false)):
 		light.light_projector = null
+		light.shadow_enabled = false
 		return
+
+	# Godot requires shadow_enabled for light_projector to be applied.
+	light.shadow_enabled = true
+	_warn_if_projector_unsupported(light)
 
 	var gobo_raw_8bit: int = _resolve_gobo_raw_8bit(controls)
 	var active_slot_index: int = _resolve_active_gobo_slot_index(controls, gobo_raw_8bit)
@@ -104,3 +109,12 @@ func _resolve_fake_gobo_texture(gobo_raw_8bit: int) -> Texture2D:
 	var texture: ImageTexture = ImageTexture.create_from_image(image)
 	_texture_cache[cache_key] = texture
 	return texture
+
+func _warn_if_projector_unsupported(light: SpotLight3D) -> void:
+	if light.has_meta("peraviz_projector_support_checked"):
+		return
+	light.set_meta("peraviz_projector_support_checked", true)
+	if RenderingServer.has_method("get_current_rendering_method"):
+		var rendering_method: String = str(RenderingServer.get_current_rendering_method())
+		if rendering_method == "gl_compatibility":
+			push_warning("Peraviz gobo projector is not supported in Compatibility renderer. Use Forward+ or Mobile.")

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -78,6 +78,7 @@ func _resolve_gobo_texture_for_slot(controls: Dictionary, slot_index: int) -> Te
 		var load_error: Error = image.load(image_path)
 		if load_error != OK:
 			return null
+		image.generate_mipmaps()
 		var texture: ImageTexture = ImageTexture.create_from_image(image)
 		_texture_cache[image_path] = texture
 		return texture
@@ -93,19 +94,23 @@ func _resolve_fake_gobo_texture(gobo_raw_8bit: int) -> Texture2D:
 	# Keep base fully open (white) so spot footprint is still visible while debugging.
 	image.fill(Color(1.0, 1.0, 1.0, 1.0))
 
-	# Bucket 0 emulates open gobo.
+	# Bucket 0 emulates open gobo. Higher buckets produce high-contrast masks
+	# so projector output changes are obvious when testing DMX mapping.
 	if fake_bucket > 0:
-		var stripe_step: int = max(6, int(6 + (fake_bucket % 12) * 2))
-		var radius: float = float(FAKE_GOBO_TEXTURE_SIZE) * (0.20 + 0.012 * float(fake_bucket % 10))
+		var step: int = max(4, int(4 + (fake_bucket % 6) * 2))
 		var center: Vector2 = Vector2(FAKE_GOBO_TEXTURE_SIZE, FAKE_GOBO_TEXTURE_SIZE) * 0.5
+		var max_radius: float = float(FAKE_GOBO_TEXTURE_SIZE) * 0.48
 		for y in range(FAKE_GOBO_TEXTURE_SIZE):
 			for x in range(FAKE_GOBO_TEXTURE_SIZE):
 				var uv: Vector2 = Vector2(float(x), float(y)) - center
 				var dist: float = uv.length()
-				var stripe: bool = ((x + y + fake_bucket) % stripe_step) < (stripe_step / 2)
-				if dist < radius and stripe:
+				if dist > max_radius:
+					continue
+				var checker: bool = (((x / step) + (y / step) + fake_bucket) % 2) == 0
+				if checker:
 					image.set_pixel(x, y, Color(0.0, 0.0, 0.0, 1.0))
 
+	image.generate_mipmaps()
 	var texture: ImageTexture = ImageTexture.create_from_image(image)
 	_texture_cache[cache_key] = texture
 	return texture

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -85,18 +85,21 @@ func _resolve_fake_gobo_texture(gobo_raw_8bit: int) -> Texture2D:
 		return _texture_cache[cache_key] as Texture2D
 
 	var image := Image.create(FAKE_GOBO_TEXTURE_SIZE, FAKE_GOBO_TEXTURE_SIZE, false, Image.FORMAT_RGBA8)
-	image.fill(Color(0.0, 0.0, 0.0, 1.0))
+	# Keep base fully open (white) so spot footprint is still visible while debugging.
+	image.fill(Color(1.0, 1.0, 1.0, 1.0))
 
-	var stripe_step: int = max(4, int(4 + (fake_bucket % 12) * 2))
-	var radius: float = float(FAKE_GOBO_TEXTURE_SIZE) * (0.18 + 0.015 * float(fake_bucket % 10))
-	var center: Vector2 = Vector2(FAKE_GOBO_TEXTURE_SIZE, FAKE_GOBO_TEXTURE_SIZE) * 0.5
-	for y in range(FAKE_GOBO_TEXTURE_SIZE):
-		for x in range(FAKE_GOBO_TEXTURE_SIZE):
-			var uv: Vector2 = Vector2(float(x), float(y)) - center
-			var dist: float = uv.length()
-			var stripe: bool = ((x + y + fake_bucket) % stripe_step) < (stripe_step / 2)
-			if dist < radius and stripe:
-				image.set_pixel(x, y, Color(1.0, 1.0, 1.0, 1.0))
+	# Bucket 0 emulates open gobo.
+	if fake_bucket > 0:
+		var stripe_step: int = max(6, int(6 + (fake_bucket % 12) * 2))
+		var radius: float = float(FAKE_GOBO_TEXTURE_SIZE) * (0.20 + 0.012 * float(fake_bucket % 10))
+		var center: Vector2 = Vector2(FAKE_GOBO_TEXTURE_SIZE, FAKE_GOBO_TEXTURE_SIZE) * 0.5
+		for y in range(FAKE_GOBO_TEXTURE_SIZE):
+			for x in range(FAKE_GOBO_TEXTURE_SIZE):
+				var uv: Vector2 = Vector2(float(x), float(y)) - center
+				var dist: float = uv.length()
+				var stripe: bool = ((x + y + fake_bucket) % stripe_step) < (stripe_step / 2)
+				if dist < radius and stripe:
+					image.set_pixel(x, y, Color(0.0, 0.0, 0.0, 1.0))
 
 	var texture: ImageTexture = ImageTexture.create_from_image(image)
 	_texture_cache[cache_key] = texture

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -16,21 +16,39 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> void:
 		light.shadow_enabled = false
 		return
 
-	# Godot requires shadow_enabled for light_projector to be applied.
+	var runtime_bindings: Array = controls.get("gobo_runtime_bindings", [])
+	if runtime_bindings.is_empty():
+		var fallback_raw_8bit: int = _resolve_gobo_raw_8bit(controls)
+		runtime_bindings = [{
+			"raw_8bit": fallback_raw_8bit,
+			"slot_index": _resolve_active_gobo_slot_index(controls, fallback_raw_8bit),
+			"slots": controls.get("gobo_slots", []),
+		}]
+
+	var active_textures: Array[Texture2D] = []
+	for wheel in runtime_bindings:
+		if wheel is not Dictionary:
+			continue
+		var slot_index: int = int(wheel.get("slot_index", 0))
+		if slot_index <= 0:
+			continue
+		var wheel_controls := {
+			"gobo_slots": wheel.get("slots", []),
+		}
+		var gobo_texture: Texture2D = _resolve_gobo_texture_for_slot(wheel_controls, slot_index)
+		if gobo_texture == null:
+			gobo_texture = _resolve_fake_gobo_texture(int(wheel.get("raw_8bit", 0)))
+		if gobo_texture != null:
+			active_textures.append(gobo_texture)
+
+	if active_textures.is_empty():
+		light.light_projector = null
+		light.shadow_enabled = false
+		return
+
 	light.shadow_enabled = true
 	_warn_if_projector_unsupported(light)
-
-	var gobo_raw_8bit: int = _resolve_gobo_raw_8bit(controls)
-	var active_slot_index: int = _resolve_active_gobo_slot_index(controls, gobo_raw_8bit)
-	if active_slot_index <= 0:
-		light.light_projector = _resolve_fake_gobo_texture(gobo_raw_8bit)
-		return
-
-	var gobo_texture: Texture2D = _resolve_gobo_texture_for_slot(controls, active_slot_index)
-	if gobo_texture == null:
-		light.light_projector = _resolve_fake_gobo_texture(gobo_raw_8bit)
-		return
-	light.light_projector = gobo_texture
+	light.light_projector = _compose_gobo_textures(active_textures)
 
 func _resolve_gobo_raw_8bit(controls: Dictionary) -> int:
 	var gobo_raw: int = int(round(clamp(float(controls.get("gobo_norm", 0.0)), 0.0, 1.0) * 255.0))
@@ -84,6 +102,43 @@ func _resolve_gobo_texture_for_slot(controls: Dictionary, slot_index: int) -> Te
 		return texture
 	return null
 
+func _compose_gobo_textures(textures: Array[Texture2D]) -> Texture2D:
+	if textures.is_empty():
+		return null
+	if textures.size() == 1:
+		return textures[0]
+
+	var key_parts: PackedStringArray = PackedStringArray()
+	for texture in textures:
+		if texture != null:
+			key_parts.append(str(texture.get_rid().get_id()))
+	var cache_key: String = "__composed_gobo_" + "_".join(key_parts)
+	if _texture_cache.has(cache_key):
+		return _texture_cache[cache_key] as Texture2D
+
+	var composed: Image = Image.create(FAKE_GOBO_TEXTURE_SIZE, FAKE_GOBO_TEXTURE_SIZE, false, Image.FORMAT_RGBA8)
+	composed.fill(Color(1.0, 1.0, 1.0, 1.0))
+	for texture in textures:
+		if texture == null:
+			continue
+		var image: Image = texture.get_image()
+		if image == null:
+			continue
+		if image.get_width() != FAKE_GOBO_TEXTURE_SIZE or image.get_height() != FAKE_GOBO_TEXTURE_SIZE:
+			image.resize(FAKE_GOBO_TEXTURE_SIZE, FAKE_GOBO_TEXTURE_SIZE, Image.INTERPOLATE_BILINEAR)
+		for y in range(FAKE_GOBO_TEXTURE_SIZE):
+			for x in range(FAKE_GOBO_TEXTURE_SIZE):
+				var dst: Color = composed.get_pixel(x, y)
+				var src: Color = image.get_pixel(x, y)
+				var src_luma: float = (src.r + src.g + src.b) / 3.0
+				var out_luma: float = dst.r * src_luma
+				composed.set_pixel(x, y, Color(out_luma, out_luma, out_luma, 1.0))
+
+	composed.generate_mipmaps()
+	var out_texture: ImageTexture = ImageTexture.create_from_image(composed)
+	_texture_cache[cache_key] = out_texture
+	return out_texture
+
 func _resolve_fake_gobo_texture(gobo_raw_8bit: int) -> Texture2D:
 	var fake_bucket: int = gobo_raw_8bit / 8
 	var cache_key: String = "__fake_gobo_%d" % fake_bucket
@@ -91,11 +146,7 @@ func _resolve_fake_gobo_texture(gobo_raw_8bit: int) -> Texture2D:
 		return _texture_cache[cache_key] as Texture2D
 
 	var image := Image.create(FAKE_GOBO_TEXTURE_SIZE, FAKE_GOBO_TEXTURE_SIZE, false, Image.FORMAT_RGBA8)
-	# Keep base fully open (white) so spot footprint is still visible while debugging.
 	image.fill(Color(1.0, 1.0, 1.0, 1.0))
-
-	# Bucket 0 emulates open gobo. Higher buckets produce high-contrast masks
-	# so projector output changes are obvious when testing DMX mapping.
 	if fake_bucket > 0:
 		var step: int = max(4, int(4 + (fake_bucket % 6) * 2))
 		var center: Vector2 = Vector2(FAKE_GOBO_TEXTURE_SIZE, FAKE_GOBO_TEXTURE_SIZE) * 0.5

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -44,7 +44,7 @@ var _fixture_emissive_cache: Dictionary = {}
 var _fixture_lens_material_cache: Dictionary = {}
 var _fixture_emitter_light_cache: Dictionary = {}
 var _fixture_emitter_photometrics: Dictionary = {}
-var _gobo_texture_cache: Dictionary = {}
+var _fixture_gobo_projector: FixtureGoboProjector = null
 var _updating_fixture_controls: bool = false
 var _visual_environment_baseline := {
 	"ambient_light_energy": 0.2,
@@ -85,6 +85,7 @@ const DmxFixtureRuntimeScript = preload("res://scripts/dmx_fixture_runtime.gd")
 const BeamRendererBaseScript = preload("res://scripts/beam_renderers/beam_renderer_base.gd")
 const LegacyConeBeamRendererScript = preload("res://scripts/beam_renderers/legacy_cone_beam_renderer.gd")
 const VolumetricBeamRendererScript = preload("res://scripts/beam_renderers/volumetric_beam_renderer.gd")
+const FixtureGoboProjectorScript = preload("res://scripts/fixture_gobo_projector.gd")
 
 const DEBUG_TOGGLE_KEY: Key = KEY_C
 const MANUAL_TEST_FLAG: String = "--peraviz_manual_fixture_test"
@@ -216,6 +217,7 @@ func _ready() -> void:
 	_capture_visual_environment_baseline()
 	_load_visual_settings_from_project()
 	_initialize_beam_renderers()
+	_fixture_gobo_projector = FixtureGoboProjectorScript.new()
 	visual_settings_window.configure(_visual_settings)
 	_apply_visual_settings(_visual_settings)
 
@@ -992,7 +994,8 @@ func _clear_scene() -> void:
 	_fixture_lens_material_cache.clear()
 	_fixture_emitter_light_cache.clear()
 	_fixture_emitter_photometrics.clear()
-	_gobo_texture_cache.clear()
+	if _fixture_gobo_projector != null:
+		_fixture_gobo_projector.clear_cache()
 	_has_loaded_bounds = false
 	_clear_debug_gizmos()
 
@@ -1831,71 +1834,8 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 		"distance_cull_m": BEAM_DISTANCE_CULL_M,
 	}
 	_update_beam_for_light(light, beam_params)
-	_apply_gobo_projection(light, controls)
-
-func _apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> void:
-	if light == null or not is_instance_valid(light):
-		return
-	if not bool(controls.get("has_gobo", false)):
-		light.projector = null
-		return
-
-	var active_slot_index: int = _resolve_active_gobo_slot_index(controls)
-	if active_slot_index <= 0:
-		light.projector = null
-		return
-
-	var gobo_texture: Texture2D = _resolve_gobo_texture_for_slot(controls, active_slot_index)
-	light.projector = gobo_texture
-
-func _resolve_active_gobo_slot_index(controls: Dictionary) -> int:
-	var gobo_ranges: Array = controls.get("gobo_ranges", [])
-	if gobo_ranges.is_empty():
-		return -1
-	var gobo_raw: int = int(round(clamp(float(controls.get("gobo_norm", 0.0)), 0.0, 1.0) * 255.0))
-	if controls.has("gobo_raw_value") and controls.has("gobo_resolution_bits"):
-		var raw_value: int = int(controls.get("gobo_raw_value", gobo_raw))
-		var resolution_bits: int = int(controls.get("gobo_resolution_bits", 8))
-		if resolution_bits > 8:
-			var shift_bits: int = max(0, resolution_bits - 8)
-			gobo_raw = raw_value >> shift_bits
-		else:
-			gobo_raw = raw_value
-	gobo_raw = clampi(gobo_raw, 0, 255)
-
-	for item in gobo_ranges:
-		if item is not Dictionary:
-			continue
-		var dmx_from: int = int(item.get("dmx_from", 0))
-		var dmx_to: int = int(item.get("dmx_to", dmx_from))
-		if dmx_to < dmx_from:
-			var swap_value: int = dmx_from
-			dmx_from = dmx_to
-			dmx_to = swap_value
-		if gobo_raw >= dmx_from and gobo_raw <= dmx_to:
-			return int(item.get("slot_index", -1))
-	return -1
-
-func _resolve_gobo_texture_for_slot(controls: Dictionary, slot_index: int) -> Texture2D:
-	var gobo_slots: Array = controls.get("gobo_slots", [])
-	for item in gobo_slots:
-		if item is not Dictionary:
-			continue
-		if int(item.get("slot_index", -1)) != slot_index:
-			continue
-		var image_path: String = str(item.get("image_path", ""))
-		if image_path.is_empty():
-			return null
-		if _gobo_texture_cache.has(image_path):
-			return _gobo_texture_cache[image_path] as Texture2D
-		var image := Image.new()
-		var load_error: Error = image.load(image_path)
-		if load_error != OK:
-			return null
-		var texture: ImageTexture = ImageTexture.create_from_image(image)
-		_gobo_texture_cache[image_path] = texture
-		return texture
-	return null
+	if _fixture_gobo_projector != null:
+		_fixture_gobo_projector.apply_gobo_projection(light, controls)
 
 func _resolve_zoom_beam_limits(light: SpotLight3D, controls: Dictionary) -> Dictionary:
 	# min/max beam angles are kept as full GDTF beam apertures (not half-angle).

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -44,6 +44,7 @@ var _fixture_emissive_cache: Dictionary = {}
 var _fixture_lens_material_cache: Dictionary = {}
 var _fixture_emitter_light_cache: Dictionary = {}
 var _fixture_emitter_photometrics: Dictionary = {}
+var _gobo_texture_cache: Dictionary = {}
 var _updating_fixture_controls: bool = false
 var _visual_environment_baseline := {
 	"ambient_light_energy": 0.2,
@@ -991,6 +992,7 @@ func _clear_scene() -> void:
 	_fixture_lens_material_cache.clear()
 	_fixture_emitter_light_cache.clear()
 	_fixture_emitter_photometrics.clear()
+	_gobo_texture_cache.clear()
 	_has_loaded_bounds = false
 	_clear_debug_gizmos()
 
@@ -1399,7 +1401,7 @@ func _apply_dmx_controls_to_fixture(fixture_uuid: String, controls: Dictionary) 
 		var tilt_degrees: float = lerp(tilt_min, tilt_max, clamp(float(controls.get("tilt_norm", 0.0)), 0.0, 1.0))
 		_apply_pan_tilt_components_to_fixture(fixture_uuid, has_pan, pan_degrees, has_tilt, tilt_degrees)
 
-	if controls.get("has_dimmer", false) or controls.get("has_zoom", false) or controls.get("has_cyan", false) or controls.get("has_magenta", false) or controls.get("has_yellow", false):
+	if controls.get("has_dimmer", false) or controls.get("has_zoom", false) or controls.get("has_cyan", false) or controls.get("has_magenta", false) or controls.get("has_yellow", false) or controls.get("has_gobo", false):
 		var dimmer_percent: float = float(MANUAL_DEFAULTS["dimmer"])
 		if controls.get("has_dimmer", false):
 			dimmer_percent = clamp(float(controls.get("dimmer_norm", 0.0)), 0.0, 1.0) * 100.0
@@ -1829,6 +1831,71 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 		"distance_cull_m": BEAM_DISTANCE_CULL_M,
 	}
 	_update_beam_for_light(light, beam_params)
+	_apply_gobo_projection(light, controls)
+
+func _apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> void:
+	if light == null or not is_instance_valid(light):
+		return
+	if not bool(controls.get("has_gobo", false)):
+		light.projector = null
+		return
+
+	var active_slot_index: int = _resolve_active_gobo_slot_index(controls)
+	if active_slot_index <= 0:
+		light.projector = null
+		return
+
+	var gobo_texture: Texture2D = _resolve_gobo_texture_for_slot(controls, active_slot_index)
+	light.projector = gobo_texture
+
+func _resolve_active_gobo_slot_index(controls: Dictionary) -> int:
+	var gobo_ranges: Array = controls.get("gobo_ranges", [])
+	if gobo_ranges.is_empty():
+		return -1
+	var gobo_raw: int = int(round(clamp(float(controls.get("gobo_norm", 0.0)), 0.0, 1.0) * 255.0))
+	if controls.has("gobo_raw_value") and controls.has("gobo_resolution_bits"):
+		var raw_value: int = int(controls.get("gobo_raw_value", gobo_raw))
+		var resolution_bits: int = int(controls.get("gobo_resolution_bits", 8))
+		if resolution_bits > 8:
+			var shift_bits: int = max(0, resolution_bits - 8)
+			gobo_raw = raw_value >> shift_bits
+		else:
+			gobo_raw = raw_value
+	gobo_raw = clampi(gobo_raw, 0, 255)
+
+	for item in gobo_ranges:
+		if item is not Dictionary:
+			continue
+		var dmx_from: int = int(item.get("dmx_from", 0))
+		var dmx_to: int = int(item.get("dmx_to", dmx_from))
+		if dmx_to < dmx_from:
+			var swap_value: int = dmx_from
+			dmx_from = dmx_to
+			dmx_to = swap_value
+		if gobo_raw >= dmx_from and gobo_raw <= dmx_to:
+			return int(item.get("slot_index", -1))
+	return -1
+
+func _resolve_gobo_texture_for_slot(controls: Dictionary, slot_index: int) -> Texture2D:
+	var gobo_slots: Array = controls.get("gobo_slots", [])
+	for item in gobo_slots:
+		if item is not Dictionary:
+			continue
+		if int(item.get("slot_index", -1)) != slot_index:
+			continue
+		var image_path: String = str(item.get("image_path", ""))
+		if image_path.is_empty():
+			return null
+		if _gobo_texture_cache.has(image_path):
+			return _gobo_texture_cache[image_path] as Texture2D
+		var image := Image.new()
+		var load_error: Error = image.load(image_path)
+		if load_error != OK:
+			return null
+		var texture: ImageTexture = ImageTexture.create_from_image(image)
+		_gobo_texture_cache[image_path] = texture
+		return texture
+	return null
 
 func _resolve_zoom_beam_limits(light: SpotLight3D, controls: Dictionary) -> Dictionary:
 	# min/max beam angles are kept as full GDTF beam apertures (not half-angle).


### PR DESCRIPTION
### Motivation
- Add support for Gobos authored inside GDTF fixture files so Peraviz can read wheel/slot media and expose gobo controls to the runtime, and project active gobos when a fixture and its GDTF provide them.
- Follow GDTF semantics for wheels, WheelSlot/MediaFileName and ChannelSet DMX ranges so gobo selection maps deterministically from DMX values.

### Description
- Native (C++): extended DMX binding types with `FixtureGoboSlot` and `FixtureGoboRange` and added gobo channel offsets/slots/ranges to `FixtureControlBinding` and `FixtureControlOffsets` in `peraviz/native/src/dmx/fixture_dmx_binding.*`.
- Parser: implemented GDTF gobo parsing in `peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp` to detect gobo attributes, build a wheel catalog from `Wheel`/`WheelSlot` elements, extract `MediaFileName` images from the .gdtf archive using `ZipAssetCache`, and resolve `ChannelSet` DMXFrom/DMXTo ranges to wheel-slot indices (with deduplication).
- API: exposed gobo channel indices, `gobo_slots` and `gobo_ranges` through `PeravizLoader::build_fixture_dimmer_bindings` so the Godot runtime receives gobo metadata (`peraviz/native/src/peraviz_loader.cpp`).
- Godot runtime (GDScript): updated DMX runtime to read gobo channels and include `gobo_slots`/`gobo_ranges` in the controls payload (`peraviz/scripts/dmx_fixture_runtime.gd`), added projector support to `SpotLight3D` in `_apply_emitter_light_state` and helpers to resolve the active slot and load/cached textures (`peraviz/scripts/load_scene.gd`).
- Small helpers and robustness: added DMX value parsing and safe extraction/lookup helpers; kept existing beam/emitter logic unchanged except for projecting gobos when available.
- Changed files (high level): `peraviz/native/src/dmx/{fixture_dmx_binding.*,gdtf_dimmer_resolver.cpp}`, `peraviz/native/src/peraviz_loader.cpp`, `peraviz/scripts/{dmx_fixture_runtime.gd,load_scene.gd}`.

### Testing
- Ran repository code-health checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both succeeded.
- Attempted UI capture with browser tooling in this environment but the Godot runtime is not served over HTTP so a screenshot attempt failed (environment limitation, not a code test).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998589c3ff483248d2623ab82171c5e)