### PR TITLE
Fix Peraviz sun direction so daylight no longer lights from below

### DIFF
--- a/peraviz/scripts/day_night_environment_controller.gd
+++ b/peraviz/scripts/day_night_environment_controller.gd
@@ -274,7 +274,7 @@ func _apply_environment_dict(state: Dictionary) -> void:
 		_directional_light.visible = directional_energy > 0.0005
 		_directional_light.light_energy = directional_energy
 		_directional_light.light_color = state["directional_color"]
-		_directional_light.rotation_degrees = Vector3(float(state["sun_elevation_deg"]), -45.0, 0.0)
+		_directional_light.rotation_degrees = Vector3(-float(state["sun_elevation_deg"]), -45.0, 0.0)
 
 
 func _warm_horizon_color(base_intensity: float, dusk_factor: float) -> Color:


### PR DESCRIPTION
### Motivation
- Daylight presets produced a visual effect of the sun lighting the scene from below because the `sun_elevation_deg` value was mapped with the wrong sign to the directional light X rotation in Peraviz.

### Description
- In `peraviz/scripts/day_night_environment_controller.gd` flipped the sign when applying the elevation to the directional light by changing `rotation_degrees = Vector3(float(state["sun_elevation_deg"]), -45.0, 0.0)` to `rotation_degrees = Vector3(-float(state["sun_elevation_deg"]), -45.0, 0.0)` so positive `sun_elevation_deg` places the sun above the horizon while keeping existing preset numbers unchanged.

### Testing
- Ran the mandatory repository checks and they passed: `tests/check_perastage_tree_modules.sh` (OK) and `tests/check_no_configmanager_get_in_gui.sh` (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c17e73c21c8324ad1a41d3f704b922)