### PR TITLE
Use fixture type color for legend SVG fills when uniform

### DIFF
--- a/gui/layoutlegenditems.cpp
+++ b/gui/layoutlegenditems.cpp
@@ -18,6 +18,7 @@
 #include "layoutlegenditems.h"
 
 #include <filesystem>
+#include <cctype>
 #include <map>
 
 #include <wx/filename.h>
@@ -33,7 +34,30 @@ struct LegendAggregate {
   std::optional<int> channelCount;
   bool mixedChannels = false;
   std::string symbolKey;
+  std::optional<std::string> firstColor;
+  bool hasMixedColors = false;
 };
+
+std::optional<std::string> NormalizeHexColor(const std::string &raw) {
+  std::string value;
+  value.reserve(raw.size());
+  for (char ch : raw) {
+    if (!std::isspace(static_cast<unsigned char>(ch)))
+      value.push_back(ch);
+  }
+  if (value.empty())
+    return std::nullopt;
+  if (!value.empty() && value.front() == '#')
+    value.erase(value.begin());
+  if (value.size() != 6)
+    return std::nullopt;
+  for (char &ch : value) {
+    if (!std::isxdigit(static_cast<unsigned char>(ch)))
+      return std::nullopt;
+    ch = static_cast<char>(std::toupper(static_cast<unsigned char>(ch)));
+  }
+  return "#" + value;
+}
 } // namespace
 
 std::vector<SharedLayoutLegendItem> BuildSharedLayoutLegendItems() {
@@ -84,6 +108,16 @@ std::vector<SharedLayoutLegendItem> BuildSharedLayoutLegendItems() {
     // symbol even when the type contains mixed fixture variants.
     if (agg.symbolKey.empty() && !symbolKey.empty())
       agg.symbolKey = symbolKey;
+
+    const std::optional<std::string> fixtureColor =
+        NormalizeHexColor(fixture.color);
+    if (!fixtureColor.has_value())
+      continue;
+    if (!agg.firstColor.has_value()) {
+      agg.firstColor = fixtureColor;
+    } else if (agg.firstColor.value() != fixtureColor.value()) {
+      agg.hasMixedColors = true;
+    }
   }
 
   std::vector<SharedLayoutLegendItem> items;
@@ -95,6 +129,8 @@ std::vector<SharedLayoutLegendItem> BuildSharedLayoutLegendItems() {
     if (agg.channelCount.has_value() && !agg.mixedChannels)
       item.channelCount = agg.channelCount;
     item.symbolKey = agg.symbolKey;
+    if (agg.firstColor.has_value() && !agg.hasMixedColors)
+      item.symbolFillHex = agg.firstColor;
     items.push_back(item);
   }
 
@@ -107,4 +143,3 @@ std::vector<SharedLayoutLegendItem> BuildSharedLayoutLegendItems() {
 
   return items;
 }
-

--- a/gui/layoutlegenditems.h
+++ b/gui/layoutlegenditems.h
@@ -26,7 +26,7 @@ struct SharedLayoutLegendItem {
   int count = 0;
   std::optional<int> channelCount;
   std::string symbolKey;
+  std::optional<std::string> symbolFillHex;
 };
 
 std::vector<SharedLayoutLegendItem> BuildSharedLayoutLegendItems();
-

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -51,6 +51,7 @@ private:
     int count = 0;
     std::optional<int> channelCount;
     std::string symbolKey;
+    std::optional<std::string> symbolFillHex;
   };
 
   struct ViewCache {

--- a/gui/layoutviewerpanel_legend.cpp
+++ b/gui/layoutviewerpanel_legend.cpp
@@ -171,6 +171,16 @@ wxColour ToWxColor(const CanvasColor &color) {
                   clamp(color.a));
 }
 
+wxColour ResolveLegendSvgFillColor(const std::optional<std::string> &hexColor) {
+  if (!hexColor.has_value())
+    return wxColour(224, 224, 224);
+
+  wxColour parsed(wxString::FromUTF8(hexColor.value()));
+  if (!parsed.IsOk())
+    return wxColour(224, 224, 224);
+  return parsed;
+}
+
 class LegendSymbolBackend : public viewer2d::IViewer2DCommandBackend {
 public:
   explicit LegendSymbolBackend(wxGCDC &dc)
@@ -729,6 +739,7 @@ LayoutViewerPanel::BuildLegendItems() const {
     item.count = shared.count;
     item.channelCount = shared.channelCount;
     item.symbolKey = shared.symbolKey;
+    item.symbolFillHex = shared.symbolFillHex;
     items.push_back(std::move(item));
   }
   return items;
@@ -745,6 +756,7 @@ size_t LayoutViewerPanel::HashLegendItems(
     int chValue = item.channelCount.value_or(-1);
     hash ^= intHasher(chValue) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
     hash ^= strHasher(item.symbolKey) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+    hash ^= strHasher(item.symbolFillHex.value_or("")) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
   }
   return hash;
 }
@@ -1073,8 +1085,9 @@ wxImage LayoutViewerPanel::BuildLegendImage(
                                   Transform2D::Identity(), symbols, backend,
                                   mapping);
       };
-      auto drawSvg = [&](const PerastageSvgSymbolData *symbol, double drawLeft,
-                         double drawTop, double scaleOverride) {
+      auto drawSvg = [&](const PerastageSvgSymbolData *symbol,
+                         const std::optional<std::string> &fillHex,
+                         double drawLeft, double drawTop, double scaleOverride) {
         if (!symbol)
           return;
         const double scale = scaleOverride > 0.0
@@ -1089,7 +1102,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
         gc->PushState();
         gc->Translate(drawLeft, drawTop);
         gc->Scale(scale, scale);
-        gc->SetBrush(wxBrush(wxColour(224, 224, 224)));
+        gc->SetBrush(wxBrush(ResolveLegendSvgFillColor(fillHex)));
         gc->SetPen(*wxTRANSPARENT_PEN);
         for (const auto &polygon : symbol->fills) {
           if (polygon.points.empty())
@@ -1155,7 +1168,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
           double symbolDrawLeft =
               topSlotLeft + std::max(0.0, (leftSlotWidth - topDrawW) * 0.5);
           if (topSvg)
-            drawSvg(topSvg, symbolDrawLeft, symbolDrawTop, pairScaleSvg);
+            drawSvg(topSvg, item.symbolFillHex, symbolDrawLeft, symbolDrawTop, pairScaleSvg);
           else
             drawSymbol(topSymbol, symbolDrawLeft, symbolDrawTop);
         }
@@ -1166,7 +1179,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
               frontSlotLeft +
               std::max(0.0, (rightSlotWidth - frontDrawW) * 0.5);
           if (frontSvg)
-            drawSvg(frontSvg, symbolDrawLeft, symbolDrawTop, pairScaleSvg);
+            drawSvg(frontSvg, item.symbolFillHex, symbolDrawLeft, symbolDrawTop, pairScaleSvg);
           else
             drawSymbol(frontSymbol, symbolDrawLeft, symbolDrawTop);
         }

--- a/gui/mainwindow_print.cpp
+++ b/gui/mainwindow_print.cpp
@@ -57,6 +57,7 @@ std::vector<LayoutLegendItem> BuildLayoutLegendItems() {
     item.count = shared.count;
     item.channelCount = shared.channelCount;
     item.symbolKey = shared.symbolKey;
+    item.symbolFillHex = shared.symbolFillHex;
     items.push_back(std::move(item));
   }
   return items;

--- a/viewer2d/pdf/layout_pdf_exporter.cpp
+++ b/viewer2d/pdf/layout_pdf_exporter.cpp
@@ -64,6 +64,35 @@ static bool ShouldTraceLabelOrder() {
   return enabled;
 }
 
+
+std::array<double, 3> ResolveLegendSvgFillRgb(
+    const std::optional<std::string> &hexColor) {
+  constexpr std::array<double, 3> kDefaultGray = {0.878, 0.878, 0.878};
+  if (!hexColor.has_value())
+    return kDefaultGray;
+
+  std::string value = *hexColor;
+  value.erase(std::remove_if(value.begin(), value.end(), [](unsigned char ch) {
+                return std::isspace(ch) != 0;
+              }),
+              value.end());
+  if (!value.empty() && value.front() == '#')
+    value.erase(value.begin());
+  if (value.size() != 6)
+    return kDefaultGray;
+  if (!std::all_of(value.begin(), value.end(), [](unsigned char ch) {
+        return std::isxdigit(ch) != 0;
+      })) {
+    return kDefaultGray;
+  }
+
+  auto parse = [&](size_t offset) {
+    return static_cast<double>(std::stoi(value.substr(offset, 2), nullptr, 16)) /
+           255.0;
+  };
+  return {parse(0), parse(2), parse(4)};
+}
+
 double ComputeTextLineAdvance(double ascent, double descent) {
   // Negative because PDF moves the text cursor downward with a negative y
   // translation. The advance mirrors the ascent + descent used by the
@@ -1508,7 +1537,9 @@ Viewer2DExportResult ExportLayoutToPdf(
                           << formatter.Format(symbolOffsetY) << " cm\n/"
                           << nameIt->second << " Do\nQ\n";
           };
-          auto drawSvg = [&](const PerastageSvgSymbolData *svg, double drawLeft,
+          auto drawSvg = [&](const PerastageSvgSymbolData *svg,
+                             const std::optional<std::string> &fillHex,
+                             double drawLeft,
                              double drawW, double drawH, double scaleOverride) {
             if (!svg || drawW <= 0.0 || drawH <= 0.0)
               return;
@@ -1523,7 +1554,10 @@ Viewer2DExportResult ExportLayoutToPdf(
                               svg->offsetYmm * scale;
             contentStream << "q\n1 0 0 1 " << formatter.Format(ox) << ' '
                           << formatter.Format(oy) << " cm\n";
-            contentStream << "0.878 0.878 0.878 rg\n";
+            const auto fillRgb = ResolveLegendSvgFillRgb(fillHex);
+            contentStream << formatter.Format(fillRgb[0]) << " "
+                          << formatter.Format(fillRgb[1]) << " "
+                          << formatter.Format(fillRgb[2]) << " rg\n";
             for (const auto &polygon : svg->fills) {
               if (polygon.points.size() < 3)
                 continue;
@@ -1560,7 +1594,7 @@ Viewer2DExportResult ExportLayoutToPdf(
             double symbolLeft =
                 topSlotLeft + std::max(0.0, (leftSlotWidth - topDrawW) * 0.5);
             if (topSvg)
-              drawSvg(topSvg, symbolLeft, topDrawW, topDrawH, pairScaleSvg);
+              drawSvg(topSvg, item.symbolFillHex, symbolLeft, topDrawW, topDrawH, pairScaleSvg);
             else
               drawSymbol(topSymbol, topDrawW, topDrawH, symbolLeft);
           }
@@ -1569,7 +1603,7 @@ Viewer2DExportResult ExportLayoutToPdf(
                 frontSlotLeft +
                 std::max(0.0, (rightSlotWidth - frontDrawW) * 0.5);
             if (frontSvg)
-              drawSvg(frontSvg, symbolLeft, frontDrawW, frontDrawH, pairScaleSvg);
+              drawSvg(frontSvg, item.symbolFillHex, symbolLeft, frontDrawW, frontDrawH, pairScaleSvg);
             else
               drawSymbol(frontSymbol, frontDrawW, frontDrawH, symbolLeft);
           }

--- a/viewer2d/viewer2dpdfexporter.h
+++ b/viewer2d/viewer2dpdfexporter.h
@@ -63,6 +63,7 @@ struct LayoutLegendItem {
   int count = 0;
   std::optional<int> channelCount;
   std::string symbolKey;
+  std::optional<std::string> symbolFillHex;
 };
 
 struct LayoutLegendExportData {


### PR DESCRIPTION
### Motivation
- Legend SVG symbols currently render with a neutral gray fill even when all fixtures of a type share the same color, which is inconsistent with the on-screen fixture coloring.
- Improve visual fidelity by using the fixture-type color in legend SVG fills when the type has a single uniform color, while preserving gray when a type has mixed colors.

### Description
- Added an optional `symbolFillHex` field to `SharedLayoutLegendItem`, `LayoutLegendItem` and their consumers to carry a per-type hex color when uniform (files updated: `gui/layoutlegenditems.*`, `gui/layoutviewerpanel.*`, `viewer2d/viewer2dpdfexporter.h`, `gui/mainwindow_print.cpp`).
- Implemented `NormalizeHexColor()` to validate/normalize fixture color strings and aggregated per-type colors in `BuildSharedLayoutLegendItems()` so `symbolFillHex` is set only when all fixtures of a type share the same valid hex color (`gui/layoutlegenditems.cpp`).
- Updated on-screen legend rendering to use a resolved wxColour for SVG fills (`ResolveLegendSvgFillColor`) and pass `symbolFillHex` into SVG draw calls so fills use the type color when available (`gui/layoutviewerpanel_legend.cpp`).
- Updated PDF layout exporter to resolve hex -> RGB and emit the fill color into the PDF drawing stream via `ResolveLegendSvgFillRgb`, and pass `symbolFillHex` into SVG export paths so PDF legend SVGs match the on-screen behavior (`viewer2d/pdf/layout_pdf_exporter.cpp`).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b7fbdce3c83248c50f3d9443a7757)