### PR TITLE
Fix legend spacing when symbols are rendered only from SVG

### DIFF
--- a/gui/layoutviewerpanel_legend.cpp
+++ b/gui/layoutviewerpanel_legend.cpp
@@ -1006,6 +1006,10 @@ wxImage LayoutViewerPanel::BuildLegendImage(
 
   double maxTopSymbolColumnWidth = 0.0;
   double maxFrontSymbolColumnWidth = 0.0;
+  bool hasSvgSymbols = false;
+  bool hasFallbackSymbols = false;
+  bool hasTopSvgSymbols = false;
+  bool hasFrontSvgSymbols = false;
   for (const auto &item : items) {
     if (item.symbolKey.empty())
       continue;
@@ -1017,6 +1021,18 @@ wxImage LayoutViewerPanel::BuildLegendImage(
         symbols, item.symbolKey, SymbolViewKind::Bottom);
     const SymbolDefinition *frontSymbol =
         FindSymbolDefinitionExact(symbols, item.symbolKey, SymbolViewKind::Front);
+    if (topSvg) {
+      hasSvgSymbols = true;
+      hasTopSvgSymbols = true;
+    } else if (topSymbol) {
+      hasFallbackSymbols = true;
+    }
+    if (frontSvg) {
+      hasSvgSymbols = true;
+      hasFrontSvgSymbols = true;
+    } else if (frontSymbol) {
+      hasFallbackSymbols = true;
+    }
     const double topDrawW =
         topSvg ? symbolDrawWidthSvg(topSvg) : symbolDrawWidth(topSymbol);
     const double frontDrawW =
@@ -1030,12 +1046,12 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   const int limitedSymbolColumnSize = std::max(4, (maxSymbolColumnSize * 2) / 5);
   const double maxMeasuredSymbolColumnWidth =
       static_cast<double>(limitedSymbolColumnSize);
-  const int topSymbolColumnSize = std::clamp(
+  int topSymbolColumnSize = std::clamp(
       static_cast<int>(std::ceil(std::min(maxTopSymbolColumnWidth,
                                           maxMeasuredSymbolColumnWidth) *
                                  kLegendSymbolColumnScale)),
       0, limitedSymbolColumnSize);
-  const int frontSymbolColumnSize = std::clamp(
+  int frontSymbolColumnSize = std::clamp(
       static_cast<int>(std::ceil(std::min(maxFrontSymbolColumnWidth,
                                           maxMeasuredSymbolColumnWidth) *
                                  kLegendSymbolColumnScale)),
@@ -1051,8 +1067,22 @@ wxImage LayoutViewerPanel::BuildLegendImage(
       std::max(0, static_cast<int>(std::lround(paddingBottom * renderZoom)));
   const int columnGapPx =
       std::max(0, static_cast<int>(std::lround(columnGap * renderZoom)));
-  const int symbolColumnGapPx =
+  int symbolColumnGapPx =
       std::max(0, static_cast<int>(std::lround(symbolColumnGap * renderZoom)));
+
+  if (hasSvgSymbols && !hasFallbackSymbols) {
+    const int minSvgColumnSize =
+        std::max(4, static_cast<int>(std::lround(symbolSize * 0.55)));
+    if (hasTopSvgSymbols)
+      topSymbolColumnSize = std::max(topSymbolColumnSize, minSvgColumnSize);
+    if (hasFrontSvgSymbols)
+      frontSymbolColumnSize =
+          std::max(frontSymbolColumnSize, minSvgColumnSize);
+    symbolColumnGapPx =
+        std::max(symbolColumnGapPx,
+                 std::max(2, static_cast<int>(std::lround(4.0 * renderZoom))));
+  }
+
   int xTopSymbol = paddingLeftPx;
   int xFrontSymbol = xTopSymbol + topSymbolColumnSize + symbolColumnGapPx;
   int xCount = xFrontSymbol + frontSymbolColumnSize + columnGapPx;

--- a/gui/layoutviewerpanel_legend.cpp
+++ b/gui/layoutviewerpanel_legend.cpp
@@ -1069,6 +1069,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
       std::max(0, static_cast<int>(std::lround(columnGap * renderZoom)));
   int symbolColumnGapPx =
       std::max(0, static_cast<int>(std::lround(symbolColumnGap * renderZoom)));
+  int symbolOuterMarginPx = 0;
 
   if (hasSvgSymbols && !hasFallbackSymbols) {
     const int minSvgColumnSize =
@@ -1080,10 +1081,12 @@ wxImage LayoutViewerPanel::BuildLegendImage(
           std::max(frontSymbolColumnSize, minSvgColumnSize);
     symbolColumnGapPx =
         std::max(symbolColumnGapPx,
-                 std::max(2, static_cast<int>(std::lround(4.0 * renderZoom))));
+                 std::max(1, static_cast<int>(std::lround(2.5 * renderZoom))));
+    symbolOuterMarginPx =
+        std::max(1, static_cast<int>(std::lround(2.0 * renderZoom)));
   }
 
-  int xTopSymbol = paddingLeftPx;
+  int xTopSymbol = paddingLeftPx + symbolOuterMarginPx;
   int xFrontSymbol = xTopSymbol + topSymbolColumnSize + symbolColumnGapPx;
   int xCount = xFrontSymbol + frontSymbolColumnSize + columnGapPx;
   int xType = xCount + maxCountWidth + columnGapPx;


### PR DESCRIPTION
### Motivation
- Legend columns and the gap between symbol columns could collapse when all legend symbols were rendered from SVG, because column widths were derived from measured SVG geometry (often much smaller than fallback-rendered symbols).
- This produced cramped symbols/margins in SVG-only legends while mixed SVG+fallback or fallback-only layouts looked correct.

### Description
- Added SVG/fallback presence tracking (`hasSvgSymbols`, `hasFallbackSymbols`, `hasTopSvgSymbols`, `hasFrontSvgSymbols`) while computing per-column metrics in `LayoutViewerPanel::BuildLegendImage` (file `gui/layoutviewerpanel_legend.cpp`).
- Made the computed column sizes mutable (`topSymbolColumnSize`, `frontSymbolColumnSize`) and the column-gap value mutable (`symbolColumnGapPx`) so they can be adjusted after measurement.
- When all rendered symbols are SVG and no fallback symbols are present, enforce a minimum SVG column width and a minimum gap between symbol columns (`minSvgColumnSize` and increased `symbolColumnGapPx`) so spacing/margins remain visually appropriate.
- Change is localized to legend layout width/gap calculation and preserves existing behavior for mixed SVG+fallback and fallback-only cases.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed (OK).
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a08333893483248770b8cab1bf459f)