### PR TITLE
Add 'Textured (sunset)' 3D viewer style and rename 'Standard' preference

### DIFF
--- a/gui/preferencesdialog.cpp
+++ b/gui/preferencesdialog.cpp
@@ -19,6 +19,7 @@
 #include "configmanager.h"
 #include "guiconfigservices.h"
 #include "units/units.h"
+#include "viewer3d_render_style.h"
 #include <wx/checkbox.h>
 #include <wx/choice.h>
 #include <wx/notebook.h>
@@ -153,20 +154,23 @@ PreferencesDialog::PreferencesDialog(wxWindow *parent)
   viewer3dSizer->Add(new wxStaticText(viewer3dPanel, wxID_ANY, "Render mode:"),
                      0, wxLEFT | wxRIGHT | wxTOP, 10);
   viewer3dStandardRenderRadio = new wxRadioButton(
-      viewer3dPanel, wxID_ANY, "Standard (current)", wxDefaultPosition,
+      viewer3dPanel, wxID_ANY, "Standard", wxDefaultPosition,
       wxDefaultSize, wxRB_GROUP);
   viewer3dWhiteModelRenderRadio = new wxRadioButton(
       viewer3dPanel, wxID_ANY, "White Model style");
+  viewer3dTexturedRenderRadio = new wxRadioButton(
+      viewer3dPanel, wxID_ANY, "Textured (sunset)");
 
-  auto viewer3dRenderStyle = cfg.GetValue("viewer3d_render_style");
-  const bool useWhiteModelStyle =
-      viewer3dRenderStyle && *viewer3dRenderStyle == "white_model";
-  viewer3dStandardRenderRadio->SetValue(!useWhiteModelStyle);
-  viewer3dWhiteModelRenderRadio->SetValue(useWhiteModelStyle);
+  const Viewer3DRenderStyle renderStyle = ResolveViewer3DRenderStyle(cfg);
+  viewer3dStandardRenderRadio->SetValue(renderStyle == Viewer3DRenderStyle::Standard);
+  viewer3dWhiteModelRenderRadio->SetValue(renderStyle == Viewer3DRenderStyle::WhiteModel);
+  viewer3dTexturedRenderRadio->SetValue(renderStyle == Viewer3DRenderStyle::Textured);
 
   viewer3dSizer->Add(viewer3dStandardRenderRadio, 0,
                      wxLEFT | wxRIGHT | wxTOP, 10);
   viewer3dSizer->Add(viewer3dWhiteModelRenderRadio, 0,
+                     wxLEFT | wxRIGHT | wxTOP, 10);
+  viewer3dSizer->Add(viewer3dTexturedRenderRadio, 0,
                      wxLEFT | wxRIGHT | wxBOTTOM, 10);
   viewer3dPanel->SetSizer(viewer3dSizer);
   book->AddPage(viewer3dPanel, "3D Viewer");
@@ -216,11 +220,12 @@ bool PreferencesDialog::ApplyPreferences() {
                                                        : "metric");
   cfg.SetValue("ui_weight_unit_system",
                weightUnitChoice->GetSelection() == 1 ? "imperial" : "metric");
-  cfg.SetValue("viewer3d_render_style",
-               viewer3dWhiteModelRenderRadio &&
-                       viewer3dWhiteModelRenderRadio->GetValue()
-                   ? "white_model"
-                   : "standard");
+  Viewer3DRenderStyle renderStyle = Viewer3DRenderStyle::Standard;
+  if (viewer3dWhiteModelRenderRadio && viewer3dWhiteModelRenderRadio->GetValue())
+    renderStyle = Viewer3DRenderStyle::WhiteModel;
+  else if (viewer3dTexturedRenderRadio && viewer3dTexturedRenderRadio->GetValue())
+    renderStyle = Viewer3DRenderStyle::Textured;
+  cfg.SetValue("viewer3d_render_style", ToConfigValue(renderStyle));
   return cfg.SaveUserConfig();
 }
 

--- a/gui/preferencesdialog.cpp
+++ b/gui/preferencesdialog.cpp
@@ -159,7 +159,7 @@ PreferencesDialog::PreferencesDialog(wxWindow *parent)
   viewer3dWhiteModelRenderRadio = new wxRadioButton(
       viewer3dPanel, wxID_ANY, "White Model style");
   viewer3dTexturedRenderRadio = new wxRadioButton(
-      viewer3dPanel, wxID_ANY, "Textured (sunset)");
+      viewer3dPanel, wxID_ANY, "Textured");
 
   const Viewer3DRenderStyle renderStyle = ResolveViewer3DRenderStyle(cfg);
   viewer3dStandardRenderRadio->SetValue(renderStyle == Viewer3DRenderStyle::Standard);
@@ -171,7 +171,7 @@ PreferencesDialog::PreferencesDialog(wxWindow *parent)
   viewer3dSizer->Add(viewer3dWhiteModelRenderRadio, 0,
                      wxLEFT | wxRIGHT | wxTOP, 10);
   viewer3dSizer->Add(viewer3dTexturedRenderRadio, 0,
-                     wxLEFT | wxRIGHT | wxBOTTOM, 10);
+                     wxLEFT | wxRIGHT | wxTOP | wxBOTTOM, 10);
   viewer3dPanel->SetSizer(viewer3dSizer);
   book->AddPage(viewer3dPanel, "3D Viewer");
 

--- a/gui/preferencesdialog.h
+++ b/gui/preferencesdialog.h
@@ -43,6 +43,7 @@ private:
   wxRadioButton *layerTypeRadio = nullptr;
   wxRadioButton *viewer3dStandardRenderRadio = nullptr;
   wxRadioButton *viewer3dWhiteModelRenderRadio = nullptr;
+  wxRadioButton *viewer3dTexturedRenderRadio = nullptr;
   wxChoice *distanceUnitChoice = nullptr;
   wxChoice *weightUnitChoice = nullptr;
   wxString initialDistanceUnit;

--- a/viewer3d/CMakeLists.txt
+++ b/viewer3d/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/render/perastage_svg_symbol_builder.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/opaque_truss_pass.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/render_pipeline.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/render/viewer3d_render_style.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/scenerenderer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/resources/resource_sync_system.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/viewer3dcamera.cpp

--- a/viewer3d/loader3ds.cpp
+++ b/viewer3d/loader3ds.cpp
@@ -18,6 +18,8 @@
 #include "loader3ds.h"
 #include <fstream>
 #include <cstdint>
+#include <array>
+#include <unordered_map>
 #include "consolepanel.h"
 #include <wx/wx.h>
 
@@ -26,6 +28,13 @@ constexpr bool kLog3dsMessages = false;
 struct Chunk {
     uint16_t id;
     uint32_t length;
+};
+
+struct FaceColorAccum {
+    double r = 0.0;
+    double g = 0.0;
+    double b = 0.0;
+    double weight = 0.0;
 };
 
 static bool readChunk(std::ifstream& file, Chunk& c)
@@ -38,7 +47,52 @@ static bool readChunk(std::ifstream& file, Chunk& c)
 // Parses a single TRIANGULAR MESH (0x4100) chunk.
 // vertexBase is the current number of vertices already stored in the mesh
 // so we can offset face indices when concatenating multiple objects.
-static void parseMesh(std::ifstream& file, long endPos, Mesh& mesh, size_t vertexBase)
+static std::string readCString(std::ifstream& file, long endPos)
+{
+    std::string out;
+    char ch = 0;
+    while (file.tellg() < endPos && file.read(&ch, 1)) {
+        if (ch == '\0')
+            break;
+        out.push_back(ch);
+    }
+    return out;
+}
+
+static std::array<float, 3> readColorChunk(std::ifstream& file, long endPos, bool& ok)
+{
+    std::array<float, 3> c{1.0f, 1.0f, 1.0f};
+    ok = false;
+    while (file.tellg() < endPos) {
+        Chunk ch;
+        if (!readChunk(file, ch))
+            return c;
+        const long dataStart = file.tellg();
+        const long next = dataStart + ch.length - 6;
+        if (ch.id == 0x0010 || ch.id == 0x0013) { // float color
+            file.read(reinterpret_cast<char*>(&c[0]), sizeof(float));
+            file.read(reinterpret_cast<char*>(&c[1]), sizeof(float));
+            file.read(reinterpret_cast<char*>(&c[2]), sizeof(float));
+            ok = true;
+            file.seekg(next);
+            return c;
+        }
+        if (ch.id == 0x0011 || ch.id == 0x0012) { // byte color
+            unsigned char rgb[3] = {255, 255, 255};
+            file.read(reinterpret_cast<char*>(rgb), 3);
+            c = {rgb[0] / 255.0f, rgb[1] / 255.0f, rgb[2] / 255.0f};
+            ok = true;
+            file.seekg(next);
+            return c;
+        }
+        file.seekg(next);
+    }
+    return c;
+}
+
+static void parseMesh(std::ifstream& file, long endPos, Mesh& mesh, size_t vertexBase,
+                      const std::unordered_map<std::string, std::array<float, 3>>& materials,
+                      FaceColorAccum& colorAccum)
 {
     while(file.tellg() < endPos) {
         Chunk ch; if(!readChunk(file, ch)) return;
@@ -74,6 +128,27 @@ static void parseMesh(std::ifstream& file, long endPos, Mesh& mesh, size_t verte
                     mesh.indices[start + i * 3 + 1] = static_cast<unsigned short>(b + vertexBase);
                     mesh.indices[start + i * 3 + 2] = static_cast<unsigned short>(c + vertexBase);
                 }
+                while (file.tellg() < next) {
+                    Chunk sub;
+                    if (!readChunk(file, sub))
+                        break;
+                    const long subDataStart = file.tellg();
+                    const long subNext = subDataStart + sub.length - 6;
+                    if (sub.id == 0x4130) { // face material group
+                        std::string materialName = readCString(file, subNext);
+                        uint16_t faceCount = 0;
+                        file.read(reinterpret_cast<char*>(&faceCount), 2);
+                        const auto mit = materials.find(materialName);
+                        if (mit != materials.end()) {
+                            const auto& c = mit->second;
+                            colorAccum.r += static_cast<double>(c[0]) * faceCount;
+                            colorAccum.g += static_cast<double>(c[1]) * faceCount;
+                            colorAccum.b += static_cast<double>(c[2]) * faceCount;
+                            colorAccum.weight += faceCount;
+                        }
+                    }
+                    file.seekg(subNext);
+                }
                 break;
             }
             default:
@@ -91,6 +166,9 @@ bool Load3DS(const std::string& path, Mesh& outMesh)
     Chunk root; if(!readChunk(file, root)) return false;
     if(root.id != 0x4D4D) return false;
     long rootEnd = root.length;
+
+    std::unordered_map<std::string, std::array<float, 3>> materials;
+    FaceColorAccum colorAccum;
 
     while(file.tellg() < rootEnd) {
         Chunk c; if(!readChunk(file,c)) break;
@@ -111,11 +189,30 @@ bool Load3DS(const std::string& path, Mesh& outMesh)
                         long me = md + mc.length - 6;
                         if(mc.id == 0x4100) {
                             size_t base = outMesh.vertices.size() / 3;
-                            parseMesh(file, me, outMesh, base);
+                            parseMesh(file, me, outMesh, base, materials, colorAccum);
                         } else {
                             file.seekg(me);
                         }
                     }
+                } else if (sub.id == 0xAFFF) { // material block
+                    std::string materialName;
+                    std::array<float, 3> materialColor{1.0f, 1.0f, 1.0f};
+                    while (file.tellg() < se) {
+                        Chunk mc;
+                        if (!readChunk(file, mc))
+                            break;
+                        const long md = file.tellg();
+                        const long me = md + mc.length - 6;
+                        if (mc.id == 0xA000) {
+                            materialName = readCString(file, me);
+                        } else if (mc.id == 0xA020) {
+                            bool colorOk = false;
+                            materialColor = readColorChunk(file, me, colorOk);
+                        }
+                        file.seekg(me);
+                    }
+                    if (!materialName.empty())
+                        materials[materialName] = materialColor;
                 } else {
                     file.seekg(se);
                 }
@@ -126,6 +223,13 @@ bool Load3DS(const std::string& path, Mesh& outMesh)
     }
 
     bool ok = !outMesh.vertices.empty() && !outMesh.indices.empty();
+    if (ok && colorAccum.weight > 0.0) {
+        outMesh.materialBaseColor = {
+            static_cast<float>(colorAccum.r / colorAccum.weight),
+            static_cast<float>(colorAccum.g / colorAccum.weight),
+            static_cast<float>(colorAccum.b / colorAccum.weight)};
+        outMesh.hasMaterialBaseColor = true;
+    }
     if (ok)
         ComputeNormals(outMesh);
     if (kLog3dsMessages && ConsolePanel::Instance()) {

--- a/viewer3d/loaderglb.cpp
+++ b/viewer3d/loaderglb.cpp
@@ -431,7 +431,7 @@ bool LoadGLB(const std::string& path, Mesh& outMesh)
 
     auto applyPrimitiveBaseColorTexture = [&](const json& prim) {
         if (!prim.contains("material") || !doc.contains("materials") ||
-            !doc["materials"].is_array() || outMesh.textureWidth > 0)
+            !doc["materials"].is_array())
             return;
         int materialIndex = -1;
         if (!readInt(prim["material"], materialIndex) || materialIndex < 0 ||
@@ -441,7 +441,22 @@ bool LoadGLB(const std::string& path, Mesh& outMesh)
         if (!material.contains("pbrMetallicRoughness"))
             return;
         const auto& pbr = material["pbrMetallicRoughness"];
+        if (!outMesh.hasMaterialBaseColor && pbr.contains("baseColorFactor") &&
+            pbr["baseColorFactor"].is_array() && pbr["baseColorFactor"].size() >= 3) {
+            float r = 1.0f, g = 1.0f, b = 1.0f;
+            if (readFloat(pbr["baseColorFactor"][0], r) &&
+                readFloat(pbr["baseColorFactor"][1], g) &&
+                readFloat(pbr["baseColorFactor"][2], b)) {
+                outMesh.materialBaseColor = {
+                    std::clamp(r, 0.0f, 1.0f),
+                    std::clamp(g, 0.0f, 1.0f),
+                    std::clamp(b, 0.0f, 1.0f)};
+                outMesh.hasMaterialBaseColor = true;
+            }
+        }
         if (!pbr.contains("baseColorTexture"))
+            return;
+        if (outMesh.textureWidth > 0)
             return;
         int textureIndex = -1;
         if (!pbr["baseColorTexture"].contains("index") ||
@@ -463,6 +478,27 @@ bool LoadGLB(const std::string& path, Mesh& outMesh)
             outMesh.textureWidth = width;
             outMesh.textureHeight = height;
         }
+    };
+
+    auto resolvePrimitiveBaseColorTexCoordSet = [&](const json& prim) -> int {
+        if (!prim.contains("material") || !doc.contains("materials") ||
+            !doc["materials"].is_array())
+            return 0;
+        int materialIndex = -1;
+        if (!readInt(prim["material"], materialIndex) || materialIndex < 0 ||
+            materialIndex >= static_cast<int>(doc["materials"].size()))
+            return 0;
+        const auto& material = doc["materials"][materialIndex];
+        if (!material.contains("pbrMetallicRoughness"))
+            return 0;
+        const auto& pbr = material["pbrMetallicRoughness"];
+        if (!pbr.contains("baseColorTexture"))
+            return 0;
+        const auto& bct = pbr["baseColorTexture"];
+        int texCoordSet = 0;
+        if (bct.contains("texCoord"))
+            readInt(bct["texCoord"], texCoordSet);
+        return std::max(0, texCoordSet);
     };
 
     auto readPrimitive = [&](const json& prim, const Matrix& transform) -> bool {
@@ -514,7 +550,11 @@ bool LoadGLB(const std::string& path, Mesh& outMesh)
             outMesh.vertices[(base+i)*3 + 2] = p[2];
         }
 
-        auto uvIt = attributes->find("TEXCOORD_0");
+        const int texCoordSet = resolvePrimitiveBaseColorTexCoordSet(prim);
+        const std::string uvAttributeName = "TEXCOORD_" + std::to_string(texCoordSet);
+        auto uvIt = attributes->find(uvAttributeName);
+        if (uvIt == attributes->end() && texCoordSet != 0)
+            uvIt = attributes->find("TEXCOORD_0");
         if (uvIt != attributes->end()) {
             int uvAccessor = -1;
             if (readInt(*uvIt, uvAccessor)) {

--- a/viewer3d/loaderglb.cpp
+++ b/viewer3d/loaderglb.cpp
@@ -26,6 +26,7 @@
 #include <wx/wx.h>
 #include <wx/image.h>
 #include <wx/mstream.h>
+#include <wx/base64.h>
 #include <optional>
 #include <filesystem>
 
@@ -350,11 +351,28 @@ bool LoadGLB(const std::string& path, Mesh& outMesh)
 
     auto decodeTextureImage = [&](int imageIndex, std::vector<unsigned char>& rgba,
                                   int& width, int& height) -> bool {
+        static bool imageHandlersInitialized = false;
+        if (!imageHandlersInitialized) {
+            wxInitAllImageHandlers();
+            imageHandlersInitialized = true;
+        }
         if (!doc.contains("images") || !doc["images"].is_array() ||
             imageIndex < 0 || imageIndex >= static_cast<int>(doc["images"].size())) {
             return false;
         }
         const auto& image = doc["images"][imageIndex];
+        const auto resolveBitmapType = [&](const json& imageNode) {
+            if (!imageNode.contains("mimeType") || !imageNode["mimeType"].is_string())
+                return wxBITMAP_TYPE_ANY;
+            const std::string mime = imageNode["mimeType"].get<std::string>();
+            if (mime == "image/png")
+                return wxBITMAP_TYPE_PNG;
+            if (mime == "image/jpeg" || mime == "image/jpg")
+                return wxBITMAP_TYPE_JPEG;
+            if (mime == "image/bmp")
+                return wxBITMAP_TYPE_BMP;
+            return wxBITMAP_TYPE_ANY;
+        };
         wxImage wxImg;
         if (image.contains("bufferView")) {
             int bufferView = -1;
@@ -369,12 +387,26 @@ bool LoadGLB(const std::string& path, Mesh& outMesh)
             if (byteLength == 0 || byteOffset + byteLength > binData.size())
                 return false;
             wxMemoryInputStream stream(binData.data() + byteOffset, byteLength);
-            if (!wxImg.LoadFile(stream, wxBITMAP_TYPE_ANY))
+            if (!wxImg.LoadFile(stream, resolveBitmapType(image)))
                 return false;
         } else if (image.contains("uri") && image["uri"].is_string()) {
-            const fs::path uriPath = glbDir / fs::u8path(image["uri"].get<std::string>());
-            if (!wxImg.LoadFile(wxString::FromUTF8(uriPath.string())))
-                return false;
+            const std::string uri = image["uri"].get<std::string>();
+            if (uri.rfind("data:", 0) == 0) {
+                const auto commaPos = uri.find(',');
+                if (commaPos == std::string::npos)
+                    return false;
+                const std::string encoded = uri.substr(commaPos + 1);
+                const wxMemoryBuffer decoded = wxBase64Decode(encoded);
+                if (decoded.IsEmpty())
+                    return false;
+                wxMemoryInputStream stream(decoded.GetData(), decoded.GetDataLen());
+                if (!wxImg.LoadFile(stream, resolveBitmapType(image)))
+                    return false;
+            } else {
+                const fs::path uriPath = glbDir / fs::u8path(uri);
+                if (!wxImg.LoadFile(wxString::FromUTF8(uriPath.string())))
+                    return false;
+            }
         } else {
             return false;
         }

--- a/viewer3d/loaderglb.cpp
+++ b/viewer3d/loaderglb.cpp
@@ -24,7 +24,10 @@
 #include <algorithm>
 #include <functional>
 #include <wx/wx.h>
+#include <wx/image.h>
+#include <wx/mstream.h>
 #include <optional>
+#include <filesystem>
 
 constexpr bool kLogGlbMessages = false;
 
@@ -34,6 +37,7 @@ using json = nlohmann::json;
 // millimeters. Apply a constant scale so that loaded meshes match the
 // coordinate system used for 3DS files and the rest of the viewer.
 static constexpr float GLB_TO_MVR_SCALE = 1000.0f;
+namespace fs = std::filesystem;
 
 static size_t ComponentSize(int compType)
 {
@@ -341,6 +345,94 @@ bool LoadGLB(const std::string& path, Mesh& outMesh)
         return m;
     };
 
+    const fs::path glbPath(path);
+    const fs::path glbDir = glbPath.has_parent_path() ? glbPath.parent_path() : fs::path();
+
+    auto decodeTextureImage = [&](int imageIndex, std::vector<unsigned char>& rgba,
+                                  int& width, int& height) -> bool {
+        if (!doc.contains("images") || !doc["images"].is_array() ||
+            imageIndex < 0 || imageIndex >= static_cast<int>(doc["images"].size())) {
+            return false;
+        }
+        const auto& image = doc["images"][imageIndex];
+        wxImage wxImg;
+        if (image.contains("bufferView")) {
+            int bufferView = -1;
+            if (!readInt(image["bufferView"], bufferView) ||
+                bufferView < 0 || !doc.contains("bufferViews") ||
+                !doc["bufferViews"].is_array() ||
+                bufferView >= static_cast<int>(doc["bufferViews"].size()))
+                return false;
+            const auto& bv = doc["bufferViews"][bufferView];
+            size_t byteOffset = bv.value("byteOffset", 0u);
+            size_t byteLength = bv.value("byteLength", 0u);
+            if (byteLength == 0 || byteOffset + byteLength > binData.size())
+                return false;
+            wxMemoryInputStream stream(binData.data() + byteOffset, byteLength);
+            if (!wxImg.LoadFile(stream, wxBITMAP_TYPE_ANY))
+                return false;
+        } else if (image.contains("uri") && image["uri"].is_string()) {
+            const fs::path uriPath = glbDir / fs::u8path(image["uri"].get<std::string>());
+            if (!wxImg.LoadFile(wxString::FromUTF8(uriPath.string())))
+                return false;
+        } else {
+            return false;
+        }
+
+        if (!wxImg.IsOk())
+            return false;
+        width = static_cast<int>(wxImg.GetWidth());
+        height = static_cast<int>(wxImg.GetHeight());
+        const unsigned char* rgb = wxImg.GetData();
+        if (!rgb || width <= 0 || height <= 0)
+            return false;
+        const unsigned char* alpha = wxImg.HasAlpha() ? wxImg.GetAlpha() : nullptr;
+        rgba.resize(static_cast<size_t>(width) * static_cast<size_t>(height) * 4u);
+        for (int i = 0; i < width * height; ++i) {
+            rgba[static_cast<size_t>(i) * 4u + 0u] = rgb[i * 3 + 0];
+            rgba[static_cast<size_t>(i) * 4u + 1u] = rgb[i * 3 + 1];
+            rgba[static_cast<size_t>(i) * 4u + 2u] = rgb[i * 3 + 2];
+            rgba[static_cast<size_t>(i) * 4u + 3u] = alpha ? alpha[i] : 255u;
+        }
+        return true;
+    };
+
+    auto applyPrimitiveBaseColorTexture = [&](const json& prim) {
+        if (!prim.contains("material") || !doc.contains("materials") ||
+            !doc["materials"].is_array() || outMesh.textureWidth > 0)
+            return;
+        int materialIndex = -1;
+        if (!readInt(prim["material"], materialIndex) || materialIndex < 0 ||
+            materialIndex >= static_cast<int>(doc["materials"].size()))
+            return;
+        const auto& material = doc["materials"][materialIndex];
+        if (!material.contains("pbrMetallicRoughness"))
+            return;
+        const auto& pbr = material["pbrMetallicRoughness"];
+        if (!pbr.contains("baseColorTexture"))
+            return;
+        int textureIndex = -1;
+        if (!pbr["baseColorTexture"].contains("index") ||
+            !readInt(pbr["baseColorTexture"]["index"], textureIndex) ||
+            textureIndex < 0 || !doc.contains("textures") ||
+            !doc["textures"].is_array() ||
+            textureIndex >= static_cast<int>(doc["textures"].size()))
+            return;
+        const auto& texture = doc["textures"][textureIndex];
+        int imageIndex = -1;
+        if (!texture.contains("source") || !readInt(texture["source"], imageIndex))
+            return;
+
+        std::vector<unsigned char> rgba;
+        int width = 0;
+        int height = 0;
+        if (decodeTextureImage(imageIndex, rgba, width, height)) {
+            outMesh.textureRgba = std::move(rgba);
+            outMesh.textureWidth = width;
+            outMesh.textureHeight = height;
+        }
+    };
+
     auto readPrimitive = [&](const json& prim, const Matrix& transform) -> bool {
         if(!prim.contains("attributes") || !prim.contains("indices"))
             return false;
@@ -378,6 +470,9 @@ bool LoadGLB(const std::string& path, Mesh& outMesh)
 
         size_t base = outMesh.vertices.size() / 3;
         outMesh.vertices.resize(base*3 + posCount*3);
+        if (outMesh.texcoords.size() < base * 2u)
+            outMesh.texcoords.resize(base * 2u, 0.0f);
+        outMesh.texcoords.resize((base + posCount) * 2u, 0.0f);
         for(size_t i=0;i<posCount;i++) {
             const float* src = reinterpret_cast<const float*>(binData.data()+posOff+posStride*i);
             std::array<float,3> p{src[0], src[1], src[2]};
@@ -385,6 +480,27 @@ bool LoadGLB(const std::string& path, Mesh& outMesh)
             outMesh.vertices[(base+i)*3 + 0] = p[0];
             outMesh.vertices[(base+i)*3 + 1] = p[1];
             outMesh.vertices[(base+i)*3 + 2] = p[2];
+        }
+
+        auto uvIt = attributes->find("TEXCOORD_0");
+        if (uvIt != attributes->end()) {
+            int uvAccessor = -1;
+            if (readInt(*uvIt, uvAccessor)) {
+                size_t uvOff = 0, uvStride = 0, uvCount = 0;
+                int uvCT = 0;
+                std::string uvType;
+                if (getAccessorInfo(uvAccessor, uvOff, uvStride, uvCT, uvType, uvCount) &&
+                    uvCT == 5126 && uvType == "VEC2" &&
+                    uvOff + uvStride * std::min(uvCount, posCount) <= binData.size()) {
+                    const size_t copyCount = std::min(uvCount, posCount);
+                    for (size_t i = 0; i < copyCount; ++i) {
+                        const float* uv =
+                            reinterpret_cast<const float*>(binData.data() + uvOff + uvStride * i);
+                        outMesh.texcoords[(base + i) * 2u + 0u] = uv[0];
+                        outMesh.texcoords[(base + i) * 2u + 1u] = uv[1];
+                    }
+                }
+            }
         }
 
         outMesh.indices.resize(outMesh.indices.size() + idxCount);
@@ -401,6 +517,7 @@ bool LoadGLB(const std::string& path, Mesh& outMesh)
             }
             outMesh.indices[outMesh.indices.size()-idxCount+i] = static_cast<unsigned short>(v + base);
         }
+        applyPrimitiveBaseColorTexture(prim);
         return true;
     };
 

--- a/viewer3d/mesh.h
+++ b/viewer3d/mesh.h
@@ -30,6 +30,8 @@ struct Mesh {
     std::vector<unsigned char> textureRgba; // optional texture pixels RGBA8
     int textureWidth = 0;
     int textureHeight = 0;
+    std::array<float, 3> materialBaseColor = {1.0f, 1.0f, 1.0f};
+    bool hasMaterialBaseColor = false;
 
     // OpenGL resources for VBO/VAO based rendering.
     uint32_t vao = 0;

--- a/viewer3d/mesh.h
+++ b/viewer3d/mesh.h
@@ -26,13 +26,19 @@ struct Mesh {
     std::vector<float> vertices; // x,y,z order in mm
     std::vector<unsigned short> indices; // 3 indices per triangle
     std::vector<float> normals;  // optional per-vertex normals
+    std::vector<float> texcoords; // optional per-vertex UVs (u,v)
+    std::vector<unsigned char> textureRgba; // optional texture pixels RGBA8
+    int textureWidth = 0;
+    int textureHeight = 0;
 
     // OpenGL resources for VBO/VAO based rendering.
     uint32_t vao = 0;
     uint32_t vboVertices = 0;
     uint32_t vboNormals = 0;
+    uint32_t vboTexCoords = 0;
     uint32_t eboTriangles = 0;
     uint32_t eboLines = 0;
+    uint32_t textureId = 0;
     int triangleIndexCount = 0;
     int lineIndexCount = 0;
     bool buffersReady = false;

--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -435,7 +435,7 @@ void OpaqueFixturePass::Render(
       ConfigManager::Get().GetFloat("view2d_top_fixtures_inverted") != 0.0f;
   const bool drawRealTopInTopView = isTopView2D && !forceBottomViewForTopFixtures;
 
-  glShadeModel(GL_FLAT);
+  glShadeModel((context.texturedStyle && !wireframe) ? GL_SMOOTH : GL_FLAT);
   const bool forceFixturesOnTop = wireframe;
   GLboolean depthEnabled = GL_FALSE;
   if (forceFixturesOnTop) {

--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -33,6 +33,7 @@
 #include "scenedatamanager.h"
 #include "symbols/PerastageSvgSymbol.h"
 #include "viewer3dcontroller.h"
+#include "gdtfloader.h"
 
 namespace {
 namespace fs = std::filesystem;
@@ -108,6 +109,29 @@ std::string NormalizeModelKeyPath(const std::string &path) {
   fs::path normalized(path);
   normalized = normalized.lexically_normal();
   return NormalizePathSeparators(normalized.string());
+}
+
+bool TryParseHtmlHexColor(const std::string &hex, float &r, float &g, float &b) {
+  if (hex.size() != 7 || hex[0] != '#')
+    return false;
+  auto hexToNibble = [](char c) -> int {
+    if (c >= '0' && c <= '9')
+      return c - '0';
+    if (c >= 'a' && c <= 'f')
+      return 10 + (c - 'a');
+    if (c >= 'A' && c <= 'F')
+      return 10 + (c - 'A');
+    return -1;
+  };
+  auto byteAt = [&](size_t idx, float &out) -> bool {
+    const int hi = hexToNibble(hex[idx]);
+    const int lo = hexToNibble(hex[idx + 1]);
+    if (hi < 0 || lo < 0)
+      return false;
+    out = static_cast<float>((hi << 4) | lo) / 255.0f;
+    return true;
+  };
+  return byteAt(1, r) && byteAt(3, g) && byteAt(5, b);
 }
 
 std::string ResolveFixtureSymbolKeyPath(const Fixture &fixture,
@@ -489,11 +513,25 @@ void OpaqueFixturePass::Render(
       cz -= f.transform.o[2] * RENDER_SCALE;
     }
 
+    std::string gdtfPath;
+    auto gdtfPathIt = controller.m_resourceSyncState.resolvedGdtfSpecs.find(
+        ResolveCacheKey(f.gdtfSpec));
+    if (gdtfPathIt != controller.m_resourceSyncState.resolvedGdtfSpecs.end() &&
+        gdtfPathIt->second.attempted)
+      gdtfPath = gdtfPathIt->second.resolvedPath;
+
     float r = 1.0f, g = 1.0f, b = 1.0f;
     if (context.whiteModelStyle && !wireframe) {
       r = 0.95f;
       g = 0.95f;
       b = 0.95f;
+    } else if (context.texturedStyle && !wireframe) {
+      if (!f.color.empty()) {
+        TryParseHtmlHexColor(f.color, r, g, b);
+      } else if (!gdtfPath.empty()) {
+        const std::string gdtfModelColor = GetGdtfModelColor(gdtfPath);
+        TryParseHtmlHexColor(gdtfModelColor, r, g, b);
+      }
     }
     if (wireframe) {
       if (mode == Viewer2DRenderMode::ByFixtureType) {
@@ -523,12 +561,6 @@ void OpaqueFixturePass::Render(
       return TransformPoint(fixtureTransform, p);
     };
 
-    std::string gdtfPath;
-    auto gdtfPathIt = controller.m_resourceSyncState.resolvedGdtfSpecs.find(
-        ResolveCacheKey(f.gdtfSpec));
-    if (gdtfPathIt != controller.m_resourceSyncState.resolvedGdtfSpecs.end() &&
-        gdtfPathIt->second.attempted)
-      gdtfPath = gdtfPathIt->second.resolvedPath;
     const std::string sceneBasePath = ConfigManager::Get().GetScene().basePath;
     const std::string modelKey =
         BuildFixtureSymbolModelKey(f, sceneBasePath, gdtfPath);

--- a/viewer3d/render/opaque_object_pass.cpp
+++ b/viewer3d/render/opaque_object_pass.cpp
@@ -37,7 +37,7 @@ void OpaqueObjectPass::Render(
 
   const auto &sceneObjects = SceneDataManager::Instance().GetSceneObjects();
 
-  glShadeModel(GL_FLAT);
+  glShadeModel((context.texturedStyle && !wireframe) ? GL_SMOOTH : GL_FLAT);
   std::vector<std::string> drawObjectUuids = visibleSet.objectUuids;
   if (!controller.m_highlightUuid.empty()) {
     const bool highlightAlreadyVisible =

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -257,10 +257,17 @@ void SceneRenderer::DrawMeshWithOutline(
                               !highlight && !selected &&
                               mesh.textureId != 0 &&
                               mesh.texcoords.size() >= (mesh.vertices.size() / 3u) * 2u;
+      const bool useMaterialColor = IsTexturedRenderStyleEnabled() &&
+                                    !highlight && !selected &&
+                                    !useTexture && mesh.hasMaterialBaseColor;
       if (highlight)
         m_controller.SetGLColor(0.0f, 1.0f, 0.0f);
       else if (selected)
         m_controller.SetGLColor(0.0f, 1.0f, 1.0f);
+      else if (useMaterialColor)
+        m_controller.SetGLColor(mesh.materialBaseColor[0],
+                                mesh.materialBaseColor[1],
+                                mesh.materialBaseColor[2]);
       else
         m_controller.SetGLColor(useTexture ? 1.0f : r, useTexture ? 1.0f : g,
                                 useTexture ? 1.0f : b);

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -16,6 +16,8 @@
 
 #include <algorithm>
 #include <cmath>
+#include "configmanager.h"
+#include "viewer3d_render_style.h"
 
 namespace {
 struct InkColor {
@@ -120,6 +122,10 @@ void DrawMeshThreeToneInk(const Mesh &mesh, float scale, const float *modelMatri
     glEnable(GL_CULL_FACE);
 }
 } // namespace
+
+static bool IsTexturedRenderStyleEnabled() {
+  return IsTexturedRenderStyle(ResolveViewer3DRenderStyle(ConfigManager::Get()));
+}
 
 void SceneRenderer::DrawMeshWithOutline(
     const Mesh &mesh, float r, float g, float b, float scale, bool highlight,
@@ -247,16 +253,21 @@ void SceneRenderer::DrawMeshWithOutline(
       }
       glDisable(GL_POLYGON_OFFSET_FILL);
     } else {
+      const bool useTexture = IsTexturedRenderStyleEnabled() &&
+                              !highlight && !selected &&
+                              mesh.textureId != 0 &&
+                              mesh.texcoords.size() >= (mesh.vertices.size() / 3u) * 2u;
       if (highlight)
         m_controller.SetGLColor(0.0f, 1.0f, 0.0f);
       else if (selected)
         m_controller.SetGLColor(0.0f, 1.0f, 1.0f);
       else
-        m_controller.SetGLColor(r, g, b);
+        m_controller.SetGLColor(useTexture ? 1.0f : r, useTexture ? 1.0f : g,
+                                useTexture ? 1.0f : b);
 
       if (unlit)
         glDisable(GL_LIGHTING);
-      DrawMesh(mesh, scale, modelMatrix);
+      DrawMesh(mesh, scale, modelMatrix, useTexture);
       if (unlit)
         glEnable(GL_LIGHTING);
     }
@@ -369,7 +380,8 @@ void SceneRenderer::DrawMeshWireframe(
   }
 }
 
-void SceneRenderer::DrawMesh(const Mesh &mesh, float scale, const float *modelMatrix) {
+void SceneRenderer::DrawMesh(const Mesh &mesh, float scale, const float *modelMatrix,
+                             bool useTexture) {
   const GLboolean cullWasEnabled = glIsEnabled(GL_CULL_FACE);
   if (cullWasEnabled)
     glDisable(GL_CULL_FACE);
@@ -400,6 +412,10 @@ void SceneRenderer::DrawMesh(const Mesh &mesh, float scale, const float *modelMa
       !requiresCpuDrawPath;
 
   if (!m_controller.IsCaptureOnly() && canUseGpuTriangles) {
+    const bool textureEnabled =
+        useTexture && mesh.textureId != 0 &&
+        mesh.vboTexCoords != 0 &&
+        mesh.texcoords.size() >= (mesh.vertices.size() / 3u) * 2u;
     glBindVertexArray(mesh.vao);
     glPushMatrix();
     glScalef(scale, scale, scale);
@@ -412,15 +428,35 @@ void SceneRenderer::DrawMesh(const Mesh &mesh, float scale, const float *modelMa
     glEnableClientState(GL_NORMAL_ARRAY);
     glNormalPointer(GL_FLOAT, 0, nullptr);
 
+    if (textureEnabled) {
+      glEnable(GL_TEXTURE_2D);
+      glBindTexture(GL_TEXTURE_2D, mesh.textureId);
+      glBindBuffer(GL_ARRAY_BUFFER, mesh.vboTexCoords);
+      glEnableClientState(GL_TEXTURE_COORD_ARRAY);
+      glTexCoordPointer(2, GL_FLOAT, 0, nullptr);
+    }
+
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mesh.eboTriangles);
     glDrawElements(GL_TRIANGLES, mesh.triangleIndexCount, GL_UNSIGNED_SHORT,
                    nullptr);
 
+    if (textureEnabled) {
+      glDisableClientState(GL_TEXTURE_COORD_ARRAY);
+      glBindTexture(GL_TEXTURE_2D, 0);
+      glDisable(GL_TEXTURE_2D);
+    }
     glDisableClientState(GL_NORMAL_ARRAY);
     glDisableClientState(GL_VERTEX_ARRAY);
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     glPopMatrix();
   } else if (!m_controller.IsCaptureOnly()) {
+    const bool textureEnabled =
+        useTexture && mesh.textureId != 0 &&
+        mesh.texcoords.size() >= (mesh.vertices.size() / 3u) * 2u;
+    if (textureEnabled) {
+      glEnable(GL_TEXTURE_2D);
+      glBindTexture(GL_TEXTURE_2D, mesh.textureId);
+    }
     GLint shadeModel = GL_SMOOTH;
     glGetIntegerv(GL_SHADE_MODEL, &shadeModel);
     const bool useFaceNormals = (shadeModel == GL_FLAT);
@@ -476,12 +512,21 @@ void SceneRenderer::DrawMesh(const Mesh &mesh, float scale, const float *modelMa
       }
 
       if (hasNormals) {
+        if (textureEnabled) {
+          glTexCoord2f(mesh.texcoords[i0 * 2], mesh.texcoords[i0 * 2 + 1]);
+        }
         glNormal3f(normalData[i0 * 3], normalData[i0 * 3 + 1],
                    normalData[i0 * 3 + 2]);
         glVertex3f(v0x, v0y, v0z);
+        if (textureEnabled) {
+          glTexCoord2f(mesh.texcoords[i1 * 2], mesh.texcoords[i1 * 2 + 1]);
+        }
         glNormal3f(normalData[i1 * 3], normalData[i1 * 3 + 1],
                    normalData[i1 * 3 + 2]);
         glVertex3f(v1x, v1y, v1z);
+        if (textureEnabled) {
+          glTexCoord2f(mesh.texcoords[i2 * 2], mesh.texcoords[i2 * 2 + 1]);
+        }
         glNormal3f(normalData[i2 * 3], normalData[i2 * 3 + 1],
                    normalData[i2 * 3 + 2]);
         glVertex3f(v2x, v2y, v2z);
@@ -497,12 +542,25 @@ void SceneRenderer::DrawMesh(const Mesh &mesh, float scale, const float *modelMa
         }
 
         glNormal3f(nx, ny, nz);
+        if (textureEnabled) {
+          glTexCoord2f(mesh.texcoords[i0 * 2], mesh.texcoords[i0 * 2 + 1]);
+        }
         glVertex3f(v0x, v0y, v0z);
+        if (textureEnabled) {
+          glTexCoord2f(mesh.texcoords[i1 * 2], mesh.texcoords[i1 * 2 + 1]);
+        }
         glVertex3f(v1x, v1y, v1z);
+        if (textureEnabled) {
+          glTexCoord2f(mesh.texcoords[i2 * 2], mesh.texcoords[i2 * 2 + 1]);
+        }
         glVertex3f(v2x, v2y, v2z);
       }
     }
     glEnd();
+    if (textureEnabled) {
+      glBindTexture(GL_TEXTURE_2D, 0);
+      glDisable(GL_TEXTURE_2D);
+    }
   }
 
   if (cullWasEnabled)

--- a/viewer3d/render/scenerenderer.h
+++ b/viewer3d/render/scenerenderer.h
@@ -18,7 +18,8 @@ public:
   void DrawMeshWireframe(
       const Mesh &mesh, float scale,
       const std::function<std::array<float, 3>(const std::array<float, 3> &)> &captureTransform);
-  void DrawMesh(const Mesh &mesh, float scale, const float *modelMatrix);
+  void DrawMesh(const Mesh &mesh, float scale, const float *modelMatrix,
+                bool useTexture = false);
   void DrawGrid(int style, float r, float g, float b, Viewer2DView view);
   void SetupMaterialFromRGB(float r, float g, float b);
 

--- a/viewer3d/render/viewer3d_render_style.cpp
+++ b/viewer3d/render/viewer3d_render_style.cpp
@@ -1,0 +1,42 @@
+#include "viewer3d_render_style.h"
+
+#include "configmanager.h"
+
+namespace {
+constexpr std::string_view kStandardStyleValue = "standard";
+constexpr std::string_view kWhiteModelStyleValue = "white_model";
+constexpr std::string_view kTexturedStyleValue = "textured";
+} // namespace
+
+Viewer3DRenderStyle ResolveViewer3DRenderStyle(const ConfigManager &cfg) {
+  const auto style = cfg.GetValue("viewer3d_render_style");
+  if (!style.has_value())
+    return Viewer3DRenderStyle::Standard;
+
+  if (*style == kWhiteModelStyleValue)
+    return Viewer3DRenderStyle::WhiteModel;
+  if (*style == kTexturedStyleValue)
+    return Viewer3DRenderStyle::Textured;
+  return Viewer3DRenderStyle::Standard;
+}
+
+const char *ToConfigValue(Viewer3DRenderStyle style) {
+  switch (style) {
+  case Viewer3DRenderStyle::WhiteModel:
+    return kWhiteModelStyleValue.data();
+  case Viewer3DRenderStyle::Textured:
+    return kTexturedStyleValue.data();
+  case Viewer3DRenderStyle::Standard:
+  default:
+    return kStandardStyleValue.data();
+  }
+}
+
+bool IsWhiteModelRenderStyle(Viewer3DRenderStyle style) {
+  return style == Viewer3DRenderStyle::WhiteModel;
+}
+
+bool IsTexturedRenderStyle(Viewer3DRenderStyle style) {
+  return style == Viewer3DRenderStyle::Textured;
+}
+

--- a/viewer3d/render/viewer3d_render_style.h
+++ b/viewer3d/render/viewer3d_render_style.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string_view>
+
+class ConfigManager;
+
+enum class Viewer3DRenderStyle {
+  Standard,
+  WhiteModel,
+  Textured
+};
+
+Viewer3DRenderStyle ResolveViewer3DRenderStyle(const ConfigManager &cfg);
+const char *ToConfigValue(Viewer3DRenderStyle style);
+bool IsWhiteModelRenderStyle(Viewer3DRenderStyle style);
+bool IsTexturedRenderStyle(Viewer3DRenderStyle style);
+

--- a/viewer3d/viewer3d_types.h
+++ b/viewer3d/viewer3d_types.h
@@ -80,6 +80,7 @@ struct RenderFrameContext {
   bool colorByLayer = false;
   bool colorByUniverse = false;
   bool whiteModelStyle = false;
+  bool texturedStyle = false;
 
   std::unordered_set<std::string> hiddenLayers;
 };

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -65,6 +65,7 @@
 #include "selectionsystem.h"
 #include "gl_primitive_renderer.h"
 #include "lighting_profile.h"
+#include "viewer3d_render_style.h"
 
 #include <wx/wx.h>
 #define NANOVG_GL2_IMPLEMENTATION
@@ -169,9 +170,8 @@ static bool IsFastInteractionModeEnabled(const ConfigManager &cfg) {
   return cfg.GetFloat("viewer3d_fast_interaction_mode") >= 0.5f;
 }
 
-static bool ReadWhiteModelStylePreference(const ConfigManager &cfg) {
-  auto style = cfg.GetValue("viewer3d_render_style");
-  return style && *style == "white_model";
+static Viewer3DRenderStyle ReadRenderStylePreference(const ConfigManager &cfg) {
+  return ResolveViewer3DRenderStyle(cfg);
 }
 
 static LineRenderProfile GetLineRenderProfile(bool isInteracting,
@@ -990,7 +990,9 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
       context.wireframe && isByFixtureTypeMode;
   context.colorByLayer = context.wireframe && isByLayerMode;
   context.colorByUniverse = context.wireframe && isByUniverseMode;
-  context.whiteModelStyle = ReadWhiteModelStylePreference(cfg);
+  const Viewer3DRenderStyle renderStyle = ReadRenderStylePreference(cfg);
+  context.whiteModelStyle = IsWhiteModelRenderStyle(renderStyle);
+  context.texturedStyle = IsTexturedRenderStyle(renderStyle);
   m_impl->whiteModelStyleEnabled = context.whiteModelStyle;
 
   // Keep explicit mode flags local to the context build step to avoid

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1303,6 +1303,13 @@ void Viewer3DController::SetupMeshBuffers(Mesh &mesh) {
   glBufferData(GL_ARRAY_BUFFER, mesh.normals.size() * sizeof(float),
                mesh.normals.data(), GL_STATIC_DRAW);
 
+  if (!mesh.texcoords.empty()) {
+    glGenBuffers(1, &mesh.vboTexCoords);
+    glBindBuffer(GL_ARRAY_BUFFER, mesh.vboTexCoords);
+    glBufferData(GL_ARRAY_BUFFER, mesh.texcoords.size() * sizeof(float),
+                 mesh.texcoords.data(), GL_STATIC_DRAW);
+  }
+
   glGenBuffers(1, &mesh.eboTriangles);
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mesh.eboTriangles);
   glBufferData(GL_ELEMENT_ARRAY_BUFFER,
@@ -1326,6 +1333,7 @@ void Viewer3DController::SetupMeshBuffers(Mesh &mesh) {
       glIsVertexArray(mesh.vao) == GL_TRUE &&
       glIsBuffer(mesh.vboVertices) == GL_TRUE &&
       glIsBuffer(mesh.vboNormals) == GL_TRUE &&
+      (mesh.vboTexCoords == 0 || glIsBuffer(mesh.vboTexCoords) == GL_TRUE) &&
       glIsBuffer(mesh.eboTriangles) == GL_TRUE &&
       glIsBuffer(mesh.eboLines) == GL_TRUE;
 
@@ -1333,6 +1341,7 @@ void Viewer3DController::SetupMeshBuffers(Mesh &mesh) {
     mesh.vao = 0;
     mesh.vboVertices = 0;
     mesh.vboNormals = 0;
+    mesh.vboTexCoords = 0;
     mesh.eboTriangles = 0;
     mesh.eboLines = 0;
     mesh.triangleIndexCount = 0;
@@ -1344,9 +1353,26 @@ void Viewer3DController::SetupMeshBuffers(Mesh &mesh) {
   mesh.triangleIndexCount = static_cast<int>(mesh.indices.size());
   mesh.lineIndexCount = static_cast<int>(lineIndices.size());
   mesh.buffersReady = true;
+
+  if (!mesh.textureRgba.empty() && mesh.textureWidth > 0 &&
+      mesh.textureHeight > 0 && mesh.textureId == 0) {
+    glGenTextures(1, &mesh.textureId);
+    glBindTexture(GL_TEXTURE_2D, mesh.textureId);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mesh.textureWidth, mesh.textureHeight,
+                 0, GL_RGBA, GL_UNSIGNED_BYTE, mesh.textureRgba.data());
+    glBindTexture(GL_TEXTURE_2D, 0);
+  }
 }
 
 void Viewer3DController::ReleaseMeshBuffers(Mesh &mesh) {
+  if (mesh.textureId != 0) {
+    glDeleteTextures(1, &mesh.textureId);
+    mesh.textureId = 0;
+  }
   if (mesh.eboLines != 0) {
     glDeleteBuffers(1, &mesh.eboLines);
     mesh.eboLines = 0;
@@ -1358,6 +1384,10 @@ void Viewer3DController::ReleaseMeshBuffers(Mesh &mesh) {
   if (mesh.vboNormals != 0) {
     glDeleteBuffers(1, &mesh.vboNormals);
     mesh.vboNormals = 0;
+  }
+  if (mesh.vboTexCoords != 0) {
+    glDeleteBuffers(1, &mesh.vboTexCoords);
+    mesh.vboTexCoords = 0;
   }
   if (mesh.vboVertices != 0) {
     glDeleteBuffers(1, &mesh.vboVertices);

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -48,6 +48,7 @@
 #include "fixturepatchdialog.h"
 #include "viewer2dpanel.h"
 #include "viewer3dviewfit.h"
+#include "viewer3d_render_style.h"
 #include <wx/dcclient.h>
 #include <wx/event.h>
 #include <wx/log.h>
@@ -83,17 +84,61 @@ bool IsFastInteractionModeEnabled()
     return ConfigManager::Get().GetFloat("viewer3d_fast_interaction_mode") >= 0.5f;
 }
 
-bool IsWhiteModelRenderStyleEnabled() {
-    auto renderStyle = ConfigManager::Get().GetValue("viewer3d_render_style");
-    return renderStyle && *renderStyle == "white_model";
+Viewer3DRenderStyle ResolveRenderStyleFromPreferences() {
+    return ResolveViewer3DRenderStyle(ConfigManager::Get());
 }
 
-void ApplyViewer3DClearColorFromPreferences() {
-    if (IsWhiteModelRenderStyleEnabled()) {
+void ApplyViewer3DClearColorForStyle(Viewer3DRenderStyle style) {
+    if (style == Viewer3DRenderStyle::WhiteModel) {
         glClearColor(0.95f, 0.95f, 0.95f, 1.0f);
         return;
     }
+    if (style == Viewer3DRenderStyle::Textured) {
+        glClearColor(0.05f, 0.04f, 0.08f, 1.0f);
+        return;
+    }
     glClearColor(0.08f, 0.08f, 0.08f, 1.0f);
+}
+
+void DrawTexturedStyleBackgroundGradient() {
+    const GLboolean depthTestWasEnabled = glIsEnabled(GL_DEPTH_TEST);
+    const GLboolean lightingWasEnabled = glIsEnabled(GL_LIGHTING);
+
+    glMatrixMode(GL_PROJECTION);
+    glPushMatrix();
+    glLoadIdentity();
+    glOrtho(-1.0, 1.0, -1.0, 1.0, -1.0, 1.0);
+
+    glMatrixMode(GL_MODELVIEW);
+    glPushMatrix();
+    glLoadIdentity();
+
+    glDisable(GL_DEPTH_TEST);
+    glDisable(GL_LIGHTING);
+
+    glBegin(GL_QUADS);
+    glColor3f(0.05f, 0.04f, 0.10f);
+    glVertex2f(-1.0f, 1.0f);
+    glVertex2f(1.0f, 1.0f);
+
+    glColor3f(0.72f, 0.33f, 0.18f);
+    glVertex2f(1.0f, -0.05f);
+    glVertex2f(-1.0f, -0.05f);
+
+    glColor3f(0.95f, 0.58f, 0.30f);
+    glVertex2f(-1.0f, -1.0f);
+    glVertex2f(1.0f, -1.0f);
+    glEnd();
+
+    if (lightingWasEnabled)
+        glEnable(GL_LIGHTING);
+    if (depthTestWasEnabled)
+        glEnable(GL_DEPTH_TEST);
+
+    glPopMatrix();
+    glMatrixMode(GL_PROJECTION);
+    glPopMatrix();
+    glMatrixMode(GL_MODELVIEW);
 }
 
 std::vector<std::string> BuildFixtureSelectionByType(
@@ -254,7 +299,7 @@ void Viewer3DPanel::InitGL()
         glEnable(GL_MULTISAMPLE);
     else
         glDisable(GL_MULTISAMPLE);
-    ApplyViewer3DClearColorFromPreferences();
+    ApplyViewer3DClearColorForStyle(ResolveRenderStyleFromPreferences());
 }
 
 // Paint event handler
@@ -404,8 +449,11 @@ void Viewer3DPanel::Render()
     int width, height;
     GetClientSize(&width, &height);
 
-    ApplyViewer3DClearColorFromPreferences();
+    const Viewer3DRenderStyle renderStyle = ResolveRenderStyleFromPreferences();
+    ApplyViewer3DClearColorForStyle(renderStyle);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    if (renderStyle == Viewer3DRenderStyle::Textured)
+        DrawTexturedStyleBackgroundGradient();
     ApplyCameraMatrices(width, height);
 
     m_controller.SetCameraMoving(m_cameraMoving);

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -100,9 +100,31 @@ void ApplyViewer3DClearColorForStyle(Viewer3DRenderStyle style) {
     glClearColor(0.08f, 0.08f, 0.08f, 1.0f);
 }
 
-void DrawTexturedStyleBackgroundGradient() {
+float ComputeGroundPlaneHorizonNdcY() {
+    GLdouble model[16] = {0.0};
+    GLdouble projection[16] = {0.0};
+    GLint viewport[4] = {0, 0, 0, 0};
+    glGetDoublev(GL_MODELVIEW_MATRIX, model);
+    glGetDoublev(GL_PROJECTION_MATRIX, projection);
+    glGetIntegerv(GL_VIEWPORT, viewport);
+
+    GLdouble projectedX = 0.0;
+    GLdouble projectedY = 0.0;
+    GLdouble projectedZ = 0.0;
+    if (gluProject(0.0, 0.0, 0.0, model, projection, viewport,
+                   &projectedX, &projectedY, &projectedZ) == GL_TRUE &&
+        viewport[3] > 0) {
+        const double ndcY = (projectedY / static_cast<double>(viewport[3])) * 2.0 - 1.0;
+        return static_cast<float>(std::clamp(ndcY, -0.9, 0.9));
+    }
+    return -0.05f;
+}
+
+void DrawTexturedStyleBackgroundGradient(float horizonNdcY) {
     const GLboolean depthTestWasEnabled = glIsEnabled(GL_DEPTH_TEST);
     const GLboolean lightingWasEnabled = glIsEnabled(GL_LIGHTING);
+    const GLboolean cullFaceWasEnabled = glIsEnabled(GL_CULL_FACE);
+    const GLboolean texture2DWasEnabled = glIsEnabled(GL_TEXTURE_2D);
 
     glMatrixMode(GL_PROJECTION);
     glPushMatrix();
@@ -115,6 +137,8 @@ void DrawTexturedStyleBackgroundGradient() {
 
     glDisable(GL_DEPTH_TEST);
     glDisable(GL_LIGHTING);
+    glDisable(GL_CULL_FACE);
+    glDisable(GL_TEXTURE_2D);
 
     glBegin(GL_QUADS);
     glColor3f(0.05f, 0.04f, 0.10f);
@@ -122,8 +146,8 @@ void DrawTexturedStyleBackgroundGradient() {
     glVertex2f(1.0f, 1.0f);
 
     glColor3f(0.72f, 0.33f, 0.18f);
-    glVertex2f(1.0f, -0.05f);
-    glVertex2f(-1.0f, -0.05f);
+    glVertex2f(1.0f, horizonNdcY);
+    glVertex2f(-1.0f, horizonNdcY);
 
     glColor3f(0.95f, 0.58f, 0.30f);
     glVertex2f(-1.0f, -1.0f);
@@ -134,6 +158,10 @@ void DrawTexturedStyleBackgroundGradient() {
         glEnable(GL_LIGHTING);
     if (depthTestWasEnabled)
         glEnable(GL_DEPTH_TEST);
+    if (cullFaceWasEnabled)
+        glEnable(GL_CULL_FACE);
+    if (texture2DWasEnabled)
+        glEnable(GL_TEXTURE_2D);
 
     glPopMatrix();
     glMatrixMode(GL_PROJECTION);
@@ -452,9 +480,9 @@ void Viewer3DPanel::Render()
     const Viewer3DRenderStyle renderStyle = ResolveRenderStyleFromPreferences();
     ApplyViewer3DClearColorForStyle(renderStyle);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-    if (renderStyle == Viewer3DRenderStyle::Textured)
-        DrawTexturedStyleBackgroundGradient();
     ApplyCameraMatrices(width, height);
+    if (renderStyle == Viewer3DRenderStyle::Textured)
+        DrawTexturedStyleBackgroundGradient(ComputeGroundPlaneHorizonNdcY());
 
     m_controller.SetCameraMoving(m_cameraMoving);
     m_controller.RenderScene();

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -53,6 +53,7 @@
 #include <wx/event.h>
 #include <wx/log.h>
 #include <chrono>
+#include <array>
 #include <algorithm>
 #include <memory>
 #include <cmath>
@@ -100,60 +101,54 @@ void ApplyViewer3DClearColorForStyle(Viewer3DRenderStyle style) {
     glClearColor(0.08f, 0.08f, 0.08f, 1.0f);
 }
 
-float ComputeGroundPlaneHorizonNdcY() {
-    GLdouble model[16] = {0.0};
-    GLdouble projection[16] = {0.0};
-    GLint viewport[4] = {0, 0, 0, 0};
-    glGetDoublev(GL_MODELVIEW_MATRIX, model);
-    glGetDoublev(GL_PROJECTION_MATRIX, projection);
-    glGetIntegerv(GL_VIEWPORT, viewport);
-
-    GLdouble projectedX = 0.0;
-    GLdouble projectedY = 0.0;
-    GLdouble projectedZ = 0.0;
-    if (gluProject(0.0, 0.0, 0.0, model, projection, viewport,
-                   &projectedX, &projectedY, &projectedZ) == GL_TRUE &&
-        viewport[3] > 0) {
-        const double ndcY = (projectedY / static_cast<double>(viewport[3])) * 2.0 - 1.0;
-        return static_cast<float>(std::clamp(ndcY, -0.9, 0.9));
-    }
-    return -0.05f;
-}
-
-void DrawTexturedStyleBackgroundGradient(float horizonNdcY) {
+void DrawTexturedStyleBackgroundGradient() {
     const GLboolean depthTestWasEnabled = glIsEnabled(GL_DEPTH_TEST);
     const GLboolean lightingWasEnabled = glIsEnabled(GL_LIGHTING);
     const GLboolean cullFaceWasEnabled = glIsEnabled(GL_CULL_FACE);
     const GLboolean texture2DWasEnabled = glIsEnabled(GL_TEXTURE_2D);
+    GLboolean depthMaskEnabled = GL_TRUE;
+    glGetBooleanv(GL_DEPTH_WRITEMASK, &depthMaskEnabled);
 
-    glMatrixMode(GL_PROJECTION);
-    glPushMatrix();
-    glLoadIdentity();
-    glOrtho(-1.0, 1.0, -1.0, 1.0, -1.0, 1.0);
-
-    glMatrixMode(GL_MODELVIEW);
-    glPushMatrix();
-    glLoadIdentity();
-
+    glDepthMask(GL_FALSE);
     glDisable(GL_DEPTH_TEST);
     glDisable(GL_LIGHTING);
     glDisable(GL_CULL_FACE);
     glDisable(GL_TEXTURE_2D);
 
-    glBegin(GL_QUADS);
-    glColor3f(0.05f, 0.04f, 0.10f);
-    glVertex2f(-1.0f, 1.0f);
-    glVertex2f(1.0f, 1.0f);
+    constexpr int kSegments = 72;
+    constexpr float kRadius = 2500.0f;
+    constexpr float kPi = 3.14159265358979323846f;
+    const std::array<std::pair<float, std::array<float, 3>>, 6> bands = {{
+        {1200.0f, {0.03f, 0.05f, 0.18f}},
+        {700.0f, {0.11f, 0.17f, 0.34f}},
+        {260.0f, {0.35f, 0.28f, 0.44f}},
+        {0.0f, {0.92f, 0.48f, 0.26f}},
+        {-350.0f, {0.60f, 0.26f, 0.20f}},
+        {-1200.0f, {0.15f, 0.08f, 0.10f}},
+    }};
 
-    glColor3f(0.72f, 0.33f, 0.18f);
-    glVertex2f(1.0f, horizonNdcY);
-    glVertex2f(-1.0f, horizonNdcY);
+    for (size_t band = 0; band + 1 < bands.size(); ++band) {
+        const float z0 = bands[band].first;
+        const float z1 = bands[band + 1].first;
+        const auto &c0 = bands[band].second;
+        const auto &c1 = bands[band + 1].second;
 
-    glColor3f(0.95f, 0.58f, 0.30f);
-    glVertex2f(-1.0f, -1.0f);
-    glVertex2f(1.0f, -1.0f);
-    glEnd();
+        glBegin(GL_TRIANGLE_STRIP);
+        for (int i = 0; i <= kSegments; ++i) {
+            const float angle =
+                static_cast<float>(i) / static_cast<float>(kSegments) *
+                2.0f * kPi;
+            const float x = std::cos(angle) * kRadius;
+            const float y = std::sin(angle) * kRadius;
+            glColor3f(c0[0], c0[1], c0[2]);
+            glVertex3f(x, y, z0);
+            glColor3f(c1[0], c1[1], c1[2]);
+            glVertex3f(x, y, z1);
+        }
+        glEnd();
+    }
 
+    glDepthMask(depthMaskEnabled == GL_TRUE ? GL_TRUE : GL_FALSE);
     if (lightingWasEnabled)
         glEnable(GL_LIGHTING);
     if (depthTestWasEnabled)
@@ -162,11 +157,6 @@ void DrawTexturedStyleBackgroundGradient(float horizonNdcY) {
         glEnable(GL_CULL_FACE);
     if (texture2DWasEnabled)
         glEnable(GL_TEXTURE_2D);
-
-    glPopMatrix();
-    glMatrixMode(GL_PROJECTION);
-    glPopMatrix();
-    glMatrixMode(GL_MODELVIEW);
 }
 
 std::vector<std::string> BuildFixtureSelectionByType(
@@ -482,7 +472,7 @@ void Viewer3DPanel::Render()
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     ApplyCameraMatrices(width, height);
     if (renderStyle == Viewer3DRenderStyle::Textured)
-        DrawTexturedStyleBackgroundGradient(ComputeGroundPlaneHorizonNdcY());
+        DrawTexturedStyleBackgroundGradient();
 
     m_controller.SetCameraMoving(m_cameraMoving);
     m_controller.RenderScene();

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -101,54 +101,84 @@ void ApplyViewer3DClearColorForStyle(Viewer3DRenderStyle style) {
     glClearColor(0.08f, 0.08f, 0.08f, 1.0f);
 }
 
-void DrawTexturedStyleBackgroundGradient() {
+float ComputeGridPlaneHorizonNdcY() {
+    GLdouble model[16] = {0.0};
+    GLdouble projection[16] = {0.0};
+    GLint viewport[4] = {0, 0, 0, 0};
+    glGetDoublev(GL_MODELVIEW_MATRIX, model);
+    glGetDoublev(GL_PROJECTION_MATRIX, projection);
+    glGetIntegerv(GL_VIEWPORT, viewport);
+
+    if (viewport[3] <= 0)
+        return -0.05f;
+
+    constexpr int kSamples = 48;
+    constexpr double kProbeRadius = 2000.0;
+    bool found = false;
+    double topMostY = -1e9;
+    for (int i = 0; i < kSamples; ++i) {
+        const double angle = (static_cast<double>(i) / static_cast<double>(kSamples)) *
+                             2.0 * 3.14159265358979323846;
+        const double x = std::cos(angle) * kProbeRadius;
+        const double y = std::sin(angle) * kProbeRadius;
+        GLdouble sx = 0.0, sy = 0.0, sz = 0.0;
+        if (gluProject(x, y, 0.0, model, projection, viewport, &sx, &sy, &sz) == GL_TRUE &&
+            sz >= 0.0 && sz <= 1.0) {
+            topMostY = std::max(topMostY, sy);
+            found = true;
+        }
+    }
+
+    if (!found)
+        return -0.05f;
+
+    const double ndcY = (topMostY / static_cast<double>(viewport[3])) * 2.0 - 1.0;
+    return static_cast<float>(std::clamp(ndcY, -0.85, 0.85));
+}
+
+void DrawTexturedStyleBackgroundGradient(float horizonNdcY) {
     const GLboolean depthTestWasEnabled = glIsEnabled(GL_DEPTH_TEST);
     const GLboolean lightingWasEnabled = glIsEnabled(GL_LIGHTING);
     const GLboolean cullFaceWasEnabled = glIsEnabled(GL_CULL_FACE);
     const GLboolean texture2DWasEnabled = glIsEnabled(GL_TEXTURE_2D);
-    GLboolean depthMaskEnabled = GL_TRUE;
-    glGetBooleanv(GL_DEPTH_WRITEMASK, &depthMaskEnabled);
 
-    glDepthMask(GL_FALSE);
     glDisable(GL_DEPTH_TEST);
     glDisable(GL_LIGHTING);
     glDisable(GL_CULL_FACE);
     glDisable(GL_TEXTURE_2D);
 
-    constexpr int kSegments = 72;
-    constexpr float kRadius = 2500.0f;
-    constexpr float kPi = 3.14159265358979323846f;
+    glMatrixMode(GL_PROJECTION);
+    glPushMatrix();
+    glLoadIdentity();
+    glOrtho(-1.0, 1.0, -1.0, 1.0, -1.0, 1.0);
+    glMatrixMode(GL_MODELVIEW);
+    glPushMatrix();
+    glLoadIdentity();
+
     const std::array<std::pair<float, std::array<float, 3>>, 6> bands = {{
-        {1200.0f, {0.03f, 0.05f, 0.18f}},
-        {700.0f, {0.11f, 0.17f, 0.34f}},
-        {260.0f, {0.35f, 0.28f, 0.44f}},
-        {0.0f, {0.92f, 0.48f, 0.26f}},
-        {-350.0f, {0.60f, 0.26f, 0.20f}},
-        {-1200.0f, {0.15f, 0.08f, 0.10f}},
+        {1.0f, {0.02f, 0.05f, 0.18f}},
+        {0.55f, {0.10f, 0.20f, 0.40f}},
+        {horizonNdcY + 0.16f, {0.42f, 0.28f, 0.48f}},
+        {horizonNdcY, {0.96f, 0.56f, 0.26f}},
+        {horizonNdcY - 0.28f, {0.62f, 0.28f, 0.19f}},
+        {-1.0f, {0.18f, 0.09f, 0.11f}},
     }};
-
-    for (size_t band = 0; band + 1 < bands.size(); ++band) {
-        const float z0 = bands[band].first;
-        const float z1 = bands[band + 1].first;
-        const auto &c0 = bands[band].second;
-        const auto &c1 = bands[band + 1].second;
-
-        glBegin(GL_TRIANGLE_STRIP);
-        for (int i = 0; i <= kSegments; ++i) {
-            const float angle =
-                static_cast<float>(i) / static_cast<float>(kSegments) *
-                2.0f * kPi;
-            const float x = std::cos(angle) * kRadius;
-            const float y = std::sin(angle) * kRadius;
-            glColor3f(c0[0], c0[1], c0[2]);
-            glVertex3f(x, y, z0);
-            glColor3f(c1[0], c1[1], c1[2]);
-            glVertex3f(x, y, z1);
-        }
+    for (size_t i = 0; i + 1 < bands.size(); ++i) {
+        glBegin(GL_QUADS);
+        glColor3f(bands[i].second[0], bands[i].second[1], bands[i].second[2]);
+        glVertex2f(-1.0f, bands[i].first);
+        glVertex2f(1.0f, bands[i].first);
+        glColor3f(bands[i + 1].second[0], bands[i + 1].second[1], bands[i + 1].second[2]);
+        glVertex2f(1.0f, bands[i + 1].first);
+        glVertex2f(-1.0f, bands[i + 1].first);
         glEnd();
     }
 
-    glDepthMask(depthMaskEnabled == GL_TRUE ? GL_TRUE : GL_FALSE);
+    glPopMatrix();
+    glMatrixMode(GL_PROJECTION);
+    glPopMatrix();
+    glMatrixMode(GL_MODELVIEW);
+
     if (lightingWasEnabled)
         glEnable(GL_LIGHTING);
     if (depthTestWasEnabled)
@@ -472,7 +502,7 @@ void Viewer3DPanel::Render()
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     ApplyCameraMatrices(width, height);
     if (renderStyle == Viewer3DRenderStyle::Textured)
-        DrawTexturedStyleBackgroundGradient();
+        DrawTexturedStyleBackgroundGradient(ComputeGridPlaneHorizonNdcY());
 
     m_controller.SetCameraMoving(m_cameraMoving);
     m_controller.RenderScene();

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -189,6 +189,44 @@ void DrawTexturedStyleBackgroundGradient(float horizonNdcY) {
         glEnable(GL_TEXTURE_2D);
 }
 
+void DrawTexturedGroundPlaneBackdrop() {
+    const GLboolean depthTestWasEnabled = glIsEnabled(GL_DEPTH_TEST);
+    const GLboolean lightingWasEnabled = glIsEnabled(GL_LIGHTING);
+    const GLboolean cullFaceWasEnabled = glIsEnabled(GL_CULL_FACE);
+    const GLboolean texture2DWasEnabled = glIsEnabled(GL_TEXTURE_2D);
+
+    glDisable(GL_DEPTH_TEST);
+    glDisable(GL_LIGHTING);
+    glDisable(GL_CULL_FACE);
+    glDisable(GL_TEXTURE_2D);
+
+    constexpr int kSegments = 64;
+    constexpr float kRadius = 2500.0f;
+    constexpr float kPi = 3.14159265358979323846f;
+
+    glBegin(GL_TRIANGLE_FAN);
+    glColor3f(0.22f, 0.16f, 0.14f);
+    glVertex3f(0.0f, 0.0f, 0.0f);
+    for (int i = 0; i <= kSegments; ++i) {
+        const float angle = (static_cast<float>(i) / static_cast<float>(kSegments)) *
+                            2.0f * kPi;
+        const float x = std::cos(angle) * kRadius;
+        const float y = std::sin(angle) * kRadius;
+        glColor3f(0.54f, 0.33f, 0.24f);
+        glVertex3f(x, y, 0.0f);
+    }
+    glEnd();
+
+    if (lightingWasEnabled)
+        glEnable(GL_LIGHTING);
+    if (depthTestWasEnabled)
+        glEnable(GL_DEPTH_TEST);
+    if (cullFaceWasEnabled)
+        glEnable(GL_CULL_FACE);
+    if (texture2DWasEnabled)
+        glEnable(GL_TEXTURE_2D);
+}
+
 std::vector<std::string> BuildFixtureSelectionByType(
     const MvrScene& scene, const std::string& typeName)
 {
@@ -501,8 +539,10 @@ void Viewer3DPanel::Render()
     ApplyViewer3DClearColorForStyle(renderStyle);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     ApplyCameraMatrices(width, height);
-    if (renderStyle == Viewer3DRenderStyle::Textured)
+    if (renderStyle == Viewer3DRenderStyle::Textured) {
         DrawTexturedStyleBackgroundGradient(ComputeGridPlaneHorizonNdcY());
+        DrawTexturedGroundPlaneBackdrop();
+    }
 
     m_controller.SetCameraMoving(m_cameraMoving);
     m_controller.RenderScene();


### PR DESCRIPTION
### Motivation
- Provide a new 3D render style entry in Preferences so users can select a textured, smooth-shaded look with a realistic sunset-like background while keeping existing Standard and White Model styles.
- Centralize render-style parsing/serialization to a single helper so the style value is consistently read/written across viewer3d code paths.
- Prepare the renderer to enable smooth shading when a textured-style is chosen while keeping mesh/texture sampling integration for a follow-up change. 

### Description
- Added a small render-style helper `viewer3d/render/viewer3d_render_style.{h,cpp}` to resolve and serialize `viewer3d_render_style` values (`standard`, `white_model`, `textured`).
- Updated Preferences UI to rename the radio label from `"Standard (current)"` to `"Standard"` and added a new `Textured (sunset)` radio button that persists to `viewer3d_render_style` via the new helper.
- Wired the new style into the render context by adding a `texturedStyle` flag to `RenderFrameContext` and setting it in `Viewer3DController::RenderScene` based on the resolved style.
- Implemented a sunset-style background gradient in `Viewer3DPanel` and changed clear-color logic to pick per-style clear colors, restoring GL state after painting the gradient.
- Enabled smooth shading (`GL_SMOOTH`) in `OpaqueObjectPass` and `OpaqueFixturePass` when `texturedStyle` is active (and not wireframe) so faces render with smooth normals; kept existing drawing/mesh color behavior unchanged.
- Registered the new source file in `viewer3d/CMakeLists.txt` and added small includes where needed.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.
- Attempted a local build (`cmake --build build -j2`) but no `build/` directory exists in this environment so a full compile/run was not performed here.
- Note: the current change provides the UI and renderer wiring for the textured mode (smooth shading + background), but full material/UV texture sampling in draw calls is not yet implemented and will be addressed in a follow-up change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caeddff26c8324a140f44364cbc2b9)