### PR TITLE
Refresh fixture table after changing fixture-type color in Summary

### DIFF
--- a/gui/summarypanel.cpp
+++ b/gui/summarypanel.cpp
@@ -18,6 +18,7 @@
 #include "summarypanel.h"
 #include "colorstore.h"
 #include "configmanager.h"
+#include "fixturetablepanel.h"
 #include "guiconfigservices.h"
 #include "viewer2dpanel.h"
 #include "viewer3dpanel.h"
@@ -378,6 +379,9 @@ void SummaryPanel::OnItemActivated(wxDataViewEvent& event) {
         if (fixture.typeName == typeName)
             fixture.color = hex;
     }
+
+    if (FixtureTablePanel::Instance())
+        FixtureTablePanel::Instance()->ReloadData();
 
     wxBitmap bmp(16, 16);
     wxMemoryDC dc(bmp);


### PR DESCRIPTION
### Motivation
- Ensure user edits to fixture-type colors made via the Summary panel are not overwritten during save because `SyncSceneData()` can read stale values from the fixture table model.

### Description
- Add `#include "fixturetablepanel.h"` and call `FixtureTablePanel::Instance()->ReloadData()` in `SummaryPanel::OnItemActivated` (file `gui/summarypanel.cpp`) immediately after applying the new color so the fixture table model and UI are updated.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2342a3f688324ba936f76172f2509)