### PR TITLE
Fix unresolved rider importer test symbols in CMake

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -429,6 +429,7 @@ add_executable(riderimporter_fixtureid_test rider_import_fixtureid_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -445,7 +446,7 @@ add_executable(riderimporter_fixtureid_test rider_import_fixtureid_test.cpp
                ${LAYOUT_SOURCES})
 target_include_directories(riderimporter_fixtureid_test PRIVATE
                            . ../core ../models ../mvr ../gui ../third_party)
-target_link_libraries(riderimporter_fixtureid_test PRIVATE ${wxWidgets_LIBRARIES})
+target_link_libraries(riderimporter_fixtureid_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
 add_test(NAME RiderImporterFixtureIds COMMAND riderimporter_fixtureid_test
          ${CMAKE_CURRENT_SOURCE_DIR}/data/rider_fixtureid_basic.txt
          ${CMAKE_CURRENT_SOURCE_DIR}/data/rider_fixtureid_over100.txt)
@@ -455,6 +456,7 @@ add_executable(rider_import_order_test rider_import_order_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -471,7 +473,7 @@ add_executable(rider_import_order_test rider_import_order_test.cpp
                ${LAYOUT_SOURCES})
 target_include_directories(rider_import_order_test PRIVATE
                            . ../core ../models ../mvr ../gui ../third_party)
-target_link_libraries(rider_import_order_test PRIVATE ${wxWidgets_LIBRARIES})
+target_link_libraries(rider_import_order_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
 add_test(NAME RiderImportOrder COMMAND rider_import_order_test
          ${CMAKE_CURRENT_SOURCE_DIR}/data/rider_fixture_order.txt)
 set_library_env(RiderImportOrder)
@@ -480,6 +482,7 @@ add_executable(rider_import_preserve_existing_test rider_import_preserve_existin
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -496,7 +499,7 @@ add_executable(rider_import_preserve_existing_test rider_import_preserve_existin
                ${LAYOUT_SOURCES})
 target_include_directories(rider_import_preserve_existing_test PRIVATE
                            . ../core ../models ../mvr ../gui ../third_party)
-target_link_libraries(rider_import_preserve_existing_test PRIVATE ${wxWidgets_LIBRARIES})
+target_link_libraries(rider_import_preserve_existing_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
 add_test(NAME RiderImportPreserveExisting COMMAND rider_import_preserve_existing_test)
 set_library_env(RiderImportPreserveExisting)
 
@@ -504,6 +507,7 @@ add_executable(rider_import_category_test rider_import_category_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -520,7 +524,7 @@ add_executable(rider_import_category_test rider_import_category_test.cpp
                ${LAYOUT_SOURCES})
 target_include_directories(rider_import_category_test PRIVATE
                            . ../core ../models ../mvr ../gui ../third_party)
-target_link_libraries(rider_import_category_test PRIVATE ${wxWidgets_LIBRARIES})
+target_link_libraries(rider_import_category_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
 add_test(NAME RiderImportCategory COMMAND rider_import_category_test)
 set_library_env(RiderImportCategory)
 
@@ -528,6 +532,7 @@ add_executable(rider_autopatch_test rider_autopatch_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_onech_stub.cpp
                ../core/riderimporter.cpp
+               ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -544,7 +549,7 @@ add_executable(rider_autopatch_test rider_autopatch_test.cpp
                ${LAYOUT_SOURCES})
 target_include_directories(rider_autopatch_test PRIVATE
                            . ../core ../models ../mvr ../gui ../third_party)
-target_link_libraries(rider_autopatch_test PRIVATE ${wxWidgets_LIBRARIES})
+target_link_libraries(rider_autopatch_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
 add_test(NAME RiderAutoPatch COMMAND rider_autopatch_test
          ${CMAKE_CURRENT_SOURCE_DIR}/data/rider_fixtureid_basic.txt)
 set_library_env(RiderAutoPatch)
@@ -553,6 +558,7 @@ add_executable(rider_layer_mode_test rider_layer_mode_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -569,7 +575,7 @@ add_executable(rider_layer_mode_test rider_layer_mode_test.cpp
                ${LAYOUT_SOURCES})
 target_include_directories(rider_layer_mode_test PRIVATE
                            . ../core ../models ../mvr ../gui ../third_party)
-target_link_libraries(rider_layer_mode_test PRIVATE ${wxWidgets_LIBRARIES})
+target_link_libraries(rider_layer_mode_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
 add_test(NAME RiderLayerMode COMMAND rider_layer_mode_test
          ${CMAKE_CURRENT_SOURCE_DIR}/data/rider_layer_mode.txt)
 set_library_env(RiderLayerMode)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -596,6 +596,7 @@ add_executable(rider_filter_preview_test rider_filter_preview_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -612,7 +613,7 @@ add_executable(rider_filter_preview_test rider_filter_preview_test.cpp
                ${LAYOUT_SOURCES})
 target_include_directories(rider_filter_preview_test PRIVATE
                            . ../core ../models ../mvr ../gui ../third_party)
-target_link_libraries(rider_filter_preview_test PRIVATE ${wxWidgets_LIBRARIES})
+target_link_libraries(rider_filter_preview_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
 add_test(NAME RiderFilterPreview COMMAND rider_filter_preview_test)
 set_library_env(RiderFilterPreview)
 
@@ -620,6 +621,7 @@ add_executable(rider_led_screen_object_test rider_led_screen_object_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -636,7 +638,7 @@ add_executable(rider_led_screen_object_test rider_led_screen_object_test.cpp
                ${LAYOUT_SOURCES})
 target_include_directories(rider_led_screen_object_test PRIVATE
                            . ../core ../models ../mvr ../gui ../third_party)
-target_link_libraries(rider_led_screen_object_test PRIVATE ${wxWidgets_LIBRARIES})
+target_link_libraries(rider_led_screen_object_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
 add_test(NAME RiderLedScreenObject COMMAND rider_led_screen_object_test)
 set_library_env(RiderLedScreenObject)
 
@@ -644,6 +646,7 @@ add_executable(rider_hoist_import_test rider_hoist_import_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -661,7 +664,7 @@ add_executable(rider_hoist_import_test rider_hoist_import_test.cpp
                ${LAYOUT_SOURCES})
 target_include_directories(rider_hoist_import_test PRIVATE
                            . ../core ../models ../mvr ../gui ../third_party)
-target_link_libraries(rider_hoist_import_test PRIVATE ${wxWidgets_LIBRARIES})
+target_link_libraries(rider_hoist_import_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
 add_test(NAME RiderHoistImport COMMAND rider_hoist_import_test)
 set_library_env(RiderHoistImport)
 
@@ -669,6 +672,7 @@ add_executable(rider_import_benchmark rider_import_benchmark.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp

--- a/tests/gdtfloader_onech_stub.cpp
+++ b/tests/gdtfloader_onech_stub.cpp
@@ -21,12 +21,17 @@
 #include "mesh.h"
 
 struct GdtfObject { Mesh mesh; Matrix transform; };
+struct GdtfChannelInfo {
+    int channel = 0;
+    std::string function;
+};
 
 bool LoadGdtf(const std::string&, std::vector<GdtfObject>&, std::string*) {
     return false;
 }
 int GetGdtfModeChannelCount(const std::string&, const std::string&) { return 1; }
 std::vector<std::string> GetGdtfModes(const std::string&) { return {}; }
+std::vector<GdtfChannelInfo> GetGdtfModeChannels(const std::string&, const std::string&) { return {}; }
 std::string GetGdtfFixtureName(const std::string& gdtfPath) { return gdtfPath; }
 std::string GetGdtfModelColor(const std::string&) { return "#000000"; }
 bool GetGdtfProperties(const std::string&, float &w, float &p) {


### PR DESCRIPTION
### Motivation
- `riderimporter.cpp` began using `GdtfFixtureCategory::InferFromGdtf` and `GetGdtfModeChannels`, which created link-time unresolved symbols in multiple rider-related test executables. 

### Description
- Added `../core/gdtf_fixture_category.cpp` to the affected test targets in `tests/CMakeLists.txt` so `GdtfFixtureCategory::InferFromGdtf` is provided. 
- Linked those test targets against `tinyxml2::tinyxml2` in `tests/CMakeLists.txt` to satisfy `gdtf_fixture_category.cpp` dependencies. 
- Added the `GdtfChannelInfo` type and a `GetGdtfModeChannels(...)` stub to `tests/gdtfloader_onech_stub.cpp` to resolve the mode-channel symbol used by the one-channel test stub. 

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed. 
- Attempted a local build invocation for `rider_autopatch_test` and `riderimporter_fixtureid_test` but the step was skipped because there is no `build/` directory in the current container.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c58c01035c8324a3f0a40e255ce420)