### PR TITLE
Create-from-text: place Smoke fixtures at floor using side-style mirrored placement

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -2599,6 +2599,8 @@ bool RiderImporter::ImportText(const std::string &text) {
   const std::string strobeCategory =
       normalizeCategory(GdtfFixtureCategory::kStrobe);
   const std::string washCategory = normalizeCategory(GdtfFixtureCategory::kWash);
+  const std::string smokeCategory =
+      normalizeCategory(GdtfFixtureCategory::kSmoke);
 
   auto isTopFrontCategory = [&](const Fixture &fixture) {
     const std::string normalized = normalizeCategory(fixture.category);
@@ -2608,59 +2610,110 @@ bool RiderImporter::ImportText(const std::string &text) {
   auto isBackBottomCategory = [&](const Fixture &fixture) {
     return normalizeCategory(fixture.category) == washCategory;
   };
+  auto isSmokeCategory = [&](const Fixture &fixture) {
+    return normalizeCategory(fixture.category) == smokeCategory;
+  };
+
+  auto placeFixturesAsSides = [&](const std::vector<Fixture *> &ordered,
+                                  float leftX, float rightX, float startY,
+                                  float endY, float z) {
+    if (ordered.empty())
+      return;
+    const int leftCount =
+        static_cast<int>(ordered.size()) / 2 + static_cast<int>(ordered.size()) % 2;
+    const int rightCount = static_cast<int>(ordered.size()) / 2;
+    auto placeSideGroup = [&](int count, float sideX,
+                              const std::function<Fixture *(int)> &pickFixture) {
+      if (count <= 0)
+        return;
+      const float step = count > 1 ? (endY - startY) / static_cast<float>(count - 1)
+                                   : 0.0f;
+      for (int i = 0; i < count; ++i) {
+        Fixture *fixture = pickFixture(i);
+        if (!fixture)
+          continue;
+        fixture->transform.o[0] = sideX;
+        fixture->transform.o[1] = startY + step * static_cast<float>(i);
+        fixture->transform.o[2] = z;
+      }
+    };
+    placeSideGroup(leftCount, leftX, [&](int i) {
+      return ordered[static_cast<size_t>(i)];
+    });
+    placeSideGroup(rightCount, rightX, [&](int i) {
+      return ordered[ordered.size() - 1U - static_cast<size_t>(i)];
+    });
+  };
+
+  float smokeLeftX = sideTrussInfo.leftX;
+  float smokeRightX = sideTrussInfo.rightX;
+  if (!sideTrussInfo.found) {
+    bool hasLxSpan = false;
+    float lxStart = 0.0f;
+    float lxEnd = 0.0f;
+    for (const auto &[positionName, info] : trussInfo) {
+      if (!info.found || !IsLxHangName(positionName))
+        continue;
+      if (!hasLxSpan) {
+        lxStart = info.startX;
+        lxEnd = info.endX;
+        hasLxSpan = true;
+      } else {
+        lxStart = std::min(lxStart, info.startX);
+        lxEnd = std::max(lxEnd, info.endX);
+      }
+    }
+    if (hasLxSpan) {
+      smokeLeftX = lxStart + 500.0f;
+      smokeRightX = lxEnd - 500.0f;
+      if (smokeLeftX > smokeRightX) {
+        const float center = (lxStart + lxEnd) * 0.5f;
+        smokeLeftX = center;
+        smokeRightX = center;
+      }
+    }
+  }
+  const float smokeStartY =
+      sideTrussInfo.found ? sideTrussInfo.startY + getHangMargin("LX1") : 1000.0f;
+  const float smokeEndY =
+      sideTrussInfo.found ? sideTrussInfo.endY - getHangMargin("LX1") : smokeStartY;
 
   for (auto &[pos, fixturesVec] : fixturesByPos) {
     if (fixturesVec.empty())
       continue;
     if (IsLxSidesHangName(pos)) {
       const std::vector<Fixture *> ordered = buildSymmetricOrder(fixturesVec);
-      if (ordered.empty())
-        continue;
-      const int leftCount =
-          static_cast<int>(ordered.size()) / 2 + static_cast<int>(ordered.size()) % 2;
-      const int rightCount = static_cast<int>(ordered.size()) / 2;
-      auto placeSideGroup = [&](int count, float sideX,
-                                const std::function<Fixture *(int)> &pickFixture) {
-        if (count <= 0)
-          return;
-        const float startY = sideTrussInfo.found
-                                 ? sideTrussInfo.startY + getHangMargin("LX1")
-                                 : 1000.0f;
-        const float endY = sideTrussInfo.found
-                               ? sideTrussInfo.endY - getHangMargin("LX1")
-                               : startY + static_cast<float>(count - 1) * 500.0f;
-        const float step = count > 1 ? (endY - startY) / static_cast<float>(count - 1)
-                                     : 0.0f;
-        for (int i = 0; i < count; ++i) {
-          Fixture *fixture = pickFixture(i);
-          if (!fixture)
-            continue;
-          fixture->transform.o[0] = sideX;
-          fixture->transform.o[1] = startY + step * static_cast<float>(i);
-          fixture->transform.o[2] = sideTrussInfo.found ? sideTrussInfo.z : 1000.0f;
-        }
-      };
-      placeSideGroup(leftCount, sideTrussInfo.leftX, [&](int i) {
-        return ordered[static_cast<size_t>(i)];
-      });
-      placeSideGroup(rightCount, sideTrussInfo.rightX, [&](int i) {
-        return ordered[ordered.size() - 1U - static_cast<size_t>(i)];
-      });
+      const float startY =
+          sideTrussInfo.found ? sideTrussInfo.startY + getHangMargin("LX1") : 1000.0f;
+      const float endY = sideTrussInfo.found ? sideTrussInfo.endY - getHangMargin("LX1")
+                                             : startY;
+      placeFixturesAsSides(ordered, sideTrussInfo.leftX, sideTrussInfo.rightX, startY,
+                           endY, sideTrussInfo.found ? sideTrussInfo.z : 1000.0f);
       continue;
     }
 
     std::vector<Fixture *> bottomFixtures;
     std::vector<Fixture *> topFrontFixtures;
+    std::vector<Fixture *> smokeFixtures;
     bottomFixtures.reserve(fixturesVec.size());
     topFrontFixtures.reserve(fixturesVec.size());
+    smokeFixtures.reserve(fixturesVec.size());
     for (Fixture *f : fixturesVec) {
       if (!f)
         continue;
+      if (isSmokeCategory(*f)) {
+        smokeFixtures.push_back(f);
+        continue;
+      }
       if (isTopFrontCategory(*f))
         topFrontFixtures.push_back(f);
       else
         bottomFixtures.push_back(f);
     }
+
+    const std::vector<Fixture *> orderedSmoke = buildSymmetricOrder(smokeFixtures);
+    placeFixturesAsSides(orderedSmoke, smokeLeftX, smokeRightX, smokeStartY, smokeEndY,
+                         0.0f);
 
     placeFixtureGroup(pos, bottomFixtures,
                       [&](Fixture &fixture, float x, float baseY, float baseZ,

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -2616,7 +2616,7 @@ bool RiderImporter::ImportText(const std::string &text) {
 
   auto placeFixturesAsSides = [&](const std::vector<Fixture *> &ordered,
                                   float leftX, float rightX, float startY,
-                                  float endY, float z) {
+                                  float endY, bool hasSideSpan, float z) {
     if (ordered.empty())
       return;
     const int leftCount =
@@ -2626,7 +2626,10 @@ bool RiderImporter::ImportText(const std::string &text) {
                               const std::function<Fixture *(int)> &pickFixture) {
       if (count <= 0)
         return;
-      const float step = count > 1 ? (endY - startY) / static_cast<float>(count - 1)
+      const float effectiveEndY =
+          hasSideSpan ? endY : startY + static_cast<float>(count - 1) * 500.0f;
+      const float step =
+          count > 1 ? (effectiveEndY - startY) / static_cast<float>(count - 1)
                                    : 0.0f;
       for (int i = 0; i < count; ++i) {
         Fixture *fixture = pickFixture(i);
@@ -2688,7 +2691,8 @@ bool RiderImporter::ImportText(const std::string &text) {
       const float endY = sideTrussInfo.found ? sideTrussInfo.endY - getHangMargin("LX1")
                                              : startY;
       placeFixturesAsSides(ordered, sideTrussInfo.leftX, sideTrussInfo.rightX, startY,
-                           endY, sideTrussInfo.found ? sideTrussInfo.z : 1000.0f);
+                           endY, sideTrussInfo.found,
+                           sideTrussInfo.found ? sideTrussInfo.z : 1000.0f);
       continue;
     }
 
@@ -2713,7 +2717,7 @@ bool RiderImporter::ImportText(const std::string &text) {
 
     const std::vector<Fixture *> orderedSmoke = buildSymmetricOrder(smokeFixtures);
     placeFixturesAsSides(orderedSmoke, smokeLeftX, smokeRightX, smokeStartY, smokeEndY,
-                         0.0f);
+                         sideTrussInfo.found, 0.0f);
 
     placeFixtureGroup(pos, bottomFixtures,
                       [&](Fixture &fixture, float x, float baseY, float baseZ,

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -323,6 +323,8 @@ After parsing, imported fixtures are distributed per hang:
    - **Bottom group**: all categories except `Wash`, `Blinder`, `Strobe`.
    - **Bottom-back override**: `Wash` is placed on the back side.
    - **Top-front group**: `Blinder` and `Strobe` are placed on top-front.
+   - **Smoke side-floor group**: `Smoke` fixtures are placed using side-style
+     mirroring (left/right split along `Y`) at floor level.
 6. `x` spacing is computed independently per group:
    - Bottom fixtures share one spacing/order pass.
    - Top-front fixtures use a separate spacing/order pass and do not affect bottom spacing.
@@ -343,6 +345,14 @@ After parsing, imported fixtures are distributed per hang:
    - Fixtures are split into two symmetric groups (left/right side).
    - Each side group is distributed along `Y` (matching side truss direction).
    - `X` anchors match side-truss anchors (or fallback anchors when no side truss exists).
+9. `Smoke` fixture distribution (all non-`LX SIDES` hangs):
+   - `Smoke` fixtures are split into two symmetric groups (left/right side),
+     distributed along `Y` using side-truss extents when available.
+   - `Z` is forced to floor (`0 mm`).
+   - `X` anchors:
+     - with real side trusses: same side-truss anchors as `LX SIDES`,
+     - fallback without side trusses: `0.5 m` inside the widest detected `LX*`
+       truss span (`left = minX + 0.5 m`, `right = maxX - 0.5 m`).
 
 ## Numbering and identity rules
 

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -348,6 +348,8 @@ After parsing, imported fixtures are distributed per hang:
 9. `Smoke` fixture distribution (all non-`LX SIDES` hangs):
    - `Smoke` fixtures are split into two symmetric groups (left/right side),
      distributed along `Y` using side-truss extents when available.
+   - Without side trusses, each side uses fallback `Y = 1.0 m` with `500 mm`
+     spacing moving upstage (same side-style fallback spacing).
    - `Z` is forced to floor (`0 mm`).
    - `X` anchors:
      - with real side trusses: same side-truss anchors as `LX SIDES`,


### PR DESCRIPTION
### Motivation
- Make imported fixtures classified as `Smoke` follow the same left/right mirrored distribution as `LX SIDES` but placed on the floor (user-visible placement tweak requested for smoke effects).
- Keep side-placement logic consistent and reusable while preserving existing `LX SIDES` behavior and truss-based fallbacks.

### Description
- Added `smoke` category detection and an `isSmokeCategory` predicate in `core/riderimporter.cpp` to identify smoke fixtures.
- Introduced `placeFixturesAsSides` helper to centralize left/right side placement and refactored existing `LX SIDES` placement to use it.
- Implemented smoke-specific anchors and fallback logic so smoke fixtures use side-style X anchors (when no side truss, anchors are `0.5 m` inside the widest detected `LX*` span) and are placed at floor level by forcing `z = 0`.
- Updated `docs/text_to_scene_rules.md` to document the new `Smoke` placement rules and the fallback behavior.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which reported `OK`.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which reported `OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca551820948324ab4a8f7e3bdfa061)