### PR TITLE
Sanitize invalid MVR archive file names before validation

### DIFF
--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -162,15 +162,36 @@ static std::string EnsureUniqueArchivePath(const std::string &proposed,
 static std::string SanitizeArchiveFileName(const std::string &input,
                                            const std::string &fallbackName) {
   constexpr size_t kMaxArchiveFileNameLength = 120;
+  auto sanitizeSingleFileName = [](std::string fileName,
+                                   const std::string &fallback) {
+    if (fileName.empty())
+      fileName = fallback;
+
+    for (char &ch : fileName) {
+      const unsigned char uch = static_cast<unsigned char>(ch);
+      if (uch < 32 || ch == ':' || ch == '\\' || ch == '/' || ch == '*' ||
+          ch == '?' || ch == '"' || ch == '<' || ch == '>' || ch == '|') {
+        ch = '_';
+      }
+    }
+
+    if (fileName.empty())
+      fileName = fallback;
+    return fileName;
+  };
+
   std::string candidate = TrimAscii(input);
   std::replace(candidate.begin(), candidate.end(), '\\', '/');
   if (candidate.empty())
-    return TruncateFileNamePreservingExtension(fallbackName, kMaxArchiveFileNameLength);
+    return TruncateFileNamePreservingExtension(
+        sanitizeSingleFileName("", fallbackName), kMaxArchiveFileNameLength);
 
   const std::string fileName = fs::path(candidate).filename().generic_string();
   if (!fileName.empty())
-    return TruncateFileNamePreservingExtension(fileName, kMaxArchiveFileNameLength);
-  return TruncateFileNamePreservingExtension(fallbackName, kMaxArchiveFileNameLength);
+    return TruncateFileNamePreservingExtension(
+        sanitizeSingleFileName(fileName, fallbackName), kMaxArchiveFileNameLength);
+  return TruncateFileNamePreservingExtension(
+      sanitizeSingleFileName("", fallbackName), kMaxArchiveFileNameLength);
 }
 
 static std::string BuildTrussGdtfArchiveName(const Truss &truss) {


### PR DESCRIPTION
### Motivation
- Exporting MVR archives could fail when source file names (e.g. `GDTFSpec`) contained characters invalid for archive-relative names (such as `: \ / * ? " < > |` or control chars), causing validation/write errors during save.
- Centralize and harden filename normalization so all exporter code paths that use `SanitizeArchiveFileName(...)` produce safe archive entry names.

### Description
- Updated `mvr/mvrexporter.cpp` to replace invalid characters and control ASCII chars with `_` before truncation inside `SanitizeArchiveFileName(...)` by adding an internal `sanitizeSingleFileName` helper lambda. 
- Ensures empty inputs fall back to the provided `fallbackName` and preserves extension-aware truncation via `TruncateFileNamePreservingExtension(...)`.
- Change is scoped to filename normalization used for GDTF and other resource export paths and does not alter higher-level exporter logic.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded (`OK`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baa607757c8324bd9b090500a439a2)