### PR TITLE
Keep load splash/blocking UI active until fixture symbols finish generating

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -558,28 +558,25 @@ bool MainWindow::GuardStartupProjectLoadAction(const wxString &actionLabel) {
 
 bool MainWindow::LoadProjectFromPath(const std::string &path,
                                      bool showBlockingLoadUi) {
-  std::unique_ptr<wxWindowDisabler> loadDisabler;
-  std::unique_ptr<wxBusyInfo> loadOverlay;
   if (showBlockingLoadUi) {
-    loadDisabler = std::make_unique<wxWindowDisabler>();
-    loadOverlay = std::make_unique<wxBusyInfo>("Loading project file...");
+    blockingProjectLoadDisabler = std::make_unique<wxWindowDisabler>();
+    blockingProjectLoadOverlay = std::make_unique<wxBusyInfo>("Loading project file...");
     wxYieldIfNeeded();
   }
 
   LockViewportInteraction();
-  auto finishLoad = [this, &loadOverlay, &loadDisabler]() {
+  auto finishLoad = [this]() {
     UnlockViewportInteraction();
-    loadOverlay.reset();
-    loadDisabler.reset();
   };
 
   if (!GetDefaultGuiConfigServices().LegacyConfigManager().LoadProject(path)) {
+    ClearBlockingProjectLoadUi();
     finishLoad();
     return false;
   }
 
   if (showBlockingLoadUi) {
-    loadOverlay = std::make_unique<wxBusyInfo>("Building scene...");
+    blockingProjectLoadOverlay = std::make_unique<wxBusyInfo>("Building scene...");
     wxYieldIfNeeded();
   } else {
     SplashScreen::SetMessage("Building scene...");
@@ -628,7 +625,7 @@ bool MainWindow::LoadProjectFromPath(const std::string &path,
   if (layerPanel)
     layerPanel->ReloadLayers();
   if (showBlockingLoadUi) {
-    loadOverlay = std::make_unique<wxBusyInfo>("Refreshing panels...");
+    blockingProjectLoadOverlay = std::make_unique<wxBusyInfo>("Refreshing panels...");
     wxYieldIfNeeded();
   } else {
     SplashScreen::SetMessage("Refreshing panels...");
@@ -638,16 +635,32 @@ bool MainWindow::LoadProjectFromPath(const std::string &path,
   RefreshRigging();
   GetDefaultGuiConfigServices().LegacyConfigManager().MarkSaved();
   if (showBlockingLoadUi) {
-    loadOverlay = std::make_unique<wxBusyInfo>("Creating fixture symbols...");
+    blockingProjectLoadOverlay = std::make_unique<wxBusyInfo>("Creating fixture symbols...");
     wxYieldIfNeeded();
   } else {
     SplashScreen::SetMessage("Creating fixture symbols...");
     wxYieldIfNeeded();
   }
+
+  if (showBlockingLoadUi) {
+    auto previousCompletionCallback = fixtureSymbolAutoUpdateCompletionCallback;
+    fixtureSymbolAutoUpdateCompletionCallback =
+        [this, previousCompletionCallback]() {
+          if (previousCompletionCallback)
+            previousCompletionCallback();
+          ClearBlockingProjectLoadUi();
+        };
+  }
+
   StartFixtureSymbolAutoUpdateForLoadedScene();
   UpdateTitle();
   finishLoad();
   return true;
+}
+
+void MainWindow::ClearBlockingProjectLoadUi() {
+  blockingProjectLoadOverlay.reset();
+  blockingProjectLoadDisabler.reset();
 }
 
 void MainWindow::LoadStartupProjectFromPath(const std::string &path) {

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -34,6 +34,8 @@ wxDECLARE_EVENT(EVT_PROJECT_LOADED, wxCommandEvent);
 // Forward declarations for GUI components
 class wxNotebook;
 class wxIdleEvent;
+class wxBusyInfo;
+class wxWindowDisabler;
 class FixtureTablePanel;
 class TrussTablePanel;
 class HoistTablePanel;
@@ -228,6 +230,7 @@ private:
                           const wxString &dialogTitle);
   void StartFixtureSymbolAutoUpdateForLoadedScene();
   void ProcessNextFixtureSymbolAutoUpdate();
+  void ClearBlockingProjectLoadUi();
   void CompleteStartupSplashInitialization();
   void RequestStartupSplashCompletion();
   void OnStartupSplashCloseIdle(wxIdleEvent &event);
@@ -257,6 +260,8 @@ private:
   bool startupSplashCloseRequested = false;
   bool startupProjectLoadPending = true;
   int viewportInteractionLockDepth = 0;
+  std::unique_ptr<wxWindowDisabler> blockingProjectLoadDisabler;
+  std::unique_ptr<wxBusyInfo> blockingProjectLoadOverlay;
 
   friend class MainWindowIoController;
   friend class MainWindowLayoutController;


### PR DESCRIPTION
### Motivation
- Ensure the UI blocking indicators shown when loading a project remain active until fixture symbol generation completes so the app is not interactable before symbols are available.
- Avoid prematurely destroying the blocking overlay and window-disabler when `LoadProjectFromPath` returns, which could expose the UI while background symbol generation is still running.

### Description
- Persisted the project-load blocking UI components by moving `wxWindowDisabler` and `wxBusyInfo` from local variables into `MainWindow` members (`blockingProjectLoadDisabler` and `blockingProjectLoadOverlay`) and added forward declarations in `gui/mainwindow.h`.
- Added `ClearBlockingProjectLoadUi()` and call sites to clear the blocking UI on load failure and when symbol generation completes.
- Chain-wired `fixtureSymbolAutoUpdateCompletionCallback` inside `LoadProjectFromPath` to call `ClearBlockingProjectLoadUi()` after any previously set completion callback runs, preserving existing startup-splash behavior.
- Files changed: `gui/mainwindow.cpp` and `gui/mainwindow.h` (moved overlay lifetime management, added helper and members, preserved previous completion callbacks).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (`OK`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c88554a6e88324ab65e6720306073e)