### PR TITLE
Fix MVR primitive cylinder export orientation and parameterized primitives

### DIFF
--- a/gui/scene_object_primitive_creation.cpp
+++ b/gui/scene_object_primitive_creation.cpp
@@ -4,6 +4,7 @@
 #include "layer.h"
 #include "mvrscene.h"
 #include "sceneobject.h"
+#include "uuidutils.h"
 
 #include <chrono>
 #include <string>
@@ -38,7 +39,7 @@ void AddPrimitiveObjects(MvrScene &scene, const std::string &layerName,
                          long long baseId) {
   for (int i = 0; i < quantity; ++i) {
     SceneObject obj;
-    obj.uuid = wxString::Format("uuid_%lld", baseId + i).ToStdString();
+    obj.uuid = GenerateUuid();
     if (quantity > 1)
       obj.name = baseName + " " + std::to_string(i + 1);
     else

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -44,6 +44,7 @@ class wxZipStreamLink;
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
+#include <functional>
 #include <iomanip>
 #include <regex>
 #include <set>
@@ -1388,15 +1389,30 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
     std::string primitiveToken;
     if (!mvr::ResolvePrimitiveTokenFromModelRef(modelRef, primitiveToken))
       return {};
-    const std::string primitiveKey = TrimAscii(modelRef).empty() ? primitiveToken : TrimAscii(modelRef);
+    const std::string normalizedModelRef = ToLowerAscii(TrimAscii(modelRef));
+    const std::string primitiveKey =
+        normalizedModelRef.empty() ? primitiveToken : normalizedModelRef;
 
     auto sourceIt = primitiveSourceByToken.find(primitiveKey);
     std::string sourcePath;
     if (sourceIt != primitiveSourceByToken.end()) {
       sourcePath = sourceIt->second;
     } else {
-      fs::path outputPath = fs::u8path(primitiveTempDir) /
-                            fs::u8path(mvr::PrimitiveArchivePathForToken(primitiveToken)).filename();
+      std::string primitiveLabel = primitiveToken;
+      const size_t colonPos = primitiveLabel.find(':');
+      if (colonPos != std::string::npos && colonPos + 1 < primitiveLabel.size())
+        primitiveLabel = primitiveLabel.substr(colonPos + 1);
+      for (char &ch : primitiveLabel) {
+        if (!std::isalnum(static_cast<unsigned char>(ch)))
+          ch = '_';
+      }
+      if (primitiveLabel.empty())
+        primitiveLabel = "shape";
+      const std::size_t primitiveHash = std::hash<std::string>{}(primitiveKey);
+      const std::string tempFileName = wxString::Format(
+          "primitive_%s_%zx.glb", primitiveLabel.c_str(), primitiveHash)
+                                           .ToStdString();
+      fs::path outputPath = fs::u8path(primitiveTempDir) / fs::u8path(tempFileName);
       if (!mvr::WritePrimitiveModelForToken(primitiveKey, outputPath.generic_string()))
         return {};
       sourcePath = outputPath.generic_string();

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -1388,18 +1388,19 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
     std::string primitiveToken;
     if (!mvr::ResolvePrimitiveTokenFromModelRef(modelRef, primitiveToken))
       return {};
+    const std::string primitiveKey = TrimAscii(modelRef).empty() ? primitiveToken : TrimAscii(modelRef);
 
-    auto sourceIt = primitiveSourceByToken.find(primitiveToken);
+    auto sourceIt = primitiveSourceByToken.find(primitiveKey);
     std::string sourcePath;
     if (sourceIt != primitiveSourceByToken.end()) {
       sourcePath = sourceIt->second;
     } else {
       fs::path outputPath = fs::u8path(primitiveTempDir) /
                             fs::u8path(mvr::PrimitiveArchivePathForToken(primitiveToken)).filename();
-      if (!mvr::WritePrimitiveModelForToken(primitiveToken, outputPath.generic_string()))
+      if (!mvr::WritePrimitiveModelForToken(primitiveKey, outputPath.generic_string()))
         return {};
       sourcePath = outputPath.generic_string();
-      primitiveSourceByToken[primitiveToken] = sourcePath;
+      primitiveSourceByToken[primitiveKey] = sourcePath;
     }
 
     const std::string preferredArchivePath =

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -2025,6 +2025,29 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
 
   auto exportSceneObject = [&](tinyxml2::XMLElement *parent,
                                const SceneObject &obj) {
+    auto matrixAlmostEqual = [](const Matrix &a, const Matrix &b, float eps = 1e-5f) {
+      for (int i = 0; i < 3; ++i) {
+        if (std::fabs(a.u[i] - b.u[i]) > eps || std::fabs(a.v[i] - b.v[i]) > eps ||
+            std::fabs(a.w[i] - b.w[i]) > eps || std::fabs(a.o[i] - b.o[i]) > eps) {
+          return false;
+        }
+      }
+      return true;
+    };
+
+    Matrix objectMatrixToWrite = obj.transform;
+    bool bakeGeometryMatrixIntoObject = false;
+    if (obj.geometries.size() == 1) {
+      const auto &singleGeometry = obj.geometries.front();
+      std::string primitiveToken;
+      if (mvr::ResolvePrimitiveTokenFromModelRef(singleGeometry.modelFile, primitiveToken) &&
+          !matrixAlmostEqual(singleGeometry.localTransform, MatrixUtils::Identity())) {
+        objectMatrixToWrite =
+            MatrixUtils::Multiply(obj.transform, singleGeometry.localTransform);
+        bakeGeometryMatrixIntoObject = true;
+      }
+    }
+
     tinyxml2::XMLElement *oe = doc.NewElement("SceneObject");
     oe->SetAttribute("uuid", obj.uuid.c_str());
     if (!obj.name.empty())
@@ -2057,7 +2080,9 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
           continue;
         g3d->SetAttribute("fileName", modelArchivePath.c_str());
 
-        std::string geoMatrixText = MatrixUtils::FormatMatrix(geo.localTransform);
+        const Matrix geoMatrixToWrite =
+            bakeGeometryMatrixIntoObject ? MatrixUtils::Identity() : geo.localTransform;
+        std::string geoMatrixText = MatrixUtils::FormatMatrix(geoMatrixToWrite);
         tinyxml2::XMLElement *geoMatrix = doc.NewElement("Matrix");
         geoMatrix->SetText(geoMatrixText.c_str());
         g3d->InsertEndChild(geoMatrix);
@@ -2082,7 +2107,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
       }
     }
 
-    std::string mstr = MatrixUtils::FormatMatrix(obj.transform);
+    std::string mstr = MatrixUtils::FormatMatrix(objectMatrixToWrite);
     tinyxml2::XMLElement *mat = doc.NewElement("Matrix");
     mat->SetText(mstr.c_str());
     oe->InsertEndChild(mat);

--- a/mvr/primitive_model_resources.cpp
+++ b/mvr/primitive_model_resources.cpp
@@ -126,25 +126,30 @@ PrimitiveMeshData BuildSphereMesh() {
   return mesh;
 }
 
-PrimitiveMeshData BuildCylinderMesh() {
+PrimitiveMeshData BuildCylinderMesh(float topRadius, float bottomRadius,
+                                    float height) {
   PrimitiveMeshData mesh;
   constexpr int kSegments = 16;
   constexpr float kPi = 3.14159265358979323846f;
   mesh.positions.reserve(static_cast<size_t>(kSegments * 2 + 2) * 3);
   mesh.indices.reserve(static_cast<size_t>(kSegments) * 12);
 
+  const float halfHeight = 0.5f * height;
+
   for (int i = 0; i < kSegments; ++i) {
     const float a = static_cast<float>(i) * 2.0f * kPi /
                     static_cast<float>(kSegments);
-    const float x = 0.5f * std::cos(a);
-    const float z = 0.5f * std::sin(a);
-    mesh.positions.insert(mesh.positions.end(), {x, 0.5f, z});
-    mesh.positions.insert(mesh.positions.end(), {x, -0.5f, z});
+    const float xTop = topRadius * std::cos(a);
+    const float yTop = topRadius * std::sin(a);
+    const float xBottom = bottomRadius * std::cos(a);
+    const float yBottom = bottomRadius * std::sin(a);
+    mesh.positions.insert(mesh.positions.end(), {xTop, yTop, halfHeight});
+    mesh.positions.insert(mesh.positions.end(), {xBottom, yBottom, -halfHeight});
   }
   const uint16_t topCenter = static_cast<uint16_t>(mesh.positions.size() / 3);
-  mesh.positions.insert(mesh.positions.end(), {0.0f, 0.5f, 0.0f});
+  mesh.positions.insert(mesh.positions.end(), {0.0f, 0.0f, halfHeight});
   const uint16_t bottomCenter = static_cast<uint16_t>(mesh.positions.size() / 3);
-  mesh.positions.insert(mesh.positions.end(), {0.0f, -0.5f, 0.0f});
+  mesh.positions.insert(mesh.positions.end(), {0.0f, 0.0f, -halfHeight});
 
   for (int i = 0; i < kSegments; ++i) {
     const uint16_t top0 = static_cast<uint16_t>(i * 2);
@@ -158,6 +163,53 @@ PrimitiveMeshData BuildCylinderMesh() {
   }
 
   return mesh;
+}
+
+PrimitiveMeshData BuildCylinderMesh() {
+  return BuildCylinderMesh(0.5f, 0.5f, 1.0f);
+}
+
+float ParsePositiveNumber(const std::string &text, float fallback) {
+  if (text.empty())
+    return fallback;
+  try {
+    const float value = std::stof(text);
+    return std::isfinite(value) && value > 0.0f ? value : fallback;
+  } catch (...) {
+    return fallback;
+  }
+}
+
+void ParseCylinderTokenDimensions(const std::string &token, float &topRadius,
+                                  float &bottomRadius, float &height) {
+  topRadius = 0.5f;
+  bottomRadius = 0.5f;
+  height = 1.0f;
+
+  const std::string normalized = NormalizeLower(token);
+  if (normalized.rfind(kCylinderToken, 0) != 0)
+    return;
+
+  const size_t separator = normalized.find(';');
+  if (separator == std::string::npos || separator + 1 >= normalized.size())
+    return;
+
+  std::stringstream ss(normalized.substr(separator + 1));
+  std::string field;
+  while (std::getline(ss, field, ';')) {
+    const size_t equalPos = field.find('=');
+    if (equalPos == std::string::npos)
+      continue;
+    const std::string key = field.substr(0, equalPos);
+    const std::string value = field.substr(equalPos + 1);
+    if (key == "top") {
+      topRadius = ParsePositiveNumber(value, topRadius);
+    } else if (key == "bottom") {
+      bottomRadius = ParsePositiveNumber(value, bottomRadius);
+    } else if (key == "height") {
+      height = ParsePositiveNumber(value, height);
+    }
+  }
 }
 
 void AppendU32(std::vector<uint8_t> &buffer, uint32_t value) {
@@ -312,8 +364,13 @@ bool WritePrimitiveModelForToken(const std::string &primitiveToken,
     return WriteGlb(BuildCubeMesh(), outputPath);
   if (normalized.rfind(kSphereToken, 0) == 0)
     return WriteGlb(BuildSphereMesh(), outputPath);
-  if (normalized.rfind(kCylinderToken, 0) == 0)
-    return WriteGlb(BuildCylinderMesh(), outputPath);
+  if (normalized.rfind(kCylinderToken, 0) == 0) {
+    float topRadius = 0.5f;
+    float bottomRadius = 0.5f;
+    float height = 1.0f;
+    ParseCylinderTokenDimensions(primitiveToken, topRadius, bottomRadius, height);
+    return WriteGlb(BuildCylinderMesh(topRadius, bottomRadius, height), outputPath);
+  }
   return false;
 }
 

--- a/mvr/primitive_model_resources.cpp
+++ b/mvr/primitive_model_resources.cpp
@@ -360,15 +360,16 @@ std::string PrimitiveArchivePathForToken(const std::string &primitiveToken,
 bool WritePrimitiveModelForToken(const std::string &primitiveToken,
                                  const std::string &outputPath) {
   const std::string normalized = NormalizeLower(primitiveToken);
-  if (normalized.rfind(kCubeToken, 0) == 0)
+  if (IsCubeRef(normalized))
     return WriteGlb(BuildCubeMesh(), outputPath);
-  if (normalized.rfind(kSphereToken, 0) == 0)
+  if (IsSphereRef(normalized))
     return WriteGlb(BuildSphereMesh(), outputPath);
-  if (normalized.rfind(kCylinderToken, 0) == 0) {
+  if (IsCylinderRef(normalized)) {
     float topRadius = 0.5f;
     float bottomRadius = 0.5f;
     float height = 1.0f;
-    ParseCylinderTokenDimensions(primitiveToken, topRadius, bottomRadius, height);
+    if (normalized.rfind(kCylinderToken, 0) == 0)
+      ParseCylinderTokenDimensions(primitiveToken, topRadius, bottomRadius, height);
     return WriteGlb(BuildCylinderMesh(topRadius, bottomRadius, height), outputPath);
   }
   return false;


### PR DESCRIPTION
### Motivation
- Exported primitive cylinders were generated with their axis misaligned relative to Perastage conventions, causing pipes to appear vertical in other MVR consumers when rotation was supplied via matrices.
- Primitives created from Edit encoded dimensions in the token (e.g. `primitive:cylinder;top=...;bottom=...;height=...`) but exported models ignored those parameters, losing fidelity in MVR packages.
- The primitive model cache keyed only by token type caused different parameterized variants to collapse into a single shared resource, breaking per-object dimensions.

### Description
- Changed cylinder mesh generation to produce a cylinder aligned on the Z axis and added an overloaded `BuildCylinderMesh(float topRadius, float bottomRadius, float height)` to honor arbitrary dimensions. (modified `mvr/primitive_model_resources.cpp`)
- Added `ParseCylinderTokenDimensions` and helpers to extract `top`, `bottom` and `height` from `primitive:cylinder;...` tokens and used the parsed values when writing GLB models for primitives. (modified `mvr/primitive_model_resources.cpp`)
- Adjusted MVR exporter primitive registration to key the primitive model cache by the full model reference (trimmed `modelRef`) instead of only the generic primitive type so parameterized variants are generated and cached separately. (modified `mvr/mvrexporter.cpp`)

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded.
- Attempted a local build check but no `build` directory exists in this environment so a full compile was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3b16e3cc08324a74c5c2cc27d6570)