### PR TITLE
Add stable support↔motor association and hoist effective-data resolver

### DIFF
--- a/core/hoistpresetlibrary.cpp
+++ b/core/hoistpresetlibrary.cpp
@@ -54,6 +54,8 @@ std::vector<HoistPreset> LoadPresets() {
     preset.id = entry.value("id", "");
     preset.name = entry.value("name", "");
     preset.motorName = entry.value("motorName", "");
+    preset.motorManufacturer = entry.value("motorManufacturer", "");
+    preset.motorModel = entry.value("motorModel", "");
     preset.dummyPreset = entry.value("dummyPreset", "");
     preset.capacityKg = ReadFloat(entry, "capacityKg");
     preset.weightKg = ReadFloat(entry, "weightKg");

--- a/core/hoistpresetlibrary.h
+++ b/core/hoistpresetlibrary.h
@@ -8,6 +8,8 @@ struct HoistPreset {
   std::string id;
   std::string name;
   std::string motorName;
+  std::string motorManufacturer;
+  std::string motorModel;
   std::string dummyPreset;
   float capacityKg = 0.0f;
   float weightKg = 0.0f;

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -67,10 +67,24 @@ std::optional<HoistPresetDefaults> FindPresetDefaults(const std::string &dummyPr
   if (!preset.has_value())
     return std::nullopt;
   HoistPresetDefaults defaults;
+  defaults.motorName = preset->motorName;
+  defaults.motorManufacturer = preset->motorManufacturer;
+  defaults.motorModel = preset->motorModel;
   defaults.capacityKg = preset->capacityKg;
   defaults.weightKg = preset->weightKg;
   defaults.hoistFunction = preset->hoistFunction;
   return defaults;
+}
+
+
+std::optional<HoistFixtureDefaults> FindFixtureDefaults(const MvrScene &scene,
+                                                       const Support &support) {
+  if (support.motorFixtureUuid.empty())
+    return std::nullopt;
+  auto it = scene.fixtures.find(support.motorFixtureUuid);
+  if (it == scene.fixtures.end())
+    return std::nullopt;
+  return BuildHoistFixtureDefaults(it->second);
 }
 
 wxArrayString BuildDummyPresetChoices() {
@@ -180,6 +194,7 @@ void HoistTablePanel::InitializeTable() {
 void HoistTablePanel::ReloadData() {
   table->DeleteAllItems();
   rowUuids.clear();
+  const MvrScene &scene = guiConfigServices->LegacyConfigManager().GetScene();
   auto &supports = guiConfigServices->LegacyConfigManager().GetScene().supports;
 
   std::vector<std::pair<std::string, Support *>> sorted;
@@ -208,10 +223,11 @@ void HoistTablePanel::ReloadData() {
     wxString type = wxString::FromUTF8(support.function);
     support.hoistDataSource = NormalizeHoistDataSource(support.hoistDataSource);
     const auto effective =
-        ResolveEffectiveSupportData(support, FindPresetDefaults(support.dummyPreset));
+        ResolveEffectiveSupportData(support, FindPresetDefaults(support.dummyPreset),
+                                    FindFixtureDefaults(scene, support));
     support.hoistFunction = NormalizeHoistFunction(support.hoistFunction);
     wxString hoistFunction = wxString::FromUTF8(effective.hoistFunction);
-    wxString motorName = wxString::FromUTF8(support.motorName);
+    wxString motorName = wxString::FromUTF8(effective.motorName);
     wxString dummyPreset = wxString::FromUTF8(support.dummyPreset);
     wxString dataSource = wxString::FromUTF8(support.hoistDataSource);
     wxString layer = support.layer == DEFAULT_LAYER_NAME
@@ -728,7 +744,9 @@ void HoistTablePanel::UpdateSceneData(bool logChanges) {
 
     if (!IsManualHoistDataSource(next.hoistDataSource)) {
       const auto effective =
-          ResolveEffectiveSupportData(next, FindPresetDefaults(next.dummyPreset));
+          ResolveEffectiveSupportData(next, FindPresetDefaults(next.dummyPreset),
+                                      FindFixtureDefaults(scene, next));
+      next.motorName = effective.motorName;
       next.capacityKg = effective.capacityKg;
       next.weightKg = effective.weightKg;
       next.hoistFunction = effective.hoistFunction;

--- a/models/support.h
+++ b/models/support.h
@@ -23,7 +23,9 @@
 #include <charconv>
 #include <optional>
 #include <string>
+
 #include "types.h"
+#include "fixture.h"
 
 // Represents a hoist parsed from MVR
 struct Support {
@@ -40,6 +42,12 @@ struct Support {
     float capacityKg = 0.0f;
     float weightKg = 0.0f;
     std::string motorName;
+    std::string motorManufacturer;
+    std::string motorModel;
+    // Stable fixture UUID linked to this hoist motor metadata.
+    std::string motorFixtureUuid;
+    // Enables inheriting missing values from linked fixture/preset defaults.
+    bool useMotorDefaults = true;
     std::string dummyPreset;
     // Defines whether values come from library defaults or user overrides.
     std::string hoistDataSource = "Inherited";
@@ -116,37 +124,97 @@ inline bool IsManualHoistDataSource(const std::string &source) {
 }
 
 struct HoistPresetDefaults {
+    std::string motorName;
+    std::string motorManufacturer;
+    std::string motorModel;
+    float capacityKg = 0.0f;
+    float weightKg = 0.0f;
+    std::string hoistFunction;
+};
+
+struct HoistFixtureDefaults {
+    std::string motorName;
+    std::string motorManufacturer;
+    std::string motorModel;
     float capacityKg = 0.0f;
     float weightKg = 0.0f;
     std::string hoistFunction;
 };
 
 struct EffectiveSupportData {
+    std::string motorName;
+    std::string motorManufacturer;
+    std::string motorModel;
     float capacityKg = 0.0f;
     float weightKg = 0.0f;
     std::string hoistFunction = "Lighting";
     std::string dataSource = "Inherited";
 };
 
+
+
+inline HoistFixtureDefaults BuildHoistFixtureDefaults(const Fixture &fixture) {
+    HoistFixtureDefaults defaults;
+    defaults.motorName = fixture.typeName;
+    defaults.motorManufacturer = "";
+    defaults.motorModel = fixture.gdtfMode;
+    defaults.capacityKg = 0.0f;
+    defaults.weightKg = fixture.weightKg;
+    defaults.hoistFunction = NormalizeHoistFunction(fixture.function);
+    return defaults;
+}
+
+inline bool HasManualNumeric(float value) { return value > 0.0f; }
+
+inline bool HasManualText(const std::string &value) { return !value.empty(); }
+
 inline EffectiveSupportData ResolveEffectiveSupportData(
     const Support &support,
-    const std::optional<HoistPresetDefaults> &presetDefaults = std::nullopt) {
+    const std::optional<HoistPresetDefaults> &presetDefaults = std::nullopt,
+    const std::optional<HoistFixtureDefaults> &fixtureDefaults = std::nullopt) {
     EffectiveSupportData resolved;
-    resolved.dataSource = NormalizeHoistDataSource(support.hoistDataSource);
+    const std::string normalizedSource = NormalizeHoistDataSource(support.hoistDataSource);
+    resolved.dataSource = normalizedSource;
 
-    if (resolved.dataSource == "Inherited" && presetDefaults.has_value()) {
-        resolved.capacityKg = presetDefaults->capacityKg;
-        resolved.weightKg = presetDefaults->weightKg;
-        const std::string inheritedFunction =
-            presetDefaults->hoistFunction.empty() ? support.hoistFunction
-                                                  : presetDefaults->hoistFunction;
-        resolved.hoistFunction = NormalizeHoistFunction(inheritedFunction);
-        return resolved;
-    }
-
+    resolved.motorName = support.motorName;
+    resolved.motorManufacturer = support.motorManufacturer;
+    resolved.motorModel = support.motorModel;
     resolved.capacityKg = support.capacityKg;
     resolved.weightKg = support.weightKg;
     resolved.hoistFunction = NormalizeHoistFunction(
         support.hoistFunction.empty() ? support.function : support.hoistFunction);
+
+    if (normalizedSource == "Manual")
+        return resolved;
+
+    if (!support.useMotorDefaults)
+        return resolved;
+
+    auto applyDefaults = [&](const auto &defaults, const char *sourceLabel) {
+        if (!HasManualText(resolved.motorName) && HasManualText(defaults.motorName))
+            resolved.motorName = defaults.motorName;
+        if (!HasManualText(resolved.motorManufacturer) &&
+            HasManualText(defaults.motorManufacturer)) {
+            resolved.motorManufacturer = defaults.motorManufacturer;
+        }
+        if (!HasManualText(resolved.motorModel) && HasManualText(defaults.motorModel))
+            resolved.motorModel = defaults.motorModel;
+        if (!HasManualNumeric(resolved.capacityKg) && HasManualNumeric(defaults.capacityKg))
+            resolved.capacityKg = defaults.capacityKg;
+        if (!HasManualNumeric(resolved.weightKg) && HasManualNumeric(defaults.weightKg))
+            resolved.weightKg = defaults.weightKg;
+        if (NormalizeHoistFunction(resolved.hoistFunction) == "Lighting" &&
+            HasManualText(defaults.hoistFunction)) {
+            resolved.hoistFunction = NormalizeHoistFunction(defaults.hoistFunction);
+        }
+        resolved.dataSource = sourceLabel;
+    };
+
+    if (fixtureDefaults.has_value())
+        applyDefaults(*fixtureDefaults, "Fixture");
+
+    if (presetDefaults.has_value())
+        applyDefaults(*presetDefaults, "Inherited");
+
     return resolved;
 }

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -1310,6 +1310,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
 
     bool hasMeta = s.capacityKg != 0.0f || s.weightKg != 0.0f ||
                    !s.hoistFunction.empty() || !s.motorName.empty() ||
+                   !s.motorManufacturer.empty() || !s.motorModel.empty() ||
+                   !s.motorFixtureUuid.empty() || !s.useMotorDefaults ||
                    !s.dummyPreset.empty() ||
                    NormalizeHoistDataSource(s.hoistDataSource) != "Inherited";
     if (hasMeta) {
@@ -1342,6 +1344,26 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
         tinyxml2::XMLElement *motorNode = doc.NewElement("MotorName");
         motorNode->SetText(s.motorName.c_str());
         info->InsertEndChild(motorNode);
+      }
+      if (!s.motorManufacturer.empty()) {
+        tinyxml2::XMLElement *manufacturerNode = doc.NewElement("MotorManufacturer");
+        manufacturerNode->SetText(s.motorManufacturer.c_str());
+        info->InsertEndChild(manufacturerNode);
+      }
+      if (!s.motorModel.empty()) {
+        tinyxml2::XMLElement *modelNode = doc.NewElement("MotorModel");
+        modelNode->SetText(s.motorModel.c_str());
+        info->InsertEndChild(modelNode);
+      }
+      if (!s.motorFixtureUuid.empty()) {
+        tinyxml2::XMLElement *fixtureNode = doc.NewElement("MotorFixtureUuid");
+        fixtureNode->SetText(s.motorFixtureUuid.c_str());
+        info->InsertEndChild(fixtureNode);
+      }
+      if (!s.useMotorDefaults) {
+        tinyxml2::XMLElement *defaultsNode = doc.NewElement("UseMotorDefaults");
+        defaultsNode->SetText("false");
+        info->InsertEndChild(defaultsNode);
       }
       if (!s.dummyPreset.empty()) {
         tinyxml2::XMLElement *presetNode = doc.NewElement("DummyPreset");

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -75,6 +75,13 @@ static std::string Trim(const std::string &s) {
   return s.substr(start, end - start + 1);
 }
 
+
+static std::string ToLowerCopy(std::string s) {
+  std::transform(s.begin(), s.end(), s.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return s;
+}
+
 static std::string NormalizeSlashes(std::string path) {
   std::replace(path.begin(), path.end(), '\\', '/');
   return path;
@@ -1148,6 +1155,24 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
               if (tinyxml2::XMLElement *mn = info->FirstChildElement("MotorName")) {
                 if (const char *txt = mn->GetText())
                   support.motorName = Trim(txt);
+              }
+              if (tinyxml2::XMLElement *mm = info->FirstChildElement("MotorManufacturer")) {
+                if (const char *txt = mm->GetText())
+                  support.motorManufacturer = Trim(txt);
+              }
+              if (tinyxml2::XMLElement *model = info->FirstChildElement("MotorModel")) {
+                if (const char *txt = model->GetText())
+                  support.motorModel = Trim(txt);
+              }
+              if (tinyxml2::XMLElement *mfu = info->FirstChildElement("MotorFixtureUuid")) {
+                if (const char *txt = mfu->GetText())
+                  support.motorFixtureUuid = Trim(txt);
+              }
+              if (tinyxml2::XMLElement *umd = info->FirstChildElement("UseMotorDefaults")) {
+                if (const char *txt = umd->GetText()) {
+                  const std::string value = ToLowerCopy(Trim(txt));
+                  support.useMotorDefaults = !(value == "false" || value == "0" || value == "no");
+                }
               }
               if (tinyxml2::XMLElement *dp = info->FirstChildElement("DummyPreset")) {
                 if (const char *txt = dp->GetText())

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -495,3 +495,10 @@ add_executable(project_session_io_test
 target_include_directories(project_session_io_test PRIVATE ../core ../third_party ../models)
 target_link_libraries(project_session_io_test PRIVATE ${wxWidgets_LIBRARIES})
 add_test(NAME ProjectSessionIO COMMAND project_session_io_test)
+
+
+add_executable(support_resolution_test
+               support_resolution_test.cpp)
+target_include_directories(support_resolution_test PRIVATE ../models)
+add_test(NAME SupportResolution COMMAND support_resolution_test)
+

--- a/tests/mvr_exporter_compliance_test.cpp
+++ b/tests/mvr_exporter_compliance_test.cpp
@@ -205,6 +205,10 @@ int main() {
   sup.name = "Hoist 1";
   sup.gdtfSpec = (tempDir / "A" / "Same.gdtf").generic_string();
   sup.motorName = "ChainMaster D8+";
+  sup.motorManufacturer = "ChainMaster";
+  sup.motorModel = "D8+";
+  sup.motorFixtureUuid = "fx-1";
+  sup.useMotorDefaults = false;
   sup.dummyPreset = "D8+ 1000kg";
   sup.hoistDataSource = "Manual";
   sup.hoistFunction = "Lighting";
@@ -278,6 +282,18 @@ int main() {
             auto *motorNode = info->FirstChildElement("MotorName");
             assert(motorNode != nullptr && motorNode->GetText() != nullptr);
             assert(std::string(motorNode->GetText()) == "ChainMaster D8+");
+            auto *manufacturerNode = info->FirstChildElement("MotorManufacturer");
+            assert(manufacturerNode != nullptr && manufacturerNode->GetText() != nullptr);
+            assert(std::string(manufacturerNode->GetText()) == "ChainMaster");
+            auto *modelNode = info->FirstChildElement("MotorModel");
+            assert(modelNode != nullptr && modelNode->GetText() != nullptr);
+            assert(std::string(modelNode->GetText()) == "D8+");
+            auto *fixtureNode = info->FirstChildElement("MotorFixtureUuid");
+            assert(fixtureNode != nullptr && fixtureNode->GetText() != nullptr);
+            assert(std::string(fixtureNode->GetText()) == "fx-1");
+            auto *defaultsNode = info->FirstChildElement("UseMotorDefaults");
+            assert(defaultsNode != nullptr && defaultsNode->GetText() != nullptr);
+            assert(std::string(defaultsNode->GetText()) == "false");
 
             auto *dummyNode = info->FirstChildElement("DummyPreset");
             assert(dummyNode != nullptr && dummyNode->GetText() != nullptr);

--- a/tests/save_load_roundtrip_test.cpp
+++ b/tests/save_load_roundtrip_test.cpp
@@ -56,12 +56,12 @@ int main() {
     SceneObject o; o.uuid = "obj1"; o.name = "Object"; o.layer = layer.name; scene.sceneObjects[o.uuid] = o;
 
     Support sManual; sManual.uuid = "sup-manual"; sManual.name = "Manual Hoist"; sManual.layer = layer.name;
-    sManual.motorName = "ChainMaster D8+"; sManual.dummyPreset = "D8+ 1000kg";
+    sManual.motorName = "ChainMaster D8+"; sManual.motorManufacturer = "ChainMaster"; sManual.motorModel = "D8+"; sManual.dummyPreset = "D8+ 1000kg";
     sManual.hoistDataSource = "Manual"; sManual.hoistFunction = "Audio";
     sManual.capacityKg = 700.0f; sManual.weightKg = 40.0f; scene.supports[sManual.uuid] = sManual;
 
     Support sInherited; sInherited.uuid = "sup-inherited"; sInherited.name = "Inherited Hoist"; sInherited.layer = layer.name;
-    sInherited.motorName = "CM Lodestar"; sInherited.dummyPreset = "Lodestar 500kg";
+    sInherited.motorName = "CM Lodestar"; sInherited.motorFixtureUuid = "fx1"; sInherited.useMotorDefaults = false; sInherited.dummyPreset = "Lodestar 500kg";
     sInherited.hoistDataSource = "Inherited"; scene.supports[sInherited.uuid] = sInherited;
 
     std::filesystem::path temp = std::filesystem::temp_directory_path() / "roundtrip_test.pera";
@@ -88,6 +88,8 @@ int main() {
 
     const auto &loadedManual = scene2.supports.at("sup-manual");
     assert(loadedManual.motorName == "ChainMaster D8+");
+    assert(loadedManual.motorManufacturer == "ChainMaster");
+    assert(loadedManual.motorModel == "D8+");
     assert(loadedManual.dummyPreset == "D8+ 1000kg");
     assert(loadedManual.hoistDataSource == "Manual");
     assert(loadedManual.capacityKg == 700.0f);
@@ -95,6 +97,8 @@ int main() {
 
     const auto &loadedInherited = scene2.supports.at("sup-inherited");
     assert(loadedInherited.motorName == "CM Lodestar");
+    assert(loadedInherited.motorFixtureUuid == "fx1");
+    assert(!loadedInherited.useMotorDefaults);
     assert(loadedInherited.dummyPreset == "Lodestar 500kg");
     assert(loadedInherited.hoistDataSource == "Inherited");
 

--- a/tests/support_resolution_test.cpp
+++ b/tests/support_resolution_test.cpp
@@ -1,0 +1,53 @@
+#include <cassert>
+
+#include "fixture.h"
+#include "support.h"
+
+int main() {
+  Support support;
+  support.hoistDataSource = "Inherited";
+  support.useMotorDefaults = true;
+  support.hoistFunction = "Lighting";
+
+  HoistPresetDefaults preset;
+  preset.motorName = "Preset Motor";
+  preset.capacityKg = 1000.0f;
+  preset.weightKg = 40.0f;
+  preset.hoistFunction = "Audio";
+
+  Fixture fixture;
+  fixture.typeName = "Fixture Motor";
+  fixture.gdtfMode = "Mode A";
+  fixture.weightKg = 55.0f;
+  fixture.function = "Video";
+  auto fixtureDefaults = BuildHoistFixtureDefaults(fixture);
+
+  const auto inherited =
+      ResolveEffectiveSupportData(support, preset, fixtureDefaults);
+  assert(inherited.motorName == "Fixture Motor");
+  assert(inherited.motorModel == "Mode A");
+  assert(inherited.capacityKg == 1000.0f);
+  assert(inherited.weightKg == 55.0f);
+  assert(inherited.hoistFunction == "Video");
+
+  support.capacityKg = 750.0f;
+  support.motorName = "Manual Motor";
+  const auto manualPriority =
+      ResolveEffectiveSupportData(support, preset, fixtureDefaults);
+  assert(manualPriority.motorName == "Manual Motor");
+  assert(manualPriority.capacityKg == 750.0f);
+
+  support.useMotorDefaults = false;
+  support.motorName.clear();
+  support.capacityKg = 0.0f;
+  const auto noDefaults = ResolveEffectiveSupportData(support, preset, fixtureDefaults);
+  assert(noDefaults.motorName.empty());
+  assert(noDefaults.capacityKg == 0.0f);
+
+  support.hoistDataSource = "Manual";
+  const auto manualSource = ResolveEffectiveSupportData(support, preset, fixtureDefaults);
+  assert(manualSource.dataSource == "Manual");
+  assert(manualSource.capacityKg == 0.0f);
+
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- Introduce stable motor association and a clear resolution policy so hoist fields can inherit sensible defaults from an associated fixture or a hoist preset while keeping manual overrides authoritative.
- Keep resolution logic pure and located in `models/` so GUI code consumes a single helper and business rules are not duplicated in UI code.
- Preserve backward compatibility when no motor association exists by falling back to existing preset/manual behavior.

### Description
- Added stable association and control fields to `Support`: `motorFixtureUuid`, `useMotorDefaults`, and motor metadata `motorManufacturer`/`motorModel`, and exposed them in the effective-data payload. (`models/support.h`)
- Implemented a pure resolver `ResolveEffectiveSupportData` plus `BuildHoistFixtureDefaults` and supporting structs (`HoistFixtureDefaults`, expanded `HoistPresetDefaults`, `EffectiveSupportData`) that apply the policy: manual values win, then associated fixture defaults when `useMotorDefaults=true`, then preset/dummy defaults. (`models/support.h`)
- Extended hoist preset model to include `motorManufacturer` and `motorModel` and loaded them from `hoist_presets.json`. (`core/hoistpresetlibrary.h`, `core/hoistpresetlibrary.cpp`)
- Wired UI to consume the model helper instead of embedding resolution rules: `gui/hoisttablepanel.cpp` calls `ResolveEffectiveSupportData` (and a small `FindFixtureDefaults` helper) to compute displayed/effective values. (`gui/hoisttablepanel.cpp`)
- Added import/export of the new fields in MVR `HoistInfo` (`MotorManufacturer`, `MotorModel`, `MotorFixtureUuid`, `UseMotorDefaults`) to keep roundtrip compatibility. (`mvr/mvrimporter.cpp`, `mvr/mvrexporter.cpp`)
- Updated tests and test setup: added `tests/support_resolution_test.cpp` for resolver behavior and updated `tests/save_load_roundtrip_test.cpp` and `tests/mvr_exporter_compliance_test.cpp` to cover new fields and roundtrip/export expectations, and registered the new test in `tests/CMakeLists.txt`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed successfully. ✅
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed successfully. ✅
- Compiled and executed the new unit `support_resolution_test` with `g++ -std=c++20 -Imodels tests/support_resolution_test.cpp -o /tmp/support_resolution_test && /tmp/support_resolution_test` and it passed. ✅
- Attempted `cmake --preset wsl-x64-debug` to configure a full build but the environment is missing `wxWidgets`, causing CMake to fail to find that dependency (environment issue, not a code regression). ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b10b942f8c83248d9f49142adc7397)