### PR TITLE
Change Layout Viewer fit shortcut from Z to F

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1027,7 +1027,7 @@ void LayoutViewerPanel::OnKeyDown(wxKeyEvent &event) {
     }
     return;
   }
-  if (key == 'Z' || key == 'z') {
+  if (key == 'F' || key == 'f') {
     ResetViewToFit();
     RequestRenderRebuild();
     Refresh();


### PR DESCRIPTION
### Motivation
- Align the Layout Viewer shortcut with other viewers so the fit-to-view action uses `F`/`f` instead of `Z`/`z`.

### Description
- Update `LayoutViewerPanel::OnKeyDown` in `gui/layoutviewerpanel.cpp` to call `ResetViewToFit()` (and then `RequestRenderRebuild()` and `Refresh()`) when `F`/`f` is pressed, replacing the previous `Z`/`z` check.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a23fdd68988324ad03beb80464a5f7)