### PR TITLE
Add context-menu toggles for text box border and transparent background

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -93,6 +93,8 @@ constexpr int kBringToFrontMenuId = wxID_HIGHEST + 499;
 constexpr int kSendToBackMenuId = wxID_HIGHEST + 500;
 constexpr int kLoadingTimerId = wxID_HIGHEST + 501;
 constexpr int kRenderDelayTimerId = wxID_HIGHEST + 502;
+constexpr int kToggleTextFrameMenuId = wxID_HIGHEST + 503;
+constexpr int kToggleTextTransparentBackgroundMenuId = wxID_HIGHEST + 504;
 constexpr int kLoadingOverlayDelayMs = 150;
 
 bool AreEqual(const layouts::Layout2DViewFrame &lhs,
@@ -385,6 +387,9 @@ wxBEGIN_EVENT_TABLE(LayoutViewerPanel, wxGLCanvas)
     EVT_MENU(kDeleteEventTableMenuId, LayoutViewerPanel::OnDeleteEventTable)
     EVT_MENU(kEditTextMenuId, LayoutViewerPanel::OnEditText)
     EVT_MENU(kDeleteTextMenuId, LayoutViewerPanel::OnDeleteText)
+    EVT_MENU(kToggleTextFrameMenuId, LayoutViewerPanel::OnToggleTextFrame)
+    EVT_MENU(kToggleTextTransparentBackgroundMenuId,
+             LayoutViewerPanel::OnToggleTextTransparentBackground)
     EVT_MENU(kEditImageMenuId, LayoutViewerPanel::OnEditImage)
     EVT_MENU(kDeleteImageMenuId, LayoutViewerPanel::OnDeleteImage)
     EVT_MENU(kBringToFrontMenuId, LayoutViewerPanel::OnBringToFront)
@@ -1371,7 +1376,15 @@ void LayoutViewerPanel::OnRightUp(wxMouseEvent &event) {
     menu.Append(kSendToBackMenuId, "Send to Back");
   } else if (selectedElementType == SelectedElementType::Text) {
     menu.Append(kEditTextMenuId, "Edit Text");
+    menu.AppendCheckItem(kToggleTextFrameMenuId, "Show Border");
+    menu.AppendCheckItem(kToggleTextTransparentBackgroundMenuId,
+                         "Transparent Background");
     menu.Append(kDeleteTextMenuId, "Delete Text");
+    if (const auto *text = GetSelectedText()) {
+      menu.Check(kToggleTextFrameMenuId, text->drawFrame);
+      menu.Check(kToggleTextTransparentBackgroundMenuId,
+                 !text->solidBackground);
+    }
     menu.AppendSeparator();
     menu.Append(kBringToFrontMenuId, "Bring to Front");
     menu.Append(kSendToBackMenuId, "Send to Back");

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -134,6 +134,8 @@ private:
   void OnDeleteEventTable(wxCommandEvent &event);
   void OnEditText(wxCommandEvent &event);
   void OnDeleteText(wxCommandEvent &event);
+  void OnToggleTextFrame(wxCommandEvent &event);
+  void OnToggleTextTransparentBackground(wxCommandEvent &event);
   void OnEditImage(wxCommandEvent &event);
   void OnDeleteImage(wxCommandEvent &event);
   void OnBringToFront(wxCommandEvent &event);

--- a/gui/layoutviewerpanel_text.cpp
+++ b/gui/layoutviewerpanel_text.cpp
@@ -200,6 +200,42 @@ void LayoutViewerPanel::OnDeleteText(wxCommandEvent &) {
   Refresh();
 }
 
+void LayoutViewerPanel::OnToggleTextFrame(wxCommandEvent &) {
+  if (selectedElementType != SelectedElementType::Text)
+    return;
+  layouts::LayoutTextDefinition *text = GetSelectedText();
+  if (!text)
+    return;
+  text->drawFrame = !text->drawFrame;
+  if (!currentLayout.name.empty()) {
+    auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+    cfg.PushUndoState("toggle layout text border");
+    layouts::LayoutManager::Get().UpdateLayoutText(currentLayout.name, *text);
+  }
+  TextCache &cache = GetTextCache(text->id);
+  cache.renderDirty = true;
+  RequestRenderRebuild();
+  Refresh();
+}
+
+void LayoutViewerPanel::OnToggleTextTransparentBackground(wxCommandEvent &) {
+  if (selectedElementType != SelectedElementType::Text)
+    return;
+  layouts::LayoutTextDefinition *text = GetSelectedText();
+  if (!text)
+    return;
+  text->solidBackground = !text->solidBackground;
+  if (!currentLayout.name.empty()) {
+    auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+    cfg.PushUndoState("toggle layout text transparent background");
+    layouts::LayoutManager::Get().UpdateLayoutText(currentLayout.name, *text);
+  }
+  TextCache &cache = GetTextCache(text->id);
+  cache.renderDirty = true;
+  RequestRenderRebuild();
+  Refresh();
+}
+
 void LayoutViewerPanel::DrawTextElement(
     const layouts::LayoutTextDefinition &text, int activeTextId) {
   TextCache &cache = GetTextCache(text.id);


### PR DESCRIPTION
### Motivation
- Allow quick formatting of Layout text boxes from the canvas context menu so users can toggle the border and background transparency without opening the edit dialog.

### Description
- Added two new checkable menu items (`Show Border`, `Transparent Background`) to the text box right-click menu and new menu IDs `kToggleTextFrameMenuId` and `kToggleTextTransparentBackgroundMenuId` in `gui/layoutviewerpanel.cpp`.
- Declared `OnToggleTextFrame` and `OnToggleTextTransparentBackground` in `gui/layoutviewerpanel.h` and wired them into the event table.
- Implemented handlers in `gui/layoutviewerpanel_text.cpp` that flip `drawFrame` / `solidBackground`, push an undo state, persist the change via `layouts::LayoutManager::Get().UpdateLayoutText(...)`, mark the text render cache dirty, request a render rebuild, and refresh the view.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca2cba9f688324ae7de4fd64912a33)