### PR TITLE
Refine 3D white-model rendering with a dedicated edge pass

### DIFF
--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -30,6 +30,33 @@ LineRenderProfile GetLineRenderProfile(bool isInteracting, bool wireframeMode,
     return {1.0f, false};
   return {wireframeMode ? 1.0f : 2.0f, true};
 }
+
+void ApplyWhiteModelEdgePassStyle(IRenderContext &controller, bool highlight,
+                                  bool selected, float lineWidth,
+                                  bool enableLineSmoothing) {
+  if (highlight)
+    controller.SetGLColor(0.0f, 0.48f, 0.0f);
+  else if (selected)
+    controller.SetGLColor(0.0f, 0.45f, 0.45f);
+  else
+    controller.SetGLColor(0.16f, 0.16f, 0.16f);
+
+  glLineWidth(lineWidth);
+  if (enableLineSmoothing) {
+    glEnable(GL_LINE_SMOOTH);
+    glHint(GL_LINE_SMOOTH_HINT, GL_NICEST);
+  } else {
+    glDisable(GL_LINE_SMOOTH);
+  }
+}
+
+void RestoreWhiteModelEdgePassStyle(bool hadLineSmoothing) {
+  if (hadLineSmoothing)
+    glEnable(GL_LINE_SMOOTH);
+  else
+    glDisable(GL_LINE_SMOOTH);
+  glLineWidth(1.0f);
+}
 } // namespace
 
 void SceneRenderer::DrawMeshWithOutline(
@@ -122,12 +149,23 @@ void SceneRenderer::DrawMeshWithOutline(
       glEnable(GL_LIGHTING);
 
     if (m_controller.IsWhiteModelStyleEnabled()) {
+      const LineRenderProfile edgeProfile =
+          GetLineRenderProfile(m_controller.IsInteracting(), false,
+                               m_controller.UseAdaptiveLineProfile());
+      const float edgeLineWidth =
+          m_controller.IsInteracting() ? 1.0f : edgeProfile.lineWidth * 0.75f;
       const GLboolean lightingWasEnabled = glIsEnabled(GL_LIGHTING);
+      const GLboolean lineSmoothWasEnabled = glIsEnabled(GL_LINE_SMOOTH);
       if (lightingWasEnabled)
         glDisable(GL_LIGHTING);
-      glLineWidth(1.0f);
-      m_controller.SetGLColor(0.0f, 0.0f, 0.0f);
+      glEnable(GL_POLYGON_OFFSET_LINE);
+      glPolygonOffset(-1.0f, -1.0f);
+      ApplyWhiteModelEdgePassStyle(m_controller, highlight, selected,
+                                   edgeLineWidth,
+                                   edgeProfile.enableLineSmoothing);
       DrawMeshWireframe(mesh, scale, captureTransform);
+      glDisable(GL_POLYGON_OFFSET_LINE);
+      RestoreWhiteModelEdgePassStyle(lineSmoothWasEnabled);
       if (lightingWasEnabled)
         glEnable(GL_LIGHTING);
     }

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -16,30 +16,8 @@
 
 #include <algorithm>
 #include <cmath>
-#include <unordered_map>
 
 namespace {
-struct EdgeKey {
-  unsigned short a = 0;
-  unsigned short b = 0;
-
-  bool operator==(const EdgeKey &other) const {
-    return a == other.a && b == other.b;
-  }
-};
-
-struct EdgeKeyHash {
-  size_t operator()(const EdgeKey &key) const {
-    return (static_cast<size_t>(key.a) << 16u) ^ static_cast<size_t>(key.b);
-  }
-};
-
-struct EdgeInfo {
-  int count = 0;
-  std::array<float, 3> firstFaceNormal = {0.0f, 0.0f, 0.0f};
-  std::array<float, 3> secondFaceNormal = {0.0f, 0.0f, 0.0f};
-};
-
 struct InkColor {
   float r = 1.0f;
   float g = 1.0f;
@@ -65,82 +43,6 @@ std::array<float, 3> NormalizeVector(float x, float y, float z) {
   if (length <= 1e-6f)
     return {0.0f, 0.0f, 1.0f};
   return {x / length, y / length, z / length};
-}
-
-std::array<float, 3> BuildFaceNormal(const std::vector<float> &vertices,
-                                     unsigned short i0, unsigned short i1,
-                                     unsigned short i2) {
-  const size_t p0 = static_cast<size_t>(i0) * 3u;
-  const size_t p1 = static_cast<size_t>(i1) * 3u;
-  const size_t p2 = static_cast<size_t>(i2) * 3u;
-  if (p0 + 2 >= vertices.size() || p1 + 2 >= vertices.size() ||
-      p2 + 2 >= vertices.size())
-    return {0.0f, 0.0f, 0.0f};
-
-  const float ax = vertices[p1] - vertices[p0];
-  const float ay = vertices[p1 + 1] - vertices[p0 + 1];
-  const float az = vertices[p1 + 2] - vertices[p0 + 2];
-  const float bx = vertices[p2] - vertices[p0];
-  const float by = vertices[p2 + 1] - vertices[p0 + 1];
-  const float bz = vertices[p2 + 2] - vertices[p0 + 2];
-
-  return NormalizeVector(ay * bz - az * by, az * bx - ax * bz,
-                         ax * by - ay * bx);
-}
-
-std::vector<unsigned short>
-BuildCreasedWireframeIndices(const std::vector<float> &vertices,
-                             const std::vector<unsigned short> &triangleIndices) {
-  static constexpr float kCreaseAngleDeg = 5.0f;
-  static constexpr float kPi = 3.14159265358979323846f;
-  const float creaseDotThreshold = std::cos(kCreaseAngleDeg * kPi / 180.0f);
-
-  std::unordered_map<EdgeKey, EdgeInfo, EdgeKeyHash> edges;
-  edges.reserve(triangleIndices.size());
-
-  auto registerEdge = [&](unsigned short i, unsigned short j,
-                          const std::array<float, 3> &faceNormal) {
-    const EdgeKey key = {std::min(i, j), std::max(i, j)};
-    EdgeInfo &info = edges[key];
-    ++info.count;
-    if (info.count == 1)
-      info.firstFaceNormal = faceNormal;
-    else if (info.count == 2)
-      info.secondFaceNormal = faceNormal;
-  };
-
-  for (size_t i = 0; i + 2 < triangleIndices.size(); i += 3) {
-    const unsigned short i0 = triangleIndices[i];
-    const unsigned short i1 = triangleIndices[i + 1];
-    const unsigned short i2 = triangleIndices[i + 2];
-    const std::array<float, 3> faceNormal =
-        BuildFaceNormal(vertices, i0, i1, i2);
-
-    registerEdge(i0, i1, faceNormal);
-    registerEdge(i1, i2, faceNormal);
-    registerEdge(i2, i0, faceNormal);
-  }
-
-  std::vector<unsigned short> lineIndices;
-  lineIndices.reserve(edges.size() * 2u);
-  for (const auto &[edge, info] : edges) {
-    if (info.count == 1) {
-      lineIndices.push_back(edge.a);
-      lineIndices.push_back(edge.b);
-      continue;
-    }
-    if (info.count == 2) {
-      const float dot = info.firstFaceNormal[0] * info.secondFaceNormal[0] +
-                        info.firstFaceNormal[1] * info.secondFaceNormal[1] +
-                        info.firstFaceNormal[2] * info.secondFaceNormal[2];
-      if (dot < creaseDotThreshold) {
-        lineIndices.push_back(edge.a);
-        lineIndices.push_back(edge.b);
-      }
-    }
-  }
-
-  return lineIndices;
 }
 
 std::array<float, 3> TransformNormal(const std::array<float, 3> &n,
@@ -419,18 +321,26 @@ void SceneRenderer::DrawMeshWireframe(
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     glPopMatrix();
   } else if (!m_controller.IsCaptureOnly()) {
-    const std::vector<unsigned short> lineIndices =
-        BuildCreasedWireframeIndices(mesh.vertices, mesh.indices);
     glBegin(GL_LINES);
-    for (size_t i = 0; i + 1 < lineIndices.size(); i += 2) {
-      const unsigned short i0 = lineIndices[i];
-      const unsigned short i1 = lineIndices[i + 1];
-      glVertex3f(mesh.vertices[i0 * 3] * scale,
-                 mesh.vertices[i0 * 3 + 1] * scale,
+    for (size_t i = 0; i + 2 < mesh.indices.size(); i += 3) {
+      const unsigned short i0 = mesh.indices[i];
+      const unsigned short i1 = mesh.indices[i + 1];
+      const unsigned short i2 = mesh.indices[i + 2];
+
+      glVertex3f(mesh.vertices[i0 * 3] * scale, mesh.vertices[i0 * 3 + 1] * scale,
                  mesh.vertices[i0 * 3 + 2] * scale);
-      glVertex3f(mesh.vertices[i1 * 3] * scale,
-                 mesh.vertices[i1 * 3 + 1] * scale,
+      glVertex3f(mesh.vertices[i1 * 3] * scale, mesh.vertices[i1 * 3 + 1] * scale,
                  mesh.vertices[i1 * 3 + 2] * scale);
+
+      glVertex3f(mesh.vertices[i1 * 3] * scale, mesh.vertices[i1 * 3 + 1] * scale,
+                 mesh.vertices[i1 * 3 + 2] * scale);
+      glVertex3f(mesh.vertices[i2 * 3] * scale, mesh.vertices[i2 * 3 + 1] * scale,
+                 mesh.vertices[i2 * 3 + 2] * scale);
+
+      glVertex3f(mesh.vertices[i2 * 3] * scale, mesh.vertices[i2 * 3 + 1] * scale,
+                 mesh.vertices[i2 * 3 + 2] * scale);
+      glVertex3f(mesh.vertices[i0 * 3] * scale, mesh.vertices[i0 * 3 + 1] * scale,
+                 mesh.vertices[i0 * 3 + 2] * scale);
     }
     glEnd();
   }

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -202,9 +202,10 @@ void SceneRenderer::DrawMeshWithOutline(
       // Keep 3D white-model aligned with the 2D viewer draw order:
       // stroke pass first, then polygon-offset fill pass.
       const LineRenderProfile lineProfile =
-          GetLineRenderProfile(false, mode == Viewer2DRenderMode::Wireframe,
+          GetLineRenderProfile(m_controller.IsInteracting(),
+                               mode == Viewer2DRenderMode::Wireframe,
                                m_controller.UseAdaptiveLineProfile());
-      const float lineWidth = lineProfile.lineWidth + 0.8f;
+      const float lineWidth = lineProfile.lineWidth;
       auto setHighlightOrSelectionColor = [&]() {
         if (highlight)
           m_controller.SetGLColor(0.0f, 1.0f, 0.0f);
@@ -213,27 +214,22 @@ void SceneRenderer::DrawMeshWithOutline(
         else
           m_controller.SetGLColor(0.0f, 0.0f, 0.0f);
       };
-      const GLboolean lightingWasEnabled = glIsEnabled(GL_LIGHTING);
-      const GLboolean lineSmoothWasEnabled = glIsEnabled(GL_LINE_SMOOTH);
-      if (lightingWasEnabled)
-        glDisable(GL_LIGHTING);
-      if (lineProfile.enableLineSmoothing) {
-        glEnable(GL_LINE_SMOOTH);
-        glHint(GL_LINE_SMOOTH_HINT, GL_NICEST);
-      } else {
-        glDisable(GL_LINE_SMOOTH);
+      const bool drawOutline =
+          !m_controller.SkipOutlinesForCurrentFrame() &&
+          m_controller.IsSelectionOutlineEnabled2D() && (highlight || selected);
+
+      if (!m_controller.IsCaptureOnly()) {
+        if (drawOutline) {
+          const float glowWidth = lineWidth + 3.0f;
+          glLineWidth(glowWidth);
+          setHighlightOrSelectionColor();
+          DrawMeshWireframe(mesh, scale, captureTransform);
+        }
+        glLineWidth(lineWidth);
+        m_controller.SetGLColor(0.0f, 0.0f, 0.0f);
       }
-      glEnable(GL_POLYGON_OFFSET_LINE);
-      glPolygonOffset(1.0f, 1.0f);
-      glLineWidth(lineWidth);
-      setHighlightOrSelectionColor();
       DrawMeshWireframe(mesh, scale, captureTransform);
-      glDisable(GL_POLYGON_OFFSET_LINE);
       glLineWidth(1.0f);
-      if (lineSmoothWasEnabled)
-        glEnable(GL_LINE_SMOOTH);
-      if (lightingWasEnabled)
-        glEnable(GL_LIGHTING);
 
       glEnable(GL_POLYGON_OFFSET_FILL);
       glPolygonOffset(-1.0f, -1.0f);

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -30,33 +30,6 @@ LineRenderProfile GetLineRenderProfile(bool isInteracting, bool wireframeMode,
     return {1.0f, false};
   return {wireframeMode ? 1.0f : 2.0f, true};
 }
-
-void ApplyWhiteModelEdgePassStyle(IRenderContext &controller, bool highlight,
-                                  bool selected, float lineWidth,
-                                  bool enableLineSmoothing) {
-  if (highlight)
-    controller.SetGLColor(0.0f, 0.48f, 0.0f);
-  else if (selected)
-    controller.SetGLColor(0.0f, 0.45f, 0.45f);
-  else
-    controller.SetGLColor(0.16f, 0.16f, 0.16f);
-
-  glLineWidth(lineWidth);
-  if (enableLineSmoothing) {
-    glEnable(GL_LINE_SMOOTH);
-    glHint(GL_LINE_SMOOTH_HINT, GL_NICEST);
-  } else {
-    glDisable(GL_LINE_SMOOTH);
-  }
-}
-
-void RestoreWhiteModelEdgePassStyle(bool hadLineSmoothing) {
-  if (hadLineSmoothing)
-    glEnable(GL_LINE_SMOOTH);
-  else
-    glDisable(GL_LINE_SMOOTH);
-  glLineWidth(1.0f);
-}
 } // namespace
 
 void SceneRenderer::DrawMeshWithOutline(
@@ -135,38 +108,45 @@ void SceneRenderer::DrawMeshWithOutline(
   }
 
   if (!m_controller.IsCaptureOnly()) {
-    if (highlight)
-      m_controller.SetGLColor(0.0f, 1.0f, 0.0f);
-    else if (selected)
-      m_controller.SetGLColor(0.0f, 1.0f, 1.0f);
-    else
-      m_controller.SetGLColor(r, g, b);
-
-    if (unlit)
-      glDisable(GL_LIGHTING);
-    DrawMesh(mesh, scale, modelMatrix);
-    if (unlit)
-      glEnable(GL_LIGHTING);
-
     if (m_controller.IsWhiteModelStyleEnabled()) {
-      const LineRenderProfile edgeProfile =
-          GetLineRenderProfile(m_controller.IsInteracting(), false,
-                               m_controller.UseAdaptiveLineProfile());
-      const float edgeLineWidth =
-          m_controller.IsInteracting() ? 1.0f : edgeProfile.lineWidth * 0.75f;
+      // Keep 3D white-model aligned with the 2D viewer draw order:
+      // stroke pass first, then polygon-offset fill pass.
+      const float lineWidth =
+          GetLineRenderProfile(m_controller.IsInteracting(),
+                               mode == Viewer2DRenderMode::Wireframe,
+                               m_controller.UseAdaptiveLineProfile())
+              .lineWidth;
       const GLboolean lightingWasEnabled = glIsEnabled(GL_LIGHTING);
-      const GLboolean lineSmoothWasEnabled = glIsEnabled(GL_LINE_SMOOTH);
       if (lightingWasEnabled)
         glDisable(GL_LIGHTING);
-      glEnable(GL_POLYGON_OFFSET_LINE);
-      glPolygonOffset(-1.0f, -1.0f);
-      ApplyWhiteModelEdgePassStyle(m_controller, highlight, selected,
-                                   edgeLineWidth,
-                                   edgeProfile.enableLineSmoothing);
+      glLineWidth(lineWidth);
+      m_controller.SetGLColor(0.0f, 0.0f, 0.0f);
       DrawMeshWireframe(mesh, scale, captureTransform);
-      glDisable(GL_POLYGON_OFFSET_LINE);
-      RestoreWhiteModelEdgePassStyle(lineSmoothWasEnabled);
+      glLineWidth(1.0f);
       if (lightingWasEnabled)
+        glEnable(GL_LIGHTING);
+
+      glEnable(GL_POLYGON_OFFSET_FILL);
+      glPolygonOffset(-1.0f, -1.0f);
+      m_controller.SetGLColor(r, g, b);
+      if (unlit)
+        glDisable(GL_LIGHTING);
+      DrawMesh(mesh, scale, modelMatrix);
+      if (unlit)
+        glEnable(GL_LIGHTING);
+      glDisable(GL_POLYGON_OFFSET_FILL);
+    } else {
+      if (highlight)
+        m_controller.SetGLColor(0.0f, 1.0f, 0.0f);
+      else if (selected)
+        m_controller.SetGLColor(0.0f, 1.0f, 1.0f);
+      else
+        m_controller.SetGLColor(r, g, b);
+
+      if (unlit)
+        glDisable(GL_LIGHTING);
+      DrawMesh(mesh, scale, modelMatrix);
+      if (unlit)
         glEnable(GL_LIGHTING);
     }
   }

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -200,7 +200,10 @@ void SceneRenderer::DrawMeshWithOutline(
     if (m_controller.IsWhiteModelStyleEnabled()) {
       // Keep 3D white-model aligned with the 2D viewer draw order:
       // stroke pass first, then polygon-offset fill pass.
-      const float lineWidth = 2.6f;
+      const LineRenderProfile lineProfile =
+          GetLineRenderProfile(false, mode == Viewer2DRenderMode::Wireframe,
+                               m_controller.UseAdaptiveLineProfile());
+      const float lineWidth = lineProfile.lineWidth + 0.8f;
       auto setHighlightOrSelectionColor = [&]() {
         if (highlight)
           m_controller.SetGLColor(0.0f, 1.0f, 1.0f);
@@ -213,7 +216,12 @@ void SceneRenderer::DrawMeshWithOutline(
       const GLboolean lineSmoothWasEnabled = glIsEnabled(GL_LINE_SMOOTH);
       if (lightingWasEnabled)
         glDisable(GL_LIGHTING);
-      glDisable(GL_LINE_SMOOTH);
+      if (lineProfile.enableLineSmoothing) {
+        glEnable(GL_LINE_SMOOTH);
+        glHint(GL_LINE_SMOOTH_HINT, GL_NICEST);
+      } else {
+        glDisable(GL_LINE_SMOOTH);
+      }
       glLineWidth(lineWidth);
       setHighlightOrSelectionColor();
       DrawMeshWireframe(mesh, scale, captureTransform);

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -200,18 +200,26 @@ void SceneRenderer::DrawMeshWithOutline(
     if (m_controller.IsWhiteModelStyleEnabled()) {
       // Keep 3D white-model aligned with the 2D viewer draw order:
       // stroke pass first, then polygon-offset fill pass.
-      const float lineWidth =
-          GetLineRenderProfile(m_controller.IsInteracting(),
-                               mode == Viewer2DRenderMode::Wireframe,
-                               m_controller.UseAdaptiveLineProfile())
-              .lineWidth;
+      const float lineWidth = 2.6f;
+      auto setHighlightOrSelectionColor = [&]() {
+        if (highlight)
+          m_controller.SetGLColor(0.0f, 1.0f, 1.0f);
+        else if (selected)
+          m_controller.SetGLColor(0.15f, 0.35f, 1.0f);
+        else
+          m_controller.SetGLColor(0.0f, 0.0f, 0.0f);
+      };
       const GLboolean lightingWasEnabled = glIsEnabled(GL_LIGHTING);
+      const GLboolean lineSmoothWasEnabled = glIsEnabled(GL_LINE_SMOOTH);
       if (lightingWasEnabled)
         glDisable(GL_LIGHTING);
+      glDisable(GL_LINE_SMOOTH);
       glLineWidth(lineWidth);
-      m_controller.SetGLColor(0.0f, 0.0f, 0.0f);
+      setHighlightOrSelectionColor();
       DrawMeshWireframe(mesh, scale, captureTransform);
       glLineWidth(1.0f);
+      if (lineSmoothWasEnabled)
+        glEnable(GL_LINE_SMOOTH);
       if (lightingWasEnabled)
         glEnable(GL_LIGHTING);
 
@@ -220,7 +228,12 @@ void SceneRenderer::DrawMeshWithOutline(
       const GLboolean fillLightingWasEnabled = glIsEnabled(GL_LIGHTING);
       if (fillLightingWasEnabled)
         glDisable(GL_LIGHTING);
-      DrawMeshThreeToneInk(mesh, scale, modelMatrix);
+      if (highlight || selected) {
+        setHighlightOrSelectionColor();
+        DrawMesh(mesh, scale, modelMatrix);
+      } else {
+        DrawMeshThreeToneInk(mesh, scale, modelMatrix);
+      }
       if (fillLightingWasEnabled)
         glEnable(GL_LIGHTING);
       glDisable(GL_POLYGON_OFFSET_FILL);

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -17,6 +17,12 @@
 #include <cmath>
 
 namespace {
+struct InkColor {
+  float r = 1.0f;
+  float g = 1.0f;
+  float b = 1.0f;
+};
+
 struct LineRenderProfile {
   float lineWidth = 1.0f;
   bool enableLineSmoothing = false;
@@ -29,6 +35,89 @@ LineRenderProfile GetLineRenderProfile(bool isInteracting, bool wireframeMode,
   if (isInteracting)
     return {1.0f, false};
   return {wireframeMode ? 1.0f : 2.0f, true};
+}
+
+std::array<float, 3> NormalizeVector(float x, float y, float z) {
+  const float length = std::sqrt(x * x + y * y + z * z);
+  if (length <= 1e-6f)
+    return {0.0f, 0.0f, 1.0f};
+  return {x / length, y / length, z / length};
+}
+
+std::array<float, 3> TransformNormal(const std::array<float, 3> &n,
+                                     const float *modelMatrix) {
+  if (!modelMatrix)
+    return n;
+  const float x = modelMatrix[0] * n[0] + modelMatrix[4] * n[1] +
+                  modelMatrix[8] * n[2];
+  const float y = modelMatrix[1] * n[0] + modelMatrix[5] * n[1] +
+                  modelMatrix[9] * n[2];
+  const float z = modelMatrix[2] * n[0] + modelMatrix[6] * n[1] +
+                  modelMatrix[10] * n[2];
+  return NormalizeVector(x, y, z);
+}
+
+InkColor QuantizeInkTone(float diffuseFactor) {
+  // 3-ink white-model palette with lighting weight:
+  // white 70%, light gray 20%, dark gray 10%.
+  static constexpr float kDarkThreshold = 0.10f;
+  static constexpr float kLightThreshold = 0.30f;
+  if (diffuseFactor <= kDarkThreshold)
+    return {0.62f, 0.62f, 0.62f};
+  if (diffuseFactor <= kLightThreshold)
+    return {0.84f, 0.84f, 0.84f};
+  return {1.0f, 1.0f, 1.0f};
+}
+
+void DrawMeshThreeToneInk(const Mesh &mesh, float scale, const float *modelMatrix) {
+  std::array<float, 3> lightDir = NormalizeVector(0.35f, -0.55f, 1.0f);
+  const bool hasNormals = mesh.normals.size() >= mesh.vertices.size();
+  const bool flipWinding =
+      (modelMatrix != nullptr) && TransformDeterminant(modelMatrix) < 0.0f;
+
+  const std::vector<unsigned short> *triangleIndices = &mesh.indices;
+  if (flipWinding) {
+    if (mesh.flippedIndicesCache.size() != mesh.indices.size()) {
+      mesh.flippedIndicesCache = mesh.indices;
+      for (size_t i = 0; i + 2 < mesh.flippedIndicesCache.size(); i += 3)
+        std::swap(mesh.flippedIndicesCache[i + 1], mesh.flippedIndicesCache[i + 2]);
+    }
+    triangleIndices = &mesh.flippedIndicesCache;
+  }
+
+  const GLboolean cullWasEnabled = glIsEnabled(GL_CULL_FACE);
+  if (cullWasEnabled)
+    glDisable(GL_CULL_FACE);
+  glShadeModel(GL_SMOOTH);
+
+  glBegin(GL_TRIANGLES);
+  for (size_t i = 0; i + 2 < triangleIndices->size(); i += 3) {
+    const unsigned short tri[3] = {(*triangleIndices)[i], (*triangleIndices)[i + 1],
+                                   (*triangleIndices)[i + 2]};
+    for (int v = 0; v < 3; ++v) {
+      const unsigned short idx = tri[v];
+      const float vx = mesh.vertices[idx * 3] * scale;
+      const float vy = mesh.vertices[idx * 3 + 1] * scale;
+      const float vz = mesh.vertices[idx * 3 + 2] * scale;
+
+      std::array<float, 3> n = {0.0f, 0.0f, 1.0f};
+      if (hasNormals) {
+        n = NormalizeVector(mesh.normals[idx * 3], mesh.normals[idx * 3 + 1],
+                            mesh.normals[idx * 3 + 2]);
+      }
+      n = TransformNormal(n, modelMatrix);
+      const float diffuse = std::max(
+          0.0f, n[0] * lightDir[0] + n[1] * lightDir[1] + n[2] * lightDir[2]);
+      const InkColor tone = QuantizeInkTone(diffuse);
+      glColor3f(tone.r, tone.g, tone.b);
+      glNormal3f(n[0], n[1], n[2]);
+      glVertex3f(vx, vy, vz);
+    }
+  }
+  glEnd();
+
+  if (cullWasEnabled)
+    glEnable(GL_CULL_FACE);
 }
 } // namespace
 
@@ -128,11 +217,11 @@ void SceneRenderer::DrawMeshWithOutline(
 
       glEnable(GL_POLYGON_OFFSET_FILL);
       glPolygonOffset(-1.0f, -1.0f);
-      m_controller.SetGLColor(r, g, b);
-      if (unlit)
+      const GLboolean fillLightingWasEnabled = glIsEnabled(GL_LIGHTING);
+      if (fillLightingWasEnabled)
         glDisable(GL_LIGHTING);
-      DrawMesh(mesh, scale, modelMatrix);
-      if (unlit)
+      DrawMeshThreeToneInk(mesh, scale, modelMatrix);
+      if (fillLightingWasEnabled)
         glEnable(GL_LIGHTING);
       glDisable(GL_POLYGON_OFFSET_FILL);
     } else {

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -14,9 +14,32 @@
 #include <GL/gl.h>
 #endif
 
+#include <algorithm>
 #include <cmath>
+#include <unordered_map>
 
 namespace {
+struct EdgeKey {
+  unsigned short a = 0;
+  unsigned short b = 0;
+
+  bool operator==(const EdgeKey &other) const {
+    return a == other.a && b == other.b;
+  }
+};
+
+struct EdgeKeyHash {
+  size_t operator()(const EdgeKey &key) const {
+    return (static_cast<size_t>(key.a) << 16u) ^ static_cast<size_t>(key.b);
+  }
+};
+
+struct EdgeInfo {
+  int count = 0;
+  std::array<float, 3> firstFaceNormal = {0.0f, 0.0f, 0.0f};
+  std::array<float, 3> secondFaceNormal = {0.0f, 0.0f, 0.0f};
+};
+
 struct InkColor {
   float r = 1.0f;
   float g = 1.0f;
@@ -42,6 +65,82 @@ std::array<float, 3> NormalizeVector(float x, float y, float z) {
   if (length <= 1e-6f)
     return {0.0f, 0.0f, 1.0f};
   return {x / length, y / length, z / length};
+}
+
+std::array<float, 3> BuildFaceNormal(const std::vector<float> &vertices,
+                                     unsigned short i0, unsigned short i1,
+                                     unsigned short i2) {
+  const size_t p0 = static_cast<size_t>(i0) * 3u;
+  const size_t p1 = static_cast<size_t>(i1) * 3u;
+  const size_t p2 = static_cast<size_t>(i2) * 3u;
+  if (p0 + 2 >= vertices.size() || p1 + 2 >= vertices.size() ||
+      p2 + 2 >= vertices.size())
+    return {0.0f, 0.0f, 0.0f};
+
+  const float ax = vertices[p1] - vertices[p0];
+  const float ay = vertices[p1 + 1] - vertices[p0 + 1];
+  const float az = vertices[p1 + 2] - vertices[p0 + 2];
+  const float bx = vertices[p2] - vertices[p0];
+  const float by = vertices[p2 + 1] - vertices[p0 + 1];
+  const float bz = vertices[p2 + 2] - vertices[p0 + 2];
+
+  return NormalizeVector(ay * bz - az * by, az * bx - ax * bz,
+                         ax * by - ay * bx);
+}
+
+std::vector<unsigned short>
+BuildCreasedWireframeIndices(const std::vector<float> &vertices,
+                             const std::vector<unsigned short> &triangleIndices) {
+  static constexpr float kCreaseAngleDeg = 5.0f;
+  static constexpr float kPi = 3.14159265358979323846f;
+  const float creaseDotThreshold = std::cos(kCreaseAngleDeg * kPi / 180.0f);
+
+  std::unordered_map<EdgeKey, EdgeInfo, EdgeKeyHash> edges;
+  edges.reserve(triangleIndices.size());
+
+  auto registerEdge = [&](unsigned short i, unsigned short j,
+                          const std::array<float, 3> &faceNormal) {
+    const EdgeKey key = {std::min(i, j), std::max(i, j)};
+    EdgeInfo &info = edges[key];
+    ++info.count;
+    if (info.count == 1)
+      info.firstFaceNormal = faceNormal;
+    else if (info.count == 2)
+      info.secondFaceNormal = faceNormal;
+  };
+
+  for (size_t i = 0; i + 2 < triangleIndices.size(); i += 3) {
+    const unsigned short i0 = triangleIndices[i];
+    const unsigned short i1 = triangleIndices[i + 1];
+    const unsigned short i2 = triangleIndices[i + 2];
+    const std::array<float, 3> faceNormal =
+        BuildFaceNormal(vertices, i0, i1, i2);
+
+    registerEdge(i0, i1, faceNormal);
+    registerEdge(i1, i2, faceNormal);
+    registerEdge(i2, i0, faceNormal);
+  }
+
+  std::vector<unsigned short> lineIndices;
+  lineIndices.reserve(edges.size() * 2u);
+  for (const auto &[edge, info] : edges) {
+    if (info.count == 1) {
+      lineIndices.push_back(edge.a);
+      lineIndices.push_back(edge.b);
+      continue;
+    }
+    if (info.count == 2) {
+      const float dot = info.firstFaceNormal[0] * info.secondFaceNormal[0] +
+                        info.firstFaceNormal[1] * info.secondFaceNormal[1] +
+                        info.firstFaceNormal[2] * info.secondFaceNormal[2];
+      if (dot < creaseDotThreshold) {
+        lineIndices.push_back(edge.a);
+        lineIndices.push_back(edge.b);
+      }
+    }
+  }
+
+  return lineIndices;
 }
 
 std::array<float, 3> TransformNormal(const std::array<float, 3> &n,
@@ -320,26 +419,18 @@ void SceneRenderer::DrawMeshWireframe(
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     glPopMatrix();
   } else if (!m_controller.IsCaptureOnly()) {
+    const std::vector<unsigned short> lineIndices =
+        BuildCreasedWireframeIndices(mesh.vertices, mesh.indices);
     glBegin(GL_LINES);
-    for (size_t i = 0; i + 2 < mesh.indices.size(); i += 3) {
-      const unsigned short i0 = mesh.indices[i];
-      const unsigned short i1 = mesh.indices[i + 1];
-      const unsigned short i2 = mesh.indices[i + 2];
-
-      glVertex3f(mesh.vertices[i0 * 3] * scale, mesh.vertices[i0 * 3 + 1] * scale,
+    for (size_t i = 0; i + 1 < lineIndices.size(); i += 2) {
+      const unsigned short i0 = lineIndices[i];
+      const unsigned short i1 = lineIndices[i + 1];
+      glVertex3f(mesh.vertices[i0 * 3] * scale,
+                 mesh.vertices[i0 * 3 + 1] * scale,
                  mesh.vertices[i0 * 3 + 2] * scale);
-      glVertex3f(mesh.vertices[i1 * 3] * scale, mesh.vertices[i1 * 3 + 1] * scale,
+      glVertex3f(mesh.vertices[i1 * 3] * scale,
+                 mesh.vertices[i1 * 3 + 1] * scale,
                  mesh.vertices[i1 * 3 + 2] * scale);
-
-      glVertex3f(mesh.vertices[i1 * 3] * scale, mesh.vertices[i1 * 3 + 1] * scale,
-                 mesh.vertices[i1 * 3 + 2] * scale);
-      glVertex3f(mesh.vertices[i2 * 3] * scale, mesh.vertices[i2 * 3 + 1] * scale,
-                 mesh.vertices[i2 * 3 + 2] * scale);
-
-      glVertex3f(mesh.vertices[i2 * 3] * scale, mesh.vertices[i2 * 3 + 1] * scale,
-                 mesh.vertices[i2 * 3 + 2] * scale);
-      glVertex3f(mesh.vertices[i0 * 3] * scale, mesh.vertices[i0 * 3 + 1] * scale,
-                 mesh.vertices[i0 * 3 + 2] * scale);
     }
     glEnd();
   }

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -206,9 +206,9 @@ void SceneRenderer::DrawMeshWithOutline(
       const float lineWidth = lineProfile.lineWidth + 0.8f;
       auto setHighlightOrSelectionColor = [&]() {
         if (highlight)
-          m_controller.SetGLColor(0.0f, 1.0f, 1.0f);
+          m_controller.SetGLColor(0.0f, 1.0f, 0.0f);
         else if (selected)
-          m_controller.SetGLColor(0.15f, 0.35f, 1.0f);
+          m_controller.SetGLColor(0.0f, 1.0f, 1.0f);
         else
           m_controller.SetGLColor(0.0f, 0.0f, 0.0f);
       };
@@ -222,9 +222,12 @@ void SceneRenderer::DrawMeshWithOutline(
       } else {
         glDisable(GL_LINE_SMOOTH);
       }
+      glEnable(GL_POLYGON_OFFSET_LINE);
+      glPolygonOffset(1.0f, 1.0f);
       glLineWidth(lineWidth);
       setHighlightOrSelectionColor();
       DrawMeshWireframe(mesh, scale, captureTransform);
+      glDisable(GL_POLYGON_OFFSET_LINE);
       glLineWidth(1.0f);
       if (lineSmoothWasEnabled)
         glEnable(GL_LINE_SMOOTH);
@@ -233,17 +236,19 @@ void SceneRenderer::DrawMeshWithOutline(
 
       glEnable(GL_POLYGON_OFFSET_FILL);
       glPolygonOffset(-1.0f, -1.0f);
-      const GLboolean fillLightingWasEnabled = glIsEnabled(GL_LIGHTING);
-      if (fillLightingWasEnabled)
-        glDisable(GL_LIGHTING);
       if (highlight || selected) {
         setHighlightOrSelectionColor();
+        if (!glIsEnabled(GL_LIGHTING))
+          glEnable(GL_LIGHTING);
         DrawMesh(mesh, scale, modelMatrix);
       } else {
+        const GLboolean fillLightingWasEnabled = glIsEnabled(GL_LIGHTING);
+        if (fillLightingWasEnabled)
+          glDisable(GL_LIGHTING);
         DrawMeshThreeToneInk(mesh, scale, modelMatrix);
+        if (fillLightingWasEnabled)
+          glEnable(GL_LIGHTING);
       }
-      if (fillLightingWasEnabled)
-        glEnable(GL_LIGHTING);
       glDisable(GL_POLYGON_OFFSET_FILL);
     } else {
       if (highlight)


### PR DESCRIPTION
### Motivation
- Improve the visual finish of the 3D "white model" render style by applying a small multi-pass pipeline (fill + explicit edge pass) similar in intent to the 2D pipeline. 
- Reduce z-fighting and produce crisper edges for normal / highlighted / selected objects while respecting interaction/adaptive line profiling.

### Description
- Add `ApplyWhiteModelEdgePassStyle` and `RestoreWhiteModelEdgePassStyle` helpers to centralize edge color, line width and smoothing setup for the white-model edge pass. 
- Use the existing adaptive line profile via `GetLineRenderProfile` to compute an edge line width that adapts during interaction. 
- Emit the edge pass using `GL_POLYGON_OFFSET_LINE` and restore previous lighting/line-smoothing state to avoid z-fighting and preserve renderer invariants. 
- Limit the change to `viewer3d/render/scenerenderer.cpp` so orchestration/controller logic is not expanded.

### Testing
- `tests/check_perastage_tree_modules.sh` was executed and returned OK. 
- `tests/check_no_configmanager_get_in_gui.sh` was executed and returned OK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca7c191e648324ad6aabdf997069dd)