### PR TITLE
Apply loaded rider file title to untitled text-created projects

### DIFF
--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -278,6 +278,13 @@ void MainWindow::OnImportRiderText(wxCommandEvent &WXUNUSED(event)) {
 
   if (consolePanel)
     consolePanel->AppendMessage("[INFO] Imported rider from text.");
+  if (currentProjectPath.empty() && currentProjectDisplayName.IsEmpty()) {
+    const wxString loadedFileTitle = dlg.GetLoadedFileTitle();
+    if (!loadedFileTitle.IsEmpty()) {
+      currentProjectDisplayName = loadedFileTitle;
+      UpdateTitle();
+    }
+  }
   RefreshAfterSceneChange();
 }
 

--- a/gui/ridertextdialog.cpp
+++ b/gui/ridertextdialog.cpp
@@ -19,6 +19,7 @@
 
 #include <wx/button.h>
 #include <wx/filedlg.h>
+#include <wx/filename.h>
 #include <wx/msgdlg.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
@@ -93,6 +94,16 @@ const std::string &RiderTextDialog::GetRiderTextUtf8() const {
   return selectedRiderTextUtf8;
 }
 
+wxString RiderTextDialog::GetLoadedFileTitle() const {
+  if (!sourceLoadedFromFile)
+    return wxEmptyString;
+
+  const wxString fileTitle = wxFileName(sourceLabel).GetName();
+  if (fileTitle.IsEmpty())
+    return wxEmptyString;
+  return fileTitle;
+}
+
 bool RiderTextDialog::TryGetCurrentText(std::string &outText) const {
   if (!textCtrl)
     return false;
@@ -156,6 +167,7 @@ void RiderTextDialog::OnLoadFromFile(wxCommandEvent &WXUNUSED(event)) {
     return;
   }
   sourceLabel = dlg.GetFilename();
+  sourceLoadedFromFile = true;
   if (sourceText)
     sourceText->SetLabel(wxString("Loaded: ") + sourceLabel);
   textCtrl->ChangeValue(loadedText);
@@ -186,6 +198,7 @@ void RiderTextDialog::OnLoadExample(wxCommandEvent &WXUNUSED(event)) {
       "1 truss lx3 12 m\n";
   textCtrl->ChangeValue(exampleText);
   sourceLabel = "Example text";
+  sourceLoadedFromFile = false;
   if (sourceText)
     sourceText->SetLabel(wxString("Loaded: ") + sourceLabel);
 }

--- a/gui/ridertextdialog.h
+++ b/gui/ridertextdialog.h
@@ -30,6 +30,7 @@ public:
                            const wxString &initialText = wxEmptyString,
                            const wxString &initialSource = wxEmptyString);
   const std::string &GetRiderTextUtf8() const;
+  wxString GetLoadedFileTitle() const;
 
 private:
   bool TryGetCurrentText(std::string &outText) const;
@@ -41,6 +42,7 @@ private:
   wxTextCtrl *textCtrl = nullptr;
   wxStaticText *sourceText = nullptr;
   wxString sourceLabel;
+  bool sourceLoadedFromFile = false;
   std::string selectedRiderTextUtf8;
 
   wxDECLARE_EVENT_TABLE();


### PR DESCRIPTION
### Motivation
- When creating a scene via the "Create by text" flow after loading a rider file, the project window should adopt the loaded file's name instead of remaining "Untitled".

### Description
- Added `sourceLoadedFromFile` and `GetLoadedFileTitle()` to `RiderTextDialog` and set the flag when loading from a file (not when using the example); updated `MainWindow::OnImportRiderText` to set `currentProjectDisplayName` from `dlg.GetLoadedFileTitle()` when `currentProjectPath` and `currentProjectDisplayName` are empty and then call `UpdateTitle()`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca3ede79e083248fd2827a0c51958e)