### PR TITLE
Fix side-view SVG lookup in Perastage GDTF symbol loader

### DIFF
--- a/core/symbols/PerastageSvgSymbol.cpp
+++ b/core/symbols/PerastageSvgSymbol.cpp
@@ -651,6 +651,14 @@ bool LoadPerastageSvgSymbolFromGdtf(const std::string &gdtfPath,
                             "SVGFrontOffsetX", "SVGFrontOffsetY"});
     }
     pushTopCandidates();
+  } else if (requestedView == SymbolViewKind::Left ||
+             requestedView == SymbolViewKind::Right) {
+    for (const auto &name : baseNameCandidates) {
+      candidates.push_back(
+          {requestedView, "models/svg_side/" + name + ".svg",
+           "SVGSideOffsetX", "SVGSideOffsetY"});
+    }
+    pushTopCandidates();
   } else {
     pushTopCandidates();
   }


### PR DESCRIPTION
### Motivation
- Lateral (side) 2D layout views were showing the top symbol because side requests fell through to the top-view candidates instead of searching the Perastage-generated side SVG path. 
- The change ensures side view symbol lookup uses the canonical archive path and offset attributes produced by Perastage symbol tooling so lateral views render the correct SVG when available.

### Description
- Added handling in `LoadPerastageSvgSymbolFromGdtf` to search `models/svg_side/<base>.svg` when `SymbolViewKind::Left` or `SymbolViewKind::Right` is requested. 
- Wired the side-view offsets to the GDTF attributes `SVGSideOffsetX` and `SVGSideOffsetY` when selecting the side SVG candidate. 
- Kept the existing fallback behavior to top-view candidates when a side SVG is not present. 
- Modified file: `core/symbols/PerastageSvgSymbol.cpp` (updated candidate list and mapping logic).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a245fbed688324b66b9b2f721714a9)