### PR TITLE
Avoid fake gobo fallback for open/no-image slots in legacy beam mode

### DIFF
--- a/peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd
+++ b/peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd
@@ -13,10 +13,6 @@ const APERTURE_BORDER_RATIO: float = 0.985
 const POINT_REDUCTION_EPSILON_START: float = 0.001
 const POINT_REDUCTION_EPSILON_MULTIPLIER: float = 1.35
 const POINT_REDUCTION_EPSILON_MAX: float = 0.25
-const OPEN_APERTURE_LUMA_MEAN_MIN: float = 0.985
-const OPEN_APERTURE_LUMA_VARIATION_MAX: float = 0.02
-const OPEN_APERTURE_ALPHA_MIN: float = 0.985
-const OPEN_APERTURE_SAMPLE_GRID: int = 8
 
 var _mesh_cache: Dictionary = {}
 
@@ -64,7 +60,7 @@ func _vectorize_gobo(gobo_texture: Texture2D, gobo_scale: float, gobo_rotation_d
 		var target_width: int = max(8, int(round(float(image.get_width()) * float(VECTORIZATION_MAX_SIZE) / float(longest_size))))
 		var target_height: int = max(8, int(round(float(image.get_height()) * float(VECTORIZATION_MAX_SIZE) / float(longest_size))))
 		image.resize(target_width, target_height, Image.INTERPOLATE_BILINEAR)
-	if apply_edge_mask_correction and _should_apply_edge_mask_correction(image):
+	if apply_edge_mask_correction:
 		_prepare_binary_mask_image(image)
 
 	var bitmap := BitMap.new()
@@ -229,38 +225,6 @@ func _distance_point_to_segment(point: Vector2, segment_start: Vector2, segment_
 	var projection: Vector2 = segment_start + (segment * t)
 	return point.distance_to(projection)
 
-func _should_apply_edge_mask_correction(image: Image) -> bool:
-	if image == null:
-		return false
-	var width: int = image.get_width()
-	var height: int = image.get_height()
-	if width <= 0 or height <= 0:
-		return false
-	var sample_grid: int = max(2, OPEN_APERTURE_SAMPLE_GRID)
-	var min_luma_alpha: float = 1.0
-	var max_luma_alpha: float = 0.0
-	var accum_luma_alpha: float = 0.0
-	var accum_alpha: float = 0.0
-	var samples: int = 0
-	for y_step in range(sample_grid):
-		for x_step in range(sample_grid):
-			var x: int = int(round((float(width - 1) * float(x_step)) / float(sample_grid - 1)))
-			var y: int = int(round((float(height - 1) * float(y_step)) / float(sample_grid - 1)))
-			var pixel: Color = image.get_pixel(x, y)
-			var luma: float = (pixel.r * 0.299) + (pixel.g * 0.587) + (pixel.b * 0.114)
-			var luma_alpha: float = luma * pixel.a
-			min_luma_alpha = min(min_luma_alpha, luma_alpha)
-			max_luma_alpha = max(max_luma_alpha, luma_alpha)
-			accum_luma_alpha += luma_alpha
-			accum_alpha += pixel.a
-			samples += 1
-	if samples <= 0:
-		return false
-	var mean_luma_alpha: float = accum_luma_alpha / float(samples)
-	var mean_alpha: float = accum_alpha / float(samples)
-	var variation: float = max_luma_alpha - min_luma_alpha
-	var looks_open_aperture: bool = mean_luma_alpha >= OPEN_APERTURE_LUMA_MEAN_MIN and mean_alpha >= OPEN_APERTURE_ALPHA_MIN and variation <= OPEN_APERTURE_LUMA_VARIATION_MAX
-	return not looks_open_aperture
 
 func _prepare_binary_mask_image(image: Image) -> void:
 	var width: int = image.get_width()

--- a/peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd
+++ b/peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd
@@ -37,6 +37,15 @@ func build_beam_mesh(gobo_texture: Texture2D, near_radius: float, far_radius: fl
 	_mesh_cache[geometry_key] = mesh
 	return mesh
 
+func build_open_beam_mesh(near_radius: float, far_radius: float, beam_height: float) -> ArrayMesh:
+	var geometry_key: String = "__open_%.4f_%.4f_%.4f" % [near_radius, far_radius, beam_height]
+	if _mesh_cache.has(geometry_key):
+		return _mesh_cache[geometry_key] as ArrayMesh
+	var polygons: Array[PackedVector2Array] = [_build_fallback_circle()]
+	var mesh: ArrayMesh = _build_extruded_mesh(polygons, max(near_radius, 0.001), max(far_radius, 0.001), max(beam_height, 0.001))
+	_mesh_cache[geometry_key] = mesh
+	return mesh
+
 func _shape_cache_key(gobo_texture: Texture2D, gobo_scale: float, gobo_rotation_deg: float) -> String:
 	if gobo_texture == null:
 		return "__fallback_shape"

--- a/peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd
+++ b/peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd
@@ -19,13 +19,13 @@ var _mesh_cache: Dictionary = {}
 func clear_cache() -> void:
 	_mesh_cache.clear()
 
-func build_beam_mesh(gobo_texture: Texture2D, near_radius: float, far_radius: float, beam_height: float, gobo_scale: float, gobo_rotation_deg: float) -> ArrayMesh:
+func build_beam_mesh(gobo_texture: Texture2D, near_radius: float, far_radius: float, beam_height: float, gobo_scale: float, gobo_rotation_deg: float, apply_edge_mask_correction: bool = true) -> ArrayMesh:
 	var shape_key: String = _shape_cache_key(gobo_texture, gobo_scale, gobo_rotation_deg)
-	var geometry_key: String = "%s_%.4f_%.4f_%.4f" % [shape_key, near_radius, far_radius, beam_height]
+	var geometry_key: String = "%s_%.4f_%.4f_%.4f_%s" % [shape_key, near_radius, far_radius, beam_height, str(apply_edge_mask_correction)]
 	if _mesh_cache.has(geometry_key):
 		return _mesh_cache[geometry_key] as ArrayMesh
 
-	var polygons: Array[PackedVector2Array] = _vectorize_gobo(gobo_texture, gobo_scale, gobo_rotation_deg)
+	var polygons: Array[PackedVector2Array] = _vectorize_gobo(gobo_texture, gobo_scale, gobo_rotation_deg, apply_edge_mask_correction)
 	if polygons.is_empty():
 		polygons = [_build_fallback_circle()]
 
@@ -38,7 +38,7 @@ func _shape_cache_key(gobo_texture: Texture2D, gobo_scale: float, gobo_rotation_
 		return "__fallback_shape"
 	return "__shape_%d_%.3f_%.3f" % [gobo_texture.get_rid().get_id(), gobo_scale, wrapf(gobo_rotation_deg, 0.0, 360.0)]
 
-func _vectorize_gobo(gobo_texture: Texture2D, gobo_scale: float, gobo_rotation_deg: float) -> Array[PackedVector2Array]:
+func _vectorize_gobo(gobo_texture: Texture2D, gobo_scale: float, gobo_rotation_deg: float, apply_edge_mask_correction: bool = true) -> Array[PackedVector2Array]:
 	if gobo_texture == null:
 		return []
 	var image: Image = gobo_texture.get_image()
@@ -51,7 +51,8 @@ func _vectorize_gobo(gobo_texture: Texture2D, gobo_scale: float, gobo_rotation_d
 		var target_width: int = max(8, int(round(float(image.get_width()) * float(VECTORIZATION_MAX_SIZE) / float(longest_size))))
 		var target_height: int = max(8, int(round(float(image.get_height()) * float(VECTORIZATION_MAX_SIZE) / float(longest_size))))
 		image.resize(target_width, target_height, Image.INTERPOLATE_BILINEAR)
-	_prepare_binary_mask_image(image)
+	if apply_edge_mask_correction:
+		_prepare_binary_mask_image(image)
 
 	var bitmap := BitMap.new()
 	bitmap.create_from_image_alpha(image, VECTORIZATION_ALPHA_THRESHOLD)

--- a/peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd
+++ b/peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd
@@ -13,6 +13,10 @@ const APERTURE_BORDER_RATIO: float = 0.985
 const POINT_REDUCTION_EPSILON_START: float = 0.001
 const POINT_REDUCTION_EPSILON_MULTIPLIER: float = 1.35
 const POINT_REDUCTION_EPSILON_MAX: float = 0.25
+const OPEN_APERTURE_LUMA_MEAN_MIN: float = 0.985
+const OPEN_APERTURE_LUMA_VARIATION_MAX: float = 0.02
+const OPEN_APERTURE_ALPHA_MIN: float = 0.985
+const OPEN_APERTURE_SAMPLE_GRID: int = 8
 
 var _mesh_cache: Dictionary = {}
 
@@ -51,7 +55,7 @@ func _vectorize_gobo(gobo_texture: Texture2D, gobo_scale: float, gobo_rotation_d
 		var target_width: int = max(8, int(round(float(image.get_width()) * float(VECTORIZATION_MAX_SIZE) / float(longest_size))))
 		var target_height: int = max(8, int(round(float(image.get_height()) * float(VECTORIZATION_MAX_SIZE) / float(longest_size))))
 		image.resize(target_width, target_height, Image.INTERPOLATE_BILINEAR)
-	if apply_edge_mask_correction:
+	if apply_edge_mask_correction and _should_apply_edge_mask_correction(image):
 		_prepare_binary_mask_image(image)
 
 	var bitmap := BitMap.new()
@@ -215,6 +219,39 @@ func _distance_point_to_segment(point: Vector2, segment_start: Vector2, segment_
 	var t: float = clamp((point - segment_start).dot(segment) / segment_length_squared, 0.0, 1.0)
 	var projection: Vector2 = segment_start + (segment * t)
 	return point.distance_to(projection)
+
+func _should_apply_edge_mask_correction(image: Image) -> bool:
+	if image == null:
+		return false
+	var width: int = image.get_width()
+	var height: int = image.get_height()
+	if width <= 0 or height <= 0:
+		return false
+	var sample_grid: int = max(2, OPEN_APERTURE_SAMPLE_GRID)
+	var min_luma_alpha: float = 1.0
+	var max_luma_alpha: float = 0.0
+	var accum_luma_alpha: float = 0.0
+	var accum_alpha: float = 0.0
+	var samples: int = 0
+	for y_step in range(sample_grid):
+		for x_step in range(sample_grid):
+			var x: int = int(round((float(width - 1) * float(x_step)) / float(sample_grid - 1)))
+			var y: int = int(round((float(height - 1) * float(y_step)) / float(sample_grid - 1)))
+			var pixel: Color = image.get_pixel(x, y)
+			var luma: float = (pixel.r * 0.299) + (pixel.g * 0.587) + (pixel.b * 0.114)
+			var luma_alpha: float = luma * pixel.a
+			min_luma_alpha = min(min_luma_alpha, luma_alpha)
+			max_luma_alpha = max(max_luma_alpha, luma_alpha)
+			accum_luma_alpha += luma_alpha
+			accum_alpha += pixel.a
+			samples += 1
+	if samples <= 0:
+		return false
+	var mean_luma_alpha: float = accum_luma_alpha / float(samples)
+	var mean_alpha: float = accum_alpha / float(samples)
+	var variation: float = max_luma_alpha - min_luma_alpha
+	var looks_open_aperture: bool = mean_luma_alpha >= OPEN_APERTURE_LUMA_MEAN_MIN and mean_alpha >= OPEN_APERTURE_ALPHA_MIN and variation <= OPEN_APERTURE_LUMA_VARIATION_MAX
+	return not looks_open_aperture
 
 func _prepare_binary_mask_image(image: Image) -> void:
 	var width: int = image.get_width()

--- a/peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd
+++ b/peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd
@@ -33,14 +33,6 @@ func build_beam_mesh(gobo_texture: Texture2D, near_radius: float, far_radius: fl
 	_mesh_cache[geometry_key] = mesh
 	return mesh
 
-func build_open_beam_mesh(near_radius: float, far_radius: float, beam_height: float) -> ArrayMesh:
-	var geometry_key: String = "__open_%.4f_%.4f_%.4f" % [near_radius, far_radius, beam_height]
-	if _mesh_cache.has(geometry_key):
-		return _mesh_cache[geometry_key] as ArrayMesh
-	var polygons: Array[PackedVector2Array] = [_build_fallback_circle()]
-	var mesh: ArrayMesh = _build_extruded_mesh(polygons, max(near_radius, 0.001), max(far_radius, 0.001), max(beam_height, 0.001))
-	_mesh_cache[geometry_key] = mesh
-	return mesh
 
 func _shape_cache_key(gobo_texture: Texture2D, gobo_scale: float, gobo_rotation_deg: float) -> String:
 	if gobo_texture == null:

--- a/peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd
@@ -14,7 +14,6 @@ const LEGACY_OVERDRIVE_GAIN_MAX: float = 5.0
 
 const MAIN_KEY: String = "peraviz_beam_prism"
 const GOBO_TEXTURE_META_KEY: String = "peraviz_gobo_texture"
-const ACTIVE_GOBO_META_KEY: String = "peraviz_has_active_gobo_texture"
 const DEBUG_AXIS_KEY: String = "peraviz_beam_debug_axis"
 const LEGACY_MID_KEY: String = "peraviz_beam_cone_mid"
 const LEGACY_CORE_KEY: String = "peraviz_beam_cone_core"
@@ -72,19 +71,10 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	var gobo_texture: Texture2D = null
 	if light.has_meta(GOBO_TEXTURE_META_KEY):
 		gobo_texture = light.get_meta(GOBO_TEXTURE_META_KEY) as Texture2D
-	var has_active_gobo: bool = bool(params.get("has_active_gobo", light.get_meta(ACTIVE_GOBO_META_KEY, false)))
-	if gobo_texture == null:
-		has_active_gobo = false
-	if not has_active_gobo:
-		gobo_texture = null
-	var prism_mesh: ArrayMesh = null
-	if has_active_gobo:
-		var gobo_scale: float = max(float(params.get("gobo_scale", 1.0)), 0.05)
-		var gobo_rotation_deg: float = float(params.get("gobo_rotation_deg", 0.0))
-		var beam_rotation_deg: float = wrapf(gobo_rotation_deg + 180.0, 0.0, 360.0)
-		prism_mesh = _mesh_builder.build_beam_mesh(gobo_texture, lens_radius, bottom_radius, beam_range, gobo_scale, beam_rotation_deg, true)
-	else:
-		prism_mesh = _mesh_builder.build_open_beam_mesh(lens_radius, bottom_radius, beam_range)
+	var gobo_scale: float = max(float(params.get("gobo_scale", 1.0)), 0.05)
+	var gobo_rotation_deg: float = float(params.get("gobo_rotation_deg", 0.0))
+	var beam_rotation_deg: float = wrapf(gobo_rotation_deg + 180.0, 0.0, 360.0)
+	var prism_mesh: ArrayMesh = _mesh_builder.build_beam_mesh(gobo_texture, lens_radius, bottom_radius, beam_range, gobo_scale, beam_rotation_deg, true)
 	if prism_mesh != null:
 		prism.mesh = prism_mesh
 	prism.position = Vector3(lens_shift_x, lens_shift_y, -(beam_range * 0.5 + lens_offset_m))

--- a/peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd
@@ -75,10 +75,14 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	var has_active_gobo: bool = bool(params.get("has_active_gobo", light.get_meta(ACTIVE_GOBO_META_KEY, false)))
 	if not has_active_gobo:
 		gobo_texture = null
-	var gobo_scale: float = max(float(params.get("gobo_scale", 1.0)), 0.05)
-	var gobo_rotation_deg: float = float(params.get("gobo_rotation_deg", 0.0))
-	var beam_rotation_deg: float = wrapf(gobo_rotation_deg + 180.0, 0.0, 360.0)
-	var prism_mesh: ArrayMesh = _mesh_builder.build_beam_mesh(gobo_texture, lens_radius, bottom_radius, beam_range, gobo_scale, beam_rotation_deg, has_active_gobo)
+	var prism_mesh: ArrayMesh = null
+	if has_active_gobo:
+		var gobo_scale: float = max(float(params.get("gobo_scale", 1.0)), 0.05)
+		var gobo_rotation_deg: float = float(params.get("gobo_rotation_deg", 0.0))
+		var beam_rotation_deg: float = wrapf(gobo_rotation_deg + 180.0, 0.0, 360.0)
+		prism_mesh = _mesh_builder.build_beam_mesh(gobo_texture, lens_radius, bottom_radius, beam_range, gobo_scale, beam_rotation_deg, true)
+	else:
+		prism_mesh = _mesh_builder.build_open_beam_mesh(lens_radius, bottom_radius, beam_range)
 	if prism_mesh != null:
 		prism.mesh = prism_mesh
 	prism.position = Vector3(lens_shift_x, lens_shift_y, -(beam_range * 0.5 + lens_offset_m))

--- a/peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd
@@ -14,6 +14,7 @@ const LEGACY_OVERDRIVE_GAIN_MAX: float = 5.0
 
 const MAIN_KEY: String = "peraviz_beam_prism"
 const GOBO_TEXTURE_META_KEY: String = "peraviz_gobo_texture"
+const ACTIVE_GOBO_META_KEY: String = "peraviz_has_active_gobo_texture"
 const DEBUG_AXIS_KEY: String = "peraviz_beam_debug_axis"
 const LEGACY_MID_KEY: String = "peraviz_beam_cone_mid"
 const LEGACY_CORE_KEY: String = "peraviz_beam_cone_core"
@@ -71,10 +72,13 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	var gobo_texture: Texture2D = null
 	if light.has_meta(GOBO_TEXTURE_META_KEY):
 		gobo_texture = light.get_meta(GOBO_TEXTURE_META_KEY) as Texture2D
+	var has_active_gobo: bool = bool(params.get("has_active_gobo", light.get_meta(ACTIVE_GOBO_META_KEY, false)))
+	if not has_active_gobo:
+		gobo_texture = null
 	var gobo_scale: float = max(float(params.get("gobo_scale", 1.0)), 0.05)
 	var gobo_rotation_deg: float = float(params.get("gobo_rotation_deg", 0.0))
 	var beam_rotation_deg: float = wrapf(gobo_rotation_deg + 180.0, 0.0, 360.0)
-	var prism_mesh: ArrayMesh = _mesh_builder.build_beam_mesh(gobo_texture, lens_radius, bottom_radius, beam_range, gobo_scale, beam_rotation_deg)
+	var prism_mesh: ArrayMesh = _mesh_builder.build_beam_mesh(gobo_texture, lens_radius, bottom_radius, beam_range, gobo_scale, beam_rotation_deg, has_active_gobo)
 	if prism_mesh != null:
 		prism.mesh = prism_mesh
 	prism.position = Vector3(lens_shift_x, lens_shift_y, -(beam_range * 0.5 + lens_offset_m))

--- a/peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd
@@ -73,6 +73,8 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	if light.has_meta(GOBO_TEXTURE_META_KEY):
 		gobo_texture = light.get_meta(GOBO_TEXTURE_META_KEY) as Texture2D
 	var has_active_gobo: bool = bool(params.get("has_active_gobo", light.get_meta(ACTIVE_GOBO_META_KEY, false)))
+	if gobo_texture == null:
+		has_active_gobo = false
 	if not has_active_gobo:
 		gobo_texture = null
 	var prism_mesh: ArrayMesh = null

--- a/peraviz/scripts/beam_renderers/volumetric_beam_shape_provider.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_shape_provider.gd
@@ -4,7 +4,7 @@ class_name VolumetricBeamShapeProvider
 func shape_mode() -> String:
 	return "base"
 
-func apply_shape(beam: MeshInstance3D, light: SpotLight3D, params: Dictionary) -> Dictionary:
+func apply_shape(_beam: MeshInstance3D, _light: SpotLight3D, _params: Dictionary) -> Dictionary:
 	return {
 		"gobo_projection_radius": 0.1,
 		"beam_rotation_deg": 0.0,

--- a/peraviz/scripts/beam_renderers/volumetric_cone_shape_provider.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_cone_shape_provider.gd
@@ -6,7 +6,7 @@ const EMITTER_CONE_MAX_BASE_RADIUS_M: float = 10.0
 func shape_mode() -> String:
 	return "cone"
 
-func apply_shape(beam: MeshInstance3D, light: SpotLight3D, params: Dictionary) -> Dictionary:
+func apply_shape(beam: MeshInstance3D, _light: SpotLight3D, params: Dictionary) -> Dictionary:
 	var beam_range: float = max(float(params.get("beam_range", 0.1)), 0.01)
 	var beam_angle: float = max(float(params.get("beam_angle", 1.0)), 0.1)
 	var lens_radius: float = max(float(params.get("lens_radius", 0.03)), 0.005)

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -217,17 +217,10 @@ func _resolve_vector_fallback_gobo_texture() -> Texture2D:
 	image.fill(Color(0.0, 0.0, 0.0, 1.0))
 	var center: Vector2 = Vector2(float(FAKE_GOBO_TEXTURE_SIZE - 1), float(FAKE_GOBO_TEXTURE_SIZE - 1)) * 0.5
 	var outer_radius: float = float(FAKE_GOBO_TEXTURE_SIZE) * 0.48
-	var ring_width: float = max(2.0, float(FAKE_GOBO_TEXTURE_SIZE) * 0.012)
-	var white_fill_radius: float = max(0.0, outer_radius - (ring_width * 2.0))
-	var black_ring_outer_radius: float = max(white_fill_radius, outer_radius - ring_width)
 	for y in range(FAKE_GOBO_TEXTURE_SIZE):
 		for x in range(FAKE_GOBO_TEXTURE_SIZE):
 			var distance_to_center: float = Vector2(float(x), float(y)).distance_to(center)
-			if distance_to_center <= white_fill_radius:
-				image.set_pixel(x, y, Color(1.0, 1.0, 1.0, 1.0))
-			elif distance_to_center <= black_ring_outer_radius:
-				image.set_pixel(x, y, Color(0.0, 0.0, 0.0, 1.0))
-			elif distance_to_center <= outer_radius:
+			if distance_to_center <= outer_radius:
 				image.set_pixel(x, y, Color(1.0, 1.0, 1.0, 1.0))
 	var texture: ImageTexture = ImageTexture.create_from_image(image)
 	_texture_cache[VECTOR_FALLBACK_GOBO_CACHE_KEY] = texture

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -15,6 +15,10 @@ const GOBO_MAX_SCALE: float = 6.4
 const GOBO_APERTURE_SCALE: float = 1.05
 const GOBO_DEFAULT_SCALE: float = 1.0
 const GOBO_DEFAULT_ROTATION_DEG: float = 0.0
+const OPEN_APERTURE_LUMA_MEAN_MIN: float = 0.985
+const OPEN_APERTURE_LUMA_VARIATION_MAX: float = 0.02
+const OPEN_APERTURE_ALPHA_MIN: float = 0.985
+const OPEN_APERTURE_SAMPLE_GRID: int = 8
 
 var _texture_cache: Dictionary = {}
 
@@ -54,7 +58,7 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 			"gobo_slots": wheel.get("slots", []),
 		}
 		var gobo_texture: Texture2D = _resolve_gobo_texture_for_slot(wheel_controls, slot_index)
-		if gobo_texture != null:
+		if gobo_texture != null and _has_effective_gobo_pattern(gobo_texture):
 			active_textures.append(gobo_texture)
 
 	if active_textures.is_empty():
@@ -206,6 +210,44 @@ func _resolve_gobo_texture_for_slot(controls: Dictionary, slot_index: int) -> Te
 		return texture
 	return null
 
+
+func _has_effective_gobo_pattern(texture: Texture2D) -> bool:
+	if texture == null:
+		return false
+	var image: Image = texture.get_image()
+	if image == null:
+		return false
+	if image.get_format() != Image.FORMAT_RGBA8:
+		image.convert(Image.FORMAT_RGBA8)
+	var width: int = image.get_width()
+	var height: int = image.get_height()
+	if width <= 0 or height <= 0:
+		return false
+	var sample_grid: int = max(2, OPEN_APERTURE_SAMPLE_GRID)
+	var min_luma_alpha: float = 1.0
+	var max_luma_alpha: float = 0.0
+	var accum_luma_alpha: float = 0.0
+	var accum_alpha: float = 0.0
+	var samples: int = 0
+	for y_step in range(sample_grid):
+		for x_step in range(sample_grid):
+			var x: int = int(round((float(width - 1) * float(x_step)) / float(sample_grid - 1)))
+			var y: int = int(round((float(height - 1) * float(y_step)) / float(sample_grid - 1)))
+			var pixel: Color = image.get_pixel(x, y)
+			var luma: float = (pixel.r * 0.299) + (pixel.g * 0.587) + (pixel.b * 0.114)
+			var luma_alpha: float = luma * pixel.a
+			min_luma_alpha = min(min_luma_alpha, luma_alpha)
+			max_luma_alpha = max(max_luma_alpha, luma_alpha)
+			accum_luma_alpha += luma_alpha
+			accum_alpha += pixel.a
+			samples += 1
+	if samples <= 0:
+		return false
+	var mean_luma_alpha: float = accum_luma_alpha / float(samples)
+	var mean_alpha: float = accum_alpha / float(samples)
+	var variation: float = max_luma_alpha - min_luma_alpha
+	var looks_open_aperture: bool = mean_luma_alpha >= OPEN_APERTURE_LUMA_MEAN_MIN and mean_alpha >= OPEN_APERTURE_ALPHA_MIN and variation <= OPEN_APERTURE_LUMA_VARIATION_MAX
+	return not looks_open_aperture
 
 func _compose_gobo_textures(textures: Array[Texture2D]) -> Texture2D:
 	if textures.is_empty():

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -3,6 +3,7 @@ class_name FixtureGoboProjector
 
 const FAKE_GOBO_TEXTURE_SIZE: int = 1024
 const GOBO_TEXTURE_META_KEY: String = "peraviz_gobo_texture"
+const ACTIVE_GOBO_META_KEY: String = "peraviz_has_active_gobo_texture"
 const GOBO_PLANE_META_KEY: String = "peraviz_gobo_plane"
 const GOBO_SHADER_PATH: String = "res://scripts/shaders/gobo_alpha_projector.gdshader"
 const GOBO_PLANE_LOCAL_Z: float = -0.043
@@ -26,9 +27,11 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 	var previous_meta_texture: Texture2D = null
 	if light.has_meta(GOBO_TEXTURE_META_KEY):
 		previous_meta_texture = light.get_meta(GOBO_TEXTURE_META_KEY) as Texture2D
+	light.set_meta(ACTIVE_GOBO_META_KEY, false)
 	if not bool(controls.get("has_gobo", false)):
 		_clear_gobo_visuals(light)
 		light.set_meta(GOBO_TEXTURE_META_KEY, null)
+		light.set_meta(ACTIVE_GOBO_META_KEY, false)
 		return previous_meta_texture != null
 
 	var runtime_bindings: Array = controls.get("gobo_runtime_bindings", [])
@@ -57,6 +60,7 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 	if active_textures.is_empty():
 		_clear_gobo_visuals(light)
 		light.set_meta(GOBO_TEXTURE_META_KEY, null)
+		light.set_meta(ACTIVE_GOBO_META_KEY, false)
 		return previous_meta_texture != null
 
 	var composed_gobo: Texture2D = _compose_gobo_textures(active_textures)
@@ -65,6 +69,7 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 	var projected_gobo: Texture2D = _transform_gobo_texture(composed_gobo, gobo_rotation_deg, gobo_scale)
 	_apply_gobo_visuals(light, projected_gobo, controls)
 	light.set_meta(GOBO_TEXTURE_META_KEY, projected_gobo)
+	light.set_meta(ACTIVE_GOBO_META_KEY, true)
 	return projected_gobo != previous_meta_texture
 
 func _apply_gobo_visuals(light: SpotLight3D, gobo_texture: Texture2D, controls: Dictionary = {}) -> void:

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -222,15 +222,18 @@ func _resolve_vector_fallback_gobo_texture() -> Texture2D:
 	image.fill(Color(0.0, 0.0, 0.0, 1.0))
 	var center: Vector2 = Vector2(float(FAKE_GOBO_TEXTURE_SIZE - 1), float(FAKE_GOBO_TEXTURE_SIZE - 1)) * 0.5
 	var outer_radius: float = float(FAKE_GOBO_TEXTURE_SIZE) * 0.48
-	var border_width: float = max(2.0, float(FAKE_GOBO_TEXTURE_SIZE) * 0.015)
-	var inner_radius: float = max(0.0, outer_radius - border_width)
+	var ring_width: float = max(2.0, float(FAKE_GOBO_TEXTURE_SIZE) * 0.012)
+	var white_fill_radius: float = max(0.0, outer_radius - (ring_width * 2.0))
+	var black_ring_outer_radius: float = max(white_fill_radius, outer_radius - ring_width)
 	for y in range(FAKE_GOBO_TEXTURE_SIZE):
 		for x in range(FAKE_GOBO_TEXTURE_SIZE):
 			var distance_to_center: float = Vector2(float(x), float(y)).distance_to(center)
-			if distance_to_center <= inner_radius:
+			if distance_to_center <= white_fill_radius:
 				image.set_pixel(x, y, Color(1.0, 1.0, 1.0, 1.0))
-			elif distance_to_center <= outer_radius:
+			elif distance_to_center <= black_ring_outer_radius:
 				image.set_pixel(x, y, Color(0.0, 0.0, 0.0, 1.0))
+			elif distance_to_center <= outer_radius:
+				image.set_pixel(x, y, Color(1.0, 1.0, 1.0, 1.0))
 	var texture: ImageTexture = ImageTexture.create_from_image(image)
 	_texture_cache[VECTOR_FALLBACK_GOBO_CACHE_KEY] = texture
 	return texture

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -3,8 +3,6 @@ class_name FixtureGoboProjector
 
 const FAKE_GOBO_TEXTURE_SIZE: int = 1024
 const GOBO_TEXTURE_META_KEY: String = "peraviz_gobo_texture"
-const ACTIVE_GOBO_META_KEY: String = "peraviz_has_active_gobo_texture"
-const FALLBACK_GOBO_META_KEY: String = "peraviz_is_vector_fallback_gobo"
 const GOBO_PLANE_META_KEY: String = "peraviz_gobo_plane"
 const GOBO_SHADER_PATH: String = "res://scripts/shaders/gobo_alpha_projector.gdshader"
 const GOBO_PLANE_LOCAL_Z: float = -0.043
@@ -29,8 +27,6 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 	var previous_meta_texture: Texture2D = null
 	if light.has_meta(GOBO_TEXTURE_META_KEY):
 		previous_meta_texture = light.get_meta(GOBO_TEXTURE_META_KEY) as Texture2D
-	light.set_meta(ACTIVE_GOBO_META_KEY, false)
-	light.set_meta(FALLBACK_GOBO_META_KEY, false)
 	if not bool(controls.get("has_gobo", false)):
 		return _apply_vector_fallback_gobo(light, previous_meta_texture, controls)
 
@@ -66,8 +62,6 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 	var projected_gobo: Texture2D = _transform_gobo_texture(composed_gobo, gobo_rotation_deg, gobo_scale)
 	_apply_gobo_visuals(light, projected_gobo, controls)
 	light.set_meta(GOBO_TEXTURE_META_KEY, projected_gobo)
-	light.set_meta(ACTIVE_GOBO_META_KEY, true)
-	light.set_meta(FALLBACK_GOBO_META_KEY, false)
 	return projected_gobo != previous_meta_texture
 
 func _apply_gobo_visuals(light: SpotLight3D, gobo_texture: Texture2D, controls: Dictionary = {}) -> void:
@@ -211,13 +205,9 @@ func _apply_vector_fallback_gobo(light: SpotLight3D, previous_meta_texture: Text
 	if fallback_texture == null:
 		_clear_gobo_visuals(light)
 		light.set_meta(GOBO_TEXTURE_META_KEY, null)
-		light.set_meta(ACTIVE_GOBO_META_KEY, false)
-		light.set_meta(FALLBACK_GOBO_META_KEY, false)
 		return previous_meta_texture != null
 	_apply_gobo_visuals(light, fallback_texture, controls)
 	light.set_meta(GOBO_TEXTURE_META_KEY, fallback_texture)
-	light.set_meta(ACTIVE_GOBO_META_KEY, true)
-	light.set_meta(FALLBACK_GOBO_META_KEY, true)
 	return fallback_texture != previous_meta_texture
 
 func _resolve_vector_fallback_gobo_texture() -> Texture2D:

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -51,7 +51,7 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 			"gobo_slots": wheel.get("slots", []),
 		}
 		var gobo_texture: Texture2D = _resolve_gobo_texture_for_slot(wheel_controls, slot_index)
-		if gobo_texture == null:
+		if gobo_texture == null and _can_apply_missing_texture_fallback(wheel_controls, slot_index):
 			gobo_texture = _resolve_fake_gobo_texture(int(wheel.get("raw_8bit", 0)))
 		if gobo_texture != null:
 			active_textures.append(gobo_texture)
@@ -202,6 +202,17 @@ func _resolve_gobo_texture_for_slot(controls: Dictionary, slot_index: int) -> Te
 		_texture_cache[image_path] = texture
 		return texture
 	return null
+
+func _can_apply_missing_texture_fallback(controls: Dictionary, slot_index: int) -> bool:
+	var gobo_slots: Array = controls.get("gobo_slots", [])
+	for item in gobo_slots:
+		if item is not Dictionary:
+			continue
+		if int(item.get("slot_index", -1)) != slot_index:
+			continue
+		var image_path: String = str(item.get("image_path", ""))
+		return not image_path.is_empty()
+	return true
 
 func _compose_gobo_textures(textures: Array[Texture2D]) -> Texture2D:
 	if textures.is_empty():

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -15,10 +15,6 @@ const GOBO_MAX_SCALE: float = 6.4
 const GOBO_APERTURE_SCALE: float = 1.05
 const GOBO_DEFAULT_SCALE: float = 1.0
 const GOBO_DEFAULT_ROTATION_DEG: float = 0.0
-const OPEN_APERTURE_LUMA_MEAN_MIN: float = 0.985
-const OPEN_APERTURE_LUMA_VARIATION_MAX: float = 0.02
-const OPEN_APERTURE_ALPHA_MIN: float = 0.985
-const OPEN_APERTURE_SAMPLE_GRID: int = 8
 
 var _texture_cache: Dictionary = {}
 
@@ -58,7 +54,7 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 			"gobo_slots": wheel.get("slots", []),
 		}
 		var gobo_texture: Texture2D = _resolve_gobo_texture_for_slot(wheel_controls, slot_index)
-		if gobo_texture != null and _has_effective_gobo_pattern(gobo_texture):
+		if gobo_texture != null:
 			active_textures.append(gobo_texture)
 
 	if active_textures.is_empty():
@@ -211,43 +207,6 @@ func _resolve_gobo_texture_for_slot(controls: Dictionary, slot_index: int) -> Te
 	return null
 
 
-func _has_effective_gobo_pattern(texture: Texture2D) -> bool:
-	if texture == null:
-		return false
-	var image: Image = texture.get_image()
-	if image == null:
-		return false
-	if image.get_format() != Image.FORMAT_RGBA8:
-		image.convert(Image.FORMAT_RGBA8)
-	var width: int = image.get_width()
-	var height: int = image.get_height()
-	if width <= 0 or height <= 0:
-		return false
-	var sample_grid: int = max(2, OPEN_APERTURE_SAMPLE_GRID)
-	var min_luma_alpha: float = 1.0
-	var max_luma_alpha: float = 0.0
-	var accum_luma_alpha: float = 0.0
-	var accum_alpha: float = 0.0
-	var samples: int = 0
-	for y_step in range(sample_grid):
-		for x_step in range(sample_grid):
-			var x: int = int(round((float(width - 1) * float(x_step)) / float(sample_grid - 1)))
-			var y: int = int(round((float(height - 1) * float(y_step)) / float(sample_grid - 1)))
-			var pixel: Color = image.get_pixel(x, y)
-			var luma: float = (pixel.r * 0.299) + (pixel.g * 0.587) + (pixel.b * 0.114)
-			var luma_alpha: float = luma * pixel.a
-			min_luma_alpha = min(min_luma_alpha, luma_alpha)
-			max_luma_alpha = max(max_luma_alpha, luma_alpha)
-			accum_luma_alpha += luma_alpha
-			accum_alpha += pixel.a
-			samples += 1
-	if samples <= 0:
-		return false
-	var mean_luma_alpha: float = accum_luma_alpha / float(samples)
-	var mean_alpha: float = accum_alpha / float(samples)
-	var variation: float = max_luma_alpha - min_luma_alpha
-	var looks_open_aperture: bool = mean_luma_alpha >= OPEN_APERTURE_LUMA_MEAN_MIN and mean_alpha >= OPEN_APERTURE_ALPHA_MIN and variation <= OPEN_APERTURE_LUMA_VARIATION_MAX
-	return not looks_open_aperture
 
 func _compose_gobo_textures(textures: Array[Texture2D]) -> Texture2D:
 	if textures.is_empty():

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -4,6 +4,7 @@ class_name FixtureGoboProjector
 const FAKE_GOBO_TEXTURE_SIZE: int = 1024
 const GOBO_TEXTURE_META_KEY: String = "peraviz_gobo_texture"
 const ACTIVE_GOBO_META_KEY: String = "peraviz_has_active_gobo_texture"
+const FALLBACK_GOBO_META_KEY: String = "peraviz_is_vector_fallback_gobo"
 const GOBO_PLANE_META_KEY: String = "peraviz_gobo_plane"
 const GOBO_SHADER_PATH: String = "res://scripts/shaders/gobo_alpha_projector.gdshader"
 const GOBO_PLANE_LOCAL_Z: float = -0.043
@@ -29,6 +30,7 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 	if light.has_meta(GOBO_TEXTURE_META_KEY):
 		previous_meta_texture = light.get_meta(GOBO_TEXTURE_META_KEY) as Texture2D
 	light.set_meta(ACTIVE_GOBO_META_KEY, false)
+	light.set_meta(FALLBACK_GOBO_META_KEY, false)
 	if not bool(controls.get("has_gobo", false)):
 		return _apply_vector_fallback_gobo(light, previous_meta_texture, controls)
 
@@ -65,6 +67,7 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 	_apply_gobo_visuals(light, projected_gobo, controls)
 	light.set_meta(GOBO_TEXTURE_META_KEY, projected_gobo)
 	light.set_meta(ACTIVE_GOBO_META_KEY, true)
+	light.set_meta(FALLBACK_GOBO_META_KEY, false)
 	return projected_gobo != previous_meta_texture
 
 func _apply_gobo_visuals(light: SpotLight3D, gobo_texture: Texture2D, controls: Dictionary = {}) -> void:
@@ -209,10 +212,12 @@ func _apply_vector_fallback_gobo(light: SpotLight3D, previous_meta_texture: Text
 		_clear_gobo_visuals(light)
 		light.set_meta(GOBO_TEXTURE_META_KEY, null)
 		light.set_meta(ACTIVE_GOBO_META_KEY, false)
+		light.set_meta(FALLBACK_GOBO_META_KEY, false)
 		return previous_meta_texture != null
 	_apply_gobo_visuals(light, fallback_texture, controls)
 	light.set_meta(GOBO_TEXTURE_META_KEY, fallback_texture)
 	light.set_meta(ACTIVE_GOBO_META_KEY, true)
+	light.set_meta(FALLBACK_GOBO_META_KEY, true)
 	return fallback_texture != previous_meta_texture
 
 func _resolve_vector_fallback_gobo_texture() -> Texture2D:

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -15,6 +15,7 @@ const GOBO_MAX_SCALE: float = 6.4
 const GOBO_APERTURE_SCALE: float = 1.05
 const GOBO_DEFAULT_SCALE: float = 1.0
 const GOBO_DEFAULT_ROTATION_DEG: float = 0.0
+const VECTOR_FALLBACK_GOBO_CACHE_KEY: String = "__vector_fallback_gobo"
 
 var _texture_cache: Dictionary = {}
 
@@ -29,10 +30,7 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 		previous_meta_texture = light.get_meta(GOBO_TEXTURE_META_KEY) as Texture2D
 	light.set_meta(ACTIVE_GOBO_META_KEY, false)
 	if not bool(controls.get("has_gobo", false)):
-		_clear_gobo_visuals(light)
-		light.set_meta(GOBO_TEXTURE_META_KEY, null)
-		light.set_meta(ACTIVE_GOBO_META_KEY, false)
-		return previous_meta_texture != null
+		return _apply_vector_fallback_gobo(light, previous_meta_texture, controls)
 
 	var runtime_bindings: Array = controls.get("gobo_runtime_bindings", [])
 	if runtime_bindings.is_empty():
@@ -58,10 +56,7 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 			active_textures.append(gobo_texture)
 
 	if active_textures.is_empty():
-		_clear_gobo_visuals(light)
-		light.set_meta(GOBO_TEXTURE_META_KEY, null)
-		light.set_meta(ACTIVE_GOBO_META_KEY, false)
-		return previous_meta_texture != null
+		return _apply_vector_fallback_gobo(light, previous_meta_texture, controls)
 
 	var composed_gobo: Texture2D = _compose_gobo_textures(active_textures)
 	var gobo_scale: float = max(float(controls.get("gobo_scale", GOBO_DEFAULT_SCALE)), 0.05)
@@ -207,6 +202,38 @@ func _resolve_gobo_texture_for_slot(controls: Dictionary, slot_index: int) -> Te
 	return null
 
 
+
+func _apply_vector_fallback_gobo(light: SpotLight3D, previous_meta_texture: Texture2D, controls: Dictionary) -> bool:
+	var fallback_texture: Texture2D = _resolve_vector_fallback_gobo_texture()
+	if fallback_texture == null:
+		_clear_gobo_visuals(light)
+		light.set_meta(GOBO_TEXTURE_META_KEY, null)
+		light.set_meta(ACTIVE_GOBO_META_KEY, false)
+		return previous_meta_texture != null
+	_apply_gobo_visuals(light, fallback_texture, controls)
+	light.set_meta(GOBO_TEXTURE_META_KEY, fallback_texture)
+	light.set_meta(ACTIVE_GOBO_META_KEY, true)
+	return fallback_texture != previous_meta_texture
+
+func _resolve_vector_fallback_gobo_texture() -> Texture2D:
+	if _texture_cache.has(VECTOR_FALLBACK_GOBO_CACHE_KEY):
+		return _texture_cache[VECTOR_FALLBACK_GOBO_CACHE_KEY] as Texture2D
+	var image := Image.create(FAKE_GOBO_TEXTURE_SIZE, FAKE_GOBO_TEXTURE_SIZE, false, Image.FORMAT_RGBA8)
+	image.fill(Color(0.0, 0.0, 0.0, 1.0))
+	var center: Vector2 = Vector2(float(FAKE_GOBO_TEXTURE_SIZE - 1), float(FAKE_GOBO_TEXTURE_SIZE - 1)) * 0.5
+	var outer_radius: float = float(FAKE_GOBO_TEXTURE_SIZE) * 0.48
+	var border_width: float = max(2.0, float(FAKE_GOBO_TEXTURE_SIZE) * 0.015)
+	var inner_radius: float = max(0.0, outer_radius - border_width)
+	for y in range(FAKE_GOBO_TEXTURE_SIZE):
+		for x in range(FAKE_GOBO_TEXTURE_SIZE):
+			var distance_to_center: float = Vector2(float(x), float(y)).distance_to(center)
+			if distance_to_center <= inner_radius:
+				image.set_pixel(x, y, Color(1.0, 1.0, 1.0, 1.0))
+			elif distance_to_center <= outer_radius:
+				image.set_pixel(x, y, Color(0.0, 0.0, 0.0, 1.0))
+	var texture: ImageTexture = ImageTexture.create_from_image(image)
+	_texture_cache[VECTOR_FALLBACK_GOBO_CACHE_KEY] = texture
+	return texture
 
 func _compose_gobo_textures(textures: Array[Texture2D]) -> Texture2D:
 	if textures.is_empty():

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -51,8 +51,6 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 			"gobo_slots": wheel.get("slots", []),
 		}
 		var gobo_texture: Texture2D = _resolve_gobo_texture_for_slot(wheel_controls, slot_index)
-		if gobo_texture == null and _can_apply_missing_texture_fallback(wheel_controls, slot_index):
-			gobo_texture = _resolve_fake_gobo_texture(int(wheel.get("raw_8bit", 0)))
 		if gobo_texture != null:
 			active_textures.append(gobo_texture)
 
@@ -203,16 +201,6 @@ func _resolve_gobo_texture_for_slot(controls: Dictionary, slot_index: int) -> Te
 		return texture
 	return null
 
-func _can_apply_missing_texture_fallback(controls: Dictionary, slot_index: int) -> bool:
-	var gobo_slots: Array = controls.get("gobo_slots", [])
-	for item in gobo_slots:
-		if item is not Dictionary:
-			continue
-		if int(item.get("slot_index", -1)) != slot_index:
-			continue
-		var image_path: String = str(item.get("image_path", ""))
-		return not image_path.is_empty()
-	return true
 
 func _compose_gobo_textures(textures: Array[Texture2D]) -> Texture2D:
 	if textures.is_empty():
@@ -292,30 +280,3 @@ func _transform_gobo_texture(base_texture: Texture2D, rotation_deg: float, scale
 	_texture_cache[cache_key] = texture
 	return texture
 
-func _resolve_fake_gobo_texture(gobo_raw_8bit: int) -> Texture2D:
-	var fake_bucket: int = gobo_raw_8bit >> 3
-	var cache_key: String = "__fake_gobo_%d" % fake_bucket
-	if _texture_cache.has(cache_key):
-		return _texture_cache[cache_key] as Texture2D
-
-	var image := Image.create(FAKE_GOBO_TEXTURE_SIZE, FAKE_GOBO_TEXTURE_SIZE, false, Image.FORMAT_RGBA8)
-	image.fill(Color(1.0, 1.0, 1.0, 1.0))
-	if fake_bucket > 0:
-		var step: int = max(4, int(4 + (fake_bucket % 6) * 2))
-		var center: Vector2 = Vector2(FAKE_GOBO_TEXTURE_SIZE, FAKE_GOBO_TEXTURE_SIZE) * 0.5
-		var max_radius: float = float(FAKE_GOBO_TEXTURE_SIZE) * 0.48
-		for y in range(FAKE_GOBO_TEXTURE_SIZE):
-			for x in range(FAKE_GOBO_TEXTURE_SIZE):
-				var uv: Vector2 = Vector2(float(x), float(y)) - center
-				var dist: float = uv.length()
-				if dist > max_radius:
-					continue
-				var x_cell: int = int(floor(float(x) / float(step)))
-				var y_cell: int = int(floor(float(y) / float(step)))
-				var checker: bool = (((x_cell + y_cell) + fake_bucket) % 2) == 0
-				if checker:
-					image.set_pixel(x, y, Color(0.0, 0.0, 0.0, 1.0))
-
-	var texture: ImageTexture = ImageTexture.create_from_image(image)
-	_texture_cache[cache_key] = texture
-	return texture

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -1683,7 +1683,13 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 	if _fixture_gobo_projector != null:
 		var gobo_controls: Dictionary = BeamOpticsControllerScript.BuildGoboControls(controls, _visual_settings, beam_defaults)
 		_fixture_gobo_projector.apply_gobo_projection(light, gobo_controls)
-	beam_params["has_active_gobo"] = bool(light.get_meta("peraviz_has_active_gobo_texture", false))
+	var resolved_gobo_texture: Texture2D = null
+	if light.has_meta("peraviz_gobo_texture"):
+		resolved_gobo_texture = light.get_meta("peraviz_gobo_texture") as Texture2D
+	var has_active_gobo: bool = resolved_gobo_texture != null
+	if light.has_meta("peraviz_has_active_gobo_texture"):
+		has_active_gobo = has_active_gobo and bool(light.get_meta("peraviz_has_active_gobo_texture", false))
+	beam_params["has_active_gobo"] = has_active_gobo
 	light.light_volumetric_fog_energy = float(_visual_settings.get("light_volumetric_fog_energy", 12.0)) * float(_visual_settings.get("haze_density_multiplier", 0.22))
 	_update_beam_for_light(light, beam_params)
 

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -1683,6 +1683,7 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 	if _fixture_gobo_projector != null:
 		var gobo_controls: Dictionary = BeamOpticsControllerScript.BuildGoboControls(controls, _visual_settings, beam_defaults)
 		_fixture_gobo_projector.apply_gobo_projection(light, gobo_controls)
+	beam_params["has_active_gobo"] = bool(light.get_meta("peraviz_has_active_gobo_texture", false))
 	light.light_volumetric_fog_energy = float(_visual_settings.get("light_volumetric_fog_energy", 12.0)) * float(_visual_settings.get("haze_density_multiplier", 0.22))
 	_update_beam_for_light(light, beam_params)
 

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -1683,15 +1683,6 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 	if _fixture_gobo_projector != null:
 		var gobo_controls: Dictionary = BeamOpticsControllerScript.BuildGoboControls(controls, _visual_settings, beam_defaults)
 		_fixture_gobo_projector.apply_gobo_projection(light, gobo_controls)
-	var resolved_gobo_texture: Texture2D = null
-	if light.has_meta("peraviz_gobo_texture"):
-		resolved_gobo_texture = light.get_meta("peraviz_gobo_texture") as Texture2D
-	var has_active_gobo: bool = resolved_gobo_texture != null
-	if light.has_meta("peraviz_has_active_gobo_texture"):
-		has_active_gobo = has_active_gobo and bool(light.get_meta("peraviz_has_active_gobo_texture", false))
-	if light.has_meta("peraviz_is_vector_fallback_gobo"):
-		has_active_gobo = has_active_gobo and not bool(light.get_meta("peraviz_is_vector_fallback_gobo", false))
-	beam_params["has_active_gobo"] = has_active_gobo
 	light.light_volumetric_fog_energy = float(_visual_settings.get("light_volumetric_fog_energy", 12.0)) * float(_visual_settings.get("haze_density_multiplier", 0.22))
 	_update_beam_for_light(light, beam_params)
 

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -1689,6 +1689,8 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 	var has_active_gobo: bool = resolved_gobo_texture != null
 	if light.has_meta("peraviz_has_active_gobo_texture"):
 		has_active_gobo = has_active_gobo and bool(light.get_meta("peraviz_has_active_gobo_texture", false))
+	if light.has_meta("peraviz_is_vector_fallback_gobo"):
+		has_active_gobo = has_active_gobo and not bool(light.get_meta("peraviz_is_vector_fallback_gobo", false))
 	beam_params["has_active_gobo"] = has_active_gobo
 	light.light_volumetric_fog_energy = float(_visual_settings.get("light_volumetric_fog_energy", 12.0)) * float(_visual_settings.get("haze_density_multiplier", 0.22))
 	_update_beam_for_light(light, beam_params)


### PR DESCRIPTION
### Motivation
- In legacy beam mode a fallback that generated a fake gobo texture for missing textures could suppress the visible cone when the slot is intentionally empty (no gobo); we need to skip that correction for open/no-image slots while keeping existing gobo behaviour unchanged.

### Description
- Gate the fake-gobo fallback in `apply_gobo_projection(...)` by adding `_can_apply_missing_texture_fallback(...)` in `peraviz/scripts/fixture_gobo_projector.gd`, which inspects the slot metadata (`image_path`) and only allows generating a fake gobo when a slot is expected to have an image but it failed to load.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad913f207883249da250e67c9b0094)