### PR TITLE
Show text-import splash immediately when creating from text

### DIFF
--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -251,17 +251,30 @@ void MainWindow::OnImportRider(wxCommandEvent &event) {
 }
 
 void MainWindow::OnImportRiderText(wxCommandEvent &WXUNUSED(event)) {
-  LockViewportInteraction();
-  ScopeExit viewportUnlock([this]() { UnlockViewportInteraction(); });
   RiderTextDialog dlg(this);
   if (dlg.ShowModal() != wxID_OK)
     return;
 
+  const std::string riderText = dlg.GetRiderTextUtf8();
+  if (riderText.empty()) {
+    wxMessageBox("Rider text is empty.", "Error", wxICON_ERROR);
+    return;
+  }
+
+  LockViewportInteraction();
+  ScopeExit viewportUnlock([this]() { UnlockViewportInteraction(); });
   std::unique_ptr<wxWindowDisabler> createDisabler =
       std::make_unique<wxWindowDisabler>();
   std::unique_ptr<wxBusyInfo> createOverlay =
       std::make_unique<wxBusyInfo>("Generating scene from text...");
   wxYieldIfNeeded();
+
+  if (!RiderImporter::ImportText(riderText)) {
+    wxMessageBox("Failed to import rider text.", "Error", wxICON_ERROR);
+    if (consolePanel)
+      consolePanel->AppendMessage("[ERROR] Failed to import rider from text.");
+    return;
+  }
 
   if (consolePanel)
     consolePanel->AppendMessage("[INFO] Imported rider from text.");

--- a/gui/ridertextdialog.cpp
+++ b/gui/ridertextdialog.cpp
@@ -89,6 +89,21 @@ RiderTextDialog::RiderTextDialog(wxWindow *parent,
   Centre();
 }
 
+const std::string &RiderTextDialog::GetRiderTextUtf8() const {
+  return selectedRiderTextUtf8;
+}
+
+bool RiderTextDialog::TryGetCurrentText(std::string &outText) const {
+  if (!textCtrl)
+    return false;
+
+  const wxString value = textCtrl->GetValue();
+  const wxScopedCharBuffer textBuffer = value.ToUTF8();
+  outText = textBuffer ? std::string(textBuffer.data(), textBuffer.length())
+                       : value.ToStdString();
+  return true;
+}
+
 void RiderTextDialog::OnLoadFromFile(wxCommandEvent &WXUNUSED(event)) {
   wxString miscDir =
       wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("misc"));
@@ -176,12 +191,8 @@ void RiderTextDialog::OnLoadExample(wxCommandEvent &WXUNUSED(event)) {
 }
 
 void RiderTextDialog::OnApplyFilter(wxCommandEvent &WXUNUSED(event)) {
-  wxString value = textCtrl->GetValue();
-  const wxScopedCharBuffer textBuffer = value.ToUTF8();
-  std::string text =
-      textBuffer ? std::string(textBuffer.data(), textBuffer.length())
-                 : value.ToStdString();
-  if (text.empty()) {
+  std::string text;
+  if (!TryGetCurrentText(text) || text.empty()) {
     wxMessageBox("Rider text is empty.", "Error", wxICON_ERROR);
     return;
   }
@@ -206,18 +217,11 @@ void RiderTextDialog::OnApplyFilter(wxCommandEvent &WXUNUSED(event)) {
 }
 
 void RiderTextDialog::OnApply(wxCommandEvent &WXUNUSED(event)) {
-  wxString value = textCtrl->GetValue();
-  const wxScopedCharBuffer textBuffer = value.ToUTF8();
-  std::string text =
-      textBuffer ? std::string(textBuffer.data(), textBuffer.length())
-                 : value.ToStdString();
-  if (text.empty()) {
+  std::string text;
+  if (!TryGetCurrentText(text) || text.empty()) {
     wxMessageBox("Rider text is empty.", "Error", wxICON_ERROR);
     return;
   }
-  if (!RiderImporter::ImportText(text)) {
-    wxMessageBox("Failed to import rider text.", "Error", wxICON_ERROR);
-    return;
-  }
+  selectedRiderTextUtf8 = std::move(text);
   EndModal(wxID_OK);
 }

--- a/gui/ridertextdialog.h
+++ b/gui/ridertextdialog.h
@@ -17,6 +17,8 @@
  */
 #pragma once
 
+#include <string>
+
 #include <wx/dialog.h>
 
 class wxTextCtrl;
@@ -27,8 +29,10 @@ public:
   explicit RiderTextDialog(wxWindow *parent,
                            const wxString &initialText = wxEmptyString,
                            const wxString &initialSource = wxEmptyString);
+  const std::string &GetRiderTextUtf8() const;
 
 private:
+  bool TryGetCurrentText(std::string &outText) const;
   void OnLoadFromFile(wxCommandEvent &event);
   void OnLoadExample(wxCommandEvent &event);
   void OnApplyFilter(wxCommandEvent &event);
@@ -37,6 +41,7 @@ private:
   wxTextCtrl *textCtrl = nullptr;
   wxStaticText *sourceText = nullptr;
   wxString sourceLabel;
+  std::string selectedRiderTextUtf8;
 
   wxDECLARE_EVENT_TABLE();
 };


### PR DESCRIPTION
### Motivation
- Users saw a brief freeze before the busy splash when creating a scene from text because parsing ran inside the modal dialog before it closed. This change moves parsing to after the dialog closes so the splash appears immediately.

### Description
- Move rider text parsing out of `RiderTextDialog::OnApply` so the dialog only collects/validates text and closes; the dialog now stores the UTF-8 text in `selectedRiderTextUtf8`.
- Add `RiderTextDialog::GetRiderTextUtf8()` and `TryGetCurrentText(...)` to centralize text extraction/conversion logic.
- Update `MainWindow::OnImportRiderText` to retrieve the text from the dialog, show the busy overlay (`wxBusyInfo`) immediately, call `RiderImporter::ImportText(...)` under the overlay, and report errors to both message box and `ConsolePanel`.
- Preserve existing UX flow: lock/unlock viewport interaction and refresh scene after successful import.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c87b1047ec8324ac6c25ad8c49840c)