### PR TITLE
Stamp Perastage mutation-audit Revision when applying fixture symbols

### DIFF
--- a/gui/windows/symbol_fixture_applier.cpp
+++ b/gui/windows/symbol_fixture_applier.cpp
@@ -357,14 +357,64 @@ bool PatchDescriptionXml(const std::string &xml,
   setOffsets(sidePath.c_str(), "SVGSideOffsetX", "SVGSideOffsetY");
   setOffsets(frontPath.c_str(), "SVGFrontOffsetX", "SVGFrontOffsetY");
 
+  tinyxml2::XMLPrinter printer;
+  doc.Print(&printer);
+  updatedXml = printer.CStr();
+  return true;
+}
+
+std::string BuildSymbolRevisionAction(
+    const std::unordered_map<std::string, SymbolPayload> &payloads,
+    const std::string &topPath,
+    const std::string &sidePath,
+    const std::string &frontPath,
+    const std::string &bottomPath) {
+  std::vector<std::string> appliedViews;
+  auto appendIfApplied = [&](const std::string &path, const char *label) {
+    if (payloads.find(path) != payloads.end())
+      appliedViews.emplace_back(label);
+  };
+
+  appendIfApplied(topPath, "top");
+  appendIfApplied(sidePath, "side");
+  appendIfApplied(frontPath, "front");
+  appendIfApplied(bottomPath, "bottom");
+
+  std::ostringstream action;
+  action << "Applied fixture SVG symbol views (";
+  for (size_t i = 0; i < appliedViews.size(); ++i) {
+    if (i > 0)
+      action << ", ";
+    action << appliedViews[i];
+  }
+  action << ")";
+  return action.str();
+}
+
+bool AppendMutationAuditMetadata(std::string &descriptionXml,
+                                 const std::unordered_map<std::string, SymbolPayload> &payloads,
+                                 const std::string &topPath,
+                                 const std::string &sidePath,
+                                 const std::string &frontPath,
+                                 const std::string &bottomPath,
+                                 std::string &errorMessage) {
+  tinyxml2::XMLDocument doc;
+  if (doc.Parse(descriptionXml.c_str(), descriptionXml.size()) !=
+      tinyxml2::XML_SUCCESS) {
+    errorMessage = "Could not parse description.xml from the GDTF file.";
+    return false;
+  }
+
+  tinyxml2::XMLElement *fixtureType = GdtfMutationAudit::EnsureFixtureType(doc);
   GdtfMutationAudit::StampPerastageMutationMetadata(fixtureType, doc);
   GdtfMutationAudit::AppendRevision(
-      fixtureType, doc, "Updated fixture SVG symbol views from Perastage",
+      fixtureType, doc,
+      BuildSymbolRevisionAction(payloads, topPath, sidePath, frontPath, bottomPath),
       GdtfMutationAudit::BuildPerastageModifiedBy());
 
   tinyxml2::XMLPrinter printer;
   doc.Print(&printer);
-  updatedXml = printer.CStr();
+  descriptionXml = printer.CStr();
   return true;
 }
 
@@ -402,6 +452,7 @@ bool RewriteGdtf(const fs::path &sourcePath,
                  const std::string &topPath,
                  const std::string &sidePath,
                  const std::string &frontPath,
+                 const std::string &bottomPath,
                  std::string &errorMessage) {
   std::vector<std::pair<std::string, std::string>> entries;
   std::vector<std::string> sampleEntries;
@@ -445,6 +496,10 @@ bool RewriteGdtf(const fs::path &sourcePath,
   std::string updatedDescription;
   if (!PatchDescriptionXml(descriptionIt->second, payloads, topPath, sidePath,
                            frontPath, updatedDescription, errorMessage)) {
+    return false;
+  }
+  if (!AppendMutationAuditMetadata(updatedDescription, payloads, topPath, sidePath,
+                                   frontPath, bottomPath, errorMessage)) {
     return false;
   }
 
@@ -575,7 +630,7 @@ bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
 
   if (options.updateSceneCopy && !scenePath.empty()) {
     if (!RewriteGdtf(scenePath, payloads, topSvgPath, sideSvgPath, frontSvgPath,
-                     errorMessage)) {
+                     bottomSvgPath, errorMessage)) {
       return false;
     }
   }
@@ -584,7 +639,7 @@ bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
     const bool libraryEqualsScene = !scenePath.empty() && libraryPath == scenePath;
     if (!libraryEqualsScene &&
         !RewriteGdtf(libraryPath, payloads, topSvgPath, sideSvgPath, frontSvgPath,
-                     errorMessage)) {
+                     bottomSvgPath, errorMessage)) {
       return false;
     }
   }

--- a/tests/symbol_fixture_applier_gdtf_test.cpp
+++ b/tests/symbol_fixture_applier_gdtf_test.cpp
@@ -15,6 +15,7 @@
 #include <wx/zipstrm.h>
 
 #include "../core/configmanager.h"
+#include "../core/gdtf_mutation_audit.h"
 #include "../core/symbols/Symbol2D.h"
 #include "../gui/windows/symbol_fixture_applier.h"
 #include "../models/fixture.h"
@@ -150,7 +151,23 @@ int main() {
   const bool hasRevision =
       fixtureType->FirstChildElement("Revisions") != nullptr &&
       fixtureType->FirstChildElement("Revisions")->FirstChildElement("Revision") != nullptr;
-  assert(!hasRevision);
+  assert(hasRevision);
+
+  tinyxml2::XMLElement *audit = fixtureType->FirstChildElement("PerastageMutationAudit");
+  assert(audit != nullptr);
+  assert(audit->IntAttribute("SchemaVersion") ==
+         GdtfMutationAudit::kPerastageGdtfMutationSchemaVersion);
+
+  tinyxml2::XMLElement *revision =
+      fixtureType->FirstChildElement("Revisions")->FirstChildElement("Revision");
+  assert(revision != nullptr);
+  const char *text = revision->Attribute("Text");
+  const char *modifiedBy = revision->Attribute("ModifiedBy");
+  assert(text != nullptr);
+  assert(modifiedBy != nullptr);
+  assert(std::string(text) ==
+         "Applied fixture SVG symbol views (top, side, front)");
+  assert(std::string(modifiedBy).rfind("Perastage ", 0) == 0);
 
   symbol_preview::FixtureSymbolInspectionResult after{};
   assert(symbol_preview::InspectFixtureSymbolState(scene.fixtures.at(fixture.uuid), scene,


### PR DESCRIPTION
### Motivation

- Ensure symbol application is auditable inside GDTF archives by recording which SVG views were applied and stamping Perastage mutation-audit metadata without weakening existing XML validation.

### Description

- Added `BuildSymbolRevisionAction` and `AppendMutationAuditMetadata` in `gui/windows/symbol_fixture_applier.cpp` to create a revision text listing applied views and to stamp `PerastageMutationAudit` metadata after `PatchDescriptionXml` and before writing the final zip.
- Kept the strict `PatchDescriptionXml` validation flow unchanged and preserved `Editor="Perastage"` behaviour while adding explicit revision entries for traceability.
- Extended `RewriteGdtf` signatures and call sites to accept a `bottom` symbol path so the revision/action text includes `bottom` when present. 
- Updated `tests/symbol_fixture_applier_gdtf_test.cpp` to assert presence of a `Revision`, presence of `PerastageMutationAudit`, correct `SchemaVersion`, and expected `Revision` text and `ModifiedBy` metadata.

### Testing

- Updated integration test `tests/symbol_fixture_applier_gdtf_test.cpp` to validate the new audit metadata assertions (test source edited, not executed in this environment). 
- Ran mandatory repository checks `bash tests/check_perastage_tree_modules.sh` and `bash tests/check_no_configmanager_get_in_gui.sh`, both succeeded. 
- Attempted `cmake --preset wsl-x64-debug` in this environment which failed due to missing `wxWidgets` development packages, so full build/test execution was not possible here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d253bf689c8324810eaee8944e8863)