### PR TITLE
peraviz: vectorize gobos and use prism extrusion for legacy beam mode

### DIFF
--- a/peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd
+++ b/peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd
@@ -7,6 +7,9 @@ const VECTORIZATION_EPSILON: float = 1.6
 const MAX_POLYGON_COUNT: int = 6
 const MIN_POLYGON_AREA: float = 0.00004
 const FALLBACK_SEGMENTS: int = 36
+const BINARY_LUMA_THRESHOLD: float = 0.5
+const OUTER_BORDER_PIXELS: int = 1
+const APERTURE_BORDER_RATIO: float = 0.985
 
 var _mesh_cache: Dictionary = {}
 
@@ -45,6 +48,8 @@ func _vectorize_gobo(gobo_texture: Texture2D, gobo_scale: float, gobo_rotation_d
 		var target_width: int = max(8, int(round(float(image.get_width()) * float(VECTORIZATION_MAX_SIZE) / float(longest_size))))
 		var target_height: int = max(8, int(round(float(image.get_height()) * float(VECTORIZATION_MAX_SIZE) / float(longest_size))))
 		image.resize(target_width, target_height, Image.INTERPOLATE_BILINEAR)
+	_prepare_binary_mask_image(image)
+
 	var bitmap := BitMap.new()
 	bitmap.create_from_image_alpha(image, VECTORIZATION_ALPHA_THRESHOLD)
 	var all_polygons: Array = bitmap.opaque_to_polygons(Rect2i(0, 0, image.get_width(), image.get_height()), VECTORIZATION_EPSILON)
@@ -90,6 +95,26 @@ func _vectorize_gobo(gobo_texture: Texture2D, gobo_scale: float, gobo_rotation_d
 		output.append(normalized[index].get("polygon", PackedVector2Array()) as PackedVector2Array)
 	return output
 
+func _prepare_binary_mask_image(image: Image) -> void:
+	var width: int = image.get_width()
+	var height: int = image.get_height()
+	if width <= 0 or height <= 0:
+		return
+	var center := Vector2((float(width) - 1.0) * 0.5, (float(height) - 1.0) * 0.5)
+	var aperture_radius: float = (min(float(width), float(height)) * 0.5) * APERTURE_BORDER_RATIO
+	for y in range(height):
+		for x in range(width):
+			if x < OUTER_BORDER_PIXELS or y < OUTER_BORDER_PIXELS or x >= (width - OUTER_BORDER_PIXELS) or y >= (height - OUTER_BORDER_PIXELS):
+				image.set_pixel(x, y, Color(0.0, 0.0, 0.0, 0.0))
+				continue
+			var pos := Vector2(float(x), float(y))
+			if pos.distance_to(center) >= aperture_radius:
+				image.set_pixel(x, y, Color(0.0, 0.0, 0.0, 0.0))
+				continue
+			var sample: Color = image.get_pixel(x, y)
+			var luma: float = (sample.r * 0.299) + (sample.g * 0.587) + (sample.b * 0.114)
+			var binary: float = 1.0 if (luma * sample.a) >= BINARY_LUMA_THRESHOLD else 0.0
+			image.set_pixel(x, y, Color(binary, binary, binary, binary))
 
 func _signed_polygon_area(polygon: PackedVector2Array) -> float:
 	var count: int = polygon.size()

--- a/peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd
+++ b/peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd
@@ -75,7 +75,7 @@ func _vectorize_gobo(gobo_texture: Texture2D, gobo_scale: float, gobo_rotation_d
 				(local.x * sin_r) + (local.y * cos_r)
 			)
 			transformed.append(Vector2(rotated.x, -rotated.y))
-		var area: float = abs(Geometry2D.poly_area(transformed))
+		var area: float = abs(_signed_polygon_area(transformed))
 		if area < MIN_POLYGON_AREA:
 			continue
 		normalized.append({"polygon": transformed, "area": area})
@@ -89,6 +89,18 @@ func _vectorize_gobo(gobo_texture: Texture2D, gobo_scale: float, gobo_rotation_d
 	for index in range(min(MAX_POLYGON_COUNT, normalized.size())):
 		output.append(normalized[index].get("polygon", PackedVector2Array()) as PackedVector2Array)
 	return output
+
+
+func _signed_polygon_area(polygon: PackedVector2Array) -> float:
+	var count: int = polygon.size()
+	if count < 3:
+		return 0.0
+	var area: float = 0.0
+	for i in range(count):
+		var current: Vector2 = polygon[i]
+		var next: Vector2 = polygon[(i + 1) % count]
+		area += (current.x * next.y) - (next.x * current.y)
+	return 0.5 * area
 
 func _build_fallback_circle() -> PackedVector2Array:
 	var polygon := PackedVector2Array()

--- a/peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd
+++ b/peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd
@@ -1,0 +1,144 @@
+extends RefCounted
+class_name GoboPrismMeshBuilder
+
+const VECTORIZATION_MAX_SIZE: int = 192
+const VECTORIZATION_ALPHA_THRESHOLD: float = 0.5
+const VECTORIZATION_EPSILON: float = 1.6
+const MAX_POLYGON_COUNT: int = 6
+const MIN_POLYGON_AREA: float = 0.00004
+const FALLBACK_SEGMENTS: int = 36
+
+var _mesh_cache: Dictionary = {}
+
+func clear_cache() -> void:
+	_mesh_cache.clear()
+
+func build_beam_mesh(gobo_texture: Texture2D, near_radius: float, far_radius: float, beam_height: float, gobo_scale: float, gobo_rotation_deg: float) -> ArrayMesh:
+	var shape_key: String = _shape_cache_key(gobo_texture, gobo_scale, gobo_rotation_deg)
+	var geometry_key: String = "%s_%.4f_%.4f_%.4f" % [shape_key, near_radius, far_radius, beam_height]
+	if _mesh_cache.has(geometry_key):
+		return _mesh_cache[geometry_key] as ArrayMesh
+
+	var polygons: Array[PackedVector2Array] = _vectorize_gobo(gobo_texture, gobo_scale, gobo_rotation_deg)
+	if polygons.is_empty():
+		polygons = [_build_fallback_circle()]
+
+	var mesh: ArrayMesh = _build_extruded_mesh(polygons, max(near_radius, 0.001), max(far_radius, 0.001), max(beam_height, 0.001))
+	_mesh_cache[geometry_key] = mesh
+	return mesh
+
+func _shape_cache_key(gobo_texture: Texture2D, gobo_scale: float, gobo_rotation_deg: float) -> String:
+	if gobo_texture == null:
+		return "__fallback_shape"
+	return "__shape_%d_%.3f_%.3f" % [gobo_texture.get_rid().get_id(), gobo_scale, wrapf(gobo_rotation_deg, 0.0, 360.0)]
+
+func _vectorize_gobo(gobo_texture: Texture2D, gobo_scale: float, gobo_rotation_deg: float) -> Array[PackedVector2Array]:
+	if gobo_texture == null:
+		return []
+	var image: Image = gobo_texture.get_image()
+	if image == null:
+		return []
+	if image.get_format() != Image.FORMAT_RGBA8:
+		image.convert(Image.FORMAT_RGBA8)
+	var longest_size: int = max(image.get_width(), image.get_height())
+	if longest_size > VECTORIZATION_MAX_SIZE:
+		var target_width: int = max(8, int(round(float(image.get_width()) * float(VECTORIZATION_MAX_SIZE) / float(longest_size))))
+		var target_height: int = max(8, int(round(float(image.get_height()) * float(VECTORIZATION_MAX_SIZE) / float(longest_size))))
+		image.resize(target_width, target_height, Image.INTERPOLATE_BILINEAR)
+	var bitmap := BitMap.new()
+	bitmap.create_from_image_alpha(image, VECTORIZATION_ALPHA_THRESHOLD)
+	var all_polygons: Array = bitmap.opaque_to_polygons(Rect2i(0, 0, image.get_width(), image.get_height()), VECTORIZATION_EPSILON)
+	if all_polygons.is_empty():
+		return []
+
+	var normalized: Array[Dictionary] = []
+	var inv_width: float = 1.0 / max(float(image.get_width()), 1.0)
+	var inv_height: float = 1.0 / max(float(image.get_height()), 1.0)
+	var center := Vector2(0.5, 0.5)
+	var rotation_rad: float = deg_to_rad(wrapf(gobo_rotation_deg, 0.0, 360.0))
+	var cos_r: float = cos(rotation_rad)
+	var sin_r: float = sin(rotation_rad)
+	var safe_scale: float = max(gobo_scale, 0.05)
+
+	for polygon_variant in all_polygons:
+		if polygon_variant is not PackedVector2Array:
+			continue
+		var polygon: PackedVector2Array = polygon_variant as PackedVector2Array
+		if polygon.size() < 3:
+			continue
+		var transformed := PackedVector2Array()
+		for point in polygon:
+			var uv := Vector2(point.x * inv_width, point.y * inv_height)
+			var local := (uv - center) * (2.0 / safe_scale)
+			var rotated := Vector2(
+				(local.x * cos_r) - (local.y * sin_r),
+				(local.x * sin_r) + (local.y * cos_r)
+			)
+			transformed.append(Vector2(rotated.x, -rotated.y))
+		var area: float = abs(Geometry2D.poly_area(transformed))
+		if area < MIN_POLYGON_AREA:
+			continue
+		normalized.append({"polygon": transformed, "area": area})
+
+	if normalized.is_empty():
+		return []
+	normalized.sort_custom(func(a: Dictionary, b: Dictionary) -> bool:
+		return float(a.get("area", 0.0)) > float(b.get("area", 0.0))
+	)
+	var output: Array[PackedVector2Array] = []
+	for index in range(min(MAX_POLYGON_COUNT, normalized.size())):
+		output.append(normalized[index].get("polygon", PackedVector2Array()) as PackedVector2Array)
+	return output
+
+func _build_fallback_circle() -> PackedVector2Array:
+	var polygon := PackedVector2Array()
+	for i in range(FALLBACK_SEGMENTS):
+		var angle: float = TAU * float(i) / float(FALLBACK_SEGMENTS)
+		polygon.append(Vector2(cos(angle), sin(angle)))
+	return polygon
+
+func _build_extruded_mesh(polygons: Array[PackedVector2Array], near_radius: float, far_radius: float, beam_height: float) -> ArrayMesh:
+	var st := SurfaceTool.new()
+	st.begin(Mesh.PRIMITIVE_TRIANGLES)
+	var half_height: float = beam_height * 0.5
+	for polygon in polygons:
+		if polygon.size() < 3:
+			continue
+		_add_caps(st, polygon, near_radius, far_radius, half_height)
+		_add_sides(st, polygon, near_radius, far_radius, half_height)
+	st.generate_normals()
+	return st.commit()
+
+func _add_caps(st: SurfaceTool, polygon: PackedVector2Array, near_radius: float, far_radius: float, half_height: float) -> void:
+	var indices: PackedInt32Array = Geometry2D.triangulate_polygon(polygon)
+	if indices.is_empty():
+		return
+	for i in range(0, indices.size(), 3):
+		var ia: int = indices[i]
+		var ib: int = indices[i + 1]
+		var ic: int = indices[i + 2]
+		var a: Vector2 = polygon[ia]
+		var b: Vector2 = polygon[ib]
+		var c: Vector2 = polygon[ic]
+		st.add_vertex(Vector3(a.x * near_radius, half_height, a.y * near_radius))
+		st.add_vertex(Vector3(b.x * near_radius, half_height, b.y * near_radius))
+		st.add_vertex(Vector3(c.x * near_radius, half_height, c.y * near_radius))
+		st.add_vertex(Vector3(c.x * far_radius, -half_height, c.y * far_radius))
+		st.add_vertex(Vector3(b.x * far_radius, -half_height, b.y * far_radius))
+		st.add_vertex(Vector3(a.x * far_radius, -half_height, a.y * far_radius))
+
+func _add_sides(st: SurfaceTool, polygon: PackedVector2Array, near_radius: float, far_radius: float, half_height: float) -> void:
+	var point_count: int = polygon.size()
+	for i in range(point_count):
+		var current: Vector2 = polygon[i]
+		var next: Vector2 = polygon[(i + 1) % point_count]
+		var near_current := Vector3(current.x * near_radius, half_height, current.y * near_radius)
+		var near_next := Vector3(next.x * near_radius, half_height, next.y * near_radius)
+		var far_current := Vector3(current.x * far_radius, -half_height, current.y * far_radius)
+		var far_next := Vector3(next.x * far_radius, -half_height, next.y * far_radius)
+		st.add_vertex(near_current)
+		st.add_vertex(near_next)
+		st.add_vertex(far_next)
+		st.add_vertex(near_current)
+		st.add_vertex(far_next)
+		st.add_vertex(far_current)

--- a/peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd
@@ -9,36 +9,33 @@ const EMITTER_CONE_FAR_ALPHA: float = 0.004
 const EMITTER_CONE_NEAR_EMISSION: float = 0.45
 const EMITTER_CONE_FAR_EMISSION: float = 0.04
 
-const MAIN_KEY: String = "peraviz_beam_cone"
-const MID_KEY: String = "peraviz_beam_cone_mid"
-const CORE_KEY: String = "peraviz_beam_cone_core"
+const MAIN_KEY: String = "peraviz_beam_prism"
 const GOBO_TEXTURE_META_KEY: String = "peraviz_gobo_texture"
 const DEBUG_AXIS_KEY: String = "peraviz_beam_debug_axis"
+const LEGACY_MID_KEY: String = "peraviz_beam_cone_mid"
+const LEGACY_CORE_KEY: String = "peraviz_beam_cone_core"
+
+const GoboPrismMeshBuilderScript = preload("res://scripts/beam_renderers/gobo_prism_mesh_builder.gd")
 
 var _material_template: ShaderMaterial
+var _mesh_builder: GoboPrismMeshBuilder
 
 func _init() -> void:
 	_material_template = ShaderMaterial.new()
 	_material_template.shader = load("res://scripts/shaders/legacy_beam_cone.gdshader")
+	_mesh_builder = GoboPrismMeshBuilderScript.new()
 
 func ensure_beam(light: SpotLight3D) -> void:
+	_cleanup_legacy_cones(light)
 	if not light.has_meta(MAIN_KEY):
-		light.set_meta(MAIN_KEY, _create_cone("PeravizBeamCone"))
-	if not light.has_meta(MID_KEY):
-		light.set_meta(MID_KEY, _create_cone("PeravizBeamMidCone"))
-	if not light.has_meta(CORE_KEY):
-		light.set_meta(CORE_KEY, _create_cone("PeravizBeamCoreCone"))
+		light.set_meta(MAIN_KEY, _create_prism("PeravizBeamPrism"))
 
 func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	ensure_beam(light)
-	var cone: MeshInstance3D = light.get_meta(MAIN_KEY) as MeshInstance3D
-	var mid_cone: MeshInstance3D = light.get_meta(MID_KEY) as MeshInstance3D
-	var core_cone: MeshInstance3D = light.get_meta(CORE_KEY) as MeshInstance3D
-	if cone == null and mid_cone == null and core_cone == null:
+	var prism: MeshInstance3D = light.get_meta(MAIN_KEY) as MeshInstance3D
+	if prism == null:
 		return
-	_attach_if_needed(light, cone)
-	_attach_if_needed(light, mid_cone)
-	_attach_if_needed(light, core_cone)
+	_attach_if_needed(light, prism)
 
 	var intensity: float = clamp(float(params.get("normalized_dimmer", 0.0)), 0.0, 1.0)
 	var scaled_intensity: float = clamp(float(params.get("scaled_intensity", 0.0)), 0.0, 20.0)
@@ -48,12 +45,7 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	var lens_radius: float = max(float(params.get("lens_radius", 0.03)), 0.005)
 	var is_visible: bool = bool(params.get("is_visible", true)) and intensity > 0.015
 
-	if cone != null:
-		cone.visible = is_visible
-	if mid_cone != null:
-		mid_cone.visible = is_visible
-	if core_cone != null:
-		core_cone.visible = is_visible
+	prism.visible = is_visible
 	if not is_visible:
 		var hidden_axis: MeshInstance3D = _ensure_debug_axis(light)
 		if hidden_axis != null:
@@ -62,9 +54,6 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	var debug_axis: MeshInstance3D = _ensure_debug_axis(light)
 	if debug_axis != null:
 		debug_axis.visible = bool(params.get("beam_debug_optics", false))
-	# Keep legacy cone beams visible even with native fog-projector gobos enabled.
-	# This preserves beam readability while the spotlight projector handles gobo footprint/fog shading.
-
 
 	var beam_half_angle_deg: float = beam_angle * 0.5
 	var radius: float = tan(deg_to_rad(beam_half_angle_deg)) * beam_range
@@ -75,91 +64,77 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	var lens_offset_m: float = max(float(params.get("lens_offset_m", params.get("near_offset", 0.0))), 0.0)
 	var lens_shift_x: float = float(params.get("lens_shift_x", 0.0))
 	var lens_shift_y: float = float(params.get("lens_shift_y", 0.0))
-	_update_cone_geometry(cone, lens_radius, bottom_radius, beam_range, lens_offset_m, lens_shift_x, lens_shift_y, 1.0)
-	_update_cone_geometry(mid_cone, lens_radius, bottom_radius, beam_range, lens_offset_m, lens_shift_x, lens_shift_y, 0.7)
-	_update_cone_geometry(core_cone, lens_radius, bottom_radius, beam_range, lens_offset_m, lens_shift_x, lens_shift_y, 0.45)
 
 	var gobo_texture: Texture2D = null
 	if light.has_meta(GOBO_TEXTURE_META_KEY):
 		gobo_texture = light.get_meta(GOBO_TEXTURE_META_KEY) as Texture2D
-	# Keep cone beam visible in all modes; native projector may still affect footprint/fog.
+	var gobo_scale: float = max(float(params.get("gobo_scale", 1.0)), 0.05)
+	var gobo_rotation_deg: float = float(params.get("gobo_rotation_deg", 0.0))
+	var prism_mesh: ArrayMesh = _mesh_builder.build_beam_mesh(gobo_texture, lens_radius, bottom_radius, beam_range, gobo_scale, gobo_rotation_deg)
+	if prism_mesh != null:
+		prism.mesh = prism_mesh
+	prism.position = Vector3(lens_shift_x, lens_shift_y, -(beam_range * 0.5 + lens_offset_m))
+
 	var color_alpha := Color(beam_color.r, beam_color.g, beam_color.b, 1.0)
 	var beam_softness: float = clamp(float(params.get("beam_softness", 0.35)), 0.02, 1.0)
 	var radial_falloff: float = max(float(params.get("beam_radial_falloff", 1.1)), 0.05)
 	var longitudinal_falloff: float = max(float(params.get("beam_longitudinal_falloff", 1.0)), 0.05)
-	var gobo_scale: float = max(float(params.get("gobo_scale", 1.0)), 0.05)
-	var gobo_rotation_deg: float = float(params.get("gobo_rotation_deg", 0.0))
 	var haze_density: float = max(float(params.get("haze_density", params.get("haze_density_multiplier", 0.22))), 0.01)
-	_update_cone_material(cone, color_alpha, scaled_intensity, beam_range, bottom_radius, beam_softness, 0.16, 0.06, 1.0, 1.0, radial_falloff, longitudinal_falloff, haze_density, gobo_scale, gobo_rotation_deg, gobo_texture)
-	_update_cone_material(mid_cone, color_alpha, scaled_intensity, beam_range, bottom_radius * 0.7, beam_softness * 0.7, 0.26, 0.04, 1.35, 1.25, radial_falloff, longitudinal_falloff, haze_density, gobo_scale, gobo_rotation_deg, gobo_texture)
-	_update_cone_material(core_cone, color_alpha, scaled_intensity, beam_range, bottom_radius * 0.45, beam_softness * 0.45, 0.35, 0.02, 1.7, 1.5, radial_falloff, longitudinal_falloff, haze_density, gobo_scale, gobo_rotation_deg, gobo_texture)
+	_update_prism_material(prism, color_alpha, scaled_intensity, beam_range, bottom_radius, beam_softness, radial_falloff, longitudinal_falloff, haze_density)
 
 func cleanup_beam(light: SpotLight3D) -> void:
-	for meta_key in [MAIN_KEY, MID_KEY, CORE_KEY]:
+	if light.has_meta(MAIN_KEY):
+		var prism: MeshInstance3D = light.get_meta(MAIN_KEY) as MeshInstance3D
+		if prism != null and is_instance_valid(prism):
+			prism.queue_free()
+		light.remove_meta(MAIN_KEY)
+	_cleanup_legacy_cones(light)
+	if _mesh_builder != null:
+		_mesh_builder.clear_cache()
+
+func _cleanup_legacy_cones(light: SpotLight3D) -> void:
+	for meta_key in [LEGACY_MID_KEY, LEGACY_CORE_KEY, "peraviz_beam_cone"]:
 		if not light.has_meta(meta_key):
 			continue
-		var cone: MeshInstance3D = light.get_meta(meta_key) as MeshInstance3D
-		if cone != null and is_instance_valid(cone):
-			cone.queue_free()
+		var legacy_cone: MeshInstance3D = light.get_meta(meta_key) as MeshInstance3D
+		if legacy_cone != null and is_instance_valid(legacy_cone):
+			legacy_cone.queue_free()
 		light.remove_meta(meta_key)
 
-func _attach_if_needed(light: SpotLight3D, cone: MeshInstance3D) -> void:
-	if cone != null and cone.get_parent() == null:
-		light.add_child(cone)
+func _attach_if_needed(light: SpotLight3D, prism: MeshInstance3D) -> void:
+	if prism != null and prism.get_parent() == null:
+		light.add_child(prism)
 
-func _create_cone(cone_name: String) -> MeshInstance3D:
-	var cone_mesh := CylinderMesh.new()
-	cone_mesh.radial_segments = 40
-	cone_mesh.rings = 6
-	cone_mesh.top_radius = 0.02
-	cone_mesh.bottom_radius = 0.6
-	cone_mesh.height = 8.0
-	var cone := MeshInstance3D.new()
-	cone.name = cone_name
-	cone.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
-	cone.mesh = cone_mesh
-	cone.material_override = _material_template.duplicate(true)
-	cone.rotation_degrees.x = 90.0
-	cone.visible = false
-	return cone
+func _create_prism(prism_name: String) -> MeshInstance3D:
+	var prism := MeshInstance3D.new()
+	prism.name = prism_name
+	prism.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
+	prism.material_override = _material_template.duplicate(true)
+	prism.rotation_degrees.x = 90.0
+	prism.visible = false
+	return prism
 
-func _update_cone_geometry(cone: MeshInstance3D, lens_radius: float, bottom_radius: float, beam_range: float, lens_offset_m: float, lens_shift_x: float, lens_shift_y: float, radius_scale: float) -> void:
-	if cone == null:
+func _update_prism_material(prism: MeshInstance3D, beam_color: Color, scaled_intensity: float, beam_range: float, gobo_projection_radius: float, lateral_softness: float, radial_falloff: float, longitudinal_falloff: float, haze_density: float) -> void:
+	if prism == null:
 		return
-	var cone_mesh: CylinderMesh = cone.mesh as CylinderMesh
-	if cone_mesh == null:
-		return
-	cone_mesh.top_radius = max(lens_radius * radius_scale, 0.003)
-	cone_mesh.bottom_radius = clamp(bottom_radius * radius_scale, 0.02, EMITTER_CONE_MAX_BASE_RADIUS_M)
-	cone_mesh.height = beam_range
-	cone.position = Vector3(lens_shift_x, lens_shift_y, -(beam_range * 0.5 + lens_offset_m))
-
-func _update_cone_material(cone: MeshInstance3D, beam_color: Color, scaled_intensity: float, beam_range: float, gobo_projection_radius: float, lateral_softness: float, lateral_emission_boost: float, noise_strength: float, alpha_scale: float, emission_scale: float, radial_falloff: float, longitudinal_falloff: float, haze_density: float, gobo_scale: float, gobo_rotation_deg: float, gobo_texture: Texture2D) -> void:
-	if cone == null:
-		return
-	cone.set_instance_shader_parameter("beam_color", beam_color)
-	cone.set_instance_shader_parameter("near_alpha", lerp(0.0, EMITTER_CONE_NEAR_ALPHA * alpha_scale, scaled_intensity))
-	cone.set_instance_shader_parameter("far_alpha", lerp(0.0, EMITTER_CONE_FAR_ALPHA * alpha_scale, scaled_intensity))
-	cone.set_instance_shader_parameter("near_emission", lerp(0.0, EMITTER_CONE_NEAR_EMISSION * emission_scale, scaled_intensity))
-	cone.set_instance_shader_parameter("far_emission", lerp(0.0, EMITTER_CONE_FAR_EMISSION * emission_scale, scaled_intensity))
-	cone.set_instance_shader_parameter("cone_height", max(beam_range, 0.001))
-	cone.set_instance_shader_parameter("gobo_projection_radius", max(gobo_projection_radius, 0.001))
-	cone.set_instance_shader_parameter("fade_end_ratio", EMITTER_CONE_FADE_END_RATIO)
-	cone.set_instance_shader_parameter("lateral_softness", clamp(lateral_softness, 0.02, 1.0))
-	cone.set_instance_shader_parameter("lateral_emission_boost", lateral_emission_boost)
-	cone.set_instance_shader_parameter("volumetric_noise_strength", noise_strength)
-	cone.set_instance_shader_parameter("radial_falloff", radial_falloff)
-	cone.set_instance_shader_parameter("longitudinal_falloff", longitudinal_falloff)
-	cone.set_instance_shader_parameter("gobo_scale", gobo_scale)
-	cone.set_instance_shader_parameter("gobo_rotation_deg", gobo_rotation_deg)
-	cone.set_instance_shader_parameter("haze_density", haze_density)
-	var cone_material: ShaderMaterial = cone.material_override as ShaderMaterial
-	if cone_material != null:
-		cone_material.set_shader_parameter("use_gobo", gobo_texture != null)
-		cone_material.set_shader_parameter("gobo_invert", false)
-		if gobo_texture != null:
-			cone_material.set_shader_parameter("gobo_texture", gobo_texture)
-
+	prism.set_instance_shader_parameter("beam_color", beam_color)
+	prism.set_instance_shader_parameter("near_alpha", lerp(0.0, EMITTER_CONE_NEAR_ALPHA, scaled_intensity))
+	prism.set_instance_shader_parameter("far_alpha", lerp(0.0, EMITTER_CONE_FAR_ALPHA, scaled_intensity))
+	prism.set_instance_shader_parameter("near_emission", lerp(0.0, EMITTER_CONE_NEAR_EMISSION, scaled_intensity))
+	prism.set_instance_shader_parameter("far_emission", lerp(0.0, EMITTER_CONE_FAR_EMISSION, scaled_intensity))
+	prism.set_instance_shader_parameter("cone_height", max(beam_range, 0.001))
+	prism.set_instance_shader_parameter("gobo_projection_radius", max(gobo_projection_radius, 0.001))
+	prism.set_instance_shader_parameter("fade_end_ratio", EMITTER_CONE_FADE_END_RATIO)
+	prism.set_instance_shader_parameter("lateral_softness", clamp(lateral_softness, 0.02, 1.0))
+	prism.set_instance_shader_parameter("lateral_emission_boost", 0.22)
+	prism.set_instance_shader_parameter("volumetric_noise_strength", 0.06)
+	prism.set_instance_shader_parameter("radial_falloff", radial_falloff)
+	prism.set_instance_shader_parameter("longitudinal_falloff", longitudinal_falloff)
+	prism.set_instance_shader_parameter("haze_density", haze_density)
+	var prism_material: ShaderMaterial = prism.material_override as ShaderMaterial
+	if prism_material != null:
+		prism_material.set_shader_parameter("use_gobo", false)
+		prism_material.set_shader_parameter("gobo_invert", false)
 
 func _ensure_debug_axis(light: SpotLight3D) -> MeshInstance3D:
 	if light.has_meta(DEBUG_AXIS_KEY):

--- a/peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd
@@ -68,7 +68,8 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 		gobo_texture = light.get_meta(GOBO_TEXTURE_META_KEY) as Texture2D
 	var gobo_scale: float = max(float(params.get("gobo_scale", 1.0)), 0.05)
 	var gobo_rotation_deg: float = float(params.get("gobo_rotation_deg", 0.0))
-	var prism_mesh: ArrayMesh = _mesh_builder.build_beam_mesh(gobo_texture, lens_radius, bottom_radius, beam_range, gobo_scale, gobo_rotation_deg)
+	var beam_rotation_deg: float = wrapf(gobo_rotation_deg + 180.0, 0.0, 360.0)
+	var prism_mesh: ArrayMesh = _mesh_builder.build_beam_mesh(gobo_texture, lens_radius, bottom_radius, beam_range, gobo_scale, beam_rotation_deg)
 	if prism_mesh != null:
 		prism.mesh = prism_mesh
 	prism.position = Vector3(lens_shift_x, lens_shift_y, -(beam_range * 0.5 + lens_offset_m))

--- a/peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd
@@ -15,15 +15,13 @@ const DEBUG_AXIS_KEY: String = "peraviz_beam_debug_axis"
 const LEGACY_MID_KEY: String = "peraviz_beam_cone_mid"
 const LEGACY_CORE_KEY: String = "peraviz_beam_cone_core"
 
-const GoboPrismMeshBuilderScript = preload("res://scripts/beam_renderers/gobo_prism_mesh_builder.gd")
-
 var _material_template: ShaderMaterial
 var _mesh_builder: GoboPrismMeshBuilder
 
 func _init() -> void:
 	_material_template = ShaderMaterial.new()
 	_material_template.shader = load("res://scripts/shaders/legacy_beam_cone.gdshader")
-	_mesh_builder = GoboPrismMeshBuilderScript.new()
+	_mesh_builder = GoboPrismMeshBuilder.new()
 
 func ensure_beam(light: SpotLight3D) -> void:
 	_cleanup_legacy_cones(light)


### PR DESCRIPTION
### Motivation
- Replace the old lightweight legacy rendering (three concentric cones with gobo on cone surface) with a more faithful, efficient representation by extruding a vectorized gobo outline along the beam direction.  
- Keep quality/performance predictable by bounding rasterization/vectorization resolution and limiting polygon complexity.  
- Keep changes modular by adding a dedicated helper for gobo vectorization/mesh-building instead of growing the renderer file.

### Description
- Added `peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd` that vectorizes gobo textures into polygons (alpha threshold → `BitMap.opaque_to_polygons`), clamps source size with `VECTORIZATION_MAX_SIZE = 192`, filters tiny polygons, caps polygon count, provides a circular fallback, and extrudes the polygons into an `ArrayMesh` (caps + sides) with an internal cache.  
- Reworked `peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd` to use a single prism mesh metadata key `peraviz_beam_prism` driven by the new `GoboPrismMeshBuilder`, replacing creation of three cone meshes and the per-cone geometry updates.  
- Integrated gobo scale/rotation into the mesh builder call and positioned the prism using lens offset/beam range; material parameters are updated via `_update_prism_material` and the prism shader is left to rely on geometry for gobo masking (shader `use_gobo` is set to `false` for the prism).  
- Added cleanup of old legacy cone metadata keys (`peraviz_beam_cone*`) when switching/making the prism to avoid stale scene nodes, and exposed a `clear_cache()` usage on cleanup.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (`OK`).  
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (`OK`).  
- Attempted an automated UI capture via the local browser tooling but the web endpoint was not available (`Page.goto` returned `ERR_EMPTY_RESPONSE`), so UI screenshot validation could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab69f0a9d08324a6c21821c3bf19d5)