### PR TITLE
Apply Auto Color to selected fixtures only when selection exists

### DIFF
--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -564,19 +564,30 @@ void MainWindow::OnAutoColor(wxCommandEvent &WXUNUSED(event)) {
     }
   }
 
+  const auto selectedFixtureIds = cfg.GetSelectedFixtures();
+  const bool hasFixtureSelection = !selectedFixtureIds.empty();
+  std::set<std::string> selectedFixtureSet(selectedFixtureIds.begin(),
+                                           selectedFixtureIds.end());
+
   std::map<std::string, std::string> typeColors;
   for (auto &[uuid, f] : scene.fixtures) {
+    if (hasFixtureSelection && selectedFixtureSet.find(uuid) == selectedFixtureSet.end())
+      continue;
+
     if (!f.gdtfSpec.empty()) {
       auto it = typeColors.find(f.gdtfSpec);
       if (it == typeColors.end()) {
         std::string c =
-            (f.color.empty() || isWhiteColor(f.color)) ? randHex() : f.color;
+            hasFixtureSelection ? randHex()
+                                : ((f.color.empty() || isWhiteColor(f.color))
+                                       ? randHex()
+                                       : f.color);
         typeColors[f.gdtfSpec] = c;
         f.color = c;
       } else {
         f.color = it->second;
       }
-    } else if (f.color.empty() || isWhiteColor(f.color)) {
+    } else if (hasFixtureSelection || f.color.empty() || isWhiteColor(f.color)) {
       f.color = randHex();
     }
   }


### PR DESCRIPTION
### Motivation
- Ensure the Auto Color tool respects the current fixture selection so that when the user has fixtures selected, autocolor operates only on that selection and can override existing colors for those fixtures.
- Preserve existing behavior when there is no selection so autocolor still assigns colors across the whole scene as before.

### Description
- Updated `OnAutoColor` in `gui/mainwindow_menu.cpp` to fetch `cfg.GetSelectedFixtures()` and build a `selectedFixtureSet` used to limit which fixtures are processed. 
- Changed the fixture loop so that if a selection exists, only selected fixtures are touched and they always receive newly generated colors, while fixtures are still grouped by `gdtfSpec` so the same type within the affected set share a color. 
- Kept the previous behavior when no selection exists (existing white/empty color checks and reuse of existing colors are preserved) and left layer-color assignment logic unchanged. 
- Technical note: `gui/mainwindow_menu.cpp` is a hotspot (~1300 LOC); this change was kept minimal and localized, and a follow-up refactor could extract menu action handlers to reduce hotspot growth.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which succeeded. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999ff4a580c8324b06243527a9abfc1)