### PR TITLE
peraviz: render DMX gobos with projector and alpha quad mesh

### DIFF
--- a/peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd
@@ -12,6 +12,7 @@ const EMITTER_CONE_FAR_EMISSION: float = 0.04
 const MAIN_KEY: String = "peraviz_beam_cone"
 const MID_KEY: String = "peraviz_beam_cone_mid"
 const CORE_KEY: String = "peraviz_beam_cone_core"
+const GOBO_TEXTURE_META_KEY: String = "peraviz_gobo_texture"
 
 var _shared_material: ShaderMaterial
 
@@ -54,6 +55,15 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 		core_cone.visible = is_visible
 	if not is_visible:
 		return
+	if light.has_meta(GOBO_TEXTURE_META_KEY):
+		if cone != null:
+			cone.visible = false
+		if mid_cone != null:
+			mid_cone.visible = false
+		if core_cone != null:
+			core_cone.visible = false
+		return
+
 
 	var beam_half_angle_deg: float = beam_angle * 0.5
 	var radius: float = tan(deg_to_rad(beam_half_angle_deg)) * beam_range

--- a/peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd
@@ -12,7 +12,6 @@ const EMITTER_CONE_FAR_EMISSION: float = 0.04
 const MAIN_KEY: String = "peraviz_beam_cone"
 const MID_KEY: String = "peraviz_beam_cone_mid"
 const CORE_KEY: String = "peraviz_beam_cone_core"
-const GOBO_TEXTURE_META_KEY: String = "peraviz_gobo_texture"
 
 var _shared_material: ShaderMaterial
 
@@ -55,15 +54,6 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 		core_cone.visible = is_visible
 	if not is_visible:
 		return
-	if light.has_meta(GOBO_TEXTURE_META_KEY):
-		if cone != null:
-			cone.visible = false
-		if mid_cone != null:
-			mid_cone.visible = false
-		if core_cone != null:
-			core_cone.visible = false
-		return
-
 
 	var beam_half_angle_deg: float = beam_angle * 0.5
 	var radius: float = tan(deg_to_rad(beam_half_angle_deg)) * beam_range

--- a/peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd
@@ -12,6 +12,7 @@ const EMITTER_CONE_FAR_EMISSION: float = 0.04
 const MAIN_KEY: String = "peraviz_beam_cone"
 const MID_KEY: String = "peraviz_beam_cone_mid"
 const CORE_KEY: String = "peraviz_beam_cone_core"
+const GOBO_TEXTURE_META_KEY: String = "peraviz_gobo_texture"
 
 var _shared_material: ShaderMaterial
 
@@ -54,6 +55,16 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 		core_cone.visible = is_visible
 	if not is_visible:
 		return
+	var native_fog_projector_enabled: bool = bool(params.get("use_native_fog_projector_gobos", true))
+	if native_fog_projector_enabled and light.has_meta(GOBO_TEXTURE_META_KEY):
+		if cone != null:
+			cone.visible = false
+		if mid_cone != null:
+			mid_cone.visible = false
+		if core_cone != null:
+			core_cone.visible = false
+		return
+
 
 	var beam_half_angle_deg: float = beam_angle * 0.5
 	var radius: float = tan(deg_to_rad(beam_half_angle_deg)) * beam_range

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -5,7 +5,6 @@ class_name VolumetricBeamRenderer
 const BEAM_META_KEY: String = "peraviz_volumetric_beam"
 const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 10.0
 const VOLUMETRIC_INTENSITY_SCALE: float = 0.75
-const GOBO_TEXTURE_META_KEY: String = "peraviz_gobo_texture"
 
 var _beam_material_template: ShaderMaterial
 var _camera: Camera3D
@@ -84,12 +83,6 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	cone.set_instance_shader_parameter("beam_haze_density", float(_settings.get("beam_haze_density", 0.17)))
 	cone.set_instance_shader_parameter("beam_anisotropy", float(_settings.get("beam_anisotropy", 0.62)))
 	cone.set_instance_shader_parameter("beam_quality", int(_settings.get("beam_quality", 1)))
-	cone.set_instance_shader_parameter("gobo_enabled", light.has_meta(GOBO_TEXTURE_META_KEY))
-	if light.has_meta(GOBO_TEXTURE_META_KEY):
-		var gobo_texture: Texture2D = light.get_meta(GOBO_TEXTURE_META_KEY) as Texture2D
-		cone.set_instance_shader_parameter("gobo_texture", gobo_texture)
-	else:
-		cone.set_instance_shader_parameter("gobo_texture", null)
 
 func cleanup_beam(light: SpotLight3D) -> void:
 	if not light.has_meta(BEAM_META_KEY):

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -5,6 +5,7 @@ class_name VolumetricBeamRenderer
 const BEAM_META_KEY: String = "peraviz_volumetric_beam"
 const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 10.0
 const VOLUMETRIC_INTENSITY_SCALE: float = 0.75
+const GOBO_TEXTURE_META_KEY: String = "peraviz_gobo_texture"
 
 var _beam_material_template: ShaderMaterial
 var _camera: Camera3D
@@ -83,6 +84,12 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	cone.set_instance_shader_parameter("beam_haze_density", float(_settings.get("beam_haze_density", 0.17)))
 	cone.set_instance_shader_parameter("beam_anisotropy", float(_settings.get("beam_anisotropy", 0.62)))
 	cone.set_instance_shader_parameter("beam_quality", int(_settings.get("beam_quality", 1)))
+	cone.set_instance_shader_parameter("gobo_enabled", light.has_meta(GOBO_TEXTURE_META_KEY))
+	if light.has_meta(GOBO_TEXTURE_META_KEY):
+		var gobo_texture: Texture2D = light.get_meta(GOBO_TEXTURE_META_KEY) as Texture2D
+		cone.set_instance_shader_parameter("gobo_texture", gobo_texture)
+	else:
+		cone.set_instance_shader_parameter("gobo_texture", null)
 
 func cleanup_beam(light: SpotLight3D) -> void:
 	if not light.has_meta(BEAM_META_KEY):

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -5,6 +5,7 @@ class_name VolumetricBeamRenderer
 const BEAM_META_KEY: String = "peraviz_volumetric_beam"
 const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 10.0
 const VOLUMETRIC_INTENSITY_SCALE: float = 0.75
+const GOBO_TEXTURE_META_KEY: String = "peraviz_gobo_texture"
 
 var _beam_material_template: ShaderMaterial
 var _camera: Camera3D
@@ -84,6 +85,13 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	cone.set_instance_shader_parameter("beam_haze_density", float(_settings.get("beam_haze_density", 0.17)))
 	cone.set_instance_shader_parameter("beam_anisotropy", float(_settings.get("beam_anisotropy", 0.62)))
 	cone.set_instance_shader_parameter("beam_quality", int(_settings.get("beam_quality", 1)))
+	var has_gobo: bool = light.has_meta(GOBO_TEXTURE_META_KEY)
+	cone.set_instance_shader_parameter("gobo_enabled", has_gobo)
+	if has_gobo:
+		var gobo_texture: Texture2D = light.get_meta(GOBO_TEXTURE_META_KEY) as Texture2D
+		cone.set_instance_shader_parameter("gobo_texture", gobo_texture)
+	else:
+		cone.set_instance_shader_parameter("gobo_texture", null)
 
 func cleanup_beam(light: SpotLight3D) -> void:
 	if not light.has_meta(BEAM_META_KEY):

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -5,7 +5,6 @@ class_name VolumetricBeamRenderer
 const BEAM_META_KEY: String = "peraviz_volumetric_beam"
 const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 10.0
 const VOLUMETRIC_INTENSITY_SCALE: float = 0.75
-const GOBO_TEXTURE_META_KEY: String = "peraviz_gobo_texture"
 
 var _beam_material_template: ShaderMaterial
 var _camera: Camera3D
@@ -55,9 +54,6 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 		cone.visible = false
 		return
 
-	if light.has_meta(GOBO_TEXTURE_META_KEY):
-		cone.visible = false
-		return
 
 	var beam_color: Color = params.get("beam_color", Color.WHITE)
 	var lens_radius: float = max(float(params.get("lens_radius", 0.03)), 0.005)

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -5,6 +5,7 @@ class_name VolumetricBeamRenderer
 const BEAM_META_KEY: String = "peraviz_volumetric_beam"
 const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 10.0
 const VOLUMETRIC_INTENSITY_SCALE: float = 0.75
+const GOBO_TEXTURE_META_KEY: String = "peraviz_gobo_texture"
 
 var _beam_material_template: ShaderMaterial
 var _camera: Camera3D
@@ -51,6 +52,10 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	var beam_angle: float = max(float(params.get("beam_angle", 1.0)), 0.1)
 
 	if not bool(params.get("is_visible", true)) or intensity <= threshold:
+		cone.visible = false
+		return
+
+	if light.has_meta(GOBO_TEXTURE_META_KEY):
 		cone.visible = false
 		return
 

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -90,6 +90,8 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	if has_gobo:
 		var gobo_texture: Texture2D = light.get_meta(GOBO_TEXTURE_META_KEY) as Texture2D
 		cone.set_instance_shader_parameter("gobo_texture", gobo_texture)
+		cone.set_instance_shader_parameter("gobo_threshold", float(_settings.get("gobo_beam_threshold", 0.5)))
+		cone.set_instance_shader_parameter("gobo_softness", float(_settings.get("gobo_beam_softness", 0.0)))
 	else:
 		cone.set_instance_shader_parameter("gobo_texture", null)
 

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -5,6 +5,7 @@ class_name VolumetricBeamRenderer
 const BEAM_META_KEY: String = "peraviz_volumetric_beam"
 const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 10.0
 const VOLUMETRIC_INTENSITY_SCALE: float = 0.75
+const GOBO_TEXTURE_META_KEY: String = "peraviz_gobo_texture"
 
 var _beam_material_template: ShaderMaterial
 var _camera: Camera3D
@@ -51,6 +52,11 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	var beam_angle: float = max(float(params.get("beam_angle", 1.0)), 0.1)
 
 	if not bool(params.get("is_visible", true)) or intensity <= threshold:
+		cone.visible = false
+		return
+
+	var native_fog_projector_enabled: bool = bool(_settings.get("use_native_fog_projector_gobos", true))
+	if native_fog_projector_enabled and light.has_meta(GOBO_TEXTURE_META_KEY):
 		cone.visible = false
 		return
 

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -5,7 +5,6 @@ class_name VolumetricBeamRenderer
 const BEAM_META_KEY: String = "peraviz_volumetric_beam"
 const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 10.0
 const VOLUMETRIC_INTENSITY_SCALE: float = 0.75
-const GOBO_TEXTURE_META_KEY: String = "peraviz_gobo_texture"
 
 var _beam_material_template: ShaderMaterial
 var _camera: Camera3D
@@ -86,17 +85,6 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	cone.set_instance_shader_parameter("beam_haze_density", float(_settings.get("beam_haze_density", 0.17)))
 	cone.set_instance_shader_parameter("beam_anisotropy", float(_settings.get("beam_anisotropy", 0.62)))
 	cone.set_instance_shader_parameter("beam_quality", int(_settings.get("beam_quality", 1)))
-	cone.set_instance_shader_parameter("gobo_top_radius", top_radius)
-	cone.set_instance_shader_parameter("gobo_bottom_radius", bottom_radius)
-	var has_gobo: bool = light.has_meta(GOBO_TEXTURE_META_KEY)
-	cone.set_instance_shader_parameter("gobo_enabled", has_gobo)
-	if has_gobo:
-		var gobo_texture: Texture2D = light.get_meta(GOBO_TEXTURE_META_KEY) as Texture2D
-		cone.set_instance_shader_parameter("gobo_texture", gobo_texture)
-		cone.set_instance_shader_parameter("gobo_threshold", float(_settings.get("gobo_beam_threshold", 0.5)))
-		cone.set_instance_shader_parameter("gobo_softness", float(_settings.get("gobo_beam_softness", 0.0)))
-	else:
-		cone.set_instance_shader_parameter("gobo_texture", null)
 
 func cleanup_beam(light: SpotLight3D) -> void:
 	if not light.has_meta(BEAM_META_KEY):

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -70,8 +70,9 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	var radius: float = tan_half_angle * beam_range
 	var bottom_radius: float = clamp(radius, 0.03, EMITTER_CONE_MAX_BASE_RADIUS_M)
 	var cone_mesh: CylinderMesh = cone.mesh as CylinderMesh
+	var top_radius: float = max(lens_radius, 0.003)
 	if cone_mesh != null:
-		cone_mesh.top_radius = max(lens_radius, 0.003)
+		cone_mesh.top_radius = top_radius
 		cone_mesh.bottom_radius = bottom_radius
 		cone_mesh.height = beam_range
 	cone.position = Vector3(0.0, 0.0, -beam_range * 0.5)
@@ -85,6 +86,8 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	cone.set_instance_shader_parameter("beam_haze_density", float(_settings.get("beam_haze_density", 0.17)))
 	cone.set_instance_shader_parameter("beam_anisotropy", float(_settings.get("beam_anisotropy", 0.62)))
 	cone.set_instance_shader_parameter("beam_quality", int(_settings.get("beam_quality", 1)))
+	cone.set_instance_shader_parameter("gobo_top_radius", top_radius)
+	cone.set_instance_shader_parameter("gobo_bottom_radius", bottom_radius)
 	var has_gobo: bool = light.has_meta(GOBO_TEXTURE_META_KEY)
 	cone.set_instance_shader_parameter("gobo_enabled", has_gobo)
 	if has_gobo:

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -11,6 +11,7 @@ const GOBO_MIN_ANGLE_DEG: float = 4.0
 const GOBO_MAX_ANGLE_DEG: float = 50.0
 const GOBO_MIN_SCALE: float = 0.555
 const GOBO_MAX_SCALE: float = 6.4
+const GOBO_APERTURE_SCALE: float = 0.95
 
 var _texture_cache: Dictionary = {}
 
@@ -115,10 +116,13 @@ func _remove_gobo_plane(light: SpotLight3D) -> void:
 func _update_gobo_plane_scale(light: SpotLight3D, gobo_plane: MeshInstance3D) -> void:
 	if light == null or gobo_plane == null:
 		return
-	var full_spot_angle_deg: float = clamp(light.spot_angle * 2.0, GOBO_MIN_ANGLE_DEG, GOBO_MAX_ANGLE_DEG)
-	var ratio: float = (full_spot_angle_deg - GOBO_MIN_ANGLE_DEG) / max(GOBO_MAX_ANGLE_DEG - GOBO_MIN_ANGLE_DEG, 0.001)
-	var plane_scale: float = lerp(GOBO_MIN_SCALE, GOBO_MAX_SCALE, ratio)
-	gobo_plane.scale = Vector3.ONE * plane_scale
+	var half_spot_angle_deg: float = clamp(light.spot_angle, GOBO_MIN_ANGLE_DEG * 0.5, GOBO_MAX_ANGLE_DEG * 0.5)
+	var local_distance: float = abs(GOBO_PLANE_LOCAL_Z)
+	var target_plane_size: float = 2.0 * local_distance * tan(deg_to_rad(half_spot_angle_deg)) * GOBO_APERTURE_SCALE
+	var base_size: float = max(GOBO_PLANE_MESH_SIZE.x, 0.0001)
+	var physical_scale: float = target_plane_size / base_size
+	var clamped_scale: float = clamp(physical_scale, GOBO_MIN_SCALE, GOBO_MAX_SCALE)
+	gobo_plane.scale = Vector3.ONE * clamped_scale
 
 func _resolve_gobo_raw_8bit(controls: Dictionary) -> int:
 	var gobo_raw: int = int(round(clamp(float(controls.get("gobo_norm", 0.0)), 0.0, 1.0) * 255.0))

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -11,7 +11,7 @@ const GOBO_MIN_ANGLE_DEG: float = 4.0
 const GOBO_MAX_ANGLE_DEG: float = 50.0
 const GOBO_MIN_SCALE: float = 0.555
 const GOBO_MAX_SCALE: float = 6.4
-const GOBO_APERTURE_SCALE: float = 1.00
+const GOBO_APERTURE_SCALE: float = 1.05
 
 var _texture_cache: Dictionary = {}
 

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -92,7 +92,7 @@ func _ensure_gobo_plane(light: SpotLight3D) -> MeshInstance3D:
 
 	var gobo_plane := MeshInstance3D.new()
 	gobo_plane.name = "PeravizGoboPlane"
-	gobo_plane.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_ON
+	gobo_plane.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_DOUBLE_SIDED
 	var quad := QuadMesh.new()
 	quad.size = GOBO_PLANE_MESH_SIZE
 	gobo_plane.mesh = quad

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -3,6 +3,14 @@ class_name FixtureGoboProjector
 
 const FAKE_GOBO_TEXTURE_SIZE: int = 1024
 const GOBO_TEXTURE_META_KEY: String = "peraviz_gobo_texture"
+const GOBO_PLANE_META_KEY: String = "peraviz_gobo_plane"
+const GOBO_SHADER_PATH: String = "res://scripts/shaders/gobo_alpha_projector.gdshader"
+const GOBO_PLANE_LOCAL_Z: float = -0.043
+const GOBO_PLANE_MESH_SIZE: Vector2 = Vector2(0.017, 0.017)
+const GOBO_MIN_ANGLE_DEG: float = 4.0
+const GOBO_MAX_ANGLE_DEG: float = 50.0
+const GOBO_MIN_SCALE: float = 0.555
+const GOBO_MAX_SCALE: float = 6.4
 
 var _texture_cache: Dictionary = {}
 
@@ -16,6 +24,7 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 	if light.has_meta(GOBO_TEXTURE_META_KEY):
 		previous_meta_texture = light.get_meta(GOBO_TEXTURE_META_KEY) as Texture2D
 	if not bool(controls.get("has_gobo", false)):
+		_clear_gobo_visuals(light)
 		light.set_meta(GOBO_TEXTURE_META_KEY, null)
 		return previous_meta_texture != null
 
@@ -45,12 +54,71 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 			active_textures.append(gobo_texture)
 
 	if active_textures.is_empty():
+		_clear_gobo_visuals(light)
 		light.set_meta(GOBO_TEXTURE_META_KEY, null)
 		return previous_meta_texture != null
 
 	var composed_gobo: Texture2D = _compose_gobo_textures(active_textures)
+	_apply_gobo_visuals(light, composed_gobo)
 	light.set_meta(GOBO_TEXTURE_META_KEY, composed_gobo)
 	return composed_gobo != previous_meta_texture
+
+func _apply_gobo_visuals(light: SpotLight3D, gobo_texture: Texture2D) -> void:
+	if light == null or not is_instance_valid(light):
+		return
+	light.set("projector", gobo_texture)
+	if gobo_texture == null:
+		_remove_gobo_plane(light)
+		return
+	var gobo_plane: MeshInstance3D = _ensure_gobo_plane(light)
+	if gobo_plane == null:
+		return
+	if gobo_plane.material_override is ShaderMaterial:
+		var gobo_material: ShaderMaterial = gobo_plane.material_override as ShaderMaterial
+		gobo_material.set_shader_parameter("gobo_texture", gobo_texture)
+	_update_gobo_plane_scale(light, gobo_plane)
+
+func _clear_gobo_visuals(light: SpotLight3D) -> void:
+	if light == null or not is_instance_valid(light):
+		return
+	light.set("projector", null)
+	_remove_gobo_plane(light)
+
+func _ensure_gobo_plane(light: SpotLight3D) -> MeshInstance3D:
+	if light.has_meta(GOBO_PLANE_META_KEY):
+		var existing_plane: MeshInstance3D = light.get_meta(GOBO_PLANE_META_KEY) as MeshInstance3D
+		if existing_plane != null and is_instance_valid(existing_plane):
+			return existing_plane
+
+	var gobo_plane := MeshInstance3D.new()
+	gobo_plane.name = "PeravizGoboPlane"
+	gobo_plane.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
+	var quad := QuadMesh.new()
+	quad.size = GOBO_PLANE_MESH_SIZE
+	gobo_plane.mesh = quad
+	var gobo_material := ShaderMaterial.new()
+	gobo_material.shader = load(GOBO_SHADER_PATH)
+	gobo_plane.material_override = gobo_material
+	gobo_plane.position = Vector3(0.0, 0.0, GOBO_PLANE_LOCAL_Z)
+	light.add_child(gobo_plane)
+	light.set_meta(GOBO_PLANE_META_KEY, gobo_plane)
+	return gobo_plane
+
+func _remove_gobo_plane(light: SpotLight3D) -> void:
+	if not light.has_meta(GOBO_PLANE_META_KEY):
+		return
+	var gobo_plane: MeshInstance3D = light.get_meta(GOBO_PLANE_META_KEY) as MeshInstance3D
+	if gobo_plane != null and is_instance_valid(gobo_plane):
+		gobo_plane.queue_free()
+	light.remove_meta(GOBO_PLANE_META_KEY)
+
+func _update_gobo_plane_scale(light: SpotLight3D, gobo_plane: MeshInstance3D) -> void:
+	if light == null or gobo_plane == null:
+		return
+	var full_spot_angle_deg: float = clamp(light.spot_angle * 2.0, GOBO_MIN_ANGLE_DEG, GOBO_MAX_ANGLE_DEG)
+	var ratio: float = (full_spot_angle_deg - GOBO_MIN_ANGLE_DEG) / max(GOBO_MAX_ANGLE_DEG - GOBO_MIN_ANGLE_DEG, 0.001)
+	var plane_scale: float = lerp(GOBO_MIN_SCALE, GOBO_MAX_SCALE, ratio)
+	gobo_plane.scale = Vector3.ONE * plane_scale
 
 func _resolve_gobo_raw_8bit(controls: Dictionary) -> int:
 	var gobo_raw: int = int(round(clamp(float(controls.get("gobo_norm", 0.0)), 0.0, 1.0) * 255.0))

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -92,7 +92,7 @@ func _ensure_gobo_plane(light: SpotLight3D) -> MeshInstance3D:
 
 	var gobo_plane := MeshInstance3D.new()
 	gobo_plane.name = "PeravizGoboPlane"
-	gobo_plane.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
+	gobo_plane.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_ON
 	var quad := QuadMesh.new()
 	quad.size = GOBO_PLANE_MESH_SIZE
 	gobo_plane.mesh = quad

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -11,7 +11,7 @@ const GOBO_MIN_ANGLE_DEG: float = 4.0
 const GOBO_MAX_ANGLE_DEG: float = 50.0
 const GOBO_MIN_SCALE: float = 0.555
 const GOBO_MAX_SCALE: float = 6.4
-const GOBO_APERTURE_SCALE: float = 0.95
+const GOBO_APERTURE_SCALE: float = 1.00
 
 var _texture_cache: Dictionary = {}
 

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -60,15 +60,19 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 		return previous_meta_texture != null
 
 	var composed_gobo: Texture2D = _compose_gobo_textures(active_textures)
-	_apply_gobo_visuals(light, composed_gobo)
+	_apply_gobo_visuals(light, composed_gobo, controls)
 	light.set_meta(GOBO_TEXTURE_META_KEY, composed_gobo)
 	return composed_gobo != previous_meta_texture
 
-func _apply_gobo_visuals(light: SpotLight3D, gobo_texture: Texture2D) -> void:
+func _apply_gobo_visuals(light: SpotLight3D, gobo_texture: Texture2D, controls: Dictionary = {}) -> void:
 	if light == null or not is_instance_valid(light):
 		return
 	light.set("projector", gobo_texture)
 	if gobo_texture == null:
+		_remove_gobo_plane(light)
+		return
+	var prefer_native_fog_projector: bool = bool(controls.get("prefer_native_fog_projector", true))
+	if prefer_native_fog_projector:
 		_remove_gobo_plane(light)
 		return
 	var gobo_plane: MeshInstance3D = _ensure_gobo_plane(light)

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -61,7 +61,7 @@ var _visual_settings := {
 	"beam_anisotropy": 0.62,
 	"beam_noise_amount": 0.06,
 	"beam_noise_scale": 1.4,
-	"volumetric_fog_density": 0.012,
+	"volumetric_fog_density": 0.0,
 	"light_volumetric_fog_energy": 8.0,
 	"volumetric_fog_volume_size": 256,
 	"volumetric_fog_depth": 64.0,

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -66,6 +66,7 @@ var _visual_settings := {
 	"volumetric_fog_volume_size": 256,
 	"volumetric_fog_depth": 64.0,
 	"volumetric_fog_use_filter": true,
+	"use_native_fog_projector_gobos": true,
 	"background_color": Color(0.129412, 0.137255, 0.156863, 1.0),
 }
 
@@ -1651,9 +1652,12 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 		"distance_cull_m": BEAM_DISTANCE_CULL_M,
 		"spot_angle_half_deg": light.spot_angle,
 		"spot_range": light.spot_range,
+		"use_native_fog_projector_gobos": bool(_visual_settings.get("use_native_fog_projector_gobos", true)),
 	}
 	if _fixture_gobo_projector != null:
-		_fixture_gobo_projector.apply_gobo_projection(light, controls)
+		var gobo_controls: Dictionary = controls.duplicate(true)
+		gobo_controls["prefer_native_fog_projector"] = bool(_visual_settings.get("use_native_fog_projector_gobos", true))
+		_fixture_gobo_projector.apply_gobo_projection(light, gobo_controls)
 	light.light_volumetric_fog_energy = float(_visual_settings.get("light_volumetric_fog_energy", 1.0))
 	_update_beam_for_light(light, beam_params)
 

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -1413,7 +1413,9 @@ func _find_or_create_emitter_light(emitter_node: Node3D) -> SpotLight3D:
 				child.rotation_degrees = EMITTER_LIGHT_DIRECTION_FIX
 			# Keep spotlight footprint behavior stable while pan/tilt moves the fixture.
 			# Self/caster shadows from fixture geometry can clip the floor footprint.
-			child.shadow_enabled = false
+			child.shadow_enabled = true
+			child.shadow_bias = 0.05
+			child.shadow_normal_bias = 1.2
 			child.set_meta("peraviz_lens_radius", lens_radius)
 			return child
 
@@ -1422,7 +1424,9 @@ func _find_or_create_emitter_light(emitter_node: Node3D) -> SpotLight3D:
 	light.position = Vector3.ZERO
 	light.rotation_degrees = EMITTER_LIGHT_DIRECTION_FIX
 	light.light_negative = false
-	light.shadow_enabled = false
+	light.shadow_enabled = true
+	light.shadow_bias = 0.05
+	light.shadow_normal_bias = 1.2
 	light.spot_range = 60.0
 	light.spot_angle = 25.0
 	light.spot_attenuation = 1.0

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -63,8 +63,8 @@ var _visual_settings := {
 	"beam_noise_scale": 1.4,
 	"volumetric_fog_density": 0.012,
 	"light_volumetric_fog_energy": 8.0,
-	"volumetric_fog_volume_size": 256,
-	"volumetric_fog_depth": 64.0,
+	"volumetric_fog_volume_size": 512,
+	"volumetric_fog_depth": 128.0,
 	"volumetric_fog_use_filter": true,
 	"background_color": Color(0.129412, 0.137255, 0.156863, 1.0),
 }

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -62,7 +62,7 @@ var _visual_settings := {
 	"beam_noise_amount": 0.06,
 	"beam_noise_scale": 1.4,
 	"volumetric_fog_density": 0.012,
-	"light_volumetric_fog_energy": 2.0,
+	"light_volumetric_fog_energy": 8.0,
 	"volumetric_fog_volume_size": 256,
 	"volumetric_fog_depth": 64.0,
 	"volumetric_fog_use_filter": true,

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -63,8 +63,8 @@ var _visual_settings := {
 	"beam_noise_scale": 1.4,
 	"volumetric_fog_density": 0.012,
 	"light_volumetric_fog_energy": 8.0,
-	"volumetric_fog_volume_size": 512,
-	"volumetric_fog_depth": 128.0,
+	"volumetric_fog_volume_size": 256,
+	"volumetric_fog_depth": 64.0,
 	"volumetric_fog_use_filter": true,
 	"background_color": Color(0.129412, 0.137255, 0.156863, 1.0),
 }

--- a/peraviz/scripts/shaders/gobo_alpha_projector.gdshader
+++ b/peraviz/scripts/shaders/gobo_alpha_projector.gdshader
@@ -1,5 +1,5 @@
 shader_type spatial;
-render_mode blend_mix, depth_draw_opaque, cull_back, diffuse_lambert, specular_schlick_ggx;
+render_mode blend_mix, depth_draw_alpha_prepass, cull_disabled, diffuse_lambert, specular_schlick_ggx;
 
 uniform sampler2D gobo_texture;
 

--- a/peraviz/scripts/shaders/gobo_alpha_projector.gdshader
+++ b/peraviz/scripts/shaders/gobo_alpha_projector.gdshader
@@ -1,0 +1,12 @@
+shader_type spatial;
+render_mode blend_mix, depth_draw_opaque, cull_back, diffuse_lambert, specular_schlick_ggx;
+
+uniform sampler2D gobo_texture;
+
+void fragment() {
+	vec4 gobo_sample = texture(gobo_texture, UV);
+	float alpha_mask = mix(1.0, 0.0, clamp(gobo_sample.r, 0.0, 1.0));
+	ALBEDO = vec3(1.0);
+	ALPHA = alpha_mask;
+	ALPHA_SCISSOR_THRESHOLD = 0.5;
+}

--- a/peraviz/scripts/shaders/gobo_alpha_projector.gdshader
+++ b/peraviz/scripts/shaders/gobo_alpha_projector.gdshader
@@ -1,5 +1,5 @@
 shader_type spatial;
-render_mode blend_mix, depth_draw_alpha_prepass, cull_disabled, diffuse_lambert, specular_schlick_ggx;
+render_mode blend_mix, depth_prepass_alpha, cull_disabled, diffuse_lambert, specular_schlick_ggx;
 
 uniform sampler2D gobo_texture;
 

--- a/peraviz/scripts/shaders/volumetric_beam.gdshader
+++ b/peraviz/scripts/shaders/volumetric_beam.gdshader
@@ -15,6 +15,9 @@ uniform float near_fade_end : hint_range(0.0, 50.0) = 1.0;
 uniform float far_fade_start : hint_range(0.1, 100.0) = 25.0;
 uniform float far_fade_end : hint_range(0.1, 100.0) = 80.0;
 instance uniform float max_brightness : hint_range(1.0, 50.0) = 10.0;
+instance uniform bool gobo_enabled = false;
+uniform sampler2D gobo_texture : source_color, filter_linear_mipmap, repeat_enable;
+uniform float gobo_contrast : hint_range(0.1, 4.0) = 1.0;
 uniform bool depth_feather_enabled = true;
 uniform float depth_fade_distance : hint_range(0.01, 5.0) = 0.5;
 
@@ -64,7 +67,14 @@ void fragment() {
 		}
 	}
 
-	float final_alpha = feather_alpha * depth_mult * dist_fade;
+	float gobo_mask = 1.0;
+	if (gobo_enabled) {
+		vec2 gobo_uv = vec2(fract(UV.x), clamp(1.0 - UV.y, 0.0, 1.0));
+		float gobo_luma = texture(gobo_texture, gobo_uv).r;
+		gobo_mask = pow(clamp(1.0 - gobo_luma, 0.0, 1.0), gobo_contrast);
+	}
+
+	float final_alpha = feather_alpha * depth_mult * dist_fade * gobo_mask;
 	if (final_alpha < 0.001) {
 		discard;
 	}

--- a/peraviz/scripts/shaders/volumetric_beam.gdshader
+++ b/peraviz/scripts/shaders/volumetric_beam.gdshader
@@ -19,6 +19,8 @@ instance uniform bool gobo_enabled = false;
 uniform sampler2D gobo_texture : source_color, filter_nearest, repeat_enable;
 uniform float gobo_threshold : hint_range(0.0, 1.0) = 0.5;
 uniform float gobo_softness : hint_range(0.0, 0.2) = 0.0;
+instance uniform float gobo_top_radius : hint_range(0.0001, 5.0) = 0.02;
+instance uniform float gobo_bottom_radius : hint_range(0.0001, 20.0) = 0.8;
 uniform bool depth_feather_enabled = true;
 uniform float depth_fade_distance : hint_range(0.01, 5.0) = 0.5;
 
@@ -70,12 +72,20 @@ void fragment() {
 
 	float gobo_visibility = 1.0;
 	if (gobo_enabled) {
-		vec2 gobo_uv = vec2(fract(UV.x), clamp(1.0 - UV.y, 0.0, 1.0));
-		float gobo_luma = texture(gobo_texture, gobo_uv).r;
-		if (gobo_softness <= 0.0001) {
-			gobo_visibility = step(gobo_threshold, gobo_luma);
+		float axial = clamp(UV.y, 0.0, 1.0);
+		float local_radius = mix(gobo_top_radius, gobo_bottom_radius, axial);
+		local_radius = max(local_radius, 0.0001);
+		vec2 radial = vec2(v_local.x, v_local.z) / local_radius;
+		vec2 gobo_uv = (radial * 0.5) + vec2(0.5);
+		if (gobo_uv.x < 0.0 || gobo_uv.x > 1.0 || gobo_uv.y < 0.0 || gobo_uv.y > 1.0) {
+			gobo_visibility = 0.0;
 		} else {
-			gobo_visibility = smoothstep(gobo_threshold - gobo_softness, gobo_threshold + gobo_softness, gobo_luma);
+			float gobo_luma = texture(gobo_texture, gobo_uv).r;
+			if (gobo_softness <= 0.0001) {
+				gobo_visibility = step(gobo_threshold, gobo_luma);
+			} else {
+				gobo_visibility = smoothstep(gobo_threshold - gobo_softness, gobo_threshold + gobo_softness, gobo_luma);
+			}
 		}
 	}
 

--- a/peraviz/scripts/shaders/volumetric_beam.gdshader
+++ b/peraviz/scripts/shaders/volumetric_beam.gdshader
@@ -15,9 +15,6 @@ uniform float near_fade_end : hint_range(0.0, 50.0) = 1.0;
 uniform float far_fade_start : hint_range(0.1, 100.0) = 25.0;
 uniform float far_fade_end : hint_range(0.1, 100.0) = 80.0;
 instance uniform float max_brightness : hint_range(1.0, 50.0) = 10.0;
-instance uniform bool gobo_enabled = false;
-uniform sampler2D gobo_texture : source_color, filter_linear_mipmap, repeat_enable;
-uniform float gobo_contrast : hint_range(0.1, 4.0) = 1.0;
 uniform bool depth_feather_enabled = true;
 uniform float depth_fade_distance : hint_range(0.01, 5.0) = 0.5;
 
@@ -67,14 +64,7 @@ void fragment() {
 		}
 	}
 
-	float gobo_mask = 1.0;
-	if (gobo_enabled) {
-		vec2 gobo_uv = vec2(fract(UV.x), clamp(1.0 - UV.y, 0.0, 1.0));
-		float gobo_luma = texture(gobo_texture, gobo_uv).r;
-		gobo_mask = pow(clamp(1.0 - gobo_luma, 0.0, 1.0), gobo_contrast);
-	}
-
-	float final_alpha = feather_alpha * depth_mult * dist_fade * gobo_mask;
+	float final_alpha = feather_alpha * depth_mult * dist_fade;
 	if (final_alpha < 0.001) {
 		discard;
 	}

--- a/peraviz/scripts/shaders/volumetric_beam.gdshader
+++ b/peraviz/scripts/shaders/volumetric_beam.gdshader
@@ -15,12 +15,6 @@ uniform float near_fade_end : hint_range(0.0, 50.0) = 1.0;
 uniform float far_fade_start : hint_range(0.1, 100.0) = 25.0;
 uniform float far_fade_end : hint_range(0.1, 100.0) = 80.0;
 instance uniform float max_brightness : hint_range(1.0, 50.0) = 10.0;
-instance uniform bool gobo_enabled = false;
-uniform sampler2D gobo_texture : source_color, filter_nearest, repeat_enable;
-uniform float gobo_threshold : hint_range(0.0, 1.0) = 0.5;
-uniform float gobo_softness : hint_range(0.0, 0.2) = 0.0;
-instance uniform float gobo_top_radius : hint_range(0.0001, 5.0) = 0.02;
-instance uniform float gobo_bottom_radius : hint_range(0.0001, 20.0) = 0.8;
 uniform bool depth_feather_enabled = true;
 uniform float depth_fade_distance : hint_range(0.01, 5.0) = 0.5;
 
@@ -70,26 +64,9 @@ void fragment() {
 		}
 	}
 
-	float gobo_visibility = 1.0;
-	if (gobo_enabled) {
-		float axial = clamp(UV.y, 0.0, 1.0);
-		float local_radius = mix(gobo_top_radius, gobo_bottom_radius, axial);
-		local_radius = max(local_radius, 0.0001);
-		vec2 radial = vec2(v_local.x, v_local.z) / local_radius;
-		vec2 gobo_uv = (radial * 0.5) + vec2(0.5);
-		if (gobo_uv.x < 0.0 || gobo_uv.x > 1.0 || gobo_uv.y < 0.0 || gobo_uv.y > 1.0) {
-			gobo_visibility = 0.0;
-		} else {
-			float gobo_luma = texture(gobo_texture, gobo_uv).r;
-			if (gobo_softness <= 0.0001) {
-				gobo_visibility = step(gobo_threshold, gobo_luma);
-			} else {
-				gobo_visibility = smoothstep(gobo_threshold - gobo_softness, gobo_threshold + gobo_softness, gobo_luma);
-			}
-		}
-	}
 
-	float final_alpha = feather_alpha * depth_mult * dist_fade * gobo_visibility;
+
+	float final_alpha = feather_alpha * depth_mult * dist_fade;
 	if (final_alpha < 0.001) {
 		discard;
 	}

--- a/peraviz/scripts/shaders/volumetric_beam.gdshader
+++ b/peraviz/scripts/shaders/volumetric_beam.gdshader
@@ -16,8 +16,9 @@ uniform float far_fade_start : hint_range(0.1, 100.0) = 25.0;
 uniform float far_fade_end : hint_range(0.1, 100.0) = 80.0;
 instance uniform float max_brightness : hint_range(1.0, 50.0) = 10.0;
 instance uniform bool gobo_enabled = false;
-uniform sampler2D gobo_texture : source_color, filter_linear_mipmap, repeat_enable;
-uniform float gobo_block_floor : hint_range(0.0, 0.5) = 0.05;
+uniform sampler2D gobo_texture : source_color, filter_nearest, repeat_enable;
+uniform float gobo_threshold : hint_range(0.0, 1.0) = 0.5;
+uniform float gobo_softness : hint_range(0.0, 0.2) = 0.0;
 uniform bool depth_feather_enabled = true;
 uniform float depth_fade_distance : hint_range(0.01, 5.0) = 0.5;
 
@@ -71,7 +72,11 @@ void fragment() {
 	if (gobo_enabled) {
 		vec2 gobo_uv = vec2(fract(UV.x), clamp(1.0 - UV.y, 0.0, 1.0));
 		float gobo_luma = texture(gobo_texture, gobo_uv).r;
-		gobo_visibility = max(gobo_luma, gobo_block_floor);
+		if (gobo_softness <= 0.0001) {
+			gobo_visibility = step(gobo_threshold, gobo_luma);
+		} else {
+			gobo_visibility = smoothstep(gobo_threshold - gobo_softness, gobo_threshold + gobo_softness, gobo_luma);
+		}
 	}
 
 	float final_alpha = feather_alpha * depth_mult * dist_fade * gobo_visibility;

--- a/peraviz/scripts/shaders/volumetric_beam.gdshader
+++ b/peraviz/scripts/shaders/volumetric_beam.gdshader
@@ -15,6 +15,9 @@ uniform float near_fade_end : hint_range(0.0, 50.0) = 1.0;
 uniform float far_fade_start : hint_range(0.1, 100.0) = 25.0;
 uniform float far_fade_end : hint_range(0.1, 100.0) = 80.0;
 instance uniform float max_brightness : hint_range(1.0, 50.0) = 10.0;
+instance uniform bool gobo_enabled = false;
+uniform sampler2D gobo_texture : source_color, filter_linear_mipmap, repeat_enable;
+uniform float gobo_block_floor : hint_range(0.0, 0.5) = 0.05;
 uniform bool depth_feather_enabled = true;
 uniform float depth_fade_distance : hint_range(0.01, 5.0) = 0.5;
 
@@ -64,7 +67,14 @@ void fragment() {
 		}
 	}
 
-	float final_alpha = feather_alpha * depth_mult * dist_fade;
+	float gobo_visibility = 1.0;
+	if (gobo_enabled) {
+		vec2 gobo_uv = vec2(fract(UV.x), clamp(1.0 - UV.y, 0.0, 1.0));
+		float gobo_luma = texture(gobo_texture, gobo_uv).r;
+		gobo_visibility = max(gobo_luma, gobo_block_floor);
+	}
+
+	float final_alpha = feather_alpha * depth_mult * dist_fade * gobo_visibility;
 	if (final_alpha < 0.001) {
 		discard;
 	}

--- a/peraviz/scripts/visual_settings_window.gd
+++ b/peraviz/scripts/visual_settings_window.gd
@@ -20,6 +20,7 @@ const DEFAULT_SETTINGS := {
 	"volumetric_fog_volume_size": 256,
 	"volumetric_fog_depth": 64.0,
 	"volumetric_fog_use_filter": true,
+	"use_native_fog_projector_gobos": true,
 	"background_color": Color(0.129412, 0.137255, 0.156863, 1.0),
 }
 

--- a/peraviz/scripts/visual_settings_window.gd
+++ b/peraviz/scripts/visual_settings_window.gd
@@ -16,7 +16,7 @@ const DEFAULT_SETTINGS := {
 	"beam_noise_amount": 0.06,
 	"beam_noise_scale": 1.4,
 	"volumetric_fog_density": 0.012,
-	"light_volumetric_fog_energy": 2.0,
+	"light_volumetric_fog_energy": 8.0,
 	"volumetric_fog_volume_size": 256,
 	"volumetric_fog_depth": 64.0,
 	"volumetric_fog_use_filter": true,

--- a/peraviz/scripts/visual_settings_window.gd
+++ b/peraviz/scripts/visual_settings_window.gd
@@ -17,8 +17,8 @@ const DEFAULT_SETTINGS := {
 	"beam_noise_scale": 1.4,
 	"volumetric_fog_density": 0.012,
 	"light_volumetric_fog_energy": 8.0,
-	"volumetric_fog_volume_size": 512,
-	"volumetric_fog_depth": 128.0,
+	"volumetric_fog_volume_size": 256,
+	"volumetric_fog_depth": 64.0,
 	"volumetric_fog_use_filter": true,
 	"background_color": Color(0.129412, 0.137255, 0.156863, 1.0),
 }

--- a/peraviz/scripts/visual_settings_window.gd
+++ b/peraviz/scripts/visual_settings_window.gd
@@ -17,8 +17,8 @@ const DEFAULT_SETTINGS := {
 	"beam_noise_scale": 1.4,
 	"volumetric_fog_density": 0.012,
 	"light_volumetric_fog_energy": 8.0,
-	"volumetric_fog_volume_size": 256,
-	"volumetric_fog_depth": 64.0,
+	"volumetric_fog_volume_size": 512,
+	"volumetric_fog_depth": 128.0,
 	"volumetric_fog_use_filter": true,
 	"background_color": Color(0.129412, 0.137255, 0.156863, 1.0),
 }

--- a/peraviz/scripts/visual_settings_window.gd
+++ b/peraviz/scripts/visual_settings_window.gd
@@ -15,7 +15,7 @@ const DEFAULT_SETTINGS := {
 	"beam_anisotropy": 0.62,
 	"beam_noise_amount": 0.06,
 	"beam_noise_scale": 1.4,
-	"volumetric_fog_density": 0.012,
+	"volumetric_fog_density": 0.0,
 	"light_volumetric_fog_energy": 8.0,
 	"volumetric_fog_volume_size": 256,
 	"volumetric_fog_depth": 64.0,


### PR DESCRIPTION
### Motivation
- Render DMX gobo textures so they visibly affect volumetric fog and the surface the beam hits by applying a projector texture and a visible alpha quad at the emitter.
- Reuse existing gobo sizing parameters and beam/zoom semantics so gobo visuals match the current light cone and zoom behavior.
- Keep logic self-contained inside the Peraviz runtime (no cross-module boundaries introduced). 

### Description
- Add constants and runtime helpers to `peraviz/scripts/fixture_gobo_projector.gd` to manage a `PeravizGoboPlane` child `QuadMesh`, including `_apply_gobo_visuals`, `_clear_gobo_visuals`, `_ensure_gobo_plane`, `_remove_gobo_plane`, and `_update_gobo_plane_scale`.
- Apply composed gobo textures to each `SpotLight3D` via the `projector` property and also set the quad's `ShaderMaterial` parameter `gobo_texture` so the mask is visible in-beam.
- Use the provided angle and scale mapping (min/max angles `4..50` deg mapped to scale `0.555..6.4`) by computing `full_spot_angle = light.spot_angle * 2.0` and linearly interpolating the plane scale.
- Add `peraviz/scripts/shaders/gobo_alpha_projector.gdshader`, a simple alpha-mask shader that samples `gobo_texture`, maps luminance to alpha, and sets `ALPHA_SCISSOR_THRESHOLD = 0.5` for crisp masking.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a882125dc48324818fdb6e9536eed4)