### PR TITLE
viewer3d: add screen-space ambient occlusion (SSAO) pass

### DIFF
--- a/viewer3d/CMakeLists.txt
+++ b/viewer3d/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/render/opaque_truss_pass.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/render_pipeline.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/scenerenderer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/render/screen_space_ambient_occlusion_pass.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/resources/resource_sync_system.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/viewer3dcamera.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/viewer3dcontroller.cpp

--- a/viewer3d/render/render_pipeline.cpp
+++ b/viewer3d/render/render_pipeline.cpp
@@ -2,6 +2,8 @@
 
 #include "viewer3dcontroller.h"
 
+#include "screen_space_ambient_occlusion_pass.h"
+
 #include <cassert>
 
 RenderPipeline::RenderPipeline(Viewer3DController &controller)
@@ -23,6 +25,7 @@ void RenderPipeline::Execute(const RenderFrameContext &context) {
   } guard{*this};
 
   RenderOpaque();
+  ScreenSpaceAmbientOcclusionPass::Render(m_context);
   RenderOverlays();
 }
 

--- a/viewer3d/render/screen_space_ambient_occlusion_pass.cpp
+++ b/viewer3d/render/screen_space_ambient_occlusion_pass.cpp
@@ -1,0 +1,163 @@
+#include "screen_space_ambient_occlusion_pass.h"
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#endif
+
+#include <GL/glew.h>
+#ifdef __APPLE__
+#define GL_SILENCE_DEPRECATION
+#include <OpenGL/gl.h>
+#else
+#include <GL/gl.h>
+#endif
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+namespace ScreenSpaceAmbientOcclusionPass {
+namespace {
+
+float Clamp01(float value) {
+  if (value < 0.0f)
+    return 0.0f;
+  if (value > 1.0f)
+    return 1.0f;
+  return value;
+}
+
+bool ShouldRender(const RenderFrameContext &context) {
+  return context.useLighting && context.useAmbientOcclusion &&
+         !context.wireframe && !context.is2DViewer;
+}
+
+} // namespace
+
+void Render(const RenderFrameContext &context) {
+  if (!ShouldRender(context))
+    return;
+
+  GLint viewport[4] = {0, 0, 0, 0};
+  glGetIntegerv(GL_VIEWPORT, viewport);
+  const int width = viewport[2];
+  const int height = viewport[3];
+  if (width <= 8 || height <= 8)
+    return;
+
+  std::vector<float> depth(static_cast<size_t>(width) *
+                           static_cast<size_t>(height));
+  glReadPixels(0, 0, width, height, GL_DEPTH_COMPONENT, GL_FLOAT, depth.data());
+
+  std::vector<unsigned char> mask(static_cast<size_t>(width) *
+                                  static_cast<size_t>(height));
+
+  const float strength = Clamp01(context.ambientOcclusionStrength);
+  const int sampleRadius = 4;
+  const float bias = 0.0009f;
+
+  for (int y = 0; y < height; ++y) {
+    for (int x = 0; x < width; ++x) {
+      const size_t idx = static_cast<size_t>(y) * static_cast<size_t>(width) +
+                         static_cast<size_t>(x);
+      const float center = depth[idx];
+
+      if (center >= 0.9999f) {
+        mask[idx] = 255;
+        continue;
+      }
+
+      float occlusion = 0.0f;
+      int sampleCount = 0;
+
+      for (int oy = -sampleRadius; oy <= sampleRadius; ++oy) {
+        const int ny = y + oy;
+        if (ny < 0 || ny >= height)
+          continue;
+        for (int ox = -sampleRadius; ox <= sampleRadius; ++ox) {
+          if (ox == 0 && oy == 0)
+            continue;
+          const int nx = x + ox;
+          if (nx < 0 || nx >= width)
+            continue;
+
+          const float distance = std::sqrt(static_cast<float>(ox * ox + oy * oy));
+          if (distance > static_cast<float>(sampleRadius))
+            continue;
+
+          const size_t nidx = static_cast<size_t>(ny) * static_cast<size_t>(width) +
+                              static_cast<size_t>(nx);
+          const float neighbor = depth[nidx];
+          const float delta = center - neighbor;
+          if (delta > bias) {
+            const float rangeWeight = 1.0f - (distance / static_cast<float>(sampleRadius));
+            occlusion += std::min(delta * 24.0f, 1.0f) * rangeWeight;
+          }
+          ++sampleCount;
+        }
+      }
+
+      const float normalized =
+          (sampleCount > 0) ? Clamp01(occlusion / static_cast<float>(sampleCount)) : 0.0f;
+      const float darkness = Clamp01(normalized * (0.85f * strength));
+      const float multiplier = 1.0f - darkness;
+      mask[idx] = static_cast<unsigned char>(std::round(multiplier * 255.0f));
+    }
+  }
+
+  GLuint aoTexture = 0;
+  glGenTextures(1, &aoTexture);
+  if (aoTexture == 0)
+    return;
+
+  glBindTexture(GL_TEXTURE_2D, aoTexture);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, width, height, 0, GL_LUMINANCE,
+               GL_UNSIGNED_BYTE, mask.data());
+
+  glPushAttrib(GL_ENABLE_BIT | GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT |
+               GL_TRANSFORM_BIT | GL_TEXTURE_BIT);
+
+  glDisable(GL_LIGHTING);
+  glDisable(GL_DEPTH_TEST);
+  glEnable(GL_TEXTURE_2D);
+  glEnable(GL_BLEND);
+  glBlendFunc(GL_DST_COLOR, GL_ZERO);
+
+  glMatrixMode(GL_PROJECTION);
+  glPushMatrix();
+  glLoadIdentity();
+  glMatrixMode(GL_MODELVIEW);
+  glPushMatrix();
+  glLoadIdentity();
+
+  glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
+  glBindTexture(GL_TEXTURE_2D, aoTexture);
+  glBegin(GL_QUADS);
+  glTexCoord2f(0.0f, 0.0f);
+  glVertex2f(-1.0f, -1.0f);
+  glTexCoord2f(1.0f, 0.0f);
+  glVertex2f(1.0f, -1.0f);
+  glTexCoord2f(1.0f, 1.0f);
+  glVertex2f(1.0f, 1.0f);
+  glTexCoord2f(0.0f, 1.0f);
+  glVertex2f(-1.0f, 1.0f);
+  glEnd();
+
+  glPopMatrix();
+  glMatrixMode(GL_PROJECTION);
+  glPopMatrix();
+  glMatrixMode(GL_MODELVIEW);
+
+  glPopAttrib();
+
+  glBindTexture(GL_TEXTURE_2D, 0);
+  glDeleteTextures(1, &aoTexture);
+}
+
+} // namespace ScreenSpaceAmbientOcclusionPass

--- a/viewer3d/render/screen_space_ambient_occlusion_pass.h
+++ b/viewer3d/render/screen_space_ambient_occlusion_pass.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "viewer3d_types.h"
+
+namespace ScreenSpaceAmbientOcclusionPass {
+
+void Render(const RenderFrameContext &context);
+
+} // namespace ScreenSpaceAmbientOcclusionPass


### PR DESCRIPTION
### Motivation
- Provide a "real" ambient occlusion pass to measure runtime and visual impact by computing screen-space occlusion from the depth buffer rather than only tuning lighting parameters.
- Keep the change modular and small by adding a dedicated render pass under `viewer3d/render/` so the `viewer3dcontroller`/pipeline remains unchanged in responsibility.
- Ensure AO only runs in the scenarios that make sense for performance testing (lit 3D views, non-wireframe, AO enabled) to avoid unnecessary cost in other modes.

### Description
- Added a new render pass `ScreenSpaceAmbientOcclusionPass` implemented in `viewer3d/render/screen_space_ambient_occlusion_pass.{h,cpp}` that reads the GL depth buffer, samples a neighborhood (radius-based CPU sampling), builds an occlusion mask, uploads it to a temporary texture and composites it as a fullscreen multiply pass.
- Integrated the pass into the frame flow by calling `ScreenSpaceAmbientOcclusionPass::Render(m_context)` between `RenderOpaque()` and `RenderOverlays()` in `viewer3d/render/render_pipeline.cpp` so AO affects opaque scene geometry before overlays are drawn.
- Registered the new source file in `viewer3d/CMakeLists.txt` to include the new pass in the build while keeping source ownership explicit and module boundaries intact.

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which passed (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which passed (`OK`).
- Attempted CMake configure with `cmake -S . -B build`, which failed in this environment due to missing system development packages for `wxWidgets` and not because of the introduced source changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dff2076788324a7364f0c246bda41)