### PR TITLE
Fix macOS SummaryPanel crash during DataView recreation

### DIFF
--- a/gui/summarypanel.cpp
+++ b/gui/summarypanel.cpp
@@ -318,6 +318,10 @@ void SummaryPanel::RecreateTableControl() {
     if (!table || !store)
         return;
 
+    // Keep the model alive while the old control is destroyed and a new one
+    // takes ownership. This avoids a dangling model pointer on macOS.
+    store->IncRef();
+
     wxSizer* sizer = GetSizer();
     if (sizer)
         sizer->Detach(table);
@@ -326,6 +330,7 @@ void SummaryPanel::RecreateTableControl() {
     table = new wxDataViewListCtrl(this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
                                    wxDV_ROW_LINES);
     table->AssociateModel(store);
+    store->DecRef();
     BindTableEvents();
 
     if (sizer) {


### PR DESCRIPTION
### Motivation
- Prevent a macOS-specific crash when replacing the `wxDataViewListCtrl` by ensuring the `wxDataViewModel` remains valid while the old control is destroyed and the new control takes ownership.

### Description
- In `gui/summarypanel.cpp` call `store->IncRef()` before destroying the old `table` and `store->DecRef()` after `table->AssociateModel(store)` so the model's lifetime is preserved across control recreation.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which returned `OK`.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which returned `OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2c78495908324855781943faa0280)