### PR TITLE
Unify layout legend aggregation and preserve vector symbol keys

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/layout2dviewdialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layouteventtabledialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layoutimageutils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/layoutlegenditems.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layoutpanel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layouttextdialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layouttextutils.cpp

--- a/gui/layoutlegenditems.cpp
+++ b/gui/layoutlegenditems.cpp
@@ -1,0 +1,110 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "layoutlegenditems.h"
+
+#include <filesystem>
+#include <map>
+
+#include <wx/filename.h>
+
+#include "configmanager.h"
+#include "gdtfloader.h"
+#include "guiconfigservices.h"
+#include "legendutils.h"
+
+namespace {
+struct LegendAggregate {
+  int count = 0;
+  std::optional<int> channelCount;
+  bool mixedChannels = false;
+  std::string symbolKey;
+};
+} // namespace
+
+std::vector<SharedLayoutLegendItem> BuildSharedLayoutLegendItems() {
+  std::map<std::string, LegendAggregate> aggregates;
+  const auto &fixtures =
+      GetDefaultGuiConfigServices().LegacyConfigManager().GetScene().fixtures;
+  const std::string &basePath =
+      GetDefaultGuiConfigServices().LegacyConfigManager().GetScene().basePath;
+
+  for (const auto &[uuid, fixture] : fixtures) {
+    (void)uuid;
+    std::string typeName = fixture.typeName;
+    std::string fullPath;
+    if (!fixture.gdtfSpec.empty()) {
+      try {
+        std::filesystem::path p =
+            basePath.empty() ? std::filesystem::u8path(fixture.gdtfSpec)
+                             : std::filesystem::u8path(basePath) /
+                                   std::filesystem::u8path(fixture.gdtfSpec);
+        fullPath = p.string();
+      } catch (const std::exception &) {
+        fullPath.clear();
+      }
+    }
+
+    if (typeName.empty() && !fullPath.empty()) {
+      wxFileName fn(fullPath);
+      typeName = fn.GetFullName().ToStdString();
+    }
+    if (typeName.empty())
+      typeName = "Unknown";
+
+    int chCount = GetGdtfModeChannelCount(fullPath, fixture.gdtfMode);
+    const std::string symbolKey = BuildFixtureSymbolKey(fixture, basePath);
+
+    LegendAggregate &agg = aggregates[typeName];
+    agg.count += 1;
+    if (chCount >= 0) {
+      if (!agg.channelCount.has_value()) {
+        agg.channelCount = chCount;
+      } else if (agg.channelCount.value() != chCount) {
+        agg.mixedChannels = true;
+      }
+    }
+
+    // Keep the first available symbol key as the legend representative for
+    // the fixture type. This ensures every row can render a generated vector
+    // symbol even when the type contains mixed fixture variants.
+    if (agg.symbolKey.empty() && !symbolKey.empty())
+      agg.symbolKey = symbolKey;
+  }
+
+  std::vector<SharedLayoutLegendItem> items;
+  items.reserve(aggregates.size());
+  for (const auto &[typeName, agg] : aggregates) {
+    SharedLayoutLegendItem item;
+    item.typeName = typeName;
+    item.count = agg.count;
+    if (agg.channelCount.has_value() && !agg.mixedChannels)
+      item.channelCount = agg.channelCount;
+    item.symbolKey = agg.symbolKey;
+    items.push_back(item);
+  }
+
+  if (items.empty()) {
+    SharedLayoutLegendItem item;
+    item.typeName = "No fixtures";
+    item.count = 0;
+    items.push_back(item);
+  }
+
+  return items;
+}
+

--- a/gui/layoutlegenditems.h
+++ b/gui/layoutlegenditems.h
@@ -1,0 +1,32 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+struct SharedLayoutLegendItem {
+  std::string typeName;
+  int count = 0;
+  std::optional<int> channelCount;
+  std::string symbolKey;
+};
+
+std::vector<SharedLayoutLegendItem> BuildSharedLayoutLegendItems();
+

--- a/gui/layoutviewerpanel_legend.cpp
+++ b/gui/layoutviewerpanel_legend.cpp
@@ -19,11 +19,8 @@
 
 #include <algorithm>
 #include <cmath>
-#include <exception>
-#include <filesystem>
 #include <functional>
 #include <limits>
-#include <map>
 #include <unordered_map>
 #include <vector>
 
@@ -36,15 +33,11 @@
 #  include <GL/glu.h>
 #endif
 
-#include "configmanager.h"
-#include "guiconfigservices.h"
-#include "gdtfloader.h"
 #include "layoutviewerpanel_shared.h"
-#include "legendutils.h"
+#include "layoutlegenditems.h"
 #include "LayoutManager.h"
 #include "viewer2dcommandrenderer.h"
 #include <wx/dcgraph.h>
-#include <wx/filename.h>
 #include <wx/graphics.h>
 
 namespace {
@@ -724,80 +717,18 @@ void LayoutViewerPanel::RefreshLegendData() {
 
 std::vector<LayoutViewerPanel::LegendItem>
 LayoutViewerPanel::BuildLegendItems() const {
-  struct LegendAggregate {
-    int count = 0;
-    std::optional<int> channelCount;
-    bool mixedChannels = false;
-    std::string symbolKey;
-    bool mixedSymbols = false;
-  };
-
-  std::map<std::string, LegendAggregate> aggregates;
-  const auto &fixtures = GetDefaultGuiConfigServices().LegacyConfigManager().GetScene().fixtures;
-  const std::string &basePath = GetDefaultGuiConfigServices().LegacyConfigManager().GetScene().basePath;
-  for (const auto &[uuid, fixture] : fixtures) {
-    (void)uuid;
-    std::string typeName = fixture.typeName;
-    std::string fullPath;
-    if (!fixture.gdtfSpec.empty()) {
-      try {
-        std::filesystem::path p =
-            basePath.empty()
-                ? std::filesystem::u8path(fixture.gdtfSpec)
-                : std::filesystem::u8path(basePath) /
-                      std::filesystem::u8path(fixture.gdtfSpec);
-        fullPath = p.string();
-      } catch (const std::exception &) {
-        fullPath.clear();
-      }
-    }
-    if (typeName.empty() && !fullPath.empty()) {
-      wxFileName fn(fullPath);
-      typeName = fn.GetFullName().ToStdString();
-    }
-    if (typeName.empty())
-      typeName = "Unknown";
-
-    int chCount = GetGdtfModeChannelCount(fullPath, fixture.gdtfMode);
-    const std::string symbolKey = BuildFixtureSymbolKey(fixture, basePath);
-    LegendAggregate &agg = aggregates[typeName];
-    agg.count += 1;
-    if (chCount >= 0) {
-      if (!agg.channelCount.has_value()) {
-        agg.channelCount = chCount;
-      } else if (agg.channelCount.value() != chCount) {
-        agg.mixedChannels = true;
-      }
-    }
-    if (!symbolKey.empty()) {
-      if (agg.symbolKey.empty()) {
-        agg.symbolKey = symbolKey;
-      } else if (agg.symbolKey != symbolKey) {
-        agg.mixedSymbols = true;
-      }
-    }
-  }
-
+  std::vector<SharedLayoutLegendItem> sharedItems =
+      BuildSharedLayoutLegendItems();
   std::vector<LegendItem> items;
-  items.reserve(aggregates.size());
-  for (const auto &[typeName, agg] : aggregates) {
+  items.reserve(sharedItems.size());
+  for (const auto &shared : sharedItems) {
     LegendItem item;
-    item.typeName = typeName;
-    item.count = agg.count;
-    if (agg.channelCount.has_value() && !agg.mixedChannels)
-      item.channelCount = agg.channelCount;
-    if (!agg.mixedSymbols)
-      item.symbolKey = agg.symbolKey;
-    items.push_back(item);
+    item.typeName = shared.typeName;
+    item.count = shared.count;
+    item.channelCount = shared.channelCount;
+    item.symbolKey = shared.symbolKey;
+    items.push_back(std::move(item));
   }
-
-  if (items.empty()) {
-    LegendItem item;
-    item.typeName = "No fixtures";
-    item.count = 0;
-    items.push_back(item);
-  }
-
   return items;
 }
 

--- a/gui/mainwindow_print.cpp
+++ b/gui/mainwindow_print.cpp
@@ -20,12 +20,10 @@
 
 #include <cmath>
 #include <filesystem>
-#include <map>
 #include <memory>
 #include <thread>
 #include <vector>
 
-#include <wx/filename.h>
 #include <wx/choicdlg.h>
 
 #include "configmanager.h"
@@ -33,10 +31,9 @@
 #include "legendsymbolcapture.h"
 #include "consolepanel.h"
 #include "fixturetablepanel.h"
-#include "gdtfloader.h"
 #include "hoisttablepanel.h"
 #include "layouttextutils.h"
-#include "legendutils.h"
+#include "layoutlegenditems.h"
 #include "Viewer2DPrintSettings.h"
 #include "print_diagnostics.h"
 #include "sceneobjecttablepanel.h"
@@ -50,75 +47,18 @@
 
 namespace {
 std::vector<LayoutLegendItem> BuildLayoutLegendItems() {
-  struct LegendAggregate {
-    int count = 0;
-    std::optional<int> channelCount;
-    bool mixedChannels = false;
-    std::string symbolKey;
-    bool mixedSymbols = false;
-  };
-
-  std::map<std::string, LegendAggregate> aggregates;
-  const auto &fixtures = GetDefaultGuiConfigServices().LegacyConfigManager().GetScene().fixtures;
-  const std::string &basePath = GetDefaultGuiConfigServices().LegacyConfigManager().GetScene().basePath;
-  for (const auto &[uuid, fixture] : fixtures) {
-    (void)uuid;
-    std::string typeName = fixture.typeName;
-    std::string fullPath;
-    if (!fixture.gdtfSpec.empty()) {
-      std::filesystem::path p = basePath.empty()
-                                    ? std::filesystem::path(fixture.gdtfSpec)
-                                    : std::filesystem::path(basePath) /
-                                          fixture.gdtfSpec;
-      fullPath = p.string();
-    }
-    if (typeName.empty() && !fullPath.empty()) {
-      wxFileName fn(fullPath);
-      typeName = fn.GetFullName().ToStdString();
-    }
-    if (typeName.empty())
-      typeName = "Unknown";
-
-    int chCount = GetGdtfModeChannelCount(fullPath, fixture.gdtfMode);
-    const std::string symbolKey = BuildFixtureSymbolKey(fixture, basePath);
-    LegendAggregate &agg = aggregates[typeName];
-    agg.count += 1;
-    if (chCount >= 0) {
-      if (!agg.channelCount.has_value()) {
-        agg.channelCount = chCount;
-      } else if (agg.channelCount.value() != chCount) {
-        agg.mixedChannels = true;
-      }
-    }
-    if (!symbolKey.empty()) {
-      if (agg.symbolKey.empty()) {
-        agg.symbolKey = symbolKey;
-      } else if (agg.symbolKey != symbolKey) {
-        agg.mixedSymbols = true;
-      }
-    }
-  }
-
+  std::vector<SharedLayoutLegendItem> sharedItems =
+      BuildSharedLayoutLegendItems();
   std::vector<LayoutLegendItem> items;
-  items.reserve(aggregates.size());
-  for (const auto &[typeName, agg] : aggregates) {
+  items.reserve(sharedItems.size());
+  for (const auto &shared : sharedItems) {
     LayoutLegendItem item;
-    item.typeName = typeName;
-    item.count = agg.count;
-    if (agg.channelCount.has_value() && !agg.mixedChannels)
-      item.channelCount = agg.channelCount;
-    if (!agg.mixedSymbols)
-      item.symbolKey = agg.symbolKey;
-    items.push_back(item);
+    item.typeName = shared.typeName;
+    item.count = shared.count;
+    item.channelCount = shared.channelCount;
+    item.symbolKey = shared.symbolKey;
+    items.push_back(std::move(item));
   }
-
-  if (items.empty()) {
-    LayoutLegendItem item;
-    item.typeName = "No fixtures";
-    item.count = 0;
-    items.push_back(item);
-  }
-
   return items;
 }
 }


### PR DESCRIPTION
### Motivation
- Provide a single, shared source of truth for layout legend rows so on-screen legends and PDF export use the same fixture-type aggregation and symbol keys.
- Ensure legend rows keep a representative vector symbol when fixture types include mixed variants so generated vector symbols are available for rendering and PDF XObjects.

### Description
- Add `gui/layoutlegenditems.h/.cpp` with `BuildSharedLayoutLegendItems()` which centralizes fixture-type aggregation and symbol-key selection used by both the UI and PDF paths.
- Update `LayoutViewerPanel::BuildLegendItems()` to consume the shared helper and avoid duplicated aggregation logic in `layoutviewerpanel_legend.cpp`.
- Update the layout PDF/print path (`mainwindow_print.cpp`) to use the shared helper so exported PDF legends match the on-screen data.
- Change aggregation behavior to retain the first available `symbolKey` per fixture type (instead of dropping symbols for mixed variants) and register the new source in `gui/CMakeLists.txt`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999ca7cfc64832488a3513802033885)