### PR TITLE
Add configurable printable 2D rulers with fixed-size ticks

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -107,6 +107,7 @@ ConfigManager::ConfigManager() {
   RegisterVariable("ruler_tick_large_m", "float", 0.2f, 0.01f, 10.0f);
   RegisterVariable("ruler_axis_x_position", "float", 0.0f, -100.0f, 100.0f);
   RegisterVariable("ruler_axis_y_position", "float", 0.0f, -100.0f, 100.0f);
+  RegisterVariable("ruler_axis_z_position", "float", 0.0f, -100.0f, 100.0f);
   RegisterVariable("print_include_grid", "float", 1.0f, 0.0f, 1.0f);
   RegisterVariable("print_viewer2d_page_size", "float", 0.0f, 0.0f, 1.0f,
                    {"print_plan_page_size", "print_page_size"});

--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -103,6 +103,10 @@ ConfigManager::ConfigManager() {
   RegisterVariable("grid_color_b", "float", 0.35f, 0.0f, 1.0f);
   RegisterVariable("grid_draw_above", "float", 0.0f, 0.0f, 1.0f);
   RegisterVariable("ruler_show", "float", 1.0f, 0.0f, 1.0f);
+  RegisterVariable("ruler_tick_small_m", "float", 0.1f, 0.01f, 10.0f);
+  RegisterVariable("ruler_tick_large_m", "float", 0.2f, 0.01f, 10.0f);
+  RegisterVariable("ruler_axis_x_position", "float", 0.0f, -100.0f, 100.0f);
+  RegisterVariable("ruler_axis_y_position", "float", 0.0f, -100.0f, 100.0f);
   RegisterVariable("print_include_grid", "float", 1.0f, 0.0f, 1.0f);
   RegisterVariable("print_viewer2d_page_size", "float", 0.0f, 0.0f, 1.0f,
                    {"print_plan_page_size", "print_page_size"});

--- a/viewer2d/viewer2d_ruler_overlay.cpp
+++ b/viewer2d/viewer2d_ruler_overlay.cpp
@@ -21,58 +21,37 @@ namespace {
 constexpr float kPixelsPerMeter = 25.0f;
 constexpr float kTickStepMeters = 0.5f;
 
-float WorldXToScreen(float xMeters, int width, float pixelsPerMeter,
-                     float offsetMetersX) {
-  return static_cast<float>(width) * 0.5f +
-         (xMeters + offsetMetersX) * pixelsPerMeter;
-}
-
-float WorldYToScreen(float yMeters, int height, float pixelsPerMeter,
-                     float offsetMetersY) {
-  return static_cast<float>(height) * 0.5f -
-         (yMeters + offsetMetersY) * pixelsPerMeter;
-}
-
 bool IsMeterTick(float valueMeters) {
   const float rounded = std::round(valueMeters);
   return std::fabs(valueMeters - rounded) < 0.0001f;
 }
 
-void DrawHorizontalRuler(float minX, float maxX, int width,
-                         float pixelsPerMeter, float offsetMetersX,
-                         float yAxis, float shortTickPixels,
-                         float longTickPixels) {
+void DrawHorizontalRuler(float minX, float maxX, float yAxis,
+                         float shortTickMeters, float longTickMeters) {
   glBegin(GL_LINES);
-  glVertex2f(0.0f, yAxis);
-  glVertex2f(static_cast<float>(width), yAxis);
+  glVertex2f(minX, yAxis);
+  glVertex2f(maxX, yAxis);
 
   const float startTick = std::ceil(minX / kTickStepMeters) * kTickStepMeters;
   for (float x = startTick; x <= maxX + 0.0001f; x += kTickStepMeters) {
-    const float sx = WorldXToScreen(x, width, pixelsPerMeter, offsetMetersX);
-    if (sx < -1.0f || sx > static_cast<float>(width) + 1.0f)
-      continue;
-    const float tick = IsMeterTick(x) ? longTickPixels : shortTickPixels;
-    glVertex2f(sx, yAxis);
-    glVertex2f(sx, yAxis + tick);
+    const float tick = IsMeterTick(x) ? longTickMeters : shortTickMeters;
+    glVertex2f(x, yAxis);
+    glVertex2f(x, yAxis + tick);
   }
   glEnd();
 }
 
-void DrawVerticalRuler(float minY, float maxY, int height,
-                       float pixelsPerMeter, float offsetMetersY, float xAxis,
-                       float shortTickPixels, float longTickPixels) {
+void DrawVerticalRuler(float minY, float maxY, float xAxis,
+                       float shortTickMeters, float longTickMeters) {
   glBegin(GL_LINES);
-  glVertex2f(xAxis, 0.0f);
-  glVertex2f(xAxis, static_cast<float>(height));
+  glVertex2f(xAxis, minY);
+  glVertex2f(xAxis, maxY);
 
   const float startTick = std::ceil(minY / kTickStepMeters) * kTickStepMeters;
   for (float y = startTick; y <= maxY + 0.0001f; y += kTickStepMeters) {
-    const float sy = WorldYToScreen(y, height, pixelsPerMeter, offsetMetersY);
-    if (sy < -1.0f || sy > static_cast<float>(height) + 1.0f)
-      continue;
-    const float tick = IsMeterTick(y) ? longTickPixels : shortTickPixels;
-    glVertex2f(xAxis, sy);
-    glVertex2f(xAxis + tick, sy);
+    const float tick = IsMeterTick(y) ? longTickMeters : shortTickMeters;
+    glVertex2f(xAxis, y);
+    glVertex2f(xAxis + tick, y);
   }
   glEnd();
 }
@@ -118,15 +97,9 @@ void DrawRulerOverlay(const RulerOverlayViewState &state, bool darkMode) {
   const float longTickMeters =
       std::max(std::max(state.largeTickMeters, shortTickMeters),
                shortTickMeters);
-  const float shortTickPixels = shortTickMeters * pixelsPerMeter;
-  const float longTickPixels = longTickMeters * pixelsPerMeter;
   const ActiveRulers activeRulers = ResolveActiveRulers(state);
-  const float yAxis =
-      WorldYToScreen(activeRulers.horizontalAxisMeters, state.height,
-                     pixelsPerMeter, offsetMetersY);
-  const float xAxis =
-      WorldXToScreen(activeRulers.verticalAxisMeters, state.width,
-                     pixelsPerMeter, offsetMetersX);
+  const float yAxis = activeRulers.horizontalAxisMeters;
+  const float xAxis = activeRulers.verticalAxisMeters;
   const float halfW = static_cast<float>(state.width) * 0.5f / pixelsPerMeter;
   const float halfH = static_cast<float>(state.height) * 0.5f / pixelsPerMeter;
 
@@ -139,30 +112,14 @@ void DrawRulerOverlay(const RulerOverlayViewState &state, bool darkMode) {
   if (depthEnabled)
     glDisable(GL_DEPTH_TEST);
 
-  glMatrixMode(GL_PROJECTION);
-  glPushMatrix();
-  glLoadIdentity();
-  glOrtho(0.0f, static_cast<float>(state.width), 0.0f,
-          static_cast<float>(state.height), -1.0f, 1.0f);
-  glMatrixMode(GL_MODELVIEW);
-  glPushMatrix();
-  glLoadIdentity();
-
   if (darkMode)
     glColor3f(1.0f, 1.0f, 1.0f);
   else
     glColor3f(0.0f, 0.0f, 0.0f);
   glLineWidth(1.0f);
 
-  DrawHorizontalRuler(minX, maxX, state.width, pixelsPerMeter, offsetMetersX,
-                      yAxis, shortTickPixels, longTickPixels);
-  DrawVerticalRuler(minY, maxY, state.height, pixelsPerMeter, offsetMetersY,
-                    xAxis, shortTickPixels, longTickPixels);
-
-  glPopMatrix();
-  glMatrixMode(GL_PROJECTION);
-  glPopMatrix();
-  glMatrixMode(GL_MODELVIEW);
+  DrawHorizontalRuler(minX, maxX, yAxis, shortTickMeters, longTickMeters);
+  DrawVerticalRuler(minY, maxY, xAxis, shortTickMeters, longTickMeters);
 
   if (depthEnabled)
     glEnable(GL_DEPTH_TEST);

--- a/viewer2d/viewer2d_ruler_overlay.cpp
+++ b/viewer2d/viewer2d_ruler_overlay.cpp
@@ -26,32 +26,56 @@ bool IsMeterTick(float valueMeters) {
   return std::fabs(valueMeters - rounded) < 0.0001f;
 }
 
-void DrawHorizontalRuler(float minX, float maxX, float yAxis,
-                         float shortTickMeters, float longTickMeters) {
-  glBegin(GL_LINES);
-  glVertex2f(minX, yAxis);
-  glVertex2f(maxX, yAxis);
+struct WorldPoint {
+  float x = 0.0f;
+  float y = 0.0f;
+  float z = 0.0f;
+};
 
-  const float startTick = std::ceil(minX / kTickStepMeters) * kTickStepMeters;
-  for (float x = startTick; x <= maxX + 0.0001f; x += kTickStepMeters) {
-    const float tick = IsMeterTick(x) ? longTickMeters : shortTickMeters;
-    glVertex2f(x, yAxis);
-    glVertex2f(x, yAxis + tick);
+WorldPoint MapViewCoordinatesToWorld(float u, float v, Viewer2DView view) {
+  switch (view) {
+  case Viewer2DView::Top:
+  case Viewer2DView::Bottom:
+    return {u, v, 0.0f};
+  case Viewer2DView::Front:
+    return {u, 0.0f, v};
+  case Viewer2DView::Side:
+    return {0.0f, u, v};
+  }
+  return {u, v, 0.0f};
+}
+
+void EmitViewLine(float u0, float v0, float u1, float v1, Viewer2DView view) {
+  const WorldPoint p0 = MapViewCoordinatesToWorld(u0, v0, view);
+  const WorldPoint p1 = MapViewCoordinatesToWorld(u1, v1, view);
+  glVertex3f(p0.x, p0.y, p0.z);
+  glVertex3f(p1.x, p1.y, p1.z);
+}
+
+void DrawHorizontalRuler(float minU, float maxU, float vAxis,
+                         float shortTickMeters, float longTickMeters,
+                         Viewer2DView view) {
+  glBegin(GL_LINES);
+  EmitViewLine(minU, vAxis, maxU, vAxis, view);
+
+  const float startTick = std::ceil(minU / kTickStepMeters) * kTickStepMeters;
+  for (float u = startTick; u <= maxU + 0.0001f; u += kTickStepMeters) {
+    const float tick = IsMeterTick(u) ? longTickMeters : shortTickMeters;
+    EmitViewLine(u, vAxis, u, vAxis + tick, view);
   }
   glEnd();
 }
 
-void DrawVerticalRuler(float minY, float maxY, float xAxis,
-                       float shortTickMeters, float longTickMeters) {
+void DrawVerticalRuler(float minV, float maxV, float uAxis,
+                       float shortTickMeters, float longTickMeters,
+                       Viewer2DView view) {
   glBegin(GL_LINES);
-  glVertex2f(xAxis, minY);
-  glVertex2f(xAxis, maxY);
+  EmitViewLine(uAxis, minV, uAxis, maxV, view);
 
-  const float startTick = std::ceil(minY / kTickStepMeters) * kTickStepMeters;
-  for (float y = startTick; y <= maxY + 0.0001f; y += kTickStepMeters) {
-    const float tick = IsMeterTick(y) ? longTickMeters : shortTickMeters;
-    glVertex2f(xAxis, y);
-    glVertex2f(xAxis + tick, y);
+  const float startTick = std::ceil(minV / kTickStepMeters) * kTickStepMeters;
+  for (float v = startTick; v <= maxV + 0.0001f; v += kTickStepMeters) {
+    const float tick = IsMeterTick(v) ? longTickMeters : shortTickMeters;
+    EmitViewLine(uAxis, v, uAxis + tick, v, view);
   }
   glEnd();
 }
@@ -118,8 +142,10 @@ void DrawRulerOverlay(const RulerOverlayViewState &state, bool darkMode) {
     glColor3f(0.0f, 0.0f, 0.0f);
   glLineWidth(1.0f);
 
-  DrawHorizontalRuler(minX, maxX, yAxis, shortTickMeters, longTickMeters);
-  DrawVerticalRuler(minY, maxY, xAxis, shortTickMeters, longTickMeters);
+  DrawHorizontalRuler(minX, maxX, yAxis, shortTickMeters, longTickMeters,
+                      state.view);
+  DrawVerticalRuler(minY, maxY, xAxis, shortTickMeters, longTickMeters,
+                    state.view);
 
   if (depthEnabled)
     glEnable(GL_DEPTH_TEST);

--- a/viewer2d/viewer2d_ruler_overlay.cpp
+++ b/viewer2d/viewer2d_ruler_overlay.cpp
@@ -84,6 +84,24 @@ CanvasStroke BuildRulerStroke(bool darkMode) {
   stroke.width = 1.0f;
   return stroke;
 }
+
+struct ActiveRulers {
+  float horizontalAxisMeters = 0.0f;
+  float verticalAxisMeters = 0.0f;
+};
+
+ActiveRulers ResolveActiveRulers(const RulerOverlayViewState &state) {
+  switch (state.view) {
+  case Viewer2DView::Top:
+  case Viewer2DView::Bottom:
+    return {state.xRulerPositionMeters, state.yRulerPositionMeters};
+  case Viewer2DView::Front:
+    return {state.xRulerPositionMeters, state.zRulerPositionMeters};
+  case Viewer2DView::Side:
+    return {state.yRulerPositionMeters, state.zRulerPositionMeters};
+  }
+  return {state.xRulerPositionMeters, state.yRulerPositionMeters};
+}
 } // namespace
 
 void DrawRulerOverlay(const RulerOverlayViewState &state, bool darkMode) {
@@ -102,12 +120,13 @@ void DrawRulerOverlay(const RulerOverlayViewState &state, bool darkMode) {
                shortTickMeters);
   const float shortTickPixels = shortTickMeters * pixelsPerMeter;
   const float longTickPixels = longTickMeters * pixelsPerMeter;
+  const ActiveRulers activeRulers = ResolveActiveRulers(state);
   const float yAxis =
-      WorldYToScreen(state.axisXPositionMeters, state.height, pixelsPerMeter,
-                     offsetMetersY);
+      WorldYToScreen(activeRulers.horizontalAxisMeters, state.height,
+                     pixelsPerMeter, offsetMetersY);
   const float xAxis =
-      WorldXToScreen(state.axisYPositionMeters, state.width, pixelsPerMeter,
-                     offsetMetersX);
+      WorldXToScreen(activeRulers.verticalAxisMeters, state.width,
+                     pixelsPerMeter, offsetMetersX);
   const float halfW = static_cast<float>(state.width) * 0.5f / pixelsPerMeter;
   const float halfH = static_cast<float>(state.height) * 0.5f / pixelsPerMeter;
 
@@ -171,9 +190,10 @@ void EmitRulerToCanvas(const RulerOverlayViewState &state, bool darkMode,
       std::max(std::max(state.largeTickMeters, shortTickMeters),
                shortTickMeters);
   auto stroke = BuildRulerStroke(darkMode);
+  const ActiveRulers activeRulers = ResolveActiveRulers(state);
 
-  const float xRulerY = state.axisXPositionMeters;
-  const float yRulerX = state.axisYPositionMeters;
+  const float xRulerY = activeRulers.horizontalAxisMeters;
+  const float yRulerX = activeRulers.verticalAxisMeters;
   canvas.DrawLine(minX, xRulerY, maxX, xRulerY, stroke);
   canvas.DrawLine(yRulerX, minY, yRulerX, maxY, stroke);
 

--- a/viewer2d/viewer2d_ruler_overlay.cpp
+++ b/viewer2d/viewer2d_ruler_overlay.cpp
@@ -20,9 +20,6 @@ namespace viewer2d {
 namespace {
 constexpr float kPixelsPerMeter = 25.0f;
 constexpr float kTickStepMeters = 0.5f;
-constexpr float kLongTickPixels = 16.0f;
-constexpr float kShortTickPixels = 9.0f;
-constexpr float kAxisPaddingPixels = 2.0f;
 
 float WorldXToScreen(float xMeters, int width, float pixelsPerMeter,
                      float offsetMetersX) {
@@ -42,8 +39,9 @@ bool IsMeterTick(float valueMeters) {
 }
 
 void DrawHorizontalRuler(float minX, float maxX, int width,
-                         float pixelsPerMeter, float offsetMetersX) {
-  const float yAxis = kAxisPaddingPixels;
+                         float pixelsPerMeter, float offsetMetersX,
+                         float yAxis, float shortTickPixels,
+                         float longTickPixels) {
   glBegin(GL_LINES);
   glVertex2f(0.0f, yAxis);
   glVertex2f(static_cast<float>(width), yAxis);
@@ -53,7 +51,7 @@ void DrawHorizontalRuler(float minX, float maxX, int width,
     const float sx = WorldXToScreen(x, width, pixelsPerMeter, offsetMetersX);
     if (sx < -1.0f || sx > static_cast<float>(width) + 1.0f)
       continue;
-    const float tick = IsMeterTick(x) ? kLongTickPixels : kShortTickPixels;
+    const float tick = IsMeterTick(x) ? longTickPixels : shortTickPixels;
     glVertex2f(sx, yAxis);
     glVertex2f(sx, yAxis + tick);
   }
@@ -61,8 +59,8 @@ void DrawHorizontalRuler(float minX, float maxX, int width,
 }
 
 void DrawVerticalRuler(float minY, float maxY, int height,
-                       float pixelsPerMeter, float offsetMetersY) {
-  const float xAxis = kAxisPaddingPixels;
+                       float pixelsPerMeter, float offsetMetersY, float xAxis,
+                       float shortTickPixels, float longTickPixels) {
   glBegin(GL_LINES);
   glVertex2f(xAxis, 0.0f);
   glVertex2f(xAxis, static_cast<float>(height));
@@ -72,11 +70,19 @@ void DrawVerticalRuler(float minY, float maxY, int height,
     const float sy = WorldYToScreen(y, height, pixelsPerMeter, offsetMetersY);
     if (sy < -1.0f || sy > static_cast<float>(height) + 1.0f)
       continue;
-    const float tick = IsMeterTick(y) ? kLongTickPixels : kShortTickPixels;
+    const float tick = IsMeterTick(y) ? longTickPixels : shortTickPixels;
     glVertex2f(xAxis, sy);
     glVertex2f(xAxis + tick, sy);
   }
   glEnd();
+}
+
+CanvasStroke BuildRulerStroke(bool darkMode) {
+  CanvasStroke stroke;
+  stroke.color = darkMode ? CanvasColor{1.0f, 1.0f, 1.0f, 1.0f}
+                          : CanvasColor{0.0f, 0.0f, 0.0f, 1.0f};
+  stroke.width = 1.0f;
+  return stroke;
 }
 } // namespace
 
@@ -90,6 +96,18 @@ void DrawRulerOverlay(const RulerOverlayViewState &state, bool darkMode) {
 
   const float offsetMetersX = state.offsetPixelsX / kPixelsPerMeter;
   const float offsetMetersY = state.offsetPixelsY / kPixelsPerMeter;
+  const float shortTickMeters = std::max(state.smallTickMeters, 0.01f);
+  const float longTickMeters =
+      std::max(std::max(state.largeTickMeters, shortTickMeters),
+               shortTickMeters);
+  const float shortTickPixels = shortTickMeters * pixelsPerMeter;
+  const float longTickPixels = longTickMeters * pixelsPerMeter;
+  const float yAxis =
+      WorldYToScreen(state.axisXPositionMeters, state.height, pixelsPerMeter,
+                     offsetMetersY);
+  const float xAxis =
+      WorldXToScreen(state.axisYPositionMeters, state.width, pixelsPerMeter,
+                     offsetMetersX);
   const float halfW = static_cast<float>(state.width) * 0.5f / pixelsPerMeter;
   const float halfH = static_cast<float>(state.height) * 0.5f / pixelsPerMeter;
 
@@ -117,9 +135,10 @@ void DrawRulerOverlay(const RulerOverlayViewState &state, bool darkMode) {
     glColor3f(0.0f, 0.0f, 0.0f);
   glLineWidth(1.0f);
 
-  DrawHorizontalRuler(minX, maxX, state.width, pixelsPerMeter,
-                      offsetMetersX);
-  DrawVerticalRuler(minY, maxY, state.height, pixelsPerMeter, offsetMetersY);
+  DrawHorizontalRuler(minX, maxX, state.width, pixelsPerMeter, offsetMetersX,
+                      yAxis, shortTickPixels, longTickPixels);
+  DrawVerticalRuler(minY, maxY, state.height, pixelsPerMeter, offsetMetersY,
+                    xAxis, shortTickPixels, longTickPixels);
 
   glPopMatrix();
   glMatrixMode(GL_PROJECTION);
@@ -128,6 +147,47 @@ void DrawRulerOverlay(const RulerOverlayViewState &state, bool darkMode) {
 
   if (depthEnabled)
     glEnable(GL_DEPTH_TEST);
+}
+
+void EmitRulerToCanvas(const RulerOverlayViewState &state, bool darkMode,
+                       ICanvas2D &canvas) {
+  if (state.width <= 0 || state.height <= 0 || state.zoom <= 0.0f)
+    return;
+
+  const float pixelsPerMeter = kPixelsPerMeter * state.zoom;
+  if (pixelsPerMeter <= 0.0f)
+    return;
+
+  const float offsetMetersX = state.offsetPixelsX / kPixelsPerMeter;
+  const float offsetMetersY = state.offsetPixelsY / kPixelsPerMeter;
+  const float halfW = static_cast<float>(state.width) * 0.5f / pixelsPerMeter;
+  const float halfH = static_cast<float>(state.height) * 0.5f / pixelsPerMeter;
+  const float minX = -halfW - offsetMetersX;
+  const float maxX = halfW - offsetMetersX;
+  const float minY = -halfH - offsetMetersY;
+  const float maxY = halfH - offsetMetersY;
+  const float shortTickMeters = std::max(state.smallTickMeters, 0.01f);
+  const float longTickMeters =
+      std::max(std::max(state.largeTickMeters, shortTickMeters),
+               shortTickMeters);
+  auto stroke = BuildRulerStroke(darkMode);
+
+  const float xRulerY = state.axisXPositionMeters;
+  const float yRulerX = state.axisYPositionMeters;
+  canvas.DrawLine(minX, xRulerY, maxX, xRulerY, stroke);
+  canvas.DrawLine(yRulerX, minY, yRulerX, maxY, stroke);
+
+  const float startX = std::ceil(minX / kTickStepMeters) * kTickStepMeters;
+  for (float x = startX; x <= maxX + 0.0001f; x += kTickStepMeters) {
+    const float tick = IsMeterTick(x) ? longTickMeters : shortTickMeters;
+    canvas.DrawLine(x, xRulerY, x, xRulerY + tick, stroke);
+  }
+
+  const float startY = std::ceil(minY / kTickStepMeters) * kTickStepMeters;
+  for (float y = startY; y <= maxY + 0.0001f; y += kTickStepMeters) {
+    const float tick = IsMeterTick(y) ? longTickMeters : shortTickMeters;
+    canvas.DrawLine(yRulerX, y, yRulerX + tick, y, stroke);
+  }
 }
 
 } // namespace viewer2d

--- a/viewer2d/viewer2d_ruler_overlay.h
+++ b/viewer2d/viewer2d_ruler_overlay.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "canvas2d.h"
 #include "viewer3dcontroller.h"
 
 namespace viewer2d {
@@ -10,9 +11,15 @@ struct RulerOverlayViewState {
   float zoom = 1.0f;
   float offsetPixelsX = 0.0f;
   float offsetPixelsY = 0.0f;
+  float smallTickMeters = 0.1f;
+  float largeTickMeters = 0.2f;
+  float axisXPositionMeters = 0.0f;
+  float axisYPositionMeters = 0.0f;
   Viewer2DView view = Viewer2DView::Top;
 };
 
 void DrawRulerOverlay(const RulerOverlayViewState &state, bool darkMode);
+void EmitRulerToCanvas(const RulerOverlayViewState &state, bool darkMode,
+                       ICanvas2D &canvas);
 
 } // namespace viewer2d

--- a/viewer2d/viewer2d_ruler_overlay.h
+++ b/viewer2d/viewer2d_ruler_overlay.h
@@ -13,8 +13,9 @@ struct RulerOverlayViewState {
   float offsetPixelsY = 0.0f;
   float smallTickMeters = 0.1f;
   float largeTickMeters = 0.2f;
-  float axisXPositionMeters = 0.0f;
-  float axisYPositionMeters = 0.0f;
+  float xRulerPositionMeters = 0.0f;
+  float yRulerPositionMeters = 0.0f;
+  float zRulerPositionMeters = 0.0f;
   Viewer2DView view = Viewer2DView::Top;
 };
 

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -670,6 +670,10 @@ void Viewer2DPanel::RenderInternal(bool swapBuffers) {
   float gridB = cfg.GetFloat("grid_color_b");
   bool drawAbove = cfg.GetFloat("grid_draw_above") != 0.0f;
   bool showRuler = cfg.GetFloat("ruler_show") != 0.0f;
+  const float rulerSmallTickMeters = cfg.GetFloat("ruler_tick_small_m");
+  const float rulerLargeTickMeters = cfg.GetFloat("ruler_tick_large_m");
+  const float rulerAxisXPosition = cfg.GetFloat("ruler_axis_x_position");
+  const float rulerAxisYPosition = cfg.GetFloat("ruler_axis_y_position");
 
   std::unique_ptr<ICanvas2D> recordingCanvas;
   if (m_captureNextFrame) {
@@ -770,8 +774,14 @@ void Viewer2DPanel::RenderInternal(bool swapBuffers) {
     rulerState.zoom = m_zoom;
     rulerState.offsetPixelsX = m_offsetX;
     rulerState.offsetPixelsY = m_offsetY;
+    rulerState.smallTickMeters = rulerSmallTickMeters;
+    rulerState.largeTickMeters = rulerLargeTickMeters;
+    rulerState.axisXPositionMeters = rulerAxisXPosition;
+    rulerState.axisYPositionMeters = rulerAxisYPosition;
     rulerState.view = m_view;
     viewer2d::DrawRulerOverlay(rulerState, darkMode);
+    if (recordingCanvas)
+      viewer2d::EmitRulerToCanvas(rulerState, darkMode, *recordingCanvas);
   }
 
   if (swapBuffers && m_enableSelection && m_rectSelecting)

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -674,6 +674,7 @@ void Viewer2DPanel::RenderInternal(bool swapBuffers) {
   const float rulerLargeTickMeters = cfg.GetFloat("ruler_tick_large_m");
   const float rulerAxisXPosition = cfg.GetFloat("ruler_axis_x_position");
   const float rulerAxisYPosition = cfg.GetFloat("ruler_axis_y_position");
+  const float rulerAxisZPosition = cfg.GetFloat("ruler_axis_z_position");
 
   std::unique_ptr<ICanvas2D> recordingCanvas;
   if (m_captureNextFrame) {
@@ -776,8 +777,9 @@ void Viewer2DPanel::RenderInternal(bool swapBuffers) {
     rulerState.offsetPixelsY = m_offsetY;
     rulerState.smallTickMeters = rulerSmallTickMeters;
     rulerState.largeTickMeters = rulerLargeTickMeters;
-    rulerState.axisXPositionMeters = rulerAxisXPosition;
-    rulerState.axisYPositionMeters = rulerAxisYPosition;
+    rulerState.xRulerPositionMeters = rulerAxisXPosition;
+    rulerState.yRulerPositionMeters = rulerAxisYPosition;
+    rulerState.zRulerPositionMeters = rulerAxisZPosition;
     rulerState.view = m_view;
     viewer2d::DrawRulerOverlay(rulerState, darkMode);
     if (recordingCanvas)

--- a/viewer2d/viewer2drenderpanel.cpp
+++ b/viewer2d/viewer2drenderpanel.cpp
@@ -103,6 +103,41 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
   m_showRuler = new wxCheckBox(rulerBoxParent, wxID_ANY, "Show ruler");
   m_showRuler->SetValue(cfg.GetFloat("ruler_show") != 0.0f);
   m_showRuler->Bind(wxEVT_CHECKBOX, &Viewer2DRenderPanel::OnShowRuler, this);
+  m_rulerAxisXPosition = new wxSpinCtrlDouble(
+      rulerBoxParent, wxID_ANY, "", wxDefaultPosition, wxDefaultSize,
+      wxSP_ARROW_KEYS | wxTE_PROCESS_ENTER);
+  m_rulerAxisXPosition->SetRange(-100.0, 100.0);
+  m_rulerAxisXPosition->SetIncrement(0.1);
+  m_rulerAxisXPosition->SetDigits(2);
+  m_rulerAxisXPosition->SetValue(cfg.GetFloat("ruler_axis_x_position"));
+  m_rulerAxisXPosition->Bind(wxEVT_SPINCTRLDOUBLE,
+                             &Viewer2DRenderPanel::OnRulerAxisXPosition, this);
+  m_rulerAxisXPosition->Bind(wxEVT_SET_FOCUS,
+                             &Viewer2DRenderPanel::OnBeginTextEdit, this);
+  m_rulerAxisXPosition->Bind(wxEVT_KILL_FOCUS,
+                             &Viewer2DRenderPanel::OnEndTextEdit, this);
+  m_rulerAxisXPosition->Bind(wxEVT_TEXT, &Viewer2DRenderPanel::OnTextChange,
+                             this);
+  m_rulerAxisXPosition->Bind(wxEVT_TEXT_ENTER,
+                             &Viewer2DRenderPanel::OnTextEnter, this);
+
+  m_rulerAxisYPosition = new wxSpinCtrlDouble(
+      rulerBoxParent, wxID_ANY, "", wxDefaultPosition, wxDefaultSize,
+      wxSP_ARROW_KEYS | wxTE_PROCESS_ENTER);
+  m_rulerAxisYPosition->SetRange(-100.0, 100.0);
+  m_rulerAxisYPosition->SetIncrement(0.1);
+  m_rulerAxisYPosition->SetDigits(2);
+  m_rulerAxisYPosition->SetValue(cfg.GetFloat("ruler_axis_y_position"));
+  m_rulerAxisYPosition->Bind(wxEVT_SPINCTRLDOUBLE,
+                             &Viewer2DRenderPanel::OnRulerAxisYPosition, this);
+  m_rulerAxisYPosition->Bind(wxEVT_SET_FOCUS,
+                             &Viewer2DRenderPanel::OnBeginTextEdit, this);
+  m_rulerAxisYPosition->Bind(wxEVT_KILL_FOCUS,
+                             &Viewer2DRenderPanel::OnEndTextEdit, this);
+  m_rulerAxisYPosition->Bind(wxEVT_TEXT, &Viewer2DRenderPanel::OnTextChange,
+                             this);
+  m_rulerAxisYPosition->Bind(wxEVT_TEXT_ENTER,
+                             &Viewer2DRenderPanel::OnTextEnter, this);
 
   auto *labelBox = new wxStaticBoxSizer(wxVERTICAL, this, "Labels");
   wxWindow *labelBoxParent = labelBox->GetStaticBox();
@@ -224,6 +259,16 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
   sizer->Add(gridBox, 0, wxALL, 5);
 
   rulerBox->Add(m_showRuler, 0, wxALL, 5);
+  auto *rulerAxisXSizer = new wxBoxSizer(wxHORIZONTAL);
+  rulerAxisXSizer->Add(new wxStaticText(rulerBoxParent, wxID_ANY, "X ruler Y"),
+                       0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
+  rulerAxisXSizer->Add(m_rulerAxisXPosition, 0);
+  rulerBox->Add(rulerAxisXSizer, 0, wxALL, 5);
+  auto *rulerAxisYSizer = new wxBoxSizer(wxHORIZONTAL);
+  rulerAxisYSizer->Add(new wxStaticText(rulerBoxParent, wxID_ANY, "Y ruler X"),
+                       0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
+  rulerAxisYSizer->Add(m_rulerAxisYPosition, 0);
+  rulerBox->Add(rulerAxisYSizer, 0, wxALL, 5);
   sizer->Add(rulerBox, 0, wxALL, 5);
 
   auto *nameSizer = new wxBoxSizer(wxHORIZONTAL);
@@ -298,6 +343,8 @@ void Viewer2DRenderPanel::ApplyConfig() {
   m_gridColor->SetColour(wxColour(rr, gg, bb));
   m_drawAbove->SetValue(cfg.GetFloat("grid_draw_above") != 0.0f);
   m_showRuler->SetValue(cfg.GetFloat("ruler_show") != 0.0f);
+  m_rulerAxisXPosition->SetValue(cfg.GetFloat("ruler_axis_x_position"));
+  m_rulerAxisYPosition->SetValue(cfg.GetFloat("ruler_axis_y_position"));
   int viewIndex = m_view->GetSelection();
   m_showLabelName->SetValue(cfg.GetFloat(NAME_KEYS[viewIndex]) != 0.0f);
   m_labelNameSize->SetValue(
@@ -384,6 +431,24 @@ void Viewer2DRenderPanel::OnDrawAbove(wxCommandEvent &evt) {
 void Viewer2DRenderPanel::OnShowRuler(wxCommandEvent &evt) {
   ConfigManager::Get().SetFloat("ruler_show",
                                 m_showRuler->GetValue() ? 1.0f : 0.0f);
+  if (auto *vp = Viewer2DPanel::Instance())
+    vp->UpdateScene(false);
+  evt.Skip();
+}
+
+void Viewer2DRenderPanel::OnRulerAxisXPosition(wxSpinDoubleEvent &evt) {
+  ConfigManager::Get().SetFloat(
+      "ruler_axis_x_position",
+      static_cast<float>(m_rulerAxisXPosition->GetValue()));
+  if (auto *vp = Viewer2DPanel::Instance())
+    vp->UpdateScene(false);
+  evt.Skip();
+}
+
+void Viewer2DRenderPanel::OnRulerAxisYPosition(wxSpinDoubleEvent &evt) {
+  ConfigManager::Get().SetFloat(
+      "ruler_axis_y_position",
+      static_cast<float>(m_rulerAxisYPosition->GetValue()));
   if (auto *vp = Viewer2DPanel::Instance())
     vp->UpdateScene(false);
   evt.Skip();
@@ -519,6 +584,12 @@ void Viewer2DRenderPanel::OnTextEnter(wxCommandEvent &evt) {
     int view = m_view->GetSelection();
     cfg.SetFloat(ANGLE_KEYS[view],
                  static_cast<float>(m_labelOffsetAngle->GetValue()));
+  } else if (evt.GetEventObject() == m_rulerAxisXPosition) {
+    cfg.SetFloat("ruler_axis_x_position",
+                 static_cast<float>(m_rulerAxisXPosition->GetValue()));
+  } else if (evt.GetEventObject() == m_rulerAxisYPosition) {
+    cfg.SetFloat("ruler_axis_y_position",
+                 static_cast<float>(m_rulerAxisYPosition->GetValue()));
   }
   if (auto *vp = Viewer2DPanel::Instance())
     vp->UpdateScene(false);

--- a/viewer2d/viewer2drenderpanel.cpp
+++ b/viewer2d/viewer2drenderpanel.cpp
@@ -138,6 +138,23 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
                              this);
   m_rulerAxisYPosition->Bind(wxEVT_TEXT_ENTER,
                              &Viewer2DRenderPanel::OnTextEnter, this);
+  m_rulerAxisZPosition = new wxSpinCtrlDouble(
+      rulerBoxParent, wxID_ANY, "", wxDefaultPosition, wxDefaultSize,
+      wxSP_ARROW_KEYS | wxTE_PROCESS_ENTER);
+  m_rulerAxisZPosition->SetRange(-100.0, 100.0);
+  m_rulerAxisZPosition->SetIncrement(0.1);
+  m_rulerAxisZPosition->SetDigits(2);
+  m_rulerAxisZPosition->SetValue(cfg.GetFloat("ruler_axis_z_position"));
+  m_rulerAxisZPosition->Bind(wxEVT_SPINCTRLDOUBLE,
+                             &Viewer2DRenderPanel::OnRulerAxisZPosition, this);
+  m_rulerAxisZPosition->Bind(wxEVT_SET_FOCUS,
+                             &Viewer2DRenderPanel::OnBeginTextEdit, this);
+  m_rulerAxisZPosition->Bind(wxEVT_KILL_FOCUS,
+                             &Viewer2DRenderPanel::OnEndTextEdit, this);
+  m_rulerAxisZPosition->Bind(wxEVT_TEXT, &Viewer2DRenderPanel::OnTextChange,
+                             this);
+  m_rulerAxisZPosition->Bind(wxEVT_TEXT_ENTER,
+                             &Viewer2DRenderPanel::OnTextEnter, this);
 
   auto *labelBox = new wxStaticBoxSizer(wxVERTICAL, this, "Labels");
   wxWindow *labelBoxParent = labelBox->GetStaticBox();
@@ -260,15 +277,20 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
 
   rulerBox->Add(m_showRuler, 0, wxALL, 5);
   auto *rulerAxisXSizer = new wxBoxSizer(wxHORIZONTAL);
-  rulerAxisXSizer->Add(new wxStaticText(rulerBoxParent, wxID_ANY, "X ruler Y"),
+  rulerAxisXSizer->Add(new wxStaticText(rulerBoxParent, wxID_ANY, "X ruler"),
                        0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
   rulerAxisXSizer->Add(m_rulerAxisXPosition, 0);
   rulerBox->Add(rulerAxisXSizer, 0, wxALL, 5);
   auto *rulerAxisYSizer = new wxBoxSizer(wxHORIZONTAL);
-  rulerAxisYSizer->Add(new wxStaticText(rulerBoxParent, wxID_ANY, "Y ruler X"),
+  rulerAxisYSizer->Add(new wxStaticText(rulerBoxParent, wxID_ANY, "Y ruler"),
                        0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
   rulerAxisYSizer->Add(m_rulerAxisYPosition, 0);
   rulerBox->Add(rulerAxisYSizer, 0, wxALL, 5);
+  auto *rulerAxisZSizer = new wxBoxSizer(wxHORIZONTAL);
+  rulerAxisZSizer->Add(new wxStaticText(rulerBoxParent, wxID_ANY, "Z ruler"),
+                       0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
+  rulerAxisZSizer->Add(m_rulerAxisZPosition, 0);
+  rulerBox->Add(rulerAxisZSizer, 0, wxALL, 5);
   sizer->Add(rulerBox, 0, wxALL, 5);
 
   auto *nameSizer = new wxBoxSizer(wxHORIZONTAL);
@@ -345,6 +367,8 @@ void Viewer2DRenderPanel::ApplyConfig() {
   m_showRuler->SetValue(cfg.GetFloat("ruler_show") != 0.0f);
   m_rulerAxisXPosition->SetValue(cfg.GetFloat("ruler_axis_x_position"));
   m_rulerAxisYPosition->SetValue(cfg.GetFloat("ruler_axis_y_position"));
+  m_rulerAxisZPosition->SetValue(cfg.GetFloat("ruler_axis_z_position"));
+  UpdateRulerControlState();
   int viewIndex = m_view->GetSelection();
   m_showLabelName->SetValue(cfg.GetFloat(NAME_KEYS[viewIndex]) != 0.0f);
   m_labelNameSize->SetValue(
@@ -454,6 +478,15 @@ void Viewer2DRenderPanel::OnRulerAxisYPosition(wxSpinDoubleEvent &evt) {
   evt.Skip();
 }
 
+void Viewer2DRenderPanel::OnRulerAxisZPosition(wxSpinDoubleEvent &evt) {
+  ConfigManager::Get().SetFloat(
+      "ruler_axis_z_position",
+      static_cast<float>(m_rulerAxisZPosition->GetValue()));
+  if (auto *vp = Viewer2DPanel::Instance())
+    vp->UpdateScene(false);
+  evt.Skip();
+}
+
 void Viewer2DRenderPanel::OnShowLabelName(wxCommandEvent &evt) {
   int view = m_view->GetSelection();
   ConfigManager::Get().SetFloat(NAME_KEYS[view],
@@ -541,10 +574,27 @@ void Viewer2DRenderPanel::ApplyViewSelection(int selection) {
   m_showLabelName->SetValue(cfg.GetFloat(NAME_KEYS[sel]) != 0.0f);
   m_showLabelId->SetValue(cfg.GetFloat(ID_KEYS[sel]) != 0.0f);
   m_showLabelAddress->SetValue(cfg.GetFloat(DMX_KEYS[sel]) != 0.0f);
+  UpdateRulerControlState();
   if (auto *vp = Viewer2DPanel::Instance()) {
     vp->SetView(static_cast<Viewer2DView>(sel));
     vp->UpdateScene(false);
   }
+}
+
+void Viewer2DRenderPanel::UpdateRulerControlState() {
+  const Viewer2DView selectedView =
+      static_cast<Viewer2DView>(m_view->GetSelection());
+  const bool showX = selectedView == Viewer2DView::Top ||
+                     selectedView == Viewer2DView::Bottom ||
+                     selectedView == Viewer2DView::Front;
+  const bool showY = selectedView == Viewer2DView::Top ||
+                     selectedView == Viewer2DView::Bottom ||
+                     selectedView == Viewer2DView::Side;
+  const bool showZ = selectedView == Viewer2DView::Front ||
+                     selectedView == Viewer2DView::Side;
+  m_rulerAxisXPosition->Enable(showX);
+  m_rulerAxisYPosition->Enable(showY);
+  m_rulerAxisZPosition->Enable(showZ);
 }
 
 void Viewer2DRenderPanel::OnBeginTextEdit(wxFocusEvent &evt) {
@@ -590,6 +640,9 @@ void Viewer2DRenderPanel::OnTextEnter(wxCommandEvent &evt) {
   } else if (evt.GetEventObject() == m_rulerAxisYPosition) {
     cfg.SetFloat("ruler_axis_y_position",
                  static_cast<float>(m_rulerAxisYPosition->GetValue()));
+  } else if (evt.GetEventObject() == m_rulerAxisZPosition) {
+    cfg.SetFloat("ruler_axis_z_position",
+                 static_cast<float>(m_rulerAxisZPosition->GetValue()));
   }
   if (auto *vp = Viewer2DPanel::Instance())
     vp->UpdateScene(false);

--- a/viewer2d/viewer2drenderpanel.h
+++ b/viewer2d/viewer2drenderpanel.h
@@ -45,6 +45,7 @@ private:
   void OnShowRuler(wxCommandEvent &evt);
   void OnRulerAxisXPosition(wxSpinDoubleEvent &evt);
   void OnRulerAxisYPosition(wxSpinDoubleEvent &evt);
+  void OnRulerAxisZPosition(wxSpinDoubleEvent &evt);
   void OnShowLabelName(wxCommandEvent &evt);
   void OnShowLabelId(wxCommandEvent &evt);
   void OnShowLabelAddress(wxCommandEvent &evt);
@@ -59,6 +60,7 @@ private:
   void OnTextChange(wxCommandEvent &evt);
   void OnTextEnter(wxCommandEvent &evt);
   void ApplyViewSelection(int selection);
+  void UpdateRulerControlState();
 
   wxRadioBox *m_radio = nullptr;
   wxCheckBox *m_darkMode = nullptr;
@@ -71,6 +73,7 @@ private:
   wxCheckBox *m_showRuler = nullptr;
   wxSpinCtrlDouble *m_rulerAxisXPosition = nullptr;
   wxSpinCtrlDouble *m_rulerAxisYPosition = nullptr;
+  wxSpinCtrlDouble *m_rulerAxisZPosition = nullptr;
   wxCheckBox *m_showLabelName = nullptr;
   wxCheckBox *m_showLabelId = nullptr;
   wxCheckBox *m_showLabelAddress = nullptr;

--- a/viewer2d/viewer2drenderpanel.h
+++ b/viewer2d/viewer2drenderpanel.h
@@ -43,6 +43,8 @@ private:
   void OnGridColor(wxColourPickerEvent &evt);
   void OnDrawAbove(wxCommandEvent &evt);
   void OnShowRuler(wxCommandEvent &evt);
+  void OnRulerAxisXPosition(wxSpinDoubleEvent &evt);
+  void OnRulerAxisYPosition(wxSpinDoubleEvent &evt);
   void OnShowLabelName(wxCommandEvent &evt);
   void OnShowLabelId(wxCommandEvent &evt);
   void OnShowLabelAddress(wxCommandEvent &evt);
@@ -67,6 +69,8 @@ private:
   wxColourPickerCtrl *m_gridColor = nullptr;
   wxCheckBox *m_drawAbove = nullptr;
   wxCheckBox *m_showRuler = nullptr;
+  wxSpinCtrlDouble *m_rulerAxisXPosition = nullptr;
+  wxSpinCtrlDouble *m_rulerAxisYPosition = nullptr;
   wxCheckBox *m_showLabelName = nullptr;
   wxCheckBox *m_showLabelId = nullptr;
   wxCheckBox *m_showLabelAddress = nullptr;


### PR DESCRIPTION
### Motivation
- Provide rulers with metric-fixed tick sizes (user wanted ~10 cm/20 cm ticks implemented as `0.10 m` / `0.20 m`) and ensure rulers are printable objects at a fixed plane with configurable positions.
- Expose per-axis ruler positioning so the X-axis ruler can be moved along Y and the Y-axis ruler along X from the 2D render options.

### Description
- Add configuration variables in `core/configmanager.cpp`: `ruler_tick_small_m`, `ruler_tick_large_m`, `ruler_axis_x_position`, and `ruler_axis_y_position` with sensible defaults. 
- Extend `RulerOverlayViewState` in `viewer2d/viewer2d_ruler_overlay.h` to carry `smallTickMeters`, `largeTickMeters`, and axis positions, and update the overlay drawing to use those physical sizes when rendering ticks.
- Factor overlay drawing to accept computed tick/axis parameters and add `EmitRulerToCanvas` in `viewer2d/viewer2d_ruler_overlay.cpp` so ruler primitives are emitted into `CommandBuffer` (making rulers printable/exportable), in addition to on-screen OpenGL overlay rendering.
- Read the new config values in `viewer2d/viewer2dpanel.cpp` and populate the overlay state; when capture/export is active, emit the ruler to the `recordingCanvas` as well so exported outputs include the rulers.
- Add UI controls in the 2D Render Options panel (`viewer2d/viewer2drenderpanel.{h,cpp}`): two `wxSpinCtrlDouble` boxes labeled `X ruler Y` and `Y ruler X` wired to `OnRulerAxisXPosition` / `OnRulerAxisYPosition` handlers that persist to `ConfigManager` and update the view live.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (OK).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8530758b083248199644fd603ea79)