### PR TITLE
Make 2D Render Options groups expand to panel width

### DIFF
--- a/viewer2d/viewer2drenderpanel.cpp
+++ b/viewer2d/viewer2drenderpanel.cpp
@@ -264,10 +264,10 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
                            this);
 
   auto *sizer = new wxBoxSizer(wxVERTICAL);
-  sizer->Add(m_radio, 0, wxALL, 5);
+  sizer->Add(m_radio, 0, wxEXPAND | wxALL, 5);
   sizer->Add(m_darkMode, 0, wxALL, 5);
   sizer->Add(m_topFixturesInverted, 0, wxALL, 5);
-  sizer->Add(m_view, 0, wxALL, 5);
+  sizer->Add(m_view, 0, wxEXPAND | wxALL, 5);
 
   gridBox->Add(m_showGrid, 0, wxALL, 5);
   gridBox->Add(m_gridStyle, 0, wxALL, 5);
@@ -277,7 +277,7 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
   colorSizer->Add(m_gridColor, 0);
   gridBox->Add(colorSizer, 0, wxALL, 5);
   gridBox->Add(m_drawAbove, 0, wxALL, 5);
-  sizer->Add(gridBox, 0, wxALL, 5);
+  sizer->Add(gridBox, 0, wxEXPAND | wxALL, 5);
 
   rulerBox->Add(m_showRuler, 0, wxALL, 5);
   auto *rulerAxisXSizer = new wxBoxSizer(wxHORIZONTAL);
@@ -295,7 +295,7 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
                        0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
   rulerAxisZSizer->Add(m_rulerAxisZPosition, 0);
   rulerBox->Add(rulerAxisZSizer, 0, wxALL, 5);
-  sizer->Add(rulerBox, 0, wxALL, 5);
+  sizer->Add(rulerBox, 0, wxEXPAND | wxALL, 5);
 
   labelBox->Add(m_labelScopeHint, 0, wxLEFT | wxRIGHT | wxTOP, 5);
   labelBox->AddSpacer(2);
@@ -333,7 +333,7 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
   angleSizer->Add(m_labelOffsetAngle, 0);
   labelBox->Add(angleSizer, 0, wxALL, 5);
 
-  sizer->Add(labelBox, 0, wxALL, 5);
+  sizer->Add(labelBox, 0, wxEXPAND | wxALL, 5);
 
   SetSizer(sizer);
   FitInside();


### PR DESCRIPTION
### Motivation
- The 2D Render Options panel showed group boxes with different widths driven by their contents, producing a visually uneven layout. 
- The intent is to make those groups resize uniformly with the panel so they expand and contract together when the panel width changes.

### Description
- Updated `viewer2d/viewer2drenderpanel.cpp` to add `wxEXPAND` when adding key groups to the root vertical sizer so they take available horizontal space. 
- The change applies to the `Render mode` radio, `View` radio, `Grid` group, `Ruler` group, and `Labels` group so each group box now stretches to the panel width. 
- This is a layout-only change (no config or behavior changes) and is localized to the panel's sizer flags.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca2748c9888324ad1e38558ab0276f)