### PR TITLE
Respect force-bottom fixture view in layout 2D SVG rendering and PDF export

### DIFF
--- a/core/layouts/LayoutCollection.h
+++ b/core/layouts/LayoutCollection.h
@@ -45,6 +45,7 @@ struct Layout2DViewCameraState {
 struct Layout2DViewRenderOptions {
   int renderMode = 2;
   bool darkMode = true;
+  bool forceBottomViewForTopFixtures = true;
   bool showGrid = true;
   int gridStyle = 0;
   float gridColorR = 0.35f;

--- a/core/layouts/LayoutCollection.h
+++ b/core/layouts/LayoutCollection.h
@@ -18,7 +18,7 @@
 #pragma once
 
 #include <array>
-#include <array>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -45,7 +45,7 @@ struct Layout2DViewCameraState {
 struct Layout2DViewRenderOptions {
   int renderMode = 2;
   bool darkMode = true;
-  bool forceBottomViewForTopFixtures = true;
+  std::optional<bool> forceBottomViewForTopFixtures;
   bool showGrid = true;
   int gridStyle = 0;
   float gridColorR = 0.35f;

--- a/core/layouts/LayoutManager.cpp
+++ b/core/layouts/LayoutManager.cpp
@@ -67,6 +67,7 @@ nlohmann::json ToJson(const Layout2DViewDefinition &view) {
       {"renderOptions",
        {{"renderMode", options.renderMode},
         {"darkMode", options.darkMode},
+        {"forceBottomViewForTopFixtures", options.forceBottomViewForTopFixtures},
         {"showGrid", options.showGrid},
         {"gridStyle", options.gridStyle},
         {"gridColorR", options.gridColorR},
@@ -233,6 +234,9 @@ void ReadRenderOptions(const nlohmann::json &obj,
     options.renderMode = it->get<int>();
   if (auto it = obj.find("darkMode"); it != obj.end() && it->is_boolean())
     options.darkMode = it->get<bool>();
+  if (auto it = obj.find("forceBottomViewForTopFixtures");
+      it != obj.end() && it->is_boolean())
+    options.forceBottomViewForTopFixtures = it->get<bool>();
   if (auto it = obj.find("showGrid"); it != obj.end() && it->is_boolean())
     options.showGrid = it->get<bool>();
   if (auto it = obj.find("gridStyle"); it != obj.end() && it->is_number())
@@ -698,6 +702,9 @@ bool ParseLayout(const nlohmann::json &value, LayoutDefinition &out) {
         if (auto it = viewObj.find("darkMode");
             it != viewObj.end() && it->is_boolean())
           options.darkMode = it->get<bool>();
+        if (auto it = viewObj.find("forceBottomViewForTopFixtures");
+            it != viewObj.end() && it->is_boolean())
+          options.forceBottomViewForTopFixtures = it->get<bool>();
         if (auto it = viewObj.find("showGrid");
             it != viewObj.end() && it->is_boolean())
           options.showGrid = it->get<bool>();

--- a/core/layouts/LayoutManager.cpp
+++ b/core/layouts/LayoutManager.cpp
@@ -65,23 +65,29 @@ nlohmann::json ToJson(const Layout2DViewDefinition &view) {
         {"viewportHeight", camera.viewportHeight},
         {"view", camera.view}}},
       {"renderOptions",
-       {{"renderMode", options.renderMode},
-        {"darkMode", options.darkMode},
-        {"forceBottomViewForTopFixtures", options.forceBottomViewForTopFixtures},
-        {"showGrid", options.showGrid},
-        {"gridStyle", options.gridStyle},
-        {"gridColorR", options.gridColorR},
-        {"gridColorG", options.gridColorG},
-        {"gridColorB", options.gridColorB},
-        {"gridDrawAbove", options.gridDrawAbove},
-        {"showLabelName", options.showLabelName},
-        {"showLabelId", options.showLabelId},
-        {"showLabelDmx", options.showLabelDmx},
-        {"labelFontSizeName", options.labelFontSizeName},
-        {"labelFontSizeId", options.labelFontSizeId},
-        {"labelFontSizeDmx", options.labelFontSizeDmx},
-        {"labelOffsetDistance", options.labelOffsetDistance},
-        {"labelOffsetAngle", options.labelOffsetAngle}}},
+       [&options]() {
+         nlohmann::json renderOptions{{"renderMode", options.renderMode},
+                                      {"darkMode", options.darkMode},
+                                      {"showGrid", options.showGrid},
+                                      {"gridStyle", options.gridStyle},
+                                      {"gridColorR", options.gridColorR},
+                                      {"gridColorG", options.gridColorG},
+                                      {"gridColorB", options.gridColorB},
+                                      {"gridDrawAbove", options.gridDrawAbove},
+                                      {"showLabelName", options.showLabelName},
+                                      {"showLabelId", options.showLabelId},
+                                      {"showLabelDmx", options.showLabelDmx},
+                                      {"labelFontSizeName", options.labelFontSizeName},
+                                      {"labelFontSizeId", options.labelFontSizeId},
+                                      {"labelFontSizeDmx", options.labelFontSizeDmx},
+                                      {"labelOffsetDistance", options.labelOffsetDistance},
+                                      {"labelOffsetAngle", options.labelOffsetAngle}};
+         if (options.forceBottomViewForTopFixtures.has_value()) {
+           renderOptions["forceBottomViewForTopFixtures"] =
+               options.forceBottomViewForTopFixtures.value();
+         }
+         return renderOptions;
+       }()},
       {"layers", {{"hiddenLayers", layers.hiddenLayers}}},
   };
 }

--- a/gui/layoutviewerpanel_render_invalidation.cpp
+++ b/gui/layoutviewerpanel_render_invalidation.cpp
@@ -38,6 +38,8 @@ size_t LayoutViewerPanel::HashViewContent(
   HashCombine(seed, std::hash<int>{}(view.camera.view));
   HashCombine(seed, std::hash<int>{}(view.renderOptions.renderMode));
   HashCombine(seed, std::hash<bool>{}(view.renderOptions.darkMode));
+  HashCombine(seed,
+              std::hash<bool>{}(view.renderOptions.forceBottomViewForTopFixtures));
   HashCombine(seed, std::hash<bool>{}(view.renderOptions.showGrid));
   HashCombine(seed, std::hash<int>{}(view.renderOptions.gridStyle));
   HashCombineFloat(seed, view.renderOptions.gridColorR);

--- a/gui/layoutviewerpanel_render_invalidation.cpp
+++ b/gui/layoutviewerpanel_render_invalidation.cpp
@@ -38,8 +38,13 @@ size_t LayoutViewerPanel::HashViewContent(
   HashCombine(seed, std::hash<int>{}(view.camera.view));
   HashCombine(seed, std::hash<int>{}(view.renderOptions.renderMode));
   HashCombine(seed, std::hash<bool>{}(view.renderOptions.darkMode));
-  HashCombine(seed,
-              std::hash<bool>{}(view.renderOptions.forceBottomViewForTopFixtures));
+  if (view.renderOptions.forceBottomViewForTopFixtures.has_value()) {
+    HashCombine(seed, std::hash<int>{}(1));
+    HashCombine(seed, std::hash<bool>{}(
+                          view.renderOptions.forceBottomViewForTopFixtures.value()));
+  } else {
+    HashCombine(seed, std::hash<int>{}(0));
+  }
   HashCombine(seed, std::hash<bool>{}(view.renderOptions.showGrid));
   HashCombine(seed, std::hash<int>{}(view.renderOptions.gridStyle));
   HashCombineFloat(seed, view.renderOptions.gridColorR);

--- a/viewer2d/viewer2dstate.cpp
+++ b/viewer2d/viewer2dstate.cpp
@@ -236,8 +236,14 @@ Viewer2DState FromLayoutDefinition(const layouts::Layout2DViewDefinition &view) 
 }
 
 void ApplyEditorRenderOptions(Viewer2DState &state, const ConfigManager &cfg) {
+  const std::optional<bool> preservedForceBottomSetting =
+      state.renderOptions.forceBottomViewForTopFixtures;
   Viewer2DState editorState = CaptureState(nullptr, cfg);
   state.renderOptions = editorState.renderOptions;
+  if (preservedForceBottomSetting.has_value()) {
+    state.renderOptions.forceBottomViewForTopFixtures =
+        preservedForceBottomSetting;
+  }
 }
 
 layouts::Layout2DViewDefinition ToLayoutDefinition(

--- a/viewer2d/viewer2dstate.cpp
+++ b/viewer2d/viewer2dstate.cpp
@@ -114,9 +114,12 @@ void ApplyState(Viewer2DPanel *panel, Viewer2DRenderPanel *renderPanel,
   cfg.SetFloat("view2d_render_mode",
                static_cast<float>(state.renderOptions.renderMode));
   cfg.SetFloat("view2d_dark_mode", state.renderOptions.darkMode ? 1.0f : 0.0f);
-  cfg.SetFloat("view2d_top_fixtures_inverted",
-               state.renderOptions.forceBottomViewForTopFixtures ? 1.0f
-                                                                  : 0.0f);
+  if (state.renderOptions.forceBottomViewForTopFixtures.has_value()) {
+    cfg.SetFloat("view2d_top_fixtures_inverted",
+                 state.renderOptions.forceBottomViewForTopFixtures.value()
+                     ? 1.0f
+                     : 0.0f);
+  }
   cfg.SetFloat("grid_show", state.renderOptions.showGrid ? 1.0f : 0.0f);
   cfg.SetFloat("grid_style", static_cast<float>(state.renderOptions.gridStyle));
   cfg.SetFloat("grid_color_r", state.renderOptions.gridColorR);

--- a/viewer2d/viewer2dstate.cpp
+++ b/viewer2d/viewer2dstate.cpp
@@ -66,6 +66,8 @@ Viewer2DState CaptureState(const Viewer2DPanel *panel,
   state.renderOptions.renderMode =
       static_cast<int>(cfg.GetFloat("view2d_render_mode"));
   state.renderOptions.darkMode = cfg.GetFloat("view2d_dark_mode") != 0.0f;
+  state.renderOptions.forceBottomViewForTopFixtures =
+      cfg.GetFloat("view2d_top_fixtures_inverted") != 0.0f;
   state.renderOptions.showGrid = cfg.GetFloat("grid_show") != 0.0f;
   state.renderOptions.gridStyle =
       static_cast<int>(cfg.GetFloat("grid_style"));
@@ -112,6 +114,9 @@ void ApplyState(Viewer2DPanel *panel, Viewer2DRenderPanel *renderPanel,
   cfg.SetFloat("view2d_render_mode",
                static_cast<float>(state.renderOptions.renderMode));
   cfg.SetFloat("view2d_dark_mode", state.renderOptions.darkMode ? 1.0f : 0.0f);
+  cfg.SetFloat("view2d_top_fixtures_inverted",
+               state.renderOptions.forceBottomViewForTopFixtures ? 1.0f
+                                                                  : 0.0f);
   cfg.SetFloat("grid_show", state.renderOptions.showGrid ? 1.0f : 0.0f);
   cfg.SetFloat("grid_style", static_cast<float>(state.renderOptions.gridStyle));
   cfg.SetFloat("grid_color_r", state.renderOptions.gridColorR);


### PR DESCRIPTION
### Motivation
- Layout 2D views did not persist or respect the "force bottom view for top fixtures" setting when resolving Perastage SVG symbols for on-canvas layout previews and PDF export, causing inconsistent fixture orientation between legends/fallbacks and layout views. 
- The goal is to make each layout 2D view carry its own setting and ensure captures/renders used for layout thumbnails and PDF output resolve SVG symbols using the correct fixture orientation.

### Description
- Added `forceBottomViewForTopFixtures` to `Layout2DViewRenderOptions` so the per-view setting is stored in layout definitions (`core/layouts/LayoutCollection.h`).
- Wired JSON serialization and parsing to persist the option in layout files and support legacy `view2dState` migration (`core/layouts/LayoutManager.cpp`).
- Mapped the new option into the viewer 2D state capture/apply flow by setting `view2d_top_fixtures_inverted` when applying a `Viewer2DState`, ensuring layout offscreen captures and PDF exporter use the intended orientation (`viewer2d/viewer2dstate.cpp`).
- Included the new option in layout view content hashing so cached view textures are invalidated when the flag changes (`gui/layoutviewerpanel_render_invalidation.cpp`).
- Key files changed: `core/layouts/LayoutCollection.h`, `core/layouts/LayoutManager.cpp`, `viewer2d/viewer2dstate.cpp`, and `gui/layoutviewerpanel_render_invalidation.cpp`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (`OK`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a069575af48324ba3b13e4685c1b0b)