### PR TITLE
Stop setting Editor="Perastage" and detect Perastage via revision/ModifiedBy; surface ModifiedBy in UI

### DIFF
--- a/core/gdtf_mutation_audit.cpp
+++ b/core/gdtf_mutation_audit.cpp
@@ -132,8 +132,6 @@ void StampPerastageMutationMetadata(tinyxml2::XMLElement *fixtureType,
   if (!fixtureType)
     return;
 
-  fixtureType->SetAttribute("Editor", "Perastage");
-
   tinyxml2::XMLElement *auditNode =
       fixtureType->FirstChildElement("PerastageMutationAudit");
   if (!auditNode) {

--- a/core/gdtf_mutation_audit.h
+++ b/core/gdtf_mutation_audit.h
@@ -53,8 +53,8 @@ void AppendRevision(tinyxml2::XMLElement *fixtureType,
                     int userId = 0,
                     const std::string &dateUtcIso8601 = "");
 
-// Stamps Perastage-owned mutation metadata under <FixtureType> and sets
-// Editor="Perastage". Metadata is stored in <PerastageMutationAudit>.
+// Stamps Perastage-owned mutation metadata under <FixtureType>.
+// Metadata is stored in <PerastageMutationAudit>.
 void StampPerastageMutationMetadata(tinyxml2::XMLElement *fixtureType,
                                     tinyxml2::XMLDocument &doc);
 

--- a/core/symbols/PerastageSvgSymbol.cpp
+++ b/core/symbols/PerastageSvgSymbol.cpp
@@ -121,6 +121,33 @@ bool EqualsNoCase(std::string_view a, std::string_view b) {
   return true;
 }
 
+bool StartsWithNoCase(std::string_view value, std::string_view prefix) {
+  if (value.size() < prefix.size())
+    return false;
+  return EqualsNoCase(value.substr(0, prefix.size()), prefix);
+}
+
+bool IsPerastageModifiedByValue(const char *modifiedByValue) {
+  if (!modifiedByValue)
+    return false;
+  return StartsWithNoCase(modifiedByValue, "Perastage");
+}
+
+bool HasPerastageRevisionModifiedBy(const tinyxml2::XMLElement *fixtureType) {
+  if (!fixtureType)
+    return false;
+  const tinyxml2::XMLElement *revisions = fixtureType->FirstChildElement("Revisions");
+  if (!revisions)
+    return false;
+  for (const tinyxml2::XMLElement *revision =
+           revisions->FirstChildElement("Revision");
+       revision; revision = revision->NextSiblingElement("Revision")) {
+    if (IsPerastageModifiedByValue(revision->Attribute("ModifiedBy")))
+      return true;
+  }
+  return false;
+}
+
 const tinyxml2::XMLElement *ResolveFixtureType(const tinyxml2::XMLDocument &doc) {
   const tinyxml2::XMLElement *fixtureType = doc.FirstChildElement("GDTF");
   if (fixtureType)
@@ -660,9 +687,11 @@ bool LoadPerastageSvgSymbolFromGdtf(const std::string &gdtfPath,
     return false;
   }
 
+  const bool revisionModifiedByPerastage =
+      HasPerastageRevisionModifiedBy(fixtureType);
   const char *editor = fixtureType->Attribute("Editor");
   const bool editorIsPerastageLegacy =
-      editor && EqualsNoCase(editor, "Perastage");
+      editor && StartsWithNoCase(editor, "Perastage");
   const auto compatibility = GdtfMutationAudit::InspectCompatibility(fixtureType);
   if (!compatibility.warning.empty()) {
     wxLogWarning("GDTF symbol compatibility warning for '%s': %s",
@@ -673,7 +702,7 @@ bool LoadPerastageSvgSymbolFromGdtf(const std::string &gdtfPath,
           ? true
           : (compatibility.mode ==
                      GdtfMutationAudit::CompatibilityMode::LegacyFallback
-                 ? editorIsPerastageLegacy
+                 ? (revisionModifiedByPerastage || editorIsPerastageLegacy)
                  : false);
 
   const tinyxml2::XMLElement *model = ResolveTargetModel(fixtureType);

--- a/docs/gdtf_mutation_policy.md
+++ b/docs/gdtf_mutation_policy.md
@@ -56,8 +56,6 @@ This schema version controls semantics for the `<PerastageMutationAudit .../>` n
 - `PerastageVersionDisplay`
 - `LastMutationDateUtc`
 
-and with `Editor="Perastage"` set on `<FixtureType>`.
-
 ## 4) Compatibility matrix (legacy / current / future reads)
 
 Compatibility is resolved by `InspectCompatibility(...)` in `core/gdtf_mutation_audit.cpp`.

--- a/gui/fixtureeditdialog.cpp
+++ b/gui/fixtureeditdialog.cpp
@@ -163,6 +163,24 @@ std::string FirstNonEmptyAttribute(tinyxml2::XMLElement *element,
   return "";
 }
 
+std::string ExtractRevisionAuthor(tinyxml2::XMLElement *revision) {
+  if (!revision)
+    return {};
+
+  if (const char *modifiedBy = revision->Attribute("ModifiedBy");
+      modifiedBy && *modifiedBy) {
+    return modifiedBy;
+  }
+  if (const char *userName = revision->Attribute("UserName");
+      userName && *userName) {
+    return userName;
+  }
+  if (const char *userId = revision->Attribute("UserID"); userId && *userId) {
+    return std::string("UserID: ") + userId;
+  }
+  return {};
+}
+
 std::string FormatMetadataTimestamp(const std::string &value) {
   if (value.empty())
     return {};
@@ -255,11 +273,9 @@ bool LoadGdtfMetadataSummary(const std::string &gdtfPath,
       }
       outSummary.lastModified =
           FirstNonEmptyAttribute(latestRevision, {"Date", "TimeStamp"});
-      outSummary.modifiedBy = FirstNonEmptyAttribute(
-          latestRevision, {"ModifiedBy", "UserName", "UserID"});
+      outSummary.modifiedBy = ExtractRevisionAuthor(latestRevision);
       if (outSummary.creator.empty()) {
-        outSummary.creator = FirstNonEmptyAttribute(
-            firstRevision, {"ModifiedBy", "UserName", "UserID"});
+        outSummary.creator = ExtractRevisionAuthor(firstRevision);
       }
       if (outSummary.creationDate.empty()) {
         outSummary.creationDate =

--- a/gui/fixtureeditdialog.cpp
+++ b/gui/fixtureeditdialog.cpp
@@ -20,11 +20,13 @@
 #include "fixturetablepanel.h"
 #include "gdtfdictionary.h"
 #include "gdtfloader.h"
+#include "gdtf_mutation_audit.h"
 #include "projectutils.h"
 #include "gdtf_fixture_category.h"
 #include "symbolcache.h"
 #include "symbols/PerastageSvgSymbol.h"
 #include "viewer3dpanel.h"
+#include <wx/datetime.h>
 #include <wx/filedlg.h>
 #include <wx/filename.h>
 #include <wx/clrpicker.h>
@@ -142,10 +144,10 @@ bool LoadGdtfThumbnail(const std::string &gdtfPath, wxBitmap &outBitmap) {
 struct GdtfMetadataSummary {
   std::string creator;
   std::string creationDate;
+  std::string modifiedBy;
   std::string revision;
   std::string lastModified;
   std::string version;
-  std::string fixtureTypeId;
 };
 
 std::string FirstNonEmptyAttribute(tinyxml2::XMLElement *element,
@@ -159,6 +161,25 @@ std::string FirstNonEmptyAttribute(tinyxml2::XMLElement *element,
       return value;
   }
   return "";
+}
+
+std::string FormatMetadataTimestamp(const std::string &value) {
+  if (value.empty())
+    return {};
+
+  wxDateTime parsed;
+  if (parsed.ParseISOCombined(value.c_str())) {
+    if (parsed.IsValid())
+      return parsed.FormatISOCombined(' ').ToStdString();
+  }
+
+  wxDateTime parsedUtc;
+  if (parsedUtc.ParseFormat(value.c_str(), "%Y-%m-%dT%H:%M:%SZ")) {
+    if (parsedUtc.IsValid())
+      return parsedUtc.FormatISOCombined(' ').ToStdString();
+  }
+
+  return value;
 }
 
 bool LoadGdtfMetadataSummary(const std::string &gdtfPath,
@@ -203,14 +224,12 @@ bool LoadGdtfMetadataSummary(const std::string &gdtfPath,
   if (!fixtureType)
     return false;
 
-  outSummary.creator = FirstNonEmptyAttribute(
-      fixtureType, {"Creator", "Author", "Editor", "Manufacturer"});
+  outSummary.creator =
+      FirstNonEmptyAttribute(fixtureType, {"Creator", "Author"});
   outSummary.creationDate = FirstNonEmptyAttribute(
       fixtureType, {"CreateDate", "CreationDate", "DateCreated"});
   outSummary.revision = FirstNonEmptyAttribute(
       fixtureType, {"Revision", "DataVersion", "Version"});
-  outSummary.fixtureTypeId =
-      FirstNonEmptyAttribute(fixtureType, {"FixtureTypeID"});
 
   if (root) {
     if (outSummary.version.empty())
@@ -223,6 +242,7 @@ bool LoadGdtfMetadataSummary(const std::string &gdtfPath,
 
   tinyxml2::XMLElement *revisions = fixtureType->FirstChildElement("Revisions");
   if (revisions) {
+    tinyxml2::XMLElement *firstRevision = revisions->FirstChildElement("Revision");
     tinyxml2::XMLElement *latestRevision = nullptr;
     for (tinyxml2::XMLElement *rev = revisions->FirstChildElement("Revision");
          rev; rev = rev->NextSiblingElement("Revision")) {
@@ -235,12 +255,13 @@ bool LoadGdtfMetadataSummary(const std::string &gdtfPath,
       }
       outSummary.lastModified =
           FirstNonEmptyAttribute(latestRevision, {"Date", "TimeStamp"});
+      outSummary.modifiedBy = FirstNonEmptyAttribute(
+          latestRevision, {"ModifiedBy", "UserName", "UserID"});
       if (outSummary.creator.empty()) {
         outSummary.creator = FirstNonEmptyAttribute(
-            latestRevision, {"ModifiedBy", "UserName", "UserID"});
+            firstRevision, {"ModifiedBy", "UserName", "UserID"});
       }
       if (outSummary.creationDate.empty()) {
-        tinyxml2::XMLElement *firstRevision = revisions->FirstChildElement("Revision");
         outSummary.creationDate =
             FirstNonEmptyAttribute(firstRevision, {"Date", "TimeStamp"});
       }
@@ -249,6 +270,8 @@ bool LoadGdtfMetadataSummary(const std::string &gdtfPath,
 
   if (outSummary.version.empty())
     outSummary.version = outSummary.revision;
+  outSummary.creationDate = FormatMetadataTimestamp(outSummary.creationDate);
+  outSummary.lastModified = FormatMetadataTimestamp(outSummary.lastModified);
 
   return true;
 }
@@ -390,7 +413,8 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
   wxFlexGridSizer *metadataGrid = new wxFlexGridSizer(2, 4, 8);
   metadataGrid->AddGrowableCol(1, 1);
   const std::array<wxString, 6> metadataLabels = {
-      "Creator", "Creation date", "Revision", "Last modified", "Version", "FixtureTypeID"};
+      "Creator", "Creation date", "ModifiedBy", "Revision", "Last modified",
+      "Version"};
   for (size_t i = 0; i < metadataLabels.size(); ++i) {
     metadataGrid->Add(new wxStaticText(this, wxID_ANY, metadataLabels[i]), 0,
                       wxALIGN_CENTER_VERTICAL);
@@ -658,8 +682,8 @@ void FixtureEditDialog::UpdateMetadataSummary() {
   };
   const std::array<wxString, 6> values = {
       toValueOrFallback(metadata.creator), toValueOrFallback(metadata.creationDate),
-      toValueOrFallback(metadata.revision), toValueOrFallback(metadata.lastModified),
-      toValueOrFallback(metadata.version), toValueOrFallback(metadata.fixtureTypeId)};
+      toValueOrFallback(metadata.modifiedBy), toValueOrFallback(metadata.revision),
+      toValueOrFallback(metadata.lastModified), toValueOrFallback(metadata.version)};
   for (size_t i = 0; i < metadataValueLabels.size() && i < values.size(); ++i) {
     if (metadataValueLabels[i])
       metadataValueLabels[i]->SetLabel(values[i]);
@@ -810,7 +834,8 @@ void FixtureEditDialog::ApplyChanges() {
           std::fabs(newWeightKg - originalWeightKg) > 0.01f;
       if (gdtfPhysicalCandidateChanged && gdtfPhysicalChanged &&
           !SetGdtfProperties(std::string(gdtfPath.ToUTF8()), newWeightKg,
-                             newPowerW, "Perastage")) {
+                             newPowerW,
+                             GdtfMutationAudit::BuildPerastageModifiedBy())) {
         wxMessageBox(
             "Could not update GDTF physical properties (Weight/PowerConsumption).",
             "GDTF update", wxOK | wxICON_WARNING, this);

--- a/gui/fixtureeditdialog.cpp
+++ b/gui/fixtureeditdialog.cpp
@@ -142,8 +142,10 @@ bool LoadGdtfThumbnail(const std::string &gdtfPath, wxBitmap &outBitmap) {
 }
 
 struct GdtfMetadataSummary {
-  std::string creator;
+  std::string manufacturer;
+  std::string description;
   std::string creationDate;
+  std::string userId;
   std::string modifiedBy;
   std::string revision;
   std::string lastModified;
@@ -163,7 +165,7 @@ std::string FirstNonEmptyAttribute(tinyxml2::XMLElement *element,
   return "";
 }
 
-std::string ExtractRevisionAuthor(tinyxml2::XMLElement *revision) {
+std::string ExtractRevisionModifiedBy(tinyxml2::XMLElement *revision) {
   if (!revision)
     return {};
 
@@ -171,14 +173,15 @@ std::string ExtractRevisionAuthor(tinyxml2::XMLElement *revision) {
       modifiedBy && *modifiedBy) {
     return modifiedBy;
   }
-  if (const char *userName = revision->Attribute("UserName");
-      userName && *userName) {
-    return userName;
-  }
-  if (const char *userId = revision->Attribute("UserID"); userId && *userId) {
-    return std::string("UserID: ") + userId;
-  }
   return {};
+}
+
+std::string ExtractRevisionUserId(tinyxml2::XMLElement *revision) {
+  if (!revision)
+    return "0";
+  if (const char *userId = revision->Attribute("UserID"); userId && *userId)
+    return userId;
+  return "0";
 }
 
 std::string FormatMetadataTimestamp(const std::string &value) {
@@ -203,6 +206,7 @@ std::string FormatMetadataTimestamp(const std::string &value) {
 bool LoadGdtfMetadataSummary(const std::string &gdtfPath,
                              GdtfMetadataSummary &outSummary) {
   outSummary = {};
+  outSummary.userId = "0";
   if (gdtfPath.empty())
     return false;
 
@@ -242,8 +246,9 @@ bool LoadGdtfMetadataSummary(const std::string &gdtfPath,
   if (!fixtureType)
     return false;
 
-  outSummary.creator =
-      FirstNonEmptyAttribute(fixtureType, {"Creator", "Author"});
+  outSummary.manufacturer =
+      FirstNonEmptyAttribute(fixtureType, {"Manufacturer"});
+  outSummary.description = FirstNonEmptyAttribute(fixtureType, {"Description"});
   outSummary.creationDate = FirstNonEmptyAttribute(
       fixtureType, {"CreateDate", "CreationDate", "DateCreated"});
   outSummary.revision = FirstNonEmptyAttribute(
@@ -273,10 +278,8 @@ bool LoadGdtfMetadataSummary(const std::string &gdtfPath,
       }
       outSummary.lastModified =
           FirstNonEmptyAttribute(latestRevision, {"Date", "TimeStamp"});
-      outSummary.modifiedBy = ExtractRevisionAuthor(latestRevision);
-      if (outSummary.creator.empty()) {
-        outSummary.creator = ExtractRevisionAuthor(firstRevision);
-      }
+      outSummary.modifiedBy = ExtractRevisionModifiedBy(latestRevision);
+      outSummary.userId = ExtractRevisionUserId(latestRevision);
       if (outSummary.creationDate.empty()) {
         outSummary.creationDate =
             FirstNonEmptyAttribute(firstRevision, {"Date", "TimeStamp"});
@@ -296,7 +299,7 @@ bool LoadGdtfMetadataSummary(const std::string &gdtfPath,
 
 FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
     : wxDialog(p, wxID_ANY, "Edit Fixture", wxDefaultPosition,
-               wxSize(760, 700)),
+               wxSize(860, 700)),
       panel(p), row(r) {
   wxBoxSizer *topSizer = new wxBoxSizer(wxVERTICAL);
   wxBoxSizer *hSizer = new wxBoxSizer(wxHORIZONTAL);
@@ -428,14 +431,14 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
 
   wxFlexGridSizer *metadataGrid = new wxFlexGridSizer(2, 4, 8);
   metadataGrid->AddGrowableCol(1, 1);
-  const std::array<wxString, 6> metadataLabels = {
-      "Creator", "Creation date", "ModifiedBy", "Revision", "Last modified",
-      "Version"};
+  const std::array<wxString, 8> metadataLabels = {
+      "Manufacturer", "Description", "Creation date", "UserID", "ModifiedBy",
+      "Revision", "Last modified", "Version"};
   for (size_t i = 0; i < metadataLabels.size(); ++i) {
     metadataGrid->Add(new wxStaticText(this, wxID_ANY, metadataLabels[i]), 0,
                       wxALIGN_CENTER_VERTICAL);
     metadataValueLabels[i] = new wxStaticText(this, wxID_ANY, "-");
-    metadataValueLabels[i]->Wrap(290);
+    metadataValueLabels[i]->Wrap(360);
     metadataGrid->Add(metadataValueLabels[i], 1, wxEXPAND);
   }
   metadataSizer->Add(metadataGrid, 1, wxEXPAND | wxALL, 6);
@@ -696,8 +699,10 @@ void FixtureEditDialog::UpdateMetadataSummary() {
       return unavailable;
     return wxString::FromUTF8(value);
   };
-  const std::array<wxString, 6> values = {
-      toValueOrFallback(metadata.creator), toValueOrFallback(metadata.creationDate),
+  const std::array<wxString, 8> values = {
+      toValueOrFallback(metadata.manufacturer),
+      toValueOrFallback(metadata.description),
+      toValueOrFallback(metadata.creationDate), toValueOrFallback(metadata.userId),
       toValueOrFallback(metadata.modifiedBy), toValueOrFallback(metadata.revision),
       toValueOrFallback(metadata.lastModified), toValueOrFallback(metadata.version)};
   for (size_t i = 0; i < metadataValueLabels.size() && i < values.size(); ++i) {

--- a/gui/fixtureeditdialog.h
+++ b/gui/fixtureeditdialog.h
@@ -56,7 +56,7 @@ private:
     wxTextCtrl* channelList = nullptr;
     FixturePreviewPanel* preview = nullptr;
     wxStaticBitmap* fixtureImagePreview = nullptr;
-    std::array<wxStaticText*, 6> metadataValueLabels{};
+    std::array<wxStaticText*, 8> metadataValueLabels{};
     std::array<wxPanel*, 3> symbolPanels{};
     std::array<bool, 3> symbolAvailability{};
     std::array<PerastageSvgSymbolData, 3> symbolData{};

--- a/gui/windows/symbol_fixture_applier.cpp
+++ b/gui/windows/symbol_fixture_applier.cpp
@@ -55,6 +55,35 @@ std::string ToLowerCopy(std::string value) {
   return value;
 }
 
+bool IsPerastageEditorValue(const char *editorValue) {
+  if (!editorValue)
+    return false;
+  const std::string editor = editorValue;
+  return editor == "Perastage" || editor.rfind("Perastage ", 0) == 0;
+}
+
+bool IsPerastageModifiedByValue(const char *modifiedByValue) {
+  if (!modifiedByValue)
+    return false;
+  const std::string modifiedBy = modifiedByValue;
+  return modifiedBy == "Perastage" || modifiedBy.rfind("Perastage ", 0) == 0;
+}
+
+bool HasPerastageRevisionModifiedBy(const tinyxml2::XMLElement *fixtureType) {
+  if (!fixtureType)
+    return false;
+  const tinyxml2::XMLElement *revisions = fixtureType->FirstChildElement("Revisions");
+  if (!revisions)
+    return false;
+  for (const tinyxml2::XMLElement *revision =
+           revisions->FirstChildElement("Revision");
+       revision; revision = revision->NextSiblingElement("Revision")) {
+    if (IsPerastageModifiedByValue(revision->Attribute("ModifiedBy")))
+      return true;
+  }
+  return false;
+}
+
 bool IsDescriptionXmlPath(const std::string &archivePath) {
   const std::string normalized = ToLowerCopy(NormalizeArchivePath(archivePath));
   return normalized == "description.xml" ||
@@ -707,8 +736,10 @@ bool InspectFixtureSymbolState(const Fixture &fixture,
   if (!fixtureType)
     return true;
 
-  const char *editor = fixtureType->Attribute("Editor");
-  const bool editorIsPerastage = editor && std::string(editor) == "Perastage";
+  const bool revisionModifiedByPerastage =
+      HasPerastageRevisionModifiedBy(fixtureType);
+  const bool editorIsPerastage =
+      IsPerastageEditorValue(fixtureType->Attribute("Editor"));
   const auto compatibility = GdtfMutationAudit::InspectCompatibility(fixtureType);
   result.warningMessage = compatibility.warning;
   result.editorIsPerastage =
@@ -716,7 +747,7 @@ bool InspectFixtureSymbolState(const Fixture &fixture,
           ? true
           : (compatibility.mode ==
                      GdtfMutationAudit::CompatibilityMode::LegacyFallback
-                 ? editorIsPerastage
+                 ? (revisionModifiedByPerastage || editorIsPerastage)
                  : false);
 
   std::string modelSvgBase = ResolveModelSvgBasename(inspectPath, errorMessage);

--- a/tests/gdtfloader_set_model_color_audit_test.cpp
+++ b/tests/gdtfloader_set_model_color_audit_test.cpp
@@ -14,7 +14,6 @@
 #include <wx/wfstream.h>
 #include <wx/zipstrm.h>
 
-#include "../core/app_version.h"
 #include "../core/gdtf_mutation_audit.h"
 #include "../viewer3d/gdtfloader.h"
 
@@ -138,8 +137,7 @@ int main() {
   assert(fixtureType != nullptr);
 
   const char *editor = fixtureType->Attribute("Editor");
-  assert(editor != nullptr);
-  assert(std::string(editor) == "Perastage");
+  assert(editor == nullptr);
 
   tinyxml2::XMLElement *models = fixtureType->FirstChildElement("Models");
   assert(models != nullptr);

--- a/tests/symbol_fixture_applier_gdtf_test.cpp
+++ b/tests/symbol_fixture_applier_gdtf_test.cpp
@@ -190,8 +190,7 @@ int main() {
   assert(fixtureType != nullptr);
 
   const char *editor = fixtureType->Attribute("Editor");
-  assert(editor != nullptr);
-  assert(std::string(editor) == "Perastage");
+  assert(editor == nullptr);
 
   const bool hasRevision =
       fixtureType->FirstChildElement("Revisions") != nullptr &&

--- a/tests/symbol_fixture_applier_gdtf_test.cpp
+++ b/tests/symbol_fixture_applier_gdtf_test.cpp
@@ -205,8 +205,10 @@ int main() {
   tinyxml2::XMLElement *revision =
       fixtureType->FirstChildElement("Revisions")->FirstChildElement("Revision");
   assert(revision != nullptr);
+  const char *date = revision->Attribute("Date");
   const char *text = revision->Attribute("Text");
   const char *modifiedBy = revision->Attribute("ModifiedBy");
+  assert(date != nullptr && std::string(date).size() > 0);
   assert(text != nullptr);
   assert(modifiedBy != nullptr);
   assert(std::string(text) ==


### PR DESCRIPTION
### Motivation
- Avoid writing `Editor="Perastage"` on `<FixtureType>` and instead rely on Perastage-owned audit metadata and `<Revision ModifiedBy="Perastage ...">` to mark Perastage mutations.
- Improve detection of Perastage-owned fixtures by recognizing `ModifiedBy`/`Editor` values that start with `Perastage` (case-insensitive) and prefer revision entries for backward-compatible identification.
- Expose the last `ModifiedBy` value and normalize timestamps in the fixture editor UI for clearer metadata presentation.

### Description
- Removed setting `Editor="Perastage"` from `StampPerastageMutationMetadata` and updated the header doc comment for `StampPerastageMutationMetadata` to reflect the change.
- Added helpers `StartsWithNoCase`, `IsPerastageModifiedByValue` and `HasPerastageRevisionModifiedBy` to detect Perastage markers from `ModifiedBy` or `Editor` values, and integrated them into symbol loading and inspection logic in `PerastageSvgSymbol.cpp` and `symbol_fixture_applier.cpp` so revision-based detection is honored.
- Updated compatibility logic to consider a Perastage revision `ModifiedBy` as an indicator of Perastage ownership when `InspectCompatibility` yields `LegacyFallback`.
- Changed `FixtureEditDialog` metadata summary to include `modifiedBy`, remove `FixtureTypeID`, parse/format ISO timestamps via `FormatMetadataTimestamp`, and use `GdtfMutationAudit::BuildPerastageModifiedBy()` when stamping property changes instead of the literal string.
- Updated documentation `docs/gdtf_mutation_policy.md` to remove the statement that `Editor="Perastage"` is written by the tool.
- Modified tests to reflect the new behavior by asserting that the `Editor` attribute is no longer present and that `PerastageMutationAudit` and `Revision` entries exist; adjusted test harness includes accordingly.

### Testing
- Ran the updated unit tests `tests/gdtfloader_set_model_color_audit_test.cpp` and `tests/symbol_fixture_applier_gdtf_test.cpp`, and both tests passed after adjusting expectations to the new audit behavior.
- Executed the relevant symbol/inspection codepaths used by the symbol applier and fixture editor in the test harness, and no regressions were observed in the automated checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d26190ab688324813fbe9b45179e32)