### PR TITLE
Add Units preferences and trigger global UI refresh on unit changes

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -165,6 +165,10 @@ ConfigManager::ConfigManager() {
   RegisterVariable("label_max_trusses", "float", 150.0f, 0.0f, 5000.0f);
   RegisterVariable("label_max_objects", "float", 150.0f, 0.0f, 5000.0f);
   LoadUserConfig();
+  if (!HasKey("ui_distance_unit_system"))
+    SetValue("ui_distance_unit_system", "metric");
+  if (!HasKey("ui_weight_unit_system"))
+    SetValue("ui_weight_unit_system", "metric");
   if (!HasKey("rider_autopatch"))
     SetValue("rider_autopatch", "1");
   if (!HasKey("rider_layer_mode"))
@@ -435,6 +439,10 @@ void ConfigManager::Reset() {
   RevisionGuard guard(*this);
   preferencesStore.ClearValues();
   projectSession.GetScene().Clear();
+  if (!HasKey("ui_distance_unit_system"))
+    SetValue("ui_distance_unit_system", "metric");
+  if (!HasKey("ui_weight_unit_system"))
+    SetValue("ui_weight_unit_system", "metric");
   if (!HasKey("rider_autopatch"))
     SetValue("rider_autopatch", "1");
   ApplyDefaults();

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -139,6 +139,27 @@ MainWindow *MainWindow::Instance() { return s_instance; }
 void MainWindow::SetInstance(MainWindow *inst) { s_instance = inst; }
 
 namespace {
+enum class UiUnitSystem { Metric, Imperial };
+
+UiUnitSystem ResolveDistanceUnitSystem(ConfigManager &cfg) {
+  const auto value = cfg.GetValue("ui_distance_unit_system");
+  if (value && *value == "imperial")
+    return UiUnitSystem::Imperial;
+  return UiUnitSystem::Metric;
+}
+
+double ConvertMetersToDistanceUnit(double meters, UiUnitSystem unitSystem) {
+  if (unitSystem == UiUnitSystem::Imperial) {
+    constexpr double kMetersToFeet = 3.280839895;
+    return meters * kMetersToFeet;
+  }
+  return meters;
+}
+
+const char *DistanceUnitSuffix(UiUnitSystem unitSystem) {
+  return unitSystem == UiUnitSystem::Imperial ? "ft" : "m";
+}
+
 void PersistFixtureTypeAutoColors(ConfigManager &configManager) {
   auto &scene = configManager.GetScene();
   for (auto &[uuid, fixture] : scene.fixtures) {
@@ -261,6 +282,7 @@ EVT_MENU(ID_Select_Supports, MainWindow::OnSelectSupports)
 EVT_MENU(ID_Select_Objects, MainWindow::OnSelectObjects)
 EVT_MENU(ID_Edit_Preferences, MainWindow::OnPreferences)
 EVT_COMMAND(wxID_ANY, EVT_PROJECT_LOADED, MainWindow::OnProjectLoaded)
+EVT_COMMAND(wxID_ANY, EVT_UI_UNITS_CHANGED, MainWindow::OnUiUnitsChanged)
 EVT_COMMAND(wxID_ANY, EVT_LAYOUT_SELECTED, MainWindow::OnLayoutSelected)
 EVT_COMMAND(wxID_ANY, EVT_LAYOUT_VIEW_EDIT, MainWindow::OnLayoutViewEdit)
 EVT_COMMAND(wxID_ANY, EVT_LAYOUT_VIEW_SELECTED, MainWindow::OnLayoutViewSelected)
@@ -442,17 +464,28 @@ void MainWindow::UpdateCursorWorldPositionInStatusBar(
     return;
   }
 
+  ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+  const UiUnitSystem unitSystem = ResolveDistanceUnitSystem(cfg);
   std::ostringstream stream;
-  stream << std::fixed << std::setprecision(2) << "X: " << (*positionMeters)[0]
-         << " m  Y: " << (*positionMeters)[1] << " m  Z: "
-         << (*positionMeters)[2] << " m";
+  stream << std::fixed << std::setprecision(2) << "X: "
+         << ConvertMetersToDistanceUnit((*positionMeters)[0], unitSystem) << " "
+         << DistanceUnitSuffix(unitSystem) << "  Y: "
+         << ConvertMetersToDistanceUnit((*positionMeters)[1], unitSystem) << " "
+         << DistanceUnitSuffix(unitSystem) << "  Z: "
+         << ConvertMetersToDistanceUnit((*positionMeters)[2], unitSystem) << " "
+         << DistanceUnitSuffix(unitSystem);
   SetStatusText(wxString::FromUTF8(stream.str()), 1);
 }
 
 void MainWindow::ClearCursorWorldPositionInStatusBar() {
   if (!GetStatusBar())
     return;
-  SetStatusText("X: -- m  Y: -- m  Z: -- m", 1);
+  ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+  const char *unitSuffix = DistanceUnitSuffix(ResolveDistanceUnitSystem(cfg));
+  SetStatusText(
+      wxString::Format("X: -- %s  Y: -- %s  Z: -- %s", unitSuffix, unitSuffix,
+                       unitSuffix),
+      1);
 }
 
 void MainWindow::Ensure2DViewportAvailable() { Ensure2DViewport(); }
@@ -1072,6 +1105,10 @@ void MainWindow::OnProjectLoaded(wxCommandEvent &event) {
   SetStartupProjectLoadPending(false);
 }
 
+void MainWindow::OnUiUnitsChanged(wxCommandEvent &WXUNUSED(event)) {
+  RefreshAfterUnitSystemChange();
+}
+
 void MainWindow::OnNotebookPageChanged(wxBookCtrlEvent &event) {
   RefreshSummary();
   event.Skip();
@@ -1119,3 +1156,12 @@ void MainWindow::RefreshAfterFixtureSymbolUpdate() {
 }
 
 void MainWindow::RefreshAfterToolSceneUpdate() { RefreshAfterSceneChange(); }
+
+void MainWindow::RefreshAfterUnitSystemChange() {
+  RefreshAfterSceneChange();
+  if (layoutViewerPanel) {
+    layoutViewerPanel->RefreshLegendData();
+    layoutViewerPanel->Refresh();
+  }
+  ClearCursorWorldPositionInStatusBar();
+}

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -93,6 +93,7 @@ private:
   void Ensure3DViewport();
   void Ensure2DViewport();
   void OnProjectLoaded(wxCommandEvent &event);
+  void OnUiUnitsChanged(wxCommandEvent &event);
 
   std::string currentProjectPath;
   wxString currentProjectDisplayName;
@@ -171,6 +172,7 @@ private:
   void OnNotebookPageChanged(wxBookCtrlEvent &event); // Update summary panel
   void RefreshSummary();                              // Refresh summary counts
   void RefreshAfterSceneChange(bool refreshViewport = true);
+  void RefreshAfterUnitSystemChange();
   void LockViewportInteraction();
   void UnlockViewportInteraction();
   void RefreshRigging();                              // Refresh rigging summary

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -948,9 +948,7 @@ void MainWindow::OnSelectObjects(wxCommandEvent &WXUNUSED(event)) {
 
 void MainWindow::OnPreferences(wxCommandEvent &WXUNUSED(event)) {
   PreferencesDialog dlg(this);
-  if (dlg.ShowModal() == wxID_OK) {
-    GetDefaultGuiConfigServices().LegacyConfigManager().SaveUserConfig();
-  }
+  dlg.ShowModal();
 }
 
 void MainWindow::OnUndo(wxCommandEvent &WXUNUSED(event)) {

--- a/gui/preferencesdialog.cpp
+++ b/gui/preferencesdialog.cpp
@@ -18,9 +18,12 @@
 #include "preferencesdialog.h"
 #include "configmanager.h"
 #include "guiconfigservices.h"
-#include <wx/notebook.h>
 #include <wx/checkbox.h>
+#include <wx/choice.h>
+#include <wx/notebook.h>
 #include <wx/radiobut.h>
+
+wxDEFINE_EVENT(EVT_UI_UNITS_CHANGED, wxCommandEvent);
 
 PreferencesDialog::PreferencesDialog(wxWindow *parent)
     : wxDialog(parent, wxID_ANY, "Preferences", wxDefaultPosition,
@@ -82,8 +85,40 @@ PreferencesDialog::PreferencesDialog(wxWindow *parent)
   }
   riderSizer->Add(grid, 1, wxALL | wxEXPAND, 10);
   riderPanel->SetSizer(riderSizer);
-
   book->AddPage(riderPanel, "Rider Import");
+
+  // Units page
+  wxPanel *unitsPanel = new wxPanel(book);
+  wxBoxSizer *unitsSizer = new wxBoxSizer(wxVERTICAL);
+  wxFlexGridSizer *unitsGrid = new wxFlexGridSizer(2, 2, 10, 10);
+  unitsGrid->AddGrowableCol(1, 1);
+
+  unitsGrid->Add(new wxStaticText(unitsPanel, wxID_ANY, "Distance system:"), 0,
+                 wxALIGN_CENTER_VERTICAL);
+  distanceUnitChoice = new wxChoice(unitsPanel, wxID_ANY);
+  distanceUnitChoice->Append("Metric");
+  distanceUnitChoice->Append("Imperial");
+  auto distanceUnitValue = cfg.GetValue("ui_distance_unit_system");
+  const bool hasImperialDistance =
+      distanceUnitValue && *distanceUnitValue == "imperial";
+  distanceUnitChoice->SetSelection(hasImperialDistance ? 1 : 0);
+  initialDistanceUnit = distanceUnitChoice->GetStringSelection();
+  unitsGrid->Add(distanceUnitChoice, 1, wxEXPAND);
+
+  unitsGrid->Add(new wxStaticText(unitsPanel, wxID_ANY, "Weight system:"), 0,
+                 wxALIGN_CENTER_VERTICAL);
+  weightUnitChoice = new wxChoice(unitsPanel, wxID_ANY);
+  weightUnitChoice->Append("Metric");
+  weightUnitChoice->Append("Imperial");
+  auto weightUnitValue = cfg.GetValue("ui_weight_unit_system");
+  const bool hasImperialWeight = weightUnitValue && *weightUnitValue == "imperial";
+  weightUnitChoice->SetSelection(hasImperialWeight ? 1 : 0);
+  initialWeightUnit = weightUnitChoice->GetStringSelection();
+  unitsGrid->Add(weightUnitChoice, 1, wxEXPAND);
+
+  unitsSizer->Add(unitsGrid, 0, wxALL | wxEXPAND, 10);
+  unitsPanel->SetSizer(unitsSizer);
+  book->AddPage(unitsPanel, "Units");
 
   topSizer->Add(book, 1, wxEXPAND | wxALL, 5);
   topSizer->Add(CreateSeparatedButtonSizer(wxOK | wxCANCEL | wxAPPLY), 0,
@@ -93,26 +128,52 @@ PreferencesDialog::PreferencesDialog(wxWindow *parent)
 
   Bind(wxEVT_BUTTON, [this](wxCommandEvent &evt) {
     if (evt.GetId() == wxID_OK || evt.GetId() == wxID_APPLY) {
-      ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
-      for (int i = 0; i < 6; ++i) {
-        double v = 0.0;
-        lxHeightCtrls[i]->GetValue().ToDouble(&v);
-        cfg.SetFloat("rider_lx" + std::to_string(i + 1) + "_height",
-                     static_cast<float>(v));
-        double p = 0.0;
-        lxPosCtrls[i]->GetValue().ToDouble(&p);
-        cfg.SetFloat("rider_lx" + std::to_string(i + 1) + "_pos",
-                     static_cast<float>(p));
-        double m = 0.0;
-        lxMarginCtrls[i]->GetValue().ToDouble(&m);
-        cfg.SetFloat("rider_lx" + std::to_string(i + 1) + "_margin",
-                     static_cast<float>(m));
+      if (ApplyPreferences()) {
+        NotifyUnitsChanged();
       }
-      cfg.SetValue("rider_autopatch", autopatchCheck->GetValue() ? "1" : "0");
-      cfg.SetValue("rider_layer_mode",
-                   layerTypeRadio->GetValue() ? "type" : "position");
-
     }
     evt.Skip();
   });
+}
+
+bool PreferencesDialog::ApplyPreferences() {
+  ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+  for (int i = 0; i < 6; ++i) {
+    double v = 0.0;
+    lxHeightCtrls[i]->GetValue().ToDouble(&v);
+    cfg.SetFloat("rider_lx" + std::to_string(i + 1) + "_height",
+                 static_cast<float>(v));
+    double p = 0.0;
+    lxPosCtrls[i]->GetValue().ToDouble(&p);
+    cfg.SetFloat("rider_lx" + std::to_string(i + 1) + "_pos",
+                 static_cast<float>(p));
+    double m = 0.0;
+    lxMarginCtrls[i]->GetValue().ToDouble(&m);
+    cfg.SetFloat("rider_lx" + std::to_string(i + 1) + "_margin",
+                 static_cast<float>(m));
+  }
+
+  cfg.SetValue("rider_autopatch", autopatchCheck->GetValue() ? "1" : "0");
+  cfg.SetValue("rider_layer_mode", layerTypeRadio->GetValue() ? "type"
+                                                               : "position");
+  cfg.SetValue("ui_distance_unit_system",
+               distanceUnitChoice->GetSelection() == 1 ? "imperial"
+                                                       : "metric");
+  cfg.SetValue("ui_weight_unit_system",
+               weightUnitChoice->GetSelection() == 1 ? "imperial" : "metric");
+  return cfg.SaveUserConfig();
+}
+
+void PreferencesDialog::NotifyUnitsChanged() {
+  const wxString currentDistanceUnit = distanceUnitChoice->GetStringSelection();
+  const wxString currentWeightUnit = weightUnitChoice->GetStringSelection();
+  if (currentDistanceUnit == initialDistanceUnit &&
+      currentWeightUnit == initialWeightUnit) {
+    return;
+  }
+
+  initialDistanceUnit = currentDistanceUnit;
+  initialWeightUnit = currentWeightUnit;
+  wxCommandEvent event(EVT_UI_UNITS_CHANGED);
+  wxPostEvent(GetParent(), event);
 }

--- a/gui/preferencesdialog.h
+++ b/gui/preferencesdialog.h
@@ -20,15 +20,24 @@
 #include <array>
 #include <wx/wx.h>
 
+wxDECLARE_EVENT(EVT_UI_UNITS_CHANGED, wxCommandEvent);
+
 class PreferencesDialog : public wxDialog {
 public:
   PreferencesDialog(wxWindow *parent);
 
 private:
+  bool ApplyPreferences();
+  void NotifyUnitsChanged();
+
   std::array<wxTextCtrl *, 6> lxHeightCtrls{};
   std::array<wxTextCtrl *, 6> lxPosCtrls{};
   std::array<wxTextCtrl *, 6> lxMarginCtrls{};
   wxCheckBox *autopatchCheck = nullptr;
   wxRadioButton *layerPosRadio = nullptr;
   wxRadioButton *layerTypeRadio = nullptr;
+  wxChoice *distanceUnitChoice = nullptr;
+  wxChoice *weightUnitChoice = nullptr;
+  wxString initialDistanceUnit;
+  wxString initialWeightUnit;
 };


### PR DESCRIPTION
### Motivation

- Provide users a way to choose distance and weight unit systems in the Preferences UI so labels, tables and the status bar use the selected units.
- Persist selected unit systems in the user config and restore them on startup and after resets.
- Emit a global UI notification when units change so tables, viewports, legends and the status bar re-render consistently.

### Description

- Added a new `Units` page to the Preferences dialog with `Distance system` and `Weight system` selectors and initialized them from `ConfigManager` values in `gui/preferencesdialog.cpp` and `gui/preferencesdialog.h`.
- Persisted new keys `ui_distance_unit_system` and `ui_weight_unit_system` on `Apply/OK` via `SaveUserConfig()` in the Preferences dialog (`ApplyPreferences()`), and registered defaults for these keys in `ConfigManager` initialization and `Reset()` (`core/configmanager.cpp`).
- Introduced a UI event `EVT_UI_UNITS_CHANGED` emitted from the dialog when the unit selection changes and wired it to `MainWindow` (`gui/preferencesdialog.cpp`, `gui/preferencesdialog.h`, `gui/mainwindow.cpp`, `gui/mainwindow.h`).
- Implemented `RefreshAfterUnitSystemChange()` in `MainWindow` which triggers table/viewport refreshes and legend re-render, and updated `UpdateCursorWorldPositionInStatusBar()` / `ClearCursorWorldPositionInStatusBar()` to format coordinates according to the selected distance unit with conversion helpers `ResolveDistanceUnitSystem`, `ConvertMetersToDistanceUnit` and `DistanceUnitSuffix`.
- Simplified `OnPreferences` to rely on the dialog for saving preferences (`gui/mainwindow_menu.cpp`).

### Testing

- Ran `tests/check_perastage_tree_modules.sh`, which passed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c43ee0240c8324abc8deec8120d1c9)