### PR TITLE
Remove debug X overlay from generated fixture symbols

### DIFF
--- a/gui/tools/scene_model_symbol_capture_service.cpp
+++ b/gui/tools/scene_model_symbol_capture_service.cpp
@@ -20,7 +20,6 @@ namespace tools {
 namespace {
 
 constexpr float kSymbolRdpEpsilon = 1.0f;
-constexpr bool kDebugOverlayGeneratedSymbolsWithX = true;
 
 class ScopedFloatConfigOverride {
 public:
@@ -165,28 +164,6 @@ void MirrorImageHorizontally(symbols::RenderedSymbolImage &render) {
   }
 }
 
-void AddDebugXOverlay(symbols::Symbol2D &symbol) {
-  if (!symbol.bounds.valid)
-    return;
-
-  // Temporary debug marker to quickly verify generated symbols vs fallback symbols.
-  // Remove this function call once visual validation is complete.
-  const symbols::Point2D topLeft{symbol.bounds.min.x, symbol.bounds.min.y};
-  const symbols::Point2D topRight{symbol.bounds.max.x, symbol.bounds.min.y};
-  const symbols::Point2D bottomLeft{symbol.bounds.min.x, symbol.bounds.max.y};
-  const symbols::Point2D bottomRight{symbol.bounds.max.x, symbol.bounds.max.y};
-
-  symbol.strokes.push_back(symbols::Polyline2D{topLeft, bottomRight});
-  symbol.strokes.push_back(symbols::Polyline2D{topRight, bottomLeft});
-}
-
-void AddDebugXOverlayToSymbols(std::vector<symbols::Symbol2D> &symbolsToMark) {
-  if (!kDebugOverlayGeneratedSymbolsWithX)
-    return;
-  for (auto &symbol : symbolsToMark)
-    AddDebugXOverlay(symbol);
-}
-
 } // namespace
 
 SceneModelSymbolCaptureResult
@@ -286,8 +263,6 @@ CaptureSceneModelOrthographicSymbols(Viewer2DOffscreenRenderer &renderer,
 
   for (auto &symbol : symbols)
     symbols::SimplifySymbolGeometry(symbol, kSymbolRdpEpsilon);
-
-  AddDebugXOverlayToSymbols(symbols);
 
   result.ok = true;
   result.symbols = std::move(symbols);


### PR DESCRIPTION
### Motivation
- A temporary debug marker that drew a large `X` on every generated fixture symbol was left in the capture flow and must be removed so generated symbols are clean.

### Description
- Removed the debug flag and the `AddDebugXOverlay` / `AddDebugXOverlayToSymbols` helpers and the call that added `X` strokes in `gui/tools/scene_model_symbol_capture_service.cpp`, leaving the capture + simplify + return flow unchanged.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a49e75ab8c83248691c250fead2e0e)