### PR TITLE
Support pipe/vara rider lines as MVR SceneObjects

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -48,6 +48,7 @@
 #include "hoist_weight_distribution.h"
 #include "layer.h"
 #include "logger.h"
+#include "sceneobject.h"
 #include "support.h"
 #include "truss.h"
 #include "trussdictionary.h"
@@ -61,14 +62,16 @@ namespace {
 // the compilation cost on every import call and makes keyword matching cheap
 // even when processing large riders.
 static const std::regex kTrussLineRe(
-    "^\\s*(?:[-*]\\s*)?(\\d+)\\s+(?:truss)\\s+([^\\n]*?)\\s+(\\d+(?:\\.\\d+)?)\\s*(?:m|metros?|meters?)\\b(?:\\s+(?:(?:para|for)\\s+)?(.+))?\\s*$",
+    "^\\s*(?:[-*]\\s*)?(\\d+)\\s+(?:truss|pipe|pipes|vara|varas)\\s+([^\\n]*?)\\s+(\\d+(?:\\.\\d+)?)\\s*(?:m|metros?|meters?)\\b(?:\\s+(?:(?:para|for)\\s+)?(.+))?\\s*$",
     std::regex::icase);
 static const std::regex kTrussLineNoLengthRe(
-    "^\\s*(?:[-*]\\s*)?(\\d+)\\s+(?:truss)\\s+([^\\n]*?)(?:\\s+(?:para|for)\\s+(.+))?\\s*$",
+    "^\\s*(?:[-*]\\s*)?(\\d+)\\s+(?:truss|pipe|pipes|vara|varas)\\s+([^\\n]*?)(?:\\s+(?:para|for)\\s+(.+))?\\s*$",
     std::regex::icase);
 static const std::regex kTrussRe(
-    "(?:truss)[^\\n]*?(\\d+(?:\\.\\d+)?)\\s*(?:m|metros?|meters?)\\b",
+    "(?:truss|pipe|pipes|vara|varas)[^\\n]*?(\\d+(?:\\.\\d+)?)\\s*(?:m|metros?|meters?)\\b",
     std::regex::icase);
+static const std::regex kPipeKeywordRe("\\b(?:pipe|pipes|vara|varas)\\b",
+                                       std::regex::icase);
 static const std::regex kLengthWithUnitRe(
     "(\\d+(?:\\.\\d+)?)\\s*(?:m|metros?|meters?)\\b", std::regex::icase);
 static const std::regex kHoistLineRe(
@@ -103,6 +106,13 @@ std::string Trim(const std::string &s) {
     return {};
   size_t end = s.find_last_not_of(" \t\r\n");
   return s.substr(start, end - start + 1);
+}
+
+enum class RiggingLineKind { Truss, Pipe };
+
+RiggingLineKind DetectRiggingLineKind(const std::string &line) {
+  return std::regex_search(line, kPipeKeywordRe) ? RiggingLineKind::Pipe
+                                                  : RiggingLineKind::Truss;
 }
 
 std::optional<std::string> ExtractParenthesizedToken(const std::string &text) {
@@ -1137,6 +1147,9 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
     }
 
     if (std::regex_match(line, m, kTrussLineRe)) {
+      const RiggingLineKind riggingKind = DetectRiggingLineKind(line);
+      const std::string riggingKeyword =
+          riggingKind == RiggingLineKind::Pipe ? "PIPE" : "TRUSS";
       int quantity = 0;
       if (!TryParseInt(m[1].str(), quantity) || quantity <= 0)
         continue;
@@ -1200,7 +1213,7 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
 
       const std::string lenText = formatLengthM(lengthM) + "m";
       auto buildLine = [&](const std::string &targetHang) {
-        std::string out = "1 TRUSS";
+        std::string out = "1 " + riggingKeyword;
         if (!model.empty())
           out += " " + model;
         out += " " + lenText;
@@ -1230,6 +1243,9 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
 
     if (std::regex_match(line, m, kTrussLineNoLengthRe) &&
         !std::regex_search(line, kLengthWithUnitRe)) {
+      const RiggingLineKind riggingKind = DetectRiggingLineKind(line);
+      const std::string riggingKeyword =
+          riggingKind == RiggingLineKind::Pipe ? "PIPE" : "TRUSS";
       int quantity = 0;
       if (!TryParseInt(m[1].str(), quantity) || quantity <= 0)
         continue;
@@ -1276,14 +1292,18 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
       hang = ResolveHangTargetFallback(hang);
       if (hang.empty())
         hang = NormalizeHangName(currentHang);
-      if (hang != "BACKDROP")
+      const bool keepLine = riggingKind == RiggingLineKind::Pipe || hang == "BACKDROP";
+      if (!keepLine)
         continue;
 
       for (int i = 0; i < quantity; ++i) {
-        std::string out = "1 TRUSS";
+        std::string out = "1 " + riggingKeyword;
         if (!model.empty())
           out += " " + model;
-        out += " " + hang;
+        if (riggingKind == RiggingLineKind::Pipe)
+          out += " 14m";
+        if (!hang.empty())
+          out += " " + hang;
         if (!trussCoordinateSuffix.empty())
           out += " " + trussCoordinateSuffix;
         if (!trussMarginSuffix.empty())
@@ -1294,6 +1314,9 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
     }
 
     if (std::regex_search(line, m, kTrussRe)) {
+      const RiggingLineKind riggingKind = DetectRiggingLineKind(line);
+      const std::string riggingKeyword =
+          riggingKind == RiggingLineKind::Pipe ? "PIPE" : "TRUSS";
       float lengthM = 0.0f;
       if (!TryParseFloat(m[1].str(), lengthM))
         continue;
@@ -1304,7 +1327,7 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
         hang = NormalizeHangName(currentHang);
       if (hang == "FLOOR")
         continue;
-      std::string out = "1 TRUSS " + formatLengthM(lengthM) + "m";
+      std::string out = "1 " + riggingKeyword + " " + formatLengthM(lengthM) + "m";
       if (!hang.empty())
         out += " " + hang;
       riggingLines.push_back(out);
@@ -1567,6 +1590,15 @@ bool RiderImporter::ImportText(const std::string &text) {
   std::unordered_set<std::string> seenTypes;
   std::vector<std::string> importedTrussUuids;
   std::vector<std::string> importedFixtureUuids;
+  struct PipeSpanInfo {
+    std::string positionName;
+    float startX = 0.0f;
+    float endX = 0.0f;
+    float y = 0.0f;
+    float z = 0.0f;
+  };
+  std::vector<PipeSpanInfo> importedPipeSpans;
+  std::unordered_set<std::string> pipeHangNames;
   struct ScreenObjectRequest {
     std::string name;
     std::string layer;
@@ -1736,6 +1768,7 @@ bool RiderImporter::ImportText(const std::string &text) {
         hoistRequests.push_back(
             {parsedHoist.quantity, parsedHoist.capacityKg, parsedHoist.target});
       } else if (std::regex_match(line, m, kTrussLineRe)) {
+        const RiggingLineKind riggingKind = DetectRiggingLineKind(line);
         int quantity = 0;
         if (!TryParseInt(m[1].str(), quantity))
           continue;
@@ -1953,6 +1986,43 @@ bool RiderImporter::ImportText(const std::string &text) {
           }
         };
 
+        auto addPipeObject = [&](const std::string &posName,
+                                 const std::optional<TrussCoordinateOverride>
+                                     &coordinateOverride) {
+          const float pipeLengthMm = length;
+          const float pipeDiameterMm = 100.0f;
+          const float fallbackCubeMm = 300.0f;
+          const float startX = coordinateOverride && coordinateOverride->hasX
+                                   ? coordinateOverride->xMm
+                                   : -0.5f * pipeLengthMm;
+          const float hangY = coordinateOverride && coordinateOverride->hasY
+                                  ? coordinateOverride->yMm
+                                  : getHangPos(posName);
+          const float hangZ = coordinateOverride && coordinateOverride->hasZ
+                                  ? coordinateOverride->zMm
+                                  : getHangHeight(posName);
+
+          SceneObject pipeObject;
+          pipeObject.uuid = GenerateUuid();
+          pipeObject.layer =
+              layerByType ? ("obj " + posName) : ("pos " + posName);
+          std::string lengthLabel = formatLength(pipeLengthMm);
+          pipeObject.name = model.empty() ? ("PIPE " + lengthLabel)
+                                          : ("PIPE " + model + " " + lengthLabel);
+          pipeObject.transform.u = {pipeLengthMm / fallbackCubeMm, 0.0f, 0.0f};
+          pipeObject.transform.v = {0.0f, pipeDiameterMm / fallbackCubeMm, 0.0f};
+          pipeObject.transform.w = {0.0f, 0.0f, pipeDiameterMm / fallbackCubeMm};
+          pipeObject.transform.o[0] = startX + 0.5f * pipeLengthMm;
+          pipeObject.transform.o[1] = hangY;
+          pipeObject.transform.o[2] = hangZ;
+
+          importedPipeSpans.push_back({posName, startX, startX + pipeLengthMm, hangY,
+                                       hangZ});
+          pipeHangNames.insert(posName);
+          scene.sceneObjects.emplace(pipeObject.uuid, pipeObject);
+          addToLayer(pipeObject.layer, pipeObject.uuid);
+        };
+
         auto resolveCoordinateOverride = [&](const std::string &posName) {
           TrussCoordinateOverride resolved;
           bool hasResolved = false;
@@ -1981,15 +2051,26 @@ bool RiderImporter::ImportText(const std::string &text) {
         };
 
         if (hang == "LX") {
-          for (int i = 0; i < quantity; ++i)
-            addTrussPieces("LX" + std::to_string(i + 1),
-                           resolveCoordinateOverride("LX" + std::to_string(i + 1)));
+          for (int i = 0; i < quantity; ++i) {
+            const std::string posName = "LX" + std::to_string(i + 1);
+            if (riggingKind == RiggingLineKind::Pipe) {
+              addPipeObject(posName, resolveCoordinateOverride(posName));
+            } else {
+              addTrussPieces(posName, resolveCoordinateOverride(posName));
+            }
+          }
         } else {
-          for (int i = 0; i < quantity; ++i)
-            addTrussPieces(hang, resolveCoordinateOverride(hang));
+          for (int i = 0; i < quantity; ++i) {
+            if (riggingKind == RiggingLineKind::Pipe) {
+              addPipeObject(hang, resolveCoordinateOverride(hang));
+            } else {
+              addTrussPieces(hang, resolveCoordinateOverride(hang));
+            }
+          }
         }
       } else if (std::regex_match(line, m, kTrussLineNoLengthRe) &&
                  !std::regex_search(line, kLengthWithUnitRe)) {
+        const RiggingLineKind riggingKind = DetectRiggingLineKind(line);
         int quantity = 0;
         if (!TryParseInt(m[1].str(), quantity))
           continue;
@@ -2026,10 +2107,85 @@ bool RiderImporter::ImportText(const std::string &text) {
         hang = ResolveHangTargetFallback(hang);
         if (hang.empty())
           hang = NormalizeHangName(currentHang);
-        if (hang != "BACKDROP")
+        const bool isPipe = riggingKind == RiggingLineKind::Pipe;
+        if (!isPipe && hang != "BACKDROP")
           continue;
         if (marginOverrideMm.has_value())
           hangMarginOverridesMm[hang] = *marginOverrideMm;
+
+        if (isPipe) {
+          const float defaultPipeLengthMm = 14000.0f;
+          const float pipeDiameterMm = 100.0f;
+          const float fallbackCubeMm = 300.0f;
+          auto addPipeObject = [&](const std::string &posName,
+                                   const std::optional<TrussCoordinateOverride>
+                                       &resolvedOverride) {
+            const float startX = resolvedOverride && resolvedOverride->hasX
+                                     ? resolvedOverride->xMm
+                                     : -0.5f * defaultPipeLengthMm;
+            const float hangY = resolvedOverride && resolvedOverride->hasY
+                                    ? resolvedOverride->yMm
+                                    : getHangPos(posName);
+            const float hangZ = resolvedOverride && resolvedOverride->hasZ
+                                    ? resolvedOverride->zMm
+                                    : getHangHeight(posName);
+
+            SceneObject pipeObject;
+            pipeObject.uuid = GenerateUuid();
+            pipeObject.layer = layerByType ? ("obj " + posName) : ("pos " + posName);
+            pipeObject.name = model.empty() ? "PIPE 14M" : ("PIPE " + model + " 14M");
+            pipeObject.transform.u = {defaultPipeLengthMm / fallbackCubeMm, 0.0f,
+                                      0.0f};
+            pipeObject.transform.v = {0.0f, pipeDiameterMm / fallbackCubeMm, 0.0f};
+            pipeObject.transform.w = {0.0f, 0.0f, pipeDiameterMm / fallbackCubeMm};
+            pipeObject.transform.o[0] = startX + 0.5f * defaultPipeLengthMm;
+            pipeObject.transform.o[1] = hangY;
+            pipeObject.transform.o[2] = hangZ;
+            scene.sceneObjects.emplace(pipeObject.uuid, pipeObject);
+            addToLayer(pipeObject.layer, pipeObject.uuid);
+            importedPipeSpans.push_back(
+                {posName, startX, startX + defaultPipeLengthMm, hangY, hangZ});
+            pipeHangNames.insert(posName);
+          };
+
+          auto resolveOverride = [&](const std::string &posName) {
+            TrussCoordinateOverride resolved;
+            bool hasResolved = false;
+            if (const auto hangOverrideIt = hangCoordinateOverrides.find(posName);
+                hangOverrideIt != hangCoordinateOverrides.end()) {
+              resolved = hangOverrideIt->second;
+              hasResolved = true;
+            }
+            if (coordinateOverride.has_value()) {
+              if (coordinateOverride->hasX) {
+                resolved.hasX = true;
+                resolved.xMm = coordinateOverride->xMm;
+              }
+              if (coordinateOverride->hasY) {
+                resolved.hasY = true;
+                resolved.yMm = coordinateOverride->yMm;
+              }
+              if (coordinateOverride->hasZ) {
+                resolved.hasZ = true;
+                resolved.zMm = coordinateOverride->zMm;
+              }
+              hasResolved = true;
+            }
+            return hasResolved ? std::optional<TrussCoordinateOverride>(resolved)
+                               : std::nullopt;
+          };
+
+          if (hang == "LX") {
+            for (int i = 0; i < quantity; ++i) {
+              const std::string posName = "LX" + std::to_string(i + 1);
+              addPipeObject(posName, resolveOverride(posName));
+            }
+          } else {
+            for (int i = 0; i < quantity; ++i)
+              addPipeObject(hang, resolveOverride(hang));
+          }
+          continue;
+        }
 
         float width = 400.0f;
         float height = 400.0f;
@@ -2132,6 +2288,7 @@ bool RiderImporter::ImportText(const std::string &text) {
           }
         }
       } else if (std::regex_search(line, m, kTrussRe)) {
+        const RiggingLineKind riggingKind = DetectRiggingLineKind(line);
         float length = 0.0f;
         if (!TryParseFloat(m[1], length))
           continue;
@@ -2177,6 +2334,46 @@ bool RiderImporter::ImportText(const std::string &text) {
         }
         if (hang == "FLOOR")
           continue;
+
+        if (riggingKind == RiggingLineKind::Pipe) {
+          const float pipeLengthMm = length;
+          const float pipeDiameterMm = 100.0f;
+          const float fallbackCubeMm = 300.0f;
+          const float startX = coordinateOverride && coordinateOverride->hasX
+                                   ? coordinateOverride->xMm
+                                   : -0.5f * pipeLengthMm;
+          const float hangY = coordinateOverride && coordinateOverride->hasY
+                                  ? coordinateOverride->yMm
+                                  : getHangPos(hang);
+          const float hangZ = coordinateOverride && coordinateOverride->hasZ
+                                  ? coordinateOverride->zMm
+                                  : getHangHeight(hang);
+
+          SceneObject pipeObject;
+          pipeObject.uuid = GenerateUuid();
+          pipeObject.layer = layerByType ? ("obj " + hang) : ("pos " + hang);
+          {
+            std::ostringstream label;
+            label << std::fixed << std::setprecision(2) << (length / 1000.0f);
+            std::string lengthText = label.str();
+            lengthText.erase(lengthText.find_last_not_of('0') + 1,
+                             std::string::npos);
+            if (!lengthText.empty() && lengthText.back() == '.')
+              lengthText.pop_back();
+            pipeObject.name = "PIPE " + lengthText + "M";
+          }
+          pipeObject.transform.u = {pipeLengthMm / fallbackCubeMm, 0.0f, 0.0f};
+          pipeObject.transform.v = {0.0f, pipeDiameterMm / fallbackCubeMm, 0.0f};
+          pipeObject.transform.w = {0.0f, 0.0f, pipeDiameterMm / fallbackCubeMm};
+          pipeObject.transform.o[0] = startX + 0.5f * pipeLengthMm;
+          pipeObject.transform.o[1] = hangY;
+          pipeObject.transform.o[2] = hangZ;
+          scene.sceneObjects.emplace(pipeObject.uuid, pipeObject);
+          addToLayer(pipeObject.layer, pipeObject.uuid);
+          importedPipeSpans.push_back({hang, startX, startX + pipeLengthMm, hangY, hangZ});
+          pipeHangNames.insert(hang);
+          continue;
+        }
 
         auto formatLength = [](float mm) {
           std::ostringstream oss;
@@ -2469,6 +2666,24 @@ bool RiderImporter::ImportText(const std::string &text) {
     } else {
       info.startX = std::min(info.startX, start);
       info.endX = std::max(info.endX, end);
+    }
+  }
+
+  for (const PipeSpanInfo &pipeInfo : importedPipeSpans) {
+    auto &info = trussInfo[pipeInfo.positionName];
+    if (!info.found) {
+      info.startX = pipeInfo.startX;
+      info.endX = pipeInfo.endX;
+      info.y = pipeInfo.y;
+      info.z = pipeInfo.z;
+      info.width = 100.0f;
+      info.found = true;
+    } else {
+      info.startX = std::min(info.startX, pipeInfo.startX);
+      info.endX = std::max(info.endX, pipeInfo.endX);
+      info.y = pipeInfo.y;
+      info.z = pipeInfo.z;
+      info.width = 100.0f;
     }
   }
 
@@ -2924,6 +3139,16 @@ bool RiderImporter::ImportText(const std::string &text) {
       placeFixturesAsSides(ordered, sideTrussInfo.leftX, sideTrussInfo.rightX, startY,
                            endY, sideTrussInfo.found,
                            sideTrussInfo.found ? sideTrussInfo.z : 1000.0f);
+      continue;
+    }
+    if (pipeHangNames.count(pos) > 0) {
+      placeFixtureGroup(pos, fixturesVec,
+                        [&](Fixture &fixture, float x, float baseY, float baseZ,
+                            float /*width*/) {
+                          fixture.transform.o[0] = x;
+                          fixture.transform.o[1] = baseY;
+                          fixture.transform.o[2] = baseZ;
+                        });
       continue;
     }
 

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -59,6 +59,15 @@
 
 namespace {
 constexpr const char *kPrimitiveCylinderToken = "primitive:cylinder";
+
+Matrix BuildCylinderAxisXLocalTransform() {
+  Matrix transform{};
+  transform.u = {0.0f, 0.0f, -1.0f};
+  transform.v = {0.0f, 1.0f, 0.0f};
+  transform.w = {1.0f, 0.0f, 0.0f};
+  transform.o = {0.0f, 0.0f, 0.0f};
+  return transform;
+}
 // Precompiled regexes used by RiderImporter. Keeping them static avoids paying
 // the compilation cost on every import call and makes keyword matching cheap
 // even when processing large riders.
@@ -2016,7 +2025,8 @@ bool RiderImporter::ImportText(const std::string &text) {
           pipeObject.transform.o[0] = startX + 0.5f * pipeLengthMm;
           pipeObject.transform.o[1] = hangY;
           pipeObject.transform.o[2] = hangZ;
-          pipeObject.geometries.push_back({kPrimitiveCylinderToken, Matrix{}});
+          pipeObject.geometries.push_back(
+              {kPrimitiveCylinderToken, BuildCylinderAxisXLocalTransform()});
 
           importedPipeSpans.push_back({posName, startX, startX + pipeLengthMm, hangY,
                                        hangZ});
@@ -2143,7 +2153,8 @@ bool RiderImporter::ImportText(const std::string &text) {
             pipeObject.transform.o[0] = startX + 0.5f * defaultPipeLengthMm;
             pipeObject.transform.o[1] = hangY;
             pipeObject.transform.o[2] = hangZ;
-            pipeObject.geometries.push_back({kPrimitiveCylinderToken, Matrix{}});
+            pipeObject.geometries.push_back(
+                {kPrimitiveCylinderToken, BuildCylinderAxisXLocalTransform()});
             scene.sceneObjects.emplace(pipeObject.uuid, pipeObject);
             addToLayer(pipeObject.layer, pipeObject.uuid);
             importedPipeSpans.push_back(
@@ -2371,7 +2382,8 @@ bool RiderImporter::ImportText(const std::string &text) {
           pipeObject.transform.o[0] = startX + 0.5f * pipeLengthMm;
           pipeObject.transform.o[1] = hangY;
           pipeObject.transform.o[2] = hangZ;
-          pipeObject.geometries.push_back({kPrimitiveCylinderToken, Matrix{}});
+          pipeObject.geometries.push_back(
+              {kPrimitiveCylinderToken, BuildCylinderAxisXLocalTransform()});
           scene.sceneObjects.emplace(pipeObject.uuid, pipeObject);
           addToLayer(pipeObject.layer, pipeObject.uuid);
           importedPipeSpans.push_back({hang, startX, startX + pipeLengthMm, hangY, hangZ});

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -58,6 +58,7 @@
 #include <filesystem>
 
 namespace {
+constexpr const char *kPrimitiveCylinderToken = "primitive:cylinder";
 // Precompiled regexes used by RiderImporter. Keeping them static avoids paying
 // the compilation cost on every import call and makes keyword matching cheap
 // even when processing large riders.
@@ -2015,6 +2016,7 @@ bool RiderImporter::ImportText(const std::string &text) {
           pipeObject.transform.o[0] = startX + 0.5f * pipeLengthMm;
           pipeObject.transform.o[1] = hangY;
           pipeObject.transform.o[2] = hangZ;
+          pipeObject.geometries.push_back({kPrimitiveCylinderToken, Matrix{}});
 
           importedPipeSpans.push_back({posName, startX, startX + pipeLengthMm, hangY,
                                        hangZ});
@@ -2141,6 +2143,7 @@ bool RiderImporter::ImportText(const std::string &text) {
             pipeObject.transform.o[0] = startX + 0.5f * defaultPipeLengthMm;
             pipeObject.transform.o[1] = hangY;
             pipeObject.transform.o[2] = hangZ;
+            pipeObject.geometries.push_back({kPrimitiveCylinderToken, Matrix{}});
             scene.sceneObjects.emplace(pipeObject.uuid, pipeObject);
             addToLayer(pipeObject.layer, pipeObject.uuid);
             importedPipeSpans.push_back(
@@ -2368,6 +2371,7 @@ bool RiderImporter::ImportText(const std::string &text) {
           pipeObject.transform.o[0] = startX + 0.5f * pipeLengthMm;
           pipeObject.transform.o[1] = hangY;
           pipeObject.transform.o[2] = hangZ;
+          pipeObject.geometries.push_back({kPrimitiveCylinderToken, Matrix{}});
           scene.sceneObjects.emplace(pipeObject.uuid, pipeObject);
           addToLayer(pipeObject.layer, pipeObject.uuid);
           importedPipeSpans.push_back({hang, startX, startX + pipeLengthMm, hangY, hangZ});

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -180,6 +180,11 @@ Supported truss syntax includes:
 - `N truss MODEL [para HANG]` (lengthless form, used for backdrop lines)
 - `N truss MODEL [for HANG]` (lengthless form, used for backdrop lines)
 - More generic fallback lines containing `truss` and a measurable length.
+- Pipe aliases are also accepted: `pipe`, `pipes`, `vara`, `varas`.
+  - `N pipe MODEL LENGTH m [para/for HANG]`
+  - `N pipe MODEL [para/for HANG]` (defaults to `14 m`).
+  - Pipe lines use the same parenthesis coordinate overrides and bracket margin
+    overrides as truss lines.
 - Optional coordinate override appended to hang in parentheses, e.g.
   - `LX1 (0, -1, 9)` => `x, y, z`
   - `LX1 ( -1, 9 )` => `y, z` (keeps default `x`)
@@ -221,6 +226,17 @@ Key truss behaviors:
      adjectives (e.g. `NEGRO`, `BLACK`) so names like `40X40 PRO NEGRO` can
      resolve against canonical dictionary entries such as `TRUSS 40X40 PRO 3M`.
 8. If model/symbol cannot be fully resolved to renderable geometry (`.3ds`/`.glb` available), importer keeps dummy-box truss data and logs a warning.
+
+Pipe-specific behavior:
+
+1. Pipe lines create `SceneObject` entries (object table), not truss entries.
+2. Imported pipes are created as simple cylindrical placeholders:
+   - length = parsed length (or `14 m` for lengthless pipe lines),
+   - radius = `5 cm` (`100 mm` diameter).
+3. Pipe lines still create/target the same normalized hang names (`LX1`, `LX2`, ...),
+   including `PUENTES LX` expansion to `LX1..LXN`.
+4. Pipes do not carry truss hang-weight fields; fixtures still keep their hang
+   position assignments exactly as usual.
 
 Special case:
 
@@ -325,14 +341,16 @@ Driven by config key `rider_layer_mode`:
 - `position` mode:
   - Fixtures: `pos <hang>`
   - Trusses: `pos <hang>`
+  - Pipe objects: `pos <hang>`
 - `type` mode:
   - Fixtures: `fix <fixture type>`
   - Trusses: `truss <hang>`
+  - Pipe objects: `obj <hang>`
 - Hoists (both modes): `rig <hoist function>`
 
 Missing/empty names fall back to the default scene layer.
 
-## Fixture distribution over trusses
+## Fixture distribution over trusses/pipes
 
 After parsing, imported fixtures are distributed per hang:
 
@@ -382,6 +400,9 @@ After parsing, imported fixtures are distributed per hang:
      - with real side trusses: same side-truss anchors as `LX SIDES`,
      - fallback without side trusses: `0.5 m` inside the widest detected `LX*`
        truss span (`left = minX + 0.5 m`, `right = maxX - 0.5 m`).
+10. If a hang is created from `pipe`/`vara` syntax, all fixture categories on
+    that hang use the same direct placement (`x` distribution + shared `baseY/baseZ`);
+    no extra front/back/top offsets are applied.
 
 ## Numbering and identity rules
 

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -233,6 +233,9 @@ Pipe-specific behavior:
 2. Imported pipes are created as simple cylindrical placeholders:
    - length = parsed length (or `14 m` for lengthless pipe lines),
    - radius = `5 cm` (`100 mm` diameter).
+   - Import stores a cylinder primitive geometry reference on the object so the
+     3D view renders the pipe directly as a cylinder (not only as a generic
+     meshless fallback box).
 3. Pipe lines still create/target the same normalized hang names (`LX1`, `LX2`, ...),
    including `PUENTES LX` expansion to `LX1..LXN`.
 4. Pipes do not carry truss hang-weight fields; fixtures still keep their hang

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -236,6 +236,8 @@ Pipe-specific behavior:
    - Import stores a cylinder primitive geometry reference on the object so the
      3D view renders the pipe directly as a cylinder (not only as a generic
      meshless fallback box).
+   - The primitive is oriented so the cylinder main axis is parallel to `X`
+     for regular pipe hangs.
 3. Pipe lines still create/target the same normalized hang names (`LX1`, `LX2`, ...),
    including `PUENTES LX` expansion to `LX1..LXN`.
 4. Pipes do not carry truss hang-weight fields; fixtures still keep their hang

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -1965,6 +1965,9 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
 
   auto exportSceneObject = [&](tinyxml2::XMLElement *parent,
                                const SceneObject &obj) {
+    auto isPrimitiveModelRef = [](const std::string &modelRef) {
+      return modelRef.rfind("primitive:", 0) == 0;
+    };
     tinyxml2::XMLElement *oe = doc.NewElement("SceneObject");
     oe->SetAttribute("uuid", obj.uuid.c_str());
     if (!obj.name.empty())
@@ -1973,7 +1976,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
     if (!obj.geometries.empty()) {
       tinyxml2::XMLElement *geos = doc.NewElement("Geometries");
       for (const auto &geo : obj.geometries) {
-        if (geo.modelFile.empty())
+        if (geo.modelFile.empty() || isPrimitiveModelRef(geo.modelFile))
           continue;
 
         tinyxml2::XMLElement *g3d = doc.NewElement("Geometry3D");
@@ -1991,7 +1994,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
 
       if (geos->FirstChild())
         oe->InsertEndChild(geos);
-    } else if (!obj.modelFile.empty()) {
+    } else if (!obj.modelFile.empty() && !isPrimitiveModelRef(obj.modelFile)) {
       tinyxml2::XMLElement *geos = doc.NewElement("Geometries");
       tinyxml2::XMLElement *g3d = doc.NewElement("Geometry3D");
       std::string modelArchivePath =

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -766,6 +766,33 @@ target_link_libraries(rider_lx_sides_import_test PRIVATE ${wxWidgets_LIBRARIES} 
 add_test(NAME RiderLxSidesImport COMMAND rider_lx_sides_import_test)
 set_library_env(RiderLxSidesImport)
 
+add_executable(rider_pipe_import_test rider_pipe_import_test.cpp
+               riderimporter_stubs.cpp
+               gdtfloader_stub.cpp
+               ../core/riderimporter.cpp
+               ../core/units/units.cpp
+               ../core/gdtf_fixture_category.cpp
+               ../core/hoist_weight_distribution.cpp
+               ../core/uuidutils.cpp
+               ../core/autopatcher.cpp
+               ../core/patchmanager.cpp
+               ../core/configmanager.cpp
+               ../core/configservices.cpp
+               ../core/projectutils.cpp
+               ../core/logger.cpp
+               ../models/mvrscene.cpp
+               ../models/fixture.cpp
+               ../models/truss.cpp
+               ../models/sceneobject.cpp
+               ../models/layer.cpp
+               ${LAYOUT_SOURCES})
+target_include_directories(rider_pipe_import_test PRIVATE
+                           . ../core ../models ../mvr ../gui ../third_party)
+target_link_libraries(rider_pipe_import_test PRIVATE ${wxWidgets_LIBRARIES}
+                                                     tinyxml2::tinyxml2)
+add_test(NAME RiderPipeImport COMMAND rider_pipe_import_test)
+set_library_env(RiderPipeImport)
+
 add_executable(rider_import_benchmark rider_import_benchmark.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp

--- a/tests/rider_pipe_import_test.cpp
+++ b/tests/rider_pipe_import_test.cpp
@@ -1,0 +1,98 @@
+#include <cassert>
+#include <cmath>
+#include <string>
+#include <wx/init.h>
+
+#include "configmanager.h"
+#include "riderimporter.h"
+
+namespace {
+
+constexpr float kEpsilon = 0.001f;
+
+bool NearlyEqual(float a, float b) { return std::abs(a - b) < kEpsilon; }
+
+} // namespace
+
+int main() {
+  wxInitializer initializer;
+  assert(initializer.IsOk());
+
+  auto &cfg = ConfigManager::Get();
+
+  cfg.Reset();
+  const std::string pipeWithLengthText =
+      "ILUMIN\n"
+      "LX1\n"
+      "2 BLINDER 2 PRO\n"
+      "RIGGING\n"
+      "1 PIPE 14m PARA LX1\n";
+  assert(RiderImporter::ImportText(pipeWithLengthText));
+
+  const auto &pipeWithLengthScene = cfg.GetScene();
+  assert(pipeWithLengthScene.trusses.empty());
+  assert(pipeWithLengthScene.sceneObjects.size() == 1);
+  assert(pipeWithLengthScene.fixtures.size() == 2);
+
+  bool foundPipeObject = false;
+  for (const auto &[uuid, object] : pipeWithLengthScene.sceneObjects) {
+    (void)uuid;
+    foundPipeObject = true;
+    assert(object.name.find("PIPE") == 0);
+    assert(NearlyEqual(object.transform.u[0], 14000.0f / 300.0f));
+    assert(NearlyEqual(object.transform.v[1], 100.0f / 300.0f));
+    assert(NearlyEqual(object.transform.w[2], 100.0f / 300.0f));
+  }
+  assert(foundPipeObject);
+
+  for (const auto &[uuid, fixture] : pipeWithLengthScene.fixtures) {
+    (void)uuid;
+    assert(fixture.positionName == "LX1");
+    assert(NearlyEqual(fixture.transform.o[1], -2000.0f));
+    assert(NearlyEqual(fixture.transform.o[2], 10000.0f));
+  }
+
+  cfg.Reset();
+  const std::string defaultPipeLengthText =
+      "RIGGING\n"
+      "3 VARAS PARA PUENTES LX\n";
+  assert(RiderImporter::ImportText(defaultPipeLengthText));
+
+  const auto &defaultPipeLengthScene = cfg.GetScene();
+  assert(defaultPipeLengthScene.trusses.empty());
+  assert(defaultPipeLengthScene.sceneObjects.size() == 3);
+
+  int lx1Count = 0;
+  int lx2Count = 0;
+  int lx3Count = 0;
+  for (const auto &[uuid, object] : defaultPipeLengthScene.sceneObjects) {
+    (void)uuid;
+    if (object.layer == "pos LX1")
+      ++lx1Count;
+    else if (object.layer == "pos LX2")
+      ++lx2Count;
+    else if (object.layer == "pos LX3")
+      ++lx3Count;
+    assert(NearlyEqual(object.transform.u[0], 14000.0f / 300.0f));
+  }
+  assert(lx1Count == 1);
+  assert(lx2Count == 1);
+  assert(lx3Count == 1);
+
+  cfg.Reset();
+  const std::string pipeCoordinateOverrideText =
+      "ILUMIN\n"
+      "LX1\n"
+      "1 BLINDER 2 PRO\n"
+      "RIGGING\n"
+      "1 PIPE 10m PARA LX1 (1, 3, 7)\n";
+  assert(RiderImporter::ImportText(pipeCoordinateOverrideText));
+
+  const auto &pipeCoordinateOverrideScene = cfg.GetScene();
+  assert(pipeCoordinateOverrideScene.fixtures.size() == 1);
+  const auto fixtureIt = pipeCoordinateOverrideScene.fixtures.begin();
+  assert(NearlyEqual(fixtureIt->second.transform.o[1], 3000.0f));
+  assert(NearlyEqual(fixtureIt->second.transform.o[2], 7000.0f));
+
+  return 0;
+}

--- a/tests/rider_pipe_import_test.cpp
+++ b/tests/rider_pipe_import_test.cpp
@@ -39,6 +39,8 @@ int main() {
     (void)uuid;
     foundPipeObject = true;
     assert(object.name.find("PIPE") == 0);
+    assert(object.geometries.size() == 1);
+    assert(object.geometries.front().modelFile == "primitive:cylinder");
     assert(NearlyEqual(object.transform.u[0], 14000.0f / 300.0f));
     assert(NearlyEqual(object.transform.v[1], 100.0f / 300.0f));
     assert(NearlyEqual(object.transform.w[2], 100.0f / 300.0f));
@@ -73,6 +75,8 @@ int main() {
       ++lx2Count;
     else if (object.layer == "pos LX3")
       ++lx3Count;
+    assert(object.geometries.size() == 1);
+    assert(object.geometries.front().modelFile == "primitive:cylinder");
     assert(NearlyEqual(object.transform.u[0], 14000.0f / 300.0f));
   }
   assert(lx1Count == 1);

--- a/tests/rider_pipe_import_test.cpp
+++ b/tests/rider_pipe_import_test.cpp
@@ -41,6 +41,9 @@ int main() {
     assert(object.name.find("PIPE") == 0);
     assert(object.geometries.size() == 1);
     assert(object.geometries.front().modelFile == "primitive:cylinder");
+    assert(NearlyEqual(object.geometries.front().localTransform.u[0], 0.0f));
+    assert(NearlyEqual(object.geometries.front().localTransform.u[2], -1.0f));
+    assert(NearlyEqual(object.geometries.front().localTransform.w[0], 1.0f));
     assert(NearlyEqual(object.transform.u[0], 14000.0f / 300.0f));
     assert(NearlyEqual(object.transform.v[1], 100.0f / 300.0f));
     assert(NearlyEqual(object.transform.w[2], 100.0f / 300.0f));
@@ -77,6 +80,7 @@ int main() {
       ++lx3Count;
     assert(object.geometries.size() == 1);
     assert(object.geometries.front().modelFile == "primitive:cylinder");
+    assert(NearlyEqual(object.geometries.front().localTransform.w[0], 1.0f));
     assert(NearlyEqual(object.transform.u[0], 14000.0f / 300.0f));
   }
   assert(lx1Count == 1);

--- a/viewer3d/render/opaque_object_pass.cpp
+++ b/viewer3d/render/opaque_object_pass.cpp
@@ -17,11 +17,13 @@
 
 #include "matrixutils.h"
 #include "mesh.h"
+#include "meshprimitives.h"
 #include "opaque_pass_utils.h"
 #include "scenedatamanager.h"
 #include "viewer3dcontroller.h"
 
 #include <algorithm>
+#include <cctype>
 #include <vector>
 
 namespace {
@@ -51,6 +53,23 @@ const Mesh &FallbackSceneObjectCubeMesh() {
     return cube;
   }();
   return mesh;
+}
+
+const Mesh &FallbackSceneObjectCylinderMesh() {
+  static const Mesh mesh = BuildCylinderMesh(0.5f, 1.0f, 24);
+  return mesh;
+}
+
+bool IsPipeSceneObject(const SceneObject &object) {
+  if (!object.modelFile.empty() || !object.geometries.empty())
+    return false;
+
+  std::string upperName = object.name;
+  std::transform(upperName.begin(), upperName.end(), upperName.begin(),
+                 [](unsigned char c) {
+                   return static_cast<char>(std::toupper(c));
+                 });
+  return upperName.rfind("PIPE", 0) == 0;
 }
 
 } // namespace
@@ -240,10 +259,13 @@ void OpaqueObjectPass::Render(
                 context.whiteModelStyle &&
                 !controller.IsSketchRenderStyleEnabled();
             const bool fallbackWireframe = wireframe;
+            const Mesh &fallbackMesh = IsPipeSceneObject(m)
+                                           ? FallbackSceneObjectCylinderMesh()
+                                           : FallbackSceneObjectCubeMesh();
             controller.DrawMeshWithOutline(
-                FallbackSceneObjectCubeMesh(), r, g, b, 0.3f, isHighlighted,
-                isSelected, cx, cy, cz, fallbackWireframe, mode,
-                captureTransformFn, useUnlitFallbackFill, matrix);
+                fallbackMesh, r, g, b, 0.3f, isHighlighted, isSelected, cx, cy,
+                cz, fallbackWireframe, mode, captureTransformFn,
+                useUnlitFallbackFill, matrix);
           }
         };
 

--- a/viewer3d/render/opaque_object_pass.cpp
+++ b/viewer3d/render/opaque_object_pass.cpp
@@ -24,6 +24,8 @@
 
 #include <algorithm>
 #include <cctype>
+#include <string_view>
+#include <unordered_map>
 #include <vector>
 
 namespace {
@@ -70,6 +72,29 @@ bool IsPipeSceneObject(const SceneObject &object) {
                    return static_cast<char>(std::toupper(c));
                  });
   return upperName.rfind("PIPE", 0) == 0;
+}
+
+const Mesh *TryGetPrimitiveSceneObjectMesh(const std::string &modelRef) {
+  constexpr std::string_view prefix = "primitive:";
+  if (modelRef.rfind(prefix.data(), 0) != 0)
+    return nullptr;
+
+  const std::string primitiveType = modelRef.substr(prefix.size());
+  if (primitiveType.empty())
+    return nullptr;
+
+  static std::unordered_map<std::string, Mesh> cache;
+  auto it = cache.find(primitiveType);
+  if (it != cache.end())
+    return &it->second;
+
+  Mesh mesh;
+  if (!BuildPrimitiveMesh(primitiveType, mesh))
+    return nullptr;
+  auto [insertedIt, inserted] =
+      cache.emplace(primitiveType, std::move(mesh));
+  (void)inserted;
+  return &insertedIt->second;
 }
 
 } // namespace
@@ -164,6 +189,16 @@ void OpaqueObjectPass::Render(
     std::vector<SceneObjectMeshPart> objectMeshParts;
     if (!m.geometries.empty()) {
       for (const auto &geo : m.geometries) {
+        if (const Mesh *primitiveMesh =
+                TryGetPrimitiveSceneObjectMesh(geo.modelFile);
+            primitiveMesh != nullptr) {
+          SceneObjectMeshPart part;
+          part.mesh = primitiveMesh;
+          part.localTransform = geo.localTransform;
+          part.modelKey = NormalizeModelKey(geo.modelFile);
+          objectMeshParts.push_back(std::move(part));
+          continue;
+        }
         std::string objectPath;
         auto pathIt = controller.m_resourceSyncState.resolvedModelRefs.find(
             ResolveCacheKey(geo.modelFile));


### PR DESCRIPTION
### Motivation
- Allow rider "create from text" to accept pipe aliases (`pipe`, `pipes`, `vara`, `varas`) and produce lightweight MVR objects so theatre-style riders can import a single pipe/rod instead of multiple truss pieces.

### Description
- Extend the rider parser to recognize pipe/vara keywords in the same truss line families and detect pipe vs truss with `kPipeKeywordRe` and `DetectRiggingLineKind` in `core/riderimporter.cpp`.
- When a pipe line is detected, create a `SceneObject` placeholder (cylindrical proxy) instead of a `Truss`, using the parsed length or a default `14 m`, and a 5 cm radius (100 mm diameter) for geometry footprint; pipe objects are added to the scene object table and assigned layers similarly to other objects.
- Integrate imported pipe spans into span/position inference used for fixture distribution and change fixture placement for pipe-backed hangs so all fixture categories share the same direct placement (no extra front/back/top offsets).
- Update filter-preview output to preserve pipe intent (`PIPE` lines), add a new test `tests/rider_pipe_import_test.cpp` and register it in `tests/CMakeLists.txt`, and document the new syntax/behavior in `docs/text_to_scene_rules.md`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed (OK).
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed (OK).
- Attempted `cmake --preset wsl-x64-debug` to validate build integration but configure failed in this environment due to missing `wxWidgets` development packages (external dependency), so test binaries were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d370b11240832491c386139bee2da1)