### PR TITLE
Fix Peraviz mesh winding and normal normalization

### DIFF
--- a/peraviz/native/src/mesh_3ds_loader.cpp
+++ b/peraviz/native/src/mesh_3ds_loader.cpp
@@ -26,6 +26,88 @@ struct MeshData {
     std::vector<float> normals;
 };
 
+void ensure_outward_winding(MeshData &mesh) {
+    const size_t vertex_count = mesh.vertices.size() / 3;
+    if (vertex_count < 3 || mesh.indices.size() < 3) {
+        return;
+    }
+
+    float cx = 0.0F;
+    float cy = 0.0F;
+    float cz = 0.0F;
+    for (size_t i = 0; i < vertex_count; ++i) {
+        cx += mesh.vertices[i * 3];
+        cy += mesh.vertices[i * 3 + 1];
+        cz += mesh.vertices[i * 3 + 2];
+    }
+    const float inv_vertex_count = 1.0F / static_cast<float>(vertex_count);
+    cx *= inv_vertex_count;
+    cy *= inv_vertex_count;
+    cz *= inv_vertex_count;
+
+    double orientation_score = 0.0;
+    double total_area = 0.0;
+
+    for (size_t i = 0; i + 2 < mesh.indices.size(); i += 3) {
+        const uint32_t i0 = mesh.indices[i];
+        const uint32_t i1 = mesh.indices[i + 1];
+        const uint32_t i2 = mesh.indices[i + 2];
+        if (i0 >= vertex_count || i1 >= vertex_count || i2 >= vertex_count) {
+            continue;
+        }
+
+        const float v0x = mesh.vertices[i0 * 3];
+        const float v0y = mesh.vertices[i0 * 3 + 1];
+        const float v0z = mesh.vertices[i0 * 3 + 2];
+
+        const float v1x = mesh.vertices[i1 * 3];
+        const float v1y = mesh.vertices[i1 * 3 + 1];
+        const float v1z = mesh.vertices[i1 * 3 + 2];
+
+        const float v2x = mesh.vertices[i2 * 3];
+        const float v2y = mesh.vertices[i2 * 3 + 1];
+        const float v2z = mesh.vertices[i2 * 3 + 2];
+
+        const float ux = v1x - v0x;
+        const float uy = v1y - v0y;
+        const float uz = v1z - v0z;
+
+        const float vx = v2x - v0x;
+        const float vy = v2y - v0y;
+        const float vz = v2z - v0z;
+
+        const float nx = uy * vz - uz * vy;
+        const float ny = uz * vx - ux * vz;
+        const float nz = ux * vy - uy * vx;
+
+        const double area = std::sqrt(static_cast<double>(nx) * nx +
+                                      static_cast<double>(ny) * ny +
+                                      static_cast<double>(nz) * nz);
+        if (area <= 1e-9) {
+            continue;
+        }
+
+        const float tx = (v0x + v1x + v2x) / 3.0F;
+        const float ty = (v0y + v1y + v2y) / 3.0F;
+        const float tz = (v0z + v1z + v2z) / 3.0F;
+
+        orientation_score += static_cast<double>(nx) * (tx - cx) +
+                             static_cast<double>(ny) * (ty - cy) +
+                             static_cast<double>(nz) * (tz - cz);
+        total_area += area;
+    }
+
+    if (total_area <= 1e-9 || std::abs(orientation_score) <= total_area * 1e-4) {
+        return;
+    }
+
+    if (orientation_score < 0.0) {
+        for (size_t i = 0; i + 2 < mesh.indices.size(); i += 3) {
+            std::swap(mesh.indices[i + 1], mesh.indices[i + 2]);
+        }
+    }
+}
+
 bool read_chunk(std::ifstream &file, Chunk &chunk) {
     if (!file.read(reinterpret_cast<char *>(&chunk.id), sizeof(chunk.id))) {
         return false;
@@ -214,6 +296,7 @@ bool load_3ds(const std::string &path, MeshData &mesh) {
         return false;
     }
 
+    ensure_outward_winding(mesh);
     compute_normals(mesh);
     return true;
 }

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -118,6 +118,8 @@ const DOUBLE_SIDED_NAME_HINTS: Array[String] = [
 const DOUBLE_SIDED_MATERIAL_HINTS: Array[String] = [
 	"lens", "glass", "visor", "fabric", "cloth", "curtain", "thin", "plane"
 ]
+const ORIENTATION_SCORE_EPSILON: float = 0.0001
+const ORIENTATION_SCORE_MIN_AREA: float = 0.0000001
 const IMPORTED_CONTENT_SCALE: float = 1.0
 const EMITTER_LIGHT_MIN_RANGE_M: float = 12.0
 const EMITTER_LIGHT_MAX_RANGE_M: float = 150.0
@@ -669,6 +671,7 @@ func _build_visual_node(data: Dictionary, item_type: String, item_class: String,
 		var loaded: Variant = _load_3d_asset(asset_path, asset_kind)
 		if loaded is Node3D:
 			var loaded_node: Node3D = loaded
+			_normalize_loaded_mesh_normals_and_winding(loaded_node)
 			_apply_selective_double_sided_to_candidates(loaded_node, data)
 			return loaded_node
 		print("[Peraviz] Asset fallback for missing/invalid model: ", asset_path, " type=", item_type, " class=", item_class, " asset_kind=", asset_kind)
@@ -719,6 +722,143 @@ func _collect_mesh_instances_recursive(root: Node3D) -> Array[MeshInstance3D]:
 		if child is Node3D:
 			output.append_array(_collect_mesh_instances_recursive(child))
 	return output
+
+func _normalize_loaded_mesh_normals_and_winding(model_root: Node3D) -> void:
+	if model_root == null:
+		return
+
+	for mesh_instance in _collect_mesh_instances_recursive(model_root):
+		if mesh_instance == null or mesh_instance.mesh == null:
+			continue
+		if mesh_instance.mesh is not ArrayMesh:
+			continue
+
+		var source_mesh: ArrayMesh = mesh_instance.mesh as ArrayMesh
+		var normalized_mesh: ArrayMesh = _build_normalized_array_mesh(source_mesh)
+		if normalized_mesh == null:
+			continue
+		mesh_instance.mesh = normalized_mesh
+
+func _build_normalized_array_mesh(source_mesh: ArrayMesh) -> ArrayMesh:
+	if source_mesh == null:
+		return null
+
+	var output_mesh := ArrayMesh.new()
+	for surface_index in range(source_mesh.get_surface_count()):
+		var primitive_type: Mesh.PrimitiveType = source_mesh.surface_get_primitive_type(surface_index)
+		var arrays: Array = source_mesh.surface_get_arrays(surface_index)
+		if primitive_type != Mesh.PRIMITIVE_TRIANGLES:
+			output_mesh.add_surface_from_arrays(primitive_type, arrays)
+			var non_triangle_material: Material = source_mesh.surface_get_material(surface_index)
+			if non_triangle_material != null:
+				output_mesh.surface_set_material(output_mesh.get_surface_count() - 1, non_triangle_material)
+			continue
+
+		if arrays.size() <= Mesh.ARRAY_INDEX:
+			output_mesh.add_surface_from_arrays(primitive_type, arrays)
+			continue
+
+		var vertices: PackedVector3Array = arrays[Mesh.ARRAY_VERTEX]
+		if vertices.is_empty():
+			output_mesh.add_surface_from_arrays(primitive_type, arrays)
+			continue
+
+		var indices: PackedInt32Array = arrays[Mesh.ARRAY_INDEX]
+		if indices.is_empty():
+			indices = PackedInt32Array()
+			indices.resize(vertices.size())
+			for i in range(vertices.size()):
+				indices[i] = i
+
+		if indices.size() < 3:
+			output_mesh.add_surface_from_arrays(primitive_type, arrays)
+			continue
+
+		var corrected_indices: PackedInt32Array = indices
+		if _should_flip_surface_winding(vertices, indices):
+			corrected_indices = _flip_triangle_indices(indices)
+
+		arrays[Mesh.ARRAY_INDEX] = corrected_indices
+		arrays[Mesh.ARRAY_NORMAL] = _compute_surface_normals(vertices, corrected_indices)
+		output_mesh.add_surface_from_arrays(primitive_type, arrays)
+
+		var surface_material: Material = source_mesh.surface_get_material(surface_index)
+		if surface_material != null:
+			output_mesh.surface_set_material(output_mesh.get_surface_count() - 1, surface_material)
+
+	return output_mesh if output_mesh.get_surface_count() > 0 else null
+
+func _should_flip_surface_winding(vertices: PackedVector3Array, indices: PackedInt32Array) -> bool:
+	if vertices.is_empty() or indices.size() < 3:
+		return false
+
+	var centroid := Vector3.ZERO
+	for vertex in vertices:
+		centroid += vertex
+	centroid /= float(vertices.size())
+
+	var orientation_score: float = 0.0
+	var total_area: float = 0.0
+	for i in range(0, indices.size() - 2, 3):
+		var i0: int = indices[i]
+		var i1: int = indices[i + 1]
+		var i2: int = indices[i + 2]
+		if i0 < 0 or i1 < 0 or i2 < 0:
+			continue
+		if i0 >= vertices.size() or i1 >= vertices.size() or i2 >= vertices.size():
+			continue
+
+		var v0: Vector3 = vertices[i0]
+		var v1: Vector3 = vertices[i1]
+		var v2: Vector3 = vertices[i2]
+		var face_normal: Vector3 = (v1 - v0).cross(v2 - v0)
+		var area: float = face_normal.length()
+		if area <= ORIENTATION_SCORE_MIN_AREA:
+			continue
+
+		var triangle_centroid: Vector3 = (v0 + v1 + v2) / 3.0
+		orientation_score += face_normal.dot(triangle_centroid - centroid)
+		total_area += area
+
+	if total_area <= ORIENTATION_SCORE_MIN_AREA:
+		return false
+	return abs(orientation_score) > total_area * ORIENTATION_SCORE_EPSILON and orientation_score < 0.0
+
+func _flip_triangle_indices(indices: PackedInt32Array) -> PackedInt32Array:
+	var flipped: PackedInt32Array = indices
+	for i in range(0, flipped.size() - 2, 3):
+		var tmp: int = flipped[i + 1]
+		flipped[i + 1] = flipped[i + 2]
+		flipped[i + 2] = tmp
+	return flipped
+
+func _compute_surface_normals(vertices: PackedVector3Array, indices: PackedInt32Array) -> PackedVector3Array:
+	var normals := PackedVector3Array()
+	normals.resize(vertices.size())
+	for i in range(vertices.size()):
+		normals[i] = Vector3.ZERO
+
+	for i in range(0, indices.size() - 2, 3):
+		var i0: int = indices[i]
+		var i1: int = indices[i + 1]
+		var i2: int = indices[i + 2]
+		if i0 < 0 or i1 < 0 or i2 < 0:
+			continue
+		if i0 >= vertices.size() or i1 >= vertices.size() or i2 >= vertices.size():
+			continue
+
+		var face_normal: Vector3 = (vertices[i1] - vertices[i0]).cross(vertices[i2] - vertices[i0])
+		normals[i0] += face_normal
+		normals[i1] += face_normal
+		normals[i2] += face_normal
+
+	for i in range(normals.size()):
+		if normals[i].length_squared() > 0.0:
+			normals[i] = normals[i].normalized()
+		else:
+			normals[i] = Vector3.UP
+
+	return normals
 
 func _should_enable_double_sided(mesh_instance: MeshInstance3D, material: Material, source_data: Dictionary) -> bool:
 	if mesh_instance == null:


### PR DESCRIPTION
### Motivation
- Peraviz sometimes receives meshes with inverted triangle winding or missing/incorrect normals from heterogeneous exporters, producing inconsistent lighting; fixes are needed at import/load time so objects and subobjects render consistently.

### Description
- Add `ensure_outward_winding(...)` to `peraviz/native/src/mesh_3ds_loader.cpp` to detect global winding inversion and flip triangle indices before normals are generated when loading native 3DS meshes.
- Add a mesh sanitation pass in `peraviz/scripts/load_scene.gd` that runs for loaded `ArrayMesh` nodes and their subobjects to: detect per-surface inverted winding, flip triangle indices when needed, recompute per-vertex normals, and preserve per-surface materials; new helpers: `_normalize_loaded_mesh_normals_and_winding`, `_build_normalized_array_mesh`, `_should_flip_surface_winding`, `_flip_triangle_indices`, and `_compute_surface_normals`.
- Introduce orientation/detection tolerances `ORIENTATION_SCORE_EPSILON` and `ORIENTATION_SCORE_MIN_AREA` to make inversion detection robust for thin/open geometry.
- Keep existing selective double-sided material logic as a fallback and apply it after geometry normalization so lenses/thin planes and mirrored-transformed nodes remain handled.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded.
- Ran `git diff --check` (no whitespace/format issues) and committed the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1c9555e9c832480b1ea1744d6d990)