### PR TITLE
Fix truss/object visibility cache getting stuck empty after deferred rebuild

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1089,6 +1089,7 @@ const Viewer3DController::VisibleSet &Viewer3DController::PrepareRenderFrame(
     const auto &fixtures = SceneDataManager::Instance().GetFixtures();
 
     std::lock_guard<std::mutex> lock(m_impl->sortedListsMutex);
+    bool rebuiltSortedLists = false;
     if (m_impl->sortedListsDirty && !context.skipOptionalWork) {
       m_impl->sortedObjects.clear();
       m_impl->sortedObjects.reserve(sceneObjects.size());
@@ -1118,6 +1119,15 @@ const Viewer3DController::VisibleSet &Viewer3DController::PrepareRenderFrame(
                 });
 
       m_impl->sortedListsDirty = false;
+      rebuiltSortedLists = true;
+    }
+
+    if (rebuiltSortedLists) {
+      // If layer candidates were cached while sorted lists were temporarily
+      // empty (for example during fast interaction), force a rebuild now.
+      // Otherwise visibility cache could keep truss/object/fixture UUID lists
+      // empty until a full scene reload increments sceneVersion.
+      m_impl->layerVisibleCandidatesSceneVersion = static_cast<size_t>(-1);
     }
   }
 


### PR DESCRIPTION
### Motivation
- Prevent trusses/objects/fixtures from remaining invisible after making scene changes and moving the view during fast interaction, by avoiding a stale layer-visible-candidates cache that can be built from temporarily empty sorted lists.

### Description
- In `viewer3d/viewer3dcontroller.cpp` (`PrepareRenderFrame`) mark when sorted lists are rebuilt and invalidate `layerVisibleCandidatesSceneVersion` (set to `static_cast<size_t>(-1)`) so cached layer-visible candidates are recomputed on the next frame.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both returned OK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2cf564cac8324b368ee5e98cea28d)