### PR TITLE
Skip unnecessary dictionary saves and show busy overlay in Dictionary editor

### DIFF
--- a/gui/dictionaryeditdialog.cpp
+++ b/gui/dictionaryeditdialog.cpp
@@ -31,11 +31,13 @@
 #include <algorithm>
 #include <filesystem>
 #include <fstream>
+#include <memory>
 #include <optional>
 #include <sstream>
 #include <vector>
 
 #include <wx/filename.h>
+#include <wx/busyinfo.h>
 
 namespace {
 struct FixtureRow {
@@ -727,6 +729,8 @@ void DictionaryEditDialog::LoadFixtures() {
     fixtureTable->AppendItem(items);
     fixturePaths.push_back(row.path);
   }
+
+  fixtureSnapshotAtLoad = BuildFixtureSnapshotFromUi();
 }
 
 void DictionaryEditDialog::LoadTrusses() {
@@ -756,6 +760,71 @@ void DictionaryEditDialog::LoadTrusses() {
     trussTable->AppendItem(items);
     trussPaths.push_back(row.path);
   }
+
+  trussSnapshotAtLoad = BuildTrussSnapshotFromUi();
+}
+
+std::vector<std::string> DictionaryEditDialog::BuildFixtureSnapshotFromUi() const {
+  std::vector<std::string> snapshot;
+  if (!fixtureTable)
+    return snapshot;
+
+  const int count = fixtureTable->GetItemCount();
+  snapshot.reserve(static_cast<size_t>(count));
+  for (int i = 0; i < count; ++i) {
+    wxVariant nameVar;
+    fixtureTable->GetValue(nameVar, i, 0);
+    const std::string name = std::string(nameVar.GetString().ToUTF8());
+    if (name.empty())
+      continue;
+    if (static_cast<size_t>(i) >= fixturePaths.size())
+      continue;
+    const std::string &path = fixturePaths[i];
+    if (path.empty())
+      continue;
+    if (!std::filesystem::exists(path))
+      continue;
+    wxVariant modeVar;
+    fixtureTable->GetValue(modeVar, i, 2);
+    const std::string mode = std::string(modeVar.GetString().ToUTF8());
+    snapshot.push_back(name + '\n' + path + '\n' + mode);
+  }
+  std::sort(snapshot.begin(), snapshot.end());
+  return snapshot;
+}
+
+std::vector<std::string> DictionaryEditDialog::BuildTrussSnapshotFromUi() const {
+  std::vector<std::string> snapshot;
+  if (!trussTable)
+    return snapshot;
+
+  const int count = trussTable->GetItemCount();
+  snapshot.reserve(static_cast<size_t>(count));
+  for (int i = 0; i < count; ++i) {
+    wxVariant nameVar;
+    trussTable->GetValue(nameVar, i, 0);
+    const std::string name = std::string(nameVar.GetString().ToUTF8());
+    if (name.empty())
+      continue;
+    if (static_cast<size_t>(i) >= trussPaths.size())
+      continue;
+    const std::string &path = trussPaths[i];
+    if (path.empty())
+      continue;
+    if (!std::filesystem::exists(path))
+      continue;
+    snapshot.push_back(name + '\n' + path);
+  }
+  std::sort(snapshot.begin(), snapshot.end());
+  return snapshot;
+}
+
+bool DictionaryEditDialog::HasFixtureChanges() const {
+  return BuildFixtureSnapshotFromUi() != fixtureSnapshotAtLoad;
+}
+
+bool DictionaryEditDialog::HasTrussChanges() const {
+  return BuildTrussSnapshotFromUi() != trussSnapshotAtLoad;
 }
 
 void DictionaryEditDialog::ShowDictionaryLoadStatusMessages() {
@@ -968,8 +1037,20 @@ void DictionaryEditDialog::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
 }
 
 void DictionaryEditDialog::OnOk(wxCommandEvent &WXUNUSED(event)) {
-  SaveFixtures();
-  SaveTrusses();
+  const bool fixtureChanged = HasFixtureChanges();
+  const bool trussChanged = HasTrussChanges();
+
+  if (!fixtureChanged && !trussChanged) {
+    EndModal(wxID_OK);
+    return;
+  }
+
+  std::unique_ptr<wxBusyInfo> saveOverlay =
+      std::make_unique<wxBusyInfo>("Saving dictionary changes...");
+  if (fixtureChanged)
+    SaveFixtures();
+  if (trussChanged)
+    SaveTrusses();
   EndModal(wxID_OK);
 }
 

--- a/gui/dictionaryeditdialog.h
+++ b/gui/dictionaryeditdialog.h
@@ -21,6 +21,9 @@
 #include <wx/notebook.h>
 #include <wx/wx.h>
 
+#include <string>
+#include <vector>
+
 class DictionaryEditDialog : public wxDialog {
 public:
   explicit DictionaryEditDialog(wxWindow *parent);
@@ -31,6 +34,10 @@ private:
   void LoadTrusses();
   void SaveFixtures();
   void SaveTrusses();
+  std::vector<std::string> BuildFixtureSnapshotFromUi() const;
+  std::vector<std::string> BuildTrussSnapshotFromUi() const;
+  bool HasFixtureChanges() const;
+  bool HasTrussChanges() const;
   void ShowDictionaryLoadStatusMessages();
   bool IsFixturesPage() const;
 
@@ -67,4 +74,6 @@ private:
 
   std::vector<std::string> fixturePaths;
   std::vector<std::string> trussPaths;
+  std::vector<std::string> fixtureSnapshotAtLoad;
+  std::vector<std::string> trussSnapshotAtLoad;
 };


### PR DESCRIPTION
### Motivation
- Closing the `Dictionary editor` with `OK` ran the full persist pipeline even when no changes existed, causing a noticeable UI freeze. 
- Reduce user-visible pauses by avoiding expensive work when the dialog state is unchanged and by giving explicit visual feedback when saves are unavoidable.

### Description
- Add UI snapshot helpers `BuildFixtureSnapshotFromUi()` and `BuildTrussSnapshotFromUi()` and store snapshots at load to detect effective changes. 
- Add `HasFixtureChanges()` and `HasTrussChanges()` and only call `SaveFixtures()` / `SaveTrusses()` when a difference is detected. 
- Show a busy overlay using `wxBusyInfo` while performing unavoidable save operations to make pauses explicit to users. 
- Header and include adjustments: new members `fixtureSnapshotAtLoad` / `trussSnapshotAtLoad` and small include additions (`<memory>`, `<string>`, `<vector>`, `<wx/busyinfo.h>`). Note: `gui/dictionaryeditdialog.cpp` is a hotspot above the recommended soft size guardrail; extract/save-diff logic into a helper (e.g., `dictionary_edit_save_pipeline.{h,cpp}`) is recommended as a next split. 

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which succeeded. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c83b894df483248601830c20f5da12)