### PR TITLE
Use Perastage_logo.png as splash screen image

### DIFF
--- a/gui/splashscreen.cpp
+++ b/gui/splashscreen.cpp
@@ -35,23 +35,36 @@ void SplashScreen::Show() {
   wxBoxSizer *sizer = new wxBoxSizer(wxVERTICAL);
 
   wxBitmap logoBmp;
-  wxIconBundle bundle;
   const std::filesystem::path resourceRoot = ProjectUtils::GetResourceRoot();
-  std::filesystem::path iconPath;
-  if (!resourceRoot.empty())
-    iconPath = resourceRoot / "Perastage.ico";
+  const std::filesystem::path splashLogoPath = resourceRoot / "Perastage_logo.png";
   std::error_code ec;
-  if (!iconPath.empty() && std::filesystem::exists(iconPath, ec)) {
-    bundle.AddIcon(PathToWxString(iconPath), wxBITMAP_TYPE_ICO);
-  } else {
-    LogMissingIcon(
-        iconPath.empty() ? std::filesystem::path("resources/Perastage.ico")
-                         : iconPath);
+  if (!resourceRoot.empty() && std::filesystem::exists(splashLogoPath, ec)) {
+    logoBmp.LoadFile(PathToWxString(splashLogoPath), wxBITMAP_TYPE_PNG);
   }
-  wxIcon icon = bundle.GetIcon(wxSize(256, 256));
-  if (icon.IsOk()) {
-    logoBmp = wxBitmap(icon);
-  } else {
+
+  if (!logoBmp.IsOk()) {
+    LogMissingIcon(splashLogoPath.empty()
+                       ? std::filesystem::path("resources/Perastage_logo.png")
+                       : splashLogoPath);
+
+    std::filesystem::path iconPath;
+    if (!resourceRoot.empty())
+      iconPath = resourceRoot / "Perastage.ico";
+    wxIconBundle bundle;
+    if (!iconPath.empty() && std::filesystem::exists(iconPath, ec)) {
+      bundle.AddIcon(PathToWxString(iconPath), wxBITMAP_TYPE_ICO);
+    } else {
+      LogMissingIcon(
+          iconPath.empty() ? std::filesystem::path("resources/Perastage.ico")
+                           : iconPath);
+    }
+    wxIcon icon = bundle.GetIcon(wxSize(256, 256));
+    if (icon.IsOk()) {
+      logoBmp = wxBitmap(icon);
+    }
+  }
+
+  if (!logoBmp.IsOk()) {
     const std::filesystem::path pngPath = resourceRoot / "perastage3d.png";
     if (!resourceRoot.empty() && std::filesystem::exists(pngPath, ec)) {
       logoBmp.LoadFile(PathToWxString(pngPath), wxBITMAP_TYPE_PNG);


### PR DESCRIPTION
### Motivation
- Use the official `resources/Perastage_logo.png` as the primary splash image so the app shows the updated branding while keeping existing robust fallbacks.

### Description
- Updated `gui/splashscreen.cpp` to load `Perastage_logo.png` (from `ProjectUtils::GetResourceRoot()`) as the first-choice splash bitmap.
- If the PNG is missing or unreadable the code now logs a warning and falls back to `Perastage.ico`, then `perastage3d.png`, and finally `wxART_MISSING_IMAGE` as the last resort.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a61fb6c1f08324b0730de56c214f54)