### PR TITLE
peraviz: add configurable day-night environment controller

### DIFF
--- a/peraviz/docs/DAY_NIGHT_ENVIRONMENT.md
+++ b/peraviz/docs/DAY_NIGHT_ENVIRONMENT.md
@@ -34,3 +34,13 @@ This document describes the built-in day/night environment baseline used by Pera
 ## Integration note
 
 `load_scene.gd` now re-applies the controller after visual-settings updates so fixture tuning UI does not permanently override day/night sky and ambient states.
+
+## Visual Settings controls
+
+The Visual Settings window now includes a dedicated **Environment** section with basic controls for:
+
+- Enabling/disabling the environment controller.
+- Preset selection (`Dawn`, `Day`, `Dusk`, `Night`, `BlackoutNight`).
+- Continuous cycle controls (`time_of_day`, `auto_advance`, `cycle_speed`).
+- Blackout-night permission toggle.
+- Core environment tuning (light intensities, ambient day/night, horizon warmth/intensity).

--- a/peraviz/docs/DAY_NIGHT_ENVIRONMENT.md
+++ b/peraviz/docs/DAY_NIGHT_ENVIRONMENT.md
@@ -1,0 +1,36 @@
+# Day/Night Environment Controller
+
+This document describes the built-in day/night environment baseline used by Peraviz.
+
+## Files changed
+
+- `peraviz/scripts/day_night_environment_controller.gd`
+- `peraviz/scripts/load_scene.gd`
+- `peraviz/test.tscn`
+
+## How to use
+
+1. Open `peraviz/test.tscn`.
+2. Select the `DayNightEnvironmentController` node.
+3. Choose one workflow:
+   - Preset mode: keep `use_continuous_cycle = false` and set `current_preset` to `Dawn`, `Day`, `Dusk`, `Night`, or `BlackoutNight`.
+   - Continuous mode: set `use_continuous_cycle = true` and adjust `time_of_day` between `0.0` and `1.0`.
+4. Optional runtime animation:
+   - Enable `auto_advance`.
+   - Tune `cycle_speed`.
+
+## Key inspector parameters
+
+- `enabled`: global on/off switch for controller ownership.
+- `use_continuous_cycle`: enables interpolation through the cycle keyframes.
+- `current_preset`: active state in preset mode.
+- `time_of_day`: normalized value for continuous mode.
+- `auto_advance` and `cycle_speed`: automatic day/night progression.
+- `day_light_intensity`, `dusk_light_intensity`, `night_light_intensity`, `moon_light_intensity`: directional light strengths.
+- `ambient_energy_day`, `ambient_energy_night`: ambient floor values.
+- `horizon_warmth`, `horizon_intensity`: horizon gradient tone and strength for dawn/dusk.
+- `allow_blackout_night`: allows near-total darkness during blackout preset.
+
+## Integration note
+
+`load_scene.gd` now re-applies the controller after visual-settings updates so fixture tuning UI does not permanently override day/night sky and ambient states.

--- a/peraviz/scripts/day_night_environment_controller.gd
+++ b/peraviz/scripts/day_night_environment_controller.gd
@@ -1,0 +1,298 @@
+@tool
+class_name DayNightEnvironmentController
+extends Node3D
+
+enum EnvironmentPreset {
+	DAWN,
+	DAY,
+	DUSK,
+	NIGHT,
+	BLACKOUT_NIGHT,
+}
+
+const CYCLE_KEYFRAMES := [
+	{"time": 0.00, "preset": EnvironmentPreset.BLACKOUT_NIGHT},
+	{"time": 0.18, "preset": EnvironmentPreset.DAWN},
+	{"time": 0.40, "preset": EnvironmentPreset.DAY},
+	{"time": 0.68, "preset": EnvironmentPreset.DUSK},
+	{"time": 0.86, "preset": EnvironmentPreset.NIGHT},
+	{"time": 1.00, "preset": EnvironmentPreset.BLACKOUT_NIGHT},
+]
+
+@export var enabled: bool = true:
+	set(value):
+		enabled = value
+		_apply_environment_state()
+
+@export var use_continuous_cycle: bool = false:
+	set(value):
+		use_continuous_cycle = value
+		_apply_environment_state()
+
+@export var current_preset: EnvironmentPreset = EnvironmentPreset.DAY:
+	set(value):
+		current_preset = value
+		_apply_environment_state()
+
+@export_range(0.0, 1.0, 0.001) var time_of_day: float = 0.40:
+	set(value):
+		time_of_day = clampf(value, 0.0, 1.0)
+		if use_continuous_cycle:
+			_apply_environment_state()
+
+@export var auto_advance: bool = false
+@export_range(0.0, 1.0, 0.0001) var cycle_speed: float = 0.02
+
+@export_group("Light")
+@export var day_light_intensity: float = 0.70
+@export var dusk_light_intensity: float = 0.18
+@export var night_light_intensity: float = 0.02
+@export var moon_light_intensity: float = 0.012
+
+@export_group("Ambient")
+@export var ambient_energy_day: float = 0.08
+@export var ambient_energy_night: float = 0.008
+
+@export_group("Sky")
+@export_range(0.0, 1.0, 0.01) var horizon_warmth: float = 0.60
+@export_range(0.0, 2.0, 0.01) var horizon_intensity: float = 1.0
+
+@export_group("Behavior")
+@export var allow_blackout_night: bool = true
+@export var force_editor_preview: bool = true
+@export_node_path("WorldEnvironment") var world_environment_path: NodePath = NodePath("../WorldEnvironment")
+@export_node_path("DirectionalLight3D") var directional_light_path: NodePath = NodePath("../DirectionalLight3D")
+
+var _world_environment: WorldEnvironment
+var _directional_light: DirectionalLight3D
+var _runtime_environment: Environment
+var _runtime_sky: Sky
+var _runtime_sky_material: ProceduralSkyMaterial
+
+
+func _ready() -> void:
+	_resolve_nodes()
+	_prepare_environment_resources()
+	_apply_environment_state()
+
+
+func _process(delta: float) -> void:
+	if not enabled:
+		return
+	if not _can_run_runtime_updates():
+		return
+	if use_continuous_cycle and auto_advance:
+		time_of_day = wrapf(time_of_day + delta * cycle_speed, 0.0, 1.0)
+		_apply_environment_state()
+
+
+func apply_now() -> void:
+	_resolve_nodes()
+	_prepare_environment_resources()
+	_apply_environment_state()
+
+
+func _can_run_runtime_updates() -> bool:
+	if Engine.is_editor_hint():
+		return force_editor_preview
+	return true
+
+
+func _resolve_nodes() -> void:
+	_world_environment = get_node_or_null(world_environment_path) as WorldEnvironment
+	_directional_light = get_node_or_null(directional_light_path) as DirectionalLight3D
+
+
+func _prepare_environment_resources() -> void:
+	if _world_environment == null:
+		return
+	if _world_environment.environment == null:
+		_world_environment.environment = Environment.new()
+	_runtime_environment = _world_environment.environment
+	if _runtime_environment.sky == null:
+		_runtime_sky = Sky.new()
+		_runtime_environment.sky = _runtime_sky
+	else:
+		_runtime_sky = _runtime_environment.sky
+	if _runtime_sky.sky_material == null or not (_runtime_sky.sky_material is ProceduralSkyMaterial):
+		_runtime_sky_material = ProceduralSkyMaterial.new()
+		_runtime_sky.sky_material = _runtime_sky_material
+	else:
+		_runtime_sky_material = _runtime_sky.sky_material as ProceduralSkyMaterial
+
+
+func _apply_environment_state() -> void:
+	if _world_environment == null or _runtime_environment == null or _runtime_sky_material == null:
+		return
+
+	if not enabled:
+		_apply_disabled_fallback()
+		return
+
+	var target_state: Dictionary = _compute_target_state()
+	_apply_environment_dict(target_state)
+
+
+func _apply_disabled_fallback() -> void:
+	_runtime_environment.background_mode = Environment.BG_COLOR
+	_runtime_environment.background_color = Color(0.1294, 0.1373, 0.1569, 1.0)
+	_runtime_environment.ambient_light_source = Environment.AMBIENT_SOURCE_COLOR
+	_runtime_environment.ambient_light_color = Color(1.0, 1.0, 1.0, 1.0)
+	_runtime_environment.ambient_light_energy = ambient_energy_day
+	if _environment_has_property(_runtime_environment, "ambient_light_sky_contribution"):
+		_runtime_environment.ambient_light_sky_contribution = 0.0
+	if _directional_light != null:
+		_directional_light.visible = false
+		_directional_light.light_energy = 0.0
+
+
+func _compute_target_state() -> Dictionary:
+	if use_continuous_cycle:
+		return _state_from_time(time_of_day)
+	return _state_for_preset(current_preset)
+
+
+func _state_from_time(normalized_time: float) -> Dictionary:
+	var t := clampf(normalized_time, 0.0, 1.0)
+	for index in range(CYCLE_KEYFRAMES.size() - 1):
+		var current: Dictionary = CYCLE_KEYFRAMES[index]
+		var next: Dictionary = CYCLE_KEYFRAMES[index + 1]
+		var start_time: float = float(current["time"])
+		var end_time: float = float(next["time"])
+		if t >= start_time and t <= end_time:
+			var span: float = max(end_time - start_time, 0.0001)
+			var local_t: float = clampf((t - start_time) / span, 0.0, 1.0)
+			return _lerp_states(_state_for_preset(int(current["preset"])), _state_for_preset(int(next["preset"])), local_t)
+	return _state_for_preset(EnvironmentPreset.BLACKOUT_NIGHT)
+
+
+func _state_for_preset(preset: EnvironmentPreset) -> Dictionary:
+	match preset:
+		EnvironmentPreset.DAWN:
+			return {
+				"sky_top_color": Color(0.12, 0.18, 0.30, 1.0),
+				"sky_horizon_color": _warm_horizon_color(0.52, 0.40),
+				"ground_bottom_color": Color(0.03, 0.04, 0.05, 1.0),
+				"sky_energy": 0.38,
+				"ambient_energy": lerpf(ambient_energy_night, ambient_energy_day, 0.35),
+				"directional_energy": dusk_light_intensity,
+				"directional_color": Color(1.00, 0.83, 0.69, 1.0),
+				"sun_elevation_deg": 8.0,
+				"moon_mode": false,
+			}
+		EnvironmentPreset.DAY:
+			return {
+				"sky_top_color": Color(0.30, 0.52, 0.83, 1.0),
+				"sky_horizon_color": Color(0.70, 0.82, 0.98, 1.0),
+				"ground_bottom_color": Color(0.09, 0.10, 0.13, 1.0),
+				"sky_energy": 1.0,
+				"ambient_energy": ambient_energy_day,
+				"directional_energy": day_light_intensity,
+				"directional_color": Color(1.0, 0.98, 0.95, 1.0),
+				"sun_elevation_deg": 52.0,
+				"moon_mode": false,
+			}
+		EnvironmentPreset.DUSK:
+			return {
+				"sky_top_color": Color(0.12, 0.16, 0.32, 1.0),
+				"sky_horizon_color": _warm_horizon_color(0.60, 0.62),
+				"ground_bottom_color": Color(0.03, 0.03, 0.05, 1.0),
+				"sky_energy": 0.32,
+				"ambient_energy": lerpf(ambient_energy_day, ambient_energy_night, 0.55),
+				"directional_energy": dusk_light_intensity,
+				"directional_color": Color(1.0, 0.76, 0.62, 1.0),
+				"sun_elevation_deg": 4.0,
+				"moon_mode": false,
+			}
+		EnvironmentPreset.NIGHT:
+			return {
+				"sky_top_color": Color(0.01, 0.02, 0.05, 1.0),
+				"sky_horizon_color": Color(0.03, 0.04, 0.06, 1.0),
+				"ground_bottom_color": Color(0.0, 0.0, 0.0, 1.0),
+				"sky_energy": 0.06,
+				"ambient_energy": ambient_energy_night,
+				"directional_energy": moon_light_intensity,
+				"directional_color": Color(0.70, 0.76, 0.95, 1.0),
+				"sun_elevation_deg": -42.0,
+				"moon_mode": true,
+			}
+		_:
+			var blackout_enabled: bool = allow_blackout_night
+			return {
+				"sky_top_color": Color.BLACK,
+				"sky_horizon_color": Color.BLACK,
+				"ground_bottom_color": Color.BLACK,
+				"sky_energy": 0.0 if blackout_enabled else 0.03,
+				"ambient_energy": 0.0 if blackout_enabled else ambient_energy_night * 0.5,
+				"directional_energy": 0.0 if blackout_enabled else night_light_intensity,
+				"directional_color": Color(0.55, 0.60, 0.82, 1.0),
+				"sun_elevation_deg": -68.0,
+				"moon_mode": true,
+			}
+
+
+func _lerp_states(start: Dictionary, target: Dictionary, t: float) -> Dictionary:
+	var result := {}
+	for key in [
+		"sky_top_color",
+		"sky_horizon_color",
+		"ground_bottom_color",
+		"sky_energy",
+		"ambient_energy",
+		"directional_energy",
+		"directional_color",
+		"sun_elevation_deg",
+	]:
+		if start[key] is Color:
+			result[key] = (start[key] as Color).lerp(target[key] as Color, t)
+		else:
+			result[key] = lerpf(float(start[key]), float(target[key]), t)
+	result["moon_mode"] = bool(start["moon_mode"]) if t < 0.5 else bool(target["moon_mode"])
+	return result
+
+
+func _apply_environment_dict(state: Dictionary) -> void:
+	_runtime_environment.background_mode = Environment.BG_SKY
+	_runtime_environment.ambient_light_source = Environment.AMBIENT_SOURCE_COLOR
+	_runtime_environment.ambient_light_color = Color(1.0, 1.0, 1.0, 1.0)
+	_runtime_environment.ambient_light_energy = max(float(state["ambient_energy"]), 0.0)
+	if _environment_has_property(_runtime_environment, "ambient_light_sky_contribution"):
+		_runtime_environment.ambient_light_sky_contribution = 0.0
+
+	_runtime_sky_material.sky_top_color = state["sky_top_color"]
+	_runtime_sky_material.sky_horizon_color = state["sky_horizon_color"]
+	_runtime_sky_material.ground_bottom_color = state["ground_bottom_color"]
+	_runtime_sky_material.ground_horizon_color = Color(0.02, 0.02, 0.02, 1.0)
+	_runtime_sky_material.sky_curve = 0.18
+	_runtime_sky_material.ground_curve = 0.20
+	_runtime_sky_material.sun_curve = 0.015
+	_runtime_sky_material.use_debanding = true
+	_runtime_sky_material.energy_multiplier = max(float(state["sky_energy"]), 0.0)
+
+	if _directional_light != null:
+		var directional_energy: float = max(float(state["directional_energy"]), 0.0)
+		_directional_light.visible = directional_energy > 0.0005
+		_directional_light.light_energy = directional_energy
+		_directional_light.light_color = state["directional_color"]
+		_directional_light.rotation_degrees = Vector3(float(state["sun_elevation_deg"]), -45.0, 0.0)
+
+
+func _warm_horizon_color(base_intensity: float, dusk_factor: float) -> Color:
+	var warm := Color(1.0, 0.56, 0.31, 1.0)
+	var cool := Color(0.40, 0.52, 0.78, 1.0)
+	var blend: Color = cool.lerp(warm, clampf(horizon_warmth + dusk_factor * 0.2, 0.0, 1.0))
+	return Color(
+		clampf(blend.r * base_intensity * horizon_intensity, 0.0, 1.0),
+		clampf(blend.g * base_intensity * horizon_intensity, 0.0, 1.0),
+		clampf(blend.b * base_intensity * horizon_intensity, 0.0, 1.0),
+		1.0
+	)
+
+
+func _environment_has_property(environment: Environment, property_name: String) -> bool:
+	if environment == null:
+		return false
+	for entry in environment.get_property_list():
+		if str(entry.get("name", "")) == property_name:
+			return true
+	return false

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -87,6 +87,21 @@ var _visual_settings := {
 	"light_volumetric_fog_energy": 12.0,
 	"use_native_fog_projector_gobos": true,
 	"background_color": Color(0.129412, 0.137255, 0.156863, 1.0),
+	"environment_enabled": true,
+	"environment_use_continuous_cycle": false,
+	"environment_current_preset": 1,
+	"environment_time_of_day": 0.4,
+	"environment_auto_advance": false,
+	"environment_cycle_speed": 0.02,
+	"environment_allow_blackout_night": true,
+	"environment_day_light_intensity": 0.7,
+	"environment_dusk_light_intensity": 0.18,
+	"environment_night_light_intensity": 0.02,
+	"environment_moon_light_intensity": 0.012,
+	"environment_ambient_energy_day": 0.08,
+	"environment_ambient_energy_night": 0.008,
+	"environment_horizon_warmth": 0.6,
+	"environment_horizon_intensity": 1.0,
 }
 
 var _dmx_receiver = null
@@ -353,7 +368,25 @@ func _environment_has_property(environment: Environment, property_name: String) 
 func _refresh_day_night_environment_controller() -> void:
 	if day_night_environment_controller == null:
 		return
+	_apply_day_night_settings_from_visual_controls()
 	day_night_environment_controller.apply_now()
+
+func _apply_day_night_settings_from_visual_controls() -> void:
+	day_night_environment_controller.enabled = bool(_visual_settings.get("environment_enabled", true))
+	day_night_environment_controller.use_continuous_cycle = bool(_visual_settings.get("environment_use_continuous_cycle", false))
+	day_night_environment_controller.current_preset = int(clamp(int(_visual_settings.get("environment_current_preset", 1)), 0, 4))
+	day_night_environment_controller.time_of_day = clampf(float(_visual_settings.get("environment_time_of_day", 0.4)), 0.0, 1.0)
+	day_night_environment_controller.auto_advance = bool(_visual_settings.get("environment_auto_advance", false))
+	day_night_environment_controller.cycle_speed = max(float(_visual_settings.get("environment_cycle_speed", 0.02)), 0.0)
+	day_night_environment_controller.allow_blackout_night = bool(_visual_settings.get("environment_allow_blackout_night", true))
+	day_night_environment_controller.day_light_intensity = max(float(_visual_settings.get("environment_day_light_intensity", 0.7)), 0.0)
+	day_night_environment_controller.dusk_light_intensity = max(float(_visual_settings.get("environment_dusk_light_intensity", 0.18)), 0.0)
+	day_night_environment_controller.night_light_intensity = max(float(_visual_settings.get("environment_night_light_intensity", 0.02)), 0.0)
+	day_night_environment_controller.moon_light_intensity = max(float(_visual_settings.get("environment_moon_light_intensity", 0.012)), 0.0)
+	day_night_environment_controller.ambient_energy_day = max(float(_visual_settings.get("environment_ambient_energy_day", 0.08)), 0.0)
+	day_night_environment_controller.ambient_energy_night = max(float(_visual_settings.get("environment_ambient_energy_night", 0.008)), 0.0)
+	day_night_environment_controller.horizon_warmth = clampf(float(_visual_settings.get("environment_horizon_warmth", 0.6)), 0.0, 1.0)
+	day_night_environment_controller.horizon_intensity = clampf(float(_visual_settings.get("environment_horizon_intensity", 1.0)), 0.0, 2.0)
 
 func _update_beam_renderer_mode(force_refresh: bool) -> void:
 	var requested_mode: int = int(clamp(int(_visual_settings.get("beam_render_mode", BEAM_RENDER_MODE_VOLUMETRIC)), BEAM_RENDER_MODE_VOLUMETRIC, BEAM_RENDER_MODE_LEGACY))

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -6,6 +6,7 @@ extends Node3D
 @onready var picker: FileDialog = $HUD/FileDialog
 @onready var camera: Camera3D = $Camera3D
 @onready var world_environment: WorldEnvironment = $WorldEnvironment
+@onready var day_night_environment_controller: DayNightEnvironmentController = $DayNightEnvironmentController
 @onready var manual_fixture_toggle: CheckButton = $HUD/ManualFixtureToggle
 @onready var fixture_debug_panel: PanelContainer = $HUD/FixtureDebugPanel
 @onready var fixture_list: ItemList = $HUD/FixtureDebugPanel/Margin/VBox/FixtureList
@@ -250,6 +251,7 @@ func _ready() -> void:
 	else:
 		push_warning("VisualSettingsWindow is not ready for configure(); initial visual settings not pushed.")
 	_apply_visual_settings(_visual_settings)
+	_refresh_day_night_environment_controller()
 
 
 func _apply_imported_content_scale() -> void:
@@ -336,6 +338,7 @@ func _apply_visual_settings(settings: Dictionary) -> void:
 	)
 	if beam_scalar_changed:
 		_refresh_existing_beam_material_scalars()
+	_refresh_day_night_environment_controller()
 
 
 
@@ -346,6 +349,11 @@ func _environment_has_property(environment: Environment, property_name: String) 
 		if str(entry.get("name", "")) == property_name:
 			return true
 	return false
+
+func _refresh_day_night_environment_controller() -> void:
+	if day_night_environment_controller == null:
+		return
+	day_night_environment_controller.apply_now()
 
 func _update_beam_renderer_mode(force_refresh: bool) -> void:
 	var requested_mode: int = int(clamp(int(_visual_settings.get("beam_render_mode", BEAM_RENDER_MODE_VOLUMETRIC)), BEAM_RENDER_MODE_VOLUMETRIC, BEAM_RENDER_MODE_LEGACY))

--- a/peraviz/scripts/visual_settings_window.gd
+++ b/peraviz/scripts/visual_settings_window.gd
@@ -33,6 +33,21 @@ const DEFAULT_SETTINGS := {
 	"light_volumetric_fog_energy": 12.0,
 	"use_native_fog_projector_gobos": true,
 	"background_color": Color(0.129412, 0.137255, 0.156863, 1.0),
+	"environment_enabled": true,
+	"environment_use_continuous_cycle": false,
+	"environment_current_preset": 1,
+	"environment_time_of_day": 0.4,
+	"environment_auto_advance": false,
+	"environment_cycle_speed": 0.02,
+	"environment_allow_blackout_night": true,
+	"environment_day_light_intensity": 0.7,
+	"environment_dusk_light_intensity": 0.18,
+	"environment_night_light_intensity": 0.02,
+	"environment_moon_light_intensity": 0.012,
+	"environment_ambient_energy_day": 0.08,
+	"environment_ambient_energy_night": 0.008,
+	"environment_horizon_warmth": 0.6,
+	"environment_horizon_intensity": 1.0,
 }
 
 var _settings: Dictionary = DEFAULT_SETTINGS.duplicate(true)
@@ -53,10 +68,16 @@ var _light_fog_energy_value_label: Label
 var _background_picker: ColorPickerButton
 var _beam_render_mode_option: OptionButton
 var _beam_quality_option: OptionButton
+var _environment_preset_option: OptionButton
+var _environment_time_slider: HSlider
+var _environment_time_value_label: Label
+var _environment_cycle_speed_slider: HSlider
+var _environment_cycle_speed_value_label: Label
+var _toggle_controls: Dictionary = {}
 
 func _init() -> void:
 	title = "Visual Settings"
-	size = Vector2i(540, 560)
+	size = Vector2i(560, 760)
 	unresizable = false
 
 func _ready() -> void:
@@ -86,10 +107,18 @@ func _build_ui() -> void:
 	root.add_theme_constant_override("margin_bottom", 12)
 	add_child(root)
 
-	var container: VBoxContainer = VBoxContainer.new()
-	container.add_theme_constant_override("separation", 10)
-	root.add_child(container)
+	var scroll: ScrollContainer = ScrollContainer.new()
+	scroll.set_anchors_preset(Control.PRESET_FULL_RECT)
+	scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	root.add_child(scroll)
 
+	var container: VBoxContainer = VBoxContainer.new()
+	container.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	container.add_theme_constant_override("separation", 10)
+	scroll.add_child(container)
+
+	_add_section_label(container, "Renderer")
 	_ambient_slider = _add_slider_row(container, "Ambient light", "ambient_multiplier", 0.0, 3.0, 0.01)
 	_spot_slider = _add_slider_row(container, "Spot intensity", "spot_multiplier", 0.0, 3.0, 0.01)
 	_beam_slider = _add_slider_row(container, "Beam intensity", "beam_multiplier", 0.0, 100.0, 0.01)
@@ -101,13 +130,30 @@ func _build_ui() -> void:
 	_beam_render_mode_option = _add_option_row(container, "Beam rendering", ["Volumetric (default)", "Lightweight (legacy)"], _on_beam_render_mode_selected)
 	_beam_quality_option = _add_option_row(container, "Beam quality", ["Low", "Medium", "High"], _on_beam_quality_selected)
 
+	_add_section_label(container, "Environment")
+	_add_toggle_row(container, "Enable environment controller", "environment_enabled")
+	_add_toggle_row(container, "Use continuous cycle", "environment_use_continuous_cycle")
+	_environment_preset_option = _add_option_row(container, "Environment preset", ["Dawn", "Day", "Dusk", "Night", "BlackoutNight"], _on_environment_preset_selected)
+	_environment_time_slider = _add_slider_row(container, "Time of day", "environment_time_of_day", 0.0, 1.0, 0.001)
+	_add_toggle_row(container, "Auto advance cycle", "environment_auto_advance")
+	_environment_cycle_speed_slider = _add_slider_row(container, "Cycle speed", "environment_cycle_speed", 0.0, 0.2, 0.0005)
+	_add_toggle_row(container, "Allow blackout night", "environment_allow_blackout_night")
+	_add_slider_row(container, "Day light intensity", "environment_day_light_intensity", 0.0, 2.0, 0.01)
+	_add_slider_row(container, "Dusk light intensity", "environment_dusk_light_intensity", 0.0, 1.0, 0.01)
+	_add_slider_row(container, "Night light intensity", "environment_night_light_intensity", 0.0, 0.3, 0.001)
+	_add_slider_row(container, "Moon light intensity", "environment_moon_light_intensity", 0.0, 0.2, 0.001)
+	_add_slider_row(container, "Ambient day energy", "environment_ambient_energy_day", 0.0, 0.3, 0.001)
+	_add_slider_row(container, "Ambient night energy", "environment_ambient_energy_night", 0.0, 0.1, 0.001)
+	_add_slider_row(container, "Horizon warmth", "environment_horizon_warmth", 0.0, 1.0, 0.01)
+	_add_slider_row(container, "Horizon intensity", "environment_horizon_intensity", 0.0, 2.0, 0.01)
+
 	var background_row: HBoxContainer = HBoxContainer.new()
 	background_row.add_theme_constant_override("separation", 8)
 	container.add_child(background_row)
 
 	var background_label: Label = Label.new()
 	background_label.text = "Background color"
-	background_label.custom_minimum_size = Vector2(150, 0)
+	background_label.custom_minimum_size = Vector2(170, 0)
 	background_row.add_child(background_label)
 
 	_background_picker = ColorPickerButton.new()
@@ -124,6 +170,12 @@ func _build_ui() -> void:
 	reset_button.pressed.connect(_on_reset_pressed)
 	actions_row.add_child(reset_button)
 
+func _add_section_label(parent: VBoxContainer, title_text: String) -> void:
+	var section_label: Label = Label.new()
+	section_label.text = title_text
+	section_label.add_theme_font_size_override("font_size", 16)
+	parent.add_child(section_label)
+
 func _add_slider_row(parent: VBoxContainer,
 		label_text: String,
 		key: String,
@@ -136,7 +188,7 @@ func _add_slider_row(parent: VBoxContainer,
 
 	var setting_label: Label = Label.new()
 	setting_label.text = label_text
-	setting_label.custom_minimum_size = Vector2(150, 0)
+	setting_label.custom_minimum_size = Vector2(170, 0)
 	row.add_child(setting_label)
 
 	var slider: HSlider = HSlider.new()
@@ -150,7 +202,7 @@ func _add_slider_row(parent: VBoxContainer,
 	row.add_child(slider)
 
 	var value_label: Label = Label.new()
-	value_label.custom_minimum_size = Vector2(56, 0)
+	value_label.custom_minimum_size = Vector2(64, 0)
 	value_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
 	row.add_child(value_label)
 
@@ -169,6 +221,10 @@ func _add_slider_row(parent: VBoxContainer,
 			_fog_fade_value_label = value_label
 		"light_volumetric_fog_energy":
 			_light_fog_energy_value_label = value_label
+		"environment_time_of_day":
+			_environment_time_value_label = value_label
+		"environment_cycle_speed":
+			_environment_cycle_speed_value_label = value_label
 
 	return slider
 
@@ -179,7 +235,7 @@ func _add_option_row(parent: VBoxContainer, label_text: String, options: Array[S
 
 	var setting_label: Label = Label.new()
 	setting_label.text = label_text
-	setting_label.custom_minimum_size = Vector2(150, 0)
+	setting_label.custom_minimum_size = Vector2(170, 0)
 	row.add_child(setting_label)
 
 	var option_button: OptionButton = OptionButton.new()
@@ -200,6 +256,7 @@ func _add_toggle_row(parent: VBoxContainer, label_text: String, key: String) -> 
 		_emit_settings_changed()
 	)
 	parent.add_child(toggle)
+	_toggle_controls[key] = toggle
 
 func _apply_settings_to_controls() -> void:
 	_ambient_slider.value = float(_settings.get("ambient_multiplier", 0.08))
@@ -211,6 +268,13 @@ func _apply_settings_to_controls() -> void:
 	_light_fog_energy_slider.value = float(_settings.get("light_volumetric_fog_energy", 12.0))
 	_beam_render_mode_option.select(clamp(int(_settings.get("beam_render_mode", 0)), 0, 1))
 	_beam_quality_option.select(clamp(int(_settings.get("beam_quality", 1)), 0, 2))
+	_environment_preset_option.select(clamp(int(_settings.get("environment_current_preset", 1)), 0, 4))
+	_environment_time_slider.value = clamp(float(_settings.get("environment_time_of_day", 0.4)), 0.0, 1.0)
+	_environment_cycle_speed_slider.value = max(float(_settings.get("environment_cycle_speed", 0.02)), 0.0)
+	for key in _toggle_controls.keys():
+		var toggle: CheckBox = _toggle_controls[key]
+		if toggle != null:
+			toggle.button_pressed = bool(_settings.get(key, false))
 	_background_picker.color = _settings.get("background_color", DEFAULT_SETTINGS["background_color"])
 	_update_value_labels()
 
@@ -238,6 +302,10 @@ func _on_beam_quality_selected(index: int) -> void:
 	_settings["beam_quality"] = clamp(index, 0, 2)
 	_emit_settings_changed()
 
+func _on_environment_preset_selected(index: int) -> void:
+	_settings["environment_current_preset"] = clamp(index, 0, 4)
+	_emit_settings_changed()
+
 func _update_value_labels() -> void:
 	_ambient_value_label.text = "%.2f" % float(_settings.get("ambient_multiplier", 0.08))
 	_spot_value_label.text = "%.2f" % float(_settings.get("spot_multiplier", 1.0))
@@ -246,6 +314,8 @@ func _update_value_labels() -> void:
 	_fog_density_value_label.text = "%.4f" % float(_settings.get("volumetric_fog_density", 0.0))
 	_fog_fade_value_label.text = "%.3f" % float(_settings.get("volumetric_fog_fade", 0.02))
 	_light_fog_energy_value_label.text = "%.2f" % float(_settings.get("light_volumetric_fog_energy", 12.0))
+	_environment_time_value_label.text = "%.3f" % float(_settings.get("environment_time_of_day", 0.4))
+	_environment_cycle_speed_value_label.text = "%.4f" % float(_settings.get("environment_cycle_speed", 0.02))
 
 func _emit_settings_changed() -> void:
 	settings_changed.emit(_settings.duplicate(true))

--- a/peraviz/test.tscn
+++ b/peraviz/test.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="Script" uid="uid://dk2vq6261dj54" path="res://scripts/load_scene.gd" id="1_script"]
 [ext_resource type="Script" uid="uid://c1syjijru4ah" path="res://scripts/editor_camera.gd" id="2_camera_script"]
 [ext_resource type="Script" uid="uid://bq8n5oubm8j8u" path="res://scripts/visual_settings_window.gd" id="3_visual_settings"]
+[ext_resource type="Script" path="res://scripts/day_night_environment_controller.gd" id="4_day_night_environment"]
 
 [sub_resource type="Environment" id="Environment_viewer"]
 background_mode = 1
@@ -55,6 +56,25 @@ directional_shadow_split_3 = 0.45
 directional_shadow_blend_splits = true
 directional_shadow_fade_start = 0.85
 directional_shadow_max_distance = 72.0
+
+[node name="DayNightEnvironmentController" type="Node3D" parent="." unique_id=364114672]
+script = ExtResource("4_day_night_environment")
+use_continuous_cycle = false
+current_preset = 1
+time_of_day = 0.4
+auto_advance = false
+cycle_speed = 0.02
+day_light_intensity = 0.7
+dusk_light_intensity = 0.18
+night_light_intensity = 0.02
+moon_light_intensity = 0.012
+ambient_energy_day = 0.08
+ambient_energy_night = 0.008
+horizon_warmth = 0.6
+horizon_intensity = 1.0
+allow_blackout_night = true
+world_environment_path = NodePath("../WorldEnvironment")
+directional_light_path = NodePath("../DirectionalLight3D")
 
 [node name="Ground" type="MeshInstance3D" parent="." unique_id=168744331]
 material_override = SubResource("StandardMaterial3D_ground")


### PR DESCRIPTION
### Motivation
- Provide a simple, maintainable day/night environment for Peraviz using only Godot 4 native resources, enabling quick artistic presets and an optional continuous cycle without changing fixture/DMX/gobo/beam systems.
- Keep the environment logic modular and decoupled so scene-level visual tuning does not interfere with existing lighting/beam rendering responsibilities.

### Description
- Added `peraviz/scripts/day_night_environment_controller.gd`, an `@tool` `DayNightEnvironmentController` that manages `WorldEnvironment`, `Environment/Sky` (using `ProceduralSkyMaterial`) and the existing `DirectionalLight3D`, exposing inspector parameters for presets, continuous `time_of_day`, auto-advance and tuning values (ambient, horizon, intensities, blackout). 
- Implemented presets `Dawn`, `Day`, `Dusk`, `Night`, and `BlackoutNight` plus smooth interpolation via a simple keyframe-to-keyframe lerp for continuous mode, and an option for near-total blackout night. 
- Integrated the controller into the main test scene by adding a `DayNightEnvironmentController` node to `peraviz/test.tscn` and wired `peraviz/scripts/load_scene.gd` to re-apply the controller after visual-setting updates so environment ownership stays consistent. 
- Added short usage documentation in `peraviz/docs/DAY_NIGHT_ENVIRONMENT.md` and left the design ready for future optional features (stars/clouds/presets) while avoiding changes to fixture/beam/gobo code paths.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd3c5cdce08324a6bd552e3677d81f)