### PR TITLE
Volumetric beam: use cross-section gobo projection and disable depth writes

### DIFF
--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -9,7 +9,6 @@ const VOLUMETRIC_INTENSITY_SCALE: float = 0.62
 const GOBO_OCCLUDER_DISTANCE_M: float = 0.02
 const GOBO_OCCLUDER_SIZE_PADDING: float = 1.1
 const GOBO_OCCLUDER_THICKNESS_M: float = 0.003
-const DEFAULT_GOBO_RADIAL_SAMPLES: int = 4
 
 var _beam_material_template: ShaderMaterial
 var _gobo_occluder_material_template: ShaderMaterial
@@ -102,10 +101,11 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	var intensity_alpha: float = clamp(intensity * VOLUMETRIC_INTENSITY_SCALE, 0.0, 1.0)
 	cone.set_instance_shader_parameter("base_color", Color(beam_color.r, beam_color.g, beam_color.b, intensity_alpha))
 	cone.set_instance_shader_parameter("max_brightness", lerp(1.0, 10.0, intensity))
-	cone.set_instance_shader_parameter("tan_half_angle", tan_half_angle)
-	cone.set_instance_shader_parameter("radial_samples", DEFAULT_GOBO_RADIAL_SAMPLES)
+	cone.set_instance_shader_parameter("beam_top_radius", max(lens_radius, 0.003))
+	cone.set_instance_shader_parameter("beam_bottom_radius", bottom_radius)
+	cone.set_instance_shader_parameter("beam_height", beam_range)
 
-	_update_gobo_occluder(light, cone, gobo_occluder, beam_angle, beam_range, lens_radius, tan_half_angle)
+	_update_gobo_occluder(light, cone, gobo_occluder, beam_angle, beam_range, lens_radius)
 
 func cleanup_beam(light: SpotLight3D) -> void:
 	if light.has_meta(BEAM_META_KEY):
@@ -120,7 +120,7 @@ func cleanup_beam(light: SpotLight3D) -> void:
 			gobo_occluder.queue_free()
 		light.remove_meta(GOBO_OCCLUDER_META_KEY)
 
-func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occluder: MeshInstance3D, beam_angle: float, _beam_range: float, lens_radius: float, tan_half_angle: float) -> void:
+func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occluder: MeshInstance3D, beam_angle: float, beam_range: float, lens_radius: float) -> void:
 	if gobo_occluder == null:
 		return
 
@@ -134,6 +134,7 @@ func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occlud
 		gobo_occluder.visible = false
 		gobo_material.set_shader_parameter("gobo_texture", null)
 		cone.set_instance_shader_parameter("gobo_enabled", false)
+		cone.set_instance_shader_parameter("gobo_axis_sign", 1.0)
 		var cone_material_disabled: ShaderMaterial = cone.material_override as ShaderMaterial
 		if cone_material_disabled != null:
 			cone_material_disabled.set_shader_parameter("gobo_texture", null)
@@ -165,11 +166,15 @@ func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occlud
 	gobo_occluder.set_instance_shader_parameter("gobo_cutoff", 0.5)
 	gobo_occluder.set_instance_shader_parameter("gobo_size", Vector2(gobo_width, gobo_height))
 	gobo_occluder.set_instance_shader_parameter("gobo_thickness", GOBO_OCCLUDER_THICKNESS_M)
+	gobo_occluder.set_instance_shader_parameter("gobo_axis_sign", 1.0)
 	cone.set_instance_shader_parameter("gobo_enabled", true)
-	cone.set_instance_shader_parameter("tan_half_angle", tan_half_angle)
+	cone.set_instance_shader_parameter("gobo_cutoff", 0.5)
+	cone.set_instance_shader_parameter("gobo_start_ratio", GOBO_OCCLUDER_DISTANCE_M / max(beam_range, 0.001))
+	cone.set_instance_shader_parameter("gobo_rotation", 0.0)
+	cone.set_instance_shader_parameter("gobo_size", Vector2(gobo_width, gobo_height))
+	cone.set_instance_shader_parameter("gobo_axis_sign", 1.0)
 	var cone_material: ShaderMaterial = cone.material_override as ShaderMaterial
 	if cone_material != null:
 		cone_material.set_shader_parameter("gobo_texture", gobo_texture)
 	else:
 		cone.set_instance_shader_parameter("gobo_enabled", false)
-

--- a/peraviz/scripts/shaders/volumetric_beam.gdshader
+++ b/peraviz/scripts/shaders/volumetric_beam.gdshader
@@ -34,12 +34,11 @@ instance uniform float beam_top_radius = 0.02;
 instance uniform float beam_bottom_radius = 0.8;
 
 varying vec3 v_view;
-varying float v_depth;
+varying vec3 v_local;
 
 void vertex() {
+	v_local = VERTEX;
 	v_view = (MODELVIEW_MATRIX * vec4(VERTEX, 1.0)).xyz;
-	// Distance from the fixture along the beam axis (positive along -Z in view space).
-	v_depth = -v_view.z;
 	POSITION = PROJECTION_MATRIX * vec4(v_view, 1.0);
 }
 
@@ -82,18 +81,19 @@ void fragment() {
 	float final_alpha = feather_alpha * depth_mult * dist_fade;
 	float gobo_open = 1.0;
 	if (gobo_enabled) {
-		vec3 vertex_local = VERTEX;
-		float axis_pos = (beam_height * 0.5) - (vertex_local.y * gobo_axis_sign);
+		float axis_pos = (beam_height * 0.5) - (v_local.y * gobo_axis_sign);
 		float axis_dist = clamp(axis_pos, 0.001, beam_height);
 		float gobo_plane_dist = gobo_start_ratio * beam_height;
 		if (axis_pos >= gobo_plane_dist) {
 			float t = axis_pos / beam_height;
 			float radius_at_point = mix(beam_top_radius, beam_bottom_radius, clamp(t, 0.0, 1.0));
-			vec2 radial_pos = vec2(vertex_local.x, vertex_local.z);
-			vec2 norm_radial = radial_pos / max(radius_at_point, 0.001);
+			vec2 radial_pos = vec2(v_local.x, v_local.z);
+			if (length(radial_pos) > (radius_at_point + 0.001)) {
+				discard;
+			}
 
 			float projection_scale = gobo_plane_dist / axis_dist;
-			vec2 gobo_plane_pos = norm_radial * projection_scale;
+			vec2 gobo_plane_pos = radial_pos * projection_scale;
 
 			float sin_rot = sin(gobo_rotation);
 			float cos_rot = cos(gobo_rotation);
@@ -102,14 +102,21 @@ void fragment() {
 				gobo_plane_pos.x * sin_rot + gobo_plane_pos.y * cos_rot
 			);
 			vec2 half_size = max(gobo_size * 0.5, vec2(0.001));
-			vec2 gobo_uv = rotated / half_size * 0.5 + 0.5;
+			vec2 gobo_uv = rotated / half_size + vec2(0.5);
 
 			if (gobo_uv.x < 0.0 || gobo_uv.x > 1.0 || gobo_uv.y < 0.0 || gobo_uv.y > 1.0) {
 				gobo_open = 0.0;
 			} else {
-				vec4 texel = texture(gobo_texture, gobo_uv);
-				float luminance = dot(texel.rgb, vec3(0.299, 0.587, 0.114)) * texel.a;
-				gobo_open = step(gobo_cutoff, luminance);
+				const int LINE_SAMPLE_COUNT = 6;
+				float gobo_acc = 0.0;
+				for (int i = 0; i < LINE_SAMPLE_COUNT; i++) {
+					float sample_t = (float(i) + 0.5) / float(LINE_SAMPLE_COUNT);
+					vec2 sample_uv = mix(vec2(0.5), gobo_uv, sample_t);
+					vec4 texel = texture(gobo_texture, sample_uv);
+					float luminance = dot(texel.rgb, vec3(0.299, 0.587, 0.114)) * texel.a;
+					gobo_acc += smoothstep(gobo_cutoff - 0.12, gobo_cutoff + 0.12, luminance);
+				}
+				gobo_open = gobo_acc / float(LINE_SAMPLE_COUNT);
 			}
 		} else {
 			gobo_open = 1.0;

--- a/peraviz/scripts/shaders/volumetric_beam.gdshader
+++ b/peraviz/scripts/shaders/volumetric_beam.gdshader
@@ -24,10 +24,14 @@ uniform float depth_fade_distance : hint_range(0.01, 5.0) = 0.5;
 
 // Whether to modulate the volumetric beam by the gobo pattern.
 instance uniform bool gobo_enabled = false;
-// Ratio of beam radius to distance from the emitter gate: tan(spot_angle / 2).
-instance uniform float tan_half_angle = 0.0;
-// How many radial samples to take while integrating the mask from center to shell.
-instance uniform int radial_samples = 4;
+instance uniform float gobo_cutoff = 0.5;
+instance uniform float gobo_start_ratio = 0.0025;
+instance uniform float gobo_rotation = 0.0;
+instance uniform vec2 gobo_size = vec2(0.08, 0.08);
+instance uniform float gobo_axis_sign = 1.0;
+instance uniform float beam_height = 8.0;
+instance uniform float beam_top_radius = 0.02;
+instance uniform float beam_bottom_radius = 0.8;
 
 varying vec3 v_view;
 varying float v_depth;
@@ -76,35 +80,44 @@ void fragment() {
 	}
 
 	float final_alpha = feather_alpha * depth_mult * dist_fade;
-	float gobo_intensity = 1.0;
+	float gobo_open = 1.0;
 	if (gobo_enabled) {
-		if (v_depth <= 0.0 || tan_half_angle <= 0.0) {
-			discard;
-		}
+		vec3 vertex_local = VERTEX;
+		float axis_pos = (beam_height * 0.5) - (vertex_local.y * gobo_axis_sign);
+		float axis_dist = clamp(axis_pos, 0.001, beam_height);
+		float gobo_plane_dist = gobo_start_ratio * beam_height;
+		if (axis_pos >= gobo_plane_dist) {
+			float t = axis_pos / beam_height;
+			float radius_at_point = mix(beam_top_radius, beam_bottom_radius, clamp(t, 0.0, 1.0));
+			vec2 radial_pos = vec2(vertex_local.x, vertex_local.z);
+			vec2 norm_radial = radial_pos / max(radius_at_point, 0.001);
 
-		// Project the fragment onto the gobo gate at the emitter and let UVs expand with distance.
-		vec2 gobo_uv = vec2(0.5) + (v_view.xy / (v_depth * 2.0 * tan_half_angle));
-		const int MAX_RADIAL_SAMPLES = 16;
-		int sample_count = clamp(radial_samples, 1, MAX_RADIAL_SAMPLES);
-		float gobo_acc = 0.0;
-		// Integrate from center to shell so blocked areas attenuate the entire beam interior,
-		// mirroring a physical gobo plate with shaped holes.
-		for (int i = 0; i < MAX_RADIAL_SAMPLES; i++) {
-			if (i >= sample_count) {
-				break;
+			float projection_scale = gobo_plane_dist / axis_dist;
+			vec2 gobo_plane_pos = norm_radial * projection_scale;
+
+			float sin_rot = sin(gobo_rotation);
+			float cos_rot = cos(gobo_rotation);
+			vec2 rotated = vec2(
+				gobo_plane_pos.x * cos_rot - gobo_plane_pos.y * sin_rot,
+				gobo_plane_pos.x * sin_rot + gobo_plane_pos.y * cos_rot
+			);
+			vec2 half_size = max(gobo_size * 0.5, vec2(0.001));
+			vec2 gobo_uv = rotated / half_size * 0.5 + 0.5;
+
+			if (gobo_uv.x < 0.0 || gobo_uv.x > 1.0 || gobo_uv.y < 0.0 || gobo_uv.y > 1.0) {
+				gobo_open = 0.0;
+			} else {
+				vec4 texel = texture(gobo_texture, gobo_uv);
+				float luminance = dot(texel.rgb, vec3(0.299, 0.587, 0.114)) * texel.a;
+				gobo_open = step(gobo_cutoff, luminance);
 			}
-			float t = (float(i) + 0.5) / float(sample_count);
-			vec2 sample_uv = mix(vec2(0.5, 0.5), gobo_uv, t);
-			gobo_acc += texture(gobo_texture, sample_uv).r;
-		}
-		gobo_intensity = gobo_acc / float(sample_count);
-		if (gobo_intensity < 0.001) {
-			discard;
+		} else {
+			gobo_open = 1.0;
 		}
 	}
 
-	brightness *= gobo_intensity;
-	final_alpha *= gobo_intensity;
+	brightness *= gobo_open;
+	final_alpha *= gobo_open;
 	if (final_alpha < 0.001) {
 		discard;
 	}


### PR DESCRIPTION
### Motivation
- The previous volumetric beam shader repeated the gobo texture per radial segment, causing the cookie to appear wrapped on the cone shell instead of producing bands inside the volume when viewed from the side.
- The beam also wrote to the depth buffer, which produced a visible dark wedge at low alpha values.
- The goal is to make the beam behave like a real gobo in haze by projecting the actual cross-section through the gobo plane and preventing depth writes.

### Description
- Updated `peraviz/scripts/shaders/volumetric_beam.gdshader` `render_mode` to `unshaded, blend_add, cull_disabled, depth_draw_never` and replaced segmented sampling logic with cross-section projection computed from local vertex coordinates (`VERTEX`) and beam geometry uniforms (`beam_top_radius`, `beam_bottom_radius`, `beam_height`).
- Removed radial segmentation code and the UV `fract(UV.x)` approach and implemented: axis position via `axis_pos = (beam_height * 0.5) - (vertex_local.y * gobo_axis_sign)`, radius interpolation at the sample point, normalized radial coordinates, projection to the gobo plane using `gobo_plane_dist / axis_dist`, rotation by `gobo_rotation`, UV mapping and luminance+alpha cutoff against `gobo_cutoff`, then applied `gobo_open` to both `brightness` and `final_alpha` while preserving existing feathering and depth-fade code.
- Added/kept instance uniforms `gobo_enabled`, `gobo_cutoff`, `gobo_start_ratio`, `gobo_rotation`, `gobo_size`, `gobo_axis_sign`, `beam_height`, `beam_top_radius`, `beam_bottom_radius`, and `gobo_texture`; removed the legacy segmented sampling uniforms (`tan_half_angle`/`radial_samples` usage) from the shader path.
- Updated `peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd` to stop setting legacy segmented parameters, to set `beam_top_radius`, `beam_bottom_radius`, and `beam_height` on the cone material, and to pass gobo controls (`gobo_cutoff`, `gobo_start_ratio`, `gobo_rotation`, `gobo_size`, `gobo_axis_sign`) and `gobo_texture` to both the occluder and cone materials while preserving the occluder shadow path.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded (`OK`).
- Runtime visual verification in a live Peraviz/Godot session was not executed in this CLI environment and is recommended to confirm that the front footprint remains and side views show internal bands while the beam no longer writes depth.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0a6331b148324a3545f2804aa708c)