### PR TITLE
Sync inherited hoist motor manufacturer/model into scene and add MVR roundtrip test

### DIFF
--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -786,6 +786,8 @@ void HoistTablePanel::UpdateSceneData(bool logChanges) {
           ResolveEffectiveSupportData(next, FindPresetDefaults(next),
                                       FindFixtureDefaults(scene, next));
       next.motorName = effective.motorName;
+      next.motorManufacturer = effective.motorManufacturer;
+      next.motorModel = effective.motorModel;
       next.capacityKg = effective.capacityKg;
       next.weightKg = effective.weightKg;
       next.hoistFunction = effective.hoistFunction;
@@ -794,6 +796,8 @@ void HoistTablePanel::UpdateSceneData(bool logChanges) {
     const bool supportChanged = old.name != next.name || old.function != next.function ||
                                 old.hoistFunction != next.hoistFunction ||
                                 old.motorName != next.motorName ||
+                                old.motorManufacturer != next.motorManufacturer ||
+                                old.motorModel != next.motorModel ||
                                 old.dummyProfileId != next.dummyProfileId ||
                                 old.dummyPreset != next.dummyPreset ||
                                 NormalizeHoistDataSource(old.hoistDataSource) !=

--- a/tests/mvr_support_userdata_roundtrip_test.cpp
+++ b/tests/mvr_support_userdata_roundtrip_test.cpp
@@ -39,6 +39,7 @@ int main() {
   motorFixture.layer = layer.name;
   motorFixture.typeName = "MotorType";
   motorFixture.gdtfSpec = "fixture.gdtf";
+  motorFixture.gdtfMode = "ChainMode";
   scene.fixtures[motorFixture.uuid] = motorFixture;
 
   Support linked;
@@ -58,6 +59,26 @@ int main() {
   dummy.dummyProfileId = "d8plus_1000kg";
   dummy.hoistFunction = "Video";
   scene.supports[dummy.uuid] = dummy;
+
+  Support inheritedDefaults;
+  inheritedDefaults.uuid = "sup-inherited-defaults";
+  inheritedDefaults.name = "Inherited Defaults";
+  inheritedDefaults.layer = layer.name;
+  inheritedDefaults.motorFixtureUuid = motorFixture.uuid;
+  inheritedDefaults.dummyProfileId = "d8plus_1000kg";
+  inheritedDefaults.hoistDataSource = "Inherited";
+  inheritedDefaults.useMotorDefaults = true;
+  HoistPresetDefaults inheritedPreset;
+  inheritedPreset.motorManufacturer = "Perastage";
+  inheritedPreset.capacityKg = 1000.0f;
+  inheritedPreset.weightKg = 40.0f;
+  inheritedPreset.hoistFunction = "Lighting";
+
+  const auto effectiveInherited = ResolveEffectiveSupportData(
+      inheritedDefaults, inheritedPreset, BuildHoistFixtureDefaults(motorFixture));
+  inheritedDefaults.motorManufacturer = effectiveInherited.motorManufacturer;
+  inheritedDefaults.motorModel = effectiveInherited.motorModel;
+  scene.supports[inheritedDefaults.uuid] = inheritedDefaults;
 
   Support manual;
   manual.uuid = "sup-manual";
@@ -79,7 +100,7 @@ int main() {
   assert(importer.ImportFromFile(mvrPath.string(), false, false));
 
   const auto &loaded = cfg.GetScene().supports;
-  assert(loaded.size() == 3);
+  assert(loaded.size() == 4);
 
   const auto &loadedLinked = loaded.at("sup-linked");
   assert(loadedLinked.motorFixtureUuid == "fx-motor");
@@ -95,6 +116,12 @@ int main() {
   assert(loadedManual.weightKg == 61.0f);
   assert(loadedManual.hoistFunction == "Audio");
 
+
+  const auto &loadedInheritedDefaults = loaded.at("sup-inherited-defaults");
+  assert(loadedInheritedDefaults.hoistDataSource == "Inherited");
+  assert(loadedInheritedDefaults.useMotorDefaults);
+  assert(loadedInheritedDefaults.motorManufacturer == "Perastage");
+  assert(loadedInheritedDefaults.motorModel == "ChainMode");
   std::filesystem::remove_all(tempDir);
   std::filesystem::remove(ProjectUtils::GetDefaultLibraryPath("fixtures") + "/fixture.gdtf");
   return 0;

--- a/tests/support_resolution_test.cpp
+++ b/tests/support_resolution_test.cpp
@@ -11,6 +11,8 @@ int main() {
 
   HoistPresetDefaults preset;
   preset.motorName = "Preset Motor";
+  preset.motorManufacturer = "Preset Manufacturer";
+  preset.motorModel = "Preset Model";
   preset.capacityKg = 1000.0f;
   preset.weightKg = 40.0f;
   preset.hoistFunction = "Audio";
@@ -25,6 +27,7 @@ int main() {
   const auto inherited =
       ResolveEffectiveSupportData(support, preset, fixtureDefaults);
   assert(inherited.motorName == "Fixture Motor");
+  assert(inherited.motorManufacturer == "Preset Manufacturer");
   assert(inherited.motorModel == "Mode A");
   assert(inherited.capacityKg == 1000.0f);
   assert(inherited.weightKg == 55.0f);
@@ -32,16 +35,22 @@ int main() {
 
   support.capacityKg = 750.0f;
   support.motorName = "Manual Motor";
+  support.motorManufacturer = "Manual Manufacturer";
   const auto manualPriority =
       ResolveEffectiveSupportData(support, preset, fixtureDefaults);
   assert(manualPriority.motorName == "Manual Motor");
+  assert(manualPriority.motorManufacturer == "Manual Manufacturer");
   assert(manualPriority.capacityKg == 750.0f);
 
   support.useMotorDefaults = false;
   support.motorName.clear();
+  support.motorManufacturer.clear();
+  support.motorModel.clear();
   support.capacityKg = 0.0f;
   const auto noDefaults = ResolveEffectiveSupportData(support, preset, fixtureDefaults);
   assert(noDefaults.motorName.empty());
+  assert(noDefaults.motorManufacturer.empty());
+  assert(noDefaults.motorModel.empty());
   assert(noDefaults.capacityKg == 0.0f);
 
   support.hoistDataSource = "Manual";


### PR DESCRIPTION
### Motivation

- Ensure that when a support uses inherited/default hoist data the `motorManufacturer` and `motorModel` fields are reflected in the scene alongside the already-handled fields so UI edits/undo and exports include them.
- Verify that `ResolveEffectiveSupportData(...)` correctly resolves manufacturer and model from fixture/preset defaults and that the MVR exporter/importer roundtrips those values when they come from inherited defaults.

### Description

- In `gui/hoisttablepanel.cpp` updated `HoistTablePanel::UpdateSceneData` so non-manual supports copy `motorManufacturer` and `motorModel` from `ResolveEffectiveSupportData(...)` and added both fields to the support change detection logic.
- Extended `tests/support_resolution_test.cpp` to assert that `ResolveEffectiveSupportData(...)` resolves `motorManufacturer` and `motorModel` correctly for inherited, manual-priority, and no-default cases.
- Added an inherited-defaults case to `tests/mvr_support_userdata_roundtrip_test.cpp` that builds a support whose manufacturer comes from preset and model from the fixture mode, then exports/imports an MVR and asserts the loaded scene preserves `motorManufacturer` and `motorModel`.

### Testing

- Ran `tests/check_perastage_tree_modules.sh` and it passed (OK).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (OK).
- Attempted `cmake --preset wsl-x64-debug` to build tests but configuration failed due to missing system `wxWidgets` dev packages, so test binaries were not built or executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b11b0e07d483249cbc9b625b680e46)