### PR TITLE
Load fixture weight and power from GDTF when importing rider fixtures

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -78,6 +78,38 @@ std::string Trim(const std::string &s) {
   return s.substr(start, end - start + 1);
 }
 
+std::string ResolveGdtfPath(const MVRScene &scene,
+                            const std::string &gdtfSpecPath) {
+  if (gdtfSpecPath.empty())
+    return {};
+
+  std::filesystem::path specPath = std::filesystem::u8path(gdtfSpecPath);
+  if (specPath.is_absolute() || scene.basePath.empty())
+    return gdtfSpecPath;
+
+  return (std::filesystem::u8path(scene.basePath) / specPath).string();
+}
+
+void ApplyFixturePhysicalPropertiesFromGdtf(const MVRScene &scene,
+                                            Fixture &fixture) {
+  if (fixture.gdtfSpec.empty())
+    return;
+
+  const std::string gdtfPath = ResolveGdtfPath(scene, fixture.gdtfSpec);
+  if (gdtfPath.empty())
+    return;
+
+  float gdtfWeightKg = 0.0f;
+  float gdtfPowerW = 0.0f;
+  if (!GetGdtfProperties(gdtfPath, gdtfWeightKg, gdtfPowerW))
+    return;
+
+  if (fixture.weightKg <= 0.0f)
+    fixture.weightKg = gdtfWeightKg;
+  if (fixture.powerConsumptionW <= 0.0f)
+    fixture.powerConsumptionW = gdtfPowerW;
+}
+
 bool TryParseFloat(const std::string &text, float &out) {
   if (text.empty())
     return false;
@@ -439,9 +471,11 @@ bool RiderImporter::ImportText(const std::string &text) {
         if (auto dictEntry = GdtfDictionary::Get(f.typeName)) {
           f.gdtfSpec = dictEntry->path;
           f.gdtfMode = dictEntry->mode;
-          std::string parsed = Trim(GetGdtfFixtureName(f.gdtfSpec));
+          const std::string resolvedGdtfPath = ResolveGdtfPath(scene, f.gdtfSpec);
+          std::string parsed = Trim(GetGdtfFixtureName(resolvedGdtfPath));
           if (!parsed.empty())
             f.typeName = parsed;
+          ApplyFixturePhysicalPropertiesFromGdtf(scene, f);
         }
         if (!seenTypes.count(f.typeName)) {
           typeOrder.push_back(f.typeName);

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -78,19 +78,19 @@ std::string Trim(const std::string &s) {
   return s.substr(start, end - start + 1);
 }
 
-std::string ResolveGdtfPath(const MVRScene &scene,
+std::string ResolveGdtfPath(const MvrScene &scene,
                             const std::string &gdtfSpecPath) {
   if (gdtfSpecPath.empty())
     return {};
 
-  std::filesystem::path specPath = std::filesystem::u8path(gdtfSpecPath);
+  std::filesystem::path specPath = std::filesystem::path(gdtfSpecPath);
   if (specPath.is_absolute() || scene.basePath.empty())
     return gdtfSpecPath;
 
-  return (std::filesystem::u8path(scene.basePath) / specPath).string();
+  return (std::filesystem::path(scene.basePath) / specPath).string();
 }
 
-void ApplyFixturePhysicalPropertiesFromGdtf(const MVRScene &scene,
+void ApplyFixturePhysicalPropertiesFromGdtf(const MvrScene &scene,
                                             Fixture &fixture) {
   if (fixture.gdtfSpec.empty())
     return;


### PR DESCRIPTION
### Motivation
- Rider-imported fixtures that reference a GDTF profile were not inheriting physical metadata (weight/power), leaving tables and rigging summaries empty or zero unless filled manually. 
- GDTF files can include `PhysicalDescriptions/Properties/Weight`, `PowerConsumption` and `WiringObject` entries (with `ElectricalPayLoad`/`ElectricalPayload`) that should be applied to created fixtures. 
- Keep the change small and localized to the rider import path to avoid large refactors of hotspot files.

### Description
- Added `ResolveGdtfPath(const MVRScene&, const std::string&)` to resolve a GDTF spec path against `scene.basePath` when the spec is relative, and return absolute/usable string. 
- Added `ApplyFixturePhysicalPropertiesFromGdtf(const MVRScene&, Fixture&)` which calls `GetGdtfProperties(...)` and fills `fixture.weightKg` and `fixture.powerConsumptionW` only when those fields are not already set. 
- Wired the helper into the rider fixture creation flow in `core/riderimporter.cpp` so fixtures created from `GdtfDictionary` entries get their type name resolved via the resolved GDTF path and receive physical properties from the GDTF. 
- Change is limited to `core/riderimporter.cpp` and preserves existing behavior when GDTF data is absent or fixture values are already provided.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed (OK). 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6cf2329c08324908865f0ea2106af)