### PR TITLE
Improve rider fallback for ambiguous LX bridge targets

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -115,6 +115,36 @@ std::optional<std::string> ExtractParenthesizedToken(const std::string &text) {
   return text.substr(open, close - open + 1);
 }
 
+std::string NormalizeHangName(const std::string &raw);
+
+std::string ResolveHangTargetFallback(const std::string &raw) {
+  std::string candidate = Trim(raw);
+  if (candidate.empty())
+    return {};
+
+  std::smatch targetMatch;
+  if (std::regex_search(candidate, targetMatch, kHoistTargetRe) &&
+      targetMatch.size() > 1) {
+    candidate = Trim(targetMatch[1].str());
+  }
+
+  // Some riders append accessories before the real target:
+  // "... + HUESITOS PARA PUENTES LX". Keep only the effective hang target.
+  const size_t plusPos = candidate.find('+');
+  if (plusPos != std::string::npos) {
+    const std::string tail = Trim(candidate.substr(plusPos + 1));
+    if (!tail.empty()) {
+      std::smatch plusTargetMatch;
+      if (std::regex_search(tail, plusTargetMatch, kHoistTargetRe) &&
+          plusTargetMatch.size() > 1) {
+        candidate = Trim(plusTargetMatch[1].str());
+      }
+    }
+  }
+
+  return NormalizeHangName(candidate);
+}
+
 bool TryExtractTrailingHangWithCoordinate(std::string &text, std::string &hangOut,
                                           std::string &coordinateSuffixOut) {
   std::smatch trailingHangMatch;
@@ -1103,7 +1133,9 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
         if (it != hangCoordinateSuffixByHang.end())
           trussCoordinateSuffix = it->second;
       }
-      hang = NormalizeHangName(hang);
+      hang = ResolveHangTargetFallback(hang);
+      if (hang.empty())
+        hang = NormalizeHangName(currentHang);
 
       // Do not keep floor trusses in filtered output because those are not
       // useful for the target lighting rigging workflow.
@@ -1173,7 +1205,9 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
         if (it != hangCoordinateSuffixByHang.end())
           trussCoordinateSuffix = it->second;
       }
-      hang = NormalizeHangName(hang);
+      hang = ResolveHangTargetFallback(hang);
+      if (hang.empty())
+        hang = NormalizeHangName(currentHang);
       if (hang != "BACKDROP")
         continue;
 
@@ -1195,7 +1229,9 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
         continue;
       std::string hang = NormalizeHangName(currentHang);
       if (std::regex_search(line, hm, kHangFindRe))
-        hang = NormalizeHangName(hm[1].str());
+        hang = ResolveHangTargetFallback(hm[1].str());
+      if (hang.empty())
+        hang = NormalizeHangName(currentHang);
       if (hang == "FLOOR")
         continue;
       std::string out = "1 TRUSS " + formatLengthM(lengthM) + "m";
@@ -1661,7 +1697,9 @@ bool RiderImporter::ImportText(const std::string &text) {
           hang = model;
           model.clear();
         }
-        hang = NormalizeHangName(hang);
+        hang = ResolveHangTargetFallback(hang);
+        if (hang.empty())
+          hang = NormalizeHangName(currentHang);
         if (hang == "FLOOR")
           continue;
 
@@ -1892,7 +1930,9 @@ bool RiderImporter::ImportText(const std::string &text) {
             model.clear();
           }
         }
-        hang = NormalizeHangName(hang);
+        hang = ResolveHangTargetFallback(hang);
+        if (hang.empty())
+          hang = NormalizeHangName(currentHang);
         if (hang != "BACKDROP")
           continue;
 
@@ -2008,10 +2048,10 @@ bool RiderImporter::ImportText(const std::string &text) {
         std::string hang = currentHang;
         std::optional<TrussCoordinateOverride> coordinateOverride =
             ParseTrussCoordinateOverride(hang, distanceUnitSystem);
-        if (std::regex_search(line, hm, kHangFindRe)) {
-          hang = hm[1];
-          hang = NormalizeHangName(hang);
-        }
+        if (std::regex_search(line, hm, kHangFindRe))
+          hang = ResolveHangTargetFallback(hm[1].str());
+        if (hang.empty())
+          hang = NormalizeHangName(currentHang);
         if (!coordinateOverride.has_value()) {
           const auto hangOverrideIt = hangCoordinateOverrides.find(hang);
           if (hangOverrideIt != hangCoordinateOverrides.end())

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -56,6 +56,9 @@ Filter behavior:
 13. Removes parenthesized notes from fixture tokens to reduce rider noise.
 14. The filter pass is idempotent for normalized truss lines ending in
     `SCREEN` (re-applying **Apply filter** keeps those lines).
+15. Truss targets with accessory suffixes are normalized to the effective hang
+    target (for example, `... + HUESITOS PARA PUENTES LX` is interpreted as
+    `PUENTES LX`).
 
 After applying the filter, users can manually adjust the filtered text and then
 press **Create**; the same normalization rules are still applied at creation

--- a/tests/rider_hoist_import_test.cpp
+++ b/tests/rider_hoist_import_test.cpp
@@ -228,5 +228,39 @@ int main() {
   assert(foundEnglishLx1);
   assert(foundEnglishBackdrop);
 
+  cfg.Reset();
+  const std::string ambiguousBridgeText =
+      "RIGGING Y ESTRUCTURAS\n"
+      "2 TRUSS 45X45 APILABLE PRO 10m + HUESITOS PARA PUENTES LX\n"
+      "4 MOTOR 500Kg + GRILLETES + ESLINGAS PARA PUENTES LX\n";
+  assert(RiderImporter::ImportText(ambiguousBridgeText));
+  const auto &ambiguousBridgeScene = cfg.GetScene();
+  int lx1TrussCount = 0;
+  int lx2TrussCount = 0;
+  int lx1SupportCount = 0;
+  int lx2SupportCount = 0;
+  bool pollutedLayerNameFound = false;
+  for (const auto &[uuid, truss] : ambiguousBridgeScene.trusses) {
+    (void)uuid;
+    if (truss.positionName == "LX1")
+      ++lx1TrussCount;
+    else if (truss.positionName == "LX2")
+      ++lx2TrussCount;
+    if (truss.layer.find("HUESITOS") != std::string::npos)
+      pollutedLayerNameFound = true;
+  }
+  for (const auto &[uuid, support] : ambiguousBridgeScene.supports) {
+    (void)uuid;
+    if (support.positionName == "LX1")
+      ++lx1SupportCount;
+    else if (support.positionName == "LX2")
+      ++lx2SupportCount;
+  }
+  assert(lx1TrussCount > 0);
+  assert(lx2TrussCount > 0);
+  assert(lx1SupportCount == 2);
+  assert(lx2SupportCount == 2);
+  assert(!pollutedLayerNameFound);
+
   return 0;
 }


### PR DESCRIPTION
### Motivation
- Some riders append accessory text (for example `+ HUESITOS PARA PUENTES LX`) which caused the importer to treat the accessory text as the truss target, producing incorrect `LX` assignment, overlapping bridge trusses and polluted layer names. 
- The goal is a small, localized fallback that extracts the effective hang target from noisy lines so `PUENTES LX` and related hoist/truss distribution are interpreted as intended.

### Description
- Added `ResolveHangTargetFallback` in `core/riderimporter.cpp` to extract the effective hang target from noisy/compound tokens (it strips `+` accessory suffixes and applies `kHoistTargetRe` before normalizing). 
- Applied this fallback in both the filter/preview pass (`RiderImporter::BuildFixtureFilterPreview`) and the import path (`RiderImporter::ImportText`) so filtered preview and actual import remain consistent. 
- Added a regression case in `tests/rider_hoist_import_test.cpp` for ambiguous bridge text to verify trusses are assigned to `LX1`/`LX2`, motors are split correctly, and no layer names are polluted. 
- Documented the new normalization behavior in `docs/text_to_scene_rules.md` (item about accessory-suffix normalization). 

### Testing
- Ran mandatory repository checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both succeeded. 
- Added an automated regression in `tests/rider_hoist_import_test.cpp` (asserts correct truss/support distribution and absence of polluted layer names). 
- Attempted `cmake --preset wsl-x64-debug` to validate build configuration but it failed in this environment due to missing `wxWidgets` development packages (failure is environmental, not related to the change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d21f05e7288324a1ade6dad523ca18)