### PR TITLE
Optimize cached RGBA texture uploads by texture size reuse

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -195,9 +195,19 @@ bool EnsurePboCapacity(unsigned int &pbo, size_t &capacity, size_t bytesNeeded) 
 }
 
 bool UploadRgbaToTexture(unsigned int texture, int width, int height,
-                         const unsigned char *data, bool allowPbo) {
+                         const unsigned char *data,
+                         const wxSize &currentTextureSize, bool allowPbo) {
   if (texture == 0 || width <= 0 || height <= 0 || data == nullptr)
     return false;
+
+  const bool needsAllocation =
+      currentTextureSize.GetWidth() != width ||
+      currentTextureSize.GetHeight() != height;
+
+  if (needsAllocation) {
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA,
+                 GL_UNSIGNED_BYTE, nullptr);
+  }
 
   const size_t bytesNeeded =
       static_cast<size_t>(width) * static_cast<size_t>(height) * 4;
@@ -1576,12 +1586,10 @@ void LayoutViewerPanel::RebuildCachedTexture() {
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
       glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-      glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA,
-                   GL_UNSIGNED_BYTE, nullptr);
       ScopedActivePixelUnpackPbo scopedPbo(cache.pixelUnpackPbo,
                                            cache.pboBytes);
       if (!UploadRgbaToTexture(cache.texture, width, height, pixels.data(),
-                               true)) {
+                               cache.textureSize, true)) {
         ClearCachedTexture(cache);
         cache.textureSize = wxSize(0, 0);
         cache.renderZoom = 0.0;
@@ -1663,12 +1671,10 @@ void LayoutViewerPanel::RebuildCachedTexture() {
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
       glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-      glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA,
-                   GL_UNSIGNED_BYTE, nullptr);
       ScopedActivePixelUnpackPbo scopedPbo(cache.pixelUnpackPbo,
                                            cache.pboBytes);
       if (!UploadRgbaToTexture(cache.texture, width, height, pixels.data(),
-                               true)) {
+                               cache.textureSize, true)) {
         ClearCachedTexture(cache);
         cache.textureSize = wxSize(0, 0);
         cache.renderZoom = 0.0;
@@ -1761,12 +1767,10 @@ void LayoutViewerPanel::RebuildCachedTexture() {
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
       glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-      glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA,
-                   GL_UNSIGNED_BYTE, nullptr);
       ScopedActivePixelUnpackPbo scopedPbo(cache.pixelUnpackPbo,
                                            cache.pboBytes);
       if (!UploadRgbaToTexture(cache.texture, width, height, pixels.data(),
-                               true)) {
+                               cache.textureSize, true)) {
         ClearCachedTexture(cache);
         cache.textureSize = wxSize(0, 0);
         cache.renderZoom = 0.0;
@@ -1858,12 +1862,10 @@ void LayoutViewerPanel::RebuildCachedTexture() {
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
       glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-      glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA,
-                   GL_UNSIGNED_BYTE, nullptr);
       ScopedActivePixelUnpackPbo scopedPbo(cache.pixelUnpackPbo,
                                            cache.pboBytes);
       if (!UploadRgbaToTexture(cache.texture, width, height, pixels.data(),
-                               true)) {
+                               cache.textureSize, true)) {
         ClearCachedTexture(cache);
         cache.textureSize = wxSize(0, 0);
         cache.renderZoom = 0.0;
@@ -1961,12 +1963,10 @@ void LayoutViewerPanel::RebuildCachedTexture() {
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
       glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-      glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA,
-                   GL_UNSIGNED_BYTE, nullptr);
       ScopedActivePixelUnpackPbo scopedPbo(cache.pixelUnpackPbo,
                                            cache.pboBytes);
       if (!UploadRgbaToTexture(cache.texture, width, height, pixels.data(),
-                               true)) {
+                               cache.textureSize, true)) {
         ClearCachedTexture(cache);
         cache.textureSize = wxSize(0, 0);
         cache.renderZoom = 0.0;


### PR DESCRIPTION
### Motivation

- Avoid unnecessary `glTexImage2D` reallocations when an existing GL texture already matches the required `width`/`height`, and prevent inconsistent cache state when an upload fails.
- Apply the same allocation-vs-subimage policy consistently across all GUI cache types that store textures.

### Description

- Changed `UploadRgbaToTexture` signature to accept the current texture size as `const wxSize &currentTextureSize` and decide whether to call `glTexImage2D` only when the size changed. 
- Updated all callers in `RebuildCachedTexture` to pass `cache.textureSize` for `ViewCache`, `LegendCache`, `EventTableCache`, `TextCache` and `ImageCache`, removing the prior unconditional `glTexImage2D` calls in each block. 
- The code now uses `glTexSubImage2D` for content uploads when the cached texture size matches, or first calls `glTexImage2D` to allocate storage when the size changed (then uploads data), and only updates `cache.textureSize` after a successful upload path. 

### Testing

- Ran `tests/check_perastage_tree_modules.sh` and it reported OK. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it reported OK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69986fac6a2c832495526c70f7a3eaaa)