### PR TITLE
Harden render pipeline teardown diagnostics

### DIFF
--- a/viewer3d/render/render_pipeline.cpp
+++ b/viewer3d/render/render_pipeline.cpp
@@ -1,36 +1,57 @@
 #include "render_pipeline.h"
 
+#include "logger.h"
 #include "viewer3dcontroller.h"
 
 #include <cassert>
+#include <sstream>
+
+namespace {
+std::string BuildTeardownDiagnostic(const RenderFrameContext &context,
+                                    const Viewer3DVisibleSet *visibleSet,
+                                    bool framePrepared) {
+  std::ostringstream oss;
+  oss << "RenderPipeline teardown with pending frame"
+      << " [framePrepared=" << framePrepared
+      << ", visibleSetPrepared=" << (visibleSet != nullptr)
+      << ", is2DViewer=" << context.is2DViewer
+      << ", wireframe=" << context.wireframe
+      << ", useFrustumCulling=" << context.useFrustumCulling
+      << ", hiddenLayers=" << context.hiddenLayers.size() << ']';
+  return oss.str();
+}
+} // namespace
 
 RenderPipeline::RenderPipeline(Viewer3DController &controller)
     : m_controller(controller) {}
 
 RenderPipeline::~RenderPipeline() {
   if (m_framePrepared) {
-    assert(false && "RenderPipeline invariant violated: FinalizeFrame() must be called");
+    Logger::Instance().Log(Logger::Level::Warn,
+                           BuildTeardownDiagnostic(m_context, m_visibleSet,
+                                                   m_framePrepared));
     FinalizeFrame();
   }
 }
 
 void RenderPipeline::Execute(const RenderFrameContext &context) {
-  PrepareFrame(context);
-
   struct FinalizeGuard {
     RenderPipeline &pipeline;
     ~FinalizeGuard() { pipeline.FinalizeFrame(); }
   } guard{*this};
 
+  PrepareFrame(context);
   RenderOpaque();
   RenderOverlays();
 }
 
 void RenderPipeline::PrepareFrame(const RenderFrameContext &context) {
   assert(!m_framePrepared && "RenderPipeline invariant violated: frame already prepared");
+  assert(!m_visibleSet &&
+         "RenderPipeline invariant violated: visible set must be null before preparation");
   m_context = context;
-  m_visibleSet = &m_controller.PrepareRenderFrame(m_context, m_frustum);
   m_framePrepared = true;
+  m_visibleSet = &m_controller.PrepareRenderFrame(m_context, m_frustum);
 }
 
 void RenderPipeline::RenderOpaque() {


### PR DESCRIPTION
### Motivation
- Avoid aborting the process during application teardown by replacing a destructive `assert(false)` in the `RenderPipeline` destructor with a non-intrusive diagnostic and defensive cleanup. 
- Ensure the `Execute -> guard -> FinalizeFrame` flow is reliable even if `PrepareRenderFrame` throws, while preserving debug-only invariants at render entry points.

### Description
- Replace the destructor assertion with a warning log via `Logger::Instance()` and a defensive `FinalizeFrame()` call, emitting the marker `RenderPipeline teardown with pending frame` plus compact frame context. 
- Move the `FinalizeGuard` construction before calling `PrepareFrame`, set `m_framePrepared = true` before invoking `PrepareRenderFrame`, and add an assert that `m_visibleSet` is null at preparation start so the guard always triggers `FinalizeFrame` even on exceptions. 
- Add `#include "logger.h"` and `<sstream>` and introduce a small helper `BuildTeardownDiagnostic` to format the teardown message.

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which succeeded. 
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce35654fd083248130b445697be359)