### PR TITLE
Add preferred-name import flow to LayoutManager templates

### DIFF
--- a/core/layouts/LayoutManager.cpp
+++ b/core/layouts/LayoutManager.cpp
@@ -329,7 +329,8 @@ bool LayoutManager::ExportLayoutTemplate(const std::string &name,
 }
 
 bool LayoutManager::ImportLayoutTemplate(const std::string &filePath,
-                                         std::string *importedLayoutName,
+                                         const std::string &preferredName,
+                                         std::string *createdLayoutName,
                                          std::string *error) {
   std::ifstream in(filePath, std::ios::binary);
   if (!in.is_open()) {
@@ -368,17 +369,18 @@ bool LayoutManager::ImportLayoutTemplate(const std::string &filePath,
   EnsureUniqueEventTableIds(imported);
   EnsureUniqueTextIds(imported);
   EnsureUniqueImageIds(imported);
+  if (!preferredName.empty())
+    imported.name = preferredName;
   imported.name = MakeUniqueLayoutName(imported.name);
 
-  if (!layouts.AddLayout(imported)) {
+  if (!AddLayout(imported)) {
     if (error)
       *error = "Could not add imported layout.";
     return false;
   }
 
-  if (importedLayoutName)
-    *importedLayoutName = imported.name;
-  SyncToConfig();
+  if (createdLayoutName)
+    *createdLayoutName = imported.name;
   return true;
 }
 

--- a/core/layouts/LayoutManager.h
+++ b/core/layouts/LayoutManager.h
@@ -58,7 +58,8 @@ public:
                             const std::string &filePath,
                             std::string *error) const;
   bool ImportLayoutTemplate(const std::string &filePath,
-                            std::string *importedLayoutName,
+                            const std::string &preferredName,
+                            std::string *createdLayoutName,
                             std::string *error);
 
   void BeginBatchUpdate();

--- a/gui/layoutpanel.cpp
+++ b/gui/layoutpanel.cpp
@@ -302,7 +302,8 @@ void LayoutPanel::OnImportLayoutTemplate(wxCommandEvent &) {
   std::string importedLayoutName;
   std::string error;
   if (!layouts::LayoutManager::Get().ImportLayoutTemplate(
-          openDialog.GetPath().ToStdString(), &importedLayoutName, &error)) {
+          openDialog.GetPath().ToStdString(), std::string(),
+          &importedLayoutName, &error)) {
     wxMessageBox("Could not import layout template.\n" +
                      wxString::FromUTF8(error),
                  "Import template", wxOK | wxICON_ERROR, this);


### PR DESCRIPTION
### Motivation
- Allow callers to suggest a preferred name when importing a layout template and return the actual created name while keeping config synchronization and core-only responsibilities intact.

### Description
- Extended `layouts::LayoutManager::ImportLayoutTemplate` to accept a `preferredName` and return the `createdLayoutName` via output pointer, and applied the preferred name before collision resolution using `MakeUniqueLayoutName`.
- Switched insertion in the import flow to call the central `AddLayout(...)` path so synchronization flows through the existing `SyncToConfig`/batch logic and avoids duplicating GUI/config logic in core.
- Updated the GUI caller in `gui/layoutpanel.cpp` to pass an empty `preferredName` to preserve current UI behavior and keep GUI changes minimal and localized.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.
- Attempted a CMake configure/build (`cmake -S . -B build && cmake --build build -j2`) which failed in this environment due to missing `wxWidgets` development files, not due to the code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a23bb612b88324b263787862cef59c)