### PR TITLE
Fix library GDTF resolution to apply fixture SVG symbols to correct file

### DIFF
--- a/gui/windows/symbol_fixture_applier.cpp
+++ b/gui/windows/symbol_fixture_applier.cpp
@@ -132,6 +132,19 @@ std::string ResolveLibraryGdtfPath(const Fixture &fixture) {
   const fs::path fixturesLibrary =
       fs::path(ProjectUtils::GetDefaultLibraryPath("fixtures"));
 
+  if (specPath.is_absolute()) {
+    ec.clear();
+    if (fs::exists(specPath, ec) && !ec)
+      return specPath.string();
+  }
+
+  if (!specFileName.empty()) {
+    ec.clear();
+    const fs::path exactPath = fixturesLibrary / specFileName;
+    if (fs::exists(exactPath, ec) && !ec)
+      return exactPath.string();
+  }
+
   auto dictOpt = GdtfDictionary::Load();
   if (dictOpt) {
     const auto &dict = *dictOpt;
@@ -147,8 +160,12 @@ std::string ResolveLibraryGdtfPath(const Fixture &fixture) {
       return it->second.path;
     };
 
-    if (std::string byType = findByKey(fixture.typeName); !byType.empty())
-      return byType;
+    if (std::string byType = findByKey(fixture.typeName); !byType.empty()) {
+      if (specFileName.empty())
+        return byType;
+      if (fs::path(byType).filename() == specFileName)
+        return byType;
+    }
 
     if (!specFileName.empty()) {
       for (const auto &[type, entry] : dict) {
@@ -165,13 +182,6 @@ std::string ResolveLibraryGdtfPath(const Fixture &fixture) {
           return entryPath.string();
       }
     }
-  }
-
-  if (!specFileName.empty()) {
-    ec.clear();
-    const fs::path exactPath = fixturesLibrary / specFileName;
-    if (fs::exists(exactPath, ec) && !ec)
-      return exactPath.string();
   }
 
   return {};


### PR DESCRIPTION
### Motivation
- Generated SVG symbol payloads could be written into the wrong GDTF archive because `ResolveLibraryGdtfPath` resolved ambiguous dictionary entries instead of the fixture’s actual referenced file, causing symbols to appear missing or be overwritten by originals.

### Description
- Update `ResolveLibraryGdtfPath` in `gui/windows/symbol_fixture_applier.cpp` to prefer an absolute `fixture.gdtfSpec` when present, then check for an exact `fixtures/<spec filename>` match before consulting the dictionary, and only accept a dictionary `typeName` entry when it either has no filename or its filename matches the fixture filename.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed and `tests/check_no_configmanager_get_in_gui.sh` which also passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5951da40c8324af63b50fbcc42784)