### PR TITLE
Peraviz: enable gobo projection on spot lights and volumetric beams

### DIFF
--- a/peraviz/README_gobos.md
+++ b/peraviz/README_gobos.md
@@ -22,9 +22,9 @@ This document summarizes how Peraviz parses and loads gobo data from GDTF fixtur
 
 ## Runtime loading behavior
 
-- Runtime still resolves the active gobo slot from DMX values.
-- Slot textures are loaded and cached for each fixture.
-- When media is missing or invalid, a temporary fallback gobo texture can be generated for DMX/debug validation.
+- Runtime resolves the active gobo slot from DMX values.
+- Slot textures are loaded and cached per fixture.
+- When media is missing or invalid, a temporary fallback gobo texture is generated for DMX/debug validation.
 - When multiple gobo wheels are active, Peraviz composes them into one cached texture by multiplying masks.
-
-> Note: projection/emission logic was intentionally removed from Peraviz runtime. The loaded textures remain available in fixture metadata for upcoming refactors.
+- The composed texture is applied to `SpotLight3D` projector data (engine property detection keeps compatibility across Godot versions).
+- The same texture is also sent to the volumetric beam shader, which performs projector-style UV reconstruction inside the cone to approximate fog gobo projection.

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -5,8 +5,10 @@ class_name VolumetricBeamRenderer
 const BEAM_META_KEY: String = "peraviz_volumetric_beam"
 const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 10.0
 const VOLUMETRIC_INTENSITY_SCALE: float = 0.75
-const GOBO_UV_SCALE_MIN: float = 0.1
-const GOBO_UV_SCALE_MAX: float = 12.0
+const GOBO_UV_SCALE_MIN: float = 0.35
+const GOBO_UV_SCALE_MAX: float = 4.0
+const GOBO_DEFAULT_STRENGTH: float = 0.7
+const GOBO_MIN_VISIBILITY: float = 0.22
 
 var _beam_material_template: ShaderMaterial
 var _camera: Camera3D
@@ -87,8 +89,11 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	cone.set_instance_shader_parameter("beam_quality", int(_settings.get("beam_quality", 1)))
 	var gobo_texture: Texture2D = params.get("gobo_texture", null) as Texture2D
 	cone.set_instance_shader_parameter("gobo_texture", gobo_texture)
-	cone.set_instance_shader_parameter("gobo_enabled", gobo_texture != null)
-	cone.set_instance_shader_parameter("gobo_uv_scale", clamp(tan_half_angle, GOBO_UV_SCALE_MIN, GOBO_UV_SCALE_MAX))
+	var has_gobo: bool = gobo_texture != null
+	cone.set_instance_shader_parameter("gobo_enabled", has_gobo)
+	cone.set_instance_shader_parameter("gobo_uv_scale", clamp(tan_half_angle * 2.0, GOBO_UV_SCALE_MIN, GOBO_UV_SCALE_MAX))
+	cone.set_instance_shader_parameter("gobo_strength", GOBO_DEFAULT_STRENGTH if has_gobo else 0.0)
+	cone.set_instance_shader_parameter("gobo_min_visibility", GOBO_MIN_VISIBILITY)
 
 func cleanup_beam(light: SpotLight3D) -> void:
 	if not light.has_meta(BEAM_META_KEY):

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -5,6 +5,8 @@ class_name VolumetricBeamRenderer
 const BEAM_META_KEY: String = "peraviz_volumetric_beam"
 const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 10.0
 const VOLUMETRIC_INTENSITY_SCALE: float = 0.75
+const GOBO_UV_SCALE_MIN: float = 0.1
+const GOBO_UV_SCALE_MAX: float = 12.0
 
 var _beam_material_template: ShaderMaterial
 var _camera: Camera3D
@@ -83,6 +85,10 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	cone.set_instance_shader_parameter("beam_haze_density", float(_settings.get("beam_haze_density", 0.17)))
 	cone.set_instance_shader_parameter("beam_anisotropy", float(_settings.get("beam_anisotropy", 0.62)))
 	cone.set_instance_shader_parameter("beam_quality", int(_settings.get("beam_quality", 1)))
+	var gobo_texture: Texture2D = params.get("gobo_texture", null) as Texture2D
+	cone.set_instance_shader_parameter("gobo_texture", gobo_texture)
+	cone.set_instance_shader_parameter("gobo_enabled", gobo_texture != null)
+	cone.set_instance_shader_parameter("gobo_uv_scale", clamp(tan_half_angle, GOBO_UV_SCALE_MIN, GOBO_UV_SCALE_MAX))
 
 func cleanup_beam(light: SpotLight3D) -> void:
 	if not light.has_meta(BEAM_META_KEY):

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -3,6 +3,7 @@ class_name FixtureGoboProjector
 
 const FAKE_GOBO_TEXTURE_SIZE: int = 1024
 const GOBO_TEXTURE_META_KEY: String = "peraviz_gobo_texture"
+const LIGHT_PROJECTOR_PROPERTY_CANDIDATES: PackedStringArray = PackedStringArray(["light_projector", "projector"])
 
 var _texture_cache: Dictionary = {}
 
@@ -16,6 +17,7 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 	if light.has_meta(GOBO_TEXTURE_META_KEY):
 		previous_meta_texture = light.get_meta(GOBO_TEXTURE_META_KEY) as Texture2D
 	if not bool(controls.get("has_gobo", false)):
+		_apply_light_projector_texture(light, null)
 		light.set_meta(GOBO_TEXTURE_META_KEY, null)
 		return previous_meta_texture != null
 
@@ -45,12 +47,26 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 			active_textures.append(gobo_texture)
 
 	if active_textures.is_empty():
+		_apply_light_projector_texture(light, null)
 		light.set_meta(GOBO_TEXTURE_META_KEY, null)
 		return previous_meta_texture != null
 
 	var composed_gobo: Texture2D = _compose_gobo_textures(active_textures)
+	_apply_light_projector_texture(light, composed_gobo)
 	light.set_meta(GOBO_TEXTURE_META_KEY, composed_gobo)
 	return composed_gobo != previous_meta_texture
+
+func _apply_light_projector_texture(light: SpotLight3D, projector_texture: Texture2D) -> void:
+	for property_name in LIGHT_PROJECTOR_PROPERTY_CANDIDATES:
+		if _has_property(light, property_name):
+			light.set(property_name, projector_texture)
+			return
+
+func _has_property(node: Object, property_name: String) -> bool:
+	for item in node.get_property_list():
+		if item is Dictionary and str(item.get("name", "")) == property_name:
+			return true
+	return false
 
 func _resolve_gobo_raw_8bit(controls: Dictionary) -> int:
 	var gobo_raw: int = int(round(clamp(float(controls.get("gobo_norm", 0.0)), 0.0, 1.0) * 255.0))

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -3,7 +3,7 @@ class_name FixtureGoboProjector
 
 const FAKE_GOBO_TEXTURE_SIZE: int = 1024
 const GOBO_TEXTURE_META_KEY: String = "peraviz_gobo_texture"
-const LIGHT_PROJECTOR_PROPERTY_CANDIDATES: PackedStringArray = PackedStringArray(["light_projector", "projector"])
+const LIGHT_PROJECTOR_PROPERTY_CANDIDATES: Array[String] = ["light_projector", "projector"]
 
 var _texture_cache: Dictionary = {}
 

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -1650,6 +1650,8 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 	}
 	if _fixture_gobo_projector != null:
 		_fixture_gobo_projector.apply_gobo_projection(light, controls)
+	if light.has_meta(FixtureGoboProjector.GOBO_TEXTURE_META_KEY):
+		beam_params["gobo_texture"] = light.get_meta(FixtureGoboProjector.GOBO_TEXTURE_META_KEY)
 	light.light_volumetric_fog_energy = float(_visual_settings.get("light_volumetric_fog_energy", 1.0))
 	_update_beam_for_light(light, beam_params)
 

--- a/peraviz/scripts/shaders/volumetric_beam.gdshader
+++ b/peraviz/scripts/shaders/volumetric_beam.gdshader
@@ -2,6 +2,9 @@ shader_type spatial;
 render_mode unshaded, blend_add, cull_disabled, depth_draw_never;
 
 uniform sampler2D DEPTH_TEXTURE : hint_depth_texture, filter_linear_mipmap;
+uniform sampler2D gobo_texture : source_color, filter_linear_mipmap, repeat_disable;
+instance uniform bool gobo_enabled = false;
+instance uniform float gobo_uv_scale : hint_range(0.1, 12.0) = 1.0;
 
 instance uniform vec4 base_color : source_color = vec4(1.0, 0.95, 0.85, 0.5);
 uniform float falloff_power : hint_range(0.1, 10.0) = 8.0;
@@ -21,10 +24,12 @@ uniform float depth_fade_distance : hint_range(0.01, 5.0) = 0.5;
 
 varying vec3 v_view;
 varying vec3 v_local;
+varying vec3 v_world_pos;
 
 void vertex() {
 	v_local = VERTEX;
 	v_view = (MODELVIEW_MATRIX * vec4(VERTEX, 1.0)).xyz;
+	v_world_pos = (MODEL_MATRIX * vec4(VERTEX, 1.0)).xyz;
 	POSITION = PROJECTION_MATRIX * vec4(v_view, 1.0);
 }
 
@@ -52,6 +57,20 @@ void fragment() {
 
 	float brightness = min(base_brightness * facing_multiplier, max_brightness);
 	float feather_alpha = mix(1.0 - feather_intensity, 1.0, pow(ndotv, feather_sharpness));
+	float gobo_mask = 1.0;
+	if (gobo_enabled) {
+		vec3 light_to_point_world = v_world_pos - (MODEL_MATRIX * vec4(0.0, 0.0, 0.0, 1.0)).xyz;
+		vec3 local_light_dir = normalize((inverse(mat3(MODEL_MATRIX)) * light_to_point_world));
+		float dir_z = max(-local_light_dir.z, 0.0001);
+		vec2 gobo_uv = (local_light_dir.xy / dir_z) / max(gobo_uv_scale, 0.0001);
+		gobo_uv = (gobo_uv * 0.5) + vec2(0.5);
+		if (gobo_uv.x < 0.0 || gobo_uv.x > 1.0 || gobo_uv.y < 0.0 || gobo_uv.y > 1.0) {
+			gobo_mask = 0.0;
+		} else {
+			vec3 gobo_color = texture(gobo_texture, gobo_uv).rgb;
+			gobo_mask = dot(gobo_color, vec3(0.299, 0.587, 0.114));
+		}
+	}
 
 	float depth_mult = 1.0;
 	if (depth_feather_enabled) {
@@ -64,7 +83,7 @@ void fragment() {
 		}
 	}
 
-	float final_alpha = feather_alpha * depth_mult * dist_fade;
+	float final_alpha = feather_alpha * depth_mult * dist_fade * gobo_mask;
 	if (final_alpha < 0.001) {
 		discard;
 	}

--- a/peraviz/scripts/shaders/volumetric_beam.gdshader
+++ b/peraviz/scripts/shaders/volumetric_beam.gdshader
@@ -59,7 +59,7 @@ void fragment() {
 	float feather_alpha = mix(1.0 - feather_intensity, 1.0, pow(ndotv, feather_sharpness));
 	float gobo_mask = 1.0;
 	if (gobo_enabled) {
-		float projector_depth = max(v_local.y + (cone_height * 0.5), 0.001);
+		float projector_depth = max(abs(v_local.y), 0.001);
 		vec2 radial = v_local.xz / projector_depth;
 		vec2 gobo_uv = (radial / max(gobo_uv_scale, 0.0001)) * 0.5 + vec2(0.5);
 		if (gobo_uv.x >= 0.0 && gobo_uv.x <= 1.0 && gobo_uv.y >= 0.0 && gobo_uv.y <= 1.0) {

--- a/peraviz/scripts/shaders/volumetric_beam.gdshader
+++ b/peraviz/scripts/shaders/volumetric_beam.gdshader
@@ -5,6 +5,8 @@ uniform sampler2D DEPTH_TEXTURE : hint_depth_texture, filter_linear_mipmap;
 uniform sampler2D gobo_texture : source_color, filter_linear_mipmap, repeat_disable;
 instance uniform bool gobo_enabled = false;
 instance uniform float gobo_uv_scale : hint_range(0.1, 12.0) = 1.0;
+instance uniform float gobo_strength : hint_range(0.0, 1.0) = 0.8;
+instance uniform float gobo_min_visibility : hint_range(0.0, 1.0) = 0.25;
 
 instance uniform vec4 base_color : source_color = vec4(1.0, 0.95, 0.85, 0.5);
 uniform float falloff_power : hint_range(0.1, 10.0) = 8.0;
@@ -24,12 +26,10 @@ uniform float depth_fade_distance : hint_range(0.01, 5.0) = 0.5;
 
 varying vec3 v_view;
 varying vec3 v_local;
-varying vec3 v_world_pos;
 
 void vertex() {
 	v_local = VERTEX;
 	v_view = (MODELVIEW_MATRIX * vec4(VERTEX, 1.0)).xyz;
-	v_world_pos = (MODEL_MATRIX * vec4(VERTEX, 1.0)).xyz;
 	POSITION = PROJECTION_MATRIX * vec4(v_view, 1.0);
 }
 
@@ -59,16 +59,14 @@ void fragment() {
 	float feather_alpha = mix(1.0 - feather_intensity, 1.0, pow(ndotv, feather_sharpness));
 	float gobo_mask = 1.0;
 	if (gobo_enabled) {
-		vec3 light_to_point_world = v_world_pos - (MODEL_MATRIX * vec4(0.0, 0.0, 0.0, 1.0)).xyz;
-		vec3 local_light_dir = normalize((inverse(mat3(MODEL_MATRIX)) * light_to_point_world));
-		float dir_z = max(-local_light_dir.z, 0.0001);
-		vec2 gobo_uv = (local_light_dir.xy / dir_z) / max(gobo_uv_scale, 0.0001);
-		gobo_uv = (gobo_uv * 0.5) + vec2(0.5);
-		if (gobo_uv.x < 0.0 || gobo_uv.x > 1.0 || gobo_uv.y < 0.0 || gobo_uv.y > 1.0) {
-			gobo_mask = 0.0;
-		} else {
+		float projector_depth = max(v_local.y + (cone_height * 0.5), 0.001);
+		vec2 radial = v_local.xz / projector_depth;
+		vec2 gobo_uv = (radial / max(gobo_uv_scale, 0.0001)) * 0.5 + vec2(0.5);
+		if (gobo_uv.x >= 0.0 && gobo_uv.x <= 1.0 && gobo_uv.y >= 0.0 && gobo_uv.y <= 1.0) {
 			vec3 gobo_color = texture(gobo_texture, gobo_uv).rgb;
-			gobo_mask = dot(gobo_color, vec3(0.299, 0.587, 0.114));
+			float sampled_luma = dot(gobo_color, vec3(0.299, 0.587, 0.114));
+			float protected_luma = max(sampled_luma, clamp(gobo_min_visibility, 0.0, 1.0));
+			gobo_mask = mix(1.0, protected_luma, clamp(gobo_strength, 0.0, 1.0));
 		}
 	}
 


### PR DESCRIPTION
### Motivation
- Bring projector-style gobo projection into Peraviz by adapting the fog-light-projectors idea at the project/script/shader level so no custom engine build is required.
- Allow composed gobo textures (from GDTF wheels) to actually drive spotlight projector properties and approximate projection into volumetric beams for fog/gobo effects.

### Description
- `peraviz/scripts/fixture_gobo_projector.gd` now detects common spotlight projector properties (`light_projector`, `projector`) and sets/clears them when a composed gobo texture is produced or removed, plus helper functions for runtime property detection (`_apply_light_projector_texture`, `_has_property`).
- `peraviz/scripts/load_scene.gd` forwards the composed gobo texture from spotlight meta into beam parameters by adding a `gobo_texture` entry on the `beam_params` dictionary when available.
- `peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd` reads `gobo_texture` from `beam_params` and sets shader instance uniforms (`gobo_texture`, `gobo_enabled`, `gobo_uv_scale`) to drive the volumetric beam material.
- `peraviz/scripts/shaders/volumetric_beam.gdshader` adds a `gobo_texture` uniform and `gobo_enabled`/`gobo_uv_scale` instance uniforms and reconstructs projector-style UVs inside the cone to sample the gobo mask and modulate the final beam alpha by the sampled luminance.
- `peraviz/README_gobos.md` was updated to document that composed textures are applied to `SpotLight3D` projector data and sent to the volumetric beam shader for an approximation of fog gobo projection.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a833defc8c83249ae04a556d2bc298)