### PR TITLE
Fix beam cutoff and restore volumetric beam visibility

### DIFF
--- a/peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd
@@ -38,11 +38,12 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 
 	var intensity: float = clamp(float(params.get("normalized_dimmer", 0.0)), 0.0, 1.0)
 	var scaled_intensity: float = clamp(float(params.get("scaled_intensity", 0.0)), 0.0, 20.0)
+	var threshold: float = float(params.get("intensity_visibility_threshold", 0.015))
 	var beam_range: float = max(float(params.get("beam_range", 0.1)), 0.01)
 	var beam_angle: float = max(float(params.get("beam_angle", 1.0)), 0.1)
 	var beam_color: Color = params.get("beam_color", Color.WHITE)
 	var lens_radius: float = max(float(params.get("lens_radius", 0.03)), 0.005)
-	var is_visible: bool = bool(params.get("is_visible", true)) and intensity > 0.015
+	var is_visible: bool = bool(params.get("is_visible", true)) and scaled_intensity > threshold
 
 	prism.visible = is_visible
 	if not is_visible:
@@ -118,11 +119,12 @@ func _create_prism(prism_name: String) -> MeshInstance3D:
 func _update_prism_material(prism: MeshInstance3D, beam_color: Color, scaled_intensity: float, beam_range: float, gobo_projection_radius: float, lateral_softness: float, radial_falloff: float, longitudinal_falloff: float, haze_density: float) -> void:
 	if prism == null:
 		return
+	var normalized_scaled_intensity: float = clamp(scaled_intensity / 20.0, 0.0, 1.0)
 	prism.set_instance_shader_parameter("beam_color", beam_color)
-	prism.set_instance_shader_parameter("near_alpha", lerp(0.0, EMITTER_CONE_NEAR_ALPHA, scaled_intensity))
-	prism.set_instance_shader_parameter("far_alpha", lerp(0.0, EMITTER_CONE_FAR_ALPHA, scaled_intensity))
-	prism.set_instance_shader_parameter("near_emission", lerp(0.0, EMITTER_CONE_NEAR_EMISSION, scaled_intensity))
-	prism.set_instance_shader_parameter("far_emission", lerp(0.0, EMITTER_CONE_FAR_EMISSION, scaled_intensity))
+	prism.set_instance_shader_parameter("near_alpha", lerp(0.0, EMITTER_CONE_NEAR_ALPHA, normalized_scaled_intensity))
+	prism.set_instance_shader_parameter("far_alpha", lerp(0.0, EMITTER_CONE_FAR_ALPHA, normalized_scaled_intensity))
+	prism.set_instance_shader_parameter("near_emission", lerp(0.0, EMITTER_CONE_NEAR_EMISSION, normalized_scaled_intensity))
+	prism.set_instance_shader_parameter("far_emission", lerp(0.0, EMITTER_CONE_FAR_EMISSION, normalized_scaled_intensity))
 	prism.set_instance_shader_parameter("cone_height", max(beam_range, 0.001))
 	prism.set_instance_shader_parameter("gobo_projection_radius", max(gobo_projection_radius, 0.001))
 	prism.set_instance_shader_parameter("fade_end_ratio", EMITTER_CONE_FADE_END_RATIO)

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -50,7 +50,6 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 		return
 
 	var intensity: float = clamp(float(params.get("scaled_intensity", 0.0)), 0.0, 20.0)
-	var normalized_intensity: float = clamp(float(params.get("normalized_dimmer", 0.0)), 0.0, 1.0)
 	var beam_intensity_norm: float = clamp(intensity / 20.0, 0.0, 1.0)
 	var threshold: float = float(params.get("intensity_visibility_threshold", 0.015))
 	var beam_range: float = max(float(params.get("beam_range", 0.1)), 0.01)
@@ -115,14 +114,16 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	cone.set_instance_shader_parameter("gobo_rotation_deg", beam_rotation_deg)
 	cone.set_instance_shader_parameter("cone_height", max(beam_range, 0.001))
 	cone.set_instance_shader_parameter("gobo_projection_radius", max(bottom_radius, 0.001))
-	cone.set_instance_shader_parameter("beam_intensity", max(normalized_intensity, beam_intensity_norm))
+	cone.set_instance_shader_parameter("beam_intensity", beam_intensity_norm)
 	var far_fade_end: float = max(400.0, beam_range * 12.0)
 	var cone_material: ShaderMaterial = cone.material_override as ShaderMaterial
 	if cone_material != null:
 		cone_material.set_shader_parameter("near_fade_end", max(2.0, beam_range * 0.2))
 		cone_material.set_shader_parameter("far_fade_start", far_fade_end * 0.6)
 		cone_material.set_shader_parameter("far_fade_end", far_fade_end)
-		cone_material.set_shader_parameter("use_gobo", gobo_texture != null)
+		# Keep the volumetric cone independent from the projector footprint.
+		# SpotLight projector textures can define floor footprint only, while this cone simulates haze volume.
+		cone_material.set_shader_parameter("use_gobo", false)
 		cone_material.set_shader_parameter("gobo_invert", false)
 		cone_material.set_shader_parameter("gobo_mirror_x", MIRROR_BEAM_SHAPE_X)
 		cone_material.set_shader_parameter("depth_feather_enabled", false)


### PR DESCRIPTION
### Motivation
- Legacy cone beam could not reach a true off state because visibility gating used the dimmer norm instead of the scaled beam intensity and shader alpha mapping; this prevented beams from fully disappearing at zero beam intensity.
- The volumetric beam path relied on a mix between dimmer norm and intensity which made volumetric cones invisible or inconsistent with the footprint projector.
- The projector footprint and volumetric beam simulation responsibilities should be separated so the spotlight projector continues to drive footprints while the volumetric cone always simulates the haze shaft.

### Description
- Use the configured visibility threshold and `scaled_intensity` to decide legacy prism visibility so the beam can reach 0 (changed in `peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd`).
- Normalize legacy `scaled_intensity` with `scaled_intensity / 20.0` before lerping alpha/emission shader parameters to make material response consistent across the configured intensity range (updated in `legacy_cone_beam_renderer.gd`).
- Set volumetric cone `beam_intensity` from the scaled intensity (`beam_intensity_norm`) instead of mixing with `normalized_dimmer`, restoring expected volumetric visibility (changed in `peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd`).
- Keep volumetric cone shader gobo masking disabled (`use_gobo = false`) so footprint projection remains controlled by the spotlight projector while the cone stays a simulated haze volume (comment and code change in `volumetric_beam_renderer.gd`).

### Testing
- Ran `./tests/check_perastage_tree_modules.sh` and it passed.
- Ran `./tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abedc915d48324aa998994d3b3102b)