### PR TITLE
Fix startup project loader thread leak on app shutdown

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -31,12 +31,14 @@
 class MyApp : public wxApp {
 public:
   virtual bool OnInit() override;
+  int OnExit() override;
   int FilterEvent(wxEvent &event) override;
   bool OnExceptionInMainLoop() override;
   void OnUnhandledException() override;
 
 private:
   std::string last_event_summary_;
+  std::thread project_loader_thread_;
 };
 
 wxIMPLEMENT_APP(MyApp);
@@ -74,7 +76,7 @@ bool MyApp::OnInit() {
 
   if (lastPathOpt) {
     std::string lastPath = *lastPathOpt;
-    std::thread([mainWindowRef, lastPath]() {
+    project_loader_thread_ = std::thread([mainWindowRef, lastPath]() {
       try {
         namespace fs = std::filesystem;
         bool loaded = false;
@@ -116,7 +118,7 @@ bool MyApp::OnInit() {
           wxQueueEvent(mainWindowRef.get(), evt.Clone());
         }
       }
-    }).detach();
+    });
   } else if (mainWindowRef) {
     wxCommandEvent evt(EVT_PROJECT_LOADED);
     evt.SetInt(0);
@@ -125,6 +127,13 @@ bool MyApp::OnInit() {
   }
 
   return true;
+}
+
+int MyApp::OnExit() {
+  if (project_loader_thread_.joinable()) {
+    project_loader_thread_.join();
+  }
+  return wxApp::OnExit();
 }
 
 int MyApp::FilterEvent(wxEvent &event) {


### PR DESCRIPTION
### Motivation
- Prevent shutdown-time leak noise caused by a detached startup worker still running when the process exits by making its lifetime deterministic.

### Description
- In `main.cpp` replaced the detached lambda thread with a `std::thread` member `project_loader_thread_` and added an `OnExit()` override that `join()`s the thread if joinable, preserving the existing async load-and-post-event behavior.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which returned OK.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which returned OK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a059746c888324849e25a1683071a7)