### PR TITLE
Propagate fixture model change to all fixtures sharing previous type

### DIFF
--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -429,6 +429,7 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
       wxString fileName = fdlg.GetFilename();
 
       std::vector<std::string> prevTypes;
+      std::unordered_set<std::string> prevTypeSet;
 
       for (const auto &itSel : selections) {
         int r = table->ItemToRow(itSel);
@@ -437,7 +438,10 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
 
         wxVariant prevType;
         table->GetValue(prevType, r, 2);
-        prevTypes.push_back(std::string(prevType.GetString().ToUTF8()));
+        const std::string prevTypeUtf8 = std::string(prevType.GetString().ToUTF8());
+        prevTypes.push_back(prevTypeUtf8);
+        if (!prevTypeUtf8.empty())
+          prevTypeSet.insert(prevTypeUtf8);
 
         if ((size_t)r >= gdtfPaths.size())
           gdtfPaths.resize(table->GetItemCount());
@@ -450,6 +454,26 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
         wxString wstr = wxString::Format("%.2f", w);
         table->SetValue(wxVariant(pstr), r, 16);
         table->SetValue(wxVariant(wstr), r, 17);
+      }
+
+      for (unsigned int i = 0; i < table->GetItemCount(); ++i) {
+        wxVariant typeVar;
+        table->GetValue(typeVar, i, 2);
+        const std::string currentType = std::string(typeVar.GetString().ToUTF8());
+        if (prevTypeSet.find(currentType) == prevTypeSet.end())
+          continue;
+
+        if ((size_t)i >= gdtfPaths.size())
+          gdtfPaths.resize(table->GetItemCount());
+
+        gdtfPaths[i] = path;
+        table->SetValue(wxVariant(fileName), i, 9);
+        table->SetValue(wxVariant(typeName), i, 2);
+
+        wxString pstr = wxString::Format("%.1f", p);
+        wxString wstr = wxString::Format("%.2f", w);
+        table->SetValue(wxVariant(pstr), i, 16);
+        table->SetValue(wxVariant(wstr), i, 17);
       }
 
       PropagateTypeValues(selections, 16);


### PR DESCRIPTION
### Motivation
- When assigning a new Model file (GDTF) via the fixture table, only the selected rows were updated while other fixtures that still referenced the same rider/type key were left out, causing inconsistent type→GDTF mappings.
- The intent is to treat a model-file reassignment as a type-level mapping change and keep all fixtures that previously referenced that type synchronized with the new GDTF.

### Description
- In `gui/fixturetablepanel.cpp` (handler for Model file column), collect the previous type names into a `prevTypeSet` before overwriting selected rows. 
- Add a pass over all table rows that updates any row whose current type is contained in `prevTypeSet` to the new `gdtfPath`, displayed filename, `typeName`, power and weight values. 
- Preserve the existing flows for `PropagateTypeValues`, `ApplyModeForGdtf` and `GdtfDictionary::Update` so the rest of the behavior is unchanged. 
- Change is intentionally minimal and scoped to `OnContextMenu` to avoid broad refactors in the known hotspot `gui/fixturetablepanel.cpp`, with a follow-up recommendation to extract the propagation logic into a dedicated helper/service.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded (`OK`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca5c42238c8324a7c2f7140a66c6b8)