### PR TITLE
Fix IntelliSense/MSVC errors and guard wxApp exception overrides

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
 )
 
 if(MSVC)
-    target_compile_options(${PROJECT_NAME} PRIVATE /Zc:__cplusplus)
+    target_compile_options(${PROJECT_NAME} PRIVATE /Zc:__cplusplus /std:c++20)
 endif()
 
 add_subdirectory(core)

--- a/main.cpp
+++ b/main.cpp
@@ -39,8 +39,10 @@ public:
   virtual bool OnInit() override;
   int OnExit() override;
   int FilterEvent(wxEvent &event) override;
+#if wxUSE_EXCEPTIONS
   bool OnExceptionInMainLoop() override;
   void OnUnhandledException() override;
+#endif
 
 private:
   void QueueProjectLoadedEvent(const wxWeakRef<MainWindow> &mainWindowRef,
@@ -233,6 +235,7 @@ void LogExceptionWithStack(const std::exception &ex,
 }
 } // namespace
 
+#if wxUSE_EXCEPTIONS
 bool MyApp::OnExceptionInMainLoop() {
   try {
     throw;
@@ -275,3 +278,4 @@ void MyApp::OnUnhandledException() {
     Logger::Instance().Log("Unhandled exception: unknown error.");
   }
 }
+#endif


### PR DESCRIPTION
### Motivation
- Resolve Visual Studio/IntelliSense parse errors where `std::optional` appears missing and cascading syntax errors caused by MSVC using a lower language mode. 
- Avoid invalid `override` diagnostics for `wxApp` exception hooks on builds where wxWidgets disables exception support.

### Description
- Add MSVC-specific compile option `/std:c++20` via `target_compile_options` in `CMakeLists.txt` to enforce C++20 language mode for Visual Studio and align IntelliSense with `cxx_std_20`.
- Wrap `MyApp::OnExceptionInMainLoop` and `MyApp::OnUnhandledException` declarations and definitions in `main.cpp` with `#if wxUSE_EXCEPTIONS` so the `override` specifier is only present when wx exception hooks are enabled.
- Modified files: `CMakeLists.txt` and `main.cpp`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (`OK`).
- Attempted `cmake -S . -B build && cmake --build build -j4` but a full local build could not complete in this environment due to missing `wxWidgets` development packages, so full compile/link validation was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2ee076d888324835ac3cabd428f86)