### PR TITLE
Harden Windows GDTF path resolution separator normalization

### DIFF
--- a/viewer3d/resources/resource_sync_system.cpp
+++ b/viewer3d/resources/resource_sync_system.cpp
@@ -48,6 +48,7 @@ std::string NormalizePath(const std::string &p) {
   std::string out = p;
   char sep = static_cast<char>(fs::path::preferred_separator);
   std::replace(out.begin(), out.end(), '\\', sep);
+  std::replace(out.begin(), out.end(), '/', sep);
   return out;
 }
 


### PR DESCRIPTION
### Motivation
- Fix a Windows regression where GDTF files were reported as “file not found” due to mixed path separators causing inconsistent path/caching and failing `ResolveGdtfPath(...)` detection.

### Description
- Normalize both backslash (`\\`) and forward slash (`/`) to the platform preferred separator in `NormalizePath(...)` inside `viewer3d/resources/resource_sync_system.cpp` so `ResolveGdtfPath(...)` variants (including `path(...)` and `u8path(...)`) and cache keys match for mixed-separator inputs.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both succeeded (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a55f08278c8324b0ee3fc9a6429aeb)