### PR TITLE
Fix stale 3D scene cache invalidation when loading projects

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -150,6 +150,8 @@ struct Viewer3DController::Impl {
   std::unique_ptr<VisibilitySystem> visibilitySystem;
   std::unique_ptr<SelectionSystem> selectionSystem;
   std::unique_ptr<LabelRenderSystem> labelRenderSystem;
+  size_t logicalSceneSignature = 0;
+  bool hasLogicalSceneSignature = false;
 };
 
 struct LineRenderProfile {
@@ -525,6 +527,37 @@ static size_t HashMatrix(const Matrix &m) {
   return seed;
 }
 
+static size_t BuildLogicalSceneSignature(
+    const std::string &basePath,
+    const std::unordered_map<std::string, Truss> &trusses,
+    const std::unordered_map<std::string, SceneObject> &objects,
+    const std::unordered_map<std::string, Fixture> &fixtures) {
+  size_t signature = HashString(basePath);
+  for (const auto &[uuid, t] : trusses) {
+    signature = HashCombine(signature, HashString(uuid));
+    signature = HashCombine(signature, HashString(t.symbolFile));
+    signature = HashCombine(signature, HashMatrix(t.transform));
+    signature = HashCombine(signature, HashFloat(t.lengthMm));
+    signature = HashCombine(signature, HashFloat(t.widthMm));
+    signature = HashCombine(signature, HashFloat(t.heightMm));
+  }
+  for (const auto &[uuid, o] : objects) {
+    signature = HashCombine(signature, HashString(uuid));
+    signature = HashCombine(signature, HashString(o.modelFile));
+    signature = HashCombine(signature, HashMatrix(o.transform));
+    for (const auto &g : o.geometries) {
+      signature = HashCombine(signature, HashString(g.modelFile));
+      signature = HashCombine(signature, HashMatrix(g.localTransform));
+    }
+  }
+  for (const auto &[uuid, f] : fixtures) {
+    signature = HashCombine(signature, HashString(uuid));
+    signature = HashCombine(signature, HashString(f.gdtfSpec));
+    signature = HashCombine(signature, HashMatrix(f.transform));
+  }
+  return signature;
+}
+
 
 static Transform2D BuildInstanceTransform2D(const Matrix &m, Viewer2DView view) {
   Transform2D t{};
@@ -822,6 +855,13 @@ void Viewer3DController::UpdateResourcesIfDirty() {
   const auto &trusses = SceneDataManager::Instance().GetTrusses();
   const auto &objects = SceneDataManager::Instance().GetSceneObjects();
   const auto &fixtures = SceneDataManager::Instance().GetFixtures();
+  const size_t logicalSceneSignature =
+      BuildLogicalSceneSignature(base, trusses, objects, fixtures);
+  const bool logicalSceneChanged =
+      !m_impl->hasLogicalSceneSignature ||
+      logicalSceneSignature != m_impl->logicalSceneSignature;
+  m_impl->logicalSceneSignature = logicalSceneSignature;
+  m_impl->hasLogicalSceneSignature = true;
 
   std::vector<const std::pair<const std::string, Truss> *> visibleTrusses;
   std::vector<const std::pair<const std::string, SceneObject> *> visibleObjects;
@@ -855,7 +895,7 @@ void Viewer3DController::UpdateResourcesIfDirty() {
       base, visibleTrusses, visibleObjects, visibleFixtures,
       m_impl->resourceSyncState, callbacks);
 
-  if (syncResult.sceneChanged) {
+  if (syncResult.sceneChanged || logicalSceneChanged) {
     ++m_impl->sceneVersion;
     m_impl->sceneChangedDirty = true;
     std::lock_guard<std::mutex> lock(m_impl->sortedListsMutex);


### PR DESCRIPTION
### Motivation
- Loading a new project could leave 3D renderer caches and pointer-based sorted lists valid if the newly loaded scene shares the same "visible" signature, causing stale geometry from the previous show to remain visible after load or when switching 3D visualization modes.

### Description
- Add `logicalSceneSignature` and `hasLogicalSceneSignature` to `Viewer3DController::Impl` to track a hash of the entire scene (basePath, trusses, scene objects, fixtures).
- Implement `BuildLogicalSceneSignature(...)` to compute a deterministic signature that includes UUIDs, model/gdtf paths, transforms and relevant numeric properties.
- Compute the logical signature inside `Viewer3DController::UpdateResourcesIfDirty()` and treat a change as an additional invalidation trigger so that `sceneVersion` increments and sorted pointer caches (`sortedObjects`, `sortedTrusses`, `sortedFixtures`) are cleared when either resource-sync reports a scene change or the logical signature changed.
- Keep the change localized to `viewer3d/viewer3dcontroller.cpp` and preserve existing resource sync and bounds rebuild flow.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (OK). 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfe7bfddfc8324899f1c0cabc844c3)