### PR TITLE
Improve Save As default name and show blocking save UI

### DIFF
--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -29,6 +29,7 @@
 
 #include <tinyxml2.h>
 #include <wx/busyinfo.h>
+#include <wx/filename.h>
 #include <wx/log.h>
 #include <wx/utils.h>
 #include <wx/wfstream.h>
@@ -161,6 +162,13 @@ void MainWindow::OnSave(wxCommandEvent &event) {
     OnSaveAs(event);
     return;
   }
+
+  std::unique_ptr<wxWindowDisabler> saveDisabler =
+      std::make_unique<wxWindowDisabler>();
+  std::unique_ptr<wxBusyInfo> saveOverlay =
+      std::make_unique<wxBusyInfo>("Saving project...");
+  wxYieldIfNeeded();
+
   auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
   // Always sync table edits before saving; each panel now applies only real changes.
   SyncSceneData();
@@ -191,12 +199,32 @@ void MainWindow::OnSaveAs(wxCommandEvent &event) {
   else
     projDir =
         wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("projects"));
-  wxFileDialog dlg(this, "Save Project", projDir, "", filter,
+
+  wxString suggestedProjectName;
+  if (!currentProjectPath.empty()) {
+    suggestedProjectName =
+        wxFileName(wxString::FromUTF8(currentProjectPath)).GetName();
+  } else if (!currentProjectDisplayName.IsEmpty() &&
+             currentProjectDisplayName != "Untitled") {
+    suggestedProjectName = currentProjectDisplayName;
+  }
+  const wxString suggestedFileName =
+      suggestedProjectName.IsEmpty() ? wxString() : suggestedProjectName + projectExtension;
+
+  wxFileDialog dlg(this, "Save Project", projDir, suggestedFileName, filter,
                    wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
   if (dlg.ShowModal() == wxID_CANCEL)
     return;
 
   currentProjectPath = EnsureProjectFileExtension(dlg.GetPath().ToStdString());
+  currentProjectDisplayName.clear();
+
+  std::unique_ptr<wxWindowDisabler> saveDisabler =
+      std::make_unique<wxWindowDisabler>();
+  std::unique_ptr<wxBusyInfo> saveOverlay =
+      std::make_unique<wxBusyInfo>("Saving project...");
+  wxYieldIfNeeded();
+
   auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
   // Always sync table edits before saving; each panel now applies only real changes.
   SyncSceneData();


### PR DESCRIPTION
### Motivation
- Suggest the current project name in the `Save As` dialog so users get a sensible default filename when saving a show. 
- Use a blocking informative overlay while saving to make the operation explicit and prevent UI interaction while IO completes. 
- Ensure that saving under a new name updates the app state and window title to reflect the newly saved project file.

### Description
- Added a suggested filename to `Save As` using the existing project path or `currentProjectDisplayName` via `wxFileName` and passed it as the `wxFileDialog` default filename. 
- Show a blocking busy overlay during `OnSave` and `OnSaveAs` by creating `wxWindowDisabler` + `wxBusyInfo("Saving project...")` and calling `wxYieldIfNeeded()`. 
- Clear the transient `currentProjectDisplayName` after a `Save As` and call the existing `UpdateTitle()` path so the window title reflects the saved filename. 
- Added `#include <wx/filename.h>` to support filename extraction and made changes in `gui/mainwindow_io.cpp`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce3220fdd883248f6bddab9ee29f51)