### PR TITLE
Add editable Legend dialog and persist per-type legend settings

### DIFF
--- a/core/layouts/LayoutCollection.h
+++ b/core/layouts/LayoutCollection.h
@@ -82,9 +82,20 @@ struct Layout2DViewDefinition {
 };
 
 struct LayoutLegendDefinition {
+  struct ItemSettings {
+    std::string typeName;
+    bool visible = true;
+    bool showBottomSymbol = true;
+    bool showFrontSymbol = true;
+    bool showSideSymbol = false;
+    std::string customName;
+  };
+
   int id = 0;
   int zIndex = 0;
   Layout2DViewFrame frame;
+  bool showChannelColumn = true;
+  std::vector<ItemSettings> itemSettings;
 };
 
 struct LayoutEventTableDefinition {

--- a/core/layouts/LayoutTemplateSerializer.cpp
+++ b/core/layouts/LayoutTemplateSerializer.cpp
@@ -156,13 +156,27 @@ nlohmann::json ToJson(const Layout2DViewDefinition &view) {
 
 nlohmann::json ToJson(const LayoutLegendDefinition &legend) {
   const auto &frame = legend.frame;
+  nlohmann::json itemSettings = nlohmann::json::array();
+  for (const auto &item : legend.itemSettings) {
+    itemSettings.push_back({
+        {"typeName", item.typeName},
+        {"visible", item.visible},
+        {"showBottomSymbol", item.showBottomSymbol},
+        {"showFrontSymbol", item.showFrontSymbol},
+        {"showSideSymbol", item.showSideSymbol},
+        {"customName", item.customName},
+    });
+  }
+
   return {{"id", legend.id},
           {"zIndex", legend.zIndex},
           {"frame",
            {{"x", frame.x},
             {"y", frame.y},
             {"width", frame.width},
-            {"height", frame.height}}}};
+            {"height", frame.height}}},
+          {"showChannelColumn", legend.showChannelColumn},
+          {"itemSettings", std::move(itemSettings)}};
 }
 
 nlohmann::json ToJson(const LayoutEventTableDefinition &table) {
@@ -428,6 +442,51 @@ bool ParseLayoutLegend(const nlohmann::json &value, LayoutLegendDefinition &out,
   auto frameIt = value.find("frame");
   if (frameIt != value.end() && frameIt->is_object())
     ReadFrame(*frameIt, out.frame, ctx);
+  if (auto channelIt = value.find("showChannelColumn");
+      channelIt != value.end() && channelIt->is_boolean()) {
+    out.showChannelColumn = channelIt->get<bool>();
+  }
+  if (auto itemSettingsIt = value.find("itemSettings");
+      itemSettingsIt != value.end()) {
+    if (!itemSettingsIt->is_array()) {
+      AddWarning(ctx, "Ignored legend 'itemSettings' because it is not an array.");
+    } else {
+      out.itemSettings.clear();
+      out.itemSettings.reserve(itemSettingsIt->size());
+      for (const auto &entry : *itemSettingsIt) {
+        if (!entry.is_object())
+          continue;
+        LayoutLegendDefinition::ItemSettings item;
+        if (auto typeIt = entry.find("typeName");
+            typeIt != entry.end() && typeIt->is_string()) {
+          item.typeName = typeIt->get<std::string>();
+        }
+        if (item.typeName.empty())
+          continue;
+        if (auto visibleIt = entry.find("visible");
+            visibleIt != entry.end() && visibleIt->is_boolean()) {
+          item.visible = visibleIt->get<bool>();
+        }
+        if (auto bottomIt = entry.find("showBottomSymbol");
+            bottomIt != entry.end() && bottomIt->is_boolean()) {
+          item.showBottomSymbol = bottomIt->get<bool>();
+        }
+        if (auto frontIt = entry.find("showFrontSymbol");
+            frontIt != entry.end() && frontIt->is_boolean()) {
+          item.showFrontSymbol = frontIt->get<bool>();
+        }
+        if (auto sideIt = entry.find("showSideSymbol");
+            sideIt != entry.end() && sideIt->is_boolean()) {
+          item.showSideSymbol = sideIt->get<bool>();
+        }
+        if (auto customIt = entry.find("customName");
+            customIt != entry.end() && customIt->is_string()) {
+          item.customName = customIt->get<std::string>();
+        }
+        out.itemSettings.push_back(std::move(item));
+      }
+    }
+  }
   return true;
 }
 

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -29,6 +29,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/hoisttablepanel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layerpanel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layout2dviewdialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/layoutlegendeditdialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layouteventtabledialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layoutimageutils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layoutlegenditems.cpp

--- a/gui/layoutlegendeditdialog.cpp
+++ b/gui/layoutlegendeditdialog.cpp
@@ -29,6 +29,12 @@ enum GridColumn {
   kColCustomName,
   kColCount,
 };
+
+wxString BoolCellValue(bool value) {
+  // wxGrid bool editor expects "1" for true and empty string for false.
+  // Using "0" can trigger assertions in debug wxWidgets builds.
+  return value ? "1" : "";
+}
 }
 
 LayoutLegendEditDialog::LayoutLegendEditDialog(
@@ -147,10 +153,10 @@ void LayoutLegendEditDialog::PopulateGrid() {
     const RowData &data = rows_[static_cast<size_t>(row)];
     grid_->SetCellValue(row, kColType, wxString::FromUTF8(data.typeName));
     grid_->SetReadOnly(row, kColType, true);
-    grid_->SetCellValue(row, kColVisible, data.visible ? "1" : "0");
-    grid_->SetCellValue(row, kColBottom, data.showBottomSymbol ? "1" : "0");
-    grid_->SetCellValue(row, kColFront, data.showFrontSymbol ? "1" : "0");
-    grid_->SetCellValue(row, kColSide, data.showSideSymbol ? "1" : "0");
+    grid_->SetCellValue(row, kColVisible, BoolCellValue(data.visible));
+    grid_->SetCellValue(row, kColBottom, BoolCellValue(data.showBottomSymbol));
+    grid_->SetCellValue(row, kColFront, BoolCellValue(data.showFrontSymbol));
+    grid_->SetCellValue(row, kColSide, BoolCellValue(data.showSideSymbol));
     grid_->SetCellValue(row, kColCustomName, wxString::FromUTF8(data.customName));
   }
 }
@@ -180,10 +186,10 @@ void LayoutLegendEditDialog::SaveFromGrid() {
 
   for (int row = 0; row < static_cast<int>(rows_.size()); ++row) {
     RowData &data = rows_[static_cast<size_t>(row)];
-    data.visible = grid_->GetCellValue(row, kColVisible) == "1";
-    data.showBottomSymbol = grid_->GetCellValue(row, kColBottom) == "1";
-    data.showFrontSymbol = grid_->GetCellValue(row, kColFront) == "1";
-    data.showSideSymbol = grid_->GetCellValue(row, kColSide) == "1";
+    data.visible = !grid_->GetCellValue(row, kColVisible).IsEmpty();
+    data.showBottomSymbol = !grid_->GetCellValue(row, kColBottom).IsEmpty();
+    data.showFrontSymbol = !grid_->GetCellValue(row, kColFront).IsEmpty();
+    data.showSideSymbol = !grid_->GetCellValue(row, kColSide).IsEmpty();
     data.customName = std::string(grid_->GetCellValue(row, kColCustomName).utf8_string());
   }
 }

--- a/gui/layoutlegendeditdialog.cpp
+++ b/gui/layoutlegendeditdialog.cpp
@@ -1,0 +1,189 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "layoutlegendeditdialog.h"
+
+#include <unordered_map>
+
+namespace {
+enum GridColumn {
+  kColType = 0,
+  kColVisible,
+  kColBottom,
+  kColFront,
+  kColSide,
+  kColCustomName,
+  kColCount,
+};
+}
+
+LayoutLegendEditDialog::LayoutLegendEditDialog(
+    wxWindow *parent, const layouts::LayoutLegendDefinition &legend,
+    const std::vector<SharedLayoutLegendItem> &availableItems)
+    : wxDialog(parent, wxID_ANY, "Edit Legend", wxDefaultPosition,
+               wxSize(860, 520), wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER) {
+  std::unordered_map<std::string, layouts::LayoutLegendDefinition::ItemSettings>
+      existingByType;
+  existingByType.reserve(legend.itemSettings.size());
+  for (const auto &item : legend.itemSettings) {
+    existingByType[item.typeName] = item;
+  }
+
+  rows_.reserve(availableItems.size());
+  for (const auto &item : availableItems) {
+    RowData row;
+    row.typeName = item.typeName;
+    if (const auto it = existingByType.find(item.typeName);
+        it != existingByType.end()) {
+      row.visible = it->second.visible;
+      row.showBottomSymbol = it->second.showBottomSymbol;
+      row.showFrontSymbol = it->second.showFrontSymbol;
+      row.showSideSymbol = it->second.showSideSymbol;
+      row.customName = it->second.customName;
+    }
+    rows_.push_back(std::move(row));
+  }
+
+  wxBoxSizer *mainSizer = new wxBoxSizer(wxVERTICAL);
+
+  showChannelColumnCheck_ =
+      new wxCheckBox(this, wxID_ANY, "Show channel count column");
+  showChannelColumnCheck_->SetValue(legend.showChannelColumn);
+  mainSizer->Add(showChannelColumnCheck_, 0, wxALL, 10);
+
+  grid_ = new wxGrid(this, wxID_ANY);
+  grid_->CreateGrid(0, kColCount);
+  grid_->EnableEditing(true);
+  grid_->SetColLabelValue(kColType, "Type");
+  grid_->SetColLabelValue(kColVisible, "Visible");
+  grid_->SetColLabelValue(kColBottom, "Bottom");
+  grid_->SetColLabelValue(kColFront, "Front");
+  grid_->SetColLabelValue(kColSide, "Side");
+  grid_->SetColLabelValue(kColCustomName, "Custom name");
+  grid_->SetColFormatBool(kColVisible);
+  grid_->SetColFormatBool(kColBottom);
+  grid_->SetColFormatBool(kColFront);
+  grid_->SetColFormatBool(kColSide);
+  grid_->SetColSize(kColType, 240);
+  grid_->SetColSize(kColVisible, 80);
+  grid_->SetColSize(kColBottom, 80);
+  grid_->SetColSize(kColFront, 80);
+  grid_->SetColSize(kColSide, 80);
+  grid_->SetColSize(kColCustomName, 220);
+  PopulateGrid();
+
+  mainSizer->Add(grid_, 1, wxEXPAND | wxLEFT | wxRIGHT, 10);
+
+  wxBoxSizer *moveSizer = new wxBoxSizer(wxHORIZONTAL);
+  wxButton *upButton = new wxButton(this, wxID_ANY, "Move Up");
+  wxButton *downButton = new wxButton(this, wxID_ANY, "Move Down");
+  moveSizer->Add(upButton, 0, wxRIGHT, 8);
+  moveSizer->Add(downButton, 0);
+  mainSizer->Add(moveSizer, 0, wxLEFT | wxRIGHT | wxTOP, 10);
+
+  mainSizer->Add(CreateStdDialogButtonSizer(wxOK | wxCANCEL), 0,
+                 wxEXPAND | wxALL, 10);
+
+  upButton->Bind(wxEVT_BUTTON,
+                 [this](wxCommandEvent &) { MoveSelectedRow(-1); });
+  downButton->Bind(wxEVT_BUTTON,
+                   [this](wxCommandEvent &) { MoveSelectedRow(1); });
+  Bind(wxEVT_BUTTON,
+       [this](wxCommandEvent &event) {
+         if (event.GetId() == wxID_OK)
+           SaveFromGrid();
+         event.Skip();
+       });
+
+  SetSizerAndFit(mainSizer);
+  CentreOnParent();
+}
+
+bool LayoutLegendEditDialog::GetShowChannelColumn() const {
+  return showChannelColumnCheck_ ? showChannelColumnCheck_->GetValue() : true;
+}
+
+std::vector<layouts::LayoutLegendDefinition::ItemSettings>
+LayoutLegendEditDialog::GetItemSettings() const {
+  std::vector<layouts::LayoutLegendDefinition::ItemSettings> settings;
+  settings.reserve(rows_.size());
+  for (const auto &row : rows_) {
+    layouts::LayoutLegendDefinition::ItemSettings item;
+    item.typeName = row.typeName;
+    item.visible = row.visible;
+    item.showBottomSymbol = row.showBottomSymbol;
+    item.showFrontSymbol = row.showFrontSymbol;
+    item.showSideSymbol = row.showSideSymbol;
+    item.customName = row.customName;
+    settings.push_back(std::move(item));
+  }
+  return settings;
+}
+
+void LayoutLegendEditDialog::PopulateGrid() {
+  if (!grid_)
+    return;
+  const int currentRows = grid_->GetNumberRows();
+  if (currentRows > 0)
+    grid_->DeleteRows(0, currentRows);
+  if (!rows_.empty())
+    grid_->AppendRows(static_cast<int>(rows_.size()));
+
+  for (int row = 0; row < static_cast<int>(rows_.size()); ++row) {
+    const RowData &data = rows_[static_cast<size_t>(row)];
+    grid_->SetCellValue(row, kColType, wxString::FromUTF8(data.typeName));
+    grid_->SetReadOnly(row, kColType, true);
+    grid_->SetCellValue(row, kColVisible, data.visible ? "1" : "0");
+    grid_->SetCellValue(row, kColBottom, data.showBottomSymbol ? "1" : "0");
+    grid_->SetCellValue(row, kColFront, data.showFrontSymbol ? "1" : "0");
+    grid_->SetCellValue(row, kColSide, data.showSideSymbol ? "1" : "0");
+    grid_->SetCellValue(row, kColCustomName, wxString::FromUTF8(data.customName));
+  }
+}
+
+void LayoutLegendEditDialog::MoveSelectedRow(int delta) {
+  if (!grid_)
+    return;
+  SaveFromGrid();
+  const int row = grid_->GetGridCursorRow();
+  if (row < 0 || row >= static_cast<int>(rows_.size()))
+    return;
+  const int target = row + delta;
+  if (target < 0 || target >= static_cast<int>(rows_.size()))
+    return;
+  std::swap(rows_[static_cast<size_t>(row)], rows_[static_cast<size_t>(target)]);
+  PopulateGrid();
+  grid_->SetGridCursor(target, grid_->GetGridCursorCol());
+  grid_->MakeCellVisible(target, grid_->GetGridCursorCol());
+}
+
+void LayoutLegendEditDialog::SaveFromGrid() {
+  if (!grid_)
+    return;
+  if (grid_->IsCellEditControlShown())
+    grid_->HideCellEditControl();
+  grid_->SaveEditControlValue();
+
+  for (int row = 0; row < static_cast<int>(rows_.size()); ++row) {
+    RowData &data = rows_[static_cast<size_t>(row)];
+    data.visible = grid_->GetCellValue(row, kColVisible) == "1";
+    data.showBottomSymbol = grid_->GetCellValue(row, kColBottom) == "1";
+    data.showFrontSymbol = grid_->GetCellValue(row, kColFront) == "1";
+    data.showSideSymbol = grid_->GetCellValue(row, kColSide) == "1";
+    data.customName = std::string(grid_->GetCellValue(row, kColCustomName).utf8_string());
+  }
+}

--- a/gui/layoutlegendeditdialog.h
+++ b/gui/layoutlegendeditdialog.h
@@ -1,0 +1,54 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <vector>
+#include <wx/grid.h>
+#include <wx/wx.h>
+
+#include "LayoutCollection.h"
+#include "layoutlegenditems.h"
+
+class LayoutLegendEditDialog : public wxDialog {
+public:
+  LayoutLegendEditDialog(
+      wxWindow *parent, const layouts::LayoutLegendDefinition &legend,
+      const std::vector<SharedLayoutLegendItem> &availableItems);
+
+  bool GetShowChannelColumn() const;
+  std::vector<layouts::LayoutLegendDefinition::ItemSettings> GetItemSettings()
+      const;
+
+private:
+  struct RowData {
+    std::string typeName;
+    bool visible = true;
+    bool showBottomSymbol = true;
+    bool showFrontSymbol = true;
+    bool showSideSymbol = false;
+    std::string customName;
+  };
+
+  void PopulateGrid();
+  void MoveSelectedRow(int delta);
+  void SaveFromGrid();
+
+  std::vector<RowData> rows_;
+  wxGrid *grid_ = nullptr;
+  wxCheckBox *showChannelColumnCheck_ = nullptr;
+};

--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -84,6 +84,7 @@ constexpr size_t kMaxRenderBytes = 64 * 1024 * 1024;
 constexpr int kEditMenuId = wxID_HIGHEST + 490;
 constexpr int kDeleteMenuId = wxID_HIGHEST + 491;
 constexpr int kDeleteLegendMenuId = wxID_HIGHEST + 492;
+constexpr int kEditLegendMenuId = wxID_HIGHEST + 505;
 constexpr int kEditEventTableMenuId = wxID_HIGHEST + 493;
 constexpr int kDeleteEventTableMenuId = wxID_HIGHEST + 494;
 constexpr int kEditTextMenuId = wxID_HIGHEST + 495;
@@ -426,6 +427,7 @@ wxBEGIN_EVENT_TABLE(LayoutViewerPanel, wxGLCanvas)
     EVT_SHOW(LayoutViewerPanel::OnShow)
     EVT_MENU(kEditMenuId, LayoutViewerPanel::OnEditView)
     EVT_MENU(kDeleteMenuId, LayoutViewerPanel::OnDeleteView)
+    EVT_MENU(kEditLegendMenuId, LayoutViewerPanel::OnEditLegend)
     EVT_MENU(kDeleteLegendMenuId, LayoutViewerPanel::OnDeleteLegend)
     EVT_MENU(kEditEventTableMenuId, LayoutViewerPanel::OnEditEventTable)
     EVT_MENU(kDeleteEventTableMenuId, LayoutViewerPanel::OnDeleteEventTable)
@@ -1150,6 +1152,11 @@ void LayoutViewerPanel::OnLeftDClick(wxMouseEvent &event) {
       OnEditEventTable(editEvent);
       return;
     }
+    if (selectedElementType == SelectedElementType::Legend) {
+      wxCommandEvent editEvent;
+      OnEditLegend(editEvent);
+      return;
+    }
     if (selectedElementType == SelectedElementType::Text) {
       wxCommandEvent editEvent;
       OnEditText(editEvent);
@@ -1416,6 +1423,7 @@ void LayoutViewerPanel::OnRightUp(wxMouseEvent &event) {
     menu.Append(kBringToFrontMenuId, "Bring to Front");
     menu.Append(kSendToBackMenuId, "Send to Back");
   } else if (selectedElementType == SelectedElementType::Legend) {
+    menu.Append(kEditLegendMenuId, "Edit Legend");
     menu.Append(kDeleteLegendMenuId, "Delete Legend");
     menu.AppendSeparator();
     menu.Append(kBringToFrontMenuId, "Bring to Front");

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -50,10 +50,14 @@ public:
 private:
   struct LegendItem {
     std::string typeName;
+    std::string displayName;
     int count = 0;
     std::optional<int> channelCount;
     std::string symbolKey;
     std::optional<std::string> symbolFillHex;
+    bool showBottomSymbol = true;
+    bool showFrontSymbol = true;
+    bool showSideSymbol = false;
   };
 
   struct ViewCache {
@@ -129,6 +133,7 @@ private:
   void OnShow(wxShowEvent &event);
   void OnEditView(wxCommandEvent &event);
   void OnDeleteView(wxCommandEvent &event);
+  void OnEditLegend(wxCommandEvent &event);
   void OnDeleteLegend(wxCommandEvent &event);
   void OnEditEventTable(wxCommandEvent &event);
   void OnDeleteEventTable(wxCommandEvent &event);

--- a/gui/layoutviewerpanel_legend.cpp
+++ b/gui/layoutviewerpanel_legend.cpp
@@ -24,6 +24,7 @@
 #include <limits>
 #include <optional>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 // Include GLEW or other OpenGL loader first if present
@@ -42,6 +43,7 @@
 #endif
 
 #include "layoutviewerpanel_shared.h"
+#include "layoutlegendeditdialog.h"
 #include "layoutlegenditems.h"
 #include "LayoutManager.h"
 #include "guiconfigservices.h"
@@ -655,6 +657,29 @@ void LayoutViewerPanel::OnDeleteLegend(wxCommandEvent &) {
   Refresh();
 }
 
+void LayoutViewerPanel::OnEditLegend(wxCommandEvent &) {
+  if (selectedElementType != SelectedElementType::Legend)
+    return;
+  layouts::LayoutLegendDefinition *legend = GetSelectedLegend();
+  if (!legend)
+    return;
+
+  const std::vector<SharedLayoutLegendItem> availableItems =
+      BuildSharedLayoutLegendItems();
+  LayoutLegendEditDialog dialog(this, *legend, availableItems);
+  if (dialog.ShowModal() != wxID_OK)
+    return;
+
+  auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+  cfg.PushUndoState("edit layout legend");
+  legend->showChannelColumn = dialog.GetShowChannelColumn();
+  legend->itemSettings = dialog.GetItemSettings();
+  layouts::LayoutManager::Get().UpdateLayoutLegend(currentLayout.name, *legend);
+  RefreshLegendData();
+  RequestRenderRebuild();
+  Refresh();
+}
+
 void LayoutViewerPanel::DrawLegendElement(
     const layouts::LayoutLegendDefinition &legend, int activeLegendId) {
   LegendCache &cache = GetLegendCache(legend.id);
@@ -745,16 +770,61 @@ std::vector<LayoutViewerPanel::LegendItem>
 LayoutViewerPanel::BuildLegendItems() const {
   std::vector<SharedLayoutLegendItem> sharedItems =
       BuildSharedLayoutLegendItems();
+  const layouts::LayoutLegendDefinition *legend = GetSelectedLegend();
+  std::unordered_map<std::string, layouts::LayoutLegendDefinition::ItemSettings>
+      settingsByType;
+  if (legend) {
+    settingsByType.reserve(legend->itemSettings.size());
+    for (const auto &settings : legend->itemSettings)
+      settingsByType[settings.typeName] = settings;
+  }
+
+  std::unordered_map<std::string, SharedLayoutLegendItem> availableByType;
+  availableByType.reserve(sharedItems.size());
+  for (const auto &shared : sharedItems)
+    availableByType.emplace(shared.typeName, shared);
+
   std::vector<LegendItem> items;
   items.reserve(sharedItems.size());
-  for (const auto &shared : sharedItems) {
+  auto appendItem = [&](const SharedLayoutLegendItem &shared) {
     LegendItem item;
     item.typeName = shared.typeName;
+    item.displayName = shared.typeName;
     item.count = shared.count;
     item.channelCount = shared.channelCount;
     item.symbolKey = shared.symbolKey;
     item.symbolFillHex = shared.symbolFillHex;
+    if (const auto it = settingsByType.find(shared.typeName);
+        it != settingsByType.end()) {
+      item.showBottomSymbol = it->second.showBottomSymbol;
+      item.showFrontSymbol = it->second.showFrontSymbol;
+      item.showSideSymbol = it->second.showSideSymbol;
+      if (!it->second.customName.empty())
+        item.displayName = it->second.customName;
+      if (!it->second.visible)
+        return;
+    }
     items.push_back(std::move(item));
+  };
+
+  if (legend) {
+    std::unordered_set<std::string> usedTypes;
+    usedTypes.reserve(legend->itemSettings.size());
+    for (const auto &settings : legend->itemSettings) {
+      const auto it = availableByType.find(settings.typeName);
+      if (it == availableByType.end())
+        continue;
+      appendItem(it->second);
+      usedTypes.insert(settings.typeName);
+    }
+    for (const auto &shared : sharedItems) {
+      if (usedTypes.find(shared.typeName) != usedTypes.end())
+        continue;
+      appendItem(shared);
+    }
+  } else {
+    for (const auto &shared : sharedItems)
+      appendItem(shared);
   }
   return items;
 }
@@ -766,12 +836,22 @@ size_t LayoutViewerPanel::HashLegendItems(
   std::hash<int> intHasher;
   for (const auto &item : items) {
     hash ^= strHasher(item.typeName) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+    hash ^= strHasher(item.displayName) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
     hash ^= intHasher(item.count) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
     int chValue = item.channelCount.value_or(-1);
     hash ^= intHasher(chValue) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
     hash ^= strHasher(item.symbolKey) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
     hash ^= strHasher(item.symbolFillHex.value_or("")) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+    hash ^= intHasher(item.showBottomSymbol ? 1 : 0) + 0x9e3779b9 + (hash << 6) +
+            (hash >> 2);
+    hash ^= intHasher(item.showFrontSymbol ? 1 : 0) + 0x9e3779b9 + (hash << 6) +
+            (hash >> 2);
+    hash ^= intHasher(item.showSideSymbol ? 1 : 0) + 0x9e3779b9 + (hash << 6) +
+            (hash >> 2);
   }
+  const auto *legend = GetSelectedLegend();
+  hash ^= intHasher((legend && legend->showChannelColumn) ? 1 : 0) +
+          0x9e3779b9 + (hash << 6) + (hash >> 2);
   return hash;
 }
 
@@ -849,11 +929,13 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   for (const auto &item : items) {
     rowTexts.push_back({
         wxString::Format("%d", item.count),
-        wxString::FromUTF8(item.typeName),
+        wxString::FromUTF8(item.displayName),
         item.channelCount.has_value()
             ? wxString::Format("%d", item.channelCount.value())
             : wxString("-")});
   }
+  const bool showChannelColumn =
+      GetSelectedLegend() ? GetSelectedLegend()->showChannelColumn : true;
 
   const int paddingLeftPx =
       std::max(0, static_cast<int>(std::lround(paddingLeft * renderZoom)));
@@ -902,13 +984,16 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   baseTextExtentCache.clear();
   dc.SetFont(baseFont);
   int maxCountWidth = measureTextWidth("Count");
-  int maxChWidth = measureTextWidth("Ch");
+  int maxChWidth = showChannelColumn ? measureTextWidth("Ch") : 0;
   for (const auto &row : rowTexts) {
     maxCountWidth = std::max(maxCountWidth, measureTextWidth(row.countText));
-    maxChWidth = std::max(maxChWidth, measureTextWidth(row.chText));
+    if (showChannelColumn)
+      maxChWidth = std::max(maxChWidth, measureTextWidth(row.chText));
   }
-  const int chExtraWidthPx = measureTextWidth("0");
-  maxChWidth += chExtraWidthPx;
+  if (showChannelColumn) {
+    const int chExtraWidthPx = measureTextWidth("0");
+    maxChWidth += chExtraWidthPx;
+  }
   const int desiredSymbolSize = static_cast<int>(std::lround(
       kLegendSymbolSizePx * renderZoom * currentFontScale));
   const int symbolSize = std::max(4, desiredSymbolSize);
@@ -1047,21 +1132,36 @@ wxImage LayoutViewerPanel::BuildLegendImage(
 
   double maxTopSymbolColumnWidth = 0.0;
   double maxFrontSymbolColumnWidth = 0.0;
+  double maxSideSymbolColumnWidth = 0.0;
   bool hasSvgSymbols = false;
   bool hasFallbackSymbols = false;
   bool hasTopSvgSymbols = false;
   bool hasFrontSvgSymbols = false;
+  bool hasSideSvgSymbols = false;
   for (const auto &item : items) {
     if (item.symbolKey.empty())
       continue;
-    const PerastageSvgSymbolData *topSvg =
-        findSvgSymbol(item.symbolKey, SymbolViewKind::Bottom);
-    const PerastageSvgSymbolData *frontSvg =
-        findSvgSymbol(item.symbolKey, SymbolViewKind::Front);
-    const SymbolDefinition *topSymbol = FindSymbolDefinitionPreferred(
-        symbols, item.symbolKey, SymbolViewKind::Bottom);
-    const SymbolDefinition *frontSymbol =
-        FindSymbolDefinitionExact(symbols, item.symbolKey, SymbolViewKind::Front);
+    const PerastageSvgSymbolData *topSvg = item.showBottomSymbol
+                                               ? findSvgSymbol(item.symbolKey, SymbolViewKind::Bottom)
+                                               : nullptr;
+    const PerastageSvgSymbolData *frontSvg = item.showFrontSymbol
+                                                 ? findSvgSymbol(item.symbolKey, SymbolViewKind::Front)
+                                                 : nullptr;
+    const PerastageSvgSymbolData *sideSvg = item.showSideSymbol
+                                                ? findSvgSymbol(item.symbolKey, SymbolViewKind::Right)
+                                                : nullptr;
+    const SymbolDefinition *topSymbol = item.showBottomSymbol
+                                            ? FindSymbolDefinitionPreferred(symbols, item.symbolKey,
+                                                                           SymbolViewKind::Bottom)
+                                            : nullptr;
+    const SymbolDefinition *frontSymbol = item.showFrontSymbol
+                                              ? FindSymbolDefinitionExact(symbols, item.symbolKey,
+                                                                          SymbolViewKind::Front)
+                                              : nullptr;
+    const SymbolDefinition *sideSymbol = item.showSideSymbol
+                                             ? FindSymbolDefinitionExact(symbols, item.symbolKey,
+                                                                         SymbolViewKind::Right)
+                                             : nullptr;
     if (topSvg) {
       hasSvgSymbols = true;
       hasTopSvgSymbols = true;
@@ -1074,12 +1174,21 @@ wxImage LayoutViewerPanel::BuildLegendImage(
     } else if (frontSymbol) {
       hasFallbackSymbols = true;
     }
+    if (sideSvg) {
+      hasSvgSymbols = true;
+      hasSideSvgSymbols = true;
+    } else if (sideSymbol) {
+      hasFallbackSymbols = true;
+    }
     const double topDrawW =
         topSvg ? symbolDrawWidthSvg(topSvg) : symbolDrawWidth(topSymbol);
     const double frontDrawW =
         frontSvg ? symbolDrawWidthSvg(frontSvg) : symbolDrawWidth(frontSymbol);
+    const double sideDrawW =
+        sideSvg ? symbolDrawWidthSvg(sideSvg) : symbolDrawWidth(sideSymbol);
     maxTopSymbolColumnWidth = std::max(maxTopSymbolColumnWidth, topDrawW);
     maxFrontSymbolColumnWidth = std::max(maxFrontSymbolColumnWidth, frontDrawW);
+    maxSideSymbolColumnWidth = std::max(maxSideSymbolColumnWidth, sideDrawW);
   }
   const int maxSymbolColumnSize =
       std::max(4, static_cast<int>(std::lround(symbolSize *
@@ -1097,6 +1206,11 @@ wxImage LayoutViewerPanel::BuildLegendImage(
                                           maxMeasuredSymbolColumnWidth) *
                                  kLegendSymbolColumnScale)),
       0, limitedSymbolColumnSize);
+  int sideSymbolColumnSize = std::clamp(
+      static_cast<int>(std::ceil(std::min(maxSideSymbolColumnWidth,
+                                          maxMeasuredSymbolColumnWidth) *
+                                 kLegendSymbolColumnScale)),
+      0, limitedSymbolColumnSize);
   const int columnGapPx =
       std::max(0, static_cast<int>(std::lround(columnGap * renderZoom)));
   int symbolColumnGapPx =
@@ -1111,6 +1225,8 @@ wxImage LayoutViewerPanel::BuildLegendImage(
     if (hasFrontSvgSymbols)
       frontSymbolColumnSize =
           std::max(frontSymbolColumnSize, minSvgColumnSize);
+    if (hasSideSvgSymbols)
+      sideSymbolColumnSize = std::max(sideSymbolColumnSize, minSvgColumnSize);
     symbolColumnGapPx =
         std::max(symbolColumnGapPx,
                  std::max(1, static_cast<int>(std::lround(2.5 * renderZoom))));
@@ -1120,12 +1236,18 @@ wxImage LayoutViewerPanel::BuildLegendImage(
 
   int xTopSymbol = paddingLeftPx + symbolOuterMarginPx;
   int xFrontSymbol = xTopSymbol + topSymbolColumnSize + symbolColumnGapPx;
-  int xCount = xFrontSymbol + frontSymbolColumnSize + columnGapPx;
+  int xSideSymbol = xFrontSymbol + frontSymbolColumnSize + symbolColumnGapPx;
+  int xCount = xSideSymbol + sideSymbolColumnSize + columnGapPx;
   int xType = xCount + maxCountWidth + columnGapPx;
   int xCh = size.GetWidth() - paddingRightPx - maxChWidth;
-  if (xCh < xType + columnGapPx)
-    xCh = xType + columnGapPx;
-  int typeWidth = std::max(0, xCh - xType - columnGapPx);
+  if (showChannelColumn) {
+    if (xCh < xType + columnGapPx)
+      xCh = xType + columnGapPx;
+  } else {
+    xCh = size.GetWidth() - paddingRightPx;
+  }
+  int typeWidth = std::max(
+      0, showChannelColumn ? (xCh - xType - columnGapPx) : (xCh - xType));
 
   auto wrapTextToTwoLines = [&](const wxString &text, int maxWidth) {
     if (maxWidth <= 0)
@@ -1175,7 +1297,8 @@ wxImage LayoutViewerPanel::BuildLegendImage(
   dc.SetFont(headerFont);
   dc.DrawText("Count", xCount, y + headerTextOffset);
   dc.DrawText("Type", xType, y + headerTextOffset);
-  dc.DrawText("Ch", xCh, y + headerTextOffset);
+  if (showChannelColumn)
+    dc.DrawText("Ch", xCh, y + headerTextOffset);
 
   y += rowHeightPx;
   dc.SetPen(wxPen(wxColour(200, 200, 200)));
@@ -1195,10 +1318,14 @@ wxImage LayoutViewerPanel::BuildLegendImage(
           symbols, item.symbolKey, SymbolViewKind::Bottom);
       const SymbolDefinition *frontSymbol = FindSymbolDefinitionExact(
           symbols, item.symbolKey, SymbolViewKind::Front);
+      const SymbolDefinition *sideSymbol = FindSymbolDefinitionExact(
+          symbols, item.symbolKey, SymbolViewKind::Right);
       const PerastageSvgSymbolData *topSvg =
           findSvgSymbol(item.symbolKey, SymbolViewKind::Bottom);
       const PerastageSvgSymbolData *frontSvg =
           findSvgSymbol(item.symbolKey, SymbolViewKind::Front);
+      const PerastageSvgSymbolData *sideSvg =
+          findSvgSymbol(item.symbolKey, SymbolViewKind::Right);
       auto drawSymbol = [&](const SymbolDefinition *symbol, double drawCenterX,
                             double drawTop) {
         if (!symbol)
@@ -1283,7 +1410,11 @@ wxImage LayoutViewerPanel::BuildLegendImage(
       const double frontDrawH =
           frontSvg ? symbolDrawHeightSvg(frontSvg)
                    : symbolDrawHeight(frontSymbol);
-      if (topDrawW > 0.0) {
+      const double sideDrawW =
+          sideSvg ? symbolDrawWidthSvg(sideSvg) : symbolDrawWidth(sideSymbol);
+      const double sideDrawH =
+          sideSvg ? symbolDrawHeightSvg(sideSvg) : symbolDrawHeight(sideSymbol);
+      if (item.showBottomSymbol && topDrawW > 0.0) {
         const double symbolDrawTop =
             y + (static_cast<double>(rowHeightPx) - topDrawH) * 0.5;
         const double symbolDrawLeft =
@@ -1297,7 +1428,7 @@ wxImage LayoutViewerPanel::BuildLegendImage(
                      xTopSymbol + static_cast<double>(topSymbolColumnSize) * 0.5,
                      symbolDrawTop);
       }
-      if (frontDrawW > 0.0) {
+      if (item.showFrontSymbol && frontDrawW > 0.0) {
         const double symbolDrawTop =
             y + (static_cast<double>(rowHeightPx) - frontDrawH) * 0.5;
         const double symbolDrawLeft =
@@ -1311,13 +1442,28 @@ wxImage LayoutViewerPanel::BuildLegendImage(
                      xFrontSymbol + static_cast<double>(frontSymbolColumnSize) * 0.5,
                      symbolDrawTop);
       }
+      if (item.showSideSymbol && sideDrawW > 0.0) {
+        const double symbolDrawTop =
+            y + (static_cast<double>(rowHeightPx) - sideDrawH) * 0.5;
+        const double symbolDrawLeft =
+            xSideSymbol +
+            std::max(0.0, (static_cast<double>(sideSymbolColumnSize) - sideDrawW) *
+                                 0.5);
+        if (sideSvg)
+          drawSvg(sideSvg, item.symbolFillHex, symbolDrawLeft, symbolDrawTop);
+        else
+          drawSymbol(sideSymbol,
+                     xSideSymbol + static_cast<double>(sideSymbolColumnSize) * 0.5,
+                     symbolDrawTop);
+      }
     }
     dc.DrawText(rowText.countText, xCount, y + rowSingleTextOffset);
     dc.DrawText(wrappedType[0], xType, y + rowTypeTextOffset);
     if (!wrappedType[1].empty())
       dc.DrawText(wrappedType[1], xType,
                   y + rowTypeTextOffset + textHeight + separatorGapPx);
-    dc.DrawText(rowText.chText, xCh, y + rowSingleTextOffset);
+    if (showChannelColumn)
+      dc.DrawText(rowText.chText, xCh, y + rowSingleTextOffset);
     y += rowHeightPx;
   }
 

--- a/tests/layout_template_serializer_test.cpp
+++ b/tests/layout_template_serializer_test.cpp
@@ -45,6 +45,9 @@ layouts::LayoutDefinition BuildFullLayoutDefinition() {
   legend.id = 12;
   legend.zIndex = 5;
   legend.frame = {2, 3, 80, 120};
+  legend.showChannelColumn = false;
+  legend.itemSettings.push_back({"Spot", true, true, false, true, "Spot Main"});
+  legend.itemSettings.push_back({"Wash", false, true, true, false, ""});
   layout.legendViews.push_back(legend);
 
   layouts::LayoutEventTableDefinition table;
@@ -100,6 +103,10 @@ void TestFullRoundTrip() {
 
   assert(layout.view2dViews.front().camera.view == 2);
   assert(layout.legendViews.front().id == 12);
+  assert(!layout.legendViews.front().showChannelColumn);
+  assert(layout.legendViews.front().itemSettings.size() == 2);
+  assert(layout.legendViews.front().itemSettings[0].typeName == "Spot");
+  assert(layout.legendViews.front().itemSettings[0].showSideSymbol);
   assert(layout.eventTables.front().fields[0] == "Venue");
   assert(layout.textViews.front().richText == "<b>Rich</b>");
   assert(layout.imageViews.front().aspectRatio == original.imageViews.front().aspectRatio);


### PR DESCRIPTION
### Motivation
- Provide a dedicated UI to edit layout legend presentation (which rows show, ordering, per-row symbol-view toggles, custom names and channel-column visibility) so users can control what appears in exported/onscreen legends.
- Persist those presentation choices in layout templates so legend configuration survives import/export and is applied when rendering.

### Description
- Added `LayoutLegendEditDialog` (`gui/layoutlegendeditdialog.h/.cpp`) that presents a grid allowing per-type toggles for visibility, `Bottom`/`Front`/`Side` symbols, a custom name column, row ordering (`Move Up` / `Move Down`) and a checkbox to toggle the channel-count column.
- Extended `layouts::LayoutLegendDefinition` in `core/layouts/LayoutCollection.h` with `ItemSettings` and `showChannelColumn` to store ordered per-type settings and channel column visibility.
- Updated JSON serializer/parsing in `core/layouts/LayoutTemplateSerializer.cpp` to export/import `showChannelColumn` and the `itemSettings` array.
- Wired the editor into the layout viewer: added an `Edit Legend` menu entry, double-click handler and `OnEditLegend` handler in `gui/layoutviewerpanel.*` to show the dialog and apply changes through `LayoutManager::UpdateLayoutLegend` with undo state.
- Adjusted legend building and rendering (`gui/layoutviewerpanel_legend.cpp`) to apply ordering, visibility, per-row display name, per-row symbol-view toggles (mapping `Side` to the `Right` symbol view), and to hide the channel column when `showChannelColumn` is false.
- Registered the new dialog in `gui/CMakeLists.txt` and added round-trip serializer assertions in `tests/layout_template_serializer_test.cpp` to cover the new fields.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which succeeded (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` which succeeded (`OK`).
- Attempted a full CMake build with `cmake -S . -B build && cmake --build build -j4` which failed due to missing system wxWidgets development dependencies (`wxWidgets_LIBRARIES` / `wxWidgets_INCLUDE_DIRS`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ceb6fccd1c83249ad456c0f2f9959a)