### PR TITLE
Add per-view SVG export in Fixture Symbol Preview

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/tools/fixture_symbol_generation_tool.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tools/scene_model_symbol_capture_service.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/windows/SymbolPreviewWindow.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/windows/symbol_preview_exporter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dialogs/GenerateFixtureSymbolsDialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/exportfixturedialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/exportobjectdialog.cpp

--- a/gui/windows/SymbolPreviewWindow.cpp
+++ b/gui/windows/SymbolPreviewWindow.cpp
@@ -2,11 +2,19 @@
 
 #include <algorithm>
 #include <cmath>
+#include <string>
 #include <vector>
 
 #include <wx/dcbuffer.h>
+#include <wx/filedlg.h>
+#include <wx/menu.h>
+#include <wx/msgdlg.h>
+
+#include "windows/symbol_preview_exporter.h"
 
 namespace {
+
+constexpr int ID_ExportSelectedViewAsSvg = wxID_HIGHEST + 240;
 
 wxPoint ToScreenPoint(const symbols::Point2D &p, const symbols::Aabb2D &bounds,
                       double scale, int originX, int originY) {
@@ -42,6 +50,9 @@ SymbolPreviewWindow::SymbolPreviewWindow(wxWindow *parent,
   SetBackgroundStyle(wxBG_STYLE_PAINT);
   Bind(wxEVT_PAINT, &SymbolPreviewWindow::OnPaint, this);
   Bind(wxEVT_SIZE, &SymbolPreviewWindow::OnSize, this);
+  Bind(wxEVT_LEFT_DOWN, &SymbolPreviewWindow::OnLeftDown, this);
+  Bind(wxEVT_MENU, &SymbolPreviewWindow::OnExportSelectedView, this,
+       ID_ExportSelectedViewAsSvg);
 }
 
 const symbols::Symbol2D *SymbolPreviewWindow::FindSymbol(
@@ -53,9 +64,97 @@ const symbols::Symbol2D *SymbolPreviewWindow::FindSymbol(
   return it == symbols.end() ? nullptr : &(*it);
 }
 
+wxString SymbolPreviewWindow::ViewLabel(symbols::SymbolView view) {
+  switch (view) {
+  case symbols::SymbolView::Front:
+    return "Front";
+  case symbols::SymbolView::Top:
+    return "Top";
+  case symbols::SymbolView::Bottom:
+    return "Bottom";
+  case symbols::SymbolView::Left:
+    return "Left";
+  }
+  return "View";
+}
+
+std::vector<SymbolPreviewWindow::PreviewCell>
+SymbolPreviewWindow::BuildPreviewCells(const wxSize &size) const {
+  const int pad = 14;
+  const int cellW = std::max(1, (size.GetWidth() - pad * 3) / 2);
+  const int cellH = std::max(1, (size.GetHeight() - pad * 3) / 2);
+
+  return {
+      {wxRect(pad, pad, cellW, cellH), symbols::SymbolView::Front, "Front"},
+      {wxRect(pad * 2 + cellW, pad, cellW, cellH), symbols::SymbolView::Top, "Top"},
+      {wxRect(pad, pad * 2 + cellH, cellW, cellH), symbols::SymbolView::Left, "Left"},
+      {wxRect(pad * 2 + cellW, pad * 2 + cellH, cellW, cellH),
+       symbols::SymbolView::Bottom, "Bottom"},
+  };
+}
+
+std::optional<SymbolPreviewWindow::PreviewCell>
+SymbolPreviewWindow::FindCellAt(const wxPoint &point) const {
+  for (const auto &cell : BuildPreviewCells(GetClientSize())) {
+    if (cell.rect.Contains(point))
+      return cell;
+  }
+  return std::nullopt;
+}
+
 void SymbolPreviewWindow::OnSize(wxSizeEvent &event) {
   Refresh(false);
   event.Skip();
+}
+
+void SymbolPreviewWindow::OnLeftDown(wxMouseEvent &event) {
+  const auto cell = FindCellAt(event.GetPosition());
+  if (!cell.has_value()) {
+    event.Skip();
+    return;
+  }
+
+  const symbols::Symbol2D *symbol = FindSymbol(symbols_, cell->view);
+  if (!symbol || !symbol->bounds.valid) {
+    wxMessageBox("This view has no drawable symbol to export.",
+                 "Fixture Symbol Preview", wxOK | wxICON_INFORMATION, this);
+    return;
+  }
+
+  selectedViewForExport_ = cell->view;
+  wxMenu menu;
+  menu.Append(ID_ExportSelectedViewAsSvg, "Export this view as SVG...");
+  PopupMenu(&menu, event.GetPosition());
+}
+
+void SymbolPreviewWindow::OnExportSelectedView(wxCommandEvent &WXUNUSED(event)) {
+  if (!selectedViewForExport_.has_value())
+    return;
+
+  const symbols::SymbolView view = selectedViewForExport_.value();
+  const symbols::Symbol2D *symbol = FindSymbol(symbols_, view);
+  if (!symbol || !symbol->bounds.valid)
+    return;
+
+  const wxString viewLabel = ViewLabel(view);
+  const wxString suggestedName =
+      "fixture_symbol_" + viewLabel.Lower() + ".svg";
+  wxFileDialog saveDialog(this, "Export Symbol View as SVG", wxEmptyString,
+                          suggestedName, "SVG files (*.svg)|*.svg",
+                          wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+  if (saveDialog.ShowModal() != wxID_OK)
+    return;
+
+  std::string errorMessage;
+  if (!symbol_preview::ExportSymbolToSvg(*symbol,
+                                         saveDialog.GetPath().ToStdString(),
+                                         errorMessage)) {
+    wxMessageBox(errorMessage, "Export Symbol View", wxOK | wxICON_ERROR, this);
+    return;
+  }
+
+  wxMessageBox("Symbol view exported successfully.", "Export Symbol View",
+               wxOK | wxICON_INFORMATION, this);
 }
 
 void SymbolPreviewWindow::OnPaint(wxPaintEvent &WXUNUSED(event)) {
@@ -63,19 +162,9 @@ void SymbolPreviewWindow::OnPaint(wxPaintEvent &WXUNUSED(event)) {
   dc.SetBackground(wxBrush(wxColour(248, 248, 248)));
   dc.Clear();
 
-  wxSize size = GetClientSize();
-  const int pad = 14;
-  const int cellW = std::max(1, (size.GetWidth() - pad * 3) / 2);
-  const int cellH = std::max(1, (size.GetHeight() - pad * 3) / 2);
-
-  DrawCell(dc, wxRect(pad, pad, cellW, cellH),
-           FindSymbol(symbols_, symbols::SymbolView::Front), "Front");
-  DrawCell(dc, wxRect(pad * 2 + cellW, pad, cellW, cellH),
-           FindSymbol(symbols_, symbols::SymbolView::Top), "Top");
-  DrawCell(dc, wxRect(pad, pad * 2 + cellH, cellW, cellH),
-           FindSymbol(symbols_, symbols::SymbolView::Left), "Left");
-  DrawCell(dc, wxRect(pad * 2 + cellW, pad * 2 + cellH, cellW, cellH),
-           FindSymbol(symbols_, symbols::SymbolView::Bottom), "Bottom");
+  for (const auto &cell : BuildPreviewCells(GetClientSize())) {
+    DrawCell(dc, cell.rect, FindSymbol(symbols_, cell.view), cell.label);
+  }
 }
 
 void SymbolPreviewWindow::DrawCell(wxDC &dc, const wxRect &cell,

--- a/gui/windows/SymbolPreviewWindow.cpp
+++ b/gui/windows/SymbolPreviewWindow.cpp
@@ -51,8 +51,6 @@ SymbolPreviewWindow::SymbolPreviewWindow(wxWindow *parent,
   SetBackgroundStyle(wxBG_STYLE_PAINT);
   Bind(wxEVT_PAINT, &SymbolPreviewWindow::OnPaint, this);
   Bind(wxEVT_SIZE, &SymbolPreviewWindow::OnSize, this);
-  Bind(wxEVT_LEFT_UP, &SymbolPreviewWindow::OnLeftUp, this);
-  Bind(wxEVT_RIGHT_UP, &SymbolPreviewWindow::OnRightUp, this);
   Bind(wxEVT_CONTEXT_MENU, &SymbolPreviewWindow::OnContextMenu, this);
   Bind(wxEVT_MENU, &SymbolPreviewWindow::OnExportSelectedView, this,
        ID_ExportSelectedViewAsSvg);
@@ -126,14 +124,6 @@ void SymbolPreviewWindow::ShowExportMenuAt(const wxPoint &point) {
   wxMenu menu;
   menu.Append(ID_ExportSelectedViewAsSvg, "Export this view as SVG...");
   PopupMenu(&menu, point);
-}
-
-void SymbolPreviewWindow::OnLeftUp(wxMouseEvent &event) {
-  ShowExportMenuAt(event.GetPosition());
-}
-
-void SymbolPreviewWindow::OnRightUp(wxMouseEvent &event) {
-  ShowExportMenuAt(event.GetPosition());
 }
 
 void SymbolPreviewWindow::OnContextMenu(wxContextMenuEvent &event) {

--- a/gui/windows/SymbolPreviewWindow.cpp
+++ b/gui/windows/SymbolPreviewWindow.cpp
@@ -9,6 +9,7 @@
 #include <wx/filedlg.h>
 #include <wx/menu.h>
 #include <wx/msgdlg.h>
+#include <wx/utils.h>
 
 #include "windows/symbol_preview_exporter.h"
 
@@ -51,6 +52,8 @@ SymbolPreviewWindow::SymbolPreviewWindow(wxWindow *parent,
   Bind(wxEVT_PAINT, &SymbolPreviewWindow::OnPaint, this);
   Bind(wxEVT_SIZE, &SymbolPreviewWindow::OnSize, this);
   Bind(wxEVT_LEFT_DOWN, &SymbolPreviewWindow::OnLeftDown, this);
+  Bind(wxEVT_RIGHT_DOWN, &SymbolPreviewWindow::OnRightDown, this);
+  Bind(wxEVT_CONTEXT_MENU, &SymbolPreviewWindow::OnContextMenu, this);
   Bind(wxEVT_MENU, &SymbolPreviewWindow::OnExportSelectedView, this,
        ID_ExportSelectedViewAsSvg);
 }
@@ -107,12 +110,10 @@ void SymbolPreviewWindow::OnSize(wxSizeEvent &event) {
   event.Skip();
 }
 
-void SymbolPreviewWindow::OnLeftDown(wxMouseEvent &event) {
-  const auto cell = FindCellAt(event.GetPosition());
-  if (!cell.has_value()) {
-    event.Skip();
+void SymbolPreviewWindow::ShowExportMenuAt(const wxPoint &point) {
+  const auto cell = FindCellAt(point);
+  if (!cell.has_value())
     return;
-  }
 
   const symbols::Symbol2D *symbol = FindSymbol(symbols_, cell->view);
   if (!symbol || !symbol->bounds.valid) {
@@ -124,7 +125,26 @@ void SymbolPreviewWindow::OnLeftDown(wxMouseEvent &event) {
   selectedViewForExport_ = cell->view;
   wxMenu menu;
   menu.Append(ID_ExportSelectedViewAsSvg, "Export this view as SVG...");
-  PopupMenu(&menu, event.GetPosition());
+  PopupMenu(&menu, point);
+}
+
+void SymbolPreviewWindow::OnLeftDown(wxMouseEvent &event) {
+  ShowExportMenuAt(event.GetPosition());
+}
+
+void SymbolPreviewWindow::OnRightDown(wxMouseEvent &event) {
+  ShowExportMenuAt(event.GetPosition());
+}
+
+void SymbolPreviewWindow::OnContextMenu(wxContextMenuEvent &event) {
+  wxPoint screenPoint = event.GetPosition();
+  wxPoint clientPoint = screenPoint;
+  if (screenPoint == wxDefaultPosition)
+    clientPoint = ScreenToClient(wxGetMousePosition());
+  else
+    clientPoint = ScreenToClient(screenPoint);
+
+  ShowExportMenuAt(clientPoint);
 }
 
 void SymbolPreviewWindow::OnExportSelectedView(wxCommandEvent &WXUNUSED(event)) {

--- a/gui/windows/SymbolPreviewWindow.cpp
+++ b/gui/windows/SymbolPreviewWindow.cpp
@@ -51,8 +51,8 @@ SymbolPreviewWindow::SymbolPreviewWindow(wxWindow *parent,
   SetBackgroundStyle(wxBG_STYLE_PAINT);
   Bind(wxEVT_PAINT, &SymbolPreviewWindow::OnPaint, this);
   Bind(wxEVT_SIZE, &SymbolPreviewWindow::OnSize, this);
-  Bind(wxEVT_LEFT_DOWN, &SymbolPreviewWindow::OnLeftDown, this);
-  Bind(wxEVT_RIGHT_DOWN, &SymbolPreviewWindow::OnRightDown, this);
+  Bind(wxEVT_LEFT_UP, &SymbolPreviewWindow::OnLeftUp, this);
+  Bind(wxEVT_RIGHT_UP, &SymbolPreviewWindow::OnRightUp, this);
   Bind(wxEVT_CONTEXT_MENU, &SymbolPreviewWindow::OnContextMenu, this);
   Bind(wxEVT_MENU, &SymbolPreviewWindow::OnExportSelectedView, this,
        ID_ExportSelectedViewAsSvg);
@@ -128,11 +128,11 @@ void SymbolPreviewWindow::ShowExportMenuAt(const wxPoint &point) {
   PopupMenu(&menu, point);
 }
 
-void SymbolPreviewWindow::OnLeftDown(wxMouseEvent &event) {
+void SymbolPreviewWindow::OnLeftUp(wxMouseEvent &event) {
   ShowExportMenuAt(event.GetPosition());
 }
 
-void SymbolPreviewWindow::OnRightDown(wxMouseEvent &event) {
+void SymbolPreviewWindow::OnRightUp(wxMouseEvent &event) {
   ShowExportMenuAt(event.GetPosition());
 }
 

--- a/gui/windows/SymbolPreviewWindow.h
+++ b/gui/windows/SymbolPreviewWindow.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <vector>
 
 #include <wx/frame.h>
@@ -12,12 +13,25 @@ public:
                       std::vector<symbols::Symbol2D> symbols);
 
 private:
+  struct PreviewCell {
+    wxRect rect;
+    symbols::SymbolView view = symbols::SymbolView::Top;
+    wxString label;
+  };
+
   void OnPaint(wxPaintEvent &event);
   void OnSize(wxSizeEvent &event);
+  void OnLeftDown(wxMouseEvent &event);
+  void OnExportSelectedView(wxCommandEvent &event);
   void DrawCell(wxDC &dc, const wxRect &cell, const symbols::Symbol2D *symbol,
                 const wxString &label);
+  std::vector<PreviewCell> BuildPreviewCells(const wxSize &size) const;
+  std::optional<PreviewCell> FindCellAt(const wxPoint &point) const;
+
   static const symbols::Symbol2D *FindSymbol(
       const std::vector<symbols::Symbol2D> &symbols, symbols::SymbolView view);
+  static wxString ViewLabel(symbols::SymbolView view);
 
   std::vector<symbols::Symbol2D> symbols_;
+  std::optional<symbols::SymbolView> selectedViewForExport_;
 };

--- a/gui/windows/SymbolPreviewWindow.h
+++ b/gui/windows/SymbolPreviewWindow.h
@@ -21,8 +21,6 @@ private:
 
   void OnPaint(wxPaintEvent &event);
   void OnSize(wxSizeEvent &event);
-  void OnLeftUp(wxMouseEvent &event);
-  void OnRightUp(wxMouseEvent &event);
   void OnContextMenu(wxContextMenuEvent &event);
   void OnExportSelectedView(wxCommandEvent &event);
   void ShowExportMenuAt(const wxPoint &point);

--- a/gui/windows/SymbolPreviewWindow.h
+++ b/gui/windows/SymbolPreviewWindow.h
@@ -22,7 +22,10 @@ private:
   void OnPaint(wxPaintEvent &event);
   void OnSize(wxSizeEvent &event);
   void OnLeftDown(wxMouseEvent &event);
+  void OnRightDown(wxMouseEvent &event);
+  void OnContextMenu(wxContextMenuEvent &event);
   void OnExportSelectedView(wxCommandEvent &event);
+  void ShowExportMenuAt(const wxPoint &point);
   void DrawCell(wxDC &dc, const wxRect &cell, const symbols::Symbol2D *symbol,
                 const wxString &label);
   std::vector<PreviewCell> BuildPreviewCells(const wxSize &size) const;

--- a/gui/windows/SymbolPreviewWindow.h
+++ b/gui/windows/SymbolPreviewWindow.h
@@ -21,8 +21,8 @@ private:
 
   void OnPaint(wxPaintEvent &event);
   void OnSize(wxSizeEvent &event);
-  void OnLeftDown(wxMouseEvent &event);
-  void OnRightDown(wxMouseEvent &event);
+  void OnLeftUp(wxMouseEvent &event);
+  void OnRightUp(wxMouseEvent &event);
   void OnContextMenu(wxContextMenuEvent &event);
   void OnExportSelectedView(wxCommandEvent &event);
   void ShowExportMenuAt(const wxPoint &point);

--- a/gui/windows/symbol_preview_exporter.cpp
+++ b/gui/windows/symbol_preview_exporter.cpp
@@ -1,0 +1,85 @@
+#include "windows/symbol_preview_exporter.h"
+
+#include <fstream>
+#include <sstream>
+
+namespace symbol_preview {
+namespace {
+
+std::string BuildPoints(const symbols::Polyline2D &line,
+                        const symbols::Aabb2D &bounds) {
+  std::ostringstream stream;
+  bool first = true;
+  for (const auto &point : line) {
+    if (!first)
+      stream << ' ';
+    first = false;
+    const float x = point.x - bounds.min.x;
+    const float y = bounds.max.y - point.y;
+    stream << x << ',' << y;
+  }
+  return stream.str();
+}
+
+} // namespace
+
+bool ExportSymbolToSvg(const symbols::Symbol2D &symbol,
+                       const std::string &filePath,
+                       std::string &errorMessage) {
+  if (!symbol.bounds.valid) {
+    errorMessage = "The selected view has no drawable symbol.";
+    return false;
+  }
+
+  const float width = symbol.bounds.max.x - symbol.bounds.min.x;
+  const float height = symbol.bounds.max.y - symbol.bounds.min.y;
+  if (width <= 0.0f || height <= 0.0f) {
+    errorMessage = "The selected view has invalid bounds.";
+    return false;
+  }
+
+  std::ofstream file(filePath);
+  if (!file.is_open()) {
+    errorMessage = "Could not open the output file.";
+    return false;
+  }
+
+  file << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
+  file << "<svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\" "
+          "viewBox=\"0 0 "
+       << width << ' ' << height << "\">\n";
+
+  for (const auto &polygon : symbol.fill) {
+    if (polygon.outer.size() < 3)
+      continue;
+
+    file << "  <polygon points=\"" << BuildPoints(polygon.outer, symbol.bounds)
+         << "\" fill=\"#e0e0e0\" stroke=\"none\"/>\n";
+    for (const auto &hole : polygon.holes) {
+      if (hole.size() < 3)
+        continue;
+      file << "  <polygon points=\"" << BuildPoints(hole, symbol.bounds)
+           << "\" fill=\"#ffffff\" stroke=\"none\"/>\n";
+    }
+  }
+
+  const float strokeWidth = symbol.strokeWidthPx < 0.0f ? 0.0f : symbol.strokeWidthPx;
+  for (const auto &line : symbol.strokes) {
+    if (line.size() < 2)
+      continue;
+    file << "  <polyline points=\"" << BuildPoints(line, symbol.bounds)
+         << "\" fill=\"none\" stroke=\"#000000\" stroke-width=\""
+         << strokeWidth << "\"/>\n";
+  }
+
+  file << "</svg>\n";
+  if (!file.good()) {
+    errorMessage = "Could not write the SVG data to disk.";
+    return false;
+  }
+
+  return true;
+}
+
+} // namespace symbol_preview
+

--- a/gui/windows/symbol_preview_exporter.h
+++ b/gui/windows/symbol_preview_exporter.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <string>
+
+#include "symbols/Symbol2D.h"
+
+namespace symbol_preview {
+
+bool ExportSymbolToSvg(const symbols::Symbol2D &symbol,
+                       const std::string &filePath,
+                       std::string &errorMessage);
+
+} // namespace symbol_preview
+


### PR DESCRIPTION
### Motivation
- Provide a way for users to export the generated fixture symbol view they click on in the "Fixture Symbol Preview" window as an SVG file.
- Keep UI responsibilities separate from file IO/export logic by extracting SVG generation into a small helper.

### Description
- Added click handling to `SymbolPreviewWindow` so clicking a preview cell opens a contextual menu with an `Export this view as SVG...` action and a file save dialog flow (`OnLeftDown`, `OnExportSelectedView`).
- Introduced `symbol_preview_exporter` with `ExportSymbolToSvg(const symbols::Symbol2D&, const std::string&, std::string&)` to generate and write SVG files including fills, holes and strokes (`gui/windows/symbol_preview_exporter.h/.cpp`).
- Updated `SymbolPreviewWindow` declaration to track preview cells and export state (`gui/windows/SymbolPreviewWindow.h`) and replaced manual cell painting with a small `BuildPreviewCells`/`FindCellAt` helper to keep rendering and hit-testing tidy.
- Registered the new exporter implementation in `gui/CMakeLists.txt` so the new source is compiled with the GUI module (`windows/symbol_preview_exporter.cpp`).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed (`OK`).
- Attempted `cmake -S . -B build` in this environment which failed due to missing system `wxWidgets` development packages (configuration error: `Could NOT find wxWidgets`), so a full local build was not completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a02699cb083248e658b82fc17f5dd)