### PR TITLE
Add per-field hoist source tracking and MVR IO

### DIFF
--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -33,6 +33,7 @@
 #include "viewer3dpanel.h"
 #include <algorithm>
 #include <cctype>
+#include <cmath>
 #include <optional>
 #include <wx/choicdlg.h>
 #include <wx/notebook.h>
@@ -59,6 +60,47 @@ bool IsNumChar(char c) {
          c == '+';
 }
 
+inline bool NearlyEqualFloat(float a, float b) {
+  return std::abs(a - b) < 0.0001f;
+}
+
+void MarkTextFieldManualIfEdited(const std::string &editedValue,
+                                 const std::string &oldEffectiveValue,
+                                 std::string &fieldSource,
+                                 const std::string &oldFieldValue,
+                                 std::string &fieldValue) {
+  if (editedValue != oldEffectiveValue) {
+    fieldSource = "Manual";
+    fieldValue = editedValue;
+    return;
+  }
+
+  if (!IsManualHoistDataSource(fieldSource))
+    fieldValue = oldFieldValue;
+}
+
+void MarkNumericFieldManualIfEdited(float editedValue, float oldEffectiveValue,
+                                    std::string &fieldSource,
+                                    float oldFieldValue, float &fieldValue) {
+  if (!NearlyEqualFloat(editedValue, oldEffectiveValue)) {
+    fieldSource = "Manual";
+    fieldValue = editedValue;
+    return;
+  }
+
+  if (!IsManualHoistDataSource(fieldSource))
+    fieldValue = oldFieldValue;
+}
+
+void SetAllHoistFieldSources(Support &support, const std::string &source) {
+  const std::string normalized = NormalizeHoistDataSource(source);
+  support.motorNameSource = normalized;
+  support.motorManufacturerSource = normalized;
+  support.motorModelSource = normalized;
+  support.capacitySource = normalized;
+  support.weightSource = normalized;
+  support.hoistFunctionSource = normalized;
+}
 
 std::optional<HoistPresetDefaults> FindPresetDefaults(const Support &support) {
   std::optional<DummyHoistProfile> profile;
@@ -234,6 +276,18 @@ void HoistTablePanel::ReloadData() {
     wxString name = wxString::FromUTF8(support.name);
     wxString type = wxString::FromUTF8(support.function);
     support.hoistDataSource = NormalizeHoistDataSource(support.hoistDataSource);
+    support.motorNameSource =
+        ResolveHoistFieldDataSource(support.motorNameSource, support.hoistDataSource);
+    support.motorManufacturerSource = ResolveHoistFieldDataSource(
+        support.motorManufacturerSource, support.hoistDataSource);
+    support.motorModelSource =
+        ResolveHoistFieldDataSource(support.motorModelSource, support.hoistDataSource);
+    support.capacitySource =
+        ResolveHoistFieldDataSource(support.capacitySource, support.hoistDataSource);
+    support.weightSource =
+        ResolveHoistFieldDataSource(support.weightSource, support.hoistDataSource);
+    support.hoistFunctionSource = ResolveHoistFieldDataSource(
+        support.hoistFunctionSource, support.hoistDataSource);
     const auto effective =
         ResolveEffectiveSupportData(support, FindPresetDefaults(support),
                                     FindFixtureDefaults(scene, support));
@@ -684,11 +738,18 @@ void HoistTablePanel::UpdateSceneData(bool logChanges) {
     table->GetValue(v, i, 2);
     next.function = std::string(v.GetString().ToUTF8());
 
+    const auto oldEffective =
+        ResolveEffectiveSupportData(old, FindPresetDefaults(old),
+                                    FindFixtureDefaults(scene, old));
+
     table->GetValue(v, i, 3);
-    next.hoistFunction = NormalizeHoistFunction(std::string(v.GetString().ToUTF8()));
+    const std::string editedHoistFunction =
+        NormalizeHoistFunction(std::string(v.GetString().ToUTF8()));
+    next.hoistFunction = editedHoistFunction;
 
     table->GetValue(v, i, 4);
-    next.motorName = std::string(v.GetString().ToUTF8());
+    const std::string editedMotorName = std::string(v.GetString().ToUTF8());
+    next.motorName = editedMotorName;
 
     table->GetValue(v, i, 5);
     next.dummyPreset = std::string(v.GetString().ToUTF8());
@@ -702,6 +763,10 @@ void HoistTablePanel::UpdateSceneData(bool logChanges) {
     table->GetValue(v, i, 6);
     next.hoistDataSource =
         NormalizeHoistDataSource(std::string(v.GetString().ToUTF8()));
+    if (IsManualHoistDataSource(next.hoistDataSource))
+      SetAllHoistFieldSources(next, "Manual");
+    else if (NormalizeHoistDataSource(old.hoistDataSource) != "Inherited")
+      SetAllHoistFieldSources(next, "Inherited");
 
     table->GetValue(v, i, 7);
     std::string layerStr = std::string(v.GetString().ToUTF8());
@@ -774,24 +839,36 @@ void HoistTablePanel::UpdateSceneData(bool logChanges) {
     table->GetValue(v, i, 16);
     double capacity = 0.0;
     v.GetString().ToDouble(&capacity);
-    next.capacityKg = static_cast<float>(capacity);
+    const float editedCapacityKg = static_cast<float>(capacity);
+    next.capacityKg = editedCapacityKg;
 
     table->GetValue(v, i, 17);
     double weight = 0.0;
     v.GetString().ToDouble(&weight);
-    next.weightKg = static_cast<float>(weight);
+    const float editedWeightKg = static_cast<float>(weight);
+    next.weightKg = editedWeightKg;
 
-    if (!IsManualHoistDataSource(next.hoistDataSource)) {
-      const auto effective =
-          ResolveEffectiveSupportData(next, FindPresetDefaults(next),
-                                      FindFixtureDefaults(scene, next));
-      next.motorName = effective.motorName;
-      next.motorManufacturer = effective.motorManufacturer;
-      next.motorModel = effective.motorModel;
-      next.capacityKg = effective.capacityKg;
-      next.weightKg = effective.weightKg;
-      next.hoistFunction = effective.hoistFunction;
-    }
+    next.motorNameSource =
+        ResolveHoistFieldDataSource(next.motorNameSource, next.hoistDataSource);
+    next.capacitySource =
+        ResolveHoistFieldDataSource(next.capacitySource, next.hoistDataSource);
+    next.weightSource =
+        ResolveHoistFieldDataSource(next.weightSource, next.hoistDataSource);
+    next.hoistFunctionSource = ResolveHoistFieldDataSource(
+        next.hoistFunctionSource, next.hoistDataSource);
+
+    MarkTextFieldManualIfEdited(editedMotorName, oldEffective.motorName,
+                                next.motorNameSource, old.motorName,
+                                next.motorName);
+    MarkNumericFieldManualIfEdited(editedCapacityKg, oldEffective.capacityKg,
+                                   next.capacitySource, old.capacityKg,
+                                   next.capacityKg);
+    MarkNumericFieldManualIfEdited(editedWeightKg, oldEffective.weightKg,
+                                   next.weightSource, old.weightKg,
+                                   next.weightKg);
+    MarkTextFieldManualIfEdited(editedHoistFunction, oldEffective.hoistFunction,
+                                next.hoistFunctionSource, old.hoistFunction,
+                                next.hoistFunction);
 
     const bool supportChanged = old.name != next.name || old.function != next.function ||
                                 old.hoistFunction != next.hoistFunction ||
@@ -806,7 +883,19 @@ void HoistTablePanel::UpdateSceneData(bool logChanges) {
                                 old.positionName != next.positionName || transformChanged ||
                                 old.chainLength != next.chainLength ||
                                 old.capacityKg != next.capacityKg ||
-                                old.weightKg != next.weightKg;
+                                old.weightKg != next.weightKg ||
+                                NormalizeHoistDataSource(old.motorNameSource) !=
+                                    NormalizeHoistDataSource(next.motorNameSource) ||
+                                NormalizeHoistDataSource(old.motorManufacturerSource) !=
+                                    NormalizeHoistDataSource(next.motorManufacturerSource) ||
+                                NormalizeHoistDataSource(old.motorModelSource) !=
+                                    NormalizeHoistDataSource(next.motorModelSource) ||
+                                NormalizeHoistDataSource(old.capacitySource) !=
+                                    NormalizeHoistDataSource(next.capacitySource) ||
+                                NormalizeHoistDataSource(old.weightSource) !=
+                                    NormalizeHoistDataSource(next.weightSource) ||
+                                NormalizeHoistDataSource(old.hoistFunctionSource) !=
+                                    NormalizeHoistDataSource(next.hoistFunctionSource);
     if (!supportChanged)
       continue;
 

--- a/models/support.h
+++ b/models/support.h
@@ -54,6 +54,12 @@ struct Support {
     std::string dummyPreset;
     // Defines whether values come from library defaults or user overrides.
     std::string hoistDataSource = "Inherited";
+    std::string motorNameSource = "Inherited";
+    std::string motorManufacturerSource = "Inherited";
+    std::string motorModelSource = "Inherited";
+    std::string capacitySource = "Inherited";
+    std::string weightSource = "Inherited";
+    std::string hoistFunctionSource = "Inherited";
     // Hoist function/category. Defaults to values returned by GetHoistFunctionOptions().
     std::string hoistFunction = "Lighting";
 
@@ -126,6 +132,14 @@ inline bool IsManualHoistDataSource(const std::string &source) {
     return NormalizeHoistDataSource(source) == "Manual";
 }
 
+inline std::string ResolveHoistFieldDataSource(const std::string &fieldSource,
+                                               const std::string &globalSource) {
+    const std::string normalizedField = NormalizeHoistDataSource(fieldSource);
+    if (!fieldSource.empty())
+        return normalizedField;
+    return NormalizeHoistDataSource(globalSource);
+}
+
 struct HoistPresetDefaults {
     std::string motorName;
     std::string motorManufacturer;
@@ -152,6 +166,12 @@ struct EffectiveSupportData {
     float weightKg = 0.0f;
     std::string hoistFunction = "Lighting";
     std::string dataSource = "Inherited";
+    std::string motorNameSource = "Inherited";
+    std::string motorManufacturerSource = "Inherited";
+    std::string motorModelSource = "Inherited";
+    std::string capacitySource = "Inherited";
+    std::string weightSource = "Inherited";
+    std::string hoistFunctionSource = "Inherited";
 };
 
 
@@ -178,6 +198,18 @@ inline EffectiveSupportData ResolveEffectiveSupportData(
     EffectiveSupportData resolved;
     const std::string normalizedSource = NormalizeHoistDataSource(support.hoistDataSource);
     resolved.dataSource = normalizedSource;
+    resolved.motorNameSource =
+        ResolveHoistFieldDataSource(support.motorNameSource, normalizedSource);
+    resolved.motorManufacturerSource = ResolveHoistFieldDataSource(
+        support.motorManufacturerSource, normalizedSource);
+    resolved.motorModelSource =
+        ResolveHoistFieldDataSource(support.motorModelSource, normalizedSource);
+    resolved.capacitySource =
+        ResolveHoistFieldDataSource(support.capacitySource, normalizedSource);
+    resolved.weightSource =
+        ResolveHoistFieldDataSource(support.weightSource, normalizedSource);
+    resolved.hoistFunctionSource = ResolveHoistFieldDataSource(
+        support.hoistFunctionSource, normalizedSource);
 
     resolved.motorName = support.motorName;
     resolved.motorManufacturer = support.motorManufacturer;
@@ -187,30 +219,51 @@ inline EffectiveSupportData ResolveEffectiveSupportData(
     resolved.hoistFunction = NormalizeHoistFunction(
         support.hoistFunction.empty() ? support.function : support.hoistFunction);
 
-    if (normalizedSource == "Manual")
-        return resolved;
-
     if (!support.useMotorDefaults)
         return resolved;
 
     auto applyDefaults = [&](const auto &defaults, const char *sourceLabel) {
-        if (!HasManualText(resolved.motorName) && HasManualText(defaults.motorName))
+        if (!IsManualHoistDataSource(resolved.motorNameSource) &&
+            !HasManualText(resolved.motorName) && HasManualText(defaults.motorName)) {
             resolved.motorName = defaults.motorName;
-        if (!HasManualText(resolved.motorManufacturer) &&
+            resolved.motorNameSource = sourceLabel;
+        }
+        if (!IsManualHoistDataSource(resolved.motorManufacturerSource) &&
+            !HasManualText(resolved.motorManufacturer) &&
             HasManualText(defaults.motorManufacturer)) {
             resolved.motorManufacturer = defaults.motorManufacturer;
+            resolved.motorManufacturerSource = sourceLabel;
         }
-        if (!HasManualText(resolved.motorModel) && HasManualText(defaults.motorModel))
+        if (!IsManualHoistDataSource(resolved.motorModelSource) &&
+            !HasManualText(resolved.motorModel) && HasManualText(defaults.motorModel)) {
             resolved.motorModel = defaults.motorModel;
-        if (!HasManualNumeric(resolved.capacityKg) && HasManualNumeric(defaults.capacityKg))
+            resolved.motorModelSource = sourceLabel;
+        }
+        if (!IsManualHoistDataSource(resolved.capacitySource) &&
+            !HasManualNumeric(resolved.capacityKg) &&
+            HasManualNumeric(defaults.capacityKg)) {
             resolved.capacityKg = defaults.capacityKg;
-        if (!HasManualNumeric(resolved.weightKg) && HasManualNumeric(defaults.weightKg))
+            resolved.capacitySource = sourceLabel;
+        }
+        if (!IsManualHoistDataSource(resolved.weightSource) &&
+            !HasManualNumeric(resolved.weightKg) && HasManualNumeric(defaults.weightKg)) {
             resolved.weightKg = defaults.weightKg;
-        if (NormalizeHoistFunction(resolved.hoistFunction) == "Lighting" &&
+            resolved.weightSource = sourceLabel;
+        }
+        if (!IsManualHoistDataSource(resolved.hoistFunctionSource) &&
+            NormalizeHoistFunction(resolved.hoistFunction) == "Lighting" &&
             HasManualText(defaults.hoistFunction)) {
             resolved.hoistFunction = NormalizeHoistFunction(defaults.hoistFunction);
+            resolved.hoistFunctionSource = sourceLabel;
         }
-        resolved.dataSource = sourceLabel;
+        if (resolved.motorNameSource == sourceLabel ||
+            resolved.motorManufacturerSource == sourceLabel ||
+            resolved.motorModelSource == sourceLabel ||
+            resolved.capacitySource == sourceLabel ||
+            resolved.weightSource == sourceLabel ||
+            resolved.hoistFunctionSource == sourceLabel) {
+            resolved.dataSource = sourceLabel;
+        }
     };
 
     if (fixtureDefaults.has_value())

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -506,7 +506,13 @@ static bool ShouldExportSupportHoistInfo(const Support &support) {
          !support.motorManufacturer.empty() || !support.motorModel.empty() ||
          !support.motorFixtureUuid.empty() || !support.useMotorDefaults ||
          !support.dummyProfileId.empty() || !support.dummyPreset.empty() ||
-         NormalizeHoistDataSource(support.hoistDataSource) != "Inherited";
+         NormalizeHoistDataSource(support.hoistDataSource) != "Inherited" ||
+         NormalizeHoistDataSource(support.motorNameSource) != "Inherited" ||
+         NormalizeHoistDataSource(support.motorManufacturerSource) != "Inherited" ||
+         NormalizeHoistDataSource(support.motorModelSource) != "Inherited" ||
+         NormalizeHoistDataSource(support.capacitySource) != "Inherited" ||
+         NormalizeHoistDataSource(support.weightSource) != "Inherited" ||
+         NormalizeHoistDataSource(support.hoistFunctionSource) != "Inherited";
 }
 
 static void AppendSupportHoistInfoUserData(tinyxml2::XMLDocument &doc,
@@ -565,6 +571,21 @@ static void AppendSupportHoistInfoUserData(tinyxml2::XMLDocument &doc,
   const std::string source = NormalizeHoistDataSource(support.hoistDataSource);
   addText("ValueSource", source);
   addText("DataSource", source); // Compatibility alias for older builds.
+
+  addText("MotorNameSource",
+          ResolveHoistFieldDataSource(support.motorNameSource, source));
+  addText("MotorManufacturerSource",
+          ResolveHoistFieldDataSource(support.motorManufacturerSource, source));
+  addText("MotorModelSource",
+          ResolveHoistFieldDataSource(support.motorModelSource, source));
+  addText("CapacitySource",
+          ResolveHoistFieldDataSource(support.capacitySource, source));
+  addText("WeightSource",
+          ResolveHoistFieldDataSource(support.weightSource, source));
+  const std::string hoistFunctionSource =
+      ResolveHoistFieldDataSource(support.hoistFunctionSource, source);
+  addText("RiggingPointSource", hoistFunctionSource);
+  addText("FunctionSource", hoistFunctionSource); // Compatibility alias.
 
   data->InsertEndChild(info);
   ud->InsertEndChild(data);

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -301,6 +301,18 @@ static void ApplySupportHoistInfoDefaults(Support &support) {
   support.hoistFunction = NormalizeHoistFunction(
       support.hoistFunction.empty() ? support.function : support.hoistFunction);
   support.hoistDataSource = NormalizeHoistDataSource(support.hoistDataSource);
+  support.motorNameSource =
+      ResolveHoistFieldDataSource(support.motorNameSource, support.hoistDataSource);
+  support.motorManufacturerSource = ResolveHoistFieldDataSource(
+      support.motorManufacturerSource, support.hoistDataSource);
+  support.motorModelSource =
+      ResolveHoistFieldDataSource(support.motorModelSource, support.hoistDataSource);
+  support.capacitySource =
+      ResolveHoistFieldDataSource(support.capacitySource, support.hoistDataSource);
+  support.weightSource =
+      ResolveHoistFieldDataSource(support.weightSource, support.hoistDataSource);
+  support.hoistFunctionSource = ResolveHoistFieldDataSource(
+      support.hoistFunctionSource, support.hoistDataSource);
   if (support.function.empty())
     support.function = support.hoistFunction;
 }
@@ -376,6 +388,37 @@ static void ReadSupportHoistInfoFromUserData(tinyxml2::XMLElement *supportNode,
       source = readText("DataSource"); // Legacy key.
     if (!source.empty())
       support.hoistDataSource = NormalizeHoistDataSource(source);
+
+    const std::string motorNameSource = readText("MotorNameSource");
+    if (!motorNameSource.empty())
+      support.motorNameSource = NormalizeHoistDataSource(motorNameSource);
+
+    const std::string motorManufacturerSource =
+        readText("MotorManufacturerSource");
+    if (!motorManufacturerSource.empty()) {
+      support.motorManufacturerSource =
+          NormalizeHoistDataSource(motorManufacturerSource);
+    }
+
+    const std::string motorModelSource = readText("MotorModelSource");
+    if (!motorModelSource.empty())
+      support.motorModelSource = NormalizeHoistDataSource(motorModelSource);
+
+    const std::string capacitySource = readText("CapacitySource");
+    if (!capacitySource.empty())
+      support.capacitySource = NormalizeHoistDataSource(capacitySource);
+
+    const std::string weightSource = readText("WeightSource");
+    if (!weightSource.empty())
+      support.weightSource = NormalizeHoistDataSource(weightSource);
+
+    std::string hoistFunctionSource = readText("RiggingPointSource");
+    if (hoistFunctionSource.empty())
+      hoistFunctionSource = readText("FunctionSource");
+    if (!hoistFunctionSource.empty()) {
+      support.hoistFunctionSource =
+          NormalizeHoistDataSource(hoistFunctionSource);
+    }
   }
 }
 bool MvrImporter::ImportFromFile(const std::string &filePath,


### PR DESCRIPTION
### Motivation
- Allow breaking inheritance per hoist field (motor name/manufacturer/model, capacity, weight, function) rather than only a global `hoistDataSource` switch.
- Preserve and expose the effective provenance for each hoist field so UI and MVR IO can read/write field-level source metadata.

### Description
- Added per-field source state to `Support`: `motorNameSource`, `motorManufacturerSource`, `motorModelSource`, `capacitySource`, `weightSource`, and `hoistFunctionSource`, and a helper `ResolveHoistFieldDataSource(...)` in `models/support.h`.
- Extended `EffectiveSupportData` and `ResolveEffectiveSupportData(...)` to return effective source tags per field and apply defaults only when the per-field source is not `Manual`.
- Updated MVR serialization in `mvr/mvrexporter.cpp` to emit the new `*Source` keys (`MotorNameSource`, `MotorManufacturerSource`, `MotorModelSource`, `CapacitySource`, `WeightSource`, and `RiggingPointSource`/`FunctionSource` alias) and updated `mvr/mvrimporter.cpp` to read those keys and apply normalized values during import.
- Modified `gui/hoisttablepanel.cpp` to normalize per-field sources at reload, add helpers to mark a field as `Manual` when a user edits a cell (without forcing global manual), propagate per-field source values when `Data Source` is toggled, and include changes to `*Source` in the change/undo detection logic.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed (`OK`).
- Attempted `cmake -S . -B build && cmake --build build -j2` which could not complete in this environment due to missing system dependency (`wxWidgets` include/libs), so build could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1923e8c048324be8c9157f9b38ed8)