### PR TITLE
Export native gobo wheel mode windows and resolved rotation payload

### DIFF
--- a/peraviz/native/src/dmx/fixture_dmx_binding.h
+++ b/peraviz/native/src/dmx/fixture_dmx_binding.h
@@ -35,6 +35,8 @@ enum class FixtureGoboRangeBehavior {
 struct FixtureGoboRange {
     int dmx_from = 0;
     int dmx_to = 255;
+    int mode_from_8bit = 0;
+    int mode_to_8bit = 255;
     int slot_index = -1;
     FixtureGoboRangeBehavior behavior = FixtureGoboRangeBehavior::kFixed;
 };
@@ -42,6 +44,8 @@ struct FixtureGoboRange {
 struct FixtureGoboRotationRange {
     int dmx_start = 0;
     int dmx_end = 255;
+    int mode_from_8bit = 0;
+    int mode_to_8bit = 255;
     float physical_from = 0.0F;
     float physical_to = 0.0F;
     bool is_stop_range = false;

--- a/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
@@ -597,6 +597,8 @@ void consume_gobo_rotation_channel_sets(tinyxml2::XMLElement *channel_function,
         peraviz::dmx::FixtureGoboRotationRange range;
         range.dmx_start = row.dmx_start;
         range.dmx_end = row.dmx_end;
+        range.mode_from_8bit = clamped_function_from;
+        range.mode_to_8bit = clamped_function_to;
         range.physical_from = row.physical_from;
         range.physical_to = row.physical_to;
         range.is_stop_range = std::fabs(row.physical_from) < 0.0001F && std::fabs(row.physical_to) < 0.0001F;
@@ -1026,7 +1028,7 @@ void consume_gobo_channel_sets(tinyxml2::XMLElement *channel_function,
             std::swap(row.dmx_from, row.dmx_to);
         }
 
-        out_wheel.ranges.push_back({row.dmx_from, row.dmx_to, row.slot_index, row.behavior});
+        out_wheel.ranges.push_back({row.dmx_from, row.dmx_to, clamped_function_from, clamped_function_to, row.slot_index, row.behavior});
     }
 }
 
@@ -1115,6 +1117,8 @@ void dedupe_and_sort_gobo_wheel(peraviz::dmx::FixtureGoboWheelOffset &wheel) {
                     [](const peraviz::dmx::FixtureGoboRange &a,
                        const peraviz::dmx::FixtureGoboRange &b) {
                         return a.dmx_from == b.dmx_from && a.dmx_to == b.dmx_to &&
+                               a.mode_from_8bit == b.mode_from_8bit &&
+                               a.mode_to_8bit == b.mode_to_8bit &&
                                a.slot_index == b.slot_index && a.behavior == b.behavior;
                     }),
         wheel.ranges.end());
@@ -1132,6 +1136,8 @@ void dedupe_and_sort_gobo_wheel(peraviz::dmx::FixtureGoboWheelOffset &wheel) {
                     [](const peraviz::dmx::FixtureGoboRotationRange &a,
                        const peraviz::dmx::FixtureGoboRotationRange &b) {
                         return a.dmx_start == b.dmx_start && a.dmx_end == b.dmx_end &&
+                               a.mode_from_8bit == b.mode_from_8bit &&
+                               a.mode_to_8bit == b.mode_to_8bit &&
                                a.physical_from == b.physical_from &&
                                a.physical_to == b.physical_to;
                     }),

--- a/peraviz/native/src/peraviz_loader.cpp
+++ b/peraviz/native/src/peraviz_loader.cpp
@@ -224,6 +224,8 @@ Dictionary PeravizLoader::build_fixture_dimmer_bindings(int universe_offset) con
             Dictionary range_item;
             range_item["dmx_from"] = range.dmx_from;
             range_item["dmx_to"] = range.dmx_to;
+            range_item["mode_from_8bit"] = range.mode_from_8bit;
+            range_item["mode_to_8bit"] = range.mode_to_8bit;
             range_item["slot_index"] = range.slot_index;
             range_item["behavior"] = static_cast<int>(range.behavior);
             gobo_ranges[range_index] = range_item;
@@ -261,6 +263,8 @@ Dictionary PeravizLoader::build_fixture_dimmer_bindings(int universe_offset) con
                 Dictionary rotation_range_item;
                 rotation_range_item["dmx_start"] = rotation_range.dmx_start;
                 rotation_range_item["dmx_end"] = rotation_range.dmx_end;
+                rotation_range_item["mode_from_8bit"] = rotation_range.mode_from_8bit;
+                rotation_range_item["mode_to_8bit"] = rotation_range.mode_to_8bit;
                 rotation_range_item["physical_from"] = rotation_range.physical_from;
                 rotation_range_item["physical_to"] = rotation_range.physical_to;
                 rotation_range_item["is_stop_range"] = rotation_range.is_stop_range;
@@ -286,6 +290,8 @@ Dictionary PeravizLoader::build_fixture_dimmer_bindings(int universe_offset) con
                 Dictionary range_item;
                 range_item["dmx_from"] = range.dmx_from;
                 range_item["dmx_to"] = range.dmx_to;
+                range_item["mode_from_8bit"] = range.mode_from_8bit;
+                range_item["mode_to_8bit"] = range.mode_to_8bit;
                 range_item["slot_index"] = range.slot_index;
                 range_item["behavior"] = static_cast<int>(range.behavior);
                 wheel_ranges[range_index] = range_item;

--- a/peraviz/scripts/dmx_fixture_runtime.gd
+++ b/peraviz/scripts/dmx_fixture_runtime.gd
@@ -289,7 +289,7 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 		var rotation_raw: int = raw_8bit
 		var rotation_has_value: bool = false
 		var rotation_ranges: Array = item.get("rotation_ranges", [])
-		var rotation_physical: float = 0.0
+		var resolved_rotation: Dictionary = {}
 		if supports_index:
 			index_norm = _read_optional_control_norm(frame, int(item.get("index_channel_index_0", -1)), int(item.get("index_fine_channel_index_0", -1)), int(item.get("index_ultra_fine_channel_index_0", -1)))
 			if index_norm < 0.0 and range_behavior == GOBO_BEHAVIOR_INDEX:
@@ -310,12 +310,16 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 				rotation_raw = raw_8bit
 				rotation_has_value = true
 			if rotation_has_value and not rotation_ranges.is_empty():
-				rotation_physical = _resolve_rotation_physical(rotation_raw, rotation_ranges)
+				resolved_rotation = _resolve_rotation_runtime(rotation_raw, rotation_ranges)
+		var active_mode_from_8bit: int = int(active_range.get("mode_from_8bit", 0))
+		var active_mode_to_8bit: int = int(active_range.get("mode_to_8bit", 255))
 		runtime_bindings.append({
 			"wheel_number": int(item.get("wheel_number", 0)),
 			"wheel_name": str(item.get("wheel_name", "")),
 			"raw_8bit": raw_8bit,
 			"slot_index": int(active_range.get("slot_index", 0)),
+			"mode_from_8bit": active_mode_from_8bit,
+			"mode_to_8bit": active_mode_to_8bit,
 			"behavior": range_behavior,
 			"supports_index": supports_index,
 			"supports_rotation": supports_rotation,
@@ -326,8 +330,13 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 			"rotation_physical_min": float(item.get("rotation_physical_min", 0.0)),
 			"rotation_physical_max": float(item.get("rotation_physical_max", 0.0)),
 			"has_rotation_physical_ranges": not rotation_ranges.is_empty(),
-			"has_rotation_physical_value": not rotation_ranges.is_empty() and rotation_has_value,
-			"rotation_physical": rotation_physical,
+			"has_rotation_physical_value": not resolved_rotation.is_empty(),
+			"rotation_physical": float(resolved_rotation.get("rotation_speed_deg_per_sec", 0.0)),
+			"rotation_speed_deg_per_sec": float(resolved_rotation.get("rotation_speed_deg_per_sec", 0.0)),
+			"rotation_direction_sign": int(resolved_rotation.get("direction_sign", 0)),
+			"is_stop": bool(resolved_rotation.get("is_stop", false)),
+			"has_resolved_rotation_range": bool(resolved_rotation.get("has_range", false)),
+			"rotation_resolved_range": resolved_rotation.get("range", {}),
 			"rotation_raw": rotation_raw,
 			"rotation_raw_value": rotation_raw,
 			"rotation_active_range": active_range,
@@ -355,7 +364,7 @@ func _resolve_norm_from_active_range(raw_8bit: int, active_range: Dictionary) ->
 	return float(clamped_raw - dmx_from) / float(dmx_to - dmx_from)
 
 
-func _resolve_rotation_physical(dmx_val: float, ranges: Array) -> float:
+func _resolve_rotation_runtime(raw_8bit: int, ranges: Array) -> Dictionary:
 	for item in ranges:
 		if item is not Dictionary:
 			continue
@@ -366,15 +375,42 @@ func _resolve_rotation_physical(dmx_val: float, ranges: Array) -> float:
 			var swap_value: int = dmx_start
 			dmx_start = dmx_end
 			dmx_end = swap_value
-		if dmx_val < float(dmx_start) or dmx_val > float(dmx_end):
+		if raw_8bit < dmx_start or raw_8bit > dmx_end:
 			continue
-		if bool(range_data.get("is_stop_range", false)):
-			return 0.0
-		if dmx_end <= dmx_start:
-			return float(range_data.get("physical_to", range_data.get("physical_from", 0.0)))
-		var ratio: float = (dmx_val - float(dmx_start)) / float(dmx_end - dmx_start)
-		return lerp(float(range_data.get("physical_from", 0.0)), float(range_data.get("physical_to", 0.0)), ratio)
-	return 0.0
+
+		var speed_deg_per_sec: float = 0.0
+		var is_stop: bool = bool(range_data.get("is_stop_range", false))
+		if not is_stop:
+			if dmx_end <= dmx_start:
+				speed_deg_per_sec = float(range_data.get("physical_to", range_data.get("physical_from", 0.0)))
+			else:
+				var ratio: float = float(raw_8bit - dmx_start) / float(dmx_end - dmx_start)
+				speed_deg_per_sec = lerp(float(range_data.get("physical_from", 0.0)), float(range_data.get("physical_to", 0.0)), ratio)
+		if absf(speed_deg_per_sec) <= 0.0001:
+			is_stop = true
+			speed_deg_per_sec = 0.0
+
+		var direction_sign: int = 0
+		if speed_deg_per_sec > 0.0:
+			direction_sign = 1
+		elif speed_deg_per_sec < 0.0:
+			direction_sign = -1
+
+		return {
+			"has_range": true,
+			"range": range_data,
+			"rotation_speed_deg_per_sec": speed_deg_per_sec,
+			"direction_sign": direction_sign,
+			"is_stop": is_stop,
+		}
+
+	return {
+		"has_range": false,
+		"range": {},
+		"rotation_speed_deg_per_sec": 0.0,
+		"direction_sign": 0,
+		"is_stop": false,
+	}
 
 
 

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -146,21 +146,23 @@ func _resolve_wheel_rotation_deg(light: SpotLight3D, controls: Dictionary, wheel
 
 	if supports_rotation and delta_sec > 0.0:
 		var speed_deg_per_sec: float = 0.0
-		var has_rotation_physical_ranges: bool = bool(wheel.get("has_rotation_physical_ranges", false))
-		var has_rotation_physical_value: bool = bool(wheel.get("has_rotation_physical_value", false))
-		if has_rotation_physical_ranges and has_rotation_physical_value:
-			speed_deg_per_sec = float(wheel.get("rotation_physical", 0.0))
-		elif rotation_norm >= 0.0 and bool(wheel.get("has_rotation_physical_limits", false)):
-			var rotation_physical_min: float = float(wheel.get("rotation_physical_min", -GOBO_ROTATION_MAX_DEG_PER_SEC * 0.5))
-			var rotation_physical_max: float = float(wheel.get("rotation_physical_max", GOBO_ROTATION_MAX_DEG_PER_SEC * 0.5))
-			if rotation_physical_min < 0.0 and rotation_physical_max > 0.0:
-				speed_deg_per_sec = _resolve_symmetric_rotation_speed(rotation_norm, rotation_physical_min, rotation_physical_max)
-			else:
-				speed_deg_per_sec = lerp(rotation_physical_min, rotation_physical_max, clamp(rotation_norm, 0.0, 1.0))
-		elif rotation_norm >= 0.0:
-			speed_deg_per_sec = _resolve_symmetric_rotation_speed(rotation_norm, -GOBO_ROTATION_MAX_DEG_PER_SEC, GOBO_ROTATION_MAX_DEG_PER_SEC)
+		var has_native_speed: bool = bool(wheel.get("has_rotation_physical_value", false))
+		if has_native_speed:
+			speed_deg_per_sec = float(wheel.get("rotation_speed_deg_per_sec", wheel.get("rotation_physical", 0.0)))
+		else:
+			# Symmetric fallback only when native-resolved speed is unavailable.
+			if rotation_norm >= 0.0 and bool(wheel.get("has_rotation_physical_limits", false)):
+				var rotation_physical_min: float = float(wheel.get("rotation_physical_min", -GOBO_ROTATION_MAX_DEG_PER_SEC * 0.5))
+				var rotation_physical_max: float = float(wheel.get("rotation_physical_max", GOBO_ROTATION_MAX_DEG_PER_SEC * 0.5))
+				if rotation_physical_min < 0.0 and rotation_physical_max > 0.0:
+					speed_deg_per_sec = _resolve_symmetric_rotation_speed(rotation_norm, rotation_physical_min, rotation_physical_max)
+				else:
+					speed_deg_per_sec = lerp(rotation_physical_min, rotation_physical_max, clamp(rotation_norm, 0.0, 1.0))
+			elif rotation_norm >= 0.0:
+				speed_deg_per_sec = _resolve_symmetric_rotation_speed(rotation_norm, -GOBO_ROTATION_MAX_DEG_PER_SEC, GOBO_ROTATION_MAX_DEG_PER_SEC)
 
-		if has_rotation_physical_ranges and absf(speed_deg_per_sec) <= 0.0001:
+		var is_stop: bool = bool(wheel.get("is_stop", false)) if has_native_speed else absf(speed_deg_per_sec) <= 0.0001
+		if is_stop:
 			spin_angle_deg = 0.0
 		else:
 			spin_angle_deg = wrapf(spin_angle_deg + (speed_deg_per_sec * delta_sec), -360000.0, 360000.0)


### PR DESCRIPTION
### Motivation
- Preserve ChannelFunction window context and compute authoritative wheel rotation physics in native code to avoid duplicate/residual range math in scripts.
- Provide explicit rotation speed, direction and stop status to consumers so visuals can rely on native-resolved values and only fallback to symmetric heuristics when native data is unavailable.

### Description
- Added `mode_from_8bit` / `mode_to_8bit` to `FixtureGoboRange` and `FixtureGoboRotationRange` to carry ChannelFunction window bounds in the native binding structs (`peraviz/native/src/dmx/fixture_dmx_binding.h`).
- Populated the new mode-window fields when parsing ChannelFunctions and ChannelSets and included them in dedupe semantics to avoid collapsing ranges that belong to different function windows (`peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp`).
- Exported the new `mode_from_8bit` / `mode_to_8bit` fields and rotation range metadata into the Godot payload from the native loader (`peraviz/native/src/peraviz_loader.cpp`).
- Simplified runtime gobo binding assembly to call a single native-resolved rotation matcher and forward `rotation_speed_deg_per_sec`, `rotation_direction_sign`, `is_stop`, and the resolved range dictionary to scripts (`peraviz/scripts/dmx_fixture_runtime.gd`).
- Updated the gobo projector to treat native/runtime-resolved `rotation_speed_deg_per_sec` and `is_stop` as authoritative and only apply the existing symmetric rotation-speed fallback when native values are not available (`peraviz/scripts/fixture_gobo_projector.gd`).

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b73422e7e88324bba81297b03d0555)