### PR TITLE
Fixture lenses render white in 3D White mode

### DIFF
--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -672,9 +672,11 @@ void OpaqueFixturePass::Render(
                   float partG = g;
                   float partB = b;
                   if (!is2DViewer && obj.isLens) {
+                    const bool isWhiteRenderMode =
+                        mode == Viewer2DRenderMode::White;
                     partR = 1.0f;
-                    partG = 0.78f;
-                    partB = 0.35f;
+                    partG = isWhiteRenderMode ? 1.0f : 0.78f;
+                    partB = isWhiteRenderMode ? 1.0f : 0.35f;
                   }
                   controller.DrawMeshWithOutline(
                       obj.mesh, partR, partG, partB, RENDER_SCALE, false, false,
@@ -733,9 +735,10 @@ void OpaqueFixturePass::Render(
           float partG = g;
           float partB = b;
           if (!is2DViewer && obj.isLens) {
+            const bool isWhiteRenderMode = mode == Viewer2DRenderMode::White;
             partR = 1.0f;
-            partG = 0.78f;
-            partB = 0.35f;
+            partG = isWhiteRenderMode ? 1.0f : 0.78f;
+            partB = isWhiteRenderMode ? 1.0f : 0.35f;
           }
           const bool drawUnlit = !is2DViewer && obj.isLens;
           controller.DrawMeshWithOutline(obj.mesh, partR, partG, partB,


### PR DESCRIPTION
### Motivation
- Lens geometry in the 3D opaque fixture pass should render pure white when the viewer is in `White` render mode instead of the default amber tint so the white visualization mode shows neutral materials.

### Description
- Modified `viewer3d/render/opaque_fixture_pass.cpp` to set lens part color to `(1.0f, 1.0f, 1.0f)` when `mode == Viewer2DRenderMode::White` by adding an `isWhiteRenderMode` check in both the symbol-capture rendering path and the regular fixture geometry rendering path, leaving the amber/yellow tint unchanged for other modes.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which reported OK.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which reported OK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccea5732b8832488127ace7fb694d4)