### PR TITLE
Keep splash screen visible until fixture symbol auto-update completes

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -304,6 +304,8 @@ MainWindow::MainWindow(const wxString &title, IGuiConfigServices *services)
   if (layoutPanel)
     layoutPanel->ReloadLayouts();
 
+  Bind(wxEVT_IDLE, &MainWindow::OnStartupSplashCloseIdle, this);
+
   UpdateTitle();
 }
 
@@ -565,6 +567,7 @@ void MainWindow::ResetProject() {
   fixtureSymbolAutoUpdateGeneratedTypeSet.clear();
   fixtureSymbolAutoUpdateRunning = false;
   fixtureSymbolAutoUpdateCompletionCallback = nullptr;
+  startupSplashCloseRequested = false;
   currentProjectPath.clear();
   if (layoutPanel)
     layoutPanel->ReloadLayouts();

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -564,6 +564,7 @@ void MainWindow::ResetProject() {
   fixtureSymbolAutoUpdateErrors.clear();
   fixtureSymbolAutoUpdateGeneratedTypeSet.clear();
   fixtureSymbolAutoUpdateRunning = false;
+  fixtureSymbolAutoUpdateCompletionCallback = nullptr;
   currentProjectPath.clear();
   if (layoutPanel)
     layoutPanel->ReloadLayouts();
@@ -919,6 +920,7 @@ void MainWindow::OnProjectLoaded(wxCommandEvent &event) {
       layoutPanel->ReloadLayouts();
     if (consolePanel)
       consolePanel->AppendMessage("Loaded " + wxString::FromUTF8(path));
+    SplashScreen::SetMessage("Loading tables...");
     if (fixturePanel)
       fixturePanel->ReloadData();
     if (trussPanel)
@@ -953,13 +955,16 @@ void MainWindow::OnProjectLoaded(wxCommandEvent &event) {
     RefreshSummary();
     RefreshRigging();
     GetDefaultGuiConfigServices().LegacyConfigManager().MarkSaved();
+    SplashScreen::SetMessage("Creating fixture symbols...");
+    fixtureSymbolAutoUpdateCompletionCallback = [this]() {
+      CompleteStartupSplashInitialization();
+    };
     StartFixtureSymbolAutoUpdateForLoadedScene();
     UpdateTitle();
   } else {
     ResetProject();
+    CompleteStartupSplashInitialization();
   }
-  SplashScreen::SetMessage("Ready");
-  SplashScreen::Hide();
 }
 
 void MainWindow::OnNotebookPageChanged(wxBookCtrlEvent &event) {

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -952,18 +952,19 @@ void MainWindow::OnProjectLoaded(wxCommandEvent &event) {
       viewport2DRenderPanel->ApplyConfig();
     if (layerPanel)
       layerPanel->ReloadLayers();
+    SplashScreen::SetMessage("Refreshing panels...");
     RefreshSummary();
     RefreshRigging();
     GetDefaultGuiConfigServices().LegacyConfigManager().MarkSaved();
     SplashScreen::SetMessage("Creating fixture symbols...");
     fixtureSymbolAutoUpdateCompletionCallback = [this]() {
-      CompleteStartupSplashInitialization();
+      RequestStartupSplashCompletion();
     };
     StartFixtureSymbolAutoUpdateForLoadedScene();
     UpdateTitle();
   } else {
     ResetProject();
-    CompleteStartupSplashInitialization();
+    RequestStartupSplashCompletion();
   }
 }
 

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -212,6 +212,7 @@ private:
   void StartFixtureSymbolAutoUpdateForLoadedScene();
   void ProcessNextFixtureSymbolAutoUpdate();
   void CompleteStartupSplashInitialization();
+  void RequestStartupSplashCompletion();
   void FlushPendingFixtureSymbolLibraryUpdates();
   std::string BuildFixtureSymbolAutoUpdateSummary() const;
   std::string defaultLayoutPerspective;

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -33,6 +33,7 @@ wxDECLARE_EVENT(EVT_PROJECT_LOADED, wxCommandEvent);
 
 // Forward declarations for GUI components
 class wxNotebook;
+class wxIdleEvent;
 class FixtureTablePanel;
 class TrussTablePanel;
 class HoistTablePanel;
@@ -213,6 +214,7 @@ private:
   void ProcessNextFixtureSymbolAutoUpdate();
   void CompleteStartupSplashInitialization();
   void RequestStartupSplashCompletion();
+  void OnStartupSplashCloseIdle(wxIdleEvent &event);
   void FlushPendingFixtureSymbolLibraryUpdates();
   std::string BuildFixtureSymbolAutoUpdateSummary() const;
   std::string defaultLayoutPerspective;
@@ -236,6 +238,7 @@ private:
   bool fixtureSymbolAutoUpdateRunning = false;
   std::function<void()> fixtureSymbolAutoUpdateCompletionCallback;
   bool startupSplashInitializationPending = true;
+  bool startupSplashCloseRequested = false;
   int viewportInteractionLockDepth = 0;
 
   friend class MainWindowIoController;

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -25,6 +25,7 @@
 #include <memory>
 #include <optional>
 #include <array>
+#include <functional>
 #include <unordered_set>
 #include <vector>
 
@@ -210,6 +211,7 @@ private:
                           const wxString &dialogTitle);
   void StartFixtureSymbolAutoUpdateForLoadedScene();
   void ProcessNextFixtureSymbolAutoUpdate();
+  void CompleteStartupSplashInitialization();
   void FlushPendingFixtureSymbolLibraryUpdates();
   std::string BuildFixtureSymbolAutoUpdateSummary() const;
   std::string defaultLayoutPerspective;
@@ -231,6 +233,8 @@ private:
   std::vector<std::string> fixtureSymbolAutoUpdateErrors;
   std::unordered_set<std::string> fixtureSymbolAutoUpdateGeneratedTypeSet;
   bool fixtureSymbolAutoUpdateRunning = false;
+  std::function<void()> fixtureSymbolAutoUpdateCompletionCallback;
+  bool startupSplashInitializationPending = true;
   int viewportInteractionLockDepth = 0;
 
   friend class MainWindowIoController;

--- a/gui/mainwindow_fixture_symbol_autoupdate.cpp
+++ b/gui/mainwindow_fixture_symbol_autoupdate.cpp
@@ -324,6 +324,12 @@ void MainWindow::FlushPendingFixtureSymbolLibraryUpdates() {
 }
 
 
+
+void MainWindow::RequestStartupSplashCompletion() {
+  CallAfter([this]() { CompleteStartupSplashInitialization(); });
+}
+
+
 void MainWindow::CompleteStartupSplashInitialization() {
   if (!startupSplashInitializationPending)
     return;

--- a/gui/mainwindow_fixture_symbol_autoupdate.cpp
+++ b/gui/mainwindow_fixture_symbol_autoupdate.cpp
@@ -326,9 +326,19 @@ void MainWindow::FlushPendingFixtureSymbolLibraryUpdates() {
 
 
 void MainWindow::RequestStartupSplashCompletion() {
-  CallAfter([this]() { CompleteStartupSplashInitialization(); });
+  if (!startupSplashInitializationPending)
+    return;
+  startupSplashCloseRequested = true;
 }
 
+void MainWindow::OnStartupSplashCloseIdle(wxIdleEvent &event) {
+  event.Skip();
+  if (!startupSplashCloseRequested)
+    return;
+
+  startupSplashCloseRequested = false;
+  CompleteStartupSplashInitialization();
+}
 
 void MainWindow::CompleteStartupSplashInitialization() {
   if (!startupSplashInitializationPending)

--- a/gui/mainwindow_fixture_symbol_autoupdate.cpp
+++ b/gui/mainwindow_fixture_symbol_autoupdate.cpp
@@ -11,6 +11,7 @@
 #include "fixture.h"
 #include "guiconfigservices.h"
 #include "opaque_pass_utils.h"
+#include "splashscreen.h"
 #include "tools/scene_model_symbol_capture_service.h"
 #include "tools/symbol_physical_calibration.h"
 #include "windows/symbol_fixture_applier.h"
@@ -137,6 +138,11 @@ void MainWindow::StartFixtureSymbolAutoUpdateForLoadedScene() {
                             false);
     ReportFixtureAutoUpdate(*this, consolePanel,
                             "Fixture symbol auto-update summary: no fixtures queued.");
+    if (fixtureSymbolAutoUpdateCompletionCallback) {
+      auto completionCallback = fixtureSymbolAutoUpdateCompletionCallback;
+      fixtureSymbolAutoUpdateCompletionCallback = nullptr;
+      completionCallback();
+    }
     return;
   }
 
@@ -156,6 +162,11 @@ void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
                             "Fixture symbol auto-update: completed.", false);
     ReportFixtureAutoUpdate(*this, consolePanel,
                             BuildFixtureSymbolAutoUpdateSummary());
+    if (fixtureSymbolAutoUpdateCompletionCallback) {
+      auto completionCallback = fixtureSymbolAutoUpdateCompletionCallback;
+      fixtureSymbolAutoUpdateCompletionCallback = nullptr;
+      completionCallback();
+    }
     return;
   }
 
@@ -214,6 +225,11 @@ void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
         "Stopped: offscreen renderer unavailable");
     ReportFixtureAutoUpdate(*this, consolePanel,
                             BuildFixtureSymbolAutoUpdateSummary());
+    if (fixtureSymbolAutoUpdateCompletionCallback) {
+      auto completionCallback = fixtureSymbolAutoUpdateCompletionCallback;
+      fixtureSymbolAutoUpdateCompletionCallback = nullptr;
+      completionCallback();
+    }
     return;
   }
 
@@ -305,4 +321,14 @@ void MainWindow::FlushPendingFixtureSymbolLibraryUpdates() {
                                                    syncError);
   }
   fixtureSymbolPendingLibrarySyncUuids.clear();
+}
+
+
+void MainWindow::CompleteStartupSplashInitialization() {
+  if (!startupSplashInitializationPending)
+    return;
+
+  startupSplashInitializationPending = false;
+  SplashScreen::SetMessage("Ready");
+  SplashScreen::Hide();
 }


### PR DESCRIPTION
### Motivation
- Ensure the splash screen remains visible during startup until fixture symbol generation and table loading finish, so users see basic progress messages and the UI does not appear ready before initialization completes.

### Description
- Added a centralized completion routine `CompleteStartupSplashInitialization()` that sets the splash to `Ready` and hides it only when startup initialization is actually done, and replaced the previous immediate `SplashScreen::Hide()` call with this flow (`gui/mainwindow_fixture_symbol_autoupdate.cpp`, `gui/mainwindow.cpp`).
- Introduced a one-shot completion callback `fixtureSymbolAutoUpdateCompletionCallback` and a flag `startupSplashInitializationPending` on `MainWindow` to coordinate splash closing with the fixture symbol auto-update process (`gui/mainwindow.h`).
- Wired progress messages into startup: `SplashScreen::SetMessage("Loading tables...")` before table reloads and `SplashScreen::SetMessage("Creating fixture symbols...")` before starting the symbol auto-update (`gui/mainwindow.cpp`).
- Invoked the completion callback from all terminal branches of the auto-update workflow (no-queue, renderer-unavailable, normal completion) and clear the callback on project reset to avoid stale callbacks (`gui/mainwindow_fixture_symbol_autoupdate.cpp`, `gui/mainwindow.cpp`).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b191d6a16883248b15148733140f3e)