### PR TITLE
Fix ruler label size scaling in PDF exports

### DIFF
--- a/viewer2d/viewer2d_ruler_overlay.cpp
+++ b/viewer2d/viewer2d_ruler_overlay.cpp
@@ -242,9 +242,10 @@ std::string FormatImperialRulerOffsetLabel(float valueMeters) {
   return out.str();
 }
 
-CanvasTextStyle BuildRulerLabelStyle(const CanvasStroke &stroke) {
+CanvasTextStyle BuildRulerLabelStyle(const CanvasStroke &stroke, float zoom) {
   CanvasTextStyle style;
-  style.fontSize = kRulerLabelFontSize;
+  const float pixelsPerMeter = kPixelsPerMeter * std::max(zoom, 0.0001f);
+  style.fontSize = kRulerLabelFontSize / pixelsPerMeter;
   style.color = stroke.color;
   return style;
 }
@@ -353,8 +354,8 @@ void EmitRulerToCanvas(const RulerOverlayViewState &state, bool darkMode,
   const float tickStepMeters = ResolveTickStepMeters(state.useImperialUnits);
   const float startX =
       ComputeStartTick(minX, kRulerZeroOriginMeters, tickStepMeters);
-  const auto horizontalTextStyle = BuildRulerLabelStyle(horizontalStroke);
-  const auto verticalTextStyle = BuildRulerLabelStyle(verticalStroke);
+  const auto horizontalTextStyle = BuildRulerLabelStyle(horizontalStroke, state.zoom);
+  const auto verticalTextStyle = BuildRulerLabelStyle(verticalStroke, state.zoom);
   for (float x = startX; x <= maxX + 0.0001f; x += tickStepMeters) {
     const auto tickKind =
         ResolveTickKind(x, kRulerZeroOriginMeters, state.useImperialUnits);


### PR DESCRIPTION
### Motivation
- Ruler labels were rendered with an incorrect (very large) font size in PDF/canvas captures because the ruler text style used a fixed pixel value instead of converting screen pixels to world units like fixture labels.

### Description
- Updated `viewer2d/viewer2d_ruler_overlay.cpp` to change `BuildRulerLabelStyle` to accept a `zoom` parameter and compute `style.fontSize` as `kRulerLabelFontSize / (kPixelsPerMeter * max(zoom, 0.0001f))`, and updated `EmitRulerToCanvas(...)` to pass `state.zoom` when building ruler text styles so printed ruler labels scale consistently with on-screen/fixture labels.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both checks succeeded (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0271015dc8324af0c8ea8c008b861)