### PR TITLE
Add per-axis ruler color controls and persistence in 2D Render Options

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -132,6 +132,15 @@ ConfigManager::ConfigManager() {
   RegisterVariable("ruler_axis_x_position", "float", 0.0f, -100.0f, 100.0f);
   RegisterVariable("ruler_axis_y_position", "float", 0.0f, -100.0f, 100.0f);
   RegisterVariable("ruler_axis_z_position", "float", 0.0f, -100.0f, 100.0f);
+  RegisterVariable("ruler_axis_x_color_r", "float", 0.0f, 0.0f, 1.0f);
+  RegisterVariable("ruler_axis_x_color_g", "float", 0.0f, 0.0f, 1.0f);
+  RegisterVariable("ruler_axis_x_color_b", "float", 0.0f, 0.0f, 1.0f);
+  RegisterVariable("ruler_axis_y_color_r", "float", 0.0f, 0.0f, 1.0f);
+  RegisterVariable("ruler_axis_y_color_g", "float", 0.0f, 0.0f, 1.0f);
+  RegisterVariable("ruler_axis_y_color_b", "float", 0.0f, 0.0f, 1.0f);
+  RegisterVariable("ruler_axis_z_color_r", "float", 0.0f, 0.0f, 1.0f);
+  RegisterVariable("ruler_axis_z_color_g", "float", 0.0f, 0.0f, 1.0f);
+  RegisterVariable("ruler_axis_z_color_b", "float", 0.0f, 0.0f, 1.0f);
   RegisterVariable("print_include_grid", "float", 1.0f, 0.0f, 1.0f);
   RegisterVariable("print_viewer2d_page_size", "float", 0.0f, 0.0f, 1.0f,
                    {"print_plan_page_size", "print_page_size"});

--- a/core/layouts/LayoutCollection.h
+++ b/core/layouts/LayoutCollection.h
@@ -53,6 +53,9 @@ struct Layout2DViewRenderOptions {
   float gridColorB = 0.35f;
   bool gridDrawAbove = false;
   bool showRuler = true;
+  std::array<float, 3> rulerColorR = {0.0f, 0.0f, 0.0f};
+  std::array<float, 3> rulerColorG = {0.0f, 0.0f, 0.0f};
+  std::array<float, 3> rulerColorB = {0.0f, 0.0f, 0.0f};
 
   std::array<bool, 3> showLabelName = {true, true, true};
   std::array<bool, 3> showLabelId = {true, true, true};

--- a/core/layouts/LayoutTemplateSerializer.cpp
+++ b/core/layouts/LayoutTemplateSerializer.cpp
@@ -131,6 +131,9 @@ nlohmann::json ToJson(const Layout2DViewDefinition &view) {
                                       {"gridColorB", options.gridColorB},
                                       {"gridDrawAbove", options.gridDrawAbove},
                                       {"showRuler", options.showRuler},
+                                      {"rulerColorR", options.rulerColorR},
+                                      {"rulerColorG", options.rulerColorG},
+                                      {"rulerColorB", options.rulerColorB},
                                       {"showLabelName", options.showLabelName},
                                       {"showLabelId", options.showLabelId},
                                       {"showLabelDmx", options.showLabelDmx},
@@ -315,6 +318,12 @@ void ReadRenderOptions(const nlohmann::json &obj,
     options.gridDrawAbove = it->get<bool>();
   if (auto it = obj.find("showRuler"); it != obj.end() && it->is_boolean())
     options.showRuler = it->get<bool>();
+  ReadFloatArray(obj, "rulerColorR", options.rulerColorR, kColorMin, kColorMax,
+                 ctx);
+  ReadFloatArray(obj, "rulerColorG", options.rulerColorG, kColorMin, kColorMax,
+                 ctx);
+  ReadFloatArray(obj, "rulerColorB", options.rulerColorB, kColorMin, kColorMax,
+                 ctx);
 
   ReadBoolArray(obj, "showLabelName", options.showLabelName, ctx);
   ReadBoolArray(obj, "showLabelId", options.showLabelId, ctx);

--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -120,6 +120,9 @@ bool AreEqual(const layouts::Layout2DViewRenderOptions &lhs,
          lhs.gridColorB == rhs.gridColorB &&
          lhs.gridDrawAbove == rhs.gridDrawAbove &&
          lhs.showRuler == rhs.showRuler &&
+         lhs.rulerColorR == rhs.rulerColorR &&
+         lhs.rulerColorG == rhs.rulerColorG &&
+         lhs.rulerColorB == rhs.rulerColorB &&
          lhs.showLabelName == rhs.showLabelName &&
          lhs.showLabelId == rhs.showLabelId &&
          lhs.showLabelDmx == rhs.showLabelDmx &&

--- a/gui/layoutviewerpanel_render_invalidation.cpp
+++ b/gui/layoutviewerpanel_render_invalidation.cpp
@@ -52,6 +52,12 @@ size_t LayoutViewerPanel::HashViewContent(
   HashCombineFloat(seed, view.renderOptions.gridColorB);
   HashCombine(seed, std::hash<bool>{}(view.renderOptions.gridDrawAbove));
   HashCombine(seed, std::hash<bool>{}(view.renderOptions.showRuler));
+  for (float red : view.renderOptions.rulerColorR)
+    HashCombineFloat(seed, red);
+  for (float green : view.renderOptions.rulerColorG)
+    HashCombineFloat(seed, green);
+  for (float blue : view.renderOptions.rulerColorB)
+    HashCombineFloat(seed, blue);
 
   for (bool enabled : view.renderOptions.showLabelName)
     HashCombine(seed, std::hash<bool>{}(enabled));

--- a/viewer2d/viewer2d_ruler_overlay.cpp
+++ b/viewer2d/viewer2d_ruler_overlay.cpp
@@ -163,10 +163,21 @@ void DrawVerticalRuler(float minV, float maxV, float uAxis,
   glEnd();
 }
 
-CanvasStroke BuildRulerStroke(bool darkMode) {
+bool IsPureBlackOrWhite(const CanvasColor &color) {
+  const bool black = color.r == 0.0f && color.g == 0.0f && color.b == 0.0f;
+  const bool white = color.r == 1.0f && color.g == 1.0f && color.b == 1.0f;
+  return black || white;
+}
+
+CanvasStroke BuildRulerStroke(bool darkMode, const CanvasColor &requestedColor) {
   CanvasStroke stroke;
-  stroke.color = darkMode ? CanvasColor{1.0f, 1.0f, 1.0f, 1.0f}
-                          : CanvasColor{0.0f, 0.0f, 0.0f, 1.0f};
+  if (IsPureBlackOrWhite(requestedColor)) {
+    stroke.color = darkMode ? CanvasColor{1.0f, 1.0f, 1.0f, 1.0f}
+                            : CanvasColor{0.0f, 0.0f, 0.0f, 1.0f};
+  } else {
+    stroke.color = requestedColor;
+    stroke.color.a = 1.0f;
+  }
   stroke.width = 1.0f;
   return stroke;
 }
@@ -174,6 +185,8 @@ CanvasStroke BuildRulerStroke(bool darkMode) {
 struct ActiveRulers {
   float horizontalAxisMeters = 0.0f;
   float verticalAxisMeters = 0.0f;
+  CanvasColor horizontalColor{0.0f, 0.0f, 0.0f, 1.0f};
+  CanvasColor verticalColor{0.0f, 0.0f, 0.0f, 1.0f};
 };
 
 float ResolveVerticalRulerRenderAxisX(const RulerOverlayViewState &state,
@@ -189,13 +202,17 @@ ActiveRulers ResolveActiveRulers(const RulerOverlayViewState &state) {
   switch (state.view) {
   case Viewer2DView::Top:
   case Viewer2DView::Bottom:
-    return {state.xRulerPositionMeters, state.yRulerPositionMeters};
+    return {state.xRulerPositionMeters, state.yRulerPositionMeters,
+            state.xRulerColor, state.yRulerColor};
   case Viewer2DView::Front:
-    return {state.xRulerPositionMeters, state.zRulerPositionMeters};
+    return {state.xRulerPositionMeters, state.zRulerPositionMeters,
+            state.xRulerColor, state.zRulerColor};
   case Viewer2DView::Side:
-    return {state.yRulerPositionMeters, state.zRulerPositionMeters};
+    return {state.yRulerPositionMeters, state.zRulerPositionMeters,
+            state.yRulerColor, state.zRulerColor};
   }
-  return {state.xRulerPositionMeters, state.yRulerPositionMeters};
+  return {state.xRulerPositionMeters, state.yRulerPositionMeters,
+          state.xRulerColor, state.yRulerColor};
 }
 
 std::string FormatRulerOffsetLabel(float valueMeters) {
@@ -279,15 +296,19 @@ void DrawRulerOverlay(const RulerOverlayViewState &state, bool darkMode) {
   if (depthEnabled)
     glDisable(GL_DEPTH_TEST);
 
-  if (darkMode)
-    glColor3f(1.0f, 1.0f, 1.0f);
-  else
-    glColor3f(0.0f, 0.0f, 0.0f);
+  const CanvasStroke horizontalStroke =
+      BuildRulerStroke(darkMode, activeRulers.horizontalColor);
+  const CanvasStroke verticalStroke =
+      BuildRulerStroke(darkMode, activeRulers.verticalColor);
   glLineWidth(1.0f);
 
+  glColor3f(horizontalStroke.color.r, horizontalStroke.color.g,
+            horizontalStroke.color.b);
   DrawHorizontalRuler(minX, maxX, yAxis, kRulerZeroOriginMeters, shortTickMeters,
                       longTickMeters, state.useImperialUnits,
                       state.view);
+  glColor3f(verticalStroke.color.r, verticalStroke.color.g,
+            verticalStroke.color.b);
   DrawVerticalRuler(minY, maxY, xAxis, kRulerZeroOriginMeters, shortTickMeters,
                     longTickMeters, state.useImperialUnits,
                     state.view);
@@ -317,19 +338,23 @@ void EmitRulerToCanvas(const RulerOverlayViewState &state, bool darkMode,
   const float longTickMeters =
       std::max(std::max(state.largeTickMeters, shortTickMeters),
                shortTickMeters);
-  auto stroke = BuildRulerStroke(darkMode);
   const ActiveRulers activeRulers = ResolveActiveRulers(state);
+  const CanvasStroke horizontalStroke =
+      BuildRulerStroke(darkMode, activeRulers.horizontalColor);
+  const CanvasStroke verticalStroke =
+      BuildRulerStroke(darkMode, activeRulers.verticalColor);
 
   const float xRulerY = activeRulers.horizontalAxisMeters;
   const float yRulerX = activeRulers.verticalAxisMeters;
   const float yRulerRenderX = ResolveVerticalRulerRenderAxisX(state, yRulerX);
-  canvas.DrawLine(minX, xRulerY, maxX, xRulerY, stroke);
-  canvas.DrawLine(yRulerRenderX, minY, yRulerRenderX, maxY, stroke);
+  canvas.DrawLine(minX, xRulerY, maxX, xRulerY, horizontalStroke);
+  canvas.DrawLine(yRulerRenderX, minY, yRulerRenderX, maxY, verticalStroke);
 
   const float tickStepMeters = ResolveTickStepMeters(state.useImperialUnits);
   const float startX =
       ComputeStartTick(minX, kRulerZeroOriginMeters, tickStepMeters);
-  const auto textStyle = BuildRulerLabelStyle(stroke);
+  const auto horizontalTextStyle = BuildRulerLabelStyle(horizontalStroke);
+  const auto verticalTextStyle = BuildRulerLabelStyle(verticalStroke);
   for (float x = startX; x <= maxX + 0.0001f; x += tickStepMeters) {
     const auto tickKind =
         ResolveTickKind(x, kRulerZeroOriginMeters, state.useImperialUnits);
@@ -337,14 +362,14 @@ void EmitRulerToCanvas(const RulerOverlayViewState &state, bool darkMode,
         ResolveTickLengthMeters(tickKind, shortTickMeters, longTickMeters);
     if (tick <= 0.0f)
       continue;
-    canvas.DrawLine(x, xRulerY, x, xRulerY + tick, stroke);
+    canvas.DrawLine(x, xRulerY, x, xRulerY + tick, horizontalStroke);
     if (tickKind == RulerTickKind::Long) {
       const float labelOffsetMeters = x - kRulerZeroOriginMeters;
       const std::string label =
           state.useImperialUnits ? FormatImperialRulerOffsetLabel(labelOffsetMeters)
                                  : FormatRulerOffsetLabel(labelOffsetMeters);
       canvas.DrawText(x, xRulerY + tick + kRulerLabelOffsetMeters, label,
-                      textStyle);
+                      horizontalTextStyle);
     }
   }
 
@@ -359,14 +384,15 @@ void EmitRulerToCanvas(const RulerOverlayViewState &state, bool darkMode,
     if (tick <= 0.0f)
       continue;
     canvas.DrawLine(yRulerRenderX, y,
-                    yRulerRenderX + tick * verticalTickDirection, y, stroke);
+                    yRulerRenderX + tick * verticalTickDirection, y,
+                    verticalStroke);
     if (tickKind == RulerTickKind::Long) {
       const float labelOffsetMeters = y - kRulerZeroOriginMeters;
       const std::string label =
           state.useImperialUnits ? FormatImperialRulerOffsetLabel(labelOffsetMeters)
                                  : FormatRulerOffsetLabel(labelOffsetMeters);
       canvas.DrawText(yRulerX + tick + kRulerLabelOffsetMeters, y, label,
-                      textStyle);
+                      verticalTextStyle);
     }
   }
 }

--- a/viewer2d/viewer2d_ruler_overlay.h
+++ b/viewer2d/viewer2d_ruler_overlay.h
@@ -16,6 +16,9 @@ struct RulerOverlayViewState {
   float xRulerPositionMeters = 0.0f;
   float yRulerPositionMeters = 0.0f;
   float zRulerPositionMeters = 0.0f;
+  CanvasColor xRulerColor{0.0f, 0.0f, 0.0f, 1.0f};
+  CanvasColor yRulerColor{0.0f, 0.0f, 0.0f, 1.0f};
+  CanvasColor zRulerColor{0.0f, 0.0f, 0.0f, 1.0f};
   bool useImperialUnits = false;
   Viewer2DView view = Viewer2DView::Top;
 };

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -679,6 +679,15 @@ void Viewer2DPanel::RenderInternal(bool swapBuffers) {
   const float rulerAxisXPosition = cfg.GetFloat("ruler_axis_x_position");
   const float rulerAxisYPosition = cfg.GetFloat("ruler_axis_y_position");
   const float rulerAxisZPosition = cfg.GetFloat("ruler_axis_z_position");
+  const float rulerAxisXColorR = cfg.GetFloat("ruler_axis_x_color_r");
+  const float rulerAxisXColorG = cfg.GetFloat("ruler_axis_x_color_g");
+  const float rulerAxisXColorB = cfg.GetFloat("ruler_axis_x_color_b");
+  const float rulerAxisYColorR = cfg.GetFloat("ruler_axis_y_color_r");
+  const float rulerAxisYColorG = cfg.GetFloat("ruler_axis_y_color_g");
+  const float rulerAxisYColorB = cfg.GetFloat("ruler_axis_y_color_b");
+  const float rulerAxisZColorR = cfg.GetFloat("ruler_axis_z_color_r");
+  const float rulerAxisZColorG = cfg.GetFloat("ruler_axis_z_color_g");
+  const float rulerAxisZColorB = cfg.GetFloat("ruler_axis_z_color_b");
   const auto distanceUnitSystem =
       Units::ParseDistanceUnitSystem(cfg.GetValue("ui_distance_unit_system"));
 
@@ -786,6 +795,12 @@ void Viewer2DPanel::RenderInternal(bool swapBuffers) {
     rulerState.xRulerPositionMeters = rulerAxisXPosition;
     rulerState.yRulerPositionMeters = rulerAxisYPosition;
     rulerState.zRulerPositionMeters = rulerAxisZPosition;
+    rulerState.xRulerColor = {rulerAxisXColorR, rulerAxisXColorG,
+                              rulerAxisXColorB, 1.0f};
+    rulerState.yRulerColor = {rulerAxisYColorR, rulerAxisYColorG,
+                              rulerAxisYColorB, 1.0f};
+    rulerState.zRulerColor = {rulerAxisZColorR, rulerAxisZColorG,
+                              rulerAxisZColorB, 1.0f};
     rulerState.useImperialUnits =
         distanceUnitSystem == Units::DistanceUnitSystem::Imperial;
     rulerState.view = m_view;

--- a/viewer2d/viewer2drenderpanel.cpp
+++ b/viewer2d/viewer2drenderpanel.cpp
@@ -40,6 +40,20 @@ const std::array<const char *, 3> ID_KEYS = {"label_show_id_top",
 const std::array<const char *, 3> DMX_KEYS = {"label_show_dmx_top",
                                               "label_show_dmx_front",
                                               "label_show_dmx_side"};
+
+wxColour BuildColorFromConfig(const ConfigManager &cfg, const char *rKey,
+                              const char *gKey, const char *bKey) {
+  return wxColour(static_cast<int>(cfg.GetFloat(rKey) * 255.0f),
+                  static_cast<int>(cfg.GetFloat(gKey) * 255.0f),
+                  static_cast<int>(cfg.GetFloat(bKey) * 255.0f));
+}
+
+void SaveColorToConfig(ConfigManager &cfg, const wxColour &color,
+                       const char *rKey, const char *gKey, const char *bKey) {
+  cfg.SetFloat(rKey, color.Red() / 255.0f);
+  cfg.SetFloat(gKey, color.Green() / 255.0f);
+  cfg.SetFloat(bKey, color.Blue() / 255.0f);
+}
 } // namespace
 
 Viewer2DRenderPanel *Viewer2DRenderPanel::s_instance = nullptr;
@@ -122,6 +136,13 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
                              this);
   m_rulerAxisXPosition->Bind(wxEVT_TEXT_ENTER,
                              &Viewer2DRenderPanel::OnTextEnter, this);
+  m_rulerAxisXPosition->SetMinSize(wxSize(80, -1));
+  m_rulerAxisXColor = new wxColourPickerCtrl(
+      rulerBoxParent, wxID_ANY,
+      BuildColorFromConfig(cfg, "ruler_axis_x_color_r", "ruler_axis_x_color_g",
+                           "ruler_axis_x_color_b"));
+  m_rulerAxisXColor->Bind(wxEVT_COLOURPICKER_CHANGED,
+                          &Viewer2DRenderPanel::OnRulerAxisXColor, this);
 
   m_rulerAxisYPosition = new wxSpinCtrlDouble(
       rulerBoxParent, wxID_ANY, "", wxDefaultPosition, wxDefaultSize,
@@ -140,6 +161,13 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
                              this);
   m_rulerAxisYPosition->Bind(wxEVT_TEXT_ENTER,
                              &Viewer2DRenderPanel::OnTextEnter, this);
+  m_rulerAxisYPosition->SetMinSize(wxSize(80, -1));
+  m_rulerAxisYColor = new wxColourPickerCtrl(
+      rulerBoxParent, wxID_ANY,
+      BuildColorFromConfig(cfg, "ruler_axis_y_color_r", "ruler_axis_y_color_g",
+                           "ruler_axis_y_color_b"));
+  m_rulerAxisYColor->Bind(wxEVT_COLOURPICKER_CHANGED,
+                          &Viewer2DRenderPanel::OnRulerAxisYColor, this);
   m_rulerAxisZPosition = new wxSpinCtrlDouble(
       rulerBoxParent, wxID_ANY, "", wxDefaultPosition, wxDefaultSize,
       wxSP_ARROW_KEYS | wxTE_PROCESS_ENTER);
@@ -157,6 +185,13 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
                              this);
   m_rulerAxisZPosition->Bind(wxEVT_TEXT_ENTER,
                              &Viewer2DRenderPanel::OnTextEnter, this);
+  m_rulerAxisZPosition->SetMinSize(wxSize(80, -1));
+  m_rulerAxisZColor = new wxColourPickerCtrl(
+      rulerBoxParent, wxID_ANY,
+      BuildColorFromConfig(cfg, "ruler_axis_z_color_r", "ruler_axis_z_color_g",
+                           "ruler_axis_z_color_b"));
+  m_rulerAxisZColor->Bind(wxEVT_COLOURPICKER_CHANGED,
+                          &Viewer2DRenderPanel::OnRulerAxisZColor, this);
 
   auto *labelBox = new wxStaticBoxSizer(wxVERTICAL, this, "Labels");
   wxWindow *labelBoxParent = labelBox->GetStaticBox();
@@ -283,17 +318,20 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
   auto *rulerAxisXSizer = new wxBoxSizer(wxHORIZONTAL);
   rulerAxisXSizer->Add(new wxStaticText(rulerBoxParent, wxID_ANY, "X ruler"),
                        0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
-  rulerAxisXSizer->Add(m_rulerAxisXPosition, 0);
+  rulerAxisXSizer->Add(m_rulerAxisXPosition, 0, wxRIGHT, 4);
+  rulerAxisXSizer->Add(m_rulerAxisXColor, 0);
   rulerBox->Add(rulerAxisXSizer, 0, wxALL, 5);
   auto *rulerAxisYSizer = new wxBoxSizer(wxHORIZONTAL);
   rulerAxisYSizer->Add(new wxStaticText(rulerBoxParent, wxID_ANY, "Y ruler"),
                        0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
-  rulerAxisYSizer->Add(m_rulerAxisYPosition, 0);
+  rulerAxisYSizer->Add(m_rulerAxisYPosition, 0, wxRIGHT, 4);
+  rulerAxisYSizer->Add(m_rulerAxisYColor, 0);
   rulerBox->Add(rulerAxisYSizer, 0, wxALL, 5);
   auto *rulerAxisZSizer = new wxBoxSizer(wxHORIZONTAL);
   rulerAxisZSizer->Add(new wxStaticText(rulerBoxParent, wxID_ANY, "Z ruler"),
                        0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
-  rulerAxisZSizer->Add(m_rulerAxisZPosition, 0);
+  rulerAxisZSizer->Add(m_rulerAxisZPosition, 0, wxRIGHT, 4);
+  rulerAxisZSizer->Add(m_rulerAxisZColor, 0);
   rulerBox->Add(rulerAxisZSizer, 0, wxALL, 5);
   sizer->Add(rulerBox, 0, wxEXPAND | wxALL, 5);
 
@@ -430,6 +468,15 @@ void Viewer2DRenderPanel::ApplyConfig() {
   m_rulerAxisXPosition->SetValue(cfg.GetFloat("ruler_axis_x_position"));
   m_rulerAxisYPosition->SetValue(cfg.GetFloat("ruler_axis_y_position"));
   m_rulerAxisZPosition->SetValue(cfg.GetFloat("ruler_axis_z_position"));
+  m_rulerAxisXColor->SetColour(
+      BuildColorFromConfig(cfg, "ruler_axis_x_color_r", "ruler_axis_x_color_g",
+                           "ruler_axis_x_color_b"));
+  m_rulerAxisYColor->SetColour(
+      BuildColorFromConfig(cfg, "ruler_axis_y_color_r", "ruler_axis_y_color_g",
+                           "ruler_axis_y_color_b"));
+  m_rulerAxisZColor->SetColour(
+      BuildColorFromConfig(cfg, "ruler_axis_z_color_r", "ruler_axis_z_color_g",
+                           "ruler_axis_z_color_b"));
   UpdateRulerControlState();
   RefreshLabelControlsFromSelection();
   if (auto *vp = Viewer2DPanel::Instance()) {
@@ -533,6 +580,33 @@ void Viewer2DRenderPanel::OnRulerAxisZPosition(wxSpinDoubleEvent &evt) {
   ConfigManager::Get().SetFloat(
       "ruler_axis_z_position",
       static_cast<float>(m_rulerAxisZPosition->GetValue()));
+  if (auto *vp = Viewer2DPanel::Instance())
+    vp->UpdateScene(false);
+  evt.Skip();
+}
+
+void Viewer2DRenderPanel::OnRulerAxisXColor(wxColourPickerEvent &evt) {
+  ConfigManager &cfg = ConfigManager::Get();
+  SaveColorToConfig(cfg, evt.GetColour(), "ruler_axis_x_color_r",
+                    "ruler_axis_x_color_g", "ruler_axis_x_color_b");
+  if (auto *vp = Viewer2DPanel::Instance())
+    vp->UpdateScene(false);
+  evt.Skip();
+}
+
+void Viewer2DRenderPanel::OnRulerAxisYColor(wxColourPickerEvent &evt) {
+  ConfigManager &cfg = ConfigManager::Get();
+  SaveColorToConfig(cfg, evt.GetColour(), "ruler_axis_y_color_r",
+                    "ruler_axis_y_color_g", "ruler_axis_y_color_b");
+  if (auto *vp = Viewer2DPanel::Instance())
+    vp->UpdateScene(false);
+  evt.Skip();
+}
+
+void Viewer2DRenderPanel::OnRulerAxisZColor(wxColourPickerEvent &evt) {
+  ConfigManager &cfg = ConfigManager::Get();
+  SaveColorToConfig(cfg, evt.GetColour(), "ruler_axis_z_color_r",
+                    "ruler_axis_z_color_g", "ruler_axis_z_color_b");
   if (auto *vp = Viewer2DPanel::Instance())
     vp->UpdateScene(false);
   evt.Skip();
@@ -691,6 +765,9 @@ void Viewer2DRenderPanel::UpdateRulerControlState() {
   m_rulerAxisXPosition->Enable(showX);
   m_rulerAxisYPosition->Enable(showY);
   m_rulerAxisZPosition->Enable(showZ);
+  m_rulerAxisXColor->Enable(showX);
+  m_rulerAxisYColor->Enable(showY);
+  m_rulerAxisZColor->Enable(showZ);
 }
 
 void Viewer2DRenderPanel::OnBeginTextEdit(wxFocusEvent &evt) {

--- a/viewer2d/viewer2drenderpanel.h
+++ b/viewer2d/viewer2drenderpanel.h
@@ -47,6 +47,9 @@ private:
   void OnRulerAxisXPosition(wxSpinDoubleEvent &evt);
   void OnRulerAxisYPosition(wxSpinDoubleEvent &evt);
   void OnRulerAxisZPosition(wxSpinDoubleEvent &evt);
+  void OnRulerAxisXColor(wxColourPickerEvent &evt);
+  void OnRulerAxisYColor(wxColourPickerEvent &evt);
+  void OnRulerAxisZColor(wxColourPickerEvent &evt);
   void OnShowLabelName(wxCommandEvent &evt);
   void OnShowLabelId(wxCommandEvent &evt);
   void OnShowLabelAddress(wxCommandEvent &evt);
@@ -78,6 +81,9 @@ private:
   wxSpinCtrlDouble *m_rulerAxisXPosition = nullptr;
   wxSpinCtrlDouble *m_rulerAxisYPosition = nullptr;
   wxSpinCtrlDouble *m_rulerAxisZPosition = nullptr;
+  wxColourPickerCtrl *m_rulerAxisXColor = nullptr;
+  wxColourPickerCtrl *m_rulerAxisYColor = nullptr;
+  wxColourPickerCtrl *m_rulerAxisZColor = nullptr;
   wxCheckBox *m_showLabelName = nullptr;
   wxCheckBox *m_showLabelId = nullptr;
   wxCheckBox *m_showLabelAddress = nullptr;

--- a/viewer2d/viewer2dstate.cpp
+++ b/viewer2d/viewer2dstate.cpp
@@ -43,6 +43,12 @@ const std::array<const char *, 3> kLabelOffsetDistanceKeys = {
 const std::array<const char *, 3> kLabelOffsetAngleKeys = {
     "label_offset_angle_top", "label_offset_angle_front",
     "label_offset_angle_side"};
+const std::array<const char *, 3> kRulerColorRKeys = {
+    "ruler_axis_x_color_r", "ruler_axis_y_color_r", "ruler_axis_z_color_r"};
+const std::array<const char *, 3> kRulerColorGKeys = {
+    "ruler_axis_x_color_g", "ruler_axis_y_color_g", "ruler_axis_z_color_g"};
+const std::array<const char *, 3> kRulerColorBKeys = {
+    "ruler_axis_x_color_b", "ruler_axis_y_color_b", "ruler_axis_z_color_b"};
 } // namespace
 
 Viewer2DState CaptureState(const Viewer2DPanel *panel,
@@ -76,6 +82,11 @@ Viewer2DState CaptureState(const Viewer2DPanel *panel,
   state.renderOptions.gridColorB = cfg.GetFloat("grid_color_b");
   state.renderOptions.gridDrawAbove = cfg.GetFloat("grid_draw_above") != 0.0f;
   state.renderOptions.showRuler = cfg.GetFloat("ruler_show") != 0.0f;
+  for (size_t i = 0; i < state.renderOptions.rulerColorR.size(); ++i) {
+    state.renderOptions.rulerColorR[i] = cfg.GetFloat(kRulerColorRKeys[i]);
+    state.renderOptions.rulerColorG[i] = cfg.GetFloat(kRulerColorGKeys[i]);
+    state.renderOptions.rulerColorB[i] = cfg.GetFloat(kRulerColorBKeys[i]);
+  }
 
   for (size_t i = 0; i < state.renderOptions.showLabelName.size(); ++i) {
     state.renderOptions.showLabelName[i] =
@@ -136,6 +147,11 @@ void ApplyState(Viewer2DPanel *panel, Viewer2DRenderPanel *renderPanel,
   cfg.SetFloat("grid_draw_above",
                state.renderOptions.gridDrawAbove ? 1.0f : 0.0f);
   cfg.SetFloat("ruler_show", state.renderOptions.showRuler ? 1.0f : 0.0f);
+  for (size_t i = 0; i < state.renderOptions.rulerColorR.size(); ++i) {
+    cfg.SetFloat(kRulerColorRKeys[i], state.renderOptions.rulerColorR[i]);
+    cfg.SetFloat(kRulerColorGKeys[i], state.renderOptions.rulerColorG[i]);
+    cfg.SetFloat(kRulerColorBKeys[i], state.renderOptions.rulerColorB[i]);
+  }
 
   for (size_t i = 0; i < state.renderOptions.showLabelName.size(); ++i) {
     cfg.SetFloat(kLabelNameKeys[i],


### PR DESCRIPTION
### Motivation
- Provide a small color box to the right of each X/Y/Z ruler control in the 2D Render Options so each ruler can be assigned a color without widening the settings column. 
- Keep existing auto-contrast behavior for pure black/white so default appearance is unchanged for users who leave those colors.
- Ensure chosen colors are applied to the on-screen ruler rendering and are saved/loaded with viewer state and layout templates.

### Description
- Added per-axis color pickers to the UI by introducing `wxColourPickerCtrl` controls in `viewer2d/viewer2drenderpanel.{h,cpp}` and slightly reduced the position `SpinCtrlDouble` width with `SetMinSize(wxSize(80,-1))` so the column width stays tight and the color box appears to the right.  Event handlers `OnRulerAxis{X,Y,Z}Color` were added and wired to save the selection.
- Persisted colors in configuration with new keys registered in `core/configmanager.cpp` as `ruler_axis_{x,y,z}_color_{r,g,b}` and added helper functions to read/write `wxColour` from/to the config in `viewer2drenderpanel.cpp`.
- Extended runtime state and layout persistence by adding `rulerColorR`, `rulerColorG`, `rulerColorB` arrays to `layouts::Layout2DViewRenderOptions` (`core/layouts/LayoutCollection.h`), serializing/deserializing them in `core/layouts/LayoutTemplateSerializer.cpp`, and carrying them through capture/apply in `viewer2d/viewer2dstate.cpp`.
- Updated ruler rendering to use per-axis colors by adding color fields to `viewer2d::RulerOverlayViewState` and wiring them through `viewer2d/viewer2dpanel.cpp`; rendering now uses the requested color unless it is pure black or pure white, in which case the previous dark/light contrast behavior is preserved (`viewer2d/viewer2d_ruler_overlay.cpp`).
- Included ruler color arrays in layout equality/hash checks and invalidation paths (`gui/layoutviewerpanel.cpp`, `gui/layoutviewerpanel_render_invalidation.cpp`) so cached layout renders update correctly when colors change.

### Testing
- Ran module/architecture checks: `tests/check_perastage_tree_modules.sh` — passed OK. 
- Ran GUI direct-ConfigManager usage check: `tests/check_no_configmanager_get_in_gui.sh` — passed OK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd4caf6af88324add6e0cc982f18f9)