### PR TITLE
Add cross-platform file association packaging for .mvr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(Perastage VERSION 0.1.0 LANGUAGES CXX)
 
 set(PERASTAGE_APP_VERSION "${PROJECT_VERSION}")
 set(PERASTAGE_APP_VERSION_DISPLAY "beta ${PROJECT_VERSION}")
+option(PERASTAGE_ASSOCIATE_PSPROJ "Register .psproj file association during packaging/installation where supported" ON)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -123,6 +124,21 @@ add_executable(${PROJECT_NAME} main.cpp
     mvr/mvrexporter.cpp
 )
 
+if(APPLE)
+    set(PERASTAGE_MACOS_INFO_PLIST "${CMAKE_BINARY_DIR}/PerastageInfo.plist")
+    set(EXECUTABLE_NAME "${PROJECT_NAME}")
+    set(PERASTAGE_VERSION "${PROJECT_VERSION}")
+    configure_file(
+        "${CMAKE_SOURCE_DIR}/cmake/PerastageInfo.plist.in"
+        "${PERASTAGE_MACOS_INFO_PLIST}"
+        @ONLY
+    )
+    set_target_properties(${PROJECT_NAME} PROPERTIES
+        MACOSX_BUNDLE TRUE
+        MACOSX_BUNDLE_INFO_PLIST "${PERASTAGE_MACOS_INFO_PLIST}"
+    )
+endif()
+
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
 target_compile_definitions(${PROJECT_NAME} PRIVATE
     PERASTAGE_APP_VERSION="${PERASTAGE_APP_VERSION}"
@@ -146,6 +162,38 @@ endif()
 set_target_properties(${PROJECT_NAME} PROPERTIES WIN32_EXECUTABLE TRUE)
 
 install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION .)
+
+if(UNIX AND NOT APPLE)
+    configure_file(
+        "${CMAKE_SOURCE_DIR}/packaging/linux/perastage.desktop.in"
+        "${CMAKE_BINARY_DIR}/perastage.desktop"
+        @ONLY
+    )
+    install(FILES "${CMAKE_BINARY_DIR}/perastage.desktop"
+        DESTINATION share/applications
+    )
+    install(FILES "${CMAKE_SOURCE_DIR}/packaging/linux/perastage-mime.xml"
+        DESTINATION share/mime/packages
+    )
+    install(FILES "${CMAKE_SOURCE_DIR}/resources/Perastage_logo_1024.png"
+        DESTINATION share/icons/hicolor/1024x1024/apps
+        RENAME perastage.png
+    )
+    install(CODE [[
+        execute_process(
+            COMMAND update-mime-database "${CMAKE_INSTALL_PREFIX}/share/mime"
+            RESULT_VARIABLE perastage_mime_result
+            OUTPUT_QUIET
+            ERROR_QUIET
+        )
+        execute_process(
+            COMMAND update-desktop-database "${CMAKE_INSTALL_PREFIX}/share/applications"
+            RESULT_VARIABLE perastage_desktop_result
+            OUTPUT_QUIET
+            ERROR_QUIET
+        )
+    ]])
+endif()
 
 # Include project directories
 target_include_directories(${PROJECT_NAME} PRIVATE
@@ -408,3 +456,39 @@ foreach(subdir IN LISTS LIBRARY_SUBDIRS)
         )
     endif()
 endforeach()
+
+set(CPACK_PACKAGE_NAME "Perastage")
+set(CPACK_PACKAGE_VENDOR "Perastage")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Perastage lighting plot editor")
+set(CPACK_PACKAGE_VERSION "${PROJECT_VERSION}")
+
+if(WIN32)
+    set(CPACK_GENERATOR "NSIS")
+    set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON)
+    set(CPACK_NSIS_DISPLAY_NAME "Perastage")
+    set(CPACK_NSIS_PACKAGE_NAME "Perastage")
+    string(CONCAT CPACK_NSIS_EXTRA_INSTALL_COMMANDS
+        "WriteRegStr HKCR '.mvr' '' 'Perastage.MVR'\\n"
+        "WriteRegStr HKCR 'Perastage.MVR' '' 'MVR Scene'\\n"
+        "WriteRegStr HKCR 'Perastage.MVR\\\\DefaultIcon' '' '$INSTDIR\\\\Perastage.exe,0'\\n"
+        "WriteRegStr HKCR 'Perastage.MVR\\\\shell\\\\open\\\\command' '' '\\\"$INSTDIR\\\\Perastage.exe\\\" \\\"%1\\\"'\\n"
+    )
+    string(CONCAT CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS
+        "DeleteRegKey HKCR 'Perastage.MVR'\\n"
+        "DeleteRegValue HKCR '.mvr' ''\\n"
+    )
+    if(PERASTAGE_ASSOCIATE_PSPROJ)
+        string(APPEND CPACK_NSIS_EXTRA_INSTALL_COMMANDS
+            "WriteRegStr HKCR '.psproj' '' 'Perastage.Project'\\n"
+            "WriteRegStr HKCR 'Perastage.Project' '' 'Perastage Project'\\n"
+            "WriteRegStr HKCR 'Perastage.Project\\\\DefaultIcon' '' '$INSTDIR\\\\Perastage.exe,0'\\n"
+            "WriteRegStr HKCR 'Perastage.Project\\\\shell\\\\open\\\\command' '' '\\\"$INSTDIR\\\\Perastage.exe\\\" \\\"%1\\\"'\\n"
+        )
+        string(APPEND CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS
+            "DeleteRegKey HKCR 'Perastage.Project'\\n"
+            "DeleteRegValue HKCR '.psproj' ''\\n"
+        )
+    endif()
+endif()
+
+include(CPack)

--- a/README.md
+++ b/README.md
@@ -156,8 +156,22 @@ These checks validate that per-instance normal transformation and mirrored-trans
 
 1. Build the Release configuration.
 2. Run the `perastage_stage` target to populate the staging directory (`out/install/<CONFIG>`, for example `out/install/Release`).
-3. Use an installer tool such as **Inno Setup** to create a self‑extracting installer and uninstaller.  The staging directory already contains the executable, DLLs, help files, library data and resources.
+3. Generate an installer with CPack (`cpack -G NSIS` in the build directory) or use another installer tool if needed. The NSIS package writes file associations for `.mvr` (and `.psproj` when `-DPERASTAGE_ASSOCIATE_PSPROJ=ON`) using ProgID entries, icon registration, and open commands.
 4. Optionally provide a portable ZIP archive for users who prefer not to run an installer.
+
+## Linux desktop integration
+
+Linux installs now include:
+
+- `share/applications/perastage.desktop` with `MimeType=application/x-perastage-mvr;application/x-perastage-project;`
+- `share/mime/packages/perastage-mime.xml` with glob rules for `*.mvr` and `*.psproj`
+- `share/icons/hicolor/1024x1024/apps/perastage.png`
+
+During `cmake --install`, Perastage also attempts to refresh MIME and desktop databases (`update-mime-database` and `update-desktop-database`) so new associations are visible without manual cache refresh.
+
+## macOS document association
+
+On macOS, Perastage builds as an app bundle with `CFBundleDocumentTypes` and UTI declarations for `.mvr`, so Finder can route `.mvr` files to Perastage.
 
 ---
 

--- a/cmake/PerastageInfo.plist.in
+++ b/cmake/PerastageInfo.plist.in
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDisplayName</key>
+  <string>Perastage</string>
+  <key>CFBundleExecutable</key>
+  <string>${EXECUTABLE_NAME}</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.perastage.app</string>
+  <key>CFBundleName</key>
+  <string>Perastage</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>${PERASTAGE_VERSION}</string>
+  <key>CFBundleVersion</key>
+  <string>${PERASTAGE_VERSION}</string>
+  <key>CFBundleDocumentTypes</key>
+  <array>
+    <dict>
+      <key>CFBundleTypeName</key>
+      <string>MVR Scene</string>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>LSItemContentTypes</key>
+      <array>
+        <string>com.perastage.mvr</string>
+      </array>
+      <key>CFBundleTypeExtensions</key>
+      <array>
+        <string>mvr</string>
+      </array>
+    </dict>
+  </array>
+  <key>UTExportedTypeDeclarations</key>
+  <array>
+    <dict>
+      <key>UTTypeIdentifier</key>
+      <string>com.perastage.mvr</string>
+      <key>UTTypeDescription</key>
+      <string>MVR Scene</string>
+      <key>UTTypeConformsTo</key>
+      <array>
+        <string>public.data</string>
+      </array>
+      <key>UTTypeTagSpecification</key>
+      <dict>
+        <key>public.filename-extension</key>
+        <array>
+          <string>mvr</string>
+        </array>
+        <key>public.mime-type</key>
+        <string>application/x-perastage-mvr</string>
+      </dict>
+    </dict>
+  </array>
+</dict>
+</plist>

--- a/help.md
+++ b/help.md
@@ -29,6 +29,12 @@ Some tools are intentionally available only in **Debug** builds:
 
 Release builds keep these entries hidden to reduce risk in production workflows.
 
+## File associations by operating system
+
+- **Windows installer (NSIS/CPack):** registers `.mvr` with a dedicated ProgID, icon, and open command. `.psproj` can also be associated when packaging enables `PERASTAGE_ASSOCIATE_PSPROJ`.
+- **Linux install:** deploys a desktop entry plus MIME XML declarations for `*.mvr` and `*.psproj`, then refreshes MIME/desktop caches when the relevant tools are available.
+- **macOS bundle:** exports `CFBundleDocumentTypes` for `.mvr` so files can be opened from Finder.
+
 ## Console Commands (complete)
 
 The console works on the current selection. If fixtures are selected, position

--- a/packaging/linux/perastage-mime.xml
+++ b/packaging/linux/perastage-mime.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+  <mime-type type="application/x-perastage-mvr">
+    <comment>My Virtual Rig file</comment>
+    <glob pattern="*.mvr"/>
+  </mime-type>
+  <mime-type type="application/x-perastage-project">
+    <comment>Perastage project archive</comment>
+    <glob pattern="*.psproj"/>
+  </mime-type>
+</mime-info>

--- a/packaging/linux/perastage.desktop.in
+++ b/packaging/linux/perastage.desktop.in
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Version=1.0
+Name=Perastage
+Comment=Lighting plot editor and MVR viewer
+Exec=Perastage %f
+Icon=perastage
+Terminal=false
+Categories=Graphics;Utility;
+MimeType=application/x-perastage-mvr;application/x-perastage-project;
+StartupNotify=true


### PR DESCRIPTION
### Motivation

- Ensure Perastage installers/registers OS-level associations so `.mvr` (and optionally `.psproj`) open with the app across Windows, Linux and macOS.
- Provide packaging artifacts and CMake wiring so installers can register icons, MIME types, desktop entries and macOS document types consistently.

### Description

- Added `PERASTAGE_ASSOCIATE_PSPROJ` CMake option and CPack/NSIS hooks to register a ProgID, default icon and open command for `.mvr` and optionally `.psproj` on Windows. 
- Added macOS bundle support by generating `cmake/PerastageInfo.plist.in` and configuring `MACOSX_BUNDLE` properties with `CFBundleDocumentTypes` and UTI declarations for `.mvr`.
- Added Linux desktop integration files `packaging/linux/perastage.desktop.in` and `packaging/linux/perastage-mime.xml`, installed them into `share/applications` and `share/mime/packages`, and added an install-time attempt to refresh `update-mime-database` and `update-desktop-database` so associations appear after `cmake --install`.
- Updated `CMakeLists.txt` to install the new artifacts and enable CPack (NSIS) packaging, and updated `README.md` and `help.md` to document the new packaging/association behavior.

### Testing

- Ran `tests/check_perastage_tree_modules.sh` which succeeded. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which succeeded. 
- Attempted `cmake -S . -B /tmp/perastage-cmake-check -DPERAVIZ_ENABLE_NATIVE=OFF` which failed in this environment due to missing `wxWidgets` system dependency and not because of the packaging changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c186d2d9008324a9d5e3849eac4f17)