### PR TITLE
Add GDTF fixture category inference, persistence and UI column

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -5,6 +5,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/credentialstore.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dummyprofilelibrary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtfdictionary.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gdtf_fixture_category.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtfnet.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/geometry/RdpSimplifier.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/guiconfigservices.cpp

--- a/core/gdtf_fixture_category.cpp
+++ b/core/gdtf_fixture_category.cpp
@@ -1,0 +1,348 @@
+#include "gdtf_fixture_category.h"
+
+#include <algorithm>
+#include <cctype>
+#include <limits>
+#include <set>
+#include <sstream>
+#include <string>
+
+#include <tinyxml2.h>
+#include <wx/wfstream.h>
+#include <wx/zipstrm.h>
+
+namespace {
+
+std::string ToLowerCopy(const std::string &value) {
+  std::string lowered = value;
+  std::transform(lowered.begin(), lowered.end(), lowered.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return lowered;
+}
+
+std::string Trim(const std::string &value) {
+  const auto first = value.find_first_not_of(" \t\r\n");
+  if (first == std::string::npos)
+    return {};
+  const auto last = value.find_last_not_of(" \t\r\n");
+  return value.substr(first, last - first + 1);
+}
+
+bool ContainsKeyword(const std::string &haystack, const char *needle) {
+  return haystack.find(needle) != std::string::npos;
+}
+
+bool ReadDescriptionXmlFromGdtf(const std::string &gdtfPath, std::string &xmlOut) {
+  wxFileInputStream input(gdtfPath);
+  if (!input.IsOk())
+    return false;
+
+  wxZipInputStream zip(input);
+  std::unique_ptr<wxZipEntry> entry;
+  while ((entry.reset(zip.GetNextEntry())), entry) {
+    const std::string name = ToLowerCopy(entry->GetName().ToStdString());
+    if (name != "description.xml")
+      continue;
+
+    std::ostringstream buffer;
+    char chunk[4096];
+    while (true) {
+      zip.Read(chunk, sizeof(chunk));
+      const size_t bytes = zip.LastRead();
+      if (bytes == 0)
+        break;
+      buffer.write(chunk, static_cast<std::streamsize>(bytes));
+    }
+    xmlOut = buffer.str();
+    return !xmlOut.empty();
+  }
+
+  return false;
+}
+
+const tinyxml2::XMLElement *ResolveFixtureType(const tinyxml2::XMLDocument &doc) {
+  const tinyxml2::XMLElement *fixtureType = doc.FirstChildElement("GDTF");
+  if (fixtureType)
+    fixtureType = fixtureType->FirstChildElement("FixtureType");
+  if (!fixtureType)
+    fixtureType = doc.FirstChildElement("FixtureType");
+  return fixtureType;
+}
+
+struct Signals {
+  bool hasPan = false;
+  bool hasTilt = false;
+  bool hasZoom = false;
+  bool hasFocus = false;
+  bool hasIris = false;
+  bool hasFrost = false;
+  bool hasGobo = false;
+  bool hasAnimationWheel = false;
+  bool hasFraming = false;
+  bool hasStrobe = false;
+  bool hasFog = false;
+  bool hasHaze = false;
+  bool hasBlower = false;
+  bool hasLaser = false;
+  bool hasVideo = false;
+  bool hasPixelControl = false;
+  bool hasSupport = false;
+  bool supportLooksLikeHoist = false;
+  bool hasBeamGeometry = false;
+  bool lampTypeIsLed = false;
+  float minBeamAngle = std::numeric_limits<float>::max();
+  float maxBeamAngle = -1.0f;
+  std::set<std::string> beamTypes;
+  std::string normalizedName;
+};
+
+void ParseGeometrySignals(const tinyxml2::XMLElement *node, Signals &signals) {
+  for (const tinyxml2::XMLElement *child = node->FirstChildElement(); child;
+       child = child->NextSiblingElement()) {
+    const std::string nodeName = ToLowerCopy(child->Name());
+
+    if (nodeName.find("beam") != std::string::npos)
+      signals.hasBeamGeometry = true;
+    if (nodeName.find("laser") != std::string::npos)
+      signals.hasLaser = true;
+    if (nodeName.find("display") != std::string::npos ||
+        nodeName.find("media") != std::string::npos)
+      signals.hasVideo = true;
+    if (nodeName.find("support") != std::string::npos)
+      signals.hasSupport = true;
+
+    const char *beamTypeAttr = child->Attribute("BeamType");
+    if (beamTypeAttr)
+      signals.beamTypes.insert(ToLowerCopy(Trim(beamTypeAttr)));
+
+    float beamAngle = 0.0f;
+    if (child->QueryFloatAttribute("BeamAngle", &beamAngle) == tinyxml2::XML_SUCCESS &&
+        beamAngle > 0.0f) {
+      signals.minBeamAngle = std::min(signals.minBeamAngle, beamAngle);
+      signals.maxBeamAngle = std::max(signals.maxBeamAngle, beamAngle);
+    }
+
+    float fieldAngle = 0.0f;
+    if (child->QueryFloatAttribute("FieldAngle", &fieldAngle) == tinyxml2::XML_SUCCESS &&
+        fieldAngle > 0.0f) {
+      signals.minBeamAngle = std::min(signals.minBeamAngle, fieldAngle);
+      signals.maxBeamAngle = std::max(signals.maxBeamAngle, fieldAngle);
+    }
+
+    if (const char *typeAttr = child->Attribute("Type")) {
+      const std::string type = ToLowerCopy(Trim(typeAttr));
+      if (type == "rope")
+        signals.supportLooksLikeHoist = true;
+    }
+
+    ParseGeometrySignals(child, signals);
+  }
+}
+
+void ParseAttributeSignals(const tinyxml2::XMLElement *node, Signals &signals) {
+  for (const tinyxml2::XMLElement *child = node->FirstChildElement(); child;
+       child = child->NextSiblingElement()) {
+    const std::string name = ToLowerCopy(child->Attribute("Name") ? child->Attribute("Name") : "");
+    const std::string pretty = ToLowerCopy(child->Attribute("Pretty") ? child->Attribute("Pretty") : "");
+    const std::string combined = name + " " + pretty;
+
+    if (ContainsKeyword(combined, "pan"))
+      signals.hasPan = true;
+    if (ContainsKeyword(combined, "tilt"))
+      signals.hasTilt = true;
+    if (ContainsKeyword(combined, "zoom"))
+      signals.hasZoom = true;
+    if (ContainsKeyword(combined, "focus"))
+      signals.hasFocus = true;
+    if (ContainsKeyword(combined, "iris"))
+      signals.hasIris = true;
+    if (ContainsKeyword(combined, "frost"))
+      signals.hasFrost = true;
+    if (ContainsKeyword(combined, "gobo"))
+      signals.hasGobo = true;
+    if (ContainsKeyword(combined, "animation"))
+      signals.hasAnimationWheel = true;
+    if (ContainsKeyword(combined, "blade") || ContainsKeyword(combined, "shaper") ||
+        ContainsKeyword(combined, "keystone"))
+      signals.hasFraming = true;
+    if (ContainsKeyword(combined, "strobe") || ContainsKeyword(combined, "shutter"))
+      signals.hasStrobe = true;
+    if (ContainsKeyword(combined, "fog"))
+      signals.hasFog = true;
+    if (ContainsKeyword(combined, "haze"))
+      signals.hasHaze = true;
+    if (ContainsKeyword(combined, "blower") || ContainsKeyword(combined, "fan"))
+      signals.hasBlower = true;
+    if (ContainsKeyword(combined, "video") || ContainsKeyword(combined, "inputsource") ||
+        ContainsKeyword(combined, "fov"))
+      signals.hasVideo = true;
+    if (ContainsKeyword(combined, "pixel") || ContainsKeyword(combined, "ledzonemode"))
+      signals.hasPixelControl = true;
+
+    ParseAttributeSignals(child, signals);
+  }
+}
+
+Signals ExtractSignals(const std::string &xml) {
+  Signals signals;
+
+  tinyxml2::XMLDocument doc;
+  if (doc.Parse(xml.c_str()) != tinyxml2::XML_SUCCESS)
+    return signals;
+
+  const tinyxml2::XMLElement *fixtureType = ResolveFixtureType(doc);
+  if (!fixtureType)
+    return signals;
+
+  const char *name = fixtureType->Attribute("Name");
+  const char *shortName = fixtureType->Attribute("ShortName");
+  const char *longName = fixtureType->Attribute("LongName");
+  signals.normalizedName = ToLowerCopy(Trim(std::string(name ? name : "") + " " +
+                                            std::string(shortName ? shortName : "") + " " +
+                                            std::string(longName ? longName : "")));
+
+  if (const tinyxml2::XMLElement *physical = fixtureType->FirstChildElement("PhysicalDescriptions")) {
+    if (const tinyxml2::XMLElement *emitters = physical->FirstChildElement("Emitters")) {
+      for (const tinyxml2::XMLElement *emitter = emitters->FirstChildElement("Emitter"); emitter;
+           emitter = emitter->NextSiblingElement("Emitter")) {
+        if (const char *lampType = emitter->Attribute("LampType")) {
+          if (ToLowerCopy(Trim(lampType)) == "led")
+            signals.lampTypeIsLed = true;
+        }
+      }
+    }
+  }
+
+  if (const tinyxml2::XMLElement *geometries = fixtureType->FirstChildElement("Geometries"))
+    ParseGeometrySignals(geometries, signals);
+
+  if (const tinyxml2::XMLElement *defs = fixtureType->FirstChildElement("AttributeDefinitions"))
+    ParseAttributeSignals(defs, signals);
+
+  return signals;
+}
+
+bool HasNameKeyword(const std::string &name, std::initializer_list<const char *> keys) {
+  for (const char *key : keys) {
+    if (ContainsKeyword(name, key))
+      return true;
+  }
+  return false;
+}
+
+} // namespace
+
+namespace GdtfFixtureCategory {
+
+bool IsValidCategory(const std::string &category) {
+  const std::string normalized = NormalizeCategory(category);
+  return !normalized.empty();
+}
+
+std::string NormalizeCategory(const std::string &category) {
+  const std::string lowered = ToLowerCopy(Trim(category));
+  if (lowered.empty())
+    return {};
+  if (lowered == "unknown")
+    return kUnknown;
+  if (lowered == "hoist")
+    return kHoist;
+  if (lowered == "smoke" || lowered == "haze" || lowered == "fog")
+    return kSmoke;
+  if (lowered == "laser")
+    return kLaser;
+  if (lowered == "video" || lowered == "display" || lowered == "media")
+    return kVideo;
+  if (lowered == "fx")
+    return kFx;
+  if (lowered == "strobe")
+    return kStrobe;
+  if (lowered == "led")
+    return kLed;
+  if (lowered == "conventional")
+    return kConventional;
+  if (lowered == "wash")
+    return kWash;
+  if (lowered == "spot")
+    return kSpot;
+  if (lowered == "beam")
+    return kBeam;
+  if (lowered == "hybrid")
+    return kHybrid;
+  return {};
+}
+
+InferenceResult InferFromGdtf(const std::string &gdtfPath) {
+  std::string xml;
+  if (!ReadDescriptionXmlFromGdtf(gdtfPath, xml))
+    return {kUnknown, "missing description.xml"};
+
+  Signals s = ExtractSignals(xml);
+  const bool hasMovement = s.hasPan && s.hasTilt;
+  const bool narrowBeam = s.minBeamAngle > 0.0f && s.minBeamAngle <= 8.0f;
+  const bool wideBeam = s.maxBeamAngle >= 20.0f;
+  const bool wideZoomRange = s.minBeamAngle > 0.0f && s.maxBeamAngle > 0.0f &&
+                             (s.maxBeamAngle - s.minBeamAngle) >= 15.0f;
+  const bool hasSpotOptics = s.hasGobo || s.hasAnimationWheel || s.hasIris ||
+                             s.hasFocus || s.hasFraming;
+  const bool washBeamType = s.beamTypes.contains("wash") || s.beamTypes.contains("pc") ||
+                            s.beamTypes.contains("fresnel") || s.beamTypes.contains("glow");
+  const bool spotBeamType = s.beamTypes.contains("spot") || s.beamTypes.contains("rectangle");
+  const bool canDoWash = s.hasFrost || washBeamType || wideBeam;
+
+  if (s.hasSupport && s.supportLooksLikeHoist && !s.hasBeamGeometry && !s.hasLaser &&
+      !s.hasVideo && !s.hasFog && !s.hasHaze) {
+    return {kHoist, "support geometry"};
+  }
+
+  if (s.hasFog || s.hasHaze || s.hasBlower ||
+      HasNameKeyword(s.normalizedName, {"haze", "hazer", "fog", "smoke"})) {
+    return {kSmoke, "fog/haze signals"};
+  }
+
+  if (s.hasLaser || HasNameKeyword(s.normalizedName, {"laser"}))
+    return {kLaser, "laser signals"};
+
+  if (s.hasVideo || HasNameKeyword(s.normalizedName, {"video", "media server", "display"}))
+    return {kVideo, "video signals"};
+
+  if (!s.hasBeamGeometry && !hasMovement &&
+      HasNameKeyword(s.normalizedName, {"pyro", "confetti", "snow", "bubble", "flame"})) {
+    return {kFx, "fx keyword"};
+  }
+
+  if (!hasMovement) {
+    if (s.hasStrobe && !s.hasGobo && !s.hasIris && !s.hasFraming && !s.hasFocus)
+      return {kStrobe, "static strobe profile"};
+    if (s.hasPixelControl &&
+        HasNameKeyword(s.normalizedName, {"pixel", "bar", "strip", "panel", "blinder"})) {
+      return {kLed, "pixel/led profile"};
+    }
+    return {kConventional, "static fallback"};
+  }
+
+  if (hasSpotOptics && (canDoWash || wideZoomRange || (narrowBeam && wideBeam)))
+    return {kHybrid, "hybrid profile"};
+
+  if (narrowBeam && !canDoWash)
+    return {kBeam, "narrow beam"};
+
+  if (hasSpotOptics || spotBeamType)
+    return {kSpot, "spot optics"};
+
+  if (canDoWash)
+    return {kWash, "wash optics"};
+
+  if (s.hasPixelControl || (s.lampTypeIsLed && HasNameKeyword(s.normalizedName, {"bar", "panel", "pixel"})))
+    return {kLed, "moving led fallback"};
+
+  if (hasSpotOptics)
+    return {kSpot, "moving fallback spot"};
+
+  if (hasMovement)
+    return {kWash, "moving fallback wash"};
+
+  return {kUnknown, "ambiguous"};
+}
+
+} // namespace GdtfFixtureCategory

--- a/core/gdtf_fixture_category.cpp
+++ b/core/gdtf_fixture_category.cpp
@@ -368,6 +368,9 @@ InferenceResult InferFromGdtf(const std::string &gdtfPath) {
   const bool strongWashCapability = s.hasFrost || washBeamType || wideZoomRange ||
                                   (narrowBeam && wideBeam);
 
+  if (!s.hasGobo)
+    return {kWash, "moving without gobo"};
+
   if (HasNameKeyword(s.normalizedName, {"profile", "followspot"}) && hasSpotOptics &&
       !strongWashCapability)
     return {kSpot, "profile optics"};

--- a/core/gdtf_fixture_category.cpp
+++ b/core/gdtf_fixture_category.cpp
@@ -109,6 +109,7 @@ struct Signals {
   bool hasBlower = false;
   bool hasLaser = false;
   bool hasVideo = false;
+  bool hasDisplayOrMediaGeometry = false;
   bool hasPixelControl = false;
   bool hasSupport = false;
   bool supportLooksLikeHoist = false;
@@ -130,8 +131,10 @@ void ParseGeometrySignals(const tinyxml2::XMLElement *node, Signals &signals) {
     if (nodeName.find("laser") != std::string::npos)
       signals.hasLaser = true;
     if (nodeName.find("display") != std::string::npos ||
-        nodeName.find("media") != std::string::npos)
+        nodeName.find("media") != std::string::npos) {
       signals.hasVideo = true;
+      signals.hasDisplayOrMediaGeometry = true;
+    }
     if (nodeName.find("support") != std::string::npos)
       signals.hasSupport = true;
 
@@ -335,8 +338,11 @@ InferenceResult InferFromGdtf(const std::string &gdtfPath) {
   if (s.hasLaser || HasNameKeyword(s.normalizedName, {"laser"}))
     return {kLaser, "laser signals"};
 
-  if (s.hasVideo || HasNameKeyword(s.normalizedName, {"video", "media server", "display"}))
+  if ((s.hasDisplayOrMediaGeometry ||
+       (!hasMovement && s.hasVideo && !s.hasBeamGeometry)) &&
+      !HasNameKeyword(s.normalizedName, {"wash", "spot", "beam", "profile"})) {
     return {kVideo, "video signals"};
+  }
 
   if (!s.hasBeamGeometry && !hasMovement &&
       HasNameKeyword(s.normalizedName, {"pyro", "confetti", "snow", "bubble", "flame"})) {
@@ -359,7 +365,14 @@ InferenceResult InferFromGdtf(const std::string &gdtfPath) {
     return {kConventional, "static fallback"};
   }
 
-  if (hasSpotOptics && (canDoWash || wideZoomRange || (narrowBeam && wideBeam)))
+  const bool strongWashCapability = s.hasFrost || washBeamType || wideZoomRange ||
+                                  (narrowBeam && wideBeam);
+
+  if (HasNameKeyword(s.normalizedName, {"profile", "followspot"}) && hasSpotOptics &&
+      !strongWashCapability)
+    return {kSpot, "profile optics"};
+
+  if (hasSpotOptics && strongWashCapability)
     return {kHybrid, "hybrid profile"};
 
   if (narrowBeam && !canDoWash)

--- a/core/gdtf_fixture_category.cpp
+++ b/core/gdtf_fixture_category.cpp
@@ -250,8 +250,13 @@ Signals ExtractSignals(const std::string &xml) {
 
 bool HasNameKeyword(const std::string &name, std::initializer_list<const char *> keys) {
   for (const char *key : keys) {
-    if (ContainsWord(name, key) || ContainsKeyword(name, key))
+    const std::string pattern = ToLowerCopy(key);
+    if (pattern.find(' ') != std::string::npos) {
+      if (ContainsKeyword(name, pattern.c_str()))
+        return true;
+    } else if (ContainsWord(name, pattern.c_str())) {
       return true;
+    }
   }
   return false;
 }
@@ -321,8 +326,9 @@ InferenceResult InferFromGdtf(const std::string &gdtfPath) {
     return {kHoist, "support geometry"};
   }
 
-  if (s.hasFog || s.hasHaze || s.hasBlower ||
-      HasNameKeyword(s.normalizedName, {"haze", "hazer", "fog", "smoke"})) {
+  if (!hasMovement &&
+      (s.hasFog || s.hasHaze || s.hasBlower ||
+       HasNameKeyword(s.normalizedName, {"haze", "hazer", "fog", "smoke"}))) {
     return {kSmoke, "fog/haze signals"};
   }
 
@@ -338,11 +344,16 @@ InferenceResult InferFromGdtf(const std::string &gdtfPath) {
   }
 
   if (!hasMovement) {
-    if ((s.hasStrobe || HasNameKeyword(s.normalizedName, {"strobe", "blinder", "flash"})) &&
-        !s.hasGobo && !s.hasIris && !s.hasFraming && !s.hasFocus)
+    const bool looksLikeLedUnit =
+        HasNameKeyword(s.normalizedName, {"pixel", "bar", "strip", "panel", "par", "blinder"});
+    const bool looksLikeStrobeName =
+        HasNameKeyword(s.normalizedName, {"strobe", "flash", "q-7", "q7"});
+
+    if ((s.hasStrobe || (s.hasShutter && looksLikeStrobeName) || looksLikeStrobeName) &&
+        !s.hasGobo && !s.hasIris && !s.hasFraming && !s.hasFocus && !looksLikeLedUnit) {
       return {kStrobe, "static strobe profile"};
-    if (s.hasPixelControl &&
-        HasNameKeyword(s.normalizedName, {"pixel", "bar", "strip", "panel", "blinder"})) {
+    }
+    if (s.hasPixelControl || (s.lampTypeIsLed && looksLikeLedUnit)) {
       return {kLed, "pixel/led profile"};
     }
     return {kConventional, "static fallback"};

--- a/core/gdtf_fixture_category.cpp
+++ b/core/gdtf_fixture_category.cpp
@@ -6,6 +6,7 @@
 #include <set>
 #include <sstream>
 #include <string>
+#include <vector>
 
 #include <tinyxml2.h>
 #include <wx/wfstream.h>
@@ -30,6 +31,28 @@ std::string Trim(const std::string &value) {
 
 bool ContainsKeyword(const std::string &haystack, const char *needle) {
   return haystack.find(needle) != std::string::npos;
+}
+
+std::vector<std::string> TokenizeWords(const std::string &text) {
+  std::vector<std::string> tokens;
+  std::string current;
+  for (unsigned char c : text) {
+    if (std::isalnum(c)) {
+      current.push_back(static_cast<char>(std::tolower(c)));
+    } else if (!current.empty()) {
+      tokens.push_back(current);
+      current.clear();
+    }
+  }
+  if (!current.empty())
+    tokens.push_back(current);
+  return tokens;
+}
+
+bool ContainsWord(const std::string &haystack, const char *needle) {
+  const std::string target = ToLowerCopy(needle);
+  const auto tokens = TokenizeWords(haystack);
+  return std::find(tokens.begin(), tokens.end(), target) != tokens.end();
 }
 
 bool ReadDescriptionXmlFromGdtf(const std::string &gdtfPath, std::string &xmlOut) {
@@ -80,6 +103,7 @@ struct Signals {
   bool hasAnimationWheel = false;
   bool hasFraming = false;
   bool hasStrobe = false;
+  bool hasShutter = false;
   bool hasFog = false;
   bool hasHaze = false;
   bool hasBlower = false;
@@ -165,13 +189,15 @@ void ParseAttributeSignals(const tinyxml2::XMLElement *node, Signals &signals) {
     if (ContainsKeyword(combined, "blade") || ContainsKeyword(combined, "shaper") ||
         ContainsKeyword(combined, "keystone"))
       signals.hasFraming = true;
-    if (ContainsKeyword(combined, "strobe") || ContainsKeyword(combined, "shutter"))
+    if (ContainsKeyword(combined, "strobe"))
       signals.hasStrobe = true;
-    if (ContainsKeyword(combined, "fog"))
+    if (ContainsKeyword(combined, "shutter"))
+      signals.hasShutter = true;
+    if (ContainsWord(combined, "fog"))
       signals.hasFog = true;
-    if (ContainsKeyword(combined, "haze"))
+    if (ContainsWord(combined, "haze"))
       signals.hasHaze = true;
-    if (ContainsKeyword(combined, "blower") || ContainsKeyword(combined, "fan"))
+    if (ContainsWord(combined, "blower") || ContainsWord(combined, "fan"))
       signals.hasBlower = true;
     if (ContainsKeyword(combined, "video") || ContainsKeyword(combined, "inputsource") ||
         ContainsKeyword(combined, "fov"))
@@ -224,7 +250,7 @@ Signals ExtractSignals(const std::string &xml) {
 
 bool HasNameKeyword(const std::string &name, std::initializer_list<const char *> keys) {
   for (const char *key : keys) {
-    if (ContainsKeyword(name, key))
+    if (ContainsWord(name, key) || ContainsKeyword(name, key))
       return true;
   }
   return false;
@@ -312,7 +338,8 @@ InferenceResult InferFromGdtf(const std::string &gdtfPath) {
   }
 
   if (!hasMovement) {
-    if (s.hasStrobe && !s.hasGobo && !s.hasIris && !s.hasFraming && !s.hasFocus)
+    if ((s.hasStrobe || HasNameKeyword(s.normalizedName, {"strobe", "blinder", "flash"})) &&
+        !s.hasGobo && !s.hasIris && !s.hasFraming && !s.hasFocus)
       return {kStrobe, "static strobe profile"};
     if (s.hasPixelControl &&
         HasNameKeyword(s.normalizedName, {"pixel", "bar", "strip", "panel", "blinder"})) {

--- a/core/gdtf_fixture_category.h
+++ b/core/gdtf_fixture_category.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <string>
+
+namespace GdtfFixtureCategory {
+
+inline constexpr const char *kUnknown = "Unknown";
+inline constexpr const char *kHoist = "Hoist";
+inline constexpr const char *kSmoke = "Smoke";
+inline constexpr const char *kLaser = "Laser";
+inline constexpr const char *kVideo = "Video";
+inline constexpr const char *kFx = "FX";
+inline constexpr const char *kStrobe = "Strobe";
+inline constexpr const char *kLed = "LED";
+inline constexpr const char *kConventional = "Conventional";
+inline constexpr const char *kWash = "Wash";
+inline constexpr const char *kSpot = "Spot";
+inline constexpr const char *kBeam = "Beam";
+inline constexpr const char *kHybrid = "Hybrid";
+
+inline constexpr const char *kManualSource = "Manual";
+inline constexpr const char *kAutoFallbackSource = "AutoFallback";
+
+struct InferenceResult {
+  std::string category;
+  std::string reason;
+};
+
+bool IsValidCategory(const std::string &category);
+std::string NormalizeCategory(const std::string &category);
+InferenceResult InferFromGdtf(const std::string &gdtfPath);
+
+} // namespace GdtfFixtureCategory

--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -88,7 +88,7 @@ std::optional<std::unordered_map<std::string, Entry>> Load() {
       fs::path p = fs::u8path(it.value().get<std::string>());
       if (!p.is_absolute())
         p = dir / p;
-      dict[it.key()] = {p.string(), ""};
+      dict[it.key()] = {p.string(), "", ""};
     } else if (it.value().is_object()) {
       Entry e;
       std::string fname;
@@ -102,6 +102,8 @@ std::optional<std::unordered_map<std::string, Entry>> Load() {
       e.path = p.string();
       if (it.value().contains("mode") && it.value()["mode"].is_string())
         e.mode = it.value()["mode"].get<std::string>();
+      if (it.value().contains("category") && it.value()["category"].is_string())
+        e.category = it.value()["category"].get<std::string>();
       dict[it.key()] = e;
     }
   }
@@ -126,6 +128,8 @@ void Save(const std::unordered_map<std::string, Entry> &dict) {
     obj["file"] = p.filename().string();
     if (!entry.mode.empty())
       obj["mode"] = entry.mode;
+    if (!entry.category.empty())
+      obj["category"] = entry.category;
     j[type] = obj;
   }
   std::ofstream out(file);
@@ -151,7 +155,7 @@ std::optional<Entry> Get(const std::string &type) {
   return it->second;
 }
 
-void Update(const std::string &type, const std::string &gdtfPath, const std::string &mode) {
+void Update(const std::string &type, const std::string &gdtfPath, const std::string &mode, const std::string &category) {
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
   if (type.empty() || gdtfPath.empty())
     return;
@@ -179,6 +183,26 @@ void Update(const std::string &type, const std::string &gdtfPath, const std::str
   e.path = dest.string();
   if (!mode.empty())
     e.mode = mode;
+  if (!category.empty())
+    e.category = category;
+  dict[type] = e;
+  Save(dict);
+}
+
+
+void UpdateCategory(const std::string &type, const std::string &category) {
+  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
+  if (type.empty())
+    return;
+  auto dictOpt = Load();
+  if (!dictOpt)
+    return;
+  auto &dict = *dictOpt;
+  Entry e;
+  auto it = dict.find(type);
+  if (it != dict.end())
+    e = it->second;
+  e.category = category;
   dict[type] = e;
   Save(dict);
 }

--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -96,6 +96,8 @@ std::optional<std::unordered_map<std::string, Entry>> Load() {
         fname = it.value()["file"].get<std::string>();
       else if (it.value().contains("path") && it.value()["path"].is_string())
         fname = it.value()["path"].get<std::string>();
+      if (fname.empty())
+        continue;
       fs::path p = fs::u8path(fname);
       if (!p.is_absolute())
         p = dir / p;
@@ -123,9 +125,14 @@ void Save(const std::unordered_map<std::string, Entry> &dict) {
   std::sort(keys.begin(), keys.end());
   for (const auto &type : keys) {
     const auto &entry = dict.at(type);
+    if (entry.path.empty())
+      continue;
     nlohmann::json obj;
     fs::path p = fs::u8path(entry.path);
-    obj["file"] = p.filename().string();
+    const std::string fileName = p.filename().string();
+    if (fileName.empty())
+      continue;
+    obj["file"] = fileName;
     if (!entry.mode.empty())
       obj["mode"] = entry.mode;
     if (!entry.category.empty())
@@ -198,12 +205,10 @@ void UpdateCategory(const std::string &type, const std::string &category) {
   if (!dictOpt)
     return;
   auto &dict = *dictOpt;
-  Entry e;
   auto it = dict.find(type);
-  if (it != dict.end())
-    e = it->second;
-  e.category = category;
-  dict[type] = e;
+  if (it == dict.end())
+    return;
+  it->second.category = category;
   Save(dict);
 }
 

--- a/core/gdtfdictionary.h
+++ b/core/gdtfdictionary.h
@@ -25,6 +25,7 @@ namespace GdtfDictionary {
     struct Entry {
         std::string path; // absolute path inside fixtures library
         std::string mode;
+        std::string category;
     };
 
     // Loads the dictionary file into a map of type -> {gdtf path in library, default mode}
@@ -35,5 +36,6 @@ namespace GdtfDictionary {
     // If the file is missing, the entry is removed and std::nullopt returned.
     std::optional<Entry> Get(const std::string& type);
     // Copies the gdtf file into the fixtures library and updates the dictionary
-    void Update(const std::string& type, const std::string& gdtfPath, const std::string& mode = {});
+    void Update(const std::string& type, const std::string& gdtfPath, const std::string& mode = {}, const std::string& category = {});
+    void UpdateCategory(const std::string& type, const std::string& category);
 }

--- a/gui/dictionaryeditdialog.cpp
+++ b/gui/dictionaryeditdialog.cpp
@@ -252,7 +252,7 @@ void DictionaryEditDialog::SaveFixtures() {
   std::unordered_map<std::string, GdtfDictionary::Entry> dict;
   dict.reserve(rows.size());
   for (const auto &row : rows)
-    dict[row.name] = {row.path, row.mode};
+    dict[row.name] = {row.path, row.mode, ""};
   GdtfDictionary::Save(dict);
 
   LoadFixtures();

--- a/gui/fixtureeditdialog.cpp
+++ b/gui/fixtureeditdialog.cpp
@@ -21,6 +21,7 @@
 #include "gdtfdictionary.h"
 #include "gdtfloader.h"
 #include "projectutils.h"
+#include "gdtf_fixture_category.h"
 #include "viewer3dpanel.h"
 #include <wx/filedlg.h>
 #include <wx/filename.h>
@@ -78,6 +79,18 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
       ctrls[i] = modelCtrl;
       grid->Add(hs, 1, wxEXPAND);
     } else if (i == 18) {
+      auto *category = new wxChoice(this, wxID_ANY);
+      const wxArrayString values = {
+          "Unknown", "Hoist", "Smoke", "Laser", "Video", "FX", "Strobe",
+          "LED", "Conventional", "Wash", "Spot", "Beam", "Hybrid"};
+      for (const auto &entry : values)
+        category->Append(entry);
+      int selection = category->FindString(v.GetString());
+      if (selection != wxNOT_FOUND)
+        category->SetSelection(selection);
+      ctrls[i] = category;
+      grid->Add(category, 1, wxEXPAND);
+    } else if (i == 19) {
       wxString colorString;
       if (v.GetType() == "wxDataViewIconText") {
         wxDataViewIconText icon;
@@ -233,6 +246,10 @@ void FixtureEditDialog::ApplyChanges() {
         panel->gdtfPaths.resize(row + 1);
       panel->gdtfPaths[row] = gdtfPath;
     } else if (i == 18) {
+      auto *category = wxDynamicCast(ctrls[i], wxChoice);
+      if (category)
+        table->SetValue(wxVariant(category->GetStringSelection()), row, i);
+    } else if (i == 19) {
       auto *picker = wxDynamicCast(ctrls[i], wxColourPickerCtrl);
       if (picker) {
         wxColour selectedColor = picker->GetColour();
@@ -267,8 +284,12 @@ void FixtureEditDialog::ApplyChanges() {
     std::string mode =
         modeChoice ? std::string(modeChoice->GetStringSelection().ToUTF8()) :
                      std::string();
+    wxVariant categoryVar;
+    table->GetValue(categoryVar, row, 18);
+    const std::string category =
+        GdtfFixtureCategory::NormalizeCategory(std::string(categoryVar.GetString().ToUTF8()));
     GdtfDictionary::Update(std::string(originalType.ToUTF8()),
-                           std::string(gdtfPath.ToUTF8()), mode);
+                           std::string(gdtfPath.ToUTF8()), mode, category);
     panel->ApplyModeForGdtf(gdtfPath, wxString::FromUTF8(mode));
   }
   panel->ResyncRows(oldOrder, selectedUuids);

--- a/gui/fixturetable/fixture_table_columns.cpp
+++ b/gui/fixturetable/fixture_table_columns.cpp
@@ -10,13 +10,13 @@ std::vector<wxString> DefaultLabels() {
           "Hang Pos",   "Universe",    "Channel",   "Mode",
           "Ch Count",   "Model file",  "Pos X",     "Pos Y",
           "Pos Z",      "Roll (X)",    "Pitch (Y)", "Yaw (Z)",
-          "Power (W)",  "Weight (kg)", "Color"};
+          "Power (W)",  "Weight (kg)", "Category", "Color"};
 }
 
 void ConfigureColumns(wxDataViewListCtrl *table,
                       const std::vector<wxString> &columnLabels) {
   std::vector<int> widths = {90, 150, 180, 100, 120, 80, 80,  120, 80, 180,
-                             80, 80,  80,  80,  80,  80, 100, 100, 80};
+                             80, 80,  80,  80,  80,  80, 100, 100, 120, 80};
   int flags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE;
 
   auto *idRenderer =

--- a/gui/fixturetable/fixture_table_edit_service.cpp
+++ b/gui/fixturetable/fixture_table_edit_service.cpp
@@ -3,6 +3,8 @@
 #include "consolepanel.h"
 #include "../dataview_edit_commit.h"
 #include "matrixutils.h"
+#include "gdtfdictionary.h"
+#include "gdtf_fixture_category.h"
 
 #include <algorithm>
 #include <unordered_map>
@@ -32,10 +34,10 @@ std::vector<int> BuildOrderedRows(const std::vector<int> &selectedRows,
 
 void PropagateTypeValues(wxDataViewListCtrl *table,
                          const wxDataViewItemArray &selections, int col) {
-  if (col != 16 && col != 17 && col != 18)
+  if (col != 16 && col != 17 && col != 18 && col != 19)
     return;
 
-  if (col == 18)
+  if (col == 19)
     return;
 
   std::unordered_map<std::string, wxString> typeValues;
@@ -189,6 +191,11 @@ void UpdateSceneData(ISceneAdapter &adapter, wxDataViewListCtrl *table,
     next.weightKg = static_cast<float>(wt);
 
     table->GetValue(v, i, 18);
+    next.category = GdtfFixtureCategory::NormalizeCategory(std::string(v.GetString().ToUTF8()));
+    if (!next.category.empty())
+      next.categorySource = GdtfFixtureCategory::kManualSource;
+
+    table->GetValue(v, i, 19);
     if (v.GetType() == "wxDataViewIconText") {
       wxDataViewIconText icon;
       icon << v;
@@ -212,6 +219,7 @@ void UpdateSceneData(ISceneAdapter &adapter, wxDataViewListCtrl *table,
                                 transformChanged ||
                                 old.powerConsumptionW != next.powerConsumptionW ||
                                 old.weightKg != next.weightKg ||
+                                old.category != next.category ||
                                 old.color != next.color;
     if (!fixtureChanged)
       continue;
@@ -219,6 +227,8 @@ void UpdateSceneData(ISceneAdapter &adapter, wxDataViewListCtrl *table,
     pushUndoIfNeeded();
     anyChanged = true;
     it->second = next;
+    if (!next.typeName.empty() && !next.category.empty())
+      GdtfDictionary::UpdateCategory(next.typeName, next.category);
     if (!it->second.position.empty())
       scene.positions[it->second.position] = it->second.positionName;
 

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -283,8 +283,10 @@ void FixtureTablePanel::ReloadData() {
     row.push_back(yaw);
     wxString power = wxString::Format("%.1f", fixture->powerConsumptionW);
     wxString weight = wxString::Format("%.2f", fixture->weightKg);
+    wxString category = wxString::FromUTF8(fixture->category);
     row.push_back(power);
     row.push_back(weight);
+    row.push_back(category);
     wxString color = wxString::FromUTF8(fixture->color);
     if (!color.IsEmpty()) {
       wxColour col(color);
@@ -587,6 +589,37 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
   table->GetValue(current, baseRow, col);
 
   if (col == 18) {
+    const wxArrayString choices = {
+        "Unknown", "Hoist", "Smoke", "Laser", "Video", "FX", "Strobe",
+        "LED", "Conventional", "Wash", "Spot", "Beam", "Hybrid"};
+    wxSingleChoiceDialog dlg(this, "Select category", "Category", choices);
+    if (!current.GetString().empty()) {
+      int sel = choices.Index(current.GetString());
+      if (sel != wxNOT_FOUND)
+        dlg.SetSelection(sel);
+    }
+    if (dlg.ShowModal() != wxID_OK)
+      return;
+    const wxString value = dlg.GetStringSelection();
+    for (const auto &it : selections) {
+      int r = table->ItemToRow(it);
+      if (r != wxNOT_FOUND)
+        table->SetValue(wxVariant(value), r, col);
+    }
+    PropagateTypeValues(selections, col);
+    ResyncRows(oldOrder, selectedUuids);
+    UpdateSceneData();
+    HighlightDuplicateFixtureIds();
+    if (Viewer3DPanel::Instance()) {
+      Viewer3DPanel::Instance()->UpdateScene();
+      Viewer3DPanel::Instance()->Refresh();
+    } else if (Viewer2DPanel::Instance()) {
+      Viewer2DPanel::Instance()->UpdateScene();
+    }
+    return;
+  }
+
+  if (col == 19) {
     wxColourData data;
     data.SetChooseFull(true);
     wxColour initial(current.GetString());

--- a/models/fixture.h
+++ b/models/fixture.h
@@ -52,6 +52,9 @@ struct Fixture {
     float powerConsumptionW = 0.0f; // Power consumption in watts
     float weightKg = 0.0f;          // Fixture weight in kilograms
 
+    std::string category;         // Fixture category (Spot, Wash, etc.)
+    std::string categorySource;   // Category source (Manual, AutoFallback, ...)
+
     // Convenience method to access translation as array
     std::array<float,3> GetPosition() const { return transform.o; }
 };

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -1195,6 +1195,17 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
       info->InsertEndChild(instanceName);
     }
 
+    if (!f.category.empty()) {
+      tinyxml2::XMLElement *category = doc.NewElement("Category");
+      category->SetText(f.category.c_str());
+      info->InsertEndChild(category);
+    }
+    if (!f.categorySource.empty()) {
+      tinyxml2::XMLElement *categorySource = doc.NewElement("CategorySource");
+      categorySource->SetText(f.categorySource.c_str());
+      info->InsertEndChild(categorySource);
+    }
+
     data->InsertEndChild(info);
     ud->InsertEndChild(data);
     fe->InsertEndChild(ud);

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -1001,6 +1001,13 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
   };
 
   std::unordered_set<std::string> usedStableUuids;
+
+  struct CachedCategory {
+    std::string category;
+    std::string source;
+    std::string reason;
+  };
+  std::unordered_map<std::string, CachedCategory> categoryByTypeKey;
   auto buildStableIdSeed = [&](const char *kind, tinyxml2::XMLElement *node,
                                const std::string &layerName,
                                const Matrix &nodeTransform,
@@ -1115,6 +1122,9 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         }
 
         ReadFixtureCategoryFromUserData(node, fixture);
+        const std::string categoryKey =
+            !fixture.typeName.empty() ? fixture.typeName : fixture.gdtfSpec;
+
         if (fixture.category.empty() && !fixture.typeName.empty()) {
           if (auto entry = GdtfDictionary::Get(fixture.typeName))
             fixture.category = GdtfFixtureCategory::NormalizeCategory(entry->category);
@@ -1122,8 +1132,13 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
             fixture.categorySource = GdtfFixtureCategory::kManualSource;
         }
 
-        if (!fixture.category.empty() && !fixture.typeName.empty())
-          GdtfDictionary::UpdateCategory(fixture.typeName, fixture.category);
+        if (fixture.category.empty() && !categoryKey.empty()) {
+          auto cacheIt = categoryByTypeKey.find(categoryKey);
+          if (cacheIt != categoryByTypeKey.end()) {
+            fixture.category = cacheIt->second.category;
+            fixture.categorySource = cacheIt->second.source;
+          }
+        }
 
         if (fixture.category.empty() && !fixture.gdtfSpec.empty()) {
           const auto inferred = GdtfFixtureCategory::InferFromGdtf(fixture.gdtfSpec);
@@ -1131,13 +1146,24 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
           if (fixture.category.empty())
             fixture.category = GdtfFixtureCategory::kUnknown;
           fixture.categorySource = GdtfFixtureCategory::kAutoFallbackSource;
-          if (!fixture.typeName.empty())
-            GdtfDictionary::UpdateCategory(fixture.typeName, fixture.category);
+          if (!categoryKey.empty()) {
+            categoryByTypeKey[categoryKey] =
+                {fixture.category, fixture.categorySource, inferred.reason};
+          }
           LogMessage(Logger::Level::Info,
                      "Auto category fallback: " + fixture.instanceName + " -> " +
                          fixture.category + " [" + inferred.reason + "]");
+        } else if (!fixture.category.empty() && !categoryKey.empty()) {
+          categoryByTypeKey[categoryKey] =
+              {fixture.category, fixture.categorySource.empty()
+                                     ? GdtfFixtureCategory::kManualSource
+                                     : fixture.categorySource,
+               "cached"};
         }
-      auto posIt = scene.positions.find(fixture.position);
+
+        if (!fixture.category.empty() && !fixture.typeName.empty())
+          GdtfDictionary::UpdateCategory(fixture.typeName, fixture.category);
+        auto posIt = scene.positions.find(fixture.position);
         if (posIt != scene.positions.end())
           fixture.positionName = posIt->second;
 

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -20,6 +20,7 @@
 #include "dummyprofilelibrary.h"
 #include "gdtfdictionary.h"
 #include "gdtfloader.h"
+#include "gdtf_fixture_category.h"
 #include "matrixutils.h"
 #include "sceneobject.h"
 #include "support.h"
@@ -351,6 +352,37 @@ static void ApplySupportHoistInfoDefaults(Support &support) {
       support.hoistFunctionSource, support.hoistDataSource);
   if (support.function.empty())
     support.function = support.hoistFunction;
+}
+
+static void ReadFixtureCategoryFromUserData(tinyxml2::XMLElement *fixtureNode,
+                                            Fixture &fixture) {
+  if (!fixtureNode)
+    return;
+
+  tinyxml2::XMLElement *ud = fixtureNode->FirstChildElement("UserData");
+  if (!ud)
+    return;
+
+  for (tinyxml2::XMLElement *data = ud->FirstChildElement("Data"); data;
+       data = data->NextSiblingElement("Data")) {
+    tinyxml2::XMLElement *info = data->FirstChildElement("FixtureInfo");
+    if (!info)
+      continue;
+
+    if (tinyxml2::XMLElement *categoryNode = info->FirstChildElement("Category")) {
+      if (const char *txt = categoryNode->GetText())
+        fixture.category = GdtfFixtureCategory::NormalizeCategory(Trim(txt));
+    }
+
+    if (tinyxml2::XMLElement *sourceNode = info->FirstChildElement("CategorySource")) {
+      if (const char *txt = sourceNode->GetText())
+        fixture.categorySource = Trim(txt);
+    }
+
+    if (!fixture.category.empty() && fixture.categorySource.empty())
+      fixture.categorySource = GdtfFixtureCategory::kManualSource;
+    return;
+  }
 }
 
 static void ReadSupportHoistInfoFromUserData(tinyxml2::XMLElement *supportNode,
@@ -1071,16 +1103,40 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                   : fs::u8path(scene.basePath) / fs::u8path(fixture.gdtfSpec);
           std::string gdtfPath = ToString(p.u8string());
           fixture.typeName = Trim(GetGdtfFixtureName(gdtfPath));
-        if (!fixture.typeName.empty())
-          fixture.gdtfSpec = gdtfPath;
-        float gw = 0.0f, gp = 0.0f;
-        if (GetGdtfProperties(gdtfPath, gw, gp)) {
-          if (fixture.weightKg == 0.0f)
-            fixture.weightKg = gw;
-          if (fixture.powerConsumptionW == 0.0f)
-            fixture.powerConsumptionW = gp;
+          if (!fixture.typeName.empty())
+            fixture.gdtfSpec = gdtfPath;
+          float gw = 0.0f, gp = 0.0f;
+          if (GetGdtfProperties(gdtfPath, gw, gp)) {
+            if (fixture.weightKg == 0.0f)
+              fixture.weightKg = gw;
+            if (fixture.powerConsumptionW == 0.0f)
+              fixture.powerConsumptionW = gp;
+          }
         }
-      }
+
+        ReadFixtureCategoryFromUserData(node, fixture);
+        if (fixture.category.empty() && !fixture.typeName.empty()) {
+          if (auto entry = GdtfDictionary::Get(fixture.typeName))
+            fixture.category = GdtfFixtureCategory::NormalizeCategory(entry->category);
+          if (!fixture.category.empty())
+            fixture.categorySource = GdtfFixtureCategory::kManualSource;
+        }
+
+        if (!fixture.category.empty() && !fixture.typeName.empty())
+          GdtfDictionary::UpdateCategory(fixture.typeName, fixture.category);
+
+        if (fixture.category.empty() && !fixture.gdtfSpec.empty()) {
+          const auto inferred = GdtfFixtureCategory::InferFromGdtf(fixture.gdtfSpec);
+          fixture.category = GdtfFixtureCategory::NormalizeCategory(inferred.category);
+          if (fixture.category.empty())
+            fixture.category = GdtfFixtureCategory::kUnknown;
+          fixture.categorySource = GdtfFixtureCategory::kAutoFallbackSource;
+          if (!fixture.typeName.empty())
+            GdtfDictionary::UpdateCategory(fixture.typeName, fixture.category);
+          LogMessage(Logger::Level::Info,
+                     "Auto category fallback: " + fixture.instanceName + " -> " +
+                         fixture.category + " [" + inferred.reason + "]");
+        }
       auto posIt = scene.positions.find(fixture.position);
         if (posIt != scene.positions.end())
           fixture.positionName = posIt->second;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,6 +69,14 @@ target_include_directories(fixture_table_parser_test PRIVATE .. ../gui)
 target_link_libraries(fixture_table_parser_test PRIVATE ${wxWidgets_LIBRARIES})
 add_test(NAME FixtureTableParser COMMAND fixture_table_parser_test)
 
+
+add_executable(gdtf_fixture_category_test
+               gdtf_fixture_category_test.cpp
+               ../core/gdtf_fixture_category.cpp)
+target_include_directories(gdtf_fixture_category_test PRIVATE ../core)
+target_link_libraries(gdtf_fixture_category_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
+add_test(NAME GdtfFixtureCategoryFallback COMMAND gdtf_fixture_category_test)
+
 add_executable(layout_template_serializer_test
                layout_template_serializer_test.cpp
                ../core/layouts/LayoutTemplateSerializer.cpp)
@@ -129,6 +137,7 @@ add_executable(save_load_roundtrip_test save_load_roundtrip_test.cpp
                ../core/configservices.cpp
                ../core/projectutils.cpp
                ../core/gdtfdictionary.cpp
+               ../core/gdtf_fixture_category.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
                ../core/truss_gdtf_builder.cpp
@@ -179,6 +188,7 @@ add_executable(rider_truss_dictionary_normalization_test
                ../core/configservices.cpp
                ../core/projectutils.cpp
                ../core/gdtfdictionary.cpp
+               ../core/gdtf_fixture_category.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
                ../core/truss_gdtf_builder.cpp
@@ -203,6 +213,7 @@ add_executable(mvr_dmx_address_test mvr_dmx_address_test.cpp
                ../core/configservices.cpp
                ../core/projectutils.cpp
                ../core/gdtfdictionary.cpp
+               ../core/gdtf_fixture_category.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
                ../core/truss_gdtf_builder.cpp
@@ -231,6 +242,7 @@ add_executable(mvr_support_userdata_roundtrip_test mvr_support_userdata_roundtri
                ../core/configservices.cpp
                ../core/projectutils.cpp
                ../core/gdtfdictionary.cpp
+               ../core/gdtf_fixture_category.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
                ../core/truss_gdtf_builder.cpp
@@ -254,11 +266,42 @@ target_link_libraries(mvr_support_userdata_roundtrip_test PRIVATE
 add_test(NAME MvrSupportUserDataRoundtrip COMMAND mvr_support_userdata_roundtrip_test)
 set_library_env(MvrSupportUserDataRoundtrip)
 
+
+add_executable(mvr_fixture_category_roundtrip_test mvr_fixture_category_roundtrip_test.cpp
+               ../core/configmanager.cpp
+               ../core/configservices.cpp
+               ../core/projectutils.cpp
+               ../core/gdtfdictionary.cpp
+               ../core/gdtf_fixture_category.cpp
+               ../core/trussdictionary.cpp
+               ../core/trussloader.cpp
+               ../core/truss_gdtf_builder.cpp
+               ../core/uuidutils.cpp
+               ../core/dummyprofilelibrary.cpp
+               ../mvr/mvrimporter.cpp
+               ../mvr/mvrexporter.cpp
+               ../core/logger.cpp
+               gdtfloader_stub.cpp
+               consolepanel_stub.cpp
+               ../models/mvrscene.cpp
+               ../models/fixture.cpp
+               ../models/truss.cpp
+               ../models/sceneobject.cpp
+               ../models/layer.cpp
+               ${LAYOUT_SOURCES})
+target_include_directories(mvr_fixture_category_roundtrip_test PRIVATE
+                           . ../core ../models ../mvr ../gui ../third_party)
+target_link_libraries(mvr_fixture_category_roundtrip_test PRIVATE
+                      ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
+add_test(NAME MvrFixtureCategoryRoundtrip COMMAND mvr_fixture_category_roundtrip_test)
+set_library_env(MvrFixtureCategoryRoundtrip)
+
 add_executable(mvr_exporter_compliance_test mvr_exporter_compliance_test.cpp
                ../core/configmanager.cpp
                ../core/configservices.cpp
                ../core/projectutils.cpp
                ../core/gdtfdictionary.cpp
+               ../core/gdtf_fixture_category.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
                ../core/truss_gdtf_builder.cpp
@@ -294,6 +337,7 @@ add_executable(rider_save_roundtrip_test rider_save_roundtrip_test.cpp
                ../core/configservices.cpp
                ../core/projectutils.cpp
                ../core/gdtfdictionary.cpp
+               ../core/gdtf_fixture_category.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
                ../core/truss_gdtf_builder.cpp

--- a/tests/gdtf_fixture_category_test.cpp
+++ b/tests/gdtf_fixture_category_test.cpp
@@ -1,0 +1,132 @@
+#include <cassert>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include <wx/init.h>
+#include <wx/wfstream.h>
+#include <wx/zipstrm.h>
+
+#include "gdtf_fixture_category.h"
+
+namespace fs = std::filesystem;
+
+static std::string WrapDescription(const std::string &name,
+                                   const std::string &geometries,
+                                   const std::string &attributes,
+                                   const std::string &emitters = "") {
+  return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+         "<GDTF DataVersion=\"1.2\">"
+         "<FixtureType Name=\"" +
+         name +
+         "\" ShortName=\"" + name +
+         "\">"
+         "<AttributeDefinitions><Attributes>" +
+         attributes +
+         "</Attributes></AttributeDefinitions>"
+         "<Geometries>" + geometries + "</Geometries>"
+         "<PhysicalDescriptions><Emitters>" + emitters +
+         "</Emitters></PhysicalDescriptions>"
+         "</FixtureType></GDTF>";
+}
+
+static bool WriteGdtf(const fs::path &path, const std::string &descriptionXml) {
+  wxFileOutputStream output(path.string());
+  if (!output.IsOk())
+    return false;
+
+  wxZipOutputStream zip(output);
+  auto *entry = new wxZipEntry("description.xml");
+  entry->SetMethod(wxZIP_METHOD_DEFLATE);
+  zip.PutNextEntry(entry);
+  zip.Write(descriptionXml.data(), descriptionXml.size());
+  zip.CloseEntry();
+  zip.Close();
+  return true;
+}
+
+int main() {
+  wxInitializer initializer;
+  assert(initializer.IsOk());
+
+  const fs::path dir = fs::temp_directory_path() / "gdtf_fixture_category_test";
+  fs::create_directories(dir);
+
+  struct Case {
+    std::string file;
+    std::string xml;
+    std::string expected;
+  };
+
+  const std::vector<Case> cases = {
+      {"moving_spot.gdtf",
+       WrapDescription("Moving Spot",
+                       "<Geometry Name=\"Root\"/><Beam Name=\"Beam\" BeamType=\"Spot\" BeamAngle=\"12\"/>",
+                       "<Attribute Name=\"Pan\"/><Attribute Name=\"Tilt\"/><Attribute Name=\"Gobo1\"/><Attribute Name=\"Focus\"/>"),
+       "Spot"},
+      {"moving_wash.gdtf",
+       WrapDescription("Moving Wash",
+                       "<Geometry Name=\"Root\"/><Beam Name=\"Beam\" BeamType=\"Wash\" BeamAngle=\"30\"/>",
+                       "<Attribute Name=\"Pan\"/><Attribute Name=\"Tilt\"/><Attribute Name=\"Frost\"/>"),
+       "Wash"},
+      {"moving_beam.gdtf",
+       WrapDescription("Moving Beam",
+                       "<Geometry Name=\"Root\"/><Beam Name=\"Beam\" BeamType=\"Spot\" BeamAngle=\"3\"/>",
+                       "<Attribute Name=\"Pan\"/><Attribute Name=\"Tilt\"/><Attribute Name=\"Prism\"/>"),
+       "Beam"},
+      {"moving_hybrid.gdtf",
+       WrapDescription("Moving Hybrid",
+                       "<Geometry Name=\"Root\"/><Beam Name=\"Beam\" BeamType=\"Spot\" BeamAngle=\"5\"/><Beam Name=\"Wide\" BeamType=\"Wash\" BeamAngle=\"28\"/>",
+                       "<Attribute Name=\"Pan\"/><Attribute Name=\"Tilt\"/><Attribute Name=\"Gobo1\"/><Attribute Name=\"Focus\"/><Attribute Name=\"Frost\"/>"),
+       "Hybrid"},
+      {"static_conventional.gdtf",
+       WrapDescription("Fresnel 2k",
+                       "<Geometry Name=\"Root\"/><Beam Name=\"Beam\" BeamType=\"Fresnel\" BeamAngle=\"35\"/>",
+                       "<Attribute Name=\"Dimmer\"/>"),
+       "Conventional"},
+      {"pixel_led.gdtf",
+       WrapDescription("LED Pixel Bar",
+                       "<Geometry Name=\"Root\"/>",
+                       "<Attribute Name=\"PixelMode\"/><Attribute Name=\"Color\"/>",
+                       "<Emitter LampType=\"LED\"/>"),
+       "LED"},
+      {"strobe.gdtf",
+       WrapDescription("Atomic Strobe",
+                       "<Geometry Name=\"Root\"/><Beam Name=\"Beam\" BeamType=\"None\" BeamAngle=\"20\"/>",
+                       "<Attribute Name=\"StrobeMode\"/><Attribute Name=\"Shutter1\"/>"),
+       "Strobe"},
+      {"haze.gdtf",
+       WrapDescription("Hazer 2",
+                       "<Geometry Name=\"Root\"/>",
+                       "<Attribute Name=\"Haze1\"/><Attribute Name=\"Blower1\"/>"),
+       "Smoke"},
+      {"laser.gdtf",
+       WrapDescription("Club Laser",
+                       "<Laser Name=\"Laser\"/>",
+                       "<Attribute Name=\"Intensity\"/>"),
+       "Laser"},
+      {"video.gdtf",
+       WrapDescription("Media Server",
+                       "<Display Name=\"Display\"/>",
+                       "<Attribute Name=\"VideoEffect\"/>"),
+       "Video"},
+      {"hoist.gdtf",
+       WrapDescription("Chain Hoist",
+                       "<Support Name=\"Support\" Type=\"Rope\"/>",
+                       "<Attribute Name=\"Speed\"/>"),
+       "Hoist"},
+      {"unknown.gdtf",
+       WrapDescription("Mystery Box", "<Geometry Name=\"Root\"/>", "<Attribute Name=\"Control\"/>"),
+       "Unknown"},
+  };
+
+  for (const auto &testCase : cases) {
+    const fs::path gdtfPath = dir / testCase.file;
+    assert(WriteGdtf(gdtfPath, testCase.xml));
+    const auto inferred = GdtfFixtureCategory::InferFromGdtf(gdtfPath.string());
+    assert(inferred.category == testCase.expected);
+  }
+
+  fs::remove_all(dir);
+  return 0;
+}

--- a/tests/mvr_fixture_category_roundtrip_test.cpp
+++ b/tests/mvr_fixture_category_roundtrip_test.cpp
@@ -1,0 +1,91 @@
+/*
+ * This file is part of Perastage.
+ */
+#include <cassert>
+#include <filesystem>
+#include <fstream>
+
+#include <wx/init.h>
+
+#include "configmanager.h"
+#include "fixture.h"
+#include "gdtfdictionary.h"
+#include "layer.h"
+#include "mvrexporter.h"
+#include "mvrimporter.h"
+#include "projectutils.h"
+
+int main() {
+  wxInitializer initializer;
+  assert(initializer.IsOk());
+
+  auto &cfg = ConfigManager::Get();
+  cfg.Reset();
+  MvrScene &scene = cfg.GetScene();
+
+  Layer layer;
+  layer.uuid = "layer1";
+  layer.name = "Layer1";
+  scene.layers[layer.uuid] = layer;
+
+  const std::filesystem::path tempDir =
+      std::filesystem::temp_directory_path() / "mvr_fixture_category_roundtrip";
+  std::filesystem::remove_all(tempDir);
+  std::filesystem::create_directories(tempDir);
+
+  const std::filesystem::path fixturePath = tempDir / "fixture.gdtf";
+  std::ofstream(fixturePath) << "fixture";
+  scene.basePath = tempDir.string();
+
+  Fixture fixture;
+  fixture.uuid = "fx1";
+  fixture.instanceName = "Fixture One";
+  fixture.layer = layer.name;
+  fixture.typeName = "FixtureType";
+  fixture.gdtfSpec = fixturePath.string();
+  fixture.gdtfMode = "ModeA";
+  fixture.category = "Spot";
+  fixture.categorySource = "Manual";
+  scene.fixtures[fixture.uuid] = fixture;
+
+  GdtfDictionary::Update("FixtureType", fixturePath.string(), "ModeA", "Wash");
+
+  const std::filesystem::path mvrPath = tempDir / "fixture_category.mvr";
+  MvrExporter exporter;
+  assert(exporter.ExportToFile(mvrPath.string()));
+
+  cfg.Reset();
+  MvrImporter importer;
+  assert(importer.ImportFromFile(mvrPath.string(), false, false));
+
+  const auto &loaded = cfg.GetScene().fixtures;
+  assert(loaded.size() == 1);
+  const Fixture &loadedFixture = loaded.at("fx1");
+  assert(loadedFixture.category == "Spot");
+
+  // Dictionary should be updated with scene (MVR) priority category.
+  auto entry = GdtfDictionary::Get("FixtureType");
+  assert(entry.has_value());
+  assert(entry->category == "Spot");
+
+  cfg.Reset();
+  MvrScene &scene2 = cfg.GetScene();
+  scene2.layers[layer.uuid] = layer;
+  Fixture fixtureWithoutCategory = fixture;
+  fixtureWithoutCategory.category.clear();
+  fixtureWithoutCategory.categorySource.clear();
+  scene2.fixtures[fixtureWithoutCategory.uuid] = fixtureWithoutCategory;
+
+  const std::filesystem::path noCategoryMvrPath = tempDir / "fixture_no_category.mvr";
+  assert(exporter.ExportToFile(noCategoryMvrPath.string()));
+
+  cfg.Reset();
+  assert(importer.ImportFromFile(noCategoryMvrPath.string(), false, false));
+  const auto &loadedNoCategory = cfg.GetScene().fixtures;
+  assert(loadedNoCategory.at("fx1").category == "Spot");
+
+  std::filesystem::remove_all(tempDir);
+  std::filesystem::remove(ProjectUtils::GetDefaultLibraryPath("fixtures") +
+                          "/fixture.gdtf");
+  return 0;
+}

--- a/tests/mvr_support_userdata_roundtrip_test.cpp
+++ b/tests/mvr_support_userdata_roundtrip_test.cpp
@@ -40,6 +40,8 @@ int main() {
   motorFixture.typeName = "MotorType";
   motorFixture.gdtfSpec = "fixture.gdtf";
   motorFixture.gdtfMode = "ChainMode";
+  motorFixture.category = "Spot";
+  motorFixture.categorySource = "Manual";
   scene.fixtures[motorFixture.uuid] = motorFixture;
 
   Support linked;
@@ -98,6 +100,10 @@ int main() {
   cfg.Reset();
   MvrImporter importer;
   assert(importer.ImportFromFile(mvrPath.string(), false, false));
+
+  const auto &loadedFixtures = cfg.GetScene().fixtures;
+  assert(loadedFixtures.size() == 1);
+  assert(loadedFixtures.at("fx-motor").category == "Spot");
 
   const auto &loaded = cfg.GetScene().supports;
   assert(loaded.size() == 4);

--- a/tests/riderimporter_stubs.cpp
+++ b/tests/riderimporter_stubs.cpp
@@ -35,7 +35,8 @@ namespace GdtfDictionary {
 std::optional<std::unordered_map<std::string, Entry>> Load() { return std::unordered_map<std::string, Entry>(); }
 void Save(const std::unordered_map<std::string, Entry> &) {}
 std::optional<Entry> Get(const std::string &) { return std::nullopt; }
-void Update(const std::string &, const std::string &, const std::string &) {}
+void Update(const std::string &, const std::string &, const std::string &, const std::string &) {}
+void UpdateCategory(const std::string &, const std::string &) {}
 }
 
 namespace TrussDictionary {


### PR DESCRIPTION
### Motivation

- Provide automatic and manual fixture category classification (Spot/Wash/Beam/etc.) from GDTF archives and expose it in the UI and project files.
- Persist category metadata in the fixtures dictionary so scene exports/imports can round-trip category info.

### Description

- Added a new core component `gdtf_fixture_category.{h,cpp}` that implements `InferFromGdtf`, `NormalizeCategory`, `IsValidCategory` and helper logic to parse `description.xml` from `.gdtf` archives and infer categories based on geometry, attributes and emitters.
- Extended `GdtfDictionary::Entry` with a `category` field and updated `Load`/`Save` to read/write `category`, changed `Update` signature to accept an optional `category`, and added `UpdateCategory` to update a type's category independently.
- Wired category support into the UI and data model by adding a `Category` column to fixture tables, editor controls in `FixtureEditDialog`, context menu support in `FixtureTablePanel`, propagation logic in `FixtureTableEditService`, and storing per-fixture `category` and `categorySource` in `models/fixture.h`.
- Updated MVR exporter/importer (`mvrexporter.cpp` / `mvrimporter.cpp`) to emit and read `Category` and `CategorySource` in `UserData/FixtureInfo`, to consult the dictionary for existing categories, and to fall back to `GdtfFixtureCategory::InferFromGdtf` when no category is present; dictionary is updated with scene-priority categories when available.
- Added `gdtf_fixture_category.cpp` to `core/CMakeLists.txt` and added/updated multiple test targets in `tests/CMakeLists.txt` to cover inference and MVR roundtrip.

### Testing

- Added unit tests `gdtf_fixture_category_test`, `mvr_fixture_category_roundtrip_test` and modified test targets to include the new category code via `tests/CMakeLists.txt` so they are built as part of the test suite.
- Added assertions in `tests/gdtf_fixture_category_test.cpp` to validate inference across representative GDTF samples and added roundtrip checks in `tests/mvr_fixture_category_roundtrip_test.cpp` and updated support/userdata roundtrip test to include category checks.
- No automated test execution results are included in this rollout; the new tests and targets are present in CMake for CI or local runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be596d1f9083249db83f825c21e58b)