### PR TITLE
Expose "Print Viewer 2D" menu option unconditionally

### DIFF
--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -330,9 +330,7 @@ void MainWindow::CreateMenuBar() {
   fileMenu->AppendSeparator();
   fileMenu->Append(ID_File_ImportMVR, "Import MVR...");
   fileMenu->Append(ID_File_ExportMVR, "Export MVR...");
-  if (ui::IsFeatureEnabled(ui::FeatureFlag::PrintViewer2DDialog)) {
-    fileMenu->Append(ID_File_PrintViewer2D, "Print Viewer 2D...");
-  }
+  fileMenu->Append(ID_File_PrintViewer2D, "Print Viewer 2D...");
   fileMenu->Append(ID_File_PrintLayout, "Print Layout...");
   fileMenu->Append(ID_File_PrintTable, "Print Table...");
   fileMenu->Append(ID_File_ExportCSV, "Export CSV...");

--- a/gui/mainwindow_print.cpp
+++ b/gui/mainwindow_print.cpp
@@ -74,8 +74,7 @@ std::vector<LayoutLegendItem> BuildLayoutLegendItems() {
 void MainWindow::OnPrintMenu(wxCommandEvent &WXUNUSED(event)) {
   wxArrayString choices;
   choices.Add("Layout");
-  if (ui::IsFeatureEnabled(ui::FeatureFlag::PrintViewer2DDialog))
-    choices.Add("Vista 2D");
+  choices.Add("Vista 2D");
   choices.Add("Tabla");
 
   wxSingleChoiceDialog dialog(this, "Selecciona qué quieres imprimir:",
@@ -87,8 +86,7 @@ void MainWindow::OnPrintMenu(wxCommandEvent &WXUNUSED(event)) {
   const int selection = dialog.GetSelection();
   if (selection == 0) {
     OnPrintLayout(printEvent);
-  } else if (ui::IsFeatureEnabled(ui::FeatureFlag::PrintViewer2DDialog) &&
-             selection == 1) {
+  } else if (selection == 1) {
     OnPrintViewer2D(printEvent);
   } else {
     OnPrintTable(printEvent);


### PR DESCRIPTION
### Motivation
- Make the "Print Viewer 2D" action accessible from the File menu and print dialog regardless of the `PrintViewer2DDialog` feature flag so users can invoke the print path even when the dialog feature gate is disabled.

### Description
- Removed the `ui::IsFeatureEnabled(ui::FeatureFlag::PrintViewer2DDialog)` guard around appending `ID_File_PrintViewer2D` in `MainWindow::CreateMenuBar` in `gui/mainwindow_menu.cpp` so the menu item is always added.
- Removed the feature-flag check around adding the "Vista 2D" choice in `MainWindow::OnPrintMenu` in `gui/mainwindow_print.cpp` so the option is always shown and selection `== 1` always dispatches to `OnPrintViewer2D`.
- Kept the runtime settings dialog in `OnPrintViewer2D` gated by `PrintViewer2DDialog`, so the dialog behavior remains feature-flagged while the menu/choice are always available.

### Testing
- Built the application successfully with the changes (`make`/CI build completed) and no compilation errors were introduced. 
- Ran the unit test suite and relevant UI/print-related smoke checks and they passed. 
- Manually exercised the File -> Print flow via the `OnPrintMenu` choice mapping to `OnPrintViewer2D` in a local smoke test and observed expected behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a58e0e97d083248a4b87c96b705e14)