### PR TITLE
Enable vector fixture symbol generation and vector preview rendering

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/riderimporter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scenedatamanager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/simplecrypt.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/symbols/Symbol2DImageBuilder.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/symbols/Symbol2DBuilder.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/trussdictionary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/truss_gdtf_builder.cpp

--- a/core/symbols/Symbol2DImageBuilder.cpp
+++ b/core/symbols/Symbol2DImageBuilder.cpp
@@ -1,0 +1,350 @@
+#include "symbols/Symbol2DImageBuilder.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <optional>
+#include <queue>
+#include <set>
+#include <unordered_map>
+
+namespace symbols {
+namespace {
+
+struct PixelMask {
+  int width = 0;
+  int height = 0;
+  std::vector<unsigned char> value;
+
+  bool InBounds(int x, int y) const {
+    return x >= 0 && y >= 0 && x < width && y < height;
+  }
+
+  unsigned char Get(int x, int y) const {
+    return value[static_cast<size_t>(y) * static_cast<size_t>(width) +
+                 static_cast<size_t>(x)];
+  }
+
+  unsigned char &Get(int x, int y) {
+    return value[static_cast<size_t>(y) * static_cast<size_t>(width) +
+                 static_cast<size_t>(x)];
+  }
+};
+
+int PixelIndex(const PixelMask &mask, int x, int y) {
+  return y * mask.width + x;
+}
+
+Point2D ToPoint(int x, int y, int imageHeight) {
+  return Point2D{static_cast<float>(x), static_cast<float>(imageHeight - 1 - y)};
+}
+
+void ExtendBounds(Aabb2D &bounds, const Point2D &p) {
+  if (!bounds.valid) {
+    bounds.min = p;
+    bounds.max = p;
+    bounds.valid = true;
+    return;
+  }
+  bounds.min.x = std::min(bounds.min.x, p.x);
+  bounds.min.y = std::min(bounds.min.y, p.y);
+  bounds.max.x = std::max(bounds.max.x, p.x);
+  bounds.max.y = std::max(bounds.max.y, p.y);
+}
+
+PixelMask BuildFillMask(const RenderedSymbolImage &render,
+                        const ImageBuildParams &params) {
+  PixelMask mask;
+  mask.width = render.width;
+  mask.height = render.height;
+  mask.value.assign(static_cast<size_t>(render.width) * static_cast<size_t>(render.height),
+                    0);
+
+  const size_t pixelCount = static_cast<size_t>(render.width) *
+                            static_cast<size_t>(render.height);
+  for (size_t i = 0; i < pixelCount; ++i) {
+    const unsigned char r = render.rgba[i * 4 + 0];
+    const unsigned char g = render.rgba[i * 4 + 1];
+    const unsigned char b = render.rgba[i * 4 + 2];
+    const unsigned char a = render.rgba[i * 4 + 3];
+
+    const bool visible = a > params.fillAlphaThreshold;
+    const bool nonWhite = !(r > params.whiteThreshold && g > params.whiteThreshold &&
+                            b > params.whiteThreshold);
+    if (visible && nonWhite)
+      mask.value[i] = 1;
+  }
+  return mask;
+}
+
+PixelMask BuildLineMask(const RenderedSymbolImage &render,
+                        const ImageBuildParams &params) {
+  PixelMask mask;
+  mask.width = render.width;
+  mask.height = render.height;
+  mask.value.assign(static_cast<size_t>(render.width) * static_cast<size_t>(render.height),
+                    0);
+
+  const size_t pixelCount = static_cast<size_t>(render.width) *
+                            static_cast<size_t>(render.height);
+  for (size_t i = 0; i < pixelCount; ++i) {
+    const unsigned char r = render.rgba[i * 4 + 0];
+    const unsigned char g = render.rgba[i * 4 + 1];
+    const unsigned char b = render.rgba[i * 4 + 2];
+    const unsigned char a = render.rgba[i * 4 + 3];
+    const int luminance = static_cast<int>(0.2126f * static_cast<float>(r) +
+                                           0.7152f * static_cast<float>(g) +
+                                           0.0722f * static_cast<float>(b));
+    if (a > params.fillAlphaThreshold && luminance < params.blackThreshold)
+      mask.value[i] = 1;
+  }
+  return mask;
+}
+
+Polyline2D TraceOuterPolygon(const PixelMask &fillMask) {
+  int minX = fillMask.width;
+  int minY = fillMask.height;
+  int maxX = -1;
+  int maxY = -1;
+
+  for (int y = 0; y < fillMask.height; ++y) {
+    for (int x = 0; x < fillMask.width; ++x) {
+      if (!fillMask.Get(x, y))
+        continue;
+      minX = std::min(minX, x);
+      minY = std::min(minY, y);
+      maxX = std::max(maxX, x);
+      maxY = std::max(maxY, y);
+    }
+  }
+
+  Polyline2D outer;
+  if (maxX < minX || maxY < minY)
+    return outer;
+
+  outer.push_back(ToPoint(minX, minY, fillMask.height));
+  outer.push_back(ToPoint(maxX + 1, minY, fillMask.height));
+  outer.push_back(ToPoint(maxX + 1, maxY + 1, fillMask.height));
+  outer.push_back(ToPoint(minX, maxY + 1, fillMask.height));
+  return outer;
+}
+
+int CountNeighbors(const PixelMask &mask, int x, int y) {
+  int count = 0;
+  for (int oy = -1; oy <= 1; ++oy) {
+    for (int ox = -1; ox <= 1; ++ox) {
+      if (ox == 0 && oy == 0)
+        continue;
+      if (mask.InBounds(x + ox, y + oy) && mask.Get(x + ox, y + oy))
+        ++count;
+    }
+  }
+  return count;
+}
+
+int CountTransitions(const PixelMask &mask, int x, int y) {
+  static constexpr std::array<std::pair<int, int>, 8> neighbors = {
+      {{0, -1}, {1, -1}, {1, 0}, {1, 1}, {0, 1}, {-1, 1}, {-1, 0}, {-1, -1}}};
+  int transitions = 0;
+  for (size_t i = 0; i < neighbors.size(); ++i) {
+    const auto [x0, y0] = neighbors[i];
+    const auto [x1, y1] = neighbors[(i + 1) % neighbors.size()];
+    const unsigned char a =
+        mask.InBounds(x + x0, y + y0) ? mask.Get(x + x0, y + y0) : 0;
+    const unsigned char b =
+        mask.InBounds(x + x1, y + y1) ? mask.Get(x + x1, y + y1) : 0;
+    if (a == 0 && b == 1)
+      ++transitions;
+  }
+  return transitions;
+}
+
+void ThinZhangSuen(PixelMask &mask) {
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    for (int phase = 0; phase < 2; ++phase) {
+      std::vector<std::pair<int, int>> toClear;
+      for (int y = 1; y < mask.height - 1; ++y) {
+        for (int x = 1; x < mask.width - 1; ++x) {
+          if (!mask.Get(x, y))
+            continue;
+          const int n = CountNeighbors(mask, x, y);
+          if (n < 2 || n > 6)
+            continue;
+          if (CountTransitions(mask, x, y) != 1)
+            continue;
+
+          const int p2 = mask.Get(x, y - 1);
+          const int p4 = mask.Get(x + 1, y);
+          const int p6 = mask.Get(x, y + 1);
+          const int p8 = mask.Get(x - 1, y);
+
+          bool shouldDelete = false;
+          if (phase == 0)
+            shouldDelete = (p2 * p4 * p6 == 0) && (p4 * p6 * p8 == 0);
+          else
+            shouldDelete = (p2 * p4 * p8 == 0) && (p2 * p6 * p8 == 0);
+
+          if (shouldDelete)
+            toClear.emplace_back(x, y);
+        }
+      }
+
+      if (!toClear.empty()) {
+        changed = true;
+        for (const auto &[x, y] : toClear)
+          mask.Get(x, y) = 0;
+      }
+    }
+  }
+}
+
+std::vector<Polyline2D> ExtractPolylines(const PixelMask &skeleton,
+                                         const ImageBuildParams &params) {
+  const int w = skeleton.width;
+  const int h = skeleton.height;
+  std::vector<std::vector<int>> adjacency(static_cast<size_t>(w * h));
+  std::vector<int> activeNodes;
+
+  for (int y = 0; y < h; ++y) {
+    for (int x = 0; x < w; ++x) {
+      if (!skeleton.Get(x, y))
+        continue;
+      const int id = PixelIndex(skeleton, x, y);
+      activeNodes.push_back(id);
+      for (int oy = -1; oy <= 1; ++oy) {
+        for (int ox = -1; ox <= 1; ++ox) {
+          if (ox == 0 && oy == 0)
+            continue;
+          const int nx = x + ox;
+          const int ny = y + oy;
+          if (!skeleton.InBounds(nx, ny) || !skeleton.Get(nx, ny))
+            continue;
+          adjacency[static_cast<size_t>(id)].push_back(PixelIndex(skeleton, nx, ny));
+        }
+      }
+    }
+  }
+
+  std::set<std::pair<int, int>> visitedEdges;
+  auto markEdge = [&visitedEdges](int a, int b) {
+    if (a > b)
+      std::swap(a, b);
+    visitedEdges.insert({a, b});
+  };
+  auto edgeVisited = [&visitedEdges](int a, int b) {
+    if (a > b)
+      std::swap(a, b);
+    return visitedEdges.find({a, b}) != visitedEdges.end();
+  };
+
+  auto nodeToPoint = [w, h](int node) {
+    const int x = node % w;
+    const int y = node / w;
+    return ToPoint(x, y, h);
+  };
+
+  auto walkFrom = [&](int start, int next) {
+    Polyline2D polyline;
+    polyline.push_back(nodeToPoint(start));
+
+    int prev = start;
+    int current = next;
+    markEdge(prev, current);
+
+    while (true) {
+      polyline.push_back(nodeToPoint(current));
+      const auto &neighbors = adjacency[static_cast<size_t>(current)];
+      const int degree = static_cast<int>(neighbors.size());
+      if (degree != 2)
+        break;
+
+      int candidate = -1;
+      for (int n : neighbors) {
+        if (n == prev)
+          continue;
+        candidate = n;
+        break;
+      }
+      if (candidate < 0 || edgeVisited(current, candidate))
+        break;
+      prev = current;
+      current = candidate;
+      markEdge(prev, current);
+    }
+
+    return polyline;
+  };
+
+  std::vector<Polyline2D> polylines;
+
+  for (int node : activeNodes) {
+    const auto &neighbors = adjacency[static_cast<size_t>(node)];
+    if (neighbors.size() != 1)
+      continue;
+    for (int next : neighbors) {
+      if (edgeVisited(node, next))
+        continue;
+      Polyline2D polyline = walkFrom(node, next);
+      if (static_cast<int>(polyline.size()) >= params.minStrokePixels)
+        polylines.push_back(std::move(polyline));
+    }
+  }
+
+  for (int node : activeNodes) {
+    for (int next : adjacency[static_cast<size_t>(node)]) {
+      if (edgeVisited(node, next))
+        continue;
+      Polyline2D polyline = walkFrom(node, next);
+      if (static_cast<int>(polyline.size()) >= params.minStrokePixels)
+        polylines.push_back(std::move(polyline));
+    }
+  }
+
+  return polylines;
+}
+
+} // namespace
+
+std::vector<Symbol2D>
+Symbol2DImageBuilder::BuildFromRenderedImages(
+    const std::vector<RenderedSymbolImage> &renders, const ImageBuildParams &params) {
+  std::vector<Symbol2D> symbols;
+  symbols.reserve(renders.size());
+
+  for (const auto &render : renders) {
+    const size_t expectedBytes = static_cast<size_t>(render.width) *
+                                 static_cast<size_t>(render.height) * 4;
+    if (render.width <= 0 || render.height <= 0 || render.rgba.size() < expectedBytes)
+      continue;
+
+    PixelMask fillMask = BuildFillMask(render, params);
+    PixelMask lineMask = BuildLineMask(render, params);
+    ThinZhangSuen(lineMask);
+
+    Symbol2D symbol;
+    symbol.view = render.view;
+    symbol.strokeWidthPx = params.previewStrokeWidthPx;
+
+    Polyline2D fillPolygon = TraceOuterPolygon(fillMask);
+    if (fillPolygon.size() >= 3)
+      symbol.fill.push_back(PolygonWithHoles2D{fillPolygon, {}});
+
+    symbol.strokes = ExtractPolylines(lineMask, params);
+
+    for (const auto &polygon : symbol.fill)
+      for (const auto &p : polygon.outer)
+        ExtendBounds(symbol.bounds, p);
+    for (const auto &line : symbol.strokes)
+      for (const auto &p : line)
+        ExtendBounds(symbol.bounds, p);
+
+    symbols.push_back(std::move(symbol));
+  }
+
+  return symbols;
+}
+
+} // namespace symbols

--- a/core/symbols/Symbol2DImageBuilder.cpp
+++ b/core/symbols/Symbol2DImageBuilder.cpp
@@ -4,6 +4,7 @@
 #include <array>
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <optional>
 #include <queue>
 #include <set>
@@ -38,12 +39,32 @@ struct RgbColor {
   unsigned char b = 255;
 };
 
+struct GridPoint {
+  int x = 0;
+  int y = 0;
+
+  bool operator==(const GridPoint &other) const {
+    return x == other.x && y == other.y;
+  }
+};
+
+struct GridPointHash {
+  size_t operator()(const GridPoint &p) const {
+    return (static_cast<size_t>(static_cast<uint32_t>(p.x)) << 32) ^
+           static_cast<size_t>(static_cast<uint32_t>(p.y));
+  }
+};
+
 int PixelIndex(const PixelMask &mask, int x, int y) {
   return y * mask.width + x;
 }
 
 Point2D ToPoint(int x, int y, int imageHeight) {
   return Point2D{static_cast<float>(x), static_cast<float>(imageHeight - 1 - y)};
+}
+
+Point2D ToVertexPoint(int x, int y, int imageHeight) {
+  return Point2D{static_cast<float>(x), static_cast<float>(imageHeight - y)};
 }
 
 void ExtendBounds(Aabb2D &bounds, const Point2D &p) {
@@ -143,30 +164,125 @@ PixelMask BuildLineMask(const RenderedSymbolImage &render,
 }
 
 Polyline2D TraceOuterPolygon(const PixelMask &fillMask) {
-  int minX = fillMask.width;
-  int minY = fillMask.height;
-  int maxX = -1;
-  int maxY = -1;
+  const int w = fillMask.width;
+  const int h = fillMask.height;
+  Polyline2D outer;
+  if (w <= 0 || h <= 0)
+    return outer;
 
-  for (int y = 0; y < fillMask.height; ++y) {
-    for (int x = 0; x < fillMask.width; ++x) {
-      if (!fillMask.Get(x, y))
+  std::vector<unsigned char> visited(static_cast<size_t>(w) * static_cast<size_t>(h), 0);
+  std::vector<std::pair<int, int>> largestComponent;
+
+  for (int y = 0; y < h; ++y) {
+    for (int x = 0; x < w; ++x) {
+      const size_t idx = static_cast<size_t>(y) * static_cast<size_t>(w) +
+                         static_cast<size_t>(x);
+      if (!fillMask.Get(x, y) || visited[idx])
         continue;
-      minX = std::min(minX, x);
-      minY = std::min(minY, y);
-      maxX = std::max(maxX, x);
-      maxY = std::max(maxY, y);
+
+      std::vector<std::pair<int, int>> component;
+      std::vector<std::pair<int, int>> queue;
+      queue.emplace_back(x, y);
+      visited[idx] = 1;
+
+      for (size_t qi = 0; qi < queue.size(); ++qi) {
+        const auto [cx, cy] = queue[qi];
+        component.emplace_back(cx, cy);
+        static constexpr std::array<std::pair<int, int>, 4> kNeighbors = {
+            {{1, 0}, {-1, 0}, {0, 1}, {0, -1}}};
+        for (const auto &[ox, oy] : kNeighbors) {
+          const int nx = cx + ox;
+          const int ny = cy + oy;
+          if (!fillMask.InBounds(nx, ny) || !fillMask.Get(nx, ny))
+            continue;
+          const size_t nidx = static_cast<size_t>(ny) * static_cast<size_t>(w) +
+                              static_cast<size_t>(nx);
+          if (visited[nidx])
+            continue;
+          visited[nidx] = 1;
+          queue.emplace_back(nx, ny);
+        }
+      }
+
+      if (component.size() > largestComponent.size())
+        largestComponent = std::move(component);
     }
   }
 
-  Polyline2D outer;
-  if (maxX < minX || maxY < minY)
+  if (largestComponent.empty())
     return outer;
 
-  outer.push_back(ToPoint(minX, minY, fillMask.height));
-  outer.push_back(ToPoint(maxX + 1, minY, fillMask.height));
-  outer.push_back(ToPoint(maxX + 1, maxY + 1, fillMask.height));
-  outer.push_back(ToPoint(minX, maxY + 1, fillMask.height));
+  std::vector<unsigned char> componentMask(static_cast<size_t>(w) * static_cast<size_t>(h), 0);
+  for (const auto &[x, y] : largestComponent) {
+    const size_t idx = static_cast<size_t>(y) * static_cast<size_t>(w) +
+                       static_cast<size_t>(x);
+    componentMask[idx] = 1;
+  }
+
+  std::unordered_multimap<GridPoint, GridPoint, GridPointHash> edges;
+  auto hasComponentAt = [&](int x, int y) {
+    if (x < 0 || y < 0 || x >= w || y >= h)
+      return false;
+    const size_t idx = static_cast<size_t>(y) * static_cast<size_t>(w) +
+                       static_cast<size_t>(x);
+    return componentMask[idx] != 0;
+  };
+  auto addEdge = [&edges](GridPoint a, GridPoint b) { edges.emplace(a, b); };
+
+  for (const auto &[x, y] : largestComponent) {
+    if (!hasComponentAt(x, y - 1))
+      addEdge(GridPoint{x, y}, GridPoint{x + 1, y});
+    if (!hasComponentAt(x + 1, y))
+      addEdge(GridPoint{x + 1, y}, GridPoint{x + 1, y + 1});
+    if (!hasComponentAt(x, y + 1))
+      addEdge(GridPoint{x + 1, y + 1}, GridPoint{x, y + 1});
+    if (!hasComponentAt(x - 1, y))
+      addEdge(GridPoint{x, y + 1}, GridPoint{x, y});
+  }
+
+  if (edges.empty())
+    return outer;
+
+  auto currentIt = std::min_element(
+      edges.begin(), edges.end(), [](const auto &a, const auto &b) {
+        if (a.first.y != b.first.y)
+          return a.first.y < b.first.y;
+        if (a.first.x != b.first.x)
+          return a.first.x < b.first.x;
+        if (a.second.y != b.second.y)
+          return a.second.y < b.second.y;
+        return a.second.x < b.second.x;
+      });
+  GridPoint start = currentIt->first;
+  GridPoint current = start;
+  GridPoint next = currentIt->second;
+  edges.erase(currentIt);
+
+  outer.push_back(ToVertexPoint(start.x, start.y, h));
+  outer.push_back(ToVertexPoint(next.x, next.y, h));
+  current = next;
+
+  const size_t maxSteps = static_cast<size_t>(w) * static_cast<size_t>(h) * 8;
+  for (size_t step = 0; step < maxSteps; ++step) {
+    auto range = edges.equal_range(current);
+    if (range.first == range.second)
+      break;
+
+    auto take = range.first;
+    GridPoint candidate = take->second;
+    edges.erase(take);
+
+    outer.push_back(ToVertexPoint(candidate.x, candidate.y, h));
+    current = candidate;
+    if (current == start)
+      break;
+  }
+
+  if (outer.size() >= 2 && outer.front().x == outer.back().x &&
+      outer.front().y == outer.back().y) {
+    outer.pop_back();
+  }
+
   return outer;
 }
 

--- a/core/symbols/Symbol2DImageBuilder.cpp
+++ b/core/symbols/Symbol2DImageBuilder.cpp
@@ -32,6 +32,12 @@ struct PixelMask {
   }
 };
 
+struct RgbColor {
+  unsigned char r = 255;
+  unsigned char g = 255;
+  unsigned char b = 255;
+};
+
 int PixelIndex(const PixelMask &mask, int x, int y) {
   return y * mask.width + x;
 }
@@ -61,6 +67,40 @@ PixelMask BuildFillMask(const RenderedSymbolImage &render,
   mask.value.assign(static_cast<size_t>(render.width) * static_cast<size_t>(render.height),
                     0);
 
+  const auto pixelRgb = [&](int x, int y) {
+    const size_t idx = (static_cast<size_t>(y) * static_cast<size_t>(render.width) +
+                        static_cast<size_t>(x)) *
+                       4;
+    return RgbColor{render.rgba[idx + 0], render.rgba[idx + 1], render.rgba[idx + 2]};
+  };
+
+  const auto isNear = [&](const RgbColor &a, const RgbColor &b) {
+    return std::abs(static_cast<int>(a.r) - static_cast<int>(b.r)) <=
+               params.backgroundTolerance &&
+           std::abs(static_cast<int>(a.g) - static_cast<int>(b.g)) <=
+               params.backgroundTolerance &&
+           std::abs(static_cast<int>(a.b) - static_cast<int>(b.b)) <=
+               params.backgroundTolerance;
+  };
+
+  std::array<RgbColor, 4> corners = {
+      pixelRgb(0, 0), pixelRgb(render.width - 1, 0),
+      pixelRgb(0, render.height - 1), pixelRgb(render.width - 1, render.height - 1)};
+
+  RgbColor background = corners[0];
+  int bestCount = -1;
+  for (const auto &candidate : corners) {
+    int count = 0;
+    for (const auto &sample : corners) {
+      if (isNear(candidate, sample))
+        ++count;
+    }
+    if (count > bestCount) {
+      bestCount = count;
+      background = candidate;
+    }
+  }
+
   const size_t pixelCount = static_cast<size_t>(render.width) *
                             static_cast<size_t>(render.height);
   for (size_t i = 0; i < pixelCount; ++i) {
@@ -70,9 +110,9 @@ PixelMask BuildFillMask(const RenderedSymbolImage &render,
     const unsigned char a = render.rgba[i * 4 + 3];
 
     const bool visible = a > params.fillAlphaThreshold;
-    const bool nonWhite = !(r > params.whiteThreshold && g > params.whiteThreshold &&
-                            b > params.whiteThreshold);
-    if (visible && nonWhite)
+    const RgbColor current{r, g, b};
+    const bool isBackgroundColor = isNear(current, background);
+    if (visible && !isBackgroundColor)
       mask.value[i] = 1;
   }
   return mask;

--- a/core/symbols/Symbol2DImageBuilder.cpp
+++ b/core/symbols/Symbol2DImageBuilder.cpp
@@ -85,6 +85,20 @@ bool PointInPolygon(const Point2D &point, const Polyline2D &polygon) {
   return inside;
 }
 
+Point2D PolygonProbePoint(const Polyline2D &polygon) {
+  Point2D probe{};
+  if (polygon.empty())
+    return probe;
+  for (const auto &p : polygon) {
+    probe.x += p.x;
+    probe.y += p.y;
+  }
+  const float inv = 1.0f / static_cast<float>(polygon.size());
+  probe.x *= inv;
+  probe.y *= inv;
+  return probe;
+}
+
 int PixelIndex(const PixelMask &mask, int x, int y) {
   return y * mask.width + x;
 }
@@ -279,7 +293,7 @@ std::vector<PolygonWithHoles2D> ExtractFillPolygons(const PixelMask &fillMask) {
     infos.push_back(LoopInfo{std::move(loop), std::abs(SignedArea(loop))});
 
   for (size_t i = 0; i < infos.size(); ++i) {
-    const Point2D probe = infos[i].polygon.front();
+    const Point2D probe = PolygonProbePoint(infos[i].polygon);
     int depth = 0;
     int owner = -1;
     float ownerArea = std::numeric_limits<float>::max();

--- a/core/symbols/Symbol2DImageBuilder.cpp
+++ b/core/symbols/Symbol2DImageBuilder.cpp
@@ -8,6 +8,7 @@
 #include <optional>
 #include <queue>
 #include <set>
+#include <limits>
 #include <unordered_map>
 
 namespace symbols {
@@ -54,6 +55,35 @@ struct GridPointHash {
            static_cast<size_t>(static_cast<uint32_t>(p.y));
   }
 };
+
+float SignedArea(const Polyline2D &polyline) {
+  if (polyline.size() < 3)
+    return 0.0f;
+  double area = 0.0;
+  for (size_t i = 0; i < polyline.size(); ++i) {
+    const Point2D &a = polyline[i];
+    const Point2D &b = polyline[(i + 1) % polyline.size()];
+    area += static_cast<double>(a.x) * static_cast<double>(b.y) -
+            static_cast<double>(b.x) * static_cast<double>(a.y);
+  }
+  return static_cast<float>(0.5 * area);
+}
+
+bool PointInPolygon(const Point2D &point, const Polyline2D &polygon) {
+  if (polygon.size() < 3)
+    return false;
+  bool inside = false;
+  for (size_t i = 0, j = polygon.size() - 1; i < polygon.size(); j = i++) {
+    const Point2D &pi = polygon[i];
+    const Point2D &pj = polygon[j];
+    const bool intersect =
+        ((pi.y > point.y) != (pj.y > point.y)) &&
+        (point.x < (pj.x - pi.x) * (point.y - pi.y) / (pj.y - pi.y + 1e-6f) + pi.x);
+    if (intersect)
+      inside = !inside;
+  }
+  return inside;
+}
 
 int PixelIndex(const PixelMask &mask, int x, int y) {
   return y * mask.width + x;
@@ -163,127 +193,133 @@ PixelMask BuildLineMask(const RenderedSymbolImage &render,
   return mask;
 }
 
-Polyline2D TraceOuterPolygon(const PixelMask &fillMask) {
+std::vector<PolygonWithHoles2D> ExtractFillPolygons(const PixelMask &fillMask) {
   const int w = fillMask.width;
   const int h = fillMask.height;
-  Polyline2D outer;
+  std::vector<PolygonWithHoles2D> result;
   if (w <= 0 || h <= 0)
-    return outer;
-
-  std::vector<unsigned char> visited(static_cast<size_t>(w) * static_cast<size_t>(h), 0);
-  std::vector<std::pair<int, int>> largestComponent;
-
-  for (int y = 0; y < h; ++y) {
-    for (int x = 0; x < w; ++x) {
-      const size_t idx = static_cast<size_t>(y) * static_cast<size_t>(w) +
-                         static_cast<size_t>(x);
-      if (!fillMask.Get(x, y) || visited[idx])
-        continue;
-
-      std::vector<std::pair<int, int>> component;
-      std::vector<std::pair<int, int>> queue;
-      queue.emplace_back(x, y);
-      visited[idx] = 1;
-
-      for (size_t qi = 0; qi < queue.size(); ++qi) {
-        const auto [cx, cy] = queue[qi];
-        component.emplace_back(cx, cy);
-        static constexpr std::array<std::pair<int, int>, 4> kNeighbors = {
-            {{1, 0}, {-1, 0}, {0, 1}, {0, -1}}};
-        for (const auto &[ox, oy] : kNeighbors) {
-          const int nx = cx + ox;
-          const int ny = cy + oy;
-          if (!fillMask.InBounds(nx, ny) || !fillMask.Get(nx, ny))
-            continue;
-          const size_t nidx = static_cast<size_t>(ny) * static_cast<size_t>(w) +
-                              static_cast<size_t>(nx);
-          if (visited[nidx])
-            continue;
-          visited[nidx] = 1;
-          queue.emplace_back(nx, ny);
-        }
-      }
-
-      if (component.size() > largestComponent.size())
-        largestComponent = std::move(component);
-    }
-  }
-
-  if (largestComponent.empty())
-    return outer;
-
-  std::vector<unsigned char> componentMask(static_cast<size_t>(w) * static_cast<size_t>(h), 0);
-  for (const auto &[x, y] : largestComponent) {
-    const size_t idx = static_cast<size_t>(y) * static_cast<size_t>(w) +
-                       static_cast<size_t>(x);
-    componentMask[idx] = 1;
-  }
+    return result;
 
   std::unordered_multimap<GridPoint, GridPoint, GridPointHash> edges;
-  auto hasComponentAt = [&](int x, int y) {
+  auto isFilledAt = [&](int x, int y) {
     if (x < 0 || y < 0 || x >= w || y >= h)
       return false;
-    const size_t idx = static_cast<size_t>(y) * static_cast<size_t>(w) +
-                       static_cast<size_t>(x);
-    return componentMask[idx] != 0;
+    return fillMask.Get(x, y) != 0;
   };
   auto addEdge = [&edges](GridPoint a, GridPoint b) { edges.emplace(a, b); };
 
-  for (const auto &[x, y] : largestComponent) {
-    if (!hasComponentAt(x, y - 1))
-      addEdge(GridPoint{x, y}, GridPoint{x + 1, y});
-    if (!hasComponentAt(x + 1, y))
-      addEdge(GridPoint{x + 1, y}, GridPoint{x + 1, y + 1});
-    if (!hasComponentAt(x, y + 1))
-      addEdge(GridPoint{x + 1, y + 1}, GridPoint{x, y + 1});
-    if (!hasComponentAt(x - 1, y))
-      addEdge(GridPoint{x, y + 1}, GridPoint{x, y});
+  for (int y = 0; y < h; ++y) {
+    for (int x = 0; x < w; ++x) {
+      if (!fillMask.Get(x, y))
+        continue;
+      if (!isFilledAt(x, y - 1))
+        addEdge(GridPoint{x, y}, GridPoint{x + 1, y});
+      if (!isFilledAt(x + 1, y))
+        addEdge(GridPoint{x + 1, y}, GridPoint{x + 1, y + 1});
+      if (!isFilledAt(x, y + 1))
+        addEdge(GridPoint{x + 1, y + 1}, GridPoint{x, y + 1});
+      if (!isFilledAt(x - 1, y))
+        addEdge(GridPoint{x, y + 1}, GridPoint{x, y});
+    }
   }
 
   if (edges.empty())
-    return outer;
+    return result;
 
-  auto currentIt = std::min_element(
-      edges.begin(), edges.end(), [](const auto &a, const auto &b) {
-        if (a.first.y != b.first.y)
-          return a.first.y < b.first.y;
-        if (a.first.x != b.first.x)
-          return a.first.x < b.first.x;
-        if (a.second.y != b.second.y)
-          return a.second.y < b.second.y;
-        return a.second.x < b.second.x;
-      });
-  GridPoint start = currentIt->first;
-  GridPoint current = start;
-  GridPoint next = currentIt->second;
-  edges.erase(currentIt);
-
-  outer.push_back(ToVertexPoint(start.x, start.y, h));
-  outer.push_back(ToVertexPoint(next.x, next.y, h));
-  current = next;
-
+  std::vector<Polyline2D> loops;
   const size_t maxSteps = static_cast<size_t>(w) * static_cast<size_t>(h) * 8;
-  for (size_t step = 0; step < maxSteps; ++step) {
-    auto range = edges.equal_range(current);
-    if (range.first == range.second)
-      break;
+  while (!edges.empty()) {
+    auto currentIt = edges.begin();
+    GridPoint start = currentIt->first;
+    GridPoint current = start;
+    GridPoint next = currentIt->second;
+    edges.erase(currentIt);
 
-    auto take = range.first;
-    GridPoint candidate = take->second;
-    edges.erase(take);
+    Polyline2D loop;
+    loop.push_back(ToVertexPoint(start.x, start.y, h));
+    loop.push_back(ToVertexPoint(next.x, next.y, h));
+    current = next;
 
-    outer.push_back(ToVertexPoint(candidate.x, candidate.y, h));
-    current = candidate;
-    if (current == start)
-      break;
+    for (size_t step = 0; step < maxSteps; ++step) {
+      auto range = edges.equal_range(current);
+      if (range.first == range.second)
+        break;
+
+      auto take = range.first;
+      GridPoint candidate = take->second;
+      edges.erase(take);
+
+      loop.push_back(ToVertexPoint(candidate.x, candidate.y, h));
+      current = candidate;
+      if (current == start)
+        break;
+    }
+
+    if (loop.size() >= 2 && loop.front().x == loop.back().x &&
+        loop.front().y == loop.back().y) {
+      loop.pop_back();
+    }
+    if (loop.size() >= 3)
+      loops.push_back(std::move(loop));
   }
 
-  if (outer.size() >= 2 && outer.front().x == outer.back().x &&
-      outer.front().y == outer.back().y) {
-    outer.pop_back();
+  if (loops.empty())
+    return result;
+
+  struct LoopInfo {
+    Polyline2D polygon;
+    float areaAbs = 0.0f;
+    int depth = 0;
+    bool isOuter = true;
+    int ownerOuter = -1;
+  };
+  std::vector<LoopInfo> infos;
+  infos.reserve(loops.size());
+  for (auto &loop : loops)
+    infos.push_back(LoopInfo{std::move(loop), std::abs(SignedArea(loop))});
+
+  for (size_t i = 0; i < infos.size(); ++i) {
+    const Point2D probe = infos[i].polygon.front();
+    int depth = 0;
+    int owner = -1;
+    float ownerArea = std::numeric_limits<float>::max();
+    for (size_t j = 0; j < infos.size(); ++j) {
+      if (i == j)
+        continue;
+      if (!PointInPolygon(probe, infos[j].polygon))
+        continue;
+      ++depth;
+      if (infos[j].areaAbs < ownerArea) {
+        ownerArea = infos[j].areaAbs;
+        owner = static_cast<int>(j);
+      }
+    }
+    infos[i].depth = depth;
+    infos[i].isOuter = (depth % 2 == 0);
+    infos[i].ownerOuter = owner;
   }
 
-  return outer;
+  std::unordered_map<int, int> outerMap;
+  for (size_t i = 0; i < infos.size(); ++i) {
+    if (!infos[i].isOuter)
+      continue;
+    outerMap[static_cast<int>(i)] = static_cast<int>(result.size());
+    result.push_back(PolygonWithHoles2D{infos[i].polygon, {}});
+  }
+
+  for (size_t i = 0; i < infos.size(); ++i) {
+    if (infos[i].isOuter)
+      continue;
+
+    int owner = infos[i].ownerOuter;
+    while (owner >= 0 && !infos[static_cast<size_t>(owner)].isOuter)
+      owner = infos[static_cast<size_t>(owner)].ownerOuter;
+    auto ownerIt = outerMap.find(owner);
+    if (ownerIt != outerMap.end())
+      result[static_cast<size_t>(ownerIt->second)].holes.push_back(infos[i].polygon);
+  }
+
+  return result;
 }
 
 int CountNeighbors(const PixelMask &mask, int x, int y) {
@@ -484,9 +520,7 @@ Symbol2DImageBuilder::BuildFromRenderedImages(
     symbol.view = render.view;
     symbol.strokeWidthPx = params.previewStrokeWidthPx;
 
-    Polyline2D fillPolygon = TraceOuterPolygon(fillMask);
-    if (fillPolygon.size() >= 3)
-      symbol.fill.push_back(PolygonWithHoles2D{fillPolygon, {}});
+    symbol.fill = ExtractFillPolygons(fillMask);
 
     symbol.strokes = ExtractPolylines(lineMask, params);
 

--- a/core/symbols/Symbol2DImageBuilder.h
+++ b/core/symbols/Symbol2DImageBuilder.h
@@ -16,7 +16,7 @@ struct RenderedSymbolImage {
 struct ImageBuildParams {
   float previewStrokeWidthPx = 2.0f;
   unsigned char fillAlphaThreshold = 10;
-  unsigned char whiteThreshold = 245;
+  unsigned char backgroundTolerance = 18;
   unsigned char blackThreshold = 80;
   int minStrokePixels = 6;
 };

--- a/core/symbols/Symbol2DImageBuilder.h
+++ b/core/symbols/Symbol2DImageBuilder.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <vector>
+
+#include "Symbol2D.h"
+
+namespace symbols {
+
+struct RenderedSymbolImage {
+  SymbolView view = SymbolView::Top;
+  int width = 0;
+  int height = 0;
+  std::vector<unsigned char> rgba;
+};
+
+struct ImageBuildParams {
+  float previewStrokeWidthPx = 2.0f;
+  unsigned char fillAlphaThreshold = 10;
+  unsigned char whiteThreshold = 245;
+  unsigned char blackThreshold = 80;
+  int minStrokePixels = 6;
+};
+
+class Symbol2DImageBuilder {
+public:
+  static std::vector<Symbol2D>
+  BuildFromRenderedImages(const std::vector<RenderedSymbolImage> &renders,
+                          const ImageBuildParams &params = ImageBuildParams{});
+};
+
+} // namespace symbols

--- a/gui/tools/fixture_symbol_generation_tool.cpp
+++ b/gui/tools/fixture_symbol_generation_tool.cpp
@@ -1,8 +1,8 @@
 #include "tools/fixture_symbol_generation_tool.h"
 
-#include <map>
-#include <array>
 #include <algorithm>
+#include <array>
+#include <map>
 #include <set>
 #include <string>
 #include <unordered_map>
@@ -10,11 +10,12 @@
 
 #include <wx/msgdlg.h>
 
-#include "guiconfigservices.h"
 #include "configmanager.h"
 #include "dialogs/GenerateFixtureSymbolsDialog.h"
+#include "guiconfigservices.h"
 #include "mainwindow.h"
 #include "opaque_pass_utils.h"
+#include "symbols/Symbol2DImageBuilder.h"
 #include "viewer2doffscreenrenderer.h"
 #include "viewer2dpanel.h"
 #include "windows/SymbolPreviewWindow.h"
@@ -75,88 +76,24 @@ std::vector<FixtureSymbolTypeOption> BuildFixtureOptions() {
   return options;
 }
 
-wxImage BuildWxImageFromRgba(const std::vector<unsigned char> &pixels, int width,
-                             int height) {
-  if (width <= 0 || height <= 0)
-    return wxImage();
-
-  const size_t pixelCount = static_cast<size_t>(width) *
-                            static_cast<size_t>(height);
-  const size_t expectedBytes = pixelCount * 4;
-  if (pixels.size() < expectedBytes)
-    return wxImage();
-
-  unsigned char *rgb = new unsigned char[pixelCount * 3];
-  unsigned char *alpha = new unsigned char[pixelCount];
-  for (size_t i = 0; i < pixelCount; ++i) {
-    rgb[i * 3 + 0] = pixels[i * 4 + 0];
-    rgb[i * 3 + 1] = pixels[i * 4 + 1];
-    rgb[i * 3 + 2] = pixels[i * 4 + 2];
-    alpha[i] = pixels[i * 4 + 3];
-  }
-
-  wxImage image(width, height);
-  image.SetData(rgb, true);
-  image.SetAlpha(alpha, true);
-  return image;
-}
-
-wxImage CropAndZoomFixture(const wxImage &source) {
-  if (!source.IsOk())
-    return source;
-
-  const int width = source.GetWidth();
-  const int height = source.GetHeight();
-  if (width <= 0 || height <= 0)
-    return source;
-
-  const unsigned char *rgb = source.GetData();
-  if (!rgb)
-    return source;
-  const unsigned char *alpha = source.HasAlpha() ? source.GetAlpha() : nullptr;
-
-  int minX = width;
-  int minY = height;
-  int maxX = -1;
-  int maxY = -1;
-
-  for (int y = 0; y < height; ++y) {
-    for (int x = 0; x < width; ++x) {
-      const size_t idx = static_cast<size_t>(y) * static_cast<size_t>(width) +
-                         static_cast<size_t>(x);
-      const unsigned char r = rgb[idx * 3 + 0];
-      const unsigned char g = rgb[idx * 3 + 1];
-      const unsigned char b = rgb[idx * 3 + 2];
-      const unsigned char a = alpha ? alpha[idx] : 255;
-      const bool opaqueEnough = a > 10;
-      const bool isBackgroundWhite = r > 245 && g > 245 && b > 245;
-      if (!opaqueEnough || isBackgroundWhite)
-        continue;
-
-      minX = std::min(minX, x);
-      minY = std::min(minY, y);
-      maxX = std::max(maxX, x);
-      maxY = std::max(maxY, y);
+void MirrorImageHorizontally(symbols::RenderedSymbolImage &render) {
+  if (render.width <= 0 || render.height <= 0)
+    return;
+  for (int y = 0; y < render.height; ++y) {
+    for (int x = 0; x < render.width / 2; ++x) {
+      const int opposite = render.width - 1 - x;
+      const size_t left =
+          (static_cast<size_t>(y) * static_cast<size_t>(render.width) +
+           static_cast<size_t>(x)) *
+          4;
+      const size_t right =
+          (static_cast<size_t>(y) * static_cast<size_t>(render.width) +
+           static_cast<size_t>(opposite)) *
+          4;
+      for (size_t c = 0; c < 4; ++c)
+        std::swap(render.rgba[left + c], render.rgba[right + c]);
     }
   }
-
-  if (maxX < minX || maxY < minY)
-    return source;
-
-  const int contentW = maxX - minX + 1;
-  const int contentH = maxY - minY + 1;
-  const int padX = std::max(16, contentW / 12);
-  const int padY = std::max(16, contentH / 12);
-
-  const int cropX = std::max(0, minX - padX);
-  const int cropY = std::max(0, minY - padY);
-  const int cropW = std::min(width - cropX, contentW + padX * 2);
-  const int cropH = std::min(height - cropY, contentH + padY * 2);
-
-  if (cropW <= 0 || cropH <= 0)
-    return source;
-
-  return source.GetSubImage(wxRect(cropX, cropY, cropW, cropH));
 }
 
 } // namespace
@@ -214,9 +151,6 @@ void RunFixtureSymbolGeneration(MainWindow &window) {
   offscreenRenderer->SetViewportSize(wxSize(1200, 1200));
   offscreenRenderer->PrepareForCapture();
   capturePanel->SetRenderMode(Viewer2DRenderMode::White);
-
-  // Warm up one offscreen frame so the first requested orthographic capture
-  // does not suffer from stale GL/controller state on first invocation.
   capturePanel->UpdateScene(true);
   {
     std::vector<unsigned char> warmupPixels;
@@ -225,49 +159,40 @@ void RunFixtureSymbolGeneration(MainWindow &window) {
     (void)capturePanel->RenderToRGBA(warmupPixels, warmupWidth, warmupHeight);
   }
 
-  std::array<wxImage, 4> images;
   struct CaptureRequest {
     Viewer2DView view = Viewer2DView::Top;
     float topFixturesInverted = 0.0f;
     bool mirrorSideHorizontally = false;
+    symbols::SymbolView symbolView = symbols::SymbolView::Top;
   };
   const std::array<CaptureRequest, 4> requests = {
-      CaptureRequest{Viewer2DView::Front, 0.0f, false},
-      CaptureRequest{Viewer2DView::Top, 0.0f, false},
-      CaptureRequest{Viewer2DView::Side, 0.0f, true},
-      CaptureRequest{Viewer2DView::Top, 1.0f, false},
+      CaptureRequest{Viewer2DView::Front, 0.0f, false, symbols::SymbolView::Front},
+      CaptureRequest{Viewer2DView::Top, 0.0f, false, symbols::SymbolView::Top},
+      CaptureRequest{Viewer2DView::Side, 0.0f, true, symbols::SymbolView::Left},
+      CaptureRequest{Viewer2DView::Top, 1.0f, false, symbols::SymbolView::Bottom},
   };
-  bool allOk = true;
-  for (size_t i = 0; i < requests.size(); ++i) {
-    ScopedFloatConfigOverride topViewOverride(
-        cfg, {{"view2d_top_fixtures_inverted", requests[i].topFixturesInverted}});
 
-    capturePanel->SetView(requests[i].view);
+  std::vector<symbols::RenderedSymbolImage> renders;
+  renders.reserve(requests.size());
+  bool allOk = true;
+  for (const auto &request : requests) {
+    ScopedFloatConfigOverride topViewOverride(
+        cfg, {{"view2d_top_fixtures_inverted", request.topFixturesInverted}});
+
+    capturePanel->SetView(request.view);
     capturePanel->UpdateScene(true);
     capturePanel->FitViewToScene();
 
-    std::vector<unsigned char> pixels;
-    int width = 0;
-    int height = 0;
-    bool ok = capturePanel->RenderToRGBA(pixels, width, height);
-    if (!ok || width <= 0 || height <= 0) {
+    symbols::RenderedSymbolImage render;
+    render.view = request.symbolView;
+    bool ok = capturePanel->RenderToRGBA(render.rgba, render.width, render.height);
+    if (!ok || render.width <= 0 || render.height <= 0) {
       allOk = false;
       break;
     }
-
-    wxImage image = BuildWxImageFromRgba(pixels, width, height);
-    if (image.IsOk()) {
-      image = image.Mirror(false);
-      image = image.Mirror(true);
-      if (requests[i].mirrorSideHorizontally)
-        image = image.Mirror(true);
-      image = CropAndZoomFixture(image);
-    }
-    images[i] = std::move(image);
-    if (!images[i].IsOk()) {
-      allOk = false;
-      break;
-    }
+    if (request.mirrorSideHorizontally)
+      MirrorImageHorizontally(render);
+    renders.push_back(std::move(render));
   }
   capturePanel->SetView(previousView);
 
@@ -277,7 +202,14 @@ void RunFixtureSymbolGeneration(MainWindow &window) {
     return;
   }
 
-  SymbolPreviewWindow *preview = new SymbolPreviewWindow(&window, images);
+  auto symbols = symbols::Symbol2DImageBuilder::BuildFromRenderedImages(renders);
+  if (symbols.size() != requests.size()) {
+    wxMessageBox("Could not generate all fixture symbols from captured views.",
+                 "Generate Fixture Symbols", wxOK | wxICON_ERROR, &window);
+    return;
+  }
+
+  SymbolPreviewWindow *preview = new SymbolPreviewWindow(&window, std::move(symbols));
   preview->Show();
 }
 

--- a/gui/tools/fixture_symbol_generation_tool.cpp
+++ b/gui/tools/fixture_symbol_generation_tool.cpp
@@ -14,9 +14,9 @@
 #include "dialogs/GenerateFixtureSymbolsDialog.h"
 #include "guiconfigservices.h"
 #include "mainwindow.h"
-#include "models/sceneobject.h"
-#include "models/support.h"
-#include "models/truss.h"
+#include "sceneobject.h"
+#include "support.h"
+#include "truss.h"
 #include "opaque_pass_utils.h"
 #include "symbols/Symbol2DImageBuilder.h"
 #include "viewer2doffscreenrenderer.h"
@@ -63,19 +63,32 @@ bool FixtureMatchesModelKeys(const Fixture &fixture,
   return false;
 }
 
+std::string FindSingleFixtureUuidForModelKeys(
+    const std::unordered_map<std::string, Fixture> &fixtures,
+    const std::vector<std::string> &modelKeys) {
+  std::string selectedUuid;
+  for (const auto &[uuid, fixture] : fixtures) {
+    if (!FixtureMatchesModelKeys(fixture, modelKeys))
+      continue;
+    if (selectedUuid.empty() || uuid < selectedUuid)
+      selectedUuid = uuid;
+  }
+  return selectedUuid;
+}
+
 class ScopedFixtureColorOverride {
 public:
-  ScopedFixtureColorOverride(ConfigManager &cfg,
-                             const std::vector<std::string> &modelKeys,
+  ScopedFixtureColorOverride(ConfigManager &cfg, const std::string &fixtureUuid,
                              const std::string &forcedHex)
       : cfg_(cfg) {
+    if (fixtureUuid.empty())
+      return;
     auto &fixtures = cfg_.GetScene().fixtures;
-    for (auto &[uuid, fixture] : fixtures) {
-      if (!FixtureMatchesModelKeys(fixture, modelKeys))
-        continue;
-      previous_.emplace_back(uuid, fixture.color);
-      fixture.color = forcedHex;
-    }
+    auto it = fixtures.find(fixtureUuid);
+    if (it == fixtures.end())
+      return;
+    previous_.emplace_back(it->first, it->second.color);
+    it->second.color = forcedHex;
   }
 
   ~ScopedFixtureColorOverride() {
@@ -95,7 +108,7 @@ private:
 class ScopedSymbolCaptureSceneOverride {
 public:
   ScopedSymbolCaptureSceneOverride(ConfigManager &cfg,
-                                   const std::vector<std::string> &modelKeys)
+                                   const std::string &fixtureUuid)
       : cfg_(cfg) {
     auto &scene = cfg_.GetScene();
     originalFixtures_ = scene.fixtures;
@@ -104,9 +117,10 @@ public:
     originalSupports_ = scene.supports;
 
     std::unordered_map<std::string, Fixture> filteredFixtures;
-    for (const auto &[uuid, fixture] : scene.fixtures) {
-      if (FixtureMatchesModelKeys(fixture, modelKeys))
-        filteredFixtures.emplace(uuid, fixture);
+    if (!fixtureUuid.empty()) {
+      auto fixtureIt = scene.fixtures.find(fixtureUuid);
+      if (fixtureIt != scene.fixtures.end())
+        filteredFixtures.emplace(fixtureIt->first, fixtureIt->second);
     }
 
     scene.fixtures = std::move(filteredFixtures);
@@ -215,11 +229,19 @@ void RunFixtureSymbolGeneration(MainWindow &window) {
   }
 
   ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+  const std::string selectedFixtureUuid =
+      FindSingleFixtureUuidForModelKeys(cfg.GetScene().fixtures,
+                                        options[static_cast<size_t>(selection)].modelKeys);
+  if (selectedFixtureUuid.empty()) {
+    wxMessageBox("Could not isolate a fixture instance for this fixture type.",
+                 "Generate Fixture Symbols", wxOK | wxICON_ERROR, &window);
+    return;
+  }
+
   const std::string forcedFixtureColor = "#3FA9F5";
-  ScopedSymbolCaptureSceneOverride isolatedSceneOverride(
-      cfg, options[static_cast<size_t>(selection)].modelKeys);
-  ScopedFixtureColorOverride selectedFixtureColorOverride(
-      cfg, options[static_cast<size_t>(selection)].modelKeys, forcedFixtureColor);
+  ScopedSymbolCaptureSceneOverride isolatedSceneOverride(cfg, selectedFixtureUuid);
+  ScopedFixtureColorOverride selectedFixtureColorOverride(cfg, selectedFixtureUuid,
+                                                          forcedFixtureColor);
   ScopedFloatConfigOverride displayOverride(
       cfg,
       {

--- a/gui/tools/fixture_symbol_generation_tool.cpp
+++ b/gui/tools/fixture_symbol_generation_tool.cpp
@@ -45,6 +45,50 @@ private:
   std::unordered_map<std::string, float> previous_;
 };
 
+bool FixtureMatchesModelKeys(const Fixture &fixture,
+                             const std::vector<std::string> &modelKeys) {
+  if (!fixture.gdtfSpec.empty() &&
+      std::find(modelKeys.begin(), modelKeys.end(),
+                NormalizeModelKey(fixture.gdtfSpec)) != modelKeys.end()) {
+    return true;
+  }
+  if (!fixture.typeName.empty() &&
+      std::find(modelKeys.begin(), modelKeys.end(), fixture.typeName) !=
+          modelKeys.end()) {
+    return true;
+  }
+  return false;
+}
+
+class ScopedFixtureColorOverride {
+public:
+  ScopedFixtureColorOverride(ConfigManager &cfg,
+                             const std::vector<std::string> &modelKeys,
+                             const std::string &forcedHex)
+      : cfg_(cfg) {
+    auto &fixtures = cfg_.GetScene().fixtures;
+    for (auto &[uuid, fixture] : fixtures) {
+      if (!FixtureMatchesModelKeys(fixture, modelKeys))
+        continue;
+      previous_.emplace_back(uuid, fixture.color);
+      fixture.color = forcedHex;
+    }
+  }
+
+  ~ScopedFixtureColorOverride() {
+    auto &fixtures = cfg_.GetScene().fixtures;
+    for (const auto &[uuid, color] : previous_) {
+      auto it = fixtures.find(uuid);
+      if (it != fixtures.end())
+        it->second.color = color;
+    }
+  }
+
+private:
+  ConfigManager &cfg_;
+  std::vector<std::pair<std::string, std::string>> previous_;
+};
+
 std::vector<FixtureSymbolTypeOption> BuildFixtureOptions() {
   std::vector<FixtureSymbolTypeOption> options;
   auto &scene = GetDefaultGuiConfigServices().LegacyConfigManager().GetScene();
@@ -129,12 +173,16 @@ void RunFixtureSymbolGeneration(MainWindow &window) {
   }
 
   ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+  const std::string forcedFixtureColor = "#3FA9F5";
+  ScopedFixtureColorOverride selectedFixtureColorOverride(
+      cfg, options[static_cast<size_t>(selection)].modelKeys, forcedFixtureColor);
   ScopedFloatConfigOverride displayOverride(
       cfg,
       {
           {"grid_show", 0.0f},
           {"view2d_dark_mode", 0.0f},
-          {"view2d_render_mode", static_cast<float>(Viewer2DRenderMode::White)},
+          {"view2d_render_mode",
+           static_cast<float>(Viewer2DRenderMode::ByFixtureType)},
           {"label_show_name_top", 0.0f},
           {"label_show_name_front", 0.0f},
           {"label_show_name_side", 0.0f},
@@ -150,7 +198,7 @@ void RunFixtureSymbolGeneration(MainWindow &window) {
 
   offscreenRenderer->SetViewportSize(wxSize(1200, 1200));
   offscreenRenderer->PrepareForCapture();
-  capturePanel->SetRenderMode(Viewer2DRenderMode::White);
+  capturePanel->SetRenderMode(Viewer2DRenderMode::ByFixtureType);
   capturePanel->UpdateScene(true);
   {
     std::vector<unsigned char> warmupPixels;

--- a/gui/tools/fixture_symbol_generation_tool.cpp
+++ b/gui/tools/fixture_symbol_generation_tool.cpp
@@ -14,6 +14,9 @@
 #include "dialogs/GenerateFixtureSymbolsDialog.h"
 #include "guiconfigservices.h"
 #include "mainwindow.h"
+#include "models/sceneobject.h"
+#include "models/support.h"
+#include "models/truss.h"
 #include "opaque_pass_utils.h"
 #include "symbols/Symbol2DImageBuilder.h"
 #include "viewer2doffscreenrenderer.h"
@@ -87,6 +90,45 @@ public:
 private:
   ConfigManager &cfg_;
   std::vector<std::pair<std::string, std::string>> previous_;
+};
+
+class ScopedSymbolCaptureSceneOverride {
+public:
+  ScopedSymbolCaptureSceneOverride(ConfigManager &cfg,
+                                   const std::vector<std::string> &modelKeys)
+      : cfg_(cfg) {
+    auto &scene = cfg_.GetScene();
+    originalFixtures_ = scene.fixtures;
+    originalTrusses_ = scene.trusses;
+    originalSceneObjects_ = scene.sceneObjects;
+    originalSupports_ = scene.supports;
+
+    std::unordered_map<std::string, Fixture> filteredFixtures;
+    for (const auto &[uuid, fixture] : scene.fixtures) {
+      if (FixtureMatchesModelKeys(fixture, modelKeys))
+        filteredFixtures.emplace(uuid, fixture);
+    }
+
+    scene.fixtures = std::move(filteredFixtures);
+    scene.trusses.clear();
+    scene.sceneObjects.clear();
+    scene.supports.clear();
+  }
+
+  ~ScopedSymbolCaptureSceneOverride() {
+    auto &scene = cfg_.GetScene();
+    scene.fixtures = std::move(originalFixtures_);
+    scene.trusses = std::move(originalTrusses_);
+    scene.sceneObjects = std::move(originalSceneObjects_);
+    scene.supports = std::move(originalSupports_);
+  }
+
+private:
+  ConfigManager &cfg_;
+  std::unordered_map<std::string, Fixture> originalFixtures_;
+  std::unordered_map<std::string, Truss> originalTrusses_;
+  std::unordered_map<std::string, SceneObject> originalSceneObjects_;
+  std::unordered_map<std::string, Support> originalSupports_;
 };
 
 std::vector<FixtureSymbolTypeOption> BuildFixtureOptions() {
@@ -174,6 +216,8 @@ void RunFixtureSymbolGeneration(MainWindow &window) {
 
   ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
   const std::string forcedFixtureColor = "#3FA9F5";
+  ScopedSymbolCaptureSceneOverride isolatedSceneOverride(
+      cfg, options[static_cast<size_t>(selection)].modelKeys);
   ScopedFixtureColorOverride selectedFixtureColorOverride(
       cfg, options[static_cast<size_t>(selection)].modelKeys, forcedFixtureColor);
   ScopedFloatConfigOverride displayOverride(

--- a/gui/windows/SymbolPreviewWindow.cpp
+++ b/gui/windows/SymbolPreviewWindow.cpp
@@ -3,25 +3,32 @@
 #include <algorithm>
 #include <cmath>
 #include <vector>
-#include <utility>
 
 #include <wx/dcbuffer.h>
-#include <wx/dcgraph.h>
 
 namespace {
 
-void DrawPolyline(wxDC &dc, const symbols::Polyline2D &line, double minX, double minY,
-                  double scale, int offsetX, int offsetY, int imageHeight) {
+wxPoint ToScreenPoint(const symbols::Point2D &p, const symbols::Aabb2D &bounds,
+                      double scale, int originX, int originY) {
+  const double sx = (static_cast<double>(p.x) - static_cast<double>(bounds.min.x)) *
+                    scale;
+  const double sy =
+      (static_cast<double>(bounds.max.y) - static_cast<double>(p.y)) * scale;
+  return wxPoint(originX + static_cast<int>(std::round(sx)),
+                 originY + static_cast<int>(std::round(sy)));
+}
+
+void DrawPolyline(wxDC &dc, const symbols::Polyline2D &line,
+                  const symbols::Aabb2D &bounds, double scale, int originX,
+                  int originY) {
   if (line.size() < 2)
     return;
+
   std::vector<wxPoint> points;
   points.reserve(line.size());
-  for (const auto &p : line) {
-    const double px = (static_cast<double>(p.x) - minX) * scale;
-    const double py = (static_cast<double>(imageHeight) - static_cast<double>(p.y) - minY) * scale;
-    points.emplace_back(offsetX + static_cast<int>(std::round(px)),
-                        offsetY + static_cast<int>(std::round(py)));
-  }
+  for (const auto &p : line)
+    points.push_back(ToScreenPoint(p, bounds, scale, originX, originY));
+
   dc.DrawLines(static_cast<int>(points.size()), points.data());
 }
 
@@ -34,13 +41,21 @@ SymbolPreviewWindow::SymbolPreviewWindow(wxWindow *parent,
       symbols_(std::move(symbols)) {
   SetBackgroundStyle(wxBG_STYLE_PAINT);
   Bind(wxEVT_PAINT, &SymbolPreviewWindow::OnPaint, this);
+  Bind(wxEVT_SIZE, &SymbolPreviewWindow::OnSize, this);
 }
 
 const symbols::Symbol2D *SymbolPreviewWindow::FindSymbol(
     const std::vector<symbols::Symbol2D> &symbols, symbols::SymbolView view) {
-  auto it = std::find_if(symbols.begin(), symbols.end(),
-                         [view](const symbols::Symbol2D &symbol) { return symbol.view == view; });
+  auto it =
+      std::find_if(symbols.begin(), symbols.end(), [view](const symbols::Symbol2D &symbol) {
+        return symbol.view == view;
+      });
   return it == symbols.end() ? nullptr : &(*it);
+}
+
+void SymbolPreviewWindow::OnSize(wxSizeEvent &event) {
+  Refresh(false);
+  event.Skip();
 }
 
 void SymbolPreviewWindow::OnPaint(wxPaintEvent &WXUNUSED(event)) {
@@ -67,7 +82,7 @@ void SymbolPreviewWindow::DrawCell(wxDC &dc, const wxRect &cell,
                                    const symbols::Symbol2D *symbol,
                                    const wxString &label) {
   dc.SetPen(wxPen(wxColour(210, 210, 210), 1));
-  dc.SetBrush(*wxTRANSPARENT_BRUSH);
+  dc.SetBrush(*wxWHITE_BRUSH);
   dc.DrawRectangle(cell);
   dc.DrawText(label, cell.GetTopLeft() + wxPoint(8, 8));
 
@@ -76,38 +91,45 @@ void SymbolPreviewWindow::DrawCell(wxDC &dc, const wxRect &cell,
 
   const int innerPad = 12;
   const int topLabel = 24;
-  const int availW = std::max(1, cell.GetWidth() - innerPad * 2);
-  const int availH = std::max(1, cell.GetHeight() - topLabel - innerPad * 2);
+  const wxRect contentRect(cell.GetX() + innerPad, cell.GetY() + topLabel,
+                           std::max(1, cell.GetWidth() - innerPad * 2),
+                           std::max(1, cell.GetHeight() - topLabel - innerPad));
 
-  const double symbolW = std::max(1.0, static_cast<double>(symbol->bounds.max.x - symbol->bounds.min.x));
-  const double symbolH = std::max(1.0, static_cast<double>(symbol->bounds.max.y - symbol->bounds.min.y));
-  const double scale = std::min(static_cast<double>(availW) / symbolW,
-                                static_cast<double>(availH) / symbolH);
+  dc.SetPen(*wxTRANSPARENT_PEN);
+  dc.SetBrush(*wxWHITE_BRUSH);
+  dc.DrawRectangle(contentRect);
+
+  const double symbolW =
+      std::max(1.0, static_cast<double>(symbol->bounds.max.x - symbol->bounds.min.x));
+  const double symbolH =
+      std::max(1.0, static_cast<double>(symbol->bounds.max.y - symbol->bounds.min.y));
+  const double scale = std::min(static_cast<double>(contentRect.GetWidth()) / symbolW,
+                                static_cast<double>(contentRect.GetHeight()) / symbolH);
 
   const int drawW = std::max(1, static_cast<int>(std::round(symbolW * scale)));
   const int drawH = std::max(1, static_cast<int>(std::round(symbolH * scale)));
-  const int x = cell.GetX() + (cell.GetWidth() - drawW) / 2;
-  const int y = cell.GetY() + topLabel + (cell.GetHeight() - topLabel - drawH) / 2;
+  const int originX = contentRect.GetX() + (contentRect.GetWidth() - drawW) / 2;
+  const int originY = contentRect.GetY() + (contentRect.GetHeight() - drawH) / 2;
 
   dc.SetPen(*wxTRANSPARENT_PEN);
-  dc.SetBrush(wxBrush(wxColour(225, 230, 238)));
+  dc.SetBrush(wxBrush(wxColour(224, 224, 224)));
   for (const auto &polygon : symbol->fill) {
     if (polygon.outer.size() < 3)
       continue;
+
     std::vector<wxPoint> pts;
     pts.reserve(polygon.outer.size());
-    for (const auto &p : polygon.outer) {
-      const double px = (static_cast<double>(p.x) - symbol->bounds.min.x) * scale;
-      const double py = (symbolH - (static_cast<double>(p.y) - symbol->bounds.min.y)) * scale;
-      pts.emplace_back(x + static_cast<int>(std::round(px)),
-                       y + static_cast<int>(std::round(py)));
-    }
+    for (const auto &p : polygon.outer)
+      pts.push_back(
+          ToScreenPoint(p, symbol->bounds, scale, originX, originY));
+
     dc.DrawPolygon(static_cast<int>(pts.size()), pts.data());
   }
 
-  dc.SetPen(wxPen(*wxBLACK, std::max(1, static_cast<int>(std::round(symbol->strokeWidthPx)))));
+  const int strokePx =
+      std::max(1, static_cast<int>(std::round(symbol->strokeWidthPx)));
+  dc.SetPen(wxPen(wxColour(0, 0, 0), strokePx, wxPENSTYLE_SOLID));
   dc.SetBrush(*wxTRANSPARENT_BRUSH);
   for (const auto &line : symbol->strokes)
-    DrawPolyline(dc, line, symbol->bounds.min.x, symbol->bounds.min.y, scale, x, y,
-                 static_cast<int>(std::ceil(symbolH)));
+    DrawPolyline(dc, line, symbol->bounds, scale, originX, originY);
 }

--- a/gui/windows/SymbolPreviewWindow.cpp
+++ b/gui/windows/SymbolPreviewWindow.cpp
@@ -1,17 +1,46 @@
 #include "windows/SymbolPreviewWindow.h"
 
 #include <algorithm>
+#include <cmath>
+#include <vector>
+#include <utility>
 
-#include <wx/bitmap.h>
 #include <wx/dcbuffer.h>
+#include <wx/dcgraph.h>
+
+namespace {
+
+void DrawPolyline(wxDC &dc, const symbols::Polyline2D &line, double minX, double minY,
+                  double scale, int offsetX, int offsetY, int imageHeight) {
+  if (line.size() < 2)
+    return;
+  std::vector<wxPoint> points;
+  points.reserve(line.size());
+  for (const auto &p : line) {
+    const double px = (static_cast<double>(p.x) - minX) * scale;
+    const double py = (static_cast<double>(imageHeight) - static_cast<double>(p.y) - minY) * scale;
+    points.emplace_back(offsetX + static_cast<int>(std::round(px)),
+                        offsetY + static_cast<int>(std::round(py)));
+  }
+  dc.DrawLines(static_cast<int>(points.size()), points.data());
+}
+
+} // namespace
 
 SymbolPreviewWindow::SymbolPreviewWindow(wxWindow *parent,
-                                         const std::array<wxImage, 4> &images)
+                                         std::vector<symbols::Symbol2D> symbols)
     : wxFrame(parent, wxID_ANY, "Fixture Symbol Preview", wxDefaultPosition,
               wxSize(1000, 760), wxDEFAULT_FRAME_STYLE | wxFRAME_FLOAT_ON_PARENT),
-      images_(images) {
+      symbols_(std::move(symbols)) {
   SetBackgroundStyle(wxBG_STYLE_PAINT);
   Bind(wxEVT_PAINT, &SymbolPreviewWindow::OnPaint, this);
+}
+
+const symbols::Symbol2D *SymbolPreviewWindow::FindSymbol(
+    const std::vector<symbols::Symbol2D> &symbols, symbols::SymbolView view) {
+  auto it = std::find_if(symbols.begin(), symbols.end(),
+                         [view](const symbols::Symbol2D &symbol) { return symbol.view == view; });
+  return it == symbols.end() ? nullptr : &(*it);
 }
 
 void SymbolPreviewWindow::OnPaint(wxPaintEvent &WXUNUSED(event)) {
@@ -24,39 +53,61 @@ void SymbolPreviewWindow::OnPaint(wxPaintEvent &WXUNUSED(event)) {
   const int cellW = std::max(1, (size.GetWidth() - pad * 3) / 2);
   const int cellH = std::max(1, (size.GetHeight() - pad * 3) / 2);
 
-  DrawCell(dc, wxRect(pad, pad, cellW, cellH), images_[0], "Front");
-  DrawCell(dc, wxRect(pad * 2 + cellW, pad, cellW, cellH), images_[1], "Top");
-  DrawCell(dc, wxRect(pad, pad * 2 + cellH, cellW, cellH), images_[2], "Left");
-  DrawCell(dc, wxRect(pad * 2 + cellW, pad * 2 + cellH, cellW, cellH), images_[3],
-           "Bottom");
+  DrawCell(dc, wxRect(pad, pad, cellW, cellH),
+           FindSymbol(symbols_, symbols::SymbolView::Front), "Front");
+  DrawCell(dc, wxRect(pad * 2 + cellW, pad, cellW, cellH),
+           FindSymbol(symbols_, symbols::SymbolView::Top), "Top");
+  DrawCell(dc, wxRect(pad, pad * 2 + cellH, cellW, cellH),
+           FindSymbol(symbols_, symbols::SymbolView::Left), "Left");
+  DrawCell(dc, wxRect(pad * 2 + cellW, pad * 2 + cellH, cellW, cellH),
+           FindSymbol(symbols_, symbols::SymbolView::Bottom), "Bottom");
 }
 
 void SymbolPreviewWindow::DrawCell(wxDC &dc, const wxRect &cell,
-                                   const wxImage &image,
+                                   const symbols::Symbol2D *symbol,
                                    const wxString &label) {
   dc.SetPen(wxPen(wxColour(210, 210, 210), 1));
   dc.SetBrush(*wxTRANSPARENT_BRUSH);
   dc.DrawRectangle(cell);
   dc.DrawText(label, cell.GetTopLeft() + wxPoint(8, 8));
 
-  if (!image.IsOk())
+  if (!symbol || !symbol->bounds.valid)
     return;
 
-  const int innerPad = 10;
+  const int innerPad = 12;
   const int topLabel = 24;
   const int availW = std::max(1, cell.GetWidth() - innerPad * 2);
   const int availH = std::max(1, cell.GetHeight() - topLabel - innerPad * 2);
 
-  const double sx = static_cast<double>(availW) / image.GetWidth();
-  const double sy = static_cast<double>(availH) / image.GetHeight();
-  const double scale = std::min(sx, sy);
+  const double symbolW = std::max(1.0, static_cast<double>(symbol->bounds.max.x - symbol->bounds.min.x));
+  const double symbolH = std::max(1.0, static_cast<double>(symbol->bounds.max.y - symbol->bounds.min.y));
+  const double scale = std::min(static_cast<double>(availW) / symbolW,
+                                static_cast<double>(availH) / symbolH);
 
-  const int drawW = std::max(1, static_cast<int>(image.GetWidth() * scale));
-  const int drawH = std::max(1, static_cast<int>(image.GetHeight() * scale));
-
+  const int drawW = std::max(1, static_cast<int>(std::round(symbolW * scale)));
+  const int drawH = std::max(1, static_cast<int>(std::round(symbolH * scale)));
   const int x = cell.GetX() + (cell.GetWidth() - drawW) / 2;
   const int y = cell.GetY() + topLabel + (cell.GetHeight() - topLabel - drawH) / 2;
 
-  wxImage scaled = image.Scale(drawW, drawH, wxIMAGE_QUALITY_HIGH);
-  dc.DrawBitmap(wxBitmap(scaled), x, y, true);
+  dc.SetPen(*wxTRANSPARENT_PEN);
+  dc.SetBrush(wxBrush(wxColour(225, 230, 238)));
+  for (const auto &polygon : symbol->fill) {
+    if (polygon.outer.size() < 3)
+      continue;
+    std::vector<wxPoint> pts;
+    pts.reserve(polygon.outer.size());
+    for (const auto &p : polygon.outer) {
+      const double px = (static_cast<double>(p.x) - symbol->bounds.min.x) * scale;
+      const double py = (symbolH - (static_cast<double>(p.y) - symbol->bounds.min.y)) * scale;
+      pts.emplace_back(x + static_cast<int>(std::round(px)),
+                       y + static_cast<int>(std::round(py)));
+    }
+    dc.DrawPolygon(static_cast<int>(pts.size()), pts.data());
+  }
+
+  dc.SetPen(wxPen(*wxBLACK, std::max(1, static_cast<int>(std::round(symbol->strokeWidthPx)))));
+  dc.SetBrush(*wxTRANSPARENT_BRUSH);
+  for (const auto &line : symbol->strokes)
+    DrawPolyline(dc, line, symbol->bounds.min.x, symbol->bounds.min.y, scale, x, y,
+                 static_cast<int>(std::ceil(symbolH)));
 }

--- a/gui/windows/SymbolPreviewWindow.cpp
+++ b/gui/windows/SymbolPreviewWindow.cpp
@@ -124,6 +124,21 @@ void SymbolPreviewWindow::DrawCell(wxDC &dc, const wxRect &cell,
           ToScreenPoint(p, symbol->bounds, scale, originX, originY));
 
     dc.DrawPolygon(static_cast<int>(pts.size()), pts.data());
+
+    if (!polygon.holes.empty()) {
+      dc.SetBrush(*wxWHITE_BRUSH);
+      for (const auto &hole : polygon.holes) {
+        if (hole.size() < 3)
+          continue;
+        std::vector<wxPoint> holePts;
+        holePts.reserve(hole.size());
+        for (const auto &p : hole)
+          holePts.push_back(
+              ToScreenPoint(p, symbol->bounds, scale, originX, originY));
+        dc.DrawPolygon(static_cast<int>(holePts.size()), holePts.data());
+      }
+      dc.SetBrush(wxBrush(wxColour(224, 224, 224)));
+    }
   }
 
   const int strokePx =

--- a/gui/windows/SymbolPreviewWindow.h
+++ b/gui/windows/SymbolPreviewWindow.h
@@ -13,6 +13,7 @@ public:
 
 private:
   void OnPaint(wxPaintEvent &event);
+  void OnSize(wxSizeEvent &event);
   void DrawCell(wxDC &dc, const wxRect &cell, const symbols::Symbol2D *symbol,
                 const wxString &label);
   static const symbols::Symbol2D *FindSymbol(

--- a/gui/windows/SymbolPreviewWindow.h
+++ b/gui/windows/SymbolPreviewWindow.h
@@ -1,19 +1,22 @@
 #pragma once
 
-#include <array>
+#include <vector>
 
 #include <wx/frame.h>
-#include <wx/image.h>
+
+#include "symbols/Symbol2D.h"
 
 class SymbolPreviewWindow : public wxFrame {
 public:
   SymbolPreviewWindow(wxWindow *parent,
-                      const std::array<wxImage, 4> &images);
+                      std::vector<symbols::Symbol2D> symbols);
 
 private:
   void OnPaint(wxPaintEvent &event);
-  void DrawCell(wxDC &dc, const wxRect &cell, const wxImage &image,
+  void DrawCell(wxDC &dc, const wxRect &cell, const symbols::Symbol2D *symbol,
                 const wxString &label);
+  static const symbols::Symbol2D *FindSymbol(
+      const std::vector<symbols::Symbol2D> &symbols, symbols::SymbolView view);
 
-  std::array<wxImage, 4> images_;
+  std::vector<symbols::Symbol2D> symbols_;
 };


### PR DESCRIPTION
### Motivation
- Provide a reproducible path from the existing orthographic RGBA captures to lightweight 2D vector symbols (fill + centerline strokes) so generated symbols can be inspected and validated before any export integration.
- Ensure preview rendering keeps stroke thickness constant in screen pixels while reusing the viewer capture pipeline (no new orthographic renderer path).

### Description
- Added a new image-to-vector builder `core/symbols/Symbol2DImageBuilder` with `RenderedSymbolImage` and `ImageBuildParams` and an API `BuildFromRenderedImages` to produce `Symbol2D` objects from captured RGBA images.
- Implemented mask extraction (fill / line thresholding), Zhang–Suen thinning (`ThinZhangSuen`), pixel-graph traversal and polyline extraction (`ExtractPolylines`), and an outer-fill trace (`TraceOuterPolygon`) to populate `Symbol2D.fill`, `Symbol2D.strokes` and bounds.
- Updated the fixture symbol generation flow in `gui/tools/fixture_symbol_generation_tool.cpp` to capture the four required views as `RenderedSymbolImage` instances (including a side-mirror helper) and to call the new builder instead of showing raw bitmaps.
- Reworked the preview UI: `gui/windows/SymbolPreviewWindow` now accepts `std::vector<symbols::Symbol2D>` and draws the 2×2 grid rendering fills and centerline strokes with a fixed-pixel pen width during fit/scale calculations, and registered the new core source in `core/CMakeLists.txt`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed successfully.
- Attempted `cmake -S . -B build` to validate compilation, but configure failed in this environment due to missing system wxWidgets development libraries so a full build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69999be51b5483248bcaa31edd0ee904)