### PR TITLE
Add volumetric gobo overlay to VolumetricBeamRenderer

### DIFF
--- a/peraviz/scripts/beam_renderers/beam_renderer_base.gd
+++ b/peraviz/scripts/beam_renderers/beam_renderer_base.gd
@@ -11,5 +11,8 @@ func ensure_beam(_light: SpotLight3D) -> void:
 func update_beam(_light: SpotLight3D, _params: Dictionary) -> void:
 	pass
 
+func update_gobo_overlay(_light: SpotLight3D) -> void:
+	pass
+
 func cleanup_beam(_light: SpotLight3D) -> void:
 	pass

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -6,8 +6,11 @@ const BEAM_META_KEY: String = "peraviz_volumetric_beam"
 const GOBO_OVERLAY_META_KEY: String = "peraviz_gobo_overlay"
 const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 10.0
 const VOLUMETRIC_INTENSITY_SCALE: float = 0.62
-const GOBO_OVERLAY_INTENSITY_SCALE: float = 1.2
-const GOBO_OVERLAY_MIN_DISTANCE_M: float = 0.05
+const GOBO_OVERLAY_DISTANCE_MULTIPLIER: float = 1.1
+const GOBO_OVERLAY_MIN_DISTANCE_M: float = 0.008
+const GOBO_MASK_CUTOFF: float = 0.5
+const GOBO_EDGE_SOFTNESS: float = 0.01
+const GOBO_RADIAL_SOFTNESS: float = 0.01
 
 var _shared_material: ShaderMaterial
 var _gobo_overlay_shader: Shader = preload("res://scripts/shaders/volumetric_gobo_overlay.gdshader")
@@ -144,9 +147,10 @@ func _update_gobo_overlay(light: SpotLight3D, params: Dictionary) -> void:
 	var beam_angle: float = max(float(params.get("beam_angle", 1.0)), 0.1)
 	var lens_radius: float = max(float(params.get("lens_radius", 0.03)), 0.005)
 	var half_angle_deg: float = beam_angle * 0.5
-	var overlay_distance: float = max(beam_range * 0.05, lens_radius * 2.0, GOBO_OVERLAY_MIN_DISTANCE_M)
-	var radius: float = tan(deg_to_rad(half_angle_deg)) * overlay_distance
-	radius = max(radius, lens_radius)
+	var overlay_distance: float = max(lens_radius * GOBO_OVERLAY_DISTANCE_MULTIPLIER, GOBO_OVERLAY_MIN_DISTANCE_M)
+	overlay_distance = min(overlay_distance, beam_range * 0.2)
+	var projected_radius: float = tan(deg_to_rad(half_angle_deg)) * overlay_distance
+	var radius: float = max(lens_radius, projected_radius)
 
 	overlay.position = Vector3(0.0, 0.0, -overlay_distance)
 	overlay.scale = Vector3(radius * 2.0, radius * 2.0, 1.0)
@@ -156,8 +160,10 @@ func _update_gobo_overlay(light: SpotLight3D, params: Dictionary) -> void:
 		overlay.visible = false
 		return
 	overlay_material.set_shader_parameter("gobo_texture", gobo_texture)
-	overlay_material.set_shader_parameter("intensity", clamp(intensity * GOBO_OVERLAY_INTENSITY_SCALE, 0.0, 3.0))
-	overlay_material.set_shader_parameter("radial_softness", 0.08)
+	overlay_material.set_shader_parameter("mask_cutoff", GOBO_MASK_CUTOFF)
+	overlay_material.set_shader_parameter("edge_softness", GOBO_EDGE_SOFTNESS)
+	overlay_material.set_shader_parameter("radial_softness", GOBO_RADIAL_SOFTNESS)
+	overlay_material.set_shader_parameter("mask_strength", clamp(intensity, 0.0, 1.0))
 	overlay.visible = true
 
 func _hide_gobo_overlay(light: SpotLight3D) -> void:

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -99,7 +99,7 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	cone.set_instance_shader_parameter("gobo_edge_softness", GOBO_EDGE_SOFTNESS)
 	cone.set_instance_shader_parameter("gobo_radial_softness", GOBO_RADIAL_SOFTNESS)
 
-	_update_gobo_overlay(light)
+	update_gobo_overlay(light)
 
 func update_gobo_overlay(light: SpotLight3D) -> void:
 	if not light.has_meta(BEAM_META_KEY):

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -3,10 +3,14 @@ extends BeamRendererBase
 class_name VolumetricBeamRenderer
 
 const BEAM_META_KEY: String = "peraviz_volumetric_beam"
+const GOBO_OVERLAY_META_KEY: String = "peraviz_gobo_overlay"
 const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 10.0
 const VOLUMETRIC_INTENSITY_SCALE: float = 0.62
+const GOBO_OVERLAY_INTENSITY_SCALE: float = 1.2
+const GOBO_OVERLAY_MIN_DISTANCE_M: float = 0.05
 
 var _shared_material: ShaderMaterial
+var _gobo_overlay_shader: Shader = preload("res://scripts/shaders/volumetric_gobo_overlay.gdshader")
 var _camera: Camera3D
 var _settings: Dictionary = {}
 
@@ -39,6 +43,19 @@ func ensure_beam(light: SpotLight3D) -> void:
 	light.add_child(cone)
 	light.set_meta(BEAM_META_KEY, cone)
 
+	var overlay_mesh := QuadMesh.new()
+	overlay_mesh.size = Vector2.ONE
+	var overlay := MeshInstance3D.new()
+	overlay.name = "PeravizGoboOverlay"
+	overlay.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
+	overlay.mesh = overlay_mesh
+	overlay.visible = false
+	var overlay_material := ShaderMaterial.new()
+	overlay_material.shader = _gobo_overlay_shader
+	overlay.material_override = overlay_material
+	light.add_child(overlay)
+	light.set_meta(GOBO_OVERLAY_META_KEY, overlay)
+
 func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	ensure_beam(light)
 	var cone: MeshInstance3D = light.get_meta(BEAM_META_KEY) as MeshInstance3D
@@ -49,6 +66,7 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	var threshold: float = float(params.get("intensity_visibility_threshold", 0.015))
 	if intensity <= threshold or not bool(params.get("is_visible", true)):
 		cone.visible = false
+		_hide_gobo_overlay(light)
 		return
 
 	var beam_range: float = max(float(params.get("beam_range", 0.1)), 0.01)
@@ -61,6 +79,7 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 		var cam_distance: float = _camera.global_position.distance_to(light.global_position)
 		if cam_distance > distance_limit or _camera.is_position_behind(light.global_position):
 			cone.visible = false
+			_hide_gobo_overlay(light)
 			return
 
 	var half_angle_deg: float = beam_angle * 0.5
@@ -90,6 +109,64 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	cone.set_instance_shader_parameter("depth_fade_distance", 0.5)
 	cone.set_instance_shader_parameter("max_brightness", lerp(1.0, 10.0, intensity))
 
+	var gobo_overlay_params := {
+		"beam_range": beam_range,
+		"beam_angle": beam_angle,
+		"lens_radius": lens_radius,
+		"scaled_intensity": intensity,
+	}
+	_update_gobo_overlay(light, gobo_overlay_params)
+
+func update_gobo_overlay(light: SpotLight3D) -> void:
+	if not light.has_meta("peraviz_beam_last_params"):
+		return
+	var params: Dictionary = light.get_meta("peraviz_beam_last_params", {})
+	if params.is_empty():
+		return
+	_update_gobo_overlay(light, params)
+
+func _update_gobo_overlay(light: SpotLight3D, params: Dictionary) -> void:
+	var overlay: MeshInstance3D = light.get_meta(GOBO_OVERLAY_META_KEY) as MeshInstance3D if light.has_meta(GOBO_OVERLAY_META_KEY) else null
+	if overlay == null:
+		return
+
+	var gobo_texture: Texture2D = light.light_projector
+	if gobo_texture == null:
+		overlay.visible = false
+		return
+
+	var intensity: float = clamp(float(params.get("scaled_intensity", 0.0)), 0.0, 3.0)
+	if intensity <= 0.001:
+		overlay.visible = false
+		return
+
+	var beam_range: float = max(float(params.get("beam_range", 0.1)), GOBO_OVERLAY_MIN_DISTANCE_M)
+	var beam_angle: float = max(float(params.get("beam_angle", 1.0)), 0.1)
+	var lens_radius: float = max(float(params.get("lens_radius", 0.03)), 0.005)
+	var half_angle_deg: float = beam_angle * 0.5
+	var overlay_distance: float = max(beam_range * 0.05, lens_radius * 2.0, GOBO_OVERLAY_MIN_DISTANCE_M)
+	var radius: float = tan(deg_to_rad(half_angle_deg)) * overlay_distance
+	radius = max(radius, lens_radius)
+
+	overlay.position = Vector3(0.0, 0.0, -overlay_distance)
+	overlay.scale = Vector3(radius * 2.0, radius * 2.0, 1.0)
+
+	var overlay_material: ShaderMaterial = overlay.material_override as ShaderMaterial
+	if overlay_material == null:
+		overlay.visible = false
+		return
+	overlay_material.set_shader_parameter("gobo_texture", gobo_texture)
+	overlay_material.set_shader_parameter("intensity", clamp(intensity * GOBO_OVERLAY_INTENSITY_SCALE, 0.0, 3.0))
+	overlay_material.set_shader_parameter("radial_softness", 0.08)
+	overlay.visible = true
+
+func _hide_gobo_overlay(light: SpotLight3D) -> void:
+	if not light.has_meta(GOBO_OVERLAY_META_KEY):
+		return
+	var overlay: MeshInstance3D = light.get_meta(GOBO_OVERLAY_META_KEY) as MeshInstance3D
+	if overlay != null:
+		overlay.visible = false
+
 func cleanup_beam(light: SpotLight3D) -> void:
 	if not light.has_meta(BEAM_META_KEY):
 		return
@@ -97,3 +174,8 @@ func cleanup_beam(light: SpotLight3D) -> void:
 	if cone != null and is_instance_valid(cone):
 		cone.queue_free()
 	light.remove_meta(BEAM_META_KEY)
+	if light.has_meta(GOBO_OVERLAY_META_KEY):
+		var overlay: MeshInstance3D = light.get_meta(GOBO_OVERLAY_META_KEY) as MeshInstance3D
+		if overlay != null and is_instance_valid(overlay):
+			overlay.queue_free()
+		light.remove_meta(GOBO_OVERLAY_META_KEY)

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -3,14 +3,17 @@ extends BeamRendererBase
 class_name VolumetricBeamRenderer
 
 const BEAM_META_KEY: String = "peraviz_volumetric_beam"
-const GOBO_OVERLAY_META_KEY: String = "peraviz_gobo_overlay"
+const GOBO_OVERLAY_ROOT_META_KEY: String = "peraviz_gobo_overlay_root"
 const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 10.0
 const VOLUMETRIC_INTENSITY_SCALE: float = 0.62
-const GOBO_OVERLAY_DISTANCE_SCALE: float = 1.15
-const GOBO_OVERLAY_MIN_DISTANCE_M: float = 0.008
+const GOBO_BASE_BEAM_ATTENUATION: float = 0.42
+const GOBO_OVERLAY_SLICE_COUNT: int = 6
+const GOBO_OVERLAY_START_RATIO: float = 0.06
+const GOBO_OVERLAY_END_RATIO: float = 0.9
+const GOBO_OVERLAY_MIN_DISTANCE_M: float = 0.03
 const GOBO_MASK_CUTOFF: float = 0.5
-const GOBO_EDGE_SOFTNESS: float = 0.01
-const GOBO_RADIAL_SOFTNESS: float = 0.03
+const GOBO_EDGE_SOFTNESS: float = 0.02
+const GOBO_RADIAL_SOFTNESS: float = 0.04
 
 var _shared_material: ShaderMaterial
 var _gobo_overlay_shader: Shader = preload("res://scripts/shaders/volumetric_gobo_overlay.gdshader")
@@ -28,6 +31,7 @@ func configure(view_camera: Camera3D, settings: Dictionary) -> void:
 func ensure_beam(light: SpotLight3D) -> void:
 	if light.has_meta(BEAM_META_KEY):
 		return
+
 	var cone_mesh := CylinderMesh.new()
 	cone_mesh.radial_segments = 48
 	cone_mesh.rings = 12
@@ -36,6 +40,7 @@ func ensure_beam(light: SpotLight3D) -> void:
 	cone_mesh.height = 8.0
 	cone_mesh.cap_top = false
 	cone_mesh.cap_bottom = false
+
 	var cone := MeshInstance3D.new()
 	cone.name = "PeravizVolumetricBeam"
 	cone.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
@@ -46,18 +51,25 @@ func ensure_beam(light: SpotLight3D) -> void:
 	light.add_child(cone)
 	light.set_meta(BEAM_META_KEY, cone)
 
-	var overlay_mesh := QuadMesh.new()
-	overlay_mesh.size = Vector2.ONE
-	var overlay := MeshInstance3D.new()
-	overlay.name = "PeravizGoboOverlay"
-	overlay.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
-	overlay.mesh = overlay_mesh
-	overlay.visible = false
-	var overlay_material := ShaderMaterial.new()
-	overlay_material.shader = _gobo_overlay_shader
-	overlay.material_override = overlay_material
-	light.add_child(overlay)
-	light.set_meta(GOBO_OVERLAY_META_KEY, overlay)
+	var overlay_root := Node3D.new()
+	overlay_root.name = "PeravizGoboOverlayRoot"
+	overlay_root.visible = false
+	light.add_child(overlay_root)
+
+	for i in range(GOBO_OVERLAY_SLICE_COUNT):
+		var overlay_mesh := QuadMesh.new()
+		overlay_mesh.size = Vector2.ONE
+		var overlay := MeshInstance3D.new()
+		overlay.name = "PeravizGoboOverlay_%d" % i
+		overlay.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
+		overlay.mesh = overlay_mesh
+		overlay.visible = false
+		var overlay_material := ShaderMaterial.new()
+		overlay_material.shader = _gobo_overlay_shader
+		overlay.material_override = overlay_material
+		overlay_root.add_child(overlay)
+
+	light.set_meta(GOBO_OVERLAY_ROOT_META_KEY, overlay_root)
 
 func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	ensure_beam(light)
@@ -96,7 +108,9 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	cone.position = Vector3(0.0, 0.0, -beam_range * 0.5)
 	cone.visible = true
 
-	var intensity_alpha: float = clamp(intensity * VOLUMETRIC_INTENSITY_SCALE, 0.0, 1.0)
+	var has_gobo: bool = light.light_projector != null
+	var base_alpha_scale: float = GOBO_BASE_BEAM_ATTENUATION if has_gobo else 1.0
+	var intensity_alpha: float = clamp(intensity * VOLUMETRIC_INTENSITY_SCALE * base_alpha_scale, 0.0, 1.0)
 	cone.set_instance_shader_parameter("base_color", Color(beam_color.r, beam_color.g, beam_color.b, intensity_alpha))
 	cone.set_instance_shader_parameter("falloff_power", 8.0)
 	cone.set_instance_shader_parameter("facing_boost", 1.5)
@@ -117,6 +131,7 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 		"beam_angle": beam_angle,
 		"lens_radius": lens_radius,
 		"scaled_intensity": intensity,
+		"beam_color": beam_color,
 	}
 	_update_gobo_overlay(light, gobo_overlay_params)
 
@@ -129,49 +144,72 @@ func update_gobo_overlay(light: SpotLight3D) -> void:
 	_update_gobo_overlay(light, params)
 
 func _update_gobo_overlay(light: SpotLight3D, params: Dictionary) -> void:
-	var overlay: MeshInstance3D = light.get_meta(GOBO_OVERLAY_META_KEY) as MeshInstance3D if light.has_meta(GOBO_OVERLAY_META_KEY) else null
-	if overlay == null:
+	var overlay_root: Node3D = light.get_meta(GOBO_OVERLAY_ROOT_META_KEY) as Node3D if light.has_meta(GOBO_OVERLAY_ROOT_META_KEY) else null
+	if overlay_root == null:
 		return
 
 	var gobo_texture: Texture2D = light.light_projector
 	if gobo_texture == null:
-		overlay.visible = false
+		overlay_root.visible = false
+		for child in overlay_root.get_children():
+			if child is MeshInstance3D:
+				(child as MeshInstance3D).visible = false
 		return
 
 	var intensity: float = clamp(float(params.get("scaled_intensity", 0.0)), 0.0, 3.0)
 	if intensity <= 0.001:
-		overlay.visible = false
+		overlay_root.visible = false
+		for child in overlay_root.get_children():
+			if child is MeshInstance3D:
+				(child as MeshInstance3D).visible = false
 		return
 
 	var beam_range: float = max(float(params.get("beam_range", 0.1)), GOBO_OVERLAY_MIN_DISTANCE_M)
 	var beam_angle: float = max(float(params.get("beam_angle", 1.0)), 0.1)
 	var lens_radius: float = max(float(params.get("lens_radius", 0.03)), 0.005)
+	var beam_color: Color = params.get("beam_color", Color.WHITE)
 	var half_angle_deg: float = beam_angle * 0.5
-	var overlay_distance: float = max(lens_radius * GOBO_OVERLAY_DISTANCE_SCALE, GOBO_OVERLAY_MIN_DISTANCE_M)
-	overlay_distance = min(overlay_distance, beam_range * 0.2)
-	var projected_radius: float = tan(deg_to_rad(half_angle_deg)) * overlay_distance
-	var radius: float = max(lens_radius, projected_radius)
 
-	overlay.position = Vector3(0.0, 0.0, -overlay_distance)
-	overlay.scale = Vector3(radius * 2.0, radius * 2.0, 1.0)
+	overlay_root.visible = true
+	var overlays: Array = overlay_root.get_children()
+	var overlay_count: int = overlays.size()
+	for i in range(overlay_count):
+		var overlay: MeshInstance3D = overlays[i] as MeshInstance3D
+		if overlay == null:
+			continue
+		var t: float = 0.0
+		if overlay_count > 1:
+			t = float(i) / float(overlay_count - 1)
+		var dist_ratio: float = lerp(GOBO_OVERLAY_START_RATIO, GOBO_OVERLAY_END_RATIO, t)
+		var overlay_distance: float = max(beam_range * dist_ratio, GOBO_OVERLAY_MIN_DISTANCE_M)
+		var projected_radius: float = tan(deg_to_rad(half_angle_deg)) * overlay_distance
+		var radius: float = max(lens_radius, projected_radius)
+		overlay.position = Vector3(0.0, 0.0, -overlay_distance)
+		overlay.scale = Vector3(radius * 2.0, radius * 2.0, 1.0)
+		overlay.visible = true
 
-	var overlay_material: ShaderMaterial = overlay.material_override as ShaderMaterial
-	if overlay_material == null:
-		overlay.visible = false
-		return
-	overlay_material.set_shader_parameter("gobo_texture", gobo_texture)
-	overlay_material.set_shader_parameter("mask_cutoff", GOBO_MASK_CUTOFF)
-	overlay_material.set_shader_parameter("edge_softness", GOBO_EDGE_SOFTNESS)
-	overlay_material.set_shader_parameter("radial_softness", GOBO_RADIAL_SOFTNESS)
-	overlay_material.set_shader_parameter("mask_strength", clamp(intensity, 0.0, 1.0))
-	overlay.visible = true
+		var slice_fade: float = lerp(1.0, 0.45, t)
+		var overlay_material: ShaderMaterial = overlay.material_override as ShaderMaterial
+		if overlay_material == null:
+			overlay.visible = false
+			continue
+		overlay_material.set_shader_parameter("gobo_texture", gobo_texture)
+		overlay_material.set_shader_parameter("mask_cutoff", GOBO_MASK_CUTOFF)
+		overlay_material.set_shader_parameter("edge_softness", GOBO_EDGE_SOFTNESS)
+		overlay_material.set_shader_parameter("radial_softness", GOBO_RADIAL_SOFTNESS)
+		overlay_material.set_shader_parameter("mask_strength", clamp(intensity * slice_fade, 0.0, 1.0))
+		overlay_material.set_shader_parameter("beam_color", beam_color)
 
 func _hide_gobo_overlay(light: SpotLight3D) -> void:
-	if not light.has_meta(GOBO_OVERLAY_META_KEY):
+	if not light.has_meta(GOBO_OVERLAY_ROOT_META_KEY):
 		return
-	var overlay: MeshInstance3D = light.get_meta(GOBO_OVERLAY_META_KEY) as MeshInstance3D
-	if overlay != null:
-		overlay.visible = false
+	var overlay_root: Node3D = light.get_meta(GOBO_OVERLAY_ROOT_META_KEY) as Node3D
+	if overlay_root == null:
+		return
+	overlay_root.visible = false
+	for child in overlay_root.get_children():
+		if child is MeshInstance3D:
+			(child as MeshInstance3D).visible = false
 
 func cleanup_beam(light: SpotLight3D) -> void:
 	if not light.has_meta(BEAM_META_KEY):
@@ -180,8 +218,8 @@ func cleanup_beam(light: SpotLight3D) -> void:
 	if cone != null and is_instance_valid(cone):
 		cone.queue_free()
 	light.remove_meta(BEAM_META_KEY)
-	if light.has_meta(GOBO_OVERLAY_META_KEY):
-		var overlay: MeshInstance3D = light.get_meta(GOBO_OVERLAY_META_KEY) as MeshInstance3D
-		if overlay != null and is_instance_valid(overlay):
-			overlay.queue_free()
-		light.remove_meta(GOBO_OVERLAY_META_KEY)
+	if light.has_meta(GOBO_OVERLAY_ROOT_META_KEY):
+		var overlay_root: Node3D = light.get_meta(GOBO_OVERLAY_ROOT_META_KEY) as Node3D
+		if overlay_root != null and is_instance_valid(overlay_root):
+			overlay_root.queue_free()
+		light.remove_meta(GOBO_OVERLAY_ROOT_META_KEY)

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -3,13 +3,17 @@ extends BeamRendererBase
 class_name VolumetricBeamRenderer
 
 const BEAM_META_KEY: String = "peraviz_volumetric_beam"
+const GOBO_OVERLAY_META_KEY: String = "peraviz_gobo_overlay"
 const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 10.0
 const VOLUMETRIC_INTENSITY_SCALE: float = 0.62
-const GOBO_MASK_CUTOFF: float = 0.55
-const GOBO_EDGE_SOFTNESS: float = 0.005
-const GOBO_RADIAL_SOFTNESS: float = 0.005
+const GOBO_OVERLAY_DISTANCE_SCALE: float = 1.15
+const GOBO_OVERLAY_MIN_DISTANCE_M: float = 0.008
+const GOBO_MASK_CUTOFF: float = 0.5
+const GOBO_EDGE_SOFTNESS: float = 0.01
+const GOBO_RADIAL_SOFTNESS: float = 0.03
 
 var _shared_material: ShaderMaterial
+var _gobo_overlay_shader: Shader = preload("res://scripts/shaders/volumetric_gobo_overlay.gdshader")
 var _camera: Camera3D
 var _settings: Dictionary = {}
 
@@ -36,11 +40,24 @@ func ensure_beam(light: SpotLight3D) -> void:
 	cone.name = "PeravizVolumetricBeam"
 	cone.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
 	cone.mesh = cone_mesh
-	cone.material_override = _shared_material.duplicate()
+	cone.material_override = _shared_material
 	cone.rotation_degrees.x = 90.0
 	cone.visible = false
 	light.add_child(cone)
 	light.set_meta(BEAM_META_KEY, cone)
+
+	var overlay_mesh := QuadMesh.new()
+	overlay_mesh.size = Vector2.ONE
+	var overlay := MeshInstance3D.new()
+	overlay.name = "PeravizGoboOverlay"
+	overlay.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
+	overlay.mesh = overlay_mesh
+	overlay.visible = false
+	var overlay_material := ShaderMaterial.new()
+	overlay_material.shader = _gobo_overlay_shader
+	overlay.material_override = overlay_material
+	light.add_child(overlay)
+	light.set_meta(GOBO_OVERLAY_META_KEY, overlay)
 
 func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	ensure_beam(light)
@@ -52,6 +69,7 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	var threshold: float = float(params.get("intensity_visibility_threshold", 0.015))
 	if intensity <= threshold or not bool(params.get("is_visible", true)):
 		cone.visible = false
+		_hide_gobo_overlay(light)
 		return
 
 	var beam_range: float = max(float(params.get("beam_range", 0.1)), 0.01)
@@ -64,15 +82,15 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 		var cam_distance: float = _camera.global_position.distance_to(light.global_position)
 		if cam_distance > distance_limit or _camera.is_position_behind(light.global_position):
 			cone.visible = false
+			_hide_gobo_overlay(light)
 			return
 
 	var half_angle_deg: float = beam_angle * 0.5
 	var radius: float = tan(deg_to_rad(half_angle_deg)) * beam_range
 	var bottom_radius: float = clamp(radius, 0.03, EMITTER_CONE_MAX_BASE_RADIUS_M)
-	var top_radius: float = max(lens_radius, 0.003)
 	var cone_mesh: CylinderMesh = cone.mesh as CylinderMesh
 	if cone_mesh != null:
-		cone_mesh.top_radius = top_radius
+		cone_mesh.top_radius = max(lens_radius, 0.003)
 		cone_mesh.bottom_radius = bottom_radius
 		cone_mesh.height = beam_range
 	cone.position = Vector3(0.0, 0.0, -beam_range * 0.5)
@@ -93,28 +111,67 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	cone.set_instance_shader_parameter("depth_feather_enabled", true)
 	cone.set_instance_shader_parameter("depth_fade_distance", 0.5)
 	cone.set_instance_shader_parameter("max_brightness", lerp(1.0, 10.0, intensity))
-	cone.set_instance_shader_parameter("beam_top_radius", top_radius)
-	cone.set_instance_shader_parameter("beam_bottom_radius", bottom_radius)
-	cone.set_instance_shader_parameter("gobo_mask_cutoff", GOBO_MASK_CUTOFF)
-	cone.set_instance_shader_parameter("gobo_edge_softness", GOBO_EDGE_SOFTNESS)
-	cone.set_instance_shader_parameter("gobo_radial_softness", GOBO_RADIAL_SOFTNESS)
 
-	update_gobo_overlay(light)
+	var gobo_overlay_params := {
+		"beam_range": beam_range,
+		"beam_angle": beam_angle,
+		"lens_radius": lens_radius,
+		"scaled_intensity": intensity,
+	}
+	_update_gobo_overlay(light, gobo_overlay_params)
 
 func update_gobo_overlay(light: SpotLight3D) -> void:
-	if not light.has_meta(BEAM_META_KEY):
+	if not light.has_meta("peraviz_beam_last_params"):
 		return
-	var cone: MeshInstance3D = light.get_meta(BEAM_META_KEY) as MeshInstance3D
-	if cone == null:
+	var params: Dictionary = light.get_meta("peraviz_beam_last_params", {})
+	if params.is_empty():
+		return
+	_update_gobo_overlay(light, params)
+
+func _update_gobo_overlay(light: SpotLight3D, params: Dictionary) -> void:
+	var overlay: MeshInstance3D = light.get_meta(GOBO_OVERLAY_META_KEY) as MeshInstance3D if light.has_meta(GOBO_OVERLAY_META_KEY) else null
+	if overlay == null:
 		return
 
 	var gobo_texture: Texture2D = light.light_projector
 	if gobo_texture == null:
-		cone.set_instance_shader_parameter("gobo_enabled", false)
+		overlay.visible = false
 		return
 
-	cone.set_instance_shader_parameter("gobo_enabled", true)
-	cone.set_instance_shader_parameter("gobo_texture", gobo_texture)
+	var intensity: float = clamp(float(params.get("scaled_intensity", 0.0)), 0.0, 3.0)
+	if intensity <= 0.001:
+		overlay.visible = false
+		return
+
+	var beam_range: float = max(float(params.get("beam_range", 0.1)), GOBO_OVERLAY_MIN_DISTANCE_M)
+	var beam_angle: float = max(float(params.get("beam_angle", 1.0)), 0.1)
+	var lens_radius: float = max(float(params.get("lens_radius", 0.03)), 0.005)
+	var half_angle_deg: float = beam_angle * 0.5
+	var overlay_distance: float = max(lens_radius * GOBO_OVERLAY_DISTANCE_SCALE, GOBO_OVERLAY_MIN_DISTANCE_M)
+	overlay_distance = min(overlay_distance, beam_range * 0.2)
+	var projected_radius: float = tan(deg_to_rad(half_angle_deg)) * overlay_distance
+	var radius: float = max(lens_radius, projected_radius)
+
+	overlay.position = Vector3(0.0, 0.0, -overlay_distance)
+	overlay.scale = Vector3(radius * 2.0, radius * 2.0, 1.0)
+
+	var overlay_material: ShaderMaterial = overlay.material_override as ShaderMaterial
+	if overlay_material == null:
+		overlay.visible = false
+		return
+	overlay_material.set_shader_parameter("gobo_texture", gobo_texture)
+	overlay_material.set_shader_parameter("mask_cutoff", GOBO_MASK_CUTOFF)
+	overlay_material.set_shader_parameter("edge_softness", GOBO_EDGE_SOFTNESS)
+	overlay_material.set_shader_parameter("radial_softness", GOBO_RADIAL_SOFTNESS)
+	overlay_material.set_shader_parameter("mask_strength", clamp(intensity, 0.0, 1.0))
+	overlay.visible = true
+
+func _hide_gobo_overlay(light: SpotLight3D) -> void:
+	if not light.has_meta(GOBO_OVERLAY_META_KEY):
+		return
+	var overlay: MeshInstance3D = light.get_meta(GOBO_OVERLAY_META_KEY) as MeshInstance3D
+	if overlay != null:
+		overlay.visible = false
 
 func cleanup_beam(light: SpotLight3D) -> void:
 	if not light.has_meta(BEAM_META_KEY):
@@ -123,3 +180,8 @@ func cleanup_beam(light: SpotLight3D) -> void:
 	if cone != null and is_instance_valid(cone):
 		cone.queue_free()
 	light.remove_meta(BEAM_META_KEY)
+	if light.has_meta(GOBO_OVERLAY_META_KEY):
+		var overlay: MeshInstance3D = light.get_meta(GOBO_OVERLAY_META_KEY) as MeshInstance3D
+		if overlay != null and is_instance_valid(overlay):
+			overlay.queue_free()
+		light.remove_meta(GOBO_OVERLAY_META_KEY)

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -3,17 +3,13 @@ extends BeamRendererBase
 class_name VolumetricBeamRenderer
 
 const BEAM_META_KEY: String = "peraviz_volumetric_beam"
-const GOBO_OVERLAY_META_KEY: String = "peraviz_gobo_overlay"
 const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 10.0
 const VOLUMETRIC_INTENSITY_SCALE: float = 0.62
-const GOBO_OVERLAY_DISTANCE_MULTIPLIER: float = 1.1
-const GOBO_OVERLAY_MIN_DISTANCE_M: float = 0.008
-const GOBO_MASK_CUTOFF: float = 0.5
-const GOBO_EDGE_SOFTNESS: float = 0.01
-const GOBO_RADIAL_SOFTNESS: float = 0.01
+const GOBO_MASK_CUTOFF: float = 0.55
+const GOBO_EDGE_SOFTNESS: float = 0.005
+const GOBO_RADIAL_SOFTNESS: float = 0.005
 
 var _shared_material: ShaderMaterial
-var _gobo_overlay_shader: Shader = preload("res://scripts/shaders/volumetric_gobo_overlay.gdshader")
 var _camera: Camera3D
 var _settings: Dictionary = {}
 
@@ -40,24 +36,11 @@ func ensure_beam(light: SpotLight3D) -> void:
 	cone.name = "PeravizVolumetricBeam"
 	cone.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
 	cone.mesh = cone_mesh
-	cone.material_override = _shared_material
+	cone.material_override = _shared_material.duplicate()
 	cone.rotation_degrees.x = 90.0
 	cone.visible = false
 	light.add_child(cone)
 	light.set_meta(BEAM_META_KEY, cone)
-
-	var overlay_mesh := QuadMesh.new()
-	overlay_mesh.size = Vector2.ONE
-	var overlay := MeshInstance3D.new()
-	overlay.name = "PeravizGoboOverlay"
-	overlay.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
-	overlay.mesh = overlay_mesh
-	overlay.visible = false
-	var overlay_material := ShaderMaterial.new()
-	overlay_material.shader = _gobo_overlay_shader
-	overlay.material_override = overlay_material
-	light.add_child(overlay)
-	light.set_meta(GOBO_OVERLAY_META_KEY, overlay)
 
 func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	ensure_beam(light)
@@ -69,7 +52,6 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	var threshold: float = float(params.get("intensity_visibility_threshold", 0.015))
 	if intensity <= threshold or not bool(params.get("is_visible", true)):
 		cone.visible = false
-		_hide_gobo_overlay(light)
 		return
 
 	var beam_range: float = max(float(params.get("beam_range", 0.1)), 0.01)
@@ -82,15 +64,15 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 		var cam_distance: float = _camera.global_position.distance_to(light.global_position)
 		if cam_distance > distance_limit or _camera.is_position_behind(light.global_position):
 			cone.visible = false
-			_hide_gobo_overlay(light)
 			return
 
 	var half_angle_deg: float = beam_angle * 0.5
 	var radius: float = tan(deg_to_rad(half_angle_deg)) * beam_range
 	var bottom_radius: float = clamp(radius, 0.03, EMITTER_CONE_MAX_BASE_RADIUS_M)
+	var top_radius: float = max(lens_radius, 0.003)
 	var cone_mesh: CylinderMesh = cone.mesh as CylinderMesh
 	if cone_mesh != null:
-		cone_mesh.top_radius = max(lens_radius, 0.003)
+		cone_mesh.top_radius = top_radius
 		cone_mesh.bottom_radius = bottom_radius
 		cone_mesh.height = beam_range
 	cone.position = Vector3(0.0, 0.0, -beam_range * 0.5)
@@ -111,67 +93,28 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	cone.set_instance_shader_parameter("depth_feather_enabled", true)
 	cone.set_instance_shader_parameter("depth_fade_distance", 0.5)
 	cone.set_instance_shader_parameter("max_brightness", lerp(1.0, 10.0, intensity))
+	cone.set_instance_shader_parameter("beam_top_radius", top_radius)
+	cone.set_instance_shader_parameter("beam_bottom_radius", bottom_radius)
+	cone.set_instance_shader_parameter("gobo_mask_cutoff", GOBO_MASK_CUTOFF)
+	cone.set_instance_shader_parameter("gobo_edge_softness", GOBO_EDGE_SOFTNESS)
+	cone.set_instance_shader_parameter("gobo_radial_softness", GOBO_RADIAL_SOFTNESS)
 
-	var gobo_overlay_params := {
-		"beam_range": beam_range,
-		"beam_angle": beam_angle,
-		"lens_radius": lens_radius,
-		"scaled_intensity": intensity,
-	}
-	_update_gobo_overlay(light, gobo_overlay_params)
+	_update_gobo_overlay(light)
 
 func update_gobo_overlay(light: SpotLight3D) -> void:
-	if not light.has_meta("peraviz_beam_last_params"):
+	if not light.has_meta(BEAM_META_KEY):
 		return
-	var params: Dictionary = light.get_meta("peraviz_beam_last_params", {})
-	if params.is_empty():
-		return
-	_update_gobo_overlay(light, params)
-
-func _update_gobo_overlay(light: SpotLight3D, params: Dictionary) -> void:
-	var overlay: MeshInstance3D = light.get_meta(GOBO_OVERLAY_META_KEY) as MeshInstance3D if light.has_meta(GOBO_OVERLAY_META_KEY) else null
-	if overlay == null:
+	var cone: MeshInstance3D = light.get_meta(BEAM_META_KEY) as MeshInstance3D
+	if cone == null:
 		return
 
 	var gobo_texture: Texture2D = light.light_projector
 	if gobo_texture == null:
-		overlay.visible = false
+		cone.set_instance_shader_parameter("gobo_enabled", false)
 		return
 
-	var intensity: float = clamp(float(params.get("scaled_intensity", 0.0)), 0.0, 3.0)
-	if intensity <= 0.001:
-		overlay.visible = false
-		return
-
-	var beam_range: float = max(float(params.get("beam_range", 0.1)), GOBO_OVERLAY_MIN_DISTANCE_M)
-	var beam_angle: float = max(float(params.get("beam_angle", 1.0)), 0.1)
-	var lens_radius: float = max(float(params.get("lens_radius", 0.03)), 0.005)
-	var half_angle_deg: float = beam_angle * 0.5
-	var overlay_distance: float = max(lens_radius * GOBO_OVERLAY_DISTANCE_MULTIPLIER, GOBO_OVERLAY_MIN_DISTANCE_M)
-	overlay_distance = min(overlay_distance, beam_range * 0.2)
-	var projected_radius: float = tan(deg_to_rad(half_angle_deg)) * overlay_distance
-	var radius: float = max(lens_radius, projected_radius)
-
-	overlay.position = Vector3(0.0, 0.0, -overlay_distance)
-	overlay.scale = Vector3(radius * 2.0, radius * 2.0, 1.0)
-
-	var overlay_material: ShaderMaterial = overlay.material_override as ShaderMaterial
-	if overlay_material == null:
-		overlay.visible = false
-		return
-	overlay_material.set_shader_parameter("gobo_texture", gobo_texture)
-	overlay_material.set_shader_parameter("mask_cutoff", GOBO_MASK_CUTOFF)
-	overlay_material.set_shader_parameter("edge_softness", GOBO_EDGE_SOFTNESS)
-	overlay_material.set_shader_parameter("radial_softness", GOBO_RADIAL_SOFTNESS)
-	overlay_material.set_shader_parameter("mask_strength", clamp(intensity, 0.0, 1.0))
-	overlay.visible = true
-
-func _hide_gobo_overlay(light: SpotLight3D) -> void:
-	if not light.has_meta(GOBO_OVERLAY_META_KEY):
-		return
-	var overlay: MeshInstance3D = light.get_meta(GOBO_OVERLAY_META_KEY) as MeshInstance3D
-	if overlay != null:
-		overlay.visible = false
+	cone.set_instance_shader_parameter("gobo_enabled", true)
+	cone.set_instance_shader_parameter("gobo_texture", gobo_texture)
 
 func cleanup_beam(light: SpotLight3D) -> void:
 	if not light.has_meta(BEAM_META_KEY):
@@ -180,8 +123,3 @@ func cleanup_beam(light: SpotLight3D) -> void:
 	if cone != null and is_instance_valid(cone):
 		cone.queue_free()
 	light.remove_meta(BEAM_META_KEY)
-	if light.has_meta(GOBO_OVERLAY_META_KEY):
-		var overlay: MeshInstance3D = light.get_meta(GOBO_OVERLAY_META_KEY) as MeshInstance3D
-		if overlay != null and is_instance_valid(overlay):
-			overlay.queue_free()
-		light.remove_meta(GOBO_OVERLAY_META_KEY)

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -1837,9 +1837,11 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 		"intensity_visibility_threshold": BEAM_INTENSITY_VISIBILITY_THRESHOLD,
 		"distance_cull_m": BEAM_DISTANCE_CULL_M,
 	}
-	_update_beam_for_light(light, beam_params)
 	if _fixture_gobo_projector != null:
 		_fixture_gobo_projector.apply_gobo_projection(light, controls)
+	_update_beam_for_light(light, beam_params)
+	if _active_beam_renderer != null:
+		_active_beam_renderer.update_gobo_overlay(light)
 
 func _resolve_zoom_beam_limits(light: SpotLight3D, controls: Dictionary) -> Dictionary:
 	# min/max beam angles are kept as full GDTF beam apertures (not half-angle).

--- a/peraviz/scripts/shaders/volumetric_beam.gdshader
+++ b/peraviz/scripts/shaders/volumetric_beam.gdshader
@@ -1,5 +1,5 @@
 shader_type spatial;
-render_mode unshaded, blend_add, cull_disabled, depth_draw_opaque;
+render_mode unshaded, blend_add, cull_disabled, depth_draw_never;
 
 uniform sampler2D DEPTH_TEXTURE : hint_depth_texture, filter_linear_mipmap;
 
@@ -24,6 +24,7 @@ instance uniform float beam_bottom_radius : hint_range(0.01, 30.0) = 0.8;
 instance uniform float gobo_mask_cutoff : hint_range(0.0, 1.0) = 0.55;
 instance uniform float gobo_edge_softness : hint_range(0.0, 0.2) = 0.005;
 instance uniform float gobo_radial_softness : hint_range(0.0, 0.2) = 0.005;
+instance uniform float volumetric_alpha_scale : hint_range(0.05, 1.0) = 0.35;
 
 varying vec3 vertex_view;
 varying vec3 vertex_local;
@@ -91,6 +92,6 @@ void fragment() {
 	float gobo_mask = compute_gobo_mask(vertex_local, UV);
 	float final_alpha = feather_alpha * depth_mult * dist_fade * gobo_mask;
 	ALBEDO = base_color.rgb * brightness * gobo_mask;
-	ALPHA = clamp(final_alpha * base_color.a, 0.0, 1.0);
+	ALPHA = clamp(final_alpha * base_color.a * volumetric_alpha_scale, 0.0, 1.0);
 	EMISSION = ALBEDO * ALPHA;
 }

--- a/peraviz/scripts/shaders/volumetric_beam.gdshader
+++ b/peraviz/scripts/shaders/volumetric_beam.gdshader
@@ -17,44 +17,16 @@ instance uniform float far_fade_end : hint_range(0.1, 100.0) = 80.0;
 instance uniform float max_brightness : hint_range(1.0, 50.0) = 10.0;
 instance uniform bool depth_feather_enabled = true;
 instance uniform float depth_fade_distance : hint_range(0.01, 5.0) = 0.5;
-instance uniform bool gobo_enabled = false;
-instance uniform sampler2D gobo_texture : hint_albedo;
-instance uniform float beam_top_radius : hint_range(0.001, 1.0) = 0.03;
-instance uniform float beam_bottom_radius : hint_range(0.01, 30.0) = 0.8;
-instance uniform float gobo_mask_cutoff : hint_range(0.0, 1.0) = 0.55;
-instance uniform float gobo_edge_softness : hint_range(0.0, 0.2) = 0.005;
-instance uniform float gobo_radial_softness : hint_range(0.0, 0.2) = 0.005;
-instance uniform float volumetric_alpha_scale : hint_range(0.05, 1.0) = 0.35;
 
 varying vec3 vertex_view;
-varying vec3 vertex_local;
 
 void vertex() {
-	vertex_local = VERTEX;
 	vertex_view = (MODELVIEW_MATRIX * vec4(VERTEX, 1.0)).xyz;
 	POSITION = PROJECTION_MATRIX * vec4(vertex_view, 1.0);
 }
 
 float get_linear_depth(float raw_depth, mat4 inv_proj_mat) {
 	return 1.0 / (raw_depth * inv_proj_mat[2][3] + inv_proj_mat[3][3]);
-}
-
-float compute_gobo_mask(vec3 local_position, vec2 cone_uv) {
-	if (!gobo_enabled) {
-		return 1.0;
-	}
-
-	float axis_t = clamp(cone_uv.y, 0.0, 1.0);
-	float beam_radius = max(mix(beam_top_radius, beam_bottom_radius, axis_t), 0.0001);
-	vec2 radial = local_position.xz / beam_radius;
-	vec2 gobo_uv = radial * 0.5 + vec2(0.5);
-	float radial_dist = length(gobo_uv - vec2(0.5));
-	float radial_falloff = 1.0 - smoothstep(0.5 - gobo_radial_softness, 0.5, radial_dist);
-
-	vec4 gobo_sample = texture(gobo_texture, gobo_uv);
-	float gobo_luma = dot(gobo_sample.rgb, vec3(0.299, 0.587, 0.114));
-	float hard_mask = smoothstep(gobo_mask_cutoff - gobo_edge_softness, gobo_mask_cutoff + gobo_edge_softness, gobo_luma);
-	return clamp(hard_mask * radial_falloff, 0.0, 1.0);
 }
 
 void fragment() {
@@ -89,9 +61,8 @@ void fragment() {
 		}
 	}
 
-	float gobo_mask = compute_gobo_mask(vertex_local, UV);
-	float final_alpha = feather_alpha * depth_mult * dist_fade * gobo_mask;
-	ALBEDO = base_color.rgb * brightness * gobo_mask;
-	ALPHA = clamp(final_alpha * base_color.a * volumetric_alpha_scale, 0.0, 1.0);
+	float final_alpha = feather_alpha * depth_mult * dist_fade;
+	ALBEDO = base_color.rgb * brightness;
+	ALPHA = clamp(final_alpha * base_color.a, 0.0, 1.0);
 	EMISSION = ALBEDO * ALPHA;
 }

--- a/peraviz/scripts/shaders/volumetric_beam.gdshader
+++ b/peraviz/scripts/shaders/volumetric_beam.gdshader
@@ -17,16 +17,43 @@ instance uniform float far_fade_end : hint_range(0.1, 100.0) = 80.0;
 instance uniform float max_brightness : hint_range(1.0, 50.0) = 10.0;
 instance uniform bool depth_feather_enabled = true;
 instance uniform float depth_fade_distance : hint_range(0.01, 5.0) = 0.5;
+instance uniform bool gobo_enabled = false;
+instance uniform sampler2D gobo_texture : hint_albedo;
+instance uniform float beam_top_radius : hint_range(0.001, 1.0) = 0.03;
+instance uniform float beam_bottom_radius : hint_range(0.01, 30.0) = 0.8;
+instance uniform float gobo_mask_cutoff : hint_range(0.0, 1.0) = 0.55;
+instance uniform float gobo_edge_softness : hint_range(0.0, 0.2) = 0.005;
+instance uniform float gobo_radial_softness : hint_range(0.0, 0.2) = 0.005;
 
 varying vec3 vertex_view;
+varying vec3 vertex_local;
 
 void vertex() {
+	vertex_local = VERTEX;
 	vertex_view = (MODELVIEW_MATRIX * vec4(VERTEX, 1.0)).xyz;
 	POSITION = PROJECTION_MATRIX * vec4(vertex_view, 1.0);
 }
 
 float get_linear_depth(float raw_depth, mat4 inv_proj_mat) {
 	return 1.0 / (raw_depth * inv_proj_mat[2][3] + inv_proj_mat[3][3]);
+}
+
+float compute_gobo_mask(vec3 local_position, vec2 cone_uv) {
+	if (!gobo_enabled) {
+		return 1.0;
+	}
+
+	float axis_t = clamp(cone_uv.y, 0.0, 1.0);
+	float beam_radius = max(mix(beam_top_radius, beam_bottom_radius, axis_t), 0.0001);
+	vec2 radial = local_position.xz / beam_radius;
+	vec2 gobo_uv = radial * 0.5 + vec2(0.5);
+	float radial_dist = length(gobo_uv - vec2(0.5));
+	float radial_falloff = 1.0 - smoothstep(0.5 - gobo_radial_softness, 0.5, radial_dist);
+
+	vec4 gobo_sample = texture(gobo_texture, gobo_uv);
+	float gobo_luma = dot(gobo_sample.rgb, vec3(0.299, 0.587, 0.114));
+	float hard_mask = smoothstep(gobo_mask_cutoff - gobo_edge_softness, gobo_mask_cutoff + gobo_edge_softness, gobo_luma);
+	return clamp(hard_mask * radial_falloff, 0.0, 1.0);
 }
 
 void fragment() {
@@ -61,8 +88,9 @@ void fragment() {
 		}
 	}
 
-	float final_alpha = feather_alpha * depth_mult * dist_fade;
-	ALBEDO = base_color.rgb * brightness;
+	float gobo_mask = compute_gobo_mask(vertex_local, UV);
+	float final_alpha = feather_alpha * depth_mult * dist_fade * gobo_mask;
+	ALBEDO = base_color.rgb * brightness * gobo_mask;
 	ALPHA = clamp(final_alpha * base_color.a, 0.0, 1.0);
 	EMISSION = ALBEDO * ALPHA;
 }

--- a/peraviz/scripts/shaders/volumetric_gobo_overlay.gdshader
+++ b/peraviz/scripts/shaders/volumetric_gobo_overlay.gdshader
@@ -1,0 +1,20 @@
+shader_type spatial;
+
+render_mode unshaded, blend_add, cull_disabled, depth_draw_never;
+
+uniform sampler2D gobo_texture : hint_albedo;
+uniform float intensity : hint_range(0.0, 3.0) = 1.0;
+uniform float radial_softness : hint_range(0.001, 1.0) = 0.08;
+
+void fragment() {
+	vec4 gobo_sample = texture(gobo_texture, UV);
+	float gobo_luma = dot(gobo_sample.rgb, vec3(0.299, 0.587, 0.114));
+	float radial_distance = length(UV - vec2(0.5));
+	float radial_falloff = 1.0 - smoothstep(0.5 - radial_softness, 0.5, radial_distance);
+	float alpha = gobo_sample.a * gobo_luma * radial_falloff * intensity;
+	vec3 gobo_color = gobo_sample.rgb * radial_falloff * intensity;
+
+	ALBEDO = gobo_color;
+	ALPHA = alpha;
+	EMISSION = gobo_color * alpha;
+}

--- a/peraviz/scripts/shaders/volumetric_gobo_overlay.gdshader
+++ b/peraviz/scripts/shaders/volumetric_gobo_overlay.gdshader
@@ -1,20 +1,23 @@
 shader_type spatial;
 
-render_mode unshaded, blend_add, cull_disabled, depth_draw_never;
+render_mode unshaded, blend_mul, cull_disabled, depth_draw_never;
 
 uniform sampler2D gobo_texture : hint_albedo;
-uniform float intensity : hint_range(0.0, 3.0) = 1.0;
-uniform float radial_softness : hint_range(0.001, 1.0) = 0.08;
+uniform float mask_cutoff : hint_range(0.0, 1.0) = 0.5;
+uniform float edge_softness : hint_range(0.0, 0.2) = 0.01;
+uniform float radial_softness : hint_range(0.0, 0.2) = 0.01;
+uniform float mask_strength : hint_range(0.0, 1.0) = 1.0;
 
 void fragment() {
 	vec4 gobo_sample = texture(gobo_texture, UV);
 	float gobo_luma = dot(gobo_sample.rgb, vec3(0.299, 0.587, 0.114));
+	float thresholded = smoothstep(mask_cutoff - edge_softness, mask_cutoff + edge_softness, gobo_luma);
+
 	float radial_distance = length(UV - vec2(0.5));
 	float radial_falloff = 1.0 - smoothstep(0.5 - radial_softness, 0.5, radial_distance);
-	float alpha = gobo_sample.a * gobo_luma * radial_falloff * intensity;
-	vec3 gobo_color = gobo_sample.rgb * radial_falloff * intensity;
+	float mask = mix(1.0, thresholded * radial_falloff, mask_strength);
 
-	ALBEDO = gobo_color;
-	ALPHA = alpha;
-	EMISSION = gobo_color * alpha;
+	ALBEDO = vec3(mask);
+	ALPHA = 1.0;
+	EMISSION = vec3(0.0);
 }

--- a/peraviz/scripts/shaders/volumetric_gobo_overlay.gdshader
+++ b/peraviz/scripts/shaders/volumetric_gobo_overlay.gdshader
@@ -1,23 +1,24 @@
 shader_type spatial;
 
-render_mode unshaded, blend_mix, cull_disabled, depth_draw_never;
+render_mode unshaded, blend_add, cull_disabled, depth_draw_never;
 
 uniform sampler2D gobo_texture : hint_albedo;
+uniform vec3 beam_color : source_color = vec3(1.0, 1.0, 1.0);
 uniform float mask_cutoff : hint_range(0.0, 1.0) = 0.5;
-uniform float edge_softness : hint_range(0.0, 0.2) = 0.01;
-uniform float radial_softness : hint_range(0.0, 0.2) = 0.03;
-uniform float mask_strength : hint_range(0.0, 1.0) = 0.85;
+uniform float edge_softness : hint_range(0.0, 0.2) = 0.02;
+uniform float radial_softness : hint_range(0.0, 0.2) = 0.04;
+uniform float mask_strength : hint_range(0.0, 1.0) = 0.65;
 
 void fragment() {
 	vec4 gobo_sample = texture(gobo_texture, UV);
 	float gobo_luma = dot(gobo_sample.rgb, vec3(0.299, 0.587, 0.114));
 	float pass_mask = smoothstep(mask_cutoff - edge_softness, mask_cutoff + edge_softness, gobo_luma);
-
 	float radial_distance = length(UV - vec2(0.5));
 	float radial_falloff = 1.0 - smoothstep(0.5 - radial_softness, 0.5, radial_distance);
-	float block_alpha = (1.0 - pass_mask) * radial_falloff * mask_strength;
+	float beam_mask = pass_mask * radial_falloff;
 
-	ALBEDO = vec3(0.0);
-	ALPHA = clamp(block_alpha, 0.0, 1.0);
-	EMISSION = vec3(0.0);
+	vec3 light_add = beam_color * beam_mask * mask_strength;
+	ALBEDO = light_add;
+	ALPHA = clamp(beam_mask * mask_strength, 0.0, 1.0);
+	EMISSION = light_add;
 }

--- a/peraviz/scripts/shaders/volumetric_gobo_overlay.gdshader
+++ b/peraviz/scripts/shaders/volumetric_gobo_overlay.gdshader
@@ -1,23 +1,23 @@
 shader_type spatial;
 
-render_mode unshaded, blend_mul, cull_disabled, depth_draw_never;
+render_mode unshaded, blend_mix, cull_disabled, depth_draw_never;
 
 uniform sampler2D gobo_texture : hint_albedo;
 uniform float mask_cutoff : hint_range(0.0, 1.0) = 0.5;
 uniform float edge_softness : hint_range(0.0, 0.2) = 0.01;
-uniform float radial_softness : hint_range(0.0, 0.2) = 0.01;
-uniform float mask_strength : hint_range(0.0, 1.0) = 1.0;
+uniform float radial_softness : hint_range(0.0, 0.2) = 0.03;
+uniform float mask_strength : hint_range(0.0, 1.0) = 0.85;
 
 void fragment() {
 	vec4 gobo_sample = texture(gobo_texture, UV);
 	float gobo_luma = dot(gobo_sample.rgb, vec3(0.299, 0.587, 0.114));
-	float thresholded = smoothstep(mask_cutoff - edge_softness, mask_cutoff + edge_softness, gobo_luma);
+	float pass_mask = smoothstep(mask_cutoff - edge_softness, mask_cutoff + edge_softness, gobo_luma);
 
 	float radial_distance = length(UV - vec2(0.5));
 	float radial_falloff = 1.0 - smoothstep(0.5 - radial_softness, 0.5, radial_distance);
-	float mask = mix(1.0, thresholded * radial_falloff, mask_strength);
+	float block_alpha = (1.0 - pass_mask) * radial_falloff * mask_strength;
 
-	ALBEDO = vec3(mask);
-	ALPHA = 1.0;
+	ALBEDO = vec3(0.0);
+	ALPHA = clamp(block_alpha, 0.0, 1.0);
 	EMISSION = vec3(0.0);
 }

--- a/peraviz/scripts/shaders/volumetric_gobo_overlay.gdshader.uid
+++ b/peraviz/scripts/shaders/volumetric_gobo_overlay.gdshader.uid
@@ -1,0 +1,1 @@
+uid://cxy2wcn6jjv0v


### PR DESCRIPTION
### Motivation
- Volumetric beams did not show gobo/projector patterns because the volumetric beam shader never sampled the `SpotLight3D.light_projector` texture, so projector images only affected geometry and not the beam volume.
- The intent is to overlay the composed gobo texture onto the volumetric beam using a simple quad-based projector so gobo patterns appear inside beams without rewriting the existing volumetric shader.

### Description
- Added a renderer hook `update_gobo_overlay()` to `BeamRendererBase` so renderers can refresh projector-dependent visuals independently of full beam rebuilds (`peraviz/scripts/beam_renderers/beam_renderer_base.gd`).
- Implemented a per-light gobo overlay in `VolumetricBeamRenderer` by creating a `PeravizGoboOverlay` `MeshInstance3D` (unit `QuadMesh`) as a child of the light, storing it in `light` meta, and updating its transform, scale and visibility from beam parameters (`peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd`).
- Added `volumetric_gobo_overlay.gdshader` which samples a `gobo_texture` with additive blending and a radial falloff, and exposed `intensity` and `radial_softness` shader parameters (`peraviz/scripts/shaders/volumetric_gobo_overlay.gdshader`).
- Integrated with the existing gobo projector flow by ensuring `_fixture_gobo_projector.apply_gobo_projection(light, controls)` is called before beam/material updates and then calling the active renderer's `update_gobo_overlay(light)` to push the composed `light.light_projector` texture to the overlay (change in `peraviz/scripts/load_scene.gd`).
- Ensured overlay visibility is synchronized with beam culling/intensity and that overlays are cleaned up when beams are removed.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (`OK`).
- Basic static validation: added and committed `peraviz/scripts/shaders/volumetric_gobo_overlay.gdshader` and updated beam renderer and scene flow; runtime visual verification in Godot was planned but not part of automated tests in this repo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f7c567b688324ae0b64f6d93dfb5c)