### PR TITLE
Make fixture symbol auto-update non-blocking and condense console logs

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -548,9 +548,9 @@ bool MainWindow::LoadProjectFromPath(const std::string &path) {
   RefreshSummary();
   RefreshRigging();
   GetDefaultGuiConfigServices().LegacyConfigManager().MarkSaved();
-  StartFixtureSymbolAutoUpdateForLoadedScene();
   UpdateTitle();
   UnlockViewportInteraction();
+  StartFixtureSymbolAutoUpdateForLoadedScene();
   return true;
 }
 
@@ -560,7 +560,9 @@ void MainWindow::ResetProject() {
   fixtureSymbolAutoUpdateQueue.clear();
   fixtureSymbolAutoUpdateProcessedKeys.clear();
   fixtureSymbolPendingLibrarySyncUuids.clear();
+  fixtureSymbolAutoUpdateGeneratedTypes.clear();
   fixtureSymbolAutoUpdateRunning = false;
+  fixtureSymbolAutoUpdateWorkerBusy = false;
   fixtureSymbolAutoUpdateGeneratedCount = 0;
   fixtureSymbolAutoUpdateFailedCount = 0;
   fixtureSymbolAutoUpdateSkippedCount = 0;

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -561,6 +561,9 @@ void MainWindow::ResetProject() {
   fixtureSymbolAutoUpdateProcessedKeys.clear();
   fixtureSymbolPendingLibrarySyncUuids.clear();
   fixtureSymbolAutoUpdateRunning = false;
+  fixtureSymbolAutoUpdateGeneratedCount = 0;
+  fixtureSymbolAutoUpdateFailedCount = 0;
+  fixtureSymbolAutoUpdateSkippedCount = 0;
   currentProjectPath.clear();
   if (layoutPanel)
     layoutPanel->ReloadLayouts();

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1001,6 +1001,10 @@ void MainWindow::EnableShortcuts(bool enable) {
 }
 
 void MainWindow::RefreshAfterFixtureSymbolUpdate() {
+  if (viewportPanel) {
+    viewportPanel->UpdateScene();
+    viewportPanel->Refresh();
+  }
   if (viewport2DPanel) {
     viewport2DPanel->InvalidateBottomSymbolCache();
     viewport2DPanel->UpdateScene(true);

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -210,6 +210,7 @@ private:
                           const wxString &dialogTitle);
   void StartFixtureSymbolAutoUpdateForLoadedScene();
   void ProcessNextFixtureSymbolAutoUpdate();
+  void ScheduleNextFixtureSymbolAutoUpdate(int delayMs = 1);
   void FlushPendingFixtureSymbolLibraryUpdates();
   std::string defaultLayoutPerspective;
   std::string default2DLayoutPerspective;

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -227,7 +227,9 @@ private:
   std::vector<std::string> fixtureSymbolAutoUpdateQueue;
   std::unordered_set<std::string> fixtureSymbolAutoUpdateProcessedKeys;
   std::unordered_set<std::string> fixtureSymbolPendingLibrarySyncUuids;
+  std::unordered_set<std::string> fixtureSymbolAutoUpdateGeneratedTypes;
   bool fixtureSymbolAutoUpdateRunning = false;
+  bool fixtureSymbolAutoUpdateWorkerBusy = false;
   size_t fixtureSymbolAutoUpdateGeneratedCount = 0;
   size_t fixtureSymbolAutoUpdateFailedCount = 0;
   size_t fixtureSymbolAutoUpdateSkippedCount = 0;

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -227,6 +227,9 @@ private:
   std::unordered_set<std::string> fixtureSymbolAutoUpdateProcessedKeys;
   std::unordered_set<std::string> fixtureSymbolPendingLibrarySyncUuids;
   bool fixtureSymbolAutoUpdateRunning = false;
+  size_t fixtureSymbolAutoUpdateGeneratedCount = 0;
+  size_t fixtureSymbolAutoUpdateFailedCount = 0;
+  size_t fixtureSymbolAutoUpdateSkippedCount = 0;
   int viewportInteractionLockDepth = 0;
 
   friend class MainWindowIoController;

--- a/gui/mainwindow_fixture_symbol_autoupdate.cpp
+++ b/gui/mainwindow_fixture_symbol_autoupdate.cpp
@@ -167,6 +167,7 @@ void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
             << ".";
     if (consolePanel)
       consolePanel->AppendMessage(wxString::FromUTF8(summary.str()));
+    RefreshAfterFixtureSymbolUpdate();
     ReportFixtureAutoUpdate(*this, consolePanel,
                             "Fixture symbol auto-update: completed.", false);
     return;

--- a/gui/mainwindow_fixture_symbol_autoupdate.cpp
+++ b/gui/mainwindow_fixture_symbol_autoupdate.cpp
@@ -5,7 +5,6 @@
 #include <memory>
 #include <string>
 #include <sstream>
-#include <thread>
 #include <unordered_map>
 #include <vector>
 
@@ -18,7 +17,6 @@
 #include "tools/symbol_physical_calibration.h"
 #include "windows/symbol_fixture_applier.h"
 
-#include <wx/app.h>
 #include <wx/timer.h>
 #include <wx/weakref.h>
 
@@ -272,69 +270,42 @@ void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
     return;
   }
 
-  fixtureSymbolAutoUpdateWorkerBusy = true;
-  const Fixture fixtureCopy = fixture;
-  const MvrScene sceneSnapshot = cfg.GetScene();
-  const auto capturedSymbols = capture.symbols;
-  const auto inspectionSnapshot = inspection;
+  std::string applyError;
+  symbol_preview::ApplySymbolsOptions applyOptions;
+  applyOptions.updateSceneCopy = true;
+  applyOptions.updateLibraryCopy = true;
+  if (symbol_preview::ApplySymbolsToFixtureGdtf(capture.symbols, fixtureUuid,
+                                                applyError, applyOptions)) {
+    std::string locationMessage = "scene";
+    if (!inspection.scenePath.empty() && !inspection.libraryPath.empty())
+      locationMessage = "scene and library";
+    else if (!inspection.libraryPath.empty())
+      locationMessage = "library";
 
-  wxWeakRef<MainWindow> weakThis(this);
-  std::thread([weakThis, capturedSymbols, fixtureCopy, sceneSnapshot,
-               inspectionSnapshot, fixtureLabel]() {
-    std::string applyError;
-    symbol_preview::ApplySymbolsOptions applyOptions;
-    applyOptions.updateSceneCopy = true;
-    applyOptions.updateLibraryCopy = true;
-    const bool applied = symbol_preview::ApplySymbolsToFixtureGdtfForFixture(
-        capturedSymbols, fixtureCopy, sceneSnapshot, applyError, applyOptions);
+    ReportFixtureAutoUpdate(
+        *this, consolePanel,
+        "Fixture symbol auto-update: symbols generated for '" + fixtureLabel +
+            "' and " + locationMessage + " GDTF updated.",
+        false);
+    ++fixtureSymbolAutoUpdateGeneratedCount;
+    fixtureSymbolAutoUpdateGeneratedTypes.insert(
+        fixture.typeName.empty() ? fixtureLabel : fixture.typeName);
+    RefreshAfterFixtureSymbolUpdate();
+  } else {
+    ++fixtureSymbolAutoUpdateFailedCount;
+    ReportFixtureAutoUpdate(
+        *this, consolePanel,
+        "Fixture symbol auto-update: failed to apply symbols for '" +
+            fixtureLabel + "' (" +
+            (applyError.empty() ? std::string("unknown apply error")
+                                : applyError) +
+            ").",
+        false);
+  }
 
-    wxTheApp->CallAfter([weakThis, applied, applyError, inspectionSnapshot,
-                         fixtureLabel, fixtureType = fixtureCopy.typeName]() {
-      if (!weakThis)
-        return;
-
-      MainWindow *window = weakThis.get();
-      if (!window->fixtureSymbolAutoUpdateRunning) {
-        window->fixtureSymbolAutoUpdateWorkerBusy = false;
-        return;
-      }
-
-      if (applied) {
-        std::string locationMessage = "scene";
-        if (!inspectionSnapshot.scenePath.empty() &&
-            !inspectionSnapshot.libraryPath.empty())
-          locationMessage = "scene and library";
-        else if (!inspectionSnapshot.libraryPath.empty())
-          locationMessage = "library";
-
-        ReportFixtureAutoUpdate(
-            *window, window->consolePanel,
-            "Fixture symbol auto-update: symbols generated for '" + fixtureLabel +
-                "' and " + locationMessage + " GDTF updated.",
-            false);
-        ++window->fixtureSymbolAutoUpdateGeneratedCount;
-        window->fixtureSymbolAutoUpdateGeneratedTypes.insert(
-            fixtureType.empty() ? fixtureLabel : fixtureType);
-        window->RefreshAfterFixtureSymbolUpdate();
-      } else {
-        ++window->fixtureSymbolAutoUpdateFailedCount;
-        ReportFixtureAutoUpdate(
-            *window, window->consolePanel,
-            "Fixture symbol auto-update: failed to apply symbols for '" +
-                fixtureLabel + "' (" +
-                (applyError.empty() ? std::string("unknown apply error")
-                                    : applyError) +
-                ").",
-            false);
-      }
-
-      window->fixtureSymbolAutoUpdateWorkerBusy = false;
-      window->ScheduleNextFixtureSymbolAutoUpdate();
-    });
-  }).detach();
-
-
+  ScheduleNextFixtureSymbolAutoUpdate();
 }
+
 
 void MainWindow::FlushPendingFixtureSymbolLibraryUpdates() {
   if (fixtureSymbolPendingLibrarySyncUuids.empty())

--- a/gui/mainwindow_fixture_symbol_autoupdate.cpp
+++ b/gui/mainwindow_fixture_symbol_autoupdate.cpp
@@ -102,7 +102,7 @@ void MainWindow::StartFixtureSymbolAutoUpdateForLoadedScene() {
   fixtureSymbolAutoUpdateProcessedKeys.clear();
   fixtureSymbolPendingLibrarySyncUuids.clear();
   fixtureSymbolAutoUpdateRunning = false;
-  window->fixtureSymbolAutoUpdateWorkerBusy = false;
+  fixtureSymbolAutoUpdateWorkerBusy = false;
   fixtureSymbolAutoUpdateGeneratedTypes.clear();
   fixtureSymbolAutoUpdateGeneratedCount = 0;
   fixtureSymbolAutoUpdateFailedCount = 0;

--- a/gui/mainwindow_fixture_symbol_autoupdate.cpp
+++ b/gui/mainwindow_fixture_symbol_autoupdate.cpp
@@ -72,25 +72,6 @@ void ReportFixtureAutoUpdate(MainWindow &window, ConsolePanel *console,
     console->AppendMessage(wxString::FromUTF8(message));
 }
 
-void ScheduleNextFixtureAutoUpdate(MainWindow &window, int delayMs = 1) {
-  static const int kProcessNextTimerId = wxWindow::NewControlId();
-  static std::unordered_map<MainWindow *, std::unique_ptr<wxTimer>> timers;
-
-  auto timerIt = timers.find(&window);
-  if (timerIt == timers.end()) {
-    auto timer = std::make_unique<wxTimer>(&window, kProcessNextTimerId);
-    window.Bind(
-        wxEVT_TIMER,
-        [windowPtr = &window](wxTimerEvent &) {
-          if (windowPtr)
-            windowPtr->ProcessNextFixtureSymbolAutoUpdate();
-        },
-        kProcessNextTimerId);
-    timerIt = timers.emplace(&window, std::move(timer)).first;
-  }
-
-  timerIt->second->StartOnce(delayMs);
-}
 
 } // namespace
 
@@ -124,7 +105,25 @@ void MainWindow::StartFixtureSymbolAutoUpdateForLoadedScene() {
   fixtureSymbolAutoUpdateRunning = true;
   ReportFixtureAutoUpdate(*this, consolePanel,
                           "Fixture symbol auto-update: started.");
-  ScheduleNextFixtureAutoUpdate(*this, 100);
+  ScheduleNextFixtureSymbolAutoUpdate(100);
+}
+
+
+void MainWindow::ScheduleNextFixtureSymbolAutoUpdate(int delayMs) {
+  static const int kProcessNextTimerId = wxWindow::NewControlId();
+  static std::unordered_map<MainWindow *, std::unique_ptr<wxTimer>> timers;
+
+  auto timerIt = timers.find(this);
+  if (timerIt == timers.end()) {
+    auto timer = std::make_unique<wxTimer>(this, kProcessNextTimerId);
+    Bind(
+        wxEVT_TIMER,
+        [this](wxTimerEvent &) { ProcessNextFixtureSymbolAutoUpdate(); },
+        kProcessNextTimerId);
+    timerIt = timers.emplace(this, std::move(timer)).first;
+  }
+
+  timerIt->second->StartOnce(delayMs);
 }
 
 void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
@@ -151,7 +150,7 @@ void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
   ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
   const auto fixtureIt = cfg.GetScene().fixtures.find(fixtureUuid);
   if (fixtureIt == cfg.GetScene().fixtures.end()) {
-    ScheduleNextFixtureAutoUpdate(*this);
+    ScheduleNextFixtureSymbolAutoUpdate();
     return;
   }
 
@@ -159,7 +158,7 @@ void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
   const std::string fixtureLabel = BuildFixtureLabel(fixture);
   const std::string key = BuildFixtureAutoUpdateKey(fixture);
   if (key.empty() || !fixtureSymbolAutoUpdateProcessedKeys.insert(key).second) {
-    ScheduleNextFixtureAutoUpdate(*this);
+    ScheduleNextFixtureSymbolAutoUpdate();
     return;
   }
 
@@ -174,13 +173,13 @@ void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
               "' (inspection error: " + inspectionError + ").", false);
       ++fixtureSymbolAutoUpdateSkippedCount;
     }
-    ScheduleNextFixtureAutoUpdate(*this);
+    ScheduleNextFixtureSymbolAutoUpdate();
     return;
   }
 
   if (!inspection.requiresSymbolGeneration) {
     ++fixtureSymbolAutoUpdateSkippedCount;
-    ScheduleNextFixtureAutoUpdate(*this);
+    ScheduleNextFixtureSymbolAutoUpdate();
     return;
   }
 
@@ -212,7 +211,7 @@ void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
             "' (" + (capture.error.empty() ? std::string("unknown capture error")
                                             : capture.error) +
             ").", false);
-    ScheduleNextFixtureAutoUpdate(*this);
+    ScheduleNextFixtureSymbolAutoUpdate();
     return;
   }
 
@@ -227,7 +226,7 @@ void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
             (calibrationError.empty() ? std::string("unknown calibration error")
                                       : calibrationError) +
             ").", false);
-    ScheduleNextFixtureAutoUpdate(*this);
+    ScheduleNextFixtureSymbolAutoUpdate();
     return;
   }
 
@@ -259,7 +258,7 @@ void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
             ").", false);
   }
 
-  ScheduleNextFixtureAutoUpdate(*this);
+  ScheduleNextFixtureSymbolAutoUpdate();
 }
 
 void MainWindow::FlushPendingFixtureSymbolLibraryUpdates() {

--- a/gui/mainwindow_fixture_symbol_autoupdate.cpp
+++ b/gui/mainwindow_fixture_symbol_autoupdate.cpp
@@ -1,10 +1,13 @@
 #include "mainwindow.h"
 
+#include <algorithm>
 #include <filesystem>
 #include <memory>
 #include <string>
 #include <sstream>
+#include <thread>
 #include <unordered_map>
+#include <vector>
 
 #include "configmanager.h"
 #include "consolepanel.h"
@@ -15,6 +18,7 @@
 #include "tools/symbol_physical_calibration.h"
 #include "windows/symbol_fixture_applier.h"
 
+#include <wx/app.h>
 #include <wx/timer.h>
 
 namespace {
@@ -37,6 +41,23 @@ std::string BuildFixtureLabel(const Fixture &fixture) {
   return "unknown fixture";
 }
 
+
+std::string BuildGeneratedTypesSummary(
+    const std::unordered_set<std::string> &generatedTypes) {
+  if (generatedTypes.empty())
+    return "none";
+
+  std::vector<std::string> types(generatedTypes.begin(), generatedTypes.end());
+  std::sort(types.begin(), types.end());
+
+  std::ostringstream out;
+  for (size_t i = 0; i < types.size(); ++i) {
+    if (i > 0)
+      out << ", ";
+    out << "'" << types[i] << "'";
+  }
+  return out.str();
+}
 void ReportFixtureAutoUpdate(MainWindow &window, ConsolePanel *console,
                              const std::string &message,
                              bool appendToConsole = true) {
@@ -80,6 +101,8 @@ void MainWindow::StartFixtureSymbolAutoUpdateForLoadedScene() {
   fixtureSymbolAutoUpdateProcessedKeys.clear();
   fixtureSymbolPendingLibrarySyncUuids.clear();
   fixtureSymbolAutoUpdateRunning = false;
+  fixtureSymbolAutoUpdateWorkerBusy = false;
+  fixtureSymbolAutoUpdateGeneratedTypes.clear();
   fixtureSymbolAutoUpdateGeneratedCount = 0;
   fixtureSymbolAutoUpdateFailedCount = 0;
   fixtureSymbolAutoUpdateSkippedCount = 0;
@@ -105,7 +128,7 @@ void MainWindow::StartFixtureSymbolAutoUpdateForLoadedScene() {
   fixtureSymbolAutoUpdateRunning = true;
   ReportFixtureAutoUpdate(*this, consolePanel,
                           "Fixture symbol auto-update: started.");
-  ScheduleNextFixtureSymbolAutoUpdate(100);
+  ScheduleNextFixtureSymbolAutoUpdate(700);
 }
 
 
@@ -129,6 +152,8 @@ void MainWindow::ScheduleNextFixtureSymbolAutoUpdate(int delayMs) {
 void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
   if (!fixtureSymbolAutoUpdateRunning)
     return;
+  if (fixtureSymbolAutoUpdateWorkerBusy)
+    return;
 
   if (fixtureSymbolAutoUpdateQueue.empty()) {
     fixtureSymbolAutoUpdateRunning = false;
@@ -136,7 +161,10 @@ void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
     summary << "Fixture symbol auto-update: completed. generated="
             << fixtureSymbolAutoUpdateGeneratedCount
             << ", failed=" << fixtureSymbolAutoUpdateFailedCount
-            << ", skipped=" << fixtureSymbolAutoUpdateSkippedCount << ".";
+            << ", skipped=" << fixtureSymbolAutoUpdateSkippedCount
+            << ", generated types="
+            << BuildGeneratedTypesSummary(fixtureSymbolAutoUpdateGeneratedTypes)
+            << ".";
     if (consolePanel)
       consolePanel->AppendMessage(wxString::FromUTF8(summary.str()));
     ReportFixtureAutoUpdate(*this, consolePanel,
@@ -230,35 +258,63 @@ void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
     return;
   }
 
-  std::string applyError;
-  symbol_preview::ApplySymbolsOptions applyOptions;
-  applyOptions.updateSceneCopy = true;
-  applyOptions.updateLibraryCopy = true;
-  if (symbol_preview::ApplySymbolsToFixtureGdtf(capture.symbols, fixtureUuid,
-                                                applyError, applyOptions)) {
-    std::string locationMessage = "scene";
-    if (!inspection.scenePath.empty() && !inspection.libraryPath.empty())
-      locationMessage = "scene and library";
-    else if (!inspection.libraryPath.empty())
-      locationMessage = "library";
+  fixtureSymbolAutoUpdateWorkerBusy = true;
+  const Fixture fixtureCopy = fixture;
+  const MvrScene sceneSnapshot = cfg.GetScene();
+  const auto capturedSymbols = capture.symbols;
+  const auto inspectionSnapshot = inspection;
 
-    ReportFixtureAutoUpdate(*this, consolePanel,
-                            "Fixture symbol auto-update: symbols generated for '" +
-                                fixtureLabel + "' and " + locationMessage +
-                                " GDTF updated.", false);
-    ++fixtureSymbolAutoUpdateGeneratedCount;
-    RefreshAfterFixtureSymbolUpdate();
-  } else {
-    ++fixtureSymbolAutoUpdateFailedCount;
-    ReportFixtureAutoUpdate(
-        *this, consolePanel,
-        "Fixture symbol auto-update: failed to apply symbols for '" + fixtureLabel +
-            "' (" + (applyError.empty() ? std::string("unknown apply error")
-                                         : applyError) +
-            ").", false);
-  }
+  std::thread([this, capturedSymbols, fixtureCopy, sceneSnapshot,
+               inspectionSnapshot, fixtureLabel]() {
+    std::string applyError;
+    symbol_preview::ApplySymbolsOptions applyOptions;
+    applyOptions.updateSceneCopy = true;
+    applyOptions.updateLibraryCopy = true;
+    const bool applied = symbol_preview::ApplySymbolsToFixtureGdtfForFixture(
+        capturedSymbols, fixtureCopy, sceneSnapshot, applyError, applyOptions);
 
-  ScheduleNextFixtureSymbolAutoUpdate();
+    wxTheApp->CallAfter([this, applied, applyError, inspectionSnapshot,
+                         fixtureLabel, fixtureType = fixtureCopy.typeName]() {
+      if (!fixtureSymbolAutoUpdateRunning) {
+        fixtureSymbolAutoUpdateWorkerBusy = false;
+        return;
+      }
+
+      if (applied) {
+        std::string locationMessage = "scene";
+        if (!inspectionSnapshot.scenePath.empty() &&
+            !inspectionSnapshot.libraryPath.empty())
+          locationMessage = "scene and library";
+        else if (!inspectionSnapshot.libraryPath.empty())
+          locationMessage = "library";
+
+        ReportFixtureAutoUpdate(
+            *this, consolePanel,
+            "Fixture symbol auto-update: symbols generated for '" + fixtureLabel +
+                "' and " + locationMessage + " GDTF updated.",
+            false);
+        ++fixtureSymbolAutoUpdateGeneratedCount;
+        fixtureSymbolAutoUpdateGeneratedTypes.insert(
+            fixtureType.empty() ? fixtureLabel : fixtureType);
+        RefreshAfterFixtureSymbolUpdate();
+      } else {
+        ++fixtureSymbolAutoUpdateFailedCount;
+        ReportFixtureAutoUpdate(
+            *this, consolePanel,
+            "Fixture symbol auto-update: failed to apply symbols for '" +
+                fixtureLabel + "' (" +
+                (applyError.empty() ? std::string("unknown apply error")
+                                    : applyError) +
+                ").",
+            false);
+      }
+
+      fixtureSymbolAutoUpdateWorkerBusy = false;
+      ScheduleNextFixtureSymbolAutoUpdate();
+    });
+  }).detach();
+
+
 }
 
 void MainWindow::FlushPendingFixtureSymbolLibraryUpdates() {

--- a/gui/mainwindow_fixture_symbol_autoupdate.cpp
+++ b/gui/mainwindow_fixture_symbol_autoupdate.cpp
@@ -20,6 +20,7 @@
 
 #include <wx/app.h>
 #include <wx/timer.h>
+#include <wx/weakref.h>
 
 namespace {
 
@@ -101,7 +102,7 @@ void MainWindow::StartFixtureSymbolAutoUpdateForLoadedScene() {
   fixtureSymbolAutoUpdateProcessedKeys.clear();
   fixtureSymbolPendingLibrarySyncUuids.clear();
   fixtureSymbolAutoUpdateRunning = false;
-  fixtureSymbolAutoUpdateWorkerBusy = false;
+  window->fixtureSymbolAutoUpdateWorkerBusy = false;
   fixtureSymbolAutoUpdateGeneratedTypes.clear();
   fixtureSymbolAutoUpdateGeneratedCount = 0;
   fixtureSymbolAutoUpdateFailedCount = 0;
@@ -134,7 +135,11 @@ void MainWindow::StartFixtureSymbolAutoUpdateForLoadedScene() {
 
 void MainWindow::ScheduleNextFixtureSymbolAutoUpdate(int delayMs) {
   if (delayMs <= 1) {
-    CallAfter([this]() { ProcessNextFixtureSymbolAutoUpdate(); });
+    wxWeakRef<MainWindow> weakThis(this);
+    CallAfter([weakThis]() {
+      if (weakThis)
+        weakThis->ProcessNextFixtureSymbolAutoUpdate();
+    });
     return;
   }
 
@@ -146,7 +151,10 @@ void MainWindow::ScheduleNextFixtureSymbolAutoUpdate(int delayMs) {
     auto timer = std::make_unique<wxTimer>(this, kProcessNextTimerId);
     Bind(
         wxEVT_TIMER,
-        [this](wxTimerEvent &) { ProcessNextFixtureSymbolAutoUpdate(); },
+        [weakThis = wxWeakRef<MainWindow>(this)](wxTimerEvent &) {
+          if (weakThis)
+            weakThis->ProcessNextFixtureSymbolAutoUpdate();
+        },
         kProcessNextTimerId);
     timerIt = timers.emplace(this, std::move(timer)).first;
   }
@@ -270,7 +278,8 @@ void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
   const auto capturedSymbols = capture.symbols;
   const auto inspectionSnapshot = inspection;
 
-  std::thread([this, capturedSymbols, fixtureCopy, sceneSnapshot,
+  wxWeakRef<MainWindow> weakThis(this);
+  std::thread([weakThis, capturedSymbols, fixtureCopy, sceneSnapshot,
                inspectionSnapshot, fixtureLabel]() {
     std::string applyError;
     symbol_preview::ApplySymbolsOptions applyOptions;
@@ -279,10 +288,14 @@ void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
     const bool applied = symbol_preview::ApplySymbolsToFixtureGdtfForFixture(
         capturedSymbols, fixtureCopy, sceneSnapshot, applyError, applyOptions);
 
-    wxTheApp->CallAfter([this, applied, applyError, inspectionSnapshot,
+    wxTheApp->CallAfter([weakThis, applied, applyError, inspectionSnapshot,
                          fixtureLabel, fixtureType = fixtureCopy.typeName]() {
-      if (!fixtureSymbolAutoUpdateRunning) {
-        fixtureSymbolAutoUpdateWorkerBusy = false;
+      if (!weakThis)
+        return;
+
+      MainWindow *window = weakThis.get();
+      if (!window->fixtureSymbolAutoUpdateRunning) {
+        window->fixtureSymbolAutoUpdateWorkerBusy = false;
         return;
       }
 
@@ -295,18 +308,18 @@ void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
           locationMessage = "library";
 
         ReportFixtureAutoUpdate(
-            *this, consolePanel,
+            *window, window->consolePanel,
             "Fixture symbol auto-update: symbols generated for '" + fixtureLabel +
                 "' and " + locationMessage + " GDTF updated.",
             false);
-        ++fixtureSymbolAutoUpdateGeneratedCount;
-        fixtureSymbolAutoUpdateGeneratedTypes.insert(
+        ++window->fixtureSymbolAutoUpdateGeneratedCount;
+        window->fixtureSymbolAutoUpdateGeneratedTypes.insert(
             fixtureType.empty() ? fixtureLabel : fixtureType);
-        RefreshAfterFixtureSymbolUpdate();
+        window->RefreshAfterFixtureSymbolUpdate();
       } else {
-        ++fixtureSymbolAutoUpdateFailedCount;
+        ++window->fixtureSymbolAutoUpdateFailedCount;
         ReportFixtureAutoUpdate(
-            *this, consolePanel,
+            *window, window->consolePanel,
             "Fixture symbol auto-update: failed to apply symbols for '" +
                 fixtureLabel + "' (" +
                 (applyError.empty() ? std::string("unknown apply error")
@@ -315,8 +328,8 @@ void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
             false);
       }
 
-      fixtureSymbolAutoUpdateWorkerBusy = false;
-      ScheduleNextFixtureSymbolAutoUpdate();
+      window->fixtureSymbolAutoUpdateWorkerBusy = false;
+      window->ScheduleNextFixtureSymbolAutoUpdate();
     });
   }).detach();
 

--- a/gui/mainwindow_fixture_symbol_autoupdate.cpp
+++ b/gui/mainwindow_fixture_symbol_autoupdate.cpp
@@ -133,6 +133,11 @@ void MainWindow::StartFixtureSymbolAutoUpdateForLoadedScene() {
 
 
 void MainWindow::ScheduleNextFixtureSymbolAutoUpdate(int delayMs) {
+  if (delayMs <= 1) {
+    CallAfter([this]() { ProcessNextFixtureSymbolAutoUpdate(); });
+    return;
+  }
+
   static const int kProcessNextTimerId = wxWindow::NewControlId();
   static std::unordered_map<MainWindow *, std::unique_ptr<wxTimer>> timers;
 

--- a/gui/mainwindow_fixture_symbol_autoupdate.cpp
+++ b/gui/mainwindow_fixture_symbol_autoupdate.cpp
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <memory>
 #include <string>
+#include <sstream>
 #include <unordered_map>
 
 #include "configmanager.h"
@@ -37,7 +38,8 @@ std::string BuildFixtureLabel(const Fixture &fixture) {
 }
 
 void ReportFixtureAutoUpdate(MainWindow &window, ConsolePanel *console,
-                             const std::string &message) {
+                             const std::string &message,
+                             bool appendToConsole = true) {
   static const int kStatusClearTimerId = wxWindow::NewControlId();
   static std::unordered_map<MainWindow *, std::unique_ptr<wxTimer>> timers;
   static std::unordered_map<MainWindow *, std::string> pendingStatusText;
@@ -66,8 +68,28 @@ void ReportFixtureAutoUpdate(MainWindow &window, ConsolePanel *console,
   pendingStatusText[&window] = message;
   timerIt->second->StartOnce(10000);
 
-  if (console)
+  if (console && appendToConsole)
     console->AppendMessage(wxString::FromUTF8(message));
+}
+
+void ScheduleNextFixtureAutoUpdate(MainWindow &window, int delayMs = 1) {
+  static const int kProcessNextTimerId = wxWindow::NewControlId();
+  static std::unordered_map<MainWindow *, std::unique_ptr<wxTimer>> timers;
+
+  auto timerIt = timers.find(&window);
+  if (timerIt == timers.end()) {
+    auto timer = std::make_unique<wxTimer>(&window, kProcessNextTimerId);
+    window.Bind(
+        wxEVT_TIMER,
+        [windowPtr = &window](wxTimerEvent &) {
+          if (windowPtr)
+            windowPtr->ProcessNextFixtureSymbolAutoUpdate();
+        },
+        kProcessNextTimerId);
+    timerIt = timers.emplace(&window, std::move(timer)).first;
+  }
+
+  timerIt->second->StartOnce(delayMs);
 }
 
 } // namespace
@@ -77,6 +99,9 @@ void MainWindow::StartFixtureSymbolAutoUpdateForLoadedScene() {
   fixtureSymbolAutoUpdateProcessedKeys.clear();
   fixtureSymbolPendingLibrarySyncUuids.clear();
   fixtureSymbolAutoUpdateRunning = false;
+  fixtureSymbolAutoUpdateGeneratedCount = 0;
+  fixtureSymbolAutoUpdateFailedCount = 0;
+  fixtureSymbolAutoUpdateSkippedCount = 0;
 
   ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
   for (const auto &[uuid, fixture] : cfg.GetScene().fixtures) {
@@ -99,7 +124,7 @@ void MainWindow::StartFixtureSymbolAutoUpdateForLoadedScene() {
   fixtureSymbolAutoUpdateRunning = true;
   ReportFixtureAutoUpdate(*this, consolePanel,
                           "Fixture symbol auto-update: started.");
-  CallAfter([this]() { ProcessNextFixtureSymbolAutoUpdate(); });
+  ScheduleNextFixtureAutoUpdate(*this, 100);
 }
 
 void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
@@ -108,8 +133,15 @@ void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
 
   if (fixtureSymbolAutoUpdateQueue.empty()) {
     fixtureSymbolAutoUpdateRunning = false;
+    std::ostringstream summary;
+    summary << "Fixture symbol auto-update: completed. generated="
+            << fixtureSymbolAutoUpdateGeneratedCount
+            << ", failed=" << fixtureSymbolAutoUpdateFailedCount
+            << ", skipped=" << fixtureSymbolAutoUpdateSkippedCount << ".";
+    if (consolePanel)
+      consolePanel->AppendMessage(wxString::FromUTF8(summary.str()));
     ReportFixtureAutoUpdate(*this, consolePanel,
-                            "Fixture symbol auto-update: completed.");
+                            "Fixture symbol auto-update: completed.", false);
     return;
   }
 
@@ -119,7 +151,7 @@ void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
   ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
   const auto fixtureIt = cfg.GetScene().fixtures.find(fixtureUuid);
   if (fixtureIt == cfg.GetScene().fixtures.end()) {
-    CallAfter([this]() { ProcessNextFixtureSymbolAutoUpdate(); });
+    ScheduleNextFixtureAutoUpdate(*this);
     return;
   }
 
@@ -127,7 +159,7 @@ void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
   const std::string fixtureLabel = BuildFixtureLabel(fixture);
   const std::string key = BuildFixtureAutoUpdateKey(fixture);
   if (key.empty() || !fixtureSymbolAutoUpdateProcessedKeys.insert(key).second) {
-    CallAfter([this]() { ProcessNextFixtureSymbolAutoUpdate(); });
+    ScheduleNextFixtureAutoUpdate(*this);
     return;
   }
 
@@ -139,26 +171,28 @@ void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
       ReportFixtureAutoUpdate(
           *this, consolePanel,
           "Fixture symbol auto-update: skipped '" + fixtureLabel +
-              "' (inspection error: " + inspectionError + ").");
+              "' (inspection error: " + inspectionError + ").", false);
+      ++fixtureSymbolAutoUpdateSkippedCount;
     }
-    CallAfter([this]() { ProcessNextFixtureSymbolAutoUpdate(); });
+    ScheduleNextFixtureAutoUpdate(*this);
     return;
   }
 
   if (!inspection.requiresSymbolGeneration) {
-    CallAfter([this]() { ProcessNextFixtureSymbolAutoUpdate(); });
+    ++fixtureSymbolAutoUpdateSkippedCount;
+    ScheduleNextFixtureAutoUpdate(*this);
     return;
   }
 
   ReportFixtureAutoUpdate(*this, consolePanel,
                           "Fixture symbol auto-update: generating symbols for '" +
-                              fixtureLabel + "'.");
+                              fixtureLabel + "'.", false);
 
   Viewer2DOffscreenRenderer *offscreenRenderer = GetOffscreenRenderer();
   if (!offscreenRenderer) {
     fixtureSymbolAutoUpdateRunning = false;
     ReportFixtureAutoUpdate(*this, consolePanel,
-                            "Fixture symbol auto-update: stopped (offscreen renderer unavailable)." );
+                            "Fixture symbol auto-update: stopped (offscreen renderer unavailable).", false);
     return;
   }
 
@@ -171,27 +205,29 @@ void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
       tools::SceneModelSymbolTarget{tools::SceneModelKind::Fixture, fixtureUuid},
       captureOptions);
   if (!capture.ok) {
+    ++fixtureSymbolAutoUpdateFailedCount;
     ReportFixtureAutoUpdate(
         *this, consolePanel,
         "Fixture symbol auto-update: failed to capture symbols for '" + fixtureLabel +
             "' (" + (capture.error.empty() ? std::string("unknown capture error")
                                             : capture.error) +
-            ").");
-    CallAfter([this]() { ProcessNextFixtureSymbolAutoUpdate(); });
+            ").", false);
+    ScheduleNextFixtureAutoUpdate(*this);
     return;
   }
 
   std::string calibrationError;
   if (!tools::CalibrateFixtureSymbolsToPhysicalUnits(
           cfg, fixtureUuid, capture.symbols, calibrationError)) {
+    ++fixtureSymbolAutoUpdateFailedCount;
     ReportFixtureAutoUpdate(
         *this, consolePanel,
         "Fixture symbol auto-update: failed to calibrate symbols for '" +
             fixtureLabel + "' (" +
             (calibrationError.empty() ? std::string("unknown calibration error")
                                       : calibrationError) +
-            ").");
-    CallAfter([this]() { ProcessNextFixtureSymbolAutoUpdate(); });
+            ").", false);
+    ScheduleNextFixtureAutoUpdate(*this);
     return;
   }
 
@@ -210,18 +246,20 @@ void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
     ReportFixtureAutoUpdate(*this, consolePanel,
                             "Fixture symbol auto-update: symbols generated for '" +
                                 fixtureLabel + "' and " + locationMessage +
-                                " GDTF updated.");
+                                " GDTF updated.", false);
+    ++fixtureSymbolAutoUpdateGeneratedCount;
     RefreshAfterFixtureSymbolUpdate();
   } else {
+    ++fixtureSymbolAutoUpdateFailedCount;
     ReportFixtureAutoUpdate(
         *this, consolePanel,
         "Fixture symbol auto-update: failed to apply symbols for '" + fixtureLabel +
             "' (" + (applyError.empty() ? std::string("unknown apply error")
                                          : applyError) +
-            ").");
+            ").", false);
   }
 
-  CallAfter([this]() { ProcessNextFixtureSymbolAutoUpdate(); });
+  ScheduleNextFixtureAutoUpdate(*this);
 }
 
 void MainWindow::FlushPendingFixtureSymbolLibraryUpdates() {

--- a/gui/windows/symbol_fixture_applier.cpp
+++ b/gui/windows/symbol_fixture_applier.cpp
@@ -10,6 +10,7 @@
 #include <cctype>
 #include <filesystem>
 #include <memory>
+#include <mutex>
 #include <sstream>
 #include <string>
 #include <unordered_map>
@@ -31,6 +32,8 @@ namespace fs = std::filesystem;
 
 namespace symbol_preview {
 namespace {
+
+std::mutex g_fixtureSymbolFileIoMutex;
 
 struct SymbolPayload {
   std::string archivePath;
@@ -528,9 +531,21 @@ bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
     return false;
   }
 
-  const MvrScene &scene = cfg.GetScene();
-  const std::string scenePath = ResolveSceneGdtfPath(fixtureIt->second, scene);
-  const std::string libraryPath = ResolveLibraryGdtfPath(fixtureIt->second);
+  return ApplySymbolsToFixtureGdtfForFixture(symbols, fixtureIt->second,
+                                             cfg.GetScene(), errorMessage,
+                                             options);
+}
+
+bool ApplySymbolsToFixtureGdtfForFixture(
+    const std::vector<symbols::Symbol2D> &symbols,
+    const Fixture &fixture,
+    const MvrScene &scene,
+    std::string &errorMessage,
+    const ApplySymbolsOptions &options) {
+  std::lock_guard<std::mutex> lock(g_fixtureSymbolFileIoMutex);
+
+  const std::string scenePath = ResolveSceneGdtfPath(fixture, scene);
+  const std::string libraryPath = ResolveLibraryGdtfPath(fixture);
   if (scenePath.empty() && libraryPath.empty()) {
     errorMessage = "Could not resolve fixture GDTF path in scene or fixtures library.";
     return false;
@@ -593,9 +608,8 @@ bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
     }
   }
 
-  if (libraryPath.empty() && !scenePath.empty() && !fixtureIt->second.typeName.empty()) {
-    GdtfDictionary::Update(fixtureIt->second.typeName, scenePath,
-                           fixtureIt->second.gdtfMode);
+  if (libraryPath.empty() && !scenePath.empty() && !fixture.typeName.empty()) {
+    GdtfDictionary::Update(fixture.typeName, scenePath, fixture.gdtfMode);
   }
 
   return true;
@@ -606,6 +620,7 @@ bool InspectFixtureSymbolState(const Fixture &fixture,
                                const MvrScene &scene,
                                FixtureSymbolInspectionResult &result,
                                std::string &errorMessage) {
+  std::lock_guard<std::mutex> lock(g_fixtureSymbolFileIoMutex);
   result = {};
 
   const std::string scenePath = ResolveSceneGdtfPath(fixture, scene);
@@ -694,6 +709,7 @@ bool InspectFixtureSymbolState(const Fixture &fixture,
 bool SyncFixtureGdtfToLibrary(const Fixture &fixture,
                               const MvrScene &scene,
                               std::string &errorMessage) {
+  std::lock_guard<std::mutex> lock(g_fixtureSymbolFileIoMutex);
   const std::string scenePath = ResolveSceneGdtfPath(fixture, scene);
   const std::string libraryPath = ResolveLibraryGdtfPath(fixture);
   if (scenePath.empty() || libraryPath.empty() || scenePath == libraryPath)

--- a/gui/windows/symbol_fixture_applier.h
+++ b/gui/windows/symbol_fixture_applier.h
@@ -33,6 +33,13 @@ bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
                                std::string &errorMessage,
                                const ApplySymbolsOptions &options = {});
 
+bool ApplySymbolsToFixtureGdtfForFixture(
+    const std::vector<symbols::Symbol2D> &symbols,
+    const Fixture &fixture,
+    const MvrScene &scene,
+    std::string &errorMessage,
+    const ApplySymbolsOptions &options = {});
+
 bool SyncFixtureGdtfToLibrary(const Fixture &fixture,
                               const MvrScene &scene,
                               std::string &errorMessage);


### PR DESCRIPTION
### Motivation
- The fixture symbol auto-update task can compete with scene load and produce many Console panel lines, so processing should be deferred/asynchronous and Console output condensed to avoid UI/blocking and spam.

### Description
- Replace immediate `CallAfter` chaining with a timer-driven scheduler `ScheduleNextFixtureAutoUpdate` that uses `wxTimer` and a short deferred start (`100 ms`) to make processing non-blocking and avoid competing with scene load work, implemented in `gui/mainwindow_fixture_symbol_autoupdate.cpp`.
- Add run counters on `MainWindow` (`fixtureSymbolAutoUpdateGeneratedCount`, `fixtureSymbolAutoUpdateFailedCount`, `fixtureSymbolAutoUpdateSkippedCount`) and reset them on start/reset in `gui/mainwindow.h` and `gui/mainwindow.cpp` to collect a compact run summary.
- Change `ReportFixtureAutoUpdate` to accept an `appendToConsole` flag and suppress per-fixture console messages while keeping detailed status bar updates, and emit a compact end-of-run summary (`generated/failed/skipped`) to the Console panel.
- Increment counters at appropriate failure/success/skip points and schedule the next item via `ScheduleNextFixtureAutoUpdate`; no change to symbol generation logic or output assets.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which completed successfully (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` which completed successfully (`OK`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5bebcf5988324a5a1a7b9abea51f2)