### PR TITLE
Peraviz: align volumetric gobo size with beam cone geometry

### DIFF
--- a/peraviz/docs/BEAM_RENDERING_MODES.md
+++ b/peraviz/docs/BEAM_RENDERING_MODES.md
@@ -29,3 +29,24 @@ Shader shaping uses:
 
 - **Axial factor** from local mesh Y to control near-lens intensity and far-end fade.
 - **Radial factor** from local XZ distance to keep the center denser than edges.
+
+
+## Volumetric gobo geometry tuning
+
+`VolumetricBeamRenderer` now derives gobo projection size directly from beam cone geometry at the occluder plane.
+There is no zoom remap multiplier anymore.
+
+You can tune these public renderer properties (or pass the same keys in renderer settings):
+
+- `gobo_occluder_distance_m` (default `0.043`): distance from lens origin to gobo occluder plane.
+- `gobo_plane_base_size_m` (default `0.017`): physical side size of the occluder quad mesh before runtime scaling.
+- `gobo_footprint_cone_fill_ratio` (default `1.0`): fill ratio applied to cone diameter at occluder depth.
+
+For fixture-specific overrides, set these light metadata keys:
+
+- `peraviz_gobo_occluder_distance_m`
+- `peraviz_gobo_plane_base_size_m`
+- `peraviz_gobo_footprint_cone_fill_ratio`
+
+The volumetric shader uniforms remain unchanged:
+`gobo_size`, `gobo_start_ratio`, and `gobo_texture`.

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -6,13 +6,13 @@ const BEAM_META_KEY: String = "peraviz_volumetric_beam"
 const GOBO_OCCLUDER_META_KEY: String = "peraviz_gobo_occluder"
 const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 10.0
 const VOLUMETRIC_INTENSITY_SCALE: float = 0.62
-const GOBO_OCCLUDER_DISTANCE_M: float = 0.043
-const GOBO_PLANE_BASE_SIZE_M: float = 0.017
-const GOBO_SIZE_ZOOM_MIN_DEG: float = 4.0
-const GOBO_SIZE_ZOOM_MAX_DEG: float = 50.0
-const GOBO_SIZE_SCALE_MIN: float = 0.555
-const GOBO_SIZE_SCALE_MAX: float = 6.4
-const GOBO_FOOTPRINT_CONE_FILL_RATIO: float = 1.0
+
+# Distance from the emitter origin to the gobo occluder plane.
+var gobo_occluder_distance_m: float = 0.043
+# Physical side size of the gobo occluder mesh (before scale multiplier).
+var gobo_plane_base_size_m: float = 0.017
+# Controls how much of the cone diameter should be used by the gobo footprint.
+var gobo_footprint_cone_fill_ratio: float = 1.0
 
 var _beam_material_template: ShaderMaterial
 var _gobo_occluder_material_template: ShaderMaterial
@@ -28,6 +28,9 @@ func _init() -> void:
 func configure(view_camera: Camera3D, settings: Dictionary) -> void:
 	_camera = view_camera
 	_settings = settings.duplicate(true)
+	gobo_occluder_distance_m = max(float(_settings.get("gobo_occluder_distance_m", gobo_occluder_distance_m)), 0.001)
+	gobo_plane_base_size_m = max(float(_settings.get("gobo_plane_base_size_m", gobo_plane_base_size_m)), 0.001)
+	gobo_footprint_cone_fill_ratio = max(float(_settings.get("gobo_footprint_cone_fill_ratio", gobo_footprint_cone_fill_ratio)), 0.001)
 
 func ensure_beam(light: SpotLight3D) -> void:
 	if not light.has_meta(BEAM_META_KEY):
@@ -51,7 +54,7 @@ func ensure_beam(light: SpotLight3D) -> void:
 
 	if not light.has_meta(GOBO_OCCLUDER_META_KEY):
 		var gobo_mesh := QuadMesh.new()
-		gobo_mesh.size = Vector2(GOBO_PLANE_BASE_SIZE_M, GOBO_PLANE_BASE_SIZE_M)
+		gobo_mesh.size = Vector2(gobo_plane_base_size_m, gobo_plane_base_size_m)
 		var gobo_occluder := MeshInstance3D.new()
 		gobo_occluder.name = "PeravizGoboOccluder"
 		gobo_occluder.mesh = gobo_mesh
@@ -112,9 +115,9 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	_update_gobo_occluder(light, cone, gobo_occluder, beam_angle, beam_range)
 
 
-func _compute_cone_diameter_at_occluder(beam_angle: float) -> float:
+func _compute_cone_diameter_at_occluder(beam_angle: float, occluder_distance_m: float = gobo_occluder_distance_m) -> float:
 	var half_angle_rad: float = deg_to_rad(max(beam_angle, 0.1) * 0.5)
-	var cone_radius_at_occluder: float = tan(half_angle_rad) * GOBO_OCCLUDER_DISTANCE_M
+	var cone_radius_at_occluder: float = tan(half_angle_rad) * max(occluder_distance_m, 0.001)
 	return max(cone_radius_at_occluder * 2.0, 0.001)
 
 func cleanup_beam(light: SpotLight3D) -> void:
@@ -151,19 +154,23 @@ func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occlud
 		return
 
 	light.shadow_enabled = true
-	var gobo_zoom_value: float = beam_angle
-	var gobo_size_mult: float = remap(clamp(gobo_zoom_value, GOBO_SIZE_ZOOM_MIN_DEG, GOBO_SIZE_ZOOM_MAX_DEG), GOBO_SIZE_ZOOM_MIN_DEG, GOBO_SIZE_ZOOM_MAX_DEG, GOBO_SIZE_SCALE_MIN, GOBO_SIZE_SCALE_MAX)
-	var cone_diameter_at_occluder: float = _compute_cone_diameter_at_occluder(beam_angle)
-	var footprint_plane_size: float = cone_diameter_at_occluder * GOBO_FOOTPRINT_CONE_FILL_RATIO
-	var footprint_scale: float = max(footprint_plane_size / GOBO_PLANE_BASE_SIZE_M, 0.001)
+	var occluder_distance_m: float = max(float(light.get_meta("peraviz_gobo_occluder_distance_m", gobo_occluder_distance_m)), 0.001)
+	var plane_base_size_m: float = max(float(light.get_meta("peraviz_gobo_plane_base_size_m", gobo_plane_base_size_m)), 0.001)
+	var cone_fill_ratio: float = max(float(light.get_meta("peraviz_gobo_footprint_cone_fill_ratio", gobo_footprint_cone_fill_ratio)), 0.001)
+	var cone_diameter_at_occluder: float = _compute_cone_diameter_at_occluder(beam_angle, occluder_distance_m)
+	var footprint_plane_size: float = cone_diameter_at_occluder * cone_fill_ratio
+	var footprint_scale: float = max(footprint_plane_size / plane_base_size_m, 0.001)
+	var gobo_mesh: QuadMesh = gobo_occluder.mesh as QuadMesh
+	if gobo_mesh != null:
+		gobo_mesh.size = Vector2(plane_base_size_m, plane_base_size_m)
 	gobo_occluder.scale = Vector3(footprint_scale, footprint_scale, 1.0)
-	gobo_occluder.position = Vector3(0.0, 0.0, -GOBO_OCCLUDER_DISTANCE_M)
+	gobo_occluder.position = Vector3(0.0, 0.0, -occluder_distance_m)
 	gobo_occluder.visible = true
 	gobo_material.set_shader_parameter("gobo_texture", gobo_texture)
-	var gobo_plane_size: float = GOBO_PLANE_BASE_SIZE_M * gobo_size_mult
+	var gobo_plane_size: float = footprint_plane_size
 	cone.set_instance_shader_parameter("gobo_enabled", true)
 	cone.set_instance_shader_parameter("gobo_cutoff", 0.5)
-	cone.set_instance_shader_parameter("gobo_start_ratio", GOBO_OCCLUDER_DISTANCE_M / max(beam_range, 0.001))
+	cone.set_instance_shader_parameter("gobo_start_ratio", occluder_distance_m / max(beam_range, 0.001))
 	cone.set_instance_shader_parameter("gobo_rotation", 0.0)
 	cone.set_instance_shader_parameter("gobo_size", Vector2(gobo_plane_size, gobo_plane_size))
 	cone.set_instance_shader_parameter("gobo_axis_sign", 1.0)


### PR DESCRIPTION
### Motivation
- The previous gobo sizing used a fixed zoom remap and scale constants which made the volumetric gobo modulation not match the physical cone footprint of the fixture. 
- The goal is for the `gobo_size` used by the volumetric shader to exactly correspond to the cone diameter at the occluder plane so projections line up for any beam angle. 
- The change also exposes simple tuning parameters so different fixture optics can override occluder distance and base gobo size.

### Description
- Removed the fixed zoom-remap constants and replaced them with configurable renderer properties: `gobo_occluder_distance_m`, `gobo_plane_base_size_m`, and `gobo_footprint_cone_fill_ratio`, read from renderer `settings` and overrideable per-light via metadata keys `peraviz_gobo_occluder_distance_m`, `peraviz_gobo_plane_base_size_m`, and `peraviz_gobo_footprint_cone_fill_ratio` in `peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd`.
- Added and used `_compute_cone_diameter_at_occluder(beam_angle, occluder_distance_m)` to compute the cone diameter at the occluder depth and derive the gobo texture size (`gobo_plane_size`) from that geometry instead of any `remap()` multiplier.
- Kept the occluder footprint scaling logic based on cone tangent math (now using the configurable base quad size) and ensured the shader uniforms are set to the calculated values: `gobo_size` set to the computed footprint size and `gobo_start_ratio` set to `occluder_distance_m / max(beam_range, 0.001)`.
- Updated the occluder quad mesh creation and runtime sizing to use the new base size and applied the footprint scale, and documented the new tuning properties and per-fixture metadata keys in `peraviz/docs/BEAM_RENDERING_MODES.md`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which passed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which passed successfully.
- Verified shader uniform usage with `rg` to confirm `gobo_size`, `gobo_start_ratio` and `gobo_texture` are still provided to `volumetric_beam.gdshader`, which returned the expected unchanged uniforms.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a22f03079483249bef7f286c395776)