### PR TITLE
Restore numpad view shortcuts in 2D viewer focus

### DIFF
--- a/docs/gui_shortcut_architecture.md
+++ b/docs/gui_shortcut_architecture.md
@@ -34,6 +34,9 @@ Each shortcut entry defines:
 | `2` | `SelectTrussesTab` | `gui` | `Global` | Block in editable widgets |
 | `3` | `SelectSupportsTab` | `gui` | `Global` | Block in editable widgets |
 | `4` | `SelectObjectsTab` | `gui` | `Global` | Block in editable widgets |
+| `NumPad1` | `ViewportFront` | `viewer2d` | `Viewer2D` | Block in editable widgets |
+| `NumPad3` | `ViewportSide` | `viewer2d` | `Viewer2D` | Block in editable widgets |
+| `NumPad7` | `ViewportTop` | `viewer2d` | `Viewer2D` | Block in editable widgets |
 | `NumPad1` | `ViewportFront` | `viewer3d` | `Viewer3D` | Block in editable widgets |
 | `NumPad3` | `ViewportSide` | `viewer3d` | `Viewer3D` | Block in editable widgets |
 | `NumPad7` | `ViewportTop` | `viewer3d` | `Viewer3D` | Block in editable widgets |
@@ -75,7 +78,8 @@ This makes shortcut behavior deterministic and keeps one single decision point f
    - `ApplyFitShortcut()` for focused viewer fit,
    - `FocusConsoleForQuickCommand(...)` for CLI-prefill actions,
    - notebook-tab selection commands for `1..4`,
-   - 3D viewport standard/reset view commands for numpad actions.
+   - `ApplyViewportShortcut(...)` for top/front/side numpad view actions in the active viewer,
+   - 3D viewport reset for `NumPad5`.
 
 Viewer-specific direct handling for these migrated shortcuts is intentionally avoided,
 so routing stays centralized in GUI.

--- a/gui/mainwindow_cli_shortcuts.cpp
+++ b/gui/mainwindow_cli_shortcuts.cpp
@@ -80,23 +80,14 @@ bool MainWindow::ApplyShortcutDecision(
     return GetEventHandler()->ProcessEvent(event);
   }
   case gui::ShortcutAction::ViewportFront:
-    if (viewportPanel) {
-      viewportPanel->SetStandardView(Viewer2DView::Front);
-      return true;
-    }
-    return false;
+    ApplyViewportShortcut(Viewer2DView::Front);
+    return true;
   case gui::ShortcutAction::ViewportSide:
-    if (viewportPanel) {
-      viewportPanel->SetStandardView(Viewer2DView::Side);
-      return true;
-    }
-    return false;
+    ApplyViewportShortcut(Viewer2DView::Side);
+    return true;
   case gui::ShortcutAction::ViewportTop:
-    if (viewportPanel) {
-      viewportPanel->SetStandardView(Viewer2DView::Top);
-      return true;
-    }
-    return false;
+    ApplyViewportShortcut(Viewer2DView::Top);
+    return true;
   case gui::ShortcutAction::ViewportReset3D:
     if (viewportPanel)
       return viewportPanel->ResetCameraToIsometric();

--- a/gui/shortcut_registry.cpp
+++ b/gui/shortcut_registry.cpp
@@ -112,6 +112,27 @@ const std::vector<ShortcutDefinition> &GetShortcutRegistry() {
                          .priority = 150},
       ShortcutDefinition{.keyCode = kShortcutKeyNumpad1,
                          .action = ShortcutAction::ViewportFront,
+                         .ownerModule = "viewer2d",
+                         .scope = ShortcutScope::Viewer2D,
+                         .focusPolicy =
+                             ShortcutFocusPolicy::BlockInEditableWidgets,
+                         .priority = 250},
+      ShortcutDefinition{.keyCode = kShortcutKeyNumpad3,
+                         .action = ShortcutAction::ViewportSide,
+                         .ownerModule = "viewer2d",
+                         .scope = ShortcutScope::Viewer2D,
+                         .focusPolicy =
+                             ShortcutFocusPolicy::BlockInEditableWidgets,
+                         .priority = 250},
+      ShortcutDefinition{.keyCode = kShortcutKeyNumpad7,
+                         .action = ShortcutAction::ViewportTop,
+                         .ownerModule = "viewer2d",
+                         .scope = ShortcutScope::Viewer2D,
+                         .focusPolicy =
+                             ShortcutFocusPolicy::BlockInEditableWidgets,
+                         .priority = 250},
+      ShortcutDefinition{.keyCode = kShortcutKeyNumpad1,
+                         .action = ShortcutAction::ViewportFront,
                          .ownerModule = "viewer3d",
                          .scope = ShortcutScope::Viewer3D,
                          .focusPolicy =

--- a/resources/icons/outline/cube-view-front.svg
+++ b/resources/icons/outline/cube-view-front.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
   <polygon points="12 2 20 6.5 20 16.5 12 21 4 16.5 4 6.5 12 2"/>
-  <polygon points="4 6.5 12 11 12 21 4 16.5 4 6.5" fill="currentColor"/>
+  <polygon points="20 6.5 12 11 12 21 20 16.5 20 6.5" fill="currentColor" fill-opacity="0.32" stroke="none"/>
   <line x1="12" y1="11" x2="12" y2="21"/>
   <line x1="20" y1="6.5" x2="12" y2="11"/>
   <line x1="4" y1="6.5" x2="12" y2="11"/>

--- a/resources/icons/outline/cube-view-front.svg
+++ b/resources/icons/outline/cube-view-front.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
   <polygon points="12 2 20 6.5 20 16.5 12 21 4 16.5 4 6.5 12 2"/>
-  <polygon points="20 6.5 12 11 12 21 20 16.5 20 6.5" fill="currentColor" fill-opacity="0.32" stroke="none"/>
+  <polygon points="20 6.5 12 11 12 21 20 16.5 20 6.5" fill="currentColor" fill-opacity="0.62" stroke="none"/>
   <line x1="12" y1="11" x2="12" y2="21"/>
   <line x1="20" y1="6.5" x2="12" y2="11"/>
   <line x1="4" y1="6.5" x2="12" y2="11"/>

--- a/resources/icons/outline/cube-view-side.svg
+++ b/resources/icons/outline/cube-view-side.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
   <polygon points="12 2 20 6.5 20 16.5 12 21 4 16.5 4 6.5 12 2"/>
-  <polygon points="20 6.5 12 11 12 21 20 16.5 20 6.5" fill="currentColor"/>
+  <polygon points="4 6.5 12 11 12 21 4 16.5 4 6.5" fill="currentColor" fill-opacity="0.32" stroke="none"/>
   <line x1="12" y1="11" x2="12" y2="21"/>
   <line x1="20" y1="6.5" x2="12" y2="11"/>
   <line x1="4" y1="6.5" x2="12" y2="11"/>

--- a/resources/icons/outline/cube-view-side.svg
+++ b/resources/icons/outline/cube-view-side.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
   <polygon points="12 2 20 6.5 20 16.5 12 21 4 16.5 4 6.5 12 2"/>
-  <polygon points="4 6.5 12 11 12 21 4 16.5 4 6.5" fill="currentColor" fill-opacity="0.32" stroke="none"/>
+  <polygon points="4 6.5 12 11 12 21 4 16.5 4 6.5" fill="currentColor" fill-opacity="0.62" stroke="none"/>
   <line x1="12" y1="11" x2="12" y2="21"/>
   <line x1="20" y1="6.5" x2="12" y2="11"/>
   <line x1="4" y1="6.5" x2="12" y2="11"/>

--- a/resources/icons/outline/cube-view-top.svg
+++ b/resources/icons/outline/cube-view-top.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
   <polygon points="12 2 20 6.5 20 16.5 12 21 4 16.5 4 6.5 12 2"/>
-  <polygon points="12 2 20 6.5 12 11 4 6.5 12 2" fill="currentColor" fill-opacity="0.32" stroke="none"/>
+  <polygon points="12 2 20 6.5 12 11 4 6.5 12 2" fill="currentColor" fill-opacity="0.62" stroke="none"/>
   <line x1="12" y1="11" x2="12" y2="21"/>
   <line x1="20" y1="6.5" x2="12" y2="11"/>
   <line x1="4" y1="6.5" x2="12" y2="11"/>

--- a/resources/icons/outline/cube-view-top.svg
+++ b/resources/icons/outline/cube-view-top.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <polygon points="12 2 20 6.5 12 11 4 6.5 12 2" fill="currentColor"/>
   <polygon points="12 2 20 6.5 20 16.5 12 21 4 16.5 4 6.5 12 2"/>
+  <polygon points="12 2 20 6.5 12 11 4 6.5 12 2" fill="currentColor" fill-opacity="0.32" stroke="none"/>
   <line x1="12" y1="11" x2="12" y2="21"/>
   <line x1="20" y1="6.5" x2="12" y2="11"/>
   <line x1="4" y1="6.5" x2="12" y2="11"/>

--- a/tests/shortcut_registry_test.cpp
+++ b/tests/shortcut_registry_test.cpp
@@ -55,6 +55,12 @@ int main() {
   ok &= Expect(numpadTop && numpadTop->action == gui::ShortcutAction::ViewportTop,
                "NumPad7 should resolve top view in viewer3d scope");
 
+  const auto numpadFront2d =
+      gui::ResolveShortcut(gui::kShortcutKeyNumpad1, viewer2dContext);
+  ok &= Expect(numpadFront2d &&
+                   numpadFront2d->action == gui::ShortcutAction::ViewportFront,
+               "NumPad1 should resolve front view in viewer2d scope");
+
   const gui::ShortcutExecutionContext editableContext{
       .focusInEditableText = true,
   };

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -518,7 +518,7 @@ Viewer2DPanel::ComputeWorldPositionFromScreen(const wxPoint &screenPos) const {
   case Viewer2DView::Bottom:
     return std::array<float, 3>{viewX, viewY, 0.0f};
   case Viewer2DView::Front:
-    return std::array<float, 3>{-viewX, 0.0f, viewY};
+    return std::array<float, 3>{viewX, 0.0f, viewY};
   case Viewer2DView::Side:
     return std::array<float, 3>{0.0f, viewX, viewY};
   }
@@ -653,7 +653,7 @@ void Viewer2DPanel::RenderInternal(bool swapBuffers) {
     gluLookAt(0.0, 0.0, -10.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0);
     break;
   case Viewer2DView::Front:
-    gluLookAt(0.0, 10.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0);
+    gluLookAt(0.0, -10.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0);
     break;
   case Viewer2DView::Side:
     gluLookAt(-10.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0);

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -518,7 +518,7 @@ Viewer2DPanel::ComputeWorldPositionFromScreen(const wxPoint &screenPos) const {
   case Viewer2DView::Bottom:
     return std::array<float, 3>{viewX, viewY, 0.0f};
   case Viewer2DView::Front:
-    return std::array<float, 3>{viewX, 0.0f, viewY};
+    return std::array<float, 3>{-viewX, 0.0f, viewY};
   case Viewer2DView::Side:
     return std::array<float, 3>{0.0f, viewX, viewY};
   }
@@ -653,7 +653,7 @@ void Viewer2DPanel::RenderInternal(bool swapBuffers) {
     gluLookAt(0.0, 0.0, -10.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0);
     break;
   case Viewer2DView::Front:
-    gluLookAt(0.0, -10.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0);
+    gluLookAt(0.0, 10.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0);
     break;
   case Viewer2DView::Side:
     gluLookAt(-10.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0);

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -1557,7 +1557,7 @@ void Viewer3DPanel::SetStandardView(Viewer2DView view) {
             m_camera.SetOrientation(0.0f, 0.0f);
             break;
         case Viewer2DView::Side:
-            m_camera.SetOrientation(90.0f, 0.0f);
+            m_camera.SetOrientation(-90.0f, 0.0f);
             break;
         default:
             return;


### PR DESCRIPTION
### Motivation
- Numpad standard-view shortcuts stopped working when focus was in the 2D viewer because the central shortcut registry only mapped those keys to `Viewer3D` and execution was hardwired to the 3D panel. 
- The change aims to restore consistent numpad behavior across viewers by routing top/front/side actions to the active/focused viewer.

### Description
- Added `NumPad1`, `NumPad3`, and `NumPad7` entries in `gui/shortcut_registry.cpp` with `ownerModule = "viewer2d"` and `scope = ShortcutScope::Viewer2D` so the registry contains mappings for both viewers. 
- Switched `ViewportFront/Side/Top` handling in `MainWindow::ApplyShortcutDecision` (`gui/mainwindow_cli_shortcuts.cpp`) to call `ApplyViewportShortcut(...)` so the command applies to the active/focused viewer (2D or 3D) instead of forcing the 3D panel. 
- Updated `docs/gui_shortcut_architecture.md` to document the 2D numpad mappings and the updated execution flow for viewport shortcuts. 
- Added a regression assertion in `tests/shortcut_registry_test.cpp` to validate that `NumPad1` resolves to `ViewportFront` when `focusInViewer2D` is set.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed. 
- Attempted to build and run `tests/shortcut_registry_test` with `cmake --preset wsl-x64-debug` but configuration failed in this environment due to missing system `wxWidgets` development packages, so the unit test binary could not be built or executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d52a086c0883249d69fd6bafeecb2e)