### PR TITLE
Add per-fixture 2D label override profiles

### DIFF
--- a/viewer2d/CMakeLists.txt
+++ b/viewer2d/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/viewer2dcommandrenderer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/viewer2doffscreenrenderer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/viewer2d_ruler_overlay.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/fixture_label_overrides.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/viewer2dpanel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/viewer2dpdfexporter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/viewer2drenderpanel.cpp

--- a/viewer2d/fixture_label_overrides.cpp
+++ b/viewer2d/fixture_label_overrides.cpp
@@ -1,0 +1,312 @@
+#include "fixture_label_overrides.h"
+
+#include "json.hpp"
+
+#include <algorithm>
+#include <array>
+#include <type_traits>
+
+namespace viewer2d {
+namespace {
+constexpr const char *kFixtureOverridesKey = "label_fixture_overrides";
+constexpr std::array<const char *, 3> kNameKeys = {"label_show_name_top",
+                                                    "label_show_name_front",
+                                                    "label_show_name_side"};
+constexpr std::array<const char *, 3> kIdKeys = {"label_show_id_top",
+                                                  "label_show_id_front",
+                                                  "label_show_id_side"};
+constexpr std::array<const char *, 3> kDmxKeys = {"label_show_dmx_top",
+                                                   "label_show_dmx_front",
+                                                   "label_show_dmx_side"};
+constexpr std::array<const char *, 3> kDistanceKeys = {
+    "label_offset_distance_top", "label_offset_distance_front",
+    "label_offset_distance_side"};
+constexpr std::array<const char *, 3> kAngleKeys = {"label_offset_angle_top",
+                                                     "label_offset_angle_front",
+                                                     "label_offset_angle_side"};
+
+template <typename T>
+void ReadOptionalArray(const nlohmann::json &obj, const char *key,
+                       std::array<std::optional<T>, 3> &out) {
+  const auto it = obj.find(key);
+  if (it == obj.end() || !it->is_array())
+    return;
+  const auto &arr = *it;
+  for (size_t i = 0; i < out.size() && i < arr.size(); ++i) {
+    const auto &entry = arr[i];
+    if constexpr (std::is_same_v<T, bool>) {
+      if (entry.is_boolean())
+        out[i] = entry.get<bool>();
+    } else {
+      if (entry.is_number())
+        out[i] = entry.get<float>();
+    }
+  }
+}
+
+template <typename T>
+nlohmann::json WriteOptionalArray(const std::array<std::optional<T>, 3> &values) {
+  nlohmann::json arr = nlohmann::json::array();
+  bool anyValue = false;
+  for (const auto &value : values) {
+    if (value.has_value()) {
+      arr.push_back(*value);
+      anyValue = true;
+    } else {
+      arr.push_back(nullptr);
+    }
+  }
+  if (!anyValue)
+    return {};
+  return arr;
+}
+
+template <typename Setter>
+void ApplyToSelection(ConfigManager &cfg,
+                      const std::vector<std::string> &fixtureUuids,
+                      Setter setter) {
+  if (fixtureUuids.empty())
+    return;
+
+  auto overrides = LoadFixtureLabelOverrides(cfg);
+  for (const auto &uuid : fixtureUuids) {
+    if (uuid.empty())
+      continue;
+    setter(overrides[uuid]);
+  }
+  SaveFixtureLabelOverrides(cfg, overrides);
+}
+} // namespace
+
+bool FixtureLabelOverride::HasAnyValue() const {
+  auto hasAnyArrayValue = [](const auto &arr) {
+    return std::any_of(arr.begin(), arr.end(), [](const auto &v) {
+      return v.has_value();
+    });
+  };
+  return hasAnyArrayValue(showLabelName) || hasAnyArrayValue(showLabelId) ||
+         hasAnyArrayValue(showLabelDmx) ||
+         hasAnyArrayValue(labelOffsetDistance) ||
+         hasAnyArrayValue(labelOffsetAngle) || labelFontSizeName.has_value() ||
+         labelFontSizeId.has_value() || labelFontSizeDmx.has_value();
+}
+
+FixtureLabelOverrideMap LoadFixtureLabelOverrides(const ConfigManager &cfg) {
+  FixtureLabelOverrideMap overrides;
+  const auto raw = cfg.GetValue(kFixtureOverridesKey);
+  if (!raw || raw->empty())
+    return overrides;
+
+  const nlohmann::json root = nlohmann::json::parse(*raw, nullptr, false);
+  if (!root.is_object())
+    return overrides;
+
+  for (auto it = root.begin(); it != root.end(); ++it) {
+    if (!it.value().is_object())
+      continue;
+    FixtureLabelOverride entry;
+    ReadOptionalArray<bool>(it.value(), "showLabelName", entry.showLabelName);
+    ReadOptionalArray<bool>(it.value(), "showLabelId", entry.showLabelId);
+    ReadOptionalArray<bool>(it.value(), "showLabelDmx", entry.showLabelDmx);
+    ReadOptionalArray<float>(it.value(), "labelOffsetDistance",
+                             entry.labelOffsetDistance);
+    ReadOptionalArray<float>(it.value(), "labelOffsetAngle",
+                             entry.labelOffsetAngle);
+    if (auto fit = it.value().find("labelFontSizeName");
+        fit != it.value().end() && fit->is_number()) {
+      entry.labelFontSizeName = fit->get<float>();
+    }
+    if (auto fit = it.value().find("labelFontSizeId");
+        fit != it.value().end() && fit->is_number()) {
+      entry.labelFontSizeId = fit->get<float>();
+    }
+    if (auto fit = it.value().find("labelFontSizeDmx");
+        fit != it.value().end() && fit->is_number()) {
+      entry.labelFontSizeDmx = fit->get<float>();
+    }
+    if (entry.HasAnyValue())
+      overrides[it.key()] = entry;
+  }
+  return overrides;
+}
+
+void SaveFixtureLabelOverrides(ConfigManager &cfg,
+                               const FixtureLabelOverrideMap &overrides) {
+  nlohmann::json root = nlohmann::json::object();
+  for (const auto &[uuid, entry] : overrides) {
+    if (!entry.HasAnyValue())
+      continue;
+    nlohmann::json fixtureJson = nlohmann::json::object();
+    if (auto arr = WriteOptionalArray(entry.showLabelName); !arr.is_null())
+      fixtureJson["showLabelName"] = arr;
+    if (auto arr = WriteOptionalArray(entry.showLabelId); !arr.is_null())
+      fixtureJson["showLabelId"] = arr;
+    if (auto arr = WriteOptionalArray(entry.showLabelDmx); !arr.is_null())
+      fixtureJson["showLabelDmx"] = arr;
+    if (auto arr = WriteOptionalArray(entry.labelOffsetDistance); !arr.is_null())
+      fixtureJson["labelOffsetDistance"] = arr;
+    if (auto arr = WriteOptionalArray(entry.labelOffsetAngle); !arr.is_null())
+      fixtureJson["labelOffsetAngle"] = arr;
+    if (entry.labelFontSizeName.has_value())
+      fixtureJson["labelFontSizeName"] = *entry.labelFontSizeName;
+    if (entry.labelFontSizeId.has_value())
+      fixtureJson["labelFontSizeId"] = *entry.labelFontSizeId;
+    if (entry.labelFontSizeDmx.has_value())
+      fixtureJson["labelFontSizeDmx"] = *entry.labelFontSizeDmx;
+    if (!fixtureJson.empty())
+      root[uuid] = std::move(fixtureJson);
+  }
+
+  if (root.empty()) {
+    cfg.RemoveKey(kFixtureOverridesKey);
+    return;
+  }
+  cfg.SetValue(kFixtureOverridesKey, root.dump());
+}
+
+float ResolveLabelFontSizeName(const ConfigManager &cfg,
+                               const FixtureLabelOverride *overrideSettings) {
+  if (overrideSettings && overrideSettings->labelFontSizeName.has_value())
+    return *overrideSettings->labelFontSizeName;
+  return cfg.GetFloat("label_font_size_name");
+}
+
+float ResolveLabelFontSizeId(const ConfigManager &cfg,
+                             const FixtureLabelOverride *overrideSettings) {
+  if (overrideSettings && overrideSettings->labelFontSizeId.has_value())
+    return *overrideSettings->labelFontSizeId;
+  return cfg.GetFloat("label_font_size_id");
+}
+
+float ResolveLabelFontSizeDmx(const ConfigManager &cfg,
+                              const FixtureLabelOverride *overrideSettings) {
+  if (overrideSettings && overrideSettings->labelFontSizeDmx.has_value())
+    return *overrideSettings->labelFontSizeDmx;
+  return cfg.GetFloat("label_font_size_dmx");
+}
+
+bool ResolveShowLabelName(const ConfigManager &cfg,
+                          const FixtureLabelOverride *overrideSettings,
+                          int viewIndex) {
+  const int clampedView = std::clamp(viewIndex, 0, 2);
+  if (overrideSettings && overrideSettings->showLabelName[clampedView].has_value())
+    return *overrideSettings->showLabelName[clampedView];
+  return cfg.GetFloat(kNameKeys[clampedView]) != 0.0f;
+}
+
+bool ResolveShowLabelId(const ConfigManager &cfg,
+                        const FixtureLabelOverride *overrideSettings,
+                        int viewIndex) {
+  const int clampedView = std::clamp(viewIndex, 0, 2);
+  if (overrideSettings && overrideSettings->showLabelId[clampedView].has_value())
+    return *overrideSettings->showLabelId[clampedView];
+  return cfg.GetFloat(kIdKeys[clampedView]) != 0.0f;
+}
+
+bool ResolveShowLabelDmx(const ConfigManager &cfg,
+                         const FixtureLabelOverride *overrideSettings,
+                         int viewIndex) {
+  const int clampedView = std::clamp(viewIndex, 0, 2);
+  if (overrideSettings && overrideSettings->showLabelDmx[clampedView].has_value())
+    return *overrideSettings->showLabelDmx[clampedView];
+  return cfg.GetFloat(kDmxKeys[clampedView]) != 0.0f;
+}
+
+float ResolveLabelOffsetDistance(const ConfigManager &cfg,
+                                 const FixtureLabelOverride *overrideSettings,
+                                 int viewIndex) {
+  const int clampedView = std::clamp(viewIndex, 0, 2);
+  if (overrideSettings &&
+      overrideSettings->labelOffsetDistance[clampedView].has_value()) {
+    return *overrideSettings->labelOffsetDistance[clampedView];
+  }
+  return cfg.GetFloat(kDistanceKeys[clampedView]);
+}
+
+float ResolveLabelOffsetAngle(const ConfigManager &cfg,
+                              const FixtureLabelOverride *overrideSettings,
+                              int viewIndex) {
+  const int clampedView = std::clamp(viewIndex, 0, 2);
+  if (overrideSettings && overrideSettings->labelOffsetAngle[clampedView].has_value())
+    return *overrideSettings->labelOffsetAngle[clampedView];
+  return cfg.GetFloat(kAngleKeys[clampedView]);
+}
+
+void ApplyShowLabelNameOverride(ConfigManager &cfg,
+                                const std::vector<std::string> &fixtureUuids,
+                                int viewIndex, bool value) {
+  const int clampedView = std::clamp(viewIndex, 0, 2);
+  ApplyToSelection(cfg, fixtureUuids,
+                   [clampedView, value](FixtureLabelOverride &entry) {
+                     entry.showLabelName[clampedView] = value;
+                   });
+}
+
+void ApplyShowLabelIdOverride(ConfigManager &cfg,
+                              const std::vector<std::string> &fixtureUuids,
+                              int viewIndex, bool value) {
+  const int clampedView = std::clamp(viewIndex, 0, 2);
+  ApplyToSelection(cfg, fixtureUuids,
+                   [clampedView, value](FixtureLabelOverride &entry) {
+                     entry.showLabelId[clampedView] = value;
+                   });
+}
+
+void ApplyShowLabelDmxOverride(ConfigManager &cfg,
+                               const std::vector<std::string> &fixtureUuids,
+                               int viewIndex, bool value) {
+  const int clampedView = std::clamp(viewIndex, 0, 2);
+  ApplyToSelection(cfg, fixtureUuids,
+                   [clampedView, value](FixtureLabelOverride &entry) {
+                     entry.showLabelDmx[clampedView] = value;
+                   });
+}
+
+void ApplyLabelOffsetDistanceOverride(
+    ConfigManager &cfg, const std::vector<std::string> &fixtureUuids,
+    int viewIndex, float value) {
+  const int clampedView = std::clamp(viewIndex, 0, 2);
+  ApplyToSelection(cfg, fixtureUuids,
+                   [clampedView, value](FixtureLabelOverride &entry) {
+                     entry.labelOffsetDistance[clampedView] = value;
+                   });
+}
+
+void ApplyLabelOffsetAngleOverride(ConfigManager &cfg,
+                                   const std::vector<std::string> &fixtureUuids,
+                                   int viewIndex, float value) {
+  const int clampedView = std::clamp(viewIndex, 0, 2);
+  ApplyToSelection(cfg, fixtureUuids,
+                   [clampedView, value](FixtureLabelOverride &entry) {
+                     entry.labelOffsetAngle[clampedView] = value;
+                   });
+}
+
+void ApplyLabelFontSizeNameOverride(ConfigManager &cfg,
+                                    const std::vector<std::string> &fixtureUuids,
+                                    float value) {
+  ApplyToSelection(cfg, fixtureUuids,
+                   [value](FixtureLabelOverride &entry) {
+                     entry.labelFontSizeName = value;
+                   });
+}
+
+void ApplyLabelFontSizeIdOverride(ConfigManager &cfg,
+                                  const std::vector<std::string> &fixtureUuids,
+                                  float value) {
+  ApplyToSelection(cfg, fixtureUuids,
+                   [value](FixtureLabelOverride &entry) {
+                     entry.labelFontSizeId = value;
+                   });
+}
+
+void ApplyLabelFontSizeDmxOverride(ConfigManager &cfg,
+                                   const std::vector<std::string> &fixtureUuids,
+                                   float value) {
+  ApplyToSelection(cfg, fixtureUuids,
+                   [value](FixtureLabelOverride &entry) {
+                     entry.labelFontSizeDmx = value;
+                   });
+}
+
+} // namespace viewer2d

--- a/viewer2d/fixture_label_overrides.h
+++ b/viewer2d/fixture_label_overrides.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include "configmanager.h"
+
+#include <array>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace viewer2d {
+
+struct FixtureLabelOverride {
+  std::array<std::optional<bool>, 3> showLabelName;
+  std::array<std::optional<bool>, 3> showLabelId;
+  std::array<std::optional<bool>, 3> showLabelDmx;
+  std::array<std::optional<float>, 3> labelOffsetDistance;
+  std::array<std::optional<float>, 3> labelOffsetAngle;
+  std::optional<float> labelFontSizeName;
+  std::optional<float> labelFontSizeId;
+  std::optional<float> labelFontSizeDmx;
+
+  bool HasAnyValue() const;
+};
+
+using FixtureLabelOverrideMap =
+    std::unordered_map<std::string, FixtureLabelOverride>;
+
+FixtureLabelOverrideMap LoadFixtureLabelOverrides(const ConfigManager &cfg);
+void SaveFixtureLabelOverrides(ConfigManager &cfg,
+                               const FixtureLabelOverrideMap &overrides);
+
+float ResolveLabelFontSizeName(const ConfigManager &cfg,
+                               const FixtureLabelOverride *overrideSettings);
+float ResolveLabelFontSizeId(const ConfigManager &cfg,
+                             const FixtureLabelOverride *overrideSettings);
+float ResolveLabelFontSizeDmx(const ConfigManager &cfg,
+                              const FixtureLabelOverride *overrideSettings);
+
+bool ResolveShowLabelName(const ConfigManager &cfg,
+                          const FixtureLabelOverride *overrideSettings,
+                          int viewIndex);
+bool ResolveShowLabelId(const ConfigManager &cfg,
+                        const FixtureLabelOverride *overrideSettings,
+                        int viewIndex);
+bool ResolveShowLabelDmx(const ConfigManager &cfg,
+                         const FixtureLabelOverride *overrideSettings,
+                         int viewIndex);
+float ResolveLabelOffsetDistance(const ConfigManager &cfg,
+                                 const FixtureLabelOverride *overrideSettings,
+                                 int viewIndex);
+float ResolveLabelOffsetAngle(const ConfigManager &cfg,
+                              const FixtureLabelOverride *overrideSettings,
+                              int viewIndex);
+
+void ApplyShowLabelNameOverride(ConfigManager &cfg,
+                                const std::vector<std::string> &fixtureUuids,
+                                int viewIndex, bool value);
+void ApplyShowLabelIdOverride(ConfigManager &cfg,
+                              const std::vector<std::string> &fixtureUuids,
+                              int viewIndex, bool value);
+void ApplyShowLabelDmxOverride(ConfigManager &cfg,
+                               const std::vector<std::string> &fixtureUuids,
+                               int viewIndex, bool value);
+void ApplyLabelOffsetDistanceOverride(
+    ConfigManager &cfg, const std::vector<std::string> &fixtureUuids,
+    int viewIndex, float value);
+void ApplyLabelOffsetAngleOverride(ConfigManager &cfg,
+                                   const std::vector<std::string> &fixtureUuids,
+                                   int viewIndex, float value);
+void ApplyLabelFontSizeNameOverride(ConfigManager &cfg,
+                                    const std::vector<std::string> &fixtureUuids,
+                                    float value);
+void ApplyLabelFontSizeIdOverride(ConfigManager &cfg,
+                                  const std::vector<std::string> &fixtureUuids,
+                                  float value);
+void ApplyLabelFontSizeDmxOverride(ConfigManager &cfg,
+                                   const std::vector<std::string> &fixtureUuids,
+                                   float value);
+
+} // namespace viewer2d

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -52,6 +52,7 @@
 #include "trusstablepanel.h"
 #include "viewer3dpanel.h"
 #include "viewer2d_support_selection.h"
+#include "viewer2drenderpanel.h"
 #include "viewer2d_ruler_overlay.h"
 #include "viewer2dviewfit.h"
 #include "units/units.h"
@@ -245,6 +246,8 @@ void ApplyFixtureSelectionToUi(const std::vector<std::string> &selection,
   if (selection != cfg.GetSelectedFixtures()) {
     cfg.PushUndoState("fixture selection");
     cfg.SetSelectedFixtures(selection);
+    if (Viewer2DRenderPanel::Instance())
+      Viewer2DRenderPanel::Instance()->RefreshLabelControlsFromSelection();
   }
   controller.SetSelectedUuids(selection);
   if (FixtureTablePanel::Instance()) {
@@ -1123,6 +1126,8 @@ void Viewer2DPanel::ApplyRectangleSelection(const wxPoint &start,
     if (selection != cfg.GetSelectedFixtures()) {
       cfg.PushUndoState("fixture selection");
       cfg.SetSelectedFixtures(selection);
+      if (Viewer2DRenderPanel::Instance())
+        Viewer2DRenderPanel::Instance()->RefreshLabelControlsFromSelection();
     }
     m_controller.SetSelectedUuids(selection);
     if (selection.empty())
@@ -1640,6 +1645,8 @@ void Viewer2DPanel::OnMouseUp(wxMouseEvent &event) {
         if (selection != cfg.GetSelectedFixtures()) {
           cfg.PushUndoState("fixture selection");
           cfg.SetSelectedFixtures(selection);
+          if (Viewer2DRenderPanel::Instance())
+            Viewer2DRenderPanel::Instance()->RefreshLabelControlsFromSelection();
         }
         m_controller.SetSelectedUuids(selection);
         FixtureTablePanel::Instance()->SelectByUuid(selection);
@@ -1707,6 +1714,8 @@ void Viewer2DPanel::OnMouseUp(wxMouseEvent &event) {
         if (!cfg.GetSelectedFixtures().empty()) {
           cfg.PushUndoState("fixture selection");
           cfg.SetSelectedFixtures({});
+          if (Viewer2DRenderPanel::Instance())
+            Viewer2DRenderPanel::Instance()->RefreshLabelControlsFromSelection();
         }
         m_controller.SetSelectedUuids({});
         FixtureTablePanel::Instance()->ClearSelection();

--- a/viewer2d/viewer2drenderpanel.cpp
+++ b/viewer2d/viewer2drenderpanel.cpp
@@ -18,9 +18,11 @@
 #include "viewer2drenderpanel.h"
 
 #include "configmanager.h"
+#include "fixture_label_overrides.h"
 #include "mainwindow.h"
 #include <algorithm>
 #include <array>
+#include <wx/settings.h>
 
 namespace {
 const std::array<const char *, 3> DIST_KEYS = {"label_offset_distance_top",
@@ -158,6 +160,8 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
 
   auto *labelBox = new wxStaticBoxSizer(wxVERTICAL, this, "Labels");
   wxWindow *labelBoxParent = labelBox->GetStaticBox();
+  m_labelScopeHint =
+      new wxStaticText(labelBoxParent, wxID_ANY, "Global profile (all fixtures)");
 
   m_showLabelName = new wxCheckBox(labelBoxParent, wxID_ANY, "Show name");
   m_showLabelName->SetValue(
@@ -293,6 +297,9 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
   rulerBox->Add(rulerAxisZSizer, 0, wxALL, 5);
   sizer->Add(rulerBox, 0, wxALL, 5);
 
+  labelBox->Add(m_labelScopeHint, 0, wxLEFT | wxRIGHT | wxTOP, 5);
+  labelBox->AddSpacer(2);
+
   auto *nameSizer = new wxBoxSizer(wxHORIZONTAL);
   nameSizer->Add(m_showLabelName, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
   nameSizer->Add(new wxStaticText(labelBoxParent, wxID_ANY, "Size"), 0,
@@ -350,6 +357,61 @@ void Viewer2DRenderPanel::SetViewSelection(Viewer2DView view) {
   ApplyViewSelection(static_cast<int>(view));
 }
 
+bool Viewer2DRenderPanel::HasFixtureSelection() const {
+  return !ConfigManager::Get().GetSelectedFixtures().empty();
+}
+
+void Viewer2DRenderPanel::RefreshLabelScopeHint() {
+  if (!m_labelScopeHint)
+    return;
+
+  if (HasFixtureSelection()) {
+    const size_t count = ConfigManager::Get().GetSelectedFixtures().size();
+    m_labelScopeHint->SetLabel(
+        wxString::Format("Selection profile active (%zu fixtures)", count));
+    m_labelScopeHint->SetForegroundColour(wxColour(0, 180, 200));
+  } else {
+    m_labelScopeHint->SetLabel("Global profile (all fixtures)");
+    m_labelScopeHint->SetForegroundColour(
+        wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
+  }
+}
+
+void Viewer2DRenderPanel::ApplyLabelControlValuesForCurrentSelection() {
+  ConfigManager &cfg = ConfigManager::Get();
+  const int viewIndex = std::clamp(m_view->GetSelection(), 0, 2);
+  const auto selectedFixtures = cfg.GetSelectedFixtures();
+  const auto overrides = viewer2d::LoadFixtureLabelOverrides(cfg);
+
+  const viewer2d::FixtureLabelOverride *settings = nullptr;
+  if (!selectedFixtures.empty()) {
+    auto it = overrides.find(selectedFixtures.front());
+    if (it != overrides.end())
+      settings = &it->second;
+  }
+
+  m_showLabelName->SetValue(
+      viewer2d::ResolveShowLabelName(cfg, settings, viewIndex));
+  m_showLabelId->SetValue(viewer2d::ResolveShowLabelId(cfg, settings, viewIndex));
+  m_showLabelAddress->SetValue(
+      viewer2d::ResolveShowLabelDmx(cfg, settings, viewIndex));
+  m_labelOffsetDistance->SetValue(
+      viewer2d::ResolveLabelOffsetDistance(cfg, settings, viewIndex));
+  m_labelOffsetAngle->SetValue(static_cast<int>(
+      viewer2d::ResolveLabelOffsetAngle(cfg, settings, viewIndex)));
+  m_labelNameSize->SetValue(static_cast<int>(
+      viewer2d::ResolveLabelFontSizeName(cfg, settings)));
+  m_labelIdSize->SetValue(
+      static_cast<int>(viewer2d::ResolveLabelFontSizeId(cfg, settings)));
+  m_labelAddressSize->SetValue(static_cast<int>(
+      viewer2d::ResolveLabelFontSizeDmx(cfg, settings)));
+}
+
+void Viewer2DRenderPanel::RefreshLabelControlsFromSelection() {
+  ApplyLabelControlValuesForCurrentSelection();
+  RefreshLabelScopeHint();
+}
+
 void Viewer2DRenderPanel::ApplyConfig() {
   ConfigManager &cfg = ConfigManager::Get();
   m_radio->SetSelection(static_cast<int>(cfg.GetFloat("view2d_render_mode")));
@@ -369,18 +431,7 @@ void Viewer2DRenderPanel::ApplyConfig() {
   m_rulerAxisYPosition->SetValue(cfg.GetFloat("ruler_axis_y_position"));
   m_rulerAxisZPosition->SetValue(cfg.GetFloat("ruler_axis_z_position"));
   UpdateRulerControlState();
-  int viewIndex = m_view->GetSelection();
-  m_showLabelName->SetValue(cfg.GetFloat(NAME_KEYS[viewIndex]) != 0.0f);
-  m_labelNameSize->SetValue(
-      static_cast<int>(cfg.GetFloat("label_font_size_name")));
-  m_showLabelId->SetValue(cfg.GetFloat(ID_KEYS[viewIndex]) != 0.0f);
-  m_labelIdSize->SetValue(static_cast<int>(cfg.GetFloat("label_font_size_id")));
-  m_showLabelAddress->SetValue(cfg.GetFloat(DMX_KEYS[viewIndex]) != 0.0f);
-  m_labelAddressSize->SetValue(
-      static_cast<int>(cfg.GetFloat("label_font_size_dmx")));
-  m_labelOffsetDistance->SetValue(cfg.GetFloat(DIST_KEYS[viewIndex]));
-  m_labelOffsetAngle->SetValue(
-      static_cast<int>(cfg.GetFloat(ANGLE_KEYS[viewIndex])));
+  RefreshLabelControlsFromSelection();
   if (auto *vp = Viewer2DPanel::Instance()) {
     vp->SetRenderMode(static_cast<Viewer2DRenderMode>(m_radio->GetSelection()));
     vp->SetView(static_cast<Viewer2DView>(m_view->GetSelection()));
@@ -489,8 +540,13 @@ void Viewer2DRenderPanel::OnRulerAxisZPosition(wxSpinDoubleEvent &evt) {
 
 void Viewer2DRenderPanel::OnShowLabelName(wxCommandEvent &evt) {
   int view = m_view->GetSelection();
-  ConfigManager::Get().SetFloat(NAME_KEYS[view],
-                                m_showLabelName->GetValue() ? 1.0f : 0.0f);
+  ConfigManager &cfg = ConfigManager::Get();
+  if (HasFixtureSelection()) {
+    viewer2d::ApplyShowLabelNameOverride(cfg, cfg.GetSelectedFixtures(), view,
+                                         m_showLabelName->GetValue());
+  } else {
+    cfg.SetFloat(NAME_KEYS[view], m_showLabelName->GetValue() ? 1.0f : 0.0f);
+  }
   if (auto *vp = Viewer2DPanel::Instance())
     vp->UpdateScene(false);
   evt.Skip();
@@ -498,8 +554,13 @@ void Viewer2DRenderPanel::OnShowLabelName(wxCommandEvent &evt) {
 
 void Viewer2DRenderPanel::OnShowLabelId(wxCommandEvent &evt) {
   int view = m_view->GetSelection();
-  ConfigManager::Get().SetFloat(ID_KEYS[view],
-                                m_showLabelId->GetValue() ? 1.0f : 0.0f);
+  ConfigManager &cfg = ConfigManager::Get();
+  if (HasFixtureSelection()) {
+    viewer2d::ApplyShowLabelIdOverride(cfg, cfg.GetSelectedFixtures(), view,
+                                       m_showLabelId->GetValue());
+  } else {
+    cfg.SetFloat(ID_KEYS[view], m_showLabelId->GetValue() ? 1.0f : 0.0f);
+  }
   if (auto *vp = Viewer2DPanel::Instance())
     vp->UpdateScene(false);
   evt.Skip();
@@ -507,33 +568,58 @@ void Viewer2DRenderPanel::OnShowLabelId(wxCommandEvent &evt) {
 
 void Viewer2DRenderPanel::OnShowLabelAddress(wxCommandEvent &evt) {
   int view = m_view->GetSelection();
-  ConfigManager::Get().SetFloat(
-      DMX_KEYS[view], m_showLabelAddress->GetValue() ? 1.0f : 0.0f);
+  ConfigManager &cfg = ConfigManager::Get();
+  if (HasFixtureSelection()) {
+    viewer2d::ApplyShowLabelDmxOverride(cfg, cfg.GetSelectedFixtures(), view,
+                                        m_showLabelAddress->GetValue());
+  } else {
+    cfg.SetFloat(DMX_KEYS[view], m_showLabelAddress->GetValue() ? 1.0f : 0.0f);
+  }
   if (auto *vp = Viewer2DPanel::Instance())
     vp->UpdateScene(false);
   evt.Skip();
 }
 
 void Viewer2DRenderPanel::OnLabelNameSize(wxSpinEvent &evt) {
-  ConfigManager::Get().SetFloat(
-      "label_font_size_name", static_cast<float>(m_labelNameSize->GetValue()));
+  ConfigManager &cfg = ConfigManager::Get();
+  if (HasFixtureSelection()) {
+    viewer2d::ApplyLabelFontSizeNameOverride(
+        cfg, cfg.GetSelectedFixtures(),
+        static_cast<float>(m_labelNameSize->GetValue()));
+  } else {
+    cfg.SetFloat("label_font_size_name",
+                 static_cast<float>(m_labelNameSize->GetValue()));
+  }
   if (auto *vp = Viewer2DPanel::Instance())
     vp->UpdateScene(false);
   evt.Skip();
 }
 
 void Viewer2DRenderPanel::OnLabelIdSize(wxSpinEvent &evt) {
-  ConfigManager::Get().SetFloat("label_font_size_id",
-                                static_cast<float>(m_labelIdSize->GetValue()));
+  ConfigManager &cfg = ConfigManager::Get();
+  if (HasFixtureSelection()) {
+    viewer2d::ApplyLabelFontSizeIdOverride(
+        cfg, cfg.GetSelectedFixtures(),
+        static_cast<float>(m_labelIdSize->GetValue()));
+  } else {
+    cfg.SetFloat("label_font_size_id",
+                 static_cast<float>(m_labelIdSize->GetValue()));
+  }
   if (auto *vp = Viewer2DPanel::Instance())
     vp->UpdateScene(false);
   evt.Skip();
 }
 
 void Viewer2DRenderPanel::OnLabelAddressSize(wxSpinEvent &evt) {
-  ConfigManager::Get().SetFloat(
-      "label_font_size_dmx",
-      static_cast<float>(m_labelAddressSize->GetValue()));
+  ConfigManager &cfg = ConfigManager::Get();
+  if (HasFixtureSelection()) {
+    viewer2d::ApplyLabelFontSizeDmxOverride(
+        cfg, cfg.GetSelectedFixtures(),
+        static_cast<float>(m_labelAddressSize->GetValue()));
+  } else {
+    cfg.SetFloat("label_font_size_dmx",
+                 static_cast<float>(m_labelAddressSize->GetValue()));
+  }
   if (auto *vp = Viewer2DPanel::Instance())
     vp->UpdateScene(false);
   evt.Skip();
@@ -541,8 +627,15 @@ void Viewer2DRenderPanel::OnLabelAddressSize(wxSpinEvent &evt) {
 
 void Viewer2DRenderPanel::OnLabelOffsetDistance(wxSpinDoubleEvent &evt) {
   int view = m_view->GetSelection();
-  ConfigManager::Get().SetFloat(
-      DIST_KEYS[view], static_cast<float>(m_labelOffsetDistance->GetValue()));
+  ConfigManager &cfg = ConfigManager::Get();
+  if (HasFixtureSelection()) {
+    viewer2d::ApplyLabelOffsetDistanceOverride(
+        cfg, cfg.GetSelectedFixtures(), view,
+        static_cast<float>(m_labelOffsetDistance->GetValue()));
+  } else {
+    cfg.SetFloat(DIST_KEYS[view],
+                 static_cast<float>(m_labelOffsetDistance->GetValue()));
+  }
   if (auto *vp = Viewer2DPanel::Instance())
     vp->UpdateScene(false);
   evt.Skip();
@@ -550,8 +643,15 @@ void Viewer2DRenderPanel::OnLabelOffsetDistance(wxSpinDoubleEvent &evt) {
 
 void Viewer2DRenderPanel::OnLabelOffsetAngle(wxSpinEvent &evt) {
   int view = m_view->GetSelection();
-  ConfigManager::Get().SetFloat(
-      ANGLE_KEYS[view], static_cast<float>(m_labelOffsetAngle->GetValue()));
+  ConfigManager &cfg = ConfigManager::Get();
+  if (HasFixtureSelection()) {
+    viewer2d::ApplyLabelOffsetAngleOverride(
+        cfg, cfg.GetSelectedFixtures(), view,
+        static_cast<float>(m_labelOffsetAngle->GetValue()));
+  } else {
+    cfg.SetFloat(ANGLE_KEYS[view],
+                 static_cast<float>(m_labelOffsetAngle->GetValue()));
+  }
   if (auto *vp = Viewer2DPanel::Instance())
     vp->UpdateScene(false);
   evt.Skip();
@@ -569,11 +669,7 @@ void Viewer2DRenderPanel::ApplyViewSelection(int selection) {
   const int sel = std::clamp(selection, 0, static_cast<int>(DIST_KEYS.size()) - 1);
   m_view->SetSelection(sel);
   cfg.SetFloat("view2d_view", static_cast<float>(sel));
-  m_labelOffsetDistance->SetValue(cfg.GetFloat(DIST_KEYS[sel]));
-  m_labelOffsetAngle->SetValue(static_cast<int>(cfg.GetFloat(ANGLE_KEYS[sel])));
-  m_showLabelName->SetValue(cfg.GetFloat(NAME_KEYS[sel]) != 0.0f);
-  m_showLabelId->SetValue(cfg.GetFloat(ID_KEYS[sel]) != 0.0f);
-  m_showLabelAddress->SetValue(cfg.GetFloat(DMX_KEYS[sel]) != 0.0f);
+  RefreshLabelControlsFromSelection();
   UpdateRulerControlState();
   if (auto *vp = Viewer2DPanel::Instance()) {
     vp->SetView(static_cast<Viewer2DView>(sel));
@@ -618,22 +714,52 @@ void Viewer2DRenderPanel::OnTextChange(wxCommandEvent &evt) {
 void Viewer2DRenderPanel::OnTextEnter(wxCommandEvent &evt) {
   ConfigManager &cfg = ConfigManager::Get();
   if (evt.GetEventObject() == m_labelNameSize) {
-    cfg.SetFloat("label_font_size_name",
-                 static_cast<float>(m_labelNameSize->GetValue()));
+    if (HasFixtureSelection()) {
+      viewer2d::ApplyLabelFontSizeNameOverride(
+          cfg, cfg.GetSelectedFixtures(),
+          static_cast<float>(m_labelNameSize->GetValue()));
+    } else {
+      cfg.SetFloat("label_font_size_name",
+                   static_cast<float>(m_labelNameSize->GetValue()));
+    }
   } else if (evt.GetEventObject() == m_labelIdSize) {
-    cfg.SetFloat("label_font_size_id",
-                 static_cast<float>(m_labelIdSize->GetValue()));
+    if (HasFixtureSelection()) {
+      viewer2d::ApplyLabelFontSizeIdOverride(
+          cfg, cfg.GetSelectedFixtures(),
+          static_cast<float>(m_labelIdSize->GetValue()));
+    } else {
+      cfg.SetFloat("label_font_size_id",
+                   static_cast<float>(m_labelIdSize->GetValue()));
+    }
   } else if (evt.GetEventObject() == m_labelAddressSize) {
-    cfg.SetFloat("label_font_size_dmx",
-                 static_cast<float>(m_labelAddressSize->GetValue()));
+    if (HasFixtureSelection()) {
+      viewer2d::ApplyLabelFontSizeDmxOverride(
+          cfg, cfg.GetSelectedFixtures(),
+          static_cast<float>(m_labelAddressSize->GetValue()));
+    } else {
+      cfg.SetFloat("label_font_size_dmx",
+                   static_cast<float>(m_labelAddressSize->GetValue()));
+    }
   } else if (evt.GetEventObject() == m_labelOffsetDistance) {
     int view = m_view->GetSelection();
-    cfg.SetFloat(DIST_KEYS[view],
-                 static_cast<float>(m_labelOffsetDistance->GetValue()));
+    if (HasFixtureSelection()) {
+      viewer2d::ApplyLabelOffsetDistanceOverride(
+          cfg, cfg.GetSelectedFixtures(), view,
+          static_cast<float>(m_labelOffsetDistance->GetValue()));
+    } else {
+      cfg.SetFloat(DIST_KEYS[view],
+                   static_cast<float>(m_labelOffsetDistance->GetValue()));
+    }
   } else if (evt.GetEventObject() == m_labelOffsetAngle) {
     int view = m_view->GetSelection();
-    cfg.SetFloat(ANGLE_KEYS[view],
-                 static_cast<float>(m_labelOffsetAngle->GetValue()));
+    if (HasFixtureSelection()) {
+      viewer2d::ApplyLabelOffsetAngleOverride(
+          cfg, cfg.GetSelectedFixtures(), view,
+          static_cast<float>(m_labelOffsetAngle->GetValue()));
+    } else {
+      cfg.SetFloat(ANGLE_KEYS[view],
+                   static_cast<float>(m_labelOffsetAngle->GetValue()));
+    }
   } else if (evt.GetEventObject() == m_rulerAxisXPosition) {
     cfg.SetFloat("ruler_axis_x_position",
                  static_cast<float>(m_rulerAxisXPosition->GetValue()));

--- a/viewer2d/viewer2drenderpanel.h
+++ b/viewer2d/viewer2drenderpanel.h
@@ -30,6 +30,7 @@ public:
 
   void ApplyConfig();
   void SetViewSelection(Viewer2DView view);
+  void RefreshLabelControlsFromSelection();
 
   static Viewer2DRenderPanel *Instance();
   static void SetInstance(Viewer2DRenderPanel *p);
@@ -60,6 +61,9 @@ private:
   void OnTextChange(wxCommandEvent &evt);
   void OnTextEnter(wxCommandEvent &evt);
   void ApplyViewSelection(int selection);
+  void ApplyLabelControlValuesForCurrentSelection();
+  void RefreshLabelScopeHint();
+  bool HasFixtureSelection() const;
   void UpdateRulerControlState();
 
   wxRadioBox *m_radio = nullptr;
@@ -82,5 +86,6 @@ private:
   wxSpinCtrl *m_labelAddressSize = nullptr;
   wxSpinCtrlDouble *m_labelOffsetDistance = nullptr;
   wxSpinCtrl *m_labelOffsetAngle = nullptr;
+  wxStaticText *m_labelScopeHint = nullptr;
   static Viewer2DRenderPanel *s_instance;
 };

--- a/viewer3d/labels/label_render_system.cpp
+++ b/viewer3d/labels/label_render_system.cpp
@@ -18,6 +18,7 @@
 #endif
 
 #include "configmanager.h"
+#include "fixture_label_overrides.h"
 #include "logger.h"
 #include "scenedatamanager.h"
 #include "support.h"
@@ -481,52 +482,8 @@ void LabelRenderSystem::DrawAllFixtureLabels(int width, int height,
   FillProjectionContext(width, height, projection);
 
   const auto hiddenLayers = SnapshotHiddenLayers(cfg);
-  const std::array<const char *, 4> nameKeys = {
-      "label_show_name_top", "label_show_name_front", "label_show_name_side",
-      "label_show_name_top"};
-  const std::array<const char *, 4> idKeys = {
-      "label_show_id_top", "label_show_id_front", "label_show_id_side",
-      "label_show_id_top"};
-  const std::array<const char *, 4> dmxKeys = {
-      "label_show_dmx_top", "label_show_dmx_front", "label_show_dmx_side",
-      "label_show_dmx_top"};
-  const std::array<const char *, 4> distKeys = {
-      "label_offset_distance_top", "label_offset_distance_front",
-      "label_offset_distance_side", "label_offset_distance_top"};
-  const std::array<const char *, 4> angleKeys = {
-      "label_offset_angle_top", "label_offset_angle_front",
-      "label_offset_angle_side", "label_offset_angle_top"};
-
-  int viewIdx = static_cast<int>(view);
-  const bool showName = cfg.GetFloat(nameKeys[viewIdx]) != 0.0f;
-  const bool showId = cfg.GetFloat(idKeys[viewIdx]) != 0.0f;
-  const bool showDmx = cfg.GetFloat(dmxKeys[viewIdx]) != 0.0f;
-  const float nameSize = cfg.GetFloat("label_font_size_name") * zoom;
-  const float idSize = cfg.GetFloat("label_font_size_id") * zoom;
-  const float dmxSize = cfg.GetFloat("label_font_size_dmx") * zoom;
-  const float labelDist = cfg.GetFloat(distKeys[viewIdx]);
-  const float labelAngle = cfg.GetFloat(angleKeys[viewIdx]);
-
-  constexpr float deg2rad = 3.14159265358979323846f / 180.0f;
-  const float angRad = labelAngle * deg2rad;
-  float offX = 0.0f;
-  float offY = 0.0f;
-  float offZ = 0.0f;
-  switch (view) {
-  case Viewer2DView::Top:
-  case Viewer2DView::Bottom:
-    offX = labelDist * std::sin(angRad);
-    offY = labelDist * std::cos(angRad);
-    break;
-  case Viewer2DView::Front:
-    offX = labelDist * std::sin(angRad);
-    offZ = labelDist * std::cos(angRad);
-    break;
-  case Viewer2DView::Side:
-    offY = -labelDist * std::sin(angRad);
-    offZ = labelDist * std::cos(angRad);
-    break;
-  }
+  const int viewIdx = static_cast<int>(view);
+  const auto fixtureOverrides = viewer2d::LoadFixtureLabelOverrides(cfg);
 
   const CullingSettings culling = GetCullingSettings(cfg);
   const float minLabelPixels = culling.minPixels2D;
@@ -578,6 +535,50 @@ void LabelRenderSystem::DrawAllFixtureLabels(int width, int height,
   for (const auto &candidate : candidates) {
     const std::string &uuid = *candidate.uuid;
     const Fixture &f = *candidate.fixture;
+    const viewer2d::FixtureLabelOverride *overrideSettings = nullptr;
+    if (auto oit = fixtureOverrides.find(uuid); oit != fixtureOverrides.end())
+      overrideSettings = &oit->second;
+
+    const bool showName =
+        viewer2d::ResolveShowLabelName(cfg, overrideSettings, viewIdx);
+    const bool showId =
+        viewer2d::ResolveShowLabelId(cfg, overrideSettings, viewIdx);
+    const bool showDmx =
+        viewer2d::ResolveShowLabelDmx(cfg, overrideSettings, viewIdx);
+    if (!showName && !showId && !showDmx)
+      continue;
+
+    const float nameSize =
+        viewer2d::ResolveLabelFontSizeName(cfg, overrideSettings) * zoom;
+    const float idSize =
+        viewer2d::ResolveLabelFontSizeId(cfg, overrideSettings) * zoom;
+    const float dmxSize =
+        viewer2d::ResolveLabelFontSizeDmx(cfg, overrideSettings) * zoom;
+    const float labelDist =
+        viewer2d::ResolveLabelOffsetDistance(cfg, overrideSettings, viewIdx);
+    const float labelAngle =
+        viewer2d::ResolveLabelOffsetAngle(cfg, overrideSettings, viewIdx);
+
+    constexpr float deg2rad = 3.14159265358979323846f / 180.0f;
+    const float angRad = labelAngle * deg2rad;
+    float offX = 0.0f;
+    float offY = 0.0f;
+    float offZ = 0.0f;
+    switch (view) {
+    case Viewer2DView::Top:
+    case Viewer2DView::Bottom:
+      offX = labelDist * std::sin(angRad);
+      offY = labelDist * std::cos(angRad);
+      break;
+    case Viewer2DView::Front:
+      offX = labelDist * std::sin(angRad);
+      offZ = labelDist * std::cos(angRad);
+      break;
+    case Viewer2DView::Side:
+      offY = -labelDist * std::sin(angRad);
+      offZ = labelDist * std::cos(angRad);
+      break;
+    }
 
     auto bit = m_controller.GetFixtureBoundsMap().find(uuid);
     const ISelectionContext::BoundingBox *bounds =


### PR DESCRIPTION
### Motivation
- Allow fixtures to have individual 2D label position/visibility/size settings that persist in the project configuration while keeping existing global 2D Render Options as the fallback and without modifying MVR/GDTF payloads. 

### Description
- Introduce a new per-fixture override model and persistence under the project config key `label_fixture_overrides` via `viewer2d::FixtureLabelOverride` (`viewer2d/fixture_label_overrides.{h,cpp}`).
- Make 2D Render Options operate in two scopes: global (no fixtures selected) and selection-profile (when fixtures are selected), add a visual scope hint in the Labels section, and read effective values from the first selected fixture when multiple are selected (`viewer2d/viewer2drenderpanel.{h,cpp}`).
- Apply edits while a selection exists as per-fixture overrides that update only the changed field across the selected fixtures (preserving other per-fixture values), and refresh the UI controls when selection changes from the 2D canvas (`viewer2d/viewer2dpanel.cpp`).
- Resolve per-fixture overrides at draw time so label drawing prefers fixture overrides and falls back to global settings, and wire the new files into the build (`viewer3d/labels/label_render_system.cpp`, `viewer2d/CMakeLists.txt`).

### Testing
- Ran project quality checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both returned `OK`.
- Attempted to configure the build with `cmake -S . -B build` which failed in this environment due to missing system `wxWidgets` development package, so a full build was not completed here (environment issue, not code error).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c983b80b6c8324a926a72b168de604)