### PR TITLE
Preserve original .gdtf basenames in MVR export and revert rider importer name changes

### DIFF
--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -117,13 +117,13 @@ static std::string SanitizeArchiveFileName(const std::string &input,
                                            const std::string &fallbackName) {
   std::string candidate = TrimAscii(input);
   std::replace(candidate.begin(), candidate.end(), '\\', '/');
-  if (candidate.find(':') != std::string::npos || (!candidate.empty() && candidate.front() == '/'))
-    candidate.clear();
-  while (!candidate.empty() && candidate.front() == '/')
-    candidate.erase(candidate.begin());
   if (candidate.empty())
-    candidate = fallbackName;
-  return fs::path(candidate).filename().generic_string();
+    return fallbackName;
+
+  const std::string fileName = fs::path(candidate).filename().generic_string();
+  if (!fileName.empty())
+    return fileName;
+  return fallbackName;
 }
 
 static std::string ExportSafeTrussModelFile(const std::string &modelFile) {


### PR DESCRIPTION
### Motivation
- The change should be limited to fixing `.gdtf` archive filename handling during MVR export so exported archives keep the original GDTF basenames from absolute or Windows-style paths. 
- Previous changes that propagated parsed fixture/truss `name`/`instanceName` in `core/riderimporter.cpp` caused unwanted behavior outside the `.gdtf` export case and needed to be reverted. 

### Description
- Reverted the prior name-normalization edits in `core/riderimporter.cpp` so import-time fixture/truss naming behavior remains unchanged and outside the scope of GDTF filename handling. 
- Updated `SanitizeArchiveFileName` in `mvr/mvrexporter.cpp` to preserve the original filename basename (via `fs::path(...).filename().generic_string()`) even when the provided path is absolute or Windows-style, and to return the provided fallback only when no valid basename is present. 
- The scope of the change is intentionally limited to archive filename sanitization for GDTF resources and does not alter other export or import logic. 

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b326236448324a4fc3084b8c9a70a)