### PR TITLE
Keep fixture and hoist labels above ruler overlay

### DIFF
--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -717,12 +717,6 @@ void Viewer2DPanel::RenderInternal(bool swapBuffers) {
                            gridR, gridG, gridB, drawAbove, true,
                            m_preferPerastageSvgSymbolsForLayouts);
 
-  // Draw labels for all fixtures after rendering the scene so they appear on
-  // top of geometry. Scale the label size with the current zoom so they behave
-  // like regular scene objects instead of remaining a constant screen size.
-  if (!pauseHeavyTasks)
-    m_controller.DrawAllFixtureLabels(w, h, m_view, m_zoom);
-
   if (m_layoutEditAspect && *m_layoutEditAspect > 0.0f) {
     if (!m_layoutEditBaseSize || m_layoutEditBaseSize->GetWidth() <= 0 ||
         m_layoutEditBaseSize->GetHeight() <= 0) {
@@ -820,6 +814,12 @@ void Viewer2DPanel::RenderInternal(bool swapBuffers) {
     if (recordingCanvas)
       viewer2d::EmitRulerToCanvas(rulerState, darkMode, *recordingCanvas);
   }
+
+  // Draw fixture/hoist labels after all overlays so they remain on top of
+  // rulers and other scene elements. Scale with zoom so labels behave like
+  // regular scene objects instead of remaining a constant screen size.
+  if (!pauseHeavyTasks)
+    m_controller.DrawAllFixtureLabels(w, h, m_view, m_zoom);
 
   if (swapBuffers && m_enableSelection && m_rectSelecting)
     DrawSelectionRectangle(w, h, darkMode);


### PR DESCRIPTION
### Motivation
- Ensure fixture and hoist text labels are rendered on top of ruler overlays and other overlays so they remain visible and unobscured.

### Description
- Moved the call to `m_controller.DrawAllFixtureLabels(w, h, m_view, m_zoom)` in `viewer2d/viewer2dpanel.cpp` to execute after ruler overlay rendering and updated the surrounding comment to document the intended draw order.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ceb845dc5c8324939fe2385cdd104a)