### PR TITLE
Fix Edit Fixture metadata panel overflow with long GDTF descriptions

### DIFF
--- a/gui/fixtureeditdialog.cpp
+++ b/gui/fixtureeditdialog.cpp
@@ -299,7 +299,7 @@ bool LoadGdtfMetadataSummary(const std::string &gdtfPath,
 
 FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
     : wxDialog(p, wxID_ANY, "Edit Fixture", wxDefaultPosition,
-               wxSize(860, 700)),
+               wxSize(900, 740)),
       panel(p), row(r) {
   wxBoxSizer *topSizer = new wxBoxSizer(wxVERTICAL);
   wxBoxSizer *hSizer = new wxBoxSizer(wxHORIZONTAL);
@@ -437,6 +437,16 @@ FixtureEditDialog::FixtureEditDialog(FixtureTablePanel *p, int r)
   for (size_t i = 0; i < metadataLabels.size(); ++i) {
     metadataGrid->Add(new wxStaticText(this, wxID_ANY, metadataLabels[i]), 0,
                       wxALIGN_CENTER_VERTICAL);
+    if (i == 1) {
+      metadataDescriptionCtrl = new wxTextCtrl(
+          this, wxID_ANY, "-", wxDefaultPosition, wxSize(-1, 90),
+          wxTE_MULTILINE | wxTE_READONLY);
+      metadataDescriptionCtrl->SetMinSize(wxSize(300, 90));
+      metadataDescriptionCtrl->ShowPosition(0);
+      metadataValueLabels[i] = nullptr;
+      metadataGrid->Add(metadataDescriptionCtrl, 1, wxEXPAND);
+      continue;
+    }
     metadataValueLabels[i] = new wxStaticText(this, wxID_ANY, "-");
     metadataValueLabels[i]->Wrap(360);
     metadataGrid->Add(metadataValueLabels[i], 1, wxEXPAND);
@@ -706,6 +716,11 @@ void FixtureEditDialog::UpdateMetadataSummary() {
       toValueOrFallback(metadata.modifiedBy), toValueOrFallback(metadata.revision),
       toValueOrFallback(metadata.lastModified), toValueOrFallback(metadata.version)};
   for (size_t i = 0; i < metadataValueLabels.size() && i < values.size(); ++i) {
+    if (i == 1 && metadataDescriptionCtrl) {
+      metadataDescriptionCtrl->SetValue(values[i]);
+      metadataDescriptionCtrl->ShowPosition(0);
+      continue;
+    }
     if (metadataValueLabels[i])
       metadataValueLabels[i]->SetLabel(values[i]);
   }

--- a/gui/fixtureeditdialog.h
+++ b/gui/fixtureeditdialog.h
@@ -54,6 +54,7 @@ private:
     wxTextCtrl* chCountCtrl = nullptr;
     wxTextCtrl* modelCtrl = nullptr;
     wxTextCtrl* channelList = nullptr;
+    wxTextCtrl* metadataDescriptionCtrl = nullptr;
     FixturePreviewPanel* preview = nullptr;
     wxStaticBitmap* fixtureImagePreview = nullptr;
     std::array<wxStaticText*, 8> metadataValueLabels{};


### PR DESCRIPTION
### Motivation
- Long `description` text in some GDTF fixtures caused the `Edit Fixture` dialog to expand a metadata column and hide other sections, breaking the expected layout.

### Description
- Replace the `Description` metadata display (previously a `wxStaticText`) with a dedicated multiline read-only `wxTextCtrl` (`metadataDescriptionCtrl`) so long text scrolls inside a bounded control instead of widening the dialog.
- Keep the other metadata fields as `wxStaticText` labels and update `UpdateMetadataSummary()` to write the description into the new control while preserving existing label behavior.
- Slightly increased the dialog default size from `860x700` to `900x740` and set a minimum size for the description control to preserve overall layout and readability.
- Modified files: `gui/fixtureeditdialog.cpp` and `gui/fixtureeditdialog.h`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2e68ecd888324bcdf58d72b4e5e42)