### PR TITLE
Fix rider truss parsing for no-`para` targets and backdrop overrides

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -495,6 +495,10 @@ std::string NormalizeHangName(const std::string &raw) {
   std::string hang = Trim(raw);
   if (hang.empty())
     return {};
+  hang = std::regex_replace(hang, std::regex("\\([^\\)]*\\)"), "");
+  hang = Trim(hang);
+  if (hang.empty())
+    return {};
   if (IsFloorAlias(hang))
     return "FLOOR";
   if (IsLxSidesAlias(hang))

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -61,10 +61,10 @@ namespace {
 // the compilation cost on every import call and makes keyword matching cheap
 // even when processing large riders.
 static const std::regex kTrussLineRe(
-    "^\\s*(?:[-*]\\s*)?(\\d+)\\s+(?:truss)\\s+([^\\n]*?)\\s+(\\d+(?:\\.\\d+)?)\\s*(?:m|metros?|meters?)\\b(?:\\s+(?:para\\s+)?(.+))?\\s*$",
+    "^\\s*(?:[-*]\\s*)?(\\d+)\\s+(?:truss)\\s+([^\\n]*?)\\s+(\\d+(?:\\.\\d+)?)\\s*(?:m|metros?|meters?)\\b(?:\\s+(?:(?:para|for)\\s+)?(.+))?\\s*$",
     std::regex::icase);
 static const std::regex kTrussLineNoLengthRe(
-    "^\\s*(?:[-*]\\s*)?(\\d+)\\s+(?:truss)\\s+([^\\n]*?)(?:\\s+para\\s+(.+))?\\s*$",
+    "^\\s*(?:[-*]\\s*)?(\\d+)\\s+(?:truss)\\s+([^\\n]*?)(?:\\s+(?:para|for)\\s+(.+))?\\s*$",
     std::regex::icase);
 static const std::regex kTrussRe(
     "(?:truss)[^\\n]*?(\\d+(?:\\.\\d+)?)\\s*(?:m|metros?|meters?)\\b",
@@ -77,7 +77,8 @@ static const std::regex kHoistLineRe(
 static const std::regex kHoistCapacityRe(
     "(\\d+(?:[\\.,]\\d+)?)\\s*(kg|kgs?|kilogramos?|kilos?|t|to|tn|ton|tons?|toneladas?)\\b",
     std::regex::icase);
-static const std::regex kHoistTargetRe("\\bpara\\s+(.+)$", std::regex::icase);
+static const std::regex kHoistTargetRe("\\b(?:para|for)\\s+(.+)$",
+                                       std::regex::icase);
 static const std::regex kFixtureLineRe("^\\s*(?:[-*]\\s*)?(\\d+)\\s+(.+)$",
                                        std::regex::icase);
 static const std::regex kQuantityOnlyRe("^\\s*(?:[-*]\\s*)?(\\d+)\\s*$");

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -867,9 +867,43 @@ BuildTrussDictionaryLookupKeys(const std::string &modelToken,
       keys.push_back(normalized);
   };
 
+  auto simplifyModelToken = [](std::string token) {
+    token = TrussDictionary::NormalizeModelKey(token);
+    if (token.empty())
+      return token;
+
+    static const std::unordered_set<std::string> kFinishWords = {
+        "NEGRO", "NEGRA", "NEGRAS", "NEGROS", "BLACK",
+        "PLATA", "SILVER", "ALUMINIO", "ALUMINUM"};
+
+    std::istringstream iss(token);
+    std::string word;
+    std::vector<std::string> kept;
+    while (iss >> word) {
+      if (kFinishWords.find(word) != kFinishWords.end())
+        continue;
+      kept.push_back(word);
+    }
+    if (kept.empty())
+      return token;
+    std::ostringstream oss;
+    for (size_t i = 0; i < kept.size(); ++i) {
+      if (i > 0)
+        oss << ' ';
+      oss << kept[i];
+    }
+    return oss.str();
+  };
+
   pushNormalized(modelToken);
   if (!modelToken.empty())
     pushNormalized("TRUSS " + modelToken);
+  const std::string simplifiedModelToken = simplifyModelToken(modelToken);
+  if (!simplifiedModelToken.empty() && simplifiedModelToken !=
+                                          TrussDictionary::NormalizeModelKey(modelToken)) {
+    pushNormalized(simplifiedModelToken);
+    pushNormalized("TRUSS " + simplifiedModelToken);
+  }
   pushNormalized(trussName);
 
   return keys;

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -61,7 +61,7 @@ namespace {
 // the compilation cost on every import call and makes keyword matching cheap
 // even when processing large riders.
 static const std::regex kTrussLineRe(
-    "^\\s*(?:[-*]\\s*)?(\\d+)\\s+(?:truss)\\s+([^\\n]*?)\\s+(\\d+(?:\\.\\d+)?)\\s*(?:m|metros?|meters?)\\b(?:\\s+para\\s+(.+))?",
+    "^\\s*(?:[-*]\\s*)?(\\d+)\\s+(?:truss)\\s+([^\\n]*?)\\s+(\\d+(?:\\.\\d+)?)\\s*(?:m|metros?|meters?)\\b(?:\\s+(?:para\\s+)?(.+))?\\s*$",
     std::regex::icase);
 static const std::regex kTrussLineNoLengthRe(
     "^\\s*(?:[-*]\\s*)?(\\d+)\\s+(?:truss)\\s+([^\\n]*?)(?:\\s+para\\s+(.+))?\\s*$",
@@ -93,6 +93,9 @@ static const std::regex kHangFindRe(
 static const std::regex kHangOnlyRe(
     "^\\s*(LX\\d+|lx\\s*sides?|screen|pantalla|proyecci[oó]n|led\\s*screen|backdrops?|tel[oó]n(?:es)?|puente\\s+de\\s+tel[oó]n(?:es)?|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)\\s*$",
                                     std::regex::icase);
+static const std::regex kTrailingHangWithCoordinateRe(
+    "(LX\\d+|lx\\s*sides?|screen|pantalla|proyecci[oó]n|led\\s*screen|backdrops?|tel[oó]n(?:es)?|puente\\s+de\\s+tel[oó]n(?:es)?|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)(?:\\s*(\\([^\\)]*\\)))?\\s*$",
+    std::regex::icase);
 std::string Trim(const std::string &s) {
   size_t start = s.find_first_not_of(" \t\r\n");
   if (start == std::string::npos)
@@ -109,6 +112,23 @@ std::optional<std::string> ExtractParenthesizedToken(const std::string &text) {
   if (close == std::string::npos || close <= open)
     return std::nullopt;
   return text.substr(open, close - open + 1);
+}
+
+bool TryExtractTrailingHangWithCoordinate(std::string &text, std::string &hangOut,
+                                          std::string &coordinateSuffixOut) {
+  std::smatch trailingHangMatch;
+  if (!std::regex_search(text, trailingHangMatch, kTrailingHangWithCoordinateRe) ||
+      trailingHangMatch.size() < 2) {
+    return false;
+  }
+
+  hangOut = Trim(trailingHangMatch[1].str());
+  coordinateSuffixOut.clear();
+  if (trailingHangMatch.size() > 2 && trailingHangMatch[2].matched)
+    coordinateSuffixOut = Trim(trailingHangMatch[2].str());
+
+  text = Trim(text.substr(0, static_cast<size_t>(trailingHangMatch.position(0))));
+  return !hangOut.empty();
 }
 
 std::string ResolveGdtfPath(const MvrScene &scene,
@@ -1099,12 +1119,11 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
             targetMatch.size() > 1) {
           hang = targetMatch[1].str();
           model = Trim(model.substr(0, static_cast<size_t>(targetMatch.position(0))));
-        } else if (std::smatch trailingHangMatch;
-                   std::regex_search(model, trailingHangMatch, kHangFindRe) &&
-                   trailingHangMatch.position(0) + trailingHangMatch.length(0) ==
-                       static_cast<std::ptrdiff_t>(model.size())) {
-          hang = trailingHangMatch[1].str();
-          model = Trim(model.substr(0, static_cast<size_t>(trailingHangMatch.position(0))));
+        } else if (std::string trailingCoordinateSuffix;
+                   TryExtractTrailingHangWithCoordinate(model, hang,
+                                                        trailingCoordinateSuffix)) {
+          if (trussCoordinateSuffix.empty())
+            trussCoordinateSuffix = trailingCoordinateSuffix;
         } else if (std::regex_match(model, kHangOnlyRe)) {
           hang = model;
           model.clear();
@@ -1823,14 +1842,12 @@ bool RiderImporter::ImportText(const std::string &text) {
             model = Trim(model.substr(0, static_cast<size_t>(targetMatch.position(0))));
             coordinateOverride =
                 ParseTrussCoordinateOverride(hang, distanceUnitSystem);
-          } else if (std::smatch trailingHangMatch;
-                     std::regex_search(model, trailingHangMatch, kHangFindRe) &&
-                     trailingHangMatch.position(0) + trailingHangMatch.length(0) ==
-                         static_cast<std::ptrdiff_t>(model.size())) {
-            hang = Trim(trailingHangMatch[1].str());
-            model = Trim(model.substr(0, static_cast<size_t>(trailingHangMatch.position(0))));
-            coordinateOverride =
-                ParseTrussCoordinateOverride(hang, distanceUnitSystem);
+          } else if (std::string trailingCoordinateSuffix;
+                     TryExtractTrailingHangWithCoordinate(model, hang,
+                                                          trailingCoordinateSuffix)) {
+            if (!trailingCoordinateSuffix.empty())
+              hang += " " + trailingCoordinateSuffix;
+            coordinateOverride = ParseTrussCoordinateOverride(hang, distanceUnitSystem);
           } else if (std::regex_match(model, kHangOnlyRe)) {
             hang = model;
             model.clear();

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -172,6 +172,7 @@ Special screen-object handling:
 Supported truss syntax includes:
 
 - `N truss MODEL LENGTH m [para HANG]`
+- `N truss MODEL LENGTH m [HANG]` (hang can appear with or without `para`)
 - `N truss MODEL [para HANG]` (lengthless form, used for backdrop lines)
 - More generic fallback lines containing `truss` and a measurable length.
 - Optional coordinate override appended to hang in parentheses, e.g.

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -173,7 +173,9 @@ Supported truss syntax includes:
 
 - `N truss MODEL LENGTH m [para HANG]`
 - `N truss MODEL LENGTH m [HANG]` (hang can appear with or without `para`)
+- `N truss MODEL LENGTH m [for HANG]`
 - `N truss MODEL [para HANG]` (lengthless form, used for backdrop lines)
+- `N truss MODEL [for HANG]` (lengthless form, used for backdrop lines)
 - More generic fallback lines containing `truss` and a measurable length.
 - Optional coordinate override appended to hang in parentheses, e.g.
   - `LX1 (0, -1, 9)` => `x, y, z`
@@ -193,7 +195,7 @@ Key truss behaviors:
      parsed `LX*` or `SCREEN` truss span.
    - If no prior `LX*`/`SCREEN` span exists, `BACKDROP` uses `12 m` by default.
 2. If model token contains dimensions like `40x40`, width/height defaults are inferred from it.
-3. `para <hang>` overrides current hang.
+3. `para <hang>` / `for <hang>` overrides current hang.
 4. Prefix cleanup supports `PUENTE`/`PUENTES` in hang names.
 5. Long trusses are split into symmetric pieces using preferred segments (`3000, 2000, 1000, 500 mm`) plus a center piece when beneficial.
 6. Each piece becomes a truss object with computed `x` placement and hang-based

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -185,6 +185,8 @@ Supported truss syntax includes:
   - This can be written both in truss targets (`... PARA LX1 (7)`) and in
     hang headers (`LX1 (7)` / `LX1 (7):`), where truss placement inherits the
     hang override.
+  - If both are present, truss-line overrides take precedence over hang-header
+    overrides for any axis values provided in the truss line.
   - The **Apply filter** pass preserves these coordinate tokens so pressing
     **Create** after filtering keeps the same truss placement overrides.
 

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -203,6 +203,9 @@ Key truss behaviors:
    Coordinate values use the active UI distance unit system (`metric` or
    `imperial`) at import time.
 7. Dictionary/model resolution is attempted using normalized lookup keys.
+   - Lookup also tries model-token variants that remove common finish/color
+     adjectives (e.g. `NEGRO`, `BLACK`) so names like `40X40 PRO NEGRO` can
+     resolve against canonical dictionary entries such as `TRUSS 40X40 PRO 3M`.
 8. If model/symbol cannot be fully resolved to renderable geometry (`.3ds`/`.glb` available), importer keeps dummy-box truss data and logs a warning.
 
 Special case:

--- a/tests/rider_filter_preview_test.cpp
+++ b/tests/rider_filter_preview_test.cpp
@@ -109,6 +109,26 @@ int main() {
     return 1;
   }
 
+  const std::string inputEnglishForKeyword =
+      "RIGGING\n"
+      "1 TRUSS 40X40 PRO NEGRO 12m for LX2 (4)\n"
+      "1 TRUSS 40X40 for BACKDROP (8)\n";
+  const std::string previewEnglishForKeyword =
+      RiderImporter::BuildFixtureFilterPreview(inputEnglishForKeyword);
+  const std::string expectedEnglishForKeyword =
+      "\n"
+      "\n"
+      "RIGGING\n"
+      "1 TRUSS 40X40 PRO NEGRO 12m LX2 (4)\n"
+      "1 TRUSS 40X40 BACKDROP (8)";
+  if (previewEnglishForKeyword != expectedEnglishForKeyword) {
+    std::cerr << "English 'for' truss targets should be preserved.\n"
+              << "Expected:\n"
+              << expectedEnglishForKeyword << "\n\nGot:\n"
+              << previewEnglishForKeyword << "\n";
+    return 1;
+  }
+
   const std::string mixedSectionsInput =
       "SONIDO\n"
       "2 CLUSTER FORMADOS POR:\n"

--- a/tests/rider_filter_preview_test.cpp
+++ b/tests/rider_filter_preview_test.cpp
@@ -89,6 +89,26 @@ int main() {
     return 1;
   }
 
+  const std::string inputWithoutParaCoordinates =
+      "RIGGING\n"
+      "1 TRUSS 40X40 PRO NEGRO 12m LX1 (-1)\n"
+      "1 TRUSS 40X40 BACKDROP (8)\n";
+  const std::string previewWithoutParaCoordinates =
+      RiderImporter::BuildFixtureFilterPreview(inputWithoutParaCoordinates);
+  const std::string expectedWithoutParaCoordinates =
+      "\n"
+      "\n"
+      "RIGGING\n"
+      "1 TRUSS 40X40 PRO NEGRO 12m LX1 (-1)\n"
+      "1 TRUSS 40X40 BACKDROP (8)";
+  if (previewWithoutParaCoordinates != expectedWithoutParaCoordinates) {
+    std::cerr << "No-PARA truss targets with coordinates should be preserved.\n"
+              << "Expected:\n"
+              << expectedWithoutParaCoordinates << "\n\nGot:\n"
+              << previewWithoutParaCoordinates << "\n";
+    return 1;
+  }
+
   const std::string mixedSectionsInput =
       "SONIDO\n"
       "2 CLUSTER FORMADOS POR:\n"

--- a/tests/rider_hoist_import_test.cpp
+++ b/tests/rider_hoist_import_test.cpp
@@ -200,6 +200,10 @@ int main() {
   assert(lx2Count > 0);
   assert(lx3Count > 0);
   assert(backdropCount > 0);
+  for (const auto &[layerUuid, layer] : noParaScene.layers) {
+    (void)layerUuid;
+    assert(layer.name.find('(') == std::string::npos);
+  }
 
   cfg.Reset();
   cfg.SetValue("ui_distance_unit_system", "metric");

--- a/tests/rider_hoist_import_test.cpp
+++ b/tests/rider_hoist_import_test.cpp
@@ -201,5 +201,28 @@ int main() {
   assert(lx3Count > 0);
   assert(backdropCount > 0);
 
+  cfg.Reset();
+  cfg.SetValue("ui_distance_unit_system", "metric");
+  const std::string englishForKeywordText =
+      "RIGGING\n"
+      "1 TRUSS 40X40 PRO NEGRO 12m for LX1 (-1)\n"
+      "1 TRUSS 40X40 for BACKDROP (8)\n";
+  assert(RiderImporter::ImportText(englishForKeywordText));
+  const auto &englishForScene = cfg.GetScene();
+  bool foundEnglishLx1 = false;
+  bool foundEnglishBackdrop = false;
+  for (const auto &[uuid, truss] : englishForScene.trusses) {
+    (void)uuid;
+    if (truss.positionName == "LX1") {
+      foundEnglishLx1 = true;
+      assert(std::abs(truss.transform.o[1] - (-1000.0f)) < 0.001f);
+    } else if (truss.positionName == "BACKDROP") {
+      foundEnglishBackdrop = true;
+      assert(std::abs(truss.transform.o[1] - 8000.0f) < 0.001f);
+    }
+  }
+  assert(foundEnglishLx1);
+  assert(foundEnglishBackdrop);
+
   return 0;
 }

--- a/tests/rider_hoist_import_test.cpp
+++ b/tests/rider_hoist_import_test.cpp
@@ -166,5 +166,40 @@ int main() {
   assert(filteredBackdropTrussHasModelInfo);
   assert(filteredBackdropSupports == 2);
 
+  cfg.Reset();
+  cfg.SetValue("ui_distance_unit_system", "metric");
+  const std::string noParaCoordinatesText =
+      "RIGGING\n"
+      "1 TRUSS 40X40 PRO NEGRO 12m LX1 (-1)\n"
+      "1 TRUSS 40X40 PRO NEGRO 12m LX2 (4)\n"
+      "1 TRUSS 40X40 PRO NEGRO 12m LX3 (7)\n"
+      "1 TRUSS 40X40 BACKDROP (8)\n";
+  assert(RiderImporter::ImportText(noParaCoordinatesText));
+  const auto &noParaScene = cfg.GetScene();
+  int lx1Count = 0;
+  int lx2Count = 0;
+  int lx3Count = 0;
+  int backdropCount = 0;
+  for (const auto &[uuid, truss] : noParaScene.trusses) {
+    (void)uuid;
+    if (truss.positionName == "LX1") {
+      ++lx1Count;
+      assert(std::abs(truss.transform.o[1] - (-1000.0f)) < 0.001f);
+    } else if (truss.positionName == "LX2") {
+      ++lx2Count;
+      assert(std::abs(truss.transform.o[1] - 4000.0f) < 0.001f);
+    } else if (truss.positionName == "LX3") {
+      ++lx3Count;
+      assert(std::abs(truss.transform.o[1] - 7000.0f) < 0.001f);
+    } else if (truss.positionName == "BACKDROP") {
+      ++backdropCount;
+      assert(std::abs(truss.transform.o[1] - 8000.0f) < 0.001f);
+    }
+  }
+  assert(lx1Count > 0);
+  assert(lx2Count > 0);
+  assert(lx3Count > 0);
+  assert(backdropCount > 0);
+
   return 0;
 }

--- a/tests/rider_truss_dictionary_normalization_test.cpp
+++ b/tests/rider_truss_dictionary_normalization_test.cpp
@@ -146,6 +146,10 @@ int main() {
   AssertModelTokenDictionaryLookupWorks("1 truss FK40Q 3 m para lx1\n");
   AssertModelTokenDictionaryLookupWorks("1 truss fk40q 3 m para lx1\n");
 
+  TrussDictionary::Update("TRUSS 40X40 PRO 3M", ToUtf8String(archivePath));
+  AssertTrussSymbolResolved("1 truss 40X40 PRO NEGRO 3m para lx1\n");
+  AssertTrussSymbolResolved("1 truss 40X40 PRO BLACK 3m for lx1\n");
+
   TrussDictionary::Save({});
   fs::remove_all(tempRoot, ec);
   return 0;


### PR DESCRIPTION
### Motivation
- Truss hang tokens written after the length (e.g. `12m LX1 (-1)`) were not reliably parsed when `para` was omitted, causing coordinate overrides to be lost and backdrop trusses to not be created as expected. 
- The change aims to preserve trailing hang+coordinate tokens and make placement behavior consistent with the documented text-to-scene rules.

### Description
- Relaxed the truss line regex to accept an optional hang after the length either with or without the `para` keyword by updating `kTrussLineRe` in `core/riderimporter.cpp`. 
- Added `kTrailingHangWithCoordinateRe` and the helper `TryExtractTrailingHangWithCoordinate(...)` to extract trailing hang names plus optional parenthesized coordinates from a model/hang token. 
- Reused the extractor in the filter-preview normalization path and import-time no-length/backdrop parsing so coordinate tokens like `LX1 (-1)` and `BACKDROP (8)` are preserved and applied when building the scene. 
- Updated documentation `docs/text_to_scene_rules.md` to clarify `LENGTH m [HANG]` (hang can appear with or without `para`) and added regression checks in `tests/rider_filter_preview_test.cpp` and `tests/rider_hoist_import_test.cpp` to cover preview preservation and placement/backdrop creation.

### Testing
- Ran repository mandatory checks: `tests/check_perastage_tree_modules.sh` (OK) and `tests/check_no_configmanager_get_in_gui.sh` (OK). 
- Attempted local configure with `cmake --preset wsl-x64-debug`, but configure failed in this container due to missing `wxWidgets` development packages so full build/tests could not be executed here. 
- Added/updated unit test cases in `tests/rider_filter_preview_test.cpp` and `tests/rider_hoist_import_test.cpp` (these provide regression coverage and will run in CI where dependencies are available).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce34ebe34c8324bbc22aa11df034aa)