### PR TITLE
Fix MainWindow viewport interaction lock access in IO handlers

### DIFF
--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -21,6 +21,7 @@
 #include <chrono>
 #include <filesystem>
 #include <fstream>
+#include <functional>
 #include <map>
 #include <set>
 #include <string>
@@ -54,20 +55,6 @@
 #include "viewer2drenderpanel.h"
 #include "viewer3dpanel.h"
 
-
-namespace {
-class ScopedViewportInteractionLock {
-public:
-  explicit ScopedViewportInteractionLock(MainWindow &window) : window_(window) {
-    window_.LockViewportInteraction();
-  }
-
-  ~ScopedViewportInteractionLock() { window_.UnlockViewportInteraction(); }
-
-private:
-  MainWindow &window_;
-};
-} // namespace
 
 void MainWindow::LockViewportInteraction() {
   ++viewportInteractionLockDepth;
@@ -193,7 +180,9 @@ void MainWindow::OnImportRider(wxCommandEvent &event) {
   std::string pathUtf8 =
       pathBuffer ? std::string(pathBuffer.data(), pathBuffer.length())
                  : dlg.GetPath().ToStdString();
-  ScopedViewportInteractionLock viewportLock(*this);
+  LockViewportInteraction();
+  auto viewportUnlock = std::unique_ptr<void, std::function<void(void *)>>(
+      nullptr, [this](void *) { UnlockViewportInteraction(); });
   if (!RiderImporter::Import(pathUtf8)) {
     wxMessageBox("Failed to import rider.", "Error", wxICON_ERROR);
     if (consolePanel)
@@ -207,7 +196,9 @@ void MainWindow::OnImportRider(wxCommandEvent &event) {
 }
 
 void MainWindow::OnImportRiderText(wxCommandEvent &WXUNUSED(event)) {
-  ScopedViewportInteractionLock viewportLock(*this);
+  LockViewportInteraction();
+  auto viewportUnlock = std::unique_ptr<void, std::function<void(void *)>>(
+      nullptr, [this](void *) { UnlockViewportInteraction(); });
   RiderTextDialog dlg(this);
   if (dlg.ShowModal() != wxID_OK)
     return;


### PR DESCRIPTION
### Motivation
- Resolve compilation error C2248 caused by a file-local RAII helper attempting to call `MainWindow` private methods from outside the class/friend scope. 
- Ensure viewport interaction is reliably locked/unlocked during IO handlers while keeping access to `LockViewportInteraction`/`UnlockViewportInteraction` within member-function context.

### Description
- Removed the file-local `ScopedViewportInteractionLock` helper from `gui/mainwindow_io.cpp`. 
- Replaced its uses in IO handlers with an explicit call to `LockViewportInteraction()` followed by a local RAII guard implemented as `std::unique_ptr<void, std::function<void(void *)>>(...)` that calls `UnlockViewportInteraction()` in its custom deleter. 
- Added `#include <functional>` to support the custom deleter type.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which succeeded. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a56406e33c8324bf823aae4a6fc835)