### PR TITLE
Add user/base dictionary fallback flow with GUI warning

### DIFF
--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -30,7 +30,11 @@ namespace fs = std::filesystem;
 
 namespace GdtfDictionary {
 
-static fs::path GetDictFile() {
+namespace {
+
+LoadStatus g_lastLoadStatus;
+
+fs::path GetUserDictFile() {
   fs::path dir = fs::u8path(ProjectUtils::GetDefaultLibraryPath("fixtures"));
   if (dir.empty())
     return {};
@@ -38,52 +42,59 @@ static fs::path GetDictFile() {
   fs::create_directories(dir, ec);
   if (ec)
     return {};
-  fs::path file = dir / "gdtf_dictionary.json";
-  if (!fs::exists(file)) {
-    fs::path baseLib = ProjectUtils::GetBaseLibraryPath("fixtures");
-    fs::path baseFile = baseLib / "gdtf_dictionary.json";
-    std::error_code ec;
-    if (fs::exists(baseFile))
-      fs::copy_file(baseFile, file, fs::copy_options::overwrite_existing, ec);
-    if (!fs::exists(file)) {
-      std::ofstream create(file);
-      if (create.is_open())
-        create << DictionaryJsonContract::MakeRoot("fixtures", nlohmann::json::object()).dump(4);
-    }
-  }
-  return file;
+  return dir / "gdtf_dictionary.json";
 }
 
-std::optional<std::unordered_map<std::string, Entry>> Load() {
-  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
+fs::path GetBaseDictFile() {
+  return ProjectUtils::GetBaseLibraryPath("fixtures") / "gdtf_dictionary.json";
+}
+
+bool RecreateUserDictionaryFromBase(const fs::path &userFile,
+                                    const fs::path &baseFile) {
+  if (userFile.empty() || baseFile.empty() || !fs::exists(baseFile))
+    return false;
+  std::error_code ec;
+  fs::copy_file(baseFile, userFile, fs::copy_options::overwrite_existing, ec);
+  if (!ec)
+    return true;
+  std::ofstream create(userFile);
+  if (!create.is_open())
+    return false;
+  create << DictionaryJsonContract::MakeRoot("fixtures",
+                                             nlohmann::json::object())
+                .dump(4);
+  return true;
+}
+
+std::optional<std::unordered_map<std::string, Entry>>
+LoadFromFile(const fs::path &file, std::string &error) {
   std::unordered_map<std::string, Entry> dict;
-  fs::path file = GetDictFile();
-  if (file.empty())
+  if (file.empty()) {
+    error = "Dictionary file path is empty";
     return std::nullopt;
+  }
+
   std::ifstream in(file);
-  if (!in.is_open())
+  if (!in.is_open()) {
+    error = "Cannot open dictionary file";
     return std::nullopt;
+  }
+
   if (in.peek() == std::ifstream::traits_type::eof()) {
-    std::ofstream out(file);
-    if (out.is_open())
-      out << DictionaryJsonContract::MakeRoot("fixtures", nlohmann::json::object()).dump(4);
     return dict;
   }
+
   nlohmann::json root;
   try {
     in >> root;
   } catch (const std::exception &ex) {
-    std::cerr << "Invalid fixtures dictionary JSON in '" << file.string()
-              << "': parse error: " << ex.what() << std::endl;
+    error = "Parse error: " + std::string(ex.what());
     return std::nullopt;
   }
 
-  std::string contractError;
-  auto entriesOpt = DictionaryJsonContract::GetEntriesForType(
-      root, "fixtures", contractError);
+  auto entriesOpt =
+      DictionaryJsonContract::GetEntriesForType(root, "fixtures", error);
   if (!entriesOpt) {
-    std::cerr << "Invalid fixtures dictionary JSON in '" << file.string()
-              << "': " << contractError << std::endl;
     return std::nullopt;
   }
 
@@ -131,9 +142,7 @@ std::optional<std::unordered_map<std::string, Entry>> Load() {
       Entry entry;
       std::string entryError;
       if (!parseEntryValue(it.value(), entry, entryError)) {
-        std::cerr << "Invalid fixtures dictionary JSON in '" << file.string()
-                  << "': invalid entry '" << it.key() << "': " << entryError
-                  << std::endl;
+        error = "Invalid entry '" + it.key() + "': " + entryError;
         return std::nullopt;
       }
       dict[it.key()] = entry;
@@ -144,21 +153,18 @@ std::optional<std::unordered_map<std::string, Entry>> Load() {
   for (size_t idx = 0; idx < entries.size(); ++idx) {
     const nlohmann::json &entryJson = entries[idx];
     if (!entryJson.is_object()) {
-      std::cerr << "Invalid fixtures dictionary JSON in '" << file.string()
-                << "': entries[" << idx << "] must be an object" << std::endl;
+      error = "entries[" + std::to_string(idx) + "] must be an object";
       return std::nullopt;
     }
     if (!entryJson.contains("name") || !entryJson["name"].is_string()) {
-      std::cerr << "Invalid fixtures dictionary JSON in '" << file.string()
-                << "': entries[" << idx << "] missing string 'name'" << std::endl;
+      error = "entries[" + std::to_string(idx) + "] missing string 'name'";
       return std::nullopt;
     }
 
     Entry entry;
     std::string entryError;
     if (!parseEntryValue(entryJson, entry, entryError)) {
-      std::cerr << "Invalid fixtures dictionary JSON in '" << file.string()
-                << "': entries[" << idx << "] " << entryError << std::endl;
+      error = "entries[" + std::to_string(idx) + "] " + entryError;
       return std::nullopt;
     }
 
@@ -167,9 +173,46 @@ std::optional<std::unordered_map<std::string, Entry>> Load() {
   return dict;
 }
 
+} // namespace
+
+std::optional<std::unordered_map<std::string, Entry>> Load() {
+  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
+  g_lastLoadStatus = {};
+
+  const fs::path userFile = GetUserDictFile();
+  const fs::path baseFile = GetBaseDictFile();
+
+  std::string userError;
+  if (auto userDict = LoadFromFile(userFile, userError))
+    return userDict;
+
+  std::cerr << "Warning: failed to load user fixtures dictionary '"
+            << userFile.string() << "': " << userError
+            << ". Falling back to base dictionary." << std::endl;
+
+  std::string baseError;
+  if (auto baseDict = LoadFromFile(baseFile, baseError)) {
+    g_lastLoadStatus.usedDefaultDictionary = true;
+    RecreateUserDictionaryFromBase(userFile, baseFile);
+    return baseDict;
+  }
+
+  g_lastLoadStatus.error =
+      "Failed to load user fixtures dictionary ('" + userFile.string() +
+      "'): " + userError + ". Failed to load base fixtures dictionary ('" +
+      baseFile.string() + "'): " + baseError;
+  std::cerr << "Error: " << g_lastLoadStatus.error << std::endl;
+  return std::nullopt;
+}
+
+LoadStatus GetLastLoadStatus() {
+  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
+  return g_lastLoadStatus;
+}
+
 void Save(const std::unordered_map<std::string, Entry> &dict) {
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
-  fs::path file = GetDictFile();
+  fs::path file = GetUserDictFile();
   if (file.empty())
     return;
   nlohmann::json entries = nlohmann::json::object();
@@ -229,7 +272,7 @@ void Update(const std::string &type, const std::string &gdtfPath, const std::str
   fs::path src = fs::u8path(gdtfPath);
   if (!fs::exists(src))
     return;
-  fs::path file = GetDictFile();
+  fs::path file = GetUserDictFile();
   if (file.empty())
     return;
   fs::path dir = file.parent_path();

--- a/core/gdtfdictionary.h
+++ b/core/gdtfdictionary.h
@@ -22,6 +22,11 @@
 #include <unordered_map>
 
 namespace GdtfDictionary {
+    struct LoadStatus {
+        bool usedDefaultDictionary = false;
+        std::string error;
+    };
+
     struct Entry {
         std::string path; // optional absolute path inside fixtures library
         std::string mode;
@@ -30,6 +35,7 @@ namespace GdtfDictionary {
 
     // Loads the dictionary file into a map of type -> {gdtf path in library, default mode}
     std::optional<std::unordered_map<std::string, Entry>> Load();
+    LoadStatus GetLastLoadStatus();
     // Saves the dictionary map back to disk
     void Save(const std::unordered_map<std::string, Entry>& dict);
     // Returns the stored entry for a given type if it exists and file exists.

--- a/core/trussdictionary.cpp
+++ b/core/trussdictionary.cpp
@@ -38,6 +38,8 @@ namespace TrussDictionary {
 
 namespace {
 
+LoadStatus g_lastLoadStatus;
+
 static std::string ToUtf8String(const fs::path &path) {
   std::u8string utf8 = path.u8string();
   return std::string(utf8.begin(), utf8.end());
@@ -75,7 +77,7 @@ static std::string CollapseAsciiWhitespace(const std::string &text) {
   return collapsed;
 }
 
-static fs::path GetDictFile() {
+static fs::path GetUserDictFile() {
   fs::path dir = fs::u8path(ProjectUtils::GetDefaultLibraryPath("trusses"));
   if (dir.empty())
     return {};
@@ -83,20 +85,27 @@ static fs::path GetDictFile() {
   fs::create_directories(dir, ec);
   if (ec)
     return {};
-  fs::path file = dir / "truss_dictionary.json";
-  if (!fs::exists(file)) {
-    fs::path baseLib = ProjectUtils::GetBaseLibraryPath("trusses");
-    fs::path baseFile = baseLib / "truss_dictionary.json";
-    std::error_code ec;
-    if (fs::exists(baseFile))
-      fs::copy_file(baseFile, file, fs::copy_options::overwrite_existing, ec);
-    if (!fs::exists(file)) {
-      std::ofstream create(file);
-      if (create.is_open())
-        create << DictionaryJsonContract::MakeRoot("trusses", nlohmann::json::object()).dump(4);
-    }
-  }
-  return file;
+  return dir / "truss_dictionary.json";
+}
+
+static fs::path GetBaseDictFile() {
+  return ProjectUtils::GetBaseLibraryPath("trusses") / "truss_dictionary.json";
+}
+
+static bool RecreateUserDictionaryFromBase(const fs::path &userFile,
+                                           const fs::path &baseFile) {
+  if (userFile.empty() || baseFile.empty() || !fs::exists(baseFile))
+    return false;
+  std::error_code ec;
+  fs::copy_file(baseFile, userFile, fs::copy_options::overwrite_existing, ec);
+  if (!ec)
+    return true;
+  std::ofstream create(userFile);
+  if (!create.is_open())
+    return false;
+  create << DictionaryJsonContract::MakeRoot("trusses", nlohmann::json::object())
+                .dump(4);
+  return true;
 }
 
 static bool EnsureMigratedToGdtf(fs::path &pathInOut, std::string &error) {
@@ -157,7 +166,7 @@ bool ImportTrussFile(const std::string &inputPath, std::string &storedPath,
     return false;
   }
 
-  fs::path dictFile = GetDictFile();
+  fs::path dictFile = GetUserDictFile();
   if (dictFile.empty()) {
     error = "Truss dictionary is not available";
     return false;
@@ -182,19 +191,22 @@ bool ImportTrussFile(const std::string &inputPath, std::string &storedPath,
 
 std::optional<std::unordered_map<std::string, std::string>> Load() {
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
+  g_lastLoadStatus = {};
+  auto loadFromFile = [](const fs::path &file, std::string &error)
+      -> std::optional<std::unordered_map<std::string, std::string>> {
   std::unordered_map<std::string, std::string> dict;
-  fs::path file = GetDictFile();
-  if (file.empty())
+  if (file.empty()) {
+    error = "Dictionary file path is empty";
     return std::nullopt;
+  }
 
   std::ifstream in(file);
-  if (!in.is_open())
+  if (!in.is_open()) {
+    error = "Cannot open dictionary file";
     return std::nullopt;
+  }
 
   if (in.peek() == std::ifstream::traits_type::eof()) {
-    std::ofstream out(file);
-    if (out.is_open())
-      out << DictionaryJsonContract::MakeRoot("trusses", nlohmann::json::object()).dump(4);
     return dict;
   }
 
@@ -202,17 +214,12 @@ std::optional<std::unordered_map<std::string, std::string>> Load() {
   try {
     in >> root;
   } catch (const std::exception &ex) {
-    std::cerr << "Invalid truss dictionary JSON in '" << file.string()
-              << "': parse error: " << ex.what() << std::endl;
+    error = "Parse error: " + std::string(ex.what());
     return std::nullopt;
   }
 
-  std::string contractError;
-  auto entriesOpt = DictionaryJsonContract::GetEntriesForType(
-      root, "trusses", contractError);
+  auto entriesOpt = DictionaryJsonContract::GetEntriesForType(root, "trusses", error);
   if (!entriesOpt) {
-    std::cerr << "Invalid truss dictionary JSON in '" << file.string()
-              << "': " << contractError << std::endl;
     return std::nullopt;
   }
 
@@ -249,16 +256,14 @@ std::optional<std::unordered_map<std::string, std::string>> Load() {
                           const std::string &sourceLabel) -> bool {
     const std::string normalizedKey = NormalizeModelKey(rawKey);
     if (normalizedKey.empty()) {
-      std::cerr << "Invalid truss dictionary JSON in '" << file.string()
-                << "': " << sourceLabel << " has an empty model name" << std::endl;
+      error = sourceLabel + " has an empty model name";
       return false;
     }
 
     fs::path path;
     std::string entryError;
     if (!resolveEntryPath(value, path, entryError)) {
-      std::cerr << "Invalid truss dictionary JSON in '" << file.string()
-                << "': " << sourceLabel << " " << entryError << std::endl;
+      error = sourceLabel + " " + entryError;
       return false;
     }
 
@@ -285,13 +290,11 @@ std::optional<std::unordered_map<std::string, std::string>> Load() {
     for (size_t idx = 0; idx < entries.size(); ++idx) {
       const nlohmann::json &entryJson = entries[idx];
       if (!entryJson.is_object()) {
-        std::cerr << "Invalid truss dictionary JSON in '" << file.string()
-                  << "': entries[" << idx << "] must be an object" << std::endl;
+        error = "entries[" + std::to_string(idx) + "] must be an object";
         return std::nullopt;
       }
       if (!entryJson.contains("name") || !entryJson["name"].is_string()) {
-        std::cerr << "Invalid truss dictionary JSON in '" << file.string()
-                  << "': entries[" << idx << "] missing string 'name'" << std::endl;
+        error = "entries[" + std::to_string(idx) + "] missing string 'name'";
         return std::nullopt;
       }
       if (!processEntry(entryJson["name"].get<std::string>(), entryJson,
@@ -304,11 +307,41 @@ std::optional<std::unordered_map<std::string, std::string>> Load() {
   if (changed)
     Save(dict);
   return dict;
+  };
+
+  const fs::path userFile = GetUserDictFile();
+  const fs::path baseFile = GetBaseDictFile();
+  std::string userError;
+  if (auto userDict = loadFromFile(userFile, userError))
+    return userDict;
+
+  std::cerr << "Warning: failed to load user truss dictionary '" << userFile.string()
+            << "': " << userError << ". Falling back to base dictionary."
+            << std::endl;
+
+  std::string baseError;
+  if (auto baseDict = loadFromFile(baseFile, baseError)) {
+    g_lastLoadStatus.usedDefaultDictionary = true;
+    RecreateUserDictionaryFromBase(userFile, baseFile);
+    return baseDict;
+  }
+
+  g_lastLoadStatus.error =
+      "Failed to load user truss dictionary ('" + userFile.string() +
+      "'): " + userError + ". Failed to load base truss dictionary ('" +
+      baseFile.string() + "'): " + baseError;
+  std::cerr << "Error: " << g_lastLoadStatus.error << std::endl;
+  return std::nullopt;
+}
+
+LoadStatus GetLastLoadStatus() {
+  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
+  return g_lastLoadStatus;
 }
 
 void Save(const std::unordered_map<std::string, std::string> &dict) {
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
-  fs::path file = GetDictFile();
+  fs::path file = GetUserDictFile();
   if (file.empty())
     return;
 

--- a/core/trussdictionary.h
+++ b/core/trussdictionary.h
@@ -22,8 +22,14 @@
 #include <unordered_map>
 
 namespace TrussDictionary {
+struct LoadStatus {
+  bool usedDefaultDictionary = false;
+  std::string error;
+};
+
 std::string NormalizeModelKey(const std::string &model);
 std::optional<std::unordered_map<std::string, std::string>> Load();
+LoadStatus GetLastLoadStatus();
 void Save(const std::unordered_map<std::string, std::string> &dict);
 std::optional<std::string> Get(const std::string &model);
 void Update(const std::string &model, const std::string &modelPath);

--- a/gui/dictionaryeditdialog.cpp
+++ b/gui/dictionaryeditdialog.cpp
@@ -92,6 +92,7 @@ DictionaryEditDialog::DictionaryEditDialog(wxWindow *parent)
   BuildLayout();
   LoadFixtures();
   LoadTrusses();
+  ShowDictionaryLoadStatusMessages();
 }
 
 void DictionaryEditDialog::BuildLayout() {
@@ -219,6 +220,42 @@ void DictionaryEditDialog::LoadTrusses() {
     items.push_back(wxString::FromUTF8(std::filesystem::path(row.path).filename().string()));
     trussTable->AppendItem(items);
     trussPaths.push_back(row.path);
+  }
+}
+
+void DictionaryEditDialog::ShowDictionaryLoadStatusMessages() {
+  bool shouldShowFallbackMessage = false;
+  std::string errorMessage;
+
+  const GdtfDictionary::LoadStatus fixturesStatus =
+      GdtfDictionary::GetLastLoadStatus();
+  if (fixturesStatus.usedDefaultDictionary)
+    shouldShowFallbackMessage = true;
+  if (!fixturesStatus.error.empty())
+    errorMessage = fixturesStatus.error;
+
+  const TrussDictionary::LoadStatus trussStatus =
+      TrussDictionary::GetLastLoadStatus();
+  if (trussStatus.usedDefaultDictionary)
+    shouldShowFallbackMessage = true;
+  if (errorMessage.empty() && !trussStatus.error.empty())
+    errorMessage = trussStatus.error;
+
+  if (!errorMessage.empty()) {
+    wxMessageBox(
+        wxString::FromUTF8(errorMessage),
+        "Dictionary load error",
+        wxICON_ERROR | wxOK,
+        this);
+    return;
+  }
+
+  if (shouldShowFallbackMessage) {
+    wxMessageBox(
+        "Se cargó diccionario por defecto debido a error en el archivo de usuario",
+        "Dictionary warning",
+        wxICON_WARNING | wxOK,
+        this);
   }
 }
 

--- a/gui/dictionaryeditdialog.h
+++ b/gui/dictionaryeditdialog.h
@@ -31,6 +31,7 @@ private:
   void LoadTrusses();
   void SaveFixtures();
   void SaveTrusses();
+  void ShowDictionaryLoadStatusMessages();
   bool IsFixturesPage() const;
 
   void OnAdd(wxCommandEvent &event);


### PR DESCRIPTION
### Motivation
- Provide a robust load flow for fixture and truss dictionaries so the app recovers from user-file IO/parse/validation errors and surfaces a clear message to the GUI when a fallback occurs.
- Ensure the GUI can present either a clear error when both user+base fail or the requested Spanish warning when the base dictionary is used as fallback.

### Description
- Implemented a two-tier load flow in `GdtfDictionary` and `TrussDictionary` where the code first attempts the user dictionary and on IO/parse/validation failure logs a warning and tries the base `library/...` dictionary, and attempts to recreate the user file from base when fallback succeeds.
- Added `LoadStatus` and `GetLastLoadStatus()` to both dictionary modules so callers can detect `usedDefaultDictionary` and load `error` details programmatically.
- Reworked file helpers to distinguish user vs base dictionary paths and centralized file-load parsing into `LoadFromFile`/`loadFromFile` helpers that return detailed parse/IO errors instead of only writing to `stderr`.
- Updated `DictionaryEditDialog` to call `ShowDictionaryLoadStatusMessages()` after loading and display either an error dialog with the load error or the exact warning message `"Se cargó diccionario por defecto debido a error en el archivo de usuario"` when a fallback occurred.

### Testing
- Ran module checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both succeeded.
- Attempted to configure/build with `cmake -S . -B build && cmake --build build -j2` which failed in this environment due to missing `wxWidgets` development packages (so full build/run tests could not be executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c59f0b15c48324bff9d3eb4cccf51c)