### PR TITLE
Centralize MVR HoistInfo import/export, document schema, and add roundtrip tests

### DIFF
--- a/docs/mvr_hoistinfo_schema.md
+++ b/docs/mvr_hoistinfo_schema.md
@@ -1,0 +1,41 @@
+# Canonical `UserData/Data/HoistInfo` schema
+
+This document defines the canonical Perastage payload for support hoist metadata inside MVR `GeneralSceneDescription.xml`.
+
+## Location
+
+- `Support/UserData/Data` with attributes:
+  - `provider="Perastage"`
+  - `ver="1.0"`
+- Canonical payload node: `HoistInfo`
+- Legacy payload node accepted on import: `MotorInfo`
+
+## Canonical fields
+
+Inside `HoistInfo`:
+
+- `Capacity` (`unit="kg"`, float)
+- `Weight` (`unit="kg"`, float)
+- `RiggingPoint` (string, normalized hoist function)
+- `MotorName` (string)
+- `MotorManufacturer` (string)
+- `MotorModel` (string)
+- `MotorFixtureUuid` (string UUID that links to a fixture)
+- `UseMotorDefaults` (`false` when explicitly disabled; omitted means `true`)
+- `DummyProfileId` (string stable profile id)
+- `DummyPreset` (string display name compatibility field)
+- `ValueSource` (`Inherited` or `Manual`)
+
+## Compatibility aliases
+
+Perastage writes canonical names and also compatibility aliases for older builds:
+
+- `Function` mirrors `RiggingPoint`.
+- `DataSource` mirrors `ValueSource`.
+
+On import, Perastage reads both canonical and compatibility aliases with this precedence:
+
+1. `RiggingPoint`, fallback `Function`
+2. `ValueSource`, fallback `DataSource`
+
+Legacy `MotorInfo` payload blocks are still parsed and migrated internally to the canonical support fields.

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -75,6 +75,11 @@ static bool ParseMvrAddressNodeText(const std::string &text, int &universeOut,
 static bool TryComputeAbsoluteDmx(int universe1Based, int address1Based,
                                   int &absoluteOut);
 
+static bool ShouldExportSupportHoistInfo(const Support &support);
+static void AppendSupportHoistInfoUserData(tinyxml2::XMLDocument &doc,
+                                           tinyxml2::XMLElement *supportNode,
+                                           const Support &support);
+
 static constexpr const char *kMvrProvider = "Perastage";
 static constexpr const char *kMvrProviderVersion = "1.0";
 
@@ -493,6 +498,77 @@ static bool ParseMvrAddressNodeText(const std::string &text, int &universeOut,
 
 int ComputeAbsoluteDmx(int universe1Based, int address1Based) {
   return ((universe1Based - 1) * 512) + address1Based;
+}
+
+static bool ShouldExportSupportHoistInfo(const Support &support) {
+  return support.capacityKg != 0.0f || support.weightKg != 0.0f ||
+         !support.hoistFunction.empty() || !support.motorName.empty() ||
+         !support.motorManufacturer.empty() || !support.motorModel.empty() ||
+         !support.motorFixtureUuid.empty() || !support.useMotorDefaults ||
+         !support.dummyProfileId.empty() || !support.dummyPreset.empty() ||
+         NormalizeHoistDataSource(support.hoistDataSource) != "Inherited";
+}
+
+static void AppendSupportHoistInfoUserData(tinyxml2::XMLDocument &doc,
+                                           tinyxml2::XMLElement *supportNode,
+                                           const Support &support) {
+  tinyxml2::XMLElement *ud = doc.NewElement("UserData");
+  tinyxml2::XMLElement *data = doc.NewElement("Data");
+  data->SetAttribute("provider", kMvrProvider);
+  data->SetAttribute("ver", kMvrProviderVersion);
+  tinyxml2::XMLElement *info = doc.NewElement("HoistInfo");
+  info->SetAttribute("uuid", support.uuid.c_str());
+
+  auto addText = [&](const char *name, const std::string &value) {
+    if (value.empty())
+      return;
+    tinyxml2::XMLElement *node = doc.NewElement(name);
+    node->SetText(value.c_str());
+    info->InsertEndChild(node);
+  };
+
+  auto addNum = [&](const char *name, float value, const char *unit) {
+    if (value == 0.0f)
+      return;
+    tinyxml2::XMLElement *node = doc.NewElement(name);
+    node->SetAttribute("unit", unit);
+    node->SetText(std::to_string(value).c_str());
+    info->InsertEndChild(node);
+  };
+
+  addNum("Capacity", support.capacityKg, "kg");
+  addNum("Weight", support.weightKg, "kg");
+
+  const std::string hoistFunction = NormalizeHoistFunction(support.hoistFunction);
+  if (!hoistFunction.empty()) {
+    addText("RiggingPoint", hoistFunction);
+    addText("Function", hoistFunction); // Compatibility alias for older builds.
+  }
+
+  addText("MotorName", support.motorName);
+  addText("MotorManufacturer", support.motorManufacturer);
+  addText("MotorModel", support.motorModel);
+  addText("MotorFixtureUuid", support.motorFixtureUuid);
+
+  if (!support.useMotorDefaults)
+    addText("UseMotorDefaults", "false");
+
+  addText("DummyProfileId", support.dummyProfileId);
+  if (!support.dummyPreset.empty()) {
+    addText("DummyPreset", support.dummyPreset);
+  } else if (!support.dummyProfileId.empty()) {
+    const auto profile = DummyProfileLibrary::FindById(support.dummyProfileId);
+    if (profile.has_value())
+      addText("DummyPreset", profile->displayName);
+  }
+
+  const std::string source = NormalizeHoistDataSource(support.hoistDataSource);
+  addText("ValueSource", source);
+  addText("DataSource", source); // Compatibility alias for older builds.
+
+  data->InsertEndChild(info);
+  ud->InsertEndChild(data);
+  supportNode->InsertEndChild(ud);
 }
 
 static bool TryComputeAbsoluteDmx(int universe1Based, int address1Based,
@@ -1309,90 +1385,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
     mat->SetText(mstr.c_str());
     se->InsertEndChild(mat);
 
-    bool hasMeta = s.capacityKg != 0.0f || s.weightKg != 0.0f ||
-                   !s.hoistFunction.empty() || !s.motorName.empty() ||
-                   !s.motorManufacturer.empty() || !s.motorModel.empty() ||
-                   !s.motorFixtureUuid.empty() || !s.useMotorDefaults ||
-                   !s.dummyProfileId.empty() ||
-                   !s.dummyPreset.empty() ||
-                   NormalizeHoistDataSource(s.hoistDataSource) != "Inherited";
-    if (hasMeta) {
-      tinyxml2::XMLElement *ud = doc.NewElement("UserData");
-      tinyxml2::XMLElement *data = doc.NewElement("Data");
-      data->SetAttribute("provider", "Perastage");
-      data->SetAttribute("ver", "1.0");
-      tinyxml2::XMLElement *info = doc.NewElement("HoistInfo");
-      info->SetAttribute("uuid", s.uuid.c_str());
-
-      auto addNum = [&](const char *n, float v, const char *unit) {
-        if (v != 0.0f) {
-          tinyxml2::XMLElement *e = doc.NewElement(n);
-          e->SetAttribute("unit", unit);
-          e->SetText(std::to_string(v).c_str());
-          info->InsertEndChild(e);
-        }
-      };
-
-      addNum("Capacity", s.capacityKg, "kg");
-      addNum("Weight", s.weightKg, "kg");
-
-      if (!s.hoistFunction.empty()) {
-        tinyxml2::XMLElement *functionNode = doc.NewElement("Function");
-        std::string hoistFunction = NormalizeHoistFunction(s.hoistFunction);
-        functionNode->SetText(hoistFunction.c_str());
-        info->InsertEndChild(functionNode);
-      }
-      if (!s.motorName.empty()) {
-        tinyxml2::XMLElement *motorNode = doc.NewElement("MotorName");
-        motorNode->SetText(s.motorName.c_str());
-        info->InsertEndChild(motorNode);
-      }
-      if (!s.motorManufacturer.empty()) {
-        tinyxml2::XMLElement *manufacturerNode = doc.NewElement("MotorManufacturer");
-        manufacturerNode->SetText(s.motorManufacturer.c_str());
-        info->InsertEndChild(manufacturerNode);
-      }
-      if (!s.motorModel.empty()) {
-        tinyxml2::XMLElement *modelNode = doc.NewElement("MotorModel");
-        modelNode->SetText(s.motorModel.c_str());
-        info->InsertEndChild(modelNode);
-      }
-      if (!s.motorFixtureUuid.empty()) {
-        tinyxml2::XMLElement *fixtureNode = doc.NewElement("MotorFixtureUuid");
-        fixtureNode->SetText(s.motorFixtureUuid.c_str());
-        info->InsertEndChild(fixtureNode);
-      }
-      if (!s.useMotorDefaults) {
-        tinyxml2::XMLElement *defaultsNode = doc.NewElement("UseMotorDefaults");
-        defaultsNode->SetText("false");
-        info->InsertEndChild(defaultsNode);
-      }
-      if (!s.dummyProfileId.empty()) {
-        tinyxml2::XMLElement *profileIdNode = doc.NewElement("DummyProfileId");
-        profileIdNode->SetText(s.dummyProfileId.c_str());
-        info->InsertEndChild(profileIdNode);
-      }
-      if (!s.dummyPreset.empty()) {
-        tinyxml2::XMLElement *presetNode = doc.NewElement("DummyPreset");
-        presetNode->SetText(s.dummyPreset.c_str());
-        info->InsertEndChild(presetNode);
-      } else if (!s.dummyProfileId.empty()) {
-        const auto profile = DummyProfileLibrary::FindById(s.dummyProfileId);
-        if (profile.has_value()) {
-          tinyxml2::XMLElement *presetNode = doc.NewElement("DummyPreset");
-          presetNode->SetText(profile->displayName.c_str());
-          info->InsertEndChild(presetNode);
-        }
-      }
-      tinyxml2::XMLElement *sourceNode = doc.NewElement("DataSource");
-      const std::string source = NormalizeHoistDataSource(s.hoistDataSource);
-      sourceNode->SetText(source.c_str());
-      info->InsertEndChild(sourceNode);
-
-      data->InsertEndChild(info);
-      ud->InsertEndChild(data);
-      se->InsertEndChild(ud);
-    }
+    if (ShouldExportSupportHoistInfo(s))
+      AppendSupportHoistInfoUserData(doc, se, s);
 
     parent->InsertEndChild(se);
   };

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -289,6 +289,95 @@ PromptGdtfConflicts(const std::vector<GdtfConflict> &conflicts) {
   return chosen;
 }
 
+
+
+static void ApplySupportHoistInfoDefaults(Support &support) {
+  if (support.dummyProfileId.empty() && !support.dummyPreset.empty()) {
+    const auto profile = DummyProfileLibrary::FindByDisplayName(support.dummyPreset);
+    if (profile.has_value())
+      support.dummyProfileId = profile->id;
+  }
+
+  support.hoistFunction = NormalizeHoistFunction(
+      support.hoistFunction.empty() ? support.function : support.hoistFunction);
+  support.hoistDataSource = NormalizeHoistDataSource(support.hoistDataSource);
+  if (support.function.empty())
+    support.function = support.hoistFunction;
+}
+
+static void ReadSupportHoistInfoFromUserData(tinyxml2::XMLElement *supportNode,
+                                             Support &support) {
+  tinyxml2::XMLElement *ud = supportNode->FirstChildElement("UserData");
+  if (!ud)
+    return;
+
+  for (tinyxml2::XMLElement *data = ud->FirstChildElement("Data"); data;
+       data = data->NextSiblingElement("Data")) {
+    tinyxml2::XMLElement *info = data->FirstChildElement("HoistInfo");
+    if (!info)
+      info = data->FirstChildElement("MotorInfo"); // Legacy block name.
+    if (!info)
+      continue;
+
+    auto readFloat = [&](const char *name, float &out) {
+      if (tinyxml2::XMLElement *el = info->FirstChildElement(name)) {
+        if (const char *txt = el->GetText()) {
+          float parsed = 0.0f;
+          if (TryParseFloat(txt, parsed))
+            out = parsed;
+        }
+      }
+    };
+    auto readText = [&](const char *name) -> std::string {
+      if (tinyxml2::XMLElement *el = info->FirstChildElement(name)) {
+        if (const char *txt = el->GetText())
+          return Trim(txt);
+      }
+      return {};
+    };
+
+    readFloat("Capacity", support.capacityKg);
+    readFloat("Weight", support.weightKg);
+
+    std::string hoistFunction = readText("RiggingPoint"); // Canonical in new schema.
+    if (hoistFunction.empty())
+      hoistFunction = readText("Function");
+    if (!hoistFunction.empty())
+      support.hoistFunction = NormalizeHoistFunction(hoistFunction);
+
+    const std::string motorName = readText("MotorName");
+    if (!motorName.empty())
+      support.motorName = motorName;
+    const std::string manufacturer = readText("MotorManufacturer");
+    if (!manufacturer.empty())
+      support.motorManufacturer = manufacturer;
+    const std::string model = readText("MotorModel");
+    if (!model.empty())
+      support.motorModel = model;
+    const std::string fixtureUuid = readText("MotorFixtureUuid");
+    if (!fixtureUuid.empty())
+      support.motorFixtureUuid = fixtureUuid;
+
+    const std::string useDefaults = ToLowerCopy(readText("UseMotorDefaults"));
+    if (!useDefaults.empty()) {
+      support.useMotorDefaults =
+          !(useDefaults == "false" || useDefaults == "0" || useDefaults == "no");
+    }
+
+    const std::string dummyPreset = readText("DummyPreset");
+    if (!dummyPreset.empty())
+      support.dummyPreset = dummyPreset;
+    const std::string dummyProfileId = readText("DummyProfileId");
+    if (!dummyProfileId.empty())
+      support.dummyProfileId = dummyProfileId;
+
+    std::string source = readText("ValueSource");
+    if (source.empty())
+      source = readText("DataSource"); // Legacy key.
+    if (!source.empty())
+      support.hoistDataSource = NormalizeHoistDataSource(source);
+  }
+}
 bool MvrImporter::ImportFromFile(const std::string &filePath,
                                  bool promptConflicts,
                                  bool applyDictionary) {
@@ -1127,82 +1216,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         support.position = readText("Position");
         support.positionName = ensurePositionEntry(support.position);
 
-        if (tinyxml2::XMLElement *ud = node->FirstChildElement("UserData")) {
-          for (tinyxml2::XMLElement *data = ud->FirstChildElement("Data"); data;
-               data = data->NextSiblingElement("Data")) {
-            tinyxml2::XMLElement *info = data->FirstChildElement("HoistInfo");
-            if (!info)
-              info = data->FirstChildElement("MotorInfo"); // Legacy name
-            if (info) {
-              auto readFloat = [&](const char *name, float &out) {
-                if (tinyxml2::XMLElement *e = info->FirstChildElement(name)) {
-                  if (const char *txt = e->GetText()) {
-                    float parsed = 0.0f;
-                    if (TryParseFloat(txt, parsed))
-                      out = parsed;
-                  }
-                }
-              };
-              readFloat("Capacity", support.capacityKg);
-              readFloat("Weight", support.weightKg);
-              if (tinyxml2::XMLElement *fn = info->FirstChildElement("Function")) {
-                if (const char *txt = fn->GetText())
-                  support.hoistFunction = NormalizeHoistFunction(Trim(txt));
-              } else if (tinyxml2::XMLElement *rp =
-                             info->FirstChildElement("RiggingPoint")) {
-                if (const char *txt = rp->GetText())
-                  support.hoistFunction = NormalizeHoistFunction(Trim(txt));
-              }
-              if (tinyxml2::XMLElement *mn = info->FirstChildElement("MotorName")) {
-                if (const char *txt = mn->GetText())
-                  support.motorName = Trim(txt);
-              }
-              if (tinyxml2::XMLElement *mm = info->FirstChildElement("MotorManufacturer")) {
-                if (const char *txt = mm->GetText())
-                  support.motorManufacturer = Trim(txt);
-              }
-              if (tinyxml2::XMLElement *model = info->FirstChildElement("MotorModel")) {
-                if (const char *txt = model->GetText())
-                  support.motorModel = Trim(txt);
-              }
-              if (tinyxml2::XMLElement *mfu = info->FirstChildElement("MotorFixtureUuid")) {
-                if (const char *txt = mfu->GetText())
-                  support.motorFixtureUuid = Trim(txt);
-              }
-              if (tinyxml2::XMLElement *umd = info->FirstChildElement("UseMotorDefaults")) {
-                if (const char *txt = umd->GetText()) {
-                  const std::string value = ToLowerCopy(Trim(txt));
-                  support.useMotorDefaults = !(value == "false" || value == "0" || value == "no");
-                }
-              }
-              if (tinyxml2::XMLElement *dp = info->FirstChildElement("DummyPreset")) {
-                if (const char *txt = dp->GetText())
-                  support.dummyPreset = Trim(txt);
-              }
-              if (tinyxml2::XMLElement *dpi = info->FirstChildElement("DummyProfileId")) {
-                if (const char *txt = dpi->GetText())
-                  support.dummyProfileId = Trim(txt);
-              }
-              if (tinyxml2::XMLElement *ds = info->FirstChildElement("DataSource")) {
-                if (const char *txt = ds->GetText())
-                  support.hoistDataSource = NormalizeHoistDataSource(Trim(txt));
-              }
-            }
-          }
-        }
-
-        if (support.dummyProfileId.empty() && !support.dummyPreset.empty()) {
-          const auto profile = DummyProfileLibrary::FindByDisplayName(support.dummyPreset);
-          if (profile.has_value())
-            support.dummyProfileId = profile->id;
-        }
-
-        if (support.hoistFunction.empty())
-          support.hoistFunction = NormalizeHoistFunction(support.function);
-
-        support.hoistDataSource = NormalizeHoistDataSource(support.hoistDataSource);
-        if (support.function.empty())
-          support.function = support.hoistFunction;
+        ReadSupportHoistInfoFromUserData(node, support);
+        ApplySupportHoistInfoDefaults(support);
         auto posIt = scene.positions.find(support.position);
         if (posIt != scene.positions.end())
           support.positionName = posIt->second;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -225,6 +225,35 @@ target_link_libraries(mvr_dmx_address_test PRIVATE
 add_test(NAME MvrDmxAddressConversion COMMAND mvr_dmx_address_test)
 set_library_env(MvrDmxAddressConversion)
 
+
+add_executable(mvr_support_userdata_roundtrip_test mvr_support_userdata_roundtrip_test.cpp
+               ../core/configmanager.cpp
+               ../core/configservices.cpp
+               ../core/projectutils.cpp
+               ../core/gdtfdictionary.cpp
+               ../core/trussdictionary.cpp
+               ../core/trussloader.cpp
+               ../core/truss_gdtf_builder.cpp
+               ../core/uuidutils.cpp
+               ../core/dummyprofilelibrary.cpp
+               ../mvr/mvrimporter.cpp
+               ../mvr/mvrexporter.cpp
+               ../core/logger.cpp
+               gdtfloader_stub.cpp
+               consolepanel_stub.cpp
+               ../models/mvrscene.cpp
+               ../models/fixture.cpp
+               ../models/truss.cpp
+               ../models/sceneobject.cpp
+               ../models/layer.cpp
+               ${LAYOUT_SOURCES})
+target_include_directories(mvr_support_userdata_roundtrip_test PRIVATE
+                           . ../core ../models ../mvr ../gui ../third_party)
+target_link_libraries(mvr_support_userdata_roundtrip_test PRIVATE
+                      ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
+add_test(NAME MvrSupportUserDataRoundtrip COMMAND mvr_support_userdata_roundtrip_test)
+set_library_env(MvrSupportUserDataRoundtrip)
+
 add_executable(mvr_exporter_compliance_test mvr_exporter_compliance_test.cpp
                ../core/configmanager.cpp
                ../core/configservices.cpp

--- a/tests/mvr_exporter_compliance_test.cpp
+++ b/tests/mvr_exporter_compliance_test.cpp
@@ -299,12 +299,16 @@ int main() {
             assert(dummyNode != nullptr && dummyNode->GetText() != nullptr);
             assert(std::string(dummyNode->GetText()) == "D8+ 1000kg");
 
-            auto *sourceNode = info->FirstChildElement("DataSource");
+            auto *sourceNode = info->FirstChildElement("ValueSource");
             assert(sourceNode != nullptr && sourceNode->GetText() != nullptr);
             assert(std::string(sourceNode->GetText()) == "Manual");
+            auto *sourceAliasNode = info->FirstChildElement("DataSource");
+            assert(sourceAliasNode != nullptr && sourceAliasNode->GetText() != nullptr);
+            assert(std::string(sourceAliasNode->GetText()) == "Manual");
 
-            auto *legacyNode = info->FirstChildElement("RiggingPoint");
-            assert(legacyNode == nullptr);
+            auto *riggingPointNode = info->FirstChildElement("RiggingPoint");
+            assert(riggingPointNode != nullptr && riggingPointNode->GetText() != nullptr);
+            assert(std::string(riggingPointNode->GetText()) == "Lighting");
           }
 
           if (std::string(cur->Name()) == "Fixture") {

--- a/tests/mvr_support_userdata_roundtrip_test.cpp
+++ b/tests/mvr_support_userdata_roundtrip_test.cpp
@@ -9,6 +9,8 @@
 #include "configmanager.h"
 #include "fixture.h"
 #include "layer.h"
+#include "mvrexporter.h"
+#include "mvrimporter.h"
 #include "projectutils.h"
 #include "support.h"
 
@@ -69,10 +71,12 @@ int main() {
   scene.supports[manual.uuid] = manual;
 
   const std::filesystem::path mvrPath = tempDir / "support_roundtrip.mvr";
-  assert(cfg.ExportMVR(mvrPath.string()));
+  MvrExporter exporter;
+  assert(exporter.ExportToFile(mvrPath.string()));
 
   cfg.Reset();
-  assert(cfg.ImportMVR(mvrPath.string(), false, false));
+  MvrImporter importer;
+  assert(importer.ImportFromFile(mvrPath.string(), false, false));
 
   const auto &loaded = cfg.GetScene().supports;
   assert(loaded.size() == 3);

--- a/tests/mvr_support_userdata_roundtrip_test.cpp
+++ b/tests/mvr_support_userdata_roundtrip_test.cpp
@@ -1,0 +1,97 @@
+/*
+ * This file is part of Perastage.
+ */
+#include <cassert>
+#include <filesystem>
+#include <fstream>
+#include <wx/init.h>
+
+#include "configmanager.h"
+#include "fixture.h"
+#include "layer.h"
+#include "projectutils.h"
+#include "support.h"
+
+int main() {
+  wxInitializer initializer;
+  assert(initializer.IsOk());
+
+  auto &cfg = ConfigManager::Get();
+  cfg.Reset();
+  MvrScene &scene = cfg.GetScene();
+
+  Layer layer;
+  layer.uuid = "layer1";
+  layer.name = "Layer1";
+  scene.layers[layer.uuid] = layer;
+
+  std::filesystem::path tempDir =
+      std::filesystem::temp_directory_path() / "mvr_support_userdata_roundtrip";
+  std::filesystem::create_directories(tempDir);
+  std::ofstream(tempDir / "fixture.gdtf") << "fixture";
+  scene.basePath = tempDir.string();
+
+  Fixture motorFixture;
+  motorFixture.uuid = "fx-motor";
+  motorFixture.instanceName = "Motor Fixture";
+  motorFixture.layer = layer.name;
+  motorFixture.typeName = "MotorType";
+  motorFixture.gdtfSpec = "fixture.gdtf";
+  scene.fixtures[motorFixture.uuid] = motorFixture;
+
+  Support linked;
+  linked.uuid = "sup-linked";
+  linked.name = "Linked";
+  linked.layer = layer.name;
+  linked.motorFixtureUuid = motorFixture.uuid;
+  linked.motorName = "CM Lodestar";
+  linked.useMotorDefaults = false;
+  linked.hoistDataSource = "Inherited";
+  scene.supports[linked.uuid] = linked;
+
+  Support dummy;
+  dummy.uuid = "sup-dummy";
+  dummy.name = "Dummy";
+  dummy.layer = layer.name;
+  dummy.dummyProfileId = "d8plus_1000kg";
+  dummy.hoistFunction = "Video";
+  scene.supports[dummy.uuid] = dummy;
+
+  Support manual;
+  manual.uuid = "sup-manual";
+  manual.name = "Manual";
+  manual.layer = layer.name;
+  manual.hoistDataSource = "Manual";
+  manual.capacityKg = 1250.0f;
+  manual.weightKg = 61.0f;
+  manual.hoistFunction = "Audio";
+  manual.motorName = "ChainMaster D8+";
+  scene.supports[manual.uuid] = manual;
+
+  const std::filesystem::path mvrPath = tempDir / "support_roundtrip.mvr";
+  assert(cfg.ExportMVR(mvrPath.string()));
+
+  cfg.Reset();
+  assert(cfg.ImportMVR(mvrPath.string(), false, false));
+
+  const auto &loaded = cfg.GetScene().supports;
+  assert(loaded.size() == 3);
+
+  const auto &loadedLinked = loaded.at("sup-linked");
+  assert(loadedLinked.motorFixtureUuid == "fx-motor");
+  assert(!loadedLinked.useMotorDefaults);
+
+  const auto &loadedDummy = loaded.at("sup-dummy");
+  assert(loadedDummy.dummyProfileId == "d8plus_1000kg");
+  assert(loadedDummy.hoistFunction == "Video");
+
+  const auto &loadedManual = loaded.at("sup-manual");
+  assert(loadedManual.hoistDataSource == "Manual");
+  assert(loadedManual.capacityKg == 1250.0f);
+  assert(loadedManual.weightKg == 61.0f);
+  assert(loadedManual.hoistFunction == "Audio");
+
+  std::filesystem::remove_all(tempDir);
+  std::filesystem::remove(ProjectUtils::GetDefaultLibraryPath("fixtures") + "/fixture.gdtf");
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- Centralize serialization and parsing of support hoist metadata in the MVR pipeline to reduce duplication and make the canonical schema explicit. 
- Preserve backward compatibility with older MVR payloads (`MotorInfo`, `Function`, `DataSource`) while migrating to a canonical `UserData/Data/HoistInfo` layout.
- Add focused roundtrip tests to cover common hoist metadata scenarios (motor-linked, dummy profile and manual overrides).

### Description
- Added documentation `docs/mvr_hoistinfo_schema.md` describing the canonical `UserData/Data/HoistInfo` fields (e.g. `Capacity`, `Weight`, `RiggingPoint`, `MotorFixtureUuid`, `DummyProfileId`, `ValueSource`) and compatibility aliases. 
- Extracted exporter helpers in `mvr/mvrexporter.cpp`: `ShouldExportSupportHoistInfo` and `AppendSupportHoistInfoUserData` to centralize writing canonical fields plus compatibility aliases (`Function`, `DataSource`).
- Extracted importer helpers in `mvr/mvrimporter.cpp`: `ReadSupportHoistInfoFromUserData` and `ApplySupportHoistInfoDefaults` to centralize reading, validation, defaults, and migration from legacy `MotorInfo`; importer now prefers canonical keys (`RiggingPoint`, `ValueSource`) and falls back to legacy aliases.
- Kept legacy behavior: `MotorInfo` blocks and alias names are still parsed and mapped into the internal `Support` model.
- Added a new test `tests/mvr_support_userdata_roundtrip_test.cpp` and registered it in `tests/CMakeLists.txt`, and updated `tests/mvr_exporter_compliance_test.cpp` assertions to validate the canonical+alias output.

### Testing
- Ran repository checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both returned OK.
- Attempted to configure/build tests with `cmake -S tests -B build/tests -DCMAKE_BUILD_TYPE=Release` and compile the test targets, but configuration failed in this environment due to missing `wxWidgets` development packages so tests were not built here.
- New tests were added and wired into `tests/CMakeLists.txt` (so they will run in CI when `wxWidgets` is available).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1166eb7f4832484e562a15b07bbd2)