### PR TITLE
Fix IntelliSense C++ standard mismatches (optional compatibility + constexpr)

### DIFF
--- a/core/app_version.h
+++ b/core/app_version.h
@@ -19,7 +19,7 @@
 
 namespace app {
 
-inline constexpr const char *kName = "Perastage";
+constexpr const char *kName = "Perastage";
 
 #ifndef PERASTAGE_APP_VERSION
 #define PERASTAGE_APP_VERSION "0.1.0"
@@ -29,7 +29,7 @@ inline constexpr const char *kName = "Perastage";
 #define PERASTAGE_APP_VERSION_DISPLAY "beta 0.1.0"
 #endif
 
-inline constexpr const char *kVersion = PERASTAGE_APP_VERSION;
-inline constexpr const char *kVersionDisplay = PERASTAGE_APP_VERSION_DISPLAY;
+constexpr const char *kVersion = PERASTAGE_APP_VERSION;
+constexpr const char *kVersionDisplay = PERASTAGE_APP_VERSION_DISPLAY;
 
 } // namespace app

--- a/core/optional_compat.h
+++ b/core/optional_compat.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#if defined(_MSVC_LANG)
+#define PERASTAGE_CXX_STD _MSVC_LANG
+#else
+#define PERASTAGE_CXX_STD __cplusplus
+#endif
+
+#if PERASTAGE_CXX_STD >= 201703L
+#include <optional>
+namespace perastage {
+template <typename T>
+using Optional = std::optional<T>;
+using std::nullopt;
+} // namespace perastage
+#elif __has_include(<experimental/optional>)
+#include <experimental/optional>
+namespace perastage {
+template <typename T>
+using Optional = std::experimental::optional<T>;
+constexpr auto nullopt = std::experimental::nullopt;
+} // namespace perastage
+#else
+#error "Perastage requires <optional> or <experimental/optional> support."
+#endif
+
+#undef PERASTAGE_CXX_STD

--- a/core/projectutils.h
+++ b/core/projectutils.h
@@ -18,15 +18,15 @@
 #pragma once
 
 #include <filesystem>
-#include <optional>
+#include "optional_compat.h"
 #include <string>
 
 namespace ProjectUtils {
-    inline constexpr const char* PROJECT_EXTENSION = ".pstg";
+    constexpr const char* PROJECT_EXTENSION = ".pstg";
 
     std::string GetLastProjectPathFile();
     bool SaveLastProjectPath(const std::string& path);
-    std::optional<std::string> LoadLastProjectPath();
+    perastage::Optional<std::string> LoadLastProjectPath();
 
     // Path containing the built-in library shipped with the executable.
     std::filesystem::path GetBaseLibraryPath(const std::string& subdir);

--- a/gui/mainwindow/ids/edit_ids.h
+++ b/gui/mainwindow/ids/edit_ids.h
@@ -2,16 +2,16 @@
 
 #include "tools_ids.h"
 
-inline constexpr int ID_Help_Help = ID_Tools_AssignSelectedFixtureCategory + 1;
-inline constexpr int ID_Help_About = ID_Help_Help + 1;
-inline constexpr int ID_Select_Fixtures = ID_Help_About + 1;
-inline constexpr int ID_Select_Trusses = ID_Select_Fixtures + 1;
-inline constexpr int ID_Select_Supports = ID_Select_Trusses + 1;
-inline constexpr int ID_Select_Objects = ID_Select_Supports + 1;
-inline constexpr int ID_Edit_Undo = ID_Select_Objects + 1;
-inline constexpr int ID_Edit_Redo = ID_Edit_Undo + 1;
-inline constexpr int ID_Edit_AddFixture = ID_Edit_Redo + 1;
-inline constexpr int ID_Edit_AddTruss = ID_Edit_AddFixture + 1;
-inline constexpr int ID_Edit_AddSceneObject = ID_Edit_AddTruss + 1;
-inline constexpr int ID_Edit_Delete = ID_Edit_AddSceneObject + 1;
-inline constexpr int ID_Edit_Preferences = ID_Edit_Delete + 1;
+constexpr int ID_Help_Help = ID_Tools_AssignSelectedFixtureCategory + 1;
+constexpr int ID_Help_About = ID_Help_Help + 1;
+constexpr int ID_Select_Fixtures = ID_Help_About + 1;
+constexpr int ID_Select_Trusses = ID_Select_Fixtures + 1;
+constexpr int ID_Select_Supports = ID_Select_Trusses + 1;
+constexpr int ID_Select_Objects = ID_Select_Supports + 1;
+constexpr int ID_Edit_Undo = ID_Select_Objects + 1;
+constexpr int ID_Edit_Redo = ID_Edit_Undo + 1;
+constexpr int ID_Edit_AddFixture = ID_Edit_Redo + 1;
+constexpr int ID_Edit_AddTruss = ID_Edit_AddFixture + 1;
+constexpr int ID_Edit_AddSceneObject = ID_Edit_AddTruss + 1;
+constexpr int ID_Edit_Delete = ID_Edit_AddSceneObject + 1;
+constexpr int ID_Edit_Preferences = ID_Edit_Delete + 1;

--- a/gui/mainwindow/ids/io_ids.h
+++ b/gui/mainwindow/ids/io_ids.h
@@ -2,16 +2,16 @@
 
 #include <wx/defs.h>
 
-inline constexpr int ID_File_New = wxID_HIGHEST + 1;
-inline constexpr int ID_File_Load = ID_File_New + 1;
-inline constexpr int ID_File_Save = ID_File_Load + 1;
-inline constexpr int ID_File_SaveAs = ID_File_Save + 1;
-inline constexpr int ID_File_ImportRider = ID_File_SaveAs + 1;
-inline constexpr int ID_File_ImportMVR = ID_File_ImportRider + 1;
-inline constexpr int ID_File_ExportMVR = ID_File_ImportMVR + 1;
-inline constexpr int ID_File_PrintViewer2D = ID_File_ExportMVR + 1;
-inline constexpr int ID_File_PrintLayout = ID_File_PrintViewer2D + 1;
-inline constexpr int ID_File_PrintTable = ID_File_PrintLayout + 1;
-inline constexpr int ID_File_PrintMenu = ID_File_PrintTable + 1;
-inline constexpr int ID_File_ExportCSV = ID_File_PrintMenu + 1;
-inline constexpr int ID_File_Close = ID_File_ExportCSV + 1;
+constexpr int ID_File_New = wxID_HIGHEST + 1;
+constexpr int ID_File_Load = ID_File_New + 1;
+constexpr int ID_File_Save = ID_File_Load + 1;
+constexpr int ID_File_SaveAs = ID_File_Save + 1;
+constexpr int ID_File_ImportRider = ID_File_SaveAs + 1;
+constexpr int ID_File_ImportMVR = ID_File_ImportRider + 1;
+constexpr int ID_File_ExportMVR = ID_File_ImportMVR + 1;
+constexpr int ID_File_PrintViewer2D = ID_File_ExportMVR + 1;
+constexpr int ID_File_PrintLayout = ID_File_PrintViewer2D + 1;
+constexpr int ID_File_PrintTable = ID_File_PrintLayout + 1;
+constexpr int ID_File_PrintMenu = ID_File_PrintTable + 1;
+constexpr int ID_File_ExportCSV = ID_File_PrintMenu + 1;
+constexpr int ID_File_Close = ID_File_ExportCSV + 1;

--- a/gui/mainwindow/ids/tools_ids.h
+++ b/gui/mainwindow/ids/tools_ids.h
@@ -2,18 +2,18 @@
 
 #include "view_ids.h"
 
-inline constexpr int ID_Tools_DownloadGdtf = ID_View_Layout_Image + 1;
-inline constexpr int ID_Tools_EditDictionaries = ID_Tools_DownloadGdtf + 1;
-inline constexpr int ID_Tools_ImportRiderText = ID_Tools_EditDictionaries + 1;
-inline constexpr int ID_Tools_DistributeHoistWeights =
+constexpr int ID_Tools_DownloadGdtf = ID_View_Layout_Image + 1;
+constexpr int ID_Tools_EditDictionaries = ID_Tools_DownloadGdtf + 1;
+constexpr int ID_Tools_ImportRiderText = ID_Tools_EditDictionaries + 1;
+constexpr int ID_Tools_DistributeHoistWeights =
     ID_Tools_ImportRiderText + 1;
-inline constexpr int ID_Tools_ExportFixture =
+constexpr int ID_Tools_ExportFixture =
     ID_Tools_DistributeHoistWeights + 1;
-inline constexpr int ID_Tools_ExportTruss = ID_Tools_ExportFixture + 1;
-inline constexpr int ID_Tools_ExportSceneObject = ID_Tools_ExportTruss + 1;
-inline constexpr int ID_Tools_AutoPatch = ID_Tools_ExportSceneObject + 1;
-inline constexpr int ID_Tools_AutoColor = ID_Tools_AutoPatch + 1;
-inline constexpr int ID_Tools_ConvertToHoist = ID_Tools_AutoColor + 1;
-inline constexpr int ID_Tools_GenerateFixtureSymbols = ID_Tools_ConvertToHoist + 1;
-inline constexpr int ID_Tools_AssignSelectedFixtureCategory =
+constexpr int ID_Tools_ExportTruss = ID_Tools_ExportFixture + 1;
+constexpr int ID_Tools_ExportSceneObject = ID_Tools_ExportTruss + 1;
+constexpr int ID_Tools_AutoPatch = ID_Tools_ExportSceneObject + 1;
+constexpr int ID_Tools_AutoColor = ID_Tools_AutoPatch + 1;
+constexpr int ID_Tools_ConvertToHoist = ID_Tools_AutoColor + 1;
+constexpr int ID_Tools_GenerateFixtureSymbols = ID_Tools_ConvertToHoist + 1;
+constexpr int ID_Tools_AssignSelectedFixtureCategory =
     ID_Tools_GenerateFixtureSymbols + 1;

--- a/gui/mainwindow/ids/view_ids.h
+++ b/gui/mainwindow/ids/view_ids.h
@@ -2,20 +2,20 @@
 
 #include "io_ids.h"
 
-inline constexpr int ID_View_ToggleConsole = ID_File_Close + 1;
-inline constexpr int ID_View_ToggleFixtures = ID_View_ToggleConsole + 1;
-inline constexpr int ID_View_ToggleViewport = ID_View_ToggleFixtures + 1;
-inline constexpr int ID_View_ToggleViewport2D = ID_View_ToggleViewport + 1;
-inline constexpr int ID_View_ToggleRender2D = ID_View_ToggleViewport2D + 1;
-inline constexpr int ID_View_ToggleLayers = ID_View_ToggleRender2D + 1;
-inline constexpr int ID_View_ToggleLayouts = ID_View_ToggleLayers + 1;
-inline constexpr int ID_View_ToggleSummary = ID_View_ToggleLayouts + 1;
-inline constexpr int ID_View_ToggleRigging = ID_View_ToggleSummary + 1;
-inline constexpr int ID_View_Layout_Default = ID_View_ToggleRigging + 1;
-inline constexpr int ID_View_Layout_2D = ID_View_Layout_Default + 1;
-inline constexpr int ID_View_Layout_Mode = ID_View_Layout_2D + 1;
-inline constexpr int ID_View_Layout_2DView = ID_View_Layout_Mode + 1;
-inline constexpr int ID_View_Layout_Legend = ID_View_Layout_2DView + 1;
-inline constexpr int ID_View_Layout_EventTable = ID_View_Layout_Legend + 1;
-inline constexpr int ID_View_Layout_Text = ID_View_Layout_EventTable + 1;
-inline constexpr int ID_View_Layout_Image = ID_View_Layout_Text + 1;
+constexpr int ID_View_ToggleConsole = ID_File_Close + 1;
+constexpr int ID_View_ToggleFixtures = ID_View_ToggleConsole + 1;
+constexpr int ID_View_ToggleViewport = ID_View_ToggleFixtures + 1;
+constexpr int ID_View_ToggleViewport2D = ID_View_ToggleViewport + 1;
+constexpr int ID_View_ToggleRender2D = ID_View_ToggleViewport2D + 1;
+constexpr int ID_View_ToggleLayers = ID_View_ToggleRender2D + 1;
+constexpr int ID_View_ToggleLayouts = ID_View_ToggleLayers + 1;
+constexpr int ID_View_ToggleSummary = ID_View_ToggleLayouts + 1;
+constexpr int ID_View_ToggleRigging = ID_View_ToggleSummary + 1;
+constexpr int ID_View_Layout_Default = ID_View_ToggleRigging + 1;
+constexpr int ID_View_Layout_2D = ID_View_Layout_Default + 1;
+constexpr int ID_View_Layout_Mode = ID_View_Layout_2D + 1;
+constexpr int ID_View_Layout_2DView = ID_View_Layout_Mode + 1;
+constexpr int ID_View_Layout_Legend = ID_View_Layout_2DView + 1;
+constexpr int ID_View_Layout_EventTable = ID_View_Layout_Legend + 1;
+constexpr int ID_View_Layout_Text = ID_View_Layout_EventTable + 1;
+constexpr int ID_View_Layout_Image = ID_View_Layout_Text + 1;

--- a/main.cpp
+++ b/main.cpp
@@ -25,7 +25,7 @@
 #include <atomic>
 #include <cctype>
 #include <new>
-#include <optional>
+#include "optional_compat.h"
 #include <string>
 #include <wx/stackwalk.h>
 #include <wx/sysopt.h>
@@ -59,7 +59,7 @@ std::string ToLowerAscii(std::string text) {
   return text;
 }
 
-std::optional<std::string> GetStartupPathFromArgs(int argc, wxChar **argv) {
+perastage::Optional<std::string> GetStartupPathFromArgs(int argc, wxChar **argv) {
   namespace fs = std::filesystem;
   const std::string projectExtension = ToLowerAscii(ProjectUtils::PROJECT_EXTENSION);
   for (int i = 1; i < argc; ++i) {
@@ -83,7 +83,7 @@ std::optional<std::string> GetStartupPathFromArgs(int argc, wxChar **argv) {
       return rawPath;
     return std::string(absoluteU8.begin(), absoluteU8.end());
   }
-  return std::nullopt;
+  return perastage::nullopt;
 }
 } // namespace
 
@@ -125,7 +125,7 @@ bool MyApp::OnInit() {
   // Start maximized so minimize and restore buttons remain available
   mainWindow->Maximize(true);
 
-  const std::optional<std::string> startupPathOpt =
+  const perastage::Optional<std::string> startupPathOpt =
       GetStartupPathFromArgs(argc, argv);
 
   SplashScreen::SetMessage("Loading last project...");


### PR DESCRIPTION
### Motivation
- The project produced many inactive IntelliSense parser errors (e.g. `std::optional` not found, `inline constexpr` mis-parsed) caused by editors/IDEs using an older C++ language mode than the build, which created noisy diagnostics although the code compiles with C++20.
- Provide a small compatibility layer and minor header adjustments to reduce IDE parser errors without changing runtime behavior.

### Description
- Added `core/optional_compat.h` that exposes `perastage::Optional<T>` and `perastage::nullopt`, selecting `std::optional` for C++17+ or falling back to `std::experimental::optional` when available.
- Replaced direct uses of `<optional>` in public headers/uses with the compatibility alias (`perastage::Optional`) and included the new header in `core/projectutils.h` and `main.cpp` to align interfaces and callers.
- Replaced `inline constexpr` namespace-scope constants with plain `constexpr` in `core/app_version.h` and the ID headers under `gui/mainwindow/ids` to avoid IntelliSense parsing failures while preserving semantics.
- Key changed files: `core/optional_compat.h` (new), `core/projectutils.h`, `core/app_version.h`, `main.cpp`, and `gui/mainwindow/ids/*` ID headers.

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which completed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which completed successfully.
- Attempted `cmake --preset wsl-x64-debug` to validate configuration and observed a CMake failure due to missing `wxWidgets` development packages in the container, which is unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2e8eb9e28832483698d063bd6c106)