### PR TITLE
Add layout template import/export to LayoutPanel and LayoutManager

### DIFF
--- a/core/layouts/LayoutManager.cpp
+++ b/core/layouts/LayoutManager.cpp
@@ -22,6 +22,8 @@
 #include "json.hpp"
 
 #include <algorithm>
+#include <fstream>
+#include <iterator>
 #include <unordered_set>
 
 namespace layouts {
@@ -294,6 +296,92 @@ bool LayoutManager::MoveLayoutImage(const std::string &name, int imageId,
   return true;
 }
 
+bool LayoutManager::ExportLayoutTemplate(const std::string &name,
+                                         const std::string &filePath,
+                                         std::string *error) const {
+  const auto &items = layouts.Items();
+  auto it = std::find_if(items.begin(), items.end(),
+                         [&name](const LayoutDefinition &layout) {
+                           return layout.name == name;
+                         });
+  if (it == items.end()) {
+    if (error)
+      *error = "Layout not found.";
+    return false;
+  }
+
+  std::ofstream out(filePath, std::ios::binary);
+  if (!out.is_open()) {
+    if (error)
+      *error = "Could not open destination file.";
+    return false;
+  }
+
+  const nlohmann::json doc = ToTemplateDocument({*it});
+  out << doc.dump(2);
+  if (!out.good()) {
+    if (error)
+      *error = "Could not write template file.";
+    return false;
+  }
+
+  return true;
+}
+
+bool LayoutManager::ImportLayoutTemplate(const std::string &filePath,
+                                         std::string *importedLayoutName,
+                                         std::string *error) {
+  std::ifstream in(filePath, std::ios::binary);
+  if (!in.is_open()) {
+    if (error)
+      *error = "Could not open template file.";
+    return false;
+  }
+
+  const std::string fileContent((std::istreambuf_iterator<char>(in)),
+                                std::istreambuf_iterator<char>());
+  nlohmann::json parsed;
+  try {
+    parsed = nlohmann::json::parse(fileContent);
+  } catch (const std::exception &ex) {
+    if (error)
+      *error = ex.what();
+    return false;
+  }
+
+  std::vector<LayoutDefinition> loaded;
+  std::string parseError;
+  if (!FromTemplateDocument(parsed, loaded, &parseError)) {
+    if (error)
+      *error = parseError;
+    return false;
+  }
+  if (loaded.empty()) {
+    if (error)
+      *error = "Template does not contain any layouts.";
+    return false;
+  }
+
+  LayoutDefinition imported = loaded.front();
+  EnsureUniqueViewIds(imported);
+  EnsureUniqueLegendIds(imported);
+  EnsureUniqueEventTableIds(imported);
+  EnsureUniqueTextIds(imported);
+  EnsureUniqueImageIds(imported);
+  imported.name = MakeUniqueLayoutName(imported.name);
+
+  if (!layouts.AddLayout(imported)) {
+    if (error)
+      *error = "Could not add imported layout.";
+    return false;
+  }
+
+  if (importedLayoutName)
+    *importedLayoutName = imported.name;
+  SyncToConfig();
+  return true;
+}
+
 void LayoutManager::BeginBatchUpdate() { ++batchDepth; }
 
 void LayoutManager::EndBatchUpdate() {
@@ -350,6 +438,27 @@ void LayoutManager::SyncToConfig() {
   }
   pendingSync = false;
   SaveToConfig(ConfigManager::Get());
+}
+
+std::string LayoutManager::MakeUniqueLayoutName(
+    const std::string &baseName) const {
+  const std::string safeBase = baseName.empty() ? "Layout" : baseName;
+  std::string candidate = safeBase;
+  int suffix = 2;
+
+  const auto &items = layouts.Items();
+  auto exists = [&items](const std::string &name) {
+    return std::any_of(items.begin(), items.end(),
+                       [&name](const LayoutDefinition &layout) {
+                         return layout.name == name;
+                       });
+  };
+
+  while (exists(candidate)) {
+    candidate = safeBase + " (" + std::to_string(suffix) + ")";
+    ++suffix;
+  }
+  return candidate;
 }
 
 } // namespace layouts

--- a/core/layouts/LayoutManager.h
+++ b/core/layouts/LayoutManager.h
@@ -54,6 +54,12 @@ public:
                          const LayoutImageDefinition &image);
   bool RemoveLayoutImage(const std::string &name, int imageId);
   bool MoveLayoutImage(const std::string &name, int imageId, bool toFront);
+  bool ExportLayoutTemplate(const std::string &name,
+                            const std::string &filePath,
+                            std::string *error) const;
+  bool ImportLayoutTemplate(const std::string &filePath,
+                            std::string *importedLayoutName,
+                            std::string *error);
 
   void BeginBatchUpdate();
   void EndBatchUpdate();
@@ -64,6 +70,7 @@ public:
 
 private:
   LayoutManager();
+  std::string MakeUniqueLayoutName(const std::string &baseName) const;
   void SyncToConfig();
 
   LayoutCollection layouts;

--- a/gui/layoutpanel.cpp
+++ b/gui/layoutpanel.cpp
@@ -20,6 +20,7 @@
 #include "columnutils.h"
 #include "LayoutManager.h"
 #include <wx/choicdlg.h>
+#include <wx/filedlg.h>
 
 LayoutPanel *LayoutPanel::s_instance = nullptr;
 wxDEFINE_EVENT(EVT_LAYOUT_SELECTED, wxCommandEvent);
@@ -37,9 +38,15 @@ LayoutPanel::LayoutPanel(wxWindow *parent) : wxPanel(parent, wxID_ANY) {
   auto *addBtn = new wxButton(this, wxID_ADD, "Add");
   auto *renameBtn = new wxButton(this, wxID_EDIT, "Rename");
   auto *delBtn = new wxButton(this, wxID_DELETE, "Delete");
+  auto *exportTemplateBtn =
+      new wxButton(this, wxID_ANY, "Export template");
+  auto *importTemplateBtn =
+      new wxButton(this, wxID_ANY, "Import template");
   btnSizer->Add(addBtn, 0, wxALL, 5);
   btnSizer->Add(renameBtn, 0, wxALL, 5);
   btnSizer->Add(delBtn, 0, wxALL, 5);
+  btnSizer->Add(exportTemplateBtn, 0, wxALL, 5);
+  btnSizer->Add(importTemplateBtn, 0, wxALL, 5);
   sizer->Add(btnSizer, 0, wxALIGN_LEFT);
 
   SetSizer(sizer);
@@ -51,6 +58,10 @@ LayoutPanel::LayoutPanel(wxWindow *parent) : wxPanel(parent, wxID_ANY) {
   addBtn->Bind(wxEVT_BUTTON, &LayoutPanel::OnAddLayout, this);
   renameBtn->Bind(wxEVT_BUTTON, &LayoutPanel::OnRenameLayout, this);
   delBtn->Bind(wxEVT_BUTTON, &LayoutPanel::OnDeleteLayout, this);
+  exportTemplateBtn->Bind(wxEVT_BUTTON,
+                          &LayoutPanel::OnExportLayoutTemplate, this);
+  importTemplateBtn->Bind(wxEVT_BUTTON,
+                          &LayoutPanel::OnImportLayoutTemplate, this);
 
   ReloadLayouts();
 }
@@ -252,6 +263,55 @@ void LayoutPanel::OnDeleteLayout(wxCommandEvent &) {
   if (layoutName == currentLayout)
     currentLayout.clear();
   ReloadLayouts();
+}
+
+void LayoutPanel::OnExportLayoutTemplate(wxCommandEvent &) {
+  if (!list)
+    return;
+
+  const int sel = list->GetSelectedRow();
+  if (sel == wxNOT_FOUND)
+    return;
+
+  const wxString selectedName = list->GetTextValue(sel, 0);
+  wxFileDialog saveDialog(this, "Export layout template", wxEmptyString,
+                          selectedName + ".json",
+                          "JSON files (*.json)|*.json",
+                          wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+  if (saveDialog.ShowModal() != wxID_OK)
+    return;
+
+  std::string error;
+  if (!layouts::LayoutManager::Get().ExportLayoutTemplate(
+          selectedName.ToStdString(), saveDialog.GetPath().ToStdString(),
+          &error)) {
+    wxMessageBox("Could not export layout template.\n" +
+                     wxString::FromUTF8(error),
+                 "Export template", wxOK | wxICON_ERROR, this);
+    return;
+  }
+}
+
+void LayoutPanel::OnImportLayoutTemplate(wxCommandEvent &) {
+  wxFileDialog openDialog(this, "Import layout template", wxEmptyString,
+                          wxEmptyString, "JSON files (*.json)|*.json",
+                          wxFD_OPEN | wxFD_FILE_MUST_EXIST);
+  if (openDialog.ShowModal() != wxID_OK)
+    return;
+
+  std::string importedLayoutName;
+  std::string error;
+  if (!layouts::LayoutManager::Get().ImportLayoutTemplate(
+          openDialog.GetPath().ToStdString(), &importedLayoutName, &error)) {
+    wxMessageBox("Could not import layout template.\n" +
+                     wxString::FromUTF8(error),
+                 "Import template", wxOK | wxICON_ERROR, this);
+    return;
+  }
+
+  currentLayout = importedLayoutName;
+  ReloadLayouts();
+  EmitLayoutSelected(importedLayoutName);
 }
 
 void LayoutPanel::EmitLayoutSelected(const std::string &layoutName) {

--- a/gui/layoutpanel.h
+++ b/gui/layoutpanel.h
@@ -36,6 +36,8 @@ private:
   void OnAddLayout(wxCommandEvent &evt);
   void OnRenameLayout(wxCommandEvent &evt);
   void OnDeleteLayout(wxCommandEvent &evt);
+  void OnExportLayoutTemplate(wxCommandEvent &evt);
+  void OnImportLayoutTemplate(wxCommandEvent &evt);
   void EmitLayoutSelected(const std::string &layoutName);
 
   wxDataViewListCtrl *list = nullptr;


### PR DESCRIPTION
### Motivation

- Provide users with the ability to export and import layout templates as `*.json` files from the layout UI while preserving clear separation between UI and core logic.
- Keep UI code focused on dialogs and event wiring and move parsing/serialization and layout creation into the layouts core.

### Description

- Added `Export template` and `Import template` buttons to `LayoutPanel` and new handlers `OnExportLayoutTemplate(wxCommandEvent&)` and `OnImportLayoutTemplate(wxCommandEvent&)` that use `wxFileDialog` for `*.json` selection (changes in `gui/layoutpanel.h/.cpp`).
- Added `LayoutManager::ExportLayoutTemplate(...)` and `LayoutManager::ImportLayoutTemplate(...)` APIs and a helper `MakeUniqueLayoutName(...)` (changes in `core/layouts/LayoutManager.h/.cpp`).
- `ExportLayoutTemplate` serializes a single layout to a template document using existing `LayoutTemplateSerializer` helpers and writes pretty JSON to the selected file, while `ImportLayoutTemplate` parses the JSON via `FromTemplateDocument`, normalizes element IDs (`EnsureUnique*`), generates a non-colliding layout name, adds the layout, and calls `SyncToConfig()`.
- After successful import the UI sets the new layout as current, calls `ReloadLayouts()`, and emits selection via `EmitLayoutSelected(...)` so the rest of the app picks up the change.

### Testing

- Ran `tests/check_perastage_tree_modules.sh` which completed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a239a2c74483249c84ba813e3c6c18)