### PR TITLE
Import LED screens as scene objects in text rider import

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -175,6 +175,34 @@ bool TryParseInt(std::string_view text, int &out) {
   return false;
 }
 
+bool TryParseScreenDimensionsMm(const std::string &text, float &widthMm,
+                                float &heightMm) {
+  static const std::regex kScreenDimensionRe(
+      "(\\d+(?:[\\.,]\\d+)?)\\s*(?:m|metros?)?\\s*[xX]\\s*(\\d+(?:[\\.,]\\d+)?)\\s*(?:m|metros?)?",
+      std::regex::icase);
+  std::smatch matches;
+  if (!std::regex_search(text, matches, kScreenDimensionRe))
+    return false;
+
+  auto parseMetricValue = [](std::string value, float &outMeters) {
+    std::replace(value.begin(), value.end(), ',', '.');
+    if (!TryParseFloat(value, outMeters))
+      return false;
+    return outMeters > 0.0f;
+  };
+
+  float widthMeters = 0.0f;
+  float heightMeters = 0.0f;
+  if (!parseMetricValue(matches[1].str(), widthMeters) ||
+      !parseMetricValue(matches[2].str(), heightMeters)) {
+    return false;
+  }
+
+  widthMm = widthMeters * 1000.0f;
+  heightMm = heightMeters * 1000.0f;
+  return true;
+}
+
 int ParseTrailingNumber(const std::string &text) {
   const size_t space = text.find_last_of(' ');
   if (space == std::string::npos || space + 1 >= text.size())
@@ -875,6 +903,14 @@ bool RiderImporter::ImportText(const std::string &text) {
   std::unordered_set<std::string> seenTypes;
   std::vector<std::string> importedTrussUuids;
   std::vector<std::string> importedFixtureUuids;
+  struct ScreenObjectRequest {
+    std::string name;
+    std::string layer;
+    std::string positionName;
+    float widthMm = 8000.0f;
+    float heightMm = 5000.0f;
+  };
+  std::vector<ScreenObjectRequest> screenObjectRequests;
   struct HoistRequest {
     int quantity = 0;
     float capacityKg = 0.0f;
@@ -894,6 +930,30 @@ bool RiderImporter::ImportText(const std::string &text) {
         if (!TryParseInt(pm[1].str(), quantity))
           quantity = baseQuantity;
         part = Trim(pm[2]);
+      }
+      const bool isScreenHang = NormalizeHangName(currentHang) == "SCREEN";
+      const bool isScreenDescription =
+          ContainsCaseInsensitive(part, "pantalla") ||
+          ContainsCaseInsensitive(part, "screen");
+      if (isScreenHang && isScreenDescription) {
+        float screenWidthMm = 8000.0f;
+        float screenHeightMm = 5000.0f;
+        TryParseScreenDimensionsMm(part, screenWidthMm, screenHeightMm);
+        int &counter = nameCounters[part];
+        for (int i = 0; i < quantity; ++i) {
+          ScreenObjectRequest request;
+          request.name = part + " " + std::to_string(++counter);
+          request.positionName = currentHang;
+          request.widthMm = screenWidthMm;
+          request.heightMm = screenHeightMm;
+          if (layerByType)
+            request.layer = "obj " + currentHang;
+          else
+            request.layer = currentHang.empty() ? defaultLayer
+                                                : "pos " + currentHang;
+          screenObjectRequests.push_back(std::move(request));
+        }
+        continue;
       }
       int &counter = nameCounters[part];
       for (int i = 0; i < quantity; ++i) {
@@ -1380,6 +1440,38 @@ bool RiderImporter::ImportText(const std::string &text) {
       info.startX = std::min(info.startX, start);
       info.endX = std::max(info.endX, end);
     }
+  }
+
+  constexpr float kScreenThicknessMm = 100.0f;
+  constexpr float kFallbackCubeMeters = 0.3f;
+  for (const ScreenObjectRequest &request : screenObjectRequests) {
+    TrussInfo info;
+    auto infoIt = trussInfo.find(request.positionName);
+    if (infoIt != trussInfo.end())
+      info = infoIt->second;
+
+    const float centerX = info.found ? (info.startX + info.endX) * 0.5f : 0.0f;
+    const float centerY =
+        info.found ? info.y : getHangPos(request.positionName);
+    const float trussZ =
+        info.found ? info.z : getHangHeight(request.positionName);
+    const float centerZ = trussZ - 200.0f - request.heightMm * 0.5f;
+
+    SceneObject screenObject;
+    screenObject.uuid = GenerateUuid();
+    screenObject.name = request.name;
+    screenObject.layer = request.layer;
+    screenObject.transform.u = {
+        request.widthMm / (kFallbackCubeMeters * 1000.0f), 0.0f, 0.0f};
+    screenObject.transform.v = {
+        0.0f, kScreenThicknessMm / (kFallbackCubeMeters * 1000.0f), 0.0f};
+    screenObject.transform.w = {
+        0.0f, 0.0f, request.heightMm / (kFallbackCubeMeters * 1000.0f)};
+    screenObject.transform.o[0] = centerX;
+    screenObject.transform.o[1] = centerY;
+    screenObject.transform.o[2] = centerZ;
+    scene.sceneObjects[screenObject.uuid] = screenObject;
+    addToLayer(screenObject.layer, screenObject.uuid);
   }
 
   auto placeHoist = [&](float x, float y, float z, float capacityKg,

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -120,6 +120,20 @@ For each fixture created:
 4. `positionName` is set from current hang.
 5. Initial hang coordinates are injected (`Y`, `Z`) and later refined by distribution logic.
 
+Special screen-object handling:
+
+- When current hang is `SCREEN` and a fixture line contains `screen` or
+  `pantalla`, the importer creates **scene objects** instead of fixtures.
+- Size parsing looks for `<width>x<height>` values in meters (accepted forms
+  include `8x5`, `8x5m`, `8m x 5m`).
+- Parsed screen dimensions are applied as:
+  - X (width) = parsed width
+  - Z (height) = parsed height
+  - Y (thickness) = fixed `0.1 m`
+- If no valid size is found, importer falls back to `8.0 x 5.0 m`.
+- Screen objects are centered on the associated screen truss span and placed so
+  their top edge sits `0.2 m` below the truss.
+
 ## Truss parsing rules
 
 Supported truss syntax includes:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -501,6 +501,29 @@ target_link_libraries(rider_filter_preview_test PRIVATE ${wxWidgets_LIBRARIES})
 add_test(NAME RiderFilterPreview COMMAND rider_filter_preview_test)
 set_library_env(RiderFilterPreview)
 
+add_executable(rider_led_screen_object_test rider_led_screen_object_test.cpp
+               riderimporter_stubs.cpp
+               gdtfloader_stub.cpp
+               ../core/riderimporter.cpp
+               ../core/uuidutils.cpp
+               ../core/autopatcher.cpp
+               ../core/patchmanager.cpp
+               ../core/configmanager.cpp
+               ../core/configservices.cpp
+               ../core/projectutils.cpp
+               ../core/logger.cpp
+               ../models/mvrscene.cpp
+               ../models/fixture.cpp
+               ../models/truss.cpp
+               ../models/sceneobject.cpp
+               ../models/layer.cpp
+               ${LAYOUT_SOURCES})
+target_include_directories(rider_led_screen_object_test PRIVATE
+                           . ../core ../models ../mvr ../gui ../third_party)
+target_link_libraries(rider_led_screen_object_test PRIVATE ${wxWidgets_LIBRARIES})
+add_test(NAME RiderLedScreenObject COMMAND rider_led_screen_object_test)
+set_library_env(RiderLedScreenObject)
+
 add_executable(rider_hoist_import_test rider_hoist_import_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp

--- a/tests/rider_led_screen_object_test.cpp
+++ b/tests/rider_led_screen_object_test.cpp
@@ -1,0 +1,40 @@
+#include <cassert>
+#include <cmath>
+#include <string>
+#include <wx/init.h>
+
+#include "configmanager.h"
+#include "riderimporter.h"
+#include "sceneobject.h"
+
+int main() {
+  wxInitializer initializer;
+  assert(initializer.IsOk());
+
+  auto &cfg = ConfigManager::Get();
+  cfg.Reset();
+
+  const std::string riderText =
+      "ILUMINACION\n"
+      "SCREEN\n"
+      "1 PANTALLA LED 8X5m 1664X1040 PIXELS Y 1100Kg PARA TRASERA\n"
+      "RIGGING\n"
+      "1 TRUSS 40X40 14m PARA PANTALLA\n";
+  assert(RiderImporter::ImportText(riderText));
+
+  const auto &scene = cfg.GetScene();
+  assert(scene.fixtures.empty());
+  assert(scene.sceneObjects.size() == 1);
+
+  const SceneObject &screen = scene.sceneObjects.begin()->second;
+  constexpr float kTolerance = 1e-3f;
+  assert(std::fabs(screen.transform.u[0] - (8.0f / 0.3f)) < kTolerance);
+  assert(std::fabs(screen.transform.v[1] - (0.1f / 0.3f)) < kTolerance);
+  assert(std::fabs(screen.transform.w[2] - (5.0f / 0.3f)) < kTolerance);
+
+  assert(screen.transform.o[0] > -kTolerance);
+  assert(screen.transform.o[0] < kTolerance);
+  assert(std::fabs(screen.transform.o[2] - 6800.0f) < 1.0f);
+
+  return 0;
+}

--- a/viewer3d/culling/bounds_cache_system.cpp
+++ b/viewer3d/culling/bounds_cache_system.cpp
@@ -386,8 +386,12 @@ void BoundsCacheSystem::RebuildIfDirty(
           {half, -half, half},
           {-half, half, half},
           {half, half, half}};
+      Matrix fallbackTm = tm;
+      fallbackTm.o[0] *= RENDER_SCALE;
+      fallbackTm.o[1] *= RENDER_SCALE;
+      fallbackTm.o[2] *= RENDER_SCALE;
       for (const auto &c : corners) {
-        auto p = TransformPoint(tm, c);
+        auto p = TransformPoint(fallbackTm, c);
         bb.min[0] = std::min(bb.min[0], p[0]);
         bb.min[1] = std::min(bb.min[1], p[1]);
         bb.min[2] = std::min(bb.min[2], p[2]);

--- a/viewer3d/render/opaque_object_pass.cpp
+++ b/viewer3d/render/opaque_object_pass.cpp
@@ -195,9 +195,20 @@ void OpaqueObjectPass::Render(
               glPopMatrix();
             }
           } else {
+            // Fallback scene objects are rendered as cubes that may be
+            // non-uniformly scaled through the object's transform matrix.
+            // Render these as double-sided geometry to avoid apparent
+            // transparency artifacts on thin objects (for example LED
+            // screens), while preserving regular culling state for the rest of
+            // the frame.
+            const GLboolean cullEnabled = glIsEnabled(GL_CULL_FACE);
+            if (cullEnabled)
+              glDisable(GL_CULL_FACE);
             controller.DrawCubeWithOutline(0.3f, r, g, b, isHighlighted,
                                            isSelected, cx, cy, cz, wireframe,
                                            mode, captureTransformFn);
+            if (cullEnabled)
+              glEnable(GL_CULL_FACE);
           }
         };
 


### PR DESCRIPTION
### Motivation
- Rider text imports previously treated LED/video screens as fixtures, which is semantically incorrect for large LED panels and prevents correct placement/visualization as scene objects.
- The change implements explicit parsing and placement rules for screen lines (size, thickness, and position relative to screen truss) so screens appear as scene objects in the 3D scene.

### Description
- Added `TryParseScreenDimensionsMm` and screen-detection logic in `core/riderimporter.cpp` to parse sizes like `8x5`, `8x5m`, and `8m x 5m` (commas allowed) and collect `ScreenObjectRequest`s. 
- When parsing a `SCREEN` hang line containing `screen`/`pantalla`, the importer now creates `SceneObject` entries instead of fixtures and computes width (X), height (Z), and thickness (Y=0.1m) with fallback `8.0 x 5.0 m` if unspecified. 
- Screen objects are centered on the associated screen truss span and positioned so the top edge sits 0.2m below the truss, using existing truss-derived `Y/Z` when available. 
- Added `tests/rider_led_screen_object_test.cpp` and registered it in `tests/CMakeLists.txt` to validate the import behavior, and updated `docs/text_to_scene_rules.md` to document the new screen-object handling.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed. 
- Attempted to configure/build the new unit test via `cmake -S . -B build -DBUILD_TESTS=ON && cmake --build build --target rider_led_screen_object_test -j4`, but the build failed in this environment due to missing `wxWidgets` development libraries (so the test was added but not executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bec5a7e5388324baa50b2cdd9b9ced)