### PR TITLE
Trim/decode/normalize GDTF paths and add mutex for GDTF cache access

### DIFF
--- a/gui/legendutils.cpp
+++ b/gui/legendutils.cpp
@@ -94,7 +94,24 @@ std::string NormalizePath(const std::string &path) {
   std::string out = path;
   char sep = static_cast<char>(fs::path::preferred_separator);
   std::replace(out.begin(), out.end(), '\\', sep);
+  std::replace(out.begin(), out.end(), '/', sep);
   return out;
+}
+
+std::string TrimPathRef(std::string value) {
+  auto isTrim = [](unsigned char c) {
+    return std::isspace(c) != 0 || c == '\r' || c == '\n' || c == '\t';
+  };
+
+  while (!value.empty() && isTrim(static_cast<unsigned char>(value.front())))
+    value.erase(value.begin());
+  while (!value.empty() && isTrim(static_cast<unsigned char>(value.back())))
+    value.pop_back();
+
+  if (value.size() >= 2 && value.front() == '"' && value.back() == '"')
+    return value.substr(1, value.size() - 2);
+
+  return value;
 }
 
 std::string NormalizeModelKey(const std::string &path) {
@@ -134,7 +151,7 @@ std::string ResolveGdtfPath(const std::string &base,
                             const std::string &spec) {
   if (spec.empty())
     return {};
-  const std::string cleanSpec = DecodePathEscapes(spec);
+  const std::string cleanSpec = DecodePathEscapes(TrimPathRef(spec));
   const std::string norm = NormalizePath(cleanSpec);
 
   fs::path absolute = fs::path(norm);

--- a/viewer3d/gdtfloader.cpp
+++ b/viewer3d/gdtfloader.cpp
@@ -46,6 +46,7 @@ class wxZipStreamLink;
 #include <sstream>
 #include <cmath>
 #include <iomanip>
+#include <mutex>
 
 namespace fs = std::filesystem;
 
@@ -201,6 +202,7 @@ static std::unordered_map<std::string, GdtfCacheEntry> g_gdtfCache;
 static std::unordered_map<std::string, fs::file_time_type> g_failedGdtfCache;
 static std::unordered_map<std::string, size_t> g_gdtfFailedAttempts;
 static std::unordered_map<std::string, std::string> g_gdtfFailureReasons;
+static std::recursive_mutex g_gdtfCacheMutex;
 
 struct MissingModelLog
 {
@@ -896,6 +898,8 @@ bool LoadGdtfGeometryTree(const std::string& gdtfPath,
                           GdtfGeometryTree& outTree,
                           std::string* outError)
 {
+    std::lock_guard<std::recursive_mutex> lock(g_gdtfCacheMutex);
+
     outTree.nodes.clear();
     outTree.axisNodeIndices.clear();
     outTree.emitterNodeIndices.clear();
@@ -969,6 +973,8 @@ bool LoadGdtf(const std::string& gdtfPath,
               std::vector<GdtfObject>& outObjects,
               std::string* outError)
 {
+    std::lock_guard<std::recursive_mutex> lock(g_gdtfCacheMutex);
+
     outObjects.clear();
     if (outError)
         outError->clear();
@@ -1111,6 +1117,8 @@ bool LoadGdtf(const std::string& gdtfPath,
 int GetGdtfModeChannelCount(const std::string& gdtfPath,
                             const std::string& modeName)
 {
+    std::lock_guard<std::recursive_mutex> lock(g_gdtfCacheMutex);
+
     if (gdtfPath.empty() || modeName.empty())
         return -1;
 
@@ -1131,6 +1139,8 @@ int GetGdtfModeChannelCount(const std::string& gdtfPath,
 
 std::vector<std::string> GetGdtfModes(const std::string& gdtfPath)
 {
+    std::lock_guard<std::recursive_mutex> lock(g_gdtfCacheMutex);
+
     std::vector<std::string> result;
     if (gdtfPath.empty())
         return result;
@@ -1146,6 +1156,8 @@ std::vector<GdtfChannelInfo> GetGdtfModeChannels(
     const std::string& gdtfPath,
     const std::string& modeName)
 {
+    std::lock_guard<std::recursive_mutex> lock(g_gdtfCacheMutex);
+
     std::vector<GdtfChannelInfo> result;
     if (gdtfPath.empty() || modeName.empty())
         return result;
@@ -1162,6 +1174,8 @@ std::vector<GdtfChannelInfo> GetGdtfModeChannels(
 
 std::string GetGdtfFixtureName(const std::string& gdtfPath)
 {
+    std::lock_guard<std::recursive_mutex> lock(g_gdtfCacheMutex);
+
     if (gdtfPath.empty())
         return {};
 
@@ -1176,6 +1190,8 @@ bool GetGdtfProperties(const std::string& gdtfPath,
                        float& outWeightKg,
                        float& outPowerW)
 {
+    std::lock_guard<std::recursive_mutex> lock(g_gdtfCacheMutex);
+
     outWeightKg = 0.0f;
     outPowerW = 0.0f;
     if (gdtfPath.empty())
@@ -1192,6 +1208,8 @@ bool GetGdtfProperties(const std::string& gdtfPath,
 
 std::string GetGdtfModelColor(const std::string& gdtfPath)
 {
+    std::lock_guard<std::recursive_mutex> lock(g_gdtfCacheMutex);
+
     if (gdtfPath.empty())
         return {};
 

--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -16,6 +16,7 @@
 #endif
 
 #include <algorithm>
+#include <cctype>
 #include <cmath>
 #include <filesystem>
 #include <optional>
@@ -63,7 +64,39 @@ std::string NormalizePathSeparators(const std::string &path) {
   std::string out = path;
   const char sep = static_cast<char>(fs::path::preferred_separator);
   std::replace(out.begin(), out.end(), '\\', sep);
+  std::replace(out.begin(), out.end(), '/', sep);
   return out;
+}
+
+std::string DecodePathEscapes(const std::string &input) {
+  std::string out;
+  out.reserve(input.size());
+  for (size_t i = 0; i < input.size(); ++i) {
+    if (i + 2 < input.size() && input[i] == '%' && input[i + 1] == '2' &&
+        input[i + 2] == '0') {
+      out.push_back(' ');
+      i += 2;
+      continue;
+    }
+    out.push_back(input[i]);
+  }
+  return out;
+}
+
+std::string TrimPathRef(std::string value) {
+  auto isTrim = [](unsigned char c) {
+    return std::isspace(c) != 0 || c == '\r' || c == '\n' || c == '\t';
+  };
+
+  while (!value.empty() && isTrim(static_cast<unsigned char>(value.front())))
+    value.erase(value.begin());
+  while (!value.empty() && isTrim(static_cast<unsigned char>(value.back())))
+    value.pop_back();
+
+  if (value.size() >= 2 && value.front() == '"' && value.back() == '"')
+    return value.substr(1, value.size() - 2);
+
+  return value;
 }
 
 std::string NormalizeModelKeyPath(const std::string &path) {
@@ -79,7 +112,12 @@ std::string ResolveFixtureSymbolKeyPath(const Fixture &fixture,
   if (fixture.gdtfSpec.empty())
     return {};
 
-  const fs::path specPath = fs::path(NormalizePathSeparators(fixture.gdtfSpec));
+  const std::string cleanedSpec =
+      NormalizePathSeparators(DecodePathEscapes(TrimPathRef(fixture.gdtfSpec)));
+  if (cleanedSpec.empty())
+    return {};
+
+  const fs::path specPath = fs::path(cleanedSpec);
   const fs::path candidate = basePath.empty() ? specPath : (fs::path(basePath) / specPath);
   std::error_code ec;
   if (fs::exists(candidate, ec) && !ec)
@@ -92,7 +130,7 @@ std::string ResolveFixtureSymbolKeyPath(const Fixture &fixture,
       return NormalizeModelKeyPath(recursive);
   }
 
-  return NormalizeModelKeyPath(fixture.gdtfSpec);
+  return NormalizeModelKeyPath(cleanedSpec);
 }
 
 std::string BuildFixtureSymbolModelKey(const Fixture &fixture,


### PR DESCRIPTION
### Motivation
- Fix inconsistent path handling for GDTF/spec references (forward slashes, surrounding quotes, whitespace and `%20` escapes) to improve model lookup and resolution.
- Make access to the global GDTF cache thread-safe to avoid races when multiple threads load or query GDTF data.

### Description
- Normalize path separator handling to also replace `'/'` with the platform `fs::path::preferred_separator` in `legendutils.cpp` and `opaque_fixture_pass.cpp` via updated normalization helpers.
- Add `TrimPathRef` helper to strip surrounding whitespace and optional quotes, and add `DecodePathEscapes` in `opaque_fixture_pass.cpp` to decode `%20` into spaces, and apply these when resolving GDTF/spec paths (used in `ResolveGdtfPath` and `ResolveFixtureSymbolKeyPath`).
- Introduce a global `std::recursive_mutex g_gdtfCacheMutex` and add `std::lock_guard` protections around GDTF cache access points including `LoadGdtf`, `LoadGdtfGeometryTree`, and the various `GetGdtf*` query functions.
- Minor includes and small refactors to use cleaned/normalized spec strings when constructing `fs::path` and model keys.

### Testing
- Project build was executed and completed successfully after the changes (`build` succeeded).
- Automated unit tests and existing GDTF-related tests were run and passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a588cac57483248c97bc54860d17c5)