### PR TITLE
Rigging: round Total Weight +5% once to 5 kg ceiling

### DIFF
--- a/gui/riggingpanel.cpp
+++ b/gui/riggingpanel.cpp
@@ -29,8 +29,8 @@
 namespace {
 constexpr const char *UNASSIGNED_POSITION = "Unassigned";
 
-float CeilToNearestTens(float value) {
-  return std::ceil(value / 10.0f) * 10.0f;
+float CeilToNearestHalfTen(float value) {
+  return std::ceil(value / 5.0f) * 5.0f;
 }
 
 bool IsRedCell(const ColorfulDataViewListStore *store, int row, int col) {
@@ -227,9 +227,7 @@ void RiggingPanel::RefreshData() {
   for (const auto &[position, totals] : rows) {
     float totalWeight =
         totals.fixtureWeight + totals.trussWeight + totals.hoistWeight;
-    float roundedTotalWeight = CeilToNearestTens(totalWeight);
-    float roundedFivePercentIncrease =
-        CeilToNearestTens(roundedTotalWeight * 1.05f);
+    float roundedFivePercentIncrease = CeilToNearestHalfTen(totalWeight * 1.05f);
     wxVector<wxVariant> row;
     row.push_back(wxString::FromUTF8(position));
     row.push_back(wxString::Format("%d", totals.fixtures));


### PR DESCRIPTION
### Motivation
- Ensure the displayed `Total Weight +5%` is computed from the raw total and then rounded once upward to the nearest 5 kg (half-decade), avoiding the previous double-rounding that used tens.

### Description
- Replaced `CeilToNearestTens` with `CeilToNearestHalfTen` (`ceil(value / 5) * 5`) and removed the intermediate pre-round of total weight so `RefreshData()` now computes `ceil_to_5kg(totalWeight * 1.05)` directly.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed; and `tests/check_no_configmanager_get_in_gui.sh` which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a1e96cc208324872bd9974f6689e0)