### PR TITLE
Parse and place backdrop (telón) trusses and assign hoists

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -1085,6 +1085,12 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
             targetMatch.size() > 1) {
           hang = targetMatch[1].str();
           model = Trim(model.substr(0, static_cast<size_t>(targetMatch.position(0))));
+        } else if (std::smatch trailingHangMatch;
+                   std::regex_search(model, trailingHangMatch, kHangFindRe) &&
+                   trailingHangMatch.position(0) + trailingHangMatch.length(0) ==
+                       static_cast<std::ptrdiff_t>(model.size())) {
+          hang = trailingHangMatch[1].str();
+          model = Trim(model.substr(0, static_cast<size_t>(trailingHangMatch.position(0))));
         } else if (std::regex_match(model, kHangOnlyRe)) {
           hang = model;
           model.clear();
@@ -1785,6 +1791,14 @@ bool RiderImporter::ImportText(const std::string &text) {
               targetMatch.size() > 1) {
             hang = Trim(targetMatch[1].str());
             model = Trim(model.substr(0, static_cast<size_t>(targetMatch.position(0))));
+            coordinateOverride =
+                ParseTrussCoordinateOverride(hang, distanceUnitSystem);
+          } else if (std::smatch trailingHangMatch;
+                     std::regex_search(model, trailingHangMatch, kHangFindRe) &&
+                     trailingHangMatch.position(0) + trailingHangMatch.length(0) ==
+                         static_cast<std::ptrdiff_t>(model.size())) {
+            hang = Trim(trailingHangMatch[1].str());
+            model = Trim(model.substr(0, static_cast<size_t>(trailingHangMatch.position(0))));
             coordinateOverride =
                 ParseTrussCoordinateOverride(hang, distanceUnitSystem);
           } else if (std::regex_match(model, kHangOnlyRe)) {

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -61,11 +61,13 @@ namespace {
 // the compilation cost on every import call and makes keyword matching cheap
 // even when processing large riders.
 static const std::regex kTrussLineRe(
-    "^\\s*(?:[-*]\\s*)?(\\d+)\\s+(?:truss)\\s+([^\\n]*?)\\s+(\\d+(?:\\.\\d+)?)\\s*(?:m|metros?|meters?)\\b(?:\\s+para\\s+(.+))?",
+    "^\\s*(?:[-*]\\s*)?(\\d+)\\s+(?:truss)\\s+([^\\n]*?)(?:\\s+(\\d+(?:\\.\\d+)?)\\s*(?:m|metros?|meters?)\\b)?(?:\\s+para\\s+(.+))?",
     std::regex::icase);
 static const std::regex kTrussRe(
     "(?:truss)[^\\n]*?(\\d+(?:\\.\\d+)?)\\s*(?:m|metros?|meters?)\\b",
     std::regex::icase);
+static const std::regex kLengthWithUnitRe(
+    "(\\d+(?:\\.\\d+)?)\\s*(?:m|metros?|meters?)\\b", std::regex::icase);
 static const std::regex kHoistLineRe(
     "^\\s*(?:[-*]\\s*)?(\\d+)\\s+(?:motor(?:es)?|hoist(?:s)?)\\b(.*)$",
     std::regex::icase);
@@ -77,16 +79,16 @@ static const std::regex kFixtureLineRe("^\\s*(?:[-*]\\s*)?(\\d+)\\s+(.+)$",
                                        std::regex::icase);
 static const std::regex kQuantityOnlyRe("^\\s*(?:[-*]\\s*)?(\\d+)\\s*$");
 static const std::regex kHangLineRe(
-    "^\\s*(LX\\d+|lx\\s*sides?|screen|pantalla|led\\s*screen|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)(?:\\s*\\([^\\)]*\\))?\\s*:?\\s*$",
+    "^\\s*(LX\\d+|lx\\s*sides?|screen|pantalla|led\\s*screen|backdrops?|tel[oó]n(?:es)?|puente\\s+de\\s+tel[oó]n(?:es)?|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)(?:\\s*\\([^\\)]*\\))?\\s*:?\\s*$",
     std::regex::icase);
 static const std::regex kHangHeaderWithSuffixRe(
-    "^\\s*(LX\\d+|lx\\s*sides?|screen|pantalla|led\\s*screen|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)(?:\\s+[^:]*)?\\s*:\\s*$",
+    "^\\s*(LX\\d+|lx\\s*sides?|screen|pantalla|led\\s*screen|backdrops?|tel[oó]n(?:es)?|puente\\s+de\\s+tel[oó]n(?:es)?|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)(?:\\s+[^:]*)?\\s*:\\s*$",
     std::regex::icase);
 static const std::regex kHangFindRe(
-    "(LX\\d+|lx\\s*sides?|screen|pantalla|led\\s*screen|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)",
+    "(LX\\d+|lx\\s*sides?|screen|pantalla|led\\s*screen|backdrops?|tel[oó]n(?:es)?|puente\\s+de\\s+tel[oó]n(?:es)?|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)",
                                     std::regex::icase);
 static const std::regex kHangOnlyRe(
-    "^\\s*(LX\\d+|lx\\s*sides?|screen|pantalla|led\\s*screen|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)\\s*$",
+    "^\\s*(LX\\d+|lx\\s*sides?|screen|pantalla|led\\s*screen|backdrops?|tel[oó]n(?:es)?|puente\\s+de\\s+tel[oó]n(?:es)?|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)\\s*$",
                                     std::regex::icase);
 std::string Trim(const std::string &s) {
   size_t start = s.find_first_not_of(" \t\r\n");
@@ -484,6 +486,9 @@ std::string NormalizeHangName(const std::string &raw) {
     return "SCREEN";
   if (hang == "SCREEN" || hang == "LEDSCREEN")
     return "SCREEN";
+  if (hang == "BACKDROP" || hang == "BACKDROPS" || hang == "TELON" ||
+      hang == "TELONES")
+    return "BACKDROP";
   if (hang == "SIDE FILL")
     return "SIDEFILL";
   if (hang == "P.A." || hang == "P.A" || hang == "PA")
@@ -1184,6 +1189,9 @@ bool RiderImporter::ImportText(const std::string &text) {
       Units::ParseDistanceUnitSystem(cfg.GetValue("ui_distance_unit_system"));
   std::optional<float> lastLightingTrussPosY;
   std::optional<float> lastLightingTrussPosZ;
+  std::optional<float> lastBackdropReferencePosY;
+  std::optional<float> lastBackdropReferencePosZ;
+  std::optional<float> lastBackdropReferenceLengthMm;
 
   auto getHangHeight = [&](const std::string &posName) {
     if (posName.rfind("LX", 0) == 0) {
@@ -1204,6 +1212,18 @@ bool RiderImporter::ImportText(const std::string &text) {
           return configuredHeight * 1000.0f - 500.0f;
       }
     }
+    if (posName == "BACKDROP") {
+      if (lastBackdropReferencePosZ)
+        return *lastBackdropReferencePosZ;
+      if (lastLightingTrussPosZ)
+        return *lastLightingTrussPosZ;
+      for (int idx = 6; idx >= 1; --idx) {
+        const float configuredHeight =
+            cfg.GetFloat("rider_lx" + std::to_string(idx) + "_height");
+        if (configuredHeight > 0.0f)
+          return configuredHeight * 1000.0f;
+      }
+    }
     return 0.0f;
   };
 
@@ -1217,6 +1237,18 @@ bool RiderImporter::ImportText(const std::string &text) {
       }
     }
     if (posName == "SCREEN") {
+      if (lastLightingTrussPosY)
+        return *lastLightingTrussPosY + 1000.0f;
+      for (int idx = 6; idx >= 1; --idx) {
+        const float configuredPos =
+            cfg.GetFloat("rider_lx" + std::to_string(idx) + "_pos");
+        if (configuredPos != 0.0f || idx == 1)
+          return configuredPos * 1000.0f + 1000.0f;
+      }
+    }
+    if (posName == "BACKDROP") {
+      if (lastBackdropReferencePosY)
+        return *lastBackdropReferencePosY + 1000.0f;
       if (lastLightingTrussPosY)
         return *lastLightingTrussPosY + 1000.0f;
       for (int idx = 6; idx >= 1; --idx) {
@@ -1447,9 +1479,15 @@ bool RiderImporter::ImportText(const std::string &text) {
           continue;
         std::string model = Trim(m[2]);
         float length = 0.0f;
-        if (!TryParseFloat(m[3], length))
-          continue;
-        length *= 1000.0f;
+        if (m.size() > 3 && m[3].matched)
+          TryParseFloat(m[3], length);
+        if (length <= 0.0f) {
+          std::smatch lm;
+          if (std::regex_search(model, lm, kLengthWithUnitRe))
+            TryParseFloat(lm[1].str(), length);
+        }
+        if (length > 0.0f)
+          length *= 1000.0f;
         float width = 400.0f;
         float height = 400.0f;
         std::smatch dm;
@@ -1489,6 +1527,11 @@ bool RiderImporter::ImportText(const std::string &text) {
         hang = NormalizeHangName(hang);
         if (hang == "FLOOR")
           continue;
+        if (length <= 0.0f) {
+          if (hang != "BACKDROP")
+            continue;
+          length = lastBackdropReferenceLengthMm.value_or(12000.0f);
+        }
 
         auto formatLength = [](float mm) {
           std::ostringstream oss;
@@ -1643,6 +1686,11 @@ bool RiderImporter::ImportText(const std::string &text) {
             }
             x += s;
             yStart += s;
+          }
+          if (IsLxHangName(posName) || posName == "SCREEN") {
+            lastBackdropReferencePosY = hangY;
+            lastBackdropReferencePosZ = hangZ;
+            lastBackdropReferenceLengthMm = total;
           }
         };
 
@@ -1808,6 +1856,11 @@ bool RiderImporter::ImportText(const std::string &text) {
           if (IsLxHangName(hang)) {
             lastLightingTrussPosY = hangY;
             lastLightingTrussPosZ = hangZ;
+          }
+          if (IsLxHangName(hang) || hang == "SCREEN") {
+            lastBackdropReferencePosY = hangY;
+            lastBackdropReferencePosZ = hangZ;
+            lastBackdropReferenceLengthMm = total;
           }
           x += s;
         }

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -1838,6 +1838,15 @@ bool RiderImporter::ImportText(const std::string &text) {
           float x = coordinateOverride && coordinateOverride->hasX
                         ? coordinateOverride->xMm
                         : -0.5f * total;
+          auto formatLength = [](float mm) {
+            std::ostringstream oss;
+            oss << std::fixed << std::setprecision(2) << mm / 1000.0f;
+            std::string s = oss.str();
+            s.erase(s.find_last_not_of('0') + 1, std::string::npos);
+            if (!s.empty() && s.back() == '.')
+              s.pop_back();
+            return s + "M";
+          };
           for (float s : pieces) {
             Truss t;
             t.uuid = GenerateUuid();
@@ -1849,6 +1858,50 @@ bool RiderImporter::ImportText(const std::string &text) {
             t.transform.o[0] = x;
             t.transform.o[1] = hangY;
             t.transform.o[2] = hangZ;
+            const std::string sizeStr = formatLength(s);
+            if (model.empty())
+              t.name = "TRUSS " + sizeStr;
+            else
+              t.name = "TRUSS " + model + " " + sizeStr;
+            t.model = model.empty() ? TrussDictionary::NormalizeModelKey(t.name)
+                                    : TrussDictionary::NormalizeModelKey(model);
+
+            const std::vector<std::string> dictionaryLookupKeys =
+                BuildTrussDictionaryLookupKeys(model, t.name);
+            std::optional<std::string> dictPath;
+            for (const std::string &lookupKey : dictionaryLookupKeys) {
+              if (lookupKey.empty())
+                continue;
+              dictPath = TrussDictionary::Get(lookupKey);
+              if (dictPath)
+                break;
+            }
+            if (dictPath) {
+              Truss parsed;
+              if (LoadTrussDefinition(*dictPath, parsed)) {
+                if (!parsed.symbolFile.empty())
+                  t.symbolFile = parsed.symbolFile;
+                t.modelFile = parsed.modelFile.empty() ? *dictPath : parsed.modelFile;
+                t.gdtfSpec = parsed.gdtfSpec;
+                t.gdtfMode = parsed.gdtfMode;
+                if (!parsed.manufacturer.empty())
+                  t.manufacturer = parsed.manufacturer;
+                if (!parsed.model.empty())
+                  t.model = TrussDictionary::NormalizeModelKey(parsed.model);
+                if (parsed.lengthMm > 0.0f)
+                  t.lengthMm = parsed.lengthMm;
+                if (parsed.widthMm > 0.0f)
+                  t.widthMm = parsed.widthMm;
+                if (parsed.heightMm > 0.0f)
+                  t.heightMm = parsed.heightMm;
+                if (parsed.weightKg > 0.0f)
+                  t.weightKg = parsed.weightKg;
+                if (!parsed.crossSection.empty())
+                  t.crossSection = parsed.crossSection;
+              } else {
+                t.modelFile = *dictPath;
+              }
+            }
             const std::string trussUuid = t.uuid;
             const std::string trussLayer = t.layer;
             scene.trusses.emplace(trussUuid, std::move(t));

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -552,6 +552,7 @@ void AssignImportedHoistNames(std::vector<Support *> &supports) {
 
   std::map<std::string, std::vector<Support *>> lxByPosition;
   std::vector<Support *> screenSupports;
+  std::vector<Support *> backdropSupports;
   std::vector<Support *> sidefillSupports;
   std::vector<Support *> paSupports;
   std::vector<Support *> otherSupports;
@@ -564,6 +565,8 @@ void AssignImportedHoistNames(std::vector<Support *> &supports) {
       lxByPosition[position].push_back(support);
     } else if (position == "SCREEN") {
       screenSupports.push_back(support);
+    } else if (position == "BACKDROP") {
+      backdropSupports.push_back(support);
     } else if (position == "SIDEFILL") {
       sidefillSupports.push_back(support);
     } else if (position == "PA" || position == "P.A.") {
@@ -590,6 +593,13 @@ void AssignImportedHoistNames(std::vector<Support *> &supports) {
   for (size_t i = 0; i < screenSupports.size(); ++i) {
     Support *support = screenSupports[i];
     support->name = "SCR " + std::to_string(i + 1);
+    support->motorName = support->name;
+  }
+
+  std::sort(backdropSupports.begin(), backdropSupports.end(), sortByX);
+  for (size_t i = 0; i < backdropSupports.size(); ++i) {
+    Support *support = backdropSupports[i];
+    support->name = "BACKDROP " + std::to_string(i + 1);
     support->motorName = support->name;
   }
 

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -1079,6 +1079,16 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
             coordinateSuffix.has_value()) {
           trussCoordinateSuffix = *coordinateSuffix;
         }
+      } else {
+        std::smatch targetMatch;
+        if (std::regex_search(model, targetMatch, kHoistTargetRe) &&
+            targetMatch.size() > 1) {
+          hang = targetMatch[1].str();
+          model = Trim(model.substr(0, static_cast<size_t>(targetMatch.position(0))));
+        } else if (std::regex_match(model, kHangOnlyRe)) {
+          hang = model;
+          model.clear();
+        }
       }
       if (trussCoordinateSuffix.empty()) {
         const auto it = hangCoordinateSuffixByHang.find(NormalizeHangName(hang));
@@ -1769,6 +1779,18 @@ bool RiderImporter::ImportText(const std::string &text) {
           hang = Trim(m[3]);
           coordinateOverride =
               ParseTrussCoordinateOverride(hang, distanceUnitSystem);
+        } else {
+          std::smatch targetMatch;
+          if (std::regex_search(model, targetMatch, kHoistTargetRe) &&
+              targetMatch.size() > 1) {
+            hang = Trim(targetMatch[1].str());
+            model = Trim(model.substr(0, static_cast<size_t>(targetMatch.position(0))));
+            coordinateOverride =
+                ParseTrussCoordinateOverride(hang, distanceUnitSystem);
+          } else if (std::regex_match(model, kHangOnlyRe)) {
+            hang = model;
+            model.clear();
+          }
         }
         hang = NormalizeHangName(hang);
         if (hang != "BACKDROP")

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -61,7 +61,10 @@ namespace {
 // the compilation cost on every import call and makes keyword matching cheap
 // even when processing large riders.
 static const std::regex kTrussLineRe(
-    "^\\s*(?:[-*]\\s*)?(\\d+)\\s+(?:truss)\\s+([^\\n]*?)(?:\\s+(\\d+(?:\\.\\d+)?)\\s*(?:m|metros?|meters?)\\b)?(?:\\s+para\\s+(.+))?",
+    "^\\s*(?:[-*]\\s*)?(\\d+)\\s+(?:truss)\\s+([^\\n]*?)\\s+(\\d+(?:\\.\\d+)?)\\s*(?:m|metros?|meters?)\\b(?:\\s+para\\s+(.+))?",
+    std::regex::icase);
+static const std::regex kTrussLineNoLengthRe(
+    "^\\s*(?:[-*]\\s*)?(\\d+)\\s+(?:truss)\\s+([^\\n]*?)(?:\\s+para\\s+(.+))?\\s*$",
     std::regex::icase);
 static const std::regex kTrussRe(
     "(?:truss)[^\\n]*?(\\d+(?:\\.\\d+)?)\\s*(?:m|metros?|meters?)\\b",
@@ -1062,6 +1065,42 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
       continue;
     }
 
+    if (std::regex_match(line, m, kTrussLineNoLengthRe) &&
+        !std::regex_search(line, kLengthWithUnitRe)) {
+      int quantity = 0;
+      if (!TryParseInt(m[1].str(), quantity) || quantity <= 0)
+        continue;
+      std::string model = Trim(m[2]);
+      std::string hang = currentHang;
+      std::string trussCoordinateSuffix;
+      if (m.size() > 3 && m[3].matched) {
+        hang = m[3].str();
+        if (const auto coordinateSuffix = ExtractParenthesizedToken(hang);
+            coordinateSuffix.has_value()) {
+          trussCoordinateSuffix = *coordinateSuffix;
+        }
+      }
+      if (trussCoordinateSuffix.empty()) {
+        const auto it = hangCoordinateSuffixByHang.find(NormalizeHangName(hang));
+        if (it != hangCoordinateSuffixByHang.end())
+          trussCoordinateSuffix = it->second;
+      }
+      hang = NormalizeHangName(hang);
+      if (hang != "BACKDROP")
+        continue;
+
+      for (int i = 0; i < quantity; ++i) {
+        std::string out = "1 TRUSS";
+        if (!model.empty())
+          out += " " + model;
+        out += " " + hang;
+        if (!trussCoordinateSuffix.empty())
+          out += " " + trussCoordinateSuffix;
+        riggingLines.push_back(out);
+      }
+      continue;
+    }
+
     if (std::regex_search(line, m, kTrussRe)) {
       float lengthM = 0.0f;
       if (!TryParseFloat(m[1].str(), lengthM))
@@ -1479,15 +1518,9 @@ bool RiderImporter::ImportText(const std::string &text) {
           continue;
         std::string model = Trim(m[2]);
         float length = 0.0f;
-        if (m.size() > 3 && m[3].matched)
-          TryParseFloat(m[3], length);
-        if (length <= 0.0f) {
-          std::smatch lm;
-          if (std::regex_search(model, lm, kLengthWithUnitRe))
-            TryParseFloat(lm[1].str(), length);
-        }
-        if (length > 0.0f)
-          length *= 1000.0f;
+        if (!TryParseFloat(m[3], length))
+          continue;
+        length *= 1000.0f;
         float width = 400.0f;
         float height = 400.0f;
         std::smatch dm;
@@ -1527,11 +1560,6 @@ bool RiderImporter::ImportText(const std::string &text) {
         hang = NormalizeHangName(hang);
         if (hang == "FLOOR")
           continue;
-        if (length <= 0.0f) {
-          if (hang != "BACKDROP")
-            continue;
-          length = lastBackdropReferenceLengthMm.value_or(12000.0f);
-        }
 
         auto formatLength = [](float mm) {
           std::ostringstream oss;
@@ -1728,6 +1756,70 @@ bool RiderImporter::ImportText(const std::string &text) {
         } else {
           for (int i = 0; i < quantity; ++i)
             addTrussPieces(hang, resolveCoordinateOverride(hang));
+        }
+      } else if (std::regex_match(line, m, kTrussLineNoLengthRe) &&
+                 !std::regex_search(line, kLengthWithUnitRe)) {
+        int quantity = 0;
+        if (!TryParseInt(m[1].str(), quantity))
+          continue;
+        std::string model = Trim(m[2]);
+        std::string hang = currentHang;
+        std::optional<TrussCoordinateOverride> coordinateOverride;
+        if (m.size() > 3 && m[3].matched) {
+          hang = Trim(m[3]);
+          coordinateOverride =
+              ParseTrussCoordinateOverride(hang, distanceUnitSystem);
+        }
+        hang = NormalizeHangName(hang);
+        if (hang != "BACKDROP")
+          continue;
+
+        float width = 400.0f;
+        float height = 400.0f;
+        std::smatch dm;
+        if (std::regex_search(
+                model, dm,
+                std::regex("(\\d+(?:\\.\\d+)?)\\s*[xX]\\s*(\\d+(?:\\.\\d+)?)"))) {
+          float parsed = 0.0f;
+          if (TryParseFloat(dm[1], parsed))
+            width = parsed * 10.0f;
+          parsed = 0.0f;
+          if (TryParseFloat(dm[2], parsed))
+            height = parsed * 10.0f;
+        }
+
+        const float fallbackLengthMm =
+            lastBackdropReferenceLengthMm.value_or(12000.0f);
+        const float hangY = coordinateOverride && coordinateOverride->hasY
+                                ? coordinateOverride->yMm
+                                : getHangPos(hang);
+        const float hangZ = coordinateOverride && coordinateOverride->hasZ
+                                ? coordinateOverride->zMm
+                                : getHangHeight(hang);
+        for (int q = 0; q < quantity; ++q) {
+          auto pieces = SplitTrussSymmetric(fallbackLengthMm);
+          float total = std::accumulate(pieces.begin(), pieces.end(), 0.0f);
+          float x = coordinateOverride && coordinateOverride->hasX
+                        ? coordinateOverride->xMm
+                        : -0.5f * total;
+          for (float s : pieces) {
+            Truss t;
+            t.uuid = GenerateUuid();
+            t.layer = layerByType ? "truss " + hang : "pos " + hang;
+            t.lengthMm = s;
+            t.widthMm = width;
+            t.heightMm = height;
+            t.positionName = hang;
+            t.transform.o[0] = x;
+            t.transform.o[1] = hangY;
+            t.transform.o[2] = hangZ;
+            const std::string trussUuid = t.uuid;
+            const std::string trussLayer = t.layer;
+            scene.trusses.emplace(trussUuid, std::move(t));
+            importedTrussUuids.push_back(trussUuid);
+            addToLayer(trussLayer, trussUuid);
+            x += s;
+          }
         }
       } else if (std::regex_search(line, m, kTrussRe)) {
         float length = 0.0f;

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -269,6 +269,7 @@ Created hoists:
 - Hoist naming defaults (ordered left-to-right on `X`):
   - `LX*` targets => `<position> <index>` (`LX1 1`, `LX1 2`, ...).
   - `SCREEN`/video targets => `SCR <index>`.
+  - `BACKDROP` targets => `BACKDROP <index>`.
   - `SIDEFILL` => `SF L`, `SF R` (adds index when side has more than one hoist).
   - `PA`/`P.A.` => `PA L <index>`, `PA R <index>`.
   - Fallback targets => `RP <index>` (Rigging Point).

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -48,11 +48,13 @@ Filter behavior:
 7. Hoist lines using `PUENTES LX` are expanded and distributed over detected
    `LX*` targets in the same filtered rigging block.
 8. Truss hang alias `PANTALLA` is normalized to `SCREEN`.
-9. Truss lines normalized to `FLOOR` are skipped in filtered output/import.
-10. Expands `+` compound lines into individual fixture lines.
-11. Supports quantity-only lines (`N` followed by description on next line).
-12. Removes parenthesized notes from fixture tokens to reduce rider noise.
-13. The filter pass is idempotent for normalized truss lines ending in
+9. Truss hang aliases `BACKDROP`, `BACKDROPS`, `TELON`, `TELONES` are
+   normalized to `BACKDROP`.
+10. Truss lines normalized to `FLOOR` are skipped in filtered output/import.
+11. Expands `+` compound lines into individual fixture lines.
+12. Supports quantity-only lines (`N` followed by description on next line).
+13. Removes parenthesized notes from fixture tokens to reduce rider noise.
+14. The filter pass is idempotent for normalized truss lines ending in
     `SCREEN` (re-applying **Apply filter** keeps those lines).
 
 After applying the filter, users can manually adjust the filtered text and then
@@ -85,6 +87,7 @@ Recognized hang labels:
 
 - `LX<number>` (for example `LX1`, `LX2`, ...)
 - `screen` / `pantalla` / `led screen`
+- `backdrop` / `backdrops` / `telon` / `telones` / `puente de telon(es)`
 - `floor`
 - `efecto` / `efectos`
 - `calle a suelo` / `calles a suelo`
@@ -105,6 +108,8 @@ Behavior:
   in both filtered text and direct import input.
 - Screen aliases (`screen`, `pantalla`, `led screen`) are normalized to
   `SCREEN`.
+- Backdrop aliases (`backdrop(s)`, `telon(es)`, `puente de telon(es)`) are
+  normalized to `BACKDROP`.
 - The active hang affects fixture/truss layer naming and default placement (`Y/Z`).
 
 ## Fixture parsing rules
@@ -161,6 +166,7 @@ Special screen-object handling:
 Supported truss syntax includes:
 
 - `N truss MODEL LENGTH m [para HANG]`
+- `N truss MODEL [para HANG]` (lengthless form, used for backdrop lines)
 - More generic fallback lines containing `truss` and a measurable length.
 - Optional coordinate override appended to hang in parentheses, e.g.
   - `LX1 (0, -1, 9)` => `x, y, z`
@@ -176,6 +182,9 @@ Supported truss syntax includes:
 Key truss behaviors:
 
 1. Length is parsed in meters and converted to millimeters.
+   - For `BACKDROP` lines without explicit length, importer reuses the latest
+     parsed `LX*` or `SCREEN` truss span.
+   - If no prior `LX*`/`SCREEN` span exists, `BACKDROP` uses `12 m` by default.
 2. If model token contains dimensions like `40x40`, width/height defaults are inferred from it.
 3. `para <hang>` overrides current hang.
 4. Prefix cleanup supports `PUENTE`/`PUENTES` in hang names.
@@ -204,6 +213,8 @@ Special case:
   and `Z = last_lx_z - 0.5m`. If no LX truss has been created yet, importer
   falls back to the highest configured LX (`height > 0`) using the same
   offsets.
+- If hang is `BACKDROP`, trusses are placed `1 m` behind the latest parsed
+  `LX*` or `SCREEN` truss (`+Y`) and keep the same height (`Z`).
 
 ## Hoist (motor) parsing and placement rules
 

--- a/tests/rider_hoist_import_test.cpp
+++ b/tests/rider_hoist_import_test.cpp
@@ -108,8 +108,8 @@ int main() {
   assert(nameCounts["SCR 2"] == 1);
   assert(nameCounts["SCR 3"] == 1);
   assert(nameCounts["SCR 4"] == 1);
-  assert(nameCounts["RP 1"] == 1);
-  assert(nameCounts["RP 2"] == 1);
+  assert(nameCounts["BACKDROP 1"] == 1);
+  assert(nameCounts["BACKDROP 2"] == 1);
   assert(nameCounts["SF L"] == 1);
   assert(nameCounts["SF R"] == 1);
   assert(nameCounts["PA L 1"] == 1);

--- a/tests/rider_hoist_import_test.cpp
+++ b/tests/rider_hoist_import_test.cpp
@@ -137,5 +137,28 @@ int main() {
   assert(foundScreenTruss);
   assert(foundBackdropTruss);
 
+  cfg.Reset();
+  const std::string filteredBackdropOnlyText =
+      "RIGGING\n"
+      "1 TRUSS 40X40 PRO NEGRO 12m LX1\n"
+      "1 TRUSS 40X40 BACKDROP\n"
+      "2 MOTOR 500Kg PARA BACKDROP\n";
+  assert(RiderImporter::ImportText(filteredBackdropOnlyText));
+  const auto &filteredScene = cfg.GetScene();
+  bool foundFilteredBackdropTruss = false;
+  int filteredBackdropSupports = 0;
+  for (const auto &[uuid, truss] : filteredScene.trusses) {
+    (void)uuid;
+    if (truss.positionName == "BACKDROP")
+      foundFilteredBackdropTruss = true;
+  }
+  for (const auto &[uuid, support] : filteredScene.supports) {
+    (void)uuid;
+    if (support.positionName == "BACKDROP")
+      ++filteredBackdropSupports;
+  }
+  assert(foundFilteredBackdropTruss);
+  assert(filteredBackdropSupports == 2);
+
   return 0;
 }

--- a/tests/rider_hoist_import_test.cpp
+++ b/tests/rider_hoist_import_test.cpp
@@ -146,11 +146,16 @@ int main() {
   assert(RiderImporter::ImportText(filteredBackdropOnlyText));
   const auto &filteredScene = cfg.GetScene();
   bool foundFilteredBackdropTruss = false;
+  bool filteredBackdropTrussHasModelInfo = false;
   int filteredBackdropSupports = 0;
   for (const auto &[uuid, truss] : filteredScene.trusses) {
     (void)uuid;
-    if (truss.positionName == "BACKDROP")
+    if (truss.positionName == "BACKDROP") {
       foundFilteredBackdropTruss = true;
+      if (!truss.modelFile.empty() || !truss.symbolFile.empty() ||
+          !truss.gdtfSpec.empty())
+        filteredBackdropTrussHasModelInfo = true;
+    }
   }
   for (const auto &[uuid, support] : filteredScene.supports) {
     (void)uuid;
@@ -158,6 +163,7 @@ int main() {
       ++filteredBackdropSupports;
   }
   assert(foundFilteredBackdropTruss);
+  assert(filteredBackdropTrussHasModelInfo);
   assert(filteredBackdropSupports == 2);
 
   return 0;

--- a/tests/rider_hoist_import_test.cpp
+++ b/tests/rider_hoist_import_test.cpp
@@ -24,12 +24,14 @@ int main() {
       "6 MOTOR 500Kg + GRILLETES + ESLINGAS PARA PUENTES LX\n"
       "1 TRUSS 40X40 PRO 14m PARA PANTALLA\n"
       "4 MOTOR 1TO + GRILLETES + ESLINGAS PARA PANTALLA\n"
+      "1 TRUSS 40X40 PARA PUENTE TELONES\n"
+      "2 MOTOR 500Kg + GRILLETES + ESLINGAS PARA PUENTE TELONES\n"
       "CABLEADO Y CONTROL DE MOTORES\n";
 
   assert(RiderImporter::ImportText(riderText));
 
   const auto &scene = cfg.GetScene();
-  assert(scene.supports.size() == 16);
+  assert(scene.supports.size() == 18);
 
   std::map<std::string, int> countByPosition;
   std::map<std::string, int> countByCapacity;
@@ -54,19 +56,21 @@ int main() {
   assert(countByPosition["LX2"] == 2);
   assert(countByPosition["LX3"] == 2);
   assert(countByPosition["SCREEN"] == 4);
+  assert(countByPosition["BACKDROP"] == 2);
 
   assert(countByCapacity["2000"] == 4);
   assert(countByCapacity["1000"] == 4);
-  assert(countByCapacity["500"] == 8);
+  assert(countByCapacity["500"] == 10);
   assert(countByFunction["P.A.:Audio"] == 4);
   assert(countByFunction["SIDEFILL:Audio"] == 2);
   assert(countByFunction["SCREEN:Video"] == 4);
   assert(countByFunction["LX1:Lighting"] == 2);
   assert(countByFunction["LX2:Lighting"] == 2);
   assert(countByFunction["LX3:Lighting"] == 2);
+  assert(countByFunction["BACKDROP:Lighting"] == 2);
   assert(countByLayer["rig Audio"] == 6);
   assert(countByLayer["rig Video"] == 4);
-  assert(countByLayer["rig Lighting"] == 6);
+  assert(countByLayer["rig Lighting"] == 8);
   bool audioLayerColorOk = false;
   bool videoLayerColorOk = false;
   bool lightingLayerColorOk = false;
@@ -104,6 +108,8 @@ int main() {
   assert(nameCounts["SCR 2"] == 1);
   assert(nameCounts["SCR 3"] == 1);
   assert(nameCounts["SCR 4"] == 1);
+  assert(nameCounts["RP 1"] == 1);
+  assert(nameCounts["RP 2"] == 1);
   assert(nameCounts["SF L"] == 1);
   assert(nameCounts["SF R"] == 1);
   assert(nameCounts["PA L 1"] == 1);
@@ -112,15 +118,24 @@ int main() {
   assert(nameCounts["PA R 2"] == 1);
 
   bool foundScreenTruss = false;
+  bool foundBackdropTruss = false;
   for (const auto &[uuid, truss] : scene.trusses) {
     (void)uuid;
     if (truss.positionName != "SCREEN")
-      continue;
-    foundScreenTruss = true;
-    assert(std::abs(truss.transform.o[1] - 5000.0f) < 0.001f);
-    assert(std::abs(truss.transform.o[2] - 8500.0f) < 0.001f);
+      if (truss.positionName != "BACKDROP")
+        continue;
+    if (truss.positionName == "SCREEN") {
+      foundScreenTruss = true;
+      assert(std::abs(truss.transform.o[1] - 5000.0f) < 0.001f);
+      assert(std::abs(truss.transform.o[2] - 8500.0f) < 0.001f);
+    } else if (truss.positionName == "BACKDROP") {
+      foundBackdropTruss = true;
+      assert(std::abs(truss.transform.o[1] - 6000.0f) < 0.001f);
+      assert(std::abs(truss.transform.o[2] - 8500.0f) < 0.001f);
+    }
   }
   assert(foundScreenTruss);
+  assert(foundBackdropTruss);
 
   return 0;
 }


### PR DESCRIPTION
### Motivation

- Riders sometimes list a bridge/backdrop (puente de telones / telón) in the rigging section; the importer must create a backdrop truss and place hoists correctly even when no explicit length is provided.
- Backdrop placement should be behind the last lighting/screen truss (+1 m in Y) at the same height as that reference, and use a sensible length fallback when missing.

### Description

- Extend hang detection and normalization to recognize backdrop aliases (`backdrop(s)`, `telón/telones`, `puente de telón(es)`) and normalize them to `BACKDROP` (updated regexes and `NormalizeHangName`).
- Relax truss-line parsing to accept quantity+truss lines without an explicit length and add `kLengthWithUnitRe` to extract inline lengths from model tokens when available.
- Implement backdrop-specific fallback logic: if a `BACKDROP` truss has no length, reuse the last parsed `LX*` or `SCREEN` span or default to `12 m`; remember the last reference span/pos/height for placement.
- Place backdrop trusses at `Y = last_reference_Y + 1000 mm` and keep the same `Z` as the reference; hoist distribution and naming use existing logic so motors targeted to `BACKDROP` are assigned over the generated span.
- Update `docs/text_to_scene_rules.md` to document the new hang aliases, lengthless backdrop syntax and placement/fallback rules.
- Add regression coverage by updating `tests/rider_hoist_import_test.cpp` to include a backdrop truss without explicit length and assert backdrop truss creation, placement and hoist assignment.

### Testing

- Ran `tests/check_perastage_tree_modules.sh` and it succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded.
- Attempted to build/run the updated `rider_hoist_import_test` via CMake, but the build could not be completed in this environment due to missing `wxWidgets` development packages (CMake failed to find `wxWidgets_LIBRARIES`/`wxWidgets_INCLUDE_DIRS`), so the test was not executed here.
- The repository change includes the updated unit test (`tests/rider_hoist_import_test.cpp`) that validates the new backdrop behavior and should pass in a CI environment with the project dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca45319b5883249bc169fac608b219)