### PR TITLE
Fix LX SIDES fallback Y anchor for text import

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -2381,10 +2381,10 @@ bool RiderImporter::ImportText(const std::string &text) {
           return;
         const float startY = sideTrussInfo.found
                                  ? sideTrussInfo.startY + getHangMargin("LX1")
-                                 : -0.5f * ((count - 1) * 500.0f);
+                                 : 1000.0f;
         const float endY = sideTrussInfo.found
                                ? sideTrussInfo.endY - getHangMargin("LX1")
-                               : 0.5f * ((count - 1) * 500.0f);
+                               : startY + static_cast<float>(count - 1) * 500.0f;
         const float step = count > 1 ? (endY - startY) / static_cast<float>(count - 1)
                                      : 0.0f;
         for (int i = 0; i < count; ++i) {

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -302,7 +302,8 @@ After parsing, imported fixtures are distributed per hang:
 2. Margin comes from `rider_lx*_margin` (for LX hangs).
 3. If no truss is found for a hang, fallback spacing is centered around origin with 500 mm steps.
    - Exception for `LX SIDES`: fixtures are still split into left/right groups
-     as if side trusses existed, but fallback height is `1.0 m`.
+     as if side trusses existed, with fallback anchors at `Y = 1.0 m`
+     and `500 mm` spacing moving upstage (positive Y).
 4. Ordering alternates fixture types symmetrically:
    - odd counts place a center fixture,
    - remaining fixtures are paired left/right.

--- a/tests/rider_lx_sides_import_test.cpp
+++ b/tests/rider_lx_sides_import_test.cpp
@@ -83,6 +83,7 @@ int main() {
   int noTrussFixtureCount = 0;
   int lx3FixtureCount = 0;
   std::set<float> noTrussSideX;
+  std::vector<float> noTrussSideY;
   for (const auto &[uuid, fixture] : sceneNoTruss.fixtures) {
     (void)uuid;
     if (fixture.positionName != "LX SIDES")
@@ -92,11 +93,14 @@ int main() {
       assert(NearlyEqual(fixture.transform.o[2], 1000.0f));
       assert(fixture.layer == "pos SIDES");
       noTrussSideX.insert(fixture.transform.o[0]);
+      noTrussSideY.push_back(fixture.transform.o[1]);
     }
   }
   assert(noTrussFixtureCount == 4);
   assert(lx3FixtureCount == 2);
   assert(noTrussSideX.size() == 2);
+  assert(!noTrussSideY.empty());
+  assert(*std::min_element(noTrussSideY.begin(), noTrussSideY.end()) >= 1000.0f);
   assert(NearlyEqual(*noTrussSideX.begin(), -6500.0f));
   assert(NearlyEqual(*noTrussSideX.rbegin(), 6500.0f));
 


### PR DESCRIPTION
### Motivation
- Imported side fixtures (`LX SIDES`) created from rider text were positioned centered at `Y = 0` when no side truss existed, which places devices too far downstage; the fallback should start at stage floor level offset `Y = 1.0 m` and move upstage from there.

### Description
- Change in `core/riderimporter.cpp`: when placing `LX SIDES` fixtures with no side truss found, set fallback `startY` to `1000.0f` (1.0 m) and compute `endY` as `startY + (count-1) * 500.0f` so fixtures are spaced `500 mm` upstage from the 1.0 m anchor.
- Update `docs/text_to_scene_rules.md` to describe the new fallback behavior for `LX SIDES` (anchors at `Y = 1.0 m` and `500 mm` spacing moving upstage).
- Extend `tests/rider_lx_sides_import_test.cpp` to assert that fallback side fixtures do not start below `Y = 1000.0f` when no side truss exists.
- Kept changes focused and localized to the rider importer and its documentation/test, satisfying the text-to-scene documentation policy.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded (`OK`).
- Attempt to build/run `rider_lx_sides_import_test` was not executed in this environment because `build/tests` is not present, so the compiled test binary was not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca4261a4b4832492fd430c9f27a0e1)