### PR TITLE
Fix layout legend PDF export to honor per-legend settings

### DIFF
--- a/gui/mainwindow_print.cpp
+++ b/gui/mainwindow_print.cpp
@@ -24,6 +24,8 @@
 #include <memory>
 #include <optional>
 #include <thread>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include <wx/choicdlg.h>
@@ -55,20 +57,66 @@ void SetPrintStatus(MainWindow *window, const wxString &message) {
   window->SetStatusText(message, 0);
 }
 
-std::vector<LayoutLegendItem> BuildLayoutLegendItems() {
+std::vector<LayoutLegendItem> BuildLayoutLegendItems(
+    const layouts::LayoutLegendDefinition *legend) {
   std::vector<SharedLayoutLegendItem> sharedItems =
       BuildSharedLayoutLegendItems();
+  std::unordered_map<std::string, layouts::LayoutLegendDefinition::ItemSettings>
+      settingsByType;
+  if (legend) {
+    settingsByType.reserve(legend->itemSettings.size());
+    for (const auto &settings : legend->itemSettings)
+      settingsByType[settings.typeName] = settings;
+  }
+
+  std::unordered_map<std::string, SharedLayoutLegendItem> availableByType;
+  availableByType.reserve(sharedItems.size());
+  for (const auto &shared : sharedItems)
+    availableByType.emplace(shared.typeName, shared);
+
   std::vector<LayoutLegendItem> items;
   items.reserve(sharedItems.size());
-  for (const auto &shared : sharedItems) {
+  auto appendItem = [&](const SharedLayoutLegendItem &shared) {
     LayoutLegendItem item;
     item.typeName = shared.typeName;
+    item.displayName = shared.typeName;
     item.count = shared.count;
     item.channelCount = shared.channelCount;
     item.symbolKey = shared.symbolKey;
     item.symbolFillHex = shared.symbolFillHex;
+    if (const auto it = settingsByType.find(shared.typeName);
+        it != settingsByType.end()) {
+      item.showBottomSymbol = it->second.showBottomSymbol;
+      item.showFrontSymbol = it->second.showFrontSymbol;
+      item.showSideSymbol = it->second.showSideSymbol;
+      if (!it->second.customName.empty())
+        item.displayName = it->second.customName;
+      if (!it->second.visible)
+        return;
+    }
     items.push_back(std::move(item));
+  };
+
+  if (legend) {
+    std::unordered_set<std::string> usedTypes;
+    usedTypes.reserve(legend->itemSettings.size());
+    for (const auto &settings : legend->itemSettings) {
+      const auto it = availableByType.find(settings.typeName);
+      if (it == availableByType.end())
+        continue;
+      appendItem(it->second);
+      usedTypes.insert(settings.typeName);
+    }
+    for (const auto &shared : sharedItems) {
+      if (usedTypes.find(shared.typeName) != usedTypes.end())
+        continue;
+      appendItem(shared);
+    }
+  } else {
+    for (const auto &shared : sharedItems)
+      appendItem(shared);
   }
+
   return items;
 }
 
@@ -388,11 +436,11 @@ void MainWindow::OnPrintLayout(wxCommandEvent &WXUNUSED(event)) {
   layoutTexts.reserve(layout->textViews.size());
   std::vector<LayoutImageExportData> layoutImages;
   layoutImages.reserve(layout->imageViews.size());
-  const auto legendItems = BuildLayoutLegendItems();
   for (const auto &legend : layout->legendViews) {
     LayoutLegendExportData legendData;
-    legendData.items = legendItems;
+    legendData.items = BuildLayoutLegendItems(&legend);
     legendData.zIndex = legend.zIndex;
+    legendData.showChannelColumn = legend.showChannelColumn;
     layouts::Layout2DViewFrame frame = legend.frame;
     frame.x = static_cast<int>(std::lround(frame.x * scaleX));
     frame.y = static_cast<int>(std::lround(frame.y * scaleY));

--- a/viewer2d/pdf/layout_pdf_exporter.cpp
+++ b/viewer2d/pdf/layout_pdf_exporter.cpp
@@ -1448,7 +1448,8 @@ Viewer2DExportResult ExportLayoutToPdf(
     const double paddingTop = 0.0;
     const double paddingBottom = 0.0;
     const double columnGap = 6.0;
-    const double symbolColumnGap = 0.0;
+    double symbolColumnGap = 0.0;
+    double symbolOuterMargin = 0.0;
     constexpr int kLegendTypeLineCount = 2;
     constexpr double kLegendLineSpacingScale = 1.0;
     constexpr double kLegendSymbolColumnScale = 1.0;
@@ -1613,16 +1614,21 @@ Viewer2DExportResult ExportLayoutToPdf(
       if (item.symbolKey.empty())
         continue;
       const PerastageSvgSymbolData *topSvg =
-          findLegendSvg(item.symbolKey, SymbolViewKind::Bottom);
+          item.showBottomSymbol
+              ? findLegendSvg(item.symbolKey, SymbolViewKind::Bottom)
+              : nullptr;
       const PerastageSvgSymbolData *frontSvg =
-          findLegendSvg(item.symbolKey, SymbolViewKind::Front);
-      const SymbolDefinition *topSymbol = legendSymbolsForSizing
-          ? FindSymbolDefinitionPreferred(legendSymbolsForSizing, item.symbolKey,
-                                          SymbolViewKind::Bottom)
-          : nullptr;
-      const SymbolDefinition *frontSymbol = legendSymbolsForSizing
-          ? FindSymbolDefinitionExact(legendSymbolsForSizing, item.symbolKey,
-                                      SymbolViewKind::Front)
+          item.showFrontSymbol ? findLegendSvg(item.symbolKey, SymbolViewKind::Front)
+                               : nullptr;
+      const SymbolDefinition *topSymbol =
+          (item.showBottomSymbol && legendSymbolsForSizing)
+              ? FindSymbolDefinitionPreferred(legendSymbolsForSizing, item.symbolKey,
+                                              SymbolViewKind::Bottom)
+              : nullptr;
+      const SymbolDefinition *frontSymbol =
+          (item.showFrontSymbol && legendSymbolsForSizing)
+              ? FindSymbolDefinitionExact(legendSymbolsForSizing, item.symbolKey,
+                                          SymbolViewKind::Front)
           : nullptr;
       maxTopSymbolColumnWidth = std::max(
           maxTopSymbolColumnWidth,
@@ -1646,14 +1652,53 @@ Viewer2DExportResult ExportLayoutToPdf(
                   kLegendSymbolColumnScale),
         0.0, static_cast<double>(limitedSymbolColumnSize));
 
-    const double xTopSymbol = frameX + paddingLeft;
+    bool hasSvgSymbols = false;
+    bool hasFallbackSymbols = false;
+    for (const auto &item : legend.items) {
+      if (item.symbolKey.empty())
+        continue;
+      const bool topVisible = item.showBottomSymbol;
+      const bool frontVisible = item.showFrontSymbol;
+      const PerastageSvgSymbolData *topSvg =
+          topVisible ? findLegendSvg(item.symbolKey, SymbolViewKind::Bottom)
+                     : nullptr;
+      const PerastageSvgSymbolData *frontSvg =
+          frontVisible ? findLegendSvg(item.symbolKey, SymbolViewKind::Front)
+                       : nullptr;
+      const SymbolDefinition *topSymbol = legendSymbolsForSizing
+          ? FindSymbolDefinitionPreferred(legendSymbolsForSizing, item.symbolKey,
+                                          SymbolViewKind::Bottom)
+          : nullptr;
+      const SymbolDefinition *frontSymbol = legendSymbolsForSizing
+          ? FindSymbolDefinitionExact(legendSymbolsForSizing, item.symbolKey,
+                                      SymbolViewKind::Front)
+          : nullptr;
+      if ((topVisible && topSvg) || (frontVisible && frontSvg)) {
+        hasSvgSymbols = true;
+      }
+      if ((topVisible && !topSvg && topSymbol) ||
+          (frontVisible && !frontSvg && frontSymbol)) {
+        hasFallbackSymbols = true;
+      }
+    }
+    if (hasSvgSymbols && !hasFallbackSymbols) {
+      symbolColumnGap = 2.5;
+      symbolOuterMargin = 2.0;
+    }
+
+    const double xTopSymbol = frameX + paddingLeft + symbolOuterMargin;
     const double xFrontSymbol = xTopSymbol + topSymbolColumnSize + symbolColumnGap;
     const double xCount = xFrontSymbol + frontSymbolColumnSize + columnGap;
     const double xType = xCount + maxCountWidth + columnGap;
     double xCh = frameX + frameW - paddingRight - maxChWidth;
-    if (xCh < xType + columnGap)
-      xCh = xType + columnGap;
-    const double typeWidth = std::max(0.0, xCh - xType - columnGap);
+    if (legend.showChannelColumn) {
+      if (xCh < xType + columnGap)
+        xCh = xType + columnGap;
+    } else {
+      xCh = frameX + frameW - paddingRight;
+    }
+    const double typeWidth = std::max(
+        0.0, legend.showChannelColumn ? (xCh - xType - columnGap) : (xCh - xType));
 
     auto wrapTextToTwoLines = [&](const std::string &text, double maxWidth) {
       if (maxWidth <= 0.0)
@@ -1718,8 +1763,10 @@ Viewer2DExportResult ExportLayoutToPdf(
                0.08, 0.08);
     appendText(xType, y - singleTextOffset - fontSize, encodeText("Type"), "F2", 0.08,
                0.08, 0.08);
-    appendText(xCh, y - singleTextOffset - fontSize, encodeText("Ch"), "F2", 0.08,
-               0.08, 0.08);
+    if (legend.showChannelColumn) {
+      appendText(xCh, y - singleTextOffset - fontSize, encodeText("Ch"), "F2",
+                 0.08, 0.08, 0.08);
+    }
 
     y -= rowHeight;
     const double separatorY = y;
@@ -1736,7 +1783,7 @@ Viewer2DExportResult ExportLayoutToPdf(
 
       const std::string countText = encodeText(std::to_string(item.count));
       const auto typeLines =
-          wrapTextToTwoLines(encodeText(item.typeName), typeWidth);
+          wrapTextToTwoLines(encodeText(item.displayName), typeWidth);
       const std::string chText =
           encodeText(item.channelCount ? std::to_string(*item.channelCount) : "-");
 
@@ -1745,17 +1792,23 @@ Viewer2DExportResult ExportLayoutToPdf(
             legend.symbolSnapshot ? legend.symbolSnapshot.get()
                                   : symbolSnapshot.get();
         const PerastageSvgSymbolData *topSvg =
-            findLegendSvg(item.symbolKey, SymbolViewKind::Bottom);
+            item.showBottomSymbol
+                ? findLegendSvg(item.symbolKey, SymbolViewKind::Bottom)
+                : nullptr;
         const PerastageSvgSymbolData *frontSvg =
-            findLegendSvg(item.symbolKey, SymbolViewKind::Front);
-        const SymbolDefinition *topSymbol = legendSymbols
-            ? FindSymbolDefinitionPreferred(legendSymbols, item.symbolKey,
-                                           SymbolViewKind::Bottom)
-            : nullptr;
-        const SymbolDefinition *frontSymbol = legendSymbols
-            ? FindSymbolDefinitionExact(legendSymbols, item.symbolKey,
-                                       SymbolViewKind::Front)
-            : nullptr;
+            item.showFrontSymbol
+                ? findLegendSvg(item.symbolKey, SymbolViewKind::Front)
+                : nullptr;
+        const SymbolDefinition *topSymbol =
+            (item.showBottomSymbol && legendSymbols)
+                ? FindSymbolDefinitionPreferred(legendSymbols, item.symbolKey,
+                                                SymbolViewKind::Bottom)
+                : nullptr;
+        const SymbolDefinition *frontSymbol =
+            (item.showFrontSymbol && legendSymbols)
+                ? FindSymbolDefinitionExact(legendSymbols, item.symbolKey,
+                                            SymbolViewKind::Front)
+                : nullptr;
 
         const double topDrawW =
             topSvg ? symbolDrawWidthSvg(topSvg) : symbolDrawWidth(topSymbol);
@@ -1891,8 +1944,10 @@ Viewer2DExportResult ExportLayoutToPdf(
         appendText(xType, secondTypeBaseline, typeLines[1], "F1", 0.08, 0.08,
                    0.08);
       }
-      appendText(xCh, y - singleTextOffset - fontSize, chText, "F1", 0.08, 0.08,
-                 0.08);
+      if (legend.showChannelColumn) {
+        appendText(xCh, y - singleTextOffset - fontSize, chText, "F1", 0.08,
+                   0.08, 0.08);
+      }
       y -= rowHeight;
     }
 

--- a/viewer2d/viewer2dpdfexporter.h
+++ b/viewer2d/viewer2dpdfexporter.h
@@ -61,16 +61,21 @@ struct LayoutViewExportData {
 
 struct LayoutLegendItem {
   std::string typeName;
+  std::string displayName;
   int count = 0;
   std::optional<int> channelCount;
   std::string symbolKey;
   std::optional<std::string> symbolFillHex;
+  bool showBottomSymbol = true;
+  bool showFrontSymbol = true;
+  bool showSideSymbol = false;
 };
 
 struct LayoutLegendExportData {
   layouts::Layout2DViewFrame frame;
   std::vector<LayoutLegendItem> items;
   int zIndex = 0;
+  bool showChannelColumn = true;
   std::shared_ptr<const SymbolDefinitionSnapshot> symbolSnapshot = nullptr;
 };
 


### PR DESCRIPTION
### Motivation
- The layout PDF export used a global shared legend list and did not preserve per-legend ordering, custom names or visibility flags, causing printed legends to show wrong names/order and incorrect symbol visibility. 
- PDF legend spacing for pure-SVG symbols was tighter than the on-screen layout, producing visually cramped symbol columns.

### Description
- Make `BuildLayoutLegendItems` aware of a specific `LayoutLegendDefinition` and build the legend rows in the order defined by each legend's `itemSettings`, applying per-row `customName` and visibility; changes live in `gui/mainwindow_print.cpp`.
- Extend the export types in `viewer2d/viewer2dpdfexporter.h` to carry `displayName`, `showBottomSymbol`, `showFrontSymbol`, `showSideSymbol`, and `showChannelColumn` so the PDF renderer has the same per-legend metadata as the layout.
- Update `viewer2d/pdf/layout_pdf_exporter.cpp` to use the per-item visibility flags when resolving/drawing fallback symbols or SVGs, to render `displayName` instead of the type key, to respect `showChannelColumn`, and to add a small `symbolColumnGap`/`symbolOuterMargin` when the legend contains only SVG symbols to better match on-screen spacing.
- All changes are localized to legend construction and PDF rendering paths (`gui/mainwindow_print.cpp`, `viewer2d/viewer2dpdfexporter.h`, `viewer2d/pdf/layout_pdf_exporter.cpp`) without introducing new cross-module dependencies.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.
- Attempted `cmake -S . -B build` and configuration failed due to missing system `wxWidgets` development packages in the environment (expected in this container), so a full build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d04473853c832486f3eeabffaf805e)