### PR TITLE
Tune initial column widths for Layers and Summary panels

### DIFF
--- a/gui/layerpanel.cpp
+++ b/gui/layerpanel.cpp
@@ -16,7 +16,6 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "layerpanel.h"
-#include "columnutils.h"
 #include "configmanager.h"
 #include "guiconfigservices.h"
 #include "fixturetablepanel.h"
@@ -69,12 +68,32 @@ LayerPanel::LayerPanel(wxWindow* parent, bool showButtons, ConfigManager* config
     : wxPanel(parent, wxID_ANY), configManager(config ? config : &GetDefaultGuiConfigServices().LegacyConfigManager())
 {
     list = new wxDataViewListCtrl(this, wxID_ANY);
-    list->AppendToggleColumn("Visible");
-    list->AppendTextColumn("Layer");
+    auto* visibleColumn = list->AppendToggleColumn("Visible");
+    auto* layerColumn = list->AppendTextColumn("Layer");
     auto* colorRenderer = new wxDataViewIconTextRenderer();
     auto* colorColumn = new wxDataViewColumn("Color", colorRenderer, 2, 40, wxALIGN_CENTER);
     list->AppendColumn(colorColumn);
-    ColumnUtils::EnforceMinColumnWidth(list);
+
+    wxClientDC dc(list);
+    dc.SetFont(list->GetFont());
+    int visibleLabelWidth = 0;
+    int colorLabelWidth = 0;
+    dc.GetTextExtent("Visible", &visibleLabelWidth, nullptr);
+    dc.GetTextExtent("Color", &colorLabelWidth, nullptr);
+
+    const int visibleWidth = visibleLabelWidth + 28; // checkbox + header padding
+    const int colorWidth = std::max(colorLabelWidth + 16, 16 + 20); // label or swatch
+
+    if (visibleColumn) {
+        visibleColumn->SetMinWidth(visibleWidth);
+        visibleColumn->SetWidth(visibleWidth);
+    }
+    if (colorColumn) {
+        colorColumn->SetMinWidth(colorWidth);
+        colorColumn->SetWidth(colorWidth);
+    }
+    if (layerColumn)
+        layerColumn->SetMinWidth(120);
 
     wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
     sizer->Add(list, 1, wxEXPAND | wxALL, 5);

--- a/gui/layerpanel.cpp
+++ b/gui/layerpanel.cpp
@@ -71,29 +71,33 @@ LayerPanel::LayerPanel(wxWindow* parent, bool showButtons, ConfigManager* config
     auto* visibleColumn = list->AppendToggleColumn("Visible");
     auto* layerColumn = list->AppendTextColumn("Layer");
     auto* colorRenderer = new wxDataViewIconTextRenderer();
-    auto* colorColumn = new wxDataViewColumn("Color", colorRenderer, 2, 40, wxALIGN_CENTER);
+    auto* colorColumn = new wxDataViewColumn("Color", colorRenderer, 2, 40, wxALIGN_CENTER,
+                                             wxDATAVIEW_COL_RESIZABLE);
     list->AppendColumn(colorColumn);
 
-    wxClientDC dc(list);
-    dc.SetFont(list->GetFont());
-    int visibleLabelWidth = 0;
-    int colorLabelWidth = 0;
-    dc.GetTextExtent("Visible", &visibleLabelWidth, nullptr);
-    dc.GetTextExtent("Color", &colorLabelWidth, nullptr);
+    auto applyInitialColumnWidths = [this, visibleColumn, layerColumn, colorColumn]() {
+        if (!list || !visibleColumn || !layerColumn || !colorColumn)
+            return;
 
-    const int visibleWidth = visibleLabelWidth + 28; // checkbox + header padding
-    const int colorWidth = std::max(colorLabelWidth + 16, 16 + 20); // label or swatch
+        wxClientDC dc(list);
+        dc.SetFont(list->GetFont());
+        int visibleLabelWidth = 0;
+        int colorLabelWidth = 0;
+        dc.GetTextExtent("Visible", &visibleLabelWidth, nullptr);
+        dc.GetTextExtent("Color", &colorLabelWidth, nullptr);
 
-    if (visibleColumn) {
+        const int visibleWidth = visibleLabelWidth + 28; // checkbox + header padding
+        const int colorWidth = std::max(colorLabelWidth + 16, 16 + 20); // label or swatch
+        const int listWidth = std::max(0, list->GetClientSize().GetWidth());
+        const int layerWidth = std::max(120, listWidth - visibleWidth - colorWidth - 8);
+
         visibleColumn->SetMinWidth(visibleWidth);
         visibleColumn->SetWidth(visibleWidth);
-    }
-    if (colorColumn) {
         colorColumn->SetMinWidth(colorWidth);
         colorColumn->SetWidth(colorWidth);
-    }
-    if (layerColumn)
         layerColumn->SetMinWidth(120);
+        layerColumn->SetWidth(layerWidth);
+    };
 
     wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
     sizer->Add(list, 1, wxEXPAND | wxALL, 5);
@@ -110,6 +114,18 @@ LayerPanel::LayerPanel(wxWindow* parent, bool showButtons, ConfigManager* config
     }
 
     SetSizer(sizer);
+    applyInitialColumnWidths();
+    CallAfter(applyInitialColumnWidths);
+
+    list->Bind(wxEVT_SIZE, [applyInitialColumnWidths](wxSizeEvent& evt) {
+        applyInitialColumnWidths();
+        evt.Skip();
+    });
+    Bind(wxEVT_SHOW, [applyInitialColumnWidths](wxShowEvent& evt) {
+        if (evt.IsShown())
+            applyInitialColumnWidths();
+        evt.Skip();
+    });
 
     list->Bind(wxEVT_DATAVIEW_ITEM_VALUE_CHANGED, &LayerPanel::OnCheck, this);
     list->Bind(wxEVT_DATAVIEW_SELECTION_CHANGED, &LayerPanel::OnSelect, this);

--- a/gui/summarypanel.cpp
+++ b/gui/summarypanel.cpp
@@ -18,6 +18,7 @@
 #include "summarypanel.h"
 #include "configmanager.h"
 #include "guiconfigservices.h"
+#include <algorithm>
 #include <map>
 
 static SummaryPanel* s_instance = nullptr;
@@ -29,21 +30,39 @@ SummaryPanel::SummaryPanel(wxWindow* parent)
     auto* countColumn = table->AppendTextColumn("Count", wxDATAVIEW_CELL_INERT, 60, wxALIGN_LEFT, wxDATAVIEW_COL_RESIZABLE);
     auto* typeColumn = table->AppendTextColumn("Type", wxDATAVIEW_CELL_INERT, 150, wxALIGN_LEFT, wxDATAVIEW_COL_RESIZABLE);
 
-    wxClientDC dc(table);
-    dc.SetFont(table->GetFont());
-    int countLabelWidth = 0;
-    dc.GetTextExtent("Count", &countLabelWidth, nullptr);
-    const int countWidth = countLabelWidth + 20;
-    if (countColumn) {
+    auto applyInitialColumnWidths = [this, countColumn, typeColumn]() {
+        if (!table || !countColumn || !typeColumn)
+            return;
+
+        wxClientDC dc(table);
+        dc.SetFont(table->GetFont());
+        int countLabelWidth = 0;
+        dc.GetTextExtent("Count", &countLabelWidth, nullptr);
+        const int countWidth = countLabelWidth + 20;
+        const int tableWidth = std::max(0, table->GetClientSize().GetWidth());
+        const int typeWidth = std::max(120, tableWidth - countWidth - 8);
+
         countColumn->SetMinWidth(countWidth);
         countColumn->SetWidth(countWidth);
-    }
-    if (typeColumn)
         typeColumn->SetMinWidth(120);
+        typeColumn->SetWidth(typeWidth);
+    };
 
     wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
     sizer->Add(table, 1, wxEXPAND | wxALL, 5);
     SetSizer(sizer);
+    applyInitialColumnWidths();
+    CallAfter(applyInitialColumnWidths);
+
+    table->Bind(wxEVT_SIZE, [applyInitialColumnWidths](wxSizeEvent& evt) {
+        applyInitialColumnWidths();
+        evt.Skip();
+    });
+    Bind(wxEVT_SHOW, [applyInitialColumnWidths](wxShowEvent& evt) {
+        if (evt.IsShown())
+            applyInitialColumnWidths();
+        evt.Skip();
+    });
 }
 
 SummaryPanel* SummaryPanel::Instance()

--- a/gui/summarypanel.cpp
+++ b/gui/summarypanel.cpp
@@ -16,7 +16,6 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "summarypanel.h"
-#include "columnutils.h"
 #include "configmanager.h"
 #include "guiconfigservices.h"
 #include <map>
@@ -27,9 +26,21 @@ SummaryPanel::SummaryPanel(wxWindow* parent)
     : wxPanel(parent, wxID_ANY)
 {
     table = new wxDataViewListCtrl(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxDV_ROW_LINES);
-    table->AppendTextColumn("Count", wxDATAVIEW_CELL_INERT, 60, wxALIGN_LEFT, wxDATAVIEW_COL_RESIZABLE);
-    table->AppendTextColumn("Type", wxDATAVIEW_CELL_INERT, 150, wxALIGN_LEFT, wxDATAVIEW_COL_RESIZABLE);
-    ColumnUtils::EnforceMinColumnWidth(table);
+    auto* countColumn = table->AppendTextColumn("Count", wxDATAVIEW_CELL_INERT, 60, wxALIGN_LEFT, wxDATAVIEW_COL_RESIZABLE);
+    auto* typeColumn = table->AppendTextColumn("Type", wxDATAVIEW_CELL_INERT, 150, wxALIGN_LEFT, wxDATAVIEW_COL_RESIZABLE);
+
+    wxClientDC dc(table);
+    dc.SetFont(table->GetFont());
+    int countLabelWidth = 0;
+    dc.GetTextExtent("Count", &countLabelWidth, nullptr);
+    const int countWidth = countLabelWidth + 20;
+    if (countColumn) {
+        countColumn->SetMinWidth(countWidth);
+        countColumn->SetWidth(countWidth);
+    }
+    if (typeColumn)
+        typeColumn->SetMinWidth(120);
+
     wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
     sizer->Add(table, 1, wxEXPAND | wxALL, 5);
     SetSizer(sizer);


### PR DESCRIPTION
### Motivation
- Improve default column geometry so the small `Visible` checkbox and `Color` swatch do not take excessive space and the `Layer`/`Type` text columns have more room when the panels are created.

### Description
- In `LayerPanel` initialization capture the new columns (`Visible`, `Layer`, `Color`) and use a `wxClientDC` to measure the header text; compute and apply sensible `SetMinWidth`/`SetWidth` values for `Visible` and `Color` and increase `Layer` minimum to `120`.
- In `SummaryPanel` initialization capture the `Count` and `Type` columns, measure the `Count` header with `wxClientDC` and set `Count` min/width and a larger minimum for `Type` to favor long names.
- Removed the now-unused `#include "columnutils.h"` usages from the touched files and dropped the previous generic `ColumnUtils::EnforceMinColumnWidth` call in favor of tailored per-column sizing.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca5e06c38c8324bc1275b1e903d9cb)