### PR TITLE
Optimize layout render invalidation using view content hashes

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/layouttextdialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layouttextutils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layoutviewerpanel.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/layoutviewerpanel_render_invalidation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layoutviewerpanel_eventtable.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layoutviewerpanel_image.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layoutviewerpanel_legend.cpp

--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1610,6 +1610,7 @@ void LayoutViewerPanel::RebuildCachedTexture() {
       }
       cache.textureSize = wxSize(width, height);
       cache.renderZoom = renderZoom;
+      cache.contentHash = HashViewContent(view);
       std::vector<unsigned char>().swap(pixels);
     }
   
@@ -2230,122 +2231,6 @@ void LayoutViewerPanel::RequestRenderRebuild() {
     }
     panel->renderDelayTimer_.StartOnce(kLoadingOverlayDelayMs);
   });
-}
-
-void LayoutViewerPanel::InvalidateRenderIfFrameChanged() {
-  const double renderZoom = GetRenderZoom();
-  const double pageWidth = currentLayout.pageSetup.PageWidthPt();
-  const double pageHeight = currentLayout.pageSetup.PageHeightPt();
-  const bool zoomChanged = lastRenderZoom != renderZoom;
-  const bool pageChanged =
-      lastPageWidthPt != pageWidth || lastPageHeightPt != pageHeight;
-  auto markDirty = [&](bool &cacheDirty) {
-    if (cacheDirty)
-      return;
-    cacheDirty = true;
-  };
-
-  for (const auto &view : currentLayout.view2dViews) {
-    ViewCache &cache = GetViewCache(view.id);
-    wxRect frameRect;
-    if (!GetFrameRect(view.frame, frameRect)) {
-      if (cache.texture != 0) {
-        markDirty(cache.renderDirty);
-        ClearCachedTexture(cache);
-        cache.textureSize = wxSize(0, 0);
-        cache.renderZoom = 0.0;
-      }
-      continue;
-    }
-    const wxSize renderSize = GetFrameSizeForZoom(view.frame, renderZoom);
-    if (cache.renderZoom == 0.0 || cache.renderZoom != renderZoom ||
-        renderSize != cache.textureSize) {
-      markDirty(cache.renderDirty);
-    }
-  }
-
-  for (const auto &legend : currentLayout.legendViews) {
-    LegendCache &cache = GetLegendCache(legend.id);
-    wxRect frameRect;
-    if (!GetFrameRect(legend.frame, frameRect)) {
-      if (cache.texture != 0) {
-        markDirty(cache.renderDirty);
-        ClearCachedTexture(cache);
-        cache.textureSize = wxSize(0, 0);
-        cache.renderZoom = 0.0;
-      }
-      continue;
-    }
-    const wxSize renderSize = GetFrameSizeForZoom(legend.frame, renderZoom);
-    if (cache.renderZoom == 0.0 || cache.renderZoom != renderZoom ||
-        renderSize != cache.textureSize) {
-      markDirty(cache.renderDirty);
-    }
-  }
-
-  for (const auto &table : currentLayout.eventTables) {
-    EventTableCache &cache = GetEventTableCache(table.id);
-    wxRect frameRect;
-    if (!GetFrameRect(table.frame, frameRect)) {
-      if (cache.texture != 0) {
-        markDirty(cache.renderDirty);
-        ClearCachedTexture(cache);
-        cache.textureSize = wxSize(0, 0);
-        cache.renderZoom = 0.0;
-      }
-      continue;
-    }
-    const wxSize renderSize = GetFrameSizeForZoom(table.frame, renderZoom);
-    if (cache.renderZoom == 0.0 || cache.renderZoom != renderZoom ||
-        renderSize != cache.textureSize) {
-      markDirty(cache.renderDirty);
-    }
-  }
-
-  for (const auto &text : currentLayout.textViews) {
-    TextCache &cache = GetTextCache(text.id);
-    wxRect frameRect;
-    if (!GetFrameRect(text.frame, frameRect)) {
-      if (cache.texture != 0) {
-        markDirty(cache.renderDirty);
-        ClearCachedTexture(cache);
-        cache.textureSize = wxSize(0, 0);
-        cache.renderZoom = 0.0;
-      }
-      continue;
-    }
-    const wxSize renderSize = GetFrameSizeForZoom(text.frame, renderZoom);
-    if (cache.renderZoom == 0.0 || cache.renderZoom != renderZoom ||
-        renderSize != cache.textureSize) {
-      markDirty(cache.renderDirty);
-    }
-  }
-
-  for (const auto &image : currentLayout.imageViews) {
-    ImageCache &cache = GetImageCache(image.id);
-    wxRect frameRect;
-    if (!GetFrameRect(image.frame, frameRect)) {
-      if (cache.texture != 0) {
-        markDirty(cache.renderDirty);
-        ClearCachedTexture(cache);
-        cache.textureSize = wxSize(0, 0);
-        cache.renderZoom = 0.0;
-      }
-      continue;
-    }
-    const wxSize renderSize = GetFrameSizeForZoom(image.frame, renderZoom);
-    if (cache.renderZoom == 0.0 || cache.renderZoom != renderZoom ||
-        renderSize != cache.textureSize) {
-      markDirty(cache.renderDirty);
-    }
-  }
-
-  if (zoomChanged || pageChanged) {
-    renderDirty = true;
-  }
-  lastRenderZoom = renderZoom;
-  lastPageWidthPt = pageWidth;
-  lastPageHeightPt = pageHeight;
 }
 
 void LayoutViewerPanel::OnLoadingTimer(wxTimerEvent &) {

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -68,6 +68,7 @@ private:
     wxSize textureSize{0, 0};
     double renderZoom = 0.0;
     bool renderDirty = true;
+    size_t contentHash = 0;
   };
 
   struct LegendCache {
@@ -180,6 +181,7 @@ private:
   bool NeedsRenderRebuild() const;
   void RequestRenderRebuild();
   void InvalidateRenderIfFrameChanged();
+  size_t HashViewContent(const layouts::Layout2DViewDefinition &view) const;
   void OnLoadingTimer(wxTimerEvent &event);
   void OnRenderDelayTimer(wxTimerEvent &event);
   bool AreTexturesReady() const;

--- a/gui/layoutviewerpanel_render_invalidation.cpp
+++ b/gui/layoutviewerpanel_render_invalidation.cpp
@@ -1,0 +1,185 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "layoutviewerpanel.h"
+
+#include <functional>
+
+namespace {
+void HashCombine(size_t &seed, size_t value) {
+  seed ^= value + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+
+void HashCombineFloat(size_t &seed, float value) {
+  HashCombine(seed, std::hash<float>{}(value));
+}
+} // namespace
+
+size_t LayoutViewerPanel::HashViewContent(
+    const layouts::Layout2DViewDefinition &view) const {
+  size_t seed = std::hash<int>{}(view.id);
+  HashCombine(seed, std::hash<float>{}(view.camera.offsetPixelsX));
+  HashCombine(seed, std::hash<float>{}(view.camera.offsetPixelsY));
+  HashCombine(seed, std::hash<float>{}(view.camera.zoom));
+  HashCombine(seed, std::hash<int>{}(view.camera.view));
+  HashCombine(seed, std::hash<int>{}(view.renderOptions.renderMode));
+  HashCombine(seed, std::hash<bool>{}(view.renderOptions.darkMode));
+  HashCombine(seed, std::hash<bool>{}(view.renderOptions.showGrid));
+  HashCombine(seed, std::hash<int>{}(view.renderOptions.gridStyle));
+  HashCombineFloat(seed, view.renderOptions.gridColorR);
+  HashCombineFloat(seed, view.renderOptions.gridColorG);
+  HashCombineFloat(seed, view.renderOptions.gridColorB);
+  HashCombine(seed, std::hash<bool>{}(view.renderOptions.gridDrawAbove));
+
+  for (bool enabled : view.renderOptions.showLabelName)
+    HashCombine(seed, std::hash<bool>{}(enabled));
+  for (bool enabled : view.renderOptions.showLabelId)
+    HashCombine(seed, std::hash<bool>{}(enabled));
+  for (bool enabled : view.renderOptions.showLabelDmx)
+    HashCombine(seed, std::hash<bool>{}(enabled));
+  HashCombineFloat(seed, view.renderOptions.labelFontSizeName);
+  HashCombineFloat(seed, view.renderOptions.labelFontSizeId);
+  HashCombineFloat(seed, view.renderOptions.labelFontSizeDmx);
+  for (float distance : view.renderOptions.labelOffsetDistance)
+    HashCombineFloat(seed, distance);
+  for (float angle : view.renderOptions.labelOffsetAngle)
+    HashCombineFloat(seed, angle);
+
+  for (const auto &hiddenLayer : view.layers.hiddenLayers)
+    HashCombine(seed, std::hash<std::string>{}(hiddenLayer));
+  return seed;
+}
+
+void LayoutViewerPanel::InvalidateRenderIfFrameChanged() {
+  const double renderZoom = GetRenderZoom();
+  const double pageWidth = currentLayout.pageSetup.PageWidthPt();
+  const double pageHeight = currentLayout.pageSetup.PageHeightPt();
+  const bool zoomChanged = lastRenderZoom != renderZoom;
+  const bool pageChanged =
+      lastPageWidthPt != pageWidth || lastPageHeightPt != pageHeight;
+  auto markDirty = [&](bool &cacheDirty) {
+    if (cacheDirty)
+      return;
+    cacheDirty = true;
+  };
+
+  for (const auto &view : currentLayout.view2dViews) {
+    ViewCache &cache = GetViewCache(view.id);
+    const size_t contentHash = HashViewContent(view);
+    if (cache.contentHash != 0 && cache.contentHash != contentHash) {
+      markDirty(cache.renderDirty);
+    }
+    wxRect frameRect;
+    if (!GetFrameRect(view.frame, frameRect)) {
+      if (cache.texture != 0) {
+        markDirty(cache.renderDirty);
+        ClearCachedTexture(cache);
+        cache.textureSize = wxSize(0, 0);
+        cache.renderZoom = 0.0;
+      }
+      continue;
+    }
+    const wxSize renderSize = GetFrameSizeForZoom(view.frame, renderZoom);
+    if (cache.renderZoom == 0.0 || cache.renderZoom != renderZoom ||
+        renderSize != cache.textureSize) {
+      markDirty(cache.renderDirty);
+    }
+  }
+
+  for (const auto &legend : currentLayout.legendViews) {
+    LegendCache &cache = GetLegendCache(legend.id);
+    wxRect frameRect;
+    if (!GetFrameRect(legend.frame, frameRect)) {
+      if (cache.texture != 0) {
+        markDirty(cache.renderDirty);
+        ClearCachedTexture(cache);
+        cache.textureSize = wxSize(0, 0);
+        cache.renderZoom = 0.0;
+      }
+      continue;
+    }
+    const wxSize renderSize = GetFrameSizeForZoom(legend.frame, renderZoom);
+    if (cache.renderZoom == 0.0 || cache.renderZoom != renderZoom ||
+        renderSize != cache.textureSize) {
+      markDirty(cache.renderDirty);
+    }
+  }
+
+  for (const auto &table : currentLayout.eventTables) {
+    EventTableCache &cache = GetEventTableCache(table.id);
+    wxRect frameRect;
+    if (!GetFrameRect(table.frame, frameRect)) {
+      if (cache.texture != 0) {
+        markDirty(cache.renderDirty);
+        ClearCachedTexture(cache);
+        cache.textureSize = wxSize(0, 0);
+        cache.renderZoom = 0.0;
+      }
+      continue;
+    }
+    const wxSize renderSize = GetFrameSizeForZoom(table.frame, renderZoom);
+    if (cache.renderZoom == 0.0 || cache.renderZoom != renderZoom ||
+        renderSize != cache.textureSize) {
+      markDirty(cache.renderDirty);
+    }
+  }
+
+  for (const auto &text : currentLayout.textViews) {
+    TextCache &cache = GetTextCache(text.id);
+    wxRect frameRect;
+    if (!GetFrameRect(text.frame, frameRect)) {
+      if (cache.texture != 0) {
+        markDirty(cache.renderDirty);
+        ClearCachedTexture(cache);
+        cache.textureSize = wxSize(0, 0);
+        cache.renderZoom = 0.0;
+      }
+      continue;
+    }
+    const wxSize renderSize = GetFrameSizeForZoom(text.frame, renderZoom);
+    if (cache.renderZoom == 0.0 || cache.renderZoom != renderZoom ||
+        renderSize != cache.textureSize) {
+      markDirty(cache.renderDirty);
+    }
+  }
+
+  for (const auto &image : currentLayout.imageViews) {
+    ImageCache &cache = GetImageCache(image.id);
+    wxRect frameRect;
+    if (!GetFrameRect(image.frame, frameRect)) {
+      if (cache.texture != 0) {
+        markDirty(cache.renderDirty);
+        ClearCachedTexture(cache);
+        cache.textureSize = wxSize(0, 0);
+        cache.renderZoom = 0.0;
+      }
+      continue;
+    }
+    const wxSize renderSize = GetFrameSizeForZoom(image.frame, renderZoom);
+    if (cache.renderZoom == 0.0 || cache.renderZoom != renderZoom ||
+        renderSize != cache.textureSize) {
+      markDirty(cache.renderDirty);
+    }
+  }
+
+  if (zoomChanged || pageChanged) {
+    renderDirty = true;
+  }
+  lastRenderZoom = renderZoom;
+  lastPageWidthPt = pageWidth;
+  lastPageHeightPt = pageHeight;
+}


### PR DESCRIPTION
### Motivation
- Reduce unnecessary full-cache invalidations in layout mode by detecting real content changes (camera, render options, layers) instead of marking everything dirty on any parameter change.
- Keep `layoutviewerpanel.cpp` growth in check by extracting invalidation logic to a focused translation unit as an incremental refactor step.

### Description
- Added `contentHash` to `ViewCache` and declared a new `HashViewContent(...)` helper to compute a stable hash of a view's content (camera, render options, hidden layers, label settings).  
- Implemented `HashViewContent(...)` and moved `InvalidateRenderIfFrameChanged()` into a new file `gui/layoutviewerpanel_render_invalidation.cpp`, where view caches are marked dirty only when the computed content hash changes while preserving zoom/page/frame-size-based invalidation.  
- Persist the computed view `contentHash` after a successful view texture rebuild so future invalidation checks are incremental.  
- Registered the new translation unit in `gui/CMakeLists.txt` and added the header declaration for `HashViewContent(...)` in `gui/layoutviewerpanel.h`.

### Testing
- Executed `tests/check_perastage_tree_modules.sh` which returned OK.  
- Executed `tests/check_no_configmanager_get_in_gui.sh` which returned OK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69987e1827188324a0a333a692ab3a84)