### PR TITLE
Clarify rigging column label for rounded total weight

### DIFF
--- a/gui/riggingpanel.cpp
+++ b/gui/riggingpanel.cpp
@@ -150,7 +150,7 @@ RiggingPanel::RiggingPanel(wxWindow *parent) : wxPanel(parent, wxID_ANY) {
   table->AppendTextColumn("Total Weight (kg)", wxDATAVIEW_CELL_INERT,
                           wxCOL_WIDTH_AUTOSIZE, wxALIGN_RIGHT,
                           wxDATAVIEW_COL_RESIZABLE);
-  table->AppendTextColumn("Total Weight +5% (kg)", wxDATAVIEW_CELL_INERT,
+  table->AppendTextColumn("Rounded Total Weight +5% (kg)", wxDATAVIEW_CELL_INERT,
                           wxCOL_WIDTH_AUTOSIZE, wxALIGN_RIGHT,
                           wxDATAVIEW_COL_RESIZABLE);
 


### PR DESCRIPTION
### Motivation
- Make the rigging table label explicitly indicate that the shown "+5%" value is a rounded/adjusted figure to avoid user confusion.

### Description
- Renamed the column label in `gui/riggingpanel.cpp` from `Total Weight +5% (kg)` to `Rounded Total Weight +5% (kg)` as a minimal, localized UI text change.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ad967731c83249358e12268be48b0)