### PR TITLE
Fix rider test executables missing Units linkage

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -217,6 +217,7 @@ add_executable(rider_truss_dictionary_normalization_test
                gdtfloader_stub.cpp
                consolepanel_stub.cpp
                ../core/riderimporter.cpp
+               ../core/units/units.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -396,6 +397,7 @@ add_executable(rider_save_roundtrip_test rider_save_roundtrip_test.cpp
                gdtfloader_stub.cpp
                consolepanel_stub.cpp
                ../core/riderimporter.cpp
+               ../core/units/units.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
                ../core/autopatcher.cpp
@@ -429,6 +431,7 @@ add_executable(riderimporter_fixtureid_test rider_import_fixtureid_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
@@ -456,6 +459,7 @@ add_executable(rider_import_order_test rider_import_order_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
@@ -482,6 +486,7 @@ add_executable(rider_import_preserve_existing_test rider_import_preserve_existin
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
@@ -507,6 +512,7 @@ add_executable(rider_import_category_test rider_import_category_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
@@ -532,6 +538,7 @@ add_executable(rider_autopatch_test rider_autopatch_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_onech_stub.cpp
                ../core/riderimporter.cpp
+               ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
@@ -558,6 +565,7 @@ add_executable(rider_layer_mode_test rider_layer_mode_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
@@ -596,6 +604,7 @@ add_executable(rider_filter_preview_test rider_filter_preview_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
@@ -621,6 +630,7 @@ add_executable(rider_led_screen_object_test rider_led_screen_object_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
@@ -646,6 +656,7 @@ add_executable(rider_hoist_import_test rider_hoist_import_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
@@ -672,6 +683,7 @@ add_executable(rider_lx_sides_import_test rider_lx_sides_import_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp
@@ -697,6 +709,7 @@ add_executable(rider_import_benchmark rider_import_benchmark.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp
                ../core/riderimporter.cpp
+               ../core/units/units.cpp
                ../core/gdtf_fixture_category.cpp
                ../core/hoist_weight_distribution.cpp
                ../core/uuidutils.cpp


### PR DESCRIPTION
### Motivation
- Rider-related test binaries that compile `../core/riderimporter.cpp` were failing to link because they did not include the translation unit that implements `Units::ParseDistanceUnitSystem` and `Units::DistanceDisplayToMillimeters`.

### Description
- Updated `tests/CMakeLists.txt` to add `../core/units/units.cpp` to every rider-related test target that directly lists `../core/riderimporter.cpp` so the `Units` symbols are provided at link time.
- The change touches the rider test targets in `tests/CMakeLists.txt` (13 test targets were updated to include the units source).

### Testing
- Ran repository checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both succeeded.
- Attempted to configure the project with `cmake --preset wsl-x64-debug`, but configuration could not complete in this environment because the system is missing `wxWidgets` developer libraries, so a full build/test run was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca3fd3d43883248c9fe426a72fd3ca)