### PR TITLE
Add dictionary import policies and UI preview/apply summaries

### DIFF
--- a/core/dictionary_import.h
+++ b/core/dictionary_import.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+enum class DictionaryImportPolicy {
+  AddMissing,
+  AddAndOverwrite,
+  ReplaceAll
+};
+
+struct DictionaryImportSummary {
+  size_t added_count = 0;
+  size_t overwritten_count = 0;
+  size_t skipped_count = 0;
+  std::vector<std::string> errors;
+
+  [[nodiscard]] bool HasErrors() const { return !errors.empty(); }
+};
+

--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -173,6 +173,45 @@ LoadFromFile(const fs::path &file, std::string &error) {
   return dict;
 }
 
+DictionaryImportSummary MergeDictionaryEntries(
+    std::unordered_map<std::string, Entry> &current,
+    const std::unordered_map<std::string, Entry> &imported,
+    DictionaryImportPolicy policy, bool applyChanges) {
+  DictionaryImportSummary summary;
+
+  if (policy == DictionaryImportPolicy::ReplaceAll) {
+    if (applyChanges)
+      current.clear();
+    for (const auto &[key, value] : imported) {
+      if (applyChanges)
+        current[key] = value;
+      ++summary.added_count;
+    }
+    return summary;
+  }
+
+  for (const auto &[key, value] : imported) {
+    const auto it = current.find(key);
+    if (it == current.end()) {
+      if (applyChanges)
+        current[key] = value;
+      ++summary.added_count;
+      continue;
+    }
+
+    if (policy == DictionaryImportPolicy::AddAndOverwrite) {
+      if (applyChanges)
+        it->second = value;
+      ++summary.overwritten_count;
+      continue;
+    }
+
+    ++summary.skipped_count;
+  }
+
+  return summary;
+}
+
 } // namespace
 
 std::optional<std::unordered_map<std::string, Entry>> Load() {
@@ -317,6 +356,54 @@ void UpdateCategory(const std::string &type, const std::string &category) {
     it->second.category = category;
   }
   Save(dict);
+}
+
+DictionaryImportSummary PreviewImportFromFile(const std::string &filePath,
+                                              DictionaryImportPolicy policy) {
+  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
+  DictionaryImportSummary summary;
+
+  std::string importError;
+  const fs::path importPath = fs::u8path(filePath);
+  auto importedOpt = LoadFromFile(importPath, importError);
+  if (!importedOpt) {
+    summary.errors.push_back("Failed to load import file: " + importError);
+    return summary;
+  }
+
+  auto currentOpt = Load();
+  if (!currentOpt) {
+    summary.errors.push_back("Failed to load current dictionary");
+    return summary;
+  }
+
+  auto current = *currentOpt;
+  return MergeDictionaryEntries(current, *importedOpt, policy, false);
+}
+
+DictionaryImportSummary ApplyImportFromFile(const std::string &filePath,
+                                            DictionaryImportPolicy policy) {
+  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
+  DictionaryImportSummary summary;
+
+  std::string importError;
+  const fs::path importPath = fs::u8path(filePath);
+  auto importedOpt = LoadFromFile(importPath, importError);
+  if (!importedOpt) {
+    summary.errors.push_back("Failed to load import file: " + importError);
+    return summary;
+  }
+
+  auto currentOpt = Load();
+  if (!currentOpt) {
+    summary.errors.push_back("Failed to load current dictionary");
+    return summary;
+  }
+
+  auto current = *currentOpt;
+  summary = MergeDictionaryEntries(current, *importedOpt, policy, true);
+  Save(current);
+  return summary;
 }
 
 } // namespace GdtfDictionary

--- a/core/gdtfdictionary.h
+++ b/core/gdtfdictionary.h
@@ -17,6 +17,8 @@
  */
 #pragma once
 
+#include "dictionary_import.h"
+
 #include <string>
 #include <optional>
 #include <unordered_map>
@@ -44,4 +46,8 @@ namespace GdtfDictionary {
     // Copies the gdtf file into the fixtures library and updates the dictionary
     void Update(const std::string& type, const std::string& gdtfPath, const std::string& mode = {}, const std::string& category = {});
     void UpdateCategory(const std::string& type, const std::string& category);
+    DictionaryImportSummary PreviewImportFromFile(
+        const std::string &filePath, DictionaryImportPolicy policy);
+    DictionaryImportSummary ApplyImportFromFile(
+        const std::string &filePath, DictionaryImportPolicy policy);
 }

--- a/core/trussdictionary.cpp
+++ b/core/trussdictionary.cpp
@@ -142,58 +142,8 @@ static bool EnsureMigratedToGdtf(fs::path &pathInOut, std::string &error) {
   return false;
 }
 
-} // namespace
-
-std::string NormalizeModelKey(const std::string &model) {
-  std::string normalized = CollapseAsciiWhitespace(TrimAsciiWhitespace(model));
-  std::transform(normalized.begin(), normalized.end(), normalized.begin(),
-                 [](unsigned char c) {
-                   return static_cast<char>(std::toupper(c));
-                 });
-
-  static const std::regex kDimensionSeparator("(\\d)\\s*[xX]\\s*(\\d)");
-  normalized = std::regex_replace(normalized, kDimensionSeparator, "$1X$2");
-  return normalized;
-}
-
-bool ImportTrussFile(const std::string &inputPath, std::string &storedPath,
-                     std::string &error) {
-  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
-  storedPath.clear();
-  fs::path src = fs::u8path(inputPath);
-  if (!fs::exists(src)) {
-    error = "Truss file does not exist";
-    return false;
-  }
-
-  fs::path dictFile = GetUserDictFile();
-  if (dictFile.empty()) {
-    error = "Truss dictionary is not available";
-    return false;
-  }
-
-  fs::path dir = dictFile.parent_path();
-  fs::path working = src;
-  if (!EnsureMigratedToGdtf(working, error))
-    return false;
-
-  fs::path dest = dir / working.filename();
-  std::error_code ec;
-  fs::copy_file(working, dest, fs::copy_options::overwrite_existing, ec);
-  if (ec) {
-    error = "Failed to copy truss file into library";
-    return false;
-  }
-
-  storedPath = ToUtf8String(dest);
-  return true;
-}
-
-std::optional<std::unordered_map<std::string, std::string>> Load() {
-  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
-  g_lastLoadStatus = {};
-  auto loadFromFile = [](const fs::path &file, std::string &error)
-      -> std::optional<std::unordered_map<std::string, std::string>> {
+static std::optional<std::unordered_map<std::string, std::string>>
+LoadFromFile(const fs::path &file, std::string &error) {
   std::unordered_map<std::string, std::string> dict;
   if (file.empty()) {
     error = "Dictionary file path is empty";
@@ -307,12 +257,108 @@ std::optional<std::unordered_map<std::string, std::string>> Load() {
   if (changed)
     Save(dict);
   return dict;
-  };
+}
+
+DictionaryImportSummary MergeDictionaryEntries(
+    std::unordered_map<std::string, std::string> &current,
+    const std::unordered_map<std::string, std::string> &imported,
+    DictionaryImportPolicy policy, bool applyChanges) {
+  DictionaryImportSummary summary;
+
+  if (policy == DictionaryImportPolicy::ReplaceAll) {
+    if (applyChanges)
+      current.clear();
+    for (const auto &[key, value] : imported) {
+      if (applyChanges)
+        current[key] = value;
+      ++summary.added_count;
+    }
+    return summary;
+  }
+
+  for (const auto &[rawKey, value] : imported) {
+    const std::string key = NormalizeModelKey(rawKey);
+    if (key.empty()) {
+      ++summary.skipped_count;
+      continue;
+    }
+
+    const auto it = current.find(key);
+    if (it == current.end()) {
+      if (applyChanges)
+        current[key] = value;
+      ++summary.added_count;
+      continue;
+    }
+
+    if (policy == DictionaryImportPolicy::AddAndOverwrite) {
+      if (applyChanges)
+        it->second = value;
+      ++summary.overwritten_count;
+      continue;
+    }
+
+    ++summary.skipped_count;
+  }
+
+  return summary;
+}
+
+} // namespace
+
+std::string NormalizeModelKey(const std::string &model) {
+  std::string normalized = CollapseAsciiWhitespace(TrimAsciiWhitespace(model));
+  std::transform(normalized.begin(), normalized.end(), normalized.begin(),
+                 [](unsigned char c) {
+                   return static_cast<char>(std::toupper(c));
+                 });
+
+  static const std::regex kDimensionSeparator("(\\d)\\s*[xX]\\s*(\\d)");
+  normalized = std::regex_replace(normalized, kDimensionSeparator, "$1X$2");
+  return normalized;
+}
+
+bool ImportTrussFile(const std::string &inputPath, std::string &storedPath,
+                     std::string &error) {
+  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
+  storedPath.clear();
+  fs::path src = fs::u8path(inputPath);
+  if (!fs::exists(src)) {
+    error = "Truss file does not exist";
+    return false;
+  }
+
+  fs::path dictFile = GetUserDictFile();
+  if (dictFile.empty()) {
+    error = "Truss dictionary is not available";
+    return false;
+  }
+
+  fs::path dir = dictFile.parent_path();
+  fs::path working = src;
+  if (!EnsureMigratedToGdtf(working, error))
+    return false;
+
+  fs::path dest = dir / working.filename();
+  std::error_code ec;
+  fs::copy_file(working, dest, fs::copy_options::overwrite_existing, ec);
+  if (ec) {
+    error = "Failed to copy truss file into library";
+    return false;
+  }
+
+  storedPath = ToUtf8String(dest);
+  return true;
+}
+
+std::optional<std::unordered_map<std::string, std::string>> Load() {
+  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
+  g_lastLoadStatus = {};
 
   const fs::path userFile = GetUserDictFile();
   const fs::path baseFile = GetBaseDictFile();
   std::string userError;
-  if (auto userDict = loadFromFile(userFile, userError))
+  if (auto userDict = LoadFromFile(userFile, userError))
     return userDict;
 
   std::cerr << "Warning: failed to load user truss dictionary '" << userFile.string()
@@ -320,7 +366,7 @@ std::optional<std::unordered_map<std::string, std::string>> Load() {
             << std::endl;
 
   std::string baseError;
-  if (auto baseDict = loadFromFile(baseFile, baseError)) {
+  if (auto baseDict = LoadFromFile(baseFile, baseError)) {
     g_lastLoadStatus.usedDefaultDictionary = true;
     RecreateUserDictionaryFromBase(userFile, baseFile);
     return baseDict;
@@ -416,6 +462,54 @@ void Update(const std::string &model, const std::string &modelPath) {
   auto &dict = *dictOpt;
   dict[normalizedModel] = storedPath;
   Save(dict);
+}
+
+DictionaryImportSummary PreviewImportFromFile(const std::string &filePath,
+                                              DictionaryImportPolicy policy) {
+  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
+  DictionaryImportSummary summary;
+
+  std::string importError;
+  const fs::path importPath = fs::u8path(filePath);
+  auto importedOpt = LoadFromFile(importPath, importError);
+  if (!importedOpt) {
+    summary.errors.push_back("Failed to load import file: " + importError);
+    return summary;
+  }
+
+  auto currentOpt = Load();
+  if (!currentOpt) {
+    summary.errors.push_back("Failed to load current dictionary");
+    return summary;
+  }
+
+  auto current = *currentOpt;
+  return MergeDictionaryEntries(current, *importedOpt, policy, false);
+}
+
+DictionaryImportSummary ApplyImportFromFile(const std::string &filePath,
+                                            DictionaryImportPolicy policy) {
+  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
+  DictionaryImportSummary summary;
+
+  std::string importError;
+  const fs::path importPath = fs::u8path(filePath);
+  auto importedOpt = LoadFromFile(importPath, importError);
+  if (!importedOpt) {
+    summary.errors.push_back("Failed to load import file: " + importError);
+    return summary;
+  }
+
+  auto currentOpt = Load();
+  if (!currentOpt) {
+    summary.errors.push_back("Failed to load current dictionary");
+    return summary;
+  }
+
+  auto current = *currentOpt;
+  summary = MergeDictionaryEntries(current, *importedOpt, policy, true);
+  Save(current);
+  return summary;
 }
 
 } // namespace TrussDictionary

--- a/core/trussdictionary.h
+++ b/core/trussdictionary.h
@@ -17,6 +17,8 @@
  */
 #pragma once
 
+#include "dictionary_import.h"
+
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -35,4 +37,8 @@ std::optional<std::string> Get(const std::string &model);
 void Update(const std::string &model, const std::string &modelPath);
 bool ImportTrussFile(const std::string &inputPath, std::string &storedPath,
                      std::string &error);
+DictionaryImportSummary PreviewImportFromFile(
+    const std::string &filePath, DictionaryImportPolicy policy);
+DictionaryImportSummary ApplyImportFromFile(
+    const std::string &filePath, DictionaryImportPolicy policy);
 } // namespace TrussDictionary

--- a/gui/dictionaryeditdialog.cpp
+++ b/gui/dictionaryeditdialog.cpp
@@ -26,6 +26,7 @@
 
 #include <algorithm>
 #include <filesystem>
+#include <sstream>
 #include <vector>
 
 #include <wx/filename.h>
@@ -84,6 +85,50 @@ void SortTrussRows(std::vector<TrussRow> &rows) {
     return a.name < b.name;
   });
 }
+
+wxString BuildSummaryText(const DictionaryImportSummary &summary) {
+  std::ostringstream oss;
+  oss << "added_count: " << summary.added_count << "\n";
+  oss << "overwritten_count: " << summary.overwritten_count << "\n";
+  oss << "skipped_count: " << summary.skipped_count << "\n";
+  oss << "errors: " << summary.errors.size();
+  if (!summary.errors.empty()) {
+    for (const auto &error : summary.errors)
+      oss << "\n- " << error;
+  }
+  return wxString::FromUTF8(oss.str());
+}
+
+wxString GetPolicyDescription(DictionaryImportPolicy policy) {
+  switch (policy) {
+  case DictionaryImportPolicy::AddMissing:
+    return "AddMissing: insert only missing keys";
+  case DictionaryImportPolicy::AddAndOverwrite:
+    return "AddAndOverwrite: insert new keys and overwrite matches";
+  case DictionaryImportPolicy::ReplaceAll:
+    return "ReplaceAll: discard current dictionary and use imported one";
+  }
+  return "Unknown policy";
+}
+
+bool AskImportPolicy(wxWindow *parent, DictionaryImportPolicy &policyOut) {
+  wxArrayString choices;
+  choices.push_back("AddMissing");
+  choices.push_back("AddAndOverwrite");
+  choices.push_back("ReplaceAll");
+  wxSingleChoiceDialog policyDlg(parent, "Select import policy",
+                                 "Dictionary import", choices);
+  if (policyDlg.ShowModal() != wxID_OK)
+    return false;
+  const int selection = policyDlg.GetSelection();
+  if (selection == 0)
+    policyOut = DictionaryImportPolicy::AddMissing;
+  else if (selection == 1)
+    policyOut = DictionaryImportPolicy::AddAndOverwrite;
+  else
+    policyOut = DictionaryImportPolicy::ReplaceAll;
+  return true;
+}
 } // namespace
 
 DictionaryEditDialog::DictionaryEditDialog(wxWindow *parent)
@@ -135,12 +180,14 @@ void DictionaryEditDialog::BuildLayout() {
   addBtn = new wxButton(this, wxID_ADD, "Add");
   deleteBtn = new wxButton(this, wxID_DELETE, "Delete");
   downloadBtn = new wxButton(this, wxID_ANY, "Download GDTF");
+  importBtn = new wxButton(this, wxID_ANY, "Import dictionary...");
   okBtn = new wxButton(this, wxID_OK, "OK");
   cancelBtn = new wxButton(this, wxID_CANCEL, "Cancel");
 
   btnSizer->Add(addBtn, 0, wxRIGHT, 5);
   btnSizer->Add(deleteBtn, 0, wxRIGHT, 5);
   btnSizer->Add(downloadBtn, 0, wxRIGHT, 10);
+  btnSizer->Add(importBtn, 0, wxRIGHT, 10);
   btnSizer->AddStretchSpacer(1);
   btnSizer->Add(okBtn, 0, wxRIGHT, 5);
   btnSizer->Add(cancelBtn, 0);
@@ -152,6 +199,7 @@ void DictionaryEditDialog::BuildLayout() {
   addBtn->Bind(wxEVT_BUTTON, &DictionaryEditDialog::OnAdd, this);
   deleteBtn->Bind(wxEVT_BUTTON, &DictionaryEditDialog::OnDelete, this);
   downloadBtn->Bind(wxEVT_BUTTON, &DictionaryEditDialog::OnDownloadGdtf, this);
+  importBtn->Bind(wxEVT_BUTTON, &DictionaryEditDialog::OnImportDictionary, this);
   okBtn->Bind(wxEVT_BUTTON, &DictionaryEditDialog::OnOk, this);
   fixtureTable->Bind(wxEVT_DATAVIEW_ITEM_ACTIVATED,
                      &DictionaryEditDialog::OnItemActivated, this);
@@ -426,6 +474,72 @@ void DictionaryEditDialog::OnOk(wxCommandEvent &WXUNUSED(event)) {
   SaveFixtures();
   SaveTrusses();
   EndModal(wxID_OK);
+}
+
+void DictionaryEditDialog::OnImportDictionary(wxCommandEvent &WXUNUSED(event)) {
+  if (IsFixturesPage()) {
+    (void)ImportFixturesDictionary();
+    return;
+  }
+  (void)ImportTrussesDictionary();
+}
+
+bool DictionaryEditDialog::ImportFixturesDictionary() {
+  wxFileDialog fileDialog(this, "Import fixtures dictionary", wxEmptyString,
+                          wxEmptyString, "JSON files (*.json)|*.json",
+                          wxFD_OPEN | wxFD_FILE_MUST_EXIST);
+  if (fileDialog.ShowModal() != wxID_OK)
+    return false;
+
+  DictionaryImportPolicy policy = DictionaryImportPolicy::AddMissing;
+  if (!AskImportPolicy(this, policy))
+    return false;
+
+  const std::string importPath = std::string(fileDialog.GetPath().ToUTF8());
+  const auto preview = GdtfDictionary::PreviewImportFromFile(importPath, policy);
+  wxString confirmText = "Policy:\n" + GetPolicyDescription(policy) +
+                         "\n\nPreview summary:\n" + BuildSummaryText(preview) +
+                         "\n\nApply import?";
+  if (wxMessageBox(confirmText, "Confirm fixtures dictionary import",
+                   wxYES_NO | wxICON_QUESTION, this) != wxYES) {
+    return false;
+  }
+
+  const auto result = GdtfDictionary::ApplyImportFromFile(importPath, policy);
+  LoadFixtures();
+  wxMessageBox("Fixtures dictionary import completed.\n\n" +
+                   BuildSummaryText(result),
+               "Fixtures dictionary import", wxOK | wxICON_INFORMATION, this);
+  return !result.HasErrors();
+}
+
+bool DictionaryEditDialog::ImportTrussesDictionary() {
+  wxFileDialog fileDialog(this, "Import trusses dictionary", wxEmptyString,
+                          wxEmptyString, "JSON files (*.json)|*.json",
+                          wxFD_OPEN | wxFD_FILE_MUST_EXIST);
+  if (fileDialog.ShowModal() != wxID_OK)
+    return false;
+
+  DictionaryImportPolicy policy = DictionaryImportPolicy::AddMissing;
+  if (!AskImportPolicy(this, policy))
+    return false;
+
+  const std::string importPath = std::string(fileDialog.GetPath().ToUTF8());
+  const auto preview = TrussDictionary::PreviewImportFromFile(importPath, policy);
+  wxString confirmText = "Policy:\n" + GetPolicyDescription(policy) +
+                         "\n\nPreview summary:\n" + BuildSummaryText(preview) +
+                         "\n\nApply import?";
+  if (wxMessageBox(confirmText, "Confirm trusses dictionary import",
+                   wxYES_NO | wxICON_QUESTION, this) != wxYES) {
+    return false;
+  }
+
+  const auto result = TrussDictionary::ApplyImportFromFile(importPath, policy);
+  LoadTrusses();
+  wxMessageBox("Trusses dictionary import completed.\n\n" +
+                   BuildSummaryText(result),
+               "Trusses dictionary import", wxOK | wxICON_INFORMATION, this);
+  return !result.HasErrors();
 }
 
 void DictionaryEditDialog::OnItemActivated(wxDataViewEvent &event) {

--- a/gui/dictionaryeditdialog.h
+++ b/gui/dictionaryeditdialog.h
@@ -37,8 +37,11 @@ private:
   void OnAdd(wxCommandEvent &event);
   void OnDelete(wxCommandEvent &event);
   void OnDownloadGdtf(wxCommandEvent &event);
+  void OnImportDictionary(wxCommandEvent &event);
   void OnOk(wxCommandEvent &event);
   void OnItemActivated(wxDataViewEvent &event);
+  bool ImportFixturesDictionary();
+  bool ImportTrussesDictionary();
 
   wxNotebook *notebook = nullptr;
   wxDataViewListCtrl *fixtureTable = nullptr;
@@ -46,6 +49,7 @@ private:
   wxButton *addBtn = nullptr;
   wxButton *deleteBtn = nullptr;
   wxButton *downloadBtn = nullptr;
+  wxButton *importBtn = nullptr;
   wxButton *okBtn = nullptr;
   wxButton *cancelBtn = nullptr;
 


### PR DESCRIPTION
### Motivation
- Provide explicit import semantics for fixture/truss dictionaries so users can choose how imported keys are merged (insert-only, overwrite, or replace-all) and get a structured summary before applying changes.

### Description
- Add shared `DictionaryImportPolicy` enum (`AddMissing`, `AddAndOverwrite`, `ReplaceAll`) and `DictionaryImportSummary` with `added_count`, `overwritten_count`, `skipped_count`, and `errors` in `core/dictionary_import.h`.
- Extend `GdtfDictionary` and `TrussDictionary` with `PreviewImportFromFile` and `ApplyImportFromFile` APIs that parse an external JSON dictionary, compute a merge according to the selected policy, and return a `DictionaryImportSummary`; implement merging helpers for the three policies and apply/save on demand.
- Update the Dictionary Editor UI (`gui/dictionaryeditdialog.{h,cpp}`) with a new "Import dictionary..." button, policy selection dialog, preview confirmation showing the structured summary, and a final completion message showing the apply summary for both fixtures and trusses.
- The semantics implemented are: `AddMissing` inserts only keys that do not exist, `AddAndOverwrite` inserts new keys and overwrites existing keys, and `ReplaceAll` discards the current dictionary and replaces it with the imported one.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it returned OK.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it returned OK.
- Attempted an in-repo `cmake -S . -B build && cmake --build build -j2`, which failed due to the environment missing `wxWidgets` development libraries (external dependency), so a full build/test could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5a1af94d483249729f1a5679964d0)