### PR TITLE
Add GdtfChannelInfo and GetGdtfModeChannels to GDTF loader header

### DIFF
--- a/tests/gdtfloader.h
+++ b/tests/gdtfloader.h
@@ -21,8 +21,13 @@
 #include "mesh.h"
 #include "types.h"
 struct GdtfObject { Mesh mesh; Matrix transform; };
+struct GdtfChannelInfo {
+    int channel = 0;
+    std::string function;
+};
 bool LoadGdtf(const std::string&, std::vector<GdtfObject>&, std::string* outError = nullptr);
 int GetGdtfModeChannelCount(const std::string&, const std::string&);
+std::vector<GdtfChannelInfo> GetGdtfModeChannels(const std::string&, const std::string&);
 std::string GetGdtfFixtureName(const std::string& gdtfPath);
 std::string GetGdtfModelColor(const std::string& gdtfPath);
 bool GetGdtfProperties(const std::string& gdtfPath,


### PR DESCRIPTION
### Motivation
- Expose detailed channel information for GDTF fixtures so callers can obtain per-channel function names and indices instead of only a channel count.

### Description
- Added a new `GdtfChannelInfo` struct with `int channel` and `std::string function` fields to represent individual mode channels.
- Added the function declaration `std::vector<GdtfChannelInfo> GetGdtfModeChannels(const std::string&, const std::string&);` to return the list of channels for a given GDTF mode.
- Kept existing declarations `LoadGdtf`, `GetGdtfModeChannelCount`, `GetGdtfFixtureName`, `GetGdtfModelColor`, and `GetGdtfProperties` unchanged.

### Testing
- Built the project including the tests to ensure the header change compiles cleanly; the build succeeded.
- Ran the existing automated test suite; all tests passed without modification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd314b3e408324adc396a52dea3643)