### PR TITLE
Refresh Rigging panel after delete actions in element tables

### DIFF
--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -997,6 +997,9 @@ void FixtureTablePanel::DeleteSelected() {
   if (SummaryPanel::Instance())
     SummaryPanel::Instance()->ShowFixtureSummary();
 
+  if (RiggingPanel::Instance())
+    RiggingPanel::Instance()->RefreshData();
+
   selectionOrder.clear();
   ResyncRows(oldOrder, {}, &oldPaths);
 }

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -747,6 +747,9 @@ void HoistTablePanel::DeleteSelected() {
   if (SummaryPanel::Instance())
     SummaryPanel::Instance()->ShowHoistSummary();
 
+  if (RiggingPanel::Instance())
+    RiggingPanel::Instance()->RefreshData();
+
   if (Viewer3DPanel::Instance()) {
     Viewer3DPanel::Instance()->SetSelectedFixtures({});
     Viewer3DPanel::Instance()->UpdateScene();

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -1101,6 +1101,9 @@ void TrussTablePanel::DeleteSelected()
     if (SummaryPanel::Instance())
         SummaryPanel::Instance()->ShowTrussSummary();
 
+    if (RiggingPanel::Instance())
+        RiggingPanel::Instance()->RefreshData();
+
     ResyncRows(oldOrder, {});
 }
 


### PR DESCRIPTION
### Motivation
- Ensure the Rigging summary/table is updated immediately after removing any element that affects rigging so the UI doesn't show stale data.

### Description
- Call `RiggingPanel::Instance()->RefreshData()` after deletion flows in `FixtureTablePanel::DeleteSelected()`, `TrussTablePanel::DeleteSelected()`, and `HoistTablePanel::DeleteSelected()` to force the Rigging panel to refresh.
- Changes made to `gui/fixturetablepanel.cpp`, `gui/trusstablepanel.cpp`, and `gui/hoisttablepanel.cpp` to add the refresh call in each delete path.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed (OK). 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a61327bb288324a59f58362d5c18f8)