### PR TITLE
Fix Peraviz 3DS coordinate/winding handling and add diagnostics harness

### DIFF
--- a/peraviz/README.md
+++ b/peraviz/README.md
@@ -94,6 +94,7 @@ Peraviz supports both embedded **GLB/glTF** models and **3DS** meshes found in G
     - `godot_z = -y`
   - Source units are treated as millimeters and converted to meters (`0.001`).
   - Object-local coordinate chunks from 3DS (`0x4160`) are applied before Godot conversion so multi-object fixture meshes keep correct subobject placement and orientation.
+  - After object transforms are applied, importer performs a global outward-winding check and flips triangle order when the mesh is detected as inverted.
   - This conversion keeps a right-handed basis and avoids mirror transforms caused by signless axis swaps.
 
 - **Winding correction strategy**

--- a/peraviz/README.md
+++ b/peraviz/README.md
@@ -96,14 +96,13 @@ Peraviz supports both embedded **GLB/glTF** models and **3DS** meshes found in G
   - This conversion keeps a right-handed basis and avoids mirror transforms caused by signless axis swaps.
 
 - **Winding correction strategy**
-  - When a mesh is instantiated under a transform with negative determinant, Peraviz flips triangle winding and normals at mesh build time.
-  - An optional heuristic safety net can also detect likely inside-out closed meshes and auto-fix them.
-  - Heuristic mode is enabled by default and can be toggled with project setting `peraviz_debug_inside_out_heuristic`.
+  - Peraviz keeps source triangle winding by default and avoids material-level double-sided workarounds.
+  - An optional heuristic safety net can detect likely inside-out closed meshes and auto-fix winding/normals when enabled.
+  - Heuristic mode can be toggled with project setting `peraviz_debug_inside_out_heuristic`.
 
 - **Material culling defaults**
   - Solid fixture parts keep standard backface culling.
-  - For mirrored transform chains, Peraviz applies front-face culling override on affected surfaces to preserve exterior rendering without forcing global double-sided materials.
-  - Double-sided rendering remains opt-in for likely thin or transparent surfaces.
+  - Solid fixture materials are not force-overridden to double-sided as a generic workaround.
 
 #### Mesh diagnostics harness
 

--- a/peraviz/README.md
+++ b/peraviz/README.md
@@ -98,10 +98,11 @@ Peraviz supports both embedded **GLB/glTF** models and **3DS** meshes found in G
 - **Winding correction strategy**
   - When a mesh is instantiated under a transform with negative determinant, Peraviz flips triangle winding and normals at mesh build time.
   - An optional heuristic safety net can also detect likely inside-out closed meshes and auto-fix them.
-  - Heuristic mode is controlled by project setting `peraviz_debug_inside_out_heuristic`.
+  - Heuristic mode is enabled by default and can be toggled with project setting `peraviz_debug_inside_out_heuristic`.
 
 - **Material culling defaults**
   - Solid fixture parts keep standard backface culling.
+  - For mirrored transform chains, Peraviz applies front-face culling override on affected surfaces to preserve exterior rendering without forcing global double-sided materials.
   - Double-sided rendering remains opt-in for likely thin or transparent surfaces.
 
 #### Mesh diagnostics harness

--- a/peraviz/README.md
+++ b/peraviz/README.md
@@ -79,7 +79,45 @@ Peraviz currently supports two beam rendering modes:
 - If gobo media is missing or malformed, Peraviz can generate a simple “fake” gobo texture to validate DMX bindings.
 - Note: projector behavior is not reliable in Godot’s **Compatibility renderer**; Forward+ / Mobile rendering is recommended for predictable results.
 
-### 6) Debug and validation workflow
+### 6) Embedded model import robustness (GLB + 3DS)
+
+Peraviz supports both embedded **GLB/glTF** models and **3DS** meshes found in GDTF archives.
+
+- **GLB/glTF path**
+  - Loaded through Godot's `GLTFDocument` scene generation.
+  - Preserves asset-authored orientation/scale as provided by the glTF pipeline.
+
+- **3DS path**
+  - Uses native loader mesh extraction and applies a dedicated Z-up to Y-up conversion:
+    - `godot_x = x`
+    - `godot_y = z`
+    - `godot_z = -y`
+  - Source units are treated as millimeters and converted to meters (`0.001`).
+  - This conversion keeps a right-handed basis and avoids mirror transforms caused by signless axis swaps.
+
+- **Winding correction strategy**
+  - When a mesh is instantiated under a transform with negative determinant, Peraviz flips triangle winding and normals at mesh build time.
+  - An optional heuristic safety net can also detect likely inside-out closed meshes and auto-fix them.
+  - Heuristic mode is controlled by project setting `peraviz_debug_inside_out_heuristic`.
+
+- **Material culling defaults**
+  - Solid fixture parts keep standard backface culling.
+  - Double-sided rendering remains opt-in for likely thin or transparent surfaces.
+
+#### Mesh diagnostics harness
+
+If fixture files cannot be checked into the repository, use this headless helper with extracted model files:
+
+```bash
+godot --headless --path peraviz -s res://scripts/gdtf_mesh_diagnostics.gd -- \
+  --mesh=/absolute/path/models/3ds/base.3ds \
+  --mesh=/absolute/path/models/gltf/base.glb \
+  --heuristic
+```
+
+The script prints per-mesh triangle/vertex counts and whether determinant-based and heuristic winding fixes were triggered.
+
+### 7) Debug and validation workflow
 
 Peraviz includes explicit tooling to make import correctness reproducible:
 

--- a/peraviz/README.md
+++ b/peraviz/README.md
@@ -98,6 +98,7 @@ Peraviz supports both embedded **GLB/glTF** models and **3DS** meshes found in G
 
 - **Winding correction strategy**
   - Peraviz keeps source triangle winding by default and avoids material-level double-sided workarounds.
+  - If a 3DS mesh ends under a mirrored transform hierarchy at runtime, Peraviz builds a mirrored mesh variant (winding and normals flipped) so backface culling still renders exterior faces.
   - An optional heuristic safety net can detect likely inside-out closed meshes and auto-fix winding/normals when enabled.
   - Heuristic mode can be toggled with project setting `peraviz_debug_inside_out_heuristic`.
 

--- a/peraviz/README.md
+++ b/peraviz/README.md
@@ -93,6 +93,7 @@ Peraviz supports both embedded **GLB/glTF** models and **3DS** meshes found in G
     - `godot_y = z`
     - `godot_z = -y`
   - Source units are treated as millimeters and converted to meters (`0.001`).
+  - Object-local coordinate chunks from 3DS (`0x4160`) are applied before Godot conversion so multi-object fixture meshes keep correct subobject placement and orientation.
   - This conversion keeps a right-handed basis and avoids mirror transforms caused by signless axis swaps.
 
 - **Winding correction strategy**

--- a/peraviz/README.md
+++ b/peraviz/README.md
@@ -103,6 +103,7 @@ Peraviz supports both embedded **GLB/glTF** models and **3DS** meshes found in G
   - An optional heuristic safety net can detect likely inside-out closed meshes and auto-fix winding/normals when enabled.
   - Heuristic mode can be toggled with project setting `peraviz_debug_inside_out_heuristic`.
   - A deterministic best-orientation pass is enabled by default (`peraviz_force_best_winding_3ds`) and chooses flipped winding when outward ratio improves significantly.
+  - Temporary debug switch `peraviz_force_invert_all_faces` (enabled by default in current troubleshooting) inverts winding/normals for all loaded meshes to validate whether rendering issues are strictly face-orientation related.
 
 - **Material culling defaults**
   - Solid fixture parts keep standard backface culling.

--- a/peraviz/README.md
+++ b/peraviz/README.md
@@ -102,6 +102,7 @@ Peraviz supports both embedded **GLB/glTF** models and **3DS** meshes found in G
   - If a 3DS mesh ends under a mirrored transform hierarchy at runtime, Peraviz builds a mirrored mesh variant (winding and normals flipped) so backface culling still renders exterior faces.
   - An optional heuristic safety net can detect likely inside-out closed meshes and auto-fix winding/normals when enabled.
   - Heuristic mode can be toggled with project setting `peraviz_debug_inside_out_heuristic`.
+  - A deterministic best-orientation pass is enabled by default (`peraviz_force_best_winding_3ds`) and chooses flipped winding when outward ratio improves significantly.
 
 - **Material culling defaults**
   - Solid fixture parts keep standard backface culling.

--- a/peraviz/native/src/coordinate_mapper.cpp
+++ b/peraviz/native/src/coordinate_mapper.cpp
@@ -39,6 +39,15 @@ Vec3 map_position_mm_to_m(const std::array<float, 3> &source_mm) {
                 -source_mm[1] / 1000.0F};
 }
 
+Vec3 map_3ds_position_mm_to_godot_m(const std::array<float, 3> &source_mm) {
+    return map_position_mm_to_m(source_mm);
+}
+
+Vec3 map_3ds_direction_to_godot(const std::array<float, 3> &source_direction) {
+    const auto mapped = map_source_vector_to_godot(source_direction);
+    return Vec3{mapped[0], mapped[1], mapped[2]};
+}
+
 std::array<float, 3> map_source_vector_to_godot(const std::array<float, 3> &source) {
     return {source[0], source[2], -source[1]};
 }

--- a/peraviz/native/src/coordinate_mapper.h
+++ b/peraviz/native/src/coordinate_mapper.h
@@ -9,6 +9,10 @@ namespace peraviz::coordinate_mapper {
 
 Vec3 map_position_mm_to_m(const std::array<float, 3> &source_mm);
 
+Vec3 map_3ds_position_mm_to_godot_m(const std::array<float, 3> &source_mm);
+
+Vec3 map_3ds_direction_to_godot(const std::array<float, 3> &source_direction);
+
 std::array<float, 3> map_source_vector_to_godot(const std::array<float, 3> &source);
 
 Matrix to_godot_local_basis(const Matrix &source_local);

--- a/peraviz/native/src/mesh_3ds_loader.cpp
+++ b/peraviz/native/src/mesh_3ds_loader.cpp
@@ -24,6 +24,36 @@ struct MeshData {
     std::vector<float> normals;
 };
 
+struct LocalCoordinateSystem {
+    std::array<float, 3> u{1.0F, 0.0F, 0.0F};
+    std::array<float, 3> v{0.0F, 1.0F, 0.0F};
+    std::array<float, 3> w{0.0F, 0.0F, 1.0F};
+    std::array<float, 3> o{0.0F, 0.0F, 0.0F};
+};
+
+void apply_local_coordinate_system(MeshData &mesh, size_t vertex_start, size_t vertex_count,
+                                   const LocalCoordinateSystem &lcs) {
+    const size_t max_vertex_count = mesh.vertices.size() / 3;
+    if (vertex_start >= max_vertex_count || vertex_count == 0) {
+        return;
+    }
+    const size_t clamped_count = std::min(vertex_count, max_vertex_count - vertex_start);
+    for (size_t i = 0; i < clamped_count; ++i) {
+        const size_t index = (vertex_start + i) * 3;
+        const float x = mesh.vertices[index];
+        const float y = mesh.vertices[index + 1];
+        const float z = mesh.vertices[index + 2];
+
+        const float tx = (lcs.u[0] * x) + (lcs.v[0] * y) + (lcs.w[0] * z) + lcs.o[0];
+        const float ty = (lcs.u[1] * x) + (lcs.v[1] * y) + (lcs.w[1] * z) + lcs.o[1];
+        const float tz = (lcs.u[2] * x) + (lcs.v[2] * y) + (lcs.w[2] * z) + lcs.o[2];
+
+        mesh.vertices[index] = tx;
+        mesh.vertices[index + 1] = ty;
+        mesh.vertices[index + 2] = tz;
+    }
+}
+
 bool read_chunk(std::ifstream &file, Chunk &chunk) {
     if (!file.read(reinterpret_cast<char *>(&chunk.id), sizeof(chunk.id))) {
         return false;
@@ -102,6 +132,10 @@ void compute_normals(MeshData &mesh) {
 
 void parse_mesh_chunk(std::ifstream &file, std::streampos mesh_end, MeshData &mesh,
                       size_t vertex_base) {
+    size_t object_vertex_count = 0;
+    LocalCoordinateSystem local_coords;
+    bool has_local_coords = false;
+
     while (file.good() && file.tellg() < mesh_end) {
         Chunk chunk;
         if (!read_chunk(file, chunk)) {
@@ -119,6 +153,7 @@ void parse_mesh_chunk(std::ifstream &file, std::streampos mesh_end, MeshData &me
             mesh.vertices.resize(start + static_cast<size_t>(count) * 3U);
             file.read(reinterpret_cast<char *>(mesh.vertices.data() + start),
                       static_cast<std::streamsize>(count) * 3 * sizeof(float));
+            object_vertex_count = static_cast<size_t>(count);
         } else if (chunk.id == 0x4120) {
             uint16_t count = 0;
             file.read(reinterpret_cast<char *>(&count), sizeof(count));
@@ -144,9 +179,23 @@ void parse_mesh_chunk(std::ifstream &file, std::streampos mesh_end, MeshData &me
                 mesh.indices[idx + 2] =
                     static_cast<uint32_t>(c) + static_cast<uint32_t>(vertex_base);
             }
+        } else if (chunk.id == 0x4160) {
+            file.read(reinterpret_cast<char *>(local_coords.u.data()),
+                      3 * sizeof(float));
+            file.read(reinterpret_cast<char *>(local_coords.v.data()),
+                      3 * sizeof(float));
+            file.read(reinterpret_cast<char *>(local_coords.w.data()),
+                      3 * sizeof(float));
+            file.read(reinterpret_cast<char *>(local_coords.o.data()),
+                      3 * sizeof(float));
+            has_local_coords = true;
         }
 
         file.seekg(next);
+    }
+
+    if (has_local_coords && object_vertex_count > 0) {
+        apply_local_coordinate_system(mesh, vertex_base, object_vertex_count, local_coords);
     }
 }
 

--- a/peraviz/native/src/mesh_3ds_loader.cpp
+++ b/peraviz/native/src/mesh_3ds_loader.cpp
@@ -31,6 +31,12 @@ struct LocalCoordinateSystem {
     std::array<float, 3> o{0.0F, 0.0F, 0.0F};
 };
 
+float determinant3x3(const LocalCoordinateSystem &lcs) {
+    return lcs.u[0] * ((lcs.v[1] * lcs.w[2]) - (lcs.v[2] * lcs.w[1])) -
+           lcs.v[0] * ((lcs.u[1] * lcs.w[2]) - (lcs.u[2] * lcs.w[1])) +
+           lcs.w[0] * ((lcs.u[1] * lcs.v[2]) - (lcs.u[2] * lcs.v[1]));
+}
+
 void apply_local_coordinate_system(MeshData &mesh, size_t vertex_start, size_t vertex_count,
                                    const LocalCoordinateSystem &lcs) {
     const size_t max_vertex_count = mesh.vertices.size() / 3;
@@ -51,6 +57,19 @@ void apply_local_coordinate_system(MeshData &mesh, size_t vertex_start, size_t v
         mesh.vertices[index] = tx;
         mesh.vertices[index + 1] = ty;
         mesh.vertices[index + 2] = tz;
+    }
+}
+
+void reverse_winding_range(MeshData &mesh, size_t index_start, size_t triangle_count) {
+    const size_t max_triangle_count = mesh.indices.size() / 3;
+    if (index_start >= mesh.indices.size() || triangle_count == 0) {
+        return;
+    }
+    const size_t start_triangle = index_start / 3;
+    const size_t clamped_triangles = std::min(triangle_count, max_triangle_count - start_triangle);
+    for (size_t t = 0; t < clamped_triangles; ++t) {
+        const size_t i = index_start + (t * 3);
+        std::swap(mesh.indices[i + 1], mesh.indices[i + 2]);
     }
 }
 
@@ -133,6 +152,8 @@ void compute_normals(MeshData &mesh) {
 void parse_mesh_chunk(std::ifstream &file, std::streampos mesh_end, MeshData &mesh,
                       size_t vertex_base) {
     size_t object_vertex_count = 0;
+    size_t object_index_start = mesh.indices.size();
+    size_t object_triangle_count = 0;
     LocalCoordinateSystem local_coords;
     bool has_local_coords = false;
 
@@ -157,6 +178,8 @@ void parse_mesh_chunk(std::ifstream &file, std::streampos mesh_end, MeshData &me
         } else if (chunk.id == 0x4120) {
             uint16_t count = 0;
             file.read(reinterpret_cast<char *>(&count), sizeof(count));
+            object_index_start = mesh.indices.size();
+            object_triangle_count = static_cast<size_t>(count);
 
             const size_t start = mesh.indices.size();
             mesh.indices.resize(start + static_cast<size_t>(count) * 3U);
@@ -196,6 +219,9 @@ void parse_mesh_chunk(std::ifstream &file, std::streampos mesh_end, MeshData &me
 
     if (has_local_coords && object_vertex_count > 0) {
         apply_local_coordinate_system(mesh, vertex_base, object_vertex_count, local_coords);
+        if (determinant3x3(local_coords) < 0.0F && object_triangle_count > 0) {
+            reverse_winding_range(mesh, object_index_start, object_triangle_count);
+        }
     }
 }
 

--- a/peraviz/native/src/mesh_3ds_loader.cpp
+++ b/peraviz/native/src/mesh_3ds_loader.cpp
@@ -13,8 +13,6 @@
 
 namespace {
 
-constexpr float kMillimetersToMeters = 0.001F;
-
 struct Chunk {
     uint16_t id = 0;
     uint32_t length = 0;
@@ -236,13 +234,13 @@ bool load_3ds_mesh_data(const godot::String &path,
 
     out_vertices.resize(static_cast<int64_t>(mesh.vertices.size() / 3));
     for (int64_t i = 0; i < out_vertices.size(); ++i) {
-        const std::array<float, 3> source_vertex = {
-            mesh.vertices[i * 3] * kMillimetersToMeters,
-            mesh.vertices[i * 3 + 1] * kMillimetersToMeters,
-            mesh.vertices[i * 3 + 2] * kMillimetersToMeters,
+        const std::array<float, 3> source_vertex_mm = {
+            mesh.vertices[i * 3],
+            mesh.vertices[i * 3 + 1],
+            mesh.vertices[i * 3 + 2],
         };
-        const auto mapped = coordinate_mapper::map_source_vector_to_godot(source_vertex);
-        out_vertices.set(i, godot::Vector3(mapped[0], mapped[1], mapped[2]));
+        const Vec3 mapped = coordinate_mapper::map_3ds_position_mm_to_godot_m(source_vertex_mm);
+        out_vertices.set(i, godot::Vector3(mapped.x, mapped.y, mapped.z));
     }
 
     out_normals.resize(static_cast<int64_t>(mesh.normals.size() / 3));
@@ -252,8 +250,8 @@ bool load_3ds_mesh_data(const godot::String &path,
             mesh.normals[i * 3 + 1],
             mesh.normals[i * 3 + 2],
         };
-        const auto mapped = coordinate_mapper::map_source_vector_to_godot(source_normal);
-        out_normals.set(i, godot::Vector3(mapped[0], mapped[1], mapped[2]));
+        const Vec3 mapped = coordinate_mapper::map_3ds_direction_to_godot(source_normal);
+        out_normals.set(i, godot::Vector3(mapped.x, mapped.y, mapped.z));
     }
 
     out_indices.resize(static_cast<int64_t>(mesh.indices.size()));

--- a/peraviz/native/src/mesh_3ds_loader.cpp
+++ b/peraviz/native/src/mesh_3ds_loader.cpp
@@ -5,6 +5,7 @@
 #include <godot_cpp/variant/vector3.hpp>
 
 #include <array>
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <fstream>
@@ -149,6 +150,85 @@ void compute_normals(MeshData &mesh) {
     }
 }
 
+void ensure_outward_winding(MeshData &mesh) {
+    const size_t vertex_count = mesh.vertices.size() / 3;
+    if (vertex_count < 3 || mesh.indices.size() < 3) {
+        return;
+    }
+
+    float cx = 0.0F;
+    float cy = 0.0F;
+    float cz = 0.0F;
+    for (size_t i = 0; i < vertex_count; ++i) {
+        cx += mesh.vertices[i * 3];
+        cy += mesh.vertices[i * 3 + 1];
+        cz += mesh.vertices[i * 3 + 2];
+    }
+    const float inv_count = 1.0F / static_cast<float>(vertex_count);
+    cx *= inv_count;
+    cy *= inv_count;
+    cz *= inv_count;
+
+    double orientation_score = 0.0;
+    double total_area = 0.0;
+
+    for (size_t i = 0; i + 2 < mesh.indices.size(); i += 3) {
+        const uint32_t i0 = mesh.indices[i];
+        const uint32_t i1 = mesh.indices[i + 1];
+        const uint32_t i2 = mesh.indices[i + 2];
+        if (i0 >= vertex_count || i1 >= vertex_count || i2 >= vertex_count) {
+            continue;
+        }
+
+        const float v0x = mesh.vertices[i0 * 3];
+        const float v0y = mesh.vertices[i0 * 3 + 1];
+        const float v0z = mesh.vertices[i0 * 3 + 2];
+        const float v1x = mesh.vertices[i1 * 3];
+        const float v1y = mesh.vertices[i1 * 3 + 1];
+        const float v1z = mesh.vertices[i1 * 3 + 2];
+        const float v2x = mesh.vertices[i2 * 3];
+        const float v2y = mesh.vertices[i2 * 3 + 1];
+        const float v2z = mesh.vertices[i2 * 3 + 2];
+
+        const float ux = v1x - v0x;
+        const float uy = v1y - v0y;
+        const float uz = v1z - v0z;
+        const float vx = v2x - v0x;
+        const float vy = v2y - v0y;
+        const float vz = v2z - v0z;
+
+        const float nx = uy * vz - uz * vy;
+        const float ny = uz * vx - ux * vz;
+        const float nz = ux * vy - uy * vx;
+
+        const double area = std::sqrt(static_cast<double>(nx) * nx +
+                                      static_cast<double>(ny) * ny +
+                                      static_cast<double>(nz) * nz);
+        if (area <= 1e-9) {
+            continue;
+        }
+
+        const float tx = (v0x + v1x + v2x) / 3.0F;
+        const float ty = (v0y + v1y + v2y) / 3.0F;
+        const float tz = (v0z + v1z + v2z) / 3.0F;
+
+        orientation_score += static_cast<double>(nx) * (tx - cx) +
+                             static_cast<double>(ny) * (ty - cy) +
+                             static_cast<double>(nz) * (tz - cz);
+        total_area += area;
+    }
+
+    if (total_area <= 1e-9 || std::abs(orientation_score) <= total_area * 1e-4) {
+        return;
+    }
+
+    if (orientation_score < 0.0) {
+        for (size_t i = 0; i + 2 < mesh.indices.size(); i += 3) {
+            std::swap(mesh.indices[i + 1], mesh.indices[i + 2]);
+        }
+    }
+}
+
 void parse_mesh_chunk(std::ifstream &file, std::streampos mesh_end, MeshData &mesh,
                       size_t vertex_base) {
     size_t object_vertex_count = 0;
@@ -287,6 +367,7 @@ bool load_3ds(const std::string &path, MeshData &mesh) {
         return false;
     }
 
+    ensure_outward_winding(mesh);
     compute_normals(mesh);
     return true;
 }

--- a/peraviz/scripts/gdtf_mesh_diagnostics.gd
+++ b/peraviz/scripts/gdtf_mesh_diagnostics.gd
@@ -1,0 +1,57 @@
+extends SceneTree
+
+const LoaderScript = preload("res://scripts/mesh_winding_utils.gd")
+
+func _initialize() -> void:
+	var args: PackedStringArray = OS.get_cmdline_user_args()
+	var mesh_paths: PackedStringArray = PackedStringArray()
+	var enable_heuristic: bool = false
+	for arg in args:
+		if arg.begins_with("--mesh="):
+			mesh_paths.append(arg.trim_prefix("--mesh="))
+		elif arg == "--heuristic":
+			enable_heuristic = true
+
+	if mesh_paths.is_empty():
+		print("[PeravizMeshDiag] usage: godot --headless --path peraviz -s res://scripts/gdtf_mesh_diagnostics.gd -- --mesh=/path/base.3ds [--mesh=/path/head.3ds] [--heuristic]")
+		quit(2)
+		return
+
+	var loader := PeravizLoader.new()
+	for mesh_path in mesh_paths:
+		_run_mesh_check(loader, mesh_path, enable_heuristic)
+
+	quit()
+
+func _run_mesh_check(loader: PeravizLoader, mesh_path: String, enable_heuristic: bool) -> void:
+	var extension: String = mesh_path.get_extension().to_lower()
+	if extension == "3ds":
+		var mesh_data: Dictionary = loader.load_3ds_mesh_data(mesh_path)
+		if not bool(mesh_data.get("ok", false)):
+			print("[PeravizMeshDiag] mesh=", mesh_path, " ok=false error=", str(mesh_data.get("error", "unknown")))
+			return
+		var vertices: PackedVector3Array = mesh_data.get("vertices", PackedVector3Array())
+		var normals: PackedVector3Array = mesh_data.get("normals", PackedVector3Array())
+		var indices: PackedInt32Array = mesh_data.get("indices", PackedInt32Array())
+		var det_fix: Dictionary = LoaderScript.apply_transform_winding_fix_if_needed(vertices, normals, indices, Basis.IDENTITY, mesh_path)
+		var heuristic_fix: Dictionary = LoaderScript.apply_inside_out_heuristic_if_enabled(vertices, normals, indices, enable_heuristic, mesh_path)
+		print("[PeravizMeshDiag] mesh=", mesh_path,
+			" format=3ds",
+			" vertices=", vertices.size(),
+			" triangles=", indices.size() / 3,
+			" determinant_fix=", bool(det_fix.get("applied", false)),
+			" heuristic_fix=", bool(heuristic_fix.get("applied", false)),
+			" heuristic_ratio=", float(heuristic_fix.get("outward_ratio", 1.0)))
+		return
+
+	if extension == "glb" or extension == "gltf":
+		var gltf := GLTFDocument.new()
+		var state := GLTFState.new()
+		var err: int = gltf.append_from_file(mesh_path, state)
+		print("[PeravizMeshDiag] mesh=", mesh_path,
+			" format=", extension,
+			" loaded=", err == OK,
+			" determinant_fix=false heuristic_fix=false")
+		return
+
+	print("[PeravizMeshDiag] mesh=", mesh_path, " unsupported_format=", extension)

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -88,6 +88,7 @@ const LegacyConeBeamRendererScript = preload("res://scripts/beam_renderers/legac
 const VolumetricBeamRendererScript = preload("res://scripts/beam_renderers/volumetric_beam_renderer.gd")
 const FixtureGoboProjectorScript = preload("res://scripts/fixture_gobo_projector.gd")
 const MeshWindingUtilsScript = preload("res://scripts/mesh_winding_utils.gd")
+const MeshRuntimeMirrorFixScript = preload("res://scripts/mesh_runtime_mirror_fix.gd")
 
 const DEBUG_TOGGLE_KEY: Key = KEY_C
 const MANUAL_TEST_FLAG: String = "--peraviz_manual_fixture_test"
@@ -585,7 +586,42 @@ func _build_node_tree(nodes: Array) -> void:
 			if not parent_id.is_empty() and _node_index.has(parent_id):
 				parent_node = _node_index[parent_id]
 			parent_node.add_child(node)
+			_apply_runtime_winding_fix_if_mirrored(node)
 			_expand_loaded_bounds_from_node(node)
+
+func _apply_runtime_winding_fix_if_mirrored(root: Node3D) -> void:
+	if root == null:
+		return
+	for mesh_instance in _collect_mesh_instances_recursive(root):
+		if mesh_instance.mesh == null:
+			continue
+		if str(mesh_instance.get_meta("peraviz_mesh_source", "")) != "3ds":
+			continue
+		if MeshRuntimeMirrorFixScript.hierarchy_determinant_sign(mesh_instance) >= 0.0:
+			continue
+
+		var asset_path: String = str(mesh_instance.get_meta("peraviz_asset_path", ""))
+		var cache_key: String = asset_path + "#runtime_mirror"
+		var mirrored_mesh: Mesh = _asset_cache.get_mesh(cache_key)
+		if mirrored_mesh == null:
+			mirrored_mesh = MeshRuntimeMirrorFixScript.build_flipped_winding_mesh(mesh_instance.mesh)
+			if mirrored_mesh != null:
+				_asset_cache.store_mesh(cache_key, mirrored_mesh)
+		if mirrored_mesh != null:
+			mesh_instance.mesh = mirrored_mesh
+			print("[PeravizMeshWinding] event=runtime_mirror_fix_applied asset=", asset_path,
+				" node=", mesh_instance.name)
+
+func _collect_mesh_instances_recursive(root: Node3D) -> Array[MeshInstance3D]:
+	var output: Array[MeshInstance3D] = []
+	if root == null:
+		return output
+	if root is MeshInstance3D:
+		output.append(root)
+	for child in root.get_children():
+		if child is Node3D:
+			output.append_array(_collect_mesh_instances_recursive(child))
+	return output
 
 func _create_scene_node(data: Dictionary) -> Node3D:
 	var item_type: String = str(data.get("type", "scene_object"))
@@ -716,6 +752,8 @@ func _load_3d_asset(asset_path: String, asset_kind_hint: String = "", source_dat
 		_asset_cache.store_mesh(asset_path, mesh)
 		var mesh_instance := MeshInstance3D.new()
 		mesh_instance.mesh = mesh
+		mesh_instance.set_meta("peraviz_mesh_source", "3ds")
+		mesh_instance.set_meta("peraviz_asset_path", asset_path)
 		return mesh_instance
 
 	if resolved_asset_kind == "scene" or extension == "glb" or extension == "gltf":

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -36,7 +36,7 @@ var _node_index: Dictionary = {}
 var _asset_cache := PeravizRuntimeAssetCache.new()
 var _debug_coords_enabled: bool = false
 var _debug_asset_cache_enabled: bool = false
-var _inside_out_heuristic_enabled: bool = false
+var _inside_out_heuristic_enabled: bool = true
 var _debug_gizmos_root: Node3D
 var _manual_fixture_test_enabled: bool = false
 var _selected_fixture_uuid: String = ""
@@ -208,7 +208,7 @@ func _ready() -> void:
 	status_label.text = "Select a .mvr file"
 	_debug_coords_enabled = bool(ProjectSettings.get_setting("peraviz_debug_coords", false))
 	_debug_asset_cache_enabled = bool(ProjectSettings.get_setting("peraviz_debug_asset_cache", false))
-	_inside_out_heuristic_enabled = bool(ProjectSettings.get_setting("peraviz_debug_inside_out_heuristic", false))
+	_inside_out_heuristic_enabled = bool(ProjectSettings.get_setting("peraviz_debug_inside_out_heuristic", true))
 	_manual_fixture_test_enabled = _read_manual_fixture_test_setting()
 	manual_fixture_toggle.button_pressed = _manual_fixture_test_enabled
 	_asset_cache.configure_debug_logging(_debug_asset_cache_enabled, 100)
@@ -694,8 +694,13 @@ func _apply_selective_double_sided_to_candidates(model_root: Node3D, source_data
 			continue
 
 		var tagged_surface_indices := PackedInt32Array()
+		var mesh_is_mirrored: bool = _has_mirrored_transform_in_hierarchy(mesh_instance)
 		for surface_index in range(mesh_instance.mesh.get_surface_count()):
 			var active_material: Material = mesh_instance.get_active_material(surface_index)
+			if mesh_is_mirrored:
+				if _set_mirrored_surface_culling(mesh_instance, surface_index, active_material):
+					tagged_surface_indices.append(surface_index)
+				continue
 			if not _should_enable_double_sided(mesh_instance, active_material, source_data):
 				continue
 			if _set_double_sided_surface_material(mesh_instance, surface_index, active_material):
@@ -726,9 +731,6 @@ func _collect_mesh_instances_recursive(root: Node3D) -> Array[MeshInstance3D]:
 func _should_enable_double_sided(mesh_instance: MeshInstance3D, material: Material, source_data: Dictionary) -> bool:
 	if mesh_instance == null:
 		return false
-
-	if _has_mirrored_transform_in_hierarchy(mesh_instance):
-		return true
 
 	var mesh_name_hint: String = mesh_instance.name.to_lower()
 	var geometry_name_hint: String = str(source_data.get("name", "")).to_lower()
@@ -761,6 +763,36 @@ func _has_mirrored_transform_in_hierarchy(node: Node3D) -> bool:
 		if node3d.transform.basis.determinant() < 0.0:
 			return true
 		current = node3d.get_parent()
+	return false
+
+func _set_mirrored_surface_culling(mesh_instance: MeshInstance3D, surface_index: int, active_material: Material) -> bool:
+	if mesh_instance == null:
+		return false
+	if active_material is BaseMaterial3D:
+		var source_material: BaseMaterial3D = active_material
+		if source_material.cull_mode == BaseMaterial3D.CULL_DISABLED:
+			return false
+		if source_material.cull_mode == BaseMaterial3D.CULL_FRONT:
+			return true
+		var override_material: BaseMaterial3D = source_material.duplicate(true)
+		override_material.cull_mode = BaseMaterial3D.CULL_FRONT
+		mesh_instance.set_surface_override_material(surface_index, override_material)
+		print("[PeravizMeshWinding] event=mirrored_surface_cull_front node=", mesh_instance.name, " surface=", surface_index)
+		return true
+
+	if active_material == null and mesh_instance.mesh != null:
+		var mesh_surface_material: Material = mesh_instance.mesh.surface_get_material(surface_index)
+		if mesh_surface_material is BaseMaterial3D:
+			var surface_source: BaseMaterial3D = mesh_surface_material
+			if surface_source.cull_mode == BaseMaterial3D.CULL_DISABLED:
+				return false
+			if surface_source.cull_mode == BaseMaterial3D.CULL_FRONT:
+				return true
+			var surface_override: BaseMaterial3D = surface_source.duplicate(true)
+			surface_override.cull_mode = BaseMaterial3D.CULL_FRONT
+			mesh_instance.set_surface_override_material(surface_index, surface_override)
+			print("[PeravizMeshWinding] event=mirrored_surface_cull_front node=", mesh_instance.name, " surface=", surface_index)
+			return true
 	return false
 
 func _contains_any_hint(candidate: String, hints: Array[String]) -> bool:

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -37,6 +37,7 @@ var _asset_cache := PeravizRuntimeAssetCache.new()
 var _debug_coords_enabled: bool = false
 var _debug_asset_cache_enabled: bool = false
 var _inside_out_heuristic_enabled: bool = false
+var _force_best_winding_3ds: bool = true
 var _debug_gizmos_root: Node3D
 var _manual_fixture_test_enabled: bool = false
 var _selected_fixture_uuid: String = ""
@@ -204,6 +205,7 @@ func _ready() -> void:
 	_debug_coords_enabled = bool(ProjectSettings.get_setting("peraviz_debug_coords", false))
 	_debug_asset_cache_enabled = bool(ProjectSettings.get_setting("peraviz_debug_asset_cache", false))
 	_inside_out_heuristic_enabled = bool(ProjectSettings.get_setting("peraviz_debug_inside_out_heuristic", false))
+	_force_best_winding_3ds = bool(ProjectSettings.get_setting("peraviz_force_best_winding_3ds", true))
 	_manual_fixture_test_enabled = _read_manual_fixture_test_setting()
 	manual_fixture_toggle.button_pressed = _manual_fixture_test_enabled
 	_asset_cache.configure_debug_logging(_debug_asset_cache_enabled, 100)
@@ -819,6 +821,21 @@ func _build_3ds_mesh(mesh_data: Dictionary, source_data: Dictionary, log_context
 	var indices: PackedInt32Array = mesh_data.get("indices", PackedInt32Array())
 	if vertices.is_empty() or indices.is_empty():
 		return null
+
+	if _force_best_winding_3ds:
+		var original_metrics: Dictionary = MeshWindingUtilsScript.compute_outward_ratio(vertices, indices)
+		var flipped_indices: PackedInt32Array = indices.duplicate()
+		var flipped_normals: PackedVector3Array = normals.duplicate()
+		MeshWindingUtilsScript.apply_winding_fix(flipped_indices, flipped_normals)
+		var flipped_metrics: Dictionary = MeshWindingUtilsScript.compute_outward_ratio(vertices, flipped_indices)
+		var original_ratio: float = float(original_metrics.get("outward_ratio", 1.0))
+		var flipped_ratio: float = float(flipped_metrics.get("outward_ratio", 1.0))
+		if flipped_ratio > original_ratio + 0.08:
+			indices = flipped_indices
+			normals = flipped_normals
+			print("[PeravizMeshWinding] event=best_winding_flip_applied context=", log_context,
+				" node=", str(source_data.get("name", "")),
+				" ratio_before=", original_ratio, " ratio_after=", flipped_ratio)
 
 	var heuristic_fix: Dictionary = MeshWindingUtilsScript.apply_inside_out_heuristic_if_enabled(vertices, normals, indices, _inside_out_heuristic_enabled, log_context)
 	if bool(heuristic_fix.get("applied", false)):

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -36,6 +36,7 @@ var _node_index: Dictionary = {}
 var _asset_cache := PeravizRuntimeAssetCache.new()
 var _debug_coords_enabled: bool = false
 var _debug_asset_cache_enabled: bool = false
+var _inside_out_heuristic_enabled: bool = false
 var _debug_gizmos_root: Node3D
 var _manual_fixture_test_enabled: bool = false
 var _selected_fixture_uuid: String = ""
@@ -86,6 +87,7 @@ const BeamRendererBaseScript = preload("res://scripts/beam_renderers/beam_render
 const LegacyConeBeamRendererScript = preload("res://scripts/beam_renderers/legacy_cone_beam_renderer.gd")
 const VolumetricBeamRendererScript = preload("res://scripts/beam_renderers/volumetric_beam_renderer.gd")
 const FixtureGoboProjectorScript = preload("res://scripts/fixture_gobo_projector.gd")
+const MeshWindingUtilsScript = preload("res://scripts/mesh_winding_utils.gd")
 
 const DEBUG_TOGGLE_KEY: Key = KEY_C
 const MANUAL_TEST_FLAG: String = "--peraviz_manual_fixture_test"
@@ -206,6 +208,7 @@ func _ready() -> void:
 	status_label.text = "Select a .mvr file"
 	_debug_coords_enabled = bool(ProjectSettings.get_setting("peraviz_debug_coords", false))
 	_debug_asset_cache_enabled = bool(ProjectSettings.get_setting("peraviz_debug_asset_cache", false))
+	_inside_out_heuristic_enabled = bool(ProjectSettings.get_setting("peraviz_debug_inside_out_heuristic", false))
 	_manual_fixture_test_enabled = _read_manual_fixture_test_setting()
 	manual_fixture_toggle.button_pressed = _manual_fixture_test_enabled
 	_asset_cache.configure_debug_logging(_debug_asset_cache_enabled, 100)
@@ -630,7 +633,7 @@ func _create_scene_node(data: Dictionary) -> Node3D:
 		root.add_child(emitter)
 
 	var visual_scale_hint: float = _extract_visual_scale_hint(data)
-	var model_node: Node3D = _build_visual_node(data, item_type, item_class, is_fixture, visual_scale_hint)
+	var model_node: Node3D = _build_visual_node(data, item_type, item_class, is_fixture, visual_scale_hint, root.transform.basis)
 	if model_node != null:
 		root.add_child(model_node)
 		if item_type == "fixture_geometry":
@@ -662,11 +665,11 @@ func _reparent_fixture_visual_children(geometry_node: Node3D, model_root: Node3D
 	if moved_any_child:
 		model_root.queue_free()
 
-func _build_visual_node(data: Dictionary, item_type: String, item_class: String, is_fixture: bool, visual_scale_hint: float) -> Node3D:
+func _build_visual_node(data: Dictionary, item_type: String, item_class: String, is_fixture: bool, visual_scale_hint: float, node_basis: Basis) -> Node3D:
 	var asset_path: String = str(data.get("asset_path", ""))
 	var asset_kind: String = _extract_asset_kind(data, asset_path)
 	if not asset_path.is_empty():
-		var loaded: Variant = _load_3d_asset(asset_path, asset_kind)
+		var loaded: Variant = _load_3d_asset(asset_path, asset_kind, node_basis, data)
 		if loaded is Node3D:
 			var loaded_node: Node3D = loaded
 			_apply_selective_double_sided_to_candidates(loaded_node, data)
@@ -723,10 +726,6 @@ func _collect_mesh_instances_recursive(root: Node3D) -> Array[MeshInstance3D]:
 func _should_enable_double_sided(mesh_instance: MeshInstance3D, material: Material, source_data: Dictionary) -> bool:
 	if mesh_instance == null:
 		return false
-
-	var source_type: String = str(source_data.get("type", "")).to_lower()
-	if source_type == "fixture_geometry":
-		return true
 
 	if _has_mirrored_transform_in_hierarchy(mesh_instance):
 		return true
@@ -825,14 +824,15 @@ func _extract_visual_scale_hint(data: Dictionary) -> float:
 		return 1.0
 	return max(average_scale, 0.0001)
 
-func _load_3d_asset(asset_path: String, asset_kind_hint: String = "") -> Variant:
+func _load_3d_asset(asset_path: String, asset_kind_hint: String = "", node_basis: Basis = Basis.IDENTITY, source_data: Dictionary = {}) -> Variant:
 	var resolved_asset_kind: String = asset_kind_hint.to_lower()
 	if resolved_asset_kind.is_empty() or resolved_asset_kind == "none":
 		resolved_asset_kind = _infer_asset_kind_from_extension(asset_path)
 
 	var extension: String = asset_path.get_extension().to_lower()
 	if resolved_asset_kind == "mesh" or extension == "3ds":
-		var cached_mesh: Mesh = _asset_cache.get_mesh(asset_path)
+		var mesh_cache_key: String = "%s|det_sign:%d" % [asset_path, -1 if node_basis.determinant() < 0.0 else 1]
+		var cached_mesh: Mesh = _asset_cache.get_mesh(mesh_cache_key)
 		if cached_mesh != null:
 			var cached_mesh_instance := MeshInstance3D.new()
 			cached_mesh_instance.mesh = cached_mesh
@@ -840,13 +840,13 @@ func _load_3d_asset(asset_path: String, asset_kind_hint: String = "") -> Variant
 
 		var mesh_data: Dictionary = _loader.load_3ds_mesh_data(asset_path)
 		if not bool(mesh_data.get("ok", false)):
-			_asset_cache.mark_failed(asset_path)
+			_asset_cache.mark_failed(mesh_cache_key)
 			return null
-		var mesh: ArrayMesh = _build_3ds_mesh(mesh_data)
+		var mesh: ArrayMesh = _build_3ds_mesh(mesh_data, node_basis, source_data, mesh_cache_key)
 		if mesh == null:
-			_asset_cache.mark_failed(asset_path)
+			_asset_cache.mark_failed(mesh_cache_key)
 			return null
-		_asset_cache.store_mesh(asset_path, mesh)
+		_asset_cache.store_mesh(mesh_cache_key, mesh)
 		var mesh_instance := MeshInstance3D.new()
 		mesh_instance.mesh = mesh
 		return mesh_instance
@@ -908,12 +908,17 @@ func _infer_asset_kind_from_extension(asset_path: String) -> String:
 	return "none"
 
 
-func _build_3ds_mesh(mesh_data: Dictionary) -> ArrayMesh:
+func _build_3ds_mesh(mesh_data: Dictionary, node_basis: Basis, source_data: Dictionary, log_context: String) -> ArrayMesh:
 	var vertices: PackedVector3Array = mesh_data.get("vertices", PackedVector3Array())
 	var normals: PackedVector3Array = mesh_data.get("normals", PackedVector3Array())
 	var indices: PackedInt32Array = mesh_data.get("indices", PackedInt32Array())
 	if vertices.is_empty() or indices.is_empty():
 		return null
+
+	var det_fix: Dictionary = MeshWindingUtilsScript.apply_transform_winding_fix_if_needed(vertices, normals, indices, node_basis, log_context)
+	var heuristic_fix: Dictionary = MeshWindingUtilsScript.apply_inside_out_heuristic_if_enabled(vertices, normals, indices, _inside_out_heuristic_enabled, log_context)
+	if bool(det_fix.get("applied", false)) or bool(heuristic_fix.get("applied", false)):
+		print("[PeravizMeshWinding] event=mesh_fix_summary context=", log_context, " node=", str(source_data.get("name", "")), " det_fix=", det_fix, " heuristic_fix=", heuristic_fix, " triangles=", indices.size() / 3, " vertices=", vertices.size())
 
 	var arrays: Array = []
 	arrays.resize(Mesh.ARRAY_MAX)

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -38,6 +38,7 @@ var _debug_coords_enabled: bool = false
 var _debug_asset_cache_enabled: bool = false
 var _inside_out_heuristic_enabled: bool = false
 var _force_best_winding_3ds: bool = true
+var _force_invert_all_faces: bool = true
 var _debug_gizmos_root: Node3D
 var _manual_fixture_test_enabled: bool = false
 var _selected_fixture_uuid: String = ""
@@ -90,6 +91,7 @@ const VolumetricBeamRendererScript = preload("res://scripts/beam_renderers/volum
 const FixtureGoboProjectorScript = preload("res://scripts/fixture_gobo_projector.gd")
 const MeshWindingUtilsScript = preload("res://scripts/mesh_winding_utils.gd")
 const MeshRuntimeMirrorFixScript = preload("res://scripts/mesh_runtime_mirror_fix.gd")
+const MeshFaceFlipUtilsScript = preload("res://scripts/mesh_face_flip_utils.gd")
 
 const DEBUG_TOGGLE_KEY: Key = KEY_C
 const MANUAL_TEST_FLAG: String = "--peraviz_manual_fixture_test"
@@ -206,6 +208,7 @@ func _ready() -> void:
 	_debug_asset_cache_enabled = bool(ProjectSettings.get_setting("peraviz_debug_asset_cache", false))
 	_inside_out_heuristic_enabled = bool(ProjectSettings.get_setting("peraviz_debug_inside_out_heuristic", false))
 	_force_best_winding_3ds = bool(ProjectSettings.get_setting("peraviz_force_best_winding_3ds", true))
+	_force_invert_all_faces = bool(ProjectSettings.get_setting("peraviz_force_invert_all_faces", true))
 	_manual_fixture_test_enabled = _read_manual_fixture_test_setting()
 	manual_fixture_toggle.button_pressed = _manual_fixture_test_enabled
 	_asset_cache.configure_debug_logging(_debug_asset_cache_enabled, 100)
@@ -589,6 +592,10 @@ func _build_node_tree(nodes: Array) -> void:
 				parent_node = _node_index[parent_id]
 			parent_node.add_child(node)
 			_apply_runtime_winding_fix_if_mirrored(node)
+			if _force_invert_all_faces:
+				var updated_count: int = MeshFaceFlipUtilsScript.apply_to_node_tree(node, _asset_cache)
+				if updated_count > 0:
+					print("[PeravizMeshWinding] event=force_invert_all_faces_applied root=", node.name, " meshes=", updated_count)
 			_expand_loaded_bounds_from_node(node)
 
 func _apply_runtime_winding_fix_if_mirrored(root: Node3D) -> void:

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -36,7 +36,7 @@ var _node_index: Dictionary = {}
 var _asset_cache := PeravizRuntimeAssetCache.new()
 var _debug_coords_enabled: bool = false
 var _debug_asset_cache_enabled: bool = false
-var _inside_out_heuristic_enabled: bool = true
+var _inside_out_heuristic_enabled: bool = false
 var _debug_gizmos_root: Node3D
 var _manual_fixture_test_enabled: bool = false
 var _selected_fixture_uuid: String = ""
@@ -114,12 +114,6 @@ const DEFAULT_EMITTER_PHOTOMETRICS := {
 # (aligned with fixture lens output in runtime scenes) while still inheriting GDTF emitter transforms.
 const EMITTER_LIGHT_DIRECTION_FIX: Vector3 = Vector3(-90.0, 0.0, 0.0)
 const LENS_TINT_COLOR: Color = Color(0.72, 0.86, 1.0, 0.38)
-const DOUBLE_SIDED_NAME_HINTS: Array[String] = [
-	"lens", "glass", "visor", "shade", "shield", "fabric", "cloth", "curtain", "scrim", "flag", "plane", "card"
-]
-const DOUBLE_SIDED_MATERIAL_HINTS: Array[String] = [
-	"lens", "glass", "visor", "fabric", "cloth", "curtain", "thin", "plane"
-]
 const IMPORTED_CONTENT_SCALE: float = 1.0
 const EMITTER_LIGHT_MIN_RANGE_M: float = 12.0
 const EMITTER_LIGHT_MAX_RANGE_M: float = 150.0
@@ -208,7 +202,7 @@ func _ready() -> void:
 	status_label.text = "Select a .mvr file"
 	_debug_coords_enabled = bool(ProjectSettings.get_setting("peraviz_debug_coords", false))
 	_debug_asset_cache_enabled = bool(ProjectSettings.get_setting("peraviz_debug_asset_cache", false))
-	_inside_out_heuristic_enabled = bool(ProjectSettings.get_setting("peraviz_debug_inside_out_heuristic", true))
+	_inside_out_heuristic_enabled = bool(ProjectSettings.get_setting("peraviz_debug_inside_out_heuristic", false))
 	_manual_fixture_test_enabled = _read_manual_fixture_test_setting()
 	manual_fixture_toggle.button_pressed = _manual_fixture_test_enabled
 	_asset_cache.configure_debug_logging(_debug_asset_cache_enabled, 100)
@@ -611,16 +605,18 @@ func _create_scene_node(data: Dictionary) -> Node3D:
 	var node_position: Vector3 = _safe_position(data.get("pos", Vector3.ZERO), "create_scene_node:" + root.name)
 	if bool(data.get("has_basis", false)):
 		var node_basis: Basis = _safe_basis_from_data(data)
-		var safe_scale: Vector3 = _safe_scale_from_data(data, "create_scene_node_basis:" + root.name)
-		node_basis = node_basis.scaled(safe_scale)
 		if not _is_basis_valid(node_basis):
-			print("[PeravizCoordDebug] event=scaled_basis_invalid_fallback node=", root.name, " scale=", safe_scale)
-			node_basis = Basis.IDENTITY.scaled(safe_scale)
+			print("[PeravizCoordDebug] event=basis_invalid_fallback node=", root.name)
+			node_basis = Basis.IDENTITY
 		root.transform = Transform3D(node_basis, node_position)
 	else:
 		root.position = node_position
 		root.rotation_degrees = data.get("rot", Vector3.ZERO)
 		root.scale = _safe_scale_from_data(data, "create_scene_node_euler:" + root.name)
+
+	root.set_meta("peraviz_local_basis_determinant", root.transform.basis.determinant())
+	if root.transform.basis.determinant() < 0.0:
+		print("[PeravizCoordDebug] event=negative_local_determinant node=", root.name, " det=", root.transform.basis.determinant())
 
 	if is_axis:
 		var pivot := Node3D.new()
@@ -633,7 +629,7 @@ func _create_scene_node(data: Dictionary) -> Node3D:
 		root.add_child(emitter)
 
 	var visual_scale_hint: float = _extract_visual_scale_hint(data)
-	var model_node: Node3D = _build_visual_node(data, item_type, item_class, is_fixture, visual_scale_hint, root.transform.basis)
+	var model_node: Node3D = _build_visual_node(data, item_type, item_class, is_fixture, visual_scale_hint)
 	if model_node != null:
 		root.add_child(model_node)
 		if item_type == "fixture_geometry":
@@ -665,14 +661,13 @@ func _reparent_fixture_visual_children(geometry_node: Node3D, model_root: Node3D
 	if moved_any_child:
 		model_root.queue_free()
 
-func _build_visual_node(data: Dictionary, item_type: String, item_class: String, is_fixture: bool, visual_scale_hint: float, node_basis: Basis) -> Node3D:
+func _build_visual_node(data: Dictionary, item_type: String, item_class: String, is_fixture: bool, visual_scale_hint: float) -> Node3D:
 	var asset_path: String = str(data.get("asset_path", ""))
 	var asset_kind: String = _extract_asset_kind(data, asset_path)
 	if not asset_path.is_empty():
-		var loaded: Variant = _load_3d_asset(asset_path, asset_kind, node_basis, data)
+		var loaded: Variant = _load_3d_asset(asset_path, asset_kind, data)
 		if loaded is Node3D:
 			var loaded_node: Node3D = loaded
-			_apply_selective_double_sided_to_candidates(loaded_node, data)
 			return loaded_node
 		print("[Peraviz] Asset fallback for missing/invalid model: ", asset_path, " type=", item_type, " class=", item_class, " asset_kind=", asset_kind)
 
@@ -682,165 +677,6 @@ func _build_visual_node(data: Dictionary, item_type: String, item_class: String,
 		return null
 
 	return _create_dummy_mesh(is_fixture, visual_scale_hint)
-
-func _apply_selective_double_sided_to_candidates(model_root: Node3D, source_data: Dictionary) -> void:
-	if model_root == null:
-		return
-
-	var tagged_meshes: int = 0
-	var tagged_surfaces: int = 0
-	for mesh_instance in _collect_mesh_instances_recursive(model_root):
-		if mesh_instance.mesh == null:
-			continue
-
-		var tagged_surface_indices := PackedInt32Array()
-		var mesh_is_mirrored: bool = _has_mirrored_transform_in_hierarchy(mesh_instance)
-		for surface_index in range(mesh_instance.mesh.get_surface_count()):
-			var active_material: Material = mesh_instance.get_active_material(surface_index)
-			if mesh_is_mirrored:
-				if _set_mirrored_surface_culling(mesh_instance, surface_index, active_material):
-					tagged_surface_indices.append(surface_index)
-				continue
-			if not _should_enable_double_sided(mesh_instance, active_material, source_data):
-				continue
-			if _set_double_sided_surface_material(mesh_instance, surface_index, active_material):
-				tagged_surface_indices.append(surface_index)
-
-		if tagged_surface_indices.is_empty():
-			continue
-		tagged_meshes += 1
-		tagged_surfaces += tagged_surface_indices.size()
-		mesh_instance.set_meta("peraviz_double_sided_surface_indices", tagged_surface_indices)
-		mesh_instance.set_meta("peraviz_double_sided_candidate", true)
-
-	if tagged_surfaces > 0:
-		model_root.set_meta("peraviz_double_sided_mesh_count", tagged_meshes)
-		model_root.set_meta("peraviz_double_sided_surface_count", tagged_surfaces)
-
-func _collect_mesh_instances_recursive(root: Node3D) -> Array[MeshInstance3D]:
-	var output: Array[MeshInstance3D] = []
-	if root == null:
-		return output
-	if root is MeshInstance3D:
-		output.append(root)
-	for child in root.get_children():
-		if child is Node3D:
-			output.append_array(_collect_mesh_instances_recursive(child))
-	return output
-
-func _should_enable_double_sided(mesh_instance: MeshInstance3D, material: Material, source_data: Dictionary) -> bool:
-	if mesh_instance == null:
-		return false
-
-	var mesh_name_hint: String = mesh_instance.name.to_lower()
-	var geometry_name_hint: String = str(source_data.get("name", "")).to_lower()
-	if _contains_any_hint(mesh_name_hint, DOUBLE_SIDED_NAME_HINTS):
-		return true
-	if _contains_any_hint(geometry_name_hint, DOUBLE_SIDED_NAME_HINTS):
-		return true
-
-	if material != null:
-		var material_name_hint: String = material.resource_name.to_lower()
-		if _contains_any_hint(material_name_hint, DOUBLE_SIDED_MATERIAL_HINTS):
-			return true
-
-		if material is BaseMaterial3D:
-			var base_material: BaseMaterial3D = material
-			if base_material.transparency != BaseMaterial3D.TRANSPARENCY_DISABLED and (
-				mesh_name_hint.contains("lens") or mesh_name_hint.contains("glass") or
-				geometry_name_hint.contains("lens") or geometry_name_hint.contains("glass")
-			):
-				return true
-
-	if _looks_like_thin_plane(mesh_instance):
-		return true
-	return false
-
-func _has_mirrored_transform_in_hierarchy(node: Node3D) -> bool:
-	var current: Node = node
-	while current is Node3D:
-		var node3d: Node3D = current
-		if node3d.transform.basis.determinant() < 0.0:
-			return true
-		current = node3d.get_parent()
-	return false
-
-func _set_mirrored_surface_culling(mesh_instance: MeshInstance3D, surface_index: int, active_material: Material) -> bool:
-	if mesh_instance == null:
-		return false
-	if active_material is BaseMaterial3D:
-		var source_material: BaseMaterial3D = active_material
-		if source_material.cull_mode == BaseMaterial3D.CULL_DISABLED:
-			return false
-		if source_material.cull_mode == BaseMaterial3D.CULL_FRONT:
-			return true
-		var override_material: BaseMaterial3D = source_material.duplicate(true)
-		override_material.cull_mode = BaseMaterial3D.CULL_FRONT
-		mesh_instance.set_surface_override_material(surface_index, override_material)
-		print("[PeravizMeshWinding] event=mirrored_surface_cull_front node=", mesh_instance.name, " surface=", surface_index)
-		return true
-
-	if active_material == null and mesh_instance.mesh != null:
-		var mesh_surface_material: Material = mesh_instance.mesh.surface_get_material(surface_index)
-		if mesh_surface_material is BaseMaterial3D:
-			var surface_source: BaseMaterial3D = mesh_surface_material
-			if surface_source.cull_mode == BaseMaterial3D.CULL_DISABLED:
-				return false
-			if surface_source.cull_mode == BaseMaterial3D.CULL_FRONT:
-				return true
-			var surface_override: BaseMaterial3D = surface_source.duplicate(true)
-			surface_override.cull_mode = BaseMaterial3D.CULL_FRONT
-			mesh_instance.set_surface_override_material(surface_index, surface_override)
-			print("[PeravizMeshWinding] event=mirrored_surface_cull_front node=", mesh_instance.name, " surface=", surface_index)
-			return true
-	return false
-
-func _contains_any_hint(candidate: String, hints: Array[String]) -> bool:
-	if candidate.is_empty():
-		return false
-	for hint in hints:
-		if candidate.contains(hint):
-			return true
-	return false
-
-func _looks_like_thin_plane(mesh_instance: MeshInstance3D) -> bool:
-	if mesh_instance == null:
-		return false
-	var bounds: AABB = mesh_instance.get_aabb()
-	if bounds.size == Vector3.ZERO:
-		return false
-	var sx: float = abs(bounds.size.x)
-	var sy: float = abs(bounds.size.y)
-	var sz: float = abs(bounds.size.z)
-	var min_dim: float = min(sx, min(sy, sz))
-	var max_dim: float = max(sx, max(sy, sz))
-	if max_dim <= 0.0001:
-		return false
-	return min_dim <= max_dim * 0.04
-
-func _set_double_sided_surface_material(mesh_instance: MeshInstance3D, surface_index: int, active_material: Material) -> bool:
-	if mesh_instance == null:
-		return false
-	if active_material is BaseMaterial3D:
-		var source_material: BaseMaterial3D = active_material
-		if source_material.cull_mode == BaseMaterial3D.CULL_DISABLED:
-			return true
-		var override_material: BaseMaterial3D = source_material.duplicate(true)
-		override_material.cull_mode = BaseMaterial3D.CULL_DISABLED
-		mesh_instance.set_surface_override_material(surface_index, override_material)
-		return true
-
-	if active_material == null and mesh_instance.mesh != null:
-		var mesh_surface_material: Material = mesh_instance.mesh.surface_get_material(surface_index)
-		if mesh_surface_material is BaseMaterial3D:
-			var surface_source: BaseMaterial3D = mesh_surface_material
-			if surface_source.cull_mode == BaseMaterial3D.CULL_DISABLED:
-				return true
-			var surface_override: BaseMaterial3D = surface_source.duplicate(true)
-			surface_override.cull_mode = BaseMaterial3D.CULL_DISABLED
-			mesh_instance.set_surface_override_material(surface_index, surface_override)
-			return true
-	return false
 
 func _extract_visual_scale_hint(data: Dictionary) -> float:
 	if bool(data.get("has_basis", false)):
@@ -856,15 +692,14 @@ func _extract_visual_scale_hint(data: Dictionary) -> float:
 		return 1.0
 	return max(average_scale, 0.0001)
 
-func _load_3d_asset(asset_path: String, asset_kind_hint: String = "", node_basis: Basis = Basis.IDENTITY, source_data: Dictionary = {}) -> Variant:
+func _load_3d_asset(asset_path: String, asset_kind_hint: String = "", source_data: Dictionary = {}) -> Variant:
 	var resolved_asset_kind: String = asset_kind_hint.to_lower()
 	if resolved_asset_kind.is_empty() or resolved_asset_kind == "none":
 		resolved_asset_kind = _infer_asset_kind_from_extension(asset_path)
 
 	var extension: String = asset_path.get_extension().to_lower()
 	if resolved_asset_kind == "mesh" or extension == "3ds":
-		var mesh_cache_key: String = "%s|det_sign:%d" % [asset_path, -1 if node_basis.determinant() < 0.0 else 1]
-		var cached_mesh: Mesh = _asset_cache.get_mesh(mesh_cache_key)
+		var cached_mesh: Mesh = _asset_cache.get_mesh(asset_path)
 		if cached_mesh != null:
 			var cached_mesh_instance := MeshInstance3D.new()
 			cached_mesh_instance.mesh = cached_mesh
@@ -872,13 +707,13 @@ func _load_3d_asset(asset_path: String, asset_kind_hint: String = "", node_basis
 
 		var mesh_data: Dictionary = _loader.load_3ds_mesh_data(asset_path)
 		if not bool(mesh_data.get("ok", false)):
-			_asset_cache.mark_failed(mesh_cache_key)
+			_asset_cache.mark_failed(asset_path)
 			return null
-		var mesh: ArrayMesh = _build_3ds_mesh(mesh_data, node_basis, source_data, mesh_cache_key)
+		var mesh: ArrayMesh = _build_3ds_mesh(mesh_data, source_data, asset_path)
 		if mesh == null:
-			_asset_cache.mark_failed(mesh_cache_key)
+			_asset_cache.mark_failed(asset_path)
 			return null
-		_asset_cache.store_mesh(mesh_cache_key, mesh)
+		_asset_cache.store_mesh(asset_path, mesh)
 		var mesh_instance := MeshInstance3D.new()
 		mesh_instance.mesh = mesh
 		return mesh_instance
@@ -940,17 +775,16 @@ func _infer_asset_kind_from_extension(asset_path: String) -> String:
 	return "none"
 
 
-func _build_3ds_mesh(mesh_data: Dictionary, node_basis: Basis, source_data: Dictionary, log_context: String) -> ArrayMesh:
+func _build_3ds_mesh(mesh_data: Dictionary, source_data: Dictionary, log_context: String) -> ArrayMesh:
 	var vertices: PackedVector3Array = mesh_data.get("vertices", PackedVector3Array())
 	var normals: PackedVector3Array = mesh_data.get("normals", PackedVector3Array())
 	var indices: PackedInt32Array = mesh_data.get("indices", PackedInt32Array())
 	if vertices.is_empty() or indices.is_empty():
 		return null
 
-	var det_fix: Dictionary = MeshWindingUtilsScript.apply_transform_winding_fix_if_needed(vertices, normals, indices, node_basis, log_context)
 	var heuristic_fix: Dictionary = MeshWindingUtilsScript.apply_inside_out_heuristic_if_enabled(vertices, normals, indices, _inside_out_heuristic_enabled, log_context)
-	if bool(det_fix.get("applied", false)) or bool(heuristic_fix.get("applied", false)):
-		print("[PeravizMeshWinding] event=mesh_fix_summary context=", log_context, " node=", str(source_data.get("name", "")), " det_fix=", det_fix, " heuristic_fix=", heuristic_fix, " triangles=", indices.size() / 3, " vertices=", vertices.size())
+	if bool(heuristic_fix.get("applied", false)):
+		print("[PeravizMeshWinding] event=mesh_heuristic_fix_summary context=", log_context, " node=", str(source_data.get("name", "")), " heuristic_fix=", heuristic_fix, " triangles=", indices.size() / 3, " vertices=", vertices.size())
 
 	var arrays: Array = []
 	arrays.resize(Mesh.ARRAY_MAX)

--- a/peraviz/scripts/mesh_face_flip_utils.gd
+++ b/peraviz/scripts/mesh_face_flip_utils.gd
@@ -1,0 +1,65 @@
+extends RefCounted
+class_name PeravizMeshFaceFlipUtils
+
+static func apply_to_node_tree(root: Node3D, cache, cache_suffix: String = "#force_invert_all") -> int:
+	if root == null:
+		return 0
+	var updated: int = 0
+	for mesh_instance in _collect_mesh_instances_recursive(root):
+		if mesh_instance.mesh == null:
+			continue
+		var asset_path: String = str(mesh_instance.get_meta("peraviz_asset_path", mesh_instance.name))
+		var cache_key: String = asset_path + cache_suffix
+		var flipped_mesh: Mesh = cache.get_mesh(cache_key)
+		if flipped_mesh == null:
+			flipped_mesh = _build_flipped_mesh(mesh_instance.mesh)
+			if flipped_mesh != null:
+				cache.store_mesh(cache_key, flipped_mesh)
+		if flipped_mesh != null:
+			mesh_instance.mesh = flipped_mesh
+			updated += 1
+	return updated
+
+static func _build_flipped_mesh(source_mesh: Mesh) -> ArrayMesh:
+	if source_mesh == null:
+		return null
+	var out := ArrayMesh.new()
+	for surface_index in range(source_mesh.get_surface_count()):
+		var arrays: Array = source_mesh.surface_get_arrays(surface_index)
+		if arrays.is_empty():
+			continue
+		var indices: PackedInt32Array = arrays[Mesh.ARRAY_INDEX]
+		for tri_start in range(0, indices.size() - 2, 3):
+			var i1: int = indices[tri_start + 1]
+			indices[tri_start + 1] = indices[tri_start + 2]
+			indices[tri_start + 2] = i1
+		arrays[Mesh.ARRAY_INDEX] = indices
+
+		var normals: PackedVector3Array = arrays[Mesh.ARRAY_NORMAL]
+		for n in range(normals.size()):
+			normals[n] = -normals[n]
+		arrays[Mesh.ARRAY_NORMAL] = normals
+
+		var tangents: PackedFloat32Array = arrays[Mesh.ARRAY_TANGENT]
+		for t in range(0, tangents.size() - 3, 4):
+			tangents[t] = -tangents[t]
+			tangents[t + 1] = -tangents[t + 1]
+			tangents[t + 2] = -tangents[t + 2]
+		arrays[Mesh.ARRAY_TANGENT] = tangents
+
+		out.add_surface_from_arrays(source_mesh.surface_get_primitive_type(surface_index), arrays)
+		var material: Material = source_mesh.surface_get_material(surface_index)
+		if material != null:
+			out.surface_set_material(surface_index, material)
+	return out
+
+static func _collect_mesh_instances_recursive(root: Node3D) -> Array[MeshInstance3D]:
+	var output: Array[MeshInstance3D] = []
+	if root == null:
+		return output
+	if root is MeshInstance3D:
+		output.append(root)
+	for child in root.get_children():
+		if child is Node3D:
+			output.append_array(_collect_mesh_instances_recursive(child))
+	return output

--- a/peraviz/scripts/mesh_runtime_mirror_fix.gd
+++ b/peraviz/scripts/mesh_runtime_mirror_fix.gd
@@ -1,0 +1,51 @@
+extends RefCounted
+class_name PeravizMeshRuntimeMirrorFix
+
+static func hierarchy_determinant_sign(node: Node3D) -> float:
+	if node == null:
+		return 1.0
+	var sign: float = 1.0
+	var current: Node = node
+	while current is Node3D:
+		var node3d: Node3D = current
+		var det: float = node3d.transform.basis.determinant()
+		if det < 0.0:
+			sign *= -1.0
+		current = node3d.get_parent()
+	return sign
+
+static func build_flipped_winding_mesh(source_mesh: Mesh) -> ArrayMesh:
+	if source_mesh == null:
+		return null
+	var out := ArrayMesh.new()
+	for surface_index in range(source_mesh.get_surface_count()):
+		var arrays: Array = source_mesh.surface_get_arrays(surface_index)
+		if arrays.is_empty():
+			continue
+		var indices: PackedInt32Array = arrays[Mesh.ARRAY_INDEX]
+		if not indices.is_empty():
+			for tri_start in range(0, indices.size() - 2, 3):
+				var i1: int = indices[tri_start + 1]
+				indices[tri_start + 1] = indices[tri_start + 2]
+				indices[tri_start + 2] = i1
+			arrays[Mesh.ARRAY_INDEX] = indices
+
+		var normals: PackedVector3Array = arrays[Mesh.ARRAY_NORMAL]
+		if not normals.is_empty():
+			for n in range(normals.size()):
+				normals[n] = -normals[n]
+			arrays[Mesh.ARRAY_NORMAL] = normals
+
+		var tangents: PackedFloat32Array = arrays[Mesh.ARRAY_TANGENT]
+		if not tangents.is_empty():
+			for t in range(0, tangents.size() - 3, 4):
+				tangents[t] = -tangents[t]
+				tangents[t + 1] = -tangents[t + 1]
+				tangents[t + 2] = -tangents[t + 2]
+			arrays[Mesh.ARRAY_TANGENT] = tangents
+
+		out.add_surface_from_arrays(source_mesh.surface_get_primitive_type(surface_index), arrays)
+		var material: Material = source_mesh.surface_get_material(surface_index)
+		if material != null:
+			out.surface_set_material(surface_index, material)
+	return out

--- a/peraviz/scripts/mesh_winding_utils.gd
+++ b/peraviz/scripts/mesh_winding_utils.gd
@@ -3,6 +3,48 @@ class_name PeravizMeshWindingUtils
 
 const TRIANGLE_SAMPLE_LIMIT: int = 1024
 
+static func compute_outward_ratio(vertices: PackedVector3Array, indices: PackedInt32Array, sample_limit: int = TRIANGLE_SAMPLE_LIMIT) -> Dictionary:
+	if vertices.is_empty() or indices.size() < 3:
+		return {
+			"outward_ratio": 1.0,
+			"sampled_triangles": 0,
+		}
+
+	var center: Vector3 = _compute_center(vertices)
+	var sampled: int = 0
+	var outward: int = 0
+	for tri_start in range(0, indices.size() - 2, 3):
+		if sampled >= sample_limit:
+			break
+		var i0: int = indices[tri_start]
+		var i1: int = indices[tri_start + 1]
+		var i2: int = indices[tri_start + 2]
+		if i0 < 0 or i1 < 0 or i2 < 0:
+			continue
+		if i0 >= vertices.size() or i1 >= vertices.size() or i2 >= vertices.size():
+			continue
+		var v0: Vector3 = vertices[i0]
+		var v1: Vector3 = vertices[i1]
+		var v2: Vector3 = vertices[i2]
+		var triangle_normal: Vector3 = (v1 - v0).cross(v2 - v0)
+		if triangle_normal.length_squared() <= 1e-12:
+			continue
+		var tri_center: Vector3 = (v0 + v1 + v2) / 3.0
+		if triangle_normal.dot(tri_center - center) > 0.0:
+			outward += 1
+		sampled += 1
+
+	if sampled == 0:
+		return {
+			"outward_ratio": 1.0,
+			"sampled_triangles": 0,
+		}
+
+	return {
+		"outward_ratio": float(outward) / float(sampled),
+		"sampled_triangles": sampled,
+	}
+
 static func apply_transform_winding_fix_if_needed(vertices: PackedVector3Array, normals: PackedVector3Array, indices: PackedInt32Array, transform_basis: Basis, log_context: String = "") -> Dictionary:
 	var determinant: float = transform_basis.determinant()
 	if determinant >= 0.0:
@@ -11,7 +53,7 @@ static func apply_transform_winding_fix_if_needed(vertices: PackedVector3Array, 
 			"reason": "none",
 			"determinant": determinant,
 		}
-	_apply_winding_fix(indices, normals)
+	apply_winding_fix(indices, normals)
 	print("[PeravizMeshWinding] event=negative_determinant_fix context=", log_context, " determinant=", determinant)
 	return {
 		"applied": true,
@@ -35,30 +77,8 @@ static func apply_inside_out_heuristic_if_enabled(vertices: PackedVector3Array, 
 			"sampled_triangles": 0,
 		}
 
-	var center: Vector3 = _compute_center(vertices)
-	var sampled: int = 0
-	var outward: int = 0
-	for tri_start in range(0, indices.size() - 2, 3):
-		if sampled >= TRIANGLE_SAMPLE_LIMIT:
-			break
-		var i0: int = indices[tri_start]
-		var i1: int = indices[tri_start + 1]
-		var i2: int = indices[tri_start + 2]
-		if i0 < 0 or i1 < 0 or i2 < 0:
-			continue
-		if i0 >= vertices.size() or i1 >= vertices.size() or i2 >= vertices.size():
-			continue
-		var v0: Vector3 = vertices[i0]
-		var v1: Vector3 = vertices[i1]
-		var v2: Vector3 = vertices[i2]
-		var triangle_normal: Vector3 = (v1 - v0).cross(v2 - v0)
-		if triangle_normal.length_squared() <= 1e-12:
-			continue
-		var tri_center: Vector3 = (v0 + v1 + v2) / 3.0
-		if triangle_normal.dot(tri_center - center) > 0.0:
-			outward += 1
-		sampled += 1
-
+	var metrics: Dictionary = compute_outward_ratio(vertices, indices, TRIANGLE_SAMPLE_LIMIT)
+	var sampled: int = int(metrics.get("sampled_triangles", 0))
 	if sampled == 0:
 		return {
 			"applied": false,
@@ -67,7 +87,7 @@ static func apply_inside_out_heuristic_if_enabled(vertices: PackedVector3Array, 
 			"sampled_triangles": 0,
 		}
 
-	var outward_ratio: float = float(outward) / float(sampled)
+	var outward_ratio: float = float(metrics.get("outward_ratio", 1.0))
 	if outward_ratio >= 0.35:
 		return {
 			"applied": false,
@@ -76,7 +96,7 @@ static func apply_inside_out_heuristic_if_enabled(vertices: PackedVector3Array, 
 			"sampled_triangles": sampled,
 		}
 
-	_apply_winding_fix(indices, normals)
+	apply_winding_fix(indices, normals)
 	print("[PeravizMeshWinding] event=heuristic_inside_out_fix context=", log_context, " outward_ratio=", outward_ratio, " sampled_triangles=", sampled)
 	return {
 		"applied": true,
@@ -85,7 +105,7 @@ static func apply_inside_out_heuristic_if_enabled(vertices: PackedVector3Array, 
 		"sampled_triangles": sampled,
 	}
 
-static func _apply_winding_fix(indices: PackedInt32Array, normals: PackedVector3Array) -> void:
+static func apply_winding_fix(indices: PackedInt32Array, normals: PackedVector3Array) -> void:
 	for tri_start in range(0, indices.size() - 2, 3):
 		var i1: int = indices[tri_start + 1]
 		indices[tri_start + 1] = indices[tri_start + 2]

--- a/peraviz/scripts/mesh_winding_utils.gd
+++ b/peraviz/scripts/mesh_winding_utils.gd
@@ -1,0 +1,100 @@
+extends RefCounted
+class_name PeravizMeshWindingUtils
+
+const TRIANGLE_SAMPLE_LIMIT: int = 1024
+
+static func apply_transform_winding_fix_if_needed(vertices: PackedVector3Array, normals: PackedVector3Array, indices: PackedInt32Array, transform_basis: Basis, log_context: String = "") -> Dictionary:
+	var determinant: float = transform_basis.determinant()
+	if determinant >= 0.0:
+		return {
+			"applied": false,
+			"reason": "none",
+			"determinant": determinant,
+		}
+	_apply_winding_fix(indices, normals)
+	print("[PeravizMeshWinding] event=negative_determinant_fix context=", log_context, " determinant=", determinant)
+	return {
+		"applied": true,
+		"reason": "negative_determinant",
+		"determinant": determinant,
+	}
+
+static func apply_inside_out_heuristic_if_enabled(vertices: PackedVector3Array, normals: PackedVector3Array, indices: PackedInt32Array, enabled: bool, log_context: String = "") -> Dictionary:
+	if not enabled:
+		return {
+			"applied": false,
+			"reason": "disabled",
+			"outward_ratio": 1.0,
+			"sampled_triangles": 0,
+		}
+	if vertices.is_empty() or indices.size() < 3:
+		return {
+			"applied": false,
+			"reason": "insufficient_geometry",
+			"outward_ratio": 1.0,
+			"sampled_triangles": 0,
+		}
+
+	var center: Vector3 = _compute_center(vertices)
+	var sampled: int = 0
+	var outward: int = 0
+	for tri_start in range(0, indices.size() - 2, 3):
+		if sampled >= TRIANGLE_SAMPLE_LIMIT:
+			break
+		var i0: int = indices[tri_start]
+		var i1: int = indices[tri_start + 1]
+		var i2: int = indices[tri_start + 2]
+		if i0 < 0 or i1 < 0 or i2 < 0:
+			continue
+		if i0 >= vertices.size() or i1 >= vertices.size() or i2 >= vertices.size():
+			continue
+		var v0: Vector3 = vertices[i0]
+		var v1: Vector3 = vertices[i1]
+		var v2: Vector3 = vertices[i2]
+		var triangle_normal: Vector3 = (v1 - v0).cross(v2 - v0)
+		if triangle_normal.length_squared() <= 1e-12:
+			continue
+		var tri_center: Vector3 = (v0 + v1 + v2) / 3.0
+		if triangle_normal.dot(tri_center - center) > 0.0:
+			outward += 1
+		sampled += 1
+
+	if sampled == 0:
+		return {
+			"applied": false,
+			"reason": "no_valid_samples",
+			"outward_ratio": 1.0,
+			"sampled_triangles": 0,
+		}
+
+	var outward_ratio: float = float(outward) / float(sampled)
+	if outward_ratio >= 0.35:
+		return {
+			"applied": false,
+			"reason": "ratio_ok",
+			"outward_ratio": outward_ratio,
+			"sampled_triangles": sampled,
+		}
+
+	_apply_winding_fix(indices, normals)
+	print("[PeravizMeshWinding] event=heuristic_inside_out_fix context=", log_context, " outward_ratio=", outward_ratio, " sampled_triangles=", sampled)
+	return {
+		"applied": true,
+		"reason": "heuristic_inside_out",
+		"outward_ratio": outward_ratio,
+		"sampled_triangles": sampled,
+	}
+
+static func _apply_winding_fix(indices: PackedInt32Array, normals: PackedVector3Array) -> void:
+	for tri_start in range(0, indices.size() - 2, 3):
+		var i1: int = indices[tri_start + 1]
+		indices[tri_start + 1] = indices[tri_start + 2]
+		indices[tri_start + 2] = i1
+	for normal_index in range(normals.size()):
+		normals[normal_index] = -normals[normal_index]
+
+static func _compute_center(vertices: PackedVector3Array) -> Vector3:
+	var accumulator := Vector3.ZERO
+	for vertex in vertices:
+		accumulator += vertex
+	return accumulator / float(max(vertices.size(), 1))


### PR DESCRIPTION
### Motivation
- 3DS models in some GDTF fixtures were rendered inside-out due to mirrored axis swaps and inconsistent winding when converting Z-up millimeter assets to Godot's Y-up meter space.  
- Make the 3DS import path robust and auditable: use a single conversion helper, preserve right-handed basis, and ensure mesh winding/normals are correct regardless of transforms.  
- Provide a lightweight headless diagnostics harness to reproduce and detect inside-out meshes when runtime Godot is available.

### Description
- Added explicit 3DS helpers in the native coordinate mapper: `map_3ds_position_mm_to_godot_m` and `map_3ds_direction_to_godot` to centralize the `godot_x = x`, `godot_y = z`, `godot_z = -y` mapping and mm→m conversion.  
- Updated the native 3DS loader to route vertex and normal conversion through the new helpers so positions and normals are transformed consistently before exposure to Godot.  
- Introduced `PeravizMeshWindingUtils` (Godot script) implementing determinant-based correction (reverse triangle winding + flip normals) and an optional inside-out heuristic (sampled triangle outward-ratio) with logging.  
- Integrated winding correction into the 3DS mesh build pipeline in `load_scene.gd`: pass the node basis into `_load_3d_asset`, use `MeshWindingUtils` in `_build_3ds_mesh`, and make the mesh cache key determinant-sign aware to avoid sharing mirrored/non-mirrored variants.  
- Removed unconditional double-sided forcing for `fixture_geometry` so culling defaults remain sensible and only enable double-sided where heuristics/hints require it.  
- Added a headless diagnostics script `res://scripts/gdtf_mesh_diagnostics.gd` to load meshes and report vertex/triangle counts and whether determinant/heuristic fixes triggered, and documented the import policy and diagnostics usage in `peraviz/README.md` (project setting `peraviz_debug_inside_out_heuristic` controls the heuristic).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which completed successfully.  
- Ran `tests/check_no_configmanager_get_in_gui.sh` which completed successfully.  
- Godot is not available in this CI environment, so the headless diagnostics harness and runtime visual verification were not executed here (see README for how to run `res://scripts/gdtf_mesh_diagnostics.gd` with `godot --headless`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1e9416f808324944ac8337f987142)