### PR TITLE
Fix macOS install rule for app bundle target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,7 +161,14 @@ endif()
 # Mark as GUI application (no console)
 set_target_properties(${PROJECT_NAME} PROPERTIES WIN32_EXECUTABLE TRUE)
 
-install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION .)
+if(APPLE)
+    install(TARGETS ${PROJECT_NAME}
+        BUNDLE DESTINATION .
+        RUNTIME DESTINATION .
+    )
+else()
+    install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION .)
+endif()
 
 if(UNIX AND NOT APPLE)
     configure_file(


### PR DESCRIPTION
### Motivation
- CMake failed on macOS with `install TARGETS given no BUNDLE DESTINATION for MACOSX_BUNDLE executable target "Perastage"`, so the app bundle target needs an explicit `BUNDLE DESTINATION` to satisfy CMake when `MACOSX_BUNDLE` is used.

### Description
- Modify `CMakeLists.txt` to add an `if(APPLE)` branch that calls `install(TARGETS ${PROJECT_NAME} BUNDLE DESTINATION . RUNTIME DESTINATION .)` and preserve the original `install(... RUNTIME DESTINATION .)` behavior for non-Apple platforms.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both tests returned `OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2b67983b08324a3975e729f05488e)