### PR TITLE
Handle long MVR entry paths during project loading

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -20,6 +20,7 @@
 #include "LayoutManager.h"
 #include "mvrexporter.h"
 #include "mvrimporter.h"
+#include "logger.h"
 #include <filesystem>
 #include <fstream>
 #include <charconv>
@@ -404,10 +405,21 @@ bool ConfigManager::LoadProject(const std::string &path) {
 
   bool ok = projectSession.LoadProject(
       path, [this](const std::string &configPath) {
-        return LoadFromFile(configPath);
+        const bool loaded = LoadFromFile(configPath);
+        if (!loaded) {
+          Logger::Instance().Log(Logger::Level::Error,
+                                 "ConfigManager::LoadProject failed to load config.json from project package.");
+        }
+        return loaded;
       },
       [](const std::string &scenePath) {
-        return MvrImporter::ImportAndRegister(scenePath, false);
+        const bool imported = MvrImporter::ImportAndRegister(scenePath, false);
+        if (!imported) {
+          Logger::Instance().Log(
+              Logger::Level::Error,
+              "ConfigManager::LoadProject failed to import scene.mvr (check previous MVR extraction/import log lines).");
+        }
+        return imported;
       });
 
   if (ok) {

--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -20,9 +20,9 @@
 #include "LayoutManager.h"
 #include "mvrexporter.h"
 #include "mvrimporter.h"
-#include "logger.h"
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <charconv>
 #include <sstream>
 #include <string_view>
@@ -407,17 +407,14 @@ bool ConfigManager::LoadProject(const std::string &path) {
       path, [this](const std::string &configPath) {
         const bool loaded = LoadFromFile(configPath);
         if (!loaded) {
-          Logger::Instance().Log(Logger::Level::Error,
-                                 "ConfigManager::LoadProject failed to load config.json from project package.");
+          std::cerr << "ConfigManager::LoadProject failed to load config.json from project package." << std::endl;
         }
         return loaded;
       },
       [](const std::string &scenePath) {
         const bool imported = MvrImporter::ImportAndRegister(scenePath, false);
         if (!imported) {
-          Logger::Instance().Log(
-              Logger::Level::Error,
-              "ConfigManager::LoadProject failed to import scene.mvr (check previous MVR extraction/import log lines).");
+          std::cerr << "ConfigManager::LoadProject failed to import scene.mvr (check previous MVR extraction/import log lines)." << std::endl;
         }
         return imported;
       });

--- a/core/configservices.cpp
+++ b/core/configservices.cpp
@@ -1,7 +1,6 @@
 #include "configservices.h"
 
 #include "json.hpp"
-#include "logger.h"
 
 #include <algorithm>
 #include <charconv>
@@ -9,6 +8,7 @@
 #include <chrono>
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <set>
 #include <memory>
 #include <sstream>
@@ -626,16 +626,14 @@ bool ProjectSession::LoadProject(const std::string &path,
   if (!scenePath.empty()) {
     const bool sceneOk = loadScene(scenePath.string());
     if (!sceneOk) {
-      Logger::Instance().Log(Logger::Level::Error,
-                             "ProjectSession::LoadProject failed while loading scene.mvr from extracted project package.");
+      std::cerr << "ProjectSession::LoadProject failed while loading scene.mvr from extracted project package." << std::endl;
     }
     ok &= sceneOk;
   }
   if (!configPath.empty()) {
     const bool configOk = loadConfig(configPath.string());
     if (!configOk) {
-      Logger::Instance().Log(Logger::Level::Error,
-                             "ProjectSession::LoadProject failed while loading config.json from extracted project package.");
+      std::cerr << "ProjectSession::LoadProject failed while loading config.json from extracted project package." << std::endl;
     }
     ok &= configOk;
   }

--- a/core/configservices.cpp
+++ b/core/configservices.cpp
@@ -1,6 +1,7 @@
 #include "configservices.h"
 
 #include "json.hpp"
+#include "logger.h"
 
 #include <algorithm>
 #include <charconv>
@@ -518,7 +519,7 @@ bool ProjectSession::SaveProject(const std::string &path,
   if (!saveConfig || !saveScene)
     return false;
 
-  TempDir tempDir("PerastageProj_");
+  TempDir tempDir("psp_");
   if (!tempDir.Valid())
     return false;
 
@@ -571,7 +572,7 @@ bool ProjectSession::LoadProject(const std::string &path,
     return false;
   wxZipInputStream zip(in);
 
-  TempDir tempDir("PerastageProj_");
+  TempDir tempDir("psp_");
   if (!tempDir.Valid())
     return false;
 
@@ -622,10 +623,22 @@ bool ProjectSession::LoadProject(const std::string &path,
   }
 
   bool ok = true;
-  if (!scenePath.empty())
-    ok &= loadScene(scenePath.string());
-  if (!configPath.empty())
-    ok &= loadConfig(configPath.string());
+  if (!scenePath.empty()) {
+    const bool sceneOk = loadScene(scenePath.string());
+    if (!sceneOk) {
+      Logger::Instance().Log(Logger::Level::Error,
+                             "ProjectSession::LoadProject failed while loading scene.mvr from extracted project package.");
+    }
+    ok &= sceneOk;
+  }
+  if (!configPath.empty()) {
+    const bool configOk = loadConfig(configPath.string());
+    if (!configOk) {
+      Logger::Instance().Log(Logger::Level::Error,
+                             "ProjectSession::LoadProject failed while loading config.json from extracted project package.");
+    }
+    ok &= configOk;
+  }
   return ok;
 }
 

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -42,6 +42,7 @@
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <system_error>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -72,6 +73,41 @@ static std::string Trim(const std::string &s) {
     return {};
   size_t end = s.find_last_not_of(ws);
   return s.substr(start, end - start + 1);
+}
+
+static std::string NormalizeSlashes(std::string path) {
+  std::replace(path.begin(), path.end(), '\\', '/');
+  return path;
+}
+
+static std::string ToLowerAscii(std::string text) {
+  std::transform(text.begin(), text.end(), text.begin(), [](unsigned char c) {
+    return static_cast<char>(std::tolower(c));
+  });
+  return text;
+}
+
+static std::string GenerateShortToken(size_t length = 10) {
+  static constexpr char kAlphabet[] = "0123456789abcdefghijklmnopqrstuvwxyz";
+  std::random_device rd;
+  std::mt19937_64 rng(rd());
+  std::uniform_int_distribution<size_t> dist(0, sizeof(kAlphabet) - 2);
+
+  std::string token;
+  token.reserve(length);
+  for (size_t i = 0; i < length; ++i)
+    token.push_back(kAlphabet[dist(rng)]);
+  return token;
+}
+
+static bool IsPathLikelyTooLong(const fs::path &path) {
+#ifdef _WIN32
+  constexpr size_t kLegacyMaxPathSafetyLimit = 245;
+  return ToString(path.u8string()).size() >= kLegacyMaxPathSafetyLimit;
+#else
+  (void)path;
+  return false;
+#endif
 }
 
 static bool TryParseFloat(const std::string &text, float &out) {
@@ -248,6 +284,7 @@ PromptGdtfConflicts(const std::vector<GdtfConflict> &conflicts) {
 bool MvrImporter::ImportFromFile(const std::string &filePath,
                                  bool promptConflicts,
                                  bool applyDictionary) {
+  pathRemap.clear();
   // Treat the incoming path as UTF-8 to preserve any non-ASCII characters
   fs::path path = fs::u8path(filePath);
 
@@ -298,17 +335,38 @@ bool MvrImporter::ImportFromFile(const std::string &filePath,
   return ParseSceneXml(scenePath, promptConflicts, applyDictionary);
 }
 
+std::string MvrImporter::NormalizeArchivePath(const std::string &archivePath) const {
+  std::string normalized = Trim(NormalizeSlashes(archivePath));
+#ifdef _WIN32
+  normalized = ToLowerAscii(normalized);
+#endif
+  return normalized;
+}
+
+std::string MvrImporter::RemapArchivePathIfNeeded(const std::string &archivePath) const {
+  const std::string normalized = NormalizeArchivePath(archivePath);
+  auto it = pathRemap.find(normalized);
+  if (it != pathRemap.end())
+    return it->second;
+  return archivePath;
+}
+
 std::string MvrImporter::CreateTemporaryDirectory() {
-  auto now = std::chrono::system_clock::now().time_since_epoch().count();
-  std::string folderName = "Perastage_" + std::to_string(now);
-
   fs::path tempBase = fs::temp_directory_path();
-  fs::path fullPath = tempBase / folderName;
+  for (int attempt = 0; attempt < 32; ++attempt) {
+    fs::path fullPath = tempBase / ("ps_" + GenerateShortToken());
+    std::error_code ec;
+    if (fs::create_directory(fullPath, ec) && !ec) {
+      // Return the path encoded as UTF-8 so it can safely be converted back
+      // using fs::u8path or passed to wxWidgets APIs expecting UTF-8 strings.
+      return ToString(fullPath.u8string());
+    }
+  }
 
-  fs::create_directory(fullPath);
-  // Return the path encoded as UTF-8 so it can safely be converted back
-  // using fs::u8path or passed to wxWidgets APIs expecting UTF-8 strings.
-  return ToString(fullPath.u8string());
+  fs::path fallback = tempBase / ("ps_" + std::to_string(
+                                      std::chrono::system_clock::now().time_since_epoch().count()));
+  fs::create_directory(fallback);
+  return ToString(fallback.u8string());
 }
 
 bool MvrImporter::ExtractMvrZip(const std::string &mvrPath,
@@ -324,8 +382,8 @@ bool MvrImporter::ExtractMvrZip(const std::string &mvrPath,
 
   while ((entry.reset(zipStream.GetNextEntry())), entry) {
     // Extract entry names using UTF-8 to preserve special characters
-    std::string filename = entry->GetName().ToUTF8().data();
-    fs::path fullPath = fs::u8path(destDir) / fs::u8path(filename);
+    std::string entryName = entry->GetName().ToUTF8().data();
+    fs::path fullPath = fs::u8path(destDir) / fs::u8path(entryName);
 
     if (entry->IsDir()) {
       std::string dirUtf8 = ToString(fullPath.u8string());
@@ -338,10 +396,58 @@ bool MvrImporter::ExtractMvrZip(const std::string &mvrPath,
     wxFileName::Mkdir(wxString::FromUTF8(parentUtf8.c_str()), wxS_DIR_DEFAULT,
                       wxPATH_MKDIR_FULL);
 
-    std::ofstream output(fullPath, std::ios::binary);
+    const std::string normalizedEntryName = NormalizeArchivePath(entryName);
+    const size_t fullPathLength = ToString(fullPath.u8string()).size();
+
+    auto tryOpenOutput = [](const fs::path &path) {
+      return std::ofstream(path, std::ios::binary);
+    };
+
+    std::ofstream output;
+    bool remapped = false;
+    if (!IsPathLikelyTooLong(fullPath))
+      output = tryOpenOutput(fullPath);
+
     if (!output.is_open()) {
-      LogMessage("Cannot create file: " + ToString(fullPath.u8string()));
+      fs::path longDir = fs::u8path(destDir) / "_long";
+      std::string extension = fs::u8path(entryName).extension().string();
+      std::string hashBase = std::to_string(std::hash<std::string>{}(normalizedEntryName));
+      wxFileName::Mkdir(wxString::FromUTF8(ToString(longDir.u8string()).c_str()),
+                        wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
+
+      for (int suffix = 0; suffix < 64 && !output.is_open(); ++suffix) {
+        std::string candidateName = hashBase;
+        if (suffix > 0)
+          candidateName += "_" + std::to_string(suffix);
+        candidateName += extension;
+        fs::path candidatePath = longDir / fs::u8path(candidateName);
+        output = tryOpenOutput(candidatePath);
+        if (output.is_open()) {
+          fullPath = candidatePath;
+          pathRemap[normalizedEntryName] = ToString((fs::path("_long") /
+                                                     fs::u8path(candidateName))
+                                                        .u8string());
+          remapped = true;
+        }
+      }
+    }
+
+    if (!output.is_open()) {
+      std::ostringstream msg;
+      msg << "Cannot create file while extracting MVR entry. entry='" << entryName
+          << "', path='" << ToString(fullPath.u8string())
+          << "', pathLength=" << fullPathLength;
+      LogMessage(Logger::Level::Error, msg.str());
       return false;
+    }
+
+    if (remapped) {
+      const std::string remappedPath = pathRemap[normalizedEntryName];
+      std::ostringstream warn;
+      warn << "MVR extraction remapped long path entry. entry='" << entryName
+           << "', remapped='" << remappedPath
+           << "', originalLength=" << fullPathLength;
+      LogMessage(Logger::Level::Warn, warn.str());
     }
 
     char buffer[4096];
@@ -467,7 +573,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         if (std::string(name) == "Geometry3D") {
           SymdefGeometry g;
           if (const char *fname = child->Attribute("fileName"))
-            g.file = fname;
+            g.file = RemapArchivePathIfNeeded(fname);
           if (const char *type = child->Attribute("geometryType"))
             g.geometryType = Trim(type);
           g.transform = composed;
@@ -555,7 +661,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
     std::string normalized = normalizeGeometryFileName(std::move(fileName));
     if (normalized.empty())
       return normalized;
-    const fs::path resolved = ResolveSceneRelativePath(scene.basePath, normalized);
+    std::string remapped = RemapArchivePathIfNeeded(normalized);
+    const fs::path resolved = ResolveSceneRelativePath(scene.basePath, remapped);
     return ToString(resolved.u8string());
   };
 
@@ -566,7 +673,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
     if (normalized.empty())
       return;
     GeometryInstance instance;
-    instance.modelFile = normalized;
+    instance.modelFile = RemapArchivePathIfNeeded(normalized);
     instance.localTransform = localTransform;
     instances.push_back(std::move(instance));
   };
@@ -735,6 +842,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
           }
         }
         if (!fixture.gdtfSpec.empty()) {
+          fixture.gdtfSpec = RemapArchivePathIfNeeded(fixture.gdtfSpec);
           fs::path p =
               scene.basePath.empty()
                   ? fs::u8path(fixture.gdtfSpec)
@@ -824,6 +932,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
 
         bool gdtfLoadFailed = false;
         if (!truss.gdtfSpec.empty()) {
+          truss.gdtfSpec = RemapArchivePathIfNeeded(truss.gdtfSpec);
           fs::path gdtfPath = scene.basePath.empty()
                                   ? fs::u8path(truss.gdtfSpec)
                                   : fs::u8path(scene.basePath) / fs::u8path(truss.gdtfSpec);
@@ -994,7 +1103,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
           return {};
         };
 
-        support.gdtfSpec = readText("GDTFSpec");
+        support.gdtfSpec = RemapArchivePathIfNeeded(readText("GDTFSpec"));
         support.gdtfMode = readText("GDTFMode");
         support.function = readText("Function");
         support.hoistFunction = NormalizeHoistFunction(support.function);

--- a/mvr/mvrimporter.h
+++ b/mvr/mvrimporter.h
@@ -17,6 +17,7 @@
  */
 #pragma once
 
+#include <unordered_map>
 #include <string>
 
 // Responsible for importing .mvr files into the application's internal data model
@@ -38,6 +39,8 @@ public:
                                   bool applyDictionary = true);
 
 private:
+    std::unordered_map<std::string, std::string> pathRemap;
+
     // Creates a temporary directory for extracting the contents of the MVR archive
     std::string CreateTemporaryDirectory();
 
@@ -49,4 +52,7 @@ private:
     // If applyDictionary is false, existing GDTF assignments are kept intact
     bool ParseSceneXml(const std::string& sceneXmlPath, bool promptConflicts,
                        bool applyDictionary);
+
+    std::string NormalizeArchivePath(const std::string& archivePath) const;
+    std::string RemapArchivePathIfNeeded(const std::string& archivePath) const;
 };

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,11 @@
+# Tests notes
+
+## MVR long-path extraction regression
+
+The MVR importer now remaps archive entries to `/_long/<hash>.<ext>` when direct extraction would exceed safe Windows path limits (MAX_PATH-compatible mode) or when file creation fails.
+
+When adding MVR parsing changes, please validate these cases:
+
+1. A normal MVR with short file names still preserves original archive-relative references.
+2. A long-path MVR still imports and resolves `GDTFSpec` and `Geometry3D/@fileName` references through the remap table.
+3. Logs include the remap warning with original entry name and original full path length.


### PR DESCRIPTION
### Motivation
- Opening some projects failed with a generic “Failed to load project” because extracting entries from an embedded MVR produced absolute paths longer than Windows MAX_PATH and file creation aborted; the importer must be resilient and prefer to recover rather than abort.
- The intent is to reduce temp-path pressure and add a robust fallback so referenced files (GDTF, Geometry3D, Symdef geometries) can still be resolved after extraction.

### Description
- Shortened temporary extraction prefixes to reduce path length pressure by changing the importer temp folder name to `ps_<token>` and the project/session temp prefix to `psp_`.
- Added a remap table (`MvrImporter::pathRemap`) and normalization helpers (`NormalizeArchivePath`, `RemapArchivePathIfNeeded`, slash/case normalization) to detect and lookup remapped archive-relative paths.
- Made `ExtractMvrZip` resilient: it tries to write the original path, checks for likely-too-long Windows paths, and on failure falls back to extracting into `/_long/<hash><optional_suffix><ext>`, records `originalArchivePath -> _long/<...>` in `pathRemap`, logs a warning with the original name, new name and original full-path length, and continues extraction instead of aborting the whole import.
- Applied remapping when resolving scene references in `ParseSceneXml`, including `GDTFSpec`, `Geometry3D/@fileName`, symdef-derived geometry files and geometry instance resolution, so remapped files are found after extraction.
- Improved diagnostics: `ProjectSession::LoadProject` and `ConfigManager::LoadProject` now log explicit error lines indicating whether `scene.mvr` or `config.json` failed to load, making future debugging clearer.
- Added a developer note `tests/README.md` describing the long-path remap behavior and what to validate when changing MVR parsing.

Files touched (high-level): `mvr/mvrimporter.{cpp,h}` (remap logic, temp dir, extraction fallback, XML remap usage), `core/configservices.cpp` (shorten `PerastageProj_` -> `psp_`, improved load diagnostics), `core/configmanager.cpp` (explicit error logging on import/load failures), and `tests/README.md` (notes).

### Testing
- Ran module/check scripts: `tests/check_perastage_tree_modules.sh` — OK.
- Ran GUI rule check: `tests/check_no_configmanager_get_in_gui.sh` — OK.
- Attempted `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` in the container, which failed due to missing system `wxWidgets` development packages (environment limitation), so a full build was not performed here.
- Manual Windows repro (opening provided `testleyend2.pstg`) could not be executed in this Linux environment; the code changes implement the requested fallback and path remapping so the importer should succeed on Windows without enabling long-path support.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3fdd5a2088324a0921ad354ae60bd)