### PR TITLE
Use Perastage SVG symbols for 2D layout fixtures with mesh fallback

### DIFF
--- a/viewer3d/CMakeLists.txt
+++ b/viewer3d/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/render/opaque_fixture_pass.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/opaque_object_pass.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/opaque_pass_utils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/render/perastage_svg_symbol_builder.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/opaque_truss_pass.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/render_pipeline.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/scenerenderer.cpp

--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -18,6 +18,7 @@
 #include "matrixutils.h"
 #include "configmanager.h"
 #include "opaque_pass_utils.h"
+#include "perastage_svg_symbol_builder.h"
 #include "scenedatamanager.h"
 #include "viewer3dcontroller.h"
 
@@ -149,6 +150,14 @@ void OpaqueFixturePass::Render(
         const auto &symbol =
             controller.m_bottomSymbolCache.GetOrCreate(symbolKey, [&](const SymbolKey &,
                                                          uint32_t symbolId) {
+              SymbolDefinition svgDefinition{};
+              if (TryBuildPerastageSvgSymbolDefinition(gdtfPath,
+                                                       symbolKey.viewKind,
+                                                       symbolId,
+                                                       svgDefinition)) {
+                return svgDefinition;
+              }
+
               SymbolDefinition definition{};
               definition.symbolId = symbolId;
               auto localCanvas =

--- a/viewer3d/render/perastage_svg_symbol_builder.cpp
+++ b/viewer3d/render/perastage_svg_symbol_builder.cpp
@@ -1,0 +1,88 @@
+#include "perastage_svg_symbol_builder.h"
+
+#include <vector>
+
+#include "opaque_pass_utils.h"
+#include "symbols/PerastageSvgSymbol.h"
+
+namespace {
+constexpr float kDefaultStrokeWidth = 1.0f;
+
+void AppendSvgPolygon(const PerastageSvgPolygon &polygon, CommandBuffer &buffer) {
+  if (polygon.points.size() < 3)
+    return;
+
+  PolygonCommand poly{};
+  poly.points.reserve(polygon.points.size() * 2);
+  for (const auto &point : polygon.points) {
+    poly.points.push_back(static_cast<float>(point.x));
+    poly.points.push_back(static_cast<float>(point.y));
+  }
+  poly.stroke.color = {0.0f, 0.0f, 0.0f, 1.0f};
+  poly.stroke.width = kDefaultStrokeWidth;
+  poly.fill.color = {0.878f, 0.878f, 0.878f, 1.0f};
+  poly.hasFill = true;
+
+  buffer.commands.emplace_back(std::move(poly));
+  buffer.metadata.push_back({true, true});
+  buffer.sources.push_back("svg");
+}
+
+void AppendSvgPolyline(const PerastageSvgPolyline &line, CommandBuffer &buffer) {
+  if (line.points.size() < 2)
+    return;
+
+  PolylineCommand polyline{};
+  polyline.points.reserve(line.points.size() * 2);
+  for (const auto &point : line.points) {
+    polyline.points.push_back(static_cast<float>(point.x));
+    polyline.points.push_back(static_cast<float>(point.y));
+  }
+  polyline.stroke.color = {0.0f, 0.0f, 0.0f, 1.0f};
+  polyline.stroke.width = kDefaultStrokeWidth;
+
+  buffer.commands.emplace_back(std::move(polyline));
+  buffer.metadata.push_back({true, false});
+  buffer.sources.push_back("svg");
+}
+} // namespace
+
+bool TryBuildPerastageSvgSymbolDefinition(const std::string &gdtfPath,
+                                          SymbolViewKind viewKind,
+                                          uint32_t symbolId,
+                                          SymbolDefinition &out) {
+  PerastageSvgSymbolData svg;
+  if (!LoadPerastageSvgSymbolFromGdtf(gdtfPath, viewKind, svg))
+    return false;
+  if (!svg.IsValid())
+    return false;
+
+  out = SymbolDefinition{};
+  out.symbolId = symbolId;
+  out.localCommands.currentSourceKey = "svg";
+
+  for (const auto &polygon : svg.fills)
+    AppendSvgPolygon(polygon, out.localCommands);
+  for (const auto &line : svg.strokes)
+    AppendSvgPolyline(line, out.localCommands);
+
+  if (out.localCommands.commands.empty())
+    return false;
+
+  for (auto &cmd : out.localCommands.commands) {
+    if (auto *polygon = std::get_if<PolygonCommand>(&cmd)) {
+      for (size_t i = 0; i + 1 < polygon->points.size(); i += 2) {
+        polygon->points[i] += static_cast<float>(svg.offsetXmm);
+        polygon->points[i + 1] += static_cast<float>(svg.offsetYmm);
+      }
+    } else if (auto *polyline = std::get_if<PolylineCommand>(&cmd)) {
+      for (size_t i = 0; i + 1 < polyline->points.size(); i += 2) {
+        polyline->points[i] += static_cast<float>(svg.offsetXmm);
+        polyline->points[i + 1] += static_cast<float>(svg.offsetYmm);
+      }
+    }
+  }
+
+  out.bounds = ComputeSymbolBounds(out.localCommands);
+  return true;
+}

--- a/viewer3d/render/perastage_svg_symbol_builder.h
+++ b/viewer3d/render/perastage_svg_symbol_builder.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <string>
+
+#include "symbolcache.h"
+
+bool TryBuildPerastageSvgSymbolDefinition(const std::string &gdtfPath,
+                                          SymbolViewKind viewKind,
+                                          uint32_t symbolId,
+                                          SymbolDefinition &out);


### PR DESCRIPTION
### Motivation
- Make layout editor 2D view elements behave like legends by reusing Perastage/GDTF SVG symbols when available so identical models instantiate the same 2D symbol; keep the existing mesh/cube capture flow as a fallback when no SVG exists or is invalid.

### Description
- Add a small helper `perastage_svg_symbol_builder` (`viewer3d/render/perastage_svg_symbol_builder.{h,cpp}`) that loads Perastage SVG from a GDTF, converts fills and strokes to `CommandBuffer` commands, applies model offsets and computes symbol bounds. 
- Update the fixture capture path in `viewer3d/render/opaque_fixture_pass.cpp` to try building an SVG-backed `SymbolDefinition` first and return it to the bottom-symbol cache when successful. 
- Register the new source file in `viewer3d/CMakeLists.txt` to keep explicit source ownership and module boundaries intact.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b892fcef883249d34468bfa85b40e)