### PR TITLE
Improve layout print diagnostics for invalid GDTF archives

### DIFF
--- a/core/symbols/PerastageSvgSymbol.cpp
+++ b/core/symbols/PerastageSvgSymbol.cpp
@@ -1,9 +1,11 @@
 #include "symbols/PerastageSvgSymbol.h"
 
 #include <algorithm>
+#include <array>
 #include <cctype>
 #include <cmath>
 #include <cstdlib>
+#include <fstream>
 #include <optional>
 #include <memory>
 #include <string_view>
@@ -35,15 +37,58 @@ bool ReadAllBytes(wxZipInputStream &zip, std::string &out) {
   return true;
 }
 
-bool ReadZipEntries(const std::string &zipPath,
-                    std::unordered_map<std::string, std::string> &entries) {
-  wxFileInputStream input(zipPath);
-  if (!input.IsOk())
+bool IsZipSignature(const std::string &zipPath) {
+  std::ifstream input(zipPath, std::ios::binary);
+  if (!input.is_open())
     return false;
+
+  std::array<unsigned char, 4> header{0, 0, 0, 0};
+  input.read(reinterpret_cast<char *>(header.data()),
+             static_cast<std::streamsize>(header.size()));
+  if (input.gcount() < static_cast<std::streamsize>(header.size()))
+    return false;
+
+  const bool isLocalHeader =
+      header[0] == 0x50 && header[1] == 0x4b && header[2] == 0x03 &&
+      header[3] == 0x04;
+  const bool isEmptyArchive =
+      header[0] == 0x50 && header[1] == 0x4b && header[2] == 0x05 &&
+      header[3] == 0x06;
+  const bool isSpannedArchive =
+      header[0] == 0x50 && header[1] == 0x4b && header[2] == 0x07 &&
+      header[3] == 0x08;
+  return isLocalHeader || isEmptyArchive || isSpannedArchive;
+}
+
+bool ReadZipEntries(const std::string &zipPath,
+                    std::unordered_map<std::string, std::string> &entries,
+                    std::string *errorDetails) {
+  if (zipPath.empty()) {
+    if (errorDetails)
+      *errorDetails = "GDTF path is empty.";
+    return false;
+  }
+
+  if (!IsZipSignature(zipPath)) {
+    if (errorDetails) {
+      *errorDetails = "The selected file is not a valid ZIP/GDTF archive: " +
+                      zipPath;
+    }
+    return false;
+  }
+
+  wxFileInputStream input(zipPath);
+  if (!input.IsOk()) {
+    if (errorDetails)
+      *errorDetails = "Could not open GDTF archive: " + zipPath;
+    return false;
+  }
 
   wxZipInputStream zipInput(input);
   std::unique_ptr<wxZipEntry> entry;
+  bool hasEntries = false;
   while ((entry.reset(zipInput.GetNextEntry())), entry) {
+    hasEntries = true;
     if (entry->IsDir())
       continue;
     std::string content;
@@ -51,6 +96,11 @@ bool ReadZipEntries(const std::string &zipPath,
       continue;
     entries[NormalizeArchivePath(entry->GetName().ToStdString())] =
         std::move(content);
+  }
+
+  if (!hasEntries && errorDetails) {
+    *errorDetails = "The GDTF archive does not contain readable ZIP entries: " +
+                    zipPath;
   }
   return true;
 }
@@ -420,28 +470,45 @@ bool ReadOffset(const tinyxml2::XMLElement *model, const char *attr,
 
 bool LoadPerastageSvgSymbolFromGdtf(const std::string &gdtfPath,
                                     SymbolViewKind requestedView,
-                                    PerastageSvgSymbolData &out) {
+                                    PerastageSvgSymbolData &out,
+                                    std::string *errorDetails) {
   std::unordered_map<std::string, std::string> entries;
-  if (!ReadZipEntries(gdtfPath, entries))
+  if (!ReadZipEntries(gdtfPath, entries, errorDetails))
     return false;
 
   auto descIt = entries.find("description.xml");
-  if (descIt == entries.end())
+  if (descIt == entries.end()) {
+    if (errorDetails)
+      *errorDetails = "description.xml was not found in GDTF archive: " +
+                      gdtfPath;
     return false;
+  }
 
   tinyxml2::XMLDocument description;
   if (description.Parse(descIt->second.c_str(), descIt->second.size()) !=
       tinyxml2::XML_SUCCESS) {
+    if (errorDetails)
+      *errorDetails = "description.xml could not be parsed for GDTF archive: " +
+                      gdtfPath;
     return false;
   }
 
   const tinyxml2::XMLElement *fixtureType = ResolveFixtureType(description);
-  if (!fixtureType)
+  if (!fixtureType) {
+    if (errorDetails)
+      *errorDetails = "FixtureType section is missing in GDTF archive: " +
+                      gdtfPath;
     return false;
+  }
 
   const char *editor = fixtureType->Attribute("Editor");
-  if (!editor || !EqualsNoCase(editor, "Perastage"))
+  if (!editor || !EqualsNoCase(editor, "Perastage")) {
+    if (errorDetails)
+      *errorDetails =
+          "GDTF archive does not contain Perastage-generated SVG symbols: " +
+          gdtfPath;
     return false;
+  }
 
   const tinyxml2::XMLElement *model = ResolveTargetModel(fixtureType);
   const std::string baseName = ResolveModelSvgBasename(model);
@@ -479,7 +546,14 @@ bool LoadPerastageSvgSymbolFromGdtf(const std::string &gdtfPath,
       continue;
 
     out = std::move(parsed);
+    if (errorDetails)
+      errorDetails->clear();
     return true;
+  }
+
+  if (errorDetails) {
+    *errorDetails = "No valid SVG symbol was found in GDTF archive: " +
+                    gdtfPath;
   }
 
   return false;

--- a/core/symbols/PerastageSvgSymbol.h
+++ b/core/symbols/PerastageSvgSymbol.h
@@ -37,4 +37,5 @@ struct PerastageSvgSymbolData {
 
 bool LoadPerastageSvgSymbolFromGdtf(const std::string &gdtfPath,
                                     SymbolViewKind requestedView,
-                                    PerastageSvgSymbolData &out);
+                                    PerastageSvgSymbolData &out,
+                                    std::string *errorDetails = nullptr);

--- a/gui/mainwindow_print.cpp
+++ b/gui/mainwindow_print.cpp
@@ -373,9 +373,14 @@ void MainWindow::OnPrintLayout(wxCommandEvent &WXUNUSED(event)) {
                                wxString::FromUTF8(res.message);
                 wxMessageBox(msg, "Print Layout", wxOK | wxICON_ERROR, this);
               } else {
-                wxMessageBox(wxString::Format("Layout saved to %s",
-                                              outputPathDisplay),
-                             "Print Layout", wxOK | wxICON_INFORMATION, this);
+                wxString successMessage =
+                    wxString::Format("Layout saved to %s", outputPathDisplay);
+                if (!res.message.empty()) {
+                  successMessage += "\n\nAdditional details:\n" +
+                                    wxString::FromUTF8(res.message);
+                }
+                wxMessageBox(successMessage, "Print Layout",
+                             wxOK | wxICON_INFORMATION, this);
               }
             });
           }).detach();

--- a/viewer2d/pdf/layout_pdf_exporter.cpp
+++ b/viewer2d/pdf/layout_pdf_exporter.cpp
@@ -67,6 +67,17 @@ static bool ShouldTraceLabelOrder() {
 }
 
 
+
+bool ShouldLoadLegendSvgFromKey(const std::string &symbolKey) {
+  if (symbolKey.empty())
+    return false;
+
+  std::filesystem::path symbolPath(symbolKey);
+  std::string extension = symbolPath.extension().string();
+  std::transform(extension.begin(), extension.end(), extension.begin(),
+                 [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+  return extension == ".gdtf";
+}
 std::array<double, 3> ResolveLegendSvgFillRgb(
     const std::optional<std::string> &hexColor) {
   constexpr std::array<double, 3> kDefaultGray = {0.878, 0.878, 0.878};
@@ -914,7 +925,7 @@ Viewer2DExportResult ExportLayoutToPdf(
   auto findLegendSvg = [&](const std::string &symbolKey,
                            SymbolViewKind viewKind)
       -> const PerastageSvgSymbolData * {
-    if (symbolKey.empty())
+    if (!ShouldLoadLegendSvgFromKey(symbolKey))
       return nullptr;
     LegendSvgCacheKey cacheKey{symbolKey, viewKind};
     auto it = legendSvgCache.find(cacheKey);

--- a/viewer2d/pdf/layout_pdf_exporter.cpp
+++ b/viewer2d/pdf/layout_pdf_exporter.cpp
@@ -910,6 +910,7 @@ Viewer2DExportResult ExportLayoutToPdf(
   std::unordered_map<LegendSvgCacheKey, std::optional<PerastageSvgSymbolData>,
                      LegendSvgCacheHasher>
       legendSvgCache;
+  std::string firstLegendSvgLoadError;
   auto findLegendSvg = [&](const std::string &symbolKey,
                            SymbolViewKind viewKind)
       -> const PerastageSvgSymbolData * {
@@ -920,8 +921,12 @@ Viewer2DExportResult ExportLayoutToPdf(
     if (it == legendSvgCache.end()) {
       PerastageSvgSymbolData data;
       std::optional<PerastageSvgSymbolData> loaded;
-      if (LoadPerastageSvgSymbolFromGdtf(symbolKey, viewKind, data))
+      std::string loadError;
+      if (LoadPerastageSvgSymbolFromGdtf(symbolKey, viewKind, data, &loadError)) {
         loaded = std::move(data);
+      } else if (firstLegendSvgLoadError.empty() && !loadError.empty()) {
+        firstLegendSvgLoadError = loadError;
+      }
       it = legendSvgCache.emplace(std::move(cacheKey), std::move(loaded)).first;
     }
     return it->second ? &it->second.value() : nullptr;
@@ -2017,6 +2022,10 @@ Viewer2DExportResult ExportLayoutToPdf(
     file << "trailer\n<< /Size " << (objects.size() + 1)
          << " /Root " << catalogIndex
          << " 0 R >>\nstartxref\n" << xrefPos << "\n%%EOF";
+    if (!firstLegendSvgLoadError.empty()) {
+      result.message =
+          "Legend SVG symbols were skipped. Reason: " + firstLegendSvgLoadError;
+    }
     result.success = true;
   } catch (const std::exception &ex) {
     result.message =


### PR DESCRIPTION
### Motivation
- Exporting layouts could show a generic "invalid zip file" error when a referenced GDTF file was not a valid ZIP/GDTF or contained missing/invalid symbol data, which is unhelpful for end users and diagnostics. 
- The exporter needed a way to surface symbol-load warnings so the UI can present actionable details instead of opaque ZIP parser failures.

### Description
- Add a ZIP signature pre-check (`IsZipSignature`) and extend `ReadZipEntries` to accept an `errorDetails` output that returns explicit failure reasons (empty path, not a ZIP/GDTF, cannot open, no readable entries). 
- Extend `LoadPerastageSvgSymbolFromGdtf(...)` to accept an optional `std::string *errorDetails` and emit explicit messages for missing `description.xml`, XML parse failures, missing `FixtureType`, wrong `Editor` value, and missing/invalid SVG content. 
- Capture the first legend SVG load error in `ExportLayoutToPdf(...)` (`firstLegendSvgLoadError`) and propagate it into `Viewer2DExportResult.message` when the export succeeds but some legend symbols were skipped. 
- Show the `Viewer2DExportResult.message` as an "Additional details" block in the successful layout save dialog (`MainWindow::OnPrintLayout`). Technical note: `viewer2d/pdf/layout_pdf_exporter.cpp` remains a large hotspot; consider extracting legend-symbol loading/warning aggregation into a focused helper in a follow-up change.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed. 
- Attempted a build check (`cmake --build`), but no `build` directory was present in the environment so the compile step was skipped.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c7095539083248fd4412018e2a2be)