### PR TITLE
Respect GDTF gobo rotation ChannelSet physical ranges

### DIFF
--- a/peraviz/native/src/dmx/fixture_dmx_binding.cpp
+++ b/peraviz/native/src/dmx/fixture_dmx_binding.cpp
@@ -163,6 +163,7 @@ FixtureBindingBuildResult build_dimmer_bindings(
             wheel_binding.has_rotation_physical_limits = wheel.has_rotation_physical_limits;
             wheel_binding.rotation_physical_min = wheel.rotation_physical_min;
             wheel_binding.rotation_physical_max = wheel.rotation_physical_max;
+            wheel_binding.rotation_ranges = wheel.rotation_ranges;
             wheel_binding.wheel_number = wheel.wheel_number;
             wheel_binding.wheel_name = wheel.wheel_name;
             wheel_binding.slots = wheel.slots;

--- a/peraviz/native/src/dmx/fixture_dmx_binding.h
+++ b/peraviz/native/src/dmx/fixture_dmx_binding.h
@@ -39,6 +39,14 @@ struct FixtureGoboRange {
     FixtureGoboRangeBehavior behavior = FixtureGoboRangeBehavior::kFixed;
 };
 
+struct FixtureGoboRotationRange {
+    int dmx_start = 0;
+    int dmx_end = 255;
+    float physical_from = 0.0F;
+    float physical_to = 0.0F;
+    bool is_stop_range = false;
+};
+
 struct FixtureGoboWheelBinding {
     FixtureAttributeChannel channel;
     FixtureAttributeChannel index_channel;
@@ -49,6 +57,7 @@ struct FixtureGoboWheelBinding {
     bool has_rotation_physical_limits = false;
     float rotation_physical_min = 0.0F;
     float rotation_physical_max = 0.0F;
+    std::vector<FixtureGoboRotationRange> rotation_ranges;
     int wheel_number = 0;
     std::string wheel_name;
     std::vector<FixtureGoboSlot> slots;
@@ -105,6 +114,7 @@ struct FixtureGoboWheelOffset {
     bool has_rotation_physical_limits = false;
     float rotation_physical_min = 0.0F;
     float rotation_physical_max = 0.0F;
+    std::vector<FixtureGoboRotationRange> rotation_ranges;
     int wheel_number = 0;
     std::string wheel_name;
     std::vector<FixtureGoboSlot> slots;

--- a/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
@@ -445,6 +445,8 @@ void consume_gobo_rotation_channel_sets(tinyxml2::XMLElement *channel_function,
                                         int function_dmx_from,
                                         int function_dmx_to);
 
+int parse_dmx_value_8bit(const char *raw_value);
+
 bool parse_float_attr_ci(tinyxml2::XMLElement *node,
                          const char *attr_name,
                          const char *attr_name_alt,

--- a/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <cmath>
 #include <filesystem>
 #include <cstdlib>
 #include <mutex>
@@ -439,6 +440,11 @@ void consume_gobo_physical_range(tinyxml2::XMLElement *channel_function,
                                  float &out_min,
                                  float &out_max);
 
+void consume_gobo_rotation_channel_sets(tinyxml2::XMLElement *channel_function,
+                                        std::vector<peraviz::dmx::FixtureGoboRotationRange> &out_ranges,
+                                        int function_dmx_from,
+                                        int function_dmx_to);
+
 bool parse_float_attr_ci(tinyxml2::XMLElement *node,
                          const char *attr_name,
                          const char *attr_name_alt,
@@ -500,6 +506,100 @@ void consume_gobo_physical_range(tinyxml2::XMLElement *channel_function,
     has_limits = true;
     out_min = physical_from;
     out_max = physical_to;
+}
+
+void consume_gobo_rotation_channel_sets(tinyxml2::XMLElement *channel_function,
+                                        std::vector<peraviz::dmx::FixtureGoboRotationRange> &out_ranges,
+                                        int function_dmx_from,
+                                        int function_dmx_to) {
+    if (!channel_function) {
+        return;
+    }
+
+    const int clamped_function_from = std::clamp(function_dmx_from, 0, 255);
+    const int clamped_function_to = std::clamp(function_dmx_to, clamped_function_from, 255);
+    const auto resolve_channel_set_dmx =
+        [clamped_function_from, clamped_function_to](int raw_value) -> int {
+            if (raw_value >= clamped_function_from && raw_value <= 255) {
+                return std::clamp(raw_value, clamped_function_from, clamped_function_to);
+            }
+            const int relative_value = clamped_function_from + std::max(0, raw_value);
+            return std::clamp(relative_value, clamped_function_from, clamped_function_to);
+        };
+
+    struct ParsedRange {
+        int dmx_start = 0;
+        int dmx_end = -1;
+        float physical_from = 0.0F;
+        float physical_to = 0.0F;
+    };
+    std::vector<ParsedRange> parsed_ranges;
+
+    for (tinyxml2::XMLElement *channel_set = channel_function->FirstChildElement(); channel_set;
+         channel_set = channel_set->NextSiblingElement()) {
+        if (lower_ascii(channel_set->Name()) != "channelset") {
+            continue;
+        }
+
+        float physical_from = 0.0F;
+        float physical_to = 0.0F;
+        const bool has_physical_from = parse_float_attr_ci(channel_set, "PhysicalFrom", "physicalfrom", physical_from);
+        const bool has_physical_to = parse_float_attr_ci(channel_set, "PhysicalTo", "physicalto", physical_to);
+        if (!has_physical_from || !has_physical_to) {
+            continue;
+        }
+
+        int raw_dmx_from = parse_dmx_value_8bit(channel_set->Attribute("DMXFrom"));
+        if (raw_dmx_from < 0) {
+            raw_dmx_from = parse_dmx_value_8bit(channel_set->Attribute("dmxfrom"));
+        }
+        if (raw_dmx_from < 0) {
+            raw_dmx_from = 0;
+        }
+        const int dmx_start = resolve_channel_set_dmx(raw_dmx_from);
+
+        int raw_dmx_to = parse_dmx_value_8bit(channel_set->Attribute("DMXTo"));
+        if (raw_dmx_to < 0) {
+            raw_dmx_to = parse_dmx_value_8bit(channel_set->Attribute("dmxto"));
+        }
+        const int dmx_end = raw_dmx_to < 0 ? -1 : resolve_channel_set_dmx(raw_dmx_to);
+
+        parsed_ranges.push_back({dmx_start, dmx_end, physical_from, physical_to});
+    }
+
+    if (parsed_ranges.empty()) {
+        return;
+    }
+
+    std::stable_sort(parsed_ranges.begin(), parsed_ranges.end(),
+                     [](const ParsedRange &a, const ParsedRange &b) {
+                         return a.dmx_start < b.dmx_start;
+                     });
+
+    for (size_t index = 0; index < parsed_ranges.size(); ++index) {
+        ParsedRange &row = parsed_ranges[index];
+        if (row.dmx_end < 0) {
+            if (index + 1 < parsed_ranges.size()) {
+                row.dmx_end = std::max(row.dmx_start, parsed_ranges[index + 1].dmx_start - 1);
+            } else {
+                row.dmx_end = clamped_function_to;
+            }
+        }
+
+        row.dmx_start = std::clamp(row.dmx_start, clamped_function_from, clamped_function_to);
+        row.dmx_end = std::clamp(row.dmx_end, clamped_function_from, clamped_function_to);
+        if (row.dmx_end < row.dmx_start) {
+            std::swap(row.dmx_start, row.dmx_end);
+        }
+
+        peraviz::dmx::FixtureGoboRotationRange range;
+        range.dmx_start = row.dmx_start;
+        range.dmx_end = row.dmx_end;
+        range.physical_from = row.physical_from;
+        range.physical_to = row.physical_to;
+        range.is_stop_range = std::fabs(row.physical_from) < 0.0001F && std::fabs(row.physical_to) < 0.0001F;
+        out_ranges.push_back(range);
+    }
 }
 
 void consume_offsets(const std::vector<int> &offsets,
@@ -1016,6 +1116,24 @@ void dedupe_and_sort_gobo_wheel(peraviz::dmx::FixtureGoboWheelOffset &wheel) {
                                a.slot_index == b.slot_index && a.behavior == b.behavior;
                     }),
         wheel.ranges.end());
+
+    std::stable_sort(wheel.rotation_ranges.begin(), wheel.rotation_ranges.end(),
+                     [](const peraviz::dmx::FixtureGoboRotationRange &a,
+                        const peraviz::dmx::FixtureGoboRotationRange &b) {
+                         if (a.dmx_start != b.dmx_start) {
+                             return a.dmx_start < b.dmx_start;
+                         }
+                         return a.dmx_end < b.dmx_end;
+                     });
+    wheel.rotation_ranges.erase(
+        std::unique(wheel.rotation_ranges.begin(), wheel.rotation_ranges.end(),
+                    [](const peraviz::dmx::FixtureGoboRotationRange &a,
+                       const peraviz::dmx::FixtureGoboRotationRange &b) {
+                        return a.dmx_start == b.dmx_start && a.dmx_end == b.dmx_end &&
+                               a.physical_from == b.physical_from &&
+                               a.physical_to == b.physical_to;
+                    }),
+        wheel.rotation_ranges.end());
 }
 
 void consume_channel_offsets(tinyxml2::XMLElement *dmx_channel,
@@ -1180,6 +1298,10 @@ void consume_channel_offsets(tinyxml2::XMLElement *dmx_channel,
                                             wheel->has_rotation_physical_limits,
                                             wheel->rotation_physical_min,
                                             wheel->rotation_physical_max);
+                consume_gobo_rotation_channel_sets(channel_function,
+                                                  wheel->rotation_ranges,
+                                                  function_dmx_from,
+                                                  function_dmx_to);
                 break;
             }
             }

--- a/peraviz/native/src/peraviz_loader.cpp
+++ b/peraviz/native/src/peraviz_loader.cpp
@@ -254,6 +254,20 @@ Dictionary PeravizLoader::build_fixture_dimmer_bindings(int universe_offset) con
             wheel_item["rotation_physical_min"] = wheel.rotation_physical_min;
             wheel_item["rotation_physical_max"] = wheel.rotation_physical_max;
 
+            Array rotation_ranges;
+            rotation_ranges.resize(static_cast<int64_t>(wheel.rotation_ranges.size()));
+            for (int64_t rotation_range_index = 0; rotation_range_index < static_cast<int64_t>(wheel.rotation_ranges.size()); ++rotation_range_index) {
+                const auto &rotation_range = wheel.rotation_ranges[static_cast<size_t>(rotation_range_index)];
+                Dictionary rotation_range_item;
+                rotation_range_item["dmx_start"] = rotation_range.dmx_start;
+                rotation_range_item["dmx_end"] = rotation_range.dmx_end;
+                rotation_range_item["physical_from"] = rotation_range.physical_from;
+                rotation_range_item["physical_to"] = rotation_range.physical_to;
+                rotation_range_item["is_stop_range"] = rotation_range.is_stop_range;
+                rotation_ranges[rotation_range_index] = rotation_range_item;
+            }
+            wheel_item["rotation_ranges"] = rotation_ranges;
+
             Array wheel_slots;
             wheel_slots.resize(static_cast<int64_t>(wheel.slots.size()));
             for (int64_t slot_index = 0; slot_index < static_cast<int64_t>(wheel.slots.size()); ++slot_index) {

--- a/peraviz/scripts/dmx_fixture_runtime.gd
+++ b/peraviz/scripts/dmx_fixture_runtime.gd
@@ -279,6 +279,7 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 			supports_rotation = has_rotation_channel
 		var index_norm: float = -1.0
 		var rotation_norm: float = -1.0
+		var rotation_raw_8bit: int = -1
 		var rotation_ranges: Array = item.get("rotation_ranges", [])
 		var rotation_physical: float = 0.0
 		if supports_index:
@@ -286,12 +287,14 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 			if index_norm < 0.0 and range_behavior == GOBO_BEHAVIOR_INDEX:
 				index_norm = _resolve_norm_from_active_range(raw_8bit, active_range)
 		if supports_rotation:
-			rotation_norm = _read_optional_control_norm(frame, int(item.get("rotation_channel_index_0", -1)), int(item.get("rotation_fine_channel_index_0", -1)), int(item.get("rotation_ultra_fine_channel_index_0", -1)))
-			if rotation_norm < 0.0 and (range_behavior == GOBO_BEHAVIOR_ROTATION or range_behavior == GOBO_BEHAVIOR_SHAKE):
+			rotation_raw_8bit = _read_optional_control_raw_8bit(frame, int(item.get("rotation_channel_index_0", -1)), int(item.get("rotation_fine_channel_index_0", -1)), int(item.get("rotation_ultra_fine_channel_index_0", -1)))
+			if rotation_raw_8bit >= 0:
+				rotation_norm = float(rotation_raw_8bit) / DMX_8BIT_MAX_VALUE
+			elif range_behavior == GOBO_BEHAVIOR_ROTATION or range_behavior == GOBO_BEHAVIOR_SHAKE:
 				rotation_norm = _resolve_norm_from_active_range(raw_8bit, active_range)
-			if rotation_norm >= 0.0 and not rotation_ranges.is_empty():
-				var rotation_dmx: int = int(round(rotation_norm * DMX_8BIT_MAX_VALUE))
-				rotation_physical = _resolve_rotation_physical(rotation_dmx, rotation_ranges)
+				rotation_raw_8bit = clampi(int(round(rotation_norm * DMX_8BIT_MAX_VALUE)), 0, int(DMX_8BIT_MAX_VALUE))
+			if rotation_raw_8bit >= 0 and not rotation_ranges.is_empty():
+				rotation_physical = _resolve_rotation_physical(rotation_raw_8bit, rotation_ranges)
 		runtime_bindings.append({
 			"wheel_number": int(item.get("wheel_number", 0)),
 			"wheel_name": str(item.get("wheel_name", "")),
@@ -307,6 +310,7 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 			"rotation_physical_min": float(item.get("rotation_physical_min", 0.0)),
 			"rotation_physical_max": float(item.get("rotation_physical_max", 0.0)),
 			"has_rotation_physical_ranges": not rotation_ranges.is_empty(),
+			"has_rotation_physical_value": not rotation_ranges.is_empty() and rotation_raw_8bit >= 0,
 			"rotation_physical": rotation_physical,
 			"rotation_ranges": rotation_ranges,
 			"index_norm": index_norm,
@@ -352,6 +356,12 @@ func _resolve_rotation_physical(dmx_val: int, ranges: Array) -> float:
 		var ratio: float = float(dmx_val - dmx_start) / float(dmx_end - dmx_start)
 		return lerp(float(range_data.get("physical_from", 0.0)), float(range_data.get("physical_to", 0.0)), ratio)
 	return 0.0
+
+func _read_optional_control_raw_8bit(frame: PackedByteArray, coarse_index: int, fine_index: int, ultra_fine_index: int) -> int:
+	if not _is_valid_channel_index(frame, coarse_index):
+		return -1
+	var value: Dictionary = _read_control_value(frame, coarse_index, fine_index, ultra_fine_index)
+	return _resolve_raw_to_8bit(int(value.get("raw", 0)), int(value.get("resolution_bits", 8)))
 
 func _read_optional_control_norm(frame: PackedByteArray, coarse_index: int, fine_index: int, ultra_fine_index: int) -> float:
 	if not _is_valid_channel_index(frame, coarse_index):

--- a/peraviz/scripts/dmx_fixture_runtime.gd
+++ b/peraviz/scripts/dmx_fixture_runtime.gd
@@ -282,7 +282,6 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 			supports_rotation = has_rotation_channel
 		var index_norm: float = -1.0
 		var rotation_norm: float = -1.0
-		var rotation_raw_8bit: int = -1
 		var rotation_ranges: Array = item.get("rotation_ranges", [])
 		var rotation_physical: float = 0.0
 		if supports_index:
@@ -290,14 +289,11 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 			if index_norm < 0.0 and range_behavior == GOBO_BEHAVIOR_INDEX:
 				index_norm = _resolve_norm_from_active_range(raw_8bit, active_range)
 		if supports_rotation:
-			rotation_raw_8bit = _read_optional_control_raw_8bit(frame, int(item.get("rotation_channel_index_0", -1)), int(item.get("rotation_fine_channel_index_0", -1)), int(item.get("rotation_ultra_fine_channel_index_0", -1)))
-			if rotation_raw_8bit >= 0:
-				rotation_norm = float(rotation_raw_8bit) / DMX_8BIT_MAX_VALUE
-			elif range_behavior == GOBO_BEHAVIOR_ROTATION or range_behavior == GOBO_BEHAVIOR_SHAKE:
+			rotation_norm = _read_optional_control_norm(frame, int(item.get("rotation_channel_index_0", -1)), int(item.get("rotation_fine_channel_index_0", -1)), int(item.get("rotation_ultra_fine_channel_index_0", -1)))
+			if rotation_norm < 0.0 and (range_behavior == GOBO_BEHAVIOR_ROTATION or range_behavior == GOBO_BEHAVIOR_SHAKE):
 				rotation_norm = _resolve_norm_from_active_range(raw_8bit, active_range)
-				rotation_raw_8bit = clampi(int(round(rotation_norm * DMX_8BIT_MAX_VALUE)), 0, int(DMX_8BIT_MAX_VALUE))
-			if rotation_raw_8bit >= 0 and not rotation_ranges.is_empty():
-				rotation_physical = _resolve_rotation_physical(rotation_raw_8bit, rotation_ranges)
+			if rotation_norm >= 0.0 and not rotation_ranges.is_empty():
+				rotation_physical = _resolve_rotation_physical(rotation_norm * DMX_8BIT_MAX_VALUE, rotation_ranges)
 		runtime_bindings.append({
 			"wheel_number": int(item.get("wheel_number", 0)),
 			"wheel_name": str(item.get("wheel_name", "")),
@@ -313,7 +309,7 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 			"rotation_physical_min": float(item.get("rotation_physical_min", 0.0)),
 			"rotation_physical_max": float(item.get("rotation_physical_max", 0.0)),
 			"has_rotation_physical_ranges": not rotation_ranges.is_empty(),
-			"has_rotation_physical_value": not rotation_ranges.is_empty() and rotation_raw_8bit >= 0,
+			"has_rotation_physical_value": not rotation_ranges.is_empty() and rotation_norm >= 0.0,
 			"rotation_physical": rotation_physical,
 			"rotation_ranges": rotation_ranges,
 			"index_norm": index_norm,
@@ -339,7 +335,7 @@ func _resolve_norm_from_active_range(raw_8bit: int, active_range: Dictionary) ->
 	return float(clamped_raw - dmx_from) / float(dmx_to - dmx_from)
 
 
-func _resolve_rotation_physical(dmx_val: int, ranges: Array) -> float:
+func _resolve_rotation_physical(dmx_val: float, ranges: Array) -> float:
 	for item in ranges:
 		if item is not Dictionary:
 			continue
@@ -350,21 +346,16 @@ func _resolve_rotation_physical(dmx_val: int, ranges: Array) -> float:
 			var swap_value: int = dmx_start
 			dmx_start = dmx_end
 			dmx_end = swap_value
-		if dmx_val < dmx_start or dmx_val > dmx_end:
+		if dmx_val < float(dmx_start) or dmx_val > float(dmx_end):
 			continue
 		if bool(range_data.get("is_stop_range", false)):
 			return 0.0
 		if dmx_end <= dmx_start:
 			return float(range_data.get("physical_to", range_data.get("physical_from", 0.0)))
-		var ratio: float = float(dmx_val - dmx_start) / float(dmx_end - dmx_start)
+		var ratio: float = (dmx_val - float(dmx_start)) / float(dmx_end - dmx_start)
 		return lerp(float(range_data.get("physical_from", 0.0)), float(range_data.get("physical_to", 0.0)), ratio)
 	return 0.0
 
-func _read_optional_control_raw_8bit(frame: PackedByteArray, coarse_index: int, fine_index: int, ultra_fine_index: int) -> int:
-	if not _is_valid_channel_index(frame, coarse_index):
-		return -1
-	var value: Dictionary = _read_control_value(frame, coarse_index, fine_index, ultra_fine_index)
-	return _resolve_raw_to_8bit(int(value.get("raw", 0)), int(value.get("resolution_bits", 8)))
 
 func _read_optional_control_norm(frame: PackedByteArray, coarse_index: int, fine_index: int, ultra_fine_index: int) -> float:
 	if not _is_valid_channel_index(frame, coarse_index):

--- a/peraviz/scripts/dmx_fixture_runtime.gd
+++ b/peraviz/scripts/dmx_fixture_runtime.gd
@@ -279,6 +279,8 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 			supports_rotation = has_rotation_channel
 		var index_norm: float = -1.0
 		var rotation_norm: float = -1.0
+		var rotation_ranges: Array = item.get("rotation_ranges", [])
+		var rotation_physical: float = 0.0
 		if supports_index:
 			index_norm = _read_optional_control_norm(frame, int(item.get("index_channel_index_0", -1)), int(item.get("index_fine_channel_index_0", -1)), int(item.get("index_ultra_fine_channel_index_0", -1)))
 			if index_norm < 0.0 and range_behavior == GOBO_BEHAVIOR_INDEX:
@@ -287,6 +289,9 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 			rotation_norm = _read_optional_control_norm(frame, int(item.get("rotation_channel_index_0", -1)), int(item.get("rotation_fine_channel_index_0", -1)), int(item.get("rotation_ultra_fine_channel_index_0", -1)))
 			if rotation_norm < 0.0 and (range_behavior == GOBO_BEHAVIOR_ROTATION or range_behavior == GOBO_BEHAVIOR_SHAKE):
 				rotation_norm = _resolve_norm_from_active_range(raw_8bit, active_range)
+			if rotation_norm >= 0.0 and not rotation_ranges.is_empty():
+				var rotation_dmx: int = int(round(rotation_norm * DMX_8BIT_MAX_VALUE))
+				rotation_physical = _resolve_rotation_physical(rotation_dmx, rotation_ranges)
 		runtime_bindings.append({
 			"wheel_number": int(item.get("wheel_number", 0)),
 			"wheel_name": str(item.get("wheel_name", "")),
@@ -298,9 +303,12 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 			"has_index_physical_limits": bool(item.get("has_index_physical_limits", false)),
 			"index_physical_min": float(item.get("index_physical_min", 0.0)),
 			"index_physical_max": float(item.get("index_physical_max", 0.0)),
-			"has_rotation_physical_limits": bool(item.get("has_rotation_physical_limits", false)),
+			"has_rotation_physical_limits": bool(item.get("has_rotation_physical_limits", false)) or not rotation_ranges.is_empty(),
 			"rotation_physical_min": float(item.get("rotation_physical_min", 0.0)),
 			"rotation_physical_max": float(item.get("rotation_physical_max", 0.0)),
+			"has_rotation_physical_ranges": not rotation_ranges.is_empty(),
+			"rotation_physical": rotation_physical,
+			"rotation_ranges": rotation_ranges,
 			"index_norm": index_norm,
 			"rotation_norm": rotation_norm,
 			"slots": item.get("slots", []),
@@ -322,6 +330,28 @@ func _resolve_norm_from_active_range(raw_8bit: int, active_range: Dictionary) ->
 		return 0.0
 	var clamped_raw: int = clampi(raw_8bit, dmx_from, dmx_to)
 	return float(clamped_raw - dmx_from) / float(dmx_to - dmx_from)
+
+
+func _resolve_rotation_physical(dmx_val: int, ranges: Array) -> float:
+	for item in ranges:
+		if item is not Dictionary:
+			continue
+		var range_data: Dictionary = item
+		var dmx_start: int = int(range_data.get("dmx_start", 0))
+		var dmx_end: int = int(range_data.get("dmx_end", dmx_start))
+		if dmx_end < dmx_start:
+			var swap_value: int = dmx_start
+			dmx_start = dmx_end
+			dmx_end = swap_value
+		if dmx_val < dmx_start or dmx_val > dmx_end:
+			continue
+		if bool(range_data.get("is_stop_range", false)):
+			return 0.0
+		if dmx_end <= dmx_start:
+			return float(range_data.get("physical_to", range_data.get("physical_from", 0.0)))
+		var ratio: float = float(dmx_val - dmx_start) / float(dmx_end - dmx_start)
+		return lerp(float(range_data.get("physical_from", 0.0)), float(range_data.get("physical_to", 0.0)), ratio)
+	return 0.0
 
 func _read_optional_control_norm(frame: PackedByteArray, coarse_index: int, fine_index: int, ultra_fine_index: int) -> float:
 	if not _is_valid_channel_index(frame, coarse_index):

--- a/peraviz/scripts/dmx_fixture_runtime.gd
+++ b/peraviz/scripts/dmx_fixture_runtime.gd
@@ -268,13 +268,16 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 		var has_index_channel: bool = _has_control_channel(item, "index_channel_index_0", "index_fine_channel_index_0", "index_ultra_fine_channel_index_0")
 		var has_rotation_channel: bool = _has_control_channel(item, "rotation_channel_index_0", "rotation_fine_channel_index_0", "rotation_ultra_fine_channel_index_0")
 		var has_behavior_ranges: bool = not ranges.is_empty()
-		var supports_index: bool = range_behavior == GOBO_BEHAVIOR_INDEX
-		var supports_rotation: bool = range_behavior == GOBO_BEHAVIOR_ROTATION or range_behavior == GOBO_BEHAVIOR_SHAKE
-		# Respect GDTF hierarchy: gobo select ChannelSet behavior decides whether
-		# index/rotation channels are active for the currently selected slot.
-		# Only fall back to direct channel availability when the fixture exposes
-		# no ChannelSet behavior ranges at all.
-		if not has_behavior_ranges:
+		var supports_index: bool = false
+		var supports_rotation: bool = false
+		if has_behavior_ranges:
+			# In many fixtures, the gobo selection range can remain fixed while
+			# dedicated index/rotation channels still drive the wheel. Keep channel
+			# authority enabled, but prevent conflicting index+spin by honoring
+			# explicit index ranges as spin-disabled segments.
+			supports_index = (range_behavior == GOBO_BEHAVIOR_INDEX) or (has_index_channel and range_behavior != GOBO_BEHAVIOR_ROTATION and range_behavior != GOBO_BEHAVIOR_SHAKE)
+			supports_rotation = (range_behavior == GOBO_BEHAVIOR_ROTATION or range_behavior == GOBO_BEHAVIOR_SHAKE) or (has_rotation_channel and range_behavior != GOBO_BEHAVIOR_INDEX)
+		else:
 			supports_index = has_index_channel
 			supports_rotation = has_rotation_channel
 		var index_norm: float = -1.0

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -146,12 +146,17 @@ func _resolve_wheel_rotation_deg(light: SpotLight3D, controls: Dictionary, wheel
 
 	if supports_rotation and rotation_norm >= 0.0 and delta_sec > 0.0:
 		var speed_deg_per_sec: float = 0.0
-		if bool(wheel.get("has_rotation_physical_limits", false)):
+		if bool(wheel.get("has_rotation_physical_ranges", false)):
+			speed_deg_per_sec = float(wheel.get("rotation_physical", 0.0))
+		elif bool(wheel.get("has_rotation_physical_limits", false)):
 			var rotation_physical_min: float = float(wheel.get("rotation_physical_min", -GOBO_ROTATION_MAX_DEG_PER_SEC * 0.5))
 			var rotation_physical_max: float = float(wheel.get("rotation_physical_max", GOBO_ROTATION_MAX_DEG_PER_SEC * 0.5))
-			speed_deg_per_sec = lerp(rotation_physical_min, rotation_physical_max, clamp(rotation_norm, 0.0, 1.0))
+			if rotation_physical_min < 0.0 and rotation_physical_max > 0.0:
+				speed_deg_per_sec = _resolve_symmetric_rotation_speed(rotation_norm, rotation_physical_min, rotation_physical_max)
+			else:
+				speed_deg_per_sec = lerp(rotation_physical_min, rotation_physical_max, clamp(rotation_norm, 0.0, 1.0))
 		else:
-			speed_deg_per_sec = (clamp(rotation_norm, 0.0, 1.0) - 0.5) * GOBO_ROTATION_MAX_DEG_PER_SEC
+			speed_deg_per_sec = _resolve_symmetric_rotation_speed(rotation_norm, -GOBO_ROTATION_MAX_DEG_PER_SEC, GOBO_ROTATION_MAX_DEG_PER_SEC)
 		spin_angle_deg = wrapf(spin_angle_deg + (speed_deg_per_sec * delta_sec), -360000.0, 360000.0)
 		wheel_spin_state[wheel_key] = spin_angle_deg
 		light.set_meta(GOBO_WHEEL_SPIN_META_KEY, wheel_spin_state)
@@ -163,6 +168,17 @@ func _resolve_wheel_rotation_deg(light: SpotLight3D, controls: Dictionary, wheel
 
 	return base_rotation_deg + spin_angle_deg
 
+
+
+func _resolve_symmetric_rotation_speed(rotation_norm: float, speed_min: float, speed_max: float) -> float:
+	var normalized: float = clamp(rotation_norm, 0.0, 1.0)
+	if normalized < 0.49:
+		var negative_ratio: float = normalized / 0.49
+		return lerp(speed_min, 0.0, negative_ratio)
+	if normalized <= 0.51:
+		return 0.0
+	var positive_ratio: float = (normalized - 0.51) / 0.49
+	return lerp(0.0, speed_max, positive_ratio)
 
 func _wheel_owns_rotation_control(wheel: Dictionary) -> bool:
 	if wheel.is_empty():

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -146,7 +146,7 @@ func _resolve_wheel_rotation_deg(light: SpotLight3D, controls: Dictionary, wheel
 
 	if supports_rotation and rotation_norm >= 0.0 and delta_sec > 0.0:
 		var speed_deg_per_sec: float = 0.0
-		if bool(wheel.get("has_rotation_physical_ranges", false)):
+		if bool(wheel.get("has_rotation_physical_ranges", false)) and bool(wheel.get("has_rotation_physical_value", false)):
 			speed_deg_per_sec = float(wheel.get("rotation_physical", 0.0))
 		elif bool(wheel.get("has_rotation_physical_limits", false)):
 			var rotation_physical_min: float = float(wheel.get("rotation_physical_min", -GOBO_ROTATION_MAX_DEG_PER_SEC * 0.5))


### PR DESCRIPTION
### Motivation
- Fix continuous gobo rotation so it respects GDTF `ChannelSet` DMX ranges and the manufacturer's physical speeds, instead of producing a constant/incorrect speed by linearly normalizing a single rotation channel.

### Description
- Add `FixtureGoboRotationRange` and a `rotation_ranges` array to per-wheel bindings (`FixtureGoboWheelBinding` / `FixtureGoboWheelOffset`) to store `dmx_start`, `dmx_end`, `physical_from`, `physical_to` and `is_stop_range` (stop-detection). 
- Implement `consume_gobo_rotation_channel_sets(...)` in `gdtf_dimmer_resolver.cpp` to parse rotation `ChannelSet` rows, normalize `DMXFrom/DMXTo` to function bounds and populate `rotation_ranges` on the appropriate wheel. 
- Wire `rotation_ranges` through the native binding layer and loader (`fixture_dmx_binding.cpp`, `peraviz_loader.cpp`) and serialize them into runtime dictionaries delivered to Godot. 
- Compute per-frame `rotation_physical` in `dmx_fixture_runtime.gd` using `_resolve_rotation_physical(...)` from the DMX value and the parsed ranges and expose `has_rotation_physical_ranges`/`rotation_physical` in each `wheel_data`. 
- Change `_resolve_wheel_rotation_deg` in `fixture_gobo_projector.gd` to: prefer `rotation_physical` when ranges exist, apply a symmetric stop-centered mapping (0.49..0.51 stop window) when only general physical min/max exist and they cross zero, and use the same symmetric mapping as a final fallback; keep delta-time accumulation and index-mode reset semantics intact.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed. 
- Note: an in-app E2E visual/DMX test with a real GDTF (e.g. Ayrton Veloce profile) could not be executed in this environment and is recommended for final verification of speed/direction behavior across forward/stop/back segments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7139640a88324aa07c8b46a45a5b9)