### PR TITLE
Remove GDTF-driven color from textured fixture pass

### DIFF
--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -112,29 +112,6 @@ std::string NormalizeModelKeyPath(const std::string &path) {
   return NormalizePathSeparators(normalized.string());
 }
 
-bool TryParseHtmlHexColor(const std::string &hex, float &r, float &g, float &b) {
-  if (hex.size() != 7 || hex[0] != '#')
-    return false;
-  auto hexToNibble = [](char c) -> int {
-    if (c >= '0' && c <= '9')
-      return c - '0';
-    if (c >= 'a' && c <= 'f')
-      return 10 + (c - 'a');
-    if (c >= 'A' && c <= 'F')
-      return 10 + (c - 'A');
-    return -1;
-  };
-  auto byteAt = [&](size_t idx, float &out) -> bool {
-    const int hi = hexToNibble(hex[idx]);
-    const int lo = hexToNibble(hex[idx + 1]);
-    if (hi < 0 || lo < 0)
-      return false;
-    out = static_cast<float>((hi << 4) | lo) / 255.0f;
-    return true;
-  };
-  return byteAt(1, r) && byteAt(3, g) && byteAt(5, b);
-}
-
 std::string ResolveFixtureSymbolKeyPath(const Fixture &fixture,
                                         const std::string &basePath) {
   if (fixture.gdtfSpec.empty())
@@ -554,13 +531,11 @@ void OpaqueFixturePass::Render(
       g = 0.95f;
       b = 0.95f;
     } else if (context.texturedStyle && !wireframe) {
+      // Keep textured fixtures on a neutral tone. Colorized modes such as
+      // ByFixtureType override this with fixture-driven colors afterwards.
       r = 0.2f;
       g = 0.2f;
       b = 0.2f;
-      if (!gdtfPath.empty()) {
-        const std::string gdtfModelColor = GetGdtfModelColor(gdtfPath);
-        TryParseHtmlHexColor(gdtfModelColor, r, g, b);
-      }
     }
     if (mode == Viewer2DRenderMode::ByFixtureType) {
       auto c = getTypeColor(f.gdtfSpec, f.color);


### PR DESCRIPTION
### Motivation
- Decouple textured rendering from GDTF metadata so textured fixtures use a predictable neutral tone instead of a model-provided color.
- Preserve existing fixture-type coloring behavior so `Viewer2DRenderMode::ByFixtureType` continues to derive color only from `fixture.color` (or the existing deterministic fallback).

### Description
- Removed the `GetGdtfModelColor(...)` lookup and the `TryParseHtmlHexColor` usage from the `context.texturedStyle` branch in `viewer3d/render/opaque_fixture_pass.cpp` and instead apply a fixed neutral tone `0.2f, 0.2f, 0.2f` for textured fixtures.
- Kept the subsequent `ByFixtureType` branch unchanged so it still calls the provided `getTypeColor(f.gdtfSpec, f.color)` and therefore honors `fixture.color` when rendering by type.
- Reviewed layout/legend flow (`gui/layoutlegenditems.cpp` and the legend rendering path) and confirmed `BuildSharedLayoutLegendItems()` continues to read `fixture.color` and propagate it as `symbolFillHex` for legend rendering.

### Testing
- Ran architecture checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both completed successfully.
- Ran quick verification searches for the changed color flow using `rg` to ensure `GetGdtfModelColor(...)` was removed from the textured pass and that `ByFixtureType` still uses `fixture.color`, and these checks returned the expected results.
- Built and committed the change locally and confirmed the modified file is `viewer3d/render/opaque_fixture_pass.cpp` and the automated checks above passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d57e098f548324a0d2c9779a5c2a8e)