### PR TITLE
Refactor volumetric beam renderer to use shape providers and add cone/gobo-prism shapes

### DIFF
--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -3,53 +3,49 @@ extends BeamRendererBase
 class_name VolumetricBeamRenderer
 
 const BEAM_META_KEY: String = "peraviz_volumetric_beam"
-const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 10.0
 const VOLUMETRIC_INTENSITY_SCALE: float = 4.0
 const VOLUMETRIC_INTENSITY_RESPONSE_EXPONENT: float = 2.2
 const INTENSITY_REFERENCE_MAX: float = 20.0
 const VOLUMETRIC_OVERDRIVE_BRIGHTNESS_MAX: float = 30.0
-const GOBO_TEXTURE_META_KEY: String = "peraviz_gobo_texture"
 const DEBUG_AXIS_KEY: String = "peraviz_beam_debug_axis"
-const MIRROR_BEAM_SHAPE_X: bool = true
+const SHAPE_MODE_GOBO_PRISM: String = "gobo_prism"
+const SHAPE_MODE_CONE: String = "cone"
 
 var _beam_material_template: ShaderMaterial
 var _camera: Camera3D
 var _settings: Dictionary = {}
+var _shape_providers: Dictionary = {}
+var _active_shape_provider: VolumetricBeamShapeProvider
 
 func _init() -> void:
 	_beam_material_template = ShaderMaterial.new()
 	_beam_material_template.shader = load("res://scripts/shaders/volumetric_beam.gdshader")
+	_shape_providers[SHAPE_MODE_GOBO_PRISM] = VolumetricGoboPrismShapeProvider.new()
+	_shape_providers[SHAPE_MODE_CONE] = VolumetricConeShapeProvider.new()
+	_active_shape_provider = _shape_providers[SHAPE_MODE_GOBO_PRISM] as VolumetricBeamShapeProvider
 
 func configure(view_camera: Camera3D, settings: Dictionary) -> void:
 	_camera = view_camera
 	_settings = settings.duplicate(true)
+	_active_shape_provider = _select_shape_provider()
 
 func ensure_beam(light: SpotLight3D) -> void:
 	if light.has_meta(BEAM_META_KEY):
 		return
-	var cone_mesh := CylinderMesh.new()
-	cone_mesh.radial_segments = 96
-	cone_mesh.rings = 24
-	cone_mesh.top_radius = 0.02
-	cone_mesh.bottom_radius = 0.8
-	cone_mesh.height = 8.0
-	cone_mesh.cap_top = false
-	cone_mesh.cap_bottom = false
-	var cone := MeshInstance3D.new()
-	cone.name = "PeravizVolumetricBeam"
-	cone.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
-	cone.mesh = cone_mesh
-	cone.material_override = _beam_material_template.duplicate(true)
-	cone.rotation_degrees.x = 90.0
-	cone.visible = false
-	light.add_child(cone)
-	light.set_meta(BEAM_META_KEY, cone)
+	var beam := MeshInstance3D.new()
+	beam.name = "PeravizVolumetricBeam"
+	beam.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
+	beam.material_override = _beam_material_template.duplicate(true)
+	beam.rotation_degrees.x = 90.0
+	beam.visible = false
+	light.add_child(beam)
+	light.set_meta(BEAM_META_KEY, beam)
 	_ensure_debug_axis(light)
 
 func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	ensure_beam(light)
-	var cone: MeshInstance3D = light.get_meta(BEAM_META_KEY) as MeshInstance3D
-	if cone == null:
+	var beam: MeshInstance3D = light.get_meta(BEAM_META_KEY) as MeshInstance3D
+	if beam == null:
 		return
 
 	var intensity_max: float = max(float(params.get("intensity_max", 100.0)), 0.01)
@@ -65,8 +61,8 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	var beam_angle: float = max(float(params.get("beam_angle", 1.0)), 0.1)
 
 	if not bool(params.get("is_visible", true)) or intensity <= threshold:
-		cone.visible = false
-		cone.set_instance_shader_parameter("beam_visibility", 0.0)
+		beam.visible = false
+		beam.set_instance_shader_parameter("beam_visibility", 0.0)
 		var hidden_axis: MeshInstance3D = _ensure_debug_axis(light)
 		if hidden_axis != null:
 			hidden_axis.visible = false
@@ -75,82 +71,64 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	if debug_axis != null:
 		debug_axis.visible = bool(params.get("beam_debug_optics", false))
 
-	# Keep debug/preview beam meshes visible even when native fog-projector gobos are enabled.
-	# Native gobo projection controls footprint/fog in renderer, while this cone keeps operator-visible beam feedback.
-
-
 	var beam_color: Color = params.get("beam_color", Color.WHITE)
-	var lens_radius: float = max(float(params.get("lens_radius", 0.03)), 0.005)
+	var shape_result: Dictionary = _active_shape_provider.apply_shape(beam, light, params)
+	var gobo_projection_radius: float = max(float(shape_result.get("gobo_projection_radius", 0.1)), 0.001)
+	var beam_rotation_deg: float = float(shape_result.get("beam_rotation_deg", 0.0))
 
-	var half_angle_deg: float = beam_angle * 0.5
-	var tan_half_angle: float = tan(deg_to_rad(half_angle_deg))
-	var radius: float = tan_half_angle * beam_range
-	var bottom_radius: float = clamp(radius, 0.03, EMITTER_CONE_MAX_BASE_RADIUS_M)
 	if bool(params.get("beam_debug_optics", false)):
-		print("[PeravizBeamOptics] angle_deg=", beam_angle, " range_m=", beam_range, " radius_end_m=", bottom_radius)
-	var gobo_texture: Texture2D = null
-	if light.has_meta(GOBO_TEXTURE_META_KEY):
-		gobo_texture = light.get_meta(GOBO_TEXTURE_META_KEY) as Texture2D
-	var gobo_scale: float = max(float(params.get("gobo_scale", 1.0)), 0.05)
-	var gobo_rotation_deg: float = float(params.get("gobo_rotation_deg", 0.0))
-	var beam_rotation_deg: float = wrapf(gobo_rotation_deg + 180.0, 0.0, 360.0)
-	var cone_mesh: CylinderMesh = cone.mesh as CylinderMesh
-	var top_radius: float = max(lens_radius, 0.003)
-	if cone_mesh != null:
-		cone_mesh.top_radius = top_radius
-		cone_mesh.bottom_radius = bottom_radius
-		cone_mesh.height = beam_range
-	var lens_offset_m: float = max(float(params.get("lens_offset_m", params.get("near_offset", 0.0))), 0.0)
-	var lens_shift_x: float = float(params.get("lens_shift_x", 0.0))
-	var lens_shift_y: float = float(params.get("lens_shift_y", 0.0))
-	cone.position = Vector3(lens_shift_x, lens_shift_y, -(beam_range * 0.5 + lens_offset_m))
-	cone.scale = Vector3.ONE
-	cone.visible = true
+		print("[PeravizBeamOptics] mode=", _active_shape_provider.shape_mode(), " angle_deg=", beam_angle, " range_m=", beam_range, " radius_end_m=", gobo_projection_radius)
+
+	beam.visible = true
 
 	var intensity_alpha: float = clamp((intensity / reference_max) * VOLUMETRIC_INTENSITY_SCALE, 0.0, 3.6)
-	cone.set_instance_shader_parameter("base_color", Color(beam_color.r, beam_color.g, beam_color.b, intensity_alpha))
-	cone.set_instance_shader_parameter("beam_visibility", 1.0)
+	beam.set_instance_shader_parameter("base_color", Color(beam_color.r, beam_color.g, beam_color.b, intensity_alpha))
+	beam.set_instance_shader_parameter("beam_visibility", 1.0)
 	var overdrive_brightness_gain: float = lerp(1.0, VOLUMETRIC_OVERDRIVE_BRIGHTNESS_MAX, overdrive_norm)
-	cone.set_instance_shader_parameter("max_brightness", lerp(8.0, 120.0, beam_intensity_norm) * overdrive_brightness_gain)
-	cone.set_instance_shader_parameter("beam_noise_amount", float(_settings.get("beam_noise_amount", 0.06)))
-	cone.set_instance_shader_parameter("beam_noise_scale", float(_settings.get("beam_noise_scale", 1.4)))
+	beam.set_instance_shader_parameter("max_brightness", lerp(8.0, 120.0, beam_intensity_norm) * overdrive_brightness_gain)
+	beam.set_instance_shader_parameter("beam_noise_amount", float(_settings.get("beam_noise_amount", 0.06)))
+	beam.set_instance_shader_parameter("beam_noise_scale", float(_settings.get("beam_noise_scale", 1.4)))
 	var haze_density: float = max(float(params.get("haze_density", params.get("haze_density_multiplier", 0.22))), 0.01)
-	cone.set_instance_shader_parameter("beam_haze_density", float(_settings.get("beam_haze_density", 0.17)) * haze_density)
-	cone.set_instance_shader_parameter("haze_density", max(haze_density, 0.2))
-	cone.set_instance_shader_parameter("beam_anisotropy", float(_settings.get("beam_anisotropy", 0.62)))
-	cone.set_instance_shader_parameter("beam_quality", int(_settings.get("beam_quality", 1)))
-	cone.set_instance_shader_parameter("radial_falloff", max(float(params.get("beam_radial_falloff", 1.1)), 0.05))
-	cone.set_instance_shader_parameter("longitudinal_falloff", max(float(params.get("beam_longitudinal_falloff", 1.0)), 0.05))
-	cone.set_instance_shader_parameter("beam_softness", clamp(float(params.get("beam_softness", 0.35)), 0.02, 1.0))
-	cone.set_instance_shader_parameter("gobo_scale", gobo_scale)
-	cone.set_instance_shader_parameter("gobo_rotation_deg", beam_rotation_deg)
-	cone.set_instance_shader_parameter("cone_height", max(beam_range, 0.001))
-	cone.set_instance_shader_parameter("gobo_projection_radius", max(bottom_radius, 0.001))
-	cone.set_instance_shader_parameter("beam_intensity", perceptual_intensity)
-	cone.set_instance_shader_parameter("beam_overdrive", overdrive_norm)
+	beam.set_instance_shader_parameter("beam_haze_density", float(_settings.get("beam_haze_density", 0.17)) * haze_density)
+	beam.set_instance_shader_parameter("haze_density", max(haze_density, 0.2))
+	beam.set_instance_shader_parameter("beam_anisotropy", float(_settings.get("beam_anisotropy", 0.62)))
+	beam.set_instance_shader_parameter("beam_quality", int(_settings.get("beam_quality", 1)))
+	beam.set_instance_shader_parameter("radial_falloff", max(float(params.get("beam_radial_falloff", 1.1)), 0.05))
+	beam.set_instance_shader_parameter("longitudinal_falloff", max(float(params.get("beam_longitudinal_falloff", 1.0)), 0.05))
+	beam.set_instance_shader_parameter("beam_softness", clamp(float(params.get("beam_softness", 0.35)), 0.02, 1.0))
+	beam.set_instance_shader_parameter("gobo_scale", max(float(params.get("gobo_scale", 1.0)), 0.05))
+	beam.set_instance_shader_parameter("gobo_rotation_deg", beam_rotation_deg)
+	beam.set_instance_shader_parameter("cone_height", max(beam_range, 0.001))
+	beam.set_instance_shader_parameter("gobo_projection_radius", gobo_projection_radius)
+	beam.set_instance_shader_parameter("beam_intensity", perceptual_intensity)
+	beam.set_instance_shader_parameter("beam_overdrive", overdrive_norm)
 	var far_fade_end: float = max(400.0, beam_range * 12.0)
-	var cone_material: ShaderMaterial = cone.material_override as ShaderMaterial
-	if cone_material != null:
-		cone_material.set_shader_parameter("near_fade_end", max(2.0, beam_range * 0.2))
-		cone_material.set_shader_parameter("far_fade_start", far_fade_end * 0.6)
-		cone_material.set_shader_parameter("far_fade_end", far_fade_end)
-		# Keep the volumetric cone independent from the projector footprint.
-		# SpotLight projector textures can define floor footprint only, while this cone simulates haze volume.
-		cone_material.set_shader_parameter("use_gobo", false)
-		cone_material.set_shader_parameter("gobo_invert", false)
-		cone_material.set_shader_parameter("gobo_mirror_x", MIRROR_BEAM_SHAPE_X)
-		cone_material.set_shader_parameter("depth_feather_enabled", false)
-		if gobo_texture != null:
-			cone_material.set_shader_parameter("gobo_texture", gobo_texture)
+	var beam_material: ShaderMaterial = beam.material_override as ShaderMaterial
+	if beam_material != null:
+		beam_material.set_shader_parameter("near_fade_end", max(2.0, beam_range * 0.2))
+		beam_material.set_shader_parameter("far_fade_start", far_fade_end * 0.6)
+		beam_material.set_shader_parameter("far_fade_end", far_fade_end)
+		beam_material.set_shader_parameter("use_gobo", false)
+		beam_material.set_shader_parameter("gobo_invert", false)
+		beam_material.set_shader_parameter("gobo_mirror_x", bool(shape_result.get("mirror_x", true)))
+		beam_material.set_shader_parameter("depth_feather_enabled", false)
 
 func cleanup_beam(light: SpotLight3D) -> void:
 	if not light.has_meta(BEAM_META_KEY):
 		return
-	var cone: MeshInstance3D = light.get_meta(BEAM_META_KEY) as MeshInstance3D
-	if cone != null and is_instance_valid(cone):
-		cone.queue_free()
+	var beam: MeshInstance3D = light.get_meta(BEAM_META_KEY) as MeshInstance3D
+	if beam != null and is_instance_valid(beam):
+		beam.queue_free()
 	light.remove_meta(BEAM_META_KEY)
+	for provider in _shape_providers.values():
+		if provider is VolumetricBeamShapeProvider:
+			(provider as VolumetricBeamShapeProvider).clear_cache()
 
+func _select_shape_provider() -> VolumetricBeamShapeProvider:
+	var requested_mode: String = str(_settings.get("volumetric_shape_mode", SHAPE_MODE_GOBO_PRISM)).to_lower()
+	if _shape_providers.has(requested_mode):
+		return _shape_providers[requested_mode] as VolumetricBeamShapeProvider
+	return _shape_providers[SHAPE_MODE_GOBO_PRISM] as VolumetricBeamShapeProvider
 
 func _ensure_debug_axis(light: SpotLight3D) -> MeshInstance3D:
 	if light.has_meta(DEBUG_AXIS_KEY):

--- a/peraviz/scripts/beam_renderers/volumetric_beam_shape_provider.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_shape_provider.gd
@@ -1,0 +1,15 @@
+extends RefCounted
+class_name VolumetricBeamShapeProvider
+
+func shape_mode() -> String:
+	return "base"
+
+func apply_shape(beam: MeshInstance3D, light: SpotLight3D, params: Dictionary) -> Dictionary:
+	return {
+		"gobo_projection_radius": 0.1,
+		"beam_rotation_deg": 0.0,
+		"mirror_x": true,
+	}
+
+func clear_cache() -> void:
+	pass

--- a/peraviz/scripts/beam_renderers/volumetric_cone_shape_provider.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_cone_shape_provider.gd
@@ -1,0 +1,38 @@
+extends VolumetricBeamShapeProvider
+class_name VolumetricConeShapeProvider
+
+const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 10.0
+
+func shape_mode() -> String:
+	return "cone"
+
+func apply_shape(beam: MeshInstance3D, light: SpotLight3D, params: Dictionary) -> Dictionary:
+	var beam_range: float = max(float(params.get("beam_range", 0.1)), 0.01)
+	var beam_angle: float = max(float(params.get("beam_angle", 1.0)), 0.1)
+	var lens_radius: float = max(float(params.get("lens_radius", 0.03)), 0.005)
+	var half_angle_deg: float = beam_angle * 0.5
+	var tan_half_angle: float = tan(deg_to_rad(half_angle_deg))
+	var radius: float = tan_half_angle * beam_range
+	var bottom_radius: float = clamp(radius, 0.03, EMITTER_CONE_MAX_BASE_RADIUS_M)
+	var cone_mesh: CylinderMesh = beam.mesh as CylinderMesh
+	if cone_mesh == null:
+		cone_mesh = CylinderMesh.new()
+		cone_mesh.radial_segments = 96
+		cone_mesh.rings = 24
+		cone_mesh.cap_top = false
+		cone_mesh.cap_bottom = false
+		beam.mesh = cone_mesh
+	cone_mesh.top_radius = max(lens_radius, 0.003)
+	cone_mesh.bottom_radius = bottom_radius
+	cone_mesh.height = beam_range
+	var lens_offset_m: float = max(float(params.get("lens_offset_m", params.get("near_offset", 0.0))), 0.0)
+	var lens_shift_x: float = float(params.get("lens_shift_x", 0.0))
+	var lens_shift_y: float = float(params.get("lens_shift_y", 0.0))
+	beam.position = Vector3(lens_shift_x, lens_shift_y, -(beam_range * 0.5 + lens_offset_m))
+	beam.scale = Vector3.ONE
+	var gobo_rotation_deg: float = float(params.get("gobo_rotation_deg", 0.0))
+	return {
+		"gobo_projection_radius": max(bottom_radius, 0.001),
+		"beam_rotation_deg": wrapf(gobo_rotation_deg + 180.0, 0.0, 360.0),
+		"mirror_x": true,
+	}

--- a/peraviz/scripts/beam_renderers/volumetric_gobo_prism_shape_provider.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_gobo_prism_shape_provider.gd
@@ -1,0 +1,41 @@
+extends VolumetricBeamShapeProvider
+class_name VolumetricGoboPrismShapeProvider
+
+const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 10.0
+const GOBO_TEXTURE_META_KEY: String = "peraviz_gobo_texture"
+const MIRROR_BEAM_SHAPE_X: bool = true
+
+var _mesh_builder: GoboPrismMeshBuilder = GoboPrismMeshBuilder.new()
+
+func shape_mode() -> String:
+	return "gobo_prism"
+
+func apply_shape(beam: MeshInstance3D, light: SpotLight3D, params: Dictionary) -> Dictionary:
+	var beam_range: float = max(float(params.get("beam_range", 0.1)), 0.01)
+	var beam_angle: float = max(float(params.get("beam_angle", 1.0)), 0.1)
+	var lens_radius: float = max(float(params.get("lens_radius", 0.03)), 0.005)
+	var beam_half_angle_deg: float = beam_angle * 0.5
+	var radius: float = tan(deg_to_rad(beam_half_angle_deg)) * beam_range
+	var bottom_radius: float = clamp(radius, 0.03, EMITTER_CONE_MAX_BASE_RADIUS_M)
+	var gobo_texture: Texture2D = null
+	if light.has_meta(GOBO_TEXTURE_META_KEY):
+		gobo_texture = light.get_meta(GOBO_TEXTURE_META_KEY) as Texture2D
+	var gobo_scale: float = max(float(params.get("gobo_scale", 1.0)), 0.05)
+	var gobo_rotation_deg: float = float(params.get("gobo_rotation_deg", 0.0))
+	var beam_rotation_deg: float = wrapf(gobo_rotation_deg + 180.0, 0.0, 360.0)
+	var prism_mesh: ArrayMesh = _mesh_builder.build_beam_mesh(gobo_texture, lens_radius, bottom_radius, beam_range, gobo_scale, beam_rotation_deg)
+	if prism_mesh != null:
+		beam.mesh = prism_mesh
+	var lens_offset_m: float = max(float(params.get("lens_offset_m", params.get("near_offset", 0.0))), 0.0)
+	var lens_shift_x: float = float(params.get("lens_shift_x", 0.0))
+	var lens_shift_y: float = float(params.get("lens_shift_y", 0.0))
+	beam.position = Vector3(lens_shift_x, lens_shift_y, -(beam_range * 0.5 + lens_offset_m))
+	beam.scale = Vector3(-1.0 if MIRROR_BEAM_SHAPE_X else 1.0, 1.0, 1.0)
+	return {
+		"gobo_projection_radius": max(bottom_radius, 0.001),
+		"beam_rotation_deg": beam_rotation_deg,
+		"mirror_x": MIRROR_BEAM_SHAPE_X,
+	}
+
+func clear_cache() -> void:
+	_mesh_builder.clear_cache()


### PR DESCRIPTION
### Motivation
- Separate beam geometry generation from the renderer so different emitter shapes can be supported and extended. 
- Replace hard-coded cone mesh logic with pluggable providers to allow specialized meshes (gobo prism) and cleaner code organization.

### Description
- Introduced a new base class `VolumetricBeamShapeProvider` and two concrete providers `VolumetricConeShapeProvider` and `VolumetricGoboPrismShapeProvider` to encapsulate beam mesh creation and shape parameters. 
- Reworked `volumetric_beam_renderer.gd` to create a generic `MeshInstance3D` per light and to delegate mesh/transform setup to the selected shape provider via `_select_shape_provider()` and `apply_shape()`. 
- Updated shader parameter handling to read shape results (`gobo_projection_radius`, `beam_rotation_deg`, `mirror_x`) returned by providers and to mirror older cone-specific parameters where appropriate. 
- Added provider cache clearing in `cleanup_beam` and removed inlined cone/gobo mesh construction and related constants from the renderer in favor of provider-specific implementations.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac828a18d48324bee9ccee038eafe3)