### PR TITLE
Limit summary panel fixture color edits to project-local scene data

### DIFF
--- a/gui/summarypanel.cpp
+++ b/gui/summarypanel.cpp
@@ -19,7 +19,6 @@
 #include "colorstore.h"
 #include "configmanager.h"
 #include "fixturetablepanel.h"
-#include "gdtfdictionary.h"
 #include "guiconfigservices.h"
 #include "viewer2dpanel.h"
 #include "viewer3dpanel.h"
@@ -399,13 +398,10 @@ void SummaryPanel::OnItemActivated(wxDataViewEvent& event) {
     const std::string typeName = table->GetTextValue(row, 2).ToStdString();
     auto& colorCfg = (*colorConfigManager);
     auto& fixtures = colorCfg.GetScene().fixtures;
-    std::string typeGdtfSpec;
 
     wxColourData data;
     for (const auto& [uuid, fixture] : fixtures) {
         (void)uuid;
-        if (fixture.typeName == typeName && typeGdtfSpec.empty())
-            typeGdtfSpec = fixture.gdtfSpec;
         if (fixture.typeName == typeName && !fixture.color.empty()) {
             data.SetColour(wxColour(wxString::FromUTF8(fixture.color)));
             break;
@@ -419,13 +415,12 @@ void SummaryPanel::OnItemActivated(wxDataViewEvent& event) {
     const wxColour color = dlg.GetColourData().GetColour();
     const std::string hex = wxString::Format("#%02X%02X%02X", color.Red(), color.Green(),
                                              color.Blue()).ToStdString();
-    colorCfg.PushUndoState("change fixture type color from summary");
+    colorCfg.PushUndoState("change fixture type color in project from summary");
     for (auto& [uuid, fixture] : fixtures) {
         (void)uuid;
         if (fixture.typeName == typeName)
             fixture.color = hex;
     }
-    GdtfDictionary::UpdateColorForFile(typeName, typeGdtfSpec, hex);
 
     if (FixtureTablePanel::Instance())
         FixtureTablePanel::Instance()->ReloadData();


### PR DESCRIPTION
### Motivation
- Prevent the summary panel from modifying global dictionary files when a user changes a fixture type color, keeping the change local to the opened project scene.
- Make the undo/log message explicit about the local/project scope to avoid confusion about where the change is applied.

### Description
- Removed the call to `GdtfDictionary::UpdateColorForFile(...)` from `SummaryPanel::OnItemActivated` so the summary UI no longer writes to the dictionary.
- Stopped computing/using `typeGdtfSpec` in this activation path and removed the now-unused `#include "gdtfdictionary.h"` from `gui/summarypanel.cpp`.
- Left the behavior that updates `fixture.color` for matching fixtures in the loaded project scene intact so viewers and tables reflect the change.
- Updated the undo text to `change fixture type color in project from summary` to clarify scope.

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which succeeded.
- Ran `rg -n "UpdateColorForFile|UpdateColor\(" gui -g '*.cpp' -g '*.h'` to confirm no remaining `gui/` callers of the dictionary color-update APIs, which returned no matches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5831a7b708324a251f810378a41e5)