### PR TITLE
Fix Linux build breakages in core GDTF and PDF parsing

### DIFF
--- a/core/gdtf_fixture_category.cpp
+++ b/core/gdtf_fixture_category.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cctype>
 #include <limits>
+#include <memory>
 #include <set>
 #include <sstream>
 #include <string>

--- a/core/pdftext.cpp
+++ b/core/pdftext.cpp
@@ -30,6 +30,7 @@ using namespace PoDoFo;
 
 namespace {
 
+#if PODOFO_VERSION >= PODOFO_MAKE_VERSION(0, 10, 0)
 void AppendEntriesToText(const std::vector<PdfTextEntry> &entries,
                          std::string &out) {
   double lastY = std::numeric_limits<double>::quiet_NaN();
@@ -51,6 +52,7 @@ void AppendEntriesToText(const std::vector<PdfTextEntry> &entries,
     lastX = right;
   }
 }
+#endif
 
 } // namespace
 


### PR DESCRIPTION
### Motivation
- Linux builds were failing due to missing `<memory>` usage for `std::unique_ptr` and references to `PdfTextEntry` when compiling against older PoDoFo versions, so the code must be adjusted to remain cross-platform.

### Description
- Added `#include <memory>` to `core/gdtf_fixture_category.cpp` so `std::unique_ptr<wxZipEntry>` compiles with GCC/Clang.
- Wrapped `AppendEntriesToText` in `core/pdftext.cpp` with `#if PODOFO_VERSION >= PODOFO_MAKE_VERSION(0, 10, 0)` to avoid referencing `PdfTextEntry` when the PoDoFo 0.10+ API is not available.
- Changes keep runtime behavior for supported PoDoFo versions unchanged and are limited to small, local fixes in the two files.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.
- Attempted a full CMake build with `cmake -S . -B build/linux-release -DCMAKE_BUILD_TYPE=Release && cmake --build build/linux-release --parallel 8`, but configuration failed due to missing system `wxWidgets` development packages (`find_package(wxWidgets)` could not locate `wxWidgets_LIBRARIES`/`wxWidgets_INCLUDE_DIRS`), so a full build could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2551f55d48324a20cfa7e8705946e)