### PR TITLE
Wrap layout legend Type names into two lines (remove ellipsis)

### DIFF
--- a/gui/layoutviewerpanel_legend.cpp
+++ b/gui/layoutviewerpanel_legend.cpp
@@ -18,6 +18,7 @@
 #include "layoutviewerpanel.h"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <functional>
 #include <limits>
@@ -883,7 +884,10 @@ wxImage LayoutViewerPanel::BuildLegendImage(
                                                             wxFONTWEIGHT_BOLD);
   }
 
-  const int lineHeight = textHeight + separatorGapPx;
+  constexpr int kLegendTypeLineCount = 2;
+  const int lineHeight =
+      (textHeight * kLegendTypeLineCount) +
+      (separatorGapPx * std::max(0, kLegendTypeLineCount - 1));
   const double rowHeight = totalRows > 0 ? availableHeight / totalRows : 0.0;
   const int desiredRowHeightPx =
       std::max(lineHeight,
@@ -1123,30 +1127,55 @@ wxImage LayoutViewerPanel::BuildLegendImage(
     xCh = xType + columnGapPx;
   int typeWidth = std::max(0, xCh - xType - columnGapPx);
 
-  auto trimTextToWidth = [&](const wxString &text, int maxWidth) {
+  auto wrapTextToTwoLines = [&](const wxString &text, int maxWidth) {
     if (maxWidth <= 0)
-      return wxString();
-    int textWidth = measureTextWidth(text);
-    if (textWidth <= maxWidth)
-      return text;
-    wxString ellipsis = "...";
-    int ellipsisWidth = measureTextWidth(ellipsis);
-    if (ellipsisWidth >= maxWidth)
-      return ellipsis.Left(1);
-    wxString trimmed = text;
-    while (!trimmed.empty() &&
-           measureTextWidth(trimmed) + ellipsisWidth > maxWidth) {
-      trimmed.RemoveLast();
+      return std::array<wxString, 2>{wxString(), wxString()};
+
+    if (measureTextWidth(text) <= maxWidth)
+      return std::array<wxString, 2>{text, wxString()};
+
+    wxString firstLine = text;
+    int splitAt = -1;
+    for (int i = static_cast<int>(text.length()) - 1; i > 0; --i) {
+      if (text[static_cast<size_t>(i)] == ' ') {
+        wxString candidate = text.Left(static_cast<size_t>(i));
+        if (!candidate.empty() && measureTextWidth(candidate) <= maxWidth) {
+          splitAt = i;
+          break;
+        }
+      }
     }
-    return trimmed + ellipsis;
+
+    if (splitAt < 0) {
+      firstLine.clear();
+      for (size_t i = 0; i < text.length(); ++i) {
+        wxString candidate = text.Left(i + 1);
+        if (measureTextWidth(candidate) > maxWidth)
+          break;
+        firstLine = candidate;
+      }
+      if (firstLine.empty() && !text.empty())
+        firstLine = text.Left(1);
+    } else {
+      firstLine = text.Left(static_cast<size_t>(splitAt));
+    }
+
+    wxString secondLine = text.Mid(firstLine.length());
+    secondLine.Trim(true);
+    secondLine.Trim(false);
+    return std::array<wxString, 2>{firstLine, secondLine};
   };
 
   int y = paddingTopPx;
-  const int textOffset = std::max(0, (rowHeightPx - textHeight) / 2);
+  const int headerTextOffset = std::max(0, (rowHeightPx - textHeight) / 2);
+  const int rowSingleTextOffset = std::max(0, (rowHeightPx - textHeight) / 2);
+  const int typeBlockHeight =
+      (textHeight * kLegendTypeLineCount) + separatorGapPx;
+  const int rowTypeTextOffset = std::max(0, (rowHeightPx - typeBlockHeight) / 2);
   dc.SetFont(headerFont);
-  dc.DrawText("Count", xCount, y + textOffset);
-  dc.DrawText("Type", xType, y + textOffset);
-  dc.DrawText("Ch", xCh, y + textOffset);
+  dc.DrawText("Count", xCount, y + headerTextOffset);
+  dc.DrawText("Type", xType, y + headerTextOffset);
+  dc.DrawText("Ch", xCh, y + headerTextOffset);
 
   y += rowHeightPx;
   dc.SetPen(wxPen(wxColour(200, 200, 200)));
@@ -1160,7 +1189,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
     const auto &rowText = rowTexts[index];
     if (y + rowHeightPx > size.GetHeight() - paddingBottomPx)
       break;
-    wxString typeText = trimTextToWidth(rowText.typeText, typeWidth);
+    const auto wrappedType = wrapTextToTwoLines(rowText.typeText, typeWidth);
     if (!item.symbolKey.empty()) {
       const SymbolDefinition *topSymbol = FindSymbolDefinitionPreferred(
           symbols, item.symbolKey, SymbolViewKind::Bottom);
@@ -1283,9 +1312,12 @@ wxImage LayoutViewerPanel::BuildLegendImage(
                      symbolDrawTop);
       }
     }
-    dc.DrawText(rowText.countText, xCount, y + textOffset);
-    dc.DrawText(typeText, xType, y + textOffset);
-    dc.DrawText(rowText.chText, xCh, y + textOffset);
+    dc.DrawText(rowText.countText, xCount, y + rowSingleTextOffset);
+    dc.DrawText(wrappedType[0], xType, y + rowTypeTextOffset);
+    if (!wrappedType[1].empty())
+      dc.DrawText(wrappedType[1], xType,
+                  y + rowTypeTextOffset + textHeight + separatorGapPx);
+    dc.DrawText(rowText.chText, xCh, y + rowSingleTextOffset);
     y += rowHeightPx;
   }
 

--- a/viewer2d/pdf/layout_pdf_exporter.cpp
+++ b/viewer2d/pdf/layout_pdf_exporter.cpp
@@ -1382,6 +1382,7 @@ Viewer2DExportResult ExportLayoutToPdf(
     const double paddingBottom = 0.0;
     const double columnGap = 6.0;
     const double symbolColumnGap = 0.0;
+    constexpr int kLegendTypeLineCount = 2;
     constexpr double kLegendLineSpacingScale = 1.0;
     constexpr double kLegendSymbolColumnScale = 1.0;
     constexpr double kLegendMaxSymbolSlotScale = 1.45;
@@ -1399,14 +1400,21 @@ Viewer2DExportResult ExportLayoutToPdf(
         std::clamp(fontSize / (14.0 * kLegendFontScale), 0.0, 1.0);
 
     const double textHeightEstimate = fontSize * 1.2;
-    const double lineHeight = textHeightEstimate + separatorGap;
+    const double lineHeight =
+        (textHeightEstimate * static_cast<double>(kLegendTypeLineCount)) +
+        (separatorGap * static_cast<double>(std::max(0, kLegendTypeLineCount - 1)));
     const double rowHeightCandidate =
         totalRows > 0 ? (availableHeight / static_cast<double>(totalRows)) : 0.0;
     const double rowHeight =
         std::max(lineHeight,
                  rowHeightCandidate * kLegendLineSpacingScale);
-    const double textOffset =
+    const double singleTextOffset =
         std::max(0.0, (rowHeight - textHeightEstimate) * 0.5);
+    const double typeBlockHeight =
+        (textHeightEstimate * static_cast<double>(kLegendTypeLineCount)) +
+        separatorGap;
+    const double typeTextOffset =
+        std::max(0.0, (rowHeight - typeBlockHeight) * 0.5);
 
     const double symbolSize = std::max(4.0, kLegendSymbolSize * fontScale);
     const double fallbackSymbolSize =
@@ -1580,24 +1588,51 @@ Viewer2DExportResult ExportLayoutToPdf(
       xCh = xType + columnGap;
     const double typeWidth = std::max(0.0, xCh - xType - columnGap);
 
-    auto trimTextToWidth = [&](const std::string &text, double maxWidth) {
+    auto wrapTextToTwoLines = [&](const std::string &text, double maxWidth) {
       if (maxWidth <= 0.0)
-        return std::string();
+        return std::array<std::string, 2>{"", ""};
       if (MeasureTextWidth(text, fontSize, fontCatalog.regular) <= maxWidth)
-        return text;
-      const std::string ellipsis = "...";
-      const double ellipsisWidth =
-          MeasureTextWidth(ellipsis, fontSize, fontCatalog.regular);
-      if (ellipsisWidth >= maxWidth)
-        return std::string(".");
-      std::string trimmed = text;
-      while (!trimmed.empty() &&
-             MeasureTextWidth(trimmed, fontSize, fontCatalog.regular) +
-                     ellipsisWidth >
-                 maxWidth) {
-        trimmed.pop_back();
+        return std::array<std::string, 2>{text, ""};
+
+      std::string firstLine = text;
+      int splitAt = -1;
+      for (int i = static_cast<int>(text.size()) - 1; i > 0; --i) {
+        if (text[static_cast<size_t>(i)] == ' ') {
+          const std::string candidate = text.substr(0, static_cast<size_t>(i));
+          if (!candidate.empty() &&
+              MeasureTextWidth(candidate, fontSize, fontCatalog.regular) <=
+                  maxWidth) {
+            splitAt = i;
+            break;
+          }
+        }
       }
-      return trimmed + ellipsis;
+
+      if (splitAt < 0) {
+        firstLine.clear();
+        for (size_t i = 0; i < text.size(); ++i) {
+          const std::string candidate = text.substr(0, i + 1);
+          if (MeasureTextWidth(candidate, fontSize, fontCatalog.regular) >
+              maxWidth) {
+            break;
+          }
+          firstLine = candidate;
+        }
+        if (firstLine.empty() && !text.empty())
+          firstLine = text.substr(0, 1);
+      } else {
+        firstLine = text.substr(0, static_cast<size_t>(splitAt));
+      }
+
+      std::string secondLine = text.substr(firstLine.size());
+      const auto secondStart = secondLine.find_first_not_of(' ');
+      if (secondStart == std::string::npos) {
+        secondLine.clear();
+      } else if (secondStart > 0) {
+        secondLine.erase(0, secondStart);
+      }
+
+      return std::array<std::string, 2>{firstLine, secondLine};
     };
 
     auto appendText = [&](double x, double y, const std::string &text,
@@ -1612,11 +1647,11 @@ Viewer2DExportResult ExportLayoutToPdf(
     };
 
     double y = frameY + frameH - paddingTop;
-    appendText(xCount, y - textOffset - fontSize, encodeText("Count"), "F2", 0.08,
+    appendText(xCount, y - singleTextOffset - fontSize, encodeText("Count"), "F2", 0.08,
                0.08, 0.08);
-    appendText(xType, y - textOffset - fontSize, encodeText("Type"), "F2", 0.08,
+    appendText(xType, y - singleTextOffset - fontSize, encodeText("Type"), "F2", 0.08,
                0.08, 0.08);
-    appendText(xCh, y - textOffset - fontSize, encodeText("Ch"), "F2", 0.08,
+    appendText(xCh, y - singleTextOffset - fontSize, encodeText("Ch"), "F2", 0.08,
                0.08, 0.08);
 
     y -= rowHeight;
@@ -1633,7 +1668,8 @@ Viewer2DExportResult ExportLayoutToPdf(
         break;
 
       const std::string countText = encodeText(std::to_string(item.count));
-      const std::string typeText = trimTextToWidth(encodeText(item.typeName), typeWidth);
+      const auto typeLines =
+          wrapTextToTwoLines(encodeText(item.typeName), typeWidth);
       const std::string chText =
           encodeText(item.channelCount ? std::to_string(*item.channelCount) : "-");
 
@@ -1774,11 +1810,19 @@ Viewer2DExportResult ExportLayoutToPdf(
         }
       }
 
-      appendText(xCount, y - textOffset - fontSize, countText, "F1", 0.08, 0.08,
+      appendText(xCount, y - singleTextOffset - fontSize, countText, "F1", 0.08, 0.08,
                  0.08);
-      appendText(xType, y - textOffset - fontSize, typeText, "F1", 0.08, 0.08,
+      appendText(xType, y - typeTextOffset - fontSize, typeLines[0], "F1", 0.08, 0.08,
                  0.08);
-      appendText(xCh, y - textOffset - fontSize, chText, "F1", 0.08, 0.08,
+      if (!typeLines[1].empty()) {
+        const double secondTypeBaseline =
+            y - typeTextOffset - fontSize +
+            ComputeTextLineAdvance(textHeightEstimate * 0.8,
+                                   textHeightEstimate * 0.2);
+        appendText(xType, secondTypeBaseline, typeLines[1], "F1", 0.08, 0.08,
+                   0.08);
+      }
+      appendText(xCh, y - singleTextOffset - fontSize, chText, "F1", 0.08, 0.08,
                  0.08);
       y -= rowHeight;
     }


### PR DESCRIPTION
### Motivation
- Make fixture names in layout legends fully readable by wrapping the `Type` column into up to two lines instead of truncating with `...` on narrow columns.
- Keep on-screen and exported/PDF legends visually consistent by applying the same wrapping behavior in both renderers.
- Preserve column alignment (symbols/count/channel) and avoid breaking row layout when a `Type` label needs two lines.

### Description
- Implemented a two-line wrapping helper `wrapTextToTwoLines` in `gui/layoutviewerpanel_legend.cpp` and replaced the old ellipsis trimming logic with it for the on-screen legend renderer.
- Adjusted legend row height and vertical offsets (`lineHeight`, header/row offsets and type block metrics) to accommodate up to two lines while preserving alignment between `Count`, `Type`, and `Ch` columns.
- Mirrored the same wrapping and vertical layout changes in the PDF exporter (`viewer2d/pdf/layout_pdf_exporter.cpp`) so exported legends match on-screen behavior, using `ComputeTextLineAdvance` to position the second PDF text line.
- Added a small include (`<array>`) and kept all new code localized to the viewer legend and PDF exporter files to maintain module boundaries.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded (OK).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded (OK).
- Build was not executed in this environment because no `build/` directory was present, so no binary verification was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd2dea787483249ef93eeaaf8ed720)