### PR TITLE
CLI: treat `t`/`thru` as range separators in pos/rot/axis commands

### DIFF
--- a/gui/consolepanel.cpp
+++ b/gui/consolepanel.cpp
@@ -809,7 +809,8 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
       size_t j = i + 1;
       bool allowAxis = (lw != "pos" && lw != "rot");
       bool allowRangeSeparator =
-          (!lw.empty() && (lw[0] == 'f' || lw[0] == 't'));
+          (lw == "pos" || lw == "rot" || lw == "x" || lw == "y" ||
+           lw == "z" || (!lw.empty() && (lw[0] == 'f' || lw[0] == 't')));
       while (j < tokens.size() &&
              !isCmd(tokens[j], allowAxis, allowRangeSeparator))
         ++j;


### PR DESCRIPTION
### Motivation
- Users expect inputs like `pos x -5 t 5` or `pos x -5 thru 5` to be treated as start/end ranges; previously the `t` token could be parsed as a new command, causing all items to be placed at the start value instead of distributed across the range.

### Description
- Adjusted the command-token boundary detection in `gui/consolepanel.cpp` so `allowRangeSeparator` is enabled for `pos`, `rot`, and direct axis commands (`x`, `y`, `z`), allowing `t`/`thru` to be treated as ordinary range separators and letting the existing range-parsing logic handle them.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both returned `OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce98281d54832497f482e64e02b4ab)