### PR TITLE
Unify MVR open policy for menu and startup-file flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 ### MVR & GDTF support
 
 - **Import MVR 1.6** scenes: read fixtures, trusses, hoists and generic objects from `.mvr` files and build the internal scene graph.
+- **Official `.mvr` open policy (menu import and OS double-click):** Perastage first asks to save unsaved changes, then opens the `.mvr` using a clean-scene reset + import flow (not merge). The same progress UI/locking behavior is used in both entry points (`wxWindowDisabler` + `wxBusyInfo`) so the workflow remains consistent.
 - **Export MVR**: write the current scene back to a new `.mvr` file so it can be opened in other lighting software.
 - **GDTF integration**:
   - A built‑in fixture dictionary maps textual fixture descriptions to GDTF files stored in the `library/` directory.

--- a/gui/mainwindow/controllers/mainwindow_io_controller.cpp
+++ b/gui/mainwindow/controllers/mainwindow_io_controller.cpp
@@ -90,7 +90,19 @@ void MainWindowIoController::OnImportMVR(wxCommandEvent &) {
 
   const wxString filePath = openFileDialog.GetPath();
   const std::string pathUtf8 = filePath.ToUTF8().data();
-  (void)ImportMvrFromPath(pathUtf8);
+  (void)ImportMvrWithOfficialPolicy(pathUtf8);
+}
+
+
+bool MainWindowIoController::ImportMvrWithOfficialPolicy(
+    const std::string &pathUtf8) {
+  if (!owner_.ConfirmSaveIfDirty(kMvrOpenAction, kMvrOpenTitle))
+    return false;
+
+  // Official policy for .mvr open/import actions:
+  // reset application scene state and then import the selected package.
+  // MvrImporter::ImportFromFile() performs the reset via ConfigManager.
+  return ImportMvrFromPath(pathUtf8);
 }
 
 bool MainWindowIoController::OpenPathFromCommandLine(
@@ -121,11 +133,8 @@ bool MainWindowIoController::OpenPathFromCommandLine(
     return true;
   }
 
-  if (extension == "mvr") {
-    if (!owner_.ConfirmSaveIfDirty("importing an MVR file", "Import MVR"))
-      return false;
-    return ImportMvrFromPath(pathUtf8);
-  }
+  if (extension == "mvr")
+    return ImportMvrWithOfficialPolicy(pathUtf8);
 
   if (owner_.GetStatusBar())
     owner_.SetStatusText("Unsupported startup file format.", 0);

--- a/gui/mainwindow/controllers/mainwindow_io_controller.h
+++ b/gui/mainwindow/controllers/mainwindow_io_controller.h
@@ -12,6 +12,10 @@ public:
   bool OpenPathFromCommandLine(const std::string &pathUtf8);
 
 private:
+  static constexpr const char *kMvrOpenAction = "importing an MVR file";
+  static constexpr const char *kMvrOpenTitle = "Import MVR";
+
   bool ImportMvrFromPath(const std::string &pathUtf8);
+  bool ImportMvrWithOfficialPolicy(const std::string &pathUtf8);
   MainWindow &owner_;
 };


### PR DESCRIPTION
### Motivation
- Ensure a consistent, documented policy when opening `.mvr` files whether invoked from the menu or via OS/file-startup, including a save-confirmation step for dirty state. 
- Declare and apply the official strategy (reset + import into a clean scene) so the behavior is explicit and consistent across entry points. 
- Reuse the existing progress/UI locking behaviour (`wxWindowDisabler` + `wxBusyInfo`) and the same confirmation messages to avoid duplicated UX code.

### Description
- Added controller-level constants `kMvrOpenAction` and `kMvrOpenTitle` in `MainWindowIoController` for the save-confirmation dialog text. 
- Introduced `ImportMvrWithOfficialPolicy(const std::string &)` in `gui/mainwindow/controllers/mainwindow_io_controller.{h,cpp}` which asks `ConfirmSaveIfDirty` and then calls the existing `ImportMvrFromPath`. 
- Routed both the menu import flow (`OnImportMVR`) and the startup/command-line `.mvr` path (`OpenPathFromCommandLine`) to the new policy wrapper so both use the same flow and messaging. 
- Documented the official `.mvr` open policy in `README.md` to explain that Perastage asks to save unsaved changes and uses a clean-scene reset + import (not merge) while reusing the same progress UI/locking pattern. 
- Did not change importer internals; `MvrImporter` still performs the `ConfigManager::Get().Reset()` during parse, and the existing `wxWindowDisabler`/`wxBusyInfo` usage remains in `ImportMvrFromPath`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c18a7762f48324b0c0b944d27625f6)