### PR TITLE
Fix mac build: include app_version in gdtfloader_set_model_color_audit_test

### DIFF
--- a/tests/gdtfloader_set_model_color_audit_test.cpp
+++ b/tests/gdtfloader_set_model_color_audit_test.cpp
@@ -14,6 +14,7 @@
 #include <wx/wfstream.h>
 #include <wx/zipstrm.h>
 
+#include "../core/app_version.h"
 #include "../core/gdtf_mutation_audit.h"
 #include "../viewer3d/gdtfloader.h"
 


### PR DESCRIPTION
### Motivation
- The macOS test build failed with "use of undeclared identifier 'app'" because `app::kVersion` is referenced in `tests/gdtfloader_set_model_color_audit_test.cpp` without including `core/app_version.h`.

### Description
- Added `#include "../core/app_version.h"` to `tests/gdtfloader_set_model_color_audit_test.cpp` to make `app::kVersion` available in that translation unit; this is a test-only compile fix with no runtime behavior changes.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2b901ca10832491320ccdd3f4ce19)