### PR TITLE
Fix missing GetGdtfModes symbol in test builds

### DIFF
--- a/tests/gdtfloader.h
+++ b/tests/gdtfloader.h
@@ -27,6 +27,7 @@ struct GdtfChannelInfo {
 };
 bool LoadGdtf(const std::string&, std::vector<GdtfObject>&, std::string* outError = nullptr);
 int GetGdtfModeChannelCount(const std::string&, const std::string&);
+std::vector<std::string> GetGdtfModes(const std::string&);
 std::vector<GdtfChannelInfo> GetGdtfModeChannels(const std::string&, const std::string&);
 std::string GetGdtfFixtureName(const std::string& gdtfPath);
 std::string GetGdtfModelColor(const std::string& gdtfPath);

--- a/tests/gdtfloader_onech_stub.cpp
+++ b/tests/gdtfloader_onech_stub.cpp
@@ -26,6 +26,7 @@ bool LoadGdtf(const std::string&, std::vector<GdtfObject>&, std::string*) {
     return false;
 }
 int GetGdtfModeChannelCount(const std::string&, const std::string&) { return 1; }
+std::vector<std::string> GetGdtfModes(const std::string&) { return {}; }
 std::string GetGdtfFixtureName(const std::string& gdtfPath) { return gdtfPath; }
 std::string GetGdtfModelColor(const std::string&) { return "#000000"; }
 bool GetGdtfProperties(const std::string&, float &w, float &p) {

--- a/tests/gdtfloader_stub.cpp
+++ b/tests/gdtfloader_stub.cpp
@@ -26,6 +26,7 @@ bool LoadGdtf(const std::string&, std::vector<GdtfObject>&, std::string*) {
     return false;
 }
 int GetGdtfModeChannelCount(const std::string&, const std::string&) { return 0; }
+std::vector<std::string> GetGdtfModes(const std::string&) { return {}; }
 std::string GetGdtfFixtureName(const std::string& gdtfPath) { return gdtfPath; }
 std::string GetGdtfModelColor(const std::string& gdtfPath) { return "#000000"; }
 bool SetGdtfModelColor(const std::string&, const std::string&) { return true; }


### PR DESCRIPTION
### Motivation
- Tests failed to compile due to an undeclared `GetGdtfModes` symbol referenced by `mvr/mvrimporter.cpp`, so the test shim API needed to match the production `gdtfloader.h` surface.

### Description
- Added `GetGdtfModes` declaration to the test shim `tests/gdtfloader.h` and added no-op stub implementations in `tests/gdtfloader_stub.cpp` and `tests/gdtfloader_onech_stub.cpp` to satisfy test-target compilation.

### Testing
- Ran `./tests/check_perastage_tree_modules.sh` which passed. 
- Ran `./tests/check_no_configmanager_get_in_gui.sh` which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2f8946ff083249ae987549e60dd04)