### PR TITLE
Improve GDTF gobo rotation detection and physical value interpolation

### DIFF
--- a/peraviz/docs/GDTF_GOBO_CONTROL.md
+++ b/peraviz/docs/GDTF_GOBO_CONTROL.md
@@ -49,3 +49,30 @@ Index and rotation are treated as different semantics:
 This keeps backward compatibility for fixtures without explicit
 `Gobo(n)Pos`/`Gobo(n)PosRotate` channels while enabling dedicated controls when
 present.
+
+## Rotation behavior detection
+
+The GDTF parser detects rotation behavior from ChannelSet and ChannelFunction
+names.  The following keywords trigger rotation classification:
+
+- Explicit: `spin`, `rotation`, `rotate`, `posrotate`, `wheelspin`
+- Direction: `cw`, `ccw`, `clockwise`, `counterclockwise` (and variants)
+- Stop: `no rotation`, `stop`
+
+When a ChannelFunction attribute indicates rotation (e.g. `Gobo1SelectSpin`)
+but the function Name is generic, ChannelSets inherit the rotation behavior
+from the attribute.
+
+## Physical speed interpolation
+
+When ChannelSets lack explicit `PhysicalFrom`/`PhysicalTo` values:
+
+1. Named stop ranges always get physical 0/0.
+2. If the parent ChannelFunction has physical values and spans both CW and CCW
+   (crosses zero), direction-aware clamping is applied: each sub-range's
+   proportional physical values are clamped to the correct direction half
+   based on the ChannelSet name (CW → negative half, CCW → positive half).
+3. Otherwise, proportional interpolation within the parent function's physical
+   range is used.
+4. As a last resort, speed and direction are inferred from the ChannelSet name
+   using default angular speed values (20–540 deg/s).

--- a/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
@@ -836,6 +836,80 @@ void consume_gobo_rotation_channel_sets(tinyxml2::XMLElement *channel_function,
             // No physical data available at all; skip this range.
             continue;
         }
+    }
+
+    // Post-process: detect bidirectional rotation channels whose ChannelSet
+    // physical values are all same-sign (commonly all-positive).  Many GDTF
+    // files encode the first half as one direction and the second half as the
+    // other, but only use unsigned angular speed values.  When a stop range
+    // divides the channel and all non-stop physical values share the same sign
+    // we negate the first half to restore the correct CW/CCW direction.
+    {
+        int first_stop_range_index = -1;
+        bool has_positive = false;
+        bool has_negative = false;
+        for (size_t ri = 0; ri < parsed_ranges.size(); ++ri) {
+            const ParsedRange &row = parsed_ranges[ri];
+            if (!row.has_physical) {
+                continue;
+            }
+            const bool is_stop =
+                std::fabs(row.physical_from) < 0.0001F &&
+                std::fabs(row.physical_to) < 0.0001F;
+            if (is_stop) {
+                if (first_stop_range_index < 0 && ri > 0) {
+                    first_stop_range_index = static_cast<int>(ri);
+                }
+                continue;
+            }
+            if (row.physical_from > 0.0001F || row.physical_to > 0.0001F) {
+                has_positive = true;
+            }
+            if (row.physical_from < -0.0001F || row.physical_to < -0.0001F) {
+                has_negative = true;
+            }
+        }
+        // Only apply correction when ALL non-stop physical values are same-sign
+        // AND there is a stop range dividing the channel into two halves.
+        if (first_stop_range_index > 0 && has_positive && !has_negative) {
+            // All positive -- negate the first half (before the stop range).
+            for (int ri = 0; ri < first_stop_range_index; ++ri) {
+                ParsedRange &row = parsed_ranges[static_cast<size_t>(ri)];
+                if (!row.has_physical) {
+                    continue;
+                }
+                const bool is_stop =
+                    std::fabs(row.physical_from) < 0.0001F &&
+                    std::fabs(row.physical_to) < 0.0001F;
+                if (!is_stop) {
+                    row.physical_from = -row.physical_from;
+                    row.physical_to = -row.physical_to;
+                }
+            }
+        } else if (first_stop_range_index > 0 && has_negative && !has_positive) {
+            // All negative -- negate the second half (after the stop range).
+            for (size_t ri = static_cast<size_t>(first_stop_range_index) + 1;
+                 ri < parsed_ranges.size(); ++ri) {
+                ParsedRange &row = parsed_ranges[ri];
+                if (!row.has_physical) {
+                    continue;
+                }
+                const bool is_stop =
+                    std::fabs(row.physical_from) < 0.0001F &&
+                    std::fabs(row.physical_to) < 0.0001F;
+                if (!is_stop) {
+                    row.physical_from = -row.physical_from;
+                    row.physical_to = -row.physical_to;
+                }
+            }
+        }
+    }
+
+    for (size_t index = 0; index < parsed_ranges.size(); ++index) {
+        const ParsedRange &row = parsed_ranges[index];
+        if (!row.has_physical) {
+            continue;
+        }
 
         peraviz::dmx::FixtureGoboRotationRange range;
         range.dmx_from = row.dmx_start;
@@ -1231,6 +1305,10 @@ void consume_gobo_channel_sets(tinyxml2::XMLElement *channel_function,
         return std::clamp(relative_value, clamped_function_from, clamped_function_to);
     };
 
+    // Track where new rotation ranges start so the post-processing sign
+    // correction only applies to the ranges added by this ChannelFunction.
+    const size_t rotation_range_start_index = out_wheel.rotation_ranges.size();
+
     int last_slot_index = -1;
     if (!out_wheel.ranges.empty()) {
         last_slot_index = out_wheel.ranges.back().slot_index;
@@ -1408,6 +1486,52 @@ void consume_gobo_channel_sets(tinyxml2::XMLElement *channel_function,
                 rotation_range.is_stop_range = std::fabs(rotation_physical_from) < 0.0001F && std::fabs(rotation_physical_to) < 0.0001F;
                 rotation_range.is_rotation_channel_range = false;
                 out_wheel.rotation_ranges.push_back(rotation_range);
+            }
+        }
+    }
+
+    // Post-process: apply bidirectional sign correction to the rotation ranges
+    // that were just added from this gobo select ChannelFunction.  Same logic
+    // as in consume_gobo_rotation_channel_sets – when all non-stop physical
+    // values share the same sign and there is a stop range dividing the
+    // channel, negate the first half to restore CW/CCW direction.
+    if (rotation_range_start_index < out_wheel.rotation_ranges.size()) {
+        int first_stop_range_index = -1;
+        bool has_positive = false;
+        bool has_negative = false;
+        for (size_t ri = rotation_range_start_index; ri < out_wheel.rotation_ranges.size(); ++ri) {
+            const auto &rr = out_wheel.rotation_ranges[ri];
+            if (rr.is_stop_range) {
+                if (first_stop_range_index < 0 &&
+                    ri > rotation_range_start_index) {
+                    first_stop_range_index = static_cast<int>(ri);
+                }
+                continue;
+            }
+            if (rr.physical_from > 0.0001F || rr.physical_to > 0.0001F) {
+                has_positive = true;
+            }
+            if (rr.physical_from < -0.0001F || rr.physical_to < -0.0001F) {
+                has_negative = true;
+            }
+        }
+        if (first_stop_range_index > 0 && has_positive && !has_negative) {
+            for (size_t ri = rotation_range_start_index;
+                 ri < static_cast<size_t>(first_stop_range_index); ++ri) {
+                auto &rr = out_wheel.rotation_ranges[ri];
+                if (!rr.is_stop_range) {
+                    rr.physical_from = -rr.physical_from;
+                    rr.physical_to = -rr.physical_to;
+                }
+            }
+        } else if (first_stop_range_index > 0 && has_negative && !has_positive) {
+            for (size_t ri = static_cast<size_t>(first_stop_range_index) + 1;
+                 ri < out_wheel.rotation_ranges.size(); ++ri) {
+                auto &rr = out_wheel.rotation_ranges[ri];
+                if (!rr.is_stop_range) {
+                    rr.physical_from = -rr.physical_from;
+                    rr.physical_to = -rr.physical_to;
+                }
             }
         }
     }

--- a/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_dimmer_resolver.cpp
@@ -334,6 +334,60 @@ bool matches_gobo_rotation_attribute(const std::string &leaf) {
            leaf.find("rotate") != std::string::npos;
 }
 
+bool name_indicates_continuous_rotation(const std::string &lower_name) {
+    if (lower_name.find("no rotation") != std::string::npos ||
+        lower_name.find("no spin") != std::string::npos) {
+        return true;
+    }
+    if (lower_name.find("spin") != std::string::npos ||
+        lower_name.find("rotation") != std::string::npos ||
+        lower_name.find("rotate") != std::string::npos ||
+        lower_name.find("posrotate") != std::string::npos ||
+        lower_name.find("wheelspin") != std::string::npos) {
+        return true;
+    }
+    if (lower_name.find("counterclockwise") != std::string::npos ||
+        lower_name.find("counter clockwise") != std::string::npos ||
+        lower_name.find("counter-clockwise") != std::string::npos ||
+        lower_name.find("anticlockwise") != std::string::npos ||
+        lower_name.find("anti clockwise") != std::string::npos ||
+        lower_name.find("anti-clockwise") != std::string::npos) {
+        return true;
+    }
+    if (lower_name.find("clockwise") != std::string::npos) {
+        return true;
+    }
+    if (lower_name.find("ccw") != std::string::npos) {
+        return true;
+    }
+    // Detect standalone "cw" (not part of "ccw" or other words).  Accept "cw"
+    // preceded by a space/start and followed by a space/end/punctuation.
+    {
+        size_t search_pos = 0;
+        while (search_pos < lower_name.size()) {
+            const size_t pos = lower_name.find("cw", search_pos);
+            if (pos == std::string::npos) {
+                break;
+            }
+            // Reject if preceded by 'c' (part of "ccw").
+            if (pos > 0 && lower_name[pos - 1] == 'c') {
+                search_pos = pos + 2;
+                continue;
+            }
+            // Accept if preceded by start-of-string, space, or punctuation.
+            const bool ok_before = (pos == 0) ||
+                !std::isalnum(static_cast<unsigned char>(lower_name[pos - 1]));
+            const bool ok_after = (pos + 2 >= lower_name.size()) ||
+                !std::isalnum(static_cast<unsigned char>(lower_name[pos + 2]));
+            if (ok_before && ok_after) {
+                return true;
+            }
+            search_pos = pos + 2;
+        }
+    }
+    return false;
+}
+
 peraviz::dmx::FixtureGoboRangeBehavior parse_gobo_range_behavior(const std::string &channel_set_name) {
     const std::string lower_name = lower_ascii(channel_set_name);
     if (lower_name.find("shake") != std::string::npos) {
@@ -341,11 +395,7 @@ peraviz::dmx::FixtureGoboRangeBehavior parse_gobo_range_behavior(const std::stri
     }
     // Keep explicit spin/rotation detection ahead of generic "pos" matching,
     // because names like "Gobo1PosRotate" include both tokens.
-    if (lower_name.find("posrotate") != std::string::npos ||
-        lower_name.find("wheelspin") != std::string::npos ||
-        lower_name.find("spin") != std::string::npos ||
-        lower_name.find("rotation") != std::string::npos ||
-        lower_name.find("rotate") != std::string::npos) {
+    if (name_indicates_continuous_rotation(lower_name)) {
         return peraviz::dmx::FixtureGoboRangeBehavior::kRotation;
     }
     // Prioritize explicit index/position semantics over generic rotate tokens,
@@ -712,22 +762,66 @@ void consume_gobo_rotation_channel_sets(tinyxml2::XMLElement *channel_function,
                 row.physical_from = 0.0F;
                 row.physical_to = 0.0F;
             } else {
-                const float fn_range =
-                    static_cast<float>(clamped_function_to - clamped_function_from);
-                if (fn_range > 0.0F) {
-                    const float t_from = std::clamp(
-                        static_cast<float>(row.dmx_start - clamped_function_from) / fn_range,
-                        0.0F, 1.0F);
-                    const float t_to = std::clamp(
-                        static_cast<float>(row.dmx_end - clamped_function_from) / fn_range,
-                        0.0F, 1.0F);
-                    row.physical_from = function_physical_from +
-                        t_from * (function_physical_to - function_physical_from);
-                    row.physical_to = function_physical_from +
-                        t_to * (function_physical_to - function_physical_from);
+                // When the ChannelSet name indicates a clear direction (CW/CCW),
+                // use direction-aware physical values from the parent function's
+                // range instead of blind proportional interpolation.  This prevents
+                // the CCW sub-range from starting with CW (negative) physical
+                // values when the function spans CW-Stop-CCW.
+                const bool fn_physical_spans_zero =
+                    (function_physical_from < 0.0F && function_physical_to > 0.0F) ||
+                    (function_physical_from > 0.0F && function_physical_to < 0.0F);
+                float inferred_from = 0.0F;
+                float inferred_to = 0.0F;
+                const bool has_name_inference = infer_rotation_physical_from_name(
+                    row.name, inferred_from, inferred_to);
+                if (fn_physical_spans_zero && has_name_inference) {
+                    // Determine direction sign from the inferred values.
+                    const float inferred_sign = (std::fabs(inferred_from) > std::fabs(inferred_to))
+                        ? (inferred_from > 0.0F ? 1.0F : -1.0F)
+                        : (inferred_to > 0.0F ? 1.0F : -1.0F);
+                    // Select the matching half of the parent function's physical range.
+                    const float fn_min = std::min(function_physical_from, function_physical_to);
+                    const float fn_max = std::max(function_physical_from, function_physical_to);
+                    // Determine sub-range position within this half.
+                    const float fn_range =
+                        static_cast<float>(clamped_function_to - clamped_function_from);
+                    const float t_from = fn_range > 0.0F
+                        ? std::clamp(static_cast<float>(row.dmx_start - clamped_function_from) / fn_range, 0.0F, 1.0F)
+                        : 0.0F;
+                    const float t_to = fn_range > 0.0F
+                        ? std::clamp(static_cast<float>(row.dmx_end - clamped_function_from) / fn_range, 0.0F, 1.0F)
+                        : 0.0F;
+                    // Proportional values from the full function.
+                    float prop_from = function_physical_from + t_from * (function_physical_to - function_physical_from);
+                    float prop_to = function_physical_from + t_to * (function_physical_to - function_physical_from);
+                    // Clamp to the correct direction half.
+                    if (inferred_sign > 0.0F) {
+                        prop_from = std::clamp(prop_from, 0.0F, fn_max);
+                        prop_to = std::clamp(prop_to, 0.0F, fn_max);
+                    } else {
+                        prop_from = std::clamp(prop_from, fn_min, 0.0F);
+                        prop_to = std::clamp(prop_to, fn_min, 0.0F);
+                    }
+                    row.physical_from = prop_from;
+                    row.physical_to = prop_to;
                 } else {
-                    row.physical_from = function_physical_from;
-                    row.physical_to = function_physical_to;
+                    const float fn_range =
+                        static_cast<float>(clamped_function_to - clamped_function_from);
+                    if (fn_range > 0.0F) {
+                        const float t_from = std::clamp(
+                            static_cast<float>(row.dmx_start - clamped_function_from) / fn_range,
+                            0.0F, 1.0F);
+                        const float t_to = std::clamp(
+                            static_cast<float>(row.dmx_end - clamped_function_from) / fn_range,
+                            0.0F, 1.0F);
+                        row.physical_from = function_physical_from +
+                            t_from * (function_physical_to - function_physical_from);
+                        row.physical_to = function_physical_from +
+                            t_to * (function_physical_to - function_physical_from);
+                    } else {
+                        row.physical_from = function_physical_from;
+                        row.physical_to = function_physical_to;
+                    }
                 }
             }
             row.has_physical = true;
@@ -1077,8 +1171,19 @@ void consume_gobo_channel_sets(tinyxml2::XMLElement *channel_function,
 
     out_wheel.wheel_name = wheel_name;
     const std::string function_name = read_attr_ci(channel_function, "Name", "name");
-    const peraviz::dmx::FixtureGoboRangeBehavior function_behavior_hint =
+    peraviz::dmx::FixtureGoboRangeBehavior function_behavior_hint =
         parse_gobo_range_behavior(function_name);
+    // Also check the ChannelFunction Attribute for rotation semantics.
+    // GoboSelectSpin-type attributes clearly indicate rotation behavior even
+    // when the function Name is generic (e.g. "Gobo 1").
+    if (function_behavior_hint == peraviz::dmx::FixtureGoboRangeBehavior::kFixed) {
+        const std::string function_attribute = lower_ascii(read_attr_ci(channel_function, "Attribute", "attribute"));
+        const peraviz::dmx::FixtureGoboRangeBehavior attribute_hint =
+            parse_gobo_range_behavior(function_attribute);
+        if (attribute_hint != peraviz::dmx::FixtureGoboRangeBehavior::kFixed) {
+            function_behavior_hint = attribute_hint;
+        }
+    }
 
     const std::vector<int> &known_slot_order = wheel_it->second.declared_slot_order;
     std::unordered_set<int> known_slots = wheel_it->second.declared_slots;
@@ -1232,13 +1337,42 @@ void consume_gobo_channel_sets(tinyxml2::XMLElement *channel_function,
                 has_rotation_physical = true;
             } else if (!has_rotation_physical && has_function_physical) {
                 // Compute proportional physical values for this ChannelSet's position
-                // within the parent ChannelFunction's DMX range.  Assigning the full
-                // function physical range to every sub-range is wrong: GDScript then
-                // interpolates each sub-range against the full physical span, producing
-                // incorrect speeds and reversed directions for split CCW/CW bands.
+                // within the parent ChannelFunction's DMX range.  When the function's
+                // physical range spans zero (CW-to-CCW), use direction-aware clamping
+                // so that each sub-range stays in the correct direction half.
+                const bool fn_physical_spans_zero =
+                    (function_physical_from < 0.0F && function_physical_to > 0.0F) ||
+                    (function_physical_from > 0.0F && function_physical_to < 0.0F);
+                float inferred_from = 0.0F;
+                float inferred_to = 0.0F;
+                const bool has_name_inference = infer_rotation_physical_from_name(
+                    row.name, inferred_from, inferred_to);
                 const float fn_range =
                     static_cast<float>(clamped_function_to - clamped_function_from);
-                if (fn_range > 0.0F) {
+                if (fn_physical_spans_zero && has_name_inference) {
+                    const float inferred_sign = (std::fabs(inferred_from) > std::fabs(inferred_to))
+                        ? (inferred_from > 0.0F ? 1.0F : -1.0F)
+                        : (inferred_to > 0.0F ? 1.0F : -1.0F);
+                    const float fn_min = std::min(function_physical_from, function_physical_to);
+                    const float fn_max = std::max(function_physical_from, function_physical_to);
+                    const float t_from = fn_range > 0.0F
+                        ? std::clamp(static_cast<float>(row.dmx_from - clamped_function_from) / fn_range, 0.0F, 1.0F)
+                        : 0.0F;
+                    const float t_to = fn_range > 0.0F
+                        ? std::clamp(static_cast<float>(row.dmx_to - clamped_function_from) / fn_range, 0.0F, 1.0F)
+                        : 0.0F;
+                    float prop_from = function_physical_from + t_from * (function_physical_to - function_physical_from);
+                    float prop_to = function_physical_from + t_to * (function_physical_to - function_physical_from);
+                    if (inferred_sign > 0.0F) {
+                        prop_from = std::clamp(prop_from, 0.0F, fn_max);
+                        prop_to = std::clamp(prop_to, 0.0F, fn_max);
+                    } else {
+                        prop_from = std::clamp(prop_from, fn_min, 0.0F);
+                        prop_to = std::clamp(prop_to, fn_min, 0.0F);
+                    }
+                    rotation_physical_from = prop_from;
+                    rotation_physical_to = prop_to;
+                } else if (fn_range > 0.0F) {
                     const float t_from = std::clamp(
                         static_cast<float>(row.dmx_from - clamped_function_from) / fn_range,
                         0.0F, 1.0F);

--- a/peraviz/scripts/dmx_fixture_runtime.gd
+++ b/peraviz/scripts/dmx_fixture_runtime.gd
@@ -284,7 +284,12 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 		var is_rotation_behavior: bool = range_behavior == GOBO_BEHAVIOR_ROTATION or range_behavior == GOBO_BEHAVIOR_SHAKE
 		var uses_range_rotation: bool = is_rotation_behavior and not has_rotation_channel
 		var supports_index: bool = (range_behavior == GOBO_BEHAVIOR_INDEX) or (has_index_channel and not is_rotation_behavior)
-		var supports_rotation: bool = is_rotation_behavior or (has_rotation_channel and range_behavior != GOBO_BEHAVIOR_INDEX)
+		# A wheel supports rotation when: the gobo select says rotation/shake,
+		# OR when a dedicated rotation channel exists (regardless of the select
+		# channel behavior – the mode-master filter in _resolve_rotation_runtime
+		# will decide whether rotation ranges are applicable for the current
+		# gobo selection).
+		var supports_rotation: bool = is_rotation_behavior or has_rotation_channel
 		var index_norm: float = -1.0
 		var index_raw: int = -1
 		var index_raw_8bit: int = -1
@@ -315,7 +320,14 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 
 		var rotation_value_available: bool = false
 		var rotation_value_norm: float = -1.0
-		if has_rotation_channel and (supports_rotation or (supports_index and not has_index_channel)):
+		# Always read the dedicated rotation channel when it exists.  The mode-
+		# master filter inside _resolve_rotation_runtime will decide whether
+		# the resolved rotation range is applicable for the current gobo slot.
+		# Previously, this read was gated on supports_rotation which depended
+		# on the gobo select behavior, causing rotation_raw_8bit to keep the
+		# gobo select value and making the rotation speed depend on which gobo
+		# was selected instead of the rotation fader position.
+		if has_rotation_channel:
 			var rotation_coarse_index: int = int(item.get("rotation_channel_index_0", -1))
 			var rotation_fine_index: int = int(item.get("rotation_fine_channel_index_0", -1))
 			var rotation_ultra_fine_index: int = int(item.get("rotation_ultra_fine_channel_index_0", -1))
@@ -340,7 +352,7 @@ func _build_runtime_gobo_bindings(binding: Dictionary, frame: PackedByteArray) -
 				index_norm = _resolve_norm_from_active_range(raw_8bit, active_range)
 
 		if supports_rotation:
-			if has_rotation_channel and rotation_value_available:
+			if rotation_value_available:
 				rotation_has_value = true
 			elif not has_rotation_channel and has_index_channel and is_rotation_behavior and index_norm >= 0.0:
 				rotation_raw_8bit = index_raw_8bit if index_raw_8bit >= 0 else raw_8bit
@@ -457,19 +469,33 @@ func _resolve_rotation_runtime(raw_8bit: int, control_norm: float, ranges: Array
 				continue
 
 			var is_stop: bool = bool(range_data.get("is_stop_range", false))
+			var physical_from: float = float(range_data.get("physical_from", 0.0))
+			var physical_to: float = float(range_data.get("physical_to", 0.0))
 			var speed_deg_per_sec: float = 0.0
 			if not is_stop:
 				if dmx_to <= dmx_from:
-					speed_deg_per_sec = float(range_data.get("physical_to", range_data.get("physical_from", 0.0)))
+					speed_deg_per_sec = physical_to if absf(physical_to) > 0.0001 else physical_from
 				else:
-					var ratio: float = float(raw_8bit - dmx_from) / float(dmx_to - dmx_from)
-					if control_norm >= 0.0:
-						var range_norm_from: float = float(dmx_from) / 255.0
-						var range_norm_to: float = float(dmx_to) / 255.0
-						var range_norm_span: float = range_norm_to - range_norm_from
-						if range_norm_span > 0.0:
-							ratio = clamp((control_norm - range_norm_from) / range_norm_span, 0.0, 1.0)
-					speed_deg_per_sec = lerp(float(range_data.get("physical_from", 0.0)), float(range_data.get("physical_to", 0.0)), ratio)
+					# Compute ratio from the 8-bit raw value first (matches the
+					# 8-bit range boundaries exactly).
+					var dmx_span: int = dmx_to - dmx_from
+					var coarse_ratio: float = float(raw_8bit - dmx_from) / float(dmx_span)
+					# When a higher-resolution control_norm is available, add
+					# sub-coarse-step precision WITHOUT the coordinate-space
+					# mismatch that occurred when converting 8-bit range boundaries
+					# to a 0..1 norm (x/255 vs x*256/65535).
+					if control_norm >= 0.0 and dmx_span > 0:
+						# control_norm spans [0..1] over the entire channel.
+						# Map the 8-bit boundaries into the same resolution by
+						# treating each coarse step as 1/256 of the full channel
+						# (which matches how 16-bit norm = coarse*256/65535
+						# aligns with coarse/256 at fine=0).
+						var range_norm_from_hr: float = float(dmx_from) / 256.0
+						var range_norm_to_hr: float = float(dmx_to + 1) / 256.0
+						var range_norm_span_hr: float = range_norm_to_hr - range_norm_from_hr
+						if range_norm_span_hr > 0.0:
+							coarse_ratio = clamp((control_norm - range_norm_from_hr) / range_norm_span_hr, 0.0, 1.0)
+					speed_deg_per_sec = lerp(physical_from, physical_to, coarse_ratio)
 			if absf(speed_deg_per_sec) <= 0.0001:
 				is_stop = true
 				speed_deg_per_sec = 0.0

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -204,6 +204,12 @@ func _wheel_owns_rotation_control(wheel: Dictionary) -> bool:
 	var index_norm: float = float(wheel.get("index_norm", -1.0))
 	if index_norm >= 0.0:
 		return true
+	# A wheel also owns rotation control when its dedicated rotation channel
+	# has resolved a non-stop speed, even if the gobo select behavior is FIXED.
+	if bool(wheel.get("has_rotation_physical_value", false)) and not bool(wheel.get("is_stop", true)):
+		var speed: float = float(wheel.get("rotation_speed_deg_per_sec", 0.0))
+		if absf(speed) > 0.0001:
+			return true
 	return false
 
 func _resolve_wheel_effect_mode(behavior: int, supports_index: bool, supports_rotation: bool) -> int:


### PR DESCRIPTION
## Summary

This PR enhances the GDTF parser's handling of gobo rotation channels by improving rotation behavior detection and implementing direction-aware physical value interpolation for split CW/CCW ranges.

## Key Changes

- **New rotation detection function**: Added `name_indicates_continuous_rotation()` to consolidate and expand rotation keyword matching, including:
  - Explicit keywords: `spin`, `rotation`, `rotate`, `posrotate`, `wheelspin`
  - Direction keywords: `cw`, `ccw`, `clockwise`, `counterclockwise` (with spacing/punctuation variants)
  - Stop keywords: `no rotation`, `no spin`
  - Robust standalone `cw` detection that avoids false matches with `ccw`

- **Attribute-based behavior hints**: Extended rotation detection to check ChannelFunction `Attribute` fields (e.g., `Gobo1SelectSpin`) when the function Name is generic, allowing proper classification even when names don't explicitly indicate rotation

- **Direction-aware physical interpolation**: Implemented smart clamping for physical value assignment when:
  - Parent ChannelFunction physical range spans zero (CW-to-CCW)
  - ChannelSet name indicates a clear direction (CW/CCW)
  - This prevents CCW sub-ranges from incorrectly starting with CW (negative) physical values

- **Refactored behavior parsing**: Consolidated rotation detection logic in `parse_gobo_range_behavior()` to use the new `name_indicates_continuous_rotation()` function

## Implementation Details

The direction-aware interpolation works by:
1. Detecting when a function's physical range crosses zero (e.g., -540 to +540)
2. Inferring the intended direction from the ChannelSet name
3. Clamping proportional physical values to the correct direction half (positive for CW, negative for CCW)
4. Falling back to standard proportional interpolation when direction cannot be inferred

This prevents incorrect speed/direction assignments in fixtures with split rotation bands and improves compatibility with GDTF files that use direction-specific ChannelSet naming conventions.

Documentation has been updated to describe the new rotation detection keywords and physical interpolation behavior.

https://claude.ai/code/session_01KvgM9kUBQt5dP7LTr8SsNY