### PR TITLE
docs: simplify README and split detailed guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ![Perastage 3D View](resources/perastage3d.png)
 
-Perastage is a C++20 desktop application for professional lighting design and show documentation. It helps lighting designers, programmers, and technicians import MVR data, manage fixtures/trusses/hoists, and generate printable 2D/3D documentation from a single project. The goal is to keep rig planning, scene visualization, and export workflows in one focused tool.
+Perastage is a C++20 desktop application for professional lighting design and show documentation. It helps lighting designers, programmers, and technicians import MVR data, manage fixtures/trusses/hoists, and generate printable 2D/3D documentation from a single project. The current stable line extends the original beta workflow set with production-ready MVR, dictionary portability, and layout/print pipelines.
 
 ## Highlights
 
@@ -39,6 +39,7 @@ The README is intentionally concise. Detailed documentation lives in `docs/`:
 
 - [Documentation policy](docs/documentation_policy.md)
 - [Feature overview](docs/features.md)
+- [Changes since beta 0.1.0](docs/changes_since_beta_0_1_0.md)
 - [Build and dependency guide](docs/build.md)
 - [Windows installation notes](docs/installation_windows.md)
 - [Packaging and platform integration](docs/packaging.md)

--- a/README.md
+++ b/README.md
@@ -1,327 +1,61 @@
 # Perastage
 
+![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)
+![Build: CMake](https://img.shields.io/badge/Build-CMake-064F8C)
+
 ![Perastage 3D View](resources/perastage3d.png)
 
-**Perastage** is a desktop application for lighting designers and technicians built in C++20.  It reads, organises and visualises show data using the **MVR** (My Virtual Rig) format and **GDTF** (General Device Type Format).  The graphical user interface is written with **wxWidgets** and the 3D/2D rendering is performed with **OpenGL**.
+Perastage is a C++20 desktop application for professional lighting design and show documentation. It helps lighting designers, programmers, and technicians import MVR data, manage fixtures/trusses/hoists, and generate printable 2D/3D documentation from a single project. The goal is to keep rig planning, scene visualization, and export workflows in one focused tool.
 
-> **Status:** first stable release (1.0.0). Core workflows (MVR import/export, editing, layout/printing, and table tooling) are production-ready and under continuous improvement. Some advanced and experimental tools remain build-gated or workflow-specific.
+## Highlights
 
----
+- Imports and exports MVR scenes with integrated GDTF fixture handling and archive-safe asset references.
+- Combines a real-time 3D viewer, a plan-focused 2D viewer, and a multi-page layout/print workflow.
+- Includes rider/text parsing to generate fixtures and truss structures directly from production notes.
+- Provides fixture, truss, hoist, and object tables with batch-edit and patch management workflows.
+- Supports flexible dictionary workflows (JSON snapshots, copied assets, and portable ZIP bundles).
+- Produces documentation outputs such as layout PDFs, table exports, and print-ready sheets.
 
-## Main features
-
-### Project management
-
-- Open and save Perastage projects (`*.pstg`) with support for multiple named pages/layouts.
-- Group fixtures, trusses, hoists and scene objects into layers and toggle their visibility/selection per layer.
-- Save and restore user preferences (window layout, last used directories, view mode, etc.).
-
-### Fixture, truss, hoist and object model
-
-- Internal data model for fixtures, trusses, hoists (supports) and generic scene objects with unique identifiers.
-- Layers allow you to organise elements and assign colours per layer; layers are used in both the 3D/2D viewers and the printing/export pipeline.
-- Scene objects include basic geometry and transform helpers for positioning, rotating and scaling elements in space.
-
-### MVR & GDTF support
-
-- **Import MVR 1.6** scenes: read fixtures, trusses, hoists and generic objects from `.mvr` files and build the internal scene graph.
-- **Official `.mvr` open policy (menu import and OS double-click):** Perastage first asks to save unsaved changes, then opens the `.mvr` using a clean-scene reset + import flow (not merge). The same progress UI/locking behavior is used in both entry points (`wxWindowDisabler` + `wxBusyInfo`) so the workflow remains consistent.
-- **Export MVR**: write the current scene back to a new `.mvr` file so it can be opened in other lighting software.
-- **GDTF integration**:
-  - A built‑in fixture dictionary maps textual fixture descriptions to GDTF files stored in the `library/` directory.
-  - Geometry loaders parse embedded GDTF models for preview and rendering in the 3D viewer.
-  - Online lookup: download fixtures from **GDTF‑Share** via the *Tools → Download GDTF fixture* dialog.
-  - Exported MVR packages store referenced GDTFs under `gdtf/` inside the archive and `GDTFSpec` always uses archive‑relative forward‑slash paths.
-  - If two different GDTF files share the same filename, export auto‑renames collisions deterministically (`name (1).gdtf`, etc.) and updates each `GDTFSpec` reference.
-  - GDTF mutation and compatibility policy for `description.xml` writes, revision stamping and schema fallback is documented in [`docs/gdtf_mutation_policy.md`](docs/gdtf_mutation_policy.md).
-  - Parametric objects exported as Fixture/Truss/Support receive non-empty `FixtureID` + globally unique `FixtureIDNumeric` values across the scene.
-
-### Rider import from text or PDF
-
-- Import simple lighting riders from plain text or PDF documents using the **Tools → Create from text** dialog.
-- The dialog provides an **Apply filter** action that replaces the editor text with the parsed fixture-only result before you press **Create**.
-- The rider importer parses typical lists of fixture quantities/types and creates corresponding dummy fixtures/trusses in the scene.
-- Truss hang tokens can include optional coordinates in parentheses to override
-  default truss placement in **Create from text** (numeric values follow the
-  active distance unit system: meters/feet), including hang headers such as
-  `LX1 (7)` / `LX1 (7):`.
-- In text import, `CALLES`/`SIDES` hang headers map to `LX SIDES` and support mirrored side-truss/fixture placement workflows.
-- The full parser and placement rule set used by this text-to-scene workflow is documented in [`docs/text_to_scene_rules.md`](docs/text_to_scene_rules.md).
-- A dictionary helps resolve type names to GDTF specifications and can be edited via the **Tools → Edit dictionaries** menu.
-- Dictionary import/export now supports three portability levels:
-  - JSON snapshot (references only, backward compatible),
-  - JSON snapshot + optional copied `assets/` folder (`*_assets/assets/...`),
-  - portable ZIP bundle (`manifest.json` + `dictionary.json` + `assets/*`).
-- Import/export flows include preflight path validation and report missing referenced files before applying changes.
-- When importing files into `library/fixtures` or `library/trusses`, filename collisions with different content prompt a policy (rename/overwrite/cancel).
-
-### Patch management
-
-- Manage DMX universes and addresses for fixtures via table dialogs.
-- **Auto patch** tool groups fixtures by hang position and type and assigns DMX channels sequentially across universes.
-- Manual patching is supported via the address and mode editors.
-
-### Colour and type helpers
-
-- **Auto color** assigns colours to layers and fixtures based on their type; truss layers default to light grey.  Existing colours are preserved if explicitly set.
-- **Convert to Hoist** converts selected fixtures into hoists/supports in the scene, retaining positions and names.
-
-### Views and layout system
-
-- **3D Viewer:** inspect trusses, fixtures, hoists and scene objects in a real‑time OpenGL viewport.  Camera controls include orbit, pan, zoom and preset views.
-- **2D Viewer:** top‑down plan view with grid, axis indicators and label options.  You can capture the vector draw commands for export (see `Viewer2DPanel::RequestFrameCapture()` in the API).
-- **Layout mode:** create multiple printable layout pages containing 2D views, legends, event tables, text boxes and images.  Layout orientation (portrait/landscape) and element ordering are editable via the Layouts panel.  The underlying `LayoutManager` API supports adding, renaming, deleting and ordering views and legends.
-- **Summary and rigging panels:** display counts and basic statistics for fixtures/trusses/hoists/objects and highlight missing weight data.
-- **Layer panel:** lists scene layers and allows switching the active layer for newly created items.
-
-### Printing and export
-
-- **Print Viewer 2D (Debug builds):** print the current 2D view directly to PDF with configurable page size and orientation. In Release builds this dialog is intentionally hidden behind `ui::FeatureFlag::PrintViewer2DDialog`.
-- **Print Layout:** print the active layout to PDF, including 2D views, legends, event tables, text and images.
-- **Print Table:** print any of the data tables (fixtures, trusses, hoists, objects) or export them to CSV via **File → Export CSV**.
-- **Export Fixture/Truss/Object:** export selected items to stand‑alone GDTF/GTRUSS or object files via the Tools menu.
-- **Layout PDF output:** export complete documentation sheets that combine viewport captures, legends, event tables, text, and image elements on named pages.
-
-### GUI helpers
-
-- **Build-gated tools:** some menu entries are intentionally Debug-only (for example *Print Viewer 2D* and *Generate fixture symbols*) to keep Release builds focused on production-safe workflows.
-- Tables for fixtures, trusses, hoists and objects support multi‑row editing shortcuts: sequential fills, range interpolation (`1 10` / `1 thru 10`), relative edits (`++0.5`, `--15`), etc.
-- Console panel for status messages and command‑line operations (e.g. selecting fixtures or trusses via textual commands).
-- Preferences dialog to set default directories, units and other settings.
-- UI units can be switched independently for distance and weight (**Edit → Preferences → Units**). Internally, distances remain canonical in **mm** and weights in **kg**; metric/imperial affects input parsing and display/labels only. See [`docs/ui_unit_systems.md`](docs/ui_unit_systems.md).
-- Login dialog stores encrypted credentials for GDTF‑Share downloads.
-
----
-
-## Repository layout
-
-The most important directories are:
-
-| Path | Purpose |
-|------|---------|
-| `main.cpp` | Application entry point (initialises wxWidgets and the main window). |
-| `core/` | Core logic and utilities: configuration, logging, rider importer, auto‑patcher, dictionaries, PDF/text helpers, layout and printing helpers, etc. |
-| `core/layouts/` | Layout system definitions and manager for printable pages. |
-| `core/print/` | Print and PDF export helpers for tables, layouts and viewers. |
-| `gui/` | wxWidgets panels, dialogs and the main window: tables, viewers, panels, dialogs and menus. |
-| `models/` | Data structures describing the scene: fixtures, trusses, hoists, layers and matrices. |
-| `mvr/` | Importers/exporters for the MVR format. |
-| `viewer3d/` | 3D rendering engine, camera controls and mesh loaders. |
-| `viewer2d/` | 2D plan view renderer and capture utilities. |
-| `third_party/` | Vendored third-party headers (for example `json.hpp`) kept separate from project modules. |
-| `library/` | Built‑in data: fixture dictionary, default trusses, textures, scene objects and example projects (`library/scene_objects/`, etc.). |
-| `resources/` | Application icon, Windows resource script and additional images (including `perastage3d.png` for this README). |
-| `tests/` | Unit tests using Catch2. |
-| `docs/` | Informal documentation and specs (MVR/GDTF notes). |
-
-For a detailed explanation of each file see `perastage_tree.md`.
-
-For repository conventions (modules, third-party code, and CMake structure), see `docs/architecture.md`.
-
----
-
-## Building
-
-Perastage uses **CMake** and targets C++20.  Build dependencies include `wxWidgets` (core/base/aui/gl/html), `tinyxml2`, `OpenGL/GLU`, `GLEW`, `CURL`, `nanovg` and `PoDoFo`.  On Windows you can use **vcpkg**, **MSYS2** or similar; on Linux/macOS use your system package manager or vcpkg.
-
-Configure and build:
+## Installation
 
 ```bash
-mkdir build
-cd build
-cmake ..
-cmake --build .
+git clone https://github.com/PeramatoG/perastage.git
+cd perastage
+cmake -S . -B build
+cmake --build build --config Release
 ```
 
-The `perastage_stage` target (Release configuration) stages runtime resources into `out/install/<CONFIG>` (for example `out/install/Release`) ready for packaging with Inno Setup.  Use `perastage_symbols` to collect `.pdb` files for crash analysis on Windows.
+For platform-specific setup, dependency installation, and packaging, see [docs/build.md](docs/build.md).
 
-Run tests from the build directory with `ctest` to execute unit tests.
+## Basic Usage
 
-### Optional Peraviz and DMX integration
+- Start the executable from your build output (`build/.../Perastage` or `Perastage.exe`).
+- Open an existing `.pstg`/`.mvr` project or create a new scene from the main menu.
+- Use **Tools → Create from text** to generate fixtures from rider-style notes, or use the table/layout panels to document the rig.
 
-Perastage includes an optional **Peraviz** viewer and DMX/Art‑Net receiver built on top of the Godot engine. These components are off by default and require extra dependencies.
+## Documentation
 
-- To enable the native Peraviz subtarget, configure CMake with `-DPERAVIZ_ENABLE_NATIVE=ON`. This target uses Python 3 to generate bindings during the build; make sure Python 3 is installed and discoverable.
-- To enable DMX/Art‑Net reception within the Peraviz viewer, pass `-DPERAVIZ_ENABLE_DMX=ON` in addition to the above option.
+The README is intentionally concise. Detailed documentation lives in `docs/`:
 
-These options are considered experimental and are not required for the core Perastage application. See `peraviz/` for details.
+- [Documentation policy](docs/documentation_policy.md)
+- [Feature overview](docs/features.md)
+- [Build and dependency guide](docs/build.md)
+- [Windows installation notes](docs/installation_windows.md)
+- [Packaging and platform integration](docs/packaging.md)
+- [Troubleshooting](docs/troubleshooting.md)
+- [Repository structure](docs/repository_layout.md)
+- [Text-to-scene parsing rules](docs/text_to_scene_rules.md)
+- [GDTF mutation policy](docs/gdtf_mutation_policy.md)
+- [GUI shortcut architecture](docs/gui_shortcut_architecture.md)
 
-### Project file format
+## Contributing
 
-Perastage project files (`*.pstg`) are standard ZIP archives. A project typically contains a `config.json` file storing user preferences and layout settings and a `scene.mvr` file storing the show data in MVR format. You can inspect or extract these files with any ZIP utility. When Perastage saves a project, it writes the updated `config.json` and `scene.mvr` back into the archive.
+Contributions are welcome. Please keep changes modular and update the matching document in `docs/` when behavior changes. If you modify parsing or shortcut behavior, also update the dedicated rule documents referenced above.
 
----
+## License
 
+Perastage is distributed under the GNU General Public License v3.0. See [LICENSE.txt](LICENSE.txt).
 
-## Manual shading verification (MVR)
+## Author
 
-To verify flat-shading consistency after importing MVR scenes:
-
-1. Build and run the app, then import an `.mvr` file that contains repeated sloped surfaces (for example roof planes).
-2. In the 3D viewer, keep solid rendering enabled and inspect surfaces with the same tilt angle.
-3. Confirm they receive consistent grayscale shading (no random white/gray mismatch on equally oriented planes).
-4. Load a representative GDTF fixture and confirm rendering is unchanged compared to previous behavior.
-
-These checks validate that per-instance normal transformation and mirrored-transform winding correction are working as expected.
-
----
-
-## Windows packaging
-
-The **official Windows installer** is Inno Setup and the repository script is:
-
-- `packaging/windows/Perastage.iss`
-
-Packaging flow:
-
-1. Build the Release configuration.
-2. Run the `perastage_stage` target to populate the staging directory (`out/install/<CONFIG>`, for example `out/install/Release`).
-3. Compile `packaging/windows/Perastage.iss` with Inno Setup.
-4. In the installer task page, choose optional file associations:
-   - `.pstg` (Perastage project files)
-   - `.mvr` (`assoc_mvr`, optional import-oriented double-click flow)
-5. Optionally provide a portable ZIP archive for users who prefer not to run an installer.
-
-Notes:
-
-- The installer writes associations under `Software\Classes` using ProgID/OpenWith entries and `ChangesAssociations=yes`.
-- Uninstall is intentionally conservative for extension ownership: it removes Perastage OpenWith/ProgID entries without forcing aggressive global cleanup of extension owners.
-- Legacy CPack/NSIS wiring is kept only as a compatibility path and is not the official installer workflow.
-
-## Linux desktop integration
-
-Linux installs now include:
-
-- `share/applications/perastage.desktop` with `MimeType=application/x-perastage-mvr;application/x-perastage-project;`
-- `share/mime/packages/perastage-mime.xml` with glob rules for `*.mvr` and `*.pstg`
-- `share/icons/hicolor/1024x1024/apps/perastage.png`
-
-During `cmake --install`, Perastage also attempts to refresh MIME and desktop databases (`update-mime-database` and `update-desktop-database`) so new associations are visible without manual cache refresh.
-
-## macOS document association
-
-On macOS, Perastage builds as an app bundle with `CFBundleDocumentTypes` and UTI declarations for `.mvr`, so Finder can route `.mvr` files to Perastage.
-
----
-
-## Windows build troubleshooting
-
-If you hit `LNK1163: invalid selection for COMDAT section` on Windows, it usually
-means stale object files were produced by a different MSVC toolset or with
-incompatible link settings. Do a clean rebuild:
-
-1. Delete the affected build directory (for example, `out/build/x64-Debug`).
-2. Re-configure CMake and rebuild the target.
-3. If you keep the build directory, use `cmake --build . --config Debug --clean-first`
-   (or the corresponding configuration) to force a clean rebuild.
-
-If Visual Studio shows many **`Error (inactive)`** diagnostics such as:
-
-- `std has no member filesystem / optional / variant / string_view / get_if / bit_cast`
-- structured-binding parse errors near `for (const auto& [a, b] : ...)`
-- follow-up parser errors (`expected ';'`, `expected ']'`, unknown identifiers)
-
-the active IntelliSense profile is usually not using C++20 yet (or is attached to
-an outdated CMake cache). This project requires **C++20**.
-
-Recommended fix sequence:
-
-1. Remove the current build directory (for example `out/build/x64-Debug`).
-2. Re-configure with CMake from a Developer PowerShell:
-   ```powershell
-   cmake -S . -B out/build/x64-Debug -G "Visual Studio 17 2022" -A x64
-   ```
-3. Build explicitly with that configured tree:
-   ```powershell
-   cmake --build out/build/x64-Debug --config Debug
-   ```
-4. In Visual Studio, open the CMake project/folder tied to that build directory
-   and wait for IntelliSense to finish reindexing.
-
-If the diagnostics are still marked as **inactive**, prioritize the real compiler
-output from `cmake --build`; inactive diagnostics alone do not necessarily mean
-the code fails to compile.
-
-### Visual Studio Code IntelliSense alignment (Windows/macOS)
-
-If VS Code shows parser cascades like:
-
-- `std has no member optional / variant / filesystem / string_view / bit_cast`
-- `cannot deduce auto`
-- `expected ';'`, `expected ']'`, unknown identifiers
-- errors inside SDK headers such as `.../c++/v1/__config`
-
-the editor is usually parsing files without the active CMake configuration.
-This repository now includes workspace settings that force VS Code C/C++
-IntelliSense to read build settings from **CMake Tools** and use **C++20**.
-
-Recommended VS Code flow:
-
-1. Install the recommended extensions (`ms-vscode.cpptools`, `ms-vscode.cmake-tools`).
-2. Run **CMake: Select Configure Preset** and choose the preset for your host:
-   - Windows: `win-x64-debug` / `win-x64-release` (or Ninja variants)
-   - macOS: `mac-arm64-debug` / `mac-arm64-release`
-3. Run **CMake: Configure**.
-4. If stale diagnostics remain, delete the selected preset build directory and
-   configure again to regenerate IntelliSense inputs.
-
-Important: if `cmake --build` succeeds but VS Code still reports semantic
-errors, trust the compiler output first; this indicates IntelliSense cache/tooling
-misalignment, not necessarily a cross-platform source incompatibility.
-
----
-
-## macOS build troubleshooting (Apple Silicon)
-
-If CMake fails with messages like:
-
-- `CMake was unable to find a build program corresponding to "Ninja"`
-- `CMAKE_CXX_COMPILER not set, after EnableLanguage`
-
-it usually means the build toolchain is incomplete in that Mac setup (not a source-code error in Perastage).
-
-Install the missing tools:
-
-```bash
-xcode-select --install
-brew install cmake ninja
-```
-
-Then verify:
-
-```bash
-xcode-select -p
-clang++ --version
-ninja --version
-cmake --version
-```
-
-If you use VS Code + CMake Tools:
-
-1. Open `Cmd+Shift+P` → **CMake: Select a Kit** and choose an Apple Clang kit (arm64).
-2. Ensure the configure preset/generator matches your environment (`Ninja` if Ninja is installed).
-3. If you changed toolchains or kits, delete the existing build directory (for example `build/mac-arm64-debug`) and configure again.
-
-When using vcpkg on Apple Silicon, keep the triplet consistent with your configure command (`-DVCPKG_TARGET_TRIPLET=arm64-osx`).
-
----
-
-## Known limitations / experimental areas
-
-- **Beta quality:** many functions in the menu (especially under Tools and Layouts) are placeholders or only partially implemented.  Error handling and input validation are minimal.
-- **Performance:** the 3D renderer is not yet optimised for very large scenes.  The 2D viewer redraws the entire scene on each change.
-- **Incomplete importers/exporters:** only MVR 1.6 is supported; other scene formats (e.g. LXFree, Vectorworks) are not yet supported.  Exporting complex layouts to other software is untested.
-- **Lack of undo/redo across some operations:** while undo/redo is provided for most editing actions, some layout operations might not be undoable.
-- **Planned features:** grouping/filtering by layer, 2D plan generation from text, automatic layout generation from simple instructions, deeper GDTF integration and improved rider import are on the roadmap.
-
-If you encounter bugs or have suggestions please open an issue with:
-
-- What you were attempting to do.
-- Steps to reproduce the problem.
-- Any relevant rider/project/MVR files (if possible).
-
----
-
-## Author & License
-
-Perastage is developed and maintained by **Luisma Peramato** (GitHub user `PeramatoG`).  It is distributed under the **GNU General Public License v3.0**.  Third‑party libraries are used under their respective licences; see `THIRD_PARTY_LICENSES.md` and the files in the `licenses/` directory for details.
+Perastage is developed and maintained by **Luisma Peramato** (GitHub: `PeramatoG`).

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,53 +1,63 @@
 # Build and Dependency Guide
 
-This document covers essential and advanced build details for Perastage. Use it together with `CMakePresets.json` when available in your environment.
+This document covers baseline and advanced build behavior for Perastage. It is the detailed companion to the short installation section in `README.md`.
 
 ## Core Requirements
 
 - CMake 3.21 or newer.
-- C++20-capable toolchain.
-- Main dependencies: wxWidgets, tinyxml2, OpenGL/GLU, GLEW, CURL, nanovg, and PoDoFo.
+- C++20-capable compiler/toolchain.
+- Required libraries include wxWidgets, tinyxml2, OpenGL/GLU, GLEW, CURL, nanovg, and PoDoFo.
 
-## Quick Build
+## Quick Build (All Platforms)
 
 ```bash
 cmake -S . -B build
 cmake --build build --config Release
 ```
 
-### Running Tests
+## Presets and Configuration Strategy
+
+When available, prefer `CMakePresets.json` for consistent local/team builds.
+
+- Single-config generators rely on `CMAKE_BUILD_TYPE`.
+- Multi-config generators (for example Visual Studio) use `--config Debug|Release`.
+
+## Running Tests
 
 ```bash
 ctest --test-dir build
 ```
 
-## Build Outputs
+## Build Targets and Outputs
 
-- The app executable is generated in the selected build output folder.
-- The `perastage_stage` target prepares runtime assets in `out/install/<CONFIG>` for packaging workflows.
-- The `perastage_symbols` target can collect debug symbols on supported Windows setups.
+- Application target: `Perastage` executable.
+- `perastage_stage`: stages runtime files in `out/install/<CONFIG>` for packaging.
+- `perastage_symbols`: collects symbol artifacts on supported Windows environments.
 
-## Optional Peraviz and DMX Options
+## Optional Peraviz and DMX/Art-Net Integration
 
-Perastage includes optional Peraviz integration and DMX/Art-Net support.
+Perastage can build optional Peraviz components when dependencies are present.
 
 ```bash
 cmake -S . -B build -DPERAVIZ_ENABLE_NATIVE=ON -DPERAVIZ_ENABLE_DMX=ON
 ```
 
-Use these options only when your environment has the required dependencies and intended runtime support.
+### Notes
+
+- These options are not required for core Perastage workflows.
+- Ensure Python 3 and dependent toolchain pieces are discoverable when enabling native Peraviz builds.
 
 ## Project File Format
 
-Perastage project files (`.pstg`) are ZIP archives that typically include:
+Perastage project files (`.pstg`) are ZIP archives that commonly include:
 
-- `config.json` for preferences and layout-related settings.
-- `scene.mvr` for show data representation.
+- `config.json` for preferences and layout/user settings,
+- `scene.mvr` for show-scene payload.
 
-Standard ZIP tools can inspect archive contents for diagnostics.
+You can inspect these archives with standard ZIP tools for diagnostics.
 
 ## Related Documents
 
 - [Windows installation notes](installation_windows.md)
 - [Packaging and platform integration](packaging.md)
-- [Troubleshooting](troubleshooting.md)
+- [Build troubleshooting](troubleshooting.md)

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,0 +1,53 @@
+# Build and Dependency Guide
+
+This document covers essential and advanced build details for Perastage. Use it together with `CMakePresets.json` when available in your environment.
+
+## Core Requirements
+
+- CMake 3.21 or newer.
+- C++20-capable toolchain.
+- Main dependencies: wxWidgets, tinyxml2, OpenGL/GLU, GLEW, CURL, nanovg, and PoDoFo.
+
+## Quick Build
+
+```bash
+cmake -S . -B build
+cmake --build build --config Release
+```
+
+### Running Tests
+
+```bash
+ctest --test-dir build
+```
+
+## Build Outputs
+
+- The app executable is generated in the selected build output folder.
+- The `perastage_stage` target prepares runtime assets in `out/install/<CONFIG>` for packaging workflows.
+- The `perastage_symbols` target can collect debug symbols on supported Windows setups.
+
+## Optional Peraviz and DMX Options
+
+Perastage includes optional Peraviz integration and DMX/Art-Net support.
+
+```bash
+cmake -S . -B build -DPERAVIZ_ENABLE_NATIVE=ON -DPERAVIZ_ENABLE_DMX=ON
+```
+
+Use these options only when your environment has the required dependencies and intended runtime support.
+
+## Project File Format
+
+Perastage project files (`.pstg`) are ZIP archives that typically include:
+
+- `config.json` for preferences and layout-related settings.
+- `scene.mvr` for show data representation.
+
+Standard ZIP tools can inspect archive contents for diagnostics.
+
+## Related Documents
+
+- [Windows installation notes](installation_windows.md)
+- [Packaging and platform integration](packaging.md)
+- [Troubleshooting](troubleshooting.md)

--- a/docs/changes_since_beta_0_1_0.md
+++ b/docs/changes_since_beta_0_1_0.md
@@ -1,0 +1,122 @@
+# Changes Since Beta 0.1.0
+
+This document tracks major functional expansion from the beta 0.1.0 era to the current stable release line. It focuses on user-visible capability growth and workflow hardening.
+
+## Release Position
+
+- Beta baseline: `0.1.0` (early workflow coverage, limited production guarantees).
+- Current release line: `1.0.0` (core workflows stabilized and documented).
+
+## Major Functional Growth
+
+## 1) MVR/Open workflow maturity
+
+### Then (beta)
+
+- Import existed but behavior differed more across entry points.
+- Open semantics could be less deterministic for unsaved work and scene resets.
+
+### Now
+
+- MVR import/export flow is a first-class production workflow.
+- `.mvr` opening from menu and OS associations follows consistent save-check and reset+import behavior.
+- Progress and UI-disabling patterns are aligned across entry points.
+
+## 2) GDTF integration and export robustness
+
+### Then (beta)
+
+- Basic fixture mapping and GDTF usage existed with limited policy formalization.
+
+### Now
+
+- Export paths use archive-relative forward-slash references.
+- Deterministic collision renaming prevents ambiguous duplicated GDTF filenames.
+- `description.xml` mutation behavior and compatibility handling is formally documented.
+- Fixture ID assignment across exported parametric objects is normalized and globally unique.
+
+## 3) Rider/text-to-scene parser expansion
+
+### Then (beta)
+
+- Text import existed in early form with narrower rule coverage.
+
+### Now
+
+- Text and PDF rider pipelines are both supported.
+- Apply-filter-first workflow improves pre-creation control.
+- Placement and hang-token parsing covers broader real-world rider syntax.
+- Parser behavior has an explicit rule contract in `docs/text_to_scene_rules.md`.
+
+## 4) Dictionary portability and asset safety
+
+### Then (beta)
+
+- Dictionary workflows were narrower and less portable.
+
+### Now
+
+- Three portability levels are supported (reference JSON, asset-copy snapshot, portable ZIP bundle).
+- Preflight validation and missing-reference reporting are integrated.
+- Collision handling supports rename/overwrite/cancel policy selection.
+
+## 5) Layout and print pipeline depth
+
+### Then (beta)
+
+- Layout and print flows were more limited and less integrated.
+
+### Now
+
+- Multi-page layout authoring supports views, legends, event tables, text, and images.
+- PDF output is suitable for complete documentation sheet generation.
+- Print workflows include tables and layout contexts, with explicit Debug/Release gating where needed.
+
+## 6) Viewer and editing workflow improvements
+
+### Then (beta)
+
+- Core 2D/3D viewing existed with fewer production controls.
+
+### Now
+
+- 3D and 2D viewers are integrated with layer, selection, and table workflows.
+- Batch editing helpers in tables support interpolation and relative updates.
+- Console command workflows and selection commands support fast operational adjustments.
+
+## 7) Platform integration and packaging hardening
+
+### Then (beta)
+
+- Packaging and file association behavior was less standardized.
+
+### Now
+
+- Windows Inno Setup path is the official installer flow.
+- Linux desktop and MIME integration are defined in install layout.
+- macOS document type metadata supports Finder file routing.
+
+## 8) Documentation and policy formalization
+
+### Then (beta)
+
+- Knowledge was concentrated in long-form mixed README content.
+
+### Now
+
+- README is a concise landing page.
+- Deep workflows are distributed across focused docs.
+- Specialized behavioral policies exist for parser rules, GDTF mutation, shortcuts, architecture, and build conventions.
+
+## Areas Still Evolving
+
+- Large-scene performance and selected advanced tooling remain active improvement areas.
+- Some utilities remain build-gated or workflow-specific by design.
+
+## Related Documents
+
+- [Feature overview](features.md)
+- [Build and dependency guide](build.md)
+- [Packaging and platform integration](packaging.md)
+- [Text-to-scene rules](text_to_scene_rules.md)
+- [GDTF mutation policy](gdtf_mutation_policy.md)

--- a/docs/documentation_policy.md
+++ b/docs/documentation_policy.md
@@ -1,0 +1,45 @@
+# Documentation Policy
+
+This document defines how Perastage documentation should be organized and maintained. The primary rule is that `README.md` stays short and acts as a landing page, while detailed workflows live in focused files under `docs/`.
+
+## README Scope
+
+- Keep `README.md` as an elevator pitch and quick-start entry point.
+- Limit it to project overview, highlights, minimal build/run steps, and links to deeper guides.
+- Do not move long troubleshooting logs, packaging checklists, or platform-specific edge cases into `README.md`.
+
+## Detailed Documentation Scope
+
+Use dedicated documents for deeper topics:
+
+- `docs/features.md` for feature breakdowns and workflow summaries.
+- `docs/build.md` for dependency, CMake, and advanced build options.
+- `docs/installation_windows.md` for Windows-specific setup notes.
+- `docs/packaging.md` for installer and desktop integration behavior.
+- `docs/troubleshooting.md` for platform-specific failure modes and fixes.
+- Existing policy/spec files (for example `docs/text_to_scene_rules.md` and `docs/gdtf_mutation_policy.md`) for behavior contracts.
+
+## Formatting Rules
+
+- Use `##` headings for major sections and `###` for subtopics.
+- Keep paragraphs short and focused.
+- Prefer bullet lists and tables for structured information.
+- Use fenced code blocks for commands and snippets.
+- Write all documentation and code comments in English.
+
+## Cross-Linking Rules
+
+- Avoid duplicating large sections across files.
+- Link related guides using relative links.
+- When adding a new major workflow, add one short bullet to `README.md` Highlights and place details in the appropriate `docs/*.md` file.
+
+## Assets and Media
+
+- Store screenshots and diagrams under `docs/` or `resources/` as appropriate.
+- Embed media only where it adds clear instructional value.
+- Compress images before committing to keep repository size manageable.
+
+## License Reference
+
+- Keep license details in `LICENSE.txt` as the single source of truth.
+- Reference the license from `README.md` and any documentation that needs legal context.

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,55 +1,148 @@
 # Perastage Feature Overview
 
-This document summarizes the main end-user capabilities in Perastage. For exact parser behavior and format compliance details, follow the linked policy documents.
+This document is the canonical feature map for the current Perastage release line. It consolidates the active workflows that have evolved from the beta period into the current production-oriented toolset.
 
-## Project and Scene Management
+## Audience and Primary Use Cases
 
-- Open and save Perastage projects (`.pstg`) with multiple named pages/layouts.
-- Organize fixtures, trusses, hoists, and objects into layers with per-layer visibility and selection control.
-- Preserve workspace preferences such as view mode, directories, and window layout.
+Perastage is designed for lighting designers, programmers, and technicians who need to:
+
+- import and normalize real show data,
+- visualize rigs in 3D and 2D,
+- maintain fixture/truss/hoist/object metadata,
+- generate printable and shareable technical documentation.
+
+## Project and Scene Lifecycle
+
+### Project files and defaults
+
+- Perastage projects use the `.pstg` format.
+- New projects can load default layout templates from `library/default_layouts/`.
+- Save, Save As, and Load workflows preserve scene and user-facing project context.
+
+### Layer-aware organization
+
+- Fixtures, trusses, hoists, and objects can be grouped into layers.
+- Layer visibility and selection behavior is shared across viewer and documentation workflows.
+- Active layer controls where newly created items are placed.
 
 ## MVR and GDTF Workflows
 
-- Import and export MVR scenes for interoperability with other lighting tools.
-- Use a built-in fixture dictionary mapped to GDTF files stored in `library/`.
-- Download fixtures from GDTF-Share through the GUI.
-- Handle GDTF filename collisions during export with deterministic renaming.
-- Follow [GDTF mutation policy](gdtf_mutation_policy.md) for `description.xml` writes, revision behavior, and schema fallback.
+### MVR import and open behavior
 
-## Rider and Text-to-Scene Import
+- Imports MVR 1.6 scenes with fixtures, trusses, hoists/supports, and generic objects.
+- `.mvr` opening uses a clean-scene reset plus import flow for deterministic behavior.
+- Menu import and OS association entry points use the same progress and UI lock strategy.
 
-- Parse rider-like text or PDF content using **Tools → Create from text**.
-- Use filter-first workflows before object creation.
-- Support common hang tokens and side mappings in parser input.
-- Maintain parser contract in [Text-to-scene rules](text_to_scene_rules.md).
+### MVR export
 
-## Patch and Data Table Tools
+- Exports the current scene back to `.mvr` for interoperability.
+- Parametric objects exported as Fixture/Truss/Support receive stable non-empty `FixtureID` and globally unique `FixtureIDNumeric` values.
 
-- Manage DMX universes, addresses, and patch assignments.
-- Use auto patch to assign channels by grouped fixture logic.
-- Edit fixtures, trusses, hoists, and objects in dedicated tables with batch operations.
+### GDTF integration and dictionary pipeline
 
-## Visualization and Layout
+- Local fixture dictionary maps textual fixture descriptions to GDTF specs under `library/`.
+- GDTF-Share download flow is available from the Tools menu.
+- Export packages GDTFs under `gdtf/` with archive-relative forward-slash paths.
+- Filename collisions are handled deterministically (`name (1).gdtf`, etc.) and references are updated.
+- Policy details for mutation, revisions, and schema fallback are maintained in [GDTF mutation policy](gdtf_mutation_policy.md).
 
-- Use a real-time OpenGL 3D viewer for scene navigation and inspection.
-- Use the 2D viewer for plan-oriented documentation and vector capture workflows.
-- Build multi-page layouts with views, legends, event tables, text blocks, and images.
+## Rider and Text-to-Scene Generation
 
-## Print and Export Outputs
+### Inputs and parsing flow
 
-- Print layouts and tables to PDF/CSV-oriented outputs.
-- Export fixture/truss/object assets through tool workflows.
-- Generate documentation sheets from layout pages.
+- Rider-like imports accept text and PDF input through **Tools → Create from text**.
+- **Apply filter** supports parser-first cleanup before final object creation.
+- Parser understands hang tokens, including optional coordinate payloads where supported.
+- `CALLES` and `SIDES` headers map into side-truss/fixture placement workflows.
 
-## GUI and Workflow Notes
+### Rules contract
 
-- Some tools are build-gated to keep Release builds focused on production workflows.
-- Unit systems for distance and weight are configurable in Preferences.
-- Shortcut scope and precedence are documented in [GUI shortcut architecture](gui_shortcut_architecture.md).
+- Parsing and placement behavior is governed by [Text-to-scene rules](text_to_scene_rules.md).
+- Any parser behavior changes must update the rules document in the same change set.
 
-## Known Limitations
+## Dictionary Portability and Asset Handling
 
-- Some advanced menu tools remain incomplete or workflow-specific.
-- Very large scenes may stress rendering and redraw paths.
-- Interchange support is centered on MVR; additional formats are limited.
-- Undo/redo coverage is broad but not universal across all operations.
+Perastage dictionary import/export supports multiple transport levels:
+
+- JSON snapshot (references only),
+- JSON snapshot with optional copied assets,
+- portable ZIP bundle with manifest and assets.
+
+Additional safeguards include:
+
+- preflight path validation,
+- missing-reference reporting,
+- collision policy prompts for differing file content.
+
+## Patch, Data Tables, and Editing Helpers
+
+### Patch management
+
+- Manual and assisted patch workflows support universe and address management.
+- Auto patch can group by hang position/type and assign channels sequentially.
+
+### Data tables
+
+- Dedicated tables for fixtures, trusses, hoists, and objects.
+- Multi-row editing helpers include fills, ranges, interpolation, and relative expressions.
+- CSV export is available through file/export workflows.
+
+### Conversion and type/color helpers
+
+- **Auto color** can assign colors by layer/type while preserving explicit colors.
+- **Convert to Hoist** transforms selected fixtures into supports while retaining scene context.
+
+## Visualization and Layout Production
+
+### 3D Viewer
+
+- OpenGL-based viewer with orbit, pan, zoom, and preset camera views.
+- Selection flows integrate with scene tables and command operations.
+
+### 2D Viewer
+
+- Top-down plan visualization with configurable grid and labels.
+- Supports vector draw-command capture for downstream document/export workflows.
+
+### Layout system
+
+- Multi-page layout authoring with page naming and orientation control.
+- Place and edit views, legends, event tables, text blocks, and image elements.
+- Layouts can be exported and printed as production documentation sheets.
+
+## Printing and Export Outputs
+
+- Layout-to-PDF output for full documentation sets.
+- Print table workflows for fixtures/trusses/hoists/objects.
+- Debug-only 2D direct print dialog is gated in Release builds via feature flags.
+
+## GUI Workflow and Operations
+
+### Console and command workflows
+
+- Console supports text command workflows for selection and transform operations.
+- Command history and prompt behavior provide fast operator iteration in large scenes.
+
+### Units and preferences
+
+- Distance and weight systems are independently configurable.
+- Internal canonical values remain millimeters (distance) and kilograms (weight).
+- Input parsing accepts explicit unit suffixes regardless of active display system.
+
+### Shortcut and interaction model
+
+- Keyboard/mouse interaction includes viewer navigation, selection, and layout editing actions.
+- Detailed precedence and scope are tracked in [GUI shortcut architecture](gui_shortcut_architecture.md).
+
+## Build-Gated and Experimental Areas
+
+- Some tools remain Debug-only for production safety in Release builds.
+- Optional Peraviz and DMX/Art-Net integrations are available for advanced setups.
+- Large-scene performance and selected advanced workflows continue to be iterated.
+
+## Related Documents
+
+- [Changes since beta 0.1.0](changes_since_beta_0_1_0.md)
+- [Build and dependency guide](build.md)
+- [Packaging and platform integration](packaging.md)
+- [Build troubleshooting](troubleshooting.md)

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,55 @@
+# Perastage Feature Overview
+
+This document summarizes the main end-user capabilities in Perastage. For exact parser behavior and format compliance details, follow the linked policy documents.
+
+## Project and Scene Management
+
+- Open and save Perastage projects (`.pstg`) with multiple named pages/layouts.
+- Organize fixtures, trusses, hoists, and objects into layers with per-layer visibility and selection control.
+- Preserve workspace preferences such as view mode, directories, and window layout.
+
+## MVR and GDTF Workflows
+
+- Import and export MVR scenes for interoperability with other lighting tools.
+- Use a built-in fixture dictionary mapped to GDTF files stored in `library/`.
+- Download fixtures from GDTF-Share through the GUI.
+- Handle GDTF filename collisions during export with deterministic renaming.
+- Follow [GDTF mutation policy](gdtf_mutation_policy.md) for `description.xml` writes, revision behavior, and schema fallback.
+
+## Rider and Text-to-Scene Import
+
+- Parse rider-like text or PDF content using **Tools → Create from text**.
+- Use filter-first workflows before object creation.
+- Support common hang tokens and side mappings in parser input.
+- Maintain parser contract in [Text-to-scene rules](text_to_scene_rules.md).
+
+## Patch and Data Table Tools
+
+- Manage DMX universes, addresses, and patch assignments.
+- Use auto patch to assign channels by grouped fixture logic.
+- Edit fixtures, trusses, hoists, and objects in dedicated tables with batch operations.
+
+## Visualization and Layout
+
+- Use a real-time OpenGL 3D viewer for scene navigation and inspection.
+- Use the 2D viewer for plan-oriented documentation and vector capture workflows.
+- Build multi-page layouts with views, legends, event tables, text blocks, and images.
+
+## Print and Export Outputs
+
+- Print layouts and tables to PDF/CSV-oriented outputs.
+- Export fixture/truss/object assets through tool workflows.
+- Generate documentation sheets from layout pages.
+
+## GUI and Workflow Notes
+
+- Some tools are build-gated to keep Release builds focused on production workflows.
+- Unit systems for distance and weight are configurable in Preferences.
+- Shortcut scope and precedence are documented in [GUI shortcut architecture](gui_shortcut_architecture.md).
+
+## Known Limitations
+
+- Some advanced menu tools remain incomplete or workflow-specific.
+- Very large scenes may stress rendering and redraw paths.
+- Interchange support is centered on MVR; additional formats are limited.
+- Undo/redo coverage is broad but not universal across all operations.

--- a/docs/installation_windows.md
+++ b/docs/installation_windows.md
@@ -1,0 +1,29 @@
+# Windows Installation Notes
+
+This guide covers practical setup for building and running Perastage on Windows. It is intentionally concise and focused on common successful paths.
+
+## Recommended Toolchain
+
+- Visual Studio 2022 with C++ desktop workload.
+- CMake (bundled with Visual Studio or standalone).
+- Dependency source such as vcpkg or MSYS2, depending on team preference.
+
+## Configure and Build
+
+From a Developer PowerShell:
+
+```powershell
+cmake -S . -B out/build/x64-Release -G "Visual Studio 17 2022" -A x64
+cmake --build out/build/x64-Release --config Release
+```
+
+## Run
+
+- Launch `Perastage.exe` from the generated build output.
+- Use `perastage_stage` when preparing a packaging-ready runtime folder.
+
+## If Configuration Fails
+
+- Verify compiler tools from `x64 Native Tools Command Prompt` or Developer PowerShell.
+- Remove stale build directories and reconfigure.
+- Follow the detailed fix paths in [Troubleshooting](troubleshooting.md).

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,0 +1,37 @@
+# Packaging and Platform Integration
+
+This document describes the supported distribution and file-association behavior for Perastage.
+
+## Windows Packaging
+
+The official Windows installer workflow uses Inno Setup:
+
+- Script: `packaging/windows/Perastage.iss`
+- Build Release and run `perastage_stage` first.
+- Compile the installer script in Inno Setup.
+- Optional associations can include `.pstg` and `.mvr`.
+
+### Association Notes
+
+- Installer writes association entries under `Software\Classes`.
+- Uninstall behavior is conservative and avoids aggressive global extension ownership cleanup.
+- Legacy CPack/NSIS wiring exists for compatibility but is not the primary path.
+
+## Linux Desktop Integration
+
+Install layouts include desktop and MIME metadata:
+
+- `share/applications/perastage.desktop`
+- `share/mime/packages/perastage-mime.xml`
+- `share/icons/hicolor/1024x1024/apps/perastage.png`
+
+During `cmake --install`, cache refresh commands may run to expose new associations.
+
+## macOS Document Association
+
+Perastage app bundles declare `.mvr` document type metadata through bundle settings so Finder can route files to the application.
+
+## Related Documents
+
+- [Build and dependency guide](build.md)
+- [Troubleshooting](troubleshooting.md)

--- a/docs/repository_layout.md
+++ b/docs/repository_layout.md
@@ -1,0 +1,24 @@
+# Repository Layout
+
+This page provides a quick map of the main Perastage modules. For exhaustive file-level mapping, see `perastage_tree.md`.
+
+## Top-Level Structure
+
+| Path | Purpose |
+|------|---------|
+| `main.cpp` | Application entry point and top-level initialization. |
+| `core/` | Core logic, import helpers, dictionaries, patching, layout and print support logic. |
+| `gui/` | wxWidgets windows, dialogs, menus, and interaction panels. |
+| `models/` | Scene data models for fixtures, trusses, hoists, and objects. |
+| `mvr/` | MVR importer/exporter implementation. |
+| `viewer3d/` | 3D rendering engine and camera/view tooling. |
+| `viewer2d/` | 2D plan view rendering and capture tools. |
+| `library/` | Bundled fixture/truss/object data and example assets. |
+| `resources/` | Icons, images, and runtime resources. |
+| `tests/` | Unit and guard scripts. |
+| `docs/` | Specifications, architecture notes, and operational documentation. |
+
+## Related Documents
+
+- `perastage_tree.md`
+- [Architecture](architecture.md)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,37 +1,60 @@
 # Build Troubleshooting
 
-This page collects common build and tooling issues that were previously embedded in the README. Use it when the baseline build commands do not succeed.
+This page collects common build and IDE/tooling failures for current Perastage development environments.
 
-## Windows: `LNK1163` COMDAT Errors
+## Windows Linker Error: `LNK1163`
 
-This usually indicates stale or incompatible object files from a different toolset or linker configuration.
+`LNK1163: invalid selection for COMDAT section` usually indicates stale or incompatible object files from a different MSVC toolset or incompatible linker settings.
 
 ### Fix Steps
 
-1. Delete the affected build directory (for example `out/build/x64-Debug`).
-2. Reconfigure CMake from a clean shell.
-3. Rebuild with `--clean-first` when needed.
+1. Delete the affected build folder (for example `out/build/x64-Debug`).
+2. Reconfigure with your intended generator and toolset.
+3. Rebuild with a clean pass.
 
 ```powershell
 cmake --build out/build/x64-Debug --config Debug --clean-first
 ```
 
-## Visual Studio and VS Code IntelliSense Mismatch
+## C++20 Symbols Missing in IntelliSense
 
-Symptoms often include inactive parser diagnostics about missing C++20 symbols (`optional`, `variant`, `filesystem`) while real builds still succeed.
+Typical editor-only symptoms:
+
+- `std has no member filesystem / optional / variant / string_view / bit_cast`
+- structured-binding parse failures
+- cascaded parser errors that do not match real compiler output
+
+This usually means the editor is not attached to the active CMake configuration.
 
 ### Fix Steps
 
-1. Remove the active build directory.
-2. Reconfigure with the intended compiler kit/preset.
-3. Build from the same configured tree.
-4. Wait for IntelliSense to reindex.
+1. Remove the current build directory.
+2. Reconfigure from a clean developer shell.
+3. Build from that same directory.
+4. Reopen/reindex IntelliSense.
 
-Compiler output from `cmake --build` is authoritative when editor diagnostics disagree.
+```powershell
+cmake -S . -B out/build/x64-Debug -G "Visual Studio 17 2022" -A x64
+cmake --build out/build/x64-Debug --config Debug
+```
 
-## macOS: Missing Ninja or Compiler Setup
+When editor diagnostics and compiler output disagree, prioritize `cmake --build` output.
 
-Typical messages include missing Ninja or unset `CMAKE_CXX_COMPILER`.
+## VS Code + CMake Tools Misalignment
+
+If VS Code shows persistent semantic errors while builds succeed:
+
+1. Select the intended configure preset in CMake Tools.
+2. Run **CMake: Configure**.
+3. If needed, delete the selected preset build directory and configure again.
+4. Verify C++ extension and CMake Tools extensions are installed and enabled.
+
+## macOS Toolchain Incomplete (Apple Silicon Common Case)
+
+Common configure failures:
+
+- missing Ninja build program,
+- `CMAKE_CXX_COMPILER not set, after EnableLanguage`.
 
 ### Fix Steps
 
@@ -44,10 +67,20 @@ ninja --version
 cmake --version
 ```
 
-If kits or generators changed, remove the previous build directory and reconfigure.
+If you changed kit/generator, delete the previous build directory and configure again.
 
-## Additional Diagnostics
+## Package-Manager and Triplet Mismatch
 
-- Confirm CMake preset and generator match your installed toolchain.
-- Keep architecture and triplet settings consistent when using package managers.
-- Capture full configure/build logs when reporting issues.
+When using vcpkg or equivalent package managers:
+
+- keep architecture/triplet consistent with your configure command,
+- avoid mixing cached outputs from different triplets/toolchains.
+
+## Reporting Issues Effectively
+
+Include the following when filing a bug report:
+
+- exact configure and build commands,
+- full error output (not only summary lines),
+- platform, compiler version, and generator information,
+- whether the failure is compiler/linker output or editor-only diagnostics.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,53 @@
+# Build Troubleshooting
+
+This page collects common build and tooling issues that were previously embedded in the README. Use it when the baseline build commands do not succeed.
+
+## Windows: `LNK1163` COMDAT Errors
+
+This usually indicates stale or incompatible object files from a different toolset or linker configuration.
+
+### Fix Steps
+
+1. Delete the affected build directory (for example `out/build/x64-Debug`).
+2. Reconfigure CMake from a clean shell.
+3. Rebuild with `--clean-first` when needed.
+
+```powershell
+cmake --build out/build/x64-Debug --config Debug --clean-first
+```
+
+## Visual Studio and VS Code IntelliSense Mismatch
+
+Symptoms often include inactive parser diagnostics about missing C++20 symbols (`optional`, `variant`, `filesystem`) while real builds still succeed.
+
+### Fix Steps
+
+1. Remove the active build directory.
+2. Reconfigure with the intended compiler kit/preset.
+3. Build from the same configured tree.
+4. Wait for IntelliSense to reindex.
+
+Compiler output from `cmake --build` is authoritative when editor diagnostics disagree.
+
+## macOS: Missing Ninja or Compiler Setup
+
+Typical messages include missing Ninja or unset `CMAKE_CXX_COMPILER`.
+
+### Fix Steps
+
+```bash
+xcode-select --install
+brew install cmake ninja
+xcode-select -p
+clang++ --version
+ninja --version
+cmake --version
+```
+
+If kits or generators changed, remove the previous build directory and reconfigure.
+
+## Additional Diagnostics
+
+- Confirm CMake preset and generator match your installed toolchain.
+- Keep architecture and triplet settings consistent when using package managers.
+- Capture full configure/build logs when reporting issues.


### PR DESCRIPTION
### Motivation

- Make the project landing page concise and focused so new users can quickly understand Perastage and find deeper guides. 
- Move long, platform-specific, and troubleshooting content out of `README.md` into dedicated `docs/` files for easier maintenance and navigation. 
- Establish a documentation policy so contributors keep the README short and add full details to targeted `docs/*` documents.

### Description

- Rewrote `README.md` as a brief elevator pitch with limited badges, hero image, a short `Highlights` list, minimal `Installation` and `Basic Usage` steps, and a documentation hub linking into `docs/`. 
- Added `docs/documentation_policy.md` to define README scope, formatting, cross-linking and asset rules. 
- Split detailed content into focused documents: `docs/features.md`, `docs/build.md`, `docs/installation_windows.md`, `docs/packaging.md`, `docs/troubleshooting.md`, and `docs/repository_layout.md`. 
- Updated the README to link to existing authoritative spec files (for example `docs/text_to_scene_rules.md` and `docs/gdtf_mutation_policy.md`) rather than re-embedding those details.

### Testing

- Ran `tests/check_perastage_tree_modules.sh` and it returned `OK`. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it returned `OK`. 
- No other automated test changes were required for these documentation-only modifications.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3b023f7988324b380601220c157a3)