### PR TITLE
Add portable ZIP bundle import/export for fixture/truss dictionaries

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/configmanager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/configservices.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/credentialstore.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/dictionary_bundle.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dummyprofilelibrary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtfdictionary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf_fixture_category.cpp

--- a/core/dictionary_bundle.cpp
+++ b/core/dictionary_bundle.cpp
@@ -1,0 +1,603 @@
+#include "dictionary_bundle.h"
+
+#include "dictionary_json_contract.h"
+#include "json.hpp"
+#include "projectutils.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cctype>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <wx/wfstream.h>
+#include <wx/zipstrm.h>
+
+namespace fs = std::filesystem;
+
+namespace DictionaryBundle {
+namespace {
+
+constexpr const char *kBundleKind = "perastage.dictionary_bundle";
+constexpr int kFormatVersion = 1;
+
+struct AssetPayload {
+  fs::path sourcePath;
+  std::string archivePath;
+  std::string checksum;
+  uintmax_t size = 0;
+};
+
+uint64_t HashBytesFnv1a64(const std::vector<unsigned char> &bytes) {
+  uint64_t hash = 1469598103934665603ull;
+  for (unsigned char value : bytes) {
+    hash ^= static_cast<uint64_t>(value);
+    hash *= 1099511628211ull;
+  }
+  return hash;
+}
+
+std::string ToLowerCopy(std::string value) {
+  std::transform(value.begin(), value.end(), value.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return value;
+}
+
+std::string BuildChecksumLabel(const std::vector<unsigned char> &bytes) {
+  std::ostringstream oss;
+  oss << "fnv1a64:" << std::hex << std::setfill('0') << std::setw(16)
+      << HashBytesFnv1a64(bytes);
+  return oss.str();
+}
+
+bool ReadFileBytes(const fs::path &path, std::vector<unsigned char> &outBytes) {
+  outBytes.clear();
+  std::ifstream in(path, std::ios::binary);
+  if (!in.is_open())
+    return false;
+
+  in.seekg(0, std::ios::end);
+  const std::streamoff length = in.tellg();
+  if (length < 0)
+    return false;
+  in.seekg(0, std::ios::beg);
+
+  outBytes.resize(static_cast<size_t>(length));
+  if (length == 0)
+    return true;
+
+  in.read(reinterpret_cast<char *>(outBytes.data()), length);
+  return in.good() || in.gcount() == length;
+}
+
+std::string TypeToString(const Type type) {
+  switch (type) {
+  case Type::Fixtures:
+    return "fixtures";
+  case Type::Trusses:
+    return "trusses";
+  }
+  return "unknown";
+}
+
+bool IsZipByHeader(const fs::path &path) {
+  std::ifstream input(path, std::ios::binary);
+  if (!input.is_open())
+    return false;
+  unsigned char sig[2] = {};
+  input.read(reinterpret_cast<char *>(sig), sizeof(sig));
+  return input.gcount() == static_cast<std::streamsize>(sizeof(sig)) &&
+         sig[0] == 'P' && sig[1] == 'K';
+}
+
+bool ReadZipEntryBytes(wxZipInputStream &zip, std::vector<unsigned char> &outBytes) {
+  outBytes.clear();
+  unsigned char chunk[4096];
+  for (;;) {
+    zip.Read(chunk, sizeof(chunk));
+    const size_t readBytes = zip.LastRead();
+    if (readBytes == 0)
+      break;
+    outBytes.insert(outBytes.end(), chunk, chunk + readBytes);
+  }
+  return true;
+}
+
+bool WriteZipEntryFromBytes(wxZipOutputStream &zip, const std::string &entryName,
+                            const std::vector<unsigned char> &bytes) {
+  auto *entry = new wxZipEntry(entryName);
+  entry->SetMethod(wxZIP_METHOD_DEFLATE);
+  zip.PutNextEntry(entry);
+  if (!bytes.empty())
+    zip.Write(bytes.data(), bytes.size());
+  zip.CloseEntry();
+  return true;
+}
+
+bool WriteZipEntryFromFile(wxZipOutputStream &zip, const std::string &entryName,
+                           const fs::path &sourcePath) {
+  std::vector<unsigned char> bytes;
+  if (!ReadFileBytes(sourcePath, bytes))
+    return false;
+  return WriteZipEntryFromBytes(zip, entryName, bytes);
+}
+
+std::string BaseNameForArchive(const fs::path &path, size_t fallbackIndex) {
+  const std::string filename = path.filename().string();
+  if (!filename.empty())
+    return filename;
+  return "asset_" + std::to_string(fallbackIndex) + ".bin";
+}
+
+fs::path MakeTempStagingDir() {
+  const auto timestamp =
+      std::chrono::system_clock::now().time_since_epoch().count();
+  fs::path dir = fs::temp_directory_path() /
+                 ("perastage-dictionary-bundle-" + std::to_string(timestamp));
+  std::error_code ec;
+  fs::create_directories(dir, ec);
+  if (ec)
+    return {};
+  return dir;
+}
+
+bool SerializeJsonToBytes(const nlohmann::json &json, std::vector<unsigned char> &outBytes) {
+  const std::string text = json.dump(2);
+  outBytes.assign(text.begin(), text.end());
+  return true;
+}
+
+nlohmann::json BuildFixturesEntriesJson(
+    const std::unordered_map<std::string, GdtfDictionary::Entry> &dict,
+    std::vector<AssetPayload> &assets, std::string &error) {
+  nlohmann::json entries = nlohmann::json::object();
+  std::unordered_map<std::string, std::string> sourceToArchivePath;
+  size_t assetIndex = 0;
+
+  std::vector<std::string> keys;
+  keys.reserve(dict.size());
+  for (const auto &[name, _] : dict)
+    keys.push_back(name);
+  std::sort(keys.begin(), keys.end());
+
+  for (const auto &name : keys) {
+    const auto &entry = dict.at(name);
+    if (entry.path.empty() && entry.mode.empty() && entry.category.empty())
+      continue;
+
+    nlohmann::json outputEntry = nlohmann::json::object();
+    if (!entry.path.empty()) {
+      const fs::path sourcePath = fs::u8path(entry.path);
+      if (!fs::exists(sourcePath)) {
+        error = "Missing fixture asset for entry '" + name + "': " + entry.path;
+        return {};
+      }
+
+      const std::string sourceKey = sourcePath.lexically_normal().string();
+      auto archiveIt = sourceToArchivePath.find(sourceKey);
+      if (archiveIt == sourceToArchivePath.end()) {
+        const std::string archivePath = "assets/" + BaseNameForArchive(sourcePath, assetIndex++);
+        std::vector<unsigned char> assetBytes;
+        if (!ReadFileBytes(sourcePath, assetBytes)) {
+          error = "Could not read fixture asset: " + entry.path;
+          return {};
+        }
+
+        AssetPayload payload;
+        payload.sourcePath = sourcePath;
+        payload.archivePath = archivePath;
+        payload.checksum = BuildChecksumLabel(assetBytes);
+        payload.size = assetBytes.size();
+        assets.push_back(payload);
+        sourceToArchivePath[sourceKey] = archivePath;
+        outputEntry["file"] = archivePath;
+      } else {
+        outputEntry["file"] = archiveIt->second;
+      }
+    }
+
+    if (!entry.mode.empty())
+      outputEntry["mode"] = entry.mode;
+    if (!entry.category.empty())
+      outputEntry["category"] = entry.category;
+
+    if (!outputEntry.empty())
+      entries[name] = std::move(outputEntry);
+  }
+
+  return entries;
+}
+
+nlohmann::json BuildTrussEntriesJson(
+    const std::unordered_map<std::string, std::string> &dict,
+    std::vector<AssetPayload> &assets, std::string &error) {
+  nlohmann::json entries = nlohmann::json::object();
+  std::unordered_map<std::string, std::string> sourceToArchivePath;
+  size_t assetIndex = 0;
+
+  std::vector<std::string> keys;
+  keys.reserve(dict.size());
+  for (const auto &[name, _] : dict)
+    keys.push_back(name);
+  std::sort(keys.begin(), keys.end());
+
+  for (const auto &name : keys) {
+    const std::string &source = dict.at(name);
+    if (source.empty())
+      continue;
+
+    const fs::path sourcePath = fs::u8path(source);
+    if (!fs::exists(sourcePath)) {
+      error = "Missing truss asset for entry '" + name + "': " + source;
+      return {};
+    }
+
+    const std::string sourceKey = sourcePath.lexically_normal().string();
+    auto archiveIt = sourceToArchivePath.find(sourceKey);
+    if (archiveIt == sourceToArchivePath.end()) {
+      const std::string archivePath = "assets/" + BaseNameForArchive(sourcePath, assetIndex++);
+      std::vector<unsigned char> assetBytes;
+      if (!ReadFileBytes(sourcePath, assetBytes)) {
+        error = "Could not read truss asset: " + source;
+        return {};
+      }
+
+      AssetPayload payload;
+      payload.sourcePath = sourcePath;
+      payload.archivePath = archivePath;
+      payload.checksum = BuildChecksumLabel(assetBytes);
+      payload.size = assetBytes.size();
+      assets.push_back(payload);
+      sourceToArchivePath[sourceKey] = archivePath;
+      entries[name] = nlohmann::json{{"file", archivePath}};
+    } else {
+      entries[name] = nlohmann::json{{"file", archiveIt->second}};
+    }
+  }
+
+  return entries;
+}
+
+bool WriteBundle(const fs::path &outputZipPath, const std::string &dictionaryType,
+                 const nlohmann::json &entries, const std::vector<AssetPayload> &assets,
+                 std::string &error) {
+  wxFileOutputStream output(outputZipPath.string());
+  if (!output.IsOk()) {
+    error = "Could not create ZIP file";
+    return false;
+  }
+
+  wxZipOutputStream zip(output);
+  nlohmann::json manifest;
+  manifest["kind"] = kBundleKind;
+  manifest["format_version"] = kFormatVersion;
+  manifest["dictionary_type"] = dictionaryType;
+  manifest["dictionary_file"] = "dictionary.json";
+  manifest["entries"] = entries;
+
+  nlohmann::json manifestAssets = nlohmann::json::array();
+  for (const auto &asset : assets) {
+    manifestAssets.push_back(nlohmann::json{{"path", asset.archivePath},
+                                            {"checksum", asset.checksum},
+                                            {"size", asset.size}});
+  }
+  manifest["assets"] = std::move(manifestAssets);
+
+  std::vector<unsigned char> manifestBytes;
+  SerializeJsonToBytes(manifest, manifestBytes);
+  WriteZipEntryFromBytes(zip, "manifest.json", manifestBytes);
+
+  const nlohmann::json dictionaryRoot =
+      DictionaryJsonContract::MakeRoot(dictionaryType, entries);
+  std::vector<unsigned char> dictionaryBytes;
+  SerializeJsonToBytes(dictionaryRoot, dictionaryBytes);
+  WriteZipEntryFromBytes(zip, "dictionary.json", dictionaryBytes);
+
+  for (const auto &asset : assets) {
+    if (!WriteZipEntryFromFile(zip, asset.archivePath, asset.sourcePath)) {
+      error = "Failed to pack asset into ZIP: " + asset.sourcePath.string();
+      return false;
+    }
+  }
+
+  zip.Close();
+  return true;
+}
+
+bool ExtractArchive(const fs::path &zipPath, const fs::path &destination,
+                    std::string &error) {
+  wxFileInputStream input(zipPath.string());
+  if (!input.IsOk()) {
+    error = "Could not open ZIP file";
+    return false;
+  }
+
+  wxZipInputStream zip(input);
+  std::unique_ptr<wxZipEntry> entry;
+  while ((entry.reset(zip.GetNextEntry())), entry) {
+    if (entry->IsDir())
+      continue;
+
+    const fs::path outPath = destination / fs::u8path(entry->GetName().ToStdString());
+    std::error_code ec;
+    fs::create_directories(outPath.parent_path(), ec);
+
+    std::ofstream out(outPath, std::ios::binary);
+    if (!out.is_open()) {
+      error = "Could not write extracted file: " + outPath.string();
+      return false;
+    }
+
+    char buffer[4096];
+    for (;;) {
+      zip.Read(buffer, sizeof(buffer));
+      const size_t bytes = zip.LastRead();
+      if (bytes == 0)
+        break;
+      out.write(buffer, static_cast<std::streamsize>(bytes));
+    }
+  }
+
+  return true;
+}
+
+bool ReadJsonFile(const fs::path &path, nlohmann::json &outJson, std::string &error) {
+  std::ifstream in(path);
+  if (!in.is_open()) {
+    error = "Could not open JSON file: " + path.string();
+    return false;
+  }
+
+  try {
+    in >> outJson;
+  } catch (const std::exception &ex) {
+    error = "Could not parse JSON file '" + path.string() + "': " + ex.what();
+    return false;
+  }
+  return true;
+}
+
+bool ResolveEntryFileField(nlohmann::json &entryJson, std::string &pathOut) {
+  pathOut.clear();
+  if (entryJson.is_string()) {
+    pathOut = entryJson.get<std::string>();
+    return !pathOut.empty();
+  }
+  if (!entryJson.is_object())
+    return false;
+  if (entryJson.contains("file") && entryJson["file"].is_string()) {
+    pathOut = entryJson["file"].get<std::string>();
+    return !pathOut.empty();
+  }
+  if (entryJson.contains("path") && entryJson["path"].is_string()) {
+    pathOut = entryJson["path"].get<std::string>();
+    return !pathOut.empty();
+  }
+  return false;
+}
+
+void RewriteEntryFileField(nlohmann::json &entryJson, const std::string &rewrittenPath) {
+  if (entryJson.is_string()) {
+    entryJson = rewrittenPath;
+    return;
+  }
+  if (!entryJson.is_object()) {
+    entryJson = nlohmann::json{{"file", rewrittenPath}};
+    return;
+  }
+  entryJson["file"] = rewrittenPath;
+  if (entryJson.contains("path"))
+    entryJson.erase("path");
+}
+
+} // namespace
+
+bool ExportFixturesBundle(
+    const std::unordered_map<std::string, GdtfDictionary::Entry> &dict,
+    const std::string &outputZipPath, std::string &error) {
+  std::vector<AssetPayload> assets;
+  const nlohmann::json entries = BuildFixturesEntriesJson(dict, assets, error);
+  if (!error.empty())
+    return false;
+
+  return WriteBundle(fs::u8path(outputZipPath), "fixtures", entries, assets, error);
+}
+
+bool ExportTrussesBundle(
+    const std::unordered_map<std::string, std::string> &dict,
+    const std::string &outputZipPath, std::string &error) {
+  std::vector<AssetPayload> assets;
+  const nlohmann::json entries = BuildTrussEntriesJson(dict, assets, error);
+  if (!error.empty())
+    return false;
+
+  return WriteBundle(fs::u8path(outputZipPath), "trusses", entries, assets, error);
+}
+
+PreparedImport PrepareBundleImport(const std::string &importPath, Type expectedType) {
+  PreparedImport result;
+
+  const fs::path path = fs::u8path(importPath);
+  if (!fs::exists(path))
+    return result;
+
+  const std::string lowerExt = ToLowerCopy(path.extension().string());
+  if (lowerExt != ".zip" && !IsZipByHeader(path))
+    return result;
+
+  const fs::path stagingDir = MakeTempStagingDir();
+  if (stagingDir.empty()) {
+    result.errors.push_back("Could not create temporary staging directory for bundle import");
+    return result;
+  }
+
+  std::string extractError;
+  if (!ExtractArchive(path, stagingDir, extractError)) {
+    result.errors.push_back(extractError);
+    result.staging_directory = stagingDir;
+    return result;
+  }
+
+  const fs::path manifestPath = stagingDir / "manifest.json";
+  if (!fs::exists(manifestPath)) {
+    std::error_code cleanupEc;
+    fs::remove_all(stagingDir, cleanupEc);
+    return result;
+  }
+
+  nlohmann::json manifest;
+  std::string parseError;
+  if (!ReadJsonFile(manifestPath, manifest, parseError)) {
+    result.errors.push_back(parseError);
+    result.staging_directory = stagingDir;
+    result.is_bundle = true;
+    return result;
+  }
+
+  if (!manifest.contains("kind") || !manifest["kind"].is_string() ||
+      manifest["kind"].get<std::string>() != kBundleKind) {
+    std::error_code cleanupEc;
+    fs::remove_all(stagingDir, cleanupEc);
+    return result;
+  }
+
+  result.is_bundle = true;
+  result.staging_directory = stagingDir;
+
+  if (!manifest.contains("dictionary_type") || !manifest["dictionary_type"].is_string()) {
+    result.errors.push_back("Bundle manifest missing 'dictionary_type'");
+    return result;
+  }
+
+  const std::string manifestType = manifest["dictionary_type"].get<std::string>();
+  const std::string expectedTypeText = TypeToString(expectedType);
+  if (manifestType != expectedTypeText) {
+    result.errors.push_back("Bundle dictionary_type mismatch (expected '" +
+                            expectedTypeText + "')");
+    return result;
+  }
+
+  if (!manifest.contains("entries")) {
+    result.errors.push_back("Bundle manifest missing 'entries'");
+    return result;
+  }
+
+  std::unordered_map<std::string, std::string> importedAssetToLibraryPath;
+  if (!manifest.contains("assets") || !manifest["assets"].is_array()) {
+    result.errors.push_back("Bundle manifest missing 'assets' array");
+    return result;
+  }
+
+  const fs::path libraryDir = fs::u8path(ProjectUtils::GetDefaultLibraryPath(expectedTypeText));
+  std::error_code ec;
+  fs::create_directories(libraryDir, ec);
+
+  for (const auto &assetJson : manifest["assets"]) {
+    if (!assetJson.is_object()) {
+      result.errors.push_back("Bundle manifest has invalid asset entry");
+      continue;
+    }
+    if (!assetJson.contains("path") || !assetJson["path"].is_string() ||
+        !assetJson.contains("checksum") || !assetJson["checksum"].is_string()) {
+      result.errors.push_back("Bundle asset is missing required fields");
+      continue;
+    }
+
+    const std::string archivePath = assetJson["path"].get<std::string>();
+    const std::string expectedChecksum = assetJson["checksum"].get<std::string>();
+    const fs::path extractedPath = stagingDir / fs::u8path(archivePath);
+    if (!fs::exists(extractedPath)) {
+      result.errors.push_back("Bundle asset not found: " + archivePath);
+      continue;
+    }
+
+    std::vector<unsigned char> bytes;
+    if (!ReadFileBytes(extractedPath, bytes)) {
+      result.errors.push_back("Could not read extracted bundle asset: " + archivePath);
+      continue;
+    }
+
+    const std::string actualChecksum = BuildChecksumLabel(bytes);
+    if (actualChecksum != expectedChecksum) {
+      result.errors.push_back("Checksum mismatch for asset: " + archivePath);
+      continue;
+    }
+
+    const fs::path destPath = libraryDir / extractedPath.filename();
+    std::error_code copyEc;
+    fs::copy_file(extractedPath, destPath, fs::copy_options::overwrite_existing, copyEc);
+    if (copyEc) {
+      result.errors.push_back("Could not copy bundle asset into library: " +
+                              destPath.string());
+      continue;
+    }
+
+    importedAssetToLibraryPath[archivePath] = destPath.string();
+  }
+
+  if (!result.errors.empty())
+    return result;
+
+  nlohmann::json rewrittenEntries = manifest["entries"];
+  auto rewriteSingle = [&](nlohmann::json &entryJson, const std::string &entryName) {
+    std::string fileField;
+    if (!ResolveEntryFileField(entryJson, fileField))
+      return;
+
+    const auto importedIt = importedAssetToLibraryPath.find(fileField);
+    if (importedIt == importedAssetToLibraryPath.end()) {
+      result.errors.push_back("Entry '" + entryName + "' references unknown bundle asset: " +
+                              fileField);
+      return;
+    }
+    RewriteEntryFileField(entryJson, importedIt->second);
+  };
+
+  if (rewrittenEntries.is_object()) {
+    for (auto it = rewrittenEntries.begin(); it != rewrittenEntries.end(); ++it)
+      rewriteSingle(it.value(), it.key());
+  } else if (rewrittenEntries.is_array()) {
+    for (size_t i = 0; i < rewrittenEntries.size(); ++i) {
+      nlohmann::json &entryJson = rewrittenEntries[i];
+      if (!entryJson.is_object() || !entryJson.contains("name") ||
+          !entryJson["name"].is_string()) {
+        continue;
+      }
+      rewriteSingle(entryJson, entryJson["name"].get<std::string>());
+    }
+  } else {
+    result.errors.push_back("Bundle 'entries' must be an object or array");
+    return result;
+  }
+
+  if (!result.errors.empty())
+    return result;
+
+  const nlohmann::json rewrittenRoot =
+      DictionaryJsonContract::MakeRoot(expectedTypeText, rewrittenEntries);
+  const fs::path rewrittenPath = stagingDir / "dictionary_rewritten.json";
+  std::ofstream out(rewrittenPath);
+  if (!out.is_open()) {
+    result.errors.push_back("Could not write rewritten dictionary snapshot");
+    return result;
+  }
+  out << rewrittenRoot.dump(2);
+  result.rewritten_snapshot_path = rewrittenPath;
+
+  return result;
+}
+
+void CleanupPreparedImport(const PreparedImport &preparedImport) {
+  if (preparedImport.staging_directory.empty())
+    return;
+  std::error_code ec;
+  fs::remove_all(preparedImport.staging_directory, ec);
+}
+
+} // namespace DictionaryBundle

--- a/core/dictionary_bundle.h
+++ b/core/dictionary_bundle.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "gdtfdictionary.h"
+
+#include <filesystem>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace DictionaryBundle {
+
+enum class Type {
+  Fixtures,
+  Trusses,
+};
+
+struct PreparedImport {
+  bool is_bundle = false;
+  std::filesystem::path rewritten_snapshot_path;
+  std::filesystem::path staging_directory;
+  std::vector<std::string> errors;
+};
+
+bool ExportFixturesBundle(
+    const std::unordered_map<std::string, GdtfDictionary::Entry> &dict,
+    const std::string &outputZipPath, std::string &error);
+bool ExportTrussesBundle(
+    const std::unordered_map<std::string, std::string> &dict,
+    const std::string &outputZipPath, std::string &error);
+
+PreparedImport PrepareBundleImport(const std::string &importPath, Type expectedType);
+void CleanupPreparedImport(const PreparedImport &preparedImport);
+
+} // namespace DictionaryBundle

--- a/docs/dictionary_portable_bundle.md
+++ b/docs/dictionary_portable_bundle.md
@@ -1,0 +1,64 @@
+# Portable dictionary bundle format
+
+Perastage keeps JSON dictionary snapshots for backward compatibility and also supports a portable ZIP bundle format for fixtures and trusses dictionaries.
+
+## Backward compatibility
+
+- Existing `.json` snapshots are still valid for import/export.
+- The current **Import dictionary...** action accepts both JSON snapshots and ZIP bundles.
+- The current **Export dictionary...** action still writes JSON snapshots.
+- A new **Export portable bundle...** action writes a ZIP bundle that includes dictionary data and required assets.
+
+## ZIP layout
+
+A portable bundle is a regular `.zip` file with the following entries:
+
+- `manifest.json`
+- `dictionary.json`
+- `assets/*` (copied assets used by the exported dictionary entries)
+
+No custom file extension is required.
+
+## `manifest.json` contract
+
+```json
+{
+  "kind": "perastage.dictionary_bundle",
+  "format_version": 1,
+  "dictionary_type": "fixtures",
+  "dictionary_file": "dictionary.json",
+  "entries": { ... },
+  "assets": [
+    {
+      "path": "assets/MyFixture.gdtf",
+      "checksum": "fnv1a64:0123456789abcdef",
+      "size": 123456
+    }
+  ]
+}
+```
+
+### Required fields
+
+- `kind`: must be `perastage.dictionary_bundle`.
+- `format_version`: bundle schema version (`1` currently).
+- `dictionary_type`: `fixtures` or `trusses`.
+- `entries`: dictionary entries for the selected dictionary type.
+- `assets`: list of packed assets with path + checksum metadata.
+
+## Import behavior for ZIP bundles
+
+When a bundle is imported:
+
+1. The ZIP is extracted to a temporary staging directory.
+2. `manifest.json` is validated (`kind`, `dictionary_type`, required fields).
+3. Every declared `assets[]` item is validated with its checksum.
+4. Assets are copied to the target library directory:
+   - fixtures -> `library/fixtures`
+   - trusses -> `library/trusses`
+5. Dictionary entries are rewritten so `file` references point to the imported library assets.
+6. The rewritten dictionary is imported using the same import policy flow used for JSON snapshots.
+
+## `dictionary.json`
+
+The bundle also includes `dictionary.json` using the existing dictionary JSON contract (`kind: perastage.dictionary`), which keeps compatibility with existing tooling and simplifies inspection/debugging.

--- a/gui/dictionaryeditdialog.cpp
+++ b/gui/dictionaryeditdialog.cpp
@@ -18,6 +18,7 @@
 #include "dictionaryeditdialog.h"
 
 #include "columnutils.h"
+#include "dictionary_bundle.h"
 #include "dictionary_json_contract.h"
 #include "gdtfdictionary.h"
 #include "gdtfloader.h"
@@ -497,6 +498,7 @@ void DictionaryEditDialog::BuildLayout() {
   downloadBtn = new wxButton(this, wxID_ANY, "Download GDTF");
   importBtn = new wxButton(this, wxID_ANY, "Import dictionary...");
   exportBtn = new wxButton(this, wxID_ANY, "Export dictionary...");
+  exportPortableBtn = new wxButton(this, wxID_ANY, "Export portable bundle...");
   resetBtn = new wxButton(this, wxID_ANY, "Reset to default");
   okBtn = new wxButton(this, wxID_OK, "OK");
   cancelBtn = new wxButton(this, wxID_CANCEL, "Cancel");
@@ -506,6 +508,7 @@ void DictionaryEditDialog::BuildLayout() {
   btnSizer->Add(downloadBtn, 0, wxRIGHT, 10);
   btnSizer->Add(importBtn, 0, wxRIGHT, 10);
   btnSizer->Add(exportBtn, 0, wxRIGHT, 5);
+  btnSizer->Add(exportPortableBtn, 0, wxRIGHT, 5);
   btnSizer->Add(resetBtn, 0, wxRIGHT, 10);
   btnSizer->AddStretchSpacer(1);
   btnSizer->Add(okBtn, 0, wxRIGHT, 5);
@@ -520,6 +523,7 @@ void DictionaryEditDialog::BuildLayout() {
   downloadBtn->Bind(wxEVT_BUTTON, &DictionaryEditDialog::OnDownloadGdtf, this);
   importBtn->Bind(wxEVT_BUTTON, &DictionaryEditDialog::OnImportDictionary, this);
   exportBtn->Bind(wxEVT_BUTTON, &DictionaryEditDialog::OnExportDictionary, this);
+  exportPortableBtn->Bind(wxEVT_BUTTON, &DictionaryEditDialog::OnExportPortableBundle, this);
   resetBtn->Bind(wxEVT_BUTTON, &DictionaryEditDialog::OnResetDictionary, this);
   okBtn->Bind(wxEVT_BUTTON, &DictionaryEditDialog::OnOk, this);
   fixtureTable->Bind(wxEVT_DATAVIEW_ITEM_ACTIVATED,
@@ -807,25 +811,44 @@ void DictionaryEditDialog::OnImportDictionary(wxCommandEvent &WXUNUSED(event)) {
 
 bool DictionaryEditDialog::ImportFixturesDictionary() {
   wxFileDialog fileDialog(this, "Import fixtures dictionary", wxEmptyString,
-                          wxEmptyString, "JSON files (*.json)|*.json",
+                          wxEmptyString,
+                          "Dictionary files (*.json;*.zip)|*.json;*.zip|JSON files (*.json)|*.json|ZIP files (*.zip)|*.zip",
                           wxFD_OPEN | wxFD_FILE_MUST_EXIST);
   if (fileDialog.ShowModal() != wxID_OK)
     return false;
-  const std::string importPath = std::string(fileDialog.GetPath().ToUTF8());
+  const std::string selectedPath = std::string(fileDialog.GetPath().ToUTF8());
+  DictionaryBundle::PreparedImport preparedImport =
+      DictionaryBundle::PrepareBundleImport(selectedPath, DictionaryBundle::Type::Fixtures);
+  if (!preparedImport.errors.empty()) {
+    DictionaryImportSummary errorSummary;
+    errorSummary.errors = preparedImport.errors;
+    wxMessageBox("Invalid fixtures dictionary file.\n\n" +
+                     BuildSummaryText(errorSummary),
+                 "Import fixtures dictionary", wxOK | wxICON_ERROR, this);
+    DictionaryBundle::CleanupPreparedImport(preparedImport);
+    return false;
+  }
+  const std::string importPath = preparedImport.is_bundle
+                                     ? preparedImport.rewritten_snapshot_path.string()
+                                     : selectedPath;
   const auto validationPreview =
       GdtfDictionary::PreviewImportFromFile(importPath, DictionaryImportPolicy::AddMissing);
   if (validationPreview.HasErrors()) {
     wxMessageBox("Invalid fixtures dictionary file.\n\n" +
                      BuildSummaryText(validationPreview),
                  "Import fixtures dictionary", wxOK | wxICON_ERROR, this);
+    DictionaryBundle::CleanupPreparedImport(preparedImport);
     return false;
   }
 
   DictionaryImportPolicy policy = DictionaryImportPolicy::AddMissing;
-  if (!AskImportPolicy(this, policy))
+  if (!AskImportPolicy(this, policy)) {
+    DictionaryBundle::CleanupPreparedImport(preparedImport);
     return false;
+  }
   if (policy == DictionaryImportPolicy::ReplaceAll &&
       !ConfirmReplaceAllOperation(this, "fixtures")) {
+    DictionaryBundle::CleanupPreparedImport(preparedImport);
     return false;
   }
 
@@ -836,12 +859,16 @@ bool DictionaryEditDialog::ImportFixturesDictionary() {
                          "\n\nApply import?";
   if (wxMessageBox(confirmText, "Confirm fixtures dictionary import",
                    wxYES_NO | wxICON_QUESTION, this) != wxYES) {
+    DictionaryBundle::CleanupPreparedImport(preparedImport);
     return false;
   }
-  if (!ConfirmImportMissingPaths(this, "Fixtures import warning", pathValidation))
+  if (!ConfirmImportMissingPaths(this, "Fixtures import warning", pathValidation)) {
+    DictionaryBundle::CleanupPreparedImport(preparedImport);
     return false;
+  }
 
   const auto result = GdtfDictionary::ApplyImportFromFile(importPath, policy);
+  DictionaryBundle::CleanupPreparedImport(preparedImport);
   LoadFixtures();
   wxMessageBox("Fixtures dictionary import completed.\n\n" +
                    BuildSummaryText(result),
@@ -851,25 +878,44 @@ bool DictionaryEditDialog::ImportFixturesDictionary() {
 
 bool DictionaryEditDialog::ImportTrussesDictionary() {
   wxFileDialog fileDialog(this, "Import trusses dictionary", wxEmptyString,
-                          wxEmptyString, "JSON files (*.json)|*.json",
+                          wxEmptyString,
+                          "Dictionary files (*.json;*.zip)|*.json;*.zip|JSON files (*.json)|*.json|ZIP files (*.zip)|*.zip",
                           wxFD_OPEN | wxFD_FILE_MUST_EXIST);
   if (fileDialog.ShowModal() != wxID_OK)
     return false;
-  const std::string importPath = std::string(fileDialog.GetPath().ToUTF8());
+  const std::string selectedPath = std::string(fileDialog.GetPath().ToUTF8());
+  DictionaryBundle::PreparedImport preparedImport =
+      DictionaryBundle::PrepareBundleImport(selectedPath, DictionaryBundle::Type::Trusses);
+  if (!preparedImport.errors.empty()) {
+    DictionaryImportSummary errorSummary;
+    errorSummary.errors = preparedImport.errors;
+    wxMessageBox("Invalid trusses dictionary file.\n\n" +
+                     BuildSummaryText(errorSummary),
+                 "Import trusses dictionary", wxOK | wxICON_ERROR, this);
+    DictionaryBundle::CleanupPreparedImport(preparedImport);
+    return false;
+  }
+  const std::string importPath = preparedImport.is_bundle
+                                     ? preparedImport.rewritten_snapshot_path.string()
+                                     : selectedPath;
   const auto validationPreview =
       TrussDictionary::PreviewImportFromFile(importPath, DictionaryImportPolicy::AddMissing);
   if (validationPreview.HasErrors()) {
     wxMessageBox("Invalid trusses dictionary file.\n\n" +
                      BuildSummaryText(validationPreview),
                  "Import trusses dictionary", wxOK | wxICON_ERROR, this);
+    DictionaryBundle::CleanupPreparedImport(preparedImport);
     return false;
   }
 
   DictionaryImportPolicy policy = DictionaryImportPolicy::AddMissing;
-  if (!AskImportPolicy(this, policy))
+  if (!AskImportPolicy(this, policy)) {
+    DictionaryBundle::CleanupPreparedImport(preparedImport);
     return false;
+  }
   if (policy == DictionaryImportPolicy::ReplaceAll &&
       !ConfirmReplaceAllOperation(this, "trusses")) {
+    DictionaryBundle::CleanupPreparedImport(preparedImport);
     return false;
   }
 
@@ -880,12 +926,16 @@ bool DictionaryEditDialog::ImportTrussesDictionary() {
                          "\n\nApply import?";
   if (wxMessageBox(confirmText, "Confirm trusses dictionary import",
                    wxYES_NO | wxICON_QUESTION, this) != wxYES) {
+    DictionaryBundle::CleanupPreparedImport(preparedImport);
     return false;
   }
-  if (!ConfirmImportMissingPaths(this, "Trusses import warning", pathValidation))
+  if (!ConfirmImportMissingPaths(this, "Trusses import warning", pathValidation)) {
+    DictionaryBundle::CleanupPreparedImport(preparedImport);
     return false;
+  }
 
   const auto result = TrussDictionary::ApplyImportFromFile(importPath, policy);
+  DictionaryBundle::CleanupPreparedImport(preparedImport);
   LoadTrusses();
   wxMessageBox("Trusses dictionary import completed.\n\n" +
                    BuildSummaryText(result),
@@ -899,6 +949,14 @@ void DictionaryEditDialog::OnExportDictionary(wxCommandEvent &WXUNUSED(event)) {
     return;
   }
   (void)ExportTrussesDictionary();
+}
+
+void DictionaryEditDialog::OnExportPortableBundle(wxCommandEvent &WXUNUSED(event)) {
+  if (IsFixturesPage()) {
+    (void)ExportFixturesPortableBundle();
+    return;
+  }
+  (void)ExportTrussesPortableBundle();
 }
 
 void DictionaryEditDialog::OnResetDictionary(wxCommandEvent &WXUNUSED(event)) {
@@ -966,6 +1024,64 @@ bool DictionaryEditDialog::ExportTrussesDictionary() {
   }
   wxMessageBox("Trusses dictionary snapshot exported successfully.",
                "Export trusses dictionary", wxICON_INFORMATION | wxOK, this);
+  return true;
+}
+
+bool DictionaryEditDialog::ExportFixturesPortableBundle() {
+  auto dictOpt = GdtfDictionary::Load();
+  if (!dictOpt) {
+    wxMessageBox("Could not load fixtures dictionary for portable export.",
+                 "Export portable fixtures bundle", wxICON_ERROR | wxOK, this);
+    return false;
+  }
+
+  wxFileDialog fileDialog(this, "Export portable fixtures bundle", wxEmptyString,
+                          "gdtf_dictionary_bundle.zip",
+                          "ZIP files (*.zip)|*.zip",
+                          wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+  if (fileDialog.ShowModal() != wxID_OK)
+    return false;
+
+  std::string error;
+  const std::string outputPath = std::string(fileDialog.GetPath().ToUTF8());
+  if (!DictionaryBundle::ExportFixturesBundle(*dictOpt, outputPath, error)) {
+    wxMessageBox("Could not write fixtures portable bundle.\n\n" +
+                     wxString::FromUTF8(error),
+                 "Export portable fixtures bundle", wxICON_ERROR | wxOK, this);
+    return false;
+  }
+
+  wxMessageBox("Fixtures portable bundle exported successfully.",
+               "Export portable fixtures bundle", wxICON_INFORMATION | wxOK, this);
+  return true;
+}
+
+bool DictionaryEditDialog::ExportTrussesPortableBundle() {
+  auto dictOpt = TrussDictionary::Load();
+  if (!dictOpt) {
+    wxMessageBox("Could not load trusses dictionary for portable export.",
+                 "Export portable trusses bundle", wxICON_ERROR | wxOK, this);
+    return false;
+  }
+
+  wxFileDialog fileDialog(this, "Export portable trusses bundle", wxEmptyString,
+                          "truss_dictionary_bundle.zip",
+                          "ZIP files (*.zip)|*.zip",
+                          wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+  if (fileDialog.ShowModal() != wxID_OK)
+    return false;
+
+  std::string error;
+  const std::string outputPath = std::string(fileDialog.GetPath().ToUTF8());
+  if (!DictionaryBundle::ExportTrussesBundle(*dictOpt, outputPath, error)) {
+    wxMessageBox("Could not write trusses portable bundle.\n\n" +
+                     wxString::FromUTF8(error),
+                 "Export portable trusses bundle", wxICON_ERROR | wxOK, this);
+    return false;
+  }
+
+  wxMessageBox("Trusses portable bundle exported successfully.",
+               "Export portable trusses bundle", wxICON_INFORMATION | wxOK, this);
   return true;
 }
 

--- a/gui/dictionaryeditdialog.h
+++ b/gui/dictionaryeditdialog.h
@@ -39,6 +39,7 @@ private:
   void OnDownloadGdtf(wxCommandEvent &event);
   void OnImportDictionary(wxCommandEvent &event);
   void OnExportDictionary(wxCommandEvent &event);
+  void OnExportPortableBundle(wxCommandEvent &event);
   void OnResetDictionary(wxCommandEvent &event);
   void OnOk(wxCommandEvent &event);
   void OnItemActivated(wxDataViewEvent &event);
@@ -46,6 +47,8 @@ private:
   bool ImportTrussesDictionary();
   bool ExportFixturesDictionary();
   bool ExportTrussesDictionary();
+  bool ExportFixturesPortableBundle();
+  bool ExportTrussesPortableBundle();
   bool ResetFixturesDictionaryToDefault();
   bool ResetTrussesDictionaryToDefault();
 
@@ -57,6 +60,7 @@ private:
   wxButton *downloadBtn = nullptr;
   wxButton *importBtn = nullptr;
   wxButton *exportBtn = nullptr;
+  wxButton *exportPortableBtn = nullptr;
   wxButton *resetBtn = nullptr;
   wxButton *okBtn = nullptr;
   wxButton *cancelBtn = nullptr;


### PR DESCRIPTION
### Motivation
- Provide a portable, self-contained way to move dictionary snapshots together with the actual assets so imports work on other machines without manual asset copying.  The change keeps existing JSON snapshot behavior for backward compatibility.

### Description
- Add a new core module `core/dictionary_bundle.{h,cpp}` that implements creating and reading regular ZIP bundles containing `manifest.json`, `dictionary.json` and an `assets/` folder, with per-asset checksum metadata using an `fnv1a64:` label and a small staging/import helper (`DictionaryBundle::PrepareBundleImport`, `CleanupPreparedImport`).
- Wire bundle export/import into the UI by updating `gui/dictionaryeditdialog.{h,cpp}` to accept `.json` or `.zip` on import, add the `Export portable bundle...` action, and use the existing import policy flow after rewriting entries to point to copied library assets.
- Keep existing JSON snapshot export/import unchanged for compatibility and document the bundle format in `docs/dictionary_portable_bundle.md` (ZIP layout, `manifest.json` contract and import behavior).
- Register the new source file in `core/CMakeLists.txt` so the new module is built with the core target.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.
- Attempted a full CMake configure/build but it failed to configure in this environment due to missing `wxWidgets` (CMake reported `Could NOT find wxWidgets`), so an actual compile/run of the new UI/ZIP code was not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c616276a00832497194e01809de298)