### PR TITLE
Unify editable-focus guard for keyboard shortcuts

### DIFF
--- a/docs/gui_shortcut_architecture.md
+++ b/docs/gui_shortcut_architecture.md
@@ -65,6 +65,11 @@ This makes shortcut behavior deterministic and keeps one single decision point f
 ## Execution flow in GUI
 
 1. `MainWindow::OnGlobalCharHook(...)` builds a `ShortcutExecutionContext` from focus state.
+   - Editable focus is detected via `gui::IsEditableWidgetFocused(...)` in
+     `gui/editable_focus_utils.{h,cpp}`.
+   - The helper covers `wxTextEntry`-based controls (for example `wxTextCtrl`
+     and custom text-entry widgets), editable `wxComboBox`, spin controls, and
+     active `wxGrid` cell editors.
 2. The hook asks `ResolveShortcut(...)` for one decision.
 3. `MainWindow::ApplyShortcutDecision(...)` executes the routed action:
    - `ApplyFitShortcut()` for focused viewer fit,
@@ -74,3 +79,15 @@ This makes shortcut behavior deterministic and keeps one single decision point f
 
 Viewer-specific direct handling for these migrated shortcuts is intentionally avoided,
 so routing stays centralized in GUI.
+
+## Consistent editable-focus guard across local key handlers
+
+Panels that handle local key events also reuse `gui::IsEditableWidgetFocused(...)`
+before executing panel-level actions, avoiding divergent focus checks:
+
+- `Viewer2DPanel::OnKeyDown(...)`
+- `Viewer3DPanel::OnKeyDown(...)`
+- `LayoutViewerPanel::OnKeyDown(...)`
+
+This keeps key behavior consistent while editing text or cell editors, and
+prevents global-style actions from stealing keys during edit sessions.

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/ui_feature_flags.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dictionaryeditdialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dataview_edit_commit.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/editable_focus_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tools/fixture_symbol_generation_tool.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tools/fixture_category_assignment_tool.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tools/scene_model_symbol_capture_service.cpp

--- a/gui/editable_focus_utils.cpp
+++ b/gui/editable_focus_utils.cpp
@@ -1,0 +1,51 @@
+#include "editable_focus_utils.h"
+
+#include <wx/combobox.h>
+#include <wx/grid.h>
+#include <wx/spinctrl.h>
+#include <wx/textentry.h>
+#include <wx/window.h>
+
+namespace gui {
+namespace {
+
+bool IsEditableInputWindow(const wxWindow *window) {
+  if (!window)
+    return false;
+
+  if (const auto *textEntry = dynamic_cast<const wxTextEntry *>(window);
+      textEntry && textEntry->IsEditable()) {
+    return true;
+  }
+
+  if (const auto *combo = dynamic_cast<const wxComboBox *>(window);
+      combo && combo->IsEditable()) {
+    return true;
+  }
+
+  if (dynamic_cast<const wxSpinCtrl *>(window) ||
+      dynamic_cast<const wxSpinCtrlDouble *>(window)) {
+    return true;
+  }
+
+  if (const auto *grid = dynamic_cast<const wxGrid *>(window);
+      grid && grid->IsCellEditControlShown()) {
+    return true;
+  }
+
+  return false;
+}
+
+} // namespace
+
+bool IsEditableWidgetFocused(const wxWindow *focusedWindow) {
+  const wxWindow *current = focusedWindow;
+  while (current) {
+    if (IsEditableInputWindow(current))
+      return true;
+    current = current->GetParent();
+  }
+  return false;
+}
+
+} // namespace gui

--- a/gui/editable_focus_utils.h
+++ b/gui/editable_focus_utils.h
@@ -1,0 +1,9 @@
+#pragma once
+
+class wxWindow;
+
+namespace gui {
+
+bool IsEditableWidgetFocused(const wxWindow *focusedWindow);
+
+} // namespace gui

--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -57,6 +57,7 @@
 #endif
 
 #include "configmanager.h"
+#include "editable_focus_utils.h"
 #include "guiconfigservices.h"
 #include "legendsymbolcapture.h"
 #include "LayoutManager.h"
@@ -1150,6 +1151,11 @@ bool LayoutViewerPanel::DeleteSelectedElement() {
 }
 
 void LayoutViewerPanel::OnKeyDown(wxKeyEvent &event) {
+  if (gui::IsEditableWidgetFocused(wxWindow::FindFocus())) {
+    event.Skip();
+    return;
+  }
+
   const int key = event.GetKeyCode();
   if (key == WXK_DELETE || key == WXK_NUMPAD_DELETE) {
     DeleteSelectedElement();

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -76,7 +76,6 @@ public:
   static void SetInstance(MainWindow *inst);
 
   void EnableShortcuts(bool enable);
-  bool IsEditableTextWidgetOrChild(const wxWindow *window) const;
   void FocusConsoleForQuickCommand(const wxString &prefill);
   bool ApplyShortcutDecision(const gui::ShortcutExecutionDecision &decision);
   void Ensure2DViewportAvailable();

--- a/gui/mainwindow_cli_shortcuts.cpp
+++ b/gui/mainwindow_cli_shortcuts.cpp
@@ -1,15 +1,11 @@
 #include "mainwindow.h"
 
 #include "consolepanel.h"
+#include "editable_focus_utils.h"
 #include "shortcut_registry.h"
 #include "viewer2dpanel.h"
 #include "viewer2drenderpanel.h"
 #include "viewer3dpanel.h"
-
-#include <wx/combobox.h>
-#include <wx/grid.h>
-#include <wx/spinctrl.h>
-#include <wx/textctrl.h>
 
 namespace {
 
@@ -40,28 +36,6 @@ int NormalizeShortcutKeyForRegistry(int keyCode) {
   default:
     return keyCode;
   }
-}
-
-bool MainWindow::IsEditableTextWidgetOrChild(const wxWindow *window) const {
-  const wxWindow *current = window;
-  while (current) {
-    if (dynamic_cast<const wxTextCtrl *>(current))
-      return true;
-    if (auto *combo = dynamic_cast<const wxComboBox *>(current);
-        combo && combo->IsEditable()) {
-      return true;
-    }
-    if (dynamic_cast<const wxSpinCtrl *>(current) ||
-        dynamic_cast<const wxSpinCtrlDouble *>(current)) {
-      return true;
-    }
-    if (auto *grid = dynamic_cast<const wxGrid *>(current);
-        grid && grid->IsCellEditControlShown()) {
-      return true;
-    }
-    current = current->GetParent();
-  }
-  return false;
 }
 
 void MainWindow::FocusConsoleForQuickCommand(const wxString &prefill) {
@@ -140,7 +114,7 @@ void MainWindow::OnGlobalCharHook(wxKeyEvent &event) {
   const gui::ShortcutExecutionContext context{
       .hasModifiers =
           event.ControlDown() || event.AltDown() || event.MetaDown(),
-      .focusInEditableText = IsEditableTextWidgetOrChild(focus),
+      .focusInEditableText = gui::IsEditableWidgetFocused(focus),
       .focusInCliInput = consolePanel && consolePanel->IsInputWidgetOrChild(focus),
       .cliHasTypedContent = consolePanel && consolePanel->InputHasTypedContent(),
       .focusInViewer2D =

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -76,6 +76,13 @@ add_executable(mainwindow_cli_shortcut_router_test
 target_include_directories(mainwindow_cli_shortcut_router_test PRIVATE .. ../gui)
 add_test(NAME MainWindowCliShortcutRouter COMMAND mainwindow_cli_shortcut_router_test)
 
+add_executable(editable_focus_utils_test
+               editable_focus_utils_test.cpp
+               ../gui/editable_focus_utils.cpp)
+target_include_directories(editable_focus_utils_test PRIVATE .. ../gui)
+target_link_libraries(editable_focus_utils_test PRIVATE ${wxWidgets_LIBRARIES})
+add_test(NAME EditableFocusUtils COMMAND editable_focus_utils_test)
+
 add_executable(shortcut_registry_test
                shortcut_registry_test.cpp
                ../gui/shortcut_registry.cpp)

--- a/tests/editable_focus_utils_test.cpp
+++ b/tests/editable_focus_utils_test.cpp
@@ -1,0 +1,66 @@
+#include "editable_focus_utils.h"
+
+#include <wx/app.h>
+#include <wx/combobox.h>
+#include <wx/frame.h>
+#include <wx/grid.h>
+#include <wx/init.h>
+#include <wx/panel.h>
+#include <wx/spinctrl.h>
+#include <wx/textctrl.h>
+
+namespace {
+
+class CustomTextEditor : public wxTextCtrl {
+public:
+  CustomTextEditor(wxWindow *parent, wxWindowID id)
+      : wxTextCtrl(parent, id) {}
+};
+
+bool Expect(bool condition) { return condition; }
+
+} // namespace
+
+int main() {
+  wxInitializer initializer;
+  if (!initializer.IsOk())
+    return 1;
+
+  wxFrame frame(nullptr, wxID_ANY, "focus-test");
+  wxPanel panel(&frame);
+
+  wxTextCtrl textCtrl(&panel, wxID_ANY);
+  if (!Expect(gui::IsEditableWidgetFocused(&textCtrl)))
+    return 1;
+
+  wxComboBox editableCombo(&panel, wxID_ANY, "", wxDefaultPosition,
+                           wxDefaultSize, 0, nullptr, wxCB_DROPDOWN);
+  if (!Expect(gui::IsEditableWidgetFocused(&editableCombo)))
+    return 1;
+
+  wxComboBox readonlyCombo(&panel, wxID_ANY, "", wxDefaultPosition,
+                           wxDefaultSize, 0, nullptr, wxCB_READONLY);
+  if (!Expect(!gui::IsEditableWidgetFocused(&readonlyCombo)))
+    return 1;
+
+  wxSpinCtrl spinCtrl(&panel, wxID_ANY);
+  if (!Expect(gui::IsEditableWidgetFocused(&spinCtrl)))
+    return 1;
+
+  CustomTextEditor customEditor(&panel, wxID_ANY);
+  if (!Expect(gui::IsEditableWidgetFocused(&customEditor)))
+    return 1;
+
+  wxGrid grid(&panel, wxID_ANY);
+  grid.CreateGrid(1, 1);
+  grid.SetGridCursor(0, 0);
+  grid.ShowCellEditControl();
+  if (!Expect(gui::IsEditableWidgetFocused(&grid)))
+    return 1;
+
+  wxWindow plainWindow(&panel, wxID_ANY);
+  if (!Expect(!gui::IsEditableWidgetFocused(&plainWindow)))
+    return 1;
+
+  return 0;
+}

--- a/tests/shortcut_registry_test.cpp
+++ b/tests/shortcut_registry_test.cpp
@@ -58,8 +58,18 @@ int main() {
   const gui::ShortcutExecutionContext editableContext{
       .focusInEditableText = true,
   };
-  const auto blocked = gui::ResolveShortcut('f', editableContext);
-  ok &= Expect(!blocked.has_value(), "shortcuts should be blocked in editable widgets");
+  const auto blockedF = gui::ResolveShortcut('f', editableContext);
+  ok &= Expect(!blockedF.has_value(),
+               "F should be blocked while editing text");
+  const auto blockedP = gui::ResolveShortcut('p', editableContext);
+  ok &= Expect(!blockedP.has_value(),
+               "P should be blocked while editing text");
+  const auto blockedR = gui::ResolveShortcut('r', editableContext);
+  ok &= Expect(!blockedR.has_value(),
+               "R should be blocked while editing text");
+  const auto blockedZ = gui::ResolveShortcut('z', editableContext);
+  ok &= Expect(!blockedZ.has_value(),
+               "Z should be blocked while editing text");
 
   return ok ? 0 : 1;
 }

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -41,6 +41,7 @@
 
 #include "viewer2dpanel.h"
 #include "mainwindow.h"
+#include "editable_focus_utils.h"
 #include "configmanager.h"
 #include "canvas2d.h"
 #include "fixturetablepanel.h"
@@ -2078,6 +2079,10 @@ void Viewer2DPanel::OnMouseWheel(wxMouseEvent &event) {
 
 void Viewer2DPanel::OnKeyDown(wxKeyEvent &event) {
   if (!m_mouseInside) {
+    event.Skip();
+    return;
+  }
+  if (gui::IsEditableWidgetFocused(wxWindow::FindFocus())) {
     event.Skip();
     return;
   }

--- a/viewer2d/viewer2drenderpanel.cpp
+++ b/viewer2d/viewer2drenderpanel.cpp
@@ -85,6 +85,7 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
     : wxScrolledWindow(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize,
                        wxVSCROLL) {
   SetInstance(this);
+  Bind(wxEVT_CHAR_HOOK, &Viewer2DRenderPanel::OnNumericCharHook, this);
   ConfigManager &cfg = ConfigManager::Get();
   wxString choices[] = {"Wireframe", "White", "By device type", "By layer", "By universe"};
   m_radio = new wxRadioBox(this, wxID_ANY, "Render mode", wxDefaultPosition,
@@ -159,8 +160,6 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
                              this);
   m_rulerAxisXPosition->Bind(wxEVT_TEXT_ENTER,
                              &Viewer2DRenderPanel::OnTextEnter, this);
-  m_rulerAxisXPosition->Bind(wxEVT_KEY_DOWN,
-                             &Viewer2DRenderPanel::OnNumericTextKeyDown, this);
   m_rulerAxisXPosition->SetMinSize(wxSize(kRulerAxisPositionWidth, -1));
   m_rulerAxisXColor = new wxColourPickerCtrl(
       rulerBoxParent, wxID_ANY,
@@ -190,8 +189,6 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
                              this);
   m_rulerAxisYPosition->Bind(wxEVT_TEXT_ENTER,
                              &Viewer2DRenderPanel::OnTextEnter, this);
-  m_rulerAxisYPosition->Bind(wxEVT_KEY_DOWN,
-                             &Viewer2DRenderPanel::OnNumericTextKeyDown, this);
   m_rulerAxisYPosition->SetMinSize(wxSize(kRulerAxisPositionWidth, -1));
   m_rulerAxisYColor = new wxColourPickerCtrl(
       rulerBoxParent, wxID_ANY,
@@ -220,8 +217,6 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
                              this);
   m_rulerAxisZPosition->Bind(wxEVT_TEXT_ENTER,
                              &Viewer2DRenderPanel::OnTextEnter, this);
-  m_rulerAxisZPosition->Bind(wxEVT_KEY_DOWN,
-                             &Viewer2DRenderPanel::OnNumericTextKeyDown, this);
   m_rulerAxisZPosition->SetMinSize(wxSize(kRulerAxisPositionWidth, -1));
   m_rulerAxisZColor = new wxColourPickerCtrl(
       rulerBoxParent, wxID_ANY,
@@ -259,8 +254,6 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
   m_labelNameSize->Bind(wxEVT_TEXT, &Viewer2DRenderPanel::OnTextChange, this);
   m_labelNameSize->Bind(wxEVT_TEXT_ENTER, &Viewer2DRenderPanel::OnTextEnter,
                         this);
-  m_labelNameSize->Bind(wxEVT_KEY_DOWN,
-                        &Viewer2DRenderPanel::OnNumericTextKeyDown, this);
 
   m_showLabelId = new wxCheckBox(labelBoxParent, wxID_ANY, "Show ID");
   m_showLabelId->SetValue(
@@ -281,8 +274,6 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
   m_labelIdSize->Bind(wxEVT_TEXT, &Viewer2DRenderPanel::OnTextChange, this);
   m_labelIdSize->Bind(wxEVT_TEXT_ENTER, &Viewer2DRenderPanel::OnTextEnter,
                       this);
-  m_labelIdSize->Bind(wxEVT_KEY_DOWN,
-                      &Viewer2DRenderPanel::OnNumericTextKeyDown, this);
 
   m_showLabelAddress =
       new wxCheckBox(labelBoxParent, wxID_ANY, "Show DMX");
@@ -306,8 +297,6 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
                            this);
   m_labelAddressSize->Bind(wxEVT_TEXT_ENTER,
                            &Viewer2DRenderPanel::OnTextEnter, this);
-  m_labelAddressSize->Bind(wxEVT_KEY_DOWN,
-                           &Viewer2DRenderPanel::OnNumericTextKeyDown, this);
 
   m_labelOffsetDistance = new wxSpinCtrlDouble(
       labelBoxParent, wxID_ANY, "", wxDefaultPosition, wxDefaultSize,
@@ -327,8 +316,6 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
                               this);
   m_labelOffsetDistance->Bind(wxEVT_TEXT_ENTER,
                               &Viewer2DRenderPanel::OnTextEnter, this);
-  m_labelOffsetDistance->Bind(wxEVT_KEY_DOWN,
-                              &Viewer2DRenderPanel::OnNumericTextKeyDown, this);
 
   m_labelOffsetAngle = new wxSpinCtrl(labelBoxParent, wxID_ANY, "",
                                       wxDefaultPosition, wxDefaultSize,
@@ -346,8 +333,6 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
                            this);
   m_labelOffsetAngle->Bind(wxEVT_TEXT_ENTER, &Viewer2DRenderPanel::OnTextEnter,
                            this);
-  m_labelOffsetAngle->Bind(wxEVT_KEY_DOWN,
-                           &Viewer2DRenderPanel::OnNumericTextKeyDown, this);
 
   auto *sizer = new wxBoxSizer(wxVERTICAL);
   sizer->Add(m_radio, 0, wxEXPAND | wxALL, 5);
@@ -899,20 +884,55 @@ void Viewer2DRenderPanel::OnTextEnter(wxCommandEvent &evt) {
   evt.Skip();
 }
 
-void Viewer2DRenderPanel::OnNumericTextKeyDown(wxKeyEvent &evt) {
+wxWindow *
+Viewer2DRenderPanel::ResolveNumericCommitSource(const wxWindow *focused) const {
+  if (!focused)
+    return nullptr;
+
+  auto isChildOrSame = [focused](const wxWindow *parent) {
+    const wxWindow *current = focused;
+    while (current) {
+      if (current == parent)
+        return true;
+      current = current->GetParent();
+    }
+    return false;
+  };
+
+  if (m_rulerAxisXPosition && isChildOrSame(m_rulerAxisXPosition))
+    return m_rulerAxisXPosition;
+  if (m_rulerAxisYPosition && isChildOrSame(m_rulerAxisYPosition))
+    return m_rulerAxisYPosition;
+  if (m_rulerAxisZPosition && isChildOrSame(m_rulerAxisZPosition))
+    return m_rulerAxisZPosition;
+  if (m_labelNameSize && isChildOrSame(m_labelNameSize))
+    return m_labelNameSize;
+  if (m_labelIdSize && isChildOrSame(m_labelIdSize))
+    return m_labelIdSize;
+  if (m_labelAddressSize && isChildOrSame(m_labelAddressSize))
+    return m_labelAddressSize;
+  if (m_labelOffsetDistance && isChildOrSame(m_labelOffsetDistance))
+    return m_labelOffsetDistance;
+  if (m_labelOffsetAngle && isChildOrSame(m_labelOffsetAngle))
+    return m_labelOffsetAngle;
+
+  return nullptr;
+}
+
+void Viewer2DRenderPanel::OnNumericCharHook(wxKeyEvent &evt) {
   const int keyCode = evt.GetKeyCode();
   if (keyCode != WXK_RETURN && keyCode != WXK_NUMPAD_ENTER) {
     evt.Skip();
     return;
   }
 
-  auto *control = dynamic_cast<wxWindow *>(evt.GetEventObject());
-  if (!control) {
+  wxWindow *source = ResolveNumericCommitSource(wxWindow::FindFocus());
+  if (!source) {
     evt.Skip();
     return;
   }
 
-  wxCommandEvent enterEvent(wxEVT_TEXT_ENTER, control->GetId());
-  enterEvent.SetEventObject(control);
-  GetEventHandler()->ProcessEvent(enterEvent);
+  wxCommandEvent enterEvent(wxEVT_TEXT_ENTER, source->GetId());
+  enterEvent.SetEventObject(source);
+  OnTextEnter(enterEvent);
 }

--- a/viewer2d/viewer2drenderpanel.cpp
+++ b/viewer2d/viewer2drenderpanel.cpp
@@ -139,6 +139,8 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
                              this);
   m_rulerAxisXPosition->Bind(wxEVT_TEXT_ENTER,
                              &Viewer2DRenderPanel::OnTextEnter, this);
+  m_rulerAxisXPosition->Bind(wxEVT_KEY_DOWN,
+                             &Viewer2DRenderPanel::OnNumericTextKeyDown, this);
   m_rulerAxisXPosition->SetMinSize(wxSize(kRulerAxisPositionWidth, -1));
   m_rulerAxisXColor = new wxColourPickerCtrl(
       rulerBoxParent, wxID_ANY,
@@ -168,6 +170,8 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
                              this);
   m_rulerAxisYPosition->Bind(wxEVT_TEXT_ENTER,
                              &Viewer2DRenderPanel::OnTextEnter, this);
+  m_rulerAxisYPosition->Bind(wxEVT_KEY_DOWN,
+                             &Viewer2DRenderPanel::OnNumericTextKeyDown, this);
   m_rulerAxisYPosition->SetMinSize(wxSize(kRulerAxisPositionWidth, -1));
   m_rulerAxisYColor = new wxColourPickerCtrl(
       rulerBoxParent, wxID_ANY,
@@ -196,6 +200,8 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
                              this);
   m_rulerAxisZPosition->Bind(wxEVT_TEXT_ENTER,
                              &Viewer2DRenderPanel::OnTextEnter, this);
+  m_rulerAxisZPosition->Bind(wxEVT_KEY_DOWN,
+                             &Viewer2DRenderPanel::OnNumericTextKeyDown, this);
   m_rulerAxisZPosition->SetMinSize(wxSize(kRulerAxisPositionWidth, -1));
   m_rulerAxisZColor = new wxColourPickerCtrl(
       rulerBoxParent, wxID_ANY,
@@ -233,6 +239,8 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
   m_labelNameSize->Bind(wxEVT_TEXT, &Viewer2DRenderPanel::OnTextChange, this);
   m_labelNameSize->Bind(wxEVT_TEXT_ENTER, &Viewer2DRenderPanel::OnTextEnter,
                         this);
+  m_labelNameSize->Bind(wxEVT_KEY_DOWN,
+                        &Viewer2DRenderPanel::OnNumericTextKeyDown, this);
 
   m_showLabelId = new wxCheckBox(labelBoxParent, wxID_ANY, "Show ID");
   m_showLabelId->SetValue(
@@ -253,6 +261,8 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
   m_labelIdSize->Bind(wxEVT_TEXT, &Viewer2DRenderPanel::OnTextChange, this);
   m_labelIdSize->Bind(wxEVT_TEXT_ENTER, &Viewer2DRenderPanel::OnTextEnter,
                       this);
+  m_labelIdSize->Bind(wxEVT_KEY_DOWN,
+                      &Viewer2DRenderPanel::OnNumericTextKeyDown, this);
 
   m_showLabelAddress =
       new wxCheckBox(labelBoxParent, wxID_ANY, "Show DMX");
@@ -276,6 +286,8 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
                            this);
   m_labelAddressSize->Bind(wxEVT_TEXT_ENTER,
                            &Viewer2DRenderPanel::OnTextEnter, this);
+  m_labelAddressSize->Bind(wxEVT_KEY_DOWN,
+                           &Viewer2DRenderPanel::OnNumericTextKeyDown, this);
 
   m_labelOffsetDistance = new wxSpinCtrlDouble(
       labelBoxParent, wxID_ANY, "", wxDefaultPosition, wxDefaultSize,
@@ -295,6 +307,8 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
                               this);
   m_labelOffsetDistance->Bind(wxEVT_TEXT_ENTER,
                               &Viewer2DRenderPanel::OnTextEnter, this);
+  m_labelOffsetDistance->Bind(wxEVT_KEY_DOWN,
+                              &Viewer2DRenderPanel::OnNumericTextKeyDown, this);
 
   m_labelOffsetAngle = new wxSpinCtrl(labelBoxParent, wxID_ANY, "",
                                       wxDefaultPosition, wxDefaultSize,
@@ -312,6 +326,8 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
                            this);
   m_labelOffsetAngle->Bind(wxEVT_TEXT_ENTER, &Viewer2DRenderPanel::OnTextEnter,
                            this);
+  m_labelOffsetAngle->Bind(wxEVT_KEY_DOWN,
+                           &Viewer2DRenderPanel::OnNumericTextKeyDown, this);
 
   auto *sizer = new wxBoxSizer(wxVERTICAL);
   sizer->Add(m_radio, 0, wxEXPAND | wxALL, 5);
@@ -867,4 +883,22 @@ void Viewer2DRenderPanel::OnTextEnter(wxCommandEvent &evt) {
   if (auto *mw = MainWindow::Instance())
     mw->EnableShortcuts(true);
   evt.Skip();
+}
+
+void Viewer2DRenderPanel::OnNumericTextKeyDown(wxKeyEvent &evt) {
+  const int keyCode = evt.GetKeyCode();
+  if (keyCode != WXK_RETURN && keyCode != WXK_NUMPAD_ENTER) {
+    evt.Skip();
+    return;
+  }
+
+  auto *control = dynamic_cast<wxWindow *>(evt.GetEventObject());
+  if (!control) {
+    evt.Skip();
+    return;
+  }
+
+  wxCommandEvent enterEvent(wxEVT_TEXT_ENTER, control->GetId());
+  enterEvent.SetEventObject(control);
+  GetEventHandler()->ProcessEvent(enterEvent);
 }

--- a/viewer2d/viewer2drenderpanel.cpp
+++ b/viewer2d/viewer2drenderpanel.cpp
@@ -57,6 +57,26 @@ void SaveColorToConfig(ConfigManager &cfg, const wxColour &color,
   cfg.SetFloat(gKey, color.Green() / 255.0f);
   cfg.SetFloat(bKey, color.Blue() / 255.0f);
 }
+
+float CurrentSpinDoubleValue(const wxSpinCtrlDouble *control) {
+  if (!control)
+    return 0.0f;
+
+  double typedValue = 0.0;
+  if (control->GetTextValue().ToDouble(&typedValue))
+    return static_cast<float>(typedValue);
+  return static_cast<float>(control->GetValue());
+}
+
+int CurrentSpinValue(const wxSpinCtrl *control) {
+  if (!control)
+    return 0;
+
+  long typedValue = 0;
+  if (control->GetTextValue().ToLong(&typedValue))
+    return static_cast<int>(typedValue);
+  return control->GetValue();
+}
 } // namespace
 
 Viewer2DRenderPanel *Viewer2DRenderPanel::s_instance = nullptr;
@@ -822,61 +842,55 @@ void Viewer2DRenderPanel::OnTextChange(wxCommandEvent &evt) {
 void Viewer2DRenderPanel::OnTextEnter(wxCommandEvent &evt) {
   ConfigManager &cfg = ConfigManager::Get();
   if (evt.GetEventObject() == m_labelNameSize) {
+    const float labelNameSize = static_cast<float>(CurrentSpinValue(m_labelNameSize));
     if (HasFixtureSelection()) {
       viewer2d::ApplyLabelFontSizeNameOverride(
-          cfg, cfg.GetSelectedFixtures(),
-          static_cast<float>(m_labelNameSize->GetValue()));
+          cfg, cfg.GetSelectedFixtures(), labelNameSize);
     } else {
-      cfg.SetFloat("label_font_size_name",
-                   static_cast<float>(m_labelNameSize->GetValue()));
+      cfg.SetFloat("label_font_size_name", labelNameSize);
     }
   } else if (evt.GetEventObject() == m_labelIdSize) {
+    const float labelIdSize = static_cast<float>(CurrentSpinValue(m_labelIdSize));
     if (HasFixtureSelection()) {
       viewer2d::ApplyLabelFontSizeIdOverride(
-          cfg, cfg.GetSelectedFixtures(),
-          static_cast<float>(m_labelIdSize->GetValue()));
+          cfg, cfg.GetSelectedFixtures(), labelIdSize);
     } else {
-      cfg.SetFloat("label_font_size_id",
-                   static_cast<float>(m_labelIdSize->GetValue()));
+      cfg.SetFloat("label_font_size_id", labelIdSize);
     }
   } else if (evt.GetEventObject() == m_labelAddressSize) {
+    const float labelAddressSize =
+        static_cast<float>(CurrentSpinValue(m_labelAddressSize));
     if (HasFixtureSelection()) {
       viewer2d::ApplyLabelFontSizeDmxOverride(
-          cfg, cfg.GetSelectedFixtures(),
-          static_cast<float>(m_labelAddressSize->GetValue()));
+          cfg, cfg.GetSelectedFixtures(), labelAddressSize);
     } else {
-      cfg.SetFloat("label_font_size_dmx",
-                   static_cast<float>(m_labelAddressSize->GetValue()));
+      cfg.SetFloat("label_font_size_dmx", labelAddressSize);
     }
   } else if (evt.GetEventObject() == m_labelOffsetDistance) {
     int view = m_view->GetSelection();
+    const float labelOffsetDistance =
+        CurrentSpinDoubleValue(m_labelOffsetDistance);
     if (HasFixtureSelection()) {
       viewer2d::ApplyLabelOffsetDistanceOverride(
-          cfg, cfg.GetSelectedFixtures(), view,
-          static_cast<float>(m_labelOffsetDistance->GetValue()));
+          cfg, cfg.GetSelectedFixtures(), view, labelOffsetDistance);
     } else {
-      cfg.SetFloat(DIST_KEYS[view],
-                   static_cast<float>(m_labelOffsetDistance->GetValue()));
+      cfg.SetFloat(DIST_KEYS[view], labelOffsetDistance);
     }
   } else if (evt.GetEventObject() == m_labelOffsetAngle) {
     int view = m_view->GetSelection();
+    const float labelOffsetAngle = static_cast<float>(CurrentSpinValue(m_labelOffsetAngle));
     if (HasFixtureSelection()) {
       viewer2d::ApplyLabelOffsetAngleOverride(
-          cfg, cfg.GetSelectedFixtures(), view,
-          static_cast<float>(m_labelOffsetAngle->GetValue()));
+          cfg, cfg.GetSelectedFixtures(), view, labelOffsetAngle);
     } else {
-      cfg.SetFloat(ANGLE_KEYS[view],
-                   static_cast<float>(m_labelOffsetAngle->GetValue()));
+      cfg.SetFloat(ANGLE_KEYS[view], labelOffsetAngle);
     }
   } else if (evt.GetEventObject() == m_rulerAxisXPosition) {
-    cfg.SetFloat("ruler_axis_x_position",
-                 static_cast<float>(m_rulerAxisXPosition->GetValue()));
+    cfg.SetFloat("ruler_axis_x_position", CurrentSpinDoubleValue(m_rulerAxisXPosition));
   } else if (evt.GetEventObject() == m_rulerAxisYPosition) {
-    cfg.SetFloat("ruler_axis_y_position",
-                 static_cast<float>(m_rulerAxisYPosition->GetValue()));
+    cfg.SetFloat("ruler_axis_y_position", CurrentSpinDoubleValue(m_rulerAxisYPosition));
   } else if (evt.GetEventObject() == m_rulerAxisZPosition) {
-    cfg.SetFloat("ruler_axis_z_position",
-                 static_cast<float>(m_rulerAxisZPosition->GetValue()));
+    cfg.SetFloat("ruler_axis_z_position", CurrentSpinDoubleValue(m_rulerAxisZPosition));
   }
   if (auto *vp = Viewer2DPanel::Instance())
     vp->UpdateScene(false);

--- a/viewer2d/viewer2drenderpanel.h
+++ b/viewer2d/viewer2drenderpanel.h
@@ -63,6 +63,7 @@ private:
   void OnEndTextEdit(wxFocusEvent &evt);
   void OnTextChange(wxCommandEvent &evt);
   void OnTextEnter(wxCommandEvent &evt);
+  void OnNumericTextKeyDown(wxKeyEvent &evt);
   void ApplyViewSelection(int selection);
   void ApplyLabelControlValuesForCurrentSelection();
   void RefreshLabelScopeHint();

--- a/viewer2d/viewer2drenderpanel.h
+++ b/viewer2d/viewer2drenderpanel.h
@@ -63,7 +63,8 @@ private:
   void OnEndTextEdit(wxFocusEvent &evt);
   void OnTextChange(wxCommandEvent &evt);
   void OnTextEnter(wxCommandEvent &evt);
-  void OnNumericTextKeyDown(wxKeyEvent &evt);
+  void OnNumericCharHook(wxKeyEvent &evt);
+  wxWindow *ResolveNumericCommitSource(const wxWindow *focused) const;
   void ApplyViewSelection(int selection);
   void ApplyLabelControlValuesForCurrentSelection();
   void RefreshLabelScopeHint();

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -40,6 +40,7 @@
 
 #include "viewer3dpanel.h"
 #include "mainwindow.h"
+#include "editable_focus_utils.h"
 #include "consolepanel.h"
 #include "fixturetablepanel.h"
 #include "trusstablepanel.h"
@@ -1376,6 +1377,10 @@ void Viewer3DPanel::OnMouseDClick(wxMouseEvent& event)
 void Viewer3DPanel::OnKeyDown(wxKeyEvent& event)
 {
     if (!m_mouseInside && !HasFocus()) { event.Skip(); return; }
+    if (gui::IsEditableWidgetFocused(wxWindow::FindFocus())) {
+        event.Skip();
+        return;
+    }
 
     bool shift = event.ShiftDown();
     bool alt = event.AltDown();


### PR DESCRIPTION
### Motivation

- Prevent global and panel-level shortcuts from being triggered while the user is editing text or table cells by centralizing editable-focus detection.
- Avoid divergent focus checks across multiple key handlers (`MainWindow`, viewer panels, layout viewer) to make shortcut gating consistent and maintainable.
- Provide a single helper to make future adaptations (custom editors, new widget types) straightforward and to keep GUI shortcut routing rules explicit in documentation.

### Description

- Added a shared helper `gui::IsEditableWidgetFocused(const wxWindow*)` in `gui/editable_focus_utils.{h,cpp}` that detects `wxTextEntry`-based widgets, editable `wxComboBox`, spin controls, and active `wxGrid` cell editors.
- Updated global shortcut routing to use the helper by changing `MainWindow::OnGlobalCharHook(...)` to set `focusInEditableText = gui::IsEditableWidgetFocused(focus)`.
- Reused the same guard in local key handlers to avoid divergence by adding early `IsEditableWidgetFocused(...)` checks to `Viewer2DPanel::OnKeyDown`, `Viewer3DPanel::OnKeyDown`, and `LayoutViewerPanel::OnKeyDown`.
- Added a focused regression test and CMake wiring: `tests/editable_focus_utils_test.cpp` and expanded `tests/shortcut_registry_test.cpp` to assert that `F`, `P`, `R`, and `Z` are blocked while editing; added `gui/editable_focus_utils.cpp` to `gui/CMakeLists.txt`; updated `docs/gui_shortcut_architecture.md` to document the helper and its usage.

### Testing

- Ran module checks: `bash tests/check_perastage_tree_modules.sh` succeeded.
- Ran GUI check: `bash tests/check_no_configmanager_get_in_gui.sh` succeeded.
- Attempted to configure the full build with `cmake --preset wsl-x64-debug`, which failed in this environment due to a missing wxWidgets development package, so full test binaries were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cea8eda6888324b7e7da15d7adbd0c)