### PR TITLE
Add configurable ruler overlay to Viewer 2D render options

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -102,6 +102,7 @@ ConfigManager::ConfigManager() {
   RegisterVariable("grid_color_g", "float", 0.35f, 0.0f, 1.0f);
   RegisterVariable("grid_color_b", "float", 0.35f, 0.0f, 1.0f);
   RegisterVariable("grid_draw_above", "float", 0.0f, 0.0f, 1.0f);
+  RegisterVariable("ruler_show", "float", 1.0f, 0.0f, 1.0f);
   RegisterVariable("print_include_grid", "float", 1.0f, 0.0f, 1.0f);
   RegisterVariable("print_viewer2d_page_size", "float", 0.0f, 0.0f, 1.0f,
                    {"print_plan_page_size", "print_page_size"});

--- a/core/layouts/LayoutCollection.h
+++ b/core/layouts/LayoutCollection.h
@@ -52,6 +52,7 @@ struct Layout2DViewRenderOptions {
   float gridColorG = 0.35f;
   float gridColorB = 0.35f;
   bool gridDrawAbove = false;
+  bool showRuler = true;
 
   std::array<bool, 3> showLabelName = {true, true, true};
   std::array<bool, 3> showLabelId = {true, true, true};

--- a/core/layouts/LayoutTemplateSerializer.cpp
+++ b/core/layouts/LayoutTemplateSerializer.cpp
@@ -130,6 +130,7 @@ nlohmann::json ToJson(const Layout2DViewDefinition &view) {
                                       {"gridColorG", options.gridColorG},
                                       {"gridColorB", options.gridColorB},
                                       {"gridDrawAbove", options.gridDrawAbove},
+                                      {"showRuler", options.showRuler},
                                       {"showLabelName", options.showLabelName},
                                       {"showLabelId", options.showLabelId},
                                       {"showLabelDmx", options.showLabelDmx},
@@ -310,6 +311,8 @@ void ReadRenderOptions(const nlohmann::json &obj,
                                     "renderOptions.gridColorB");
   if (auto it = obj.find("gridDrawAbove"); it != obj.end() && it->is_boolean())
     options.gridDrawAbove = it->get<bool>();
+  if (auto it = obj.find("showRuler"); it != obj.end() && it->is_boolean())
+    options.showRuler = it->get<bool>();
 
   ReadBoolArray(obj, "showLabelName", options.showLabelName, ctx);
   ReadBoolArray(obj, "showLabelId", options.showLabelId, ctx);

--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -117,6 +117,7 @@ bool AreEqual(const layouts::Layout2DViewRenderOptions &lhs,
          lhs.gridColorR == rhs.gridColorR && lhs.gridColorG == rhs.gridColorG &&
          lhs.gridColorB == rhs.gridColorB &&
          lhs.gridDrawAbove == rhs.gridDrawAbove &&
+         lhs.showRuler == rhs.showRuler &&
          lhs.showLabelName == rhs.showLabelName &&
          lhs.showLabelId == rhs.showLabelId &&
          lhs.showLabelDmx == rhs.showLabelDmx &&

--- a/gui/layoutviewerpanel_render_invalidation.cpp
+++ b/gui/layoutviewerpanel_render_invalidation.cpp
@@ -51,6 +51,7 @@ size_t LayoutViewerPanel::HashViewContent(
   HashCombineFloat(seed, view.renderOptions.gridColorG);
   HashCombineFloat(seed, view.renderOptions.gridColorB);
   HashCombine(seed, std::hash<bool>{}(view.renderOptions.gridDrawAbove));
+  HashCombine(seed, std::hash<bool>{}(view.renderOptions.showRuler));
 
   for (bool enabled : view.renderOptions.showLabelName)
     HashCombine(seed, std::hash<bool>{}(enabled));

--- a/viewer2d/CMakeLists.txt
+++ b/viewer2d/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/symbolcache.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/viewer2dcommandrenderer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/viewer2doffscreenrenderer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/viewer2d_ruler_overlay.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/viewer2dpanel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/viewer2dpdfexporter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/viewer2drenderpanel.cpp

--- a/viewer2d/viewer2d_ruler_overlay.cpp
+++ b/viewer2d/viewer2d_ruler_overlay.cpp
@@ -1,0 +1,127 @@
+#include "viewer2d_ruler_overlay.h"
+
+#ifdef __APPLE__
+#define GL_SILENCE_DEPRECATION
+#include <OpenGL/gl.h>
+#else
+#include <GL/gl.h>
+#endif
+
+#include <algorithm>
+#include <cmath>
+
+namespace viewer2d {
+namespace {
+constexpr float kPixelsPerMeter = 25.0f;
+constexpr float kTickStepMeters = 0.5f;
+constexpr float kLongTickPixels = 16.0f;
+constexpr float kShortTickPixels = 9.0f;
+constexpr float kAxisPaddingPixels = 2.0f;
+
+float WorldXToScreen(float xMeters, int width, float pixelsPerMeter,
+                     float offsetMetersX) {
+  return static_cast<float>(width) * 0.5f +
+         (xMeters + offsetMetersX) * pixelsPerMeter;
+}
+
+float WorldYToScreen(float yMeters, int height, float pixelsPerMeter,
+                     float offsetMetersY) {
+  return static_cast<float>(height) * 0.5f -
+         (yMeters + offsetMetersY) * pixelsPerMeter;
+}
+
+bool IsMeterTick(float valueMeters) {
+  const float rounded = std::round(valueMeters);
+  return std::fabs(valueMeters - rounded) < 0.0001f;
+}
+
+void DrawHorizontalRuler(float minX, float maxX, int width,
+                         float pixelsPerMeter, float offsetMetersX) {
+  const float yAxis = kAxisPaddingPixels;
+  glBegin(GL_LINES);
+  glVertex2f(0.0f, yAxis);
+  glVertex2f(static_cast<float>(width), yAxis);
+
+  const float startTick = std::ceil(minX / kTickStepMeters) * kTickStepMeters;
+  for (float x = startTick; x <= maxX + 0.0001f; x += kTickStepMeters) {
+    const float sx = WorldXToScreen(x, width, pixelsPerMeter, offsetMetersX);
+    if (sx < -1.0f || sx > static_cast<float>(width) + 1.0f)
+      continue;
+    const float tick = IsMeterTick(x) ? kLongTickPixels : kShortTickPixels;
+    glVertex2f(sx, yAxis);
+    glVertex2f(sx, yAxis + tick);
+  }
+  glEnd();
+}
+
+void DrawVerticalRuler(float minY, float maxY, int height,
+                       float pixelsPerMeter, float offsetMetersY) {
+  const float xAxis = kAxisPaddingPixels;
+  glBegin(GL_LINES);
+  glVertex2f(xAxis, 0.0f);
+  glVertex2f(xAxis, static_cast<float>(height));
+
+  const float startTick = std::ceil(minY / kTickStepMeters) * kTickStepMeters;
+  for (float y = startTick; y <= maxY + 0.0001f; y += kTickStepMeters) {
+    const float sy = WorldYToScreen(y, height, pixelsPerMeter, offsetMetersY);
+    if (sy < -1.0f || sy > static_cast<float>(height) + 1.0f)
+      continue;
+    const float tick = IsMeterTick(y) ? kLongTickPixels : kShortTickPixels;
+    glVertex2f(xAxis, sy);
+    glVertex2f(xAxis + tick, sy);
+  }
+  glEnd();
+}
+} // namespace
+
+void DrawRulerOverlay(const RulerOverlayViewState &state, bool darkMode) {
+  if (state.width <= 0 || state.height <= 0 || state.zoom <= 0.0f)
+    return;
+
+  const float pixelsPerMeter = kPixelsPerMeter * state.zoom;
+  if (pixelsPerMeter <= 0.0f)
+    return;
+
+  const float offsetMetersX = state.offsetPixelsX / kPixelsPerMeter;
+  const float offsetMetersY = state.offsetPixelsY / kPixelsPerMeter;
+  const float halfW = static_cast<float>(state.width) * 0.5f / pixelsPerMeter;
+  const float halfH = static_cast<float>(state.height) * 0.5f / pixelsPerMeter;
+
+  const float minX = -halfW - offsetMetersX;
+  const float maxX = halfW - offsetMetersX;
+  const float minY = -halfH - offsetMetersY;
+  const float maxY = halfH - offsetMetersY;
+
+  GLboolean depthEnabled = glIsEnabled(GL_DEPTH_TEST);
+  if (depthEnabled)
+    glDisable(GL_DEPTH_TEST);
+
+  glMatrixMode(GL_PROJECTION);
+  glPushMatrix();
+  glLoadIdentity();
+  glOrtho(0.0f, static_cast<float>(state.width), 0.0f,
+          static_cast<float>(state.height), -1.0f, 1.0f);
+  glMatrixMode(GL_MODELVIEW);
+  glPushMatrix();
+  glLoadIdentity();
+
+  if (darkMode)
+    glColor3f(1.0f, 1.0f, 1.0f);
+  else
+    glColor3f(0.0f, 0.0f, 0.0f);
+  glLineWidth(1.0f);
+
+  DrawHorizontalRuler(minX, maxX, state.width, pixelsPerMeter,
+                      offsetMetersX);
+  DrawVerticalRuler(minY, maxY, state.height, pixelsPerMeter, offsetMetersY);
+
+  glPopMatrix();
+  glMatrixMode(GL_PROJECTION);
+  glPopMatrix();
+  glMatrixMode(GL_MODELVIEW);
+
+  if (depthEnabled)
+    glEnable(GL_DEPTH_TEST);
+}
+
+} // namespace viewer2d

--- a/viewer2d/viewer2d_ruler_overlay.h
+++ b/viewer2d/viewer2d_ruler_overlay.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "viewer3dcontroller.h"
+
+namespace viewer2d {
+
+struct RulerOverlayViewState {
+  int width = 0;
+  int height = 0;
+  float zoom = 1.0f;
+  float offsetPixelsX = 0.0f;
+  float offsetPixelsY = 0.0f;
+  Viewer2DView view = Viewer2DView::Top;
+};
+
+void DrawRulerOverlay(const RulerOverlayViewState &state, bool darkMode);
+
+} // namespace viewer2d

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -52,6 +52,7 @@
 #include "trusstablepanel.h"
 #include "viewer3dpanel.h"
 #include "viewer2d_support_selection.h"
+#include "viewer2d_ruler_overlay.h"
 #include "viewer2dviewfit.h"
 #include <wx/app.h>
 #include <wx/utils.h>
@@ -668,6 +669,7 @@ void Viewer2DPanel::RenderInternal(bool swapBuffers) {
   float gridG = cfg.GetFloat("grid_color_g");
   float gridB = cfg.GetFloat("grid_color_b");
   bool drawAbove = cfg.GetFloat("grid_draw_above") != 0.0f;
+  bool showRuler = cfg.GetFloat("ruler_show") != 0.0f;
 
   std::unique_ptr<ICanvas2D> recordingCanvas;
   if (m_captureNextFrame) {
@@ -759,6 +761,17 @@ void Viewer2DPanel::RenderInternal(bool swapBuffers) {
       if (depthEnabled)
         glEnable(GL_DEPTH_TEST);
     }
+  }
+
+  if (showRuler) {
+    viewer2d::RulerOverlayViewState rulerState;
+    rulerState.width = w;
+    rulerState.height = h;
+    rulerState.zoom = m_zoom;
+    rulerState.offsetPixelsX = m_offsetX;
+    rulerState.offsetPixelsY = m_offsetY;
+    rulerState.view = m_view;
+    viewer2d::DrawRulerOverlay(rulerState, darkMode);
   }
 
   if (swapBuffers && m_enableSelection && m_rectSelecting)

--- a/viewer2d/viewer2drenderpanel.cpp
+++ b/viewer2d/viewer2drenderpanel.cpp
@@ -97,6 +97,13 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
   m_drawAbove->SetValue(cfg.GetFloat("grid_draw_above") != 0.0f);
   m_drawAbove->Bind(wxEVT_CHECKBOX, &Viewer2DRenderPanel::OnDrawAbove, this);
 
+  auto *rulerBox = new wxStaticBoxSizer(wxVERTICAL, this, "Ruler");
+  wxWindow *rulerBoxParent = rulerBox->GetStaticBox();
+
+  m_showRuler = new wxCheckBox(rulerBoxParent, wxID_ANY, "Show ruler");
+  m_showRuler->SetValue(cfg.GetFloat("ruler_show") != 0.0f);
+  m_showRuler->Bind(wxEVT_CHECKBOX, &Viewer2DRenderPanel::OnShowRuler, this);
+
   auto *labelBox = new wxStaticBoxSizer(wxVERTICAL, this, "Labels");
   wxWindow *labelBoxParent = labelBox->GetStaticBox();
 
@@ -216,6 +223,9 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
   gridBox->Add(m_drawAbove, 0, wxALL, 5);
   sizer->Add(gridBox, 0, wxALL, 5);
 
+  rulerBox->Add(m_showRuler, 0, wxALL, 5);
+  sizer->Add(rulerBox, 0, wxALL, 5);
+
   auto *nameSizer = new wxBoxSizer(wxHORIZONTAL);
   nameSizer->Add(m_showLabelName, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
   nameSizer->Add(new wxStaticText(labelBoxParent, wxID_ANY, "Size"), 0,
@@ -287,6 +297,7 @@ void Viewer2DRenderPanel::ApplyConfig() {
   int bb = static_cast<int>(cfg.GetFloat("grid_color_b") * 255.0f);
   m_gridColor->SetColour(wxColour(rr, gg, bb));
   m_drawAbove->SetValue(cfg.GetFloat("grid_draw_above") != 0.0f);
+  m_showRuler->SetValue(cfg.GetFloat("ruler_show") != 0.0f);
   int viewIndex = m_view->GetSelection();
   m_showLabelName->SetValue(cfg.GetFloat(NAME_KEYS[viewIndex]) != 0.0f);
   m_labelNameSize->SetValue(
@@ -365,6 +376,14 @@ void Viewer2DRenderPanel::OnGridColor(wxColourPickerEvent &evt) {
 void Viewer2DRenderPanel::OnDrawAbove(wxCommandEvent &evt) {
   ConfigManager::Get().SetFloat("grid_draw_above",
                                 m_drawAbove->GetValue() ? 1.0f : 0.0f);
+  if (auto *vp = Viewer2DPanel::Instance())
+    vp->UpdateScene(false);
+  evt.Skip();
+}
+
+void Viewer2DRenderPanel::OnShowRuler(wxCommandEvent &evt) {
+  ConfigManager::Get().SetFloat("ruler_show",
+                                m_showRuler->GetValue() ? 1.0f : 0.0f);
   if (auto *vp = Viewer2DPanel::Instance())
     vp->UpdateScene(false);
   evt.Skip();

--- a/viewer2d/viewer2drenderpanel.h
+++ b/viewer2d/viewer2drenderpanel.h
@@ -42,6 +42,7 @@ private:
   void OnGridStyle(wxCommandEvent &evt);
   void OnGridColor(wxColourPickerEvent &evt);
   void OnDrawAbove(wxCommandEvent &evt);
+  void OnShowRuler(wxCommandEvent &evt);
   void OnShowLabelName(wxCommandEvent &evt);
   void OnShowLabelId(wxCommandEvent &evt);
   void OnShowLabelAddress(wxCommandEvent &evt);
@@ -65,6 +66,7 @@ private:
   wxRadioBox *m_gridStyle = nullptr;
   wxColourPickerCtrl *m_gridColor = nullptr;
   wxCheckBox *m_drawAbove = nullptr;
+  wxCheckBox *m_showRuler = nullptr;
   wxCheckBox *m_showLabelName = nullptr;
   wxCheckBox *m_showLabelId = nullptr;
   wxCheckBox *m_showLabelAddress = nullptr;

--- a/viewer2d/viewer2dstate.cpp
+++ b/viewer2d/viewer2dstate.cpp
@@ -75,6 +75,7 @@ Viewer2DState CaptureState(const Viewer2DPanel *panel,
   state.renderOptions.gridColorG = cfg.GetFloat("grid_color_g");
   state.renderOptions.gridColorB = cfg.GetFloat("grid_color_b");
   state.renderOptions.gridDrawAbove = cfg.GetFloat("grid_draw_above") != 0.0f;
+  state.renderOptions.showRuler = cfg.GetFloat("ruler_show") != 0.0f;
 
   for (size_t i = 0; i < state.renderOptions.showLabelName.size(); ++i) {
     state.renderOptions.showLabelName[i] =
@@ -127,6 +128,7 @@ void ApplyState(Viewer2DPanel *panel, Viewer2DRenderPanel *renderPanel,
   cfg.SetFloat("grid_color_b", state.renderOptions.gridColorB);
   cfg.SetFloat("grid_draw_above",
                state.renderOptions.gridDrawAbove ? 1.0f : 0.0f);
+  cfg.SetFloat("ruler_show", state.renderOptions.showRuler ? 1.0f : 0.0f);
 
   for (size_t i = 0; i < state.renderOptions.showLabelName.size(); ++i) {
     cfg.SetFloat(kLabelNameKeys[i],


### PR DESCRIPTION
### Motivation
- Provide an on-screen metric ruler in 2D views so users can see scale at-a-glance and measure distances while editing layouts. 
- Expose the ruler as a user-toggleable option inside the existing "2D Render Options" panel so it follows the same UI/behavior patterns as the grid options. 
- Persist the ruler setting together with layout view render options so saved layouts and cached view comparisons remain consistent.

### Description
- Added a new `ruler_show` configuration variable (default `true`) and hooked it into `ConfigManager` so ruler visibility is user-configurable. 
- Added a small Ruler section to the "2D Render Options" UI with a `Show ruler` checkbox and an event handler that updates the view at runtime (changes in `viewer2d/viewer2drenderpanel.{h,cpp}`). 
- Implemented a dedicated overlay module `viewer2d/viewer2d_ruler_overlay.{h,cpp}` that draws two rulers (horizontal + vertical) with long ticks every 1.0 m and short ticks every 0.5 m, color adapted to dark/light mode, and integrated the overlay into `viewer2d/viewer2dpanel.cpp` when `ruler_show` is enabled. 
- Extended layout render options model/serialization and layout viewer cache/hash logic (`core/layouts/LayoutCollection.h`, `core/layouts/LayoutTemplateSerializer.cpp`, `viewer2d/viewer2dstate.cpp`, `gui/layoutviewerpanel*.cpp`) so `showRuler` is stored, restored and considered when comparing/invalidation occurs, and added the new overlay source to `viewer2d/CMakeLists.txt`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed. 
- Attempted a local CMake build with the `wsl-x64-debug` preset and the build failed in this environment due to missing `wxWidgets` development files (environment dependency, not a code error in the change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c84332b8608324927f1d2eb91ed548)