### PR TITLE
Add GDTF dictionary color field parsing, saving, and coverage

### DIFF
--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -203,14 +203,18 @@ LoadFromFile(const fs::path &file, std::string &error) {
       entry.mode = value["mode"].get<std::string>();
     if (value.contains("category") && value["category"].is_string())
       entry.category = value["category"].get<std::string>();
+    if (value.contains("color") && value["color"].is_string())
+      entry.color = value["color"].get<std::string>();
     if (value.contains("source") && value["source"].is_string())
       entry.source = value["source"].get<std::string>();
     if (value.contains("imported_at") && value["imported_at"].is_string())
       entry.importedAt = value["imported_at"].get<std::string>();
     if (value.contains("sha256") && value["sha256"].is_string())
       entry.sha256 = value["sha256"].get<std::string>();
-    if (entry.path.empty() && entry.mode.empty() && entry.category.empty()) {
-      entryError = "entry object must include at least one of file/path/mode/category";
+    if (entry.path.empty() && entry.mode.empty() && entry.category.empty() &&
+        entry.color.empty()) {
+      entryError =
+          "entry object must include at least one of file/path/mode/category/color";
       return false;
     }
     return true;
@@ -360,7 +364,8 @@ bool Save(const std::unordered_map<std::string, Entry> &dict,
   std::sort(keys.begin(), keys.end());
   for (const auto &type : keys) {
     const auto &entry = dict.at(type);
-    if (entry.path.empty() && entry.mode.empty() && entry.category.empty())
+    if (entry.path.empty() && entry.mode.empty() && entry.category.empty() &&
+        entry.color.empty())
       continue;
     nlohmann::json obj;
     if (!entry.path.empty()) {
@@ -373,6 +378,8 @@ bool Save(const std::unordered_map<std::string, Entry> &dict,
       obj["mode"] = entry.mode;
     if (!entry.category.empty())
       obj["category"] = entry.category;
+    if (!entry.color.empty())
+      obj["color"] = entry.color;
     if (!entry.source.empty())
       obj["source"] = entry.source;
     if (!entry.importedAt.empty())

--- a/core/gdtfdictionary.h
+++ b/core/gdtfdictionary.h
@@ -33,6 +33,7 @@ namespace GdtfDictionary {
         std::string path; // optional absolute path inside fixtures library
         std::string mode;
         std::string category;
+        std::string color;
         std::string source; // optional original import path
         std::string importedAt; // optional UTC ISO-8601 timestamp
         std::string sha256; // optional file hash for diagnostics

--- a/library/fixtures/gdtf_dictionary.json
+++ b/library/fixtures/gdtf_dictionary.json
@@ -3,6 +3,7 @@
     "entries": {
         "Aleda B-EYE K10": {
             "category": "Wash",
+            "color": "#7A5CFA",
             "file": "Aleda B-EYE K10.gdtf",
             "mode": "Shapes"
         },
@@ -67,6 +68,7 @@
         },
         "JDC-1": {
             "category": "Strobe",
+            "color": "#FFD966",
             "file": "JDC-1.gdtf",
             "mode": "DMX Mode 1 (Compressed Pro)"
         },
@@ -290,6 +292,7 @@
         },
         "Tour Hazer II": {
             "category": "Smoke",
+            "color": "#9E9E9E",
             "file": "Tour Hazer II.gdtf",
             "mode": "Default"
         },

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -104,6 +104,17 @@ target_include_directories(gdtf_fixture_category_test PRIVATE ../core)
 target_link_libraries(gdtf_fixture_category_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
 add_test(NAME GdtfFixtureCategoryFallback COMMAND gdtf_fixture_category_test)
 
+add_executable(gdtf_dictionary_color_roundtrip_test
+               gdtf_dictionary_color_roundtrip_test.cpp
+               ../core/gdtfdictionary.cpp
+               ../core/projectutils.cpp
+               ../core/logger.cpp)
+target_include_directories(gdtf_dictionary_color_roundtrip_test PRIVATE
+                           . ../core ../third_party)
+target_link_libraries(gdtf_dictionary_color_roundtrip_test PRIVATE
+                      ${wxWidgets_LIBRARIES})
+add_test(NAME GdtfDictionaryColorRoundtrip COMMAND gdtf_dictionary_color_roundtrip_test)
+
 add_executable(layout_template_serializer_test
                layout_template_serializer_test.cpp
                ../core/layouts/LayoutTemplateSerializer.cpp)

--- a/tests/gdtf_dictionary_color_roundtrip_test.cpp
+++ b/tests/gdtf_dictionary_color_roundtrip_test.cpp
@@ -1,0 +1,91 @@
+/*
+ * This file is part of Perastage.
+ */
+#include <cassert>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include <wx/init.h>
+
+#include "dictionary_json_contract.h"
+#include "gdtfdictionary.h"
+#include "json.hpp"
+#include "projectutils.h"
+
+namespace {
+
+std::string ReadFile(const std::filesystem::path &path) {
+  std::ifstream in(path, std::ios::binary);
+  std::ostringstream buffer;
+  buffer << in.rdbuf();
+  return buffer.str();
+}
+
+void WriteFile(const std::filesystem::path &path, const std::string &content) {
+  std::ofstream out(path, std::ios::binary | std::ios::trunc);
+  assert(out.is_open());
+  out << content;
+  assert(out.good());
+}
+
+} // namespace
+
+int main() {
+  wxInitializer initializer;
+  assert(initializer.IsOk());
+
+  const std::filesystem::path fixturesDir =
+      std::filesystem::u8path(ProjectUtils::GetDefaultLibraryPath("fixtures"));
+  std::filesystem::create_directories(fixturesDir);
+  const std::filesystem::path dictPath = fixturesDir / "gdtf_dictionary.json";
+
+  const bool hadOriginal = std::filesystem::exists(dictPath);
+  const std::string originalContent = hadOriginal ? ReadFile(dictPath) : std::string{};
+
+  const std::filesystem::path fixtureFile = fixturesDir / "color_fixture.gdtf";
+  WriteFile(fixtureFile, "fixture");
+
+  nlohmann::json entries = nlohmann::json::object();
+  entries["ColorOnlyType"] = {{"color", "#112233"}};
+  entries["FullType"] = {{"file", fixtureFile.string()},
+                         {"mode", "ModeA"},
+                         {"category", "Wash"},
+                         {"color", "#ABCDEF"}};
+  WriteFile(dictPath,
+            DictionaryJsonContract::MakeRoot("fixtures", std::move(entries)).dump(4));
+
+  auto loadedOpt = GdtfDictionary::Load();
+  assert(loadedOpt.has_value());
+
+  const auto colorOnlyIt = loadedOpt->find("ColorOnlyType");
+  assert(colorOnlyIt != loadedOpt->end());
+  assert(colorOnlyIt->second.color == "#112233");
+  assert(colorOnlyIt->second.path.empty());
+
+  const auto fullIt = loadedOpt->find("FullType");
+  assert(fullIt != loadedOpt->end());
+  assert(fullIt->second.color == "#ABCDEF");
+
+  assert(GdtfDictionary::Save(*loadedOpt));
+
+  nlohmann::json savedRoot;
+  {
+    std::ifstream in(dictPath);
+    assert(in.is_open());
+    in >> savedRoot;
+  }
+
+  assert(savedRoot.contains("entries"));
+  assert(savedRoot["entries"]["ColorOnlyType"]["color"] == "#112233");
+  assert(savedRoot["entries"]["FullType"]["color"] == "#ABCDEF");
+
+  std::filesystem::remove(fixtureFile);
+  if (hadOriginal)
+    WriteFile(dictPath, originalContent);
+  else
+    std::filesystem::remove(dictPath);
+
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- Allow per-fixture color metadata to be stored in the fixtures dictionary so tools can carry/display color information and accept entries that only provide color as configuration metadata.

### Description
- Extended `GdtfDictionary::Entry` with a new `color` string field in `core/gdtfdictionary.h`.
- Updated parsing in `core/gdtfdictionary.cpp::LoadFromFile(...)` to read the `color` property and relaxed validation so an object with only `color` is considered valid.
- Updated serialization in `core/gdtfdictionary.cpp::Save(...)` to persist `color` and avoid dropping entries that only contain `color`.
- Added sample `color` values to `library/fixtures/gdtf_dictionary.json` and added a new test `tests/gdtf_dictionary_color_roundtrip_test.cpp` that verifies parsing and roundtrip save of `color`, and registered the test in `tests/CMakeLists.txt`.

### Testing
- Ran `bash tests/check_perastage_tree_modules.sh` which passed.
- Ran `bash tests/check_no_configmanager_get_in_gui.sh` which passed.
- Attempted `cmake -S tests -B build/tests -DCMAKE_BUILD_TYPE=Release` which failed in this environment due to a missing system dependency (`wxWidgets`), not due to repository changes.
- Ran `python -m json.tool library/fixtures/gdtf_dictionary.json` to validate the sample JSON which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5702cd8208324bb793969dd20ddac)