### PR TITLE
Add conflict-selection dialog for dictionary asset exports

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -5,6 +5,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/consolepanel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ui_feature_flags.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dictionaryeditdialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/dictionary_export_conflict_dialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dataview_edit_commit.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/editable_focus_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tools/fixture_symbol_generation_tool.cpp

--- a/gui/dictionary_export_conflict_dialog.cpp
+++ b/gui/dictionary_export_conflict_dialog.cpp
@@ -1,0 +1,115 @@
+#include "dictionary_export_conflict_dialog.h"
+
+#include <wx/button.h>
+#include <wx/dataview.h>
+#include <wx/sizer.h>
+#include <wx/stattext.h>
+
+namespace {
+constexpr unsigned int kKeepExistingColumn = 1;
+constexpr unsigned int kUseNewColumn = 2;
+} // namespace
+
+DictionaryExportConflictDialog::DictionaryExportConflictDialog(
+    wxWindow *parent, const wxString &title, std::vector<Item> items)
+    : wxDialog(parent, wxID_ANY, title, wxDefaultPosition, wxSize(980, 560),
+               wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
+      items_(std::move(items)) {
+  wxBoxSizer *topSizer = new wxBoxSizer(wxVERTICAL);
+  topSizer->Add(new wxStaticText(
+                    this, wxID_ANY,
+                    "The following files already exist with different content.\n"
+                    "Choose whether to keep the existing file or use the new exported file."),
+                0, wxALL, 10);
+
+  table_ = new wxDataViewListCtrl(this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
+                                  wxDV_ROW_LINES | wxDV_VERT_RULES);
+  const int textFlags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE;
+  table_->AppendTextColumn("File", wxDATAVIEW_CELL_INERT, 180, wxALIGN_LEFT,
+                           textFlags);
+  table_->AppendToggleColumn("Keep existing", wxDATAVIEW_CELL_ACTIVATABLE, 120,
+                             wxALIGN_CENTER, wxDATAVIEW_COL_RESIZABLE);
+  table_->AppendToggleColumn("Use new", wxDATAVIEW_CELL_ACTIVATABLE, 120,
+                             wxALIGN_CENTER, wxDATAVIEW_COL_RESIZABLE);
+  table_->AppendTextColumn("Existing path", wxDATAVIEW_CELL_INERT, 250,
+                           wxALIGN_LEFT, textFlags);
+  table_->AppendTextColumn("New source", wxDATAVIEW_CELL_INERT, 250,
+                           wxALIGN_LEFT, textFlags);
+  topSizer->Add(table_, 1, wxEXPAND | wxLEFT | wxRIGHT, 10);
+
+  wxBoxSizer *actionsSizer = new wxBoxSizer(wxHORIZONTAL);
+  wxButton *selectExistingButton =
+      new wxButton(this, wxID_ANY, "Select all existing");
+  wxButton *selectNewButton = new wxButton(this, wxID_ANY, "Select all new");
+  actionsSizer->Add(selectExistingButton, 0, wxRIGHT, 8);
+  actionsSizer->Add(selectNewButton, 0, wxRIGHT, 8);
+  actionsSizer->AddStretchSpacer(1);
+  actionsSizer->Add(CreateSeparatedButtonSizer(wxOK | wxCANCEL), 0,
+                    wxALIGN_CENTER_VERTICAL);
+
+  topSizer->Add(actionsSizer, 0, wxEXPAND | wxALL, 10);
+  SetSizerAndFit(topSizer);
+  SetMinSize(wxSize(860, 480));
+
+  RefreshTable();
+
+  selectExistingButton->Bind(wxEVT_BUTTON,
+                             &DictionaryExportConflictDialog::SetAllToExisting,
+                             this);
+  selectNewButton->Bind(wxEVT_BUTTON,
+                        &DictionaryExportConflictDialog::SetAllToNew, this);
+  table_->Bind(wxEVT_DATAVIEW_ITEM_VALUE_CHANGED,
+               &DictionaryExportConflictDialog::OnTableValueChanged, this);
+}
+
+const std::vector<DictionaryExportConflictDialog::Item> &
+DictionaryExportConflictDialog::GetItems() const {
+  return items_;
+}
+
+void DictionaryExportConflictDialog::RefreshTable() {
+  if (!table_)
+    return;
+
+  table_->DeleteAllItems();
+  for (const Item &item : items_) {
+    wxVector<wxVariant> values;
+    values.push_back(wxVariant(wxString::FromUTF8(item.file_name)));
+    values.push_back(wxVariant(!item.use_new));
+    values.push_back(wxVariant(item.use_new));
+    values.push_back(wxVariant(wxString::FromUTF8(item.existing_path)));
+    values.push_back(wxVariant(wxString::FromUTF8(item.new_source_path)));
+    table_->AppendItem(values);
+  }
+}
+
+void DictionaryExportConflictDialog::SetAllToExisting(wxCommandEvent &WXUNUSED(event)) {
+  for (Item &item : items_)
+    item.use_new = false;
+  RefreshTable();
+}
+
+void DictionaryExportConflictDialog::SetAllToNew(wxCommandEvent &WXUNUSED(event)) {
+  for (Item &item : items_)
+    item.use_new = true;
+  RefreshTable();
+}
+
+void DictionaryExportConflictDialog::OnTableValueChanged(wxDataViewEvent &event) {
+  const wxDataViewItem dataViewItem = event.GetItem();
+  if (!dataViewItem.IsOk())
+    return;
+
+  const int row = table_->ItemToRow(dataViewItem);
+  if (row < 0 || static_cast<size_t>(row) >= items_.size())
+    return;
+
+  const unsigned int column = event.GetColumn();
+  if (column == kKeepExistingColumn) {
+    items_[static_cast<size_t>(row)].use_new = false;
+    RefreshTable();
+  } else if (column == kUseNewColumn) {
+    items_[static_cast<size_t>(row)].use_new = true;
+    RefreshTable();
+  }
+}

--- a/gui/dictionary_export_conflict_dialog.cpp
+++ b/gui/dictionary_export_conflict_dialog.cpp
@@ -24,6 +24,7 @@ DictionaryExportConflictDialog::DictionaryExportConflictDialog(
 
   table_ = new wxDataViewListCtrl(this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
                                   wxDV_ROW_LINES | wxDV_VERT_RULES);
+  table_->SetMinSize(wxSize(940, 460));
   const int textFlags = wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE;
   table_->AppendTextColumn("File", wxDATAVIEW_CELL_INERT, 180, wxALIGN_LEFT,
                            textFlags);
@@ -48,8 +49,10 @@ DictionaryExportConflictDialog::DictionaryExportConflictDialog(
                     wxALIGN_CENTER_VERTICAL);
 
   topSizer->Add(actionsSizer, 0, wxEXPAND | wxALL, 10);
-  SetSizerAndFit(topSizer);
-  SetMinSize(wxSize(860, 480));
+  SetSizer(topSizer);
+  SetMinSize(wxSize(1100, 720));
+  SetSize(wxSize(1260, 820));
+  Layout();
 
   RefreshTable();
 

--- a/gui/dictionary_export_conflict_dialog.h
+++ b/gui/dictionary_export_conflict_dialog.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <wx/dialog.h>
+
+class wxDataViewEvent;
+class wxDataViewListCtrl;
+class wxCommandEvent;
+
+class DictionaryExportConflictDialog : public wxDialog {
+public:
+  struct Item {
+    std::string file_name;
+    std::string existing_path;
+    std::string new_source_path;
+    bool use_new = true;
+  };
+
+  DictionaryExportConflictDialog(wxWindow *parent, const wxString &title,
+                                 std::vector<Item> items);
+
+  const std::vector<Item> &GetItems() const;
+
+private:
+  void RefreshTable();
+  void SetAllToExisting(wxCommandEvent &event);
+  void SetAllToNew(wxCommandEvent &event);
+  void OnTableValueChanged(wxDataViewEvent &event);
+
+  std::vector<Item> items_;
+  wxDataViewListCtrl *table_ = nullptr;
+};

--- a/gui/dictionaryeditdialog.cpp
+++ b/gui/dictionaryeditdialog.cpp
@@ -18,6 +18,7 @@
 #include "dictionaryeditdialog.h"
 
 #include "columnutils.h"
+#include "dictionary_export_conflict_dialog.h"
 #include "colorstore.h"
 #include "dictionary_bundle.h"
 #include "dictionary_json_contract.h"
@@ -137,6 +138,11 @@ struct SnapshotExportResult {
   size_t copied_assets = 0;
   size_t missing_assets = 0;
   std::vector<std::string> copy_errors;
+};
+
+struct SnapshotExportConflictResolution {
+  bool accepted = true;
+  std::unordered_map<std::string, bool> useNewByFileName;
 };
 
 struct ImportPathValidationSummary {
@@ -269,15 +275,10 @@ bool AskCopyReferencedAssets(wxWindow *parent, const wxString &title,
   return true;
 }
 
-std::filesystem::path BuildSnapshotAssetsDir(
-    const std::filesystem::path &snapshotPath) {
-  return snapshotPath.parent_path() /
-         (snapshotPath.stem().string() + "_assets");
-}
-
 std::optional<std::string> CopySnapshotAsset(
     const std::filesystem::path &sourcePath,
-    const std::filesystem::path &targetAssetsDir) {
+    const std::filesystem::path &targetAssetsDir,
+    const std::unordered_map<std::string, bool> &useNewByFileName) {
   if (!HasExistingPath(sourcePath))
     return std::nullopt;
 
@@ -290,11 +291,70 @@ std::optional<std::string> CopySnapshotAsset(
   if (fileName.empty())
     return std::nullopt;
   const std::filesystem::path destPath = targetAssetsDir / fileName;
+  const auto keepExistingIt = useNewByFileName.find(fileName);
+  if (keepExistingIt != useNewByFileName.end() && !keepExistingIt->second &&
+      HasExistingPath(destPath)) {
+    return fileName;
+  }
   std::filesystem::copy_file(sourcePath, destPath,
                              std::filesystem::copy_options::overwrite_existing, ec);
   if (ec)
     return std::nullopt;
-  return std::string("assets/") + fileName;
+  return fileName;
+}
+
+template <typename GatherPathsFn>
+SnapshotExportConflictResolution ResolveExportConflicts(
+    wxWindow *parent, const wxString &title,
+    const std::filesystem::path &outputPath,
+    GatherPathsFn &&gatherSourcePaths) {
+  SnapshotExportConflictResolution resolution;
+  const std::filesystem::path outputDir = outputPath.parent_path();
+
+  std::vector<std::filesystem::path> sourcePaths = gatherSourcePaths();
+  std::sort(sourcePaths.begin(), sourcePaths.end(),
+            [](const std::filesystem::path &a, const std::filesystem::path &b) {
+              return a.filename().string() < b.filename().string();
+            });
+  sourcePaths.erase(std::unique(sourcePaths.begin(), sourcePaths.end()), sourcePaths.end());
+
+  std::vector<DictionaryExportConflictDialog::Item> conflicts;
+  for (const std::filesystem::path &sourcePath : sourcePaths) {
+    if (!HasExistingPath(sourcePath))
+      continue;
+    const std::string fileName = sourcePath.filename().string();
+    if (fileName.empty())
+      continue;
+    const std::filesystem::path destinationPath = outputDir / fileName;
+    if (!HasExistingPath(destinationPath))
+      continue;
+
+    const auto sourceHash = FileImportUtils::ComputeFileSha256(sourcePath);
+    const auto destinationHash = FileImportUtils::ComputeFileSha256(destinationPath);
+    if (sourceHash && destinationHash && *sourceHash == *destinationHash)
+      continue;
+
+    conflicts.push_back(DictionaryExportConflictDialog::Item{
+        fileName, destinationPath.string(), sourcePath.string(), true});
+  }
+
+  std::sort(conflicts.begin(), conflicts.end(),
+            [](const DictionaryExportConflictDialog::Item &a,
+               const DictionaryExportConflictDialog::Item &b) {
+              return a.file_name < b.file_name;
+            });
+
+  if (conflicts.empty())
+    return resolution;
+
+  DictionaryExportConflictDialog dialog(parent, title, std::move(conflicts));
+  if (dialog.ShowModal() != wxID_OK) {
+    resolution.accepted = false;
+    return resolution;
+  }
+  for (const auto &item : dialog.GetItems())
+    resolution.useNewByFileName[item.file_name] = item.use_new;
+  return resolution;
 }
 
 std::optional<nlohmann::json> LoadJsonFromFile(const std::string &filePath,
@@ -599,6 +659,7 @@ bool ConfirmReplaceAllOperation(wxWindow *parent, const wxString &dictionaryName
 }
 
 bool SaveFixturesSnapshotToFile(
+    wxWindow *parent,
     const std::string &outputPath,
     const std::unordered_map<std::string, GdtfDictionary::Entry> &dict,
     bool copyReferencedAssets, SnapshotExportResult &exportResult) {
@@ -609,8 +670,23 @@ bool SaveFixturesSnapshotToFile(
   std::sort(keys.begin(), keys.end());
 
   const std::filesystem::path outputFsPath = std::filesystem::u8path(outputPath);
-  const std::filesystem::path targetAssetsDir =
-      BuildSnapshotAssetsDir(outputFsPath) / "assets";
+  const std::filesystem::path targetAssetsDir = outputFsPath.parent_path();
+  std::unordered_map<std::string, bool> useNewByFileName;
+  if (copyReferencedAssets) {
+    auto resolution = ResolveExportConflicts(
+        parent, "Resolve fixture export conflicts", outputFsPath, [&dict]() {
+          std::vector<std::filesystem::path> paths;
+          paths.reserve(dict.size());
+          for (const auto &[_, entry] : dict) {
+            if (!entry.path.empty())
+              paths.push_back(std::filesystem::u8path(entry.path));
+          }
+          return paths;
+        });
+    if (!resolution.accepted)
+      return false;
+    useNewByFileName = std::move(resolution.useNewByFileName);
+  }
 
   nlohmann::json entries = nlohmann::json::object();
   for (const auto &name : keys) {
@@ -621,7 +697,8 @@ bool SaveFixturesSnapshotToFile(
     if (!entry.path.empty()) {
       const std::filesystem::path sourcePath = std::filesystem::u8path(entry.path);
       if (copyReferencedAssets) {
-        const auto copiedRelativePath = CopySnapshotAsset(sourcePath, targetAssetsDir);
+        const auto copiedRelativePath =
+            CopySnapshotAsset(sourcePath, targetAssetsDir, useNewByFileName);
         if (copiedRelativePath) {
           obj["file"] = *copiedRelativePath;
           ++exportResult.copied_assets;
@@ -653,7 +730,7 @@ bool SaveFixturesSnapshotToFile(
   return true;
 }
 
-bool SaveTrussesSnapshotToFile(const std::string &outputPath,
+bool SaveTrussesSnapshotToFile(wxWindow *parent, const std::string &outputPath,
                                const std::unordered_map<std::string, std::string> &dict,
                                bool copyReferencedAssets,
                                SnapshotExportResult &exportResult) {
@@ -664,8 +741,23 @@ bool SaveTrussesSnapshotToFile(const std::string &outputPath,
   std::sort(keys.begin(), keys.end());
 
   const std::filesystem::path outputFsPath = std::filesystem::u8path(outputPath);
-  const std::filesystem::path targetAssetsDir =
-      BuildSnapshotAssetsDir(outputFsPath) / "assets";
+  const std::filesystem::path targetAssetsDir = outputFsPath.parent_path();
+  std::unordered_map<std::string, bool> useNewByFileName;
+  if (copyReferencedAssets) {
+    auto resolution = ResolveExportConflicts(
+        parent, "Resolve truss export conflicts", outputFsPath, [&dict]() {
+          std::vector<std::filesystem::path> paths;
+          paths.reserve(dict.size());
+          for (const auto &[_, path] : dict) {
+            if (!path.empty())
+              paths.push_back(std::filesystem::u8path(path));
+          }
+          return paths;
+        });
+    if (!resolution.accepted)
+      return false;
+    useNewByFileName = std::move(resolution.useNewByFileName);
+  }
 
   nlohmann::json entries = nlohmann::json::object();
   for (const auto &name : keys) {
@@ -674,7 +766,8 @@ bool SaveTrussesSnapshotToFile(const std::string &outputPath,
       continue;
     const std::filesystem::path sourcePath = std::filesystem::u8path(path);
     if (copyReferencedAssets) {
-      const auto copiedRelativePath = CopySnapshotAsset(sourcePath, targetAssetsDir);
+      const auto copiedRelativePath =
+          CopySnapshotAsset(sourcePath, targetAssetsDir, useNewByFileName);
       if (copiedRelativePath) {
         entries[name] = nlohmann::json{{"file", *copiedRelativePath}};
         ++exportResult.copied_assets;
@@ -1505,7 +1598,7 @@ bool DictionaryEditDialog::ExportFixturesDictionary() {
 
   const std::string outputPath = std::string(fileDialog.GetPath().ToUTF8());
   SnapshotExportResult exportResult;
-  if (!SaveFixturesSnapshotToFile(outputPath, *dictOpt, copyReferencedAssets,
+  if (!SaveFixturesSnapshotToFile(this, outputPath, *dictOpt, copyReferencedAssets,
                                   exportResult)) {
     wxMessageBox("Could not write fixtures dictionary snapshot.",
                  "Export fixtures dictionary", wxICON_ERROR | wxOK, this);
@@ -1557,7 +1650,7 @@ bool DictionaryEditDialog::ExportTrussesDictionary() {
 
   const std::string outputPath = std::string(fileDialog.GetPath().ToUTF8());
   SnapshotExportResult exportResult;
-  if (!SaveTrussesSnapshotToFile(outputPath, *dictOpt, copyReferencedAssets,
+  if (!SaveTrussesSnapshotToFile(this, outputPath, *dictOpt, copyReferencedAssets,
                                  exportResult)) {
     wxMessageBox("Could not write trusses dictionary snapshot.",
                  "Export trusses dictionary", wxICON_ERROR | wxOK, this);
@@ -1591,17 +1684,17 @@ bool DictionaryEditDialog::ExportFixturesPortableBundle() {
   const wxString fixturesDir =
       wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("fixtures"));
   wxFileDialog fileDialog(this, "Export portable fixtures bundle", fixturesDir,
-                          "gdtf_dictionary_bundle.zip",
-                          "ZIP files (*.zip)|*.zip",
+                          "gdtf_dictionary_bundle.json",
+                          "JSON files (*.json)|*.json",
                           wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
   if (fileDialog.ShowModal() != wxID_OK)
     return false;
 
-  std::string error;
   const std::string outputPath = std::string(fileDialog.GetPath().ToUTF8());
-  if (!DictionaryBundle::ExportFixturesBundle(*dictOpt, outputPath, error)) {
-    wxMessageBox("Could not write fixtures portable bundle.\n\n" +
-                     wxString::FromUTF8(error),
+  SnapshotExportResult exportResult;
+  if (!SaveFixturesSnapshotToFile(this, outputPath, *dictOpt, true,
+                                  exportResult)) {
+    wxMessageBox("Could not write fixtures portable bundle.",
                  "Export portable fixtures bundle", wxICON_ERROR | wxOK, this);
     return false;
   }
@@ -1622,17 +1715,17 @@ bool DictionaryEditDialog::ExportTrussesPortableBundle() {
   const wxString trussesDir =
       wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("trusses"));
   wxFileDialog fileDialog(this, "Export portable trusses bundle", trussesDir,
-                          "truss_dictionary_bundle.zip",
-                          "ZIP files (*.zip)|*.zip",
+                          "truss_dictionary_bundle.json",
+                          "JSON files (*.json)|*.json",
                           wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
   if (fileDialog.ShowModal() != wxID_OK)
     return false;
 
-  std::string error;
   const std::string outputPath = std::string(fileDialog.GetPath().ToUTF8());
-  if (!DictionaryBundle::ExportTrussesBundle(*dictOpt, outputPath, error)) {
-    wxMessageBox("Could not write trusses portable bundle.\n\n" +
-                     wxString::FromUTF8(error),
+  SnapshotExportResult exportResult;
+  if (!SaveTrussesSnapshotToFile(this, outputPath, *dictOpt, true,
+                                 exportResult)) {
+    wxMessageBox("Could not write trusses portable bundle.",
                  "Export portable trusses bundle", wxICON_ERROR | wxOK, this);
     return false;
   }


### PR DESCRIPTION
### Motivation
- Ensure exported dictionary snapshots (`.json`) and their referenced assets are placed in the same destination folder and provide a user-driven resolution for file content conflicts when copying assets.
- Avoid silently overwriting or ignoring conflicting files by showing only real conflicts (content differs) and letting the user choose per-file or in bulk whether to keep the existing destination file or use the new exported file.
- Keep the export UX consistent for both fixtures and trusses and reuse the same conflict-resolution flow for the portable bundle export path.

### Description
- Added a new dialog `DictionaryExportConflictDialog` (`gui/dictionary_export_conflict_dialog.h/.cpp`) that shows alphabetically-sorted conflicts in a table with per-row selectors for `Keep existing` vs `Use new` and buttons to `Select all existing` / `Select all new`; rows default to `Use new`.
- Implemented conflict detection and resolution flow in `gui/dictionaryeditdialog.cpp` via `ResolveExportConflicts(...)` which computes file checksums using `FileImportUtils::ComputeFileSha256` and presents only differing files to the dialog, then applies the chosen policy per filename when copying.
- Changed asset copy/export behavior so the exported `.json` and referenced assets are written into the same folder as the `.json` file and referenced by filename; updated `CopySnapshotAsset(...)` and the `SaveFixturesSnapshotToFile` / `SaveTrussesSnapshotToFile` call sites to accept the conflict decisions and write files into the chosen output directory.
- Updated the portable bundle export actions to produce a `.json` snapshot using the same export+asset-copy flow (replacing the previous ZIP-based bundle export in this PR) and registered the new dialog in `gui/CMakeLists.txt`.
- Technical note: `gui/dictionaryeditdialog.cpp` is a large hotspot (~1.7k LOC) and now contains new conflict-resolution logic; recommended follow-up split is to extract the `ResolveExportConflicts` and asset-copy helpers into an adjacent helper/utility file to keep the dialog focused on UI only, per project `AGENTS.md` file-size guidance.

### Testing
- Ran module/style checks: `tests/check_perastage_tree_modules.sh` (passed) and `tests/check_no_configmanager_get_in_gui.sh` (passed).
- Attempted project configure/build with `cmake -S . -B build` and `cmake --build build -j2` in CI-like environment, but CMake configuration failed due to missing `wxWidgets` development libraries in this environment (failure unrelated to the change itself).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d36b76d79c8324b202cccd7768e58b)