### PR TITLE
Force pure white polygon fill in 3D White render mode

### DIFF
--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -222,12 +222,13 @@ void SceneRenderer::DrawMeshWithOutline(
 
   if (!m_controller.IsCaptureOnly()) {
     if (m_controller.IsWhiteModelStyleEnabled()) {
+      const bool usePureWhiteFillInWhiteMode =
+          !IsSketchRenderStyleEnabled() && mode == Viewer2DRenderMode::White;
       const bool useColorFillInWhiteStyle =
           !IsSketchRenderStyleEnabled() &&
-          (mode == Viewer2DRenderMode::White ||
-          mode == Viewer2DRenderMode::ByFixtureType ||
-          mode == Viewer2DRenderMode::ByLayer ||
-          mode == Viewer2DRenderMode::ByUniverse);
+          (mode == Viewer2DRenderMode::ByFixtureType ||
+           mode == Viewer2DRenderMode::ByLayer ||
+           mode == Viewer2DRenderMode::ByUniverse);
       // Keep 3D white-model aligned with the 2D viewer draw order:
       // stroke pass first, then polygon-offset fill pass.
       const LineRenderProfile lineProfile =
@@ -267,6 +268,14 @@ void SceneRenderer::DrawMeshWithOutline(
         if (!glIsEnabled(GL_LIGHTING))
           glEnable(GL_LIGHTING);
         DrawMesh(mesh, scale, modelMatrix);
+      } else if (usePureWhiteFillInWhiteMode) {
+        const GLboolean fillLightingWasEnabled = glIsEnabled(GL_LIGHTING);
+        if (fillLightingWasEnabled)
+          glDisable(GL_LIGHTING);
+        m_controller.SetGLColor(1.0f, 1.0f, 1.0f);
+        DrawMesh(mesh, scale, modelMatrix);
+        if (fillLightingWasEnabled)
+          glEnable(GL_LIGHTING);
       } else if (useColorFillInWhiteStyle) {
         const GLboolean fillLightingWasEnabled = glIsEnabled(GL_LIGHTING);
         if (fillLightingWasEnabled)


### PR DESCRIPTION
### Motivation
- The 3D "White" render mode was producing off-white/gray fills because object colors were used for polygon fills, but this mode is intended to be a strict two-ink (white + black) view. 

### Description
- Modified `SceneRenderer::DrawMeshWithOutline` in `viewer3d/render/scenerenderer.cpp` to introduce `usePureWhiteFillInWhiteMode` and separate the White-mode fill path from other white-model classification modes. 
- When the active mode is `Viewer2DRenderMode::White` the polygon fill is forced to pure white via `m_controller.SetGLColor(1.0f, 1.0f, 1.0f)` while preserving existing lighting state handling. 
- Kept the existing color-preserving flat fills for `ByFixtureType`, `ByLayer`, and `ByUniverse` modes and preserved the three-tone/sketch behavior for `WhiteModel` where intended. 
- No structural module boundary changes were introduced and the change is localized to the renderer file. 

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which returned OK. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which returned OK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccfad929948324beb641c17ca67d72)