### PR TITLE
Fix missing LayoutDefaultsLoader linkage in layout test executables

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -113,6 +113,7 @@ add_executable(layout_template_import_name_collision_test
                layout_template_import_name_collision_test.cpp
                configmanager_layoutmanager_stub.cpp
                ../core/layouts/LayoutManager.cpp
+               ../core/layouts/LayoutDefaultsLoader.cpp
                ../core/layouts/LayoutCollection.cpp
                ../core/layouts/LayoutTemplateSerializer.cpp)
 add_test(NAME LayoutTemplateImportNameCollision
@@ -124,6 +125,7 @@ endfunction()
 
 set(LAYOUT_SOURCES
     ../core/layouts/LayoutManager.cpp
+    ../core/layouts/LayoutDefaultsLoader.cpp
     ../core/layouts/LayoutCollection.cpp
     ../core/layouts/LayoutTemplateSerializer.cpp)
 


### PR DESCRIPTION
### Motivation
- Ensure tests that compile `LayoutManager.cpp` directly also link the implementation of `LoadLayoutDefaultsFromLibrary` to avoid unresolved external linker errors on Windows.

### Description
- Add `../core/layouts/LayoutDefaultsLoader.cpp` to the `layout_template_import_name_collision_test` target and to the shared `LAYOUT_SOURCES` so test executables compile/link the defaults loader implementation.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed; ran `tests/check_no_configmanager_get_in_gui.sh` which passed; attempted to configure the full test build with CMake but the environment is missing the `wxWidgets` development packages so a full build could not be completed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d24d6cdf848324879573a9c0f929d1)