### PR TITLE
Lock orthographic symbol capture scale across views

### DIFF
--- a/gui/tools/scene_model_symbol_capture_service.cpp
+++ b/gui/tools/scene_model_symbol_capture_service.cpp
@@ -1,6 +1,8 @@
 #include "tools/scene_model_symbol_capture_service.h"
 
 #include <array>
+#include <cmath>
+#include <limits>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -15,6 +17,7 @@
 #include "truss.h"
 #include "viewer2doffscreenrenderer.h"
 #include "viewer2dpanel.h"
+#include "viewer2dcommandrenderer.h"
 
 namespace tools {
 namespace {
@@ -232,13 +235,59 @@ CaptureSceneModelOrthographicSymbols(Viewer2DOffscreenRenderer &renderer,
   std::vector<symbols::RenderedSymbolImage> renders;
   renders.reserve(requests.size());
 
+  struct PreparedViewState {
+    Viewer2DViewState state;
+    CaptureRequest request;
+  };
+
+  std::vector<PreparedViewState> preparedStates;
+  preparedStates.reserve(requests.size());
+
+  float commonOrthographicZoom = std::numeric_limits<float>::max();
   for (const auto &request : requests) {
     ScopedFloatConfigOverride topViewOverride(
         cfg, {{"view2d_top_fixtures_inverted", request.topFixturesInverted}});
 
     capturePanel->SetView(request.view);
     capturePanel->UpdateScene(true);
-    capturePanel->FitViewToScene();
+    if (!capturePanel->FitViewToScene()) {
+      capturePanel->SetView(previousView);
+      result.error = "Could not compute a common orthographic fit for all symbol views.";
+      return result;
+    }
+
+    Viewer2DViewState fitState = capturePanel->GetViewState();
+    commonOrthographicZoom = std::min(commonOrthographicZoom, fitState.zoom);
+    preparedStates.push_back(PreparedViewState{fitState, request});
+  }
+
+  if (!std::isfinite(commonOrthographicZoom) || commonOrthographicZoom <= 0.0f) {
+    capturePanel->SetView(previousView);
+    result.error = "Computed orthographic zoom is invalid for symbol capture.";
+    return result;
+  }
+
+  const double commonWorldToPixelScale =
+      viewer2d::kViewer2DPixelsPerMeter * static_cast<double>(commonOrthographicZoom);
+  if (!std::isfinite(commonWorldToPixelScale) || commonWorldToPixelScale <= 0.0) {
+    capturePanel->SetView(previousView);
+    result.error = "Computed world-to-pixel scale is invalid for symbol capture.";
+    return result;
+  }
+
+  for (const auto &preparedState : preparedStates) {
+    const auto &request = preparedState.request;
+    ScopedFloatConfigOverride topViewOverride(
+        cfg, {{"view2d_top_fixtures_inverted", request.topFixturesInverted}});
+
+    capturePanel->ApplyViewState(preparedState.state.offsetPixelsX,
+                                 preparedState.state.offsetPixelsY,
+                                 commonOrthographicZoom, request.view,
+                                 Viewer2DRenderMode::ByFixtureType);
+    capturePanel->UpdateScene(true);
+
+    // Keep a single world-unit scale (GDTF physical units) across Front/Top/
+    // Side/Bottom captures so inter-view proportions remain physically valid.
 
     symbols::RenderedSymbolImage render;
     render.view = request.symbolView;


### PR DESCRIPTION
### Motivation
- Ensure orthographic symbol captures (Top/Front/Side/Bottom) use a single world-unit scale per GDTF so inter-view physical proportions are preserved for asymmetric fixtures.
- Prevent each view from independently calling `FitViewToScene()` and producing different zooms which distort relative Top vs Front dimensions in generated SVGs.

### Description
- Precompute per-view fit states and collect them before rendering, then derive a single `commonOrthographicZoom` used for all captures in `gui/tools/scene_model_symbol_capture_service.cpp`.
- Replace the in-loop `FitViewToScene()` behavior with `ApplyViewState(...)` using each view's offsets but the shared zoom so only orientation differs between captures.
- Add validation for the computed orthographic zoom and the derived world->pixel scale and include the necessary headers (`<cmath>`, `<limits>` and `viewer2dcommandrenderer.h`).
- Add a technical code comment at the capture point explaining that inter-view scale must remain locked to preserve physical proportions (GDTF units).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed successfully.
- Attempted a local build but no `build` directory was present so compilation was skipped in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b74ce4b448324b76770f877f43d6d)