### PR TITLE
Add startup CLI handling for .psproj and .mvr files

### DIFF
--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -63,6 +63,7 @@ public:
   ~MainWindow();
 
   bool LoadProjectFromPath(const std::string &path); // Load given project
+  bool OpenPathFromCommandLine(const std::string &path);
   void ResetProject();                               // Clear current project
 
   static MainWindow *Instance();

--- a/gui/mainwindow/controllers/mainwindow_io_controller.cpp
+++ b/gui/mainwindow/controllers/mainwindow_io_controller.cpp
@@ -9,24 +9,14 @@
 #include <wx/utils.h>
 
 #include <memory>
+#include <string>
 
 #include "consolepanel.h"
 #include "mvrimporter.h"
 #include "projectutils.h"
 
-void MainWindowIoController::OnImportMVR(wxCommandEvent &) {
-  wxString miscDir =
-      wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("misc"));
-  wxFileDialog openFileDialog(&owner_, "Import MVR file", miscDir, "",
-                              "MVR files (*.mvr)|*.mvr",
-                              wxFD_OPEN | wxFD_FILE_MUST_EXIST);
-
-  if (openFileDialog.ShowModal() == wxID_CANCEL)
-    return;
-
-  const wxString filePath = openFileDialog.GetPath();
-  const std::string pathUtf8 = filePath.ToUTF8().data();
-
+bool MainWindowIoController::ImportMvrFromPath(const std::string &pathUtf8) {
+  const wxString filePath = wxString::FromUTF8(pathUtf8);
   auto setImportStatus = [this](const wxString &message) {
     if (!owner_.GetStatusBar())
       return;
@@ -70,7 +60,7 @@ void MainWindowIoController::OnImportMVR(wxCommandEvent &) {
     wxMessageBox("Failed to import MVR file.", "Error", wxICON_ERROR);
     if (owner_.consolePanel)
       owner_.consolePanel->AppendMessage("Failed to import " + filePath);
-    return;
+    return false;
   }
 
   setImportStatus("MVR import: refreshing panels...");
@@ -85,4 +75,65 @@ void MainWindowIoController::OnImportMVR(wxCommandEvent &) {
     const wxString fileName = wxFileName(filePath).GetFullName();
     owner_.SetStatusText("MVR imported: " + fileName, 0);
   }
+  return true;
+}
+
+void MainWindowIoController::OnImportMVR(wxCommandEvent &) {
+  wxString miscDir =
+      wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("misc"));
+  wxFileDialog openFileDialog(&owner_, "Import MVR file", miscDir, "",
+                              "MVR files (*.mvr)|*.mvr",
+                              wxFD_OPEN | wxFD_FILE_MUST_EXIST);
+
+  if (openFileDialog.ShowModal() == wxID_CANCEL)
+    return;
+
+  const wxString filePath = openFileDialog.GetPath();
+  const std::string pathUtf8 = filePath.ToUTF8().data();
+  (void)ImportMvrFromPath(pathUtf8);
+}
+
+bool MainWindowIoController::OpenPathFromCommandLine(
+    const std::string &pathUtf8) {
+  std::string extension = wxFileName(wxString::FromUTF8(pathUtf8)).GetExt()
+                              .Lower()
+                              .ToStdString();
+
+  if (extension == "psproj") {
+    if (!owner_.ConfirmSaveIfDirty("loading a project", "Open Project"))
+      return false;
+
+    if (!owner_.LoadProjectFromPath(pathUtf8)) {
+      wxMessageBox("Failed to load project.", "Error", wxICON_ERROR);
+      if (owner_.GetStatusBar())
+        owner_.SetStatusText("Project load failed.", 0);
+      if (owner_.consolePanel) {
+        owner_.consolePanel->AppendMessage("Failed to load " +
+                                           wxString::FromUTF8(pathUtf8));
+      }
+      return false;
+    }
+
+    if (owner_.GetStatusBar()) {
+      wxFileName fileInfo(wxString::FromUTF8(pathUtf8));
+      owner_.SetStatusText("Project loaded: " + fileInfo.GetFullName(), 0);
+    }
+    return true;
+  }
+
+  if (extension == "mvr") {
+    if (!owner_.ConfirmSaveIfDirty("importing an MVR file", "Import MVR"))
+      return false;
+    return ImportMvrFromPath(pathUtf8);
+  }
+
+  if (owner_.GetStatusBar())
+    owner_.SetStatusText("Unsupported startup file format.", 0);
+  if (owner_.consolePanel) {
+    owner_.consolePanel->AppendMessage("Unsupported startup file: " +
+                                       wxString::FromUTF8(pathUtf8));
+  }
+  wxMessageBox("Unsupported startup file. Use .psproj or .mvr files.",
+               "Unsupported file", wxICON_WARNING);
+  return false;
 }

--- a/gui/mainwindow/controllers/mainwindow_io_controller.h
+++ b/gui/mainwindow/controllers/mainwindow_io_controller.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 class MainWindow;
 class wxCommandEvent;
 
@@ -7,7 +9,9 @@ class MainWindowIoController {
 public:
   explicit MainWindowIoController(MainWindow &owner) : owner_(owner) {}
   void OnImportMVR(wxCommandEvent &event);
+  bool OpenPathFromCommandLine(const std::string &pathUtf8);
 
 private:
+  bool ImportMvrFromPath(const std::string &pathUtf8);
   MainWindow &owner_;
 };

--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -150,6 +150,12 @@ void MainWindow::OnLoad(wxCommandEvent &event) {
     wxMessageBox("Failed to load project.", "Error", wxICON_ERROR);
 }
 
+bool MainWindow::OpenPathFromCommandLine(const std::string &path) {
+  if (!ioController)
+    return false;
+  return ioController->OpenPathFromCommandLine(path);
+}
+
 void MainWindow::OnSave(wxCommandEvent &event) {
   if (currentProjectPath.empty()) {
     OnSaveAs(event);

--- a/main.cpp
+++ b/main.cpp
@@ -22,8 +22,12 @@
 #include "projectutils.h"
 #include "splashscreen.h"
 #include <filesystem>
+#include <algorithm>
 #include <atomic>
+#include <cctype>
 #include <new>
+#include <optional>
+#include <string>
 #include <thread>
 #include <wx/stackwalk.h>
 #include <wx/sysopt.h>
@@ -49,6 +53,41 @@ private:
   std::thread project_loader_thread_;
   std::atomic<bool> project_load_event_sent_{false};
 };
+
+namespace {
+std::string ToLowerAscii(std::string text) {
+  std::transform(text.begin(), text.end(), text.begin(), [](unsigned char c) {
+    return static_cast<char>(std::tolower(c));
+  });
+  return text;
+}
+
+std::optional<std::string> GetStartupPathFromArgs(int argc, wxChar **argv) {
+  namespace fs = std::filesystem;
+  for (int i = 1; i < argc; ++i) {
+    const std::string rawPath = wxString(argv[i]).ToStdString();
+    if (rawPath.empty())
+      continue;
+
+    const fs::path candidate = fs::u8path(rawPath);
+    const std::u8string extensionU8 = candidate.extension().u8string();
+    const std::string extension(extensionU8.begin(), extensionU8.end());
+    const std::string normalizedExtension = ToLowerAscii(extension);
+    if (normalizedExtension != ".psproj" && normalizedExtension != ".mvr")
+      continue;
+
+    std::error_code ec;
+    fs::path absolutePath = fs::absolute(candidate, ec);
+    if (ec)
+      return rawPath;
+    const std::u8string absoluteU8 = absolutePath.u8string();
+    if (absoluteU8.empty())
+      return rawPath;
+    return std::string(absoluteU8.begin(), absoluteU8.end());
+  }
+  return std::nullopt;
+}
+} // namespace
 
 wxIMPLEMENT_APP(MyApp);
 
@@ -88,11 +127,22 @@ bool MyApp::OnInit() {
   // Start maximized so minimize and restore buttons remain available
   mainWindow->Maximize(true);
 
+  const std::optional<std::string> startupPathOpt =
+      GetStartupPathFromArgs(argc, argv);
+
   SplashScreen::SetMessage("Loading last project...");
   wxWeakRef<MainWindow> mainWindowRef(mainWindow);
   auto lastPathOpt = ProjectUtils::LoadLastProjectPath();
 
-  if (lastPathOpt) {
+  if (startupPathOpt && mainWindowRef) {
+    QueueProjectLoadedEvent(mainWindowRef, false, false);
+    const std::string startupPath = *startupPathOpt;
+    mainWindow->CallAfter([mainWindowRef, startupPath]() {
+      if (!mainWindowRef)
+        return;
+      mainWindowRef->OpenPathFromCommandLine(startupPath);
+    });
+  } else if (lastPathOpt) {
     std::string lastPath = *lastPathOpt;
     project_loader_thread_ = std::thread([this, mainWindowRef, lastPath]() {
       try {


### PR DESCRIPTION
### Motivation
- Provide a way to open a `.psproj` project or import a `.mvr` file when the app is launched with a file argument and make that flow match the existing manual UI behavior. 
- Reuse existing project load / MVR import logic so command-line usage shows the same status, confirmation and console messages as interactive actions.

### Description
- Added startup argument detection in `main.cpp` (`GetStartupPathFromArgs`) that looks for `.psproj` or `.mvr` in `argc/argv` and schedules handling via `CallAfter` so the action runs on the UI thread. 
- Exposed `MainWindow::OpenPathFromCommandLine(const std::string&)` as the centralized entry point for command-line file handling. 
- Extended `MainWindowIoController` with `OpenPathFromCommandLine(...)` and extracted `ImportMvrFromPath(...)` so CLI-driven MVR import reuses `MvrImporter::ImportAndRegister(...)`, the busy overlay / interaction lock, status-bar updates and `consolePanel` logging like the manual import flow. 
- The command-line flows: `.psproj` → `LoadProjectFromPath(...)` and `.mvr` → `ImportAndRegister(...)`, and both prompt via `ConfirmSaveIfDirty(...)` if a project has unsaved changes; success/failure messages are written to the status bar and `consolePanel` to match existing UX.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1815da8e883249db6cc0c6ddb483c)