### PR TITLE
Deterministic hoist naming on import (LX/SCREEN/PA/SIDEFILL) and LX margin tweak

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -310,13 +310,112 @@ float ParseHoistCapacityKg(const std::string &text) {
   return tons ? value * 1000.0f : value;
 }
 
-std::string BuildHoistName(float capacityKg, const std::string &positionName) {
-  int rounded = static_cast<int>(std::round(capacityKg));
-  std::ostringstream oss;
-  oss << "Motor " << rounded << " Kg";
-  if (!positionName.empty())
-    oss << " " << positionName;
-  return oss.str();
+bool IsLxHangName(const std::string &positionName) {
+  if (positionName.size() < 3 || positionName.rfind("LX", 0) != 0)
+    return false;
+  for (size_t i = 2; i < positionName.size(); ++i) {
+    if (!std::isdigit(static_cast<unsigned char>(positionName[i])))
+      return false;
+  }
+  return true;
+}
+
+std::string BuildIndexedName(const std::string &prefix, int index,
+                             bool omitIndexForSingle) {
+  if (omitIndexForSingle && index == 1)
+    return prefix;
+  return prefix + " " + std::to_string(index);
+}
+
+void AssignImportedHoistNames(std::vector<Support *> &supports) {
+  if (supports.empty())
+    return;
+
+  auto sortByX = [](Support *a, Support *b) {
+    if (a->transform.o[0] != b->transform.o[0])
+      return a->transform.o[0] < b->transform.o[0];
+    return a->uuid < b->uuid;
+  };
+
+  std::map<std::string, std::vector<Support *>> lxByPosition;
+  std::vector<Support *> screenSupports;
+  std::vector<Support *> sidefillSupports;
+  std::vector<Support *> paSupports;
+  std::vector<Support *> otherSupports;
+
+  for (Support *support : supports) {
+    if (!support)
+      continue;
+    const std::string position = NormalizeHangName(support->positionName);
+    if (IsLxHangName(position)) {
+      lxByPosition[position].push_back(support);
+    } else if (position == "SCREEN") {
+      screenSupports.push_back(support);
+    } else if (position == "SIDEFILL") {
+      sidefillSupports.push_back(support);
+    } else if (position == "PA" || position == "P.A.") {
+      paSupports.push_back(support);
+    } else {
+      otherSupports.push_back(support);
+    }
+  }
+
+  for (auto &[position, items] : lxByPosition) {
+    std::sort(items.begin(), items.end(), sortByX);
+    for (size_t i = 0; i < items.size(); ++i) {
+      Support *support = items[i];
+      support->name = position + " " + std::to_string(i + 1);
+      support->motorName = support->name;
+    }
+  }
+
+  std::sort(screenSupports.begin(), screenSupports.end(), sortByX);
+  for (size_t i = 0; i < screenSupports.size(); ++i) {
+    Support *support = screenSupports[i];
+    support->name = "SCR " + std::to_string(i + 1);
+    support->motorName = support->name;
+  }
+
+  auto assignLeftRightNames = [&](std::vector<Support *> &items,
+                                  const std::string &leftPrefix,
+                                  const std::string &rightPrefix,
+                                  bool omitIndexForSingle) {
+    std::vector<Support *> left;
+    std::vector<Support *> right;
+    for (Support *support : items) {
+      if (!support)
+        continue;
+      if (support->transform.o[0] <= 0.0f)
+        left.push_back(support);
+      else
+        right.push_back(support);
+    }
+    std::sort(left.begin(), left.end(), sortByX);
+    std::sort(right.begin(), right.end(), sortByX);
+
+    for (size_t i = 0; i < left.size(); ++i) {
+      Support *support = left[i];
+      support->name =
+          BuildIndexedName(leftPrefix, static_cast<int>(i + 1), omitIndexForSingle);
+      support->motorName = support->name;
+    }
+    for (size_t i = 0; i < right.size(); ++i) {
+      Support *support = right[i];
+      support->name =
+          BuildIndexedName(rightPrefix, static_cast<int>(i + 1), omitIndexForSingle);
+      support->motorName = support->name;
+    }
+  };
+
+  assignLeftRightNames(sidefillSupports, "SF L", "SF R", true);
+  assignLeftRightNames(paSupports, "PA L", "PA R", false);
+
+  std::sort(otherSupports.begin(), otherSupports.end(), sortByX);
+  for (size_t i = 0; i < otherSupports.size(); ++i) {
+    Support *support = otherSupports[i];
+    support->name = "RP " + std::to_string(i + 1);
+    support->motorName = support->name;
+  }
 }
 
 std::string PickDummyHoistProfileId(float capacityKg) {
@@ -1500,6 +1599,7 @@ bool RiderImporter::ImportText(const std::string &text) {
     addToLayer(screenObject.layer, screenObject.uuid);
   }
 
+  std::vector<std::string> importedSupportUuids;
   auto placeHoist = [&](float x, float y, float z, float capacityKg,
                         const std::string &positionName,
                         const std::string &hoistFunction) {
@@ -1516,7 +1616,7 @@ bool RiderImporter::ImportText(const std::string &text) {
     support.hoistDataSource = "Manual";
     support.capacitySource = "Manual";
     support.hoistFunctionSource = "Manual";
-    support.name = BuildHoistName(capacityKg, positionName);
+    support.name = "HOIST";
     support.dummyProfileId = PickDummyHoistProfileId(capacityKg);
     support.motorName = support.name;
     support.motorNameSource = "Manual";
@@ -1530,6 +1630,7 @@ bool RiderImporter::ImportText(const std::string &text) {
 
     const std::string supportUuid = support.uuid;
     scene.supports[supportUuid] = support;
+    importedSupportUuids.push_back(supportUuid);
     addToLayer(layerName, supportUuid, ResolveHoistLayerColor(normalizedFunction));
   };
 
@@ -1632,10 +1733,21 @@ bool RiderImporter::ImportText(const std::string &text) {
         placeHoist(x, y, z, request.capacityKg, "SCREEN", hoistFunction);
       }
     } else {
+      const float marginMm = IsLxHangName(request.target) ? 1000.0f : 2000.0f;
       distributeAcrossTruss(request.target, request.quantity, request.capacityKg,
-                            2000.0f, hoistFunction);
+                            marginMm, hoistFunction);
     }
   }
+
+  std::vector<Support *> importedSupports;
+  importedSupports.reserve(importedSupportUuids.size());
+  for (const std::string &uuid : importedSupportUuids) {
+    auto it = scene.supports.find(uuid);
+    if (it == scene.supports.end())
+      continue;
+    importedSupports.push_back(&it->second);
+  }
+  AssignImportedHoistNames(importedSupports);
 
   std::unordered_map<std::string, std::vector<Fixture *>> fixturesByPos;
   fixturesByPos.reserve(importedFixtureUuids.size());

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -26,6 +26,7 @@
 #include <functional>
 #include <iomanip>
 #include <limits>
+#include <map>
 #include <numeric>
 #include <optional>
 #include <regex>
@@ -360,7 +361,11 @@ void AssignImportedHoistNames(std::vector<Support *> &supports) {
     }
   }
 
-  for (auto &[position, items] : lxByPosition) {
+  for (std::map<std::string, std::vector<Support *> >::iterator it =
+           lxByPosition.begin();
+       it != lxByPosition.end(); ++it) {
+    const std::string &position = it->first;
+    std::vector<Support *> &items = it->second;
     std::sort(items.begin(), items.end(), sortByX);
     for (size_t i = 0; i < items.size(); ++i) {
       Support *support = items[i];

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -201,6 +201,7 @@ Placement defaults:
    - Quantity is distributed across detected `LX*` trusses (`LX1`, `LX2`, ...).
    - Each per-LX set is placed on that truss at the same `Y/Z`, using a 1 m
      margin from truss ends in `X`.
+   - Direct `LX<number>` hoist targets also use a 1 m margin from truss ends.
 4. **SCREEN hoists**
    - Distributed using internal truss divisions (for `N` hoists, truss span is
      split into `N+1` equal parts and hoists are placed on internal cuts).
@@ -215,6 +216,12 @@ Created hoists:
   - `PA`, `P.A.`, `SIDEFILL`, `OUTFILL` => `Audio`
   - `SCREEN`, `LEDSCREEN`, `VIDEO` => `Video`
   - Any other target => `Lighting`
+- Hoist naming defaults (ordered left-to-right on `X`):
+  - `LX*` targets => `<position> <index>` (`LX1 1`, `LX1 2`, ...).
+  - `SCREEN`/video targets => `SCR <index>`.
+  - `SIDEFILL` => `SF L`, `SF R` (adds index when side has more than one hoist).
+  - `PA`/`P.A.` => `PA L <index>`, `PA R <index>`.
+  - Fallback targets => `RP <index>` (Rigging Point).
 - Hoists are assigned to rig layers by function:
    - `rig Audio`, `rig Video`, `rig Lighting`, etc.
    - Missing rig layers are created automatically.

--- a/tests/rider_hoist_import_test.cpp
+++ b/tests/rider_hoist_import_test.cpp
@@ -36,6 +36,7 @@ int main() {
   std::map<std::string, int> countByFunction;
   std::map<std::string, int> countByLayer;
   std::map<std::string, std::vector<float>> xByPosition;
+  std::map<std::string, int> nameCounts;
   for (const auto &[uuid, support] : scene.supports) {
     (void)uuid;
     countByPosition[support.positionName]++;
@@ -44,6 +45,7 @@ int main() {
     countByFunction[support.positionName + ":" + support.hoistFunction]++;
     countByLayer[support.layer]++;
     xByPosition[support.positionName].push_back(support.transform.o[0]);
+    nameCounts[support.name]++;
   }
 
   assert(countByPosition["P.A."] == 4);
@@ -91,6 +93,23 @@ int main() {
   assert(std::abs(xByPosition["SCREEN"][1] - (-1400.0f)) < 0.001f);
   assert(std::abs(xByPosition["SCREEN"][2] - 1400.0f) < 0.001f);
   assert(std::abs(xByPosition["SCREEN"][3] - 4200.0f) < 0.001f);
+
+  assert(nameCounts["LX1 1"] == 1);
+  assert(nameCounts["LX1 2"] == 1);
+  assert(nameCounts["LX2 1"] == 1);
+  assert(nameCounts["LX2 2"] == 1);
+  assert(nameCounts["LX3 1"] == 1);
+  assert(nameCounts["LX3 2"] == 1);
+  assert(nameCounts["SCR 1"] == 1);
+  assert(nameCounts["SCR 2"] == 1);
+  assert(nameCounts["SCR 3"] == 1);
+  assert(nameCounts["SCR 4"] == 1);
+  assert(nameCounts["SF L"] == 1);
+  assert(nameCounts["SF R"] == 1);
+  assert(nameCounts["PA L 1"] == 1);
+  assert(nameCounts["PA L 2"] == 1);
+  assert(nameCounts["PA R 1"] == 1);
+  assert(nameCounts["PA R 2"] == 1);
 
   bool foundScreenTruss = false;
   for (const auto &[uuid, truss] : scene.trusses) {


### PR DESCRIPTION
### Motivation
- Provide deterministic, human-friendly names for imported hoists instead of generic or capacity-based names to make scene editing and referencing easier.
- Ensure per-hang ordering and left/right grouping when assigning names so multi-hoist targets are predictable and consistent.
- Use a smaller placement margin for direct `LX<number>` targets so hoists distributed on LX trusses respect the expected 1 m edge margin.

### Description
- Replaced the old `BuildHoistName` usage with a new post-import naming pass implemented in `AssignImportedHoistNames`, which classifies supports by position and assigns ordered names for `LX*`, `SCREEN`, `SIDEFILL`, `PA/P.A.` and fallback `RP` targets.
- Added helper functions `IsLxHangName` and `BuildIndexedName`, changed initial auto-created hoist name to a placeholder (`"HOIST"`), and then set final `name` and `motorName` during the assignment pass.
- Collected created support UUIDs (`importedSupportUuids`), resolved them to `Support *` pointers, and invoked `AssignImportedHoistNames` after placement; also adjusted distribution margin to `1000.0f` for `LX` targets and kept `2000.0f` for others.
- Updated documentation (`docs/text_to_scene_rules.md`) to describe the new naming defaults and behavior for direct `LX<number>` targets.

### Testing
- Updated and ran the unit test `tests/rider_hoist_import_test.cpp`, which validates support counts, positions, layers, X placements, and the new deterministic names, and the test passed.
- Verified the rig layer coloring and dummy hoist profile selection assertions in the same test, which also passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf09b9e47483248133f6a945c4b120)