### PR TITLE
Fix inside-out 3DS meshes by correcting winding and mirrored transforms

### DIFF
--- a/peraviz/docs/COORDINATE_SYSTEM.md
+++ b/peraviz/docs/COORDINATE_SYSTEM.md
@@ -168,3 +168,30 @@ rg -n "PeravizCoordDebug|PeravizBaseline|PeravizNative|PeravizCoordDebugLegend" 
 ```
 
 This produces a concise trace to verify scale, axis remap, handedness declaration, beam local reference, and per-node transform mapping.
+
+
+## 7) 3DS mesh winding correction and mirrored transforms
+
+Peraviz applies two winding safeguards for `.3ds` assets (mesh import path only):
+
+1. **Axis/unit conversion before winding checks**
+   - Positions are converted from mm to m and remapped `(x, y, z) -> (x, z, -y)`.
+   - Normals are remapped with the same axis conversion.
+
+2. **Outward-winding correction in native loader**
+   - The 3DS loader computes a centroid-based orientation score.
+   - For each triangle it accumulates an area-weighted signed term using:
+     - triangle normal (`cross(edge1, edge2)`),
+     - triangle centroid offset from the mesh centroid,
+     - and normal length as weight.
+   - If the score is negative, triangle indices are flipped (`i1 <-> i2`) and vertex normals are negated.
+
+3. **Negative determinant compensation in Godot mesh build**
+   - `_build_3ds_mesh()` checks mirrored transforms via hierarchy determinant (`basis.determinant() < 0`).
+   - For mirrored instances, indices and normals are flipped again so front faces remain outward after transform.
+
+4. **Double-sided material policy**
+   - Double-sided culling is now reserved for thin/translucent candidates (for example `lens` / `glass` hints, thin-plane geometry).
+   - Mirrored-transform detection is not used as a blanket trigger for disabling culling.
+
+GLB/glTF scene import path is intentionally unchanged by this logic.

--- a/peraviz/native/src/mesh_3ds_loader.cpp
+++ b/peraviz/native/src/mesh_3ds_loader.cpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <fstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace {
@@ -25,6 +26,102 @@ struct MeshData {
     std::vector<uint32_t> indices;
     std::vector<float> normals;
 };
+
+float dot3(float ax, float ay, float az, float bx, float by, float bz) {
+    return ax * bx + ay * by + az * bz;
+}
+
+void cross3(float ax, float ay, float az, float bx, float by, float bz, float &rx, float &ry,
+            float &rz) {
+    rx = ay * bz - az * by;
+    ry = az * bx - ax * bz;
+    rz = ax * by - ay * bx;
+}
+
+// Ensures triangle winding points away from the mesh centroid after Godot axis mapping.
+// The score is area-weighted by triangle normal length and signed by the direction from the
+// global centroid to each triangle centroid. A negative score means most faces are inward.
+void ensure_outward_winding(std::vector<float> &vertices,
+                            std::vector<uint32_t> &indices,
+                            std::vector<float> &normals) {
+    const size_t vertex_count = vertices.size() / 3;
+    if (vertex_count == 0 || indices.size() < 3) {
+        return;
+    }
+
+    float centroid_x = 0.0F;
+    float centroid_y = 0.0F;
+    float centroid_z = 0.0F;
+    for (size_t i = 0; i < vertex_count; ++i) {
+        centroid_x += vertices[i * 3];
+        centroid_y += vertices[i * 3 + 1];
+        centroid_z += vertices[i * 3 + 2];
+    }
+    const float inv_vertex_count = 1.0F / static_cast<float>(vertex_count);
+    centroid_x *= inv_vertex_count;
+    centroid_y *= inv_vertex_count;
+    centroid_z *= inv_vertex_count;
+
+    double orientation_score = 0.0;
+    for (size_t i = 0; i + 2 < indices.size(); i += 3) {
+        const uint32_t i0 = indices[i];
+        const uint32_t i1 = indices[i + 1];
+        const uint32_t i2 = indices[i + 2];
+        if (i0 >= vertex_count || i1 >= vertex_count || i2 >= vertex_count) {
+            continue;
+        }
+
+        const float v0x = vertices[i0 * 3];
+        const float v0y = vertices[i0 * 3 + 1];
+        const float v0z = vertices[i0 * 3 + 2];
+        const float v1x = vertices[i1 * 3];
+        const float v1y = vertices[i1 * 3 + 1];
+        const float v1z = vertices[i1 * 3 + 2];
+        const float v2x = vertices[i2 * 3];
+        const float v2y = vertices[i2 * 3 + 1];
+        const float v2z = vertices[i2 * 3 + 2];
+
+        const float e1x = v1x - v0x;
+        const float e1y = v1y - v0y;
+        const float e1z = v1z - v0z;
+        const float e2x = v2x - v0x;
+        const float e2y = v2y - v0y;
+        const float e2z = v2z - v0z;
+
+        float nx = 0.0F;
+        float ny = 0.0F;
+        float nz = 0.0F;
+        cross3(e1x, e1y, e1z, e2x, e2y, e2z, nx, ny, nz);
+
+        const float normal_len = std::sqrt(nx * nx + ny * ny + nz * nz);
+        if (normal_len <= 1e-8F) {
+            continue;
+        }
+
+        const float tri_center_x = (v0x + v1x + v2x) / 3.0F;
+        const float tri_center_y = (v0y + v1y + v2y) / 3.0F;
+        const float tri_center_z = (v0z + v1z + v2z) / 3.0F;
+
+        const float cx = tri_center_x - centroid_x;
+        const float cy = tri_center_y - centroid_y;
+        const float cz = tri_center_z - centroid_z;
+        const float signed_term = dot3(nx, ny, nz, cx, cy, cz);
+        orientation_score += static_cast<double>(signed_term) * static_cast<double>(normal_len);
+    }
+
+    if (orientation_score >= 0.0) {
+        return;
+    }
+
+    for (size_t i = 0; i + 2 < indices.size(); i += 3) {
+        std::swap(indices[i + 1], indices[i + 2]);
+    }
+    for (size_t i = 0; i + 2 < normals.size(); i += 3) {
+        normals[i] = -normals[i];
+        normals[i + 1] = -normals[i + 1];
+        normals[i + 2] = -normals[i + 2];
+    }
+}
 
 bool read_chunk(std::ifstream &file, Chunk &chunk) {
     if (!file.read(reinterpret_cast<char *>(&chunk.id), sizeof(chunk.id))) {
@@ -234,26 +331,44 @@ bool load_3ds_mesh_data(const godot::String &path,
         return false;
     }
 
-    out_vertices.resize(static_cast<int64_t>(mesh.vertices.size() / 3));
-    for (int64_t i = 0; i < out_vertices.size(); ++i) {
+    std::vector<float> mapped_vertices(mesh.vertices.size());
+    for (size_t i = 0; i < mesh.vertices.size() / 3; ++i) {
         const std::array<float, 3> source_vertex = {
             mesh.vertices[i * 3] * kMillimetersToMeters,
             mesh.vertices[i * 3 + 1] * kMillimetersToMeters,
             mesh.vertices[i * 3 + 2] * kMillimetersToMeters,
         };
         const auto mapped = coordinate_mapper::map_source_vector_to_godot(source_vertex);
-        out_vertices.set(i, godot::Vector3(mapped[0], mapped[1], mapped[2]));
+        mapped_vertices[i * 3] = mapped[0];
+        mapped_vertices[i * 3 + 1] = mapped[1];
+        mapped_vertices[i * 3 + 2] = mapped[2];
     }
 
-    out_normals.resize(static_cast<int64_t>(mesh.normals.size() / 3));
-    for (int64_t i = 0; i < out_normals.size(); ++i) {
+    std::vector<float> mapped_normals(mesh.normals.size());
+    for (size_t i = 0; i < mesh.normals.size() / 3; ++i) {
         const std::array<float, 3> source_normal = {
             mesh.normals[i * 3],
             mesh.normals[i * 3 + 1],
             mesh.normals[i * 3 + 2],
         };
         const auto mapped = coordinate_mapper::map_source_vector_to_godot(source_normal);
-        out_normals.set(i, godot::Vector3(mapped[0], mapped[1], mapped[2]));
+        mapped_normals[i * 3] = mapped[0];
+        mapped_normals[i * 3 + 1] = mapped[1];
+        mapped_normals[i * 3 + 2] = mapped[2];
+    }
+
+    ensure_outward_winding(mapped_vertices, mesh.indices, mapped_normals);
+
+    out_vertices.resize(static_cast<int64_t>(mapped_vertices.size() / 3));
+    for (int64_t i = 0; i < out_vertices.size(); ++i) {
+        out_vertices.set(i, godot::Vector3(mapped_vertices[i * 3], mapped_vertices[i * 3 + 1],
+                                           mapped_vertices[i * 3 + 2]));
+    }
+
+    out_normals.resize(static_cast<int64_t>(mapped_normals.size() / 3));
+    for (int64_t i = 0; i < out_normals.size(); ++i) {
+        out_normals.set(i, godot::Vector3(mapped_normals[i * 3], mapped_normals[i * 3 + 1],
+                                          mapped_normals[i * 3 + 2]));
     }
 
     out_indices.resize(static_cast<int64_t>(mesh.indices.size()));

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -630,7 +630,7 @@ func _create_scene_node(data: Dictionary) -> Node3D:
 		root.add_child(emitter)
 
 	var visual_scale_hint: float = _extract_visual_scale_hint(data)
-	var model_node: Node3D = _build_visual_node(data, item_type, item_class, is_fixture, visual_scale_hint)
+	var model_node: Node3D = _build_visual_node(data, item_type, item_class, is_fixture, visual_scale_hint, root)
 	if model_node != null:
 		root.add_child(model_node)
 		if item_type == "fixture_geometry":
@@ -662,11 +662,11 @@ func _reparent_fixture_visual_children(geometry_node: Node3D, model_root: Node3D
 	if moved_any_child:
 		model_root.queue_free()
 
-func _build_visual_node(data: Dictionary, item_type: String, item_class: String, is_fixture: bool, visual_scale_hint: float) -> Node3D:
+func _build_visual_node(data: Dictionary, item_type: String, item_class: String, is_fixture: bool, visual_scale_hint: float, owner_node: Node3D) -> Node3D:
 	var asset_path: String = str(data.get("asset_path", ""))
 	var asset_kind: String = _extract_asset_kind(data, asset_path)
 	if not asset_path.is_empty():
-		var loaded: Variant = _load_3d_asset(asset_path, asset_kind)
+		var loaded: Variant = _load_3d_asset(asset_path, asset_kind, owner_node)
 		if loaded is Node3D:
 			var loaded_node: Node3D = loaded
 			_apply_selective_double_sided_to_candidates(loaded_node, data)
@@ -726,9 +726,6 @@ func _should_enable_double_sided(mesh_instance: MeshInstance3D, material: Materi
 
 	var source_type: String = str(source_data.get("type", "")).to_lower()
 	if source_type == "fixture_geometry":
-		return true
-
-	if _has_mirrored_transform_in_hierarchy(mesh_instance):
 		return true
 
 	var mesh_name_hint: String = mesh_instance.name.to_lower()
@@ -825,7 +822,7 @@ func _extract_visual_scale_hint(data: Dictionary) -> float:
 		return 1.0
 	return max(average_scale, 0.0001)
 
-func _load_3d_asset(asset_path: String, asset_kind_hint: String = "") -> Variant:
+func _load_3d_asset(asset_path: String, asset_kind_hint: String = "", owner_node: Node3D = null) -> Variant:
 	var resolved_asset_kind: String = asset_kind_hint.to_lower()
 	if resolved_asset_kind.is_empty() or resolved_asset_kind == "none":
 		resolved_asset_kind = _infer_asset_kind_from_extension(asset_path)
@@ -842,7 +839,7 @@ func _load_3d_asset(asset_path: String, asset_kind_hint: String = "") -> Variant
 		if not bool(mesh_data.get("ok", false)):
 			_asset_cache.mark_failed(asset_path)
 			return null
-		var mesh: ArrayMesh = _build_3ds_mesh(mesh_data)
+		var mesh: ArrayMesh = _build_3ds_mesh(mesh_data, owner_node)
 		if mesh == null:
 			_asset_cache.mark_failed(asset_path)
 			return null
@@ -908,12 +905,22 @@ func _infer_asset_kind_from_extension(asset_path: String) -> String:
 	return "none"
 
 
-func _build_3ds_mesh(mesh_data: Dictionary) -> ArrayMesh:
+func _build_3ds_mesh(mesh_data: Dictionary, owner_node: Node3D = null) -> ArrayMesh:
 	var vertices: PackedVector3Array = mesh_data.get("vertices", PackedVector3Array())
 	var normals: PackedVector3Array = mesh_data.get("normals", PackedVector3Array())
 	var indices: PackedInt32Array = mesh_data.get("indices", PackedInt32Array())
 	if vertices.is_empty() or indices.is_empty():
 		return null
+
+	## Mirror compensation: a negative determinant reverses front-face winding.
+	var is_mirrored: bool = owner_node != null and _has_mirrored_transform_in_hierarchy(owner_node)
+	if is_mirrored:
+		_flip_triangles_and_normals(indices, normals)
+
+	## Safety-net heuristic for malformed assets that still look inward after primary fixes.
+	if _looks_inside_out(vertices, indices, 128):
+		push_warning("[Peraviz] 3DS mesh still appears inward after initial winding fixes; applying fallback flip")
+		_flip_triangles_and_normals(indices, normals)
 
 	var arrays: Array = []
 	arrays.resize(Mesh.ARRAY_MAX)
@@ -924,6 +931,56 @@ func _build_3ds_mesh(mesh_data: Dictionary) -> ArrayMesh:
 	var array_mesh := ArrayMesh.new()
 	array_mesh.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, arrays)
 	return array_mesh
+
+
+# Reverses triangle winding and flips normals to keep lighting consistent.
+func _flip_triangles_and_normals(indices: PackedInt32Array, normals: PackedVector3Array) -> void:
+	var triangle_count: int = indices.size() / 3
+	for triangle_idx in range(triangle_count):
+		var base: int = triangle_idx * 3
+		var i1: int = indices[base + 1]
+		indices[base + 1] = indices[base + 2]
+		indices[base + 2] = i1
+
+	for normal_idx in range(normals.size()):
+		normals[normal_idx] = -normals[normal_idx]
+
+
+# Samples triangles and checks whether normals generally point toward the mesh centroid.
+func _looks_inside_out(vertices: PackedVector3Array, indices: PackedInt32Array, max_triangles: int) -> bool:
+	if vertices.is_empty() or indices.size() < 3:
+		return false
+
+	var centroid := Vector3.ZERO
+	for v in vertices:
+		centroid += v
+	centroid /= float(vertices.size())
+
+	var orientation_score: float = 0.0
+	var triangle_count: int = indices.size() / 3
+	var step: int = max(1, int(ceil(float(triangle_count) / float(max(1, max_triangles)))))
+	for triangle_idx in range(0, triangle_count, step):
+		var base: int = triangle_idx * 3
+		var i0: int = indices[base]
+		var i1: int = indices[base + 1]
+		var i2: int = indices[base + 2]
+		if i0 < 0 or i1 < 0 or i2 < 0:
+			continue
+		if i0 >= vertices.size() or i1 >= vertices.size() or i2 >= vertices.size():
+			continue
+
+		var v0: Vector3 = vertices[i0]
+		var v1: Vector3 = vertices[i1]
+		var v2: Vector3 = vertices[i2]
+		var normal: Vector3 = (v1 - v0).cross(v2 - v0)
+		var normal_len: float = normal.length()
+		if normal_len <= 1e-7:
+			continue
+
+		var triangle_center: Vector3 = (v0 + v1 + v2) / 3.0
+		orientation_score += normal.dot(triangle_center - centroid) * normal_len
+
+	return orientation_score < 0.0
 
 
 func _create_dummy_mesh(is_fixture: bool, visual_scale_hint: float) -> Node3D:

--- a/peraviz/scripts/repro_mac_axiom_vs_robin.gd
+++ b/peraviz/scripts/repro_mac_axiom_vs_robin.gd
@@ -1,0 +1,38 @@
+extends Node3D
+
+@export_file("*.mvr") var robin_megapointe_mvr: String
+@export_file("*.mvr") var mac_axiom_hybrid_mvr: String
+@export var fixture_spacing_m: float = 6.0
+@export var viewer_scene: PackedScene = preload("res://test.tscn")
+
+# Manual repro harness for winding/culling validation.
+# It spawns two independent viewers side by side so both fixtures can be audited quickly:
+# - Robin MegaPointe (GLB path, expected baseline)
+# - MAC Axiom Hybrid (3DS path, used for inside-out regression checks)
+func _ready() -> void:
+	_spawn_viewer(robin_megapointe_mvr, Vector3(-fixture_spacing_m * 0.5, 0.0, 0.0), "RobinMegaPointe")
+	_spawn_viewer(mac_axiom_hybrid_mvr, Vector3(fixture_spacing_m * 0.5, 0.0, 0.0), "MacAxiomHybrid")
+
+func _spawn_viewer(mvr_path: String, offset: Vector3, debug_name: String) -> void:
+	if viewer_scene == null:
+		push_warning("[PeravizRepro] Missing viewer scene; cannot spawn " + debug_name)
+		return
+
+	if mvr_path.is_empty():
+		push_warning("[PeravizRepro] Missing MVR path for " + debug_name)
+		return
+
+	var viewer_root := viewer_scene.instantiate()
+	if viewer_root is not Node3D:
+		push_warning("[PeravizRepro] Instanced viewer root is not Node3D for " + debug_name)
+		return
+
+	var viewer_node: Node3D = viewer_root
+	viewer_node.name = "Viewer_" + debug_name
+	add_child(viewer_node)
+	viewer_node.position = offset
+
+	if viewer_node.has_method("_on_file_selected"):
+		viewer_node.call_deferred("_on_file_selected", mvr_path)
+	else:
+		push_warning("[PeravizRepro] Viewer script does not expose _on_file_selected for " + debug_name)


### PR DESCRIPTION
### Motivation
- 3DS assets were rendering inside–out because loaded triangle winding was not corrected after axis/unit remap and mirrored transforms in the hierarchy were handled by making materials double‑sided instead of fixing winding. 
- The goal is to make `.3ds` imports match the viewer behaviour by ensuring meshes are outward‑wound and by compensating mirrored transforms at build time so backface culling can remain enabled for opaque geometry.

### Description
- Added a centroid-based outward‑winding correction `ensure_outward_winding(...)` in `peraviz/native/src/mesh_3ds_loader.cpp` that computes an area-weighted orientation score after axis/unit mapping and flips triangle index order and vertex normals when the score is negative. 
- Changed the 3DS build path in `peraviz/scripts/load_scene.gd` to pass the owning node context into `_build_3ds_mesh(...)`, detect mirrored transforms via `_has_mirrored_transform_in_hierarchy(...)`, and flip indices/normals for mirrored instances so rendered faces remain outward after the transform. 
- Added a safety‑net heuristic `_looks_inside_out(...)` and a helper `_flip_triangles_and_normals(...)` in `load_scene.gd` to optionally reflip malformed assets and log a warning, and preserved the GLB/glTF import path unchanged. 
- Reduced reliance on blanket double‑sided materials by removing mirrored‑transform detection as a trigger in `_should_enable_double_sided(...)` and kept double‑sided only for thin/translucent/name/material hints; added a small repro harness script `peraviz/scripts/repro_mac_axiom_vs_robin.gd` and documentation notes in `peraviz/docs/COORDINATE_SYSTEM.md` describing axis mapping and the winding/determinant fixes.

### Testing
- Ran the mandatory repository checks `tests/check_perastage_tree_modules.sh` which passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed. 
- Performed a local whitespace/diff safety check (`diff --check` equivalent) with no issues, and added a manual repro script to visually validate that Robin MegaPointe (GLB) remains correct and MAC Axiom Hybrid (3DS) no longer appears inside–out with backface culling enabled.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2312673248324b620e03d36181b46)