### PR TITLE
Add category fallback reason, support text-only GDTF dictionary entries, and respect manual categories

### DIFF
--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -96,16 +96,18 @@ std::optional<std::unordered_map<std::string, Entry>> Load() {
         fname = it.value()["file"].get<std::string>();
       else if (it.value().contains("path") && it.value()["path"].is_string())
         fname = it.value()["path"].get<std::string>();
-      if (fname.empty())
-        continue;
-      fs::path p = fs::u8path(fname);
-      if (!p.is_absolute())
-        p = dir / p;
-      e.path = p.string();
+      if (!fname.empty()) {
+        fs::path p = fs::u8path(fname);
+        if (!p.is_absolute())
+          p = dir / p;
+        e.path = p.string();
+      }
       if (it.value().contains("mode") && it.value()["mode"].is_string())
         e.mode = it.value()["mode"].get<std::string>();
       if (it.value().contains("category") && it.value()["category"].is_string())
         e.category = it.value()["category"].get<std::string>();
+      if (e.path.empty() && e.mode.empty() && e.category.empty())
+        continue;
       dict[it.key()] = e;
     }
   }
@@ -125,18 +127,21 @@ void Save(const std::unordered_map<std::string, Entry> &dict) {
   std::sort(keys.begin(), keys.end());
   for (const auto &type : keys) {
     const auto &entry = dict.at(type);
-    if (entry.path.empty())
+    if (entry.path.empty() && entry.mode.empty() && entry.category.empty())
       continue;
     nlohmann::json obj;
-    fs::path p = fs::u8path(entry.path);
-    const std::string fileName = p.filename().string();
-    if (fileName.empty())
-      continue;
-    obj["file"] = fileName;
+    if (!entry.path.empty()) {
+      fs::path p = fs::u8path(entry.path);
+      const std::string fileName = p.filename().string();
+      if (!fileName.empty())
+        obj["file"] = fileName;
+    }
     if (!entry.mode.empty())
       obj["mode"] = entry.mode;
     if (!entry.category.empty())
       obj["category"] = entry.category;
+    if (obj.empty())
+      continue;
     j[type] = obj;
   }
   std::ofstream out(file);
@@ -154,7 +159,7 @@ std::optional<Entry> Get(const std::string &type) {
   auto it = dict.find(type);
   if (it == dict.end())
     return std::nullopt;
-  if (!fs::exists(it->second.path)) {
+  if (!it->second.path.empty() && !fs::exists(it->second.path)) {
     dict.erase(it);
     Save(dict);
     return std::nullopt;
@@ -206,9 +211,13 @@ void UpdateCategory(const std::string &type, const std::string &category) {
     return;
   auto &dict = *dictOpt;
   auto it = dict.find(type);
-  if (it == dict.end())
-    return;
-  it->second.category = category;
+  if (it == dict.end()) {
+    Entry e;
+    e.category = category;
+    dict[type] = e;
+  } else {
+    it->second.category = category;
+  }
   Save(dict);
 }
 

--- a/core/gdtfdictionary.h
+++ b/core/gdtfdictionary.h
@@ -23,7 +23,7 @@
 
 namespace GdtfDictionary {
     struct Entry {
-        std::string path; // absolute path inside fixtures library
+        std::string path; // optional absolute path inside fixtures library
         std::string mode;
         std::string category;
     };

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -160,6 +160,8 @@ void EnsureFixtureCategoryForImport(const MvrScene &scene, Fixture &fixture) {
 
   if (fixture.category.empty()) {
     fixture.category = inferCategoryFromName(fixture.typeName);
+    if (!fixture.category.empty())
+      fixture.categorySourceReason = "name hint typeName";
   }
 
   if (fixture.category.empty() && !fixture.gdtfSpec.empty()) {
@@ -167,13 +169,19 @@ void EnsureFixtureCategoryForImport(const MvrScene &scene, Fixture &fixture) {
         ResolveGdtfPath(scene, fixture.gdtfSpec);
     const std::filesystem::path gdtfPath(resolvedGdtfPath);
     fixture.category = inferCategoryFromName(gdtfPath.stem().string());
+    if (!fixture.category.empty())
+      fixture.categorySourceReason = "name hint gdtf filename";
   }
 
-  if (fixture.category.empty())
+  if (fixture.category.empty()) {
     fixture.category = GdtfFixtureCategory::kUnknown;
+    fixture.categorySourceReason = "no hints";
+  }
 
   if (fixture.categorySource.empty())
     fixture.categorySource = GdtfFixtureCategory::kAutoFallbackSource;
+  if (fixture.categorySource == GdtfFixtureCategory::kManualSource)
+    fixture.categorySourceReason.clear();
 }
 
 bool TryParseFloat(const std::string &text, float &out) {
@@ -1152,6 +1160,7 @@ bool RiderImporter::ImportText(const std::string &text) {
           if (!dictionaryCategory.empty()) {
             f.category = dictionaryCategory;
             f.categorySource = GdtfFixtureCategory::kManualSource;
+            f.categorySourceReason.clear();
           }
           const std::string resolvedGdtfPath = ResolveGdtfPath(scene, f.gdtfSpec);
           std::string parsed = Trim(GetGdtfFixtureName(resolvedGdtfPath));

--- a/gui/fixturetable/fixture_table_edit_service.cpp
+++ b/gui/fixturetable/fixture_table_edit_service.cpp
@@ -65,6 +65,7 @@ void PropagateTypeValues(wxDataViewListCtrl *table,
 void UpdateSceneData(ISceneAdapter &adapter, wxDataViewListCtrl *table,
                      const std::vector<std::string> &rowUuids,
                      const std::vector<wxString> &gdtfPaths,
+                     const std::unordered_set<std::string> *manualCategoryUuids,
                      bool logChanges) {
   // Ensure in-place cell editors commit pending values before reading table rows.
   if (table)
@@ -94,6 +95,9 @@ void UpdateSceneData(ISceneAdapter &adapter, wxDataViewListCtrl *table,
 
     const Fixture old = it->second;
     Fixture next = old;
+    const bool forceManualCategory =
+        manualCategoryUuids &&
+        manualCategoryUuids->find(rowUuids[i]) != manualCategoryUuids->end();
 
     if (i < gdtfPaths.size())
       next.gdtfSpec = std::string(gdtfPaths[i].ToUTF8());
@@ -205,8 +209,11 @@ void UpdateSceneData(ISceneAdapter &adapter, wxDataViewListCtrl *table,
 
     table->GetValue(v, i, 18);
     next.category = GdtfFixtureCategory::NormalizeCategory(std::string(v.GetString().ToUTF8()));
-    if (!next.category.empty())
+    if (!next.category.empty() &&
+        (forceManualCategory || next.category != old.category)) {
       next.categorySource = GdtfFixtureCategory::kManualSource;
+      next.categorySourceReason.clear();
+    }
 
     table->GetValue(v, i, 19);
     if (v.GetType() == "wxDataViewIconText") {
@@ -234,6 +241,8 @@ void UpdateSceneData(ISceneAdapter &adapter, wxDataViewListCtrl *table,
                                 !Units::NearlyEqualWeightKilograms(old.weightKg, next.weightKg,
                                                                  0.001) ||
                                 old.category != next.category ||
+                                old.categorySource != next.categorySource ||
+                                old.categorySourceReason != next.categorySourceReason ||
                                 old.color != next.color;
     if (!fixtureChanged)
       continue;
@@ -241,8 +250,10 @@ void UpdateSceneData(ISceneAdapter &adapter, wxDataViewListCtrl *table,
     pushUndoIfNeeded();
     anyChanged = true;
     it->second = next;
-    if (!next.typeName.empty() && !next.category.empty())
+    if (!next.typeName.empty() && !next.category.empty() &&
+        next.categorySource == GdtfFixtureCategory::kManualSource) {
       GdtfDictionary::UpdateCategory(next.typeName, next.category);
+    }
     if (!it->second.position.empty())
       scene.positions[it->second.position] = it->second.positionName;
 

--- a/gui/fixturetable/fixture_table_edit_service.h
+++ b/gui/fixturetable/fixture_table_edit_service.h
@@ -29,6 +29,7 @@ void PropagateTypeValues(wxDataViewListCtrl *table,
 void UpdateSceneData(ISceneAdapter &adapter, wxDataViewListCtrl *table,
                      const std::vector<std::string> &rowUuids,
                      const std::vector<wxString> &gdtfPaths,
+                     const std::unordered_set<std::string> *manualCategoryUuids = nullptr,
                      bool logChanges = true);
 
 } // namespace FixtureTableEditService

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -24,6 +24,7 @@
 #include "fixturetable/fixture_table_columns.h"
 #include "fixturetable/fixture_table_edit_service.h"
 #include "fixturetable/fixture_table_parser.h"
+#include "gdtf_fixture_category.h"
 #include "gdtfdictionary.h"
 #include "gdtfloader.h"
 #include "layerpanel.h"
@@ -150,6 +151,17 @@ wxString BuildFixtureTooltipForColumn(int modelColumn) {
   if (modelColumn == 5 || modelColumn == 6)
     return "DMX patch conflict detected. Universe and channel overlap with another fixture.";
   return wxString();
+}
+
+wxString BuildCategoryFallbackTooltip(const Fixture &fixture) {
+  if (fixture.categorySource != GdtfFixtureCategory::kAutoFallbackSource)
+    return wxString();
+  if (!fixture.categorySourceReason.empty()) {
+    return wxString::Format(
+        "Category auto-assigned by fallback: %s.",
+        wxString::FromUTF8(fixture.categorySourceReason).c_str());
+  }
+  return "Category auto-assigned by fallback.";
 }
 } // namespace
 
@@ -659,12 +671,26 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
     if (dlg.ShowModal() != wxID_OK)
       return;
     const wxString value = dlg.GetStringSelection();
+    std::unordered_set<std::string> selectedTypes;
     for (const auto &it : selections) {
       int r = table->ItemToRow(it);
-      if (r != wxNOT_FOUND)
+      if (r != wxNOT_FOUND) {
         table->SetValue(wxVariant(value), r, col);
+        wxVariant typeValue;
+        table->GetValue(typeValue, r, 2);
+        selectedTypes.insert(std::string(typeValue.GetString().ToUTF8()));
+      }
     }
     PropagateTypeValues(selections, col);
+    for (unsigned int row = 0; row < table->GetItemCount() &&
+                               row < rowUuids.size();
+         ++row) {
+      wxVariant typeValue;
+      table->GetValue(typeValue, row, 2);
+      const std::string typeName = std::string(typeValue.GetString().ToUTF8());
+      if (selectedTypes.find(typeName) != selectedTypes.end())
+        manualCategoryUuidsPending.insert(rowUuids[row]);
+    }
     ResyncRows(oldOrder, selectedUuids);
     UpdateSceneData();
     HighlightDuplicateFixtureIds();
@@ -1190,8 +1216,18 @@ void FixtureTablePanel::UpdateHoverTooltip(const wxPoint &position) {
   if (item.IsOk() && column) {
     int row = table->ItemToRow(item);
     int modelColumn = column->GetModelColumn();
-    if (IsRedCell(store, row, modelColumn))
-      tooltip = BuildFixtureTooltipForColumn(modelColumn);
+    if (IsRedCell(store, row, modelColumn)) {
+      if (modelColumn == 18 && row >= 0 &&
+          static_cast<size_t>(row) < rowUuids.size()) {
+        const auto &fixtures =
+            guiConfigServices->LegacyConfigManager().GetScene().fixtures;
+        auto it = fixtures.find(rowUuids[static_cast<size_t>(row)]);
+        if (it != fixtures.end())
+          tooltip = BuildCategoryFallbackTooltip(it->second);
+      } else {
+        tooltip = BuildFixtureTooltipForColumn(modelColumn);
+      }
+    }
   }
 
   if (tooltip == activeHoverTooltip)
@@ -1308,7 +1344,9 @@ void FixtureTablePanel::PropagateTypeValues(
 void FixtureTablePanel::UpdateSceneData(bool logChanges) {
   ConfigManagerSceneAdapter adapter;
   FixtureTableEditService::UpdateSceneData(adapter, table, rowUuids, gdtfPaths,
-                                         logChanges);
+                                           &manualCategoryUuidsPending,
+                                           logChanges);
+  manualCategoryUuidsPending.clear();
 
   HighlightDuplicateFixtureIds();
 
@@ -1402,7 +1440,26 @@ void FixtureTablePanel::HighlightDuplicateFixtureIds() {
   }
 
   HighlightPatchConflicts();
+  HighlightAutoFallbackCategories();
   table->Refresh();
+}
+
+void FixtureTablePanel::HighlightAutoFallbackCategories() {
+  auto &fixtures = guiConfigServices->LegacyConfigManager().GetScene().fixtures;
+  for (unsigned i = 0; i < table->GetItemCount(); ++i) {
+    store->ClearCellTextColour(i, 18);
+
+    if (i >= rowUuids.size())
+      continue;
+    auto it = fixtures.find(rowUuids[i]);
+    if (it == fixtures.end())
+      continue;
+
+    const Fixture &fixture = it->second;
+    if (fixture.categorySource == GdtfFixtureCategory::kAutoFallbackSource) {
+      store->SetCellTextColour(i, 18, *wxRED);
+    }
+  }
 }
 
 void FixtureTablePanel::ResyncRows(

--- a/gui/fixturetablepanel.h
+++ b/gui/fixturetablepanel.h
@@ -22,6 +22,7 @@
 #include <wx/time.h>
 #include <vector>
 #include <string>
+#include <unordered_set>
 #include "colorstore.h"
 #include "positionvalueupdate.h"
 
@@ -62,6 +63,7 @@ private:
     bool dragSelecting = false;
     int startRow = -1;
     std::vector<int> selectionOrder;
+    std::unordered_set<std::string> manualCategoryUuidsPending;
     IGuiConfigServices *guiConfigServices = nullptr;
 
     void InitializeTable(); // Set up columns
@@ -83,6 +85,7 @@ private:
     void ApplyModeForGdtf(const wxString& path, const wxString& preferredMode = wxString());
     void HighlightDuplicateFixtureIds();
     void HighlightPatchConflicts();
+    void HighlightAutoFallbackCategories();
 
     wxString activeHoverTooltip;
 };

--- a/gui/tools/fixture_category_assignment_tool.cpp
+++ b/gui/tools/fixture_category_assignment_tool.cpp
@@ -65,6 +65,7 @@ void RunFixtureCategoryAssignment(MainWindow &window) {
     }
     fixture.category = inferredCategory;
     fixture.categorySource = GdtfFixtureCategory::kAutoFallbackSource;
+    fixture.categorySourceReason = inferred.reason;
     if (!fixture.typeName.empty() &&
         inferredCategory != GdtfFixtureCategory::kUnknown) {
       updatedTypeCategories.insert({fixture.typeName, inferredCategory});
@@ -80,8 +81,7 @@ void RunFixtureCategoryAssignment(MainWindow &window) {
     return;
   }
 
-  for (const auto &[typeName, category] : updatedTypeCategories)
-    GdtfDictionary::UpdateCategory(typeName, category);
+  (void)updatedTypeCategories;
 
   window.RefreshAfterToolSceneUpdate();
 

--- a/models/fixture.h
+++ b/models/fixture.h
@@ -54,6 +54,7 @@ struct Fixture {
 
     std::string category;         // Fixture category (Spot, Wash, etc.)
     std::string categorySource;   // Category source (Manual, AutoFallback, ...)
+    std::string categorySourceReason; // Why category fallback was applied
 
     // Convenience method to access translation as array
     std::array<float,3> GetPosition() const { return transform.o; }

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -1459,6 +1459,11 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
       categorySource->SetText(f.categorySource.c_str());
       info->InsertEndChild(categorySource);
     }
+    if (!f.categorySourceReason.empty()) {
+      tinyxml2::XMLElement *categoryReason = doc.NewElement("CategoryReason");
+      categoryReason->SetText(f.categorySourceReason.c_str());
+      info->InsertEndChild(categoryReason);
+    }
 
     data->InsertEndChild(info);
     ud->InsertEndChild(data);

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -477,9 +477,15 @@ static void ReadFixtureCategoryFromUserData(tinyxml2::XMLElement *fixtureNode,
       if (const char *txt = sourceNode->GetText())
         fixture.categorySource = Trim(txt);
     }
+    if (tinyxml2::XMLElement *reasonNode = info->FirstChildElement("CategoryReason")) {
+      if (const char *txt = reasonNode->GetText())
+        fixture.categorySourceReason = Trim(txt);
+    }
 
     if (!fixture.category.empty() && fixture.categorySource.empty())
       fixture.categorySource = GdtfFixtureCategory::kManualSource;
+    if (fixture.categorySource == GdtfFixtureCategory::kManualSource)
+      fixture.categorySourceReason.clear();
     return;
   }
 }
@@ -1320,10 +1326,13 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
             !fixture.typeName.empty() ? fixture.typeName : fixture.gdtfSpec;
 
         if (fixture.category.empty() && !fixture.typeName.empty()) {
-          if (auto entry = GdtfDictionary::Get(fixture.typeName))
+          if (auto entry = GdtfDictionary::Get(fixture.typeName)) {
             fixture.category = GdtfFixtureCategory::NormalizeCategory(entry->category);
-          if (!fixture.category.empty())
+          }
+          if (!fixture.category.empty()) {
             fixture.categorySource = GdtfFixtureCategory::kManualSource;
+            fixture.categorySourceReason.clear();
+          }
         }
 
         if (fixture.category.empty() && !categoryKey.empty()) {
@@ -1331,6 +1340,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
           if (cacheIt != categoryByTypeKey.end()) {
             fixture.category = cacheIt->second.category;
             fixture.categorySource = cacheIt->second.source;
+            fixture.categorySourceReason = cacheIt->second.reason;
           }
         }
 
@@ -1340,6 +1350,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
           if (fixture.category.empty())
             fixture.category = GdtfFixtureCategory::kUnknown;
           fixture.categorySource = GdtfFixtureCategory::kAutoFallbackSource;
+          fixture.categorySourceReason = inferred.reason;
           if (!categoryKey.empty()) {
             categoryByTypeKey[categoryKey] =
                 {fixture.category, fixture.categorySource, inferred.reason};
@@ -1352,11 +1363,14 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
               {fixture.category, fixture.categorySource.empty()
                                      ? GdtfFixtureCategory::kManualSource
                                      : fixture.categorySource,
-               "cached"};
+               fixture.categorySourceReason.empty() ? "cached"
+                                                   : fixture.categorySourceReason};
         }
 
-        if (!fixture.category.empty() && !fixture.typeName.empty())
+        if (!fixture.category.empty() && !fixture.typeName.empty() &&
+            fixture.categorySource == GdtfFixtureCategory::kManualSource) {
           GdtfDictionary::UpdateCategory(fixture.typeName, fixture.category);
+        }
         auto posIt = scene.positions.find(fixture.position);
         if (posIt != scene.positions.end())
           fixture.positionName = posIt->second;

--- a/tests/save_load_roundtrip_test.cpp
+++ b/tests/save_load_roundtrip_test.cpp
@@ -49,6 +49,11 @@ int main() {
 
     // Dictionary entry that should NOT be applied on load
     GdtfDictionary::Update("FixtureType", (tempDir / "dict.gdtf").string(), "");
+    GdtfDictionary::UpdateCategory("TextOnlyType", "Spot");
+    auto textOnlyEntry = GdtfDictionary::Get("TextOnlyType");
+    assert(textOnlyEntry.has_value());
+    assert(textOnlyEntry->category == "Spot");
+    assert(textOnlyEntry->path.empty());
 
     Fixture f; f.uuid = "fx1"; f.instanceName = "Fixture"; f.layer = layer.name; f.typeName = "FixtureType"; f.gdtfSpec = "orig.gdtf"; f.color = "#445566"; f.fixtureIdText = "S101A"; f.fixtureIdNumeric = 101; f.fixtureId = 101; scene.fixtures[f.uuid] = f;
     Fixture f2; f2.uuid = "fx2"; f2.instanceName = "Fixture 2"; f2.layer = layer.name; f2.typeName = "FixtureType"; f2.gdtfSpec = "orig.gdtf"; f2.fixtureIdText = "S101B"; f2.fixtureIdNumeric = 101; f2.fixtureId = 101; scene.fixtures[f2.uuid] = f2;


### PR DESCRIPTION
### Motivation
- Capture and expose why a fixture category was auto-assigned so users can see the fallback reason. 
- Allow dictionary entries that only contain textual metadata (category/mode) without a local GDTF file path. 
- Respect manually-assigned categories when editing multiple fixtures and avoid overwriting them or incorrectly updating the dictionary.

### Description
- Added `categorySourceReason` to `Fixture` and threaded it through import/export by reading/writing `CategoryReason` in MVR XML via `MvrImporter`/`MvrExporter` and by populating the field when inferring categories (`GdtfFixtureCategory::InferFromGdtf`).
- Updated the GDTF dictionary loading/saving in `gdtfdictionary.cpp` to accept entries that have only `mode`/`category` without a `file` path, avoid writing empty objects, and avoid removing entries that lack a path when checking existence (`Load`, `Save`, `Get`, `UpdateCategory`).
- Ensure dictionary `UpdateCategory` can create a text-only entry when none exists by storing a category-only `Entry`.
- Surface the fallback reason in the UI by adding `BuildCategoryFallbackTooltip`, highlighting auto-fallback categories in the fixture table with `HighlightAutoFallbackCategories`, and showing the reason in hover tooltips.
- When importing and editing, clear `categorySourceReason` for manual categories and only call `GdtfDictionary::UpdateCategory` when a category is explicitly manual; added logic to preserve manual category intent when multiple rows are edited by passing a `manualCategoryUuids` set through `UpdateSceneData` and marking pending manual updates from the context menu.
- Adjusted `fixture_category_assignment_tool` to set `categorySourceReason` from inferred results and stopped automatically updating the dictionary for those batch auto-assignments.
- Added small test coverage adjustment in `tests/save_load_roundtrip_test.cpp` to verify a text-only dictionary entry can be created and retains its empty `path`.

### Testing
- Built the project and ran the `save_load_roundtrip_test` which verifies dictionary text-only entries and scene roundtrip behavior, and the test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4213914188324b25a6a8d2b81caf0)