### PR TITLE
Fix Peraviz normals/winding handling and replace double-sided fallback with mirrored-mesh fix

### DIFF
--- a/peraviz/native/src/mesh_3ds_loader.cpp
+++ b/peraviz/native/src/mesh_3ds_loader.cpp
@@ -4,6 +4,7 @@
 
 #include <godot_cpp/variant/vector3.hpp>
 
+#include <algorithm>
 #include <array>
 #include <cmath>
 #include <cstdint>
@@ -25,6 +26,89 @@ struct MeshData {
     std::vector<uint32_t> indices;
     std::vector<float> normals;
 };
+
+void ensure_outward_winding(MeshData &mesh) {
+    const size_t vertex_count = mesh.vertices.size() / 3;
+    if (vertex_count < 3 || mesh.indices.size() < 3) {
+        return;
+    }
+
+    float cx = 0.0F;
+    float cy = 0.0F;
+    float cz = 0.0F;
+    for (size_t i = 0; i < vertex_count; ++i) {
+        cx += mesh.vertices[i * 3];
+        cy += mesh.vertices[i * 3 + 1];
+        cz += mesh.vertices[i * 3 + 2];
+    }
+
+    const float inv_vertex_count = 1.0F / static_cast<float>(vertex_count);
+    cx *= inv_vertex_count;
+    cy *= inv_vertex_count;
+    cz *= inv_vertex_count;
+
+    double orientation_score = 0.0;
+    double total_area = 0.0;
+
+    for (size_t i = 0; i + 2 < mesh.indices.size(); i += 3) {
+        const uint32_t i0 = mesh.indices[i];
+        const uint32_t i1 = mesh.indices[i + 1];
+        const uint32_t i2 = mesh.indices[i + 2];
+        if (i0 >= vertex_count || i1 >= vertex_count || i2 >= vertex_count) {
+            continue;
+        }
+
+        const float v0x = mesh.vertices[i0 * 3];
+        const float v0y = mesh.vertices[i0 * 3 + 1];
+        const float v0z = mesh.vertices[i0 * 3 + 2];
+        const float v1x = mesh.vertices[i1 * 3];
+        const float v1y = mesh.vertices[i1 * 3 + 1];
+        const float v1z = mesh.vertices[i1 * 3 + 2];
+        const float v2x = mesh.vertices[i2 * 3];
+        const float v2y = mesh.vertices[i2 * 3 + 1];
+        const float v2z = mesh.vertices[i2 * 3 + 2];
+
+        const float ux = v1x - v0x;
+        const float uy = v1y - v0y;
+        const float uz = v1z - v0z;
+        const float vx = v2x - v0x;
+        const float vy = v2y - v0y;
+        const float vz = v2z - v0z;
+
+        const float nx = uy * vz - uz * vy;
+        const float ny = uz * vx - ux * vz;
+        const float nz = ux * vy - uy * vx;
+
+        const double area = std::sqrt(static_cast<double>(nx) * nx +
+                                      static_cast<double>(ny) * ny +
+                                      static_cast<double>(nz) * nz);
+        if (area <= 1e-9) {
+            continue;
+        }
+
+        const float tx = (v0x + v1x + v2x) / 3.0F;
+        const float ty = (v0y + v1y + v2y) / 3.0F;
+        const float tz = (v0z + v1z + v2z) / 3.0F;
+        const float to_center_x = tx - cx;
+        const float to_center_y = ty - cy;
+        const float to_center_z = tz - cz;
+
+        orientation_score += static_cast<double>(nx) * to_center_x +
+                             static_cast<double>(ny) * to_center_y +
+                             static_cast<double>(nz) * to_center_z;
+        total_area += area;
+    }
+
+    if (total_area <= 1e-9 || std::abs(orientation_score) <= total_area * 1e-4) {
+        return;
+    }
+
+    if (orientation_score < 0.0) {
+        for (size_t i = 0; i + 2 < mesh.indices.size(); i += 3) {
+            std::swap(mesh.indices[i + 1], mesh.indices[i + 2]);
+        }
+    }
+}
 
 bool read_chunk(std::ifstream &file, Chunk &chunk) {
     if (!file.read(reinterpret_cast<char *>(&chunk.id), sizeof(chunk.id))) {
@@ -214,6 +298,7 @@ bool load_3ds(const std::string &path, MeshData &mesh) {
         return false;
     }
 
+    ensure_outward_winding(mesh);
     compute_normals(mesh);
     return true;
 }

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -758,8 +758,6 @@ func _create_mesh_with_flipped_winding(source_mesh: Mesh) -> ArrayMesh:
 		else:
 			_flip_triangle_vertex_order_for_unindexed_surface(arrays)
 
-		_invert_surface_normals_and_tangents(arrays)
-
 		mirrored.add_surface_from_arrays(primitive_type, arrays, [], {}, source_array_mesh.surface_get_format(surface_index))
 
 		var surface_material: Material = source_array_mesh.surface_get_material(surface_index)
@@ -767,21 +765,6 @@ func _create_mesh_with_flipped_winding(source_mesh: Mesh) -> ArrayMesh:
 			mirrored.surface_set_material(surface_index, surface_material)
 
 	return mirrored
-
-func _invert_surface_normals_and_tangents(arrays: Array) -> void:
-	var normals: PackedVector3Array = arrays[Mesh.ARRAY_NORMAL]
-	if not normals.is_empty():
-		for i in range(normals.size()):
-			normals[i] = -normals[i]
-		arrays[Mesh.ARRAY_NORMAL] = normals
-
-	var tangents: PackedFloat32Array = arrays[Mesh.ARRAY_TANGENT]
-	if not tangents.is_empty():
-		for i in range(0, tangents.size() - 3, 4):
-			tangents[i] = -tangents[i]
-			tangents[i + 1] = -tangents[i + 1]
-			tangents[i + 2] = -tangents[i + 2]
-		arrays[Mesh.ARRAY_TANGENT] = tangents
 
 func _flip_triangle_vertex_order_for_unindexed_surface(arrays: Array) -> void:
 	var vertices: PackedVector3Array = arrays[Mesh.ARRAY_VERTEX]
@@ -792,25 +775,6 @@ func _flip_triangle_vertex_order_for_unindexed_surface(arrays: Array) -> void:
 		vertices[i + 1] = vertices[i + 2]
 		vertices[i + 2] = tmp_vertex
 	arrays[Mesh.ARRAY_VERTEX] = vertices
-
-	var normals: PackedVector3Array = arrays[Mesh.ARRAY_NORMAL]
-	if normals.size() == vertices.size():
-		for i in range(0, normals.size() - 2, 3):
-			var tmp_normal: Vector3 = normals[i + 1]
-			normals[i + 1] = normals[i + 2]
-			normals[i + 2] = tmp_normal
-		arrays[Mesh.ARRAY_NORMAL] = normals
-
-	var tangents: PackedFloat32Array = arrays[Mesh.ARRAY_TANGENT]
-	if tangents.size() == vertices.size() * 4:
-		for i in range(0, vertices.size() - 2, 3):
-			var b1: int = (i + 1) * 4
-			var b2: int = (i + 2) * 4
-			for c in range(4):
-				var tmp_tangent: float = tangents[b1 + c]
-				tangents[b1 + c] = tangents[b2 + c]
-				tangents[b2 + c] = tmp_tangent
-		arrays[Mesh.ARRAY_TANGENT] = tangents
 
 func _extract_visual_scale_hint(data: Dictionary) -> float:
 	if bool(data.get("has_basis", false)):

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -44,6 +44,7 @@ var _fixture_emissive_cache: Dictionary = {}
 var _fixture_lens_material_cache: Dictionary = {}
 var _fixture_emitter_light_cache: Dictionary = {}
 var _fixture_emitter_photometrics: Dictionary = {}
+var _mirrored_mesh_cache: Dictionary = {}
 var _fixture_gobo_projector: FixtureGoboProjector = null
 var _updating_fixture_controls: bool = false
 var _visual_environment_baseline := {
@@ -112,12 +113,6 @@ const DEFAULT_EMITTER_PHOTOMETRICS := {
 # (aligned with fixture lens output in runtime scenes) while still inheriting GDTF emitter transforms.
 const EMITTER_LIGHT_DIRECTION_FIX: Vector3 = Vector3(-90.0, 0.0, 0.0)
 const LENS_TINT_COLOR: Color = Color(0.72, 0.86, 1.0, 0.38)
-const DOUBLE_SIDED_NAME_HINTS: Array[String] = [
-	"lens", "glass", "visor", "shade", "shield", "fabric", "cloth", "curtain", "scrim", "flag", "plane", "card"
-]
-const DOUBLE_SIDED_MATERIAL_HINTS: Array[String] = [
-	"lens", "glass", "visor", "fabric", "cloth", "curtain", "thin", "plane"
-]
 const IMPORTED_CONTENT_SCALE: float = 1.0
 const EMITTER_LIGHT_MIN_RANGE_M: float = 12.0
 const EMITTER_LIGHT_MAX_RANGE_M: float = 150.0
@@ -669,7 +664,7 @@ func _build_visual_node(data: Dictionary, item_type: String, item_class: String,
 		var loaded: Variant = _load_3d_asset(asset_path, asset_kind)
 		if loaded is Node3D:
 			var loaded_node: Node3D = loaded
-			_apply_selective_double_sided_to_candidates(loaded_node, data)
+			_apply_mesh_winding_compatibility(loaded_node)
 			return loaded_node
 		print("[Peraviz] Asset fallback for missing/invalid model: ", asset_path, " type=", item_type, " class=", item_class, " asset_kind=", asset_kind)
 
@@ -680,34 +675,12 @@ func _build_visual_node(data: Dictionary, item_type: String, item_class: String,
 
 	return _create_dummy_mesh(is_fixture, visual_scale_hint)
 
-func _apply_selective_double_sided_to_candidates(model_root: Node3D, source_data: Dictionary) -> void:
+func _apply_mesh_winding_compatibility(model_root: Node3D) -> void:
 	if model_root == null:
 		return
 
-	var tagged_meshes: int = 0
-	var tagged_surfaces: int = 0
 	for mesh_instance in _collect_mesh_instances_recursive(model_root):
-		if mesh_instance.mesh == null:
-			continue
-
-		var tagged_surface_indices := PackedInt32Array()
-		for surface_index in range(mesh_instance.mesh.get_surface_count()):
-			var active_material: Material = mesh_instance.get_active_material(surface_index)
-			if not _should_enable_double_sided(mesh_instance, active_material, source_data):
-				continue
-			if _set_double_sided_surface_material(mesh_instance, surface_index, active_material):
-				tagged_surface_indices.append(surface_index)
-
-		if tagged_surface_indices.is_empty():
-			continue
-		tagged_meshes += 1
-		tagged_surfaces += tagged_surface_indices.size()
-		mesh_instance.set_meta("peraviz_double_sided_surface_indices", tagged_surface_indices)
-		mesh_instance.set_meta("peraviz_double_sided_candidate", true)
-
-	if tagged_surfaces > 0:
-		model_root.set_meta("peraviz_double_sided_mesh_count", tagged_meshes)
-		model_root.set_meta("peraviz_double_sided_surface_count", tagged_surfaces)
+		_apply_mirrored_instance_winding(mesh_instance)
 
 func _collect_mesh_instances_recursive(root: Node3D) -> Array[MeshInstance3D]:
 	var output: Array[MeshInstance3D] = []
@@ -720,40 +693,15 @@ func _collect_mesh_instances_recursive(root: Node3D) -> Array[MeshInstance3D]:
 			output.append_array(_collect_mesh_instances_recursive(child))
 	return output
 
-func _should_enable_double_sided(mesh_instance: MeshInstance3D, material: Material, source_data: Dictionary) -> bool:
-	if mesh_instance == null:
-		return false
+func _apply_mirrored_instance_winding(mesh_instance: MeshInstance3D) -> void:
+	if mesh_instance == null or mesh_instance.mesh == null:
+		return
+	if not _has_mirrored_transform_in_hierarchy(mesh_instance):
+		return
 
-	var source_type: String = str(source_data.get("type", "")).to_lower()
-	if source_type == "fixture_geometry":
-		return true
-
-	if _has_mirrored_transform_in_hierarchy(mesh_instance):
-		return true
-
-	var mesh_name_hint: String = mesh_instance.name.to_lower()
-	var geometry_name_hint: String = str(source_data.get("name", "")).to_lower()
-	if _contains_any_hint(mesh_name_hint, DOUBLE_SIDED_NAME_HINTS):
-		return true
-	if _contains_any_hint(geometry_name_hint, DOUBLE_SIDED_NAME_HINTS):
-		return true
-
-	if material != null:
-		var material_name_hint: String = material.resource_name.to_lower()
-		if _contains_any_hint(material_name_hint, DOUBLE_SIDED_MATERIAL_HINTS):
-			return true
-
-		if material is BaseMaterial3D:
-			var base_material: BaseMaterial3D = material
-			if base_material.transparency != BaseMaterial3D.TRANSPARENCY_DISABLED and (
-				mesh_name_hint.contains("lens") or mesh_name_hint.contains("glass") or
-				geometry_name_hint.contains("lens") or geometry_name_hint.contains("glass")
-			):
-				return true
-
-	if _looks_like_thin_plane(mesh_instance):
-		return true
-	return false
+	var mirrored_mesh: Mesh = _get_or_create_mirrored_mesh(mesh_instance.mesh)
+	if mirrored_mesh != null:
+		mesh_instance.mesh = mirrored_mesh
 
 func _has_mirrored_transform_in_hierarchy(node: Node3D) -> bool:
 	var current: Node = node
@@ -764,52 +712,48 @@ func _has_mirrored_transform_in_hierarchy(node: Node3D) -> bool:
 		current = node3d.get_parent()
 	return false
 
-func _contains_any_hint(candidate: String, hints: Array[String]) -> bool:
-	if candidate.is_empty():
-		return false
-	for hint in hints:
-		if candidate.contains(hint):
-			return true
-	return false
+func _get_or_create_mirrored_mesh(source_mesh: Mesh) -> Mesh:
+	if source_mesh == null:
+		return null
 
-func _looks_like_thin_plane(mesh_instance: MeshInstance3D) -> bool:
-	if mesh_instance == null:
-		return false
-	var bounds: AABB = mesh_instance.get_aabb()
-	if bounds.size == Vector3.ZERO:
-		return false
-	var sx: float = abs(bounds.size.x)
-	var sy: float = abs(bounds.size.y)
-	var sz: float = abs(bounds.size.z)
-	var min_dim: float = min(sx, min(sy, sz))
-	var max_dim: float = max(sx, max(sy, sz))
-	if max_dim <= 0.0001:
-		return false
-	return min_dim <= max_dim * 0.04
+	var source_rid: RID = source_mesh.get_rid()
+	if _mirrored_mesh_cache.has(source_rid):
+		return _mirrored_mesh_cache[source_rid]
 
-func _set_double_sided_surface_material(mesh_instance: MeshInstance3D, surface_index: int, active_material: Material) -> bool:
-	if mesh_instance == null:
-		return false
-	if active_material is BaseMaterial3D:
-		var source_material: BaseMaterial3D = active_material
-		if source_material.cull_mode == BaseMaterial3D.CULL_DISABLED:
-			return true
-		var override_material: BaseMaterial3D = source_material.duplicate(true)
-		override_material.cull_mode = BaseMaterial3D.CULL_DISABLED
-		mesh_instance.set_surface_override_material(surface_index, override_material)
-		return true
+	var mirrored: ArrayMesh = _create_mesh_with_flipped_winding(source_mesh)
+	if mirrored != null:
+		_mirrored_mesh_cache[source_rid] = mirrored
+	return mirrored
 
-	if active_material == null and mesh_instance.mesh != null:
-		var mesh_surface_material: Material = mesh_instance.mesh.surface_get_material(surface_index)
-		if mesh_surface_material is BaseMaterial3D:
-			var surface_source: BaseMaterial3D = mesh_surface_material
-			if surface_source.cull_mode == BaseMaterial3D.CULL_DISABLED:
-				return true
-			var surface_override: BaseMaterial3D = surface_source.duplicate(true)
-			surface_override.cull_mode = BaseMaterial3D.CULL_DISABLED
-			mesh_instance.set_surface_override_material(surface_index, surface_override)
-			return true
-	return false
+func _create_mesh_with_flipped_winding(source_mesh: Mesh) -> ArrayMesh:
+	if source_mesh == null:
+		return null
+
+	var source_array_mesh: ArrayMesh = source_mesh as ArrayMesh
+	if source_array_mesh == null:
+		return null
+
+	var mirrored := ArrayMesh.new()
+	for surface_index in range(source_array_mesh.get_surface_count()):
+		var arrays: Array = source_array_mesh.surface_get_arrays(surface_index)
+		if arrays.is_empty():
+			continue
+
+		var indices: PackedInt32Array = arrays[Mesh.ARRAY_INDEX]
+		if not indices.is_empty():
+			for i in range(0, indices.size() - 2, 3):
+				var tmp: int = indices[i + 1]
+				indices[i + 1] = indices[i + 2]
+				indices[i + 2] = tmp
+			arrays[Mesh.ARRAY_INDEX] = indices
+
+		mirrored.add_surface_from_arrays(source_array_mesh.surface_get_primitive_type(surface_index), arrays, [], {}, source_array_mesh.surface_get_format(surface_index))
+
+		var surface_material: Material = source_array_mesh.surface_get_material(surface_index)
+		if surface_material != null:
+			mirrored.surface_set_material(surface_index, surface_material)
+
+	return mirrored
 
 func _extract_visual_scale_hint(data: Dictionary) -> float:
 	if bool(data.get("has_basis", false)):
@@ -983,7 +927,6 @@ func _create_gdtf_primitive_mesh(data: Dictionary) -> Node3D:
 	var material := StandardMaterial3D.new()
 	material.albedo_color = Color(0.2, 0.2, 0.22, 1.0)
 	material.roughness = 0.3
-	material.cull_mode = BaseMaterial3D.CULL_DISABLED
 	mesh_instance.material_override = material
 	return mesh_instance
 
@@ -994,6 +937,7 @@ func _clear_scene() -> void:
 		child.queue_free()
 	_node_index.clear()
 	_asset_cache.clear()
+	_mirrored_mesh_cache.clear()
 	_fixture_emissive_cache.clear()
 	_fixture_lens_material_cache.clear()
 	_fixture_emitter_light_cache.clear()

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -758,6 +758,8 @@ func _create_mesh_with_flipped_winding(source_mesh: Mesh) -> ArrayMesh:
 		else:
 			_flip_triangle_vertex_order_for_unindexed_surface(arrays)
 
+		_invert_surface_normals_and_tangents(arrays)
+
 		mirrored.add_surface_from_arrays(primitive_type, arrays, [], {}, source_array_mesh.surface_get_format(surface_index))
 
 		var surface_material: Material = source_array_mesh.surface_get_material(surface_index)
@@ -765,6 +767,21 @@ func _create_mesh_with_flipped_winding(source_mesh: Mesh) -> ArrayMesh:
 			mirrored.surface_set_material(surface_index, surface_material)
 
 	return mirrored
+
+func _invert_surface_normals_and_tangents(arrays: Array) -> void:
+	var normals: PackedVector3Array = arrays[Mesh.ARRAY_NORMAL]
+	if not normals.is_empty():
+		for i in range(normals.size()):
+			normals[i] = -normals[i]
+		arrays[Mesh.ARRAY_NORMAL] = normals
+
+	var tangents: PackedFloat32Array = arrays[Mesh.ARRAY_TANGENT]
+	if not tangents.is_empty():
+		for i in range(0, tangents.size() - 3, 4):
+			tangents[i] = -tangents[i]
+			tangents[i + 1] = -tangents[i + 1]
+			tangents[i + 2] = -tangents[i + 2]
+		arrays[Mesh.ARRAY_TANGENT] = tangents
 
 func _flip_triangle_vertex_order_for_unindexed_surface(arrays: Array) -> void:
 	var vertices: PackedVector3Array = arrays[Mesh.ARRAY_VERTEX]

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -705,12 +705,13 @@ func _apply_mirrored_instance_winding(mesh_instance: MeshInstance3D) -> void:
 
 func _has_mirrored_transform_in_hierarchy(node: Node3D) -> bool:
 	var current: Node = node
+	var has_mirrored_parity: bool = false
 	while current is Node3D:
 		var node3d: Node3D = current
 		if node3d.transform.basis.determinant() < 0.0:
-			return true
+			has_mirrored_parity = not has_mirrored_parity
 		current = node3d.get_parent()
-	return false
+	return has_mirrored_parity
 
 func _get_or_create_mirrored_mesh(source_mesh: Mesh) -> Mesh:
 	if source_mesh == null:
@@ -739,6 +740,14 @@ func _create_mesh_with_flipped_winding(source_mesh: Mesh) -> ArrayMesh:
 		if arrays.is_empty():
 			continue
 
+		var primitive_type: int = source_array_mesh.surface_get_primitive_type(surface_index)
+		if primitive_type != Mesh.PRIMITIVE_TRIANGLES:
+			mirrored.add_surface_from_arrays(primitive_type, arrays, [], {}, source_array_mesh.surface_get_format(surface_index))
+			var passthrough_material: Material = source_array_mesh.surface_get_material(surface_index)
+			if passthrough_material != null:
+				mirrored.surface_set_material(surface_index, passthrough_material)
+			continue
+
 		var indices: PackedInt32Array = arrays[Mesh.ARRAY_INDEX]
 		if not indices.is_empty():
 			for i in range(0, indices.size() - 2, 3):
@@ -746,14 +755,45 @@ func _create_mesh_with_flipped_winding(source_mesh: Mesh) -> ArrayMesh:
 				indices[i + 1] = indices[i + 2]
 				indices[i + 2] = tmp
 			arrays[Mesh.ARRAY_INDEX] = indices
+		else:
+			_flip_triangle_vertex_order_for_unindexed_surface(arrays)
 
-		mirrored.add_surface_from_arrays(source_array_mesh.surface_get_primitive_type(surface_index), arrays, [], {}, source_array_mesh.surface_get_format(surface_index))
+		mirrored.add_surface_from_arrays(primitive_type, arrays, [], {}, source_array_mesh.surface_get_format(surface_index))
 
 		var surface_material: Material = source_array_mesh.surface_get_material(surface_index)
 		if surface_material != null:
 			mirrored.surface_set_material(surface_index, surface_material)
 
 	return mirrored
+
+func _flip_triangle_vertex_order_for_unindexed_surface(arrays: Array) -> void:
+	var vertices: PackedVector3Array = arrays[Mesh.ARRAY_VERTEX]
+	if vertices.size() < 3:
+		return
+	for i in range(0, vertices.size() - 2, 3):
+		var tmp_vertex: Vector3 = vertices[i + 1]
+		vertices[i + 1] = vertices[i + 2]
+		vertices[i + 2] = tmp_vertex
+	arrays[Mesh.ARRAY_VERTEX] = vertices
+
+	var normals: PackedVector3Array = arrays[Mesh.ARRAY_NORMAL]
+	if normals.size() == vertices.size():
+		for i in range(0, normals.size() - 2, 3):
+			var tmp_normal: Vector3 = normals[i + 1]
+			normals[i + 1] = normals[i + 2]
+			normals[i + 2] = tmp_normal
+		arrays[Mesh.ARRAY_NORMAL] = normals
+
+	var tangents: PackedFloat32Array = arrays[Mesh.ARRAY_TANGENT]
+	if tangents.size() == vertices.size() * 4:
+		for i in range(0, vertices.size() - 2, 3):
+			var b1: int = (i + 1) * 4
+			var b2: int = (i + 2) * 4
+			for c in range(4):
+				var tmp_tangent: float = tangents[b1 + c]
+				tangents[b1 + c] = tangents[b2 + c]
+				tangents[b2 + c] = tmp_tangent
+		arrays[Mesh.ARRAY_TANGENT] = tangents
 
 func _extract_visual_scale_hint(data: Dictionary) -> float:
 	if bool(data.get("has_basis", false)):


### PR DESCRIPTION
### Motivation
- MVR/3DS assets from heterogeneous toolchains sometimes arrive with inverted triangle winding or mirrored transforms that produce wrong normals/culling and incorrect lighting in Peraviz. The intent is to match Perastage behavior: detect and correct global winding and avoid broad double-sided forcing. 
- Prefer correcting geometry (indices/normals or mirrored-instance meshes) rather than forcing materials to be double-sided, so culling and lighting remain physically consistent.
- Keep runtime behavior consistent with Peraviz coordinate/handedness mappings while fixing visualization artifacts produced by source meshes.
- Note: `peraviz/scripts/load_scene.gd` is a large file; refactoring/extraction is recommended as a follow-up to keep responsibilities small (suggestion: extract mesh-winding and mirrored-mesh helpers into a dedicated `load_scene_mesh_utils.gd`).

### Description
- Added an outward-winding detection+correction in the native 3DS loader by introducing `ensure_outward_winding(MeshData&)` and calling it before normal computation, so globally inverted triangle order is corrected at import time (`peraviz/native/src/mesh_3ds_loader.cpp`).
- Replaced the previous selective "force double-sided" material override path with a mirrored-instance winding strategy in Godot: detect negative-determinant transforms in the node hierarchy and swap triangle indices for those instances, storing mirrored ArrayMesh copies in a cache keyed by the source mesh RID (`peraviz/scripts/load_scene.gd`).
- Added `_mirrored_mesh_cache` with lifecycle management (cleared on scene clear) to avoid regenerating mirrored meshes repeatedly and to keep runtime allocations bounded (`peraviz/scripts/load_scene.gd`).
- Removed unconditional `cull_mode = CULL_DISABLED` on generated GDTF primitive meshes so primitives obey correct culling by default (`peraviz/scripts/load_scene.gd`).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (OK).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (OK).
- Attempted `cmake -S peraviz/native -B /tmp/peraviz-build` to validate native build configuration; CMake configuration failed in this environment due to a missing `tinyxml2` development package (environmental dependency), so full native compile/test was not completed (expected failure in this sandbox).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1db7bee908324835c93cec7f2a6e7)