### PR TITLE
Add Summary panel to 2D View Editor and persist fixture-type visibility in layouts

### DIFF
--- a/core/layouts/LayoutCollection.h
+++ b/core/layouts/LayoutCollection.h
@@ -66,6 +66,7 @@ struct Layout2DViewRenderOptions {
 
 struct Layout2DViewLayers {
   std::vector<std::string> hiddenLayers;
+  std::vector<std::string> hiddenFixtureTypes;
 };
 
 struct Layout2DViewDefinition {

--- a/core/layouts/LayoutTemplateSerializer.cpp
+++ b/core/layouts/LayoutTemplateSerializer.cpp
@@ -145,7 +145,9 @@ nlohmann::json ToJson(const Layout2DViewDefinition &view) {
          }
          return renderOptions;
        }()},
-      {"layers", {{"hiddenLayers", layers.hiddenLayers}}},
+      {"layers",
+       {{"hiddenLayers", layers.hiddenLayers},
+        {"hiddenFixtureTypes", layers.hiddenFixtureTypes}}},
   };
 }
 
@@ -339,22 +341,40 @@ void ReadRenderOptions(const nlohmann::json &obj,
 
 void ReadLayers(const nlohmann::json &obj, Layout2DViewLayers &layers,
                 const ParseContext &ctx) {
+  layers.hiddenLayers.clear();
+  layers.hiddenFixtureTypes.clear();
+
   if (auto it = obj.find("hiddenLayers"); it != obj.end()) {
     if (!it->is_array()) {
       AddWarning(ctx, "Ignored 'hiddenLayers' because it is not an array.");
-      return;
+    } else {
+      std::unordered_set<std::string> dedupe;
+      for (const auto &entry : *it) {
+        if (!entry.is_string())
+          continue;
+        std::string layerName = entry.get<std::string>();
+        if (layerName.empty())
+          continue;
+        if (dedupe.insert(layerName).second)
+          layers.hiddenLayers.push_back(std::move(layerName));
+      }
     }
+  }
 
-    layers.hiddenLayers.clear();
-    std::unordered_set<std::string> dedupe;
-    for (const auto &entry : *it) {
-      if (!entry.is_string())
-        continue;
-      std::string layerName = entry.get<std::string>();
-      if (layerName.empty())
-        continue;
-      if (dedupe.insert(layerName).second)
-        layers.hiddenLayers.push_back(std::move(layerName));
+  if (auto it = obj.find("hiddenFixtureTypes"); it != obj.end()) {
+    if (!it->is_array()) {
+      AddWarning(ctx, "Ignored 'hiddenFixtureTypes' because it is not an array.");
+    } else {
+      std::unordered_set<std::string> dedupe;
+      for (const auto &entry : *it) {
+        if (!entry.is_string())
+          continue;
+        std::string typeName = entry.get<std::string>();
+        if (typeName.empty())
+          continue;
+        if (dedupe.insert(typeName).second)
+          layers.hiddenFixtureTypes.push_back(std::move(typeName));
+      }
     }
   }
 }
@@ -501,6 +521,13 @@ bool ParseLegacySingleView(const nlohmann::json &value, LayoutDefinition &out,
     for (const auto &entry : *it) {
       if (entry.is_string())
         layers.hiddenLayers.push_back(entry.get<std::string>());
+    }
+  }
+  if (auto it = viewObj.find("hiddenFixtureTypes");
+      it != viewObj.end() && it->is_array()) {
+    for (const auto &entry : *it) {
+      if (entry.is_string())
+        layers.hiddenFixtureTypes.push_back(entry.get<std::string>());
     }
   }
 

--- a/gui/layout2dviewdialog.cpp
+++ b/gui/layout2dviewdialog.cpp
@@ -1,6 +1,8 @@
 #include "layout2dviewdialog.h"
 
+#include "configmanager.h"
 #include "layerpanel.h"
+#include "summarypanel.h"
 #include "viewer2dpanel.h"
 #include "viewer2drenderpanel.h"
 
@@ -13,7 +15,9 @@
 #include <wx/sizer.h>
 #include <wx/stattext.h>
 
-Layout2DViewDialog::Layout2DViewDialog(wxWindow *parent)
+Layout2DViewDialog::Layout2DViewDialog(wxWindow *parent,
+                                       ConfigManager *visibilityConfig,
+                                       ConfigManager *colorConfig)
     : wxDialog(parent, wxID_ANY, "2D View Editor", wxDefaultPosition,
                wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER |
                                    wxMAXIMIZE_BOX | wxMINIMIZE_BOX) {
@@ -22,14 +26,20 @@ Layout2DViewDialog::Layout2DViewDialog(wxWindow *parent)
 
   viewerPanel = new Viewer2DPanel(this, false, false, false);
   renderPanel = new Viewer2DRenderPanel(this);
-  layerPanel = new LayerPanel(this, false);
+  layerPanel = new LayerPanel(this, false, visibilityConfig);
+  summaryPanel = new SummaryPanel(this, visibilityConfig, colorConfig);
 
   renderPanel->SetMinSize(wxSize(260, -1));
-  layerPanel->SetMinSize(wxSize(220, -1));
+  layerPanel->SetMinSize(wxSize(250, 220));
+  summaryPanel->SetMinSize(wxSize(250, 220));
+
+  auto *rightColumnSizer = new wxBoxSizer(wxVERTICAL);
+  rightColumnSizer->Add(layerPanel, 1, wxEXPAND | wxBOTTOM, 8);
+  rightColumnSizer->Add(summaryPanel, 1, wxEXPAND);
 
   contentSizer->Add(viewerPanel, 1, wxEXPAND | wxALL, 8);
   contentSizer->Add(renderPanel, 0, wxEXPAND | wxTOP | wxBOTTOM | wxRIGHT, 8);
-  contentSizer->Add(layerPanel, 0, wxEXPAND | wxTOP | wxBOTTOM | wxRIGHT, 8);
+  contentSizer->Add(rightColumnSizer, 0, wxEXPAND | wxTOP | wxBOTTOM | wxRIGHT, 8);
 
   mainSizer->Add(contentSizer, 1, wxEXPAND);
 
@@ -77,6 +87,9 @@ void Layout2DViewDialog::OnCancel(wxCommandEvent &event) {
 void Layout2DViewDialog::OnShow(wxShowEvent &event) {
   if (event.IsShown() && layerPanel) {
     layerPanel->ReloadLayers();
+  }
+  if (event.IsShown() && summaryPanel) {
+    summaryPanel->ShowFixtureSummary();
   }
   if (event.IsShown() && viewerPanel) {
     auto retries = std::make_shared<int>(3);

--- a/gui/layout2dviewdialog.h
+++ b/gui/layout2dviewdialog.h
@@ -5,12 +5,16 @@
 class Viewer2DPanel;
 class Viewer2DRenderPanel;
 class LayerPanel;
+class SummaryPanel;
+class ConfigManager;
 class wxSlider;
 class wxStaticText;
 
 class Layout2DViewDialog : public wxDialog {
 public:
-  explicit Layout2DViewDialog(wxWindow *parent);
+  explicit Layout2DViewDialog(wxWindow *parent,
+                              ConfigManager *visibilityConfig = nullptr,
+                              ConfigManager *colorConfig = nullptr);
 
   Viewer2DPanel *GetViewerPanel() const { return viewerPanel; }
   Viewer2DRenderPanel *GetRenderPanel() const { return renderPanel; }
@@ -25,6 +29,7 @@ private:
   Viewer2DPanel *viewerPanel = nullptr;
   Viewer2DRenderPanel *renderPanel = nullptr;
   LayerPanel *layerPanel = nullptr;
+  SummaryPanel *summaryPanel = nullptr;
   wxSlider *scaleSlider = nullptr;
   wxStaticText *scaleValueLabel = nullptr;
 };

--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -132,7 +132,8 @@ bool AreEqual(const layouts::Layout2DViewRenderOptions &lhs,
 
 bool AreEqual(const layouts::Layout2DViewLayers &lhs,
               const layouts::Layout2DViewLayers &rhs) {
-  return lhs.hiddenLayers == rhs.hiddenLayers;
+  return lhs.hiddenLayers == rhs.hiddenLayers &&
+         lhs.hiddenFixtureTypes == rhs.hiddenFixtureTypes;
 }
 
 bool AreEqual(const layouts::Layout2DViewDefinition &lhs,

--- a/gui/layoutviewerpanel_render_invalidation.cpp
+++ b/gui/layoutviewerpanel_render_invalidation.cpp
@@ -69,6 +69,8 @@ size_t LayoutViewerPanel::HashViewContent(
 
   for (const auto &hiddenLayer : view.layers.hiddenLayers)
     HashCombine(seed, std::hash<std::string>{}(hiddenLayer));
+  for (const auto &hiddenFixtureType : view.layers.hiddenFixtureTypes)
+    HashCombine(seed, std::hash<std::string>{}(hiddenFixtureType));
   return seed;
 }
 

--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -895,7 +895,7 @@ void MainWindow::BeginLayout2DViewEdit() {
 
   ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
 
-  Layout2DViewDialog dialog(this);
+  Layout2DViewDialog dialog(this, &cfg, &cfg);
   layout2DViewEditPanel = dialog.GetViewerPanel();
   layout2DViewEditRenderPanel = dialog.GetRenderPanel();
   if (layout2DViewEditPanel) {

--- a/gui/summarypanel.cpp
+++ b/gui/summarypanel.cpp
@@ -29,8 +29,17 @@
 
 static SummaryPanel* s_instance = nullptr;
 
-SummaryPanel::SummaryPanel(wxWindow* parent)
-    : wxPanel(parent, wxID_ANY)
+SummaryPanel::SummaryPanel(wxWindow* parent, ConfigManager* visibilityConfig,
+                           ConfigManager* colorConfig)
+    : wxPanel(parent, wxID_ANY),
+      visibilityConfigManager(visibilityConfig
+                                  ? visibilityConfig
+                                  : &GetDefaultGuiConfigServices().LegacyConfigManager()),
+      colorConfigManager(colorConfig
+                             ? colorConfig
+                             : (visibilityConfigManager
+                                    ? visibilityConfigManager
+                                    : &GetDefaultGuiConfigServices().LegacyConfigManager()))
 {
     store = new ColorfulDataViewListStore();
     table = new wxDataViewListCtrl(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxDV_ROW_LINES);
@@ -148,7 +157,7 @@ void SummaryPanel::ShowFixtureSummary()
 {
     if (!table || !store) return;
     std::map<std::string, FixtureSummaryRow> grouped;
-    const auto& fixtures = GetDefaultGuiConfigServices().LegacyConfigManager().GetScene().fixtures;
+    const auto& fixtures = (*visibilityConfigManager).GetScene().fixtures;
     for (const auto& [uuid, fix] : fixtures) {
         (void)uuid;
         auto& row = grouped[fix.typeName];
@@ -159,7 +168,7 @@ void SummaryPanel::ShowFixtureSummary()
     }
 
     const auto hiddenFixtureTypes =
-        GetDefaultGuiConfigServices().LegacyConfigManager().GetHiddenFixtureTypes();
+        (*visibilityConfigManager).GetHiddenFixtureTypes();
     std::vector<FixtureSummaryRow> rows;
     rows.reserve(grouped.size());
     for (auto& [typeName, row] : grouped) {
@@ -175,7 +184,7 @@ void SummaryPanel::ShowFixtureSummary()
 void SummaryPanel::ShowTrussSummary()
 {
     std::map<std::string,int> counts;
-    const auto& trusses = GetDefaultGuiConfigServices().LegacyConfigManager().GetScene().trusses;
+    const auto& trusses = (*visibilityConfigManager).GetScene().trusses;
     for (const auto& [uuid, truss] : trusses)
         counts[truss.model]++;
     std::vector<std::pair<std::string,int>> items(counts.begin(), counts.end());
@@ -187,7 +196,7 @@ void SummaryPanel::ShowHoistSummary()
     if (!table) return;
 
     std::map<std::string, int> hoistCounts;
-    const auto& supports = GetDefaultGuiConfigServices().LegacyConfigManager().GetScene().supports;
+    const auto& supports = (*visibilityConfigManager).GetScene().supports;
     for (const auto& [uuid, support] : supports) {
         std::string type = support.function.empty() ? "Hoist" : support.function;
         hoistCounts[type]++;
@@ -200,7 +209,7 @@ void SummaryPanel::ShowHoistSummary()
 void SummaryPanel::ShowSceneObjectSummary()
 {
     std::map<std::string,int> counts;
-    const auto& objs = GetDefaultGuiConfigServices().LegacyConfigManager().GetScene().sceneObjects;
+    const auto& objs = (*visibilityConfigManager).GetScene().sceneObjects;
     for (const auto& [uuid, obj] : objs)
         counts[obj.name]++;
     std::vector<std::pair<std::string,int>> items(counts.begin(), counts.end());
@@ -267,7 +276,7 @@ void SummaryPanel::RefreshFixtureVisibilityStyles() {
         return;
 
     const auto hiddenFixtureTypes =
-        GetDefaultGuiConfigServices().LegacyConfigManager().GetHiddenFixtureTypes();
+        (*visibilityConfigManager).GetHiddenFixtureTypes();
     for (unsigned int row = 0; row < table->GetItemCount(); ++row) {
         store->ClearRowTextColour(row);
         wxString typeName = table->GetTextValue(static_cast<int>(row), 2);
@@ -301,12 +310,12 @@ void SummaryPanel::OnItemValueChanged(wxDataViewEvent& event) {
     const std::string typeName = table->GetTextValue(row, 2).ToStdString();
 
     auto hiddenFixtureTypes =
-        GetDefaultGuiConfigServices().LegacyConfigManager().GetHiddenFixtureTypes();
+        (*visibilityConfigManager).GetHiddenFixtureTypes();
     if (visible)
         hiddenFixtureTypes.erase(typeName);
     else
         hiddenFixtureTypes.insert(typeName);
-    GetDefaultGuiConfigServices().LegacyConfigManager().SetHiddenFixtureTypes(hiddenFixtureTypes);
+    (*visibilityConfigManager).SetHiddenFixtureTypes(hiddenFixtureTypes);
     RefreshFixtureVisibilityStyles();
     RefreshVisibleViewers();
 }
@@ -319,8 +328,8 @@ void SummaryPanel::OnItemActivated(wxDataViewEvent& event) {
         return;
 
     const std::string typeName = table->GetTextValue(row, 2).ToStdString();
-    auto& cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
-    auto& fixtures = cfg.GetScene().fixtures;
+    auto& colorCfg = (*colorConfigManager);
+    auto& fixtures = colorCfg.GetScene().fixtures;
 
     wxColourData data;
     for (const auto& [uuid, fixture] : fixtures) {
@@ -338,7 +347,7 @@ void SummaryPanel::OnItemActivated(wxDataViewEvent& event) {
     const wxColour color = dlg.GetColourData().GetColour();
     const std::string hex = wxString::Format("#%02X%02X%02X", color.Red(), color.Green(),
                                              color.Blue()).ToStdString();
-    cfg.PushUndoState("change fixture type color from summary");
+    colorCfg.PushUndoState("change fixture type color from summary");
     for (auto& [uuid, fixture] : fixtures) {
         (void)uuid;
         if (fixture.typeName == typeName)

--- a/gui/summarypanel.h
+++ b/gui/summarypanel.h
@@ -21,11 +21,13 @@
 #include <wx/dataview.h>
 
 class ColorfulDataViewListStore;
+class ConfigManager;
 
 // Panel that shows a summary count of items by type/model/name
 class SummaryPanel : public wxPanel {
 public:
-    explicit SummaryPanel(wxWindow* parent);
+    explicit SummaryPanel(wxWindow* parent, ConfigManager* visibilityConfig = nullptr,
+                          ConfigManager* colorConfig = nullptr);
 
     void ShowFixtureSummary();
     void ShowTrussSummary();
@@ -50,6 +52,8 @@ private:
 
     wxDataViewListCtrl* table = nullptr;
     ColorfulDataViewListStore* store = nullptr;
+    ConfigManager* visibilityConfigManager = nullptr;
+    ConfigManager* colorConfigManager = nullptr;
     SummaryMode mode = SummaryMode::Generic;
     wxString activeHoverTooltip;
 

--- a/viewer2d/viewer2dstate.cpp
+++ b/viewer2d/viewer2dstate.cpp
@@ -98,6 +98,13 @@ Viewer2DState CaptureState(const Viewer2DPanel *panel,
   state.layers.hiddenLayers.insert(state.layers.hiddenLayers.end(),
                                    hidden.begin(), hidden.end());
   std::sort(state.layers.hiddenLayers.begin(), state.layers.hiddenLayers.end());
+  state.layers.hiddenFixtureTypes.clear();
+  auto hiddenFixtureTypes = cfg.GetHiddenFixtureTypes();
+  state.layers.hiddenFixtureTypes.insert(state.layers.hiddenFixtureTypes.end(),
+                                         hiddenFixtureTypes.begin(),
+                                         hiddenFixtureTypes.end());
+  std::sort(state.layers.hiddenFixtureTypes.begin(),
+            state.layers.hiddenFixtureTypes.end());
 
   return state;
 }
@@ -150,6 +157,10 @@ void ApplyState(Viewer2DPanel *panel, Viewer2DRenderPanel *renderPanel,
   std::unordered_set<std::string> hidden(state.layers.hiddenLayers.begin(),
                                          state.layers.hiddenLayers.end());
   cfg.SetHiddenLayers(hidden);
+  std::unordered_set<std::string> hiddenFixtureTypes(
+      state.layers.hiddenFixtureTypes.begin(),
+      state.layers.hiddenFixtureTypes.end());
+  cfg.SetHiddenFixtureTypes(hiddenFixtureTypes);
 
   if (panel && updatePanels) {
     if (persistCameraToConfig) {


### PR DESCRIPTION
### Motivation
- Make the right column of the "2D View Editor" wider and add a Summary instance next to Layers so fixture-type visibility can be edited per-view without clipping the "Color" label. 
- Persist visibility-by-type (Summary) per layout-view while keeping fixture colors shared across viewers. 
- Ensure layout export/import round-trips the per-view visibility settings and that view-cache invalidation reacts to visibility changes.

### Description
- Added `hiddenFixtureTypes` to `layouts::Layout2DViewLayers` and wired JSON serialization/deserialization (including legacy single-view import) in the layout template serializer. 
- Extended `viewer2d::Viewer2DState` capture/apply logic to include `hiddenFixtureTypes` and round-trip it through `ConfigManager` when editing/restoring a 2D view. 
- Made `SummaryPanel` accept injected `ConfigManager*` instances for visibility and color ownership so visibility can be per-view while color edits remain shared; updated summary code to use the injected managers. 
- Updated `Layout2DViewDialog` to widen the right column and stack `LayerPanel` + `SummaryPanel`, and passed `ConfigManager` references from the layout editor entry point; updated layout view equality/hash/invalidation to include `hiddenFixtureTypes` so cached renders update correctly.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd3e53f6d0832494326d67c2c898eb)