### PR TITLE
Optimize text extent calculations for legend and event table rendering

### DIFF
--- a/gui/layoutviewerpanel_eventtable.cpp
+++ b/gui/layoutviewerpanel_eventtable.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <array>
 #include <functional>
+#include <unordered_map>
 
 // Include GLEW or other OpenGL loader first if present
 #ifdef __APPLE__
@@ -297,13 +298,34 @@ wxImage LayoutViewerPanel::BuildEventTableImage(
       layoutviewerpanel::detail::MakeSharedFont(emphasizedFontSizePx,
                                                 wxFONTWEIGHT_BOLD);
 
+  std::unordered_map<wxString, wxSize, wxStringHash, wxStringEqual>
+      labelTextExtentCache;
+  std::unordered_map<wxString, wxSize, wxStringHash, wxStringEqual>
+      baseTextExtentCache;
+  std::unordered_map<wxString, wxSize, wxStringHash, wxStringEqual>
+      emphasizedTextExtentCache;
+
+  auto measureTextExtent =
+      [&](const wxString &text,
+          std::unordered_map<wxString, wxSize, wxStringHash, wxStringEqual>
+              &cache) {
+        auto cacheIt = cache.find(text);
+        if (cacheIt != cache.end())
+          return cacheIt->second;
+        int width = 0;
+        int height = 0;
+        dc.GetTextExtent(text, &width, &height);
+        wxSize sizeMeasured(width, height);
+        cache.emplace(text, sizeMeasured);
+        return sizeMeasured;
+      };
+
   dc.SetFont(labelFont);
   int maxLabelWidth = 0;
   for (const auto &label : kEventTableLabels) {
-    int w = 0;
-    int h = 0;
-    dc.GetTextExtent(wxString::FromUTF8(label), &w, &h);
-    maxLabelWidth = std::max(maxLabelWidth, w);
+    const wxSize labelSize =
+        measureTextExtent(wxString::FromUTF8(label), labelTextExtentCache);
+    maxLabelWidth = std::max(maxLabelWidth, labelSize.GetWidth());
   }
 
   const int paddingLeftPx =
@@ -324,23 +346,22 @@ wxImage LayoutViewerPanel::BuildEventTableImage(
   const int maxValueWidth =
       std::max(0, size.GetWidth() - paddingRightPx - valueX);
 
-  auto trimTextToWidth = [&](const wxString &text, int maxWidth) {
+  auto trimTextToWidth =
+      [&](const wxString &text, int maxWidth,
+          std::unordered_map<wxString, wxSize, wxStringHash, wxStringEqual>
+              &cache) {
     if (maxWidth <= 0)
       return wxString();
-    int textWidth = 0;
-    int textHeight = 0;
-    dc.GetTextExtent(text, &textWidth, &textHeight);
+    int textWidth = measureTextExtent(text, cache).GetWidth();
     if (textWidth <= maxWidth)
       return text;
     wxString ellipsis = "...";
-    int ellipsisWidth = 0;
-    int ellipsisHeight = 0;
-    dc.GetTextExtent(ellipsis, &ellipsisWidth, &ellipsisHeight);
+    const int ellipsisWidth = measureTextExtent(ellipsis, cache).GetWidth();
     if (ellipsisWidth >= maxWidth)
       return ellipsis.Left(1);
     wxString trimmed = text;
     while (!trimmed.empty()) {
-      dc.GetTextExtent(trimmed, &textWidth, &textHeight);
+      textWidth = measureTextExtent(trimmed, cache).GetWidth();
       if (textWidth + ellipsisWidth <= maxWidth)
         break;
       trimmed.RemoveLast();
@@ -352,9 +373,8 @@ wxImage LayoutViewerPanel::BuildEventTableImage(
     const int rowTop = paddingTopPx + static_cast<int>(idx) * rowHeightPx;
     wxString labelText = wxString::FromUTF8(kEventTableLabels[idx]);
     dc.SetFont(labelFont);
-    int labelHeight = 0;
-    int labelWidth = 0;
-    dc.GetTextExtent(labelText, &labelWidth, &labelHeight);
+    const wxSize labelSize = measureTextExtent(labelText, labelTextExtentCache);
+    const int labelHeight = labelSize.GetHeight();
     int labelY = rowTop + (rowHeightPx - labelHeight) / 2;
     dc.DrawText(labelText, labelX, labelY);
 
@@ -367,10 +387,12 @@ wxImage LayoutViewerPanel::BuildEventTableImage(
     } else {
       dc.SetFont(baseFont);
     }
-    wxString trimmed = trimTextToWidth(valueText, maxValueWidth);
-    int valueHeight = 0;
-    int valueWidth = 0;
-    dc.GetTextExtent(trimmed, &valueWidth, &valueHeight);
+    auto &valueTextExtentCache =
+        (idx == 0) ? emphasizedTextExtentCache : baseTextExtentCache;
+    wxString trimmed = trimTextToWidth(valueText, maxValueWidth,
+                                       valueTextExtentCache);
+    const int valueHeight =
+        measureTextExtent(trimmed, valueTextExtentCache).GetHeight();
     int valueY = rowTop + (rowHeightPx - valueHeight) / 2;
     dc.DrawText(trimmed, valueX, valueY);
   }

--- a/gui/layoutviewerpanel_legend.cpp
+++ b/gui/layoutviewerpanel_legend.cpp
@@ -24,6 +24,7 @@
 #include <functional>
 #include <limits>
 #include <map>
+#include <unordered_map>
 #include <vector>
 
 // Include GLEW or other OpenGL loader first if present
@@ -861,23 +862,49 @@ wxImage LayoutViewerPanel::BuildLegendImage(
       layoutviewerpanel::detail::MakeSharedFont(fontSizePx,
                                                 wxFONTWEIGHT_BOLD);
 
+  std::unordered_map<wxString, wxSize, wxStringHash, wxStringEqual>
+      baseTextExtentCache;
+  auto measureTextExtent =
+      [&](const wxString &text,
+          std::unordered_map<wxString, wxSize, wxStringHash, wxStringEqual>
+              &cache) {
+        auto cacheIt = cache.find(text);
+        if (cacheIt != cache.end())
+          return cacheIt->second;
+        int width = 0;
+        int height = 0;
+        dc.GetTextExtent(text, &width, &height);
+        wxSize sizeMeasured(width, height);
+        cache.emplace(text, sizeMeasured);
+        return sizeMeasured;
+      };
+
   auto measureTextWidth = [&](const wxString &text) {
-    int w = 0;
-    int h = 0;
-    dc.GetTextExtent(text, &w, &h);
-    return w;
+    return measureTextExtent(text, baseTextExtentCache).GetWidth();
   };
+
+  struct LegendRowText {
+    wxString countText;
+    wxString typeText;
+    wxString chText;
+  };
+  std::vector<LegendRowText> rowTexts;
+  rowTexts.reserve(items.size());
+  for (const auto &item : items) {
+    rowTexts.push_back({
+        wxString::Format("%d", item.count),
+        wxString::FromUTF8(item.typeName),
+        item.channelCount.has_value()
+            ? wxString::Format("%d", item.channelCount.value())
+            : wxString("-")});
+  }
 
   dc.SetFont(baseFont);
   int maxCountWidth = measureTextWidth("Count");
   int maxChWidth = measureTextWidth("Ch");
-  for (const auto &item : items) {
-    maxCountWidth = std::max(
-        maxCountWidth, measureTextWidth(wxString::Format("%d", item.count)));
-    wxString chText = item.channelCount.has_value()
-                          ? wxString::Format("%d", item.channelCount.value())
-                          : wxString("-");
-    maxChWidth = std::max(maxChWidth, measureTextWidth(chText));
+  for (const auto &row : rowTexts) {
+    maxCountWidth = std::max(maxCountWidth, measureTextWidth(row.countText));
+    maxChWidth = std::max(maxChWidth, measureTextWidth(row.chText));
   }
   const int leftTrimPx = measureTextWidth("000");
   const int chExtraWidthPx = measureTextWidth("0");
@@ -998,15 +1025,12 @@ wxImage LayoutViewerPanel::BuildLegendImage(
 
   dc.SetFont(baseFont);
   LegendSymbolBackend backend(dc);
-  for (const auto &item : items) {
+  for (size_t index = 0; index < items.size(); ++index) {
+    const auto &item = items[index];
+    const auto &rowText = rowTexts[index];
     if (y + rowHeightPx > size.GetHeight() - paddingBottomPx)
       break;
-    wxString countText = wxString::Format("%d", item.count);
-    wxString typeText =
-        trimTextToWidth(wxString::FromUTF8(item.typeName), typeWidth);
-    wxString chText = item.channelCount.has_value()
-                          ? wxString::Format("%d", item.channelCount.value())
-                          : wxString("-");
+    wxString typeText = trimTextToWidth(rowText.typeText, typeWidth);
     if (symbols && !item.symbolKey.empty()) {
       const SymbolDefinition *topSymbol = FindSymbolDefinitionPreferred(
           symbols, item.symbolKey, SymbolViewKind::Top);
@@ -1076,9 +1100,9 @@ wxImage LayoutViewerPanel::BuildLegendImage(
         }
       }
     }
-    dc.DrawText(countText, xCount, y + textOffset);
+    dc.DrawText(rowText.countText, xCount, y + textOffset);
     dc.DrawText(typeText, xType, y + textOffset);
-    dc.DrawText(chText, xCh, y + textOffset);
+    dc.DrawText(rowText.chText, xCh, y + textOffset);
     y += rowHeightPx;
   }
 


### PR DESCRIPTION
### Motivation
- Reduce CPU cost during legend and event table rendering by eliminating repeated `dc.GetTextExtent()` calls in `BuildLegendImage()` and `BuildEventTableImage()` without changing visual output.
- Keep changes local to existing renderer functions to avoid UI/behavior regressions while improving performance.
- Files touched are GUI hotspots; extraction was not feasible in this small PR, so a short follow-up split is recommended (see Description).

### Description
- Added per-render text-extent caches (`std::unordered_map<wxString, wxSize>`) and a `measureTextExtent` helper to avoid repeated `dc.GetTextExtent()` calls in both `BuildLegendImage()` and `BuildEventTableImage()`.
- Precomputed per-row text (`count/type/ch`) for the legend and reused those strings for both column-width calculation and drawing to avoid repeated formatting and measurement.
- In the event table renderer implemented separate caches per font/style (label/base/emphasized) and reused cached extents for trimming and vertical centering.
- Did not change drawing order or symbol rendering (did not implement grouping or a preference toggle) to ensure no visual differences; recommended follow-up extraction: move legend/event-table measurement and trimming helpers into a small helper file (e.g. `gui/layoutviewerpanel_legend_helpers.{cpp,h}`) if further refactors are needed.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed.
- Attempted `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` which failed in this environment due to missing `wxWidgets` (environment dependency, not a code failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699880f021808324bc183e00ef0e0e77)