### PR TITLE
Prepare Peraviz beams for Godot fog light projector support (native cookie path)

### DIFF
--- a/peraviz/README_gobos.md
+++ b/peraviz/README_gobos.md
@@ -57,6 +57,14 @@ If the footprint looks correct on the floor but the beam in air looks too soft, 
 
 Peraviz now applies those shadow-cookie defaults when gobos are active in `shadow_cookie` mode, while keeping them user-tunable from Visual Settings.
 
+### Godot fog projector integration (PR #106395)
+
+Peraviz beam fallback is now prepared for engines where `SpotLight3D.light_projector` affects volumetric fog (Godot PR #106395):
+
+- If gobo mode is `projector_cookie` **and** fog projectors are supported, Peraviz keeps the mesh beam subtle so native fog projector patterning dominates.
+- If gobo mode is `shadow_cookie`, behavior remains the same (occluder + spotlight shadows in fog).
+- Runtime detection defaults to Godot `>= 4.5`, and can be overridden with project setting `peraviz_fog_light_projectors` (`"auto"`, `"enabled"`, `"disabled"`).
+
 
 ### Scale and resolution notes
 

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -82,7 +82,7 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	var threshold: float = float(params.get("intensity_visibility_threshold", 0.015))
 	var beam_range: float = max(float(params.get("beam_range", 0.1)), 0.01)
 	var beam_angle: float = max(float(params.get("beam_angle", 1.0)), 0.1)
-	var prefer_native_shadow_cookie: bool = bool(params.get("prefer_native_shadow_cookie_volumetric", false))
+	var prefer_native_cookie_volumetric: bool = bool(params.get("prefer_native_cookie_volumetric", false))
 
 	if not bool(params.get("is_visible", true)):
 		cone.visible = false
@@ -108,10 +108,10 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 				gobo_occluder.visible = false
 			return
 
-	# In native shadow-cookie mode keep a subtle non-gobo mesh cone only for beam readability,
-	# while cookie patterning in air still comes from SpotLight shadows in volumetric fog.
+	# In native fog-cookie mode keep a subtle non-gobo mesh cone only for beam readability,
+	# while cookie patterning in air comes from the spotlight fog pipeline.
 	var mesh_intensity: float = intensity
-	if prefer_native_shadow_cookie:
+	if prefer_native_cookie_volumetric:
 		mesh_intensity = max(intensity * 0.35, threshold * 1.1)
 
 	var half_angle_deg: float = beam_angle * 0.5
@@ -133,7 +133,7 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	cone.set_instance_shader_parameter("beam_bottom_radius", bottom_radius)
 	cone.set_instance_shader_parameter("beam_height", beam_range)
 
-	_update_gobo_occluder(light, cone, gobo_occluder, beam_angle, beam_range, not prefer_native_shadow_cookie)
+	_update_gobo_occluder(light, cone, gobo_occluder, beam_angle, beam_range, not prefer_native_cookie_volumetric)
 
 func _compute_cone_diameter_at_occluder(beam_angle: float) -> float:
 	var half_angle_rad: float = deg_to_rad(max(beam_angle, 0.1) * 0.5)

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -415,9 +415,14 @@ func _supports_fog_light_projectors() -> bool:
 func _should_prefer_native_cookie_volumetric(light: SpotLight3D) -> bool:
 	if light == null or not is_instance_valid(light):
 		return false
-	if light.get_meta("peraviz_gobo_texture", null) == null:
+	if not light.has_meta("peraviz_gobo_texture"):
 		return false
-	var projection_mode: int = int(light.get_meta("peraviz_gobo_projection_mode", FixtureGoboProjector.ProjectionMode.SHADOW_COOKIE))
+	var gobo_texture: Texture2D = light.get_meta("peraviz_gobo_texture") as Texture2D
+	if gobo_texture == null:
+		return false
+	var projection_mode: int = FixtureGoboProjector.ProjectionMode.SHADOW_COOKIE
+	if light.has_meta("peraviz_gobo_projection_mode"):
+		projection_mode = int(light.get_meta("peraviz_gobo_projection_mode"))
 	if projection_mode == FixtureGoboProjector.ProjectionMode.SHADOW_COOKIE:
 		return true
 	if projection_mode == FixtureGoboProjector.ProjectionMode.PROJECTOR_COOKIE:

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -141,7 +141,7 @@ const GOBO_SHADOW_COOKIE_BEAM_ATTENUATION: float = 0.5
 const GOBO_SHADOW_COOKIE_SHADOW_BIAS: float = 0.02
 const GOBO_SHADOW_COOKIE_SHADOW_NORMAL_BIAS: float = 0.8
 const GOBO_SHADOW_COOKIE_SHADOW_BLUR: float = 0.2
-const GOBO_SHADOW_COOKIE_MESH_BEAM_INTENSITY_MULTIPLIER: float = 0.55
+const GOBO_NATIVE_COOKIE_MESH_BEAM_INTENSITY_MULTIPLIER: float = 0.55
 const EMITTER_CONE_FADE_END_RATIO: float = 0.82
 const EMITTER_CONE_NEAR_ALPHA: float = 0.16
 const EMITTER_CONE_FAR_ALPHA: float = 0.004
@@ -389,14 +389,40 @@ func _update_existing_beam_material_scalars(light: SpotLight3D) -> void:
 		return
 	var beam_multiplier: float = float(_visual_settings.get("beam_multiplier", 1.0))
 	beam_params["scaled_intensity"] = clamp(base_intensity * beam_multiplier, 0.0, BEAM_INTENSITY_MAX)
-	var use_shadow_cookie_gobo: bool = (
-		int(light.get_meta("peraviz_gobo_projection_mode", 0)) == FixtureGoboProjector.ProjectionMode.SHADOW_COOKIE
-		and light.get_meta("peraviz_gobo_texture", null) != null
-	)
-	if use_shadow_cookie_gobo:
-		beam_params["scaled_intensity"] = float(beam_params.get("scaled_intensity", 0.0)) * GOBO_SHADOW_COOKIE_MESH_BEAM_INTENSITY_MULTIPLIER
+	if _should_prefer_native_cookie_volumetric(light):
+		beam_params["prefer_native_cookie_volumetric"] = true
+		beam_params["scaled_intensity"] = float(beam_params.get("scaled_intensity", 0.0)) * GOBO_NATIVE_COOKIE_MESH_BEAM_INTENSITY_MULTIPLIER
+	else:
+		beam_params["prefer_native_cookie_volumetric"] = false
 	beam_params["beam_quality"] = int(_visual_settings.get("beam_quality", 1))
 	_update_beam_for_light(light, beam_params)
+
+func _supports_fog_light_projectors() -> bool:
+	var override_mode: String = str(ProjectSettings.get_setting("peraviz_fog_light_projectors", "auto")).to_lower()
+	if override_mode == "enabled":
+		return true
+	if override_mode == "disabled":
+		return false
+	var version_info: Dictionary = Engine.get_version_info()
+	var major: int = int(version_info.get("major", 0))
+	var minor: int = int(version_info.get("minor", 0))
+	if major > 4:
+		return true
+	if major < 4:
+		return false
+	return minor >= 5
+
+func _should_prefer_native_cookie_volumetric(light: SpotLight3D) -> bool:
+	if light == null or not is_instance_valid(light):
+		return false
+	if light.get_meta("peraviz_gobo_texture", null) == null:
+		return false
+	var projection_mode: int = int(light.get_meta("peraviz_gobo_projection_mode", FixtureGoboProjector.ProjectionMode.SHADOW_COOKIE))
+	if projection_mode == FixtureGoboProjector.ProjectionMode.SHADOW_COOKIE:
+		return true
+	if projection_mode == FixtureGoboProjector.ProjectionMode.PROJECTOR_COOKIE:
+		return _supports_fog_light_projectors()
+	return false
 
 func _update_beam_for_light(light: SpotLight3D, beam_params: Dictionary) -> void:
 	if _active_beam_renderer == null:
@@ -1675,17 +1701,19 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 		"spot_angle_half_deg": light.spot_angle,
 		"spot_range": light.spot_range,
 	}
-	if use_shadow_cookie_gobo:
-		# Match the #11987 workaround behavior: keep occluder shadows for native volumetric fog,
-		# but disable the additive fake beam mesh to avoid concentric/double cone artifacts.
-		beam_params["prefer_native_shadow_cookie_volumetric"] = true
-		beam_params["scaled_intensity"] = float(beam_params.get("scaled_intensity", 0.0)) * GOBO_SHADOW_COOKIE_MESH_BEAM_INTENSITY_MULTIPLIER
-
 	var gobo_changed: bool = false
 	if _fixture_gobo_projector != null:
 		var gobo_controls: Dictionary = controls.duplicate(true)
 		gobo_controls["gobo_projection_mode"] = str(_visual_settings.get("gobo_projection_mode", "shadow_cookie"))
 		gobo_changed = _fixture_gobo_projector.apply_gobo_projection(light, gobo_controls)
+
+	if _should_prefer_native_cookie_volumetric(light):
+		# Keep mesh beam subtle when the native fog pipeline already carries gobo cookies
+		# (shadow-cookie workaround and Godot fog projector path).
+		beam_params["prefer_native_cookie_volumetric"] = true
+		beam_params["scaled_intensity"] = float(beam_params.get("scaled_intensity", 0.0)) * GOBO_NATIVE_COOKIE_MESH_BEAM_INTENSITY_MULTIPLIER
+	else:
+		beam_params["prefer_native_cookie_volumetric"] = false
 	light.light_volumetric_fog_energy = float(_visual_settings.get("light_volumetric_fog_energy", 1.0))
 	_update_beam_for_light(light, beam_params)
 	if gobo_changed:


### PR DESCRIPTION
### Motivation
- Align Peraviz beam fallback with Godot proposal #11987 and Godot PR #106395 so gobos can be handled either via the existing shadow-cookie occluder or the engine-native fog projector path without producing double-cone artifacts. 
- Provide a single, engine-aware code path that keeps the mesh beam subtle when the fog pipeline already applies the gobo cookie, while preserving current behavior on older engines.

### Description
- Added runtime capability detection and override via `peraviz_fog_light_projectors` and the helper functions `_supports_fog_light_projectors()` and `_should_prefer_native_cookie_volumetric()` in `peraviz/scripts/load_scene.gd`. 
- Unified the mesh-beam fallback flag to `prefer_native_cookie_volumetric` and propagated it into `peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd` so the volumetric renderer reduces mesh intensity when native cookie handling is preferred. 
- Renamed the intensity multiplier constant to `GOBO_NATIVE_COOKIE_MESH_BEAM_INTENSITY_MULTIPLIER` and updated the logic that scales `beam_params["scaled_intensity"]` when native cookie handling is used. 
- Documented the new behavior and the `peraviz_fog_light_projectors` override in `peraviz/README_gobos.md` (notes on `auto|enabled|disabled` and default detection of Godot `>= 4.5`).
- Technical note: `peraviz/scripts/load_scene.gd` is a large hotspot file; the next recommended split is to extract fog-projector / gobo preference helpers into a small `peraviz/scripts/beam_helpers.gd` module to keep responsibilities isolated per the code health guidelines.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a40a9423608324b117078f590871bd)