### PR TITLE
Recognize PROYECCION/PROYECCIÓN as screen hang alias in rider importer

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -82,16 +82,16 @@ static const std::regex kFixtureLineRe("^\\s*(?:[-*]\\s*)?(\\d+)\\s+(.+)$",
                                        std::regex::icase);
 static const std::regex kQuantityOnlyRe("^\\s*(?:[-*]\\s*)?(\\d+)\\s*$");
 static const std::regex kHangLineRe(
-    "^\\s*(LX\\d+|lx\\s*sides?|screen|pantalla|led\\s*screen|backdrops?|tel[oó]n(?:es)?|puente\\s+de\\s+tel[oó]n(?:es)?|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)(?:\\s*\\([^\\)]*\\))?\\s*:?\\s*$",
+    "^\\s*(LX\\d+|lx\\s*sides?|screen|pantalla|proyecci[oó]n|led\\s*screen|backdrops?|tel[oó]n(?:es)?|puente\\s+de\\s+tel[oó]n(?:es)?|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)(?:\\s*\\([^\\)]*\\))?\\s*:?\\s*$",
     std::regex::icase);
 static const std::regex kHangHeaderWithSuffixRe(
-    "^\\s*(LX\\d+|lx\\s*sides?|screen|pantalla|led\\s*screen|backdrops?|tel[oó]n(?:es)?|puente\\s+de\\s+tel[oó]n(?:es)?|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)(?:\\s+[^:]*)?\\s*:\\s*$",
+    "^\\s*(LX\\d+|lx\\s*sides?|screen|pantalla|proyecci[oó]n|led\\s*screen|backdrops?|tel[oó]n(?:es)?|puente\\s+de\\s+tel[oó]n(?:es)?|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)(?:\\s+[^:]*)?\\s*:\\s*$",
     std::regex::icase);
 static const std::regex kHangFindRe(
-    "(LX\\d+|lx\\s*sides?|screen|pantalla|led\\s*screen|backdrops?|tel[oó]n(?:es)?|puente\\s+de\\s+tel[oó]n(?:es)?|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)",
+    "(LX\\d+|lx\\s*sides?|screen|pantalla|proyecci[oó]n|led\\s*screen|backdrops?|tel[oó]n(?:es)?|puente\\s+de\\s+tel[oó]n(?:es)?|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)",
                                     std::regex::icase);
 static const std::regex kHangOnlyRe(
-    "^\\s*(LX\\d+|lx\\s*sides?|screen|pantalla|led\\s*screen|backdrops?|tel[oó]n(?:es)?|puente\\s+de\\s+tel[oó]n(?:es)?|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)\\s*$",
+    "^\\s*(LX\\d+|lx\\s*sides?|screen|pantalla|proyecci[oó]n|led\\s*screen|backdrops?|tel[oó]n(?:es)?|puente\\s+de\\s+tel[oó]n(?:es)?|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)\\s*$",
                                     std::regex::icase);
 std::string Trim(const std::string &s) {
   size_t start = s.find_first_not_of(" \t\r\n");
@@ -485,7 +485,7 @@ std::string NormalizeHangName(const std::string &raw) {
     hang = Trim(hang.substr(8));
   else if (hang.rfind("PUENTE ", 0) == 0)
     hang = Trim(hang.substr(7));
-  if (hang == "PANTALLA")
+  if (hang == "PANTALLA" || hang == "PROYECCION" || hang == "PROYECCIÓN")
     return "SCREEN";
   if (hang == "SCREEN" || hang == "LEDSCREEN")
     return "SCREEN";

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -86,7 +86,7 @@ The importer keeps parsing state with sections (fixtures/rigging/control):
 Recognized hang labels:
 
 - `LX<number>` (for example `LX1`, `LX2`, ...)
-- `screen` / `pantalla` / `led screen`
+- `screen` / `pantalla` / `proyeccion` / `proyección` / `led screen`
 - `backdrop` / `backdrops` / `telon` / `telones` / `puente de telon(es)`
 - `floor`
 - `efecto` / `efectos`
@@ -106,7 +106,7 @@ Behavior:
 - Side-position aliases (`calle(s)`, `side(s)`) are normalized to `LX SIDES`.
 - Explicit normalized headers such as `LX SIDES` are accepted as hang labels
   in both filtered text and direct import input.
-- Screen aliases (`screen`, `pantalla`, `led screen`) are normalized to
+- Screen aliases (`screen`, `pantalla`, `proyeccion`, `proyección`, `led screen`) are normalized to
   `SCREEN`.
 - Backdrop aliases (`backdrop(s)`, `telon(es)`, `puente de telon(es)`) are
   normalized to `BACKDROP`.

--- a/tests/rider_led_screen_object_test.cpp
+++ b/tests/rider_led_screen_object_test.cpp
@@ -19,6 +19,12 @@ int main() {
       "1 PANTALLA LED 8X5m 1664X1040 PIXELS Y 1100Kg PARA TRASERA\n"
       "RIGGING\n"
       "1 TRUSS 40X40 14m PARA PANTALLA\n";
+  const std::string projectionAliasRiderText =
+      "VIDEO\n"
+      "PROYECCION\n"
+      "1 PANTALLA LED 8X4.5m 1664X936 PIXELS PARA TRASERA\n"
+      "RIGGING\n"
+      "1 TRUSS 40X40 PRO 14m PARA PUENTE PANTALLA\n";
 
   auto importAndReadScreenTransform = [&](const std::string &input) {
     cfg.Reset();
@@ -51,6 +57,19 @@ int main() {
   assert(std::fabs(directY - filteredY) < kPositionTolerance);
   assert(std::fabs(directZ - filteredZ) < kPositionTolerance);
   assert(std::fabs(directZ - 6800.0f) < 1.0f);
+
+  cfg.Reset();
+  assert(RiderImporter::ImportText(projectionAliasRiderText));
+  const auto &projectionAliasScene = cfg.GetScene();
+  assert(projectionAliasScene.fixtures.empty());
+  assert(projectionAliasScene.sceneObjects.size() == 1);
+  const SceneObject &projectionAliasScreen =
+      projectionAliasScene.sceneObjects.begin()->second;
+  constexpr float kTolerance = 1e-3f;
+  assert(std::fabs(projectionAliasScreen.transform.u[0] - (8.0f / 0.3f)) <
+         kTolerance);
+  assert(std::fabs(projectionAliasScreen.transform.w[2] - (4.5f / 0.3f)) <
+         kTolerance);
 
   return 0;
 }


### PR DESCRIPTION
### Motivation
- Riders sometimes use Spanish "PROYECCION/PROYECCIÓN" as the screen section header and the importer didn't treat it as a screen hang, so screen objects and their parsed dimensions were not created.

### Description
- Added `proyecci[oó]n` to the hang-detection regular expressions (`kHangLineRe`, `kHangHeaderWithSuffixRe`, `kHangFindRe`, `kHangOnlyRe`) in `core/riderimporter.cpp` so "PROYECCION"/"PROYECCIÓN" is recognized as a hang header.
- Normalized `PROYECCION` / `PROYECCIÓN` to `SCREEN` in `NormalizeHangName(...)` so the existing screen-object creation path is used.
- Updated `docs/text_to_scene_rules.md` to document `proyeccion`/`proyección` as screen aliases.
- Extended `tests/rider_led_screen_object_test.cpp` with a rider using `PROYECCION` and a decimal height (`8X4.5m`) to validate parsing and scene-object creation.

### Testing
- Ran the mandatory repo checks: `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both passed.
- Attempted to build and run the `RiderLedScreenObject` test via CMake, but CMake configuration failed in this environment due to missing `wxWidgets` (so the unit test could not be executed here); this is an environment limitation, not a code failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca58b04a9883248ab9c23b06cf903b)