### PR TITLE
Silence wx warning popups by routing wx logs to Logger

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -29,6 +29,7 @@
 #include <string>
 #include <wx/stackwalk.h>
 #include <wx/sysopt.h>
+#include <wx/log.h>
 #include <wx/weakref.h>
 #include <wx/wx.h>
 #include <wx/filename.h>
@@ -52,6 +53,30 @@ private:
 };
 
 namespace {
+class PerastageWxLogTarget final : public wxLog {
+public:
+  void DoLogTextAtLevel(wxLogLevel level, const wxString &msg) override {
+    Logger::Level loggerLevel = Logger::Level::Info;
+    switch (level) {
+    case wxLOG_Error:
+    case wxLOG_FatalError:
+      loggerLevel = Logger::Level::Error;
+      break;
+    case wxLOG_Warning:
+      loggerLevel = Logger::Level::Warn;
+      break;
+    case wxLOG_Info:
+    case wxLOG_Message:
+      loggerLevel = Logger::Level::Info;
+      break;
+    default:
+      loggerLevel = Logger::Level::Debug;
+      break;
+    }
+    Logger::Instance().Log(loggerLevel, msg.ToStdString());
+  }
+};
+
 std::string ToLowerAscii(std::string text) {
   std::transform(text.begin(), text.end(), text.begin(), [](unsigned char c) {
     return static_cast<char>(std::tolower(c));
@@ -118,6 +143,9 @@ bool MyApp::OnInit() {
 
   // Initialize logging system (overwrites log file each launch)
   Logger::Instance();
+  if (wxLog *previousTarget = wxLog::SetActiveTarget(new PerastageWxLogTarget())) {
+    delete previousTarget;
+  }
 
   SplashScreen::SetMessage("Creating main window...");
   MainWindow *mainWindow = new MainWindow(app::kName);


### PR DESCRIPTION
### Motivation
- Prevent non-critical wxWidgets warnings from interrupting users with blocking popups while preserving the messages in the application log for diagnosis.
- Centralize wx log handling so UI warnings are non-blocking and follow the existing asynchronous `Logger` filtering and file output.

### Description
- Added `#include <wx/log.h>` and implemented a `PerastageWxLogTarget : public wxLog` in `main.cpp` that maps `wxLogLevel` values to `Logger::Level` and forwards messages to `Logger::Instance().Log(...)`.
- Installed the new log target in `MyApp::OnInit()` immediately after initializing `Logger::Instance()` and safely deleted the previous wx log target to avoid leaks.
- The change is localized to `main.cpp` and only affects how wxWidgets messages are delivered (they are recorded to the app log instead of showing GUI warning popups).

### Testing
- `tests/check_perastage_tree_modules.sh` — OK.
- `tests/check_no_configmanager_get_in_gui.sh` — OK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4296fdc78832486a5329349663da9)