### PR TITLE
Add gobo wheel rotation debug fields and conditional QA logging

### DIFF
--- a/peraviz/native/src/peraviz_loader.cpp
+++ b/peraviz/native/src/peraviz_loader.cpp
@@ -255,6 +255,17 @@ Dictionary PeravizLoader::build_fixture_dimmer_bindings(int universe_offset) con
             wheel_item["has_rotation_physical_limits"] = wheel.has_rotation_physical_limits;
             wheel_item["rotation_physical_min"] = wheel.rotation_physical_min;
             wheel_item["rotation_physical_max"] = wheel.rotation_physical_max;
+            wheel_item["rotation_source_channel"] = String("select");
+            wheel_item["rotation_raw_coarse"] = -1;
+            wheel_item["rotation_raw_fine"] = -1;
+            wheel_item["rotation_raw_8bit"] = -1;
+            wheel_item["rotation_mode_window_from"] = -1;
+            wheel_item["rotation_mode_window_to"] = -1;
+            wheel_item["rotation_matched_range_start"] = -1;
+            wheel_item["rotation_matched_range_end"] = -1;
+            wheel_item["rotation_matched_physical_from"] = 0.0;
+            wheel_item["rotation_matched_physical_to"] = 0.0;
+            wheel_item["rotation_is_stop_range"] = false;
 
             Array rotation_ranges;
             rotation_ranges.resize(static_cast<int64_t>(wheel.rotation_ranges.size()));

--- a/peraviz/scripts/dmx_fixture_runtime.gd
+++ b/peraviz/scripts/dmx_fixture_runtime.gd
@@ -287,6 +287,12 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 		var index_norm: float = -1.0
 		var rotation_norm: float = -1.0
 		var rotation_raw: int = raw_8bit
+		var rotation_raw_coarse: int = raw_8bit
+		var rotation_raw_fine: int = -1
+		var rotation_raw_8bit: int = raw_8bit
+		var rotation_source_channel: String = "select"
+		var rotation_mode_window_from: int = int(active_range.get("mode_from_8bit", 0))
+		var rotation_mode_window_to: int = int(active_range.get("mode_to_8bit", 255))
 		var rotation_has_value: bool = false
 		var rotation_ranges: Array = item.get("rotation_ranges", [])
 		var resolved_rotation: Dictionary = {}
@@ -296,23 +302,44 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 				index_norm = _resolve_norm_from_active_range(raw_8bit, active_range)
 		if supports_rotation:
 			if has_rotation_channel:
-				var rotation_value: Dictionary = _read_optional_control_value(frame, int(item.get("rotation_channel_index_0", -1)), int(item.get("rotation_fine_channel_index_0", -1)), int(item.get("rotation_ultra_fine_channel_index_0", -1)))
+				var rotation_coarse_index: int = int(item.get("rotation_channel_index_0", -1))
+				var rotation_fine_index: int = int(item.get("rotation_fine_channel_index_0", -1))
+				var rotation_ultra_fine_index: int = int(item.get("rotation_ultra_fine_channel_index_0", -1))
+				var rotation_value: Dictionary = _read_optional_control_value(frame, rotation_coarse_index, rotation_fine_index, rotation_ultra_fine_index)
 				if not rotation_value.is_empty():
 					rotation_norm = clamp(float(rotation_value.get("norm", 0.0)), 0.0, 1.0)
-					rotation_raw = _resolve_raw_to_8bit(int(rotation_value.get("raw", 0)), int(rotation_value.get("resolution_bits", 8)))
+					rotation_raw_8bit = _resolve_raw_to_8bit(int(rotation_value.get("raw", 0)), int(rotation_value.get("resolution_bits", 8)))
+					rotation_raw = rotation_raw_8bit
+					rotation_source_channel = "rotation"
+					rotation_raw_coarse = int(frame[rotation_coarse_index]) if _is_valid_channel_index(frame, rotation_coarse_index) else rotation_raw_8bit
+					rotation_raw_fine = int(frame[rotation_fine_index]) if _is_valid_channel_index(frame, rotation_fine_index) else -1
 					rotation_has_value = true
 			if uses_range_rotation:
 				rotation_norm = _resolve_norm_from_active_range(raw_8bit, active_range)
 				rotation_raw = raw_8bit
+				rotation_raw_8bit = raw_8bit
+				rotation_source_channel = "select"
+				rotation_raw_coarse = raw_8bit
+				rotation_raw_fine = -1
 				rotation_has_value = true
 			elif rotation_norm < 0.0 and is_rotation_behavior:
 				rotation_norm = _resolve_norm_from_active_range(raw_8bit, active_range)
 				rotation_raw = raw_8bit
+				rotation_raw_8bit = raw_8bit
+				rotation_source_channel = "select"
+				rotation_raw_coarse = raw_8bit
+				rotation_raw_fine = -1
 				rotation_has_value = true
 			if rotation_has_value and not rotation_ranges.is_empty():
 				resolved_rotation = _resolve_rotation_runtime(rotation_raw, rotation_ranges)
 		var active_mode_from_8bit: int = int(active_range.get("mode_from_8bit", 0))
 		var active_mode_to_8bit: int = int(active_range.get("mode_to_8bit", 255))
+		var matched_range: Dictionary = resolved_rotation.get("range", {})
+		var rotation_matched_range_start: int = int(matched_range.get("dmx_start", -1))
+		var rotation_matched_range_end: int = int(matched_range.get("dmx_end", -1))
+		var rotation_matched_physical_from: float = float(matched_range.get("physical_from", 0.0))
+		var rotation_matched_physical_to: float = float(matched_range.get("physical_to", 0.0))
+		var rotation_is_stop_range: bool = bool(matched_range.get("is_stop_range", false))
 		runtime_bindings.append({
 			"wheel_number": int(item.get("wheel_number", 0)),
 			"wheel_name": str(item.get("wheel_name", "")),
@@ -337,6 +364,17 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 			"is_stop": bool(resolved_rotation.get("is_stop", false)),
 			"has_resolved_rotation_range": bool(resolved_rotation.get("has_range", false)),
 			"rotation_resolved_range": resolved_rotation.get("range", {}),
+			"rotation_source_channel": rotation_source_channel,
+			"rotation_raw_coarse": rotation_raw_coarse,
+			"rotation_raw_fine": rotation_raw_fine,
+			"rotation_raw_8bit": rotation_raw_8bit,
+			"rotation_mode_window_from": rotation_mode_window_from,
+			"rotation_mode_window_to": rotation_mode_window_to,
+			"rotation_matched_range_start": rotation_matched_range_start,
+			"rotation_matched_range_end": rotation_matched_range_end,
+			"rotation_matched_physical_from": rotation_matched_physical_from,
+			"rotation_matched_physical_to": rotation_matched_physical_to,
+			"rotation_is_stop_range": rotation_is_stop_range,
 			"rotation_raw": rotation_raw,
 			"rotation_raw_value": rotation_raw,
 			"rotation_active_range": active_range,

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -25,6 +25,8 @@ const GOBO_APPLIED_ROTATION_DEG_META_KEY: String = "peraviz_gobo_applied_rotatio
 const GOBO_WHEEL_MODE_META_KEY: String = "peraviz_gobo_wheel_mode"
 const GOBO_INDEX_MAX_DEG: float = 360.0
 const GOBO_ROTATION_MAX_DEG_PER_SEC: float = 720.0
+const GOBO_ROTATION_DEBUG_SETTING_KEY: String = "peraviz_debug_gobo_rotation"
+const GOBO_ROTATION_DEBUG_DEFAULT: bool = false
 
 const GOBO_BEHAVIOR_FIXED: int = 0
 const GOBO_BEHAVIOR_INDEX: int = 1
@@ -174,8 +176,35 @@ func _resolve_wheel_rotation_deg(light: SpotLight3D, controls: Dictionary, wheel
 		light.set_meta(GOBO_WHEEL_SPIN_META_KEY, wheel_spin_state)
 		return base_rotation_deg
 
+	_log_rotation_debug_if_enabled(wheel, wheel_key, behavior, rotation_norm, delta_sec)
 	return base_rotation_deg + spin_angle_deg
 
+
+
+func _log_rotation_debug_if_enabled(wheel: Dictionary, wheel_key: String, behavior: int, rotation_norm: float, delta_sec: float) -> void:
+	if not bool(ProjectSettings.get_setting(GOBO_ROTATION_DEBUG_SETTING_KEY, GOBO_ROTATION_DEBUG_DEFAULT)):
+		return
+	print("[PeravizGoboRotation] wheel_key=%s wheel_number=%d wheel_name=%s behavior=%d source=%s raw_coarse=%d raw_fine=%d raw_8bit=%d mode_window=%d-%d matched_range=%d-%d matched_physical=%.4f->%.4f stop=%s dir=%d speed_dps=%.4f norm=%.4f dt=%.4f" % [
+		wheel_key,
+		int(wheel.get("wheel_number", 0)),
+		str(wheel.get("wheel_name", "")),
+		behavior,
+		str(wheel.get("rotation_source_channel", "")),
+		int(wheel.get("rotation_raw_coarse", -1)),
+		int(wheel.get("rotation_raw_fine", -1)),
+		int(wheel.get("rotation_raw_8bit", -1)),
+		int(wheel.get("rotation_mode_window_from", -1)),
+		int(wheel.get("rotation_mode_window_to", -1)),
+		int(wheel.get("rotation_matched_range_start", -1)),
+		int(wheel.get("rotation_matched_range_end", -1)),
+		float(wheel.get("rotation_matched_physical_from", 0.0)),
+		float(wheel.get("rotation_matched_physical_to", 0.0)),
+		str(bool(wheel.get("rotation_is_stop_range", false))),
+		int(wheel.get("rotation_direction_sign", 0)),
+		float(wheel.get("rotation_speed_deg_per_sec", wheel.get("rotation_physical", 0.0))),
+		rotation_norm,
+		delta_sec,
+	])
 
 
 func _resolve_symmetric_rotation_speed(rotation_norm: float, speed_min: float, speed_max: float) -> float:


### PR DESCRIPTION
### Motivation
- Provide QA with detailed, per-wheel rotation data so stop/direction/speed transitions can be validated during DMX sweeps.
- Ensure native bindings always include safe default rotation debug fields so downstream runtime code can rely on stable keys.
- Surface the runtime-resolved rotation values (source, raw coarse/fine/8-bit, mode window, matched range/physical, stop flag) to the projector for inspection when needed.

### Description
- Added default rotation debug fields to the native serializer in `peraviz/native/src/peraviz_loader.cpp`: `rotation_source_channel`, `rotation_raw_coarse`, `rotation_raw_fine`, `rotation_raw_8bit`, `rotation_mode_window_from`, `rotation_mode_window_to`, `rotation_matched_range_start`, `rotation_matched_range_end`, `rotation_matched_physical_from`, `rotation_matched_physical_to`, and `rotation_is_stop_range`.
- Extended `peraviz/scripts/dmx_fixture_runtime.gd` to compute and populate the same rotation debug fields for each gobo wheel (including selecting `select` vs `rotation` as the source, computing coarse/fine/8-bit raw values, mode window, matched range and physicals, and stop-range status) and pass them unchanged as part of the runtime `gobo_runtime_bindings` payload.
- Added a ProjectSettings-gated single-line structured log in `peraviz/scripts/fixture_gobo_projector.gd` (gated by `peraviz_debug_gobo_rotation`) that prints a compact, QA-friendly line containing wheel id, source, raw values, mode window, matched range/physical range, stop flag, direction sign and resolved speed and timing.
- Kept behavior unchanged when the debug flag is disabled so normal runtime performance is preserved.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it completed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it completed successfully.
- No other automated unit tests were added in this change; the new logging is gated behind `ProjectSettings["peraviz_debug_gobo_rotation"]` for QA use.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7360770e88324b67f52d9a5d07589)