### PR TITLE
Avoid startup freeze when loading last project (add timeout and single-event guard)

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -21,7 +21,9 @@
 #include "mainwindow.h"
 #include "projectutils.h"
 #include "splashscreen.h"
+#include <chrono>
 #include <filesystem>
+#include <atomic>
 #include <new>
 #include <thread>
 #include <wx/stackwalk.h>
@@ -38,8 +40,13 @@ public:
   void OnUnhandledException() override;
 
 private:
+  void QueueProjectLoadedEvent(const wxWeakRef<MainWindow> &mainWindowRef,
+                               bool loaded, bool clearLastProject,
+                               const std::string &path = {});
+
   std::string last_event_summary_;
   std::thread project_loader_thread_;
+  std::atomic<bool> project_load_event_sent_{false};
 };
 
 wxIMPLEMENT_APP(MyApp);
@@ -94,37 +101,29 @@ bool MyApp::OnInit() {
           if (!loaded)
             clearLastProject = true;
         }
-        if (mainWindowRef) {
-          wxCommandEvent evt(EVT_PROJECT_LOADED);
-          evt.SetInt(loaded ? 1 : 0);
-          evt.SetExtraLong(clearLastProject ? 1 : 0);
-          evt.SetString(path);
-          wxQueueEvent(mainWindowRef.get(), evt.Clone());
-        }
+        QueueProjectLoadedEvent(mainWindowRef, loaded, clearLastProject, path);
       } catch (const std::exception &ex) {
         Logger::Instance().Log(
             std::string("Failed to load last project: ") + ex.what());
-        if (mainWindowRef) {
-          wxCommandEvent evt(EVT_PROJECT_LOADED);
-          evt.SetInt(0);
-          evt.SetExtraLong(1);
-          wxQueueEvent(mainWindowRef.get(), evt.Clone());
-        }
+        QueueProjectLoadedEvent(mainWindowRef, false, true);
       } catch (...) {
         Logger::Instance().Log("Failed to load last project: unknown error.");
-        if (mainWindowRef) {
-          wxCommandEvent evt(EVT_PROJECT_LOADED);
-          evt.SetInt(0);
-          evt.SetExtraLong(1);
-          wxQueueEvent(mainWindowRef.get(), evt.Clone());
-        }
+        QueueProjectLoadedEvent(mainWindowRef, false, true);
       }
     });
+
+    std::thread([this, mainWindowRef]() {
+      constexpr auto kProjectLoadTimeout = std::chrono::seconds(8);
+      std::this_thread::sleep_for(kProjectLoadTimeout);
+      if (project_load_event_sent_.load())
+        return;
+      Logger::Instance().Log(
+          "Timed out loading last project during startup; opening empty "
+          "project instead.");
+      QueueProjectLoadedEvent(mainWindowRef, false, true);
+    }).detach();
   } else if (mainWindowRef) {
-    wxCommandEvent evt(EVT_PROJECT_LOADED);
-    evt.SetInt(0);
-    evt.SetExtraLong(0);
-    wxQueueEvent(mainWindowRef.get(), evt.Clone());
+    QueueProjectLoadedEvent(mainWindowRef, false, false);
   }
 
   return true;
@@ -135,6 +134,22 @@ int MyApp::OnExit() {
     project_loader_thread_.join();
   }
   return wxApp::OnExit();
+}
+
+void MyApp::QueueProjectLoadedEvent(const wxWeakRef<MainWindow> &mainWindowRef,
+                                    bool loaded, bool clearLastProject,
+                                    const std::string &path) {
+  if (!mainWindowRef)
+    return;
+  bool expected = false;
+  if (!project_load_event_sent_.compare_exchange_strong(expected, true))
+    return;
+
+  wxCommandEvent evt(EVT_PROJECT_LOADED);
+  evt.SetInt(loaded ? 1 : 0);
+  evt.SetExtraLong(clearLastProject ? 1 : 0);
+  evt.SetString(wxString::FromUTF8(path));
+  wxQueueEvent(mainWindowRef.get(), evt.Clone());
 }
 
 int MyApp::FilterEvent(wxEvent &event) {


### PR DESCRIPTION
### Motivation
- The app could hang on the splash screen at "Loading last project..." when the remembered project path is slow/inaccessible (observed in non-admin Windows/Explorer scenarios). 
- Startup must remain responsive even if the background last-project load blocks or errors.

### Description
- Added a single helper `QueueProjectLoadedEvent(...)` on `MyApp` and an `std::atomic<bool> project_load_event_sent_` flag so the project-loaded event is emitted exactly once (prevents races between normal completion, exceptions, and fallback). 
- Replaced the in-thread direct `wxQueueEvent` calls with `QueueProjectLoadedEvent(...)` and kept the existing background load and exception handling path. 
- Added an 8-second watchdog thread that logs a timeout and queues a fallback empty-project event if the background loader does not finish in time. 
- Updated includes and declarations in `main.cpp` (`<chrono>`, `<atomic>`) and changed the event string handling to use `wxString::FromUTF8(...)` when queuing the event.

### Testing
- `tests/check_perastage_tree_modules.sh` ran and returned OK. 
- `tests/check_no_configmanager_get_in_gui.sh` ran and returned OK. 
- Attempted `cmake --build build --target perastage_stage -j4` failed due to a missing `build/` directory in the environment. 
- Attempted `cmake -S . -B build` failed because `wxWidgets` is not available in the current environment, so a full build/test could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6b1b1d3488324a203fce3555ce430)