### PR TITLE
Remove startup timeout fallback to fix project-load race (main.cpp)

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -21,7 +21,6 @@
 #include "mainwindow.h"
 #include "projectutils.h"
 #include "splashscreen.h"
-#include <chrono>
 #include <filesystem>
 #include <atomic>
 #include <new>
@@ -62,7 +61,7 @@ bool MyApp::OnInit() {
   {
     wxFileName exe(wxStandardPaths::Get().GetExecutablePath());
     if (exe.IsOk()) {
-    wxFileName::SetCwd(exe.GetPath());
+      wxFileName::SetCwd(exe.GetPath());
     }
   }
 
@@ -124,16 +123,6 @@ bool MyApp::OnInit() {
       }
     });
 
-    std::thread([this, mainWindowRef]() {
-      constexpr auto kProjectLoadTimeout = std::chrono::seconds(8);
-      std::this_thread::sleep_for(kProjectLoadTimeout);
-      if (project_load_event_sent_.load())
-        return;
-      Logger::Instance().Log(
-          "Timed out loading last project during startup; opening empty "
-          "project instead.");
-      QueueProjectLoadedEvent(mainWindowRef, false, true);
-    }).detach();
   } else if (mainWindowRef) {
     QueueProjectLoadedEvent(mainWindowRef, false, false);
   }


### PR DESCRIPTION
### Motivation
- The app could post a fallback “open empty project” event after a fixed 8s timeout while the background last-project loader was still running, producing conflicting startup states (e.g. window showing “Untitled” while the real load completes) that can appear as a hang during "loading project...".
- Launch-from-Explorer / non-admin file access timing differences made the race more likely on Windows, so removing the competing timeout avoids the inconsistent UI state.

### Description
- Removed the detached 8-second timeout fallback thread that posted a fallback `QueueProjectLoadedEvent(..., false, true)` during startup, leaving the asynchronous last-project load and its success/error event flow unchanged (file modified: `main.cpp`).
- Kept the background thread that performs `ConfigManager::Get().LoadProject(...)` and the normal `EVT_PROJECT_LOADED` event path intact.
- Fixed indentation in the block that sets the process working directory from the executable path (no functional change).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (OK).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (OK).
- Attempted `cmake --build --preset wsl-release-stage --target perastage_stage` but it failed in this environment because the preset/build directory is not present here (environment limitation).
- Attempted `cmake --preset wsl-x64-release` but configuration failed in this container due to missing `wxWidgets` (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6b591c99083248413e8207b58b97b)