### PR TITLE
Add global P/R shortcuts to focus CLI with safe non-destructive prefill

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -51,6 +51,8 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow/controllers/mainwindow_view_controller.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_io.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_layout.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_cli_shortcut_router.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_cli_shortcuts.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_view_shortcuts.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_menu.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_print.cpp

--- a/gui/consolepanel.cpp
+++ b/gui/consolepanel.cpp
@@ -277,6 +277,41 @@ ConsolePanel *ConsolePanel::Instance() { return s_instance; }
 
 void ConsolePanel::SetInstance(ConsolePanel *panel) { s_instance = panel; }
 
+bool ConsolePanel::IsInputWidgetOrChild(const wxWindow *window) const {
+  if (!window || !m_inputCtrl)
+    return false;
+
+  const wxWindow *current = window;
+  while (current) {
+    if (current == m_inputCtrl)
+      return true;
+    current = current->GetParent();
+  }
+  return false;
+}
+
+bool ConsolePanel::InputHasTypedContent() const {
+  if (!m_inputCtrl)
+    return false;
+
+  wxString value = m_inputCtrl->GetValue();
+  if (value.StartsWith(">>> "))
+    value = value.Mid(4);
+  value.Trim(true).Trim(false);
+  return !value.IsEmpty();
+}
+
+void ConsolePanel::FocusInputWithOptionalPrefill(const wxString &text) {
+  if (!m_inputCtrl)
+    return;
+
+  if (!text.IsEmpty() && !InputHasTypedContent())
+    m_inputCtrl->SetValue(">>> " + text);
+
+  m_inputCtrl->SetFocus();
+  m_inputCtrl->SetInsertionPointEnd();
+}
+
 void ConsolePanel::OnScroll(wxScrollWinEvent &event) {
   if (!m_textCtrl) {
     event.Skip();

--- a/gui/consolepanel.h
+++ b/gui/consolepanel.h
@@ -33,6 +33,9 @@ public:
     // Access singleton instance
     static ConsolePanel* Instance();
     static void SetInstance(ConsolePanel* panel);
+    bool IsInputWidgetOrChild(const wxWindow* window) const;
+    bool InputHasTypedContent() const;
+    void FocusInputWithOptionalPrefill(const wxString& text);
 
 private:
     wxTextCtrl* m_textCtrl = nullptr;

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -315,6 +315,7 @@ MainWindow::MainWindow(const wxString &title, IGuiConfigServices *services)
     layoutPanel->ReloadLayouts();
 
   Bind(wxEVT_IDLE, &MainWindow::OnStartupSplashCloseIdle, this);
+  Bind(wxEVT_CHAR_HOOK, &MainWindow::OnGlobalCharHook, this);
 
   SetStartupProjectLoadPending(true);
   UpdateTitle();

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -75,6 +75,8 @@ public:
   static void SetInstance(MainWindow *inst);
 
   void EnableShortcuts(bool enable);
+  bool IsEditableTextWidgetOrChild(const wxWindow *window) const;
+  void FocusConsoleForQuickCommand(const wxString &prefill);
   void Ensure2DViewportAvailable();
   Viewer2DPanel *GetLayoutCapturePanel() const;
   Viewer2DOffscreenRenderer *GetOffscreenRenderer();
@@ -173,6 +175,7 @@ private:
   void OnSelectSupports(wxCommandEvent &event);       // Switch to supports tab
   void OnSelectObjects(wxCommandEvent &event);        // Switch to objects tab
   void OnNotebookPageChanged(wxBookCtrlEvent &event); // Update summary panel
+  void OnGlobalCharHook(wxKeyEvent &event);
   void RefreshSummary();                              // Refresh summary counts
   void RefreshAfterSceneChange(bool refreshViewport = true);
   void RefreshAfterUnitSystemChange();

--- a/gui/mainwindow_cli_shortcut_router.cpp
+++ b/gui/mainwindow_cli_shortcut_router.cpp
@@ -1,0 +1,30 @@
+#include "mainwindow_cli_shortcut_router.h"
+
+#include <cctype>
+
+namespace gui {
+
+CliShortcutRouteResult RouteCliShortcut(int keyCode,
+                                        const CliShortcutRouteContext &context) {
+  CliShortcutRouteResult result;
+
+  if (context.hasModifiers || context.focusInCliInput ||
+      context.focusInEditableText) {
+    return result;
+  }
+
+  const int normalizedKey = std::toupper(keyCode);
+  if (normalizedKey == 'P') {
+    result.shouldFocusCli = true;
+    if (!context.cliHasTypedContent)
+      result.prefill = "pos ";
+  } else if (normalizedKey == 'R') {
+    result.shouldFocusCli = true;
+    if (!context.cliHasTypedContent)
+      result.prefill = "rot ";
+  }
+
+  return result;
+}
+
+} // namespace gui

--- a/gui/mainwindow_cli_shortcut_router.h
+++ b/gui/mainwindow_cli_shortcut_router.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <string>
+
+namespace gui {
+
+struct CliShortcutRouteContext {
+  bool hasModifiers = false;
+  bool focusInCliInput = false;
+  bool focusInEditableText = false;
+  bool cliHasTypedContent = false;
+};
+
+struct CliShortcutRouteResult {
+  bool shouldFocusCli = false;
+  std::string prefill;
+};
+
+CliShortcutRouteResult RouteCliShortcut(int keyCode,
+                                        const CliShortcutRouteContext &context);
+
+} // namespace gui

--- a/gui/mainwindow_cli_shortcuts.cpp
+++ b/gui/mainwindow_cli_shortcuts.cpp
@@ -1,0 +1,61 @@
+#include "mainwindow.h"
+
+#include "consolepanel.h"
+#include "mainwindow_cli_shortcut_router.h"
+
+#include <wx/combobox.h>
+#include <wx/textctrl.h>
+
+bool MainWindow::IsEditableTextWidgetOrChild(const wxWindow *window) const {
+  const wxWindow *current = window;
+  while (current) {
+    if (dynamic_cast<const wxTextCtrl *>(current))
+      return true;
+    if (auto *combo = dynamic_cast<const wxComboBox *>(current);
+        combo && combo->IsEditable()) {
+      return true;
+    }
+    current = current->GetParent();
+  }
+  return false;
+}
+
+void MainWindow::FocusConsoleForQuickCommand(const wxString &prefill) {
+  if (!consolePanel)
+    return;
+
+  if (auiManager) {
+    auto &pane = auiManager->GetPane("Console");
+    if (pane.IsOk() && !pane.IsShown()) {
+      pane.Show(true);
+      auiManager->Update();
+      UpdateViewMenuChecks();
+    }
+  }
+
+  consolePanel->FocusInputWithOptionalPrefill(prefill);
+}
+
+void MainWindow::OnGlobalCharHook(wxKeyEvent &event) {
+  if (!consolePanel) {
+    event.Skip();
+    return;
+  }
+
+  const gui::CliShortcutRouteContext context{
+      .hasModifiers =
+          event.ControlDown() || event.AltDown() || event.MetaDown(),
+      .focusInCliInput = consolePanel->IsInputWidgetOrChild(FindFocus()),
+      .focusInEditableText = IsEditableTextWidgetOrChild(FindFocus()),
+      .cliHasTypedContent = consolePanel->InputHasTypedContent(),
+  };
+
+  const gui::CliShortcutRouteResult route =
+      gui::RouteCliShortcut(event.GetKeyCode(), context);
+  if (!route.shouldFocusCli) {
+    event.Skip();
+    return;
+  }
+
+  FocusConsoleForQuickCommand(wxString::FromUTF8(route.prefill));
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,6 +69,12 @@ target_include_directories(fixture_table_parser_test PRIVATE .. ../gui)
 target_link_libraries(fixture_table_parser_test PRIVATE ${wxWidgets_LIBRARIES})
 add_test(NAME FixtureTableParser COMMAND fixture_table_parser_test)
 
+add_executable(mainwindow_cli_shortcut_router_test
+               mainwindow_cli_shortcut_router_test.cpp
+               ../gui/mainwindow_cli_shortcut_router.cpp)
+target_include_directories(mainwindow_cli_shortcut_router_test PRIVATE .. ../gui)
+add_test(NAME MainWindowCliShortcutRouter COMMAND mainwindow_cli_shortcut_router_test)
+
 
 add_executable(ui_unit_utils_test
                ui_unit_utils_test.cpp

--- a/tests/mainwindow_cli_shortcut_router_test.cpp
+++ b/tests/mainwindow_cli_shortcut_router_test.cpp
@@ -1,0 +1,55 @@
+#include "mainwindow_cli_shortcut_router.h"
+
+#include <cassert>
+
+int main() {
+  {
+    const gui::CliShortcutRouteContext context{
+        .hasModifiers = false,
+        .focusInCliInput = false,
+        .focusInEditableText = false,
+        .cliHasTypedContent = false,
+    };
+    const auto result = gui::RouteCliShortcut('P', context);
+    assert(result.shouldFocusCli);
+    assert(result.prefill == "pos ");
+  }
+
+  {
+    const gui::CliShortcutRouteContext context{
+        .hasModifiers = false,
+        .focusInCliInput = true,
+        .focusInEditableText = false,
+        .cliHasTypedContent = false,
+    };
+    const auto result = gui::RouteCliShortcut('R', context);
+    assert(!result.shouldFocusCli);
+    assert(result.prefill.empty());
+  }
+
+  {
+    const gui::CliShortcutRouteContext context{
+        .hasModifiers = false,
+        .focusInCliInput = false,
+        .focusInEditableText = true,
+        .cliHasTypedContent = false,
+    };
+    const auto result = gui::RouteCliShortcut('P', context);
+    assert(!result.shouldFocusCli);
+    assert(result.prefill.empty());
+  }
+
+  {
+    const gui::CliShortcutRouteContext context{
+        .hasModifiers = false,
+        .focusInCliInput = false,
+        .focusInEditableText = false,
+        .cliHasTypedContent = true,
+    };
+    const auto result = gui::RouteCliShortcut('R', context);
+    assert(result.shouldFocusCli);
+    assert(result.prefill.empty());
+  }
+
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- Provide a small, centralized way to send quick scene-edit commands to the CLI by pressing `P` or `R` from anywhere in the GUI without breaking existing shortcuts or in-widget typing. 
- Keep the change modular and responsibility-focused by routing decision logic out of `MainWindow` into a dedicated router module.

### Description
- Added a CLI shortcut router module `gui/mainwindow_cli_shortcut_router.{h,cpp}` that decides whether `P`/`R` should focus the CLI and whether to prefill `pos ` / `rot ` based on context. 
- Added `gui/mainwindow_cli_shortcuts.cpp` which hooks `MainWindow` into `wxEVT_CHAR_HOOK`, computes focus/context (CLI input, editable text widgets, modifier keys) and forwards prefill/focus requests to the console. 
- Extended `ConsolePanel` (`consolepanel.h/.cpp`) with helpers `IsInputWidgetOrChild`, `InputHasTypedContent`, and `FocusInputWithOptionalPrefill` to safely focus and prefill without overwriting user-typed content. 
- Registered new sources and the test in `gui/CMakeLists.txt` and `tests/CMakeLists.txt`, and added `tests/mainwindow_cli_shortcut_router_test.cpp` with unit tests for routing logic.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed. 
- Attempted full `cmake`/`ctest` build of the test target but CMake configuration failed in this environment due to missing `wxWidgets` development package; this is an environment issue and not a code failure. 
- Compiled and executed the router unit test directly with `g++ -std=c++20 -I. -Igui tests/mainwindow_cli_shortcut_router_test.cpp gui/mainwindow_cli_shortcut_router.cpp` and it ran successfully (all assertions passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce9a127c90832490936a33110f2524)