### PR TITLE
Ensure undo/redo coverage for layout creation and editing flows

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1062,6 +1062,8 @@ void LayoutViewerPanel::OnLeftDown(wxMouseEvent &event) {
       dragStartFrame = selectedFrame;
       CaptureMouse();
       if (!currentLayout.name.empty()) {
+        auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+        cfg.PushUndoState("edit layout element frame");
         layouts::LayoutManager::Get().BeginBatchUpdate();
       }
       return;
@@ -1417,6 +1419,8 @@ void LayoutViewerPanel::OnBringToFront(wxCommandEvent &) {
       return;
     it->zIndex = maxZ + 1;
     if (!currentLayout.name.empty()) {
+      auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+      cfg.PushUndoState("bring layout element to front");
       layouts::LayoutManager::Get().UpdateLayout2DView(currentLayout.name, *it);
     }
   } else if (selectedElementType == SelectedElementType::Legend) {
@@ -1430,6 +1434,8 @@ void LayoutViewerPanel::OnBringToFront(wxCommandEvent &) {
       return;
     it->zIndex = maxZ + 1;
     if (!currentLayout.name.empty()) {
+      auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+      cfg.PushUndoState("bring layout element to front");
       layouts::LayoutManager::Get().UpdateLayoutLegend(currentLayout.name,
                                                        *it);
     }
@@ -1444,6 +1450,8 @@ void LayoutViewerPanel::OnBringToFront(wxCommandEvent &) {
       return;
     it->zIndex = maxZ + 1;
     if (!currentLayout.name.empty()) {
+      auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+      cfg.PushUndoState("bring layout element to front");
       layouts::LayoutManager::Get().UpdateLayoutEventTable(currentLayout.name,
                                                            *it);
     }
@@ -1458,6 +1466,8 @@ void LayoutViewerPanel::OnBringToFront(wxCommandEvent &) {
       return;
     it->zIndex = maxZ + 1;
     if (!currentLayout.name.empty()) {
+      auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+      cfg.PushUndoState("bring layout element to front");
       layouts::LayoutManager::Get().UpdateLayoutText(currentLayout.name, *it);
     }
   } else if (selectedElementType == SelectedElementType::Image) {
@@ -1471,6 +1481,8 @@ void LayoutViewerPanel::OnBringToFront(wxCommandEvent &) {
       return;
     it->zIndex = maxZ + 1;
     if (!currentLayout.name.empty()) {
+      auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+      cfg.PushUndoState("bring layout element to front");
       layouts::LayoutManager::Get().UpdateLayoutImage(currentLayout.name, *it);
     }
   } else {
@@ -1497,6 +1509,8 @@ void LayoutViewerPanel::OnSendToBack(wxCommandEvent &) {
       return;
     it->zIndex = minZ - 1;
     if (!currentLayout.name.empty()) {
+      auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+      cfg.PushUndoState("send layout element to back");
       layouts::LayoutManager::Get().UpdateLayout2DView(currentLayout.name, *it);
     }
   } else if (selectedElementType == SelectedElementType::Legend) {
@@ -1510,6 +1524,8 @@ void LayoutViewerPanel::OnSendToBack(wxCommandEvent &) {
       return;
     it->zIndex = minZ - 1;
     if (!currentLayout.name.empty()) {
+      auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+      cfg.PushUndoState("send layout element to back");
       layouts::LayoutManager::Get().UpdateLayoutLegend(currentLayout.name,
                                                        *it);
     }
@@ -1524,6 +1540,8 @@ void LayoutViewerPanel::OnSendToBack(wxCommandEvent &) {
       return;
     it->zIndex = minZ - 1;
     if (!currentLayout.name.empty()) {
+      auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+      cfg.PushUndoState("send layout element to back");
       layouts::LayoutManager::Get().UpdateLayoutEventTable(currentLayout.name,
                                                            *it);
     }
@@ -1538,6 +1556,8 @@ void LayoutViewerPanel::OnSendToBack(wxCommandEvent &) {
       return;
     it->zIndex = minZ - 1;
     if (!currentLayout.name.empty()) {
+      auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+      cfg.PushUndoState("send layout element to back");
       layouts::LayoutManager::Get().UpdateLayoutText(currentLayout.name, *it);
     }
   } else if (selectedElementType == SelectedElementType::Image) {
@@ -1551,6 +1571,8 @@ void LayoutViewerPanel::OnSendToBack(wxCommandEvent &) {
       return;
     it->zIndex = minZ - 1;
     if (!currentLayout.name.empty()) {
+      auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+      cfg.PushUndoState("send layout element to back");
       layouts::LayoutManager::Get().UpdateLayoutImage(currentLayout.name, *it);
     }
   } else {

--- a/gui/layoutviewerpanel_eventtable.cpp
+++ b/gui/layoutviewerpanel_eventtable.cpp
@@ -126,6 +126,8 @@ void LayoutViewerPanel::OnEditEventTable(wxCommandEvent &) {
   LayoutEventTableDialog dialog(this, *table);
   if (dialog.ShowModal() != wxID_OK)
     return;
+  auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+  cfg.PushUndoState("edit layout event table");
   table->fields = dialog.GetFields();
   if (!currentLayout.name.empty()) {
     layouts::LayoutManager::Get().UpdateLayoutEventTable(currentLayout.name,

--- a/gui/layoutviewerpanel_image.cpp
+++ b/gui/layoutviewerpanel_image.cpp
@@ -127,6 +127,8 @@ void LayoutViewerPanel::OnEditImage(wxCommandEvent &) {
   auto result = PromptForLayoutImage(this, "Selecciona una imagen");
   if (!result)
     return;
+  auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+  cfg.PushUndoState("edit layout image");
 
   wxScopedCharBuffer pathBuf = result->path.ToUTF8();
   image->imagePath = pathBuf.data() ? pathBuf.data() : "";

--- a/gui/layoutviewerpanel_text.cpp
+++ b/gui/layoutviewerpanel_text.cpp
@@ -125,6 +125,8 @@ void LayoutViewerPanel::OnEditText(wxCommandEvent &) {
                           text->drawFrame);
   if (dialog.ShowModal() != wxID_OK)
     return;
+  auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+  cfg.PushUndoState("edit layout text");
   wxString updatedRichText = dialog.GetRichText();
   wxString updatedPlainText = dialog.GetPlainText();
   const bool hadRichText = !text->richText.empty();

--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -715,6 +715,7 @@ void MainWindow::OnLayoutAdd2DView(wxCommandEvent &WXUNUSED(event)) {
   layouts::Layout2DViewDefinition view =
       viewer2d::ToLayoutDefinition(baseState, frame);
 
+  cfg.PushUndoState("add layout 2d view");
   layouts::LayoutManager::Get().UpdateLayout2DView(activeLayoutName, view);
 
   if (layoutViewerPanel) {
@@ -745,6 +746,8 @@ void MainWindow::OnLayoutAddLegend(wxCommandEvent &WXUNUSED(event)) {
   layouts::LayoutLegendDefinition legend;
   legend.frame = BuildDefaultLayoutLegendFrame(*layout);
 
+  auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+  cfg.PushUndoState("add layout legend");
   layouts::LayoutManager::Get().UpdateLayoutLegend(activeLayoutName, legend);
 
   if (layoutViewerPanel) {
@@ -775,6 +778,8 @@ void MainWindow::OnLayoutAddEventTable(wxCommandEvent &WXUNUSED(event)) {
   layouts::LayoutEventTableDefinition table;
   table.frame = BuildDefaultLayoutEventTableFrame(*layout);
 
+  auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+  cfg.PushUndoState("add layout event table");
   layouts::LayoutManager::Get().UpdateLayoutEventTable(activeLayoutName, table);
 
   if (layoutViewerPanel) {
@@ -808,6 +813,8 @@ void MainWindow::OnLayoutAddText(wxCommandEvent &WXUNUSED(event)) {
   text.solidBackground = true;
   text.drawFrame = true;
 
+  auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+  cfg.PushUndoState("add layout text");
   layouts::LayoutManager::Get().UpdateLayoutText(activeLayoutName, text);
 
   if (layoutViewerPanel) {
@@ -845,6 +852,8 @@ void MainWindow::OnLayoutAddImage(wxCommandEvent &WXUNUSED(event)) {
   image.imagePath = pathBuf.data() ? pathBuf.data() : "";
   image.aspectRatio = result->aspectRatio;
 
+  auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+  cfg.PushUndoState("add layout image");
   layouts::LayoutManager::Get().UpdateLayoutImage(activeLayoutName, image);
 
   if (layoutViewerPanel) {
@@ -1003,6 +1012,7 @@ void MainWindow::OnLayout2DViewOk(wxCommandEvent &WXUNUSED(event)) {
   } else if (editableView) {
     updatedView.zIndex = editableView->zIndex;
   }
+  cfg.PushUndoState("edit layout 2d view");
   layouts::LayoutManager::Get().UpdateLayout2DView(activeLayoutName,
                                                    updatedView);
 


### PR DESCRIPTION
### Motivation
- Layout creation and in-canvas edits were mutating layout data without always recording an undo checkpoint, making many layout actions irreversible by the user.
- Add consistent undo save points so common layout workflows (add, move/resize, edit properties, change z-order) integrate with the existing undo/redo stack.

### Description
- Added `cfg.PushUndoState(...)` before layout creation calls in `MainWindow::OnLayoutAdd2DView`, `OnLayoutAddLegend`, `OnLayoutAddEventTable`, `OnLayoutAddText`, and `OnLayoutAddImage` to record undo checkpoints when adding elements (file: `gui/mainwindow_layout.cpp`).
- Added `cfg.PushUndoState("edit layout 2d view")` when confirming the 2D view editor in `MainWindow::OnLayout2DViewOk` so edits in the dialog are undoable (file: `gui/mainwindow_layout.cpp`).
- Added an undo push when starting a frame drag in `LayoutViewerPanel::OnLeftDown` to make move/resize operations reversible, and added `BeginBatchUpdate`/`EndBatchUpdate` pairing as before (file: `gui/layoutviewerpanel.cpp`).
- Added undo pushes for z-order operations (`Bring to Front` / `Send to Back`) for all layout element types, and added undo pushes when editing element properties from context actions (`OnEditEventTable`, `OnEditText`, `OnEditImage`) so those changes become part of the undo history (files: `gui/layoutviewerpanel.cpp`, `gui/layoutviewerpanel_eventtable.cpp`, `gui/layoutviewerpanel_text.cpp`, `gui/layoutviewerpanel_image.cpp`).
- Changes are localized to the existing layout interaction paths and follow the existing `ConfigManager` undo API (`GetDefaultGuiConfigServices().LegacyConfigManager().PushUndoState(...)`).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded (OK).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cea2fa5e808324b5e55d28c1b301fa)