### PR TITLE
Fix macOS fixture editor crash caused by stale mouse capture

### DIFF
--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -1162,6 +1162,16 @@ void FixtureTablePanel::OnItemActivated(wxDataViewEvent &event) {
     event.Skip();
     return;
   }
+
+  // On macOS, opening a modal editor from a double-click can happen while a
+  // drag-selection capture is still active. Releasing capture before opening
+  // the dialog avoids a later destruction-time assert/crash.
+  if (dragSelecting) {
+    dragSelecting = false;
+    if (HasCapture())
+      ReleaseMouse();
+  }
+
   int r = table->ItemToRow(item);
   if (r == wxNOT_FOUND)
     return;
@@ -1187,7 +1197,8 @@ void FixtureTablePanel::OnLeftDown(wxMouseEvent &evt) {
 void FixtureTablePanel::OnLeftUp(wxMouseEvent &evt) {
   if (dragSelecting) {
     dragSelecting = false;
-    ReleaseMouse();
+    if (HasCapture())
+      ReleaseMouse();
   }
   evt.Skip();
 }


### PR DESCRIPTION
### Motivation
- Prevent a macOS-specific crash/assert triggered when double-clicking a fixture row to open the modal editor while a drag-selection mouse capture is still active, which can lead to `~wxWindowBase()` assert failures in wxWidgets.

### Description
- In `gui/fixturetablepanel.cpp`, release an active drag-selection capture before creating the modal `FixtureEditDialog` by clearing `dragSelecting` and calling `ReleaseMouse()` guarded with `HasCapture()` in `OnItemActivated`.
- Harden `OnLeftUp` to call `ReleaseMouse()` only when `HasCapture()` is true to avoid invalid capture releases.
- Change touches only small, focused logic in `gui/fixturetablepanel.cpp`; this file is ~1200+ LOC so no large extraction was performed in this small fix, but the next recommended split is to extract mouse-capture/selection handling into a dedicated helper/class to keep UI hotspot growth minimal as per project guidelines.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d368accf0483249d9748f3edabdfa3)