### PR TITLE
Strengthen 3D ambient occlusion lighting response

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -148,6 +148,8 @@ ConfigManager::ConfigManager() {
                    1.0f);
   RegisterVariable("viewer3d_ambient_occlusion", "float", 1.0f, 0.0f,
                    1.0f);
+  RegisterVariable("viewer3d_ambient_occlusion_strength", "float", 1.0f,
+                   0.0f, 1.0f);
   RegisterVariable("render_culling_enabled", "float", 1.0f, 0.0f, 1.0f);
   RegisterVariable("render_culling_min_pixels_3d", "float", 2.0f, 0.0f,
                    64.0f);

--- a/viewer3d/render/lighting_profile.cpp
+++ b/viewer3d/render/lighting_profile.cpp
@@ -17,6 +17,20 @@
 
 namespace Viewer3DLightingProfile {
 
+namespace {
+float Clamp01(float value) {
+  if (value < 0.0f)
+    return 0.0f;
+  if (value > 1.0f)
+    return 1.0f;
+  return value;
+}
+
+float Lerp(float from, float to, float t) {
+  return from + ((to - from) * t);
+}
+} // namespace
+
 void ApplyEnhancedBasicLighting(const LightingOptions &options) {
   glEnable(GL_LIGHTING);
   // Keep normal lengths stable after model transforms with scaling.
@@ -27,8 +41,10 @@ void ApplyEnhancedBasicLighting(const LightingOptions &options) {
 
   // Slightly lower ambient contribution and add multiple directional lights.
   // This improves depth cues for similar gray materials at low runtime cost.
-  const float globalAmbientIntensity =
-      options.ambientOcclusionEnabled ? 0.08f : 0.14f;
+  const float aoStrength =
+      options.ambientOcclusionEnabled ? Clamp01(options.ambientOcclusionStrength)
+                                      : 0.0f;
+  const float globalAmbientIntensity = Lerp(0.14f, 0.03f, aoStrength);
   const GLfloat globalAmbient[] = {globalAmbientIntensity,
                                    globalAmbientIntensity,
                                    globalAmbientIntensity, 1.0f};
@@ -47,8 +63,7 @@ void ApplyEnhancedBasicLighting(const LightingOptions &options) {
   glLightfv(GL_LIGHT0, GL_POSITION, keyPosition);
 
   const GLfloat fillAmbient[] = {0.0f, 0.0f, 0.0f, 1.0f};
-  const float fillDiffuseIntensity =
-      options.ambientOcclusionEnabled ? 0.24f : 0.32f;
+  const float fillDiffuseIntensity = Lerp(0.32f, 0.12f, aoStrength);
   const GLfloat fillDiffuse[] = {fillDiffuseIntensity, fillDiffuseIntensity,
                                  fillDiffuseIntensity + 0.04f, 1.0f};
   const GLfloat fillSpecular[] = {0.0f, 0.0f, 0.0f, 1.0f};

--- a/viewer3d/render/lighting_profile.h
+++ b/viewer3d/render/lighting_profile.h
@@ -4,6 +4,7 @@ namespace Viewer3DLightingProfile {
 
 struct LightingOptions {
   bool ambientOcclusionEnabled = true;
+  float ambientOcclusionStrength = 1.0f;
 };
 
 void ApplyEnhancedBasicLighting(const LightingOptions &options);

--- a/viewer3d/viewer3d_types.h
+++ b/viewer3d/viewer3d_types.h
@@ -63,6 +63,7 @@ struct RenderFrameContext {
 
   bool useLighting = true;
   bool useAmbientOcclusion = true;
+  float ambientOcclusionStrength = 1.0f;
   bool drawGridBeforeScene = false;
   bool drawGridAfterScene = false;
   bool useFrustumCulling = false;

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -962,6 +962,8 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
   context.useLighting = !context.wireframe;
   context.useAmbientOcclusion =
       cfg.GetFloat("viewer3d_ambient_occlusion") >= 0.5f;
+  context.ambientOcclusionStrength =
+      cfg.GetFloat("viewer3d_ambient_occlusion_strength");
 
   const bool shouldDrawGrid = context.showGrid;
   const bool shouldDrawGridBeforeScene = shouldDrawGrid && !context.gridOnTop;
@@ -1052,7 +1054,8 @@ void Viewer3DController::RenderOpaqueFrame(const RenderFrameContext &context,
   const Viewer2DView view = context.view;
 
   if (context.useLighting)
-    SetupBasicLighting(context.useAmbientOcclusion);
+    SetupBasicLighting(context.useAmbientOcclusion,
+                      context.ambientOcclusionStrength);
   else
     glDisable(GL_LIGHTING);
 
@@ -1408,9 +1411,11 @@ void Viewer3DController::ApplyTransform(const float matrix[16],
 }
 
 // Initializes simple lighting for the scene
-void Viewer3DController::SetupBasicLighting(bool ambientOcclusionEnabled) {
+void Viewer3DController::SetupBasicLighting(bool ambientOcclusionEnabled,
+                                          float ambientOcclusionStrength) {
   Viewer3DLightingProfile::LightingOptions options;
   options.ambientOcclusionEnabled = ambientOcclusionEnabled;
+  options.ambientOcclusionStrength = ambientOcclusionStrength;
   Viewer3DLightingProfile::ApplyEnhancedBasicLighting(options);
 }
 

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -204,7 +204,8 @@ private:
   void DrawGrid(int style, float r, float g, float b,
                 Viewer2DView view = Viewer2DView::Top);
   void DrawAxes();
-  void SetupBasicLighting(bool ambientOcclusionEnabled);
+  void SetupBasicLighting(bool ambientOcclusionEnabled,
+                          float ambientOcclusionStrength);
   void SetupMaterialFromRGB(float r, float g, float b);
   void SetGLColor(float r, float g, float b) const override;
   std::array<float, 3> AdjustColor(float r, float g, float b) const;


### PR DESCRIPTION
### Motivation
- The built-in AO toggle produced only a subtle lighting change that was often imperceptible in the 3D viewer, so the intent is to make AO-style contrast stronger and tunable without adding a full SSAO post-process.
- Keep the solution lightweight and compatible with the existing fixed-function OpenGL lighting path used by the viewer.

### Description
- Added a runtime config key `viewer3d_ambient_occlusion_strength` (float 0..1, default `1.0`) and registered it in `core/configmanager.cpp` so AO intensity can be tuned at runtime.
- Threaded `ambientOcclusionStrength` through the frame context by adding `float ambientOcclusionStrength` to `RenderFrameContext` and reading the new config in `viewer3d/viewer3dcontroller.cpp`.
- Updated `Viewer3DController::SetupBasicLighting` signature to accept the strength and pass it into the lighting profile, and forwarded the value where lighting is initialized in the render path (`viewer3d/viewer3dcontroller.h/.cpp`).
- Extended the lighting profile (`viewer3d/render/lighting_profile.h/.cpp`) with `ambientOcclusionStrength` in `LightingOptions`, added `Clamp01` and `Lerp` helpers, and interpolated global ambient and fill diffuse intensities based on AO strength to produce a more noticeable AO-like effect while remaining cheap.

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699df706ff5c83248d396648f9185af5)