### PR TITLE
Apply GDTF ChannelSet PhysicalFrom/PhysicalTo to gobo spin (direction & speed)

### DIFF
--- a/peraviz/native/src/dmx/fixture_dmx_binding.cpp
+++ b/peraviz/native/src/dmx/fixture_dmx_binding.cpp
@@ -167,6 +167,7 @@ FixtureBindingBuildResult build_dimmer_bindings(
             wheel_binding.wheel_name = wheel.wheel_name;
             wheel_binding.slots = wheel.slots;
             wheel_binding.ranges = wheel.ranges;
+            wheel_binding.rotation_ranges = wheel.rotation_ranges;
             binding.gobo_wheels.push_back(std::move(wheel_binding));
         }
         binding.has_zoom_physical_limits = offsets.has_zoom_physical_limits;

--- a/peraviz/native/src/dmx/fixture_dmx_binding.h
+++ b/peraviz/native/src/dmx/fixture_dmx_binding.h
@@ -110,6 +110,7 @@ struct FixtureGoboWheelOffset {
     int rotation_coarse_offset_1_based = -1;
     int rotation_fine_offset_1_based = -1;
     int rotation_ultra_fine_offset_1_based = -1;
+    int rotation_source_priority = -1;
     bool has_index_physical_limits = false;
     float index_physical_min = 0.0F;
     float index_physical_max = 0.0F;

--- a/peraviz/native/src/dmx/fixture_dmx_binding.h
+++ b/peraviz/native/src/dmx/fixture_dmx_binding.h
@@ -42,6 +42,13 @@ struct FixtureGoboRange {
     float physical_to = 0.0F;
 };
 
+struct FixtureGoboPhysicalRange {
+    int dmx_from = 0;
+    int dmx_to = 255;
+    float physical_from = 0.0F;
+    float physical_to = 0.0F;
+};
+
 struct FixtureGoboWheelBinding {
     FixtureAttributeChannel channel;
     FixtureAttributeChannel index_channel;
@@ -56,6 +63,7 @@ struct FixtureGoboWheelBinding {
     std::string wheel_name;
     std::vector<FixtureGoboSlot> slots;
     std::vector<FixtureGoboRange> ranges;
+    std::vector<FixtureGoboPhysicalRange> rotation_ranges;
 };
 
 struct FixtureControlBinding {
@@ -112,6 +120,7 @@ struct FixtureGoboWheelOffset {
     std::string wheel_name;
     std::vector<FixtureGoboSlot> slots;
     std::vector<FixtureGoboRange> ranges;
+    std::vector<FixtureGoboPhysicalRange> rotation_ranges;
 };
 
 struct FixtureControlOffsets {

--- a/peraviz/native/src/dmx/fixture_dmx_binding.h
+++ b/peraviz/native/src/dmx/fixture_dmx_binding.h
@@ -37,6 +37,9 @@ struct FixtureGoboRange {
     int dmx_to = 255;
     int slot_index = -1;
     FixtureGoboRangeBehavior behavior = FixtureGoboRangeBehavior::kFixed;
+    bool has_physical_limits = false;
+    float physical_from = 0.0F;
+    float physical_to = 0.0F;
 };
 
 struct FixtureGoboWheelBinding {

--- a/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
@@ -1049,6 +1049,21 @@ bool has_non_zero_rotation_physical_value(float value) {
     return std::fabs(value) > 0.0001F;
 }
 
+int rotation_source_priority_from_attribute(const std::string &raw_attribute) {
+    const std::string lower = lower_ascii(raw_attribute);
+    const std::string leaf = last_attribute_segment(lower);
+    if (leaf.find("posrotate") != std::string::npos) {
+        return 3;
+    }
+    if (leaf.find("wheelspin") != std::string::npos) {
+        return 2;
+    }
+    if (leaf.find("spin") != std::string::npos || leaf.find("rotate") != std::string::npos) {
+        return 1;
+    }
+    return 0;
+}
+
 bool has_motion_in_rotation_ranges(const std::vector<peraviz::dmx::FixtureGoboPhysicalRange> &ranges) {
     for (const auto &range : ranges) {
         if (has_non_zero_rotation_physical_value(range.physical_from) ||
@@ -1331,6 +1346,8 @@ void consume_channel_offsets(tinyxml2::XMLElement *dmx_channel,
                       has_non_zero_rotation_physical_value(candidate_max) ||
                       std::fabs(candidate_max - candidate_min) > 0.0001F));
 
+                const int candidate_priority =
+                    rotation_source_priority_from_attribute(read_attr_ci(channel_function, "Attribute", "attribute"));
                 const bool has_existing_rotation_source = wheel->rotation_coarse_offset_1_based > 0;
                 const bool existing_has_motion =
                     has_motion_in_rotation_ranges(wheel->rotation_ranges) ||
@@ -1340,11 +1357,15 @@ void consume_channel_offsets(tinyxml2::XMLElement *dmx_channel,
                       std::fabs(wheel->rotation_physical_max - wheel->rotation_physical_min) > 0.0001F));
 
                 bool should_select_candidate = !has_existing_rotation_source;
-                if (!should_select_candidate && candidate_coarse > 0 &&
-                    candidate_coarse < wheel->rotation_coarse_offset_1_based) {
+                if (!should_select_candidate && candidate_priority > wheel->rotation_source_priority) {
                     should_select_candidate = true;
                 }
-                if (!should_select_candidate && candidate_coarse == wheel->rotation_coarse_offset_1_based &&
+                if (!should_select_candidate && candidate_priority == wheel->rotation_source_priority &&
+                    candidate_coarse > 0 && candidate_coarse < wheel->rotation_coarse_offset_1_based) {
+                    should_select_candidate = true;
+                }
+                if (!should_select_candidate && candidate_priority == wheel->rotation_source_priority &&
+                    candidate_coarse == wheel->rotation_coarse_offset_1_based &&
                     candidate_has_motion && !existing_has_motion) {
                     should_select_candidate = true;
                 }
@@ -1356,6 +1377,7 @@ void consume_channel_offsets(tinyxml2::XMLElement *dmx_channel,
                 wheel->rotation_coarse_offset_1_based = candidate_coarse;
                 wheel->rotation_fine_offset_1_based = candidate_fine;
                 wheel->rotation_ultra_fine_offset_1_based = candidate_ultra_fine;
+                wheel->rotation_source_priority = candidate_priority;
                 wheel->has_rotation_physical_limits = candidate_has_limits;
                 wheel->rotation_physical_min = candidate_min;
                 wheel->rotation_physical_max = candidate_max;

--- a/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
@@ -1286,14 +1286,34 @@ void consume_channel_offsets(tinyxml2::XMLElement *dmx_channel,
                 if (!wheel) {
                     break;
                 }
+
+                int candidate_coarse = -1;
+                int candidate_fine = -1;
+                int candidate_ultra_fine = -1;
                 consume_offsets(offsets, parsed_attribute.is_fine, parsed_attribute.byte_index,
-                                wheel->rotation_coarse_offset_1_based,
-                                wheel->rotation_fine_offset_1_based,
-                                wheel->rotation_ultra_fine_offset_1_based);
+                                candidate_coarse, candidate_fine, candidate_ultra_fine);
+
+                const bool has_existing_rotation_source = wheel->rotation_coarse_offset_1_based > 0;
+                const bool should_select_candidate =
+                    !has_existing_rotation_source ||
+                    (candidate_coarse > 0 && candidate_coarse < wheel->rotation_coarse_offset_1_based);
+                if (!should_select_candidate) {
+                    break;
+                }
+
+                wheel->rotation_coarse_offset_1_based = candidate_coarse;
+                wheel->rotation_fine_offset_1_based = candidate_fine;
+                wheel->rotation_ultra_fine_offset_1_based = candidate_ultra_fine;
+
+                wheel->has_rotation_physical_limits = false;
+                wheel->rotation_physical_min = 0.0F;
+                wheel->rotation_physical_max = 0.0F;
                 consume_gobo_physical_range(channel_function,
                                             wheel->has_rotation_physical_limits,
                                             wheel->rotation_physical_min,
                                             wheel->rotation_physical_max);
+
+                wheel->rotation_ranges.clear();
                 consume_gobo_rotation_channel_sets(channel_function,
                                                   wheel->rotation_ranges,
                                                   function_dmx_from,

--- a/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
@@ -439,6 +439,13 @@ void consume_gobo_physical_range(tinyxml2::XMLElement *channel_function,
                                  float &out_min,
                                  float &out_max);
 
+void consume_gobo_rotation_channel_sets(tinyxml2::XMLElement *channel_function,
+                                        std::vector<peraviz::dmx::FixtureGoboPhysicalRange> &out_ranges,
+                                        int function_dmx_from,
+                                        int function_dmx_to);
+
+int parse_dmx_value_8bit(const char *raw_value);
+
 bool parse_float_attr_ci(tinyxml2::XMLElement *node,
                          const char *attr_name,
                          const char *attr_name_alt,
@@ -500,6 +507,94 @@ void consume_gobo_physical_range(tinyxml2::XMLElement *channel_function,
     has_limits = true;
     out_min = physical_from;
     out_max = physical_to;
+}
+
+void consume_gobo_rotation_channel_sets(tinyxml2::XMLElement *channel_function,
+                                        std::vector<peraviz::dmx::FixtureGoboPhysicalRange> &out_ranges,
+                                        int function_dmx_from,
+                                        int function_dmx_to) {
+    if (!channel_function) {
+        return;
+    }
+
+    const int clamped_function_from = std::clamp(function_dmx_from, 0, 255);
+    const int clamped_function_to = std::clamp(function_dmx_to, clamped_function_from, 255);
+    const auto resolve_channel_set_dmx =
+        [clamped_function_from, clamped_function_to](int raw_value) -> int {
+        if (raw_value >= clamped_function_from && raw_value <= 255) {
+            return std::clamp(raw_value, clamped_function_from, clamped_function_to);
+        }
+        const int relative_value = clamped_function_from + std::max(0, raw_value);
+        return std::clamp(relative_value, clamped_function_from, clamped_function_to);
+    };
+
+    struct ParsedRotationSet {
+        int dmx_from = 0;
+        int dmx_to = -1;
+        float physical_from = 0.0F;
+        float physical_to = 0.0F;
+    };
+    std::vector<ParsedRotationSet> parsed_sets;
+
+    for (tinyxml2::XMLElement *channel_set = channel_function->FirstChildElement(); channel_set;
+         channel_set = channel_set->NextSiblingElement()) {
+        if (lower_ascii(channel_set->Name()) != "channelset") {
+            continue;
+        }
+
+        float physical_from = 0.0F;
+        float physical_to = 0.0F;
+        const bool has_physical_from = parse_float_attr_ci(channel_set, "PhysicalFrom", "physicalfrom", physical_from);
+        const bool has_physical_to = parse_float_attr_ci(channel_set, "PhysicalTo", "physicalto", physical_to);
+        if (!has_physical_from || !has_physical_to) {
+            continue;
+        }
+
+        int raw_dmx_from = parse_dmx_value_8bit(channel_set->Attribute("DMXFrom"));
+        if (raw_dmx_from < 0) {
+            raw_dmx_from = parse_dmx_value_8bit(channel_set->Attribute("dmxfrom"));
+        }
+        if (raw_dmx_from < 0) {
+            raw_dmx_from = 0;
+        }
+        const int dmx_from = resolve_channel_set_dmx(raw_dmx_from);
+
+        int raw_dmx_to = parse_dmx_value_8bit(channel_set->Attribute("DMXTo"));
+        if (raw_dmx_to < 0) {
+            raw_dmx_to = parse_dmx_value_8bit(channel_set->Attribute("dmxto"));
+        }
+        const int dmx_to = raw_dmx_to < 0 ? -1 : resolve_channel_set_dmx(raw_dmx_to);
+
+        parsed_sets.push_back({dmx_from, dmx_to, physical_from, physical_to});
+    }
+
+    if (parsed_sets.empty()) {
+        return;
+    }
+
+    std::stable_sort(parsed_sets.begin(), parsed_sets.end(),
+                     [](const ParsedRotationSet &a, const ParsedRotationSet &b) {
+                         return a.dmx_from < b.dmx_from;
+                     });
+
+    for (size_t i = 0; i < parsed_sets.size(); ++i) {
+        ParsedRotationSet &row = parsed_sets[i];
+        if (row.dmx_to < 0) {
+            if (i + 1 < parsed_sets.size()) {
+                row.dmx_to = std::max(row.dmx_from, parsed_sets[i + 1].dmx_from - 1);
+            } else {
+                row.dmx_to = clamped_function_to;
+            }
+        }
+        row.dmx_from = std::clamp(row.dmx_from, clamped_function_from, clamped_function_to);
+        row.dmx_to = std::clamp(row.dmx_to, clamped_function_from, clamped_function_to);
+        if (row.dmx_to < row.dmx_from) {
+            std::swap(row.dmx_from, row.dmx_to);
+            std::swap(row.physical_from, row.physical_to);
+        }
+
+        out_ranges.push_back({row.dmx_from, row.dmx_to, row.physical_from, row.physical_to});
+    }
 }
 
 void consume_offsets(const std::vector<int> &offsets,
@@ -1198,6 +1293,10 @@ void consume_channel_offsets(tinyxml2::XMLElement *dmx_channel,
                                             wheel->has_rotation_physical_limits,
                                             wheel->rotation_physical_min,
                                             wheel->rotation_physical_max);
+                consume_gobo_rotation_channel_sets(channel_function,
+                                                  wheel->rotation_ranges,
+                                                  function_dmx_from,
+                                                  function_dmx_to);
                 break;
             }
             }

--- a/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
@@ -830,6 +830,9 @@ void consume_gobo_channel_sets(tinyxml2::XMLElement *channel_function,
         int slot_index = -1;
         peraviz::dmx::FixtureGoboRangeBehavior behavior =
             peraviz::dmx::FixtureGoboRangeBehavior::kFixed;
+        bool has_physical_limits = false;
+        float physical_from = 0.0F;
+        float physical_to = 0.0F;
     };
     std::vector<ParsedGoboSet> parsed_sets;
 
@@ -897,7 +900,14 @@ void consume_gobo_channel_sets(tinyxml2::XMLElement *channel_function,
             // In that case, inherit the function behavior for all rows.
             behavior = function_behavior_hint;
         }
-        parsed_sets.push_back({dmx_from, dmx_to, slot_index, behavior});
+        float physical_from = 0.0F;
+        float physical_to = 0.0F;
+        const bool has_physical_from = parse_float_attr_ci(channel_set, "PhysicalFrom", "physicalfrom", physical_from);
+        const bool has_physical_to = parse_float_attr_ci(channel_set, "PhysicalTo", "physicalto", physical_to);
+        const bool has_physical_limits = has_physical_from && has_physical_to;
+
+        parsed_sets.push_back({dmx_from, dmx_to, slot_index, behavior,
+                               has_physical_limits, physical_from, physical_to});
     }
 
     if (parsed_sets.empty()) {
@@ -924,7 +934,15 @@ void consume_gobo_channel_sets(tinyxml2::XMLElement *channel_function,
             std::swap(row.dmx_from, row.dmx_to);
         }
 
-        out_wheel.ranges.push_back({row.dmx_from, row.dmx_to, row.slot_index, row.behavior});
+        peraviz::dmx::FixtureGoboRange range;
+        range.dmx_from = row.dmx_from;
+        range.dmx_to = row.dmx_to;
+        range.slot_index = row.slot_index;
+        range.behavior = row.behavior;
+        range.has_physical_limits = row.has_physical_limits;
+        range.physical_from = row.physical_from;
+        range.physical_to = row.physical_to;
+        out_wheel.ranges.push_back(range);
     }
 }
 

--- a/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <cmath>
 #include <filesystem>
 #include <cstdlib>
 #include <mutex>
@@ -1043,6 +1044,22 @@ void consume_gobo_channel_sets(tinyxml2::XMLElement *channel_function,
 }
 
 
+
+bool has_non_zero_rotation_physical_value(float value) {
+    return std::fabs(value) > 0.0001F;
+}
+
+bool has_motion_in_rotation_ranges(const std::vector<peraviz::dmx::FixtureGoboPhysicalRange> &ranges) {
+    for (const auto &range : ranges) {
+        if (has_non_zero_rotation_physical_value(range.physical_from) ||
+            has_non_zero_rotation_physical_value(range.physical_to) ||
+            std::fabs(range.physical_to - range.physical_from) > 0.0001F) {
+            return true;
+        }
+    }
+    return false;
+}
+
 int parse_last_number_token(const std::string &text) {
     int value = 0;
     bool found = false;
@@ -1293,10 +1310,45 @@ void consume_channel_offsets(tinyxml2::XMLElement *dmx_channel,
                 consume_offsets(offsets, parsed_attribute.is_fine, parsed_attribute.byte_index,
                                 candidate_coarse, candidate_fine, candidate_ultra_fine);
 
+                bool candidate_has_limits = false;
+                float candidate_min = 0.0F;
+                float candidate_max = 0.0F;
+                consume_gobo_physical_range(channel_function,
+                                            candidate_has_limits,
+                                            candidate_min,
+                                            candidate_max);
+
+                std::vector<peraviz::dmx::FixtureGoboPhysicalRange> candidate_ranges;
+                consume_gobo_rotation_channel_sets(channel_function,
+                                                  candidate_ranges,
+                                                  function_dmx_from,
+                                                  function_dmx_to);
+
+                const bool candidate_has_motion =
+                    has_motion_in_rotation_ranges(candidate_ranges) ||
+                    (candidate_has_limits &&
+                     (has_non_zero_rotation_physical_value(candidate_min) ||
+                      has_non_zero_rotation_physical_value(candidate_max) ||
+                      std::fabs(candidate_max - candidate_min) > 0.0001F));
+
                 const bool has_existing_rotation_source = wheel->rotation_coarse_offset_1_based > 0;
-                const bool should_select_candidate =
-                    !has_existing_rotation_source ||
-                    (candidate_coarse > 0 && candidate_coarse < wheel->rotation_coarse_offset_1_based);
+                const bool existing_has_motion =
+                    has_motion_in_rotation_ranges(wheel->rotation_ranges) ||
+                    (wheel->has_rotation_physical_limits &&
+                     (has_non_zero_rotation_physical_value(wheel->rotation_physical_min) ||
+                      has_non_zero_rotation_physical_value(wheel->rotation_physical_max) ||
+                      std::fabs(wheel->rotation_physical_max - wheel->rotation_physical_min) > 0.0001F));
+
+                bool should_select_candidate = !has_existing_rotation_source;
+                if (!should_select_candidate && candidate_coarse > 0 &&
+                    candidate_coarse < wheel->rotation_coarse_offset_1_based) {
+                    should_select_candidate = true;
+                }
+                if (!should_select_candidate && candidate_coarse == wheel->rotation_coarse_offset_1_based &&
+                    candidate_has_motion && !existing_has_motion) {
+                    should_select_candidate = true;
+                }
+
                 if (!should_select_candidate) {
                     break;
                 }
@@ -1304,20 +1356,10 @@ void consume_channel_offsets(tinyxml2::XMLElement *dmx_channel,
                 wheel->rotation_coarse_offset_1_based = candidate_coarse;
                 wheel->rotation_fine_offset_1_based = candidate_fine;
                 wheel->rotation_ultra_fine_offset_1_based = candidate_ultra_fine;
-
-                wheel->has_rotation_physical_limits = false;
-                wheel->rotation_physical_min = 0.0F;
-                wheel->rotation_physical_max = 0.0F;
-                consume_gobo_physical_range(channel_function,
-                                            wheel->has_rotation_physical_limits,
-                                            wheel->rotation_physical_min,
-                                            wheel->rotation_physical_max);
-
-                wheel->rotation_ranges.clear();
-                consume_gobo_rotation_channel_sets(channel_function,
-                                                  wheel->rotation_ranges,
-                                                  function_dmx_from,
-                                                  function_dmx_to);
+                wheel->has_rotation_physical_limits = candidate_has_limits;
+                wheel->rotation_physical_min = candidate_min;
+                wheel->rotation_physical_max = candidate_max;
+                wheel->rotation_ranges = std::move(candidate_ranges);
                 break;
             }
             }

--- a/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
@@ -640,46 +640,6 @@ void consume_offsets(const std::vector<int> &offsets,
 }
 
 
-int count_valid_channel_bytes(int coarse, int fine, int ultra_fine) {
-    int count = 0;
-    if (coarse > 0) {
-        ++count;
-    }
-    if (fine > 0) {
-        ++count;
-    }
-    if (ultra_fine > 0) {
-        ++count;
-    }
-    return count;
-}
-
-void consume_offsets_prefer_higher_resolution(const std::vector<int> &offsets,
-                                              bool is_fine,
-                                              int byte_index,
-                                              int &coarse,
-                                              int &fine,
-                                              int &ultra_fine) {
-    int candidate_coarse = -1;
-    int candidate_fine = -1;
-    int candidate_ultra_fine = -1;
-    consume_offsets(offsets, is_fine, byte_index,
-                    candidate_coarse, candidate_fine, candidate_ultra_fine);
-
-    const int current_resolution = count_valid_channel_bytes(coarse, fine, ultra_fine);
-    const int candidate_resolution =
-        count_valid_channel_bytes(candidate_coarse, candidate_fine, candidate_ultra_fine);
-
-    if (candidate_resolution <= 0) {
-        return;
-    }
-    if (candidate_resolution > current_resolution || current_resolution <= 0) {
-        coarse = candidate_coarse;
-        fine = candidate_fine;
-        ultra_fine = candidate_ultra_fine;
-    }
-}
-
 int parse_positive_int(const char *raw) {
     if (!raw) {
         return -1;
@@ -1326,12 +1286,10 @@ void consume_channel_offsets(tinyxml2::XMLElement *dmx_channel,
                 if (!wheel) {
                     break;
                 }
-                consume_offsets_prefer_higher_resolution(offsets,
-                                                         parsed_attribute.is_fine,
-                                                         parsed_attribute.byte_index,
-                                                         wheel->rotation_coarse_offset_1_based,
-                                                         wheel->rotation_fine_offset_1_based,
-                                                         wheel->rotation_ultra_fine_offset_1_based);
+                consume_offsets(offsets, parsed_attribute.is_fine, parsed_attribute.byte_index,
+                                wheel->rotation_coarse_offset_1_based,
+                                wheel->rotation_fine_offset_1_based,
+                                wheel->rotation_ultra_fine_offset_1_based);
                 consume_gobo_physical_range(channel_function,
                                             wheel->has_rotation_physical_limits,
                                             wheel->rotation_physical_min,

--- a/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
@@ -639,6 +639,47 @@ void consume_offsets(const std::vector<int> &offsets,
     }
 }
 
+
+int count_valid_channel_bytes(int coarse, int fine, int ultra_fine) {
+    int count = 0;
+    if (coarse > 0) {
+        ++count;
+    }
+    if (fine > 0) {
+        ++count;
+    }
+    if (ultra_fine > 0) {
+        ++count;
+    }
+    return count;
+}
+
+void consume_offsets_prefer_higher_resolution(const std::vector<int> &offsets,
+                                              bool is_fine,
+                                              int byte_index,
+                                              int &coarse,
+                                              int &fine,
+                                              int &ultra_fine) {
+    int candidate_coarse = -1;
+    int candidate_fine = -1;
+    int candidate_ultra_fine = -1;
+    consume_offsets(offsets, is_fine, byte_index,
+                    candidate_coarse, candidate_fine, candidate_ultra_fine);
+
+    const int current_resolution = count_valid_channel_bytes(coarse, fine, ultra_fine);
+    const int candidate_resolution =
+        count_valid_channel_bytes(candidate_coarse, candidate_fine, candidate_ultra_fine);
+
+    if (candidate_resolution <= 0) {
+        return;
+    }
+    if (candidate_resolution > current_resolution || current_resolution <= 0) {
+        coarse = candidate_coarse;
+        fine = candidate_fine;
+        ultra_fine = candidate_ultra_fine;
+    }
+}
+
 int parse_positive_int(const char *raw) {
     if (!raw) {
         return -1;
@@ -1285,10 +1326,12 @@ void consume_channel_offsets(tinyxml2::XMLElement *dmx_channel,
                 if (!wheel) {
                     break;
                 }
-                consume_offsets(offsets, parsed_attribute.is_fine, parsed_attribute.byte_index,
-                                wheel->rotation_coarse_offset_1_based,
-                                wheel->rotation_fine_offset_1_based,
-                                wheel->rotation_ultra_fine_offset_1_based);
+                consume_offsets_prefer_higher_resolution(offsets,
+                                                         parsed_attribute.is_fine,
+                                                         parsed_attribute.byte_index,
+                                                         wheel->rotation_coarse_offset_1_based,
+                                                         wheel->rotation_fine_offset_1_based,
+                                                         wheel->rotation_ultra_fine_offset_1_based);
                 consume_gobo_physical_range(channel_function,
                                             wheel->has_rotation_physical_limits,
                                             wheel->rotation_physical_min,

--- a/peraviz/native/src/peraviz_loader.cpp
+++ b/peraviz/native/src/peraviz_loader.cpp
@@ -226,6 +226,9 @@ Dictionary PeravizLoader::build_fixture_dimmer_bindings(int universe_offset) con
             range_item["dmx_to"] = range.dmx_to;
             range_item["slot_index"] = range.slot_index;
             range_item["behavior"] = static_cast<int>(range.behavior);
+            range_item["has_physical_limits"] = range.has_physical_limits;
+            range_item["physical_from"] = range.physical_from;
+            range_item["physical_to"] = range.physical_to;
             gobo_ranges[range_index] = range_item;
         }
         item["gobo_ranges"] = gobo_ranges;
@@ -274,6 +277,9 @@ Dictionary PeravizLoader::build_fixture_dimmer_bindings(int universe_offset) con
                 range_item["dmx_to"] = range.dmx_to;
                 range_item["slot_index"] = range.slot_index;
                 range_item["behavior"] = static_cast<int>(range.behavior);
+                range_item["has_physical_limits"] = range.has_physical_limits;
+                range_item["physical_from"] = range.physical_from;
+                range_item["physical_to"] = range.physical_to;
                 wheel_ranges[range_index] = range_item;
             }
             wheel_item["ranges"] = wheel_ranges;

--- a/peraviz/native/src/peraviz_loader.cpp
+++ b/peraviz/native/src/peraviz_loader.cpp
@@ -283,6 +283,19 @@ Dictionary PeravizLoader::build_fixture_dimmer_bindings(int universe_offset) con
                 wheel_ranges[range_index] = range_item;
             }
             wheel_item["ranges"] = wheel_ranges;
+
+            Array rotation_ranges;
+            rotation_ranges.resize(static_cast<int64_t>(wheel.rotation_ranges.size()));
+            for (int64_t range_index = 0; range_index < static_cast<int64_t>(wheel.rotation_ranges.size()); ++range_index) {
+                const auto &range = wheel.rotation_ranges[static_cast<size_t>(range_index)];
+                Dictionary range_item;
+                range_item["dmx_from"] = range.dmx_from;
+                range_item["dmx_to"] = range.dmx_to;
+                range_item["physical_from"] = range.physical_from;
+                range_item["physical_to"] = range.physical_to;
+                rotation_ranges[range_index] = range_item;
+            }
+            wheel_item["rotation_ranges"] = rotation_ranges;
             gobo_wheels[wheel_index] = wheel_item;
         }
         item["gobo_wheels"] = gobo_wheels;

--- a/peraviz/scripts/dmx_fixture_runtime.gd
+++ b/peraviz/scripts/dmx_fixture_runtime.gd
@@ -267,16 +267,12 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 		var range_behavior: int = int(active_range.get("behavior", GOBO_BEHAVIOR_FIXED))
 		var has_index_channel: bool = _has_control_channel(item, "index_channel_index_0", "index_fine_channel_index_0", "index_ultra_fine_channel_index_0")
 		var has_rotation_channel: bool = _has_control_channel(item, "rotation_channel_index_0", "rotation_fine_channel_index_0", "rotation_ultra_fine_channel_index_0")
-		var has_behavior_ranges: bool = not ranges.is_empty()
-		var supports_index: bool = range_behavior == GOBO_BEHAVIOR_INDEX
-		var supports_rotation: bool = range_behavior == GOBO_BEHAVIOR_ROTATION or range_behavior == GOBO_BEHAVIOR_SHAKE
-		# Respect GDTF hierarchy: gobo select ChannelSet behavior decides whether
-		# index/rotation channels are active for the currently selected slot.
-		# Only fall back to direct channel availability when the fixture exposes
-		# no ChannelSet behavior ranges at all.
-		if not has_behavior_ranges:
-			supports_index = has_index_channel
-			supports_rotation = has_rotation_channel
+		var supports_index: bool = has_index_channel or range_behavior == GOBO_BEHAVIOR_INDEX
+		var supports_rotation: bool = has_rotation_channel or range_behavior == GOBO_BEHAVIOR_ROTATION or range_behavior == GOBO_BEHAVIOR_SHAKE
+		# Keep dedicated index/rotation channels active whenever present so runtime
+		# reacts to live channel changes even if gobo select ranges are fixed-only.
+		# ChannelSet behavior still contributes fallback semantics when no dedicated
+		# control channel is provided by the fixture mode.
 		var index_norm: float = -1.0
 		var rotation_norm: float = -1.0
 		var rotation_from_range: bool = false

--- a/peraviz/scripts/dmx_fixture_runtime.gd
+++ b/peraviz/scripts/dmx_fixture_runtime.gd
@@ -267,12 +267,16 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 		var range_behavior: int = int(active_range.get("behavior", GOBO_BEHAVIOR_FIXED))
 		var has_index_channel: bool = _has_control_channel(item, "index_channel_index_0", "index_fine_channel_index_0", "index_ultra_fine_channel_index_0")
 		var has_rotation_channel: bool = _has_control_channel(item, "rotation_channel_index_0", "rotation_fine_channel_index_0", "rotation_ultra_fine_channel_index_0")
-		var supports_index: bool = has_index_channel or range_behavior == GOBO_BEHAVIOR_INDEX
-		var supports_rotation: bool = has_rotation_channel or range_behavior == GOBO_BEHAVIOR_ROTATION or range_behavior == GOBO_BEHAVIOR_SHAKE
-		# Keep dedicated index/rotation channels active whenever present so runtime
-		# reacts to live channel changes even if gobo select ranges are fixed-only.
-		# ChannelSet behavior still contributes fallback semantics when no dedicated
-		# control channel is provided by the fixture mode.
+		var has_behavior_ranges: bool = not ranges.is_empty()
+		var supports_index: bool = range_behavior == GOBO_BEHAVIOR_INDEX
+		var supports_rotation: bool = range_behavior == GOBO_BEHAVIOR_ROTATION or range_behavior == GOBO_BEHAVIOR_SHAKE
+		# Respect GDTF hierarchy: gobo select ChannelSet behavior decides whether
+		# index/rotation channels are active for the currently selected slot.
+		# Only fall back to direct channel availability when the fixture exposes
+		# no ChannelSet behavior ranges at all.
+		if not has_behavior_ranges:
+			supports_index = has_index_channel
+			supports_rotation = has_rotation_channel
 		var index_norm: float = -1.0
 		var rotation_norm: float = -1.0
 		var rotation_from_range: bool = false

--- a/peraviz/scripts/dmx_fixture_runtime.gd
+++ b/peraviz/scripts/dmx_fixture_runtime.gd
@@ -279,6 +279,9 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 			supports_rotation = has_rotation_channel
 		var index_norm: float = -1.0
 		var rotation_norm: float = -1.0
+		var rotation_raw_8bit: int = -1
+		var rotation_speed_hz: float = 0.0
+		var has_rotation_speed_hz: bool = false
 		var rotation_from_range: bool = false
 		var has_range_physical_limits: bool = bool(active_range.get("has_physical_limits", false))
 		var range_physical_from: float = float(active_range.get("physical_from", 0.0))
@@ -288,7 +291,13 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 			if index_norm < 0.0 and range_behavior == GOBO_BEHAVIOR_INDEX:
 				index_norm = _resolve_norm_from_active_range(raw_8bit, active_range)
 		if supports_rotation:
-			rotation_norm = _read_optional_control_norm(frame, int(item.get("rotation_channel_index_0", -1)), int(item.get("rotation_fine_channel_index_0", -1)), int(item.get("rotation_ultra_fine_channel_index_0", -1)))
+			var rotation_value: Dictionary = _read_optional_control_value(frame, int(item.get("rotation_channel_index_0", -1)), int(item.get("rotation_fine_channel_index_0", -1)), int(item.get("rotation_ultra_fine_channel_index_0", -1)))
+			rotation_norm = float(rotation_value.get("norm", -1.0))
+			rotation_raw_8bit = int(rotation_value.get("raw_8bit", -1))
+			if rotation_raw_8bit >= 0:
+				var rotation_speed: Dictionary = _resolve_physical_from_ranges(rotation_raw_8bit, item.get("rotation_ranges", []))
+				has_rotation_speed_hz = bool(rotation_speed.get("has_value", false))
+				rotation_speed_hz = float(rotation_speed.get("value", 0.0))
 			if rotation_norm < 0.0 and (range_behavior == GOBO_BEHAVIOR_ROTATION or range_behavior == GOBO_BEHAVIOR_SHAKE):
 				rotation_from_range = true
 				rotation_norm = _resolve_norm_from_active_range(raw_8bit, active_range)
@@ -315,6 +324,9 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 			"range_physical_to": range_physical_to,
 			"index_norm": index_norm,
 			"rotation_norm": rotation_norm,
+			"rotation_raw_8bit": rotation_raw_8bit,
+			"has_rotation_speed_hz": has_rotation_speed_hz,
+			"rotation_speed_hz": rotation_speed_hz,
 			"slots": item.get("slots", []),
 			"ranges": ranges,
 		})
@@ -360,6 +372,38 @@ func _read_optional_control_norm(frame: PackedByteArray, coarse_index: int, fine
 		return -1.0
 	var value: Dictionary = _read_control_value(frame, coarse_index, fine_index, ultra_fine_index)
 	return clamp(float(value.get("norm", 0.0)), 0.0, 1.0)
+
+func _read_optional_control_value(frame: PackedByteArray, coarse_index: int, fine_index: int, ultra_fine_index: int) -> Dictionary:
+	if not _is_valid_channel_index(frame, coarse_index):
+		return {"norm": -1.0, "raw_8bit": -1}
+	var value: Dictionary = _read_control_value(frame, coarse_index, fine_index, ultra_fine_index)
+	return {
+		"norm": clamp(float(value.get("norm", 0.0)), 0.0, 1.0),
+		"raw_8bit": _resolve_raw_to_8bit(int(value.get("raw", 0)), int(value.get("resolution_bits", 8))),
+	}
+
+func _resolve_physical_from_ranges(raw_8bit: int, ranges: Array) -> Dictionary:
+	for range_item in ranges:
+		if range_item is not Dictionary:
+			continue
+		var dmx_from: int = int(range_item.get("dmx_from", 0))
+		var dmx_to: int = int(range_item.get("dmx_to", dmx_from))
+		var physical_from: float = float(range_item.get("physical_from", 0.0))
+		var physical_to: float = float(range_item.get("physical_to", 0.0))
+		if dmx_to < dmx_from:
+			var swap_dmx: int = dmx_from
+			dmx_from = dmx_to
+			dmx_to = swap_dmx
+			var swap_physical: float = physical_from
+			physical_from = physical_to
+			physical_to = swap_physical
+		if raw_8bit < dmx_from or raw_8bit > dmx_to:
+			continue
+		if dmx_to <= dmx_from:
+			return {"has_value": true, "value": physical_from}
+		var norm: float = float(raw_8bit - dmx_from) / float(dmx_to - dmx_from)
+		return {"has_value": true, "value": lerp(physical_from, physical_to, clamp(norm, 0.0, 1.0))}
+	return {"has_value": false, "value": 0.0}
 
 func _resolve_raw_to_8bit(raw_value: int, resolution_bits: int) -> int:
 	if resolution_bits >= 24:

--- a/peraviz/scripts/dmx_fixture_runtime.gd
+++ b/peraviz/scripts/dmx_fixture_runtime.gd
@@ -279,6 +279,7 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 			supports_rotation = has_rotation_channel
 		var index_norm: float = -1.0
 		var rotation_norm: float = -1.0
+		var rotation_from_range: bool = false
 		var has_range_physical_limits: bool = bool(active_range.get("has_physical_limits", false))
 		var range_physical_from: float = float(active_range.get("physical_from", 0.0))
 		var range_physical_to: float = float(active_range.get("physical_to", 0.0))
@@ -289,6 +290,7 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 		if supports_rotation:
 			rotation_norm = _read_optional_control_norm(frame, int(item.get("rotation_channel_index_0", -1)), int(item.get("rotation_fine_channel_index_0", -1)), int(item.get("rotation_ultra_fine_channel_index_0", -1)))
 			if rotation_norm < 0.0 and (range_behavior == GOBO_BEHAVIOR_ROTATION or range_behavior == GOBO_BEHAVIOR_SHAKE):
+				rotation_from_range = true
 				rotation_norm = _resolve_norm_from_active_range(raw_8bit, active_range)
 				if has_range_physical_limits:
 					range_physical_from = _resolve_physical_from_active_range(int(active_range.get("dmx_from", raw_8bit)), active_range, range_physical_from)
@@ -307,6 +309,7 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 			"has_rotation_physical_limits": bool(item.get("has_rotation_physical_limits", false)),
 			"rotation_physical_min": float(item.get("rotation_physical_min", 0.0)),
 			"rotation_physical_max": float(item.get("rotation_physical_max", 0.0)),
+			"rotation_from_range": rotation_from_range,
 			"has_range_physical_limits": has_range_physical_limits,
 			"range_physical_from": range_physical_from,
 			"range_physical_to": range_physical_to,

--- a/peraviz/scripts/dmx_fixture_runtime.gd
+++ b/peraviz/scripts/dmx_fixture_runtime.gd
@@ -280,8 +280,8 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 		var index_norm: float = -1.0
 		var rotation_norm: float = -1.0
 		var rotation_raw_8bit: int = -1
-		var rotation_speed_hz: float = 0.0
-		var has_rotation_speed_hz: bool = false
+		var rotation_speed_deg_per_sec: float = 0.0
+		var has_rotation_speed_deg_per_sec: bool = false
 		var rotation_from_range: bool = false
 		var has_range_physical_limits: bool = bool(active_range.get("has_physical_limits", false))
 		var range_physical_from: float = float(active_range.get("physical_from", 0.0))
@@ -296,8 +296,8 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 			rotation_raw_8bit = int(rotation_value.get("raw_8bit", -1))
 			if rotation_raw_8bit >= 0:
 				var rotation_speed: Dictionary = _resolve_physical_from_ranges(rotation_raw_8bit, item.get("rotation_ranges", []))
-				has_rotation_speed_hz = bool(rotation_speed.get("has_value", false))
-				rotation_speed_hz = float(rotation_speed.get("value", 0.0))
+				has_rotation_speed_deg_per_sec = bool(rotation_speed.get("has_value", false))
+				rotation_speed_deg_per_sec = float(rotation_speed.get("value", 0.0))
 			if rotation_norm < 0.0 and (range_behavior == GOBO_BEHAVIOR_ROTATION or range_behavior == GOBO_BEHAVIOR_SHAKE):
 				rotation_from_range = true
 				rotation_norm = _resolve_norm_from_active_range(raw_8bit, active_range)
@@ -325,8 +325,8 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 			"index_norm": index_norm,
 			"rotation_norm": rotation_norm,
 			"rotation_raw_8bit": rotation_raw_8bit,
-			"has_rotation_speed_hz": has_rotation_speed_hz,
-			"rotation_speed_hz": rotation_speed_hz,
+			"has_rotation_speed_deg_per_sec": has_rotation_speed_deg_per_sec,
+			"rotation_speed_deg_per_sec": rotation_speed_deg_per_sec,
 			"slots": item.get("slots", []),
 			"ranges": ranges,
 		})

--- a/peraviz/scripts/dmx_fixture_runtime.gd
+++ b/peraviz/scripts/dmx_fixture_runtime.gd
@@ -374,15 +374,28 @@ func _read_optional_control_norm(frame: PackedByteArray, coarse_index: int, fine
 	return clamp(float(value.get("norm", 0.0)), 0.0, 1.0)
 
 func _read_optional_control_value(frame: PackedByteArray, coarse_index: int, fine_index: int, ultra_fine_index: int) -> Dictionary:
-	if not _is_valid_channel_index(frame, coarse_index):
-		return {"norm": -1.0, "raw_8bit": -1}
-	var value: Dictionary = _read_control_value(frame, coarse_index, fine_index, ultra_fine_index)
+	var resolved_coarse: int = coarse_index
+	var resolved_fine: int = fine_index
+	var resolved_ultra_fine: int = ultra_fine_index
+	if not _is_valid_channel_index(frame, resolved_coarse):
+		if _is_valid_channel_index(frame, fine_index):
+			resolved_coarse = fine_index
+			resolved_fine = -1
+			resolved_ultra_fine = -1
+		elif _is_valid_channel_index(frame, ultra_fine_index):
+			resolved_coarse = ultra_fine_index
+			resolved_fine = -1
+			resolved_ultra_fine = -1
+		else:
+			return {"norm": -1.0, "raw_8bit": -1}
+	var value: Dictionary = _read_control_value(frame, resolved_coarse, resolved_fine, resolved_ultra_fine)
 	return {
 		"norm": clamp(float(value.get("norm", 0.0)), 0.0, 1.0),
 		"raw_8bit": _resolve_raw_to_8bit(int(value.get("raw", 0)), int(value.get("resolution_bits", 8))),
 	}
 
 func _resolve_physical_from_ranges(raw_8bit: int, ranges: Array) -> Dictionary:
+	var active_match: Dictionary = {"has_value": false, "value": 0.0}
 	for range_item in ranges:
 		if range_item is not Dictionary:
 			continue
@@ -400,10 +413,11 @@ func _resolve_physical_from_ranges(raw_8bit: int, ranges: Array) -> Dictionary:
 		if raw_8bit < dmx_from or raw_8bit > dmx_to:
 			continue
 		if dmx_to <= dmx_from:
-			return {"has_value": true, "value": physical_from}
+			active_match = {"has_value": true, "value": physical_from}
+			continue
 		var norm: float = float(raw_8bit - dmx_from) / float(dmx_to - dmx_from)
-		return {"has_value": true, "value": lerp(physical_from, physical_to, clamp(norm, 0.0, 1.0))}
-	return {"has_value": false, "value": 0.0}
+		active_match = {"has_value": true, "value": lerp(physical_from, physical_to, clamp(norm, 0.0, 1.0))}
+	return active_match
 
 func _resolve_raw_to_8bit(raw_value: int, resolution_bits: int) -> int:
 	if resolution_bits >= 24:

--- a/peraviz/scripts/dmx_fixture_runtime.gd
+++ b/peraviz/scripts/dmx_fixture_runtime.gd
@@ -279,6 +279,9 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 			supports_rotation = has_rotation_channel
 		var index_norm: float = -1.0
 		var rotation_norm: float = -1.0
+		var has_range_physical_limits: bool = bool(active_range.get("has_physical_limits", false))
+		var range_physical_from: float = float(active_range.get("physical_from", 0.0))
+		var range_physical_to: float = float(active_range.get("physical_to", 0.0))
 		if supports_index:
 			index_norm = _read_optional_control_norm(frame, int(item.get("index_channel_index_0", -1)), int(item.get("index_fine_channel_index_0", -1)), int(item.get("index_ultra_fine_channel_index_0", -1)))
 			if index_norm < 0.0 and range_behavior == GOBO_BEHAVIOR_INDEX:
@@ -287,6 +290,9 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 			rotation_norm = _read_optional_control_norm(frame, int(item.get("rotation_channel_index_0", -1)), int(item.get("rotation_fine_channel_index_0", -1)), int(item.get("rotation_ultra_fine_channel_index_0", -1)))
 			if rotation_norm < 0.0 and (range_behavior == GOBO_BEHAVIOR_ROTATION or range_behavior == GOBO_BEHAVIOR_SHAKE):
 				rotation_norm = _resolve_norm_from_active_range(raw_8bit, active_range)
+				if has_range_physical_limits:
+					range_physical_from = _resolve_physical_from_active_range(int(active_range.get("dmx_from", raw_8bit)), active_range, range_physical_from)
+					range_physical_to = _resolve_physical_from_active_range(int(active_range.get("dmx_to", raw_8bit)), active_range, range_physical_to)
 		runtime_bindings.append({
 			"wheel_number": int(item.get("wheel_number", 0)),
 			"wheel_name": str(item.get("wheel_name", "")),
@@ -301,6 +307,9 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 			"has_rotation_physical_limits": bool(item.get("has_rotation_physical_limits", false)),
 			"rotation_physical_min": float(item.get("rotation_physical_min", 0.0)),
 			"rotation_physical_max": float(item.get("rotation_physical_max", 0.0)),
+			"has_range_physical_limits": has_range_physical_limits,
+			"range_physical_from": range_physical_from,
+			"range_physical_to": range_physical_to,
 			"index_norm": index_norm,
 			"rotation_norm": rotation_norm,
 			"slots": item.get("slots", []),
@@ -310,6 +319,26 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 
 func _has_control_channel(binding: Dictionary, coarse_key: String, fine_key: String, ultra_fine_key: String) -> bool:
 	return int(binding.get(coarse_key, -1)) >= 0 or int(binding.get(fine_key, -1)) >= 0 or int(binding.get(ultra_fine_key, -1)) >= 0
+
+func _resolve_physical_from_active_range(raw_8bit: int, active_range: Dictionary, fallback_value: float = 0.0) -> float:
+	if not bool(active_range.get("has_physical_limits", false)):
+		return fallback_value
+	var dmx_from: int = int(active_range.get("dmx_from", 0))
+	var dmx_to: int = int(active_range.get("dmx_to", dmx_from))
+	var physical_from: float = float(active_range.get("physical_from", fallback_value))
+	var physical_to: float = float(active_range.get("physical_to", fallback_value))
+	if dmx_to < dmx_from:
+		var swap_dmx: int = dmx_from
+		dmx_from = dmx_to
+		dmx_to = swap_dmx
+		var swap_physical: float = physical_from
+		physical_from = physical_to
+		physical_to = swap_physical
+	if dmx_to <= dmx_from:
+		return physical_from
+	var clamped_raw: int = clampi(raw_8bit, dmx_from, dmx_to)
+	var norm: float = float(clamped_raw - dmx_from) / float(dmx_to - dmx_from)
+	return lerp(physical_from, physical_to, clamp(norm, 0.0, 1.0))
 
 func _resolve_norm_from_active_range(raw_8bit: int, active_range: Dictionary) -> float:
 	var dmx_from: int = int(active_range.get("dmx_from", 0))

--- a/peraviz/scripts/dmx_fixture_runtime.gd
+++ b/peraviz/scripts/dmx_fixture_runtime.gd
@@ -374,21 +374,9 @@ func _read_optional_control_norm(frame: PackedByteArray, coarse_index: int, fine
 	return clamp(float(value.get("norm", 0.0)), 0.0, 1.0)
 
 func _read_optional_control_value(frame: PackedByteArray, coarse_index: int, fine_index: int, ultra_fine_index: int) -> Dictionary:
-	var resolved_coarse: int = coarse_index
-	var resolved_fine: int = fine_index
-	var resolved_ultra_fine: int = ultra_fine_index
-	if not _is_valid_channel_index(frame, resolved_coarse):
-		if _is_valid_channel_index(frame, fine_index):
-			resolved_coarse = fine_index
-			resolved_fine = -1
-			resolved_ultra_fine = -1
-		elif _is_valid_channel_index(frame, ultra_fine_index):
-			resolved_coarse = ultra_fine_index
-			resolved_fine = -1
-			resolved_ultra_fine = -1
-		else:
-			return {"norm": -1.0, "raw_8bit": -1}
-	var value: Dictionary = _read_control_value(frame, resolved_coarse, resolved_fine, resolved_ultra_fine)
+	if not _is_valid_channel_index(frame, coarse_index):
+		return {"norm": -1.0, "raw_8bit": -1}
+	var value: Dictionary = _read_control_value(frame, coarse_index, fine_index, ultra_fine_index)
 	return {
 		"norm": clamp(float(value.get("norm", 0.0)), 0.0, 1.0),
 		"raw_8bit": _resolve_raw_to_8bit(int(value.get("raw", 0)), int(value.get("resolution_bits", 8))),
@@ -417,6 +405,10 @@ func _resolve_physical_from_ranges(raw_8bit: int, ranges: Array) -> Dictionary:
 			continue
 		var norm: float = float(raw_8bit - dmx_from) / float(dmx_to - dmx_from)
 		active_match = {"has_value": true, "value": lerp(physical_from, physical_to, clamp(norm, 0.0, 1.0))}
+	if bool(active_match.get("has_value", false)):
+		return active_match
+	if not ranges.is_empty():
+		return {"has_value": true, "value": 0.0}
 	return active_match
 
 func _resolve_raw_to_8bit(raw_value: int, resolution_bits: int) -> int:

--- a/peraviz/scripts/dmx_gobo_range_resolver.gd
+++ b/peraviz/scripts/dmx_gobo_range_resolver.gd
@@ -28,6 +28,9 @@ static func resolve_active_range(raw_8bit: int, ranges: Array) -> Dictionary:
 			"behavior": int(range_item.get("behavior", GOBO_BEHAVIOR_FIXED)),
 			"dmx_from": dmx_from,
 			"dmx_to": dmx_to,
+			"has_physical_limits": bool(range_item.get("has_physical_limits", false)),
+			"physical_from": float(range_item.get("physical_from", 0.0)),
+			"physical_to": float(range_item.get("physical_to", 0.0)),
 		}
 		has_match = true
 
@@ -35,5 +38,8 @@ static func resolve_active_range(raw_8bit: int, ranges: Array) -> Dictionary:
 		return {
 			"slot_index": 0,
 			"behavior": GOBO_BEHAVIOR_FIXED,
+			"has_physical_limits": false,
+			"physical_from": 0.0,
+			"physical_to": 0.0,
 		}
 	return active_match

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -25,6 +25,7 @@ const GOBO_APPLIED_ROTATION_DEG_META_KEY: String = "peraviz_gobo_applied_rotatio
 const GOBO_WHEEL_MODE_META_KEY: String = "peraviz_gobo_wheel_mode"
 const GOBO_INDEX_MAX_DEG: float = 360.0
 const GOBO_ROTATION_MAX_DEG_PER_SEC: float = 720.0
+const GOBO_FREQUENCY_TO_DEG_PER_SEC: float = 360.0
 
 const GOBO_BEHAVIOR_FIXED: int = 0
 const GOBO_BEHAVIOR_INDEX: int = 1
@@ -148,13 +149,15 @@ func _resolve_wheel_rotation_deg(light: SpotLight3D, controls: Dictionary, wheel
 		var speed_deg_per_sec: float = 0.0
 		var rotation_from_range: bool = bool(wheel.get("rotation_from_range", false))
 		if rotation_from_range and bool(wheel.get("has_range_physical_limits", false)):
-			var range_physical_from: float = float(wheel.get("range_physical_from", 0.0))
-			var range_physical_to: float = float(wheel.get("range_physical_to", 0.0))
-			speed_deg_per_sec = lerp(range_physical_from, range_physical_to, clamp(rotation_norm, 0.0, 1.0))
+			var range_physical_from_hz: float = float(wheel.get("range_physical_from", 0.0))
+			var range_physical_to_hz: float = float(wheel.get("range_physical_to", 0.0))
+			var speed_hz: float = lerp(range_physical_from_hz, range_physical_to_hz, clamp(rotation_norm, 0.0, 1.0))
+			speed_deg_per_sec = speed_hz * GOBO_FREQUENCY_TO_DEG_PER_SEC
 		elif bool(wheel.get("has_rotation_physical_limits", false)):
-			var rotation_physical_min: float = float(wheel.get("rotation_physical_min", -GOBO_ROTATION_MAX_DEG_PER_SEC * 0.5))
-			var rotation_physical_max: float = float(wheel.get("rotation_physical_max", GOBO_ROTATION_MAX_DEG_PER_SEC * 0.5))
-			speed_deg_per_sec = lerp(rotation_physical_min, rotation_physical_max, clamp(rotation_norm, 0.0, 1.0))
+			var rotation_physical_min_hz: float = float(wheel.get("rotation_physical_min", -GOBO_ROTATION_MAX_DEG_PER_SEC * 0.5 / GOBO_FREQUENCY_TO_DEG_PER_SEC))
+			var rotation_physical_max_hz: float = float(wheel.get("rotation_physical_max", GOBO_ROTATION_MAX_DEG_PER_SEC * 0.5 / GOBO_FREQUENCY_TO_DEG_PER_SEC))
+			var speed_hz: float = lerp(rotation_physical_min_hz, rotation_physical_max_hz, clamp(rotation_norm, 0.0, 1.0))
+			speed_deg_per_sec = speed_hz * GOBO_FREQUENCY_TO_DEG_PER_SEC
 		else:
 			speed_deg_per_sec = (clamp(rotation_norm, 0.0, 1.0) - 0.5) * GOBO_ROTATION_MAX_DEG_PER_SEC
 		spin_angle_deg = wrapf(spin_angle_deg + (speed_deg_per_sec * delta_sec), -360000.0, 360000.0)

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -146,7 +146,8 @@ func _resolve_wheel_rotation_deg(light: SpotLight3D, controls: Dictionary, wheel
 
 	if supports_rotation and rotation_norm >= 0.0 and delta_sec > 0.0:
 		var speed_deg_per_sec: float = 0.0
-		if bool(wheel.get("has_range_physical_limits", false)):
+		var rotation_from_range: bool = bool(wheel.get("rotation_from_range", false))
+		if rotation_from_range and bool(wheel.get("has_range_physical_limits", false)):
 			var range_physical_from: float = float(wheel.get("range_physical_from", 0.0))
 			var range_physical_to: float = float(wheel.get("range_physical_to", 0.0))
 			speed_deg_per_sec = lerp(range_physical_from, range_physical_to, clamp(rotation_norm, 0.0, 1.0))

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -146,7 +146,11 @@ func _resolve_wheel_rotation_deg(light: SpotLight3D, controls: Dictionary, wheel
 
 	if supports_rotation and rotation_norm >= 0.0 and delta_sec > 0.0:
 		var speed_deg_per_sec: float = 0.0
-		if bool(wheel.get("has_rotation_physical_limits", false)):
+		if bool(wheel.get("has_range_physical_limits", false)):
+			var range_physical_from: float = float(wheel.get("range_physical_from", 0.0))
+			var range_physical_to: float = float(wheel.get("range_physical_to", 0.0))
+			speed_deg_per_sec = lerp(range_physical_from, range_physical_to, clamp(rotation_norm, 0.0, 1.0))
+		elif bool(wheel.get("has_rotation_physical_limits", false)):
 			var rotation_physical_min: float = float(wheel.get("rotation_physical_min", -GOBO_ROTATION_MAX_DEG_PER_SEC * 0.5))
 			var rotation_physical_max: float = float(wheel.get("rotation_physical_max", GOBO_ROTATION_MAX_DEG_PER_SEC * 0.5))
 			speed_deg_per_sec = lerp(rotation_physical_min, rotation_physical_max, clamp(rotation_norm, 0.0, 1.0))

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -148,7 +148,9 @@ func _resolve_wheel_rotation_deg(light: SpotLight3D, controls: Dictionary, wheel
 	if supports_rotation and rotation_norm >= 0.0 and delta_sec > 0.0:
 		var speed_deg_per_sec: float = 0.0
 		var rotation_from_range: bool = bool(wheel.get("rotation_from_range", false))
-		if rotation_from_range and bool(wheel.get("has_range_physical_limits", false)):
+		if bool(wheel.get("has_rotation_speed_hz", false)):
+			speed_deg_per_sec = float(wheel.get("rotation_speed_hz", 0.0)) * GOBO_FREQUENCY_TO_DEG_PER_SEC
+		elif rotation_from_range and bool(wheel.get("has_range_physical_limits", false)):
 			var range_physical_from_hz: float = float(wheel.get("range_physical_from", 0.0))
 			var range_physical_to_hz: float = float(wheel.get("range_physical_to", 0.0))
 			var speed_hz: float = lerp(range_physical_from_hz, range_physical_to_hz, clamp(rotation_norm, 0.0, 1.0))

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -145,26 +145,33 @@ func _resolve_wheel_rotation_deg(light: SpotLight3D, controls: Dictionary, wheel
 		light.set_meta(GOBO_WHEEL_SPIN_META_KEY, wheel_spin_state)
 		return base_rotation_deg
 
-	if supports_rotation and rotation_norm >= 0.0 and delta_sec > 0.0:
+	if supports_rotation and delta_sec > 0.0:
 		var speed_deg_per_sec: float = 0.0
+		var has_speed_command: bool = false
 		var rotation_from_range: bool = bool(wheel.get("rotation_from_range", false))
 		if bool(wheel.get("has_rotation_speed_hz", false)):
+			has_speed_command = true
 			speed_deg_per_sec = float(wheel.get("rotation_speed_hz", 0.0)) * GOBO_FREQUENCY_TO_DEG_PER_SEC
-		elif rotation_from_range and bool(wheel.get("has_range_physical_limits", false)):
+		elif rotation_from_range and bool(wheel.get("has_range_physical_limits", false)) and rotation_norm >= 0.0:
+			has_speed_command = true
 			var range_physical_from_hz: float = float(wheel.get("range_physical_from", 0.0))
 			var range_physical_to_hz: float = float(wheel.get("range_physical_to", 0.0))
 			var speed_hz: float = lerp(range_physical_from_hz, range_physical_to_hz, clamp(rotation_norm, 0.0, 1.0))
 			speed_deg_per_sec = speed_hz * GOBO_FREQUENCY_TO_DEG_PER_SEC
-		elif bool(wheel.get("has_rotation_physical_limits", false)):
+		elif bool(wheel.get("has_rotation_physical_limits", false)) and rotation_norm >= 0.0:
+			has_speed_command = true
 			var rotation_physical_min_hz: float = float(wheel.get("rotation_physical_min", -GOBO_ROTATION_MAX_DEG_PER_SEC * 0.5 / GOBO_FREQUENCY_TO_DEG_PER_SEC))
 			var rotation_physical_max_hz: float = float(wheel.get("rotation_physical_max", GOBO_ROTATION_MAX_DEG_PER_SEC * 0.5 / GOBO_FREQUENCY_TO_DEG_PER_SEC))
 			var speed_hz: float = lerp(rotation_physical_min_hz, rotation_physical_max_hz, clamp(rotation_norm, 0.0, 1.0))
 			speed_deg_per_sec = speed_hz * GOBO_FREQUENCY_TO_DEG_PER_SEC
-		else:
+		elif rotation_norm >= 0.0:
+			has_speed_command = true
 			speed_deg_per_sec = (clamp(rotation_norm, 0.0, 1.0) - 0.5) * GOBO_ROTATION_MAX_DEG_PER_SEC
-		spin_angle_deg = wrapf(spin_angle_deg + (speed_deg_per_sec * delta_sec), -360000.0, 360000.0)
-		wheel_spin_state[wheel_key] = spin_angle_deg
-		light.set_meta(GOBO_WHEEL_SPIN_META_KEY, wheel_spin_state)
+
+		if has_speed_command:
+			spin_angle_deg = wrapf(spin_angle_deg + (speed_deg_per_sec * delta_sec), -360000.0, 360000.0)
+			wheel_spin_state[wheel_key] = spin_angle_deg
+			light.set_meta(GOBO_WHEEL_SPIN_META_KEY, wheel_spin_state)
 
 	if not supports_rotation:
 		wheel_spin_state[wheel_key] = 0.0

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -25,7 +25,6 @@ const GOBO_APPLIED_ROTATION_DEG_META_KEY: String = "peraviz_gobo_applied_rotatio
 const GOBO_WHEEL_MODE_META_KEY: String = "peraviz_gobo_wheel_mode"
 const GOBO_INDEX_MAX_DEG: float = 360.0
 const GOBO_ROTATION_MAX_DEG_PER_SEC: float = 720.0
-const GOBO_FREQUENCY_TO_DEG_PER_SEC: float = 360.0
 
 const GOBO_BEHAVIOR_FIXED: int = 0
 const GOBO_BEHAVIOR_INDEX: int = 1
@@ -149,21 +148,19 @@ func _resolve_wheel_rotation_deg(light: SpotLight3D, controls: Dictionary, wheel
 		var speed_deg_per_sec: float = 0.0
 		var has_speed_command: bool = false
 		var rotation_from_range: bool = bool(wheel.get("rotation_from_range", false))
-		if bool(wheel.get("has_rotation_speed_hz", false)):
+		if bool(wheel.get("has_rotation_speed_deg_per_sec", false)):
 			has_speed_command = true
-			speed_deg_per_sec = float(wheel.get("rotation_speed_hz", 0.0)) * GOBO_FREQUENCY_TO_DEG_PER_SEC
+			speed_deg_per_sec = float(wheel.get("rotation_speed_deg_per_sec", 0.0))
 		elif rotation_from_range and bool(wheel.get("has_range_physical_limits", false)) and rotation_norm >= 0.0:
 			has_speed_command = true
-			var range_physical_from_hz: float = float(wheel.get("range_physical_from", 0.0))
-			var range_physical_to_hz: float = float(wheel.get("range_physical_to", 0.0))
-			var speed_hz: float = lerp(range_physical_from_hz, range_physical_to_hz, clamp(rotation_norm, 0.0, 1.0))
-			speed_deg_per_sec = speed_hz * GOBO_FREQUENCY_TO_DEG_PER_SEC
+			var range_physical_from_deg_per_sec: float = float(wheel.get("range_physical_from", 0.0))
+			var range_physical_to_deg_per_sec: float = float(wheel.get("range_physical_to", 0.0))
+			speed_deg_per_sec = lerp(range_physical_from_deg_per_sec, range_physical_to_deg_per_sec, clamp(rotation_norm, 0.0, 1.0))
 		elif bool(wheel.get("has_rotation_physical_limits", false)) and rotation_norm >= 0.0:
 			has_speed_command = true
-			var rotation_physical_min_hz: float = float(wheel.get("rotation_physical_min", -GOBO_ROTATION_MAX_DEG_PER_SEC * 0.5 / GOBO_FREQUENCY_TO_DEG_PER_SEC))
-			var rotation_physical_max_hz: float = float(wheel.get("rotation_physical_max", GOBO_ROTATION_MAX_DEG_PER_SEC * 0.5 / GOBO_FREQUENCY_TO_DEG_PER_SEC))
-			var speed_hz: float = lerp(rotation_physical_min_hz, rotation_physical_max_hz, clamp(rotation_norm, 0.0, 1.0))
-			speed_deg_per_sec = speed_hz * GOBO_FREQUENCY_TO_DEG_PER_SEC
+			var rotation_physical_min_deg_per_sec: float = float(wheel.get("rotation_physical_min", -GOBO_ROTATION_MAX_DEG_PER_SEC * 0.5))
+			var rotation_physical_max_deg_per_sec: float = float(wheel.get("rotation_physical_max", GOBO_ROTATION_MAX_DEG_PER_SEC * 0.5))
+			speed_deg_per_sec = lerp(rotation_physical_min_deg_per_sec, rotation_physical_max_deg_per_sec, clamp(rotation_norm, 0.0, 1.0))
 		elif rotation_norm >= 0.0:
 			has_speed_command = true
 			speed_deg_per_sec = (clamp(rotation_norm, 0.0, 1.0) - 0.5) * GOBO_ROTATION_MAX_DEG_PER_SEC


### PR DESCRIPTION
### Motivation
- Continuous `Gobo(n)PosRotate` / wheel spin in Peraviz was always using the same direction/speed because ChannelSet physical limits in GDTF were not parsed or applied at runtime.
- Parse and carry per-ChannelSet `PhysicalFrom`/`PhysicalTo` so active range semantics (direction + speed) drive the continuous spin effect when present.

### Description
- Added physical metadata to range model by extending `FixtureGoboRange` with `has_physical_limits`, `physical_from`, and `physical_to` (`peraviz/native/src/dmx/fixture_dmx_binding.h`).
- Parsed `PhysicalFrom`/`PhysicalTo` from each GDTF `ChannelSet` and persisted them into per-range entries during GDTF parsing (`peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp`).
- Exposed the new range fields through the native→Godot bridge in `PeravizLoader::build_fixture_dimmer_bindings` so GDScript can consume range physicals (`peraviz/native/src/peraviz_loader.cpp`).
- Extended the runtime range resolver and DMX binding builder in GDScript to carry `has_physical_limits` / `physical_from` / `physical_to` into `runtime_bindings` and added `_resolve_physical_from_active_range` helper to compute physical values for a given DMX position (`peraviz/scripts/dmx_gobo_range_resolver.gd`, `peraviz/scripts/dmx_fixture_runtime.gd`).
- Updated gobo projection spin integration to prefer active-range physical limits when present, falling back to wheel-level rotation limits or normalized mapping only otherwise (`peraviz/scripts/fixture_gobo_projector.gd`).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1d39d13b88324a19a60c76c7a37a4)