### PR TITLE
Fix mirrored model transforms in Peraviz basis path

### DIFF
--- a/peraviz/docs/COORDINATE_SYSTEM.md
+++ b/peraviz/docs/COORDINATE_SYSTEM.md
@@ -57,6 +57,12 @@ After source vector remap:
 
 This is done with the documented intent to preserve parent/child composition correctness (`C * R * C^-1` mapping path).
 
+### Runtime application rule for imported basis
+- When native data provides `has_basis=true`, `load_scene.gd` now applies that basis
+  directly to `Node3D.transform` (without multiplying by a second scale).
+- Rationale: imported basis vectors already encode the original local scale/mirroring,
+  so re-applying an extra scale can distort mirrored model instances.
+
 ## 3) Runtime axis convention (up and forward)
 
 Peraviz runtime uses Godot conventions:

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -729,11 +729,9 @@ func _create_scene_node(data: Dictionary) -> Node3D:
 	var node_position: Vector3 = _safe_position(data.get("pos", Vector3.ZERO), "create_scene_node:" + root.name)
 	if bool(data.get("has_basis", false)):
 		var node_basis: Basis = _safe_basis_from_data(data)
-		var safe_scale: Vector3 = _safe_scale_from_data(data, "create_scene_node_basis:" + root.name)
-		node_basis = node_basis.scaled(safe_scale)
 		if not _is_basis_valid(node_basis):
-			print("[PeravizCoordDebug] event=scaled_basis_invalid_fallback node=", root.name, " scale=", safe_scale)
-			node_basis = Basis.IDENTITY.scaled(safe_scale)
+			print("[PeravizCoordDebug] event=basis_invalid_fallback node=", root.name)
+			node_basis = Basis.IDENTITY
 		root.transform = Transform3D(node_basis, node_position)
 	else:
 		root.position = node_position


### PR DESCRIPTION
### Motivation
- Imported native transforms that include a full local basis can already encode local scale and mirroring, and applying an extra runtime scale caused mirrored instances to be distorted compared to Perastage.
- The change aims to align Peraviz node instantiation with Perastage semantics so mirrored models use the same basis/axis interpretation and handedness.

### Description
- When `has_basis=true` the code now applies the imported `Basis` directly to `Node3D.transform` in `peraviz/scripts/load_scene.gd` instead of also multiplying the basis by a runtime scale. 
- Replaced the previous scaled-basis fallback with a simpler defensive `basis_invalid_fallback` that sets `Basis.IDENTITY` when the provided basis is invalid. 
- Documented the runtime rule in `peraviz/docs/COORDINATE_SYSTEM.md` explaining that imported basis vectors already encode scale/mirroring and should not be re-scaled at load time.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both reported `OK`.
- Verified the modified paths: `peraviz/scripts/load_scene.gd` and `peraviz/docs/COORDINATE_SYSTEM.md` were updated and no other automated checks failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdce3157d883249e8c3de4ec482eda)