### PR TITLE
Translate export fixtures dialog checkbox label to English

### DIFF
--- a/gui/dictionaryeditdialog.cpp
+++ b/gui/dictionaryeditdialog.cpp
@@ -160,7 +160,7 @@ bool AskCopyReferencedAssets(wxWindow *parent, const wxString &title,
   wxBoxSizer *topSizer = new wxBoxSizer(wxVERTICAL);
   wxCheckBox *copyAssetsCheckbox =
       new wxCheckBox(&optionsDialog, wxID_ANY,
-                     "Copiar también los archivos referenciados");
+                     "Copy referenced files too");
   copyAssetsCheckbox->SetValue(false);
 
   topSizer->Add(


### PR DESCRIPTION
### Motivation
- Ensure all user-facing UI text is in English by replacing a Spanish label found in the export fixtures dictionary options dialog.

### Description
- Updated the checkbox label in `AskCopyReferencedAssets` inside `gui/dictionaryeditdialog.cpp` from the Spanish string to "Copy referenced files too" and made no behavioral changes.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c84094d1008324997bb8dfadaad5b0)