### PR TITLE
Add LX SIDES parsing and side truss/fixture placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 - Import simple lighting riders from plain text or PDF documents using the **Tools → Create from text** dialog.
 - The dialog provides an **Apply filter** action that replaces the editor text with the parsed fixture-only result before you press **Create**.
 - The rider importer parses typical lists of fixture quantities/types and creates corresponding dummy fixtures/trusses in the scene.
+- In text import, `CALLES`/`SIDES` hang headers map to `LX SIDES` and support mirrored side-truss/fixture placement workflows.
 - The full parser and placement rule set used by this text-to-scene workflow is documented in [`docs/text_to_scene_rules.md`](docs/text_to_scene_rules.md).
 - A dictionary helps resolve type names to GDTF specifications and can be edited via the **Tools → Edit dictionaries** menu.
 - Dictionary import/export now supports three portability levels:

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -76,13 +76,13 @@ static const std::regex kFixtureLineRe("^\\s*(?:[-*]\\s*)?(\\d+)\\s+(.+)$",
                                        std::regex::icase);
 static const std::regex kQuantityOnlyRe("^\\s*(?:[-*]\\s*)?(\\d+)\\s*$");
 static const std::regex kHangLineRe(
-    "^\\s*(LX\\d+|screen|pantalla|led\\s*screen|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?)\\s*:?\\s*$",
+    "^\\s*(LX\\d+|screen|pantalla|led\\s*screen|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)\\s*:?\\s*$",
     std::regex::icase);
 static const std::regex kHangFindRe(
-    "(LX\\d+|screen|pantalla|led\\s*screen|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?)",
+    "(LX\\d+|screen|pantalla|led\\s*screen|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)",
                                     std::regex::icase);
 static const std::regex kHangOnlyRe(
-    "^\\s*(LX\\d+|screen|pantalla|led\\s*screen|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?)\\s*$",
+    "^\\s*(LX\\d+|screen|pantalla|led\\s*screen|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)\\s*$",
                                     std::regex::icase);
 std::string Trim(const std::string &s) {
   size_t start = s.find_first_not_of(" \t\r\n");
@@ -389,6 +389,7 @@ std::vector<std::string> SplitPlus(const std::string &s) {
 }
 
 bool IsFloorAlias(std::string_view value);
+bool IsLxSidesAlias(std::string_view value);
 
 std::string NormalizeHangName(const std::string &raw) {
   std::string hang = Trim(raw);
@@ -396,6 +397,8 @@ std::string NormalizeHangName(const std::string &raw) {
     return {};
   if (IsFloorAlias(hang))
     return "FLOOR";
+  if (IsLxSidesAlias(hang))
+    return "LX SIDES";
   std::transform(hang.begin(), hang.end(), hang.begin(), [](unsigned char c) {
     return static_cast<char>(std::toupper(c));
   });
@@ -442,6 +445,10 @@ bool IsLxHangName(const std::string &positionName) {
       return false;
   }
   return true;
+}
+
+bool IsLxSidesHangName(const std::string &positionName) {
+  return NormalizeHangName(positionName) == "LX SIDES";
 }
 
 std::string BuildIndexedName(const std::string &prefix, int index,
@@ -640,6 +647,14 @@ bool IsFloorAlias(std::string_view value) {
   const bool groundLaneAlias = ContainsCaseInsensitive(value, "ground") &&
                                ContainsCaseInsensitive(value, "lane");
   return effectAlias || floorAlias || streetToFloorAlias || groundLaneAlias;
+}
+
+bool IsLxSidesAlias(std::string_view value) {
+  const bool hasStreetAlias = ContainsCaseInsensitive(value, "calle");
+  const bool hasSideAlias = ContainsCaseInsensitive(value, "side");
+  const bool hasFloorAlias = ContainsCaseInsensitive(value, "suelo") ||
+                             ContainsCaseInsensitive(value, "ground");
+  return (hasStreetAlias || hasSideAlias) && !hasFloorAlias;
 }
 
 std::string ReadTextFile(const std::string &path) {
@@ -1290,15 +1305,7 @@ bool RiderImporter::ImportText(const std::string &text) {
     std::smatch hm;
     if (std::regex_match(line, hm, kHangLineRe)) {
       havePending = false;
-      std::string captured = hm[1];
-      if (IsFloorAlias(captured)) {
-        currentHang = "FLOOR";
-      } else {
-        currentHang = captured;
-        std::transform(
-            currentHang.begin(), currentHang.end(), currentHang.begin(),
-            [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
-      }
+      currentHang = NormalizeHangName(hm[1].str());
       // If we weren't in any section yet, assume fixtures when a hang position
       // appears
       if (!inRigging && !inFixtures)
@@ -1359,10 +1366,38 @@ bool RiderImporter::ImportText(const std::string &text) {
           return s + "M";
         };
 
+        auto getWidestLxSpan = [&]() {
+          bool found = false;
+          float minX = 0.0f;
+          float maxX = 0.0f;
+          for (const auto &[existingUuid, existingTruss] : scene.trusses) {
+            (void)existingUuid;
+            if (!IsLxHangName(existingTruss.positionName))
+              continue;
+            const float start = existingTruss.transform.o[0];
+            const float end = start + existingTruss.lengthMm;
+            if (!found) {
+              minX = start;
+              maxX = end;
+              found = true;
+            } else {
+              minX = std::min(minX, start);
+              maxX = std::max(maxX, end);
+            }
+          }
+          if (!found) {
+            minX = -3000.0f;
+            maxX = 3000.0f;
+          }
+          return std::pair<float, float>{minX, maxX};
+        };
+
         auto addTrussPieces = [&](const std::string &posName) {
           auto pieces = SplitTrussSymmetric(length);
           float total = std::accumulate(pieces.begin(), pieces.end(), 0.0f);
+          const bool isLxSides = IsLxSidesHangName(posName);
           float x = -0.5f * total;
+          float yStart = -0.5f * total;
           for (float s : pieces) {
             Truss t;
             t.uuid = GenerateUuid();
@@ -1379,12 +1414,17 @@ bool RiderImporter::ImportText(const std::string &text) {
             t.widthMm = width;
             t.heightMm = height;
             t.positionName = posName;
+            if (isLxSides) {
+              t.transform.u = {0.0f, 1.0f, 0.0f};
+              t.transform.v = {-1.0f, 0.0f, 0.0f};
+              t.transform.w = {0.0f, 0.0f, 1.0f};
+            }
             t.transform.o[0] = x;
-            t.transform.o[1] = getHangPos(posName);
+            t.transform.o[1] = isLxSides ? yStart : getHangPos(posName);
             // Position dummy truss so its base sits at the hang height.
             // Real truss models are inserted from their bottom, so using the
             // raw hang height keeps the base aligned when swapping models.
-            t.transform.o[2] = getHangHeight(posName);
+            t.transform.o[2] = isLxSides ? 5000.0f : getHangHeight(posName);
             std::string sizeStr = formatLength(s);
             if (model.empty())
               t.name = "TRUSS " + sizeStr;
@@ -1433,14 +1473,29 @@ bool RiderImporter::ImportText(const std::string &text) {
             }
             const std::string trussUuid = t.uuid;
             const std::string trussLayer = t.layer;
-            scene.trusses.emplace(trussUuid, std::move(t));
-            importedTrussUuids.push_back(trussUuid);
-            addToLayer(trussLayer, trussUuid);
-            if (posName.rfind("LX", 0) == 0) {
+            if (isLxSides) {
+              const auto [lxStartX, lxEndX] = getWidestLxSpan();
+              const float sideOffset = 500.0f;
+              for (float sideX : {lxStartX - sideOffset, lxEndX + sideOffset}) {
+                Truss sideTruss = t;
+                sideTruss.uuid = GenerateUuid();
+                sideTruss.transform.o[0] = sideX;
+                const std::string sideTrussUuid = sideTruss.uuid;
+                scene.trusses.emplace(sideTrussUuid, std::move(sideTruss));
+                importedTrussUuids.push_back(sideTrussUuid);
+                addToLayer(trussLayer, sideTrussUuid);
+              }
+            } else {
+              scene.trusses.emplace(trussUuid, std::move(t));
+              importedTrussUuids.push_back(trussUuid);
+              addToLayer(trussLayer, trussUuid);
+            }
+            if (IsLxHangName(posName)) {
               lastLightingTrussPosY = getHangPos(posName);
               lastLightingTrussPosZ = getHangHeight(posName);
             }
             x += s;
+            yStart += s;
           }
         };
 
@@ -1539,7 +1594,7 @@ bool RiderImporter::ImportText(const std::string &text) {
           scene.trusses.emplace(trussUuid, std::move(t));
           importedTrussUuids.push_back(trussUuid);
           addToLayer(trussLayer, trussUuid);
-          if (hang.rfind("LX", 0) == 0) {
+          if (IsLxHangName(hang)) {
             lastLightingTrussPosY = getHangPos(hang);
             lastLightingTrussPosZ = getHangHeight(hang);
           }
@@ -1685,7 +1740,36 @@ bool RiderImporter::ImportText(const std::string &text) {
     bool found = false;
   };
   std::unordered_map<std::string, TrussInfo> trussInfo;
+  struct SideTrussInfo {
+    float leftX = -3500.0f;
+    float rightX = 3500.0f;
+    float startY = -2000.0f;
+    float endY = 2000.0f;
+    float z = 1000.0f;
+    bool found = false;
+  };
+  SideTrussInfo sideTrussInfo;
   for (const auto &[uuid, t] : scene.trusses) {
+    (void)uuid;
+    if (IsLxSidesHangName(t.positionName)) {
+      const float sideX = t.transform.o[0];
+      const float startY = t.transform.o[1];
+      const float endY = startY + t.lengthMm;
+      if (!sideTrussInfo.found) {
+        sideTrussInfo.leftX = sideX;
+        sideTrussInfo.rightX = sideX;
+        sideTrussInfo.startY = std::min(startY, endY);
+        sideTrussInfo.endY = std::max(startY, endY);
+        sideTrussInfo.z = t.transform.o[2];
+        sideTrussInfo.found = true;
+      } else {
+        sideTrussInfo.leftX = std::min(sideTrussInfo.leftX, sideX);
+        sideTrussInfo.rightX = std::max(sideTrussInfo.rightX, sideX);
+        sideTrussInfo.startY = std::min(sideTrussInfo.startY, std::min(startY, endY));
+        sideTrussInfo.endY = std::max(sideTrussInfo.endY, std::max(startY, endY));
+      }
+      continue;
+    }
     auto &info = trussInfo[t.positionName];
     float start = t.transform.o[0];
     float end = start + t.lengthMm;
@@ -2023,6 +2107,37 @@ bool RiderImporter::ImportText(const std::string &text) {
   for (auto &[pos, fixturesVec] : fixturesByPos) {
     if (fixturesVec.empty())
       continue;
+    if (IsLxSidesHangName(pos)) {
+      const std::vector<Fixture *> ordered = buildSymmetricOrder(fixturesVec);
+      if (ordered.empty())
+        continue;
+      const int leftCount =
+          static_cast<int>(ordered.size()) / 2 + static_cast<int>(ordered.size()) % 2;
+      const int rightCount = static_cast<int>(ordered.size()) / 2;
+      auto placeSideGroup = [&](int startIndex, int count, float sideX) {
+        if (count <= 0)
+          return;
+        const float startY = sideTrussInfo.found
+                                 ? sideTrussInfo.startY + getHangMargin("LX1")
+                                 : -0.5f * ((count - 1) * 500.0f);
+        const float endY = sideTrussInfo.found
+                               ? sideTrussInfo.endY - getHangMargin("LX1")
+                               : 0.5f * ((count - 1) * 500.0f);
+        const float step = count > 1 ? (endY - startY) / static_cast<float>(count - 1)
+                                     : 0.0f;
+        for (int i = 0; i < count; ++i) {
+          Fixture *fixture = ordered[static_cast<size_t>(startIndex + i)];
+          if (!fixture)
+            continue;
+          fixture->transform.o[0] = sideX;
+          fixture->transform.o[1] = startY + step * static_cast<float>(i);
+          fixture->transform.o[2] = sideTrussInfo.found ? sideTrussInfo.z : 1000.0f;
+        }
+      };
+      placeSideGroup(0, leftCount, sideTrussInfo.leftX);
+      placeSideGroup(leftCount, rightCount, sideTrussInfo.rightX);
+      continue;
+    }
 
     std::vector<Fixture *> bottomFixtures;
     std::vector<Fixture *> topFrontFixtures;

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -78,6 +78,9 @@ static const std::regex kQuantityOnlyRe("^\\s*(?:[-*]\\s*)?(\\d+)\\s*$");
 static const std::regex kHangLineRe(
     "^\\s*(LX\\d+|screen|pantalla|led\\s*screen|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)\\s*:?\\s*$",
     std::regex::icase);
+static const std::regex kHangHeaderWithSuffixRe(
+    "^\\s*(LX\\d+|screen|pantalla|led\\s*screen|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)(?:\\s+[^:]*)?\\s*:\\s*$",
+    std::regex::icase);
 static const std::regex kHangFindRe(
     "(LX\\d+|screen|pantalla|led\\s*screen|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)",
                                     std::regex::icase);
@@ -884,7 +887,8 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
 
     std::smatch m;
     std::smatch hm;
-    if (std::regex_match(line, hm, kHangLineRe)) {
+    if (std::regex_match(line, hm, kHangLineRe) ||
+        std::regex_match(line, hm, kHangHeaderWithSuffixRe)) {
       havePending = false;
       std::string captured = hm[1];
       if (IsFloorAlias(captured)) {

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -76,16 +76,16 @@ static const std::regex kFixtureLineRe("^\\s*(?:[-*]\\s*)?(\\d+)\\s+(.+)$",
                                        std::regex::icase);
 static const std::regex kQuantityOnlyRe("^\\s*(?:[-*]\\s*)?(\\d+)\\s*$");
 static const std::regex kHangLineRe(
-    "^\\s*(LX\\d+|screen|pantalla|led\\s*screen|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)\\s*:?\\s*$",
+    "^\\s*(LX\\d+|lx\\s*sides?|screen|pantalla|led\\s*screen|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)\\s*:?\\s*$",
     std::regex::icase);
 static const std::regex kHangHeaderWithSuffixRe(
-    "^\\s*(LX\\d+|screen|pantalla|led\\s*screen|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)(?:\\s+[^:]*)?\\s*:\\s*$",
+    "^\\s*(LX\\d+|lx\\s*sides?|screen|pantalla|led\\s*screen|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)(?:\\s+[^:]*)?\\s*:\\s*$",
     std::regex::icase);
 static const std::regex kHangFindRe(
-    "(LX\\d+|screen|pantalla|led\\s*screen|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)",
+    "(LX\\d+|lx\\s*sides?|screen|pantalla|led\\s*screen|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)",
                                     std::regex::icase);
 static const std::regex kHangOnlyRe(
-    "^\\s*(LX\\d+|screen|pantalla|led\\s*screen|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)\\s*$",
+    "^\\s*(LX\\d+|lx\\s*sides?|screen|pantalla|led\\s*screen|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)\\s*$",
                                     std::regex::icase);
 std::string Trim(const std::string &s) {
   size_t start = s.find_first_not_of(" \t\r\n");
@@ -1307,7 +1307,8 @@ bool RiderImporter::ImportText(const std::string &text) {
 
     std::smatch m;
     std::smatch hm;
-    if (std::regex_match(line, hm, kHangLineRe)) {
+    if (std::regex_match(line, hm, kHangLineRe) ||
+        std::regex_match(line, hm, kHangHeaderWithSuffixRe)) {
       havePending = false;
       currentHang = NormalizeHangName(hm[1].str());
       // If we weren't in any section yet, assume fixtures when a hang position
@@ -1787,6 +1788,34 @@ bool RiderImporter::ImportText(const std::string &text) {
     } else {
       info.startX = std::min(info.startX, start);
       info.endX = std::max(info.endX, end);
+    }
+  }
+
+  if (!layerByType && !sideTrussInfo.found) {
+    auto removeFromLayer = [&](const std::string &layerName,
+                               const std::string &childUuid) {
+      auto layerIt = layerLookup.find(layerName);
+      if (layerIt == layerLookup.end() || !layerIt->second)
+        return;
+      std::vector<std::string> &children = layerIt->second->childUUIDs;
+      children.erase(std::remove(children.begin(), children.end(), childUuid),
+                     children.end());
+    };
+
+    for (const std::string &fixtureUuid : importedFixtureUuids) {
+      auto fixtureIt = scene.fixtures.find(fixtureUuid);
+      if (fixtureIt == scene.fixtures.end())
+        continue;
+      Fixture &fixture = fixtureIt->second;
+      if (!IsLxSidesHangName(fixture.positionName))
+        continue;
+
+      const std::string oldLayer = fixture.layer;
+      fixture.layer = "pos SIDES";
+      if (oldLayer != fixture.layer) {
+        removeFromLayer(oldLayer, fixture.uuid);
+        addToLayer(fixture.layer, fixture.uuid);
+      }
     }
   }
 

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -1791,6 +1791,28 @@ bool RiderImporter::ImportText(const std::string &text) {
     }
   }
 
+  if (!sideTrussInfo.found) {
+    bool hasLxSpan = false;
+    float lxStart = 0.0f;
+    float lxEnd = 0.0f;
+    for (const auto &[positionName, info] : trussInfo) {
+      if (!info.found || !IsLxHangName(positionName))
+        continue;
+      if (!hasLxSpan) {
+        lxStart = info.startX;
+        lxEnd = info.endX;
+        hasLxSpan = true;
+      } else {
+        lxStart = std::min(lxStart, info.startX);
+        lxEnd = std::max(lxEnd, info.endX);
+      }
+    }
+    if (hasLxSpan) {
+      sideTrussInfo.leftX = lxStart - 500.0f;
+      sideTrussInfo.rightX = lxEnd + 500.0f;
+    }
+  }
+
   if (!layerByType && !sideTrussInfo.found) {
     auto removeFromLayer = [&](const std::string &layerName,
                                const std::string &childUuid) {
@@ -2147,7 +2169,8 @@ bool RiderImporter::ImportText(const std::string &text) {
       const int leftCount =
           static_cast<int>(ordered.size()) / 2 + static_cast<int>(ordered.size()) % 2;
       const int rightCount = static_cast<int>(ordered.size()) / 2;
-      auto placeSideGroup = [&](int startIndex, int count, float sideX) {
+      auto placeSideGroup = [&](int count, float sideX,
+                                const std::function<Fixture *(int)> &pickFixture) {
         if (count <= 0)
           return;
         const float startY = sideTrussInfo.found
@@ -2159,7 +2182,7 @@ bool RiderImporter::ImportText(const std::string &text) {
         const float step = count > 1 ? (endY - startY) / static_cast<float>(count - 1)
                                      : 0.0f;
         for (int i = 0; i < count; ++i) {
-          Fixture *fixture = ordered[static_cast<size_t>(startIndex + i)];
+          Fixture *fixture = pickFixture(i);
           if (!fixture)
             continue;
           fixture->transform.o[0] = sideX;
@@ -2167,8 +2190,12 @@ bool RiderImporter::ImportText(const std::string &text) {
           fixture->transform.o[2] = sideTrussInfo.found ? sideTrussInfo.z : 1000.0f;
         }
       };
-      placeSideGroup(0, leftCount, sideTrussInfo.leftX);
-      placeSideGroup(leftCount, rightCount, sideTrussInfo.rightX);
+      placeSideGroup(leftCount, sideTrussInfo.leftX, [&](int i) {
+        return ordered[static_cast<size_t>(i)];
+      });
+      placeSideGroup(rightCount, sideTrussInfo.rightX, [&](int i) {
+        return ordered[ordered.size() - 1U - static_cast<size_t>(i)];
+      });
       continue;
     }
 

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -89,12 +89,15 @@ Recognized hang labels:
 - `efecto` / `efectos`
 - `calle a suelo` / `calles a suelo`
 - `ground lane` / `ground lanes`
+- `calle` / `calles`
+- `side` / `sides`
 
 Behavior:
 
 - Hang labels are normalized to uppercase (`LX1`, `FLOOR`, ...).
 - Floor aliases (`floor`, `efecto(s)`, `calle(s) a suelo`, `ground lane(s)`)
   are normalized to `FLOOR`.
+- Side-position aliases (`calle(s)`, `side(s)`) are normalized to `LX SIDES`.
 - Screen aliases (`screen`, `pantalla`, `led screen`) are normalized to
   `SCREEN`.
 - The active hang affects fixture/truss layer naming and default placement (`Y/Z`).
@@ -164,6 +167,12 @@ Key truss behaviors:
 Special case:
 
 - If hang is exactly `LX`, quantity `N` expands to `LX1..LXN`.
+- If hang resolves to `LX SIDES`, importer creates two mirrored side trusses
+  (left/right) per split piece:
+  - `X` anchor: `0.5 m` outside the widest detected `LX*` truss span.
+  - `Y` direction: truss axis is aligned along `Y` (not `X`).
+  - `Z` (height): fixed at `5.0 m`.
+  - If no `LX*` truss exists, importer uses a fallback reference span of `[-3, +3] m`.
 - If hang is `SCREEN` and there is no dedicated screen config key, trusses are
   placed from the last created LX truss reference, with `Y = last_lx_y + 1m`
   and `Z = last_lx_z - 0.5m`. If no LX truss has been created yet, importer
@@ -266,6 +275,8 @@ After parsing, imported fixtures are distributed per hang:
 1. Truss span for each hang is inferred from imported truss pieces.
 2. Margin comes from `rider_lx*_margin` (for LX hangs).
 3. If no truss is found for a hang, fallback spacing is centered around origin with 500 mm steps.
+   - Exception for `LX SIDES`: fixtures are still split into left/right groups
+     as if side trusses existed, but fallback height is `1.0 m`.
 4. Ordering alternates fixture types symmetrically:
    - odd counts place a center fixture,
    - remaining fixtures are paired left/right.
@@ -289,6 +300,10 @@ After parsing, imported fixtures are distributed per hang:
      - `x`: evenly spaced from start to end (top group),
      - `y`: `baseY - trussWidth/2`,
      - `z`: `baseZ + trussWidth/2`.
+8. `LX SIDES` fixture distribution:
+   - Fixtures are split into two symmetric groups (left/right side).
+   - Each side group is distributed along `Y` (matching side truss direction).
+   - `X` anchors match side-truss anchors (or fallback anchors when no side truss exists).
 
 ## Numbering and identity rules
 

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -101,6 +101,8 @@ Behavior:
 - Floor aliases (`floor`, `efecto(s)`, `calle(s) a suelo`, `ground lane(s)`)
   are normalized to `FLOOR`.
 - Side-position aliases (`calle(s)`, `side(s)`) are normalized to `LX SIDES`.
+- Explicit normalized headers such as `LX SIDES` are accepted as hang labels
+  in both filtered text and direct import input.
 - Screen aliases (`screen`, `pantalla`, `led screen`) are normalized to
   `SCREEN`.
 - The active hang affects fixture/truss layer naming and default placement (`Y/Z`).
@@ -131,6 +133,8 @@ For each fixture created:
    - Fixture display/type name can be replaced by the parsed GDTF fixture name when available.
    - Physical properties (weight/power) are filled from GDTF when missing.
 4. `positionName` is set from current hang.
+   - In layer-by-position mode, side fixtures use `pos LX SIDES` when side
+     trusses exist and fallback to `pos SIDES` when no side truss is present.
 5. Initial hang coordinates are injected (`Y`, `Z`) and later refined by distribution logic.
 6. Importer falls back to category `Unknown` only when category is still empty
    after the above steps (for example, dummy fixtures without usable GDTF data).

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -135,6 +135,9 @@ For each fixture created:
 4. `positionName` is set from current hang.
    - In layer-by-position mode, side fixtures use `pos LX SIDES` when side
      trusses exist and fallback to `pos SIDES` when no side truss is present.
+   - Side fixtures are ordered as a linear sequence and then mirrored by side:
+     first half rises on the left side, second half rises on the right side in
+     reverse order.
 5. Initial hang coordinates are injected (`Y`, `Z`) and later refined by distribution logic.
 6. Importer falls back to category `Unknown` only when category is still empty
    after the above steps (for example, dummy fixtures without usable GDTF data).
@@ -180,6 +183,9 @@ Special case:
   - `Y` direction: truss axis is aligned along `Y` (not `X`).
   - `Z` (height): fixed at `5.0 m`.
   - If no `LX*` truss exists, importer uses a fallback reference span of `[-3, +3] m`.
+- If no side truss exists but `LX*` trusses are available, side fixtures still
+  use mirrored fallback anchors at `0.5 m` outside the widest detected `LX*`
+  truss span.
 - If hang is `SCREEN` and there is no dedicated screen config key, trusses are
   placed from the last created LX truss reference, with `Y = last_lx_y + 1m`
   and `Z = last_lx_z - 0.5m`. If no LX truss has been created yet, importer

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -95,6 +95,9 @@ Recognized hang labels:
 Behavior:
 
 - Hang labels are normalized to uppercase (`LX1`, `FLOOR`, ...).
+- Fixture hang headers can include extra descriptive suffix text before `:`
+  (for example `CALLES EN LAYHER:`), while still keeping the detected hang
+  alias (`CALLES` -> `LX SIDES`).
 - Floor aliases (`floor`, `efecto(s)`, `calle(s) a suelo`, `ground lane(s)`)
   are normalized to `FLOOR`.
 - Side-position aliases (`calle(s)`, `side(s)`) are normalized to `LX SIDES`.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -668,6 +668,31 @@ target_link_libraries(rider_hoist_import_test PRIVATE ${wxWidgets_LIBRARIES} tin
 add_test(NAME RiderHoistImport COMMAND rider_hoist_import_test)
 set_library_env(RiderHoistImport)
 
+add_executable(rider_lx_sides_import_test rider_lx_sides_import_test.cpp
+               riderimporter_stubs.cpp
+               gdtfloader_stub.cpp
+               ../core/riderimporter.cpp
+               ../core/gdtf_fixture_category.cpp
+               ../core/hoist_weight_distribution.cpp
+               ../core/uuidutils.cpp
+               ../core/autopatcher.cpp
+               ../core/patchmanager.cpp
+               ../core/configmanager.cpp
+               ../core/configservices.cpp
+               ../core/projectutils.cpp
+               ../core/logger.cpp
+               ../models/mvrscene.cpp
+               ../models/fixture.cpp
+               ../models/truss.cpp
+               ../models/sceneobject.cpp
+               ../models/layer.cpp
+               ${LAYOUT_SOURCES})
+target_include_directories(rider_lx_sides_import_test PRIVATE
+                           . ../core ../models ../mvr ../gui ../third_party)
+target_link_libraries(rider_lx_sides_import_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
+add_test(NAME RiderLxSidesImport COMMAND rider_lx_sides_import_test)
+set_library_env(RiderLxSidesImport)
+
 add_executable(rider_import_benchmark rider_import_benchmark.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp

--- a/tests/rider_lx_sides_import_test.cpp
+++ b/tests/rider_lx_sides_import_test.cpp
@@ -70,20 +70,26 @@ int main() {
   cfg.Reset();
   const std::string withoutSideTruss =
       "ILUMINACION\n"
-      "CALLES:\n"
+      "LX3:\n"
+      "2 SPOT\n"
+      "CALLES EN LAYHER:\n"
       "4 PAR\n";
   assert(RiderImporter::ImportText(withoutSideTruss));
   const auto &sceneNoTruss = cfg.GetScene();
 
   int noTrussFixtureCount = 0;
+  int lx3FixtureCount = 0;
   for (const auto &[uuid, fixture] : sceneNoTruss.fixtures) {
     (void)uuid;
     if (fixture.positionName != "LX SIDES")
-      continue;
-    ++noTrussFixtureCount;
-    assert(NearlyEqual(fixture.transform.o[2], 1000.0f));
+      ++lx3FixtureCount;
+    else {
+      ++noTrussFixtureCount;
+      assert(NearlyEqual(fixture.transform.o[2], 1000.0f));
+    }
   }
   assert(noTrussFixtureCount == 4);
+  assert(lx3FixtureCount == 2);
 
   return 0;
 }

--- a/tests/rider_lx_sides_import_test.cpp
+++ b/tests/rider_lx_sides_import_test.cpp
@@ -59,6 +59,7 @@ int main() {
     fixtureX.push_back(fixture.transform.o[0]);
     fixtureY.push_back(fixture.transform.o[1]);
     assert(NearlyEqual(fixture.transform.o[2], 5000.0f));
+    assert(fixture.layer == "pos LX SIDES");
   }
   assert(fixtureX.size() == 6);
   std::sort(fixtureX.begin(), fixtureX.end());
@@ -86,10 +87,36 @@ int main() {
     else {
       ++noTrussFixtureCount;
       assert(NearlyEqual(fixture.transform.o[2], 1000.0f));
+      assert(fixture.layer == "pos SIDES");
     }
   }
   assert(noTrussFixtureCount == 4);
   assert(lx3FixtureCount == 2);
+
+  cfg.Reset();
+  const std::string alreadyFiltered =
+      "LX3\n"
+      "2 SPOT\n"
+      "\n"
+      "LX SIDES\n"
+      "4 PAR\n";
+  assert(RiderImporter::ImportText(alreadyFiltered));
+  const auto &sceneFiltered = cfg.GetScene();
+
+  int filteredSidesCount = 0;
+  int filteredLx3Count = 0;
+  for (const auto &[uuid, fixture] : sceneFiltered.fixtures) {
+    (void)uuid;
+    if (fixture.positionName == "LX SIDES") {
+      ++filteredSidesCount;
+      assert(fixture.layer == "pos SIDES");
+      assert(NearlyEqual(fixture.transform.o[2], 1000.0f));
+    } else if (fixture.positionName == "LX3") {
+      ++filteredLx3Count;
+    }
+  }
+  assert(filteredSidesCount == 4);
+  assert(filteredLx3Count == 2);
 
   return 0;
 }

--- a/tests/rider_lx_sides_import_test.cpp
+++ b/tests/rider_lx_sides_import_test.cpp
@@ -1,0 +1,89 @@
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <set>
+#include <string>
+#include <vector>
+#include <wx/init.h>
+
+#include "configmanager.h"
+#include "riderimporter.h"
+
+namespace {
+bool NearlyEqual(float a, float b) {
+  return std::abs(a - b) < 0.001f;
+}
+}
+
+int main() {
+  wxInitializer initializer;
+  assert(initializer.IsOk());
+
+  auto &cfg = ConfigManager::Get();
+
+  cfg.Reset();
+  const std::string withSideTruss =
+      "ILUMINACION\n"
+      "LX1:\n"
+      "4 SPOT\n"
+      "SIDES:\n"
+      "6 WASH\n"
+      "RIGGING\n"
+      "1 TRUSS 40X40 10m PARA LX1\n"
+      "1 TRUSS 40X40 6m PARA SIDES\n";
+
+  assert(RiderImporter::ImportText(withSideTruss));
+  const auto &sceneWithTruss = cfg.GetScene();
+
+  int sideTrussCount = 0;
+  std::set<float> sideTrussX;
+  for (const auto &[uuid, truss] : sceneWithTruss.trusses) {
+    (void)uuid;
+    if (truss.positionName != "LX SIDES")
+      continue;
+    ++sideTrussCount;
+    sideTrussX.insert(truss.transform.o[0]);
+    assert(NearlyEqual(truss.transform.o[2], 5000.0f));
+    assert(NearlyEqual(truss.transform.u[0], 0.0f));
+    assert(NearlyEqual(truss.transform.u[1], 1.0f));
+  }
+  assert(sideTrussCount >= 2);
+  assert(sideTrussX.size() >= 2);
+
+  std::vector<float> fixtureX;
+  std::vector<float> fixtureY;
+  for (const auto &[uuid, fixture] : sceneWithTruss.fixtures) {
+    (void)uuid;
+    if (fixture.positionName != "LX SIDES")
+      continue;
+    fixtureX.push_back(fixture.transform.o[0]);
+    fixtureY.push_back(fixture.transform.o[1]);
+    assert(NearlyEqual(fixture.transform.o[2], 5000.0f));
+  }
+  assert(fixtureX.size() == 6);
+  std::sort(fixtureX.begin(), fixtureX.end());
+  std::sort(fixtureY.begin(), fixtureY.end());
+  assert(fixtureX.front() < 0.0f);
+  assert(fixtureX.back() > 0.0f);
+  assert(!NearlyEqual(fixtureY.front(), fixtureY.back()));
+
+  cfg.Reset();
+  const std::string withoutSideTruss =
+      "ILUMINACION\n"
+      "CALLES:\n"
+      "4 PAR\n";
+  assert(RiderImporter::ImportText(withoutSideTruss));
+  const auto &sceneNoTruss = cfg.GetScene();
+
+  int noTrussFixtureCount = 0;
+  for (const auto &[uuid, fixture] : sceneNoTruss.fixtures) {
+    (void)uuid;
+    if (fixture.positionName != "LX SIDES")
+      continue;
+    ++noTrussFixtureCount;
+    assert(NearlyEqual(fixture.transform.o[2], 1000.0f));
+  }
+  assert(noTrussFixtureCount == 4);
+
+  return 0;
+}

--- a/tests/rider_lx_sides_import_test.cpp
+++ b/tests/rider_lx_sides_import_test.cpp
@@ -74,12 +74,15 @@ int main() {
       "LX3:\n"
       "2 SPOT\n"
       "CALLES EN LAYHER:\n"
-      "4 PAR\n";
+      "4 PAR\n"
+      "RIGGING\n"
+      "1 TRUSS 40X40 12m PARA LX1\n";
   assert(RiderImporter::ImportText(withoutSideTruss));
   const auto &sceneNoTruss = cfg.GetScene();
 
   int noTrussFixtureCount = 0;
   int lx3FixtureCount = 0;
+  std::set<float> noTrussSideX;
   for (const auto &[uuid, fixture] : sceneNoTruss.fixtures) {
     (void)uuid;
     if (fixture.positionName != "LX SIDES")
@@ -88,10 +91,14 @@ int main() {
       ++noTrussFixtureCount;
       assert(NearlyEqual(fixture.transform.o[2], 1000.0f));
       assert(fixture.layer == "pos SIDES");
+      noTrussSideX.insert(fixture.transform.o[0]);
     }
   }
   assert(noTrussFixtureCount == 4);
   assert(lx3FixtureCount == 2);
+  assert(noTrussSideX.size() == 2);
+  assert(NearlyEqual(*noTrussSideX.begin(), -6500.0f));
+  assert(NearlyEqual(*noTrussSideX.rbegin(), 6500.0f));
 
   cfg.Reset();
   const std::string alreadyFiltered =


### PR DESCRIPTION
### Motivation
- Rider text import must treat `CALLES`/`SIDES` as side-stage hang positions and create proper side-truss and fixture placements instead of ignoring or treating them as floor aliases.
- Side trusses/fixtures need a different spatial alignment (along Y) and fixed offsets relative to the main `LX*` span to match expected stage layouts.

### Description
- Extended hang detection regexes and normalization so `calle(s)` / `side(s)` are recognized and normalized to `LX SIDES` via `NormalizeHangName` and a new `IsLxSidesAlias` helper in `core/riderimporter.cpp`.
- Implemented side-truss creation for `LX SIDES` rigging entries: truss pieces are mirrored (left/right), truss axis aligned along `Y` (`transform.u/v/w` rotated), placed 0.5 m outside the widest detected `LX*` span, and set at a fixed height of 5.0 m (fallback span used if no `LX*` exists).
- Added fixture distribution logic for `LX SIDES` so fixtures tagged to that position are split into symmetric left/right groups and distributed along the side-truss Y axis, with a fallback height of 1.0 m when no side truss is present.
- Updated doc rules in `docs/text_to_scene_rules.md` and the user-facing note in `README.md` describing the new `LX SIDES` behavior as required for text-to-scene changes.
- Added a regression test `tests/rider_lx_sides_import_test.cpp` and wired it into `tests/CMakeLists.txt` to cover both cases (with and without explicit side truss definitions).

### Testing
- Ran `./tests/check_perastage_tree_modules.sh` and it succeeded.
- Ran `./tests/check_no_configmanager_get_in_gui.sh` and it succeeded.
- Tried to configure/build tests with `cmake -S . -B build/tests -DBUILD_TESTS=ON`, which failed in this environment because the `wxWidgets` development package was not available (so test binaries were not compiled here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca28e548a48324a7a0d482d08b8726)