### PR TITLE
docs: sync README/help with current beta and build-gated features

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Perastage** is a desktop application for lighting designers and technicians built in C++20.  It reads, organises and visualises show data using the **MVR** (My Virtual Rig) format and **GDTF** (General Device Type Format).  The graphical user interface is written with **wxWidgets** and the 3D/2D rendering is performed with **OpenGL**.
 
-> **Status:** this project is in an early beta stage.  Many menu items are only stubs and not all code paths have been fully tested.  Expect incomplete features, placeholder interfaces and potential crashes.  User feedback is very welcome.
+> **Status:** active beta. Core workflows (MVR import/export, editing, layout/printing, and table tooling) are usable and under continuous stabilization. Some advanced and experimental tools remain build-gated or workflow-specific.
 
 ---
 
@@ -61,13 +61,15 @@
 
 ### Printing and export
 
-- **Print Viewer 2D:** print the current 2D view directly to PDF with configurable page size and orientation.
+- **Print Viewer 2D (Debug builds):** print the current 2D view directly to PDF with configurable page size and orientation. In Release builds this dialog is intentionally hidden behind `ui::FeatureFlag::PrintViewer2DDialog`.
 - **Print Layout:** print the active layout to PDF, including 2D views, legends, event tables, text and images.
 - **Print Table:** print any of the data tables (fixtures, trusses, hoists, objects) or export them to CSV via **File → Export CSV**.
 - **Export Fixture/Truss/Object:** export selected items to stand‑alone GDTF/GTRUSS or object files via the Tools menu.
+- **Layout PDF output:** export complete documentation sheets that combine viewport captures, legends, event tables, text, and image elements on named pages.
 
 ### GUI helpers
 
+- **Build-gated tools:** some menu entries are intentionally Debug-only (for example *Print Viewer 2D* and *Generate fixture symbols*) to keep Release builds focused on production-safe workflows.
 - Tables for fixtures, trusses, hoists and objects support multi‑row editing shortcuts: sequential fills, range interpolation (`1 10` / `1 thru 10`), relative edits (`++0.5`, `--15`), etc.
 - Console panel for status messages and command‑line operations (e.g. selecting fixtures or trusses via textual commands).
 - Preferences dialog to set default directories, units and other settings.

--- a/help.md
+++ b/help.md
@@ -6,7 +6,7 @@
 1. Launch the application.
 2. Use **File > Import MVR...** to load an `.mvr` file.
 3. Use the table tabs (**Fixtures**, **Trusses**, **Hoists**, **Objects**) to inspect data.
-4. Toggle panels via the **View** menu if any pane is hidden.
+4. Toggle panes via the **View** menu if any pane is hidden (Console, Layers, Layouts, Summary, Rigging, 2D Viewer, 3D Viewer, and 2D Render Options).
 
 ## Project Files
 
@@ -18,6 +18,16 @@ Perastage projects (`.psproj`) store the scene, layouts, and user settings.
 - **Load** opens an existing `.psproj` file.
 - **Save** stores changes in the current project file.
 - **Save As...** writes the project under a new name or location.
+
+
+## Build-dependent tools
+
+Some tools are intentionally available only in **Debug** builds:
+
+- **File > Print Viewer 2D...**
+- **Tools > Generate fixture symbols**
+
+Release builds keep these entries hidden to reduce risk in production workflows.
 
 ## Console Commands (complete)
 
@@ -108,7 +118,7 @@ Notes:
 | Shortcut | Action |
 | --- | --- |
 | Delete | Delete selected layout element |
-| Z | Reset layout view to fit |
+| F | Reset layout view to fit |
 
 ## Mouse Shortcuts (complete)
 

--- a/perastage_tree.md
+++ b/perastage_tree.md
@@ -10,7 +10,8 @@ This map is aligned with the terminology used in `README.md` and `docs/architect
 Perastage/
 ├── main.cpp                     # wxWidgets application entry point.
 ├── CMakeLists.txt               # Root build orchestration and global dependencies.
-├── README.md                    # Product overview and repository layout.
+├── README.md                    # Product overview, features, and build notes.
+├── help.md                      # In-app help content (English/Spanish sections).
 ├── docs/architecture.md         # Architecture and repository conventions.
 ├── core/                        # Shared business logic and cross-cutting services.
 │   ├── layouts/                 # Printable layout/page management.


### PR DESCRIPTION
### Motivation
- Bring user-facing documentation into alignment with the current active-beta state and recent UI gating decisions so release artifacts accurately describe available workflows. 
- Make the in-app help and repository map explicitly reflect Debug-only tooling and the actual keyboard behavior used in the UI. 
- Ensure the top-level repository map lists maintained help content so docs are discoverable from the high-level view. 

### Description
- Updated `README.md` status text to describe an "active beta" and clarified that some advanced tools are build-gated. 
- Marked `Print Viewer 2D` as a Debug-only dialog and added a first-class note about `Layout PDF` output in the printing/export section. 
- Edited `help.md` to clarify visible panes in Quick Start, added a `Build-dependent tools` section documenting Debug-only entries (e.g. `File > Print Viewer 2D...` and `Tools > Generate fixture symbols`), and corrected the Layout View fit shortcut from `Z` to `F`. 
- Updated `perastage_tree.md` to include `help.md` in the top-level map and refreshed README-related description lines. 

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it reported OK. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it reported OK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a55af174888324b1a734792d033c5b)