### PR TITLE
Use layer color for 2D hoist symbols and parse layer hex colors

### DIFF
--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -225,9 +225,12 @@ Created hoists:
 - Hoists are assigned to rig layers by function:
    - `rig Audio`, `rig Video`, `rig Lighting`, etc.
    - Missing rig layers are created automatically.
-   - Newly created rig layers receive the same color used by hoist symbols:
+   - Newly created rig layers use these default colors:
      `Audio=#FF0000`, `Video=#00FF00`, `Scenic=#0000FF`, `Extra=#8F00FF`,
      `Other=#C7A3C7`, `Lighting=#FF00FF`.
+   - Hoist symbols are drawn with white fill and use their current layer color
+     for the colored regions/outline, so changing a hoist to another layer
+     updates the symbol color automatically.
 - Hoist loads are auto-distributed after import for each hang position that
   received newly created hoists:
   - Position total uses the same rigging table rule: sum of fixture+truss+hoist
@@ -237,8 +240,6 @@ Created hoists:
   - If hoists are collinear and count is `2..8`, the importer applies standard
     percentage factors (`2: 50/50`, `3: 19/62/19`, ... , `8: 6/16/14/14/14/14/16/6`),
     then rounds each hoist load up to the next 5 kg.
-  - If any fixture/truss/hoist in a hang has missing weight (`<= 0`), hoists in
-    that hang are shown in red in 2D to highlight incomplete pipeline data.
 
 ## Layer assignment rules
 

--- a/viewer3d/render/hoist_symbol_renderer.cpp
+++ b/viewer3d/render/hoist_symbol_renderer.cpp
@@ -14,7 +14,6 @@
 #endif
 
 #include "configmanager.h"
-#include "hoist_weight_distribution.h"
 #include "support.h"
 
 #include <algorithm>
@@ -62,6 +61,53 @@ RgbColor ResolveHoistFunctionColor(const std::string &hoistFunctionRaw) {
   if (hoistFunction == "Other")
     return {0.78f, 0.64f, 0.78f};
   return {1.0f, 0.0f, 1.0f}; // Lighting (default)
+}
+
+int HexNibbleValue(char c) {
+  if (c >= '0' && c <= '9')
+    return c - '0';
+  if (c >= 'a' && c <= 'f')
+    return 10 + (c - 'a');
+  if (c >= 'A' && c <= 'F')
+    return 10 + (c - 'A');
+  return -1;
+}
+
+bool TryParseHexColor(const std::string &hex, RgbColor &out) {
+  if (hex.size() != 7 || hex[0] != '#')
+    return false;
+
+  const int rHi = HexNibbleValue(hex[1]);
+  const int rLo = HexNibbleValue(hex[2]);
+  const int gHi = HexNibbleValue(hex[3]);
+  const int gLo = HexNibbleValue(hex[4]);
+  const int bHi = HexNibbleValue(hex[5]);
+  const int bLo = HexNibbleValue(hex[6]);
+  if (rHi < 0 || rLo < 0 || gHi < 0 || gLo < 0 || bHi < 0 || bLo < 0)
+    return false;
+
+  const float inv255 = 1.0f / 255.0f;
+  out.r = static_cast<float>((rHi << 4) | rLo) * inv255;
+  out.g = static_cast<float>((gHi << 4) | gLo) * inv255;
+  out.b = static_cast<float>((bHi << 4) | bLo) * inv255;
+  return true;
+}
+
+RgbColor ResolveHoistLayerColor(const MvrScene &scene, const Support &support) {
+  const std::string normalizedLayer = NormalizedLayerName(support.layer);
+  for (const auto &[layerUuid, layer] : scene.layers) {
+    (void)layerUuid;
+    if (layer.name != normalizedLayer)
+      continue;
+    RgbColor parsed;
+    if (TryParseHexColor(layer.color, parsed))
+      return parsed;
+    break;
+  }
+
+  const std::string functionValue =
+      support.hoistFunction.empty() ? support.function : support.hoistFunction;
+  return ResolveHoistFunctionColor(functionValue);
 }
 
 HoistShape ResolveHoistShape(float capacityKg) {
@@ -335,24 +381,13 @@ void Render(IRenderContext &renderContext, const RenderFrameContext &context) {
     return;
 
   const MvrScene &scene = ConfigManager::Get().GetScene();
-  const auto missingWeightByPosition =
-      HoistWeightDistribution::BuildMissingWeightMapByHangPosition(scene);
-
   const auto &supports = scene.supports;
   for (const auto &[uuid, support] : supports) {
     (void)uuid;
     if (!IsLayerVisible(context.hiddenLayers, support.layer))
       continue;
 
-    const std::string functionValue =
-        support.hoistFunction.empty() ? support.function : support.hoistFunction;
-
-    RgbColor color = ResolveHoistFunctionColor(functionValue);
-    const std::string positionName =
-        support.positionName.empty() ? std::string("Unassigned") : support.positionName;
-    auto missingIt = missingWeightByPosition.find(positionName);
-    if (missingIt != missingWeightByPosition.end() && missingIt->second)
-      color = {1.0f, 0.0f, 0.0f};
+    const RgbColor color = ResolveHoistLayerColor(scene, support);
 
     DrawHoistSymbol(renderContext, support, color);
   }


### PR DESCRIPTION
### Motivation
- When creating rig layers via "Create by text" the hoist symbols should use the layer color as their accent while keeping the white fill, and moving a hoist between layers should update its symbol color automatically.
- Replace the previous fixed-color/weight-based override which prevented layer-driven coloring and caused hoists to appear red in the reported scenario.

### Description
- Added `HexNibbleValue`, `TryParseHexColor` and `ResolveHoistLayerColor` to `viewer3d/render/hoist_symbol_renderer.cpp` so the renderer reads a layer `#RRGGBB` color (via `ConfigManager::Get().GetScene()`) and converts it to RGB for symbol accents while falling back to the function-based color when missing or invalid.
- Switched hoist rendering to use the resolved layer color for accent regions and outlines and preserved the white fill in the symbol geometry by calling `DrawHoistSymbol(..., color)` with the computed color.
- Removed the `hoist_weight_distribution.h` dependency and the previous missing-weight red override from the symbol renderer so layer color is the authoritative accent color.
- Updated `docs/text_to_scene_rules.md` to list the default rig layer colors used by text import and to document that hoist symbols use white fill plus their layer color accents.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf236505988324bbf40c031471e2d2)