### PR TITLE
Add 2D hoist capacity symbols with function-based colors

### DIFF
--- a/viewer3d/CMakeLists.txt
+++ b/viewer3d/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/meshprimitives.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/picking/selectionsystem.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/gl_primitive_renderer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/render/hoist_symbol_renderer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/lighting_profile.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/opaque_fixture_pass.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/opaque_object_pass.cpp

--- a/viewer3d/render/hoist_symbol_renderer.cpp
+++ b/viewer3d/render/hoist_symbol_renderer.cpp
@@ -1,0 +1,316 @@
+#include "hoist_symbol_renderer.h"
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#endif
+
+#ifdef __APPLE__
+#define GL_SILENCE_DEPRECATION
+#include <OpenGL/gl.h>
+#else
+#include <GL/gl.h>
+#endif
+
+#include "configmanager.h"
+#include "support.h"
+#include "viewer3dcontroller.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace HoistSymbolRenderer {
+namespace {
+
+constexpr float kSymbolSizeMeters = 0.5f;
+constexpr float kHalfSizeMeters = kSymbolSizeMeters * 0.5f;
+constexpr float kLineWidth = 1.2f;
+constexpr float kPi = 3.14159265358979323846f;
+
+struct RgbColor {
+  float r = 1.0f;
+  float g = 0.0f;
+  float b = 1.0f;
+};
+
+enum class HoistShape { Ton2, Ton1, TonHalf, TonQuarter, TonEighth };
+
+std::string NormalizedLayerName(const std::string &layer) {
+  return layer.empty() ? std::string(DEFAULT_LAYER_NAME) : layer;
+}
+
+bool IsLayerVisible(const std::unordered_set<std::string> &hiddenLayers,
+                    const std::string &layer) {
+  return hiddenLayers.find(NormalizedLayerName(layer)) == hiddenLayers.end();
+}
+
+RgbColor ResolveHoistFunctionColor(const std::string &hoistFunctionRaw) {
+  const std::string hoistFunction = NormalizeHoistFunction(hoistFunctionRaw);
+  if (hoistFunction == "Audio")
+    return {1.0f, 0.0f, 0.0f};
+  if (hoistFunction == "Video")
+    return {0.0f, 1.0f, 0.0f};
+  if (hoistFunction == "Scenic")
+    return {0.0f, 0.0f, 1.0f};
+  if (hoistFunction == "Extra")
+    return {0.56f, 0.0f, 1.0f};
+  if (hoistFunction == "Other")
+    return {0.78f, 0.64f, 0.78f};
+  return {1.0f, 0.0f, 1.0f}; // Lighting (default)
+}
+
+HoistShape ResolveHoistShape(float capacityKg) {
+  if (capacityKg >= 1500.0f)
+    return HoistShape::Ton2;
+  if (capacityKg >= 750.0f)
+    return HoistShape::Ton1;
+  if (capacityKg >= 375.0f)
+    return HoistShape::TonHalf;
+  if (capacityKg >= 187.5f)
+    return HoistShape::TonQuarter;
+  return HoistShape::TonEighth;
+}
+
+std::array<float, 3> MakePoint(float x, float y, float z) { return {x, y, z}; }
+
+void DrawFillPolygon(Viewer3DController &controller,
+                     const std::vector<std::array<float, 3>> &points,
+                     const RgbColor &color) {
+  if (points.size() < 3)
+    return;
+
+  if (!controller.IsCaptureOnly()) {
+    controller.SetGLColor(color.r, color.g, color.b);
+    glBegin(GL_TRIANGLE_FAN);
+    for (const auto &p : points)
+      glVertex3f(p[0], p[1], p[2]);
+    glEnd();
+  }
+
+  CanvasStroke stroke;
+  stroke.width = 0.0f;
+  stroke.color = {color.r, color.g, color.b, 1.0f};
+  CanvasFill fill;
+  fill.color = {color.r, color.g, color.b, 1.0f};
+  controller.RecordPolygon(points, stroke, &fill);
+}
+
+void DrawOutlineLoop(Viewer3DController &controller,
+                     const std::vector<std::array<float, 3>> &points,
+                     const RgbColor &color) {
+  if (points.size() < 2)
+    return;
+
+  if (!controller.IsCaptureOnly()) {
+    glLineWidth(kLineWidth);
+    controller.SetGLColor(color.r, color.g, color.b);
+    glBegin(GL_LINE_LOOP);
+    for (const auto &p : points)
+      glVertex3f(p[0], p[1], p[2]);
+    glEnd();
+    glLineWidth(1.0f);
+  }
+
+  CanvasStroke stroke;
+  stroke.width = kLineWidth;
+  stroke.color = {color.r, color.g, color.b, 1.0f};
+  for (size_t i = 0; i < points.size(); ++i)
+    controller.RecordLine(points[i], points[(i + 1) % points.size()], stroke);
+}
+
+void DrawSegment(Viewer3DController &controller, const std::array<float, 3> &a,
+                 const std::array<float, 3> &b, const RgbColor &color) {
+  if (!controller.IsCaptureOnly()) {
+    glLineWidth(kLineWidth);
+    controller.SetGLColor(color.r, color.g, color.b);
+    glBegin(GL_LINES);
+    glVertex3f(a[0], a[1], a[2]);
+    glVertex3f(b[0], b[1], b[2]);
+    glEnd();
+    glLineWidth(1.0f);
+  }
+
+  CanvasStroke stroke;
+  stroke.width = kLineWidth;
+  stroke.color = {color.r, color.g, color.b, 1.0f};
+  controller.RecordLine(a, b, stroke);
+}
+
+void DrawSquareSymbol(Viewer3DController &controller, float cx, float cy,
+                      float z, const RgbColor &color) {
+  const float minX = cx - kHalfSizeMeters;
+  const float maxX = cx + kHalfSizeMeters;
+  const float minY = cy - kHalfSizeMeters;
+  const float maxY = cy + kHalfSizeMeters;
+  const float midX = cx;
+  const float midY = cy;
+
+  DrawFillPolygon(controller,
+                  {MakePoint(midX, midY, z), MakePoint(maxX, midY, z),
+                   MakePoint(maxX, maxY, z), MakePoint(midX, maxY, z)},
+                  color);
+  DrawFillPolygon(controller,
+                  {MakePoint(minX, minY, z), MakePoint(midX, minY, z),
+                   MakePoint(midX, midY, z), MakePoint(minX, midY, z)},
+                  color);
+
+  DrawOutlineLoop(controller,
+                  {MakePoint(minX, minY, z), MakePoint(maxX, minY, z),
+                   MakePoint(maxX, maxY, z), MakePoint(minX, maxY, z)},
+                  color);
+  DrawSegment(controller, MakePoint(cx, minY, z), MakePoint(cx, maxY, z), color);
+  DrawSegment(controller, MakePoint(minX, cy, z), MakePoint(maxX, cy, z), color);
+}
+
+void DrawDiamondSymbol(Viewer3DController &controller, float cx, float cy,
+                       float z, const RgbColor &color) {
+  const auto top = MakePoint(cx, cy + kHalfSizeMeters, z);
+  const auto right = MakePoint(cx + kHalfSizeMeters, cy, z);
+  const auto bottom = MakePoint(cx, cy - kHalfSizeMeters, z);
+  const auto left = MakePoint(cx - kHalfSizeMeters, cy, z);
+  const auto center = MakePoint(cx, cy, z);
+
+  DrawFillPolygon(controller, {center, right, top}, color);
+  DrawFillPolygon(controller, {center, left, bottom}, color);
+  DrawOutlineLoop(controller, {top, right, bottom, left}, color);
+  DrawSegment(controller, left, right, color);
+  DrawSegment(controller, bottom, top, color);
+}
+
+void DrawCircleSymbol(Viewer3DController &controller, float cx, float cy,
+                      float z, const RgbColor &color) {
+  constexpr int kSegments = 40;
+  std::vector<std::array<float, 3>> ring;
+  ring.reserve(static_cast<size_t>(kSegments));
+  for (int i = 0; i < kSegments; ++i) {
+    const float t = 2.0f * kPi *
+                    (static_cast<float>(i) / static_cast<float>(kSegments));
+    ring.push_back(
+        MakePoint(cx + std::cos(t) * kHalfSizeMeters, cy + std::sin(t) * kHalfSizeMeters, z));
+  }
+
+  constexpr int kQuarterSegments = 11;
+  std::vector<std::array<float, 3>> topRight;
+  topRight.reserve(static_cast<size_t>(kQuarterSegments + 2));
+  topRight.push_back(MakePoint(cx, cy, z));
+  for (int i = 0; i <= kQuarterSegments; ++i) {
+    const float t = static_cast<float>(i) / static_cast<float>(kQuarterSegments) *
+                    (kPi * 0.5f);
+    topRight.push_back(MakePoint(cx + std::cos(t) * kHalfSizeMeters,
+                                 cy + std::sin(t) * kHalfSizeMeters, z));
+  }
+
+  std::vector<std::array<float, 3>> bottomLeft;
+  bottomLeft.reserve(static_cast<size_t>(kQuarterSegments + 2));
+  bottomLeft.push_back(MakePoint(cx, cy, z));
+  for (int i = 0; i <= kQuarterSegments; ++i) {
+    const float t = kPi +
+                    static_cast<float>(i) / static_cast<float>(kQuarterSegments) *
+                        (kPi * 0.5f);
+    bottomLeft.push_back(MakePoint(cx + std::cos(t) * kHalfSizeMeters,
+                                   cy + std::sin(t) * kHalfSizeMeters, z));
+  }
+
+  DrawFillPolygon(controller, topRight, color);
+  DrawFillPolygon(controller, bottomLeft, color);
+  DrawOutlineLoop(controller, ring, color);
+  DrawSegment(controller, MakePoint(cx - kHalfSizeMeters, cy, z),
+              MakePoint(cx + kHalfSizeMeters, cy, z), color);
+  DrawSegment(controller, MakePoint(cx, cy - kHalfSizeMeters, z),
+              MakePoint(cx, cy + kHalfSizeMeters, z), color);
+}
+
+void DrawTriangleSymbol(Viewer3DController &controller, float cx, float cy,
+                        float z, const RgbColor &color) {
+  const auto top = MakePoint(cx, cy + kHalfSizeMeters, z);
+  const auto left = MakePoint(cx - kHalfSizeMeters, cy - kHalfSizeMeters, z);
+  const auto right = MakePoint(cx + kHalfSizeMeters, cy - kHalfSizeMeters, z);
+  const auto center = MakePoint(cx, cy - kHalfSizeMeters / 6.0f, z);
+
+  DrawFillPolygon(controller, {top, MakePoint(cx - 0.06f, cy + 0.03f, z), center},
+                  color);
+  DrawFillPolygon(controller, {left, MakePoint(cx - 0.08f, cy - 0.05f, z), center},
+                  color);
+
+  DrawOutlineLoop(controller, {top, right, left}, color);
+  DrawSegment(controller, top, center, color);
+  DrawSegment(controller, left, center, color);
+  DrawSegment(controller, right, center, color);
+}
+
+void DrawPentagonSymbol(Viewer3DController &controller, float cx, float cy,
+                        float z, const RgbColor &color) {
+  const auto top = MakePoint(cx, cy + kHalfSizeMeters, z);
+  const auto rightTop = MakePoint(cx + kHalfSizeMeters * 0.85f,
+                                  cy + kHalfSizeMeters * 0.25f, z);
+  const auto rightBottom =
+      MakePoint(cx + kHalfSizeMeters * 0.55f, cy - kHalfSizeMeters, z);
+  const auto leftBottom =
+      MakePoint(cx - kHalfSizeMeters * 0.55f, cy - kHalfSizeMeters, z);
+  const auto leftTop =
+      MakePoint(cx - kHalfSizeMeters * 0.85f, cy + kHalfSizeMeters * 0.25f, z);
+  const auto center = MakePoint(cx, cy - kHalfSizeMeters * 0.15f, z);
+
+  DrawFillPolygon(controller, {top, rightTop, center}, color);
+  DrawFillPolygon(controller, {leftBottom, rightBottom, center}, color);
+
+  DrawOutlineLoop(controller, {top, rightTop, rightBottom, leftBottom, leftTop}, color);
+  DrawSegment(controller, top, center, color);
+  DrawSegment(controller, leftTop, center, color);
+  DrawSegment(controller, rightTop, center, color);
+  DrawSegment(controller, leftBottom, center, color);
+  DrawSegment(controller, rightBottom, center, color);
+}
+
+void DrawHoistSymbol(Viewer3DController &controller, const Support &support,
+                     const RgbColor &color) {
+  const HoistShape shape = ResolveHoistShape(support.capacityKg);
+  const float cx = support.transform.o[0] * RENDER_SCALE;
+  const float cy = support.transform.o[1] * RENDER_SCALE;
+  const float z = support.transform.o[2] * RENDER_SCALE;
+
+  switch (shape) {
+  case HoistShape::Ton2:
+    DrawSquareSymbol(controller, cx, cy, z, color);
+    break;
+  case HoistShape::Ton1:
+    DrawCircleSymbol(controller, cx, cy, z, color);
+    break;
+  case HoistShape::TonHalf:
+    DrawTriangleSymbol(controller, cx, cy, z, color);
+    break;
+  case HoistShape::TonQuarter:
+    DrawDiamondSymbol(controller, cx, cy, z, color);
+    break;
+  case HoistShape::TonEighth:
+    DrawPentagonSymbol(controller, cx, cy, z, color);
+    break;
+  }
+}
+
+} // namespace
+
+void Render(Viewer3DController &controller, const RenderFrameContext &context) {
+  if (!context.is2DViewer)
+    return;
+  if (context.view != Viewer2DView::Top && context.view != Viewer2DView::Bottom)
+    return;
+
+  const auto &supports = ConfigManager::Get().GetScene().supports;
+  for (const auto &[uuid, support] : supports) {
+    (void)uuid;
+    if (!IsLayerVisible(context.hiddenLayers, support.layer))
+      continue;
+
+    const std::string functionValue =
+        support.hoistFunction.empty() ? support.function : support.hoistFunction;
+    DrawHoistSymbol(controller, support, ResolveHoistFunctionColor(functionValue));
+  }
+}
+
+} // namespace HoistSymbolRenderer

--- a/viewer3d/render/hoist_symbol_renderer.cpp
+++ b/viewer3d/render/hoist_symbol_renderer.cpp
@@ -77,6 +77,8 @@ HoistShape ResolveHoistShape(float capacityKg) {
 
 std::array<float, 3> MakePoint(float x, float y, float z) { return {x, y, z}; }
 
+RgbColor WhiteColor() { return {1.0f, 1.0f, 1.0f}; }
+
 void DrawFillPolygon(IRenderContext &renderContext,
                      const std::vector<std::array<float, 3>> &points,
                      const RgbColor &color) {
@@ -150,6 +152,10 @@ void DrawSquareSymbol(IRenderContext &renderContext, float cx, float cy,
   const float midY = cy;
 
   DrawFillPolygon(renderContext,
+                  {MakePoint(minX, minY, z), MakePoint(maxX, minY, z),
+                   MakePoint(maxX, maxY, z), MakePoint(minX, maxY, z)},
+                  WhiteColor());
+  DrawFillPolygon(renderContext,
                   {MakePoint(midX, midY, z), MakePoint(maxX, midY, z),
                    MakePoint(maxX, maxY, z), MakePoint(midX, maxY, z)},
                   color);
@@ -174,6 +180,7 @@ void DrawDiamondSymbol(IRenderContext &renderContext, float cx, float cy,
   const auto left = MakePoint(cx - kHalfSizeMeters, cy, z);
   const auto center = MakePoint(cx, cy, z);
 
+  DrawFillPolygon(renderContext, {top, right, bottom, left}, WhiteColor());
   DrawFillPolygon(renderContext, {center, right, top}, color);
   DrawFillPolygon(renderContext, {center, left, bottom}, color);
   DrawOutlineLoop(renderContext, {top, right, bottom, left}, color);
@@ -215,6 +222,7 @@ void DrawCircleSymbol(IRenderContext &renderContext, float cx, float cy,
                                    cy + std::sin(t) * kHalfSizeMeters, z));
   }
 
+  DrawFillPolygon(renderContext, ring, WhiteColor());
   DrawFillPolygon(renderContext, topRight, color);
   DrawFillPolygon(renderContext, bottomLeft, color);
   DrawOutlineLoop(renderContext, ring, color);
@@ -229,22 +237,29 @@ void DrawTriangleSymbol(IRenderContext &renderContext, float cx, float cy,
   const auto top = MakePoint(cx, cy + kHalfSizeMeters, z);
   const auto left = MakePoint(cx - kHalfSizeMeters, cy - kHalfSizeMeters, z);
   const auto right = MakePoint(cx + kHalfSizeMeters, cy - kHalfSizeMeters, z);
-  const auto leftMid =
-      MakePoint((top[0] + left[0]) * 0.5f, (top[1] + left[1]) * 0.5f, z);
-  const auto rightMid =
-      MakePoint((top[0] + right[0]) * 0.5f, (top[1] + right[1]) * 0.5f, z);
   const auto center = MakePoint(cx, cy - kHalfSizeMeters * 0.05f, z);
   const auto baseMid = MakePoint(cx, cy - kHalfSizeMeters, z);
+  const float crossY = center[1];
 
-  // Match the 1/2-Ton reference: red apex triangle + red lower-left block.
-  DrawFillPolygon(renderContext, {top, leftMid, rightMid}, color);
-  DrawFillPolygon(renderContext, {left, leftMid, center, baseMid}, color);
+  const auto pointOnEdgeAtY = [z](const std::array<float, 3> &a,
+                                  const std::array<float, 3> &b, float y) {
+    const float dy = b[1] - a[1];
+    if (std::fabs(dy) < 1e-6f)
+      return MakePoint(a[0], y, z);
+    const float t = (y - a[1]) / dy;
+    return MakePoint(a[0] + (b[0] - a[0]) * t, y, z);
+  };
+  const auto leftCross = pointOnEdgeAtY(top, left, crossY);
+  const auto rightCross = pointOnEdgeAtY(top, right, crossY);
+
+  DrawFillPolygon(renderContext, {top, right, left}, WhiteColor());
+  // Same fill pattern for all symbols: top-right + bottom-left.
+  DrawFillPolygon(renderContext, {top, rightCross, center}, color);
+  DrawFillPolygon(renderContext, {leftCross, left, baseMid, center}, color);
 
   DrawOutlineLoop(renderContext, {top, right, left}, color);
-  DrawSegment(renderContext, leftMid, rightMid, color);
-  DrawSegment(renderContext, leftMid, center, color);
-  DrawSegment(renderContext, rightMid, center, color);
-  DrawSegment(renderContext, center, baseMid, color);
+  DrawSegment(renderContext, leftCross, rightCross, color);
+  DrawSegment(renderContext, top, baseMid, color);
 }
 
 void DrawPentagonSymbol(IRenderContext &renderContext, float cx, float cy,
@@ -259,16 +274,29 @@ void DrawPentagonSymbol(IRenderContext &renderContext, float cx, float cy,
   const auto leftTop =
       MakePoint(cx - kHalfSizeMeters * 0.85f, cy + kHalfSizeMeters * 0.25f, z);
   const auto center = MakePoint(cx, cy - kHalfSizeMeters * 0.15f, z);
+  const auto bottomMid =
+      MakePoint((leftBottom[0] + rightBottom[0]) * 0.5f,
+                (leftBottom[1] + rightBottom[1]) * 0.5f, z);
 
-  DrawFillPolygon(renderContext, {top, rightTop, center}, color);
-  DrawFillPolygon(renderContext, {leftBottom, rightBottom, center}, color);
+  const auto pointOnEdgeAtY = [z](const std::array<float, 3> &a,
+                                  const std::array<float, 3> &b, float y) {
+    const float dy = b[1] - a[1];
+    if (std::fabs(dy) < 1e-6f)
+      return MakePoint(a[0], y, z);
+    const float t = (y - a[1]) / dy;
+    return MakePoint(a[0] + (b[0] - a[0]) * t, y, z);
+  };
+  const auto leftCross = pointOnEdgeAtY(leftTop, leftBottom, center[1]);
+  const auto rightCross = pointOnEdgeAtY(rightTop, rightBottom, center[1]);
+
+  DrawFillPolygon(renderContext, {top, rightTop, rightBottom, leftBottom, leftTop},
+                  WhiteColor());
+  DrawFillPolygon(renderContext, {top, rightTop, rightCross, center}, color);
+  DrawFillPolygon(renderContext, {leftCross, leftBottom, bottomMid, center}, color);
 
   DrawOutlineLoop(renderContext, {top, rightTop, rightBottom, leftBottom, leftTop}, color);
-  DrawSegment(renderContext, top, center, color);
-  DrawSegment(renderContext, leftTop, center, color);
-  DrawSegment(renderContext, rightTop, center, color);
-  DrawSegment(renderContext, leftBottom, center, color);
-  DrawSegment(renderContext, rightBottom, center, color);
+  DrawSegment(renderContext, leftCross, rightCross, color);
+  DrawSegment(renderContext, top, bottomMid, color);
 }
 
 void DrawHoistSymbol(IRenderContext &renderContext, const Support &support,

--- a/viewer3d/render/hoist_symbol_renderer.cpp
+++ b/viewer3d/render/hoist_symbol_renderer.cpp
@@ -15,7 +15,6 @@
 
 #include "configmanager.h"
 #include "support.h"
-#include "viewer3dcontroller.h"
 
 #include <algorithm>
 #include <array>
@@ -78,14 +77,14 @@ HoistShape ResolveHoistShape(float capacityKg) {
 
 std::array<float, 3> MakePoint(float x, float y, float z) { return {x, y, z}; }
 
-void DrawFillPolygon(Viewer3DController &controller,
+void DrawFillPolygon(IRenderContext &renderContext,
                      const std::vector<std::array<float, 3>> &points,
                      const RgbColor &color) {
   if (points.size() < 3)
     return;
 
-  if (!controller.IsCaptureOnly()) {
-    controller.SetGLColor(color.r, color.g, color.b);
+  if (!renderContext.IsCaptureOnly()) {
+    renderContext.SetGLColor(color.r, color.g, color.b);
     glBegin(GL_TRIANGLE_FAN);
     for (const auto &p : points)
       glVertex3f(p[0], p[1], p[2]);
@@ -97,18 +96,18 @@ void DrawFillPolygon(Viewer3DController &controller,
   stroke.color = {color.r, color.g, color.b, 1.0f};
   CanvasFill fill;
   fill.color = {color.r, color.g, color.b, 1.0f};
-  controller.RecordPolygon(points, stroke, &fill);
+  renderContext.RecordPolygon(points, stroke, &fill);
 }
 
-void DrawOutlineLoop(Viewer3DController &controller,
+void DrawOutlineLoop(IRenderContext &renderContext,
                      const std::vector<std::array<float, 3>> &points,
                      const RgbColor &color) {
   if (points.size() < 2)
     return;
 
-  if (!controller.IsCaptureOnly()) {
+  if (!renderContext.IsCaptureOnly()) {
     glLineWidth(kLineWidth);
-    controller.SetGLColor(color.r, color.g, color.b);
+    renderContext.SetGLColor(color.r, color.g, color.b);
     glBegin(GL_LINE_LOOP);
     for (const auto &p : points)
       glVertex3f(p[0], p[1], p[2]);
@@ -120,14 +119,14 @@ void DrawOutlineLoop(Viewer3DController &controller,
   stroke.width = kLineWidth;
   stroke.color = {color.r, color.g, color.b, 1.0f};
   for (size_t i = 0; i < points.size(); ++i)
-    controller.RecordLine(points[i], points[(i + 1) % points.size()], stroke);
+    renderContext.RecordLine(points[i], points[(i + 1) % points.size()], stroke);
 }
 
-void DrawSegment(Viewer3DController &controller, const std::array<float, 3> &a,
+void DrawSegment(IRenderContext &renderContext, const std::array<float, 3> &a,
                  const std::array<float, 3> &b, const RgbColor &color) {
-  if (!controller.IsCaptureOnly()) {
+  if (!renderContext.IsCaptureOnly()) {
     glLineWidth(kLineWidth);
-    controller.SetGLColor(color.r, color.g, color.b);
+    renderContext.SetGLColor(color.r, color.g, color.b);
     glBegin(GL_LINES);
     glVertex3f(a[0], a[1], a[2]);
     glVertex3f(b[0], b[1], b[2]);
@@ -138,10 +137,10 @@ void DrawSegment(Viewer3DController &controller, const std::array<float, 3> &a,
   CanvasStroke stroke;
   stroke.width = kLineWidth;
   stroke.color = {color.r, color.g, color.b, 1.0f};
-  controller.RecordLine(a, b, stroke);
+  renderContext.RecordLine(a, b, stroke);
 }
 
-void DrawSquareSymbol(Viewer3DController &controller, float cx, float cy,
+void DrawSquareSymbol(IRenderContext &renderContext, float cx, float cy,
                       float z, const RgbColor &color) {
   const float minX = cx - kHalfSizeMeters;
   const float maxX = cx + kHalfSizeMeters;
@@ -150,24 +149,24 @@ void DrawSquareSymbol(Viewer3DController &controller, float cx, float cy,
   const float midX = cx;
   const float midY = cy;
 
-  DrawFillPolygon(controller,
+  DrawFillPolygon(renderContext,
                   {MakePoint(midX, midY, z), MakePoint(maxX, midY, z),
                    MakePoint(maxX, maxY, z), MakePoint(midX, maxY, z)},
                   color);
-  DrawFillPolygon(controller,
+  DrawFillPolygon(renderContext,
                   {MakePoint(minX, minY, z), MakePoint(midX, minY, z),
                    MakePoint(midX, midY, z), MakePoint(minX, midY, z)},
                   color);
 
-  DrawOutlineLoop(controller,
+  DrawOutlineLoop(renderContext,
                   {MakePoint(minX, minY, z), MakePoint(maxX, minY, z),
                    MakePoint(maxX, maxY, z), MakePoint(minX, maxY, z)},
                   color);
-  DrawSegment(controller, MakePoint(cx, minY, z), MakePoint(cx, maxY, z), color);
-  DrawSegment(controller, MakePoint(minX, cy, z), MakePoint(maxX, cy, z), color);
+  DrawSegment(renderContext, MakePoint(cx, minY, z), MakePoint(cx, maxY, z), color);
+  DrawSegment(renderContext, MakePoint(minX, cy, z), MakePoint(maxX, cy, z), color);
 }
 
-void DrawDiamondSymbol(Viewer3DController &controller, float cx, float cy,
+void DrawDiamondSymbol(IRenderContext &renderContext, float cx, float cy,
                        float z, const RgbColor &color) {
   const auto top = MakePoint(cx, cy + kHalfSizeMeters, z);
   const auto right = MakePoint(cx + kHalfSizeMeters, cy, z);
@@ -175,14 +174,14 @@ void DrawDiamondSymbol(Viewer3DController &controller, float cx, float cy,
   const auto left = MakePoint(cx - kHalfSizeMeters, cy, z);
   const auto center = MakePoint(cx, cy, z);
 
-  DrawFillPolygon(controller, {center, right, top}, color);
-  DrawFillPolygon(controller, {center, left, bottom}, color);
-  DrawOutlineLoop(controller, {top, right, bottom, left}, color);
-  DrawSegment(controller, left, right, color);
-  DrawSegment(controller, bottom, top, color);
+  DrawFillPolygon(renderContext, {center, right, top}, color);
+  DrawFillPolygon(renderContext, {center, left, bottom}, color);
+  DrawOutlineLoop(renderContext, {top, right, bottom, left}, color);
+  DrawSegment(renderContext, left, right, color);
+  DrawSegment(renderContext, bottom, top, color);
 }
 
-void DrawCircleSymbol(Viewer3DController &controller, float cx, float cy,
+void DrawCircleSymbol(IRenderContext &renderContext, float cx, float cy,
                       float z, const RgbColor &color) {
   constexpr int kSegments = 40;
   std::vector<std::array<float, 3>> ring;
@@ -216,34 +215,34 @@ void DrawCircleSymbol(Viewer3DController &controller, float cx, float cy,
                                    cy + std::sin(t) * kHalfSizeMeters, z));
   }
 
-  DrawFillPolygon(controller, topRight, color);
-  DrawFillPolygon(controller, bottomLeft, color);
-  DrawOutlineLoop(controller, ring, color);
-  DrawSegment(controller, MakePoint(cx - kHalfSizeMeters, cy, z),
+  DrawFillPolygon(renderContext, topRight, color);
+  DrawFillPolygon(renderContext, bottomLeft, color);
+  DrawOutlineLoop(renderContext, ring, color);
+  DrawSegment(renderContext, MakePoint(cx - kHalfSizeMeters, cy, z),
               MakePoint(cx + kHalfSizeMeters, cy, z), color);
-  DrawSegment(controller, MakePoint(cx, cy - kHalfSizeMeters, z),
+  DrawSegment(renderContext, MakePoint(cx, cy - kHalfSizeMeters, z),
               MakePoint(cx, cy + kHalfSizeMeters, z), color);
 }
 
-void DrawTriangleSymbol(Viewer3DController &controller, float cx, float cy,
+void DrawTriangleSymbol(IRenderContext &renderContext, float cx, float cy,
                         float z, const RgbColor &color) {
   const auto top = MakePoint(cx, cy + kHalfSizeMeters, z);
   const auto left = MakePoint(cx - kHalfSizeMeters, cy - kHalfSizeMeters, z);
   const auto right = MakePoint(cx + kHalfSizeMeters, cy - kHalfSizeMeters, z);
   const auto center = MakePoint(cx, cy - kHalfSizeMeters / 6.0f, z);
 
-  DrawFillPolygon(controller, {top, MakePoint(cx - 0.06f, cy + 0.03f, z), center},
+  DrawFillPolygon(renderContext, {top, MakePoint(cx - 0.06f, cy + 0.03f, z), center},
                   color);
-  DrawFillPolygon(controller, {left, MakePoint(cx - 0.08f, cy - 0.05f, z), center},
+  DrawFillPolygon(renderContext, {left, MakePoint(cx - 0.08f, cy - 0.05f, z), center},
                   color);
 
-  DrawOutlineLoop(controller, {top, right, left}, color);
-  DrawSegment(controller, top, center, color);
-  DrawSegment(controller, left, center, color);
-  DrawSegment(controller, right, center, color);
+  DrawOutlineLoop(renderContext, {top, right, left}, color);
+  DrawSegment(renderContext, top, center, color);
+  DrawSegment(renderContext, left, center, color);
+  DrawSegment(renderContext, right, center, color);
 }
 
-void DrawPentagonSymbol(Viewer3DController &controller, float cx, float cy,
+void DrawPentagonSymbol(IRenderContext &renderContext, float cx, float cy,
                         float z, const RgbColor &color) {
   const auto top = MakePoint(cx, cy + kHalfSizeMeters, z);
   const auto rightTop = MakePoint(cx + kHalfSizeMeters * 0.85f,
@@ -256,18 +255,18 @@ void DrawPentagonSymbol(Viewer3DController &controller, float cx, float cy,
       MakePoint(cx - kHalfSizeMeters * 0.85f, cy + kHalfSizeMeters * 0.25f, z);
   const auto center = MakePoint(cx, cy - kHalfSizeMeters * 0.15f, z);
 
-  DrawFillPolygon(controller, {top, rightTop, center}, color);
-  DrawFillPolygon(controller, {leftBottom, rightBottom, center}, color);
+  DrawFillPolygon(renderContext, {top, rightTop, center}, color);
+  DrawFillPolygon(renderContext, {leftBottom, rightBottom, center}, color);
 
-  DrawOutlineLoop(controller, {top, rightTop, rightBottom, leftBottom, leftTop}, color);
-  DrawSegment(controller, top, center, color);
-  DrawSegment(controller, leftTop, center, color);
-  DrawSegment(controller, rightTop, center, color);
-  DrawSegment(controller, leftBottom, center, color);
-  DrawSegment(controller, rightBottom, center, color);
+  DrawOutlineLoop(renderContext, {top, rightTop, rightBottom, leftBottom, leftTop}, color);
+  DrawSegment(renderContext, top, center, color);
+  DrawSegment(renderContext, leftTop, center, color);
+  DrawSegment(renderContext, rightTop, center, color);
+  DrawSegment(renderContext, leftBottom, center, color);
+  DrawSegment(renderContext, rightBottom, center, color);
 }
 
-void DrawHoistSymbol(Viewer3DController &controller, const Support &support,
+void DrawHoistSymbol(IRenderContext &renderContext, const Support &support,
                      const RgbColor &color) {
   const HoistShape shape = ResolveHoistShape(support.capacityKg);
   const float cx = support.transform.o[0] * RENDER_SCALE;
@@ -276,26 +275,26 @@ void DrawHoistSymbol(Viewer3DController &controller, const Support &support,
 
   switch (shape) {
   case HoistShape::Ton2:
-    DrawSquareSymbol(controller, cx, cy, z, color);
+    DrawSquareSymbol(renderContext, cx, cy, z, color);
     break;
   case HoistShape::Ton1:
-    DrawCircleSymbol(controller, cx, cy, z, color);
+    DrawCircleSymbol(renderContext, cx, cy, z, color);
     break;
   case HoistShape::TonHalf:
-    DrawTriangleSymbol(controller, cx, cy, z, color);
+    DrawTriangleSymbol(renderContext, cx, cy, z, color);
     break;
   case HoistShape::TonQuarter:
-    DrawDiamondSymbol(controller, cx, cy, z, color);
+    DrawDiamondSymbol(renderContext, cx, cy, z, color);
     break;
   case HoistShape::TonEighth:
-    DrawPentagonSymbol(controller, cx, cy, z, color);
+    DrawPentagonSymbol(renderContext, cx, cy, z, color);
     break;
   }
 }
 
 } // namespace
 
-void Render(Viewer3DController &controller, const RenderFrameContext &context) {
+void Render(IRenderContext &renderContext, const RenderFrameContext &context) {
   if (!context.is2DViewer)
     return;
   if (context.view != Viewer2DView::Top && context.view != Viewer2DView::Bottom)
@@ -309,7 +308,7 @@ void Render(Viewer3DController &controller, const RenderFrameContext &context) {
 
     const std::string functionValue =
         support.hoistFunction.empty() ? support.function : support.hoistFunction;
-    DrawHoistSymbol(controller, support, ResolveHoistFunctionColor(functionValue));
+    DrawHoistSymbol(renderContext, support, ResolveHoistFunctionColor(functionValue));
   }
 }
 

--- a/viewer3d/render/hoist_symbol_renderer.cpp
+++ b/viewer3d/render/hoist_symbol_renderer.cpp
@@ -229,17 +229,22 @@ void DrawTriangleSymbol(IRenderContext &renderContext, float cx, float cy,
   const auto top = MakePoint(cx, cy + kHalfSizeMeters, z);
   const auto left = MakePoint(cx - kHalfSizeMeters, cy - kHalfSizeMeters, z);
   const auto right = MakePoint(cx + kHalfSizeMeters, cy - kHalfSizeMeters, z);
-  const auto center = MakePoint(cx, cy - kHalfSizeMeters / 6.0f, z);
+  const auto leftMid =
+      MakePoint((top[0] + left[0]) * 0.5f, (top[1] + left[1]) * 0.5f, z);
+  const auto rightMid =
+      MakePoint((top[0] + right[0]) * 0.5f, (top[1] + right[1]) * 0.5f, z);
+  const auto center = MakePoint(cx, cy - kHalfSizeMeters * 0.05f, z);
+  const auto baseMid = MakePoint(cx, cy - kHalfSizeMeters, z);
 
-  DrawFillPolygon(renderContext, {top, MakePoint(cx - 0.06f, cy + 0.03f, z), center},
-                  color);
-  DrawFillPolygon(renderContext, {left, MakePoint(cx - 0.08f, cy - 0.05f, z), center},
-                  color);
+  // Match the 1/2-Ton reference: red apex triangle + red lower-left block.
+  DrawFillPolygon(renderContext, {top, leftMid, rightMid}, color);
+  DrawFillPolygon(renderContext, {left, leftMid, center, baseMid}, color);
 
   DrawOutlineLoop(renderContext, {top, right, left}, color);
-  DrawSegment(renderContext, top, center, color);
-  DrawSegment(renderContext, left, center, color);
-  DrawSegment(renderContext, right, center, color);
+  DrawSegment(renderContext, leftMid, rightMid, color);
+  DrawSegment(renderContext, leftMid, center, color);
+  DrawSegment(renderContext, rightMid, center, color);
+  DrawSegment(renderContext, center, baseMid, color);
 }
 
 void DrawPentagonSymbol(IRenderContext &renderContext, float cx, float cy,

--- a/viewer3d/render/hoist_symbol_renderer.h
+++ b/viewer3d/render/hoist_symbol_renderer.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "viewer3d_types.h"
+
+class Viewer3DController;
+
+namespace HoistSymbolRenderer {
+
+void Render(Viewer3DController &controller, const RenderFrameContext &context);
+
+} // namespace HoistSymbolRenderer

--- a/viewer3d/render/hoist_symbol_renderer.h
+++ b/viewer3d/render/hoist_symbol_renderer.h
@@ -1,11 +1,10 @@
 #pragma once
 
+#include "irendercontext.h"
 #include "viewer3d_types.h"
-
-class Viewer3DController;
 
 namespace HoistSymbolRenderer {
 
-void Render(Viewer3DController &controller, const RenderFrameContext &context);
+void Render(IRenderContext &renderContext, const RenderFrameContext &context);
 
 } // namespace HoistSymbolRenderer

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -56,6 +56,7 @@
 #include "scenerenderer.h"
 #include "render_pipeline.h"
 #include "opaque_fixture_pass.h"
+#include "hoist_symbol_renderer.h"
 #include "opaque_object_pass.h"
 #include "opaque_truss_pass.h"
 #include "bounds_cache_system.h"
@@ -1110,6 +1111,7 @@ void Viewer3DController::RenderOpaqueFrame(const RenderFrameContext &context,
                           resolveSymbolView);
   OpaqueFixturePass::Render(*this, context, visibleSet, getTypeColor,
                             getLayerColor, resolveSymbolView);
+  HoistSymbolRenderer::Render(*this, context);
 }
 
 void Viewer3DController::RenderOverlayFrame(const RenderFrameContext &context,


### PR DESCRIPTION
### Motivation
- Provide a per-hoist visual symbol in 2D layouts that encodes capacity and function per the requested design. 
- Keep the change modular by adding a dedicated renderer instead of growing `viewer3dcontroller.cpp`. 

### Description
- Add a new renderer module `viewer3d/render/HoistSymbolRenderer` (`hoist_symbol_renderer.h/.cpp`) that draws a 0.5 m symbol on the X,Y plane for each `Support` in the scene. 
- Select symbol shape by capacity tier (`>=1500kg` → square, `>=750kg` → circle, `>=375kg` → triangle, `>=187.5kg` → diamond, otherwise pentagon) and apply color by hoist function with the requested mapping (`Lighting` → magenta, `Audio` → red, `Video` → green, `Scenic` → blue, `Extra` → violet, `Other` → lilac). 
- Symbols are drawn for screen output and also recorded to the capture/export canvas so captures/exports include the symbols, and hidden-layer filtering is respected. 
- Wire the new renderer into the render flow by calling `HoistSymbolRenderer::Render(...)` from `Viewer3DController::RenderOpaqueFrame` and register the source in `viewer3d/CMakeLists.txt`. 

### Testing
- Run `./tests/check_perastage_tree_modules.sh` which passed. 
- Run `./tests/check_no_configmanager_get_in_gui.sh` which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69becdd004348324906ab2b071b5e3b1)