### PR TITLE
Refactor gobo beam visibility: add policy helper and UI toggle for fog vs geometry fallback

### DIFF
--- a/peraviz/README_gobos.md
+++ b/peraviz/README_gobos.md
@@ -38,6 +38,17 @@ This mode is the default because it aligns the in-air volumetric look with the f
 Peraviz keeps `SpotLight3D.light_projector` support as an explicit alternative mode (`projector_cookie`).
 Use it only when intentionally testing projector behavior.
 
+### Geometry fallback mode (beam only, no mixing)
+
+When `Gobo beam visibility` is set to `Geometry shader fallback`, Peraviz now uses a strict
+beam-only mode for gobo visibility in air:
+
+- no shadow-cookie projection path,
+- no `light_projector` footprint projection,
+- gobo texture is applied only inside the volumetric beam shader.
+
+This keeps methods separated and avoids mixed artifacts when comparing approaches.
+
 ### Additional notes
 
 - `SpotLight3D.shadow_enabled` must be `true` for shadow-cookie gobos.

--- a/peraviz/README_gobos.md
+++ b/peraviz/README_gobos.md
@@ -57,12 +57,12 @@ If the footprint looks correct on the floor but the beam in air looks too soft, 
 
 Peraviz now applies those shadow-cookie defaults when gobos are active in `shadow_cookie` mode, while keeping them user-tunable from Visual Settings.
 
-Current Peraviz defaults are aligned to that recipe:
+Current Peraviz defaults are tuned for balanced readability without overexposing the beam volume:
 
-- `volumetric_fog_density = 0.02`
-- `light_volumetric_fog_energy = 3.5`
+- `volumetric_fog_density = 0.007`
+- `light_volumetric_fog_energy = 1.6`
 - `shadow_blur = 0.1` for active shadow-cookie gobos
-- volumetric fog froxel controls default to `volume_size = 256`, `volume_depth = 128`, `use_filter = false`
+- volumetric fog froxel controls default to `volume_size = 256`, `volume_depth = 96`, `use_filter = true`
 
 
 ### Scale and resolution notes

--- a/peraviz/README_gobos.md
+++ b/peraviz/README_gobos.md
@@ -57,6 +57,13 @@ If the footprint looks correct on the floor but the beam in air looks too soft, 
 
 Peraviz now applies those shadow-cookie defaults when gobos are active in `shadow_cookie` mode, while keeping them user-tunable from Visual Settings.
 
+Current Peraviz defaults are aligned to that recipe:
+
+- `volumetric_fog_density = 0.02`
+- `light_volumetric_fog_energy = 3.5`
+- `shadow_blur = 0.1` for active shadow-cookie gobos
+- volumetric fog froxel controls default to `volume_size = 256`, `volume_depth = 128`, `use_filter = false`
+
 
 ### Scale and resolution notes
 

--- a/peraviz/README_gobos.md
+++ b/peraviz/README_gobos.md
@@ -49,6 +49,10 @@ beam-only mode for gobo visibility in air:
 
 This keeps methods separated and avoids mixed artifacts when comparing approaches.
 
+In `shadow_cookie` mode, Peraviz restricts the spotlight `shadow_caster_mask`
+to the dedicated gobo-occluder layer so dynamic scene/player geometry does not
+erase the gobo pattern when crossing the beam.
+
 ### Additional notes
 
 - `SpotLight3D.shadow_enabled` must be `true` for shadow-cookie gobos.

--- a/peraviz/README_gobos.md
+++ b/peraviz/README_gobos.md
@@ -77,7 +77,10 @@ Current Peraviz defaults are tuned for balanced readability without overexposing
 - `volumetric_fog_density = 0.007`
 - `light_volumetric_fog_energy = 1.6`
 - `shadow_blur = 0.1` for active shadow-cookie gobos
-- volumetric fog froxel controls default to `volume_size = 256`, `volume_depth = 96`, `use_filter = true`
+- volumetric fog froxel controls default to `volume_size = 512`, `volume_depth = 96`, `use_filter = true`
+
+In `fog_shadow` mode, `Beam intensity` also scales `light_volumetric_fog_energy` so the
+control has visible impact on in-air haze brightness even when additive cone rendering is disabled.
 
 
 ### Scale and resolution notes

--- a/peraviz/scripts/beam_renderers/gobo_beam_visibility_policy.gd
+++ b/peraviz/scripts/beam_renderers/gobo_beam_visibility_policy.gd
@@ -17,9 +17,6 @@ enum BeamVisibilityMode {
 func resolve_visibility_mode(settings: Dictionary,
 		prefer_native_shadow_cookie: bool,
 		gobo_projection_mode: int) -> int:
-	if gobo_projection_mode == PROJECTOR_COOKIE_PROJECTION_MODE:
-		return BeamVisibilityMode.GEOMETRY_SHADER
-
 	var mode_name: String = str(settings.get("gobo_beam_visibility_mode", "fog_shadow")).to_lower()
 	if mode_name == "geometry_shader":
 		return BeamVisibilityMode.GEOMETRY_SHADER
@@ -34,4 +31,3 @@ func compute_occluder_plane_size_world(beam_angle: float, gobo_scale_ratio: floa
 	var cone_radius_at_occluder: float = tan(half_angle_rad) * GOBO_OCCLUDER_DISTANCE_M
 	var footprint_plane_size: float = max(cone_radius_at_occluder * 2.0, 0.001) * GOBO_FOOTPRINT_CONE_FILL_RATIO
 	return max(footprint_plane_size * max(gobo_scale_ratio, 0.001) * GOBO_COOKIE_OVERSCAN_RATIO, 0.001)
-

--- a/peraviz/scripts/beam_renderers/gobo_beam_visibility_policy.gd
+++ b/peraviz/scripts/beam_renderers/gobo_beam_visibility_policy.gd
@@ -1,0 +1,37 @@
+extends RefCounted
+class_name GoboBeamVisibilityPolicy
+
+const SHADOW_COOKIE_PROJECTION_MODE: int = 0
+const PROJECTOR_COOKIE_PROJECTION_MODE: int = 1
+
+const GOBO_OCCLUDER_DISTANCE_M: float = 0.043
+const GOBO_PLANE_BASE_SIZE_M: float = 0.017
+const GOBO_FOOTPRINT_CONE_FILL_RATIO: float = 1.0
+const GOBO_COOKIE_OVERSCAN_RATIO: float = 1.12
+
+enum BeamVisibilityMode {
+	FOG_SHADOW,
+	GEOMETRY_SHADER,
+}
+
+func resolve_visibility_mode(settings: Dictionary,
+		prefer_native_shadow_cookie: bool,
+		gobo_projection_mode: int) -> int:
+	if gobo_projection_mode == PROJECTOR_COOKIE_PROJECTION_MODE:
+		return BeamVisibilityMode.GEOMETRY_SHADER
+
+	var mode_name: String = str(settings.get("gobo_beam_visibility_mode", "fog_shadow")).to_lower()
+	if mode_name == "geometry_shader":
+		return BeamVisibilityMode.GEOMETRY_SHADER
+
+	if prefer_native_shadow_cookie:
+		return BeamVisibilityMode.FOG_SHADOW
+
+	return BeamVisibilityMode.FOG_SHADOW
+
+func compute_occluder_plane_size_world(beam_angle: float, gobo_scale_ratio: float) -> float:
+	var half_angle_rad: float = deg_to_rad(max(beam_angle, 0.1) * 0.5)
+	var cone_radius_at_occluder: float = tan(half_angle_rad) * GOBO_OCCLUDER_DISTANCE_M
+	var footprint_plane_size: float = max(cone_radius_at_occluder * 2.0, 0.001) * GOBO_FOOTPRINT_CONE_FILL_RATIO
+	return max(footprint_plane_size * max(gobo_scale_ratio, 0.001) * GOBO_COOKIE_OVERSCAN_RATIO, 0.001)
+

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -5,6 +5,7 @@ class_name VolumetricBeamRenderer
 const BEAM_META_KEY: String = "peraviz_volumetric_beam"
 const GOBO_OCCLUDER_META_KEY: String = "peraviz_gobo_occluder"
 const GOBO_OCCLUDER_SHADER_MATERIAL_META_KEY: String = "peraviz_gobo_occluder_shader_material"
+const GOBO_OCCLUDER_SHADOW_LAYER_MASK: int = 1 << 19
 const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 10.0
 const VOLUMETRIC_INTENSITY_SCALE: float = 0.75
 const GOBO_DEBUG_MATERIAL_COLOR: Color = Color(0.1, 0.9, 0.2, 0.3)
@@ -64,6 +65,7 @@ func ensure_beam(light: SpotLight3D) -> void:
 		gobo_occluder.mesh = gobo_mesh
 		var occluder_shader_material: ShaderMaterial = _gobo_occluder_material_template.duplicate(true)
 		gobo_occluder.material_override = occluder_shader_material
+		gobo_occluder.layers = GOBO_OCCLUDER_SHADOW_LAYER_MASK
 		gobo_occluder.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_SHADOWS_ONLY
 		gobo_occluder.visible = false
 		light.add_child(gobo_occluder)
@@ -206,7 +208,7 @@ func _update_gobo_occluder(light: SpotLight3D,
 
 	if update_cone_shader:
 		cone.set_instance_shader_parameter("gobo_enabled", true)
-		cone.set_instance_shader_parameter("gobo_cutoff", 0.38)
+		cone.set_instance_shader_parameter("gobo_cutoff", 0.72)
 		cone.set_instance_shader_parameter("gobo_start_ratio", _gobo_visibility_policy.GOBO_OCCLUDER_DISTANCE_M / max(beam_range, 0.001))
 		cone.set_instance_shader_parameter("gobo_rotation", 0.0)
 		cone.set_instance_shader_parameter("gobo_size", Vector2(gobo_plane_size_world, gobo_plane_size_world))

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -112,12 +112,15 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 				gobo_occluder.visible = false
 			return
 
-	# In native shadow-cookie mode keep a subtle non-gobo mesh cone only for beam readability,
-	# while cookie patterning in air still comes from SpotLight shadows in volumetric fog.
-	var mesh_intensity: float = intensity
+	# In native shadow-cookie mode keep no additive cone when gobo is active.
+	# This avoids froxel-like square borders and preserves physically-driven fog shadows.
 	if visibility_mode == GoboBeamVisibilityPolicy.BeamVisibilityMode.FOG_SHADOW and gobo_active:
-		# For coherent fog-shadow gobos avoid washing the footprint/beam with additive cone shading.
-		mesh_intensity = threshold * 1.02
+		cone.visible = false
+		_update_gobo_occluder(light, cone, gobo_occluder, beam_angle, beam_range, prefer_native_shadow_cookie, visibility_mode)
+		return
+
+	# In other modes keep a controllable mesh cone.
+	var mesh_intensity: float = intensity
 	if prefer_native_shadow_cookie and not (visibility_mode == GoboBeamVisibilityPolicy.BeamVisibilityMode.FOG_SHADOW and gobo_active):
 		mesh_intensity = max(intensity * 0.35, threshold * 1.1)
 
@@ -173,6 +176,13 @@ func _update_gobo_occluder(light: SpotLight3D,
 
 	var gobo_texture: Texture2D = light.get_meta("peraviz_gobo_texture", null) as Texture2D
 	var gobo_projection_mode: int = int(light.get_meta("peraviz_gobo_projection_mode", 0))
+	if gobo_projection_mode == _gobo_visibility_policy.PROJECTOR_COOKIE_PROJECTION_MODE:
+		# Projector-cookie mode should not mix with occluder or beam-shader gobo masking.
+		gobo_occluder.visible = false
+		gobo_occluder.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
+		gobo_occluder.material_override = null
+		cone.set_instance_shader_parameter("gobo_enabled", false)
+		return
 	var visibility_mode: int = visibility_mode_override
 	if visibility_mode < 0:
 		visibility_mode = _gobo_visibility_policy.resolve_visibility_mode(_settings, prefer_native_shadow_cookie, gobo_projection_mode)

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -7,12 +7,9 @@ const GOBO_OCCLUDER_META_KEY: String = "peraviz_gobo_occluder"
 const GOBO_OCCLUDER_SHADER_MATERIAL_META_KEY: String = "peraviz_gobo_occluder_shader_material"
 const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 10.0
 const VOLUMETRIC_INTENSITY_SCALE: float = 0.75
-const GOBO_OCCLUDER_DISTANCE_M: float = 0.043
-const GOBO_PLANE_BASE_SIZE_M: float = 0.017
-const GOBO_FOOTPRINT_CONE_FILL_RATIO: float = 1.0
-const GOBO_COOKIE_OVERSCAN_RATIO: float = 1.12
 const GOBO_DEBUG_MATERIAL_COLOR: Color = Color(0.1, 0.9, 0.2, 0.3)
 const GOBO_DEBUG_LOG_THROTTLE_MS: int = 400
+const GoboBeamVisibilityPolicyScript = preload("res://scripts/beam_renderers/gobo_beam_visibility_policy.gd")
 
 var _beam_material_template: ShaderMaterial
 var _gobo_occluder_material_template: ShaderMaterial
@@ -20,8 +17,10 @@ var _gobo_occluder_debug_material: StandardMaterial3D
 var _camera: Camera3D
 var _settings: Dictionary = {}
 var _last_gobo_debug_log_ticks_by_light: Dictionary = {}
+var _gobo_visibility_policy: GoboBeamVisibilityPolicy
 
 func _init() -> void:
+	_gobo_visibility_policy = GoboBeamVisibilityPolicyScript.new()
 	_beam_material_template = ShaderMaterial.new()
 	_beam_material_template.shader = load("res://scripts/shaders/volumetric_beam.gdshader")
 	_gobo_occluder_material_template = ShaderMaterial.new()
@@ -59,7 +58,7 @@ func ensure_beam(light: SpotLight3D) -> void:
 
 	if not light.has_meta(GOBO_OCCLUDER_META_KEY):
 		var gobo_mesh := QuadMesh.new()
-		gobo_mesh.size = Vector2(GOBO_PLANE_BASE_SIZE_M, GOBO_PLANE_BASE_SIZE_M)
+		gobo_mesh.size = Vector2(_gobo_visibility_policy.GOBO_PLANE_BASE_SIZE_M, _gobo_visibility_policy.GOBO_PLANE_BASE_SIZE_M)
 		var gobo_occluder := MeshInstance3D.new()
 		gobo_occluder.name = "PeravizGoboOccluder"
 		gobo_occluder.mesh = gobo_mesh
@@ -133,12 +132,7 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	cone.set_instance_shader_parameter("beam_bottom_radius", bottom_radius)
 	cone.set_instance_shader_parameter("beam_height", beam_range)
 
-	_update_gobo_occluder(light, cone, gobo_occluder, beam_angle, beam_range, not prefer_native_shadow_cookie)
-
-func _compute_cone_diameter_at_occluder(beam_angle: float) -> float:
-	var half_angle_rad: float = deg_to_rad(max(beam_angle, 0.1) * 0.5)
-	var cone_radius_at_occluder: float = tan(half_angle_rad) * GOBO_OCCLUDER_DISTANCE_M
-	return max(cone_radius_at_occluder * 2.0, 0.001)
+	_update_gobo_occluder(light, cone, gobo_occluder, beam_angle, beam_range, prefer_native_shadow_cookie)
 
 func cleanup_beam(light: SpotLight3D) -> void:
 	if light.has_meta(BEAM_META_KEY):
@@ -155,7 +149,7 @@ func cleanup_beam(light: SpotLight3D) -> void:
 	if light.has_meta(GOBO_OCCLUDER_SHADER_MATERIAL_META_KEY):
 		light.remove_meta(GOBO_OCCLUDER_SHADER_MATERIAL_META_KEY)
 
-func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occluder: MeshInstance3D, beam_angle: float, beam_range: float, update_cone_shader: bool = true) -> void:
+func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occluder: MeshInstance3D, beam_angle: float, beam_range: float, prefer_native_shadow_cookie: bool = false) -> void:
 	if gobo_occluder == null:
 		return
 
@@ -165,10 +159,9 @@ func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occlud
 
 	var gobo_texture: Texture2D = light.get_meta("peraviz_gobo_texture", null) as Texture2D
 	var gobo_projection_mode: int = int(light.get_meta("peraviz_gobo_projection_mode", 0))
-	if gobo_projection_mode == 1:
-		gobo_occluder.visible = false
-		cone.set_instance_shader_parameter("gobo_enabled", false)
-		return
+	var visibility_mode: int = _gobo_visibility_policy.resolve_visibility_mode(_settings, prefer_native_shadow_cookie, gobo_projection_mode)
+	var use_shadow_occluder: bool = visibility_mode == GoboBeamVisibilityPolicy.BeamVisibilityMode.FOG_SHADOW
+	var update_cone_shader: bool = visibility_mode == GoboBeamVisibilityPolicy.BeamVisibilityMode.GEOMETRY_SHADER
 
 	var gobo_active := gobo_texture != null
 	if not gobo_active:
@@ -182,29 +175,25 @@ func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occlud
 		return
 
 	var gobo_scale_ratio: float = max(float(_settings.get("gobo_scale_ratio", 1.0)), 0.001)
-	var cone_diameter_at_occluder: float = _compute_cone_diameter_at_occluder(beam_angle)
-	var footprint_plane_size: float = cone_diameter_at_occluder * GOBO_FOOTPRINT_CONE_FILL_RATIO
-	# Slight overscan avoids having the cone boundary and cookie boundary collide exactly,
-	# which reduces checker/dither-like borders in volumetric fog froxels.
-	var gobo_plane_size_world: float = max(footprint_plane_size * gobo_scale_ratio * GOBO_COOKIE_OVERSCAN_RATIO, 0.001)
-	var footprint_scale: float = max(gobo_plane_size_world / GOBO_PLANE_BASE_SIZE_M, 0.001)
+	var gobo_plane_size_world: float = _gobo_visibility_policy.compute_occluder_plane_size_world(beam_angle, gobo_scale_ratio)
+	var footprint_scale: float = max(gobo_plane_size_world / _gobo_visibility_policy.GOBO_PLANE_BASE_SIZE_M, 0.001)
 	gobo_occluder.scale = Vector3(footprint_scale, footprint_scale, 1.0)
-	gobo_occluder.position = Vector3(0.0, 0.0, -GOBO_OCCLUDER_DISTANCE_M)
-	gobo_occluder.visible = true
+	gobo_occluder.position = Vector3(0.0, 0.0, -_gobo_visibility_policy.GOBO_OCCLUDER_DISTANCE_M)
+	gobo_occluder.visible = use_shadow_occluder
 	gobo_material.set_shader_parameter("gobo_texture", gobo_texture)
 
 	var gobo_debug_visible: bool = bool(_settings.get("gobo_debug_show_occluder", false))
-	if gobo_debug_visible:
+	if gobo_debug_visible and use_shadow_occluder:
 		gobo_occluder.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_ON
 		gobo_occluder.material_override = _gobo_occluder_debug_material
 	else:
-		gobo_occluder.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_SHADOWS_ONLY
-		gobo_occluder.material_override = gobo_material
+		gobo_occluder.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_SHADOWS_ONLY if use_shadow_occluder else GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
+		gobo_occluder.material_override = gobo_material if use_shadow_occluder else null
 
 	if update_cone_shader:
 		cone.set_instance_shader_parameter("gobo_enabled", true)
 		cone.set_instance_shader_parameter("gobo_cutoff", 0.38)
-		cone.set_instance_shader_parameter("gobo_start_ratio", GOBO_OCCLUDER_DISTANCE_M / max(beam_range, 0.001))
+		cone.set_instance_shader_parameter("gobo_start_ratio", _gobo_visibility_policy.GOBO_OCCLUDER_DISTANCE_M / max(beam_range, 0.001))
 		cone.set_instance_shader_parameter("gobo_rotation", 0.0)
 		cone.set_instance_shader_parameter("gobo_size", Vector2(gobo_plane_size_world, gobo_plane_size_world))
 		cone.set_instance_shader_parameter("gobo_axis_sign", 1.0)

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -112,15 +112,11 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 				gobo_occluder.visible = false
 			return
 
-	# In native shadow-cookie mode keep no additive cone when gobo is active.
-	# This avoids froxel-like square borders and preserves physically-driven fog shadows.
-	if visibility_mode == GoboBeamVisibilityPolicy.BeamVisibilityMode.FOG_SHADOW and gobo_active:
-		cone.visible = false
-		_update_gobo_occluder(light, cone, gobo_occluder, beam_angle, beam_range, prefer_native_shadow_cookie, visibility_mode)
-		return
-
-	# In other modes keep a controllable mesh cone.
+	# Keep a very subtle cone in shadow-cookie mode so the in-air gobo silhouette remains readable
+	# without reintroducing strong additive washout.
 	var mesh_intensity: float = intensity
+	if visibility_mode == GoboBeamVisibilityPolicy.BeamVisibilityMode.FOG_SHADOW and gobo_active:
+		mesh_intensity = threshold * 1.05
 	if prefer_native_shadow_cookie and not (visibility_mode == GoboBeamVisibilityPolicy.BeamVisibilityMode.FOG_SHADOW and gobo_active):
 		mesh_intensity = max(intensity * 0.35, threshold * 1.1)
 
@@ -187,7 +183,8 @@ func _update_gobo_occluder(light: SpotLight3D,
 	if visibility_mode < 0:
 		visibility_mode = _gobo_visibility_policy.resolve_visibility_mode(_settings, prefer_native_shadow_cookie, gobo_projection_mode)
 	var use_shadow_occluder: bool = visibility_mode == GoboBeamVisibilityPolicy.BeamVisibilityMode.FOG_SHADOW
-	var update_cone_shader: bool = visibility_mode == GoboBeamVisibilityPolicy.BeamVisibilityMode.GEOMETRY_SHADER
+	var use_shadow_cookie_cone_assist: bool = visibility_mode == GoboBeamVisibilityPolicy.BeamVisibilityMode.FOG_SHADOW and bool(_settings.get("gobo_shadow_cookie_cone_assist", true))
+	var update_cone_shader: bool = visibility_mode == GoboBeamVisibilityPolicy.BeamVisibilityMode.GEOMETRY_SHADER or use_shadow_cookie_cone_assist
 
 	var gobo_active := gobo_texture != null
 	if not gobo_active:
@@ -218,7 +215,7 @@ func _update_gobo_occluder(light: SpotLight3D,
 
 	if update_cone_shader:
 		cone.set_instance_shader_parameter("gobo_enabled", true)
-		cone.set_instance_shader_parameter("gobo_cutoff", 0.72)
+		cone.set_instance_shader_parameter("gobo_cutoff", 0.45)
 		cone.set_instance_shader_parameter("gobo_start_ratio", _gobo_visibility_policy.GOBO_OCCLUDER_DISTANCE_M / max(beam_range, 0.001))
 		cone.set_instance_shader_parameter("gobo_rotation", 0.0)
 		cone.set_instance_shader_parameter("gobo_size", Vector2(gobo_plane_size_world, gobo_plane_size_world))

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -82,6 +82,9 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	var beam_range: float = max(float(params.get("beam_range", 0.1)), 0.01)
 	var beam_angle: float = max(float(params.get("beam_angle", 1.0)), 0.1)
 	var prefer_native_shadow_cookie: bool = bool(params.get("prefer_native_shadow_cookie_volumetric", false))
+	var gobo_projection_mode: int = int(light.get_meta("peraviz_gobo_projection_mode", 0))
+	var visibility_mode: int = _gobo_visibility_policy.resolve_visibility_mode(_settings, prefer_native_shadow_cookie, gobo_projection_mode)
+	var gobo_active: bool = (light.get_meta("peraviz_gobo_texture", null) as Texture2D) != null
 
 	if not bool(params.get("is_visible", true)):
 		cone.visible = false
@@ -110,7 +113,10 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	# In native shadow-cookie mode keep a subtle non-gobo mesh cone only for beam readability,
 	# while cookie patterning in air still comes from SpotLight shadows in volumetric fog.
 	var mesh_intensity: float = intensity
-	if prefer_native_shadow_cookie:
+	if visibility_mode == GoboBeamVisibilityPolicy.BeamVisibilityMode.FOG_SHADOW and gobo_active:
+		# For coherent fog-shadow gobos avoid washing the footprint/beam with additive cone shading.
+		mesh_intensity = threshold * 1.02
+	if prefer_native_shadow_cookie and not (visibility_mode == GoboBeamVisibilityPolicy.BeamVisibilityMode.FOG_SHADOW and gobo_active):
 		mesh_intensity = max(intensity * 0.35, threshold * 1.1)
 
 	var half_angle_deg: float = beam_angle * 0.5
@@ -132,7 +138,7 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	cone.set_instance_shader_parameter("beam_bottom_radius", bottom_radius)
 	cone.set_instance_shader_parameter("beam_height", beam_range)
 
-	_update_gobo_occluder(light, cone, gobo_occluder, beam_angle, beam_range, prefer_native_shadow_cookie)
+	_update_gobo_occluder(light, cone, gobo_occluder, beam_angle, beam_range, prefer_native_shadow_cookie, visibility_mode)
 
 func cleanup_beam(light: SpotLight3D) -> void:
 	if light.has_meta(BEAM_META_KEY):
@@ -149,7 +155,13 @@ func cleanup_beam(light: SpotLight3D) -> void:
 	if light.has_meta(GOBO_OCCLUDER_SHADER_MATERIAL_META_KEY):
 		light.remove_meta(GOBO_OCCLUDER_SHADER_MATERIAL_META_KEY)
 
-func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occluder: MeshInstance3D, beam_angle: float, beam_range: float, prefer_native_shadow_cookie: bool = false) -> void:
+func _update_gobo_occluder(light: SpotLight3D,
+		cone: MeshInstance3D,
+		gobo_occluder: MeshInstance3D,
+		beam_angle: float,
+		beam_range: float,
+		prefer_native_shadow_cookie: bool = false,
+		visibility_mode_override: int = -1) -> void:
 	if gobo_occluder == null:
 		return
 
@@ -159,7 +171,9 @@ func _update_gobo_occluder(light: SpotLight3D, cone: MeshInstance3D, gobo_occlud
 
 	var gobo_texture: Texture2D = light.get_meta("peraviz_gobo_texture", null) as Texture2D
 	var gobo_projection_mode: int = int(light.get_meta("peraviz_gobo_projection_mode", 0))
-	var visibility_mode: int = _gobo_visibility_policy.resolve_visibility_mode(_settings, prefer_native_shadow_cookie, gobo_projection_mode)
+	var visibility_mode: int = visibility_mode_override
+	if visibility_mode < 0:
+		visibility_mode = _gobo_visibility_policy.resolve_visibility_mode(_settings, prefer_native_shadow_cookie, gobo_projection_mode)
 	var use_shadow_occluder: bool = visibility_mode == GoboBeamVisibilityPolicy.BeamVisibilityMode.FOG_SHADOW
 	var update_cone_shader: bool = visibility_mode == GoboBeamVisibilityPolicy.BeamVisibilityMode.GEOMETRY_SHADER
 

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -8,6 +8,7 @@ const GOBO_MODE_META_KEY: String = "peraviz_gobo_projection_mode"
 enum ProjectionMode {
 	SHADOW_COOKIE,
 	PROJECTOR_COOKIE,
+	BEAM_ONLY,
 }
 
 var _texture_cache: Dictionary = {}
@@ -68,15 +69,24 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 	if projection_mode == ProjectionMode.PROJECTOR_COOKIE:
 		_warn_if_projector_unsupported(light)
 		light.light_projector = composed_gobo
+		light.shadow_enabled = true
+	elif projection_mode == ProjectionMode.BEAM_ONLY:
+		# Geometry fallback mode: feed the beam shader with gobo texture, but keep light projection disabled
+		# to avoid mixing methods (no floor cookie and no shadow-cookie fog path).
+		light.light_projector = null
+		light.shadow_enabled = false
 	else:
 		# Keep projector disabled in the sample-like path to avoid double gobo projection.
 		light.light_projector = null
+		light.shadow_enabled = true
 	return composed_gobo != previous_meta_texture
 
 func _resolve_projection_mode(controls: Dictionary) -> int:
 	var mode_name: String = str(controls.get("gobo_projection_mode", "shadow_cookie")).to_lower()
 	if mode_name == "projector_cookie":
 		return ProjectionMode.PROJECTOR_COOKIE
+	if mode_name == "beam_only":
+		return ProjectionMode.BEAM_ONLY
 	return ProjectionMode.SHADOW_COOKIE
 
 func _resolve_gobo_raw_8bit(controls: Dictionary) -> int:

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -61,8 +61,8 @@ var _visual_settings := {
 	"beam_anisotropy": 0.62,
 	"beam_noise_amount": 0.06,
 	"beam_noise_scale": 1.4,
-	"volumetric_fog_density": 0.02,
-	"light_volumetric_fog_energy": 3.5,
+	"volumetric_fog_density": 0.007,
+	"light_volumetric_fog_energy": 1.6,
 	"gobo_scale_ratio": 1.0,
 	"gobo_debug_show_occluder": false,
 	"gobo_debug_log_parameters": false,
@@ -70,8 +70,8 @@ var _visual_settings := {
 	"gobo_projection_mode": "shadow_cookie",
 	"gobo_beam_visibility_mode": "fog_shadow",
 	"volumetric_fog_volume_size": 256,
-	"volumetric_fog_depth": 128.0,
-	"volumetric_fog_use_filter": false,
+	"volumetric_fog_depth": 96.0,
+	"volumetric_fog_use_filter": true,
 	"background_color": Color(0.129412, 0.137255, 0.156863, 1.0),
 }
 
@@ -142,7 +142,7 @@ const GOBO_SHADOW_COOKIE_BEAM_ATTENUATION: float = 0.5
 const GOBO_SHADOW_COOKIE_SHADOW_BIAS: float = 0.02
 const GOBO_SHADOW_COOKIE_SHADOW_NORMAL_BIAS: float = 0.8
 const GOBO_SHADOW_COOKIE_SHADOW_BLUR: float = 0.1
-const GOBO_SHADOW_COOKIE_MESH_BEAM_INTENSITY_MULTIPLIER: float = 0.55
+const GOBO_SHADOW_COOKIE_MESH_BEAM_INTENSITY_MULTIPLIER: float = 0.25
 const EMITTER_CONE_FADE_END_RATIO: float = 0.82
 const EMITTER_CONE_NEAR_ALPHA: float = 0.16
 const EMITTER_CONE_FAR_ALPHA: float = 0.004
@@ -281,22 +281,23 @@ func _apply_visual_settings(settings: Dictionary) -> void:
 		world_environment.environment.glow_bloom = float(_visual_environment_baseline.get("glow_bloom", 0.05)) * float(_visual_settings.get("bloom_multiplier", 1.0))
 		world_environment.environment.background_color = _visual_settings.get("background_color", _visual_environment_baseline.get("background_color", Color(0.129412, 0.137255, 0.156863, 1.0)))
 		world_environment.environment.volumetric_fog_enabled = true
-		world_environment.environment.volumetric_fog_density = float(_visual_settings.get("volumetric_fog_density", 0.02))
+		world_environment.environment.volumetric_fog_density = float(_visual_settings.get("volumetric_fog_density", 0.007))
 
 	# Godot volumetric fog froxel controls are renderer-level project settings.
 	# Keep them aligned with visual settings for the #11987 shadow-cookie workflow.
 	var fog_volume_size: int = int(round(float(_visual_settings.get("volumetric_fog_volume_size", 256))))
-	var fog_volume_depth: int = int(round(float(_visual_settings.get("volumetric_fog_depth", 128.0))) )
-	var fog_use_filter: bool = bool(_visual_settings.get("volumetric_fog_use_filter", false))
+	var fog_volume_depth: int = int(round(float(_visual_settings.get("volumetric_fog_depth", 96.0))) )
+	var fog_use_filter: bool = bool(_visual_settings.get("volumetric_fog_use_filter", true))
 	ProjectSettings.set_setting("rendering/environment/volumetric_fog/volume_size", fog_volume_size)
 	ProjectSettings.set_setting("rendering/environment/volumetric_fog/volume_depth", fog_volume_depth)
 	ProjectSettings.set_setting("rendering/environment/volumetric_fog/use_filter", fog_use_filter)
 	if world_environment != null and world_environment.environment != null:
 		_apply_environment_froxel_settings(world_environment.environment, fog_volume_size, fog_volume_depth, fog_use_filter)
+		_refresh_volumetric_fog_environment_binding()
 	# This setting can require a renderer restart in Godot to re-allocate froxel buffers.
 	# Intentionally not persisted to disk in debug workflow.
 	if status_label != null:
-		status_label.text = "Volumetric fog quality changes may require scene reload to fully apply (Godot froxel grid)."
+		status_label.text = "Applied volumetric fog quality and refreshed environment binding."
 
 	_update_beam_renderer_mode(false)
 	_save_visual_settings_to_project()
@@ -336,6 +337,17 @@ func _environment_has_property(environment: Environment, property_name: String) 
 		if str(entry.get("name", "")) == property_name:
 			return true
 	return false
+
+func _refresh_volumetric_fog_environment_binding() -> void:
+	if world_environment == null:
+		return
+	var current_environment: Environment = world_environment.environment
+	if current_environment == null:
+		return
+	# Rebinding the same Environment resource helps force renderer-side refresh
+	# for volumetric fog buffers in some Godot versions.
+	world_environment.environment = null
+	world_environment.environment = current_environment
 
 func _update_beam_renderer_mode(force_refresh: bool) -> void:
 	var requested_mode: int = int(clamp(int(_visual_settings.get("beam_render_mode", BEAM_RENDER_MODE_VOLUMETRIC)), BEAM_RENDER_MODE_VOLUMETRIC, BEAM_RENDER_MODE_LEGACY))
@@ -381,7 +393,7 @@ func _refresh_existing_beam_material_scalars() -> void:
 func _apply_light_scalars_to_light(light: SpotLight3D) -> void:
 	var base_energy: float = float(light.get_meta("peraviz_base_light_energy", light.light_energy))
 	light.light_energy = base_energy * float(_visual_settings.get("spot_multiplier", 1.0))
-	light.light_volumetric_fog_energy = float(_visual_settings.get("light_volumetric_fog_energy", 3.5))
+	light.light_volumetric_fog_energy = float(_visual_settings.get("light_volumetric_fog_energy", 1.6))
 
 func _update_existing_beam_material_scalars(light: SpotLight3D) -> void:
 	var base_intensity: float = float(light.get_meta("peraviz_beam_base_intensity", 0.0))
@@ -1691,7 +1703,7 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 		var gobo_controls: Dictionary = controls.duplicate(true)
 		gobo_controls["gobo_projection_mode"] = str(_visual_settings.get("gobo_projection_mode", "shadow_cookie"))
 		gobo_changed = _fixture_gobo_projector.apply_gobo_projection(light, gobo_controls)
-	light.light_volumetric_fog_energy = float(_visual_settings.get("light_volumetric_fog_energy", 3.5))
+	light.light_volumetric_fog_energy = float(_visual_settings.get("light_volumetric_fog_energy", 1.6))
 	_update_beam_for_light(light, beam_params)
 	if gobo_changed:
 		# Re-apply beam uniforms immediately when gobo texture changes so volumetric modulation updates without frame delay.

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -69,7 +69,7 @@ var _visual_settings := {
 	"gobo_debug_log_volumetric_details": false,
 	"gobo_projection_mode": "shadow_cookie",
 	"gobo_beam_visibility_mode": "fog_shadow",
-	"volumetric_fog_volume_size": 256,
+	"volumetric_fog_volume_size": 512,
 	"volumetric_fog_depth": 96.0,
 	"volumetric_fog_use_filter": true,
 	"background_color": Color(0.129412, 0.137255, 0.156863, 1.0),
@@ -143,6 +143,8 @@ const GOBO_SHADOW_COOKIE_SHADOW_BIAS: float = 0.02
 const GOBO_SHADOW_COOKIE_SHADOW_NORMAL_BIAS: float = 0.25
 const GOBO_SHADOW_COOKIE_SHADOW_BLUR: float = 0.0
 const GOBO_SHADOW_COOKIE_MESH_BEAM_INTENSITY_MULTIPLIER: float = 0.25
+const GOBO_SPOT_RANGE_MIN_M: float = 12.0
+const GOBO_SPOT_RANGE_MAX_M: float = 24.0
 const GOBO_SHADOW_COOKIE_ONLY_CASTER_MASK: int = 1 << 19
 const LIGHT_DEFAULT_SHADOW_CASTER_MASK: int = 0xFFFFF
 const EMITTER_CONE_FADE_END_RATIO: float = 0.82
@@ -395,7 +397,8 @@ func _refresh_existing_beam_material_scalars() -> void:
 func _apply_light_scalars_to_light(light: SpotLight3D) -> void:
 	var base_energy: float = float(light.get_meta("peraviz_base_light_energy", light.light_energy))
 	light.light_energy = base_energy * float(_visual_settings.get("spot_multiplier", 1.0))
-	light.light_volumetric_fog_energy = float(_visual_settings.get("light_volumetric_fog_energy", 1.6))
+	var visual_beam_multiplier: float = float(_visual_settings.get("beam_multiplier", 1.0))
+	light.light_volumetric_fog_energy = float(_visual_settings.get("light_volumetric_fog_energy", 1.6)) * visual_beam_multiplier
 
 func _update_existing_beam_material_scalars(light: SpotLight3D) -> void:
 	var base_intensity: float = float(light.get_meta("peraviz_beam_base_intensity", 0.0))
@@ -1658,7 +1661,7 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 	light.spot_range = clamp(cone_range * EMITTER_LIGHT_FOOTPRINT_RANGE_MULTIPLIER, EMITTER_LIGHT_MIN_EFFECTIVE_RANGE_M, EMITTER_LIGHT_MAX_RANGE_M)
 	if bool(controls.get("has_gobo", false)):
 		# Sample-like fallback for gobo readability: keep spotlight range in a tight zoom-linked window.
-		light.spot_range = remap(clamp(beam_angle, 6.0, 50.0), 6.0, 50.0, 60.0, 30.0)
+		light.spot_range = remap(clamp(beam_angle, 6.0, 50.0), 6.0, 50.0, GOBO_SPOT_RANGE_MAX_M, GOBO_SPOT_RANGE_MIN_M)
 	var gobo_projection_mode: String = str(_visual_settings.get("gobo_projection_mode", "shadow_cookie"))
 	var gobo_beam_visibility_mode: String = str(_visual_settings.get("gobo_beam_visibility_mode", "fog_shadow")).to_lower()
 	var use_shadow_cookie_gobo: bool = bool(controls.get("has_gobo", false)) and gobo_projection_mode == "shadow_cookie" and gobo_beam_visibility_mode != "geometry_shader"
@@ -1714,7 +1717,8 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 			effective_gobo_projection_mode = "beam_only"
 		gobo_controls["gobo_projection_mode"] = effective_gobo_projection_mode
 		gobo_changed = _fixture_gobo_projector.apply_gobo_projection(light, gobo_controls)
-	light.light_volumetric_fog_energy = float(_visual_settings.get("light_volumetric_fog_energy", 1.6))
+	var visual_beam_multiplier: float = float(_visual_settings.get("beam_multiplier", 1.0))
+	light.light_volumetric_fog_energy = float(_visual_settings.get("light_volumetric_fog_energy", 1.6)) * visual_beam_multiplier
 	_update_beam_for_light(light, beam_params)
 	if gobo_changed:
 		# Re-apply beam uniforms immediately when gobo texture changes so volumetric modulation updates without frame delay.

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -68,6 +68,7 @@ var _visual_settings := {
 	"gobo_debug_log_parameters": false,
 	"gobo_debug_log_volumetric_details": false,
 	"gobo_projection_mode": "shadow_cookie",
+	"gobo_beam_visibility_mode": "fog_shadow",
 	"volumetric_fog_volume_size": 256,
 	"volumetric_fog_depth": 64.0,
 	"volumetric_fog_use_filter": true,
@@ -389,9 +390,11 @@ func _update_existing_beam_material_scalars(light: SpotLight3D) -> void:
 		return
 	var beam_multiplier: float = float(_visual_settings.get("beam_multiplier", 1.0))
 	beam_params["scaled_intensity"] = clamp(base_intensity * beam_multiplier, 0.0, BEAM_INTENSITY_MAX)
+	var gobo_beam_visibility_mode: String = str(_visual_settings.get("gobo_beam_visibility_mode", "fog_shadow")).to_lower()
 	var use_shadow_cookie_gobo: bool = (
 		int(light.get_meta("peraviz_gobo_projection_mode", 0)) == FixtureGoboProjector.ProjectionMode.SHADOW_COOKIE
 		and light.get_meta("peraviz_gobo_texture", null) != null
+		and gobo_beam_visibility_mode != "geometry_shader"
 	)
 	if use_shadow_cookie_gobo:
 		beam_params["scaled_intensity"] = float(beam_params.get("scaled_intensity", 0.0)) * GOBO_SHADOW_COOKIE_MESH_BEAM_INTENSITY_MULTIPLIER
@@ -1643,7 +1646,8 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 		# Sample-like fallback for gobo readability: keep spotlight range in a tight zoom-linked window.
 		light.spot_range = remap(clamp(beam_angle, 6.0, 50.0), 6.0, 50.0, 60.0, 30.0)
 	var gobo_projection_mode: String = str(_visual_settings.get("gobo_projection_mode", "shadow_cookie"))
-	var use_shadow_cookie_gobo: bool = bool(controls.get("has_gobo", false)) and gobo_projection_mode == "shadow_cookie"
+	var gobo_beam_visibility_mode: String = str(_visual_settings.get("gobo_beam_visibility_mode", "fog_shadow")).to_lower()
+	var use_shadow_cookie_gobo: bool = bool(controls.get("has_gobo", false)) and gobo_projection_mode == "shadow_cookie" and gobo_beam_visibility_mode != "geometry_shader"
 	if use_shadow_cookie_gobo:
 		# Match the #11987 reference setup: tighter angle attenuation + sharp shadows improve in-air beam definition.
 		spot_attenuation = min(spot_attenuation, GOBO_SHADOW_COOKIE_BEAM_ATTENUATION)
@@ -1674,6 +1678,7 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 		"distance_cull_m": BEAM_DISTANCE_CULL_M,
 		"spot_angle_half_deg": light.spot_angle,
 		"spot_range": light.spot_range,
+		"gobo_beam_visibility_mode": gobo_beam_visibility_mode,
 	}
 	if use_shadow_cookie_gobo:
 		# Match the #11987 workaround behavior: keep occluder shadows for native volumetric fog,

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -61,8 +61,8 @@ var _visual_settings := {
 	"beam_anisotropy": 0.62,
 	"beam_noise_amount": 0.06,
 	"beam_noise_scale": 1.4,
-	"volumetric_fog_density": 0.012,
-	"light_volumetric_fog_energy": 2.0,
+	"volumetric_fog_density": 0.02,
+	"light_volumetric_fog_energy": 3.5,
 	"gobo_scale_ratio": 1.0,
 	"gobo_debug_show_occluder": false,
 	"gobo_debug_log_parameters": false,
@@ -70,8 +70,8 @@ var _visual_settings := {
 	"gobo_projection_mode": "shadow_cookie",
 	"gobo_beam_visibility_mode": "fog_shadow",
 	"volumetric_fog_volume_size": 256,
-	"volumetric_fog_depth": 64.0,
-	"volumetric_fog_use_filter": true,
+	"volumetric_fog_depth": 128.0,
+	"volumetric_fog_use_filter": false,
 	"background_color": Color(0.129412, 0.137255, 0.156863, 1.0),
 }
 
@@ -141,7 +141,7 @@ const EMITTER_LIGHT_SPOT_ATTENUATION_MAX: float = 1.5
 const GOBO_SHADOW_COOKIE_BEAM_ATTENUATION: float = 0.5
 const GOBO_SHADOW_COOKIE_SHADOW_BIAS: float = 0.02
 const GOBO_SHADOW_COOKIE_SHADOW_NORMAL_BIAS: float = 0.8
-const GOBO_SHADOW_COOKIE_SHADOW_BLUR: float = 0.2
+const GOBO_SHADOW_COOKIE_SHADOW_BLUR: float = 0.1
 const GOBO_SHADOW_COOKIE_MESH_BEAM_INTENSITY_MULTIPLIER: float = 0.55
 const EMITTER_CONE_FADE_END_RATIO: float = 0.82
 const EMITTER_CONE_NEAR_ALPHA: float = 0.16
@@ -281,13 +281,13 @@ func _apply_visual_settings(settings: Dictionary) -> void:
 		world_environment.environment.glow_bloom = float(_visual_environment_baseline.get("glow_bloom", 0.05)) * float(_visual_settings.get("bloom_multiplier", 1.0))
 		world_environment.environment.background_color = _visual_settings.get("background_color", _visual_environment_baseline.get("background_color", Color(0.129412, 0.137255, 0.156863, 1.0)))
 		world_environment.environment.volumetric_fog_enabled = true
-		world_environment.environment.volumetric_fog_density = float(_visual_settings.get("volumetric_fog_density", 0.01))
+		world_environment.environment.volumetric_fog_density = float(_visual_settings.get("volumetric_fog_density", 0.02))
 
 	# Godot volumetric fog froxel controls are renderer-level project settings.
 	# Keep them aligned with visual settings for the #11987 shadow-cookie workflow.
 	var fog_volume_size: int = int(round(float(_visual_settings.get("volumetric_fog_volume_size", 256))))
-	var fog_volume_depth: int = int(round(float(_visual_settings.get("volumetric_fog_depth", 64.0))) )
-	var fog_use_filter: bool = bool(_visual_settings.get("volumetric_fog_use_filter", true))
+	var fog_volume_depth: int = int(round(float(_visual_settings.get("volumetric_fog_depth", 128.0))) )
+	var fog_use_filter: bool = bool(_visual_settings.get("volumetric_fog_use_filter", false))
 	ProjectSettings.set_setting("rendering/environment/volumetric_fog/volume_size", fog_volume_size)
 	ProjectSettings.set_setting("rendering/environment/volumetric_fog/volume_depth", fog_volume_depth)
 	ProjectSettings.set_setting("rendering/environment/volumetric_fog/use_filter", fog_use_filter)
@@ -381,7 +381,7 @@ func _refresh_existing_beam_material_scalars() -> void:
 func _apply_light_scalars_to_light(light: SpotLight3D) -> void:
 	var base_energy: float = float(light.get_meta("peraviz_base_light_energy", light.light_energy))
 	light.light_energy = base_energy * float(_visual_settings.get("spot_multiplier", 1.0))
-	light.light_volumetric_fog_energy = float(_visual_settings.get("light_volumetric_fog_energy", 1.0))
+	light.light_volumetric_fog_energy = float(_visual_settings.get("light_volumetric_fog_energy", 3.5))
 
 func _update_existing_beam_material_scalars(light: SpotLight3D) -> void:
 	var base_intensity: float = float(light.get_meta("peraviz_beam_base_intensity", 0.0))
@@ -1691,7 +1691,7 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 		var gobo_controls: Dictionary = controls.duplicate(true)
 		gobo_controls["gobo_projection_mode"] = str(_visual_settings.get("gobo_projection_mode", "shadow_cookie"))
 		gobo_changed = _fixture_gobo_projector.apply_gobo_projection(light, gobo_controls)
-	light.light_volumetric_fog_energy = float(_visual_settings.get("light_volumetric_fog_energy", 1.0))
+	light.light_volumetric_fog_energy = float(_visual_settings.get("light_volumetric_fog_energy", 3.5))
 	_update_beam_for_light(light, beam_params)
 	if gobo_changed:
 		# Re-apply beam uniforms immediately when gobo texture changes so volumetric modulation updates without frame delay.

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -140,9 +140,11 @@ const EMITTER_LIGHT_SPOT_ATTENUATION_MIN: float = 0.0669
 const EMITTER_LIGHT_SPOT_ATTENUATION_MAX: float = 1.5
 const GOBO_SHADOW_COOKIE_BEAM_ATTENUATION: float = 0.5
 const GOBO_SHADOW_COOKIE_SHADOW_BIAS: float = 0.02
-const GOBO_SHADOW_COOKIE_SHADOW_NORMAL_BIAS: float = 0.8
-const GOBO_SHADOW_COOKIE_SHADOW_BLUR: float = 0.1
+const GOBO_SHADOW_COOKIE_SHADOW_NORMAL_BIAS: float = 0.25
+const GOBO_SHADOW_COOKIE_SHADOW_BLUR: float = 0.0
 const GOBO_SHADOW_COOKIE_MESH_BEAM_INTENSITY_MULTIPLIER: float = 0.25
+const GOBO_SHADOW_COOKIE_ONLY_CASTER_MASK: int = 1 << 19
+const LIGHT_DEFAULT_SHADOW_CASTER_MASK: int = 0xFFFFF
 const EMITTER_CONE_FADE_END_RATIO: float = 0.82
 const EMITTER_CONE_NEAR_ALPHA: float = 0.16
 const EMITTER_CONE_FAR_ALPHA: float = 0.004
@@ -1666,6 +1668,11 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 		light.shadow_bias = GOBO_SHADOW_COOKIE_SHADOW_BIAS
 		light.shadow_normal_bias = GOBO_SHADOW_COOKIE_SHADOW_NORMAL_BIAS
 		light.shadow_blur = GOBO_SHADOW_COOKIE_SHADOW_BLUR
+		# Keep spotlight shadows driven only by the gobo occluder, so player/scene geometry
+		# does not erase gobo detail while moving through the beam.
+		light.shadow_caster_mask = GOBO_SHADOW_COOKIE_ONLY_CASTER_MASK
+	else:
+		light.shadow_caster_mask = LIGHT_DEFAULT_SHADOW_CASTER_MASK
 	light.spot_attenuation = spot_attenuation
 	light.light_color = _derive_emitter_color(photometric, controls)
 	var beam_color: Color = _derive_emitter_color(photometric, controls, BEAM_COLOR_TEMPERATURE_STRENGTH)

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -1701,7 +1701,11 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 	var gobo_changed: bool = false
 	if _fixture_gobo_projector != null:
 		var gobo_controls: Dictionary = controls.duplicate(true)
-		gobo_controls["gobo_projection_mode"] = str(_visual_settings.get("gobo_projection_mode", "shadow_cookie"))
+		var effective_gobo_projection_mode: String = str(_visual_settings.get("gobo_projection_mode", "shadow_cookie"))
+		if gobo_beam_visibility_mode == "geometry_shader":
+			# Strict geometry fallback: do not combine with light projector or shadow-cookie footprint.
+			effective_gobo_projection_mode = "beam_only"
+		gobo_controls["gobo_projection_mode"] = effective_gobo_projection_mode
 		gobo_changed = _fixture_gobo_projector.apply_gobo_projection(light, gobo_controls)
 	light.light_volumetric_fog_energy = float(_visual_settings.get("light_volumetric_fog_energy", 1.6))
 	_update_beam_for_light(light, beam_params)

--- a/peraviz/scripts/shaders/volumetric_beam.gdshader
+++ b/peraviz/scripts/shaders/volumetric_beam.gdshader
@@ -83,7 +83,6 @@ void fragment() {
 	float gobo_open = 1.0;
 	if (gobo_enabled) {
 		float axis_pos = (beam_height * 0.5) - (v_local.y * gobo_axis_sign);
-		float axis_dist = clamp(axis_pos, 0.001, beam_height);
 		float gobo_plane_dist = gobo_start_ratio * beam_height;
 		if (axis_pos >= gobo_plane_dist) {
 			float t = axis_pos / beam_height;
@@ -93,8 +92,11 @@ void fragment() {
 				discard;
 			}
 
-			float projection_scale = gobo_plane_dist / axis_dist;
-			vec2 gobo_plane_pos = radial_pos * projection_scale;
+			// Geometry-fallback projection: normalize by beam radius at the current slice
+			// to keep gobo structure visible across the full cone volume.
+			vec2 gobo_plane_pos = radial_pos / max(radius_at_point, 0.001);
+			float gobo_scale = max(gobo_size.x / 0.08, 0.001);
+			gobo_plane_pos /= gobo_scale;
 
 			float sin_rot = sin(gobo_rotation);
 			float cos_rot = cos(gobo_rotation);
@@ -102,22 +104,14 @@ void fragment() {
 				gobo_plane_pos.x * cos_rot - gobo_plane_pos.y * sin_rot,
 				gobo_plane_pos.x * sin_rot + gobo_plane_pos.y * cos_rot
 			);
-			vec2 half_size = max(gobo_size * 0.5, vec2(0.001));
-			vec2 gobo_uv = rotated / half_size + vec2(0.5);
+			vec2 gobo_uv = rotated * 0.5 + vec2(0.5);
 
 			if (gobo_uv.x < 0.0 || gobo_uv.x > 1.0 || gobo_uv.y < 0.0 || gobo_uv.y > 1.0) {
 				gobo_open = 0.0;
 			} else {
-				const int LINE_SAMPLE_COUNT = 2;
-				float gobo_acc = 0.0;
-				for (int i = 0; i < LINE_SAMPLE_COUNT; i++) {
-					float sample_t = (float(i) + 0.5) / float(LINE_SAMPLE_COUNT);
-					vec2 sample_uv = mix(vec2(0.5), gobo_uv, sample_t);
-					vec4 texel = texture(gobo_texture, sample_uv);
-					float luminance = dot(texel.rgb, vec3(0.299, 0.587, 0.114)) * texel.a;
-					gobo_acc += smoothstep(gobo_cutoff - 0.04, gobo_cutoff + 0.04, luminance);
-				}
-				gobo_open = gobo_acc / float(LINE_SAMPLE_COUNT);
+				vec4 texel = texture(gobo_texture, gobo_uv);
+				float luminance = dot(texel.rgb, vec3(0.299, 0.587, 0.114)) * texel.a;
+				gobo_open = smoothstep(gobo_cutoff - 0.05, gobo_cutoff + 0.05, luminance);
 			}
 		} else {
 			gobo_open = 1.0;

--- a/peraviz/scripts/visual_settings_window.gd
+++ b/peraviz/scripts/visual_settings_window.gd
@@ -15,8 +15,8 @@ const DEFAULT_SETTINGS := {
 	"beam_anisotropy": 0.62,
 	"beam_noise_amount": 0.06,
 	"beam_noise_scale": 1.4,
-	"volumetric_fog_density": 0.012,
-	"light_volumetric_fog_energy": 2.0,
+	"volumetric_fog_density": 0.02,
+	"light_volumetric_fog_energy": 3.5,
 	"gobo_scale_ratio": 1.0,
 	"gobo_debug_show_occluder": false,
 	"gobo_debug_log_parameters": false,
@@ -24,8 +24,8 @@ const DEFAULT_SETTINGS := {
 	"gobo_projection_mode": "shadow_cookie",
 	"gobo_beam_visibility_mode": "fog_shadow",
 	"volumetric_fog_volume_size": 256,
-	"volumetric_fog_depth": 64.0,
-	"volumetric_fog_use_filter": true,
+	"volumetric_fog_depth": 128.0,
+	"volumetric_fog_use_filter": false,
 	"background_color": Color(0.129412, 0.137255, 0.156863, 1.0),
 }
 
@@ -97,7 +97,7 @@ func _build_ui() -> void:
 	_fog_density_slider = _add_slider_row(container, "Volumetric fog density", "volumetric_fog_density", 0.0, 0.08, 0.001)
 	_fog_volume_size_slider = _add_slider_row(container, "Fog volume size", "volumetric_fog_volume_size", 64.0, 512.0, 32.0)
 	_fog_depth_slider = _add_slider_row(container, "Fog volume depth", "volumetric_fog_depth", 16.0, 256.0, 4.0)
-	_light_fog_energy_slider = _add_slider_row(container, "Light fog energy", "light_volumetric_fog_energy", 0.0, 8.0, 0.05)
+	_light_fog_energy_slider = _add_slider_row(container, "Light fog energy", "light_volumetric_fog_energy", 0.0, 5000.0, 5.0)
 	_gobo_scale_slider = _add_slider_row(container, "Gobo scale ratio", "gobo_scale_ratio", 0.2, 2.5, 0.01)
 	_beam_render_mode_option = _add_option_row(container, "Beam rendering", ["Volumetric (default)", "Lightweight (legacy)"], _on_beam_render_mode_selected)
 	_beam_quality_option = _add_option_row(container, "Beam quality", ["Low", "Medium", "High"], _on_beam_quality_selected)
@@ -217,10 +217,10 @@ func _apply_settings_to_controls() -> void:
 	_spot_slider.value = float(_settings.get("spot_multiplier", 1.0))
 	_beam_slider.value = float(_settings.get("beam_multiplier", 1.0))
 	_bloom_slider.value = float(_settings.get("bloom_multiplier", 1.0))
-	_fog_density_slider.value = float(_settings.get("volumetric_fog_density", 0.01))
+	_fog_density_slider.value = float(_settings.get("volumetric_fog_density", 0.02))
 	_fog_volume_size_slider.value = float(_settings.get("volumetric_fog_volume_size", 256))
-	_fog_depth_slider.value = float(_settings.get("volumetric_fog_depth", 64.0))
-	_light_fog_energy_slider.value = float(_settings.get("light_volumetric_fog_energy", 1.0))
+	_fog_depth_slider.value = float(_settings.get("volumetric_fog_depth", 128.0))
+	_light_fog_energy_slider.value = float(_settings.get("light_volumetric_fog_energy", 3.5))
 	_gobo_scale_slider.value = float(_settings.get("gobo_scale_ratio", 1.0))
 	_beam_render_mode_option.select(clamp(int(_settings.get("beam_render_mode", 0)), 0, 1))
 	_beam_quality_option.select(clamp(int(_settings.get("beam_quality", 1)), 0, 2))
@@ -268,10 +268,10 @@ func _update_value_labels() -> void:
 	_spot_value_label.text = "%.2f" % float(_settings.get("spot_multiplier", 1.0))
 	_beam_value_label.text = "%.2f" % float(_settings.get("beam_multiplier", 1.0))
 	_bloom_value_label.text = "%.2f" % float(_settings.get("bloom_multiplier", 1.0))
-	_fog_density_value_label.text = "%.3f" % float(_settings.get("volumetric_fog_density", 0.01))
+	_fog_density_value_label.text = "%.3f" % float(_settings.get("volumetric_fog_density", 0.02))
 	_fog_volume_size_value_label.text = "%d" % int(round(float(_settings.get("volumetric_fog_volume_size", 256))))
-	_fog_depth_value_label.text = "%.1f" % float(_settings.get("volumetric_fog_depth", 64.0))
-	_light_fog_energy_value_label.text = "%.2f" % float(_settings.get("light_volumetric_fog_energy", 1.0))
+	_fog_depth_value_label.text = "%.1f" % float(_settings.get("volumetric_fog_depth", 128.0))
+	_light_fog_energy_value_label.text = "%.2f" % float(_settings.get("light_volumetric_fog_energy", 3.5))
 	_gobo_scale_value_label.text = "%.2f" % float(_settings.get("gobo_scale_ratio", 1.0))
 
 func _emit_settings_changed() -> void:

--- a/peraviz/scripts/visual_settings_window.gd
+++ b/peraviz/scripts/visual_settings_window.gd
@@ -22,6 +22,7 @@ const DEFAULT_SETTINGS := {
 	"gobo_debug_log_parameters": false,
 	"gobo_debug_log_volumetric_details": false,
 	"gobo_projection_mode": "shadow_cookie",
+	"gobo_beam_visibility_mode": "fog_shadow",
 	"volumetric_fog_volume_size": 256,
 	"volumetric_fog_depth": 64.0,
 	"volumetric_fog_use_filter": true,
@@ -51,6 +52,7 @@ var _background_picker: ColorPickerButton
 var _beam_render_mode_option: OptionButton
 var _beam_quality_option: OptionButton
 var _gobo_projection_option: OptionButton
+var _gobo_beam_visibility_option: OptionButton
 
 func _init() -> void:
 	title = "Visual Settings"
@@ -100,6 +102,7 @@ func _build_ui() -> void:
 	_beam_render_mode_option = _add_option_row(container, "Beam rendering", ["Volumetric (default)", "Lightweight (legacy)"], _on_beam_render_mode_selected)
 	_beam_quality_option = _add_option_row(container, "Beam quality", ["Low", "Medium", "High"], _on_beam_quality_selected)
 	_gobo_projection_option = _add_option_row(container, "Gobo projection", ["Shadow cookie", "Projector cookie"], _on_gobo_projection_selected)
+	_gobo_beam_visibility_option = _add_option_row(container, "Gobo beam visibility", ["Fog shadow (recommended)", "Geometry shader fallback"], _on_gobo_beam_visibility_selected)
 	_add_toggle_row(container, "Debug gobo occluder", "gobo_debug_show_occluder")
 	_add_toggle_row(container, "Log gobo parameters", "gobo_debug_log_parameters")
 	_add_toggle_row(container, "Log volumetric internals", "gobo_debug_log_volumetric_details")
@@ -223,6 +226,8 @@ func _apply_settings_to_controls() -> void:
 	_beam_quality_option.select(clamp(int(_settings.get("beam_quality", 1)), 0, 2))
 	var mode_name: String = str(_settings.get("gobo_projection_mode", "shadow_cookie")).to_lower()
 	_gobo_projection_option.select(1 if mode_name == "projector_cookie" else 0)
+	var gobo_beam_visibility_mode: String = str(_settings.get("gobo_beam_visibility_mode", "fog_shadow")).to_lower()
+	_gobo_beam_visibility_option.select(1 if gobo_beam_visibility_mode == "geometry_shader" else 0)
 	_background_picker.color = _settings.get("background_color", DEFAULT_SETTINGS["background_color"])
 	_update_value_labels()
 
@@ -252,6 +257,10 @@ func _on_beam_quality_selected(index: int) -> void:
 
 func _on_gobo_projection_selected(index: int) -> void:
 	_settings["gobo_projection_mode"] = "projector_cookie" if index == 1 else "shadow_cookie"
+	_emit_settings_changed()
+
+func _on_gobo_beam_visibility_selected(index: int) -> void:
+	_settings["gobo_beam_visibility_mode"] = "geometry_shader" if index == 1 else "fog_shadow"
 	_emit_settings_changed()
 
 func _update_value_labels() -> void:

--- a/peraviz/scripts/visual_settings_window.gd
+++ b/peraviz/scripts/visual_settings_window.gd
@@ -15,8 +15,8 @@ const DEFAULT_SETTINGS := {
 	"beam_anisotropy": 0.62,
 	"beam_noise_amount": 0.06,
 	"beam_noise_scale": 1.4,
-	"volumetric_fog_density": 0.02,
-	"light_volumetric_fog_energy": 3.5,
+	"volumetric_fog_density": 0.007,
+	"light_volumetric_fog_energy": 1.6,
 	"gobo_scale_ratio": 1.0,
 	"gobo_debug_show_occluder": false,
 	"gobo_debug_log_parameters": false,
@@ -24,8 +24,8 @@ const DEFAULT_SETTINGS := {
 	"gobo_projection_mode": "shadow_cookie",
 	"gobo_beam_visibility_mode": "fog_shadow",
 	"volumetric_fog_volume_size": 256,
-	"volumetric_fog_depth": 128.0,
-	"volumetric_fog_use_filter": false,
+	"volumetric_fog_depth": 96.0,
+	"volumetric_fog_use_filter": true,
 	"background_color": Color(0.129412, 0.137255, 0.156863, 1.0),
 }
 
@@ -97,7 +97,7 @@ func _build_ui() -> void:
 	_fog_density_slider = _add_slider_row(container, "Volumetric fog density", "volumetric_fog_density", 0.0, 0.08, 0.001)
 	_fog_volume_size_slider = _add_slider_row(container, "Fog volume size", "volumetric_fog_volume_size", 64.0, 512.0, 32.0)
 	_fog_depth_slider = _add_slider_row(container, "Fog volume depth", "volumetric_fog_depth", 16.0, 256.0, 4.0)
-	_light_fog_energy_slider = _add_slider_row(container, "Light fog energy", "light_volumetric_fog_energy", 0.0, 5000.0, 5.0)
+	_light_fog_energy_slider = _add_slider_row(container, "Light fog energy", "light_volumetric_fog_energy", 0.0, 200.0, 0.1)
 	_gobo_scale_slider = _add_slider_row(container, "Gobo scale ratio", "gobo_scale_ratio", 0.2, 2.5, 0.01)
 	_beam_render_mode_option = _add_option_row(container, "Beam rendering", ["Volumetric (default)", "Lightweight (legacy)"], _on_beam_render_mode_selected)
 	_beam_quality_option = _add_option_row(container, "Beam quality", ["Low", "Medium", "High"], _on_beam_quality_selected)
@@ -217,10 +217,10 @@ func _apply_settings_to_controls() -> void:
 	_spot_slider.value = float(_settings.get("spot_multiplier", 1.0))
 	_beam_slider.value = float(_settings.get("beam_multiplier", 1.0))
 	_bloom_slider.value = float(_settings.get("bloom_multiplier", 1.0))
-	_fog_density_slider.value = float(_settings.get("volumetric_fog_density", 0.02))
+	_fog_density_slider.value = float(_settings.get("volumetric_fog_density", 0.007))
 	_fog_volume_size_slider.value = float(_settings.get("volumetric_fog_volume_size", 256))
-	_fog_depth_slider.value = float(_settings.get("volumetric_fog_depth", 128.0))
-	_light_fog_energy_slider.value = float(_settings.get("light_volumetric_fog_energy", 3.5))
+	_fog_depth_slider.value = float(_settings.get("volumetric_fog_depth", 96.0))
+	_light_fog_energy_slider.value = float(_settings.get("light_volumetric_fog_energy", 1.6))
 	_gobo_scale_slider.value = float(_settings.get("gobo_scale_ratio", 1.0))
 	_beam_render_mode_option.select(clamp(int(_settings.get("beam_render_mode", 0)), 0, 1))
 	_beam_quality_option.select(clamp(int(_settings.get("beam_quality", 1)), 0, 2))
@@ -268,10 +268,10 @@ func _update_value_labels() -> void:
 	_spot_value_label.text = "%.2f" % float(_settings.get("spot_multiplier", 1.0))
 	_beam_value_label.text = "%.2f" % float(_settings.get("beam_multiplier", 1.0))
 	_bloom_value_label.text = "%.2f" % float(_settings.get("bloom_multiplier", 1.0))
-	_fog_density_value_label.text = "%.3f" % float(_settings.get("volumetric_fog_density", 0.02))
+	_fog_density_value_label.text = "%.3f" % float(_settings.get("volumetric_fog_density", 0.007))
 	_fog_volume_size_value_label.text = "%d" % int(round(float(_settings.get("volumetric_fog_volume_size", 256))))
-	_fog_depth_value_label.text = "%.1f" % float(_settings.get("volumetric_fog_depth", 128.0))
-	_light_fog_energy_value_label.text = "%.2f" % float(_settings.get("light_volumetric_fog_energy", 3.5))
+	_fog_depth_value_label.text = "%.1f" % float(_settings.get("volumetric_fog_depth", 96.0))
+	_light_fog_energy_value_label.text = "%.2f" % float(_settings.get("light_volumetric_fog_energy", 1.6))
 	_gobo_scale_value_label.text = "%.2f" % float(_settings.get("gobo_scale_ratio", 1.0))
 
 func _emit_settings_changed() -> void:

--- a/peraviz/scripts/visual_settings_window.gd
+++ b/peraviz/scripts/visual_settings_window.gd
@@ -23,7 +23,7 @@ const DEFAULT_SETTINGS := {
 	"gobo_debug_log_volumetric_details": false,
 	"gobo_projection_mode": "shadow_cookie",
 	"gobo_beam_visibility_mode": "fog_shadow",
-	"volumetric_fog_volume_size": 256,
+	"volumetric_fog_volume_size": 512,
 	"volumetric_fog_depth": 96.0,
 	"volumetric_fog_use_filter": true,
 	"background_color": Color(0.129412, 0.137255, 0.156863, 1.0),
@@ -95,7 +95,7 @@ func _build_ui() -> void:
 	_beam_slider = _add_slider_row(container, "Beam intensity", "beam_multiplier", 0.0, 8.0, 0.01)
 	_bloom_slider = _add_slider_row(container, "Bloom", "bloom_multiplier", 0.0, 3.0, 0.01)
 	_fog_density_slider = _add_slider_row(container, "Volumetric fog density", "volumetric_fog_density", 0.0, 0.08, 0.001)
-	_fog_volume_size_slider = _add_slider_row(container, "Fog volume size", "volumetric_fog_volume_size", 64.0, 512.0, 32.0)
+	_fog_volume_size_slider = _add_slider_row(container, "Fog volume size", "volumetric_fog_volume_size", 64.0, 1024.0, 32.0)
 	_fog_depth_slider = _add_slider_row(container, "Fog volume depth", "volumetric_fog_depth", 16.0, 256.0, 4.0)
 	_light_fog_energy_slider = _add_slider_row(container, "Light fog energy", "light_volumetric_fog_energy", 0.0, 200.0, 0.1)
 	_gobo_scale_slider = _add_slider_row(container, "Gobo scale ratio", "gobo_scale_ratio", 0.2, 2.5, 0.01)
@@ -218,7 +218,7 @@ func _apply_settings_to_controls() -> void:
 	_beam_slider.value = float(_settings.get("beam_multiplier", 1.0))
 	_bloom_slider.value = float(_settings.get("bloom_multiplier", 1.0))
 	_fog_density_slider.value = float(_settings.get("volumetric_fog_density", 0.007))
-	_fog_volume_size_slider.value = float(_settings.get("volumetric_fog_volume_size", 256))
+	_fog_volume_size_slider.value = float(_settings.get("volumetric_fog_volume_size", 512))
 	_fog_depth_slider.value = float(_settings.get("volumetric_fog_depth", 96.0))
 	_light_fog_energy_slider.value = float(_settings.get("light_volumetric_fog_energy", 1.6))
 	_gobo_scale_slider.value = float(_settings.get("gobo_scale_ratio", 1.0))
@@ -269,7 +269,7 @@ func _update_value_labels() -> void:
 	_beam_value_label.text = "%.2f" % float(_settings.get("beam_multiplier", 1.0))
 	_bloom_value_label.text = "%.2f" % float(_settings.get("bloom_multiplier", 1.0))
 	_fog_density_value_label.text = "%.3f" % float(_settings.get("volumetric_fog_density", 0.007))
-	_fog_volume_size_value_label.text = "%d" % int(round(float(_settings.get("volumetric_fog_volume_size", 256))))
+	_fog_volume_size_value_label.text = "%d" % int(round(float(_settings.get("volumetric_fog_volume_size", 512))))
 	_fog_depth_value_label.text = "%.1f" % float(_settings.get("volumetric_fog_depth", 96.0))
 	_light_fog_energy_value_label.text = "%.2f" % float(_settings.get("light_volumetric_fog_energy", 1.6))
 	_gobo_scale_value_label.text = "%.2f" % float(_settings.get("gobo_scale_ratio", 1.0))

--- a/peraviz/test.tscn
+++ b/peraviz/test.tscn
@@ -46,7 +46,7 @@ script = ExtResource("2_camera_script")
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="." unique_id=426373555]
 transform = Transform3D(0.8480481, -0.41758206, 0.32625088, 0, 0.6156615, 0.7880107, -0.52991927, -0.668271, 0.5221106, 0, 0, 0)
 light_angular_distance = 0.35
-shadow_enabled = true
+shadow_enabled = false
 shadow_bias = 0.015
 shadow_normal_bias = 0.7
 directional_shadow_split_1 = 0.08


### PR DESCRIPTION
### Motivation
- Godot stable does not apply `Light3D.light_projector` into volumetric fog, so Peraviz must keep a robust shadow-occluder default while offering a geometry fallback; this change separates that decision logic from renderer code.
- Make occluder sizing and visibility strategy explicit so future changes (engine patches or custom builds) can be integrated with minimal surface changes.

### Description
- Added a new helper `GoboBeamVisibilityPolicy` (`peraviz/scripts/beam_renderers/gobo_beam_visibility_policy.gd`) that resolves the beam visibility strategy (`fog_shadow` vs `geometry_shader`) and computes the physical occluder plane size from `beam_angle` and `gobo_scale_ratio`.
- Updated `VolumetricBeamRenderer` (`peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd`) to delegate visibility and sizing to the new policy, to enable/disable the near-lens quad occluder and to switch cone shader usage according to the resolved strategy.
- Added a runtime visual setting `gobo_beam_visibility_mode` and wired it into `load_scene.gd` (`peraviz/scripts/load_scene.gd`) so attenuation/shadow-cookie behavior is only applied when the fog-shadow strategy is active; beam parameter propagation was extended to carry the selected visibility mode.
- Extended the Visual Settings UI (`peraviz/scripts/visual_settings_window.gd`) with a `Gobo beam visibility` option exposing: `Fog shadow (recommended)` and `Geometry shader fallback` so users can toggle the rendering strategy at runtime.

### Testing
- Ran mandatory repository checks: `tests/check_perastage_tree_modules.sh` (OK) and `tests/check_no_configmanager_get_in_gui.sh` (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a71eb44c6c8324970e362186789bdf)