### PR TITLE
Add missing GDTF mode channel stub for tests

### DIFF
--- a/tests/gdtfloader_stub.cpp
+++ b/tests/gdtfloader_stub.cpp
@@ -22,11 +22,17 @@
 
 struct GdtfObject { Mesh mesh; Matrix transform; };
 
+struct GdtfChannelInfo {
+    int channel = 0;
+    std::string function;
+};
+
 bool LoadGdtf(const std::string&, std::vector<GdtfObject>&, std::string*) {
     return false;
 }
 int GetGdtfModeChannelCount(const std::string&, const std::string&) { return 0; }
 std::vector<std::string> GetGdtfModes(const std::string&) { return {}; }
+std::vector<GdtfChannelInfo> GetGdtfModeChannels(const std::string&, const std::string&) { return {}; }
 std::string GetGdtfFixtureName(const std::string& gdtfPath) { return gdtfPath; }
 std::string GetGdtfModelColor(const std::string& gdtfPath) { return "#000000"; }
 bool SetGdtfModelColor(const std::string&, const std::string&) { return true; }


### PR DESCRIPTION
### Motivation
- Fix linker error `LNK2019` from test targets that use the stub loader because `core/riderimporter.cpp` calls `GetGdtfModeChannels` but the test stub did not provide the symbol or the `GdtfChannelInfo` type.

### Description
- Add `GdtfChannelInfo` struct and a stub `GetGdtfModeChannels(const std::string&, const std::string&)` returning an empty vector to `tests/gdtfloader_stub.cpp` so the test translation unit exposes the same channel-info API used by import code.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.
- Attempted `cmake --preset wsl-x64-debug` to validate a build, but configuration failed in this environment due to missing `wxWidgets`, so a full link/build verification was not possible here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c58ae8b6108324ad16b1ee8c50ff71)