### PR TITLE
Show blocking splash overlay while loading project files

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -532,17 +532,21 @@ bool MainWindow::GuardStartupProjectLoadAction(const wxString &actionLabel) {
 bool MainWindow::LoadProjectFromPath(const std::string &path) {
   std::unique_ptr<wxWindowDisabler> loadDisabler =
       std::make_unique<wxWindowDisabler>();
-  ScopeExit enableWindows([&loadDisabler]() { loadDisabler.reset(); });
   SplashScreen::Options splashOptions;
   splashOptions.showLogo = false;
   SplashScreen::Show(splashOptions);
   SplashScreen::SetMessage("Loading project file...");
   wxYieldIfNeeded();
-  ScopeExit splashHide([]() { SplashScreen::Hide(); });
 
   LockViewportInteraction();
-  ScopeExit viewportUnlock([this]() { UnlockViewportInteraction(); });
+  auto finishLoad = [this, &loadDisabler]() {
+    UnlockViewportInteraction();
+    SplashScreen::Hide();
+    loadDisabler.reset();
+  };
+
   if (!GetDefaultGuiConfigServices().LegacyConfigManager().LoadProject(path)) {
+    finishLoad();
     return false;
   }
 
@@ -595,6 +599,7 @@ bool MainWindow::LoadProjectFromPath(const std::string &path) {
   SplashScreen::SetMessage("Creating fixture symbols...");
   StartFixtureSymbolAutoUpdateForLoadedScene();
   UpdateTitle();
+  finishLoad();
   return true;
 }
 

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -41,6 +41,7 @@
 #include <wx/aboutdlg.h>
 #include <wx/app.h>
 #include <wx/artprov.h>
+#include <wx/busyinfo.h>
 #include <wx/event.h>
 #include <wx/filefn.h>
 #include <wx/filename.h>
@@ -532,16 +533,14 @@ bool MainWindow::GuardStartupProjectLoadAction(const wxString &actionLabel) {
 bool MainWindow::LoadProjectFromPath(const std::string &path) {
   std::unique_ptr<wxWindowDisabler> loadDisabler =
       std::make_unique<wxWindowDisabler>();
-  SplashScreen::Options splashOptions;
-  splashOptions.showLogo = false;
-  SplashScreen::Show(splashOptions);
-  SplashScreen::SetMessage("Loading project file...");
+  std::unique_ptr<wxBusyInfo> loadOverlay =
+      std::make_unique<wxBusyInfo>("Loading project file...");
   wxYieldIfNeeded();
 
   LockViewportInteraction();
-  auto finishLoad = [this, &loadDisabler]() {
+  auto finishLoad = [this, &loadOverlay, &loadDisabler]() {
     UnlockViewportInteraction();
-    SplashScreen::Hide();
+    loadOverlay.reset();
     loadDisabler.reset();
   };
 
@@ -550,7 +549,8 @@ bool MainWindow::LoadProjectFromPath(const std::string &path) {
     return false;
   }
 
-  SplashScreen::SetMessage("Building scene...");
+  loadOverlay = std::make_unique<wxBusyInfo>("Building scene...");
+  wxYieldIfNeeded();
   Ensure3DViewport();
 
   currentProjectPath = path;
@@ -592,11 +592,13 @@ bool MainWindow::LoadProjectFromPath(const std::string &path) {
     viewport2DRenderPanel->ApplyConfig();
   if (layerPanel)
     layerPanel->ReloadLayers();
-  SplashScreen::SetMessage("Refreshing panels...");
+  loadOverlay = std::make_unique<wxBusyInfo>("Refreshing panels...");
+  wxYieldIfNeeded();
   RefreshSummary();
   RefreshRigging();
   GetDefaultGuiConfigServices().LegacyConfigManager().MarkSaved();
-  SplashScreen::SetMessage("Creating fixture symbols...");
+  loadOverlay = std::make_unique<wxBusyInfo>("Creating fixture symbols...");
+  wxYieldIfNeeded();
   StartFixtureSymbolAutoUpdateForLoadedScene();
   UpdateTitle();
   finishLoad();

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -56,6 +56,7 @@
 #include <wx/settings.h>
 #include <wx/textctrl.h>
 #include <wx/tokenzr.h>
+#include <wx/utils.h>
 #include <wx/wfstream.h>
 class wxZipStreamLink;
 #include <wx/log.h>
@@ -529,13 +530,23 @@ bool MainWindow::GuardStartupProjectLoadAction(const wxString &actionLabel) {
 }
 
 bool MainWindow::LoadProjectFromPath(const std::string &path) {
+  std::unique_ptr<wxWindowDisabler> loadDisabler =
+      std::make_unique<wxWindowDisabler>();
+  ScopeExit enableWindows([&loadDisabler]() { loadDisabler.reset(); });
+  SplashScreen::Options splashOptions;
+  splashOptions.showLogo = false;
+  SplashScreen::Show(splashOptions);
+  SplashScreen::SetMessage("Loading project file...");
+  wxYieldIfNeeded();
+  ScopeExit splashHide([]() { SplashScreen::Hide(); });
+
   LockViewportInteraction();
+  ScopeExit viewportUnlock([this]() { UnlockViewportInteraction(); });
   if (!GetDefaultGuiConfigServices().LegacyConfigManager().LoadProject(path)) {
-    UnlockViewportInteraction();
     return false;
   }
 
-
+  SplashScreen::SetMessage("Building scene...");
   Ensure3DViewport();
 
   currentProjectPath = path;
@@ -577,12 +588,13 @@ bool MainWindow::LoadProjectFromPath(const std::string &path) {
     viewport2DRenderPanel->ApplyConfig();
   if (layerPanel)
     layerPanel->ReloadLayers();
+  SplashScreen::SetMessage("Refreshing panels...");
   RefreshSummary();
   RefreshRigging();
   GetDefaultGuiConfigServices().LegacyConfigManager().MarkSaved();
+  SplashScreen::SetMessage("Creating fixture symbols...");
   StartFixtureSymbolAutoUpdateForLoadedScene();
   UpdateTitle();
-  UnlockViewportInteraction();
   return true;
 }
 

--- a/gui/splashscreen.cpp
+++ b/gui/splashscreen.cpp
@@ -72,10 +72,7 @@ void ApplyRoundedShape(wxFrame *frame, int radius) {
   frame->SetShape(region);
 }
 
-wxBitmap BuildSplashBitmap(bool showLogo) {
-  if (!showLogo)
-    return wxBitmap();
-
+wxBitmap BuildSplashBitmap() {
   wxBitmap logoBmp;
   const std::filesystem::path resourceRoot = ProjectUtils::GetResourceRoot();
   const std::filesystem::path splashLogoPath =
@@ -117,10 +114,6 @@ wxBitmap BuildSplashBitmap(bool showLogo) {
 }
 
 void SplashScreen::Show() {
-  Show(Options{});
-}
-
-void SplashScreen::Show(const Options &options) {
   if (g_splash)
     return;
 
@@ -131,14 +124,8 @@ void SplashScreen::Show(const Options &options) {
   wxPanel *panel = new wxPanel(g_splash);
   wxBoxSizer *sizer = new wxBoxSizer(wxVERTICAL);
 
-  if (const wxBitmap logoBmp = BuildSplashBitmap(options.showLogo);
-      logoBmp.IsOk()) {
-    wxStaticBitmap *logo = new wxStaticBitmap(panel, wxID_ANY, logoBmp);
-    sizer->AddStretchSpacer(1);
-    sizer->Add(logo, 0, wxALIGN_CENTER | wxALL, 10);
-  } else {
-    sizer->AddStretchSpacer(1);
-  }
+  wxBitmap logoBmp = BuildSplashBitmap();
+  wxStaticBitmap *logo = new wxStaticBitmap(panel, wxID_ANY, logoBmp);
 
   g_label =
       new wxStaticText(panel, wxID_ANY, "Loading Perastage...", wxDefaultPosition,
@@ -147,6 +134,8 @@ void SplashScreen::Show(const Options &options) {
   font.MakeBold();
   g_label->SetFont(font);
 
+  sizer->AddStretchSpacer(1);
+  sizer->Add(logo, 0, wxALIGN_CENTER | wxALL, 10);
   sizer->Add(g_label, 0, wxALIGN_CENTER | wxBOTTOM, 20);
   sizer->AddStretchSpacer(1);
   panel->SetSizerAndFit(sizer);

--- a/gui/splashscreen.cpp
+++ b/gui/splashscreen.cpp
@@ -71,22 +71,15 @@ void ApplyRoundedShape(wxFrame *frame, int radius) {
   const wxRegion region(maskBitmap, *wxBLACK);
   frame->SetShape(region);
 }
-}
 
-void SplashScreen::Show() {
-  if (g_splash)
-    return;
-
-  g_splash = new wxFrame(nullptr, wxID_ANY, "", wxDefaultPosition, wxDefaultSize,
-                         wxFRAME_NO_TASKBAR | wxSTAY_ON_TOP | wxBORDER_NONE |
-                             wxFRAME_SHAPED);
-
-  wxPanel *panel = new wxPanel(g_splash);
-  wxBoxSizer *sizer = new wxBoxSizer(wxVERTICAL);
+wxBitmap BuildSplashBitmap(bool showLogo) {
+  if (!showLogo)
+    return wxBitmap();
 
   wxBitmap logoBmp;
   const std::filesystem::path resourceRoot = ProjectUtils::GetResourceRoot();
-  const std::filesystem::path splashLogoPath = resourceRoot / "Perastage_logo.png";
+  const std::filesystem::path splashLogoPath =
+      resourceRoot / "Perastage_logo.png";
   std::error_code ec;
   if (!resourceRoot.empty() && std::filesystem::exists(splashLogoPath, ec)) {
     logoBmp.LoadFile(PathToWxString(splashLogoPath), wxBITMAP_TYPE_PNG);
@@ -119,9 +112,33 @@ void SplashScreen::Show() {
                                        wxSize(256, 256));
   }
 
-  logoBmp = ScaleDownBitmap(logoBmp, kSplashLogoMaxSize);
+  return ScaleDownBitmap(logoBmp, kSplashLogoMaxSize);
+}
+}
 
-  wxStaticBitmap *logo = new wxStaticBitmap(panel, wxID_ANY, logoBmp);
+void SplashScreen::Show() {
+  Show(Options{});
+}
+
+void SplashScreen::Show(const Options &options) {
+  if (g_splash)
+    return;
+
+  g_splash = new wxFrame(nullptr, wxID_ANY, "", wxDefaultPosition, wxDefaultSize,
+                         wxFRAME_NO_TASKBAR | wxSTAY_ON_TOP | wxBORDER_NONE |
+                             wxFRAME_SHAPED);
+
+  wxPanel *panel = new wxPanel(g_splash);
+  wxBoxSizer *sizer = new wxBoxSizer(wxVERTICAL);
+
+  if (const wxBitmap logoBmp = BuildSplashBitmap(options.showLogo);
+      logoBmp.IsOk()) {
+    wxStaticBitmap *logo = new wxStaticBitmap(panel, wxID_ANY, logoBmp);
+    sizer->AddStretchSpacer(1);
+    sizer->Add(logo, 0, wxALIGN_CENTER | wxALL, 10);
+  } else {
+    sizer->AddStretchSpacer(1);
+  }
 
   g_label =
       new wxStaticText(panel, wxID_ANY, "Loading Perastage...", wxDefaultPosition,
@@ -130,8 +147,6 @@ void SplashScreen::Show() {
   font.MakeBold();
   g_label->SetFont(font);
 
-  sizer->AddStretchSpacer(1);
-  sizer->Add(logo, 0, wxALIGN_CENTER | wxALL, 10);
   sizer->Add(g_label, 0, wxALIGN_CENTER | wxBOTTOM, 20);
   sizer->AddStretchSpacer(1);
   panel->SetSizerAndFit(sizer);

--- a/gui/splashscreen.h
+++ b/gui/splashscreen.h
@@ -3,12 +3,7 @@
 
 class SplashScreen {
 public:
-  struct Options {
-    bool showLogo = true;
-  };
-
   static void Show();
-  static void Show(const Options &options);
   static void SetMessage(const wxString &message);
   static void Hide();
 };

--- a/gui/splashscreen.h
+++ b/gui/splashscreen.h
@@ -3,7 +3,12 @@
 
 class SplashScreen {
 public:
+  struct Options {
+    bool showLogo = true;
+  };
+
   static void Show();
+  static void Show(const Options &options);
   static void SetMessage(const wxString &message);
   static void Hide();
 };


### PR DESCRIPTION
### Motivation
- Prevent user interaction during project file load so the app cannot be manipulated while scene data is still being built, avoiding race conditions and errors. 
- Align project-loading UX with existing blocking flows (startup and rider/text generation) by providing a clear, blocking status overlay. 

### Description
- Add `SplashScreen::Options` and an overload `SplashScreen::Show(const Options&)` to allow callers to show the splash with or without the logo by passing `Options{ .showLogo = false }`. 
- Extracted splash bitmap construction to `BuildSplashBitmap(bool showLogo)` and kept the default `Show()` behavior unchanged for startup. 
- Update `MainWindow::LoadProjectFromPath` to disable all windows via `wxWindowDisabler`, show a non-logo splash, update status with `SplashScreen::SetMessage(...)` during load stages, call `wxYieldIfNeeded()`, and use `ScopeExit` guards to reliably hide the splash and re-enable windows and viewport interaction on all return paths. 
- Modified files: `gui/splashscreen.h`, `gui/splashscreen.cpp`, and `gui/mainwindow.cpp`. 

### Testing
- Ran `bash tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `bash tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1940f545483249ca7928076a0247e)