### PR TITLE
Edit basic primitive scene-object properties on double-click

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,7 @@ add_executable(${PROJECT_NAME} main.cpp
     models/truss.cpp
     mvr/mvrimporter.cpp
     mvr/mvrexporter.cpp
+    mvr/primitive_model_resources.cpp
 )
 
 if(APPLE)

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -2761,7 +2761,6 @@ bool RiderImporter::ImportText(const std::string &text) {
   }
 
   constexpr float kScreenThicknessMm = 100.0f;
-  constexpr float kFallbackCubeMeters = 0.3f;
   for (const ScreenObjectRequest &request : screenObjectRequests) {
     TrussInfo info;
     auto infoIt = trussInfo.find(request.positionName);
@@ -2780,11 +2779,11 @@ bool RiderImporter::ImportText(const std::string &text) {
     screenObject.name = request.name;
     screenObject.layer = request.layer;
     screenObject.transform.u = {
-        request.widthMm / (kFallbackCubeMeters * 1000.0f), 0.0f, 0.0f};
+        request.widthMm / 1000.0f, 0.0f, 0.0f};
     screenObject.transform.v = {
-        0.0f, kScreenThicknessMm / (kFallbackCubeMeters * 1000.0f), 0.0f};
+        0.0f, kScreenThicknessMm / 1000.0f, 0.0f};
     screenObject.transform.w = {
-        0.0f, 0.0f, request.heightMm / (kFallbackCubeMeters * 1000.0f)};
+        0.0f, 0.0f, request.heightMm / 1000.0f};
     screenObject.transform.o[0] = centerX;
     screenObject.transform.o[1] = centerY;
     screenObject.transform.o[2] = centerZ;

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -59,6 +59,7 @@
 
 namespace {
 constexpr const char *kPrimitiveCylinderToken = "primitive:cylinder";
+constexpr const char *kPrimitiveCubeToken = "primitive:cube";
 
 Matrix BuildCylinderAxisXLocalTransform() {
   Matrix transform{};
@@ -2787,6 +2788,7 @@ bool RiderImporter::ImportText(const std::string &text) {
     screenObject.transform.o[0] = centerX;
     screenObject.transform.o[1] = centerY;
     screenObject.transform.o[2] = centerZ;
+    screenObject.geometries.push_back({kPrimitiveCubeToken, Matrix{}});
     scene.sceneObjects[screenObject.uuid] = screenObject;
     addToLayer(screenObject.layer, screenObject.uuid);
   }

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -64,6 +64,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/preferencesdialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scene_object_primitive_creation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scene_object_primitive_dialogs.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/scene_object_primitive_editing.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ridertextdialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/riggingpanel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sceneobjecttablepanel.cpp

--- a/gui/scene_object_primitive_dialogs.cpp
+++ b/gui/scene_object_primitive_dialogs.cpp
@@ -12,10 +12,12 @@ namespace {
 
 class SphereDialog : public wxDialog {
 public:
-  explicit SphereDialog(wxWindow *parent)
-      : wxDialog(parent, wxID_ANY, "Add Sphere", wxDefaultPosition,
+  SphereDialog(wxWindow *parent, const wxString &title,
+               const SphereRequest &initialRequest, bool includeQuantity)
+      : wxDialog(parent, wxID_ANY, title, wxDefaultPosition,
                  wxDefaultSize,
-                 wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER) {
+                 wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
+        includeQuantity_(includeQuantity) {
     auto *root = new wxBoxSizer(wxVERTICAL);
     auto *grid = new wxFlexGridSizer(2, 2, 8, 8);
 
@@ -25,15 +27,17 @@ public:
     radiusCtrl_->SetRange(0.01, 1000.0);
     radiusCtrl_->SetIncrement(0.1);
     radiusCtrl_->SetDigits(2);
-    radiusCtrl_->SetValue(1.0);
+    radiusCtrl_->SetValue(initialRequest.radiusMeters);
     grid->Add(radiusCtrl_, 1, wxEXPAND);
 
-    grid->Add(new wxStaticText(this, wxID_ANY, "Units:"),
-              0, wxALIGN_CENTER_VERTICAL);
-    quantityCtrl_ = new wxSpinCtrl(this, wxID_ANY);
-    quantityCtrl_->SetRange(1, 1000);
-    quantityCtrl_->SetValue(1);
-    grid->Add(quantityCtrl_, 1, wxEXPAND);
+    if (includeQuantity_) {
+      grid->Add(new wxStaticText(this, wxID_ANY, "Units:"),
+                0, wxALIGN_CENTER_VERTICAL);
+      quantityCtrl_ = new wxSpinCtrl(this, wxID_ANY);
+      quantityCtrl_->SetRange(1, 1000);
+      quantityCtrl_->SetValue(initialRequest.quantity);
+      grid->Add(quantityCtrl_, 1, wxEXPAND);
+    }
 
     grid->AddGrowableCol(1, 1);
     root->Add(grid, 1, wxALL | wxEXPAND, 12);
@@ -46,34 +50,39 @@ public:
   SphereRequest Request() const {
     SphereRequest request;
     request.radiusMeters = radiusCtrl_->GetValue();
-    request.quantity = quantityCtrl_->GetValue();
+    request.quantity = includeQuantity_ ? quantityCtrl_->GetValue() : 1;
     return request;
   }
 
 private:
   wxSpinCtrlDouble *radiusCtrl_ = nullptr;
   wxSpinCtrl *quantityCtrl_ = nullptr;
+  bool includeQuantity_ = true;
 };
 
 class CubeDialog : public wxDialog {
 public:
-  explicit CubeDialog(wxWindow *parent)
-      : wxDialog(parent, wxID_ANY, "Add Cube", wxDefaultPosition,
+  CubeDialog(wxWindow *parent, const wxString &title,
+             const CubeRequest &initialRequest, bool includeQuantity)
+      : wxDialog(parent, wxID_ANY, title, wxDefaultPosition,
                  wxDefaultSize,
-                 wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER) {
+                 wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
+        includeQuantity_(includeQuantity) {
     auto *root = new wxBoxSizer(wxVERTICAL);
     auto *grid = new wxFlexGridSizer(4, 2, 8, 8);
 
-    lengthCtrl_ = AddDimensionRow(grid, "Length (m):", 1.0);
-    heightCtrl_ = AddDimensionRow(grid, "Height (m):", 1.0);
-    widthCtrl_ = AddDimensionRow(grid, "Width (m):", 1.0);
+    lengthCtrl_ = AddDimensionRow(grid, "Length (m):", initialRequest.lengthMeters);
+    heightCtrl_ = AddDimensionRow(grid, "Height (m):", initialRequest.heightMeters);
+    widthCtrl_ = AddDimensionRow(grid, "Width (m):", initialRequest.widthMeters);
 
-    grid->Add(new wxStaticText(this, wxID_ANY, "Units:"),
-              0, wxALIGN_CENTER_VERTICAL);
-    quantityCtrl_ = new wxSpinCtrl(this, wxID_ANY);
-    quantityCtrl_->SetRange(1, 1000);
-    quantityCtrl_->SetValue(1);
-    grid->Add(quantityCtrl_, 1, wxEXPAND);
+    if (includeQuantity_) {
+      grid->Add(new wxStaticText(this, wxID_ANY, "Units:"),
+                0, wxALIGN_CENTER_VERTICAL);
+      quantityCtrl_ = new wxSpinCtrl(this, wxID_ANY);
+      quantityCtrl_->SetRange(1, 1000);
+      quantityCtrl_->SetValue(initialRequest.quantity);
+      grid->Add(quantityCtrl_, 1, wxEXPAND);
+    }
 
     grid->AddGrowableCol(1, 1);
     root->Add(grid, 1, wxALL | wxEXPAND, 12);
@@ -88,7 +97,7 @@ public:
     request.lengthMeters = lengthCtrl_->GetValue();
     request.heightMeters = heightCtrl_->GetValue();
     request.widthMeters = widthCtrl_->GetValue();
-    request.quantity = quantityCtrl_->GetValue();
+    request.quantity = includeQuantity_ ? quantityCtrl_->GetValue() : 1;
     return request;
   }
 
@@ -110,6 +119,7 @@ private:
   wxSpinCtrlDouble *heightCtrl_ = nullptr;
   wxSpinCtrlDouble *widthCtrl_ = nullptr;
   wxSpinCtrl *quantityCtrl_ = nullptr;
+  bool includeQuantity_ = true;
 };
 
 constexpr double kMetersToMillimeters = 1000.0;
@@ -119,7 +129,7 @@ constexpr double kPrimitiveSphereDiameterMillimeters = 1000.0;
 } // namespace
 
 bool ShowSphereDialog(wxWindow *parent, SphereRequest &outRequest) {
-  SphereDialog dialog(parent);
+  SphereDialog dialog(parent, "Add Sphere", SphereRequest{}, true);
   if (dialog.ShowModal() != wxID_OK)
     return false;
 
@@ -128,11 +138,29 @@ bool ShowSphereDialog(wxWindow *parent, SphereRequest &outRequest) {
 }
 
 bool ShowCubeDialog(wxWindow *parent, CubeRequest &outRequest) {
-  CubeDialog dialog(parent);
+  CubeDialog dialog(parent, "Add Cube", CubeRequest{}, true);
   if (dialog.ShowModal() != wxID_OK)
     return false;
 
   outRequest = dialog.Request();
+  return true;
+}
+
+bool ShowSphereEditDialog(wxWindow *parent, SphereRequest &inOutRequest) {
+  SphereDialog dialog(parent, "Edit Sphere", inOutRequest, false);
+  if (dialog.ShowModal() != wxID_OK)
+    return false;
+
+  inOutRequest = dialog.Request();
+  return true;
+}
+
+bool ShowCubeEditDialog(wxWindow *parent, CubeRequest &inOutRequest) {
+  CubeDialog dialog(parent, "Edit Cube", inOutRequest, false);
+  if (dialog.ShowModal() != wxID_OK)
+    return false;
+
+  inOutRequest = dialog.Request();
   return true;
 }
 

--- a/gui/scene_object_primitive_dialogs.cpp
+++ b/gui/scene_object_primitive_dialogs.cpp
@@ -122,6 +122,84 @@ private:
   bool includeQuantity_ = true;
 };
 
+class ScreenEditDialog : public wxDialog {
+public:
+  ScreenEditDialog(wxWindow *parent, const ScreenEditRequest &initial)
+      : wxDialog(parent, wxID_ANY, "Edit Screen", wxDefaultPosition,
+                 wxDefaultSize,
+                 wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER) {
+    auto *root = new wxBoxSizer(wxVERTICAL);
+    auto *grid = new wxFlexGridSizer(2, 2, 8, 8);
+
+    widthCtrl_ = AddDimensionRow(grid, "Width (m):", initial.widthMeters);
+    heightCtrl_ = AddDimensionRow(grid, "Height (m):", initial.heightMeters);
+
+    grid->AddGrowableCol(1, 1);
+    root->Add(grid, 1, wxALL | wxEXPAND, 12);
+    root->Add(CreateSeparatedButtonSizer(wxOK | wxCANCEL),
+              0, wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND, 12);
+    SetSizerAndFit(root);
+  }
+
+  ScreenEditRequest Request() const {
+    ScreenEditRequest request;
+    request.widthMeters = widthCtrl_->GetValue();
+    request.heightMeters = heightCtrl_->GetValue();
+    return request;
+  }
+
+private:
+  wxSpinCtrlDouble *AddDimensionRow(wxFlexGridSizer *grid, const char *label,
+                                    double defaultValue) {
+    grid->Add(new wxStaticText(this, wxID_ANY, label), 0, wxALIGN_CENTER_VERTICAL);
+    auto *ctrl = new wxSpinCtrlDouble(this, wxID_ANY);
+    ctrl->SetRange(0.01, 1000.0);
+    ctrl->SetIncrement(0.1);
+    ctrl->SetDigits(2);
+    ctrl->SetValue(defaultValue);
+    grid->Add(ctrl, 1, wxEXPAND);
+    return ctrl;
+  }
+
+  wxSpinCtrlDouble *widthCtrl_ = nullptr;
+  wxSpinCtrlDouble *heightCtrl_ = nullptr;
+};
+
+class PipeEditDialog : public wxDialog {
+public:
+  PipeEditDialog(wxWindow *parent, const PipeEditRequest &initial)
+      : wxDialog(parent, wxID_ANY, "Edit Pipe", wxDefaultPosition,
+                 wxDefaultSize,
+                 wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER) {
+    auto *root = new wxBoxSizer(wxVERTICAL);
+    auto *grid = new wxFlexGridSizer(1, 2, 8, 8);
+
+    grid->Add(new wxStaticText(this, wxID_ANY, "Length (m):"),
+              0, wxALIGN_CENTER_VERTICAL);
+    lengthCtrl_ = new wxSpinCtrlDouble(this, wxID_ANY);
+    lengthCtrl_->SetRange(0.01, 1000.0);
+    lengthCtrl_->SetIncrement(0.1);
+    lengthCtrl_->SetDigits(2);
+    lengthCtrl_->SetValue(initial.lengthMeters);
+    grid->Add(lengthCtrl_, 1, wxEXPAND);
+
+    grid->AddGrowableCol(1, 1);
+    root->Add(grid, 1, wxALL | wxEXPAND, 12);
+    root->Add(CreateSeparatedButtonSizer(wxOK | wxCANCEL),
+              0, wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND, 12);
+    SetSizerAndFit(root);
+  }
+
+  PipeEditRequest Request() const {
+    PipeEditRequest request;
+    request.lengthMeters = lengthCtrl_->GetValue();
+    return request;
+  }
+
+private:
+  wxSpinCtrlDouble *lengthCtrl_ = nullptr;
+};
+
 constexpr double kMetersToMillimeters = 1000.0;
 constexpr double kPrimitiveCubeSizeMillimeters = 1000.0;
 constexpr double kPrimitiveSphereDiameterMillimeters = 1000.0;
@@ -157,6 +235,24 @@ bool ShowSphereEditDialog(wxWindow *parent, SphereRequest &inOutRequest) {
 
 bool ShowCubeEditDialog(wxWindow *parent, CubeRequest &inOutRequest) {
   CubeDialog dialog(parent, "Edit Cube", inOutRequest, false);
+  if (dialog.ShowModal() != wxID_OK)
+    return false;
+
+  inOutRequest = dialog.Request();
+  return true;
+}
+
+bool ShowScreenEditDialog(wxWindow *parent, ScreenEditRequest &inOutRequest) {
+  ScreenEditDialog dialog(parent, inOutRequest);
+  if (dialog.ShowModal() != wxID_OK)
+    return false;
+
+  inOutRequest = dialog.Request();
+  return true;
+}
+
+bool ShowPipeEditDialog(wxWindow *parent, PipeEditRequest &inOutRequest) {
+  PipeEditDialog dialog(parent, inOutRequest);
   if (dialog.ShowModal() != wxID_OK)
     return false;
 

--- a/gui/scene_object_primitive_dialogs.h
+++ b/gui/scene_object_primitive_dialogs.h
@@ -20,6 +20,8 @@ struct CubeRequest {
 
 bool ShowSphereDialog(wxWindow *parent, SphereRequest &outRequest);
 bool ShowCubeDialog(wxWindow *parent, CubeRequest &outRequest);
+bool ShowSphereEditDialog(wxWindow *parent, SphereRequest &inOutRequest);
+bool ShowCubeEditDialog(wxWindow *parent, CubeRequest &inOutRequest);
 
 Matrix BuildSphereScaleTransform(double radiusMeters);
 Matrix BuildCubeScaleTransform(double lengthMeters, double heightMeters,

--- a/gui/scene_object_primitive_dialogs.h
+++ b/gui/scene_object_primitive_dialogs.h
@@ -18,10 +18,21 @@ struct CubeRequest {
   int quantity = 1;
 };
 
+struct ScreenEditRequest {
+  double widthMeters = 8.0;
+  double heightMeters = 5.0;
+};
+
+struct PipeEditRequest {
+  double lengthMeters = 14.0;
+};
+
 bool ShowSphereDialog(wxWindow *parent, SphereRequest &outRequest);
 bool ShowCubeDialog(wxWindow *parent, CubeRequest &outRequest);
 bool ShowSphereEditDialog(wxWindow *parent, SphereRequest &inOutRequest);
 bool ShowCubeEditDialog(wxWindow *parent, CubeRequest &inOutRequest);
+bool ShowScreenEditDialog(wxWindow *parent, ScreenEditRequest &inOutRequest);
+bool ShowPipeEditDialog(wxWindow *parent, PipeEditRequest &inOutRequest);
 
 Matrix BuildSphereScaleTransform(double radiusMeters);
 Matrix BuildCubeScaleTransform(double lengthMeters, double heightMeters,

--- a/gui/scene_object_primitive_editing.cpp
+++ b/gui/scene_object_primitive_editing.cpp
@@ -14,11 +14,14 @@ namespace {
 
 constexpr const char *kPrimitiveSphereToken = "primitive:sphere";
 constexpr const char *kPrimitiveCubeToken = "primitive:cube";
+constexpr const char *kPrimitiveCylinderToken = "primitive:cylinder";
+constexpr float kScreenDepthMeters = 0.1f;
 
 enum class PrimitiveKind {
   None,
   Sphere,
   Cube,
+  Cylinder,
 };
 
 struct PrimitiveGeometryTarget {
@@ -51,7 +54,28 @@ PrimitiveKind PrimitiveKindFromToken(const std::string &token) {
     return PrimitiveKind::Sphere;
   if (normalized.rfind(kPrimitiveCubeToken, 0) == 0)
     return PrimitiveKind::Cube;
+  if (normalized.rfind(kPrimitiveCylinderToken, 0) == 0)
+    return PrimitiveKind::Cylinder;
   return PrimitiveKind::None;
+}
+std::array<float, 3> AxisWithLength(const std::array<float, 3> &axis,
+                                    float length) {
+  const float current = AxisLength(axis);
+  if (current < 1e-6f)
+    return {length, 0.0f, 0.0f};
+  const float scale = length / current;
+  return {axis[0] * scale, axis[1] * scale, axis[2] * scale};
+}
+
+bool IsScreenObject(const SceneObject &object) {
+  const std::string name = ToLowerTrimmed(object.name);
+  return name.find("screen") != std::string::npos ||
+         name.find("pantalla") != std::string::npos;
+}
+
+bool IsPipeObject(const SceneObject &object) {
+  const std::string name = ToLowerTrimmed(object.name);
+  return name.rfind("pipe", 0) == 0;
 }
 
 PrimitiveGeometryTarget ResolvePrimitiveTarget(const SceneObject &object) {
@@ -96,6 +120,41 @@ bool EditPrimitiveObjectByUuid(wxWindow *parent, ConfigManager &cfg,
     return false;
 
   SceneObject &object = it->second;
+
+  if (IsScreenObject(object)) {
+    ScreenEditRequest request;
+    request.widthMeters = std::max(0.01, static_cast<double>(AxisLength(object.transform.u)));
+    request.heightMeters = std::max(0.01, static_cast<double>(AxisLength(object.transform.w)));
+    if (!ShowScreenEditDialog(parent, request))
+      return false;
+
+    const auto oldU = object.transform.u;
+    const auto oldV = object.transform.v;
+    const auto oldW = object.transform.w;
+    object.transform.u = AxisWithLength(object.transform.u, static_cast<float>(request.widthMeters));
+    object.transform.v = AxisWithLength(object.transform.v, kScreenDepthMeters);
+    object.transform.w = AxisWithLength(object.transform.w, static_cast<float>(request.heightMeters));
+
+    if (object.transform.u == oldU && object.transform.v == oldV && object.transform.w == oldW)
+      return false;
+    cfg.PushUndoState("edit screen geometry");
+    return true;
+  }
+
+  if (IsPipeObject(object)) {
+    PipeEditRequest request;
+    request.lengthMeters = std::max(0.01, static_cast<double>(AxisLength(object.transform.u)));
+    if (!ShowPipeEditDialog(parent, request))
+      return false;
+
+    const auto oldU = object.transform.u;
+    object.transform.u = AxisWithLength(object.transform.u, static_cast<float>(request.lengthMeters));
+    if (object.transform.u == oldU)
+      return false;
+    cfg.PushUndoState("edit pipe geometry");
+    return true;
+  }
+
   const PrimitiveGeometryTarget target = ResolvePrimitiveTarget(object);
   if (target.kind == PrimitiveKind::None)
     return false;

--- a/gui/scene_object_primitive_editing.cpp
+++ b/gui/scene_object_primitive_editing.cpp
@@ -5,6 +5,7 @@
 #include "sceneobject.h"
 
 #include <algorithm>
+#include <cctype>
 #include <cmath>
 #include <string>
 
@@ -14,21 +15,75 @@ namespace {
 constexpr const char *kPrimitiveSphereToken = "primitive:sphere";
 constexpr const char *kPrimitiveCubeToken = "primitive:cube";
 
+enum class PrimitiveKind {
+  None,
+  Sphere,
+  Cube,
+};
+
+struct PrimitiveGeometryTarget {
+  PrimitiveKind kind = PrimitiveKind::None;
+  size_t geometryIndex = 0;
+  bool usesGeometryEntry = false;
+};
+
 float AxisLength(const std::array<float, 3> &axis) {
   return std::sqrt(axis[0] * axis[0] + axis[1] * axis[1] + axis[2] * axis[2]);
 }
 
-std::string PrimaryPrimitiveToken(const SceneObject &object) {
-  if (!object.geometries.empty())
-    return object.geometries.front().modelFile;
-  return object.modelFile;
+std::string ToLowerTrimmed(std::string value) {
+  value.erase(value.begin(),
+              std::find_if(value.begin(), value.end(), [](unsigned char c) {
+                return !std::isspace(c);
+              }));
+  value.erase(std::find_if(value.rbegin(), value.rend(),
+                           [](unsigned char c) { return !std::isspace(c); })
+                  .base(),
+              value.end());
+  std::transform(value.begin(), value.end(), value.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return value;
 }
 
-bool IsEditablePrimitive(const SceneObject &object) {
-  if (object.geometries.empty())
-    return false;
-  const std::string token = PrimaryPrimitiveToken(object);
-  return token == kPrimitiveSphereToken || token == kPrimitiveCubeToken;
+PrimitiveKind PrimitiveKindFromToken(const std::string &token) {
+  const std::string normalized = ToLowerTrimmed(token);
+  if (normalized.rfind(kPrimitiveSphereToken, 0) == 0)
+    return PrimitiveKind::Sphere;
+  if (normalized.rfind(kPrimitiveCubeToken, 0) == 0)
+    return PrimitiveKind::Cube;
+  return PrimitiveKind::None;
+}
+
+PrimitiveGeometryTarget ResolvePrimitiveTarget(const SceneObject &object) {
+  for (size_t i = 0; i < object.geometries.size(); ++i) {
+    const PrimitiveKind kind =
+        PrimitiveKindFromToken(object.geometries[i].modelFile);
+    if (kind != PrimitiveKind::None) {
+      PrimitiveGeometryTarget target;
+      target.kind = kind;
+      target.geometryIndex = i;
+      target.usesGeometryEntry = true;
+      return target;
+    }
+  }
+
+  const PrimitiveKind modelKind = PrimitiveKindFromToken(object.modelFile);
+  if (modelKind != PrimitiveKind::None) {
+    PrimitiveGeometryTarget target;
+    target.kind = modelKind;
+    target.geometryIndex = 0;
+    target.usesGeometryEntry = false;
+    return target;
+  }
+
+  return {};
+}
+
+Matrix ResolveEditableTransform(const SceneObject &object,
+                               const PrimitiveGeometryTarget &target) {
+  if (target.usesGeometryEntry && target.geometryIndex < object.geometries.size())
+    return object.geometries[target.geometryIndex].localTransform;
+  return Matrix{};
 }
 
 } // namespace
@@ -41,16 +96,16 @@ bool EditPrimitiveObjectByUuid(wxWindow *parent, ConfigManager &cfg,
     return false;
 
   SceneObject &object = it->second;
-  if (!IsEditablePrimitive(object))
+  const PrimitiveGeometryTarget target = ResolvePrimitiveTarget(object);
+  if (target.kind == PrimitiveKind::None)
     return false;
 
-  const std::string token = PrimaryPrimitiveToken(object);
-  const Matrix currentTransform = object.geometries.front().localTransform;
+  const Matrix currentTransform = ResolveEditableTransform(object, target);
 
   Matrix updatedTransform = currentTransform;
   bool accepted = false;
 
-  if (token == kPrimitiveSphereToken) {
+  if (target.kind == PrimitiveKind::Sphere) {
     SphereRequest request;
     const double uniformScale = std::max(
         {static_cast<double>(AxisLength(currentTransform.u)),
@@ -61,7 +116,7 @@ bool EditPrimitiveObjectByUuid(wxWindow *parent, ConfigManager &cfg,
     if (!accepted)
       return false;
     updatedTransform = BuildSphereScaleTransform(request.radiusMeters);
-  } else if (token == kPrimitiveCubeToken) {
+  } else if (target.kind == PrimitiveKind::Cube) {
     CubeRequest request;
     request.lengthMeters =
         std::max(static_cast<double>(AxisLength(currentTransform.u)), 0.01);
@@ -84,7 +139,14 @@ bool EditPrimitiveObjectByUuid(wxWindow *parent, ConfigManager &cfg,
     return false;
 
   cfg.PushUndoState("edit primitive geometry");
-  object.geometries.front().localTransform = updatedTransform;
+  if (target.usesGeometryEntry && target.geometryIndex < object.geometries.size()) {
+    object.geometries[target.geometryIndex].localTransform = updatedTransform;
+  } else {
+    GeometryInstance geometry;
+    geometry.modelFile = object.modelFile;
+    geometry.localTransform = updatedTransform;
+    object.geometries.push_back(geometry);
+  }
 
   return true;
 }

--- a/gui/scene_object_primitive_editing.cpp
+++ b/gui/scene_object_primitive_editing.cpp
@@ -1,0 +1,92 @@
+#include "scene_object_primitive_editing.h"
+
+#include "configmanager.h"
+#include "scene_object_primitive_dialogs.h"
+#include "sceneobject.h"
+
+#include <algorithm>
+#include <cmath>
+#include <string>
+
+namespace scene_object_primitives {
+namespace {
+
+constexpr const char *kPrimitiveSphereToken = "primitive:sphere";
+constexpr const char *kPrimitiveCubeToken = "primitive:cube";
+
+float AxisLength(const std::array<float, 3> &axis) {
+  return std::sqrt(axis[0] * axis[0] + axis[1] * axis[1] + axis[2] * axis[2]);
+}
+
+std::string PrimaryPrimitiveToken(const SceneObject &object) {
+  if (!object.geometries.empty())
+    return object.geometries.front().modelFile;
+  return object.modelFile;
+}
+
+bool IsEditablePrimitive(const SceneObject &object) {
+  if (object.geometries.empty())
+    return false;
+  const std::string token = PrimaryPrimitiveToken(object);
+  return token == kPrimitiveSphereToken || token == kPrimitiveCubeToken;
+}
+
+} // namespace
+
+bool EditPrimitiveObjectByUuid(wxWindow *parent, ConfigManager &cfg,
+                               const std::string &uuid) {
+  auto &scene = cfg.GetScene();
+  auto it = scene.sceneObjects.find(uuid);
+  if (it == scene.sceneObjects.end())
+    return false;
+
+  SceneObject &object = it->second;
+  if (!IsEditablePrimitive(object))
+    return false;
+
+  const std::string token = PrimaryPrimitiveToken(object);
+  const Matrix currentTransform = object.geometries.front().localTransform;
+
+  Matrix updatedTransform = currentTransform;
+  bool accepted = false;
+
+  if (token == kPrimitiveSphereToken) {
+    SphereRequest request;
+    const double uniformScale = std::max(
+        {static_cast<double>(AxisLength(currentTransform.u)),
+         static_cast<double>(AxisLength(currentTransform.v)),
+         static_cast<double>(AxisLength(currentTransform.w)), 0.01});
+    request.radiusMeters = uniformScale * 0.5;
+    accepted = ShowSphereEditDialog(parent, request);
+    if (!accepted)
+      return false;
+    updatedTransform = BuildSphereScaleTransform(request.radiusMeters);
+  } else if (token == kPrimitiveCubeToken) {
+    CubeRequest request;
+    request.lengthMeters =
+        std::max(static_cast<double>(AxisLength(currentTransform.u)), 0.01);
+    request.heightMeters =
+        std::max(static_cast<double>(AxisLength(currentTransform.v)), 0.01);
+    request.widthMeters =
+        std::max(static_cast<double>(AxisLength(currentTransform.w)), 0.01);
+    accepted = ShowCubeEditDialog(parent, request);
+    if (!accepted)
+      return false;
+    updatedTransform = BuildCubeScaleTransform(request.lengthMeters,
+                                               request.heightMeters,
+                                               request.widthMeters);
+  }
+
+  if (!accepted ||
+      (updatedTransform.u == currentTransform.u &&
+       updatedTransform.v == currentTransform.v &&
+       updatedTransform.w == currentTransform.w))
+    return false;
+
+  cfg.PushUndoState("edit primitive geometry");
+  object.geometries.front().localTransform = updatedTransform;
+
+  return true;
+}
+
+} // namespace scene_object_primitives

--- a/gui/scene_object_primitive_editing.h
+++ b/gui/scene_object_primitive_editing.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+
+class ConfigManager;
+class wxWindow;
+
+namespace scene_object_primitives {
+
+bool EditPrimitiveObjectByUuid(wxWindow *parent, ConfigManager &cfg,
+                               const std::string &uuid);
+
+} // namespace scene_object_primitives

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -110,6 +110,16 @@ RangeParts SplitRangeParts(const wxString& value)
             parts.push_back(part);
     return {parts, usedSeparator, trailingSeparator};
 }
+
+std::string ModelRefForDisplay(const SceneObject &object)
+{
+    const std::string primary = object.GetPrimaryModel();
+    if (primary.rfind("primitive:sphere", 0) == 0)
+        return "primitive_sphere.glb";
+    if (primary.rfind("primitive:cube", 0) == 0)
+        return "primitive_cube.glb";
+    return primary;
+}
 } // namespace
 
 SceneObjectTablePanel::SceneObjectTablePanel(wxWindow* parent, IGuiConfigServices* services)
@@ -208,7 +218,7 @@ void SceneObjectTablePanel::ReloadData()
         wxString name = wxString::FromUTF8(obj.name);
         wxString layer = obj.layer == DEFAULT_LAYER_NAME ? wxString()
                                                           : wxString::FromUTF8(obj.layer);
-        wxString model = wxString::FromUTF8(obj.modelFile);
+        wxString model = wxString::FromUTF8(ModelRefForDisplay(obj));
 
         auto posArr = obj.transform.o;
         wxString posX = wxString::FromUTF8(Units::FormatDistanceFromMillimeters(

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -119,12 +119,11 @@ RangeParts SplitRangeParts(const wxString& value)
 std::string ModelRefForDisplay(const SceneObject &object)
 {
     const std::string primary = object.GetPrimaryModel();
-    if (primary.rfind("primitive:sphere", 0) == 0)
-        return "primitive_sphere.glb";
-    if (primary.rfind("primitive:cube", 0) == 0)
-        return "primitive_cube.glb";
-    if (primary.rfind("primitive:cylinder", 0) == 0)
-        return "primitive_cylinder.glb";
+    if (primary.rfind("primitive:", 0) == 0) {
+        const std::string archivePath = mvr::PrimitiveArchivePathForToken(primary, object.uuid);
+        if (!archivePath.empty())
+            return std::filesystem::path(archivePath).filename().string();
+    }
     return primary;
 }
 
@@ -261,8 +260,11 @@ void SceneObjectTablePanel::ReloadData()
         wxString modelFullPath;
         const std::string &base = guiConfigServices->LegacyConfigManager().GetScene().basePath;
         if (primaryModel.rfind("primitive:", 0) == 0) {
-            model = wxString::FromUTF8(ModelRefForDisplay(obj));
             modelFullPath = ResolvePrimitivePreviewPath(obj, base);
+            if (!modelFullPath.IsEmpty())
+                model = wxFileName(modelFullPath).GetFullName();
+            else
+                model = wxString::FromUTF8(ModelRefForDisplay(obj));
         } else if (!primaryModel.empty()) {
             wxFileName fullPath(base.empty() ? wxString::FromUTF8(primaryModel)
                                              : wxString::FromUTF8((std::filesystem::path(base) /

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -127,6 +127,7 @@ SceneObjectTablePanel::SceneObjectTablePanel(wxWindow* parent, IGuiConfigService
   const wxColour selectionForeground(0, 0, 0);
   store->SetSelectionColours(selectionBackground, selectionForeground);
     table->Bind(wxEVT_LEFT_DOWN, &SceneObjectTablePanel::OnLeftDown, this);
+    table->Bind(wxEVT_LEFT_DCLICK, &SceneObjectTablePanel::OnLeftDClick, this);
     table->Bind(wxEVT_LEFT_UP, &SceneObjectTablePanel::OnLeftUp, this);
     table->Bind(wxEVT_MOTION, &SceneObjectTablePanel::OnMouseMove, this);
     table->Bind(wxEVT_DATAVIEW_SELECTION_CHANGED,
@@ -452,6 +453,36 @@ void SceneObjectTablePanel::OnLeftDown(wxMouseEvent& evt)
         table->SelectRow(startRow);
         CaptureMouse();
     }
+    evt.Skip();
+}
+
+void SceneObjectTablePanel::OnLeftDClick(wxMouseEvent& evt)
+{
+    wxDataViewItem item;
+    wxDataViewColumn* col;
+    table->HitTest(evt.GetPosition(), item, col);
+    const int row = table->ItemToRow(item);
+    if (row == wxNOT_FOUND || static_cast<size_t>(row) >= rowUuids.size()) {
+        evt.Skip();
+        return;
+    }
+
+    const std::string uuid = rowUuids[static_cast<size_t>(row)];
+    ConfigManager &cfg = guiConfigServices->LegacyConfigManager();
+    const bool edited = scene_object_primitives::EditPrimitiveObjectByUuid(
+        this, cfg, uuid);
+    if (edited) {
+        if (Viewer3DPanel::Instance()) {
+            Viewer3DPanel::Instance()->UpdateScene();
+            Viewer3DPanel::Instance()->Refresh();
+        } else if (Viewer2DPanel::Instance()) {
+            Viewer2DPanel::Instance()->UpdateScene();
+        }
+        ReloadData();
+        SelectByUuid({uuid});
+        return;
+    }
+
     evt.Skip();
 }
 
@@ -874,13 +905,12 @@ void SceneObjectTablePanel::OnItemActivated(wxDataViewEvent &event)
         return;
     }
 
+    const std::string uuid = rowUuids[static_cast<size_t>(row)];
     ConfigManager &cfg = guiConfigServices->LegacyConfigManager();
     const bool edited = scene_object_primitives::EditPrimitiveObjectByUuid(
-        this, cfg, rowUuids[static_cast<size_t>(row)]);
-    if (!edited) {
-        event.Skip();
+        this, cfg, uuid);
+    if (!edited)
         return;
-    }
 
     if (Viewer3DPanel::Instance()) {
         Viewer3DPanel::Instance()->UpdateScene();
@@ -890,4 +920,5 @@ void SceneObjectTablePanel::OnItemActivated(wxDataViewEvent &event)
     }
 
     ReloadData();
+    SelectByUuid({uuid});
 }

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -22,6 +22,7 @@
 #include "guiconfigservices.h"
 #include "layerpanel.h"
 #include "matrixutils.h"
+#include "projectutils.h"
 #include "scene_object_primitive_editing.h"
 #include "stringutils.h"
 #include "summarypanel.h"
@@ -33,8 +34,11 @@
 #include <algorithm>
 #include <cctype>
 #include <cmath>
+#include <filesystem>
 #include <wx/notebook.h>
 #include <wx/choicdlg.h>
+#include <wx/filedlg.h>
+#include <wx/filename.h>
 #include <wx/wupdlock.h> // freeze/thaw UI during batch edits
 #include <wx/version.h>
 
@@ -199,6 +203,7 @@ void SceneObjectTablePanel::ReloadData()
     }
 
     table->DeleteAllItems();
+    modelPaths.clear();
     rowUuids.clear();
     const auto& objs = guiConfigServices->LegacyConfigManager().GetScene().sceneObjects;
 
@@ -220,7 +225,19 @@ void SceneObjectTablePanel::ReloadData()
         wxString name = wxString::FromUTF8(obj.name);
         wxString layer = obj.layer == DEFAULT_LAYER_NAME ? wxString()
                                                           : wxString::FromUTF8(obj.layer);
-        wxString model = wxString::FromUTF8(ModelRefForDisplay(obj));
+        const std::string primaryModel = obj.GetPrimaryModel();
+        wxString model;
+        wxString modelFullPath;
+        if (primaryModel.rfind("primitive:", 0) == 0) {
+            model = wxString::FromUTF8(ModelRefForDisplay(obj));
+        } else if (!primaryModel.empty()) {
+            const std::string &base = guiConfigServices->LegacyConfigManager().GetScene().basePath;
+            wxFileName fullPath(base.empty() ? wxString::FromUTF8(primaryModel)
+                                             : wxString::FromUTF8((std::filesystem::path(base) /
+                                                                   std::filesystem::path(primaryModel)).string()));
+            modelFullPath = fullPath.GetFullPath();
+            model = fullPath.GetFullName();
+        }
 
         auto posArr = obj.transform.o;
         wxString posX = wxString::FromUTF8(Units::FormatDistanceFromMillimeters(
@@ -246,6 +263,7 @@ void SceneObjectTablePanel::ReloadData()
         row.push_back(yaw);
 
         store->AppendItem(row, rowUuids.size());
+        modelPaths.push_back(modelFullPath);
         rowUuids.push_back(uuid);
     }
 
@@ -308,6 +326,48 @@ void SceneObjectTablePanel::OnContextMenu(wxDataViewEvent& event)
             if (r != wxNOT_FOUND)
                 table->SetValue(wxVariant(val), r, col);
         }
+        ResyncRows(oldOrder, selectedUuids);
+        UpdateSceneData();
+        if (Viewer3DPanel::Instance())
+        {
+            Viewer3DPanel::Instance()->UpdateScene();
+            Viewer3DPanel::Instance()->Refresh();
+        }
+        else if (Viewer2DPanel::Instance())
+        {
+            Viewer2DPanel::Instance()->UpdateScene();
+        }
+        return;
+    }
+
+    if (col == 2)
+    {
+        wxString initialDir = wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("objects"));
+        if (row >= 0 && static_cast<size_t>(row) < modelPaths.size() && !modelPaths[static_cast<size_t>(row)].IsEmpty()) {
+            wxFileName current(modelPaths[static_cast<size_t>(row)]);
+            if (current.DirExists())
+                initialDir = current.GetPath();
+        }
+
+        wxFileDialog fdlg(this, "Select Object Model", initialDir, wxEmptyString,
+                          "3D files (*.glb;*.gltf;*.3ds;*.obj)|*.glb;*.gltf;*.3ds;*.obj|All files|*.*",
+                          wxFD_OPEN | wxFD_FILE_MUST_EXIST);
+        if (fdlg.ShowModal() != wxID_OK)
+            return;
+
+        wxString selectedPath = fdlg.GetPath();
+        wxString displayName = wxFileName(selectedPath).GetFullName();
+        for (const auto& itSel : selections)
+        {
+            int r = table->ItemToRow(itSel);
+            if (r == wxNOT_FOUND)
+                continue;
+            table->SetValue(wxVariant(displayName), r, col);
+            if (static_cast<size_t>(r) >= modelPaths.size())
+                modelPaths.resize(table->GetItemCount());
+            modelPaths[static_cast<size_t>(r)] = selectedPath;
+        }
+
         ResyncRows(oldOrder, selectedUuids);
         UpdateSceneData();
         if (Viewer3DPanel::Instance())
@@ -660,6 +720,16 @@ void SceneObjectTablePanel::UpdateSceneData(bool logChanges)
         else
             next.layer = layerStr;
 
+        const bool hasPrimitiveModel = old.GetPrimaryModel().rfind("primitive:", 0) == 0;
+        if (i < modelPaths.size() && !modelPaths[i].IsEmpty())
+            next.modelFile = std::string(modelPaths[i].ToUTF8());
+        else if (hasPrimitiveModel)
+            next.modelFile = old.modelFile;
+        else {
+            table->GetValue(v, i, 2);
+            next.modelFile = std::string(v.GetString().ToUTF8());
+        }
+
         const auto distanceUnit = ResolveDistanceUnitSystem();
         double xMm = old.transform.o[0], yMm = old.transform.o[1], zMm = old.transform.o[2];
         table->GetValue(v, i, 3);
@@ -716,7 +786,9 @@ void SceneObjectTablePanel::UpdateSceneData(bool logChanges)
                  static_cast<float>(zMm)});
         }
 
-        const bool objectChanged = old.layer != next.layer || transformChanged;
+        const bool objectChanged = old.layer != next.layer ||
+                                   old.modelFile != next.modelFile ||
+                                   transformChanged;
         if (!objectChanged)
             continue;
 
@@ -872,15 +944,20 @@ void SceneObjectTablePanel::ResyncRows(const std::vector<std::string>& oldOrder,
 {
     unsigned int count = table->GetItemCount();
     std::vector<std::string> newOrder(count);
+    std::vector<wxString> newPaths(count);
     for (unsigned int i = 0; i < count; ++i)
     {
         wxDataViewItem it = table->RowToItem(i);
         unsigned long idx = store->GetItemData(it);
-        if (idx < oldOrder.size())
+        if (idx < oldOrder.size()) {
             newOrder[i] = oldOrder[idx];
+            if (idx < modelPaths.size())
+                newPaths[i] = modelPaths[idx];
+        }
         store->SetItemData(it, i);
     }
     rowUuids.swap(newOrder);
+    modelPaths.swap(newPaths);
 
     table->UnselectAll();
     for (const auto& uuid : selectedUuids)

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -118,6 +118,8 @@ std::string ModelRefForDisplay(const SceneObject &object)
         return "primitive_sphere.glb";
     if (primary.rfind("primitive:cube", 0) == 0)
         return "primitive_cube.glb";
+    if (primary.rfind("primitive:cylinder", 0) == 0)
+        return "primitive_cylinder.glb";
     return primary;
 }
 } // namespace

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -22,6 +22,7 @@
 #include "guiconfigservices.h"
 #include "layerpanel.h"
 #include "matrixutils.h"
+#include "primitive_model_resources.h"
 #include "projectutils.h"
 #include "scene_object_primitive_editing.h"
 #include "stringutils.h"
@@ -126,6 +127,36 @@ std::string ModelRefForDisplay(const SceneObject &object)
         return "primitive_cylinder.glb";
     return primary;
 }
+
+wxString ResolvePrimitivePreviewPath(const SceneObject &object,
+                                     const std::string &basePath)
+{
+    const std::string token = object.GetPrimaryModel();
+    std::string archiveRel = mvr::PrimitiveArchivePathForToken(token, object.uuid);
+    if (archiveRel.empty())
+        archiveRel = mvr::PrimitiveArchivePathForToken(token);
+
+    if (!archiveRel.empty() && !basePath.empty()) {
+        std::filesystem::path candidate = std::filesystem::path(basePath) /
+                                          std::filesystem::path(archiveRel);
+        if (std::filesystem::exists(candidate))
+            return wxString::FromUTF8(candidate.string());
+    }
+
+    std::filesystem::path cacheDir = std::filesystem::temp_directory_path() /
+                                     "perastage_primitive_preview";
+    std::error_code ec;
+    std::filesystem::create_directories(cacheDir, ec);
+    std::string fileName = std::filesystem::path(
+        mvr::PrimitiveArchivePathForToken(token, object.uuid)).filename().string();
+    if (fileName.empty())
+        fileName = std::filesystem::path(ModelRefForDisplay(object)).string();
+    std::filesystem::path outPath = cacheDir / std::filesystem::path(fileName);
+    if (!std::filesystem::exists(outPath) &&
+        !mvr::WritePrimitiveModelForToken(token, outPath.string()))
+        return wxString();
+    return wxString::FromUTF8(outPath.string());
+}
 } // namespace
 
 SceneObjectTablePanel::SceneObjectTablePanel(wxWindow* parent, IGuiConfigServices* services)
@@ -228,10 +259,11 @@ void SceneObjectTablePanel::ReloadData()
         const std::string primaryModel = obj.GetPrimaryModel();
         wxString model;
         wxString modelFullPath;
+        const std::string &base = guiConfigServices->LegacyConfigManager().GetScene().basePath;
         if (primaryModel.rfind("primitive:", 0) == 0) {
             model = wxString::FromUTF8(ModelRefForDisplay(obj));
+            modelFullPath = ResolvePrimitivePreviewPath(obj, base);
         } else if (!primaryModel.empty()) {
-            const std::string &base = guiConfigServices->LegacyConfigManager().GetScene().basePath;
             wxFileName fullPath(base.empty() ? wxString::FromUTF8(primaryModel)
                                              : wxString::FromUTF8((std::filesystem::path(base) /
                                                                    std::filesystem::path(primaryModel)).string()));

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -22,6 +22,7 @@
 #include "guiconfigservices.h"
 #include "layerpanel.h"
 #include "matrixutils.h"
+#include "scene_object_primitive_editing.h"
 #include "stringutils.h"
 #include "summarypanel.h"
 #include "dataview_edit_commit.h"
@@ -135,6 +136,8 @@ SceneObjectTablePanel::SceneObjectTablePanel(wxWindow* parent, IGuiConfigService
                 &SceneObjectTablePanel::OnContextMenu, this);
     table->Bind(wxEVT_DATAVIEW_COLUMN_SORTED,
                 &SceneObjectTablePanel::OnColumnSorted, this);
+    table->Bind(wxEVT_DATAVIEW_ITEM_ACTIVATED,
+                &SceneObjectTablePanel::OnItemActivated, this);
 
     Bind(wxEVT_MOUSE_CAPTURE_LOST, &SceneObjectTablePanel::OnCaptureLost, this);
 
@@ -860,4 +863,31 @@ void SceneObjectTablePanel::OnColumnSorted(wxDataViewEvent& event)
     std::vector<std::string> oldOrder = rowUuids;
     ResyncRows(oldOrder, selectedUuids);
     event.Skip();
+}
+
+void SceneObjectTablePanel::OnItemActivated(wxDataViewEvent &event)
+{
+    const wxDataViewItem item = event.GetItem();
+    const int row = table->ItemToRow(item);
+    if (row == wxNOT_FOUND || static_cast<size_t>(row) >= rowUuids.size()) {
+        event.Skip();
+        return;
+    }
+
+    ConfigManager &cfg = guiConfigServices->LegacyConfigManager();
+    const bool edited = scene_object_primitives::EditPrimitiveObjectByUuid(
+        this, cfg, rowUuids[static_cast<size_t>(row)]);
+    if (!edited) {
+        event.Skip();
+        return;
+    }
+
+    if (Viewer3DPanel::Instance()) {
+        Viewer3DPanel::Instance()->UpdateScene();
+        Viewer3DPanel::Instance()->Refresh();
+    } else if (Viewer2DPanel::Instance()) {
+        Viewer2DPanel::Instance()->UpdateScene();
+    }
+
+    ReloadData();
 }

--- a/gui/sceneobjecttablepanel.h
+++ b/gui/sceneobjecttablepanel.h
@@ -52,6 +52,7 @@ private:
     ColorfulDataViewListStore* store;
     wxDataViewListCtrl* table;
     std::vector<wxString> columnLabels;
+    std::vector<wxString> modelPaths;
     std::vector<std::string> rowUuids;
     std::string highlightedUuid;
     bool dragSelecting = false;

--- a/gui/sceneobjecttablepanel.h
+++ b/gui/sceneobjecttablepanel.h
@@ -61,6 +61,7 @@ private:
     void OnSelectionChanged(wxDataViewEvent& evt);
     void OnContextMenu(wxDataViewEvent& event);
     void OnColumnSorted(wxDataViewEvent& event);
+    void OnItemActivated(wxDataViewEvent& event);
     void ResyncRows(const std::vector<std::string>& oldOrder,
                     const std::vector<std::string>& selectedUuids);
     void OnLeftDown(wxMouseEvent& evt);

--- a/gui/sceneobjecttablepanel.h
+++ b/gui/sceneobjecttablepanel.h
@@ -65,6 +65,7 @@ private:
     void ResyncRows(const std::vector<std::string>& oldOrder,
                     const std::vector<std::string>& selectedUuids);
     void OnLeftDown(wxMouseEvent& evt);
+    void OnLeftDClick(wxMouseEvent& evt);
     void OnLeftUp(wxMouseEvent& evt);
     void OnMouseMove(wxMouseEvent& evt);
     void OnCaptureLost(wxMouseCaptureLostEvent& evt);

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -1383,7 +1383,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
     return archivePath;
   };
 
-  auto registerPrimitiveModelResource = [&](const std::string &modelRef) -> std::string {
+  auto registerPrimitiveModelResource = [&](const std::string &modelRef,
+                                            const std::string &objectUuid) -> std::string {
     std::string primitiveToken;
     if (!mvr::ResolvePrimitiveTokenFromModelRef(modelRef, primitiveToken))
       return {};
@@ -1402,7 +1403,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
     }
 
     const std::string preferredArchivePath =
-        mvr::PrimitiveArchivePathForToken(primitiveToken);
+        mvr::PrimitiveArchivePathForToken(primitiveToken, objectUuid);
     return registerResource(sourcePath, preferredArchivePath);
   };
 
@@ -2003,7 +2004,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
           continue;
 
         tinyxml2::XMLElement *g3d = doc.NewElement("Geometry3D");
-        std::string modelArchivePath = registerPrimitiveModelResource(geo.modelFile);
+        std::string modelArchivePath =
+            registerPrimitiveModelResource(geo.modelFile, obj.uuid);
         if (modelArchivePath.empty()) {
           modelArchivePath = registerModelResource(geo.modelFile, "object.3ds");
         }
@@ -2024,7 +2026,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
     } else if (!obj.modelFile.empty()) {
       tinyxml2::XMLElement *geos = doc.NewElement("Geometries");
       tinyxml2::XMLElement *g3d = doc.NewElement("Geometry3D");
-      std::string modelArchivePath = registerPrimitiveModelResource(obj.modelFile);
+      std::string modelArchivePath =
+          registerPrimitiveModelResource(obj.modelFile, obj.uuid);
       if (modelArchivePath.empty()) {
         modelArchivePath = registerModelResource(obj.modelFile, "object.3ds");
       }

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -1395,7 +1395,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
     } else {
       fs::path outputPath = fs::u8path(primitiveTempDir) /
                             fs::u8path(mvr::PrimitiveArchivePathForToken(primitiveToken)).filename();
-      if (!mvr::WritePrimitiveObjForToken(primitiveToken, outputPath.generic_string()))
+      if (!mvr::WritePrimitiveModelForToken(primitiveToken, outputPath.generic_string()))
         return {};
       sourcePath = outputPath.generic_string();
       primitiveSourceByToken[primitiveToken] = sourcePath;

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -22,6 +22,7 @@
 #include "logger.h"
 #include "matrixutils.h"
 #include "projectutils.h"
+#include "primitive_model_resources.h"
 #include "support.h"
 #include "uuidutils.h"
 #include "truss_gdtf_builder.h"
@@ -1287,7 +1288,9 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
   std::unordered_map<std::string, GdtfOverrides> gdtfOverrides;
   std::unordered_map<std::string, std::string> trussArchiveByTypeKey;
   std::unordered_map<std::string, std::string> trussInstanceToTypeKey;
+  std::unordered_map<std::string, std::string> primitiveSourceByToken;
   std::unordered_set<std::string> reservedArchivePaths;
+  const std::string primitiveTempDir = CreateTempDir();
 
   auto normalizeSourcePath = [&](const std::string &rawPath) {
     fs::path src = fs::path(rawPath);
@@ -1378,6 +1381,29 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
         rawModelSource, SanitizeArchiveFileName(rawModelSource, fallbackArchiveName));
     registerModelTextureDependencies(rawModelSource);
     return archivePath;
+  };
+
+  auto registerPrimitiveModelResource = [&](const std::string &modelRef) -> std::string {
+    std::string primitiveToken;
+    if (!mvr::ResolvePrimitiveTokenFromModelRef(modelRef, primitiveToken))
+      return {};
+
+    auto sourceIt = primitiveSourceByToken.find(primitiveToken);
+    std::string sourcePath;
+    if (sourceIt != primitiveSourceByToken.end()) {
+      sourcePath = sourceIt->second;
+    } else {
+      fs::path outputPath = fs::u8path(primitiveTempDir) /
+                            fs::u8path(mvr::PrimitiveArchivePathForToken(primitiveToken)).filename();
+      if (!mvr::WritePrimitiveObjForToken(primitiveToken, outputPath.generic_string()))
+        return {};
+      sourcePath = outputPath.generic_string();
+      primitiveSourceByToken[primitiveToken] = sourcePath;
+    }
+
+    const std::string preferredArchivePath =
+        mvr::PrimitiveArchivePathForToken(primitiveToken);
+    return registerResource(sourcePath, preferredArchivePath);
   };
 
   auto assignIds = [&]() {
@@ -1965,9 +1991,6 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
 
   auto exportSceneObject = [&](tinyxml2::XMLElement *parent,
                                const SceneObject &obj) {
-    auto isPrimitiveModelRef = [](const std::string &modelRef) {
-      return modelRef.rfind("primitive:", 0) == 0;
-    };
     tinyxml2::XMLElement *oe = doc.NewElement("SceneObject");
     oe->SetAttribute("uuid", obj.uuid.c_str());
     if (!obj.name.empty())
@@ -1976,12 +1999,16 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
     if (!obj.geometries.empty()) {
       tinyxml2::XMLElement *geos = doc.NewElement("Geometries");
       for (const auto &geo : obj.geometries) {
-        if (geo.modelFile.empty() || isPrimitiveModelRef(geo.modelFile))
+        if (geo.modelFile.empty())
           continue;
 
         tinyxml2::XMLElement *g3d = doc.NewElement("Geometry3D");
-        std::string modelArchivePath =
-            registerModelResource(geo.modelFile, "object.3ds");
+        std::string modelArchivePath = registerPrimitiveModelResource(geo.modelFile);
+        if (modelArchivePath.empty()) {
+          modelArchivePath = registerModelResource(geo.modelFile, "object.3ds");
+        }
+        if (modelArchivePath.empty())
+          continue;
         g3d->SetAttribute("fileName", modelArchivePath.c_str());
 
         std::string geoMatrixText = MatrixUtils::FormatMatrix(geo.localTransform);
@@ -1994,14 +2021,18 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
 
       if (geos->FirstChild())
         oe->InsertEndChild(geos);
-    } else if (!obj.modelFile.empty() && !isPrimitiveModelRef(obj.modelFile)) {
+    } else if (!obj.modelFile.empty()) {
       tinyxml2::XMLElement *geos = doc.NewElement("Geometries");
       tinyxml2::XMLElement *g3d = doc.NewElement("Geometry3D");
-      std::string modelArchivePath =
-          registerModelResource(obj.modelFile, "object.3ds");
-      g3d->SetAttribute("fileName", modelArchivePath.c_str());
-      oe->InsertEndChild(geos);
-      geos->InsertEndChild(g3d);
+      std::string modelArchivePath = registerPrimitiveModelResource(obj.modelFile);
+      if (modelArchivePath.empty()) {
+        modelArchivePath = registerModelResource(obj.modelFile, "object.3ds");
+      }
+      if (!modelArchivePath.empty()) {
+        g3d->SetAttribute("fileName", modelArchivePath.c_str());
+        oe->InsertEndChild(geos);
+        geos->InsertEndChild(g3d);
+      }
     }
 
     std::string mstr = MatrixUtils::FormatMatrix(obj.transform);

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -22,6 +22,7 @@
 #include "gdtfloader.h"
 #include "gdtf_fixture_category.h"
 #include "matrixutils.h"
+#include "primitive_model_resources.h"
 #include "sceneobject.h"
 #include "support.h"
 #include "groupobject.h"
@@ -1221,7 +1222,12 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
     std::string normalized = normalizeGeometryFileName(std::move(fileName));
     if (normalized.empty())
       return normalized;
+    std::string primitiveToken;
+    if (mvr::ResolvePrimitiveTokenFromModelRef(normalized, primitiveToken))
+      return primitiveToken;
     std::string remapped = RemapArchivePathIfNeeded(normalized);
+    if (mvr::ResolvePrimitiveTokenFromModelRef(remapped, primitiveToken))
+      return primitiveToken;
     fs::path remappedPath = fs::u8path(remapped);
     fs::path resolved = ResolveSceneRelativePath(scene.basePath, remapped);
     if (!remappedPath.has_extension()) {

--- a/mvr/primitive_model_resources.cpp
+++ b/mvr/primitive_model_resources.cpp
@@ -4,6 +4,7 @@
 #include <cctype>
 #include <cstdint>
 #include <cstring>
+#include <cmath>
 #include <filesystem>
 #include <fstream>
 #include <sstream>
@@ -17,8 +18,10 @@ namespace {
 
 constexpr const char *kSphereToken = "primitive:sphere";
 constexpr const char *kCubeToken = "primitive:cube";
+constexpr const char *kCylinderToken = "primitive:cylinder";
 constexpr const char *kSphereArchiveName = "primitives/perastage_primitive_sphere.glb";
 constexpr const char *kCubeArchiveName = "primitives/perastage_primitive_cube.glb";
+constexpr const char *kCylinderArchiveName = "primitives/perastage_primitive_cylinder.glb";
 
 std::string NormalizeLower(std::string value) {
   value.erase(value.begin(),
@@ -47,6 +50,12 @@ bool IsCubeRef(const std::string &normalized) {
          normalized.find("perastage_primitive_cube.glb") != std::string::npos ||
          normalized.find("perastage_primitive_cube.obj") != std::string::npos ||
          normalized.find("primitive_cube_") != std::string::npos;
+}
+
+bool IsCylinderRef(const std::string &normalized) {
+  return normalized.rfind(kCylinderToken, 0) == 0 ||
+         normalized.find("perastage_primitive_cylinder.glb") != std::string::npos ||
+         normalized.find("primitive_cylinder_") != std::string::npos;
 }
 
 std::string SanitizeUuidForFileName(const std::string &objectUuid) {
@@ -114,6 +123,40 @@ PrimitiveMeshData BuildSphereMesh() {
       7, 11, 12, 7, 12, 8, 8, 12, 9, 8, 9, 5,
       9, 13, 10, 10, 13, 11, 11, 13, 12, 12, 13, 9,
   };
+  return mesh;
+}
+
+PrimitiveMeshData BuildCylinderMesh() {
+  PrimitiveMeshData mesh;
+  constexpr int kSegments = 16;
+  constexpr float kPi = 3.14159265358979323846f;
+  mesh.positions.reserve(static_cast<size_t>(kSegments * 2 + 2) * 3);
+  mesh.indices.reserve(static_cast<size_t>(kSegments) * 12);
+
+  for (int i = 0; i < kSegments; ++i) {
+    const float a = static_cast<float>(i) * 2.0f * kPi /
+                    static_cast<float>(kSegments);
+    const float x = 0.5f * std::cos(a);
+    const float z = 0.5f * std::sin(a);
+    mesh.positions.insert(mesh.positions.end(), {x, 0.5f, z});
+    mesh.positions.insert(mesh.positions.end(), {x, -0.5f, z});
+  }
+  const uint16_t topCenter = static_cast<uint16_t>(mesh.positions.size() / 3);
+  mesh.positions.insert(mesh.positions.end(), {0.0f, 0.5f, 0.0f});
+  const uint16_t bottomCenter = static_cast<uint16_t>(mesh.positions.size() / 3);
+  mesh.positions.insert(mesh.positions.end(), {0.0f, -0.5f, 0.0f});
+
+  for (int i = 0; i < kSegments; ++i) {
+    const uint16_t top0 = static_cast<uint16_t>(i * 2);
+    const uint16_t bot0 = static_cast<uint16_t>(i * 2 + 1);
+    const uint16_t top1 = static_cast<uint16_t>(((i + 1) % kSegments) * 2);
+    const uint16_t bot1 = static_cast<uint16_t>(((i + 1) % kSegments) * 2 + 1);
+
+    mesh.indices.insert(mesh.indices.end(), {top0, bot0, bot1, top0, bot1, top1});
+    mesh.indices.insert(mesh.indices.end(), {topCenter, top1, top0});
+    mesh.indices.insert(mesh.indices.end(), {bottomCenter, bot0, bot1});
+  }
+
   return mesh;
 }
 
@@ -229,6 +272,10 @@ bool ResolvePrimitiveTokenFromModelRef(const std::string &modelRef,
     outPrimitiveToken = kCubeToken;
     return true;
   }
+  if (IsCylinderRef(normalized)) {
+    outPrimitiveToken = kCylinderToken;
+    return true;
+  }
   return false;
 }
 
@@ -238,6 +285,8 @@ std::string PrimitiveArchivePathForToken(const std::string &primitiveToken) {
     return kSphereArchiveName;
   if (normalized.rfind(kCubeToken, 0) == 0)
     return kCubeArchiveName;
+  if (normalized.rfind(kCylinderToken, 0) == 0)
+    return kCylinderArchiveName;
   return {};
 }
 
@@ -251,6 +300,8 @@ std::string PrimitiveArchivePathForToken(const std::string &primitiveToken,
     return "primitives/primitive_sphere_" + suffix + ".glb";
   if (normalized.rfind(kCubeToken, 0) == 0)
     return "primitives/primitive_cube_" + suffix + ".glb";
+  if (normalized.rfind(kCylinderToken, 0) == 0)
+    return "primitives/primitive_cylinder_" + suffix + ".glb";
   return {};
 }
 
@@ -261,6 +312,8 @@ bool WritePrimitiveModelForToken(const std::string &primitiveToken,
     return WriteGlb(BuildCubeMesh(), outputPath);
   if (normalized.rfind(kSphereToken, 0) == 0)
     return WriteGlb(BuildSphereMesh(), outputPath);
+  if (normalized.rfind(kCylinderToken, 0) == 0)
+    return WriteGlb(BuildCylinderMesh(), outputPath);
   return false;
 }
 

--- a/mvr/primitive_model_resources.cpp
+++ b/mvr/primitive_model_resources.cpp
@@ -2,9 +2,13 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdint>
+#include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <sstream>
 #include <string>
+#include <vector>
 
 namespace fs = std::filesystem;
 
@@ -13,8 +17,8 @@ namespace {
 
 constexpr const char *kSphereToken = "primitive:sphere";
 constexpr const char *kCubeToken = "primitive:cube";
-constexpr const char *kSphereArchiveName = "primitives/perastage_primitive_sphere.obj";
-constexpr const char *kCubeArchiveName = "primitives/perastage_primitive_cube.obj";
+constexpr const char *kSphereArchiveName = "primitives/perastage_primitive_sphere.glb";
+constexpr const char *kCubeArchiveName = "primitives/perastage_primitive_cube.glb";
 
 std::string NormalizeLower(std::string value) {
   value.erase(value.begin(),
@@ -33,81 +37,169 @@ std::string NormalizeLower(std::string value) {
 
 bool IsSphereRef(const std::string &normalized) {
   return normalized.rfind(kSphereToken, 0) == 0 ||
+         normalized.find("perastage_primitive_sphere.glb") != std::string::npos ||
          normalized.find("perastage_primitive_sphere.obj") != std::string::npos;
 }
 
 bool IsCubeRef(const std::string &normalized) {
   return normalized.rfind(kCubeToken, 0) == 0 ||
+         normalized.find("perastage_primitive_cube.glb") != std::string::npos ||
          normalized.find("perastage_primitive_cube.obj") != std::string::npos;
 }
 
-const char *ObjDataForToken(const std::string &primitiveToken) {
-  const std::string normalized = NormalizeLower(primitiveToken);
-  if (normalized.rfind(kCubeToken, 0) == 0) {
-    return R"OBJ(o PerastagePrimitiveCube
-v -0.5 -0.5 -0.5
-v 0.5 -0.5 -0.5
-v 0.5 0.5 -0.5
-v -0.5 0.5 -0.5
-v -0.5 -0.5 0.5
-v 0.5 -0.5 0.5
-v 0.5 0.5 0.5
-v -0.5 0.5 0.5
-f 1 2 3
-f 1 3 4
-f 5 8 7
-f 5 7 6
-f 1 5 6
-f 1 6 2
-f 2 6 7
-f 2 7 3
-f 3 7 8
-f 3 8 4
-f 4 8 5
-f 4 5 1
-)OBJ";
+struct PrimitiveMeshData {
+  std::vector<float> positions;
+  std::vector<uint16_t> indices;
+};
+
+PrimitiveMeshData BuildCubeMesh() {
+  PrimitiveMeshData mesh;
+  mesh.positions = {
+      -0.5f, -0.5f, -0.5f,
+      0.5f,  -0.5f, -0.5f,
+      0.5f,  0.5f,  -0.5f,
+      -0.5f, 0.5f,  -0.5f,
+      -0.5f, -0.5f, 0.5f,
+      0.5f,  -0.5f, 0.5f,
+      0.5f,  0.5f,  0.5f,
+      -0.5f, 0.5f,  0.5f,
+  };
+  mesh.indices = {
+      0, 1, 2, 0, 2, 3,
+      4, 7, 6, 4, 6, 5,
+      0, 4, 5, 0, 5, 1,
+      1, 5, 6, 1, 6, 2,
+      2, 6, 7, 2, 7, 3,
+      3, 7, 4, 3, 4, 0,
+  };
+  return mesh;
+}
+
+PrimitiveMeshData BuildSphereMesh() {
+  PrimitiveMeshData mesh;
+  mesh.positions = {
+      0.0f,  0.5f,  0.0f,
+      0.353553f, 0.353553f, 0.0f,
+      0.0f,  0.353553f, 0.353553f,
+      -0.353553f, 0.353553f, 0.0f,
+      0.0f,  0.353553f, -0.353553f,
+      0.5f, 0.0f, 0.0f,
+      0.0f, 0.0f, 0.5f,
+      -0.5f, 0.0f, 0.0f,
+      0.0f, 0.0f, -0.5f,
+      0.353553f, -0.353553f, 0.0f,
+      0.0f, -0.353553f, 0.353553f,
+      -0.353553f, -0.353553f, 0.0f,
+      0.0f, -0.353553f, -0.353553f,
+      0.0f, -0.5f, 0.0f,
+  };
+  mesh.indices = {
+      0, 1, 2, 0, 2, 3, 0, 3, 4, 0, 4, 1,
+      1, 5, 2, 2, 6, 3, 3, 7, 4, 4, 8, 1,
+      5, 9, 10, 5, 10, 6, 6, 10, 11, 6, 11, 7,
+      7, 11, 12, 7, 12, 8, 8, 12, 9, 8, 9, 5,
+      9, 13, 10, 10, 13, 11, 11, 13, 12, 12, 13, 9,
+  };
+  return mesh;
+}
+
+void AppendU32(std::vector<uint8_t> &buffer, uint32_t value) {
+  buffer.push_back(static_cast<uint8_t>(value & 0xFFu));
+  buffer.push_back(static_cast<uint8_t>((value >> 8u) & 0xFFu));
+  buffer.push_back(static_cast<uint8_t>((value >> 16u) & 0xFFu));
+  buffer.push_back(static_cast<uint8_t>((value >> 24u) & 0xFFu));
+}
+
+void AppendBytes(std::vector<uint8_t> &buffer, const void *data, size_t size) {
+  const auto *ptr = static_cast<const uint8_t *>(data);
+  buffer.insert(buffer.end(), ptr, ptr + size);
+}
+
+bool WriteGlb(const PrimitiveMeshData &mesh, const std::string &outputPath) {
+  if (mesh.positions.empty() || mesh.indices.empty())
+    return false;
+
+  float minX = mesh.positions[0], minY = mesh.positions[1], minZ = mesh.positions[2];
+  float maxX = minX, maxY = minY, maxZ = minZ;
+  for (size_t i = 0; i + 2 < mesh.positions.size(); i += 3) {
+    minX = std::min(minX, mesh.positions[i]);
+    minY = std::min(minY, mesh.positions[i + 1]);
+    minZ = std::min(minZ, mesh.positions[i + 2]);
+    maxX = std::max(maxX, mesh.positions[i]);
+    maxY = std::max(maxY, mesh.positions[i + 1]);
+    maxZ = std::max(maxZ, mesh.positions[i + 2]);
   }
 
-  if (normalized.rfind(kSphereToken, 0) == 0) {
-    return R"OBJ(o PerastagePrimitiveSphere
-v 0 0.5 0
-v 0.353553 0.353553 0
-v 0 0.353553 0.353553
-v -0.353553 0.353553 0
-v 0 0.353553 -0.353553
-v 0.5 0 0
-v 0 0 0.5
-v -0.5 0 0
-v 0 0 -0.5
-v 0.353553 -0.353553 0
-v 0 -0.353553 0.353553
-v -0.353553 -0.353553 0
-v 0 -0.353553 -0.353553
-v 0 -0.5 0
-f 1 2 3
-f 1 3 4
-f 1 4 5
-f 1 5 2
-f 2 6 3
-f 3 7 4
-f 4 8 5
-f 5 9 2
-f 6 10 11
-f 6 11 7
-f 7 11 12
-f 7 12 8
-f 8 12 13
-f 8 13 9
-f 9 13 10
-f 9 10 6
-f 10 14 11
-f 11 14 12
-f 12 14 13
-f 13 14 10
-)OBJ";
-  }
+  const uint32_t positionBytes = static_cast<uint32_t>(mesh.positions.size() * sizeof(float));
+  const uint32_t indexBytes = static_cast<uint32_t>(mesh.indices.size() * sizeof(uint16_t));
 
-  return nullptr;
+  std::vector<uint8_t> bin;
+  bin.reserve(positionBytes + indexBytes + 4);
+  AppendBytes(bin, mesh.positions.data(), positionBytes);
+  while ((bin.size() % 4u) != 0u)
+    bin.push_back(0u);
+  const uint32_t indexOffset = static_cast<uint32_t>(bin.size());
+  AppendBytes(bin, mesh.indices.data(), indexBytes);
+  while ((bin.size() % 4u) != 0u)
+    bin.push_back(0u);
+  const uint32_t totalBinBytes = static_cast<uint32_t>(bin.size());
+
+  std::ostringstream json;
+  json << "{"
+       << "\"asset\":{\"version\":\"2.0\"},"
+       << "\"buffers\":[{\"byteLength\":" << totalBinBytes << "}],"
+       << "\"bufferViews\":["
+       << "{\"buffer\":0,\"byteOffset\":0,\"byteLength\":" << positionBytes
+       << ",\"target\":34962},"
+       << "{\"buffer\":0,\"byteOffset\":" << indexOffset
+       << ",\"byteLength\":" << indexBytes << ",\"target\":34963}"
+       << "],"
+       << "\"accessors\":["
+       << "{\"bufferView\":0,\"componentType\":5126,\"count\":"
+       << (mesh.positions.size() / 3u)
+       << ",\"type\":\"VEC3\",\"min\":[" << minX << "," << minY << "," << minZ
+       << "],\"max\":[" << maxX << "," << maxY << "," << maxZ << "]},"
+       << "{\"bufferView\":1,\"componentType\":5123,\"count\":"
+       << mesh.indices.size() << ",\"type\":\"SCALAR\"}"
+       << "],"
+       << "\"meshes\":[{\"primitives\":[{\"attributes\":{\"POSITION\":0},\"indices\":1}]}],"
+       << "\"nodes\":[{\"mesh\":0}],"
+       << "\"scenes\":[{\"nodes\":[0]}],"
+       << "\"scene\":0"
+       << "}";
+
+  std::string jsonText = json.str();
+  while ((jsonText.size() % 4u) != 0u)
+    jsonText.push_back(' ');
+
+  const uint32_t jsonLen = static_cast<uint32_t>(jsonText.size());
+  const uint32_t totalLen = 12u + 8u + jsonLen + 8u + totalBinBytes;
+
+  std::vector<uint8_t> glb;
+  glb.reserve(totalLen);
+  AppendU32(glb, 0x46546C67u);
+  AppendU32(glb, 2u);
+  AppendU32(glb, totalLen);
+
+  AppendU32(glb, jsonLen);
+  AppendU32(glb, 0x4E4F534Au);
+  AppendBytes(glb, jsonText.data(), jsonText.size());
+
+  AppendU32(glb, totalBinBytes);
+  AppendU32(glb, 0x004E4942u);
+  AppendBytes(glb, bin.data(), bin.size());
+
+  std::error_code ec;
+  const fs::path output = fs::u8path(outputPath);
+  if (output.has_parent_path())
+    fs::create_directories(output.parent_path(), ec);
+
+  std::ofstream out(output, std::ios::binary | std::ios::trunc);
+  if (!out.is_open())
+    return false;
+  out.write(reinterpret_cast<const char *>(glb.data()),
+            static_cast<std::streamsize>(glb.size()));
+  return out.good();
 }
 
 } // namespace
@@ -135,23 +227,14 @@ std::string PrimitiveArchivePathForToken(const std::string &primitiveToken) {
   return {};
 }
 
-bool WritePrimitiveObjForToken(const std::string &primitiveToken,
-                               const std::string &outputPath) {
-  const char *objData = ObjDataForToken(primitiveToken);
-  if (objData == nullptr)
-    return false;
-
-  std::error_code ec;
-  const fs::path output = fs::u8path(outputPath);
-  if (output.has_parent_path())
-    fs::create_directories(output.parent_path(), ec);
-
-  std::ofstream out(output, std::ios::binary | std::ios::trunc);
-  if (!out.is_open())
-    return false;
-
-  out << objData;
-  return out.good();
+bool WritePrimitiveModelForToken(const std::string &primitiveToken,
+                                 const std::string &outputPath) {
+  const std::string normalized = NormalizeLower(primitiveToken);
+  if (normalized.rfind(kCubeToken, 0) == 0)
+    return WriteGlb(BuildCubeMesh(), outputPath);
+  if (normalized.rfind(kSphereToken, 0) == 0)
+    return WriteGlb(BuildSphereMesh(), outputPath);
+  return false;
 }
 
 } // namespace mvr

--- a/mvr/primitive_model_resources.cpp
+++ b/mvr/primitive_model_resources.cpp
@@ -38,13 +38,27 @@ std::string NormalizeLower(std::string value) {
 bool IsSphereRef(const std::string &normalized) {
   return normalized.rfind(kSphereToken, 0) == 0 ||
          normalized.find("perastage_primitive_sphere.glb") != std::string::npos ||
-         normalized.find("perastage_primitive_sphere.obj") != std::string::npos;
+         normalized.find("perastage_primitive_sphere.obj") != std::string::npos ||
+         normalized.find("primitive_sphere_") != std::string::npos;
 }
 
 bool IsCubeRef(const std::string &normalized) {
   return normalized.rfind(kCubeToken, 0) == 0 ||
          normalized.find("perastage_primitive_cube.glb") != std::string::npos ||
-         normalized.find("perastage_primitive_cube.obj") != std::string::npos;
+         normalized.find("perastage_primitive_cube.obj") != std::string::npos ||
+         normalized.find("primitive_cube_") != std::string::npos;
+}
+
+std::string SanitizeUuidForFileName(const std::string &objectUuid) {
+  std::string out;
+  out.reserve(objectUuid.size());
+  for (char ch : objectUuid) {
+    if (std::isalnum(static_cast<unsigned char>(ch)))
+      out.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(ch))));
+    else
+      out.push_back('_');
+  }
+  return out;
 }
 
 struct PrimitiveMeshData {
@@ -224,6 +238,19 @@ std::string PrimitiveArchivePathForToken(const std::string &primitiveToken) {
     return kSphereArchiveName;
   if (normalized.rfind(kCubeToken, 0) == 0)
     return kCubeArchiveName;
+  return {};
+}
+
+std::string PrimitiveArchivePathForToken(const std::string &primitiveToken,
+                                         const std::string &objectUuid) {
+  const std::string normalized = NormalizeLower(primitiveToken);
+  const std::string suffix = SanitizeUuidForFileName(objectUuid);
+  if (suffix.empty())
+    return PrimitiveArchivePathForToken(primitiveToken);
+  if (normalized.rfind(kSphereToken, 0) == 0)
+    return "primitives/primitive_sphere_" + suffix + ".glb";
+  if (normalized.rfind(kCubeToken, 0) == 0)
+    return "primitives/primitive_cube_" + suffix + ".glb";
   return {};
 }
 

--- a/mvr/primitive_model_resources.cpp
+++ b/mvr/primitive_model_resources.cpp
@@ -1,0 +1,157 @@
+#include "primitive_model_resources.h"
+
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace mvr {
+namespace {
+
+constexpr const char *kSphereToken = "primitive:sphere";
+constexpr const char *kCubeToken = "primitive:cube";
+constexpr const char *kSphereArchiveName = "primitives/perastage_primitive_sphere.obj";
+constexpr const char *kCubeArchiveName = "primitives/perastage_primitive_cube.obj";
+
+std::string NormalizeLower(std::string value) {
+  value.erase(value.begin(),
+              std::find_if(value.begin(), value.end(), [](unsigned char c) {
+                return !std::isspace(c);
+              }));
+  value.erase(std::find_if(value.rbegin(), value.rend(),
+                           [](unsigned char c) { return !std::isspace(c); })
+                  .base(),
+              value.end());
+  std::replace(value.begin(), value.end(), '\\', '/');
+  std::transform(value.begin(), value.end(), value.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return value;
+}
+
+bool IsSphereRef(const std::string &normalized) {
+  return normalized.rfind(kSphereToken, 0) == 0 ||
+         normalized.find("perastage_primitive_sphere.obj") != std::string::npos;
+}
+
+bool IsCubeRef(const std::string &normalized) {
+  return normalized.rfind(kCubeToken, 0) == 0 ||
+         normalized.find("perastage_primitive_cube.obj") != std::string::npos;
+}
+
+const char *ObjDataForToken(const std::string &primitiveToken) {
+  const std::string normalized = NormalizeLower(primitiveToken);
+  if (normalized.rfind(kCubeToken, 0) == 0) {
+    return R"OBJ(o PerastagePrimitiveCube
+v -0.5 -0.5 -0.5
+v 0.5 -0.5 -0.5
+v 0.5 0.5 -0.5
+v -0.5 0.5 -0.5
+v -0.5 -0.5 0.5
+v 0.5 -0.5 0.5
+v 0.5 0.5 0.5
+v -0.5 0.5 0.5
+f 1 2 3
+f 1 3 4
+f 5 8 7
+f 5 7 6
+f 1 5 6
+f 1 6 2
+f 2 6 7
+f 2 7 3
+f 3 7 8
+f 3 8 4
+f 4 8 5
+f 4 5 1
+)OBJ";
+  }
+
+  if (normalized.rfind(kSphereToken, 0) == 0) {
+    return R"OBJ(o PerastagePrimitiveSphere
+v 0 0.5 0
+v 0.353553 0.353553 0
+v 0 0.353553 0.353553
+v -0.353553 0.353553 0
+v 0 0.353553 -0.353553
+v 0.5 0 0
+v 0 0 0.5
+v -0.5 0 0
+v 0 0 -0.5
+v 0.353553 -0.353553 0
+v 0 -0.353553 0.353553
+v -0.353553 -0.353553 0
+v 0 -0.353553 -0.353553
+v 0 -0.5 0
+f 1 2 3
+f 1 3 4
+f 1 4 5
+f 1 5 2
+f 2 6 3
+f 3 7 4
+f 4 8 5
+f 5 9 2
+f 6 10 11
+f 6 11 7
+f 7 11 12
+f 7 12 8
+f 8 12 13
+f 8 13 9
+f 9 13 10
+f 9 10 6
+f 10 14 11
+f 11 14 12
+f 12 14 13
+f 13 14 10
+)OBJ";
+  }
+
+  return nullptr;
+}
+
+} // namespace
+
+bool ResolvePrimitiveTokenFromModelRef(const std::string &modelRef,
+                                       std::string &outPrimitiveToken) {
+  const std::string normalized = NormalizeLower(modelRef);
+  if (IsSphereRef(normalized)) {
+    outPrimitiveToken = kSphereToken;
+    return true;
+  }
+  if (IsCubeRef(normalized)) {
+    outPrimitiveToken = kCubeToken;
+    return true;
+  }
+  return false;
+}
+
+std::string PrimitiveArchivePathForToken(const std::string &primitiveToken) {
+  const std::string normalized = NormalizeLower(primitiveToken);
+  if (normalized.rfind(kSphereToken, 0) == 0)
+    return kSphereArchiveName;
+  if (normalized.rfind(kCubeToken, 0) == 0)
+    return kCubeArchiveName;
+  return {};
+}
+
+bool WritePrimitiveObjForToken(const std::string &primitiveToken,
+                               const std::string &outputPath) {
+  const char *objData = ObjDataForToken(primitiveToken);
+  if (objData == nullptr)
+    return false;
+
+  std::error_code ec;
+  const fs::path output = fs::u8path(outputPath);
+  if (output.has_parent_path())
+    fs::create_directories(output.parent_path(), ec);
+
+  std::ofstream out(output, std::ios::binary | std::ios::trunc);
+  if (!out.is_open())
+    return false;
+
+  out << objData;
+  return out.good();
+}
+
+} // namespace mvr

--- a/mvr/primitive_model_resources.h
+++ b/mvr/primitive_model_resources.h
@@ -7,6 +7,8 @@ namespace mvr {
 bool ResolvePrimitiveTokenFromModelRef(const std::string &modelRef,
                                        std::string &outPrimitiveToken);
 std::string PrimitiveArchivePathForToken(const std::string &primitiveToken);
+std::string PrimitiveArchivePathForToken(const std::string &primitiveToken,
+                                         const std::string &objectUuid);
 bool WritePrimitiveModelForToken(const std::string &primitiveToken,
                                  const std::string &outputPath);
 

--- a/mvr/primitive_model_resources.h
+++ b/mvr/primitive_model_resources.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+
+namespace mvr {
+
+bool ResolvePrimitiveTokenFromModelRef(const std::string &modelRef,
+                                       std::string &outPrimitiveToken);
+std::string PrimitiveArchivePathForToken(const std::string &primitiveToken);
+bool WritePrimitiveObjForToken(const std::string &primitiveToken,
+                               const std::string &outputPath);
+
+} // namespace mvr

--- a/mvr/primitive_model_resources.h
+++ b/mvr/primitive_model_resources.h
@@ -7,7 +7,7 @@ namespace mvr {
 bool ResolvePrimitiveTokenFromModelRef(const std::string &modelRef,
                                        std::string &outPrimitiveToken);
 std::string PrimitiveArchivePathForToken(const std::string &primitiveToken);
-bool WritePrimitiveObjForToken(const std::string &primitiveToken,
-                               const std::string &outputPath);
+bool WritePrimitiveModelForToken(const std::string &primitiveToken,
+                                 const std::string &outputPath);
 
 } // namespace mvr

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -1625,12 +1625,8 @@ void Viewer2DPanel::OnMouseDClick(wxMouseEvent &event) {
   std::string uuid;
   ConfigManager &cfg = ConfigManager::Get();
 
-  if (SceneObjectTablePanel::Instance() &&
-      SceneObjectTablePanel::Instance()->IsActivePage()) {
-    if (!m_controller.GetSceneObjectLabelAt(event.GetX(), event.GetY(), w, h,
-                                            label, pos, &uuid))
-      return;
-
+  if (m_controller.GetSceneObjectLabelAt(event.GetX(), event.GetY(), w, h,
+                                         label, pos, &uuid)) {
     const bool edited = scene_object_primitives::EditPrimitiveObjectByUuid(
         this, cfg, uuid);
     if (!edited)

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -1625,7 +1625,11 @@ void Viewer2DPanel::OnMouseDClick(wxMouseEvent &event) {
   std::string uuid;
   ConfigManager &cfg = ConfigManager::Get();
 
-  if (m_controller.GetSceneObjectLabelAt(event.GetX(), event.GetY(), w, h,
+  const bool sceneObjectsActive =
+      SceneObjectTablePanel::Instance() &&
+      SceneObjectTablePanel::Instance()->IsActivePage();
+  if (sceneObjectsActive &&
+      m_controller.GetSceneObjectLabelAt(event.GetX(), event.GetY(), w, h,
                                          label, pos, &uuid)) {
     const bool edited = scene_object_primitives::EditPrimitiveObjectByUuid(
         this, cfg, uuid);

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -49,6 +49,7 @@
 #include "hoisttablepanel.h"
 #include "logger.h"
 #include "positionvalueupdate.h"
+#include "scene_object_primitive_editing.h"
 #include "sceneobjecttablepanel.h"
 #include "trusstablepanel.h"
 #include "viewer3dpanel.h"
@@ -1622,11 +1623,38 @@ void Viewer2DPanel::OnMouseDClick(wxMouseEvent &event) {
   wxString label;
   wxPoint pos;
   std::string uuid;
+  ConfigManager &cfg = ConfigManager::Get();
+
+  if (SceneObjectTablePanel::Instance() &&
+      SceneObjectTablePanel::Instance()->IsActivePage()) {
+    if (!m_controller.GetSceneObjectLabelAt(event.GetX(), event.GetY(), w, h,
+                                            label, pos, &uuid))
+      return;
+
+    const bool edited = scene_object_primitives::EditPrimitiveObjectByUuid(
+        this, cfg, uuid);
+    if (!edited)
+      return;
+
+    if (SceneObjectTablePanel::Instance()) {
+      SceneObjectTablePanel::Instance()->ReloadData();
+      SceneObjectTablePanel::Instance()->SelectByUuid({uuid});
+    }
+
+    UpdateScene(false);
+    if (Viewer3DPanel::Instance()) {
+      Viewer3DPanel::Instance()->UpdateScene();
+      Viewer3DPanel::Instance()->Refresh();
+    }
+    Refresh();
+    return;
+  }
+
   if (!m_controller.GetFixtureLabelAt(event.GetX(), event.GetY(), w, h, label,
                                       pos, &uuid))
     return;
 
-  auto &scene = ConfigManager::Get().GetScene();
+  auto &scene = cfg.GetScene();
   auto it = scene.fixtures.find(uuid);
   if (it == scene.fixtures.end())
     return;

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -45,6 +45,7 @@
 #include "fixturetablepanel.h"
 #include "trusstablepanel.h"
 #include "sceneobjecttablepanel.h"
+#include "scene_object_primitive_editing.h"
 #include "configmanager.h"
 #include "fixturepatchdialog.h"
 #include "viewer2dpanel.h"
@@ -1348,9 +1349,17 @@ void Viewer3DPanel::OnMouseDClick(wxMouseEvent& event)
     if (cameraWasMoving)
         m_controller.SetCameraMoving(false);
 
-    const bool found =
-        m_controller.GetFixtureLabelAt(event.GetX(), event.GetY(), w, h, label,
-                                       pos, &uuid);
+    const bool sceneObjectsActive =
+        SceneObjectTablePanel::Instance() &&
+        SceneObjectTablePanel::Instance()->IsActivePage();
+
+    const bool found = sceneObjectsActive
+                           ? m_controller.GetSceneObjectLabelAt(
+                                 event.GetX(), event.GetY(), w, h, label, pos,
+                                 &uuid)
+                           : m_controller.GetFixtureLabelAt(
+                                 event.GetX(), event.GetY(), w, h, label, pos,
+                                 &uuid);
 
     if (cameraWasMoving)
         m_controller.SetCameraMoving(true);
@@ -1360,7 +1369,28 @@ void Viewer3DPanel::OnMouseDClick(wxMouseEvent& event)
     if (uuid.empty())
         return;
 
-    auto& scene = ConfigManager::Get().GetScene();
+    ConfigManager &cfg = ConfigManager::Get();
+    if (sceneObjectsActive) {
+        const bool edited = scene_object_primitives::EditPrimitiveObjectByUuid(
+            this, cfg, uuid);
+        if (!edited)
+            return;
+
+        if (SceneObjectTablePanel::Instance()) {
+            SceneObjectTablePanel::Instance()->ReloadData();
+            SceneObjectTablePanel::Instance()->SelectByUuid({uuid});
+        }
+
+        UpdateScene();
+        Refresh();
+        if (Viewer2DPanel::Instance()) {
+            Viewer2DPanel::Instance()->UpdateScene();
+            Viewer2DPanel::Instance()->Refresh();
+        }
+        return;
+    }
+
+    auto& scene = cfg.GetScene();
     auto it = scene.fixtures.find(uuid);
     if (it == scene.fixtures.end())
         return;

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -1349,17 +1349,13 @@ void Viewer3DPanel::OnMouseDClick(wxMouseEvent& event)
     if (cameraWasMoving)
         m_controller.SetCameraMoving(false);
 
-    const bool sceneObjectsActive =
-        SceneObjectTablePanel::Instance() &&
-        SceneObjectTablePanel::Instance()->IsActivePage();
+    const bool foundSceneObject = m_controller.GetSceneObjectLabelAt(
+        event.GetX(), event.GetY(), w, h, label, pos, &uuid);
 
-    const bool found = sceneObjectsActive
-                           ? m_controller.GetSceneObjectLabelAt(
-                                 event.GetX(), event.GetY(), w, h, label, pos,
-                                 &uuid)
-                           : m_controller.GetFixtureLabelAt(
-                                 event.GetX(), event.GetY(), w, h, label, pos,
-                                 &uuid);
+    bool found = foundSceneObject;
+    if (!found)
+        found = m_controller.GetFixtureLabelAt(event.GetX(), event.GetY(), w, h,
+                                               label, pos, &uuid);
 
     if (cameraWasMoving)
         m_controller.SetCameraMoving(true);
@@ -1370,7 +1366,7 @@ void Viewer3DPanel::OnMouseDClick(wxMouseEvent& event)
         return;
 
     ConfigManager &cfg = ConfigManager::Get();
-    if (sceneObjectsActive) {
+    if (foundSceneObject) {
         const bool edited = scene_object_primitives::EditPrimitiveObjectByUuid(
             this, cfg, uuid);
         if (!edited)

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -1349,8 +1349,13 @@ void Viewer3DPanel::OnMouseDClick(wxMouseEvent& event)
     if (cameraWasMoving)
         m_controller.SetCameraMoving(false);
 
-    const bool foundSceneObject = m_controller.GetSceneObjectLabelAt(
-        event.GetX(), event.GetY(), w, h, label, pos, &uuid);
+    const bool sceneObjectsActive =
+        SceneObjectTablePanel::Instance() &&
+        SceneObjectTablePanel::Instance()->IsActivePage();
+
+    const bool foundSceneObject = sceneObjectsActive &&
+        m_controller.GetSceneObjectLabelAt(event.GetX(), event.GetY(), w, h,
+                                           label, pos, &uuid);
 
     bool found = foundSceneObject;
     if (!found)


### PR DESCRIPTION
### Motivation
- Users should be able to double-click a basic geometry placed in an MVR (primitive sphere/cube) and edit its properties in-place instead of recreating the object. 
- Keep change small and modular by adding a focused helper service for primitive editing and reusing existing primitive dialogs in an edit mode.

### Description
- Add a primitive editing service in `gui/scene_object_primitive_editing.h/.cpp` that detects editable tokens `primitive:sphere` and `primitive:cube`, converts the object's current transform to dialog parameters, shows the appropriate edit dialog and persists changes with an undo (`edit primitive geometry`).
- Wire table item activation to editing by binding `wxEVT_DATAVIEW_ITEM_ACTIVATED` in `gui/sceneobjecttablepanel.cpp` and calling `scene_object_primitives::EditPrimitiveObjectByUuid(...)` when a row is double-clicked; refreshes 2D/3D viewers and reloads the table after successful edits.
- Reuse and extend primitive dialogs: `gui/scene_object_primitive_dialogs.cpp/.h` now expose `ShowSphereEditDialog` and `ShowCubeEditDialog` and accept initial values and a mode that hides the quantity control for edit flows.
- Register the new source in the GUI build by adding `scene_object_primitive_editing.cpp` to `gui/CMakeLists.txt`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed (`OK`).
- Attempted a full CMake build with `cmake -S . -B build && cmake --build build -j2`, which failed in this environment because system `wxWidgets` development libraries are not available (build error unrelated to the change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d38d701b6083248eccf922656849a7)