### PR TITLE
Read fixture category during text import and apply fallback

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -1096,7 +1096,8 @@ bool RiderImporter::ImportText(const std::string &text) {
         if (auto dictEntry = GdtfDictionary::Get(f.typeName)) {
           f.gdtfSpec = dictEntry->path;
           f.gdtfMode = dictEntry->mode;
-          const std::string dictionaryCategory = Trim(dictEntry->category);
+          const std::string dictionaryCategory =
+              GdtfFixtureCategory::NormalizeCategory(Trim(dictEntry->category));
           if (!dictionaryCategory.empty()) {
             f.category = dictionaryCategory;
             f.categorySource = GdtfFixtureCategory::kManualSource;
@@ -1106,6 +1107,13 @@ bool RiderImporter::ImportText(const std::string &text) {
           if (!parsed.empty())
             f.typeName = parsed;
           ApplyFixturePhysicalPropertiesFromGdtf(scene, f);
+        }
+        if (f.category.empty() && !f.gdtfSpec.empty()) {
+          const std::string resolvedGdtfPath = ResolveGdtfPath(scene, f.gdtfSpec);
+          const auto inferred = GdtfFixtureCategory::InferFromGdtf(resolvedGdtfPath);
+          f.category = GdtfFixtureCategory::NormalizeCategory(inferred.category);
+          if (!f.category.empty())
+            f.categorySource = GdtfFixtureCategory::kAutoFallbackSource;
         }
         if (f.category.empty()) {
           f.category = GdtfFixtureCategory::kUnknown;

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -43,6 +43,7 @@
 #include "configmanager.h"
 #include "fixture.h"
 #include "gdtfdictionary.h"
+#include "gdtf_fixture_category.h"
 #include "gdtfloader.h"
 #include "hoist_weight_distribution.h"
 #include "layer.h"
@@ -1095,11 +1096,20 @@ bool RiderImporter::ImportText(const std::string &text) {
         if (auto dictEntry = GdtfDictionary::Get(f.typeName)) {
           f.gdtfSpec = dictEntry->path;
           f.gdtfMode = dictEntry->mode;
+          const std::string dictionaryCategory = Trim(dictEntry->category);
+          if (!dictionaryCategory.empty()) {
+            f.category = dictionaryCategory;
+            f.categorySource = GdtfFixtureCategory::kManualSource;
+          }
           const std::string resolvedGdtfPath = ResolveGdtfPath(scene, f.gdtfSpec);
           std::string parsed = Trim(GetGdtfFixtureName(resolvedGdtfPath));
           if (!parsed.empty())
             f.typeName = parsed;
           ApplyFixturePhysicalPropertiesFromGdtf(scene, f);
+        }
+        if (f.category.empty()) {
+          f.category = GdtfFixtureCategory::kUnknown;
+          f.categorySource = GdtfFixtureCategory::kAutoFallbackSource;
         }
         if (!seenTypes.count(f.typeName)) {
           typeOrder.push_back(f.typeName);

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -1096,8 +1096,7 @@ bool RiderImporter::ImportText(const std::string &text) {
         if (auto dictEntry = GdtfDictionary::Get(f.typeName)) {
           f.gdtfSpec = dictEntry->path;
           f.gdtfMode = dictEntry->mode;
-          const std::string dictionaryCategory =
-              GdtfFixtureCategory::NormalizeCategory(Trim(dictEntry->category));
+          const std::string dictionaryCategory = Trim(dictEntry->category);
           if (!dictionaryCategory.empty()) {
             f.category = dictionaryCategory;
             f.categorySource = GdtfFixtureCategory::kManualSource;
@@ -1107,13 +1106,6 @@ bool RiderImporter::ImportText(const std::string &text) {
           if (!parsed.empty())
             f.typeName = parsed;
           ApplyFixturePhysicalPropertiesFromGdtf(scene, f);
-        }
-        if (f.category.empty() && !f.gdtfSpec.empty()) {
-          const std::string resolvedGdtfPath = ResolveGdtfPath(scene, f.gdtfSpec);
-          const auto inferred = GdtfFixtureCategory::InferFromGdtf(resolvedGdtfPath);
-          f.category = GdtfFixtureCategory::NormalizeCategory(inferred.category);
-          if (!f.category.empty())
-            f.categorySource = GdtfFixtureCategory::kAutoFallbackSource;
         }
         if (f.category.empty()) {
           f.category = GdtfFixtureCategory::kUnknown;

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -120,16 +120,13 @@ For each fixture created:
 2. `typeName` is set from parsed text and may be refined through the GDTF dictionary.
 3. If dictionary entry exists:
    - `gdtfSpec` and `gdtfMode` are assigned.
-   - If dictionary category is defined and valid, it is copied into fixture `category`
+   - If dictionary category is defined, it is copied into fixture `category`
      with source `Manual`.
    - Fixture display/type name can be replaced by the parsed GDTF fixture name when available.
    - Physical properties (weight/power) are filled from GDTF when missing.
 4. `positionName` is set from current hang.
 5. Initial hang coordinates are injected (`Y`, `Z`) and later refined by distribution logic.
-6. If fixture category is still empty but fixture has a resolved `gdtfSpec`,
-   importer runs the same GDTF inference fallback used in scene imports and
-   stores the inferred category with source `AutoFallback`.
-7. Importer falls back to category `Unknown` only when category is still empty
+6. Importer falls back to category `Unknown` only when category is still empty
    after the above steps (for example, dummy fixtures without usable GDTF data).
 
 Special screen-object handling:

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -120,14 +120,17 @@ For each fixture created:
 2. `typeName` is set from parsed text and may be refined through the GDTF dictionary.
 3. If dictionary entry exists:
    - `gdtfSpec` and `gdtfMode` are assigned.
-   - If dictionary category is defined, it is copied into fixture `category`
+   - If dictionary category is defined and valid, it is copied into fixture `category`
      with source `Manual`.
    - Fixture display/type name can be replaced by the parsed GDTF fixture name when available.
    - Physical properties (weight/power) are filled from GDTF when missing.
 4. `positionName` is set from current hang.
 5. Initial hang coordinates are injected (`Y`, `Z`) and later refined by distribution logic.
-6. If fixture category is still empty after dictionary resolution, importer assigns
-   fallback category `Unknown` with source `AutoFallback`.
+6. If fixture category is still empty but fixture has a resolved `gdtfSpec`,
+   importer runs the same GDTF inference fallback used in scene imports and
+   stores the inferred category with source `AutoFallback`.
+7. Importer falls back to category `Unknown` only when category is still empty
+   after the above steps (for example, dummy fixtures without usable GDTF data).
 
 Special screen-object handling:
 

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -120,10 +120,14 @@ For each fixture created:
 2. `typeName` is set from parsed text and may be refined through the GDTF dictionary.
 3. If dictionary entry exists:
    - `gdtfSpec` and `gdtfMode` are assigned.
+   - If dictionary category is defined, it is copied into fixture `category`
+     with source `Manual`.
    - Fixture display/type name can be replaced by the parsed GDTF fixture name when available.
    - Physical properties (weight/power) are filled from GDTF when missing.
 4. `positionName` is set from current hang.
 5. Initial hang coordinates are injected (`Y`, `Z`) and later refined by distribution logic.
+6. If fixture category is still empty after dictionary resolution, importer assigns
+   fallback category `Unknown` with source `AutoFallback`.
 
 Special screen-object handling:
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -364,7 +364,6 @@ add_executable(riderimporter_fixtureid_test rider_import_fixtureid_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
-               ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -391,7 +390,6 @@ add_executable(rider_import_order_test rider_import_order_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
-               ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -417,7 +415,6 @@ add_executable(rider_import_preserve_existing_test rider_import_preserve_existin
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
-               ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -442,7 +439,6 @@ add_executable(rider_import_category_test rider_import_category_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
-               ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -467,7 +463,6 @@ add_executable(rider_autopatch_test rider_autopatch_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_onech_stub.cpp
                ../core/riderimporter.cpp
-               ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -493,7 +488,6 @@ add_executable(rider_layer_mode_test rider_layer_mode_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
-               ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -531,7 +525,6 @@ add_executable(rider_filter_preview_test rider_filter_preview_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
-               ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -556,7 +549,6 @@ add_executable(rider_led_screen_object_test rider_led_screen_object_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
-               ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -581,7 +573,6 @@ add_executable(rider_hoist_import_test rider_hoist_import_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
-               ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -607,7 +598,6 @@ add_executable(rider_import_benchmark rider_import_benchmark.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
-               ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -435,6 +435,30 @@ target_link_libraries(rider_import_preserve_existing_test PRIVATE ${wxWidgets_LI
 add_test(NAME RiderImportPreserveExisting COMMAND rider_import_preserve_existing_test)
 set_library_env(RiderImportPreserveExisting)
 
+add_executable(rider_import_category_test rider_import_category_test.cpp
+               riderimporter_stubs.cpp
+               gdtfloader_stub.cpp
+               ../core/riderimporter.cpp
+               ../core/hoist_weight_distribution.cpp
+               ../core/uuidutils.cpp
+               ../core/autopatcher.cpp
+               ../core/patchmanager.cpp
+               ../core/configmanager.cpp
+               ../core/configservices.cpp
+               ../core/projectutils.cpp
+               ../core/logger.cpp
+               ../models/mvrscene.cpp
+               ../models/fixture.cpp
+               ../models/truss.cpp
+               ../models/sceneobject.cpp
+               ../models/layer.cpp
+               ${LAYOUT_SOURCES})
+target_include_directories(rider_import_category_test PRIVATE
+                           . ../core ../models ../mvr ../gui ../third_party)
+target_link_libraries(rider_import_category_test PRIVATE ${wxWidgets_LIBRARIES})
+add_test(NAME RiderImportCategory COMMAND rider_import_category_test)
+set_library_env(RiderImportCategory)
+
 add_executable(rider_autopatch_test rider_autopatch_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_onech_stub.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -364,6 +364,7 @@ add_executable(riderimporter_fixtureid_test rider_import_fixtureid_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -390,6 +391,7 @@ add_executable(rider_import_order_test rider_import_order_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -415,6 +417,7 @@ add_executable(rider_import_preserve_existing_test rider_import_preserve_existin
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -439,6 +442,7 @@ add_executable(rider_import_category_test rider_import_category_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -463,6 +467,7 @@ add_executable(rider_autopatch_test rider_autopatch_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_onech_stub.cpp
                ../core/riderimporter.cpp
+               ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -488,6 +493,7 @@ add_executable(rider_layer_mode_test rider_layer_mode_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -525,6 +531,7 @@ add_executable(rider_filter_preview_test rider_filter_preview_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -549,6 +556,7 @@ add_executable(rider_led_screen_object_test rider_led_screen_object_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -573,6 +581,7 @@ add_executable(rider_hoist_import_test rider_hoist_import_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -598,6 +607,7 @@ add_executable(rider_import_benchmark rider_import_benchmark.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp

--- a/tests/rider_import_category_test.cpp
+++ b/tests/rider_import_category_test.cpp
@@ -1,0 +1,30 @@
+#include <cassert>
+#include <string>
+#include <wx/init.h>
+
+#include "configmanager.h"
+#include "gdtf_fixture_category.h"
+#include "riderimporter.h"
+
+int main() {
+  wxInitializer initializer;
+  assert(initializer.IsOk());
+
+  auto &cfg = ConfigManager::Get();
+  cfg.Reset();
+
+  const std::string riderText = "ilumin\n"
+                                "LX1\n"
+                                "2 Spot\n";
+  assert(RiderImporter::ImportText(riderText));
+
+  const auto &fixtures = cfg.GetScene().fixtures;
+  assert(fixtures.size() == 2);
+  for (const auto &[uuid, fixture] : fixtures) {
+    (void)uuid;
+    assert(fixture.category == GdtfFixtureCategory::kUnknown);
+    assert(fixture.categorySource == GdtfFixtureCategory::kAutoFallbackSource);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- The fixture table UI reads `fixture->category`, but text-to-scene imports sometimes left that field empty which produced blank Category cells.  
- Ensure text-imported fixtures always have a deterministic category so UI and downstream logic can rely on it.  
- Prefer copying dictionary-provided category when available and otherwise assign a clear fallback.

### Description
- When creating fixtures from text in `RiderImporter::ImportText`, copy `GdtfDictionary::Entry::category` into the new `Fixture::category` and set `categorySource` to `GdtfFixtureCategory::kManualSource` when present.  
- Add a guaranteed fallback so newly created fixtures get `category = GdtfFixtureCategory::kUnknown` and `categorySource = GdtfFixtureCategory::kAutoFallbackSource` if no category was assigned.  
- Added an `#include "gdtf_fixture_category.h"` in `core/riderimporter.cpp`.  
- Added a regression test `tests/rider_import_category_test.cpp` that asserts imported fixtures receive the fallback category when no dictionary category exists, and registered the test in `tests/CMakeLists.txt`.  
- Updated `docs/text_to_scene_rules.md` to document category resolution and the `Unknown`/`AutoFallback` fallback behavior.

### Testing
- Ran repository quality checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both succeeded.  
- Added `rider_import_category_test` to the test CMake target list and attempted to build/run it locally, but the build step failed due to missing `wxWidgets` development libraries in the environment.  
- The new test is present and ready to run in CI or on a machine with `wxWidgets`; recommended run commands are `cmake -S . -B build/tests` then `cmake --build build/tests --target rider_import_category_test` and `ctest --test-dir build/tests -R RiderImportCategory --output-on-failure`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c042fbf838832490c5664b74a65006)