### PR TITLE
Show app name and version in startup splash

### DIFF
--- a/gui/splashscreen.cpp
+++ b/gui/splashscreen.cpp
@@ -1,4 +1,5 @@
 #include "splashscreen.h"
+#include "app_version.h"
 #include "logger.h"
 #include "projectutils.h"
 #include <algorithm>
@@ -129,6 +130,13 @@ void SplashScreen::Show() {
 
   wxBitmap logoBmp = BuildSplashBitmap();
   wxStaticBitmap *logo = new wxStaticBitmap(panel, wxID_ANY, logoBmp);
+  wxStaticText *appInfoLabel =
+      new wxStaticText(panel, wxID_ANY,
+                       wxString::Format("%s %s", app::kName, app::kVersionDisplay),
+                       wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER);
+  wxFont appInfoFont = appInfoLabel->GetFont();
+  appInfoFont.MakeBold();
+  appInfoLabel->SetFont(appInfoFont);
 
   g_label =
       new wxStaticText(panel, wxID_ANY, "Loading Perastage...", wxDefaultPosition,
@@ -138,6 +146,7 @@ void SplashScreen::Show() {
   g_label->SetFont(font);
 
   sizer->AddStretchSpacer(1);
+  sizer->Add(appInfoLabel, 0, wxALIGN_CENTER | wxTOP | wxBOTTOM, 10);
   sizer->Add(logo, 0, wxALIGN_CENTER | wxALL, 10);
   sizer->Add(g_label, 0, wxALIGN_CENTER | wxBOTTOM, 20);
   sizer->AddStretchSpacer(1);


### PR DESCRIPTION
### Motivation
- Make the application name and display version visible on the startup splash so users immediately see the program identity and version at launch.
- Reuse existing centralized app metadata rather than hardcoding strings to keep versioning consistent across the UI.

### Description
- Added `#include "app_version.h"` to `gui/splashscreen.cpp` and created a new `wxStaticText` called `appInfoLabel` that displays `app::kName` and `app::kVersionDisplay` formatted together.
- Styled the new label in bold to match the existing status text, and inserted it into the top of the splash `wxBoxSizer` above the splash icon so it is centered over the logo.
- Kept the existing loading status `g_label` and `SplashScreen::SetMessage` behavior unchanged.
- File modified: `gui/splashscreen.cpp`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which passed (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which passed (`OK`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c995b2bfd48324be9d25c21606bfa2)