### PR TITLE
Fix freeze when double-clicking .exe from Windows Explorer

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -962,6 +962,8 @@ void MainWindow::OnProjectLoaded(wxCommandEvent &event) {
   bool clearLastProject = event.GetExtraLong() != 0;
   std::string path = event.GetString().ToStdString();
   Ensure3DViewport();
+  if (viewportPanel)
+    viewportPanel->SetStartupLoadPending(false);
   if (clearLastProject)
     ProjectUtils::SaveLastProjectPath("");
   if (loaded && !path.empty()) {

--- a/main.cpp
+++ b/main.cpp
@@ -21,6 +21,7 @@
 #include "mainwindow.h"
 #include "projectutils.h"
 #include "splashscreen.h"
+#include "viewer3dpanel.h"
 #include <filesystem>
 #include <algorithm>
 #include <atomic>
@@ -135,7 +136,17 @@ bool MyApp::OnInit() {
   wxWeakRef<MainWindow> mainWindowRef(mainWindow);
   auto lastPathOpt = ProjectUtils::LoadLastProjectPath();
 
+  // Tell the 3D viewport to skip resource sync while the background loader
+  // is active.  This prevents the paint handler from reading scene data that
+  // the loader thread is mutating, which otherwise causes a data race that
+  // can block the main thread on recursive file searches (the "Loading last
+  // project..." freeze observed when double-clicking the .exe from Explorer).
+  if (Viewer3DPanel::Instance())
+    Viewer3DPanel::Instance()->SetStartupLoadPending(true);
+
   if (startupPathOpt && mainWindowRef) {
+    if (Viewer3DPanel::Instance())
+      Viewer3DPanel::Instance()->SetStartupLoadPending(false);
     QueueProjectLoadedEvent(mainWindowRef, false, false);
     const std::string startupPath = *startupPathOpt;
     mainWindow->CallAfter([mainWindowRef, startupPath]() {
@@ -175,6 +186,8 @@ bool MyApp::OnInit() {
     });
 
   } else if (mainWindowRef) {
+    if (Viewer3DPanel::Instance())
+      Viewer3DPanel::Instance()->SetStartupLoadPending(false);
     QueueProjectLoadedEvent(mainWindowRef, false, false);
   }
 

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -253,14 +253,17 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
     }
     InitGL();
 
+    const bool startupLoading = m_startupLoadPending.load();
     const bool pauseHeavyTasks = ShouldPauseHeavyTasks();
     m_controller.ResetDebugPerFrameCounters();
     m_controller.UpdateFrameStateLightweight();
-    if (m_sceneSyncPending) {
-        m_controller.UpdateResourcesIfDirty();
-        m_sceneSyncPending = false;
-    } else if (!pauseHeavyTasks && !m_cameraMoving) {
-        m_controller.UpdateResourcesIfDirty();
+    if (!startupLoading) {
+        if (m_sceneSyncPending) {
+            m_controller.UpdateResourcesIfDirty();
+            m_sceneSyncPending = false;
+        } else if (!pauseHeavyTasks && !m_cameraMoving) {
+            m_controller.UpdateResourcesIfDirty();
+        }
     }
 
     const int updateResourcesCallsPerFrame =

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -67,6 +67,13 @@ public:
     bool ShouldPauseHeavyTasks();
     bool IsCameraMoving() const { return m_cameraMoving; }
 
+    // Pause resource sync while a background project load is in progress.
+    // This prevents the paint handler from reading scene data that is being
+    // modified by the loader thread, which otherwise causes a data race that
+    // can block the main thread on heavy recursive file searches.
+    void SetStartupLoadPending(bool pending) { m_startupLoadPending.store(pending); }
+    bool IsStartupLoadPending() const { return m_startupLoadPending.load(); }
+
 private:
     wxGLContext* m_glContext;
     Viewer3DCamera m_camera;
@@ -134,6 +141,7 @@ private:
 
     Viewer3DController m_controller;
 
+    std::atomic<bool> m_startupLoadPending{false};
     std::atomic<bool> m_threadRunning{false};
     std::thread m_refreshThread;
     void RefreshLoop();


### PR DESCRIPTION
## Summary

- **Root cause**: The 3D viewport's paint handler runs at ~60 fps and calls `UpdateResourcesIfDirty()`, which reads the scene's fixture/truss/object maps and resolves resource paths (including recursive directory searches via `FindFileRecursive`). When the background project-loader thread is simultaneously modifying those same maps (`Clear()` → populate in `ParseSceneXml`), this data race blocks the main thread on heavy I/O, causing the "Loading last project…" freeze and "(No responde)" window.
- **Why only Explorer double-click**: Thread scheduling differences when launching from Explorer (vs VS/CMD/admin) make the race window reliably hit — the paint handler sees partially-populated scene data, fails fast path resolution, and falls through to expensive recursive directory traversal on the main thread.
- **Fix**: Add an `std::atomic<bool> m_startupLoadPending` flag to `Viewer3DPanel` that pauses resource sync in `OnPaint` while the background loader is active. The flag is set before the loader thread starts and cleared in `OnProjectLoaded`, ensuring the paint handler never touches scene data being mutated by another thread.

## Test plan

- [ ] Build on Windows with Visual Studio
- [ ] Verify double-clicking the .exe from Explorer loads the last project without freezing
- [ ] Verify launching from CMD still works
- [ ] Verify launching from VS (F5) still works
- [ ] Verify Run as Administrator from Explorer still works
- [ ] Verify that after loading completes, the 3D viewport renders correctly (resource sync resumes)

https://claude.ai/code/session_011iEiJXjU5pJUZv75r4AS9r