### PR TITLE
Release singleton-owned memory before app shutdown leak dump

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "app_version.h"
+#include "configmanager.h"
 #include "logger.h"
 #include "mainwindow.h"
 #include "projectutils.h"
@@ -156,6 +157,11 @@ bool MyApp::OnInit() {
 }
 
 int MyApp::OnExit() {
+  // Release application-level singletons before CRT leak reporting runs in
+  // debug builds on Windows.
+  ConfigManager::Get().Reset();
+  ConfigManager::Get().ClearHistory();
+  wxImage::CleanUpHandlers();
   return wxApp::OnExit();
 }
 


### PR DESCRIPTION
### Motivation
- Windows debug CRT leak reports were showing allocations that persist until process teardown because application singletons and framework globals (e.g. `ConfigManager`, wx image handlers) are destroyed too late, polluting leak diagnostics.

### Description
- Added `#include "configmanager.h"` and explicit cleanup in `MyApp::OnExit()` to call `ConfigManager::Get().Reset()`, `ConfigManager::Get().ClearHistory()` and `wxImage::CleanUpHandlers()` so application-owned state is released before the CRT leak dump.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd529173ac83248283c46000d8a87e)