### PR TITLE
Preload default layout templates for new projects (LayoutDefaultsLoader + UI integration)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/hoistpresetlibrary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/hoist_weight_distribution.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layouts/LayoutCollection.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/layouts/LayoutDefaultsLoader.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layouts/LayoutManager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layouts/LayoutTemplateSerializer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layoutviewpresets.cpp

--- a/core/layouts/LayoutDefaultsLoader.cpp
+++ b/core/layouts/LayoutDefaultsLoader.cpp
@@ -1,0 +1,162 @@
+#include "LayoutDefaultsLoader.h"
+
+#include "LayoutTemplateSerializer.h"
+#include "json.hpp"
+#include "projectutils.h"
+
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+
+namespace layouts {
+namespace {
+namespace fs = std::filesystem;
+
+std::string ToUtf8String(const fs::path &path) {
+  const std::u8string utf8 = path.u8string();
+  return std::string(utf8.begin(), utf8.end());
+}
+
+bool IsJsonTemplateFile(const fs::path &filePath) {
+  if (!filePath.has_extension())
+    return false;
+  std::string ext = filePath.extension().string();
+  std::transform(ext.begin(), ext.end(), ext.begin(), [](unsigned char ch) {
+    return static_cast<char>(std::tolower(ch));
+  });
+  return ext == ".json";
+}
+
+std::string StripResourcesPrefix(const std::string &relativePath) {
+  constexpr const char *kPrefixForward = "resources/";
+  constexpr const char *kPrefixBackward = "resources\\";
+  if (relativePath.rfind(kPrefixForward, 0) == 0)
+    return relativePath.substr(std::char_traits<char>::length(kPrefixForward));
+  if (relativePath.rfind(kPrefixBackward, 0) == 0)
+    return relativePath.substr(std::char_traits<char>::length(kPrefixBackward));
+  return relativePath;
+}
+
+std::string ResolveImagePath(const std::string &rawPath,
+                             const fs::path &templateDir) {
+  if (rawPath.empty())
+    return rawPath;
+
+  fs::path parsedPath = fs::u8path(rawPath);
+  std::error_code ec;
+  if (parsedPath.is_absolute()) {
+    fs::path absolutePath = fs::absolute(parsedPath, ec);
+    if (!ec)
+      return ToUtf8String(absolutePath);
+    return rawPath;
+  }
+
+  auto asAbsoluteIfExists = [](const fs::path &candidate) -> std::string {
+    std::error_code candidateEc;
+    if (!fs::exists(candidate, candidateEc) || candidateEc)
+      return {};
+    fs::path absolutePath = fs::absolute(candidate, candidateEc);
+    if (candidateEc)
+      return {};
+    return ToUtf8String(absolutePath);
+  };
+
+  const fs::path fromTemplate = templateDir / parsedPath;
+  if (std::string resolved = asAbsoluteIfExists(fromTemplate); !resolved.empty())
+    return resolved;
+
+  const fs::path resourceRoot = ProjectUtils::GetResourceRoot();
+  if (!resourceRoot.empty()) {
+    const fs::path fromResourceRoot = resourceRoot / parsedPath;
+    if (std::string resolved = asAbsoluteIfExists(fromResourceRoot);
+        !resolved.empty()) {
+      return resolved;
+    }
+
+    const std::string strippedPath = StripResourcesPrefix(rawPath);
+    if (strippedPath != rawPath) {
+      const fs::path strippedCandidate = resourceRoot / fs::u8path(strippedPath);
+      if (std::string resolved = asAbsoluteIfExists(strippedCandidate);
+          !resolved.empty()) {
+        return resolved;
+      }
+    }
+  }
+
+  return rawPath;
+}
+
+void ResolveLayoutImagePaths(std::vector<LayoutDefinition> &loadedLayouts,
+                             const fs::path &templateDir) {
+  for (auto &layout : loadedLayouts) {
+    for (auto &image : layout.imageViews)
+      image.imagePath = ResolveImagePath(image.imagePath, templateDir);
+  }
+}
+
+} // namespace
+
+LayoutDefaultsLoadResult LoadLayoutDefaultsFromLibrary(
+    const std::string &librarySubdir) {
+  LayoutDefaultsLoadResult result;
+
+  const std::string defaultsDirUtf8 =
+      ProjectUtils::GetDefaultLibraryPath(librarySubdir);
+  if (defaultsDirUtf8.empty())
+    return result;
+
+  std::error_code ec;
+  const fs::path defaultsDir = fs::u8path(defaultsDirUtf8);
+  if (!fs::exists(defaultsDir, ec) || ec || !fs::is_directory(defaultsDir, ec) ||
+      ec) {
+    return result;
+  }
+
+  std::vector<fs::path> templateFiles;
+  for (const auto &entry : fs::directory_iterator(defaultsDir, ec)) {
+    if (ec)
+      break;
+    if (!entry.is_regular_file())
+      continue;
+    if (!IsJsonTemplateFile(entry.path()))
+      continue;
+    templateFiles.push_back(entry.path());
+  }
+  std::sort(templateFiles.begin(), templateFiles.end());
+
+  for (const fs::path &templateFile : templateFiles) {
+    ++result.filesScanned;
+
+    std::ifstream in(templateFile, std::ios::binary);
+    if (!in.is_open())
+      continue;
+
+    const std::string fileContent((std::istreambuf_iterator<char>(in)),
+                                  std::istreambuf_iterator<char>());
+    nlohmann::json parsed;
+    try {
+      parsed = nlohmann::json::parse(fileContent);
+    } catch (...) {
+      continue;
+    }
+
+    std::vector<LayoutDefinition> loadedLayouts;
+    std::string parseError;
+    if (!FromTemplateDocument(parsed, loadedLayouts, &parseError) ||
+        loadedLayouts.empty()) {
+      continue;
+    }
+
+    ResolveLayoutImagePaths(loadedLayouts, templateFile.parent_path());
+    result.filesImported++;
+    result.layouts.insert(result.layouts.end(),
+                          std::make_move_iterator(loadedLayouts.begin()),
+                          std::make_move_iterator(loadedLayouts.end()));
+  }
+
+  return result;
+}
+
+} // namespace layouts

--- a/core/layouts/LayoutDefaultsLoader.h
+++ b/core/layouts/LayoutDefaultsLoader.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "LayoutCollection.h"
+
+#include <string>
+#include <vector>
+
+namespace layouts {
+
+struct LayoutDefaultsLoadResult {
+  std::vector<LayoutDefinition> layouts;
+  int filesScanned = 0;
+  int filesImported = 0;
+};
+
+LayoutDefaultsLoadResult LoadLayoutDefaultsFromLibrary(
+    const std::string &librarySubdir = "default_layouts");
+
+} // namespace layouts

--- a/core/layouts/LayoutManager.cpp
+++ b/core/layouts/LayoutManager.cpp
@@ -17,6 +17,7 @@
  */
 #include "LayoutManager.h"
 
+#include "LayoutDefaultsLoader.h"
 #include "LayoutTemplateSerializer.h"
 #include "configmanager.h"
 #include "json.hpp"
@@ -24,6 +25,7 @@
 #include <algorithm>
 #include <fstream>
 #include <iterator>
+#include <unordered_map>
 #include <unordered_set>
 
 namespace layouts {
@@ -431,6 +433,42 @@ void LayoutManager::SaveToConfig(ConfigManager &cfg) const {
 void LayoutManager::ResetToDefault(ConfigManager &cfg) {
   layouts = LayoutCollection();
   SaveToConfig(cfg);
+}
+
+bool LayoutManager::LoadDefaultsForNewProject(ConfigManager &cfg) {
+  LayoutDefaultsLoadResult loadedDefaults = LoadLayoutDefaultsFromLibrary();
+  if (loadedDefaults.layouts.empty())
+    return false;
+
+  std::unordered_map<std::string, int> suffixByBaseName;
+  std::unordered_set<std::string> usedNames;
+  for (auto &layout : loadedDefaults.layouts) {
+    EnsureUniqueViewIds(layout);
+    EnsureUniqueLegendIds(layout);
+    EnsureUniqueEventTableIds(layout);
+    EnsureUniqueTextIds(layout);
+    EnsureUniqueImageIds(layout);
+
+    std::string baseName = layout.name.empty() ? "Layout" : layout.name;
+    int suffix = suffixByBaseName[baseName];
+    std::string candidate = baseName;
+    if (suffix > 1)
+      candidate = baseName + " (" + std::to_string(suffix) + ")";
+    while (usedNames.count(candidate) > 0) {
+      ++suffix;
+      candidate = baseName + " (" + std::to_string(suffix) + ")";
+    }
+    if (suffix <= 1)
+      suffixByBaseName[baseName] = 2;
+    else
+      suffixByBaseName[baseName] = suffix + 1;
+    usedNames.insert(candidate);
+    layout.name = candidate;
+  }
+
+  layouts.ReplaceAll(std::move(loadedDefaults.layouts));
+  SaveToConfig(cfg);
+  return true;
 }
 
 void LayoutManager::SyncToConfig() {

--- a/core/layouts/LayoutManager.h
+++ b/core/layouts/LayoutManager.h
@@ -68,6 +68,7 @@ public:
   void LoadFromConfig(ConfigManager &cfg);
   void SaveToConfig(ConfigManager &cfg) const;
   void ResetToDefault(ConfigManager &cfg);
+  bool LoadDefaultsForNewProject(ConfigManager &cfg);
 
 private:
   LayoutManager();

--- a/docs/default_layout_templates.md
+++ b/docs/default_layout_templates.md
@@ -1,0 +1,39 @@
+# Default layout templates for new projects
+
+Perastage can preload layout templates when creating a **new** project.
+
+## Folder
+
+Place template files in:
+
+- `library/default_layouts/`
+
+The directory is resolved through `ProjectUtils::GetDefaultLibraryPath("default_layouts")`,
+so packaged defaults can be copied to the user library fallback when needed.
+
+## File format
+
+- One or more `.json` files.
+- Each file must follow the layout template schema consumed by
+  `layouts::FromTemplateDocument(...)`.
+- Files are processed in alphabetical order.
+- Invalid files are ignored; Perastage continues with the remaining files.
+
+If no valid templates are found, Perastage keeps the existing behavior and starts
+with the built-in empty layout.
+
+## Image paths in templates
+
+`imageViews[].path` supports:
+
+1. **Absolute paths** (kept as-is).
+2. **Relative paths to the template file directory**.
+3. **Relative paths to app resources**:
+   - `resources/<file>` (for example `resources/Perastage_logo.png`).
+
+At load time, relative paths are resolved to absolute paths when the file exists.
+
+## Scope
+
+Template loading is only applied when the user uses **New Project**.
+It does not alter loading of existing project files.

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -84,6 +84,7 @@ using json = nlohmann::json;
 #include "gdtfnet.h"
 #include "gdtfsearchdialog.h"
 #include "layout2dviewdialog.h"
+#include "LayoutManager.h"
 #include "layoutviewpresets.h"
 #include "mainwindow_io_controller.h"
 #include "mainwindow_layout_controller.h"
@@ -701,9 +702,12 @@ void MainWindow::LoadStartupProjectFromPath(const std::string &path) {
   SetStartupProjectLoadPending(false);
 }
 
-void MainWindow::ResetProject() {
-  GetDefaultGuiConfigServices().LegacyConfigManager().Reset();
-  GetDefaultGuiConfigServices().LegacyConfigManager().MarkSaved();
+void MainWindow::ResetProject(bool applyLayoutDefaultsForNewProject) {
+  auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+  cfg.Reset();
+  if (applyLayoutDefaultsForNewProject)
+    layouts::LayoutManager::Get().LoadDefaultsForNewProject(cfg);
+  cfg.MarkSaved();
   fixtureSymbolAutoUpdateQueue.clear();
   fixtureSymbolAutoUpdateProcessedKeys.clear();
   fixtureSymbolPendingLibrarySyncUuids.clear();

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -70,7 +70,7 @@ public:
                            bool showBlockingLoadUi = true); // Load given project
   void LoadStartupProjectFromPath(const std::string &path);
   bool OpenPathFromCommandLine(const std::string &path);
-  void ResetProject();                               // Clear current project
+  void ResetProject(bool applyLayoutDefaultsForNewProject = false); // Clear current project
 
   static MainWindow *Instance();
   static void SetInstance(MainWindow *inst);

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -435,7 +435,7 @@ void MainWindow::OnNew(wxCommandEvent &WXUNUSED(event)) {
   if (!ConfirmSaveIfDirty("creating a new project", "New Project"))
     return;
 
-  ResetProject();
+  ResetProject(true);
 }
 
 void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {

--- a/help.md
+++ b/help.md
@@ -14,7 +14,9 @@ Perastage projects (`.pstg`) store the scene, layouts, and user settings.
 
 **File > New / Load / Save / Save As...**
 
-- **New** creates a blank project.
+- **New** creates a new project. If default layout templates are available in
+  `library/default_layouts/`, they are loaded; otherwise Perastage keeps the
+  built-in blank layout.
 - **Load** opens an existing `.pstg` file.
 - **Save** stores changes in the current project file.
 - **Save As...** writes the project under a new name or location.

--- a/library/default_layouts/plan_view.json
+++ b/library/default_layouts/plan_view.json
@@ -1,0 +1,245 @@
+{
+  "schemaVersion": 1,
+  "resources": {
+    "imagePathPolicy": "preserve_original_path"
+  },
+  "layouts": [
+    {
+      "name": "Plan View",
+      "pageSetup": {
+        "pageSize": "A4",
+        "landscape": true
+      },
+      "resources": {
+        "imagePathPolicy": "preserve_original_path"
+      },
+      "view2dViews": [
+        {
+          "id": 1,
+          "zIndex": 0,
+          "drawFrame": true,
+          "frame": {
+            "x": 10,
+            "y": 10,
+            "width": 620,
+            "height": 570
+          },
+          "camera": {
+            "offsetPixelsX": -0.000003000000106112566,
+            "offsetPixelsY": -72.39942169189453,
+            "zoom": 1.610509991645813,
+            "viewportWidth": 620,
+            "viewportHeight": 570,
+            "view": 0
+          },
+          "layers": {
+            "hiddenLayers": [
+              "rig Audio",
+              "rig Lighting"
+            ],
+            "hiddenFixtureTypes": []
+          },
+          "renderOptions": {
+            "renderMode": 2,
+            "darkMode": true,
+            "showGrid": true,
+            "gridStyle": 2,
+            "gridColorR": 0.7529410123825073,
+            "gridColorG": 0.7529410123825073,
+            "gridColorB": 0.7529410123825073,
+            "gridDrawAbove": false,
+            "showRuler": true,
+            "rulerColorR": [
+              0.0,
+              0.0,
+              0.0
+            ],
+            "rulerColorG": [
+              0.5019609928131104,
+              0.5019609928131104,
+              0.0
+            ],
+            "rulerColorB": [
+              1.0,
+              1.0,
+              0.0
+            ],
+            "showLabelName": [
+              true,
+              true,
+              true
+            ],
+            "showLabelId": [
+              true,
+              true,
+              true
+            ],
+            "showLabelDmx": [
+              true,
+              true,
+              true
+            ],
+            "labelFontSizeName": 3.0,
+            "labelFontSizeId": 2.0,
+            "labelFontSizeDmx": 4.0,
+            "labelOffsetDistance": [
+              0.5,
+              0.5,
+              0.5
+            ],
+            "labelOffsetAngle": [
+              180.0,
+              180.0,
+              180.0
+            ],
+            "forceBottomViewForTopFixtures": true
+          }
+        }
+      ],
+      "imageViews": [
+        {
+          "id": 1,
+          "zIndex": 1,
+          "frame": {
+            "x": 705,
+            "y": 15,
+            "width": 65,
+            "height": 65
+          },
+          "path": "resources/Perastage_logo.png",
+          "aspectRatio": 1.0
+        }
+      ],
+      "legendViews": [
+        {
+          "id": 1,
+          "zIndex": 2,
+          "frame": {
+            "x": 640,
+            "y": 85,
+            "width": 195,
+            "height": 215
+          },
+          "showChannelColumn": true,
+          "itemSettings": [
+            {
+              "typeName": "MAC Quantum Profile",
+              "visible": true,
+              "showBottomSymbol": true,
+              "showFrontSymbol": true,
+              "showSideSymbol": false,
+              "customName": ""
+            },
+            {
+              "typeName": "Aleda B-EYE K10",
+              "visible": true,
+              "showBottomSymbol": true,
+              "showFrontSymbol": true,
+              "showSideSymbol": false,
+              "customName": ""
+            },
+            {
+              "typeName": "XBEAM 17 CMY",
+              "visible": true,
+              "showBottomSymbol": true,
+              "showFrontSymbol": true,
+              "showSideSymbol": false,
+              "customName": ""
+            },
+            {
+              "typeName": "BLINDER 4 PRO",
+              "visible": true,
+              "showBottomSymbol": true,
+              "showFrontSymbol": true,
+              "showSideSymbol": false,
+              "customName": ""
+            },
+            {
+              "typeName": "PIXEL STROBE 400 RGB",
+              "visible": true,
+              "showBottomSymbol": true,
+              "showFrontSymbol": true,
+              "showSideSymbol": false,
+              "customName": ""
+            },
+            {
+              "typeName": "PAR PRO 270 5-IN-1",
+              "visible": true,
+              "showBottomSymbol": true,
+              "showFrontSymbol": true,
+              "showSideSymbol": false,
+              "customName": ""
+            },
+            {
+              "typeName": "Tour Hazer II",
+              "visible": true,
+              "showBottomSymbol": true,
+              "showFrontSymbol": true,
+              "showSideSymbol": false,
+              "customName": ""
+            },
+            {
+              "typeName": "theFAN",
+              "visible": true,
+              "showBottomSymbol": true,
+              "showFrontSymbol": true,
+              "showSideSymbol": false,
+              "customName": "Turbine"
+            }
+          ]
+        }
+      ],
+      "textViews": [
+        {
+          "id": 1,
+          "zIndex": 3,
+          "frame": {
+            "x": 10,
+            "y": 15,
+            "width": 240,
+            "height": 30
+          },
+          "text": "PLAN VIEW",
+          "richText": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<richtext version=\"1.0.0.0\" xmlns=\"http://www.wxwidgets.org\">\n  <paragraphlayout textcolor=\"#FFFFFF\">\n    <paragraph>\n      <text textcolor=\"#000000\" fontpointsize=\"15\" fontweight=\"700\">P</text>\n      <text textcolor=\"#FFFFFF\" fontpointsize=\"15\" fontweight=\"700\">LAN VIEW</text>\n    </paragraph>\n  </paragraphlayout>\n</richtext>\n",
+          "solidBackground": false,
+          "drawFrame": false
+        },
+        {
+          "id": 2,
+          "zIndex": 5,
+          "frame": {
+            "x": 680,
+            "y": 565,
+            "width": 160,
+            "height": 25
+          },
+          "text": "www.luismaperamato.com",
+          "richText": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<richtext version=\"1.0.0.0\" xmlns=\"http://www.wxwidgets.org\">\n  <paragraphlayout textcolor=\"#FFFFFF\">\n    <paragraph alignment=\"3\">\n      <text textcolor=\"#000000\" fontstyle=\"93\" fontweight=\"400\">w</text>\n      <text textcolor=\"#FFFFFF\" fontstyle=\"93\" fontweight=\"400\">ww.luismaperamato.com</text>\n    </paragraph>\n  </paragraphlayout>\n</richtext>\n",
+          "solidBackground": false,
+          "drawFrame": false
+        }
+      ],
+      "eventTables": [
+        {
+          "id": 1,
+          "zIndex": 4,
+          "frame": {
+            "x": 640,
+            "y": 445,
+            "width": 195,
+            "height": 120
+          },
+          "fields": {
+            "venue": "",
+            "location": "",
+            "date": "",
+            "stage": "",
+            "version": "",
+            "design": "",
+            "mail": ""
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Allow creating a new project prepopulated with user-packaged layout templates stored in the library instead of always starting with a blank layout.
- Provide a robust loader that can import multiple JSON templates from `library/default_layouts/` and resolve image paths against the template directory and app resources.

### Description
- Add `layouts::LoadLayoutDefaultsFromLibrary` implemented in `LayoutDefaultsLoader.cpp` with image path resolution (`ResolveImagePath`) and JSON template discovery/validation logic, and expose `LayoutDefaultsLoadResult` in `LayoutDefaultsLoader.h`.
- Add `LayoutManager::LoadDefaultsForNewProject` which applies unique IDs/names to imported layouts, replaces the current collection and persists to config; declare the method in `LayoutManager.h` and implement it in `LayoutManager.cpp`.
- Integrate the new defaults flow into the UI by adding an optional parameter to `MainWindow::ResetProject` and calling `ResetProject(true)` from the New Project action, and include `LayoutManager.h` where needed.
- Include a sample default template `library/default_layouts/plan_view.json`, add usage documentation `docs/default_layout_templates.md`, and wire the new source file into `core/CMakeLists.txt`.

### Testing
- Configured and built the project with `cmake` and `cmake --build` successfully.
- Ran the automated test suite with `ctest` and observed no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2380f868483249f9088277d1e013a)