### PR TITLE
Add native gobo vectorizer, vector metadata pipeline, and polygon cleanup

### DIFF
--- a/docs/peraviz_gobo_vectorization_assessment.md
+++ b/docs/peraviz_gobo_vectorization_assessment.md
@@ -1,0 +1,127 @@
+# Peraviz gobo vectorization assessment and C++ module proposal
+
+## Goal
+Assess how gobo vectorization is currently implemented in Peraviz (Godot), compare it against Perastage symbol vectorization (including the SVG symbol generation workflow), and evaluate the feasibility of introducing a dedicated C++ gobo vectorization module.
+
+## 1) Current implementation in Peraviz (Godot)
+
+Peraviz currently vectorizes gobos in `gobo_prism_mesh_builder.gd` through a **bitmap-to-polygon** pipeline:
+
+1. Convert gobo texture to `RGBA8` and downscale to a max size (`VECTORIZATION_MAX_SIZE = 192`).
+2. Optional mask cleanup (`_prepare_binary_mask_image`) applies border clipping and binary thresholding.
+3. Use `BitMap.create_from_image_alpha(..., VECTORIZATION_ALPHA_THRESHOLD)`.
+4. Extract polygons with `BitMap.opaque_to_polygons(..., VECTORIZATION_EPSILON)`.
+5. Normalize, rotate, scale, and Y-flip points.
+6. Apply iterative RDP-style simplification and hard cap total points.
+7. Extrude polygons to a 3D beam prism mesh.
+
+### Practical consequences
+
+- This is **fast and simple**, but it is fundamentally raster contour extraction.
+- Smooth curves are represented as dense piecewise-linear boundaries and later simplified; this can visibly degrade circles into jagged polygons.
+- There is no explicit representation of:
+  - curve primitives (arc/cubic/quadratic);
+  - topological vertex identity (shared vertices across contours);
+  - canonical contour direction (CW/CCW policy beyond implicit area sign);
+  - edge semantic orientation metadata.
+
+## 2) Perastage symbol vectorization workflow (reference)
+
+Perastage has a richer symbol workflow:
+
+- `Symbol2DImageBuilder` builds vector symbols from rendered RGBA images using:
+  - fill/background separation;
+  - contour extraction for fills with hole ownership inference;
+  - stroke extraction via skeletonization (Zhang-Suen) and graph traversal.
+- `SymbolGeometrySimplifier` applies RDP simplification to strokes and closed polygon rings.
+- The symbol preview/export pipeline writes SVG using polygon/polyline primitives.
+
+### Strengths vs Peraviz current gobo vectorization
+
+- Better separation of **fill geometry** and **stroke geometry**.
+- Hole handling and ownership are explicit in polygon-with-holes structures.
+- The process already supports production usage in a symbol generation tool and export flow.
+
+### Shared limitation with Peraviz
+
+- Geometry is still polygon/polyline based after raster analysis.
+- There is no native curve-fitting stage that emits arc/bezier primitives.
+- Therefore, both pipelines can approximate circles as segmented paths unless source data is already analytic SVG.
+
+## 3) Why circles become jagged in Peraviz gobos
+
+The observed issue (circle turning into serrated polygon) is consistent with the current stack:
+
+- Downscaling to max 192 px reduces high-frequency boundary fidelity.
+- Binary thresholding introduces staircase boundaries on anti-aliased edges.
+- `opaque_to_polygons` emits linear contours.
+- Point-reduction then removes vertices based on epsilon, which can break smoothness if tuned for budget.
+- Final mesh directly follows the resulting piecewise-linear contour.
+
+So the artifact is not a rendering bug by itself; it is an expected geometric consequence of the chosen vectorization method.
+
+## 4) Feasibility of a dedicated C++ gobo vectorization module
+
+## Recommendation
+
+**Yes, it is feasible and technically justified** to create a dedicated C++ module for gobo vectorization, especially if the objective is preserving smooth geometry and topological semantics.
+
+A native module can provide:
+
+- deterministic topology extraction;
+- curve detection/fitting (arc/bezier) before polygonization;
+- stable vertex/edge graph with shared-vertex identity;
+- consistent winding and directional metadata;
+- configurable tessellation quality for GPU mesh generation.
+
+### Proposed module scope
+
+Suggested module name and ownership:
+
+- `core/gobo_vectorization/` (engine-agnostic geometry logic)
+- optional Peraviz adapter in `peraviz/native/` to expose API to Godot.
+
+Suggested C++ API output model:
+
+- `GoboVectorShape`
+  - `std::vector<Contour>`
+- `Contour`
+  - ordered `Segments` (Line/Arc/Bezier)
+  - `winding` (CW/CCW)
+  - `is_hole`
+- `TopologyGraph`
+  - shared vertices (id + position)
+  - half-edges with direction/sense
+
+This model directly supports your request for curves, shared vertices, line direction, and orientation.
+
+## 5) Integration strategy (incremental, low risk)
+
+1. **Phase 1 (parity mode)**
+   - Move current bitmap-to-polygon logic to C++ with equivalent output.
+   - Keep Godot-side behavior visually identical.
+2. **Phase 2 (curve-aware mode, opt-in)**
+   - Add contour smoothing + analytic fitting (arcs/beziers).
+   - Keep quality/performance knobs exposed.
+3. **Phase 3 (topology-aware mesh generation)**
+   - Build extrusion from contour graph with explicit winding and edge direction.
+   - Add robust handling of holes and nested contours.
+4. **Phase 4 (regression harness)**
+   - Golden images and geometry snapshots for representative production gobos.
+   - Numeric checks: area error, Hausdorff-like contour deviation, vertex count budget.
+
+## 6) Risks and mitigations
+
+- **Performance risk**: curve fitting/topology can be heavier.
+  - Mitigate with multi-tier quality presets and cache keying.
+- **Behavior drift**: existing fixtures may change look.
+  - Mitigate with compatibility mode and A/B toggles per fixture/profile.
+- **Complexity risk**: adding geometry kernel increases maintenance.
+  - Mitigate by keeping module boundary strict and documenting contracts.
+
+## 7) Decision summary
+
+- The current Peraviz vectorization path is fit for speed and broad compatibility but not for high-fidelity smooth contours.
+- Perastage symbol tooling demonstrates stronger 2D extraction architecture, but still primarily polygonal.
+- A dedicated C++ gobo-vectorization module is a solid next step if quality and geometric semantics are priorities.
+- The best path is incremental: parity first, then curve/topology features behind guarded rollout flags.

--- a/peraviz/native/CMakeLists.txt
+++ b/peraviz/native/CMakeLists.txt
@@ -79,6 +79,7 @@ add_library(peraviz_native SHARED
     src/gdtf_scene_builder.cpp
     src/mvr_scene_loader.cpp
     src/peraviz_loader.cpp
+    src/gobo_vectorizer.cpp
     src/register_types.cpp
     src/entry.cpp
 )

--- a/peraviz/native/src/gobo_vectorizer.cpp
+++ b/peraviz/native/src/gobo_vectorizer.cpp
@@ -1,0 +1,127 @@
+#include "gobo_vectorizer.h"
+
+#include <godot_cpp/classes/bit_map.hpp>
+#include <godot_cpp/classes/image.hpp>
+#include <godot_cpp/variant/color.hpp>
+#include <godot_cpp/core/math.hpp>
+#include <godot_cpp/variant/packed_vector2_array.hpp>
+
+#include <algorithm>
+#include <cmath>
+
+namespace {
+
+constexpr int kOuterBorderPixels = 1;
+constexpr float kApertureBorderRatio = 0.985F;
+
+void prepare_binary_mask_image(const godot::Ref<godot::Image> &image,
+                               float luma_alpha_threshold,
+                               bool apply_edge_mask_correction) {
+    if (image.is_null()) {
+        return;
+    }
+
+    const int width = image->get_width();
+    const int height = image->get_height();
+    if (width <= 0 || height <= 0) {
+        return;
+    }
+
+    const godot::Vector2 center((static_cast<float>(width) - 1.0F) * 0.5F,
+                                (static_cast<float>(height) - 1.0F) * 0.5F);
+    const float aperture_radius =
+        (static_cast<float>(std::min(width, height)) * 0.5F) * kApertureBorderRatio;
+
+    for (int y = 0; y < height; ++y) {
+        for (int x = 0; x < width; ++x) {
+            if (apply_edge_mask_correction) {
+                if (x < kOuterBorderPixels || y < kOuterBorderPixels ||
+                    x >= (width - kOuterBorderPixels) ||
+                    y >= (height - kOuterBorderPixels)) {
+                    image->set_pixel(x, y, godot::Color(0.0, 0.0, 0.0, 0.0));
+                    continue;
+                }
+                const godot::Vector2 pos(static_cast<float>(x), static_cast<float>(y));
+                if (pos.distance_to(center) >= aperture_radius) {
+                    image->set_pixel(x, y, godot::Color(0.0, 0.0, 0.0, 0.0));
+                    continue;
+                }
+            }
+
+            const godot::Color sample = image->get_pixel(x, y);
+            const float luma = sample.r * 0.299F + sample.g * 0.587F + sample.b * 0.114F;
+            const float binary = (luma * sample.a) >= luma_alpha_threshold ? 1.0F : 0.0F;
+            image->set_pixel(x, y, godot::Color(binary, binary, binary, binary));
+        }
+    }
+}
+
+} // namespace
+
+namespace godot {
+
+void PeravizGoboVectorizer::_bind_methods() {
+    ClassDB::bind_method(D_METHOD("vectorize_image", "image_path", "max_size",
+                                   "luma_alpha_threshold", "apply_edge_mask_correction"),
+                         &PeravizGoboVectorizer::vectorize_image,
+                         DEFVAL(192), DEFVAL(0.5), DEFVAL(true));
+}
+
+Dictionary PeravizGoboVectorizer::vectorize_image(const String &image_path,
+                                                  int max_size,
+                                                  float luma_alpha_threshold,
+                                                  bool apply_edge_mask_correction) const {
+    Dictionary result;
+    result["ok"] = false;
+    result["width"] = 0;
+    result["height"] = 0;
+    result["polygons"] = Array();
+
+    if (image_path.is_empty()) {
+        result["error"] = String("image_path is empty");
+        return result;
+    }
+
+    Ref<Image> image;
+    image.instantiate();
+    const Error load_error = image->load(image_path);
+    if (load_error != OK) {
+        result["error"] = String("failed to load gobo image");
+        return result;
+    }
+
+    if (image->get_format() != Image::FORMAT_RGBA8) {
+        image->convert(Image::FORMAT_RGBA8);
+    }
+
+    const int longest_size = std::max(image->get_width(), image->get_height());
+    const int safe_max_size = std::max(max_size, 8);
+    if (longest_size > safe_max_size) {
+        const int target_width =
+            std::max(8, static_cast<int>(Math::round(static_cast<float>(image->get_width()) *
+                                                static_cast<float>(safe_max_size) /
+                                                static_cast<float>(longest_size))));
+        const int target_height =
+            std::max(8, static_cast<int>(Math::round(static_cast<float>(image->get_height()) *
+                                                static_cast<float>(safe_max_size) /
+                                                static_cast<float>(longest_size))));
+        image->resize(target_width, target_height, Image::INTERPOLATE_BILINEAR);
+    }
+
+    prepare_binary_mask_image(image, luma_alpha_threshold, apply_edge_mask_correction);
+
+    Ref<BitMap> bitmap;
+    bitmap.instantiate();
+    bitmap->create_from_image_alpha(image, 0.5);
+
+    const Rect2i rect(0, 0, image->get_width(), image->get_height());
+    Array polygons = bitmap->opaque_to_polygons(rect, 1.6);
+
+    result["ok"] = true;
+    result["width"] = image->get_width();
+    result["height"] = image->get_height();
+    result["polygons"] = polygons;
+    return result;
+}
+
+} // namespace godot

--- a/peraviz/native/src/gobo_vectorizer.h
+++ b/peraviz/native/src/gobo_vectorizer.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <godot_cpp/classes/object.hpp>
+#include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/variant/array.hpp>
+#include <godot_cpp/variant/dictionary.hpp>
+#include <godot_cpp/variant/string.hpp>
+
+namespace godot {
+
+class PeravizGoboVectorizer : public Object {
+    GDCLASS(PeravizGoboVectorizer, Object)
+
+protected:
+    static void _bind_methods();
+
+public:
+    Dictionary vectorize_image(const String &image_path,
+                               int max_size = 192,
+                               float luma_alpha_threshold = 0.5,
+                               bool apply_edge_mask_correction = true) const;
+};
+
+} // namespace godot

--- a/peraviz/native/src/register_types.cpp
+++ b/peraviz/native/src/register_types.cpp
@@ -2,6 +2,7 @@
 
 #include "hello_world.h"
 #include "peraviz_loader.h"
+#include "gobo_vectorizer.h"
 
 #ifdef PERAVIZ_ENABLE_DMX
 #include "peraviz_dmx_receiver.h"
@@ -14,6 +15,7 @@ void initialize_peraviz_module(godot::ModuleInitializationLevel p_level) {
 
     godot::ClassDB::register_class<godot::HelloWorld>();
     godot::ClassDB::register_class<godot::PeravizLoader>();
+    godot::ClassDB::register_class<godot::PeravizGoboVectorizer>();
 #ifdef PERAVIZ_ENABLE_DMX
     godot::ClassDB::register_class<godot::PeravizDmxReceiver>();
 #endif

--- a/peraviz/scripts/beam_renderers/gobo_polygon_cleanup.gd
+++ b/peraviz/scripts/beam_renderers/gobo_polygon_cleanup.gd
@@ -1,0 +1,113 @@
+extends RefCounted
+class_name GoboPolygonCleanup
+
+const NEAR_POINT_EPSILON: float = 0.0005
+const COLLINEAR_EPSILON: float = 0.00005
+
+static func sanitize_polygons(polygons: Array[PackedVector2Array], min_area: float) -> Array[PackedVector2Array]:
+	var output: Array[PackedVector2Array] = []
+	for polygon in polygons:
+		var sanitized: PackedVector2Array = _sanitize_single_polygon(polygon, min_area)
+		if sanitized.size() >= 3:
+			output.append(sanitized)
+	return output
+
+static func _sanitize_single_polygon(polygon: PackedVector2Array, min_area: float) -> PackedVector2Array:
+	if polygon.size() < 3:
+		return PackedVector2Array()
+
+	var deduped: PackedVector2Array = _remove_near_duplicate_points(polygon)
+	if deduped.size() < 3:
+		return PackedVector2Array()
+
+	var simplified: PackedVector2Array = _remove_collinear_points(deduped)
+	if simplified.size() < 3:
+		return PackedVector2Array()
+
+	if _has_edge_crossings(simplified):
+		simplified = _reorder_points_by_angle(simplified)
+
+	if simplified.size() < 3:
+		return PackedVector2Array()
+
+	var area: float = _signed_polygon_area(simplified)
+	if abs(area) < min_area:
+		return PackedVector2Array()
+
+	if area < 0.0:
+		simplified.reverse()
+
+	return simplified
+
+static func _remove_near_duplicate_points(polygon: PackedVector2Array) -> PackedVector2Array:
+	var result := PackedVector2Array()
+	for point in polygon:
+		if result.is_empty() or point.distance_to(result[result.size() - 1]) > NEAR_POINT_EPSILON:
+			result.append(point)
+	if result.size() > 2 and result[0].distance_to(result[result.size() - 1]) <= NEAR_POINT_EPSILON:
+		result.remove_at(result.size() - 1)
+	return result
+
+static func _remove_collinear_points(polygon: PackedVector2Array) -> PackedVector2Array:
+	if polygon.size() < 4:
+		return polygon
+	var cleaned := PackedVector2Array()
+	var count: int = polygon.size()
+	for i in range(count):
+		var prev: Vector2 = polygon[(i - 1 + count) % count]
+		var current: Vector2 = polygon[i]
+		var next: Vector2 = polygon[(i + 1) % count]
+		var cross: float = abs((current - prev).cross(next - current))
+		if cross > COLLINEAR_EPSILON:
+			cleaned.append(current)
+	return cleaned
+
+static func _has_edge_crossings(polygon: PackedVector2Array) -> bool:
+	var count: int = polygon.size()
+	if count < 4:
+		return false
+	for i in range(count):
+		var a0: Vector2 = polygon[i]
+		var a1: Vector2 = polygon[(i + 1) % count]
+		for j in range(i + 1, count):
+			if abs(i - j) <= 1:
+				continue
+			if i == 0 and j == count - 1:
+				continue
+			var b0: Vector2 = polygon[j]
+			var b1: Vector2 = polygon[(j + 1) % count]
+			if Geometry2D.segment_intersects_segment(a0, a1, b0, b1) != null:
+				return true
+	return false
+
+static func _reorder_points_by_angle(polygon: PackedVector2Array) -> PackedVector2Array:
+	var centroid := Vector2.ZERO
+	for point in polygon:
+		centroid += point
+	centroid /= float(max(polygon.size(), 1))
+
+	var items: Array[Dictionary] = []
+	for point in polygon:
+		items.append({
+			"point": point,
+			"angle": atan2(point.y - centroid.y, point.x - centroid.x),
+		})
+	items.sort_custom(func(a: Dictionary, b: Dictionary) -> bool:
+		return float(a.get("angle", 0.0)) < float(b.get("angle", 0.0))
+	)
+
+	var ordered := PackedVector2Array()
+	for item in items:
+		ordered.append(item.get("point", Vector2.ZERO) as Vector2)
+	return _remove_near_duplicate_points(ordered)
+
+static func _signed_polygon_area(polygon: PackedVector2Array) -> float:
+	var count: int = polygon.size()
+	if count < 3:
+		return 0.0
+	var area: float = 0.0
+	for i in range(count):
+		var current: Vector2 = polygon[i]
+		var next: Vector2 = polygon[(i + 1) % count]
+		area += (current.x * next.y) - (next.x * current.y)
+	return 0.5 * area

--- a/peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd
+++ b/peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd
@@ -12,7 +12,13 @@ const OUTER_BORDER_PIXELS: int = 1
 const APERTURE_BORDER_RATIO: float = 0.985
 const POINT_REDUCTION_EPSILON_START: float = 0.001
 const POINT_REDUCTION_EPSILON_MULTIPLIER: float = 1.35
-const POINT_REDUCTION_EPSILON_MAX: float = 0.25
+const POINT_REDUCTION_EPSILON_MAX: float = 0.08
+const GOBO_VECTOR_POLYGONS_META_KEY: String = "peraviz_gobo_vector_polygons"
+const GOBO_VECTOR_WIDTH_META_KEY: String = "peraviz_gobo_vector_width"
+const GOBO_VECTOR_HEIGHT_META_KEY: String = "peraviz_gobo_vector_height"
+const DEBUG_GOBO_VECTORIZATION: bool = false
+
+const GoboPolygonCleanupScript = preload("res://scripts/beam_renderers/gobo_polygon_cleanup.gd")
 
 var _mesh_cache: Dictionary = {}
 
@@ -42,6 +48,15 @@ func _shape_cache_key(gobo_texture: Texture2D, gobo_scale: float, gobo_rotation_
 func _vectorize_gobo(gobo_texture: Texture2D, gobo_scale: float, gobo_rotation_deg: float, apply_edge_mask_correction: bool = true) -> Array[PackedVector2Array]:
 	if gobo_texture == null:
 		return []
+
+	var native_polygons: Array[PackedVector2Array] = _vectorize_from_texture_metadata(gobo_texture, gobo_scale, gobo_rotation_deg)
+	if not native_polygons.is_empty():
+		var cleaned_native: Array[PackedVector2Array] = GoboPolygonCleanupScript.sanitize_polygons(native_polygons, MIN_POLYGON_AREA)
+		if not cleaned_native.is_empty():
+			if DEBUG_GOBO_VECTORIZATION:
+				print("[PeravizGoboVectorization] source=metadata polygons=", cleaned_native.size(), " points=", _count_polygon_points(cleaned_native))
+			return _reduce_polygon_point_count(cleaned_native, MAX_TOTAL_VECTOR_POINTS)
+
 	var image: Image = gobo_texture.get_image()
 	if image == null:
 		return []
@@ -54,6 +69,9 @@ func _vectorize_gobo(gobo_texture: Texture2D, gobo_scale: float, gobo_rotation_d
 		image.resize(target_width, target_height, Image.INTERPOLATE_BILINEAR)
 	if apply_edge_mask_correction:
 		_prepare_binary_mask_image(image)
+
+	if DEBUG_GOBO_VECTORIZATION:
+		print("[PeravizGoboVectorization] source=raster texture=", gobo_texture.get_rid().get_id())
 
 	var bitmap := BitMap.new()
 	bitmap.create_from_image_alpha(image, VECTORIZATION_ALPHA_THRESHOLD)
@@ -98,7 +116,59 @@ func _vectorize_gobo(gobo_texture: Texture2D, gobo_scale: float, gobo_rotation_d
 	var output: Array[PackedVector2Array] = []
 	for item in normalized:
 		output.append(item.get("polygon", PackedVector2Array()) as PackedVector2Array)
-	return _reduce_polygon_point_count(output, MAX_TOTAL_VECTOR_POINTS)
+	var cleaned_output: Array[PackedVector2Array] = GoboPolygonCleanupScript.sanitize_polygons(output, MIN_POLYGON_AREA)
+	if cleaned_output.is_empty():
+		return []
+	return _reduce_polygon_point_count(cleaned_output, MAX_TOTAL_VECTOR_POINTS)
+
+
+func _vectorize_from_texture_metadata(gobo_texture: Texture2D, gobo_scale: float, gobo_rotation_deg: float) -> Array[PackedVector2Array]:
+	if gobo_texture == null or not gobo_texture.has_meta(GOBO_VECTOR_POLYGONS_META_KEY):
+		return []
+	var raw_polygons: Array = gobo_texture.get_meta(GOBO_VECTOR_POLYGONS_META_KEY, [])
+	var source_width: int = int(gobo_texture.get_meta(GOBO_VECTOR_WIDTH_META_KEY, 0))
+	var source_height: int = int(gobo_texture.get_meta(GOBO_VECTOR_HEIGHT_META_KEY, 0))
+	if source_width <= 0 or source_height <= 0 or raw_polygons.is_empty():
+		return []
+
+	var inv_width: float = 1.0 / max(float(source_width), 1.0)
+	var inv_height: float = 1.0 / max(float(source_height), 1.0)
+	var center := Vector2(0.5, 0.5)
+	var rotation_rad: float = deg_to_rad(wrapf(gobo_rotation_deg, 0.0, 360.0))
+	var cos_r: float = cos(rotation_rad)
+	var sin_r: float = sin(rotation_rad)
+	var safe_scale: float = max(gobo_scale, 0.05)
+
+	var normalized: Array[Dictionary] = []
+	for polygon_variant in raw_polygons:
+		if polygon_variant is not PackedVector2Array:
+			continue
+		var polygon: PackedVector2Array = polygon_variant as PackedVector2Array
+		if polygon.size() < 3:
+			continue
+		var transformed := PackedVector2Array()
+		for point in polygon:
+			var uv := Vector2(point.x * inv_width, point.y * inv_height)
+			var local := (uv - center) * (2.0 / safe_scale)
+			var rotated := Vector2(
+				(local.x * cos_r) - (local.y * sin_r),
+				(local.x * sin_r) + (local.y * cos_r)
+			)
+			transformed.append(Vector2(rotated.x, -rotated.y))
+		var area: float = abs(_signed_polygon_area(transformed))
+		if area < MIN_POLYGON_AREA:
+			continue
+		normalized.append({"polygon": transformed, "area": area})
+
+	if normalized.is_empty():
+		return []
+	normalized.sort_custom(func(a: Dictionary, b: Dictionary) -> bool:
+		return float(a.get("area", 0.0)) > float(b.get("area", 0.0))
+	)
+	var output: Array[PackedVector2Array] = []
+	for item in normalized:
+		output.append(item.get("polygon", PackedVector2Array()) as PackedVector2Array)
+	return GoboPolygonCleanupScript.sanitize_polygons(output, MIN_POLYGON_AREA)
 
 func _reduce_polygon_point_count(polygons: Array[PackedVector2Array], max_points: int) -> Array[PackedVector2Array]:
 	if polygons.is_empty():
@@ -114,9 +184,11 @@ func _reduce_polygon_point_count(polygons: Array[PackedVector2Array], max_points
 			var simplified: PackedVector2Array = _simplify_closed_polygon(polygon, epsilon)
 			if simplified.size() < 3:
 				continue
-			if abs(_signed_polygon_area(simplified)) < MIN_POLYGON_AREA:
+			var cleaned_simplified: Array[PackedVector2Array] = GoboPolygonCleanupScript.sanitize_polygons([simplified], MIN_POLYGON_AREA)
+			if cleaned_simplified.is_empty():
+				iteration.append(polygon)
 				continue
-			iteration.append(simplified)
+			iteration.append(cleaned_simplified[0])
 		reduced = iteration
 		epsilon *= POINT_REDUCTION_EPSILON_MULTIPLIER
 
@@ -144,7 +216,8 @@ func _reduce_polygon_point_count(polygons: Array[PackedVector2Array], max_points
 
 	if final_polygons.is_empty():
 		final_polygons.append(sorted[0].get("polygon", PackedVector2Array()) as PackedVector2Array)
-	return final_polygons
+	var final_cleaned: Array[PackedVector2Array] = GoboPolygonCleanupScript.sanitize_polygons(final_polygons, MIN_POLYGON_AREA)
+	return final_cleaned if not final_cleaned.is_empty() else final_polygons
 
 func _count_polygon_points(polygons: Array[PackedVector2Array]) -> int:
 	var total: int = 0

--- a/peraviz/scripts/dmx_fixture_runtime.gd
+++ b/peraviz/scripts/dmx_fixture_runtime.gd
@@ -8,16 +8,20 @@ const DMX_16BIT_STEPS: int = 65536
 const DMX_24BIT_STEPS: int = 16777216
 const FORCE_COARSE_ONLY_DMX_READ: bool = false
 
+const GoboVectorizationCacheScript = preload("res://scripts/gobo_vectorization/gobo_vectorization_cache.gd")
+
 var _loader = null
 var _scene_registry: SceneRegistry = null
 var _bindings: Array = []
 var _unbound: Array = []
 var _fixture_nodes: Dictionary = {}
 var _used_universes: Dictionary = {}
+var _gobo_vectorization_cache: GoboVectorizationCache = null
 
 func configure(loader, scene_registry: SceneRegistry) -> void:
 	_loader = loader
 	_scene_registry = scene_registry
+	_gobo_vectorization_cache = GoboVectorizationCacheScript.new()
 
 func rebuild(universe_offset: int) -> Dictionary:
 	_bindings.clear()
@@ -35,6 +39,9 @@ func rebuild(universe_offset: int) -> Dictionary:
 	var result: Dictionary = _loader.build_fixture_dimmer_bindings(universe_offset)
 	_bindings = result.get("bindings", [])
 	_unbound = result.get("unbound", [])
+
+	if _gobo_vectorization_cache != null:
+		_gobo_vectorization_cache.enrich_bindings_with_vector_gobos(_bindings)
 
 	for binding in _bindings:
 		if binding is not Dictionary:

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -16,6 +16,9 @@ const GOBO_APERTURE_SCALE: float = 1.05
 const GOBO_DEFAULT_SCALE: float = 1.0
 const GOBO_DEFAULT_ROTATION_DEG: float = 0.0
 const VECTOR_FALLBACK_GOBO_CACHE_KEY: String = "__vector_fallback_gobo"
+const GOBO_VECTOR_POLYGONS_META_KEY: String = "peraviz_gobo_vector_polygons"
+const GOBO_VECTOR_WIDTH_META_KEY: String = "peraviz_gobo_vector_width"
+const GOBO_VECTOR_HEIGHT_META_KEY: String = "peraviz_gobo_vector_height"
 
 var _texture_cache: Dictionary = {}
 
@@ -197,6 +200,7 @@ func _resolve_gobo_texture_for_slot(controls: Dictionary, slot_index: int) -> Te
 		if image.get_format() != Image.FORMAT_RGBA8:
 			image.convert(Image.FORMAT_RGBA8)
 		var texture: ImageTexture = ImageTexture.create_from_image(image)
+		_apply_vector_metadata_from_slot(texture, item)
 		_texture_cache[image_path] = texture
 		return texture
 	return null
@@ -263,6 +267,8 @@ func _compose_gobo_textures(textures: Array[Texture2D]) -> Texture2D:
 				composed.set_pixel(x, y, Color(out_luma, out_luma, out_luma, out_luma))
 
 	var out_texture: ImageTexture = ImageTexture.create_from_image(composed)
+	if textures.size() == 1:
+		_copy_vector_metadata(out_texture, textures[0])
 	_texture_cache[cache_key] = out_texture
 	return out_texture
 
@@ -304,6 +310,27 @@ func _transform_gobo_texture(base_texture: Texture2D, rotation_deg: float, scale
 				continue
 			out_image.set_pixel(x, y, src_image.get_pixel(int(src_pos.x), int(src_pos.y)))
 	var texture: ImageTexture = ImageTexture.create_from_image(out_image)
+	_copy_vector_metadata(texture, base_texture)
 	_texture_cache[cache_key] = texture
 	return texture
+
+func _apply_vector_metadata_from_slot(texture: Texture2D, slot: Dictionary) -> void:
+	if texture == null:
+		return
+	if slot.has("vector_polygons"):
+		texture.set_meta(GOBO_VECTOR_POLYGONS_META_KEY, slot.get("vector_polygons", []))
+	if slot.has("vector_width"):
+		texture.set_meta(GOBO_VECTOR_WIDTH_META_KEY, int(slot.get("vector_width", 0)))
+	if slot.has("vector_height"):
+		texture.set_meta(GOBO_VECTOR_HEIGHT_META_KEY, int(slot.get("vector_height", 0)))
+
+func _copy_vector_metadata(target_texture: Texture2D, source_texture: Texture2D) -> void:
+	if target_texture == null or source_texture == null:
+		return
+	if source_texture.has_meta(GOBO_VECTOR_POLYGONS_META_KEY):
+		target_texture.set_meta(GOBO_VECTOR_POLYGONS_META_KEY, source_texture.get_meta(GOBO_VECTOR_POLYGONS_META_KEY))
+	if source_texture.has_meta(GOBO_VECTOR_WIDTH_META_KEY):
+		target_texture.set_meta(GOBO_VECTOR_WIDTH_META_KEY, source_texture.get_meta(GOBO_VECTOR_WIDTH_META_KEY))
+	if source_texture.has_meta(GOBO_VECTOR_HEIGHT_META_KEY):
+		target_texture.set_meta(GOBO_VECTOR_HEIGHT_META_KEY, source_texture.get_meta(GOBO_VECTOR_HEIGHT_META_KEY))
 

--- a/peraviz/scripts/gobo_vectorization/gobo_vectorization_cache.gd
+++ b/peraviz/scripts/gobo_vectorization/gobo_vectorization_cache.gd
@@ -1,0 +1,71 @@
+extends RefCounted
+class_name GoboVectorizationCache
+
+const VECTOR_POLYGONS_KEY: String = "vector_polygons"
+const VECTOR_WIDTH_KEY: String = "vector_width"
+const VECTOR_HEIGHT_KEY: String = "vector_height"
+const VECTORIZATION_MAX_SIZE: int = 512
+const VECTORIZATION_LUMA_ALPHA_THRESHOLD: float = 0.5
+
+var _native_vectorizer: Object = null
+var _cache_by_image_path: Dictionary = {}
+
+func _init() -> void:
+	if ClassDB.class_exists("PeravizGoboVectorizer"):
+		_native_vectorizer = ClassDB.instantiate("PeravizGoboVectorizer")
+
+func is_available() -> bool:
+	return _native_vectorizer != null
+
+func clear() -> void:
+	_cache_by_image_path.clear()
+
+func enrich_bindings_with_vector_gobos(bindings: Array) -> void:
+	if not is_available():
+		return
+	for index in range(bindings.size()):
+		var binding: Variant = bindings[index]
+		if binding is not Dictionary:
+			continue
+		var updated_binding: Dictionary = (binding as Dictionary).duplicate(true)
+		updated_binding["gobo_slots"] = _enrich_slots(updated_binding.get("gobo_slots", []))
+		updated_binding["gobo1_slots"] = _enrich_slots(updated_binding.get("gobo1_slots", []))
+		updated_binding["gobo_wheels"] = _enrich_wheels(updated_binding.get("gobo_wheels", []))
+		bindings[index] = updated_binding
+
+func _enrich_wheels(raw_wheels: Array) -> Array:
+	var enriched: Array = []
+	for wheel_variant in raw_wheels:
+		if wheel_variant is not Dictionary:
+			enriched.append(wheel_variant)
+			continue
+		var wheel: Dictionary = (wheel_variant as Dictionary).duplicate(true)
+		wheel["slots"] = _enrich_slots(wheel.get("slots", []))
+		enriched.append(wheel)
+	return enriched
+
+func _enrich_slots(raw_slots: Array) -> Array:
+	var enriched: Array = []
+	for slot_variant in raw_slots:
+		if slot_variant is not Dictionary:
+			enriched.append(slot_variant)
+			continue
+		var slot: Dictionary = (slot_variant as Dictionary).duplicate(true)
+		var image_path: String = str(slot.get("image_path", ""))
+		if image_path.is_empty():
+			enriched.append(slot)
+			continue
+		var cached: Dictionary = _get_or_create_vector_entry(image_path)
+		if bool(cached.get("ok", false)):
+			slot[VECTOR_POLYGONS_KEY] = cached.get("polygons", [])
+			slot[VECTOR_WIDTH_KEY] = int(cached.get("width", 0))
+			slot[VECTOR_HEIGHT_KEY] = int(cached.get("height", 0))
+		enriched.append(slot)
+	return enriched
+
+func _get_or_create_vector_entry(image_path: String) -> Dictionary:
+	if _cache_by_image_path.has(image_path):
+		return _cache_by_image_path[image_path] as Dictionary
+	var result: Dictionary = _native_vectorizer.call("vectorize_image", image_path, VECTORIZATION_MAX_SIZE, VECTORIZATION_LUMA_ALPHA_THRESHOLD, true)
+	_cache_by_image_path[image_path] = result
+	return result


### PR DESCRIPTION
### Motivation

- Provide a native C++ vectorization entrypoint to enable deterministic and higher-fidelity gobo extraction and to prepare for curve/topology-aware features.
- Avoid jagged circle artifacts caused by the existing bitmap-to-polygon raster pipeline and allow production-imported vector geometry to be preserved end-to-end. 
- Expose vectorization results as texture metadata so the GDScript pipeline can prefer precomputed vector polygons and reduce runtime raster analysis.

### Description

- Added a design/assessment doc `docs/peraviz_gobo_vectorization_assessment.md` describing the rationale and proposed C++ module API. 
- Implemented a native Godot binding `PeravizGoboVectorizer` in `peraviz/native/src/gobo_vectorizer.cpp`/`.h`, registered it in `register_types.cpp`, and added it to the `peraviz/native/CMakeLists.txt` build sources. 
- Added a runtime vectorization cache `peraviz/scripts/gobo_vectorization/gobo_vectorization_cache.gd` that calls the native vectorizer to enrich fixture/gobo slot metadata. 
- Added polygon sanitation logic in `peraviz/scripts/beam_renderers/gobo_polygon_cleanup.gd` and integrated it into the pipeline to remove duplicates, collinear points, crossings, small areas, and to enforce winding. 
- Updated `peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd` to: prefer metadata polygons when present, normalize/transform metadata-sourced polygons, call the cleanup script, tighten simplification bounds (`POINT_REDUCTION_EPSILON_MAX`), and use the cleanup during simplification and final selection. 
- Updated `peraviz/scripts/fixture_gobo_projector.gd` to copy/propagate vector metadata from slot definitions and compositions, and to set metadata on transformed/composed textures. 
- Updated `peraviz/scripts/dmx_fixture_runtime.gd` to instantiate and use the `GoboVectorizationCache` for binding enrichment. 

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aff5f388fc8324b1b911b1406d911d)