### PR TITLE
Add unified hoist metadata flow with preset-backed UI editing

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtfnet.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/geometry/RdpSimplifier.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/guiconfigservices.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/hoistpresetlibrary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layouts/LayoutCollection.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layouts/LayoutManager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layouts/LayoutTemplateSerializer.cpp

--- a/core/hoistpresetlibrary.cpp
+++ b/core/hoistpresetlibrary.cpp
@@ -1,0 +1,77 @@
+#include "hoistpresetlibrary.h"
+
+#include "projectutils.h"
+#include "support.h"
+#include "json.hpp"
+
+#include <filesystem>
+#include <fstream>
+
+namespace fs = std::filesystem;
+using json = nlohmann::json;
+
+namespace {
+
+float ReadFloat(const json &obj, const char *key) {
+  auto it = obj.find(key);
+  if (it == obj.end())
+    return 0.0f;
+  if (it->is_number_float())
+    return it->get<float>();
+  if (it->is_number_integer())
+    return static_cast<float>(it->get<int>());
+  return 0.0f;
+}
+
+} // namespace
+
+namespace HoistPresetLibrary {
+
+std::vector<HoistPreset> LoadPresets() {
+  std::vector<HoistPreset> presets;
+  const std::string baseDir = ProjectUtils::GetDefaultLibraryPath("hoists");
+  if (baseDir.empty())
+    return presets;
+
+  const fs::path filePath = fs::u8path(baseDir) / "hoist_presets.json";
+  if (!fs::exists(filePath))
+    return presets;
+
+  std::ifstream input(filePath);
+  if (!input.is_open())
+    return presets;
+
+  json root;
+  input >> root;
+  if (!root.is_array())
+    return presets;
+
+  for (const auto &entry : root) {
+    if (!entry.is_object())
+      continue;
+
+    HoistPreset preset;
+    preset.id = entry.value("id", "");
+    preset.name = entry.value("name", "");
+    preset.motorName = entry.value("motorName", "");
+    preset.dummyPreset = entry.value("dummyPreset", "");
+    preset.capacityKg = ReadFloat(entry, "capacityKg");
+    preset.weightKg = ReadFloat(entry, "weightKg");
+    preset.hoistFunction = NormalizeHoistFunction(entry.value("hoistFunction", "Lighting"));
+    if (!preset.dummyPreset.empty())
+      presets.push_back(preset);
+  }
+
+  return presets;
+}
+
+std::optional<HoistPreset> FindByDummyPreset(const std::string &dummyPreset) {
+  const auto presets = LoadPresets();
+  for (const auto &preset : presets) {
+    if (preset.dummyPreset == dummyPreset)
+      return preset;
+  }
+  return std::nullopt;
+}
+
+} // namespace HoistPresetLibrary

--- a/core/hoistpresetlibrary.h
+++ b/core/hoistpresetlibrary.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+struct HoistPreset {
+  std::string id;
+  std::string name;
+  std::string motorName;
+  std::string dummyPreset;
+  float capacityKg = 0.0f;
+  float weightKg = 0.0f;
+  std::string hoistFunction = "Lighting";
+};
+
+namespace HoistPresetLibrary {
+std::vector<HoistPreset> LoadPresets();
+std::optional<HoistPreset> FindByDummyPreset(const std::string &dummyPreset);
+} // namespace HoistPresetLibrary

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -22,6 +22,7 @@
 #include "configmanager.h"
 #include "guiconfigservices.h"
 #include "layerpanel.h"
+#include "hoistpresetlibrary.h"
 #include "matrixutils.h"
 #include "riggingpanel.h"
 #include "stringutils.h"
@@ -32,6 +33,7 @@
 #include "viewer3dpanel.h"
 #include <algorithm>
 #include <cctype>
+#include <optional>
 #include <wx/choicdlg.h>
 #include <wx/notebook.h>
 #include <wx/wupdlock.h> // freeze/thaw UI during batch edits
@@ -55,6 +57,29 @@ struct RangeParts {
 bool IsNumChar(char c) {
   return std::isdigit(static_cast<unsigned char>(c)) || c == '.' || c == '-' ||
          c == '+';
+}
+
+
+std::optional<HoistPresetDefaults> FindPresetDefaults(const std::string &dummyPreset) {
+  if (dummyPreset.empty())
+    return std::nullopt;
+  auto preset = HoistPresetLibrary::FindByDummyPreset(dummyPreset);
+  if (!preset.has_value())
+    return std::nullopt;
+  HoistPresetDefaults defaults;
+  defaults.capacityKg = preset->capacityKg;
+  defaults.weightKg = preset->weightKg;
+  defaults.hoistFunction = preset->hoistFunction;
+  return defaults;
+}
+
+wxArrayString BuildDummyPresetChoices() {
+  wxArrayString choices;
+  choices.push_back("");
+  const auto presets = HoistPresetLibrary::LoadPresets();
+  for (const auto &preset : presets)
+    choices.push_back(wxString::FromUTF8(preset.dummyPreset));
+  return choices;
 }
 
 RangeParts SplitRangeParts(const wxString &value) {
@@ -136,12 +161,13 @@ HoistTablePanel::HoistTablePanel(wxWindow *parent, IGuiConfigServices *services)
 HoistTablePanel::~HoistTablePanel() { store = nullptr; }
 
 void HoistTablePanel::InitializeTable() {
-  columnLabels = {"Hoist ID",    "Name",       "Type",      "Function",
-                  "Layer",       "Hang Pos",   "Pos X",     "Pos Y",
-                  "Pos Z",       "Roll (X)",   "Pitch (Y)", "Yaw (Z)",
+  columnLabels = {"Hoist ID",      "Name",          "Type",      "Function",
+                  "Motor",         "Dummy Preset",  "Data Source", "Layer",
+                  "Hang Pos",      "Pos X",         "Pos Y",     "Pos Z",
+                  "Roll (X)",      "Pitch (Y)",     "Yaw (Z)",
                   "Chain Length (m)", "Capacity (kg)", "Weight (kg)"};
-  std::vector<int> widths = {70,  150, 120, 120, 100, 120, 80,  80,
-                             80,  80,  80,  80,  110, 110, 100};
+  std::vector<int> widths = {70, 150, 120, 120, 130, 150, 110, 100, 120,
+                             80, 80, 80, 80, 80, 80, 110, 110, 100};
   for (size_t i = 0; i < columnLabels.size(); ++i)
     table->AppendColumn(new wxDataViewColumn(
         columnLabels[i], new ColorfulTextRenderer(wxDATAVIEW_CELL_INERT,
@@ -180,8 +206,14 @@ void HoistTablePanel::ReloadData() {
     row.push_back(wxVariant(hoistId));
     wxString name = wxString::FromUTF8(support.name);
     wxString type = wxString::FromUTF8(support.function);
+    support.hoistDataSource = NormalizeHoistDataSource(support.hoistDataSource);
+    const auto effective =
+        ResolveEffectiveSupportData(support, FindPresetDefaults(support.dummyPreset));
     support.hoistFunction = NormalizeHoistFunction(support.hoistFunction);
-    wxString hoistFunction = wxString::FromUTF8(support.hoistFunction);
+    wxString hoistFunction = wxString::FromUTF8(effective.hoistFunction);
+    wxString motorName = wxString::FromUTF8(support.motorName);
+    wxString dummyPreset = wxString::FromUTF8(support.dummyPreset);
+    wxString dataSource = wxString::FromUTF8(support.hoistDataSource);
     wxString layer = support.layer == DEFAULT_LAYER_NAME
                          ? wxString()
                          : wxString::FromUTF8(support.layer);
@@ -198,12 +230,15 @@ void HoistTablePanel::ReloadData() {
     wxString yaw = wxString::Format("%.1f", euler[0]) + DegreeSymbol();
 
     wxString chainLen = wxString::Format("%.2f", support.chainLength);
-    wxString capacity = wxString::Format("%.2f", support.capacityKg);
-    wxString weight = wxString::Format("%.2f", support.weightKg);
+    wxString capacity = wxString::Format("%.2f", effective.capacityKg);
+    wxString weight = wxString::Format("%.2f", effective.weightKg);
 
     row.push_back(name);
     row.push_back(type);
     row.push_back(hoistFunction);
+    row.push_back(motorName);
+    row.push_back(dummyPreset);
+    row.push_back(dataSource);
     row.push_back(layer);
     row.push_back(posName);
     row.push_back(posX);
@@ -304,7 +339,54 @@ void HoistTablePanel::OnContextMenu(wxDataViewEvent &event) {
     return;
   }
 
-  if (col == 4) {
+  if (col == 5) {
+    wxArrayString choices = BuildDummyPresetChoices();
+    wxSingleChoiceDialog sdlg(this, "Select dummy preset", "Dummy Preset", choices);
+    if (sdlg.ShowModal() != wxID_OK)
+      return;
+    wxString sel = sdlg.GetStringSelection();
+    for (const auto &itSel : selections) {
+      int r = table->ItemToRow(itSel);
+      if (r != wxNOT_FOUND)
+        table->SetValue(wxVariant(sel), r, col);
+    }
+    ResyncRows(oldOrder, selectedUuids);
+    UpdateSceneData();
+    if (Viewer3DPanel::Instance()) {
+      Viewer3DPanel::Instance()->UpdateScene();
+      Viewer3DPanel::Instance()->Refresh();
+    } else if (Viewer2DPanel::Instance()) {
+      Viewer2DPanel::Instance()->UpdateScene();
+    }
+    return;
+  }
+
+  if (col == 6) {
+    wxArrayString choices;
+    choices.push_back("Inherited");
+    choices.push_back("Manual");
+    wxSingleChoiceDialog sdlg(this, "Select data source", "Data Source", choices);
+    if (sdlg.ShowModal() != wxID_OK)
+      return;
+    wxString sel = sdlg.GetStringSelection();
+    for (const auto &itSel : selections) {
+      int r = table->ItemToRow(itSel);
+      if (r != wxNOT_FOUND)
+        table->SetValue(wxVariant(sel), r, col);
+    }
+    ResyncRows(oldOrder, selectedUuids);
+    UpdateSceneData();
+    ReloadData();
+    if (Viewer3DPanel::Instance()) {
+      Viewer3DPanel::Instance()->UpdateScene();
+      Viewer3DPanel::Instance()->Refresh();
+    } else if (Viewer2DPanel::Instance()) {
+      Viewer2DPanel::Instance()->UpdateScene();
+    }
+    return;
+  }
+
+  if (col == 7) {
     auto layers = guiConfigServices->LegacyConfigManager().GetLayerNames();
     wxArrayString choices;
     for (const auto &n : layers)
@@ -338,10 +420,10 @@ void HoistTablePanel::OnContextMenu(wxDataViewEvent &event) {
 
   wxString value = dlg.GetValue().Trim(true).Trim(false);
 
-  bool numericCol = (col >= 6);
+  bool numericCol = (col >= 9);
   bool relative = false;
   double delta = 0.0;
-  if (numericCol && col <= 14 &&
+  if (numericCol && col <= 17 &&
       (value.StartsWith("++") || value.StartsWith("--"))) {
     wxString numStr = value.Mid(2);
     if (numStr.ToDouble(&delta)) {
@@ -360,7 +442,7 @@ void HoistTablePanel::OnContextMenu(wxDataViewEvent &event) {
         wxVariant cv;
         table->GetValue(cv, r, col);
         wxString cur = cv.GetString();
-        if (col >= 9 && col <= 11) {
+        if (col >= 12 && col <= 14) {
           if (!DegreeSymbol().empty())
             cur.Replace(DegreeSymbol(), "");
         }
@@ -368,10 +450,10 @@ void HoistTablePanel::OnContextMenu(wxDataViewEvent &event) {
         cur.ToDouble(&curVal);
         double newVal = curVal + delta;
         wxString out;
-        if (col >= 9 && col <= 11)
+        if (col >= 12 && col <= 14)
           out = wxString::Format("%.1f", newVal) + DegreeSymbol();
         else
-          out = wxString::Format((col == 12) ? "%.2f" : "%.3f", newVal);
+          out = wxString::Format((col == 15) ? "%.2f" : "%.3f", newVal);
         table->SetValue(wxVariant(out), r, col);
       }
     } else {
@@ -412,10 +494,10 @@ void HoistTablePanel::OnContextMenu(wxDataViewEvent &event) {
           val = v1 + static_cast<double>(i);
 
         wxString out;
-        if (col >= 9 && col <= 11)
+        if (col >= 12 && col <= 14)
           out = wxString::Format("%.1f", val) + DegreeSymbol();
         else
-          out = wxString::Format((col == 12) ? "%.2f" : "%.3f", val);
+          out = wxString::Format((col == 15) ? "%.2f" : "%.3f", val);
 
         int r = table->ItemToRow(selections[i]);
         if (r != wxNOT_FOUND)
@@ -557,39 +639,49 @@ void HoistTablePanel::UpdateSceneData(bool logChanges) {
     next.hoistFunction = NormalizeHoistFunction(std::string(v.GetString().ToUTF8()));
 
     table->GetValue(v, i, 4);
+    next.motorName = std::string(v.GetString().ToUTF8());
+
+    table->GetValue(v, i, 5);
+    next.dummyPreset = std::string(v.GetString().ToUTF8());
+
+    table->GetValue(v, i, 6);
+    next.hoistDataSource =
+        NormalizeHoistDataSource(std::string(v.GetString().ToUTF8()));
+
+    table->GetValue(v, i, 7);
     std::string layerStr = std::string(v.GetString().ToUTF8());
     if (layerStr.empty())
       next.layer.clear();
     else
       next.layer = layerStr;
 
-    table->GetValue(v, i, 5);
+    table->GetValue(v, i, 8);
     next.positionName = std::string(v.GetString().ToUTF8());
 
     double x = 0, y = 0, z = 0;
-    table->GetValue(v, i, 6);
+    table->GetValue(v, i, 9);
     v.GetString().ToDouble(&x);
-    table->GetValue(v, i, 7);
+    table->GetValue(v, i, 10);
     v.GetString().ToDouble(&y);
-    table->GetValue(v, i, 8);
+    table->GetValue(v, i, 11);
     v.GetString().ToDouble(&z);
 
     double roll = 0, pitch = 0, yaw = 0;
-    table->GetValue(v, i, 9);
+    table->GetValue(v, i, 12);
     {
       wxString s = v.GetString();
       if (!DegreeSymbol().empty())
             s.Replace(DegreeSymbol(), "");
       s.ToDouble(&roll);
     }
-    table->GetValue(v, i, 10);
+    table->GetValue(v, i, 13);
     {
       wxString s = v.GetString();
       if (!DegreeSymbol().empty())
             s.Replace(DegreeSymbol(), "");
       s.ToDouble(&pitch);
     }
-    table->GetValue(v, i, 11);
+    table->GetValue(v, i, 14);
     {
       wxString s = v.GetString();
       if (!DegreeSymbol().empty())
@@ -619,23 +711,35 @@ void HoistTablePanel::UpdateSceneData(bool logChanges) {
            static_cast<float>(z * 1000.0)});
     }
 
-    table->GetValue(v, i, 12);
+    table->GetValue(v, i, 15);
     double chainLen = 0.0;
     v.GetString().ToDouble(&chainLen);
     next.chainLength = static_cast<float>(chainLen);
 
-    table->GetValue(v, i, 13);
+    table->GetValue(v, i, 16);
     double capacity = 0.0;
     v.GetString().ToDouble(&capacity);
     next.capacityKg = static_cast<float>(capacity);
 
-    table->GetValue(v, i, 14);
+    table->GetValue(v, i, 17);
     double weight = 0.0;
     v.GetString().ToDouble(&weight);
     next.weightKg = static_cast<float>(weight);
 
+    if (!IsManualHoistDataSource(next.hoistDataSource)) {
+      const auto effective =
+          ResolveEffectiveSupportData(next, FindPresetDefaults(next.dummyPreset));
+      next.capacityKg = effective.capacityKg;
+      next.weightKg = effective.weightKg;
+      next.hoistFunction = effective.hoistFunction;
+    }
+
     const bool supportChanged = old.name != next.name || old.function != next.function ||
                                 old.hoistFunction != next.hoistFunction ||
+                                old.motorName != next.motorName ||
+                                old.dummyPreset != next.dummyPreset ||
+                                NormalizeHoistDataSource(old.hoistDataSource) !=
+                                    NormalizeHoistDataSource(next.hoistDataSource) ||
                                 old.layer != next.layer ||
                                 old.positionName != next.positionName || transformChanged ||
                                 old.chainLength != next.chainLength ||

--- a/library/hoists/hoist_presets.json
+++ b/library/hoists/hoist_presets.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "dummy_chainmaster_d8plus_1000",
+    "name": "ChainMaster D8+ 1000kg",
+    "motorName": "ChainMaster D8+",
+    "dummyPreset": "D8+ 1000kg",
+    "capacityKg": 1000.0,
+    "weightKg": 42.0,
+    "hoistFunction": "Lighting"
+  },
+  {
+    "id": "dummy_lodestar_500",
+    "name": "CM Lodestar 500kg",
+    "motorName": "CM Lodestar",
+    "dummyPreset": "Lodestar 500kg",
+    "capacityKg": 500.0,
+    "weightKg": 31.5,
+    "hoistFunction": "Audio"
+  }
+]

--- a/models/support.h
+++ b/models/support.h
@@ -21,6 +21,7 @@
 #include <array>
 #include <cctype>
 #include <charconv>
+#include <optional>
 #include <string>
 #include "types.h"
 
@@ -38,6 +39,10 @@ struct Support {
 
     float capacityKg = 0.0f;
     float weightKg = 0.0f;
+    std::string motorName;
+    std::string dummyPreset;
+    // Defines whether values come from library defaults or user overrides.
+    std::string hoistDataSource = "Inherited";
     // Hoist function/category. Defaults to values returned by GetHoistFunctionOptions().
     std::string hoistFunction = "Lighting";
 
@@ -84,4 +89,64 @@ inline std::string NormalizeHoistFunction(const std::string &rawValue) {
     }
 
     return trimmed;
+}
+
+inline std::string NormalizeHoistDataSource(const std::string &rawValue) {
+    auto trimmed = rawValue;
+    auto trimSpaces = [](std::string &s) {
+        auto notSpace = [](unsigned char ch) { return !std::isspace(ch); };
+        s.erase(s.begin(), std::find_if(s.begin(), s.end(), notSpace));
+        s.erase(std::find_if(s.rbegin(), s.rend(), notSpace).base(), s.end());
+    };
+    trimSpaces(trimmed);
+    if (trimmed.empty())
+        return "Inherited";
+
+    std::transform(trimmed.begin(), trimmed.end(), trimmed.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    if (trimmed == "manual")
+        return "Manual";
+    if (trimmed == "inherited")
+        return "Inherited";
+    return "Inherited";
+}
+
+inline bool IsManualHoistDataSource(const std::string &source) {
+    return NormalizeHoistDataSource(source) == "Manual";
+}
+
+struct HoistPresetDefaults {
+    float capacityKg = 0.0f;
+    float weightKg = 0.0f;
+    std::string hoistFunction;
+};
+
+struct EffectiveSupportData {
+    float capacityKg = 0.0f;
+    float weightKg = 0.0f;
+    std::string hoistFunction = "Lighting";
+    std::string dataSource = "Inherited";
+};
+
+inline EffectiveSupportData ResolveEffectiveSupportData(
+    const Support &support,
+    const std::optional<HoistPresetDefaults> &presetDefaults = std::nullopt) {
+    EffectiveSupportData resolved;
+    resolved.dataSource = NormalizeHoistDataSource(support.hoistDataSource);
+
+    if (resolved.dataSource == "Inherited" && presetDefaults.has_value()) {
+        resolved.capacityKg = presetDefaults->capacityKg;
+        resolved.weightKg = presetDefaults->weightKg;
+        const std::string inheritedFunction =
+            presetDefaults->hoistFunction.empty() ? support.hoistFunction
+                                                  : presetDefaults->hoistFunction;
+        resolved.hoistFunction = NormalizeHoistFunction(inheritedFunction);
+        return resolved;
+    }
+
+    resolved.capacityKg = support.capacityKg;
+    resolved.weightKg = support.weightKg;
+    resolved.hoistFunction = NormalizeHoistFunction(
+        support.hoistFunction.empty() ? support.function : support.hoistFunction);
+    return resolved;
 }

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -1309,7 +1309,9 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
     se->InsertEndChild(mat);
 
     bool hasMeta = s.capacityKg != 0.0f || s.weightKg != 0.0f ||
-                   !s.hoistFunction.empty();
+                   !s.hoistFunction.empty() || !s.motorName.empty() ||
+                   !s.dummyPreset.empty() ||
+                   NormalizeHoistDataSource(s.hoistDataSource) != "Inherited";
     if (hasMeta) {
       tinyxml2::XMLElement *ud = doc.NewElement("UserData");
       tinyxml2::XMLElement *data = doc.NewElement("Data");
@@ -1331,11 +1333,25 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
       addNum("Weight", s.weightKg, "kg");
 
       if (!s.hoistFunction.empty()) {
-        tinyxml2::XMLElement *rp = doc.NewElement("RiggingPoint");
+        tinyxml2::XMLElement *functionNode = doc.NewElement("Function");
         std::string hoistFunction = NormalizeHoistFunction(s.hoistFunction);
-        rp->SetText(hoistFunction.c_str());
-        info->InsertEndChild(rp);
+        functionNode->SetText(hoistFunction.c_str());
+        info->InsertEndChild(functionNode);
       }
+      if (!s.motorName.empty()) {
+        tinyxml2::XMLElement *motorNode = doc.NewElement("MotorName");
+        motorNode->SetText(s.motorName.c_str());
+        info->InsertEndChild(motorNode);
+      }
+      if (!s.dummyPreset.empty()) {
+        tinyxml2::XMLElement *presetNode = doc.NewElement("DummyPreset");
+        presetNode->SetText(s.dummyPreset.c_str());
+        info->InsertEndChild(presetNode);
+      }
+      tinyxml2::XMLElement *sourceNode = doc.NewElement("DataSource");
+      const std::string source = NormalizeHoistDataSource(s.hoistDataSource);
+      sourceNode->SetText(source.c_str());
+      info->InsertEndChild(sourceNode);
 
       data->InsertEndChild(info);
       ud->InsertEndChild(data);

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -1137,10 +1137,25 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
               };
               readFloat("Capacity", support.capacityKg);
               readFloat("Weight", support.weightKg);
-              if (tinyxml2::XMLElement *rp =
-                      info->FirstChildElement("RiggingPoint")) {
+              if (tinyxml2::XMLElement *fn = info->FirstChildElement("Function")) {
+                if (const char *txt = fn->GetText())
+                  support.hoistFunction = NormalizeHoistFunction(Trim(txt));
+              } else if (tinyxml2::XMLElement *rp =
+                             info->FirstChildElement("RiggingPoint")) {
                 if (const char *txt = rp->GetText())
                   support.hoistFunction = NormalizeHoistFunction(Trim(txt));
+              }
+              if (tinyxml2::XMLElement *mn = info->FirstChildElement("MotorName")) {
+                if (const char *txt = mn->GetText())
+                  support.motorName = Trim(txt);
+              }
+              if (tinyxml2::XMLElement *dp = info->FirstChildElement("DummyPreset")) {
+                if (const char *txt = dp->GetText())
+                  support.dummyPreset = Trim(txt);
+              }
+              if (tinyxml2::XMLElement *ds = info->FirstChildElement("DataSource")) {
+                if (const char *txt = ds->GetText())
+                  support.hoistDataSource = NormalizeHoistDataSource(Trim(txt));
               }
             }
           }
@@ -1149,6 +1164,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         if (support.hoistFunction.empty())
           support.hoistFunction = NormalizeHoistFunction(support.function);
 
+        support.hoistDataSource = NormalizeHoistDataSource(support.hoistDataSource);
         if (support.function.empty())
           support.function = support.hoistFunction;
         auto posIt = scene.positions.find(support.position);

--- a/tests/mvr_exporter_compliance_test.cpp
+++ b/tests/mvr_exporter_compliance_test.cpp
@@ -204,6 +204,12 @@ int main() {
   sup.uuid = "sup-1";
   sup.name = "Hoist 1";
   sup.gdtfSpec = (tempDir / "A" / "Same.gdtf").generic_string();
+  sup.motorName = "ChainMaster D8+";
+  sup.dummyPreset = "D8+ 1000kg";
+  sup.hoistDataSource = "Manual";
+  sup.hoistFunction = "Lighting";
+  sup.capacityKg = 1000.0f;
+  sup.weightKg = 42.0f;
   scene.supports[sup.uuid] = sup;
 
   MvrExporter exporter;
@@ -260,6 +266,30 @@ int main() {
           assert(value > 0);
           assert(fixtureIdText == std::to_string(value));
           assert(numericIds.insert(value).second);
+
+          if (std::string(cur->Name()) == "Support") {
+            auto *ud = cur->FirstChildElement("UserData");
+            assert(ud != nullptr);
+            auto *data = ud->FirstChildElement("Data");
+            assert(data != nullptr);
+            auto *info = data->FirstChildElement("HoistInfo");
+            assert(info != nullptr);
+
+            auto *motorNode = info->FirstChildElement("MotorName");
+            assert(motorNode != nullptr && motorNode->GetText() != nullptr);
+            assert(std::string(motorNode->GetText()) == "ChainMaster D8+");
+
+            auto *dummyNode = info->FirstChildElement("DummyPreset");
+            assert(dummyNode != nullptr && dummyNode->GetText() != nullptr);
+            assert(std::string(dummyNode->GetText()) == "D8+ 1000kg");
+
+            auto *sourceNode = info->FirstChildElement("DataSource");
+            assert(sourceNode != nullptr && sourceNode->GetText() != nullptr);
+            assert(std::string(sourceNode->GetText()) == "Manual");
+
+            auto *legacyNode = info->FirstChildElement("RiggingPoint");
+            assert(legacyNode == nullptr);
+          }
 
           if (std::string(cur->Name()) == "Fixture") {
             const char *uuidAttr = cur->Attribute("uuid");

--- a/tests/save_load_roundtrip_test.cpp
+++ b/tests/save_load_roundtrip_test.cpp
@@ -27,6 +27,7 @@
 #include "truss.h"
 #include "sceneobject.h"
 #include "layer.h"
+#include "support.h"
 
 int main() {
     wxInitializer initializer;
@@ -54,6 +55,15 @@ int main() {
     Truss t; t.uuid = "tr1"; t.name = "Truss"; t.layer = layer.name; scene.trusses[t.uuid] = t;
     SceneObject o; o.uuid = "obj1"; o.name = "Object"; o.layer = layer.name; scene.sceneObjects[o.uuid] = o;
 
+    Support sManual; sManual.uuid = "sup-manual"; sManual.name = "Manual Hoist"; sManual.layer = layer.name;
+    sManual.motorName = "ChainMaster D8+"; sManual.dummyPreset = "D8+ 1000kg";
+    sManual.hoistDataSource = "Manual"; sManual.hoistFunction = "Audio";
+    sManual.capacityKg = 700.0f; sManual.weightKg = 40.0f; scene.supports[sManual.uuid] = sManual;
+
+    Support sInherited; sInherited.uuid = "sup-inherited"; sInherited.name = "Inherited Hoist"; sInherited.layer = layer.name;
+    sInherited.motorName = "CM Lodestar"; sInherited.dummyPreset = "Lodestar 500kg";
+    sInherited.hoistDataSource = "Inherited"; scene.supports[sInherited.uuid] = sInherited;
+
     std::filesystem::path temp = std::filesystem::temp_directory_path() / "roundtrip_test.pera";
     assert(cfg.SaveProject(temp.string()));
 
@@ -65,6 +75,7 @@ int main() {
     assert(scene2.fixtures.size() == 2);
     assert(scene2.trusses.size() == 1);
     assert(scene2.sceneObjects.size() == 1);
+    assert(scene2.supports.size() == 2);
     assert(scene2.fixtures.at("fx1").instanceName == "Fixture");
     assert(scene2.trusses.at("tr1").name == "Truss");
     assert(scene2.sceneObjects.at("obj1").name == "Object");
@@ -74,6 +85,18 @@ int main() {
     assert(scene2.fixtures.at("fx2").fixtureIdText == "S101B");
     assert(scene2.fixtures.at("fx2").fixtureIdNumeric == 101);
     assert(scene2.layers.at("layer1").color == "#112233");
+
+    const auto &loadedManual = scene2.supports.at("sup-manual");
+    assert(loadedManual.motorName == "ChainMaster D8+");
+    assert(loadedManual.dummyPreset == "D8+ 1000kg");
+    assert(loadedManual.hoistDataSource == "Manual");
+    assert(loadedManual.capacityKg == 700.0f);
+    assert(loadedManual.weightKg == 40.0f);
+
+    const auto &loadedInherited = scene2.supports.at("sup-inherited");
+    assert(loadedInherited.motorName == "CM Lodestar");
+    assert(loadedInherited.dummyPreset == "Lodestar 500kg");
+    assert(loadedInherited.hoistDataSource == "Inherited");
 
     const auto &loaded = scene2.fixtures.at("fx1");
     assert(std::filesystem::path(loaded.gdtfSpec).filename() == "orig.gdtf");


### PR DESCRIPTION
### Motivation
- Provide a single, consistent hoist/Support metadata model that supports motor association, dummy preset defaults, and an inherited/manual data-source model for effective capacity/weight/function values.
- Expose preset-backed defaults in the GUI so users can pick library presets or override values manually while keeping legacy MVR compatibility.
- Surface hoist metadata in MVR export/import using a unified `HoistInfo` payload while still accepting legacy nodes.

### Description
- Extended `Support` with `motorName`, `dummyPreset`, `hoistDataSource` and helpers: `NormalizeHoistDataSource`, `IsManualHoistDataSource`, `ResolveEffectiveSupportData`, and `HoistPresetDefaults`/`EffectiveSupportData` structs in `models/support.h` to compute effective values from presets.
- Added a small hoist preset catalog API `core/hoistpresetlibrary.{h,cpp}` and seeded `library/hoists/hoist_presets.json` with dummy presets; wired `hoistpresetlibrary.cpp` into `core/CMakeLists.txt`.
- Updated MVR roundtrip to read/write unified hoist metadata: `Function` (preferred), `MotorName`, `DummyPreset`, `DataSource` and kept legacy fallbacks (`MotorInfo`, `RiggingPoint`) in `mvr/mvrimporter.cpp` and wrote the new nodes in `mvr/mvrexporter.cpp`.
- Extended `gui/hoisttablepanel.cpp` to add columns and editors for `Motor`, `Dummy Preset`, and `Data Source` (Inherited/Manual), to load available dummy presets from the library, and to apply inherited preset defaults when `Data Source` is `Inherited` while preserving manual overrides.
- Added/updated tests to cover support metadata roundtrip and MVR export payload verification by modifying `tests/save_load_roundtrip_test.cpp` and `tests/mvr_exporter_compliance_test.cpp` to include checks for the new hoist fields.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed: OK.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed: OK.
- Attempted `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` to build tests, but configuration failed in this environment due to missing system `wxWidgets` development package, so full test binaries were not built here (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b107f860e883249611705f69747de7)