### PR TITLE
Unify rider import with Apply filter normalization

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -803,6 +803,12 @@ bool RiderImporter::ImportText(const std::string &text) {
   if (text.empty())
     return false;
 
+  // Keep scene creation consistent with the dialog preview flow:
+  // import always consumes the same normalized text produced by the
+  // filter pass used by "Apply filter".
+  const std::string filteredText = BuildFixtureFilterPreview(text);
+  const std::string &textToImport = filteredText.empty() ? text : filteredText;
+
   ConfigManager &cfg = ConfigManager::Get();
   cfg.PushUndoState("import rider");
   auto &scene = cfg.GetScene();
@@ -891,7 +897,7 @@ bool RiderImporter::ImportText(const std::string &text) {
     layerPtr->childUUIDs.push_back(uid);
   };
 
-  std::istringstream iss(text);
+  std::istringstream iss(textToImport);
   std::string line;
   bool inFixtures = false;
   bool inRigging = false;

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -28,6 +28,10 @@ The dialog includes an **Apply filter** button that runs the same line
 selection rules used by fixture parsing, and replaces the editor content with
 the filtered result before scene creation.
 
+`Create` also runs that same filter pass internally. This keeps scene creation
+deterministic whether users click **Create** directly after loading text or
+click **Apply filter** first and then **Create**.
+
 Filter behavior:
 
 1. Keeps only lines interpreted as fixture entries in fixture sections.
@@ -52,7 +56,8 @@ Filter behavior:
     `SCREEN` (re-applying **Apply filter** keeps those lines).
 
 After applying the filter, users can manually adjust the filtered text and then
-press **Create**.
+press **Create**; the same normalization rules are still applied at creation
+time.
 
 ## Input normalization
 

--- a/tests/rider_led_screen_object_test.cpp
+++ b/tests/rider_led_screen_object_test.cpp
@@ -1,6 +1,7 @@
 #include <cassert>
 #include <cmath>
 #include <string>
+#include <tuple>
 #include <wx/init.h>
 
 #include "configmanager.h"
@@ -12,29 +13,44 @@ int main() {
   assert(initializer.IsOk());
 
   auto &cfg = ConfigManager::Get();
-  cfg.Reset();
-
   const std::string riderText =
       "ILUMINACION\n"
       "SCREEN\n"
       "1 PANTALLA LED 8X5m 1664X1040 PIXELS Y 1100Kg PARA TRASERA\n"
       "RIGGING\n"
       "1 TRUSS 40X40 14m PARA PANTALLA\n";
-  assert(RiderImporter::ImportText(riderText));
 
-  const auto &scene = cfg.GetScene();
-  assert(scene.fixtures.empty());
-  assert(scene.sceneObjects.size() == 1);
+  auto importAndReadScreenTransform = [&](const std::string &input) {
+    cfg.Reset();
+    assert(RiderImporter::ImportText(input));
 
-  const SceneObject &screen = scene.sceneObjects.begin()->second;
-  constexpr float kTolerance = 1e-3f;
-  assert(std::fabs(screen.transform.u[0] - (8.0f / 0.3f)) < kTolerance);
-  assert(std::fabs(screen.transform.v[1] - (0.1f / 0.3f)) < kTolerance);
-  assert(std::fabs(screen.transform.w[2] - (5.0f / 0.3f)) < kTolerance);
+    const auto &scene = cfg.GetScene();
+    assert(scene.fixtures.empty());
+    assert(scene.sceneObjects.size() == 1);
 
-  assert(screen.transform.o[0] > -kTolerance);
-  assert(screen.transform.o[0] < kTolerance);
-  assert(std::fabs(screen.transform.o[2] - 6800.0f) < 1.0f);
+    const SceneObject &screen = scene.sceneObjects.begin()->second;
+    constexpr float kTolerance = 1e-3f;
+    assert(std::fabs(screen.transform.u[0] - (8.0f / 0.3f)) < kTolerance);
+    assert(std::fabs(screen.transform.v[1] - (0.1f / 0.3f)) < kTolerance);
+    assert(std::fabs(screen.transform.w[2] - (5.0f / 0.3f)) < kTolerance);
+    assert(screen.transform.o[0] > -kTolerance);
+    assert(screen.transform.o[0] < kTolerance);
+
+    return std::make_tuple(screen.transform.o[0], screen.transform.o[1],
+                           screen.transform.o[2]);
+  };
+
+  const auto [directX, directY, directZ] = importAndReadScreenTransform(riderText);
+  const std::string filtered = RiderImporter::BuildFixtureFilterPreview(riderText);
+  assert(!filtered.empty());
+  const auto [filteredX, filteredY, filteredZ] =
+      importAndReadScreenTransform(filtered);
+
+  constexpr float kPositionTolerance = 1.0f;
+  assert(std::fabs(directX - filteredX) < kPositionTolerance);
+  assert(std::fabs(directY - filteredY) < kPositionTolerance);
+  assert(std::fabs(directZ - filteredZ) < kPositionTolerance);
+  assert(std::fabs(directZ - 6800.0f) < 1.0f);
 
   return 0;
 }


### PR DESCRIPTION
### Motivation
- Fix inconsistent scene creation where `Create` produced different placements than using `Apply filter` first by ensuring both paths use the same normalized text. 
- Prevent user-visible divergences (e.g. screen placement) caused by duplicating parsing/normalization logic between preview and import.

### Description
- Make `RiderImporter::ImportText` consume the normalized output from `BuildFixtureFilterPreview` by using the filtered text as the import input and falling back to raw text only when the filter returns empty (`core/riderimporter.cpp`).
- Add a regression in `tests/rider_led_screen_object_test.cpp` that imports the same rider both directly and via the filtered preview and asserts screen `X/Y/Z` positions match within tolerance.
- Update documentation in `docs/text_to_scene_rules.md` to state that `Create` internally runs the same filter pass used by the `Apply filter` preview.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which succeeded (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` which succeeded (`OK`).
- Attempted to configure/build tests with `cmake -S . -B build/tests -DBUILD_TESTS=ON` but CMake failed in this environment due to missing `wxWidgets` development libraries, so test binaries were not built here (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bed7d2b8388324b55ba0cc617805ea)