### PR TITLE
Isolate 2D rendering from 3D render-style preferences

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -174,6 +174,16 @@ static Viewer3DRenderStyle ReadRenderStylePreference(const ConfigManager &cfg) {
   return ResolveViewer3DRenderStyle(cfg);
 }
 
+Viewer3DRenderStyle ResolveRenderStyleForContext(const ConfigManager &cfg,
+                                                 bool is2DViewer) {
+  if (is2DViewer) {
+    // Keep 2D render paths isolated from user-selected 3D styles.
+    // The 2D viewer rendering was tuned against the standard style.
+    return Viewer3DRenderStyle::Standard;
+  }
+  return ReadRenderStylePreference(cfg);
+}
+
 static LineRenderProfile GetLineRenderProfile(bool isInteracting,
                                               bool wireframeMode,
                                               bool adaptiveEnabled) {
@@ -989,7 +999,8 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
   context.colorByFixtureType = isByFixtureTypeMode;
   context.colorByLayer = isByLayerMode;
   context.colorByUniverse = isByUniverseMode;
-  const Viewer3DRenderStyle renderStyle = ReadRenderStylePreference(cfg);
+  const Viewer3DRenderStyle renderStyle =
+      ResolveRenderStyleForContext(cfg, context.is2DViewer);
   context.whiteModelStyle = IsWhiteModelRenderStyle(renderStyle);
   context.texturedStyle = IsTexturedRenderStyle(renderStyle);
   m_impl->whiteModelStyleEnabled = context.whiteModelStyle;


### PR DESCRIPTION
### Motivation
- 2D viewers occasionally rendered with non-standard 3D styles (white-model/textured/by-layer/etc.), causing incorrect fills (black areas); the intent is to prevent 3D-only style flags from leaking into 2D rendering paths.

### Description
- Added `ResolveRenderStyleForContext(const ConfigManager&, bool is2DViewer)` in `viewer3d/viewer3dcontroller.cpp` and made it return `Viewer3DRenderStyle::Standard` when `is2DViewer` is true.
- Replaced the direct preference read (`ReadRenderStylePreference`) when building the render context with `ResolveRenderStyleForContext(cfg, context.is2DViewer)` so 2D render paths always use the standard style while 3D viewers keep user-selected styles.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd2f2fc41483249072e586e0020d28)