### PR TITLE
Fix MVR truss export to reuse GDTF per truss type

### DIFF
--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -186,6 +186,20 @@ static std::string BuildTrussGdtfArchiveName(const Truss &truss) {
   return SanitizeArchiveFileName(baseName, "truss.gdtf");
 }
 
+static std::string BuildTrussTypeKey(const Truss &truss) {
+  std::ostringstream key;
+  key << TrimAscii(truss.gdtfSpec) << '|'
+      << TrimAscii(truss.modelFile) << '|'
+      << TrimAscii(truss.manufacturer) << '|'
+      << TrimAscii(truss.model) << '|'
+      << TrimAscii(truss.crossSection) << '|'
+      << truss.lengthMm << '|'
+      << truss.widthMm << '|'
+      << truss.heightMm << '|'
+      << truss.weightKg;
+  return key.str();
+}
+
 static bool IsValidMvrFileName(const std::string &value) {
   if (value.empty())
     return false;
@@ -714,6 +728,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
   std::unordered_map<std::string, std::string> sourceToArchivePath;
   std::unordered_map<std::string, std::string> gdtfArchiveByObjectUuid;
   std::unordered_map<std::string, GdtfOverrides> gdtfOverrides;
+  std::unordered_map<std::string, std::string> trussArchiveByTypeKey;
   std::unordered_set<std::string> reservedArchivePaths;
 
   auto normalizeSourcePath = [&](const std::string &rawPath) {
@@ -1099,22 +1114,33 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
     addInt("CustomId", t.customId);
     addInt("CustomIdType", t.customIdType);
 
-    std::string trussSourceGdtf = t.gdtfSpec;
-    if (trussSourceGdtf.empty() && fs::path(t.modelFile).extension() == ".gdtf")
-      trussSourceGdtf = t.modelFile;
+    std::string trussTypeKey = BuildTrussTypeKey(t);
+    std::string trussGdtfArchivePath;
+    auto trussArchiveIt = trussArchiveByTypeKey.find(trussTypeKey);
+    if (trussArchiveIt != trussArchiveByTypeKey.end()) {
+      trussGdtfArchivePath = trussArchiveIt->second;
+      if (!t.uuid.empty())
+        gdtfArchiveByObjectUuid[t.uuid] = trussGdtfArchivePath;
+    } else {
+      std::string trussSourceGdtf = t.gdtfSpec;
+      if (trussSourceGdtf.empty() && fs::path(t.modelFile).extension() == ".gdtf")
+        trussSourceGdtf = t.modelFile;
 
-    if (trussSourceGdtf.empty()) {
-      fs::path tempPath = fs::temp_directory_path() /
-                          ("perastage-truss-export-" + (t.uuid.empty() ? std::string("truss") : t.uuid) + ".gdtf");
-      std::string conversionError;
-      if (BuildTrussGdtfFromInstance(t, tempPath, &conversionError)) {
-        trussSourceGdtf = tempPath.string();
+      if (trussSourceGdtf.empty()) {
+        fs::path tempPath = fs::temp_directory_path() /
+                            ("perastage-truss-export-" + (t.uuid.empty() ? std::string("truss") : t.uuid) + ".gdtf");
+        std::string conversionError;
+        if (BuildTrussGdtfFromInstance(t, tempPath, &conversionError))
+          trussSourceGdtf = tempPath.string();
       }
+
+      std::string trussPreferredName = BuildTrussGdtfArchiveName(t);
+      trussGdtfArchivePath =
+          registerGdtfResource(t.uuid, trussSourceGdtf, trussPreferredName, true);
+      if (!trussGdtfArchivePath.empty())
+        trussArchiveByTypeKey[trussTypeKey] = trussGdtfArchivePath;
     }
 
-    std::string trussPreferredName = BuildTrussGdtfArchiveName(t);
-    std::string trussGdtfArchivePath =
-        registerGdtfResource(t.uuid, trussSourceGdtf, trussPreferredName, false);
     if (!trussGdtfArchivePath.empty()) {
       tinyxml2::XMLElement *e = doc.NewElement("GDTFSpec");
       e->SetText(trussGdtfArchivePath.c_str());


### PR DESCRIPTION
### Motivation
- Export was producing one `.gdtf` per truss instance instead of sharing a single GDTF for identical truss types, which duplicates resources and diverges from typical MVR semantics.

### Description
- Added `BuildTrussTypeKey(const Truss&)` to compute a stable key from truss metadata and dimensions. 
- Introduced a `trussArchiveByTypeKey` cache and updated the truss export path to reuse an existing GDTF archive when the type key matches. 
- Kept the fallback of building a GDTF from an instance via `BuildTrussGdtfFromInstance()` when no source exists, but now the resulting archive is cached by type. 
- Changes are implemented in `mvr/mvrexporter.cpp` and preserve per-UUID mapping in `gdtfArchiveByObjectUuid` for validation and MVR output consistency.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5a5d4f3148324b063c7510105ecd6)