### PR TITLE
Fix link errors in layout_template_import_name_collision_test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -114,6 +114,7 @@ add_executable(layout_template_import_name_collision_test
                configmanager_layoutmanager_stub.cpp
                ../core/layouts/LayoutManager.cpp
                ../core/layouts/LayoutDefaultsLoader.cpp
+               ../core/projectutils.cpp
                ../core/layouts/LayoutCollection.cpp
                ../core/layouts/LayoutTemplateSerializer.cpp)
 add_test(NAME LayoutTemplateImportNameCollision

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -835,6 +835,10 @@ add_executable(symbol_fixture_applier_gdtf_test symbol_fixture_applier_gdtf_test
                ../core/gdtf_mutation_audit.cpp
                ../core/projectutils.cpp
                ../core/uuidutils.cpp
+               ../core/trussdictionary.cpp
+               ../core/trussloader.cpp
+               ../core/truss_gdtf_builder.cpp
+               ../core/dummyprofilelibrary.cpp
                ../core/logger.cpp
                ../models/mvrscene.cpp
                ../models/fixture.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -787,6 +787,7 @@ set_library_env(RiderImportBenchmark)
 
 add_executable(gdtfloader_primitive_test gdtfloader_primitive_test.cpp
                ../viewer3d/gdtfloader.cpp
+               ../core/gdtf_mutation_audit.cpp
                ../viewer3d/loader3ds.cpp
                ../viewer3d/loaderglb.cpp
                ../viewer3d/meshprimitives.cpp
@@ -799,6 +800,7 @@ set_library_env(GdtfLoaderPrimitiveFallback)
 
 add_executable(gdtfloader_channel_modes_test gdtfloader_channel_modes_test.cpp
                ../viewer3d/gdtfloader.cpp
+               ../core/gdtf_mutation_audit.cpp
                ../viewer3d/loader3ds.cpp
                ../viewer3d/loaderglb.cpp
                ../viewer3d/meshprimitives.cpp
@@ -811,6 +813,7 @@ set_library_env(GdtfLoaderChannelModeSummaries)
 
 add_executable(gdtfloader_set_properties_test gdtfloader_set_properties_test.cpp
                ../viewer3d/gdtfloader.cpp
+               ../core/gdtf_mutation_audit.cpp
                ../viewer3d/loader3ds.cpp
                ../viewer3d/loaderglb.cpp
                ../viewer3d/meshprimitives.cpp
@@ -829,6 +832,7 @@ add_executable(symbol_fixture_applier_gdtf_test symbol_fixture_applier_gdtf_test
                ../core/guiconfigservices.cpp
                ../core/gdtfdictionary.cpp
                ../core/gdtf_fixture_category.cpp
+               ../core/gdtf_mutation_audit.cpp
                ../core/projectutils.cpp
                ../core/uuidutils.cpp
                ../core/logger.cpp
@@ -841,7 +845,10 @@ add_executable(symbol_fixture_applier_gdtf_test symbol_fixture_applier_gdtf_test
                ../viewer3d/loader3ds.cpp
                ../viewer3d/loaderglb.cpp
                ../viewer3d/meshprimitives.cpp
-               consolepanel_stub.cpp)
+               ../mvr/mvrimporter.cpp
+               ../mvr/mvrexporter.cpp
+               consolepanel_stub.cpp
+               ${LAYOUT_SOURCES})
 target_include_directories(symbol_fixture_applier_gdtf_test PRIVATE
                            . .. ../core ../models ../gui ../viewer3d ../third_party)
 target_link_libraries(symbol_fixture_applier_gdtf_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
@@ -855,6 +862,7 @@ add_executable(mvr_patched_gdtf_export_test mvr_patched_gdtf_export_test.cpp
                ../core/projectutils.cpp
                ../core/gdtfdictionary.cpp
                ../core/gdtf_fixture_category.cpp
+               ../core/gdtf_mutation_audit.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp
                ../core/truss_gdtf_builder.cpp
@@ -870,7 +878,9 @@ add_executable(mvr_patched_gdtf_export_test mvr_patched_gdtf_export_test.cpp
                ../viewer3d/loader3ds.cpp
                ../viewer3d/loaderglb.cpp
                ../viewer3d/meshprimitives.cpp
-               consolepanel_stub.cpp)
+               ../mvr/mvrimporter.cpp
+               consolepanel_stub.cpp
+               ${LAYOUT_SOURCES})
 target_include_directories(mvr_patched_gdtf_export_test PRIVATE
                            . .. ../core ../models ../mvr ../gui ../viewer3d ../third_party)
 target_link_libraries(mvr_patched_gdtf_export_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -117,6 +117,8 @@ add_executable(layout_template_import_name_collision_test
                ../core/projectutils.cpp
                ../core/layouts/LayoutCollection.cpp
                ../core/layouts/LayoutTemplateSerializer.cpp)
+target_link_libraries(layout_template_import_name_collision_test
+                      PRIVATE ${wxWidgets_LIBRARIES})
 add_test(NAME LayoutTemplateImportNameCollision
          COMMAND layout_template_import_name_collision_test)
 


### PR DESCRIPTION
### Motivation
- The `layout_template_import_name_collision_test` target failed to link due to unresolved symbols from `ProjectUtils` used by `LayoutDefaultsLoader.cpp`, so the test executable needs `projectutils` compilation unit included.

### Description
- Added `../core/projectutils.cpp` to the source list for the `layout_template_import_name_collision_test` target in `tests/CMakeLists.txt`, which provides `ProjectUtils::GetResourceRoot()` and `ProjectUtils::GetDefaultLibraryPath(...)` needed by `LayoutDefaultsLoader.cpp`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed; ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d24e2330ac8324948229ab033bc60a)