### PR TITLE
Add writable-directory fallbacks for startup config and dictionary files

### DIFF
--- a/core/configservices.cpp
+++ b/core/configservices.cpp
@@ -315,7 +315,16 @@ bool UserPreferencesStore::SaveToFile(const std::string &path) const {
 std::string UserPreferencesStore::GetUserConfigFile() {
   wxString dir = wxStandardPaths::Get().GetUserDataDir();
   std::filesystem::path p = std::filesystem::path(dir.ToStdString());
-  std::filesystem::create_directories(p);
+  std::error_code ec;
+  std::filesystem::create_directories(p, ec);
+  if (ec) {
+    ec.clear();
+    const wxString tempDir = wxStandardPaths::Get().GetTempDir();
+    p = std::filesystem::path(tempDir.ToStdString()) / "Perastage";
+    std::filesystem::create_directories(p, ec);
+    if (ec)
+      return {};
+  }
   p /= "user_config.json";
   return p.string();
 }

--- a/core/credentialstore.cpp
+++ b/core/credentialstore.cpp
@@ -30,7 +30,15 @@ static std::string GetCredFile()
 {
     wxString dir = wxStandardPaths::Get().GetUserDataDir();
     fs::path p = fs::path(dir.ToStdString());
-    fs::create_directories(p);
+    std::error_code ec;
+    fs::create_directories(p, ec);
+    if (ec) {
+        ec.clear();
+        p = fs::path(wxStandardPaths::Get().GetTempDir().ToStdString()) / "Perastage";
+        fs::create_directories(p, ec);
+        if (ec)
+            return {};
+    }
     p /= "gdtf_credentials.json";
     return p.string();
 }
@@ -40,7 +48,10 @@ bool Save(const Credentials& cred)
     nlohmann::json j;
     j["username"] = cred.username;
     j["password"] = SimpleCrypt::Encode(cred.password);
-    std::ofstream out(GetCredFile());
+    const std::string credFile = GetCredFile();
+    if (credFile.empty())
+        return false;
+    std::ofstream out(credFile);
     if (!out.is_open())
         return false;
     out << j.dump(4);
@@ -49,7 +60,10 @@ bool Save(const Credentials& cred)
 
 std::optional<Credentials> Load()
 {
-    std::ifstream in(GetCredFile());
+    const std::string credFile = GetCredFile();
+    if (credFile.empty())
+        return std::nullopt;
+    std::ifstream in(credFile);
     if (!in.is_open())
         return std::nullopt;
     nlohmann::json j;
@@ -67,4 +81,3 @@ std::optional<Credentials> Load()
 }
 
 } // namespace CredentialStore
-

--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -32,7 +32,10 @@ static fs::path GetDictFile() {
   fs::path dir = fs::u8path(ProjectUtils::GetDefaultLibraryPath("fixtures"));
   if (dir.empty())
     return {};
-  fs::create_directories(dir);
+  std::error_code ec;
+  fs::create_directories(dir, ec);
+  if (ec)
+    return {};
   fs::path file = dir / "gdtf_dictionary.json";
   if (!fs::exists(file)) {
     fs::path baseLib = ProjectUtils::GetBaseLibraryPath("fixtures");

--- a/core/trussdictionary.cpp
+++ b/core/trussdictionary.cpp
@@ -77,7 +77,10 @@ static fs::path GetDictFile() {
   fs::path dir = fs::u8path(ProjectUtils::GetDefaultLibraryPath("trusses"));
   if (dir.empty())
     return {};
-  fs::create_directories(dir);
+  std::error_code ec;
+  fs::create_directories(dir, ec);
+  if (ec)
+    return {};
   fs::path file = dir / "truss_dictionary.json";
   if (!fs::exists(file)) {
     fs::path baseLib = ProjectUtils::GetBaseLibraryPath("trusses");


### PR DESCRIPTION
### Motivation

- Prevent application startup hangs or failures when first-run write paths (e.g., `GetUserDataDir()`) are not writable in portable/non-installed runs on Windows. 
- Avoid requiring elevation to open projects or show main window when the app cannot create its user data files. 
- Make dictionary and credential initialization robust against permission errors so the app can continue with reasonable fallbacks.

### Description

- Update `UserPreferencesStore::GetUserConfigFile()` in `core/configservices.cpp` to use non-throwing `std::filesystem::create_directories(..., std::error_code)` and fall back to `wxStandardPaths::Get().GetTempDir()/Perastage` when the user data dir cannot be created, returning empty on failure. 
- Harden `core/credentialstore.cpp` `GetCredFile()` with `std::error_code`-based directory creation, fallback to temp `Perastage` folder, and guard reads/writes by returning early if no writable path is available. 
- Make `core/gdtfdictionary.cpp` and `core/trussdictionary.cpp` use `std::error_code` for `create_directories` and gracefully return an empty path when directories cannot be prepared so dictionary loading/saving is skipped safely. 
- Overall changes limit assumptions about writable startup locations and add simple, deterministic fallbacks to temporary per-user directories to avoid crashes or admin-only behavior.

### Testing

- Ran `tests/check_perastage_tree_modules.sh`, which passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which passed. 
- Attempted to run `cmake --build build --target perastage_stage` in this environment but the build directory does not exist here, so an actual build/test run was not performed in this workspace.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6b900dda483248bbf69c36218e818)