### PR TITLE
Use geometric gobo sizing at occluder distance

### DIFF
--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -51,7 +51,7 @@ func ensure_beam(light: SpotLight3D) -> void:
 		gobo_occluder.name = "PeravizGoboOccluder"
 		gobo_occluder.mesh = gobo_mesh
 		gobo_occluder.material_override = _gobo_occluder_material_template.duplicate(true)
-		gobo_occluder.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_ON
+		gobo_occluder.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_SHADOWS_ONLY
 		gobo_occluder.visible = false
 		gobo_occluder.set_disable_scale(true)
 		light.add_child(gobo_occluder)
@@ -151,6 +151,7 @@ func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occlud
 	if gobo_mesh != null:
 		gobo_mesh.size = Vector2(gobo_occluder_plane_size, gobo_occluder_plane_size)
 	gobo_occluder.scale = Vector3.ONE
+	gobo_occluder.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_SHADOWS_ONLY
 	gobo_occluder.position = Vector3(0.0, 0.0, -GOBO_OCCLUDER_DISTANCE_M)
 	gobo_occluder.visible = true
 	gobo_material.set_shader_parameter("gobo_texture", gobo_texture)

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -51,7 +51,7 @@ func ensure_beam(light: SpotLight3D) -> void:
 		gobo_occluder.name = "PeravizGoboOccluder"
 		gobo_occluder.mesh = gobo_mesh
 		gobo_occluder.material_override = _gobo_occluder_material_template.duplicate(true)
-		gobo_occluder.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_SHADOWS_ONLY
+		gobo_occluder.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_ON
 		gobo_occluder.visible = false
 		gobo_occluder.set_disable_scale(true)
 		light.add_child(gobo_occluder)
@@ -88,7 +88,7 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 
 	var half_angle_deg: float = beam_angle * 0.5
 	var tan_half_angle: float = tan(deg_to_rad(half_angle_deg))
-	var radius: float = max(lens_radius, 0.003) + (tan_half_angle * beam_range)
+	var radius: float = tan_half_angle * beam_range
 	var bottom_radius: float = clamp(radius, 0.03, EMITTER_CONE_MAX_BASE_RADIUS_M)
 	var cone_mesh: CylinderMesh = cone.mesh as CylinderMesh
 	if cone_mesh != null:
@@ -105,7 +105,7 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	cone.set_instance_shader_parameter("beam_bottom_radius", bottom_radius)
 	cone.set_instance_shader_parameter("beam_height", beam_range)
 
-	_update_gobo_occluder(light, cone, gobo_occluder, beam_angle, beam_range, lens_radius)
+	_update_gobo_occluder(light, cone, gobo_occluder, beam_angle, beam_range)
 
 func cleanup_beam(light: SpotLight3D) -> void:
 	if light.has_meta(BEAM_META_KEY):
@@ -120,7 +120,7 @@ func cleanup_beam(light: SpotLight3D) -> void:
 			gobo_occluder.queue_free()
 		light.remove_meta(GOBO_OCCLUDER_META_KEY)
 
-func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occluder: MeshInstance3D, beam_angle: float, beam_range: float, lens_radius: float) -> void:
+func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occluder: MeshInstance3D, beam_angle: float, beam_range: float) -> void:
 	if gobo_occluder == null:
 		return
 
@@ -142,16 +142,12 @@ func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occlud
 
 	light.shadow_enabled = true
 	var half_angle_rad: float = deg_to_rad(beam_angle * 0.5)
-	var beam_diameter_at_gobo: float = (2.0 * max(lens_radius, 0.003)) + (2.0 * tan(half_angle_rad) * GOBO_OCCLUDER_DISTANCE_M)
+	var beam_diameter_at_gobo: float = 2.0 * tan(half_angle_rad) * GOBO_OCCLUDER_DISTANCE_M
 	var gobo_plane_size: float = max(beam_diameter_at_gobo, GOBO_MIN_PLANE_SIZE_M)
-	var light_scale: Vector3 = light.global_basis.get_scale()
-	var light_uniform_scale: float = max(max(abs(light_scale.x), abs(light_scale.y)), abs(light_scale.z))
-	var gobo_occluder_plane_size: float = gobo_plane_size * max(light_uniform_scale, 0.001)
 	var gobo_mesh: QuadMesh = gobo_occluder.mesh as QuadMesh
 	if gobo_mesh != null:
-		gobo_mesh.size = Vector2(gobo_occluder_plane_size, gobo_occluder_plane_size)
+		gobo_mesh.size = Vector2(gobo_plane_size, gobo_plane_size)
 	gobo_occluder.scale = Vector3.ONE
-	gobo_occluder.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_SHADOWS_ONLY
 	gobo_occluder.position = Vector3(0.0, 0.0, -GOBO_OCCLUDER_DISTANCE_M)
 	gobo_occluder.visible = true
 	gobo_material.set_shader_parameter("gobo_texture", gobo_texture)
@@ -159,7 +155,7 @@ func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occlud
 	cone.set_instance_shader_parameter("gobo_cutoff", 0.5)
 	cone.set_instance_shader_parameter("gobo_start_ratio", GOBO_OCCLUDER_DISTANCE_M / max(beam_range, 0.001))
 	cone.set_instance_shader_parameter("gobo_rotation", 0.0)
-	cone.set_instance_shader_parameter("gobo_size", Vector2(gobo_occluder_plane_size, gobo_occluder_plane_size))
+	cone.set_instance_shader_parameter("gobo_size", Vector2(gobo_plane_size, gobo_plane_size))
 	cone.set_instance_shader_parameter("gobo_axis_sign", 1.0)
 	var cone_material: ShaderMaterial = cone.material_override as ShaderMaterial
 	if cone_material != null:

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -7,7 +7,7 @@ const GOBO_OCCLUDER_META_KEY: String = "peraviz_gobo_occluder"
 const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 10.0
 const VOLUMETRIC_INTENSITY_SCALE: float = 0.62
 const GOBO_OCCLUDER_DISTANCE_M: float = 0.043
-const GOBO_MIN_PLANE_SIZE_M: float = 0.001
+const GOBO_MIN_PLANE_SIZE_M: float = 0.0095
 
 var _beam_material_template: ShaderMaterial
 var _gobo_occluder_material_template: ShaderMaterial

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -158,7 +158,7 @@ func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occlud
 	cone.set_instance_shader_parameter("gobo_cutoff", 0.5)
 	cone.set_instance_shader_parameter("gobo_start_ratio", GOBO_OCCLUDER_DISTANCE_M / max(beam_range, 0.001))
 	cone.set_instance_shader_parameter("gobo_rotation", 0.0)
-	cone.set_instance_shader_parameter("gobo_size", Vector2(gobo_plane_size, gobo_plane_size))
+	cone.set_instance_shader_parameter("gobo_size", Vector2(gobo_occluder_plane_size, gobo_occluder_plane_size))
 	cone.set_instance_shader_parameter("gobo_axis_sign", 1.0)
 	var cone_material: ShaderMaterial = cone.material_override as ShaderMaterial
 	if cone_material != null:

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -7,11 +7,7 @@ const GOBO_OCCLUDER_META_KEY: String = "peraviz_gobo_occluder"
 const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 10.0
 const VOLUMETRIC_INTENSITY_SCALE: float = 0.62
 const GOBO_OCCLUDER_DISTANCE_M: float = 0.043
-const GOBO_PLANE_BASE_SIZE_M: float = 0.017
-const GOBO_SIZE_ZOOM_MIN_DEG: float = 4.0
-const GOBO_SIZE_ZOOM_MAX_DEG: float = 50.0
-const GOBO_SIZE_SCALE_MIN: float = 0.555
-const GOBO_SIZE_SCALE_MAX: float = 6.4
+const GOBO_MIN_PLANE_SIZE_M: float = 0.001
 
 var _beam_material_template: ShaderMaterial
 var _gobo_occluder_material_template: ShaderMaterial
@@ -50,7 +46,7 @@ func ensure_beam(light: SpotLight3D) -> void:
 
 	if not light.has_meta(GOBO_OCCLUDER_META_KEY):
 		var gobo_mesh := QuadMesh.new()
-		gobo_mesh.size = Vector2(GOBO_PLANE_BASE_SIZE_M, GOBO_PLANE_BASE_SIZE_M)
+		gobo_mesh.size = Vector2(GOBO_MIN_PLANE_SIZE_M, GOBO_MIN_PLANE_SIZE_M)
 		var gobo_occluder := MeshInstance3D.new()
 		gobo_occluder.name = "PeravizGoboOccluder"
 		gobo_occluder.mesh = gobo_mesh
@@ -145,13 +141,16 @@ func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occlud
 		return
 
 	light.shadow_enabled = true
-	var gobo_zoom_value: float = beam_angle
-	var gobo_size_mult: float = remap(clamp(gobo_zoom_value, GOBO_SIZE_ZOOM_MIN_DEG, GOBO_SIZE_ZOOM_MAX_DEG), GOBO_SIZE_ZOOM_MIN_DEG, GOBO_SIZE_ZOOM_MAX_DEG, GOBO_SIZE_SCALE_MIN, GOBO_SIZE_SCALE_MAX)
-	gobo_occluder.scale = Vector3(gobo_size_mult, gobo_size_mult, 1.0)
+	var half_angle_rad: float = deg_to_rad(beam_angle * 0.5)
+	var beam_diameter_at_gobo: float = 2.0 * tan(half_angle_rad) * GOBO_OCCLUDER_DISTANCE_M
+	var gobo_plane_size: float = max(beam_diameter_at_gobo, GOBO_MIN_PLANE_SIZE_M)
+	var gobo_mesh: QuadMesh = gobo_occluder.mesh as QuadMesh
+	if gobo_mesh != null:
+		gobo_mesh.size = Vector2(gobo_plane_size, gobo_plane_size)
+	gobo_occluder.scale = Vector3.ONE
 	gobo_occluder.position = Vector3(0.0, 0.0, -GOBO_OCCLUDER_DISTANCE_M)
 	gobo_occluder.visible = true
 	gobo_material.set_shader_parameter("gobo_texture", gobo_texture)
-	var gobo_plane_size: float = GOBO_PLANE_BASE_SIZE_M * gobo_size_mult
 	cone.set_instance_shader_parameter("gobo_enabled", true)
 	cone.set_instance_shader_parameter("gobo_cutoff", 0.5)
 	cone.set_instance_shader_parameter("gobo_start_ratio", GOBO_OCCLUDER_DISTANCE_M / max(beam_range, 0.001))

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -105,7 +105,7 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	cone.set_instance_shader_parameter("beam_bottom_radius", bottom_radius)
 	cone.set_instance_shader_parameter("beam_height", beam_range)
 
-	_update_gobo_occluder(light, cone, gobo_occluder, beam_angle, beam_range)
+	_update_gobo_occluder(light, cone, gobo_occluder, beam_angle, beam_range, lens_radius)
 
 func cleanup_beam(light: SpotLight3D) -> void:
 	if light.has_meta(BEAM_META_KEY):
@@ -120,7 +120,7 @@ func cleanup_beam(light: SpotLight3D) -> void:
 			gobo_occluder.queue_free()
 		light.remove_meta(GOBO_OCCLUDER_META_KEY)
 
-func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occluder: MeshInstance3D, beam_angle: float, beam_range: float) -> void:
+func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occluder: MeshInstance3D, beam_angle: float, beam_range: float, lens_radius: float) -> void:
 	if gobo_occluder == null:
 		return
 
@@ -142,7 +142,7 @@ func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occlud
 
 	light.shadow_enabled = true
 	var half_angle_rad: float = deg_to_rad(beam_angle * 0.5)
-	var beam_diameter_at_gobo: float = 2.0 * tan(half_angle_rad) * GOBO_OCCLUDER_DISTANCE_M
+	var beam_diameter_at_gobo: float = (2.0 * max(lens_radius, 0.003)) + (2.0 * tan(half_angle_rad) * GOBO_OCCLUDER_DISTANCE_M)
 	var gobo_plane_size: float = max(beam_diameter_at_gobo, GOBO_MIN_PLANE_SIZE_M)
 	var gobo_mesh: QuadMesh = gobo_occluder.mesh as QuadMesh
 	if gobo_mesh != null:

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -144,9 +144,12 @@ func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occlud
 	var half_angle_rad: float = deg_to_rad(beam_angle * 0.5)
 	var beam_diameter_at_gobo: float = (2.0 * max(lens_radius, 0.003)) + (2.0 * tan(half_angle_rad) * GOBO_OCCLUDER_DISTANCE_M)
 	var gobo_plane_size: float = max(beam_diameter_at_gobo, GOBO_MIN_PLANE_SIZE_M)
+	var light_scale: Vector3 = light.global_basis.get_scale()
+	var light_uniform_scale: float = max(max(abs(light_scale.x), abs(light_scale.y)), abs(light_scale.z))
+	var gobo_occluder_plane_size: float = gobo_plane_size * max(light_uniform_scale, 0.001)
 	var gobo_mesh: QuadMesh = gobo_occluder.mesh as QuadMesh
 	if gobo_mesh != null:
-		gobo_mesh.size = Vector2(gobo_plane_size, gobo_plane_size)
+		gobo_mesh.size = Vector2(gobo_occluder_plane_size, gobo_occluder_plane_size)
 	gobo_occluder.scale = Vector3.ONE
 	gobo_occluder.position = Vector3(0.0, 0.0, -GOBO_OCCLUDER_DISTANCE_M)
 	gobo_occluder.visible = true

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -88,7 +88,7 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 
 	var half_angle_deg: float = beam_angle * 0.5
 	var tan_half_angle: float = tan(deg_to_rad(half_angle_deg))
-	var radius: float = tan_half_angle * beam_range
+	var radius: float = max(lens_radius, 0.003) + (tan_half_angle * beam_range)
 	var bottom_radius: float = clamp(radius, 0.03, EMITTER_CONE_MAX_BASE_RADIUS_M)
 	var cone_mesh: CylinderMesh = cone.mesh as CylinderMesh
 	if cone_mesh != null:

--- a/peraviz/scripts/shaders/volumetric_beam.gdshader
+++ b/peraviz/scripts/shaders/volumetric_beam.gdshader
@@ -92,9 +92,7 @@ void fragment() {
 				discard;
 			}
 
-			float beam_slope = (beam_bottom_radius - beam_top_radius) / max(beam_height, 0.001);
-			float radius_at_gobo = max(beam_top_radius + (beam_slope * gobo_plane_dist), 0.001);
-			float projection_scale = radius_at_gobo / max(radius_at_point, 0.001);
+			float projection_scale = gobo_plane_dist / axis_dist;
 			vec2 gobo_plane_pos = radial_pos * projection_scale;
 
 			float sin_rot = sin(gobo_rotation);

--- a/peraviz/scripts/shaders/volumetric_beam.gdshader
+++ b/peraviz/scripts/shaders/volumetric_beam.gdshader
@@ -92,7 +92,9 @@ void fragment() {
 				discard;
 			}
 
-			float projection_scale = gobo_plane_dist / axis_dist;
+			float beam_slope = (beam_bottom_radius - beam_top_radius) / max(beam_height, 0.001);
+			float radius_at_gobo = max(beam_top_radius + (beam_slope * gobo_plane_dist), 0.001);
+			float projection_scale = radius_at_gobo / max(radius_at_point, 0.001);
 			vec2 gobo_plane_pos = radial_pos * projection_scale;
 
 			float sin_rot = sin(gobo_rotation);


### PR DESCRIPTION
### Motivation
- Replace heuristic remap sizing with a physically coherent geometric size for the gobo plane so the occluder matches the beam cone at the occluder distance and avoids inconsistent visual paths.
- Prevent numerical degeneration for very small beam angles by enforcing a reasonable minimum plane size.
- Remove obsolete zoom/scale constants that are no longer needed with the geometric approach.

### Description
- Replaced the `remap(...)`-based `gobo_size_mult` computation in `_update_gobo_occluder(...)` with a geometric calculation using `half_angle_rad = deg_to_rad(beam_angle * 0.5)` and `beam_diameter_at_gobo = 2.0 * tan(half_angle_rad) * GOBO_OCCLUDER_DISTANCE_M`.
- Applied the computed diameter as the gobo plane size for both the `QuadMesh` (`gobo_mesh.size`) and the shader parameter `gobo_size`, and set `gobo_occluder.scale` to `Vector3.ONE` so both rendering paths use the same spatial basis.
- Added `GOBO_MIN_PLANE_SIZE_M` as a minimum clamp to avoid degenerate sizes and initialized the `QuadMesh` with this minimum to keep a valid default.
- Removed the now-unused constants `GOBO_PLANE_BASE_SIZE_M`, `GOBO_SIZE_ZOOM_*` and `GOBO_SIZE_SCALE_*` and preserved `gobo_start_ratio` as `GOBO_OCCLUDER_DISTANCE_M / beam_range` (with a safe `max(beam_range, 0.001)` denominator).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1ef97cad48324a95495b5937adbe0)