### PR TITLE
Create rig layers per hoist function, adjust LX/SCREEN hoist placement and colors

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -377,6 +377,21 @@ std::string ResolveHoistFunctionForTarget(const std::string &target) {
   return "Lighting";
 }
 
+std::string ResolveHoistLayerColor(const std::string &hoistFunctionRaw) {
+  const std::string hoistFunction = NormalizeHoistFunction(hoistFunctionRaw);
+  if (hoistFunction == "Audio")
+    return "#FF0000";
+  if (hoistFunction == "Video")
+    return "#00FF00";
+  if (hoistFunction == "Scenic")
+    return "#0000FF";
+  if (hoistFunction == "Extra")
+    return "#8F00FF";
+  if (hoistFunction == "Other")
+    return "#C7A3C7";
+  return "#FF00FF"; // Lighting (default).
+}
+
 // Performs a case-insensitive substring search without lowercasing the entire
 // haystack. This keeps the per-line processing in Import() cheap while still
 // matching section headers regardless of their capitalization.
@@ -879,7 +894,8 @@ bool RiderImporter::ImportText(const std::string &text) {
   for (auto &[id, layer] : scene.layers)
     layerLookup.emplace(layer.name, &layer);
 
-  auto addToLayer = [&](const std::string &lname, const std::string &uid) {
+  auto addToLayer = [&](const std::string &lname, const std::string &uid,
+                        const std::string &layerColor = std::string()) {
     std::string name = lname.empty() ? DEFAULT_LAYER_NAME : lname;
     Layer *layerPtr = nullptr;
     auto it = layerLookup.find(name);
@@ -889,10 +905,13 @@ bool RiderImporter::ImportText(const std::string &text) {
       Layer l;
       l.uuid = name == DEFAULT_LAYER_NAME ? "layer_default" : GenerateUuid();
       l.name = name;
+      l.color = layerColor;
       auto [insertedIt, inserted] =
           scene.layers.emplace(l.uuid, std::move(l));
       layerPtr = &insertedIt->second;
       layerLookup.emplace(layerPtr->name, layerPtr);
+    } else if (!layerColor.empty() && layerPtr->color.empty()) {
+      layerPtr->color = layerColor;
     }
     layerPtr->childUUIDs.push_back(uid);
   };
@@ -1504,16 +1523,13 @@ bool RiderImporter::ImportText(const std::string &text) {
     support.motorModelSource = "Manual";
     support.weightSource = "Manual";
 
-    std::string layerName = defaultLayer;
-    if (layerByType && !positionName.empty())
-      layerName = "hoist " + positionName;
-    else if (!layerByType && !positionName.empty())
-      layerName = "pos " + positionName;
+    const std::string normalizedFunction = NormalizeHoistFunction(hoistFunction);
+    std::string layerName = "rig " + normalizedFunction;
     support.layer = layerName;
 
     const std::string supportUuid = support.uuid;
     scene.supports[supportUuid] = support;
-    addToLayer(layerName, supportUuid);
+    addToLayer(layerName, supportUuid, ResolveHoistLayerColor(normalizedFunction));
   };
 
   auto distributeAcrossTruss = [&](const std::string &positionName, int quantity,
@@ -1589,7 +1605,7 @@ bool RiderImporter::ImportText(const std::string &text) {
       int rem = request.quantity % static_cast<int>(lxNames.size());
       for (size_t i = 0; i < lxNames.size(); ++i) {
         int qty = base + (static_cast<int>(i) < rem ? 1 : 0);
-        distributeAcrossTruss(lxNames[i], qty, request.capacityKg, 2000.0f,
+        distributeAcrossTruss(lxNames[i], qty, request.capacityKg, 1000.0f,
                               hoistFunction);
       }
     } else if (request.target == "PA") {
@@ -1599,8 +1615,21 @@ bool RiderImporter::ImportText(const std::string &text) {
       distributePaOrSidefill("SIDEFILL", request.quantity, request.capacityKg, true,
                              hoistFunction);
     } else if (request.target == "SCREEN") {
-      distributeAcrossTruss("SCREEN", request.quantity, request.capacityKg, 0.0f,
-                            hoistFunction);
+      if (request.quantity <= 0)
+        continue;
+      TrussInfo info;
+      auto infoIt = trussInfo.find("SCREEN");
+      if (infoIt != trussInfo.end())
+        info = infoIt->second;
+      const float y = info.found ? info.y : getHangPos("SCREEN");
+      const float z = info.found ? info.z : getHangHeight("SCREEN");
+      const float span = info.found ? (info.endX - info.startX) : (1000.0f * request.quantity);
+      const float part = span / static_cast<float>(request.quantity + 1);
+      const float startX = info.found ? info.startX : (-0.5f * span);
+      for (int i = 0; i < request.quantity; ++i) {
+        const float x = startX + part * static_cast<float>(i + 1);
+        placeHoist(x, y, z, request.capacityKg, "SCREEN", hoistFunction);
+      }
     } else {
       distributeAcrossTruss(request.target, request.quantity, request.capacityKg,
                             2000.0f, hoistFunction);

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -199,10 +199,11 @@ Placement defaults:
    - Placed 2 m behind `LX1` on `Y`.
 3. **LX hoists (`PUENTES LX`)**
    - Quantity is distributed across detected `LX*` trusses (`LX1`, `LX2`, ...).
-   - Each per-LX set is placed on that truss at the same `Y/Z`, using a 2 m
+   - Each per-LX set is placed on that truss at the same `Y/Z`, using a 1 m
      margin from truss ends in `X`.
 4. **SCREEN hoists**
-   - Distributed equidistantly along the `SCREEN` truss span.
+   - Distributed using internal truss divisions (for `N` hoists, truss span is
+     split into `N+1` equal parts and hoists are placed on internal cuts).
 
 Created hoists:
 
@@ -214,6 +215,12 @@ Created hoists:
   - `PA`, `P.A.`, `SIDEFILL`, `OUTFILL` => `Audio`
   - `SCREEN`, `LEDSCREEN`, `VIDEO` => `Video`
   - Any other target => `Lighting`
+- Hoists are assigned to rig layers by function:
+   - `rig Audio`, `rig Video`, `rig Lighting`, etc.
+   - Missing rig layers are created automatically.
+   - Newly created rig layers receive the same color used by hoist symbols:
+     `Audio=#FF0000`, `Video=#00FF00`, `Scenic=#0000FF`, `Extra=#8F00FF`,
+     `Other=#C7A3C7`, `Lighting=#FF00FF`.
 
 ## Layer assignment rules
 
@@ -225,6 +232,7 @@ Driven by config key `rider_layer_mode`:
 - `type` mode:
   - Fixtures: `fix <fixture type>`
   - Trusses: `truss <hang>`
+- Hoists (both modes): `rig <hoist function>`
 
 Missing/empty names fall back to the default scene layer.
 

--- a/tests/rider_hoist_import_test.cpp
+++ b/tests/rider_hoist_import_test.cpp
@@ -1,7 +1,9 @@
 #include <cassert>
 #include <cmath>
 #include <map>
+#include <algorithm>
 #include <string>
+#include <vector>
 #include <wx/init.h>
 
 #include "configmanager.h"
@@ -32,12 +34,16 @@ int main() {
   std::map<std::string, int> countByPosition;
   std::map<std::string, int> countByCapacity;
   std::map<std::string, int> countByFunction;
+  std::map<std::string, int> countByLayer;
+  std::map<std::string, std::vector<float>> xByPosition;
   for (const auto &[uuid, support] : scene.supports) {
     (void)uuid;
     countByPosition[support.positionName]++;
     const int cap = static_cast<int>(support.capacityKg + 0.5f);
     countByCapacity[std::to_string(cap)]++;
     countByFunction[support.positionName + ":" + support.hoistFunction]++;
+    countByLayer[support.layer]++;
+    xByPosition[support.positionName].push_back(support.transform.o[0]);
   }
 
   assert(countByPosition["P.A."] == 4);
@@ -56,6 +62,35 @@ int main() {
   assert(countByFunction["LX1:Lighting"] == 2);
   assert(countByFunction["LX2:Lighting"] == 2);
   assert(countByFunction["LX3:Lighting"] == 2);
+  assert(countByLayer["rig Audio"] == 6);
+  assert(countByLayer["rig Video"] == 4);
+  assert(countByLayer["rig Lighting"] == 6);
+  bool audioLayerColorOk = false;
+  bool videoLayerColorOk = false;
+  bool lightingLayerColorOk = false;
+  for (const auto &[uuid, layer] : scene.layers) {
+    (void)uuid;
+    if (layer.name == "rig Audio")
+      audioLayerColorOk = (layer.color == "#FF0000");
+    if (layer.name == "rig Video")
+      videoLayerColorOk = (layer.color == "#00FF00");
+    if (layer.name == "rig Lighting")
+      lightingLayerColorOk = (layer.color == "#FF00FF");
+  }
+  assert(audioLayerColorOk);
+  assert(videoLayerColorOk);
+  assert(lightingLayerColorOk);
+
+  for (auto &[positionName, values] : xByPosition) {
+    (void)positionName;
+    std::sort(values.begin(), values.end());
+  }
+  assert(std::abs(xByPosition["LX1"][0] - (-6000.0f)) < 0.001f);
+  assert(std::abs(xByPosition["LX1"][1] - 6000.0f) < 0.001f);
+  assert(std::abs(xByPosition["SCREEN"][0] - (-4200.0f)) < 0.001f);
+  assert(std::abs(xByPosition["SCREEN"][1] - (-1400.0f)) < 0.001f);
+  assert(std::abs(xByPosition["SCREEN"][2] - 1400.0f) < 0.001f);
+  assert(std::abs(xByPosition["SCREEN"][3] - 4200.0f) < 0.001f);
 
   bool foundScreenTruss = false;
   for (const auto &[uuid, truss] : scene.trusses) {

--- a/tests/rider_layer_mode_test.cpp
+++ b/tests/rider_layer_mode_test.cpp
@@ -23,6 +23,7 @@
 #include "configmanager.h"
 #include "riderimporter.h"
 #include "fixture.h"
+#include "support.h"
 #include "truss.h"
 
 int main(int argc, char **argv) {
@@ -48,6 +49,10 @@ int main(int argc, char **argv) {
     if (!t.positionName.empty())
       assert(t.layer == std::string("pos ") + t.positionName);
   }
+  for (const auto &p : scenePos.supports) {
+    const Support &s = p.second;
+    assert(s.layer == std::string("rig ") + NormalizeHoistFunction(s.hoistFunction));
+  }
 
   // Layers by fixture type (trusses still by position)
   cfg.Reset();
@@ -62,6 +67,10 @@ int main(int argc, char **argv) {
     const Truss &t = p.second;
     if (!t.positionName.empty())
       assert(t.layer == std::string("truss ") + t.positionName);
+  }
+  for (const auto &p : sceneType.supports) {
+    const Support &s = p.second;
+    assert(s.layer == std::string("rig ") + NormalizeHoistFunction(s.hoistFunction));
   }
   return 0;
 }


### PR DESCRIPTION
### Motivation
- Import hoists created by the "Create by text" flow must be organized into function-specific rig layers (`rig Audio`, `rig Video`, `rig Lighting`, etc.) and those layers should be auto-created when missing using the same color used by hoist symbols. 
- Lighting hoists placed on LX trusses should sit 1 m from truss ends instead of 2 m. 
- Video/SCREEN hoists should be distributed avoiding endpoints by dividing the truss span into internal cuts (for `N` hoists use `N+1` parts). 
- The change updates text-to-scene behavior so documentation and tests must reflect the new placement and layer rules.

### Description
- Added `ResolveHoistLayerColor` and changed `addToLayer` to accept an optional `layerColor` and to create missing layers with that color, and to update empty layer colors when applicable. (see `core/riderimporter.cpp`).
- Hoists are now assigned to layers named `rig <Function>` (e.g. `rig Audio`) when created, and new rig layers are created automatically with function-matching colors. (see `placeHoist` usage and layer creation in `core/riderimporter.cpp`).
- LX hoist edge margin reduced from `2000.0f` to `1000.0f` (2 m -> 1 m) when distributing across LX trusses, and SCREEN hoist distribution now places `N` hoists at the internal `N+1` cuts of the span instead of simple end-inclusive equidistant spacing (see changed distribution logic in `core/riderimporter.cpp`).
- Updated `docs/text_to_scene_rules.md` to document the new LX margin, SCREEN distribution rule, and rig-layer naming/colors. 
- Updated tests: `tests/rider_hoist_import_test.cpp` and `tests/rider_layer_mode_test.cpp` to assert layer naming, layer colors, and the adjusted LX/SCREEN placement coordinates. 
- Hotspot note: `core/riderimporter.cpp` is large (above the soft guardrail); recommended follow-ups are extracting hoist parsing/placement and text-normalization into separate files (`core/riderimporter_hoists.{h,cpp}`, `core/riderimporter_text_norm.{h,cpp}`) to keep responsibilities modular.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (`OK`).
- Attempted `cmake --preset wsl-x64-debug` to configure a local build but configuration failed due to missing `wxWidgets` in the environment, so the project build and unit test execution were not performed in this container (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf03b9017c832499fd143c0ae1fc4e)