### PR TITLE
Include primitive_model_resources.cpp in MVR-related test targets to fix linker errors

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -177,6 +177,7 @@ add_executable(save_load_roundtrip_test save_load_roundtrip_test.cpp
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
                ../mvr/mvrexporter.cpp
+               ../mvr/primitive_model_resources.cpp
                ../core/gdtf_mutation_audit.cpp
                ../core/logger.cpp
                gdtfloader_stub.cpp
@@ -207,6 +208,7 @@ add_executable(project_support_userdata_roundtrip_test project_support_userdata_
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
                ../mvr/mvrexporter.cpp
+               ../mvr/primitive_model_resources.cpp
                ../core/gdtf_mutation_audit.cpp
                ../core/logger.cpp
                gdtfloader_stub.cpp
@@ -260,6 +262,7 @@ add_executable(rider_truss_dictionary_normalization_test
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
                ../mvr/mvrexporter.cpp
+               ../mvr/primitive_model_resources.cpp
                ../core/gdtf_mutation_audit.cpp
                ../core/logger.cpp
                ../models/mvrscene.cpp
@@ -275,6 +278,7 @@ add_test(NAME RiderTrussDictionaryNormalization COMMAND rider_truss_dictionary_n
 
 add_executable(mvr_dmx_address_test mvr_dmx_address_test.cpp
                ../mvr/mvrexporter.cpp
+               ../mvr/primitive_model_resources.cpp
                ../core/gdtf_mutation_audit.cpp
                ../core/configmanager.cpp
                ../core/configservices.cpp
@@ -317,6 +321,7 @@ add_executable(mvr_support_userdata_roundtrip_test mvr_support_userdata_roundtri
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
                ../mvr/mvrexporter.cpp
+               ../mvr/primitive_model_resources.cpp
                ../core/gdtf_mutation_audit.cpp
                ../core/logger.cpp
                gdtfloader_stub.cpp
@@ -348,6 +353,7 @@ add_executable(mvr_fixture_category_roundtrip_test mvr_fixture_category_roundtri
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
                ../mvr/mvrexporter.cpp
+               ../mvr/primitive_model_resources.cpp
                ../core/gdtf_mutation_audit.cpp
                ../core/logger.cpp
                gdtfloader_stub.cpp
@@ -378,6 +384,7 @@ add_executable(mvr_truss_roundtrip_structure_test mvr_truss_roundtrip_structure_
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
                ../mvr/mvrexporter.cpp
+               ../mvr/primitive_model_resources.cpp
                ../core/gdtf_mutation_audit.cpp
                ../core/logger.cpp
                gdtfloader_stub.cpp
@@ -408,6 +415,7 @@ add_executable(mvr_exporter_compliance_test mvr_exporter_compliance_test.cpp
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
                ../mvr/mvrexporter.cpp
+               ../mvr/primitive_model_resources.cpp
                ../core/gdtf_mutation_audit.cpp
                ../core/logger.cpp
                gdtfloader_stub.cpp
@@ -446,6 +454,7 @@ add_executable(rider_save_roundtrip_test rider_save_roundtrip_test.cpp
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
                ../mvr/mvrexporter.cpp
+               ../mvr/primitive_model_resources.cpp
                ../core/gdtf_mutation_audit.cpp
                ../core/logger.cpp
                ../models/mvrscene.cpp
@@ -900,6 +909,7 @@ add_executable(symbol_fixture_applier_gdtf_test symbol_fixture_applier_gdtf_test
                ../viewer3d/meshprimitives.cpp
                ../mvr/mvrimporter.cpp
                ../mvr/mvrexporter.cpp
+               ../mvr/primitive_model_resources.cpp
                ../core/gdtf_mutation_audit.cpp
                consolepanel_stub.cpp
                ${LAYOUT_SOURCES})
@@ -911,6 +921,7 @@ set_library_env(SymbolFixtureApplierGdtfMutation)
 
 add_executable(mvr_patched_gdtf_export_test mvr_patched_gdtf_export_test.cpp
                ../mvr/mvrexporter.cpp
+               ../mvr/primitive_model_resources.cpp
                ../core/configmanager.cpp
                ../core/configservices.cpp
                ../core/projectutils.cpp


### PR DESCRIPTION
### Motivation
- Several test executables that compile `mvr/mvrimporter.cpp` and/or `mvr/mvrexporter.cpp` failed to link with `LNK2019`/`LNK2001` unresolved externals for `mvr::ResolvePrimitiveTokenFromModelRef`, `mvr::PrimitiveArchivePathForToken` (both overloads) and `mvr::WritePrimitiveModelForToken`.
- Those symbols are implemented in `mvr/primitive_model_resources.cpp`, which was part of the main application target but missing from the affected test targets.

### Description
- Updated `tests/CMakeLists.txt` to add `../mvr/primitive_model_resources.cpp` to every `add_executable(...)` target that directly compiles `mvrimporter.cpp` and/or `mvrexporter.cpp` so the test binaries include the necessary definitions.
- This change keeps all modifications limited to the test build files and does not alter public APIs or source logic.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.
- Attempted `cmake --preset wsl-x64-debug` to validate a local configure/build, but the environment is missing `wxWidgets` development packages so a full build/link verification could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3adc107388324916a0cdef7845346)