### PR TITLE
Warn on print only when layout is fully empty

### DIFF
--- a/gui/mainwindow_print.cpp
+++ b/gui/mainwindow_print.cpp
@@ -217,8 +217,12 @@ void MainWindow::OnPrintLayout(wxCommandEvent &WXUNUSED(event)) {
                  this);
     return;
   }
-  if (layout->view2dViews.empty()) {
-    wxMessageBox("The selected layout has no 2D views to print.",
+  const bool layoutIsEmpty =
+      layout->view2dViews.empty() && layout->legendViews.empty() &&
+      layout->eventTables.empty() && layout->textViews.empty() &&
+      layout->imageViews.empty();
+  if (layoutIsEmpty) {
+    wxMessageBox("The selected layout is empty.",
                  "Print Layout", wxOK | wxICON_INFORMATION, this);
     return;
   }

--- a/viewer2d/pdf/layout_pdf_exporter.cpp
+++ b/viewer2d/pdf/layout_pdf_exporter.cpp
@@ -677,8 +677,8 @@ Viewer2DExportResult ExportLayoutToPdf(
     const std::filesystem::path &outputPath) {
   Viewer2DExportResult result{};
 
-  if (views.empty()) {
-    result.message = "No layout views were provided for export.";
+  if (views.empty() && legends.empty() && tables.empty() && texts.empty()) {
+    result.message = "The selected layout is empty.";
     return result;
   }
 
@@ -851,7 +851,8 @@ Viewer2DExportResult ExportLayoutToPdf(
     }
   }
 
-  if (layoutGroups.empty()) {
+  if (layoutGroups.empty() && legends.empty() && tables.empty() &&
+      texts.empty()) {
     result.message = "Nothing to export";
     return result;
   }


### PR DESCRIPTION
### Motivation
- Printing a layout was blocked with a warning whenever it had no 2D views even if the layout contained other exportable content (legends, tables, text or images). This change makes the warning appear only when the layout is truly empty.

### Description
- Treat a layout as empty only when `view2dViews`, `legendViews`, `eventTables`, `textViews` and `imageViews` are all empty by updating `MainWindow::OnPrintLayout` in `gui/mainwindow_print.cpp`.
- Update early validation in `ExportLayoutToPdf` in `viewer2d/pdf/layout_pdf_exporter.cpp` to only fail when all exportable collections (`views`, `legends`, `tables`, `texts`) are empty.
- Strengthen the later `Nothing to export` check with the same all-empty criterion to avoid rejecting layouts that contain non-2D elements.

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which succeeded (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which succeeded (`OK`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999fc4652c88324bdc904cf9d3b9dc7)