### PR TITLE
Guard metadata read in FixtureGoboProjector to stop missing gobo meta error

### DIFF
--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -12,7 +12,9 @@ func clear_cache() -> void:
 func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 	if light == null or not is_instance_valid(light):
 		return false
-	var previous_meta_texture: Texture2D = light.get_meta(GOBO_TEXTURE_META_KEY, null) as Texture2D
+	var previous_meta_texture: Texture2D = null
+	if light.has_meta(GOBO_TEXTURE_META_KEY):
+		previous_meta_texture = light.get_meta(GOBO_TEXTURE_META_KEY) as Texture2D
 	if not bool(controls.get("has_gobo", false)):
 		light.set_meta(GOBO_TEXTURE_META_KEY, null)
 		light.light_projector = null


### PR DESCRIPTION
### Motivation
- Godot repeatedly logged "The object does not have any 'meta' values with the key 'peraviz_gobo_texture'" when `apply_gobo_projection` attempted to read metadata that was not set, causing noisy runtime errors.

### Description
- Update `peraviz/scripts/fixture_gobo_projector.gd` so `previous_meta_texture` is initialized to `null` and `light.has_meta(GOBO_TEXTURE_META_KEY)` is checked before calling `light.get_meta(...)`, preserving existing behavior while avoiding the error.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both reported OK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1e97b9d348324960439e3171fecff)