### PR TITLE
Fix offscreen Viewer2D renderer cleanup on shutdown

### DIFF
--- a/viewer2d/viewer2doffscreenrenderer.cpp
+++ b/viewer2d/viewer2doffscreenrenderer.cpp
@@ -33,7 +33,13 @@ Viewer2DOffscreenRenderer::Viewer2DOffscreenRenderer(wxWindow *parent) {
   panel_->UpdateScene(true);
 }
 
-Viewer2DOffscreenRenderer::~Viewer2DOffscreenRenderer() = default;
+Viewer2DOffscreenRenderer::~Viewer2DOffscreenRenderer() {
+  if (host_) {
+    host_->Destroy();
+    host_ = nullptr;
+    panel_ = nullptr;
+  }
+}
 
 void Viewer2DOffscreenRenderer::SetViewportSize(const wxSize &size) {
   if (!panel_)


### PR DESCRIPTION
### Motivation
- Intermittent CRT leak reports were observed at shutdown after offscreen capture / symbol generation workflows, likely caused by the hidden offscreen host panel and its child `Viewer2DPanel` not being deterministically torn down.

### Description
- Change `Viewer2DOffscreenRenderer::~Viewer2DOffscreenRenderer` in `viewer2d/viewer2doffscreenrenderer.cpp` to call `host_->Destroy()` and clear `host_` and `panel_` so the hidden host and its child are destroyed immediately during renderer teardown.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` — OK.
- Ran `tests/check_no_configmanager_get_in_gui.sh` — OK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999d04f7d44832498e5d4b1e266b7b4)