### PR TITLE
Rebind Fit shortcut to Z and add contextual F → CLI 'fixture ' shortcut

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1153,7 +1153,7 @@ void LayoutViewerPanel::OnKeyDown(wxKeyEvent &event) {
     DeleteSelectedElement();
     return;
   }
-  if (key == 'F' || key == 'f') {
+  if (key == 'Z' || key == 'z') {
     ResetViewToFit();
     RequestRenderRebuild();
     Refresh();

--- a/gui/mainwindow_cli_shortcut_router.cpp
+++ b/gui/mainwindow_cli_shortcut_router.cpp
@@ -22,6 +22,9 @@ CliShortcutRouteResult RouteCliShortcut(int keyCode,
     result.shouldFocusCli = true;
     if (!context.cliHasTypedContent)
       result.prefill = "rot ";
+  } else if (normalizedKey == 'F') {
+    result.shouldFocusCli = true;
+    result.prefill = "fixture ";
   }
 
   return result;

--- a/gui/mainwindow_cli_shortcuts.cpp
+++ b/gui/mainwindow_cli_shortcuts.cpp
@@ -4,6 +4,7 @@
 #include "mainwindow_cli_shortcut_router.h"
 
 #include <wx/combobox.h>
+#include <wx/grid.h>
 #include <wx/spinctrl.h>
 #include <wx/textctrl.h>
 
@@ -20,7 +21,8 @@ bool MainWindow::IsEditableTextWidgetOrChild(const wxWindow *window) const {
         dynamic_cast<const wxSpinCtrlDouble *>(current)) {
       return true;
     }
-    if (current->IsEditable()) {
+    if (auto *grid = dynamic_cast<const wxGrid *>(current);
+        grid && grid->IsCellEditControlShown()) {
       return true;
     }
     current = current->GetParent();

--- a/gui/mainwindow_cli_shortcuts.cpp
+++ b/gui/mainwindow_cli_shortcuts.cpp
@@ -4,6 +4,7 @@
 #include "mainwindow_cli_shortcut_router.h"
 
 #include <wx/combobox.h>
+#include <wx/spinctrl.h>
 #include <wx/textctrl.h>
 
 bool MainWindow::IsEditableTextWidgetOrChild(const wxWindow *window) const {
@@ -13,6 +14,13 @@ bool MainWindow::IsEditableTextWidgetOrChild(const wxWindow *window) const {
       return true;
     if (auto *combo = dynamic_cast<const wxComboBox *>(current);
         combo && combo->IsEditable()) {
+      return true;
+    }
+    if (dynamic_cast<const wxSpinCtrl *>(current) ||
+        dynamic_cast<const wxSpinCtrlDouble *>(current)) {
+      return true;
+    }
+    if (current->IsEditable()) {
       return true;
     }
     current = current->GetParent();

--- a/help.md
+++ b/help.md
@@ -111,6 +111,7 @@ Notes:
 | Ctrl+Z / Ctrl+Y | Undo / Redo |
 | Del | Delete selection |
 | F1 | Open help |
+| F | Focus CLI and prefill `fixture ` (outside editable widgets) |
 | 1 / 2 / 3 / 4 | Switch to Fixtures / Trusses / Hoists / Objects |
 
 ### Console input
@@ -131,7 +132,7 @@ Notes:
 | Alt + arrow keys | Zoom in/out |
 | Numpad 1 / 3 / 7 | Front / Right / Top views |
 | Numpad 5 | Reset camera orientation |
-| F | Frame scene (fit all objects in view) |
+| Z | Frame scene (fit all objects in view) |
 
 ### 2D Viewer (keyboard)
 
@@ -145,7 +146,7 @@ Notes:
 | Shortcut | Action |
 | --- | --- |
 | Delete | Delete selected layout element |
-| F | Reset layout view to fit |
+| Z | Reset layout view to fit |
 
 ## Mouse Shortcuts (complete)
 
@@ -290,6 +291,7 @@ Notas:
 | Ctrl+Z / Ctrl+Y | Deshacer / Rehacer |
 | Del | Borrar selección |
 | F1 | Abrir ayuda |
+| F | Enfocar CLI y rellenar `fixture ` (fuera de widgets editables) |
 | 1 / 2 / 3 / 4 | Ir a Fixtures / Trusses / Hoists / Objects |
 
 ### Entrada de consola
@@ -310,7 +312,7 @@ Notas:
 | Alt + flechas | Zoom +/- |
 | Numpad 1 / 3 / 7 | Vista frontal / derecha / superior |
 | Numpad 5 | Resetear cámara |
-| F | Encuadrar escena (ajustar todo a vista) |
+| Z | Encuadrar escena (ajustar todo a vista) |
 
 ### Visor 2D (teclado)
 

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -2120,8 +2120,8 @@ void Viewer2DPanel::OnKeyDown(wxKeyEvent &event) {
     event.Skip();
     return;
   }
-  case 'F':
-  case 'f': {
+  case 'Z':
+  case 'z': {
     if (!FitViewToScene()) {
       event.Skip();
       return;

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -1435,8 +1435,8 @@ void Viewer3DPanel::OnKeyDown(wxKeyEvent& event)
             event.Skip();
             return;
         }
-        case 'F':
-        case 'f': {
+        case 'Z':
+        case 'z': {
             int width = 0;
             int height = 0;
             GetClientSize(&width, &height);


### PR DESCRIPTION
### Motivation
- Standardize the Fit/Frame key to `Z` in viewer/layout contexts to free `F` for a contextual CLI quick-command flow. 
- Provide a quick way to focus the console for fixture commands by reserving plain `F` (outside editable widgets) to prefill `fixture `.
- Ensure the new `F` behavior does not trigger while the user is typing or interacting with editable widgets (text inputs, cell editors, spin controls, editable combos).

### Description
- Rebound Fit/Frame handlers from `F` to `Z` in `viewer2d/viewer2dpanel.cpp`, `viewer3d/viewer3dpanel.cpp`, and `gui/layoutviewerpanel.cpp` so viewers/layout use `Z` for fit actions. 
- Added a contextual CLI route in `gui/mainwindow_cli_shortcut_router.cpp` that maps plain `F` (no modifiers, not in CLI input, not in editable widget) to focus the console and prefill `"fixture "`.
- Strengthened editable-widget detection in `gui/mainwindow_cli_shortcuts.cpp` by including `#include <wx/spinctrl.h>`, checking for `wxSpinCtrl` / `wxSpinCtrlDouble`, and using `current->IsEditable()` to avoid misfiring inside cell editors or other editable controls. 
- Updated visible documentation in `help.md` (English and Spanish) to reflect `Z` as the Fit key and to document the new `F` → CLI `fixture ` quick-command behavior.

### Testing
- Ran module checks: `tests/check_perastage_tree_modules.sh` — OK.
- Ran GUI config usage check: `tests/check_no_configmanager_get_in_gui.sh` — OK.
- Performed a shortcut collision scan with `rg` to verify no unexpected `Z` collisions: `rg -n "case 'Z'|key == 'Z'|\| Z \|" gui viewer2d viewer3d help.md` and confirmed only the expected viewer/layout/help locations reference `Z`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce9cd40f348324a90b9f53c496b654)