### PR TITLE
Prefer model-based filenames for autogenerated truss GDTF exports

### DIFF
--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -167,6 +167,25 @@ static std::string SanitizeArchiveFileName(const std::string &input,
   return TruncateFileNamePreservingExtension(fallbackName, kMaxArchiveFileNameLength);
 }
 
+static std::string BuildTrussGdtfArchiveName(const Truss &truss) {
+  std::string baseName = TrimAscii(truss.model);
+  if (baseName.empty()) {
+    if (truss.lengthMm > 0.0f) {
+      const int lengthMeters = static_cast<int>(std::lround(truss.lengthMm / 1000.0f));
+      if (lengthMeters > 0)
+        baseName = "truss " + std::to_string(lengthMeters) + "m";
+    }
+  }
+  if (baseName.empty())
+    baseName = "truss";
+
+  fs::path candidate(baseName);
+  if (candidate.extension().empty())
+    baseName += ".gdtf";
+
+  return SanitizeArchiveFileName(baseName, "truss.gdtf");
+}
+
 static bool IsValidMvrFileName(const std::string &value) {
   if (value.empty())
     return false;
@@ -1093,14 +1112,9 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
       }
     }
 
-    std::string trussPreferredName =
-        SanitizeArchiveFileName(trussSourceGdtf, "truss.gdtf");
-    std::string trussUniqueName = SanitizeArchiveFileName(
-        (t.uuid.empty() ? std::string("truss") : t.uuid) + "-" +
-            trussPreferredName,
-        "truss.gdtf");
+    std::string trussPreferredName = BuildTrussGdtfArchiveName(t);
     std::string trussGdtfArchivePath =
-        registerGdtfResource(t.uuid, trussSourceGdtf, trussUniqueName, false);
+        registerGdtfResource(t.uuid, trussSourceGdtf, trussPreferredName, false);
     if (!trussGdtfArchivePath.empty()) {
       tinyxml2::XMLElement *e = doc.NewElement("GDTFSpec");
       e->SetText(trussGdtfArchivePath.c_str());


### PR DESCRIPTION
### Motivation
- Exported truss `.gdtf` files were being given long/opaque names (UUIDs or temp paths); the intent is to produce shorter, human-readable filenames derived from truss metadata.

### Description
- Added `BuildTrussGdtfArchiveName(const Truss &)` which constructs a preferred archive filename using `truss.model` when available, otherwise falling back to `truss <N>m` (if `lengthMm` is known) or `truss`, and ensures the `.gdtf` extension and sanitization via `SanitizeArchiveFileName`.
- Replaced the previous UUID-prefixed truss naming in `mvr/mvrexporter.cpp` with the new model-based preferred name and pass that to `registerGdtfResource` so exported archive entries are readable.
- Kept existing uniqueness and length guarding by relying on the existing archive-path sanitization and uniqueness helpers (`SanitizeArchiveFileName` / `EnsureUniqueArchivePath`).
- Change is scoped to `mvr/mvrexporter.cpp` and follows the exporter responsibilities without introducing new cross-module coupling.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5a1a4cafc8324ad178363777272e3)