### PR TITLE
Preserve truss model-file names without rewriting them

### DIFF
--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -126,38 +126,6 @@ static std::string SanitizeArchiveFileName(const std::string &input,
   return fallbackName;
 }
 
-static std::string ExportSafeTrussModelFile(const std::string &modelFile) {
-  std::string candidate = TrimAscii(modelFile);
-  if (candidate.empty())
-    return {};
-
-  const bool hasDriveLetter = candidate.size() >= 2 && std::isalpha(candidate[0]) != 0 &&
-                              candidate[1] == ':';
-  const bool hasAbsolutePrefix = candidate.front() == '/' || candidate.front() == '\\' ||
-                                 candidate.rfind("//", 0) == 0 ||
-                                 candidate.rfind("\\\\", 0) == 0;
-  const bool isAbsolutePath = hasAbsolutePrefix || fs::path(candidate).is_absolute();
-
-  if (isAbsolutePath || hasDriveLetter) {
-    std::replace(candidate.begin(), candidate.end(), '\\', '/');
-    while (!candidate.empty() && candidate.back() == '/')
-      candidate.pop_back();
-    const size_t sep = candidate.find_last_of('/');
-    candidate = sep == std::string::npos ? candidate : candidate.substr(sep + 1);
-  }
-
-  candidate = TrimAscii(candidate);
-  if (candidate.empty() || candidate.find(':') != std::string::npos)
-    return {};
-
-  if (candidate.front() == '/' || candidate.front() == '\\' ||
-      candidate.rfind("//", 0) == 0 || candidate.rfind("\\\\", 0) == 0)
-    return {};
-
-  return candidate;
-}
-
-
 static bool IsValidMvrFileName(const std::string &value) {
   if (value.empty())
     return false;
@@ -1143,7 +1111,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
       addNum("Height", t.heightMm, "mm");
       addNum("Weight", t.weightKg, "kg");
       addTxt("CrossSection", t.crossSection);
-      addTxt("ModelFile", ExportSafeTrussModelFile(t.modelFile));
+      addTxt("ModelFile", t.modelFile);
       addTxt("HangPos", t.positionName);
       data->InsertEndChild(info);
       ud->InsertEndChild(data);

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -915,7 +915,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
               if (tinyxml2::XMLElement *mf =
                       info->FirstChildElement("ModelFile"))
                 if (mf->GetText())
-                  truss.modelFile = Trim(mf->GetText());
+                  truss.modelFile = mf->GetText();
               if (tinyxml2::XMLElement *hp = info->FirstChildElement("HangPos"))
                 if (hp->GetText())
                   truss.positionName = Trim(hp->GetText());

--- a/viewer3d/render/opaque_truss_pass.cpp
+++ b/viewer3d/render/opaque_truss_pass.cpp
@@ -150,7 +150,7 @@ void OpaqueTrussPass::Render(
 
       if (!modelKey.empty()) {
         SymbolKey symbolKey;
-        symbolKey.modelKey = "truss:" + modelKey;
+        symbolKey.modelKey = modelKey;
         symbolKey.viewKind = resolveSymbolView(captureView);
         symbolKey.styleVersion = 1;
 


### PR DESCRIPTION
### Motivation
- Fix incorrect transformation of truss model paths/keys that produced invalid references like `truss:C:\...\main.3ds` on Windows, causing downstream model loads to fail. 
- Keep the canonical names used in the Trusses table, `ModelFile`, and MVR round-trip stable and unmodified during import/export/rendering.

### Description
- Stop prefixing the symbol cache key with `truss:` in `viewer3d/render/opaque_truss_pass.cpp` so `modelKey` remains exactly the chosen name/path. 
- Preserve `TrussInfo/ModelFile` text exactly when exporting MVR by writing `t.modelFile` unchanged in `mvr/mvrexporter.cpp`. 
- Preserve `TrussInfo/ModelFile` text exactly when importing MVR by assigning the XML text directly to `truss.modelFile` (no `Trim`) in `mvr/mvrimporter.cpp`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c6796f20083248b6a1db58e4dc3b9)