### PR TITLE
Centralize GUI shortcut registry and focus routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,12 @@ Keep Perastage clean and modular while continuing to deliver new features, follo
      must update `docs/text_to_scene_rules.md` in the same PR.
    - If behavior becomes user-visible, also update Help/README references.
 
+8. **Shortcut documentation policy**
+   - Any change that adds, removes, or remaps GUI shortcuts must update
+     `docs/gui_shortcut_architecture.md` in the same PR.
+   - If shortcut scope/priority/focus behavior changes, document the
+     resolution and precedence impact in that file.
+
 ## Current hotspots (watch for growth)
 - `gui/layoutviewerpanel.cpp`
 - `viewer2d/viewer2dpanel.cpp`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,3 +30,7 @@ This document defines the expected directory conventions for Perastage.
 
 - Scene-object presets live in `library/scene_objects/`.
 - Any new code/path references must use `scene_objects` (underscore), not `scene objects`.
+
+## GUI architecture references
+
+- Keyboard shortcut routing and scope rules are documented in `docs/gui_shortcut_architecture.md`.

--- a/docs/gui_shortcut_architecture.md
+++ b/docs/gui_shortcut_architecture.md
@@ -30,6 +30,14 @@ Each shortcut entry defines:
 | `P` | `CliPrefillPos` | `cli` | `Cli` | Block in editable widgets |
 | `R` | `CliPrefillRot` | `cli` | `Cli` | Block in editable widgets |
 | `F` | `CliPrefillFixture` | `cli` | `Cli` | Block in editable widgets |
+| `1` | `SelectFixturesTab` | `gui` | `Global` | Block in editable widgets |
+| `2` | `SelectTrussesTab` | `gui` | `Global` | Block in editable widgets |
+| `3` | `SelectSupportsTab` | `gui` | `Global` | Block in editable widgets |
+| `4` | `SelectObjectsTab` | `gui` | `Global` | Block in editable widgets |
+| `NumPad1` | `ViewportFront` | `viewer3d` | `Viewer3D` | Block in editable widgets |
+| `NumPad3` | `ViewportSide` | `viewer3d` | `Viewer3D` | Block in editable widgets |
+| `NumPad7` | `ViewportTop` | `viewer3d` | `Viewer3D` | Block in editable widgets |
+| `NumPad5` | `ViewportReset3D` | `viewer3d` | `Viewer3D` | Block in editable widgets |
 
 ## Priority and resolution rules
 
@@ -58,9 +66,11 @@ This makes shortcut behavior deterministic and keeps one single decision point f
 
 1. `MainWindow::OnGlobalCharHook(...)` builds a `ShortcutExecutionContext` from focus state.
 2. The hook asks `ResolveShortcut(...)` for one decision.
-3. `MainWindow::ApplyShortcutDecision(...)` executes either:
-   - `ApplyFitShortcut()` for focused viewer scope, or
-   - `FocusConsoleForQuickCommand(...)` for CLI-prefill actions.
+3. `MainWindow::ApplyShortcutDecision(...)` executes the routed action:
+   - `ApplyFitShortcut()` for focused viewer fit,
+   - `FocusConsoleForQuickCommand(...)` for CLI-prefill actions,
+   - notebook-tab selection commands for `1..4`,
+   - 3D viewport standard/reset view commands for numpad actions.
 
 Viewer-specific direct handling for these migrated shortcuts is intentionally avoided,
 so routing stays centralized in GUI.

--- a/docs/gui_shortcut_architecture.md
+++ b/docs/gui_shortcut_architecture.md
@@ -1,0 +1,66 @@
+# GUI shortcut architecture
+
+## Goal
+
+Perastage uses a centralized GUI shortcut registry to keep keyboard behavior explicit,
+validated and consistent across modules.
+
+## Central registry
+
+The canonical shortcut map lives in:
+
+- `gui/shortcut_registry.h`
+- `gui/shortcut_registry.cpp`
+
+Each shortcut entry defines:
+
+- **Key combination** (`keyCode` for non-modifier shortcuts).
+- **Action** (`ShortcutAction`).
+- **Owner module** (`ownerModule`).
+- **Scope** (`ShortcutScope`: `Global`, `Viewer2D`, `Viewer3D`, `Cli`).
+- **Focus policy** (`ShortcutFocusPolicy`: allowed or blocked in editable widgets).
+- **Priority** (used when multiple entries share the same key across scopes).
+
+## Current shortcut map
+
+| Key | Action | Owner | Scope | Focus policy |
+|---|---|---|---|---|
+| `Z` | `FitView` | `viewer2d` | `Viewer2D` | Block in editable widgets |
+| `Z` | `FitView` | `viewer3d` | `Viewer3D` | Block in editable widgets |
+| `P` | `CliPrefillPos` | `cli` | `Cli` | Block in editable widgets |
+| `R` | `CliPrefillRot` | `cli` | `Cli` | Block in editable widgets |
+| `F` | `CliPrefillFixture` | `cli` | `Cli` | Block in editable widgets |
+
+## Priority and resolution rules
+
+Resolution is performed by `ResolveShortcut(...)`.
+
+1. Normalize key code to uppercase.
+2. Filter shortcuts with matching key.
+3. Apply focus gating through `CanExecuteShortcut(...)`:
+   - reject when modifiers are active,
+   - reject when policy blocks editable-focus and focus is in editable text,
+   - require scope/focus match (for example, `Viewer2D` requires focus in 2D viewer).
+4. Select the highest-priority shortcut among eligible entries.
+5. Return one execution decision for `MainWindow::OnGlobalCharHook(...)`.
+
+This makes shortcut behavior deterministic and keeps one single decision point for
+"can this shortcut run under current focus?".
+
+## Startup/test validation
+
+`ValidateShortcutRegistry()` detects collisions by `(scope, normalized key)`.
+
+- Called at `MainWindow` startup (debug assertion + error log).
+- Covered by `tests/shortcut_registry_test.cpp`.
+
+## Execution flow in GUI
+
+1. `MainWindow::OnGlobalCharHook(...)` builds a `ShortcutExecutionContext` from focus state.
+2. The hook asks `ResolveShortcut(...)` for one decision.
+3. `MainWindow::ApplyShortcutDecision(...)` executes either:
+   - `ApplyFitShortcut()` for focused viewer scope, or
+   - `FocusConsoleForQuickCommand(...)` for CLI-prefill actions.
+
+Viewer-specific direct handling for these migrated shortcuts is intentionally avoided,
+so routing stays centralized in GUI.

--- a/gui/AGENTS.md
+++ b/gui/AGENTS.md
@@ -23,3 +23,7 @@ These rules apply to everything under `gui/`.
 
 4. **Dependencies**
    - Avoid introducing GUI dependencies on internal details of other modules when a public API or helper exists in the owning module.
+
+5. **Shortcut changes must update docs**
+   - If you add, remove, or modify keyboard shortcuts in `gui/` or their routing,
+     update `docs/gui_shortcut_architecture.md` in the same change.

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -60,6 +60,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/ridertextdialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/riggingpanel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sceneobjecttablepanel.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/shortcut_registry.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/selectfixturetypedialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/selectnamedialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/splashscreen.cpp

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -314,6 +314,12 @@ MainWindow::MainWindow(const wxString &title, IGuiConfigServices *services)
   if (layoutPanel)
     layoutPanel->ReloadLayouts();
 
+  const auto shortcutRegistryErrors = gui::ValidateShortcutRegistry();
+  for (const std::string &error : shortcutRegistryErrors)
+    wxLogError("Shortcut registry validation failed: %s", error.c_str());
+  wxASSERT_MSG(shortcutRegistryErrors.empty(),
+               "Shortcut registry contains scope collisions");
+
   Bind(wxEVT_IDLE, &MainWindow::OnStartupSplashCloseIdle, this);
   Bind(wxEVT_CHAR_HOOK, &MainWindow::OnGlobalCharHook, this);
 

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1155,6 +1155,7 @@ void MainWindow::RefreshRigging() {
 }
 
 void MainWindow::EnableShortcuts(bool enable) {
+  shortcutHandlingEnabled = enable;
   if (enable)
     SetAcceleratorTable(m_accel);
   else

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -19,6 +19,7 @@
 
 #include "edit_ids.h"
 #include "viewer2dstate.h"
+#include "shortcut_registry.h"
 #include <wx/aui/aui.h>
 #include <wx/frame.h>
 
@@ -77,6 +78,7 @@ public:
   void EnableShortcuts(bool enable);
   bool IsEditableTextWidgetOrChild(const wxWindow *window) const;
   void FocusConsoleForQuickCommand(const wxString &prefill);
+  bool ApplyShortcutDecision(const gui::ShortcutExecutionDecision &decision);
   void Ensure2DViewportAvailable();
   Viewer2DPanel *GetLayoutCapturePanel() const;
   Viewer2DOffscreenRenderer *GetOffscreenRenderer();
@@ -224,6 +226,7 @@ private:
   void ShowLayoutLoadingIndicator(const wxString &message);
   void ClearLayoutLoadingIndicator();
   void ApplyViewportShortcut(Viewer2DView view);
+  bool ApplyFitShortcut();
   bool HasActiveLayout2DView() const;
   void SyncSceneData();
   void SyncLayerVisibilityPanels();

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -128,6 +128,7 @@ private:
   wxAuiToolBar *toolsToolBar = nullptr;
 
   wxAcceleratorTable m_accel;
+  bool shortcutHandlingEnabled = true;
   std::unique_ptr<MainWindowIoController> ioController;
   std::unique_ptr<MainWindowLayoutController> layoutController;
   std::unique_ptr<MainWindowPrintController> printController;

--- a/gui/mainwindow_cli_shortcut_router.cpp
+++ b/gui/mainwindow_cli_shortcut_router.cpp
@@ -1,30 +1,34 @@
 #include "mainwindow_cli_shortcut_router.h"
 
-#include <cctype>
+#include "shortcut_registry.h"
 
 namespace gui {
 
 CliShortcutRouteResult RouteCliShortcut(int keyCode,
                                         const CliShortcutRouteContext &context) {
+  const ShortcutExecutionContext shortcutContext{
+      .hasModifiers = context.hasModifiers,
+      .focusInEditableText = context.focusInEditableText,
+      .focusInCliInput = context.focusInCliInput,
+      .cliHasTypedContent = context.cliHasTypedContent,
+      .focusInViewer2D = false,
+      .focusInViewer3D = false,
+  };
+
   CliShortcutRouteResult result;
-
-  if (context.hasModifiers || context.focusInCliInput ||
-      context.focusInEditableText) {
+  const auto decision = ResolveShortcut(keyCode, shortcutContext);
+  if (!decision.has_value())
     return result;
-  }
 
-  const int normalizedKey = std::toupper(keyCode);
-  if (normalizedKey == 'P') {
+  switch (decision->action) {
+  case ShortcutAction::CliPrefillPos:
+  case ShortcutAction::CliPrefillRot:
+  case ShortcutAction::CliPrefillFixture:
     result.shouldFocusCli = true;
-    if (!context.cliHasTypedContent)
-      result.prefill = "pos ";
-  } else if (normalizedKey == 'R') {
-    result.shouldFocusCli = true;
-    if (!context.cliHasTypedContent)
-      result.prefill = "rot ";
-  } else if (normalizedKey == 'F') {
-    result.shouldFocusCli = true;
-    result.prefill = "fixture ";
+    result.prefill = decision->cliPrefill;
+    break;
+  default:
+    break;
   }
 
   return result;

--- a/gui/mainwindow_cli_shortcuts.cpp
+++ b/gui/mainwindow_cli_shortcuts.cpp
@@ -1,12 +1,28 @@
 #include "mainwindow.h"
 
 #include "consolepanel.h"
-#include "mainwindow_cli_shortcut_router.h"
+#include "shortcut_registry.h"
 
 #include <wx/combobox.h>
 #include <wx/grid.h>
 #include <wx/spinctrl.h>
 #include <wx/textctrl.h>
+
+namespace {
+
+bool IsChildOrSame(const wxWindow *root, const wxWindow *window) {
+  if (!root || !window)
+    return false;
+  const wxWindow *current = window;
+  while (current) {
+    if (current == root)
+      return true;
+    current = current->GetParent();
+  }
+  return false;
+}
+
+} // namespace
 
 bool MainWindow::IsEditableTextWidgetOrChild(const wxWindow *window) const {
   const wxWindow *current = window;
@@ -46,26 +62,37 @@ void MainWindow::FocusConsoleForQuickCommand(const wxString &prefill) {
   consolePanel->FocusInputWithOptionalPrefill(prefill);
 }
 
-void MainWindow::OnGlobalCharHook(wxKeyEvent &event) {
-  if (!consolePanel) {
-    event.Skip();
-    return;
+bool MainWindow::ApplyShortcutDecision(
+    const gui::ShortcutExecutionDecision &decision) {
+  switch (decision.action) {
+  case gui::ShortcutAction::FitView:
+    return ApplyFitShortcut();
+  case gui::ShortcutAction::CliPrefillPos:
+  case gui::ShortcutAction::CliPrefillRot:
+  case gui::ShortcutAction::CliPrefillFixture:
+    FocusConsoleForQuickCommand(wxString::FromUTF8(decision.cliPrefill));
+    return true;
   }
+  return false;
+}
 
-  const gui::CliShortcutRouteContext context{
+void MainWindow::OnGlobalCharHook(wxKeyEvent &event) {
+  const wxWindow *focus = FindFocus();
+  const gui::ShortcutExecutionContext context{
       .hasModifiers =
           event.ControlDown() || event.AltDown() || event.MetaDown(),
-      .focusInCliInput = consolePanel->IsInputWidgetOrChild(FindFocus()),
-      .focusInEditableText = IsEditableTextWidgetOrChild(FindFocus()),
-      .cliHasTypedContent = consolePanel->InputHasTypedContent(),
+      .focusInEditableText = IsEditableTextWidgetOrChild(focus),
+      .focusInCliInput = consolePanel && consolePanel->IsInputWidgetOrChild(focus),
+      .cliHasTypedContent = consolePanel && consolePanel->InputHasTypedContent(),
+      .focusInViewer2D =
+          IsChildOrSame(viewport2DPanel, focus) ||
+          IsChildOrSame(viewport2DRenderPanel, focus),
+      .focusInViewer3D = IsChildOrSame(viewportPanel, focus),
   };
 
-  const gui::CliShortcutRouteResult route =
-      gui::RouteCliShortcut(event.GetKeyCode(), context);
-  if (!route.shouldFocusCli) {
+  const auto decision = gui::ResolveShortcut(event.GetKeyCode(), context);
+  if (!decision.has_value() || !ApplyShortcutDecision(*decision)) {
     event.Skip();
     return;
   }
-
-  FocusConsoleForQuickCommand(wxString::FromUTF8(route.prefill));
 }

--- a/gui/mainwindow_cli_shortcuts.cpp
+++ b/gui/mainwindow_cli_shortcuts.cpp
@@ -2,6 +2,7 @@
 
 #include "consolepanel.h"
 #include "shortcut_registry.h"
+#include "viewer3dpanel.h"
 
 #include <wx/combobox.h>
 #include <wx/grid.h>
@@ -23,6 +24,21 @@ bool IsChildOrSame(const wxWindow *root, const wxWindow *window) {
 }
 
 } // namespace
+
+int NormalizeShortcutKeyForRegistry(int keyCode) {
+  switch (keyCode) {
+  case WXK_NUMPAD1:
+    return gui::kShortcutKeyNumpad1;
+  case WXK_NUMPAD3:
+    return gui::kShortcutKeyNumpad3;
+  case WXK_NUMPAD5:
+    return gui::kShortcutKeyNumpad5;
+  case WXK_NUMPAD7:
+    return gui::kShortcutKeyNumpad7;
+  default:
+    return keyCode;
+  }
+}
 
 bool MainWindow::IsEditableTextWidgetOrChild(const wxWindow *window) const {
   const wxWindow *current = window;
@@ -72,11 +88,52 @@ bool MainWindow::ApplyShortcutDecision(
   case gui::ShortcutAction::CliPrefillFixture:
     FocusConsoleForQuickCommand(wxString::FromUTF8(decision.cliPrefill));
     return true;
+  case gui::ShortcutAction::SelectFixturesTab:
+  case gui::ShortcutAction::SelectTrussesTab:
+  case gui::ShortcutAction::SelectSupportsTab:
+  case gui::ShortcutAction::SelectObjectsTab: {
+    int commandId = ID_Select_Fixtures;
+    if (decision.action == gui::ShortcutAction::SelectTrussesTab)
+      commandId = ID_Select_Trusses;
+    else if (decision.action == gui::ShortcutAction::SelectSupportsTab)
+      commandId = ID_Select_Supports;
+    else if (decision.action == gui::ShortcutAction::SelectObjectsTab)
+      commandId = ID_Select_Objects;
+
+    wxCommandEvent event(wxEVT_MENU, commandId);
+    return GetEventHandler()->ProcessEvent(event);
+  }
+  case gui::ShortcutAction::ViewportFront:
+    if (viewportPanel) {
+      viewportPanel->SetStandardView(Viewer2DView::Front);
+      return true;
+    }
+    return false;
+  case gui::ShortcutAction::ViewportSide:
+    if (viewportPanel) {
+      viewportPanel->SetStandardView(Viewer2DView::Side);
+      return true;
+    }
+    return false;
+  case gui::ShortcutAction::ViewportTop:
+    if (viewportPanel) {
+      viewportPanel->SetStandardView(Viewer2DView::Top);
+      return true;
+    }
+    return false;
+  case gui::ShortcutAction::ViewportReset3D:
+    if (viewportPanel)
+      return viewportPanel->ResetCameraToIsometric();
+    return false;
   }
   return false;
 }
 
 void MainWindow::OnGlobalCharHook(wxKeyEvent &event) {
+  if (!shortcutHandlingEnabled) {
+    event.Skip();
+    return;
+  }
   const wxWindow *focus = FindFocus();
   const gui::ShortcutExecutionContext context{
       .hasModifiers =
@@ -90,7 +147,8 @@ void MainWindow::OnGlobalCharHook(wxKeyEvent &event) {
       .focusInViewer3D = IsChildOrSame(viewportPanel, focus),
   };
 
-  const auto decision = gui::ResolveShortcut(event.GetKeyCode(), context);
+  const int normalizedKeyCode = NormalizeShortcutKeyForRegistry(event.GetKeyCode());
+  const auto decision = gui::ResolveShortcut(normalizedKeyCode, context);
   if (!decision.has_value() || !ApplyShortcutDecision(*decision)) {
     event.Skip();
     return;

--- a/gui/mainwindow_cli_shortcuts.cpp
+++ b/gui/mainwindow_cli_shortcuts.cpp
@@ -2,6 +2,8 @@
 
 #include "consolepanel.h"
 #include "shortcut_registry.h"
+#include "viewer2dpanel.h"
+#include "viewer2drenderpanel.h"
 #include "viewer3dpanel.h"
 
 #include <wx/combobox.h>

--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -435,13 +435,9 @@ void MainWindow::SetupLayout() {
   if (riggingPanel)
     riggingPanel->RefreshData();
 
-  // Keyboard shortcuts to switch notebook pages
-  wxAcceleratorEntry entries[4];
-  entries[0].Set(wxACCEL_NORMAL, (int)'1', ID_Select_Fixtures);
-  entries[1].Set(wxACCEL_NORMAL, (int)'2', ID_Select_Trusses);
-  entries[2].Set(wxACCEL_NORMAL, (int)'3', ID_Select_Supports);
-  entries[3].Set(wxACCEL_NORMAL, (int)'4', ID_Select_Objects);
-  m_accel = wxAcceleratorTable(4, entries);
+  // Keyboard shortcuts are routed through MainWindow::OnGlobalCharHook
+  // using gui::ShortcutRegistry.
+  m_accel = wxAcceleratorTable();
   SetAcceleratorTable(m_accel);
 
   CreateStatusBar(3);

--- a/gui/mainwindow_view_shortcuts.cpp
+++ b/gui/mainwindow_view_shortcuts.cpp
@@ -38,6 +38,21 @@ void MainWindow::OnViewportSideView(wxCommandEvent &WXUNUSED(event)) {
   ApplyViewportShortcut(Viewer2DView::Side);
 }
 
+
+bool MainWindow::ApplyFitShortcut() {
+  const wxWindow *focusedWindow = wxWindow::FindFocus();
+  const bool focusIn2D = IsChildOrSame(viewport2DPanel, focusedWindow) ||
+                         IsChildOrSame(viewport2DRenderPanel, focusedWindow);
+  if (focusIn2D && viewport2DPanel)
+    return viewport2DPanel->FitViewToScene();
+
+  const bool focusIn3D = IsChildOrSame(viewportPanel, focusedWindow);
+  if (focusIn3D && viewportPanel)
+    return viewportPanel->FrameSceneToFit();
+
+  return false;
+}
+
 void MainWindow::ApplyViewportShortcut(Viewer2DView view) {
   const bool is2DShown = IsPaneShown(auiManager, "2DViewport");
   const bool is3DShown = IsPaneShown(auiManager, "3DViewport");

--- a/gui/shortcut_registry.cpp
+++ b/gui/shortcut_registry.cpp
@@ -8,7 +8,11 @@
 namespace gui {
 namespace {
 
-int NormalizeKeyCode(int keyCode) { return std::toupper(keyCode); }
+int NormalizeKeyCode(int keyCode) {
+  if (keyCode >= 0 && keyCode <= 255)
+    return std::toupper(static_cast<unsigned char>(keyCode));
+  return keyCode;
+}
 
 std::optional<std::string> CliPrefillForAction(const ShortcutAction action,
                                                const bool cliHasTypedContent) {
@@ -78,6 +82,62 @@ const std::vector<ShortcutDefinition> &GetShortcutRegistry() {
                          .focusPolicy =
                              ShortcutFocusPolicy::BlockInEditableWidgets,
                          .priority = 200},
+      ShortcutDefinition{.keyCode = '1',
+                         .action = ShortcutAction::SelectFixturesTab,
+                         .ownerModule = "gui",
+                         .scope = ShortcutScope::Global,
+                         .focusPolicy =
+                             ShortcutFocusPolicy::BlockInEditableWidgets,
+                         .priority = 150},
+      ShortcutDefinition{.keyCode = '2',
+                         .action = ShortcutAction::SelectTrussesTab,
+                         .ownerModule = "gui",
+                         .scope = ShortcutScope::Global,
+                         .focusPolicy =
+                             ShortcutFocusPolicy::BlockInEditableWidgets,
+                         .priority = 150},
+      ShortcutDefinition{.keyCode = '3',
+                         .action = ShortcutAction::SelectSupportsTab,
+                         .ownerModule = "gui",
+                         .scope = ShortcutScope::Global,
+                         .focusPolicy =
+                             ShortcutFocusPolicy::BlockInEditableWidgets,
+                         .priority = 150},
+      ShortcutDefinition{.keyCode = '4',
+                         .action = ShortcutAction::SelectObjectsTab,
+                         .ownerModule = "gui",
+                         .scope = ShortcutScope::Global,
+                         .focusPolicy =
+                             ShortcutFocusPolicy::BlockInEditableWidgets,
+                         .priority = 150},
+      ShortcutDefinition{.keyCode = kShortcutKeyNumpad1,
+                         .action = ShortcutAction::ViewportFront,
+                         .ownerModule = "viewer3d",
+                         .scope = ShortcutScope::Viewer3D,
+                         .focusPolicy =
+                             ShortcutFocusPolicy::BlockInEditableWidgets,
+                         .priority = 250},
+      ShortcutDefinition{.keyCode = kShortcutKeyNumpad3,
+                         .action = ShortcutAction::ViewportSide,
+                         .ownerModule = "viewer3d",
+                         .scope = ShortcutScope::Viewer3D,
+                         .focusPolicy =
+                             ShortcutFocusPolicy::BlockInEditableWidgets,
+                         .priority = 250},
+      ShortcutDefinition{.keyCode = kShortcutKeyNumpad7,
+                         .action = ShortcutAction::ViewportTop,
+                         .ownerModule = "viewer3d",
+                         .scope = ShortcutScope::Viewer3D,
+                         .focusPolicy =
+                             ShortcutFocusPolicy::BlockInEditableWidgets,
+                         .priority = 250},
+      ShortcutDefinition{.keyCode = kShortcutKeyNumpad5,
+                         .action = ShortcutAction::ViewportReset3D,
+                         .ownerModule = "viewer3d",
+                         .scope = ShortcutScope::Viewer3D,
+                         .focusPolicy =
+                             ShortcutFocusPolicy::BlockInEditableWidgets,
+                         .priority = 250},
   };
   return kRegistry;
 }
@@ -106,9 +166,12 @@ std::vector<std::string> ValidateShortcutRegistry() {
       details += shortcut.ownerModule;
     }
 
-    errors.push_back("Shortcut collision for key '" +
-                     std::string(1, static_cast<char>(normalizedKey)) +
-                     "' in same scope. Owners: " + details);
+    const std::string keyLabel =
+        (normalizedKey >= 32 && normalizedKey <= 126)
+            ? ("'" + std::string(1, static_cast<char>(normalizedKey)) + "'")
+            : ("code " + std::to_string(normalizedKey));
+    errors.push_back("Shortcut collision for key " + keyLabel +
+                     " in same scope. Owners: " + details);
   }
 
   return errors;

--- a/gui/shortcut_registry.cpp
+++ b/gui/shortcut_registry.cpp
@@ -1,0 +1,156 @@
+#include "shortcut_registry.h"
+
+#include <algorithm>
+#include <cctype>
+#include <map>
+#include <tuple>
+
+namespace gui {
+namespace {
+
+int NormalizeKeyCode(int keyCode) { return std::toupper(keyCode); }
+
+std::optional<std::string> CliPrefillForAction(const ShortcutAction action,
+                                               const bool cliHasTypedContent) {
+  switch (action) {
+  case ShortcutAction::CliPrefillPos:
+    return cliHasTypedContent ? std::optional<std::string>{} : "pos ";
+  case ShortcutAction::CliPrefillRot:
+    return cliHasTypedContent ? std::optional<std::string>{} : "rot ";
+  case ShortcutAction::CliPrefillFixture:
+    return "fixture ";
+  default:
+    return std::nullopt;
+  }
+}
+
+bool ScopeMatchesFocus(const ShortcutScope scope,
+                      const ShortcutExecutionContext &context) {
+  switch (scope) {
+  case ShortcutScope::Global:
+    return true;
+  case ShortcutScope::Viewer2D:
+    return context.focusInViewer2D;
+  case ShortcutScope::Viewer3D:
+    return context.focusInViewer3D;
+  case ShortcutScope::Cli:
+    return !context.focusInCliInput;
+  }
+  return false;
+}
+
+} // namespace
+
+const std::vector<ShortcutDefinition> &GetShortcutRegistry() {
+  static const std::vector<ShortcutDefinition> kRegistry = {
+      ShortcutDefinition{.keyCode = 'Z',
+                         .action = ShortcutAction::FitView,
+                         .ownerModule = "viewer2d",
+                         .scope = ShortcutScope::Viewer2D,
+                         .focusPolicy =
+                             ShortcutFocusPolicy::BlockInEditableWidgets,
+                         .priority = 300},
+      ShortcutDefinition{.keyCode = 'Z',
+                         .action = ShortcutAction::FitView,
+                         .ownerModule = "viewer3d",
+                         .scope = ShortcutScope::Viewer3D,
+                         .focusPolicy =
+                             ShortcutFocusPolicy::BlockInEditableWidgets,
+                         .priority = 300},
+      ShortcutDefinition{.keyCode = 'P',
+                         .action = ShortcutAction::CliPrefillPos,
+                         .ownerModule = "cli",
+                         .scope = ShortcutScope::Cli,
+                         .focusPolicy =
+                             ShortcutFocusPolicy::BlockInEditableWidgets,
+                         .priority = 200},
+      ShortcutDefinition{.keyCode = 'R',
+                         .action = ShortcutAction::CliPrefillRot,
+                         .ownerModule = "cli",
+                         .scope = ShortcutScope::Cli,
+                         .focusPolicy =
+                             ShortcutFocusPolicy::BlockInEditableWidgets,
+                         .priority = 200},
+      ShortcutDefinition{.keyCode = 'F',
+                         .action = ShortcutAction::CliPrefillFixture,
+                         .ownerModule = "cli",
+                         .scope = ShortcutScope::Cli,
+                         .focusPolicy =
+                             ShortcutFocusPolicy::BlockInEditableWidgets,
+                         .priority = 200},
+  };
+  return kRegistry;
+}
+
+std::vector<std::string> ValidateShortcutRegistry() {
+  std::vector<std::string> errors;
+  std::map<std::tuple<ShortcutScope, int>, std::vector<size_t>> index;
+  const auto &registry = GetShortcutRegistry();
+
+  for (size_t i = 0; i < registry.size(); ++i) {
+    const int normalizedKey = NormalizeKeyCode(registry[i].keyCode);
+    index[{registry[i].scope, normalizedKey}].push_back(i);
+  }
+
+  for (const auto &[key, indices] : index) {
+    if (indices.size() <= 1)
+      continue;
+
+    const auto &[scope, normalizedKey] = key;
+    (void)scope;
+    std::string details;
+    for (size_t i = 0; i < indices.size(); ++i) {
+      const ShortcutDefinition &shortcut = registry[indices[i]];
+      if (!details.empty())
+        details += ", ";
+      details += shortcut.ownerModule;
+    }
+
+    errors.push_back("Shortcut collision for key '" +
+                     std::string(1, static_cast<char>(normalizedKey)) +
+                     "' in same scope. Owners: " + details);
+  }
+
+  return errors;
+}
+
+bool CanExecuteShortcut(const ShortcutDefinition &shortcut,
+                        const ShortcutExecutionContext &context) {
+  if (context.hasModifiers)
+    return false;
+  if (shortcut.focusPolicy == ShortcutFocusPolicy::BlockInEditableWidgets &&
+      context.focusInEditableText) {
+    return false;
+  }
+  return ScopeMatchesFocus(shortcut.scope, context);
+}
+
+std::optional<ShortcutExecutionDecision>
+ResolveShortcut(int keyCode, const ShortcutExecutionContext &context) {
+  const int normalizedKey = NormalizeKeyCode(keyCode);
+  const auto &registry = GetShortcutRegistry();
+
+  const ShortcutDefinition *best = nullptr;
+  for (const ShortcutDefinition &shortcut : registry) {
+    if (NormalizeKeyCode(shortcut.keyCode) != normalizedKey)
+      continue;
+    if (!CanExecuteShortcut(shortcut, context))
+      continue;
+
+    if (!best || shortcut.priority > best->priority)
+      best = &shortcut;
+  }
+
+  if (!best)
+    return std::nullopt;
+
+  ShortcutExecutionDecision decision;
+  decision.action = best->action;
+  if (const auto prefill = CliPrefillForAction(best->action, context.cliHasTypedContent);
+      prefill.has_value()) {
+    decision.cliPrefill = *prefill;
+  }
+  return decision;
+}
+
+} // namespace gui

--- a/gui/shortcut_registry.h
+++ b/gui/shortcut_registry.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace gui {
+
+enum class ShortcutScope {
+  Global,
+  Viewer2D,
+  Viewer3D,
+  Cli,
+};
+
+enum class ShortcutFocusPolicy {
+  AllowInEditableWidgets,
+  BlockInEditableWidgets,
+};
+
+enum class ShortcutAction {
+  FitView,
+  CliPrefillPos,
+  CliPrefillRot,
+  CliPrefillFixture,
+};
+
+struct ShortcutDefinition {
+  int keyCode = 0;
+  ShortcutAction action = ShortcutAction::FitView;
+  std::string ownerModule;
+  ShortcutScope scope = ShortcutScope::Global;
+  ShortcutFocusPolicy focusPolicy = ShortcutFocusPolicy::BlockInEditableWidgets;
+  int priority = 0;
+};
+
+struct ShortcutExecutionContext {
+  bool hasModifiers = false;
+  bool focusInEditableText = false;
+  bool focusInCliInput = false;
+  bool cliHasTypedContent = false;
+  bool focusInViewer2D = false;
+  bool focusInViewer3D = false;
+};
+
+struct ShortcutExecutionDecision {
+  ShortcutAction action = ShortcutAction::FitView;
+  std::string cliPrefill;
+};
+
+const std::vector<ShortcutDefinition> &GetShortcutRegistry();
+std::vector<std::string> ValidateShortcutRegistry();
+bool CanExecuteShortcut(const ShortcutDefinition &shortcut,
+                        const ShortcutExecutionContext &context);
+std::optional<ShortcutExecutionDecision>
+ResolveShortcut(int keyCode, const ShortcutExecutionContext &context);
+
+} // namespace gui

--- a/gui/shortcut_registry.h
+++ b/gui/shortcut_registry.h
@@ -6,6 +6,11 @@
 
 namespace gui {
 
+inline constexpr int kShortcutKeyNumpad1 = 10001;
+inline constexpr int kShortcutKeyNumpad3 = 10003;
+inline constexpr int kShortcutKeyNumpad5 = 10005;
+inline constexpr int kShortcutKeyNumpad7 = 10007;
+
 enum class ShortcutScope {
   Global,
   Viewer2D,
@@ -23,6 +28,14 @@ enum class ShortcutAction {
   CliPrefillPos,
   CliPrefillRot,
   CliPrefillFixture,
+  SelectFixturesTab,
+  SelectTrussesTab,
+  SelectSupportsTab,
+  SelectObjectsTab,
+  ViewportFront,
+  ViewportSide,
+  ViewportTop,
+  ViewportReset3D,
 };
 
 struct ShortcutDefinition {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -71,9 +71,16 @@ add_test(NAME FixtureTableParser COMMAND fixture_table_parser_test)
 
 add_executable(mainwindow_cli_shortcut_router_test
                mainwindow_cli_shortcut_router_test.cpp
-               ../gui/mainwindow_cli_shortcut_router.cpp)
+               ../gui/mainwindow_cli_shortcut_router.cpp
+               ../gui/shortcut_registry.cpp)
 target_include_directories(mainwindow_cli_shortcut_router_test PRIVATE .. ../gui)
 add_test(NAME MainWindowCliShortcutRouter COMMAND mainwindow_cli_shortcut_router_test)
+
+add_executable(shortcut_registry_test
+               shortcut_registry_test.cpp
+               ../gui/shortcut_registry.cpp)
+target_include_directories(shortcut_registry_test PRIVATE .. ../gui)
+add_test(NAME ShortcutRegistry COMMAND shortcut_registry_test)
 
 
 add_executable(ui_unit_utils_test

--- a/tests/shortcut_registry_test.cpp
+++ b/tests/shortcut_registry_test.cpp
@@ -1,0 +1,52 @@
+#include "shortcut_registry.h"
+
+#include <iostream>
+
+namespace {
+
+bool Expect(bool condition, const char *message) {
+  if (condition)
+    return true;
+  std::cerr << "FAILED: " << message << '\n';
+  return false;
+}
+
+} // namespace
+
+int main() {
+  bool ok = true;
+
+  const auto errors = gui::ValidateShortcutRegistry();
+  ok &= Expect(errors.empty(), "registry should not have scope collisions");
+
+  const gui::ShortcutExecutionContext viewer2dContext{
+      .focusInViewer2D = true,
+  };
+  const auto fit2d = gui::ResolveShortcut('z', viewer2dContext);
+  ok &= Expect(fit2d.has_value(), "fit should resolve in viewer2d scope");
+  ok &= Expect(fit2d && fit2d->action == gui::ShortcutAction::FitView,
+               "fit action should be selected");
+
+  const gui::ShortcutExecutionContext cliContext{
+      .cliHasTypedContent = false,
+  };
+  const auto pos = gui::ResolveShortcut('p', cliContext);
+  ok &= Expect(pos.has_value(), "pos shortcut should resolve in cli scope");
+  ok &= Expect(pos && pos->cliPrefill == "pos ", "pos shortcut prefill mismatch");
+
+  const gui::ShortcutExecutionContext typedCliContext{
+      .cliHasTypedContent = true,
+  };
+  const auto rot = gui::ResolveShortcut('r', typedCliContext);
+  ok &= Expect(rot.has_value(), "rot shortcut should resolve");
+  ok &= Expect(rot && rot->cliPrefill.empty(),
+               "rot should not force prefill when CLI has typed content");
+
+  const gui::ShortcutExecutionContext editableContext{
+      .focusInEditableText = true,
+  };
+  const auto blocked = gui::ResolveShortcut('f', editableContext);
+  ok &= Expect(!blocked.has_value(), "shortcuts should be blocked in editable widgets");
+
+  return ok ? 0 : 1;
+}

--- a/tests/shortcut_registry_test.cpp
+++ b/tests/shortcut_registry_test.cpp
@@ -42,6 +42,19 @@ int main() {
   ok &= Expect(rot && rot->cliPrefill.empty(),
                "rot should not force prefill when CLI has typed content");
 
+
+  const gui::ShortcutExecutionContext tableContext{};
+  const auto fixturesTab = gui::ResolveShortcut('1', tableContext);
+  ok &= Expect(fixturesTab && fixturesTab->action == gui::ShortcutAction::SelectFixturesTab,
+               "1 should resolve fixtures tab action");
+
+  const gui::ShortcutExecutionContext viewer3dContext{
+      .focusInViewer3D = true,
+  };
+  const auto numpadTop = gui::ResolveShortcut(gui::kShortcutKeyNumpad7, viewer3dContext);
+  ok &= Expect(numpadTop && numpadTop->action == gui::ShortcutAction::ViewportTop,
+               "NumPad7 should resolve top view in viewer3d scope");
+
   const gui::ShortcutExecutionContext editableContext{
       .focusInEditableText = true,
   };

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -2120,14 +2120,6 @@ void Viewer2DPanel::OnKeyDown(wxKeyEvent &event) {
     event.Skip();
     return;
   }
-  case 'Z':
-  case 'z': {
-    if (!FitViewToScene()) {
-      event.Skip();
-      return;
-    }
-    break;
-  }
   default:
     event.Skip();
     return;

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -1435,27 +1435,27 @@ void Viewer3DPanel::OnKeyDown(wxKeyEvent& event)
             event.Skip();
             return;
         }
-        case 'Z':
-        case 'z': {
-            int width = 0;
-            int height = 0;
-            GetClientSize(&width, &height);
-            if (!viewer3d::FrameSceneInCamera(m_controller, width, height, m_camera)) {
-                event.Skip();
-                return;
-            }
-            m_isInteracting = true;
-            m_cameraMoving = true;
-            m_lastInteractionTime = std::chrono::steady_clock::now();
-            m_controller.SetInteracting(true);
-            break;
-        }
         default:
             event.Skip();
             return;
     }
 
     Refresh();
+}
+
+bool Viewer3DPanel::FrameSceneToFit() {
+    int width = 0;
+    int height = 0;
+    GetClientSize(&width, &height);
+    if (!viewer3d::FrameSceneInCamera(m_controller, width, height, m_camera))
+        return false;
+
+    m_isInteracting = true;
+    m_cameraMoving = true;
+    m_lastInteractionTime = std::chrono::steady_clock::now();
+    m_controller.SetInteracting(true);
+    Refresh();
+    return true;
 }
 
 void Viewer3DPanel::SetStandardView(Viewer2DView view) {

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -1413,18 +1413,6 @@ void Viewer3DPanel::OnKeyDown(wxKeyEvent& event)
             else
                 m_camera.targetPitch = std::clamp(m_camera.targetPitch - 5.0f, -89.0f, 89.0f);
             break;
-        case WXK_NUMPAD1: // Front
-            SetStandardView(Viewer2DView::Front);
-            break;
-        case WXK_NUMPAD3: // Right
-            SetStandardView(Viewer2DView::Side);
-            break;
-        case WXK_NUMPAD7: // Top
-            SetStandardView(Viewer2DView::Top);
-            break;
-        case WXK_NUMPAD5: // Reset/isometric
-            m_camera.Reset();
-            break;
         case WXK_DELETE:
         case WXK_NUMPAD_DELETE: {
             if (MainWindow::Instance()) {
@@ -1441,6 +1429,12 @@ void Viewer3DPanel::OnKeyDown(wxKeyEvent& event)
     }
 
     Refresh();
+}
+
+bool Viewer3DPanel::ResetCameraToIsometric() {
+    m_camera.Reset();
+    Refresh();
+    return true;
 }
 
 bool Viewer3DPanel::FrameSceneToFit() {

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -68,6 +68,7 @@ public:
     bool IsCameraMoving() const { return m_cameraMoving; }
     void SetStandardView(Viewer2DView view);
     bool FrameSceneToFit();
+    bool ResetCameraToIsometric();
 
 private:
     wxGLContext* m_glContext;

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -67,6 +67,7 @@ public:
     bool ShouldPauseHeavyTasks();
     bool IsCameraMoving() const { return m_cameraMoving; }
     void SetStandardView(Viewer2DView view);
+    bool FrameSceneToFit();
 
 private:
     wxGLContext* m_glContext;


### PR DESCRIPTION
### Motivation

- Keep keyboard shortcut behavior explicit, validated and centralized to avoid scattered key handling logic across viewer panels and the main window. 
- Provide a single decision point that respects scope (global/2D/3D/CLI), owner module, focus-policy and priority when deciding whether a shortcut can run. 
- Migrate the main quick-actions (`Fit`, `pos`, `rot`, `fixture`) into that registry so routing and focus gating are deterministic. 
- Document the shortcut map and resolution rules for future contributors and CI checks. 

### Description

- Added a central registry API in `gui/shortcut_registry.h` and implementation in `gui/shortcut_registry.cpp` which defines `ShortcutDefinition`, `ShortcutScope`, `ShortcutFocusPolicy`, `ShortcutAction`, `ShortcutExecutionContext`, `ResolveShortcut(...)` and `ValidateShortcutRegistry()`. 
- Migrated primary shortcuts into the registry (`Z` → `FitView` for `Viewer2D`/`Viewer3D`, `P` → `pos`, `R` → `rot`, `F` → `fixture`) and implemented scope/priority/focus gating resolution. 
- Centralized runtime routing: `MainWindow::OnGlobalCharHook(...)` now builds a `ShortcutExecutionContext`, calls `ResolveShortcut(...)`, and dispatches via `MainWindow::ApplyShortcutDecision(...)` which runs either `ApplyFitShortcut()` or `FocusConsoleForQuickCommand(...)`. 
- Removed direct `Z` handling from viewer key handlers and introduced `Viewer3DPanel::FrameSceneToFit()` with `MainWindow::ApplyFitShortcut()` to delegate fit behavior through the registry decision. 
- Added tests and build wiring: new `tests/shortcut_registry_test.cpp`, updated `tests/CMakeLists.txt` and `gui/CMakeLists.txt` to include `shortcut_registry.cpp`. 
- Added a technical doc `docs/gui_shortcut_architecture.md` and referenced it from `docs/architecture.md`. 

### Testing

- Ran `tests/check_perastage_tree_modules.sh` and it succeeded. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded. 
- Compiled and executed the registry unit checks with `g++ -std=c++20 -I. -Igui tests/shortcut_registry_test.cpp gui/shortcut_registry.cpp -o /tmp/shortcut_registry_test && /tmp/shortcut_registry_test` and the test passed. 
- Compiled and executed the CLI router test with `g++ -std=c++20 -I. -Igui tests/mainwindow_cli_shortcut_router_test.cpp gui/mainwindow_cli_shortcut_router.cpp gui/shortcut_registry.cpp -o /tmp/mainwindow_cli_shortcut_router_test && /tmp/mainwindow_cli_shortcut_router_test` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cea261fa4c8324a29c761feb83fde6)