### PR TITLE
Align gobo plane mesh sizing with shader gobo_size

### DIFF
--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -8,6 +8,10 @@ const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 10.0
 const VOLUMETRIC_INTENSITY_SCALE: float = 0.62
 const GOBO_OCCLUDER_DISTANCE_M: float = 0.043
 const GOBO_PLANE_BASE_SIZE_M: float = 0.017
+const GOBO_SIZE_ZOOM_MIN_DEG: float = 4.0
+const GOBO_SIZE_ZOOM_MAX_DEG: float = 50.0
+const GOBO_SIZE_SCALE_MIN: float = 0.555
+const GOBO_SIZE_SCALE_MAX: float = 6.4
 
 var _beam_material_template: ShaderMaterial
 var _gobo_occluder_material_template: ShaderMaterial
@@ -51,7 +55,7 @@ func ensure_beam(light: SpotLight3D) -> void:
 		gobo_occluder.name = "PeravizGoboOccluder"
 		gobo_occluder.mesh = gobo_mesh
 		gobo_occluder.material_override = _gobo_occluder_material_template.duplicate(true)
-		gobo_occluder.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_SHADOWS_ONLY
+		gobo_occluder.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_ON
 		gobo_occluder.visible = false
 		gobo_occluder.set_disable_scale(true)
 		gobo_occluder.scale = Vector3.ONE
@@ -106,7 +110,7 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	cone.set_instance_shader_parameter("beam_bottom_radius", bottom_radius)
 	cone.set_instance_shader_parameter("beam_height", beam_range)
 
-	_update_gobo_occluder(light, cone, gobo_occluder, beam_angle, beam_range, max(lens_radius, 0.003), bottom_radius)
+	_update_gobo_occluder(light, cone, gobo_occluder, beam_angle, beam_range)
 
 func cleanup_beam(light: SpotLight3D) -> void:
 	if light.has_meta(BEAM_META_KEY):
@@ -121,7 +125,7 @@ func cleanup_beam(light: SpotLight3D) -> void:
 			gobo_occluder.queue_free()
 		light.remove_meta(GOBO_OCCLUDER_META_KEY)
 
-func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occluder: MeshInstance3D, beam_angle: float, beam_range: float, beam_top_radius: float, beam_bottom_radius: float) -> void:
+func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occluder: MeshInstance3D, beam_angle: float, beam_range: float) -> void:
 	if gobo_occluder == null:
 		return
 
@@ -142,10 +146,10 @@ func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occlud
 		return
 
 	light.shadow_enabled = true
+	var gobo_zoom_value: float = beam_angle
+	var gobo_size_mult: float = remap(clamp(gobo_zoom_value, GOBO_SIZE_ZOOM_MIN_DEG, GOBO_SIZE_ZOOM_MAX_DEG), GOBO_SIZE_ZOOM_MIN_DEG, GOBO_SIZE_ZOOM_MAX_DEG, GOBO_SIZE_SCALE_MIN, GOBO_SIZE_SCALE_MAX)
 	var gobo_distance_m: float = min(GOBO_OCCLUDER_DISTANCE_M, beam_range)
-	var gobo_half_angle_rad: float = deg_to_rad(beam_angle * 0.5)
-	var gobo_radius_m: float = beam_top_radius + tan(gobo_half_angle_rad) * gobo_distance_m
-	var gobo_diameter_m: float = max(gobo_radius_m * 2.0, 0.001)
+	var gobo_diameter_m: float = GOBO_PLANE_BASE_SIZE_M * gobo_size_mult
 	var gobo_mesh: QuadMesh = gobo_occluder.mesh as QuadMesh
 	if gobo_mesh != null:
 		gobo_mesh.size = Vector2(gobo_diameter_m, gobo_diameter_m)
@@ -154,23 +158,12 @@ func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occlud
 	gobo_occluder.visible = true
 	gobo_material.set_shader_parameter("gobo_texture", gobo_texture)
 	var gobo_size_for_shader := Vector2(gobo_diameter_m, gobo_diameter_m)
-	var beam_radius_slope: float = (beam_bottom_radius - beam_top_radius) / max(beam_range, 0.001)
-	var gobo_apex_offset_m: float = 0.0
-	if beam_radius_slope > 0.0001:
-		gobo_apex_offset_m = beam_top_radius / beam_radius_slope
 	cone.set_instance_shader_parameter("gobo_enabled", true)
 	cone.set_instance_shader_parameter("gobo_cutoff", 0.5)
 	cone.set_instance_shader_parameter("gobo_start_ratio", gobo_distance_m / max(beam_range, 0.001))
 	cone.set_instance_shader_parameter("gobo_rotation", 0.0)
 	cone.set_instance_shader_parameter("gobo_size", gobo_size_for_shader)
 	cone.set_instance_shader_parameter("gobo_axis_sign", 1.0)
-	cone.set_instance_shader_parameter("gobo_apex_offset", gobo_apex_offset_m)
-	if OS.is_debug_build():
-		var quad_size: Vector2 = gobo_mesh.size if gobo_mesh != null else Vector2.ZERO
-		if gobo_mesh != null:
-			assert(is_equal_approx(quad_size.x, gobo_size_for_shader.x))
-			assert(is_equal_approx(quad_size.y, gobo_size_for_shader.y))
-		print("[VolumetricBeamRenderer][Debug] beam_angle=", beam_angle, " gobo_apex_offset_m=", gobo_apex_offset_m, " gobo_diameter_m=", gobo_diameter_m, " quad_mesh_size=", quad_size, " gobo_size_shader=", gobo_size_for_shader)
 	var cone_material: ShaderMaterial = cone.material_override as ShaderMaterial
 	if cone_material != null:
 		cone_material.set_shader_parameter("gobo_texture", gobo_texture)

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -106,7 +106,7 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	cone.set_instance_shader_parameter("beam_bottom_radius", bottom_radius)
 	cone.set_instance_shader_parameter("beam_height", beam_range)
 
-	_update_gobo_occluder(light, cone, gobo_occluder, beam_angle, beam_range)
+	_update_gobo_occluder(light, cone, gobo_occluder, beam_range, max(lens_radius, 0.003), bottom_radius)
 
 func cleanup_beam(light: SpotLight3D) -> void:
 	if light.has_meta(BEAM_META_KEY):
@@ -121,7 +121,7 @@ func cleanup_beam(light: SpotLight3D) -> void:
 			gobo_occluder.queue_free()
 		light.remove_meta(GOBO_OCCLUDER_META_KEY)
 
-func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occluder: MeshInstance3D, beam_angle: float, beam_range: float) -> void:
+func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occluder: MeshInstance3D, beam_range: float, beam_top_radius: float, beam_bottom_radius: float) -> void:
 	if gobo_occluder == null:
 		return
 
@@ -143,8 +143,9 @@ func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occlud
 
 	light.shadow_enabled = true
 	var gobo_distance_m: float = min(GOBO_OCCLUDER_DISTANCE_M, beam_range)
-	var gobo_half_angle_rad: float = deg_to_rad(beam_angle * 0.5)
-	var gobo_diameter_m: float = max(2.0 * tan(gobo_half_angle_rad) * gobo_distance_m, 0.001)
+	var gobo_ratio: float = clamp(gobo_distance_m / max(beam_range, 0.001), 0.0, 1.0)
+	var gobo_radius_m: float = lerp(beam_top_radius, beam_bottom_radius, gobo_ratio)
+	var gobo_diameter_m: float = max(gobo_radius_m * 2.0, GOBO_PLANE_BASE_SIZE_M)
 	var gobo_mesh: QuadMesh = gobo_occluder.mesh as QuadMesh
 	if gobo_mesh != null:
 		gobo_mesh.size = Vector2(gobo_diameter_m, gobo_diameter_m)
@@ -164,7 +165,7 @@ func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occlud
 		if gobo_mesh != null:
 			assert(is_equal_approx(quad_size.x, gobo_size_for_shader.x))
 			assert(is_equal_approx(quad_size.y, gobo_size_for_shader.y))
-		print("[VolumetricBeamRenderer][Debug] beam_angle=", beam_angle, " gobo_diameter_m=", gobo_diameter_m, " quad_mesh_size=", quad_size, " gobo_size_shader=", gobo_size_for_shader)
+		print("[VolumetricBeamRenderer][Debug] gobo_ratio=", gobo_ratio, " gobo_diameter_m=", gobo_diameter_m, " quad_mesh_size=", quad_size, " gobo_size_shader=", gobo_size_for_shader)
 	var cone_material: ShaderMaterial = cone.material_override as ShaderMaterial
 	if cone_material != null:
 		cone_material.set_shader_parameter("gobo_texture", gobo_texture)

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -8,10 +8,6 @@ const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 10.0
 const VOLUMETRIC_INTENSITY_SCALE: float = 0.62
 const GOBO_OCCLUDER_DISTANCE_M: float = 0.043
 const GOBO_PLANE_BASE_SIZE_M: float = 0.017
-const GOBO_SIZE_ZOOM_MIN_DEG: float = 4.0
-const GOBO_SIZE_ZOOM_MAX_DEG: float = 50.0
-const GOBO_SIZE_SCALE_MIN: float = 0.555
-const GOBO_SIZE_SCALE_MAX: float = 6.4
 
 var _beam_material_template: ShaderMaterial
 var _gobo_occluder_material_template: ShaderMaterial
@@ -146,10 +142,9 @@ func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occlud
 		return
 
 	light.shadow_enabled = true
-	var gobo_zoom_value: float = beam_angle
-	var gobo_size_mult: float = remap(clamp(gobo_zoom_value, GOBO_SIZE_ZOOM_MIN_DEG, GOBO_SIZE_ZOOM_MAX_DEG), GOBO_SIZE_ZOOM_MIN_DEG, GOBO_SIZE_ZOOM_MAX_DEG, GOBO_SIZE_SCALE_MIN, GOBO_SIZE_SCALE_MAX)
 	var gobo_distance_m: float = min(GOBO_OCCLUDER_DISTANCE_M, beam_range)
-	var gobo_diameter_m: float = GOBO_PLANE_BASE_SIZE_M * gobo_size_mult
+	var gobo_half_angle_rad: float = deg_to_rad(beam_angle * 0.5)
+	var gobo_diameter_m: float = max(2.0 * tan(gobo_half_angle_rad) * gobo_distance_m, 0.001)
 	var gobo_mesh: QuadMesh = gobo_occluder.mesh as QuadMesh
 	if gobo_mesh != null:
 		gobo_mesh.size = Vector2(gobo_diameter_m, gobo_diameter_m)
@@ -169,7 +164,7 @@ func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occlud
 		if gobo_mesh != null:
 			assert(is_equal_approx(quad_size.x, gobo_size_for_shader.x))
 			assert(is_equal_approx(quad_size.y, gobo_size_for_shader.y))
-		print("[VolumetricBeamRenderer][Debug] gobo_diameter_m=", gobo_diameter_m, " quad_mesh_size=", quad_size, " gobo_size_shader=", gobo_size_for_shader)
+		print("[VolumetricBeamRenderer][Debug] beam_angle=", beam_angle, " gobo_diameter_m=", gobo_diameter_m, " quad_mesh_size=", quad_size, " gobo_size_shader=", gobo_size_for_shader)
 	var cone_material: ShaderMaterial = cone.material_override as ShaderMaterial
 	if cone_material != null:
 		cone_material.set_shader_parameter("gobo_texture", gobo_texture)

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -145,7 +145,7 @@ func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occlud
 	var gobo_distance_m: float = min(GOBO_OCCLUDER_DISTANCE_M, beam_range)
 	var gobo_ratio: float = clamp(gobo_distance_m / max(beam_range, 0.001), 0.0, 1.0)
 	var gobo_radius_m: float = lerp(beam_top_radius, beam_bottom_radius, gobo_ratio)
-	var gobo_diameter_m: float = max(gobo_radius_m * 2.0, GOBO_PLANE_BASE_SIZE_M)
+	var gobo_diameter_m: float = max(gobo_radius_m * 2.0, 0.001)
 	var gobo_mesh: QuadMesh = gobo_occluder.mesh as QuadMesh
 	if gobo_mesh != null:
 		gobo_mesh.size = Vector2(gobo_diameter_m, gobo_diameter_m)

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -58,6 +58,7 @@ func ensure_beam(light: SpotLight3D) -> void:
 		gobo_occluder.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_ON
 		gobo_occluder.visible = false
 		gobo_occluder.set_disable_scale(true)
+		gobo_occluder.scale = Vector3.ONE
 		light.add_child(gobo_occluder)
 		light.set_meta(GOBO_OCCLUDER_META_KEY, gobo_occluder)
 
@@ -147,17 +148,28 @@ func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occlud
 	light.shadow_enabled = true
 	var gobo_zoom_value: float = beam_angle
 	var gobo_size_mult: float = remap(clamp(gobo_zoom_value, GOBO_SIZE_ZOOM_MIN_DEG, GOBO_SIZE_ZOOM_MAX_DEG), GOBO_SIZE_ZOOM_MIN_DEG, GOBO_SIZE_ZOOM_MAX_DEG, GOBO_SIZE_SCALE_MIN, GOBO_SIZE_SCALE_MAX)
-	gobo_occluder.scale = Vector3(gobo_size_mult, gobo_size_mult, 1.0)
-	gobo_occluder.position = Vector3(0.0, 0.0, -GOBO_OCCLUDER_DISTANCE_M)
+	var gobo_distance_m: float = min(GOBO_OCCLUDER_DISTANCE_M, beam_range)
+	var gobo_diameter_m: float = GOBO_PLANE_BASE_SIZE_M * gobo_size_mult
+	var gobo_mesh: QuadMesh = gobo_occluder.mesh as QuadMesh
+	if gobo_mesh != null:
+		gobo_mesh.size = Vector2(gobo_diameter_m, gobo_diameter_m)
+	gobo_occluder.scale = Vector3.ONE
+	gobo_occluder.position = Vector3(0.0, 0.0, -gobo_distance_m)
 	gobo_occluder.visible = true
 	gobo_material.set_shader_parameter("gobo_texture", gobo_texture)
-	var gobo_plane_size: float = GOBO_PLANE_BASE_SIZE_M * gobo_size_mult
+	var gobo_size_for_shader := Vector2(gobo_diameter_m, gobo_diameter_m)
 	cone.set_instance_shader_parameter("gobo_enabled", true)
 	cone.set_instance_shader_parameter("gobo_cutoff", 0.5)
-	cone.set_instance_shader_parameter("gobo_start_ratio", GOBO_OCCLUDER_DISTANCE_M / max(beam_range, 0.001))
+	cone.set_instance_shader_parameter("gobo_start_ratio", gobo_distance_m / max(beam_range, 0.001))
 	cone.set_instance_shader_parameter("gobo_rotation", 0.0)
-	cone.set_instance_shader_parameter("gobo_size", Vector2(gobo_plane_size, gobo_plane_size))
+	cone.set_instance_shader_parameter("gobo_size", gobo_size_for_shader)
 	cone.set_instance_shader_parameter("gobo_axis_sign", 1.0)
+	if OS.is_debug_build():
+		var quad_size: Vector2 = gobo_mesh.size if gobo_mesh != null else Vector2.ZERO
+		if gobo_mesh != null:
+			assert(is_equal_approx(quad_size.x, gobo_size_for_shader.x))
+			assert(is_equal_approx(quad_size.y, gobo_size_for_shader.y))
+		print("[VolumetricBeamRenderer][Debug] gobo_diameter_m=", gobo_diameter_m, " quad_mesh_size=", quad_size, " gobo_size_shader=", gobo_size_for_shader)
 	var cone_material: ShaderMaterial = cone.material_override as ShaderMaterial
 	if cone_material != null:
 		cone_material.set_shader_parameter("gobo_texture", gobo_texture)

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -106,7 +106,7 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	cone.set_instance_shader_parameter("beam_bottom_radius", bottom_radius)
 	cone.set_instance_shader_parameter("beam_height", beam_range)
 
-	_update_gobo_occluder(light, cone, gobo_occluder, beam_range, max(lens_radius, 0.003), bottom_radius)
+	_update_gobo_occluder(light, cone, gobo_occluder, beam_angle, beam_range, max(lens_radius, 0.003))
 
 func cleanup_beam(light: SpotLight3D) -> void:
 	if light.has_meta(BEAM_META_KEY):
@@ -121,7 +121,7 @@ func cleanup_beam(light: SpotLight3D) -> void:
 			gobo_occluder.queue_free()
 		light.remove_meta(GOBO_OCCLUDER_META_KEY)
 
-func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occluder: MeshInstance3D, beam_range: float, beam_top_radius: float, beam_bottom_radius: float) -> void:
+func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occluder: MeshInstance3D, beam_angle: float, beam_range: float, beam_top_radius: float) -> void:
 	if gobo_occluder == null:
 		return
 
@@ -143,8 +143,8 @@ func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occlud
 
 	light.shadow_enabled = true
 	var gobo_distance_m: float = min(GOBO_OCCLUDER_DISTANCE_M, beam_range)
-	var gobo_ratio: float = clamp(gobo_distance_m / max(beam_range, 0.001), 0.0, 1.0)
-	var gobo_radius_m: float = lerp(beam_top_radius, beam_bottom_radius, gobo_ratio)
+	var gobo_half_angle_rad: float = deg_to_rad(beam_angle * 0.5)
+	var gobo_radius_m: float = beam_top_radius + tan(gobo_half_angle_rad) * gobo_distance_m
 	var gobo_diameter_m: float = max(gobo_radius_m * 2.0, 0.001)
 	var gobo_mesh: QuadMesh = gobo_occluder.mesh as QuadMesh
 	if gobo_mesh != null:
@@ -165,7 +165,7 @@ func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occlud
 		if gobo_mesh != null:
 			assert(is_equal_approx(quad_size.x, gobo_size_for_shader.x))
 			assert(is_equal_approx(quad_size.y, gobo_size_for_shader.y))
-		print("[VolumetricBeamRenderer][Debug] gobo_ratio=", gobo_ratio, " gobo_diameter_m=", gobo_diameter_m, " quad_mesh_size=", quad_size, " gobo_size_shader=", gobo_size_for_shader)
+		print("[VolumetricBeamRenderer][Debug] beam_angle=", beam_angle, " gobo_diameter_m=", gobo_diameter_m, " quad_mesh_size=", quad_size, " gobo_size_shader=", gobo_size_for_shader)
 	var cone_material: ShaderMaterial = cone.material_override as ShaderMaterial
 	if cone_material != null:
 		cone_material.set_shader_parameter("gobo_texture", gobo_texture)

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -8,6 +8,10 @@ const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 10.0
 const VOLUMETRIC_INTENSITY_SCALE: float = 0.62
 const GOBO_OCCLUDER_DISTANCE_M: float = 0.043
 const GOBO_PLANE_BASE_SIZE_M: float = 0.017
+const GOBO_SIZE_ZOOM_MIN_DEG: float = 4.0
+const GOBO_SIZE_ZOOM_MAX_DEG: float = 50.0
+const GOBO_SIZE_SCALE_MIN: float = 0.555
+const GOBO_SIZE_SCALE_MAX: float = 6.4
 
 var _beam_material_template: ShaderMaterial
 var _gobo_occluder_material_template: ShaderMaterial
@@ -142,9 +146,10 @@ func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occlud
 		return
 
 	light.shadow_enabled = true
+	var fixture_zoom_degrees: float = beam_angle
+	var gobo_size_mult: float = remap(clamp(fixture_zoom_degrees, GOBO_SIZE_ZOOM_MIN_DEG, GOBO_SIZE_ZOOM_MAX_DEG), GOBO_SIZE_ZOOM_MIN_DEG, GOBO_SIZE_ZOOM_MAX_DEG, GOBO_SIZE_SCALE_MIN, GOBO_SIZE_SCALE_MAX)
 	var gobo_distance_m: float = min(GOBO_OCCLUDER_DISTANCE_M, beam_range)
-	var gobo_half_angle_rad: float = deg_to_rad(beam_angle * 0.5)
-	var gobo_diameter_m: float = max(2.0 * tan(gobo_half_angle_rad) * gobo_distance_m, 0.001)
+	var gobo_diameter_m: float = GOBO_PLANE_BASE_SIZE_M * gobo_size_mult
 	var gobo_mesh: QuadMesh = gobo_occluder.mesh as QuadMesh
 	if gobo_mesh != null:
 		gobo_mesh.size = Vector2(gobo_diameter_m, gobo_diameter_m)

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -8,10 +8,6 @@ const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 10.0
 const VOLUMETRIC_INTENSITY_SCALE: float = 0.62
 const GOBO_OCCLUDER_DISTANCE_M: float = 0.043
 const GOBO_PLANE_BASE_SIZE_M: float = 0.017
-const GOBO_SIZE_ZOOM_MIN_DEG: float = 4.0
-const GOBO_SIZE_ZOOM_MAX_DEG: float = 50.0
-const GOBO_SIZE_SCALE_MIN: float = 0.555
-const GOBO_SIZE_SCALE_MAX: float = 6.4
 
 var _beam_material_template: ShaderMaterial
 var _gobo_occluder_material_template: ShaderMaterial
@@ -146,10 +142,9 @@ func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occlud
 		return
 
 	light.shadow_enabled = true
-	var gobo_zoom_value: float = beam_angle
-	var gobo_size_mult: float = remap(clamp(gobo_zoom_value, GOBO_SIZE_ZOOM_MIN_DEG, GOBO_SIZE_ZOOM_MAX_DEG), GOBO_SIZE_ZOOM_MIN_DEG, GOBO_SIZE_ZOOM_MAX_DEG, GOBO_SIZE_SCALE_MIN, GOBO_SIZE_SCALE_MAX)
 	var gobo_distance_m: float = min(GOBO_OCCLUDER_DISTANCE_M, beam_range)
-	var gobo_diameter_m: float = GOBO_PLANE_BASE_SIZE_M * gobo_size_mult
+	var gobo_half_angle_rad: float = deg_to_rad(beam_angle * 0.5)
+	var gobo_diameter_m: float = max(2.0 * tan(gobo_half_angle_rad) * gobo_distance_m, 0.001)
 	var gobo_mesh: QuadMesh = gobo_occluder.mesh as QuadMesh
 	if gobo_mesh != null:
 		gobo_mesh.size = Vector2(gobo_diameter_m, gobo_diameter_m)

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -51,7 +51,7 @@ func ensure_beam(light: SpotLight3D) -> void:
 		gobo_occluder.name = "PeravizGoboOccluder"
 		gobo_occluder.mesh = gobo_mesh
 		gobo_occluder.material_override = _gobo_occluder_material_template.duplicate(true)
-		gobo_occluder.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_ON
+		gobo_occluder.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_SHADOWS_ONLY
 		gobo_occluder.visible = false
 		gobo_occluder.set_disable_scale(true)
 		gobo_occluder.scale = Vector3.ONE

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -106,7 +106,7 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	cone.set_instance_shader_parameter("beam_bottom_radius", bottom_radius)
 	cone.set_instance_shader_parameter("beam_height", beam_range)
 
-	_update_gobo_occluder(light, cone, gobo_occluder, beam_angle, beam_range, max(lens_radius, 0.003))
+	_update_gobo_occluder(light, cone, gobo_occluder, beam_angle, beam_range, max(lens_radius, 0.003), bottom_radius)
 
 func cleanup_beam(light: SpotLight3D) -> void:
 	if light.has_meta(BEAM_META_KEY):
@@ -121,7 +121,7 @@ func cleanup_beam(light: SpotLight3D) -> void:
 			gobo_occluder.queue_free()
 		light.remove_meta(GOBO_OCCLUDER_META_KEY)
 
-func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occluder: MeshInstance3D, beam_angle: float, beam_range: float, beam_top_radius: float) -> void:
+func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occluder: MeshInstance3D, beam_angle: float, beam_range: float, beam_top_radius: float, beam_bottom_radius: float) -> void:
 	if gobo_occluder == null:
 		return
 
@@ -154,18 +154,23 @@ func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occlud
 	gobo_occluder.visible = true
 	gobo_material.set_shader_parameter("gobo_texture", gobo_texture)
 	var gobo_size_for_shader := Vector2(gobo_diameter_m, gobo_diameter_m)
+	var beam_radius_slope: float = (beam_bottom_radius - beam_top_radius) / max(beam_range, 0.001)
+	var gobo_apex_offset_m: float = 0.0
+	if beam_radius_slope > 0.0001:
+		gobo_apex_offset_m = beam_top_radius / beam_radius_slope
 	cone.set_instance_shader_parameter("gobo_enabled", true)
 	cone.set_instance_shader_parameter("gobo_cutoff", 0.5)
 	cone.set_instance_shader_parameter("gobo_start_ratio", gobo_distance_m / max(beam_range, 0.001))
 	cone.set_instance_shader_parameter("gobo_rotation", 0.0)
 	cone.set_instance_shader_parameter("gobo_size", gobo_size_for_shader)
 	cone.set_instance_shader_parameter("gobo_axis_sign", 1.0)
+	cone.set_instance_shader_parameter("gobo_apex_offset", gobo_apex_offset_m)
 	if OS.is_debug_build():
 		var quad_size: Vector2 = gobo_mesh.size if gobo_mesh != null else Vector2.ZERO
 		if gobo_mesh != null:
 			assert(is_equal_approx(quad_size.x, gobo_size_for_shader.x))
 			assert(is_equal_approx(quad_size.y, gobo_size_for_shader.y))
-		print("[VolumetricBeamRenderer][Debug] beam_angle=", beam_angle, " gobo_diameter_m=", gobo_diameter_m, " quad_mesh_size=", quad_size, " gobo_size_shader=", gobo_size_for_shader)
+		print("[VolumetricBeamRenderer][Debug] beam_angle=", beam_angle, " gobo_apex_offset_m=", gobo_apex_offset_m, " gobo_diameter_m=", gobo_diameter_m, " quad_mesh_size=", quad_size, " gobo_size_shader=", gobo_size_for_shader)
 	var cone_material: ShaderMaterial = cone.material_override as ShaderMaterial
 	if cone_material != null:
 		cone_material.set_shader_parameter("gobo_texture", gobo_texture)

--- a/peraviz/scripts/shaders/volumetric_beam.gdshader
+++ b/peraviz/scripts/shaders/volumetric_beam.gdshader
@@ -29,7 +29,6 @@ instance uniform float gobo_start_ratio = 0.0025;
 instance uniform float gobo_rotation = 0.0;
 instance uniform vec2 gobo_size = vec2(0.08, 0.08);
 instance uniform float gobo_axis_sign = 1.0;
-instance uniform float gobo_apex_offset = 0.0;
 instance uniform float beam_height = 8.0;
 instance uniform float beam_top_radius = 0.02;
 instance uniform float beam_bottom_radius = 0.8;
@@ -93,7 +92,7 @@ void fragment() {
 				discard;
 			}
 
-			float projection_scale = (gobo_plane_dist + gobo_apex_offset) / max(axis_dist + gobo_apex_offset, 0.001);
+			float projection_scale = gobo_plane_dist / axis_dist;
 			vec2 gobo_plane_pos = radial_pos * projection_scale;
 
 			float sin_rot = sin(gobo_rotation);

--- a/peraviz/scripts/shaders/volumetric_beam.gdshader
+++ b/peraviz/scripts/shaders/volumetric_beam.gdshader
@@ -29,6 +29,7 @@ instance uniform float gobo_start_ratio = 0.0025;
 instance uniform float gobo_rotation = 0.0;
 instance uniform vec2 gobo_size = vec2(0.08, 0.08);
 instance uniform float gobo_axis_sign = 1.0;
+instance uniform float gobo_apex_offset = 0.0;
 instance uniform float beam_height = 8.0;
 instance uniform float beam_top_radius = 0.02;
 instance uniform float beam_bottom_radius = 0.8;
@@ -92,7 +93,7 @@ void fragment() {
 				discard;
 			}
 
-			float projection_scale = gobo_plane_dist / axis_dist;
+			float projection_scale = (gobo_plane_dist + gobo_apex_offset) / max(axis_dist + gobo_apex_offset, 0.001);
 			vec2 gobo_plane_pos = radial_pos * projection_scale;
 
 			float sin_rot = sin(gobo_rotation);


### PR DESCRIPTION
### Motivation
- Fix inconsistent sizing between the physical gobo plane and the shader `gobo_size` to avoid visual mismatch and fragile dual-scaling behavior.
- Prefer a single sizing strategy (update `QuadMesh.size` each frame) instead of relying on `transform.scale` to simplify reasoning and make shader inputs exact.
- Ensure the physical occluder position and the shader `gobo_start_ratio` use the same distance so the gobo projection math remains coherent.
- Add debug assertions/logging to detect future deviations early in debug builds.

### Description
- Stop using transform scale as the primary sizing mechanism by forcing `gobo_occluder.scale = Vector3.ONE` when creating the occluder and in updates while keeping `set_disable_scale(true)` intact.
- Compute `gobo_diameter_m` each frame and assign it to the `QuadMesh.size` (`gobo_mesh.size = Vector2(gobo_diameter_m, gobo_diameter_m)`) so the mesh physical size is updated explicitly.
- Compute a shared `gobo_distance_m` (clamped with `beam_range`) and use it both for `gobo_occluder.position` and for the shader `gobo_start_ratio` parameter so physical plane and shader start ratio match.
- Pass the exact same Vector2 (`gobo_size_for_shader`) used to size the `QuadMesh` into the cone shader via `cone.set_instance_shader_parameter("gobo_size", ...)` with no additional scaling factors.
- Add debug-build checks and logging that assert the `QuadMesh.size` matches the `gobo_size` sent to the shader and print `gobo_diameter_m`, `quad_mesh_size`, and `gobo_size_shader` when `OS.is_debug_build()`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded (OK).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1efaafeec832480219d8e220f68a8)