### PR TITLE
Fix grid color instability in standard render mode

### DIFF
--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -745,8 +745,11 @@ void SceneRenderer::DrawGrid(int style, float r, float g, float b,
 
   const GLboolean lineSmoothWasEnabled = glIsEnabled(GL_LINE_SMOOTH);
   const GLboolean lightingWasEnabled = glIsEnabled(GL_LIGHTING);
+  const GLboolean texture2DWasEnabled = glIsEnabled(GL_TEXTURE_2D);
   if (lightingWasEnabled)
     glDisable(GL_LIGHTING);
+  if (texture2DWasEnabled)
+    glDisable(GL_TEXTURE_2D);
   if (profile.enableLineSmoothing)
     glEnable(GL_LINE_SMOOTH);
   else
@@ -873,6 +876,9 @@ void SceneRenderer::DrawGrid(int style, float r, float g, float b,
 
   if (lightingWasEnabled)
     glEnable(GL_LIGHTING);
+
+  if (texture2DWasEnabled)
+    glEnable(GL_TEXTURE_2D);
 }
 
 void SceneRenderer::SetupMaterialFromRGB(float r, float g, float b) {


### PR DESCRIPTION
### Motivation
- The scene grid could randomly appear dark/black in the Standard render style because `GL_TEXTURE_2D` state from earlier draws was still enabled when the grid was rendered, so the grid could pick up unintended texturing.

### Description
- Preserve the current `GL_TEXTURE_2D` state with `glIsEnabled(GL_TEXTURE_2D)`, disable `GL_TEXTURE_2D` while drawing the grid, and restore the previous `GL_TEXTURE_2D` state afterwards in `viewer3d/render/scenerenderer.cpp` to prevent the grid from inheriting stale texture state.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d38e022b808324a1f00b17cd9ec2e1)