### PR TITLE
Fix GDTF gobo rotation range parsing and runtime resolution

### DIFF
--- a/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
@@ -1336,7 +1336,10 @@ void consume_channel_offsets(tinyxml2::XMLElement *dmx_channel,
             if (function_dmx_to < 0) {
                 function_dmx_to = 255;
                 if (channel_function_index + 1 < channel_functions.size()) {
-                    function_dmx_to = function_dmx_from_values[channel_function_index + 1] - 1;
+                    const int next_function_dmx_from = function_dmx_from_values[channel_function_index + 1];
+                    if (next_function_dmx_from > function_dmx_from) {
+                        function_dmx_to = next_function_dmx_from - 1;
+                    }
                 }
             }
             function_dmx_to = std::clamp(function_dmx_to, function_dmx_from, 255);

--- a/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
@@ -326,7 +326,10 @@ bool matches_gobo_rotation_attribute(const std::string &leaf) {
         return false;
     }
     return leaf.find("posrotate") != std::string::npos ||
+           leaf.find("posrot") != std::string::npos ||
            leaf.find("wheelspin") != std::string::npos ||
+           leaf.find("wheelrotation") != std::string::npos ||
+           leaf.find("rotation") != std::string::npos ||
            leaf.find("spin") != std::string::npos ||
            leaf.find("rotate") != std::string::npos;
 }
@@ -443,7 +446,9 @@ void consume_gobo_physical_range(tinyxml2::XMLElement *channel_function,
 void consume_gobo_rotation_channel_sets(tinyxml2::XMLElement *channel_function,
                                         std::vector<peraviz::dmx::FixtureGoboRotationRange> &out_ranges,
                                         int function_dmx_from,
-                                        int function_dmx_to);
+                                        int function_dmx_to,
+                                        int mode_window_from,
+                                        int mode_window_to);
 
 int parse_dmx_value_8bit(const char *raw_value);
 
@@ -513,7 +518,9 @@ void consume_gobo_physical_range(tinyxml2::XMLElement *channel_function,
 void consume_gobo_rotation_channel_sets(tinyxml2::XMLElement *channel_function,
                                         std::vector<peraviz::dmx::FixtureGoboRotationRange> &out_ranges,
                                         int function_dmx_from,
-                                        int function_dmx_to) {
+                                        int function_dmx_to,
+                                        int mode_window_from,
+                                        int mode_window_to) {
     if (!channel_function) {
         return;
     }
@@ -569,7 +576,30 @@ void consume_gobo_rotation_channel_sets(tinyxml2::XMLElement *channel_function,
         parsed_ranges.push_back({dmx_start, dmx_end, physical_from, physical_to});
     }
 
+    const int clamped_mode_from = std::clamp(mode_window_from, 0, 255);
+    const int clamped_mode_to = std::clamp(mode_window_to, clamped_mode_from, 255);
+
     if (parsed_ranges.empty()) {
+        float function_physical_from = 0.0F;
+        float function_physical_to = 0.0F;
+        const bool has_function_physical_from =
+            parse_float_attr_ci(channel_function, "PhysicalFrom", "physicalfrom", function_physical_from);
+        const bool has_function_physical_to =
+            parse_float_attr_ci(channel_function, "PhysicalTo", "physicalto", function_physical_to);
+        if (!has_function_physical_from || !has_function_physical_to) {
+            return;
+        }
+
+        peraviz::dmx::FixtureGoboRotationRange range;
+        range.dmx_start = clamped_function_from;
+        range.dmx_end = clamped_function_to;
+        range.mode_from_8bit = clamped_mode_from;
+        range.mode_to_8bit = clamped_mode_to;
+        range.physical_from = function_physical_from;
+        range.physical_to = function_physical_to;
+        range.is_stop_range = std::fabs(function_physical_from) < 0.0001F &&
+                              std::fabs(function_physical_to) < 0.0001F;
+        out_ranges.push_back(range);
         return;
     }
 
@@ -597,8 +627,8 @@ void consume_gobo_rotation_channel_sets(tinyxml2::XMLElement *channel_function,
         peraviz::dmx::FixtureGoboRotationRange range;
         range.dmx_start = row.dmx_start;
         range.dmx_end = row.dmx_end;
-        range.mode_from_8bit = clamped_function_from;
-        range.mode_to_8bit = clamped_function_to;
+        range.mode_from_8bit = clamped_mode_from;
+        range.mode_to_8bit = clamped_mode_to;
         range.physical_from = row.physical_from;
         range.physical_to = row.physical_to;
         range.is_stop_range = std::fabs(row.physical_from) < 0.0001F && std::fabs(row.physical_to) < 0.0001F;
@@ -1177,25 +1207,38 @@ void consume_channel_offsets(tinyxml2::XMLElement *dmx_channel,
         std::vector<int> function_dmx_to_values;
         function_dmx_from_values.reserve(channel_functions.size());
         function_dmx_to_values.reserve(channel_functions.size());
+        std::vector<int> function_mode_from_values;
+        std::vector<int> function_mode_to_values;
+        function_mode_from_values.reserve(channel_functions.size());
+        function_mode_to_values.reserve(channel_functions.size());
         for (tinyxml2::XMLElement *channel_function : channel_functions) {
-            int function_dmx_from = parse_dmx_value_8bit(channel_function->Attribute("ModeFrom"));
+            int function_dmx_from = parse_dmx_value_8bit(channel_function->Attribute("DMXFrom"));
             if (function_dmx_from < 0) {
-                function_dmx_from = parse_dmx_value_8bit(channel_function->Attribute("modefrom"));
+                function_dmx_from = parse_dmx_value_8bit(channel_function->Attribute("dmxfrom"));
             }
-            int function_dmx_to = parse_dmx_value_8bit(channel_function->Attribute("ModeTo"));
-            if (function_dmx_to < 0) {
-                function_dmx_to = parse_dmx_value_8bit(channel_function->Attribute("modeto"));
-            }
-
-            if (function_dmx_from < 0) {
-                function_dmx_from = parse_dmx_value_8bit(channel_function->Attribute("DMXFrom"));
-                if (function_dmx_from < 0) {
-                    function_dmx_from = parse_dmx_value_8bit(channel_function->Attribute("dmxfrom"));
-                }
-            }
-
             if (function_dmx_from < 0) {
                 function_dmx_from = 0;
+            }
+
+            int function_dmx_to = parse_dmx_value_8bit(channel_function->Attribute("DMXTo"));
+            if (function_dmx_to < 0) {
+                function_dmx_to = parse_dmx_value_8bit(channel_function->Attribute("dmxto"));
+            }
+
+            int function_mode_from = parse_dmx_value_8bit(channel_function->Attribute("ModeFrom"));
+            if (function_mode_from < 0) {
+                function_mode_from = parse_dmx_value_8bit(channel_function->Attribute("modefrom"));
+            }
+            if (function_mode_from < 0) {
+                function_mode_from = function_dmx_from;
+            }
+
+            int function_mode_to = parse_dmx_value_8bit(channel_function->Attribute("ModeTo"));
+            if (function_mode_to < 0) {
+                function_mode_to = parse_dmx_value_8bit(channel_function->Attribute("modeto"));
+            }
+            if (function_mode_to < 0) {
+                function_mode_to = 255;
             }
 
             function_dmx_from = std::clamp(function_dmx_from, 0, 255);
@@ -1206,8 +1249,16 @@ void consume_channel_offsets(tinyxml2::XMLElement *dmx_channel,
                 }
             }
 
+            function_mode_from = std::clamp(function_mode_from, 0, 255);
+            function_mode_to = std::clamp(function_mode_to, 0, 255);
+            if (function_mode_to < function_mode_from) {
+                std::swap(function_mode_to, function_mode_from);
+            }
+
             function_dmx_from_values.push_back(function_dmx_from);
             function_dmx_to_values.push_back(function_dmx_to);
+            function_mode_from_values.push_back(function_mode_from);
+            function_mode_to_values.push_back(function_mode_to);
         }
 
         for (size_t channel_function_index = 0;
@@ -1223,6 +1274,8 @@ void consume_channel_offsets(tinyxml2::XMLElement *dmx_channel,
                 }
             }
             function_dmx_to = std::clamp(function_dmx_to, function_dmx_from, 255);
+            const int function_mode_from = function_mode_from_values[channel_function_index];
+            const int function_mode_to = function_mode_to_values[channel_function_index];
             const char *attribute = channel_function->Attribute("Attribute");
             if (!attribute) {
                 attribute = channel_function->Attribute("attribute");
@@ -1345,7 +1398,9 @@ void consume_channel_offsets(tinyxml2::XMLElement *dmx_channel,
                 consume_gobo_rotation_channel_sets(channel_function,
                                                   wheel->rotation_ranges,
                                                   function_dmx_from,
-                                                  function_dmx_to);
+                                                  function_dmx_to,
+                                                  function_mode_from,
+                                                  function_mode_to);
                 break;
             }
             }

--- a/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
@@ -527,6 +527,8 @@ void consume_gobo_rotation_channel_sets(tinyxml2::XMLElement *channel_function,
 
     const int clamped_function_from = std::clamp(function_dmx_from, 0, 255);
     const int clamped_function_to = std::clamp(function_dmx_to, clamped_function_from, 255);
+    const int clamped_mode_from = std::clamp(mode_window_from, 0, 255);
+    const int clamped_mode_to = std::clamp(mode_window_to, clamped_mode_from, 255);
     const auto resolve_channel_set_dmx =
         [clamped_function_from, clamped_function_to](int raw_value) -> int {
             if (raw_value >= clamped_function_from && raw_value <= 255) {
@@ -575,9 +577,6 @@ void consume_gobo_rotation_channel_sets(tinyxml2::XMLElement *channel_function,
 
         parsed_ranges.push_back({dmx_start, dmx_end, physical_from, physical_to});
     }
-
-    const int clamped_mode_from = std::clamp(mode_window_from, 0, 255);
-    const int clamped_mode_to = std::clamp(mode_window_to, clamped_mode_from, 255);
 
     if (parsed_ranges.empty()) {
         float function_physical_from = 0.0F;
@@ -938,7 +937,9 @@ void consume_gobo_channel_sets(tinyxml2::XMLElement *channel_function,
                                const GoboWheelCatalog &wheel_catalog,
                                peraviz::dmx::FixtureGoboWheelOffset &out_wheel,
                                int function_dmx_from,
-                               int function_dmx_to) {
+                               int function_dmx_to,
+                               int mode_window_from,
+                               int mode_window_to) {
     if (!channel_function) {
         return;
     }
@@ -973,11 +974,16 @@ void consume_gobo_channel_sets(tinyxml2::XMLElement *channel_function,
         int slot_index = -1;
         peraviz::dmx::FixtureGoboRangeBehavior behavior =
             peraviz::dmx::FixtureGoboRangeBehavior::kFixed;
+        bool has_physical = false;
+        float physical_from = 0.0F;
+        float physical_to = 0.0F;
     };
     std::vector<ParsedGoboSet> parsed_sets;
 
     const int clamped_function_from = std::clamp(function_dmx_from, 0, 255);
     const int clamped_function_to = std::clamp(function_dmx_to, clamped_function_from, 255);
+    const int clamped_mode_from = std::clamp(mode_window_from, 0, 255);
+    const int clamped_mode_to = std::clamp(mode_window_to, clamped_mode_from, 255);
 
     const auto resolve_channel_set_dmx =
         [clamped_function_from, clamped_function_to](int raw_value) -> int {
@@ -1040,7 +1046,12 @@ void consume_gobo_channel_sets(tinyxml2::XMLElement *channel_function,
             // In that case, inherit the function behavior for all rows.
             behavior = function_behavior_hint;
         }
-        parsed_sets.push_back({dmx_from, dmx_to, slot_index, behavior});
+        float physical_from = 0.0F;
+        float physical_to = 0.0F;
+        const bool has_physical_from = parse_float_attr_ci(channel_set, "PhysicalFrom", "physicalfrom", physical_from);
+        const bool has_physical_to = parse_float_attr_ci(channel_set, "PhysicalTo", "physicalto", physical_to);
+        const bool has_physical = has_physical_from && has_physical_to;
+        parsed_sets.push_back({dmx_from, dmx_to, slot_index, behavior, has_physical, physical_from, physical_to});
     }
 
     if (parsed_sets.empty()) {
@@ -1067,7 +1078,21 @@ void consume_gobo_channel_sets(tinyxml2::XMLElement *channel_function,
             std::swap(row.dmx_from, row.dmx_to);
         }
 
-        out_wheel.ranges.push_back({row.dmx_from, row.dmx_to, clamped_function_from, clamped_function_to, row.slot_index, row.behavior});
+        out_wheel.ranges.push_back({row.dmx_from, row.dmx_to, clamped_mode_from, clamped_mode_to, row.slot_index, row.behavior});
+
+        if ((row.behavior == peraviz::dmx::FixtureGoboRangeBehavior::kRotation ||
+             row.behavior == peraviz::dmx::FixtureGoboRangeBehavior::kShake) &&
+            row.has_physical) {
+            peraviz::dmx::FixtureGoboRotationRange rotation_range;
+            rotation_range.dmx_start = row.dmx_from;
+            rotation_range.dmx_end = row.dmx_to;
+            rotation_range.mode_from_8bit = clamped_mode_from;
+            rotation_range.mode_to_8bit = clamped_mode_to;
+            rotation_range.physical_from = row.physical_from;
+            rotation_range.physical_to = row.physical_to;
+            rotation_range.is_stop_range = std::fabs(row.physical_from) < 0.0001F && std::fabs(row.physical_to) < 0.0001F;
+            out_wheel.rotation_ranges.push_back(rotation_range);
+        }
     }
 }
 
@@ -1357,7 +1382,8 @@ void consume_channel_offsets(tinyxml2::XMLElement *dmx_channel,
                                 wheel->fine_offset_1_based,
                                 wheel->ultra_fine_offset_1_based);
                 consume_gobo_channel_sets(channel_function, wheel_catalog, *wheel,
-                                          function_dmx_from, function_dmx_to);
+                                          function_dmx_from, function_dmx_to,
+                                          function_mode_from, function_mode_to);
                 break;
             }
             case AttributeRole::kGoboIndex: {

--- a/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
@@ -1225,20 +1225,25 @@ void consume_channel_offsets(tinyxml2::XMLElement *dmx_channel,
                 function_dmx_to = parse_dmx_value_8bit(channel_function->Attribute("dmxto"));
             }
 
-            int function_mode_from = parse_dmx_value_8bit(channel_function->Attribute("ModeFrom"));
-            if (function_mode_from < 0) {
-                function_mode_from = parse_dmx_value_8bit(channel_function->Attribute("modefrom"));
-            }
-            if (function_mode_from < 0) {
-                function_mode_from = function_dmx_from;
+            const bool has_mode_master =
+                channel_function->Attribute("ModeMaster") != nullptr ||
+                channel_function->Attribute("modemaster") != nullptr;
+
+            int parsed_mode_from = parse_dmx_value_8bit(channel_function->Attribute("ModeFrom"));
+            if (parsed_mode_from < 0) {
+                parsed_mode_from = parse_dmx_value_8bit(channel_function->Attribute("modefrom"));
             }
 
-            int function_mode_to = parse_dmx_value_8bit(channel_function->Attribute("ModeTo"));
-            if (function_mode_to < 0) {
-                function_mode_to = parse_dmx_value_8bit(channel_function->Attribute("modeto"));
+            int parsed_mode_to = parse_dmx_value_8bit(channel_function->Attribute("ModeTo"));
+            if (parsed_mode_to < 0) {
+                parsed_mode_to = parse_dmx_value_8bit(channel_function->Attribute("modeto"));
             }
-            if (function_mode_to < 0) {
-                function_mode_to = 255;
+
+            int function_mode_from = 0;
+            int function_mode_to = 255;
+            if (has_mode_master || parsed_mode_from >= 0 || parsed_mode_to >= 0) {
+                function_mode_from = parsed_mode_from >= 0 ? parsed_mode_from : 0;
+                function_mode_to = parsed_mode_to >= 0 ? parsed_mode_to : 255;
             }
 
             function_dmx_from = std::clamp(function_dmx_from, 0, 255);

--- a/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
@@ -529,6 +529,14 @@ void consume_gobo_rotation_channel_sets(tinyxml2::XMLElement *channel_function,
     const int clamped_function_to = std::clamp(function_dmx_to, clamped_function_from, 255);
     const int clamped_mode_from = std::clamp(mode_window_from, 0, 255);
     const int clamped_mode_to = std::clamp(mode_window_to, clamped_mode_from, 255);
+    float function_physical_from = 0.0F;
+    float function_physical_to = 0.0F;
+    const bool has_function_physical_from =
+        parse_float_attr_ci(channel_function, "PhysicalFrom", "physicalfrom", function_physical_from);
+    const bool has_function_physical_to =
+        parse_float_attr_ci(channel_function, "PhysicalTo", "physicalto", function_physical_to);
+    const bool has_function_physical = has_function_physical_from && has_function_physical_to;
+
     const auto resolve_channel_set_dmx =
         [clamped_function_from, clamped_function_to](int raw_value) -> int {
             if (raw_value >= clamped_function_from && raw_value <= 255) {
@@ -974,6 +982,7 @@ void consume_gobo_channel_sets(tinyxml2::XMLElement *channel_function,
         int slot_index = -1;
         peraviz::dmx::FixtureGoboRangeBehavior behavior =
             peraviz::dmx::FixtureGoboRangeBehavior::kFixed;
+        std::string name;
         bool has_physical = false;
         float physical_from = 0.0F;
         float physical_to = 0.0F;
@@ -984,6 +993,14 @@ void consume_gobo_channel_sets(tinyxml2::XMLElement *channel_function,
     const int clamped_function_to = std::clamp(function_dmx_to, clamped_function_from, 255);
     const int clamped_mode_from = std::clamp(mode_window_from, 0, 255);
     const int clamped_mode_to = std::clamp(mode_window_to, clamped_mode_from, 255);
+
+    float function_physical_from = 0.0F;
+    float function_physical_to = 0.0F;
+    const bool has_function_physical_from =
+        parse_float_attr_ci(channel_function, "PhysicalFrom", "physicalfrom", function_physical_from);
+    const bool has_function_physical_to =
+        parse_float_attr_ci(channel_function, "PhysicalTo", "physicalto", function_physical_to);
+    const bool has_function_physical = has_function_physical_from && has_function_physical_to;
 
     const auto resolve_channel_set_dmx =
         [clamped_function_from, clamped_function_to](int raw_value) -> int {
@@ -1051,7 +1068,7 @@ void consume_gobo_channel_sets(tinyxml2::XMLElement *channel_function,
         const bool has_physical_from = parse_float_attr_ci(channel_set, "PhysicalFrom", "physicalfrom", physical_from);
         const bool has_physical_to = parse_float_attr_ci(channel_set, "PhysicalTo", "physicalto", physical_to);
         const bool has_physical = has_physical_from && has_physical_to;
-        parsed_sets.push_back({dmx_from, dmx_to, slot_index, behavior, has_physical, physical_from, physical_to});
+        parsed_sets.push_back({dmx_from, dmx_to, slot_index, behavior, channel_set_name, has_physical, physical_from, physical_to});
     }
 
     if (parsed_sets.empty()) {
@@ -1080,18 +1097,37 @@ void consume_gobo_channel_sets(tinyxml2::XMLElement *channel_function,
 
         out_wheel.ranges.push_back({row.dmx_from, row.dmx_to, clamped_mode_from, clamped_mode_to, row.slot_index, row.behavior});
 
-        if ((row.behavior == peraviz::dmx::FixtureGoboRangeBehavior::kRotation ||
-             row.behavior == peraviz::dmx::FixtureGoboRangeBehavior::kShake) &&
-            row.has_physical) {
-            peraviz::dmx::FixtureGoboRotationRange rotation_range;
-            rotation_range.dmx_start = row.dmx_from;
-            rotation_range.dmx_end = row.dmx_to;
-            rotation_range.mode_from_8bit = clamped_mode_from;
-            rotation_range.mode_to_8bit = clamped_mode_to;
-            rotation_range.physical_from = row.physical_from;
-            rotation_range.physical_to = row.physical_to;
-            rotation_range.is_stop_range = std::fabs(row.physical_from) < 0.0001F && std::fabs(row.physical_to) < 0.0001F;
-            out_wheel.rotation_ranges.push_back(rotation_range);
+        if (row.behavior == peraviz::dmx::FixtureGoboRangeBehavior::kRotation ||
+            row.behavior == peraviz::dmx::FixtureGoboRangeBehavior::kShake) {
+            float rotation_physical_from = row.physical_from;
+            float rotation_physical_to = row.physical_to;
+            bool has_rotation_physical = row.has_physical;
+            if (!has_rotation_physical && has_function_physical) {
+                rotation_physical_from = function_physical_from;
+                rotation_physical_to = function_physical_to;
+                has_rotation_physical = true;
+            }
+
+            const std::string lower_name = lower_ascii(row.name);
+            const bool is_named_stop = lower_name.find("no rotation") != std::string::npos ||
+                                       lower_name.find("stop") != std::string::npos;
+            if (!has_rotation_physical && is_named_stop) {
+                rotation_physical_from = 0.0F;
+                rotation_physical_to = 0.0F;
+                has_rotation_physical = true;
+            }
+
+            if (has_rotation_physical) {
+                peraviz::dmx::FixtureGoboRotationRange rotation_range;
+                rotation_range.dmx_start = row.dmx_from;
+                rotation_range.dmx_end = row.dmx_to;
+                rotation_range.mode_from_8bit = clamped_mode_from;
+                rotation_range.mode_to_8bit = clamped_mode_to;
+                rotation_range.physical_from = rotation_physical_from;
+                rotation_range.physical_to = rotation_physical_to;
+                rotation_range.is_stop_range = std::fabs(rotation_physical_from) < 0.0001F && std::fabs(rotation_physical_to) < 0.0001F;
+                out_wheel.rotation_ranges.push_back(rotation_range);
+            }
         }
     }
 }

--- a/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
@@ -1454,10 +1454,35 @@ void consume_channel_offsets(tinyxml2::XMLElement *dmx_channel,
                 if (!wheel) {
                     break;
                 }
+
+                int candidate_rotation_coarse = -1;
+                int candidate_rotation_fine = -1;
+                int candidate_rotation_ultra_fine = -1;
                 consume_offsets(offsets, parsed_attribute.is_fine, parsed_attribute.byte_index,
-                                wheel->rotation_coarse_offset_1_based,
-                                wheel->rotation_fine_offset_1_based,
-                                wheel->rotation_ultra_fine_offset_1_based);
+                                candidate_rotation_coarse,
+                                candidate_rotation_fine,
+                                candidate_rotation_ultra_fine);
+
+                const std::string attribute_lower = lower_ascii(trim_ascii(attribute));
+                const bool has_mode_master =
+                    channel_function->Attribute("ModeMaster") != nullptr ||
+                    channel_function->Attribute("modemaster") != nullptr;
+                const bool prefers_position_rotation_channel =
+                    attribute_lower.find("posrotate") != std::string::npos ||
+                    attribute_lower.find("posrotation") != std::string::npos ||
+                    (attribute_lower.find("gobo") != std::string::npos &&
+                     attribute_lower.find("pos") != std::string::npos &&
+                     attribute_lower.find("rotate") != std::string::npos);
+                const bool should_replace_rotation_channel =
+                    wheel->rotation_coarse_offset_1_based <= 0 ||
+                    (candidate_rotation_coarse > 0 && candidate_rotation_coarse < wheel->rotation_coarse_offset_1_based) ||
+                    (candidate_rotation_coarse > 0 && (has_mode_master || prefers_position_rotation_channel));
+                if (should_replace_rotation_channel) {
+                    wheel->rotation_coarse_offset_1_based = candidate_rotation_coarse;
+                    wheel->rotation_fine_offset_1_based = candidate_rotation_fine;
+                    wheel->rotation_ultra_fine_offset_1_based = candidate_rotation_ultra_fine;
+                }
+
                 consume_gobo_physical_range(channel_function,
                                             wheel->has_rotation_physical_limits,
                                             wheel->rotation_physical_min,

--- a/peraviz/scripts/dmx_fixture_runtime.gd
+++ b/peraviz/scripts/dmx_fixture_runtime.gd
@@ -318,7 +318,8 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 		var rotation_has_value: bool = false
 		var rotation_ranges: Array = item.get("rotation_ranges", [])
 		var resolved_rotation: Dictionary = {}
-		if supports_index:
+		var should_read_index_channel: bool = has_index_channel and (supports_index or (supports_rotation and not has_rotation_channel))
+		if should_read_index_channel:
 			var index_coarse_index: int = int(item.get("index_channel_index_0", -1))
 			var index_fine_index: int = int(item.get("index_fine_channel_index_0", -1))
 			var index_ultra_fine_index: int = int(item.get("index_ultra_fine_channel_index_0", -1))
@@ -329,8 +330,8 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 				index_raw_8bit = _resolve_raw_to_8bit(index_raw, int(index_value.get("resolution_bits", 8)))
 				index_raw_coarse = int(frame[index_coarse_index]) if _is_valid_channel_index(frame, index_coarse_index) else index_raw_8bit
 				index_raw_fine = int(frame[index_fine_index]) if _is_valid_channel_index(frame, index_fine_index) else -1
-			if index_norm < 0.0 and range_behavior == GOBO_BEHAVIOR_INDEX:
-				index_norm = _resolve_norm_from_active_range(raw_8bit, active_range)
+		if supports_index and index_norm < 0.0 and range_behavior == GOBO_BEHAVIOR_INDEX:
+			index_norm = _resolve_norm_from_active_range(raw_8bit, active_range)
 		if supports_rotation:
 			if has_rotation_channel:
 				var rotation_coarse_index: int = int(item.get("rotation_channel_index_0", -1))

--- a/peraviz/scripts/dmx_fixture_runtime.gd
+++ b/peraviz/scripts/dmx_fixture_runtime.gd
@@ -345,9 +345,10 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 				rotation_raw_fine = -1
 				rotation_has_value = true
 			if rotation_has_value and not rotation_ranges.is_empty():
-				resolved_rotation = _resolve_rotation_runtime(rotation_raw, rotation_ranges)
+				resolved_rotation = _resolve_rotation_runtime(rotation_raw_8bit, rotation_ranges, rotation_mode_window_from, rotation_mode_window_to)
 		var active_mode_from_8bit: int = int(active_range.get("mode_from_8bit", 0))
 		var active_mode_to_8bit: int = int(active_range.get("mode_to_8bit", 255))
+		var has_resolved_rotation_range: bool = bool(resolved_rotation.get("has_range", false))
 		var matched_range: Dictionary = resolved_rotation.get("range", {})
 		var rotation_matched_range_start: int = int(matched_range.get("dmx_start", -1))
 		var rotation_matched_range_end: int = int(matched_range.get("dmx_end", -1))
@@ -371,12 +372,12 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 			"rotation_physical_min": float(item.get("rotation_physical_min", 0.0)),
 			"rotation_physical_max": float(item.get("rotation_physical_max", 0.0)),
 			"has_rotation_physical_ranges": not rotation_ranges.is_empty(),
-			"has_rotation_physical_value": not resolved_rotation.is_empty(),
+			"has_rotation_physical_value": has_resolved_rotation_range,
 			"rotation_physical": float(resolved_rotation.get("rotation_speed_deg_per_sec", 0.0)),
 			"rotation_speed_deg_per_sec": float(resolved_rotation.get("rotation_speed_deg_per_sec", 0.0)),
 			"rotation_direction_sign": int(resolved_rotation.get("direction_sign", 0)),
-			"is_stop": bool(resolved_rotation.get("is_stop", false)),
-			"has_resolved_rotation_range": bool(resolved_rotation.get("has_range", false)),
+			"is_stop": bool(resolved_rotation.get("is_stop", true)),
+			"has_resolved_rotation_range": has_resolved_rotation_range,
 			"rotation_resolved_range": resolved_rotation.get("range", {}),
 			"rotation_source_channel": rotation_source_channel,
 			"rotation_raw_coarse": rotation_raw_coarse,
@@ -416,11 +417,27 @@ func _resolve_norm_from_active_range(raw_8bit: int, active_range: Dictionary) ->
 	return float(clamped_raw - dmx_from) / float(dmx_to - dmx_from)
 
 
-func _resolve_rotation_runtime(raw_8bit: int, ranges: Array) -> Dictionary:
+func _resolve_rotation_runtime(raw_8bit: int, ranges: Array, active_mode_from: int, active_mode_to: int) -> Dictionary:
+	var mode_from: int = active_mode_from
+	var mode_to: int = active_mode_to
+	if mode_to < mode_from:
+		var active_mode_swap: int = mode_from
+		mode_from = mode_to
+		mode_to = active_mode_swap
+
 	for item in ranges:
 		if item is not Dictionary:
 			continue
 		var range_data: Dictionary = item
+		var range_mode_from: int = int(range_data.get("mode_from_8bit", 0))
+		var range_mode_to: int = int(range_data.get("mode_to_8bit", 255))
+		if range_mode_to < range_mode_from:
+			var mode_swap_value: int = range_mode_from
+			range_mode_from = range_mode_to
+			range_mode_to = mode_swap_value
+		if range_mode_from > mode_to or range_mode_to < mode_from:
+			continue
+
 		var dmx_start: int = int(range_data.get("dmx_start", 0))
 		var dmx_end: int = int(range_data.get("dmx_end", dmx_start))
 		if dmx_end < dmx_start:
@@ -461,7 +478,7 @@ func _resolve_rotation_runtime(raw_8bit: int, ranges: Array) -> Dictionary:
 		"range": {},
 		"rotation_speed_deg_per_sec": 0.0,
 		"direction_sign": 0,
-		"is_stop": false,
+		"is_stop": true,
 	}
 
 

--- a/peraviz/scripts/dmx_fixture_runtime.gd
+++ b/peraviz/scripts/dmx_fixture_runtime.gd
@@ -299,6 +299,10 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 		if uses_range_rotation:
 			supports_rotation = true
 		var index_norm: float = -1.0
+		var index_raw: int = -1
+		var index_raw_8bit: int = -1
+		var index_raw_coarse: int = -1
+		var index_raw_fine: int = -1
 		var rotation_norm: float = -1.0
 		var rotation_raw: int = raw_8bit
 		var rotation_raw_coarse: int = raw_8bit
@@ -315,7 +319,16 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 		var rotation_ranges: Array = item.get("rotation_ranges", [])
 		var resolved_rotation: Dictionary = {}
 		if supports_index:
-			index_norm = _read_optional_control_norm(frame, int(item.get("index_channel_index_0", -1)), int(item.get("index_fine_channel_index_0", -1)), int(item.get("index_ultra_fine_channel_index_0", -1)))
+			var index_coarse_index: int = int(item.get("index_channel_index_0", -1))
+			var index_fine_index: int = int(item.get("index_fine_channel_index_0", -1))
+			var index_ultra_fine_index: int = int(item.get("index_ultra_fine_channel_index_0", -1))
+			var index_value: Dictionary = _read_optional_control_value(frame, index_coarse_index, index_fine_index, index_ultra_fine_index)
+			if not index_value.is_empty():
+				index_norm = clamp(float(index_value.get("norm", 0.0)), 0.0, 1.0)
+				index_raw = int(index_value.get("raw", 0))
+				index_raw_8bit = _resolve_raw_to_8bit(index_raw, int(index_value.get("resolution_bits", 8)))
+				index_raw_coarse = int(frame[index_coarse_index]) if _is_valid_channel_index(frame, index_coarse_index) else index_raw_8bit
+				index_raw_fine = int(frame[index_fine_index]) if _is_valid_channel_index(frame, index_fine_index) else -1
 			if index_norm < 0.0 and range_behavior == GOBO_BEHAVIOR_INDEX:
 				index_norm = _resolve_norm_from_active_range(raw_8bit, active_range)
 		if supports_rotation:
@@ -332,7 +345,17 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 					rotation_raw_coarse = int(frame[rotation_coarse_index]) if _is_valid_channel_index(frame, rotation_coarse_index) else rotation_raw_8bit
 					rotation_raw_fine = int(frame[rotation_fine_index]) if _is_valid_channel_index(frame, rotation_fine_index) else -1
 					rotation_has_value = true
-			if uses_range_rotation:
+			if not has_rotation_channel and has_index_channel and is_rotation_behavior and index_norm >= 0.0:
+				rotation_norm = index_norm
+				rotation_raw_8bit = index_raw_8bit if index_raw_8bit >= 0 else raw_8bit
+				rotation_raw = rotation_raw_8bit
+				rotation_source_channel = "index"
+				rotation_mode_window_from = int(active_range.get("mode_from_8bit", 0))
+				rotation_mode_window_to = int(active_range.get("mode_to_8bit", 255))
+				rotation_raw_coarse = index_raw_coarse if index_raw_coarse >= 0 else rotation_raw_8bit
+				rotation_raw_fine = index_raw_fine
+				rotation_has_value = true
+			if uses_range_rotation and not rotation_has_value:
 				rotation_norm = _resolve_norm_from_active_range(raw_8bit, active_range)
 				rotation_raw = raw_8bit
 				rotation_raw_8bit = raw_8bit

--- a/peraviz/scripts/dmx_fixture_runtime.gd
+++ b/peraviz/scripts/dmx_fixture_runtime.gd
@@ -305,8 +305,12 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 		var rotation_raw_fine: int = -1
 		var rotation_raw_8bit: int = raw_8bit
 		var rotation_source_channel: String = "select"
-		var rotation_mode_window_from: int = int(active_range.get("mode_from_8bit", 0))
-		var rotation_mode_window_to: int = int(active_range.get("mode_to_8bit", 255))
+		# Dedicated rotation channels should not inherit mode window limits from the
+		# active gobo select range, otherwise speed resolution may vary by slot.
+		# Keep a wide window by default and only scope to select-range mode windows
+		# when rotation is sourced from the select channel itself.
+		var rotation_mode_window_from: int = 0
+		var rotation_mode_window_to: int = 255
 		var rotation_has_value: bool = false
 		var rotation_ranges: Array = item.get("rotation_ranges", [])
 		var resolved_rotation: Dictionary = {}
@@ -333,6 +337,8 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 				rotation_raw = raw_8bit
 				rotation_raw_8bit = raw_8bit
 				rotation_source_channel = "select"
+				rotation_mode_window_from = int(active_range.get("mode_from_8bit", 0))
+				rotation_mode_window_to = int(active_range.get("mode_to_8bit", 255))
 				rotation_raw_coarse = raw_8bit
 				rotation_raw_fine = -1
 				rotation_has_value = true
@@ -341,6 +347,8 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 				rotation_raw = raw_8bit
 				rotation_raw_8bit = raw_8bit
 				rotation_source_channel = "select"
+				rotation_mode_window_from = int(active_range.get("mode_from_8bit", 0))
+				rotation_mode_window_to = int(active_range.get("mode_to_8bit", 255))
 				rotation_raw_coarse = raw_8bit
 				rotation_raw_fine = -1
 				rotation_has_value = true


### PR DESCRIPTION
### Motivation
- Continuous gobo rotation speeds were not following GDTF physical ranges because `ModeFrom/ModeTo` were being (mis)used as the ChannelFunction DMX bounds instead of `DMXFrom/DMXTo`.
- ChannelSet `PhysicalFrom/PhysicalTo` can be omitted and should inherit physics from the parent ChannelFunction, otherwise native speed/direction is lost.
- Runtime logic marked fixtures as having native rotation speed even when no physical rotation range matched, forcing incorrect fallback behavior.

### Description
- In `peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp` changed function parsing to use `DMXFrom`/`DMXTo` for ChannelFunction DMX windows, preserved `ModeFrom/ModeTo` as separate mode-window values, and propagated mode windows into produced `FixtureGoboRotationRange` entries so mode-dependent ranges can be filtered at runtime.
- In `consume_gobo_rotation_channel_sets` added a fallback path that builds a single rotation range from ChannelFunction `PhysicalFrom/PhysicalTo` when ChannelSets lack physical values, including `is_stop_range` detection, and set `mode_from_8bit`/`mode_to_8bit` on ranges.
- Broadened `matches_gobo_rotation_attribute` token matching to include additional naming variants (`rotation`, `wheelrotation`, `posrot`) to detect rotation channels more robustly.
- In `peraviz/scripts/dmx_fixture_runtime.gd` changed runtime resolution to use the explicit `rotation_raw_8bit`, to call `_resolve_rotation_runtime(raw_8bit, ranges, active_mode_from, active_mode_to)`, to only mark `has_rotation_physical_value` when a real physical range matched (`has_range == true`), and to treat unresolved rotation as `is_stop=true` for safer debug/default behavior.
- `_resolve_rotation_runtime` now filters candidate ranges by mode-window overlap before matching DMX ranges and otherwise keeps the existing interpolation and sign semantics from `PhysicalFrom/PhysicalTo`.

Files changed: `peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp`, `peraviz/scripts/dmx_fixture_runtime.gd`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b883ca00e88324beaa076bd2d1ea4f)