### PR TITLE
Resolve relative truss symbol paths and improve missing-file warnings in MVR and Rider importers

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -152,6 +152,26 @@ bool IsRenderableTrussGeometry(const std::string &path) {
   return ext == ".3ds" || ext == ".glb";
 }
 
+std::filesystem::path ResolveTrussSymbolPath(const Truss &truss) {
+  std::filesystem::path symbolPath = std::filesystem::u8path(truss.symbolFile);
+  if (symbolPath.is_absolute())
+    return symbolPath;
+
+  if (!truss.modelFile.empty()) {
+    std::filesystem::path modelPath = std::filesystem::u8path(truss.modelFile);
+    if (modelPath.is_absolute())
+      return modelPath.parent_path() / symbolPath;
+  }
+
+  if (!truss.gdtfSpec.empty()) {
+    std::filesystem::path gdtfPath = std::filesystem::u8path(truss.gdtfSpec);
+    if (gdtfPath.is_absolute())
+      return gdtfPath.parent_path() / symbolPath;
+  }
+
+  return symbolPath;
+}
+
 std::string DescribeTrussForLog(const Truss &truss) {
   const std::string displayName = truss.name.empty() ? "(unnamed)" : truss.name;
   std::ostringstream oss;
@@ -748,8 +768,9 @@ bool RiderImporter::ImportText(const std::string &text) {
       continue;
 
     Truss &t = trussIt->second;
+    const std::filesystem::path resolvedSymbolPath = ResolveTrussSymbolPath(t);
     if (IsRenderableTrussGeometry(t.symbolFile) &&
-        std::filesystem::exists(std::filesystem::u8path(t.symbolFile)))
+        std::filesystem::exists(resolvedSymbolPath))
       continue;
 
     Truss parsed;
@@ -831,9 +852,9 @@ bool RiderImporter::ImportText(const std::string &text) {
     if (!parsed.crossSection.empty())
       t.crossSection = parsed.crossSection;
 
+    const std::filesystem::path resolvedSymbolPath = ResolveTrussSymbolPath(t);
     bool symbolLooksRenderable = IsRenderableTrussGeometry(t.symbolFile);
-    bool symbolExists =
-        symbolLooksRenderable && std::filesystem::exists(std::filesystem::u8path(t.symbolFile));
+    bool symbolExists = symbolLooksRenderable && std::filesystem::exists(resolvedSymbolPath);
     if (!symbolExists) {
       std::ostringstream reason;
       if (t.symbolFile.empty()) {
@@ -841,7 +862,8 @@ bool RiderImporter::ImportText(const std::string &text) {
       } else if (!symbolLooksRenderable) {
         reason << "symbolFile extension is not .3ds/.glb";
       } else {
-        reason << "symbolFile does not exist on disk";
+        reason << "symbolFile does not exist on disk (checked path='"
+               << resolvedSymbolPath.string() << "')";
       }
       std::ostringstream oss;
       oss << "Rider import truss fallback to dummy box: "

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -852,9 +852,11 @@ bool RiderImporter::ImportText(const std::string &text) {
     if (!parsed.crossSection.empty())
       t.crossSection = parsed.crossSection;
 
-    const std::filesystem::path resolvedSymbolPath = ResolveTrussSymbolPath(t);
+    const std::filesystem::path resolvedSymbolPathAfterDefinition =
+        ResolveTrussSymbolPath(t);
     bool symbolLooksRenderable = IsRenderableTrussGeometry(t.symbolFile);
-    bool symbolExists = symbolLooksRenderable && std::filesystem::exists(resolvedSymbolPath);
+    bool symbolExists =
+        symbolLooksRenderable && std::filesystem::exists(resolvedSymbolPathAfterDefinition);
     if (!symbolExists) {
       std::ostringstream reason;
       if (t.symbolFile.empty()) {
@@ -863,7 +865,7 @@ bool RiderImporter::ImportText(const std::string &text) {
         reason << "symbolFile extension is not .3ds/.glb";
       } else {
         reason << "symbolFile does not exist on disk (checked path='"
-               << resolvedSymbolPath.string() << "')";
+               << resolvedSymbolPathAfterDefinition.string() << "')";
       }
       std::ostringstream oss;
       oss << "Rider import truss fallback to dummy box: "

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -112,6 +112,14 @@ static bool IsRenderableTrussGeometry(const std::string &path) {
   return ext == ".3ds" || ext == ".glb";
 }
 
+static fs::path ResolveSceneRelativePath(const std::string &basePath,
+                                         const std::string &pathText) {
+  fs::path path = fs::u8path(pathText);
+  if (path.is_absolute() || basePath.empty())
+    return path;
+  return fs::u8path(basePath) / path;
+}
+
 static std::string DescribeTrussForLog(const Truss &truss) {
   const std::string displayName = truss.name.empty() ? "(unnamed)" : truss.name;
   std::ostringstream oss;
@@ -543,6 +551,14 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
     return ToString(path.u8string());
   };
 
+  auto normalizeAndResolveGeometryFileName = [&](std::string fileName) {
+    std::string normalized = normalizeGeometryFileName(std::move(fileName));
+    if (normalized.empty())
+      return normalized;
+    const fs::path resolved = ResolveSceneRelativePath(scene.basePath, normalized);
+    return ToString(resolved.u8string());
+  };
+
   auto appendGeometryInstance = [&](std::vector<GeometryInstance> &instances,
                                     const std::string &fileName,
                                     const Matrix &localTransform) {
@@ -844,7 +860,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                   geos->FirstChildElement("Geometry3D")) {
             const char *file = g3d->Attribute("fileName");
             if (file)
-              truss.symbolFile = file;
+              truss.symbolFile = normalizeAndResolveGeometryFileName(file);
             Matrix geoMatrix = MatrixUtils::Identity();
             parseMatrixOrIdentity(g3d, "Matrix", "Truss/Geometry3D", geoMatrix, true);
             truss.transform = MatrixUtils::Multiply(nodeTransform, geoMatrix);
@@ -856,7 +872,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
             resolveSymdefReference(sym, symGeometries, symType, symMatrix);
             Matrix symLocal = symMatrix;
             if (!symGeometries.empty()) {
-              truss.symbolFile = symGeometries.front().file;
+              truss.symbolFile =
+                  normalizeAndResolveGeometryFileName(symGeometries.front().file);
               symLocal = MatrixUtils::Multiply(symMatrix,
                                                symGeometries.front().transform);
             }
@@ -924,9 +941,10 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
           }
         }
 
+        const fs::path resolvedSymbolPath =
+            ResolveSceneRelativePath(scene.basePath, truss.symbolFile);
         const bool symbolRenderable = IsRenderableTrussGeometry(truss.symbolFile);
-        const bool symbolExists =
-            symbolRenderable && fs::exists(fs::u8path(truss.symbolFile));
+        const bool symbolExists = symbolRenderable && fs::exists(resolvedSymbolPath);
         if (!symbolExists) {
           std::ostringstream reason;
           if (truss.symbolFile.empty()) {
@@ -934,7 +952,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
           } else if (!symbolRenderable) {
             reason << "symbolFile extension is not .3ds/.glb";
           } else {
-            reason << "symbolFile does not exist on disk";
+            reason << "symbolFile does not exist on disk (checked path='"
+                   << ToString(resolvedSymbolPath.u8string()) << "')";
           }
           if (gdtfLoadFailed)
             reason << "; LoadTrussDefinition(gdtfSpec) returned false";


### PR DESCRIPTION
### Motivation
- Importers emitted many false `symbolFile does not exist on disk` warnings because relative `symbolFile` names were checked against the current working directory instead of the MVR extraction base or the truss definition location.
- The change aims to resolve relative geometry paths correctly and make warnings actionable by showing the concrete path that was checked.

### Description
- In `mvr/mvrimporter.cpp` added `ResolveSceneRelativePath()` and `normalizeAndResolveGeometryFileName()` and use them when assigning `truss.symbolFile` so geometry names are normalized (extension completion) and resolved against `scene.basePath` before `fs::exists` checks.
- In `mvr/mvrimporter.cpp` existence checks now use the resolved path and warnings include the checked path string to improve diagnostics.
- In `core/riderimporter.cpp` added `ResolveTrussSymbolPath()` and use it to resolve relative `symbolFile` entries using absolute `modelFile` or `gdtfSpec` parent folders when available, and use the resolved path for `std::filesystem::exists` checks.
- Both importers now log the resolved path in the warning message when a renderable symbol is reported missing, reducing noise from incorrect absence reports.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it returned OK.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it returned OK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dfa5b5308832490c9f8b8383b69d2)