### PR TITLE
Fix missing white-mode fill flag in SceneRenderer

### DIFF
--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -310,6 +310,8 @@ void SceneRenderer::DrawMeshWithOutline(
           (mode == Viewer2DRenderMode::ByFixtureType ||
            mode == Viewer2DRenderMode::ByLayer ||
            mode == Viewer2DRenderMode::ByUniverse);
+      const bool usePureWhiteFillInWhiteMode =
+          !IsSketchRenderStyleEnabled() && mode == Viewer2DRenderMode::White;
       // Keep 3D white-model aligned with the 2D viewer draw order:
       // stroke pass first, then polygon-offset fill pass.
       const LineRenderProfile lineProfile =


### PR DESCRIPTION
### Motivation
- Restore missing `usePureWhiteFillInWhiteMode` flag in `SceneRenderer::DrawMeshWithOutline` to fix build error `C2065` and ensure the "White" render mode uses a pure white fill consistent with the 2D viewer behavior.

### Description
- Add `const bool usePureWhiteFillInWhiteMode = !IsSketchRenderStyleEnabled() && mode == Viewer2DRenderMode::White;` to `viewer3d/render/scenerenderer.cpp` so the white-mode rendering branch selects a pure white fill when appropriate.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd2c2f2e288324b4e3f0e8e35793b7)