### PR TITLE
Fix layout PDF export to include image elements

### DIFF
--- a/gui/mainwindow_print.cpp
+++ b/gui/mainwindow_print.cpp
@@ -18,9 +18,11 @@
 #include "mainwindow.h"
 #include "viewer2dstate.h"
 
+#include <algorithm>
 #include <cmath>
 #include <filesystem>
 #include <memory>
+#include <optional>
 #include <thread>
 #include <vector>
 
@@ -68,6 +70,67 @@ std::vector<LayoutLegendItem> BuildLayoutLegendItems() {
     items.push_back(std::move(item));
   }
   return items;
+}
+
+std::optional<LayoutImageExportData> BuildLayoutImageExportData(
+    const layouts::LayoutImageDefinition &imageDef, double scaleX,
+    double scaleY) {
+  LayoutImageExportData data;
+  data.zIndex = imageDef.zIndex;
+  data.frame = imageDef.frame;
+  data.frame.x = static_cast<int>(std::lround(data.frame.x * scaleX));
+  data.frame.y = static_cast<int>(std::lround(data.frame.y * scaleY));
+  data.frame.width = static_cast<int>(std::lround(data.frame.width * scaleX));
+  data.frame.height = static_cast<int>(std::lround(data.frame.height * scaleY));
+  if (data.frame.width <= 0 || data.frame.height <= 0)
+    return std::nullopt;
+  if (imageDef.imagePath.empty())
+    return std::nullopt;
+
+  wxImage sourceImage;
+  if (!sourceImage.LoadFile(wxString::FromUTF8(imageDef.imagePath)))
+    return std::nullopt;
+  if (sourceImage.GetWidth() <= 0 || sourceImage.GetHeight() <= 0)
+    return std::nullopt;
+
+  wxImage scaled = sourceImage.Scale(data.frame.width, data.frame.height,
+                                     wxIMAGE_QUALITY_HIGH);
+  if (!scaled.IsOk() || scaled.GetWidth() <= 0 || scaled.GetHeight() <= 0)
+    return std::nullopt;
+
+  data.pixelWidth = scaled.GetWidth();
+  data.pixelHeight = scaled.GetHeight();
+  data.pixels.resize(static_cast<size_t>(data.pixelWidth) *
+                     static_cast<size_t>(data.pixelHeight) * 3u);
+
+  const unsigned char *rgb = scaled.GetData();
+  const unsigned char *alpha = scaled.HasAlpha() ? scaled.GetAlpha() : nullptr;
+  if (!rgb)
+    return std::nullopt;
+  for (int idx = 0; idx < data.pixelWidth * data.pixelHeight; ++idx) {
+    const size_t rgbOffset = static_cast<size_t>(idx) * 3u;
+    if (!alpha) {
+      data.pixels[rgbOffset + 0] = rgb[rgbOffset + 0];
+      data.pixels[rgbOffset + 1] = rgb[rgbOffset + 1];
+      data.pixels[rgbOffset + 2] = rgb[rgbOffset + 2];
+      continue;
+    }
+
+    const double a = static_cast<double>(alpha[idx]) / 255.0;
+    data.pixels[rgbOffset + 0] = static_cast<unsigned char>(
+        std::clamp((static_cast<double>(rgb[rgbOffset + 0]) * a) +
+                       (255.0 * (1.0 - a)),
+                   0.0, 255.0));
+    data.pixels[rgbOffset + 1] = static_cast<unsigned char>(
+        std::clamp((static_cast<double>(rgb[rgbOffset + 1]) * a) +
+                       (255.0 * (1.0 - a)),
+                   0.0, 255.0));
+    data.pixels[rgbOffset + 2] = static_cast<unsigned char>(
+        std::clamp((static_cast<double>(rgb[rgbOffset + 2]) * a) +
+                       (255.0 * (1.0 - a)),
+                   0.0, 255.0));
+  }
+  return data;
 }
 }
 
@@ -303,6 +366,8 @@ void MainWindow::OnPrintLayout(wxCommandEvent &WXUNUSED(event)) {
   layoutTables.reserve(layout->eventTables.size());
   std::vector<LayoutTextExportData> layoutTexts;
   layoutTexts.reserve(layout->textViews.size());
+  std::vector<LayoutImageExportData> layoutImages;
+  layoutImages.reserve(layout->imageViews.size());
   const auto legendItems = BuildLayoutLegendItems();
   for (const auto &legend : layout->legendViews) {
     LayoutLegendExportData legendData;
@@ -332,6 +397,11 @@ void MainWindow::OnPrintLayout(wxCommandEvent &WXUNUSED(event)) {
     layoutTexts.push_back(
         layouttext::BuildLayoutTextExportData(text, scaleX, scaleY));
   }
+  for (const auto &image : layout->imageViews) {
+    auto imageData = BuildLayoutImageExportData(image, scaleX, scaleY);
+    if (imageData.has_value())
+      layoutImages.push_back(std::move(*imageData));
+  }
   auto exportViews = std::make_shared<std::vector<LayoutViewExportData>>();
   exportViews->reserve(layoutViews.size());
   auto exportLegends =
@@ -343,6 +413,9 @@ void MainWindow::OnPrintLayout(wxCommandEvent &WXUNUSED(event)) {
   auto exportTexts =
       std::make_shared<std::vector<LayoutTextExportData>>(
           std::move(layoutTexts));
+  auto exportImages =
+      std::make_shared<std::vector<LayoutImageExportData>>(
+          std::move(layoutImages));
 
   if (capturePanel)
     capturePanel->SetPreferPerastageSvgSymbolsForLayouts(true);
@@ -353,7 +426,7 @@ void MainWindow::OnPrintLayout(wxCommandEvent &WXUNUSED(event)) {
       [this, captureNext, exportViews, layoutViews, offscreenRenderer,
        capturePanel, cfgPtr, useSimplifiedFootprints, includeGrid, scaleX,
        scaleY, outputPageW, outputPageH, outputLandscape, exportLegends,
-       exportTables, exportTexts, outputPathWx](size_t index) mutable {
+       exportTables, exportTexts, exportImages, outputPathWx](size_t index) mutable {
         if (index >= layoutViews.size()) {
           Viewer2DPrintOptions opts;
           opts.pageWidthPt = outputPageW;
@@ -369,6 +442,7 @@ void MainWindow::OnPrintLayout(wxCommandEvent &WXUNUSED(event)) {
           auto legendsToExport = std::move(*exportLegends);
           auto tablesToExport = std::move(*exportTables);
           auto textsToExport = std::move(*exportTexts);
+          auto imagesToExport = std::move(*exportImages);
           if (capturePanel) {
             auto legendSymbols =
                 CaptureLegendSymbolSnapshot(capturePanel, *cfgPtr, true);
@@ -380,10 +454,11 @@ void MainWindow::OnPrintLayout(wxCommandEvent &WXUNUSED(event)) {
           std::thread([this, views = std::move(viewsToExport), opts,
                        legends = std::move(legendsToExport),
                        tables = std::move(tablesToExport),
-                       texts = std::move(textsToExport), outputPath,
+                       texts = std::move(textsToExport),
+                       images = std::move(imagesToExport), outputPath,
                        outputPathDisplay]() {
             Viewer2DExportResult res =
-                ExportLayoutToPdf(views, legends, tables, texts, opts,
+                ExportLayoutToPdf(views, legends, tables, texts, images, opts,
                                   outputPath);
 
             wxTheApp->CallAfter([this, res, outputPathDisplay]() {

--- a/gui/mainwindow_print.cpp
+++ b/gui/mainwindow_print.cpp
@@ -75,6 +75,11 @@ std::vector<LayoutLegendItem> BuildLayoutLegendItems() {
 std::optional<LayoutImageExportData> BuildLayoutImageExportData(
     const layouts::LayoutImageDefinition &imageDef, double scaleX,
     double scaleY) {
+  constexpr double kPdfPointsPerInch = 72.0;
+  constexpr double kTargetPrintDpi = 300.0;
+  constexpr int kMaxImageSidePx = 8192;
+  constexpr int kMaxImagePixels = 8192 * 8192;
+
   LayoutImageExportData data;
   data.zIndex = imageDef.zIndex;
   data.frame = imageDef.frame;
@@ -93,8 +98,23 @@ std::optional<LayoutImageExportData> BuildLayoutImageExportData(
   if (sourceImage.GetWidth() <= 0 || sourceImage.GetHeight() <= 0)
     return std::nullopt;
 
-  wxImage scaled = sourceImage.Scale(data.frame.width, data.frame.height,
-                                     wxIMAGE_QUALITY_HIGH);
+  const double frameWidthInches =
+      static_cast<double>(data.frame.width) / kPdfPointsPerInch;
+  const double frameHeightInches =
+      static_cast<double>(data.frame.height) / kPdfPointsPerInch;
+  int targetPixelWidth = static_cast<int>(
+      std::lround(std::max(1.0, frameWidthInches * kTargetPrintDpi)));
+  int targetPixelHeight = static_cast<int>(
+      std::lround(std::max(1.0, frameHeightInches * kTargetPrintDpi)));
+  targetPixelWidth = std::clamp(targetPixelWidth, 1, kMaxImageSidePx);
+  targetPixelHeight = std::clamp(targetPixelHeight, 1, kMaxImageSidePx);
+  if (targetPixelWidth > 0 &&
+      targetPixelHeight > (kMaxImagePixels / targetPixelWidth)) {
+    targetPixelHeight = std::max(1, kMaxImagePixels / targetPixelWidth);
+  }
+
+  wxImage scaled =
+      sourceImage.Scale(targetPixelWidth, targetPixelHeight, wxIMAGE_QUALITY_HIGH);
   if (!scaled.IsOk() || scaled.GetWidth() <= 0 || scaled.GetHeight() <= 0)
     return std::nullopt;
 

--- a/viewer2d/pdf/layout_pdf_exporter.cpp
+++ b/viewer2d/pdf/layout_pdf_exporter.cpp
@@ -717,11 +717,13 @@ Viewer2DExportResult ExportLayoutToPdf(
     const std::vector<LayoutLegendExportData> &legends,
     const std::vector<LayoutEventTableExportData> &tables,
     const std::vector<LayoutTextExportData> &texts,
+    const std::vector<LayoutImageExportData> &images,
     const Viewer2DPrintOptions &options,
     const std::filesystem::path &outputPath) {
   Viewer2DExportResult result{};
 
-  if (views.empty() && legends.empty() && tables.empty() && texts.empty()) {
+  if (views.empty() && legends.empty() && tables.empty() && texts.empty() &&
+      images.empty()) {
     result.message = "The selected layout is empty.";
     return result;
   }
@@ -898,7 +900,7 @@ Viewer2DExportResult ExportLayoutToPdf(
   }
 
   if (layoutGroups.empty() && legends.empty() && tables.empty() &&
-      texts.empty()) {
+      texts.empty() && images.empty()) {
     result.message = "Nothing to export";
     return result;
   }
@@ -1191,6 +1193,40 @@ Viewer2DExportResult ExportLayoutToPdf(
     return objects.size();
   };
 
+  auto appendImageObject = [&](const LayoutImageExportData &image,
+                               const std::string &name) -> size_t {
+    if (image.pixelWidth <= 0 || image.pixelHeight <= 0)
+      return 0;
+    if (image.pixels.size() !=
+        static_cast<size_t>(image.pixelWidth * image.pixelHeight * 3)) {
+      Logger::Instance().Log("PDF export: skipping invalid layout image '" +
+                             name + "' due to pixel buffer mismatch");
+      return 0;
+    }
+    std::string rawData(reinterpret_cast<const char *>(image.pixels.data()),
+                        image.pixels.size());
+    std::string encodedData;
+    bool compressed = false;
+    if (options.compressStreams) {
+      std::string error;
+      if (PdfDeflater::Compress(rawData, encodedData, error)) {
+        compressed = true;
+      }
+    }
+    const std::string &streamData = compressed ? encodedData : rawData;
+
+    std::ostringstream imageObj;
+    imageObj << "<< /Type /XObject /Subtype /Image /Width " << image.pixelWidth
+             << " /Height " << image.pixelHeight
+             << " /ColorSpace /DeviceRGB /BitsPerComponent 8";
+    if (compressed)
+      imageObj << " /Filter /FlateDecode";
+    imageObj << " /Length " << streamData.size() << " >>\nstream\n"
+             << streamData << "endstream";
+    objects.push_back({imageObj.str()});
+    return objects.size();
+  };
+
 
   auto populateViewSymbolNames =
       [&](const LayoutCommandGroup &group,
@@ -1284,8 +1320,23 @@ Viewer2DExportResult ExportLayoutToPdf(
   }
 
 
+  std::vector<std::string> imageXObjectNames(images.size());
+  for (size_t idx = 0; idx < images.size(); ++idx) {
+    const auto &image = images[idx];
+    if (image.pixelWidth <= 0 || image.pixelHeight <= 0)
+      continue;
+    if (image.frame.width <= 0 || image.frame.height <= 0)
+      continue;
+    const std::string xObjectName = "I" + std::to_string(idx);
+    size_t objectId = appendImageObject(image, xObjectName);
+    if (objectId == 0)
+      continue;
+    xObjectNameIds[xObjectName] = objectId;
+    imageXObjectNames[idx] = xObjectName;
+  }
+
   struct LayoutRenderElement {
-    enum class Type { View, Legend, EventTable, Text };
+    enum class Type { View, Legend, EventTable, Text, Image };
     Type type = Type::View;
     size_t index = 0;
     int zIndex = 0;
@@ -1294,7 +1345,7 @@ Viewer2DExportResult ExportLayoutToPdf(
 
   std::vector<LayoutRenderElement> renderOrder;
   renderOrder.reserve(layoutGroups.size() + legends.size() + tables.size() +
-                      texts.size());
+                      texts.size() + images.size());
   size_t renderOrderIndex = 0;
   for (size_t idx = 0; idx < layoutGroups.size(); ++idx) {
     renderOrder.push_back(
@@ -1314,6 +1365,11 @@ Viewer2DExportResult ExportLayoutToPdf(
   for (size_t idx = 0; idx < texts.size(); ++idx) {
     renderOrder.push_back(
         {LayoutRenderElement::Type::Text, idx, texts[idx].zIndex,
+         renderOrderIndex++});
+  }
+  for (size_t idx = 0; idx < images.size(); ++idx) {
+    renderOrder.push_back(
+        {LayoutRenderElement::Type::Image, idx, images[idx].zIndex,
          renderOrderIndex++});
   }
 
@@ -2019,6 +2075,28 @@ Viewer2DExportResult ExportLayoutToPdf(
     }
   };
 
+  auto renderImage = [&](size_t idx) {
+    if (idx >= images.size() || idx >= imageXObjectNames.size())
+      return;
+    const auto &image = images[idx];
+    const std::string &xObjectName = imageXObjectNames[idx];
+    if (xObjectName.empty())
+      return;
+    const double frameW = static_cast<double>(image.frame.width);
+    const double frameH = static_cast<double>(image.frame.height);
+    if (frameW <= 0.0 || frameH <= 0.0)
+      return;
+    const double frameX = static_cast<double>(image.frame.x);
+    const double frameY =
+        pageH - image.frame.y - static_cast<double>(image.frame.height);
+    contentStream << "q\n"
+                  << formatter.Format(frameW) << " 0 0 "
+                  << formatter.Format(frameH) << ' '
+                  << formatter.Format(frameX) << ' '
+                  << formatter.Format(frameY) << " cm\n/"
+                  << xObjectName << " Do\nQ\n";
+  };
+
   for (const auto &entry : renderOrder) {
     if (entry.type == LayoutRenderElement::Type::View) {
       renderViewGroup(entry.index);
@@ -2026,6 +2104,8 @@ Viewer2DExportResult ExportLayoutToPdf(
       renderLegend(entry.index);
     } else if (entry.type == LayoutRenderElement::Type::EventTable) {
       renderEventTable(entry.index);
+    } else if (entry.type == LayoutRenderElement::Type::Image) {
+      renderImage(entry.index);
     } else {
       renderText(entry.index);
     }

--- a/viewer2d/viewer2dpdfexporter.h
+++ b/viewer2d/viewer2dpdfexporter.h
@@ -102,6 +102,15 @@ struct LayoutTextExportData {
   std::vector<Line> lines;
 };
 
+struct LayoutImageExportData {
+  layouts::Layout2DViewFrame frame;
+  int zIndex = 0;
+  int pixelWidth = 0;
+  int pixelHeight = 0;
+  // RGB24 pixels (row-major, top-left origin).
+  std::vector<unsigned char> pixels;
+};
+
 // Writes the captured 2D drawing commands to a vector PDF that mirrors the
 // current viewport state. Returns structured information so callers can surface
 // meaningful errors to the user.
@@ -117,5 +126,6 @@ Viewer2DExportResult ExportLayoutToPdf(
     const std::vector<LayoutLegendExportData> &legends,
     const std::vector<LayoutEventTableExportData> &tables,
     const std::vector<LayoutTextExportData> &texts,
+    const std::vector<LayoutImageExportData> &images,
     const Viewer2DPrintOptions &options,
     const std::filesystem::path &outputPath);


### PR DESCRIPTION
### Motivation

- Layout image elements (`imageViews`) were not included when exporting layouts to PDF, causing missing images in printed/exported PDFs.  
- The change ensures images are captured, scaled and rendered into the generated PDF while preserving existing z-ordering and compression options.

### Description

- Added `LayoutImageExportData` and extended the `ExportLayoutToPdf` API to accept image payloads.  
- Implemented image preparation in `MainWindow::OnPrintLayout` to load, scale and alpha-composite source images into an RGB pixel buffer for export.  
- Added PDF image XObject generation and registration in `viewer2d/pdf/layout_pdf_exporter.cpp`, and integrated image drawing into the layout render ordering so images respect `zIndex`.  
- Technical note: `viewer2d/pdf/layout_pdf_exporter.cpp` is a hotspot and has grown; follow-up work should extract element renderers (e.g., symbol/image/legend renderers) out of this file into dedicated modules (suggested split: page composition vs element renderers / `layout_pdf_image_renderer.cpp`) to keep responsibilities modular.

### Testing

- `tests/check_perastage_tree_modules.sh` — passed.  
- `tests/check_no_configmanager_get_in_gui.sh` — passed.  
- `cmake -S . -B build && cmake --build build -j2` — attempted but failed in this environment due to missing wxWidgets development libraries (environment limitation, not a code regression).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d02b41ef6c8324a3515edb882800bc)