### PR TITLE
Make symbol extraction/export scale-aware (world units per pixel)

### DIFF
--- a/core/symbols/Symbol2DImageBuilder.cpp
+++ b/core/symbols/Symbol2DImageBuilder.cpp
@@ -103,12 +103,16 @@ int PixelIndex(const PixelMask &mask, int x, int y) {
   return y * mask.width + x;
 }
 
-Point2D ToPoint(int x, int y, int imageHeight) {
-  return Point2D{static_cast<float>(x), static_cast<float>(imageHeight - 1 - y)};
+Point2D ToPoint(int x, int y, int imageHeight, float worldUnitsPerPixel) {
+  const float scale = worldUnitsPerPixel > 0.0f ? worldUnitsPerPixel : 1.0f;
+  return Point2D{static_cast<float>(x) * scale,
+                 static_cast<float>(imageHeight - 1 - y) * scale};
 }
 
-Point2D ToVertexPoint(int x, int y, int imageHeight) {
-  return Point2D{static_cast<float>(x), static_cast<float>(imageHeight - y)};
+Point2D ToVertexPoint(int x, int y, int imageHeight, float worldUnitsPerPixel) {
+  const float scale = worldUnitsPerPixel > 0.0f ? worldUnitsPerPixel : 1.0f;
+  return Point2D{static_cast<float>(x) * scale,
+                 static_cast<float>(imageHeight - y) * scale};
 }
 
 void ExtendBounds(Aabb2D &bounds, const Point2D &p) {
@@ -207,7 +211,8 @@ PixelMask BuildLineMask(const RenderedSymbolImage &render,
   return mask;
 }
 
-std::vector<PolygonWithHoles2D> ExtractFillPolygons(const PixelMask &fillMask) {
+std::vector<PolygonWithHoles2D> ExtractFillPolygons(const PixelMask &fillMask,
+                                             float worldUnitsPerPixel) {
   const int w = fillMask.width;
   const int h = fillMask.height;
   std::vector<PolygonWithHoles2D> result;
@@ -250,8 +255,8 @@ std::vector<PolygonWithHoles2D> ExtractFillPolygons(const PixelMask &fillMask) {
     edges.erase(currentIt);
 
     Polyline2D loop;
-    loop.push_back(ToVertexPoint(start.x, start.y, h));
-    loop.push_back(ToVertexPoint(next.x, next.y, h));
+    loop.push_back(ToVertexPoint(start.x, start.y, h, worldUnitsPerPixel));
+    loop.push_back(ToVertexPoint(next.x, next.y, h, worldUnitsPerPixel));
     current = next;
 
     for (size_t step = 0; step < maxSteps; ++step) {
@@ -263,7 +268,7 @@ std::vector<PolygonWithHoles2D> ExtractFillPolygons(const PixelMask &fillMask) {
       GridPoint candidate = take->second;
       edges.erase(take);
 
-      loop.push_back(ToVertexPoint(candidate.x, candidate.y, h));
+      loop.push_back(ToVertexPoint(candidate.x, candidate.y, h, worldUnitsPerPixel));
       current = candidate;
       if (current == start)
         break;
@@ -408,7 +413,8 @@ void ThinZhangSuen(PixelMask &mask) {
 }
 
 std::vector<Polyline2D> ExtractPolylines(const PixelMask &skeleton,
-                                         const ImageBuildParams &params) {
+                                         const ImageBuildParams &params,
+                                         float worldUnitsPerPixel) {
   const int w = skeleton.width;
   const int h = skeleton.height;
   std::vector<std::vector<int>> adjacency(static_cast<size_t>(w * h));
@@ -446,10 +452,10 @@ std::vector<Polyline2D> ExtractPolylines(const PixelMask &skeleton,
     return visitedEdges.find({a, b}) != visitedEdges.end();
   };
 
-  auto nodeToPoint = [w, h](int node) {
+  auto nodeToPoint = [w, h, worldUnitsPerPixel](int node) {
     const int x = node % w;
     const int y = node / w;
-    return ToPoint(x, y, h);
+    return ToPoint(x, y, h, worldUnitsPerPixel);
   };
 
   auto walkFrom = [&](int start, int next) {
@@ -534,9 +540,12 @@ Symbol2DImageBuilder::BuildFromRenderedImages(
     symbol.view = render.view;
     symbol.strokeWidthPx = params.previewStrokeWidthPx;
 
-    symbol.fill = ExtractFillPolygons(fillMask);
+    const float worldUnitsPerPixel =
+        render.worldUnitsPerPixel > 0.0f ? render.worldUnitsPerPixel : 1.0f;
 
-    symbol.strokes = ExtractPolylines(lineMask, params);
+    symbol.fill = ExtractFillPolygons(fillMask, worldUnitsPerPixel);
+
+    symbol.strokes = ExtractPolylines(lineMask, params, worldUnitsPerPixel);
 
     for (const auto &polygon : symbol.fill)
       for (const auto &p : polygon.outer)

--- a/core/symbols/Symbol2DImageBuilder.h
+++ b/core/symbols/Symbol2DImageBuilder.h
@@ -10,6 +10,7 @@ struct RenderedSymbolImage {
   SymbolView view = SymbolView::Top;
   int width = 0;
   int height = 0;
+  float worldUnitsPerPixel = 1.0f;
   std::vector<unsigned char> rgba;
 };
 

--- a/gui/tools/scene_model_symbol_capture_service.cpp
+++ b/gui/tools/scene_model_symbol_capture_service.cpp
@@ -291,6 +291,8 @@ CaptureSceneModelOrthographicSymbols(Viewer2DOffscreenRenderer &renderer,
 
     symbols::RenderedSymbolImage render;
     render.view = request.symbolView;
+    render.worldUnitsPerPixel =
+        static_cast<float>(1.0 / commonWorldToPixelScale);
     const bool ok = capturePanel->RenderToRGBA(render.rgba, render.width, render.height);
     if (!ok || render.width <= 0 || render.height <= 0) {
       capturePanel->SetView(previousView);

--- a/gui/windows/symbol_preview_exporter.cpp
+++ b/gui/windows/symbol_preview_exporter.cpp
@@ -1,21 +1,68 @@
 #include "windows/symbol_preview_exporter.h"
 
+#include <algorithm>
 #include <fstream>
 #include <sstream>
 
 namespace symbol_preview {
 namespace {
 
+symbols::Point2D NormalizePointToBounds(const symbols::Point2D &point,
+                                        const symbols::Aabb2D &bounds) {
+  return symbols::Point2D{point.x - bounds.min.x, bounds.max.y - point.y};
+}
+
+void ExtendBounds(symbols::Aabb2D &bounds, const symbols::Point2D &point) {
+  if (!bounds.valid) {
+    bounds.min = point;
+    bounds.max = point;
+    bounds.valid = true;
+    return;
+  }
+  bounds.min.x = std::min(bounds.min.x, point.x);
+  bounds.min.y = std::min(bounds.min.y, point.y);
+  bounds.max.x = std::max(bounds.max.x, point.x);
+  bounds.max.y = std::max(bounds.max.y, point.y);
+}
+
+symbols::Aabb2D BuildNormalizedPhysicalBounds(const symbols::Symbol2D &symbol) {
+  symbols::Aabb2D normalized;
+  if (!symbol.bounds.valid)
+    return normalized;
+
+  for (const auto &polygon : symbol.fill) {
+    for (const auto &point : polygon.outer)
+      ExtendBounds(normalized, NormalizePointToBounds(point, symbol.bounds));
+    for (const auto &hole : polygon.holes)
+      for (const auto &point : hole)
+        ExtendBounds(normalized, NormalizePointToBounds(point, symbol.bounds));
+  }
+
+  for (const auto &line : symbol.strokes)
+    for (const auto &point : line)
+      ExtendBounds(normalized, NormalizePointToBounds(point, symbol.bounds));
+
+  if (!normalized.valid)
+    normalized = symbols::Aabb2D{symbols::Point2D{0.0f, 0.0f},
+                                 symbols::Point2D{symbol.bounds.max.x - symbol.bounds.min.x,
+                                                  symbol.bounds.max.y - symbol.bounds.min.y},
+                                 true};
+  return normalized;
+}
+
+
 std::string BuildPoints(const symbols::Polyline2D &line,
-                        const symbols::Aabb2D &bounds) {
+                        const symbols::Aabb2D &sourceBounds) {
   std::ostringstream stream;
   bool first = true;
   for (const auto &point : line) {
     if (!first)
       stream << ' ';
     first = false;
-    const float x = point.x - bounds.min.x;
-    const float y = bounds.max.y - point.y;
+    const symbols::Point2D normalizedPoint =
+        NormalizePointToBounds(point, sourceBounds);
+    const float x = normalizedPoint.x;
+    const float y = normalizedPoint.y;
     stream << x << ',' << y;
   }
   return stream.str();
@@ -28,8 +75,9 @@ bool BuildSvgContent(const symbols::Symbol2D &symbol, std::string &svgContent,
     return false;
   }
 
-  const float width = symbol.bounds.max.x - symbol.bounds.min.x;
-  const float height = symbol.bounds.max.y - symbol.bounds.min.y;
+  const symbols::Aabb2D normalizedBounds = BuildNormalizedPhysicalBounds(symbol);
+  const float width = normalizedBounds.valid ? (normalizedBounds.max.x - normalizedBounds.min.x) : 0.0f;
+  const float height = normalizedBounds.valid ? (normalizedBounds.max.y - normalizedBounds.min.y) : 0.0f;
   if (width <= 0.0f || height <= 0.0f) {
     errorMessage = "The selected view has invalid bounds.";
     return false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,13 @@ add_executable(rdp_simplifier_test
 target_include_directories(rdp_simplifier_test PRIVATE ../core)
 add_test(NAME RdpSimplifierGeometry COMMAND rdp_simplifier_test)
 
+add_executable(symbol2d_image_builder_scale_test
+               symbol2d_image_builder_scale_test.cpp
+               ../core/symbols/Symbol2DImageBuilder.cpp
+               ../gui/windows/symbol_preview_exporter.cpp)
+target_include_directories(symbol2d_image_builder_scale_test PRIVATE .. ../core ../gui)
+add_test(NAME Symbol2DImageBuilderScale COMMAND symbol2d_image_builder_scale_test)
+
 add_executable(pdf_font_metrics_test
                pdf_font_metrics_test.cpp
                ../viewer2d/pdf/font_metrics.cpp)

--- a/tests/symbol2d_image_builder_scale_test.cpp
+++ b/tests/symbol2d_image_builder_scale_test.cpp
@@ -1,0 +1,94 @@
+#include "symbols/Symbol2DImageBuilder.h"
+#include "windows/symbol_preview_exporter.h"
+
+#include <cmath>
+#include <iostream>
+#include <string>
+
+namespace {
+
+bool Near(float a, float b, float eps = 1e-3f) { return std::fabs(a - b) <= eps; }
+
+void FillRect(symbols::RenderedSymbolImage &render, int minX, int minY, int maxX,
+              int maxY) {
+  render.rgba.assign(static_cast<size_t>(render.width) * static_cast<size_t>(render.height) *
+                         4,
+                     255);
+  for (int y = minY; y < maxY; ++y) {
+    for (int x = minX; x < maxX; ++x) {
+      const size_t idx =
+          (static_cast<size_t>(y) * static_cast<size_t>(render.width) +
+           static_cast<size_t>(x)) *
+          4;
+      render.rgba[idx + 0] = 200;
+      render.rgba[idx + 1] = 200;
+      render.rgba[idx + 2] = 200;
+      render.rgba[idx + 3] = 255;
+    }
+  }
+}
+
+float SymbolWidth(const symbols::Symbol2D &symbol) {
+  return symbol.bounds.max.x - symbol.bounds.min.x;
+}
+
+float SymbolHeight(const symbols::Symbol2D &symbol) {
+  return symbol.bounds.max.y - symbol.bounds.min.y;
+}
+
+} // namespace
+
+int main() {
+  symbols::RenderedSymbolImage top;
+  top.view = symbols::SymbolView::Top;
+  top.width = 100;
+  top.height = 100;
+  top.worldUnitsPerPixel = 0.02f;
+  FillRect(top, 20, 30, 70, 50);
+
+  symbols::RenderedSymbolImage front;
+  front.view = symbols::SymbolView::Front;
+  front.width = 200;
+  front.height = 200;
+  front.worldUnitsPerPixel = 0.04f;
+  FillRect(front, 40, 110, 65, 120);
+
+  const auto symbolsBuilt =
+      symbols::Symbol2DImageBuilder::BuildFromRenderedImages({top, front});
+  if (symbolsBuilt.size() != 2) {
+    std::cerr << "Expected top/front symbols to be built\n";
+    return 1;
+  }
+
+  const symbols::Symbol2D &topSymbol = symbolsBuilt[0];
+  const symbols::Symbol2D &frontSymbol = symbolsBuilt[1];
+
+  const float topWidth = SymbolWidth(topSymbol);
+  const float topHeight = SymbolHeight(topSymbol);
+  const float frontWidth = SymbolWidth(frontSymbol);
+  const float frontHeight = SymbolHeight(frontSymbol);
+
+  if (!Near(topWidth, 1.0f) || !Near(topHeight, 0.4f)) {
+    std::cerr << "Top symbol should be expressed in world units\n";
+    return 1;
+  }
+
+  if (!Near(frontWidth, 1.0f) || !Near(frontHeight, 0.4f)) {
+    std::cerr << "Front symbol should preserve world proportions despite viewport occupancy\n";
+    return 1;
+  }
+
+  std::string svg;
+  std::string error;
+  if (!symbol_preview::ExportSymbolToSvgString(topSymbol, svg, error)) {
+    std::cerr << "SVG export failed: " << error << "\n";
+    return 1;
+  }
+
+  if (svg.find("viewBox=\"0 0 1 0.4\"") == std::string::npos) {
+    std::cerr << "SVG viewBox should use normalized physical bounds\n";
+    return 1;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- Decouple symbol geometry from raw render pixels so symbol outlines and bounds are expressed in physical world units and inter-view proportions remain correct. 
- Ensure Top/Front/Side exports keep relative physical proportions even when silhouettes occupy different percentages of the viewport.

### Description
- Add `worldUnitsPerPixel` to `symbols::RenderedSymbolImage` so each captured image carries its physical scale (`core/symbols/Symbol2DImageBuilder.h`).
- Populate `render.worldUnitsPerPixel` in `CaptureSceneModelOrthographicSymbols` using the common orthographic camera scale (`1.0 / commonWorldToPixelScale`) so all captures share a physical scale reference (`gui/tools/scene_model_symbol_capture_service.cpp`).
- Convert pixel coordinates to world units inside `Symbol2DImageBuilder` by applying the per-render `worldUnitsPerPixel`: updated `ToPoint`/`ToVertexPoint`, added scale parameters to `ExtractFillPolygons` and `ExtractPolylines`, and apply the factor in `BuildFromRenderedImages` (`core/symbols/Symbol2DImageBuilder.cpp`).
- Compute SVG `viewBox` from normalized physical bounds (geometry expressed in world units) and normalize point coordinates for export, so previews use physical-unit bounds rather than raw pixels (`gui/windows/symbol_preview_exporter.cpp`).
- Add a regression test `symbol2d_image_builder_scale_test` that builds small synthetic renders to validate geometry is produced in world units, that Top/Front proportions match, and that exported SVG `viewBox` uses normalized physical bounds, and register it in `tests/CMakeLists.txt`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (`OK`).
- Attempted to configure/build and run the new `Symbol2DImageBuilderScale` test, but local CMake configure failed due to missing `wxWidgets` CMake package (`wxWidgets_LIBRARIES` / `wxWidgets_INCLUDE_DIRS`), so the compiled test execution could not be completed in this environment (requires a build environment with wxWidgets).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b7679ab3c83248b53d3adfb003d8f)