### PR TITLE
Change console output text color to green

### DIFF
--- a/gui/consolepanel.cpp
+++ b/gui/consolepanel.cpp
@@ -127,7 +127,7 @@ ConsolePanel::ConsolePanel(wxWindow *parent) : wxPanel(parent, wxID_ANY) {
   m_textCtrl = new wxTextCtrl(this, wxID_ANY, "", wxDefaultPosition,
                               wxDefaultSize, wxTE_MULTILINE | wxTE_READONLY);
   m_textCtrl->SetBackgroundColour(*wxBLACK);
-  m_textCtrl->SetForegroundColour(wxColour(200, 200, 200));
+  m_textCtrl->SetForegroundColour(wxColour(0, 255, 0));
   wxFont font(10, wxFONTFAMILY_TELETYPE, wxFONTSTYLE_NORMAL,
               wxFONTWEIGHT_NORMAL);
   m_textCtrl->SetFont(font);


### PR DESCRIPTION
### Motivation
- Improve console readability by switching the in-app console text from a light gray/white to a terminal-style green color.

### Description
- Replace the console text foreground color in `gui/consolepanel.cpp` by calling `m_textCtrl->SetForegroundColour(wxColour(0, 255, 0));` instead of the previous `wxColour(200, 200, 200)`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be704eeb3883248a437559fb6d6de4)