### PR TITLE
Fix GDTF gobo rotation physical value interpolation

### DIFF
--- a/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
@@ -583,7 +583,11 @@ void consume_gobo_rotation_channel_sets(tinyxml2::XMLElement *channel_function,
         const bool has_physical_to = parse_float_attr_ci(channel_set, "PhysicalTo", "physicalto", physical_to);
         const bool has_physical = has_physical_from && has_physical_to;
 
-        const std::string set_name = read_attr_ci(channel_set, "Name", "name");
+        const char *name_attr = channel_set->Attribute("Name");
+        if (!name_attr) {
+            name_attr = channel_set->Attribute("name");
+        }
+        const std::string set_name = name_attr ? name_attr : "";
         parsed_ranges.push_back({dmx_start, dmx_end, physical_from, physical_to, has_physical, set_name});
     }
 

--- a/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
@@ -538,25 +538,27 @@ void consume_gobo_rotation_channel_sets(tinyxml2::XMLElement *channel_function,
             return std::clamp(relative_value, clamped_function_from, clamped_function_to);
         };
 
+    float function_physical_from = 0.0F;
+    float function_physical_to = 0.0F;
+    const bool has_function_physical_from =
+        parse_float_attr_ci(channel_function, "PhysicalFrom", "physicalfrom", function_physical_from);
+    const bool has_function_physical_to =
+        parse_float_attr_ci(channel_function, "PhysicalTo", "physicalto", function_physical_to);
+    const bool has_function_physical = has_function_physical_from && has_function_physical_to;
+
     struct ParsedRange {
         int dmx_start = 0;
         int dmx_end = -1;
         float physical_from = 0.0F;
         float physical_to = 0.0F;
+        bool has_physical = false;
+        std::string name;
     };
     std::vector<ParsedRange> parsed_ranges;
 
     for (tinyxml2::XMLElement *channel_set = channel_function->FirstChildElement(); channel_set;
          channel_set = channel_set->NextSiblingElement()) {
         if (lower_ascii(channel_set->Name()) != "channelset") {
-            continue;
-        }
-
-        float physical_from = 0.0F;
-        float physical_to = 0.0F;
-        const bool has_physical_from = parse_float_attr_ci(channel_set, "PhysicalFrom", "physicalfrom", physical_from);
-        const bool has_physical_to = parse_float_attr_ci(channel_set, "PhysicalTo", "physicalto", physical_to);
-        if (!has_physical_from || !has_physical_to) {
             continue;
         }
 
@@ -575,17 +577,18 @@ void consume_gobo_rotation_channel_sets(tinyxml2::XMLElement *channel_function,
         }
         const int dmx_end = raw_dmx_to < 0 ? -1 : resolve_channel_set_dmx(raw_dmx_to);
 
-        parsed_ranges.push_back({dmx_start, dmx_end, physical_from, physical_to});
+        float physical_from = 0.0F;
+        float physical_to = 0.0F;
+        const bool has_physical_from = parse_float_attr_ci(channel_set, "PhysicalFrom", "physicalfrom", physical_from);
+        const bool has_physical_to = parse_float_attr_ci(channel_set, "PhysicalTo", "physicalto", physical_to);
+        const bool has_physical = has_physical_from && has_physical_to;
+
+        const std::string set_name = read_attr_ci(channel_set, "Name", "name");
+        parsed_ranges.push_back({dmx_start, dmx_end, physical_from, physical_to, has_physical, set_name});
     }
 
     if (parsed_ranges.empty()) {
-        float function_physical_from = 0.0F;
-        float function_physical_to = 0.0F;
-        const bool has_function_physical_from =
-            parse_float_attr_ci(channel_function, "PhysicalFrom", "physicalfrom", function_physical_from);
-        const bool has_function_physical_to =
-            parse_float_attr_ci(channel_function, "PhysicalTo", "physicalto", function_physical_to);
-        if (!has_function_physical_from || !has_function_physical_to) {
+        if (!has_function_physical) {
             return;
         }
 
@@ -622,6 +625,42 @@ void consume_gobo_rotation_channel_sets(tinyxml2::XMLElement *channel_function,
         row.dmx_end = std::clamp(row.dmx_end, clamped_function_from, clamped_function_to);
         if (row.dmx_end < row.dmx_start) {
             std::swap(row.dmx_start, row.dmx_end);
+        }
+
+        // Fill in proportional physical values for ChannelSets that don't carry
+        // their own, using the parent ChannelFunction's physical range as reference.
+        if (!row.has_physical && has_function_physical) {
+            const std::string lower_name = lower_ascii(row.name);
+            const bool is_named_stop = lower_name.find("no rotation") != std::string::npos ||
+                                       lower_name.find("stop") != std::string::npos;
+            if (is_named_stop) {
+                row.physical_from = 0.0F;
+                row.physical_to = 0.0F;
+            } else {
+                const float fn_range =
+                    static_cast<float>(clamped_function_to - clamped_function_from);
+                if (fn_range > 0.0F) {
+                    const float t_from = std::clamp(
+                        static_cast<float>(row.dmx_start - clamped_function_from) / fn_range,
+                        0.0F, 1.0F);
+                    const float t_to = std::clamp(
+                        static_cast<float>(row.dmx_end - clamped_function_from) / fn_range,
+                        0.0F, 1.0F);
+                    row.physical_from = function_physical_from +
+                        t_from * (function_physical_to - function_physical_from);
+                    row.physical_to = function_physical_from +
+                        t_to * (function_physical_to - function_physical_from);
+                } else {
+                    row.physical_from = function_physical_from;
+                    row.physical_to = function_physical_to;
+                }
+            }
+            row.has_physical = true;
+        }
+
+        if (!row.has_physical) {
+            // No physical data available at all; skip this range.
+            continue;
         }
 
         peraviz::dmx::FixtureGoboRotationRange range;
@@ -1101,18 +1140,39 @@ void consume_gobo_channel_sets(tinyxml2::XMLElement *channel_function,
             float rotation_physical_from = row.physical_from;
             float rotation_physical_to = row.physical_to;
             bool has_rotation_physical = row.has_physical;
-            if (!has_rotation_physical && has_function_physical) {
-                rotation_physical_from = function_physical_from;
-                rotation_physical_to = function_physical_to;
-                has_rotation_physical = true;
-            }
 
+            // Named stop ranges take priority: treat them as zero-speed regardless of
+            // any function-level physical values.
             const std::string lower_name = lower_ascii(row.name);
             const bool is_named_stop = lower_name.find("no rotation") != std::string::npos ||
                                        lower_name.find("stop") != std::string::npos;
             if (!has_rotation_physical && is_named_stop) {
                 rotation_physical_from = 0.0F;
                 rotation_physical_to = 0.0F;
+                has_rotation_physical = true;
+            } else if (!has_rotation_physical && has_function_physical) {
+                // Compute proportional physical values for this ChannelSet's position
+                // within the parent ChannelFunction's DMX range.  Assigning the full
+                // function physical range to every sub-range is wrong: GDScript then
+                // interpolates each sub-range against the full physical span, producing
+                // incorrect speeds and reversed directions for split CCW/CW bands.
+                const float fn_range =
+                    static_cast<float>(clamped_function_to - clamped_function_from);
+                if (fn_range > 0.0F) {
+                    const float t_from = std::clamp(
+                        static_cast<float>(row.dmx_from - clamped_function_from) / fn_range,
+                        0.0F, 1.0F);
+                    const float t_to = std::clamp(
+                        static_cast<float>(row.dmx_to - clamped_function_from) / fn_range,
+                        0.0F, 1.0F);
+                    rotation_physical_from = function_physical_from +
+                        t_from * (function_physical_to - function_physical_from);
+                    rotation_physical_to = function_physical_from +
+                        t_to * (function_physical_to - function_physical_from);
+                } else {
+                    rotation_physical_from = function_physical_from;
+                    rotation_physical_to = function_physical_to;
+                }
                 has_rotation_physical = true;
             }
 


### PR DESCRIPTION
## Summary
This PR fixes the calculation of physical values for gobo rotation channel sets that lack explicit physical range definitions. Previously, the code would assign the entire parent ChannelFunction's physical range to each sub-range, causing incorrect speed calculations and reversed directions for split CCW/CW bands.

## Key Changes
- **Refactored ParsedRange struct**: Added `has_physical` flag and `name` field to track whether physical values are explicitly defined and to enable name-based detection of stop ranges.

- **Moved function-level physical parsing**: Extracted parsing of ChannelFunction's PhysicalFrom/PhysicalTo attributes to the beginning of the function, making them available for fallback calculations.

- **Implemented proportional interpolation**: When a ChannelSet lacks explicit physical values, the code now computes proportional physical values based on the ChannelSet's position within the parent ChannelFunction's DMX range, rather than assigning the full function range to each sub-range.

- **Added named stop detection**: Channel sets with names containing "no rotation" or "stop" are now correctly identified and assigned zero physical values, taking priority over function-level physical ranges.

- **Applied fix to both rotation functions**: The proportional interpolation logic is now consistently applied in both `consume_gobo_rotation_channel_sets()` and `consume_gobo_channel_sets()` functions.

## Implementation Details
The proportional interpolation uses the following approach:
1. Calculate the normalized position (0.0-1.0) of each channel set's DMX range within the parent function's DMX range
2. Map this normalized position to the parent function's physical range
3. This ensures that split CCW/CW bands and other multi-range configurations maintain correct relative speeds and directions

https://claude.ai/code/session_01Harje2iLAQuu8omN5FSwGz