### PR TITLE
Decouple ruler offset controls from tick origins

### DIFF
--- a/viewer2d/viewer2d_ruler_overlay.cpp
+++ b/viewer2d/viewer2d_ruler_overlay.cpp
@@ -31,6 +31,7 @@ constexpr float kImperialShortTickStepMeters = 6.0f * kMetersPerInch;
 constexpr float kImperialLongTickStepMeters = kInchesPerFoot * kMetersPerInch;
 constexpr float kRulerLabelFontSize = 3.0f;
 constexpr float kRulerLabelOffsetMeters = 0.12f;
+constexpr float kRulerZeroOriginMeters = 0.0f;
 
 enum class RulerTickKind { None, Short, Long };
 
@@ -274,10 +275,10 @@ void DrawRulerOverlay(const RulerOverlayViewState &state, bool darkMode) {
     glColor3f(0.0f, 0.0f, 0.0f);
   glLineWidth(1.0f);
 
-  DrawHorizontalRuler(minX, maxX, yAxis, xAxis, shortTickMeters,
+  DrawHorizontalRuler(minX, maxX, yAxis, kRulerZeroOriginMeters, shortTickMeters,
                       longTickMeters, state.useImperialUnits,
                       state.view);
-  DrawVerticalRuler(minY, maxY, xAxis, yAxis, shortTickMeters,
+  DrawVerticalRuler(minY, maxY, xAxis, kRulerZeroOriginMeters, shortTickMeters,
                     longTickMeters, state.useImperialUnits,
                     state.view);
 
@@ -315,17 +316,19 @@ void EmitRulerToCanvas(const RulerOverlayViewState &state, bool darkMode,
   canvas.DrawLine(yRulerX, minY, yRulerX, maxY, stroke);
 
   const float tickStepMeters = ResolveTickStepMeters(state.useImperialUnits);
-  const float startX = ComputeStartTick(minX, yRulerX, tickStepMeters);
+  const float startX =
+      ComputeStartTick(minX, kRulerZeroOriginMeters, tickStepMeters);
   const auto textStyle = BuildRulerLabelStyle(stroke);
   for (float x = startX; x <= maxX + 0.0001f; x += tickStepMeters) {
-    const auto tickKind = ResolveTickKind(x, yRulerX, state.useImperialUnits);
+    const auto tickKind =
+        ResolveTickKind(x, kRulerZeroOriginMeters, state.useImperialUnits);
     const float tick =
         ResolveTickLengthMeters(tickKind, shortTickMeters, longTickMeters);
     if (tick <= 0.0f)
       continue;
     canvas.DrawLine(x, xRulerY, x, xRulerY + tick, stroke);
     if (tickKind == RulerTickKind::Long) {
-      const float labelOffsetMeters = x - yRulerX;
+      const float labelOffsetMeters = x - kRulerZeroOriginMeters;
       const std::string label =
           state.useImperialUnits ? FormatImperialRulerOffsetLabel(labelOffsetMeters)
                                  : FormatRulerOffsetLabel(labelOffsetMeters);
@@ -334,10 +337,12 @@ void EmitRulerToCanvas(const RulerOverlayViewState &state, bool darkMode,
     }
   }
 
-  const float startY = ComputeStartTick(minY, xRulerY, tickStepMeters);
+  const float startY =
+      ComputeStartTick(minY, kRulerZeroOriginMeters, tickStepMeters);
   const float verticalTickDirection = VerticalTickDirection(state.view);
   for (float y = startY; y <= maxY + 0.0001f; y += tickStepMeters) {
-    const auto tickKind = ResolveTickKind(y, xRulerY, state.useImperialUnits);
+    const auto tickKind =
+        ResolveTickKind(y, kRulerZeroOriginMeters, state.useImperialUnits);
     const float tick =
         ResolveTickLengthMeters(tickKind, shortTickMeters, longTickMeters);
     if (tick <= 0.0f)
@@ -345,7 +350,7 @@ void EmitRulerToCanvas(const RulerOverlayViewState &state, bool darkMode,
     canvas.DrawLine(yRulerX, y, yRulerX + tick * verticalTickDirection, y,
                     stroke);
     if (tickKind == RulerTickKind::Long) {
-      const float labelOffsetMeters = y - xRulerY;
+      const float labelOffsetMeters = y - kRulerZeroOriginMeters;
       const std::string label =
           state.useImperialUnits ? FormatImperialRulerOffsetLabel(labelOffsetMeters)
                                  : FormatRulerOffsetLabel(labelOffsetMeters);
@@ -382,15 +387,17 @@ BuildRulerScreenLabels(const RulerOverlayViewState &state) {
   const float yRulerX = activeRulers.verticalAxisMeters;
 
   const float tickStepMeters = ResolveTickStepMeters(state.useImperialUnits);
-  const float startX = ComputeStartTick(minX, yRulerX, tickStepMeters);
+  const float startX =
+      ComputeStartTick(minX, kRulerZeroOriginMeters, tickStepMeters);
   for (float x = startX; x <= maxX + 0.0001f; x += tickStepMeters) {
-    const auto tickKind = ResolveTickKind(x, yRulerX, state.useImperialUnits);
+    const auto tickKind =
+        ResolveTickKind(x, kRulerZeroOriginMeters, state.useImperialUnits);
     if (tickKind != RulerTickKind::Long)
       continue;
     const float tick =
         ResolveTickLengthMeters(tickKind, shortTickMeters, longTickMeters);
     const float worldY = xRulerY + tick + kRulerLabelOffsetMeters;
-    const float labelOffsetMeters = x - yRulerX;
+    const float labelOffsetMeters = x - kRulerZeroOriginMeters;
     const std::string label =
         state.useImperialUnits ? FormatImperialRulerOffsetLabel(labelOffsetMeters)
                                : FormatRulerOffsetLabel(labelOffsetMeters);
@@ -399,15 +406,17 @@ BuildRulerScreenLabels(const RulerOverlayViewState &state) {
                       label, true, false});
   }
 
-  const float startY = ComputeStartTick(minY, xRulerY, tickStepMeters);
+  const float startY =
+      ComputeStartTick(minY, kRulerZeroOriginMeters, tickStepMeters);
   for (float y = startY; y <= maxY + 0.0001f; y += tickStepMeters) {
-    const auto tickKind = ResolveTickKind(y, xRulerY, state.useImperialUnits);
+    const auto tickKind =
+        ResolveTickKind(y, kRulerZeroOriginMeters, state.useImperialUnits);
     if (tickKind != RulerTickKind::Long)
       continue;
     const float tick =
         ResolveTickLengthMeters(tickKind, shortTickMeters, longTickMeters);
     const float worldX = yRulerX + tick + kRulerLabelOffsetMeters;
-    const float labelOffsetMeters = y - xRulerY;
+    const float labelOffsetMeters = y - kRulerZeroOriginMeters;
     const std::string label =
         state.useImperialUnits ? FormatImperialRulerOffsetLabel(labelOffsetMeters)
                                : FormatRulerOffsetLabel(labelOffsetMeters);

--- a/viewer2d/viewer2d_ruler_overlay.cpp
+++ b/viewer2d/viewer2d_ruler_overlay.cpp
@@ -176,6 +176,15 @@ struct ActiveRulers {
   float verticalAxisMeters = 0.0f;
 };
 
+float ResolveVerticalRulerRenderAxisX(const RulerOverlayViewState &state,
+                                      float verticalAxisMeters) {
+  // Side view uses a mirrored horizontal world direction relative to the
+  // screen-space overlays. Flip only the rendered vertical ruler anchor so its
+  // movement matches the label direction.
+  return state.view == Viewer2DView::Side ? -verticalAxisMeters
+                                          : verticalAxisMeters;
+}
+
 ActiveRulers ResolveActiveRulers(const RulerOverlayViewState &state) {
   switch (state.view) {
   case Viewer2DView::Top:
@@ -256,7 +265,8 @@ void DrawRulerOverlay(const RulerOverlayViewState &state, bool darkMode) {
                shortTickMeters);
   const ActiveRulers activeRulers = ResolveActiveRulers(state);
   const float yAxis = activeRulers.horizontalAxisMeters;
-  const float xAxis = activeRulers.verticalAxisMeters;
+  const float xAxis =
+      ResolveVerticalRulerRenderAxisX(state, activeRulers.verticalAxisMeters);
   const float halfW = static_cast<float>(state.width) * 0.5f / pixelsPerMeter;
   const float halfH = static_cast<float>(state.height) * 0.5f / pixelsPerMeter;
 
@@ -312,8 +322,9 @@ void EmitRulerToCanvas(const RulerOverlayViewState &state, bool darkMode,
 
   const float xRulerY = activeRulers.horizontalAxisMeters;
   const float yRulerX = activeRulers.verticalAxisMeters;
+  const float yRulerRenderX = ResolveVerticalRulerRenderAxisX(state, yRulerX);
   canvas.DrawLine(minX, xRulerY, maxX, xRulerY, stroke);
-  canvas.DrawLine(yRulerX, minY, yRulerX, maxY, stroke);
+  canvas.DrawLine(yRulerRenderX, minY, yRulerRenderX, maxY, stroke);
 
   const float tickStepMeters = ResolveTickStepMeters(state.useImperialUnits);
   const float startX =
@@ -347,8 +358,8 @@ void EmitRulerToCanvas(const RulerOverlayViewState &state, bool darkMode,
         ResolveTickLengthMeters(tickKind, shortTickMeters, longTickMeters);
     if (tick <= 0.0f)
       continue;
-    canvas.DrawLine(yRulerX, y, yRulerX + tick * verticalTickDirection, y,
-                    stroke);
+    canvas.DrawLine(yRulerRenderX, y,
+                    yRulerRenderX + tick * verticalTickDirection, y, stroke);
     if (tickKind == RulerTickKind::Long) {
       const float labelOffsetMeters = y - kRulerZeroOriginMeters;
       const std::string label =


### PR DESCRIPTION
## Summary
- keep each ruler position control independent by using a fixed world-origin (0.0) for ruler tick calculations
- preserve user-configured ruler line positions for visual placement in all 2D views
- update on-screen and export/capture ruler labels so values are measured from axis zero instead of ruler intersection

## Why
The previous behavior coupled tick origins to the opposite ruler line position, so moving one control effectively changed both rulers' zero reference. This made all rulers feel linked. With this change, users can move each ruler line for readability while axis zero remains fixed.

## Validation
- `tests/check_perastage_tree_modules.sh`
- `tests/check_no_configmanager_get_in_gui.sh`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c888d2e4788324b95f3cecdb5b22d8)