### PR TITLE
Refactor fixture XML patching to shared mutation-audit helpers

### DIFF
--- a/core/gdtf_mutation_audit.cpp
+++ b/core/gdtf_mutation_audit.cpp
@@ -113,4 +113,75 @@ void StampPerastageMutationMetadata(tinyxml2::XMLElement *fixtureType,
   auditNode->SetAttribute("LastMutationDateUtc", BuildIsoTimestampUtcNow().c_str());
 }
 
+tinyxml2::XMLElement *EnsurePhysicalPropertiesNode(
+    tinyxml2::XMLElement *fixtureType, tinyxml2::XMLDocument &doc) {
+  if (!fixtureType)
+    return nullptr;
+
+  tinyxml2::XMLElement *physicalDescriptions =
+      fixtureType->FirstChildElement("PhysicalDescriptions");
+  if (!physicalDescriptions) {
+    physicalDescriptions = doc.NewElement("PhysicalDescriptions");
+    fixtureType->InsertEndChild(physicalDescriptions);
+  }
+
+  tinyxml2::XMLElement *properties =
+      physicalDescriptions->FirstChildElement("Properties");
+  if (!properties) {
+    properties = doc.NewElement("Properties");
+    physicalDescriptions->InsertEndChild(properties);
+  }
+  return properties;
+}
+
+bool ApplyPhysicalProperties(tinyxml2::XMLElement *fixtureType,
+                             tinyxml2::XMLDocument &doc,
+                             const std::optional<float> &weightKg,
+                             const std::optional<float> &powerConsumptionW) {
+  if (!fixtureType)
+    return false;
+
+  if (!weightKg.has_value() && !powerConsumptionW.has_value())
+    return false;
+
+  tinyxml2::XMLElement *properties = EnsurePhysicalPropertiesNode(fixtureType, doc);
+  if (!properties)
+    return false;
+
+  bool mutated = false;
+  if (weightKg.has_value()) {
+    tinyxml2::XMLElement *weightNode = properties->FirstChildElement("Weight");
+    if (!weightNode)
+      weightNode = properties->InsertNewChildElement("Weight");
+    weightNode->SetAttribute("Value", *weightKg);
+    mutated = true;
+  }
+
+  if (powerConsumptionW.has_value()) {
+    tinyxml2::XMLElement *powerNode =
+        properties->FirstChildElement("PowerConsumption");
+    if (!powerNode)
+      powerNode = properties->InsertNewChildElement("PowerConsumption");
+    powerNode->SetAttribute("Value", *powerConsumptionW);
+    mutated = true;
+  }
+
+  return mutated;
+}
+
+bool ApplyPhysicalPropertiesWithAudit(
+    tinyxml2::XMLElement *fixtureType, tinyxml2::XMLDocument &doc,
+    const std::optional<float> &weightKg,
+    const std::optional<float> &powerConsumptionW, const std::string &revisionText,
+    const std::string &modifiedBy) {
+  const bool mutated =
+      ApplyPhysicalProperties(fixtureType, doc, weightKg, powerConsumptionW);
+  if (!mutated)
+    return false;
+
+  StampPerastageMutationMetadata(fixtureType, doc);
+  AppendRevision(fixtureType, doc, revisionText, modifiedBy);
+  return true;
+}
+
 } // namespace GdtfMutationAudit

--- a/core/gdtf_mutation_audit.h
+++ b/core/gdtf_mutation_audit.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <string>
 
 #include <tinyxml2.h>
@@ -38,5 +39,27 @@ void AppendRevision(tinyxml2::XMLElement *fixtureType,
 // Editor="Perastage". Metadata is stored in <PerastageMutationAudit>.
 void StampPerastageMutationMetadata(tinyxml2::XMLElement *fixtureType,
                                     tinyxml2::XMLDocument &doc);
+
+// Returns the <Properties> node under
+// <FixtureType>/<PhysicalDescriptions>/<Properties>, creating missing nodes.
+tinyxml2::XMLElement *EnsurePhysicalPropertiesNode(
+    tinyxml2::XMLElement *fixtureType, tinyxml2::XMLDocument &doc);
+
+// Applies Weight/PowerConsumption values under PhysicalDescriptions/Properties.
+// Only values provided through optionals are written.
+// Returns true when at least one property was written.
+bool ApplyPhysicalProperties(
+    tinyxml2::XMLElement *fixtureType, tinyxml2::XMLDocument &doc,
+    const std::optional<float> &weightKg,
+    const std::optional<float> &powerConsumptionW);
+
+// Applies physical properties and, when a mutation happened, stamps Perastage
+// mutation metadata and appends a revision.
+// Returns true when at least one property was written.
+bool ApplyPhysicalPropertiesWithAudit(
+    tinyxml2::XMLElement *fixtureType, tinyxml2::XMLDocument &doc,
+    const std::optional<float> &weightKg,
+    const std::optional<float> &powerConsumptionW, const std::string &revisionText,
+    const std::string &modifiedBy = "");
 
 } // namespace GdtfMutationAudit

--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -23,6 +23,7 @@
 #include <fstream>
 #include <functional>
 #include <map>
+#include <optional>
 #include <set>
 #include <string>
 #include <vector>
@@ -533,39 +534,17 @@ void MainWindow::OnExportFixture(wxCommandEvent &WXUNUSED(event)) {
     return;
   }
 
-  tinyxml2::XMLElement *phys = ft->FirstChildElement("PhysicalDescriptions");
-  if (!phys)
-    phys =
-        ft->InsertEndChild(doc.NewElement("PhysicalDescriptions"))->ToElement();
-  tinyxml2::XMLElement *props = phys->FirstChildElement("Properties");
-  if (!props)
-    props = phys->InsertEndChild(doc.NewElement("Properties"))->ToElement();
-
-  bool mutated = false;
-  if (chosen->weightKg != 0.0f) {
-    tinyxml2::XMLElement *w = props->FirstChildElement("Weight");
-    if (!w)
-      w = props->InsertEndChild(doc.NewElement("Weight"))->ToElement();
-    w->SetAttribute("Value", chosen->weightKg);
-    mutated = true;
-  }
-
-  if (chosen->powerConsumptionW != 0.0f) {
-    tinyxml2::XMLElement *pc = props->FirstChildElement("PowerConsumption");
-    if (!pc)
-      pc = props->InsertEndChild(doc.NewElement("PowerConsumption"))
-               ->ToElement();
-    pc->SetAttribute("Value", chosen->powerConsumptionW);
-    mutated = true;
-  }
-
-  if (mutated) {
-    GdtfMutationAudit::StampPerastageMutationMetadata(ft, doc);
-    GdtfMutationAudit::AppendRevision(
-        ft, doc,
-        "Exported fixture with updated physical properties from Perastage",
-        GdtfMutationAudit::BuildPerastageModifiedBy());
-  }
+  const std::optional<float> weightKg =
+      (chosen->weightKg != 0.0f) ? std::optional<float>(chosen->weightKg)
+                                 : std::nullopt;
+  const std::optional<float> powerConsumptionW =
+      (chosen->powerConsumptionW != 0.0f)
+          ? std::optional<float>(chosen->powerConsumptionW)
+          : std::nullopt;
+  GdtfMutationAudit::ApplyPhysicalPropertiesWithAudit(
+      ft, doc, weightKg, powerConsumptionW,
+      "Exported fixture with updated physical properties from Perastage",
+      GdtfMutationAudit::BuildPerastageModifiedBy());
 
   doc.SaveFile(descPath.string().c_str());
 

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -18,6 +18,7 @@
 #include "mvrexporter.h"
 #include "configmanager.h"
 #include "dummyprofilelibrary.h"
+#include "gdtf_mutation_audit.h"
 #include "logger.h"
 #include "matrixutils.h"
 #include "projectutils.h"
@@ -49,6 +50,7 @@ class wxZipStreamLink;
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <optional>
 
 namespace fs = std::filesystem;
 
@@ -1082,6 +1084,7 @@ static std::string CreatePatchedGdtf(const std::string &gdtfPath,
     ft = doc.FirstChildElement("FixtureType");
   if (!ft)
     return {};
+  bool patched = false;
   if (!ov.color.empty()) {
     tinyxml2::XMLElement *models = ft->FirstChildElement("Models");
     if (models) {
@@ -1089,32 +1092,24 @@ static std::string CreatePatchedGdtf(const std::string &gdtfPath,
       for (tinyxml2::XMLElement *m = models->FirstChildElement("Model"); m;
            m = m->NextSiblingElement("Model"))
         m->SetAttribute("Color", cie.c_str());
+      patched = true;
     }
   }
-  if (ov.hasWeightKg || ov.hasPowerW) {
-    tinyxml2::XMLElement *phys = ft->FirstChildElement("PhysicalDescriptions");
-    if (!phys)
-      phys = ft->InsertNewChildElement("PhysicalDescriptions");
-    tinyxml2::XMLElement *props = phys->FirstChildElement("Properties");
-    if (!props)
-      props = phys->InsertNewChildElement("Properties");
-    if (ov.hasWeightKg) {
-      tinyxml2::XMLElement *w = props->FirstChildElement("Weight");
-      if (!w)
-        w = props->InsertNewChildElement("Weight");
-      w->SetAttribute("Value", ov.weightKg);
-    }
-    if (ov.hasPowerW) {
-      tinyxml2::XMLElement *p = props->FirstChildElement("PowerConsumption");
-      if (!p)
-        p = props->InsertNewChildElement("PowerConsumption");
-      p->SetAttribute("Value", ov.powerW);
-    }
-  }
-  if (!ov.manufacturer.empty())
+  const std::optional<float> weightKg =
+      ov.hasWeightKg ? std::optional<float>(ov.weightKg) : std::nullopt;
+  const std::optional<float> powerW =
+      ov.hasPowerW ? std::optional<float>(ov.powerW) : std::nullopt;
+  patched = GdtfMutationAudit::ApplyPhysicalProperties(
+                ft, doc, weightKg, powerW) ||
+            patched;
+  if (!ov.manufacturer.empty()) {
     ft->SetAttribute("Manufacturer", ov.manufacturer.c_str());
-  if (!ov.model.empty())
+    patched = true;
+  }
+  if (!ov.model.empty()) {
     ft->SetAttribute("Name", ov.model.c_str());
+    patched = true;
+  }
 
   if (ov.hasLengthMm || ov.hasWidthMm || ov.hasHeightMm) {
     tinyxml2::XMLElement *models = ft->FirstChildElement("Models");
@@ -1130,6 +1125,14 @@ static std::string CreatePatchedGdtf(const std::string &gdtfPath,
       model->SetAttribute("Width", ov.widthMm / 1000.0f);
     if (ov.hasHeightMm)
       model->SetAttribute("Height", ov.heightMm / 1000.0f);
+    patched = true;
+  }
+
+  if (patched) {
+    GdtfMutationAudit::StampPerastageMutationMetadata(ft, doc);
+    GdtfMutationAudit::AppendRevision(
+        ft, doc, "Patched fixture metadata for MVR export",
+        GdtfMutationAudit::BuildPerastageModifiedBy());
   }
 
   doc.SaveFile(descPath.c_str());

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -177,6 +177,7 @@ add_executable(save_load_roundtrip_test save_load_roundtrip_test.cpp
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
                ../mvr/mvrexporter.cpp
+               ../core/gdtf_mutation_audit.cpp
                ../core/logger.cpp
                gdtfloader_stub.cpp
                consolepanel_stub.cpp
@@ -206,6 +207,7 @@ add_executable(project_support_userdata_roundtrip_test project_support_userdata_
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
                ../mvr/mvrexporter.cpp
+               ../core/gdtf_mutation_audit.cpp
                ../core/logger.cpp
                gdtfloader_stub.cpp
                consolepanel_stub.cpp
@@ -258,6 +260,7 @@ add_executable(rider_truss_dictionary_normalization_test
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
                ../mvr/mvrexporter.cpp
+               ../core/gdtf_mutation_audit.cpp
                ../core/logger.cpp
                ../models/mvrscene.cpp
                ../models/fixture.cpp
@@ -272,6 +275,7 @@ add_test(NAME RiderTrussDictionaryNormalization COMMAND rider_truss_dictionary_n
 
 add_executable(mvr_dmx_address_test mvr_dmx_address_test.cpp
                ../mvr/mvrexporter.cpp
+               ../core/gdtf_mutation_audit.cpp
                ../core/configmanager.cpp
                ../core/configservices.cpp
                ../core/projectutils.cpp
@@ -313,6 +317,7 @@ add_executable(mvr_support_userdata_roundtrip_test mvr_support_userdata_roundtri
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
                ../mvr/mvrexporter.cpp
+               ../core/gdtf_mutation_audit.cpp
                ../core/logger.cpp
                gdtfloader_stub.cpp
                consolepanel_stub.cpp
@@ -343,6 +348,7 @@ add_executable(mvr_fixture_category_roundtrip_test mvr_fixture_category_roundtri
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
                ../mvr/mvrexporter.cpp
+               ../core/gdtf_mutation_audit.cpp
                ../core/logger.cpp
                gdtfloader_stub.cpp
                consolepanel_stub.cpp
@@ -372,6 +378,7 @@ add_executable(mvr_truss_roundtrip_structure_test mvr_truss_roundtrip_structure_
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
                ../mvr/mvrexporter.cpp
+               ../core/gdtf_mutation_audit.cpp
                ../core/logger.cpp
                gdtfloader_stub.cpp
                consolepanel_stub.cpp
@@ -401,6 +408,7 @@ add_executable(mvr_exporter_compliance_test mvr_exporter_compliance_test.cpp
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
                ../mvr/mvrexporter.cpp
+               ../core/gdtf_mutation_audit.cpp
                ../core/logger.cpp
                gdtfloader_stub.cpp
                consolepanel_stub.cpp
@@ -438,6 +446,7 @@ add_executable(rider_save_roundtrip_test rider_save_roundtrip_test.cpp
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
                ../mvr/mvrexporter.cpp
+               ../core/gdtf_mutation_audit.cpp
                ../core/logger.cpp
                ../models/mvrscene.cpp
                ../models/fixture.cpp
@@ -864,6 +873,7 @@ add_executable(symbol_fixture_applier_gdtf_test symbol_fixture_applier_gdtf_test
                ../viewer3d/meshprimitives.cpp
                ../mvr/mvrimporter.cpp
                ../mvr/mvrexporter.cpp
+               ../core/gdtf_mutation_audit.cpp
                consolepanel_stub.cpp
                ${LAYOUT_SOURCES})
 target_include_directories(symbol_fixture_applier_gdtf_test PRIVATE


### PR DESCRIPTION
### Motivation
- Remove duplicated `description.xml` mutation logic and centralize Perastage audit/revision stamping for GDTF mutations to improve traceability and reduce code duplication.
- Ensure MVR-side GDTF patching and GUI export behavior use the same, auditable path without changing exported fields or consumer-visible output.

### Description
- Added helpers in `core/gdtf_mutation_audit`: `EnsurePhysicalPropertiesNode`, `ApplyPhysicalProperties`, and `ApplyPhysicalPropertiesWithAudit` to manage `PhysicalDescriptions/Properties` creation, write `Weight`/`PowerConsumption`, and optionally stamp mutation audit + append a revision using `AppendRevision`/`StampPerastageMutationMetadata`.
- Replaced manual `description.xml` edits in `MainWindow::OnExportFixture` with a call to `GdtfMutationAudit::ApplyPhysicalPropertiesWithAudit` so GUI export uses the shared helper while preserving the same non-zero-only semantics.
- Updated `mvr::CreatePatchedGdtf` to call `GdtfMutationAudit::ApplyPhysicalProperties` for weight/power, detect when any patch (color/physical/dimensions/identity) occurred, and append formal Perastage mutation metadata + a revision when patches were applied.
- Kept final export behavior unchanged (same fields written into resulting GDTF), only unified traceability/version stamping through the central helper.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed (OK).
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d254bba67c8324b423b2ac1b79c6ec)