### PR TITLE
Add hoist hover/selection parity and 2D drag support

### DIFF
--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -691,6 +691,8 @@ void HoistTablePanel::OnSelectionChanged(wxDataViewEvent &evt) {
   }
   if (Viewer3DPanel::Instance())
     Viewer3DPanel::Instance()->SetSelectedFixtures(uuids);
+  if (Viewer2DPanel::Instance())
+    Viewer2DPanel::Instance()->SetSelectedUuids(uuids);
   UpdateSelectionHighlight();
   evt.Skip();
 }
@@ -706,6 +708,24 @@ void HoistTablePanel::UpdateSelectionHighlight() {
       selectedRows[r] = true;
   }
   store->SetSelectedRows(selectedRows);
+}
+
+void HoistTablePanel::ApplyPositionValueUpdates(
+    const std::vector<PositionValueUpdate> &updates) {
+  if (!table)
+    return;
+
+  wxWindowUpdateLocker locker(table);
+  for (const auto &update : updates) {
+    auto pos = std::find(rowUuids.begin(), rowUuids.end(), update.uuid);
+    if (pos == rowUuids.end())
+      continue;
+
+    int row = static_cast<int>(pos - rowUuids.begin());
+    table->SetValue(wxVariant(wxString::FromUTF8(update.posX)), row, 9);
+    table->SetValue(wxVariant(wxString::FromUTF8(update.posY)), row, 10);
+    table->SetValue(wxVariant(wxString::FromUTF8(update.posZ)), row, 11);
+  }
 }
 
 void HoistTablePanel::UpdateSceneData(bool logChanges) {

--- a/gui/hoisttablepanel.h
+++ b/gui/hoisttablepanel.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <vector>
 #include "colorstore.h"
+#include "positionvalueupdate.h"
 
 class IGuiConfigServices;
 
@@ -37,6 +38,7 @@ public:
   void SelectByUuid(const std::vector<std::string> &uuids);
   bool IsActivePage() const;
   void DeleteSelected();
+  void ApplyPositionValueUpdates(const std::vector<PositionValueUpdate> &updates);
   wxDataViewListCtrl *GetTableCtrl() const { return table; }
 
   static HoistTablePanel *Instance();

--- a/viewer2d/CMakeLists.txt
+++ b/viewer2d/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/viewer2dpanel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/viewer2dpdfexporter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/viewer2drenderpanel.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/viewer2d_support_selection.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/viewer2dstate.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/viewer2dviewfit.cpp
 )

--- a/viewer2d/viewer2d_support_selection.cpp
+++ b/viewer2d/viewer2d_support_selection.cpp
@@ -1,5 +1,11 @@
 #include "viewer2d_support_selection.h"
 
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#endif
+
 #ifdef __APPLE__
 #define GL_SILENCE_DEPRECATION
 #include <OpenGL/gl.h>

--- a/viewer2d/viewer2d_support_selection.cpp
+++ b/viewer2d/viewer2d_support_selection.cpp
@@ -1,0 +1,127 @@
+#include "viewer2d_support_selection.h"
+
+#ifdef __APPLE__
+#define GL_SILENCE_DEPRECATION
+#include <OpenGL/gl.h>
+#include <OpenGL/glu.h>
+#else
+#include <GL/gl.h>
+#include <GL/glu.h>
+#endif
+
+#include "support.h"
+#include "viewer3d_types.h"
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace Viewer2DSupportSelection {
+namespace {
+
+constexpr int kHoistHitRadiusPixels = 14;
+
+std::string NormalizeLayerName(const std::string &layer) {
+  return layer.empty() ? std::string(DEFAULT_LAYER_NAME) : layer;
+}
+
+bool IsLayerVisible(const std::unordered_set<std::string> &hiddenLayers,
+                    const std::string &layer) {
+  return hiddenLayers.find(NormalizeLayerName(layer)) == hiddenLayers.end();
+}
+
+bool ProjectSupportCenter(const Support &support, int viewportHeight,
+                          wxPoint &outScreenPos) {
+  GLdouble model[16];
+  GLdouble projection[16];
+  GLint viewport[4];
+  glGetDoublev(GL_MODELVIEW_MATRIX, model);
+  glGetDoublev(GL_PROJECTION_MATRIX, projection);
+  glGetIntegerv(GL_VIEWPORT, viewport);
+
+  const double x = static_cast<double>(support.transform.o[0] * RENDER_SCALE);
+  const double y = static_cast<double>(support.transform.o[1] * RENDER_SCALE);
+  const double z = static_cast<double>(support.transform.o[2] * RENDER_SCALE);
+
+  double sx = 0.0;
+  double sy = 0.0;
+  double sz = 0.0;
+  if (gluProject(x, y, z, model, projection, viewport, &sx, &sy, &sz) != GL_TRUE)
+    return false;
+
+  outScreenPos.x = static_cast<int>(sx);
+  outScreenPos.y = static_cast<int>(viewportHeight - sy);
+  return true;
+}
+
+wxString BuildHoistLabel(const std::string &uuid, const Support &support) {
+  wxString label = support.name.empty() ? wxString::FromUTF8(uuid)
+                                        : wxString::FromUTF8(support.name);
+  label += wxString::Format("\nh = %.2f m", support.transform.o[2] / 1000.0f);
+  return label;
+}
+
+} // namespace
+
+bool FindHoistAtScreenPoint(int mouseX, int mouseY, int viewportHeight,
+                            const MvrScene &scene,
+                            const std::unordered_set<std::string> &hiddenLayers,
+                            std::string &outUuid, wxPoint &outScreenPos,
+                            wxString &outLabel) {
+  bool found = false;
+  int bestDistanceSquared = std::numeric_limits<int>::max();
+  for (const auto &[uuid, support] : scene.supports) {
+    if (!IsLayerVisible(hiddenLayers, support.layer))
+      continue;
+
+    wxPoint projected;
+    if (!ProjectSupportCenter(support, viewportHeight, projected))
+      continue;
+
+    const int dx = projected.x - mouseX;
+    const int dy = projected.y - mouseY;
+    const int distanceSquared = dx * dx + dy * dy;
+    if (distanceSquared > kHoistHitRadiusPixels * kHoistHitRadiusPixels)
+      continue;
+    if (distanceSquared >= bestDistanceSquared)
+      continue;
+
+    found = true;
+    bestDistanceSquared = distanceSquared;
+    outUuid = uuid;
+    outScreenPos = projected;
+    outLabel = BuildHoistLabel(uuid, support);
+  }
+  return found;
+}
+
+std::vector<std::string>
+GetHoistsInScreenRect(int x1, int y1, int x2, int y2, int viewportWidth,
+                      int viewportHeight, const MvrScene &scene,
+                      const std::unordered_set<std::string> &hiddenLayers) {
+  const int minX = std::max(0, std::min(x1, x2));
+  const int maxX = std::min(viewportWidth, std::max(x1, x2));
+  const int minY = std::max(0, std::min(y1, y2));
+  const int maxY = std::min(viewportHeight, std::max(y1, y2));
+
+  std::vector<std::string> selection;
+  selection.reserve(scene.supports.size());
+
+  for (const auto &[uuid, support] : scene.supports) {
+    if (!IsLayerVisible(hiddenLayers, support.layer))
+      continue;
+
+    wxPoint projected;
+    if (!ProjectSupportCenter(support, viewportHeight, projected))
+      continue;
+
+    if (projected.x < minX || projected.x > maxX || projected.y < minY ||
+        projected.y > maxY) {
+      continue;
+    }
+    selection.push_back(uuid);
+  }
+
+  return selection;
+}
+
+} // namespace Viewer2DSupportSelection

--- a/viewer2d/viewer2d_support_selection.cpp
+++ b/viewer2d/viewer2d_support_selection.cpp
@@ -16,6 +16,7 @@
 #endif
 
 #include "support.h"
+#include "configservices.h"
 #include "viewer3d_types.h"
 #include <algorithm>
 #include <cmath>

--- a/viewer2d/viewer2d_support_selection.h
+++ b/viewer2d/viewer2d_support_selection.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "mvrscene.h"
+#include <string>
+#include <unordered_set>
+#include <vector>
+#include <wx/gdicmn.h>
+#include <wx/string.h>
+
+namespace Viewer2DSupportSelection {
+
+bool FindHoistAtScreenPoint(int mouseX, int mouseY, int viewportHeight,
+                            const MvrScene &scene,
+                            const std::unordered_set<std::string> &hiddenLayers,
+                            std::string &outUuid, wxPoint &outScreenPos,
+                            wxString &outLabel);
+
+std::vector<std::string>
+GetHoistsInScreenRect(int x1, int y1, int x2, int y2, int viewportWidth,
+                      int viewportHeight, const MvrScene &scene,
+                      const std::unordered_set<std::string> &hiddenLayers);
+
+} // namespace Viewer2DSupportSelection

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -45,11 +45,13 @@
 #include "canvas2d.h"
 #include "fixturetablepanel.h"
 #include "fixturepatchdialog.h"
+#include "hoisttablepanel.h"
 #include "logger.h"
 #include "positionvalueupdate.h"
 #include "sceneobjecttablepanel.h"
 #include "trusstablepanel.h"
 #include "viewer3dpanel.h"
+#include "viewer2d_support_selection.h"
 #include "viewer2dviewfit.h"
 #include <wx/app.h>
 #include <wx/utils.h>
@@ -320,6 +322,9 @@ void Viewer2DPanel::UpdateScene(bool reload) {
     } else if (TrussTablePanel::Instance() &&
                TrussTablePanel::Instance()->IsActivePage()) {
       selection = cfg.GetSelectedTrusses();
+    } else if (HoistTablePanel::Instance() &&
+               HoistTablePanel::Instance()->IsActivePage()) {
+      selection = cfg.GetSelectedSupports();
     } else if (SceneObjectTablePanel::Instance() &&
                SceneObjectTablePanel::Instance()->IsActivePage()) {
       selection = cfg.GetSelectedSceneObjects();
@@ -873,6 +878,20 @@ void Viewer2DPanel::OnPaint(wxPaintEvent &WXUNUSED(event)) {
       if (SceneObjectTablePanel::Instance())
         SceneObjectTablePanel::Instance()->HighlightObject(std::string());
     }
+  } else if (!skipLabelWork && HoistTablePanel::Instance() &&
+             HoistTablePanel::Instance()->IsActivePage()) {
+    const auto hiddenLayers = ConfigManager::Get().GetHiddenLayers();
+    found = Viewer2DSupportSelection::FindHoistAtScreenPoint(
+        m_lastMousePos.x, m_lastMousePos.y, h, ConfigManager::Get().GetScene(),
+        hiddenLayers, newUuid, newPos, newLabel);
+    if (found) {
+      if (FixtureTablePanel::Instance())
+        FixtureTablePanel::Instance()->HighlightFixture(std::string());
+      if (TrussTablePanel::Instance())
+        TrussTablePanel::Instance()->HighlightTruss(std::string());
+      if (SceneObjectTablePanel::Instance())
+        SceneObjectTablePanel::Instance()->HighlightObject(std::string());
+    }
   } else if (!skipLabelWork && SceneObjectTablePanel::Instance() &&
              SceneObjectTablePanel::Instance()->IsActivePage()) {
     found = m_controller.GetSceneObjectLabelAt(m_lastMousePos.x,
@@ -898,6 +917,9 @@ void Viewer2DPanel::OnPaint(wxPaintEvent &WXUNUSED(event)) {
     else if (TrussTablePanel::Instance() &&
              TrussTablePanel::Instance()->IsActivePage())
       TrussTablePanel::Instance()->HighlightTruss(std::string(m_hoverUuid));
+    else if (HoistTablePanel::Instance() &&
+             HoistTablePanel::Instance()->IsActivePage())
+      HoistTablePanel::Instance()->HighlightHoist(std::string(m_hoverUuid));
     else if (SceneObjectTablePanel::Instance() &&
              SceneObjectTablePanel::Instance()->IsActivePage())
       SceneObjectTablePanel::Instance()->HighlightObject(std::string(m_hoverUuid));
@@ -910,6 +932,8 @@ void Viewer2DPanel::OnPaint(wxPaintEvent &WXUNUSED(event)) {
       FixtureTablePanel::Instance()->HighlightFixture(std::string());
     if (TrussTablePanel::Instance())
       TrussTablePanel::Instance()->HighlightTruss(std::string());
+    if (HoistTablePanel::Instance())
+      HoistTablePanel::Instance()->HighlightHoist(std::string());
     if (SceneObjectTablePanel::Instance())
       SceneObjectTablePanel::Instance()->HighlightObject(std::string());
   } else if (skipLabelWork) {
@@ -977,6 +1001,10 @@ void Viewer2DPanel::ApplySelectionDelta(
     applyDelta(scene.trusses);
     ScheduleDragTableUpdate();
     break;
+  case DragTarget::Supports:
+    applyDelta(scene.supports);
+    ScheduleDragTableUpdate();
+    break;
   case DragTarget::SceneObjects:
     applyDelta(scene.sceneObjects);
     ScheduleDragTableUpdate();
@@ -1002,6 +1030,13 @@ void Viewer2DPanel::FinalizeSelectionDrag() {
       auto selection = cfg.GetSelectedTrusses();
       TrussTablePanel::Instance()->ReloadData();
       TrussTablePanel::Instance()->SelectByUuid(selection);
+    }
+    break;
+  case DragTarget::Supports:
+    if (HoistTablePanel::Instance()) {
+      auto selection = cfg.GetSelectedSupports();
+      HoistTablePanel::Instance()->ReloadData();
+      HoistTablePanel::Instance()->SelectByUuid(selection);
     }
     break;
   case DragTarget::SceneObjects:
@@ -1067,6 +1102,20 @@ void Viewer2DPanel::ApplyRectangleSelection(const wxPoint &start,
       TrussTablePanel::Instance()->ClearSelection();
     else
       TrussTablePanel::Instance()->SelectByUuid(selection);
+  } else if (HoistTablePanel::Instance() &&
+             HoistTablePanel::Instance()->IsActivePage()) {
+    auto selection = Viewer2DSupportSelection::GetHoistsInScreenRect(
+        start.x, start.y, end.x, end.y, w, h, cfg.GetScene(),
+        cfg.GetHiddenLayers());
+    if (selection != cfg.GetSelectedSupports()) {
+      cfg.PushUndoState("support selection");
+      cfg.SetSelectedSupports(selection);
+    }
+    m_controller.SetSelectedUuids(selection);
+    if (selection.empty())
+      HoistTablePanel::Instance()->ClearSelection();
+    else
+      HoistTablePanel::Instance()->SelectByUuid(selection);
   } else if (SceneObjectTablePanel::Instance() &&
              SceneObjectTablePanel::Instance()->IsActivePage()) {
     auto selection = m_controller.GetSceneObjectsInScreenRect(
@@ -1218,6 +1267,10 @@ void Viewer2DPanel::StartDragTableUpdateWorker() {
           if (TrussTablePanel::Instance())
             TrussTablePanel::Instance()->ApplyPositionValueUpdates(updates);
           break;
+        case DragTarget::Supports:
+          if (HoistTablePanel::Instance())
+            HoistTablePanel::Instance()->ApplyPositionValueUpdates(updates);
+          break;
         case DragTarget::SceneObjects:
           if (SceneObjectTablePanel::Instance())
             SceneObjectTablePanel::Instance()->ApplyPositionValueUpdates(
@@ -1275,6 +1328,15 @@ Viewer2DPanel::BuildDragTablePositionSnapshots(
     for (const auto &uuid : uuids) {
       auto it = scene.sceneObjects.find(uuid);
       if (it == scene.sceneObjects.end())
+        continue;
+      auto posArr = it->second.transform.o;
+      snapshots.push_back({uuid, posArr[0], posArr[1], posArr[2]});
+    }
+    break;
+  case DragTarget::Supports:
+    for (const auto &uuid : uuids) {
+      auto it = scene.supports.find(uuid);
+      if (it == scene.supports.end())
         continue;
       auto posArr = it->second.transform.o;
       snapshots.push_back({uuid, posArr[0], posArr[1], posArr[2]});
@@ -1371,6 +1433,12 @@ void Viewer2DPanel::OnMouseDown(wxMouseEvent &event) {
       found = m_controller.GetTrussLabelAt(event.GetX(), event.GetY(), w, h,
                                            label, pos, &uuid);
       target = DragTarget::Trusses;
+    } else if (HoistTablePanel::Instance() &&
+               HoistTablePanel::Instance()->IsActivePage()) {
+      found = Viewer2DSupportSelection::FindHoistAtScreenPoint(
+          event.GetX(), event.GetY(), h, ConfigManager::Get().GetScene(),
+          ConfigManager::Get().GetHiddenLayers(), uuid, pos, label);
+      target = DragTarget::Supports;
     } else if (SceneObjectTablePanel::Instance() &&
                SceneObjectTablePanel::Instance()->IsActivePage()) {
       found = m_controller.GetSceneObjectLabelAt(event.GetX(), event.GetY(), w,
@@ -1387,6 +1455,9 @@ void Viewer2DPanel::OnMouseDown(wxMouseEvent &event) {
         break;
       case DragTarget::Trusses:
         selection = cfg.GetSelectedTrusses();
+        break;
+      case DragTarget::Supports:
+        selection = cfg.GetSelectedSupports();
         break;
       case DragTarget::SceneObjects:
         selection = cfg.GetSelectedSceneObjects();
@@ -1498,6 +1569,11 @@ void Viewer2DPanel::OnMouseUp(wxMouseEvent &event) {
              TrussTablePanel::Instance()->IsActivePage())
       found = m_controller.GetTrussLabelAt(event.GetX(), event.GetY(), w, h,
                                            label, pos, &uuid);
+    else if (HoistTablePanel::Instance() &&
+             HoistTablePanel::Instance()->IsActivePage())
+      found = Viewer2DSupportSelection::FindHoistAtScreenPoint(
+          event.GetX(), event.GetY(), h, ConfigManager::Get().GetScene(),
+          ConfigManager::Get().GetHiddenLayers(), uuid, pos, label);
     else if (SceneObjectTablePanel::Instance() &&
              SceneObjectTablePanel::Instance()->IsActivePage())
       found = m_controller.GetSceneObjectLabelAt(event.GetX(), event.GetY(), w,
@@ -1545,6 +1621,25 @@ void Viewer2DPanel::OnMouseUp(wxMouseEvent &event) {
         }
         m_controller.SetSelectedUuids(selection);
         TrussTablePanel::Instance()->SelectByUuid(selection);
+      } else if (HoistTablePanel::Instance() &&
+                 HoistTablePanel::Instance()->IsActivePage()) {
+        if (additive)
+          selection = HoistTablePanel::Instance()->GetSelectedUuids();
+        if (additive) {
+          auto it = std::find(selection.begin(), selection.end(), uuid);
+          if (it != selection.end())
+            selection.erase(it);
+          else
+            selection.push_back(uuid);
+        } else {
+          selection = {uuid};
+        }
+        if (selection != cfg.GetSelectedSupports()) {
+          cfg.PushUndoState("support selection");
+          cfg.SetSelectedSupports(selection);
+        }
+        m_controller.SetSelectedUuids(selection);
+        HoistTablePanel::Instance()->SelectByUuid(selection);
       } else if (SceneObjectTablePanel::Instance() &&
                  SceneObjectTablePanel::Instance()->IsActivePage()) {
         if (additive)
@@ -1582,6 +1677,14 @@ void Viewer2DPanel::OnMouseUp(wxMouseEvent &event) {
         }
         m_controller.SetSelectedUuids({});
         TrussTablePanel::Instance()->ClearSelection();
+      } else if (HoistTablePanel::Instance() &&
+                 HoistTablePanel::Instance()->IsActivePage()) {
+        if (!cfg.GetSelectedSupports().empty()) {
+          cfg.PushUndoState("support selection");
+          cfg.SetSelectedSupports({});
+        }
+        m_controller.SetSelectedUuids({});
+        HoistTablePanel::Instance()->ClearSelection();
       } else if (SceneObjectTablePanel::Instance() &&
                  SceneObjectTablePanel::Instance()->IsActivePage()) {
         if (!cfg.GetSelectedSceneObjects().empty()) {
@@ -1905,6 +2008,8 @@ void Viewer2DPanel::OnMouseLeave(wxMouseEvent &event) {
       FixtureTablePanel::Instance()->HighlightFixture(std::string());
     if (TrussTablePanel::Instance())
       TrussTablePanel::Instance()->HighlightTruss(std::string());
+    if (HoistTablePanel::Instance())
+      HoistTablePanel::Instance()->HighlightHoist(std::string());
     if (SceneObjectTablePanel::Instance())
       SceneObjectTablePanel::Instance()->HighlightObject(std::string());
     Refresh();

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -133,7 +133,7 @@ public:
 private:
   enum class DragMode { None, View, Selection, RectSelection };
   enum class DragAxis { None, Horizontal, Vertical };
-  enum class DragTarget { None, Fixtures, Trusses, SceneObjects };
+  enum class DragTarget { None, Fixtures, Trusses, Supports, SceneObjects };
 
   void InitGL();
   void Render();

--- a/viewer3d/interfaces/irendercontext.h
+++ b/viewer3d/interfaces/irendercontext.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "canvas2d.h"
+#include <string>
 
 class IRenderContext {
 public:
@@ -10,6 +11,8 @@ public:
   virtual bool UseAdaptiveLineProfile() const = 0;
   virtual bool SkipOutlinesForCurrentFrame() const = 0;
   virtual bool IsSelectionOutlineEnabled2D() const = 0;
+  virtual bool IsUuidHighlighted(const std::string &uuid) const = 0;
+  virtual bool IsUuidSelected(const std::string &uuid) const = 0;
   virtual bool IsCaptureOnly() const = 0;
   virtual ICanvas2D *GetCaptureCanvas() const = 0;
   virtual bool CaptureIncludesGrid() const = 0;

--- a/viewer3d/render/hoist_symbol_renderer.cpp
+++ b/viewer3d/render/hoist_symbol_renderer.cpp
@@ -29,6 +29,7 @@ namespace {
 constexpr float kSymbolSizeMeters = 0.5f;
 constexpr float kHalfSizeMeters = kSymbolSizeMeters * 0.5f;
 constexpr float kLineWidth = 1.2f;
+constexpr float kSelectionLineWidth = 2.4f;
 constexpr float kPi = 3.14159265358979323846f;
 
 struct RgbColor {
@@ -125,6 +126,8 @@ HoistShape ResolveHoistShape(float capacityKg) {
 std::array<float, 3> MakePoint(float x, float y, float z) { return {x, y, z}; }
 
 RgbColor WhiteColor() { return {1.0f, 1.0f, 1.0f}; }
+RgbColor HighlightColor() { return {0.0f, 1.0f, 0.0f}; }
+RgbColor SelectedColor() { return {0.0f, 1.0f, 1.0f}; }
 
 void DrawFillPolygon(IRenderContext &renderContext,
                      const std::vector<std::array<float, 3>> &points,
@@ -150,12 +153,12 @@ void DrawFillPolygon(IRenderContext &renderContext,
 
 void DrawOutlineLoop(IRenderContext &renderContext,
                      const std::vector<std::array<float, 3>> &points,
-                     const RgbColor &color) {
+                     const RgbColor &color, float lineWidth = kLineWidth) {
   if (points.size() < 2)
     return;
 
   if (!renderContext.IsCaptureOnly()) {
-    glLineWidth(kLineWidth);
+    glLineWidth(lineWidth);
     renderContext.SetGLColor(color.r, color.g, color.b);
     glBegin(GL_LINE_LOOP);
     for (const auto &p : points)
@@ -165,16 +168,17 @@ void DrawOutlineLoop(IRenderContext &renderContext,
   }
 
   CanvasStroke stroke;
-  stroke.width = kLineWidth;
+  stroke.width = lineWidth;
   stroke.color = {color.r, color.g, color.b, 1.0f};
   for (size_t i = 0; i < points.size(); ++i)
     renderContext.RecordLine(points[i], points[(i + 1) % points.size()], stroke);
 }
 
 void DrawSegment(IRenderContext &renderContext, const std::array<float, 3> &a,
-                 const std::array<float, 3> &b, const RgbColor &color) {
+                 const std::array<float, 3> &b, const RgbColor &color,
+                 float lineWidth = kLineWidth) {
   if (!renderContext.IsCaptureOnly()) {
-    glLineWidth(kLineWidth);
+    glLineWidth(lineWidth);
     renderContext.SetGLColor(color.r, color.g, color.b);
     glBegin(GL_LINES);
     glVertex3f(a[0], a[1], a[2]);
@@ -184,13 +188,14 @@ void DrawSegment(IRenderContext &renderContext, const std::array<float, 3> &a,
   }
 
   CanvasStroke stroke;
-  stroke.width = kLineWidth;
+  stroke.width = lineWidth;
   stroke.color = {color.r, color.g, color.b, 1.0f};
   renderContext.RecordLine(a, b, stroke);
 }
 
 void DrawSquareSymbol(IRenderContext &renderContext, float cx, float cy,
-                      float z, const RgbColor &color) {
+                      float z, const RgbColor &color,
+                      const RgbColor &outlineColor, float outlineWidth) {
   const float minX = cx - kHalfSizeMeters;
   const float maxX = cx + kHalfSizeMeters;
   const float minY = cy - kHalfSizeMeters;
@@ -214,13 +219,16 @@ void DrawSquareSymbol(IRenderContext &renderContext, float cx, float cy,
   DrawOutlineLoop(renderContext,
                   {MakePoint(minX, minY, z), MakePoint(maxX, minY, z),
                    MakePoint(maxX, maxY, z), MakePoint(minX, maxY, z)},
-                  color);
-  DrawSegment(renderContext, MakePoint(cx, minY, z), MakePoint(cx, maxY, z), color);
-  DrawSegment(renderContext, MakePoint(minX, cy, z), MakePoint(maxX, cy, z), color);
+                  outlineColor, outlineWidth);
+  DrawSegment(renderContext, MakePoint(cx, minY, z), MakePoint(cx, maxY, z),
+              outlineColor, outlineWidth);
+  DrawSegment(renderContext, MakePoint(minX, cy, z), MakePoint(maxX, cy, z),
+              outlineColor, outlineWidth);
 }
 
 void DrawDiamondSymbol(IRenderContext &renderContext, float cx, float cy,
-                       float z, const RgbColor &color) {
+                       float z, const RgbColor &color,
+                       const RgbColor &outlineColor, float outlineWidth) {
   const auto top = MakePoint(cx, cy + kHalfSizeMeters, z);
   const auto right = MakePoint(cx + kHalfSizeMeters, cy, z);
   const auto bottom = MakePoint(cx, cy - kHalfSizeMeters, z);
@@ -230,13 +238,15 @@ void DrawDiamondSymbol(IRenderContext &renderContext, float cx, float cy,
   DrawFillPolygon(renderContext, {top, right, bottom, left}, WhiteColor());
   DrawFillPolygon(renderContext, {center, right, top}, color);
   DrawFillPolygon(renderContext, {center, left, bottom}, color);
-  DrawOutlineLoop(renderContext, {top, right, bottom, left}, color);
-  DrawSegment(renderContext, left, right, color);
-  DrawSegment(renderContext, bottom, top, color);
+  DrawOutlineLoop(renderContext, {top, right, bottom, left}, outlineColor,
+                  outlineWidth);
+  DrawSegment(renderContext, left, right, outlineColor, outlineWidth);
+  DrawSegment(renderContext, bottom, top, outlineColor, outlineWidth);
 }
 
 void DrawCircleSymbol(IRenderContext &renderContext, float cx, float cy,
-                      float z, const RgbColor &color) {
+                      float z, const RgbColor &color,
+                      const RgbColor &outlineColor, float outlineWidth) {
   constexpr int kSegments = 40;
   std::vector<std::array<float, 3>> ring;
   ring.reserve(static_cast<size_t>(kSegments));
@@ -272,15 +282,18 @@ void DrawCircleSymbol(IRenderContext &renderContext, float cx, float cy,
   DrawFillPolygon(renderContext, ring, WhiteColor());
   DrawFillPolygon(renderContext, topRight, color);
   DrawFillPolygon(renderContext, bottomLeft, color);
-  DrawOutlineLoop(renderContext, ring, color);
+  DrawOutlineLoop(renderContext, ring, outlineColor, outlineWidth);
   DrawSegment(renderContext, MakePoint(cx - kHalfSizeMeters, cy, z),
-              MakePoint(cx + kHalfSizeMeters, cy, z), color);
+              MakePoint(cx + kHalfSizeMeters, cy, z), outlineColor,
+              outlineWidth);
   DrawSegment(renderContext, MakePoint(cx, cy - kHalfSizeMeters, z),
-              MakePoint(cx, cy + kHalfSizeMeters, z), color);
+              MakePoint(cx, cy + kHalfSizeMeters, z), outlineColor,
+              outlineWidth);
 }
 
 void DrawTriangleSymbol(IRenderContext &renderContext, float cx, float cy,
-                        float z, const RgbColor &color) {
+                        float z, const RgbColor &color,
+                        const RgbColor &outlineColor, float outlineWidth) {
   const auto top = MakePoint(cx, cy + kHalfSizeMeters, z);
   const auto left = MakePoint(cx - kHalfSizeMeters, cy - kHalfSizeMeters, z);
   const auto right = MakePoint(cx + kHalfSizeMeters, cy - kHalfSizeMeters, z);
@@ -304,13 +317,14 @@ void DrawTriangleSymbol(IRenderContext &renderContext, float cx, float cy,
   DrawFillPolygon(renderContext, {top, rightCross, center}, color);
   DrawFillPolygon(renderContext, {leftCross, left, baseMid, center}, color);
 
-  DrawOutlineLoop(renderContext, {top, right, left}, color);
-  DrawSegment(renderContext, leftCross, rightCross, color);
-  DrawSegment(renderContext, top, baseMid, color);
+  DrawOutlineLoop(renderContext, {top, right, left}, outlineColor, outlineWidth);
+  DrawSegment(renderContext, leftCross, rightCross, outlineColor, outlineWidth);
+  DrawSegment(renderContext, top, baseMid, outlineColor, outlineWidth);
 }
 
 void DrawPentagonSymbol(IRenderContext &renderContext, float cx, float cy,
-                        float z, const RgbColor &color) {
+                        float z, const RgbColor &color,
+                        const RgbColor &outlineColor, float outlineWidth) {
   const auto top = MakePoint(cx, cy + kHalfSizeMeters, z);
   const auto rightTop = MakePoint(cx + kHalfSizeMeters * 0.85f,
                                   cy + kHalfSizeMeters * 0.25f, z);
@@ -341,13 +355,16 @@ void DrawPentagonSymbol(IRenderContext &renderContext, float cx, float cy,
   DrawFillPolygon(renderContext, {top, rightTop, rightCross, center}, color);
   DrawFillPolygon(renderContext, {leftCross, leftBottom, bottomMid, center}, color);
 
-  DrawOutlineLoop(renderContext, {top, rightTop, rightBottom, leftBottom, leftTop}, color);
-  DrawSegment(renderContext, leftCross, rightCross, color);
-  DrawSegment(renderContext, top, bottomMid, color);
+  DrawOutlineLoop(renderContext,
+                  {top, rightTop, rightBottom, leftBottom, leftTop},
+                  outlineColor, outlineWidth);
+  DrawSegment(renderContext, leftCross, rightCross, outlineColor, outlineWidth);
+  DrawSegment(renderContext, top, bottomMid, outlineColor, outlineWidth);
 }
 
 void DrawHoistSymbol(IRenderContext &renderContext, const Support &support,
-                     const RgbColor &color) {
+                     const RgbColor &color, const RgbColor &outlineColor,
+                     float outlineWidth) {
   const HoistShape shape = ResolveHoistShape(support.capacityKg);
   const float cx = support.transform.o[0] * RENDER_SCALE;
   const float cy = support.transform.o[1] * RENDER_SCALE;
@@ -355,19 +372,24 @@ void DrawHoistSymbol(IRenderContext &renderContext, const Support &support,
 
   switch (shape) {
   case HoistShape::Ton2:
-    DrawSquareSymbol(renderContext, cx, cy, z, color);
+    DrawSquareSymbol(renderContext, cx, cy, z, color, outlineColor,
+                     outlineWidth);
     break;
   case HoistShape::Ton1:
-    DrawCircleSymbol(renderContext, cx, cy, z, color);
+    DrawCircleSymbol(renderContext, cx, cy, z, color, outlineColor,
+                     outlineWidth);
     break;
   case HoistShape::TonHalf:
-    DrawTriangleSymbol(renderContext, cx, cy, z, color);
+    DrawTriangleSymbol(renderContext, cx, cy, z, color, outlineColor,
+                       outlineWidth);
     break;
   case HoistShape::TonQuarter:
-    DrawDiamondSymbol(renderContext, cx, cy, z, color);
+    DrawDiamondSymbol(renderContext, cx, cy, z, color, outlineColor,
+                      outlineWidth);
     break;
   case HoistShape::TonEighth:
-    DrawPentagonSymbol(renderContext, cx, cy, z, color);
+    DrawPentagonSymbol(renderContext, cx, cy, z, color, outlineColor,
+                       outlineWidth);
     break;
   }
 }
@@ -383,13 +405,24 @@ void Render(IRenderContext &renderContext, const RenderFrameContext &context) {
   const MvrScene &scene = ConfigManager::Get().GetScene();
   const auto &supports = scene.supports;
   for (const auto &[uuid, support] : supports) {
-    (void)uuid;
     if (!IsLayerVisible(context.hiddenLayers, support.layer))
       continue;
 
     const RgbColor color = ResolveHoistLayerColor(scene, support);
+    const bool isHighlighted = renderContext.IsUuidHighlighted(uuid);
+    const bool isSelected = renderContext.IsUuidSelected(uuid);
+    const bool useOutlineColors =
+        context.is2DViewer && renderContext.IsSelectionOutlineEnabled2D();
+    const RgbColor outlineColor =
+        useOutlineColors ? (isHighlighted ? HighlightColor()
+                                          : (isSelected ? SelectedColor() : color))
+                         : color;
+    const float outlineWidth =
+        useOutlineColors && (isHighlighted || isSelected)
+            ? kSelectionLineWidth
+            : kLineWidth;
 
-    DrawHoistSymbol(renderContext, support, color);
+    DrawHoistSymbol(renderContext, support, color, outlineColor, outlineWidth);
   }
 }
 

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1565,6 +1565,15 @@ bool Viewer3DController::IsSelectionOutlineEnabled2D() const {
   return m_impl->showSelectionOutline2D;
 }
 
+bool Viewer3DController::IsUuidHighlighted(const std::string &uuid) const {
+  return !uuid.empty() && m_impl->highlightUuid == uuid;
+}
+
+bool Viewer3DController::IsUuidSelected(const std::string &uuid) const {
+  return !uuid.empty() &&
+         m_impl->selectedUuids.find(uuid) != m_impl->selectedUuids.end();
+}
+
 bool Viewer3DController::IsCaptureOnly() const { return m_impl->captureOnly; }
 
 ICanvas2D *Viewer3DController::GetCaptureCanvas() const {

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -239,6 +239,8 @@ private:
   bool UseAdaptiveLineProfile() const override;
   bool SkipOutlinesForCurrentFrame() const override;
   bool IsSelectionOutlineEnabled2D() const override;
+  bool IsUuidHighlighted(const std::string &uuid) const override;
+  bool IsUuidSelected(const std::string &uuid) const override;
   bool IsCaptureOnly() const override;
   ICanvas2D *GetCaptureCanvas() const override;
   bool CaptureIncludesGrid() const override;


### PR DESCRIPTION
### Motivation
- Bring Hoists (supports) to feature parity with Fixtures/Trusses in the 2D view so hover highlighting, selection (single/rectangle), and 2D drag-move behave the same and reuse existing selection/update pipeline.
- Avoid duplicating projection/selection math inside `viewer2dpanel.cpp` by extracting hoist-specific hit/rect logic into a small helper module.

### Description
- Added a dedicated helper `viewer2d_support_selection.{h,cpp}` implementing hoist hit-testing and rectangle selection and registered it in `viewer2d/CMakeLists.txt` to keep selection math separate from the main panel code.
- Updated `viewer2dpanel` to support a new `DragTarget::Supports`, to call the new helper for hover/hit tests and rectangle selection, to include supports in `BuildDragTablePositionSnapshots`, and to reuse the existing drag position update worker and `PositionValueUpdate` delivery for live table updates.
- Extended `HoistTablePanel` with `ApplyPositionValueUpdates(...)` and wired table <-> viewer synchronization so table selection changes call `Viewer2DPanel::SetSelectedUuids(...)` and the 2D hover/selection sets the table hover/selection (green hover row and selection behavior matches other tables).
- Kept interactions and naming consistent with the fixtures/trusses flow (reused `PositionValueUpdate` and the drag-update worker), minimizing duplicated logic and preserving the existing selection/undo semantics.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (`OK`).
- Attempted a local build (`cmake --build build -j2`) but no `build` directory was present in this environment so a full compile was not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3e535313083249c078c46967d5109)