### PR TITLE
Fix 3D grid color flicker by disabling lighting during grid draw

### DIFF
--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -744,6 +744,9 @@ void SceneRenderer::DrawGrid(int style, float r, float g, float b,
   stroke.width = profile.lineWidth;
 
   const GLboolean lineSmoothWasEnabled = glIsEnabled(GL_LINE_SMOOTH);
+  const GLboolean lightingWasEnabled = glIsEnabled(GL_LIGHTING);
+  if (lightingWasEnabled)
+    glDisable(GL_LIGHTING);
   if (profile.enableLineSmoothing)
     glEnable(GL_LINE_SMOOTH);
   else
@@ -867,6 +870,9 @@ void SceneRenderer::DrawGrid(int style, float r, float g, float b,
     glEnable(GL_LINE_SMOOTH);
   else
     glDisable(GL_LINE_SMOOTH);
+
+  if (lightingWasEnabled)
+    glEnable(GL_LIGHTING);
 }
 
 void SceneRenderer::SetupMaterialFromRGB(float r, float g, float b) {


### PR DESCRIPTION
### Motivation
- The reference grid could appear darker or black at some camera angles because `GL_LIGHTING` affected fixed-function line rendering, and the grid should always use its configured color.

### Description
- Updated `SceneRenderer::DrawGrid` in `viewer3d/render/scenerenderer.cpp` to snapshot `GL_LIGHTING` with `glIsEnabled(GL_LIGHTING)`, disable lighting while drawing the grid, and restore the previous lighting state after drawing.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both checks passed (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d38553eddc832488949ef15fcc5abd)