### PR TITLE
Add ambient occlusion config toggle and propagate to 3D lighting

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -146,6 +146,8 @@ ConfigManager::ConfigManager() {
                    1.0f);
   RegisterVariable("viewer3d_fast_interaction_mode", "float", 1.0f, 0.0f,
                    1.0f);
+  RegisterVariable("viewer3d_ambient_occlusion", "float", 1.0f, 0.0f,
+                   1.0f);
   RegisterVariable("render_culling_enabled", "float", 1.0f, 0.0f, 1.0f);
   RegisterVariable("render_culling_min_pixels_3d", "float", 2.0f, 0.0f,
                    64.0f);

--- a/viewer3d/render/lighting_profile.cpp
+++ b/viewer3d/render/lighting_profile.cpp
@@ -17,7 +17,7 @@
 
 namespace Viewer3DLightingProfile {
 
-void ApplyEnhancedBasicLighting() {
+void ApplyEnhancedBasicLighting(const LightingOptions &options) {
   glEnable(GL_LIGHTING);
   // Keep normal lengths stable after model transforms with scaling.
   glEnable(GL_NORMALIZE);
@@ -27,7 +27,11 @@ void ApplyEnhancedBasicLighting() {
 
   // Slightly lower ambient contribution and add multiple directional lights.
   // This improves depth cues for similar gray materials at low runtime cost.
-  const GLfloat globalAmbient[] = {0.14f, 0.14f, 0.14f, 1.0f};
+  const float globalAmbientIntensity =
+      options.ambientOcclusionEnabled ? 0.08f : 0.14f;
+  const GLfloat globalAmbient[] = {globalAmbientIntensity,
+                                   globalAmbientIntensity,
+                                   globalAmbientIntensity, 1.0f};
   glLightModelfv(GL_LIGHT_MODEL_AMBIENT, globalAmbient);
   glLightModeli(GL_LIGHT_MODEL_TWO_SIDE, GL_TRUE);
 
@@ -43,7 +47,10 @@ void ApplyEnhancedBasicLighting() {
   glLightfv(GL_LIGHT0, GL_POSITION, keyPosition);
 
   const GLfloat fillAmbient[] = {0.0f, 0.0f, 0.0f, 1.0f};
-  const GLfloat fillDiffuse[] = {0.32f, 0.32f, 0.36f, 1.0f};
+  const float fillDiffuseIntensity =
+      options.ambientOcclusionEnabled ? 0.24f : 0.32f;
+  const GLfloat fillDiffuse[] = {fillDiffuseIntensity, fillDiffuseIntensity,
+                                 fillDiffuseIntensity + 0.04f, 1.0f};
   const GLfloat fillSpecular[] = {0.0f, 0.0f, 0.0f, 1.0f};
   const GLfloat fillPosition[] = {-1.5f, 2.0f, 1.0f, 0.0f};
 

--- a/viewer3d/render/lighting_profile.h
+++ b/viewer3d/render/lighting_profile.h
@@ -2,6 +2,10 @@
 
 namespace Viewer3DLightingProfile {
 
-void ApplyEnhancedBasicLighting();
+struct LightingOptions {
+  bool ambientOcclusionEnabled = true;
+};
+
+void ApplyEnhancedBasicLighting(const LightingOptions &options);
 
 } // namespace Viewer3DLightingProfile

--- a/viewer3d/viewer3d_types.h
+++ b/viewer3d/viewer3d_types.h
@@ -62,6 +62,7 @@ struct RenderFrameContext {
   bool is2DViewer = false;
 
   bool useLighting = true;
+  bool useAmbientOcclusion = true;
   bool drawGridBeforeScene = false;
   bool drawGridAfterScene = false;
   bool useFrustumCulling = false;

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -960,6 +960,8 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
   const bool isByLayerMode = context.mode == Viewer2DRenderMode::ByLayer;
 
   context.useLighting = !context.wireframe;
+  context.useAmbientOcclusion =
+      cfg.GetFloat("viewer3d_ambient_occlusion") >= 0.5f;
 
   const bool shouldDrawGrid = context.showGrid;
   const bool shouldDrawGridBeforeScene = shouldDrawGrid && !context.gridOnTop;
@@ -1050,7 +1052,7 @@ void Viewer3DController::RenderOpaqueFrame(const RenderFrameContext &context,
   const Viewer2DView view = context.view;
 
   if (context.useLighting)
-    SetupBasicLighting();
+    SetupBasicLighting(context.useAmbientOcclusion);
   else
     glDisable(GL_LIGHTING);
 
@@ -1406,8 +1408,10 @@ void Viewer3DController::ApplyTransform(const float matrix[16],
 }
 
 // Initializes simple lighting for the scene
-void Viewer3DController::SetupBasicLighting() {
-  Viewer3DLightingProfile::ApplyEnhancedBasicLighting();
+void Viewer3DController::SetupBasicLighting(bool ambientOcclusionEnabled) {
+  Viewer3DLightingProfile::LightingOptions options;
+  options.ambientOcclusionEnabled = ambientOcclusionEnabled;
+  Viewer3DLightingProfile::ApplyEnhancedBasicLighting(options);
 }
 
 void Viewer3DController::DrawFixtureLabels(int width, int height) {

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -204,7 +204,7 @@ private:
   void DrawGrid(int style, float r, float g, float b,
                 Viewer2DView view = Viewer2DView::Top);
   void DrawAxes();
-  void SetupBasicLighting();
+  void SetupBasicLighting(bool ambientOcclusionEnabled);
   void SetupMaterialFromRGB(float r, float g, float b);
   void SetGLColor(float r, float g, float b) const override;
   std::array<float, 3> AdjustColor(float r, float g, float b) const;


### PR DESCRIPTION
### Motivation

- Provide an ambient occlusion (AO) toggle path for the 3D viewer so AO can be selected later in UI while keeping it enabled by default. 

### Description

- Added a new config variable `viewer3d_ambient_occlusion` (default `1.0`) so AO can be enabled/disabled from configuration (`core/configmanager.cpp`).
- Extended `RenderFrameContext` with `useAmbientOcclusion` and read the preference in `RenderScene` to propagate per-frame AO state (`viewer3d/viewer3d_types.h`, `viewer3d/viewer3dcontroller.cpp`).
- Changed `Viewer3DController::SetupBasicLighting` to accept AO state and updated `viewer3d/render/lighting_profile` API to take a `LightingOptions` struct; the lighting profile applies a darker ambient/fill profile when AO is enabled (`viewer3d/viewer3dcontroller.h`, `viewer3d/viewer3dcontroller.cpp`, `viewer3d/render/lighting_profile.h`, `viewer3d/render/lighting_profile.cpp`).
- Kept AO enabled by default and deferred adding UI controls in this change so the option is selectable from config now but not exposed in the GUI yet.

### Testing

- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.
- Attempted build but no `build` directory was present in this environment so a full compile was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699da87791848324b33346ecbc2e3f83)