### PR TITLE
Fix UTF-8 preservation in layout event table fields

### DIFF
--- a/gui/layouteventtabledialog.cpp
+++ b/gui/layouteventtabledialog.cpp
@@ -56,9 +56,8 @@ std::array<std::string, 7> LayoutEventTableDialog::GetFields() const {
   std::array<std::string, 7> fields{};
   for (size_t idx = 0; idx < fieldControls_.size(); ++idx) {
     if (fieldControls_[idx]) {
-      wxString value = fieldControls_[idx]->GetValue();
-      value.Trim(true).Trim(false);
-      fields[idx] = value.ToStdString();
+      const wxString value = fieldControls_[idx]->GetValue();
+      fields[idx] = std::string(value.utf8_string());
     }
   }
   return fields;


### PR DESCRIPTION
### Motivation
- Preserve user-entered special characters and exact spacing in layout Event Table fields by avoiding locale-dependent conversion and automatic trimming.

### Description
- In `LayoutEventTableDialog::GetFields` in `gui/layouteventtabledialog.cpp` replace the previous `wxString` -> `std::string` path with `value.utf8_string()` and remove the `Trim()` calls so field text is stored as UTF-8 exactly as entered.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cea6c5cbb883248cc3f753a71b1a6c)