### PR TITLE
Improve 3D element separation with lightweight enhanced lighting

### DIFF
--- a/viewer3d/CMakeLists.txt
+++ b/viewer3d/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/meshprimitives.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/picking/selectionsystem.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/gl_primitive_renderer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/render/lighting_profile.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/opaque_fixture_pass.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/opaque_object_pass.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/opaque_pass_utils.cpp

--- a/viewer3d/render/lighting_profile.cpp
+++ b/viewer3d/render/lighting_profile.cpp
@@ -1,0 +1,66 @@
+#include "lighting_profile.h"
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#undef DrawText
+#endif
+
+#include <GL/glew.h>
+#ifdef __APPLE__
+#define GL_SILENCE_DEPRECATION
+#include <OpenGL/gl.h>
+#else
+#include <GL/gl.h>
+#endif
+
+namespace Viewer3DLightingProfile {
+
+void ApplyEnhancedBasicLighting() {
+  glEnable(GL_LIGHTING);
+  // Keep normal lengths stable after model transforms with scaling.
+  glEnable(GL_NORMALIZE);
+  glEnable(GL_CULL_FACE);
+  glCullFace(GL_BACK);
+  glFrontFace(GL_CCW);
+
+  // Slightly lower ambient contribution and add multiple directional lights.
+  // This improves depth cues for similar gray materials at low runtime cost.
+  const GLfloat globalAmbient[] = {0.14f, 0.14f, 0.14f, 1.0f};
+  glLightModelfv(GL_LIGHT_MODEL_AMBIENT, globalAmbient);
+  glLightModeli(GL_LIGHT_MODEL_TWO_SIDE, GL_TRUE);
+
+  const GLfloat keyAmbient[] = {0.08f, 0.08f, 0.08f, 1.0f};
+  const GLfloat keyDiffuse[] = {0.78f, 0.78f, 0.78f, 1.0f};
+  const GLfloat keySpecular[] = {0.35f, 0.35f, 0.35f, 1.0f};
+  const GLfloat keyPosition[] = {2.0f, -4.0f, 5.0f, 0.0f};
+
+  glEnable(GL_LIGHT0);
+  glLightfv(GL_LIGHT0, GL_AMBIENT, keyAmbient);
+  glLightfv(GL_LIGHT0, GL_DIFFUSE, keyDiffuse);
+  glLightfv(GL_LIGHT0, GL_SPECULAR, keySpecular);
+  glLightfv(GL_LIGHT0, GL_POSITION, keyPosition);
+
+  const GLfloat fillAmbient[] = {0.0f, 0.0f, 0.0f, 1.0f};
+  const GLfloat fillDiffuse[] = {0.32f, 0.32f, 0.36f, 1.0f};
+  const GLfloat fillSpecular[] = {0.0f, 0.0f, 0.0f, 1.0f};
+  const GLfloat fillPosition[] = {-1.5f, 2.0f, 1.0f, 0.0f};
+
+  glEnable(GL_LIGHT1);
+  glLightfv(GL_LIGHT1, GL_AMBIENT, fillAmbient);
+  glLightfv(GL_LIGHT1, GL_DIFFUSE, fillDiffuse);
+  glLightfv(GL_LIGHT1, GL_SPECULAR, fillSpecular);
+  glLightfv(GL_LIGHT1, GL_POSITION, fillPosition);
+
+  glEnable(GL_COLOR_MATERIAL);
+  glColorMaterial(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE);
+
+  const GLfloat materialSpecular[] = {0.18f, 0.18f, 0.18f, 1.0f};
+  glMaterialfv(GL_FRONT_AND_BACK, GL_SPECULAR, materialSpecular);
+  glMaterialf(GL_FRONT_AND_BACK, GL_SHININESS, 24.0f);
+
+  glShadeModel(GL_SMOOTH);
+}
+
+} // namespace Viewer3DLightingProfile

--- a/viewer3d/render/lighting_profile.h
+++ b/viewer3d/render/lighting_profile.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace Viewer3DLightingProfile {
+
+void ApplyEnhancedBasicLighting();
+
+} // namespace Viewer3DLightingProfile

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -63,6 +63,7 @@
 #include "label_render_system.h"
 #include "selectionsystem.h"
 #include "gl_primitive_renderer.h"
+#include "lighting_profile.h"
 
 #include <wx/wx.h>
 #define NANOVG_GL2_IMPLEMENTATION
@@ -1406,29 +1407,7 @@ void Viewer3DController::ApplyTransform(const float matrix[16],
 
 // Initializes simple lighting for the scene
 void Viewer3DController::SetupBasicLighting() {
-  glEnable(GL_LIGHTING);
-  // Keep normal lengths stable after model transforms with scaling.
-  glEnable(GL_NORMALIZE);
-  glEnable(GL_LIGHT0);
-  glEnable(GL_CULL_FACE);
-  glCullFace(GL_BACK);
-  glFrontFace(GL_CCW);
-
-  GLfloat ambient[] = {0.2f, 0.2f, 0.2f, 1.0f};
-  GLfloat diffuse[] = {0.8f, 0.8f, 0.8f, 1.0f};
-  GLfloat specular[] = {1.0f, 1.0f, 1.0f, 1.0f};
-  GLfloat position[] = {2.0f, -4.0f, 5.0f, 0.0f};
-
-  glLightfv(GL_LIGHT0, GL_AMBIENT, ambient);
-  glLightfv(GL_LIGHT0, GL_DIFFUSE, diffuse);
-  glLightfv(GL_LIGHT0, GL_SPECULAR, specular);
-  glLightfv(GL_LIGHT0, GL_POSITION, position);
-
-  glLightModeli(GL_LIGHT_MODEL_TWO_SIDE, GL_TRUE);
-
-  glEnable(GL_COLOR_MATERIAL);
-  glColorMaterial(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE);
-  glShadeModel(GL_SMOOTH);
+  Viewer3DLightingProfile::ApplyEnhancedBasicLighting();
 }
 
 void Viewer3DController::DrawFixtureLabels(int width, int height) {


### PR DESCRIPTION
### Motivation
- The 3D viewer can look flat when many objects use similar gray tones, making elements hard to distinguish. 
- The goal was to improve depth cues and visual separation with minimal runtime cost and without introducing a heavy SSAO/post-process pipeline. 

### Description
- Extracted lighting setup into a new render unit `viewer3d/render/lighting_profile.h` and `viewer3d/render/lighting_profile.cpp` that exposes `Viewer3DLightingProfile::ApplyEnhancedBasicLighting()`. 
- Replaced the previous inline lighting code by calling `Viewer3DLightingProfile::ApplyEnhancedBasicLighting()` from `Viewer3DController::SetupBasicLighting()`. 
- The new profile reduces global ambient contribution, adds a key directional light (`GL_LIGHT0`) and a fill directional light (`GL_LIGHT1`), and tunes material specular/shininess to improve volume cues at low cost. 
- Added the new source to `viewer3d/CMakeLists.txt` so the module is built as part of the `viewer3d` target. 

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699da68d7edc83248c0d6a5a41fa2ac0)