### PR TITLE
Add 2D cursor X/Y/Z (meters) to status bar

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -26,12 +26,14 @@
 #include <filesystem>
 #include <fstream>
 #include <functional>
+#include <iomanip>
 #include <iterator>
 #include <wx/event.h>
 #include <map>
 #include <memory>
 #include <optional>
 #include <set>
+#include <sstream>
 #include <random>
 #include <string>
 #include <thread>
@@ -338,6 +340,10 @@ void MainWindow::Ensure2DViewport() {
     return;
   int halfWidth = GetClientSize().GetWidth() / 2;
   viewport2DPanel = new Viewer2DPanel(this);
+  viewport2DPanel->SetCursorWorldPositionCallback(
+      [this](const std::optional<std::array<float, 3>> &positionMeters) {
+        UpdateCursorWorldPositionInStatusBar(positionMeters);
+      });
   Viewer2DPanel::SetInstance(viewport2DPanel);
   viewport2DPanel->LoadViewFromConfig();
   auiManager->AddPane(viewport2DPanel, wxAuiPaneInfo()
@@ -412,6 +418,28 @@ void MainWindow::Ensure2DViewport() {
     pane3d.Show();
     auiManager->Update();
   }
+}
+
+void MainWindow::UpdateCursorWorldPositionInStatusBar(
+    const std::optional<std::array<float, 3>> &positionMeters) {
+  if (!GetStatusBar())
+    return;
+  if (!positionMeters.has_value()) {
+    ClearCursorWorldPositionInStatusBar();
+    return;
+  }
+
+  std::ostringstream stream;
+  stream << std::fixed << std::setprecision(2) << "X: " << (*positionMeters)[0]
+         << " m  Y: " << (*positionMeters)[1] << " m  Z: "
+         << (*positionMeters)[2] << " m";
+  SetStatusText(wxString::FromUTF8(stream.str()), 1);
+}
+
+void MainWindow::ClearCursorWorldPositionInStatusBar() {
+  if (!GetStatusBar())
+    return;
+  SetStatusText("X: -- m  Y: -- m  Z: -- m", 1);
 }
 
 void MainWindow::Ensure2DViewportAvailable() { Ensure2DViewport(); }

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -24,6 +24,7 @@
 
 #include <memory>
 #include <optional>
+#include <array>
 #include <unordered_set>
 #include <vector>
 
@@ -79,6 +80,9 @@ private:
   void CreateMenuBar(); // Create menus
   void CreateToolBars(); // Create toolbars
   void UpdateToolBarAvailability();
+  void UpdateCursorWorldPositionInStatusBar(
+      const std::optional<std::array<float, 3>> &positionMeters);
+  void ClearCursorWorldPositionInStatusBar();
   void UpdateTitle();   // Refresh window title
   void Ensure3DViewport();
   void Ensure2DViewport();

--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -348,11 +348,12 @@ void MainWindow::SetupLayout() {
   m_accel = wxAcceleratorTable(4, entries);
   SetAcceleratorTable(m_accel);
 
-  CreateStatusBar(2);
-  const int statusWidths[] = {-1, 220};
-  SetStatusWidths(2, statusWidths);
+  CreateStatusBar(3);
+  const int statusWidths[] = {-1, 260, 220};
+  SetStatusWidths(3, statusWidths);
   SetStatusText("Ready", 0);
-  SetStatusText("Version " + wxString::FromUTF8(app::kVersionDisplay), 1);
+  SetStatusText("X: -- m  Y: -- m  Z: -- m", 1);
+  SetStatusText("Version " + wxString::FromUTF8(app::kVersionDisplay), 2);
 
   // Ensure the View menu reflects the actual pane visibility
   UpdateViewMenuChecks();
@@ -775,6 +776,12 @@ void MainWindow::BeginLayout2DViewEdit() {
   Layout2DViewDialog dialog(this);
   layout2DViewEditPanel = dialog.GetViewerPanel();
   layout2DViewEditRenderPanel = dialog.GetRenderPanel();
+  if (layout2DViewEditPanel) {
+    layout2DViewEditPanel->SetCursorWorldPositionCallback(
+        [this](const std::optional<std::array<float, 3>> &positionMeters) {
+          UpdateCursorWorldPositionInStatusBar(positionMeters);
+        });
+  }
 
   Viewer2DPanel *prevPanel = Viewer2DPanel::Instance();
   Viewer2DRenderPanel *prevRenderPanel = Viewer2DRenderPanel::Instance();
@@ -813,6 +820,7 @@ void MainWindow::BeginLayout2DViewEdit() {
 
   layout2DViewEditPanel = nullptr;
   layout2DViewEditRenderPanel = nullptr;
+  ClearCursorWorldPositionInStatusBar();
   Viewer2DPanel::SetInstance(prevPanel);
   Viewer2DRenderPanel::SetInstance(prevRenderPanel);
 }

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -458,6 +458,59 @@ void Viewer2DPanel::SetLayoutEditOverlayScale(float scale) {
   Refresh();
 }
 
+void Viewer2DPanel::SetCursorWorldPositionCallback(
+    CursorWorldPositionCallback callback) {
+  m_cursorWorldPositionCallback = std::move(callback);
+}
+
+std::optional<std::array<float, 3>>
+Viewer2DPanel::ComputeWorldPositionFromScreen(const wxPoint &screenPos) const {
+  const wxSize size = GetClientSize();
+  const int width = size.GetWidth();
+  const int height = size.GetHeight();
+  if (width <= 0 || height <= 0)
+    return std::nullopt;
+
+  const float pixelsPerMeter = PIXELS_PER_METER * m_zoom;
+  if (pixelsPerMeter <= 0.0f)
+    return std::nullopt;
+
+  const float offsetMetersX = m_offsetX / PIXELS_PER_METER;
+  const float offsetMetersY = m_offsetY / PIXELS_PER_METER;
+
+  const float viewX =
+      (static_cast<float>(screenPos.x) - static_cast<float>(width) * 0.5f) /
+          pixelsPerMeter -
+      offsetMetersX;
+  const float viewY =
+      (static_cast<float>(height) * 0.5f - static_cast<float>(screenPos.y)) /
+          pixelsPerMeter -
+      offsetMetersY;
+
+  switch (m_view) {
+  case Viewer2DView::Top:
+  case Viewer2DView::Bottom:
+    return std::array<float, 3>{viewX, viewY, 0.0f};
+  case Viewer2DView::Front:
+    return std::array<float, 3>{viewX, 0.0f, viewY};
+  case Viewer2DView::Side:
+    return std::array<float, 3>{0.0f, viewX, viewY};
+  }
+  return std::array<float, 3>{viewX, viewY, 0.0f};
+}
+
+void Viewer2DPanel::NotifyCursorWorldPosition(const wxPoint &screenPos) {
+  if (!m_cursorWorldPositionCallback)
+    return;
+  m_cursorWorldPositionCallback(ComputeWorldPositionFromScreen(screenPos));
+}
+
+void Viewer2DPanel::ClearCursorWorldPosition() {
+  if (!m_cursorWorldPositionCallback)
+    return;
+  m_cursorWorldPositionCallback(std::nullopt);
+}
+
 std::optional<wxSize> Viewer2DPanel::GetLayoutEditOverlaySize() const {
   if (!m_layoutEditAspect)
     return std::nullopt;
@@ -1670,6 +1723,7 @@ void Viewer2DPanel::OnCaptureLost(wxMouseCaptureLostEvent &WXUNUSED(event)) {
 
 void Viewer2DPanel::OnMouseMove(wxMouseEvent &event) {
   wxPoint pos = event.GetPosition();
+  NotifyCursorWorldPosition(pos);
 
   if (m_dragMode == DragMode::RectSelection && event.Dragging()) {
     m_rectSelectEnd = pos;
@@ -1816,12 +1870,14 @@ void Viewer2DPanel::OnKeyDown(wxKeyEvent &event) {
 
 void Viewer2DPanel::OnMouseEnter(wxMouseEvent &event) {
   m_mouseInside = true;
+  NotifyCursorWorldPosition(event.GetPosition());
   SetFocus();
   event.Skip();
 }
 
 void Viewer2DPanel::OnMouseLeave(wxMouseEvent &event) {
   m_mouseInside = false;
+  ClearCursorWorldPosition();
   if (m_enableSelection) {
     m_hasHover = false;
     m_hoverUuid.clear();

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -126,6 +126,10 @@ public:
   float GetLayoutEditOverlayScale() const { return m_layoutEditScale; }
   std::optional<wxSize> GetLayoutEditOverlaySize() const;
 
+  using CursorWorldPositionCallback =
+      std::function<void(const std::optional<std::array<float, 3>> &)>;
+  void SetCursorWorldPositionCallback(CursorWorldPositionCallback callback);
+
 private:
   enum class DragMode { None, View, Selection, RectSelection };
   enum class DragAxis { None, Horizontal, Vertical };
@@ -149,6 +153,10 @@ private:
   void OnCaptureLost(wxMouseCaptureLostEvent &event);
 
   std::array<float, 3> MapDragDelta(float dxMeters, float dyMeters) const;
+  std::optional<std::array<float, 3>>
+  ComputeWorldPositionFromScreen(const wxPoint &screenPos) const;
+  void NotifyCursorWorldPosition(const wxPoint &screenPos);
+  void ClearCursorWorldPosition();
   void ApplySelectionDelta(const std::array<float, 3> &deltaMeters);
   void FinalizeSelectionDrag();
   void ApplyRectangleSelection(const wxPoint &start, const wxPoint &end);
@@ -201,6 +209,7 @@ private:
   wxTimer m_interactionResumeTimer;
   bool m_enableSelection = true;
   std::string m_hoverUuid;
+  CursorWorldPositionCallback m_cursorWorldPositionCallback;
 
   bool m_captureNextFrame = false;
   bool m_useSimplifiedFootprints = false;


### PR DESCRIPTION
### Motivation
- Provide live X/Y/Z coordinates (in meters) for the cursor when interacting with the 2D layout viewport so users can see the world position under the pointer. 
- Ensure the same feedback is available when editing a layout 2D view so coordinates are always visible while composing layouts.

### Description
- Added a third, dedicated status-bar field and adjusted widths so the bar contains: `message`, `coordinates`, and `version` (changed in `gui/mainwindow_layout.cpp`).
- Implemented a `CursorWorldPositionCallback` API on `Viewer2DPanel` and logic to compute world coordinates from screen position in `Viewer2DPanel::ComputeWorldPositionFromScreen`, with mapping for `Top/Bottom`, `Front`, and `Side` views, and hooked notifications on `OnMouseMove`, `OnMouseEnter`, and `OnMouseLeave` to `NotifyCursorWorldPosition` / `ClearCursorWorldPosition` (changes in `viewer2d/viewer2dpanel.h` and `viewer2d/viewer2dpanel.cpp`).
- Wired the callback from `MainWindow::Ensure2DViewport()` and the layout 2D edit dialog flow so `MainWindow` updates the coordinates field via `UpdateCursorWorldPositionInStatusBar` and restores placeholder text when the cursor leaves or editing ends (`gui/mainwindow.cpp`, `gui/mainwindow.h`, `gui/mainwindow_layout.cpp`).
- Display uses meters with two decimal places (`std::ostringstream` formatting), and placeholder text `"X: -- m  Y: -- m  Z: -- m"` is shown when no position is available; files touched: `viewer2d/viewer2dpanel.{h,cpp}`, `gui/mainwindow.{h,cpp}`, `gui/mainwindow_layout.cpp`.
- Technical note: the change is intentionally small and focused, but `viewer2d/viewer2dpanel.cpp` is a hotspot file; consider extracting cursor/world-coordinate helpers or a small `viewer2d/cursor_overlay.*` helper in a follow-up if additional cursor/overlay features are added.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.
- Attempted a build invocation but there is no local `build` directory in this environment so compilation was skipped (no build performed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4abaaef3c83249e7305904681f066)