### PR TITLE
Add fixture-type color & visibility controls to Summary and honor them in 2D/3D rendering

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -33,6 +33,7 @@
 
 namespace {
 constexpr const char *kHiddenLayersConfigKey = "view_hidden_layers";
+constexpr const char *kHiddenFixtureTypesConfigKey = "view_hidden_fixture_types";
 constexpr const char *kLayoutsConfigKey = "layouts_collection";
 
 std::string SerializeHiddenLayerChecks(
@@ -57,6 +58,29 @@ DeserializeHiddenLayerChecks(const std::optional<std::string> &serialized) {
       hiddenLayers.insert(entry.get<std::string>());
   }
   return hiddenLayers;
+}
+
+std::string SerializeStringSet(const std::unordered_set<std::string> &values) {
+  std::vector<std::string> sorted(values.begin(), values.end());
+  std::sort(sorted.begin(), sorted.end());
+  return nlohmann::json(sorted).dump();
+}
+
+std::unordered_set<std::string>
+DeserializeStringSet(const std::optional<std::string> &serialized) {
+  std::unordered_set<std::string> values;
+  if (!serialized || serialized->empty())
+    return values;
+
+  nlohmann::json parsed = nlohmann::json::parse(*serialized, nullptr, false);
+  if (!parsed.is_array())
+    return values;
+
+  for (const auto &entry : parsed) {
+    if (entry.is_string())
+      values.insert(entry.get<std::string>());
+  }
+  return values;
 }
 } // namespace
 
@@ -308,6 +332,21 @@ bool ConfigManager::IsLayerVisible(const std::string &layer) const {
   return layerVisibilityState.IsLayerVisible(layer);
 }
 
+std::unordered_set<std::string> ConfigManager::GetHiddenFixtureTypes() const {
+  return DeserializeStringSet(GetValue(kHiddenFixtureTypesConfigKey));
+}
+
+void ConfigManager::SetHiddenFixtureTypes(
+    const std::unordered_set<std::string> &types) {
+  SetValue(kHiddenFixtureTypesConfigKey, SerializeStringSet(types));
+}
+
+bool ConfigManager::IsFixtureTypeVisible(
+    const std::string &fixtureType) const {
+  const auto hiddenFixtureTypes = GetHiddenFixtureTypes();
+  return hiddenFixtureTypes.find(fixtureType) == hiddenFixtureTypes.end();
+}
+
 void ConfigManager::SetLayerColor(const std::string &layer,
                                   const std::string &color) {
   layerVisibilityState.SetLayerColor(projectSession.GetScene(), layer, color);
@@ -390,6 +429,8 @@ bool ConfigManager::SaveProject(const std::string &path) {
   layouts::LayoutManager::Get().SaveToConfig(*this);
   SetValue(kHiddenLayersConfigKey,
            SerializeHiddenLayerChecks(layerVisibilityState.GetHiddenLayers()));
+  SetValue(kHiddenFixtureTypesConfigKey,
+           SerializeStringSet(GetHiddenFixtureTypes()));
   bool ok = projectSession.SaveProject(
       path, [this](const std::string &configPath) {
         return SaveToFile(configPath);
@@ -433,6 +474,8 @@ bool ConfigManager::LoadProject(const std::string &path) {
   if (ok) {
     layerVisibilityState.SetHiddenLayers(
         DeserializeHiddenLayerChecks(GetValue(kHiddenLayersConfigKey)));
+    SetHiddenFixtureTypes(
+        DeserializeStringSet(GetValue(kHiddenFixtureTypesConfigKey)));
     restoreUserPreferences();
     ClearHistory();
     selectionState.Clear();

--- a/core/configmanager.h
+++ b/core/configmanager.h
@@ -83,6 +83,9 @@ public:
     std::unordered_set<std::string> GetHiddenLayers() const;
     void SetHiddenLayers(const std::unordered_set<std::string>& layers);
     bool IsLayerVisible(const std::string& layer) const;
+    std::unordered_set<std::string> GetHiddenFixtureTypes() const;
+    void SetHiddenFixtureTypes(const std::unordered_set<std::string>& types);
+    bool IsFixtureTypeVisible(const std::string& fixtureType) const;
 
     // Layer color management
     void SetLayerColor(const std::string& layer, const std::string& color);

--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -327,7 +327,7 @@ void MainWindow::SetupLayout() {
                                       .Layer(1)
                                       .Row(0)
                                       .Position(0)
-                                      .BestSize(250, 300)
+                                      .BestSize(300, 300)
                                       .CloseButton(true)
                                       .MaximizeButton(true)
                                       .PaneBorder(true));
@@ -370,7 +370,7 @@ void MainWindow::SetupLayout() {
                                         .Layer(1)
                                         .Row(0)
                                         .Position(1)
-                                        .BestSize(250, 150)
+                                        .BestSize(300, 150)
                                         .CloseButton(true)
                                         .MaximizeButton(true)
                                         .PaneBorder(true));

--- a/gui/summarypanel.cpp
+++ b/gui/summarypanel.cpp
@@ -16,22 +16,68 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "summarypanel.h"
+#include "colorstore.h"
 #include "configmanager.h"
 #include "guiconfigservices.h"
+#include "viewer2dpanel.h"
+#include "viewer3dpanel.h"
+#include <wx/colordlg.h>
+#include <wx/dcmemory.h>
 #include <algorithm>
 #include <map>
+#include <unordered_set>
 
 static SummaryPanel* s_instance = nullptr;
 
 SummaryPanel::SummaryPanel(wxWindow* parent)
     : wxPanel(parent, wxID_ANY)
 {
+    store = new ColorfulDataViewListStore();
     table = new wxDataViewListCtrl(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxDV_ROW_LINES);
-    auto* countColumn = table->AppendTextColumn("Count", wxDATAVIEW_CELL_INERT, 60, wxALIGN_LEFT, wxDATAVIEW_COL_RESIZABLE);
-    auto* typeColumn = table->AppendTextColumn("Type", wxDATAVIEW_CELL_INERT, 150, wxALIGN_LEFT, wxDATAVIEW_COL_RESIZABLE);
+    table->AssociateModel(store);
+    store->DecRef();
 
-    auto applyInitialColumnWidths = [this, countColumn, typeColumn]() {
-        if (!table || !countColumn || !typeColumn)
+    auto applyInitialColumnWidths = [this]() {
+        if (!table)
+            return;
+
+        const int tableWidth = std::max(0, table->GetClientSize().GetWidth());
+        if (mode == SummaryMode::Fixture) {
+            auto* visibleColumn = table->GetColumn(0);
+            auto* countColumn = table->GetColumn(1);
+            auto* typeColumn = table->GetColumn(2);
+            auto* colorColumn = table->GetColumn(3);
+            if (!visibleColumn || !countColumn || !typeColumn || !colorColumn)
+                return;
+
+            wxClientDC dc(table);
+            dc.SetFont(table->GetFont());
+            int visibleLabelWidth = 0;
+            int countLabelWidth = 0;
+            int colorLabelWidth = 0;
+            dc.GetTextExtent("Visible", &visibleLabelWidth, nullptr);
+            dc.GetTextExtent("Count", &countLabelWidth, nullptr);
+            dc.GetTextExtent("Color", &colorLabelWidth, nullptr);
+
+            const int visibleWidth = visibleLabelWidth + 30;
+            const int countWidth = countLabelWidth + 20;
+            const int colorWidth = std::max(60, colorLabelWidth + 24);
+            const int typeWidth = std::max(120, tableWidth - visibleWidth - countWidth - colorWidth - 8);
+
+            visibleColumn->SetMinWidth(visibleWidth);
+            visibleColumn->SetWidth(visibleWidth);
+            countColumn->SetMinWidth(countWidth);
+            countColumn->SetWidth(countWidth);
+            typeColumn->SetMinWidth(120);
+            typeColumn->SetWidth(typeWidth);
+            colorColumn->SetMinWidth(colorWidth);
+            colorColumn->SetWidth(colorWidth);
+            return;
+        }
+
+        auto* countColumn = table->GetColumn(0);
+        auto* typeColumn = table->GetColumn(1);
+        if (!countColumn || !typeColumn)
             return;
 
         wxClientDC dc(table);
@@ -39,9 +85,7 @@ SummaryPanel::SummaryPanel(wxWindow* parent)
         int countLabelWidth = 0;
         dc.GetTextExtent("Count", &countLabelWidth, nullptr);
         const int countWidth = countLabelWidth + 20;
-        const int tableWidth = std::max(0, table->GetClientSize().GetWidth());
         const int typeWidth = std::max(120, tableWidth - countWidth - 8);
-
         countColumn->SetMinWidth(countWidth);
         countColumn->SetWidth(countWidth);
         typeColumn->SetMinWidth(120);
@@ -63,6 +107,15 @@ SummaryPanel::SummaryPanel(wxWindow* parent)
             applyInitialColumnWidths();
         evt.Skip();
     });
+
+    table->Bind(wxEVT_DATAVIEW_ITEM_VALUE_CHANGED,
+                &SummaryPanel::OnItemValueChanged, this);
+    table->Bind(wxEVT_DATAVIEW_ITEM_ACTIVATED,
+                &SummaryPanel::OnItemActivated, this);
+    table->Bind(wxEVT_MOTION, &SummaryPanel::OnMouseMove, this);
+    table->Bind(wxEVT_LEAVE_WINDOW, &SummaryPanel::OnMouseLeave, this);
+
+    EnsureColumnsForMode(SummaryMode::Generic);
 }
 
 SummaryPanel* SummaryPanel::Instance()
@@ -77,30 +130,43 @@ void SummaryPanel::SetInstance(SummaryPanel* panel)
 
 void SummaryPanel::ShowSummary(const std::vector<std::pair<std::string,int>>& items)
 {
-    if (!table) return;
-    table->DeleteAllItems();
+    if (!table || !store) return;
+    EnsureColumnsForMode(SummaryMode::Generic);
+    store->DeleteAllItems();
     for (const auto& [name, count] : items) {
         wxVector<wxVariant> row;
-        // Append the count as a string so it renders correctly in the text column
         row.push_back(wxString::Format("%d", count));
         row.push_back(wxString::FromUTF8(name));
-        table->AppendItem(row);
+        store->AppendItem(row);
     }
 }
 
 void SummaryPanel::ShowFixtureSummary()
 {
-    if (!table) return;
-
-    table->DeleteAllItems();
-
-    std::map<std::string, int> fixtureCounts;
+    if (!table || !store) return;
+    std::map<std::string, FixtureSummaryRow> grouped;
     const auto& fixtures = GetDefaultGuiConfigServices().LegacyConfigManager().GetScene().fixtures;
-    for (const auto& [uuid, fix] : fixtures)
-        fixtureCounts[fix.typeName]++;
-    std::vector<std::pair<std::string, int>> fixtureItems(fixtureCounts.begin(), fixtureCounts.end());
+    for (const auto& [uuid, fix] : fixtures) {
+        (void)uuid;
+        auto& row = grouped[fix.typeName];
+        row.typeName = fix.typeName;
+        row.count += 1;
+        if (row.colorHex.empty() && !fix.color.empty())
+            row.colorHex = fix.color;
+    }
 
-    ShowSummary(fixtureItems);
+    const auto hiddenFixtureTypes =
+        GetDefaultGuiConfigServices().LegacyConfigManager().GetHiddenFixtureTypes();
+    std::vector<FixtureSummaryRow> rows;
+    rows.reserve(grouped.size());
+    for (auto& [typeName, row] : grouped) {
+        row.visible = hiddenFixtureTypes.find(typeName) == hiddenFixtureTypes.end();
+        rows.push_back(row);
+    }
+    std::sort(rows.begin(), rows.end(), [](const auto& a, const auto& b) {
+        return a.typeName < b.typeName;
+    });
+    ShowFixtureSummaryRows(rows);
 }
 
 void SummaryPanel::ShowTrussSummary()
@@ -136,4 +202,191 @@ void SummaryPanel::ShowSceneObjectSummary()
         counts[obj.name]++;
     std::vector<std::pair<std::string,int>> items(counts.begin(), counts.end());
     ShowSummary(items);
+}
+
+void SummaryPanel::ShowFixtureSummaryRows(
+    const std::vector<FixtureSummaryRow>& rows) {
+    EnsureColumnsForMode(SummaryMode::Fixture);
+    store->DeleteAllItems();
+    for (const auto& rowData : rows) {
+        wxVector<wxVariant> row;
+        row.push_back(wxVariant(rowData.visible));
+        row.push_back(wxString::Format("%d", rowData.count));
+        row.push_back(wxString::FromUTF8(rowData.typeName));
+
+        wxBitmap bmp(16, 16);
+        wxMemoryDC dc(bmp);
+        wxColour color;
+        if (!rowData.colorHex.empty() && color.Set(wxString::FromUTF8(rowData.colorHex)))
+            dc.SetBrush(wxBrush(color));
+        else
+            dc.SetBrush(wxBrush(wxColour(128, 128, 128)));
+        dc.SetPen(*wxBLACK_PEN);
+        dc.DrawRectangle(0, 0, 16, 16);
+        dc.SelectObject(wxNullBitmap);
+        wxDataViewIconText icon(wxString::FromUTF8(rowData.colorHex), bmp);
+        row.push_back(wxVariant(icon));
+        store->AppendItem(row);
+    }
+    RefreshFixtureVisibilityStyles();
+}
+
+void SummaryPanel::EnsureColumnsForMode(SummaryMode requestedMode) {
+    if (!table)
+        return;
+    if (mode == requestedMode && table->GetColumnCount() > 0)
+        return;
+
+    while (table->GetColumnCount() > 0)
+        table->DeleteColumn(table->GetColumn(0));
+
+    if (requestedMode == SummaryMode::Fixture) {
+        table->AppendToggleColumn("Visible", wxDATAVIEW_CELL_ACTIVATABLE, 70,
+                                  wxALIGN_LEFT, wxDATAVIEW_COL_RESIZABLE);
+        table->AppendTextColumn("Count", wxDATAVIEW_CELL_INERT, 60, wxALIGN_LEFT,
+                                wxDATAVIEW_COL_RESIZABLE);
+        table->AppendTextColumn("Type", wxDATAVIEW_CELL_INERT, 150, wxALIGN_LEFT,
+                                wxDATAVIEW_COL_RESIZABLE);
+        auto* colorRenderer = new wxDataViewIconTextRenderer();
+        table->AppendColumn(new wxDataViewColumn(
+            "Color", colorRenderer, 3, 80, wxALIGN_LEFT, wxDATAVIEW_COL_RESIZABLE));
+    } else {
+        table->AppendTextColumn("Count", wxDATAVIEW_CELL_INERT, 60, wxALIGN_LEFT,
+                                wxDATAVIEW_COL_RESIZABLE);
+        table->AppendTextColumn("Type", wxDATAVIEW_CELL_INERT, 150, wxALIGN_LEFT,
+                                wxDATAVIEW_COL_RESIZABLE);
+    }
+    mode = requestedMode;
+}
+
+void SummaryPanel::RefreshFixtureVisibilityStyles() {
+    if (!table || !store || mode != SummaryMode::Fixture)
+        return;
+
+    const auto hiddenFixtureTypes =
+        GetDefaultGuiConfigServices().LegacyConfigManager().GetHiddenFixtureTypes();
+    for (unsigned int row = 0; row < table->GetItemCount(); ++row) {
+        store->ClearRowTextColour(row);
+        wxString typeName = table->GetTextValue(static_cast<int>(row), 2);
+        if (hiddenFixtureTypes.find(typeName.ToStdString()) != hiddenFixtureTypes.end())
+            store->SetRowTextColour(row, *wxRED);
+    }
+    table->Refresh();
+}
+
+void SummaryPanel::RefreshVisibleViewers() const {
+    if (Viewer2DPanel::Instance()) {
+        Viewer2DPanel::Instance()->UpdateScene(false);
+        Viewer2DPanel::Instance()->Refresh();
+    }
+    if (Viewer3DPanel::Instance()) {
+        Viewer3DPanel::Instance()->UpdateScene();
+        Viewer3DPanel::Instance()->Refresh();
+    }
+}
+
+void SummaryPanel::OnItemValueChanged(wxDataViewEvent& event) {
+    if (!table || mode != SummaryMode::Fixture || event.GetColumn() != 0)
+        return;
+    const int row = table->ItemToRow(event.GetItem());
+    if (row == wxNOT_FOUND)
+        return;
+
+    wxVariant value;
+    table->GetValue(value, row, 0);
+    const bool visible = value.GetBool();
+    const std::string typeName = table->GetTextValue(row, 2).ToStdString();
+
+    auto hiddenFixtureTypes =
+        GetDefaultGuiConfigServices().LegacyConfigManager().GetHiddenFixtureTypes();
+    if (visible)
+        hiddenFixtureTypes.erase(typeName);
+    else
+        hiddenFixtureTypes.insert(typeName);
+    GetDefaultGuiConfigServices().LegacyConfigManager().SetHiddenFixtureTypes(hiddenFixtureTypes);
+    RefreshFixtureVisibilityStyles();
+    RefreshVisibleViewers();
+}
+
+void SummaryPanel::OnItemActivated(wxDataViewEvent& event) {
+    if (!table || mode != SummaryMode::Fixture)
+        return;
+    const int row = table->ItemToRow(event.GetItem());
+    if (row == wxNOT_FOUND || event.GetColumn() != 3)
+        return;
+
+    const std::string typeName = table->GetTextValue(row, 2).ToStdString();
+    auto& cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+    auto& fixtures = cfg.GetScene().fixtures;
+
+    wxColourData data;
+    for (const auto& [uuid, fixture] : fixtures) {
+        (void)uuid;
+        if (fixture.typeName == typeName && !fixture.color.empty()) {
+            data.SetColour(wxColour(wxString::FromUTF8(fixture.color)));
+            break;
+        }
+    }
+
+    wxColourDialog dlg(this, &data);
+    if (dlg.ShowModal() != wxID_OK)
+        return;
+
+    const wxColour color = dlg.GetColourData().GetColour();
+    const std::string hex = wxString::Format("#%02X%02X%02X", color.Red(), color.Green(),
+                                             color.Blue()).ToStdString();
+    cfg.PushUndoState("change fixture type color from summary");
+    for (auto& [uuid, fixture] : fixtures) {
+        (void)uuid;
+        if (fixture.typeName == typeName)
+            fixture.color = hex;
+    }
+
+    wxBitmap bmp(16, 16);
+    wxMemoryDC dc(bmp);
+    dc.SetBrush(wxBrush(color));
+    dc.SetPen(*wxBLACK_PEN);
+    dc.DrawRectangle(0, 0, 16, 16);
+    dc.SelectObject(wxNullBitmap);
+    table->SetValue(wxVariant(wxDataViewIconText(wxString::FromUTF8(hex), bmp)), row, 3);
+    RefreshVisibleViewers();
+}
+
+void SummaryPanel::OnMouseMove(wxMouseEvent& event) {
+    if (!table || mode != SummaryMode::Fixture) {
+        event.Skip();
+        return;
+    }
+
+    wxDataViewItem item;
+    wxDataViewColumn* column = nullptr;
+    table->HitTest(event.GetPosition(), item, column);
+
+    wxString tooltip;
+    if (item.IsOk()) {
+        const int row = table->ItemToRow(item);
+        if (row != wxNOT_FOUND) {
+            wxVariant value;
+            table->GetValue(value, row, 0);
+            if (!value.GetBool())
+                tooltip = "Fixture type hidden: not rendered in 2D/3D viewers.";
+        }
+    }
+
+    if (tooltip != activeHoverTooltip) {
+        table->SetToolTip(tooltip);
+        activeHoverTooltip = tooltip;
+    }
+    event.Skip();
+}
+
+void SummaryPanel::OnMouseLeave(wxMouseEvent& event) {
+    if (activeHoverTooltip.empty()) {
+        event.Skip();
+        return;
+    }
+    activeHoverTooltip.clear();
+    if (table)
+        table->SetToolTip(wxString());
+    event.Skip();
 }

--- a/gui/summarypanel.cpp
+++ b/gui/summarypanel.cpp
@@ -227,7 +227,7 @@ void SummaryPanel::ShowFixtureSummaryRows(
         dc.SetPen(*wxBLACK_PEN);
         dc.DrawRectangle(0, 0, 16, 16);
         dc.SelectObject(wxNullBitmap);
-        wxDataViewIconText icon(wxString::FromUTF8(rowData.colorHex), bmp);
+        wxDataViewIconText icon("", bmp);
         row.push_back(wxVariant(icon));
         store->AppendItem(row);
     }
@@ -351,7 +351,7 @@ void SummaryPanel::OnItemActivated(wxDataViewEvent& event) {
     dc.SetPen(*wxBLACK_PEN);
     dc.DrawRectangle(0, 0, 16, 16);
     dc.SelectObject(wxNullBitmap);
-    table->SetValue(wxVariant(wxDataViewIconText(wxString::FromUTF8(hex), bmp)), row, 3);
+    table->SetValue(wxVariant(wxDataViewIconText("", bmp)), row, 3);
     RefreshVisibleViewers();
 }
 

--- a/gui/summarypanel.cpp
+++ b/gui/summarypanel.cpp
@@ -37,8 +37,12 @@ SummaryPanel::SummaryPanel(wxWindow* parent)
     table->AssociateModel(store);
     store->DecRef();
 
+    EnsureColumnsForMode(SummaryMode::Generic);
+
     auto applyInitialColumnWidths = [this]() {
         if (!table)
+            return;
+        if (table->GetColumnCount() == 0)
             return;
 
         const int tableWidth = std::max(0, table->GetClientSize().GetWidth());
@@ -115,7 +119,6 @@ SummaryPanel::SummaryPanel(wxWindow* parent)
     table->Bind(wxEVT_MOTION, &SummaryPanel::OnMouseMove, this);
     table->Bind(wxEVT_LEAVE_WINDOW, &SummaryPanel::OnMouseLeave, this);
 
-    EnsureColumnsForMode(SummaryMode::Generic);
 }
 
 SummaryPanel* SummaryPanel::Instance()

--- a/gui/summarypanel.h
+++ b/gui/summarypanel.h
@@ -20,6 +20,8 @@
 #include <wx/wx.h>
 #include <wx/dataview.h>
 
+class ColorfulDataViewListStore;
+
 // Panel that shows a summary count of items by type/model/name
 class SummaryPanel : public wxPanel {
 public:
@@ -34,6 +36,30 @@ public:
     static void SetInstance(SummaryPanel* panel);
 
 private:
+    enum class SummaryMode {
+        Fixture,
+        Generic
+    };
+
+    struct FixtureSummaryRow {
+        std::string typeName;
+        int count = 0;
+        std::string colorHex;
+        bool visible = true;
+    };
+
     wxDataViewListCtrl* table = nullptr;
+    ColorfulDataViewListStore* store = nullptr;
+    SummaryMode mode = SummaryMode::Generic;
+    wxString activeHoverTooltip;
+
     void ShowSummary(const std::vector<std::pair<std::string,int>>& items);
+    void ShowFixtureSummaryRows(const std::vector<FixtureSummaryRow>& rows);
+    void EnsureColumnsForMode(SummaryMode requestedMode);
+    void RefreshFixtureVisibilityStyles();
+    void RefreshVisibleViewers() const;
+    void OnItemValueChanged(wxDataViewEvent& event);
+    void OnItemActivated(wxDataViewEvent& event);
+    void OnMouseMove(wxMouseEvent& event);
+    void OnMouseLeave(wxMouseEvent& event);
 };

--- a/viewer3d/culling/bounds_cache_system.cpp
+++ b/viewer3d/culling/bounds_cache_system.cpp
@@ -116,7 +116,8 @@ void BoundsCacheSystem::RebuildIfDirty(
 
   context.fixtureBounds.clear();
   for (const auto &[uuid, f] : fixtures) {
-    if (!IsLayerVisibleCached(hiddenLayers, f.layer))
+    if (!IsLayerVisibleCached(hiddenLayers, f.layer) ||
+        !ConfigManager::Get().IsFixtureTypeVisible(f.typeName))
       continue;
     Viewer3DBoundingBox bb;
     Matrix fix = f.transform;

--- a/viewer3d/culling/visibilitysystem.cpp
+++ b/viewer3d/culling/visibilitysystem.cpp
@@ -499,7 +499,8 @@ bool VisibilitySystem::TryBuildLayerVisibleCandidates(
       continue;
     const auto &uuid = entry->first;
     const auto &fixture = entry->second;
-    if (!IsLayerVisibleCached(hiddenLayers, fixture.layer))
+    if (!IsLayerVisibleCached(hiddenLayers, fixture.layer) ||
+        !ConfigManager::Get().IsFixtureTypeVisible(fixture.typeName))
       continue;
     if (fixtures.find(uuid) != fixtures.end())
       out.fixtureUuids.push_back(uuid);

--- a/viewer3d/labels/label_render_system.cpp
+++ b/viewer3d/labels/label_render_system.cpp
@@ -501,7 +501,8 @@ void LabelRenderSystem::DrawAllFixtureLabels(int width, int height,
   const auto &fixtures = SceneDataManager::Instance().GetFixtures();
   candidates.reserve(fixtures.size());
   for (const auto &[uuid, f] : fixtures) {
-    if (!IsLayerVisibleCached(hiddenLayers, f.layer))
+    if (!IsLayerVisibleCached(hiddenLayers, f.layer) ||
+        !cfg.IsFixtureTypeVisible(f.typeName))
       continue;
 
     auto bit = m_controller.GetFixtureBoundsMap().find(uuid);

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -820,7 +820,8 @@ void Viewer3DController::UpdateResourcesIfDirty() {
       visibleObjects.push_back(&entry);
   }
   for (const auto &entry : fixtures) {
-    if (IsLayerVisibleCached(hiddenLayers, entry.second.layer))
+    if (IsLayerVisibleCached(hiddenLayers, entry.second.layer) &&
+        cfg.IsFixtureTypeVisible(entry.second.typeName))
       visibleFixtures.push_back(&entry);
   }
 


### PR DESCRIPTION
### Motivation
- Provide per-fixture-type controls in the Summary panel to view/change the assigned color and toggle visibility for rendering. 
- Persist fixture-type visibility so the choice is kept with the project and used during render/culling. 
- Make hidden fixture types behave like other tables (red row + tooltip) and immediately affect Viewer2D/Viewer3D output.

### Description
- Summary panel: migrated fixture summary to use `ColorfulDataViewListStore` and added a fixture-mode table with columns `Visible` (toggle), `Count`, `Type`, and `Color` plus hover tooltip handling; clicking the color cell opens a color dialog and applies the chosen hex to all fixtures of that type. Files changed: `gui/summarypanel.h`, `gui/summarypanel.cpp`.
- Config persistence/API: added project persistence key `view_hidden_fixture_types` and new `ConfigManager` helpers `GetHiddenFixtureTypes()`, `SetHiddenFixtureTypes(...)`, and `IsFixtureTypeVisible(...)`, plus `SerializeStringSet`/`DeserializeStringSet` helpers to store/restore the set. Files changed: `core/configmanager.h`, `core/configmanager.cpp`.
- Rendering / culling integration: wired fixture-type visibility checks into the render and visibility paths so disabled types are excluded from resource sync, visible-set construction, bounds cache, and label candidate collection; locations updated include `viewer3d/viewer3dcontroller.cpp`, `viewer3d/culling/visibilitysystem.cpp`, `viewer3d/culling/bounds_cache_system.cpp`, and `viewer3d/labels/label_render_system.cpp`.
- UI behavior: rows for hidden fixture types are drawn in red and show a tooltip indicating the type is hidden; toggling visibility updates `ConfigManager` and forces an immediate refresh of Viewer2D and Viewer3D.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded.
- Attempted a full CMake build (`cmake -S . -B build && cmake --build build -j2`) but it failed in this environment due to missing `wxWidgets` development packages, so a local build with correct GUI dependencies is still required (failure is environmental, not from code changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca6b54a82483248023edd47f0ecb81)