### PR TITLE
Splash: load PNG logo, add scaling, rounded window shape and robust fallbacks

### DIFF
--- a/gui/splashscreen.cpp
+++ b/gui/splashscreen.cpp
@@ -1,9 +1,12 @@
 #include "splashscreen.h"
 #include "projectutils.h"
+#include <algorithm>
 #include <filesystem>
 #include <wx/artprov.h>
-#include <wx/iconbndl.h>
+#include <wx/bitmap.h>
+#include <wx/dcmemory.h>
 #include <wx/log.h>
+#include <wx/region.h>
 #include <wx/sizer.h>
 #include <wx/statbmp.h>
 #include <wx/stattext.h>
@@ -12,6 +15,9 @@
 namespace {
 wxFrame *g_splash = nullptr;
 wxStaticText *g_label = nullptr;
+
+constexpr int kFallbackIconSize = 256;
+constexpr int kRoundedCornerRadius = 16;
 
 wxString PathToWxString(const std::filesystem::path &path) {
   const std::u8string utf8 = path.u8string();
@@ -22,44 +28,92 @@ wxString PathToWxString(const std::filesystem::path &path) {
 void LogMissingIcon(const std::filesystem::path &path) {
   wxLogWarning("Splash icon not found at '" + PathToWxString(path) + "'");
 }
+
+wxBitmap ScaleBitmapByFactor(const wxBitmap &bitmap, double factor) {
+  if (!bitmap.IsOk() || factor <= 0.0 || factor == 1.0)
+    return bitmap;
+
+  wxImage image = bitmap.ConvertToImage();
+  if (!image.IsOk())
+    return bitmap;
+
+  const int scaledWidth = std::max(1, static_cast<int>(image.GetWidth() * factor));
+  const int scaledHeight =
+      std::max(1, static_cast<int>(image.GetHeight() * factor));
+  image.Rescale(scaledWidth, scaledHeight, wxIMAGE_QUALITY_HIGH);
+  return wxBitmap(image);
 }
+
+void ApplyRoundedShape(wxFrame *frame, int radius) {
+  if (!frame)
+    return;
+
+  const wxSize size = frame->GetSize();
+  if (size.GetWidth() <= 0 || size.GetHeight() <= 0)
+    return;
+
+  wxBitmap shapeBitmap(size.GetWidth(), size.GetHeight(), 32);
+  wxMemoryDC dc(shapeBitmap);
+  dc.SetBackground(*wxBLACK_BRUSH);
+  dc.Clear();
+  dc.SetBrush(*wxWHITE_BRUSH);
+  dc.SetPen(*wxTRANSPARENT_PEN);
+  dc.DrawRoundedRectangle(0, 0, size.GetWidth(), size.GetHeight(), radius);
+  dc.SelectObject(wxNullBitmap);
+
+  frame->SetShape(wxRegion(shapeBitmap, *wxBLACK));
+}
+} // namespace
 
 void SplashScreen::Show() {
   if (g_splash)
     return;
 
   g_splash = new wxFrame(nullptr, wxID_ANY, "", wxDefaultPosition, wxDefaultSize,
-                         wxFRAME_NO_TASKBAR | wxSTAY_ON_TOP | wxBORDER_NONE);
+                         wxFRAME_NO_TASKBAR | wxSTAY_ON_TOP | wxBORDER_NONE |
+                             wxFRAME_SHAPED);
 
   wxPanel *panel = new wxPanel(g_splash);
   wxBoxSizer *sizer = new wxBoxSizer(wxVERTICAL);
 
   wxBitmap logoBmp;
-  wxIconBundle bundle;
+  bool loadedFromSplashLogo = false;
   const std::filesystem::path resourceRoot = ProjectUtils::GetResourceRoot();
-  std::filesystem::path iconPath;
-  if (!resourceRoot.empty())
-    iconPath = resourceRoot / "Perastage.ico";
+  const std::filesystem::path splashLogoPath = resourceRoot / "Perastage_logo.png";
   std::error_code ec;
-  if (!iconPath.empty() && std::filesystem::exists(iconPath, ec)) {
-    bundle.AddIcon(PathToWxString(iconPath), wxBITMAP_TYPE_ICO);
-  } else {
-    LogMissingIcon(
-        iconPath.empty() ? std::filesystem::path("resources/Perastage.ico")
-                         : iconPath);
+  if (!resourceRoot.empty() && std::filesystem::exists(splashLogoPath, ec)) {
+    logoBmp.LoadFile(PathToWxString(splashLogoPath), wxBITMAP_TYPE_PNG);
+    loadedFromSplashLogo = logoBmp.IsOk();
   }
-  wxIcon icon = bundle.GetIcon(wxSize(256, 256));
-  if (icon.IsOk()) {
-    logoBmp = wxBitmap(icon);
-  } else {
-    const std::filesystem::path pngPath = resourceRoot / "perastage3d.png";
-    if (!resourceRoot.empty() && std::filesystem::exists(pngPath, ec)) {
-      logoBmp.LoadFile(PathToWxString(pngPath), wxBITMAP_TYPE_PNG);
+
+  if (loadedFromSplashLogo) {
+    logoBmp = ScaleBitmapByFactor(logoBmp, 0.5);
+  }
+
+  if (!logoBmp.IsOk()) {
+    LogMissingIcon(splashLogoPath.empty()
+                       ? std::filesystem::path("resources/Perastage_logo.png")
+                       : splashLogoPath);
+
+    std::filesystem::path iconPath;
+    if (!resourceRoot.empty())
+      iconPath = resourceRoot / "Perastage.ico";
+    wxIcon icon;
+    if (!iconPath.empty() && std::filesystem::exists(iconPath, ec)) {
+      icon.LoadFile(PathToWxString(iconPath), wxBITMAP_TYPE_ICO);
+    } else {
+      LogMissingIcon(
+          iconPath.empty() ? std::filesystem::path("resources/Perastage.ico")
+                           : iconPath);
     }
-    if (!logoBmp.IsOk()) {
-      logoBmp = wxArtProvider::GetBitmap(wxART_MISSING_IMAGE, wxART_OTHER,
-                                         wxSize(256, 256));
+    if (icon.IsOk()) {
+      logoBmp = wxBitmap(icon);
     }
+  }
+
+  if (!logoBmp.IsOk()) {
+    logoBmp = wxArtProvider::GetBitmap(wxART_MISSING_IMAGE, wxART_OTHER,
+                                       wxSize(kFallbackIconSize, kFallbackIconSize));
   }
 
   wxStaticBitmap *logo = new wxStaticBitmap(panel, wxID_ANY, logoBmp);
@@ -78,6 +132,7 @@ void SplashScreen::Show() {
   panel->SetSizerAndFit(sizer);
 
   g_splash->SetClientSize(panel->GetBestSize());
+  ApplyRoundedShape(g_splash, kRoundedCornerRadius);
   g_splash->CentreOnScreen();
   g_splash->Show();
   g_splash->Raise();


### PR DESCRIPTION
### Motivation
- Replace the old icon-bundle based splash loading with a clearer PNG-first flow and improve appearance with rounded corners and predictable fallbacks.
- Ensure the splash always shows an image even if some resource files are missing by adding logging and fallback assets.
- Improve bitmap handling by allowing controlled scaling and using shaped frames for a modern UI look.

### Description
- Load `resources/Perastage_logo.png` first into a `wxBitmap`, scale it by `0.5` when present using the new `ScaleBitmapByFactor` helper, and fall back to `Perastage.ico` or `wxART_MISSING_IMAGE` when needed.
- Add `ApplyRoundedShape` and enable `wxFRAME_SHAPED` to give the splash a rounded rectangle shape using a mask bitmap and `wxRegion`, with parameters exposed as `kRoundedCornerRadius` and `kFallbackIconSize`.
- Replace use of `wxIconBundle` with direct `wxIcon::LoadFile` and add robust missing-file logging via `LogMissingIcon`, plus new includes required for bitmap/DC/region operations.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a61fb6c1f08324b0730de56c214f54)