### PR TITLE
Prevent project fixture mode edits from mutating dictionary defaults

### DIFF
--- a/gui/fixtureeditdialog.cpp
+++ b/gui/fixtureeditdialog.cpp
@@ -889,8 +889,16 @@ void FixtureEditDialog::ApplyChanges() {
       table->GetValue(categoryVar, row, 18);
       const std::string category = GdtfFixtureCategory::NormalizeCategory(
           std::string(categoryVar.GetString().ToUTF8()));
-      GdtfDictionary::Update(std::string(originalType.ToUTF8()),
-                             std::string(gdtfPath.ToUTF8()), mode, category);
+      const bool modeOnlyChange =
+          (modifiedColumns.size() > 7 && modifiedColumns[7]) &&
+          !(modifiedColumns.size() > 2 && modifiedColumns[2]) &&
+          !(modifiedColumns.size() > 9 && modifiedColumns[9]) &&
+          !(modifiedColumns.size() > 18 && modifiedColumns[18]);
+      if (!modeOnlyChange) {
+        // Keep dictionary default modes immutable outside dictionary editor.
+        GdtfDictionary::Update(std::string(originalType.ToUTF8()),
+                               std::string(gdtfPath.ToUTF8()), {}, category);
+      }
       panel->ApplyModeForGdtf(gdtfPath, wxString::FromUTF8(mode));
     }
   }

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -489,15 +489,12 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
       }
       ApplyModeForGdtf(path, dictMode);
 
-      // Update dictionary with final mode for each previous type
+      // Keep dictionary default modes immutable from project table edits.
       for (size_t idx = 0; idx < selections.size(); ++idx) {
         int r = table->ItemToRow(selections[idx]);
         if (r == wxNOT_FOUND)
           continue;
-        wxVariant modeVar;
-        table->GetValue(modeVar, r, 7);
-        GdtfDictionary::Update(prevTypes[idx], pathUtf8,
-                               std::string(modeVar.GetString().ToUTF8()));
+        GdtfDictionary::Update(prevTypes[idx], pathUtf8);
       }
     }
     ResyncRows(oldOrder, selectedUuids);
@@ -559,11 +556,6 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
           chCount >= 0 ? wxString::Format("%d", chCount) : wxString();
       table->SetValue(wxVariant(chStr), sr, 8);
 
-      wxVariant typeVar;
-      table->GetValue(typeVar, sr, 2);
-      GdtfDictionary::Update(std::string(typeVar.GetString().ToUTF8()),
-                             std::string(gdtfPath.ToUTF8()),
-                             std::string(sel.ToUTF8()));
     }
     ApplyModeForGdtf(gdtfPath, sel);
 

--- a/gui/windows/symbol_fixture_applier.cpp
+++ b/gui/windows/symbol_fixture_applier.cpp
@@ -674,8 +674,8 @@ bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
   }
 
   if (libraryPath.empty() && !scenePath.empty() && !fixtureIt->second.typeName.empty()) {
-    GdtfDictionary::Update(fixtureIt->second.typeName, scenePath,
-                           fixtureIt->second.gdtfMode);
+    // Keep dictionary default modes immutable outside dictionary editor.
+    GdtfDictionary::Update(fixtureIt->second.typeName, scenePath);
   }
 
   return true;


### PR DESCRIPTION
### Motivation
- The dictionary "default mode" is a global mapping that should only be changed from the dictionary editor and must not be overwritten by per-project or per-fixture table edits.
- Project-level decisions (table edits, symbol application, or mode-only edits in the fixture editor) must remain local to the scene and not affect `text-to-scene` resolution that relies on dictionary defaults.

### Description
- Changed `gui/fixturetablepanel.cpp` so replacing fixture files in the table still updates the dictionary path via `GdtfDictionary::Update(type, path)`, but no longer writes the selected DMX mode back into the dictionary default.
- Updated `gui/fixtureeditdialog.cpp` to detect `modeOnlyChange` and avoid calling `GdtfDictionary::Update` when only the mode was edited; when metadata sync is required the dictionary update is performed without overwriting the stored default mode (mode argument left empty) and the category may still be updated.
- Updated `gui/windows/symbol_fixture_applier.cpp` to stop writing the fixture mode into the dictionary when applying symbols, calling `GdtfDictionary::Update(type, path)` without a mode to preserve the existing default.
- Affected files: `gui/fixturetablepanel.cpp`, `gui/fixtureeditdialog.cpp`, `gui/windows/symbol_fixture_applier.cpp`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (`OK`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2eb9ccbd08324a2274dff5f374bab)