### PR TITLE
Unify support HoistInfo serialization in SceneObject UserData

### DIFF
--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -111,6 +111,12 @@ static std::string TrimAscii(std::string value) {
   return value;
 }
 
+static std::string ToLowerAscii(std::string value) {
+  std::transform(value.begin(), value.end(), value.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return value;
+}
+
 static void LogLegacyPositionUuidWarning(const std::string &message) {
   Logger::Instance().Log(Logger::Level::Warn, message);
 }
@@ -657,7 +663,7 @@ static tinyxml2::XMLElement *FindFirstPerastageUserData(tinyxml2::XMLElement *no
          data = data->NextSiblingElement("Data")) {
       const std::string provider = TrimAscii(
           data->Attribute("provider") ? data->Attribute("provider") : "");
-      if (provider.empty() || ToLowerCopy(provider) == "perastage")
+      if (provider.empty() || ToLowerAscii(provider) == "perastage")
         return ud;
     }
   }
@@ -677,7 +683,7 @@ static tinyxml2::XMLElement *FindOrCreatePerastageDataNode(tinyxml2::XMLDocument
        data = data->NextSiblingElement("Data")) {
     const std::string provider =
         TrimAscii(data->Attribute("provider") ? data->Attribute("provider") : "");
-    if (provider.empty() || ToLowerCopy(provider) == "perastage")
+    if (provider.empty() || ToLowerAscii(provider) == "perastage")
       return data;
   }
 

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -78,8 +78,11 @@ static bool TryComputeAbsoluteDmx(int universe1Based, int address1Based,
                                   int &absoluteOut);
 
 static bool ShouldExportSupportHoistInfo(const Support &support);
+static tinyxml2::XMLElement *FindFirstPerastageUserData(tinyxml2::XMLElement *node);
+static tinyxml2::XMLElement *FindOrCreatePerastageDataNode(tinyxml2::XMLDocument &doc,
+                                                            tinyxml2::XMLElement *node);
 static void AppendSupportHoistInfoUserData(tinyxml2::XMLDocument &doc,
-                                           tinyxml2::XMLElement *supportNode,
+                                           tinyxml2::XMLElement *supportData,
                                            const Support &support);
 static bool IsCanonicalUuidString(const std::string &value);
 static void LogLegacyPositionUuidWarning(const std::string &message);
@@ -644,13 +647,50 @@ static bool ShouldExportSupportHoistInfo(const Support &support) {
          NormalizeHoistDataSource(support.hoistFunctionSource) != "Inherited";
 }
 
-static void AppendSupportHoistInfoUserData(tinyxml2::XMLDocument &doc,
-                                           tinyxml2::XMLElement *supportNode,
-                                           const Support &support) {
-  tinyxml2::XMLElement *ud = doc.NewElement("UserData");
+static tinyxml2::XMLElement *FindFirstPerastageUserData(tinyxml2::XMLElement *node) {
+  if (!node)
+    return nullptr;
+
+  for (tinyxml2::XMLElement *ud = node->FirstChildElement("UserData"); ud;
+       ud = ud->NextSiblingElement("UserData")) {
+    for (tinyxml2::XMLElement *data = ud->FirstChildElement("Data"); data;
+         data = data->NextSiblingElement("Data")) {
+      const std::string provider = TrimAscii(
+          data->Attribute("provider") ? data->Attribute("provider") : "");
+      if (provider.empty() || ToLowerCopy(provider) == "perastage")
+        return ud;
+    }
+  }
+
+  return nullptr;
+}
+
+static tinyxml2::XMLElement *FindOrCreatePerastageDataNode(tinyxml2::XMLDocument &doc,
+                                                            tinyxml2::XMLElement *node) {
+  tinyxml2::XMLElement *ud = FindFirstPerastageUserData(node);
+  if (!ud) {
+    ud = doc.NewElement("UserData");
+    node->InsertEndChild(ud);
+  }
+
+  for (tinyxml2::XMLElement *data = ud->FirstChildElement("Data"); data;
+       data = data->NextSiblingElement("Data")) {
+    const std::string provider =
+        TrimAscii(data->Attribute("provider") ? data->Attribute("provider") : "");
+    if (provider.empty() || ToLowerCopy(provider) == "perastage")
+      return data;
+  }
+
   tinyxml2::XMLElement *data = doc.NewElement("Data");
   data->SetAttribute("provider", kMvrProvider);
   data->SetAttribute("ver", kMvrProviderVersion);
+  ud->InsertEndChild(data);
+  return data;
+}
+
+static void AppendSupportHoistInfoUserData(tinyxml2::XMLDocument &doc,
+                                           tinyxml2::XMLElement *supportData,
+                                           const Support &support) {
   tinyxml2::XMLElement *info = doc.NewElement("HoistInfo");
   info->SetAttribute("uuid", support.uuid.c_str());
 
@@ -717,9 +757,7 @@ static void AppendSupportHoistInfoUserData(tinyxml2::XMLDocument &doc,
   addText("RiggingPointSource", hoistFunctionSource);
   addText("FunctionSource", hoistFunctionSource); // Compatibility alias.
 
-  data->InsertEndChild(info);
-  ud->InsertEndChild(data);
-  supportNode->InsertEndChild(ud);
+  supportData->InsertEndChild(info);
 }
 
 static bool TryComputeAbsoluteDmx(int universe1Based, int address1Based,
@@ -1645,10 +1683,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
       }
     };
 
-    tinyxml2::XMLElement *ud = doc.NewElement("UserData");
-    tinyxml2::XMLElement *data = doc.NewElement("Data");
-    data->SetAttribute("provider", kMvrProvider);
-    data->SetAttribute("ver", kMvrProviderVersion);
+    tinyxml2::XMLElement *data = FindOrCreatePerastageDataNode(doc, se);
     tinyxml2::XMLElement *info = doc.NewElement("SupportInfo");
     info->SetAttribute("uuid", s.uuid.c_str());
     std::string supportGdtfArchivePath = registerGdtfResource(s.uuid, s.gdtfSpec, "");
@@ -1661,8 +1696,6 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
     addSupportInfo("PositionName", s.positionName, info);
     if (info->FirstChild())
       data->InsertEndChild(info);
-    ud->InsertEndChild(data);
-    se->InsertEndChild(ud);
 
     std::string mstr = MatrixUtils::FormatMatrix(s.transform);
     tinyxml2::XMLElement *mat = doc.NewElement("Matrix");
@@ -1670,7 +1703,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
     se->InsertEndChild(mat);
 
     if (ShouldExportSupportHoistInfo(s))
-      AppendSupportHoistInfoUserData(doc, se, s);
+      AppendSupportHoistInfoUserData(doc, data, s);
 
     parent->InsertEndChild(se);
   };

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -486,106 +486,105 @@ static void ReadFixtureCategoryFromUserData(tinyxml2::XMLElement *fixtureNode,
 
 static void ReadSupportHoistInfoFromUserData(tinyxml2::XMLElement *supportNode,
                                              Support &support) {
-  tinyxml2::XMLElement *ud = supportNode->FirstChildElement("UserData");
-  if (!ud)
-    return;
+  for (tinyxml2::XMLElement *ud = supportNode->FirstChildElement("UserData"); ud;
+       ud = ud->NextSiblingElement("UserData")) {
+    for (tinyxml2::XMLElement *data = ud->FirstChildElement("Data"); data;
+         data = data->NextSiblingElement("Data")) {
+      tinyxml2::XMLElement *info = data->FirstChildElement("HoistInfo");
+      if (!info)
+        info = data->FirstChildElement("MotorInfo"); // Legacy block name.
+      if (!info)
+        continue;
 
-  for (tinyxml2::XMLElement *data = ud->FirstChildElement("Data"); data;
-       data = data->NextSiblingElement("Data")) {
-    tinyxml2::XMLElement *info = data->FirstChildElement("HoistInfo");
-    if (!info)
-      info = data->FirstChildElement("MotorInfo"); // Legacy block name.
-    if (!info)
-      continue;
-
-    auto readFloat = [&](const char *name, float &out) {
-      if (tinyxml2::XMLElement *el = info->FirstChildElement(name)) {
-        if (const char *txt = el->GetText()) {
-          float parsed = 0.0f;
-          if (TryParseFloat(txt, parsed))
-            out = parsed;
+      auto readFloat = [&](const char *name, float &out) {
+        if (tinyxml2::XMLElement *el = info->FirstChildElement(name)) {
+          if (const char *txt = el->GetText()) {
+            float parsed = 0.0f;
+            if (TryParseFloat(txt, parsed))
+              out = parsed;
+          }
         }
+      };
+      auto readText = [&](const char *name) -> std::string {
+        if (tinyxml2::XMLElement *el = info->FirstChildElement(name)) {
+          if (const char *txt = el->GetText())
+            return Trim(txt);
+        }
+        return {};
+      };
+
+      readFloat("Capacity", support.capacityKg);
+      readFloat("Weight", support.weightKg);
+      readFloat("Load", support.loadKg);
+
+      std::string hoistFunction = readText("RiggingPoint"); // Canonical in new schema.
+      if (hoistFunction.empty())
+        hoistFunction = readText("Function");
+      if (!hoistFunction.empty())
+        support.hoistFunction = NormalizeHoistFunction(hoistFunction);
+
+      const std::string motorName = readText("MotorName");
+      if (!motorName.empty())
+        support.motorName = motorName;
+      const std::string manufacturer = readText("MotorManufacturer");
+      if (!manufacturer.empty())
+        support.motorManufacturer = manufacturer;
+      const std::string model = readText("MotorModel");
+      if (!model.empty())
+        support.motorModel = model;
+      const std::string fixtureUuid = readText("MotorFixtureUuid");
+      if (!fixtureUuid.empty())
+        support.motorFixtureUuid = fixtureUuid;
+
+      const std::string useDefaults = ToLowerCopy(readText("UseMotorDefaults"));
+      if (!useDefaults.empty()) {
+        support.useMotorDefaults =
+            !(useDefaults == "false" || useDefaults == "0" || useDefaults == "no");
       }
-    };
-    auto readText = [&](const char *name) -> std::string {
-      if (tinyxml2::XMLElement *el = info->FirstChildElement(name)) {
-        if (const char *txt = el->GetText())
-          return Trim(txt);
+
+      const std::string dummyPreset = readText("DummyPreset");
+      if (!dummyPreset.empty())
+        support.dummyPreset = dummyPreset;
+      const std::string dummyProfileId = readText("DummyProfileId");
+      if (!dummyProfileId.empty())
+        support.dummyProfileId = dummyProfileId;
+
+      std::string source = readText("ValueSource");
+      if (source.empty())
+        source = readText("DataSource"); // Legacy key.
+      if (!source.empty())
+        support.hoistDataSource = NormalizeHoistDataSource(source);
+
+      const std::string motorNameSource = readText("MotorNameSource");
+      if (!motorNameSource.empty())
+        support.motorNameSource = NormalizeHoistDataSource(motorNameSource);
+
+      const std::string motorManufacturerSource =
+          readText("MotorManufacturerSource");
+      if (!motorManufacturerSource.empty()) {
+        support.motorManufacturerSource =
+            NormalizeHoistDataSource(motorManufacturerSource);
       }
-      return {};
-    };
 
-    readFloat("Capacity", support.capacityKg);
-    readFloat("Weight", support.weightKg);
-    readFloat("Load", support.loadKg);
+      const std::string motorModelSource = readText("MotorModelSource");
+      if (!motorModelSource.empty())
+        support.motorModelSource = NormalizeHoistDataSource(motorModelSource);
 
-    std::string hoistFunction = readText("RiggingPoint"); // Canonical in new schema.
-    if (hoistFunction.empty())
-      hoistFunction = readText("Function");
-    if (!hoistFunction.empty())
-      support.hoistFunction = NormalizeHoistFunction(hoistFunction);
+      const std::string capacitySource = readText("CapacitySource");
+      if (!capacitySource.empty())
+        support.capacitySource = NormalizeHoistDataSource(capacitySource);
 
-    const std::string motorName = readText("MotorName");
-    if (!motorName.empty())
-      support.motorName = motorName;
-    const std::string manufacturer = readText("MotorManufacturer");
-    if (!manufacturer.empty())
-      support.motorManufacturer = manufacturer;
-    const std::string model = readText("MotorModel");
-    if (!model.empty())
-      support.motorModel = model;
-    const std::string fixtureUuid = readText("MotorFixtureUuid");
-    if (!fixtureUuid.empty())
-      support.motorFixtureUuid = fixtureUuid;
+      const std::string weightSource = readText("WeightSource");
+      if (!weightSource.empty())
+        support.weightSource = NormalizeHoistDataSource(weightSource);
 
-    const std::string useDefaults = ToLowerCopy(readText("UseMotorDefaults"));
-    if (!useDefaults.empty()) {
-      support.useMotorDefaults =
-          !(useDefaults == "false" || useDefaults == "0" || useDefaults == "no");
-    }
-
-    const std::string dummyPreset = readText("DummyPreset");
-    if (!dummyPreset.empty())
-      support.dummyPreset = dummyPreset;
-    const std::string dummyProfileId = readText("DummyProfileId");
-    if (!dummyProfileId.empty())
-      support.dummyProfileId = dummyProfileId;
-
-    std::string source = readText("ValueSource");
-    if (source.empty())
-      source = readText("DataSource"); // Legacy key.
-    if (!source.empty())
-      support.hoistDataSource = NormalizeHoistDataSource(source);
-
-    const std::string motorNameSource = readText("MotorNameSource");
-    if (!motorNameSource.empty())
-      support.motorNameSource = NormalizeHoistDataSource(motorNameSource);
-
-    const std::string motorManufacturerSource =
-        readText("MotorManufacturerSource");
-    if (!motorManufacturerSource.empty()) {
-      support.motorManufacturerSource =
-          NormalizeHoistDataSource(motorManufacturerSource);
-    }
-
-    const std::string motorModelSource = readText("MotorModelSource");
-    if (!motorModelSource.empty())
-      support.motorModelSource = NormalizeHoistDataSource(motorModelSource);
-
-    const std::string capacitySource = readText("CapacitySource");
-    if (!capacitySource.empty())
-      support.capacitySource = NormalizeHoistDataSource(capacitySource);
-
-    const std::string weightSource = readText("WeightSource");
-    if (!weightSource.empty())
-      support.weightSource = NormalizeHoistDataSource(weightSource);
-
-    std::string hoistFunctionSource = readText("RiggingPointSource");
-    if (hoistFunctionSource.empty())
-      hoistFunctionSource = readText("FunctionSource");
-    if (!hoistFunctionSource.empty()) {
-      support.hoistFunctionSource =
-          NormalizeHoistDataSource(hoistFunctionSource);
+      std::string hoistFunctionSource = readText("RiggingPointSource");
+      if (hoistFunctionSource.empty())
+        hoistFunctionSource = readText("FunctionSource");
+      if (!hoistFunctionSource.empty()) {
+        support.hoistFunctionSource =
+            NormalizeHoistDataSource(hoistFunctionSource);
+      }
     }
   }
 }
@@ -1762,7 +1761,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
           support.name = obj.name;
           support.layer = obj.layer;
           support.transform = obj.transform;
-          if (tinyxml2::XMLElement *ud = node->FirstChildElement("UserData")) {
+          for (tinyxml2::XMLElement *ud = node->FirstChildElement("UserData"); ud;
+               ud = ud->NextSiblingElement("UserData")) {
             for (tinyxml2::XMLElement *data = ud->FirstChildElement("Data"); data;
                  data = data->NextSiblingElement("Data")) {
               const std::string provider = ToLowerCopy(

--- a/tests/mvr_exporter_compliance_test.cpp
+++ b/tests/mvr_exporter_compliance_test.cpp
@@ -470,10 +470,16 @@ int main() {
   assert(std::string(supportSceneObject->Attribute("geometryType")) == "support");
   auto *supportUserData = supportSceneObject->FirstChildElement("UserData");
   assert(supportUserData != nullptr);
+  assert(supportUserData->NextSiblingElement("UserData") == nullptr);
   auto *supportData = supportUserData->FirstChildElement("Data");
   assert(supportData != nullptr);
   auto *supportInfo = supportData->FirstChildElement("SupportInfo");
   assert(supportInfo != nullptr);
+  auto *hoistInfo = supportData->FirstChildElement("HoistInfo");
+  assert(hoistInfo != nullptr);
+  auto *capacityNode = hoistInfo->FirstChildElement("Capacity");
+  assert(capacityNode != nullptr && capacityNode->GetText() != nullptr &&
+         std::string(capacityNode->GetText()) == "1000.000000");
   auto *supportPositionNode = supportInfo->FirstChildElement("Position");
   assert(supportPositionNode != nullptr && supportPositionNode->GetText() != nullptr);
   assert(CanonicalizeUuid(supportPositionNode->GetText()) ==

--- a/tests/mvr_support_userdata_roundtrip_test.cpp
+++ b/tests/mvr_support_userdata_roundtrip_test.cpp
@@ -92,6 +92,14 @@ int main() {
   manual.loadKg = 410.0f;
   manual.hoistFunction = "Audio";
   manual.motorName = "ChainMaster D8+";
+  manual.motorNameSource = "Manual";
+  manual.motorManufacturer = "ChainMaster";
+  manual.motorManufacturerSource = "Manual";
+  manual.motorModel = "D8+";
+  manual.motorModelSource = "Manual";
+  manual.capacitySource = "Manual";
+  manual.weightSource = "Manual";
+  manual.hoistFunctionSource = "Manual";
   scene.supports[manual.uuid] = manual;
 
   const std::filesystem::path mvrPath = tempDir / "support_roundtrip.mvr";
@@ -123,6 +131,15 @@ int main() {
   assert(loadedManual.weightKg == 61.0f);
   assert(loadedManual.loadKg == 410.0f);
   assert(loadedManual.hoistFunction == "Audio");
+  assert(loadedManual.motorName == "ChainMaster D8+");
+  assert(loadedManual.motorManufacturer == "ChainMaster");
+  assert(loadedManual.motorModel == "D8+");
+  assert(loadedManual.motorNameSource == "Manual");
+  assert(loadedManual.motorManufacturerSource == "Manual");
+  assert(loadedManual.motorModelSource == "Manual");
+  assert(loadedManual.capacitySource == "Manual");
+  assert(loadedManual.weightSource == "Manual");
+  assert(loadedManual.hoistFunctionSource == "Manual");
 
 
   const auto &loadedInheritedDefaults = loaded.at("sup-inherited-defaults");


### PR DESCRIPTION
### Motivation

- Avoid emitting multiple sibling `UserData` nodes for the same `SceneObject` support by consolidating Perastage custom fields in a single `UserData/Data` block. 
- Make MVR import more robust by reading hoist/support metadata from all `UserData` siblings when present so legacy/third-party nodes do not hide Perastage data. 
- Preserve non-standard Perastage fields while not modifying or breaking official MVR/GDTF nodes by keeping custom data inside `Data` elements with `provider="Perastage"`.

### Description

- Added helpers `FindFirstPerastageUserData(...)` and `FindOrCreatePerastageDataNode(...)` and changed `AppendSupportHoistInfoUserData(...)` to accept an existing `Data` node and append a `HoistInfo` child there. 
- Modified exporter to call `FindOrCreatePerastageDataNode(...)` so `SupportInfo` and `HoistInfo` are written into the same Perastage `UserData/Data` block instead of creating a new sibling `UserData`. 
- Hardened importer parsing by iterating `UserData` siblings (`FirstChildElement("UserData")` + `NextSiblingElement("UserData")`) in both `ReadSupportHoistInfoFromUserData(...)` and the `parseSceneObj` reconstruction path so all Perastage `Data` blocks are considered. 
- Updated tests `tests/mvr_support_userdata_roundtrip_test.cpp` and `tests/mvr_exporter_compliance_test.cpp` to assert a single `UserData` for support SceneObjects and to verify that `capacityKg`, `weightKg`, `loadKg`, `hoistFunction`, `hoistDataSource` and per-field sources survive the roundtrip.

### Testing

- Ran `tests/check_perastage_tree_modules.sh` and it succeeded. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded. 
- Attempted configuration with `cmake --preset wsl-x64-debug` in the local container which failed due to missing system wxWidgets development packages (environment issue), not due to code changes; unit tests modified in this PR should be executed by CI where full deps are available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c43646e8348324aec4c3c364bf5f21)