### PR TITLE
Populate motor metadata when converting fixtures to hoists

### DIFF
--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -648,6 +648,10 @@ void MainWindow::OnConvertToHoist(wxCommandEvent &WXUNUSED(event)) {
     s.layer = fixture.layer;
     s.capacityKg = 0.0f;
     s.weightKg = fixture.weightKg;
+    s.motorName = fixture.instanceName.empty() ? fixture.typeName : fixture.instanceName;
+    s.motorModel = fixture.gdtfMode;
+    s.motorFixtureUuid = fixture.uuid;
+    s.hoistDataSource = "Manual";
     s.hoistFunction = NormalizeHoistFunction(s.function);
     s.transform = fixture.transform;
 


### PR DESCRIPTION
### Motivation
- Ensure hoist `Support` objects created by converting fixtures carry motor metadata and source information so UI, persistence, and linkage to the original fixture remain correct.

### Description
- Set `motorName`, `motorModel`, `motorFixtureUuid`, and `hoistDataSource` on the new `Support` in `OnConvertToHoist`, with `motorName` chosen as `instanceName` or falling back to `typeName`, `motorModel` set to `gdtfMode`, and `hoistDataSource` set to `"Manual"`.

### Testing
- Built the application (`make`) and ran the automated unit tests (`ctest`), and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0f0cd02e48324b805c8c9c5adddd7)