### PR TITLE
Fix Windows OpenGL header include prerequisites

### DIFF
--- a/gui/layoutviewerpanel_eventtable.cpp
+++ b/gui/layoutviewerpanel_eventtable.cpp
@@ -23,6 +23,12 @@
 #include <unordered_map>
 
 // Include GLEW or other OpenGL loader first if present
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#endif
+
 #ifdef __APPLE__
 #  include <OpenGL/gl.h>
 #  include <OpenGL/glu.h>

--- a/gui/layoutviewerpanel_image.cpp
+++ b/gui/layoutviewerpanel_image.cpp
@@ -25,6 +25,12 @@
 #include <functional>
 
 // Include GLEW or other OpenGL loader first if present
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#endif
+
 #ifdef __APPLE__
 #  include <OpenGL/gl.h>
 #  include <OpenGL/glu.h>

--- a/gui/layoutviewerpanel_legend.cpp
+++ b/gui/layoutviewerpanel_legend.cpp
@@ -26,6 +26,12 @@
 #include <vector>
 
 // Include GLEW or other OpenGL loader first if present
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#endif
+
 #ifdef __APPLE__
 #  include <OpenGL/gl.h>
 #  include <OpenGL/glu.h>

--- a/gui/layoutviewerpanel_text.cpp
+++ b/gui/layoutviewerpanel_text.cpp
@@ -21,6 +21,12 @@
 #include <functional>
 
 // Include GLEW or other OpenGL loader first if present
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#endif
+
 #ifdef __APPLE__
 #  include <OpenGL/gl.h>
 #  include <OpenGL/glu.h>

--- a/gui/layoutviewerpanel_view.cpp
+++ b/gui/layoutviewerpanel_view.cpp
@@ -21,6 +21,12 @@
 #include <memory>
 
 // Include GLEW or other OpenGL loader first if present
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#endif
+
 #ifdef __APPLE__
 #  include <OpenGL/gl.h>
 #  include <OpenGL/glu.h>

--- a/viewer2d/viewer2d_ruler_overlay.cpp
+++ b/viewer2d/viewer2d_ruler_overlay.cpp
@@ -1,5 +1,11 @@
 #include "viewer2d_ruler_overlay.h"
 
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#endif
+
 #ifdef __APPLE__
 #define GL_SILENCE_DEPRECATION
 #include <OpenGL/gl.h>


### PR DESCRIPTION
### Motivation
- Windows builds were failing with parser errors inside `GL/gl.h` (e.g. `C2144`, `C2182`, `C2146`) because required Windows calling-convention macros like `WINGDIAPI`/`APIENTRY` were not defined before including OpenGL headers. 
- The change is a minimal include-order fix to ensure consistent preprocessor definitions on `_WIN32` without changing rendering logic.

### Description
- Add a `_WIN32` guarded block that defines `WIN32_LEAN_AND_MEAN`, `NOMINMAX` and `#include <windows.h>` immediately before including `GL/gl.h`/`GL/glu.h` in affected translation units. 
- Files updated: `viewer2d/viewer2d_ruler_overlay.cpp`, `gui/layoutviewerpanel_text.cpp`, `gui/layoutviewerpanel_view.cpp`, `gui/layoutviewerpanel_image.cpp`, `gui/layoutviewerpanel_eventtable.cpp`, and `gui/layoutviewerpanel_legend.cpp`.
- The change only adjusts include ordering and platform guards and does not modify runtime logic or module boundaries.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it returned OK. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it returned OK. 
- Performed a repository scan to verify that `GL/gl.h` includes in `gui/` and `viewer2d/` files now have the required `windows.h` include on `_WIN32`, and the scan found no remaining missing cases.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8455ddb708324bd1647c7d273775d)