### PR TITLE
Peraviz: render gobos inside legacy and volumetric beams via cached shader materials

### DIFF
--- a/peraviz/docs/BEAM_RENDERING_MODES.md
+++ b/peraviz/docs/BEAM_RENDERING_MODES.md
@@ -5,6 +5,12 @@ Peraviz now provides two beam rendering modes in **Visual Settings**:
 - **Volumetric (default)**: realistic haze shaft rendering with distance attenuation, view-dependent scattering, soft end fade and quality presets.
 - **Lightweight (legacy)**: previous cone-based beam rendering for low-resource systems.
 
+## Gobo in beam behavior
+
+- Surface footprint projection remains unchanged and still relies on `SpotLight3D.light_projector`.
+- Beam gobo visibility is implemented in beam shaders by modulation, using a gobo-aware material cache keyed by projector texture RID.
+- Cached beam materials update immediately when beam gobo settings change, without rebuilding fixture beam nodes.
+
 ## Performance guidance
 
 - Use **Volumetric + Low** on integrated GPUs.

--- a/peraviz/scripts/beam_renderers/beam_renderer_base.gd
+++ b/peraviz/scripts/beam_renderers/beam_renderer_base.gd
@@ -13,3 +13,6 @@ func update_beam(_light: SpotLight3D, _params: Dictionary) -> void:
 
 func cleanup_beam(_light: SpotLight3D) -> void:
 	pass
+
+func clear_cached_materials() -> void:
+	pass

--- a/peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd
@@ -10,32 +10,44 @@ const EMITTER_CONE_NEAR_EMISSION: float = 0.45
 const EMITTER_CONE_FAR_EMISSION: float = 0.04
 
 const MAIN_KEY: String = "peraviz_beam_cone"
-const MID_KEY: String = "peraviz_beam_cone_mid"
+const OVERLAY_KEY: String = "peraviz_beam_cone_overlay"
 const CORE_KEY: String = "peraviz_beam_cone_core"
 
+const GoboBeamMaterialCacheScript = preload("res://scripts/rendering/gobo_beam_material_cache.gd")
+
 var _shared_material: ShaderMaterial
+var _settings: Dictionary = {}
+var _camera: Camera3D
+var _gobo_material_cache: GoboBeamMaterialCache
 
 func _init() -> void:
 	_shared_material = ShaderMaterial.new()
 	_shared_material.shader = load("res://scripts/shaders/legacy_beam_cone.gdshader")
+	_gobo_material_cache = GoboBeamMaterialCacheScript.new()
+	_gobo_material_cache.configure_base_material(_shared_material)
+
+func configure(view_camera: Camera3D, settings: Dictionary) -> void:
+	_camera = view_camera
+	_settings = settings.duplicate(true)
+	_gobo_material_cache.apply_settings_to_all_cached_materials(_settings)
 
 func ensure_beam(light: SpotLight3D) -> void:
 	if not light.has_meta(MAIN_KEY):
 		light.set_meta(MAIN_KEY, _create_cone("PeravizBeamCone"))
-	if not light.has_meta(MID_KEY):
-		light.set_meta(MID_KEY, _create_cone("PeravizBeamMidCone"))
+	if not light.has_meta(OVERLAY_KEY):
+		light.set_meta(OVERLAY_KEY, _create_cone("PeravizBeamOverlayCone"))
 	if not light.has_meta(CORE_KEY):
 		light.set_meta(CORE_KEY, _create_cone("PeravizBeamCoreCone"))
 
 func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	ensure_beam(light)
 	var cone: MeshInstance3D = light.get_meta(MAIN_KEY) as MeshInstance3D
-	var mid_cone: MeshInstance3D = light.get_meta(MID_KEY) as MeshInstance3D
+	var overlay_cone: MeshInstance3D = light.get_meta(OVERLAY_KEY) as MeshInstance3D
 	var core_cone: MeshInstance3D = light.get_meta(CORE_KEY) as MeshInstance3D
-	if cone == null and mid_cone == null and core_cone == null:
+	if cone == null and overlay_cone == null and core_cone == null:
 		return
 	_attach_if_needed(light, cone)
-	_attach_if_needed(light, mid_cone)
+	_attach_if_needed(light, overlay_cone)
 	_attach_if_needed(light, core_cone)
 
 	var intensity: float = clamp(float(params.get("normalized_dimmer", 0.0)), 0.0, 1.0)
@@ -46,36 +58,68 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	var lens_radius: float = max(float(params.get("lens_radius", 0.03)), 0.005)
 	var is_visible: bool = bool(params.get("is_visible", true)) and intensity > 0.015
 
+	var cone_count: int = int(clamp(int(_settings.get("legacy_cone_count", 2)), 2, 3))
 	if cone != null:
 		cone.visible = is_visible
-	if mid_cone != null:
-		mid_cone.visible = is_visible
+	if overlay_cone != null:
+		overlay_cone.visible = is_visible
 	if core_cone != null:
-		core_cone.visible = is_visible
+		core_cone.visible = is_visible and cone_count >= 3
 	if not is_visible:
 		return
 
 	var beam_half_angle_deg: float = beam_angle * 0.5
 	var radius: float = tan(deg_to_rad(beam_half_angle_deg)) * beam_range
 	var bottom_radius: float = clamp(radius, 0.03, EMITTER_CONE_MAX_BASE_RADIUS_M)
+	var overlay_scale: float = clamp(float(_settings.get("legacy_overlay_scale", 0.96)), 0.85, 0.995)
+	var core_scale: float = clamp(float(_settings.get("legacy_core_scale", 0.92)), 0.8, 0.99)
 
 	_update_cone_geometry(cone, lens_radius, bottom_radius, beam_range, 1.0)
-	_update_cone_geometry(mid_cone, lens_radius, bottom_radius, beam_range, 0.7)
-	_update_cone_geometry(core_cone, lens_radius, bottom_radius, beam_range, 0.45)
+	_update_cone_geometry(overlay_cone, lens_radius, bottom_radius, beam_range, overlay_scale)
+	if cone_count >= 3:
+		_update_cone_geometry(core_cone, lens_radius, bottom_radius, beam_range, core_scale)
+
+	var beam_gobo_enabled: bool = bool(_settings.get("beam_gobo_enabled", true))
+	var gobo_texture: Texture2D = light.light_projector if light.light_projector is Texture2D else null
+	if beam_gobo_enabled:
+		beam_gobo_enabled = gobo_texture != null
+	if beam_gobo_enabled:
+		var max_distance: float = float(_settings.get("legacy_beam_gobo_max_distance", 90.0))
+		if _camera != null and max_distance > 0.0:
+			var cam_distance: float = _camera.global_position.distance_to(light.global_position)
+			if cam_distance > max_distance:
+				beam_gobo_enabled = false
+
+	var overlay_material: ShaderMaterial = _gobo_material_cache.resolve_material(
+		_shared_material,
+		gobo_texture,
+		_settings,
+		beam_gobo_enabled
+	)
+	if cone != null:
+		cone.material_override = _shared_material
+	if overlay_cone != null:
+		overlay_cone.material_override = overlay_material
+	if core_cone != null:
+		core_cone.material_override = _shared_material
 
 	var color_alpha := Color(beam_color.r, beam_color.g, beam_color.b, 1.0)
 	_update_cone_material(cone, color_alpha, scaled_intensity, beam_range, 0.35, 0.16, 0.06, 1.0, 1.0)
-	_update_cone_material(mid_cone, color_alpha, scaled_intensity, beam_range, 0.18, 0.26, 0.04, 1.35, 1.25)
-	_update_cone_material(core_cone, color_alpha, scaled_intensity, beam_range, 0.09, 0.35, 0.02, 1.7, 1.5)
+	_update_cone_material(overlay_cone, color_alpha, scaled_intensity, beam_range, 0.24, 0.26, 0.04, 1.05, 1.25)
+	if cone_count >= 3:
+		_update_cone_material(core_cone, color_alpha, scaled_intensity, beam_range, 0.18, 0.3, 0.03, 0.95, 1.35)
 
 func cleanup_beam(light: SpotLight3D) -> void:
-	for meta_key in [MAIN_KEY, MID_KEY, CORE_KEY]:
+	for meta_key in [MAIN_KEY, OVERLAY_KEY, CORE_KEY]:
 		if not light.has_meta(meta_key):
 			continue
 		var cone: MeshInstance3D = light.get_meta(meta_key) as MeshInstance3D
 		if cone != null and is_instance_valid(cone):
 			cone.queue_free()
 		light.remove_meta(meta_key)
+
+func clear_cached_materials() -> void:
+	_gobo_material_cache.clear()
 
 func _attach_if_needed(light: SpotLight3D, cone: MeshInstance3D) -> void:
 	if cone != null and cone.get_parent() == null:

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -6,17 +6,23 @@ const BEAM_META_KEY: String = "peraviz_volumetric_beam"
 const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 10.0
 const VOLUMETRIC_INTENSITY_SCALE: float = 0.62
 
+const GoboBeamMaterialCacheScript = preload("res://scripts/rendering/gobo_beam_material_cache.gd")
+
 var _shared_material: ShaderMaterial
 var _camera: Camera3D
 var _settings: Dictionary = {}
+var _gobo_material_cache: GoboBeamMaterialCache
 
 func _init() -> void:
 	_shared_material = ShaderMaterial.new()
 	_shared_material.shader = load("res://scripts/shaders/volumetric_beam.gdshader")
+	_gobo_material_cache = GoboBeamMaterialCacheScript.new()
+	_gobo_material_cache.configure_base_material(_shared_material)
 
 func configure(view_camera: Camera3D, settings: Dictionary) -> void:
 	_camera = view_camera
 	_settings = settings.duplicate(true)
+	_gobo_material_cache.apply_settings_to_all_cached_materials(_settings)
 
 func ensure_beam(light: SpotLight3D) -> void:
 	if light.has_meta(BEAM_META_KEY):
@@ -74,6 +80,12 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	cone.position = Vector3(0.0, 0.0, -beam_range * 0.5)
 	cone.visible = true
 
+	var beam_gobo_enabled: bool = bool(_settings.get("beam_gobo_enabled", true))
+	var gobo_texture: Texture2D = light.light_projector if light.light_projector is Texture2D else null
+	if beam_gobo_enabled:
+		beam_gobo_enabled = gobo_texture != null
+	cone.material_override = _gobo_material_cache.resolve_material(_shared_material, gobo_texture, _settings, beam_gobo_enabled)
+
 	var intensity_alpha: float = clamp(intensity * VOLUMETRIC_INTENSITY_SCALE, 0.0, 1.0)
 	cone.set_instance_shader_parameter("base_color", Color(beam_color.r, beam_color.g, beam_color.b, intensity_alpha))
 	cone.set_instance_shader_parameter("falloff_power", 8.0)
@@ -97,3 +109,6 @@ func cleanup_beam(light: SpotLight3D) -> void:
 	if cone != null and is_instance_valid(cone):
 		cone.queue_free()
 	light.remove_meta(BEAM_META_KEY)
+
+func clear_cached_materials() -> void:
+	_gobo_material_cache.clear()

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -62,6 +62,15 @@ var _visual_settings := {
 	"beam_anisotropy": 0.62,
 	"beam_noise_amount": 0.06,
 	"beam_noise_scale": 1.4,
+	"beam_gobo_enabled": true,
+	"beam_gobo_strength": 1.0,
+	"beam_gobo_softness": 0.0,
+	"beam_gobo_gamma": 1.0,
+	"beam_gobo_rotation": 0.0,
+	"legacy_cone_count": 2,
+	"legacy_overlay_scale": 0.96,
+	"legacy_core_scale": 0.92,
+	"legacy_beam_gobo_max_distance": 90.0,
 	"background_color": Color(0.129412, 0.137255, 0.156863, 1.0),
 }
 
@@ -996,6 +1005,9 @@ func _clear_scene() -> void:
 	_fixture_emitter_photometrics.clear()
 	if _fixture_gobo_projector != null:
 		_fixture_gobo_projector.clear_cache()
+	for renderer in _beam_renderers.values():
+		if renderer is BeamRendererBase:
+			renderer.clear_cached_materials()
 	_has_loaded_bounds = false
 	_clear_debug_gizmos()
 
@@ -1833,9 +1845,9 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 		"intensity_visibility_threshold": BEAM_INTENSITY_VISIBILITY_THRESHOLD,
 		"distance_cull_m": BEAM_DISTANCE_CULL_M,
 	}
-	_update_beam_for_light(light, beam_params)
 	if _fixture_gobo_projector != null:
 		_fixture_gobo_projector.apply_gobo_projection(light, controls)
+	_update_beam_for_light(light, beam_params)
 
 func _resolve_zoom_beam_limits(light: SpotLight3D, controls: Dictionary) -> Dictionary:
 	# min/max beam angles are kept as full GDTF beam apertures (not half-angle).

--- a/peraviz/scripts/rendering/gobo_beam_material_cache.gd
+++ b/peraviz/scripts/rendering/gobo_beam_material_cache.gd
@@ -1,0 +1,58 @@
+extends RefCounted
+class_name GoboBeamMaterialCache
+
+var _base_material: ShaderMaterial
+var _material_cache: Dictionary = {}
+
+func configure_base_material(base_material: ShaderMaterial) -> void:
+	_base_material = base_material
+
+func clear() -> void:
+	_material_cache.clear()
+
+func resolve_material(base_material: ShaderMaterial, gobo_tex: Texture2D, settings: Dictionary, enable_flag: bool) -> ShaderMaterial:
+	if base_material == null:
+		return null
+	if _base_material == null or _base_material != base_material:
+		configure_base_material(base_material)
+
+	if not enable_flag or gobo_tex == null:
+		_apply_gobo_uniforms(base_material, settings, false)
+		base_material.set_shader_parameter("gobo_texture", null)
+		return base_material
+
+	var rid_key: int = int(gobo_tex.get_rid().get_id())
+	if rid_key <= 0:
+		_apply_gobo_uniforms(base_material, settings, false)
+		base_material.set_shader_parameter("gobo_texture", null)
+		return base_material
+
+	if not _material_cache.has(rid_key):
+		var cached_material: ShaderMaterial = base_material.duplicate() as ShaderMaterial
+		cached_material.set_shader_parameter("gobo_texture", gobo_tex)
+		_material_cache[rid_key] = cached_material
+
+	var resolved_material: ShaderMaterial = _material_cache[rid_key] as ShaderMaterial
+	if resolved_material == null:
+		_apply_gobo_uniforms(base_material, settings, false)
+		base_material.set_shader_parameter("gobo_texture", null)
+		return base_material
+
+	_apply_gobo_uniforms(resolved_material, settings, true)
+	return resolved_material
+
+func apply_settings_to_all_cached_materials(settings: Dictionary) -> void:
+	if _base_material != null:
+		_apply_gobo_uniforms(_base_material, settings, false)
+	for material in _material_cache.values():
+		if material is ShaderMaterial:
+			_apply_gobo_uniforms(material, settings, true)
+
+func _apply_gobo_uniforms(material: ShaderMaterial, settings: Dictionary, enabled: bool) -> void:
+	if material == null:
+		return
+	material.set_shader_parameter("gobo_enabled", enabled)
+	material.set_shader_parameter("gobo_strength", clamp(float(settings.get("beam_gobo_strength", 1.0)), 0.0, 1.0))
+	material.set_shader_parameter("gobo_mip_bias", clamp(float(settings.get("beam_gobo_softness", 0.0)), 0.0, 6.0))
+	material.set_shader_parameter("gobo_gamma", clamp(float(settings.get("beam_gobo_gamma", 1.0)), 0.25, 4.0))
+	material.set_shader_parameter("gobo_rotation_rad", clamp(float(settings.get("beam_gobo_rotation", 0.0)), -6.283, 6.283))

--- a/peraviz/scripts/rendering/gobo_beam_material_cache.gd.uid
+++ b/peraviz/scripts/rendering/gobo_beam_material_cache.gd.uid
@@ -1,0 +1,1 @@
+uid://drwo64hzv3f6o

--- a/peraviz/scripts/shaders/legacy_beam_cone.gdshader
+++ b/peraviz/scripts/shaders/legacy_beam_cone.gdshader
@@ -13,7 +13,28 @@ instance uniform float lateral_emission_boost = 0.16;
 instance uniform float volumetric_noise_strength = 0.06;
 instance uniform float volumetric_noise_scale = 14.0;
 
+uniform bool gobo_enabled = false;
+uniform sampler2D gobo_texture : source_color, filter_linear_mipmap, repeat_disable;
+uniform float gobo_strength : hint_range(0.0, 1.0) = 1.0;
+uniform float gobo_rotation_rad : hint_range(-6.283, 6.283) = 0.0;
+uniform float gobo_mip_bias : hint_range(0.0, 6.0) = 0.0;
+uniform float gobo_gamma : hint_range(0.25, 4.0) = 1.0;
+
 varying float beam_axial;
+
+float sample_gobo_polar(float axial01, float angle01) {
+	vec2 centered_uv = vec2(angle01 - 0.5, axial01 - 0.5);
+	float cos_r = cos(gobo_rotation_rad);
+	float sin_r = sin(gobo_rotation_rad);
+	vec2 rotated = vec2(
+		(centered_uv.x * cos_r) - (centered_uv.y * sin_r),
+		(centered_uv.x * sin_r) + (centered_uv.y * cos_r)
+	);
+	vec2 sample_uv = clamp(rotated + vec2(0.5), vec2(0.0), vec2(1.0));
+	float sampled = textureLod(gobo_texture, sample_uv, gobo_mip_bias).r;
+	float curved = pow(clamp(sampled, 0.0, 1.0), max(gobo_gamma, 0.001));
+	return mix(1.0, curved, clamp(gobo_strength, 0.0, 1.0));
+}
 
 void vertex() {
 	float normalized_y = (VERTEX.y / max(cone_height, 0.0001)) + 0.5;
@@ -29,7 +50,11 @@ void fragment() {
 	float axial_noise = sin((beam_axial * volumetric_noise_scale) + (TIME * 0.9));
 	float beam_noise = 1.0 + (axial_noise * volumetric_noise_strength);
 	float center_boost = (1.0 + (lateral_emission_boost * lateral_fade)) * beam_noise;
+	float gobo_mult = 1.0;
+	if (gobo_enabled) {
+		gobo_mult = sample_gobo_polar(near_factor, fract(UV.x));
+	}
 	ALBEDO = beam_color.rgb;
-	ALPHA = mix(far_alpha, near_alpha, near_factor) * end_fade * lateral_fade;
-	EMISSION = beam_color.rgb * (mix(far_emission, near_emission, near_factor) * end_fade * center_boost);
+	ALPHA = mix(far_alpha, near_alpha, near_factor) * end_fade * lateral_fade * gobo_mult;
+	EMISSION = beam_color.rgb * (mix(far_emission, near_emission, near_factor) * end_fade * center_boost * gobo_mult);
 }

--- a/peraviz/scripts/shaders/volumetric_beam.gdshader
+++ b/peraviz/scripts/shaders/volumetric_beam.gdshader
@@ -2,6 +2,12 @@ shader_type spatial;
 render_mode unshaded, blend_add, cull_disabled, depth_draw_opaque;
 
 uniform sampler2D DEPTH_TEXTURE : hint_depth_texture, filter_linear_mipmap;
+uniform bool gobo_enabled = false;
+uniform sampler2D gobo_texture : source_color, filter_linear_mipmap, repeat_disable;
+uniform float gobo_strength : hint_range(0.0, 1.0) = 1.0;
+uniform float gobo_rotation_rad : hint_range(-6.283, 6.283) = 0.0;
+uniform float gobo_mip_bias : hint_range(0.0, 6.0) = 0.0;
+uniform float gobo_gamma : hint_range(0.25, 4.0) = 1.0;
 
 instance uniform vec4 base_color : source_color = vec4(1.0, 0.95, 0.85, 0.5);
 instance uniform float falloff_power : hint_range(0.1, 10.0) = 8.0;
@@ -19,6 +25,20 @@ instance uniform bool depth_feather_enabled = true;
 instance uniform float depth_fade_distance : hint_range(0.01, 5.0) = 0.5;
 
 varying vec3 vertex_view;
+
+float sample_gobo_polar(float axial01, float angle01) {
+	vec2 centered_uv = vec2(angle01 - 0.5, axial01 - 0.5);
+	float cos_r = cos(gobo_rotation_rad);
+	float sin_r = sin(gobo_rotation_rad);
+	vec2 rotated = vec2(
+		(centered_uv.x * cos_r) - (centered_uv.y * sin_r),
+		(centered_uv.x * sin_r) + (centered_uv.y * cos_r)
+	);
+	vec2 sample_uv = clamp(rotated + vec2(0.5), vec2(0.0), vec2(1.0));
+	float sampled = textureLod(gobo_texture, sample_uv, gobo_mip_bias).r;
+	float curved = pow(clamp(sampled, 0.0, 1.0), max(gobo_gamma, 0.001));
+	return mix(1.0, curved, clamp(gobo_strength, 0.0, 1.0));
+}
 
 void vertex() {
 	vertex_view = (MODELVIEW_MATRIX * vec4(VERTEX, 1.0)).xyz;
@@ -49,6 +69,10 @@ void fragment() {
 
 	float brightness = min(base_brightness * facing_multiplier, max_brightness);
 	float feather_alpha = mix(1.0 - feather_intensity, 1.0, pow(ndotv, feather_sharpness));
+	float gobo_mult = 1.0;
+	if (gobo_enabled) {
+		gobo_mult = sample_gobo_polar(1.0 - UV.y, fract(UV.x));
+	}
 
 	float depth_mult = 1.0;
 	if (depth_feather_enabled) {
@@ -61,8 +85,8 @@ void fragment() {
 		}
 	}
 
-	float final_alpha = feather_alpha * depth_mult * dist_fade;
-	ALBEDO = base_color.rgb * brightness;
+	float final_alpha = feather_alpha * depth_mult * dist_fade * gobo_mult;
+	ALBEDO = base_color.rgb * (brightness * gobo_mult);
 	ALPHA = clamp(final_alpha * base_color.a, 0.0, 1.0);
 	EMISSION = ALBEDO * ALPHA;
 }

--- a/peraviz/scripts/visual_settings_window.gd
+++ b/peraviz/scripts/visual_settings_window.gd
@@ -15,25 +15,42 @@ const DEFAULT_SETTINGS := {
 	"beam_anisotropy": 0.62,
 	"beam_noise_amount": 0.06,
 	"beam_noise_scale": 1.4,
+	"beam_gobo_enabled": true,
+	"beam_gobo_strength": 1.0,
+	"beam_gobo_softness": 0.0,
+	"beam_gobo_gamma": 1.0,
+	"beam_gobo_rotation": 0.0,
+	"legacy_cone_count": 2,
+	"legacy_overlay_scale": 0.96,
+	"legacy_core_scale": 0.92,
+	"legacy_beam_gobo_max_distance": 90.0,
 	"background_color": Color(0.129412, 0.137255, 0.156863, 1.0),
 }
 
 var _settings: Dictionary = DEFAULT_SETTINGS.duplicate(true)
+var _value_labels: Dictionary = {}
+
 var _ambient_slider: HSlider
-var _ambient_value_label: Label
 var _spot_slider: HSlider
-var _spot_value_label: Label
 var _beam_slider: HSlider
-var _beam_value_label: Label
 var _bloom_slider: HSlider
-var _bloom_value_label: Label
+var _beam_gobo_enabled_check: CheckBox
+var _beam_gobo_strength_slider: HSlider
+var _beam_gobo_softness_slider: HSlider
+var _beam_gobo_gamma_slider: HSlider
+var _beam_gobo_rotation_slider: HSlider
+var _legacy_overlay_scale_slider: HSlider
+var _legacy_core_scale_slider: HSlider
+var _legacy_beam_gobo_max_distance_slider: HSlider
+
 var _background_picker: ColorPickerButton
 var _beam_render_mode_option: OptionButton
 var _beam_quality_option: OptionButton
+var _legacy_cone_count_option: OptionButton
 
 func _init() -> void:
 	title = "Visual Settings"
-	size = Vector2i(460, 400)
+	size = Vector2i(500, 560)
 	unresizable = false
 
 func _ready() -> void:
@@ -63,9 +80,14 @@ func _build_ui() -> void:
 	root.add_theme_constant_override("margin_bottom", 12)
 	add_child(root)
 
+	var scroll: ScrollContainer = ScrollContainer.new()
+	scroll.set_anchors_preset(Control.PRESET_FULL_RECT)
+	root.add_child(scroll)
+
 	var container: VBoxContainer = VBoxContainer.new()
+	container.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	container.add_theme_constant_override("separation", 10)
-	root.add_child(container)
+	scroll.add_child(container)
 
 	_ambient_slider = _add_slider_row(container, "Ambient light", "ambient_multiplier", 0.0, 3.0, 0.01)
 	_spot_slider = _add_slider_row(container, "Spot intensity", "spot_multiplier", 0.0, 3.0, 0.01)
@@ -74,13 +96,26 @@ func _build_ui() -> void:
 	_beam_render_mode_option = _add_option_row(container, "Beam rendering", ["Volumetric (default)", "Lightweight (legacy)"], _on_beam_render_mode_selected)
 	_beam_quality_option = _add_option_row(container, "Beam quality", ["Low", "Medium", "High"], _on_beam_quality_selected)
 
+	_add_section_header(container, "Beam Gobos")
+	_beam_gobo_enabled_check = _add_checkbox_row(container, "Enable beam gobos", "beam_gobo_enabled")
+	_beam_gobo_strength_slider = _add_slider_row(container, "Gobo strength", "beam_gobo_strength", 0.0, 1.0, 0.01)
+	_beam_gobo_softness_slider = _add_slider_row(container, "Gobo softness", "beam_gobo_softness", 0.0, 6.0, 0.05)
+	_beam_gobo_gamma_slider = _add_slider_row(container, "Gobo gamma", "beam_gobo_gamma", 0.25, 4.0, 0.01)
+	_beam_gobo_rotation_slider = _add_slider_row(container, "Gobo rotation", "beam_gobo_rotation", -6.283, 6.283, 0.01)
+
+	_add_section_header(container, "Legacy beam tuning")
+	_legacy_cone_count_option = _add_option_row(container, "Legacy cone count", ["2 cones", "3 cones"], _on_legacy_cone_count_selected)
+	_legacy_overlay_scale_slider = _add_slider_row(container, "Overlay scale", "legacy_overlay_scale", 0.85, 0.995, 0.001)
+	_legacy_core_scale_slider = _add_slider_row(container, "Core scale", "legacy_core_scale", 0.8, 0.99, 0.001)
+	_legacy_beam_gobo_max_distance_slider = _add_slider_row(container, "Gobo max distance", "legacy_beam_gobo_max_distance", 0.0, 300.0, 1.0)
+
 	var background_row: HBoxContainer = HBoxContainer.new()
 	background_row.add_theme_constant_override("separation", 8)
 	container.add_child(background_row)
 
 	var background_label: Label = Label.new()
 	background_label.text = "Background color"
-	background_label.custom_minimum_size = Vector2(150, 0)
+	background_label.custom_minimum_size = Vector2(170, 0)
 	background_row.add_child(background_label)
 
 	_background_picker = ColorPickerButton.new()
@@ -97,6 +132,12 @@ func _build_ui() -> void:
 	reset_button.pressed.connect(_on_reset_pressed)
 	actions_row.add_child(reset_button)
 
+func _add_section_header(parent: VBoxContainer, text: String) -> void:
+	var header: Label = Label.new()
+	header.text = text
+	header.add_theme_font_size_override("font_size", 15)
+	parent.add_child(header)
+
 func _add_slider_row(parent: VBoxContainer,
 		label_text: String,
 		key: String,
@@ -109,7 +150,7 @@ func _add_slider_row(parent: VBoxContainer,
 
 	var setting_label: Label = Label.new()
 	setting_label.text = label_text
-	setting_label.custom_minimum_size = Vector2(150, 0)
+	setting_label.custom_minimum_size = Vector2(170, 0)
 	row.add_child(setting_label)
 
 	var slider: HSlider = HSlider.new()
@@ -123,21 +164,22 @@ func _add_slider_row(parent: VBoxContainer,
 	row.add_child(slider)
 
 	var value_label: Label = Label.new()
-	value_label.custom_minimum_size = Vector2(44, 0)
+	value_label.custom_minimum_size = Vector2(56, 0)
 	value_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
 	row.add_child(value_label)
-
-	match key:
-		"ambient_multiplier":
-			_ambient_value_label = value_label
-		"spot_multiplier":
-			_spot_value_label = value_label
-		"beam_multiplier":
-			_beam_value_label = value_label
-		"bloom_multiplier":
-			_bloom_value_label = value_label
+	_value_labels[key] = value_label
 
 	return slider
+
+func _add_checkbox_row(parent: VBoxContainer, label_text: String, key: String) -> CheckBox:
+	var check_box: CheckBox = CheckBox.new()
+	check_box.text = label_text
+	check_box.toggled.connect(func(pressed: bool) -> void:
+		_settings[key] = pressed
+		_emit_settings_changed()
+	)
+	parent.add_child(check_box)
+	return check_box
 
 func _add_option_row(parent: VBoxContainer, label_text: String, options: Array[String], on_selected: Callable) -> OptionButton:
 	var row: HBoxContainer = HBoxContainer.new()
@@ -146,7 +188,7 @@ func _add_option_row(parent: VBoxContainer, label_text: String, options: Array[S
 
 	var setting_label: Label = Label.new()
 	setting_label.text = label_text
-	setting_label.custom_minimum_size = Vector2(150, 0)
+	setting_label.custom_minimum_size = Vector2(170, 0)
 	row.add_child(setting_label)
 
 	var option_button: OptionButton = OptionButton.new()
@@ -165,6 +207,15 @@ func _apply_settings_to_controls() -> void:
 	_bloom_slider.value = float(_settings.get("bloom_multiplier", 1.0))
 	_beam_render_mode_option.select(clamp(int(_settings.get("beam_render_mode", 0)), 0, 1))
 	_beam_quality_option.select(clamp(int(_settings.get("beam_quality", 1)), 0, 2))
+	_beam_gobo_enabled_check.button_pressed = bool(_settings.get("beam_gobo_enabled", true))
+	_beam_gobo_strength_slider.value = float(_settings.get("beam_gobo_strength", 1.0))
+	_beam_gobo_softness_slider.value = float(_settings.get("beam_gobo_softness", 0.0))
+	_beam_gobo_gamma_slider.value = float(_settings.get("beam_gobo_gamma", 1.0))
+	_beam_gobo_rotation_slider.value = float(_settings.get("beam_gobo_rotation", 0.0))
+	_legacy_cone_count_option.select(0 if int(_settings.get("legacy_cone_count", 2)) <= 2 else 1)
+	_legacy_overlay_scale_slider.value = float(_settings.get("legacy_overlay_scale", 0.96))
+	_legacy_core_scale_slider.value = float(_settings.get("legacy_core_scale", 0.92))
+	_legacy_beam_gobo_max_distance_slider.value = float(_settings.get("legacy_beam_gobo_max_distance", 90.0))
 	_background_picker.color = _settings.get("background_color", DEFAULT_SETTINGS["background_color"])
 	_update_value_labels()
 
@@ -190,11 +241,16 @@ func _on_beam_quality_selected(index: int) -> void:
 	_settings["beam_quality"] = clamp(index, 0, 2)
 	_emit_settings_changed()
 
+func _on_legacy_cone_count_selected(index: int) -> void:
+	_settings["legacy_cone_count"] = 2 if index <= 0 else 3
+	_emit_settings_changed()
+
 func _update_value_labels() -> void:
-	_ambient_value_label.text = "%.2f" % float(_settings.get("ambient_multiplier", 1.0))
-	_spot_value_label.text = "%.2f" % float(_settings.get("spot_multiplier", 1.0))
-	_beam_value_label.text = "%.2f" % float(_settings.get("beam_multiplier", 1.0))
-	_bloom_value_label.text = "%.2f" % float(_settings.get("bloom_multiplier", 1.0))
+	for key in _value_labels.keys():
+		var label: Label = _value_labels[key] as Label
+		if label == null:
+			continue
+		label.text = "%.2f" % float(_settings.get(key, 0.0))
 
 func _emit_settings_changed() -> void:
 	settings_changed.emit(_settings.duplicate(true))


### PR DESCRIPTION
### Motivation

- Make fixture gobos visible inside beam/haze geometry while keeping the existing surface footprint projection unchanged (continue to use `SpotLight3D.light_projector`).
- Support Godot limitation that instance uniforms cannot carry textures by using a per-texture material cache to avoid per-instance sampler bindings and limit runtime cost.
- Provide a pragmatic low-risk solution: shader modulation + material cache for both LEGACY (performance-first) and VOLUMETRIC (realism-first) beam modes and add user-facing controls for tuning.

### Description

- Added a reusable material cache `peraviz/scripts/rendering/gobo_beam_material_cache.gd` (`GoboBeamMaterialCache`) that keys duplicated `ShaderMaterial`s by projector texture RID, exposes `resolve_material(...)`, `clear()` and `apply_settings_to_all_cached_materials(...)` to update gobo-related uniforms without rebuilding nodes.
- Extended both beam shaders (`peraviz/scripts/shaders/legacy_beam_cone.gdshader` and `peraviz/scripts/shaders/volumetric_beam.gdshader`) with gobo uniforms (`gobo_enabled`, `gobo_texture`, `gobo_strength`, `gobo_rotation_rad`, `gobo_mip_bias`, `gobo_gamma`) and a shared helper `sample_gobo_polar(...)` that uses `textureLod(..., gobo_mip_bias)` and applies gamma/strength to produce a modulation multiplier.
- Updated beam renderers to use the cache: `LegacyConeBeamRenderer` now uses outer + overlay cones by default (optional 3rd core cone), pushes inner shells closer to the outer shell, and applies gobo modulation only to the overlay cone; it also supports a distance-based disable (`legacy_beam_gobo_max_distance`). `VolumetricBeamRenderer` resolves a gobo-aware cached material for the volumetric cone and multiplies brightness/alpha by the gobo multiplier.
- Added `clear_cached_materials()` to `BeamRendererBase` and wired cache invalidation on scene clear in `peraviz/scripts/load_scene.gd`; also reordered emitter update so `_fixture_gobo_projector.apply_gobo_projection(...)` runs before beam update to avoid a one-frame lag.
- Exposed Beam Gobo controls and legacy tuning in the Visual Settings UI (`peraviz/scripts/visual_settings_window.gd`) and added default keys to `_visual_settings` in `peraviz/scripts/load_scene.gd` (`beam_gobo_enabled`, `beam_gobo_strength`, `beam_gobo_softness`, `beam_gobo_gamma`, `beam_gobo_rotation`, `legacy_cone_count`, `legacy_overlay_scale`, `legacy_core_scale`, `legacy_beam_gobo_max_distance`).
- Documented the approach in `peraviz/docs/BEAM_RENDERING_MODES.md` with a short note that footprint projection is unchanged and the beam gobo is implemented via shader modulation + material cache.

### Testing

- Ran `tests/check_perastage_tree_modules.sh` and it passed (module layout check OK).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (no prohibited calls in GUI code).
- A Playwright UI screenshot attempt failed in this environment with `ERR_EMPTY_RESPONSE` because no HTTP server was serving at the target URL; this is an environment issue and not a code test failure.
- No engine runtime smoke tests were executed in this CI environment; shader and runtime behavior were implemented to preserve existing footprint logic and expose runtime toggles so manual in-editor checks are expected (see PR notes for manual checklist).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998f0e8ba20832488fce411050e6357)