### PR TITLE
Avoid drawing axes in 2D capture renders

### DIFF
--- a/viewer3d/viewer3d_types.h
+++ b/viewer3d/viewer3d_types.h
@@ -53,6 +53,7 @@ struct RenderFrameContext {
   Viewer2DView view = Viewer2DView::Top;
   bool wireframe = false;
   bool showGrid = true;
+  bool showAxes = true;
   int gridStyle = 0;
   float gridR = 0.35f;
   float gridG = 0.35f;

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -888,6 +888,7 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
   context.mode = mode;
   context.view = view;
   context.showGrid = showGrid;
+  context.showAxes = !is2DViewer;
   context.gridStyle = gridStyle;
   context.gridR = gridR;
   context.gridG = gridG;
@@ -1095,7 +1096,8 @@ void Viewer3DController::RenderOverlayFrame(const RenderFrameContext &context,
     glEnable(GL_DEPTH_TEST);
   }
 
-  DrawAxes();
+  if (context.showAxes)
+    DrawAxes();
 }
 
 void Viewer3DController::FinalizeRenderFrame() {


### PR DESCRIPTION
### Motivation
- Offscreen 2D captures used to generate vector symbols included the 3D coordinate axes in the rendered input images, which caused the axes to be embedded in generated symbols and must be avoided.

### Description
- Added a `showAxes` flag to `RenderFrameContext` (`viewer3d/viewer3d_types.h`) so overlay rendering can be controlled per-render.
- Set `context.showAxes = !is2DViewer` in `RenderScene` to disable axes when rendering for 2D/offscreen capture flows (`viewer3d/viewer3dcontroller.cpp`).
- Updated `RenderOverlayFrame` to call `DrawAxes()` only when `context.showAxes` is enabled, preventing axes from being recorded into capture canvases (`viewer3d/viewer3dcontroller.cpp`).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999e685bb2883248f35107494887011)