### PR TITLE
Improve gobo prism side smoothing and reduce NORMAL-driven beam striping

### DIFF
--- a/peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd
+++ b/peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd
@@ -261,18 +261,19 @@ func _build_extruded_mesh(polygons: Array[PackedVector2Array], near_radius: floa
 	var st := SurfaceTool.new()
 	st.begin(Mesh.PRIMITIVE_TRIANGLES)
 	var half_height: float = beam_height * 0.5
+	var vertex_offset: int = 0
 	for polygon in polygons:
 		if polygon.size() < 3:
 			continue
-		_add_caps(st, polygon, near_radius, far_radius, half_height)
-		_add_sides(st, polygon, near_radius, far_radius, half_height)
+		vertex_offset = _add_caps(st, polygon, near_radius, far_radius, half_height, vertex_offset)
+		vertex_offset = _add_sides(st, polygon, near_radius, far_radius, half_height, vertex_offset)
 	st.generate_normals()
 	return st.commit()
 
-func _add_caps(st: SurfaceTool, polygon: PackedVector2Array, near_radius: float, far_radius: float, half_height: float) -> void:
+func _add_caps(st: SurfaceTool, polygon: PackedVector2Array, near_radius: float, far_radius: float, half_height: float, vertex_offset: int) -> int:
 	var indices: PackedInt32Array = Geometry2D.triangulate_polygon(polygon)
 	if indices.is_empty():
-		return
+		return vertex_offset
 	for i in range(0, indices.size(), 3):
 		var ia: int = indices[i]
 		var ib: int = indices[i + 1]
@@ -286,11 +287,19 @@ func _add_caps(st: SurfaceTool, polygon: PackedVector2Array, near_radius: float,
 		st.add_vertex(Vector3(c.x * far_radius, -half_height, c.y * far_radius))
 		st.add_vertex(Vector3(b.x * far_radius, -half_height, b.y * far_radius))
 		st.add_vertex(Vector3(a.x * far_radius, -half_height, a.y * far_radius))
+		st.add_index(vertex_offset)
+		st.add_index(vertex_offset + 1)
+		st.add_index(vertex_offset + 2)
+		st.add_index(vertex_offset + 3)
+		st.add_index(vertex_offset + 4)
+		st.add_index(vertex_offset + 5)
+		vertex_offset += 6
+	return vertex_offset
 
-func _add_sides(st: SurfaceTool, polygon: PackedVector2Array, near_radius: float, far_radius: float, half_height: float) -> void:
+func _add_sides(st: SurfaceTool, polygon: PackedVector2Array, near_radius: float, far_radius: float, half_height: float, vertex_offset: int) -> int:
 	var point_count: int = polygon.size()
 	if point_count < 2:
-		return
+		return vertex_offset
 
 	var near_indices := PackedInt32Array()
 	var far_indices := PackedInt32Array()
@@ -305,11 +314,13 @@ func _add_sides(st: SurfaceTool, polygon: PackedVector2Array, near_radius: float
 		# Using one smooth group across the full side ring enables real normal smoothing.
 		# If hard edges are needed, assign unique smooth groups per edge before adding vertices.
 		st.set_smooth_group(0)
-		near_indices[i] = st.get_vertex_count()
+		near_indices[i] = vertex_offset
 		st.add_vertex(near_vertex)
+		vertex_offset += 1
 		st.set_smooth_group(0)
-		far_indices[i] = st.get_vertex_count()
+		far_indices[i] = vertex_offset
 		st.add_vertex(far_vertex)
+		vertex_offset += 1
 
 	for i in range(point_count):
 		var next_i: int = (i + 1) % point_count
@@ -323,3 +334,4 @@ func _add_sides(st: SurfaceTool, polygon: PackedVector2Array, near_radius: float
 		st.add_index(near_current_index)
 		st.add_index(far_next_index)
 		st.add_index(far_current_index)
+	return vertex_offset

--- a/peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd
+++ b/peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd
@@ -289,16 +289,37 @@ func _add_caps(st: SurfaceTool, polygon: PackedVector2Array, near_radius: float,
 
 func _add_sides(st: SurfaceTool, polygon: PackedVector2Array, near_radius: float, far_radius: float, half_height: float) -> void:
 	var point_count: int = polygon.size()
+	if point_count < 2:
+		return
+
+	var near_indices := PackedInt32Array()
+	var far_indices := PackedInt32Array()
+	near_indices.resize(point_count)
+	far_indices.resize(point_count)
+
 	for i in range(point_count):
-		var current: Vector2 = polygon[i]
-		var next: Vector2 = polygon[(i + 1) % point_count]
-		var near_current := Vector3(current.x * near_radius, half_height, current.y * near_radius)
-		var near_next := Vector3(next.x * near_radius, half_height, next.y * near_radius)
-		var far_current := Vector3(current.x * far_radius, -half_height, current.y * far_radius)
-		var far_next := Vector3(next.x * far_radius, -half_height, next.y * far_radius)
-		st.add_vertex(near_current)
-		st.add_vertex(near_next)
-		st.add_vertex(far_next)
-		st.add_vertex(near_current)
-		st.add_vertex(far_next)
-		st.add_vertex(far_current)
+		var point: Vector2 = polygon[i]
+		var near_vertex := Vector3(point.x * near_radius, half_height, point.y * near_radius)
+		var far_vertex := Vector3(point.x * far_radius, -half_height, point.y * far_radius)
+
+		# Using one smooth group across the full side ring enables real normal smoothing.
+		# If hard edges are needed, assign unique smooth groups per edge before adding vertices.
+		st.set_smooth_group(0)
+		near_indices[i] = st.get_vertex_count()
+		st.add_vertex(near_vertex)
+		st.set_smooth_group(0)
+		far_indices[i] = st.get_vertex_count()
+		st.add_vertex(far_vertex)
+
+	for i in range(point_count):
+		var next_i: int = (i + 1) % point_count
+		var near_current_index: int = near_indices[i]
+		var near_next_index: int = near_indices[next_i]
+		var far_current_index: int = far_indices[i]
+		var far_next_index: int = far_indices[next_i]
+		st.add_index(near_current_index)
+		st.add_index(near_next_index)
+		st.add_index(far_next_index)
+		st.add_index(near_current_index)
+		st.add_index(far_next_index)
+		st.add_index(far_current_index)

--- a/peraviz/scripts/shaders/volumetric_beam.gdshader
+++ b/peraviz/scripts/shaders/volumetric_beam.gdshader
@@ -79,6 +79,13 @@ float radial_profile_from_local(vec3 local_pos) {
 	return radial_profile * mix(1.0, edge_feather, 0.82);
 }
 
+float axial_visibility_from_local(vec3 local_pos) {
+	float source_y = 0.5 * cone_height;
+	float axial_progress = clamp((source_y - local_pos.y) / max(cone_height, 0.0001), 0.0, 1.0);
+	float core = 1.0 - smoothstep(0.0, 0.95, axial_progress);
+	return max(core, 0.08);
+}
+
 float sample_gobo_mask(vec2 uv) {
 	if (uv.x < 0.0 || uv.x > 1.0 || uv.y < 0.0 || uv.y > 1.0) {
 		return 0.0;
@@ -120,11 +127,14 @@ void fragment() {
 	vec3 n = normalize(NORMAL);
 	vec3 v = normalize(-v_view);
 	float ndotv = abs(dot(n, v));
+	float normal_influence = pow(clamp(ndotv, 0.0, 1.0), facing_power);
 	float location_weight = pow(max(1.0 - axial_progress, 0.0), boost_along_y);
-	float facing_multiplier = 1.0 + (facing_boost * location_weight * pow(ndotv, facing_power));
+	float facing_multiplier = 1.0 + (facing_boost * location_weight * (0.35 * normal_influence));
 
 	float brightness = min(base_brightness * facing_multiplier, max_brightness);
-	float feather_alpha = mix(1.0 - feather_intensity, 1.0, pow(clamp(ndotv, 0.0, 1.0), feather_sharpness * max(radial_falloff, 0.05)));
+	float stable_shape = clamp((0.7 * radial_profile_from_local(v_local)) + (0.3 * axial_visibility_from_local(v_local)), 0.0, 1.0);
+	float feather_mix = (0.75 * stable_shape) + (0.25 * pow(clamp(ndotv, 0.0, 1.0), feather_sharpness * max(radial_falloff, 0.05)));
+	float feather_alpha = mix(1.0 - feather_intensity, 1.0, feather_mix);
 	feather_alpha = max(feather_alpha, 0.08);
 	float radial_profile = radial_profile_from_local(v_local);
 


### PR DESCRIPTION
### Motivation
- Vectorized gobo prism sides currently emit duplicated vertices per triangle which prevents true normal smoothing and causes visible facet striping on low-poly gobos. 
- The volumetric beam shader relied heavily on `NORMAL` for alpha/brightness which accentuates striping on faceted geometry. 

### Description
- Reworked `_add_sides` in `peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd` to emit one near/far vertex per polygon point and reuse them via indices for side quads, removing per-triangle duplication. 
- Added calls to `SurfaceTool.set_smooth_group(0)` immediately before emitting side vertices so side faces share a smoothing group and produce smooth normals, with an in-code note about using per-edge groups for hard edges. 
- Modified `peraviz/scripts/shaders/volumetric_beam.gdshader` to introduce `axial_visibility_from_local()` and blend it with the radial profile to create a more stable geometric alpha/brightness term, reducing dominant dependence on `NORMAL`. 
- Reduced the weight of `abs(dot(n, v))` by computing a `normal_influence` and using it only as a secondary contribution for facing/feathering to avoid striping while retaining some view-dependent response. 

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af1ec16ebc8324bfaebf166826eb6d)