### PR TITLE
Refresh layout views when scene content changes

### DIFF
--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -45,6 +45,7 @@ public:
   const layouts::Layout2DViewDefinition *GetEditableView() const;
   bool DeleteSelectedElement();
   void RefreshLegendData();
+  void RefreshAfterSceneContentUpdate();
   void RefreshAfterFixtureSymbolUpdate();
 
 private:

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -196,6 +196,7 @@ private:
   bool NeedsRenderRebuild() const;
   void RequestRenderRebuild();
   void InvalidateRenderIfFrameChanged();
+  size_t ComputeSceneContentHash() const;
   size_t HashViewContent(const layouts::Layout2DViewDefinition &view) const;
   void OnLoadingTimer(wxTimerEvent &event);
   void OnRenderDelayTimer(wxTimerEvent &event);
@@ -297,6 +298,8 @@ private:
   double lastRenderZoom = 0.0;
   double lastPageWidthPt = 0.0;
   double lastPageHeightPt = 0.0;
+  size_t lastSceneContentHash = 0;
+  bool hasSceneContentHash = false;
   bool renderPending = false;
   bool isLoading = false;
   bool loadingRequested = false;

--- a/gui/layoutviewerpanel_render_invalidation.cpp
+++ b/gui/layoutviewerpanel_render_invalidation.cpp
@@ -19,6 +19,8 @@
 
 #include <functional>
 
+#include "guiconfigservices.h"
+
 namespace {
 void HashCombine(size_t &seed, size_t value) {
   seed ^= value + 0x9e3779b9 + (seed << 6) + (seed >> 2);
@@ -27,7 +29,29 @@ void HashCombine(size_t &seed, size_t value) {
 void HashCombineFloat(size_t &seed, float value) {
   HashCombine(seed, std::hash<float>{}(value));
 }
+
+template <typename TMap>
+size_t HashSceneUuidMap(const TMap &items) {
+  size_t aggregate = std::hash<size_t>{}(items.size());
+  const std::hash<std::string> strHasher;
+  for (const auto &[uuid, value] : items) {
+    (void)value;
+    const size_t entryHash = strHasher(uuid);
+    aggregate ^= entryHash + 0x9e3779b9 + (aggregate << 6) + (aggregate >> 2);
+  }
+  return aggregate;
+}
 } // namespace
+
+size_t LayoutViewerPanel::ComputeSceneContentHash() const {
+  const auto &scene = GetDefaultGuiConfigServices().LegacyConfigManager().GetScene();
+  size_t hash = 0;
+  HashCombine(hash, HashSceneUuidMap(scene.fixtures));
+  HashCombine(hash, HashSceneUuidMap(scene.trusses));
+  HashCombine(hash, HashSceneUuidMap(scene.sceneObjects));
+  HashCombine(hash, HashSceneUuidMap(scene.supports));
+  return hash;
+}
 
 size_t LayoutViewerPanel::HashViewContent(
     const layouts::Layout2DViewDefinition &view) const {
@@ -87,6 +111,9 @@ void LayoutViewerPanel::InvalidateRenderIfFrameChanged() {
   const bool zoomChanged = lastRenderZoom != renderZoom;
   const bool pageChanged =
       lastPageWidthPt != pageWidth || lastPageHeightPt != pageHeight;
+  const size_t sceneContentHash = ComputeSceneContentHash();
+  const bool sceneContentChanged =
+      !hasSceneContentHash || sceneContentHash != lastSceneContentHash;
   auto markDirty = [&](bool &cacheDirty) {
     if (cacheDirty)
       return;
@@ -97,6 +124,11 @@ void LayoutViewerPanel::InvalidateRenderIfFrameChanged() {
     ViewCache &cache = GetViewCache(view.id);
     const size_t contentHash = HashViewContent(view);
     if (cache.contentHash != 0 && cache.contentHash != contentHash) {
+      markDirty(cache.renderDirty);
+    }
+    if (sceneContentChanged) {
+      cache.captureVersion = -1;
+      cache.captureInProgress = false;
       markDirty(cache.renderDirty);
     }
     wxRect frameRect;
@@ -118,6 +150,9 @@ void LayoutViewerPanel::InvalidateRenderIfFrameChanged() {
 
   for (const auto &legend : currentLayout.legendViews) {
     LegendCache &cache = GetLegendCache(legend.id);
+    if (sceneContentChanged) {
+      markDirty(cache.renderDirty);
+    }
     wxRect frameRect;
     if (!GetFrameRect(legend.frame, frameRect)) {
       if (cache.texture != 0) {
@@ -192,12 +227,14 @@ void LayoutViewerPanel::InvalidateRenderIfFrameChanged() {
     }
   }
 
-  if (zoomChanged || pageChanged) {
+  if (zoomChanged || pageChanged || sceneContentChanged) {
     renderDirty = true;
   }
   lastRenderZoom = renderZoom;
   lastPageWidthPt = pageWidth;
   lastPageHeightPt = pageHeight;
+  lastSceneContentHash = sceneContentHash;
+  hasSceneContentHash = true;
 }
 
 void LayoutViewerPanel::RefreshAfterSceneContentUpdate() {

--- a/gui/layoutviewerpanel_render_invalidation.cpp
+++ b/gui/layoutviewerpanel_render_invalidation.cpp
@@ -19,6 +19,7 @@
 
 #include <functional>
 
+#include "configmanager.h"
 #include "guiconfigservices.h"
 
 namespace {

--- a/gui/layoutviewerpanel_render_invalidation.cpp
+++ b/gui/layoutviewerpanel_render_invalidation.cpp
@@ -200,7 +200,7 @@ void LayoutViewerPanel::InvalidateRenderIfFrameChanged() {
   lastPageHeightPt = pageHeight;
 }
 
-void LayoutViewerPanel::RefreshAfterFixtureSymbolUpdate() {
+void LayoutViewerPanel::RefreshAfterSceneContentUpdate() {
   viewRenderVersion++;
   captureInProgress = false;
 
@@ -217,4 +217,8 @@ void LayoutViewerPanel::RefreshAfterFixtureSymbolUpdate() {
   renderDirty = true;
   RequestRenderRebuild();
   Refresh();
+}
+
+void LayoutViewerPanel::RefreshAfterFixtureSymbolUpdate() {
+  RefreshAfterSceneContentUpdate();
 }

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1029,6 +1029,8 @@ void MainWindow::RefreshAfterSceneChange(bool refreshViewport) {
   if (sceneObjPanel)
     sceneObjPanel->ReloadData();
   RefreshSummary();
+  if (layoutViewerPanel)
+    layoutViewerPanel->RefreshAfterSceneContentUpdate();
   if (refreshViewport) {
     if (viewportPanel) {
       viewportPanel->UpdateScene();


### PR DESCRIPTION
### Motivation
- Layout views and legends remained stale after adding or deleting scene elements because cached render textures were not invalidated, so layouts did not reflect current scene content.

### Description
- Add a new API `LayoutViewerPanel::RefreshAfterSceneContentUpdate()` that invalidates view/legend render caches and requests a rebuild.
- Make `RefreshAfterFixtureSymbolUpdate()` delegate to `RefreshAfterSceneContentUpdate()` to centralize invalidation logic.
- Call `layoutViewerPanel->RefreshAfterSceneContentUpdate()` from `MainWindow::RefreshAfterSceneChange()` after reloading scene tables so layout textures are refreshed when the scene changes.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d23fdd1d088324980d65042ac60cf6)