### PR TITLE
Add optional asset-copy mode for dictionary snapshot export and robust relative import resolution

### DIFF
--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -66,6 +66,24 @@ bool RecreateUserDictionaryFromBase(const fs::path &userFile,
   return true;
 }
 
+fs::path ResolveImportedPath(const fs::path &jsonFile,
+                             const std::string &rawPathText) {
+  const fs::path parsedPath = fs::u8path(rawPathText);
+  if (parsedPath.is_absolute())
+    return parsedPath;
+
+  const fs::path jsonDir = jsonFile.parent_path();
+  const fs::path directPath = jsonDir / parsedPath;
+  if (fs::exists(directPath))
+    return directPath;
+
+  const fs::path snapshotAssetsPath =
+      jsonDir / (jsonFile.stem().string() + "_assets") / parsedPath;
+  if (fs::exists(snapshotAssetsPath))
+    return snapshotAssetsPath;
+  return directPath;
+}
+
 std::optional<std::unordered_map<std::string, Entry>>
 LoadFromFile(const fs::path &file, std::string &error) {
   std::unordered_map<std::string, Entry> dict;
@@ -99,13 +117,17 @@ LoadFromFile(const fs::path &file, std::string &error) {
   }
 
   const nlohmann::json &entries = **entriesOpt;
-  fs::path dir = file.parent_path();
-  auto parseEntryValue = [&dir](const nlohmann::json &value, Entry &entry,
+  auto parseEntryValue = [&file](const nlohmann::json &value,
+                                 const std::string &entryKey, Entry &entry,
                                 std::string &entryError) -> bool {
     if (value.is_string()) {
-      fs::path p = fs::u8path(value.get<std::string>());
-      if (!p.is_absolute())
-        p = dir / p;
+      const std::string rawPath = value.get<std::string>();
+      fs::path p = ResolveImportedPath(file, rawPath);
+      if (!fs::u8path(rawPath).is_absolute() && !fs::exists(p)) {
+        std::cerr << "Warning: fixtures dictionary entry '" << entryKey
+                  << "' references missing relative path '" << rawPath
+                  << "' resolved from '" << file.string() << "'." << std::endl;
+      }
       entry.path = p.string();
       return true;
     }
@@ -121,9 +143,12 @@ LoadFromFile(const fs::path &file, std::string &error) {
       fname = value["path"].get<std::string>();
 
     if (!fname.empty()) {
-      fs::path p = fs::u8path(fname);
-      if (!p.is_absolute())
-        p = dir / p;
+      fs::path p = ResolveImportedPath(file, fname);
+      if (!fs::u8path(fname).is_absolute() && !fs::exists(p)) {
+        std::cerr << "Warning: fixtures dictionary entry '" << entryKey
+                  << "' references missing relative path '" << fname
+                  << "' resolved from '" << file.string() << "'." << std::endl;
+      }
       entry.path = p.string();
     }
     if (value.contains("mode") && value["mode"].is_string())
@@ -141,7 +166,7 @@ LoadFromFile(const fs::path &file, std::string &error) {
     for (auto it = entries.begin(); it != entries.end(); ++it) {
       Entry entry;
       std::string entryError;
-      if (!parseEntryValue(it.value(), entry, entryError)) {
+      if (!parseEntryValue(it.value(), it.key(), entry, entryError)) {
         error = "Invalid entry '" + it.key() + "': " + entryError;
         return std::nullopt;
       }
@@ -163,12 +188,13 @@ LoadFromFile(const fs::path &file, std::string &error) {
 
     Entry entry;
     std::string entryError;
-    if (!parseEntryValue(entryJson, entry, entryError)) {
+    const std::string entryName = entryJson["name"].get<std::string>();
+    if (!parseEntryValue(entryJson, entryName, entry, entryError)) {
       error = "entries[" + std::to_string(idx) + "] " + entryError;
       return std::nullopt;
     }
 
-    dict[entryJson["name"].get<std::string>()] = entry;
+    dict[entryName] = entry;
   }
   return dict;
 }

--- a/core/trussdictionary.cpp
+++ b/core/trussdictionary.cpp
@@ -108,6 +108,24 @@ static bool RecreateUserDictionaryFromBase(const fs::path &userFile,
   return true;
 }
 
+static fs::path ResolveImportedPath(const fs::path &jsonFile,
+                                    const std::string &rawPathText) {
+  const fs::path parsedPath = fs::u8path(rawPathText);
+  if (parsedPath.is_absolute())
+    return parsedPath;
+
+  const fs::path jsonDir = jsonFile.parent_path();
+  const fs::path directPath = jsonDir / parsedPath;
+  if (fs::exists(directPath))
+    return directPath;
+
+  const fs::path snapshotAssetsPath =
+      jsonDir / (jsonFile.stem().string() + "_assets") / parsedPath;
+  if (fs::exists(snapshotAssetsPath))
+    return snapshotAssetsPath;
+  return directPath;
+}
+
 static bool EnsureMigratedToGdtf(fs::path &pathInOut, std::string &error) {
   std::string ext = LowerExt(pathInOut);
   if (ext == ".gdtf")
@@ -174,11 +192,11 @@ LoadFromFile(const fs::path &file, std::string &error) {
   }
 
   const nlohmann::json &entries = **entriesOpt;
-  fs::path dir = file.parent_path();
   bool changed = false;
 
-  auto resolveEntryPath = [&dir](const nlohmann::json &value, fs::path &entryPath,
-                                 std::string &entryError) -> bool {
+  auto resolveEntryPath = [&file](const nlohmann::json &value, fs::path &entryPath,
+                                  std::string &entryError,
+                                  std::string &rawPathOut) -> bool {
     std::string pathValue;
     if (value.is_string()) {
       pathValue = value.get<std::string>();
@@ -196,9 +214,8 @@ LoadFromFile(const fs::path &file, std::string &error) {
       return false;
     }
 
-    entryPath = fs::u8path(pathValue);
-    if (!entryPath.is_absolute())
-      entryPath = dir / entryPath;
+    rawPathOut = pathValue;
+    entryPath = ResolveImportedPath(file, pathValue);
     return true;
   };
 
@@ -211,14 +228,22 @@ LoadFromFile(const fs::path &file, std::string &error) {
     }
 
     fs::path path;
+    std::string rawPath;
     std::string entryError;
-    if (!resolveEntryPath(value, path, entryError)) {
+    if (!resolveEntryPath(value, path, entryError, rawPath)) {
       error = sourceLabel + " " + entryError;
       return false;
     }
 
-    if (!fs::exists(path))
+    if (!fs::exists(path)) {
+      if (!fs::u8path(rawPath).is_absolute()) {
+        std::cerr << "Warning: trusses dictionary " << sourceLabel
+                  << " references missing relative path '" << rawPath
+                  << "' resolved from '" << file.string() << "'."
+                  << std::endl;
+      }
       return true;
+    }
 
     std::string migrationError;
     fs::path migrated = path;

--- a/gui/dictionaryeditdialog.cpp
+++ b/gui/dictionaryeditdialog.cpp
@@ -54,6 +54,13 @@ struct ExportPathStatusSummary {
   size_t missing_entries = 0;
 };
 
+struct SnapshotExportResult {
+  bool success = false;
+  size_t copied_assets = 0;
+  size_t missing_assets = 0;
+  std::vector<std::string> copy_errors;
+};
+
 struct ImportPathValidationSummary {
   size_t checked_entries = 0;
   size_t found_entries = 0;
@@ -66,6 +73,23 @@ bool HasExistingPath(const std::filesystem::path &candidate) {
     return false;
   std::error_code ec;
   return std::filesystem::exists(candidate, ec);
+}
+
+std::filesystem::path ResolveImportRelativePath(
+    const std::filesystem::path &jsonPath, const std::filesystem::path &rawPath) {
+  if (rawPath.is_absolute())
+    return rawPath;
+
+  const std::filesystem::path importDir = jsonPath.parent_path();
+  const std::filesystem::path directPath = importDir / rawPath;
+  if (HasExistingPath(directPath))
+    return directPath;
+
+  const std::filesystem::path snapshotAssetsPath =
+      importDir / (jsonPath.stem().string() + "_assets") / rawPath;
+  if (HasExistingPath(snapshotAssetsPath))
+    return snapshotAssetsPath;
+  return directPath;
 }
 
 void RegisterMissingExample(ImportPathValidationSummary &summary,
@@ -119,6 +143,59 @@ bool ConfirmExportReferences(wxWindow *parent, const wxString &title,
   return confirmDialog.ShowModal() == wxID_OK;
 }
 
+bool AskCopyReferencedAssets(wxWindow *parent, const wxString &title,
+                             bool &copyAssetsOut) {
+  wxDialog optionsDialog(parent, wxID_ANY, title);
+  wxBoxSizer *topSizer = new wxBoxSizer(wxVERTICAL);
+  wxCheckBox *copyAssetsCheckbox =
+      new wxCheckBox(&optionsDialog, wxID_ANY,
+                     "Copiar también los archivos referenciados");
+  copyAssetsCheckbox->SetValue(false);
+
+  topSizer->Add(
+      new wxStaticText(
+          &optionsDialog, wxID_ANY,
+          "Exporting without copying files keeps the previous behavior."),
+      0, wxALL, 10);
+  topSizer->Add(copyAssetsCheckbox, 0, wxLEFT | wxRIGHT | wxBOTTOM, 10);
+  topSizer->Add(optionsDialog.CreateSeparatedButtonSizer(wxOK | wxCANCEL), 0,
+                wxEXPAND | wxALL, 10);
+  optionsDialog.SetSizerAndFit(topSizer);
+
+  if (optionsDialog.ShowModal() != wxID_OK)
+    return false;
+  copyAssetsOut = copyAssetsCheckbox->GetValue();
+  return true;
+}
+
+std::filesystem::path BuildSnapshotAssetsDir(
+    const std::filesystem::path &snapshotPath) {
+  return snapshotPath.parent_path() /
+         (snapshotPath.stem().string() + "_assets");
+}
+
+std::optional<std::string> CopySnapshotAsset(
+    const std::filesystem::path &sourcePath,
+    const std::filesystem::path &targetAssetsDir) {
+  if (!HasExistingPath(sourcePath))
+    return std::nullopt;
+
+  std::error_code ec;
+  std::filesystem::create_directories(targetAssetsDir, ec);
+  if (ec)
+    return std::nullopt;
+
+  const std::string fileName = sourcePath.filename().string();
+  if (fileName.empty())
+    return std::nullopt;
+  const std::filesystem::path destPath = targetAssetsDir / fileName;
+  std::filesystem::copy_file(sourcePath, destPath,
+                             std::filesystem::copy_options::overwrite_existing, ec);
+  if (ec)
+    return std::nullopt;
+  return std::string("assets/") + fileName;
+}
+
 std::optional<nlohmann::json> LoadJsonFromFile(const std::string &filePath,
                                                std::string &error) {
   std::ifstream in(filePath);
@@ -150,8 +227,7 @@ ImportPathValidationSummary ValidateFixtureImportPaths(const std::string &import
   if (!entriesOpt)
     return summary;
 
-  const std::filesystem::path importDir =
-      std::filesystem::u8path(importPath).parent_path();
+  const std::filesystem::path importFilePath = std::filesystem::u8path(importPath);
   const std::filesystem::path libraryDir = std::filesystem::u8path(
       ProjectUtils::GetDefaultLibraryPath("fixtures"));
 
@@ -169,7 +245,7 @@ ImportPathValidationSummary ValidateFixtureImportPaths(const std::string &import
     ++summary.checked_entries;
     const std::filesystem::path sourcePath = std::filesystem::u8path(rawPath);
     const std::filesystem::path importRelativePath =
-        sourcePath.is_absolute() ? sourcePath : importDir / sourcePath;
+        ResolveImportRelativePath(importFilePath, sourcePath);
     const std::filesystem::path libraryRelativePath = libraryDir / sourcePath.filename();
     if (HasExistingPath(importRelativePath) || HasExistingPath(libraryRelativePath)) {
       ++summary.found_entries;
@@ -210,8 +286,7 @@ ImportPathValidationSummary ValidateTrussImportPaths(const std::string &importPa
   if (!entriesOpt)
     return summary;
 
-  const std::filesystem::path importDir =
-      std::filesystem::u8path(importPath).parent_path();
+  const std::filesystem::path importFilePath = std::filesystem::u8path(importPath);
   const std::filesystem::path libraryDir =
       std::filesystem::u8path(ProjectUtils::GetDefaultLibraryPath("trusses"));
 
@@ -229,7 +304,7 @@ ImportPathValidationSummary ValidateTrussImportPaths(const std::string &importPa
     ++summary.checked_entries;
     const std::filesystem::path sourcePath = std::filesystem::u8path(rawPath);
     const std::filesystem::path importRelativePath =
-        sourcePath.is_absolute() ? sourcePath : importDir / sourcePath;
+        ResolveImportRelativePath(importFilePath, sourcePath);
     const std::filesystem::path libraryRelativePath = libraryDir / sourcePath.filename();
     if (HasExistingPath(importRelativePath) || HasExistingPath(libraryRelativePath)) {
       ++summary.found_entries;
@@ -382,13 +457,19 @@ bool ConfirmReplaceAllOperation(wxWindow *parent, const wxString &dictionaryName
                       parent) == wxYES;
 }
 
-bool SaveFixturesSnapshotToFile(const std::string &outputPath,
-                                const std::unordered_map<std::string, GdtfDictionary::Entry> &dict) {
+bool SaveFixturesSnapshotToFile(
+    const std::string &outputPath,
+    const std::unordered_map<std::string, GdtfDictionary::Entry> &dict,
+    bool copyReferencedAssets, SnapshotExportResult &exportResult) {
   std::vector<std::string> keys;
   keys.reserve(dict.size());
   for (const auto &[name, _] : dict)
     keys.push_back(name);
   std::sort(keys.begin(), keys.end());
+
+  const std::filesystem::path outputFsPath = std::filesystem::u8path(outputPath);
+  const std::filesystem::path targetAssetsDir =
+      BuildSnapshotAssetsDir(outputFsPath) / "assets";
 
   nlohmann::json entries = nlohmann::json::object();
   for (const auto &name : keys) {
@@ -397,9 +478,21 @@ bool SaveFixturesSnapshotToFile(const std::string &outputPath,
       continue;
     nlohmann::json obj;
     if (!entry.path.empty()) {
-      const std::string fileName = std::filesystem::path(entry.path).filename().string();
-      if (!fileName.empty())
-        obj["file"] = fileName;
+      const std::filesystem::path sourcePath = std::filesystem::u8path(entry.path);
+      if (copyReferencedAssets) {
+        const auto copiedRelativePath = CopySnapshotAsset(sourcePath, targetAssetsDir);
+        if (copiedRelativePath) {
+          obj["file"] = *copiedRelativePath;
+          ++exportResult.copied_assets;
+        } else {
+          ++exportResult.missing_assets;
+          exportResult.copy_errors.push_back(name + " -> " + entry.path);
+        }
+      } else {
+        const std::string fileName = sourcePath.filename().string();
+        if (!fileName.empty())
+          obj["file"] = fileName;
+      }
     }
     if (!entry.mode.empty())
       obj["mode"] = entry.mode;
@@ -415,26 +508,45 @@ bool SaveFixturesSnapshotToFile(const std::string &outputPath,
   if (!out.is_open())
     return false;
   out << root.dump(4);
+  exportResult.success = true;
   return true;
 }
 
 bool SaveTrussesSnapshotToFile(const std::string &outputPath,
-                               const std::unordered_map<std::string, std::string> &dict) {
+                               const std::unordered_map<std::string, std::string> &dict,
+                               bool copyReferencedAssets,
+                               SnapshotExportResult &exportResult) {
   std::vector<std::string> keys;
   keys.reserve(dict.size());
   for (const auto &[name, _] : dict)
     keys.push_back(name);
   std::sort(keys.begin(), keys.end());
 
+  const std::filesystem::path outputFsPath = std::filesystem::u8path(outputPath);
+  const std::filesystem::path targetAssetsDir =
+      BuildSnapshotAssetsDir(outputFsPath) / "assets";
+
   nlohmann::json entries = nlohmann::json::object();
   for (const auto &name : keys) {
     const auto &path = dict.at(name);
     if (path.empty())
       continue;
-    const std::string fileName = std::filesystem::path(path).filename().string();
+    const std::filesystem::path sourcePath = std::filesystem::u8path(path);
+    if (copyReferencedAssets) {
+      const auto copiedRelativePath = CopySnapshotAsset(sourcePath, targetAssetsDir);
+      if (copiedRelativePath) {
+        entries[name] = nlohmann::json{{"file", *copiedRelativePath}};
+        ++exportResult.copied_assets;
+      } else {
+        ++exportResult.missing_assets;
+        exportResult.copy_errors.push_back(name + " -> " + path);
+      }
+      continue;
+    }
+    const std::string fileName = sourcePath.filename().string();
     if (fileName.empty())
       continue;
-    entries[name] = nlohmann::json{ {"file", fileName} };
+    entries[name] = nlohmann::json{{"file", fileName}};
   }
 
   const nlohmann::json root =
@@ -443,6 +555,7 @@ bool SaveTrussesSnapshotToFile(const std::string &outputPath,
   if (!out.is_open())
     return false;
   out << root.dump(4);
+  exportResult.success = true;
   return true;
 }
 } // namespace
@@ -986,14 +1099,34 @@ bool DictionaryEditDialog::ExportFixturesDictionary() {
   if (fileDialog.ShowModal() != wxID_OK)
     return false;
 
+  bool copyReferencedAssets = false;
+  if (!AskCopyReferencedAssets(this, "Export fixtures dictionary options",
+                               copyReferencedAssets)) {
+    return false;
+  }
+
   const std::string outputPath = std::string(fileDialog.GetPath().ToUTF8());
-  if (!SaveFixturesSnapshotToFile(outputPath, *dictOpt)) {
+  SnapshotExportResult exportResult;
+  if (!SaveFixturesSnapshotToFile(outputPath, *dictOpt, copyReferencedAssets,
+                                  exportResult)) {
     wxMessageBox("Could not write fixtures dictionary snapshot.",
                  "Export fixtures dictionary", wxICON_ERROR | wxOK, this);
     return false;
   }
-  wxMessageBox("Fixtures dictionary snapshot exported successfully.",
-               "Export fixtures dictionary", wxICON_INFORMATION | wxOK, this);
+
+  wxString info = "Fixtures dictionary snapshot exported successfully.";
+  if (copyReferencedAssets) {
+    info += "\nCopied assets: " + wxString::Format("%zu", exportResult.copied_assets);
+    if (exportResult.missing_assets > 0) {
+      info += "\nMissing assets: " +
+              wxString::Format("%zu", exportResult.missing_assets);
+      const size_t exampleCount = std::min<size_t>(exportResult.copy_errors.size(), 5);
+      for (size_t i = 0; i < exampleCount; ++i)
+        info += "\n- " + wxString::FromUTF8(exportResult.copy_errors[i]);
+    }
+  }
+  wxMessageBox(info, "Export fixtures dictionary", wxICON_INFORMATION | wxOK,
+               this);
   return true;
 }
 
@@ -1016,14 +1149,34 @@ bool DictionaryEditDialog::ExportTrussesDictionary() {
   if (fileDialog.ShowModal() != wxID_OK)
     return false;
 
+  bool copyReferencedAssets = false;
+  if (!AskCopyReferencedAssets(this, "Export trusses dictionary options",
+                               copyReferencedAssets)) {
+    return false;
+  }
+
   const std::string outputPath = std::string(fileDialog.GetPath().ToUTF8());
-  if (!SaveTrussesSnapshotToFile(outputPath, *dictOpt)) {
+  SnapshotExportResult exportResult;
+  if (!SaveTrussesSnapshotToFile(outputPath, *dictOpt, copyReferencedAssets,
+                                 exportResult)) {
     wxMessageBox("Could not write trusses dictionary snapshot.",
                  "Export trusses dictionary", wxICON_ERROR | wxOK, this);
     return false;
   }
-  wxMessageBox("Trusses dictionary snapshot exported successfully.",
-               "Export trusses dictionary", wxICON_INFORMATION | wxOK, this);
+
+  wxString info = "Trusses dictionary snapshot exported successfully.";
+  if (copyReferencedAssets) {
+    info += "\nCopied assets: " + wxString::Format("%zu", exportResult.copied_assets);
+    if (exportResult.missing_assets > 0) {
+      info += "\nMissing assets: " +
+              wxString::Format("%zu", exportResult.missing_assets);
+      const size_t exampleCount = std::min<size_t>(exportResult.copy_errors.size(), 5);
+      for (size_t i = 0; i < exampleCount; ++i)
+        info += "\n- " + wxString::FromUTF8(exportResult.copy_errors[i]);
+    }
+  }
+  wxMessageBox(info, "Export trusses dictionary", wxICON_INFORMATION | wxOK,
+               this);
   return true;
 }
 


### PR DESCRIPTION
### Motivation
- Provide a portable snapshot export mode that can also copy referenced fixture/truss files so snapshots are self-contained and portable.
- Make import resolution more robust by resolving relative `file`/`path` entries relative to the JSON location and by falling back to an `<snapshot>_assets` sibling directory when present.
- Preserve existing behavior when the new option is not selected so current workflows remain unchanged.

### Description
- GUI: added an export options dialog with a checkbox labeled `"Copiar también los archivos referenciados"` via `AskCopyReferencedAssets` and a `SnapshotExportResult` struct to report copy results in `gui/dictionaryeditdialog.cpp`.
- Snapshot export: extended `SaveFixturesSnapshotToFile` and `SaveTrussesSnapshotToFile` to accept a `copyReferencedAssets` flag and `SnapshotExportResult`, create a sibling `<snapshot_name>_assets/assets/` directory, copy existing referenced files there, and write relative `assets/<file>` values into exported JSON when copying; kept prior behavior (only filename) when the flag is false.
- Import resolution: added `ResolveImportedPath` (in `core/gdtfdictionary.cpp` and `core/trussdictionary.cpp`) and GUI helper `ResolveImportRelativePath` to resolve non-absolute `file`/`path` entries first against the JSON directory and then against a `<json_stem>_assets/` sibling directory, and emit a warning to `stderr` when a relative reference cannot be resolved.
- Validation: updated GUI import pre-validation (`ValidateFixtureImportPaths` and `ValidateTrussImportPaths`) to use the same relative-path fallback logic so the preview matches actual importer behavior.
- Files changed: `gui/dictionaryeditdialog.cpp`, `core/gdtfdictionary.cpp`, `core/trussdictionary.cpp`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (`OK`).
- No further automated unit tests were added or run in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c61b7afcfc8324b7a1dd36a4130298)