### PR TITLE
Auto-generate and stage fixture SVG symbols on project load

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -45,6 +45,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/legendsymbolcapture.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/logindialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_fixture_symbol_autoupdate.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow/controllers/mainwindow_io_controller.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow/controllers/mainwindow_view_controller.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_io.cpp

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -510,6 +510,7 @@ bool MainWindow::LoadProjectFromPath(const std::string &path) {
   RefreshSummary();
   RefreshRigging();
   GetDefaultGuiConfigServices().LegacyConfigManager().MarkSaved();
+  StartFixtureSymbolAutoUpdateForLoadedScene();
   UpdateTitle();
   return true;
 }
@@ -517,6 +518,10 @@ bool MainWindow::LoadProjectFromPath(const std::string &path) {
 void MainWindow::ResetProject() {
   GetDefaultGuiConfigServices().LegacyConfigManager().Reset();
   GetDefaultGuiConfigServices().LegacyConfigManager().MarkSaved();
+  fixtureSymbolAutoUpdateQueue.clear();
+  fixtureSymbolAutoUpdateProcessedKeys.clear();
+  fixtureSymbolPendingLibrarySyncUuids.clear();
+  fixtureSymbolAutoUpdateRunning = false;
   currentProjectPath.clear();
   if (layoutPanel)
     layoutPanel->ReloadLayouts();

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -24,6 +24,8 @@
 
 #include <memory>
 #include <optional>
+#include <unordered_set>
+#include <vector>
 
 wxDECLARE_EVENT(EVT_PROJECT_LOADED, wxCommandEvent);
 
@@ -200,6 +202,9 @@ private:
   void SyncLayerVisibilityPanels();
   bool ConfirmSaveIfDirty(const wxString &actionLabel,
                           const wxString &dialogTitle);
+  void StartFixtureSymbolAutoUpdateForLoadedScene();
+  void ProcessNextFixtureSymbolAutoUpdate();
+  void FlushPendingFixtureSymbolLibraryUpdates();
   std::string defaultLayoutPerspective;
   std::string default2DLayoutPerspective;
   std::string defaultLayoutModePerspective;
@@ -212,6 +217,10 @@ private:
   Viewer2DRenderPanel *layout2DViewEditRenderPanel = nullptr;
   std::optional<viewer2d::Viewer2DState> standalone2DState;
   std::unique_ptr<wxBusyCursor> layoutRenderCursor;
+  std::vector<std::string> fixtureSymbolAutoUpdateQueue;
+  std::unordered_set<std::string> fixtureSymbolAutoUpdateProcessedKeys;
+  std::unordered_set<std::string> fixtureSymbolPendingLibrarySyncUuids;
+  bool fixtureSymbolAutoUpdateRunning = false;
 
   friend class MainWindowIoController;
   friend class MainWindowLayoutController;

--- a/gui/mainwindow_fixture_symbol_autoupdate.cpp
+++ b/gui/mainwindow_fixture_symbol_autoupdate.cpp
@@ -1,0 +1,146 @@
+#include "mainwindow.h"
+
+#include <string>
+
+#include "configmanager.h"
+#include "consolepanel.h"
+#include "fixture.h"
+#include "guiconfigservices.h"
+#include "opaque_pass_utils.h"
+#include "tools/scene_model_symbol_capture_service.h"
+#include "tools/symbol_physical_calibration.h"
+#include "windows/symbol_fixture_applier.h"
+
+namespace {
+
+std::string BuildFixtureAutoUpdateKey(const Fixture &fixture) {
+  if (!fixture.typeName.empty())
+    return fixture.typeName;
+  if (!fixture.gdtfSpec.empty())
+    return NormalizeModelKey(fixture.gdtfSpec);
+  return {};
+}
+
+} // namespace
+
+void MainWindow::StartFixtureSymbolAutoUpdateForLoadedScene() {
+  fixtureSymbolAutoUpdateQueue.clear();
+  fixtureSymbolAutoUpdateProcessedKeys.clear();
+  fixtureSymbolPendingLibrarySyncUuids.clear();
+  fixtureSymbolAutoUpdateRunning = false;
+
+  ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+  for (const auto &[uuid, fixture] : cfg.GetScene().fixtures) {
+    const std::string key = BuildFixtureAutoUpdateKey(fixture);
+    if (key.empty())
+      continue;
+    if (!fixtureSymbolAutoUpdateProcessedKeys.insert(key).second)
+      continue;
+    fixtureSymbolAutoUpdateQueue.push_back(uuid);
+  }
+
+  fixtureSymbolAutoUpdateProcessedKeys.clear();
+
+  if (fixtureSymbolAutoUpdateQueue.empty())
+    return;
+
+  fixtureSymbolAutoUpdateRunning = true;
+  CallAfter([this]() { ProcessNextFixtureSymbolAutoUpdate(); });
+}
+
+void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
+  if (!fixtureSymbolAutoUpdateRunning)
+    return;
+
+  if (fixtureSymbolAutoUpdateQueue.empty()) {
+    fixtureSymbolAutoUpdateRunning = false;
+    return;
+  }
+
+  const std::string fixtureUuid = fixtureSymbolAutoUpdateQueue.back();
+  fixtureSymbolAutoUpdateQueue.pop_back();
+
+  ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+  const auto fixtureIt = cfg.GetScene().fixtures.find(fixtureUuid);
+  if (fixtureIt == cfg.GetScene().fixtures.end()) {
+    CallAfter([this]() { ProcessNextFixtureSymbolAutoUpdate(); });
+    return;
+  }
+
+  const std::string key = BuildFixtureAutoUpdateKey(fixtureIt->second);
+  if (key.empty() || !fixtureSymbolAutoUpdateProcessedKeys.insert(key).second) {
+    CallAfter([this]() { ProcessNextFixtureSymbolAutoUpdate(); });
+    return;
+  }
+
+  std::string inspectionError;
+  symbol_preview::FixtureSymbolInspectionResult inspection;
+  if (!symbol_preview::InspectFixtureSymbolState(fixtureIt->second, cfg.GetScene(),
+                                                 inspection, inspectionError)) {
+    if (consolePanel && !inspectionError.empty()) {
+      consolePanel->AppendMessage(
+          "Fixture symbol auto-update skipped: " + wxString::FromUTF8(inspectionError));
+    }
+    CallAfter([this]() { ProcessNextFixtureSymbolAutoUpdate(); });
+    return;
+  }
+
+  if (!inspection.requiresSymbolGeneration) {
+    CallAfter([this]() { ProcessNextFixtureSymbolAutoUpdate(); });
+    return;
+  }
+
+  Viewer2DOffscreenRenderer *offscreenRenderer = GetOffscreenRenderer();
+  if (!offscreenRenderer) {
+    fixtureSymbolAutoUpdateRunning = false;
+    return;
+  }
+
+  const std::string forcedFixtureColor = "#3FA9F5";
+  tools::SceneModelSymbolCaptureOptions captureOptions;
+  captureOptions.forcedFixtureColor = forcedFixtureColor;
+
+  auto capture = tools::CaptureSceneModelOrthographicSymbols(
+      *offscreenRenderer, cfg,
+      tools::SceneModelSymbolTarget{tools::SceneModelKind::Fixture, fixtureUuid},
+      captureOptions);
+  if (!capture.ok) {
+    CallAfter([this]() { ProcessNextFixtureSymbolAutoUpdate(); });
+    return;
+  }
+
+  std::string calibrationError;
+  if (!tools::CalibrateFixtureSymbolsToPhysicalUnits(
+          cfg, fixtureUuid, capture.symbols, calibrationError)) {
+    CallAfter([this]() { ProcessNextFixtureSymbolAutoUpdate(); });
+    return;
+  }
+
+  std::string applyError;
+  symbol_preview::ApplySymbolsOptions applyOptions;
+  applyOptions.updateSceneCopy = true;
+  applyOptions.updateLibraryCopy = false;
+  if (symbol_preview::ApplySymbolsToFixtureGdtf(capture.symbols, fixtureUuid,
+                                                applyError, applyOptions)) {
+    fixtureSymbolPendingLibrarySyncUuids.insert(fixtureUuid);
+    RefreshAfterFixtureSymbolUpdate();
+  }
+
+  CallAfter([this]() { ProcessNextFixtureSymbolAutoUpdate(); });
+}
+
+void MainWindow::FlushPendingFixtureSymbolLibraryUpdates() {
+  if (fixtureSymbolPendingLibrarySyncUuids.empty())
+    return;
+
+  ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+  std::string syncError;
+  for (const std::string &fixtureUuid : fixtureSymbolPendingLibrarySyncUuids) {
+    const auto fixtureIt = cfg.GetScene().fixtures.find(fixtureUuid);
+    if (fixtureIt == cfg.GetScene().fixtures.end())
+      continue;
+    (void)symbol_preview::SyncFixtureGdtfToLibrary(fixtureIt->second, cfg.GetScene(),
+                                                   syncError);
+  }
+  fixtureSymbolPendingLibrarySyncUuids.clear();
+}

--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -85,6 +85,7 @@ void MainWindow::OnSave(wxCommandEvent &event) {
   auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
   // Always sync table edits before saving; each panel now applies only real changes.
   SyncSceneData();
+  FlushPendingFixtureSymbolLibraryUpdates();
   SaveUserConfigWithViewport2DState();
   if (!cfg.SaveProject(currentProjectPath))
     wxMessageBox("Failed to save project.", "Error", wxICON_ERROR);
@@ -119,6 +120,7 @@ void MainWindow::OnSaveAs(wxCommandEvent &event) {
   auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
   // Always sync table edits before saving; each panel now applies only real changes.
   SyncSceneData();
+  FlushPendingFixtureSymbolLibraryUpdates();
   SaveUserConfigWithViewport2DState();
   if (!cfg.SaveProject(currentProjectPath))
     wxMessageBox("Failed to save project.", "Error", wxICON_ERROR);

--- a/gui/windows/symbol_fixture_applier.cpp
+++ b/gui/windows/symbol_fixture_applier.cpp
@@ -494,7 +494,8 @@ bool RewriteGdtf(const fs::path &sourcePath,
 
 bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
                                const std::string &fixtureUuid,
-                               std::string &errorMessage) {
+                               std::string &errorMessage,
+                               const ApplySymbolsOptions &options) {
   if (fixtureUuid.empty()) {
     errorMessage = "No fixture was selected for this symbol preview.";
     return false;
@@ -509,23 +510,15 @@ bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
   }
 
   const MvrScene &scene = cfg.GetScene();
-  std::vector<fs::path> targetPaths;
-  std::unordered_set<std::string> uniqueTargets;
-
   const std::string scenePath = ResolveSceneGdtfPath(fixtureIt->second, scene);
-  if (!scenePath.empty() && uniqueTargets.insert(scenePath).second)
-    targetPaths.emplace_back(scenePath);
-
   const std::string libraryPath = ResolveLibraryGdtfPath(fixtureIt->second);
-  if (!libraryPath.empty() && uniqueTargets.insert(libraryPath).second)
-    targetPaths.emplace_back(libraryPath);
-
-  if (targetPaths.empty()) {
+  if (scenePath.empty() && libraryPath.empty()) {
     errorMessage = "Could not resolve fixture GDTF path in scene or fixtures library.";
     return false;
   }
 
-  std::string modelSvgBase = ResolveModelSvgBasename(targetPaths.front(), errorMessage);
+  const std::string inspectPath = scenePath.empty() ? libraryPath : scenePath;
+  std::string modelSvgBase = ResolveModelSvgBasename(inspectPath, errorMessage);
   if (modelSvgBase.empty())
     return false;
 
@@ -565,10 +558,20 @@ bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
     return false;
   }
 
-  for (const auto &targetPath : targetPaths) {
-    if (!RewriteGdtf(targetPath, payloads, topSvgPath, sideSvgPath, frontSvgPath,
-                     errorMessage))
+  if (options.updateSceneCopy && !scenePath.empty()) {
+    if (!RewriteGdtf(scenePath, payloads, topSvgPath, sideSvgPath, frontSvgPath,
+                     errorMessage)) {
       return false;
+    }
+  }
+
+  if (options.updateLibraryCopy && !libraryPath.empty()) {
+    const bool libraryEqualsScene = !scenePath.empty() && libraryPath == scenePath;
+    if (!libraryEqualsScene &&
+        !RewriteGdtf(libraryPath, payloads, topSvgPath, sideSvgPath, frontSvgPath,
+                     errorMessage)) {
+      return false;
+    }
   }
 
   if (libraryPath.empty() && !scenePath.empty() && !fixtureIt->second.typeName.empty()) {
@@ -576,6 +579,113 @@ bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
                            fixtureIt->second.gdtfMode);
   }
 
+  return true;
+}
+
+
+bool InspectFixtureSymbolState(const Fixture &fixture,
+                               const MvrScene &scene,
+                               FixtureSymbolInspectionResult &result,
+                               std::string &errorMessage) {
+  result = {};
+
+  const std::string scenePath = ResolveSceneGdtfPath(fixture, scene);
+  const std::string libraryPath = ResolveLibraryGdtfPath(fixture);
+  result.scenePath = scenePath;
+  result.libraryPath = libraryPath;
+
+  std::string inspectPath = scenePath.empty() ? libraryPath : scenePath;
+  if (inspectPath.empty())
+    return true;
+
+  result.hasResolvableGdtf = true;
+
+  wxFileInputStream input(inspectPath);
+  if (!input.IsOk()) {
+    errorMessage = "Could not open fixture GDTF file for inspection.";
+    return false;
+  }
+
+  wxZipInputStream zipInput(input);
+  std::unique_ptr<wxZipEntry> entry;
+  std::string descriptionXml;
+  while ((entry.reset(zipInput.GetNextEntry())), entry) {
+    if (entry->IsDir())
+      continue;
+    const std::string entryName = NormalizeArchivePath(entry->GetName().ToStdString());
+    if (!IsDescriptionXmlPath(entryName))
+      continue;
+    if (!ReadAllBytes(zipInput, descriptionXml)) {
+      errorMessage = "Could not read description.xml from the GDTF file.";
+      return false;
+    }
+    break;
+  }
+
+  if (descriptionXml.empty())
+    return true;
+
+  tinyxml2::XMLDocument doc;
+  if (doc.Parse(descriptionXml.c_str(), descriptionXml.size()) != tinyxml2::XML_SUCCESS)
+    return true;
+
+  tinyxml2::XMLElement *fixtureType = doc.FirstChildElement("GDTF");
+  if (fixtureType)
+    fixtureType = fixtureType->FirstChildElement("FixtureType");
+  if (!fixtureType)
+    fixtureType = doc.FirstChildElement("FixtureType");
+  if (!fixtureType)
+    return true;
+
+  const char *editor = fixtureType->Attribute("Editor");
+  result.editorIsPerastage = editor && std::string(editor) == "Perastage";
+
+  std::string modelSvgBase = ResolveModelSvgBasename(inspectPath, errorMessage);
+  if (modelSvgBase.empty()) {
+    errorMessage.clear();
+    return true;
+  }
+
+  const std::unordered_set<std::string> requiredPaths = {
+      NormalizeArchivePath("models/svg/" + modelSvgBase + ".svg"),
+      NormalizeArchivePath("models/svg_side/" + modelSvgBase + ".svg"),
+      NormalizeArchivePath("models/svg_front/" + modelSvgBase + ".svg")};
+
+  std::unordered_set<std::string> foundPaths;
+  wxFileInputStream inputSymbols(inspectPath);
+  if (!inputSymbols.IsOk())
+    return true;
+
+  wxZipInputStream zipSymbols(inputSymbols);
+  while ((entry.reset(zipSymbols.GetNextEntry())), entry) {
+    if (entry->IsDir())
+      continue;
+    const std::string normalized =
+        NormalizeArchivePath(entry->GetName().ToStdString());
+    if (requiredPaths.find(normalized) != requiredPaths.end())
+      foundPaths.insert(normalized);
+  }
+
+  result.hasValidSvgSymbolSet =
+      result.editorIsPerastage && foundPaths.size() == requiredPaths.size();
+  result.requiresSymbolGeneration = !result.hasValidSvgSymbolSet;
+  return true;
+}
+
+bool SyncFixtureGdtfToLibrary(const Fixture &fixture,
+                              const MvrScene &scene,
+                              std::string &errorMessage) {
+  const std::string scenePath = ResolveSceneGdtfPath(fixture, scene);
+  const std::string libraryPath = ResolveLibraryGdtfPath(fixture);
+  if (scenePath.empty() || libraryPath.empty() || scenePath == libraryPath)
+    return true;
+
+  std::error_code ec;
+  fs::copy_file(scenePath, libraryPath, fs::copy_options::overwrite_existing, ec);
+  if (ec) {
+    errorMessage = "Could not update fixture in the fixtures library.";
+    return false;
+  }
   return true;
 }
 

--- a/gui/windows/symbol_fixture_applier.h
+++ b/gui/windows/symbol_fixture_applier.h
@@ -3,12 +3,38 @@
 #include <string>
 #include <vector>
 
+#include "fixture.h"
+#include "mvrscene.h"
 #include "symbols/Symbol2D.h"
 
 namespace symbol_preview {
 
+struct ApplySymbolsOptions {
+  bool updateSceneCopy = true;
+  bool updateLibraryCopy = true;
+};
+
+struct FixtureSymbolInspectionResult {
+  bool hasResolvableGdtf = false;
+  bool editorIsPerastage = false;
+  bool hasValidSvgSymbolSet = false;
+  bool requiresSymbolGeneration = false;
+  std::string scenePath;
+  std::string libraryPath;
+};
+
+bool InspectFixtureSymbolState(const Fixture &fixture,
+                               const MvrScene &scene,
+                               FixtureSymbolInspectionResult &result,
+                               std::string &errorMessage);
+
 bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
                                const std::string &fixtureUuid,
-                               std::string &errorMessage);
+                               std::string &errorMessage,
+                               const ApplySymbolsOptions &options = {});
+
+bool SyncFixtureGdtfToLibrary(const Fixture &fixture,
+                              const MvrScene &scene,
+                              std::string &errorMessage);
 
 } // namespace symbol_preview


### PR DESCRIPTION
### Motivation
- Provide a non-blocking background flow that ensures fixtures used in a loaded scene get Perastage-generated SVG symbols applied without delaying project load. 
- Detect whether a fixture GDTF is already authored by Perastage and already contains valid SVG views and only generate/apply symbols when needed. 
- Defer persistent library updates until an explicit user save, so scene files are updated immediately while library writes are done safely on save.

### Description
- Added a background incremental updater in `gui/mainwindow_fixture_symbol_autoupdate.cpp` that enqueues fixtures on project load and processes them with `CallAfter`, capturing orthographic views via `tools::CaptureSceneModelOrthographicSymbols`, calibrating with `tools::CalibrateFixtureSymbolsToPhysicalUnits`, and applying generated symbols to the scene copy. 
- Extended the symbol applier with `ApplySymbolsOptions`, `FixtureSymbolInspectionResult`, `InspectFixtureSymbolState` and `SyncFixtureGdtfToLibrary` in `gui/windows/symbol_fixture_applier.h` / `.cpp`, and changed `ApplySymbolsToFixtureGdtf` to accept options so load-time updates can patch only the scene copy. 
- Wired lifecycle and state: `MainWindow` gained queue/state members and new methods `StartFixtureSymbolAutoUpdateForLoadedScene`, `ProcessNextFixtureSymbolAutoUpdate`, and `FlushPendingFixtureSymbolLibraryUpdates`; `LoadProjectFromPath` now starts the auto-update and `OnSave`/`OnSaveAs` call `FlushPendingFixtureSymbolLibraryUpdates` to persist library changes. 
- Registered the new source in `gui/CMakeLists.txt` and kept source ownership explicit; scene→library sync uses `fs::copy_file` guarded to avoid overwriting when identical.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed. 
- Attempted `cmake -S . -B build` in the environment but configuration failed due to missing `wxWidgets` development packages (so a full build was not completed in CI here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4a16b75bc83249792297730f0a0b0)