### PR TITLE
Add strict JSON contract validation for dictionary imports

### DIFF
--- a/core/dictionary_json_contract.h
+++ b/core/dictionary_json_contract.h
@@ -1,0 +1,135 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "json.hpp"
+
+#include <optional>
+#include <string>
+
+namespace DictionaryJsonContract {
+
+inline constexpr const char *kKind = "perastage.dictionary";
+inline constexpr int kSchemaVersion = 1;
+
+struct ParsedDictionary {
+  std::string dictionaryType;
+  const nlohmann::json *entries = nullptr;
+};
+
+inline bool IsSupportedDictionaryType(const std::string &value) {
+  return value == "fixtures" || value == "trusses" || value == "combined";
+}
+
+inline bool Parse(const nlohmann::json &root, ParsedDictionary &out,
+                  std::string &error) {
+  if (!root.is_object()) {
+    error = "root must be a JSON object";
+    return false;
+  }
+
+  const auto kindIt = root.find("kind");
+  if (kindIt == root.end() || !kindIt->is_string()) {
+    error = "missing or invalid 'kind' (expected string 'perastage.dictionary')";
+    return false;
+  }
+  if (kindIt->get<std::string>() != kKind) {
+    error = "invalid 'kind' (expected 'perastage.dictionary')";
+    return false;
+  }
+
+  const auto schemaVersionIt = root.find("schema_version");
+  if (schemaVersionIt == root.end() || !schemaVersionIt->is_number_integer()) {
+    error = "missing or invalid 'schema_version' (expected integer)";
+    return false;
+  }
+  if (schemaVersionIt->get<int>() != kSchemaVersion) {
+    error = "unsupported 'schema_version' (expected 1)";
+    return false;
+  }
+
+  const auto dictionaryTypeIt = root.find("dictionary_type");
+  if (dictionaryTypeIt == root.end() || !dictionaryTypeIt->is_string()) {
+    error = "missing or invalid 'dictionary_type' (expected fixtures/trusses/combined)";
+    return false;
+  }
+
+  const std::string dictionaryType = dictionaryTypeIt->get<std::string>();
+  if (!IsSupportedDictionaryType(dictionaryType)) {
+    error = "invalid 'dictionary_type' (expected fixtures/trusses/combined)";
+    return false;
+  }
+
+  const auto entriesIt = root.find("entries");
+  if (entriesIt == root.end()) {
+    error = "missing required 'entries'";
+    return false;
+  }
+  if (!entriesIt->is_object() && !entriesIt->is_array()) {
+    error = "invalid 'entries' (expected object or array)";
+    return false;
+  }
+
+  out.dictionaryType = dictionaryType;
+  out.entries = &(*entriesIt);
+  return true;
+}
+
+inline std::optional<const nlohmann::json *>
+GetEntriesForType(const nlohmann::json &root, const std::string &expectedType,
+                  std::string &error) {
+  ParsedDictionary parsed;
+  if (!Parse(root, parsed, error))
+    return std::nullopt;
+
+  if (parsed.dictionaryType == "combined") {
+    if (!parsed.entries->is_object()) {
+      error = "combined dictionaries require 'entries' to be an object";
+      return std::nullopt;
+    }
+    const auto childIt = parsed.entries->find(expectedType);
+    if (childIt == parsed.entries->end()) {
+      error = "combined dictionary is missing entries for '" + expectedType + "'";
+      return std::nullopt;
+    }
+    if (!childIt->is_object() && !childIt->is_array()) {
+      error = "combined entries for '" + expectedType + "' must be object or array";
+      return std::nullopt;
+    }
+    return &(*childIt);
+  }
+
+  if (parsed.dictionaryType != expectedType) {
+    error = "dictionary_type mismatch (expected '" + expectedType + "')";
+    return std::nullopt;
+  }
+
+  return parsed.entries;
+}
+
+inline nlohmann::json MakeRoot(const std::string &dictionaryType,
+                               nlohmann::json entries) {
+  nlohmann::json root = nlohmann::json::object();
+  root["kind"] = kKind;
+  root["schema_version"] = kSchemaVersion;
+  root["dictionary_type"] = dictionaryType;
+  root["entries"] = std::move(entries);
+  return root;
+}
+
+} // namespace DictionaryJsonContract

--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -16,12 +16,14 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "gdtfdictionary.h"
+#include "dictionary_json_contract.h"
 #include "json.hpp"
 #include "projectutils.h"
 #include "startup_file_access_gate.h"
 #include <algorithm>
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <vector>
 
 namespace fs = std::filesystem;
@@ -46,7 +48,7 @@ static fs::path GetDictFile() {
     if (!fs::exists(file)) {
       std::ofstream create(file);
       if (create.is_open())
-        create << "{}";
+        create << DictionaryJsonContract::MakeRoot("fixtures", nlohmann::json::object()).dump(4);
     }
   }
   return file;
@@ -64,52 +66,103 @@ std::optional<std::unordered_map<std::string, Entry>> Load() {
   if (in.peek() == std::ifstream::traits_type::eof()) {
     std::ofstream out(file);
     if (out.is_open())
-      out << "{}";
+      out << DictionaryJsonContract::MakeRoot("fixtures", nlohmann::json::object()).dump(4);
     return dict;
   }
-  nlohmann::json j;
+  nlohmann::json root;
   try {
-    in >> j;
-  } catch (...) {
-    std::ofstream out(file);
-    if (out.is_open())
-      out << "{}";
-    return dict;
+    in >> root;
+  } catch (const std::exception &ex) {
+    std::cerr << "Invalid fixtures dictionary JSON in '" << file.string()
+              << "': parse error: " << ex.what() << std::endl;
+    return std::nullopt;
   }
-  if (!j.is_object()) {
-    std::ofstream out(file);
-    if (out.is_open())
-      out << "{}";
-    return dict;
+
+  std::string contractError;
+  auto entriesOpt = DictionaryJsonContract::GetEntriesForType(
+      root, "fixtures", contractError);
+  if (!entriesOpt) {
+    std::cerr << "Invalid fixtures dictionary JSON in '" << file.string()
+              << "': " << contractError << std::endl;
+    return std::nullopt;
   }
+
+  const nlohmann::json &entries = **entriesOpt;
   fs::path dir = file.parent_path();
-  for (auto it = j.begin(); it != j.end(); ++it) {
-    if (it.value().is_string()) {
-      fs::path p = fs::u8path(it.value().get<std::string>());
+  auto parseEntryValue = [&dir](const nlohmann::json &value, Entry &entry,
+                                std::string &entryError) -> bool {
+    if (value.is_string()) {
+      fs::path p = fs::u8path(value.get<std::string>());
       if (!p.is_absolute())
         p = dir / p;
-      dict[it.key()] = {p.string(), "", ""};
-    } else if (it.value().is_object()) {
-      Entry e;
-      std::string fname;
-      if (it.value().contains("file") && it.value()["file"].is_string())
-        fname = it.value()["file"].get<std::string>();
-      else if (it.value().contains("path") && it.value()["path"].is_string())
-        fname = it.value()["path"].get<std::string>();
-      if (!fname.empty()) {
-        fs::path p = fs::u8path(fname);
-        if (!p.is_absolute())
-          p = dir / p;
-        e.path = p.string();
-      }
-      if (it.value().contains("mode") && it.value()["mode"].is_string())
-        e.mode = it.value()["mode"].get<std::string>();
-      if (it.value().contains("category") && it.value()["category"].is_string())
-        e.category = it.value()["category"].get<std::string>();
-      if (e.path.empty() && e.mode.empty() && e.category.empty())
-        continue;
-      dict[it.key()] = e;
+      entry.path = p.string();
+      return true;
     }
+    if (!value.is_object()) {
+      entryError = "entry must be string or object";
+      return false;
+    }
+
+    std::string fname;
+    if (value.contains("file") && value["file"].is_string())
+      fname = value["file"].get<std::string>();
+    else if (value.contains("path") && value["path"].is_string())
+      fname = value["path"].get<std::string>();
+
+    if (!fname.empty()) {
+      fs::path p = fs::u8path(fname);
+      if (!p.is_absolute())
+        p = dir / p;
+      entry.path = p.string();
+    }
+    if (value.contains("mode") && value["mode"].is_string())
+      entry.mode = value["mode"].get<std::string>();
+    if (value.contains("category") && value["category"].is_string())
+      entry.category = value["category"].get<std::string>();
+    if (entry.path.empty() && entry.mode.empty() && entry.category.empty()) {
+      entryError = "entry object must include at least one of file/path/mode/category";
+      return false;
+    }
+    return true;
+  };
+
+  if (entries.is_object()) {
+    for (auto it = entries.begin(); it != entries.end(); ++it) {
+      Entry entry;
+      std::string entryError;
+      if (!parseEntryValue(it.value(), entry, entryError)) {
+        std::cerr << "Invalid fixtures dictionary JSON in '" << file.string()
+                  << "': invalid entry '" << it.key() << "': " << entryError
+                  << std::endl;
+        return std::nullopt;
+      }
+      dict[it.key()] = entry;
+    }
+    return dict;
+  }
+
+  for (size_t idx = 0; idx < entries.size(); ++idx) {
+    const nlohmann::json &entryJson = entries[idx];
+    if (!entryJson.is_object()) {
+      std::cerr << "Invalid fixtures dictionary JSON in '" << file.string()
+                << "': entries[" << idx << "] must be an object" << std::endl;
+      return std::nullopt;
+    }
+    if (!entryJson.contains("name") || !entryJson["name"].is_string()) {
+      std::cerr << "Invalid fixtures dictionary JSON in '" << file.string()
+                << "': entries[" << idx << "] missing string 'name'" << std::endl;
+      return std::nullopt;
+    }
+
+    Entry entry;
+    std::string entryError;
+    if (!parseEntryValue(entryJson, entry, entryError)) {
+      std::cerr << "Invalid fixtures dictionary JSON in '" << file.string()
+                << "': entries[" << idx << "] " << entryError << std::endl;
+      return std::nullopt;
+    }
+
+    dict[entryJson["name"].get<std::string>()] = entry;
   }
   return dict;
 }
@@ -119,7 +172,7 @@ void Save(const std::unordered_map<std::string, Entry> &dict) {
   fs::path file = GetDictFile();
   if (file.empty())
     return;
-  nlohmann::json j;
+  nlohmann::json entries = nlohmann::json::object();
   std::vector<std::string> keys;
   keys.reserve(dict.size());
   for (const auto &[type, entry] : dict)
@@ -142,12 +195,14 @@ void Save(const std::unordered_map<std::string, Entry> &dict) {
       obj["category"] = entry.category;
     if (obj.empty())
       continue;
-    j[type] = obj;
+    entries[type] = obj;
   }
+
+  const nlohmann::json root = DictionaryJsonContract::MakeRoot("fixtures", std::move(entries));
   std::ofstream out(file);
   if (!out.is_open())
     return;
-  out << j.dump(4);
+  out << root.dump(4);
 }
 
 std::optional<Entry> Get(const std::string &type) {

--- a/core/trussdictionary.cpp
+++ b/core/trussdictionary.cpp
@@ -17,6 +17,7 @@
  */
 #include "trussdictionary.h"
 
+#include "dictionary_json_contract.h"
 #include "json.hpp"
 #include "projectutils.h"
 #include "truss_gdtf_builder.h"
@@ -27,6 +28,7 @@
 #include <cctype>
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <regex>
 #include <vector>
 
@@ -91,7 +93,7 @@ static fs::path GetDictFile() {
     if (!fs::exists(file)) {
       std::ofstream create(file);
       if (create.is_open())
-        create << "{}";
+        create << DictionaryJsonContract::MakeRoot("trusses", nlohmann::json::object()).dump(4);
     }
   }
   return file;
@@ -192,52 +194,111 @@ std::optional<std::unordered_map<std::string, std::string>> Load() {
   if (in.peek() == std::ifstream::traits_type::eof()) {
     std::ofstream out(file);
     if (out.is_open())
-      out << "{}";
+      out << DictionaryJsonContract::MakeRoot("trusses", nlohmann::json::object()).dump(4);
     return dict;
   }
 
-  nlohmann::json j;
+  nlohmann::json root;
   try {
-    in >> j;
-  } catch (...) {
-    std::ofstream out(file);
-    if (out.is_open())
-      out << "{}";
-    return dict;
+    in >> root;
+  } catch (const std::exception &ex) {
+    std::cerr << "Invalid truss dictionary JSON in '" << file.string()
+              << "': parse error: " << ex.what() << std::endl;
+    return std::nullopt;
   }
 
-  if (!j.is_object()) {
-    std::ofstream out(file);
-    if (out.is_open())
-      out << "{}";
-    return dict;
+  std::string contractError;
+  auto entriesOpt = DictionaryJsonContract::GetEntriesForType(
+      root, "trusses", contractError);
+  if (!entriesOpt) {
+    std::cerr << "Invalid truss dictionary JSON in '" << file.string()
+              << "': " << contractError << std::endl;
+    return std::nullopt;
   }
 
+  const nlohmann::json &entries = **entriesOpt;
   fs::path dir = file.parent_path();
   bool changed = false;
 
-  for (auto it = j.begin(); it != j.end(); ++it) {
-    if (!it.value().is_string())
-      continue;
+  auto resolveEntryPath = [&dir](const nlohmann::json &value, fs::path &entryPath,
+                                 std::string &entryError) -> bool {
+    std::string pathValue;
+    if (value.is_string()) {
+      pathValue = value.get<std::string>();
+    } else if (value.is_object()) {
+      if (value.contains("file") && value["file"].is_string())
+        pathValue = value["file"].get<std::string>();
+      else if (value.contains("path") && value["path"].is_string())
+        pathValue = value["path"].get<std::string>();
+      else {
+        entryError = "entry object must include string 'file' or 'path'";
+        return false;
+      }
+    } else {
+      entryError = "entry must be string or object";
+      return false;
+    }
 
-    const std::string normalizedKey = NormalizeModelKey(it.key());
-    if (normalizedKey.empty())
-      continue;
+    entryPath = fs::u8path(pathValue);
+    if (!entryPath.is_absolute())
+      entryPath = dir / entryPath;
+    return true;
+  };
 
-    fs::path path = fs::u8path(it.value().get<std::string>());
-    if (!path.is_absolute())
-      path = dir / path;
+  auto processEntry = [&](const std::string &rawKey, const nlohmann::json &value,
+                          const std::string &sourceLabel) -> bool {
+    const std::string normalizedKey = NormalizeModelKey(rawKey);
+    if (normalizedKey.empty()) {
+      std::cerr << "Invalid truss dictionary JSON in '" << file.string()
+                << "': " << sourceLabel << " has an empty model name" << std::endl;
+      return false;
+    }
+
+    fs::path path;
+    std::string entryError;
+    if (!resolveEntryPath(value, path, entryError)) {
+      std::cerr << "Invalid truss dictionary JSON in '" << file.string()
+                << "': " << sourceLabel << " " << entryError << std::endl;
+      return false;
+    }
+
     if (!fs::exists(path))
-      continue;
+      return true;
 
-    std::string error;
+    std::string migrationError;
     fs::path migrated = path;
-    if (!EnsureMigratedToGdtf(migrated, error))
-      continue;
+    if (!EnsureMigratedToGdtf(migrated, migrationError))
+      return true;
 
-    if (migrated != path || normalizedKey != it.key())
+    if (migrated != path || normalizedKey != rawKey)
       changed = true;
     dict[normalizedKey] = ToUtf8String(migrated);
+    return true;
+  };
+
+  if (entries.is_object()) {
+    for (auto it = entries.begin(); it != entries.end(); ++it) {
+      if (!processEntry(it.key(), it.value(), "entry '" + it.key() + "'"))
+        return std::nullopt;
+    }
+  } else {
+    for (size_t idx = 0; idx < entries.size(); ++idx) {
+      const nlohmann::json &entryJson = entries[idx];
+      if (!entryJson.is_object()) {
+        std::cerr << "Invalid truss dictionary JSON in '" << file.string()
+                  << "': entries[" << idx << "] must be an object" << std::endl;
+        return std::nullopt;
+      }
+      if (!entryJson.contains("name") || !entryJson["name"].is_string()) {
+        std::cerr << "Invalid truss dictionary JSON in '" << file.string()
+                  << "': entries[" << idx << "] missing string 'name'" << std::endl;
+        return std::nullopt;
+      }
+      if (!processEntry(entryJson["name"].get<std::string>(), entryJson,
+                        "entries[" + std::to_string(idx) + "]")) {
+        return std::nullopt;
+      }
+    }
   }
 
   if (changed)
@@ -251,7 +312,7 @@ void Save(const std::unordered_map<std::string, std::string> &dict) {
   if (file.empty())
     return;
 
-  nlohmann::json j;
+  nlohmann::json entries = nlohmann::json::object();
   std::unordered_map<std::string, std::string> normalizedDict;
   normalizedDict.reserve(dict.size());
   for (const auto &[model, path] : dict) {
@@ -271,12 +332,13 @@ void Save(const std::unordered_map<std::string, std::string> &dict) {
     fs::path forced = p;
     if (forced.extension() != ".gdtf")
       forced.replace_extension(".gdtf");
-    j[model] = forced.filename().string();
+    entries[model] = forced.filename().string();
   }
 
+  const nlohmann::json root = DictionaryJsonContract::MakeRoot("trusses", std::move(entries));
   std::ofstream out(file);
   if (out.is_open())
-    out << j.dump(4);
+    out << root.dump(4);
 }
 
 std::optional<std::string> Get(const std::string &model) {

--- a/library/fixtures/gdtf_dictionary.json
+++ b/library/fixtures/gdtf_dictionary.json
@@ -1,246 +1,251 @@
 {
-    "Aleda B-EYE K10": {
-        "file": "Aleda B-EYE K10.gdtf",
-        "mode": "Shapes"
-    },
-    "Aleda K10 B-EYE (Bulb=LED)": {
-        "file": "Aleda B-EYE K10.gdtf",
-        "mode": "Shapes"
-    },
-    "BLINDER 2 PRO": {
-        "file": "BLINDER 2 PRO.gdtf",
-        "mode": "2ch d001"
-    },
-    "BLINDER 4 PRO": {
-        "file": "BLINDER 4 PRO.gdtf",
-        "mode": "4ch d001"
-    },
-    "BMFL WashBeam (Bulb=HTI 1700W_PS Lok-it_)": {
-        "file": "Robin BMFL WashBeam.gdtf",
-        "mode": "Mode 1 - Standard 16 bit"
-    },
-    "Beam 201": {
-        "file": "Sharpy.gdtf",
-        "mode": "Standard"
-    },
-    "Beam201": {
-        "file": "Sharpy.gdtf",
-        "mode": "Standard"
-    },
-    "Blinder 2": {
-        "file": "Sunrise2IP.gdtf",
-        "mode": "STANDARD"
-    },
-    "Chauvet Color Strike M": {
-        "file": "Custom@Light_Instr_Chauvet_Color_Strike_M.gdtf",
-        "mode": "Default"
-    },
-    "Era 800 Performance (Bulb=LED 6500K)": {
-        "file": "ERA 800 Performance.gdtf",
-        "mode": "Basic"
-    },
-    "HY B-EYE K15 (Bulb=LED)": {
-        "file": "Aleda B-EYE K10.gdtf",
-        "mode": "Shapes"
-    },
-    "Impression X4 Bar 20 (Bulb=LED) (Lens=Standard)": {
-        "file": "impression X4 Bar 20.gdtf",
-        "mode": "Norm"
-    },
-    "Intella Storm 1000 RGB (Bulb=LED)": {
-        "file": "PIXEL STROBE 400 RGB.gdtf",
-        "mode": "8ch"
-    },
-    "JDC-1": {
-        "file": "JDC-1.gdtf",
-        "mode": "DMX Mode 1 (Compressed Pro)"
-    },
-    "JNR BLinder 4x100C (Bulb=LED 3200K)": {
-        "file": "BLINDER 4 PRO.gdtf",
-        "mode": "8ch A001"
-    },
-    "LED-BL4 (Bulb=LED)": {
-        "file": "BLINDER 4 PRO.gdtf",
-        "mode": "8ch A001"
-    },
-    "LITELEE B-EYE L10R": {
-        "file": "Aleda B-EYE K10.gdtf",
-        "mode": "Shapes"
-    },
-    "LITELEES B-EYE L10R (LIBRERÍA K10)": {
-        "file": "Aleda B-EYE K10.gdtf",
-        "mode": "Shapes"
-    },
-    "MAC Axiom (Bulb=Sirius HRI 440W)": {
-        "file": "MAC Axiom Hybrid.gdtf",
-        "mode": "Basic"
-    },
-    "MAC Quantum Profile": {
-        "file": "MAC Quantum Profile.gdtf",
-        "mode": "Extended"
-    },
-    "MAC Quantum Profile (Bulb=LED)": {
-        "file": "MAC Quantum Profile.gdtf",
-        "mode": "Basic"
-    },
-    "MAC Quantum Wash": {
-        "file": "MAC Quantum Wash.gdtf",
-        "mode": "Basic"
-    },
-    "MAC Quantum Wash (Bulb=LED)": {
-        "file": "MAC Quantum Wash.gdtf",
-        "mode": "Basic"
-    },
-    "MARK BEAM 201": {
-        "file": "Sharpy.gdtf",
-        "mode": "Standard"
-    },
-    "MARTIN MAC AXIOM HYBRID": {
-        "file": "MAC Axiom Hybrid.gdtf",
-        "mode": "Basic"
-    },
-    "MARTIN MAC QUANTUM PROFILE": {
-        "file": "MAC Quantum Profile.gdtf",
-        "mode": "Basic"
-    },
-    "MARTIN MAC QUANTUM WASH": {
-        "file": "MAC Quantum Wash.gdtf",
-        "mode": "Basic"
-    },
-    "Mac Viper Profile": {
-        "file": "MAC Viper Profile.gdtf",
-        "mode": "Basic"
-    },
-    "Martin Professional@MAC Encore Performance CLD": {
-        "file": "MAC Encore Performance CLD.gdtf",
-        "mode": "Basic"
-    },
-    "Megapointe": {
-        "file": "Robin MegaPointe.gdtf",
-        "mode": "Mode 1 - Standard 16 - bit"
-    },
-    "PAR PRO 270 5-IN-1": {
-        "file": "PAR PRO 270 5-in-1.gdtf",
-        "mode": "8ch"
-    },
-    "PIXEL STROBE 400 RGB": {
-        "file": "PIXEL STROBE 400 RGB.gdtf",
-        "mode": "8ch"
-    },
-    "PROLIGHT BLINDER 2 PRO": {
-        "file": "BLINDER 2 PRO.gdtf",
-        "mode": "2ch d001"
-    },
-    "PROLIGHT BLINDER 4 PRO": {
-        "file": "BLINDER 4 PRO.gdtf",
-        "mode": "4ch d001"
-    },
-    "PROLIGHT PIXEL STROBE 400 RGB": {
-        "file": "PIXEL STROBE 400 RGB.gdtf",
-        "mode": "8ch"
-    },
-    "PROLIGHT X BEAM 17 CMY": {
-        "file": "XBEAM 17 CMY.gdtf",
-        "mode": "25ch"
-    },
-    "Q-7": {
-        "file": "Q-7.gdtf",
-        "mode": "6 Channel RAW"
-    },
-    "RoHS 18x10 LED Par RGBWA (Bulb=LED) (Lens=30 deg)": {
-        "file": "PAR PRO 270 5-in-1.gdtf",
-        "mode": "8ch"
-    },
-    "Robin MMX Spot": {
-        "file": "Robin MMX Spot.gdtf",
-        "mode": "Mode 1 - Standard"
-    },
-    "Robin MMX WashBeam": {
-        "file": "Robin MMX WashBeam.gdtf",
-        "mode": "Mode 1 - Standard"
-    },
-    "Robin MegaPointe": {
-        "file": "Robin MegaPointe.gdtf",
-        "mode": "Mode 1 - Standard 16 - bit"
-    },
-    "Robin MegaPointe (Bulb=Sirius HRI 475W)": {
-        "file": "Robin MegaPointe.gdtf",
-        "mode": "Mode 1 - Standard 16 - bit"
-    },
-    "Robin Spiider": {
-        "file": "Robin Spiider.gdtf",
-        "mode": "Mode 3 - Advanced"
-    },
-    "Robin iEsprite": {
-        "file": "Robin iEsprite.gdtf",
-        "mode": "Mode 1 - Standard 16 bit"
-    },
-    "Robin iSpiiderX": {
-        "file": "Robin iSpiiderX.gdtf",
-        "mode": "Mode 3 - Advanced"
-    },
-    "S-K15 LIROLITE": {
-        "file": "Aleda B-EYE K10.gdtf",
-        "mode": "Shapes"
-    },
-    "SGM Q7": {
-        "file": "Q-7.gdtf",
-        "mode": "3 Channel RAW"
-    },
-    "Sharpy": {
-        "file": "Sharpy.gdtf",
-        "mode": "Vector"
-    },
-    "Spiider": {
-        "file": "Robin Spiider.gdtf",
-        "mode": "Mode 3 - Advanced"
-    },
-    "Spiider (Bulb=LED)": {
-        "file": "Robin Spiider.gdtf",
-        "mode": "Mode 3 - Advanced"
-    },
-    "Strike Array 2 (Bulb=LED)": {
-        "file": "BLINDER 2 PRO.gdtf",
-        "mode": "6ch A001"
-    },
-    "SunRise 2IP": {
-        "file": "Sunrise2IP.gdtf",
-        "mode": "UNO"
-    },
-    "Sunrise2IP": {
-        "file": "Sunrise2IP.gdtf",
-        "mode": "UNO"
-    },
-    "TOUR HAZER II": {
-        "file": "Tour Hazer II.gdtf",
-        "mode": "Default"
-    },
-    "Tour Hazer 2": {
-        "file": "Tour Hazer II.gdtf",
-        "mode": "Default"
-    },
-    "XBEAM 17 CMY": {
-        "file": "XBEAM 17 CMY.gdtf",
-        "mode": "25ch"
-    },
-    "XBeam 17 CMY (Bulb=Sirius HRI 440W)": {
-        "file": "XBEAM 17 CMY.gdtf",
-        "mode": "25ch"
-    },
-    "cegadoras": {
-        "file": "Sunrise2IP.gdtf",
-        "mode": "STANDARD"
-    },
-    "quantum spot": {
-        "file": "MAC Quantum Profile.gdtf",
-        "mode": "Extended"
-    },
-    "quantum wash": {
-        "file": "MAC Quantum Wash.gdtf",
-        "mode": "Basic"
-    },
-    "sharpy": {
-        "file": "Sharpy.gdtf",
-        "mode": "Vector"
+    "kind": "perastage.dictionary",
+    "schema_version": 1,
+    "dictionary_type": "fixtures",
+    "entries": {
+        "Aleda B-EYE K10": {
+            "file": "Aleda B-EYE K10.gdtf",
+            "mode": "Shapes"
+        },
+        "Aleda K10 B-EYE (Bulb=LED)": {
+            "file": "Aleda B-EYE K10.gdtf",
+            "mode": "Shapes"
+        },
+        "BLINDER 2 PRO": {
+            "file": "BLINDER 2 PRO.gdtf",
+            "mode": "2ch d001"
+        },
+        "BLINDER 4 PRO": {
+            "file": "BLINDER 4 PRO.gdtf",
+            "mode": "4ch d001"
+        },
+        "BMFL WashBeam (Bulb=HTI 1700W_PS Lok-it_)": {
+            "file": "Robin BMFL WashBeam.gdtf",
+            "mode": "Mode 1 - Standard 16 bit"
+        },
+        "Beam 201": {
+            "file": "Sharpy.gdtf",
+            "mode": "Standard"
+        },
+        "Beam201": {
+            "file": "Sharpy.gdtf",
+            "mode": "Standard"
+        },
+        "Blinder 2": {
+            "file": "Sunrise2IP.gdtf",
+            "mode": "STANDARD"
+        },
+        "Chauvet Color Strike M": {
+            "file": "Custom@Light_Instr_Chauvet_Color_Strike_M.gdtf",
+            "mode": "Default"
+        },
+        "Era 800 Performance (Bulb=LED 6500K)": {
+            "file": "ERA 800 Performance.gdtf",
+            "mode": "Basic"
+        },
+        "HY B-EYE K15 (Bulb=LED)": {
+            "file": "Aleda B-EYE K10.gdtf",
+            "mode": "Shapes"
+        },
+        "Impression X4 Bar 20 (Bulb=LED) (Lens=Standard)": {
+            "file": "impression X4 Bar 20.gdtf",
+            "mode": "Norm"
+        },
+        "Intella Storm 1000 RGB (Bulb=LED)": {
+            "file": "PIXEL STROBE 400 RGB.gdtf",
+            "mode": "8ch"
+        },
+        "JDC-1": {
+            "file": "JDC-1.gdtf",
+            "mode": "DMX Mode 1 (Compressed Pro)"
+        },
+        "JNR BLinder 4x100C (Bulb=LED 3200K)": {
+            "file": "BLINDER 4 PRO.gdtf",
+            "mode": "8ch A001"
+        },
+        "LED-BL4 (Bulb=LED)": {
+            "file": "BLINDER 4 PRO.gdtf",
+            "mode": "8ch A001"
+        },
+        "LITELEE B-EYE L10R": {
+            "file": "Aleda B-EYE K10.gdtf",
+            "mode": "Shapes"
+        },
+        "LITELEES B-EYE L10R (LIBRERÍA K10)": {
+            "file": "Aleda B-EYE K10.gdtf",
+            "mode": "Shapes"
+        },
+        "MAC Axiom (Bulb=Sirius HRI 440W)": {
+            "file": "MAC Axiom Hybrid.gdtf",
+            "mode": "Basic"
+        },
+        "MAC Quantum Profile": {
+            "file": "MAC Quantum Profile.gdtf",
+            "mode": "Extended"
+        },
+        "MAC Quantum Profile (Bulb=LED)": {
+            "file": "MAC Quantum Profile.gdtf",
+            "mode": "Basic"
+        },
+        "MAC Quantum Wash": {
+            "file": "MAC Quantum Wash.gdtf",
+            "mode": "Basic"
+        },
+        "MAC Quantum Wash (Bulb=LED)": {
+            "file": "MAC Quantum Wash.gdtf",
+            "mode": "Basic"
+        },
+        "MARK BEAM 201": {
+            "file": "Sharpy.gdtf",
+            "mode": "Standard"
+        },
+        "MARTIN MAC AXIOM HYBRID": {
+            "file": "MAC Axiom Hybrid.gdtf",
+            "mode": "Basic"
+        },
+        "MARTIN MAC QUANTUM PROFILE": {
+            "file": "MAC Quantum Profile.gdtf",
+            "mode": "Basic"
+        },
+        "MARTIN MAC QUANTUM WASH": {
+            "file": "MAC Quantum Wash.gdtf",
+            "mode": "Basic"
+        },
+        "Mac Viper Profile": {
+            "file": "MAC Viper Profile.gdtf",
+            "mode": "Basic"
+        },
+        "Martin Professional@MAC Encore Performance CLD": {
+            "file": "MAC Encore Performance CLD.gdtf",
+            "mode": "Basic"
+        },
+        "Megapointe": {
+            "file": "Robin MegaPointe.gdtf",
+            "mode": "Mode 1 - Standard 16 - bit"
+        },
+        "PAR PRO 270 5-IN-1": {
+            "file": "PAR PRO 270 5-in-1.gdtf",
+            "mode": "8ch"
+        },
+        "PIXEL STROBE 400 RGB": {
+            "file": "PIXEL STROBE 400 RGB.gdtf",
+            "mode": "8ch"
+        },
+        "PROLIGHT BLINDER 2 PRO": {
+            "file": "BLINDER 2 PRO.gdtf",
+            "mode": "2ch d001"
+        },
+        "PROLIGHT BLINDER 4 PRO": {
+            "file": "BLINDER 4 PRO.gdtf",
+            "mode": "4ch d001"
+        },
+        "PROLIGHT PIXEL STROBE 400 RGB": {
+            "file": "PIXEL STROBE 400 RGB.gdtf",
+            "mode": "8ch"
+        },
+        "PROLIGHT X BEAM 17 CMY": {
+            "file": "XBEAM 17 CMY.gdtf",
+            "mode": "25ch"
+        },
+        "Q-7": {
+            "file": "Q-7.gdtf",
+            "mode": "6 Channel RAW"
+        },
+        "RoHS 18x10 LED Par RGBWA (Bulb=LED) (Lens=30 deg)": {
+            "file": "PAR PRO 270 5-in-1.gdtf",
+            "mode": "8ch"
+        },
+        "Robin MMX Spot": {
+            "file": "Robin MMX Spot.gdtf",
+            "mode": "Mode 1 - Standard"
+        },
+        "Robin MMX WashBeam": {
+            "file": "Robin MMX WashBeam.gdtf",
+            "mode": "Mode 1 - Standard"
+        },
+        "Robin MegaPointe": {
+            "file": "Robin MegaPointe.gdtf",
+            "mode": "Mode 1 - Standard 16 - bit"
+        },
+        "Robin MegaPointe (Bulb=Sirius HRI 475W)": {
+            "file": "Robin MegaPointe.gdtf",
+            "mode": "Mode 1 - Standard 16 - bit"
+        },
+        "Robin Spiider": {
+            "file": "Robin Spiider.gdtf",
+            "mode": "Mode 3 - Advanced"
+        },
+        "Robin iEsprite": {
+            "file": "Robin iEsprite.gdtf",
+            "mode": "Mode 1 - Standard 16 bit"
+        },
+        "Robin iSpiiderX": {
+            "file": "Robin iSpiiderX.gdtf",
+            "mode": "Mode 3 - Advanced"
+        },
+        "S-K15 LIROLITE": {
+            "file": "Aleda B-EYE K10.gdtf",
+            "mode": "Shapes"
+        },
+        "SGM Q7": {
+            "file": "Q-7.gdtf",
+            "mode": "3 Channel RAW"
+        },
+        "Sharpy": {
+            "file": "Sharpy.gdtf",
+            "mode": "Vector"
+        },
+        "Spiider": {
+            "file": "Robin Spiider.gdtf",
+            "mode": "Mode 3 - Advanced"
+        },
+        "Spiider (Bulb=LED)": {
+            "file": "Robin Spiider.gdtf",
+            "mode": "Mode 3 - Advanced"
+        },
+        "Strike Array 2 (Bulb=LED)": {
+            "file": "BLINDER 2 PRO.gdtf",
+            "mode": "6ch A001"
+        },
+        "SunRise 2IP": {
+            "file": "Sunrise2IP.gdtf",
+            "mode": "UNO"
+        },
+        "Sunrise2IP": {
+            "file": "Sunrise2IP.gdtf",
+            "mode": "UNO"
+        },
+        "TOUR HAZER II": {
+            "file": "Tour Hazer II.gdtf",
+            "mode": "Default"
+        },
+        "Tour Hazer 2": {
+            "file": "Tour Hazer II.gdtf",
+            "mode": "Default"
+        },
+        "XBEAM 17 CMY": {
+            "file": "XBEAM 17 CMY.gdtf",
+            "mode": "25ch"
+        },
+        "XBeam 17 CMY (Bulb=Sirius HRI 440W)": {
+            "file": "XBEAM 17 CMY.gdtf",
+            "mode": "25ch"
+        },
+        "cegadoras": {
+            "file": "Sunrise2IP.gdtf",
+            "mode": "STANDARD"
+        },
+        "quantum spot": {
+            "file": "MAC Quantum Profile.gdtf",
+            "mode": "Extended"
+        },
+        "quantum wash": {
+            "file": "MAC Quantum Wash.gdtf",
+            "mode": "Basic"
+        },
+        "sharpy": {
+            "file": "Sharpy.gdtf",
+            "mode": "Vector"
+        }
     }
 }

--- a/library/trusses/truss_dictionary.json
+++ b/library/trusses/truss_dictionary.json
@@ -1,14 +1,19 @@
 {
-    "TRUSS 0.5M": "FK40Q H-50.gdtf",
-    "TRUSS 1M": "FK40Q H-100.gdtf",
-	"TRUSS 2M": "FK40Q H-200.gdtf",
-    "TRUSS 3M": "FK40Q H-300.gdtf",
-    "TRUSS 40X40 0.5M": "FK40Q H-50.gdtf",
-    "TRUSS 40X40 1M": "FK40Q H-100.gdtf",
-	"TRUSS 40X40 2M": "FK40Q H-200.gdtf",
-    "TRUSS 40X40 3M": "FK40Q H-300.gdtf",
-	"TRUSS 40X40 PRO 0.5M": "FK40Q H-50.gdtf",
-    "TRUSS 40X40 PRO 1M": "FK40Q H-100.gdtf",
-    "TRUSS 40X40 PRO 2M": "FK40Q H-200.gdtf",
-    "TRUSS 40X40 PRO 3M": "FK40Q H-300.gdtf"
+    "kind": "perastage.dictionary",
+    "schema_version": 1,
+    "dictionary_type": "trusses",
+    "entries": {
+        "TRUSS 0.5M": "FK40Q H-50.gdtf",
+        "TRUSS 1M": "FK40Q H-100.gdtf",
+        "TRUSS 2M": "FK40Q H-200.gdtf",
+        "TRUSS 3M": "FK40Q H-300.gdtf",
+        "TRUSS 40X40 0.5M": "FK40Q H-50.gdtf",
+        "TRUSS 40X40 1M": "FK40Q H-100.gdtf",
+        "TRUSS 40X40 2M": "FK40Q H-200.gdtf",
+        "TRUSS 40X40 3M": "FK40Q H-300.gdtf",
+        "TRUSS 40X40 PRO 0.5M": "FK40Q H-50.gdtf",
+        "TRUSS 40X40 PRO 1M": "FK40Q H-100.gdtf",
+        "TRUSS 40X40 PRO 2M": "FK40Q H-200.gdtf",
+        "TRUSS 40X40 PRO 3M": "FK40Q H-300.gdtf"
+    }
 }


### PR DESCRIPTION
### Motivation
- Prevent silent/partial consumption of malformed dictionary JSON files by enforcing a clear root contract before any merge or processing.  
- Provide readable validation errors for common problems (parse error, missing fields, wrong `dictionary_type`, bad `entries` shape).  
- Support future combined payloads and unambiguous upgrade path by standardizing dictionary files to a single schema version.

### Description
- Add `core/dictionary_json_contract.h` which defines the required root (`kind`, `schema_version`, `dictionary_type`, `entries`), helpers to validate/unwrap the expected `entries` section, and `MakeRoot` for producing compliant output.  
- Validate the contract in `GdtfDictionary::Load` before any entry processing, implementing readable stderr messages on parse/contract/entry failures and rejecting invalid files before merge.  
- Apply the same validation and stricter entry resolution in `TrussDictionary::Load`, and update both `Save()` implementations to emit the contract-wrapped root so saved dictionaries are compliant.  
- Migrate the bundled library files `library/fixtures/gdtf_dictionary.json` and `library/trusses/truss_dictionary.json` to the new schema v1 wrapper.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.  
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c59d798a8483249b867d47943f84a4)