### PR TITLE
docs: explain canonical mm/kg and metric/imperial UI parsing rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@
 - Tables for fixtures, trusses, hoists and objects support multi‑row editing shortcuts: sequential fills, range interpolation (`1 10` / `1 thru 10`), relative edits (`++0.5`, `--15`), etc.
 - Console panel for status messages and command‑line operations (e.g. selecting fixtures or trusses via textual commands).
 - Preferences dialog to set default directories, units and other settings.
+- UI units can be switched independently for distance and weight (**Edit → Preferences → Units**). Internally, distances remain canonical in **mm** and weights in **kg**; metric/imperial affects input parsing and display/labels only. See [`docs/ui_unit_systems.md`](docs/ui_unit_systems.md).
 - Login dialog stores encrypted credentials for GDTF‑Share downloads.
 
 ---

--- a/docs/ui_unit_systems.md
+++ b/docs/ui_unit_systems.md
@@ -1,0 +1,124 @@
+# UI Unit Systems (Metric/Imperial)
+
+This document describes how Perastage handles user-facing unit systems after the metric/imperial UI support changes.
+
+## Canonical internal units
+
+Perastage keeps a single canonical representation internally:
+
+- **Distance:** millimeters (**mm**)
+- **Weight:** kilograms (**kg**)
+
+The selected UI system (Metric or Imperial) only affects how values are **displayed**, **parsed from text input**, and **labeled** in tables/dialogs.
+
+### Why this matters
+
+- Data consistency across modules (tables, labels, import dialogs, 2D/3D overlays).
+- No schema split or duplicated scene state for metric vs imperial.
+- Stable project persistence and deterministic conversion paths.
+
+## Config keys and scope
+
+The active UI systems are stored in user config:
+
+- `ui_distance_unit_system`: `metric` or `imperial`
+- `ui_weight_unit_system`: `metric` or `imperial`
+
+These keys drive formatting/parsing in dialogs and tables (fixtures/trusses/hoists/objects, rider import fields, support labels, etc.).
+
+## Display and conversion rules
+
+### Distance
+
+Canonical distance is mm.
+
+- Metric display = `mm / 1000` -> meters (`m`)
+- Imperial display = `mm / 304.8` -> feet (`ft`)
+
+### Weight
+
+Canonical weight is kg.
+
+- Metric display = `kg` (`kg`)
+- Imperial display = `kg * 2.2046226218487757` -> pounds (`lb`)
+
+## Parsing rules by input text
+
+Input parsing is case-insensitive and trims whitespace.
+
+### Distance parsing to mm
+
+Order of parsing:
+
+1. **Feet/inches notation** (`5' 6"`, `5'6"`, `5'`)  
+   -> interpreted as feet + inches, converted using `25.4 mm/in`.
+2. **Explicit suffix** (`m`, `ft`, `in`)  
+   Examples: `2.5m`, `12ft`, `18in`.
+3. **Plain number without suffix**  
+   Interpreted in the currently selected UI distance system:
+   - Metric UI: number means **meters**
+   - Imperial UI: number means **feet**
+
+### Weight parsing to kg
+
+Order of parsing:
+
+1. **Explicit suffix** (`kg`, `lb`)  
+   Examples: `10kg`, `220lb`.
+2. **Plain number without suffix**  
+   Interpreted in the currently selected UI weight system:
+   - Metric UI: number means **kilograms**
+   - Imperial UI: number means **pounds**
+
+### Practical implications
+
+- Explicit suffixes always override the selected UI system.
+- A plain numeric value follows the active UI system.
+- Invalid text is rejected by parser call sites that require numeric conversion.
+
+## Rounding/precision policy (formatting)
+
+Perastage uses fixed decimal formatting by UI context:
+
+### Distance
+
+- **Table:** 3 decimals
+- **Label (compact/UI labels):** 2 decimals
+- **Inspector/editor precision:** 4 decimals
+
+### Weight
+
+- **Table:** 2 decimals
+- **Label (compact/UI labels):** 1 decimal
+- **Inspector/editor precision:** 3 decimals
+
+This is a **display/formatting policy**. Canonical internal values remain in mm/kg and are not re-quantized globally.
+
+## Examples (editing and visualization)
+
+## Metric UI examples
+
+Distance system = Metric, Weight system = Metric.
+
+- Editing `height` with `6.2` -> interpreted as `6.2 m` -> stored internally as `6200 mm`.
+- Editing `height` with `18ft` -> explicit suffix accepted -> stored as `5486.4 mm` even in Metric UI.
+- Editing `weight` with `120` -> interpreted as `120 kg`.
+- Editing `weight` with `220lb` -> explicit suffix accepted -> stored as `~99.79 kg`.
+- Visualization labels show `m` and `kg` suffixes.
+
+## Imperial UI examples
+
+Distance system = Imperial, Weight system = Imperial.
+
+- Editing `height` with `20` -> interpreted as `20 ft` -> stored as `6096 mm`.
+- Editing `height` with `5' 6"` -> parsed as feet/inches -> stored as `1676.4 mm`.
+- Editing `height` with `2.5m` -> explicit suffix accepted -> stored as `2500 mm`.
+- Editing `weight` with `220` -> interpreted as `220 lb` -> stored as `~99.79 kg`.
+- Editing `weight` with `100kg` -> explicit suffix accepted -> stored as `100 kg`.
+- Visualization labels show `ft` and `lb` suffixes.
+
+## Notes for maintainers
+
+- Keep all new persistence/data-model fields in canonical mm/kg when representing distances/weights.
+- Any new UI editor/renderer should reuse the units helper API (`core/units/units.*`) for formatting/parsing consistency.
+- If a new UI context is introduced, define and document its decimal precision explicitly.

--- a/help.md
+++ b/help.md
@@ -19,6 +19,27 @@ Perastage projects (`.pstg`) store the scene, layouts, and user settings.
 - **Save** stores changes in the current project file.
 - **Save As...** writes the project under a new name or location.
 
+## Units (Metric/Imperial)
+
+Set unit systems in **Edit > Preferences > Units**:
+
+- **Distance system:** Metric (`m`) or Imperial (`ft`)
+- **Weight system:** Metric (`kg`) or Imperial (`lb`)
+
+Behavior:
+
+- Internal canonical values remain in **mm** (distance) and **kg** (weight).
+- The unit preference changes **display labels** and **plain-number input interpretation**.
+- Inputs with explicit suffixes (`m`, `ft`, `in`, `kg`, `lb`) are accepted regardless of active system.
+
+Examples:
+
+- Metric distance active: entering `6.2` means `6.2 m`.
+- Imperial distance active: entering `6.2` means `6.2 ft`.
+- Entering `5' 6"` always parses as feet/inches distance.
+- Metric weight active: entering `120` means `120 kg`; imperial means `120 lb`.
+
+Formatting precision depends on UI context (table/label/inspector). See [`docs/ui_unit_systems.md`](docs/ui_unit_systems.md) for complete parsing and rounding rules.
 
 ## Build-dependent tools
 
@@ -191,6 +212,28 @@ Los proyectos de Perastage (`.pstg`) guardan la escena, los layouts y la configu
 - **Cargar** abre un `.pstg` existente.
 - **Guardar** guarda los cambios en el proyecto actual.
 - **Guardar como...** guarda el proyecto con otro nombre o en otra ubicación.
+
+## Unidades (Métrico/Imperial)
+
+Configura las unidades en **Edit > Preferences > Units**:
+
+- **Distance system:** Metric (`m`) o Imperial (`ft`)
+- **Weight system:** Metric (`kg`) o Imperial (`lb`)
+
+Comportamiento:
+
+- Internamente los valores canónicos siguen en **mm** (distancia) y **kg** (peso).
+- La preferencia cambia las **etiquetas de visualización** y cómo se interpreta una entrada numérica sin sufijo.
+- Entradas con sufijo explícito (`m`, `ft`, `in`, `kg`, `lb`) funcionan en cualquier sistema activo.
+
+Ejemplos:
+
+- Distancia en metric: `6.2` se interpreta como `6.2 m`.
+- Distancia en imperial: `6.2` se interpreta como `6.2 ft`.
+- `5' 6"` siempre se interpreta como pies/pulgadas.
+- Peso en metric: `120` se interpreta como `120 kg`; en imperial como `120 lb`.
+
+La precisión de redondeo/formato depende del contexto (tabla/label/inspector). Consulta [`docs/ui_unit_systems.md`](docs/ui_unit_systems.md) para reglas completas de parseo y redondeo.
 
 ## Comandos de consola (completo)
 


### PR DESCRIPTION
### Motivation

- Clarify and centralise the behaviour introduced for Metric/Imperial UI unit switching so users and maintainers understand the canonical units, parsing rules and display rounding/precision.
- Prevent confusion about storage vs. display by documenting that the internal canonical representation remains in `mm` (distance) and `kg` (weight).
- Provide concrete editing and visualization examples so users know how plain numbers and explicit suffixes are interpreted in each UI system.

### Description

- Added `docs/ui_unit_systems.md` with the full specification: canonical internal units (`mm`/`kg`), config keys (`ui_distance_unit_system`, `ui_weight_unit_system`), display conversion rules, parsing order (feet/inches, explicit suffix, plain number interpreted by active UI), and rounding/precision policy per UI context.
- Updated `README.md` to mention the new Units preference (`Edit → Preferences → Units`) and link to `docs/ui_unit_systems.md`. 
- Updated `help.md` (English and Spanish sections) with user-facing guidance on the Units preference, parsing behaviour, examples and a link to the detailed doc. 
- This is documentation-only; no runtime logic or API behaviour was changed and maintainers guidance was added to reuse `core/units/units.*` for new UI contexts.

### Testing

- Ran `tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c45863d294832482de9375b51e386b)