### PR TITLE
RiderImporter: place fixtures by category into bottom-front, bottom-back and top-front zones

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -1927,20 +1927,27 @@ bool RiderImporter::ImportText(const std::string &text) {
     }
   };
 
-  auto isTopFrontCategory = [](const Fixture &fixture) {
-    const std::string normalized =
-        GdtfFixtureCategory::NormalizeCategory(fixture.category);
-    return normalized == GdtfFixtureCategory::NormalizeCategory(
-                             GdtfFixtureCategory::kBlinder) ||
-           normalized == GdtfFixtureCategory::NormalizeCategory(
-                             GdtfFixtureCategory::kStrobe);
+  auto normalizeCategory = [](std::string category) {
+    std::transform(category.begin(), category.end(), category.begin(),
+                   [](unsigned char c) {
+                     return static_cast<char>(std::tolower(c));
+                   });
+    return category;
   };
 
-  auto isBackBottomCategory = [](const Fixture &fixture) {
-    const std::string normalized =
-        GdtfFixtureCategory::NormalizeCategory(fixture.category);
-    return normalized ==
-           GdtfFixtureCategory::NormalizeCategory(GdtfFixtureCategory::kWash);
+  const std::string blinderCategory =
+      normalizeCategory(GdtfFixtureCategory::kBlinder);
+  const std::string strobeCategory =
+      normalizeCategory(GdtfFixtureCategory::kStrobe);
+  const std::string washCategory = normalizeCategory(GdtfFixtureCategory::kWash);
+
+  auto isTopFrontCategory = [&](const Fixture &fixture) {
+    const std::string normalized = normalizeCategory(fixture.category);
+    return normalized == blinderCategory || normalized == strobeCategory;
+  };
+
+  auto isBackBottomCategory = [&](const Fixture &fixture) {
+    return normalizeCategory(fixture.category) == washCategory;
   };
 
   for (auto &[pos, fixturesVec] : fixturesByPos) {

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -1836,11 +1836,11 @@ bool RiderImporter::ImportText(const std::string &text) {
     fixturesByPos[fixtureIt->second.positionName].push_back(&fixtureIt->second);
   }
 
-  for (auto &[pos, fixturesVec] : fixturesByPos) {
+  auto buildSymmetricOrder = [](const std::vector<Fixture *> &fixturesVec) {
+    std::vector<Fixture *> ordered;
     if (fixturesVec.empty())
-      continue;
+      return ordered;
 
-    // Count fixtures by type
     std::unordered_map<std::string, int> counts;
     std::vector<std::string> types;
     for (Fixture *f : fixturesVec) {
@@ -1849,13 +1849,12 @@ bool RiderImporter::ImportText(const std::string &text) {
       counts[f->typeName]++;
     }
 
-    // Build ordering ensuring odd counts place one fixture at the center
     int total = static_cast<int>(fixturesVec.size());
     std::vector<std::string> center;
     for (const std::string &t : types) {
       if (counts[t] % 2 == 1) {
         center.push_back(t);
-        counts[t]--; // leave an even number for pairing
+        counts[t]--;
       }
     }
 
@@ -1866,7 +1865,7 @@ bool RiderImporter::ImportText(const std::string &text) {
       const std::string &t = types[idx % types.size()];
       if (counts[t] > 0) {
         left.push_back(t);
-        counts[t] -= 2; // use one pair of this type
+        counts[t] -= 2;
       }
       ++idx;
     }
@@ -1877,14 +1876,12 @@ bool RiderImporter::ImportText(const std::string &text) {
     std::reverse(right.begin(), right.end());
     order.insert(order.end(), right.begin(), right.end());
 
-    // Map fixtures by type for assignment
     std::unordered_map<std::string, std::vector<Fixture *>> byType;
     for (Fixture *f : fixturesVec)
       byType[f->typeName].push_back(f);
     for (auto &[type, vec] : byType)
       std::reverse(vec.begin(), vec.end());
 
-    std::vector<Fixture *> ordered;
     ordered.reserve(total);
     for (const std::string &t : order) {
       auto &vec = byType[t];
@@ -1893,6 +1890,20 @@ bool RiderImporter::ImportText(const std::string &text) {
       ordered.push_back(vec.back());
       vec.pop_back();
     }
+    return ordered;
+  };
+
+  auto placeFixtureGroup = [&](const std::string &pos,
+                               const std::vector<Fixture *> &fixturesVec,
+                               const std::function<void(Fixture &, float, float,
+                                                        float, float)> &applyPlacement) {
+    if (fixturesVec.empty())
+      return;
+
+    const std::vector<Fixture *> ordered = buildSymmetricOrder(fixturesVec);
+    const int total = static_cast<int>(ordered.size());
+    if (total <= 0)
+      return;
 
     TrussInfo info;
     auto it = trussInfo.find(pos);
@@ -1908,12 +1919,64 @@ bool RiderImporter::ImportText(const std::string &text) {
     float width = info.found ? info.width : 400.0f;
     float step = (total > 1) ? (endX - startX) / (total - 1) : 0.0f;
 
-    for (int i = 0; i < total && i < static_cast<int>(ordered.size()); ++i) {
-      Fixture *f = ordered[i];
-      f->transform.o[0] = startX + i * step;
-      f->transform.o[1] = baseY - width * 0.5f;
-      f->transform.o[2] = baseZ;
+    for (int i = 0; i < total; ++i) {
+      Fixture *f = ordered[static_cast<size_t>(i)];
+      if (!f)
+        continue;
+      applyPlacement(*f, startX + i * step, baseY, baseZ, width);
     }
+  };
+
+  auto isTopFrontCategory = [](const Fixture &fixture) {
+    const std::string normalized =
+        GdtfFixtureCategory::NormalizeCategory(fixture.category);
+    return normalized == GdtfFixtureCategory::NormalizeCategory(
+                             GdtfFixtureCategory::kBlinder) ||
+           normalized == GdtfFixtureCategory::NormalizeCategory(
+                             GdtfFixtureCategory::kStrobe);
+  };
+
+  auto isBackBottomCategory = [](const Fixture &fixture) {
+    const std::string normalized =
+        GdtfFixtureCategory::NormalizeCategory(fixture.category);
+    return normalized ==
+           GdtfFixtureCategory::NormalizeCategory(GdtfFixtureCategory::kWash);
+  };
+
+  for (auto &[pos, fixturesVec] : fixturesByPos) {
+    if (fixturesVec.empty())
+      continue;
+
+    std::vector<Fixture *> bottomFixtures;
+    std::vector<Fixture *> topFrontFixtures;
+    bottomFixtures.reserve(fixturesVec.size());
+    topFrontFixtures.reserve(fixturesVec.size());
+    for (Fixture *f : fixturesVec) {
+      if (!f)
+        continue;
+      if (isTopFrontCategory(*f))
+        topFrontFixtures.push_back(f);
+      else
+        bottomFixtures.push_back(f);
+    }
+
+    placeFixtureGroup(pos, bottomFixtures,
+                      [&](Fixture &fixture, float x, float baseY, float baseZ,
+                          float width) {
+                        fixture.transform.o[0] = x;
+                        fixture.transform.o[1] =
+                            isBackBottomCategory(fixture) ? baseY + width * 0.5f
+                                                           : baseY - width * 0.5f;
+                        fixture.transform.o[2] = baseZ;
+                      });
+
+    placeFixtureGroup(pos, topFrontFixtures,
+                      [&](Fixture &fixture, float x, float baseY, float baseZ,
+                          float width) {
+                        fixture.transform.o[0] = x;
+                        fixture.transform.o[1] = baseY - width * 0.5f;
+                        fixture.transform.o[2] = baseZ + width * 0.5f;
+                      });
   }
 
   // Assign fixture IDs and instance names to imported fixtures only.

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -269,10 +269,26 @@ After parsing, imported fixtures are distributed per hang:
 4. Ordering alternates fixture types symmetrically:
    - odd counts place a center fixture,
    - remaining fixtures are paired left/right.
-5. Final fixture transform:
-   - `x`: evenly spaced from start to end,
-   - `y`: front side of truss (`baseY - trussWidth/2`),
-   - `z`: hang height.
+5. Fixtures are split into placement groups:
+   - **Bottom group**: all categories except `Wash`, `Blinder`, `Strobe`.
+   - **Bottom-back override**: `Wash` is placed on the back side.
+   - **Top-front group**: `Blinder` and `Strobe` are placed on top-front.
+6. `x` spacing is computed independently per group:
+   - Bottom fixtures share one spacing/order pass.
+   - Top-front fixtures use a separate spacing/order pass and do not affect bottom spacing.
+7. Final fixture transform by group:
+   - Bottom-front:
+     - `x`: evenly spaced from start to end (bottom group),
+     - `y`: `baseY - trussWidth/2`,
+     - `z`: `baseZ`.
+   - Bottom-back (`Wash`):
+     - `x`: from bottom group spacing,
+     - `y`: `baseY + trussWidth/2`,
+     - `z`: `baseZ`.
+   - Top-front (`Blinder`, `Strobe`):
+     - `x`: evenly spaced from start to end (top group),
+     - `y`: `baseY - trussWidth/2`,
+     - `z`: `baseZ + trussWidth/2`.
 
 ## Numbering and identity rules
 

--- a/tests/rider_import_category_test.cpp
+++ b/tests/rider_import_category_test.cpp
@@ -1,8 +1,11 @@
 #include <cassert>
+#include <cmath>
 #include <string>
+#include <vector>
 #include <wx/init.h>
 
 #include "configmanager.h"
+#include "fixture.h"
 #include "gdtf_fixture_category.h"
 #include "riderimporter.h"
 
@@ -16,26 +19,44 @@ int main() {
   const std::string riderText = "ilumin\n"
                                 "LX1\n"
                                 "2 Spot\n"
+                                "1 Wash\n"
                                 "1 Blinder\n"
+                                "1 Estrobo\n"
                                 "1 Turbina FX\n"
                                 "1 Hybrid 300\n";
   assert(RiderImporter::ImportText(riderText));
 
   const auto &fixtures = cfg.GetScene().fixtures;
-  assert(fixtures.size() == 5);
+  assert(fixtures.size() == 7);
 
+  std::vector<const Fixture *> spots;
+  std::vector<const Fixture *> washes;
+  std::vector<const Fixture *> blinders;
+  std::vector<const Fixture *> strobes;
   int spotCount = 0;
+  int washCount = 0;
   int blinderCount = 0;
+  int strobeCount = 0;
   int smokeCount = 0;
   int hybridCount = 0;
   for (const auto &[uuid, fixture] : fixtures) {
     (void)uuid;
     if (fixture.typeName == "Spot") {
       ++spotCount;
+      spots.push_back(&fixture);
       assert(fixture.category == GdtfFixtureCategory::kSpot);
+    } else if (fixture.typeName == "Wash") {
+      ++washCount;
+      washes.push_back(&fixture);
+      assert(fixture.category == GdtfFixtureCategory::kWash);
     } else if (fixture.typeName == "Blinder") {
       ++blinderCount;
+      blinders.push_back(&fixture);
       assert(fixture.category == GdtfFixtureCategory::kBlinder);
+    } else if (fixture.typeName == "Estrobo") {
+      ++strobeCount;
+      strobes.push_back(&fixture);
+      assert(fixture.category == GdtfFixtureCategory::kStrobe);
     } else if (fixture.typeName == "Turbina FX") {
       ++smokeCount;
       assert(fixture.category == GdtfFixtureCategory::kSmoke);
@@ -48,9 +69,28 @@ int main() {
     assert(fixture.categorySource == GdtfFixtureCategory::kAutoFallbackSource);
   }
   assert(spotCount == 2);
+  assert(washCount == 1);
   assert(blinderCount == 1);
+  assert(strobeCount == 1);
   assert(smokeCount == 1);
   assert(hybridCount == 1);
+  assert(!spots.empty());
+  assert(!washes.empty());
+  assert(!blinders.empty());
+  assert(!strobes.empty());
+
+  const float kTolerance = 0.001f;
+  const float frontBottomY = spots.front()->transform.o[1];
+  const float bottomZ = spots.front()->transform.o[2];
+  assert(std::fabs(washes.front()->transform.o[1] - (frontBottomY + 400.0f)) <
+         kTolerance);
+  assert(std::fabs(washes.front()->transform.o[2] - bottomZ) < kTolerance);
+  assert(std::fabs(blinders.front()->transform.o[1] - frontBottomY) < kTolerance);
+  assert(std::fabs(strobes.front()->transform.o[1] - frontBottomY) < kTolerance);
+  assert(std::fabs(blinders.front()->transform.o[2] - (bottomZ + 200.0f)) <
+         kTolerance);
+  assert(std::fabs(strobes.front()->transform.o[2] - (bottomZ + 200.0f)) <
+         kTolerance);
 
   return 0;
 }


### PR DESCRIPTION
### Motivation
- Improve text-to-scene fixture placement so fixtures are positioned on different parts of the truss depending on their category instead of all landing at the front-bottom position.
- Ensure top/front fixtures do not influence the X-spacing of bottom fixtures by computing spacing independently per placement group.
- Keep existing symmetric left/center/right ordering per group so numbering and X-distribution behavior remains predictable.

### Description
- Split fixture placement in `core/riderimporter.cpp` into two independent ordering/placement passes per hang: a bottom group and a top-front group, with a reusable `buildSymmetricOrder` and `placeFixtureGroup` helper.
- Apply category rules: `Wash` fixtures are placed bottom-back, `Blinder` and `Strobe` fixtures are placed top-front, and all other categories remain bottom-front; Y/Z are set accordingly using `baseY`, `width`, and `baseZ`.
- Update `docs/text_to_scene_rules.md` to document the new grouping, independent X-spacing per group, and the final transform rules for bottom-front, bottom-back, and top-front placements.
- Extend `tests/rider_import_category_test.cpp` to include `Wash` and `Estrobo` fixtures and assert both category inference and the expected Y/Z placement relative to front-bottom fixtures.

### Testing
- Ran architecture/guardrail checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both succeeded.
- Attempted to configure a debug build with `cmake --preset wsl-x64-debug` to run the test suite, but configuration failed due to missing `wxWidgets_LIBRARIES`/`wxWidgets_INCLUDE_DIRS` in the environment, so unit tests were not executed in this run.
- No other automated test failures were observed for the changes applied in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0758bef108324a6016cd8473df793)