### PR TITLE
GDTF mutation-metadata compatibility policy for symbol inspection and loading

### DIFF
--- a/core/gdtf_mutation_audit.cpp
+++ b/core/gdtf_mutation_audit.cpp
@@ -29,6 +29,40 @@ std::string BuildIsoTimestampUtcNow() {
 
 } // namespace
 
+CompatibilityDecision
+InspectCompatibility(const tinyxml2::XMLElement *fixtureType) {
+  CompatibilityDecision decision;
+  if (!fixtureType)
+    return decision;
+
+  const tinyxml2::XMLElement *auditNode =
+      fixtureType->FirstChildElement("PerastageMutationAudit");
+  if (!auditNode)
+    return decision;
+
+  int schemaVersion = -1;
+  if (auditNode->QueryIntAttribute("SchemaVersion", &schemaVersion) !=
+      tinyxml2::XML_SUCCESS) {
+    decision.mode = CompatibilityMode::SafeFallbackUnknownVersion;
+    decision.warning =
+        "PerastageMutationAudit metadata is present but SchemaVersion is "
+        "missing or invalid. Using safe fallback compatibility mode.";
+    return decision;
+  }
+
+  if (schemaVersion == kPerastageGdtfMutationSchemaVersion) {
+    decision.mode = CompatibilityMode::KnownPerastageVersion;
+    return decision;
+  }
+
+  decision.mode = CompatibilityMode::SafeFallbackUnknownVersion;
+  decision.warning =
+      "PerastageMutationAudit SchemaVersion=" + std::to_string(schemaVersion) +
+      " is not supported by this Perastage build. Using safe fallback "
+      "compatibility mode.";
+  return decision;
+}
+
 tinyxml2::XMLElement *EnsureFixtureType(tinyxml2::XMLDocument &doc) {
   tinyxml2::XMLElement *root = doc.FirstChildElement("GDTF");
   if (root) {

--- a/core/gdtf_mutation_audit.h
+++ b/core/gdtf_mutation_audit.h
@@ -12,9 +12,27 @@ namespace GdtfMutationAudit {
 // only Perastage mutation-audit semantics.
 inline constexpr int kPerastageGdtfMutationSchemaVersion = 1;
 
+enum class CompatibilityMode {
+  LegacyFallback,
+  KnownPerastageVersion,
+  SafeFallbackUnknownVersion,
+};
+
+struct CompatibilityDecision {
+  CompatibilityMode mode = CompatibilityMode::LegacyFallback;
+  std::string warning;
+};
+
 // Returns the root <FixtureType> node, creating <GDTF>/<FixtureType> when
 // needed for mutation operations.
 tinyxml2::XMLElement *EnsureFixtureType(tinyxml2::XMLDocument &doc);
+
+// Decides how to treat Perastage mutation metadata compatibility for a
+// FixtureType node.
+// - No metadata node: legacy fallback (compatible with older files).
+// - Known schema version: treat as trusted Perastage metadata.
+// - Unknown schema version: safe fallback with warning.
+CompatibilityDecision InspectCompatibility(const tinyxml2::XMLElement *fixtureType);
 
 // Returns the <Revisions> node under fixtureType, creating it when missing.
 tinyxml2::XMLElement *EnsureRevisionsNode(tinyxml2::XMLElement *fixtureType,

--- a/core/symbols/PerastageSvgSymbol.cpp
+++ b/core/symbols/PerastageSvgSymbol.cpp
@@ -1,4 +1,5 @@
 #include "symbols/PerastageSvgSymbol.h"
+#include "gdtf_mutation_audit.h"
 #include "startup_file_access_gate.h"
 
 #include <algorithm>
@@ -16,6 +17,7 @@
 
 #include <tinyxml2.h>
 #include <wx/wfstream.h>
+#include <wx/log.h>
 #include <wx/zipstrm.h>
 
 namespace {
@@ -659,7 +661,20 @@ bool LoadPerastageSvgSymbolFromGdtf(const std::string &gdtfPath,
   }
 
   const char *editor = fixtureType->Attribute("Editor");
-  const bool editorIsPerastage = editor && EqualsNoCase(editor, "Perastage");
+  const bool editorIsPerastageLegacy =
+      editor && EqualsNoCase(editor, "Perastage");
+  const auto compatibility = GdtfMutationAudit::InspectCompatibility(fixtureType);
+  if (!compatibility.warning.empty()) {
+    wxLogWarning("GDTF symbol compatibility warning for '%s': %s",
+                 gdtfPath.c_str(), compatibility.warning.c_str());
+  }
+  const bool editorIsPerastage =
+      compatibility.mode == GdtfMutationAudit::CompatibilityMode::KnownPerastageVersion
+          ? true
+          : (compatibility.mode ==
+                     GdtfMutationAudit::CompatibilityMode::LegacyFallback
+                 ? editorIsPerastageLegacy
+                 : false);
 
   const tinyxml2::XMLElement *model = ResolveTargetModel(fixtureType);
   const std::string baseName = ResolveModelSvgBasename(model);

--- a/gui/mainwindow_fixture_symbol_autoupdate.cpp
+++ b/gui/mainwindow_fixture_symbol_autoupdate.cpp
@@ -205,6 +205,14 @@ void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
     return;
   }
 
+  if (!inspection.warningMessage.empty()) {
+    ReportFixtureAutoUpdate(
+        *this, consolePanel,
+        "Fixture symbol auto-update: warning for '" + fixtureLabel + "' (" +
+            inspection.warningMessage + ").",
+        false);
+  }
+
   if (!inspection.requiresSymbolGeneration) {
     CallAfter([this]() { ProcessNextFixtureSymbolAutoUpdate(); });
     return;

--- a/gui/windows/symbol_fixture_applier.cpp
+++ b/gui/windows/symbol_fixture_applier.cpp
@@ -708,7 +708,16 @@ bool InspectFixtureSymbolState(const Fixture &fixture,
     return true;
 
   const char *editor = fixtureType->Attribute("Editor");
-  result.editorIsPerastage = editor && std::string(editor) == "Perastage";
+  const bool editorIsPerastage = editor && std::string(editor) == "Perastage";
+  const auto compatibility = GdtfMutationAudit::InspectCompatibility(fixtureType);
+  result.warningMessage = compatibility.warning;
+  result.editorIsPerastage =
+      compatibility.mode == GdtfMutationAudit::CompatibilityMode::KnownPerastageVersion
+          ? true
+          : (compatibility.mode ==
+                     GdtfMutationAudit::CompatibilityMode::LegacyFallback
+                 ? editorIsPerastage
+                 : false);
 
   std::string modelSvgBase = ResolveModelSvgBasename(inspectPath, errorMessage);
   if (modelSvgBase.empty()) {

--- a/gui/windows/symbol_fixture_applier.h
+++ b/gui/windows/symbol_fixture_applier.h
@@ -19,6 +19,7 @@ struct FixtureSymbolInspectionResult {
   bool editorIsPerastage = false;
   bool hasValidSvgSymbolSet = false;
   bool requiresSymbolGeneration = false;
+  std::string warningMessage;
   std::string scenePath;
   std::string libraryPath;
 };

--- a/tests/symbol_fixture_applier_gdtf_test.cpp
+++ b/tests/symbol_fixture_applier_gdtf_test.cpp
@@ -64,6 +64,50 @@ std::string MakeFixtureGdtf() {
   return outPath;
 }
 
+std::string MakeFixtureGdtfFromFixtureTypeXml(const std::string &fixtureTypeXml) {
+  wxFileName tempName(wxFileName::CreateTempFileName("gdtf_symbol_compat_"));
+  const std::string outPath = tempName.GetFullPath().ToStdString() + ".gdtf";
+  wxRemoveFile(tempName.GetFullPath());
+
+  wxFFileOutputStream fileOut(outPath);
+  assert(fileOut.IsOk());
+  wxZipOutputStream zipOut(fileOut);
+
+  zipOut.PutNextEntry("description.xml");
+  const std::string xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                          "<GDTF DataVersion=\"1.2\">" +
+                          fixtureTypeXml + "</GDTF>";
+  zipOut.Write(xml.data(), xml.size());
+
+  const std::string symbolBody = "<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>";
+  zipOut.PutNextEntry("models/svg/Body.svg");
+  zipOut.Write(symbolBody.data(), symbolBody.size());
+  zipOut.PutNextEntry("models/svg_side/Body.svg");
+  zipOut.Write(symbolBody.data(), symbolBody.size());
+  zipOut.PutNextEntry("models/svg_front/Body.svg");
+  zipOut.Write(symbolBody.data(), symbolBody.size());
+  zipOut.Close();
+
+  return outPath;
+}
+
+symbol_preview::FixtureSymbolInspectionResult InspectFixturePath(const std::string &fixtureUuid,
+                                                                 const std::string &gdtfPath) {
+  auto &cfg = ConfigManager::Get();
+  Fixture fixture;
+  fixture.uuid = fixtureUuid;
+  fixture.typeName = "SymbolFixture";
+  fixture.gdtfSpec = gdtfPath;
+  cfg.GetScene().fixtures[fixture.uuid] = fixture;
+
+  symbol_preview::FixtureSymbolInspectionResult inspection{};
+  std::string errorMessage;
+  assert(symbol_preview::InspectFixtureSymbolState(fixture, cfg.GetScene(), inspection,
+                                                   errorMessage));
+  assert(errorMessage.empty());
+  return inspection;
+}
+
 std::vector<symbols::Symbol2D> BuildSymbols() {
   auto makeView = [](symbols::SymbolView view) {
     symbols::Symbol2D symbol;
@@ -106,6 +150,7 @@ int main() {
   assert(errorMessage.empty());
   assert(before.hasResolvableGdtf);
   assert(!before.editorIsPerastage);
+  assert(before.requiresSymbolGeneration);
 
   const auto symbols = BuildSymbols();
   symbol_preview::ApplySymbolsOptions options;
@@ -177,6 +222,30 @@ int main() {
   assert(after.hasValidSvgSymbolSet);
   assert(!after.requiresSymbolGeneration);
 
+  const std::string currentVersionPath = MakeFixtureGdtfFromFixtureTypeXml(
+      "<FixtureType Name=\"Current\" Manufacturer=\"Acme\" Editor=\"Vendor\">"
+      "<Models><Model Name=\"Body\" File=\"\" PrimitiveType=\"Cube\"/></Models>"
+      "<PerastageMutationAudit SchemaVersion=\"1\"/>"
+      "</FixtureType>");
+  const auto currentVersion =
+      InspectFixturePath("fixture-current-version", currentVersionPath);
+  assert(currentVersion.editorIsPerastage);
+  assert(currentVersion.hasValidSvgSymbolSet);
+  assert(!currentVersion.requiresSymbolGeneration);
+  assert(currentVersion.warningMessage.empty());
+
+  const std::string unknownVersionPath = MakeFixtureGdtfFromFixtureTypeXml(
+      "<FixtureType Name=\"Future\" Manufacturer=\"Acme\" Editor=\"Perastage\">"
+      "<Models><Model Name=\"Body\" File=\"\" PrimitiveType=\"Cube\"/></Models>"
+      "<PerastageMutationAudit SchemaVersion=\"999\"/>"
+      "</FixtureType>");
+  const auto unknownVersion =
+      InspectFixturePath("fixture-unknown-version", unknownVersionPath);
+  assert(!unknownVersion.editorIsPerastage);
+  assert(!unknownVersion.hasValidSvgSymbolSet);
+  assert(unknownVersion.requiresSymbolGeneration);
+  assert(!unknownVersion.warningMessage.empty());
+
   std::vector<GdtfObject> objects;
   std::string loadError;
   assert(LoadGdtf(gdtfPath, objects, &loadError));
@@ -184,6 +253,8 @@ int main() {
 
   std::error_code ec;
   fs::remove(gdtfPath, ec);
+  fs::remove(currentVersionPath, ec);
+  fs::remove(unknownVersionPath, ec);
   cfg.Reset();
   return 0;
 }


### PR DESCRIPTION
### Motivation
- Ensure GDTF symbol loading/inspection is backward-compatible with older GDTF files without Perastage metadata and resilient to future/unknown Perastage schema versions, while centralizing the compatibility decision.

### Description
- Added `CompatibilityMode`, `CompatibilityDecision`, and `InspectCompatibility` to `core/gdtf_mutation_audit` to classify fixture metadata as legacy (no metadata), known Perastage version, or unknown/future version.
- Updated `symbol_preview::InspectFixtureSymbolState` (`gui/windows/symbol_fixture_applier.cpp`) and `FixtureSymbolInspectionResult` to use `InspectCompatibility` and include a `warningMessage` so decisions about the Perastage mark and regeneration fall back safely.
- Applied the same compatibility decision in GDTF symbol loading (`core/symbols/PerastageSvgSymbol.cpp`) and emit `wxLogWarning` for unknown schema versions while preserving safe fallback behavior.
- Surface compatibility warnings in the fixture auto-update flow (`gui/mainwindow_fixture_symbol_autoupdate.cpp`) and added tests in `tests/symbol_fixture_applier_gdtf_test.cpp` for legacy/no metadata, current/known schema, and unknown schema cases.

### Testing
- Ran the mandatory architecture checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both completed with `OK`.
- Attempted to configure the build with `cmake --preset wsl-x64-debug` but configuration failed in this environment due to missing `wxWidgets` development packages (`wxWidgets_LIBRARIES` / `wxWidgets_INCLUDE_DIRS`), so unit tests were not executed here.
- Added/updated the unit test `symbol_fixture_applier_gdtf_test` which implements the three compatibility scenarios and is expected to pass when built in an environment with the required GUI dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2571222e88324bbe1a730f0e5a8bd)