### PR TITLE
Add 'Apply symbol to fixture' action to Symbol Preview and GDTF applier

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/tools/fixture_symbol_generation_tool.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tools/scene_model_symbol_capture_service.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/windows/SymbolPreviewWindow.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/windows/symbol_fixture_applier.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/windows/symbol_preview_exporter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dialogs/GenerateFixtureSymbolsDialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/exportfixturedialog.cpp

--- a/gui/tools/fixture_symbol_generation_tool.cpp
+++ b/gui/tools/fixture_symbol_generation_tool.cpp
@@ -128,8 +128,8 @@ void RunFixtureSymbolGeneration(MainWindow &window) {
     return;
   }
 
-  SymbolPreviewWindow *preview =
-      new SymbolPreviewWindow(&window, std::move(capture.symbols));
+  SymbolPreviewWindow *preview = new SymbolPreviewWindow(
+      &window, std::move(capture.symbols), selectedFixtureUuid);
   preview->Show();
 }
 

--- a/gui/windows/SymbolPreviewWindow.cpp
+++ b/gui/windows/SymbolPreviewWindow.cpp
@@ -113,22 +113,34 @@ void SymbolPreviewWindow::OnSize(wxSizeEvent &event) {
   event.Skip();
 }
 
+bool SymbolPreviewWindow::HasAnyValidSymbol() const {
+  for (const auto &symbol : symbols_) {
+    if (symbol.bounds.valid)
+      return true;
+  }
+  return false;
+}
+
 void SymbolPreviewWindow::ShowExportMenuAt(const wxPoint &point) {
   const auto cell = FindCellAt(point);
   if (!cell.has_value())
     return;
 
   const symbols::Symbol2D *symbol = FindSymbol(symbols_, cell->view);
-  if (!symbol || !symbol->bounds.valid) {
-    wxMessageBox("This view has no drawable symbol to export.",
+  wxMenu menu;
+  if (symbol && symbol->bounds.valid) {
+    selectedViewForExport_ = cell->view;
+    menu.Append(ID_ExportSelectedViewAsSvg, "Export this view as SVG...");
+  }
+
+  if (HasAnyValidSymbol())
+    menu.Append(ID_ApplySymbolToFixture, "Apply views to fixture...");
+
+  if (menu.GetMenuItemCount() == 0) {
+    wxMessageBox("No valid symbol views are available.",
                  "Fixture Symbol Preview", wxOK | wxICON_INFORMATION, this);
     return;
   }
-
-  selectedViewForExport_ = cell->view;
-  wxMenu menu;
-  menu.Append(ID_ExportSelectedViewAsSvg, "Export this view as SVG...");
-  menu.Append(ID_ApplySymbolToFixture, "Apply symbol to fixture...");
   PopupMenu(&menu, point);
 }
 
@@ -177,13 +189,13 @@ void SymbolPreviewWindow::OnExportSelectedView(wxCommandEvent &WXUNUSED(event)) 
 void SymbolPreviewWindow::OnApplySymbolToFixture(wxCommandEvent &WXUNUSED(event)) {
   std::string errorMessage;
   if (!symbol_preview::ApplySymbolsToFixtureGdtf(symbols_, fixtureUuid_, errorMessage)) {
-    wxMessageBox(errorMessage, "Apply Symbol to Fixture", wxOK | wxICON_ERROR,
+    wxMessageBox(errorMessage, "Apply Views to Fixture", wxOK | wxICON_ERROR,
                  this);
     return;
   }
 
   wxMessageBox("Symbol views applied to fixture GDTF successfully.",
-               "Apply Symbol to Fixture", wxOK | wxICON_INFORMATION, this);
+               "Apply Views to Fixture", wxOK | wxICON_INFORMATION, this);
 }
 
 void SymbolPreviewWindow::OnPaint(wxPaintEvent &WXUNUSED(event)) {

--- a/gui/windows/SymbolPreviewWindow.cpp
+++ b/gui/windows/SymbolPreviewWindow.cpp
@@ -194,7 +194,7 @@ void SymbolPreviewWindow::OnApplySymbolToFixture(wxCommandEvent &WXUNUSED(event)
     return;
   }
 
-  wxMessageBox("Symbol views applied to fixture GDTF successfully.",
+  wxMessageBox("Symbol views applied to fixture GDTF successfully.\nCheck the file in your fixtures library.",
                "Apply Views to Fixture", wxOK | wxICON_INFORMATION, this);
 }
 

--- a/gui/windows/SymbolPreviewWindow.cpp
+++ b/gui/windows/SymbolPreviewWindow.cpp
@@ -11,11 +11,13 @@
 #include <wx/msgdlg.h>
 #include <wx/utils.h>
 
+#include "windows/symbol_fixture_applier.h"
 #include "windows/symbol_preview_exporter.h"
 
 namespace {
 
 constexpr int ID_ExportSelectedViewAsSvg = wxID_HIGHEST + 240;
+constexpr int ID_ApplySymbolToFixture = wxID_HIGHEST + 241;
 
 wxPoint ToScreenPoint(const symbols::Point2D &p, const symbols::Aabb2D &bounds,
                       double scale, int originX, int originY) {
@@ -44,16 +46,19 @@ void DrawPolyline(wxDC &dc, const symbols::Polyline2D &line,
 } // namespace
 
 SymbolPreviewWindow::SymbolPreviewWindow(wxWindow *parent,
-                                         std::vector<symbols::Symbol2D> symbols)
+                                         std::vector<symbols::Symbol2D> symbols,
+                                         std::string fixtureUuid)
     : wxFrame(parent, wxID_ANY, "Fixture Symbol Preview", wxDefaultPosition,
               wxSize(1000, 760), wxDEFAULT_FRAME_STYLE | wxFRAME_FLOAT_ON_PARENT),
-      symbols_(std::move(symbols)) {
+      symbols_(std::move(symbols)), fixtureUuid_(std::move(fixtureUuid)) {
   SetBackgroundStyle(wxBG_STYLE_PAINT);
   Bind(wxEVT_PAINT, &SymbolPreviewWindow::OnPaint, this);
   Bind(wxEVT_SIZE, &SymbolPreviewWindow::OnSize, this);
   Bind(wxEVT_CONTEXT_MENU, &SymbolPreviewWindow::OnContextMenu, this);
   Bind(wxEVT_MENU, &SymbolPreviewWindow::OnExportSelectedView, this,
        ID_ExportSelectedViewAsSvg);
+  Bind(wxEVT_MENU, &SymbolPreviewWindow::OnApplySymbolToFixture, this,
+       ID_ApplySymbolToFixture);
 }
 
 const symbols::Symbol2D *SymbolPreviewWindow::FindSymbol(
@@ -123,6 +128,7 @@ void SymbolPreviewWindow::ShowExportMenuAt(const wxPoint &point) {
   selectedViewForExport_ = cell->view;
   wxMenu menu;
   menu.Append(ID_ExportSelectedViewAsSvg, "Export this view as SVG...");
+  menu.Append(ID_ApplySymbolToFixture, "Apply symbol to fixture...");
   PopupMenu(&menu, point);
 }
 
@@ -165,6 +171,19 @@ void SymbolPreviewWindow::OnExportSelectedView(wxCommandEvent &WXUNUSED(event)) 
 
   wxMessageBox("Symbol view exported successfully.", "Export Symbol View",
                wxOK | wxICON_INFORMATION, this);
+}
+
+
+void SymbolPreviewWindow::OnApplySymbolToFixture(wxCommandEvent &WXUNUSED(event)) {
+  std::string errorMessage;
+  if (!symbol_preview::ApplySymbolsToFixtureGdtf(symbols_, fixtureUuid_, errorMessage)) {
+    wxMessageBox(errorMessage, "Apply Symbol to Fixture", wxOK | wxICON_ERROR,
+                 this);
+    return;
+  }
+
+  wxMessageBox("Symbol views applied to fixture GDTF successfully.",
+               "Apply Symbol to Fixture", wxOK | wxICON_INFORMATION, this);
 }
 
 void SymbolPreviewWindow::OnPaint(wxPaintEvent &WXUNUSED(event)) {

--- a/gui/windows/SymbolPreviewWindow.h
+++ b/gui/windows/SymbolPreviewWindow.h
@@ -30,6 +30,7 @@ private:
                 const wxString &label);
   std::vector<PreviewCell> BuildPreviewCells(const wxSize &size) const;
   std::optional<PreviewCell> FindCellAt(const wxPoint &point) const;
+  bool HasAnyValidSymbol() const;
 
   static const symbols::Symbol2D *FindSymbol(
       const std::vector<symbols::Symbol2D> &symbols, symbols::SymbolView view);

--- a/gui/windows/SymbolPreviewWindow.h
+++ b/gui/windows/SymbolPreviewWindow.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <optional>
+#include <string>
 #include <vector>
 
 #include <wx/frame.h>
@@ -9,8 +10,8 @@
 
 class SymbolPreviewWindow : public wxFrame {
 public:
-  SymbolPreviewWindow(wxWindow *parent,
-                      std::vector<symbols::Symbol2D> symbols);
+  SymbolPreviewWindow(wxWindow *parent, std::vector<symbols::Symbol2D> symbols,
+                      std::string fixtureUuid);
 
 private:
   struct PreviewCell {
@@ -23,6 +24,7 @@ private:
   void OnSize(wxSizeEvent &event);
   void OnContextMenu(wxContextMenuEvent &event);
   void OnExportSelectedView(wxCommandEvent &event);
+  void OnApplySymbolToFixture(wxCommandEvent &event);
   void ShowExportMenuAt(const wxPoint &point);
   void DrawCell(wxDC &dc, const wxRect &cell, const symbols::Symbol2D *symbol,
                 const wxString &label);
@@ -34,5 +36,6 @@ private:
   static wxString ViewLabel(symbols::SymbolView view);
 
   std::vector<symbols::Symbol2D> symbols_;
+  std::string fixtureUuid_;
   std::optional<symbols::SymbolView> selectedViewForExport_;
 };

--- a/gui/windows/symbol_fixture_applier.cpp
+++ b/gui/windows/symbol_fixture_applier.cpp
@@ -30,6 +30,13 @@ struct SymbolPayload {
   float offsetY = 0.0f;
 };
 
+std::string NormalizeArchivePath(std::string value) {
+  std::replace(value.begin(), value.end(), '\\', '/');
+  while (!value.empty() && value.front() == '/')
+    value.erase(value.begin());
+  return value;
+}
+
 bool ReadAllBytes(wxZipInputStream &zip, std::string &out) {
   out.clear();
   char buffer[4096];
@@ -117,7 +124,7 @@ bool BuildSymbolPayload(const std::vector<symbols::Symbol2D> &symbols,
   if (!symbol || !symbol->bounds.valid)
     return false;
 
-  out.archivePath = archivePath;
+  out.archivePath = NormalizeArchivePath(archivePath);
   out.offsetX = -symbol->bounds.min.x;
   out.offsetY = -symbol->bounds.min.y;
   if (!symbol_preview::ExportSymbolToSvgString(*symbol, out.svg, errorMessage))
@@ -200,12 +207,12 @@ bool VerifyArchiveEntries(const fs::path &archivePath,
   std::unordered_map<std::string, bool> found;
   for (const auto &[path, payload] : payloads) {
     (void)payload;
-    found[path] = false;
+    found[NormalizeArchivePath(path)] = false;
   }
 
   std::unique_ptr<wxZipEntry> entry;
   while ((entry.reset(zipInput.GetNextEntry())), entry) {
-    const std::string name = entry->GetName().ToStdString();
+    const std::string name = NormalizeArchivePath(entry->GetName().ToStdString());
     auto it = found.find(name);
     if (it != found.end())
       it->second = true;
@@ -260,14 +267,16 @@ bool RewriteGdtf(const fs::path &sourcePath,
 
   descriptionIt->second = std::move(updatedDescription);
   for (const auto &[path, payload] : payloads) {
+    const std::string normalizedPath = NormalizeArchivePath(path);
     auto existing = std::find_if(entries.begin(), entries.end(),
                                  [&](const auto &entry) {
-                                   return entry.first == path;
+                                   return NormalizeArchivePath(entry.first) ==
+                                          normalizedPath;
                                  });
     if (existing != entries.end())
       existing->second = payload.svg;
     else
-      entries.emplace_back(path, payload.svg);
+      entries.emplace_back(normalizedPath, payload.svg);
   }
 
   const fs::path tempPath = sourcePath.string() + ".tmp";

--- a/gui/windows/symbol_fixture_applier.cpp
+++ b/gui/windows/symbol_fixture_applier.cpp
@@ -15,6 +15,7 @@
 #include "configmanager.h"
 #include "guiconfigservices.h"
 #include "gdtfdictionary.h"
+#include "projectutils.h"
 #include "windows/symbol_preview_exporter.h"
 
 namespace fs = std::filesystem;
@@ -80,6 +81,20 @@ std::string ResolveGdtfPath(const Fixture &fixture) {
       if (fs::exists(entryPath, ec) && !ec)
         return entryPath.string();
     }
+  }
+
+  std::error_code ec;
+  const fs::path fixturesLibrary =
+      fs::path(ProjectUtils::GetDefaultLibraryPath("fixtures"));
+
+  if (specPath.is_absolute() && fs::exists(specPath, ec) && !ec)
+    return specPath.string();
+
+  if (!specFileName.empty()) {
+    ec.clear();
+    const fs::path fromLibrary = fixturesLibrary / specFileName;
+    if (fs::exists(fromLibrary, ec) && !ec)
+      return fromLibrary.string();
   }
 
   return {};
@@ -282,7 +297,7 @@ bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
 
   const std::string gdtfPath = ResolveGdtfPath(fixtureIt->second);
   if (gdtfPath.empty()) {
-    errorMessage = "Could not resolve fixture GDTF in dictionary (by type or file name).";
+    errorMessage = "Could not resolve fixture GDTF path in fixtures library.";
     return false;
   }
 

--- a/gui/windows/symbol_fixture_applier.cpp
+++ b/gui/windows/symbol_fixture_applier.cpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -50,26 +51,46 @@ bool ReadAllBytes(wxZipInputStream &zip, std::string &out) {
   return true;
 }
 
-std::string ResolveGdtfPath(const Fixture &fixture) {
+std::string ResolveSceneGdtfPath(const Fixture &fixture, const MvrScene &scene) {
+  const fs::path specPath = fs::path(fixture.gdtfSpec);
+  if (specPath.empty())
+    return {};
+
+  std::error_code ec;
+  if (specPath.is_absolute() && fs::exists(specPath, ec) && !ec)
+    return specPath.string();
+
+  if (!scene.basePath.empty()) {
+    ec.clear();
+    const fs::path fromScene = fs::path(scene.basePath) / specPath;
+    if (fs::exists(fromScene, ec) && !ec)
+      return fromScene.string();
+  }
+
+  ec.clear();
+  const fs::path fromCwd = fs::current_path(ec) / specPath;
+  if (!ec && fs::exists(fromCwd, ec) && !ec)
+    return fromCwd.string();
+
+  return {};
+}
+
+std::string ResolveLibraryGdtfPath(const Fixture &fixture) {
   const fs::path specPath = fs::path(fixture.gdtfSpec);
   const std::string specFileName = specPath.filename().string();
+  if (specFileName.empty())
+    return {};
 
   std::error_code ec;
   const fs::path fixturesLibrary =
       fs::path(ProjectUtils::GetDefaultLibraryPath("fixtures"));
-
-  if (!specFileName.empty()) {
-    const fs::path preferredPath = fixturesLibrary / specFileName;
-    if (fs::exists(preferredPath, ec) && !ec)
-      return preferredPath.string();
-  }
-
-  if (specPath.is_absolute() && fs::exists(specPath, ec) && !ec)
-    return specPath.string();
+  const fs::path preferredPath = fixturesLibrary / specFileName;
+  if (fs::exists(preferredPath, ec) && !ec)
+    return preferredPath.string();
 
   auto dictOpt = GdtfDictionary::Load();
   if (!dictOpt)
-    return {};
+    return preferredPath.string();
 
   const auto &dict = *dictOpt;
   auto findByKey = [&](const std::string &key) -> std::string {
@@ -87,23 +108,21 @@ std::string ResolveGdtfPath(const Fixture &fixture) {
   if (std::string byType = findByKey(fixture.typeName); !byType.empty())
     return byType;
 
-  if (!specFileName.empty()) {
-    for (const auto &[type, entry] : dict) {
-      (void)type;
-      if (entry.path.empty())
-        continue;
+  for (const auto &[type, entry] : dict) {
+    (void)type;
+    if (entry.path.empty())
+      continue;
 
-      const fs::path entryPath = fs::path(entry.path);
-      if (entryPath.filename() != specFileName)
-        continue;
+    const fs::path entryPath = fs::path(entry.path);
+    if (entryPath.filename() != specFileName)
+      continue;
 
-      std::error_code localEc;
-      if (fs::exists(entryPath, localEc) && !localEc)
-        return entryPath.string();
-    }
+    std::error_code localEc;
+    if (fs::exists(entryPath, localEc) && !localEc)
+      return entryPath.string();
   }
 
-  return {};
+  return preferredPath.string();
 }
 
 const symbols::Symbol2D *FindSymbol(const std::vector<symbols::Symbol2D> &symbols,
@@ -337,9 +356,20 @@ bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
     return false;
   }
 
-  const std::string gdtfPath = ResolveGdtfPath(fixtureIt->second);
-  if (gdtfPath.empty()) {
-    errorMessage = "Could not resolve fixture GDTF path in fixtures library.";
+  const MvrScene &scene = cfg.GetScene();
+  std::vector<fs::path> targetPaths;
+  std::unordered_set<std::string> uniqueTargets;
+
+  const std::string scenePath = ResolveSceneGdtfPath(fixtureIt->second, scene);
+  if (!scenePath.empty() && uniqueTargets.insert(scenePath).second)
+    targetPaths.emplace_back(scenePath);
+
+  const std::string libraryPath = ResolveLibraryGdtfPath(fixtureIt->second);
+  if (!libraryPath.empty() && uniqueTargets.insert(libraryPath).second)
+    targetPaths.emplace_back(libraryPath);
+
+  if (targetPaths.empty()) {
+    errorMessage = "Could not resolve fixture GDTF path in scene or fixtures library.";
     return false;
   }
 
@@ -377,7 +407,12 @@ bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
     return false;
   }
 
-  return RewriteGdtf(fs::path(gdtfPath), payloads, errorMessage);
+  for (const auto &targetPath : targetPaths) {
+    if (!RewriteGdtf(targetPath, payloads, errorMessage))
+      return false;
+  }
+
+  return true;
 }
 
 } // namespace symbol_preview

--- a/gui/windows/symbol_fixture_applier.cpp
+++ b/gui/windows/symbol_fixture_applier.cpp
@@ -43,14 +43,46 @@ bool ReadAllBytes(wxZipInputStream &zip, std::string &out) {
 }
 
 std::string ResolveGdtfPath(const Fixture &fixture) {
-  if (fixture.typeName.empty())
+  auto dictOpt = GdtfDictionary::Load();
+  if (!dictOpt)
     return {};
 
-  const auto dictEntry = GdtfDictionary::Get(fixture.typeName);
-  if (!dictEntry || dictEntry->path.empty())
-    return {};
+  const auto &dict = *dictOpt;
+  auto findByKey = [&](const std::string &key) -> std::string {
+    if (key.empty())
+      return {};
+    auto it = dict.find(key);
+    if (it == dict.end() || it->second.path.empty())
+      return {};
+    std::error_code ec;
+    if (!fs::exists(it->second.path, ec) || ec)
+      return {};
+    return it->second.path;
+  };
 
-  return dictEntry->path;
+  if (std::string byType = findByKey(fixture.typeName); !byType.empty())
+    return byType;
+
+  const fs::path specPath = fs::path(fixture.gdtfSpec);
+  const std::string specFileName = specPath.filename().string();
+
+  if (!specFileName.empty()) {
+    for (const auto &[type, entry] : dict) {
+      (void)type;
+      if (entry.path.empty())
+        continue;
+
+      const fs::path entryPath = fs::path(entry.path);
+      if (entryPath.filename() != specFileName)
+        continue;
+
+      std::error_code ec;
+      if (fs::exists(entryPath, ec) && !ec)
+        return entryPath.string();
+    }
+  }
+
+  return {};
 }
 
 const symbols::Symbol2D *FindSymbol(const std::vector<symbols::Symbol2D> &symbols,
@@ -196,21 +228,23 @@ bool RewriteGdtf(const fs::path &sourcePath,
   }
 
   const fs::path tempPath = sourcePath.string() + ".tmp";
-  wxFileOutputStream output(tempPath.string());
-  if (!output.IsOk()) {
-    errorMessage = "Could not open temporary GDTF file for writing.";
-    return false;
-  }
+  {
+    wxFileOutputStream output(tempPath.string());
+    if (!output.IsOk()) {
+      errorMessage = "Could not open temporary GDTF file for writing.";
+      return false;
+    }
 
-  wxZipOutputStream zipOutput(output);
-  for (const auto &[name, content] : entries) {
-    auto *zipEntry = new wxZipEntry(name);
-    zipEntry->SetMethod(wxZIP_METHOD_DEFLATE);
-    zipOutput.PutNextEntry(zipEntry);
-    zipOutput.Write(content.data(), content.size());
-    zipOutput.CloseEntry();
+    wxZipOutputStream zipOutput(output);
+    for (const auto &[name, content] : entries) {
+      auto *zipEntry = new wxZipEntry(name);
+      zipEntry->SetMethod(wxZIP_METHOD_DEFLATE);
+      zipOutput.PutNextEntry(zipEntry);
+      zipOutput.Write(content.data(), content.size());
+      zipOutput.CloseEntry();
+    }
+    zipOutput.Close();
   }
-  zipOutput.Close();
 
   std::error_code ec;
   fs::rename(tempPath, sourcePath, ec);
@@ -239,16 +273,16 @@ bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
   }
 
   ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
-  MvrScene &scene = cfg.GetScene();
-  auto fixtureIt = scene.fixtures.find(fixtureUuid);
-  if (fixtureIt == scene.fixtures.end()) {
+  const auto &fixtures = cfg.GetScene().fixtures;
+  auto fixtureIt = fixtures.find(fixtureUuid);
+  if (fixtureIt == fixtures.end()) {
     errorMessage = "Could not resolve the selected fixture in the scene.";
     return false;
   }
 
   const std::string gdtfPath = ResolveGdtfPath(fixtureIt->second);
   if (gdtfPath.empty()) {
-    errorMessage = "Could not resolve the fixture GDTF file path. Only fixtures present in the GDTF dictionary can be updated.";
+    errorMessage = "Could not resolve fixture GDTF in dictionary (by type or file name).";
     return false;
   }
 

--- a/gui/windows/symbol_fixture_applier.cpp
+++ b/gui/windows/symbol_fixture_applier.cpp
@@ -2,7 +2,6 @@
 
 #include <filesystem>
 #include <memory>
-#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -42,24 +41,24 @@ bool ReadAllBytes(wxZipInputStream &zip, std::string &out) {
   return true;
 }
 
-std::string ResolveGdtfPath(const Fixture &fixture, const Scene &scene) {
+std::string ResolveGdtfPath(const Fixture &fixture, const MvrScene &scene) {
   if (fixture.gdtfSpec.empty())
     return {};
 
-  const fs::path specPath = fs::u8path(fixture.gdtfSpec);
+  const fs::path specPath = fs::path(fixture.gdtfSpec);
   std::error_code ec;
   if (specPath.is_absolute() && fs::exists(specPath, ec) && !ec)
     return specPath.string();
 
   if (!scene.basePath.empty()) {
-    fs::path localPath = fs::u8path(scene.basePath) / specPath;
+    fs::path localPath = fs::path(scene.basePath) / specPath;
     ec.clear();
     if (fs::exists(localPath, ec) && !ec)
       return localPath.string();
   }
 
   fs::path libraryPath =
-      fs::u8path(ProjectUtils::GetDefaultLibraryPath("fixtures")) / specPath.filename();
+      fs::path(ProjectUtils::GetDefaultLibraryPath("fixtures")) / specPath.filename();
   ec.clear();
   if (fs::exists(libraryPath, ec) && !ec)
     return libraryPath.string();
@@ -241,7 +240,7 @@ bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
   }
 
   ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
-  Scene &scene = cfg.GetScene();
+  MvrScene &scene = cfg.GetScene();
   auto fixtureIt = scene.fixtures.find(fixtureUuid);
   if (fixtureIt == scene.fixtures.end()) {
     errorMessage = "Could not resolve the selected fixture in the scene.";
@@ -281,7 +280,7 @@ bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
     return false;
   }
 
-  return RewriteGdtf(fs::u8path(gdtfPath), payloads, errorMessage);
+  return RewriteGdtf(fs::path(gdtfPath), payloads, errorMessage);
 }
 
 } // namespace symbol_preview

--- a/gui/windows/symbol_fixture_applier.cpp
+++ b/gui/windows/symbol_fixture_applier.cpp
@@ -1,6 +1,7 @@
 #include "windows/symbol_fixture_applier.h"
 
 #include <algorithm>
+#include <cctype>
 #include <filesystem>
 #include <memory>
 #include <string>
@@ -36,6 +37,17 @@ std::string NormalizeArchivePath(std::string value) {
   while (!value.empty() && value.front() == '/')
     value.erase(value.begin());
   return value;
+}
+
+
+std::string CanonicalFileKey(const std::string &value) {
+  std::string out;
+  out.reserve(value.size());
+  for (unsigned char c : value) {
+    if (std::isalnum(c) != 0)
+      out.push_back(static_cast<char>(std::tolower(c)));
+  }
+  return out;
 }
 
 bool ReadAllBytes(wxZipInputStream &zip, std::string &out) {
@@ -78,51 +90,73 @@ std::string ResolveSceneGdtfPath(const Fixture &fixture, const MvrScene &scene) 
 std::string ResolveLibraryGdtfPath(const Fixture &fixture) {
   const fs::path specPath = fs::path(fixture.gdtfSpec);
   const std::string specFileName = specPath.filename().string();
-  if (specFileName.empty())
-    return {};
 
   std::error_code ec;
   const fs::path fixturesLibrary =
       fs::path(ProjectUtils::GetDefaultLibraryPath("fixtures"));
-  const fs::path preferredPath = fixturesLibrary / specFileName;
-  if (fs::exists(preferredPath, ec) && !ec)
-    return preferredPath.string();
 
   auto dictOpt = GdtfDictionary::Load();
-  if (!dictOpt)
-    return preferredPath.string();
+  if (dictOpt) {
+    const auto &dict = *dictOpt;
+    auto findByKey = [&](const std::string &key) -> std::string {
+      if (key.empty())
+        return {};
+      auto it = dict.find(key);
+      if (it == dict.end() || it->second.path.empty())
+        return {};
+      std::error_code localEc;
+      if (!fs::exists(it->second.path, localEc) || localEc)
+        return {};
+      return it->second.path;
+    };
 
-  const auto &dict = *dictOpt;
-  auto findByKey = [&](const std::string &key) -> std::string {
-    if (key.empty())
-      return {};
-    auto it = dict.find(key);
-    if (it == dict.end() || it->second.path.empty())
-      return {};
-    std::error_code localEc;
-    if (!fs::exists(it->second.path, localEc) || localEc)
-      return {};
-    return it->second.path;
-  };
+    if (std::string byType = findByKey(fixture.typeName); !byType.empty())
+      return byType;
 
-  if (std::string byType = findByKey(fixture.typeName); !byType.empty())
-    return byType;
+    if (!specFileName.empty()) {
+      for (const auto &[type, entry] : dict) {
+        (void)type;
+        if (entry.path.empty())
+          continue;
 
-  for (const auto &[type, entry] : dict) {
-    (void)type;
-    if (entry.path.empty())
-      continue;
+        const fs::path entryPath = fs::path(entry.path);
+        if (entryPath.filename() != specFileName)
+          continue;
 
-    const fs::path entryPath = fs::path(entry.path);
-    if (entryPath.filename() != specFileName)
-      continue;
-
-    std::error_code localEc;
-    if (fs::exists(entryPath, localEc) && !localEc)
-      return entryPath.string();
+        std::error_code localEc;
+        if (fs::exists(entryPath, localEc) && !localEc)
+          return entryPath.string();
+      }
+    }
   }
 
-  return preferredPath.string();
+  if (!specFileName.empty()) {
+    ec.clear();
+    const fs::path exactPath = fixturesLibrary / specFileName;
+    if (fs::exists(exactPath, ec) && !ec)
+      return exactPath.string();
+
+    const std::string wantedKey = CanonicalFileKey(fs::path(specFileName).stem().string());
+    if (!wantedKey.empty()) {
+      for (fs::directory_iterator it(fixturesLibrary, ec), end; !ec && it != end;
+           it.increment(ec)) {
+        if (ec)
+          break;
+        if (!it->is_regular_file(ec) || ec)
+          continue;
+
+        const fs::path candidate = it->path();
+        if (candidate.extension() != ".gdtf")
+          continue;
+
+        const std::string candidateKey = CanonicalFileKey(candidate.stem().string());
+        if (candidateKey == wantedKey)
+          return candidate.string();
+      }
+    }
+  }
+
+  return {};
 }
 
 const symbols::Symbol2D *FindSymbol(const std::vector<symbols::Symbol2D> &symbols,

--- a/gui/windows/symbol_fixture_applier.cpp
+++ b/gui/windows/symbol_fixture_applier.cpp
@@ -44,6 +44,22 @@ bool ReadAllBytes(wxZipInputStream &zip, std::string &out) {
 }
 
 std::string ResolveGdtfPath(const Fixture &fixture) {
+  const fs::path specPath = fs::path(fixture.gdtfSpec);
+  const std::string specFileName = specPath.filename().string();
+
+  std::error_code ec;
+  const fs::path fixturesLibrary =
+      fs::path(ProjectUtils::GetDefaultLibraryPath("fixtures"));
+
+  if (!specFileName.empty()) {
+    const fs::path preferredPath = fixturesLibrary / specFileName;
+    if (fs::exists(preferredPath, ec) && !ec)
+      return preferredPath.string();
+  }
+
+  if (specPath.is_absolute() && fs::exists(specPath, ec) && !ec)
+    return specPath.string();
+
   auto dictOpt = GdtfDictionary::Load();
   if (!dictOpt)
     return {};
@@ -55,17 +71,14 @@ std::string ResolveGdtfPath(const Fixture &fixture) {
     auto it = dict.find(key);
     if (it == dict.end() || it->second.path.empty())
       return {};
-    std::error_code ec;
-    if (!fs::exists(it->second.path, ec) || ec)
+    std::error_code localEc;
+    if (!fs::exists(it->second.path, localEc) || localEc)
       return {};
     return it->second.path;
   };
 
   if (std::string byType = findByKey(fixture.typeName); !byType.empty())
     return byType;
-
-  const fs::path specPath = fs::path(fixture.gdtfSpec);
-  const std::string specFileName = specPath.filename().string();
 
   if (!specFileName.empty()) {
     for (const auto &[type, entry] : dict) {
@@ -77,24 +90,10 @@ std::string ResolveGdtfPath(const Fixture &fixture) {
       if (entryPath.filename() != specFileName)
         continue;
 
-      std::error_code ec;
-      if (fs::exists(entryPath, ec) && !ec)
+      std::error_code localEc;
+      if (fs::exists(entryPath, localEc) && !localEc)
         return entryPath.string();
     }
-  }
-
-  std::error_code ec;
-  const fs::path fixturesLibrary =
-      fs::path(ProjectUtils::GetDefaultLibraryPath("fixtures"));
-
-  if (specPath.is_absolute() && fs::exists(specPath, ec) && !ec)
-    return specPath.string();
-
-  if (!specFileName.empty()) {
-    ec.clear();
-    const fs::path fromLibrary = fixturesLibrary / specFileName;
-    if (fs::exists(fromLibrary, ec) && !ec)
-      return fromLibrary.string();
   }
 
   return {};
@@ -191,6 +190,35 @@ bool PatchDescriptionXml(const std::string &xml,
   return true;
 }
 
+bool VerifyArchiveEntries(const fs::path &archivePath,
+                        const std::unordered_map<std::string, SymbolPayload> &payloads) {
+  wxFileInputStream input(archivePath.string());
+  if (!input.IsOk())
+    return false;
+
+  wxZipInputStream zipInput(input);
+  std::unordered_map<std::string, bool> found;
+  for (const auto &[path, payload] : payloads) {
+    (void)payload;
+    found[path] = false;
+  }
+
+  std::unique_ptr<wxZipEntry> entry;
+  while ((entry.reset(zipInput.GetNextEntry())), entry) {
+    const std::string name = entry->GetName().ToStdString();
+    auto it = found.find(name);
+    if (it != found.end())
+      it->second = true;
+  }
+
+  for (const auto &[path, wasFound] : found) {
+    (void)path;
+    if (!wasFound)
+      return false;
+  }
+  return true;
+}
+
 bool RewriteGdtf(const fs::path &sourcePath,
                  const std::unordered_map<std::string, SymbolPayload> &payloads,
                  std::string &errorMessage) {
@@ -271,6 +299,11 @@ bool RewriteGdtf(const fs::path &sourcePath,
   }
   if (ec) {
     errorMessage = "Could not replace the original GDTF file.";
+    return false;
+  }
+
+  if (!VerifyArchiveEntries(sourcePath, payloads)) {
+    errorMessage = "GDTF was saved but generated SVG views were not found in archive.";
     return false;
   }
 

--- a/gui/windows/symbol_fixture_applier.cpp
+++ b/gui/windows/symbol_fixture_applier.cpp
@@ -1,5 +1,6 @@
 #include "windows/symbol_fixture_applier.h"
 
+#include <algorithm>
 #include <filesystem>
 #include <memory>
 #include <string>
@@ -13,7 +14,7 @@
 
 #include "configmanager.h"
 #include "guiconfigservices.h"
-#include "projectutils.h"
+#include "gdtfdictionary.h"
 #include "windows/symbol_preview_exporter.h"
 
 namespace fs = std::filesystem;
@@ -41,29 +42,15 @@ bool ReadAllBytes(wxZipInputStream &zip, std::string &out) {
   return true;
 }
 
-std::string ResolveGdtfPath(const Fixture &fixture, const MvrScene &scene) {
-  if (fixture.gdtfSpec.empty())
+std::string ResolveGdtfPath(const Fixture &fixture) {
+  if (fixture.typeName.empty())
     return {};
 
-  const fs::path specPath = fs::path(fixture.gdtfSpec);
-  std::error_code ec;
-  if (specPath.is_absolute() && fs::exists(specPath, ec) && !ec)
-    return specPath.string();
+  const auto dictEntry = GdtfDictionary::Get(fixture.typeName);
+  if (!dictEntry || dictEntry->path.empty())
+    return {};
 
-  if (!scene.basePath.empty()) {
-    fs::path localPath = fs::path(scene.basePath) / specPath;
-    ec.clear();
-    if (fs::exists(localPath, ec) && !ec)
-      return localPath.string();
-  }
-
-  fs::path libraryPath =
-      fs::path(ProjectUtils::GetDefaultLibraryPath("fixtures")) / specPath.filename();
-  ec.clear();
-  if (fs::exists(libraryPath, ec) && !ec)
-    return libraryPath.string();
-
-  return {};
+  return dictEntry->path;
 }
 
 const symbols::Symbol2D *FindSymbol(const std::vector<symbols::Symbol2D> &symbols,
@@ -160,27 +147,31 @@ bool PatchDescriptionXml(const std::string &xml,
 bool RewriteGdtf(const fs::path &sourcePath,
                  const std::unordered_map<std::string, SymbolPayload> &payloads,
                  std::string &errorMessage) {
-  wxFileInputStream input(sourcePath.string());
-  if (!input.IsOk()) {
-    errorMessage = "Could not open fixture GDTF file for reading.";
-    return false;
+  std::vector<std::pair<std::string, std::string>> entries;
+  {
+    wxFileInputStream input(sourcePath.string());
+    if (!input.IsOk()) {
+      errorMessage = "Could not open fixture GDTF file for reading.";
+      return false;
+    }
+
+    wxZipInputStream zipInput(input);
+    std::unique_ptr<wxZipEntry> entry;
+    while ((entry.reset(zipInput.GetNextEntry())), entry) {
+      const std::string name = entry->GetName().ToStdString();
+      if (entry->IsDir())
+        continue;
+
+      std::string content;
+      ReadAllBytes(zipInput, content);
+      entries.emplace_back(name, std::move(content));
+    }
   }
 
-  wxZipInputStream zipInput(input);
-  std::unordered_map<std::string, std::string> entries;
-
-  std::unique_ptr<wxZipEntry> entry;
-  while ((entry.reset(zipInput.GetNextEntry())), entry) {
-    const std::string name = entry->GetName().ToStdString();
-    if (entry->IsDir())
-      continue;
-
-    std::string content;
-    ReadAllBytes(zipInput, content);
-    entries[name] = std::move(content);
-  }
-
-  auto descriptionIt = entries.find("description.xml");
+  auto descriptionIt = std::find_if(entries.begin(), entries.end(),
+                                    [](const auto &entry) {
+                                      return entry.first == "description.xml";
+                                    });
   if (descriptionIt == entries.end()) {
     errorMessage = "The GDTF file does not contain description.xml.";
     return false;
@@ -192,9 +183,17 @@ bool RewriteGdtf(const fs::path &sourcePath,
     return false;
   }
 
-  entries["description.xml"] = std::move(updatedDescription);
-  for (const auto &[path, payload] : payloads)
-    entries[path] = payload.svg;
+  descriptionIt->second = std::move(updatedDescription);
+  for (const auto &[path, payload] : payloads) {
+    auto existing = std::find_if(entries.begin(), entries.end(),
+                                 [&](const auto &entry) {
+                                   return entry.first == path;
+                                 });
+    if (existing != entries.end())
+      existing->second = payload.svg;
+    else
+      entries.emplace_back(path, payload.svg);
+  }
 
   const fs::path tempPath = sourcePath.string() + ".tmp";
   wxFileOutputStream output(tempPath.string());
@@ -247,9 +246,9 @@ bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
     return false;
   }
 
-  const std::string gdtfPath = ResolveGdtfPath(fixtureIt->second, scene);
+  const std::string gdtfPath = ResolveGdtfPath(fixtureIt->second);
   if (gdtfPath.empty()) {
-    errorMessage = "Could not resolve the fixture GDTF file path.";
+    errorMessage = "Could not resolve the fixture GDTF file path. Only fixtures present in the GDTF dictionary can be updated.";
     return false;
   }
 
@@ -274,9 +273,16 @@ bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
     payloads[frontPayload.archivePath] = std::move(frontPayload);
   }
 
+  SymbolPayload bottomPayload;
+  if (BuildSymbolPayload(symbols, symbols::SymbolView::Bottom,
+                         "models/svg/bottom.svg", bottomPayload,
+                         errorMessage)) {
+    payloads[bottomPayload.archivePath] = std::move(bottomPayload);
+  }
+
   if (payloads.empty()) {
     errorMessage =
-        "No valid Top, Left, or Front symbol was available to apply to the fixture.";
+        "No valid symbol views were available to apply to the fixture.";
     return false;
   }
 

--- a/gui/windows/symbol_fixture_applier.cpp
+++ b/gui/windows/symbol_fixture_applier.cpp
@@ -129,6 +129,86 @@ std::string ResolveLibraryGdtfPath(const Fixture &fixture) {
   return {};
 }
 
+
+std::string ResolveModelSvgBasename(const fs::path &gdtfPath,
+                                    std::string &errorMessage) {
+  wxFileInputStream input(gdtfPath.string());
+  if (!input.IsOk()) {
+    errorMessage = "Could not open fixture GDTF file for reading.";
+    return {};
+  }
+
+  wxZipInputStream zipInput(input);
+  std::unique_ptr<wxZipEntry> entry;
+  std::string descriptionXml;
+  while ((entry.reset(zipInput.GetNextEntry())), entry) {
+    if (entry->IsDir())
+      continue;
+    if (NormalizeArchivePath(entry->GetName().ToStdString()) != "description.xml")
+      continue;
+    if (!ReadAllBytes(zipInput, descriptionXml)) {
+      errorMessage = "Could not read description.xml from the GDTF file.";
+      return {};
+    }
+    break;
+  }
+
+  if (descriptionXml.empty()) {
+    errorMessage = "The GDTF file does not contain description.xml.";
+    return {};
+  }
+
+  tinyxml2::XMLDocument doc;
+  if (doc.Parse(descriptionXml.c_str(), descriptionXml.size()) !=
+      tinyxml2::XML_SUCCESS) {
+    errorMessage = "Could not parse description.xml from the GDTF file.";
+    return {};
+  }
+
+  tinyxml2::XMLElement *fixtureType = doc.FirstChildElement("GDTF");
+  if (fixtureType)
+    fixtureType = fixtureType->FirstChildElement("FixtureType");
+  if (!fixtureType)
+    fixtureType = doc.FirstChildElement("FixtureType");
+  if (!fixtureType) {
+    errorMessage = "Could not find FixtureType node in description.xml.";
+    return {};
+  }
+
+  tinyxml2::XMLElement *models = fixtureType->FirstChildElement("Models");
+  if (!models) {
+    errorMessage = "Could not find Models node in description.xml.";
+    return {};
+  }
+
+  tinyxml2::XMLElement *targetModel = nullptr;
+  for (tinyxml2::XMLElement *model = models->FirstChildElement("Model"); model;
+       model = model->NextSiblingElement("Model")) {
+    const char *name = model->Attribute("Name");
+    if (name && std::string(name) == "Main") {
+      targetModel = model;
+      break;
+    }
+    if (!targetModel)
+      targetModel = model;
+  }
+
+  if (!targetModel) {
+    errorMessage = "Could not find any Model node in description.xml.";
+    return {};
+  }
+
+  const char *fileAttr = targetModel->Attribute("File");
+  if (fileAttr && std::string(fileAttr).size() > 0)
+    return std::string(fileAttr);
+
+  const char *nameAttr = targetModel->Attribute("Name");
+  if (nameAttr && std::string(nameAttr).size() > 0)
+    return std::string(nameAttr);
+
+  return "main";
+}
+
 const symbols::Symbol2D *FindSymbol(const std::vector<symbols::Symbol2D> &symbols,
                                     symbols::SymbolView view) {
   for (const auto &symbol : symbols) {
@@ -158,6 +238,9 @@ bool BuildSymbolPayload(const std::vector<symbols::Symbol2D> &symbols,
 
 bool PatchDescriptionXml(const std::string &xml,
                          const std::unordered_map<std::string, SymbolPayload> &payloads,
+                         const std::string &topPath,
+                         const std::string &sidePath,
+                         const std::string &frontPath,
                          std::string &updatedXml,
                          std::string &errorMessage) {
   tinyxml2::XMLDocument doc;
@@ -210,9 +293,9 @@ bool PatchDescriptionXml(const std::string &xml,
     targetModel->SetAttribute(yAttr, it->second.offsetY);
   };
 
-  setOffsets("models/svg/main.svg", "SVGOffsetX", "SVGOffsetY");
-  setOffsets("models/svg_side/main.svg", "SVGSideOffsetX", "SVGSideOffsetY");
-  setOffsets("models/svg_front/main.svg", "SVGFrontOffsetX", "SVGFrontOffsetY");
+  setOffsets(topPath.c_str(), "SVGOffsetX", "SVGOffsetY");
+  setOffsets(sidePath.c_str(), "SVGSideOffsetX", "SVGSideOffsetY");
+  setOffsets(frontPath.c_str(), "SVGFrontOffsetX", "SVGFrontOffsetY");
 
   tinyxml2::XMLPrinter printer;
   doc.Print(&printer);
@@ -251,6 +334,9 @@ bool VerifyArchiveEntries(const fs::path &archivePath,
 
 bool RewriteGdtf(const fs::path &sourcePath,
                  const std::unordered_map<std::string, SymbolPayload> &payloads,
+                 const std::string &topPath,
+                 const std::string &sidePath,
+                 const std::string &frontPath,
                  std::string &errorMessage) {
   std::vector<std::pair<std::string, std::string>> entries;
   {
@@ -283,8 +369,8 @@ bool RewriteGdtf(const fs::path &sourcePath,
   }
 
   std::string updatedDescription;
-  if (!PatchDescriptionXml(descriptionIt->second, payloads, updatedDescription,
-                           errorMessage)) {
+  if (!PatchDescriptionXml(descriptionIt->second, payloads, topPath, sidePath,
+                           frontPath, updatedDescription, errorMessage)) {
     return false;
   }
 
@@ -377,31 +463,37 @@ bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
     return false;
   }
 
+  std::string modelSvgBase = ResolveModelSvgBasename(targetPaths.front(), errorMessage);
+  if (modelSvgBase.empty())
+    return false;
+
+  const std::string topSvgPath = "models/svg/" + modelSvgBase + ".svg";
+  const std::string sideSvgPath = "models/svg_side/" + modelSvgBase + ".svg";
+  const std::string frontSvgPath = "models/svg_front/" + modelSvgBase + ".svg";
+  const std::string bottomSvgPath = "models/svg/" + modelSvgBase + "_bottom.svg";
+
   std::unordered_map<std::string, SymbolPayload> payloads;
   SymbolPayload topPayload;
-  if (BuildSymbolPayload(symbols, symbols::SymbolView::Top, "models/svg/main.svg",
+  if (BuildSymbolPayload(symbols, symbols::SymbolView::Top, topSvgPath,
                          topPayload, errorMessage)) {
     payloads[topPayload.archivePath] = std::move(topPayload);
   }
 
   SymbolPayload sidePayload;
-  if (BuildSymbolPayload(symbols, symbols::SymbolView::Left,
-                         "models/svg_side/main.svg", sidePayload,
-                         errorMessage)) {
+  if (BuildSymbolPayload(symbols, symbols::SymbolView::Left, sideSvgPath,
+                         sidePayload, errorMessage)) {
     payloads[sidePayload.archivePath] = std::move(sidePayload);
   }
 
   SymbolPayload frontPayload;
-  if (BuildSymbolPayload(symbols, symbols::SymbolView::Front,
-                         "models/svg_front/main.svg", frontPayload,
-                         errorMessage)) {
+  if (BuildSymbolPayload(symbols, symbols::SymbolView::Front, frontSvgPath,
+                         frontPayload, errorMessage)) {
     payloads[frontPayload.archivePath] = std::move(frontPayload);
   }
 
   SymbolPayload bottomPayload;
-  if (BuildSymbolPayload(symbols, symbols::SymbolView::Bottom,
-                         "models/svg/bottom.svg", bottomPayload,
-                         errorMessage)) {
+  if (BuildSymbolPayload(symbols, symbols::SymbolView::Bottom, bottomSvgPath,
+                         bottomPayload, errorMessage)) {
     payloads[bottomPayload.archivePath] = std::move(bottomPayload);
   }
 
@@ -412,7 +504,8 @@ bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
   }
 
   for (const auto &targetPath : targetPaths) {
-    if (!RewriteGdtf(targetPath, payloads, errorMessage))
+    if (!RewriteGdtf(targetPath, payloads, topSvgPath, sideSvgPath, frontSvgPath,
+                     errorMessage))
       return false;
   }
 

--- a/gui/windows/symbol_fixture_applier.cpp
+++ b/gui/windows/symbol_fixture_applier.cpp
@@ -1,7 +1,6 @@
 #include "windows/symbol_fixture_applier.h"
 
 #include <algorithm>
-#include <cctype>
 #include <filesystem>
 #include <memory>
 #include <string>
@@ -39,16 +38,6 @@ std::string NormalizeArchivePath(std::string value) {
   return value;
 }
 
-
-std::string CanonicalFileKey(const std::string &value) {
-  std::string out;
-  out.reserve(value.size());
-  for (unsigned char c : value) {
-    if (std::isalnum(c) != 0)
-      out.push_back(static_cast<char>(std::tolower(c)));
-  }
-  return out;
-}
 
 bool ReadAllBytes(wxZipInputStream &zip, std::string &out) {
   out.clear();
@@ -135,25 +124,6 @@ std::string ResolveLibraryGdtfPath(const Fixture &fixture) {
     const fs::path exactPath = fixturesLibrary / specFileName;
     if (fs::exists(exactPath, ec) && !ec)
       return exactPath.string();
-
-    const std::string wantedKey = CanonicalFileKey(fs::path(specFileName).stem().string());
-    if (!wantedKey.empty()) {
-      for (fs::directory_iterator it(fixturesLibrary, ec), end; !ec && it != end;
-           it.increment(ec)) {
-        if (ec)
-          break;
-        if (!it->is_regular_file(ec) || ec)
-          continue;
-
-        const fs::path candidate = it->path();
-        if (candidate.extension() != ".gdtf")
-          continue;
-
-        const std::string candidateKey = CanonicalFileKey(candidate.stem().string());
-        if (candidateKey == wantedKey)
-          return candidate.string();
-      }
-    }
   }
 
   return {};

--- a/gui/windows/symbol_fixture_applier.cpp
+++ b/gui/windows/symbol_fixture_applier.cpp
@@ -1,0 +1,287 @@
+#include "windows/symbol_fixture_applier.h"
+
+#include <filesystem>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <tinyxml2.h>
+#include <wx/wfstream.h>
+#include <wx/zipstrm.h>
+
+#include "configmanager.h"
+#include "guiconfigservices.h"
+#include "projectutils.h"
+#include "windows/symbol_preview_exporter.h"
+
+namespace fs = std::filesystem;
+
+namespace symbol_preview {
+namespace {
+
+struct SymbolPayload {
+  std::string archivePath;
+  std::string svg;
+  float offsetX = 0.0f;
+  float offsetY = 0.0f;
+};
+
+bool ReadAllBytes(wxZipInputStream &zip, std::string &out) {
+  out.clear();
+  char buffer[4096];
+  while (true) {
+    zip.Read(buffer, sizeof(buffer));
+    const size_t count = zip.LastRead();
+    if (count == 0)
+      break;
+    out.append(buffer, count);
+  }
+  return true;
+}
+
+std::string ResolveGdtfPath(const Fixture &fixture, const Scene &scene) {
+  if (fixture.gdtfSpec.empty())
+    return {};
+
+  const fs::path specPath = fs::u8path(fixture.gdtfSpec);
+  std::error_code ec;
+  if (specPath.is_absolute() && fs::exists(specPath, ec) && !ec)
+    return specPath.string();
+
+  if (!scene.basePath.empty()) {
+    fs::path localPath = fs::u8path(scene.basePath) / specPath;
+    ec.clear();
+    if (fs::exists(localPath, ec) && !ec)
+      return localPath.string();
+  }
+
+  fs::path libraryPath =
+      fs::u8path(ProjectUtils::GetDefaultLibraryPath("fixtures")) / specPath.filename();
+  ec.clear();
+  if (fs::exists(libraryPath, ec) && !ec)
+    return libraryPath.string();
+
+  return {};
+}
+
+const symbols::Symbol2D *FindSymbol(const std::vector<symbols::Symbol2D> &symbols,
+                                    symbols::SymbolView view) {
+  for (const auto &symbol : symbols) {
+    if (symbol.view == view)
+      return &symbol;
+  }
+  return nullptr;
+}
+
+bool BuildSymbolPayload(const std::vector<symbols::Symbol2D> &symbols,
+                        symbols::SymbolView view,
+                        const std::string &archivePath,
+                        SymbolPayload &out,
+                        std::string &errorMessage) {
+  const symbols::Symbol2D *symbol = FindSymbol(symbols, view);
+  if (!symbol || !symbol->bounds.valid)
+    return false;
+
+  out.archivePath = archivePath;
+  out.offsetX = -symbol->bounds.min.x;
+  out.offsetY = -symbol->bounds.min.y;
+  if (!symbol_preview::ExportSymbolToSvgString(*symbol, out.svg, errorMessage))
+    return false;
+
+  return true;
+}
+
+bool PatchDescriptionXml(const std::string &xml,
+                         const std::unordered_map<std::string, SymbolPayload> &payloads,
+                         std::string &updatedXml,
+                         std::string &errorMessage) {
+  tinyxml2::XMLDocument doc;
+  if (doc.Parse(xml.c_str(), xml.size()) != tinyxml2::XML_SUCCESS) {
+    errorMessage = "Could not parse description.xml from the GDTF file.";
+    return false;
+  }
+
+  tinyxml2::XMLElement *fixtureType = doc.FirstChildElement("GDTF");
+  if (fixtureType)
+    fixtureType = fixtureType->FirstChildElement("FixtureType");
+  if (!fixtureType)
+    fixtureType = doc.FirstChildElement("FixtureType");
+  if (!fixtureType) {
+    errorMessage = "Could not find FixtureType node in description.xml.";
+    return false;
+  }
+
+  fixtureType->SetAttribute("Editor", "Perastage");
+
+  tinyxml2::XMLElement *models = fixtureType->FirstChildElement("Models");
+  if (!models) {
+    errorMessage = "Could not find Models node in description.xml.";
+    return false;
+  }
+
+  tinyxml2::XMLElement *targetModel = nullptr;
+  for (tinyxml2::XMLElement *model = models->FirstChildElement("Model"); model;
+       model = model->NextSiblingElement("Model")) {
+    const char *name = model->Attribute("Name");
+    if (name && std::string(name) == "Main") {
+      targetModel = model;
+      break;
+    }
+    if (!targetModel)
+      targetModel = model;
+  }
+
+  if (!targetModel) {
+    errorMessage = "Could not find any Model node in description.xml.";
+    return false;
+  }
+
+  auto setOffsets = [&](const char *entryPath, const char *xAttr,
+                        const char *yAttr) {
+    auto it = payloads.find(entryPath);
+    if (it == payloads.end())
+      return;
+    targetModel->SetAttribute(xAttr, it->second.offsetX);
+    targetModel->SetAttribute(yAttr, it->second.offsetY);
+  };
+
+  setOffsets("models/svg/main.svg", "SVGOffsetX", "SVGOffsetY");
+  setOffsets("models/svg_side/main.svg", "SVGSideOffsetX", "SVGSideOffsetY");
+  setOffsets("models/svg_front/main.svg", "SVGFrontOffsetX", "SVGFrontOffsetY");
+
+  tinyxml2::XMLPrinter printer;
+  doc.Print(&printer);
+  updatedXml = printer.CStr();
+  return true;
+}
+
+bool RewriteGdtf(const fs::path &sourcePath,
+                 const std::unordered_map<std::string, SymbolPayload> &payloads,
+                 std::string &errorMessage) {
+  wxFileInputStream input(sourcePath.string());
+  if (!input.IsOk()) {
+    errorMessage = "Could not open fixture GDTF file for reading.";
+    return false;
+  }
+
+  wxZipInputStream zipInput(input);
+  std::unordered_map<std::string, std::string> entries;
+
+  std::unique_ptr<wxZipEntry> entry;
+  while ((entry.reset(zipInput.GetNextEntry())), entry) {
+    const std::string name = entry->GetName().ToStdString();
+    if (entry->IsDir())
+      continue;
+
+    std::string content;
+    ReadAllBytes(zipInput, content);
+    entries[name] = std::move(content);
+  }
+
+  auto descriptionIt = entries.find("description.xml");
+  if (descriptionIt == entries.end()) {
+    errorMessage = "The GDTF file does not contain description.xml.";
+    return false;
+  }
+
+  std::string updatedDescription;
+  if (!PatchDescriptionXml(descriptionIt->second, payloads, updatedDescription,
+                           errorMessage)) {
+    return false;
+  }
+
+  entries["description.xml"] = std::move(updatedDescription);
+  for (const auto &[path, payload] : payloads)
+    entries[path] = payload.svg;
+
+  const fs::path tempPath = sourcePath.string() + ".tmp";
+  wxFileOutputStream output(tempPath.string());
+  if (!output.IsOk()) {
+    errorMessage = "Could not open temporary GDTF file for writing.";
+    return false;
+  }
+
+  wxZipOutputStream zipOutput(output);
+  for (const auto &[name, content] : entries) {
+    auto *zipEntry = new wxZipEntry(name);
+    zipEntry->SetMethod(wxZIP_METHOD_DEFLATE);
+    zipOutput.PutNextEntry(zipEntry);
+    zipOutput.Write(content.data(), content.size());
+    zipOutput.CloseEntry();
+  }
+  zipOutput.Close();
+
+  std::error_code ec;
+  fs::rename(tempPath, sourcePath, ec);
+  if (ec) {
+    ec.clear();
+    fs::remove(sourcePath, ec);
+    ec.clear();
+    fs::rename(tempPath, sourcePath, ec);
+  }
+  if (ec) {
+    errorMessage = "Could not replace the original GDTF file.";
+    return false;
+  }
+
+  return true;
+}
+
+} // namespace
+
+bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
+                               const std::string &fixtureUuid,
+                               std::string &errorMessage) {
+  if (fixtureUuid.empty()) {
+    errorMessage = "No fixture was selected for this symbol preview.";
+    return false;
+  }
+
+  ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+  Scene &scene = cfg.GetScene();
+  auto fixtureIt = scene.fixtures.find(fixtureUuid);
+  if (fixtureIt == scene.fixtures.end()) {
+    errorMessage = "Could not resolve the selected fixture in the scene.";
+    return false;
+  }
+
+  const std::string gdtfPath = ResolveGdtfPath(fixtureIt->second, scene);
+  if (gdtfPath.empty()) {
+    errorMessage = "Could not resolve the fixture GDTF file path.";
+    return false;
+  }
+
+  std::unordered_map<std::string, SymbolPayload> payloads;
+  SymbolPayload topPayload;
+  if (BuildSymbolPayload(symbols, symbols::SymbolView::Top, "models/svg/main.svg",
+                         topPayload, errorMessage)) {
+    payloads[topPayload.archivePath] = std::move(topPayload);
+  }
+
+  SymbolPayload sidePayload;
+  if (BuildSymbolPayload(symbols, symbols::SymbolView::Left,
+                         "models/svg_side/main.svg", sidePayload,
+                         errorMessage)) {
+    payloads[sidePayload.archivePath] = std::move(sidePayload);
+  }
+
+  SymbolPayload frontPayload;
+  if (BuildSymbolPayload(symbols, symbols::SymbolView::Front,
+                         "models/svg_front/main.svg", frontPayload,
+                         errorMessage)) {
+    payloads[frontPayload.archivePath] = std::move(frontPayload);
+  }
+
+  if (payloads.empty()) {
+    errorMessage =
+        "No valid Top, Left, or Front symbol was available to apply to the fixture.";
+    return false;
+  }
+
+  return RewriteGdtf(fs::u8path(gdtfPath), payloads, errorMessage);
+}
+
+} // namespace symbol_preview

--- a/gui/windows/symbol_fixture_applier.h
+++ b/gui/windows/symbol_fixture_applier.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "symbols/Symbol2D.h"
+
+namespace symbol_preview {
+
+bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
+                               const std::string &fixtureUuid,
+                               std::string &errorMessage);
+
+} // namespace symbol_preview

--- a/gui/windows/symbol_preview_exporter.cpp
+++ b/gui/windows/symbol_preview_exporter.cpp
@@ -21,11 +21,8 @@ std::string BuildPoints(const symbols::Polyline2D &line,
   return stream.str();
 }
 
-} // namespace
-
-bool ExportSymbolToSvg(const symbols::Symbol2D &symbol,
-                       const std::string &filePath,
-                       std::string &errorMessage) {
+bool BuildSvgContent(const symbols::Symbol2D &symbol, std::string &svgContent,
+                     std::string &errorMessage) {
   if (!symbol.bounds.valid) {
     errorMessage = "The selected view has no drawable symbol.";
     return false;
@@ -38,12 +35,7 @@ bool ExportSymbolToSvg(const symbols::Symbol2D &symbol,
     return false;
   }
 
-  std::ofstream file(filePath);
-  if (!file.is_open()) {
-    errorMessage = "Could not open the output file.";
-    return false;
-  }
-
+  std::ostringstream file;
   file << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
   file << "<svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\" "
           "viewBox=\"0 0 "
@@ -78,8 +70,33 @@ bool ExportSymbolToSvg(const symbols::Symbol2D &symbol,
     return false;
   }
 
+  svgContent = file.str();
   return true;
 }
 
-} // namespace symbol_preview
+} // namespace
 
+bool ExportSymbolToSvg(const symbols::Symbol2D &symbol,
+                       const std::string &filePath,
+                       std::string &errorMessage) {
+  std::string svgContent;
+  if (!BuildSvgContent(symbol, svgContent, errorMessage))
+    return false;
+
+  std::ofstream file(filePath);
+  if (!file.is_open()) {
+    errorMessage = "Could not open the output file.";
+    return false;
+  }
+
+  file << svgContent;
+  return file.good();
+}
+
+bool ExportSymbolToSvgString(const symbols::Symbol2D &symbol,
+                             std::string &svgContent,
+                             std::string &errorMessage) {
+  return BuildSvgContent(symbol, svgContent, errorMessage);
+}
+
+} // namespace symbol_preview

--- a/gui/windows/symbol_preview_exporter.h
+++ b/gui/windows/symbol_preview_exporter.h
@@ -10,5 +10,8 @@ bool ExportSymbolToSvg(const symbols::Symbol2D &symbol,
                        const std::string &filePath,
                        std::string &errorMessage);
 
-} // namespace symbol_preview
+bool ExportSymbolToSvgString(const symbols::Symbol2D &symbol,
+                             std::string &svgContent,
+                             std::string &errorMessage);
 
+} // namespace symbol_preview


### PR DESCRIPTION
### Motivation
- Allow users to persist generated 2D vector symbols into the fixture's GDTF so symbols do not need to be regenerated each session and follow the GDTF spec for SVG placement and offsets.

### Description
- Added a new context-menu action "Apply symbol to fixture…" in `SymbolPreviewWindow` with a new menu ID and a bound handler `OnApplySymbolToFixture` that invokes the applier.
- Propagated fixture context into the preview by extending `SymbolPreviewWindow` constructor to accept and store the selected fixture UUID and updated the symbol generation call site to pass it through.
- Implemented a new module `gui/windows/symbol_fixture_applier.{h,cpp}` that resolves the fixture GDTF path (library/project), builds SVG payloads for Top/Left/Front views (using new in-memory SVG generation), patches `description.xml` (sets `Editor="Perastage"` and `SVGOffsetX/Y` / `SVGSideOffsetX/Y` / `SVGFrontOffsetX/Y` on the primary model), and rewrites the GDTF archive embedding the SVGs into `models/svg`, `models/svg_side` and `models/svg_front` while preserving other entries.
- Exposed an in-memory SVG builder via `ExportSymbolToSvgString` and refactored the existing exporter to reuse the builder so file export behavior is preserved.
- Registered the new applier source in `gui/CMakeLists.txt` and kept UI changes minimal (new action + wiring) to respect module boundaries.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.
- Attempted a local CMake configuration/build (`cmake -S . -B build && cmake --build build -j2`) but the build could not complete in this environment due to a missing system dependency (wxWidgets development package), so compilation was not validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ad9a0e97c83248647b0009b1da587)