### PR TITLE
Make wireframe lines visible in dark mode (Viewer2D)

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -123,6 +123,7 @@ struct Viewer3DController::Impl {
   bool captureUseSymbols = false;
   SymbolCache bottomSymbolCache;
   bool darkMode = false;
+  Viewer2DRenderMode activeRenderMode = Viewer2DRenderMode::White;
   bool showSelectionOutline2D = false;
   bool isInteracting = false;
   bool cameraMoving = false;
@@ -899,6 +900,7 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
                                      bool is2DViewer,
                                      bool preferPerastageSvgSymbolsForLayouts) {
   ConfigManager &cfg = ConfigManager::Get();
+  m_impl->activeRenderMode = mode;
 
   RenderFrameContext context;
   context.wireframe = wireframe;
@@ -1165,6 +1167,9 @@ std::array<float, 3> Viewer3DController::AdjustColor(float r, float g,
                                                      float b) const {
   if (!m_impl->darkMode)
     return {r, g, b};
+  if (m_impl->activeRenderMode == Viewer2DRenderMode::Wireframe &&
+      r == 0.0f && g == 0.0f && b == 0.0f)
+    return {1.0f, 1.0f, 1.0f};
   return {r, g, b};
 }
 


### PR DESCRIPTION
### Motivation
- On-screen 2D wireframe lines drawn as pure black are not visible in dark mode, so the viewer needs to invert those strokes for the display while leaving capture/print output unchanged.

### Description
- Track the active 2D render mode in `Viewer3DController::Impl` and set it at the start of `RenderScene` so the controller knows when the viewer is in `Wireframe` mode, implemented in `viewer3d/viewer3dcontroller.cpp`.
- Update `AdjustColor`/`SetGLColor` to return white for pure-black input when `darkMode` is enabled and `activeRenderMode == Viewer2DRenderMode::Wireframe`, affecting only on-screen GL color paths and not capture/export logic.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca3eca472883248cd7936ff5b8a01d)