### PR TITLE
Use tool-based vector symbol capture for layout legends

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1532,7 +1532,7 @@ void LayoutViewerPanel::RebuildCachedTexture() {
     ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
     std::shared_ptr<const SymbolDefinitionSnapshot> legendSymbols;
     if (!currentLayout.legendViews.empty()) {
-      legendSymbols = CaptureLegendSymbolSnapshot(capturePanel, cfg, true);
+      legendSymbols = CaptureLegendSymbolSnapshot(offscreenRenderer, cfg, true);
     }
     std::vector<unsigned char> legendPixels;
     std::vector<unsigned char> eventTablePixels;

--- a/gui/legendsymbolcapture.cpp
+++ b/gui/legendsymbolcapture.cpp
@@ -1,9 +1,14 @@
 #include "legendsymbolcapture.h"
 
+#include <algorithm>
+#include <unordered_map>
 #include <unordered_set>
+#include <utility>
 
 #include "configmanager.h"
-#include "viewer2dpanel.h"
+#include "legendutils.h"
+#include "tools/scene_model_symbol_capture_service.h"
+#include "viewer2doffscreenrenderer.h"
 
 namespace {
 class ScopedHiddenLayersClear {
@@ -24,40 +29,146 @@ private:
   std::unordered_set<std::string> previous_;
 };
 
-std::shared_ptr<const SymbolDefinitionSnapshot>
-CaptureLegendSymbolSnapshotWithAllLayers(Viewer2DPanel *capturePanel,
-                                         bool requireTopAndFrontViews) {
-  if (!capturePanel)
-    return {};
+SymbolViewKind ToSymbolViewKind(symbols::SymbolView view) {
+  switch (view) {
+  case symbols::SymbolView::Front:
+    return SymbolViewKind::Front;
+  case symbols::SymbolView::Top:
+    return SymbolViewKind::Top;
+  case symbols::SymbolView::Bottom:
+    return SymbolViewKind::Bottom;
+  case symbols::SymbolView::Left:
+  default:
+    return SymbolViewKind::Left;
+  }
+}
 
-  const Viewer2DView previousView = capturePanel->GetView();
+CanvasColor SolidBlack() {
+  return CanvasColor{0.0f, 0.0f, 0.0f, 1.0f};
+}
 
-  auto captureView = [&](Viewer2DView view) {
-    capturePanel->SetView(view);
-    capturePanel->CaptureFrameNow([](CommandBuffer, Viewer2DViewState) {}, true,
-                                  false);
-  };
+std::vector<float> FlattenPolyline(const symbols::Polyline2D &polyline) {
+  std::vector<float> points;
+  points.reserve(polyline.size() * 2);
+  for (const auto &point : polyline) {
+    points.push_back(point.x);
+    points.push_back(point.y);
+  }
+  return points;
+}
 
-  if (requireTopAndFrontViews) {
-    // Capture both required legend views explicitly. A global "has front/top"
-    // check is not enough because one model may have Front while others only
-    // have Top.
-    captureView(Viewer2DView::Top);
-    captureView(Viewer2DView::Front);
-  } else {
-    // Keep a fresh snapshot even when only the current view is needed.
-    captureView(previousView);
+SymbolDefinition BuildDefinitionFromToolSymbol(const std::string &modelKey,
+                                               const symbols::Symbol2D &symbol,
+                                               uint32_t symbolId) {
+  SymbolDefinition definition;
+  definition.symbolId = symbolId;
+  definition.key.modelKey = modelKey;
+  definition.key.viewKind = ToSymbolViewKind(symbol.view);
+  definition.key.styleVersion = 1;
+  definition.bounds.min.x = symbol.bounds.min.x;
+  definition.bounds.min.y = symbol.bounds.min.y;
+  definition.bounds.max.x = symbol.bounds.max.x;
+  definition.bounds.max.y = symbol.bounds.max.y;
+
+  const CanvasColor black = SolidBlack();
+  const CanvasStroke stroke{black, symbol.strokeWidthPx};
+  const CanvasFill fill{black};
+
+  auto &buffer = definition.localCommands;
+  buffer.currentSourceKey = "legend_tool_capture";
+
+  for (const auto &polygon : symbol.fill) {
+    PolygonCommand cmd;
+    cmd.points = FlattenPolyline(polygon.outer);
+    if (cmd.points.size() >= 6) {
+      cmd.stroke = stroke;
+      cmd.fill = fill;
+      cmd.hasFill = true;
+      buffer.commands.push_back(std::move(cmd));
+      buffer.metadata.push_back(CommandMetadata{true, true});
+      buffer.sources.push_back(buffer.currentSourceKey);
+    }
   }
 
-  capturePanel->SetView(previousView);
-  return capturePanel->GetBottomSymbolCacheSnapshot();
+  for (const auto &polyline : symbol.strokes) {
+    PolylineCommand cmd;
+    cmd.points = FlattenPolyline(polyline);
+    if (cmd.points.size() >= 4) {
+      cmd.stroke = stroke;
+      buffer.commands.push_back(std::move(cmd));
+      buffer.metadata.push_back(CommandMetadata{true, false});
+      buffer.sources.push_back(buffer.currentSourceKey);
+    }
+  }
+
+  return definition;
 }
+
+std::vector<std::pair<std::string, std::string>>
+CollectLegendFixtureTargets(const ConfigManager &cfg) {
+  std::vector<std::pair<std::string, std::string>> targets;
+  const auto &scene = cfg.GetScene();
+  for (const auto &[uuid, fixture] : scene.fixtures) {
+    const std::string modelKey = BuildFixtureSymbolKey(fixture, scene.basePath);
+    if (modelKey.empty())
+      continue;
+    targets.emplace_back(modelKey, uuid);
+  }
+
+  std::sort(targets.begin(), targets.end(),
+            [](const auto &lhs, const auto &rhs) { return lhs.first < rhs.first; });
+  targets.erase(std::unique(targets.begin(), targets.end(),
+                            [](const auto &lhs, const auto &rhs) {
+                              return lhs.first == rhs.first;
+                            }),
+                targets.end());
+  return targets;
+}
+
+std::shared_ptr<const SymbolDefinitionSnapshot>
+CaptureLegendSymbolSnapshotWithTool(Viewer2DOffscreenRenderer *offscreenRenderer,
+                                    ConfigManager &cfg) {
+  if (!offscreenRenderer)
+    return {};
+
+  const auto targets = CollectLegendFixtureTargets(cfg);
+  if (targets.empty())
+    return {};
+
+  auto snapshot = std::make_shared<SymbolDefinitionSnapshot>();
+  uint32_t nextSymbolId = 1;
+
+  for (const auto &[modelKey, fixtureUuid] : targets) {
+    tools::SceneModelSymbolCaptureOptions options;
+    options.alignToLocalAxes = false;
+    const auto capture = tools::CaptureSceneModelOrthographicSymbols(
+        *offscreenRenderer, cfg,
+        tools::SceneModelSymbolTarget{tools::SceneModelKind::Fixture,
+                                      fixtureUuid},
+        options);
+    if (!capture.ok)
+      continue;
+
+    for (const auto &toolSymbol : capture.symbols) {
+      SymbolDefinition definition =
+          BuildDefinitionFromToolSymbol(modelKey, toolSymbol, nextSymbolId++);
+      snapshot->emplace(definition.symbolId, std::move(definition));
+    }
+  }
+
+  if (snapshot->empty())
+    return {};
+
+  return snapshot;
+}
+
 } // namespace
 
 std::shared_ptr<const SymbolDefinitionSnapshot>
-CaptureLegendSymbolSnapshot(Viewer2DPanel *capturePanel, ConfigManager &cfg,
+CaptureLegendSymbolSnapshot(Viewer2DOffscreenRenderer *offscreenRenderer,
+                            ConfigManager &cfg,
                             bool requireTopAndFrontViews) {
+  (void)requireTopAndFrontViews;
   ScopedHiddenLayersClear hiddenLayersGuard(cfg);
-  return CaptureLegendSymbolSnapshotWithAllLayers(capturePanel,
-                                                  requireTopAndFrontViews);
+  return CaptureLegendSymbolSnapshotWithTool(offscreenRenderer, cfg);
 }

--- a/gui/legendsymbolcapture.cpp
+++ b/gui/legendsymbolcapture.cpp
@@ -1,9 +1,12 @@
 #include "legendsymbolcapture.h"
 
 #include <algorithm>
-#include <unordered_map>
+#include <cstddef>
+#include <functional>
+#include <mutex>
 #include <unordered_set>
 #include <utility>
+#include <vector>
 
 #include "configmanager.h"
 #include "legendutils.h"
@@ -28,6 +31,34 @@ private:
   ConfigManager &cfg_;
   std::unordered_set<std::string> previous_;
 };
+
+struct LegendCaptureTarget {
+  std::string modelKey;
+  std::string fixtureUuid;
+
+  bool operator==(const LegendCaptureTarget &other) const {
+    return modelKey == other.modelKey && fixtureUuid == other.fixtureUuid;
+  }
+};
+
+struct LegendSymbolSnapshotCache {
+  size_t fingerprint = 0;
+  std::shared_ptr<const SymbolDefinitionSnapshot> snapshot;
+};
+
+size_t HashCombine(size_t seed, size_t value) {
+  seed ^= value + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+  return seed;
+}
+
+size_t HashTargets(const std::vector<LegendCaptureTarget> &targets) {
+  size_t seed = 0;
+  for (const auto &target : targets) {
+    seed = HashCombine(seed, std::hash<std::string>{}(target.modelKey));
+    seed = HashCombine(seed, std::hash<std::string>{}(target.fixtureUuid));
+  }
+  return seed;
+}
 
 SymbolViewKind ToSymbolViewKind(symbols::SymbolView view) {
   switch (view) {
@@ -104,22 +135,28 @@ SymbolDefinition BuildDefinitionFromToolSymbol(const std::string &modelKey,
   return definition;
 }
 
-std::vector<std::pair<std::string, std::string>>
-CollectLegendFixtureTargets(const ConfigManager &cfg) {
-  std::vector<std::pair<std::string, std::string>> targets;
+std::vector<LegendCaptureTarget> CollectLegendFixtureTargets(
+    const ConfigManager &cfg) {
+  std::vector<LegendCaptureTarget> targets;
   const auto &scene = cfg.GetScene();
   for (const auto &[uuid, fixture] : scene.fixtures) {
     const std::string modelKey = BuildFixtureSymbolKey(fixture, scene.basePath);
     if (modelKey.empty())
       continue;
-    targets.emplace_back(modelKey, uuid);
+    targets.push_back(LegendCaptureTarget{modelKey, uuid});
   }
 
   std::sort(targets.begin(), targets.end(),
-            [](const auto &lhs, const auto &rhs) { return lhs.first < rhs.first; });
+            [](const LegendCaptureTarget &lhs, const LegendCaptureTarget &rhs) {
+              if (lhs.modelKey == rhs.modelKey)
+                return lhs.fixtureUuid < rhs.fixtureUuid;
+              return lhs.modelKey < rhs.modelKey;
+            });
+
   targets.erase(std::unique(targets.begin(), targets.end(),
-                            [](const auto &lhs, const auto &rhs) {
-                              return lhs.first == rhs.first;
+                            [](const LegendCaptureTarget &lhs,
+                               const LegendCaptureTarget &rhs) {
+                              return lhs.modelKey == rhs.modelKey;
                             }),
                 targets.end());
   return targets;
@@ -127,31 +164,29 @@ CollectLegendFixtureTargets(const ConfigManager &cfg) {
 
 std::shared_ptr<const SymbolDefinitionSnapshot>
 CaptureLegendSymbolSnapshotWithTool(Viewer2DOffscreenRenderer *offscreenRenderer,
-                                    ConfigManager &cfg) {
-  if (!offscreenRenderer)
-    return {};
-
-  const auto targets = CollectLegendFixtureTargets(cfg);
-  if (targets.empty())
+                                    ConfigManager &cfg,
+                                    const std::vector<LegendCaptureTarget>
+                                        &targets) {
+  if (!offscreenRenderer || targets.empty())
     return {};
 
   auto snapshot = std::make_shared<SymbolDefinitionSnapshot>();
   uint32_t nextSymbolId = 1;
 
-  for (const auto &[modelKey, fixtureUuid] : targets) {
+  for (const auto &target : targets) {
     tools::SceneModelSymbolCaptureOptions options;
     options.alignToLocalAxes = false;
     const auto capture = tools::CaptureSceneModelOrthographicSymbols(
         *offscreenRenderer, cfg,
         tools::SceneModelSymbolTarget{tools::SceneModelKind::Fixture,
-                                      fixtureUuid},
+                                      target.fixtureUuid},
         options);
     if (!capture.ok)
       continue;
 
     for (const auto &toolSymbol : capture.symbols) {
-      SymbolDefinition definition =
-          BuildDefinitionFromToolSymbol(modelKey, toolSymbol, nextSymbolId++);
+      SymbolDefinition definition = BuildDefinitionFromToolSymbol(
+          target.modelKey, toolSymbol, nextSymbolId++);
       snapshot->emplace(definition.symbolId, std::move(definition));
     }
   }
@@ -169,6 +204,33 @@ CaptureLegendSymbolSnapshot(Viewer2DOffscreenRenderer *offscreenRenderer,
                             ConfigManager &cfg,
                             bool requireTopAndFrontViews) {
   (void)requireTopAndFrontViews;
+
+  static std::mutex cacheMutex;
+  static LegendSymbolSnapshotCache cache;
+
+  const auto targets = CollectLegendFixtureTargets(cfg);
+  if (targets.empty())
+    return {};
+
+  const size_t fingerprint = HashTargets(targets);
+  {
+    std::lock_guard<std::mutex> lock(cacheMutex);
+    if (cache.snapshot && cache.fingerprint == fingerprint)
+      return cache.snapshot;
+  }
+
   ScopedHiddenLayersClear hiddenLayersGuard(cfg);
-  return CaptureLegendSymbolSnapshotWithTool(offscreenRenderer, cfg);
+  std::shared_ptr<const SymbolDefinitionSnapshot> snapshot =
+      CaptureLegendSymbolSnapshotWithTool(offscreenRenderer, cfg, targets);
+
+  if (!snapshot)
+    return {};
+
+  {
+    std::lock_guard<std::mutex> lock(cacheMutex);
+    cache.fingerprint = fingerprint;
+    cache.snapshot = snapshot;
+  }
+
+  return snapshot;
 }

--- a/gui/legendsymbolcapture.h
+++ b/gui/legendsymbolcapture.h
@@ -5,9 +5,9 @@
 #include "symbolcache.h"
 
 class ConfigManager;
-class Viewer2DPanel;
-enum class Viewer2DView;
+class Viewer2DOffscreenRenderer;
 
 std::shared_ptr<const SymbolDefinitionSnapshot>
-CaptureLegendSymbolSnapshot(Viewer2DPanel *capturePanel, ConfigManager &cfg,
+CaptureLegendSymbolSnapshot(Viewer2DOffscreenRenderer *offscreenRenderer,
+                            ConfigManager &cfg,
                             bool requireTopAndFrontViews);

--- a/gui/mainwindow_print.cpp
+++ b/gui/mainwindow_print.cpp
@@ -347,7 +347,7 @@ void MainWindow::OnPrintLayout(wxCommandEvent &WXUNUSED(event)) {
           auto textsToExport = std::move(*exportTexts);
           if (capturePanel) {
             auto legendSymbols =
-                CaptureLegendSymbolSnapshot(capturePanel, *cfgPtr, true);
+                CaptureLegendSymbolSnapshot(offscreenRenderer, *cfgPtr, true);
             for (auto &legend : legendsToExport) {
               legend.symbolSnapshot = legendSymbols;
             }


### PR DESCRIPTION
### Motivation
- Replace the current legend symbol raster/capture path with the new tools-based vector symbol generator so layout legends and exported PDFs embed scalable vector drawings instead of bitmaps. 

### Description
- Implemented a tool-based capture flow that calls `tools::CaptureSceneModelOrthographicSymbols` and converts `symbols::Symbol2D` outputs into `SymbolDefinitionSnapshot` entries composed of `PolygonCommand`/`PolylineCommand` (black strokes/fills) for reuse by legend rendering and PDF export. (`gui/legendsymbolcapture.cpp`, `core/symbols/*` used)
- Replaced the legend snapshot API to accept a `Viewer2DOffscreenRenderer*` and updated call sites so the offscreen renderer is passed to the new capture routine (`gui/legendsymbolcapture.h`, `gui/layoutviewerpanel.cpp`, `gui/mainwindow_print.cpp`).
- Legend generation now collects one fixture model key per fixture type (`BuildFixtureSymbolKey`) and captures vector symbols per model, deduplicating targets before conversion to the symbol snapshot. (`gui/legendsymbolcapture.cpp`)
- Kept hidden-layer guarding logic and produced `CommandBuffer` entries with `currentSourceKey="legend_tool_capture"` so existing rendering/export code can consume the generated symbol snapshot without pulling raster paths. (`gui/legendsymbolcapture.cpp`)

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed successfully. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed successfully. 
- Attempted full CMake configure/build (`cmake -S . -B build && cmake --build build -j2`) in the environment but it failed due to missing `wxWidgets` development packages (environment limitation), so a full build was not completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999dd90dd148324aa755df1b03f8854)