### PR TITLE
Flip side-view cube toolbar icon filled face

### DIFF
--- a/resources/icons/outline/cube-view-side.svg
+++ b/resources/icons/outline/cube-view-side.svg
@@ -1,7 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
   <polygon points="12 2 20 6.5 20 16.5 12 21 4 16.5 4 6.5 12 2"/>
-  <polygon points="20 6.5 12 11 12 21 20 16.5 20 6.5" fill="currentColor" fill-opacity="0.8" stroke="none"/>
+  <polygon points="12 2 4 6.5 4 16.5 12 11" fill="currentColor" fill-opacity="0.8" stroke="none"/>
+  <line x1="12" y1="2" x2="12" y2="11"/>
   <line x1="12" y1="11" x2="12" y2="21"/>
-  <line x1="20" y1="6.5" x2="12" y2="11"/>
-  <line x1="4" y1="6.5" x2="12" y2="11"/>
+  <line x1="12" y1="11" x2="20" y2="6.5"/>
+  <line x1="12" y1="11" x2="20" y2="16.5"/>
+  <line x1="12" y1="11" x2="4" y2="16.5"/>
+  <line x1="12" y1="11" x2="4" y2="6.5"/>
 </svg>

--- a/resources/icons/outline/cube-view-side.svg
+++ b/resources/icons/outline/cube-view-side.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
   <polygon points="12 2 20 6.5 20 16.5 12 21 4 16.5 4 6.5 12 2"/>
-  <polygon points="4 6.5 12 11 12 21 4 16.5 4 6.5" fill="currentColor" fill-opacity="0.8" stroke="none"/>
+  <polygon points="20 6.5 12 11 12 21 20 16.5 20 6.5" fill="currentColor" fill-opacity="0.8" stroke="none"/>
   <line x1="12" y1="11" x2="12" y2="21"/>
   <line x1="20" y1="6.5" x2="12" y2="11"/>
   <line x1="4" y1="6.5" x2="12" y2="11"/>


### PR DESCRIPTION
### Motivation
- Move the shaded face of the side-view cube toolbar icon to the opposite face while keeping the cube orientation and position unchanged to match the requested visual tweak.

### Description
- Modified `resources/icons/outline/cube-view-side.svg` by changing which `<polygon>` uses `fill="currentColor"` so the filled face is on the opposite cube face.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d53b3ed5cc83249ff99d0af36bb296)