### PR TITLE
Defer layout element resize repaint until mouse release

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -560,23 +560,35 @@ void LayoutViewerPanel::OnPaint(wxPaintEvent &) {
 
     const layouts::Layout2DViewDefinition *activeView =
         static_cast<const LayoutViewerPanel *>(this)->GetEditableView();
-    const int activeViewId =
+    const bool showDeferredResizeOverlay =
+        deferredResizeFrame_.has_value() && dragMode != FrameDragMode::None &&
+        dragMode != FrameDragMode::Move;
+    const int selectedViewId =
         selectedElementType == SelectedElementType::View2D && activeView
             ? activeView->id
             : -1;
-    const int activeLegendId =
+    const int selectedLegendId =
         selectedElementType == SelectedElementType::Legend ? selectedElementId
                                                            : -1;
-    const int activeEventTableId =
+    const int selectedEventTableId =
         selectedElementType == SelectedElementType::EventTable
             ? selectedElementId
             : -1;
-    const int activeTextId =
+    const int selectedTextId =
         selectedElementType == SelectedElementType::Text ? selectedElementId
                                                          : -1;
-    const int activeImageId =
+    const int selectedImageId =
         selectedElementType == SelectedElementType::Image ? selectedElementId
                                                           : -1;
+
+    const int activeViewId = showDeferredResizeOverlay ? -1 : selectedViewId;
+    const int activeLegendId =
+        showDeferredResizeOverlay ? -1 : selectedLegendId;
+    const int activeEventTableId =
+        showDeferredResizeOverlay ? -1 : selectedEventTableId;
+    const int activeTextId = showDeferredResizeOverlay ? -1 : selectedTextId;
+    const int activeImageId =
+        showDeferredResizeOverlay ? -1 : selectedImageId;
 
     Viewer2DPanel *capturePanel = nullptr;
     Viewer2DOffscreenRenderer *offscreenRenderer = nullptr;
@@ -649,6 +661,9 @@ void LayoutViewerPanel::OnPaint(wxPaintEvent &) {
       }
     }
 
+    if (showDeferredResizeOverlay)
+      DrawDeferredResizeOverlay();
+
     const bool texturesReady = AreTexturesReady();
     auto hasTexture = [](const auto &cacheMap, int id) {
       auto it = cacheMap.find(id);
@@ -659,36 +674,36 @@ void LayoutViewerPanel::OnPaint(wxPaintEvent &) {
       if (!activeView) {
         activeElementHasTexture = false;
       } else {
-        activeElementHasTexture = hasTexture(viewCaches_, activeViewId);
+        activeElementHasTexture = hasTexture(viewCaches_, selectedViewId);
       }
     } else if (selectedElementType == SelectedElementType::Legend) {
-      const auto *legend = findLegendById(activeLegendId);
+      const auto *legend = findLegendById(selectedLegendId);
       if (!legend) {
         activeElementHasTexture = false;
       } else {
-        activeElementHasTexture = hasTexture(legendCaches_, activeLegendId);
+        activeElementHasTexture = hasTexture(legendCaches_, selectedLegendId);
       }
     } else if (selectedElementType == SelectedElementType::EventTable) {
-      const auto *table = findEventTableById(activeEventTableId);
+      const auto *table = findEventTableById(selectedEventTableId);
       if (!table) {
         activeElementHasTexture = false;
       } else {
         activeElementHasTexture =
-            hasTexture(eventTableCaches_, activeEventTableId);
+            hasTexture(eventTableCaches_, selectedEventTableId);
       }
     } else if (selectedElementType == SelectedElementType::Text) {
-      const auto *text = findTextById(activeTextId);
+      const auto *text = findTextById(selectedTextId);
       if (!text) {
         activeElementHasTexture = false;
       } else {
-        activeElementHasTexture = hasTexture(textCaches_, activeTextId);
+        activeElementHasTexture = hasTexture(textCaches_, selectedTextId);
       }
     } else if (selectedElementType == SelectedElementType::Image) {
-      const auto *image = findImageById(activeImageId);
+      const auto *image = findImageById(selectedImageId);
       if (!image) {
         activeElementHasTexture = false;
       } else {
-        activeElementHasTexture = hasTexture(imageCaches_, activeImageId);
+        activeElementHasTexture = hasTexture(imageCaches_, selectedImageId);
       }
     }
     const bool showLoadingOverlay =
@@ -749,6 +764,44 @@ void LayoutViewerPanel::DrawLoadingOverlay(const wxSize &size) {
   glVertex2f(x, y + textHeight);
   glEnd();
   glDisable(GL_TEXTURE_2D);
+}
+
+void LayoutViewerPanel::DrawDeferredResizeOverlay() {
+  if (!deferredResizeFrame_.has_value())
+    return;
+  if (dragMode == FrameDragMode::None || dragMode == FrameDragMode::Move)
+    return;
+
+  wxRect frameRect;
+  if (!GetFrameRect(*deferredResizeFrame_, frameRect))
+    return;
+
+  glColor4ub(160, 160, 160, 110);
+  glBegin(GL_QUADS);
+  glVertex2f(static_cast<float>(frameRect.GetLeft()),
+             static_cast<float>(frameRect.GetTop()));
+  glVertex2f(static_cast<float>(frameRect.GetRight()),
+             static_cast<float>(frameRect.GetTop()));
+  glVertex2f(static_cast<float>(frameRect.GetRight()),
+             static_cast<float>(frameRect.GetBottom()));
+  glVertex2f(static_cast<float>(frameRect.GetLeft()),
+             static_cast<float>(frameRect.GetBottom()));
+  glEnd();
+
+  glColor4ub(0, 128, 255, 255);
+  glLineWidth(2.0f);
+  glBegin(GL_LINE_LOOP);
+  glVertex2f(static_cast<float>(frameRect.GetLeft()),
+             static_cast<float>(frameRect.GetTop()));
+  glVertex2f(static_cast<float>(frameRect.GetRight()),
+             static_cast<float>(frameRect.GetTop()));
+  glVertex2f(static_cast<float>(frameRect.GetRight()),
+             static_cast<float>(frameRect.GetBottom()));
+  glVertex2f(static_cast<float>(frameRect.GetLeft()),
+             static_cast<float>(frameRect.GetBottom()));
+  glEnd();
+
+  DrawSelectionHandles(frameRect);
 }
 
 void LayoutViewerPanel::EnsureLoadingTextTexture() {
@@ -1094,6 +1147,7 @@ void LayoutViewerPanel::OnMouseMove(wxMouseEvent &event) {
       ApplyFrameUpdateToSelection(frame, true);
     } else {
       deferredResizeFrame_ = frame;
+      Refresh();
     }
     return;
   }

--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -880,6 +880,7 @@ void LayoutViewerPanel::OnSize(wxSizeEvent &) {
 
 void LayoutViewerPanel::OnLeftDown(wxMouseEvent &event) {
   SetFocus();
+  deferredResizeFrame_.reset();
   const wxPoint pos = event.GetPosition();
   SelectElementAtPosition(pos);
   layouts::Layout2DViewFrame selectedFrame;
@@ -906,6 +907,10 @@ void LayoutViewerPanel::OnLeftDown(wxMouseEvent &event) {
 
 void LayoutViewerPanel::OnLeftUp(wxMouseEvent &) {
   if (dragMode != FrameDragMode::None) {
+    if (dragMode != FrameDragMode::Move && deferredResizeFrame_.has_value()) {
+      ApplyFrameUpdateToSelection(*deferredResizeFrame_, false);
+    }
+    deferredResizeFrame_.reset();
     dragMode = FrameDragMode::None;
     layouts::LayoutManager::Get().EndBatchUpdate();
     if (HasCapture())
@@ -1084,16 +1089,11 @@ void LayoutViewerPanel::OnMouseMove(wxMouseEvent &event) {
         }
       }
     }
-    if (selectedElementType == SelectedElementType::Legend) {
-      UpdateLegendFrame(frame, dragMode == FrameDragMode::Move);
-    } else if (selectedElementType == SelectedElementType::EventTable) {
-      UpdateEventTableFrame(frame, dragMode == FrameDragMode::Move);
-    } else if (selectedElementType == SelectedElementType::Text) {
-      UpdateTextFrame(frame, dragMode == FrameDragMode::Move);
-    } else if (selectedElementType == SelectedElementType::Image) {
-      UpdateImageFrame(frame, dragMode == FrameDragMode::Move);
+    const bool updatePosition = dragMode == FrameDragMode::Move;
+    if (updatePosition) {
+      ApplyFrameUpdateToSelection(frame, true);
     } else {
-      UpdateFrame(frame, dragMode == FrameDragMode::Move);
+      deferredResizeFrame_ = frame;
     }
     return;
   }
@@ -1140,10 +1140,26 @@ void LayoutViewerPanel::OnMouseWheel(wxMouseEvent &event) {
 
 void LayoutViewerPanel::OnCaptureLost(wxMouseCaptureLostEvent &) {
   isPanning = false;
+  deferredResizeFrame_.reset();
   if (dragMode != FrameDragMode::None) {
     layouts::LayoutManager::Get().EndBatchUpdate();
   }
   dragMode = FrameDragMode::None;
+}
+
+void LayoutViewerPanel::ApplyFrameUpdateToSelection(
+    const layouts::Layout2DViewFrame &frame, bool updatePosition) {
+  if (selectedElementType == SelectedElementType::Legend) {
+    UpdateLegendFrame(frame, updatePosition);
+  } else if (selectedElementType == SelectedElementType::EventTable) {
+    UpdateEventTableFrame(frame, updatePosition);
+  } else if (selectedElementType == SelectedElementType::Text) {
+    UpdateTextFrame(frame, updatePosition);
+  } else if (selectedElementType == SelectedElementType::Image) {
+    UpdateImageFrame(frame, updatePosition);
+  } else {
+    UpdateFrame(frame, updatePosition);
+  }
 }
 
 void LayoutViewerPanel::OnRightUp(wxMouseEvent &event) {

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -149,6 +149,7 @@ private:
                        int activeTextId);
   void DrawImageElement(const layouts::LayoutImageDefinition &image,
                         int activeImageId);
+  void DrawDeferredResizeOverlay();
   void DrawLoadingOverlay(const wxSize &size);
   void EnsureLoadingTextTexture();
   void ClearLoadingTextTexture();

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -170,6 +170,8 @@ private:
                        bool updatePosition);
   void UpdateImageFrame(const layouts::Layout2DViewFrame &frame,
                         bool updatePosition);
+  void ApplyFrameUpdateToSelection(const layouts::Layout2DViewFrame &frame,
+                                   bool updatePosition);
   bool InitGL();
   void RebuildCachedTexture();
   void ClearCachedTexture();
@@ -270,6 +272,7 @@ private:
   FrameDragMode hoverMode = FrameDragMode::None;
   wxPoint dragStartPos{0, 0};
   layouts::Layout2DViewFrame dragStartFrame;
+  std::optional<layouts::Layout2DViewFrame> deferredResizeFrame_;
   int layoutVersion = 0;
   int viewRenderVersion = 0;
   bool captureInProgress = false;


### PR DESCRIPTION
### Motivation
- Resizing layout elements applied frame updates on every mouse move which triggered continuous repaints and produced choppy UI; the intent is to reduce repaint frequency during a resize interaction and only commit the change once the mouse is released.

### Description
- Added an optional `deferredResizeFrame_` field to `LayoutViewerPanel` to hold a temporary frame while the user is resizing an element.
- Introduced `ApplyFrameUpdateToSelection(...)` to centralize dispatching frame updates to the correct `Update*Frame` function for the currently selected element type.
- Changed `OnMouseMove` so that resize drags store the computed `frame` in `deferredResizeFrame_` instead of calling `UpdateFrame`/`UpdateLegendFrame`/etc. on every move, while move drags still apply updates immediately.
- Ensured `deferredResizeFrame_` is cleared on new drags (`OnLeftDown`) and capture loss (`OnCaptureLost`), and applied once on mouse release (`OnLeftUp`) while preserving the existing `BeginBatchUpdate`/`EndBatchUpdate` behavior.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b82b338e08324ae02263696626597)