### PR TITLE
Add RDP simplifier and apply it as final step for generated fixture symbols

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -5,6 +5,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/credentialstore.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtfdictionary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtfnet.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/geometry/RdpSimplifier.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/guiconfigservices.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layouts/LayoutCollection.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layouts/LayoutManager.cpp
@@ -20,6 +21,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/scenedatamanager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/simplecrypt.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/symbols/Symbol2DImageBuilder.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/symbols/SymbolGeometrySimplifier.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/symbols/Symbol2DBuilder.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/trussdictionary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/truss_gdtf_builder.cpp

--- a/core/geometry/RdpSimplifier.cpp
+++ b/core/geometry/RdpSimplifier.cpp
@@ -1,0 +1,166 @@
+#include "geometry/RdpSimplifier.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <stack>
+
+namespace geometry {
+namespace {
+
+constexpr float kDedupThreshold = 1e-4f;
+
+bool NearEqual(const symbols::Point2D &a, const symbols::Point2D &b,
+               float threshold = kDedupThreshold) {
+  return std::fabs(a.x - b.x) <= threshold && std::fabs(a.y - b.y) <= threshold;
+}
+
+std::vector<symbols::Point2D>
+RemoveConsecutiveDuplicates(const std::vector<symbols::Point2D> &pts) {
+  std::vector<symbols::Point2D> cleaned;
+  cleaned.reserve(pts.size());
+  for (const auto &point : pts) {
+    if (cleaned.empty() || !NearEqual(cleaned.back(), point))
+      cleaned.push_back(point);
+  }
+  return cleaned;
+}
+
+float DistanceSquaredToSegment(const symbols::Point2D &point,
+                               const symbols::Point2D &segmentStart,
+                               const symbols::Point2D &segmentEnd) {
+  const float dx = segmentEnd.x - segmentStart.x;
+  const float dy = segmentEnd.y - segmentStart.y;
+  const float segLenSq = dx * dx + dy * dy;
+  if (segLenSq <= std::numeric_limits<float>::epsilon()) {
+    const float px = point.x - segmentStart.x;
+    const float py = point.y - segmentStart.y;
+    return px * px + py * py;
+  }
+
+  const float t = ((point.x - segmentStart.x) * dx +
+                   (point.y - segmentStart.y) * dy) /
+                  segLenSq;
+  const float clamped = std::clamp(t, 0.0f, 1.0f);
+  const float projX = segmentStart.x + clamped * dx;
+  const float projY = segmentStart.y + clamped * dy;
+  const float diffX = point.x - projX;
+  const float diffY = point.y - projY;
+  return diffX * diffX + diffY * diffY;
+}
+
+std::vector<symbols::Point2D>
+SimplifyOpenPolyline(const std::vector<symbols::Point2D> &pts, float epsilon) {
+  if (pts.size() <= 2)
+    return pts;
+
+  const float epsilonSq = epsilon * epsilon;
+  std::vector<unsigned char> keep(pts.size(), 0);
+  keep.front() = 1;
+  keep.back() = 1;
+
+  std::stack<std::pair<size_t, size_t>> ranges;
+  ranges.push({0, pts.size() - 1});
+
+  while (!ranges.empty()) {
+    const auto [start, end] = ranges.top();
+    ranges.pop();
+    if (end <= start + 1)
+      continue;
+
+    float maxDistanceSq = -1.0f;
+    size_t splitIndex = start;
+    for (size_t i = start + 1; i < end; ++i) {
+      const float distanceSq = DistanceSquaredToSegment(pts[i], pts[start], pts[end]);
+      if (distanceSq > maxDistanceSq) {
+        maxDistanceSq = distanceSq;
+        splitIndex = i;
+      }
+    }
+
+    if (maxDistanceSq > epsilonSq) {
+      keep[splitIndex] = 1;
+      ranges.push({start, splitIndex});
+      ranges.push({splitIndex, end});
+    }
+  }
+
+  std::vector<symbols::Point2D> simplified;
+  simplified.reserve(pts.size());
+  for (size_t i = 0; i < pts.size(); ++i) {
+    if (keep[i])
+      simplified.push_back(pts[i]);
+  }
+
+  if (simplified.size() < 2)
+    return pts;
+  return simplified;
+}
+
+size_t CountUniqueVertices(const std::vector<symbols::Point2D> &pts) {
+  std::vector<symbols::Point2D> uniques;
+  uniques.reserve(pts.size());
+  for (const auto &point : pts) {
+    bool exists = false;
+    for (const auto &u : uniques) {
+      if (NearEqual(u, point)) {
+        exists = true;
+        break;
+      }
+    }
+    if (!exists)
+      uniques.push_back(point);
+  }
+  return uniques.size();
+}
+
+} // namespace
+
+std::vector<symbols::Point2D>
+SimplifyRdpPolyline(const std::vector<symbols::Point2D> &pts, float epsilon) {
+  if (pts.size() <= 2)
+    return pts;
+
+  const auto cleaned = RemoveConsecutiveDuplicates(pts);
+  if (cleaned.size() <= 2)
+    return cleaned;
+
+  return SimplifyOpenPolyline(cleaned, epsilon);
+}
+
+std::vector<symbols::Point2D>
+SimplifyRdpPolygonClosed(const std::vector<symbols::Point2D> &pts, float epsilon) {
+  if (pts.size() < 3)
+    return pts;
+
+  std::vector<symbols::Point2D> ring = RemoveConsecutiveDuplicates(pts);
+  if (ring.size() < 3)
+    return pts;
+
+  const bool inputExplicitlyClosed = NearEqual(ring.front(), ring.back());
+  if (inputExplicitlyClosed)
+    ring.pop_back();
+
+  if (ring.size() < 3)
+    return pts;
+
+  std::vector<symbols::Point2D> duplicated = ring;
+  duplicated.push_back(ring.front());
+  const auto simplifiedOpen = SimplifyOpenPolyline(duplicated, epsilon);
+  if (simplifiedOpen.size() < 2)
+    return pts;
+
+  std::vector<symbols::Point2D> simplified = simplifiedOpen;
+  if (NearEqual(simplified.front(), simplified.back()))
+    simplified.pop_back();
+
+  if (CountUniqueVertices(simplified) < 3)
+    return pts;
+
+  if (inputExplicitlyClosed)
+    simplified.push_back(simplified.front());
+  return simplified;
+}
+
+} // namespace geometry

--- a/core/geometry/RdpSimplifier.h
+++ b/core/geometry/RdpSimplifier.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <vector>
+
+#include "symbols/Symbol2DTypes.h"
+
+namespace geometry {
+
+std::vector<symbols::Point2D>
+SimplifyRdpPolyline(const std::vector<symbols::Point2D> &pts, float epsilon);
+
+std::vector<symbols::Point2D>
+SimplifyRdpPolygonClosed(const std::vector<symbols::Point2D> &pts, float epsilon);
+
+} // namespace geometry

--- a/core/symbols/SymbolGeometrySimplifier.cpp
+++ b/core/symbols/SymbolGeometrySimplifier.cpp
@@ -1,0 +1,86 @@
+#include "symbols/SymbolGeometrySimplifier.h"
+
+#include <cmath>
+#include <cstddef>
+#include <sstream>
+#include <utility>
+
+#include "geometry/RdpSimplifier.h"
+#include "logger.h"
+
+namespace symbols {
+namespace {
+
+
+bool NearEqual(const Point2D &a, const Point2D &b, float threshold = 1e-4f) {
+  return std::fabs(a.x - b.x) <= threshold && std::fabs(a.y - b.y) <= threshold;
+}
+
+size_t CountPolylinePoints(const std::vector<Polyline2D> &polylines) {
+  size_t total = 0;
+  for (const auto &polyline : polylines)
+    total += polyline.size();
+  return total;
+}
+
+size_t CountPolygonPoints(const std::vector<PolygonWithHoles2D> &polygons) {
+  size_t total = 0;
+  for (const auto &polygon : polygons) {
+    total += polygon.outer.size();
+    for (const auto &hole : polygon.holes)
+      total += hole.size();
+  }
+  return total;
+}
+
+void SimplifyPolygonRing(Polyline2D &ring, float epsilon) {
+  const auto original = ring;
+  Polyline2D simplified = geometry::SimplifyRdpPolygonClosed(ring, epsilon);
+
+  const bool hasClosure =
+      simplified.size() >= 2 && NearEqual(simplified.front(), simplified.back());
+  const size_t uniqueVertices = hasClosure ? simplified.size() - 1 : simplified.size();
+  if (uniqueVertices < 3) {
+    ring = original;
+    return;
+  }
+
+  ring = std::move(simplified);
+}
+
+} // namespace
+
+void SimplifySymbolGeometry(Symbol2D &symbol, float epsilon) {
+  const size_t beforePoints = CountPolylinePoints(symbol.strokes) +
+                              CountPolygonPoints(symbol.fill);
+
+  for (auto &polyline : symbol.strokes) {
+    if (polyline.size() <= 2)
+      continue;
+    polyline = geometry::SimplifyRdpPolyline(polyline, epsilon);
+  }
+
+  for (auto &polygon : symbol.fill) {
+    SimplifyPolygonRing(polygon.outer, epsilon);
+    for (auto &hole : polygon.holes)
+      SimplifyPolygonRing(hole, epsilon);
+  }
+
+  const size_t afterPoints = CountPolylinePoints(symbol.strokes) +
+                             CountPolygonPoints(symbol.fill);
+
+  if (beforePoints == 0)
+    return;
+
+  const double reduction =
+      (1.0 - static_cast<double>(afterPoints) / static_cast<double>(beforePoints)) *
+      100.0;
+
+  std::ostringstream oss;
+  oss << "Symbol RDP simplification view=" << static_cast<int>(symbol.view)
+      << " points " << beforePoints << " -> " << afterPoints
+      << " (" << reduction << "%)";
+  Logger::Instance().Log(Logger::Level::Debug, oss.str());
+}
+
+} // namespace symbols

--- a/core/symbols/SymbolGeometrySimplifier.h
+++ b/core/symbols/SymbolGeometrySimplifier.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "Symbol2D.h"
+
+namespace symbols {
+
+void SimplifySymbolGeometry(Symbol2D &symbol, float epsilon);
+
+} // namespace symbols

--- a/gui/tools/scene_model_symbol_capture_service.cpp
+++ b/gui/tools/scene_model_symbol_capture_service.cpp
@@ -11,12 +11,15 @@
 #include "sceneobject.h"
 #include "support.h"
 #include "symbols/Symbol2DImageBuilder.h"
+#include "symbols/SymbolGeometrySimplifier.h"
 #include "truss.h"
 #include "viewer2doffscreenrenderer.h"
 #include "viewer2dpanel.h"
 
 namespace tools {
 namespace {
+
+constexpr float kSymbolRdpEpsilon = 1.0f;
 
 class ScopedFloatConfigOverride {
 public:
@@ -257,6 +260,9 @@ CaptureSceneModelOrthographicSymbols(Viewer2DOffscreenRenderer &renderer,
     result.error = "Could not generate all symbols from captured views.";
     return result;
   }
+
+  for (auto &symbol : symbols)
+    symbols::SimplifySymbolGeometry(symbol, kSymbolRdpEpsilon);
 
   result.ok = true;
   result.symbols = std::move(symbols);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,12 @@ add_executable(matrixutils_test matrixutils_test.cpp)
 target_include_directories(matrixutils_test PRIVATE ../models)
 add_test(NAME MatrixUtilsParsingAndComposition COMMAND matrixutils_test)
 
+add_executable(rdp_simplifier_test
+               rdp_simplifier_test.cpp
+               ../core/geometry/RdpSimplifier.cpp)
+target_include_directories(rdp_simplifier_test PRIVATE ../core)
+add_test(NAME RdpSimplifierGeometry COMMAND rdp_simplifier_test)
+
 add_executable(pdf_font_metrics_test
                pdf_font_metrics_test.cpp
                ../viewer2d/pdf/font_metrics.cpp)

--- a/tests/rdp_simplifier_test.cpp
+++ b/tests/rdp_simplifier_test.cpp
@@ -1,0 +1,61 @@
+#include "geometry/RdpSimplifier.h"
+
+#include <cmath>
+#include <iostream>
+
+namespace {
+
+bool Near(float a, float b, float eps = 1e-4f) { return std::fabs(a - b) <= eps; }
+
+symbols::Point2D Pt(float x, float y) { return symbols::Point2D{x, y}; }
+
+} // namespace
+
+int main() {
+  {
+    std::vector<symbols::Point2D> polyline;
+    for (int i = 0; i <= 20; ++i)
+      polyline.push_back(Pt(static_cast<float>(i), 0.05f * std::sin(i * 0.2f)));
+
+    auto simplified = geometry::SimplifyRdpPolyline(polyline, 1.0f);
+    if (simplified.size() != 2) {
+      std::cerr << "Polyline simplification did not collapse to endpoints\n";
+      return 1;
+    }
+    if (!Near(simplified.front().x, 0.0f) || !Near(simplified.back().x, 20.0f)) {
+      std::cerr << "Polyline simplification changed endpoints\n";
+      return 1;
+    }
+  }
+
+  {
+    std::vector<symbols::Point2D> rectangle = {
+        Pt(0, 0), Pt(5, 0), Pt(10, 0), Pt(10, 4), Pt(10, 8), Pt(5, 8),
+        Pt(0, 8), Pt(0, 4), Pt(0, 0),
+    };
+
+    auto simplified = geometry::SimplifyRdpPolygonClosed(rectangle, 1.0f);
+    if (simplified.size() != 5) {
+      std::cerr << "Rectangle simplification should keep 4 corners and closure\n";
+      return 1;
+    }
+    if (!Near(simplified.front().x, simplified.back().x) ||
+        !Near(simplified.front().y, simplified.back().y)) {
+      std::cerr << "Rectangle output is not closed\n";
+      return 1;
+    }
+  }
+
+  {
+    std::vector<symbols::Point2D> tinyTriangle = {
+        Pt(0.0f, 0.0f), Pt(0.1f, 0.0f), Pt(0.0f, 0.1f), Pt(0.0f, 0.0f)};
+
+    auto simplified = geometry::SimplifyRdpPolygonClosed(tinyTriangle, 1.0f);
+    if (simplified.size() != tinyTriangle.size()) {
+      std::cerr << "Tiny polygon should keep original geometry\n";
+      return 1;
+    }
+  }
+
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- Reduce SVG/PDF size and vertex counts by simplifying generated vector symbol geometry (polylines and polygon outlines) while keeping visual fidelity at a tolerance of `1.0` symbol units.
- Ensure simplification is applied as the last transformation before preview and serialization so both UI preview and GDTF/SVG embedding benefit from the reduced geometry.

### Description
- Added a GUI-agnostic Ramer–Douglas–Peucker module `core/geometry/RdpSimplifier.{h,cpp}` implementing iterative (stack-based) RDP with squared-distance math and a small de-duplication threshold (`1e-4`).
- Added a symbol-level pass `symbols::SimplifySymbolGeometry(Symbol2D&, float)` in `core/symbols/SymbolGeometrySimplifier.{h,cpp}` that simplifies `strokes` and `fill` rings, preserves polygon closure, and falls back to the original geometry if simplification would produce fewer than 3 unique vertices for a polygon.
- Integrated the pass into the capture pipeline in `gui/tools/scene_model_symbol_capture_service.cpp` as the final step using a single tunable constant `kSymbolRdpEpsilon = 1.0f` so both preview and exported/embedded symbol payloads use simplified geometry.
- Kept draw order and styles unchanged, added debug logging for `before -> after` point counts, and registered new sources in `core/CMakeLists.txt`.
- Added a small test `tests/rdp_simplifier_test.cpp` and wired it into `tests/CMakeLists.txt` verifying polyline collapse, rectangle simplification with closure, and tiny-polygon fallback.

### Testing
- Ran repository checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both succeeded.
- Built and executed the lightweight geometry test directly with `g++ -std=c++20 -Icore tests/rdp_simplifier_test.cpp core/geometry/RdpSimplifier.cpp` and the test passed.
- Attempted full `cmake` + `ctest` for the `tests` tree, but the environment lacks discoverable `wxWidgets` dev packages so the CMake configure step failed (this is an environment limitation, not a code error).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b2cdcc0f88324a8b65f3c116aaa09)