### PR TITLE
Make ruler labels inherit active ruler colors

### DIFF
--- a/viewer2d/viewer2d_ruler_overlay.cpp
+++ b/viewer2d/viewer2d_ruler_overlay.cpp
@@ -398,7 +398,7 @@ void EmitRulerToCanvas(const RulerOverlayViewState &state, bool darkMode,
 }
 
 std::vector<RulerScreenLabel>
-BuildRulerScreenLabels(const RulerOverlayViewState &state) {
+BuildRulerScreenLabels(const RulerOverlayViewState &state, bool darkMode) {
   std::vector<RulerScreenLabel> labels;
   if (state.width <= 0 || state.height <= 0 || state.zoom <= 0.0f)
     return labels;
@@ -420,6 +420,10 @@ BuildRulerScreenLabels(const RulerOverlayViewState &state) {
       std::max(std::max(state.largeTickMeters, shortTickMeters),
                shortTickMeters);
   const ActiveRulers activeRulers = ResolveActiveRulers(state);
+  const CanvasStroke horizontalStroke =
+      BuildRulerStroke(darkMode, activeRulers.horizontalColor);
+  const CanvasStroke verticalStroke =
+      BuildRulerStroke(darkMode, activeRulers.verticalColor);
   const float xRulerY = activeRulers.horizontalAxisMeters;
   const float yRulerX = activeRulers.verticalAxisMeters;
 
@@ -440,7 +444,7 @@ BuildRulerScreenLabels(const RulerOverlayViewState &state) {
                                : FormatRulerOffsetLabel(labelOffsetMeters);
     labels.push_back({WorldToScreenX(x, state, pixelsPerMeter),
                       WorldToScreenY(worldY, state, pixelsPerMeter),
-                      label, true, false});
+                      label, true, false, horizontalStroke.color});
   }
 
   const float startY =
@@ -459,7 +463,7 @@ BuildRulerScreenLabels(const RulerOverlayViewState &state) {
                                : FormatRulerOffsetLabel(labelOffsetMeters);
     labels.push_back({WorldToScreenX(worldX, state, pixelsPerMeter),
                       WorldToScreenY(y, state, pixelsPerMeter),
-                      label, false, true});
+                      label, false, true, verticalStroke.color});
   }
   return labels;
 }

--- a/viewer2d/viewer2d_ruler_overlay.h
+++ b/viewer2d/viewer2d_ruler_overlay.h
@@ -29,12 +29,13 @@ struct RulerScreenLabel {
   std::string text;
   bool centerOnX = false;
   bool centerOnY = false;
+  CanvasColor color{0.0f, 0.0f, 0.0f, 1.0f};
 };
 
 void DrawRulerOverlay(const RulerOverlayViewState &state, bool darkMode);
 void EmitRulerToCanvas(const RulerOverlayViewState &state, bool darkMode,
                        ICanvas2D &canvas);
 std::vector<RulerScreenLabel>
-BuildRulerScreenLabels(const RulerOverlayViewState &state);
+BuildRulerScreenLabels(const RulerOverlayViewState &state, bool darkMode);
 
 } // namespace viewer2d

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -800,14 +800,16 @@ void Viewer2DPanel::RenderInternal(bool swapBuffers) {
         distanceUnitSystem == Units::DistanceUnitSystem::Imperial;
     rulerState.view = m_view;
     viewer2d::DrawRulerOverlay(rulerState, darkMode);
-    const auto rulerLabels = viewer2d::BuildRulerScreenLabels(rulerState);
+    const auto rulerLabels =
+        viewer2d::BuildRulerScreenLabels(rulerState, darkMode);
     if (!rulerLabels.empty()) {
       std::vector<OverlayTextLabel> overlayLabels;
       overlayLabels.reserve(rulerLabels.size());
       for (const auto &label : rulerLabels) {
         overlayLabels.push_back(
             {label.xPixels, label.yPixels, label.text, label.centerOnX,
-             label.centerOnY, 3.0f * m_zoom});
+             label.centerOnY, 3.0f * m_zoom, true, label.color.r,
+             label.color.g, label.color.b});
       }
       m_controller.DrawOverlayTextLabels(overlayLabels, darkMode);
     }

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -40,6 +40,7 @@
 #include <GL/glu.h>
 #endif
 #include <cstdlib>
+#include <algorithm>
 #include <numeric>
 
 #include "configmanager.h"
@@ -1581,7 +1582,14 @@ void Viewer3DController::DrawOverlayTextLabels(
       }
     }
 
-    nvgFillColor(m_impl->vg, textColor);
+    if (label.hasCustomColor) {
+      nvgFillColor(m_impl->vg,
+                   nvgRGBAf(std::clamp(label.colorR, 0.0f, 1.0f),
+                            std::clamp(label.colorG, 0.0f, 1.0f),
+                            std::clamp(label.colorB, 0.0f, 1.0f), 1.0f));
+    } else {
+      nvgFillColor(m_impl->vg, textColor);
+    }
     nvgText(m_impl->vg, label.xPixels, label.yPixels, label.text.c_str(),
             nullptr);
   }

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -57,6 +57,10 @@ struct OverlayTextLabel {
   bool centerOnX = false;
   bool centerOnY = false;
   float fontSize = 3.0f;
+  bool hasCustomColor = false;
+  float colorR = 0.0f;
+  float colorG = 0.0f;
+  float colorB = 0.0f;
 };
 
 class Viewer3DController : public IRenderContext,


### PR DESCRIPTION
### Motivation
- Ensure ruler/tick labels use the same effective color as their corresponding ruler axis (including dark-mode resolution for pure black/white configured colors) while preserving the existing label outline behavior.
- Keep label rendering consistent with the on-screen ruler stroke so legends are visually tied to the ruler they describe.

### Description
- Add per-label color support to the 2D ruler pipeline by extending `RulerScreenLabel` with a `CanvasColor` and changing `BuildRulerScreenLabels(...)` to accept `darkMode` so the resolved fill color matches `BuildRulerStroke(...)` semantics.
- Thread per-label color through `viewer2d::BuildRulerScreenLabels(...)` -> `viewer2dpanel` -> `OverlayTextLabel` by extending `OverlayTextLabel` with `hasCustomColor` and `colorR/G/B` fields and populating them when pushing ruler labels.
- Make `Viewer3DController::DrawOverlayTextLabels(...)` honor `hasCustomColor` and use the provided RGB values for fill (clamped), while leaving the outline/stroke drawing unchanged.
- Minor include addition (`<algorithm>`) to support `std::clamp` usage.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (OK).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0223c8f588324aa988d2d25c07a7c)