### PR TITLE
Default fixture-only rider lists to FLOOR hang

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -1155,7 +1155,11 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
       continue;
     }
 
-    if (inFixtures && std::regex_match(line, m, kFixtureLineRe)) {
+    if (!inControl && !inRigging && std::regex_match(line, m, kFixtureLineRe)) {
+      if (!inFixtures)
+        inFixtures = true;
+      if (currentHang.empty())
+        currentHang = "FLOOR";
       int baseQuantity = 0;
       if (!TryParseInt(m[1].str(), baseQuantity))
         continue;
@@ -1163,7 +1167,11 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
       continue;
     }
 
-    if (inFixtures && std::regex_match(line, m, kQuantityOnlyRe)) {
+    if (!inControl && !inRigging && std::regex_match(line, m, kQuantityOnlyRe)) {
+      if (!inFixtures)
+        inFixtures = true;
+      if (currentHang.empty())
+        currentHang = "FLOOR";
       if (!TryParseInt(m[1].str(), pendingQuantity))
         continue;
       havePending = true;
@@ -2055,13 +2063,23 @@ bool RiderImporter::ImportText(const std::string &text) {
           }
           x += s;
         }
-      } else if (inFixtures && std::regex_match(line, m, kFixtureLineRe)) {
+      } else if (!inControl && !inRigging &&
+                 std::regex_match(line, m, kFixtureLineRe)) {
+        if (!inFixtures)
+          inFixtures = true;
+        if (currentHang.empty())
+          currentHang = "FLOOR";
         int baseQuantity = 0;
         if (!TryParseInt(m[1].str(), baseQuantity))
           continue;
         std::string desc = Trim(m[2]);
         addFixtures(baseQuantity, desc);
-      } else if (inFixtures && std::regex_match(line, m, kQuantityOnlyRe)) {
+      } else if (!inControl && !inRigging &&
+                 std::regex_match(line, m, kQuantityOnlyRe)) {
+        if (!inFixtures)
+          inFixtures = true;
+        if (currentHang.empty())
+          currentHang = "FLOOR";
         if (!TryParseInt(m[1].str(), pendingQuantity))
           continue;
         havePending = true;

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -887,6 +887,7 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
   bool inFixtures = false;
   bool inRigging = false;
   bool inControl = false;
+  bool seenSectionHeader = false;
   bool havePending = false;
   int pendingQuantity = 0;
   std::string currentHang;
@@ -953,6 +954,7 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
         ContainsCaseInsensitive(line, "video") ||
         ContainsCaseInsensitive(line, "realizacion") ||
         ContainsCaseInsensitive(line, "control")) {
+      seenSectionHeader = true;
       inFixtures = false;
       inRigging = false;
       inControl = ContainsCaseInsensitive(line, "control");
@@ -960,6 +962,7 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
       continue;
     }
     if (ContainsCaseInsensitive(line, "rigging")) {
+      seenSectionHeader = true;
       inFixtures = false;
       inRigging = true;
       inControl = false;
@@ -969,6 +972,7 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
     if (!inControl && (ContainsCaseInsensitive(line, "ilumin") ||
                        ContainsCaseInsensitive(line, "robotica") ||
                        ContainsCaseInsensitive(line, "convencion"))) {
+      seenSectionHeader = true;
       inFixtures = true;
       inRigging = false;
       havePending = false;
@@ -1155,8 +1159,11 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
       continue;
     }
 
-    if (!inControl && !inRigging && std::regex_match(line, m, kFixtureLineRe)) {
-      if (!inFixtures)
+    const bool canAssumeHeaderlessFixtureList =
+        !seenSectionHeader && !inFixtures && !inControl && !inRigging;
+    if ((inFixtures || canAssumeHeaderlessFixtureList) &&
+        std::regex_match(line, m, kFixtureLineRe)) {
+      if (canAssumeHeaderlessFixtureList)
         inFixtures = true;
       if (currentHang.empty())
         currentHang = "FLOOR";
@@ -1167,8 +1174,9 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
       continue;
     }
 
-    if (!inControl && !inRigging && std::regex_match(line, m, kQuantityOnlyRe)) {
-      if (!inFixtures)
+    if ((inFixtures || canAssumeHeaderlessFixtureList) &&
+        std::regex_match(line, m, kQuantityOnlyRe)) {
+      if (canAssumeHeaderlessFixtureList)
         inFixtures = true;
       if (currentHang.empty())
         currentHang = "FLOOR";
@@ -1379,6 +1387,7 @@ bool RiderImporter::ImportText(const std::string &text) {
   bool inFixtures = false;
   bool inRigging = false;
   bool inControl = false;
+  bool seenSectionHeader = false;
   std::string currentHang;
   std::unordered_map<std::string, int> nameCounters;
   std::vector<std::string> typeOrder;
@@ -1496,6 +1505,7 @@ bool RiderImporter::ImportText(const std::string &text) {
         ContainsCaseInsensitive(line, "video") ||
         ContainsCaseInsensitive(line, "realizacion") ||
         ContainsCaseInsensitive(line, "control")) {
+      seenSectionHeader = true;
       inFixtures = false;
       inRigging = false;
       inControl = ContainsCaseInsensitive(line, "control");
@@ -1503,6 +1513,7 @@ bool RiderImporter::ImportText(const std::string &text) {
       continue;
     }
     if (ContainsCaseInsensitive(line, "rigging")) {
+      seenSectionHeader = true;
       inFixtures = false;
       inRigging = true;
       inControl = false;
@@ -1512,6 +1523,7 @@ bool RiderImporter::ImportText(const std::string &text) {
     if (!inControl && (ContainsCaseInsensitive(line, "ilumin") ||
                        ContainsCaseInsensitive(line, "robotica") ||
                        ContainsCaseInsensitive(line, "convencion"))) {
+      seenSectionHeader = true;
       inFixtures = true;
       inRigging = false;
       havePending = false;
@@ -2063,26 +2075,30 @@ bool RiderImporter::ImportText(const std::string &text) {
           }
           x += s;
         }
-      } else if (!inControl && !inRigging &&
-                 std::regex_match(line, m, kFixtureLineRe)) {
-        if (!inFixtures)
-          inFixtures = true;
-        if (currentHang.empty())
-          currentHang = "FLOOR";
-        int baseQuantity = 0;
-        if (!TryParseInt(m[1].str(), baseQuantity))
-          continue;
-        std::string desc = Trim(m[2]);
-        addFixtures(baseQuantity, desc);
-      } else if (!inControl && !inRigging &&
-                 std::regex_match(line, m, kQuantityOnlyRe)) {
-        if (!inFixtures)
-          inFixtures = true;
-        if (currentHang.empty())
-          currentHang = "FLOOR";
-        if (!TryParseInt(m[1].str(), pendingQuantity))
-          continue;
-        havePending = true;
+      } else {
+        const bool canAssumeHeaderlessFixtureList =
+            !seenSectionHeader && !inFixtures && !inControl && !inRigging;
+        if ((inFixtures || canAssumeHeaderlessFixtureList) &&
+            std::regex_match(line, m, kFixtureLineRe)) {
+          if (canAssumeHeaderlessFixtureList)
+            inFixtures = true;
+          if (currentHang.empty())
+            currentHang = "FLOOR";
+          int baseQuantity = 0;
+          if (!TryParseInt(m[1].str(), baseQuantity))
+            continue;
+          std::string desc = Trim(m[2]);
+          addFixtures(baseQuantity, desc);
+        } else if ((inFixtures || canAssumeHeaderlessFixtureList) &&
+                   std::regex_match(line, m, kQuantityOnlyRe)) {
+          if (canAssumeHeaderlessFixtureList)
+            inFixtures = true;
+          if (currentHang.empty())
+            currentHang = "FLOOR";
+          if (!TryParseInt(m[1].str(), pendingQuantity))
+            continue;
+          havePending = true;
+        }
       }
     }
   }

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -80,6 +80,9 @@ The importer keeps parsing state with sections (fixtures/rigging/control):
   `sonido`, `audio`, `control de p.a.`, `monitores`, `microfon`, `video`,
   `realizacion`, or `control`.
 - If a hang-position line appears before explicit sections, the importer assumes fixtures mode.
+- If fixture list lines appear before explicit sections and no hang header has
+  been defined yet, the importer assumes fixtures mode and defaults active hang
+  to `FLOOR`.
 
 ## Hang/position detection
 
@@ -138,6 +141,8 @@ For each fixture created:
    - Fixture display/type name can be replaced by the parsed GDTF fixture name when available.
    - Physical properties (weight/power) are filled from GDTF when missing.
 4. `positionName` is set from current hang.
+   - If no hang header was parsed for a fixture list block, `positionName`
+     defaults to `FLOOR`.
    - In layer-by-position mode, side fixtures use `pos LX SIDES` when side
      trusses exist and fallback to `pos SIDES` when no side truss is present.
    - Side fixtures are ordered as a linear sequence and then mirrored by side:

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -80,9 +80,9 @@ The importer keeps parsing state with sections (fixtures/rigging/control):
   `sonido`, `audio`, `control de p.a.`, `monitores`, `microfon`, `video`,
   `realizacion`, or `control`.
 - If a hang-position line appears before explicit sections, the importer assumes fixtures mode.
-- If fixture list lines appear before explicit sections and no hang header has
-  been defined yet, the importer assumes fixtures mode and defaults active hang
-  to `FLOOR`.
+- If fixture list lines appear before **any recognized section header** and no
+  hang header has been defined yet, the importer assumes fixtures mode and
+  defaults active hang to `FLOOR`.
 
 ## Hang/position detection
 
@@ -141,7 +141,8 @@ For each fixture created:
    - Fixture display/type name can be replaced by the parsed GDTF fixture name when available.
    - Physical properties (weight/power) are filled from GDTF when missing.
 4. `positionName` is set from current hang.
-   - If no hang header was parsed for a fixture list block, `positionName`
+   - If no hang header was parsed and parsing started from a headerless
+     fixture list (before any recognized section header), `positionName`
      defaults to `FLOOR`.
    - In layer-by-position mode, side fixtures use `pos LX SIDES` when side
      trusses exist and fallback to `pos SIDES` when no side truss is present.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -626,6 +626,33 @@ target_link_libraries(rider_filter_preview_test PRIVATE ${wxWidgets_LIBRARIES} t
 add_test(NAME RiderFilterPreview COMMAND rider_filter_preview_test)
 set_library_env(RiderFilterPreview)
 
+add_executable(rider_floor_default_hang_test rider_floor_default_hang_test.cpp
+               riderimporter_stubs.cpp
+               gdtfloader_stub.cpp
+               ../core/riderimporter.cpp
+               ../core/units/units.cpp
+               ../core/gdtf_fixture_category.cpp
+               ../core/hoist_weight_distribution.cpp
+               ../core/uuidutils.cpp
+               ../core/autopatcher.cpp
+               ../core/patchmanager.cpp
+               ../core/configmanager.cpp
+               ../core/configservices.cpp
+               ../core/projectutils.cpp
+               ../core/logger.cpp
+               ../models/mvrscene.cpp
+               ../models/fixture.cpp
+               ../models/truss.cpp
+               ../models/sceneobject.cpp
+               ../models/layer.cpp
+               ${LAYOUT_SOURCES})
+target_include_directories(rider_floor_default_hang_test PRIVATE
+                           . ../core ../models ../mvr ../gui ../third_party)
+target_link_libraries(rider_floor_default_hang_test PRIVATE ${wxWidgets_LIBRARIES}
+                                                            tinyxml2::tinyxml2)
+add_test(NAME RiderFloorDefaultHang COMMAND rider_floor_default_hang_test)
+set_library_env(RiderFloorDefaultHang)
+
 add_executable(rider_led_screen_object_test rider_led_screen_object_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp

--- a/tests/rider_filter_preview_test.cpp
+++ b/tests/rider_filter_preview_test.cpp
@@ -89,5 +89,25 @@ int main() {
     return 1;
   }
 
+  const std::string mixedSectionsInput =
+      "SONIDO\n"
+      "2 CLUSTER FORMADOS POR:\n"
+      "ILUMINACION\n"
+      "LX1:\n"
+      "4 SPOT\n";
+  const std::string mixedSectionsExpected =
+      "LX1\n"
+      "4 SPOT";
+  const std::string mixedSectionsPreview =
+      RiderImporter::BuildFixtureFilterPreview(mixedSectionsInput);
+  if (mixedSectionsPreview != mixedSectionsExpected) {
+    std::cerr << "Audio sections should not leak into fixture preview when "
+                 "using headerless FLOOR fallback.\n"
+              << "Expected:\n"
+              << mixedSectionsExpected << "\n\nGot:\n"
+              << mixedSectionsPreview << "\n";
+    return 1;
+  }
+
   return 0;
 }

--- a/tests/rider_floor_default_hang_test.cpp
+++ b/tests/rider_floor_default_hang_test.cpp
@@ -1,0 +1,35 @@
+#include <cassert>
+#include <string>
+#include <wx/init.h>
+
+#include "configmanager.h"
+#include "fixture.h"
+#include "riderimporter.h"
+
+int main() {
+  wxInitializer initializer;
+  assert(initializer.IsOk());
+
+  auto &cfg = ConfigManager::Get();
+  cfg.Reset();
+
+  const std::string riderText = "8 Spot\n"
+                                "4 Wash\n";
+  assert(RiderImporter::ImportText(riderText));
+
+  const auto &scene = cfg.GetScene();
+  assert(scene.fixtures.size() == 12);
+  for (const auto &[uuid, fixture] : scene.fixtures) {
+    (void)uuid;
+    assert(fixture.positionName == "FLOOR");
+    assert(fixture.layer == "pos FLOOR");
+  }
+
+  const std::string preview = RiderImporter::BuildFixtureFilterPreview(riderText);
+  const std::string expectedPreview = "FLOOR\n"
+                                      "8 Spot\n"
+                                      "4 Wash";
+  assert(preview == expectedPreview);
+
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- Fixture list lines without an explicit hang header were not creating fixtures because no active hang was set, so the importer should treat headerless fixture lists as `FLOOR` to match user expectations.

### Description
- When parsing fixture lines or quantity-only lines in both `BuildFixtureFilterPreview` and `ImportText`, if the parser is not in `control`/`rigging` and no current hang is set, the importer now enters fixtures mode and sets `currentHang` to `FLOOR` (changes in `core/riderimporter.cpp`).
- Added a regression test `tests/rider_floor_default_hang_test.cpp` and registered it in `tests/CMakeLists.txt` to validate import and preview behavior for headerless fixture lists.
- Documented the new fallback in `docs/text_to_scene_rules.md` so the text-to-scene rules explicitly state that headerless fixture blocks default to `FLOOR`.
- Technical note: the changes touch the large `core/riderimporter.cpp`; recommend extracting the fixture parsing/preview logic into a dedicated helper module (for example `core/rider_fixture_parser.*`) in a follow-up PR to reduce hotspot size and improve modularity.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.
- Attempted to configure the project with `cmake --preset wsl-x64-debug` to build and run C++ tests, but configuration failed due to missing `wxWidgets` (`wxWidgets_LIBRARIES` / `wxWidgets_INCLUDE_DIRS`), so the new unit test was added but not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb8911c9508324b3820b17f3791a82)