### PR TITLE
Fix legend symbol spacing and reduce empty left column space

### DIFF
--- a/gui/layoutviewerpanel_legend.cpp
+++ b/gui/layoutviewerpanel_legend.cpp
@@ -48,7 +48,7 @@ constexpr int kLegendSymbolSizePx =
     static_cast<int>(64 * kLegendContentScale);
 constexpr double kLegendFallbackSymbolScale = 2.0;
 constexpr double kLegendSvgSymbolScale = 0.4;
-constexpr double kLegendMaxSymbolSlotScale = 2.4;
+constexpr double kLegendMaxSymbolSlotScale = 1.45;
 
 int SymbolViewRank(SymbolViewKind kind) {
   switch (kind) {
@@ -986,11 +986,15 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   const int maxSymbolColumnSize =
       std::max(4, static_cast<int>(std::lround(symbolSize *
                                                kLegendMaxSymbolSlotScale)));
+  const double maxMeasuredSymbolColumnWidth = static_cast<double>(maxSymbolColumnSize);
   const int topSymbolColumnSize = std::clamp(
-      static_cast<int>(std::ceil(maxTopSymbolColumnWidth * kLegendSymbolColumnScale)),
+      static_cast<int>(std::ceil(std::min(maxTopSymbolColumnWidth,
+                                          maxMeasuredSymbolColumnWidth) *
+                                 kLegendSymbolColumnScale)),
       0, maxSymbolColumnSize);
   const int frontSymbolColumnSize = std::clamp(
-      static_cast<int>(std::ceil(maxFrontSymbolColumnWidth *
+      static_cast<int>(std::ceil(std::min(maxFrontSymbolColumnWidth,
+                                          maxMeasuredSymbolColumnWidth) *
                                  kLegendSymbolColumnScale)),
       0, maxSymbolColumnSize);
   const int rowHeightPx = baseRowHeightPx;
@@ -1158,7 +1162,8 @@ wxImage LayoutViewerPanel::BuildLegendImage(
             y + (static_cast<double>(rowHeightPx) - topDrawH) * 0.5;
         const double symbolDrawLeft =
             xTopSymbol +
-            std::max(0.0, static_cast<double>(topSymbolColumnSize) - topDrawW);
+            std::max(0.0, (static_cast<double>(topSymbolColumnSize) - topDrawW) *
+                                 0.5);
         if (topSvg)
           drawSvg(topSvg, item.symbolFillHex, symbolDrawLeft, symbolDrawTop, pairScaleSvg);
         else
@@ -1167,7 +1172,10 @@ wxImage LayoutViewerPanel::BuildLegendImage(
       if (frontDrawW > 0.0) {
         const double symbolDrawTop =
             y + (static_cast<double>(rowHeightPx) - frontDrawH) * 0.5;
-        const double symbolDrawLeft = xFrontSymbol;
+        const double symbolDrawLeft =
+            xFrontSymbol +
+            std::max(0.0, (static_cast<double>(frontSymbolColumnSize) - frontDrawW) *
+                                 0.5);
         if (frontSvg)
           drawSvg(frontSvg, item.symbolFillHex, symbolDrawLeft, symbolDrawTop, pairScaleSvg);
         else

--- a/gui/layoutviewerpanel_legend.cpp
+++ b/gui/layoutviewerpanel_legend.cpp
@@ -957,7 +957,8 @@ wxImage LayoutViewerPanel::BuildLegendImage(
     return std::min(topScale, frontScale);
   };
 
-  double maxSymbolColumnWidth = symbolSize;
+  double maxTopSymbolColumnWidth = 0.0;
+  double maxFrontSymbolColumnWidth = 0.0;
   for (const auto &item : items) {
     if (item.symbolKey.empty())
       continue;
@@ -979,15 +980,19 @@ wxImage LayoutViewerPanel::BuildLegendImage(
             ? frontSvg->viewBoxWidth * pairScaleSvg
             : (frontSvg ? symbolDrawWidthSvg(frontSvg)
                         : symbolDrawWidth(frontSymbol));
-    maxSymbolColumnWidth = std::max(maxSymbolColumnWidth, topDrawW);
-    maxSymbolColumnWidth = std::max(maxSymbolColumnWidth, frontDrawW);
+    maxTopSymbolColumnWidth = std::max(maxTopSymbolColumnWidth, topDrawW);
+    maxFrontSymbolColumnWidth = std::max(maxFrontSymbolColumnWidth, frontDrawW);
   }
   const int maxSymbolColumnSize =
       std::max(4, static_cast<int>(std::lround(symbolSize *
                                                kLegendMaxSymbolSlotScale)));
-  const int symbolColumnSize = std::clamp(
-      static_cast<int>(std::ceil(maxSymbolColumnWidth * kLegendSymbolColumnScale)),
-      4, maxSymbolColumnSize);
+  const int topSymbolColumnSize = std::clamp(
+      static_cast<int>(std::ceil(maxTopSymbolColumnWidth * kLegendSymbolColumnScale)),
+      0, maxSymbolColumnSize);
+  const int frontSymbolColumnSize = std::clamp(
+      static_cast<int>(std::ceil(maxFrontSymbolColumnWidth *
+                                 kLegendSymbolColumnScale)),
+      0, maxSymbolColumnSize);
   const int rowHeightPx = baseRowHeightPx;
   const int paddingLeftPx =
       std::max(0, static_cast<int>(std::lround(paddingLeft * renderZoom)));
@@ -1002,8 +1007,8 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   const int symbolColumnGapPx =
       std::max(0, static_cast<int>(std::lround(symbolColumnGap * renderZoom)));
   int xTopSymbol = std::max(0, paddingLeftPx - leftTrimPx);
-  int xFrontSymbol = xTopSymbol + symbolColumnSize + symbolColumnGapPx;
-  int xCount = xFrontSymbol + symbolColumnSize + columnGapPx;
+  int xFrontSymbol = xTopSymbol + topSymbolColumnSize + symbolColumnGapPx;
+  int xCount = xFrontSymbol + frontSymbolColumnSize + columnGapPx;
   int xType = xCount + maxCountWidth + columnGapPx;
   int xCh = size.GetWidth() - paddingRightPx - maxChWidth;
   if (xCh < xType + columnGapPx)
@@ -1031,8 +1036,6 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   int y = paddingTopPx;
   const int textOffset = std::max(0, (rowHeightPx - textHeight) / 2);
   dc.SetFont(headerFont);
-  dc.DrawText("Top", xTopSymbol, y + textOffset);
-  dc.DrawText("Front", xFrontSymbol, y + textOffset);
   dc.DrawText("Count", xCount, y + textOffset);
   dc.DrawText("Type", xType, y + textOffset);
   dc.DrawText("Ch", xCh, y + textOffset);
@@ -1155,7 +1158,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
             y + (static_cast<double>(rowHeightPx) - topDrawH) * 0.5;
         const double symbolDrawLeft =
             xTopSymbol +
-            std::max(0.0, (static_cast<double>(symbolColumnSize) - topDrawW) * 0.5);
+            std::max(0.0, (static_cast<double>(topSymbolColumnSize) - topDrawW) * 0.5);
         if (topSvg)
           drawSvg(topSvg, item.symbolFillHex, symbolDrawLeft, symbolDrawTop, pairScaleSvg);
         else
@@ -1166,7 +1169,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
             y + (static_cast<double>(rowHeightPx) - frontDrawH) * 0.5;
         const double symbolDrawLeft =
             xFrontSymbol +
-            std::max(0.0, (static_cast<double>(symbolColumnSize) - frontDrawW) * 0.5);
+            std::max(0.0, (static_cast<double>(frontSymbolColumnSize) - frontDrawW) * 0.5);
         if (frontSvg)
           drawSvg(frontSvg, item.symbolFillHex, symbolDrawLeft, symbolDrawTop, pairScaleSvg);
         else

--- a/gui/layoutviewerpanel_legend.cpp
+++ b/gui/layoutviewerpanel_legend.cpp
@@ -782,8 +782,8 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   const int paddingRight = 4;
   const int paddingTop = 6;
   const int paddingBottom = 2;
-  const int columnGap = 8;
-  const int symbolColumnGap = 2;
+  const int columnGap = 6;
+  const int symbolColumnGap = 1;
   constexpr double kLegendLineSpacingScale = 1.0;
   constexpr double kLegendSymbolColumnScale = 1.0;
   const int totalRows = static_cast<int>(items.size()) + 1;
@@ -1158,7 +1158,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
             y + (static_cast<double>(rowHeightPx) - topDrawH) * 0.5;
         const double symbolDrawLeft =
             xTopSymbol +
-            std::max(0.0, (static_cast<double>(topSymbolColumnSize) - topDrawW) * 0.5);
+            std::max(0.0, static_cast<double>(topSymbolColumnSize) - topDrawW);
         if (topSvg)
           drawSvg(topSvg, item.symbolFillHex, symbolDrawLeft, symbolDrawTop, pairScaleSvg);
         else
@@ -1167,9 +1167,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
       if (frontDrawW > 0.0) {
         const double symbolDrawTop =
             y + (static_cast<double>(rowHeightPx) - frontDrawH) * 0.5;
-        const double symbolDrawLeft =
-            xFrontSymbol +
-            std::max(0.0, (static_cast<double>(frontSymbolColumnSize) - frontDrawW) * 0.5);
+        const double symbolDrawLeft = xFrontSymbol;
         if (frontSvg)
           drawSvg(frontSvg, item.symbolFillHex, symbolDrawLeft, symbolDrawTop, pairScaleSvg);
         else

--- a/gui/layoutviewerpanel_legend.cpp
+++ b/gui/layoutviewerpanel_legend.cpp
@@ -48,8 +48,6 @@ constexpr int kLegendSymbolSizePx =
     static_cast<int>(64 * kLegendContentScale);
 constexpr double kLegendFallbackSymbolScale = 2.0;
 constexpr double kLegendSvgSymbolScale = 0.4;
-constexpr double kLegendFallbackPairOverlapScale = 0.85;
-constexpr double kLegendSvgPairGapScale = 0.18;
 constexpr double kLegendMaxSymbolSlotScale = 2.4;
 
 int SymbolViewRank(SymbolViewKind kind) {
@@ -878,11 +876,6 @@ wxImage LayoutViewerPanel::BuildLegendImage(
       std::max(4.0, static_cast<double>(symbolSize) * kLegendFallbackSymbolScale);
   const double svgSymbolSize =
       std::max(4.0, static_cast<double>(symbolSize) * kLegendSvgSymbolScale);
-  const double fallbackSymbolPairGapPx =
-      -std::max(1.0, static_cast<double>(symbolSize) *
-                         kLegendFallbackPairOverlapScale);
-  const double svgSymbolPairGapPx =
-      std::max(1.0, static_cast<double>(symbolSize) * kLegendSvgPairGapScale);
   auto symbolDrawWidth = [&](const SymbolDefinition *symbol) -> double {
     if (!symbol)
       return 0.0;
@@ -964,45 +957,37 @@ wxImage LayoutViewerPanel::BuildLegendImage(
     return std::min(topScale, frontScale);
   };
 
-  auto pairGapForRow = [&](const PerastageSvgSymbolData *topSvg,
-                           const PerastageSvgSymbolData *frontSvg) {
-    if (topSvg && frontSvg)
-      return svgSymbolPairGapPx;
-    return fallbackSymbolPairGapPx;
-  };
-  double maxSymbolPairWidth = symbolSize;
+  double maxSymbolColumnWidth = symbolSize;
   for (const auto &item : items) {
-      if (item.symbolKey.empty())
-        continue;
-      const PerastageSvgSymbolData *topSvg =
-          findSvgSymbol(item.symbolKey, SymbolViewKind::Top);
-      const PerastageSvgSymbolData *frontSvg =
-          findSvgSymbol(item.symbolKey, SymbolViewKind::Front);
-      const SymbolDefinition *topSymbol = FindSymbolDefinitionPreferred(
-          symbols, item.symbolKey, SymbolViewKind::Top);
-      const SymbolDefinition *frontSymbol = FindSymbolDefinitionExact(
-          symbols, item.symbolKey, SymbolViewKind::Front);
-      const double pairScaleSvg = sharedPairScaleSvg(topSvg, frontSvg);
-      const double topDrawW =
-          (topSvg && pairScaleSvg > 0.0)
-              ? topSvg->viewBoxWidth * pairScaleSvg
-              : (topSvg ? symbolDrawWidthSvg(topSvg) : symbolDrawWidth(topSymbol));
-      const double frontDrawW =
-          (frontSvg && pairScaleSvg > 0.0)
-              ? frontSvg->viewBoxWidth * pairScaleSvg
-              : (frontSvg ? symbolDrawWidthSvg(frontSvg)
-                          : symbolDrawWidth(frontSymbol));
-      double rowPairWidth = std::max(topDrawW, frontDrawW);
-      if (topDrawW > 0.0 && frontDrawW > 0.0)
-        rowPairWidth = topDrawW + frontDrawW + pairGapForRow(topSvg, frontSvg);
-      maxSymbolPairWidth = std::max(maxSymbolPairWidth, rowPairWidth);
-    }
-  const int maxSymbolSlotSize =
+    if (item.symbolKey.empty())
+      continue;
+    const PerastageSvgSymbolData *topSvg =
+        findSvgSymbol(item.symbolKey, SymbolViewKind::Top);
+    const PerastageSvgSymbolData *frontSvg =
+        findSvgSymbol(item.symbolKey, SymbolViewKind::Front);
+    const SymbolDefinition *topSymbol =
+        FindSymbolDefinitionPreferred(symbols, item.symbolKey, SymbolViewKind::Top);
+    const SymbolDefinition *frontSymbol =
+        FindSymbolDefinitionExact(symbols, item.symbolKey, SymbolViewKind::Front);
+    const double pairScaleSvg = sharedPairScaleSvg(topSvg, frontSvg);
+    const double topDrawW =
+        (topSvg && pairScaleSvg > 0.0)
+            ? topSvg->viewBoxWidth * pairScaleSvg
+            : (topSvg ? symbolDrawWidthSvg(topSvg) : symbolDrawWidth(topSymbol));
+    const double frontDrawW =
+        (frontSvg && pairScaleSvg > 0.0)
+            ? frontSvg->viewBoxWidth * pairScaleSvg
+            : (frontSvg ? symbolDrawWidthSvg(frontSvg)
+                        : symbolDrawWidth(frontSymbol));
+    maxSymbolColumnWidth = std::max(maxSymbolColumnWidth, topDrawW);
+    maxSymbolColumnWidth = std::max(maxSymbolColumnWidth, frontDrawW);
+  }
+  const int maxSymbolColumnSize =
       std::max(4, static_cast<int>(std::lround(symbolSize *
                                                kLegendMaxSymbolSlotScale)));
-  const int symbolSlotSize = std::clamp(
-      static_cast<int>(std::ceil(maxSymbolPairWidth * kLegendSymbolColumnScale)),
-      4, maxSymbolSlotSize);
+  const int symbolColumnSize = std::clamp(
+      static_cast<int>(std::ceil(maxSymbolColumnWidth * kLegendSymbolColumnScale)),
+      4, maxSymbolColumnSize);
   const int rowHeightPx = baseRowHeightPx;
   const int paddingLeftPx =
       std::max(0, static_cast<int>(std::lround(paddingLeft * renderZoom)));
@@ -1016,8 +1001,9 @@ wxImage LayoutViewerPanel::BuildLegendImage(
       std::max(0, static_cast<int>(std::lround(columnGap * renderZoom)));
   const int symbolColumnGapPx =
       std::max(0, static_cast<int>(std::lround(symbolColumnGap * renderZoom)));
-  int xSymbol = paddingLeftPx - leftTrimPx;
-  int xCount = xSymbol + symbolSlotSize + symbolColumnGapPx;
+  int xTopSymbol = std::max(0, paddingLeftPx - leftTrimPx);
+  int xFrontSymbol = xTopSymbol + symbolColumnSize + symbolColumnGapPx;
+  int xCount = xFrontSymbol + symbolColumnSize + columnGapPx;
   int xType = xCount + maxCountWidth + columnGapPx;
   int xCh = size.GetWidth() - paddingRightPx - maxChWidth;
   if (xCh < xType + columnGapPx)
@@ -1045,13 +1031,15 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   int y = paddingTopPx;
   const int textOffset = std::max(0, (rowHeightPx - textHeight) / 2);
   dc.SetFont(headerFont);
+  dc.DrawText("Top", xTopSymbol, y + textOffset);
+  dc.DrawText("Front", xFrontSymbol, y + textOffset);
   dc.DrawText("Count", xCount, y + textOffset);
   dc.DrawText("Type", xType, y + textOffset);
   dc.DrawText("Ch", xCh, y + textOffset);
 
   y += rowHeightPx;
   dc.SetPen(wxPen(wxColour(200, 200, 200)));
-  dc.DrawLine(xSymbol, y, size.GetWidth() - paddingRightPx, y);
+  dc.DrawLine(xTopSymbol, y, size.GetWidth() - paddingRightPx, y);
   y += separatorGapPx;
 
   dc.SetFont(baseFont);
@@ -1162,46 +1150,27 @@ wxImage LayoutViewerPanel::BuildLegendImage(
                                     ? frontSvg->viewBoxHeight * pairScaleSvg
                                     : (frontSvg ? symbolDrawHeightSvg(frontSvg)
                                                 : symbolDrawHeight(frontSymbol));
-      if (topDrawW > 0.0 || frontDrawW > 0.0) {
-        const double slotWidth = static_cast<double>(symbolSlotSize);
-        double rowPairWidth = std::max(topDrawW, frontDrawW);
-        if (topDrawW > 0.0 && frontDrawW > 0.0)
-          rowPairWidth = topDrawW + frontDrawW + pairGapForRow(topSvg, frontSvg);
-        const double rowStart =
-            xSymbol + std::max(0.0, (slotWidth - rowPairWidth) * 0.5);
-        double leftSlotWidth = rowPairWidth;
-        double rightSlotWidth = rowPairWidth;
-        double topSlotLeft = rowStart;
-        double frontSlotLeft = rowStart;
-        if (topDrawW > 0.0 && frontDrawW > 0.0) {
-          leftSlotWidth = topDrawW;
-          rightSlotWidth = frontDrawW;
-          frontSlotLeft =
-              rowStart + topDrawW + pairGapForRow(topSvg, frontSvg);
-        } else if (frontDrawW > 0.0) {
-          frontSlotLeft = rowStart;
-        }
-        if (topDrawW > 0.0) {
-          double symbolDrawTop =
-              y + (static_cast<double>(rowHeightPx) - topDrawH) * 0.5;
-          double symbolDrawLeft =
-              topSlotLeft + std::max(0.0, (leftSlotWidth - topDrawW) * 0.5);
-          if (topSvg)
-            drawSvg(topSvg, item.symbolFillHex, symbolDrawLeft, symbolDrawTop, pairScaleSvg);
-          else
-            drawSymbol(topSymbol, symbolDrawLeft, symbolDrawTop);
-        }
-        if (frontDrawW > 0.0) {
-          double symbolDrawTop =
-              y + (static_cast<double>(rowHeightPx) - frontDrawH) * 0.5;
-          double symbolDrawLeft =
-              frontSlotLeft +
-              std::max(0.0, (rightSlotWidth - frontDrawW) * 0.5);
-          if (frontSvg)
-            drawSvg(frontSvg, item.symbolFillHex, symbolDrawLeft, symbolDrawTop, pairScaleSvg);
-          else
-            drawSymbol(frontSymbol, symbolDrawLeft, symbolDrawTop);
-        }
+      if (topDrawW > 0.0) {
+        const double symbolDrawTop =
+            y + (static_cast<double>(rowHeightPx) - topDrawH) * 0.5;
+        const double symbolDrawLeft =
+            xTopSymbol +
+            std::max(0.0, (static_cast<double>(symbolColumnSize) - topDrawW) * 0.5);
+        if (topSvg)
+          drawSvg(topSvg, item.symbolFillHex, symbolDrawLeft, symbolDrawTop, pairScaleSvg);
+        else
+          drawSymbol(topSymbol, symbolDrawLeft, symbolDrawTop);
+      }
+      if (frontDrawW > 0.0) {
+        const double symbolDrawTop =
+            y + (static_cast<double>(rowHeightPx) - frontDrawH) * 0.5;
+        const double symbolDrawLeft =
+            xFrontSymbol +
+            std::max(0.0, (static_cast<double>(symbolColumnSize) - frontDrawW) * 0.5);
+        if (frontSvg)
+          drawSvg(frontSvg, item.symbolFillHex, symbolDrawLeft, symbolDrawTop, pairScaleSvg);
+        else
+          drawSymbol(frontSymbol, symbolDrawLeft, symbolDrawTop);
       }
     }
     dc.DrawText(rowText.countText, xCount, y + textOffset);

--- a/gui/layoutviewerpanel_legend.cpp
+++ b/gui/layoutviewerpanel_legend.cpp
@@ -1114,7 +1114,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
       const PerastageSvgSymbolData *frontSvg =
           findSvgSymbol(item.symbolKey, SymbolViewKind::Front);
       auto drawSymbol = [&](const SymbolDefinition *symbol, double drawCenterX,
-                            double drawCenterY) {
+                            double drawTop) {
         if (!symbol)
           return;
         const float symbolW = symbol->bounds.max.x - symbol->bounds.min.x;
@@ -1130,8 +1130,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
         mapping.scale = scale;
         mapping.offsetX =
             drawCenterX - (0.0 - static_cast<double>(mapping.minX)) * mapping.scale;
-        mapping.offsetY = drawCenterY - drawH -
-                          (0.0 - static_cast<double>(mapping.minY)) * mapping.scale;
+        mapping.offsetY = drawTop;
         mapping.drawHeight = drawH;
         backend.SetStrokeScale(
             mapping.scale > 0.0 ? 1.0 / mapping.scale : 1.0);
@@ -1210,7 +1209,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
         else
           drawSymbol(topSymbol,
                      xTopSymbol + static_cast<double>(topSymbolColumnSize) * 0.5,
-                     y + static_cast<double>(rowHeightPx) * 0.5);
+                     symbolDrawTop);
       }
       if (frontDrawW > 0.0) {
         const double symbolDrawTop =
@@ -1224,7 +1223,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
         else
           drawSymbol(frontSymbol,
                      xFrontSymbol + static_cast<double>(frontSymbolColumnSize) * 0.5,
-                     y + static_cast<double>(rowHeightPx) * 0.5);
+                     symbolDrawTop);
       }
     }
     dc.DrawText(rowText.countText, xCount, y + textOffset);

--- a/gui/layoutviewerpanel_legend.cpp
+++ b/gui/layoutviewerpanel_legend.cpp
@@ -1027,7 +1027,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   const int maxSymbolColumnSize =
       std::max(4, static_cast<int>(std::lround(symbolSize *
                                                kLegendMaxSymbolSlotScale)));
-  const int limitedSymbolColumnSize = std::max(4, maxSymbolColumnSize / 2);
+  const int limitedSymbolColumnSize = std::max(4, (maxSymbolColumnSize * 2) / 5);
   const double maxMeasuredSymbolColumnWidth =
       static_cast<double>(limitedSymbolColumnSize);
   const int topSymbolColumnSize = std::clamp(
@@ -1083,12 +1083,6 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   int y = paddingTopPx;
   const int textOffset = std::max(0, (rowHeightPx - textHeight) / 2);
   dc.SetFont(headerFont);
-  const int topHeaderX =
-      xTopSymbol + std::max(0, (topSymbolColumnSize - measureTextWidth("I")) / 2);
-  const int frontHeaderX = xFrontSymbol +
-                           std::max(0, (frontSymbolColumnSize - measureTextWidth("I")) / 2);
-  dc.DrawText("I", topHeaderX, y + textOffset);
-  dc.DrawText("I", frontHeaderX, y + textOffset);
   dc.DrawText("Count", xCount, y + textOffset);
   dc.DrawText("Type", xType, y + textOffset);
   dc.DrawText("Ch", xCh, y + textOffset);

--- a/gui/layoutviewerpanel_legend.cpp
+++ b/gui/layoutviewerpanel_legend.cpp
@@ -932,29 +932,77 @@ wxImage LayoutViewerPanel::BuildLegendImage(
     }
     return cacheIt->second ? &cacheIt->second.value() : nullptr;
   };
-  auto symbolDrawWidthSvg = [&](const PerastageSvgSymbolData *symbol) -> double {
-    if (!symbol || symbol->viewBoxWidth <= 0.0 || symbol->viewBoxHeight <= 0.0)
+  struct SvgGeometryMetrics {
+    bool valid = false;
+    double minX = 0.0;
+    double minY = 0.0;
+    double width = 0.0;
+    double height = 0.0;
+  };
+  auto svgGeometryMetrics =
+      [&](const PerastageSvgSymbolData *symbol) -> SvgGeometryMetrics {
+    SvgGeometryMetrics metrics;
+    if (!symbol)
+      return metrics;
+
+    bool hasPoint = false;
+    double minX = 0.0;
+    double minY = 0.0;
+    double maxX = 0.0;
+    double maxY = 0.0;
+    auto includePoint = [&](const PerastageSvgPoint &pt) {
+      if (!hasPoint) {
+        minX = maxX = pt.x;
+        minY = maxY = pt.y;
+        hasPoint = true;
+        return;
+      }
+      minX = std::min(minX, pt.x);
+      minY = std::min(minY, pt.y);
+      maxX = std::max(maxX, pt.x);
+      maxY = std::max(maxY, pt.y);
+    };
+
+    for (const auto &polygon : symbol->fills) {
+      for (const auto &pt : polygon.points)
+        includePoint(pt);
+      for (const auto &hole : polygon.holes)
+        for (const auto &pt : hole)
+          includePoint(pt);
+    }
+    for (const auto &line : symbol->strokes)
+      for (const auto &pt : line.points)
+        includePoint(pt);
+
+    if (!hasPoint)
+      return metrics;
+
+    metrics.minX = minX;
+    metrics.minY = minY;
+    metrics.width = std::max(0.0, maxX - minX);
+    metrics.height = std::max(0.0, maxY - minY);
+    metrics.valid = metrics.width > 0.0 && metrics.height > 0.0;
+    return metrics;
+  };
+  auto svgScaleForDraw = [&](const PerastageSvgSymbolData *symbol) -> double {
+    SvgGeometryMetrics metrics = svgGeometryMetrics(symbol);
+    if (!metrics.valid)
       return 0.0;
-    const double scale = std::min(svgSymbolSize / symbol->viewBoxWidth,
-                                  svgSymbolSize / symbol->viewBoxHeight);
-    return symbol->viewBoxWidth * scale;
+    return std::min(svgSymbolSize / metrics.width, svgSymbolSize / metrics.height);
+  };
+  auto symbolDrawWidthSvg = [&](const PerastageSvgSymbolData *symbol) -> double {
+    SvgGeometryMetrics metrics = svgGeometryMetrics(symbol);
+    const double scale = svgScaleForDraw(symbol);
+    if (!metrics.valid || scale <= 0.0)
+      return 0.0;
+    return metrics.width * scale;
   };
   auto symbolDrawHeightSvg = [&](const PerastageSvgSymbolData *symbol) -> double {
-    if (!symbol || symbol->viewBoxWidth <= 0.0 || symbol->viewBoxHeight <= 0.0)
+    SvgGeometryMetrics metrics = svgGeometryMetrics(symbol);
+    const double scale = svgScaleForDraw(symbol);
+    if (!metrics.valid || scale <= 0.0)
       return 0.0;
-    const double scale = std::min(svgSymbolSize / symbol->viewBoxWidth,
-                                  svgSymbolSize / symbol->viewBoxHeight);
-    return symbol->viewBoxHeight * scale;
-  };
-  auto sharedPairScaleSvg = [&](const PerastageSvgSymbolData *topSvg,
-                                const PerastageSvgSymbolData *frontSvg) {
-    if (!topSvg || !frontSvg)
-      return 0.0;
-    const double topScale = std::min(svgSymbolSize / topSvg->viewBoxWidth,
-                                     svgSymbolSize / topSvg->viewBoxHeight);
-    const double frontScale = std::min(svgSymbolSize / frontSvg->viewBoxWidth,
-                                       svgSymbolSize / frontSvg->viewBoxHeight);
-    return std::min(topScale, frontScale);
+    return metrics.height * scale;
   };
 
   double maxTopSymbolColumnWidth = 0.0;
@@ -970,16 +1018,10 @@ wxImage LayoutViewerPanel::BuildLegendImage(
         FindSymbolDefinitionPreferred(symbols, item.symbolKey, SymbolViewKind::Top);
     const SymbolDefinition *frontSymbol =
         FindSymbolDefinitionExact(symbols, item.symbolKey, SymbolViewKind::Front);
-    const double pairScaleSvg = sharedPairScaleSvg(topSvg, frontSvg);
     const double topDrawW =
-        (topSvg && pairScaleSvg > 0.0)
-            ? topSvg->viewBoxWidth * pairScaleSvg
-            : (topSvg ? symbolDrawWidthSvg(topSvg) : symbolDrawWidth(topSymbol));
+        topSvg ? symbolDrawWidthSvg(topSvg) : symbolDrawWidth(topSymbol);
     const double frontDrawW =
-        (frontSvg && pairScaleSvg > 0.0)
-            ? frontSvg->viewBoxWidth * pairScaleSvg
-            : (frontSvg ? symbolDrawWidthSvg(frontSvg)
-                        : symbolDrawWidth(frontSymbol));
+        frontSvg ? symbolDrawWidthSvg(frontSvg) : symbolDrawWidth(frontSymbol);
     maxTopSymbolColumnWidth = std::max(maxTopSymbolColumnWidth, topDrawW);
     maxFrontSymbolColumnWidth = std::max(maxFrontSymbolColumnWidth, frontDrawW);
   }
@@ -1092,14 +1134,12 @@ wxImage LayoutViewerPanel::BuildLegendImage(
       };
       auto drawSvg = [&](const PerastageSvgSymbolData *symbol,
                          const std::optional<std::string> &fillHex,
-                         double drawLeft, double drawTop, double scaleOverride) {
+                         double drawLeft, double drawTop) {
         if (!symbol)
           return;
-        const double scale = scaleOverride > 0.0
-                                 ? scaleOverride
-                                 : std::min(svgSymbolSize / symbol->viewBoxWidth,
-                                            svgSymbolSize / symbol->viewBoxHeight);
-        if (scale <= 0.0)
+        const SvgGeometryMetrics metrics = svgGeometryMetrics(symbol);
+        const double scale = svgScaleForDraw(symbol);
+        if (!metrics.valid || scale <= 0.0)
           return;
         wxGraphicsContext *gc = dc.GetGraphicsContext();
         if (!gc)
@@ -1107,6 +1147,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
         gc->PushState();
         gc->Translate(drawLeft, drawTop);
         gc->Scale(scale, scale);
+        gc->Translate(-metrics.minX, -metrics.minY);
         gc->SetBrush(wxBrush(ResolveLegendSvgFillColor(fillHex)));
         gc->SetPen(*wxTRANSPARENT_PEN);
         for (const auto &polygon : symbol->fills) {
@@ -1140,23 +1181,15 @@ wxImage LayoutViewerPanel::BuildLegendImage(
         }
         gc->PopState();
       };
-      const double pairScaleSvg = sharedPairScaleSvg(topSvg, frontSvg);
-      const double topDrawW = (topSvg && pairScaleSvg > 0.0)
-                                  ? topSvg->viewBoxWidth * pairScaleSvg
-                                  : (topSvg ? symbolDrawWidthSvg(topSvg)
-                                            : symbolDrawWidth(topSymbol));
-      const double frontDrawW = (frontSvg && pairScaleSvg > 0.0)
-                                    ? frontSvg->viewBoxWidth * pairScaleSvg
-                                    : (frontSvg ? symbolDrawWidthSvg(frontSvg)
-                                                : symbolDrawWidth(frontSymbol));
-      const double topDrawH = (topSvg && pairScaleSvg > 0.0)
-                                  ? topSvg->viewBoxHeight * pairScaleSvg
-                                  : (topSvg ? symbolDrawHeightSvg(topSvg)
-                                            : symbolDrawHeight(topSymbol));
-      const double frontDrawH = (frontSvg && pairScaleSvg > 0.0)
-                                    ? frontSvg->viewBoxHeight * pairScaleSvg
-                                    : (frontSvg ? symbolDrawHeightSvg(frontSvg)
-                                                : symbolDrawHeight(frontSymbol));
+      const double topDrawW =
+          topSvg ? symbolDrawWidthSvg(topSvg) : symbolDrawWidth(topSymbol);
+      const double frontDrawW =
+          frontSvg ? symbolDrawWidthSvg(frontSvg) : symbolDrawWidth(frontSymbol);
+      const double topDrawH =
+          topSvg ? symbolDrawHeightSvg(topSvg) : symbolDrawHeight(topSymbol);
+      const double frontDrawH =
+          frontSvg ? symbolDrawHeightSvg(frontSvg)
+                   : symbolDrawHeight(frontSymbol);
       if (topDrawW > 0.0) {
         const double symbolDrawTop =
             y + (static_cast<double>(rowHeightPx) - topDrawH) * 0.5;
@@ -1165,7 +1198,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
             std::max(0.0, (static_cast<double>(topSymbolColumnSize) - topDrawW) *
                                  0.5);
         if (topSvg)
-          drawSvg(topSvg, item.symbolFillHex, symbolDrawLeft, symbolDrawTop, pairScaleSvg);
+          drawSvg(topSvg, item.symbolFillHex, symbolDrawLeft, symbolDrawTop);
         else
           drawSymbol(topSymbol, symbolDrawLeft, symbolDrawTop);
       }
@@ -1177,7 +1210,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
             std::max(0.0, (static_cast<double>(frontSymbolColumnSize) - frontDrawW) *
                                  0.5);
         if (frontSvg)
-          drawSvg(frontSvg, item.symbolFillHex, symbolDrawLeft, symbolDrawTop, pairScaleSvg);
+          drawSvg(frontSvg, item.symbolFillHex, symbolDrawLeft, symbolDrawTop);
         else
           drawSymbol(frontSymbol, symbolDrawLeft, symbolDrawTop);
       }

--- a/gui/layoutviewerpanel_legend.cpp
+++ b/gui/layoutviewerpanel_legend.cpp
@@ -1113,8 +1113,8 @@ wxImage LayoutViewerPanel::BuildLegendImage(
           findSvgSymbol(item.symbolKey, SymbolViewKind::Top);
       const PerastageSvgSymbolData *frontSvg =
           findSvgSymbol(item.symbolKey, SymbolViewKind::Front);
-      auto drawSymbol = [&](const SymbolDefinition *symbol, double drawLeft,
-                            double drawTop) {
+      auto drawSymbol = [&](const SymbolDefinition *symbol, double drawCenterX,
+                            double drawCenterY) {
         if (!symbol)
           return;
         const float symbolW = symbol->bounds.max.x - symbol->bounds.min.x;
@@ -1128,8 +1128,10 @@ wxImage LayoutViewerPanel::BuildLegendImage(
         mapping.minX = symbol->bounds.min.x;
         mapping.minY = symbol->bounds.min.y;
         mapping.scale = scale;
-        mapping.offsetX = drawLeft;
-        mapping.offsetY = drawTop;
+        mapping.offsetX =
+            drawCenterX - (0.0 - static_cast<double>(mapping.minX)) * mapping.scale;
+        mapping.offsetY = drawCenterY - drawH -
+                          (0.0 - static_cast<double>(mapping.minY)) * mapping.scale;
         mapping.drawHeight = drawH;
         backend.SetStrokeScale(
             mapping.scale > 0.0 ? 1.0 / mapping.scale : 1.0);
@@ -1206,7 +1208,9 @@ wxImage LayoutViewerPanel::BuildLegendImage(
         if (topSvg)
           drawSvg(topSvg, item.symbolFillHex, symbolDrawLeft, symbolDrawTop);
         else
-          drawSymbol(topSymbol, symbolDrawLeft, symbolDrawTop);
+          drawSymbol(topSymbol,
+                     xTopSymbol + static_cast<double>(topSymbolColumnSize) * 0.5,
+                     y + static_cast<double>(rowHeightPx) * 0.5);
       }
       if (frontDrawW > 0.0) {
         const double symbolDrawTop =
@@ -1218,7 +1222,9 @@ wxImage LayoutViewerPanel::BuildLegendImage(
         if (frontSvg)
           drawSvg(frontSvg, item.symbolFillHex, symbolDrawLeft, symbolDrawTop);
         else
-          drawSymbol(frontSymbol, symbolDrawLeft, symbolDrawTop);
+          drawSymbol(frontSymbol,
+                     xFrontSymbol + static_cast<double>(frontSymbolColumnSize) * 0.5,
+                     y + static_cast<double>(rowHeightPx) * 0.5);
       }
     }
     dc.DrawText(rowText.countText, xCount, y + textOffset);

--- a/gui/layoutviewerpanel_legend.cpp
+++ b/gui/layoutviewerpanel_legend.cpp
@@ -778,10 +778,10 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   dc.SetTextForeground(wxColour(20, 20, 20));
   dc.SetPen(*wxTRANSPARENT_PEN);
 
-  const int paddingLeft = 2;
-  const int paddingRight = 4;
-  const int paddingTop = 6;
-  const int paddingBottom = 2;
+  const int paddingLeft = 0;
+  const int paddingRight = 0;
+  const int paddingTop = 0;
+  const int paddingBottom = 0;
   const int columnGap = 6;
   const int symbolColumnGap = 0;
   constexpr double kLegendLineSpacingScale = 1.0;
@@ -1081,6 +1081,12 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   int y = paddingTopPx;
   const int textOffset = std::max(0, (rowHeightPx - textHeight) / 2);
   dc.SetFont(headerFont);
+  const int topHeaderX =
+      xTopSymbol + std::max(0, (topSymbolColumnSize - measureTextWidth("I")) / 2);
+  const int frontHeaderX = xFrontSymbol +
+                           std::max(0, (frontSymbolColumnSize - measureTextWidth("I")) / 2);
+  dc.DrawText("I", topHeaderX, y + textOffset);
+  dc.DrawText("I", frontHeaderX, y + textOffset);
   dc.DrawText("Count", xCount, y + textOffset);
   dc.DrawText("Type", xType, y + textOffset);
   dc.DrawText("Ch", xCh, y + textOffset);

--- a/gui/layoutviewerpanel_legend.cpp
+++ b/gui/layoutviewerpanel_legend.cpp
@@ -1027,17 +1027,19 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   const int maxSymbolColumnSize =
       std::max(4, static_cast<int>(std::lround(symbolSize *
                                                kLegendMaxSymbolSlotScale)));
-  const double maxMeasuredSymbolColumnWidth = static_cast<double>(maxSymbolColumnSize);
+  const int limitedSymbolColumnSize = std::max(4, maxSymbolColumnSize / 2);
+  const double maxMeasuredSymbolColumnWidth =
+      static_cast<double>(limitedSymbolColumnSize);
   const int topSymbolColumnSize = std::clamp(
       static_cast<int>(std::ceil(std::min(maxTopSymbolColumnWidth,
                                           maxMeasuredSymbolColumnWidth) *
                                  kLegendSymbolColumnScale)),
-      0, maxSymbolColumnSize);
+      0, limitedSymbolColumnSize);
   const int frontSymbolColumnSize = std::clamp(
       static_cast<int>(std::ceil(std::min(maxFrontSymbolColumnWidth,
                                           maxMeasuredSymbolColumnWidth) *
                                  kLegendSymbolColumnScale)),
-      0, maxSymbolColumnSize);
+      0, limitedSymbolColumnSize);
   const int rowHeightPx = baseRowHeightPx;
   const int paddingLeftPx =
       std::max(0, static_cast<int>(std::lround(paddingLeft * renderZoom)));

--- a/gui/layoutviewerpanel_legend.cpp
+++ b/gui/layoutviewerpanel_legend.cpp
@@ -48,6 +48,9 @@ constexpr int kLegendSymbolSizePx =
     static_cast<int>(64 * kLegendContentScale);
 constexpr double kLegendFallbackSymbolScale = 2.0;
 constexpr double kLegendSvgSymbolScale = 0.4;
+constexpr double kLegendFallbackPairOverlapScale = 0.85;
+constexpr double kLegendSvgPairGapScale = 0.18;
+constexpr double kLegendMaxSymbolSlotScale = 2.4;
 
 int SymbolViewRank(SymbolViewKind kind) {
   switch (kind) {
@@ -785,7 +788,6 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   const int symbolColumnGap = 2;
   constexpr double kLegendLineSpacingScale = 1.0;
   constexpr double kLegendSymbolColumnScale = 1.0;
-  constexpr double kLegendSymbolPairOverlapScale = 0.5;
   const int totalRows = static_cast<int>(items.size()) + 1;
   const int baseHeight = logicalSize.GetHeight() > 0 ? logicalSize.GetHeight()
                                                      : size.GetHeight();
@@ -876,9 +878,11 @@ wxImage LayoutViewerPanel::BuildLegendImage(
       std::max(4.0, static_cast<double>(symbolSize) * kLegendFallbackSymbolScale);
   const double svgSymbolSize =
       std::max(4.0, static_cast<double>(symbolSize) * kLegendSvgSymbolScale);
-  const double symbolPairGapPx =
+  const double fallbackSymbolPairGapPx =
       -std::max(1.0, static_cast<double>(symbolSize) *
-                         kLegendSymbolPairOverlapScale);
+                         kLegendFallbackPairOverlapScale);
+  const double svgSymbolPairGapPx =
+      std::max(1.0, static_cast<double>(symbolSize) * kLegendSvgPairGapScale);
   auto symbolDrawWidth = [&](const SymbolDefinition *symbol) -> double {
     if (!symbol)
       return 0.0;
@@ -960,7 +964,12 @@ wxImage LayoutViewerPanel::BuildLegendImage(
     return std::min(topScale, frontScale);
   };
 
-  auto pairGapForRow = [&]() { return symbolPairGapPx; };
+  auto pairGapForRow = [&](const PerastageSvgSymbolData *topSvg,
+                           const PerastageSvgSymbolData *frontSvg) {
+    if (topSvg && frontSvg)
+      return svgSymbolPairGapPx;
+    return fallbackSymbolPairGapPx;
+  };
   double maxSymbolPairWidth = symbolSize;
   for (const auto &item : items) {
       if (item.symbolKey.empty())
@@ -985,12 +994,15 @@ wxImage LayoutViewerPanel::BuildLegendImage(
                           : symbolDrawWidth(frontSymbol));
       double rowPairWidth = std::max(topDrawW, frontDrawW);
       if (topDrawW > 0.0 && frontDrawW > 0.0)
-        rowPairWidth = topDrawW + frontDrawW + pairGapForRow();
+        rowPairWidth = topDrawW + frontDrawW + pairGapForRow(topSvg, frontSvg);
       maxSymbolPairWidth = std::max(maxSymbolPairWidth, rowPairWidth);
     }
-  const int symbolSlotSize = std::max(
-      4, static_cast<int>(std::ceil(maxSymbolPairWidth *
-                                    kLegendSymbolColumnScale)));
+  const int maxSymbolSlotSize =
+      std::max(4, static_cast<int>(std::lround(symbolSize *
+                                               kLegendMaxSymbolSlotScale)));
+  const int symbolSlotSize = std::clamp(
+      static_cast<int>(std::ceil(maxSymbolPairWidth * kLegendSymbolColumnScale)),
+      4, maxSymbolSlotSize);
   const int rowHeightPx = baseRowHeightPx;
   const int paddingLeftPx =
       std::max(0, static_cast<int>(std::lround(paddingLeft * renderZoom)));
@@ -1154,7 +1166,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
         const double slotWidth = static_cast<double>(symbolSlotSize);
         double rowPairWidth = std::max(topDrawW, frontDrawW);
         if (topDrawW > 0.0 && frontDrawW > 0.0)
-          rowPairWidth = topDrawW + frontDrawW + pairGapForRow();
+          rowPairWidth = topDrawW + frontDrawW + pairGapForRow(topSvg, frontSvg);
         const double rowStart =
             xSymbol + std::max(0.0, (slotWidth - rowPairWidth) * 0.5);
         double leftSlotWidth = rowPairWidth;
@@ -1164,7 +1176,8 @@ wxImage LayoutViewerPanel::BuildLegendImage(
         if (topDrawW > 0.0 && frontDrawW > 0.0) {
           leftSlotWidth = topDrawW;
           rightSlotWidth = frontDrawW;
-          frontSlotLeft = rowStart + topDrawW + pairGapForRow();
+          frontSlotLeft =
+              rowStart + topDrawW + pairGapForRow(topSvg, frontSvg);
         } else if (frontDrawW > 0.0) {
           frontSlotLeft = rowStart;
         }

--- a/gui/layoutviewerpanel_legend.cpp
+++ b/gui/layoutviewerpanel_legend.cpp
@@ -783,7 +783,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   const int paddingTop = 6;
   const int paddingBottom = 2;
   const int columnGap = 6;
-  const int symbolColumnGap = 1;
+  const int symbolColumnGap = 0;
   constexpr double kLegendLineSpacingScale = 1.0;
   constexpr double kLegendSymbolColumnScale = 1.0;
   const int totalRows = static_cast<int>(items.size()) + 1;
@@ -853,7 +853,6 @@ wxImage LayoutViewerPanel::BuildLegendImage(
     maxCountWidth = std::max(maxCountWidth, measureTextWidth(row.countText));
     maxChWidth = std::max(maxChWidth, measureTextWidth(row.chText));
   }
-  const int leftTrimPx = measureTextWidth("000");
   const int chExtraWidthPx = measureTextWidth("0");
   maxChWidth += chExtraWidthPx;
 
@@ -965,14 +964,14 @@ wxImage LayoutViewerPanel::BuildLegendImage(
 
     for (const auto &polygon : symbol->fills) {
       for (const auto &pt : polygon.points)
-        includePoint(pt);
+        includePoint({pt.x + symbol->offsetXmm, pt.y + symbol->offsetYmm});
       for (const auto &hole : polygon.holes)
         for (const auto &pt : hole)
-          includePoint(pt);
+          includePoint({pt.x + symbol->offsetXmm, pt.y + symbol->offsetYmm});
     }
     for (const auto &line : symbol->strokes)
       for (const auto &pt : line.points)
-        includePoint(pt);
+        includePoint({pt.x + symbol->offsetXmm, pt.y + symbol->offsetYmm});
 
     if (!hasPoint)
       return metrics;
@@ -1052,7 +1051,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
       std::max(0, static_cast<int>(std::lround(columnGap * renderZoom)));
   const int symbolColumnGapPx =
       std::max(0, static_cast<int>(std::lround(symbolColumnGap * renderZoom)));
-  int xTopSymbol = std::max(0, paddingLeftPx - leftTrimPx);
+  int xTopSymbol = paddingLeftPx;
   int xFrontSymbol = xTopSymbol + topSymbolColumnSize + symbolColumnGapPx;
   int xCount = xFrontSymbol + frontSymbolColumnSize + columnGapPx;
   int xType = xCount + maxCountWidth + columnGapPx;
@@ -1147,6 +1146,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
         gc->PushState();
         gc->Translate(drawLeft, drawTop);
         gc->Scale(scale, scale);
+        gc->Translate(symbol->offsetXmm, symbol->offsetYmm);
         gc->Translate(-metrics.minX, -metrics.minY);
         gc->SetBrush(wxBrush(ResolveLegendSvgFillColor(fillHex)));
         gc->SetPen(*wxTRANSPARENT_PEN);


### PR DESCRIPTION
### Motivation
- Legend symbol rendering showed inconsistent spacing: default (fallback) symbols appeared too far apart while SVG-generated symbols overlapped, and oversized symbol bounds caused excessive empty space at the left of the legend table. 
- The fix aims to make pair spacing consistent and avoid visual overlap for SVGs while preventing extreme symbol column expansion from pushing table text to the right.

### Description
- Added three tuning constants: `kLegendFallbackPairOverlapScale`, `kLegendSvgPairGapScale`, and `kLegendMaxSymbolSlotScale` in `gui/layoutviewerpanel_legend.cpp` to control fallback overlap, SVG gap, and a max symbol column width. 
- Reworked the per-row pair gap calculation to return a different gap for rows that have both top+front SVG symbols versus fallback-rendered symbols, and applied that value everywhere the pair gap was used. 
- Capped computed `symbolSlotSize` using `kLegendMaxSymbolSlotScale` so very large symbol bounds no longer create excessive empty left column space. 
- Updated final symbol placement code paths to use the new `pairGapForRow(topSvg, frontSvg)` API so SVG and fallback spacing are consistent during layout and drawing.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed. 
- Changes touched `gui/layoutviewerpanel_legend.cpp` (large file); the modifications were kept small and localized, and a future cleanup could extract sizing/spacing logic into a helper per the code health guidelines.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c70ecd11c8324bd551fa835049bc1)