### PR TITLE
Preserve MVR GroupObject and truss semantics; add Perastage truss GDTF sidecar with stable FixtureTypeID

### DIFF
--- a/core/scenedatamanager.cpp
+++ b/core/scenedatamanager.cpp
@@ -39,8 +39,7 @@ const std::unordered_map<std::string, SceneObject>& SceneDataManager::GetSceneOb
     return ConfigManager::Get().GetScene().sceneObjects;
 }
 
-const std::unordered_map<std::string, SceneObject>& SceneDataManager::GetGroupObjects() const
+const std::unordered_map<std::string, GroupObject>& SceneDataManager::GetGroupObjects() const
 {
-    static std::unordered_map<std::string, SceneObject> empty;
-    return empty;
+    return ConfigManager::Get().GetScene().groupObjects;
 }

--- a/core/scenedatamanager.h
+++ b/core/scenedatamanager.h
@@ -22,6 +22,7 @@
 #include "fixture.h"
 #include "truss.h"
 #include "sceneobject.h"
+#include "groupobject.h"
 
 // Simple singleton wrapper providing access to the scene data
 class SceneDataManager {
@@ -32,7 +33,7 @@ public:
     const std::unordered_map<std::string, Truss>& GetTrusses() const;
     const std::unordered_map<std::string, SceneObject>& GetSceneObjects() const;
     // Currently no group objects are stored, return empty map
-    const std::unordered_map<std::string, SceneObject>& GetGroupObjects() const;
+    const std::unordered_map<std::string, GroupObject>& GetGroupObjects() const;
 
 private:
     SceneDataManager() = default;

--- a/core/truss_gdtf_builder.cpp
+++ b/core/truss_gdtf_builder.cpp
@@ -18,6 +18,7 @@
 #include "truss_gdtf_builder.h"
 
 #include "json.hpp"
+#include "uuidutils.h"
 
 #include <tinyxml2.h>
 #include <wx/filename.h>
@@ -28,6 +29,7 @@
 #include <cctype>
 #include <fstream>
 #include <memory>
+#include <sstream>
 
 namespace fs = std::filesystem;
 using nlohmann::json;
@@ -43,6 +45,7 @@ struct TrussSourceData {
   float weightKg = 0.0f;
   fs::path geometryPath;
   fs::path symbolPath;
+  std::string typeKey;
 };
 
 static std::string Trim(std::string value) {
@@ -205,6 +208,15 @@ static bool ReadLegacyGtruss(const fs::path &gtrussPath, TrussSourceData &out,
   return true;
 }
 
+static std::string BuildStableFixtureTypeId(const TrussSourceData &data) {
+  std::ostringstream seed;
+  seed << "perastage-truss-type:" << data.manufacturer << '|'
+       << data.model << '|' << data.lengthMm << '|' << data.widthMm << '|'
+       << data.heightMm << '|' << data.weightKg << '|'
+       << data.typeKey;
+  return DeriveDeterministicUuid(seed.str());
+}
+
 static std::string BuildDescriptionXml(const TrussSourceData &data) {
   tinyxml2::XMLDocument doc;
   auto *decl = doc.NewDeclaration("xml version=\"1.0\" encoding=\"UTF-8\"");
@@ -219,7 +231,7 @@ static std::string BuildDescriptionXml(const TrussSourceData &data) {
   fixtureType->SetAttribute("Name", fixtureName.c_str());
   fixtureType->SetAttribute("ShortName", fixtureName.c_str());
   fixtureType->SetAttribute("Manufacturer", data.manufacturer.c_str());
-  fixtureType->SetAttribute("FixtureTypeID", "00000000-0000-0000-0000-000000000001");
+  fixtureType->SetAttribute("FixtureTypeID", BuildStableFixtureTypeId(data).c_str());
   root->InsertEndChild(fixtureType);
 
   auto *attributes = doc.NewElement("AttributeDefinitions");
@@ -339,6 +351,7 @@ bool BuildTrussGdtfFromInstance(const Truss &truss, const fs::path &outGdtfPath,
   source.widthMm = truss.widthMm;
   source.heightMm = truss.heightMm;
   source.weightKg = truss.weightKg;
+  source.typeKey = truss.perastageTypeKey;
 
   auto pickGeometry = [&](const std::string &path) {
     fs::path p = fs::u8path(path);

--- a/models/groupobject.h
+++ b/models/groupobject.h
@@ -15,23 +15,32 @@
  * You should have received a copy of the GNU General Public License
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
-#include "mvrscene.h"
+#pragma once
 
-void MvrScene::Clear() {
-    fixtures.clear();
-    trusses.clear();
-    supports.clear();
-    sceneObjects.clear();
-    groupObjects.clear();
-    layers.clear();
-    positions.clear();
-    symdefFiles.clear();
-    symdefTypes.clear();
-    symdefMatrices.clear();
-    symdefGeometries.clear();
-    provider.clear();
-    providerVersion.clear();
-    basePath.clear();
-    versionMajor = 1;
-    versionMinor = 6;
-}
+#include <string>
+#include <vector>
+
+#include "types.h"
+
+enum class MvrNodeType {
+  Fixture,
+  Truss,
+  Support,
+  SceneObject,
+  GroupObject,
+};
+
+struct GroupObjectChildRef {
+  MvrNodeType type = MvrNodeType::SceneObject;
+  std::string uuid;
+};
+
+struct GroupObject {
+  std::string uuid;
+  std::string name;
+  std::string layer;
+  std::string parentGroupUuid;
+  Matrix transform{};
+  Matrix localTransform{};
+  std::vector<GroupObjectChildRef> children;
+};

--- a/models/mvrscene.h
+++ b/models/mvrscene.h
@@ -23,6 +23,7 @@
 #include "fixture.h"
 #include "truss.h"
 #include "sceneobject.h"
+#include "groupobject.h"
 #include "support.h"
 #include "layer.h"
 
@@ -45,6 +46,7 @@ public:
     std::unordered_map<std::string, Truss> trusses;
     std::unordered_map<std::string, Support> supports;
     std::unordered_map<std::string, SceneObject> sceneObjects;
+    std::unordered_map<std::string, GroupObject> groupObjects;
     std::unordered_map<std::string, Layer> layers;
     // Lookup tables for additional references
     std::unordered_map<std::string, std::string> positions;   // uuid -> name

--- a/models/truss.h
+++ b/models/truss.h
@@ -22,6 +22,14 @@
 
 // Represents a truss object parsed from MVR
 struct Truss {
+    enum class GeometryRepresentation {
+        Unknown = 0,
+        SymbolSymdef,
+        Geometry3D,
+        PublicGdtf,
+        NativePerastage
+    };
+
     std::string uuid;
     std::string name;
     std::string gdtfSpec;
@@ -49,4 +57,15 @@ struct Truss {
     int customIdType = 0;
 
     Matrix transform;
+    Matrix localTransform;
+    Matrix sourceSymbolMatrix;
+    Matrix sourceGeometryMatrix;
+    bool hasLocalTransform = false;
+
+    GeometryRepresentation sourceRepresentation = GeometryRepresentation::Unknown;
+    std::string sourceSymdefUuid;
+    std::string sourceGeometryType;
+    std::string parentGroupUuid;
+    std::string perastageTypeKey;
+    std::string perastageAuxGdtfArchivePath;
 };

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -227,6 +227,21 @@ static std::string BuildTrussTypeKey(const Truss &truss) {
   return key.str();
 }
 
+static const char *ToRepresentationText(Truss::GeometryRepresentation representation) {
+  switch (representation) {
+  case Truss::GeometryRepresentation::SymbolSymdef:
+    return "SymbolSymdef";
+  case Truss::GeometryRepresentation::Geometry3D:
+    return "Geometry3D";
+  case Truss::GeometryRepresentation::PublicGdtf:
+    return "PublicGdtf";
+  case Truss::GeometryRepresentation::NativePerastage:
+    return "NativePerastage";
+  default:
+    return "Unknown";
+  }
+}
+
 static bool IsValidMvrFileName(const std::string &value) {
   if (value.empty())
     return false;
@@ -850,6 +865,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
   std::unordered_map<std::string, std::string> gdtfArchiveByObjectUuid;
   std::unordered_map<std::string, GdtfOverrides> gdtfOverrides;
   std::unordered_map<std::string, std::string> trussArchiveByTypeKey;
+  std::unordered_map<std::string, std::string> trussInstanceToTypeKey;
   std::unordered_set<std::string> reservedArchivePaths;
 
   auto normalizeSourcePath = [&](const std::string &rawPath) {
@@ -1266,12 +1282,14 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
           trussSourceGdtf = tempPath.string();
       }
 
-      std::string trussPreferredName = BuildTrussGdtfArchiveName(t);
+      std::string trussPreferredName = "Perastage/truss_types/" + BuildTrussGdtfArchiveName(t);
       trussGdtfArchivePath =
           registerGdtfResource(t.uuid, trussSourceGdtf, trussPreferredName, true);
       if (!trussGdtfArchivePath.empty())
         trussArchiveByTypeKey[trussTypeKey] = trussGdtfArchivePath;
     }
+    if (!trussTypeKey.empty())
+      trussInstanceToTypeKey[t.uuid] = trussTypeKey;
 
     if (!trussGdtfArchivePath.empty()) {
       tinyxml2::XMLElement *e = doc.NewElement("GDTFSpec");
@@ -1314,28 +1332,48 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
       }
     }
 
-    if (trussGeometryAuthority == TrussGeometryAuthority::MvrGeometry && !t.symbolFile.empty()) {
-      std::string ext = fs::path(t.symbolFile).extension().string();
-      std::transform(ext.begin(), ext.end(), ext.begin(),
-                     [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-      if (ext == ".3ds" || ext == ".glb") {
+    if (trussGeometryAuthority == TrussGeometryAuthority::MvrGeometry) {
+      if (t.sourceRepresentation == Truss::GeometryRepresentation::SymbolSymdef &&
+          !t.sourceSymdefUuid.empty()) {
         tinyxml2::XMLElement *geos = doc.NewElement("Geometries");
-        tinyxml2::XMLElement *g3d = doc.NewElement("Geometry3D");
-        std::string symbolArchivePath = registerResource(
-            t.symbolFile,
-            SanitizeArchiveFileName(t.symbolFile, "truss.3ds"));
-        g3d->SetAttribute("fileName", symbolArchivePath.c_str());
-        geos->InsertEndChild(g3d);
+        tinyxml2::XMLElement *sym = doc.NewElement("Symbol");
+        sym->SetAttribute("symdef", t.sourceSymdefUuid.c_str());
+        tinyxml2::XMLElement *symMat = doc.NewElement("Matrix");
+        symMat->SetText(MatrixUtils::FormatMatrix(t.sourceSymbolMatrix).c_str());
+        sym->InsertEndChild(symMat);
+        geos->InsertEndChild(sym);
         te->InsertEndChild(geos);
+        wxLogMessage("MVR export truss keeps Symbol/Symdef uuid=%s symdef=%s",
+                     t.uuid.c_str(), t.sourceSymdefUuid.c_str());
+      } else if (!t.symbolFile.empty()) {
+        std::string ext = fs::path(t.symbolFile).extension().string();
+        std::transform(ext.begin(), ext.end(), ext.begin(),
+                       [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        if (ext == ".3ds" || ext == ".glb") {
+          tinyxml2::XMLElement *geos = doc.NewElement("Geometries");
+          tinyxml2::XMLElement *g3d = doc.NewElement("Geometry3D");
+          std::string symbolArchivePath = registerResource(
+              t.symbolFile,
+              SanitizeArchiveFileName(t.symbolFile, "truss.3ds"));
+          g3d->SetAttribute("fileName", symbolArchivePath.c_str());
+          if (!t.sourceGeometryType.empty())
+            g3d->SetAttribute("geometryType", t.sourceGeometryType.c_str());
+          tinyxml2::XMLElement *geoMat = doc.NewElement("Matrix");
+          geoMat->SetText(MatrixUtils::FormatMatrix(t.sourceGeometryMatrix).c_str());
+          g3d->InsertEndChild(geoMat);
+          geos->InsertEndChild(g3d);
+          te->InsertEndChild(geos);
+          wxLogMessage("MVR export truss uses direct Geometry3D uuid=%s", t.uuid.c_str());
+        }
       }
     }
-    std::string mstr = MatrixUtils::FormatMatrix(t.transform);
+    const Matrix matrixToWrite = t.hasLocalTransform ? t.localTransform : t.transform;
+    std::string mstr = MatrixUtils::FormatMatrix(matrixToWrite);
     tinyxml2::XMLElement *mat = doc.NewElement("Matrix");
     mat->SetText(mstr.c_str());
     te->InsertEndChild(mat);
 
-    const bool shouldWriteMvrTrussMetadata = trussGdtfArchivePath.empty();
-    bool hasMeta = shouldWriteMvrTrussMetadata &&
+    bool hasMeta =
                    (!t.manufacturer.empty() || !t.model.empty() ||
                     t.lengthMm != 0.0f || t.widthMm != 0.0f ||
                     t.heightMm != 0.0f || t.weightKg != 0.0f ||
@@ -1372,6 +1410,9 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
       addTxt("CrossSection", t.crossSection);
       addTxt("ModelFile", t.modelFile);
       addTxt("HangPos", t.positionName);
+      addTxt("Representation", ToRepresentationText(t.sourceRepresentation));
+      addTxt("TypeKey", trussTypeKey);
+      addTxt("AuxGdtf", trussGdtfArchivePath);
       data->InsertEndChild(info);
       ud->InsertEndChild(data);
       te->InsertEndChild(ud);
@@ -1500,6 +1541,47 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
     parent->InsertEndChild(oe);
   };
 
+  auto exportGroupObject = [&](auto &&self, tinyxml2::XMLElement *parent,
+                               const GroupObject &group) -> void {
+    tinyxml2::XMLElement *go = doc.NewElement("GroupObject");
+    go->SetAttribute("uuid", group.uuid.c_str());
+    if (!group.name.empty())
+      go->SetAttribute("name", group.name.c_str());
+    tinyxml2::XMLElement *mat = doc.NewElement("Matrix");
+    mat->SetText(MatrixUtils::FormatMatrix(group.localTransform).c_str());
+    go->InsertEndChild(mat);
+
+    tinyxml2::XMLElement *childList = doc.NewElement("ChildList");
+    for (const auto &childRef : group.children) {
+      if (childRef.type == MvrNodeType::Truss) {
+        auto it = scene.trusses.find(childRef.uuid);
+        if (it != scene.trusses.end())
+          exportTruss(childList, it->second);
+      } else if (childRef.type == MvrNodeType::SceneObject) {
+        auto it = scene.sceneObjects.find(childRef.uuid);
+        if (it != scene.sceneObjects.end())
+          exportSceneObject(childList, it->second);
+      } else if (childRef.type == MvrNodeType::Fixture) {
+        auto it = scene.fixtures.find(childRef.uuid);
+        if (it != scene.fixtures.end())
+          exportFixture(childList, it->second);
+      } else if (childRef.type == MvrNodeType::Support) {
+        auto it = scene.supports.find(childRef.uuid);
+        if (it != scene.supports.end())
+          exportSupport(childList, it->second);
+      } else if (childRef.type == MvrNodeType::GroupObject) {
+        auto it = scene.groupObjects.find(childRef.uuid);
+        if (it != scene.groupObjects.end())
+          self(self, childList, it->second);
+      }
+    }
+
+    if (childList->FirstChild())
+      go->InsertEndChild(childList);
+    parent->InsertEndChild(go);
+    wxLogMessage("MVR export preserved GroupObject uuid=%s", group.uuid.c_str());
+  };
+
   for (const auto &[layerUuid, layer] : scene.layers) {
     if (layer.name == DEFAULT_LAYER_NAME)
       continue;
@@ -1519,8 +1601,25 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
 
     tinyxml2::XMLElement *childList = doc.NewElement("ChildList");
 
+    for (const auto &[uid, group] : scene.groupObjects) {
+      if (group.layer != layer.name || !group.parentGroupUuid.empty())
+        continue;
+      exportGroupObject(exportGroupObject, childList, group);
+    }
+
     for (const auto &[uid, f] : scene.fixtures) {
       if (f.layer != layer.name)
+        continue;
+      bool grouped = false;
+      for (const auto &[gid, g] : scene.groupObjects) {
+        if (std::any_of(g.children.begin(), g.children.end(), [&](const GroupObjectChildRef &r) {
+              return r.type == MvrNodeType::Fixture && r.uuid == uid;
+            })) {
+          grouped = true;
+          break;
+        }
+      }
+      if (grouped)
         continue;
       exportFixture(childList, f);
     }
@@ -1528,17 +1627,41 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
     for (const auto &[uid, t] : scene.trusses) {
       if (t.layer != layer.name)
         continue;
+      if (!t.parentGroupUuid.empty())
+        continue;
       exportTruss(childList, t);
     }
 
     for (const auto &[uid, s] : scene.supports) {
       if (s.layer != layer.name)
         continue;
+      bool grouped = false;
+      for (const auto &[gid, g] : scene.groupObjects) {
+        if (std::any_of(g.children.begin(), g.children.end(), [&](const GroupObjectChildRef &r) {
+              return r.type == MvrNodeType::Support && r.uuid == uid;
+            })) {
+          grouped = true;
+          break;
+        }
+      }
+      if (grouped)
+        continue;
       exportSupport(childList, s);
     }
 
     for (const auto &[uid, obj] : scene.sceneObjects) {
       if (obj.layer != layer.name)
+        continue;
+      bool grouped = false;
+      for (const auto &[gid, g] : scene.groupObjects) {
+        if (std::any_of(g.children.begin(), g.children.end(), [&](const GroupObjectChildRef &r) {
+              return r.type == MvrNodeType::SceneObject && r.uuid == uid;
+            })) {
+          grouped = true;
+          break;
+        }
+      }
+      if (grouped)
         continue;
       exportSceneObject(childList, obj);
     }
@@ -1551,26 +1674,91 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
 
   // Objects with no layer
   tinyxml2::XMLElement *rootChildList = doc.NewElement("ChildList");
+  for (const auto &[uid, group] : scene.groupObjects) {
+    if (!(group.layer == DEFAULT_LAYER_NAME || group.layer.empty()) || !group.parentGroupUuid.empty())
+      continue;
+    exportGroupObject(exportGroupObject, rootChildList, group);
+  }
   for (const auto &[uid, f] : scene.fixtures) {
-    if (f.layer == DEFAULT_LAYER_NAME || f.layer.empty())
+    if (!(f.layer == DEFAULT_LAYER_NAME || f.layer.empty()))
+      continue;
+    bool grouped = false;
+    for (const auto &[gid, g] : scene.groupObjects) {
+      if (std::any_of(g.children.begin(), g.children.end(), [&](const GroupObjectChildRef &r) {
+            return r.type == MvrNodeType::Fixture && r.uuid == uid;
+          })) {
+        grouped = true;
+        break;
+      }
+    }
+    if (!grouped)
       exportFixture(rootChildList, f);
   }
   for (const auto &[uid, t] : scene.trusses) {
-    if (t.layer == DEFAULT_LAYER_NAME || t.layer.empty())
+    if ((t.layer == DEFAULT_LAYER_NAME || t.layer.empty()) && t.parentGroupUuid.empty())
       exportTruss(rootChildList, t);
   }
   for (const auto &[uid, s] : scene.supports) {
-    if (s.layer == DEFAULT_LAYER_NAME || s.layer.empty())
+    if (!(s.layer == DEFAULT_LAYER_NAME || s.layer.empty()))
+      continue;
+    bool grouped = false;
+    for (const auto &[gid, g] : scene.groupObjects) {
+      if (std::any_of(g.children.begin(), g.children.end(), [&](const GroupObjectChildRef &r) {
+            return r.type == MvrNodeType::Support && r.uuid == uid;
+          })) {
+        grouped = true;
+        break;
+      }
+    }
+    if (!grouped)
       exportSupport(rootChildList, s);
   }
   for (const auto &[uid, obj] : scene.sceneObjects) {
-    if (obj.layer == DEFAULT_LAYER_NAME || obj.layer.empty())
+    if (!(obj.layer == DEFAULT_LAYER_NAME || obj.layer.empty()))
+      continue;
+    bool grouped = false;
+    for (const auto &[gid, g] : scene.groupObjects) {
+      if (std::any_of(g.children.begin(), g.children.end(), [&](const GroupObjectChildRef &r) {
+            return r.type == MvrNodeType::SceneObject && r.uuid == uid;
+          })) {
+        grouped = true;
+        break;
+      }
+    }
+    if (!grouped)
       exportSceneObject(rootChildList, obj);
   }
   if (rootChildList->FirstChild())
     layersNode->InsertEndChild(rootChildList);
 
   sceneNode->InsertEndChild(layersNode);
+
+  if (!trussArchiveByTypeKey.empty()) {
+    tinyxml2::XMLElement *sceneUserData = doc.NewElement("UserData");
+    tinyxml2::XMLElement *data = doc.NewElement("Data");
+    data->SetAttribute("provider", "Perastage");
+    data->SetAttribute("ver", "1.0");
+    tinyxml2::XMLElement *manifest = doc.NewElement("TrussSidecarManifest");
+    for (const auto &[typeKey, archivePath] : trussArchiveByTypeKey) {
+      tinyxml2::XMLElement *typeNode = doc.NewElement("Type");
+      typeNode->SetAttribute("key", typeKey.c_str());
+      typeNode->SetAttribute("gdtf", archivePath.c_str());
+      manifest->InsertEndChild(typeNode);
+      wxLogMessage("MVR export generated truss sidecar GDTF typeKey=%s archive=%s",
+                   typeKey.c_str(), archivePath.c_str());
+    }
+    for (const auto &[uuid, typeKey] : trussInstanceToTypeKey) {
+      tinyxml2::XMLElement *instNode = doc.NewElement("Instance");
+      instNode->SetAttribute("uuid", uuid.c_str());
+      instNode->SetAttribute("typeKey", typeKey.c_str());
+      manifest->InsertEndChild(instNode);
+      wxLogMessage("MVR export linked truss instance to sidecar uuid=%s typeKey=%s",
+                   uuid.c_str(), typeKey.c_str());
+    }
+    data->InsertEndChild(manifest);
+    sceneUserData->InsertEndChild(data);
+    sceneNode->InsertEndChild(sceneUserData);
+  }
 
   std::unordered_map<std::string, int> plannedArchiveEntries;
   plannedArchiveEntries["GeneralSceneDescription.xml"] = 1;

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -24,6 +24,7 @@
 #include "matrixutils.h"
 #include "sceneobject.h"
 #include "support.h"
+#include "groupobject.h"
 #include "uuidutils.h"
 #include "trussloader.h"
 
@@ -207,6 +208,20 @@ static std::string DescribeTrussForLog(const Truss &truss) {
       << truss.model << "', modelFile='" << truss.modelFile << "', gdtfSpec='"
       << truss.gdtfSpec << "', symbolFile='" << truss.symbolFile << "'";
   return oss.str();
+}
+
+static Truss::GeometryRepresentation ParseTrussRepresentation(
+    const std::string &value) {
+  const std::string lower = ToLowerCopy(Trim(value));
+  if (lower == "symbolsymdef")
+    return Truss::GeometryRepresentation::SymbolSymdef;
+  if (lower == "geometry3d")
+    return Truss::GeometryRepresentation::Geometry3D;
+  if (lower == "publicgdtf")
+    return Truss::GeometryRepresentation::PublicGdtf;
+  if (lower == "nativeperastage")
+    return Truss::GeometryRepresentation::NativePerastage;
+  return Truss::GeometryRepresentation::Unknown;
 }
 
 static std::string CieToHex(const std::string &cie) {
@@ -759,6 +774,33 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
       numericOut = std::atoi(textOut.c_str());
   };
 
+  std::unordered_map<std::string, std::string> perastageTypeToGdtfPath;
+  std::unordered_map<std::string, std::string> perastageInstanceToTypeKey;
+  if (tinyxml2::XMLElement *sceneUserData = sceneNode->FirstChildElement("UserData")) {
+    for (tinyxml2::XMLElement *data = sceneUserData->FirstChildElement("Data"); data;
+         data = data->NextSiblingElement("Data")) {
+      const std::string provider = ToLowerCopy(Trim(data->Attribute("provider") ? data->Attribute("provider") : ""));
+      if (provider != "perastage")
+        continue;
+      if (tinyxml2::XMLElement *manifest = data->FirstChildElement("TrussSidecarManifest")) {
+        for (tinyxml2::XMLElement *type = manifest->FirstChildElement("Type"); type;
+             type = type->NextSiblingElement("Type")) {
+          const char *key = type->Attribute("key");
+          const char *path = type->Attribute("gdtf");
+          if (key && path)
+            perastageTypeToGdtfPath[Trim(key)] = RemapArchivePathIfNeeded(path);
+        }
+        for (tinyxml2::XMLElement *inst = manifest->FirstChildElement("Instance"); inst;
+             inst = inst->NextSiblingElement("Instance")) {
+          const char *uuid = inst->Attribute("uuid");
+          const char *key = inst->Attribute("typeKey");
+          if (uuid && key)
+            perastageInstanceToTypeKey[CanonicalizeUuid(Trim(uuid))] = Trim(key);
+        }
+      }
+    }
+  }
+
   // ---- Parse AUXData for Symdefs and Positions ----
   if (tinyxml2::XMLElement *auxNode = sceneNode->FirstChildElement("AUXData")) {
     for (tinyxml2::XMLElement *pos = auxNode->FirstChildElement("Position");
@@ -984,7 +1026,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
   };
 
   // ---- Helper lambdas for object parsing ----
-  std::function<void(tinyxml2::XMLElement *, const std::string &, const Matrix &)>
+  std::function<void(tinyxml2::XMLElement *, const std::string &, const Matrix &, const std::string &)>
       parseChildList;
 
   auto ensurePositionEntry = [&](const std::string &positionId)
@@ -1055,6 +1097,19 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
 
     usedStableUuids.insert(stableUuid);
     return stableUuid;
+  };
+
+  auto referenceUuidForNode = [&](const char *kind, tinyxml2::XMLElement *node,
+                                  const std::string &layerName,
+                                  const Matrix &nodeTransform) {
+    const char *uuidAttr = node->Attribute("uuid");
+    std::string rawUuid = uuidAttr ? Trim(uuidAttr) : std::string{};
+    std::string stableUuid = CanonicalizeUuid(rawUuid);
+    if (!stableUuid.empty())
+      return stableUuid;
+    const std::string seed =
+        buildStableIdSeed(kind, node, layerName, nodeTransform, rawUuid);
+    return DeriveDeterministicUuid(seed);
   };
 
   std::function<void(tinyxml2::XMLElement *, const std::string &, const Matrix &)>
@@ -1214,14 +1269,19 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         scene.fixtures[fixture.uuid] = fixture;
       };
 
-  std::function<void(tinyxml2::XMLElement *, const std::string &, const Matrix &)> parseTruss =
+  std::function<void(tinyxml2::XMLElement *, const std::string &, const Matrix &, const Matrix &, const std::string &)> parseTruss =
       [&](tinyxml2::XMLElement *node, const std::string &layerName,
-          const Matrix &nodeTransform) {
+          const Matrix &nodeTransform, const Matrix &localTransform, const std::string &parentGroupUuid) {
         Truss truss;
         truss.uuid =
             resolveStableUuid("Truss", node, layerName, nodeTransform);
         truss.layer = layerName;
         truss.transform = nodeTransform;
+        truss.localTransform = localTransform;
+        truss.hasLocalTransform = true;
+        truss.parentGroupUuid = parentGroupUuid;
+        truss.sourceSymbolMatrix = MatrixUtils::Identity();
+        truss.sourceGeometryMatrix = MatrixUtils::Identity();
         if (const char *nameAttr = node->Attribute("name"))
           truss.name = nameAttr;
 
@@ -1237,6 +1297,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
 
         bool gdtfLoadFailed = false;
         if (!truss.gdtfSpec.empty()) {
+          truss.sourceRepresentation = Truss::GeometryRepresentation::PublicGdtf;
           truss.gdtfSpec = RemapArchivePathIfNeeded(truss.gdtfSpec);
           fs::path gdtfPath = scene.basePath.empty()
                                   ? fs::u8path(truss.gdtfSpec)
@@ -1272,18 +1333,27 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                 node->FirstChildElement("Geometries")) {
           if (tinyxml2::XMLElement *g3d =
                   geos->FirstChildElement("Geometry3D")) {
+            truss.sourceRepresentation = Truss::GeometryRepresentation::Geometry3D;
             const char *file = g3d->Attribute("fileName");
             if (file)
               truss.symbolFile = normalizeAndResolveGeometryFileName(file);
             Matrix geoMatrix = MatrixUtils::Identity();
             parseMatrixOrIdentity(g3d, "Matrix", "Truss/Geometry3D", geoMatrix, true);
+            truss.sourceGeometryMatrix = geoMatrix;
+            if (const char *type = g3d->Attribute("geometryType"))
+              truss.sourceGeometryType = Trim(type);
             truss.transform = MatrixUtils::Multiply(nodeTransform, geoMatrix);
           } else if (tinyxml2::XMLElement *sym =
                          geos->FirstChildElement("Symbol")) {
+            truss.sourceRepresentation = Truss::GeometryRepresentation::SymbolSymdef;
             std::vector<SymdefGeometry> symGeometries;
             std::string symType;
             Matrix symMatrix = MatrixUtils::Identity();
             resolveSymdefReference(sym, symGeometries, symType, symMatrix);
+            if (const char *symdef = sym->Attribute("symdef"))
+              truss.sourceSymdefUuid = Trim(symdef);
+            truss.sourceSymbolMatrix = symMatrix;
+            truss.sourceGeometryType = symType;
             Matrix symLocal = symMatrix;
             if (!symGeometries.empty()) {
               truss.symbolFile =
@@ -1292,6 +1362,9 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                                                symGeometries.front().transform);
             }
             truss.transform = MatrixUtils::Multiply(nodeTransform, symLocal);
+            LogMessage(Logger::Level::Info,
+                       "MVR import truss preserves Symbol/Symdef representation for uuid='" +
+                           truss.uuid + "', symdef='" + truss.sourceSymdefUuid + "'");
           }
         }
 
@@ -1353,7 +1426,43 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
               if (tinyxml2::XMLElement *hp = info->FirstChildElement("HangPos"))
                 if (hp->GetText())
                   truss.positionName = Trim(hp->GetText());
+              if (tinyxml2::XMLElement *rep = info->FirstChildElement("Representation"))
+                if (rep->GetText())
+                  truss.sourceRepresentation = ParseTrussRepresentation(rep->GetText());
+              if (tinyxml2::XMLElement *tk = info->FirstChildElement("TypeKey"))
+                if (tk->GetText())
+                  truss.perastageTypeKey = Trim(tk->GetText());
+              if (tinyxml2::XMLElement *ag = info->FirstChildElement("AuxGdtf"))
+                if (ag->GetText())
+                  truss.perastageAuxGdtfArchivePath = RemapArchivePathIfNeeded(Trim(ag->GetText()));
               break;
+            }
+          }
+        }
+
+        auto manifestIt = perastageInstanceToTypeKey.find(truss.uuid);
+        if (manifestIt != perastageInstanceToTypeKey.end()) {
+          truss.perastageTypeKey = manifestIt->second;
+          auto typeIt = perastageTypeToGdtfPath.find(truss.perastageTypeKey);
+          if (typeIt != perastageTypeToGdtfPath.end()) {
+            truss.perastageAuxGdtfArchivePath = typeIt->second;
+            fs::path auxPath = scene.basePath.empty()
+                                   ? fs::u8path(typeIt->second)
+                                   : fs::u8path(scene.basePath) / fs::u8path(typeIt->second);
+            Truss sidecar;
+            if (LoadTrussDefinition(ToString(auxPath.u8string()), sidecar)) {
+              if (truss.manufacturer.empty())
+                truss.manufacturer = sidecar.manufacturer;
+              if (truss.model.empty())
+                truss.model = sidecar.model;
+              if (truss.lengthMm <= 0.0f)
+                truss.lengthMm = sidecar.lengthMm;
+              if (truss.widthMm <= 0.0f)
+                truss.widthMm = sidecar.widthMm;
+              if (truss.heightMm <= 0.0f)
+                truss.heightMm = sidecar.heightMm;
+              if (truss.weightKg <= 0.0f)
+                truss.weightKg = sidecar.weightKg;
             }
           }
         }
@@ -1433,10 +1542,10 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         scene.supports[support.uuid] = support;
       };
 
-  std::function<void(tinyxml2::XMLElement *, const std::string &, const Matrix &)>
+  std::function<void(tinyxml2::XMLElement *, const std::string &, const Matrix &, const Matrix &, const std::string &)>
       parseSceneObj = [&](tinyxml2::XMLElement *node,
                           const std::string &layerName,
-                          const Matrix &nodeTransform) {
+                          const Matrix &nodeTransform, const Matrix &localTransform, const std::string &parentGroupUuid) {
         SceneObject obj;
         obj.uuid =
             resolveStableUuid("SceneObject", node, layerName, nodeTransform);
@@ -1511,7 +1620,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
       };
 
   parseChildList = [&](tinyxml2::XMLElement *cl, const std::string &layerName,
-                       const Matrix &parentTransform) {
+                       const Matrix &parentTransform, const std::string &parentGroupUuid) {
     for (tinyxml2::XMLElement *child = cl->FirstChildElement(); child;
          child = child->NextSiblingElement()) {
       const char *name = child->Name();
@@ -1525,16 +1634,52 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
       std::string nodeName = name;
       if (nodeName == "Fixture") {
         parseFixture(child, layerName, nodeTransform);
+        if (!parentGroupUuid.empty()) {
+          scene.groupObjects[parentGroupUuid].children.push_back(
+              {MvrNodeType::Fixture, referenceUuidForNode("Fixture", child, layerName, nodeTransform)});
+        }
       } else if (nodeName == "Truss") {
-        parseTruss(child, layerName, nodeTransform);
+        parseTruss(child, layerName, nodeTransform, local, parentGroupUuid);
+        if (!parentGroupUuid.empty()) {
+          scene.groupObjects[parentGroupUuid].children.push_back(
+              {MvrNodeType::Truss, referenceUuidForNode("Truss", child, layerName, nodeTransform)});
+        }
       } else if (nodeName == "Support") {
         parseSupport(child, layerName, nodeTransform);
+        if (!parentGroupUuid.empty()) {
+          scene.groupObjects[parentGroupUuid].children.push_back(
+              {MvrNodeType::Support, referenceUuidForNode("Support", child, layerName, nodeTransform)});
+        }
       } else if (nodeName == "SceneObject") {
-        parseSceneObj(child, layerName, nodeTransform);
+        parseSceneObj(child, layerName, nodeTransform, local, parentGroupUuid);
+        if (!parentGroupUuid.empty()) {
+          scene.groupObjects[parentGroupUuid].children.push_back(
+              {MvrNodeType::SceneObject,
+               referenceUuidForNode("SceneObject", child, layerName, nodeTransform)});
+        }
+      } else if (nodeName == "GroupObject") {
+        GroupObject group;
+        group.uuid = resolveStableUuid("GroupObject", child, layerName, nodeTransform);
+        group.layer = layerName;
+        group.transform = nodeTransform;
+        group.localTransform = local;
+        group.parentGroupUuid = parentGroupUuid;
+        if (const char *nameAttr = child->Attribute("name"))
+          group.name = nameAttr;
+        scene.groupObjects[group.uuid] = group;
+        if (!parentGroupUuid.empty()) {
+          scene.groupObjects[parentGroupUuid].children.push_back(
+              {MvrNodeType::GroupObject, group.uuid});
+        }
+        LogMessage(Logger::Level::Info,
+                   "MVR import preserved GroupObject uuid='" + group.uuid + "'");
+        if (tinyxml2::XMLElement *inner = child->FirstChildElement("ChildList"))
+          parseChildList(inner, layerName, nodeTransform, group.uuid);
+        continue;
       }
 
       if (tinyxml2::XMLElement *inner = child->FirstChildElement("ChildList"))
-        parseChildList(inner, layerName, nodeTransform);
+        parseChildList(inner, layerName, nodeTransform, parentGroupUuid);
     }
   };
   tinyxml2::XMLElement *layersNode = sceneNode->FirstChildElement("Layers");
@@ -1543,7 +1688,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
 
   for (tinyxml2::XMLElement *cl = layersNode->FirstChildElement("ChildList");
        cl; cl = cl->NextSiblingElement("ChildList")) {
-    parseChildList(cl, DEFAULT_LAYER_NAME, MatrixUtils::Identity());
+    parseChildList(cl, DEFAULT_LAYER_NAME, MatrixUtils::Identity(), "");
   }
 
   for (tinyxml2::XMLElement *layer = layersNode->FirstChildElement("Layer");
@@ -1555,7 +1700,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
     tinyxml2::XMLElement *childList = layer->FirstChildElement("ChildList");
     if (childList)
       parseChildList(childList, isDefaultLayer ? DEFAULT_LAYER_NAME : layerStr,
-                     MatrixUtils::Identity());
+                     MatrixUtils::Identity(), "");
 
     if (!isDefaultLayer) {
       Layer l;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -297,6 +297,35 @@ target_link_libraries(mvr_fixture_category_roundtrip_test PRIVATE
 add_test(NAME MvrFixtureCategoryRoundtrip COMMAND mvr_fixture_category_roundtrip_test)
 set_library_env(MvrFixtureCategoryRoundtrip)
 
+add_executable(mvr_truss_roundtrip_structure_test mvr_truss_roundtrip_structure_test.cpp
+               ../core/configmanager.cpp
+               ../core/configservices.cpp
+               ../core/projectutils.cpp
+               ../core/gdtfdictionary.cpp
+               ../core/gdtf_fixture_category.cpp
+               ../core/trussdictionary.cpp
+               ../core/trussloader.cpp
+               ../core/truss_gdtf_builder.cpp
+               ../core/uuidutils.cpp
+               ../core/dummyprofilelibrary.cpp
+               ../mvr/mvrimporter.cpp
+               ../mvr/mvrexporter.cpp
+               ../core/logger.cpp
+               gdtfloader_stub.cpp
+               consolepanel_stub.cpp
+               ../models/mvrscene.cpp
+               ../models/fixture.cpp
+               ../models/truss.cpp
+               ../models/sceneobject.cpp
+               ../models/layer.cpp
+               ${LAYOUT_SOURCES})
+target_include_directories(mvr_truss_roundtrip_structure_test PRIVATE
+                           . ../core ../models ../mvr ../gui ../third_party)
+target_link_libraries(mvr_truss_roundtrip_structure_test PRIVATE
+                      ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
+add_test(NAME MvrTrussRoundtripStructure COMMAND mvr_truss_roundtrip_structure_test)
+set_library_env(MvrTrussRoundtripStructure)
+
 add_executable(mvr_exporter_compliance_test mvr_exporter_compliance_test.cpp
                ../core/configmanager.cpp
                ../core/configservices.cpp

--- a/tests/mvr_truss_roundtrip_structure_test.cpp
+++ b/tests/mvr_truss_roundtrip_structure_test.cpp
@@ -1,0 +1,208 @@
+/*
+ * This file is part of Perastage.
+ */
+#include <cassert>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include <tinyxml2.h>
+#include <wx/init.h>
+#include <wx/wfstream.h>
+#include <wx/zipstrm.h>
+
+#include "configmanager.h"
+#include "matrixutils.h"
+#include "mvrexporter.h"
+#include "mvrimporter.h"
+#include "truss_gdtf_builder.h"
+
+namespace fs = std::filesystem;
+
+static std::string ReadCurrentZipEntry(wxZipInputStream &zip) {
+  std::string content;
+  char buffer[4096];
+  while (true) {
+    zip.Read(buffer, sizeof(buffer));
+    size_t bytes = zip.LastRead();
+    if (bytes == 0)
+      break;
+    content.append(buffer, bytes);
+  }
+  return content;
+}
+
+static std::unordered_map<std::string, std::string>
+ReadArchiveTextEntries(const fs::path &archivePath) {
+  wxFileInputStream input(archivePath.generic_string());
+  assert(input.IsOk());
+  wxZipInputStream zip(input);
+  std::unordered_map<std::string, std::string> entries;
+  std::unique_ptr<wxZipEntry> entry;
+  while ((entry.reset(zip.GetNextEntry())), entry) {
+    entries[entry->GetName().ToStdString()] = ReadCurrentZipEntry(zip);
+  }
+  return entries;
+}
+
+static std::string ReadFixtureTypeIdFromGdtf(const fs::path &gdtfPath) {
+  const auto entries = ReadArchiveTextEntries(gdtfPath);
+  auto it = entries.find("description.xml");
+  assert(it != entries.end());
+  tinyxml2::XMLDocument doc;
+  assert(doc.Parse(it->second.c_str()) == tinyxml2::XML_SUCCESS);
+  tinyxml2::XMLElement *root = doc.FirstChildElement("GDTF");
+  assert(root != nullptr);
+  tinyxml2::XMLElement *fixtureType = root->FirstChildElement("FixtureType");
+  assert(fixtureType != nullptr);
+  const char *id = fixtureType->Attribute("FixtureTypeID");
+  assert(id != nullptr);
+  return id;
+}
+
+int main() {
+  wxInitializer initializer;
+  assert(initializer.IsOk());
+
+  const fs::path tempDir =
+      fs::temp_directory_path() / "mvr_truss_roundtrip_structure_test";
+  fs::remove_all(tempDir);
+  fs::create_directories(tempDir / "models");
+
+  const fs::path symModel = tempDir / "models" / "sym_truss.3ds";
+  std::ofstream(symModel) << "sym-model";
+
+  auto &cfg = ConfigManager::Get();
+  cfg.Reset();
+  MvrScene &scene = cfg.GetScene();
+  scene.basePath = tempDir.generic_string();
+
+  const std::string symdefUuid = "11111111-1111-1111-1111-111111111111";
+  SymdefGeometry symGeo;
+  symGeo.file = symModel.generic_string();
+  symGeo.transform = MatrixUtils::Identity();
+  scene.symdefGeometries[symdefUuid] = {symGeo};
+  scene.symdefFiles[symdefUuid] = symModel.generic_string();
+  scene.symdefMatrices[symdefUuid] = MatrixUtils::Identity();
+
+  GroupObject group;
+  group.uuid = "22222222-2222-2222-2222-222222222222";
+  group.name = "Imported Group";
+  group.layer = DEFAULT_LAYER_NAME;
+  group.localTransform = MatrixUtils::Identity();
+  group.transform = MatrixUtils::Identity();
+  scene.groupObjects[group.uuid] = group;
+
+  Truss truss;
+  truss.uuid = "33333333-3333-3333-3333-333333333333";
+  truss.name = "Truss A";
+  truss.layer = DEFAULT_LAYER_NAME;
+  truss.localTransform = MatrixUtils::Identity();
+  truss.transform = MatrixUtils::Identity();
+  truss.sourceRepresentation = Truss::GeometryRepresentation::SymbolSymdef;
+  truss.sourceSymdefUuid = symdefUuid;
+  truss.sourceSymbolMatrix = MatrixUtils::Identity();
+  truss.parentGroupUuid = group.uuid;
+  truss.symbolFile = symModel.generic_string();
+  truss.modelFile = symModel.generic_string();
+  truss.manufacturer = "Perastage";
+  truss.model = "Tower 40";
+  truss.lengthMm = 3000.0f;
+  truss.widthMm = 400.0f;
+  truss.heightMm = 400.0f;
+  truss.weightKg = 40.0f;
+  truss.crossSection = "40x40";
+  scene.trusses[truss.uuid] = truss;
+  scene.groupObjects[group.uuid].children.push_back({MvrNodeType::Truss, truss.uuid});
+
+  MvrExporter exporter;
+  const fs::path mvrPath = tempDir / "roundtrip.mvr";
+  assert(exporter.ExportToFile(mvrPath.string()));
+
+  const auto entries = ReadArchiveTextEntries(mvrPath);
+  const auto xmlIt = entries.find("GeneralSceneDescription.xml");
+  assert(xmlIt != entries.end());
+
+  tinyxml2::XMLDocument xml;
+  assert(xml.Parse(xmlIt->second.c_str()) == tinyxml2::XML_SUCCESS);
+  tinyxml2::XMLElement *sceneNode =
+      xml.FirstChildElement("GeneralSceneDescription")->FirstChildElement("Scene");
+  assert(sceneNode != nullptr);
+
+  tinyxml2::XMLElement *layers = sceneNode->FirstChildElement("Layers");
+  assert(layers != nullptr);
+  tinyxml2::XMLElement *rootChildList = layers->FirstChildElement("ChildList");
+  assert(rootChildList != nullptr);
+  tinyxml2::XMLElement *groupNode = rootChildList->FirstChildElement("GroupObject");
+  assert(groupNode != nullptr);
+  tinyxml2::XMLElement *groupChildList = groupNode->FirstChildElement("ChildList");
+  assert(groupChildList != nullptr);
+  tinyxml2::XMLElement *trussNode = groupChildList->FirstChildElement("Truss");
+  assert(trussNode != nullptr);
+  tinyxml2::XMLElement *geos = trussNode->FirstChildElement("Geometries");
+  assert(geos != nullptr);
+  tinyxml2::XMLElement *symbol = geos->FirstChildElement("Symbol");
+  assert(symbol != nullptr);
+  assert(geos->FirstChildElement("Geometry3D") == nullptr);
+  assert(std::string(symbol->Attribute("symdef")) == symdefUuid);
+
+  tinyxml2::XMLElement *aux = sceneNode->FirstChildElement("AUXData");
+  assert(aux != nullptr);
+  bool foundSymdef = false;
+  for (tinyxml2::XMLElement *sym = aux->FirstChildElement("Symdef"); sym;
+       sym = sym->NextSiblingElement("Symdef")) {
+    if (std::string(sym->Attribute("uuid")) == symdefUuid) {
+      foundSymdef = true;
+      break;
+    }
+  }
+  assert(foundSymdef);
+
+  tinyxml2::XMLElement *sceneUserData = sceneNode->FirstChildElement("UserData");
+  assert(sceneUserData != nullptr);
+  tinyxml2::XMLElement *manifest = sceneUserData->FirstChildElement("Data")->FirstChildElement("TrussSidecarManifest");
+  assert(manifest != nullptr);
+  tinyxml2::XMLElement *typeNode = manifest->FirstChildElement("Type");
+  assert(typeNode != nullptr);
+  assert(std::string(typeNode->Attribute("gdtf")).rfind("Perastage/truss_types/", 0) == 0);
+
+  cfg.Reset();
+  MvrImporter importer;
+  assert(importer.ImportFromFile(mvrPath.string(), false, false));
+  auto &importedScene = ConfigManager::Get().GetScene();
+  assert(importedScene.groupObjects.size() == 1);
+  assert(importedScene.trusses.size() == 1);
+  const Truss &importedTruss = importedScene.trusses.begin()->second;
+  assert(importedTruss.sourceRepresentation == Truss::GeometryRepresentation::SymbolSymdef);
+  assert(!importedTruss.perastageAuxGdtfArchivePath.empty());
+  assert(importedTruss.manufacturer == "Perastage");
+  assert(importedTruss.model == "Tower 40");
+
+  Truss typeA;
+  typeA.symbolFile = symModel.generic_string();
+  typeA.modelFile = symModel.generic_string();
+  typeA.manufacturer = "Perastage";
+  typeA.model = "Tower 40";
+  typeA.lengthMm = 3000.0f;
+  typeA.widthMm = 400.0f;
+  typeA.heightMm = 400.0f;
+  typeA.weightKg = 40.0f;
+
+  Truss typeASame = typeA;
+  Truss typeB = typeA;
+  typeB.model = "Tower 50";
+
+  const fs::path gdtfA1 = tempDir / "typeA1.gdtf";
+  const fs::path gdtfA2 = tempDir / "typeA2.gdtf";
+  const fs::path gdtfB = tempDir / "typeB.gdtf";
+  std::string error;
+  assert(BuildTrussGdtfFromInstance(typeA, gdtfA1, &error));
+  assert(BuildTrussGdtfFromInstance(typeASame, gdtfA2, &error));
+  assert(BuildTrussGdtfFromInstance(typeB, gdtfB, &error));
+  assert(ReadFixtureTypeIdFromGdtf(gdtfA1) == ReadFixtureTypeIdFromGdtf(gdtfA2));
+  assert(ReadFixtureTypeIdFromGdtf(gdtfA1) != ReadFixtureTypeIdFromGdtf(gdtfB));
+
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- The MVR roundtrip flattened GroupObject and symbol-based truss semantics, causing loss of original hierarchy and public geometry representation and breaking external viewers; synthetic truss GDTFs used a single fixed FixtureTypeID which is incorrect for type identity.
- The goal is to export an MVR that is faithful to the original public XML structure while keeping Perastage-specific metadata in a parallel, explicit sidecar layer so roundtrips do not lose Perastage data.

### Description
- Add a first-class `GroupObject` model and storage in the scene and preserve nested parent/child relations during import/export so `GroupObject` nodes roundtrip intact (new `models/groupobject.h`, `models/mvrscene.*`, `core/scenedatamanager.*`, importer/exporter wiring in `mvr/mvrimporter.cpp` and `mvr/mvrexporter.cpp`).
- Extend `Truss` model with origin/representation fields and matrices so importer records whether a truss came as `Symbol/Symdef`, `Geometry3D`, or `GDTF`, and exporter re-emits the same public geometry form instead of materializing everything (changes in `models/truss.h`, `mvr/mvrimporter.cpp`, `mvr/mvrexporter.cpp`).
- Implement an explicit Perastage truss sidecar manifest and stable per-type auxiliary GDTF storage under `Perastage/truss_types/...`, emit `TrussSidecarManifest` linking type keys to GDTF files and instances, and make the importer read+merge sidecar GDTF metadata without replacing public geometry (changes in `mvr/mvrexporter.cpp`, `mvr/mvrimporter.cpp`).
- Make synthetic truss GDTF `FixtureTypeID` deterministic and stable per truss type by deriving the ID from a type-defining seed (manufacturer/model/dimensions/weight/typeKey) to ensure identical types share the same ID and different types differ (changes in `core/truss_gdtf_builder.cpp`).

Files (key): `mvr/mvrimporter.cpp`, `mvr/mvrexporter.cpp`, `core/truss_gdtf_builder.cpp`, `models/truss.h`, `models/groupobject.h` (new), `models/mvrscene.h/.cpp`, `core/scenedatamanager.h/.cpp`, `tests/mvr_truss_roundtrip_structure_test.cpp`, and `tests/CMakeLists.txt`.

### Testing
- Ran repository policy checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both succeeded.
- Attempted to configure the full test build with `cmake --preset wsl-x64-debug` but configure failed in this environment due to missing `wxWidgets` development packages, so full test execution is pending in CI or a developer environment with dependencies installed.
- Added an automated regression test `tests/mvr_truss_roundtrip_structure_test.cpp` (registered in `tests/CMakeLists.txt`) which validates: preservation of `GroupObject` and Symbol/Symdef roundtrip, AUXData symdef presence, explicit Perastage `TrussSidecarManifest` emission, importer merge of sidecar metadata, and deterministic per-type `FixtureTypeID` behavior; the test is included but not executed here due to the missing build dependency.
- Manual/CI validation required: run full test suite in CI or locally with `wxWidgets` installed to confirm compilation and that the new test and existing MVR/GDTF tests pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2919213dc832481633842792cb2e6)