### PR TITLE
Apply layout scaling to PDF export fonts for larger paper sizes

### DIFF
--- a/gui/mainwindow_print.cpp
+++ b/gui/mainwindow_print.cpp
@@ -500,6 +500,8 @@ void MainWindow::OnPrintLayout(wxCommandEvent &WXUNUSED(event)) {
           opts.pageWidthPt = outputPageW;
           opts.pageHeightPt = outputPageH;
           opts.marginPt = 0.0;
+          opts.layoutScaleX = scaleX;
+          opts.layoutScaleY = scaleY;
           opts.landscape = outputLandscape;
           opts.printIncludeGrid = includeGrid;
           opts.useSimplifiedFootprints = useSimplifiedFootprints;

--- a/viewer2d/pdf/layout_pdf_exporter.cpp
+++ b/viewer2d/pdf/layout_pdf_exporter.cpp
@@ -751,6 +751,8 @@ Viewer2DExportResult ExportLayoutToPdf(
     result.message = "The selected paper size leaves no space for drawing.";
     return result;
   }
+  const double layoutScale =
+      std::max(0.1, (options.layoutScaleX + options.layoutScaleY) * 0.5);
 
   struct CommandGroup {
     std::vector<CanvasCommand> commands;
@@ -1464,6 +1466,7 @@ Viewer2DExportResult ExportLayoutToPdf(
     fontSize = std::clamp(fontSize, 6.0, 14.0);
     // Compensate PDF point units so legend typography matches on-screen Layout Viewer sizing.
     fontSize *= (kLegendFontScale * 1.5);
+    fontSize *= layoutScale;
     const double fontScale =
         std::clamp(fontSize / (14.0 * kLegendFontScale), 0.0, 1.0);
 
@@ -1989,6 +1992,7 @@ Viewer2DExportResult ExportLayoutToPdf(
         totalRows > 0 ? (availableHeight / totalRows) - 2.0 : 10.0;
     fontSize = std::clamp(fontSize, 6.0, 14.0);
     fontSize *= kLegendFontScale;
+    fontSize *= layoutScale;
     const double emphasizedFontSize =
         std::max(fontSize + 1.0, fontSize * 1.1);
 
@@ -2089,9 +2093,12 @@ Viewer2DExportResult ExportLayoutToPdf(
     for (const auto &line : text.lines) {
       double lineFontSize =
           text.fontSize > 0 ? static_cast<double>(text.fontSize) : 12.0;
+      lineFontSize *= layoutScale;
       for (const auto &run : line.runs) {
         const double runSize =
-            run.fontSize > 0 ? static_cast<double>(run.fontSize) : lineFontSize;
+            run.fontSize > 0
+                ? static_cast<double>(run.fontSize) * layoutScale
+                : lineFontSize;
         lineFontSize = std::max(lineFontSize, runSize);
       }
       const double lineHeight = lineFontSize * 1.2;
@@ -2100,7 +2107,9 @@ Viewer2DExportResult ExportLayoutToPdf(
       double lineWidth = 0.0;
       for (const auto &run : line.runs) {
         const double runSize =
-            run.fontSize > 0 ? static_cast<double>(run.fontSize) : lineFontSize;
+            run.fontSize > 0
+                ? static_cast<double>(run.fontSize) * layoutScale
+                : lineFontSize;
         const PdfFontDefinition *font =
             run.bold ? fontCatalog.bold : fontCatalog.regular;
         const std::string encoded = encodeText(run.text);
@@ -2120,7 +2129,9 @@ Viewer2DExportResult ExportLayoutToPdf(
       }
       for (const auto &run : line.runs) {
         const double runSize =
-            run.fontSize > 0 ? static_cast<double>(run.fontSize) : lineFontSize;
+            run.fontSize > 0
+                ? static_cast<double>(run.fontSize) * layoutScale
+                : lineFontSize;
         const char *fontKey = run.bold ? "F2" : "F1";
         const PdfFontDefinition *font =
             run.bold ? fontCatalog.bold : fontCatalog.regular;

--- a/viewer2d/viewer2dpdfexporter.h
+++ b/viewer2d/viewer2dpdfexporter.h
@@ -38,6 +38,8 @@ struct Viewer2DPrintOptions {
   double pageWidthPt = 297.0 * kMmToPt;  // A3 portrait width
   double pageHeightPt = 420.0 * kMmToPt; // A3 portrait height
   double marginPt = 36.0;                // Half an inch margin for readability
+  double layoutScaleX = 1.0;
+  double layoutScaleY = 1.0;
   bool landscape = false;
   bool compressStreams = true;
   int floatPrecision = 3;


### PR DESCRIPTION
### Motivation
- Printing a layout designed for one paper size (e.g. A4) to a larger paper (e.g. A3) made some panel fonts appear smaller because the PDF exporter did not account for the layout-to-output page scaling. 
- The change ensures typography in exported layout PDFs better matches on-screen/layout sizing when the output page differs from the original layout dimensions.

### Description
- Added `layoutScaleX` and `layoutScaleY` to `Viewer2DPrintOptions` in `viewer2d/viewer2dpdfexporter.h` to carry precomputed layout→output scale factors. 
- Wired the `scaleX`/`scaleY` computed in `MainWindow::OnPrintLayout` into the export options in `gui/mainwindow_print.cpp`. 
- In `ExportLayoutToPdf` (`viewer2d/pdf/layout_pdf_exporter.cpp`) derived a single `layoutScale` from those options and applied it to font size computations for legends, event tables, and layout text line/run sizing so printed typography scales consistently; the derived scale is clamped to a minimum of `0.1`. 
- Affected files: `viewer2d/viewer2dpdfexporter.h`, `gui/mainwindow_print.cpp`, and `viewer2d/pdf/layout_pdf_exporter.cpp`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d04dee7c308324aba5edbe31d62b57)