### PR TITLE
Record and display fixture category fallback reason

### DIFF
--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -88,7 +88,7 @@ std::optional<std::unordered_map<std::string, Entry>> Load() {
       fs::path p = fs::u8path(it.value().get<std::string>());
       if (!p.is_absolute())
         p = dir / p;
-      dict[it.key()] = {p.string(), "", ""};
+      dict[it.key()] = {p.string(), "", "", "", ""};
     } else if (it.value().is_object()) {
       Entry e;
       std::string fname;
@@ -106,7 +106,16 @@ std::optional<std::unordered_map<std::string, Entry>> Load() {
         e.mode = it.value()["mode"].get<std::string>();
       if (it.value().contains("category") && it.value()["category"].is_string())
         e.category = it.value()["category"].get<std::string>();
-      if (e.path.empty() && e.mode.empty() && e.category.empty())
+      if (it.value().contains("categorySource") &&
+          it.value()["categorySource"].is_string()) {
+        e.categorySource = it.value()["categorySource"].get<std::string>();
+      }
+      if (it.value().contains("categoryReason") &&
+          it.value()["categoryReason"].is_string()) {
+        e.categoryReason = it.value()["categoryReason"].get<std::string>();
+      }
+      if (e.path.empty() && e.mode.empty() && e.category.empty() &&
+          e.categorySource.empty() && e.categoryReason.empty())
         continue;
       dict[it.key()] = e;
     }
@@ -127,7 +136,8 @@ void Save(const std::unordered_map<std::string, Entry> &dict) {
   std::sort(keys.begin(), keys.end());
   for (const auto &type : keys) {
     const auto &entry = dict.at(type);
-    if (entry.path.empty() && entry.mode.empty() && entry.category.empty())
+    if (entry.path.empty() && entry.mode.empty() && entry.category.empty() &&
+        entry.categorySource.empty() && entry.categoryReason.empty())
       continue;
     nlohmann::json obj;
     if (!entry.path.empty()) {
@@ -140,6 +150,10 @@ void Save(const std::unordered_map<std::string, Entry> &dict) {
       obj["mode"] = entry.mode;
     if (!entry.category.empty())
       obj["category"] = entry.category;
+    if (!entry.categorySource.empty())
+      obj["categorySource"] = entry.categorySource;
+    if (!entry.categoryReason.empty())
+      obj["categoryReason"] = entry.categoryReason;
     if (obj.empty())
       continue;
     j[type] = obj;
@@ -202,7 +216,9 @@ void Update(const std::string &type, const std::string &gdtfPath, const std::str
 }
 
 
-void UpdateCategory(const std::string &type, const std::string &category) {
+void UpdateCategory(const std::string &type, const std::string &category,
+                    const std::string &categorySource,
+                    const std::string &categoryReason) {
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
   if (type.empty())
     return;
@@ -214,9 +230,13 @@ void UpdateCategory(const std::string &type, const std::string &category) {
   if (it == dict.end()) {
     Entry e;
     e.category = category;
+    e.categorySource = categorySource;
+    e.categoryReason = categoryReason;
     dict[type] = e;
   } else {
     it->second.category = category;
+    it->second.categorySource = categorySource;
+    it->second.categoryReason = categoryReason;
   }
   Save(dict);
 }

--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -96,16 +96,18 @@ std::optional<std::unordered_map<std::string, Entry>> Load() {
         fname = it.value()["file"].get<std::string>();
       else if (it.value().contains("path") && it.value()["path"].is_string())
         fname = it.value()["path"].get<std::string>();
-      if (fname.empty())
-        continue;
-      fs::path p = fs::u8path(fname);
-      if (!p.is_absolute())
-        p = dir / p;
-      e.path = p.string();
+      if (!fname.empty()) {
+        fs::path p = fs::u8path(fname);
+        if (!p.is_absolute())
+          p = dir / p;
+        e.path = p.string();
+      }
       if (it.value().contains("mode") && it.value()["mode"].is_string())
         e.mode = it.value()["mode"].get<std::string>();
       if (it.value().contains("category") && it.value()["category"].is_string())
         e.category = it.value()["category"].get<std::string>();
+      if (e.path.empty() && e.mode.empty() && e.category.empty())
+        continue;
       dict[it.key()] = e;
     }
   }
@@ -125,18 +127,21 @@ void Save(const std::unordered_map<std::string, Entry> &dict) {
   std::sort(keys.begin(), keys.end());
   for (const auto &type : keys) {
     const auto &entry = dict.at(type);
-    if (entry.path.empty())
+    if (entry.path.empty() && entry.mode.empty() && entry.category.empty())
       continue;
     nlohmann::json obj;
-    fs::path p = fs::u8path(entry.path);
-    const std::string fileName = p.filename().string();
-    if (fileName.empty())
-      continue;
-    obj["file"] = fileName;
+    if (!entry.path.empty()) {
+      fs::path p = fs::u8path(entry.path);
+      const std::string fileName = p.filename().string();
+      if (!fileName.empty())
+        obj["file"] = fileName;
+    }
     if (!entry.mode.empty())
       obj["mode"] = entry.mode;
     if (!entry.category.empty())
       obj["category"] = entry.category;
+    if (obj.empty())
+      continue;
     j[type] = obj;
   }
   std::ofstream out(file);
@@ -154,7 +159,7 @@ std::optional<Entry> Get(const std::string &type) {
   auto it = dict.find(type);
   if (it == dict.end())
     return std::nullopt;
-  if (!fs::exists(it->second.path)) {
+  if (!it->second.path.empty() && !fs::exists(it->second.path)) {
     dict.erase(it);
     Save(dict);
     return std::nullopt;
@@ -206,9 +211,13 @@ void UpdateCategory(const std::string &type, const std::string &category) {
     return;
   auto &dict = *dictOpt;
   auto it = dict.find(type);
-  if (it == dict.end())
-    return;
-  it->second.category = category;
+  if (it == dict.end()) {
+    Entry e;
+    e.category = category;
+    dict[type] = e;
+  } else {
+    it->second.category = category;
+  }
   Save(dict);
 }
 

--- a/core/gdtfdictionary.h
+++ b/core/gdtfdictionary.h
@@ -23,7 +23,7 @@
 
 namespace GdtfDictionary {
     struct Entry {
-        std::string path; // absolute path inside fixtures library
+        std::string path; // optional absolute path inside fixtures library
         std::string mode;
         std::string category;
     };

--- a/core/gdtfdictionary.h
+++ b/core/gdtfdictionary.h
@@ -26,6 +26,8 @@ namespace GdtfDictionary {
         std::string path; // optional absolute path inside fixtures library
         std::string mode;
         std::string category;
+        std::string categorySource;
+        std::string categoryReason;
     };
 
     // Loads the dictionary file into a map of type -> {gdtf path in library, default mode}
@@ -37,5 +39,7 @@ namespace GdtfDictionary {
     std::optional<Entry> Get(const std::string& type);
     // Copies the gdtf file into the fixtures library and updates the dictionary
     void Update(const std::string& type, const std::string& gdtfPath, const std::string& mode = {}, const std::string& category = {});
-    void UpdateCategory(const std::string& type, const std::string& category);
+    void UpdateCategory(const std::string& type, const std::string& category,
+                        const std::string& categorySource = {},
+                        const std::string& categoryReason = {});
 }

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -1159,8 +1159,12 @@ bool RiderImporter::ImportText(const std::string &text) {
           const std::string dictionaryCategory = Trim(dictEntry->category);
           if (!dictionaryCategory.empty()) {
             f.category = dictionaryCategory;
-            f.categorySource = GdtfFixtureCategory::kManualSource;
-            f.categorySourceReason.clear();
+            f.categorySource = dictEntry->categorySource.empty()
+                                   ? GdtfFixtureCategory::kManualSource
+                                   : dictEntry->categorySource;
+            f.categorySourceReason = dictEntry->categoryReason;
+            if (f.categorySource == GdtfFixtureCategory::kManualSource)
+              f.categorySourceReason.clear();
           }
           const std::string resolvedGdtfPath = ResolveGdtfPath(scene, f.gdtfSpec);
           std::string parsed = Trim(GetGdtfFixtureName(resolvedGdtfPath));

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -160,6 +160,8 @@ void EnsureFixtureCategoryForImport(const MvrScene &scene, Fixture &fixture) {
 
   if (fixture.category.empty()) {
     fixture.category = inferCategoryFromName(fixture.typeName);
+    if (!fixture.category.empty())
+      fixture.categorySourceReason = "name hint typeName";
   }
 
   if (fixture.category.empty() && !fixture.gdtfSpec.empty()) {
@@ -167,13 +169,19 @@ void EnsureFixtureCategoryForImport(const MvrScene &scene, Fixture &fixture) {
         ResolveGdtfPath(scene, fixture.gdtfSpec);
     const std::filesystem::path gdtfPath(resolvedGdtfPath);
     fixture.category = inferCategoryFromName(gdtfPath.stem().string());
+    if (!fixture.category.empty())
+      fixture.categorySourceReason = "name hint gdtf filename";
   }
 
-  if (fixture.category.empty())
+  if (fixture.category.empty()) {
     fixture.category = GdtfFixtureCategory::kUnknown;
+    fixture.categorySourceReason = "no hints";
+  }
 
   if (fixture.categorySource.empty())
     fixture.categorySource = GdtfFixtureCategory::kAutoFallbackSource;
+  if (fixture.categorySource == GdtfFixtureCategory::kManualSource)
+    fixture.categorySourceReason.clear();
 }
 
 bool TryParseFloat(const std::string &text, float &out) {
@@ -1152,6 +1160,7 @@ bool RiderImporter::ImportText(const std::string &text) {
           if (!dictionaryCategory.empty()) {
             f.category = dictionaryCategory;
             f.categorySource = GdtfFixtureCategory::kManualSource;
+            f.categorySourceReason.clear();
           }
           const std::string resolvedGdtfPath = ResolveGdtfPath(scene, f.gdtfSpec);
           std::string parsed = Trim(GetGdtfFixtureName(resolvedGdtfPath));

--- a/gui/fixturetable/fixture_table_edit_service.cpp
+++ b/gui/fixturetable/fixture_table_edit_service.cpp
@@ -236,6 +236,8 @@ void UpdateSceneData(ISceneAdapter &adapter, wxDataViewListCtrl *table,
                                 !Units::NearlyEqualWeightKilograms(old.weightKg, next.weightKg,
                                                                  0.001) ||
                                 old.category != next.category ||
+                                old.categorySource != next.categorySource ||
+                                old.categorySourceReason != next.categorySourceReason ||
                                 old.color != next.color;
     if (!fixtureChanged)
       continue;

--- a/gui/fixturetable/fixture_table_edit_service.cpp
+++ b/gui/fixturetable/fixture_table_edit_service.cpp
@@ -251,7 +251,9 @@ void UpdateSceneData(ISceneAdapter &adapter, wxDataViewListCtrl *table,
     anyChanged = true;
     it->second = next;
     if (!next.typeName.empty() && !next.category.empty())
-      GdtfDictionary::UpdateCategory(next.typeName, next.category);
+      GdtfDictionary::UpdateCategory(next.typeName, next.category,
+                                     next.categorySource,
+                                     next.categorySourceReason);
     if (!it->second.position.empty())
       scene.positions[it->second.position] = it->second.positionName;
 

--- a/gui/fixturetable/fixture_table_edit_service.cpp
+++ b/gui/fixturetable/fixture_table_edit_service.cpp
@@ -65,6 +65,7 @@ void PropagateTypeValues(wxDataViewListCtrl *table,
 void UpdateSceneData(ISceneAdapter &adapter, wxDataViewListCtrl *table,
                      const std::vector<std::string> &rowUuids,
                      const std::vector<wxString> &gdtfPaths,
+                     const std::unordered_set<std::string> *manualCategoryUuids,
                      bool logChanges) {
   // Ensure in-place cell editors commit pending values before reading table rows.
   if (table)
@@ -94,6 +95,9 @@ void UpdateSceneData(ISceneAdapter &adapter, wxDataViewListCtrl *table,
 
     const Fixture old = it->second;
     Fixture next = old;
+    const bool forceManualCategory =
+        manualCategoryUuids &&
+        manualCategoryUuids->find(rowUuids[i]) != manualCategoryUuids->end();
 
     if (i < gdtfPaths.size())
       next.gdtfSpec = std::string(gdtfPaths[i].ToUTF8());
@@ -205,7 +209,8 @@ void UpdateSceneData(ISceneAdapter &adapter, wxDataViewListCtrl *table,
 
     table->GetValue(v, i, 18);
     next.category = GdtfFixtureCategory::NormalizeCategory(std::string(v.GetString().ToUTF8()));
-    if (!next.category.empty()) {
+    if (!next.category.empty() &&
+        (forceManualCategory || next.category != old.category)) {
       next.categorySource = GdtfFixtureCategory::kManualSource;
       next.categorySourceReason.clear();
     }

--- a/gui/fixturetable/fixture_table_edit_service.cpp
+++ b/gui/fixturetable/fixture_table_edit_service.cpp
@@ -205,8 +205,10 @@ void UpdateSceneData(ISceneAdapter &adapter, wxDataViewListCtrl *table,
 
     table->GetValue(v, i, 18);
     next.category = GdtfFixtureCategory::NormalizeCategory(std::string(v.GetString().ToUTF8()));
-    if (!next.category.empty())
+    if (!next.category.empty()) {
       next.categorySource = GdtfFixtureCategory::kManualSource;
+      next.categorySourceReason.clear();
+    }
 
     table->GetValue(v, i, 19);
     if (v.GetType() == "wxDataViewIconText") {

--- a/gui/fixturetable/fixture_table_edit_service.h
+++ b/gui/fixturetable/fixture_table_edit_service.h
@@ -29,6 +29,7 @@ void PropagateTypeValues(wxDataViewListCtrl *table,
 void UpdateSceneData(ISceneAdapter &adapter, wxDataViewListCtrl *table,
                      const std::vector<std::string> &rowUuids,
                      const std::vector<wxString> &gdtfPaths,
+                     const std::unordered_set<std::string> *manualCategoryUuids = nullptr,
                      bool logChanges = true);
 
 } // namespace FixtureTableEditService

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -24,6 +24,7 @@
 #include "fixturetable/fixture_table_columns.h"
 #include "fixturetable/fixture_table_edit_service.h"
 #include "fixturetable/fixture_table_parser.h"
+#include "gdtf_fixture_category.h"
 #include "gdtfdictionary.h"
 #include "gdtfloader.h"
 #include "layerpanel.h"
@@ -150,6 +151,17 @@ wxString BuildFixtureTooltipForColumn(int modelColumn) {
   if (modelColumn == 5 || modelColumn == 6)
     return "DMX patch conflict detected. Universe and channel overlap with another fixture.";
   return wxString();
+}
+
+wxString BuildCategoryFallbackTooltip(const Fixture &fixture) {
+  if (fixture.categorySource != GdtfFixtureCategory::kAutoFallbackSource)
+    return wxString();
+  if (!fixture.categorySourceReason.empty()) {
+    return wxString::Format(
+        "Category auto-assigned by fallback: %s.",
+        wxString::FromUTF8(fixture.categorySourceReason).c_str());
+  }
+  return "Category auto-assigned by fallback.";
 }
 } // namespace
 
@@ -1190,8 +1202,18 @@ void FixtureTablePanel::UpdateHoverTooltip(const wxPoint &position) {
   if (item.IsOk() && column) {
     int row = table->ItemToRow(item);
     int modelColumn = column->GetModelColumn();
-    if (IsRedCell(store, row, modelColumn))
-      tooltip = BuildFixtureTooltipForColumn(modelColumn);
+    if (IsRedCell(store, row, modelColumn)) {
+      if (modelColumn == 18 && row >= 0 &&
+          static_cast<size_t>(row) < rowUuids.size()) {
+        const auto &fixtures =
+            guiConfigServices->LegacyConfigManager().GetScene().fixtures;
+        auto it = fixtures.find(rowUuids[static_cast<size_t>(row)]);
+        if (it != fixtures.end())
+          tooltip = BuildCategoryFallbackTooltip(it->second);
+      } else {
+        tooltip = BuildFixtureTooltipForColumn(modelColumn);
+      }
+    }
   }
 
   if (tooltip == activeHoverTooltip)
@@ -1402,7 +1424,26 @@ void FixtureTablePanel::HighlightDuplicateFixtureIds() {
   }
 
   HighlightPatchConflicts();
+  HighlightAutoFallbackCategories();
   table->Refresh();
+}
+
+void FixtureTablePanel::HighlightAutoFallbackCategories() {
+  auto &fixtures = guiConfigServices->LegacyConfigManager().GetScene().fixtures;
+  for (unsigned i = 0; i < table->GetItemCount(); ++i) {
+    store->ClearCellTextColour(i, 18);
+
+    if (i >= rowUuids.size())
+      continue;
+    auto it = fixtures.find(rowUuids[i]);
+    if (it == fixtures.end())
+      continue;
+
+    const Fixture &fixture = it->second;
+    if (fixture.categorySource == GdtfFixtureCategory::kAutoFallbackSource) {
+      store->SetCellTextColour(i, 18, *wxRED);
+    }
+  }
 }
 
 void FixtureTablePanel::ResyncRows(

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -676,6 +676,8 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
       if (r != wxNOT_FOUND)
         table->SetValue(wxVariant(value), r, col);
     }
+    for (const auto &uuid : selectedUuids)
+      manualCategoryUuidsPending.insert(uuid);
     PropagateTypeValues(selections, col);
     ResyncRows(oldOrder, selectedUuids);
     UpdateSceneData();
@@ -1330,7 +1332,9 @@ void FixtureTablePanel::PropagateTypeValues(
 void FixtureTablePanel::UpdateSceneData(bool logChanges) {
   ConfigManagerSceneAdapter adapter;
   FixtureTableEditService::UpdateSceneData(adapter, table, rowUuids, gdtfPaths,
-                                         logChanges);
+                                           &manualCategoryUuidsPending,
+                                           logChanges);
+  manualCategoryUuidsPending.clear();
 
   HighlightDuplicateFixtureIds();
 

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -671,14 +671,26 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
     if (dlg.ShowModal() != wxID_OK)
       return;
     const wxString value = dlg.GetStringSelection();
+    std::unordered_set<std::string> selectedTypes;
     for (const auto &it : selections) {
       int r = table->ItemToRow(it);
-      if (r != wxNOT_FOUND)
+      if (r != wxNOT_FOUND) {
         table->SetValue(wxVariant(value), r, col);
+        wxVariant typeValue;
+        table->GetValue(typeValue, r, 2);
+        selectedTypes.insert(std::string(typeValue.GetString().ToUTF8()));
+      }
     }
-    for (const auto &uuid : selectedUuids)
-      manualCategoryUuidsPending.insert(uuid);
     PropagateTypeValues(selections, col);
+    for (unsigned int row = 0; row < table->GetItemCount() &&
+                               row < rowUuids.size();
+         ++row) {
+      wxVariant typeValue;
+      table->GetValue(typeValue, row, 2);
+      const std::string typeName = std::string(typeValue.GetString().ToUTF8());
+      if (selectedTypes.find(typeName) != selectedTypes.end())
+        manualCategoryUuidsPending.insert(rowUuids[row]);
+    }
     ResyncRows(oldOrder, selectedUuids);
     UpdateSceneData();
     HighlightDuplicateFixtureIds();

--- a/gui/fixturetablepanel.h
+++ b/gui/fixturetablepanel.h
@@ -83,6 +83,7 @@ private:
     void ApplyModeForGdtf(const wxString& path, const wxString& preferredMode = wxString());
     void HighlightDuplicateFixtureIds();
     void HighlightPatchConflicts();
+    void HighlightAutoFallbackCategories();
 
     wxString activeHoverTooltip;
 };

--- a/gui/fixturetablepanel.h
+++ b/gui/fixturetablepanel.h
@@ -22,6 +22,7 @@
 #include <wx/time.h>
 #include <vector>
 #include <string>
+#include <unordered_set>
 #include "colorstore.h"
 #include "positionvalueupdate.h"
 
@@ -62,6 +63,7 @@ private:
     bool dragSelecting = false;
     int startRow = -1;
     std::vector<int> selectionOrder;
+    std::unordered_set<std::string> manualCategoryUuidsPending;
     IGuiConfigServices *guiConfigServices = nullptr;
 
     void InitializeTable(); // Set up columns

--- a/gui/tools/fixture_category_assignment_tool.cpp
+++ b/gui/tools/fixture_category_assignment_tool.cpp
@@ -65,6 +65,7 @@ void RunFixtureCategoryAssignment(MainWindow &window) {
     }
     fixture.category = inferredCategory;
     fixture.categorySource = GdtfFixtureCategory::kAutoFallbackSource;
+    fixture.categorySourceReason = inferred.reason;
     if (!fixture.typeName.empty() &&
         inferredCategory != GdtfFixtureCategory::kUnknown) {
       updatedTypeCategories.insert({fixture.typeName, inferredCategory});

--- a/gui/tools/fixture_category_assignment_tool.cpp
+++ b/gui/tools/fixture_category_assignment_tool.cpp
@@ -82,7 +82,9 @@ void RunFixtureCategoryAssignment(MainWindow &window) {
   }
 
   for (const auto &[typeName, category] : updatedTypeCategories)
-    GdtfDictionary::UpdateCategory(typeName, category);
+    GdtfDictionary::UpdateCategory(typeName, category,
+                                   GdtfFixtureCategory::kAutoFallbackSource,
+                                   "batch assignment tool");
 
   window.RefreshAfterToolSceneUpdate();
 

--- a/models/fixture.h
+++ b/models/fixture.h
@@ -54,6 +54,7 @@ struct Fixture {
 
     std::string category;         // Fixture category (Spot, Wash, etc.)
     std::string categorySource;   // Category source (Manual, AutoFallback, ...)
+    std::string categorySourceReason; // Why category fallback was applied
 
     // Convenience method to access translation as array
     std::array<float,3> GetPosition() const { return transform.o; }

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -1459,6 +1459,11 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
       categorySource->SetText(f.categorySource.c_str());
       info->InsertEndChild(categorySource);
     }
+    if (!f.categorySourceReason.empty()) {
+      tinyxml2::XMLElement *categoryReason = doc.NewElement("CategoryReason");
+      categoryReason->SetText(f.categorySourceReason.c_str());
+      info->InsertEndChild(categoryReason);
+    }
 
     data->InsertEndChild(info);
     ud->InsertEndChild(data);

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -477,9 +477,15 @@ static void ReadFixtureCategoryFromUserData(tinyxml2::XMLElement *fixtureNode,
       if (const char *txt = sourceNode->GetText())
         fixture.categorySource = Trim(txt);
     }
+    if (tinyxml2::XMLElement *reasonNode = info->FirstChildElement("CategoryReason")) {
+      if (const char *txt = reasonNode->GetText())
+        fixture.categorySourceReason = Trim(txt);
+    }
 
     if (!fixture.category.empty() && fixture.categorySource.empty())
       fixture.categorySource = GdtfFixtureCategory::kManualSource;
+    if (fixture.categorySource == GdtfFixtureCategory::kManualSource)
+      fixture.categorySourceReason.clear();
     return;
   }
 }
@@ -1322,8 +1328,10 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         if (fixture.category.empty() && !fixture.typeName.empty()) {
           if (auto entry = GdtfDictionary::Get(fixture.typeName))
             fixture.category = GdtfFixtureCategory::NormalizeCategory(entry->category);
-          if (!fixture.category.empty())
+          if (!fixture.category.empty()) {
             fixture.categorySource = GdtfFixtureCategory::kManualSource;
+            fixture.categorySourceReason.clear();
+          }
         }
 
         if (fixture.category.empty() && !categoryKey.empty()) {
@@ -1331,6 +1339,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
           if (cacheIt != categoryByTypeKey.end()) {
             fixture.category = cacheIt->second.category;
             fixture.categorySource = cacheIt->second.source;
+            fixture.categorySourceReason = cacheIt->second.reason;
           }
         }
 
@@ -1340,6 +1349,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
           if (fixture.category.empty())
             fixture.category = GdtfFixtureCategory::kUnknown;
           fixture.categorySource = GdtfFixtureCategory::kAutoFallbackSource;
+          fixture.categorySourceReason = inferred.reason;
           if (!categoryKey.empty()) {
             categoryByTypeKey[categoryKey] =
                 {fixture.category, fixture.categorySource, inferred.reason};
@@ -1352,7 +1362,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
               {fixture.category, fixture.categorySource.empty()
                                      ? GdtfFixtureCategory::kManualSource
                                      : fixture.categorySource,
-               "cached"};
+               fixture.categorySourceReason.empty() ? "cached"
+                                                   : fixture.categorySourceReason};
         }
 
         if (!fixture.category.empty() && !fixture.typeName.empty())

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -1326,11 +1326,16 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
             !fixture.typeName.empty() ? fixture.typeName : fixture.gdtfSpec;
 
         if (fixture.category.empty() && !fixture.typeName.empty()) {
-          if (auto entry = GdtfDictionary::Get(fixture.typeName))
+          if (auto entry = GdtfDictionary::Get(fixture.typeName)) {
             fixture.category = GdtfFixtureCategory::NormalizeCategory(entry->category);
+            fixture.categorySource = entry->categorySource;
+            fixture.categorySourceReason = entry->categoryReason;
+          }
           if (!fixture.category.empty()) {
-            fixture.categorySource = GdtfFixtureCategory::kManualSource;
-            fixture.categorySourceReason.clear();
+            if (fixture.categorySource.empty())
+              fixture.categorySource = GdtfFixtureCategory::kManualSource;
+            if (fixture.categorySource == GdtfFixtureCategory::kManualSource)
+              fixture.categorySourceReason.clear();
           }
         }
 
@@ -1367,7 +1372,9 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         }
 
         if (!fixture.category.empty() && !fixture.typeName.empty())
-          GdtfDictionary::UpdateCategory(fixture.typeName, fixture.category);
+          GdtfDictionary::UpdateCategory(fixture.typeName, fixture.category,
+                                         fixture.categorySource,
+                                         fixture.categorySourceReason);
         auto posIt = scene.positions.find(fixture.position);
         if (posIt != scene.positions.end())
           fixture.positionName = posIt->second;

--- a/tests/riderimporter_stubs.cpp
+++ b/tests/riderimporter_stubs.cpp
@@ -36,7 +36,8 @@ std::optional<std::unordered_map<std::string, Entry>> Load() { return std::unord
 void Save(const std::unordered_map<std::string, Entry> &) {}
 std::optional<Entry> Get(const std::string &) { return std::nullopt; }
 void Update(const std::string &, const std::string &, const std::string &, const std::string &) {}
-void UpdateCategory(const std::string &, const std::string &) {}
+void UpdateCategory(const std::string &, const std::string &,
+                    const std::string &, const std::string &) {}
 }
 
 namespace TrussDictionary {

--- a/tests/save_load_roundtrip_test.cpp
+++ b/tests/save_load_roundtrip_test.cpp
@@ -49,6 +49,11 @@ int main() {
 
     // Dictionary entry that should NOT be applied on load
     GdtfDictionary::Update("FixtureType", (tempDir / "dict.gdtf").string(), "");
+    GdtfDictionary::UpdateCategory("TextOnlyType", "Spot");
+    auto textOnlyEntry = GdtfDictionary::Get("TextOnlyType");
+    assert(textOnlyEntry.has_value());
+    assert(textOnlyEntry->category == "Spot");
+    assert(textOnlyEntry->path.empty());
 
     Fixture f; f.uuid = "fx1"; f.instanceName = "Fixture"; f.layer = layer.name; f.typeName = "FixtureType"; f.gdtfSpec = "orig.gdtf"; f.color = "#445566"; f.fixtureIdText = "S101A"; f.fixtureIdNumeric = 101; f.fixtureId = 101; scene.fixtures[f.uuid] = f;
     Fixture f2; f2.uuid = "fx2"; f2.instanceName = "Fixture 2"; f2.layer = layer.name; f2.typeName = "FixtureType"; f2.gdtfSpec = "orig.gdtf"; f2.fixtureIdText = "S101B"; f2.fixtureIdNumeric = 101; f2.fixtureId = 101; scene.fixtures[f2.uuid] = f2;

--- a/tests/save_load_roundtrip_test.cpp
+++ b/tests/save_load_roundtrip_test.cpp
@@ -49,10 +49,11 @@ int main() {
 
     // Dictionary entry that should NOT be applied on load
     GdtfDictionary::Update("FixtureType", (tempDir / "dict.gdtf").string(), "");
-    GdtfDictionary::UpdateCategory("TextOnlyType", "Spot");
+    GdtfDictionary::UpdateCategory("TextOnlyType", "Spot", "Manual", "");
     auto textOnlyEntry = GdtfDictionary::Get("TextOnlyType");
     assert(textOnlyEntry.has_value());
     assert(textOnlyEntry->category == "Spot");
+    assert(textOnlyEntry->categorySource == "Manual");
     assert(textOnlyEntry->path.empty());
 
     Fixture f; f.uuid = "fx1"; f.instanceName = "Fixture"; f.layer = layer.name; f.typeName = "FixtureType"; f.gdtfSpec = "orig.gdtf"; f.color = "#445566"; f.fixtureIdText = "S101A"; f.fixtureIdNumeric = 101; f.fixtureId = 101; scene.fixtures[f.uuid] = f;


### PR DESCRIPTION
### Motivation
- Preserve why a fixture category was auto-assigned so users can understand fallback decisions and avoid confusion when categories are inferred.
- Surface that information in the UI and exports so workflows that rely on imported/exported scenes retain the provenance of category values.

### Description
- Added `categorySourceReason` to `Fixture` and threaded it through import/export and assignment logic to record the human-friendly reason for auto-fallback decisions.
- Set `categorySourceReason` when categories are inferred from names, GDTF filenames, or when `GdtfFixtureCategory::InferFromGdtf` is used, and clear the reason when the category is explicitly set to manual (`kManualSource`).
- Persisted the reason in MVR export/import using the new `CategoryReason` XML element and read it back when importing (`ReadFixtureCategoryFromUserData`).
- Updated GUI: added a tooltip generator `BuildCategoryFallbackTooltip`, highlighted auto-fallback category cells in the fixture table (`HighlightAutoFallbackCategories`), and ensured editing the category via the table clears/sets the reason appropriately.
- Updated the fixture category assignment tool to store the inferred `reason` when auto-assigning categories and cached the reason when populating `categoryByTypeKey`.

### Testing
- Built the project and ran the automated test suite with `cmake --build . && ctest -j`, and the test suite completed successfully with no failures.
- Ran import/export related regression tests (scene import/export and GDTF inference tests) as part of the CI test run; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4213914188324b25a6a8d2b81caf0)