### PR TITLE
Lock viewport interactions while loading/importing scenes

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -497,8 +497,11 @@ void MainWindow::OnPaneClose(wxAuiManagerEvent &event) {
 }
 
 bool MainWindow::LoadProjectFromPath(const std::string &path) {
-  if (!GetDefaultGuiConfigServices().LegacyConfigManager().LoadProject(path))
+  LockViewportInteraction();
+  if (!GetDefaultGuiConfigServices().LegacyConfigManager().LoadProject(path)) {
+    UnlockViewportInteraction();
     return false;
+  }
 
 
   Ensure3DViewport();
@@ -547,6 +550,7 @@ bool MainWindow::LoadProjectFromPath(const std::string &path) {
   GetDefaultGuiConfigServices().LegacyConfigManager().MarkSaved();
   StartFixtureSymbolAutoUpdateForLoadedScene();
   UpdateTitle();
+  UnlockViewportInteraction();
   return true;
 }
 

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -162,6 +162,8 @@ private:
   void OnNotebookPageChanged(wxBookCtrlEvent &event); // Update summary panel
   void RefreshSummary();                              // Refresh summary counts
   void RefreshAfterSceneChange(bool refreshViewport = true);
+  void LockViewportInteraction();
+  void UnlockViewportInteraction();
   void RefreshRigging();                              // Refresh rigging summary
 
   void OnPreferences(wxCommandEvent &event);        // Show preferences dialog
@@ -225,6 +227,7 @@ private:
   std::unordered_set<std::string> fixtureSymbolAutoUpdateProcessedKeys;
   std::unordered_set<std::string> fixtureSymbolPendingLibrarySyncUuids;
   bool fixtureSymbolAutoUpdateRunning = false;
+  int viewportInteractionLockDepth = 0;
 
   friend class MainWindowIoController;
   friend class MainWindowLayoutController;

--- a/gui/mainwindow/controllers/mainwindow_io_controller.cpp
+++ b/gui/mainwindow/controllers/mainwindow_io_controller.cpp
@@ -21,7 +21,10 @@ void MainWindowIoController::OnImportMVR(wxCommandEvent &) {
 
   wxString filePath = openFileDialog.GetPath();
   std::string pathUtf8 = filePath.ToUTF8().data();
-  if (!MvrImporter::ImportAndRegister(pathUtf8)) {
+  owner_.LockViewportInteraction();
+  const bool imported = MvrImporter::ImportAndRegister(pathUtf8);
+  owner_.UnlockViewportInteraction();
+  if (!imported) {
     wxMessageBox("Failed to import MVR file.", "Error", wxICON_ERROR);
     if (owner_.consolePanel)
       owner_.consolePanel->AppendMessage("Failed to import " + filePath);

--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -40,6 +40,7 @@
 #include "fixture.h"
 #include "fixturetablepanel.h"
 #include "hoisttablepanel.h"
+#include "layoutviewerpanel.h"
 #include "mvrexporter.h"
 #include "mvrimporter.h"
 #include "projectutils.h"
@@ -52,6 +53,50 @@
 #include "viewer2dpanel.h"
 #include "viewer2drenderpanel.h"
 #include "viewer3dpanel.h"
+
+
+namespace {
+class ScopedViewportInteractionLock {
+public:
+  explicit ScopedViewportInteractionLock(MainWindow &window) : window_(window) {
+    window_.LockViewportInteraction();
+  }
+
+  ~ScopedViewportInteractionLock() { window_.UnlockViewportInteraction(); }
+
+private:
+  MainWindow &window_;
+};
+} // namespace
+
+void MainWindow::LockViewportInteraction() {
+  ++viewportInteractionLockDepth;
+  if (viewportInteractionLockDepth > 1)
+    return;
+
+  if (viewportPanel)
+    viewportPanel->Disable();
+  if (viewport2DPanel)
+    viewport2DPanel->Disable();
+  if (layoutViewerPanel)
+    layoutViewerPanel->Disable();
+}
+
+void MainWindow::UnlockViewportInteraction() {
+  if (viewportInteractionLockDepth <= 0)
+    return;
+
+  --viewportInteractionLockDepth;
+  if (viewportInteractionLockDepth > 0)
+    return;
+
+  if (viewportPanel)
+    viewportPanel->Enable();
+  if (viewport2DPanel)
+    viewport2DPanel->Enable();
+  if (layoutViewerPanel)
+    layoutViewerPanel->Enable();
+}
 
 void MainWindow::OnLoad(wxCommandEvent &event) {
   if (!ConfirmSaveIfDirty("loading a project", "Open Project"))
@@ -148,6 +193,7 @@ void MainWindow::OnImportRider(wxCommandEvent &event) {
   std::string pathUtf8 =
       pathBuffer ? std::string(pathBuffer.data(), pathBuffer.length())
                  : dlg.GetPath().ToStdString();
+  ScopedViewportInteractionLock viewportLock(*this);
   if (!RiderImporter::Import(pathUtf8)) {
     wxMessageBox("Failed to import rider.", "Error", wxICON_ERROR);
     if (consolePanel)
@@ -161,6 +207,7 @@ void MainWindow::OnImportRider(wxCommandEvent &event) {
 }
 
 void MainWindow::OnImportRiderText(wxCommandEvent &WXUNUSED(event)) {
+  ScopedViewportInteractionLock viewportLock(*this);
   RiderTextDialog dlg(this);
   if (dlg.ShowModal() != wxID_OK)
     return;


### PR DESCRIPTION
### Motivation
- Users reported intermittent scene generation issues when moving the 3D view during project load or when creating/importing scenes from text/files, suggesting a race between IO/scene setup and viewport interaction.  
- The change adds a short-lived, nestable lock to disable viewport input during critical scene load/import operations to reduce the chance of concurrent camera/view updates interfering with scene construction.

### Description
- Added `MainWindow::LockViewportInteraction()` and `MainWindow::UnlockViewportInteraction()` plus a `viewportInteractionLockDepth` counter to support nested locks and re-enable viewports only when the last lock is released.  
- Implemented a small RAII helper `ScopedViewportInteractionLock` in `gui/mainwindow_io.cpp` to scope locking around import flows.  
- Applied the scoped lock to the sensitive code paths: `LoadProjectFromPath()`, `OnImportRider()`, and `OnImportRiderText()` to block the `viewportPanel`, `viewport2DPanel`, and `layoutViewerPanel` while the scene is loaded or parsed.  
- Applied the same lock around the MVR import flow in `MainWindowIoController::OnImportMVR()` so file-based imports also block viewport interaction until import completes.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.  
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.  
- Attempted to configure a local build with `cmake -S . -B build` but the environment lacks wxWidgets development libraries so full build verification failed (configuration error reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a561d940648324b4577e1e3b950586)