### PR TITLE
Fix malformed control flow in RiderImporter layer assignment

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -910,7 +910,8 @@ bool RiderImporter::ImportText(const std::string &text) {
           scene.layers.emplace(l.uuid, std::move(l));
       layerPtr = &insertedIt->second;
       layerLookup.emplace(layerPtr->name, layerPtr);
-    } else if (!layerColor.empty() && layerPtr->color.empty()) {
+    }
+    if (!layerColor.empty() && layerPtr->color.empty()) {
       layerPtr->color = layerColor;
     }
     layerPtr->childUUIDs.push_back(uid);


### PR DESCRIPTION
### Motivation
- Fix a malformed control-flow block in `RiderImporter::ImportText` that caused the compiler to emit cascading syntax and undeclared-identifier errors by leaving the `else` attached to the wrong branch.

### Description
- Close the `else` block in the `addToLayer` lambda in `core/riderimporter.cpp` and make the color-assignment a separate `if` so `layerColor` is applied whether the layer was found or newly created.
- Technical note: `core/riderimporter.cpp` is larger than the 1200–1500 LOC soft limit, so consider extracting the import-parsing logic into a dedicated helper/file in a follow-up PR to reduce hotspot risk.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf057274f8832495d6999b6de634fe)