### PR TITLE
Add dummy hoist profile catalog, loader, Support.dummyProfileId and MVR persistence

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/configmanager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/configservices.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/credentialstore.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/dummyprofilelibrary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtfdictionary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtfnet.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/geometry/RdpSimplifier.cpp

--- a/core/dummyprofilelibrary.cpp
+++ b/core/dummyprofilelibrary.cpp
@@ -1,0 +1,93 @@
+#include "dummyprofilelibrary.h"
+
+#include "json.hpp"
+#include "projectutils.h"
+#include "support.h"
+
+#include <filesystem>
+#include <fstream>
+
+namespace fs = std::filesystem;
+using json = nlohmann::json;
+
+namespace {
+
+float ReadFloat(const json &obj, const char *key) {
+  auto it = obj.find(key);
+  if (it == obj.end())
+    return 0.0f;
+  if (it->is_number_float())
+    return it->get<float>();
+  if (it->is_number_integer())
+    return static_cast<float>(it->get<int>());
+  return 0.0f;
+}
+
+} // namespace
+
+namespace DummyProfileLibrary {
+
+std::vector<DummyHoistProfile> LoadProfiles() {
+  std::vector<DummyHoistProfile> profiles;
+  const std::string baseDir = ProjectUtils::GetDefaultLibraryPath("hoists");
+  if (baseDir.empty())
+    return profiles;
+
+  const fs::path filePath = fs::u8path(baseDir) / "dummy_profiles.json";
+  if (!fs::exists(filePath))
+    return profiles;
+
+  std::ifstream input(filePath);
+  if (!input.is_open())
+    return profiles;
+
+  json root;
+  input >> root;
+  if (!root.is_array())
+    return profiles;
+
+  for (const auto &entry : root) {
+    if (!entry.is_object())
+      continue;
+
+    DummyHoistProfile profile;
+    profile.id = entry.value("id", "");
+    profile.displayName = entry.value("displayName", "");
+    profile.motorName = entry.value("motorName", "");
+    profile.motorManufacturer = entry.value("motorManufacturer", "");
+    profile.motorModel = entry.value("motorModel", "");
+    profile.capacityKg = ReadFloat(entry, "capacityKg");
+    profile.weightKg = ReadFloat(entry, "weightKg");
+    profile.hoistFunction =
+        NormalizeHoistFunction(entry.value("hoistFunction", "Lighting"));
+
+    if (!profile.id.empty() && !profile.displayName.empty())
+      profiles.push_back(profile);
+  }
+
+  return profiles;
+}
+
+std::optional<DummyHoistProfile> FindById(const std::string &profileId) {
+  if (profileId.empty())
+    return std::nullopt;
+  const auto profiles = LoadProfiles();
+  for (const auto &profile : profiles) {
+    if (profile.id == profileId)
+      return profile;
+  }
+  return std::nullopt;
+}
+
+std::optional<DummyHoistProfile> FindByDisplayName(const std::string &displayName) {
+  if (displayName.empty())
+    return std::nullopt;
+  const auto profiles = LoadProfiles();
+  for (const auto &profile : profiles) {
+    if (profile.displayName == displayName)
+      return profile;
+  }
+  return std::nullopt;
+}
+
+} // namespace DummyProfileLibrary

--- a/core/dummyprofilelibrary.h
+++ b/core/dummyprofilelibrary.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+struct DummyHoistProfile {
+  std::string id;
+  std::string displayName;
+  std::string motorName;
+  std::string motorManufacturer;
+  std::string motorModel;
+  float capacityKg = 0.0f;
+  float weightKg = 0.0f;
+  std::string hoistFunction = "Lighting";
+};
+
+namespace DummyProfileLibrary {
+std::vector<DummyHoistProfile> LoadProfiles();
+std::optional<DummyHoistProfile> FindById(const std::string &profileId);
+std::optional<DummyHoistProfile> FindByDisplayName(const std::string &displayName);
+} // namespace DummyProfileLibrary

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -22,7 +22,7 @@
 #include "configmanager.h"
 #include "guiconfigservices.h"
 #include "layerpanel.h"
-#include "hoistpresetlibrary.h"
+#include "dummyprofilelibrary.h"
 #include "matrixutils.h"
 #include "riggingpanel.h"
 #include "stringutils.h"
@@ -60,19 +60,22 @@ bool IsNumChar(char c) {
 }
 
 
-std::optional<HoistPresetDefaults> FindPresetDefaults(const std::string &dummyPreset) {
-  if (dummyPreset.empty())
+std::optional<HoistPresetDefaults> FindPresetDefaults(const Support &support) {
+  std::optional<DummyHoistProfile> profile;
+  if (!support.dummyProfileId.empty())
+    profile = DummyProfileLibrary::FindById(support.dummyProfileId);
+  if (!profile.has_value() && !support.dummyPreset.empty())
+    profile = DummyProfileLibrary::FindByDisplayName(support.dummyPreset);
+  if (!profile.has_value())
     return std::nullopt;
-  auto preset = HoistPresetLibrary::FindByDummyPreset(dummyPreset);
-  if (!preset.has_value())
-    return std::nullopt;
+
   HoistPresetDefaults defaults;
-  defaults.motorName = preset->motorName;
-  defaults.motorManufacturer = preset->motorManufacturer;
-  defaults.motorModel = preset->motorModel;
-  defaults.capacityKg = preset->capacityKg;
-  defaults.weightKg = preset->weightKg;
-  defaults.hoistFunction = preset->hoistFunction;
+  defaults.motorName = profile->motorName;
+  defaults.motorManufacturer = profile->motorManufacturer;
+  defaults.motorModel = profile->motorModel;
+  defaults.capacityKg = profile->capacityKg;
+  defaults.weightKg = profile->weightKg;
+  defaults.hoistFunction = profile->hoistFunction;
   return defaults;
 }
 
@@ -90,10 +93,19 @@ std::optional<HoistFixtureDefaults> FindFixtureDefaults(const MvrScene &scene,
 wxArrayString BuildDummyPresetChoices() {
   wxArrayString choices;
   choices.push_back("");
-  const auto presets = HoistPresetLibrary::LoadPresets();
-  for (const auto &preset : presets)
-    choices.push_back(wxString::FromUTF8(preset.dummyPreset));
+  const auto profiles = DummyProfileLibrary::LoadProfiles();
+  for (const auto &profile : profiles)
+    choices.push_back(wxString::FromUTF8(profile.displayName));
   return choices;
+}
+
+std::string ResolveDummyProfileDisplayName(const Support &support) {
+  if (!support.dummyProfileId.empty()) {
+    const auto profile = DummyProfileLibrary::FindById(support.dummyProfileId);
+    if (profile.has_value())
+      return profile->displayName;
+  }
+  return support.dummyPreset;
 }
 
 RangeParts SplitRangeParts(const wxString &value) {
@@ -223,12 +235,12 @@ void HoistTablePanel::ReloadData() {
     wxString type = wxString::FromUTF8(support.function);
     support.hoistDataSource = NormalizeHoistDataSource(support.hoistDataSource);
     const auto effective =
-        ResolveEffectiveSupportData(support, FindPresetDefaults(support.dummyPreset),
+        ResolveEffectiveSupportData(support, FindPresetDefaults(support),
                                     FindFixtureDefaults(scene, support));
     support.hoistFunction = NormalizeHoistFunction(support.hoistFunction);
     wxString hoistFunction = wxString::FromUTF8(effective.hoistFunction);
     wxString motorName = wxString::FromUTF8(effective.motorName);
-    wxString dummyPreset = wxString::FromUTF8(support.dummyPreset);
+    wxString dummyPreset = wxString::FromUTF8(ResolveDummyProfileDisplayName(support));
     wxString dataSource = wxString::FromUTF8(support.hoistDataSource);
     wxString layer = support.layer == DEFAULT_LAYER_NAME
                          ? wxString()
@@ -356,16 +368,37 @@ void HoistTablePanel::OnContextMenu(wxDataViewEvent &event) {
   }
 
   if (col == 5) {
+    ConfigManager &cfg = guiConfigServices->LegacyConfigManager();
+    const auto &supports = cfg.GetScene().supports;
+
     wxArrayString choices = BuildDummyPresetChoices();
     wxSingleChoiceDialog sdlg(this, "Select dummy preset", "Dummy Preset", choices);
     if (sdlg.ShowModal() != wxID_OK)
       return;
+
     wxString sel = sdlg.GetStringSelection();
+    bool updatedAnyRow = false;
     for (const auto &itSel : selections) {
       int r = table->ItemToRow(itSel);
-      if (r != wxNOT_FOUND)
-        table->SetValue(wxVariant(sel), r, col);
+      if (r == wxNOT_FOUND || static_cast<size_t>(r) >= rowUuids.size())
+        continue;
+
+      auto supportIt = supports.find(rowUuids[static_cast<size_t>(r)]);
+      if (supportIt == supports.end())
+        continue;
+      if (!supportIt->second.motorFixtureUuid.empty())
+        continue;
+
+      table->SetValue(wxVariant(sel), r, col);
+      updatedAnyRow = true;
     }
+
+    if (!updatedAnyRow) {
+      wxMessageBox("Dummy preset can only be assigned when there is no linked motor fixture.",
+                   "Dummy Preset", wxOK | wxICON_INFORMATION, this);
+      return;
+    }
+
     ResyncRows(oldOrder, selectedUuids);
     UpdateSceneData();
     if (Viewer3DPanel::Instance()) {
@@ -659,6 +692,12 @@ void HoistTablePanel::UpdateSceneData(bool logChanges) {
 
     table->GetValue(v, i, 5);
     next.dummyPreset = std::string(v.GetString().ToUTF8());
+    if (next.dummyPreset.empty()) {
+      next.dummyProfileId.clear();
+    } else {
+      const auto profile = DummyProfileLibrary::FindByDisplayName(next.dummyPreset);
+      next.dummyProfileId = profile.has_value() ? profile->id : "";
+    }
 
     table->GetValue(v, i, 6);
     next.hoistDataSource =
@@ -744,7 +783,7 @@ void HoistTablePanel::UpdateSceneData(bool logChanges) {
 
     if (!IsManualHoistDataSource(next.hoistDataSource)) {
       const auto effective =
-          ResolveEffectiveSupportData(next, FindPresetDefaults(next.dummyPreset),
+          ResolveEffectiveSupportData(next, FindPresetDefaults(next),
                                       FindFixtureDefaults(scene, next));
       next.motorName = effective.motorName;
       next.capacityKg = effective.capacityKg;
@@ -755,6 +794,7 @@ void HoistTablePanel::UpdateSceneData(bool logChanges) {
     const bool supportChanged = old.name != next.name || old.function != next.function ||
                                 old.hoistFunction != next.hoistFunction ||
                                 old.motorName != next.motorName ||
+                                old.dummyProfileId != next.dummyProfileId ||
                                 old.dummyPreset != next.dummyPreset ||
                                 NormalizeHoistDataSource(old.hoistDataSource) !=
                                     NormalizeHoistDataSource(next.hoistDataSource) ||

--- a/library/hoists/dummy_profiles.json
+++ b/library/hoists/dummy_profiles.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "dummy_standard_500kg",
+    "displayName": "Standard Dummy 500 kg",
+    "motorName": "Standard Dummy Motor 500",
+    "motorManufacturer": "Perastage",
+    "motorModel": "DUMMY-500",
+    "capacityKg": 500.0,
+    "weightKg": 25.0,
+    "hoistFunction": "Lighting"
+  },
+  {
+    "id": "dummy_standard_1000kg",
+    "displayName": "Standard Dummy 1000 kg",
+    "motorName": "Standard Dummy Motor 1000",
+    "motorManufacturer": "Perastage",
+    "motorModel": "DUMMY-1000",
+    "capacityKg": 1000.0,
+    "weightKg": 40.0,
+    "hoistFunction": "Lighting"
+  },
+  {
+    "id": "dummy_standard_2000kg",
+    "displayName": "Standard Dummy 2000 kg",
+    "motorName": "Standard Dummy Motor 2000",
+    "motorManufacturer": "Perastage",
+    "motorModel": "DUMMY-2000",
+    "capacityKg": 2000.0,
+    "weightKg": 65.0,
+    "hoistFunction": "Lighting"
+  }
+]

--- a/models/support.h
+++ b/models/support.h
@@ -48,6 +48,9 @@ struct Support {
     std::string motorFixtureUuid;
     // Enables inheriting missing values from linked fixture/preset defaults.
     bool useMotorDefaults = true;
+    // Stable ID for a dummy hoist profile from library/hoists/dummy_profiles.json.
+    std::string dummyProfileId;
+    // Legacy display label kept for backward compatibility with older files.
     std::string dummyPreset;
     // Defines whether values come from library defaults or user overrides.
     std::string hoistDataSource = "Inherited";

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -17,6 +17,7 @@
  */
 #include "mvrexporter.h"
 #include "configmanager.h"
+#include "dummyprofilelibrary.h"
 #include "matrixutils.h"
 #include "support.h"
 #include "uuidutils.h"
@@ -1312,6 +1313,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
                    !s.hoistFunction.empty() || !s.motorName.empty() ||
                    !s.motorManufacturer.empty() || !s.motorModel.empty() ||
                    !s.motorFixtureUuid.empty() || !s.useMotorDefaults ||
+                   !s.dummyProfileId.empty() ||
                    !s.dummyPreset.empty() ||
                    NormalizeHoistDataSource(s.hoistDataSource) != "Inherited";
     if (hasMeta) {
@@ -1365,10 +1367,22 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
         defaultsNode->SetText("false");
         info->InsertEndChild(defaultsNode);
       }
+      if (!s.dummyProfileId.empty()) {
+        tinyxml2::XMLElement *profileIdNode = doc.NewElement("DummyProfileId");
+        profileIdNode->SetText(s.dummyProfileId.c_str());
+        info->InsertEndChild(profileIdNode);
+      }
       if (!s.dummyPreset.empty()) {
         tinyxml2::XMLElement *presetNode = doc.NewElement("DummyPreset");
         presetNode->SetText(s.dummyPreset.c_str());
         info->InsertEndChild(presetNode);
+      } else if (!s.dummyProfileId.empty()) {
+        const auto profile = DummyProfileLibrary::FindById(s.dummyProfileId);
+        if (profile.has_value()) {
+          tinyxml2::XMLElement *presetNode = doc.NewElement("DummyPreset");
+          presetNode->SetText(profile->displayName.c_str());
+          info->InsertEndChild(presetNode);
+        }
       }
       tinyxml2::XMLElement *sourceNode = doc.NewElement("DataSource");
       const std::string source = NormalizeHoistDataSource(s.hoistDataSource);

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -17,6 +17,7 @@
  */
 #include "mvrimporter.h"
 #include "configmanager.h"
+#include "dummyprofilelibrary.h"
 #include "gdtfdictionary.h"
 #include "gdtfloader.h"
 #include "matrixutils.h"
@@ -1178,12 +1179,22 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                 if (const char *txt = dp->GetText())
                   support.dummyPreset = Trim(txt);
               }
+              if (tinyxml2::XMLElement *dpi = info->FirstChildElement("DummyProfileId")) {
+                if (const char *txt = dpi->GetText())
+                  support.dummyProfileId = Trim(txt);
+              }
               if (tinyxml2::XMLElement *ds = info->FirstChildElement("DataSource")) {
                 if (const char *txt = ds->GetText())
                   support.hoistDataSource = NormalizeHoistDataSource(Trim(txt));
               }
             }
           }
+        }
+
+        if (support.dummyProfileId.empty() && !support.dummyPreset.empty()) {
+          const auto profile = DummyProfileLibrary::FindByDisplayName(support.dummyPreset);
+          if (profile.has_value())
+            support.dummyProfileId = profile->id;
         }
 
         if (support.hoistFunction.empty())

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -133,6 +133,7 @@ add_executable(save_load_roundtrip_test save_load_roundtrip_test.cpp
                ../core/trussloader.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/uuidutils.cpp
+               ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
                ../mvr/mvrexporter.cpp
                ../core/logger.cpp
@@ -181,6 +182,7 @@ add_executable(rider_truss_dictionary_normalization_test
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
                ../core/truss_gdtf_builder.cpp
+               ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
                ../mvr/mvrexporter.cpp
                ../core/logger.cpp
@@ -205,6 +207,7 @@ add_executable(mvr_dmx_address_test mvr_dmx_address_test.cpp
                ../core/trussloader.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/uuidutils.cpp
+               ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
                ../core/logger.cpp
                gdtfloader_stub.cpp
@@ -231,6 +234,7 @@ add_executable(mvr_exporter_compliance_test mvr_exporter_compliance_test.cpp
                ../core/trussloader.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/uuidutils.cpp
+               ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
                ../mvr/mvrexporter.cpp
                ../core/logger.cpp
@@ -264,6 +268,7 @@ add_executable(rider_save_roundtrip_test rider_save_roundtrip_test.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
                ../core/truss_gdtf_builder.cpp
+               ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
                ../mvr/mvrexporter.cpp
                ../core/logger.cpp
@@ -501,4 +506,3 @@ add_executable(support_resolution_test
                support_resolution_test.cpp)
 target_include_directories(support_resolution_test PRIVATE ../models)
 add_test(NAME SupportResolution COMMAND support_resolution_test)
-


### PR DESCRIPTION
### Motivation
- Provide a stable, internal identifier for standard dummy hoist profiles (500/1000/2000 kg) so defaults can be resolved deterministically instead of relying only on a free-form legacy label.
- Keep logic in the data/core layer and preserve backward compatibility with existing `DummyPreset` labels while enabling faithful round-trip in MVR import/export.

### Description
- Added a JSON catalog at `library/hoists/dummy_profiles.json` with three standard dummy profiles containing `id`, `displayName`, motor metadata, capacity and weight, and `hoistFunction`.
- Implemented a data-layer loader `core/dummyprofilelibrary.{h,cpp}` with `LoadProfiles()`, `FindById()` and `FindByDisplayName()` to normalize and expose profiles to other modules, and registered the new `dummyprofilelibrary.cpp` in `core/CMakeLists.txt`.
- Extended `struct Support` (`models/support.h`) with a stable `dummyProfileId` while keeping `dummyPreset` as the legacy display label for compatibility.
- Updated UI (`gui/hoisttablepanel.cpp`) to:
  - resolve hoist defaults via `FindPresetDefaults(const Support &)` using `dummyProfileId` (fallback to `dummyPreset` display name),
  - display the profile `displayName` in the table via a `ResolveDummyProfileDisplayName()` helper,
  - when editing/setting a dummy preset from the UI, only allow assignment when the support has no linked `motorFixtureUuid`, and populate `dummyProfileId` when possible from the chosen display name.
- Updated MVR handling to persist the new ID and retain legacy behavior:
  - `mvr/mvrimporter.cpp` reads optional `DummyProfileId` from `UserData/HoistInfo` and, if absent, attempts to resolve `dummyProfileId` from legacy `DummyPreset` display names.
  - `mvr/mvrexporter.cpp` includes `DummyProfileId` in `UserData/HoistInfo` and emits a `DummyPreset` label when possible for older consumers.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.
- Ran `cmake -S . -B build` in this environment and configuration failed due to missing system dev packages for `wxWidgets` (`wxWidgets_LIBRARIES`, `wxWidgets_INCLUDE_DIRS`), so a full build could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b112aaf2348324b75ec6a9b10374a2)