### PR TITLE
Fix ruler-label font scaling mismatch in PDF exports

### DIFF
--- a/viewer2d/viewer2d_ruler_overlay.cpp
+++ b/viewer2d/viewer2d_ruler_overlay.cpp
@@ -243,9 +243,15 @@ std::string FormatImperialRulerOffsetLabel(float valueMeters) {
 }
 
 CanvasTextStyle BuildRulerLabelStyle(const CanvasStroke &stroke, float zoom) {
+  (void)zoom;
   CanvasTextStyle style;
-  const float pixelsPerMeter = kPixelsPerMeter * std::max(zoom, 0.0001f);
-  style.fontSize = kRulerLabelFontSize / pixelsPerMeter;
+  // Screen overlays render ruler labels at kRulerLabelFontSize * zoom pixels
+  // so they scale with the scene exactly like fixture labels. For captured
+  // canvas output (PDF export), convert that to world units while preserving
+  // the same zoom-scaled behavior:
+  // worldSize = (kRulerLabelFontSize * zoom) / (kPixelsPerMeter * zoom)
+  //           = kRulerLabelFontSize / kPixelsPerMeter.
+  style.fontSize = kRulerLabelFontSize / kPixelsPerMeter;
   style.color = stroke.color;
   return style;
 }


### PR DESCRIPTION
### Motivation
- Ruler labels in exported PDFs looked smaller than fixture labels because the capture path converted the screen-scaled label size using an extra `/ zoom`, making printed ruler text not match on-screen zoomed behavior.

### Description
- Updated `BuildRulerLabelStyle` in `viewer2d/viewer2d_ruler_overlay.cpp` to ignore the `zoom` parameter and compute `style.fontSize = kRulerLabelFontSize / kPixelsPerMeter` so the world-unit size preserves the on-screen zoom-scaled appearance.
- Added an inline comment explaining the scaling equivalence to prevent future regressions.
- Change is localized to the ruler overlay label construction and does not modify public APIs or other rendering paths.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2277f38a08324988c9d81aea61167)