### PR TITLE
Add bottom status bar and centralize app version (beta 0.1.0)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,10 @@
 cmake_minimum_required(VERSION 3.21)
 cmake_policy(SET CMP0074 NEW)
 
-project(Perastage VERSION 1.0 LANGUAGES CXX)
+project(Perastage VERSION 0.1.0 LANGUAGES CXX)
+
+set(PERASTAGE_APP_VERSION "${PROJECT_VERSION}")
+set(PERASTAGE_APP_VERSION_DISPLAY "beta ${PROJECT_VERSION}")
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -121,6 +124,10 @@ add_executable(${PROJECT_NAME} main.cpp
 )
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
+target_compile_definitions(${PROJECT_NAME} PRIVATE
+    PERASTAGE_APP_VERSION="${PERASTAGE_APP_VERSION}"
+    PERASTAGE_APP_VERSION_DISPLAY="${PERASTAGE_APP_VERSION_DISPLAY}"
+)
 
 if(MSVC)
     target_compile_options(${PROJECT_NAME} PRIVATE /Zc:__cplusplus)

--- a/core/app_version.h
+++ b/core/app_version.h
@@ -1,0 +1,35 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+namespace app {
+
+inline constexpr const char *kName = "Perastage";
+
+#ifndef PERASTAGE_APP_VERSION
+#define PERASTAGE_APP_VERSION "0.1.0"
+#endif
+
+#ifndef PERASTAGE_APP_VERSION_DISPLAY
+#define PERASTAGE_APP_VERSION_DISPLAY "beta 0.1.0"
+#endif
+
+inline constexpr const char *kVersion = PERASTAGE_APP_VERSION;
+inline constexpr const char *kVersionDisplay = PERASTAGE_APP_VERSION_DISPLAY;
+
+} // namespace app

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -64,6 +64,7 @@ class wxZipStreamLink;
 
 using json = nlohmann::json;
 #include "addfixturedialog.h"
+#include "app_version.h"
 #include "autopatcher.h"
 #include "configmanager.h"
 #include "guiconfigservices.h"
@@ -553,7 +554,7 @@ void MainWindow::ResetProject() {
 }
 
 void MainWindow::UpdateTitle() {
-  wxString title = "Perastage";
+  wxString title = app::kName;
   if (!currentProjectPath.empty()) {
     wxFileName fn(wxString::FromUTF8(currentProjectPath));
     title += " - " + fn.GetName();

--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -22,6 +22,7 @@
 
 #include <wx/notebook.h>
 
+#include "app_version.h"
 #include "configmanager.h"
 #include "guiconfigservices.h"
 #include "consolepanel.h"
@@ -346,6 +347,12 @@ void MainWindow::SetupLayout() {
   entries[3].Set(wxACCEL_NORMAL, (int)'4', ID_Select_Objects);
   m_accel = wxAcceleratorTable(4, entries);
   SetAcceleratorTable(m_accel);
+
+  CreateStatusBar(2);
+  const int statusWidths[] = {-1, 220};
+  SetStatusWidths(2, statusWidths);
+  SetStatusText("Ready", 0);
+  SetStatusText("Version " + wxString::FromUTF8(app::kVersionDisplay), 1);
 
   // Ensure the View menu reflects the actual pane visibility
   UpdateViewMenuChecks();

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -43,6 +43,7 @@
 #include "addfixturedialog.h"
 #include "autopatcher.h"
 #include "ui_feature_flags.h"
+#include "app_version.h"
 #include "configmanager.h"
 #include "guiconfigservices.h"
 #include "consolepanel.h"
@@ -798,8 +799,8 @@ void MainWindow::OnShowHelp(wxCommandEvent &WXUNUSED(event)) {
 
 void MainWindow::OnShowAbout(wxCommandEvent &WXUNUSED(event)) {
   wxAboutDialogInfo info;
-  info.SetName("Perastage");
-  info.SetVersion("1.0");
+  info.SetName(app::kName);
+  info.SetVersion(app::kVersionDisplay);
   wxString description =
       "High-performance MVR scene viewer with 3D rendering support.\n\n"
       "This application makes use of the following open-source libraries:\n"

--- a/main.cpp
+++ b/main.cpp
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
+#include "app_version.h"
 #include "configmanager.h"
 #include "logger.h"
 #include "mainwindow.h"
@@ -44,7 +45,7 @@ private:
 wxIMPLEMENT_APP(MyApp);
 
 bool MyApp::OnInit() {
-  SetAppName("Perastage");
+  SetAppName(app::kName);
   SetVendorName("Perasoft");
 
   // Enable support for common image formats used by the app
@@ -65,7 +66,7 @@ bool MyApp::OnInit() {
   Logger::Instance();
 
   SplashScreen::SetMessage("Creating main window...");
-  MainWindow *mainWindow = new MainWindow("Perastage");
+  MainWindow *mainWindow = new MainWindow(app::kName);
   mainWindow->Show(true);
   // Start maximized so minimize and restore buttons remain available
   mainWindow->Maximize(true);


### PR DESCRIPTION
### Motivation
- Provide a persistent status area for runtime messages and a visible app version in the main window. 
- Remove scattered hardcoded version strings (previously `1.0`) and centralize the application name/version in a single header so UI and build metadata stay consistent.

### Description
- Added a new header `core/app_version.h` that defines `app::kName`, `app::kVersion` and `app::kVersionDisplay` and defaults to `0.1.0` / `beta 0.1.0` when not provided by the build system. 
- Updated `CMakeLists.txt` to set `project(... VERSION 0.1.0)` and to expose `PERASTAGE_APP_VERSION` and `PERASTAGE_APP_VERSION_DISPLAY` as compile definitions for sources to consume. 
- Replaced hardcoded UI strings to use the centralized constants (`app::kName` / `app::kVersionDisplay`) in `main.cpp`, `gui/mainwindow.cpp` and `gui/mainwindow_menu.cpp`. 
- Added a bottom status bar to the main window in `gui/mainwindow_layout.cpp` with two fields (left: runtime messages initialized to `Ready`; right: fixed text showing `Version beta 0.1.0`).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed. 
- Attempted a CMake configure with `cmake -S . -B build` and it failed in this environment due to the missing system dependency `wxWidgets` (this is an environment issue, not a code regression).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4a5c139588324ba2cffaf4f6705dd)