### PR TITLE
Use imported MVR filename as window title for unsaved scenes

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -558,6 +558,7 @@ bool MainWindow::LoadProjectFromPath(const std::string &path,
   Ensure3DViewport();
 
   currentProjectPath = path;
+  currentProjectDisplayName.clear();
   ProjectUtils::SaveLastProjectPath(currentProjectPath);
 
   ApplySavedLayout();
@@ -661,6 +662,7 @@ void MainWindow::ResetProject() {
   fixtureSymbolAutoUpdateCompletionCallback = nullptr;
   startupSplashCloseRequested = false;
   currentProjectPath.clear();
+  currentProjectDisplayName.clear();
   if (layoutPanel)
     layoutPanel->ReloadLayouts();
   if (fixturePanel)
@@ -695,6 +697,8 @@ void MainWindow::UpdateTitle() {
   if (!currentProjectPath.empty()) {
     wxFileName fn(wxString::FromUTF8(currentProjectPath));
     title += " - " + fn.GetName();
+  } else if (!currentProjectDisplayName.empty()) {
+    title += " - " + wxString::FromUTF8(currentProjectDisplayName);
   } else {
     title += " - Untitled";
   }
@@ -1009,6 +1013,7 @@ void MainWindow::OnProjectLoaded(wxCommandEvent &event) {
     ProjectUtils::SaveLastProjectPath("");
   if (loaded && !path.empty()) {
     currentProjectPath = path;
+    currentProjectDisplayName.clear();
     ProjectUtils::SaveLastProjectPath(currentProjectPath);
     ApplySavedLayout();
     if (layoutPanel)

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -697,8 +697,8 @@ void MainWindow::UpdateTitle() {
   if (!currentProjectPath.empty()) {
     wxFileName fn(wxString::FromUTF8(currentProjectPath));
     title += " - " + fn.GetName();
-  } else if (!currentProjectDisplayName.empty()) {
-    title += " - " + wxString::FromUTF8(currentProjectDisplayName);
+  } else if (!currentProjectDisplayName.IsEmpty()) {
+    title += " - " + currentProjectDisplayName;
   } else {
     title += " - Untitled";
   }

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -95,6 +95,7 @@ private:
   void OnProjectLoaded(wxCommandEvent &event);
 
   std::string currentProjectPath;
+  std::string currentProjectDisplayName;
   IGuiConfigServices *guiConfigServices = nullptr;
   wxNotebook *notebook = nullptr;
   FixtureTablePanel *fixturePanel = nullptr;

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -95,7 +95,7 @@ private:
   void OnProjectLoaded(wxCommandEvent &event);
 
   std::string currentProjectPath;
-  std::string currentProjectDisplayName;
+  wxString currentProjectDisplayName;
   IGuiConfigServices *guiConfigServices = nullptr;
   wxNotebook *notebook = nullptr;
   FixtureTablePanel *fixturePanel = nullptr;

--- a/gui/mainwindow/controllers/mainwindow_io_controller.cpp
+++ b/gui/mainwindow/controllers/mainwindow_io_controller.cpp
@@ -66,6 +66,11 @@ bool MainWindowIoController::ImportMvrFromPath(const std::string &pathUtf8) {
   setImportStatus("MVR import: refreshing panels...");
   if (owner_.consolePanel)
     owner_.consolePanel->AppendMessage("Imported " + filePath);
+  owner_.currentProjectPath.clear();
+  owner_.currentProjectDisplayName =
+      wxFileName(filePath).GetName().ToStdString();
+  ProjectUtils::SaveLastProjectPath("");
+  owner_.UpdateTitle();
   owner_.RefreshAfterSceneChange();
 
   importOverlay.reset();

--- a/gui/mainwindow/controllers/mainwindow_io_controller.cpp
+++ b/gui/mainwindow/controllers/mainwindow_io_controller.cpp
@@ -67,8 +67,7 @@ bool MainWindowIoController::ImportMvrFromPath(const std::string &pathUtf8) {
   if (owner_.consolePanel)
     owner_.consolePanel->AppendMessage("Imported " + filePath);
   owner_.currentProjectPath.clear();
-  owner_.currentProjectDisplayName =
-      wxFileName(filePath).GetName().ToStdString();
+  owner_.currentProjectDisplayName = wxFileName(filePath).GetName();
   ProjectUtils::SaveLastProjectPath("");
   owner_.UpdateTitle();
   owner_.RefreshAfterSceneChange();


### PR DESCRIPTION
### Motivation
- When an external `.mvr` is imported into an empty/unsaved session the UI stayed `Untitled` (or retained a previous project name), which is confusing for users expecting the scene to adopt the imported filename.
- The goal is to show a sensible transient project name for imported MVRs without converting them into saved `.perastage` projects.

### Description
- Added a transient `currentProjectDisplayName` member to `MainWindow` to hold a display name for unsaved scenes (`gui/mainwindow.h`).
- Updated `MainWindow::UpdateTitle()` to prefer the project path name, then `currentProjectDisplayName`, and finally `Untitled` when composing the window title (`gui/mainwindow.cpp`).
- On successful MVR import `ImportMvrFromPath` now clears `currentProjectPath`, sets `currentProjectDisplayName` to the imported MVR base filename, clears the persisted last-project path via `ProjectUtils::SaveLastProjectPath("")`, and refreshes the title and UI (`gui/mainwindow/controllers/mainwindow_io_controller.cpp`).
- Ensured the transient display name is cleared when loading or resetting a regular project so title state remains consistent (`gui/mainwindow.cpp`).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it completed successfully (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it completed successfully (`OK`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c30d4e006c8324b7280b6edeb99a3f)