### PR TITLE
Show active table name in Summary panel title

### DIFF
--- a/gui/summarypanel.cpp
+++ b/gui/summarypanel.cpp
@@ -151,13 +151,16 @@ void SummaryPanel::UpdatePaneCaption(const wxString& suffix) {
     if (!pane.IsOk())
         return;
 
-    const wxString caption = suffix.empty() ? "Summary" : ("Summary - " + suffix);
+    const wxString caption = suffix.empty()
+                                 ? wxString("Summary")
+                                 : wxString::Format("Summary - %s", suffix);
     if (pane.caption == caption)
         return;
 
     pane.Caption(caption);
     manager->Update();
 }
+
 void SummaryPanel::ShowSummary(const std::vector<std::pair<std::string,int>>& items)
 {
     if (!table || !store) return;

--- a/gui/summarypanel.cpp
+++ b/gui/summarypanel.cpp
@@ -23,6 +23,7 @@
 #include "viewer3dpanel.h"
 #include <wx/colordlg.h>
 #include <wx/dcmemory.h>
+#include <wx/aui/framemanager.h>
 #include <algorithm>
 #include <map>
 #include <unordered_set>
@@ -140,6 +141,23 @@ void SummaryPanel::SetInstance(SummaryPanel* panel)
     s_instance = panel;
 }
 
+
+void SummaryPanel::UpdatePaneCaption(const wxString& suffix) {
+    wxAuiManager* manager = wxAuiManager::GetManager(this);
+    if (!manager)
+        return;
+
+    wxAuiPaneInfo& pane = manager->GetPane(this);
+    if (!pane.IsOk())
+        return;
+
+    const wxString caption = suffix.empty() ? "Summary" : ("Summary - " + suffix);
+    if (pane.caption == caption)
+        return;
+
+    pane.Caption(caption);
+    manager->Update();
+}
 void SummaryPanel::ShowSummary(const std::vector<std::pair<std::string,int>>& items)
 {
     if (!table || !store) return;
@@ -155,6 +173,7 @@ void SummaryPanel::ShowSummary(const std::vector<std::pair<std::string,int>>& it
 
 void SummaryPanel::ShowFixtureSummary()
 {
+    UpdatePaneCaption("Fixtures");
     if (!table || !store) return;
     std::map<std::string, FixtureSummaryRow> grouped;
     const auto& fixtures = (*visibilityConfigManager).GetScene().fixtures;
@@ -183,6 +202,7 @@ void SummaryPanel::ShowFixtureSummary()
 
 void SummaryPanel::ShowTrussSummary()
 {
+    UpdatePaneCaption("Trusses");
     std::map<std::string,int> counts;
     const auto& trusses = (*visibilityConfigManager).GetScene().trusses;
     for (const auto& [uuid, truss] : trusses)
@@ -193,6 +213,7 @@ void SummaryPanel::ShowTrussSummary()
 
 void SummaryPanel::ShowHoistSummary()
 {
+    UpdatePaneCaption("Hoists");
     if (!table) return;
 
     std::map<std::string, int> hoistCounts;
@@ -208,6 +229,7 @@ void SummaryPanel::ShowHoistSummary()
 
 void SummaryPanel::ShowSceneObjectSummary()
 {
+    UpdatePaneCaption("Objects");
     std::map<std::string,int> counts;
     const auto& objs = (*visibilityConfigManager).GetScene().sceneObjects;
     for (const auto& [uuid, obj] : objs)

--- a/gui/summarypanel.h
+++ b/gui/summarypanel.h
@@ -58,6 +58,7 @@ private:
     wxString activeHoverTooltip;
 
     void ShowSummary(const std::vector<std::pair<std::string,int>>& items);
+    void UpdatePaneCaption(const wxString& suffix);
     void ShowFixtureSummaryRows(const std::vector<FixtureSummaryRow>& rows);
     void EnsureColumnsForMode(SummaryMode requestedMode);
     void RefreshFixtureVisibilityStyles();


### PR DESCRIPTION
### Motivation
- Improve UX by showing which data set the Summary panel is displaying (e.g. "Summary - Fixtures") so the pane caption provides immediate context when docked.

### Description
- Added `SummaryPanel::UpdatePaneCaption(const wxString&)` and wired it to the summary entry points so `ShowFixtureSummary`, `ShowTrussSummary`, `ShowHoistSummary` and `ShowSceneObjectSummary` update the AUI pane caption to `Summary - <section>`; the update is a no-op when no `wxAuiManager`/pane is available, and the change includes the necessary header and a declaration in `summarypanel.h`.

### Testing
- Ran required architectural checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both succeeded (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfeb71071c83249bffb502695decc6)