### PR TITLE
Switch Perastage project extension to .pstg and update associations/docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(Perastage VERSION 0.1.0 LANGUAGES CXX)
 
 set(PERASTAGE_APP_VERSION "${PROJECT_VERSION}")
 set(PERASTAGE_APP_VERSION_DISPLAY "beta ${PROJECT_VERSION}")
-option(PERASTAGE_ASSOCIATE_PSPROJ "Register .psproj file association during packaging/installation where supported" ON)
+option(PERASTAGE_ASSOCIATE_PSTG "Register .pstg file association during packaging/installation where supported" ON)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -477,16 +477,16 @@ if(WIN32)
         "DeleteRegKey HKCR 'Perastage.MVR'\\n"
         "DeleteRegValue HKCR '.mvr' ''\\n"
     )
-    if(PERASTAGE_ASSOCIATE_PSPROJ)
+    if(PERASTAGE_ASSOCIATE_PSTG)
         string(APPEND CPACK_NSIS_EXTRA_INSTALL_COMMANDS
-            "WriteRegStr HKCR '.psproj' '' 'Perastage.Project'\\n"
+            "WriteRegStr HKCR '.pstg' '' 'Perastage.Project'\\n"
             "WriteRegStr HKCR 'Perastage.Project' '' 'Perastage Project'\\n"
             "WriteRegStr HKCR 'Perastage.Project\\\\DefaultIcon' '' '$INSTDIR\\\\Perastage.exe,0'\\n"
             "WriteRegStr HKCR 'Perastage.Project\\\\shell\\\\open\\\\command' '' '\\\"$INSTDIR\\\\Perastage.exe\\\" \\\"%1\\\"'\\n"
         )
         string(APPEND CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS
             "DeleteRegKey HKCR 'Perastage.Project'\\n"
-            "DeleteRegValue HKCR '.psproj' ''\\n"
+            "DeleteRegValue HKCR '.pstg' ''\\n"
         )
     endif()
 endif()

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ### Project management
 
-- Open and save Perastage projects (`*.psproj`) with support for multiple named pages/layouts.
+- Open and save Perastage projects (`*.pstg`) with support for multiple named pages/layouts.
 - Group fixtures, trusses, hoists and scene objects into layers and toggle their visibility/selection per layer.
 - Save and restore user preferences (window layout, last used directories, view mode, etc.).
 
@@ -134,7 +134,7 @@ These options are considered experimental and are not required for the core Pera
 
 ### Project file format
 
-Perastage project files (`*.psproj`) are standard ZIP archives. A project typically contains a `config.json` file storing user preferences and layout settings and a `scene.mvr` file storing the show data in MVR format. You can inspect or extract these files with any ZIP utility. When Perastage saves a project, it writes the updated `config.json` and `scene.mvr` back into the archive.
+Perastage project files (`*.pstg`) are standard ZIP archives. A project typically contains a `config.json` file storing user preferences and layout settings and a `scene.mvr` file storing the show data in MVR format. You can inspect or extract these files with any ZIP utility. When Perastage saves a project, it writes the updated `config.json` and `scene.mvr` back into the archive.
 
 ---
 
@@ -156,7 +156,7 @@ These checks validate that per-instance normal transformation and mirrored-trans
 
 1. Build the Release configuration.
 2. Run the `perastage_stage` target to populate the staging directory (`out/install/<CONFIG>`, for example `out/install/Release`).
-3. Generate an installer with CPack (`cpack -G NSIS` in the build directory) or use another installer tool if needed. The NSIS package writes file associations for `.mvr` (and `.psproj` when `-DPERASTAGE_ASSOCIATE_PSPROJ=ON`) using ProgID entries, icon registration, and open commands.
+3. Generate an installer with CPack (`cpack -G NSIS` in the build directory) or use another installer tool if needed. The NSIS package writes file associations for `.mvr` (and `.pstg` when `-DPERASTAGE_ASSOCIATE_PSTG=ON`) using ProgID entries, icon registration, and open commands.
 4. Optionally provide a portable ZIP archive for users who prefer not to run an installer.
 
 ## Linux desktop integration
@@ -164,7 +164,7 @@ These checks validate that per-instance normal transformation and mirrored-trans
 Linux installs now include:
 
 - `share/applications/perastage.desktop` with `MimeType=application/x-perastage-mvr;application/x-perastage-project;`
-- `share/mime/packages/perastage-mime.xml` with glob rules for `*.mvr` and `*.psproj`
+- `share/mime/packages/perastage-mime.xml` with glob rules for `*.mvr` and `*.pstg`
 - `share/icons/hicolor/1024x1024/apps/perastage.png`
 
 During `cmake --install`, Perastage also attempts to refresh MIME and desktop databases (`update-mime-database` and `update-desktop-database`) so new associations are visible without manual cache refresh.

--- a/gui/mainwindow/controllers/mainwindow_io_controller.cpp
+++ b/gui/mainwindow/controllers/mainwindow_io_controller.cpp
@@ -98,8 +98,12 @@ bool MainWindowIoController::OpenPathFromCommandLine(
   std::string extension = wxFileName(wxString::FromUTF8(pathUtf8)).GetExt()
                               .Lower()
                               .ToStdString();
+  std::string projectExtension = wxString::FromUTF8(ProjectUtils::PROJECT_EXTENSION)
+                                     .AfterFirst('.')
+                                     .Lower()
+                                     .ToStdString();
 
-  if (extension == "psproj") {
+  if (extension == projectExtension) {
     if (!owner_.ConfirmSaveIfDirty("loading a project", "Open Project"))
       return false;
 
@@ -133,7 +137,9 @@ bool MainWindowIoController::OpenPathFromCommandLine(
     owner_.consolePanel->AppendMessage("Unsupported startup file: " +
                                        wxString::FromUTF8(pathUtf8));
   }
-  wxMessageBox("Unsupported startup file. Use .psproj or .mvr files.",
+  wxMessageBox("Unsupported startup file. Use " +
+                   wxString::FromUTF8(ProjectUtils::PROJECT_EXTENSION) +
+                   " or .mvr files.",
                "Unsupported file", wxICON_WARNING);
   return false;
 }

--- a/help.md
+++ b/help.md
@@ -10,12 +10,12 @@
 
 ## Project Files
 
-Perastage projects (`.psproj`) store the scene, layouts, and user settings.
+Perastage projects (`.pstg`) store the scene, layouts, and user settings.
 
 **File > New / Load / Save / Save As...**
 
 - **New** creates a blank project.
-- **Load** opens an existing `.psproj` file.
+- **Load** opens an existing `.pstg` file.
 - **Save** stores changes in the current project file.
 - **Save As...** writes the project under a new name or location.
 
@@ -31,8 +31,8 @@ Release builds keep these entries hidden to reduce risk in production workflows.
 
 ## File associations by operating system
 
-- **Windows installer (NSIS/CPack):** registers `.mvr` with a dedicated ProgID, icon, and open command. `.psproj` can also be associated when packaging enables `PERASTAGE_ASSOCIATE_PSPROJ`.
-- **Linux install:** deploys a desktop entry plus MIME XML declarations for `*.mvr` and `*.psproj`, then refreshes MIME/desktop caches when the relevant tools are available.
+- **Windows installer (NSIS/CPack):** registers `.mvr` with a dedicated ProgID, icon, and open command. `.pstg` can also be associated when packaging enables `PERASTAGE_ASSOCIATE_PSTG`.
+- **Linux install:** deploys a desktop entry plus MIME XML declarations for `*.mvr` and `*.pstg`, then refreshes MIME/desktop caches when the relevant tools are available.
 - **macOS bundle:** exports `CFBundleDocumentTypes` for `.mvr` so files can be opened from Finder.
 
 ## Console Commands (complete)
@@ -183,12 +183,12 @@ Notes:
 
 ## Archivos de proyecto
 
-Los proyectos de Perastage (`.psproj`) guardan la escena, los layouts y la configuración del usuario.
+Los proyectos de Perastage (`.pstg`) guardan la escena, los layouts y la configuración del usuario.
 
 **File > New / Load / Save / Save As...**
 
 - **Nuevo** crea un proyecto en blanco.
-- **Cargar** abre un `.psproj` existente.
+- **Cargar** abre un `.pstg` existente.
 - **Guardar** guarda los cambios en el proyecto actual.
 - **Guardar como...** guarda el proyecto con otro nombre o en otra ubicación.
 

--- a/main.cpp
+++ b/main.cpp
@@ -64,6 +64,7 @@ std::string ToLowerAscii(std::string text) {
 
 std::optional<std::string> GetStartupPathFromArgs(int argc, wxChar **argv) {
   namespace fs = std::filesystem;
+  const std::string projectExtension = ToLowerAscii(ProjectUtils::PROJECT_EXTENSION);
   for (int i = 1; i < argc; ++i) {
     const std::string rawPath = wxString(argv[i]).ToStdString();
     if (rawPath.empty())
@@ -73,7 +74,7 @@ std::optional<std::string> GetStartupPathFromArgs(int argc, wxChar **argv) {
     const std::u8string extensionU8 = candidate.extension().u8string();
     const std::string extension(extensionU8.begin(), extensionU8.end());
     const std::string normalizedExtension = ToLowerAscii(extension);
-    if (normalizedExtension != ".psproj" && normalizedExtension != ".mvr")
+    if (normalizedExtension != projectExtension && normalizedExtension != ".mvr")
       continue;
 
     std::error_code ec;

--- a/packaging/linux/perastage-mime.xml
+++ b/packaging/linux/perastage-mime.xml
@@ -6,6 +6,6 @@
   </mime-type>
   <mime-type type="application/x-perastage-project">
     <comment>Perastage project archive</comment>
-    <glob pattern="*.psproj"/>
+    <glob pattern="*.pstg"/>
   </mime-type>
 </mime-info>


### PR DESCRIPTION
### Motivation
- Standardize the Perastage project file extension from `.psproj` to `.pstg` across build, runtime, packaging and documentation.
- Ensure installer MIME/desktop integrations and runtime startup handling use the canonical project extension constant.
- Keep documentation and help text consistent with the new extension and packaging option name.

### Description
- Renamed the packaging CMake option from `PERASTAGE_ASSOCIATE_PSPROJ` to `PERASTAGE_ASSOCIATE_PSTG` and updated NSIS registry install/uninstall commands to write `.pstg` associations.
- Updated runtime file-start handling to use the centralized `ProjectUtils::PROJECT_EXTENSION` value in `mainwindow_io_controller.cpp` and `main.cpp` instead of hard-coded `.psproj` strings.
- Replaced references to `.psproj` with `.pstg` in `README.md` and `help.md` to reflect the new project file extension.
- Updated the Linux MIME XML (`packaging/linux/perastage-mime.xml`) to register the `*.pstg` glob pattern.

### Testing
- Configured and built the project with CMake using `cmake ..` and `cmake --build .` and the build completed successfully.
- Ran the test suite with `ctest` from the build directory and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c17feda4c48324b024be02ea9e53ee)