### PR TITLE
Volumetric gobo masking inside Peraviz beam volumes

### DIFF
--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -120,7 +120,7 @@ func cleanup_beam(light: SpotLight3D) -> void:
 			gobo_occluder.queue_free()
 		light.remove_meta(GOBO_OCCLUDER_META_KEY)
 
-func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occluder: MeshInstance3D, beam_angle: float, beam_range: float, lens_radius: float, tan_half_angle: float) -> void:
+func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occluder: MeshInstance3D, beam_angle: float, _beam_range: float, lens_radius: float, tan_half_angle: float) -> void:
 	if gobo_occluder == null:
 		return
 

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -9,6 +9,7 @@ const VOLUMETRIC_INTENSITY_SCALE: float = 0.62
 const GOBO_OCCLUDER_DISTANCE_M: float = 0.02
 const GOBO_OCCLUDER_SIZE_PADDING: float = 1.1
 const GOBO_OCCLUDER_THICKNESS_M: float = 0.003
+const DEFAULT_GOBO_RADIAL_SAMPLES: int = 4
 
 var _beam_material_template: ShaderMaterial
 var _gobo_occluder_material_template: ShaderMaterial
@@ -87,7 +88,8 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 			return
 
 	var half_angle_deg: float = beam_angle * 0.5
-	var radius: float = tan(deg_to_rad(half_angle_deg)) * beam_range
+	var tan_half_angle: float = tan(deg_to_rad(half_angle_deg))
+	var radius: float = tan_half_angle * beam_range
 	var bottom_radius: float = clamp(radius, 0.03, EMITTER_CONE_MAX_BASE_RADIUS_M)
 	var cone_mesh: CylinderMesh = cone.mesh as CylinderMesh
 	if cone_mesh != null:
@@ -100,14 +102,10 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	var intensity_alpha: float = clamp(intensity * VOLUMETRIC_INTENSITY_SCALE, 0.0, 1.0)
 	cone.set_instance_shader_parameter("base_color", Color(beam_color.r, beam_color.g, beam_color.b, intensity_alpha))
 	cone.set_instance_shader_parameter("max_brightness", lerp(1.0, 10.0, intensity))
-	cone.set_instance_shader_parameter("beam_height", beam_range)
-	if cone_mesh != null:
-		cone.set_instance_shader_parameter("beam_top_radius", cone_mesh.top_radius)
-		cone.set_instance_shader_parameter("beam_bottom_radius", cone_mesh.bottom_radius)
-		cone.set_instance_shader_parameter("gobo_segment_count", float(cone_mesh.radial_segments))
-		cone.set_instance_shader_parameter("gobo_ring_count", float(cone_mesh.rings))
+	cone.set_instance_shader_parameter("tan_half_angle", tan_half_angle)
+	cone.set_instance_shader_parameter("radial_samples", DEFAULT_GOBO_RADIAL_SAMPLES)
 
-	_update_gobo_occluder(light, cone, gobo_occluder, beam_angle, beam_range, lens_radius)
+	_update_gobo_occluder(light, cone, gobo_occluder, beam_angle, beam_range, lens_radius, tan_half_angle)
 
 func cleanup_beam(light: SpotLight3D) -> void:
 	if light.has_meta(BEAM_META_KEY):
@@ -122,7 +120,7 @@ func cleanup_beam(light: SpotLight3D) -> void:
 			gobo_occluder.queue_free()
 		light.remove_meta(GOBO_OCCLUDER_META_KEY)
 
-func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occluder: MeshInstance3D, beam_angle: float, beam_range: float, lens_radius: float) -> void:
+func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occluder: MeshInstance3D, beam_angle: float, beam_range: float, lens_radius: float, tan_half_angle: float) -> void:
 	if gobo_occluder == null:
 		return
 
@@ -136,7 +134,9 @@ func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occlud
 		gobo_occluder.visible = false
 		gobo_material.set_shader_parameter("gobo_texture", null)
 		cone.set_instance_shader_parameter("gobo_enabled", false)
-		cone.set_instance_shader_parameter("gobo_axis_sign", 1.0)
+		var cone_material_disabled: ShaderMaterial = cone.material_override as ShaderMaterial
+		if cone_material_disabled != null:
+			cone_material_disabled.set_shader_parameter("gobo_texture", null)
 		return
 
 	light.shadow_enabled = true
@@ -166,14 +166,7 @@ func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occlud
 	gobo_occluder.set_instance_shader_parameter("gobo_size", Vector2(gobo_width, gobo_height))
 	gobo_occluder.set_instance_shader_parameter("gobo_thickness", GOBO_OCCLUDER_THICKNESS_M)
 	cone.set_instance_shader_parameter("gobo_enabled", true)
-	cone.set_instance_shader_parameter("gobo_cutoff", 0.5)
-	cone.set_instance_shader_parameter("gobo_start_ratio", clamp(GOBO_OCCLUDER_DISTANCE_M / beam_range, 0.0, 1.0))
-	cone.set_instance_shader_parameter("gobo_rotation", 0.0)
-	cone.set_instance_shader_parameter("gobo_size", Vector2(gobo_width, gobo_height))
-	var beam_world_dir: Vector3 = -light.global_transform.basis.z.normalized()
-	var cone_axis_world: Vector3 = (cone.global_transform.basis * Vector3.DOWN).normalized()
-	var axis_sign: float = 1.0 if cone_axis_world.dot(beam_world_dir) >= 0.0 else -1.0
-	cone.set_instance_shader_parameter("gobo_axis_sign", axis_sign)
+	cone.set_instance_shader_parameter("tan_half_angle", tan_half_angle)
 	var cone_material: ShaderMaterial = cone.material_override as ShaderMaterial
 	if cone_material != null:
 		cone_material.set_shader_parameter("gobo_texture", gobo_texture)

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -142,7 +142,7 @@ func _compose_gobo_textures(textures: Array[Texture2D]) -> Texture2D:
 	return out_texture
 
 func _resolve_fake_gobo_texture(gobo_raw_8bit: int) -> Texture2D:
-	var fake_bucket: int = gobo_raw_8bit / 8
+	var fake_bucket: int = gobo_raw_8bit >> 3
 	var cache_key: String = "__fake_gobo_%d" % fake_bucket
 	if _texture_cache.has(cache_key):
 		return _texture_cache[cache_key] as Texture2D
@@ -159,7 +159,9 @@ func _resolve_fake_gobo_texture(gobo_raw_8bit: int) -> Texture2D:
 				var dist: float = uv.length()
 				if dist > max_radius:
 					continue
-				var checker: bool = (((x / step) + (y / step) + fake_bucket) % 2) == 0
+				var x_cell: int = int(floor(float(x) / float(step)))
+				var y_cell: int = int(floor(float(y) / float(step)))
+				var checker: bool = (((x_cell + y_cell) + fake_bucket) % 2) == 0
 				if checker:
 					image.set_pixel(x, y, Color(0.0, 0.0, 0.0, 1.0))
 

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -8,13 +8,14 @@ var _texture_cache: Dictionary = {}
 func clear_cache() -> void:
 	_texture_cache.clear()
 
-func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> void:
+func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 	if light == null or not is_instance_valid(light):
-		return
+		return false
+	var previous_projector: Texture2D = light.light_projector
 	if not bool(controls.get("has_gobo", false)):
 		light.light_projector = null
 		light.shadow_enabled = false
-		return
+		return previous_projector != null
 
 	var runtime_bindings: Array = controls.get("gobo_runtime_bindings", [])
 	if runtime_bindings.is_empty():
@@ -44,11 +45,12 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> void:
 	if active_textures.is_empty():
 		light.light_projector = null
 		light.shadow_enabled = false
-		return
+		return previous_projector != null
 
 	light.shadow_enabled = true
 	_warn_if_projector_unsupported(light)
 	light.light_projector = _compose_gobo_textures(active_textures)
+	return light.light_projector != previous_projector
 
 func _resolve_gobo_raw_8bit(controls: Dictionary) -> int:
 	var gobo_raw: int = int(round(clamp(float(controls.get("gobo_norm", 0.0)), 0.0, 1.0) * 255.0))

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -2011,13 +2011,13 @@ func _update_emitter_beam_cone(light: SpotLight3D, beam_angle: float, beam_range
 
 	var intensity: float = clamp(normalized_dimmer, 0.0, 1.0)
 	light.set_meta("peraviz_beam_base_intensity", intensity)
-	var is_visible: bool = intensity > 0.015
+	var beam_is_visible: bool = intensity > 0.015
 	if cone != null:
-		cone.visible = is_visible
+		cone.visible = beam_is_visible
 	if mid_cone != null:
-		mid_cone.visible = is_visible
+		mid_cone.visible = beam_is_visible
 	if core_cone != null:
-		core_cone.visible = is_visible
+		core_cone.visible = beam_is_visible
 
 	var beam_multiplier: float = float(_visual_settings.get("beam_multiplier", 1.0))
 	var scaled_intensity: float = clamp(intensity * beam_multiplier, 0.0, 3.0)

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -1839,9 +1839,13 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 		"intensity_visibility_threshold": BEAM_INTENSITY_VISIBILITY_THRESHOLD,
 		"distance_cull_m": BEAM_DISTANCE_CULL_M,
 	}
-	_update_beam_for_light(light, beam_params)
+	var gobo_changed: bool = false
 	if _fixture_gobo_projector != null:
-		_fixture_gobo_projector.apply_gobo_projection(light, controls)
+		gobo_changed = _fixture_gobo_projector.apply_gobo_projection(light, controls)
+	_update_beam_for_light(light, beam_params)
+	if gobo_changed:
+		# Re-apply beam uniforms immediately when gobo texture changes so volumetric modulation updates without frame delay.
+		_update_beam_for_light(light, beam_params)
 
 func _resolve_zoom_beam_limits(light: SpotLight3D, controls: Dictionary) -> Dictionary:
 	# min/max beam angles are kept as full GDTF beam apertures (not half-angle).

--- a/peraviz/scripts/shaders/volumetric_beam.gdshader
+++ b/peraviz/scripts/shaders/volumetric_beam.gdshader
@@ -1,8 +1,11 @@
 shader_type spatial;
-render_mode unshaded, blend_add, cull_disabled, depth_draw_opaque;
+render_mode unshaded, blend_add, cull_disabled, depth_draw_never;
 
 uniform sampler2D DEPTH_TEXTURE : hint_depth_texture, filter_linear_mipmap;
-uniform sampler2D gobo_texture;
+# Godot Light3D projector textures affect lit surfaces, not built-in volumetric fog.
+# This shader performs explicit gobo masking inside the beam volume.
+# The gobo mask sampled in beam space. White passes light; black blocks it.
+uniform sampler2D gobo_texture : hint_black_white;
 
 instance uniform vec4 base_color : source_color = vec4(1.0, 0.95, 0.85, 0.5);
 uniform float falloff_power : hint_range(0.1, 10.0) = 8.0;
@@ -18,25 +21,22 @@ uniform float far_fade_end : hint_range(0.1, 100.0) = 80.0;
 instance uniform float max_brightness : hint_range(1.0, 50.0) = 10.0;
 uniform bool depth_feather_enabled = true;
 uniform float depth_fade_distance : hint_range(0.01, 5.0) = 0.5;
-instance uniform bool gobo_enabled = false;
-instance uniform float gobo_cutoff : hint_range(0.0, 1.0) = 0.5;
-instance uniform float gobo_start_ratio : hint_range(0.0, 1.0) = 0.0;
-instance uniform float gobo_rotation : hint_range(-6.2831853, 6.2831853) = 0.0;
-instance uniform vec2 gobo_size = vec2(0.08, 0.08);
-instance uniform float gobo_axis_sign : hint_range(-1.0, 1.0) = 1.0;
-instance uniform float beam_height : hint_range(0.01, 200.0) = 8.0;
-instance uniform float beam_top_radius : hint_range(0.001, 100.0) = 0.02;
-instance uniform float beam_bottom_radius : hint_range(0.001, 100.0) = 0.8;
-instance uniform float gobo_segment_count : hint_range(1.0, 256.0) = 48.0;
-instance uniform float gobo_ring_count : hint_range(1.0, 256.0) = 12.0;
 
-varying vec3 vertex_view;
-varying vec3 vertex_local;
+# Whether to modulate the volumetric beam by the gobo pattern.
+instance uniform bool gobo_enabled = false;
+# Ratio of beam radius to distance from the emitter gate: tan(spot_angle / 2).
+instance uniform float tan_half_angle = 0.0;
+# How many radial samples to take while integrating the mask from center to shell.
+instance uniform int radial_samples = 4;
+
+varying vec3 v_view;
+varying float v_depth;
 
 void vertex() {
-	vertex_local = VERTEX;
-	vertex_view = (MODELVIEW_MATRIX * vec4(VERTEX, 1.0)).xyz;
-	POSITION = PROJECTION_MATRIX * vec4(vertex_view, 1.0);
+	v_view = (MODELVIEW_MATRIX * vec4(VERTEX, 1.0)).xyz;
+	# Distance from the fixture along the beam axis (positive along -Z in view space).
+	v_depth = -v_view.z;
+	POSITION = PROJECTION_MATRIX * vec4(v_view, 1.0);
 }
 
 float get_linear_depth(float raw_depth, mat4 inv_proj_mat) {
@@ -44,7 +44,7 @@ float get_linear_depth(float raw_depth, mat4 inv_proj_mat) {
 }
 
 void fragment() {
-	float dist = length(vertex_view);
+	float dist = length(v_view);
 	float near_alpha = smoothstep(near_fade_start, near_fade_end, dist);
 	float far_alpha = 1.0 - smoothstep(far_fade_start, far_fade_end, dist);
 	float dist_fade = near_alpha * far_alpha;
@@ -56,7 +56,7 @@ void fragment() {
 	float base_brightness = base_color.a * apex_fade;
 
 	vec3 n = normalize(NORMAL);
-	vec3 v = normalize(-vertex_view);
+	vec3 v = normalize(-v_view);
 	float ndotv = max(0.0, dot(n, v));
 	float location_weight = pow(max(1.0 - UV.y, 0.0), boost_along_y);
 	float facing_multiplier = 1.0 + (facing_boost * location_weight * pow(ndotv, facing_power));
@@ -69,46 +69,44 @@ void fragment() {
 		float scene_depth = texture(DEPTH_TEXTURE, SCREEN_UV).r;
 		if (scene_depth < 0.9999) {
 			float scene_linear = get_linear_depth(scene_depth, INV_PROJECTION_MATRIX);
-			float frag_linear = -vertex_view.z;
+			float frag_linear = -v_view.z;
 			float diff = scene_linear - frag_linear;
 			depth_mult = smoothstep(0.0, depth_fade_distance, diff);
 		}
 	}
 
 	float final_alpha = feather_alpha * depth_mult * dist_fade;
+	float gobo_intensity = 1.0;
 	if (gobo_enabled) {
-		float axis_distance = clamp((beam_height * 0.5) - (vertex_local.y * gobo_axis_sign), 0.0, beam_height);
-		float axis_ratio = axis_distance / max(beam_height, 0.001);
-		float gobo_plane_distance = gobo_start_ratio * beam_height;
-		if (axis_ratio >= gobo_start_ratio && axis_distance > 0.001) {
-			float seg_count = max(gobo_segment_count, 1.0);
-			float ring_count = max(gobo_ring_count, 1.0);
-			float seg_u = (floor(fract(UV.x) * seg_count) + 0.5) / seg_count;
-			float ring_v = (floor(axis_ratio * ring_count) + 0.5) / ring_count;
-			float current_radius = mix(beam_top_radius, beam_bottom_radius, clamp(ring_v, 0.0, 1.0));
-			float angle = seg_u * 6.2831853;
-			vec2 radial_pos = vec2(cos(angle), sin(angle)) * current_radius;
-			float projection_scale = gobo_plane_distance / axis_distance;
-			vec2 gobo_plane_pos = radial_pos * projection_scale;
-			float sin_angle = sin(gobo_rotation);
-			float cos_angle = cos(gobo_rotation);
-			vec2 rotated = vec2(
-				gobo_plane_pos.x * cos_angle - gobo_plane_pos.y * sin_angle,
-				gobo_plane_pos.x * sin_angle + gobo_plane_pos.y * cos_angle
-			);
-			vec2 half_size = max(gobo_size * 0.5, vec2(0.001));
-			vec2 gobo_uv = rotated / half_size * 0.5 + 0.5;
-			float inside = step(0.0, gobo_uv.x) * step(gobo_uv.x, 1.0) * step(0.0, gobo_uv.y) * step(gobo_uv.y, 1.0);
-			float gobo_open = 0.0;
-			if (inside > 0.5) {
-				vec4 texel = texture(gobo_texture, gobo_uv);
-				float luma = dot(texel.rgb, vec3(0.299, 0.587, 0.114));
-				float effective_luma = luma * texel.a;
-				gobo_open = step(gobo_cutoff, effective_luma);
-			}
-			brightness *= gobo_open;
-			final_alpha *= gobo_open;
+		if (v_depth <= 0.0 || tan_half_angle <= 0.0) {
+			discard;
 		}
+
+		# Project the fragment onto the gobo gate at the emitter and let UVs expand with distance.
+		vec2 gobo_uv = vec2(0.5) + (v_view.xy / (v_depth * 2.0 * tan_half_angle));
+		const int MAX_RADIAL_SAMPLES = 16;
+		int sample_count = clamp(radial_samples, 1, MAX_RADIAL_SAMPLES);
+		float gobo_acc = 0.0;
+		# Integrate from center to shell so blocked areas attenuate the entire beam interior,
+		# mirroring a physical gobo plate with shaped holes.
+		for (int i = 0; i < MAX_RADIAL_SAMPLES; i++) {
+			if (i >= sample_count) {
+				break;
+			}
+			float t = (float(i) + 0.5) / float(sample_count);
+			vec2 sample_uv = mix(vec2(0.5, 0.5), gobo_uv, t);
+			gobo_acc += texture(gobo_texture, sample_uv).r;
+		}
+		gobo_intensity = gobo_acc / float(sample_count);
+		if (gobo_intensity < 0.001) {
+			discard;
+		}
+	}
+
+	brightness *= gobo_intensity;
+	final_alpha *= gobo_intensity;
+	if (final_alpha < 0.001) {
+		discard;
 	}
 
 	ALBEDO = base_color.rgb * brightness;

--- a/peraviz/scripts/shaders/volumetric_beam.gdshader
+++ b/peraviz/scripts/shaders/volumetric_beam.gdshader
@@ -5,7 +5,7 @@ uniform sampler2D DEPTH_TEXTURE : hint_depth_texture, filter_linear_mipmap;
 // Godot Light3D projector textures affect lit surfaces, not built-in volumetric fog.
 // This shader performs explicit gobo masking inside the beam volume.
 // The gobo mask sampled in beam space. White passes light; black blocks it.
-uniform sampler2D gobo_texture : hint_black_white;
+uniform sampler2D gobo_texture : source_color, hint_default_white;
 
 instance uniform vec4 base_color : source_color = vec4(1.0, 0.95, 0.85, 0.5);
 uniform float falloff_power : hint_range(0.1, 10.0) = 8.0;

--- a/peraviz/scripts/shaders/volumetric_beam.gdshader
+++ b/peraviz/scripts/shaders/volumetric_beam.gdshader
@@ -2,9 +2,9 @@ shader_type spatial;
 render_mode unshaded, blend_add, cull_disabled, depth_draw_never;
 
 uniform sampler2D DEPTH_TEXTURE : hint_depth_texture, filter_linear_mipmap;
-# Godot Light3D projector textures affect lit surfaces, not built-in volumetric fog.
-# This shader performs explicit gobo masking inside the beam volume.
-# The gobo mask sampled in beam space. White passes light; black blocks it.
+// Godot Light3D projector textures affect lit surfaces, not built-in volumetric fog.
+// This shader performs explicit gobo masking inside the beam volume.
+// The gobo mask sampled in beam space. White passes light; black blocks it.
 uniform sampler2D gobo_texture : hint_black_white;
 
 instance uniform vec4 base_color : source_color = vec4(1.0, 0.95, 0.85, 0.5);
@@ -22,11 +22,11 @@ instance uniform float max_brightness : hint_range(1.0, 50.0) = 10.0;
 uniform bool depth_feather_enabled = true;
 uniform float depth_fade_distance : hint_range(0.01, 5.0) = 0.5;
 
-# Whether to modulate the volumetric beam by the gobo pattern.
+// Whether to modulate the volumetric beam by the gobo pattern.
 instance uniform bool gobo_enabled = false;
-# Ratio of beam radius to distance from the emitter gate: tan(spot_angle / 2).
+// Ratio of beam radius to distance from the emitter gate: tan(spot_angle / 2).
 instance uniform float tan_half_angle = 0.0;
-# How many radial samples to take while integrating the mask from center to shell.
+// How many radial samples to take while integrating the mask from center to shell.
 instance uniform int radial_samples = 4;
 
 varying vec3 v_view;
@@ -34,7 +34,7 @@ varying float v_depth;
 
 void vertex() {
 	v_view = (MODELVIEW_MATRIX * vec4(VERTEX, 1.0)).xyz;
-	# Distance from the fixture along the beam axis (positive along -Z in view space).
+	// Distance from the fixture along the beam axis (positive along -Z in view space).
 	v_depth = -v_view.z;
 	POSITION = PROJECTION_MATRIX * vec4(v_view, 1.0);
 }
@@ -82,13 +82,13 @@ void fragment() {
 			discard;
 		}
 
-		# Project the fragment onto the gobo gate at the emitter and let UVs expand with distance.
+		// Project the fragment onto the gobo gate at the emitter and let UVs expand with distance.
 		vec2 gobo_uv = vec2(0.5) + (v_view.xy / (v_depth * 2.0 * tan_half_angle));
 		const int MAX_RADIAL_SAMPLES = 16;
 		int sample_count = clamp(radial_samples, 1, MAX_RADIAL_SAMPLES);
 		float gobo_acc = 0.0;
-		# Integrate from center to shell so blocked areas attenuate the entire beam interior,
-		# mirroring a physical gobo plate with shaped holes.
+		// Integrate from center to shell so blocked areas attenuate the entire beam interior,
+		// mirroring a physical gobo plate with shaped holes.
 		for (int i = 0; i < MAX_RADIAL_SAMPLES; i++) {
 			if (i >= sample_count) {
 				break;


### PR DESCRIPTION
### Motivation

- Make gobos modulate light inside the volumetric beam (interior) rather than only on the cone surface so projector masks behave like physical gobos. 
- Avoid the dark depth-slice artifact caused by the beam writing depth when alpha is near zero by changing depth write behaviour and discarding fully-blocked fragments. 
- Keep the existing cylinder-mesh volumetric approach and 2D texture sampling to maintain similar performance (no 3D textures or fog-volume replacement). 

### Description

- Added in-volume gobo support to the shader at `peraviz/scripts/shaders/volumetric_beam.gdshader` by introducing per-instance uniforms `gobo_enabled`, `gobo_texture : hint_black_white`, `tan_half_angle` and `radial_samples`, passing `v_depth` from `vertex()` and computing perspective-correct gobo UVs in `fragment()`; the shader radially integrates mask samples from center-to-shell and multiplies the beam color/alpha by the integrated mask. 
- Changed the shader `render_mode` from `depth_draw_opaque` to `depth_draw_never` and added early `discard` when gobo intensity or final alpha is near zero to prevent writing depth for blocked regions. 
- Updated `VolumetricBeamRenderer` (`peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd`) to compute `tan_half_angle = tan(deg_to_rad(beam_angle*0.5))`, set `tan_half_angle` and `radial_samples` on the per-instance material, enable/disable `gobo_enabled`, and bind/clear `gobo_texture` on the cone material so the shader receives the projector texture. 
- Modified gobo handling in `FixtureGoboProjector` (`peraviz/scripts/fixture_gobo_projector.gd`) so `apply_gobo_projection` returns whether the projector texture changed, and updated `load_scene.gd` to re-apply beam uniforms immediately when the projector changes to avoid a one-frame desync. 

### Testing

- Ran `tests/check_perastage_tree_modules.sh` which returned OK. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which returned OK. 
- Performed local code inspection to confirm new shader uniforms are set by the renderer and that the shader clamps radial samples (`MAX_RADIAL_SAMPLES`) to bound cost.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a08438399083249852b71bdba7494d)