### PR TITLE
Set App as default in GDTF conflicts dialog and add batch select buttons

### DIFF
--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -395,8 +395,8 @@ PromptGdtfConflicts(const std::vector<GdtfConflict> &conflicts) {
   }
 
   wxBoxSizer *batchSelectionSizer = new wxBoxSizer(wxHORIZONTAL);
-  wxButton *selectAllAppButton = new wxButton(&dlg, wxID_ANY, "Select all App");
   wxButton *selectAllMvrButton = new wxButton(&dlg, wxID_ANY, "Select all MVR");
+  wxButton *selectAllAppButton = new wxButton(&dlg, wxID_ANY, "Select all App");
   selectAllAppButton->Bind(wxEVT_BUTTON,
                            [&appBtns, &selectAll](wxCommandEvent &) {
                              selectAll(appBtns);
@@ -405,8 +405,8 @@ PromptGdtfConflicts(const std::vector<GdtfConflict> &conflicts) {
                            [&mvrBtns, &selectAll](wxCommandEvent &) {
                              selectAll(mvrBtns);
                            });
-  batchSelectionSizer->Add(selectAllAppButton, 0, wxRIGHT, 5);
-  batchSelectionSizer->Add(selectAllMvrButton, 0);
+  batchSelectionSizer->Add(selectAllMvrButton, 0, wxRIGHT, 5);
+  batchSelectionSizer->Add(selectAllAppButton, 0);
 
   topSizer->Add(batchSelectionSizer, 0, wxLEFT | wxRIGHT | wxTOP, 10);
   topSizer->Add(grid, 1, wxALL, 10);

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -398,9 +398,13 @@ PromptGdtfConflicts(const std::vector<GdtfConflict> &conflicts) {
   wxButton *selectAllAppButton = new wxButton(&dlg, wxID_ANY, "Select all App");
   wxButton *selectAllMvrButton = new wxButton(&dlg, wxID_ANY, "Select all MVR");
   selectAllAppButton->Bind(wxEVT_BUTTON,
-                           [&appBtns](wxCommandEvent &) { selectAll(appBtns); });
+                           [&appBtns, &selectAll](wxCommandEvent &) {
+                             selectAll(appBtns);
+                           });
   selectAllMvrButton->Bind(wxEVT_BUTTON,
-                           [&mvrBtns](wxCommandEvent &) { selectAll(mvrBtns); });
+                           [&mvrBtns, &selectAll](wxCommandEvent &) {
+                             selectAll(mvrBtns);
+                           });
   batchSelectionSizer->Add(selectAllAppButton, 0, wxRIGHT, 5);
   batchSelectionSizer->Add(selectAllMvrButton, 0);
 

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -365,6 +365,13 @@ PromptGdtfConflicts(const std::vector<GdtfConflict> &conflicts) {
   if (conflicts.empty())
     return chosen;
 
+  auto selectAll = [](const std::vector<wxRadioButton *> &buttons) {
+    for (wxRadioButton *button : buttons) {
+      if (button)
+        button->SetValue(true);
+    }
+  };
+
   wxDialog dlg(nullptr, wxID_ANY, "GDTF conflicts");
   wxBoxSizer *topSizer = new wxBoxSizer(wxVERTICAL);
   wxFlexGridSizer *grid = new wxFlexGridSizer(3, 5, 5);
@@ -380,13 +387,24 @@ PromptGdtfConflicts(const std::vector<GdtfConflict> &conflicts) {
     wxRadioButton *mvr = new wxRadioButton(
         &dlg, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, wxRB_GROUP);
     wxRadioButton *app = new wxRadioButton(&dlg, wxID_ANY, "");
-    mvr->SetValue(true);
+    app->SetValue(true);
     grid->Add(mvr, 0, wxALIGN_CENTER);
     grid->Add(app, 0, wxALIGN_CENTER);
     mvrBtns.push_back(mvr);
     appBtns.push_back(app);
   }
 
+  wxBoxSizer *batchSelectionSizer = new wxBoxSizer(wxHORIZONTAL);
+  wxButton *selectAllAppButton = new wxButton(&dlg, wxID_ANY, "Select all App");
+  wxButton *selectAllMvrButton = new wxButton(&dlg, wxID_ANY, "Select all MVR");
+  selectAllAppButton->Bind(wxEVT_BUTTON,
+                           [&appBtns](wxCommandEvent &) { selectAll(appBtns); });
+  selectAllMvrButton->Bind(wxEVT_BUTTON,
+                           [&mvrBtns](wxCommandEvent &) { selectAll(mvrBtns); });
+  batchSelectionSizer->Add(selectAllAppButton, 0, wxRIGHT, 5);
+  batchSelectionSizer->Add(selectAllMvrButton, 0);
+
+  topSizer->Add(batchSelectionSizer, 0, wxLEFT | wxRIGHT | wxTOP, 10);
   topSizer->Add(grid, 1, wxALL, 10);
   topSizer->Add(dlg.CreateSeparatedButtonSizer(wxOK | wxCANCEL), 0,
                 wxEXPAND | wxALL, 10);


### PR DESCRIPTION
### Motivation
- Improve the GDTF conflict resolution UX by defaulting each row to the `App` choice and providing a quick way to switch all rows to `App` or `MVR`.

### Description
- Updated `PromptGdtfConflicts` in `mvr/mvrimporter.cpp` to preselect the `App` radio button for each conflict row, added a `selectAll` lambda and two buttons (`Select all App` and `Select all MVR`) that set all radio buttons accordingly, and left the final per-row resolution logic (`chosen[...]`) unchanged.
- Technical note: `mvr/mvrimporter.cpp` is a large hotspot; consider extracting the conflict-dialog UI into a small helper/source file in a follow-up per the repository code-health guidelines.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c30a034044832498c9840bcdf5d947)