### PR TITLE
Add Category column to Dictionary Editor fixtures and persist per-file category updates

### DIFF
--- a/gui/dictionaryeditdialog.cpp
+++ b/gui/dictionaryeditdialog.cpp
@@ -22,6 +22,7 @@
 #include "dictionary_json_contract.h"
 #include "file_import_utils.h"
 #include "gdtfdictionary.h"
+#include "gdtf_fixture_category.h"
 #include "gdtfloader.h"
 #include "json.hpp"
 #include "mainwindow.h"
@@ -44,6 +45,7 @@ struct FixtureRow {
   std::string name;
   std::string path;
   std::string mode;
+  std::string category;
   std::string source;
   std::string sha256;
 };
@@ -635,6 +637,8 @@ void DictionaryEditDialog::BuildLayout() {
                                  wxALIGN_LEFT, flags);
   fixtureTable->AppendTextColumn("Mode", wxDATAVIEW_CELL_INERT, 120,
                                  wxALIGN_LEFT, flags);
+  fixtureTable->AppendTextColumn("Category", wxDATAVIEW_CELL_INERT, 130,
+                                 wxALIGN_LEFT, flags);
   ColumnUtils::EnforceMinColumnWidth(fixtureTable);
   fixtureSizer->Add(fixtureTable, 1, wxEXPAND | wxALL, 8);
   fixturePanel->SetSizer(fixtureSizer);
@@ -715,7 +719,7 @@ void DictionaryEditDialog::LoadFixtures() {
       continue;
     if (!std::filesystem::exists(entry.path))
       continue;
-    FixtureRow row{ name, entry.path, entry.mode };
+    FixtureRow row{ name, entry.path, entry.mode, entry.category };
     rows.push_back(row);
   }
   SortFixtureRows(rows);
@@ -726,6 +730,7 @@ void DictionaryEditDialog::LoadFixtures() {
     items.push_back(wxString::FromUTF8(row.name));
     items.push_back(wxString::FromUTF8(std::filesystem::path(row.path).filename().string()));
     items.push_back(wxString::FromUTF8(row.mode));
+    items.push_back(wxString::FromUTF8(row.category));
     fixtureTable->AppendItem(items);
     fixturePaths.push_back(row.path);
   }
@@ -886,7 +891,12 @@ void DictionaryEditDialog::SaveFixtures() {
     auto copied = CopyToLibrary(this, path, "fixtures");
     if (!copied)
       continue;
-    rows.push_back({name, copied->path, mode, copied->source, copied->sha256});
+    wxVariant categoryVar;
+    fixtureTable->GetValue(categoryVar, i, 3);
+    const std::string category = GdtfFixtureCategory::NormalizeCategory(
+        std::string(categoryVar.GetString().ToUTF8()));
+    rows.push_back(
+        {name, copied->path, mode, category, copied->source, copied->sha256});
   }
 
   SortFixtureRows(rows);
@@ -896,6 +906,7 @@ void DictionaryEditDialog::SaveFixtures() {
     GdtfDictionary::Entry entry;
     entry.path = row.path;
     entry.mode = row.mode;
+    entry.category = row.category;
     entry.source = row.source;
     entry.importedAt = FileImportUtils::NowUtcIso8601();
     if (!row.sha256.empty())
@@ -971,6 +982,7 @@ void DictionaryEditDialog::OnAdd(wxCommandEvent &WXUNUSED(event)) {
     items.push_back(wxString::FromUTF8(name));
     items.push_back(wxString::FromUTF8(std::filesystem::path(fullPath).filename().string()));
     items.push_back(wxString::FromUTF8(mode));
+    items.push_back(wxString());
     fixtureTable->AppendItem(items);
     fixturePaths.push_back(fullPath);
   } else {
@@ -1034,6 +1046,50 @@ void DictionaryEditDialog::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
     wxCommandEvent evt(wxEVT_MENU, ID_Tools_DownloadGdtf);
     parent->ProcessWindowEvent(evt);
   }
+}
+
+void DictionaryEditDialog::UpdateFixtureCategoryForFile(
+    int row, const std::string &category) {
+  if (!fixtureTable || row < 0 || static_cast<size_t>(row) >= fixturePaths.size())
+    return;
+  const std::string targetPath = fixturePaths[static_cast<size_t>(row)];
+  if (targetPath.empty())
+    return;
+
+  std::vector<std::string> matchingNames;
+  const int rowCount = fixtureTable->GetItemCount();
+  for (int i = 0; i < rowCount; ++i) {
+    if (static_cast<size_t>(i) >= fixturePaths.size())
+      continue;
+    if (fixturePaths[static_cast<size_t>(i)] != targetPath)
+      continue;
+
+    fixtureTable->SetValue(wxVariant(wxString::FromUTF8(category)), i, 3);
+    wxVariant nameVar;
+    fixtureTable->GetValue(nameVar, i, 0);
+    const std::string name = std::string(nameVar.GetString().ToUTF8());
+    if (!name.empty())
+      matchingNames.push_back(name);
+  }
+
+  if (matchingNames.empty())
+    return;
+  auto dictOpt = GdtfDictionary::Load();
+  if (!dictOpt)
+    return;
+  auto &dict = *dictOpt;
+  bool changed = false;
+  for (const auto &name : matchingNames) {
+    auto it = dict.find(name);
+    if (it == dict.end())
+      continue;
+    if (it->second.category == category)
+      continue;
+    it->second.category = category;
+    changed = true;
+  }
+  if (changed)
+    GdtfDictionary::Save(dict);
 }
 
 void DictionaryEditDialog::OnOk(wxCommandEvent &WXUNUSED(event)) {
@@ -1451,6 +1507,28 @@ void DictionaryEditDialog::OnItemActivated(wxDataViewEvent &event) {
         std::string mode = std::string(dlg.GetStringSelection().ToUTF8());
         table->SetValue(wxVariant(wxString::FromUTF8(mode)), row, 2);
       }
+      return;
+    }
+    if (col == 3) {
+      wxVariant current;
+      table->GetValue(current, row, col);
+      const wxArrayString choices = {
+          "Beam",         "Blinder", "Conventional", "FX",    "Hoist",
+          "Hybrid",       "Laser",   "LED",          "Smoke", "Spot",
+          "Strobe",       "Unknown", "Video",        "Wash"};
+      wxSingleChoiceDialog dlg(this, "Select category", "Category", choices);
+      if (!current.GetString().empty()) {
+        const int currentSelection = choices.Index(current.GetString());
+        if (currentSelection != wxNOT_FOUND)
+          dlg.SetSelection(currentSelection);
+      }
+      if (dlg.ShowModal() != wxID_OK)
+        return;
+      const std::string selectedCategory = GdtfFixtureCategory::NormalizeCategory(
+          std::string(dlg.GetStringSelection().ToUTF8()));
+      if (selectedCategory.empty())
+        return;
+      UpdateFixtureCategoryForFile(row, selectedCategory);
       return;
     }
     if (col != 1)

--- a/gui/dictionaryeditdialog.h
+++ b/gui/dictionaryeditdialog.h
@@ -40,6 +40,7 @@ private:
   bool HasTrussChanges() const;
   void ShowDictionaryLoadStatusMessages();
   bool IsFixturesPage() const;
+  void UpdateFixtureCategoryForFile(int row, const std::string &category);
 
   void OnAdd(wxCommandEvent &event);
   void OnDelete(wxCommandEvent &event);


### PR DESCRIPTION
### Motivation
- Provide the Dictionary editor fixtures table with a Category column and allow users to set categories per-fixture file, updating all entries that reference the same file and persisting the change to the user dictionary JSON only.

### Description
- Added a new `Category` column to the fixtures page in `DictionaryEditDialog` and extended the `FixtureRow` struct to carry `category` values.
- Load and save paths were extended so `GdtfDictionary::Entry::category` is read in `LoadFixtures()` and written in `SaveFixtures()` when the dialog persists the snapshot.
- Implemented `UpdateFixtureCategoryForFile(int row, const std::string &category)` which updates every table row that shares the same file path, then loads the user fixtures dictionary via `GdtfDictionary::Load()`, updates matching entries' `category` fields and calls `GdtfDictionary::Save()` to persist the `.json` metadata (no asset copying in this flow).
- Wire UI activation so activating the Category cell opens a `wxSingleChoiceDialog` (same UX style as the fixtures table), applies the normalized category to matching rows, and triggers immediate dictionary save.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both reported `OK`.
- No additional automated unit tests were added for this UI change in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8807554808324992a5d6b4bc7e46a)