### PR TITLE
Harden Viewer3D refresh shutdown flow

### DIFF
--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -805,6 +805,7 @@ void MainWindow::OnCloseWindow(wxCloseEvent &event) {
 
   if (viewportPanel)
     viewportPanel->StopRefreshThread();
+  viewportPanel = nullptr;
 
   Destroy();
 }

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -75,7 +75,6 @@ EVT_KEY_DOWN(Viewer3DPanel::OnKeyDown)
 EVT_ENTER_WINDOW(Viewer3DPanel::OnMouseEnter)
 EVT_LEAVE_WINDOW(Viewer3DPanel::OnMouseLeave)
 EVT_MOUSE_CAPTURE_LOST(Viewer3DPanel::OnCaptureLost)
-EVT_THREAD(wxEVT_VIEWER_REFRESH, Viewer3DPanel::OnThreadRefresh)
 wxEND_EVENT_TABLE()
 
 
@@ -389,16 +388,21 @@ Viewer3DPanel::Viewer3DPanel(wxWindow* parent)
     m_glContext(new wxGLContext(this))
 {
     SetBackgroundStyle(wxBG_STYLE_CUSTOM);
+    Bind(wxEVT_THREAD, &Viewer3DPanel::OnThreadRefresh, this, wxEVT_VIEWER_REFRESH);
     m_threadRunning = true;
     m_refreshThread = std::thread(&Viewer3DPanel::RefreshLoop, this);
 }
 
 Viewer3DPanel::~Viewer3DPanel()
 {
+    m_shuttingDown = true;
+    Unbind(wxEVT_THREAD, &Viewer3DPanel::OnThreadRefresh, this, wxEVT_VIEWER_REFRESH);
+    DeletePendingEvents();
     if (HasCapture())
         ReleaseMouse();
     StopRefreshThread();
     delete m_glContext;
+    m_glContext = nullptr;
     SetInstance(nullptr);
 }
 
@@ -1542,6 +1546,8 @@ void Viewer3DPanel::RefreshLoop()
     using namespace std::chrono_literals;
     while (m_threadRunning)
     {
+        if (m_shuttingDown)
+            return;
         wxThreadEvent* evt = new wxThreadEvent(wxEVT_VIEWER_REFRESH);
         wxQueueEvent(this, evt);
         std::this_thread::sleep_for(16ms);
@@ -1550,6 +1556,8 @@ void Viewer3DPanel::RefreshLoop()
 
 void Viewer3DPanel::OnThreadRefresh(wxThreadEvent& event)
 {
+    if (m_shuttingDown || !m_glContext || IsBeingDeleted())
+        return;
     Refresh();
 }
 

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -137,6 +137,7 @@ private:
     Viewer3DController m_controller;
 
     std::atomic<bool> m_threadRunning{false};
+    std::atomic<bool> m_shuttingDown{false};
     std::thread m_refreshThread;
     void RefreshLoop();
     void OnThreadRefresh(wxThreadEvent& event);


### PR DESCRIPTION
### Motivation
- Prevent late `wxEVT_VIEWER_REFRESH` callbacks and background refresh queuing from running after the 3D panel teardown, which can lead to invalid GL context use or crashes.
- Ensure the refresh thread and event handlers are reliably stopped/drained during application or panel shutdown to avoid race conditions.

### Description
- Added an atomic shutdown flag `m_shuttingDown` to `Viewer3DPanel` to coordinate teardown with the refresh thread (`viewer3d/viewer3dpanel.h`).
- Moved the refresh event hookup to a runtime `Bind(...)` and removed the static `EVT_THREAD` entry so the handler can be `Unbind(...)` during teardown, and set `m_shuttingDown = true` early in `~Viewer3DPanel()` while calling `DeletePendingEvents()` and nulling `m_glContext` after stopping the thread (`viewer3d/viewer3dpanel.cpp`).
- Guarded `RefreshLoop()` to stop enqueueing events when `m_shuttingDown` is set and guarded `OnThreadRefresh(...)` to return early if `m_shuttingDown` is true, the GL context is null, or the window is being deleted (`viewer3d/viewer3dpanel.cpp`).
- Prevented late-close refresh routes by nulling `viewportPanel` in `MainWindow::OnCloseWindow()` after calling `StopRefreshThread()` so callers cannot later `Refresh()` the panel (`gui/mainwindow_menu.cpp`).
- Note: `viewer3dpanel.cpp` is a large hotspot; consider extracting refresh/thread and event lifecycle responsibilities into a small `viewer3d` helper/module (e.g., `refresh_thread_manager.*`) in a follow-up PR to keep responsibilities isolated.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it completed successfully (OK).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it completed successfully (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce337cc6ec8324b0d246a1293fe715)