### PR TITLE
Fix rider_autopatch_test link error from missing GDTF stub symbols

### DIFF
--- a/tests/gdtfloader_onech_stub.cpp
+++ b/tests/gdtfloader_onech_stub.cpp
@@ -27,3 +27,9 @@ bool LoadGdtf(const std::string&, std::vector<GdtfObject>&, std::string*) {
 }
 int GetGdtfModeChannelCount(const std::string&, const std::string&) { return 1; }
 std::string GetGdtfFixtureName(const std::string& gdtfPath) { return gdtfPath; }
+std::string GetGdtfModelColor(const std::string&) { return "#000000"; }
+bool GetGdtfProperties(const std::string&, float &w, float &p) {
+    w = 0.0f;
+    p = 0.0f;
+    return false;
+}


### PR DESCRIPTION
### Motivation
- The `rider_autopatch_test` target links `core/riderimporter.cpp`, which calls `GetGdtfProperties(...)`, but the one-channel test stub did not provide that symbol causing a linker error (`undefined reference`).

### Description
- Added missing stub implementations `GetGdtfModelColor` and `GetGdtfProperties` to `tests/gdtfloader_onech_stub.cpp` that return sensible defaults (`"#000000"` for color and `false` while zeroing weight/power). 
- This brings the one-channel GDTF test stub into alignment with the API declared in `tests/gdtfloader.h` so `rider_autopatch_test` can link successfully.

### Testing
- Ran `./tests/check_perastage_tree_modules.sh` which succeeded. 
- Ran `./tests/check_no_configmanager_get_in_gui.sh` which succeeded. 
- Attempted `cmake --preset wsl-x64-debug` to validate a full build but configuration failed due to missing system `wxWidgets` development files in the environment, so a full local binary build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6d36998388324a5132da9fb791f97)