### PR TITLE
Fix Peraviz gobo meta lookup when key is absent

### DIFF
--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -12,9 +12,7 @@ func clear_cache() -> void:
 func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 	if light == null or not is_instance_valid(light):
 		return false
-	var previous_meta_texture: Texture2D = null
-	if light.has_meta(GOBO_TEXTURE_META_KEY):
-		previous_meta_texture = light.get_meta(GOBO_TEXTURE_META_KEY) as Texture2D
+	var previous_meta_texture: Texture2D = light.get_meta(GOBO_TEXTURE_META_KEY, null) as Texture2D
 	if not bool(controls.get("has_gobo", false)):
 		light.set_meta(GOBO_TEXTURE_META_KEY, null)
 		light.light_projector = null


### PR DESCRIPTION
### Motivation
- Prevent a Godot runtime error when `apply_gobo_projection()` attempts to read the `peraviz_gobo_texture` meta from a `SpotLight3D` that does not yet have that key set.

### Description
- Use `light.get_meta(GOBO_TEXTURE_META_KEY, null) as Texture2D` in `peraviz/scripts/fixture_gobo_projector.gd` instead of the previous `has_meta` + `get_meta` pattern so a missing meta returns `null` safely.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1e672ea38832486c97d2800875506)