### PR TITLE
Block New/Open actions while startup project loads

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -306,6 +306,7 @@ MainWindow::MainWindow(const wxString &title, IGuiConfigServices *services)
 
   Bind(wxEVT_IDLE, &MainWindow::OnStartupSplashCloseIdle, this);
 
+  SetStartupProjectLoadPending(true);
   UpdateTitle();
 }
 
@@ -496,6 +497,32 @@ bool MainWindow::ConfirmSaveIfDirty(const wxString &actionLabel,
 void MainWindow::OnPaneClose(wxAuiManagerEvent &event) {
   event.Skip();
   CallAfter(&MainWindow::UpdateViewMenuChecks);
+}
+
+void MainWindow::SetStartupProjectLoadPending(bool pending) {
+  startupProjectLoadPending = pending;
+
+  wxMenuBar *menuBar = GetMenuBar();
+  if (menuBar) {
+    menuBar->Enable(ID_File_New, !pending);
+    menuBar->Enable(ID_File_Load, !pending);
+  }
+
+  if (fileToolBar) {
+    fileToolBar->EnableTool(ID_File_New, !pending);
+    fileToolBar->EnableTool(ID_File_Load, !pending);
+    fileToolBar->Refresh();
+  }
+}
+
+bool MainWindow::GuardStartupProjectLoadAction(const wxString &actionLabel) {
+  if (!startupProjectLoadPending)
+    return true;
+
+  wxMessageBox("Please wait until the startup project loading finishes before " +
+                   actionLabel + ".",
+               "Perastage is still loading", wxOK | wxICON_INFORMATION, this);
+  return false;
 }
 
 bool MainWindow::LoadProjectFromPath(const std::string &path) {
@@ -969,6 +996,7 @@ void MainWindow::OnProjectLoaded(wxCommandEvent &event) {
     ResetProject();
     RequestStartupSplashCompletion();
   }
+  SetStartupProjectLoadPending(false);
 }
 
 void MainWindow::OnNotebookPageChanged(wxBookCtrlEvent &event) {

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -208,6 +208,8 @@ private:
   bool HasActiveLayout2DView() const;
   void SyncSceneData();
   void SyncLayerVisibilityPanels();
+  void SetStartupProjectLoadPending(bool pending);
+  bool GuardStartupProjectLoadAction(const wxString &actionLabel);
   bool ConfirmSaveIfDirty(const wxString &actionLabel,
                           const wxString &dialogTitle);
   void StartFixtureSymbolAutoUpdateForLoadedScene();
@@ -239,6 +241,7 @@ private:
   std::function<void()> fixtureSymbolAutoUpdateCompletionCallback;
   bool startupSplashInitializationPending = true;
   bool startupSplashCloseRequested = false;
+  bool startupProjectLoadPending = true;
   int viewportInteractionLockDepth = 0;
 
   friend class MainWindowIoController;

--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -121,6 +121,9 @@ void MainWindow::UnlockViewportInteraction() {
 }
 
 void MainWindow::OnLoad(wxCommandEvent &event) {
+  if (!GuardStartupProjectLoadAction("opening another project"))
+    return;
+
   if (!ConfirmSaveIfDirty("loading a project", "Open Project"))
     return;
 

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -405,6 +405,9 @@ void MainWindow::CreateMenuBar() {
 }
 
 void MainWindow::OnNew(wxCommandEvent &WXUNUSED(event)) {
+  if (!GuardStartupProjectLoadAction("creating a new project"))
+    return;
+
   if (!ConfirmSaveIfDirty("creating a new project", "New Project"))
     return;
 


### PR DESCRIPTION
### Motivation
- Prevent race between the asynchronous "load last project" startup flow and user actions that mutate project state, which could cause crashes when triggering `New` or `Open` while the app is still loading the last project.

### Description
- Added a startup load guard state `startupProjectLoadPending` and two helpers: `SetStartupProjectLoadPending(bool)` and `GuardStartupProjectLoadAction(const wxString&)` in `MainWindow` (`gui/mainwindow.h`, `gui/mainwindow.cpp`).
- Call `SetStartupProjectLoadPending(true)` during `MainWindow` construction and clear it at the end of `OnProjectLoaded` so the guard covers the entire startup load window.
- Disable `File -> New` and `File -> Open` menu items and their toolbar buttons while startup load is pending, and show an informative message box when the user attempts these actions early.
- Add guard checks in `OnNew` (`gui/mainwindow_menu.cpp`) and `OnLoad` (`gui/mainwindow_io.cpp`) to early-return if startup loading is still in progress.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` (result: OK).
- Ran `tests/check_no_configmanager_get_in_gui.sh` (result: OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd347fb92c83249273f22f3e8d0693)