### PR TITLE
Add scene-model orthographic symbol capture service and refactor fixture tool

### DIFF
--- a/docs/scene_model_symbol_capture.md
+++ b/docs/scene_model_symbol_capture.md
@@ -1,0 +1,57 @@
+# Scene model symbol capture service
+
+This document describes the reusable API that captures vector symbols for any 3D model instance present in the scene.
+
+## Purpose
+
+`CaptureSceneModelOrthographicSymbols` generalizes the workflow used by the fixture symbol generation tool so other modules can request symbols for:
+
+- Fixture instances.
+- Truss instances.
+- Generic scene objects.
+
+The result is a vector-ready set of orthographic symbols (`Front`, `Top`, `Left`, `Bottom`) generated from the same 2D offscreen capture pipeline.
+
+## Location
+
+- Header: `gui/tools/scene_model_symbol_capture_service.h`
+- Implementation: `gui/tools/scene_model_symbol_capture_service.cpp`
+
+## Public API
+
+```cpp
+SceneModelSymbolCaptureResult
+CaptureSceneModelOrthographicSymbols(Viewer2DOffscreenRenderer &renderer,
+                                     ConfigManager &cfg,
+                                     const SceneModelSymbolTarget &target,
+                                     const SceneModelSymbolCaptureOptions &options = {});
+```
+
+### Input
+
+- `target.kind`: `Fixture`, `Truss`, or `SceneObject`.
+- `target.uuid`: UUID of the specific scene instance.
+- `options.alignToLocalAxes`:
+  - `false` (default): captures with current world orientation.
+  - `true`: temporarily removes world rotation while preserving per-axis scale, so orthographic views are captured in the object's local axes (useful for rotated instances).
+- `options.forcedFixtureColor`: optional color override for fixture captures.
+
+### Output
+
+`SceneModelSymbolCaptureResult` returns:
+
+- `ok`: true when all four views were captured and converted.
+- `error`: user-readable error when capture fails.
+- `symbols`: generated `symbols::Symbol2D` list.
+
+## Internal process summary
+
+1. Isolate the requested scene instance in a temporary scene override.
+2. Optionally align the instance transform to local axes.
+3. Apply capture-focused config overrides (hide grid/labels, force symbol-friendly render settings).
+4. Capture source RGBA images for `Front`, `Top`, `Side` (mirrored to `Left`), and inverted `Top` (as `Bottom`).
+5. Convert images to vector symbols with `symbols::Symbol2DImageBuilder`.
+
+## Current integration
+
+The existing fixture symbol generation tool now delegates capture to this service, so the same pipeline can be reused by future PDF/layout vector workflows.

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -5,6 +5,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/consolepanel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dictionaryeditdialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tools/fixture_symbol_generation_tool.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/tools/scene_model_symbol_capture_service.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/windows/SymbolPreviewWindow.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dialogs/GenerateFixtureSymbolsDialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/exportfixturedialog.cpp

--- a/gui/tools/fixture_symbol_generation_tool.cpp
+++ b/gui/tools/fixture_symbol_generation_tool.cpp
@@ -1,7 +1,6 @@
 #include "tools/fixture_symbol_generation_tool.h"
 
 #include <algorithm>
-#include <array>
 #include <map>
 #include <set>
 #include <string>
@@ -14,39 +13,13 @@
 #include "dialogs/GenerateFixtureSymbolsDialog.h"
 #include "guiconfigservices.h"
 #include "mainwindow.h"
-#include "sceneobject.h"
-#include "support.h"
-#include "truss.h"
 #include "opaque_pass_utils.h"
-#include "symbols/Symbol2DImageBuilder.h"
+#include "tools/scene_model_symbol_capture_service.h"
 #include "viewer2doffscreenrenderer.h"
-#include "viewer2dpanel.h"
 #include "windows/SymbolPreviewWindow.h"
 
 namespace tools {
 namespace {
-
-class ScopedFloatConfigOverride {
-public:
-  ScopedFloatConfigOverride(ConfigManager &cfg,
-                            std::initializer_list<std::pair<const char *, float>> values)
-      : cfg_(cfg) {
-    for (const auto &entry : values) {
-      const std::string key(entry.first);
-      previous_[key] = cfg_.GetFloat(key);
-      cfg_.SetFloat(key, entry.second);
-    }
-  }
-
-  ~ScopedFloatConfigOverride() {
-    for (const auto &[key, value] : previous_)
-      cfg_.SetFloat(key, value);
-  }
-
-private:
-  ConfigManager &cfg_;
-  std::unordered_map<std::string, float> previous_;
-};
 
 bool FixtureMatchesModelKeys(const Fixture &fixture,
                              const std::vector<std::string> &modelKeys) {
@@ -75,75 +48,6 @@ std::string FindSingleFixtureUuidForModelKeys(
   }
   return selectedUuid;
 }
-
-class ScopedFixtureColorOverride {
-public:
-  ScopedFixtureColorOverride(ConfigManager &cfg, const std::string &fixtureUuid,
-                             const std::string &forcedHex)
-      : cfg_(cfg) {
-    if (fixtureUuid.empty())
-      return;
-    auto &fixtures = cfg_.GetScene().fixtures;
-    auto it = fixtures.find(fixtureUuid);
-    if (it == fixtures.end())
-      return;
-    previous_.emplace_back(it->first, it->second.color);
-    it->second.color = forcedHex;
-  }
-
-  ~ScopedFixtureColorOverride() {
-    auto &fixtures = cfg_.GetScene().fixtures;
-    for (const auto &[uuid, color] : previous_) {
-      auto it = fixtures.find(uuid);
-      if (it != fixtures.end())
-        it->second.color = color;
-    }
-  }
-
-private:
-  ConfigManager &cfg_;
-  std::vector<std::pair<std::string, std::string>> previous_;
-};
-
-class ScopedSymbolCaptureSceneOverride {
-public:
-  ScopedSymbolCaptureSceneOverride(ConfigManager &cfg,
-                                   const std::string &fixtureUuid)
-      : cfg_(cfg) {
-    auto &scene = cfg_.GetScene();
-    originalFixtures_ = scene.fixtures;
-    originalTrusses_ = scene.trusses;
-    originalSceneObjects_ = scene.sceneObjects;
-    originalSupports_ = scene.supports;
-
-    std::unordered_map<std::string, Fixture> filteredFixtures;
-    if (!fixtureUuid.empty()) {
-      auto fixtureIt = scene.fixtures.find(fixtureUuid);
-      if (fixtureIt != scene.fixtures.end())
-        filteredFixtures.emplace(fixtureIt->first, fixtureIt->second);
-    }
-
-    scene.fixtures = std::move(filteredFixtures);
-    scene.trusses.clear();
-    scene.sceneObjects.clear();
-    scene.supports.clear();
-  }
-
-  ~ScopedSymbolCaptureSceneOverride() {
-    auto &scene = cfg_.GetScene();
-    scene.fixtures = std::move(originalFixtures_);
-    scene.trusses = std::move(originalTrusses_);
-    scene.sceneObjects = std::move(originalSceneObjects_);
-    scene.supports = std::move(originalSupports_);
-  }
-
-private:
-  ConfigManager &cfg_;
-  std::unordered_map<std::string, Fixture> originalFixtures_;
-  std::unordered_map<std::string, Truss> originalTrusses_;
-  std::unordered_map<std::string, SceneObject> originalSceneObjects_;
-  std::unordered_map<std::string, Support> originalSupports_;
-};
 
 std::vector<FixtureSymbolTypeOption> BuildFixtureOptions() {
   std::vector<FixtureSymbolTypeOption> options;
@@ -176,26 +80,6 @@ std::vector<FixtureSymbolTypeOption> BuildFixtureOptions() {
   return options;
 }
 
-void MirrorImageHorizontally(symbols::RenderedSymbolImage &render) {
-  if (render.width <= 0 || render.height <= 0)
-    return;
-  for (int y = 0; y < render.height; ++y) {
-    for (int x = 0; x < render.width / 2; ++x) {
-      const int opposite = render.width - 1 - x;
-      const size_t left =
-          (static_cast<size_t>(y) * static_cast<size_t>(render.width) +
-           static_cast<size_t>(x)) *
-          4;
-      const size_t right =
-          (static_cast<size_t>(y) * static_cast<size_t>(render.width) +
-           static_cast<size_t>(opposite)) *
-          4;
-      for (size_t c = 0; c < 4; ++c)
-        std::swap(render.rgba[left + c], render.rgba[right + c]);
-    }
-  }
-}
-
 } // namespace
 
 void RunFixtureSymbolGeneration(MainWindow &window) {
@@ -221,13 +105,6 @@ void RunFixtureSymbolGeneration(MainWindow &window) {
                  "Generate Fixture Symbols", wxOK | wxICON_ERROR, &window);
     return;
   }
-  Viewer2DPanel *capturePanel = offscreenRenderer->GetPanel();
-  if (!capturePanel) {
-    wxMessageBox("Could not create 2D capture panel instance.",
-                 "Generate Fixture Symbols", wxOK | wxICON_ERROR, &window);
-    return;
-  }
-
   ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
   const std::string selectedFixtureUuid =
       FindSingleFixtureUuidForModelKeys(cfg.GetScene().fixtures,
@@ -239,91 +116,20 @@ void RunFixtureSymbolGeneration(MainWindow &window) {
   }
 
   const std::string forcedFixtureColor = "#3FA9F5";
-  ScopedSymbolCaptureSceneOverride isolatedSceneOverride(cfg, selectedFixtureUuid);
-  ScopedFixtureColorOverride selectedFixtureColorOverride(cfg, selectedFixtureUuid,
-                                                          forcedFixtureColor);
-  ScopedFloatConfigOverride displayOverride(
-      cfg,
-      {
-          {"grid_show", 0.0f},
-          {"view2d_dark_mode", 0.0f},
-          {"view2d_render_mode",
-           static_cast<float>(Viewer2DRenderMode::ByFixtureType)},
-          {"label_show_name_top", 0.0f},
-          {"label_show_name_front", 0.0f},
-          {"label_show_name_side", 0.0f},
-          {"label_show_id_top", 0.0f},
-          {"label_show_id_front", 0.0f},
-          {"label_show_id_side", 0.0f},
-          {"label_show_dmx_top", 0.0f},
-          {"label_show_dmx_front", 0.0f},
-          {"label_show_dmx_side", 0.0f},
-      });
-
-  const Viewer2DView previousView = capturePanel->GetView();
-
-  offscreenRenderer->SetViewportSize(wxSize(1200, 1200));
-  offscreenRenderer->PrepareForCapture();
-  capturePanel->SetRenderMode(Viewer2DRenderMode::ByFixtureType);
-  capturePanel->UpdateScene(true);
-  {
-    std::vector<unsigned char> warmupPixels;
-    int warmupWidth = 0;
-    int warmupHeight = 0;
-    (void)capturePanel->RenderToRGBA(warmupPixels, warmupWidth, warmupHeight);
-  }
-
-  struct CaptureRequest {
-    Viewer2DView view = Viewer2DView::Top;
-    float topFixturesInverted = 0.0f;
-    bool mirrorSideHorizontally = false;
-    symbols::SymbolView symbolView = symbols::SymbolView::Top;
-  };
-  const std::array<CaptureRequest, 4> requests = {
-      CaptureRequest{Viewer2DView::Front, 0.0f, false, symbols::SymbolView::Front},
-      CaptureRequest{Viewer2DView::Top, 0.0f, false, symbols::SymbolView::Top},
-      CaptureRequest{Viewer2DView::Side, 0.0f, true, symbols::SymbolView::Left},
-      CaptureRequest{Viewer2DView::Top, 1.0f, false, symbols::SymbolView::Bottom},
-  };
-
-  std::vector<symbols::RenderedSymbolImage> renders;
-  renders.reserve(requests.size());
-  bool allOk = true;
-  for (const auto &request : requests) {
-    ScopedFloatConfigOverride topViewOverride(
-        cfg, {{"view2d_top_fixtures_inverted", request.topFixturesInverted}});
-
-    capturePanel->SetView(request.view);
-    capturePanel->UpdateScene(true);
-    capturePanel->FitViewToScene();
-
-    symbols::RenderedSymbolImage render;
-    render.view = request.symbolView;
-    bool ok = capturePanel->RenderToRGBA(render.rgba, render.width, render.height);
-    if (!ok || render.width <= 0 || render.height <= 0) {
-      allOk = false;
-      break;
-    }
-    if (request.mirrorSideHorizontally)
-      MirrorImageHorizontally(render);
-    renders.push_back(std::move(render));
-  }
-  capturePanel->SetView(previousView);
-
-  if (!allOk) {
-    wxMessageBox("Could not capture all orthographic source images from the 2D viewer.",
-                 "Generate Fixture Symbols", wxOK | wxICON_ERROR, &window);
+  SceneModelSymbolCaptureOptions captureOptions;
+  captureOptions.forcedFixtureColor = forcedFixtureColor;
+  auto capture = CaptureSceneModelOrthographicSymbols(
+      *offscreenRenderer, cfg,
+      SceneModelSymbolTarget{SceneModelKind::Fixture, selectedFixtureUuid},
+      captureOptions);
+  if (!capture.ok) {
+    wxMessageBox(capture.error, "Generate Fixture Symbols", wxOK | wxICON_ERROR,
+                 &window);
     return;
   }
 
-  auto symbols = symbols::Symbol2DImageBuilder::BuildFromRenderedImages(renders);
-  if (symbols.size() != requests.size()) {
-    wxMessageBox("Could not generate all fixture symbols from captured views.",
-                 "Generate Fixture Symbols", wxOK | wxICON_ERROR, &window);
-    return;
-  }
-
-  SymbolPreviewWindow *preview = new SymbolPreviewWindow(&window, std::move(symbols));
+  SymbolPreviewWindow *preview =
+      new SymbolPreviewWindow(&window, std::move(capture.symbols));
   preview->Show();
 }
 

--- a/gui/tools/scene_model_symbol_capture_service.cpp
+++ b/gui/tools/scene_model_symbol_capture_service.cpp
@@ -1,0 +1,266 @@
+#include "tools/scene_model_symbol_capture_service.h"
+
+#include <array>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "configmanager.h"
+#include "fixture.h"
+#include "matrixutils.h"
+#include "sceneobject.h"
+#include "support.h"
+#include "symbols/Symbol2DImageBuilder.h"
+#include "truss.h"
+#include "viewer2doffscreenrenderer.h"
+#include "viewer2dpanel.h"
+
+namespace tools {
+namespace {
+
+class ScopedFloatConfigOverride {
+public:
+  ScopedFloatConfigOverride(ConfigManager &cfg,
+                            std::initializer_list<std::pair<const char *, float>> values)
+      : cfg_(cfg) {
+    for (const auto &entry : values) {
+      const std::string key(entry.first);
+      previous_[key] = cfg_.GetFloat(key);
+      cfg_.SetFloat(key, entry.second);
+    }
+  }
+
+  ~ScopedFloatConfigOverride() {
+    for (const auto &[key, value] : previous_)
+      cfg_.SetFloat(key, value);
+  }
+
+private:
+  ConfigManager &cfg_;
+  std::unordered_map<std::string, float> previous_;
+};
+
+class ScopedFixtureColorOverride {
+public:
+  ScopedFixtureColorOverride(ConfigManager &cfg, const std::string &fixtureUuid,
+                             const std::optional<std::string> &forcedHex)
+      : cfg_(cfg) {
+    if (!forcedHex || fixtureUuid.empty())
+      return;
+    auto &fixtures = cfg_.GetScene().fixtures;
+    auto it = fixtures.find(fixtureUuid);
+    if (it == fixtures.end())
+      return;
+    previous_.emplace_back(it->first, it->second.color);
+    it->second.color = *forcedHex;
+  }
+
+  ~ScopedFixtureColorOverride() {
+    auto &fixtures = cfg_.GetScene().fixtures;
+    for (const auto &[uuid, color] : previous_) {
+      auto it = fixtures.find(uuid);
+      if (it != fixtures.end())
+        it->second.color = color;
+    }
+  }
+
+private:
+  ConfigManager &cfg_;
+  std::vector<std::pair<std::string, std::string>> previous_;
+};
+
+class ScopedSingleModelSceneOverride {
+public:
+  ScopedSingleModelSceneOverride(ConfigManager &cfg,
+                                 const SceneModelSymbolTarget &target,
+                                 bool alignToLocalAxes)
+      : cfg_(cfg) {
+    auto &scene = cfg_.GetScene();
+    originalFixtures_ = scene.fixtures;
+    originalTrusses_ = scene.trusses;
+    originalSceneObjects_ = scene.sceneObjects;
+    originalSupports_ = scene.supports;
+
+    scene.fixtures.clear();
+    scene.trusses.clear();
+    scene.sceneObjects.clear();
+    scene.supports.clear();
+
+    switch (target.kind) {
+    case SceneModelKind::Fixture: {
+      auto it = originalFixtures_.find(target.uuid);
+      if (it != originalFixtures_.end()) {
+        Fixture fixture = it->second;
+        if (alignToLocalAxes)
+          fixture.transform = AlignRotationToIdentityKeepingScale(fixture.transform);
+        scene.fixtures.emplace(it->first, std::move(fixture));
+      }
+      break;
+    }
+    case SceneModelKind::Truss: {
+      auto it = originalTrusses_.find(target.uuid);
+      if (it != originalTrusses_.end()) {
+        Truss truss = it->second;
+        if (alignToLocalAxes)
+          truss.transform = AlignRotationToIdentityKeepingScale(truss.transform);
+        scene.trusses.emplace(it->first, std::move(truss));
+      }
+      break;
+    }
+    case SceneModelKind::SceneObject: {
+      auto it = originalSceneObjects_.find(target.uuid);
+      if (it != originalSceneObjects_.end()) {
+        SceneObject object = it->second;
+        if (alignToLocalAxes)
+          object.transform = AlignRotationToIdentityKeepingScale(object.transform);
+        scene.sceneObjects.emplace(it->first, std::move(object));
+      }
+      break;
+    }
+    }
+  }
+
+  ~ScopedSingleModelSceneOverride() {
+    auto &scene = cfg_.GetScene();
+    scene.fixtures = std::move(originalFixtures_);
+    scene.trusses = std::move(originalTrusses_);
+    scene.sceneObjects = std::move(originalSceneObjects_);
+    scene.supports = std::move(originalSupports_);
+  }
+
+private:
+  static Matrix AlignRotationToIdentityKeepingScale(const Matrix &source) {
+    Matrix identity = MatrixUtils::Identity();
+    return MatrixUtils::ApplyRotationPreservingScale(source, identity, source.o);
+  }
+
+  ConfigManager &cfg_;
+  std::unordered_map<std::string, Fixture> originalFixtures_;
+  std::unordered_map<std::string, Truss> originalTrusses_;
+  std::unordered_map<std::string, SceneObject> originalSceneObjects_;
+  std::unordered_map<std::string, Support> originalSupports_;
+};
+
+void MirrorImageHorizontally(symbols::RenderedSymbolImage &render) {
+  if (render.width <= 0 || render.height <= 0)
+    return;
+  for (int y = 0; y < render.height; ++y) {
+    for (int x = 0; x < render.width / 2; ++x) {
+      const int opposite = render.width - 1 - x;
+      const size_t left =
+          (static_cast<size_t>(y) * static_cast<size_t>(render.width) +
+           static_cast<size_t>(x)) *
+          4;
+      const size_t right =
+          (static_cast<size_t>(y) * static_cast<size_t>(render.width) +
+           static_cast<size_t>(opposite)) *
+          4;
+      for (size_t c = 0; c < 4; ++c)
+        std::swap(render.rgba[left + c], render.rgba[right + c]);
+    }
+  }
+}
+
+} // namespace
+
+SceneModelSymbolCaptureResult
+CaptureSceneModelOrthographicSymbols(Viewer2DOffscreenRenderer &renderer,
+                                     ConfigManager &cfg,
+                                     const SceneModelSymbolTarget &target,
+                                     const SceneModelSymbolCaptureOptions &options) {
+  SceneModelSymbolCaptureResult result;
+
+  Viewer2DPanel *capturePanel = renderer.GetPanel();
+  if (!capturePanel) {
+    result.error = "Could not create 2D capture panel instance.";
+    return result;
+  }
+
+  ScopedSingleModelSceneOverride isolatedSceneOverride(cfg, target,
+                                                       options.alignToLocalAxes);
+  ScopedFixtureColorOverride selectedFixtureColorOverride(
+      cfg, target.kind == SceneModelKind::Fixture ? target.uuid : std::string(),
+      options.forcedFixtureColor);
+  ScopedFloatConfigOverride displayOverride(
+      cfg,
+      {
+          {"grid_show", 0.0f},
+          {"view2d_dark_mode", 0.0f},
+          {"view2d_render_mode", static_cast<float>(Viewer2DRenderMode::ByFixtureType)},
+          {"label_show_name_top", 0.0f},
+          {"label_show_name_front", 0.0f},
+          {"label_show_name_side", 0.0f},
+          {"label_show_id_top", 0.0f},
+          {"label_show_id_front", 0.0f},
+          {"label_show_id_side", 0.0f},
+          {"label_show_dmx_top", 0.0f},
+          {"label_show_dmx_front", 0.0f},
+          {"label_show_dmx_side", 0.0f},
+      });
+
+  const Viewer2DView previousView = capturePanel->GetView();
+
+  renderer.SetViewportSize(options.viewportSize);
+  renderer.PrepareForCapture();
+  capturePanel->SetRenderMode(Viewer2DRenderMode::ByFixtureType);
+  capturePanel->UpdateScene(true);
+
+  {
+    std::vector<unsigned char> warmupPixels;
+    int warmupWidth = 0;
+    int warmupHeight = 0;
+    (void)capturePanel->RenderToRGBA(warmupPixels, warmupWidth, warmupHeight);
+  }
+
+  struct CaptureRequest {
+    Viewer2DView view = Viewer2DView::Top;
+    float topFixturesInverted = 0.0f;
+    bool mirrorSideHorizontally = false;
+    symbols::SymbolView symbolView = symbols::SymbolView::Top;
+  };
+
+  const std::array<CaptureRequest, 4> requests = {
+      CaptureRequest{Viewer2DView::Front, 0.0f, false, symbols::SymbolView::Front},
+      CaptureRequest{Viewer2DView::Top, 0.0f, false, symbols::SymbolView::Top},
+      CaptureRequest{Viewer2DView::Side, 0.0f, true, symbols::SymbolView::Left},
+      CaptureRequest{Viewer2DView::Top, 1.0f, false, symbols::SymbolView::Bottom},
+  };
+
+  std::vector<symbols::RenderedSymbolImage> renders;
+  renders.reserve(requests.size());
+
+  for (const auto &request : requests) {
+    ScopedFloatConfigOverride topViewOverride(
+        cfg, {{"view2d_top_fixtures_inverted", request.topFixturesInverted}});
+
+    capturePanel->SetView(request.view);
+    capturePanel->UpdateScene(true);
+    capturePanel->FitViewToScene();
+
+    symbols::RenderedSymbolImage render;
+    render.view = request.symbolView;
+    const bool ok = capturePanel->RenderToRGBA(render.rgba, render.width, render.height);
+    if (!ok || render.width <= 0 || render.height <= 0) {
+      capturePanel->SetView(previousView);
+      result.error = "Could not capture all orthographic source images from the 2D viewer.";
+      return result;
+    }
+    if (request.mirrorSideHorizontally)
+      MirrorImageHorizontally(render);
+    renders.push_back(std::move(render));
+  }
+
+  capturePanel->SetView(previousView);
+
+  auto symbols = symbols::Symbol2DImageBuilder::BuildFromRenderedImages(renders);
+  if (symbols.size() != requests.size()) {
+    result.error = "Could not generate all symbols from captured views.";
+    return result;
+  }
+
+  result.ok = true;
+  result.symbols = std::move(symbols);
+  return result;
+}
+
+} // namespace tools

--- a/gui/tools/scene_model_symbol_capture_service.h
+++ b/gui/tools/scene_model_symbol_capture_service.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <wx/gdicmn.h>
+
+#include "symbols/Symbol2D.h"
+
+class ConfigManager;
+class Viewer2DOffscreenRenderer;
+
+namespace tools {
+
+enum class SceneModelKind {
+  Fixture,
+  Truss,
+  SceneObject,
+};
+
+struct SceneModelSymbolTarget {
+  SceneModelKind kind = SceneModelKind::Fixture;
+  std::string uuid;
+};
+
+struct SceneModelSymbolCaptureOptions {
+  bool alignToLocalAxes = false;
+  std::optional<std::string> forcedFixtureColor;
+  wxSize viewportSize = wxSize(1200, 1200);
+};
+
+struct SceneModelSymbolCaptureResult {
+  bool ok = false;
+  std::string error;
+  std::vector<symbols::Symbol2D> symbols;
+};
+
+SceneModelSymbolCaptureResult
+CaptureSceneModelOrthographicSymbols(Viewer2DOffscreenRenderer &renderer,
+                                     ConfigManager &cfg,
+                                     const SceneModelSymbolTarget &target,
+                                     const SceneModelSymbolCaptureOptions &options = {});
+
+} // namespace tools


### PR DESCRIPTION
### Motivation

- Provide a reusable API so any module can request vector orthographic symbols for a specific 3D model instance (fixture, truss, or generic scene object) instead of duplicating capture logic. 
- Support capturing orthographic views for objects that are rotated in the world by optionally aligning to the object local axes while preserving scale.

### Description

- Added a new service header and implementation: `gui/tools/scene_model_symbol_capture_service.h` and `gui/tools/scene_model_symbol_capture_service.cpp` exposing `CaptureSceneModelOrthographicSymbols(...)` and public types `SceneModelKind`, `SceneModelSymbolTarget`, `SceneModelSymbolCaptureOptions`, and `SceneModelSymbolCaptureResult`.
- The service isolates a single scene instance, applies capture-focused config overrides, optionally aligns rotation to local axes (`alignToLocalAxes`), captures RGBA images from orthographic `Front/Top/Side` (mirrors Side to Left and inverted Top to Bottom), and converts captures to vector `symbols::Symbol2D` via `symbols::Symbol2DImageBuilder`.
- Refactored the fixture symbol generation tool (`gui/tools/fixture_symbol_generation_tool.cpp`) to call the new service instead of owning duplicated capture logic; preview UI and existing workflow are preserved.
- Added the new implementation to GUI sources (`gui/CMakeLists.txt`) and added documentation `docs/scene_model_symbol_capture.md` describing the API and intended usage for future PDF/layout vector workflows.

### Testing

- Ran module checks: `tests/check_perastage_tree_modules.sh` — OK.
- Ran GUI rule check: `tests/check_no_configmanager_get_in_gui.sh` — OK.
- Attempted full configure/build (`cmake -S . -B build && cmake --build build -j2`) but configuration failed in this environment due to missing wxWidgets development packages (`wxWidgets_LIBRARIES` / `wxWidgets_INCLUDE_DIRS`), so a local build was not completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999b4d7ab608324ba7f148f839376a0)