### PR TITLE
Unify UI unit parsing/formatting around canonical mm/kg values

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -32,6 +32,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/trussdictionary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/truss_gdtf_builder.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/trussloader.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ui_unit_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/uuidutils.cpp
 )
 

--- a/core/ui_unit_utils.cpp
+++ b/core/ui_unit_utils.cpp
@@ -1,0 +1,129 @@
+#include "ui_unit_utils.h"
+
+#include <charconv>
+#include <cmath>
+#include <iomanip>
+#include <sstream>
+
+namespace UiUnitUtils {
+namespace {
+
+constexpr double kMillimetersPerMeter = 1000.0;
+constexpr double kMillimetersPerFoot = 304.8;
+constexpr double kPoundsPerKilogram = 2.2046226218487757;
+
+int DistanceDecimalsFor(ValueFormatContext context) {
+  switch (context) {
+  case ValueFormatContext::Table:
+    return 3;
+  case ValueFormatContext::Label:
+    return 2;
+  case ValueFormatContext::Inspector:
+    return 4;
+  }
+  return 3;
+}
+
+int WeightDecimalsFor(ValueFormatContext context) {
+  switch (context) {
+  case ValueFormatContext::Table:
+    return 2;
+  case ValueFormatContext::Label:
+    return 1;
+  case ValueFormatContext::Inspector:
+    return 3;
+  }
+  return 2;
+}
+
+std::optional<double> ParseDouble(const std::string &rawValue) {
+  std::string trimmed = rawValue;
+  const auto begin = trimmed.find_first_not_of(" \t\r\n");
+  if (begin == std::string::npos)
+    return std::nullopt;
+  const auto end = trimmed.find_last_not_of(" \t\r\n");
+  trimmed = trimmed.substr(begin, end - begin + 1);
+
+  double value = 0.0;
+  const char *start = trimmed.data();
+  const char *finish = trimmed.data() + trimmed.size();
+  auto result = std::from_chars(start, finish, value);
+  if (result.ec != std::errc() || result.ptr != finish)
+    return std::nullopt;
+  return value;
+}
+
+std::string FormatNumber(double value, int decimals) {
+  std::ostringstream stream;
+  stream << std::fixed << std::setprecision(decimals) << value;
+  return stream.str();
+}
+
+} // namespace
+
+DistanceUnitSystem ParseDistanceUnitSystem(const std::optional<std::string> &rawValue) {
+  if (rawValue && *rawValue == "imperial")
+    return DistanceUnitSystem::Imperial;
+  return DistanceUnitSystem::Metric;
+}
+
+WeightUnitSystem ParseWeightUnitSystem(const std::optional<std::string> &rawValue) {
+  if (rawValue && *rawValue == "imperial")
+    return WeightUnitSystem::Imperial;
+  return WeightUnitSystem::Metric;
+}
+
+std::string DistanceUnitSuffix(DistanceUnitSystem unitSystem) {
+  return unitSystem == DistanceUnitSystem::Imperial ? "ft" : "m";
+}
+
+std::string WeightUnitSuffix(WeightUnitSystem unitSystem) {
+  return unitSystem == WeightUnitSystem::Imperial ? "lb" : "kg";
+}
+
+std::string FormatDistanceFromMillimeters(double valueMm,
+                                          DistanceUnitSystem unitSystem,
+                                          ValueFormatContext context) {
+  const double displayValue =
+      unitSystem == DistanceUnitSystem::Imperial ? valueMm / kMillimetersPerFoot
+                                                 : valueMm / kMillimetersPerMeter;
+  return FormatNumber(displayValue, DistanceDecimalsFor(context));
+}
+
+std::string FormatWeightFromKilograms(double valueKg,
+                                      WeightUnitSystem unitSystem,
+                                      ValueFormatContext context) {
+  const double displayValue =
+      unitSystem == WeightUnitSystem::Imperial ? valueKg * kPoundsPerKilogram
+                                               : valueKg;
+  return FormatNumber(displayValue, WeightDecimalsFor(context));
+}
+
+std::optional<double> ParseDistanceToMillimeters(const std::string &rawValue,
+                                                 DistanceUnitSystem unitSystem) {
+  const auto parsed = ParseDouble(rawValue);
+  if (!parsed.has_value())
+    return std::nullopt;
+  return unitSystem == DistanceUnitSystem::Imperial
+             ? *parsed * kMillimetersPerFoot
+             : *parsed * kMillimetersPerMeter;
+}
+
+std::optional<double> ParseWeightToKilograms(const std::string &rawValue,
+                                             WeightUnitSystem unitSystem) {
+  const auto parsed = ParseDouble(rawValue);
+  if (!parsed.has_value())
+    return std::nullopt;
+  return unitSystem == WeightUnitSystem::Imperial ? *parsed / kPoundsPerKilogram
+                                                  : *parsed;
+}
+
+bool NearlyEqualDistanceMillimeters(double lhsMm, double rhsMm, double toleranceMm) {
+  return std::abs(lhsMm - rhsMm) <= toleranceMm;
+}
+
+bool NearlyEqualWeightKilograms(double lhsKg, double rhsKg, double toleranceKg) {
+  return std::abs(lhsKg - rhsKg) <= toleranceKg;
+}
+
+} // namespace UiUnitUtils

--- a/core/ui_unit_utils.h
+++ b/core/ui_unit_utils.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+namespace UiUnitUtils {
+
+enum class DistanceUnitSystem { Metric, Imperial };
+enum class WeightUnitSystem { Metric, Imperial };
+enum class ValueFormatContext { Table, Label, Inspector };
+
+DistanceUnitSystem ParseDistanceUnitSystem(const std::optional<std::string> &rawValue);
+WeightUnitSystem ParseWeightUnitSystem(const std::optional<std::string> &rawValue);
+
+std::string DistanceUnitSuffix(DistanceUnitSystem unitSystem);
+std::string WeightUnitSuffix(WeightUnitSystem unitSystem);
+
+std::string FormatDistanceFromMillimeters(double valueMm,
+                                          DistanceUnitSystem unitSystem,
+                                          ValueFormatContext context);
+std::string FormatWeightFromKilograms(double valueKg,
+                                      WeightUnitSystem unitSystem,
+                                      ValueFormatContext context);
+
+std::optional<double> ParseDistanceToMillimeters(const std::string &rawValue,
+                                                 DistanceUnitSystem unitSystem);
+std::optional<double> ParseWeightToKilograms(const std::string &rawValue,
+                                             WeightUnitSystem unitSystem);
+
+bool NearlyEqualDistanceMillimeters(double lhsMm, double rhsMm, double toleranceMm);
+bool NearlyEqualWeightKilograms(double lhsKg, double rhsKg, double toleranceKg);
+
+} // namespace UiUnitUtils

--- a/gui/fixturetable/fixture_table_edit_service.cpp
+++ b/gui/fixturetable/fixture_table_edit_service.cpp
@@ -7,6 +7,7 @@
 #include "gdtf_fixture_category.h"
 
 #include <algorithm>
+#include <cmath>
 #include <unordered_map>
 
 namespace FixtureTableEditService {
@@ -70,6 +71,8 @@ void UpdateSceneData(ISceneAdapter &adapter, wxDataViewListCtrl *table,
     DataViewEditCommit::CommitPendingEdit(table);
 
   auto &scene = adapter.GetScene();
+  const auto distanceUnitSystem = adapter.GetDistanceUnitSystem();
+  const auto weightUnitSystem = adapter.GetWeightUnitSystem();
 
   size_t updatedCount = 0;
   wxString firstName, firstUuid;
@@ -124,13 +127,24 @@ void UpdateSceneData(ISceneAdapter &adapter, wxDataViewListCtrl *table,
     else
       next.address.clear();
 
-    double x = 0, y = 0, z = 0;
+    double xMm = old.transform.o[0];
+    double yMm = old.transform.o[1];
+    double zMm = old.transform.o[2];
     table->GetValue(v, i, 10);
-    v.GetString().ToDouble(&x);
+    if (const auto parsed = UiUnitUtils::ParseDistanceToMillimeters(
+            std::string(v.GetString().ToUTF8()), distanceUnitSystem);
+        parsed.has_value())
+      xMm = *parsed;
     table->GetValue(v, i, 11);
-    v.GetString().ToDouble(&y);
+    if (const auto parsed = UiUnitUtils::ParseDistanceToMillimeters(
+            std::string(v.GetString().ToUTF8()), distanceUnitSystem);
+        parsed.has_value())
+      yMm = *parsed;
     table->GetValue(v, i, 12);
-    v.GetString().ToDouble(&z);
+    if (const auto parsed = UiUnitUtils::ParseDistanceToMillimeters(
+            std::string(v.GetString().ToUTF8()), distanceUnitSystem);
+        parsed.has_value())
+      zMm = *parsed;
 
     double roll = 0, pitch = 0, yaw = 0;
     table->GetValue(v, i, 13);
@@ -157,18 +171,15 @@ void UpdateSceneData(ISceneAdapter &adapter, wxDataViewListCtrl *table,
 
     const auto currentEuler = MatrixUtils::MatrixToEuler(old.transform);
     const bool transformChanged =
-        wxString::Format("%.3f", old.transform.o[0] / 1000.0f) !=
-            wxString::Format("%.3f", x) ||
-        wxString::Format("%.3f", old.transform.o[1] / 1000.0f) !=
-            wxString::Format("%.3f", y) ||
-        wxString::Format("%.3f", old.transform.o[2] / 1000.0f) !=
-            wxString::Format("%.3f", z) ||
-        wxString::Format("%.1f", currentEuler[2]) !=
-            wxString::Format("%.1f", roll) ||
-        wxString::Format("%.1f", currentEuler[1]) !=
-            wxString::Format("%.1f", pitch) ||
-        wxString::Format("%.1f", currentEuler[0]) !=
-            wxString::Format("%.1f", yaw);
+        !UiUnitUtils::NearlyEqualDistanceMillimeters(old.transform.o[0], xMm,
+                                                     0.5) ||
+        !UiUnitUtils::NearlyEqualDistanceMillimeters(old.transform.o[1], yMm,
+                                                     0.5) ||
+        !UiUnitUtils::NearlyEqualDistanceMillimeters(old.transform.o[2], zMm,
+                                                     0.5) ||
+        std::abs(static_cast<double>(currentEuler[2]) - roll) > 0.05 ||
+        std::abs(static_cast<double>(currentEuler[1]) - pitch) > 0.05 ||
+        std::abs(static_cast<double>(currentEuler[0]) - yaw) > 0.05;
 
     if (transformChanged) {
       Matrix rot = MatrixUtils::EulerToMatrix(
@@ -176,8 +187,8 @@ void UpdateSceneData(ISceneAdapter &adapter, wxDataViewListCtrl *table,
           static_cast<float>(roll));
       next.transform = MatrixUtils::ApplyRotationPreservingScale(
           old.transform, rot,
-          {static_cast<float>(x * 1000.0), static_cast<float>(y * 1000.0),
-           static_cast<float>(z * 1000.0)});
+          {static_cast<float>(xMm), static_cast<float>(yMm),
+           static_cast<float>(zMm)});
     }
 
     table->GetValue(v, i, 16);
@@ -186,9 +197,11 @@ void UpdateSceneData(ISceneAdapter &adapter, wxDataViewListCtrl *table,
     next.powerConsumptionW = static_cast<float>(pw);
 
     table->GetValue(v, i, 17);
-    double wt = 0.0;
-    v.GetString().ToDouble(&wt);
-    next.weightKg = static_cast<float>(wt);
+    if (const auto parsedWeightKg = UiUnitUtils::ParseWeightToKilograms(
+            std::string(v.GetString().ToUTF8()), weightUnitSystem);
+        parsedWeightKg.has_value()) {
+      next.weightKg = static_cast<float>(*parsedWeightKg);
+    }
 
     table->GetValue(v, i, 18);
     next.category = GdtfFixtureCategory::NormalizeCategory(std::string(v.GetString().ToUTF8()));
@@ -218,7 +231,8 @@ void UpdateSceneData(ISceneAdapter &adapter, wxDataViewListCtrl *table,
                                 old.gdtfMode != next.gdtfMode ||
                                 transformChanged ||
                                 old.powerConsumptionW != next.powerConsumptionW ||
-                                old.weightKg != next.weightKg ||
+                                !UiUnitUtils::NearlyEqualWeightKilograms(old.weightKg, next.weightKg,
+                                                                 0.001) ||
                                 old.category != next.category ||
                                 old.color != next.color;
     if (!fixtureChanged)

--- a/gui/fixturetable/fixture_table_edit_service.h
+++ b/gui/fixturetable/fixture_table_edit_service.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "mvrscene.h"
+#include "ui_unit_utils.h"
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -15,6 +16,8 @@ public:
   virtual ~ISceneAdapter() = default;
   virtual void PushUndoState(const std::string &description) = 0;
   virtual MvrScene &GetScene() = 0;
+  virtual UiUnitUtils::DistanceUnitSystem GetDistanceUnitSystem() const = 0;
+  virtual UiUnitUtils::WeightUnitSystem GetWeightUnitSystem() const = 0;
 };
 
 std::vector<int> BuildOrderedRows(const std::vector<int> &selectedRows,

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -216,6 +216,24 @@ void FixtureTablePanel::InitializeTable() {
 }
 
 void FixtureTablePanel::ReloadData() {
+  auto &cfg = guiConfigServices->LegacyConfigManager();
+  const auto distanceUnit = UiUnitUtils::ParseDistanceUnitSystem(
+      cfg.GetValue("ui_distance_unit_system"));
+  const auto weightUnit = UiUnitUtils::ParseWeightUnitSystem(
+      cfg.GetValue("ui_weight_unit_system"));
+  const wxString distanceSuffix =
+      wxString::FromUTF8(UiUnitUtils::DistanceUnitSuffix(distanceUnit));
+  const wxString weightSuffix =
+      wxString::FromUTF8(UiUnitUtils::WeightUnitSuffix(weightUnit));
+  columnLabels[10] = "Pos X (" + distanceSuffix + ")";
+  columnLabels[11] = "Pos Y (" + distanceSuffix + ")";
+  columnLabels[12] = "Pos Z (" + distanceSuffix + ")";
+  columnLabels[17] = "Weight (" + weightSuffix + ")";
+  for (size_t i = 0; i < columnLabels.size(); ++i) {
+    if (auto *column = table->GetColumn(static_cast<unsigned int>(i)))
+      column->SetTitle(columnLabels[i]);
+  }
+
   store->DeleteAllItems();
   gdtfPaths.clear();
   rowUuids.clear();
@@ -281,11 +299,6 @@ void FixtureTablePanel::ReloadData() {
         chCount >= 0 ? wxString::Format("%d", chCount) : wxString();
 
     auto posArr = fixture->GetPosition();
-    auto &cfg = guiConfigServices->LegacyConfigManager();
-    const auto distanceUnit = UiUnitUtils::ParseDistanceUnitSystem(
-        cfg.GetValue("ui_distance_unit_system"));
-    const auto weightUnit = UiUnitUtils::ParseWeightUnitSystem(
-        cfg.GetValue("ui_weight_unit_system"));
     wxString posX = wxString::FromUTF8(UiUnitUtils::FormatDistanceFromMillimeters(
         posArr[0], distanceUnit, UiUnitUtils::ValueFormatContext::Table));
     wxString posY = wxString::FromUTF8(UiUnitUtils::FormatDistanceFromMillimeters(

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -33,6 +33,7 @@
 #include "riggingpanel.h"
 #include "stringutils.h"
 #include "summarypanel.h"
+#include "ui_unit_utils.h"
 #include "viewer2dpanel.h"
 #include "viewer3dpanel.h"
 #include <algorithm>
@@ -66,6 +67,18 @@ public:
   }
 
   MvrScene &GetScene() override { return GetDefaultGuiConfigServices().LegacyConfigManager().GetScene(); }
+
+  UiUnitUtils::DistanceUnitSystem GetDistanceUnitSystem() const override {
+    const auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+    return UiUnitUtils::ParseDistanceUnitSystem(
+        cfg.GetValue("ui_distance_unit_system"));
+  }
+
+  UiUnitUtils::WeightUnitSystem GetWeightUnitSystem() const override {
+    const auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+    return UiUnitUtils::ParseWeightUnitSystem(
+        cfg.GetValue("ui_weight_unit_system"));
+  }
 };
 
 bool IsRedCell(const ColorfulDataViewListStore *store, int row, int col) {
@@ -186,6 +199,19 @@ FixtureTablePanel::~FixtureTablePanel() {
 
 void FixtureTablePanel::InitializeTable() {
   columnLabels = FixtureTableColumns::DefaultLabels();
+  auto &cfg = guiConfigServices->LegacyConfigManager();
+  const auto distanceUnit = UiUnitUtils::ParseDistanceUnitSystem(
+      cfg.GetValue("ui_distance_unit_system"));
+  const auto weightUnit = UiUnitUtils::ParseWeightUnitSystem(
+      cfg.GetValue("ui_weight_unit_system"));
+  const wxString distanceSuffix =
+      wxString::FromUTF8(UiUnitUtils::DistanceUnitSuffix(distanceUnit));
+  const wxString weightSuffix =
+      wxString::FromUTF8(UiUnitUtils::WeightUnitSuffix(weightUnit));
+  columnLabels[10] = "Pos X (" + distanceSuffix + ")";
+  columnLabels[11] = "Pos Y (" + distanceSuffix + ")";
+  columnLabels[12] = "Pos Z (" + distanceSuffix + ")";
+  columnLabels[17] = "Weight (" + weightSuffix + ")";
   FixtureTableColumns::ConfigureColumns(table, columnLabels);
 }
 
@@ -255,9 +281,17 @@ void FixtureTablePanel::ReloadData() {
         chCount >= 0 ? wxString::Format("%d", chCount) : wxString();
 
     auto posArr = fixture->GetPosition();
-    wxString posX = wxString::Format("%.3f", posArr[0] / 1000.0f);
-    wxString posY = wxString::Format("%.3f", posArr[1] / 1000.0f);
-    wxString posZ = wxString::Format("%.3f", posArr[2] / 1000.0f);
+    auto &cfg = guiConfigServices->LegacyConfigManager();
+    const auto distanceUnit = UiUnitUtils::ParseDistanceUnitSystem(
+        cfg.GetValue("ui_distance_unit_system"));
+    const auto weightUnit = UiUnitUtils::ParseWeightUnitSystem(
+        cfg.GetValue("ui_weight_unit_system"));
+    wxString posX = wxString::FromUTF8(UiUnitUtils::FormatDistanceFromMillimeters(
+        posArr[0], distanceUnit, UiUnitUtils::ValueFormatContext::Table));
+    wxString posY = wxString::FromUTF8(UiUnitUtils::FormatDistanceFromMillimeters(
+        posArr[1], distanceUnit, UiUnitUtils::ValueFormatContext::Table));
+    wxString posZ = wxString::FromUTF8(UiUnitUtils::FormatDistanceFromMillimeters(
+        posArr[2], distanceUnit, UiUnitUtils::ValueFormatContext::Table));
     wxString posName = wxString::FromUTF8(fixture->positionName);
 
     auto euler = MatrixUtils::MatrixToEuler(fixture->transform);
@@ -282,7 +316,8 @@ void FixtureTablePanel::ReloadData() {
     row.push_back(pitch);
     row.push_back(yaw);
     wxString power = wxString::Format("%.1f", fixture->powerConsumptionW);
-    wxString weight = wxString::Format("%.2f", fixture->weightKg);
+    wxString weight = wxString::FromUTF8(UiUnitUtils::FormatWeightFromKilograms(
+        fixture->weightKg, weightUnit, UiUnitUtils::ValueFormatContext::Table));
     wxString category = wxString::FromUTF8(fixture->category);
     row.push_back(power);
     row.push_back(weight);

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -29,6 +29,7 @@
 #include "summarypanel.h"
 #include "dataview_edit_commit.h"
 #include "support.h"
+#include "ui_unit_utils.h"
 #include "viewer2dpanel.h"
 #include "viewer3dpanel.h"
 #include <algorithm>
@@ -47,6 +48,16 @@ namespace {
 const wxString &DegreeSymbol() {
   static const wxString kDegreeSymbol = wxString::FromUTF8("\xC2\xB0");
   return kDegreeSymbol;
+}
+
+UiUnitUtils::DistanceUnitSystem ResolveDistanceUnitSystem() {
+  auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+  return UiUnitUtils::ParseDistanceUnitSystem(cfg.GetValue("ui_distance_unit_system"));
+}
+
+UiUnitUtils::WeightUnitSystem ResolveWeightUnitSystem() {
+  auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+  return UiUnitUtils::ParseWeightUnitSystem(cfg.GetValue("ui_weight_unit_system"));
 }
 
 struct RangeParts {
@@ -229,12 +240,16 @@ HoistTablePanel::HoistTablePanel(wxWindow *parent, IGuiConfigServices *services)
 HoistTablePanel::~HoistTablePanel() { store = nullptr; }
 
 void HoistTablePanel::InitializeTable() {
+  const auto distanceUnit = ResolveDistanceUnitSystem();
+  const auto weightUnit = ResolveWeightUnitSystem();
+  const wxString distanceSuffix = wxString::FromUTF8(UiUnitUtils::DistanceUnitSuffix(distanceUnit));
+  const wxString weightSuffix = wxString::FromUTF8(UiUnitUtils::WeightUnitSuffix(weightUnit));
   columnLabels = {"Hoist ID",      "Name",          "Type",      "Function",
                   "Motor",         "Dummy Preset",  "Data Source", "Layer",
-                  "Hang Pos",      "Pos X",         "Pos Y",     "Pos Z",
+                  "Hang Pos",      "Pos X (" + distanceSuffix + ")",         "Pos Y (" + distanceSuffix + ")",     "Pos Z (" + distanceSuffix + ")",
                   "Roll (X)",      "Pitch (Y)",     "Yaw (Z)",
-                  "Chain Length (m)", "Capacity (kg)", "Weight (kg)",
-                  "Load (kg)"};
+                  "Chain Length (m)", "Capacity (" + weightSuffix + ")", "Weight (" + weightSuffix + ")",
+                  "Load (" + weightSuffix + ")"};
   std::vector<int> widths = {70, 150, 120, 120, 130, 150, 110, 100, 120,
                              80, 80, 80, 80, 80, 80, 110, 110, 100, 100};
   for (size_t i = 0; i < columnLabels.size(); ++i)
@@ -302,10 +317,15 @@ void HoistTablePanel::ReloadData() {
                          : wxString::FromUTF8(support.layer);
     wxString posName = wxString::FromUTF8(support.positionName);
 
+    const auto distanceUnit = ResolveDistanceUnitSystem();
+    const auto weightUnit = ResolveWeightUnitSystem();
     auto posArr = support.transform.o;
-    wxString posX = wxString::Format("%.3f", posArr[0] / 1000.0f);
-    wxString posY = wxString::Format("%.3f", posArr[1] / 1000.0f);
-    wxString posZ = wxString::Format("%.3f", posArr[2] / 1000.0f);
+    wxString posX = wxString::FromUTF8(UiUnitUtils::FormatDistanceFromMillimeters(
+        posArr[0], distanceUnit, UiUnitUtils::ValueFormatContext::Table));
+    wxString posY = wxString::FromUTF8(UiUnitUtils::FormatDistanceFromMillimeters(
+        posArr[1], distanceUnit, UiUnitUtils::ValueFormatContext::Table));
+    wxString posZ = wxString::FromUTF8(UiUnitUtils::FormatDistanceFromMillimeters(
+        posArr[2], distanceUnit, UiUnitUtils::ValueFormatContext::Table));
 
     auto euler = MatrixUtils::MatrixToEuler(support.transform);
     wxString roll = wxString::Format("%.1f", euler[2]) + DegreeSymbol();
@@ -313,9 +333,12 @@ void HoistTablePanel::ReloadData() {
     wxString yaw = wxString::Format("%.1f", euler[0]) + DegreeSymbol();
 
     wxString chainLen = wxString::Format("%.2f", support.chainLength);
-    wxString capacity = wxString::Format("%.2f", effective.capacityKg);
-    wxString weight = wxString::Format("%.2f", effective.weightKg);
-    wxString load = wxString::Format("%.2f", support.loadKg);
+    wxString capacity = wxString::FromUTF8(UiUnitUtils::FormatWeightFromKilograms(
+        effective.capacityKg, weightUnit, UiUnitUtils::ValueFormatContext::Table));
+    wxString weight = wxString::FromUTF8(UiUnitUtils::FormatWeightFromKilograms(
+        effective.weightKg, weightUnit, UiUnitUtils::ValueFormatContext::Table));
+    wxString load = wxString::FromUTF8(UiUnitUtils::FormatWeightFromKilograms(
+        support.loadKg, weightUnit, UiUnitUtils::ValueFormatContext::Table));
 
     row.push_back(name);
     row.push_back(type);
@@ -801,13 +824,18 @@ void HoistTablePanel::UpdateSceneData(bool logChanges) {
     table->GetValue(v, i, 8);
     next.positionName = std::string(v.GetString().ToUTF8());
 
-    double x = 0, y = 0, z = 0;
+    const auto distanceUnit = ResolveDistanceUnitSystem();
+    const auto weightUnit = ResolveWeightUnitSystem();
+    double xMm = old.transform.o[0], yMm = old.transform.o[1], zMm = old.transform.o[2];
     table->GetValue(v, i, 9);
-    v.GetString().ToDouble(&x);
+    if (const auto parsed = UiUnitUtils::ParseDistanceToMillimeters(std::string(v.GetString().ToUTF8()), distanceUnit); parsed.has_value())
+      xMm = *parsed;
     table->GetValue(v, i, 10);
-    v.GetString().ToDouble(&y);
+    if (const auto parsed = UiUnitUtils::ParseDistanceToMillimeters(std::string(v.GetString().ToUTF8()), distanceUnit); parsed.has_value())
+      yMm = *parsed;
     table->GetValue(v, i, 11);
-    v.GetString().ToDouble(&z);
+    if (const auto parsed = UiUnitUtils::ParseDistanceToMillimeters(std::string(v.GetString().ToUTF8()), distanceUnit); parsed.has_value())
+      zMm = *parsed;
 
     double roll = 0, pitch = 0, yaw = 0;
     table->GetValue(v, i, 12);
@@ -834,15 +862,12 @@ void HoistTablePanel::UpdateSceneData(bool logChanges) {
 
     const auto currentEuler = MatrixUtils::MatrixToEuler(old.transform);
     const bool transformChanged =
-        wxString::Format("%.3f", old.transform.o[0] / 1000.0f) !=
-            wxString::Format("%.3f", x) ||
-        wxString::Format("%.3f", old.transform.o[1] / 1000.0f) !=
-            wxString::Format("%.3f", y) ||
-        wxString::Format("%.3f", old.transform.o[2] / 1000.0f) !=
-            wxString::Format("%.3f", z) ||
-        wxString::Format("%.1f", currentEuler[2]) != wxString::Format("%.1f", roll) ||
-        wxString::Format("%.1f", currentEuler[1]) != wxString::Format("%.1f", pitch) ||
-        wxString::Format("%.1f", currentEuler[0]) != wxString::Format("%.1f", yaw);
+        !UiUnitUtils::NearlyEqualDistanceMillimeters(old.transform.o[0], xMm, 0.5) ||
+        !UiUnitUtils::NearlyEqualDistanceMillimeters(old.transform.o[1], yMm, 0.5) ||
+        !UiUnitUtils::NearlyEqualDistanceMillimeters(old.transform.o[2], zMm, 0.5) ||
+        std::abs(static_cast<double>(currentEuler[2]) - roll) > 0.05 ||
+        std::abs(static_cast<double>(currentEuler[1]) - pitch) > 0.05 ||
+        std::abs(static_cast<double>(currentEuler[0]) - yaw) > 0.05;
 
     if (transformChanged) {
       Matrix rot = MatrixUtils::EulerToMatrix(static_cast<float>(yaw),
@@ -850,8 +875,8 @@ void HoistTablePanel::UpdateSceneData(bool logChanges) {
                                               static_cast<float>(roll));
       next.transform = MatrixUtils::ApplyRotationPreservingScale(
           old.transform, rot,
-          {static_cast<float>(x * 1000.0), static_cast<float>(y * 1000.0),
-           static_cast<float>(z * 1000.0)});
+          {static_cast<float>(xMm), static_cast<float>(yMm),
+           static_cast<float>(zMm)});
     }
 
     table->GetValue(v, i, 15);
@@ -860,21 +885,22 @@ void HoistTablePanel::UpdateSceneData(bool logChanges) {
     next.chainLength = static_cast<float>(chainLen);
 
     table->GetValue(v, i, 16);
-    double capacity = 0.0;
-    v.GetString().ToDouble(&capacity);
-    const float editedCapacityKg = static_cast<float>(capacity);
-    next.capacityKg = editedCapacityKg;
+    float editedCapacityKg = old.capacityKg;
+    if (const auto parsed = UiUnitUtils::ParseWeightToKilograms(std::string(v.GetString().ToUTF8()), weightUnit); parsed.has_value()) {
+      editedCapacityKg = static_cast<float>(*parsed);
+      next.capacityKg = editedCapacityKg;
+    }
 
     table->GetValue(v, i, 17);
-    double weight = 0.0;
-    v.GetString().ToDouble(&weight);
-    const float editedWeightKg = static_cast<float>(weight);
-    next.weightKg = editedWeightKg;
+    float editedWeightKg = old.weightKg;
+    if (const auto parsed = UiUnitUtils::ParseWeightToKilograms(std::string(v.GetString().ToUTF8()), weightUnit); parsed.has_value()) {
+      editedWeightKg = static_cast<float>(*parsed);
+      next.weightKg = editedWeightKg;
+    }
 
     table->GetValue(v, i, 18);
-    double load = 0.0;
-    v.GetString().ToDouble(&load);
-    next.loadKg = static_cast<float>(load);
+    if (const auto parsed = UiUnitUtils::ParseWeightToKilograms(std::string(v.GetString().ToUTF8()), weightUnit); parsed.has_value())
+      next.loadKg = static_cast<float>(*parsed);
 
     next.motorNameSource =
         ResolveHoistFieldDataSource(next.motorNameSource, next.hoistDataSource);
@@ -910,9 +936,9 @@ void HoistTablePanel::UpdateSceneData(bool logChanges) {
                                 old.layer != next.layer ||
                                 old.positionName != next.positionName || transformChanged ||
                                 old.chainLength != next.chainLength ||
-                                old.capacityKg != next.capacityKg ||
-                                old.weightKg != next.weightKg ||
-                                old.loadKg != next.loadKg ||
+                                !UiUnitUtils::NearlyEqualWeightKilograms(old.capacityKg, next.capacityKg, 0.001) ||
+                                !UiUnitUtils::NearlyEqualWeightKilograms(old.weightKg, next.weightKg, 0.001) ||
+                                !UiUnitUtils::NearlyEqualWeightKilograms(old.loadKg, next.loadKg, 0.001) ||
                                 NormalizeHoistDataSource(old.motorNameSource) !=
                                     NormalizeHoistDataSource(next.motorNameSource) ||
                                 NormalizeHoistDataSource(old.motorManufacturerSource) !=

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -262,6 +262,23 @@ void HoistTablePanel::InitializeTable() {
 }
 
 void HoistTablePanel::ReloadData() {
+  const auto distanceUnit = ResolveDistanceUnitSystem();
+  const auto weightUnit = ResolveWeightUnitSystem();
+  const wxString distanceSuffix =
+      wxString::FromUTF8(UiUnitUtils::DistanceUnitSuffix(distanceUnit));
+  const wxString weightSuffix =
+      wxString::FromUTF8(UiUnitUtils::WeightUnitSuffix(weightUnit));
+  columnLabels[9] = "Pos X (" + distanceSuffix + ")";
+  columnLabels[10] = "Pos Y (" + distanceSuffix + ")";
+  columnLabels[11] = "Pos Z (" + distanceSuffix + ")";
+  columnLabels[16] = "Capacity (" + weightSuffix + ")";
+  columnLabels[17] = "Weight (" + weightSuffix + ")";
+  columnLabels[18] = "Load (" + weightSuffix + ")";
+  for (size_t i = 0; i < columnLabels.size(); ++i) {
+    if (auto *column = table->GetColumn(static_cast<unsigned int>(i)))
+      column->SetTitle(columnLabels[i]);
+  }
+
   table->DeleteAllItems();
   rowUuids.clear();
   const MvrScene &scene = guiConfigServices->LegacyConfigManager().GetScene();
@@ -317,8 +334,6 @@ void HoistTablePanel::ReloadData() {
                          : wxString::FromUTF8(support.layer);
     wxString posName = wxString::FromUTF8(support.positionName);
 
-    const auto distanceUnit = ResolveDistanceUnitSystem();
-    const auto weightUnit = ResolveWeightUnitSystem();
     auto posArr = support.transform.o;
     wxString posX = wxString::FromUTF8(UiUnitUtils::FormatDistanceFromMillimeters(
         posArr[0], distanceUnit, UiUnitUtils::ValueFormatContext::Table));

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -118,6 +118,7 @@ using json = nlohmann::json;
 #include "viewer2dpdfexporter.h"
 #include "print_diagnostics.h"
 #include "support.h"
+#include "ui_unit_utils.h"
 #include "trussloader.h"
 #include "trusstablepanel.h"
 #include "viewer2dpanel.h"
@@ -139,26 +140,6 @@ MainWindow *MainWindow::Instance() { return s_instance; }
 void MainWindow::SetInstance(MainWindow *inst) { s_instance = inst; }
 
 namespace {
-enum class UiUnitSystem { Metric, Imperial };
-
-UiUnitSystem ResolveDistanceUnitSystem(ConfigManager &cfg) {
-  const auto value = cfg.GetValue("ui_distance_unit_system");
-  if (value && *value == "imperial")
-    return UiUnitSystem::Imperial;
-  return UiUnitSystem::Metric;
-}
-
-double ConvertMetersToDistanceUnit(double meters, UiUnitSystem unitSystem) {
-  if (unitSystem == UiUnitSystem::Imperial) {
-    constexpr double kMetersToFeet = 3.280839895;
-    return meters * kMetersToFeet;
-  }
-  return meters;
-}
-
-const char *DistanceUnitSuffix(UiUnitSystem unitSystem) {
-  return unitSystem == UiUnitSystem::Imperial ? "ft" : "m";
-}
 
 void PersistFixtureTypeAutoColors(ConfigManager &configManager) {
   auto &scene = configManager.GetScene();
@@ -465,15 +446,23 @@ void MainWindow::UpdateCursorWorldPositionInStatusBar(
   }
 
   ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
-  const UiUnitSystem unitSystem = ResolveDistanceUnitSystem(cfg);
+  const auto distanceUnitSystem = UiUnitUtils::ParseDistanceUnitSystem(
+      cfg.GetValue("ui_distance_unit_system"));
+  const std::string unitSuffix = UiUnitUtils::DistanceUnitSuffix(distanceUnitSystem);
   std::ostringstream stream;
-  stream << std::fixed << std::setprecision(2) << "X: "
-         << ConvertMetersToDistanceUnit((*positionMeters)[0], unitSystem) << " "
-         << DistanceUnitSuffix(unitSystem) << "  Y: "
-         << ConvertMetersToDistanceUnit((*positionMeters)[1], unitSystem) << " "
-         << DistanceUnitSuffix(unitSystem) << "  Z: "
-         << ConvertMetersToDistanceUnit((*positionMeters)[2], unitSystem) << " "
-         << DistanceUnitSuffix(unitSystem);
+  stream << "X: "
+         << UiUnitUtils::FormatDistanceFromMillimeters(
+                static_cast<double>((*positionMeters)[0]) * 1000.0,
+                distanceUnitSystem, UiUnitUtils::ValueFormatContext::Label)
+         << " " << unitSuffix << "  Y: "
+         << UiUnitUtils::FormatDistanceFromMillimeters(
+                static_cast<double>((*positionMeters)[1]) * 1000.0,
+                distanceUnitSystem, UiUnitUtils::ValueFormatContext::Label)
+         << " " << unitSuffix << "  Z: "
+         << UiUnitUtils::FormatDistanceFromMillimeters(
+                static_cast<double>((*positionMeters)[2]) * 1000.0,
+                distanceUnitSystem, UiUnitUtils::ValueFormatContext::Label)
+         << " " << unitSuffix;
   SetStatusText(wxString::FromUTF8(stream.str()), 1);
 }
 
@@ -481,10 +470,12 @@ void MainWindow::ClearCursorWorldPositionInStatusBar() {
   if (!GetStatusBar())
     return;
   ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
-  const char *unitSuffix = DistanceUnitSuffix(ResolveDistanceUnitSystem(cfg));
+  const auto distanceUnitSystem = UiUnitUtils::ParseDistanceUnitSystem(
+      cfg.GetValue("ui_distance_unit_system"));
+  const std::string unitSuffix = UiUnitUtils::DistanceUnitSuffix(distanceUnitSystem);
   SetStatusText(
-      wxString::Format("X: -- %s  Y: -- %s  Z: -- %s", unitSuffix, unitSuffix,
-                       unitSuffix),
+      wxString::Format("X: -- %s  Y: -- %s  Z: -- %s", unitSuffix.c_str(), unitSuffix.c_str(),
+                       unitSuffix.c_str()),
       1);
 }
 

--- a/gui/riggingpanel.cpp
+++ b/gui/riggingpanel.cpp
@@ -25,6 +25,7 @@
 #include "columnutils.h"
 #include "configmanager.h"
 #include "guiconfigservices.h"
+#include "ui_unit_utils.h"
 
 namespace {
 constexpr const char *UNASSIGNED_POSITION = "Unassigned";
@@ -50,6 +51,11 @@ bool IsRedCell(const ColorfulDataViewListStore *store, int row, int col) {
 
   const wxDataViewItemAttr &attr = store->cellAttrs[rowIndex][colIndex];
   return attr.HasColour() && attr.GetColour() == *wxRED;
+}
+
+UiUnitUtils::WeightUnitSystem ResolveWeightUnitSystem() {
+  auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+  return UiUnitUtils::ParseWeightUnitSystem(cfg.GetValue("ui_weight_unit_system"));
 }
 
 wxString BuildRiggingTooltipForColumn(int modelColumn) {
@@ -130,6 +136,9 @@ RiggingPanel::RiggingPanel(wxWindow *parent) : wxPanel(parent, wxID_ANY) {
     BindTableHoverEvents(table, this, &RiggingPanel::OnMouseMove,
                          &RiggingPanel::OnMouseLeave);
   });
+  const auto weightUnit = ResolveWeightUnitSystem();
+  const wxString weightSuffix =
+      wxString::FromUTF8(UiUnitUtils::WeightUnitSuffix(weightUnit));
   table->AppendTextColumn("Position", wxDATAVIEW_CELL_INERT, wxCOL_WIDTH_AUTOSIZE,
                           wxALIGN_LEFT, wxDATAVIEW_COL_RESIZABLE);
   table->AppendTextColumn("Fixtures", wxDATAVIEW_CELL_INERT, wxCOL_WIDTH_AUTOSIZE,
@@ -138,19 +147,24 @@ RiggingPanel::RiggingPanel(wxWindow *parent) : wxPanel(parent, wxID_ANY) {
                           wxALIGN_RIGHT, wxDATAVIEW_COL_RESIZABLE);
   table->AppendTextColumn("Hoists", wxDATAVIEW_CELL_INERT, wxCOL_WIDTH_AUTOSIZE,
                           wxALIGN_RIGHT, wxDATAVIEW_COL_RESIZABLE);
-  table->AppendTextColumn("Fixture Weight (kg)", wxDATAVIEW_CELL_INERT,
+  table->AppendTextColumn("Fixture Weight (" + weightSuffix + ")",
+                          wxDATAVIEW_CELL_INERT,
                           wxCOL_WIDTH_AUTOSIZE, wxALIGN_RIGHT,
                           wxDATAVIEW_COL_RESIZABLE);
-  table->AppendTextColumn("Truss Weight (kg)", wxDATAVIEW_CELL_INERT,
+  table->AppendTextColumn("Truss Weight (" + weightSuffix + ")",
+                          wxDATAVIEW_CELL_INERT,
                           wxCOL_WIDTH_AUTOSIZE, wxALIGN_RIGHT,
                           wxDATAVIEW_COL_RESIZABLE);
-  table->AppendTextColumn("Hoists Weight (kg)", wxDATAVIEW_CELL_INERT,
+  table->AppendTextColumn("Hoists Weight (" + weightSuffix + ")",
+                          wxDATAVIEW_CELL_INERT,
                           wxCOL_WIDTH_AUTOSIZE, wxALIGN_RIGHT,
                           wxDATAVIEW_COL_RESIZABLE);
-  table->AppendTextColumn("Total Weight (kg)", wxDATAVIEW_CELL_INERT,
+  table->AppendTextColumn("Total Weight (" + weightSuffix + ")",
+                          wxDATAVIEW_CELL_INERT,
                           wxCOL_WIDTH_AUTOSIZE, wxALIGN_RIGHT,
                           wxDATAVIEW_COL_RESIZABLE);
-  table->AppendTextColumn("Rounded Total Weight +5% (kg)", wxDATAVIEW_CELL_INERT,
+  table->AppendTextColumn("Rounded Total Weight +5% (" + weightSuffix + ")",
+                          wxDATAVIEW_CELL_INERT,
                           wxCOL_WIDTH_AUTOSIZE, wxALIGN_RIGHT,
                           wxDATAVIEW_COL_RESIZABLE);
 
@@ -193,6 +207,7 @@ void RiggingPanel::RefreshData() {
   };
 
   std::map<std::string, Totals> rows;
+  const auto weightUnit = ResolveWeightUnitSystem();
   const auto &scene = GetDefaultGuiConfigServices().LegacyConfigManager().GetScene();
   for (const auto &[uuid, fixture] : scene.fixtures) {
     std::string pos = fixture.positionName.empty() ? UNASSIGNED_POSITION
@@ -237,11 +252,17 @@ void RiggingPanel::RefreshData() {
     row.push_back(wxString::Format("%d", totals.fixtures));
     row.push_back(wxString::Format("%d", totals.trusses));
     row.push_back(wxString::Format("%d", totals.hoists));
-    row.push_back(wxString::Format("%.2f", totals.fixtureWeight));
-    row.push_back(wxString::Format("%.2f", totals.trussWeight));
-    row.push_back(wxString::Format("%.2f", totals.hoistWeight));
-    row.push_back(wxString::Format("%.2f", totalWeight));
-    row.push_back(wxString::Format("%.2f", roundedFivePercentIncrease));
+    row.push_back(wxString::FromUTF8(UiUnitUtils::FormatWeightFromKilograms(
+        totals.fixtureWeight, weightUnit, UiUnitUtils::ValueFormatContext::Table)));
+    row.push_back(wxString::FromUTF8(UiUnitUtils::FormatWeightFromKilograms(
+        totals.trussWeight, weightUnit, UiUnitUtils::ValueFormatContext::Table)));
+    row.push_back(wxString::FromUTF8(UiUnitUtils::FormatWeightFromKilograms(
+        totals.hoistWeight, weightUnit, UiUnitUtils::ValueFormatContext::Table)));
+    row.push_back(wxString::FromUTF8(UiUnitUtils::FormatWeightFromKilograms(
+        totalWeight, weightUnit, UiUnitUtils::ValueFormatContext::Table)));
+    row.push_back(wxString::FromUTF8(UiUnitUtils::FormatWeightFromKilograms(
+        roundedFivePercentIncrease, weightUnit,
+        UiUnitUtils::ValueFormatContext::Table)));
     unsigned int rowIndex = table->GetItemCount();
     table->AppendItem(row);
 

--- a/gui/riggingpanel.cpp
+++ b/gui/riggingpanel.cpp
@@ -208,6 +208,16 @@ void RiggingPanel::RefreshData() {
 
   std::map<std::string, Totals> rows;
   const auto weightUnit = ResolveWeightUnitSystem();
+  const wxString weightSuffix =
+      wxString::FromUTF8(UiUnitUtils::WeightUnitSuffix(weightUnit));
+  if (table->GetColumnCount() >= 9) {
+    table->GetColumn(4)->SetTitle("Fixture Weight (" + weightSuffix + ")");
+    table->GetColumn(5)->SetTitle("Truss Weight (" + weightSuffix + ")");
+    table->GetColumn(6)->SetTitle("Hoists Weight (" + weightSuffix + ")");
+    table->GetColumn(7)->SetTitle("Total Weight (" + weightSuffix + ")");
+    table->GetColumn(8)->SetTitle("Rounded Total Weight +5% (" + weightSuffix +
+                                  ")");
+  }
   const auto &scene = GetDefaultGuiConfigServices().LegacyConfigManager().GetScene();
   for (const auto &[uuid, fixture] : scene.fixtures) {
     std::string pos = fixture.positionName.empty() ? UNASSIGNED_POSITION

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -27,8 +27,10 @@
 #include "dataview_edit_commit.h"
 #include "viewer2dpanel.h"
 #include "viewer3dpanel.h"
+#include "ui_unit_utils.h"
 #include <algorithm>
 #include <cctype>
+#include <cmath>
 #include <wx/notebook.h>
 #include <wx/choicdlg.h>
 #include <wx/wupdlock.h> // freeze/thaw UI during batch edits
@@ -41,6 +43,11 @@ namespace {
 const wxString &DegreeSymbol() {
   static const wxString kDegreeSymbol = wxString::FromUTF8("\xC2\xB0");
   return kDegreeSymbol;
+}
+
+UiUnitUtils::DistanceUnitSystem ResolveDistanceUnitSystem() {
+    auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+    return UiUnitUtils::ParseDistanceUnitSystem(cfg.GetValue("ui_distance_unit_system"));
 }
 
 struct RangeParts {
@@ -144,8 +151,10 @@ SceneObjectTablePanel::~SceneObjectTablePanel()
 
 void SceneObjectTablePanel::InitializeTable()
 {
+    const auto distanceUnit = ResolveDistanceUnitSystem();
+    const wxString distanceSuffix = wxString::FromUTF8(UiUnitUtils::DistanceUnitSuffix(distanceUnit));
     columnLabels = {"Name", "Layer", "Model File",
-                    "Pos X", "Pos Y", "Pos Z",
+                    "Pos X (" + distanceSuffix + ")", "Pos Y (" + distanceSuffix + ")", "Pos Z (" + distanceSuffix + ")",
                     "Roll (X)", "Pitch (Y)", "Yaw (Z)"};
     std::vector<int> widths = {150, 100, 180,
                                80, 80, 80,
@@ -185,10 +194,14 @@ void SceneObjectTablePanel::ReloadData()
                                                           : wxString::FromUTF8(obj.layer);
         wxString model = wxString::FromUTF8(obj.modelFile);
 
+        const auto distanceUnit = ResolveDistanceUnitSystem();
         auto posArr = obj.transform.o;
-        wxString posX = wxString::Format("%.3f", posArr[0] / 1000.0f);
-        wxString posY = wxString::Format("%.3f", posArr[1] / 1000.0f);
-        wxString posZ = wxString::Format("%.3f", posArr[2] / 1000.0f);
+        wxString posX = wxString::FromUTF8(UiUnitUtils::FormatDistanceFromMillimeters(
+            posArr[0], distanceUnit, UiUnitUtils::ValueFormatContext::Table));
+        wxString posY = wxString::FromUTF8(UiUnitUtils::FormatDistanceFromMillimeters(
+            posArr[1], distanceUnit, UiUnitUtils::ValueFormatContext::Table));
+        wxString posZ = wxString::FromUTF8(UiUnitUtils::FormatDistanceFromMillimeters(
+            posArr[2], distanceUnit, UiUnitUtils::ValueFormatContext::Table));
 
         auto euler = MatrixUtils::MatrixToEuler(obj.transform);
         wxString roll = wxString::Format("%.1f", euler[2]) + DegreeSymbol();
@@ -590,13 +603,17 @@ void SceneObjectTablePanel::UpdateSceneData(bool logChanges)
         else
             next.layer = layerStr;
 
-        double x = 0, y = 0, z = 0;
+        const auto distanceUnit = ResolveDistanceUnitSystem();
+        double xMm = old.transform.o[0], yMm = old.transform.o[1], zMm = old.transform.o[2];
         table->GetValue(v, i, 3);
-        v.GetString().ToDouble(&x);
+        if (const auto parsed = UiUnitUtils::ParseDistanceToMillimeters(std::string(v.GetString().ToUTF8()), distanceUnit); parsed.has_value())
+            xMm = *parsed;
         table->GetValue(v, i, 4);
-        v.GetString().ToDouble(&y);
+        if (const auto parsed = UiUnitUtils::ParseDistanceToMillimeters(std::string(v.GetString().ToUTF8()), distanceUnit); parsed.has_value())
+            yMm = *parsed;
         table->GetValue(v, i, 5);
-        v.GetString().ToDouble(&z);
+        if (const auto parsed = UiUnitUtils::ParseDistanceToMillimeters(std::string(v.GetString().ToUTF8()), distanceUnit); parsed.has_value())
+            zMm = *parsed;
 
         double roll = 0, pitch = 0, yaw = 0;
         table->GetValue(v, i, 6);
@@ -623,18 +640,12 @@ void SceneObjectTablePanel::UpdateSceneData(bool logChanges)
 
         const auto currentEuler = MatrixUtils::MatrixToEuler(old.transform);
         const bool transformChanged =
-            wxString::Format("%.3f", old.transform.o[0] / 1000.0f) !=
-                wxString::Format("%.3f", x) ||
-            wxString::Format("%.3f", old.transform.o[1] / 1000.0f) !=
-                wxString::Format("%.3f", y) ||
-            wxString::Format("%.3f", old.transform.o[2] / 1000.0f) !=
-                wxString::Format("%.3f", z) ||
-            wxString::Format("%.1f", currentEuler[2]) !=
-                wxString::Format("%.1f", roll) ||
-            wxString::Format("%.1f", currentEuler[1]) !=
-                wxString::Format("%.1f", pitch) ||
-            wxString::Format("%.1f", currentEuler[0]) !=
-                wxString::Format("%.1f", yaw);
+            !UiUnitUtils::NearlyEqualDistanceMillimeters(old.transform.o[0], xMm, 0.5) ||
+            !UiUnitUtils::NearlyEqualDistanceMillimeters(old.transform.o[1], yMm, 0.5) ||
+            !UiUnitUtils::NearlyEqualDistanceMillimeters(old.transform.o[2], zMm, 0.5) ||
+            std::abs(static_cast<double>(currentEuler[2]) - roll) > 0.05 ||
+            std::abs(static_cast<double>(currentEuler[1]) - pitch) > 0.05 ||
+            std::abs(static_cast<double>(currentEuler[0]) - yaw) > 0.05;
 
         if (transformChanged)
         {
@@ -643,9 +654,9 @@ void SceneObjectTablePanel::UpdateSceneData(bool logChanges)
                                                     static_cast<float>(roll));
             next.transform = MatrixUtils::ApplyRotationPreservingScale(
                 old.transform, rot,
-                {static_cast<float>(x * 1000.0),
-                 static_cast<float>(y * 1000.0),
-                 static_cast<float>(z * 1000.0)});
+                {static_cast<float>(xMm),
+                 static_cast<float>(yMm),
+                 static_cast<float>(zMm)});
         }
 
         const bool objectChanged = old.layer != next.layer || transformChanged;

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -170,6 +170,17 @@ void SceneObjectTablePanel::InitializeTable()
 
 void SceneObjectTablePanel::ReloadData()
 {
+    const auto distanceUnit = ResolveDistanceUnitSystem();
+    const wxString distanceSuffix =
+        wxString::FromUTF8(UiUnitUtils::DistanceUnitSuffix(distanceUnit));
+    columnLabels[3] = "Pos X (" + distanceSuffix + ")";
+    columnLabels[4] = "Pos Y (" + distanceSuffix + ")";
+    columnLabels[5] = "Pos Z (" + distanceSuffix + ")";
+    for (size_t i = 0; i < columnLabels.size(); ++i) {
+        if (auto *column = table->GetColumn(static_cast<unsigned int>(i)))
+            column->SetTitle(columnLabels[i]);
+    }
+
     table->DeleteAllItems();
     rowUuids.clear();
     const auto& objs = guiConfigServices->LegacyConfigManager().GetScene().sceneObjects;
@@ -194,7 +205,6 @@ void SceneObjectTablePanel::ReloadData()
                                                           : wxString::FromUTF8(obj.layer);
         wxString model = wxString::FromUTF8(obj.modelFile);
 
-        const auto distanceUnit = ResolveDistanceUnitSystem();
         auto posArr = obj.transform.o;
         wxString posX = wxString::FromUTF8(UiUnitUtils::FormatDistanceFromMillimeters(
             posArr[0], distanceUnit, UiUnitUtils::ValueFormatContext::Table));

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -30,9 +30,11 @@
 #include "dataview_edit_commit.h"
 #include "trussdictionary.h"
 #include "trussloader.h"
+#include "ui_unit_utils.h"
 #include "viewer2dpanel.h"
 #include "viewer3dpanel.h"
 #include <cctype>
+#include <cmath>
 #include <filesystem>
 #include <wx/filedlg.h>
 #include <wx/filename.h>
@@ -52,6 +54,17 @@ namespace {
 const wxString &DegreeSymbol() {
   static const wxString kDegreeSymbol = wxString::FromUTF8("\xC2\xB0");
   return kDegreeSymbol;
+}
+
+
+UiUnitUtils::DistanceUnitSystem ResolveDistanceUnitSystem() {
+    auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+    return UiUnitUtils::ParseDistanceUnitSystem(cfg.GetValue("ui_distance_unit_system"));
+}
+
+UiUnitUtils::WeightUnitSystem ResolveWeightUnitSystem() {
+    auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+    return UiUnitUtils::ParseWeightUnitSystem(cfg.GetValue("ui_weight_unit_system"));
 }
 
 struct RangeParts {
@@ -178,11 +191,15 @@ TrussTablePanel::~TrussTablePanel()
 
 void TrussTablePanel::InitializeTable()
 {
+    const auto distanceUnit = ResolveDistanceUnitSystem();
+    const auto weightUnit = ResolveWeightUnitSystem();
+    const wxString distanceSuffix = wxString::FromUTF8(UiUnitUtils::DistanceUnitSuffix(distanceUnit));
+    const wxString weightSuffix = wxString::FromUTF8(UiUnitUtils::WeightUnitSuffix(weightUnit));
     columnLabels = {"Name", "Layer", "Model File", "Hang Pos",
-                    "Pos X", "Pos Y", "Pos Z",
+                    "Pos X (" + distanceSuffix + ")", "Pos Y (" + distanceSuffix + ")", "Pos Z (" + distanceSuffix + ")",
                     "Roll (X)", "Pitch (Y)", "Yaw (Z)",
                     "Manufacturer", "Model",
-                    "Length (m)", "Width (m)", "Height (m)", "Weight (kg)"};
+                    "Length (" + distanceSuffix + ")", "Width (" + distanceSuffix + ")", "Height (" + distanceSuffix + ")", "Weight (" + weightSuffix + ")"};
     std::vector<int> widths = {150, 100, 180, 120,
                                80, 80, 80,
                                80, 80, 80,
@@ -251,10 +268,15 @@ void TrussTablePanel::ReloadData()
         symbolPaths.push_back(wxString::FromUTF8(symbolFullPath));
         wxString model = wxFileName(modelFull).GetFullName();
 
+        const auto distanceUnit = ResolveDistanceUnitSystem();
+        const auto weightUnit = ResolveWeightUnitSystem();
         auto posArr = truss.transform.o;
-        wxString posX = wxString::Format("%.3f", posArr[0] / 1000.0f);
-        wxString posY = wxString::Format("%.3f", posArr[1] / 1000.0f);
-        wxString posZ = wxString::Format("%.3f", posArr[2] / 1000.0f);
+        wxString posX = wxString::FromUTF8(UiUnitUtils::FormatDistanceFromMillimeters(
+            posArr[0], distanceUnit, UiUnitUtils::ValueFormatContext::Table));
+        wxString posY = wxString::FromUTF8(UiUnitUtils::FormatDistanceFromMillimeters(
+            posArr[1], distanceUnit, UiUnitUtils::ValueFormatContext::Table));
+        wxString posZ = wxString::FromUTF8(UiUnitUtils::FormatDistanceFromMillimeters(
+            posArr[2], distanceUnit, UiUnitUtils::ValueFormatContext::Table));
 
         auto euler = MatrixUtils::MatrixToEuler(truss.transform);
         wxString roll = wxString::Format("%.1f", euler[2]) + DegreeSymbol();
@@ -274,14 +296,20 @@ void TrussTablePanel::ReloadData()
         row.push_back(yaw);
         wxString manuf = wxString::FromUTF8(truss.manufacturer);
         wxString modelName = wxString::FromUTF8(truss.model);
-        wxString len = wxString::Format("%.2f", truss.lengthMm / 1000.0f);
+        wxString len = wxString::FromUTF8(UiUnitUtils::FormatDistanceFromMillimeters(
+            truss.lengthMm, distanceUnit, UiUnitUtils::ValueFormatContext::Table));
         wxString wid = truss.widthMm > 0.0f
-                           ? wxString::Format("%.2f", truss.widthMm / 1000.0f)
+                           ? wxString::FromUTF8(UiUnitUtils::FormatDistanceFromMillimeters(
+                                 truss.widthMm, distanceUnit,
+                                 UiUnitUtils::ValueFormatContext::Table))
                            : wxString();
         wxString hei = truss.heightMm > 0.0f
-                            ? wxString::Format("%.2f", truss.heightMm / 1000.0f)
+                            ? wxString::FromUTF8(UiUnitUtils::FormatDistanceFromMillimeters(
+                                  truss.heightMm, distanceUnit,
+                                  UiUnitUtils::ValueFormatContext::Table))
                             : wxString();
-        wxString weight = wxString::Format("%.2f", truss.weightKg);
+        wxString weight = wxString::FromUTF8(UiUnitUtils::FormatWeightFromKilograms(
+            truss.weightKg, weightUnit, UiUnitUtils::ValueFormatContext::Table));
         row.push_back(manuf);
         row.push_back(modelName);
         row.push_back(len);
@@ -820,13 +848,18 @@ void TrussTablePanel::UpdateSceneData(bool logChanges)
         table->GetValue(v, i, 3);
         next.positionName = std::string(v.GetString().mb_str());
 
-        double x = 0, y = 0, z = 0;
+        const auto distanceUnit = ResolveDistanceUnitSystem();
+        const auto weightUnit = ResolveWeightUnitSystem();
+        double xMm = old.transform.o[0], yMm = old.transform.o[1], zMm = old.transform.o[2];
         table->GetValue(v, i, 4);
-        v.GetString().ToDouble(&x);
+        if (const auto parsed = UiUnitUtils::ParseDistanceToMillimeters(std::string(v.GetString().ToUTF8()), distanceUnit); parsed.has_value())
+            xMm = *parsed;
         table->GetValue(v, i, 5);
-        v.GetString().ToDouble(&y);
+        if (const auto parsed = UiUnitUtils::ParseDistanceToMillimeters(std::string(v.GetString().ToUTF8()), distanceUnit); parsed.has_value())
+            yMm = *parsed;
         table->GetValue(v, i, 6);
-        v.GetString().ToDouble(&z);
+        if (const auto parsed = UiUnitUtils::ParseDistanceToMillimeters(std::string(v.GetString().ToUTF8()), distanceUnit); parsed.has_value())
+            zMm = *parsed;
 
         double roll = 0, pitch = 0, yaw = 0;
         table->GetValue(v, i, 7);
@@ -853,15 +886,12 @@ void TrussTablePanel::UpdateSceneData(bool logChanges)
 
         const auto currentEuler = MatrixUtils::MatrixToEuler(old.transform);
         const bool transformChanged =
-            wxString::Format("%.3f", old.transform.o[0] / 1000.0f) !=
-                wxString::Format("%.3f", x) ||
-            wxString::Format("%.3f", old.transform.o[1] / 1000.0f) !=
-                wxString::Format("%.3f", y) ||
-            wxString::Format("%.3f", old.transform.o[2] / 1000.0f) !=
-                wxString::Format("%.3f", z) ||
-            wxString::Format("%.1f", currentEuler[2]) != wxString::Format("%.1f", roll) ||
-            wxString::Format("%.1f", currentEuler[1]) != wxString::Format("%.1f", pitch) ||
-            wxString::Format("%.1f", currentEuler[0]) != wxString::Format("%.1f", yaw);
+            !UiUnitUtils::NearlyEqualDistanceMillimeters(old.transform.o[0], xMm, 0.5) ||
+            !UiUnitUtils::NearlyEqualDistanceMillimeters(old.transform.o[1], yMm, 0.5) ||
+            !UiUnitUtils::NearlyEqualDistanceMillimeters(old.transform.o[2], zMm, 0.5) ||
+            std::abs(static_cast<double>(currentEuler[2]) - roll) > 0.05 ||
+            std::abs(static_cast<double>(currentEuler[1]) - pitch) > 0.05 ||
+            std::abs(static_cast<double>(currentEuler[0]) - yaw) > 0.05;
 
         if (transformChanged)
         {
@@ -870,9 +900,9 @@ void TrussTablePanel::UpdateSceneData(bool logChanges)
                                                     static_cast<float>(roll));
             next.transform = MatrixUtils::ApplyRotationPreservingScale(
                 old.transform, rot,
-                {static_cast<float>(x * 1000.0),
-                 static_cast<float>(y * 1000.0),
-                 static_cast<float>(z * 1000.0)});
+                {static_cast<float>(xMm),
+                 static_cast<float>(yMm),
+                 static_cast<float>(zMm)});
         }
 
         table->GetValue(v, i, 10);
@@ -880,19 +910,26 @@ void TrussTablePanel::UpdateSceneData(bool logChanges)
         table->GetValue(v, i, 11);
         next.model = std::string(v.GetString().mb_str());
 
-        double len = 0.0, wid = 0.0, hei = 0.0, weight = 0.0;
         table->GetValue(v, i, 12);
-        v.GetString().ToDouble(&len);
+        if (const auto parsed = UiUnitUtils::ParseDistanceToMillimeters(
+                std::string(v.GetString().ToUTF8()), distanceUnit);
+            parsed.has_value())
+            next.lengthMm = static_cast<float>(*parsed);
         table->GetValue(v, i, 13);
-        v.GetString().ToDouble(&wid);
+        if (const auto parsed = UiUnitUtils::ParseDistanceToMillimeters(
+                std::string(v.GetString().ToUTF8()), distanceUnit);
+            parsed.has_value())
+            next.widthMm = static_cast<float>(*parsed);
         table->GetValue(v, i, 14);
-        v.GetString().ToDouble(&hei);
+        if (const auto parsed = UiUnitUtils::ParseDistanceToMillimeters(
+                std::string(v.GetString().ToUTF8()), distanceUnit);
+            parsed.has_value())
+            next.heightMm = static_cast<float>(*parsed);
         table->GetValue(v, i, 15);
-        v.GetString().ToDouble(&weight);
-        next.lengthMm = static_cast<float>(len * 1000.0);
-        next.widthMm = static_cast<float>(wid * 1000.0);
-        next.heightMm = static_cast<float>(hei * 1000.0);
-        next.weightKg = static_cast<float>(weight);
+        if (const auto parsed = UiUnitUtils::ParseWeightToKilograms(
+                std::string(v.GetString().ToUTF8()), weightUnit);
+            parsed.has_value())
+            next.weightKg = static_cast<float>(*parsed);
 
         const bool trussChanged =
             old.name != next.name ||
@@ -903,10 +940,10 @@ void TrussTablePanel::UpdateSceneData(bool logChanges)
             transformChanged ||
             old.manufacturer != next.manufacturer ||
             old.model != next.model ||
-            old.lengthMm != next.lengthMm ||
-            old.widthMm != next.widthMm ||
-            old.heightMm != next.heightMm ||
-            old.weightKg != next.weightKg;
+            !UiUnitUtils::NearlyEqualDistanceMillimeters(old.lengthMm, next.lengthMm, 0.5) ||
+            !UiUnitUtils::NearlyEqualDistanceMillimeters(old.widthMm, next.widthMm, 0.5) ||
+            !UiUnitUtils::NearlyEqualDistanceMillimeters(old.heightMm, next.heightMm, 0.5) ||
+            !UiUnitUtils::NearlyEqualWeightKilograms(old.weightKg, next.weightKg, 0.001);
 
         if (trussChanged)
         {

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -216,6 +216,24 @@ void TrussTablePanel::InitializeTable()
 
 void TrussTablePanel::ReloadData()
 {
+    const auto distanceUnit = ResolveDistanceUnitSystem();
+    const auto weightUnit = ResolveWeightUnitSystem();
+    const wxString distanceSuffix =
+        wxString::FromUTF8(UiUnitUtils::DistanceUnitSuffix(distanceUnit));
+    const wxString weightSuffix =
+        wxString::FromUTF8(UiUnitUtils::WeightUnitSuffix(weightUnit));
+    columnLabels[4] = "Pos X (" + distanceSuffix + ")";
+    columnLabels[5] = "Pos Y (" + distanceSuffix + ")";
+    columnLabels[6] = "Pos Z (" + distanceSuffix + ")";
+    columnLabels[12] = "Length (" + distanceSuffix + ")";
+    columnLabels[13] = "Width (" + distanceSuffix + ")";
+    columnLabels[14] = "Height (" + distanceSuffix + ")";
+    columnLabels[15] = "Weight (" + weightSuffix + ")";
+    for (size_t i = 0; i < columnLabels.size(); ++i) {
+        if (auto *column = table->GetColumn(static_cast<unsigned int>(i)))
+            column->SetTitle(columnLabels[i]);
+    }
+
     table->DeleteAllItems();
     rowUuids.clear();
     modelPaths.clear();
@@ -268,8 +286,6 @@ void TrussTablePanel::ReloadData()
         symbolPaths.push_back(wxString::FromUTF8(symbolFullPath));
         wxString model = wxFileName(modelFull).GetFullName();
 
-        const auto distanceUnit = ResolveDistanceUnitSystem();
-        const auto weightUnit = ResolveWeightUnitSystem();
         auto posArr = truss.transform.o;
         wxString posX = wxString::FromUTF8(UiUnitUtils::FormatDistanceFromMillimeters(
             posArr[0], distanceUnit, UiUnitUtils::ValueFormatContext::Table));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,6 +70,12 @@ target_link_libraries(fixture_table_parser_test PRIVATE ${wxWidgets_LIBRARIES})
 add_test(NAME FixtureTableParser COMMAND fixture_table_parser_test)
 
 
+add_executable(ui_unit_utils_test
+               ui_unit_utils_test.cpp
+               ../core/ui_unit_utils.cpp)
+target_include_directories(ui_unit_utils_test PRIVATE ../core)
+add_test(NAME UiUnitUtilsRoundTrip COMMAND ui_unit_utils_test)
+
 add_executable(gdtf_fixture_category_test
                gdtf_fixture_category_test.cpp
                ../core/gdtf_fixture_category.cpp)

--- a/tests/ui_unit_utils_test.cpp
+++ b/tests/ui_unit_utils_test.cpp
@@ -1,0 +1,62 @@
+#include "ui_unit_utils.h"
+
+#include <cassert>
+#include <cmath>
+#include <iostream>
+
+namespace {
+
+void AssertImperialDistanceRoundTrip() {
+  constexpr double kInputFeet = 12.345;
+  const auto parsedMm = UiUnitUtils::ParseDistanceToMillimeters(
+      "12.345", UiUnitUtils::DistanceUnitSystem::Imperial);
+  assert(parsedMm.has_value());
+
+  const std::string printedFeet = UiUnitUtils::FormatDistanceFromMillimeters(
+      *parsedMm, UiUnitUtils::DistanceUnitSystem::Imperial,
+      UiUnitUtils::ValueFormatContext::Table);
+  assert(printedFeet == "12.345");
+
+  const auto reparsedMm = UiUnitUtils::ParseDistanceToMillimeters(
+      printedFeet, UiUnitUtils::DistanceUnitSystem::Imperial);
+  assert(reparsedMm.has_value());
+
+  assert(UiUnitUtils::NearlyEqualDistanceMillimeters(*parsedMm, *reparsedMm,
+                                                     0.001));
+
+  const double driftFeet =
+      std::abs(((*reparsedMm - *parsedMm) / 304.8));
+  assert(driftFeet < 1e-6);
+  assert(std::abs(((*parsedMm / 304.8) - kInputFeet)) < 1e-9);
+}
+
+void AssertImperialWeightRoundTrip() {
+  constexpr double kInputPounds = 77.77;
+  const auto parsedKg = UiUnitUtils::ParseWeightToKilograms(
+      "77.77", UiUnitUtils::WeightUnitSystem::Imperial);
+  assert(parsedKg.has_value());
+
+  const std::string printedLb = UiUnitUtils::FormatWeightFromKilograms(
+      *parsedKg, UiUnitUtils::WeightUnitSystem::Imperial,
+      UiUnitUtils::ValueFormatContext::Table);
+  assert(printedLb == "77.77");
+
+  const auto reparsedKg = UiUnitUtils::ParseWeightToKilograms(
+      printedLb, UiUnitUtils::WeightUnitSystem::Imperial);
+  assert(reparsedKg.has_value());
+
+  assert(UiUnitUtils::NearlyEqualWeightKilograms(*parsedKg, *reparsedKg,
+                                                 1e-6));
+  const double driftPounds = std::abs((*reparsedKg - *parsedKg) * 2.2046226218487757);
+  assert(driftPounds < 1e-6);
+  assert(std::abs((*parsedKg * 2.2046226218487757 - kInputPounds)) < 1e-9);
+}
+
+} // namespace
+
+int main() {
+  AssertImperialDistanceRoundTrip();
+  AssertImperialWeightRoundTrip();
+  std::cout << "ui_unit_utils_test passed" << std::endl;
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- Centralize UI unit handling so internal canonical values remain mm/kg, UI input is parsed once as numeric display values, outputs are formatted deterministically per context, formatted-string comparisons are avoided, and imperial round-trip drift is prevented.

### Description
- Add `core/ui_unit_utils.{h,cpp}` providing parse-from-display -> canonical conversions, context-aware formatting (`Table/Label/Inspector`), unit suffix helpers, and tolerance comparators for mm/kg.
- Wire `UiUnitUtils` into fixture table flow so column labels show unit suffixes, displayed position/weight values are formatted from canonical values, edited UI strings are parsed once to canonical mm/kg on save, and transform/weight change detection compares canonical values with tolerances instead of formatted strings (changes in `gui/fixturetable/fixture_table_edit_service.*` and `gui/fixturetablepanel.cpp`).
- Use `UiUnitUtils` for status-bar cursor world-position formatting in `gui/mainwindow.cpp` and expose unit-system accessors on the fixture table scene adapter implementation.
- Add `tests/ui_unit_utils_test.cpp` and CMake wiring, and register `core/ui_unit_utils.cpp` in `core/CMakeLists.txt` to provide an automated round-trip test for imperial distance/weight formatting/parsing.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both reported OK.
- Compiled and executed the standalone unit test with `g++ -std=c++20 -Icore tests/ui_unit_utils_test.cpp core/ui_unit_utils.cpp` and the test printed success (`ui_unit_utils_test passed`).
- Attempting `cmake --preset wsl-x64-debug` in this environment failed due to missing `wxWidgets` development packages, so a full IDE/GUI build was not completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c441cbb1dc8324a255be15e0700c36)