### PR TITLE
Add truss coordinate overrides for Create from text rider import

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@
 - Import simple lighting riders from plain text or PDF documents using the **Tools → Create from text** dialog.
 - The dialog provides an **Apply filter** action that replaces the editor text with the parsed fixture-only result before you press **Create**.
 - The rider importer parses typical lists of fixture quantities/types and creates corresponding dummy fixtures/trusses in the scene.
+- Truss hang tokens can include optional coordinates in parentheses to override
+  default truss placement in **Create from text** (numeric values follow the
+  active distance unit system: meters/feet).
 - In text import, `CALLES`/`SIDES` hang headers map to `LX SIDES` and support mirrored side-truss/fixture placement workflows.
 - The full parser and placement rule set used by this text-to-scene workflow is documented in [`docs/text_to_scene_rules.md`](docs/text_to_scene_rules.md).
 - A dictionary helps resolve type names to GDTF specifications and can be edited via the **Tools → Edit dictionaries** menu.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@
 - The rider importer parses typical lists of fixture quantities/types and creates corresponding dummy fixtures/trusses in the scene.
 - Truss hang tokens can include optional coordinates in parentheses to override
   default truss placement in **Create from text** (numeric values follow the
-  active distance unit system: meters/feet).
+  active distance unit system: meters/feet), including hang headers such as
+  `LX1 (7)` / `LX1 (7):`.
 - In text import, `CALLES`/`SIDES` hang headers map to `LX SIDES` and support mirrored side-truss/fixture placement workflows.
 - The full parser and placement rule set used by this text-to-scene workflow is documented in [`docs/text_to_scene_rules.md`](docs/text_to_scene_rules.md).
 - A dictionary helps resolve type names to GDTF specifications and can be edited via the **Tools → Edit dictionaries** menu.

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -77,7 +77,7 @@ static const std::regex kFixtureLineRe("^\\s*(?:[-*]\\s*)?(\\d+)\\s+(.+)$",
                                        std::regex::icase);
 static const std::regex kQuantityOnlyRe("^\\s*(?:[-*]\\s*)?(\\d+)\\s*$");
 static const std::regex kHangLineRe(
-    "^\\s*(LX\\d+|lx\\s*sides?|screen|pantalla|led\\s*screen|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)\\s*:?\\s*$",
+    "^\\s*(LX\\d+|lx\\s*sides?|screen|pantalla|led\\s*screen|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)(?:\\s*\\([^\\)]*\\))?\\s*:?\\s*$",
     std::regex::icase);
 static const std::regex kHangHeaderWithSuffixRe(
     "^\\s*(LX\\d+|lx\\s*sides?|screen|pantalla|led\\s*screen|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)(?:\\s+[^:]*)?\\s*:\\s*$",
@@ -1254,6 +1254,8 @@ bool RiderImporter::ImportText(const std::string &text) {
   std::vector<HoistRequest> hoistRequests;
   int pendingQuantity = 0;
   bool havePending = false;
+  std::unordered_map<std::string, TrussCoordinateOverride>
+      hangCoordinateOverrides;
 
   auto addFixtures = [&](int baseQuantity, const std::string &desc) {
     auto parts = SplitPlus(desc);
@@ -1374,6 +1376,12 @@ bool RiderImporter::ImportText(const std::string &text) {
         std::regex_match(line, hm, kHangHeaderWithSuffixRe)) {
       havePending = false;
       currentHang = NormalizeHangName(hm[1].str());
+      std::string hangLineWithOverrides = line;
+      if (const auto parsedOverride = ParseTrussCoordinateOverride(
+              hangLineWithOverrides, distanceUnitSystem);
+          parsedOverride.has_value()) {
+        hangCoordinateOverrides[currentHang] = *parsedOverride;
+      }
       // If we weren't in any section yet, assume fixtures when a hang position
       // appears
       if (!inRigging && !inFixtures)
@@ -1595,12 +1603,40 @@ bool RiderImporter::ImportText(const std::string &text) {
           }
         };
 
+        auto resolveCoordinateOverride = [&](const std::string &posName) {
+          TrussCoordinateOverride resolved;
+          bool hasResolved = false;
+          if (const auto hangOverrideIt = hangCoordinateOverrides.find(posName);
+              hangOverrideIt != hangCoordinateOverrides.end()) {
+            resolved = hangOverrideIt->second;
+            hasResolved = true;
+          }
+          if (coordinateOverride.has_value()) {
+            if (coordinateOverride->hasX) {
+              resolved.hasX = true;
+              resolved.xMm = coordinateOverride->xMm;
+            }
+            if (coordinateOverride->hasY) {
+              resolved.hasY = true;
+              resolved.yMm = coordinateOverride->yMm;
+            }
+            if (coordinateOverride->hasZ) {
+              resolved.hasZ = true;
+              resolved.zMm = coordinateOverride->zMm;
+            }
+            hasResolved = true;
+          }
+          return hasResolved ? std::optional<TrussCoordinateOverride>(resolved)
+                             : std::nullopt;
+        };
+
         if (hang == "LX") {
           for (int i = 0; i < quantity; ++i)
-            addTrussPieces("LX" + std::to_string(i + 1), coordinateOverride);
+            addTrussPieces("LX" + std::to_string(i + 1),
+                           resolveCoordinateOverride("LX" + std::to_string(i + 1)));
         } else {
           for (int i = 0; i < quantity; ++i)
-            addTrussPieces(hang, coordinateOverride);
+            addTrussPieces(hang, resolveCoordinateOverride(hang));
         }
       } else if (std::regex_search(line, m, kTrussRe)) {
         float length = 0.0f;
@@ -1613,6 +1649,11 @@ bool RiderImporter::ImportText(const std::string &text) {
         if (std::regex_search(line, hm, kHangFindRe)) {
           hang = hm[1];
           hang = NormalizeHangName(hang);
+        }
+        if (!coordinateOverride.has_value()) {
+          const auto hangOverrideIt = hangCoordinateOverrides.find(hang);
+          if (hangOverrideIt != hangCoordinateOverrides.end())
+            coordinateOverride = hangOverrideIt->second;
         }
         if (hang == "FLOOR")
           continue;

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -96,6 +96,16 @@ std::string Trim(const std::string &s) {
   return s.substr(start, end - start + 1);
 }
 
+std::optional<std::string> ExtractParenthesizedToken(const std::string &text) {
+  const size_t open = text.find('(');
+  if (open == std::string::npos)
+    return std::nullopt;
+  const size_t close = text.find(')', open + 1);
+  if (close == std::string::npos || close <= open)
+    return std::nullopt;
+  return text.substr(open, close - open + 1);
+}
+
 std::string ResolveGdtfPath(const MvrScene &scene,
                             const std::string &gdtfSpecPath) {
   if (gdtfSpecPath.empty())
@@ -864,6 +874,7 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
   std::string currentHang;
   std::vector<std::string> hangOrder;
   std::unordered_map<std::string, std::vector<std::string>> fixturesByHang;
+  std::unordered_map<std::string, std::string> hangCoordinateSuffixByHang;
   std::vector<std::string> riggingLines;
   struct HoistPreviewRequest {
     int quantity = 0;
@@ -957,6 +968,10 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
       } else {
         currentHang = NormalizeHangName(captured);
       }
+      if (const auto coordinateSuffix = ExtractParenthesizedToken(line);
+          coordinateSuffix.has_value()) {
+        hangCoordinateSuffixByHang[currentHang] = *coordinateSuffix;
+      }
       if (!inRigging && !inFixtures)
         inFixtures = true;
       continue;
@@ -979,11 +994,33 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
       if (!TryParseFloat(m[3].str(), lengthM))
         continue;
       std::string hang = currentHang;
+      std::string trussCoordinateSuffix;
       if (m.size() > 4 && m[4].matched) {
         hang = m[4].str();
+        if (const auto coordinateSuffix = ExtractParenthesizedToken(hang);
+            coordinateSuffix.has_value()) {
+          trussCoordinateSuffix = *coordinateSuffix;
+        }
       } else if (std::regex_match(model, kHangOnlyRe)) {
         hang = model;
         model.clear();
+      } else {
+        std::string modelForHang = model;
+        if (const auto coordinateSuffix = ExtractParenthesizedToken(modelForHang);
+            coordinateSuffix.has_value()) {
+          trussCoordinateSuffix = *coordinateSuffix;
+        }
+        modelForHang = std::regex_replace(modelForHang, std::regex("\\([^\\)]*\\)"), "");
+        modelForHang = Trim(modelForHang);
+        if (std::regex_match(modelForHang, kHangOnlyRe)) {
+          hang = modelForHang;
+          model.clear();
+        }
+      }
+      if (trussCoordinateSuffix.empty()) {
+        const auto it = hangCoordinateSuffixByHang.find(NormalizeHangName(hang));
+        if (it != hangCoordinateSuffixByHang.end())
+          trussCoordinateSuffix = it->second;
       }
       hang = NormalizeHangName(hang);
 
@@ -1000,6 +1037,8 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
         out += " " + lenText;
         if (!targetHang.empty())
           out += " " + targetHang;
+        if (!trussCoordinateSuffix.empty())
+          out += " " + trussCoordinateSuffix;
         riggingLines.push_back(out);
         if (targetHang.rfind("LX", 0) == 0 &&
             std::find(lxTargetsInRigging.begin(), lxTargetsInRigging.end(),
@@ -1070,6 +1109,10 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
     if (!firstSection)
       preview << "\n\n";
     preview << hang;
+    const auto coordinateIt = hangCoordinateSuffixByHang.find(hang);
+    if (coordinateIt != hangCoordinateSuffixByHang.end() &&
+        !coordinateIt->second.empty())
+      preview << " " << coordinateIt->second;
     for (const std::string &fixtureLine : it->second)
       preview << "\n" << fixtureLine;
     firstSection = false;
@@ -1643,6 +1686,10 @@ bool RiderImporter::ImportText(const std::string &text) {
         if (!TryParseFloat(m[1], length))
           continue;
         length *= 1000.0f;
+        std::string lineWithCoordinateOverride = line;
+        const auto lineCoordinateOverride =
+            ParseTrussCoordinateOverride(lineWithCoordinateOverride,
+                                         distanceUnitSystem);
         std::string hang = currentHang;
         std::optional<TrussCoordinateOverride> coordinateOverride =
             ParseTrussCoordinateOverride(hang, distanceUnitSystem);
@@ -1654,6 +1701,23 @@ bool RiderImporter::ImportText(const std::string &text) {
           const auto hangOverrideIt = hangCoordinateOverrides.find(hang);
           if (hangOverrideIt != hangCoordinateOverrides.end())
             coordinateOverride = hangOverrideIt->second;
+        }
+        if (lineCoordinateOverride.has_value()) {
+          TrussCoordinateOverride merged =
+              coordinateOverride.value_or(TrussCoordinateOverride{});
+          if (lineCoordinateOverride->hasX) {
+            merged.hasX = true;
+            merged.xMm = lineCoordinateOverride->xMm;
+          }
+          if (lineCoordinateOverride->hasY) {
+            merged.hasY = true;
+            merged.yMm = lineCoordinateOverride->yMm;
+          }
+          if (lineCoordinateOverride->hasZ) {
+            merged.hasZ = true;
+            merged.zMm = lineCoordinateOverride->zMm;
+          }
+          coordinateOverride = merged;
         }
         if (hang == "FLOOR")
           continue;

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -52,6 +52,7 @@
 #include "truss.h"
 #include "trussdictionary.h"
 #include "trussloader.h"
+#include "units/units.h"
 #include "uuidutils.h"
 #include <filesystem>
 
@@ -300,6 +301,66 @@ bool TryParseInt(std::string_view text, int &out) {
     return true;
   }
   return false;
+}
+
+struct TrussCoordinateOverride {
+  bool hasX = false;
+  bool hasY = false;
+  bool hasZ = false;
+  float xMm = 0.0f;
+  float yMm = 0.0f;
+  float zMm = 0.0f;
+};
+
+std::optional<TrussCoordinateOverride> ParseTrussCoordinateOverride(
+    std::string &text, Units::DistanceUnitSystem unitSystem) {
+  const size_t open = text.find('(');
+  if (open == std::string::npos)
+    return std::nullopt;
+
+  const size_t close = text.find(')', open + 1);
+  if (close == std::string::npos || close <= open + 1)
+    return std::nullopt;
+
+  const std::string inside = text.substr(open + 1, close - open - 1);
+  static const std::regex kCoordinateNumberRe("[-+]?\\d+(?:[\\.,]\\d+)?");
+  std::vector<double> values;
+  values.reserve(3);
+  for (std::sregex_iterator it(inside.begin(), inside.end(), kCoordinateNumberRe),
+       end;
+       it != end && values.size() < 3; ++it) {
+    std::string token = it->str();
+    std::replace(token.begin(), token.end(), ',', '.');
+    float parsed = 0.0f;
+    if (!TryParseFloat(token, parsed))
+      continue;
+    values.push_back(
+        Units::DistanceDisplayToMillimeters(static_cast<double>(parsed), unitSystem));
+  }
+  if (values.empty())
+    return std::nullopt;
+
+  text.erase(open, close - open + 1);
+  text = Trim(text);
+
+  TrussCoordinateOverride override;
+  if (values.size() >= 3) {
+    override.hasX = true;
+    override.hasY = true;
+    override.hasZ = true;
+    override.xMm = static_cast<float>(values[0]);
+    override.yMm = static_cast<float>(values[1]);
+    override.zMm = static_cast<float>(values[2]);
+  } else if (values.size() == 2) {
+    override.hasY = true;
+    override.hasZ = true;
+    override.yMm = static_cast<float>(values[0]);
+    override.zMm = static_cast<float>(values[1]);
+  } else {
+    override.hasY = true;
+    override.yMm = static_cast<float>(values[0]);
+  }
+  return override;
 }
 
 bool TryParseScreenDimensionsMm(const std::string &text, float &widthMm,
@@ -1076,6 +1137,8 @@ bool RiderImporter::ImportText(const std::string &text) {
   std::string defaultLayer = cfg.GetCurrentLayer();
   auto modeVal = cfg.GetValue("rider_layer_mode");
   bool layerByType = modeVal && *modeVal == "type";
+  const Units::DistanceUnitSystem distanceUnitSystem =
+      Units::ParseDistanceUnitSystem(cfg.GetValue("ui_distance_unit_system"));
   std::optional<float> lastLightingTrussPosY;
   std::optional<float> lastLightingTrussPosZ;
 
@@ -1350,9 +1413,25 @@ bool RiderImporter::ImportText(const std::string &text) {
             height = parsed * 10.0f;
         }
         std::string hang = currentHang;
+        std::optional<TrussCoordinateOverride> coordinateOverride;
         if (m.size() > 4 && m[4].matched) {
           hang = Trim(m[4]);
-        } else if (std::regex_match(model, kHangOnlyRe)) {
+          coordinateOverride =
+              ParseTrussCoordinateOverride(hang, distanceUnitSystem);
+        } else {
+          std::string modelForHang = model;
+          const auto modelCoordinateOverride =
+              ParseTrussCoordinateOverride(modelForHang, distanceUnitSystem);
+          if (std::regex_match(modelForHang, kHangOnlyRe)) {
+            hang = modelForHang;
+            coordinateOverride = modelCoordinateOverride;
+            model.clear();
+          } else if (modelCoordinateOverride.has_value()) {
+            model = modelForHang;
+            coordinateOverride = modelCoordinateOverride;
+          }
+        }
+        if (std::regex_match(model, kHangOnlyRe)) {
           hang = model;
           model.clear();
         }
@@ -1397,12 +1476,24 @@ bool RiderImporter::ImportText(const std::string &text) {
           return std::pair<float, float>{minX, maxX};
         };
 
-        auto addTrussPieces = [&](const std::string &posName) {
+        auto addTrussPieces = [&](const std::string &posName,
+                                  const std::optional<TrussCoordinateOverride>
+                                      &coordinateOverride) {
           auto pieces = SplitTrussSymmetric(length);
           float total = std::accumulate(pieces.begin(), pieces.end(), 0.0f);
           const bool isLxSides = IsLxSidesHangName(posName);
-          float x = -0.5f * total;
-          float yStart = -0.5f * total;
+          float x = coordinateOverride && coordinateOverride->hasX
+                        ? coordinateOverride->xMm
+                        : -0.5f * total;
+          float yStart = coordinateOverride && coordinateOverride->hasY
+                             ? coordinateOverride->yMm
+                             : -0.5f * total;
+          const float hangY = coordinateOverride && coordinateOverride->hasY
+                                  ? coordinateOverride->yMm
+                                  : getHangPos(posName);
+          const float hangZ = coordinateOverride && coordinateOverride->hasZ
+                                  ? coordinateOverride->zMm
+                                  : getHangHeight(posName);
           for (float s : pieces) {
             Truss t;
             t.uuid = GenerateUuid();
@@ -1425,11 +1516,11 @@ bool RiderImporter::ImportText(const std::string &text) {
               t.transform.w = {0.0f, 0.0f, 1.0f};
             }
             t.transform.o[0] = x;
-            t.transform.o[1] = isLxSides ? yStart : getHangPos(posName);
+            t.transform.o[1] = isLxSides ? yStart : hangY;
             // Position dummy truss so its base sits at the hang height.
             // Real truss models are inserted from their bottom, so using the
             // raw hang height keeps the base aligned when swapping models.
-            t.transform.o[2] = isLxSides ? 5000.0f : getHangHeight(posName);
+            t.transform.o[2] = hangZ;
             std::string sizeStr = formatLength(s);
             if (model.empty())
               t.name = "TRUSS " + sizeStr;
@@ -1496,8 +1587,8 @@ bool RiderImporter::ImportText(const std::string &text) {
               addToLayer(trussLayer, trussUuid);
             }
             if (IsLxHangName(posName)) {
-              lastLightingTrussPosY = getHangPos(posName);
-              lastLightingTrussPosZ = getHangHeight(posName);
+              lastLightingTrussPosY = hangY;
+              lastLightingTrussPosZ = hangZ;
             }
             x += s;
             yStart += s;
@@ -1506,10 +1597,10 @@ bool RiderImporter::ImportText(const std::string &text) {
 
         if (hang == "LX") {
           for (int i = 0; i < quantity; ++i)
-            addTrussPieces("LX" + std::to_string(i + 1));
+            addTrussPieces("LX" + std::to_string(i + 1), coordinateOverride);
         } else {
           for (int i = 0; i < quantity; ++i)
-            addTrussPieces(hang);
+            addTrussPieces(hang, coordinateOverride);
         }
       } else if (std::regex_search(line, m, kTrussRe)) {
         float length = 0.0f;
@@ -1517,6 +1608,8 @@ bool RiderImporter::ImportText(const std::string &text) {
           continue;
         length *= 1000.0f;
         std::string hang = currentHang;
+        std::optional<TrussCoordinateOverride> coordinateOverride =
+            ParseTrussCoordinateOverride(hang, distanceUnitSystem);
         if (std::regex_search(line, hm, kHangFindRe)) {
           hang = hm[1];
           hang = NormalizeHangName(hang);
@@ -1538,7 +1631,15 @@ bool RiderImporter::ImportText(const std::string &text) {
         float height = 400.0f;
         auto pieces = SplitTrussSymmetric(length);
         float total = std::accumulate(pieces.begin(), pieces.end(), 0.0f);
-        float x = -0.5f * total;
+        float x = coordinateOverride && coordinateOverride->hasX
+                      ? coordinateOverride->xMm
+                      : -0.5f * total;
+        const float hangY = coordinateOverride && coordinateOverride->hasY
+                                ? coordinateOverride->yMm
+                                : getHangPos(hang);
+        const float hangZ = coordinateOverride && coordinateOverride->hasZ
+                                ? coordinateOverride->zMm
+                                : getHangHeight(hang);
         for (float s : pieces) {
           Truss t;
           t.uuid = GenerateUuid();
@@ -1556,10 +1657,10 @@ bool RiderImporter::ImportText(const std::string &text) {
           t.heightMm = height;
           t.positionName = hang;
           t.transform.o[0] = x;
-          t.transform.o[1] = getHangPos(hang);
+          t.transform.o[1] = hangY;
           // Store the hang height directly so the base matches real models
           // that are inserted from the bottom.
-          t.transform.o[2] = getHangHeight(hang);
+          t.transform.o[2] = hangZ;
           std::string sizeStr = formatLength(s);
           t.name = "TRUSS " + sizeStr;
           t.model = TrussDictionary::NormalizeModelKey(t.name);
@@ -1600,8 +1701,8 @@ bool RiderImporter::ImportText(const std::string &text) {
           importedTrussUuids.push_back(trussUuid);
           addToLayer(trussLayer, trussUuid);
           if (IsLxHangName(hang)) {
-            lastLightingTrussPosY = getHangPos(hang);
-            lastLightingTrussPosZ = getHangHeight(hang);
+            lastLightingTrussPosY = hangY;
+            lastLightingTrussPosZ = hangZ;
           }
           x += s;
         }

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -170,6 +170,8 @@ Supported truss syntax includes:
   - This can be written both in truss targets (`... PARA LX1 (7)`) and in
     hang headers (`LX1 (7)` / `LX1 (7):`), where truss placement inherits the
     hang override.
+  - The **Apply filter** pass preserves these coordinate tokens so pressing
+    **Create** after filtering keeps the same truss placement overrides.
 
 Key truss behaviors:
 

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -167,6 +167,9 @@ Supported truss syntax includes:
   - `LX1 ( -1, 9 )` => `y, z` (keeps default `x`)
   - `LX1 (7)` => `y` only (keeps default `x, z`)
   - Non-numeric text inside parentheses is ignored while extracting numbers.
+  - This can be written both in truss targets (`... PARA LX1 (7)`) and in
+    hang headers (`LX1 (7)` / `LX1 (7):`), where truss placement inherits the
+    hang override.
 
 Key truss behaviors:
 

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -162,6 +162,11 @@ Supported truss syntax includes:
 
 - `N truss MODEL LENGTH m [para HANG]`
 - More generic fallback lines containing `truss` and a measurable length.
+- Optional coordinate override appended to hang in parentheses, e.g.
+  - `LX1 (0, -1, 9)` => `x, y, z`
+  - `LX1 ( -1, 9 )` => `y, z` (keeps default `x`)
+  - `LX1 (7)` => `y` only (keeps default `x, z`)
+  - Non-numeric text inside parentheses is ignored while extracting numbers.
 
 Key truss behaviors:
 
@@ -170,7 +175,10 @@ Key truss behaviors:
 3. `para <hang>` overrides current hang.
 4. Prefix cleanup supports `PUENTE`/`PUENTES` in hang names.
 5. Long trusses are split into symmetric pieces using preferred segments (`3000, 2000, 1000, 500 mm`) plus a center piece when beneficial.
-6. Each piece becomes a truss object with computed `x` placement and hang-based `y/z`.
+6. Each piece becomes a truss object with computed `x` placement and hang-based
+   `y/z`, unless a coordinate override is provided in the hang token.
+   Coordinate values use the active UI distance unit system (`metric` or
+   `imperial`) at import time.
 7. Dictionary/model resolution is attempted using normalized lookup keys.
 8. If model/symbol cannot be fully resolved to renderable geometry (`.3ds`/`.glb` available), importer keeps dummy-box truss data and logs a warning.
 

--- a/tests/rider_filter_preview_test.cpp
+++ b/tests/rider_filter_preview_test.cpp
@@ -67,5 +67,27 @@ int main() {
     return 1;
   }
 
+  const std::string inputWithCoordinates =
+      "LX1 (6)\n"
+      "2 SPOT\n"
+      "RIGGING\n"
+      "1 TRUSS 40X40 14m PARA LX1 (6)\n";
+  const std::string previewWithCoordinates =
+      RiderImporter::BuildFixtureFilterPreview(inputWithCoordinates);
+  const std::string expectedWithCoordinates =
+      "LX1 (6)\n"
+      "2 SPOT\n"
+      "\n"
+      "\n"
+      "RIGGING\n"
+      "1 TRUSS 40X40 14m LX1 (6)";
+  if (previewWithCoordinates != expectedWithCoordinates) {
+    std::cerr << "Coordinate overrides should be preserved in filtered preview.\n"
+              << "Expected:\n"
+              << expectedWithCoordinates << "\n\nGot:\n"
+              << previewWithCoordinates << "\n";
+    return 1;
+  }
+
   return 0;
 }

--- a/tests/rider_lx_sides_import_test.cpp
+++ b/tests/rider_lx_sides_import_test.cpp
@@ -179,5 +179,31 @@ int main() {
   }
   assert(singleTrussCount > 0);
 
+  cfg.Reset();
+  cfg.SetValue("ui_distance_unit_system", "metric");
+  const std::string headerCoordinateOverrideWithoutColon =
+      "LX1 (6)\n"
+      "2 SPOT\n"
+      "RIGGING\n"
+      "1 TRUSS 40X40 14m\n";
+  assert(RiderImporter::ImportText(headerCoordinateOverrideWithoutColon));
+  const auto &sceneHeaderOverride = cfg.GetScene();
+  int headerFixtures = 0;
+  int headerTrusses = 0;
+  for (const auto &[uuid, fixture] : sceneHeaderOverride.fixtures) {
+    (void)uuid;
+    if (fixture.positionName == "LX1")
+      ++headerFixtures;
+  }
+  for (const auto &[uuid, truss] : sceneHeaderOverride.trusses) {
+    (void)uuid;
+    if (truss.positionName != "LX1")
+      continue;
+    ++headerTrusses;
+    assert(NearlyEqual(truss.transform.o[1], 6000.0f));
+  }
+  assert(headerFixtures == 2);
+  assert(headerTrusses > 0);
+
   return 0;
 }

--- a/tests/rider_lx_sides_import_test.cpp
+++ b/tests/rider_lx_sides_import_test.cpp
@@ -125,5 +125,59 @@ int main() {
   assert(filteredSidesCount == 4);
   assert(filteredLx3Count == 2);
 
+  cfg.Reset();
+  cfg.SetValue("ui_distance_unit_system", "metric");
+  const std::string withCoordinateOverrideMetric =
+      "RIGGING\n"
+      "1 TRUSS LX1 (abc 0, -1, 9 z) 14m\n";
+  assert(RiderImporter::ImportText(withCoordinateOverrideMetric));
+  const auto &sceneMetric = cfg.GetScene();
+  int metricTrussCount = 0;
+  for (const auto &[uuid, truss] : sceneMetric.trusses) {
+    (void)uuid;
+    ++metricTrussCount;
+    assert(truss.positionName == "LX1");
+    assert(NearlyEqual(truss.transform.o[0], 0.0f));
+    assert(NearlyEqual(truss.transform.o[1], -1000.0f));
+    assert(NearlyEqual(truss.transform.o[2], 9000.0f));
+  }
+  assert(metricTrussCount > 0);
+
+  cfg.Reset();
+  cfg.SetValue("ui_distance_unit_system", "imperial");
+  const std::string withCoordinateOverrideImperial =
+      "RIGGING\n"
+      "1 TRUSS LX1 (2, 10) 14m\n";
+  assert(RiderImporter::ImportText(withCoordinateOverrideImperial));
+  const auto &sceneImperial = cfg.GetScene();
+  int imperialTrussCount = 0;
+  for (const auto &[uuid, truss] : sceneImperial.trusses) {
+    (void)uuid;
+    ++imperialTrussCount;
+    assert(truss.positionName == "LX1");
+    // Two values map to Y/Z in active distance units (feet here).
+    assert(NearlyEqual(truss.transform.o[1], 2.0f * 304.8f));
+    assert(NearlyEqual(truss.transform.o[2], 10.0f * 304.8f));
+  }
+  assert(imperialTrussCount > 0);
+
+  cfg.Reset();
+  cfg.SetValue("ui_distance_unit_system", "metric");
+  const std::string withSingleCoordinateOverride =
+      "RIGGING\n"
+      "1 TRUSS LX1 (7) 14m\n";
+  assert(RiderImporter::ImportText(withSingleCoordinateOverride));
+  const auto &sceneSingle = cfg.GetScene();
+  int singleTrussCount = 0;
+  for (const auto &[uuid, truss] : sceneSingle.trusses) {
+    (void)uuid;
+    ++singleTrussCount;
+    assert(truss.positionName == "LX1");
+    // One value maps only to Y; X/Z keep defaults for LX1.
+    assert(NearlyEqual(truss.transform.o[1], 7000.0f));
+    assert(NearlyEqual(truss.transform.o[2], 10000.0f));
+  }
+  assert(singleTrussCount > 0);
+
   return 0;
 }


### PR DESCRIPTION
### Motivation
- Allow users to override default truss placement when importing riders from text by appending coordinates in parentheses to the hang token, with values interpreted in the active distance unit system.

### Description
- Added parsing of parenthesized coordinate overrides and conversion to millimeters using the active UI distance unit system via `Units::ParseDistanceUnitSystem` and `Units::DistanceDisplayToMillimeters` in `core/riderimporter.cpp` (new `TrussCoordinateOverride` + `ParseTrussCoordinateOverride`).
- Applied overrides to truss placement in both the explicit `N truss MODEL LENGTH` path and the generic fallback `truss ... LENGTH` path, following mapping rules: `3 → x,y,z`, `2 → y,z` (keep default x), `1 → y` (keep default x,z).
- Ignored non-numeric text inside parentheses when extracting numbers and removed the parenthesized text from the parsed hang/model token before continuing parsing.
- Updated user-visible docs and help: `docs/text_to_scene_rules.md` and `README.md` describe the new syntax, and added tests in `tests/rider_lx_sides_import_test.cpp` to cover metric/imperial/single-value cases.

### Testing
- Ran repository checks: `tests/check_perastage_tree_modules.sh` — OK.
- Ran repository checks: `tests/check_no_configmanager_get_in_gui.sh` — OK.
- Added/updated C++ test assertions in `tests/rider_lx_sides_import_test.cpp`; full C++ test execution could not be completed in this environment because local CMake configure failed due to missing `wxWidgets` (dependency not available), so build-run of the test suite was not performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca37acd0f8832480de93957c3e29c9)