### PR TITLE
Do not lowercase/slugify GDTF filenames during MVR export

### DIFF
--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -158,26 +158,6 @@ static std::string ExportSafeTrussModelFile(const std::string &modelFile) {
 }
 
 
-static std::string SlugifyArchiveName(const std::string &input) {
-  std::string out;
-  out.reserve(input.size());
-  bool lastUnderscore = false;
-  for (unsigned char c : input) {
-    if (std::isalnum(c) != 0) {
-      out.push_back(static_cast<char>(std::tolower(c)));
-      lastUnderscore = false;
-    } else if (!lastUnderscore) {
-      out.push_back('_');
-      lastUnderscore = true;
-    }
-  }
-  while (!out.empty() && out.front() == '_')
-    out.erase(out.begin());
-  while (!out.empty() && out.back() == '_')
-    out.pop_back();
-  return out;
-}
-
 static bool IsValidMvrFileName(const std::string &value) {
   if (value.empty())
     return false;
@@ -932,9 +912,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
       addInt("UnitNumber", f.unitNumber);
     addInt("CustomId", f.customId);
     addInt("CustomIdType", f.customIdType);
-    std::string fixtureSlug = SlugifyArchiveName(f.typeName);
-    std::string fixtureFallback = SanitizeArchiveFileName(f.gdtfSpec, "fixture.gdtf");
-    std::string fixtureName = fixtureSlug.empty() ? fixtureFallback : (fixtureSlug + ".gdtf");
+    std::string fixtureName = SanitizeArchiveFileName(f.gdtfSpec, "fixture.gdtf");
     std::string fixtureGdtfArchivePath = registerGdtfResource(f.uuid, f.gdtfSpec, fixtureName);
     addStr("GDTFSpec", fixtureGdtfArchivePath);
     if (!f.gdtfSpec.empty() &&
@@ -1078,8 +1056,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
       }
     }
 
-    std::string trussSlug = SlugifyArchiveName(t.model.empty() ? t.name : t.model);
-    std::string trussPreferredName = trussSlug.empty() ? "truss.gdtf" : (trussSlug + ".gdtf");
+    std::string trussPreferredName = SanitizeArchiveFileName(trussSourceGdtf, "truss.gdtf");
     std::string trussGdtfArchivePath = registerGdtfResource(t.uuid, trussSourceGdtf, trussPreferredName);
     if (!trussGdtfArchivePath.empty()) {
       tinyxml2::XMLElement *e = doc.NewElement("GDTFSpec");


### PR DESCRIPTION
### Motivation
- The MVR exporter was altering library GDTF filenames by slugifying (lowercasing and replacing non-alnum with `_`), causing exported archive names to differ from the original filenames in the library; exports and UI views should preserve the original file names (while still keeping path safety).

### Description
- Removed the internal slugification step by deleting `SlugifyArchiveName` from `mvr/mvrexporter.cpp`.
- Use `SanitizeArchiveFileName(...)` directly when selecting the archive filename for fixtures and trusses instead of generating a slug-based name, so original base filenames (including case and spaces) are preserved while applying path safety checks.
- Kept existing uniqueness and collision handling via `EnsureUniqueArchivePath`, so duplicate archive names are still resolved safely.
- File modified: `mvr/mvrexporter.cpp` (export name selection logic for GDTF resources).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (OK).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b305c0cc48324a062eb305240eac7)