### PR TITLE
Guard peraviz gobo meta access to avoid Godot error loop

### DIFF
--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -12,7 +12,9 @@ func clear_cache() -> void:
 func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 	if light == null or not is_instance_valid(light):
 		return false
-	var previous_meta_texture: Texture2D = light.get_meta(GOBO_TEXTURE_META_KEY, null) as Texture2D
+	var previous_meta_texture: Texture2D = null
+	if light.has_meta(GOBO_TEXTURE_META_KEY):
+		previous_meta_texture = light.get_meta(GOBO_TEXTURE_META_KEY) as Texture2D
 	if not bool(controls.get("has_gobo", false)):
 		light.set_meta(GOBO_TEXTURE_META_KEY, null)
 		light.light_projector = null


### PR DESCRIPTION
### Motivation
- Avoid noisy Godot runtime errors and repeated stack traces caused by reading a non-existent `meta` key `peraviz_gobo_texture` in the gobo projector, which produced a loop of error logs during runtime.

### Description
- Replace direct `get_meta(..., null)` usage with a `has_meta(...)` check and conditional `get_meta(...)` call in `peraviz/scripts/fixture_gobo_projector.gd` so `apply_gobo_projection()` only reads the metadata when the key exists.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both completed successfully (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1e8e0a4bc8324a602d4663452c78f)