### PR TITLE
Fix Linux crash in rider text source label formatting

### DIFF
--- a/core/pdftext.cpp
+++ b/core/pdftext.cpp
@@ -147,8 +147,8 @@ std::string ExtractPdfText(const std::string &path) {
       out.pop_back();
     return out;
   } catch (const PdfError &e) {
-    wxLogError("PoDoFo failed to extract text from '%s': %s",
-               wxString::FromUTF8(path), wxString::FromUTF8(e.what()));
+    wxLogError("PoDoFo failed to extract text from '" +
+               wxString::FromUTF8(path) + "': " + wxString::FromUTF8(e.what()));
   }
   return {};
 }

--- a/core/pdftext.cpp
+++ b/core/pdftext.cpp
@@ -147,8 +147,8 @@ std::string ExtractPdfText(const std::string &path) {
       out.pop_back();
     return out;
   } catch (const PdfError &e) {
-    wxLogError("PoDoFo failed to extract text from '%s': %s", path.c_str(),
-               e.what());
+    wxLogError("PoDoFo failed to extract text from '%s': %s",
+               wxString::FromUTF8(path), wxString::FromUTF8(e.what()));
   }
   return {};
 }

--- a/core/projectutils.cpp
+++ b/core/projectutils.cpp
@@ -35,6 +35,16 @@ std::string ToUtf8String(const fs::path& path)
     return std::string(utf8.begin(), utf8.end());
 }
 
+
+fs::path WxStringToPath(const wxString& value)
+{
+    const wxScopedCharBuffer utf8 = value.ToUTF8();
+    if (utf8)
+        return fs::u8path(std::string(utf8.data(), utf8.length()));
+
+    return fs::path(value.ToStdString());
+}
+
 void CopyLibrarySubdir(const fs::path& source, const fs::path& destination)
 {
     std::error_code ec;
@@ -75,7 +85,7 @@ std::optional<fs::path> FindExistingPath(const fs::path& start,
 fs::path GetBaseLibraryPath(const std::string& subdir)
 {
     wxFileName exe(wxStandardPaths::Get().GetExecutablePath());
-    fs::path exeBase = fs::path(exe.GetPath().ToStdString());
+    fs::path exeBase = WxStringToPath(exe.GetPath());
     fs::path suffix = fs::path("library") / subdir;
     if (auto found = FindExistingPath(exeBase, suffix))
         return *found;
@@ -87,7 +97,7 @@ fs::path GetBaseLibraryPath(const std::string& subdir)
 fs::path GetResourceRoot()
 {
     wxFileName exe(wxStandardPaths::Get().GetExecutablePath());
-    fs::path exeBase = fs::path(exe.GetPath().ToStdString());
+    fs::path exeBase = WxStringToPath(exe.GetPath());
     fs::path suffix = fs::path("resources");
     if (auto found = FindExistingPath(exeBase, suffix))
         return *found;
@@ -95,7 +105,7 @@ fs::path GetResourceRoot()
         return *found;
     const wxString resourcesDir = wxStandardPaths::Get().GetResourcesDir();
     if (!resourcesDir.empty()) {
-        fs::path resourcesPath = fs::path(resourcesDir.ToStdString());
+        fs::path resourcesPath = WxStringToPath(resourcesDir);
         std::error_code ec;
         if (fs::exists(resourcesPath, ec))
             return resourcesPath;
@@ -108,7 +118,7 @@ std::string GetLastProjectPathFile()
     wxString dir = wxStandardPaths::Get().GetUserDataDir();
     if (dir.empty())
         return {};
-    fs::path p = fs::path(dir.ToStdString());
+    fs::path p = WxStringToPath(dir);
     std::error_code ec;
     fs::create_directories(p, ec);
     if (ec)
@@ -171,7 +181,7 @@ std::optional<std::string> LoadLastProjectPath()
         return ToUtf8String(currentCandidate);
     ec.clear();
     wxFileName exe(wxStandardPaths::Get().GetExecutablePath());
-    fs::path exeBase = fs::path(exe.GetPath().ToStdString());
+    fs::path exeBase = WxStringToPath(exe.GetPath());
     fs::path exeCandidate = fs::absolute(exeBase / candidate, ec);
     if (!ec && isValidFile(exeCandidate))
         return ToUtf8String(exeCandidate);
@@ -192,7 +202,7 @@ std::string GetDefaultLibraryPath(const std::string& subdir)
 
 #ifdef NDEBUG
     fs::path baseLib = GetBaseLibraryPath(subdir);
-    fs::path userLib = fs::path(wxStandardPaths::Get().GetUserDataDir().ToStdString()) /
+    fs::path userLib = WxStringToPath(wxStandardPaths::Get().GetUserDataDir()) /
                       "library" / subdir;
 
     CopyLibrarySubdir(baseLib, userLib);
@@ -208,7 +218,7 @@ std::string GetDefaultLibraryPath(const std::string& subdir)
     if (!ec)
         return baseLib.string();
 
-    fs::path userLib = fs::path(wxStandardPaths::Get().GetUserDataDir().ToStdString()) /
+    fs::path userLib = WxStringToPath(wxStandardPaths::Get().GetUserDataDir()) /
                       "library" / subdir;
     ec.clear();
     fs::create_directories(userLib, ec);

--- a/gui/consolepanel.cpp
+++ b/gui/consolepanel.cpp
@@ -79,8 +79,8 @@ void ConsolePanel::AppendMessage(const wxString &msg) {
 
   if (safeMsg == m_lastMessage) {
     m_repeatCount++;
-    wxString combined = wxString::Format("%s (repeated %zu times)", safeMsg,
-                                        m_repeatCount);
+    wxString combined = safeMsg + " (repeated " +
+                        wxString::Format("%zu", m_repeatCount) + " times)";
     long endPos = m_textCtrl->GetLastPosition();
     if (m_lastLineStart < endPos)
       m_textCtrl->Remove(m_lastLineStart, endPos);
@@ -323,8 +323,7 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
         auto end = token.data() + token.size();
         auto result = std::from_chars(begin, end, value);
         if (result.ec != std::errc{} || result.ptr != end) {
-          AppendMessage(wxString::Format("Invalid selection id: %s",
-                                         wxString::FromUTF8(token).c_str()));
+          AppendMessage("Invalid selection id: " + wxString::FromUTF8(token));
           return false;
         }
         return true;

--- a/gui/fixtureeditdialog.cpp
+++ b/gui/fixtureeditdialog.cpp
@@ -191,7 +191,7 @@ void FixtureEditDialog::UpdateChannels() {
     wxString func = wxString::FromUTF8(ch.function);
     if (func.empty())
       func = "-";
-    msg += wxString::Format("%d: %s\n", ch.channel, func);
+    msg += wxString::Format("%d: ", ch.channel) + func + "\n";
   }
   channelList->SetValue(msg);
   int chCount = GetGdtfModeChannelCount(std::string(gdtfPath.ToUTF8()),

--- a/gui/fixturepatchdialog.cpp
+++ b/gui/fixturepatchdialog.cpp
@@ -20,7 +20,7 @@
 
 FixturePatchDialog::FixturePatchDialog(wxWindow* parent, const Fixture& fixture)
     : wxDialog(parent, wxID_ANY,
-        wxString::Format("%s", wxString::FromUTF8(fixture.instanceName)),
+        wxString::FromUTF8(fixture.instanceName),
         wxDefaultPosition, wxDefaultSize)
 {
     wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);

--- a/gui/fixturetable/fixture_table_edit_service.cpp
+++ b/gui/fixturetable/fixture_table_edit_service.cpp
@@ -9,6 +9,13 @@
 
 namespace FixtureTableEditService {
 
+namespace {
+const wxString &DegreeSymbol() {
+  static const wxString kDegreeSymbol = wxString::FromUTF8("\xC2\xB0");
+  return kDegreeSymbol;
+}
+}
+
 std::vector<int> BuildOrderedRows(const std::vector<int> &selectedRows,
                                   const std::vector<int> &selectionOrder) {
   std::vector<int> orderedRows;
@@ -127,19 +134,22 @@ void UpdateSceneData(ISceneAdapter &adapter, wxDataViewListCtrl *table,
     table->GetValue(v, i, 13);
     {
       wxString s = v.GetString();
-      s.Replace("°", "");
+      if (!DegreeSymbol().empty())
+        s.Replace(DegreeSymbol(), "");
       s.ToDouble(&roll);
     }
     table->GetValue(v, i, 14);
     {
       wxString s = v.GetString();
-      s.Replace("°", "");
+      if (!DegreeSymbol().empty())
+        s.Replace(DegreeSymbol(), "");
       s.ToDouble(&pitch);
     }
     table->GetValue(v, i, 15);
     {
       wxString s = v.GetString();
-      s.Replace("°", "");
+      if (!DegreeSymbol().empty())
+        s.Replace(DegreeSymbol(), "");
       s.ToDouble(&yaw);
     }
 

--- a/gui/fixturetable/fixture_table_edit_service.cpp
+++ b/gui/fixturetable/fixture_table_edit_service.cpp
@@ -229,8 +229,7 @@ void UpdateSceneData(ISceneAdapter &adapter, wxDataViewListCtrl *table,
     if (console) {
       wxString msg;
       if (updatedCount == 1)
-        msg = wxString::Format("Updated fixture %s (UUID %s)", firstName,
-                               firstUuid);
+        msg = "Updated fixture " + firstName + " (UUID " + firstUuid + ")";
       else if (updatedCount > 1)
         msg = wxString::Format("Updated %zu fixtures", updatedCount);
       if (!msg.empty())

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -786,8 +786,8 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
                                                       selectionOrder);
 
         for (size_t i = 0; i < orderedRows.size(); ++i) {
-          wxString newName =
-              wxString::Format("%s %ld", prefix, baseNum + (long)i);
+          wxString newName = prefix + " " +
+                             wxString::Format("%ld", baseNum + (long)i);
           table->SetValue(wxVariant(newName), orderedRows[i], col);
         }
       } else {

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -53,6 +53,12 @@
 namespace fs = std::filesystem;
 
 namespace {
+
+const wxString &DegreeSymbol() {
+  static const wxString kDegreeSymbol = wxString::FromUTF8("\xC2\xB0");
+  return kDegreeSymbol;
+}
+
 class ConfigManagerSceneAdapter : public FixtureTableEditService::ISceneAdapter {
 public:
   void PushUndoState(const std::string &description) override {
@@ -255,9 +261,9 @@ void FixtureTablePanel::ReloadData() {
     wxString posName = wxString::FromUTF8(fixture->positionName);
 
     auto euler = MatrixUtils::MatrixToEuler(fixture->transform);
-    wxString roll = wxString::Format("%.1f\u00B0", euler[2]);
-    wxString pitch = wxString::Format("%.1f\u00B0", euler[1]);
-    wxString yaw = wxString::Format("%.1f\u00B0", euler[0]);
+    wxString roll = wxString::Format("%.1f", euler[2]) + DegreeSymbol();
+    wxString pitch = wxString::Format("%.1f", euler[1]) + DegreeSymbol();
+    wxString yaw = wxString::Format("%.1f", euler[0]) + DegreeSymbol();
 
     row.push_back(fixtureID);
     row.push_back(name);
@@ -659,7 +665,7 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
         double newVal = curVal + delta;
         wxString out;
         if (col >= 13 && col <= 15)
-          out = wxString::Format("%.1f\u00B0", newVal);
+          out = wxString::Format("%.1f", newVal) + DegreeSymbol();
         else
           out = wxString::Format("%.3f", newVal);
         table->SetValue(wxVariant(out), r, col);
@@ -756,7 +762,7 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
 
           wxString out;
           if (col >= 13 && col <= 15)
-            out = wxString::Format("%.1f\u00B0", val);
+            out = wxString::Format("%.1f", val) + DegreeSymbol();
           else
             out = wxString::Format("%.3f", val);
 

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -658,8 +658,10 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
         wxVariant cv;
         table->GetValue(cv, r, col);
         wxString cur = cv.GetString();
-        if (col >= 13 && col <= 15)
-          cur.Replace("\u00B0", "");
+        if (col >= 13 && col <= 15) {
+          if (!DegreeSymbol().empty())
+            cur.Replace(DegreeSymbol(), "");
+        }
         double curVal = 0.0;
         cur.ToDouble(&curVal);
         double newVal = curVal + delta;

--- a/gui/gdtfsearchdialog.cpp
+++ b/gui/gdtfsearchdialog.cpp
@@ -207,7 +207,7 @@ void GdtfSearchDialog::UpdateResults()
     wxString b = normalize(manufacturerCtrl->GetValue());
     wxString m = normalize(fixtureCtrl->GetValue());
     if (ConsolePanel::Instance()) {
-        wxString msg = wxString::Format("Filtering manufacturer='%s' fixture='%s'", b, m);
+        wxString msg = "Filtering manufacturer='" + b + "' fixture='" + m + "'";
         ConsolePanel::Instance()->AppendMessage(msg);
     }
     for (size_t i = 0; i < entries.size(); ++i) {

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -360,8 +360,10 @@ void HoistTablePanel::OnContextMenu(wxDataViewEvent &event) {
         wxVariant cv;
         table->GetValue(cv, r, col);
         wxString cur = cv.GetString();
-        if (col >= 9 && col <= 11)
-          cur.Replace("\u00B0", "");
+        if (col >= 9 && col <= 11) {
+          if (!DegreeSymbol().empty())
+            cur.Replace(DegreeSymbol(), "");
+        }
         double curVal = 0.0;
         cur.ToDouble(&curVal);
         double newVal = curVal + delta;
@@ -576,19 +578,22 @@ void HoistTablePanel::UpdateSceneData(bool logChanges) {
     table->GetValue(v, i, 9);
     {
       wxString s = v.GetString();
-      s.Replace("°", "");
+      if (!DegreeSymbol().empty())
+            s.Replace(DegreeSymbol(), "");
       s.ToDouble(&roll);
     }
     table->GetValue(v, i, 10);
     {
       wxString s = v.GetString();
-      s.Replace("°", "");
+      if (!DegreeSymbol().empty())
+            s.Replace(DegreeSymbol(), "");
       s.ToDouble(&pitch);
     }
     table->GetValue(v, i, 11);
     {
       wxString s = v.GetString();
-      s.Replace("°", "");
+      if (!DegreeSymbol().empty())
+            s.Replace(DegreeSymbol(), "");
       s.ToDouble(&yaw);
     }
 

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -40,6 +40,12 @@
 static HoistTablePanel *s_instance = nullptr;
 
 namespace {
+
+const wxString &DegreeSymbol() {
+  static const wxString kDegreeSymbol = wxString::FromUTF8("\xC2\xB0");
+  return kDegreeSymbol;
+}
+
 struct RangeParts {
   wxArrayString parts;
   bool usedSeparator = false;
@@ -187,9 +193,9 @@ void HoistTablePanel::ReloadData() {
     wxString posZ = wxString::Format("%.3f", posArr[2] / 1000.0f);
 
     auto euler = MatrixUtils::MatrixToEuler(support.transform);
-    wxString roll = wxString::Format("%.1f\u00B0", euler[2]);
-    wxString pitch = wxString::Format("%.1f\u00B0", euler[1]);
-    wxString yaw = wxString::Format("%.1f\u00B0", euler[0]);
+    wxString roll = wxString::Format("%.1f", euler[2]) + DegreeSymbol();
+    wxString pitch = wxString::Format("%.1f", euler[1]) + DegreeSymbol();
+    wxString yaw = wxString::Format("%.1f", euler[0]) + DegreeSymbol();
 
     wxString chainLen = wxString::Format("%.2f", support.chainLength);
     wxString capacity = wxString::Format("%.2f", support.capacityKg);
@@ -361,7 +367,7 @@ void HoistTablePanel::OnContextMenu(wxDataViewEvent &event) {
         double newVal = curVal + delta;
         wxString out;
         if (col >= 9 && col <= 11)
-          out = wxString::Format("%.1f\u00B0", newVal);
+          out = wxString::Format("%.1f", newVal) + DegreeSymbol();
         else
           out = wxString::Format((col == 12) ? "%.2f" : "%.3f", newVal);
         table->SetValue(wxVariant(out), r, col);
@@ -405,7 +411,7 @@ void HoistTablePanel::OnContextMenu(wxDataViewEvent &event) {
 
         wxString out;
         if (col >= 9 && col <= 11)
-          out = wxString::Format("%.1f\u00B0", val);
+          out = wxString::Format("%.1f", val) + DegreeSymbol();
         else
           out = wxString::Format((col == 12) ? "%.2f" : "%.3f", val);
 

--- a/gui/layouttextutils.cpp
+++ b/gui/layouttextutils.cpp
@@ -71,7 +71,7 @@ wxFont MakeRenderFont(int sizePx, bool bold, bool italic,
   return font;
 }
 
-const char *FormatName(int format) {
+wxString FormatName(int format) {
   switch (static_cast<wxRichTextFileType>(format)) {
     case wxRICHTEXT_TYPE_XML:
       return "XML";
@@ -152,33 +152,33 @@ bool LoadRichTextBufferFromString(wxRichTextBuffer &buffer,
   if (status == RichTextOpStatus::kSuccess)
     return true;
   if (status == RichTextOpStatus::kNoHandler) {
-    wxLogWarning("No rich text handler found for %s format.",
-                 FormatName(wxRICHTEXT_TYPE_XML));
+    wxLogWarning("No rich text handler found for " +
+                 FormatName(wxRICHTEXT_TYPE_XML) + " format.");
   } else {
-    wxLogWarning("Failed to load rich text buffer using %s format.",
-                 FormatName(wxRICHTEXT_TYPE_XML));
+    wxLogWarning("Failed to load rich text buffer using " +
+                 FormatName(wxRICHTEXT_TYPE_XML) + " format.");
   }
 #if defined(wxRICHTEXT_TYPE_RICHTEXT)
   status = LoadBufferFromUtf8(buffer, content, wxRICHTEXT_TYPE_RICHTEXT);
   if (status == RichTextOpStatus::kSuccess)
     return true;
   if (status == RichTextOpStatus::kNoHandler) {
-    wxLogWarning("No rich text handler found for %s format.",
-                 FormatName(wxRICHTEXT_TYPE_RICHTEXT));
+    wxLogWarning("No rich text handler found for " +
+                 FormatName(wxRICHTEXT_TYPE_RICHTEXT) + " format.");
   } else {
-    wxLogWarning("Failed to load rich text buffer using %s format.",
-                 FormatName(wxRICHTEXT_TYPE_RICHTEXT));
+    wxLogWarning("Failed to load rich text buffer using " +
+                 FormatName(wxRICHTEXT_TYPE_RICHTEXT) + " format.");
   }
 #endif
   status = LoadBufferFromUtf8(buffer, content, wxRICHTEXT_TYPE_TEXT);
   if (status == RichTextOpStatus::kSuccess)
     return true;
   if (status == RichTextOpStatus::kNoHandler) {
-    wxLogWarning("No rich text handler found for %s format.",
-                 FormatName(wxRICHTEXT_TYPE_TEXT));
+    wxLogWarning("No rich text handler found for " +
+                 FormatName(wxRICHTEXT_TYPE_TEXT) + " format.");
   } else {
-    wxLogWarning("Failed to load rich text buffer using %s format.",
-                 FormatName(wxRICHTEXT_TYPE_TEXT));
+    wxLogWarning("Failed to load rich text buffer using " +
+                 FormatName(wxRICHTEXT_TYPE_TEXT) + " format.");
   }
   return false;
 }
@@ -189,22 +189,22 @@ wxString SaveRichTextBufferToString(wxRichTextBuffer &buffer) {
   if (output.status == RichTextOpStatus::kSuccess)
     return output.data;
   if (output.status == RichTextOpStatus::kNoHandler) {
-    wxLogWarning("No rich text handler found for %s format.",
-                 FormatName(wxRICHTEXT_TYPE_XML));
+    wxLogWarning("No rich text handler found for " +
+                 FormatName(wxRICHTEXT_TYPE_XML) + " format.");
   } else {
-    wxLogWarning("Failed to save rich text buffer using %s format.",
-                 FormatName(wxRICHTEXT_TYPE_XML));
+    wxLogWarning("Failed to save rich text buffer using " +
+                 FormatName(wxRICHTEXT_TYPE_XML) + " format.");
   }
 #if defined(wxRICHTEXT_TYPE_RICHTEXT)
   output = SaveBufferToUtf8(buffer, wxRICHTEXT_TYPE_RICHTEXT);
   if (output.status == RichTextOpStatus::kSuccess)
     return output.data;
   if (output.status == RichTextOpStatus::kNoHandler) {
-    wxLogWarning("No rich text handler found for %s format.",
-                 FormatName(wxRICHTEXT_TYPE_RICHTEXT));
+    wxLogWarning("No rich text handler found for " +
+                 FormatName(wxRICHTEXT_TYPE_RICHTEXT) + " format.");
   } else {
-    wxLogWarning("Failed to save rich text buffer using %s format.",
-                 FormatName(wxRICHTEXT_TYPE_RICHTEXT));
+    wxLogWarning("Failed to save rich text buffer using " +
+                 FormatName(wxRICHTEXT_TYPE_RICHTEXT) + " format.");
   }
 #endif
   return wxEmptyString;

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -152,6 +152,12 @@ void LogMissingIcon(const std::filesystem::path &path) {
   wxLogWarning("Main window icon not found at '%s'", path.string().c_str());
 }
 
+wxString PathToWxString(const std::filesystem::path &path) {
+  const std::u8string utf8 = path.u8string();
+  const std::string utf8Str(utf8.begin(), utf8.end());
+  return wxString::FromUTF8(utf8Str.c_str());
+}
+
 wxFont BuildDefaultUiFont() {
   wxFont defaultFont = wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT);
   const wxString faceName =
@@ -271,7 +277,7 @@ MainWindow::MainWindow(const wxString &title, IGuiConfigServices *services)
     iconPath = resourceRoot / "Perastage.ico";
   std::error_code ec;
   if (!iconPath.empty() && std::filesystem::exists(iconPath, ec)) {
-    icon.LoadFile(iconPath.string(), wxBITMAP_TYPE_ICO);
+    icon.LoadFile(PathToWxString(iconPath), wxBITMAP_TYPE_ICO);
   } else {
     LogMissingIcon(
         iconPath.empty() ? std::filesystem::path("resources/Perastage.ico")

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -155,7 +155,7 @@ wxString PathToWxString(const std::filesystem::path &path) {
 }
 
 void LogMissingIcon(const std::filesystem::path &path) {
-  wxLogWarning("Main window icon not found at '%s'", PathToWxString(path));
+  wxLogWarning("Main window icon not found at '" + PathToWxString(path) + "'");
 }
 
 wxFont BuildDefaultUiFont() {
@@ -473,7 +473,7 @@ bool MainWindow::ConfirmSaveIfDirty(const wxString &actionLabel,
 
   wxMessageDialog dlg(
       this,
-      wxString::Format("Do you want to save changes before %s?", actionLabel),
+      "Do you want to save changes before " + actionLabel + "?",
       dialogTitle, wxYES_NO | wxCANCEL | wxICON_QUESTION);
 
   int res = dlg.ShowModal();

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -148,14 +148,14 @@ void PersistFixtureTypeAutoColors(ConfigManager &configManager) {
   }
 }
 
-void LogMissingIcon(const std::filesystem::path &path) {
-  wxLogWarning("Main window icon not found at '%s'", path.string().c_str());
-}
-
 wxString PathToWxString(const std::filesystem::path &path) {
   const std::u8string utf8 = path.u8string();
   const std::string utf8Str(utf8.begin(), utf8.end());
   return wxString::FromUTF8(utf8Str.c_str());
+}
+
+void LogMissingIcon(const std::filesystem::path &path) {
+  wxLogWarning("Main window icon not found at '%s'", PathToWxString(path));
 }
 
 wxFont BuildDefaultUiFont() {

--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -57,9 +57,10 @@ void MainWindow::OnLoad(wxCommandEvent &event) {
   if (!ConfirmSaveIfDirty("loading a project", "Open Project"))
     return;
 
-  wxString filter = wxString::Format("Perastage files (*%s)|*%s",
-                                     ProjectUtils::PROJECT_EXTENSION,
-                                     ProjectUtils::PROJECT_EXTENSION);
+  const wxString projectExtension =
+      wxString::FromUTF8(ProjectUtils::PROJECT_EXTENSION);
+  wxString filter = "Perastage files (*" + projectExtension + ")|*" +
+                    projectExtension;
   wxString projDir;
   if (auto last = ProjectUtils::LoadLastProjectPath())
     projDir =
@@ -98,9 +99,10 @@ void MainWindow::OnSave(wxCommandEvent &event) {
 }
 
 void MainWindow::OnSaveAs(wxCommandEvent &event) {
-  wxString filter = wxString::Format("Perastage files (*%s)|*%s",
-                                     ProjectUtils::PROJECT_EXTENSION,
-                                     ProjectUtils::PROJECT_EXTENSION);
+  const wxString projectExtension =
+      wxString::FromUTF8(ProjectUtils::PROJECT_EXTENSION);
+  wxString filter = "Perastage files (*" + projectExtension + ")|*" +
+                    projectExtension;
   wxString projDir;
   if (!currentProjectPath.empty())
     projDir = wxString::FromUTF8(
@@ -272,8 +274,7 @@ void MainWindow::OnExportFixture(wxCommandEvent &WXUNUSED(event)) {
   auto extractZip = [](const std::string &zipPath, const std::string &destDir) {
     if (!fs::exists(zipPath)) {
       if (ConsolePanel::Instance()) {
-        wxString msg = wxString::Format("GDTF: cannot open %s",
-                                        wxString::FromUTF8(zipPath));
+        wxString msg = "GDTF: cannot open " + wxString::FromUTF8(zipPath);
         ConsolePanel::Instance()->AppendMessage(msg);
       }
       return false;
@@ -282,8 +283,7 @@ void MainWindow::OnExportFixture(wxCommandEvent &WXUNUSED(event)) {
     wxFileInputStream input(zipPath);
     if (!input.IsOk()) {
       if (ConsolePanel::Instance()) {
-        wxString msg = wxString::Format("GDTF: cannot open %s",
-                                        wxString::FromUTF8(zipPath));
+        wxString msg = "GDTF: cannot open " + wxString::FromUTF8(zipPath);
         ConsolePanel::Instance()->AppendMessage(msg);
       }
       return false;

--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -142,7 +142,10 @@ void MainWindow::OnImportRider(wxCommandEvent &event) {
   if (dlg.ShowModal() == wxID_CANCEL)
     return;
 
-  std::string pathUtf8 = dlg.GetPath().ToStdString();
+  const wxScopedCharBuffer pathBuffer = dlg.GetPath().ToUTF8();
+  std::string pathUtf8 =
+      pathBuffer ? std::string(pathBuffer.data(), pathBuffer.length())
+                 : dlg.GetPath().ToStdString();
   if (!RiderImporter::Import(pathUtf8)) {
     wxMessageBox("Failed to import rider.", "Error", wxICON_ERROR);
     if (consolePanel)

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -73,6 +73,14 @@
 #include "viewer3dpanel.h"
 
 namespace {
+
+std::string WxToUtf8(const wxString &value) {
+  const wxScopedCharBuffer utf8 = value.ToUTF8();
+  if (utf8)
+    return std::string(utf8.data(), utf8.length());
+  return value.ToStdString();
+}
+
 struct HelpMarkdown {
   std::string english;
   std::string spanish;
@@ -427,21 +435,21 @@ void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
       wxString::FromUTF8(loginDlg.GetUsername()).Trim(true).Trim(false);
   wxString password = wxString::FromUTF8(loginDlg.GetPassword());
   GetDefaultGuiConfigServices().LegacyConfigManager().SetValue("gdtf_username",
-                                std::string(username.mb_str()));
+                                WxToUtf8(username));
   GetDefaultGuiConfigServices().LegacyConfigManager().SetValue(
-      "gdtf_password", SimpleCrypt::Encode(std::string(password.mb_str())));
+      "gdtf_password", SimpleCrypt::Encode(WxToUtf8(password)));
   CredentialStore::Save(
-      {std::string(username.mb_str()), std::string(password.mb_str())});
+      {WxToUtf8(username), WxToUtf8(password)});
 
   if (!currentProjectPath.empty())
     GetDefaultGuiConfigServices().LegacyConfigManager().SaveProject(currentProjectPath);
 
   wxString cookieFileWx = wxFileName::GetTempDir() + "/gdtf_session.txt";
-  std::string cookieFile = std::string(cookieFileWx.mb_str());
+  std::string cookieFile = WxToUtf8(cookieFileWx);
   long httpCode = 0;
   if (consolePanel)
     consolePanel->AppendMessage("Logging into GDTF Share using libcurl");
-  if (!GdtfLogin(std::string(username.mb_str()), std::string(password.mb_str()),
+  if (!GdtfLogin(WxToUtf8(username), WxToUtf8(password),
                  cookieFile, httpCode)) {
     wxMessageBox("Failed to connect to GDTF Share.", "Login Error",
                  wxOK | wxICON_ERROR);
@@ -491,8 +499,8 @@ void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
         if (consolePanel)
           consolePanel->AppendMessage("Downloading via libcurl rid=" + rid);
         long dlCode = 0;
-        bool ok = GdtfDownload(std::string(rid.mb_str()),
-                               std::string(dest.mb_str()), cookieFile, dlCode);
+        bool ok = GdtfDownload(WxToUtf8(rid),
+                               WxToUtf8(dest), cookieFile, dlCode);
         if (consolePanel)
           consolePanel->AppendMessage(
               wxString::Format("Download HTTP code: %ld", dlCode));
@@ -746,7 +754,7 @@ void MainWindow::OnShowHelp(wxCommandEvent &WXUNUSED(event)) {
   helpPath.SetFullName("help.md");
   if (helpPath.Exists()) {
     // Read the file contents.
-    std::ifstream in(helpPath.GetFullPath().ToStdString());
+    std::ifstream in(WxToUtf8(helpPath.GetFullPath()));
     std::string markdown((std::istreambuf_iterator<char>(in)),
                          std::istreambuf_iterator<char>());
     HelpMarkdown help = SplitHelpMarkdown(markdown);
@@ -966,10 +974,10 @@ void MainWindow::OnAddFixture(wxCommandEvent &WXUNUSED(event)) {
       if (fdlg.ShowModal() != wxID_OK)
         return;
       wxString gdtfPathWx = fdlg.GetPath();
-      gdtfPath = std::string(gdtfPathWx.mb_str());
+      gdtfPath = WxToUtf8(gdtfPathWx);
       defaultName = GetGdtfFixtureName(gdtfPath);
       if (defaultName.empty())
-        defaultName = wxFileName(gdtfPathWx).GetName().ToStdString();
+        defaultName = WxToUtf8(wxFileName(gdtfPathWx).GetName());
     } else {
       int sel = chooseDlg.GetSelection();
       if (sel < 0 || sel >= static_cast<int>(types.size()))
@@ -990,10 +998,10 @@ void MainWindow::OnAddFixture(wxCommandEvent &WXUNUSED(event)) {
     if (fdlg.ShowModal() != wxID_OK)
       return;
     wxString gdtfPathWx = fdlg.GetPath();
-    gdtfPath = std::string(gdtfPathWx.mb_str());
+    gdtfPath = WxToUtf8(gdtfPathWx);
     defaultName = GetGdtfFixtureName(gdtfPath);
     if (defaultName.empty())
-      defaultName = wxFileName(gdtfPathWx).GetName().ToStdString();
+      defaultName = WxToUtf8(wxFileName(gdtfPathWx).GetName());
   }
 
   std::vector<std::string> modes = GetGdtfModes(gdtfPath);
@@ -1100,8 +1108,8 @@ void MainWindow::OnAddTruss(wxCommandEvent &WXUNUSED(event)) {
       if (fdlg.ShowModal() != wxID_OK)
         return;
       wxFileName fn(fdlg.GetPath());
-      defaultName = fn.GetName().ToStdString();
-      path = std::string(fdlg.GetPath().mb_str());
+      defaultName = WxToUtf8(fn.GetName());
+      path = WxToUtf8(fdlg.GetPath());
     } else {
       int sel = chooseDlg.GetSelection();
       if (sel < 0 || sel >= static_cast<int>(names.size()))
@@ -1117,8 +1125,8 @@ void MainWindow::OnAddTruss(wxCommandEvent &WXUNUSED(event)) {
     if (fdlg.ShowModal() != wxID_OK)
       return;
     wxFileName fn(fdlg.GetPath());
-    defaultName = fn.GetName().ToStdString();
-    path = std::string(fdlg.GetPath().mb_str());
+    defaultName = WxToUtf8(fn.GetName());
+    path = WxToUtf8(fdlg.GetPath());
   }
 
   Truss baseTruss;
@@ -1224,8 +1232,8 @@ void MainWindow::OnAddSceneObject(wxCommandEvent &WXUNUSED(event)) {
       if (fdlg.ShowModal() != wxID_OK)
         return;
       wxFileName fn(fdlg.GetPath());
-      defaultName = fn.GetName().ToStdString();
-      path = std::string(fdlg.GetPath().mb_str());
+      defaultName = WxToUtf8(fn.GetName());
+      path = WxToUtf8(fdlg.GetPath());
     } else {
       int sel = chooseDlg.GetSelection();
       if (sel < 0 || sel >= static_cast<int>(names.size()))
@@ -1241,8 +1249,8 @@ void MainWindow::OnAddSceneObject(wxCommandEvent &WXUNUSED(event)) {
     if (fdlg.ShowModal() != wxID_OK)
       return;
     wxFileName fn(fdlg.GetPath());
-    defaultName = fn.GetName().ToStdString();
-    path = std::string(fdlg.GetPath().mb_str());
+    defaultName = WxToUtf8(fn.GetName());
+    path = WxToUtf8(fdlg.GetPath());
   }
 
   long qty = wxGetNumberFromUser("Enter object quantity:", wxEmptyString,

--- a/gui/mainwindow_print.cpp
+++ b/gui/mainwindow_print.cpp
@@ -173,7 +173,7 @@ void MainWindow::OnPrintViewer2D(wxCommandEvent &WXUNUSED(event)) {
         if (capturePanel)
           fixtureReport = capturePanel->GetLastFixtureDebugReport();
         if (!fixtureReport.empty()) {
-          wxLogMessage("%s", wxString::FromUTF8(fixtureReport));
+          wxLogMessage(wxString::FromUTF8(fixtureReport));
           if (ConsolePanel::Instance()) {
             ConsolePanel::Instance()->AppendMessage(
                 wxString::FromUTF8(fixtureReport));
@@ -200,8 +200,7 @@ void MainWindow::OnPrintViewer2D(wxCommandEvent &WXUNUSED(event)) {
               wxMessageBox(msg, "Print Viewer 2D", wxOK | wxICON_ERROR, this);
             } else {
               SetPrintStatus(this, "");
-              wxMessageBox(wxString::Format("2D view saved to %s",
-                                            outputPathDisplay),
+              wxMessageBox("2D view saved to " + outputPathDisplay,
                            "Print Viewer 2D", wxOK | wxICON_INFORMATION, this);
             }
           });
@@ -393,8 +392,7 @@ void MainWindow::OnPrintLayout(wxCommandEvent &WXUNUSED(event)) {
                 wxMessageBox(msg, "Print Layout", wxOK | wxICON_ERROR, this);
               } else {
                 SetPrintStatus(this, "");
-                wxString successMessage =
-                    wxString::Format("Layout saved to %s", outputPathDisplay);
+                wxString successMessage = "Layout saved to " + outputPathDisplay;
                 wxMessageBox(successMessage, "Print Layout",
                              wxOK | wxICON_INFORMATION, this);
               }

--- a/gui/ridertextdialog.cpp
+++ b/gui/ridertextdialog.cpp
@@ -137,10 +137,10 @@ void RiderTextDialog::OnLoadExample(wxCommandEvent &WXUNUSED(event)) {
 
 void RiderTextDialog::OnApply(wxCommandEvent &WXUNUSED(event)) {
   wxString value = textCtrl->GetValue();
-  std::string text = value.ToStdString(wxConvUTF8);
-  if (text.empty() && !value.empty()) {
-    text = value.ToStdString();
-  }
+  const wxScopedCharBuffer textBuffer = value.ToUTF8();
+  std::string text =
+      textBuffer ? std::string(textBuffer.data(), textBuffer.length())
+                 : value.ToStdString();
   if (text.empty()) {
     wxMessageBox("Rider text is empty.", "Error", wxICON_ERROR);
     return;

--- a/gui/ridertextdialog.cpp
+++ b/gui/ridertextdialog.cpp
@@ -52,7 +52,7 @@ RiderTextDialog::RiderTextDialog(wxWindow *parent,
   wxBoxSizer *headerSizer = new wxBoxSizer(wxHORIZONTAL);
   const wxString sourceTextLabel =
       sourceLabel.empty() ? wxString("No source loaded.")
-                          : wxString::Format("Loaded: %s", sourceLabel);
+                          : wxString("Loaded: ") + sourceLabel;
   sourceText = new wxStaticText(this, wxID_ANY, sourceTextLabel);
   headerSizer->Add(sourceText, 1, wxALIGN_CENTER_VERTICAL | wxRIGHT, 8);
   wxButton *loadButton = new wxButton(this, ID_RiderText_Load, "Load rider...");
@@ -98,7 +98,7 @@ void RiderTextDialog::OnLoadFromFile(wxCommandEvent &WXUNUSED(event)) {
   }
   sourceLabel = dlg.GetFilename();
   if (sourceText)
-    sourceText->SetLabel(wxString::Format("Loaded: %s", sourceLabel));
+    sourceText->SetLabel(wxString("Loaded: ") + sourceLabel);
   textCtrl->ChangeValue(wxString::FromUTF8(text));
   wxMessageBox("Rider imported successfully.", "Success", wxICON_INFORMATION);
 }
@@ -129,7 +129,7 @@ void RiderTextDialog::OnLoadExample(wxCommandEvent &WXUNUSED(event)) {
   textCtrl->ChangeValue(exampleText);
   sourceLabel = "Example text";
   if (sourceText)
-    sourceText->SetLabel(wxString::Format("Loaded: %s", sourceLabel));
+    sourceText->SetLabel(wxString("Loaded: ") + sourceLabel);
 }
 
 void RiderTextDialog::OnApply(wxCommandEvent &WXUNUSED(event)) {

--- a/gui/ridertextdialog.cpp
+++ b/gui/ridertextdialog.cpp
@@ -90,7 +90,10 @@ void RiderTextDialog::OnLoadFromFile(wxCommandEvent &WXUNUSED(event)) {
   if (dlg.ShowModal() == wxID_CANCEL)
     return;
 
-  std::string pathUtf8 = dlg.GetPath().ToStdString();
+  const wxScopedCharBuffer pathBuffer = dlg.GetPath().ToUTF8();
+  std::string pathUtf8 =
+      pathBuffer ? std::string(pathBuffer.data(), pathBuffer.length())
+                 : dlg.GetPath().ToStdString();
   std::string text = RiderImporter::LoadText(pathUtf8);
   if (text.empty()) {
     wxMessageBox("Failed to import rider.", "Error", wxICON_ERROR);

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -37,6 +37,12 @@
 static SceneObjectTablePanel* s_instance = nullptr;
 
 namespace {
+
+const wxString &DegreeSymbol() {
+  static const wxString kDegreeSymbol = wxString::FromUTF8("\xC2\xB0");
+  return kDegreeSymbol;
+}
+
 struct RangeParts {
     wxArrayString parts;
     bool usedSeparator = false;
@@ -185,9 +191,9 @@ void SceneObjectTablePanel::ReloadData()
         wxString posZ = wxString::Format("%.3f", posArr[2] / 1000.0f);
 
         auto euler = MatrixUtils::MatrixToEuler(obj.transform);
-        wxString roll = wxString::Format("%.1f\u00B0", euler[2]);
-        wxString pitch = wxString::Format("%.1f\u00B0", euler[1]);
-        wxString yaw = wxString::Format("%.1f\u00B0", euler[0]);
+        wxString roll = wxString::Format("%.1f", euler[2]) + DegreeSymbol();
+        wxString pitch = wxString::Format("%.1f", euler[1]) + DegreeSymbol();
+        wxString yaw = wxString::Format("%.1f", euler[0]) + DegreeSymbol();
 
         row.push_back(name);
         row.push_back(layer);
@@ -315,7 +321,7 @@ void SceneObjectTablePanel::OnContextMenu(wxDataViewEvent& event)
                 double newVal = curVal + delta;
                 wxString out;
                 if (col >= 6)
-                    out = wxString::Format("%.1f\u00B0", newVal);
+                    out = wxString::Format("%.1f", newVal) + DegreeSymbol();
                 else
                     out = wxString::Format("%.3f", newVal);
                 table->SetValue(wxVariant(out), r, col);
@@ -369,7 +375,7 @@ void SceneObjectTablePanel::OnContextMenu(wxDataViewEvent& event)
 
                 wxString out;
                 if (col >= 6)
-                    out = wxString::Format("%.1f\u00B0", val);
+                    out = wxString::Format("%.1f", val) + DegreeSymbol();
                 else
                     out = wxString::Format("%.3f", val);
 

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -314,8 +314,10 @@ void SceneObjectTablePanel::OnContextMenu(wxDataViewEvent& event)
                 wxVariant cv;
                 table->GetValue(cv, r, col);
                 wxString cur = cv.GetString();
-                if (col >= 6)
-                    cur.Replace("\u00B0", "");
+                if (col >= 6) {
+                    if (!DegreeSymbol().empty())
+                        cur.Replace(DegreeSymbol(), "");
+                }
                 double curVal = 0.0;
                 cur.ToDouble(&curVal);
                 double newVal = curVal + delta;
@@ -600,19 +602,22 @@ void SceneObjectTablePanel::UpdateSceneData(bool logChanges)
         table->GetValue(v, i, 6);
         {
             wxString s = v.GetString();
-            s.Replace("°", "");
+            if (!DegreeSymbol().empty())
+            s.Replace(DegreeSymbol(), "");
             s.ToDouble(&roll);
         }
         table->GetValue(v, i, 7);
         {
             wxString s = v.GetString();
-            s.Replace("°", "");
+            if (!DegreeSymbol().empty())
+            s.Replace(DegreeSymbol(), "");
             s.ToDouble(&pitch);
         }
         table->GetValue(v, i, 8);
         {
             wxString s = v.GetString();
-            s.Replace("°", "");
+            if (!DegreeSymbol().empty())
+            s.Replace(DegreeSymbol(), "");
             s.ToDouble(&yaw);
         }
 

--- a/gui/splashscreen.cpp
+++ b/gui/splashscreen.cpp
@@ -49,11 +49,18 @@ void SplashScreen::Show() {
                          : iconPath);
   }
   wxIcon icon = bundle.GetIcon(wxSize(256, 256));
-  if (icon.IsOk())
+  if (icon.IsOk()) {
     logoBmp = wxBitmap(icon);
-  else
-    logoBmp =
-        wxArtProvider::GetBitmap(wxART_MISSING_IMAGE, wxART_OTHER, wxSize(256, 256));
+  } else {
+    const std::filesystem::path pngPath = resourceRoot / "perastage3d.png";
+    if (!resourceRoot.empty() && std::filesystem::exists(pngPath, ec)) {
+      logoBmp.LoadFile(PathToWxString(pngPath), wxBITMAP_TYPE_PNG);
+    }
+    if (!logoBmp.IsOk()) {
+      logoBmp = wxArtProvider::GetBitmap(wxART_MISSING_IMAGE, wxART_OTHER,
+                                         wxSize(256, 256));
+    }
+  }
 
   wxStaticBitmap *logo = new wxStaticBitmap(panel, wxID_ANY, logoBmp);
 

--- a/gui/splashscreen.cpp
+++ b/gui/splashscreen.cpp
@@ -13,14 +13,14 @@ namespace {
 wxFrame *g_splash = nullptr;
 wxStaticText *g_label = nullptr;
 
-void LogMissingIcon(const std::filesystem::path &path) {
-  wxLogWarning("Splash icon not found at '%s'", path.string().c_str());
-}
-
 wxString PathToWxString(const std::filesystem::path &path) {
   const std::u8string utf8 = path.u8string();
   const std::string utf8Str(utf8.begin(), utf8.end());
   return wxString::FromUTF8(utf8Str.c_str());
+}
+
+void LogMissingIcon(const std::filesystem::path &path) {
+  wxLogWarning("Splash icon not found at '%s'", PathToWxString(path));
 }
 }
 

--- a/gui/splashscreen.cpp
+++ b/gui/splashscreen.cpp
@@ -16,6 +16,12 @@ wxStaticText *g_label = nullptr;
 void LogMissingIcon(const std::filesystem::path &path) {
   wxLogWarning("Splash icon not found at '%s'", path.string().c_str());
 }
+
+wxString PathToWxString(const std::filesystem::path &path) {
+  const std::u8string utf8 = path.u8string();
+  const std::string utf8Str(utf8.begin(), utf8.end());
+  return wxString::FromUTF8(utf8Str.c_str());
+}
 }
 
 void SplashScreen::Show() {
@@ -36,7 +42,7 @@ void SplashScreen::Show() {
     iconPath = resourceRoot / "Perastage.ico";
   std::error_code ec;
   if (!iconPath.empty() && std::filesystem::exists(iconPath, ec)) {
-    bundle.AddIcon(iconPath.string(), wxBITMAP_TYPE_ICO);
+    bundle.AddIcon(PathToWxString(iconPath), wxBITMAP_TYPE_ICO);
   } else {
     LogMissingIcon(
         iconPath.empty() ? std::filesystem::path("resources/Perastage.ico")

--- a/gui/splashscreen.cpp
+++ b/gui/splashscreen.cpp
@@ -20,7 +20,7 @@ wxString PathToWxString(const std::filesystem::path &path) {
 }
 
 void LogMissingIcon(const std::filesystem::path &path) {
-  wxLogWarning("Splash icon not found at '%s'", PathToWxString(path));
+  wxLogWarning("Splash icon not found at '" + PathToWxString(path) + "'");
 }
 }
 

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -506,8 +506,10 @@ void TrussTablePanel::OnContextMenu(wxDataViewEvent& event)
                 wxVariant cv;
                 table->GetValue(cv, r, col);
                 wxString cur = cv.GetString();
-                if (col >= 7)
-                    cur.Replace("\u00B0", "");
+                if (col >= 7) {
+                    if (!DegreeSymbol().empty())
+                        cur.Replace(DegreeSymbol(), "");
+                }
                 double curVal = 0.0;
                 cur.ToDouble(&curVal);
                 double newVal = curVal + delta;
@@ -830,19 +832,22 @@ void TrussTablePanel::UpdateSceneData(bool logChanges)
         table->GetValue(v, i, 7);
         {
             wxString s = v.GetString();
-            s.Replace("°", "");
+            if (!DegreeSymbol().empty())
+            s.Replace(DegreeSymbol(), "");
             s.ToDouble(&roll);
         }
         table->GetValue(v, i, 8);
         {
             wxString s = v.GetString();
-            s.Replace("°", "");
+            if (!DegreeSymbol().empty())
+            s.Replace(DegreeSymbol(), "");
             s.ToDouble(&pitch);
         }
         table->GetValue(v, i, 9);
         {
             wxString s = v.GetString();
-            s.Replace("°", "");
+            if (!DegreeSymbol().empty())
+            s.Replace(DegreeSymbol(), "");
             s.ToDouble(&yaw);
         }
 

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -48,6 +48,12 @@ static TrussTablePanel* s_instance = nullptr;
 namespace fs = std::filesystem;
 
 namespace {
+
+const wxString &DegreeSymbol() {
+  static const wxString kDegreeSymbol = wxString::FromUTF8("\xC2\xB0");
+  return kDegreeSymbol;
+}
+
 struct RangeParts {
     wxArrayString parts;
     bool usedSeparator = false;
@@ -251,9 +257,9 @@ void TrussTablePanel::ReloadData()
         wxString posZ = wxString::Format("%.3f", posArr[2] / 1000.0f);
 
         auto euler = MatrixUtils::MatrixToEuler(truss.transform);
-        wxString roll = wxString::Format("%.1f\u00B0", euler[2]);
-        wxString pitch = wxString::Format("%.1f\u00B0", euler[1]);
-        wxString yaw = wxString::Format("%.1f\u00B0", euler[0]);
+        wxString roll = wxString::Format("%.1f", euler[2]) + DegreeSymbol();
+        wxString pitch = wxString::Format("%.1f", euler[1]) + DegreeSymbol();
+        wxString yaw = wxString::Format("%.1f", euler[0]) + DegreeSymbol();
 
         row.push_back(name);
         row.push_back(layer);
@@ -507,7 +513,7 @@ void TrussTablePanel::OnContextMenu(wxDataViewEvent& event)
                 double newVal = curVal + delta;
                 wxString out;
                 if (col >= 7)
-                    out = wxString::Format("%.1f\u00B0", newVal);
+                    out = wxString::Format("%.1f", newVal) + DegreeSymbol();
                 else
                     out = wxString::Format("%.3f", newVal);
                 table->SetValue(wxVariant(out), r, col);
@@ -561,7 +567,7 @@ void TrussTablePanel::OnContextMenu(wxDataViewEvent& event)
 
                 wxString out;
                 if (col >= 7)
-                    out = wxString::Format("%.1f\u00B0", val);
+                    out = wxString::Format("%.1f", val) + DegreeSymbol();
                 else
                     out = wxString::Format("%.3f", val);
 

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -69,10 +69,8 @@ void AppendTrussUpdateLog(const std::vector<std::pair<std::string, std::string>>
     if (updates.size() == 1)
     {
         const auto& [name, uuid] = updates.front();
-        console->AppendMessage(
-            wxString::Format("Updated truss %s (UUID %s)",
-                             wxString::FromUTF8(name.c_str()),
-                             wxString::FromUTF8(uuid.c_str())));
+        console->AppendMessage("Updated truss " + wxString::FromUTF8(name) +
+                               " (UUID " + wxString::FromUTF8(uuid) + ")");
         return;
     }
 

--- a/viewer3d/resources/resource_sync_system.cpp
+++ b/viewer3d/resources/resource_sync_system.cpp
@@ -26,6 +26,23 @@ std::string FindFileRecursive(const std::string &baseDir,
   return {};
 }
 
+
+std::string TrimPathRef(std::string value) {
+  auto isTrim = [](unsigned char c) {
+    return std::isspace(c) != 0 || c == '\r' || c == '\n' || c == '\t';
+  };
+
+  while (!value.empty() && isTrim(static_cast<unsigned char>(value.front())))
+    value.erase(value.begin());
+  while (!value.empty() && isTrim(static_cast<unsigned char>(value.back())))
+    value.pop_back();
+
+  if (value.size() >= 2 && value.front() == '"' && value.back() == '"')
+    return value.substr(1, value.size() - 2);
+
+  return value;
+}
+
 std::string NormalizePath(const std::string &p) {
   std::string out = p;
   char sep = static_cast<char>(fs::path::preferred_separator);
@@ -42,14 +59,15 @@ std::string NormalizeModelKey(const std::string &p) {
 }
 
 std::string ResolveCacheKey(const std::string &pathRef) {
-  return NormalizeModelKey(pathRef);
+  return NormalizeModelKey(TrimPathRef(pathRef));
 }
 
 std::string ResolveGdtfPath(const std::string &base, const std::string &spec,
                             bool allowRecursiveFallback = false) {
-  if (spec.empty())
+  const std::string cleanSpec = TrimPathRef(spec);
+  if (cleanSpec.empty())
     return {};
-  fs::path p(spec);
+  fs::path p(cleanSpec);
   if (p.is_absolute() && fs::exists(p))
     return p.string();
   fs::path candidate = fs::path(base) / p;
@@ -205,28 +223,30 @@ ResourceSyncResult ResourceSyncSystem::Sync(
   result.hasSceneSignature = state.hasSceneSignature;
 
   auto ensureGdtfResolvedPath = [&](const std::string &spec) {
-    if (spec.empty())
+    const std::string cleanSpec = TrimPathRef(spec);
+    if (cleanSpec.empty())
       return;
-    const std::string key = ResolveCacheKey(spec);
+    const std::string key = ResolveCacheKey(cleanSpec);
     auto [it, inserted] =
         state.resolvedGdtfSpecs.try_emplace(key, ResourceSyncState::PathResolutionEntry{});
     if (!inserted && it->second.attempted && !it->second.resolvedPath.empty() &&
         fs::exists(fs::u8path(it->second.resolvedPath)))
       return;
-    it->second.resolvedPath = ResolveGdtfPath(basePath, spec, true);
+    it->second.resolvedPath = ResolveGdtfPath(basePath, cleanSpec, true);
     it->second.attempted = true;
   };
 
   auto ensureModelResolvedPath = [&](const std::string &modelRef) {
-    if (modelRef.empty())
+    const std::string cleanModelRef = TrimPathRef(modelRef);
+    if (cleanModelRef.empty())
       return;
-    const std::string key = ResolveCacheKey(modelRef);
+    const std::string key = ResolveCacheKey(cleanModelRef);
     auto [it, inserted] =
         state.resolvedModelRefs.try_emplace(key, ResourceSyncState::PathResolutionEntry{});
     if (!inserted && it->second.attempted && !it->second.resolvedPath.empty() &&
         fs::exists(fs::u8path(it->second.resolvedPath)))
       return;
-    it->second.resolvedPath = ResolveModelPath(basePath, modelRef, true);
+    it->second.resolvedPath = ResolveModelPath(basePath, cleanModelRef, true);
     it->second.attempted = true;
   };
 

--- a/viewer3d/resources/resource_sync_system.cpp
+++ b/viewer3d/resources/resource_sync_system.cpp
@@ -5,6 +5,7 @@
 #include "matrixutils.h"
 
 #include <algorithm>
+#include <array>
 #include <cctype>
 #include <cmath>
 #include <filesystem>
@@ -67,14 +68,36 @@ std::string ResolveGdtfPath(const std::string &base, const std::string &spec,
   const std::string cleanSpec = TrimPathRef(spec);
   if (cleanSpec.empty())
     return {};
-  fs::path p(cleanSpec);
-  if (p.is_absolute() && fs::exists(p))
-    return p.string();
-  fs::path candidate = fs::path(base) / p;
-  if (fs::exists(candidate))
-    return candidate.string();
+
+  const std::array<std::string, 2> variants = {cleanSpec,
+                                               NormalizePath(cleanSpec)};
+
+  std::error_code ec;
+  for (const std::string &variant : variants) {
+    fs::path absoluteCandidate = fs::path(variant);
+    if (absoluteCandidate.is_absolute() && fs::exists(absoluteCandidate, ec))
+      return absoluteCandidate.string();
+    ec.clear();
+
+    fs::path relativeCandidate = fs::path(base) / absoluteCandidate;
+    if (fs::exists(relativeCandidate, ec))
+      return relativeCandidate.string();
+    ec.clear();
+
+    fs::path utf8AbsoluteCandidate = fs::u8path(variant);
+    if (utf8AbsoluteCandidate.is_absolute() &&
+        fs::exists(utf8AbsoluteCandidate, ec))
+      return utf8AbsoluteCandidate.string();
+    ec.clear();
+
+    fs::path utf8RelativeCandidate = fs::path(base) / utf8AbsoluteCandidate;
+    if (fs::exists(utf8RelativeCandidate, ec))
+      return utf8RelativeCandidate.string();
+    ec.clear();
+  }
+
   if (allowRecursiveFallback)
-    return FindFileRecursive(base, p.filename().string());
+    return FindFileRecursive(base, fs::path(cleanSpec).filename().string());
   return {};
 }
 


### PR DESCRIPTION
### Motivation
- Prevent a segmentation fault on Linux caused by using `wxString::Format("Loaded: %s", sourceLabel)` with `wxString` values by using a safer concatenation approach that preserves behavior on Windows/macOS.

### Description
- Replace `wxString::Format("Loaded: %s", sourceLabel)` with `wxString("Loaded: ") + sourceLabel` in `gui/ridertextdialog.cpp` for the initial label and the two code paths that update the label after loading a file or loading the example.

### Testing
- Ran `./tests/check_perastage_tree_modules.sh` and `./tests/check_no_configmanager_get_in_gui.sh`, both returned OK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a540f200a08324a9d86c1ff7e96976)