### PR TITLE
Add render mode submenu to 3D viewer context menu

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -169,6 +169,7 @@ ConfigManager::ConfigManager() {
   RegisterVariable("view2d_top_fixtures_inverted", "float", 1.0f, 0.0f,
                    1.0f);
   RegisterVariable("viewer3d_aa_quality", "float", 1.0f, 0.0f, 2.0f);
+  RegisterVariable("viewer3d_render_mode", "float", 0.0f, 0.0f, 4.0f);
   RegisterVariable("viewer3d_adaptive_line_profile", "float", 1.0f, 0.0f, 1.0f);
   RegisterVariable("viewer3d_skip_labels_when_moving", "float", 1.0f, 0.0f,
                    1.0f);

--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -169,7 +169,6 @@ ConfigManager::ConfigManager() {
   RegisterVariable("view2d_top_fixtures_inverted", "float", 1.0f, 0.0f,
                    1.0f);
   RegisterVariable("viewer3d_aa_quality", "float", 1.0f, 0.0f, 2.0f);
-  RegisterVariable("viewer3d_render_mode", "float", 0.0f, 0.0f, 4.0f);
   RegisterVariable("viewer3d_adaptive_line_profile", "float", 1.0f, 0.0f, 1.0f);
   RegisterVariable("viewer3d_skip_labels_when_moving", "float", 1.0f, 0.0f,
                    1.0f);

--- a/gui/preferencesdialog.cpp
+++ b/gui/preferencesdialog.cpp
@@ -183,13 +183,13 @@ PreferencesDialog::PreferencesDialog(wxWindow *parent)
 
   viewer3dSizer->Add(viewer3dStandardRenderRadio, 0,
                      wxLEFT | wxRIGHT | wxTOP, 10);
-  viewer3dSizer->Add(viewer3dWhiteRenderRadio, 0,
-                     wxLEFT | wxRIGHT | wxTOP, 10);
   viewer3dSizer->Add(viewer3dWhiteModelRenderRadio, 0,
                      wxLEFT | wxRIGHT | wxTOP, 10);
   viewer3dSizer->Add(viewer3dTexturedRenderRadio, 0,
                      wxLEFT | wxRIGHT | wxTOP, 10);
   viewer3dSizer->Add(viewer3dWireframeRenderRadio, 0,
+                     wxLEFT | wxRIGHT | wxTOP, 10);
+  viewer3dSizer->Add(viewer3dWhiteRenderRadio, 0,
                      wxLEFT | wxRIGHT | wxTOP, 10);
   viewer3dSizer->Add(viewer3dByDeviceTypeRenderRadio, 0,
                      wxLEFT | wxRIGHT | wxTOP, 10);

--- a/gui/preferencesdialog.cpp
+++ b/gui/preferencesdialog.cpp
@@ -156,8 +156,10 @@ PreferencesDialog::PreferencesDialog(wxWindow *parent)
   viewer3dStandardRenderRadio = new wxRadioButton(
       viewer3dPanel, wxID_ANY, "Standard", wxDefaultPosition,
       wxDefaultSize, wxRB_GROUP);
+  viewer3dWhiteRenderRadio = new wxRadioButton(
+      viewer3dPanel, wxID_ANY, "White");
   viewer3dWhiteModelRenderRadio = new wxRadioButton(
-      viewer3dPanel, wxID_ANY, "White Model style");
+      viewer3dPanel, wxID_ANY, "Sketch mode");
   viewer3dTexturedRenderRadio = new wxRadioButton(
       viewer3dPanel, wxID_ANY, "Textured");
   viewer3dWireframeRenderRadio = new wxRadioButton(
@@ -171,6 +173,7 @@ PreferencesDialog::PreferencesDialog(wxWindow *parent)
 
   const Viewer3DRenderStyle renderStyle = ResolveViewer3DRenderStyle(cfg);
   viewer3dStandardRenderRadio->SetValue(renderStyle == Viewer3DRenderStyle::Standard);
+  viewer3dWhiteRenderRadio->SetValue(renderStyle == Viewer3DRenderStyle::White);
   viewer3dWhiteModelRenderRadio->SetValue(renderStyle == Viewer3DRenderStyle::WhiteModel);
   viewer3dTexturedRenderRadio->SetValue(renderStyle == Viewer3DRenderStyle::Textured);
   viewer3dWireframeRenderRadio->SetValue(renderStyle == Viewer3DRenderStyle::Wireframe);
@@ -179,6 +182,8 @@ PreferencesDialog::PreferencesDialog(wxWindow *parent)
   viewer3dByUniverseRenderRadio->SetValue(renderStyle == Viewer3DRenderStyle::ByUniverse);
 
   viewer3dSizer->Add(viewer3dStandardRenderRadio, 0,
+                     wxLEFT | wxRIGHT | wxTOP, 10);
+  viewer3dSizer->Add(viewer3dWhiteRenderRadio, 0,
                      wxLEFT | wxRIGHT | wxTOP, 10);
   viewer3dSizer->Add(viewer3dWhiteModelRenderRadio, 0,
                      wxLEFT | wxRIGHT | wxTOP, 10);
@@ -241,7 +246,9 @@ bool PreferencesDialog::ApplyPreferences() {
   cfg.SetValue("ui_weight_unit_system",
                weightUnitChoice->GetSelection() == 1 ? "imperial" : "metric");
   Viewer3DRenderStyle renderStyle = Viewer3DRenderStyle::Standard;
-  if (viewer3dWhiteModelRenderRadio && viewer3dWhiteModelRenderRadio->GetValue())
+  if (viewer3dWhiteRenderRadio && viewer3dWhiteRenderRadio->GetValue())
+    renderStyle = Viewer3DRenderStyle::White;
+  else if (viewer3dWhiteModelRenderRadio && viewer3dWhiteModelRenderRadio->GetValue())
     renderStyle = Viewer3DRenderStyle::WhiteModel;
   else if (viewer3dTexturedRenderRadio && viewer3dTexturedRenderRadio->GetValue())
     renderStyle = Viewer3DRenderStyle::Textured;

--- a/gui/preferencesdialog.cpp
+++ b/gui/preferencesdialog.cpp
@@ -160,17 +160,37 @@ PreferencesDialog::PreferencesDialog(wxWindow *parent)
       viewer3dPanel, wxID_ANY, "White Model style");
   viewer3dTexturedRenderRadio = new wxRadioButton(
       viewer3dPanel, wxID_ANY, "Textured");
+  viewer3dWireframeRenderRadio = new wxRadioButton(
+      viewer3dPanel, wxID_ANY, "Wireframe");
+  viewer3dByDeviceTypeRenderRadio = new wxRadioButton(
+      viewer3dPanel, wxID_ANY, "By device type");
+  viewer3dByLayerRenderRadio = new wxRadioButton(
+      viewer3dPanel, wxID_ANY, "By layer");
+  viewer3dByUniverseRenderRadio = new wxRadioButton(
+      viewer3dPanel, wxID_ANY, "By universe");
 
   const Viewer3DRenderStyle renderStyle = ResolveViewer3DRenderStyle(cfg);
   viewer3dStandardRenderRadio->SetValue(renderStyle == Viewer3DRenderStyle::Standard);
   viewer3dWhiteModelRenderRadio->SetValue(renderStyle == Viewer3DRenderStyle::WhiteModel);
   viewer3dTexturedRenderRadio->SetValue(renderStyle == Viewer3DRenderStyle::Textured);
+  viewer3dWireframeRenderRadio->SetValue(renderStyle == Viewer3DRenderStyle::Wireframe);
+  viewer3dByDeviceTypeRenderRadio->SetValue(renderStyle == Viewer3DRenderStyle::ByDeviceType);
+  viewer3dByLayerRenderRadio->SetValue(renderStyle == Viewer3DRenderStyle::ByLayer);
+  viewer3dByUniverseRenderRadio->SetValue(renderStyle == Viewer3DRenderStyle::ByUniverse);
 
   viewer3dSizer->Add(viewer3dStandardRenderRadio, 0,
                      wxLEFT | wxRIGHT | wxTOP, 10);
   viewer3dSizer->Add(viewer3dWhiteModelRenderRadio, 0,
                      wxLEFT | wxRIGHT | wxTOP, 10);
   viewer3dSizer->Add(viewer3dTexturedRenderRadio, 0,
+                     wxLEFT | wxRIGHT | wxTOP, 10);
+  viewer3dSizer->Add(viewer3dWireframeRenderRadio, 0,
+                     wxLEFT | wxRIGHT | wxTOP, 10);
+  viewer3dSizer->Add(viewer3dByDeviceTypeRenderRadio, 0,
+                     wxLEFT | wxRIGHT | wxTOP, 10);
+  viewer3dSizer->Add(viewer3dByLayerRenderRadio, 0,
+                     wxLEFT | wxRIGHT | wxTOP, 10);
+  viewer3dSizer->Add(viewer3dByUniverseRenderRadio, 0,
                      wxLEFT | wxRIGHT | wxTOP | wxBOTTOM, 10);
   viewer3dPanel->SetSizer(viewer3dSizer);
   book->AddPage(viewer3dPanel, "3D Viewer");
@@ -225,6 +245,14 @@ bool PreferencesDialog::ApplyPreferences() {
     renderStyle = Viewer3DRenderStyle::WhiteModel;
   else if (viewer3dTexturedRenderRadio && viewer3dTexturedRenderRadio->GetValue())
     renderStyle = Viewer3DRenderStyle::Textured;
+  else if (viewer3dWireframeRenderRadio && viewer3dWireframeRenderRadio->GetValue())
+    renderStyle = Viewer3DRenderStyle::Wireframe;
+  else if (viewer3dByDeviceTypeRenderRadio && viewer3dByDeviceTypeRenderRadio->GetValue())
+    renderStyle = Viewer3DRenderStyle::ByDeviceType;
+  else if (viewer3dByLayerRenderRadio && viewer3dByLayerRenderRadio->GetValue())
+    renderStyle = Viewer3DRenderStyle::ByLayer;
+  else if (viewer3dByUniverseRenderRadio && viewer3dByUniverseRenderRadio->GetValue())
+    renderStyle = Viewer3DRenderStyle::ByUniverse;
   cfg.SetValue("viewer3d_render_style", ToConfigValue(renderStyle));
   return cfg.SaveUserConfig();
 }

--- a/gui/preferencesdialog.h
+++ b/gui/preferencesdialog.h
@@ -42,6 +42,7 @@ private:
   wxRadioButton *layerPosRadio = nullptr;
   wxRadioButton *layerTypeRadio = nullptr;
   wxRadioButton *viewer3dStandardRenderRadio = nullptr;
+  wxRadioButton *viewer3dWhiteRenderRadio = nullptr;
   wxRadioButton *viewer3dWhiteModelRenderRadio = nullptr;
   wxRadioButton *viewer3dTexturedRenderRadio = nullptr;
   wxRadioButton *viewer3dWireframeRenderRadio = nullptr;

--- a/gui/preferencesdialog.h
+++ b/gui/preferencesdialog.h
@@ -44,6 +44,10 @@ private:
   wxRadioButton *viewer3dStandardRenderRadio = nullptr;
   wxRadioButton *viewer3dWhiteModelRenderRadio = nullptr;
   wxRadioButton *viewer3dTexturedRenderRadio = nullptr;
+  wxRadioButton *viewer3dWireframeRenderRadio = nullptr;
+  wxRadioButton *viewer3dByDeviceTypeRenderRadio = nullptr;
+  wxRadioButton *viewer3dByLayerRenderRadio = nullptr;
+  wxRadioButton *viewer3dByUniverseRenderRadio = nullptr;
   wxChoice *distanceUnitChoice = nullptr;
   wxChoice *weightUnitChoice = nullptr;
   wxString initialDistanceUnit;

--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -533,23 +533,21 @@ void OpaqueFixturePass::Render(
         TryParseHtmlHexColor(gdtfModelColor, r, g, b);
       }
     }
-    if (wireframe) {
-      if (mode == Viewer2DRenderMode::ByFixtureType) {
-        auto c = getTypeColor(f.gdtfSpec, f.color);
-        r = c[0];
-        g = c[1];
-        b = c[2];
-      } else if (mode == Viewer2DRenderMode::ByLayer) {
-        auto c = getLayerColor(f.layer);
-        r = c[0];
-        g = c[1];
-        b = c[2];
-      } else if (mode == Viewer2DRenderMode::ByUniverse) {
-        auto c = GetUniverseColor(ParseUniverseFromAddress(f.address));
-        r = c[0];
-        g = c[1];
-        b = c[2];
-      }
+    if (mode == Viewer2DRenderMode::ByFixtureType) {
+      auto c = getTypeColor(f.gdtfSpec, f.color);
+      r = c[0];
+      g = c[1];
+      b = c[2];
+    } else if (mode == Viewer2DRenderMode::ByLayer) {
+      auto c = getLayerColor(f.layer);
+      r = c[0];
+      g = c[1];
+      b = c[2];
+    } else if (mode == Viewer2DRenderMode::ByUniverse) {
+      auto c = GetUniverseColor(ParseUniverseFromAddress(f.address));
+      r = c[0];
+      g = c[1];
+      b = c[2];
     }
 
     Matrix fixtureTransform = f.transform;

--- a/viewer3d/render/opaque_object_pass.cpp
+++ b/viewer3d/render/opaque_object_pass.cpp
@@ -210,14 +210,13 @@ void OpaqueObjectPass::Render(
             if (cullEnabled)
               glDisable(GL_CULL_FACE);
             const bool useUnlitFallbackFill =
-                !isHighlighted && !isSelected &&
-                (mode == Viewer2DRenderMode::White ||
-                 mode == Viewer2DRenderMode::ByLayer);
+                !isHighlighted && !isSelected && context.whiteModelStyle;
             const GLboolean lightingEnabled = glIsEnabled(GL_LIGHTING);
             if (useUnlitFallbackFill && lightingEnabled)
               glDisable(GL_LIGHTING);
+            const bool fallbackWireframe = wireframe || context.whiteModelStyle;
             controller.DrawCubeWithOutline(0.3f, r, g, b, isHighlighted,
-                                           isSelected, cx, cy, cz, wireframe,
+                                           isSelected, cx, cy, cz, fallbackWireframe,
                                            mode, captureTransformFn);
             if (useUnlitFallbackFill && lightingEnabled)
               glEnable(GL_LIGHTING);

--- a/viewer3d/render/opaque_object_pass.cpp
+++ b/viewer3d/render/opaque_object_pass.cpp
@@ -90,7 +90,7 @@ void OpaqueObjectPass::Render(
       g = 0.95f;
       b = 0.95f;
     }
-    if (wireframe && mode == Viewer2DRenderMode::ByLayer) {
+    if (mode == Viewer2DRenderMode::ByLayer) {
       auto c = getLayerColor(m.layer);
       r = c[0];
       g = c[1];

--- a/viewer3d/render/opaque_object_pass.cpp
+++ b/viewer3d/render/opaque_object_pass.cpp
@@ -209,9 +209,18 @@ void OpaqueObjectPass::Render(
             const GLboolean cullEnabled = glIsEnabled(GL_CULL_FACE);
             if (cullEnabled)
               glDisable(GL_CULL_FACE);
+            const bool useUnlitFallbackFill =
+                !isHighlighted && !isSelected &&
+                (mode == Viewer2DRenderMode::White ||
+                 mode == Viewer2DRenderMode::ByLayer);
+            const GLboolean lightingEnabled = glIsEnabled(GL_LIGHTING);
+            if (useUnlitFallbackFill && lightingEnabled)
+              glDisable(GL_LIGHTING);
             controller.DrawCubeWithOutline(0.3f, r, g, b, isHighlighted,
                                            isSelected, cx, cy, cz, wireframe,
                                            mode, captureTransformFn);
+            if (useUnlitFallbackFill && lightingEnabled)
+              glEnable(GL_LIGHTING);
             if (cullEnabled)
               glEnable(GL_CULL_FACE);
           }

--- a/viewer3d/render/opaque_truss_pass.cpp
+++ b/viewer3d/render/opaque_truss_pass.cpp
@@ -89,7 +89,7 @@ void OpaqueTrussPass::Render(
       g = 0.95f;
       b = 0.95f;
     }
-    if (wireframe && mode == Viewer2DRenderMode::ByLayer) {
+    if (mode == Viewer2DRenderMode::ByLayer) {
       auto c = getLayerColor(t.layer);
       r = c[0];
       g = c[1];

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -137,6 +137,18 @@ void SceneRenderer::DrawMeshWithOutline(
   (void)cx;
   (void)cy;
   (void)cz;
+  const bool forceDisableTexture =
+      mode == Viewer2DRenderMode::Wireframe ||
+      mode == Viewer2DRenderMode::ByFixtureType ||
+      mode == Viewer2DRenderMode::ByLayer ||
+      mode == Viewer2DRenderMode::ByUniverse;
+  const GLboolean texture2DWasEnabled = glIsEnabled(GL_TEXTURE_2D);
+  if (forceDisableTexture && texture2DWasEnabled)
+    glDisable(GL_TEXTURE_2D);
+  const auto restoreTextureState = [&]() {
+    if (forceDisableTexture && texture2DWasEnabled)
+      glEnable(GL_TEXTURE_2D);
+  };
 
   if (wireframe) {
     float lineWidth =
@@ -199,6 +211,7 @@ void SceneRenderer::DrawMeshWithOutline(
         glDisable(GL_POLYGON_OFFSET_FILL);
       }
     }
+    restoreTextureState();
     return;
   }
 
@@ -315,6 +328,7 @@ void SceneRenderer::DrawMeshWithOutline(
       m_controller.RecordPolygon(pts, stroke, &fill);
     }
   }
+  restoreTextureState();
 }
 
 void SceneRenderer::DrawMeshWireframe(

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -204,6 +204,10 @@ void SceneRenderer::DrawMeshWithOutline(
 
   if (!m_controller.IsCaptureOnly()) {
     if (m_controller.IsWhiteModelStyleEnabled()) {
+      const bool useColorFillInWhiteStyle =
+          mode == Viewer2DRenderMode::ByFixtureType ||
+          mode == Viewer2DRenderMode::ByLayer ||
+          mode == Viewer2DRenderMode::ByUniverse;
       // Keep 3D white-model aligned with the 2D viewer draw order:
       // stroke pass first, then polygon-offset fill pass.
       const LineRenderProfile lineProfile =
@@ -243,6 +247,14 @@ void SceneRenderer::DrawMeshWithOutline(
         if (!glIsEnabled(GL_LIGHTING))
           glEnable(GL_LIGHTING);
         DrawMesh(mesh, scale, modelMatrix);
+      } else if (useColorFillInWhiteStyle) {
+        const GLboolean fillLightingWasEnabled = glIsEnabled(GL_LIGHTING);
+        if (!fillLightingWasEnabled)
+          glEnable(GL_LIGHTING);
+        m_controller.SetGLColor(r, g, b);
+        DrawMesh(mesh, scale, modelMatrix);
+        if (!fillLightingWasEnabled)
+          glDisable(GL_LIGHTING);
       } else {
         const GLboolean fillLightingWasEnabled = glIsEnabled(GL_LIGHTING);
         if (fillLightingWasEnabled)

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -144,6 +144,7 @@ void SceneRenderer::DrawMeshWithOutline(
   (void)cz;
   const bool forceDisableTexture =
       mode == Viewer2DRenderMode::Wireframe ||
+      mode == Viewer2DRenderMode::White ||
       mode == Viewer2DRenderMode::ByFixtureType ||
       mode == Viewer2DRenderMode::ByLayer ||
       mode == Viewer2DRenderMode::ByUniverse;

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -262,12 +262,12 @@ void SceneRenderer::DrawMeshWithOutline(
         DrawMesh(mesh, scale, modelMatrix);
       } else if (useColorFillInWhiteStyle) {
         const GLboolean fillLightingWasEnabled = glIsEnabled(GL_LIGHTING);
-        if (!fillLightingWasEnabled)
-          glEnable(GL_LIGHTING);
+        if (fillLightingWasEnabled)
+          glDisable(GL_LIGHTING);
         m_controller.SetGLColor(r, g, b);
         DrawMesh(mesh, scale, modelMatrix);
-        if (!fillLightingWasEnabled)
-          glDisable(GL_LIGHTING);
+        if (fillLightingWasEnabled)
+          glEnable(GL_LIGHTING);
       } else {
         const GLboolean fillLightingWasEnabled = glIsEnabled(GL_LIGHTING);
         if (fillLightingWasEnabled)

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -144,7 +144,6 @@ void SceneRenderer::DrawMeshWithOutline(
   (void)cz;
   const bool forceDisableTexture =
       mode == Viewer2DRenderMode::Wireframe ||
-      mode == Viewer2DRenderMode::White ||
       mode == Viewer2DRenderMode::ByFixtureType ||
       mode == Viewer2DRenderMode::ByLayer ||
       mode == Viewer2DRenderMode::ByUniverse;

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -127,6 +127,11 @@ static bool IsTexturedRenderStyleEnabled() {
   return IsTexturedRenderStyle(ResolveViewer3DRenderStyle(ConfigManager::Get()));
 }
 
+static bool IsSketchRenderStyleEnabled() {
+  return ResolveViewer3DRenderStyle(ConfigManager::Get()) ==
+         Viewer3DRenderStyle::WhiteModel;
+}
+
 void SceneRenderer::DrawMeshWithOutline(
     const Mesh &mesh, float r, float g, float b, float scale, bool highlight,
     bool selected, float cx, float cy, float cz, bool wireframe,
@@ -218,9 +223,11 @@ void SceneRenderer::DrawMeshWithOutline(
   if (!m_controller.IsCaptureOnly()) {
     if (m_controller.IsWhiteModelStyleEnabled()) {
       const bool useColorFillInWhiteStyle =
+          !IsSketchRenderStyleEnabled() &&
+          (mode == Viewer2DRenderMode::White ||
           mode == Viewer2DRenderMode::ByFixtureType ||
           mode == Viewer2DRenderMode::ByLayer ||
-          mode == Viewer2DRenderMode::ByUniverse;
+          mode == Viewer2DRenderMode::ByUniverse);
       // Keep 3D white-model aligned with the 2D viewer draw order:
       // stroke pass first, then polygon-offset fill pass.
       const LineRenderProfile lineProfile =

--- a/viewer3d/render/viewer3d_render_style.cpp
+++ b/viewer3d/render/viewer3d_render_style.cpp
@@ -4,6 +4,7 @@
 
 namespace {
 constexpr std::string_view kStandardStyleValue = "standard";
+constexpr std::string_view kWhiteStyleValue = "white";
 constexpr std::string_view kWhiteModelStyleValue = "white_model";
 constexpr std::string_view kTexturedStyleValue = "textured";
 constexpr std::string_view kWireframeStyleValue = "wireframe";
@@ -19,6 +20,8 @@ Viewer3DRenderStyle ResolveViewer3DRenderStyle(const ConfigManager &cfg) {
 
   if (*style == kWhiteModelStyleValue)
     return Viewer3DRenderStyle::WhiteModel;
+  if (*style == kWhiteStyleValue)
+    return Viewer3DRenderStyle::White;
   if (*style == kTexturedStyleValue)
     return Viewer3DRenderStyle::Textured;
   if (*style == kWireframeStyleValue)
@@ -34,6 +37,8 @@ Viewer3DRenderStyle ResolveViewer3DRenderStyle(const ConfigManager &cfg) {
 
 const char *ToConfigValue(Viewer3DRenderStyle style) {
   switch (style) {
+  case Viewer3DRenderStyle::White:
+    return kWhiteStyleValue.data();
   case Viewer3DRenderStyle::WhiteModel:
     return kWhiteModelStyleValue.data();
   case Viewer3DRenderStyle::Textured:
@@ -54,6 +59,7 @@ const char *ToConfigValue(Viewer3DRenderStyle style) {
 
 bool IsWhiteModelRenderStyle(Viewer3DRenderStyle style) {
   return style == Viewer3DRenderStyle::WhiteModel ||
+         style == Viewer3DRenderStyle::White ||
          style == Viewer3DRenderStyle::ByDeviceType ||
          style == Viewer3DRenderStyle::ByLayer ||
          style == Viewer3DRenderStyle::ByUniverse;

--- a/viewer3d/render/viewer3d_render_style.cpp
+++ b/viewer3d/render/viewer3d_render_style.cpp
@@ -6,6 +6,10 @@ namespace {
 constexpr std::string_view kStandardStyleValue = "standard";
 constexpr std::string_view kWhiteModelStyleValue = "white_model";
 constexpr std::string_view kTexturedStyleValue = "textured";
+constexpr std::string_view kWireframeStyleValue = "wireframe";
+constexpr std::string_view kByDeviceTypeStyleValue = "by_device_type";
+constexpr std::string_view kByLayerStyleValue = "by_layer";
+constexpr std::string_view kByUniverseStyleValue = "by_universe";
 } // namespace
 
 Viewer3DRenderStyle ResolveViewer3DRenderStyle(const ConfigManager &cfg) {
@@ -17,6 +21,14 @@ Viewer3DRenderStyle ResolveViewer3DRenderStyle(const ConfigManager &cfg) {
     return Viewer3DRenderStyle::WhiteModel;
   if (*style == kTexturedStyleValue)
     return Viewer3DRenderStyle::Textured;
+  if (*style == kWireframeStyleValue)
+    return Viewer3DRenderStyle::Wireframe;
+  if (*style == kByDeviceTypeStyleValue)
+    return Viewer3DRenderStyle::ByDeviceType;
+  if (*style == kByLayerStyleValue)
+    return Viewer3DRenderStyle::ByLayer;
+  if (*style == kByUniverseStyleValue)
+    return Viewer3DRenderStyle::ByUniverse;
   return Viewer3DRenderStyle::Standard;
 }
 
@@ -26,6 +38,14 @@ const char *ToConfigValue(Viewer3DRenderStyle style) {
     return kWhiteModelStyleValue.data();
   case Viewer3DRenderStyle::Textured:
     return kTexturedStyleValue.data();
+  case Viewer3DRenderStyle::Wireframe:
+    return kWireframeStyleValue.data();
+  case Viewer3DRenderStyle::ByDeviceType:
+    return kByDeviceTypeStyleValue.data();
+  case Viewer3DRenderStyle::ByLayer:
+    return kByLayerStyleValue.data();
+  case Viewer3DRenderStyle::ByUniverse:
+    return kByUniverseStyleValue.data();
   case Viewer3DRenderStyle::Standard:
   default:
     return kStandardStyleValue.data();
@@ -33,10 +53,12 @@ const char *ToConfigValue(Viewer3DRenderStyle style) {
 }
 
 bool IsWhiteModelRenderStyle(Viewer3DRenderStyle style) {
-  return style == Viewer3DRenderStyle::WhiteModel;
+  return style == Viewer3DRenderStyle::WhiteModel ||
+         style == Viewer3DRenderStyle::ByDeviceType ||
+         style == Viewer3DRenderStyle::ByLayer ||
+         style == Viewer3DRenderStyle::ByUniverse;
 }
 
 bool IsTexturedRenderStyle(Viewer3DRenderStyle style) {
   return style == Viewer3DRenderStyle::Textured;
 }
-

--- a/viewer3d/render/viewer3d_render_style.h
+++ b/viewer3d/render/viewer3d_render_style.h
@@ -6,6 +6,7 @@ class ConfigManager;
 
 enum class Viewer3DRenderStyle {
   Standard,
+  White,
   WhiteModel,
   Textured,
   Wireframe,

--- a/viewer3d/render/viewer3d_render_style.h
+++ b/viewer3d/render/viewer3d_render_style.h
@@ -7,11 +7,14 @@ class ConfigManager;
 enum class Viewer3DRenderStyle {
   Standard,
   WhiteModel,
-  Textured
+  Textured,
+  Wireframe,
+  ByDeviceType,
+  ByLayer,
+  ByUniverse
 };
 
 Viewer3DRenderStyle ResolveViewer3DRenderStyle(const ConfigManager &cfg);
 const char *ToConfigValue(Viewer3DRenderStyle style);
 bool IsWhiteModelRenderStyle(Viewer3DRenderStyle style);
 bool IsTexturedRenderStyle(Viewer3DRenderStyle style);
-

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -986,10 +986,9 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
   context.drawGridBeforeScene = shouldDrawGridBeforeScene;
   context.drawGridAfterScene = shouldDrawGridAfterScene;
 
-  context.colorByFixtureType =
-      context.wireframe && isByFixtureTypeMode;
-  context.colorByLayer = context.wireframe && isByLayerMode;
-  context.colorByUniverse = context.wireframe && isByUniverseMode;
+  context.colorByFixtureType = isByFixtureTypeMode;
+  context.colorByLayer = isByLayerMode;
+  context.colorByUniverse = isByUniverseMode;
   const Viewer3DRenderStyle renderStyle = ReadRenderStylePreference(cfg);
   context.whiteModelStyle = IsWhiteModelRenderStyle(renderStyle);
   context.texturedStyle = IsTexturedRenderStyle(renderStyle);

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -112,7 +112,8 @@ Viewer2DRenderMode ToSceneRenderMode(Viewer3DRenderStyle style) {
 }
 
 void ApplyViewer3DClearColorForStyle(Viewer3DRenderStyle style) {
-    if (style == Viewer3DRenderStyle::WhiteModel) {
+    if (style == Viewer3DRenderStyle::Wireframe ||
+        IsWhiteModelRenderStyle(style)) {
         glClearColor(0.95f, 0.95f, 0.95f, 1.0f);
         return;
     }

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -85,26 +85,54 @@ bool IsFastInteractionModeEnabled()
     return ConfigManager::Get().GetFloat("viewer3d_fast_interaction_mode") >= 0.5f;
 }
 
-Viewer2DRenderMode ResolveViewerRenderModePreference() {
-    const int mode = static_cast<int>(ConfigManager::Get().GetFloat("view2d_render_mode"));
+enum class Viewer3DViewportRenderMode {
+    Solid = 0,
+    Wireframe = 1,
+    ByDeviceType = 2,
+    ByLayer = 3,
+    ByUniverse = 4
+};
+
+Viewer3DViewportRenderMode ResolveViewer3DRenderModePreference() {
+    const int mode = static_cast<int>(ConfigManager::Get().GetFloat("viewer3d_render_mode"));
     switch (mode) {
-        case static_cast<int>(Viewer2DRenderMode::Wireframe):
-            return Viewer2DRenderMode::Wireframe;
-        case static_cast<int>(Viewer2DRenderMode::White):
-            return Viewer2DRenderMode::White;
-        case static_cast<int>(Viewer2DRenderMode::ByFixtureType):
-            return Viewer2DRenderMode::ByFixtureType;
-        case static_cast<int>(Viewer2DRenderMode::ByLayer):
-            return Viewer2DRenderMode::ByLayer;
-        case static_cast<int>(Viewer2DRenderMode::ByUniverse):
-            return Viewer2DRenderMode::ByUniverse;
+        case static_cast<int>(Viewer3DViewportRenderMode::Wireframe):
+            return Viewer3DViewportRenderMode::Wireframe;
+        case static_cast<int>(Viewer3DViewportRenderMode::ByDeviceType):
+            return Viewer3DViewportRenderMode::ByDeviceType;
+        case static_cast<int>(Viewer3DViewportRenderMode::ByLayer):
+            return Viewer3DViewportRenderMode::ByLayer;
+        case static_cast<int>(Viewer3DViewportRenderMode::ByUniverse):
+            return Viewer3DViewportRenderMode::ByUniverse;
+        case static_cast<int>(Viewer3DViewportRenderMode::Solid):
+            return Viewer3DViewportRenderMode::Solid;
         default:
-            return Viewer2DRenderMode::White;
+            return Viewer3DViewportRenderMode::Solid;
     }
 }
 
 Viewer3DRenderStyle ResolveRenderStyleFromPreferences() {
     return ResolveViewer3DRenderStyle(ConfigManager::Get());
+}
+
+bool IsWireframeRenderMode(Viewer3DViewportRenderMode mode) {
+    return mode != Viewer3DViewportRenderMode::Solid;
+}
+
+Viewer2DRenderMode ToSceneRenderMode(Viewer3DViewportRenderMode mode) {
+    switch (mode) {
+        case Viewer3DViewportRenderMode::Wireframe:
+            return Viewer2DRenderMode::Wireframe;
+        case Viewer3DViewportRenderMode::ByDeviceType:
+            return Viewer2DRenderMode::ByFixtureType;
+        case Viewer3DViewportRenderMode::ByLayer:
+            return Viewer2DRenderMode::ByLayer;
+        case Viewer3DViewportRenderMode::ByUniverse:
+            return Viewer2DRenderMode::ByUniverse;
+        case Viewer3DViewportRenderMode::Solid:
+        default:
+            return Viewer2DRenderMode::White;
+    }
 }
 
 void ApplyViewer3DClearColorForStyle(Viewer3DRenderStyle style) {
@@ -563,7 +591,9 @@ void Viewer3DPanel::Render()
     }
 
     m_controller.SetCameraMoving(m_cameraMoving);
-    m_controller.RenderScene(false, ResolveViewerRenderModePreference());
+    const Viewer3DViewportRenderMode renderMode = ResolveViewer3DRenderModePreference();
+    m_controller.RenderScene(IsWireframeRenderMode(renderMode),
+                             ToSceneRenderMode(renderMode));
 
     glFlush();
 }
@@ -778,11 +808,6 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent& event)
     if (m_draggedSincePress)
         return;
 
-    if (!(FixtureTablePanel::Instance() && FixtureTablePanel::Instance()->IsActivePage())) {
-        event.Skip();
-        return;
-    }
-
     int w, h;
     GetClientSize(&w, &h);
     if (w <= 0 || h <= 0 || !IsShownOnScreen()) {
@@ -790,43 +815,48 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent& event)
         return;
     }
 
-    SetCurrent(*m_glContext);
-    wxString label;
-    wxPoint pos;
-    std::string hitUuid;
-    if (m_controller.GetFixtureLabelAt(event.GetX(), event.GetY(), w, h, label, pos, &hitUuid)) {
-        event.Skip();
-        return;
-    }
-
+    const bool fixturePageActive =
+        FixtureTablePanel::Instance() && FixtureTablePanel::Instance()->IsActivePage();
     const auto& scene = ConfigManager::Get().GetScene();
-    if (scene.fixtures.empty())
-        return;
-
     std::set<std::string> typeNames;
     std::set<std::string> positionNames;
     bool hasNoPosition = false;
-    for (const auto& [uuid, fixture] : scene.fixtures) {
-        if (!fixture.typeName.empty())
-            typeNames.insert(fixture.typeName);
-        if (fixture.positionName.empty())
-            hasNoPosition = true;
-        else
-            positionNames.insert(fixture.positionName);
+    bool showSelectionSubmenus = false;
+    if (fixturePageActive && !scene.fixtures.empty()) {
+        SetCurrent(*m_glContext);
+        wxString label;
+        wxPoint pos;
+        std::string hitUuid;
+        if (!m_controller.GetFixtureLabelAt(event.GetX(), event.GetY(), w, h, label, pos,
+                                            &hitUuid)) {
+            for (const auto& [uuid, fixture] : scene.fixtures) {
+                if (!fixture.typeName.empty())
+                    typeNames.insert(fixture.typeName);
+                if (fixture.positionName.empty())
+                    hasNoPosition = true;
+                else
+                    positionNames.insert(fixture.positionName);
+            }
+            showSelectionSubmenus = true;
+        }
     }
 
     wxMenu rootMenu;
     auto typeSubmenu = std::make_unique<wxMenu>();
     auto positionSubmenu = std::make_unique<wxMenu>();
+    auto renderStyleSubmenu = std::make_unique<wxMenu>();
     auto renderModeSubmenu = std::make_unique<wxMenu>();
 
     constexpr int kSelectTypeAllId = wxID_HIGHEST + 900;
     constexpr int kSelectTypeBaseId = wxID_HIGHEST + 901;
     constexpr int kSelectPositionNoneId = wxID_HIGHEST + 1100;
     constexpr int kSelectPositionBaseId = wxID_HIGHEST + 1101;
-    constexpr int kRenderModeWireframeId = wxID_HIGHEST + 1300;
-    constexpr int kRenderModeWhiteId = wxID_HIGHEST + 1301;
-    constexpr int kRenderModeByFixtureTypeId = wxID_HIGHEST + 1302;
+    constexpr int kRenderStyleStandardId = wxID_HIGHEST + 1200;
+    constexpr int kRenderStyleWhiteModelId = wxID_HIGHEST + 1201;
+    constexpr int kRenderStyleTexturedId = wxID_HIGHEST + 1202;
+    constexpr int kRenderModeSolidId = wxID_HIGHEST + 1300;
+    constexpr int kRenderModeWireframeId = wxID_HIGHEST + 1301;
+    constexpr int kRenderModeByDeviceTypeId = wxID_HIGHEST + 1302;
     constexpr int kRenderModeByLayerId = wxID_HIGHEST + 1303;
     constexpr int kRenderModeByUniverseId = wxID_HIGHEST + 1304;
 
@@ -848,63 +878,101 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent& event)
         positionSubmenu->Append(nextPositionId++, wxString::FromUTF8(positionName));
     }
 
-    renderModeSubmenu->AppendRadioItem(kRenderModeWireframeId, "Wireframe");
-    renderModeSubmenu->AppendRadioItem(kRenderModeWhiteId, "White");
-    renderModeSubmenu->AppendRadioItem(kRenderModeByFixtureTypeId, "By fixture type");
-    renderModeSubmenu->AppendRadioItem(kRenderModeByLayerId, "By layer");
-    renderModeSubmenu->AppendRadioItem(kRenderModeByUniverseId, "By universe");
-    const Viewer2DRenderMode activeRenderMode = ResolveViewerRenderModePreference();
-    switch (activeRenderMode) {
-        case Viewer2DRenderMode::Wireframe:
-            renderModeSubmenu->Check(kRenderModeWireframeId, true);
+    renderStyleSubmenu->AppendRadioItem(kRenderStyleStandardId, "Standard");
+    renderStyleSubmenu->AppendRadioItem(kRenderStyleWhiteModelId, "White model");
+    renderStyleSubmenu->AppendRadioItem(kRenderStyleTexturedId, "Textured");
+    const Viewer3DRenderStyle activeRenderStyle = ResolveRenderStyleFromPreferences();
+    switch (activeRenderStyle) {
+        case Viewer3DRenderStyle::WhiteModel:
+            renderStyleSubmenu->Check(kRenderStyleWhiteModelId, true);
             break;
-        case Viewer2DRenderMode::ByFixtureType:
-            renderModeSubmenu->Check(kRenderModeByFixtureTypeId, true);
+        case Viewer3DRenderStyle::Textured:
+            renderStyleSubmenu->Check(kRenderStyleTexturedId, true);
             break;
-        case Viewer2DRenderMode::ByLayer:
-            renderModeSubmenu->Check(kRenderModeByLayerId, true);
-            break;
-        case Viewer2DRenderMode::ByUniverse:
-            renderModeSubmenu->Check(kRenderModeByUniverseId, true);
-            break;
-        case Viewer2DRenderMode::White:
+        case Viewer3DRenderStyle::Standard:
         default:
-            renderModeSubmenu->Check(kRenderModeWhiteId, true);
+            renderStyleSubmenu->Check(kRenderStyleStandardId, true);
             break;
     }
 
-    rootMenu.AppendSubMenu(typeSubmenu.release(), "Select by fixture type");
-    rootMenu.AppendSubMenu(positionSubmenu.release(), "Select by position");
-    rootMenu.AppendSeparator();
+    renderModeSubmenu->AppendRadioItem(kRenderModeSolidId, "Solid");
+    renderModeSubmenu->AppendRadioItem(kRenderModeWireframeId, "Wireframe");
+    renderModeSubmenu->AppendRadioItem(kRenderModeByDeviceTypeId, "By device type");
+    renderModeSubmenu->AppendRadioItem(kRenderModeByLayerId, "By layer");
+    renderModeSubmenu->AppendRadioItem(kRenderModeByUniverseId, "By universe");
+    const Viewer3DViewportRenderMode activeRenderMode = ResolveViewer3DRenderModePreference();
+    switch (activeRenderMode) {
+        case Viewer3DViewportRenderMode::Wireframe:
+            renderModeSubmenu->Check(kRenderModeWireframeId, true);
+            break;
+        case Viewer3DViewportRenderMode::ByDeviceType:
+            renderModeSubmenu->Check(kRenderModeByDeviceTypeId, true);
+            break;
+        case Viewer3DViewportRenderMode::ByLayer:
+            renderModeSubmenu->Check(kRenderModeByLayerId, true);
+            break;
+        case Viewer3DViewportRenderMode::ByUniverse:
+            renderModeSubmenu->Check(kRenderModeByUniverseId, true);
+            break;
+        case Viewer3DViewportRenderMode::Solid:
+        default:
+            renderModeSubmenu->Check(kRenderModeSolidId, true);
+            break;
+    }
+
+    if (showSelectionSubmenus) {
+        rootMenu.AppendSubMenu(typeSubmenu.release(), "Select by fixture type");
+        rootMenu.AppendSubMenu(positionSubmenu.release(), "Select by position");
+        rootMenu.AppendSeparator();
+    }
+    rootMenu.AppendSubMenu(renderStyleSubmenu.release(), "Render style");
     rootMenu.AppendSubMenu(renderModeSubmenu.release(), "Render mode");
 
     const int selectedId = GetPopupMenuSelectionFromUser(rootMenu, event.GetPosition());
     if (selectedId == wxID_NONE)
         return;
 
-    auto applyRenderModeSelection = [this](Viewer2DRenderMode mode) {
-        ConfigManager::Get().SetFloat("view2d_render_mode", static_cast<float>(mode));
+    auto applyRenderStyleSelection = [this](Viewer3DRenderStyle style) {
+        ConfigManager::Get().SetValue("viewer3d_render_style", ToConfigValue(style));
         Refresh();
     };
 
+    if (selectedId == kRenderStyleStandardId) {
+        applyRenderStyleSelection(Viewer3DRenderStyle::Standard);
+        return;
+    }
+    if (selectedId == kRenderStyleWhiteModelId) {
+        applyRenderStyleSelection(Viewer3DRenderStyle::WhiteModel);
+        return;
+    }
+    if (selectedId == kRenderStyleTexturedId) {
+        applyRenderStyleSelection(Viewer3DRenderStyle::Textured);
+        return;
+    }
+
+    auto applyRenderModeSelection = [this](Viewer3DViewportRenderMode mode) {
+        ConfigManager::Get().SetFloat("viewer3d_render_mode", static_cast<float>(mode));
+        Refresh();
+    };
+
+    if (selectedId == kRenderModeSolidId) {
+        applyRenderModeSelection(Viewer3DViewportRenderMode::Solid);
+        return;
+    }
     if (selectedId == kRenderModeWireframeId) {
-        applyRenderModeSelection(Viewer2DRenderMode::Wireframe);
+        applyRenderModeSelection(Viewer3DViewportRenderMode::Wireframe);
         return;
     }
-    if (selectedId == kRenderModeWhiteId) {
-        applyRenderModeSelection(Viewer2DRenderMode::White);
-        return;
-    }
-    if (selectedId == kRenderModeByFixtureTypeId) {
-        applyRenderModeSelection(Viewer2DRenderMode::ByFixtureType);
+    if (selectedId == kRenderModeByDeviceTypeId) {
+        applyRenderModeSelection(Viewer3DViewportRenderMode::ByDeviceType);
         return;
     }
     if (selectedId == kRenderModeByLayerId) {
-        applyRenderModeSelection(Viewer2DRenderMode::ByLayer);
+        applyRenderModeSelection(Viewer3DViewportRenderMode::ByLayer);
         return;
     }
     if (selectedId == kRenderModeByUniverseId) {
-        applyRenderModeSelection(Viewer2DRenderMode::ByUniverse);
+        applyRenderModeSelection(Viewer3DViewportRenderMode::ByUniverse);
         return;
     }
 

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -85,51 +85,27 @@ bool IsFastInteractionModeEnabled()
     return ConfigManager::Get().GetFloat("viewer3d_fast_interaction_mode") >= 0.5f;
 }
 
-enum class Viewer3DViewportRenderMode {
-    Solid = 0,
-    Wireframe = 1,
-    ByDeviceType = 2,
-    ByLayer = 3,
-    ByUniverse = 4
-};
-
-Viewer3DViewportRenderMode ResolveViewer3DRenderModePreference() {
-    const int mode = static_cast<int>(ConfigManager::Get().GetFloat("viewer3d_render_mode"));
-    switch (mode) {
-        case static_cast<int>(Viewer3DViewportRenderMode::Wireframe):
-            return Viewer3DViewportRenderMode::Wireframe;
-        case static_cast<int>(Viewer3DViewportRenderMode::ByDeviceType):
-            return Viewer3DViewportRenderMode::ByDeviceType;
-        case static_cast<int>(Viewer3DViewportRenderMode::ByLayer):
-            return Viewer3DViewportRenderMode::ByLayer;
-        case static_cast<int>(Viewer3DViewportRenderMode::ByUniverse):
-            return Viewer3DViewportRenderMode::ByUniverse;
-        case static_cast<int>(Viewer3DViewportRenderMode::Solid):
-            return Viewer3DViewportRenderMode::Solid;
-        default:
-            return Viewer3DViewportRenderMode::Solid;
-    }
-}
-
 Viewer3DRenderStyle ResolveRenderStyleFromPreferences() {
     return ResolveViewer3DRenderStyle(ConfigManager::Get());
 }
 
-bool IsWireframeRenderMode(Viewer3DViewportRenderMode mode) {
-    return mode != Viewer3DViewportRenderMode::Solid;
+bool IsWireframeRenderStyle(Viewer3DRenderStyle style) {
+    return style == Viewer3DRenderStyle::Wireframe;
 }
 
-Viewer2DRenderMode ToSceneRenderMode(Viewer3DViewportRenderMode mode) {
-    switch (mode) {
-        case Viewer3DViewportRenderMode::Wireframe:
+Viewer2DRenderMode ToSceneRenderMode(Viewer3DRenderStyle style) {
+    switch (style) {
+        case Viewer3DRenderStyle::Wireframe:
             return Viewer2DRenderMode::Wireframe;
-        case Viewer3DViewportRenderMode::ByDeviceType:
+        case Viewer3DRenderStyle::ByDeviceType:
             return Viewer2DRenderMode::ByFixtureType;
-        case Viewer3DViewportRenderMode::ByLayer:
+        case Viewer3DRenderStyle::ByLayer:
             return Viewer2DRenderMode::ByLayer;
-        case Viewer3DViewportRenderMode::ByUniverse:
+        case Viewer3DRenderStyle::ByUniverse:
             return Viewer2DRenderMode::ByUniverse;
-        case Viewer3DViewportRenderMode::Solid:
+        case Viewer3DRenderStyle::WhiteModel:
+        case Viewer3DRenderStyle::Textured:
+        case Viewer3DRenderStyle::Standard:
         default:
             return Viewer2DRenderMode::White;
     }
@@ -591,9 +567,9 @@ void Viewer3DPanel::Render()
     }
 
     m_controller.SetCameraMoving(m_cameraMoving);
-    const Viewer3DViewportRenderMode renderMode = ResolveViewer3DRenderModePreference();
-    m_controller.RenderScene(IsWireframeRenderMode(renderMode),
-                             ToSceneRenderMode(renderMode));
+    const Viewer3DRenderStyle renderStyle = ResolveRenderStyleFromPreferences();
+    m_controller.RenderScene(IsWireframeRenderStyle(renderStyle),
+                             ToSceneRenderMode(renderStyle));
 
     glFlush();
 }
@@ -845,7 +821,6 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent& event)
     auto typeSubmenu = std::make_unique<wxMenu>();
     auto positionSubmenu = std::make_unique<wxMenu>();
     auto renderStyleSubmenu = std::make_unique<wxMenu>();
-    auto renderModeSubmenu = std::make_unique<wxMenu>();
 
     constexpr int kSelectTypeAllId = wxID_HIGHEST + 900;
     constexpr int kSelectTypeBaseId = wxID_HIGHEST + 901;
@@ -854,11 +829,10 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent& event)
     constexpr int kRenderStyleStandardId = wxID_HIGHEST + 1200;
     constexpr int kRenderStyleWhiteModelId = wxID_HIGHEST + 1201;
     constexpr int kRenderStyleTexturedId = wxID_HIGHEST + 1202;
-    constexpr int kRenderModeSolidId = wxID_HIGHEST + 1300;
-    constexpr int kRenderModeWireframeId = wxID_HIGHEST + 1301;
-    constexpr int kRenderModeByDeviceTypeId = wxID_HIGHEST + 1302;
-    constexpr int kRenderModeByLayerId = wxID_HIGHEST + 1303;
-    constexpr int kRenderModeByUniverseId = wxID_HIGHEST + 1304;
+    constexpr int kRenderStyleWireframeId = wxID_HIGHEST + 1203;
+    constexpr int kRenderStyleByDeviceTypeId = wxID_HIGHEST + 1204;
+    constexpr int kRenderStyleByLayerId = wxID_HIGHEST + 1205;
+    constexpr int kRenderStyleByUniverseId = wxID_HIGHEST + 1206;
 
     typeSubmenu->Append(kSelectTypeAllId, "All fixtures");
     std::vector<std::string> orderedTypes;
@@ -881,8 +855,24 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent& event)
     renderStyleSubmenu->AppendRadioItem(kRenderStyleStandardId, "Standard");
     renderStyleSubmenu->AppendRadioItem(kRenderStyleWhiteModelId, "White model");
     renderStyleSubmenu->AppendRadioItem(kRenderStyleTexturedId, "Textured");
+    renderStyleSubmenu->AppendRadioItem(kRenderStyleWireframeId, "Wireframe");
+    renderStyleSubmenu->AppendRadioItem(kRenderStyleByDeviceTypeId, "By device type");
+    renderStyleSubmenu->AppendRadioItem(kRenderStyleByLayerId, "By layer");
+    renderStyleSubmenu->AppendRadioItem(kRenderStyleByUniverseId, "By universe");
     const Viewer3DRenderStyle activeRenderStyle = ResolveRenderStyleFromPreferences();
     switch (activeRenderStyle) {
+        case Viewer3DRenderStyle::Wireframe:
+            renderStyleSubmenu->Check(kRenderStyleWireframeId, true);
+            break;
+        case Viewer3DRenderStyle::ByDeviceType:
+            renderStyleSubmenu->Check(kRenderStyleByDeviceTypeId, true);
+            break;
+        case Viewer3DRenderStyle::ByLayer:
+            renderStyleSubmenu->Check(kRenderStyleByLayerId, true);
+            break;
+        case Viewer3DRenderStyle::ByUniverse:
+            renderStyleSubmenu->Check(kRenderStyleByUniverseId, true);
+            break;
         case Viewer3DRenderStyle::WhiteModel:
             renderStyleSubmenu->Check(kRenderStyleWhiteModelId, true);
             break;
@@ -895,38 +885,12 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent& event)
             break;
     }
 
-    renderModeSubmenu->AppendRadioItem(kRenderModeSolidId, "Solid");
-    renderModeSubmenu->AppendRadioItem(kRenderModeWireframeId, "Wireframe");
-    renderModeSubmenu->AppendRadioItem(kRenderModeByDeviceTypeId, "By device type");
-    renderModeSubmenu->AppendRadioItem(kRenderModeByLayerId, "By layer");
-    renderModeSubmenu->AppendRadioItem(kRenderModeByUniverseId, "By universe");
-    const Viewer3DViewportRenderMode activeRenderMode = ResolveViewer3DRenderModePreference();
-    switch (activeRenderMode) {
-        case Viewer3DViewportRenderMode::Wireframe:
-            renderModeSubmenu->Check(kRenderModeWireframeId, true);
-            break;
-        case Viewer3DViewportRenderMode::ByDeviceType:
-            renderModeSubmenu->Check(kRenderModeByDeviceTypeId, true);
-            break;
-        case Viewer3DViewportRenderMode::ByLayer:
-            renderModeSubmenu->Check(kRenderModeByLayerId, true);
-            break;
-        case Viewer3DViewportRenderMode::ByUniverse:
-            renderModeSubmenu->Check(kRenderModeByUniverseId, true);
-            break;
-        case Viewer3DViewportRenderMode::Solid:
-        default:
-            renderModeSubmenu->Check(kRenderModeSolidId, true);
-            break;
-    }
-
     if (showSelectionSubmenus) {
         rootMenu.AppendSubMenu(typeSubmenu.release(), "Select by fixture type");
         rootMenu.AppendSubMenu(positionSubmenu.release(), "Select by position");
         rootMenu.AppendSeparator();
     }
     rootMenu.AppendSubMenu(renderStyleSubmenu.release(), "Render style");
-    rootMenu.AppendSubMenu(renderModeSubmenu.release(), "Render mode");
 
     const int selectedId = GetPopupMenuSelectionFromUser(rootMenu, event.GetPosition());
     if (selectedId == wxID_NONE)
@@ -949,30 +913,20 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent& event)
         applyRenderStyleSelection(Viewer3DRenderStyle::Textured);
         return;
     }
-
-    auto applyRenderModeSelection = [this](Viewer3DViewportRenderMode mode) {
-        ConfigManager::Get().SetFloat("viewer3d_render_mode", static_cast<float>(mode));
-        Refresh();
-    };
-
-    if (selectedId == kRenderModeSolidId) {
-        applyRenderModeSelection(Viewer3DViewportRenderMode::Solid);
+    if (selectedId == kRenderStyleWireframeId) {
+        applyRenderStyleSelection(Viewer3DRenderStyle::Wireframe);
         return;
     }
-    if (selectedId == kRenderModeWireframeId) {
-        applyRenderModeSelection(Viewer3DViewportRenderMode::Wireframe);
+    if (selectedId == kRenderStyleByDeviceTypeId) {
+        applyRenderStyleSelection(Viewer3DRenderStyle::ByDeviceType);
         return;
     }
-    if (selectedId == kRenderModeByDeviceTypeId) {
-        applyRenderModeSelection(Viewer3DViewportRenderMode::ByDeviceType);
+    if (selectedId == kRenderStyleByLayerId) {
+        applyRenderStyleSelection(Viewer3DRenderStyle::ByLayer);
         return;
     }
-    if (selectedId == kRenderModeByLayerId) {
-        applyRenderModeSelection(Viewer3DViewportRenderMode::ByLayer);
-        return;
-    }
-    if (selectedId == kRenderModeByUniverseId) {
-        applyRenderModeSelection(Viewer3DViewportRenderMode::ByUniverse);
+    if (selectedId == kRenderStyleByUniverseId) {
+        applyRenderStyleSelection(Viewer3DRenderStyle::ByUniverse);
         return;
     }
 

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -85,6 +85,24 @@ bool IsFastInteractionModeEnabled()
     return ConfigManager::Get().GetFloat("viewer3d_fast_interaction_mode") >= 0.5f;
 }
 
+Viewer2DRenderMode ResolveViewerRenderModePreference() {
+    const int mode = static_cast<int>(ConfigManager::Get().GetFloat("view2d_render_mode"));
+    switch (mode) {
+        case static_cast<int>(Viewer2DRenderMode::Wireframe):
+            return Viewer2DRenderMode::Wireframe;
+        case static_cast<int>(Viewer2DRenderMode::White):
+            return Viewer2DRenderMode::White;
+        case static_cast<int>(Viewer2DRenderMode::ByFixtureType):
+            return Viewer2DRenderMode::ByFixtureType;
+        case static_cast<int>(Viewer2DRenderMode::ByLayer):
+            return Viewer2DRenderMode::ByLayer;
+        case static_cast<int>(Viewer2DRenderMode::ByUniverse):
+            return Viewer2DRenderMode::ByUniverse;
+        default:
+            return Viewer2DRenderMode::White;
+    }
+}
+
 Viewer3DRenderStyle ResolveRenderStyleFromPreferences() {
     return ResolveViewer3DRenderStyle(ConfigManager::Get());
 }
@@ -545,7 +563,7 @@ void Viewer3DPanel::Render()
     }
 
     m_controller.SetCameraMoving(m_cameraMoving);
-    m_controller.RenderScene();
+    m_controller.RenderScene(false, ResolveViewerRenderModePreference());
 
     glFlush();
 }
@@ -800,11 +818,17 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent& event)
     wxMenu rootMenu;
     auto typeSubmenu = std::make_unique<wxMenu>();
     auto positionSubmenu = std::make_unique<wxMenu>();
+    auto renderModeSubmenu = std::make_unique<wxMenu>();
 
     constexpr int kSelectTypeAllId = wxID_HIGHEST + 900;
     constexpr int kSelectTypeBaseId = wxID_HIGHEST + 901;
     constexpr int kSelectPositionNoneId = wxID_HIGHEST + 1100;
     constexpr int kSelectPositionBaseId = wxID_HIGHEST + 1101;
+    constexpr int kRenderModeWireframeId = wxID_HIGHEST + 1300;
+    constexpr int kRenderModeWhiteId = wxID_HIGHEST + 1301;
+    constexpr int kRenderModeByFixtureTypeId = wxID_HIGHEST + 1302;
+    constexpr int kRenderModeByLayerId = wxID_HIGHEST + 1303;
+    constexpr int kRenderModeByUniverseId = wxID_HIGHEST + 1304;
 
     typeSubmenu->Append(kSelectTypeAllId, "All fixtures");
     std::vector<std::string> orderedTypes;
@@ -824,12 +848,65 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent& event)
         positionSubmenu->Append(nextPositionId++, wxString::FromUTF8(positionName));
     }
 
+    renderModeSubmenu->AppendRadioItem(kRenderModeWireframeId, "Wireframe");
+    renderModeSubmenu->AppendRadioItem(kRenderModeWhiteId, "White");
+    renderModeSubmenu->AppendRadioItem(kRenderModeByFixtureTypeId, "By fixture type");
+    renderModeSubmenu->AppendRadioItem(kRenderModeByLayerId, "By layer");
+    renderModeSubmenu->AppendRadioItem(kRenderModeByUniverseId, "By universe");
+    const Viewer2DRenderMode activeRenderMode = ResolveViewerRenderModePreference();
+    switch (activeRenderMode) {
+        case Viewer2DRenderMode::Wireframe:
+            renderModeSubmenu->Check(kRenderModeWireframeId, true);
+            break;
+        case Viewer2DRenderMode::ByFixtureType:
+            renderModeSubmenu->Check(kRenderModeByFixtureTypeId, true);
+            break;
+        case Viewer2DRenderMode::ByLayer:
+            renderModeSubmenu->Check(kRenderModeByLayerId, true);
+            break;
+        case Viewer2DRenderMode::ByUniverse:
+            renderModeSubmenu->Check(kRenderModeByUniverseId, true);
+            break;
+        case Viewer2DRenderMode::White:
+        default:
+            renderModeSubmenu->Check(kRenderModeWhiteId, true);
+            break;
+    }
+
     rootMenu.AppendSubMenu(typeSubmenu.release(), "Select by fixture type");
     rootMenu.AppendSubMenu(positionSubmenu.release(), "Select by position");
+    rootMenu.AppendSeparator();
+    rootMenu.AppendSubMenu(renderModeSubmenu.release(), "Render mode");
 
     const int selectedId = GetPopupMenuSelectionFromUser(rootMenu, event.GetPosition());
     if (selectedId == wxID_NONE)
         return;
+
+    auto applyRenderModeSelection = [this](Viewer2DRenderMode mode) {
+        ConfigManager::Get().SetFloat("view2d_render_mode", static_cast<float>(mode));
+        Refresh();
+    };
+
+    if (selectedId == kRenderModeWireframeId) {
+        applyRenderModeSelection(Viewer2DRenderMode::Wireframe);
+        return;
+    }
+    if (selectedId == kRenderModeWhiteId) {
+        applyRenderModeSelection(Viewer2DRenderMode::White);
+        return;
+    }
+    if (selectedId == kRenderModeByFixtureTypeId) {
+        applyRenderModeSelection(Viewer2DRenderMode::ByFixtureType);
+        return;
+    }
+    if (selectedId == kRenderModeByLayerId) {
+        applyRenderModeSelection(Viewer2DRenderMode::ByLayer);
+        return;
+    }
+    if (selectedId == kRenderModeByUniverseId) {
+        applyRenderModeSelection(Viewer2DRenderMode::ByUniverse);
+        return;
+    }
 
     if (selectedId == kSelectTypeAllId) {
         ApplyFixtureSelectionToUi(BuildFixtureSelectionByType(scene, ""), this,

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -567,7 +567,6 @@ void Viewer3DPanel::Render()
     }
 
     m_controller.SetCameraMoving(m_cameraMoving);
-    const Viewer3DRenderStyle renderStyle = ResolveRenderStyleFromPreferences();
     m_controller.RenderScene(IsWireframeRenderStyle(renderStyle),
                              ToSceneRenderMode(renderStyle));
 

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -855,10 +855,10 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent& event)
     }
 
     renderStyleSubmenu->AppendRadioItem(kRenderStyleStandardId, "Standard");
-    renderStyleSubmenu->AppendRadioItem(kRenderStyleWhiteId, "White");
     renderStyleSubmenu->AppendRadioItem(kRenderStyleSketchId, "Sketch mode");
     renderStyleSubmenu->AppendRadioItem(kRenderStyleTexturedId, "Textured");
     renderStyleSubmenu->AppendRadioItem(kRenderStyleWireframeId, "Wireframe");
+    renderStyleSubmenu->AppendRadioItem(kRenderStyleWhiteId, "White");
     renderStyleSubmenu->AppendRadioItem(kRenderStyleByDeviceTypeId, "By device type");
     renderStyleSubmenu->AppendRadioItem(kRenderStyleByLayerId, "By layer");
     renderStyleSubmenu->AppendRadioItem(kRenderStyleByUniverseId, "By universe");

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -103,6 +103,7 @@ Viewer2DRenderMode ToSceneRenderMode(Viewer3DRenderStyle style) {
             return Viewer2DRenderMode::ByLayer;
         case Viewer3DRenderStyle::ByUniverse:
             return Viewer2DRenderMode::ByUniverse;
+        case Viewer3DRenderStyle::White:
         case Viewer3DRenderStyle::WhiteModel:
         case Viewer3DRenderStyle::Textured:
         case Viewer3DRenderStyle::Standard:
@@ -827,12 +828,13 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent& event)
     constexpr int kSelectPositionNoneId = wxID_HIGHEST + 1100;
     constexpr int kSelectPositionBaseId = wxID_HIGHEST + 1101;
     constexpr int kRenderStyleStandardId = wxID_HIGHEST + 1200;
-    constexpr int kRenderStyleWhiteModelId = wxID_HIGHEST + 1201;
-    constexpr int kRenderStyleTexturedId = wxID_HIGHEST + 1202;
-    constexpr int kRenderStyleWireframeId = wxID_HIGHEST + 1203;
-    constexpr int kRenderStyleByDeviceTypeId = wxID_HIGHEST + 1204;
-    constexpr int kRenderStyleByLayerId = wxID_HIGHEST + 1205;
-    constexpr int kRenderStyleByUniverseId = wxID_HIGHEST + 1206;
+    constexpr int kRenderStyleWhiteId = wxID_HIGHEST + 1201;
+    constexpr int kRenderStyleSketchId = wxID_HIGHEST + 1202;
+    constexpr int kRenderStyleTexturedId = wxID_HIGHEST + 1203;
+    constexpr int kRenderStyleWireframeId = wxID_HIGHEST + 1204;
+    constexpr int kRenderStyleByDeviceTypeId = wxID_HIGHEST + 1205;
+    constexpr int kRenderStyleByLayerId = wxID_HIGHEST + 1206;
+    constexpr int kRenderStyleByUniverseId = wxID_HIGHEST + 1207;
 
     typeSubmenu->Append(kSelectTypeAllId, "All fixtures");
     std::vector<std::string> orderedTypes;
@@ -853,7 +855,8 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent& event)
     }
 
     renderStyleSubmenu->AppendRadioItem(kRenderStyleStandardId, "Standard");
-    renderStyleSubmenu->AppendRadioItem(kRenderStyleWhiteModelId, "White model");
+    renderStyleSubmenu->AppendRadioItem(kRenderStyleWhiteId, "White");
+    renderStyleSubmenu->AppendRadioItem(kRenderStyleSketchId, "Sketch mode");
     renderStyleSubmenu->AppendRadioItem(kRenderStyleTexturedId, "Textured");
     renderStyleSubmenu->AppendRadioItem(kRenderStyleWireframeId, "Wireframe");
     renderStyleSubmenu->AppendRadioItem(kRenderStyleByDeviceTypeId, "By device type");
@@ -873,8 +876,11 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent& event)
         case Viewer3DRenderStyle::ByUniverse:
             renderStyleSubmenu->Check(kRenderStyleByUniverseId, true);
             break;
+        case Viewer3DRenderStyle::White:
+            renderStyleSubmenu->Check(kRenderStyleWhiteId, true);
+            break;
         case Viewer3DRenderStyle::WhiteModel:
-            renderStyleSubmenu->Check(kRenderStyleWhiteModelId, true);
+            renderStyleSubmenu->Check(kRenderStyleSketchId, true);
             break;
         case Viewer3DRenderStyle::Textured:
             renderStyleSubmenu->Check(kRenderStyleTexturedId, true);
@@ -905,7 +911,11 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent& event)
         applyRenderStyleSelection(Viewer3DRenderStyle::Standard);
         return;
     }
-    if (selectedId == kRenderStyleWhiteModelId) {
+    if (selectedId == kRenderStyleWhiteId) {
+        applyRenderStyleSelection(Viewer3DRenderStyle::White);
+        return;
+    }
+    if (selectedId == kRenderStyleSketchId) {
         applyRenderStyleSelection(Viewer3DRenderStyle::WhiteModel);
         return;
     }


### PR DESCRIPTION
### Motivation
- Provide quick access to the viewer render modes from the 3D viewer right-click context menu so users can change `view2d_render_mode` without opening preferences. 
- Ensure the 3D panel consumes the configured render-mode preference each frame so the menu selection takes immediate effect.
- Keep the change small and local to the viewer UI code while observing the project hotspot guardrail for large files.

### Description
- Added `ResolveViewerRenderModePreference()` which reads `view2d_render_mode` from `ConfigManager` and returns the corresponding `Viewer2DRenderMode`. 
- Updated `Viewer3DPanel::Render()` to call `m_controller.RenderScene(false, ResolveViewerRenderModePreference())` so the panel uses the configured render mode per frame. 
- Extended `Viewer3DPanel::OnRightUp()` to append a `Render mode` submenu with radio items for `Wireframe`, `White`, `By fixture type`, `By layer`, and `By universe`, pre-check the active mode, and apply selections by writing `view2d_render_mode` via `ConfigManager::Get().SetFloat(...)` and calling `Refresh()`. 
- All changes are contained in `viewer3d/viewer3dpanel.cpp`; because this file is a hotspot and is >1200 LOC, the next recommended split if more context-menu responsibilities are added is to extract menu construction/dispatch to a dedicated helper unit.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccca5acaac8324a405cb9eb965a7d1)