### PR TITLE
Prompt hoist load recalculation when weights change in tables

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -26,6 +26,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/fixturetable/fixture_table_parser.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fixturetablepanel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtfsearchdialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/hoist_load_limit_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/hoist_load_recalculation_prompt.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/hoisttablepanel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layerpanel.cpp

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -26,6 +26,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/fixturetable/fixture_table_parser.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fixturetablepanel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtfsearchdialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/hoist_load_recalculation_prompt.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/hoisttablepanel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layerpanel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layout2dviewdialog.cpp

--- a/gui/fixturetable/fixture_table_edit_service.cpp
+++ b/gui/fixturetable/fixture_table_edit_service.cpp
@@ -17,6 +17,12 @@ const wxString &DegreeSymbol() {
   static const wxString kDegreeSymbol = wxString::FromUTF8("\xC2\xB0");
   return kDegreeSymbol;
 }
+
+constexpr const char *kUnassignedPosition = "Unassigned";
+
+std::string NormalizePositionName(const std::string &positionName) {
+  return positionName.empty() ? kUnassignedPosition : positionName;
+}
 }
 
 std::vector<int> BuildOrderedRows(const std::vector<int> &selectedRows,
@@ -66,6 +72,7 @@ void UpdateSceneData(ISceneAdapter &adapter, wxDataViewListCtrl *table,
                      const std::vector<std::string> &rowUuids,
                      const std::vector<wxString> &gdtfPaths,
                      const std::unordered_set<std::string> *manualCategoryUuids,
+                     std::unordered_set<std::string> *changedWeightPositions,
                      bool logChanges) {
   // Ensure in-place cell editors commit pending values before reading table rows.
   if (table)
@@ -201,11 +208,14 @@ void UpdateSceneData(ISceneAdapter &adapter, wxDataViewListCtrl *table,
     next.powerConsumptionW = static_cast<float>(pw);
 
     table->GetValue(v, i, 17);
+    const float previousWeightKg = next.weightKg;
     if (const auto parsedWeightKg = Units::ParseWeightToKilograms(
             std::string(v.GetString().ToUTF8()), weightUnitSystem);
         parsedWeightKg.has_value()) {
       next.weightKg = static_cast<float>(*parsedWeightKg);
     }
+    const bool weightChanged = !Units::NearlyEqualWeightKilograms(
+        previousWeightKg, next.weightKg, 0.001);
 
     table->GetValue(v, i, 18);
     next.category = GdtfFixtureCategory::NormalizeCategory(std::string(v.GetString().ToUTF8()));
@@ -249,6 +259,10 @@ void UpdateSceneData(ISceneAdapter &adapter, wxDataViewListCtrl *table,
 
     pushUndoIfNeeded();
     anyChanged = true;
+    if (weightChanged && changedWeightPositions) {
+      changedWeightPositions->insert(NormalizePositionName(old.positionName));
+      changedWeightPositions->insert(NormalizePositionName(next.positionName));
+    }
     it->second = next;
     if (!next.typeName.empty() && !next.category.empty() &&
         next.categorySource == GdtfFixtureCategory::kManualSource) {

--- a/gui/fixturetable/fixture_table_edit_service.h
+++ b/gui/fixturetable/fixture_table_edit_service.h
@@ -30,6 +30,7 @@ void UpdateSceneData(ISceneAdapter &adapter, wxDataViewListCtrl *table,
                      const std::vector<std::string> &rowUuids,
                      const std::vector<wxString> &gdtfPaths,
                      const std::unordered_set<std::string> *manualCategoryUuids = nullptr,
+                     std::unordered_set<std::string> *changedWeightPositions = nullptr,
                      bool logChanges = true);
 
 } // namespace FixtureTableEditService

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -27,6 +27,7 @@
 #include "gdtf_fixture_category.h"
 #include "gdtfdictionary.h"
 #include "gdtfloader.h"
+#include "hoist_load_recalculation_prompt.h"
 #include "layerpanel.h"
 #include "matrixutils.h"
 #include "patchmanager.h"
@@ -1369,10 +1370,15 @@ void FixtureTablePanel::PropagateTypeValues(
 
 void FixtureTablePanel::UpdateSceneData(bool logChanges) {
   ConfigManagerSceneAdapter adapter;
+  std::unordered_set<std::string> changedWeightPositions;
   FixtureTableEditService::UpdateSceneData(adapter, table, rowUuids, gdtfPaths,
                                            &manualCategoryUuidsPending,
+                                           &changedWeightPositions,
                                            logChanges);
   manualCategoryUuidsPending.clear();
+
+  HoistLoadRecalculationPrompt::PromptAndApply(
+      guiConfigServices->LegacyConfigManager(), this, changedWeightPositions);
 
   HighlightDuplicateFixtureIds();
 

--- a/gui/hoist_load_limit_utils.cpp
+++ b/gui/hoist_load_limit_utils.cpp
@@ -1,0 +1,34 @@
+#include "hoist_load_limit_utils.h"
+
+namespace HoistLoadLimitUtils {
+
+namespace {
+constexpr float kNearCapacityMarginKg = 75.0f;
+constexpr float kToleranceKg = 0.001f;
+}
+
+LoadLimitState Evaluate(const float loadKg, const float capacityKg) {
+  if (capacityKg <= 0.0f)
+    return LoadLimitState::Normal;
+
+  if (loadKg + kToleranceKg >= capacityKg)
+    return LoadLimitState::AtOrAboveCapacity;
+
+  if (loadKg >= capacityKg - kNearCapacityMarginKg)
+    return LoadLimitState::NearCapacity;
+
+  return LoadLimitState::Normal;
+}
+
+std::string TooltipForState(const LoadLimitState state) {
+  switch (state) {
+  case LoadLimitState::NearCapacity:
+    return "Load is within 75 kg of hoist capacity.";
+  case LoadLimitState::AtOrAboveCapacity:
+    return "Load meets or exceeds hoist capacity.";
+  default:
+    return std::string();
+  }
+}
+
+} // namespace HoistLoadLimitUtils

--- a/gui/hoist_load_limit_utils.h
+++ b/gui/hoist_load_limit_utils.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <string>
+
+namespace HoistLoadLimitUtils {
+
+enum class LoadLimitState {
+  Normal,
+  NearCapacity,
+  AtOrAboveCapacity,
+};
+
+LoadLimitState Evaluate(float loadKg, float capacityKg);
+
+inline bool IsCritical(LoadLimitState state) {
+  return state != LoadLimitState::Normal;
+}
+
+std::string TooltipForState(LoadLimitState state);
+
+} // namespace HoistLoadLimitUtils

--- a/gui/hoist_load_recalculation_prompt.cpp
+++ b/gui/hoist_load_recalculation_prompt.cpp
@@ -1,9 +1,11 @@
 #include "hoist_load_recalculation_prompt.h"
 
 #include "configmanager.h"
+#include "hoist_load_limit_utils.h"
 #include "hoist_weight_distribution.h"
 #include "hoisttablepanel.h"
 #include "rigging_extra_weight_settings.h"
+#include "support.h"
 
 #include <algorithm>
 #include <vector>
@@ -69,6 +71,41 @@ bool PromptAndApply(ConfigManager &cfg, wxWindow *parent,
   std::sort(supportUuids.begin(), supportUuids.end());
   HoistWeightDistribution::ApplyForImportedSupports(scene, supportUuids,
                                                      roundedTotalsByPosition);
+
+  size_t nearCapacityCount = 0;
+  size_t overloadedCount = 0;
+  for (const auto &supportUuid : supportUuids) {
+    auto supportIt = scene.supports.find(supportUuid);
+    if (supportIt == scene.supports.end())
+      continue;
+    const auto effective = ResolveEffectiveSupportData(supportIt->second);
+    const auto state =
+        HoistLoadLimitUtils::Evaluate(supportIt->second.loadKg, effective.capacityKg);
+    if (state == HoistLoadLimitUtils::LoadLimitState::NearCapacity)
+      ++nearCapacityCount;
+    else if (state == HoistLoadLimitUtils::LoadLimitState::AtOrAboveCapacity)
+      ++overloadedCount;
+  }
+
+  if (nearCapacityCount > 0 || overloadedCount > 0) {
+    wxString warningMessage;
+    if (overloadedCount > 0 && nearCapacityCount > 0) {
+      warningMessage = wxString::Format(
+          "%zu hoist(s) reached or exceeded capacity and %zu hoist(s) are within "
+          "75 kg of capacity after recalculation.",
+          overloadedCount, nearCapacityCount);
+    } else if (overloadedCount > 0) {
+      warningMessage = wxString::Format(
+          "%zu hoist(s) reached or exceeded capacity after recalculation.",
+          overloadedCount);
+    } else {
+      warningMessage = wxString::Format(
+          "%zu hoist(s) are within 75 kg of capacity after recalculation.",
+          nearCapacityCount);
+    }
+    wxMessageBox(warningMessage, "Hoist load warning", wxOK | wxICON_WARNING,
+                 parent);
+  }
 
   if (reloadHoistTable && HoistTablePanel::Instance())
     HoistTablePanel::Instance()->ReloadData();

--- a/gui/hoist_load_recalculation_prompt.cpp
+++ b/gui/hoist_load_recalculation_prompt.cpp
@@ -1,0 +1,79 @@
+#include "hoist_load_recalculation_prompt.h"
+
+#include "configmanager.h"
+#include "hoist_weight_distribution.h"
+#include "hoisttablepanel.h"
+#include "rigging_extra_weight_settings.h"
+
+#include <algorithm>
+#include <vector>
+#include <wx/msgdlg.h>
+
+namespace {
+
+constexpr const char *kUnassignedPosition = "Unassigned";
+
+std::string NormalizePositionName(const std::string &positionName) {
+  return positionName.empty() ? kUnassignedPosition : positionName;
+}
+
+} // namespace
+
+namespace HoistLoadRecalculationPrompt {
+
+bool PromptAndApply(ConfigManager &cfg, wxWindow *parent,
+                    const std::unordered_set<std::string> &positionNames,
+                    const bool reloadHoistTable) {
+  if (positionNames.empty())
+    return false;
+
+  auto &scene = cfg.GetScene();
+  std::unordered_set<std::string> supportsInPositions;
+  supportsInPositions.reserve(scene.supports.size());
+  for (const auto &[supportUuid, support] : scene.supports) {
+    const std::string supportPosition = NormalizePositionName(support.positionName);
+    if (positionNames.find(supportPosition) != positionNames.end())
+      supportsInPositions.insert(supportUuid);
+  }
+
+  if (supportsInPositions.empty())
+    return false;
+
+  wxString message;
+  if (positionNames.size() == 1) {
+    message = wxString::Format(
+        "Position \"%s\" has hoists.\n\nDo you want to recalculate hoist loads "
+        "using the updated rounded rigging total?",
+        wxString::FromUTF8(positionNames.begin()->c_str()));
+  } else {
+    message = wxString::Format(
+        "%zu positions with hoists were updated.\n\nDo you want to recalculate "
+        "hoist loads using the updated rounded rigging totals?",
+        positionNames.size());
+  }
+
+  const int answer = wxMessageBox(message, "Recalculate hoist loads",
+                                  wxYES_NO | wxICON_QUESTION, parent);
+  if (answer != wxYES)
+    return false;
+
+  const auto extraWeights = RiggingExtraWeightSettings::ParseEntries(
+      cfg.GetValue(RiggingExtraWeightSettings::ConfigKey()));
+  const auto roundedTotalsByPosition =
+      HoistWeightDistribution::BuildRoundedRiggingTotalByHangPosition(
+          scene,
+          RiggingExtraWeightSettings::BuildKilogramsByPosition(extraWeights));
+
+  std::vector<std::string> supportUuids(supportsInPositions.begin(),
+                                        supportsInPositions.end());
+  std::sort(supportUuids.begin(), supportUuids.end());
+  HoistWeightDistribution::ApplyForImportedSupports(scene, supportUuids,
+                                                     roundedTotalsByPosition);
+
+  if (reloadHoistTable && HoistTablePanel::Instance())
+    HoistTablePanel::Instance()->ReloadData();
+
+  return true;
+}
+
+} // namespace HoistLoadRecalculationPrompt

--- a/gui/hoist_load_recalculation_prompt.h
+++ b/gui/hoist_load_recalculation_prompt.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+#include <unordered_set>
+
+class ConfigManager;
+class wxWindow;
+
+namespace HoistLoadRecalculationPrompt {
+
+bool PromptAndApply(ConfigManager &cfg, wxWindow *parent,
+                    const std::unordered_set<std::string> &positionNames,
+                    bool reloadHoistTable = true);
+
+} // namespace HoistLoadRecalculationPrompt

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -21,6 +21,7 @@
 #include "colorfulrenderers.h"
 #include "configmanager.h"
 #include "guiconfigservices.h"
+#include "hoist_load_recalculation_prompt.h"
 #include "layerpanel.h"
 #include "dummyprofilelibrary.h"
 #include "matrixutils.h"
@@ -49,6 +50,12 @@ namespace {
 const wxString &DegreeSymbol() {
   static const wxString kDegreeSymbol = wxString::FromUTF8("\xC2\xB0");
   return kDegreeSymbol;
+}
+
+constexpr const char *kUnassignedPosition = "Unassigned";
+
+std::string NormalizePositionName(const std::string &positionName) {
+  return positionName.empty() ? kUnassignedPosition : positionName;
 }
 
 Units::DistanceUnitSystem ResolveDistanceUnitSystem() {
@@ -776,6 +783,7 @@ void HoistTablePanel::UpdateSceneData(bool logChanges) {
   auto &scene = cfg.GetScene();
   size_t count = std::min((size_t)table->GetItemCount(), rowUuids.size());
   bool anyChanged = false;
+  std::unordered_set<std::string> changedWeightPositions;
   bool undoPushed = false;
   auto pushUndoIfNeeded = [&]() {
     if (!undoPushed) {
@@ -967,11 +975,17 @@ void HoistTablePanel::UpdateSceneData(bool logChanges) {
                                     NormalizeHoistDataSource(next.weightSource) ||
                                 NormalizeHoistDataSource(old.hoistFunctionSource) !=
                                     NormalizeHoistDataSource(next.hoistFunctionSource);
+    const bool weightChanged =
+        !Units::NearlyEqualWeightKilograms(old.weightKg, next.weightKg, 0.001);
     if (!supportChanged)
       continue;
 
     pushUndoIfNeeded();
     anyChanged = true;
+    if (weightChanged) {
+      changedWeightPositions.insert(NormalizePositionName(old.positionName));
+      changedWeightPositions.insert(NormalizePositionName(next.positionName));
+    }
     it->second = next;
     if (!it->second.position.empty())
       scene.positions[it->second.position] = it->second.positionName;
@@ -979,6 +993,11 @@ void HoistTablePanel::UpdateSceneData(bool logChanges) {
 
   if (!anyChanged)
     return;
+
+  const bool loadsRecalculated = HoistLoadRecalculationPrompt::PromptAndApply(
+      cfg, this, changedWeightPositions, false);
+  if (loadsRecalculated)
+    ReloadData();
 
   if (SummaryPanel::Instance())
     SummaryPanel::Instance()->ShowHoistSummary();

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -809,7 +809,7 @@ void HoistTablePanel::OnMouseLeave(wxMouseEvent &evt) {
 }
 
 void HoistTablePanel::UpdateHoverTooltip(const wxPoint &position) {
-  if (EditableFocusUtils::IsAnyEditableTextControlFocused(table))
+  if (gui::IsEditableWidgetFocused(wxWindow::FindFocus()))
     return;
 
   wxDataViewItem item;

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -20,6 +20,7 @@
 #include "columnutils.h"
 #include "colorfulrenderers.h"
 #include "configmanager.h"
+#include "editable_focus_utils.h"
 #include "guiconfigservices.h"
 #include "hoist_load_recalculation_prompt.h"
 #include "layerpanel.h"
@@ -56,6 +57,69 @@ constexpr const char *kUnassignedPosition = "Unassigned";
 
 std::string NormalizePositionName(const std::string &positionName) {
   return positionName.empty() ? kUnassignedPosition : positionName;
+}
+
+bool IsRedCell(const ColorfulDataViewListStore *store, int row, int col) {
+  if (!store || row < 0 || col < 0)
+    return false;
+
+  const size_t rowIndex = static_cast<size_t>(row);
+  const size_t colIndex = static_cast<size_t>(col);
+  if (rowIndex >= store->cellAttrs.size())
+    return false;
+  if (colIndex >= store->cellAttrs[rowIndex].size())
+    return false;
+
+  const wxDataViewItemAttr &attr = store->cellAttrs[rowIndex][colIndex];
+  return attr.HasColour() && attr.GetColour() == *wxRED;
+}
+
+void SetTableAndChildTooltips(wxDataViewListCtrl *table,
+                              const wxString &tooltip) {
+  if (!table)
+    return;
+
+  table->SetToolTip(tooltip);
+  wxWindowList &children = table->GetChildren();
+  for (wxWindowList::compatibility_iterator it = children.GetFirst(); it;
+       it = it->GetNext()) {
+    if (wxWindow *child = it->GetData())
+      child->SetToolTip(tooltip);
+  }
+}
+
+wxPoint NormalizeMousePositionForTable(wxDataViewListCtrl *table,
+                                       const wxMouseEvent &event) {
+  wxPoint position = event.GetPosition();
+  wxWindow *sourceWindow = dynamic_cast<wxWindow *>(event.GetEventObject());
+  if (!table || !sourceWindow || sourceWindow == table)
+    return position;
+
+  return table->ScreenToClient(sourceWindow->ClientToScreen(position));
+}
+
+template <typename Owner>
+void BindTableHoverEvents(wxDataViewListCtrl *table, Owner *owner,
+                          void (Owner::*onMouseMove)(wxMouseEvent &),
+                          void (Owner::*onMouseLeave)(wxMouseEvent &)) {
+  if (!table || !owner)
+    return;
+
+  auto bindEvents = [&](wxWindow *window) {
+    if (!window)
+      return;
+    window->Unbind(wxEVT_MOTION, onMouseMove, owner);
+    window->Unbind(wxEVT_LEAVE_WINDOW, onMouseLeave, owner);
+    window->Bind(wxEVT_MOTION, onMouseMove, owner);
+    window->Bind(wxEVT_LEAVE_WINDOW, onMouseLeave, owner);
+  };
+
+  bindEvents(table);
+  wxWindowList &children = table->GetChildren();
+  for (wxWindowList::compatibility_iterator it = children.GetFirst(); it;
+       it = it->GetNext()) {
+    bindEvents(it->GetData());
+  }
 }
 
 Units::DistanceUnitSystem ResolveDistanceUnitSystem() {
@@ -227,7 +291,12 @@ HoistTablePanel::HoistTablePanel(wxWindow *parent, IGuiConfigServices *services)
   store->SetSelectionColours(selectionBackground, selectionForeground);
   table->Bind(wxEVT_LEFT_DOWN, &HoistTablePanel::OnLeftDown, this);
   table->Bind(wxEVT_LEFT_UP, &HoistTablePanel::OnLeftUp, this);
-  table->Bind(wxEVT_MOTION, &HoistTablePanel::OnMouseMove, this);
+  BindTableHoverEvents(table, this, &HoistTablePanel::OnMouseMove,
+                       &HoistTablePanel::OnMouseLeave);
+  table->CallAfter([this]() {
+    BindTableHoverEvents(table, this, &HoistTablePanel::OnMouseMove,
+                         &HoistTablePanel::OnMouseLeave);
+  });
   table->Bind(wxEVT_DATAVIEW_SELECTION_CHANGED,
               &HoistTablePanel::OnSelectionChanged, this);
 
@@ -289,6 +358,7 @@ void HoistTablePanel::ReloadData() {
 
   table->DeleteAllItems();
   rowUuids.clear();
+  rowLoadStates.clear();
   const MvrScene &scene = guiConfigServices->LegacyConfigManager().GetScene();
   auto &supports = guiConfigServices->LegacyConfigManager().GetScene().supports;
 
@@ -362,6 +432,8 @@ void HoistTablePanel::ReloadData() {
         effective.weightKg, weightUnit, Units::ValueFormatContext::Table));
     wxString load = wxString::FromUTF8(Units::FormatWeightFromKilograms(
         support.loadKg, weightUnit, Units::ValueFormatContext::Table));
+    const auto loadState =
+        HoistLoadLimitUtils::Evaluate(support.loadKg, effective.capacityKg);
 
     row.push_back(name);
     row.push_back(type);
@@ -383,7 +455,13 @@ void HoistTablePanel::ReloadData() {
     row.push_back(load);
 
     store->AppendItem(row, rowUuids.size());
+    const unsigned int rowIndex = static_cast<unsigned int>(rowUuids.size());
+    if (HoistLoadLimitUtils::IsCritical(loadState))
+      store->SetCellTextColour(rowIndex, 18, *wxRED);
+    else
+      store->ClearCellTextColour(rowIndex, 18);
     rowUuids.push_back(uuid);
+    rowLoadStates.push_back(loadState);
     ++hoistId;
   }
 
@@ -702,13 +780,15 @@ void HoistTablePanel::OnCaptureLost(wxMouseCaptureLostEvent &WXUNUSED(evt)) {
 }
 
 void HoistTablePanel::OnMouseMove(wxMouseEvent &evt) {
+  UpdateHoverTooltip(NormalizeMousePositionForTable(table, evt));
+
   if (!dragSelecting || !evt.Dragging()) {
     evt.Skip();
     return;
   }
   wxDataViewItem item;
   wxDataViewColumn *col;
-  table->HitTest(evt.GetPosition(), item, col);
+  table->HitTest(NormalizeMousePositionForTable(table, evt), item, col);
   int row = table->ItemToRow(item);
   if (row != wxNOT_FOUND) {
     int minRow = std::min(startRow, row);
@@ -718,6 +798,40 @@ void HoistTablePanel::OnMouseMove(wxMouseEvent &evt) {
       table->SelectRow(r);
   }
   evt.Skip();
+}
+
+void HoistTablePanel::OnMouseLeave(wxMouseEvent &evt) {
+  if (!activeHoverTooltip.IsEmpty()) {
+    SetTableAndChildTooltips(table, wxString());
+    activeHoverTooltip.clear();
+  }
+  evt.Skip();
+}
+
+void HoistTablePanel::UpdateHoverTooltip(const wxPoint &position) {
+  if (EditableFocusUtils::IsAnyEditableTextControlFocused(table))
+    return;
+
+  wxDataViewItem item;
+  wxDataViewColumn *column = nullptr;
+  table->HitTest(position, item, column);
+
+  wxString tooltip;
+  if (item.IsOk() && column) {
+    const int row = table->ItemToRow(item);
+    const int modelColumn = column->GetModelColumn();
+    if (modelColumn == 18 && IsRedCell(store, row, modelColumn) && row >= 0 &&
+        static_cast<size_t>(row) < rowLoadStates.size()) {
+      tooltip = wxString::FromUTF8(HoistLoadLimitUtils::TooltipForState(
+          rowLoadStates[static_cast<size_t>(row)]));
+    }
+  }
+
+  if (tooltip == activeHoverTooltip)
+    return;
+
+  SetTableAndChildTooltips(table, tooltip);
+  activeHoverTooltip = tooltip;
 }
 
 void HoistTablePanel::OnSelectionChanged(wxDataViewEvent &evt) {

--- a/gui/hoisttablepanel.h
+++ b/gui/hoisttablepanel.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <vector>
 #include "colorstore.h"
+#include "hoist_load_limit_utils.h"
 #include "positionvalueupdate.h"
 
 class IGuiConfigServices;
@@ -51,6 +52,8 @@ private:
   wxDataViewListCtrl *table;
   std::vector<wxString> columnLabels;
   std::vector<std::string> rowUuids;
+  std::vector<HoistLoadLimitUtils::LoadLimitState> rowLoadStates;
+  wxString activeHoverTooltip;
   bool dragSelecting = false;
   int startRow = -1;
   IGuiConfigServices *guiConfigServices = nullptr;
@@ -64,6 +67,8 @@ private:
   void OnLeftDown(wxMouseEvent &evt);
   void OnLeftUp(wxMouseEvent &evt);
   void OnMouseMove(wxMouseEvent &evt);
+  void OnMouseLeave(wxMouseEvent &evt);
   void OnCaptureLost(wxMouseCaptureLostEvent &evt);
+  void UpdateHoverTooltip(const wxPoint &position);
   void UpdateSelectionHighlight();
 };

--- a/gui/riggingpanel.cpp
+++ b/gui/riggingpanel.cpp
@@ -27,8 +27,7 @@
 #include "columnutils.h"
 #include "configmanager.h"
 #include "guiconfigservices.h"
-#include "hoist_weight_distribution.h"
-#include "hoisttablepanel.h"
+#include "hoist_load_recalculation_prompt.h"
 #include "mainwindow.h"
 #include "rigging_extra_weight_settings.h"
 #include "units/unit_label_utils.h"
@@ -442,35 +441,7 @@ void RiggingPanel::OnItemValueChanged(wxDataViewEvent &event) {
   cfg.SetValue(RiggingExtraWeightSettings::ConfigKey(),
                RiggingExtraWeightSettings::SerializeEntries(extraWeights));
 
-  auto &scene = cfg.GetScene();
-  std::vector<std::string> supportsInPosition;
-  supportsInPosition.reserve(scene.supports.size());
-  for (const auto &[supportUuid, support] : scene.supports) {
-    const std::string supportPosition = support.positionName.empty()
-                                            ? UNASSIGNED_POSITION
-                                            : support.positionName;
-    if (supportPosition == positionName)
-      supportsInPosition.push_back(supportUuid);
-  }
-
-  if (!supportsInPosition.empty()) {
-    const wxString message = wxString::Format(
-        "Position \"%s\" has hoists.\n\nDo you want to recalculate hoist loads "
-        "using the updated rounded rigging total?",
-        wxString::FromUTF8(positionName));
-    const int answer = wxMessageBox(message, "Recalculate hoist loads",
-                                    wxYES_NO | wxICON_QUESTION, this);
-    if (answer == wxYES) {
-      const auto roundedTotalsByPosition =
-          HoistWeightDistribution::BuildRoundedRiggingTotalByHangPosition(
-              scene, RiggingExtraWeightSettings::BuildKilogramsByPosition(
-                         extraWeights));
-      HoistWeightDistribution::ApplyForImportedSupports(
-          scene, supportsInPosition, roundedTotalsByPosition);
-      if (HoistTablePanel::Instance())
-        HoistTablePanel::Instance()->ReloadData();
-    }
-  }
+  HoistLoadRecalculationPrompt::PromptAndApply(cfg, this, {positionName});
 
   RefreshData();
 }

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -21,6 +21,7 @@
 #include "configmanager.h"
 #include "guiconfigservices.h"
 #include "consolepanel.h"
+#include "hoist_load_recalculation_prompt.h"
 #include "layerpanel.h"
 #include "matrixutils.h"
 #include "projectutils.h"
@@ -55,6 +56,12 @@ namespace {
 const wxString &DegreeSymbol() {
   static const wxString kDegreeSymbol = wxString::FromUTF8("\xC2\xB0");
   return kDegreeSymbol;
+}
+
+constexpr const char *kUnassignedPosition = "Unassigned";
+
+std::string NormalizePositionName(const std::string &positionName) {
+    return positionName.empty() ? kUnassignedPosition : positionName;
 }
 
 
@@ -807,6 +814,7 @@ void TrussTablePanel::UpdateSceneData(bool logChanges)
     };
     std::unordered_map<std::string, Dim> dims;
     std::unordered_set<std::string> changedTrussIds;
+    std::unordered_set<std::string> changedWeightPositions;
     std::vector<std::pair<std::string, std::string>> updatedTrusses;
 
     auto makeKey = [](const std::string& n,
@@ -961,11 +969,17 @@ void TrussTablePanel::UpdateSceneData(bool logChanges)
             !Units::NearlyEqualDistanceMillimeters(old.widthMm, next.widthMm, 0.5) ||
             !Units::NearlyEqualDistanceMillimeters(old.heightMm, next.heightMm, 0.5) ||
             !Units::NearlyEqualWeightKilograms(old.weightKg, next.weightKg, 0.001);
+        const bool weightChanged =
+            !Units::NearlyEqualWeightKilograms(old.weightKg, next.weightKg, 0.001);
 
         if (trussChanged)
         {
             pushUndoIfNeeded();
             anyChanged = true;
+            if (weightChanged) {
+                changedWeightPositions.insert(NormalizePositionName(old.positionName));
+                changedWeightPositions.insert(NormalizePositionName(next.positionName));
+            }
             it->second = next;
             if (!it->second.position.empty())
                 scene.positions[it->second.position] = it->second.positionName;
@@ -1013,6 +1027,7 @@ void TrussTablePanel::UpdateSceneData(bool logChanges)
             it->second.widthMm = widMm;
             it->second.heightMm = heiMm;
             it->second.weightKg = weightKg;
+            changedWeightPositions.insert(NormalizePositionName(it->second.positionName));
 
             wxString lenStr = wxString::Format("%.2f", lenMm / 1000.0f);
             wxString widStr =
@@ -1034,6 +1049,8 @@ void TrussTablePanel::UpdateSceneData(bool logChanges)
 
     if (!anyChanged)
         return;
+
+    HoistLoadRecalculationPrompt::PromptAndApply(cfg, this, changedWeightPositions);
 
     if (SummaryPanel::Instance() && IsActivePage())
         SummaryPanel::Instance()->ShowTrussSummary();


### PR DESCRIPTION
### Motivation
- Keep hoist-load recalculation UX consistent across places where total rigging weight can change (fixtures, trusses, hoists and the rigging extra-weight table) by centralizing the confirmation and apply logic.
- Avoid duplicated prompt/apply code in multiple panels and make it easy to trigger recalculation only for positions actually affected by weight edits.

### Description
- Added a shared helper `HoistLoadRecalculationPrompt::PromptAndApply` (`gui/hoist_load_recalculation_prompt.{h,cpp}`) that shows the existing recalculation confirmation dialog and applies `HoistWeightDistribution` using `RiggingExtraWeightSettings` for the selected positions.
- Extended `FixtureTableEditService::UpdateSceneData` to accept an optional `changedWeightPositions` output set and record positions where fixture `weightKg` changed (`gui/fixturetable/fixture_table_edit_service.{h,cpp}`).
- Wired the shared helper into panels so the prompt appears when relevant weights change: `FixtureTablePanel` (`gui/fixturetablepanel.cpp`), `TrussTablePanel` (`gui/trusstablepanel.cpp`), and `HoistTablePanel` (`gui/hoisttablepanel.cpp`).
- Replaced duplicated inline logic in `RiggingPanel::OnItemValueChanged` with the shared helper (`gui/riggingpanel.cpp`).
- Registered the new source file in `gui/CMakeLists.txt`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (OK).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (OK).
- Attempted `cmake -S . -B build` but configuration failed in this environment because `wxWidgets` development libraries are not installed (expected environment limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfee55f4ac832485cbdf03af024b03)