### PR TITLE
Fix MVR export of primitive SceneObjects for better interop

### DIFF
--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -1454,6 +1454,11 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
         stringId = std::to_string(numeric);
       result[uid] = {stringId, numeric};
     }
+
+    for (const auto &[uid, obj] : scene.sceneObjects) {
+      int numeric = allocId();
+      result[uid] = {std::to_string(numeric), numeric};
+    }
     return result;
   };
 
@@ -1948,6 +1953,17 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
     if (!s.name.empty())
       se->SetAttribute("name", s.name.c_str());
 
+    auto supportIdIt = assignedIds.find(s.uuid);
+    int supportNumericId = (supportIdIt != assignedIds.end()) ? supportIdIt->second.second : 0;
+    if (supportNumericId <= 0)
+      supportNumericId = 1;
+    tinyxml2::XMLElement *supportId = doc.NewElement("FixtureID");
+    supportId->SetText(std::to_string(supportNumericId).c_str());
+    se->InsertEndChild(supportId);
+    tinyxml2::XMLElement *supportIdNumeric = doc.NewElement("FixtureIDNumeric");
+    supportIdNumeric->SetText(std::to_string(supportNumericId).c_str());
+    se->InsertEndChild(supportIdNumeric);
+
     auto addSupportInfo = [&](const char *n, const std::string &v,
                               tinyxml2::XMLElement *info) {
       if (!v.empty()) {
@@ -1996,6 +2012,17 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
     oe->SetAttribute("uuid", obj.uuid.c_str());
     if (!obj.name.empty())
       oe->SetAttribute("name", obj.name.c_str());
+
+    auto idIt = assignedIds.find(obj.uuid);
+    int numericId = (idIt != assignedIds.end()) ? idIt->second.second : 0;
+    if (numericId <= 0)
+      numericId = 1;
+    tinyxml2::XMLElement *idNode = doc.NewElement("FixtureID");
+    idNode->SetText(std::to_string(numericId).c_str());
+    oe->InsertEndChild(idNode);
+    tinyxml2::XMLElement *numNode = doc.NewElement("FixtureIDNumeric");
+    numNode->SetText(std::to_string(numericId).c_str());
+    oe->InsertEndChild(numNode);
 
     if (!obj.geometries.empty()) {
       tinyxml2::XMLElement *geos = doc.NewElement("Geometries");

--- a/mvr/primitive_model_resources.cpp
+++ b/mvr/primitive_model_resources.cpp
@@ -19,9 +19,9 @@ namespace {
 constexpr const char *kSphereToken = "primitive:sphere";
 constexpr const char *kCubeToken = "primitive:cube";
 constexpr const char *kCylinderToken = "primitive:cylinder";
-constexpr const char *kSphereArchiveName = "primitives/perastage_primitive_sphere.glb";
-constexpr const char *kCubeArchiveName = "primitives/perastage_primitive_cube.glb";
-constexpr const char *kCylinderArchiveName = "primitives/perastage_primitive_cylinder.glb";
+constexpr const char *kSphereArchiveName = "perastage_primitive_sphere.glb";
+constexpr const char *kCubeArchiveName = "perastage_primitive_cube.glb";
+constexpr const char *kCylinderArchiveName = "perastage_primitive_cylinder.glb";
 
 std::string NormalizeLower(std::string value) {
   value.erase(value.begin(),
@@ -297,11 +297,11 @@ std::string PrimitiveArchivePathForToken(const std::string &primitiveToken,
   if (suffix.empty())
     return PrimitiveArchivePathForToken(primitiveToken);
   if (normalized.rfind(kSphereToken, 0) == 0)
-    return "primitives/primitive_sphere_" + suffix + ".glb";
+    return "primitive_sphere_" + suffix + ".glb";
   if (normalized.rfind(kCubeToken, 0) == 0)
-    return "primitives/primitive_cube_" + suffix + ".glb";
+    return "primitive_cube_" + suffix + ".glb";
   if (normalized.rfind(kCylinderToken, 0) == 0)
-    return "primitives/primitive_cylinder_" + suffix + ".glb";
+    return "primitive_cylinder_" + suffix + ".glb";
   return {};
 }
 


### PR DESCRIPTION
### Motivation
- Primitive scene objects created by text import (pipes/screens) and the Edit menu were not preserved when exporting to MVR because exported `SceneObject` nodes lacked consistent identifiers and the primitive asset paths were nested in a `primitives/` subpath that some importers did not resolve.
- The MVR 1.6 specification expects `SceneObject`/`VideoScreen` geometry entries under `Geometries` with `Geometry3D@fileName` referencing files relative to the archive root and scene nodes to carry discoverable identifiers for interoperability.
- Support nodes that are emitted as `SceneObject` fallbacks also need the same identifier fields so downstream tools can recognize them.

### Description
- Added `scene.sceneObjects` to the exporter ID assignment so `SceneObject` instances receive stable `FixtureID`/`FixtureIDNumeric` entries in the MVR (`mvr/mvrexporter.cpp`).
- Emit `FixtureID` and `FixtureIDNumeric` for exported `SceneObject` nodes and for `Support` fallbacks serialized as `SceneObject` so objects carry explicit numeric identifiers (`mvr/mvrexporter.cpp`).
- Flattened primitive asset archive names by removing the `primitives/` directory prefix and adjusted the per-object primitive file naming to be root-relative (changed constants and returned archive paths in `mvr/primitive_model_resources.cpp`).
- Files changed: `mvr/mvrexporter.cpp` and `mvr/primitive_model_resources.cpp`.

### Testing
- Ran module quality checks `tests/check_perastage_tree_modules.sh` which passed (`OK`).
- Ran GUI rule check `tests/check_no_configmanager_get_in_gui.sh` which passed (`OK`).
- Attempted to build and run `mvr_exporter_compliance_test` via CMake, but the build/run failed in this environment due to a missing system dependency (`wxWidgets`) so the full exporter compliance test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3ac2854b48324afe010f87b2a2b68)