### PR TITLE
Add busy overlays and input lock during rider scene generation

### DIFF
--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -28,7 +28,9 @@
 #include <vector>
 
 #include <tinyxml2.h>
+#include <wx/busyinfo.h>
 #include <wx/log.h>
+#include <wx/utils.h>
 #include <wx/wfstream.h>
 #include <wx/zipstrm.h>
 
@@ -218,6 +220,12 @@ void MainWindow::OnImportRider(wxCommandEvent &event) {
   const std::filesystem::path selectedPath(dlg.GetPath().ToStdWstring());
   const auto pathU8 = selectedPath.u8string();
   const std::string pathUtf8(pathU8.begin(), pathU8.end());
+  std::unique_ptr<wxWindowDisabler> importDisabler =
+      std::make_unique<wxWindowDisabler>();
+  std::unique_ptr<wxBusyInfo> importOverlay =
+      std::make_unique<wxBusyInfo>("Creating scene from rider...");
+  wxYieldIfNeeded();
+
   LockViewportInteraction();
   ScopeExit viewportUnlock([this]() { UnlockViewportInteraction(); });
   if (!RiderImporter::Import(pathUtf8)) {
@@ -225,9 +233,14 @@ void MainWindow::OnImportRider(wxCommandEvent &event) {
     if (consolePanel)
       consolePanel->AppendMessage("[ERROR] Failed to import " + dlg.GetPath());
   } else {
+    importOverlay.reset();
+    importDisabler.reset();
     wxMessageBox("Rider imported successfully.", "Success", wxICON_INFORMATION);
     if (consolePanel)
       consolePanel->AppendMessage("[INFO] Imported " + dlg.GetPath());
+    importDisabler = std::make_unique<wxWindowDisabler>();
+    importOverlay = std::make_unique<wxBusyInfo>("Refreshing scene view...");
+    wxYieldIfNeeded();
     RefreshAfterSceneChange();
   }
 }
@@ -238,6 +251,12 @@ void MainWindow::OnImportRiderText(wxCommandEvent &WXUNUSED(event)) {
   RiderTextDialog dlg(this);
   if (dlg.ShowModal() != wxID_OK)
     return;
+
+  std::unique_ptr<wxWindowDisabler> createDisabler =
+      std::make_unique<wxWindowDisabler>();
+  std::unique_ptr<wxBusyInfo> createOverlay =
+      std::make_unique<wxBusyInfo>("Generating scene from text...");
+  wxYieldIfNeeded();
 
   if (consolePanel)
     consolePanel->AppendMessage("[INFO] Imported rider from text.");


### PR DESCRIPTION
### Motivation
- Prevent users from interacting with the viewports while a rider import or "Create by text" operation is generating scene data, which could leave the 3D view out of sync or not rendered.

### Description
- Added `#include <wx/busyinfo.h>` and `#include <wx/utils.h>` to `gui/mainwindow_io.cpp` to support busy overlays and `wxYieldIfNeeded()`.
- In `MainWindow::OnImportRider` created a `wxWindowDisabler` + `wxBusyInfo` with message "Creating scene from rider..." before calling `RiderImporter::Import(...)` and yield to the UI.
- After a successful import the import overlay is cleared and a second `wxWindowDisabler` + `wxBusyInfo` with message "Refreshing scene view..." is shown while calling `RefreshAfterSceneChange()` to keep the viewport locked during refresh.
- In `MainWindow::OnImportRiderText` added a `wxWindowDisabler` + `wxBusyInfo` with message "Generating scene from text..." immediately after dialog confirmation and before `RefreshAfterSceneChange()` to cover text-based scene creation.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it returned OK.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it returned OK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bef84948c88324a5a382ce6398ab22)