### PR TITLE
Fix oversized rider pipe cylinders in text-to-scene import

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -2000,8 +2000,8 @@ bool RiderImporter::ImportText(const std::string &text) {
                                  const std::optional<TrussCoordinateOverride>
                                      &coordinateOverride) {
           const float pipeLengthMm = length;
-          const float pipeDiameterMm = 100.0f;
-          const float fallbackCubeMm = 300.0f;
+          const float pipeDiameterMm = 50.0f;
+          const float primitiveCylinderHeightMm = 1000.0f;
           const float startX = coordinateOverride && coordinateOverride->hasX
                                    ? coordinateOverride->xMm
                                    : -0.5f * pipeLengthMm;
@@ -2019,9 +2019,11 @@ bool RiderImporter::ImportText(const std::string &text) {
           std::string lengthLabel = formatLength(pipeLengthMm);
           pipeObject.name = model.empty() ? ("PIPE " + lengthLabel)
                                           : ("PIPE " + model + " " + lengthLabel);
-          pipeObject.transform.u = {pipeLengthMm / fallbackCubeMm, 0.0f, 0.0f};
-          pipeObject.transform.v = {0.0f, pipeDiameterMm / fallbackCubeMm, 0.0f};
-          pipeObject.transform.w = {0.0f, 0.0f, pipeDiameterMm / fallbackCubeMm};
+          pipeObject.transform.u = {pipeLengthMm / primitiveCylinderHeightMm, 0.0f,
+                                    0.0f};
+          pipeObject.transform.v = {0.0f, pipeDiameterMm / primitiveCylinderHeightMm,
+                                    0.0f};
+          pipeObject.transform.w = {0.0f, 0.0f, pipeDiameterMm / primitiveCylinderHeightMm};
           pipeObject.transform.o[0] = startX + 0.5f * pipeLengthMm;
           pipeObject.transform.o[1] = hangY;
           pipeObject.transform.o[2] = hangZ;
@@ -2127,8 +2129,8 @@ bool RiderImporter::ImportText(const std::string &text) {
 
         if (isPipe) {
           const float defaultPipeLengthMm = 14000.0f;
-          const float pipeDiameterMm = 100.0f;
-          const float fallbackCubeMm = 300.0f;
+          const float pipeDiameterMm = 50.0f;
+          const float primitiveCylinderHeightMm = 1000.0f;
           auto addPipeObject = [&](const std::string &posName,
                                    const std::optional<TrussCoordinateOverride>
                                        &resolvedOverride) {
@@ -2146,10 +2148,12 @@ bool RiderImporter::ImportText(const std::string &text) {
             pipeObject.uuid = GenerateUuid();
             pipeObject.layer = layerByType ? ("obj " + posName) : ("pos " + posName);
             pipeObject.name = model.empty() ? "PIPE 14M" : ("PIPE " + model + " 14M");
-            pipeObject.transform.u = {defaultPipeLengthMm / fallbackCubeMm, 0.0f,
+            pipeObject.transform.u = {defaultPipeLengthMm / primitiveCylinderHeightMm,
+                                      0.0f, 0.0f};
+            pipeObject.transform.v = {0.0f, pipeDiameterMm / primitiveCylinderHeightMm,
                                       0.0f};
-            pipeObject.transform.v = {0.0f, pipeDiameterMm / fallbackCubeMm, 0.0f};
-            pipeObject.transform.w = {0.0f, 0.0f, pipeDiameterMm / fallbackCubeMm};
+            pipeObject.transform.w = {
+                0.0f, 0.0f, pipeDiameterMm / primitiveCylinderHeightMm};
             pipeObject.transform.o[0] = startX + 0.5f * defaultPipeLengthMm;
             pipeObject.transform.o[1] = hangY;
             pipeObject.transform.o[2] = hangZ;
@@ -2351,8 +2355,8 @@ bool RiderImporter::ImportText(const std::string &text) {
 
         if (riggingKind == RiggingLineKind::Pipe) {
           const float pipeLengthMm = length;
-          const float pipeDiameterMm = 100.0f;
-          const float fallbackCubeMm = 300.0f;
+          const float pipeDiameterMm = 50.0f;
+          const float primitiveCylinderHeightMm = 1000.0f;
           const float startX = coordinateOverride && coordinateOverride->hasX
                                    ? coordinateOverride->xMm
                                    : -0.5f * pipeLengthMm;
@@ -2376,9 +2380,11 @@ bool RiderImporter::ImportText(const std::string &text) {
               lengthText.pop_back();
             pipeObject.name = "PIPE " + lengthText + "M";
           }
-          pipeObject.transform.u = {pipeLengthMm / fallbackCubeMm, 0.0f, 0.0f};
-          pipeObject.transform.v = {0.0f, pipeDiameterMm / fallbackCubeMm, 0.0f};
-          pipeObject.transform.w = {0.0f, 0.0f, pipeDiameterMm / fallbackCubeMm};
+          pipeObject.transform.u = {pipeLengthMm / primitiveCylinderHeightMm, 0.0f,
+                                    0.0f};
+          pipeObject.transform.v = {0.0f, pipeDiameterMm / primitiveCylinderHeightMm,
+                                    0.0f};
+          pipeObject.transform.w = {0.0f, 0.0f, pipeDiameterMm / primitiveCylinderHeightMm};
           pipeObject.transform.o[0] = startX + 0.5f * pipeLengthMm;
           pipeObject.transform.o[1] = hangY;
           pipeObject.transform.o[2] = hangZ;

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -232,7 +232,7 @@ Pipe-specific behavior:
 1. Pipe lines create `SceneObject` entries (object table), not truss entries.
 2. Imported pipes are created as simple cylindrical placeholders:
    - length = parsed length (or `14 m` for lengthless pipe lines),
-   - radius = `5 cm` (`100 mm` diameter).
+   - radius = `2.5 cm` (`50 mm` diameter).
    - Import stores a cylinder primitive geometry reference on the object so the
      3D view renders the pipe directly as a cylinder (not only as a generic
      meshless fallback box).

--- a/tests/rider_pipe_import_test.cpp
+++ b/tests/rider_pipe_import_test.cpp
@@ -44,9 +44,9 @@ int main() {
     assert(NearlyEqual(object.geometries.front().localTransform.u[0], 0.0f));
     assert(NearlyEqual(object.geometries.front().localTransform.u[2], -1.0f));
     assert(NearlyEqual(object.geometries.front().localTransform.w[0], 1.0f));
-    assert(NearlyEqual(object.transform.u[0], 14000.0f / 300.0f));
-    assert(NearlyEqual(object.transform.v[1], 100.0f / 300.0f));
-    assert(NearlyEqual(object.transform.w[2], 100.0f / 300.0f));
+    assert(NearlyEqual(object.transform.u[0], 14000.0f / 1000.0f));
+    assert(NearlyEqual(object.transform.v[1], 50.0f / 1000.0f));
+    assert(NearlyEqual(object.transform.w[2], 50.0f / 1000.0f));
   }
   assert(foundPipeObject);
 
@@ -81,7 +81,7 @@ int main() {
     assert(object.geometries.size() == 1);
     assert(object.geometries.front().modelFile == "primitive:cylinder");
     assert(NearlyEqual(object.geometries.front().localTransform.w[0], 1.0f));
-    assert(NearlyEqual(object.transform.u[0], 14000.0f / 300.0f));
+    assert(NearlyEqual(object.transform.u[0], 14000.0f / 1000.0f));
   }
   assert(lx1Count == 1);
   assert(lx2Count == 1);


### PR DESCRIPTION
### Motivation
- Text-to-scene import created pipe placeholders using a 300 mm fallback reference while the `primitive:cylinder` mesh has a 1000 mm base height, producing visually oversized cylinders and incorrect diameter. 
- Pipes should render as realistic placeholders (14 m default length when unspecified and 2.5 cm radius), so transforms and docs/tests must match the primitive geometry and MVR/reference specs.

### Description
- Change the pipe sizing math in `core/riderimporter.cpp` to normalize transforms against a `primitive:cylinder` base height of `1000 mm` and set placeholder diameter to `50 mm` (radius 2.5 cm) in all pipe creation branches. 
- Update `tests/rider_pipe_import_test.cpp` expectations to reflect the new normalization (`/ 1000.0f`) and the new diameter (`50.0f / 1000.0f`).
- Update `docs/text_to_scene_rules.md` to document the pipe radius change to `2.5 cm` (50 mm diameter).
- The change keeps existing axis/orientation behavior and applies the fix consistently across explicit-length, default-length, and general rigging parse paths.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded. 
- Attempted to configure/build tests with `cmake -S . -B build` but the local environment is missing `wxWidgets`, so unit test binaries could not be built or executed here; test expectations in `tests/rider_pipe_import_test.cpp` were updated to match the new behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3838023688324b428caa61e5a5e53)