### PR TITLE
Add 'Show Border' toggle for layout 2D view elements

### DIFF
--- a/core/layouts/LayoutCollection.h
+++ b/core/layouts/LayoutCollection.h
@@ -76,6 +76,7 @@ struct Layout2DViewDefinition {
   int id = 0;
   int zIndex = 0;
   Layout2DViewFrame frame;
+  bool drawFrame = true;
   Layout2DViewCameraState camera;
   Layout2DViewRenderOptions renderOptions;
   Layout2DViewLayers layers;

--- a/core/layouts/LayoutTemplateSerializer.cpp
+++ b/core/layouts/LayoutTemplateSerializer.cpp
@@ -113,6 +113,7 @@ nlohmann::json ToJson(const Layout2DViewDefinition &view) {
       {"zIndex", view.zIndex},
       {"frame",
        {{"x", frame.x}, {"y", frame.y}, {"width", frame.width}, {"height", frame.height}}},
+      {"drawFrame", view.drawFrame},
       {"camera",
        {{"offsetPixelsX", camera.offsetPixelsX},
         {"offsetPixelsY", camera.offsetPixelsY},
@@ -411,6 +412,9 @@ bool ParseLayout2DView(const nlohmann::json &value, Layout2DViewDefinition &out,
     out.id = idIt->get<int>();
   if (auto zIt = value.find("zIndex"); zIt != value.end() && zIt->is_number_integer())
     out.zIndex = zIt->get<int>();
+  if (auto drawFrameIt = value.find("drawFrame");
+      drawFrameIt != value.end() && drawFrameIt->is_boolean())
+    out.drawFrame = drawFrameIt->get<bool>();
 
   auto frameIt = value.find("frame");
   if (frameIt != value.end() && frameIt->is_object())

--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -97,6 +97,7 @@ constexpr int kLoadingTimerId = wxID_HIGHEST + 501;
 constexpr int kRenderDelayTimerId = wxID_HIGHEST + 502;
 constexpr int kToggleTextFrameMenuId = wxID_HIGHEST + 503;
 constexpr int kToggleTextTransparentBackgroundMenuId = wxID_HIGHEST + 504;
+constexpr int kToggleViewFrameMenuId = wxID_HIGHEST + 506;
 constexpr int kLoadingOverlayDelayMs = 150;
 
 double GetMaxZoomForFrame(const layouts::Layout2DViewFrame &frame) {
@@ -185,6 +186,7 @@ bool AreEqual(const layouts::Layout2DViewDefinition &lhs,
   return lhs.id == rhs.id && lhs.zIndex == rhs.zIndex &&
          AreEqual(lhs.frame, rhs.frame) && AreEqual(lhs.camera, rhs.camera) &&
          AreEqual(lhs.renderOptions, rhs.renderOptions) &&
+         lhs.drawFrame == rhs.drawFrame &&
          AreEqual(lhs.layers, rhs.layers);
 }
 
@@ -427,6 +429,7 @@ wxBEGIN_EVENT_TABLE(LayoutViewerPanel, wxGLCanvas)
     EVT_SHOW(LayoutViewerPanel::OnShow)
     EVT_MENU(kEditMenuId, LayoutViewerPanel::OnEditView)
     EVT_MENU(kDeleteMenuId, LayoutViewerPanel::OnDeleteView)
+    EVT_MENU(kToggleViewFrameMenuId, LayoutViewerPanel::OnToggleViewFrame)
     EVT_MENU(kEditLegendMenuId, LayoutViewerPanel::OnEditLegend)
     EVT_MENU(kDeleteLegendMenuId, LayoutViewerPanel::OnDeleteLegend)
     EVT_MENU(kEditEventTableMenuId, LayoutViewerPanel::OnEditEventTable)
@@ -1418,7 +1421,10 @@ void LayoutViewerPanel::OnRightUp(wxMouseEvent &event) {
   wxMenu menu;
   if (selectedElementType == SelectedElementType::View2D) {
     menu.Append(kEditMenuId, "2D View Editor");
+    menu.AppendCheckItem(kToggleViewFrameMenuId, "Show Border");
     menu.Append(kDeleteMenuId, "Delete 2D View");
+    if (const auto *view = GetEditableView())
+      menu.Check(kToggleViewFrameMenuId, view->drawFrame);
     menu.AppendSeparator();
     menu.Append(kBringToFrontMenuId, "Bring to Front");
     menu.Append(kSendToBackMenuId, "Send to Back");

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -133,6 +133,7 @@ private:
   void OnShow(wxShowEvent &event);
   void OnEditView(wxCommandEvent &event);
   void OnDeleteView(wxCommandEvent &event);
+  void OnToggleViewFrame(wxCommandEvent &event);
   void OnEditLegend(wxCommandEvent &event);
   void OnDeleteLegend(wxCommandEvent &event);
   void OnEditEventTable(wxCommandEvent &event);

--- a/gui/layoutviewerpanel_view.cpp
+++ b/gui/layoutviewerpanel_view.cpp
@@ -128,6 +128,23 @@ void LayoutViewerPanel::OnDeleteView(wxCommandEvent &) {
   Refresh();
 }
 
+void LayoutViewerPanel::OnToggleViewFrame(wxCommandEvent &) {
+  if (selectedElementType != SelectedElementType::View2D)
+    return;
+  layouts::Layout2DViewDefinition *view = GetEditableView();
+  if (!view)
+    return;
+  view->drawFrame = !view->drawFrame;
+  if (!currentLayout.name.empty()) {
+    auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+    cfg.PushUndoState("toggle layout 2d view border");
+    layouts::LayoutManager::Get().UpdateLayout2DView(currentLayout.name,
+                                                     *view);
+  }
+  RequestRenderRebuild();
+  Refresh();
+}
+
 void LayoutViewerPanel::UpdateFrame(const layouts::Layout2DViewFrame &frame,
                                     bool updatePosition) {
   layouts::Layout2DViewDefinition *view = GetEditableView();
@@ -267,23 +284,25 @@ void LayoutViewerPanel::DrawViewElement(
     glEnd();
   }
 
-  if (view.id == activeViewId) {
-    glColor4ub(60, 160, 240, 255);
-    glLineWidth(2.0f);
-  } else {
-    glColor4ub(160, 160, 160, 255);
-    glLineWidth(1.0f);
+  if (view.drawFrame || view.id == activeViewId) {
+    if (view.id == activeViewId) {
+      glColor4ub(60, 160, 240, 255);
+      glLineWidth(2.0f);
+    } else {
+      glColor4ub(160, 160, 160, 255);
+      glLineWidth(1.0f);
+    }
+    glBegin(GL_LINE_LOOP);
+    glVertex2f(static_cast<float>(frameRect.GetLeft()),
+               static_cast<float>(frameRect.GetTop()));
+    glVertex2f(static_cast<float>(frameRight),
+               static_cast<float>(frameRect.GetTop()));
+    glVertex2f(static_cast<float>(frameRight),
+               static_cast<float>(frameBottom));
+    glVertex2f(static_cast<float>(frameRect.GetLeft()),
+               static_cast<float>(frameRect.GetBottom()));
+    glEnd();
   }
-  glBegin(GL_LINE_LOOP);
-  glVertex2f(static_cast<float>(frameRect.GetLeft()),
-             static_cast<float>(frameRect.GetTop()));
-  glVertex2f(static_cast<float>(frameRight),
-             static_cast<float>(frameRect.GetTop()));
-  glVertex2f(static_cast<float>(frameRight),
-             static_cast<float>(frameBottom));
-  glVertex2f(static_cast<float>(frameRect.GetLeft()),
-             static_cast<float>(frameRect.GetBottom()));
-  glEnd();
 
   if (view.id == activeViewId)
     DrawSelectionHandles(frameRect);

--- a/gui/mainwindow_print.cpp
+++ b/gui/mainwindow_print.cpp
@@ -454,6 +454,7 @@ void MainWindow::OnPrintLayout(wxCommandEvent &WXUNUSED(event)) {
                   static_cast<int>(std::lround(frame.height * scaleY));
               data.frame = frame;
               data.zIndex = view.zIndex;
+              data.drawFrame = view.drawFrame;
               if (capturePanel)
                 data.symbolSnapshot =
                     capturePanel->GetBottomSymbolCacheSnapshot();

--- a/tests/layout_template_serializer_test.cpp
+++ b/tests/layout_template_serializer_test.cpp
@@ -15,6 +15,7 @@ layouts::LayoutDefinition BuildFullLayoutDefinition() {
   view.id = 11;
   view.zIndex = 4;
   view.frame = {10, 20, 300, 200};
+  view.drawFrame = false;
   view.camera.offsetPixelsX = 12.5f;
   view.camera.offsetPixelsY = -2.0f;
   view.camera.zoom = 2.5f;
@@ -102,6 +103,7 @@ void TestFullRoundTrip() {
   assert(layout.imageViews.size() == 1);
 
   assert(layout.view2dViews.front().camera.view == 2);
+  assert(!layout.view2dViews.front().drawFrame);
   assert(layout.legendViews.front().id == 12);
   assert(!layout.legendViews.front().showChannelColumn);
   assert(layout.legendViews.front().itemSettings.size() == 2);

--- a/viewer2d/pdf/layout_pdf_exporter.cpp
+++ b/viewer2d/pdf/layout_pdf_exporter.cpp
@@ -1350,11 +1350,13 @@ Viewer2DExportResult ExportLayoutToPdf(
                                             group.mapping, formatter,
                                             mainOptions);
     contentStream << "Q\n";
-    contentStream << "q\n0 0 0 RG 0.5 w "
-                  << formatter.Format(group.frameX) << ' '
-                  << formatter.Format(group.frameY) << ' '
-                  << formatter.Format(group.frameW) << ' '
-                  << formatter.Format(group.frameH) << " re S\nQ\n";
+    if (views[idx].drawFrame) {
+      contentStream << "q\n0 0 0 RG 0.5 w "
+                    << formatter.Format(group.frameX) << ' '
+                    << formatter.Format(group.frameY) << ' '
+                    << formatter.Format(group.frameW) << ' '
+                    << formatter.Format(group.frameH) << " re S\nQ\n";
+    }
   };
 
   auto renderLegend = [&](size_t idx) {

--- a/viewer2d/viewer2dpdfexporter.h
+++ b/viewer2d/viewer2dpdfexporter.h
@@ -55,6 +55,7 @@ struct LayoutViewExportData {
   Viewer2DViewState viewState;
   layouts::Layout2DViewFrame frame;
   int zIndex = 0;
+  bool drawFrame = true;
   std::shared_ptr<const SymbolDefinitionSnapshot> symbolSnapshot;
 };
 


### PR DESCRIPTION
### Motivation
- Provide the same per-element "Show Border" control for Layout 2D View elements as already available for Text elements, with the border visible by default.
- Make the setting persistent across layout templates and respected by PDF export so printouts match the on-screen configuration.

### Description
- Added a `drawFrame` boolean to `layouts::Layout2DViewDefinition` with default `true` and included it in equality checks; file changed: `core/layouts/LayoutCollection.h` and `gui/layoutviewerpanel.cpp`.
- Wired `drawFrame` into the template serializer by emitting `drawFrame` in `ToJson` and reading it in `ParseLayout2DView`; file changed: `core/layouts/LayoutTemplateSerializer.cpp`.
- Added a context-menu check item `Show Border` for `View2D` elements, a menu id and event binding, and implemented `OnToggleViewFrame` to flip `view->drawFrame`, push an undo state and persist via `LayoutManager`; files changed: `gui/layoutviewerpanel.cpp`, `gui/layoutviewerpanel.h`, and `gui/layoutviewerpanel_view.cpp`.
- Made on-screen rendering respect the `drawFrame` flag while still drawing the selection outline for the active view; file changed: `gui/layoutviewerpanel_view.cpp`.
- Propagated `drawFrame` into print/export by adding `drawFrame` to `LayoutViewExportData` and passing it when capturing layout views, and conditionally drawing frame rectangles in the PDF exporter; files changed: `viewer2d/viewer2dpdfexporter.h`, `gui/mainwindow_print.cpp`, and `viewer2d/pdf/layout_pdf_exporter.cpp`.
- Extended serializer unit test coverage to assert `drawFrame` roundtrip behavior; file changed: `tests/layout_template_serializer_test.cpp`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded (OK). 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfe49e90508324b79e735ef9a513e6)