### PR TITLE
Fix mouse capture release when closing layout viewer

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -315,6 +315,9 @@ LayoutViewerPanel::LayoutViewerPanel(wxWindow *parent)
 }
 
 LayoutViewerPanel::~LayoutViewerPanel() {
+  if (HasCapture()) {
+    ReleaseMouse();
+  }
   Unbind(wxEVT_TIMER, &LayoutViewerPanel::OnLoadingTimer, this,
          kLoadingTimerId);
   Unbind(wxEVT_TIMER, &LayoutViewerPanel::OnRenderDelayTimer, this,


### PR DESCRIPTION
### Motivation
- Release mouse capture in `LayoutViewerPanel` destructor to avoid the `wxMouseCapture::IsInCaptureStack(this)` assert and potential crash when closing the application during an active drag/resize.

### Description
- Add an explicit `if (HasCapture()) ReleaseMouse();` at the start of `LayoutViewerPanel::~LayoutViewerPanel()` in `gui/layoutviewerpanel.cpp` so the panel is removed from wx's capture stack before it is destroyed.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b870ad2e08324a45f051e9f047cca)