### PR TITLE
Make white/by-* 3D render modes use pure white clear color

### DIFF
--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -113,8 +113,11 @@ Viewer2DRenderMode ToSceneRenderMode(Viewer3DRenderStyle style) {
 }
 
 void ApplyViewer3DClearColorForStyle(Viewer3DRenderStyle style) {
-    if (style == Viewer3DRenderStyle::Wireframe ||
-        IsWhiteModelRenderStyle(style)) {
+    if (IsWhiteModelRenderStyle(style)) {
+        glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
+        return;
+    }
+    if (style == Viewer3DRenderStyle::Wireframe) {
         glClearColor(0.95f, 0.95f, 0.95f, 1.0f);
         return;
     }


### PR DESCRIPTION
### Motivation
- The 3D viewer should present a completely white background for the "white" and all "by ..." render modes (ByDeviceType/ByLayer/ByUniverse) so rendered models appear on a pure white canvas.

### Description
- Change `ApplyViewer3DClearColorForStyle` in `viewer3d/viewer3dpanel.cpp` to call `glClearColor(1.0f, 1.0f, 1.0f, 1.0f)` when `IsWhiteModelRenderStyle(style)` is true, while keeping the existing light-gray clear color for `Viewer3DRenderStyle::Wireframe` and preserving `Textured`/`Standard` behavior.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both scripts completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd2201195883248991c6bb1ac80705)