### PR TITLE
Deepen GDTF channel parsing to expose ChannelSet and ModeMaster summaries

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -471,6 +471,18 @@ target_link_libraries(gdtfloader_primitive_test PRIVATE ${wxWidgets_LIBRARIES} t
 add_test(NAME GdtfLoaderPrimitiveFallback COMMAND gdtfloader_primitive_test)
 set_library_env(GdtfLoaderPrimitiveFallback)
 
+add_executable(gdtfloader_channel_modes_test gdtfloader_channel_modes_test.cpp
+               ../viewer3d/gdtfloader.cpp
+               ../viewer3d/loader3ds.cpp
+               ../viewer3d/loaderglb.cpp
+               ../viewer3d/meshprimitives.cpp
+               consolepanel_stub.cpp)
+target_include_directories(gdtfloader_channel_modes_test PRIVATE
+                           . ../viewer3d ../models ../gui ../third_party)
+target_link_libraries(gdtfloader_channel_modes_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
+add_test(NAME GdtfLoaderChannelModeSummaries COMMAND gdtfloader_channel_modes_test)
+set_library_env(GdtfLoaderChannelModeSummaries)
+
 
 add_executable(user_preferences_store_test
                user_preferences_store_test.cpp

--- a/tests/gdtfloader_channel_modes_test.cpp
+++ b/tests/gdtfloader_channel_modes_test.cpp
@@ -1,0 +1,101 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "gdtfloader.h"
+
+#include <cassert>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include <wx/filename.h>
+#include <wx/wfstream.h>
+class wxZipStreamLink;
+#include <wx/zipstrm.h>
+
+namespace {
+std::string MakeGdtf()
+{
+    wxFileName tempName(wxFileName::CreateTempFileName("gdtf_modes_"));
+    const std::string outPath = tempName.GetFullPath().ToStdString() + ".gdtf";
+    wxRemoveFile(tempName.GetFullPath());
+
+    wxFFileOutputStream fileOut(outPath);
+    assert(fileOut.IsOk());
+    wxZipOutputStream zipOut(fileOut);
+
+    zipOut.PutNextEntry("description.xml");
+    const std::string xml =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        "<GDTF DataVersion=\"1.2\">"
+        "<FixtureType Name=\"ModeSummaryFixture\">"
+        "<DMXModes>"
+        "<DMXMode Name=\"Standard\">"
+        "<DMXChannels>"
+        "<DMXChannel Offset=\"1\">"
+        "<LogicalChannel Attribute=\"Gobo2\">"
+        "<ChannelFunction Name=\"Gobo2Index\" Attribute=\"Gobo2\" DMXFrom=\"0/1\">"
+        "<ChannelSet Name=\"Open\" DMXFrom=\"0/1\"/>"
+        "<ChannelSet Name=\"Gobo 1 Index\" DMXFrom=\"16/1\"/>"
+        "</ChannelFunction>"
+        "<ChannelFunction Name=\"Gobo2Rotate\" Attribute=\"Gobo2\" DMXFrom=\"128/1\">"
+        "<ChannelSet Name=\"Rotate Left Fast\" DMXFrom=\"128/1\"/>"
+        "<ChannelSet Name=\"Stop\" DMXFrom=\"192/1\"/>"
+        "<ChannelSet Name=\"Rotate Right Fast\" DMXFrom=\"255/1\"/>"
+        "</ChannelFunction>"
+        "</LogicalChannel>"
+        "</DMXChannel>"
+        "<DMXChannel Offset=\"2\">"
+        "<LogicalChannel Attribute=\"Gobo2PosRotate\">"
+        "<ChannelFunction Name=\"Gobo2PosRotate\" Attribute=\"Gobo2PosRotate\" "
+        "ModeMaster=\"Gobo2Rotate\" ModeFrom=\"128/1\" ModeTo=\"255/1\"/>"
+        "</LogicalChannel>"
+        "</DMXChannel>"
+        "</DMXChannels>"
+        "</DMXMode>"
+        "</DMXModes>"
+        "</FixtureType>"
+        "</GDTF>";
+    zipOut.Write(xml.data(), xml.size());
+    zipOut.Close();
+
+    return outPath;
+}
+}
+
+int main()
+{
+    const std::string gdtfPath = MakeGdtf();
+    const std::vector<GdtfChannelInfo> channels =
+        GetGdtfModeChannels(gdtfPath, "Standard");
+    assert(channels.size() == 2);
+    assert(channels[0].channel == 1);
+    assert(channels[1].channel == 2);
+
+    const std::string& goboSummary = channels[0].function;
+    assert(goboSummary.find("Gobo2") != std::string::npos);
+    assert(goboSummary.find("sets: Open@0") != std::string::npos);
+    assert(goboSummary.find("Rotate Left Fast@128") != std::string::npos);
+
+    const std::string& dedicatedSummary = channels[1].function;
+    assert(dedicatedSummary.find("Gobo2PosRotate") != std::string::npos);
+    assert(dedicatedSummary.find("mode master: Gobo2 128-255") != std::string::npos);
+
+    std::error_code ec;
+    std::filesystem::remove(gdtfPath, ec);
+    return 0;
+}

--- a/viewer3d/gdtfloader.cpp
+++ b/viewer3d/gdtfloader.cpp
@@ -500,6 +500,164 @@ static void ParseModes(tinyxml2::XMLElement* ft,
                 }
                 return std::string{};
             };
+            auto parseDmxEndpointValue = [&](const char* rawValue) {
+                if (!rawValue || !*rawValue)
+                    return std::string{};
+                std::string value = rawValue;
+                trim(value);
+                if (value.empty())
+                    return std::string{};
+                const size_t separatorPos = value.find_first_of("/.");
+                if (separatorPos != std::string::npos)
+                    value = value.substr(0, separatorPos);
+                int parsed = 0;
+                if (!TryParseInt(value, parsed))
+                    return std::string{};
+                return std::to_string(parsed);
+            };
+            auto parseChannelSetsSummary =
+                [&](tinyxml2::XMLElement* channelFunction) {
+                    std::vector<std::string> channelSets;
+                    if (!channelFunction)
+                        return channelSets;
+                    for (tinyxml2::XMLElement* channelSet = channelFunction->FirstChildElement("ChannelSet");
+                         channelSet;
+                         channelSet = channelSet->NextSiblingElement("ChannelSet")) {
+                        std::string label;
+                        if (const char* name = channelSet->Attribute("Name"))
+                            label = name;
+                        if (label.empty()) {
+                            if (const char* wheelSlot = channelSet->Attribute("WheelSlotIndex")) {
+                                label = "WheelSlot ";
+                                label += wheelSlot;
+                            }
+                        }
+                        const std::string dmxFrom =
+                            parseDmxEndpointValue(channelSet->Attribute("DMXFrom"));
+                        if (!dmxFrom.empty()) {
+                            if (!label.empty())
+                                label += "@";
+                            label += dmxFrom;
+                        }
+                        if (label.empty())
+                            label = "unnamed";
+                        channelSets.push_back(std::move(label));
+                    }
+                    return channelSets;
+                };
+            auto tryResolveModeMasterReference =
+                [&](const std::unordered_map<std::string, std::string>& modeMasterNameByReference,
+                    const std::string& reference) {
+                    if (reference.empty())
+                        return std::string{};
+                    auto it = modeMasterNameByReference.find(reference);
+                    if (it == modeMasterNameByReference.end())
+                        return reference;
+                    return it->second;
+                };
+            auto buildFunctionSummary =
+                [&](tinyxml2::XMLElement* dmxChannel) {
+                    if (!dmxChannel)
+                        return std::string{};
+
+                    std::unordered_map<std::string, std::string> modeMasterNameByReference;
+                    for (tinyxml2::XMLElement* lc = dmxChannel->FirstChildElement("LogicalChannel");
+                         lc; lc = lc->NextSiblingElement("LogicalChannel")) {
+                        for (tinyxml2::XMLElement* cf = lc->FirstChildElement("ChannelFunction");
+                             cf; cf = cf->NextSiblingElement("ChannelFunction")) {
+                            const char* name = cf->Attribute("Name");
+                            const char* attr = cf->Attribute("Attribute");
+                            if (!attr)
+                                attr = cf->Attribute("attribute");
+                            if (name && *name && attr && *attr)
+                                modeMasterNameByReference[name] = attr;
+                            if (attr && *attr)
+                                modeMasterNameByReference[attr] = attr;
+                        }
+                    }
+
+                    std::vector<std::string> summaries;
+                    for (tinyxml2::XMLElement* lc = dmxChannel->FirstChildElement("LogicalChannel");
+                         lc; lc = lc->NextSiblingElement("LogicalChannel")) {
+                        std::string logicalAttribute;
+                        if (const char* attr = lc->Attribute("Attribute"))
+                            logicalAttribute = attr;
+                        if (logicalAttribute.empty()) {
+                            if (const char* attr = lc->Attribute("attribute"))
+                                logicalAttribute = attr;
+                        }
+
+                        bool logicalChannelHadFunction = false;
+                        for (tinyxml2::XMLElement* cf = lc->FirstChildElement("ChannelFunction");
+                             cf; cf = cf->NextSiblingElement("ChannelFunction")) {
+                            logicalChannelHadFunction = true;
+                            std::string attribute = logicalAttribute;
+                            if (const char* attr = cf->Attribute("Attribute"))
+                                attribute = attr;
+                            if (attribute.empty()) {
+                                if (const char* attr = cf->Attribute("attribute"))
+                                    attribute = attr;
+                            }
+                            std::string summary = attribute;
+                            if (summary.empty()) {
+                                if (const char* name = cf->Attribute("Name"))
+                                    summary = name;
+                            }
+                            if (summary.empty())
+                                summary = "Function";
+
+                            const std::vector<std::string> channelSets =
+                                parseChannelSetsSummary(cf);
+                            if (!channelSets.empty()) {
+                                summary += " [sets: ";
+                                for (size_t index = 0; index < channelSets.size(); ++index) {
+                                    if (index > 0)
+                                        summary += ", ";
+                                    summary += channelSets[index];
+                                }
+                                summary += "]";
+                            }
+
+                            const char* modeMasterRaw = cf->Attribute("ModeMaster");
+                            if (modeMasterRaw && *modeMasterRaw) {
+                                const std::string modeMaster =
+                                    tryResolveModeMasterReference(modeMasterNameByReference,
+                                                                  modeMasterRaw);
+                                std::string range;
+                                const std::string modeFrom =
+                                    parseDmxEndpointValue(cf->Attribute("ModeFrom"));
+                                const std::string modeTo =
+                                    parseDmxEndpointValue(cf->Attribute("ModeTo"));
+                                if (!modeFrom.empty() || !modeTo.empty()) {
+                                    range = " ";
+                                    range += modeFrom.empty() ? "?" : modeFrom;
+                                    range += "-";
+                                    range += modeTo.empty() ? "?" : modeTo;
+                                }
+                                summary += " [mode master: ";
+                                summary += modeMaster.empty() ? std::string(modeMasterRaw) : modeMaster;
+                                summary += range;
+                                summary += "]";
+                            }
+
+                            summaries.push_back(std::move(summary));
+                        }
+
+                        if (!logicalChannelHadFunction && !logicalAttribute.empty())
+                            summaries.push_back(std::move(logicalAttribute));
+                    }
+
+                    if (summaries.empty())
+                        return extractFunctionName(dmxChannel);
+
+                    std::string merged;
+                    for (size_t index = 0; index < summaries.size(); ++index) {
+                        if (index > 0)
+                            merged += " | ";
+                        merged += summaries[index];
+                    }
+                    return merged;
+                };
             auto suffixForByte = [](size_t byteIndex) {
                 if (byteIndex == 1)
                     return std::string(" (fine)");
@@ -512,7 +670,7 @@ static void ParseModes(tinyxml2::XMLElement* ft,
                  c; c = c->NextSiblingElement("DMXChannel"))
             {
                 const std::vector<int> offsets = parseOffsets(c->Attribute("Offset"));
-                const std::string baseFunction = extractFunctionName(c);
+                const std::string baseFunction = buildFunctionSummary(c);
 
                 if (!offsets.empty()) {
                     for (size_t i = 0; i < offsets.size(); ++i) {


### PR DESCRIPTION
### Motivation
- Fixtures often multiplex gobo index/rotation/shake semantics into the same DMX channel and expose a separate dedicated channel that must be interpreted differently depending on the active slot and `ModeMaster` ranges, so the loader must present that information clearly. 
- The change aims to make GDTF parsing more explicit about `ChannelSet` ranges and `ModeMaster` relationships so UI and higher-level logic can decide how to interpret a dedicated rotation/velocity channel. 
- A short technical note: `viewer3d/gdtfloader.cpp` is a controller/hotspot file and now contains extra parsing logic, so the next recommended split is to extract the channel-summary construction into a small helper unit (e.g. `viewer3d/gdtf_channel_summary.{cpp,h}`) to keep responsibilities modular. 

### Description
- Enhanced DMX channel parsing inside `ParseModes` in `viewer3d/gdtfloader.cpp` by adding `parseDmxEndpointValue`, `parseChannelSetsSummary`, `tryResolveModeMasterReference` and `buildFunctionSummary` helpers and using the summary as the `GdtfChannelInfo::function` value. 
- The summary now includes ChannelSet names with parsed DMX start values and explicit `ModeMaster` references with parsed `ModeFrom`/`ModeTo` ranges when present, and attempts to resolve referenced names to human-readable attributes. 
- Added a focused regression test `tests/gdtfloader_channel_modes_test.cpp` that builds a synthetic GDTF (gobo index + rotation blocks and a dedicated mode-master-linked channel) and asserts the parsed summaries contain slot and mode-master range details. 
- Registered the new test in `tests/CMakeLists.txt` so it runs under the test suite once dependencies are available. 

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it completed successfully. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it completed successfully. 
- Attempted to configure and build the new test targets with `cmake -S tests -B build-tests && cmake --build build-tests --target gdtfloader_channel_modes_test gdtfloader_primitive_test -j4`, but configuration failed in this environment because the `wxWidgets` development package (wxWidgets libraries/include) is not available so test compilation could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc522ccbec832482023735b0d45075)