### PR TITLE
Add per-position editable Extra Weight column to Rigging panel

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/print/PageSetup.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/print/Viewer2DPrintSettings.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/projectutils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/rigging_extra_weight_settings.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/riderimporter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scenedatamanager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/simplecrypt.cpp

--- a/core/hoist_weight_distribution.cpp
+++ b/core/hoist_weight_distribution.cpp
@@ -143,7 +143,9 @@ BuildMissingWeightMapByHangPosition(const MvrScene &scene) {
 }
 
 std::unordered_map<std::string, float>
-BuildRoundedRiggingTotalByHangPosition(const MvrScene &scene) {
+BuildRoundedRiggingTotalByHangPosition(
+    const MvrScene &scene,
+    const std::unordered_map<std::string, float> &extraWeightKgByPosition) {
   std::unordered_map<std::string, float> roundedTotals;
 
   auto accumulateWeight = [&](const std::string &positionName, float weightKg) {
@@ -161,6 +163,9 @@ BuildRoundedRiggingTotalByHangPosition(const MvrScene &scene) {
   for (const auto &[uuid, support] : scene.supports) {
     (void)uuid;
     accumulateWeight(support.positionName, support.weightKg);
+  }
+  for (const auto &[positionName, extraWeightKg] : extraWeightKgByPosition) {
+    accumulateWeight(positionName, extraWeightKg);
   }
 
   for (auto &[positionName, total] : roundedTotals)

--- a/core/hoist_weight_distribution.h
+++ b/core/hoist_weight_distribution.h
@@ -15,7 +15,9 @@ std::unordered_map<std::string, bool>
 BuildMissingWeightMapByHangPosition(const MvrScene &scene);
 
 std::unordered_map<std::string, float>
-BuildRoundedRiggingTotalByHangPosition(const MvrScene &scene);
+BuildRoundedRiggingTotalByHangPosition(
+    const MvrScene &scene,
+    const std::unordered_map<std::string, float> &extraWeightKgByPosition = {});
 
 void ApplyForImportedSupports(MvrScene &scene,
                               const std::vector<std::string> &importedSupportUuids,

--- a/core/rigging_extra_weight_settings.cpp
+++ b/core/rigging_extra_weight_settings.cpp
@@ -1,0 +1,60 @@
+#include "rigging_extra_weight_settings.h"
+
+#include <map>
+
+#include "json.hpp"
+
+namespace RiggingExtraWeightSettings {
+
+EntriesByPosition ParseEntries(const std::optional<std::string> &serialized) {
+  EntriesByPosition result;
+  if (!serialized || serialized->empty())
+    return result;
+
+  const nlohmann::json parsed = nlohmann::json::parse(*serialized, nullptr, false);
+  if (!parsed.is_object())
+    return result;
+
+  for (auto it = parsed.begin(); it != parsed.end(); ++it) {
+    if (!it.value().is_object())
+      continue;
+
+    Entry entry;
+    if (const auto valueIt = it.value().find("valueKg");
+        valueIt != it.value().end() && valueIt->is_number()) {
+      entry.valueKg = static_cast<float>(valueIt->get<double>());
+    }
+    if (const auto sourceIt = it.value().find("source");
+        sourceIt != it.value().end() && sourceIt->is_string() &&
+        sourceIt->get<std::string>() == "auto_unvalidated") {
+      entry.requiresValidation = true;
+    }
+
+    result[it.key()] = entry;
+  }
+
+  return result;
+}
+
+std::string SerializeEntries(const EntriesByPosition &entries) {
+  nlohmann::json root = nlohmann::json::object();
+  std::map<std::string, Entry> sortedEntries(entries.begin(), entries.end());
+  for (const auto &[position, entry] : sortedEntries) {
+    nlohmann::json item = nlohmann::json::object();
+    item["valueKg"] = entry.valueKg;
+    item["source"] = entry.requiresValidation ? "auto_unvalidated" : "manual";
+    root[position] = std::move(item);
+  }
+  return root.dump();
+}
+
+KilogramsByPosition BuildKilogramsByPosition(const EntriesByPosition &entries) {
+  KilogramsByPosition kilogramsByPosition;
+  kilogramsByPosition.reserve(entries.size());
+  for (const auto &[position, entry] : entries) {
+    kilogramsByPosition[position] = entry.valueKg;
+  }
+  return kilogramsByPosition;
+}
+
+} // namespace RiggingExtraWeightSettings

--- a/core/rigging_extra_weight_settings.h
+++ b/core/rigging_extra_weight_settings.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+namespace RiggingExtraWeightSettings {
+
+struct Entry {
+  float valueKg = 0.0f;
+  bool requiresValidation = false;
+};
+
+using EntriesByPosition = std::unordered_map<std::string, Entry>;
+using KilogramsByPosition = std::unordered_map<std::string, float>;
+
+constexpr const char *ConfigKey() { return "rigging_position_extra_weights_v1"; }
+
+EntriesByPosition ParseEntries(const std::optional<std::string> &serialized);
+std::string SerializeEntries(const EntriesByPosition &entries);
+KilogramsByPosition BuildKilogramsByPosition(const EntriesByPosition &entries);
+
+} // namespace RiggingExtraWeightSettings

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -64,6 +64,7 @@
 #include "markdown.h"
 #include "preferencesdialog.h"
 #include "projectutils.h"
+#include "rigging_extra_weight_settings.h"
 #include "riggingpanel.h"
 #include "sceneobjecttablepanel.h"
 #include "selectfixturetypedialog.h"
@@ -611,8 +612,12 @@ void MainWindow::OnDistributeHoistWeights(wxCommandEvent &WXUNUSED(event)) {
   }
 
   cfg.PushUndoState("distribute hoist weights");
+  const auto extraWeights = RiggingExtraWeightSettings::ParseEntries(
+      cfg.GetValue(RiggingExtraWeightSettings::ConfigKey()));
   const auto roundedTotalsByPosition =
-      HoistWeightDistribution::BuildRoundedRiggingTotalByHangPosition(scene);
+      HoistWeightDistribution::BuildRoundedRiggingTotalByHangPosition(
+          scene,
+          RiggingExtraWeightSettings::BuildKilogramsByPosition(extraWeights));
   HoistWeightDistribution::ApplyForImportedSupports(
       scene, selectedSupportUuids, roundedTotalsByPosition);
   RefreshAfterSceneChange();

--- a/gui/riggingpanel.cpp
+++ b/gui/riggingpanel.cpp
@@ -21,24 +21,20 @@
 #include <map>
 #include <unordered_map>
 #include <string>
+#include <vector>
 
 #include "colorstore.h"
 #include "columnutils.h"
 #include "configmanager.h"
 #include "guiconfigservices.h"
-#include "json.hpp"
+#include "hoist_weight_distribution.h"
+#include "hoisttablepanel.h"
+#include "rigging_extra_weight_settings.h"
 #include "units/unit_label_utils.h"
 #include "units/units.h"
 
 namespace {
 constexpr const char *UNASSIGNED_POSITION = "Unassigned";
-constexpr const char *kRiggingExtraWeightsConfigKey =
-    "rigging_position_extra_weights_v1";
-
-struct RiggingExtraWeightEntry {
-  float valueKg = 0.0f;
-  bool requiresValidation = false;
-};
 
 float RoundUpToNextFiveKg(float valueKg) {
   constexpr float kFiveKgStep = 5.0f;
@@ -84,49 +80,6 @@ wxString BuildRiggingTooltipForColumn(int modelColumn) {
   default:
     return wxString();
   }
-}
-
-std::unordered_map<std::string, RiggingExtraWeightEntry>
-LoadRiggingExtraWeights(const ConfigManager &cfg) {
-  std::unordered_map<std::string, RiggingExtraWeightEntry> result;
-  const auto serialized = cfg.GetValue(kRiggingExtraWeightsConfigKey);
-  if (!serialized || serialized->empty())
-    return result;
-
-  const nlohmann::json parsed = nlohmann::json::parse(*serialized, nullptr, false);
-  if (!parsed.is_object())
-    return result;
-
-  for (auto it = parsed.begin(); it != parsed.end(); ++it) {
-    if (!it.value().is_object())
-      continue;
-    RiggingExtraWeightEntry entry;
-    if (const auto valueIt = it.value().find("valueKg");
-        valueIt != it.value().end() && valueIt->is_number()) {
-      entry.valueKg = static_cast<float>(valueIt->get<double>());
-    }
-    if (const auto sourceIt = it.value().find("source");
-        sourceIt != it.value().end() && sourceIt->is_string() &&
-        sourceIt->get<std::string>() == "auto_unvalidated") {
-      entry.requiresValidation = true;
-    }
-    result[it.key()] = entry;
-  }
-  return result;
-}
-
-std::string SerializeRiggingExtraWeights(
-    const std::unordered_map<std::string, RiggingExtraWeightEntry> &entries) {
-  nlohmann::json root = nlohmann::json::object();
-  std::map<std::string, RiggingExtraWeightEntry> sortedEntries(entries.begin(),
-                                                               entries.end());
-  for (const auto &[position, entry] : sortedEntries) {
-    nlohmann::json item = nlohmann::json::object();
-    item["valueKg"] = entry.valueKg;
-    item["source"] = entry.requiresValidation ? "auto_unvalidated" : "manual";
-    root[position] = std::move(item);
-  }
-  return root.dump();
 }
 
 void SetTableAndChildTooltips(wxDataViewListCtrl *table,
@@ -193,6 +146,8 @@ RiggingPanel::RiggingPanel(wxWindow *parent) : wxPanel(parent, wxID_ANY) {
   });
   table->Bind(wxEVT_DATAVIEW_ITEM_VALUE_CHANGED,
               &RiggingPanel::OnItemValueChanged, this);
+  table->Bind(wxEVT_DATAVIEW_ITEM_ACTIVATED, &RiggingPanel::OnItemActivated,
+              this);
   const auto weightUnit = ResolveWeightUnitSystem();
   const wxString weightSuffix =
       wxString::FromUTF8(Units::WeightUnitSuffix(weightUnit));
@@ -284,7 +239,9 @@ void RiggingPanel::RefreshData() {
   }
   auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
   const auto &scene = cfg.GetScene();
-  const auto extraWeights = LoadRiggingExtraWeights(cfg);
+  const auto extraWeights =
+      RiggingExtraWeightSettings::ParseEntries(
+          cfg.GetValue(RiggingExtraWeightSettings::ConfigKey()));
   for (const auto &[uuid, fixture] : scene.fixtures) {
     std::string pos = fixture.positionName.empty() ? UNASSIGNED_POSITION
                                                    : fixture.positionName;
@@ -387,6 +344,21 @@ void RiggingPanel::RefreshData() {
   table->Refresh();
 }
 
+void RiggingPanel::OnItemActivated(wxDataViewEvent &event) {
+  if (!table) {
+    event.Skip();
+    return;
+  }
+
+  if (event.GetColumn() != 7) {
+    event.Skip();
+    return;
+  }
+
+  table->EditItem(event.GetItem(), table->GetColumn(7));
+  event.Skip();
+}
+
 void RiggingPanel::OnItemValueChanged(wxDataViewEvent &event) {
   if (!table)
     return;
@@ -410,18 +382,43 @@ void RiggingPanel::OnItemValueChanged(wxDataViewEvent &event) {
   }
 
   auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
-  auto extraWeights = LoadRiggingExtraWeights(cfg);
+  auto extraWeights = RiggingExtraWeightSettings::ParseEntries(
+      cfg.GetValue(RiggingExtraWeightSettings::ConfigKey()));
   const std::string &positionName = rowPositions[static_cast<size_t>(row)];
   const float valueKg = static_cast<float>(*parsedKg);
   if (Units::NearlyEqualWeightKilograms(valueKg, 0.0, 0.0001)) {
     extraWeights.erase(positionName);
   } else {
-    RiggingExtraWeightEntry &entry = extraWeights[positionName];
+    RiggingExtraWeightSettings::Entry &entry = extraWeights[positionName];
     entry.valueKg = valueKg;
     entry.requiresValidation = false;
   }
-  cfg.SetValue(kRiggingExtraWeightsConfigKey,
-               SerializeRiggingExtraWeights(extraWeights));
+
+  cfg.SetValue(RiggingExtraWeightSettings::ConfigKey(),
+               RiggingExtraWeightSettings::SerializeEntries(extraWeights));
+
+  auto &scene = cfg.GetScene();
+  std::vector<std::string> supportsInPosition;
+  supportsInPosition.reserve(scene.supports.size());
+  for (const auto &[supportUuid, support] : scene.supports) {
+    const std::string supportPosition = support.positionName.empty()
+                                            ? UNASSIGNED_POSITION
+                                            : support.positionName;
+    if (supportPosition == positionName)
+      supportsInPosition.push_back(supportUuid);
+  }
+
+  if (!supportsInPosition.empty()) {
+    const auto roundedTotalsByPosition =
+        HoistWeightDistribution::BuildRoundedRiggingTotalByHangPosition(
+            scene, RiggingExtraWeightSettings::BuildKilogramsByPosition(
+                       extraWeights));
+    HoistWeightDistribution::ApplyForImportedSupports(
+        scene, supportsInPosition, roundedTotalsByPosition);
+    if (HoistTablePanel::Instance())
+      HoistTablePanel::Instance()->ReloadData();
+  }
+
   RefreshData();
 }
 

--- a/gui/riggingpanel.cpp
+++ b/gui/riggingpanel.cpp
@@ -19,17 +19,26 @@
 
 #include <cmath>
 #include <map>
+#include <unordered_map>
 #include <string>
 
 #include "colorstore.h"
 #include "columnutils.h"
 #include "configmanager.h"
 #include "guiconfigservices.h"
+#include "json.hpp"
 #include "units/unit_label_utils.h"
 #include "units/units.h"
 
 namespace {
 constexpr const char *UNASSIGNED_POSITION = "Unassigned";
+constexpr const char *kRiggingExtraWeightsConfigKey =
+    "rigging_position_extra_weights_v1";
+
+struct RiggingExtraWeightEntry {
+  float valueKg = 0.0f;
+  bool requiresValidation = false;
+};
 
 float RoundUpToNextFiveKg(float valueKg) {
   constexpr float kFiveKgStep = 5.0f;
@@ -68,11 +77,56 @@ wxString BuildRiggingTooltipForColumn(int modelColumn) {
   case 6:
     return "Hoist weight includes zero or missing values in this position.";
   case 7:
+    return "Extra weight was auto-calculated and must be validated by the user.";
   case 8:
-    return "Total weight includes items with zero or missing weight.";
+  case 9:
+    return "Total weight includes values that need attention (missing weights or pending validation).";
   default:
     return wxString();
   }
+}
+
+std::unordered_map<std::string, RiggingExtraWeightEntry>
+LoadRiggingExtraWeights(const ConfigManager &cfg) {
+  std::unordered_map<std::string, RiggingExtraWeightEntry> result;
+  const auto serialized = cfg.GetValue(kRiggingExtraWeightsConfigKey);
+  if (!serialized || serialized->empty())
+    return result;
+
+  const nlohmann::json parsed = nlohmann::json::parse(*serialized, nullptr, false);
+  if (!parsed.is_object())
+    return result;
+
+  for (auto it = parsed.begin(); it != parsed.end(); ++it) {
+    if (!it.value().is_object())
+      continue;
+    RiggingExtraWeightEntry entry;
+    if (const auto valueIt = it.value().find("valueKg");
+        valueIt != it.value().end() && valueIt->is_number()) {
+      entry.valueKg = static_cast<float>(valueIt->get<double>());
+    }
+    if (const auto sourceIt = it.value().find("source");
+        sourceIt != it.value().end() && sourceIt->is_string() &&
+        sourceIt->get<std::string>() == "auto_unvalidated") {
+      entry.requiresValidation = true;
+    }
+    result[it.key()] = entry;
+  }
+  return result;
+}
+
+std::string SerializeRiggingExtraWeights(
+    const std::unordered_map<std::string, RiggingExtraWeightEntry> &entries) {
+  nlohmann::json root = nlohmann::json::object();
+  std::map<std::string, RiggingExtraWeightEntry> sortedEntries(entries.begin(),
+                                                               entries.end());
+  for (const auto &[position, entry] : sortedEntries) {
+    nlohmann::json item = nlohmann::json::object();
+    item["valueKg"] = entry.valueKg;
+    item["source"] = entry.requiresValidation ? "auto_unvalidated" : "manual";
+    root[position] = std::move(item);
+  }
+  return root.dump();
 }
 
 void SetTableAndChildTooltips(wxDataViewListCtrl *table,
@@ -137,6 +191,8 @@ RiggingPanel::RiggingPanel(wxWindow *parent) : wxPanel(parent, wxID_ANY) {
     BindTableHoverEvents(table, this, &RiggingPanel::OnMouseMove,
                          &RiggingPanel::OnMouseLeave);
   });
+  table->Bind(wxEVT_DATAVIEW_ITEM_VALUE_CHANGED,
+              &RiggingPanel::OnItemValueChanged, this);
   const auto weightUnit = ResolveWeightUnitSystem();
   const wxString weightSuffix =
       wxString::FromUTF8(Units::WeightUnitSuffix(weightUnit));
@@ -158,6 +214,10 @@ RiggingPanel::RiggingPanel(wxWindow *parent) : wxPanel(parent, wxID_ANY) {
                           wxDATAVIEW_COL_RESIZABLE);
   table->AppendTextColumn("Hoists Weight (" + weightSuffix + ")",
                           wxDATAVIEW_CELL_INERT,
+                          wxCOL_WIDTH_AUTOSIZE, wxALIGN_RIGHT,
+                          wxDATAVIEW_COL_RESIZABLE);
+  table->AppendTextColumn("Extra Weight (" + weightSuffix + ")",
+                          wxDATAVIEW_CELL_EDITABLE,
                           wxCOL_WIDTH_AUTOSIZE, wxALIGN_RIGHT,
                           wxDATAVIEW_COL_RESIZABLE);
   table->AppendTextColumn("Total Weight (" + weightSuffix + ")",
@@ -202,6 +262,8 @@ void RiggingPanel::RefreshData() {
     float fixtureWeight = 0.0f;
     float trussWeight = 0.0f;
     float hoistWeight = 0.0f;
+    float extraWeight = 0.0f;
+    bool hasAutoUnvalidatedExtraWeight = false;
     bool hasZeroWeightFixture = false;
     bool hasZeroWeightTruss = false;
     bool hasZeroWeightHoist = false;
@@ -211,15 +273,18 @@ void RiggingPanel::RefreshData() {
   const auto weightUnit = ResolveWeightUnitSystem();
   const wxString weightSuffix =
       wxString::FromUTF8(Units::WeightUnitSuffix(weightUnit));
-  if (table->GetColumnCount() >= 9) {
+  if (table->GetColumnCount() >= 10) {
     table->GetColumn(4)->SetTitle("Fixture Weight (" + weightSuffix + ")");
     table->GetColumn(5)->SetTitle("Truss Weight (" + weightSuffix + ")");
     table->GetColumn(6)->SetTitle("Hoists Weight (" + weightSuffix + ")");
-    table->GetColumn(7)->SetTitle("Total Weight (" + weightSuffix + ")");
-    table->GetColumn(8)->SetTitle("Rounded Total Weight +5% (" + weightSuffix +
+    table->GetColumn(7)->SetTitle("Extra Weight (" + weightSuffix + ")");
+    table->GetColumn(8)->SetTitle("Total Weight (" + weightSuffix + ")");
+    table->GetColumn(9)->SetTitle("Rounded Total Weight +5% (" + weightSuffix +
                                   ")");
   }
-  const auto &scene = GetDefaultGuiConfigServices().LegacyConfigManager().GetScene();
+  auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+  const auto &scene = cfg.GetScene();
+  const auto extraWeights = LoadRiggingExtraWeights(cfg);
   for (const auto &[uuid, fixture] : scene.fixtures) {
     std::string pos = fixture.positionName.empty() ? UNASSIGNED_POSITION
                                                    : fixture.positionName;
@@ -250,13 +315,23 @@ void RiggingPanel::RefreshData() {
       entry.hasZeroWeightHoist = true;
   }
 
+  for (auto &[position, totals] : rows) {
+    if (const auto it = extraWeights.find(position); it != extraWeights.end()) {
+      totals.extraWeight = it->second.valueKg;
+      totals.hasAutoUnvalidatedExtraWeight = it->second.requiresValidation;
+    }
+  }
+
   // Ensure both the view and the custom store start from a clean state so
   // text colours get recalculated on every refresh.
   store->DeleteAllItems();
   table->DeleteAllItems();
+  rowPositions.clear();
+  rowPositions.reserve(rows.size());
   for (const auto &[position, totals] : rows) {
     float totalWeight =
-        totals.fixtureWeight + totals.trussWeight + totals.hoistWeight;
+        totals.fixtureWeight + totals.trussWeight + totals.hoistWeight +
+        totals.extraWeight;
     float roundedFivePercentIncrease = RoundUpToNextFiveKg(totalWeight);
     wxVector<wxVariant> row;
     row.push_back(wxString::FromUTF8(position));
@@ -270,12 +345,15 @@ void RiggingPanel::RefreshData() {
     row.push_back(wxString::FromUTF8(Units::FormatWeightFromKilograms(
         totals.hoistWeight, weightUnit, Units::ValueFormatContext::Table)));
     row.push_back(wxString::FromUTF8(Units::FormatWeightFromKilograms(
+        totals.extraWeight, weightUnit, Units::ValueFormatContext::Table)));
+    row.push_back(wxString::FromUTF8(Units::FormatWeightFromKilograms(
         totalWeight, weightUnit, Units::ValueFormatContext::Table)));
     row.push_back(wxString::FromUTF8(Units::FormatWeightFromKilograms(
         roundedFivePercentIncrease, weightUnit,
         Units::ValueFormatContext::Table)));
     unsigned int rowIndex = table->GetItemCount();
     table->AppendItem(row);
+    rowPositions.push_back(position);
 
     const bool fixtureWeightZero = totals.hasZeroWeightFixture;
     const bool trussWeightZero = totals.hasZeroWeightTruss;
@@ -288,9 +366,16 @@ void RiggingPanel::RefreshData() {
     if (hoistWeightZero)
       store->SetCellTextColour(rowIndex, 6, *wxRED);
 
-    if (fixtureWeightZero || trussWeightZero || hoistWeightZero) {
+    if (totals.hasAutoUnvalidatedExtraWeight)
       store->SetCellTextColour(rowIndex, 7, *wxRED);
+
+    if (fixtureWeightZero || trussWeightZero || hoistWeightZero) {
       store->SetCellTextColour(rowIndex, 8, *wxRED);
+      store->SetCellTextColour(rowIndex, 9, *wxRED);
+    }
+    if (totals.hasAutoUnvalidatedExtraWeight) {
+      store->SetCellTextColour(rowIndex, 8, *wxRED);
+      store->SetCellTextColour(rowIndex, 9, *wxRED);
     }
   }
 
@@ -300,6 +385,44 @@ void RiggingPanel::RefreshData() {
   // refresh is triggered (e.g. after loading/importing data or editing
   // weights in the tables).
   table->Refresh();
+}
+
+void RiggingPanel::OnItemValueChanged(wxDataViewEvent &event) {
+  if (!table)
+    return;
+
+  const int editedColumn = event.GetColumn();
+  if (editedColumn != 7)
+    return;
+
+  const int row = static_cast<int>(table->ItemToRow(event.GetItem()));
+  if (row < 0 || static_cast<size_t>(row) >= rowPositions.size())
+    return;
+
+  const auto weightUnit = ResolveWeightUnitSystem();
+  const wxString rawValue =
+      table->GetTextValue(static_cast<unsigned int>(row), 7);
+  const auto parsedKg = Units::ParseWeightToKilograms(
+      std::string(rawValue.ToUTF8()), weightUnit);
+  if (!parsedKg.has_value()) {
+    RefreshData();
+    return;
+  }
+
+  auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+  auto extraWeights = LoadRiggingExtraWeights(cfg);
+  const std::string &positionName = rowPositions[static_cast<size_t>(row)];
+  const float valueKg = static_cast<float>(*parsedKg);
+  if (Units::NearlyEqualWeightKilograms(valueKg, 0.0, 0.0001)) {
+    extraWeights.erase(positionName);
+  } else {
+    RiggingExtraWeightEntry &entry = extraWeights[positionName];
+    entry.valueKg = valueKg;
+    entry.requiresValidation = false;
+  }
+  cfg.SetValue(kRiggingExtraWeightsConfigKey,
+               SerializeRiggingExtraWeights(extraWeights));
+  RefreshData();
 }
 
 

--- a/gui/riggingpanel.cpp
+++ b/gui/riggingpanel.cpp
@@ -29,6 +29,7 @@
 #include "guiconfigservices.h"
 #include "hoist_weight_distribution.h"
 #include "hoisttablepanel.h"
+#include "mainwindow.h"
 #include "rigging_extra_weight_settings.h"
 #include "units/unit_label_utils.h"
 #include "units/units.h"
@@ -148,6 +149,12 @@ RiggingPanel::RiggingPanel(wxWindow *parent) : wxPanel(parent, wxID_ANY) {
               &RiggingPanel::OnItemValueChanged, this);
   table->Bind(wxEVT_DATAVIEW_ITEM_ACTIVATED, &RiggingPanel::OnItemActivated,
               this);
+  table->Bind(wxEVT_DATAVIEW_ITEM_CONTEXT_MENU,
+              &RiggingPanel::OnItemContextMenu, this);
+  table->Bind(wxEVT_DATAVIEW_ITEM_EDITING_STARTED,
+              &RiggingPanel::OnItemEditingStarted, this);
+  table->Bind(wxEVT_DATAVIEW_ITEM_EDITING_DONE,
+              &RiggingPanel::OnItemEditingDone, this);
   const auto weightUnit = ResolveWeightUnitSystem();
   const wxString weightSuffix =
       wxString::FromUTF8(Units::WeightUnitSuffix(weightUnit));
@@ -359,6 +366,42 @@ void RiggingPanel::OnItemActivated(wxDataViewEvent &event) {
   event.Skip();
 }
 
+void RiggingPanel::OnItemContextMenu(wxDataViewEvent &event) {
+  if (!table) {
+    event.Skip();
+    return;
+  }
+
+  const wxDataViewItem item = event.GetItem();
+  const int column = event.GetColumn();
+  if (!item.IsOk() || column != 7) {
+    event.Skip();
+    return;
+  }
+
+  table->EditItem(item, table->GetColumn(7));
+  event.Skip();
+}
+
+void RiggingPanel::OnItemEditingStarted(wxDataViewEvent &event) {
+  if (event.GetColumn() == 7 && !shortcutsTemporarilyDisabled) {
+    if (MainWindow::Instance()) {
+      MainWindow::Instance()->EnableShortcuts(false);
+      shortcutsTemporarilyDisabled = true;
+    }
+  }
+  event.Skip();
+}
+
+void RiggingPanel::OnItemEditingDone(wxDataViewEvent &event) {
+  if (event.GetColumn() == 7 && shortcutsTemporarilyDisabled) {
+    if (MainWindow::Instance())
+      MainWindow::Instance()->EnableShortcuts(true);
+    shortcutsTemporarilyDisabled = false;
+  }
+  event.Skip();
+}
+
 void RiggingPanel::OnItemValueChanged(wxDataViewEvent &event) {
   if (!table)
     return;
@@ -409,14 +452,22 @@ void RiggingPanel::OnItemValueChanged(wxDataViewEvent &event) {
   }
 
   if (!supportsInPosition.empty()) {
-    const auto roundedTotalsByPosition =
-        HoistWeightDistribution::BuildRoundedRiggingTotalByHangPosition(
-            scene, RiggingExtraWeightSettings::BuildKilogramsByPosition(
-                       extraWeights));
-    HoistWeightDistribution::ApplyForImportedSupports(
-        scene, supportsInPosition, roundedTotalsByPosition);
-    if (HoistTablePanel::Instance())
-      HoistTablePanel::Instance()->ReloadData();
+    const wxString message = wxString::Format(
+        "Position \"%s\" has hoists.\n\nDo you want to recalculate hoist loads "
+        "using the updated rounded rigging total?",
+        wxString::FromUTF8(positionName));
+    const int answer = wxMessageBox(message, "Recalculate hoist loads",
+                                    wxYES_NO | wxICON_QUESTION, this);
+    if (answer == wxYES) {
+      const auto roundedTotalsByPosition =
+          HoistWeightDistribution::BuildRoundedRiggingTotalByHangPosition(
+              scene, RiggingExtraWeightSettings::BuildKilogramsByPosition(
+                         extraWeights));
+      HoistWeightDistribution::ApplyForImportedSupports(
+          scene, supportsInPosition, roundedTotalsByPosition);
+      if (HoistTablePanel::Instance())
+        HoistTablePanel::Instance()->ReloadData();
+    }
   }
 
   RefreshData();

--- a/gui/riggingpanel.h
+++ b/gui/riggingpanel.h
@@ -20,6 +20,9 @@
 #include <wx/dataview.h>
 #include <wx/wx.h>
 
+#include <string>
+#include <vector>
+
 class ColorfulDataViewListStore;
 
 // Panel that summarizes rigging information grouped by position
@@ -33,6 +36,7 @@ public:
   static void SetInstance(RiggingPanel *panel);
 
 private:
+  void OnItemValueChanged(wxDataViewEvent &event);
   void OnMouseMove(wxMouseEvent &event);
   void OnMouseLeave(wxMouseEvent &event);
   void UpdateHoverTooltip(const wxPoint &position);
@@ -40,4 +44,5 @@ private:
   wxDataViewListCtrl *table = nullptr;
   ColorfulDataViewListStore *store = nullptr;
   wxString activeHoverTooltip;
+  std::vector<std::string> rowPositions;
 };

--- a/gui/riggingpanel.h
+++ b/gui/riggingpanel.h
@@ -36,6 +36,7 @@ public:
   static void SetInstance(RiggingPanel *panel);
 
 private:
+  void OnItemActivated(wxDataViewEvent &event);
   void OnItemValueChanged(wxDataViewEvent &event);
   void OnMouseMove(wxMouseEvent &event);
   void OnMouseLeave(wxMouseEvent &event);

--- a/gui/riggingpanel.h
+++ b/gui/riggingpanel.h
@@ -37,6 +37,9 @@ public:
 
 private:
   void OnItemActivated(wxDataViewEvent &event);
+  void OnItemContextMenu(wxDataViewEvent &event);
+  void OnItemEditingStarted(wxDataViewEvent &event);
+  void OnItemEditingDone(wxDataViewEvent &event);
   void OnItemValueChanged(wxDataViewEvent &event);
   void OnMouseMove(wxMouseEvent &event);
   void OnMouseLeave(wxMouseEvent &event);
@@ -46,4 +49,5 @@ private:
   ColorfulDataViewListStore *store = nullptr;
   wxString activeHoverTooltip;
   std::vector<std::string> rowPositions;
+  bool shortcutsTemporarilyDisabled = false;
 };


### PR DESCRIPTION
### Motivation
- Provide a user-editable per-position “extra weight” field in the Rigging summary so users can add scenography/screen/PA extra mass per hang position and allow future auto-calculated values to be represented and validated.

### Description
- Added an `Extra Weight` editable column to the Rigging panel (`gui/riggingpanel.h` / `gui/riggingpanel.cpp`) using `wxDATAVIEW_CELL_EDITABLE` and wired `OnItemValueChanged` to handle edits.
- Included the extra weight in `Total Weight` and `Rounded Total Weight +5%` calculations so totals reflect the new per-position input (column layout: position, fixtures, trusses, hoists, fixture weight, truss weight, hoists weight, extra weight, total weight, rounded total).
- Persisted per-position extra weights in project config under `rigging_position_extra_weights_v1` as JSON via `ConfigManager::SetValue` and `nlohmann::json`; values are stored with `valueKg` and `source` (supports `manual` and `auto_unvalidated` for future use).
- Kept `0` as neutral (no effect on totals and rendered with normal text); implemented rendering rules so auto-unvalidated extra weights mark the extra-weight cell and dependent totals in red and show a tooltip indicating validation is required; tooltip text for totals updated to cover missing or pending-validation values.
- Implemented a small row->position mapping (`rowPositions`) so edits persist against the correct position and used `Units::ParseWeightToKilograms` / `Units::FormatWeightFromKilograms` for unit-aware parsing/formatting.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed (`OK`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca68efad108324a674ccb3a1e417fb)