### PR TITLE
Fix missing 2D fixture symbols in layout PDF export

### DIFF
--- a/viewer2d/pdf/layout_pdf_exporter.cpp
+++ b/viewer2d/pdf/layout_pdf_exporter.cpp
@@ -921,7 +921,7 @@ Viewer2DExportResult ExportLayoutToPdf(
   std::unordered_map<LegendSvgCacheKey, std::optional<PerastageSvgSymbolData>,
                      LegendSvgCacheHasher>
       legendSvgCache;
-  std::string firstLegendSvgLoadError;
+  std::unordered_map<std::string, std::string> svgLoadIssues;
   auto findLegendSvg = [&](const std::string &symbolKey,
                            SymbolViewKind viewKind)
       -> const PerastageSvgSymbolData * {
@@ -935,8 +935,8 @@ Viewer2DExportResult ExportLayoutToPdf(
       std::string loadError;
       if (LoadPerastageSvgSymbolFromGdtf(symbolKey, viewKind, data, &loadError)) {
         loaded = std::move(data);
-      } else if (firstLegendSvgLoadError.empty() && !loadError.empty()) {
-        firstLegendSvgLoadError = loadError;
+      } else if (!loadError.empty()) {
+        svgLoadIssues.emplace(symbolKey, loadError);
       }
       it = legendSvgCache.emplace(std::move(cacheKey), std::move(loaded)).first;
     }
@@ -1229,28 +1229,13 @@ Viewer2DExportResult ExportLayoutToPdf(
         auto defIt = symbolSnapshot->find(entry.first);
         if (defIt == symbolSnapshot->end())
           continue;
-        bool usedSvg = false;
-        if (!defIt->second.key.modelKey.empty()) {
-          if (const PerastageSvgSymbolData *svg =
-                  findLegendSvg(defIt->second.key.modelKey,
-                                defIt->second.key.viewKind)) {
-            constexpr std::array<double, 3> kDefaultSvgFillRgb = {
-                224.0 / 255.0, 224.0 / 255.0, 224.0 / 255.0};
-            xObjectNameIds[entry.second] =
-                appendPerastageSvgSymbolObject(*svg, 1.0, group.strokeScale,
-                                               kDefaultSvgFillRgb);
-            usedSvg = true;
-          }
-        }
-        if (!usedSvg) {
-          xObjectNameIds[entry.second] =
-              appendSymbolObject(entry.second,
-                                 defIt->second.localCommands.commands,
-                                 defIt->second.localCommands.metadata,
-                                 defIt->second.localCommands.sources,
-                                 1.0, group.strokeScale,
-                                 defIt->second.bounds);
-        }
+        xObjectNameIds[entry.second] =
+            appendSymbolObject(entry.second,
+                               defIt->second.localCommands.commands,
+                               defIt->second.localCommands.metadata,
+                               defIt->second.localCommands.sources,
+                               1.0, group.strokeScale,
+                               defIt->second.bounds);
       }
     }
   }
@@ -2075,9 +2060,20 @@ Viewer2DExportResult ExportLayoutToPdf(
     file << "trailer\n<< /Size " << (objects.size() + 1)
          << " /Root " << catalogIndex
          << " 0 R >>\nstartxref\n" << xrefPos << "\n%%EOF";
-    if (!firstLegendSvgLoadError.empty()) {
-      result.message =
-          "Legend SVG symbols were skipped. Reason: " + firstLegendSvgLoadError;
+    if (!svgLoadIssues.empty()) {
+      std::vector<std::string> failedKeys;
+      failedKeys.reserve(svgLoadIssues.size());
+      for (const auto &entry : svgLoadIssues)
+        failedKeys.push_back(entry.first);
+      std::sort(failedKeys.begin(), failedKeys.end());
+
+      std::ostringstream details;
+      details << "SVG symbols were skipped for " << failedKeys.size()
+              << " model(s).";
+      for (const auto &key : failedKeys) {
+        details << "\n- " << key;
+      }
+      result.message = details.str();
     }
     result.success = true;
   } catch (const std::exception &ex) {

--- a/viewer2d/pdf/layout_pdf_exporter.cpp
+++ b/viewer2d/pdf/layout_pdf_exporter.cpp
@@ -1145,25 +1145,57 @@ Viewer2DExportResult ExportLayoutToPdf(
                                             double symbolScale,
                                             double strokeScale,
                                             const std::array<double, 3> &fillRgb) {
+    double minX = std::numeric_limits<double>::max();
+    double minY = std::numeric_limits<double>::max();
+    double maxX = std::numeric_limits<double>::lowest();
+    double maxY = std::numeric_limits<double>::lowest();
+    bool hasGeometry = false;
+    auto includePoint = [&](double x, double y) {
+      hasGeometry = true;
+      minX = std::min(minX, x);
+      minY = std::min(minY, y);
+      maxX = std::max(maxX, x);
+      maxY = std::max(maxY, y);
+    };
+
+    for (const auto &polygon : svg.fills) {
+      for (const auto &pt : polygon.points)
+        includePoint(pt.x + svg.offsetXmm, pt.y + svg.offsetYmm);
+      for (const auto &hole : polygon.holes) {
+        for (const auto &pt : hole)
+          includePoint(pt.x + svg.offsetXmm, pt.y + svg.offsetYmm);
+      }
+    }
+    for (const auto &line : svg.strokes) {
+      for (const auto &pt : line.points)
+        includePoint(pt.x + svg.offsetXmm, pt.y + svg.offsetYmm);
+    }
+    if (!hasGeometry) {
+      minX = svg.offsetXmm;
+      minY = svg.offsetYmm;
+      maxX = svg.offsetXmm + svg.viewBoxWidth;
+      maxY = svg.offsetYmm + svg.viewBoxHeight;
+    }
+
     std::ostringstream symbolContent;
     symbolContent << formatter.Format(fillRgb[0]) << " "
                   << formatter.Format(fillRgb[1]) << " "
                   << formatter.Format(fillRgb[2]) << " rg\n";
     symbolContent << "0 0 0 RG " << formatter.Format(strokeScale) << " w\n";
-    symbolContent << "q\n1 0 0 1 "
-                  << formatter.Format(svg.offsetXmm * symbolScale) << " "
-                  << formatter.Format(svg.offsetYmm * symbolScale) << " cm\n";
 
     auto appendPolygonPath = [&](const std::vector<PerastageSvgPoint> &points) {
       if (points.size() < 3)
         return;
-      symbolContent << formatter.Format(points[0].x * symbolScale) << ' '
-                    << formatter.Format((svg.viewBoxHeight - points[0].y) * symbolScale)
+      symbolContent << formatter.Format((points[0].x + svg.offsetXmm) * symbolScale)
+                    << ' '
+                    << formatter.Format((points[0].y + svg.offsetYmm) * symbolScale)
                     << " m\n";
       for (size_t i = 1; i < points.size(); ++i) {
-        symbolContent << formatter.Format(points[i].x * symbolScale) << ' '
-                      << formatter.Format((svg.viewBoxHeight - points[i].y) * symbolScale)
-                      << " l\n";
+        symbolContent
+            << formatter.Format((points[i].x + svg.offsetXmm) * symbolScale)
+            << ' '
+            << formatter.Format((points[i].y + svg.offsetYmm) * symbolScale)
+            << " l\n";
       }
       symbolContent << "h\n";
     };
@@ -1179,17 +1211,20 @@ Viewer2DExportResult ExportLayoutToPdf(
     for (const auto &line : svg.strokes) {
       if (line.points.size() < 2)
         continue;
-      symbolContent << formatter.Format(line.points[0].x * symbolScale) << ' '
-                    << formatter.Format((svg.viewBoxHeight - line.points[0].y) * symbolScale)
-                    << " m\n";
+      symbolContent
+          << formatter.Format((line.points[0].x + svg.offsetXmm) * symbolScale)
+          << ' '
+          << formatter.Format((line.points[0].y + svg.offsetYmm) * symbolScale)
+          << " m\n";
       for (size_t i = 1; i < line.points.size(); ++i) {
-        symbolContent << formatter.Format(line.points[i].x * symbolScale) << ' '
-                      << formatter.Format((svg.viewBoxHeight - line.points[i].y) * symbolScale)
-                      << " l\n";
+        symbolContent
+            << formatter.Format((line.points[i].x + svg.offsetXmm) * symbolScale)
+            << ' '
+            << formatter.Format((line.points[i].y + svg.offsetYmm) * symbolScale)
+            << " l\n";
       }
       symbolContent << "S\n";
     }
-    symbolContent << "Q\n";
 
     std::string symbolStream = symbolContent.str();
     std::string compressedSymbol;
@@ -1199,16 +1234,13 @@ Viewer2DExportResult ExportLayoutToPdf(
       compressed = PdfDeflater::Compress(symbolStream, compressedSymbol, error);
     }
     const std::string &stream = compressed ? compressedSymbol : symbolStream;
-    const double minX = svg.offsetXmm * symbolScale;
-    const double minY = svg.offsetYmm * symbolScale;
-    const double maxX = (svg.offsetXmm + svg.viewBoxWidth) * symbolScale;
-    const double maxY = (svg.offsetYmm + svg.viewBoxHeight) * symbolScale;
+
     std::ostringstream xobj;
     xobj << "<< /Type /XObject /Subtype /Form /BBox ["
-         << formatter.Format(std::min(minX, maxX)) << ' '
-         << formatter.Format(std::min(minY, maxY)) << ' '
-         << formatter.Format(std::max(minX, maxX)) << ' '
-         << formatter.Format(std::max(minY, maxY))
+         << formatter.Format(minX * symbolScale) << ' '
+         << formatter.Format(minY * symbolScale) << ' '
+         << formatter.Format(maxX * symbolScale) << ' '
+         << formatter.Format(maxY * symbolScale)
          << "] /Resources << >> /Length " << stream.size();
     if (compressed)
       xobj << " /Filter /FlateDecode";
@@ -1216,7 +1248,6 @@ Viewer2DExportResult ExportLayoutToPdf(
     objects.push_back({xobj.str()});
     return objects.size();
   };
-
 
   auto populateViewSymbolNames =
       [&](const LayoutCommandGroup &group,

--- a/viewer2d/pdf/layout_pdf_exporter.cpp
+++ b/viewer2d/pdf/layout_pdf_exporter.cpp
@@ -51,6 +51,7 @@ using namespace layout_pdf_internal;
 
 constexpr double kLegendContentScale = 0.7;
 constexpr double kPdfPointsPerPixel = 72.0 / 96.0;
+constexpr double kMillimetersToMeters = 0.001;
 constexpr double kLegendSymbolSize =
     96.0 * 2.0 / 3.0 * kLegendContentScale;
 constexpr double kLegendFontScale =
@@ -942,6 +943,30 @@ Viewer2DExportResult ExportLayoutToPdf(
     }
     return it->second ? &it->second.value() : nullptr;
   };
+  auto resolveSymbolFillRgb = [&](const SymbolDefinition &definition) {
+    std::array<double, 3> fillRgb = {224.0 / 255.0, 224.0 / 255.0, 224.0 / 255.0};
+    for (const auto &cmd : definition.localCommands.commands) {
+      if (const auto *polygon = std::get_if<PolygonCommand>(&cmd)) {
+        if (polygon->hasFill) {
+          fillRgb = {polygon->fill.color.r, polygon->fill.color.g,
+                     polygon->fill.color.b};
+          break;
+        }
+      } else if (const auto *rect = std::get_if<RectangleCommand>(&cmd)) {
+        if (rect->hasFill) {
+          fillRgb = {rect->fill.color.r, rect->fill.color.g, rect->fill.color.b};
+          break;
+        }
+      } else if (const auto *circle = std::get_if<CircleCommand>(&cmd)) {
+        if (circle->hasFill) {
+          fillRgb = {circle->fill.color.r, circle->fill.color.g,
+                     circle->fill.color.b};
+          break;
+        }
+      }
+    }
+    return fillRgb;
+  };
   const double legendStrokeScale = 1.0 / viewer2d::kViewer2DPixelsPerMeter;
   auto makeLegendIdName = [](uint32_t symbolId) {
     return "L" + std::to_string(symbolId);
@@ -1229,13 +1254,27 @@ Viewer2DExportResult ExportLayoutToPdf(
         auto defIt = symbolSnapshot->find(entry.first);
         if (defIt == symbolSnapshot->end())
           continue;
-        xObjectNameIds[entry.second] =
-            appendSymbolObject(entry.second,
-                               defIt->second.localCommands.commands,
-                               defIt->second.localCommands.metadata,
-                               defIt->second.localCommands.sources,
-                               1.0, group.strokeScale,
-                               defIt->second.bounds);
+        bool usedSvg = false;
+        if (!defIt->second.key.modelKey.empty()) {
+          if (const PerastageSvgSymbolData *svg =
+                  findLegendSvg(defIt->second.key.modelKey,
+                                defIt->second.key.viewKind)) {
+            xObjectNameIds[entry.second] =
+                appendPerastageSvgSymbolObject(*svg, kMillimetersToMeters,
+                                               group.strokeScale,
+                                               resolveSymbolFillRgb(defIt->second));
+            usedSvg = true;
+          }
+        }
+        if (!usedSvg) {
+          xObjectNameIds[entry.second] =
+              appendSymbolObject(entry.second,
+                                 defIt->second.localCommands.commands,
+                                 defIt->second.localCommands.metadata,
+                                 defIt->second.localCommands.sources,
+                                 1.0, group.strokeScale,
+                                 defIt->second.bounds);
+        }
       }
     }
   }

--- a/viewer2d/pdf/layout_pdf_exporter.cpp
+++ b/viewer2d/pdf/layout_pdf_exporter.cpp
@@ -942,28 +942,6 @@ Viewer2DExportResult ExportLayoutToPdf(
     }
     return it->second ? &it->second.value() : nullptr;
   };
-  auto resolveSymbolFillRgb = [&](const SymbolDefinition &definition) {
-    std::array<double, 3> fillRgb = {224.0 / 255.0, 224.0 / 255.0,
-                                     224.0 / 255.0};
-    for (const auto &cmd : definition.localCommands.commands) {
-      if (const auto *polygon = std::get_if<PolygonCommand>(&cmd)) {
-        if (polygon->hasFill)
-          return std::array<double, 3>{polygon->fill.color.r,
-                                       polygon->fill.color.g,
-                                       polygon->fill.color.b};
-      } else if (const auto *rect = std::get_if<RectangleCommand>(&cmd)) {
-        if (rect->hasFill)
-          return std::array<double, 3>{rect->fill.color.r, rect->fill.color.g,
-                                       rect->fill.color.b};
-      } else if (const auto *circle = std::get_if<CircleCommand>(&cmd)) {
-        if (circle->hasFill)
-          return std::array<double, 3>{circle->fill.color.r,
-                                       circle->fill.color.g,
-                                       circle->fill.color.b};
-      }
-    }
-    return fillRgb;
-  };
   const double legendStrokeScale = 1.0 / viewer2d::kViewer2DPixelsPerMeter;
   auto makeLegendIdName = [](uint32_t symbolId) {
     return "L" + std::to_string(symbolId);
@@ -1329,27 +1307,13 @@ Viewer2DExportResult ExportLayoutToPdf(
         auto defIt = symbolSnapshot->find(entry.first);
         if (defIt == symbolSnapshot->end())
           continue;
-        bool usedSvg = false;
-        if (!defIt->second.key.modelKey.empty()) {
-          if (const PerastageSvgSymbolData *svg =
-                  findLegendSvg(defIt->second.key.modelKey,
-                                defIt->second.key.viewKind)) {
-            xObjectNameIds[entry.second] =
-                appendPerastageSvgSymbolObject(*svg, defIt->second.key.viewKind,
-                                               0.001, group.strokeScale,
-                                               resolveSymbolFillRgb(defIt->second));
-            usedSvg = true;
-          }
-        }
-        if (!usedSvg) {
-          xObjectNameIds[entry.second] =
-              appendSymbolObject(entry.second,
-                                 defIt->second.localCommands.commands,
-                                 defIt->second.localCommands.metadata,
-                                 defIt->second.localCommands.sources,
-                                 1.0, group.strokeScale,
-                                 defIt->second.bounds);
-        }
+        xObjectNameIds[entry.second] =
+            appendSymbolObject(entry.second,
+                               defIt->second.localCommands.commands,
+                               defIt->second.localCommands.metadata,
+                               defIt->second.localCommands.sources,
+                               1.0, group.strokeScale,
+                               defIt->second.bounds);
       }
     }
   }

--- a/viewer2d/pdf/layout_pdf_exporter.cpp
+++ b/viewer2d/pdf/layout_pdf_exporter.cpp
@@ -942,6 +942,28 @@ Viewer2DExportResult ExportLayoutToPdf(
     }
     return it->second ? &it->second.value() : nullptr;
   };
+  auto resolveSymbolFillRgb = [&](const SymbolDefinition &definition) {
+    std::array<double, 3> fillRgb = {224.0 / 255.0, 224.0 / 255.0,
+                                     224.0 / 255.0};
+    for (const auto &cmd : definition.localCommands.commands) {
+      if (const auto *polygon = std::get_if<PolygonCommand>(&cmd)) {
+        if (polygon->hasFill)
+          return std::array<double, 3>{polygon->fill.color.r,
+                                       polygon->fill.color.g,
+                                       polygon->fill.color.b};
+      } else if (const auto *rect = std::get_if<RectangleCommand>(&cmd)) {
+        if (rect->hasFill)
+          return std::array<double, 3>{rect->fill.color.r, rect->fill.color.g,
+                                       rect->fill.color.b};
+      } else if (const auto *circle = std::get_if<CircleCommand>(&cmd)) {
+        if (circle->hasFill)
+          return std::array<double, 3>{circle->fill.color.r,
+                                       circle->fill.color.g,
+                                       circle->fill.color.b};
+      }
+    }
+    return fillRgb;
+  };
   const double legendStrokeScale = 1.0 / viewer2d::kViewer2DPixelsPerMeter;
   auto makeLegendIdName = [](uint32_t symbolId) {
     return "L" + std::to_string(symbolId);
@@ -1117,6 +1139,7 @@ Viewer2DExportResult ExportLayoutToPdf(
   };
 
   auto appendPerastageSvgSymbolObject = [&](const PerastageSvgSymbolData &svg,
+                                            SymbolViewKind requestedViewKind,
                                             double symbolScale,
                                             double strokeScale,
                                             const std::array<double, 3> &fillRgb) {
@@ -1152,6 +1175,46 @@ Viewer2DExportResult ExportLayoutToPdf(
       maxY = svg.offsetYmm + svg.viewBoxHeight;
     }
 
+    auto transformedSvgPoint = [&](double x, double y) {
+      const double rawX = x + svg.offsetXmm;
+      const double rawY = y + svg.offsetYmm;
+      if (requestedViewKind == SymbolViewKind::Bottom &&
+          svg.viewKind == SymbolViewKind::Top) {
+        return std::array<double, 2>{2.0 * minX - rawX, 2.0 * minY - rawY};
+      }
+      return std::array<double, 2>{rawX, rawY};
+    };
+
+    double transformedMinX = std::numeric_limits<double>::max();
+    double transformedMinY = std::numeric_limits<double>::max();
+    double transformedMaxX = std::numeric_limits<double>::lowest();
+    double transformedMaxY = std::numeric_limits<double>::lowest();
+    auto includeTransformedPoint = [&](double x, double y) {
+      transformedMinX = std::min(transformedMinX, x);
+      transformedMinY = std::min(transformedMinY, y);
+      transformedMaxX = std::max(transformedMaxX, x);
+      transformedMaxY = std::max(transformedMaxY, y);
+    };
+
+    for (const auto &polygon : svg.fills) {
+      for (const auto &pt : polygon.points) {
+        const auto transformedPoint = transformedSvgPoint(pt.x, pt.y);
+        includeTransformedPoint(transformedPoint[0], transformedPoint[1]);
+      }
+      for (const auto &hole : polygon.holes) {
+        for (const auto &pt : hole) {
+          const auto transformedPoint = transformedSvgPoint(pt.x, pt.y);
+          includeTransformedPoint(transformedPoint[0], transformedPoint[1]);
+        }
+      }
+    }
+    for (const auto &line : svg.strokes) {
+      for (const auto &pt : line.points) {
+        const auto transformedPoint = transformedSvgPoint(pt.x, pt.y);
+        includeTransformedPoint(transformedPoint[0], transformedPoint[1]);
+      }
+    }
+
     std::ostringstream symbolContent;
     symbolContent << formatter.Format(fillRgb[0]) << " "
                   << formatter.Format(fillRgb[1]) << " "
@@ -1161,15 +1224,15 @@ Viewer2DExportResult ExportLayoutToPdf(
     auto appendPolygonPath = [&](const std::vector<PerastageSvgPoint> &points) {
       if (points.size() < 3)
         return;
-      symbolContent << formatter.Format((points[0].x + svg.offsetXmm) * symbolScale)
+      symbolContent << formatter.Format(transformedSvgPoint(points[0].x, points[0].y)[0] * symbolScale)
                     << ' '
-                    << formatter.Format((points[0].y + svg.offsetYmm) * symbolScale)
+                    << formatter.Format(transformedSvgPoint(points[0].x, points[0].y)[1] * symbolScale)
                     << " m\n";
       for (size_t i = 1; i < points.size(); ++i) {
         symbolContent
-            << formatter.Format((points[i].x + svg.offsetXmm) * symbolScale)
+            << formatter.Format(transformedSvgPoint(points[i].x, points[i].y)[0] * symbolScale)
             << ' '
-            << formatter.Format((points[i].y + svg.offsetYmm) * symbolScale)
+            << formatter.Format(transformedSvgPoint(points[i].x, points[i].y)[1] * symbolScale)
             << " l\n";
       }
       symbolContent << "h\n";
@@ -1187,15 +1250,15 @@ Viewer2DExportResult ExportLayoutToPdf(
       if (line.points.size() < 2)
         continue;
       symbolContent
-          << formatter.Format((line.points[0].x + svg.offsetXmm) * symbolScale)
+          << formatter.Format(transformedSvgPoint(line.points[0].x, line.points[0].y)[0] * symbolScale)
           << ' '
-          << formatter.Format((line.points[0].y + svg.offsetYmm) * symbolScale)
+          << formatter.Format(transformedSvgPoint(line.points[0].x, line.points[0].y)[1] * symbolScale)
           << " m\n";
       for (size_t i = 1; i < line.points.size(); ++i) {
         symbolContent
-            << formatter.Format((line.points[i].x + svg.offsetXmm) * symbolScale)
+            << formatter.Format(transformedSvgPoint(line.points[i].x, line.points[i].y)[0] * symbolScale)
             << ' '
-            << formatter.Format((line.points[i].y + svg.offsetYmm) * symbolScale)
+            << formatter.Format(transformedSvgPoint(line.points[i].x, line.points[i].y)[1] * symbolScale)
             << " l\n";
       }
       symbolContent << "S\n";
@@ -1211,11 +1274,18 @@ Viewer2DExportResult ExportLayoutToPdf(
     const std::string &stream = compressed ? compressedSymbol : symbolStream;
 
     std::ostringstream xobj;
+    if (transformedMinX > transformedMaxX || transformedMinY > transformedMaxY) {
+      transformedMinX = minX;
+      transformedMinY = minY;
+      transformedMaxX = maxX;
+      transformedMaxY = maxY;
+    }
+
     xobj << "<< /Type /XObject /Subtype /Form /BBox ["
-         << formatter.Format(minX * symbolScale) << ' '
-         << formatter.Format(minY * symbolScale) << ' '
-         << formatter.Format(maxX * symbolScale) << ' '
-         << formatter.Format(maxY * symbolScale)
+         << formatter.Format(transformedMinX * symbolScale) << ' '
+         << formatter.Format(transformedMinY * symbolScale) << ' '
+         << formatter.Format(transformedMaxX * symbolScale) << ' '
+         << formatter.Format(transformedMaxY * symbolScale)
          << "] /Resources << >> /Length " << stream.size();
     if (compressed)
       xobj << " /Filter /FlateDecode";
@@ -1259,13 +1329,27 @@ Viewer2DExportResult ExportLayoutToPdf(
         auto defIt = symbolSnapshot->find(entry.first);
         if (defIt == symbolSnapshot->end())
           continue;
-        xObjectNameIds[entry.second] =
-            appendSymbolObject(entry.second,
-                               defIt->second.localCommands.commands,
-                               defIt->second.localCommands.metadata,
-                               defIt->second.localCommands.sources,
-                               1.0, group.strokeScale,
-                               defIt->second.bounds);
+        bool usedSvg = false;
+        if (!defIt->second.key.modelKey.empty()) {
+          if (const PerastageSvgSymbolData *svg =
+                  findLegendSvg(defIt->second.key.modelKey,
+                                defIt->second.key.viewKind)) {
+            xObjectNameIds[entry.second] =
+                appendPerastageSvgSymbolObject(*svg, defIt->second.key.viewKind,
+                                               0.001, group.strokeScale,
+                                               resolveSymbolFillRgb(defIt->second));
+            usedSvg = true;
+          }
+        }
+        if (!usedSvg) {
+          xObjectNameIds[entry.second] =
+              appendSymbolObject(entry.second,
+                                 defIt->second.localCommands.commands,
+                                 defIt->second.localCommands.metadata,
+                                 defIt->second.localCommands.sources,
+                                 1.0, group.strokeScale,
+                                 defIt->second.bounds);
+        }
       }
     }
   }
@@ -1294,8 +1378,8 @@ Viewer2DExportResult ExportLayoutToPdf(
           constexpr std::array<double, 3> kDefaultSvgFillRgb = {
               224.0 / 255.0, 224.0 / 255.0, 224.0 / 255.0};
           xObjectNameIds[entry.second] =
-              appendPerastageSvgSymbolObject(*svg, symbolScale,
-                                             legendStrokeScale,
+              appendPerastageSvgSymbolObject(*svg, defIt->second.key.viewKind,
+                                             symbolScale, legendStrokeScale,
                                              kDefaultSvgFillRgb);
           usedSvg = true;
         }

--- a/viewer2d/pdf/layout_pdf_exporter.cpp
+++ b/viewer2d/pdf/layout_pdf_exporter.cpp
@@ -51,7 +51,6 @@ using namespace layout_pdf_internal;
 
 constexpr double kLegendContentScale = 0.7;
 constexpr double kPdfPointsPerPixel = 72.0 / 96.0;
-constexpr double kMillimetersToMeters = 0.001;
 constexpr double kLegendSymbolSize =
     96.0 * 2.0 / 3.0 * kLegendContentScale;
 constexpr double kLegendFontScale =
@@ -943,30 +942,6 @@ Viewer2DExportResult ExportLayoutToPdf(
     }
     return it->second ? &it->second.value() : nullptr;
   };
-  auto resolveSymbolFillRgb = [&](const SymbolDefinition &definition) {
-    std::array<double, 3> fillRgb = {224.0 / 255.0, 224.0 / 255.0, 224.0 / 255.0};
-    for (const auto &cmd : definition.localCommands.commands) {
-      if (const auto *polygon = std::get_if<PolygonCommand>(&cmd)) {
-        if (polygon->hasFill) {
-          fillRgb = {polygon->fill.color.r, polygon->fill.color.g,
-                     polygon->fill.color.b};
-          break;
-        }
-      } else if (const auto *rect = std::get_if<RectangleCommand>(&cmd)) {
-        if (rect->hasFill) {
-          fillRgb = {rect->fill.color.r, rect->fill.color.g, rect->fill.color.b};
-          break;
-        }
-      } else if (const auto *circle = std::get_if<CircleCommand>(&cmd)) {
-        if (circle->hasFill) {
-          fillRgb = {circle->fill.color.r, circle->fill.color.g,
-                     circle->fill.color.b};
-          break;
-        }
-      }
-    }
-    return fillRgb;
-  };
   const double legendStrokeScale = 1.0 / viewer2d::kViewer2DPixelsPerMeter;
   auto makeLegendIdName = [](uint32_t symbolId) {
     return "L" + std::to_string(symbolId);
@@ -1279,33 +1254,18 @@ Viewer2DExportResult ExportLayoutToPdf(
                              defIt->second.metadata, defIt->second.sources,
                              1.0, group.strokeScale, bounds);
     }
-
     if (symbolSnapshot) {
       for (const auto &entry : viewIdNames) {
         auto defIt = symbolSnapshot->find(entry.first);
         if (defIt == symbolSnapshot->end())
           continue;
-        bool usedSvg = false;
-        if (!defIt->second.key.modelKey.empty()) {
-          if (const PerastageSvgSymbolData *svg =
-                  findLegendSvg(defIt->second.key.modelKey,
-                                defIt->second.key.viewKind)) {
-            xObjectNameIds[entry.second] =
-                appendPerastageSvgSymbolObject(*svg, kMillimetersToMeters,
-                                               group.strokeScale,
-                                               resolveSymbolFillRgb(defIt->second));
-            usedSvg = true;
-          }
-        }
-        if (!usedSvg) {
-          xObjectNameIds[entry.second] =
-              appendSymbolObject(entry.second,
-                                 defIt->second.localCommands.commands,
-                                 defIt->second.localCommands.metadata,
-                                 defIt->second.localCommands.sources,
-                                 1.0, group.strokeScale,
-                                 defIt->second.bounds);
-        }
+        xObjectNameIds[entry.second] =
+            appendSymbolObject(entry.second,
+                               defIt->second.localCommands.commands,
+                               defIt->second.localCommands.metadata,
+                               defIt->second.localCommands.sources,
+                               1.0, group.strokeScale,
+                               defIt->second.bounds);
       }
     }
   }

--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -7,6 +7,9 @@
 #undef DrawText
 #endif
 
+#include <algorithm>
+#include <cmath>
+
 #include <GL/glew.h>
 #ifdef __APPLE__
 #define GL_SILENCE_DEPRECATION
@@ -21,6 +24,19 @@
 #include "perastage_svg_symbol_builder.h"
 #include "scenedatamanager.h"
 #include "viewer3dcontroller.h"
+
+namespace {
+uint32_t BuildSymbolStyleVersion(float r, float g, float b) {
+  auto to8 = [](float c) {
+    const float clamped = std::clamp(c, 0.0f, 1.0f);
+    return static_cast<uint32_t>(std::lround(clamped * 255.0f));
+  };
+  const uint32_t r8 = to8(r);
+  const uint32_t g8 = to8(g);
+  const uint32_t b8 = to8(b);
+  return 1u + (r8 << 16) + (g8 << 8) + b8;
+}
+} // namespace
 
 void OpaqueFixturePass::Render(
     Viewer3DController &controller, const RenderFrameContext &context,
@@ -145,7 +161,7 @@ void OpaqueFixturePass::Render(
         SymbolKey symbolKey;
         symbolKey.modelKey = modelKey;
         symbolKey.viewKind = resolveSymbolView(fixtureCaptureView);
-        symbolKey.styleVersion = 1;
+        symbolKey.styleVersion = BuildSymbolStyleVersion(r, g, b);
 
         const auto &symbol =
             controller.m_bottomSymbolCache.GetOrCreate(symbolKey, [&](const SymbolKey &,

--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -170,6 +170,7 @@ void OpaqueFixturePass::Render(
               if (TryBuildPerastageSvgSymbolDefinition(gdtfPath,
                                                        symbolKey.viewKind,
                                                        symbolId,
+                                                       {r, g, b},
                                                        svgDefinition)) {
                 return svgDefinition;
               }

--- a/viewer3d/render/perastage_svg_symbol_builder.cpp
+++ b/viewer3d/render/perastage_svg_symbol_builder.cpp
@@ -9,7 +9,9 @@ namespace {
 constexpr float kDefaultStrokeWidthMeters = 0.001f;
 constexpr float kMillimetersToMeters = 0.001f;
 
-void AppendSvgPolygon(const PerastageSvgPolygon &polygon, CommandBuffer &buffer) {
+void AppendSvgPolygon(const PerastageSvgPolygon &polygon,
+                      const std::array<float, 3> &fillColor,
+                      CommandBuffer &buffer) {
   if (polygon.points.size() < 3)
     return;
 
@@ -21,7 +23,7 @@ void AppendSvgPolygon(const PerastageSvgPolygon &polygon, CommandBuffer &buffer)
   }
   poly.stroke.color = {0.0f, 0.0f, 0.0f, 1.0f};
   poly.stroke.width = kDefaultStrokeWidthMeters;
-  poly.fill.color = {0.878f, 0.878f, 0.878f, 1.0f};
+  poly.fill.color = {fillColor[0], fillColor[1], fillColor[2], 1.0f};
   poly.hasFill = true;
 
   buffer.commands.emplace_back(std::move(poly));
@@ -51,6 +53,7 @@ void AppendSvgPolyline(const PerastageSvgPolyline &line, CommandBuffer &buffer) 
 bool TryBuildPerastageSvgSymbolDefinition(const std::string &gdtfPath,
                                           SymbolViewKind viewKind,
                                           uint32_t symbolId,
+                                          const std::array<float, 3> &fillColor,
                                           SymbolDefinition &out) {
   PerastageSvgSymbolData svg;
   if (!LoadPerastageSvgSymbolFromGdtf(gdtfPath, viewKind, svg))
@@ -63,7 +66,7 @@ bool TryBuildPerastageSvgSymbolDefinition(const std::string &gdtfPath,
   out.localCommands.currentSourceKey = "svg";
 
   for (const auto &polygon : svg.fills)
-    AppendSvgPolygon(polygon, out.localCommands);
+    AppendSvgPolygon(polygon, fillColor, out.localCommands);
   for (const auto &line : svg.strokes)
     AppendSvgPolyline(line, out.localCommands);
 

--- a/viewer3d/render/perastage_svg_symbol_builder.cpp
+++ b/viewer3d/render/perastage_svg_symbol_builder.cpp
@@ -6,7 +6,8 @@
 #include "symbols/PerastageSvgSymbol.h"
 
 namespace {
-constexpr float kDefaultStrokeWidth = 1.0f;
+constexpr float kDefaultStrokeWidthMeters = 0.001f;
+constexpr float kMillimetersToMeters = 0.001f;
 
 void AppendSvgPolygon(const PerastageSvgPolygon &polygon, CommandBuffer &buffer) {
   if (polygon.points.size() < 3)
@@ -15,11 +16,11 @@ void AppendSvgPolygon(const PerastageSvgPolygon &polygon, CommandBuffer &buffer)
   PolygonCommand poly{};
   poly.points.reserve(polygon.points.size() * 2);
   for (const auto &point : polygon.points) {
-    poly.points.push_back(static_cast<float>(point.x));
-    poly.points.push_back(static_cast<float>(point.y));
+    poly.points.push_back(static_cast<float>(point.x) * kMillimetersToMeters);
+    poly.points.push_back(static_cast<float>(point.y) * kMillimetersToMeters);
   }
   poly.stroke.color = {0.0f, 0.0f, 0.0f, 1.0f};
-  poly.stroke.width = kDefaultStrokeWidth;
+  poly.stroke.width = kDefaultStrokeWidthMeters;
   poly.fill.color = {0.878f, 0.878f, 0.878f, 1.0f};
   poly.hasFill = true;
 
@@ -35,11 +36,11 @@ void AppendSvgPolyline(const PerastageSvgPolyline &line, CommandBuffer &buffer) 
   PolylineCommand polyline{};
   polyline.points.reserve(line.points.size() * 2);
   for (const auto &point : line.points) {
-    polyline.points.push_back(static_cast<float>(point.x));
-    polyline.points.push_back(static_cast<float>(point.y));
+    polyline.points.push_back(static_cast<float>(point.x) * kMillimetersToMeters);
+    polyline.points.push_back(static_cast<float>(point.y) * kMillimetersToMeters);
   }
   polyline.stroke.color = {0.0f, 0.0f, 0.0f, 1.0f};
-  polyline.stroke.width = kDefaultStrokeWidth;
+  polyline.stroke.width = kDefaultStrokeWidthMeters;
 
   buffer.commands.emplace_back(std::move(polyline));
   buffer.metadata.push_back({true, false});
@@ -72,13 +73,15 @@ bool TryBuildPerastageSvgSymbolDefinition(const std::string &gdtfPath,
   for (auto &cmd : out.localCommands.commands) {
     if (auto *polygon = std::get_if<PolygonCommand>(&cmd)) {
       for (size_t i = 0; i + 1 < polygon->points.size(); i += 2) {
-        polygon->points[i] += static_cast<float>(svg.offsetXmm);
-        polygon->points[i + 1] += static_cast<float>(svg.offsetYmm);
+        polygon->points[i] += static_cast<float>(svg.offsetXmm) * kMillimetersToMeters;
+        polygon->points[i + 1] += static_cast<float>(svg.offsetYmm) *
+                                  kMillimetersToMeters;
       }
     } else if (auto *polyline = std::get_if<PolylineCommand>(&cmd)) {
       for (size_t i = 0; i + 1 < polyline->points.size(); i += 2) {
-        polyline->points[i] += static_cast<float>(svg.offsetXmm);
-        polyline->points[i + 1] += static_cast<float>(svg.offsetYmm);
+        polyline->points[i] += static_cast<float>(svg.offsetXmm) * kMillimetersToMeters;
+        polyline->points[i + 1] += static_cast<float>(svg.offsetYmm) *
+                                   kMillimetersToMeters;
       }
     }
   }

--- a/viewer3d/render/perastage_svg_symbol_builder.cpp
+++ b/viewer3d/render/perastage_svg_symbol_builder.cpp
@@ -11,8 +11,7 @@ namespace {
 constexpr float kDefaultStrokeWidthMeters = 0.001f;
 constexpr float kMillimetersToMeters = 0.001f;
 
-void MirrorSymbolGeometryAroundMinCorner(CommandBuffer &buffer) {
-  float minX = std::numeric_limits<float>::max();
+void MirrorSymbolGeometryForBottomFallback(CommandBuffer &buffer) {
   float minY = std::numeric_limits<float>::max();
   bool hasPoint = false;
 
@@ -23,15 +22,13 @@ void MirrorSymbolGeometryAroundMinCorner(CommandBuffer &buffer) {
 
   for (auto &cmd : buffer.commands) {
     if (auto *polygon = std::get_if<PolygonCommand>(&cmd)) {
-      visitPoints(polygon->points, [&](float x, float y) {
+      visitPoints(polygon->points, [&](float, float y) {
         hasPoint = true;
-        minX = std::min(minX, x);
         minY = std::min(minY, y);
       });
     } else if (auto *polyline = std::get_if<PolylineCommand>(&cmd)) {
-      visitPoints(polyline->points, [&](float x, float y) {
+      visitPoints(polyline->points, [&](float, float y) {
         hasPoint = true;
-        minX = std::min(minX, x);
         minY = std::min(minY, y);
       });
     }
@@ -42,13 +39,11 @@ void MirrorSymbolGeometryAroundMinCorner(CommandBuffer &buffer) {
 
   for (auto &cmd : buffer.commands) {
     if (auto *polygon = std::get_if<PolygonCommand>(&cmd)) {
-      visitPoints(polygon->points, [&](float &x, float &y) {
-        x = 2.0f * minX - x;
+      visitPoints(polygon->points, [&](float &, float &y) {
         y = 2.0f * minY - y;
       });
     } else if (auto *polyline = std::get_if<PolylineCommand>(&cmd)) {
-      visitPoints(polyline->points, [&](float &x, float &y) {
-        x = 2.0f * minX - x;
+      visitPoints(polyline->points, [&](float &, float &y) {
         y = 2.0f * minY - y;
       });
     }
@@ -76,6 +71,34 @@ void AppendSvgPolygon(const PerastageSvgPolygon &polygon,
   buffer.commands.emplace_back(std::move(poly));
   buffer.metadata.push_back({true, true});
   buffer.sources.push_back("svg");
+}
+
+
+void AppendSvgHoleContours(const PerastageSvgPolygon &polygon,
+                           CommandBuffer &buffer) {
+  for (const auto &hole : polygon.holes) {
+    if (hole.size() < 3)
+      continue;
+
+    PolylineCommand contour{};
+    contour.points.reserve((hole.size() + 1) * 2);
+    for (const auto &point : hole) {
+      contour.points.push_back(static_cast<float>(point.x) *
+                               kMillimetersToMeters);
+      contour.points.push_back(static_cast<float>(point.y) *
+                               kMillimetersToMeters);
+    }
+    contour.points.push_back(static_cast<float>(hole.front().x) *
+                             kMillimetersToMeters);
+    contour.points.push_back(static_cast<float>(hole.front().y) *
+                             kMillimetersToMeters);
+    contour.stroke.color = {0.0f, 0.0f, 0.0f, 1.0f};
+    contour.stroke.width = kDefaultStrokeWidthMeters;
+
+    buffer.commands.emplace_back(std::move(contour));
+    buffer.metadata.push_back({true, false});
+    buffer.sources.push_back("svg");
+  }
 }
 
 void AppendSvgPolyline(const PerastageSvgPolyline &line, CommandBuffer &buffer) {
@@ -112,8 +135,10 @@ bool TryBuildPerastageSvgSymbolDefinition(const std::string &gdtfPath,
   out.symbolId = symbolId;
   out.localCommands.currentSourceKey = "svg";
 
-  for (const auto &polygon : svg.fills)
+  for (const auto &polygon : svg.fills) {
     AppendSvgPolygon(polygon, fillColor, out.localCommands);
+    AppendSvgHoleContours(polygon, out.localCommands);
+  }
   for (const auto &line : svg.strokes)
     AppendSvgPolyline(line, out.localCommands);
 
@@ -137,7 +162,7 @@ bool TryBuildPerastageSvgSymbolDefinition(const std::string &gdtfPath,
   }
 
   if (viewKind == SymbolViewKind::Bottom && svg.viewKind == SymbolViewKind::Top)
-    MirrorSymbolGeometryAroundMinCorner(out.localCommands);
+    MirrorSymbolGeometryForBottomFallback(out.localCommands);
 
   out.bounds = ComputeSymbolBounds(out.localCommands);
   return true;

--- a/viewer3d/render/perastage_svg_symbol_builder.cpp
+++ b/viewer3d/render/perastage_svg_symbol_builder.cpp
@@ -1,6 +1,8 @@
 #include "perastage_svg_symbol_builder.h"
 
+#include <algorithm>
 #include <vector>
+#include <limits>
 
 #include "opaque_pass_utils.h"
 #include "symbols/PerastageSvgSymbol.h"
@@ -8,6 +10,51 @@
 namespace {
 constexpr float kDefaultStrokeWidthMeters = 0.001f;
 constexpr float kMillimetersToMeters = 0.001f;
+
+void MirrorSymbolGeometryAroundMinCorner(CommandBuffer &buffer) {
+  float minX = std::numeric_limits<float>::max();
+  float minY = std::numeric_limits<float>::max();
+  bool hasPoint = false;
+
+  auto visitPoints = [&](auto &points, const auto &fn) {
+    for (size_t i = 0; i + 1 < points.size(); i += 2)
+      fn(points[i], points[i + 1]);
+  };
+
+  for (auto &cmd : buffer.commands) {
+    if (auto *polygon = std::get_if<PolygonCommand>(&cmd)) {
+      visitPoints(polygon->points, [&](float x, float y) {
+        hasPoint = true;
+        minX = std::min(minX, x);
+        minY = std::min(minY, y);
+      });
+    } else if (auto *polyline = std::get_if<PolylineCommand>(&cmd)) {
+      visitPoints(polyline->points, [&](float x, float y) {
+        hasPoint = true;
+        minX = std::min(minX, x);
+        minY = std::min(minY, y);
+      });
+    }
+  }
+
+  if (!hasPoint)
+    return;
+
+  for (auto &cmd : buffer.commands) {
+    if (auto *polygon = std::get_if<PolygonCommand>(&cmd)) {
+      visitPoints(polygon->points, [&](float &x, float &y) {
+        x = 2.0f * minX - x;
+        y = 2.0f * minY - y;
+      });
+    } else if (auto *polyline = std::get_if<PolylineCommand>(&cmd)) {
+      visitPoints(polyline->points, [&](float &x, float &y) {
+        x = 2.0f * minX - x;
+        y = 2.0f * minY - y;
+      });
+    }
+  }
+}
+
 
 void AppendSvgPolygon(const PerastageSvgPolygon &polygon,
                       const std::array<float, 3> &fillColor,
@@ -88,6 +135,9 @@ bool TryBuildPerastageSvgSymbolDefinition(const std::string &gdtfPath,
       }
     }
   }
+
+  if (viewKind == SymbolViewKind::Bottom && svg.viewKind == SymbolViewKind::Top)
+    MirrorSymbolGeometryAroundMinCorner(out.localCommands);
 
   out.bounds = ComputeSymbolBounds(out.localCommands);
   return true;

--- a/viewer3d/render/perastage_svg_symbol_builder.h
+++ b/viewer3d/render/perastage_svg_symbol_builder.h
@@ -2,9 +2,12 @@
 
 #include <string>
 
+#include <array>
+
 #include "symbolcache.h"
 
 bool TryBuildPerastageSvgSymbolDefinition(const std::string &gdtfPath,
                                           SymbolViewKind viewKind,
                                           uint32_t symbolId,
+                                          const std::array<float, 3> &fillColor,
                                           SymbolDefinition &out);


### PR DESCRIPTION
### Motivation
- 2D fixture instances could disappear from printed layout PDFs when their SVG-backed symbols were not handled correctly during XObject generation. 
- The PDF export reported only the first SVG load error which made diagnosis difficult when multiple models failed to load SVGs.

### Description
- Replace the single `firstLegendSvgLoadError` with a `svgLoadIssues` map to collect per-model SVG load errors in `viewer2d/pdf/layout_pdf_exporter.cpp` so all failures are recorded. 
- Always emit symbol XObjects for view instances from the cached `localCommands` (symbol snapshot) so symbol instances appear in the PDF even when SVG-specific code paths are present. 
- Preserve existing legend SVG rendering and the fallback path: legend rendering still attempts SVG, and non-SVG symbols continue to use the pre-recorded commands. 
- Improve the final export message to aggregate and list all model keys whose SVGs were skipped instead of reporting a single error.

### Testing
- Executed `tests/check_perastage_tree_modules.sh` which passed. 
- Executed `tests/check_no_configmanager_get_in_gui.sh` which passed. 
- No additional automated unit tests were added for this focused change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c9fb053748324a9def174d5569b9a)