### PR TITLE
Apply GDTF dictionary colors to fixture creation and type changes

### DIFF
--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -511,6 +511,42 @@ void UpdateCategoryForFile(const std::string &type, const std::string &gdtfPath,
   Save(dict);
 }
 
+void UpdateColor(const std::string &type, const std::string &color) {
+  UpdateColorForFile(type, {}, color);
+}
+
+void UpdateColorForFile(const std::string &type, const std::string &gdtfPath,
+                        const std::string &color) {
+  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
+  if (type.empty())
+    return;
+  auto dictOpt = Load();
+  if (!dictOpt)
+    return;
+  auto &dict = *dictOpt;
+  auto it = dict.find(type);
+  if (it == dict.end()) {
+    Entry e;
+    e.color = color;
+    dict[type] = e;
+  } else {
+    std::string sharedPath = it->second.path;
+    if (sharedPath.empty() && !gdtfPath.empty())
+      sharedPath = gdtfPath;
+    it->second.color = color;
+    for (auto &[entryType, entry] : dict) {
+      if (entryType == type)
+        continue;
+      const bool samePath = PathsMatchForDictionaryEntries(entry.path, sharedPath);
+      const bool sameFileName = PathsShareFileName(entry.path, sharedPath);
+      if (!samePath && !sameFileName)
+        continue;
+      entry.color = color;
+    }
+  }
+  Save(dict);
+}
+
 DictionaryImportSummary PreviewImportFromFile(const std::string &filePath,
                                               DictionaryImportPolicy policy) {
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());

--- a/core/gdtfdictionary.h
+++ b/core/gdtfdictionary.h
@@ -54,6 +54,9 @@ namespace GdtfDictionary {
     void UpdateCategory(const std::string& type, const std::string& category);
     void UpdateCategoryForFile(const std::string& type, const std::string& gdtfPath,
                                const std::string& category);
+    void UpdateColor(const std::string& type, const std::string& color);
+    void UpdateColorForFile(const std::string& type, const std::string& gdtfPath,
+                            const std::string& color);
     DictionaryImportSummary PreviewImportFromFile(
         const std::string &filePath, DictionaryImportPolicy policy);
     DictionaryImportSummary ApplyImportFromFile(

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -1687,6 +1687,8 @@ bool RiderImporter::ImportText(const std::string &text) {
         if (auto dictEntry = GdtfDictionary::Get(f.typeName)) {
           f.gdtfSpec = dictEntry->path;
           f.gdtfMode = dictEntry->mode;
+          if (!dictEntry->color.empty())
+            f.color = dictEntry->color;
           const std::string dictionaryCategory = Trim(dictEntry->category);
           if (!dictionaryCategory.empty()) {
             f.category = dictionaryCategory;

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -139,6 +139,7 @@ For each fixture created:
 2. `typeName` is set from parsed text and may be refined through the GDTF dictionary.
 3. If dictionary entry exists:
    - `gdtfSpec` and `gdtfMode` are assigned.
+   - If dictionary color is defined, it is copied into fixture `color`.
    - If dictionary category is defined, it is copied into fixture `category`
      with source `Manual`.
    - Fixture display/type name can be replaced by the parsed GDTF fixture name when available.
@@ -172,6 +173,19 @@ Special screen-object handling:
 - If no valid size is found, importer falls back to `8.0 x 5.0 m`.
 - Screen objects are centered on the associated screen truss span and placed so
   their top edge sits `0.2 m` below the truss.
+
+## Fixture color precedence
+
+Fixture color resolution follows this order:
+
+1. Explicit fixture color (already stored on the fixture row/object).
+2. Dictionary color for the fixture `typeName`.
+3. Deterministic fallback color (GDTF/model-derived fallback used by the
+   current creation flow).
+
+When changing a fixture type color from Summary, Perastage updates matching
+fixtures in the scene and also persists that color in dictionary entries for
+the edited type (and entries sharing the same GDTF file identity).
 
 ## Truss parsing rules
 

--- a/gui/fixtureeditdialog.cpp
+++ b/gui/fixtureeditdialog.cpp
@@ -53,6 +53,23 @@ bool ParseFloatOrDefault(const wxString &text, float &out) {
   return true;
 }
 
+void SetFixtureColorCell(wxDataViewListCtrl *table, int row,
+                         const std::string &hexColor) {
+  if (!table || row == wxNOT_FOUND || hexColor.empty())
+    return;
+  wxBitmap colorSwatch(16, 16);
+  {
+    wxMemoryDC dc(colorSwatch);
+    dc.SetPen(*wxTRANSPARENT_PEN);
+    dc.SetBrush(wxBrush(wxColour(wxString::FromUTF8(hexColor))));
+    dc.DrawRectangle(0, 0, 16, 16);
+    dc.SelectObject(wxNullBitmap);
+  }
+  wxVariant colorValue;
+  colorValue << wxDataViewIconText(wxString::FromUTF8(hexColor), colorSwatch);
+  table->SetValue(colorValue, row, 19);
+}
+
 bool LoadGdtfThumbnail(const std::string &gdtfPath, wxBitmap &outBitmap) {
   if (gdtfPath.empty())
     return false;
@@ -856,6 +873,21 @@ void FixtureEditDialog::ApplyChanges() {
   const bool gdtfPhysicalCandidateChanged =
       (modifiedColumns.size() > 16 && modifiedColumns[16]) ||
       (modifiedColumns.size() > 17 && modifiedColumns[17]);
+  const bool gdtfTypeOrModelChanged =
+      (modifiedColumns.size() > 2 && modifiedColumns[2]) ||
+      (modifiedColumns.size() > 9 && modifiedColumns[9]);
+  const bool fixtureColorChanged =
+      (modifiedColumns.size() > 19 && modifiedColumns[19]);
+
+  if (gdtfTypeOrModelChanged && !fixtureColorChanged) {
+    wxVariant typeVar;
+    table->GetValue(typeVar, row, 2);
+    const std::string currentType = std::string(typeVar.GetString().ToUTF8());
+    if (auto dictEntry = GdtfDictionary::Get(currentType)) {
+      if (!dictEntry->color.empty())
+        SetFixtureColorCell(table, row, dictEntry->color);
+    }
+  }
 
   if (!gdtfPath.empty()) {
     if (ctrls.size() > 17) {

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -167,6 +167,22 @@ wxString BuildCategoryFallbackTooltip(const Fixture &fixture) {
   }
   return "Category auto-assigned by fallback.";
 }
+
+void SetFixtureColorCell(wxDataViewListCtrl *table, int row,
+                         const std::string &hexColor) {
+  if (!table || row == wxNOT_FOUND || hexColor.empty())
+    return;
+  wxBitmap bmp(16, 16);
+  wxMemoryDC dc(bmp);
+  dc.SetPen(*wxTRANSPARENT_PEN);
+  dc.SetBrush(wxBrush(wxColour(wxString::FromUTF8(hexColor))));
+  dc.DrawRectangle(0, 0, 16, 16);
+  dc.SelectObject(wxNullBitmap);
+
+  wxVariant colorValue;
+  colorValue << wxDataViewIconText(wxString::FromUTF8(hexColor), bmp);
+  table->SetValue(colorValue, row, 19);
+}
 } // namespace
 
 FixtureTablePanel::FixtureTablePanel(wxWindow *parent, IGuiConfigServices *services)
@@ -434,6 +450,8 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
       if (typeName.empty())
         typeName = wxFileName(path).GetName();
       wxString fileName = fdlg.GetFilename();
+      const std::string typeNameUtf8 = std::string(typeName.ToUTF8());
+      const auto dictColor = GdtfDictionary::Get(typeNameUtf8);
 
       std::vector<std::string> prevTypes;
       std::unordered_set<std::string> prevTypeSet;
@@ -461,6 +479,8 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
         wxString wstr = wxString::Format("%.2f", w);
         table->SetValue(wxVariant(pstr), r, 16);
         table->SetValue(wxVariant(wstr), r, 17);
+        if (dictColor && !dictColor->color.empty())
+          SetFixtureColorCell(table, r, dictColor->color);
       }
 
       for (unsigned int i = 0; i < table->GetItemCount(); ++i) {
@@ -481,6 +501,8 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
         wxString wstr = wxString::Format("%.2f", w);
         table->SetValue(wxVariant(pstr), i, 16);
         table->SetValue(wxVariant(wstr), i, 17);
+        if (dictColor && !dictColor->color.empty())
+          SetFixtureColorCell(table, i, dictColor->color);
       }
 
       PropagateTypeValues(selections, 16);

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -55,6 +55,7 @@
 #include "dictionaryeditdialog.h"
 #include "fixture.h"
 #include "fixturetablepanel.h"
+#include "gdtfdictionary.h"
 #include "gdtfloader.h"
 #include "gdtfnet.h"
 #include "gdtfsearchdialog.h"

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -1162,6 +1162,10 @@ void MainWindow::OnAddFixture(wxCommandEvent &WXUNUSED(event)) {
   float weight = 0.0f, power = 0.0f;
   GetGdtfProperties(gdtfPath, weight, power);
   std::string defaultColor = GetGdtfModelColor(gdtfPath);
+  if (auto dictEntry = GdtfDictionary::Get(defaultName)) {
+    if (!dictEntry->color.empty())
+      defaultColor = dictEntry->color;
+  }
 
   int count = dlg.GetUnitCount();
   std::string name = dlg.GetFixtureName();

--- a/gui/summarypanel.cpp
+++ b/gui/summarypanel.cpp
@@ -19,6 +19,7 @@
 #include "colorstore.h"
 #include "configmanager.h"
 #include "fixturetablepanel.h"
+#include "gdtfdictionary.h"
 #include "guiconfigservices.h"
 #include "viewer2dpanel.h"
 #include "viewer3dpanel.h"
@@ -398,10 +399,13 @@ void SummaryPanel::OnItemActivated(wxDataViewEvent& event) {
     const std::string typeName = table->GetTextValue(row, 2).ToStdString();
     auto& colorCfg = (*colorConfigManager);
     auto& fixtures = colorCfg.GetScene().fixtures;
+    std::string typeGdtfSpec;
 
     wxColourData data;
     for (const auto& [uuid, fixture] : fixtures) {
         (void)uuid;
+        if (fixture.typeName == typeName && typeGdtfSpec.empty())
+            typeGdtfSpec = fixture.gdtfSpec;
         if (fixture.typeName == typeName && !fixture.color.empty()) {
             data.SetColour(wxColour(wxString::FromUTF8(fixture.color)));
             break;
@@ -421,6 +425,7 @@ void SummaryPanel::OnItemActivated(wxDataViewEvent& event) {
         if (fixture.typeName == typeName)
             fixture.color = hex;
     }
+    GdtfDictionary::UpdateColorForFile(typeName, typeGdtfSpec, hex);
 
     if (FixtureTablePanel::Instance())
         FixtureTablePanel::Instance()->ReloadData();


### PR DESCRIPTION
### Motivation
- Ensure a single, predictable source of truth for fixture display colors by honoring stored dictionary colors where available when creating or changing fixture types. 
- Make text/rider imports and GDTF replacement flows consistent with dictionary metadata so fixtures produced by automated flows get the intended visual color. 
- Persist user edits of a type color (from the Summary panel) back into the dictionary so future creations/replacements reuse the chosen color.

### Description
- Added dictionary color persistence APIs `GdtfDictionary::UpdateColor` and `GdtfDictionary::UpdateColorForFile` (with propagation to other dictionary entries that share the same GDTF identity) in `core/gdtfdictionary.{h,cpp}`. 
- Prioritized dictionary color when creating fixtures in `MainWindow::OnAddFixture` by checking `GdtfDictionary::Get(typeName)->color` and only falling back to the model-derived color when dictionary color is empty in `gui/mainwindow_menu.cpp`. 
- Applied dictionary color during rider/text imports in `core/riderimporter.cpp` by setting `f.color` when `dictEntry->color` exists. 
- Persisted Summary-panel type color edits into the dictionary via `GdtfDictionary::UpdateColorForFile(...)` while still updating matching fixtures in-scene in `gui/summarypanel.cpp`. 
- Re-applied dictionary color on GDTF replacement/type-change flows by adding a small helper to set the color cell and invoking it from the fixture table `col == 9` replacement path and from the fixture edit dialog when type/model changed but the user did not explicitly change color, implemented in `gui/fixturetablepanel.cpp` and `gui/fixtureeditdialog.cpp`. 
- Documented the final color precedence and the persistence behavior in `docs/text_to_scene_rules.md` as: explicit fixture color > dictionary type color > deterministic fallback.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5733f5cd483249700b91cf197ddbd)