### PR TITLE
Bump version to 1.0.0 and remove beta display

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.21)
 cmake_policy(SET CMP0074 NEW)
 
-project(Perastage VERSION 0.1.0 LANGUAGES CXX)
+project(Perastage VERSION 1.0.0 LANGUAGES CXX)
 
 set(PERASTAGE_APP_VERSION "${PROJECT_VERSION}")
-set(PERASTAGE_APP_VERSION_DISPLAY "beta ${PROJECT_VERSION}")
+set(PERASTAGE_APP_VERSION_DISPLAY "${PROJECT_VERSION}")
 option(PERASTAGE_ASSOCIATE_PSTG "Register .pstg file association during packaging/installation where supported" ON)
 
 set(CMAKE_CXX_STANDARD 20)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Perastage** is a desktop application for lighting designers and technicians built in C++20.  It reads, organises and visualises show data using the **MVR** (My Virtual Rig) format and **GDTF** (General Device Type Format).  The graphical user interface is written with **wxWidgets** and the 3D/2D rendering is performed with **OpenGL**.
 
-> **Status:** active beta. Core workflows (MVR import/export, editing, layout/printing, and table tooling) are usable and under continuous stabilization. Some advanced and experimental tools remain build-gated or workflow-specific.
+> **Status:** first stable release (1.0.0). Core workflows (MVR import/export, editing, layout/printing, and table tooling) are production-ready and under continuous improvement. Some advanced and experimental tools remain build-gated or workflow-specific.
 
 ---
 

--- a/core/app_version.h
+++ b/core/app_version.h
@@ -22,11 +22,11 @@ namespace app {
 constexpr const char *kName = "Perastage";
 
 #ifndef PERASTAGE_APP_VERSION
-#define PERASTAGE_APP_VERSION "0.1.0"
+#define PERASTAGE_APP_VERSION "1.0.0"
 #endif
 
 #ifndef PERASTAGE_APP_VERSION_DISPLAY
-#define PERASTAGE_APP_VERSION_DISPLAY "beta 0.1.0"
+#define PERASTAGE_APP_VERSION_DISPLAY "1.0.0"
 #endif
 
 constexpr const char *kVersion = PERASTAGE_APP_VERSION;

--- a/packaging/windows/Perastage.iss
+++ b/packaging/windows/Perastage.iss
@@ -3,7 +3,7 @@
 ; exposes .mvr association as an optional installer task.
 
 #define MyAppName "Perastage"
-#define MyAppVersion "0.1.0"
+#define MyAppVersion "1.0.0"
 #define MyAppPublisher "Perasoft"
 #define MyAppURL "https://github.com/PeramatoG/Perastage"
 #define MyAppExeName "Perastage.exe"


### PR DESCRIPTION
### Motivation
- Publish the first stable release by aligning build-time and user-visible version strings to `1.0.0` so runtime surfaces, metadata and packaging are consistent.
- Remove the lingering `beta` display label from the UI and documentation to reflect the stable release status.

### Description
- Updated the project version in `CMakeLists.txt` from `0.1.0` to `1.0.0` and made `PERASTAGE_APP_VERSION_DISPLAY` use `${PROJECT_VERSION}` (removed the `beta` prefix).
- Updated fallback macros in `core/app_version.h` to set `PERASTAGE_APP_VERSION` and `PERASTAGE_APP_VERSION_DISPLAY` to `1.0.0`.
- Updated the Windows installer script `packaging/windows/Perastage.iss` definition `MyAppVersion` to `1.0.0` so packaging artifacts remain aligned with the app version.
- Updated `README.md` status text to indicate the first stable release `1.0.0` instead of active beta.

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which passed.
- Verified version references with `rg` across `CMakeLists.txt`, `core/app_version.h`, `packaging/windows/Perastage.iss`, and `README.md` to confirm all visible/versioned surfaces were updated to `1.0.0`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3a9f173c883249f55d1e52efe4822)