### PR TITLE
Add Inno Setup installer script and optional .mvr association

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,10 +155,25 @@ These checks validate that per-instance normal transformation and mirrored-trans
 
 ## Windows packaging
 
+The **official Windows installer** is Inno Setup and the repository script is:
+
+- `packaging/windows/Perastage.iss`
+
+Packaging flow:
+
 1. Build the Release configuration.
 2. Run the `perastage_stage` target to populate the staging directory (`out/install/<CONFIG>`, for example `out/install/Release`).
-3. Generate an installer with CPack (`cpack -G NSIS` in the build directory) or use another installer tool if needed. The NSIS package writes file associations for `.mvr` (and `.pstg` when `-DPERASTAGE_ASSOCIATE_PSTG=ON`) using ProgID entries, icon registration, and open commands.
-4. Optionally provide a portable ZIP archive for users who prefer not to run an installer.
+3. Compile `packaging/windows/Perastage.iss` with Inno Setup.
+4. In the installer task page, choose optional file associations:
+   - `.pstg` (Perastage project files)
+   - `.mvr` (`assoc_mvr`, optional import-oriented double-click flow)
+5. Optionally provide a portable ZIP archive for users who prefer not to run an installer.
+
+Notes:
+
+- The installer writes associations under `Software\Classes` using ProgID/OpenWith entries and `ChangesAssociations=yes`.
+- Uninstall is intentionally conservative for extension ownership: it removes Perastage OpenWith/ProgID entries without forcing aggressive global cleanup of extension owners.
+- Legacy CPack/NSIS wiring is kept only as a compatibility path and is not the official installer workflow.
 
 ## Linux desktop integration
 

--- a/help.md
+++ b/help.md
@@ -31,7 +31,7 @@ Release builds keep these entries hidden to reduce risk in production workflows.
 
 ## File associations by operating system
 
-- **Windows installer (NSIS/CPack):** registers `.mvr` with a dedicated ProgID, icon, and open command. `.pstg` can also be associated when packaging enables `PERASTAGE_ASSOCIATE_PSTG`.
+- **Windows installer (official: Inno Setup):** `packaging/windows/Perastage.iss` registers ProgID/icon/open-command entries for `.pstg`, plus an optional installer task (`assoc_mvr`) to associate `.mvr` for double-click import flow.
 - **Linux install:** deploys a desktop entry plus MIME XML declarations for `*.mvr` and `*.pstg`, then refreshes MIME/desktop caches when the relevant tools are available.
 - **macOS bundle:** exports `CFBundleDocumentTypes` for `.mvr` so files can be opened from Finder.
 

--- a/packaging/windows/Perastage.iss
+++ b/packaging/windows/Perastage.iss
@@ -1,0 +1,80 @@
+; Perastage Windows installer (official) - Inno Setup
+; This script keeps file-type registration in HKCU/HKA Software\Classes and
+; exposes .mvr association as an optional installer task.
+
+#define MyAppName "Perastage"
+#define MyAppVersion "0.1.0"
+#define MyAppPublisher "Perasoft"
+#define MyAppURL "https://github.com/PeramatoG/Perastage"
+#define MyAppExeName "Perastage.exe"
+
+#define AssocProjectExt ".pstg"
+#define AssocProjectProgId "Perastage.Project"
+#define AssocProjectName "Perastage Project"
+
+#define AssocMvrExt ".mvr"
+#define AssocMvrProgId "Perastage.MVR"
+#define AssocMvrName "MVR Scene"
+
+[Setup]
+AppId={{1A0AC65C-067C-41ED-9A73-5B324ADDD0D8}
+AppName={#MyAppName}
+AppVersion={#MyAppVersion}
+AppPublisher={#MyAppPublisher}
+AppPublisherURL={#MyAppURL}
+AppSupportURL={#MyAppURL}
+AppUpdatesURL={#MyAppURL}
+DefaultDirName={autopf}\{#MyAppName}
+UninstallDisplayIcon={app}\{#MyAppExeName}
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+ChangesAssociations=yes
+DisableProgramGroupPage=yes
+; Replace these paths in CI/local packaging jobs as needed.
+LicenseFile=out\install\Release\LICENSE.txt
+OutputDir=out\installer
+OutputBaseFilename=Perastage_{#MyAppVersion}_Setup
+SetupIconFile=out\install\Release\resources\Perastage.ico
+SolidCompression=yes
+WizardStyle=modern
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+Name: "spanish"; MessagesFile: "compiler:Languages\Spanish.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+Name: "assoc_pstg"; Description: "Associate .pstg project files with {#MyAppName}"; GroupDescription: "File associations"; Flags: checkedonce
+Name: "assoc_mvr"; Description: "Associate .mvr files with {#MyAppName} (optional import workflow)"; GroupDescription: "File associations"; Flags: unchecked
+
+[Files]
+Source: "out\install\Release\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
+Source: "out\install\Release\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Registry]
+; Register both ProgIDs in Classes (HKA -> HKLM/HKCU based on install mode).
+Root: HKA; Subkey: "Software\Classes\{#AssocProjectProgId}"; ValueType: string; ValueName: ""; ValueData: "{#AssocProjectName}"; Flags: uninsdeletekey
+Root: HKA; Subkey: "Software\Classes\{#AssocProjectProgId}\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\{#MyAppExeName},0"; Flags: uninsdeletekey
+Root: HKA; Subkey: "Software\Classes\{#AssocProjectProgId}\shell\open\command"; ValueType: string; ValueName: ""; ValueData: "\"{app}\\{#MyAppExeName}\" \"%1\""; Flags: uninsdeletekey
+
+Root: HKA; Subkey: "Software\Classes\{#AssocMvrProgId}"; ValueType: string; ValueName: ""; ValueData: "{#AssocMvrName}"; Flags: uninsdeletekey
+Root: HKA; Subkey: "Software\Classes\{#AssocMvrProgId}\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\{#MyAppExeName},0"; Flags: uninsdeletekey
+Root: HKA; Subkey: "Software\Classes\{#AssocMvrProgId}\shell\open\command"; ValueType: string; ValueName: ""; ValueData: "\"{app}\\{#MyAppExeName}\" \"%1\""; Flags: uninsdeletekey
+
+; Safe uninstall policy: only remove our OpenWith entries and keep extension owner untouched.
+Root: HKA; Subkey: "Software\Classes\{#AssocProjectExt}\OpenWithProgids"; ValueType: string; ValueName: "{#AssocProjectProgId}"; ValueData: ""; Tasks: assoc_pstg; Flags: uninsdeletevalue
+Root: HKA; Subkey: "Software\Classes\{#AssocMvrExt}\OpenWithProgids"; ValueType: string; ValueName: "{#AssocMvrProgId}"; ValueData: ""; Tasks: assoc_mvr; Flags: uninsdeletevalue
+
+; Optional default association tasks (user-selected in installer UI).
+Root: HKA; Subkey: "Software\Classes\{#AssocProjectExt}"; ValueType: string; ValueName: ""; ValueData: "{#AssocProjectProgId}"; Tasks: assoc_pstg
+Root: HKA; Subkey: "Software\Classes\{#AssocMvrExt}"; ValueType: string; ValueName: ""; ValueData: "{#AssocMvrProgId}"; Tasks: assoc_mvr
+
+; Register executable under OpenWith so users can switch default app in Windows UI.
+Root: HKA; Subkey: "Software\Classes\Applications\{#MyAppExeName}\shell\open\command"; ValueType: string; ValueName: ""; ValueData: "\"{app}\\{#MyAppExeName}\" \"%1\""; Flags: uninsdeletekey
+
+[Icons]
+Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
+Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent


### PR DESCRIPTION
### Motivation

- Standardize the official Windows packaging workflow on Inno Setup and provide a single canonical installer script in the repository (`packaging/windows/Perastage.iss`).
- Expose `.mvr` association as an optional, user-selectable installer task so double-clicking an `.mvr` can launch Perastage into the import flow when the user chooses it.
- Avoid aggressive removal of extension ownership at uninstall time by keeping uninstall behavior conservative and limited to Perastage-owned OpenWith/ProgID entries.
- Prevent divergence between legacy CPack/NSIS wiring and the official installer by documenting the official workflow and keeping NSIS only as compatibility.

### Description

- Added `packaging/windows/Perastage.iss` containing an Inno Setup script that writes ProgID/OpenWith entries under `Software\Classes` (using `HKA`) and sets `ChangesAssociations=yes`.
- Introduced installer tasks `assoc_pstg` (project association) and `assoc_mvr` (optional MVR association) with the open command preserved as `"{app}\\Perastage.exe" "%1"`.
- Implemented a conservative uninstall policy in the script that removes Perastage OpenWith/ProgID entries (`uninsdeletevalue/uninsdeletekey`) without forcing global extension-owner cleanup.
- Updated `README.md` and `help.md` to declare Inno Setup as the official Windows installer and to document the optional `assoc_mvr` task and uninstall policy.

### Testing

- Ran `tests/check_perastage_tree_modules.sh`, which passed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2e5c225d08324b7ed4600c556c8ef)