### PR TITLE
Fix startup project-load lambda to capture `this`

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -95,7 +95,7 @@ bool MyApp::OnInit() {
 
   if (lastPathOpt) {
     std::string lastPath = *lastPathOpt;
-    project_loader_thread_ = std::thread([mainWindowRef, lastPath]() {
+    project_loader_thread_ = std::thread([this, mainWindowRef, lastPath]() {
       try {
         namespace fs = std::filesystem;
         bool loaded = false;
@@ -112,14 +112,15 @@ bool MyApp::OnInit() {
           if (!loaded)
             clearLastProject = true;
         }
-        QueueProjectLoadedEvent(mainWindowRef, loaded, clearLastProject, path);
+        this->QueueProjectLoadedEvent(mainWindowRef, loaded, clearLastProject,
+                                      path);
       } catch (const std::exception &ex) {
         Logger::Instance().Log(
             std::string("Failed to load last project: ") + ex.what());
-        QueueProjectLoadedEvent(mainWindowRef, false, true);
+        this->QueueProjectLoadedEvent(mainWindowRef, false, true);
       } catch (...) {
         Logger::Instance().Log("Failed to load last project: unknown error.");
-        QueueProjectLoadedEvent(mainWindowRef, false, true);
+        this->QueueProjectLoadedEvent(mainWindowRef, false, true);
       }
     });
 


### PR DESCRIPTION
### Motivation
- Ensure the startup project-loader lambda can call the non-static member `QueueProjectLoadedEvent` on the `MyApp` instance to resolve MSVC errors C2352/C3493 during build.

### Description
- Capture `this` in the lambda in `main.cpp` and update calls inside the lambda to use `this->QueueProjectLoadedEvent(...)` so member access is valid from the thread lambda.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both passed; `cmake --preset wsl-x64-debug` was attempted but failed in this environment due to missing `wxWidgets` development packages (failure is environmental and unrelated to the fix).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6b395c84483248ba450e939463f77)