### PR TITLE
Require fixture mode match when propagating GDTF dictionary color

### DIFF
--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -80,6 +80,16 @@ bool ModesMatchForDictionaryEntries(const std::string &lhs,
   return NormalizeModeKey(lhs) == NormalizeModeKey(rhs);
 }
 
+bool EntriesShareFixtureFamily(const Entry &entry, const std::string &referencePath,
+                               const std::string &referenceMode) {
+  const bool samePath =
+      PathsMatchForDictionaryEntries(entry.path, referencePath);
+  const bool sameFileName = PathsShareFileName(entry.path, referencePath);
+  if (!samePath && !sameFileName)
+    return false;
+  return ModesMatchForDictionaryEntries(entry.mode, referenceMode);
+}
+
 bool IsDummy1ChFallbackType(const std::string &type) {
   return NormalizeAsciiKey(type) == "dummy1ch";
 }
@@ -576,15 +586,19 @@ void UpdateColorForFile(const std::string &type, const std::string &gdtfPath,
   if (auto existingKey = FindEquivalentTypeKey(dict, normalizedType))
     keyToUse = *existingKey;
   auto it = dict.find(keyToUse);
+  std::string sharedPath;
+  std::string sharedMode = mode;
   if (it == dict.end()) {
     Entry e;
+    if (!gdtfPath.empty())
+      e.path = gdtfPath;
     if (!mode.empty())
       e.mode = mode;
     e.color = color;
     dict[keyToUse] = e;
+    sharedPath = e.path;
   } else {
-    std::string sharedPath = it->second.path;
-    std::string sharedMode = mode;
+    sharedPath = it->second.path;
     if (sharedPath.empty() && !gdtfPath.empty())
       sharedPath = gdtfPath;
     if (sharedMode.empty())
@@ -592,17 +606,25 @@ void UpdateColorForFile(const std::string &type, const std::string &gdtfPath,
     if (!mode.empty())
       it->second.mode = mode;
     it->second.color = color;
-    for (auto &[entryType, entry] : dict) {
-      if (entryType == keyToUse)
-        continue;
-      const bool samePath = PathsMatchForDictionaryEntries(entry.path, sharedPath);
-      const bool sameFileName = PathsShareFileName(entry.path, sharedPath);
-      if (!samePath && !sameFileName)
-        continue;
-      if (!ModesMatchForDictionaryEntries(entry.mode, sharedMode))
-        continue;
-      entry.color = color;
-    }
+  }
+
+  if (sharedMode.empty()) {
+    auto keyIt = dict.find(keyToUse);
+    if (keyIt != dict.end())
+      sharedMode = keyIt->second.mode;
+  }
+  if (sharedPath.empty()) {
+    auto keyIt = dict.find(keyToUse);
+    if (keyIt != dict.end())
+      sharedPath = keyIt->second.path;
+  }
+
+  for (auto &[entryType, entry] : dict) {
+    if (entryType == keyToUse)
+      continue;
+    if (!EntriesShareFixtureFamily(entry, sharedPath, sharedMode))
+      continue;
+    entry.color = color;
   }
   Save(dict);
 }

--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -586,7 +586,7 @@ void UpdateColorForFile(const std::string &type, const std::string &gdtfPath,
   if (auto existingKey = FindEquivalentTypeKey(dict, normalizedType))
     keyToUse = *existingKey;
   auto it = dict.find(keyToUse);
-  std::string sharedPath;
+  std::string sharedPath = gdtfPath;
   std::string sharedMode = mode;
   if (it == dict.end()) {
     Entry e;
@@ -596,13 +596,13 @@ void UpdateColorForFile(const std::string &type, const std::string &gdtfPath,
       e.mode = mode;
     e.color = color;
     dict[keyToUse] = e;
-    sharedPath = e.path;
   } else {
-    sharedPath = it->second.path;
-    if (sharedPath.empty() && !gdtfPath.empty())
-      sharedPath = gdtfPath;
+    if (sharedPath.empty())
+      sharedPath = it->second.path;
     if (sharedMode.empty())
       sharedMode = it->second.mode;
+    if (!gdtfPath.empty())
+      it->second.path = gdtfPath;
     if (!mode.empty())
       it->second.mode = mode;
     it->second.color = color;

--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -71,6 +71,15 @@ std::string NormalizeAsciiKey(std::string value) {
   return value;
 }
 
+std::string NormalizeModeKey(const std::string &mode) {
+  return NormalizeAsciiKey(mode);
+}
+
+bool ModesMatchForDictionaryEntries(const std::string &lhs,
+                                    const std::string &rhs) {
+  return NormalizeModeKey(lhs) == NormalizeModeKey(rhs);
+}
+
 bool IsDummy1ChFallbackType(const std::string &type) {
   return NormalizeAsciiKey(type) == "dummy1ch";
 }
@@ -550,11 +559,11 @@ void UpdateCategoryForFile(const std::string &type, const std::string &gdtfPath,
 }
 
 void UpdateColor(const std::string &type, const std::string &color) {
-  UpdateColorForFile(type, {}, color);
+  UpdateColorForFile(type, {}, {}, color);
 }
 
 void UpdateColorForFile(const std::string &type, const std::string &gdtfPath,
-                        const std::string &color) {
+                        const std::string &mode, const std::string &color) {
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
   const std::string normalizedType = NormalizeTypeKey(type);
   if (normalizedType.empty())
@@ -569,12 +578,19 @@ void UpdateColorForFile(const std::string &type, const std::string &gdtfPath,
   auto it = dict.find(keyToUse);
   if (it == dict.end()) {
     Entry e;
+    if (!mode.empty())
+      e.mode = mode;
     e.color = color;
     dict[keyToUse] = e;
   } else {
     std::string sharedPath = it->second.path;
+    std::string sharedMode = mode;
     if (sharedPath.empty() && !gdtfPath.empty())
       sharedPath = gdtfPath;
+    if (sharedMode.empty())
+      sharedMode = it->second.mode;
+    if (!mode.empty())
+      it->second.mode = mode;
     it->second.color = color;
     for (auto &[entryType, entry] : dict) {
       if (entryType == keyToUse)
@@ -582,6 +598,8 @@ void UpdateColorForFile(const std::string &type, const std::string &gdtfPath,
       const bool samePath = PathsMatchForDictionaryEntries(entry.path, sharedPath);
       const bool sameFileName = PathsShareFileName(entry.path, sharedPath);
       if (!samePath && !sameFileName)
+        continue;
+      if (!ModesMatchForDictionaryEntries(entry.mode, sharedMode))
         continue;
       entry.color = color;
     }

--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -90,6 +90,30 @@ bool EntriesShareFixtureFamily(const Entry &entry, const std::string &referenceP
   return ModesMatchForDictionaryEntries(entry.mode, referenceMode);
 }
 
+void HarmonizeColorsByFixtureFamily(std::unordered_map<std::string, Entry> &dict) {
+  std::vector<std::string> keys;
+  keys.reserve(dict.size());
+  for (const auto &[key, _] : dict)
+    keys.push_back(key);
+  std::sort(keys.begin(), keys.end());
+
+  for (const auto &sourceKey : keys) {
+    const auto sourceIt = dict.find(sourceKey);
+    if (sourceIt == dict.end())
+      continue;
+    const Entry &source = sourceIt->second;
+    if (source.path.empty() || source.mode.empty() || source.color.empty())
+      continue;
+    for (auto &[targetKey, target] : dict) {
+      if (targetKey == sourceKey)
+        continue;
+      if (!EntriesShareFixtureFamily(target, source.path, source.mode))
+        continue;
+      target.color = source.color;
+    }
+  }
+}
+
 bool IsDummy1ChFallbackType(const std::string &type) {
   return NormalizeAsciiKey(type) == "dummy1ch";
 }
@@ -274,6 +298,7 @@ LoadFromFile(const fs::path &file, std::string &error) {
       }
       dict[it.key()] = entry;
     }
+    HarmonizeColorsByFixtureFamily(dict);
     return dict;
   }
 
@@ -298,6 +323,7 @@ LoadFromFile(const fs::path &file, std::string &error) {
 
     dict[entryName] = entry;
   }
+  HarmonizeColorsByFixtureFamily(dict);
   return dict;
 }
 

--- a/core/gdtfdictionary.h
+++ b/core/gdtfdictionary.h
@@ -56,6 +56,7 @@ namespace GdtfDictionary {
                                const std::string& category);
     void UpdateColor(const std::string& type, const std::string& color);
     void UpdateColorForFile(const std::string& type, const std::string& gdtfPath,
+                            const std::string& mode,
                             const std::string& color);
     DictionaryImportSummary PreviewImportFromFile(
         const std::string &filePath, DictionaryImportPolicy policy);

--- a/gui/dictionaryeditdialog.cpp
+++ b/gui/dictionaryeditdialog.cpp
@@ -82,6 +82,33 @@ std::string ExtractFixtureColorText(const wxVariant &value) {
   return std::string(value.GetString().ToUTF8());
 }
 
+std::string NormalizeFixtureModeKey(std::string value) {
+  std::transform(value.begin(), value.end(), value.begin(),
+                 [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+  value.erase(std::remove_if(value.begin(), value.end(),
+                             [](unsigned char ch) {
+                               return std::isspace(ch) != 0 || ch == '_' || ch == '-';
+                             }),
+              value.end());
+  return value;
+}
+
+bool FixturePathsMatchForColorFamily(const std::string &lhs,
+                                     const std::string &rhs) {
+  if (lhs.empty() || rhs.empty())
+    return false;
+  const std::filesystem::path leftPath = std::filesystem::u8path(lhs).lexically_normal();
+  const std::filesystem::path rightPath = std::filesystem::u8path(rhs).lexically_normal();
+  if (leftPath == rightPath)
+    return true;
+  if (!leftPath.filename().empty() && leftPath.filename() == rightPath.filename())
+    return true;
+  std::error_code ec;
+  return std::filesystem::exists(leftPath, ec) && !ec &&
+         std::filesystem::exists(rightPath, ec) && !ec &&
+         std::filesystem::equivalent(leftPath, rightPath, ec) && !ec;
+}
+
 void SetFixtureColorCell(wxDataViewListCtrl *table, int row,
                          const std::string &hexColor) {
   if (!table || row == wxNOT_FOUND)
@@ -1422,6 +1449,36 @@ void DictionaryEditDialog::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
   }
 }
 
+void DictionaryEditDialog::UpdateFixtureColorForFileAndMode(
+    int row, const std::string &colorHex) {
+  if (!fixtureTable || row < 0 || static_cast<size_t>(row) >= fixturePaths.size())
+    return;
+  const std::string targetPath = fixturePaths[static_cast<size_t>(row)];
+  if (targetPath.empty())
+    return;
+
+  wxVariant targetModeVar;
+  fixtureTable->GetValue(targetModeVar, row, kFixtureModeColumn);
+  const std::string targetModeKey =
+      NormalizeFixtureModeKey(std::string(targetModeVar.GetString().ToUTF8()));
+
+  const int rowCount = fixtureTable->GetItemCount();
+  for (int i = 0; i < rowCount; ++i) {
+    if (static_cast<size_t>(i) >= fixturePaths.size())
+      continue;
+    if (!FixturePathsMatchForColorFamily(fixturePaths[static_cast<size_t>(i)],
+                                         targetPath))
+      continue;
+    wxVariant modeVar;
+    fixtureTable->GetValue(modeVar, i, kFixtureModeColumn);
+    const std::string modeKey =
+        NormalizeFixtureModeKey(std::string(modeVar.GetString().ToUTF8()));
+    if (modeKey != targetModeKey)
+      continue;
+    SetFixtureColorCell(fixtureTable, i, colorHex);
+  }
+}
+
 void DictionaryEditDialog::UpdateFixtureCategoryForFile(
     int row, const std::string &category) {
   if (!fixtureTable || row < 0 || static_cast<size_t>(row) >= fixturePaths.size())
@@ -1950,7 +2007,7 @@ void DictionaryEditDialog::OnItemActivated(wxDataViewEvent &event) {
           wxString::Format("#%02X%02X%02X", selected.Red(), selected.Green(),
                            selected.Blue())
               .ToStdString();
-      SetFixtureColorCell(table, row, hex);
+      UpdateFixtureColorForFileAndMode(row, hex);
       return;
     }
     if (col != kFixtureFileColumn)

--- a/gui/dictionaryeditdialog.h
+++ b/gui/dictionaryeditdialog.h
@@ -43,6 +43,7 @@ private:
   void ShowDictionaryLoadStatusMessages();
   bool IsFixturesPage() const;
   void UpdateFixtureCategoryForFile(int row, const std::string &category);
+  void UpdateFixtureColorForFileAndMode(int row, const std::string &colorHex);
   void OnFixtureTableMouseMove(wxMouseEvent &event);
   void OnFixtureTableMouseLeave(wxMouseEvent &event);
   void OnTrussTableMouseMove(wxMouseEvent &event);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -115,6 +115,18 @@ target_link_libraries(gdtf_dictionary_color_roundtrip_test PRIVATE
                       ${wxWidgets_LIBRARIES})
 add_test(NAME GdtfDictionaryColorRoundtrip COMMAND gdtf_dictionary_color_roundtrip_test)
 
+add_executable(gdtf_dictionary_color_mode_propagation_test
+               gdtf_dictionary_color_mode_propagation_test.cpp
+               ../core/gdtfdictionary.cpp
+               ../core/projectutils.cpp
+               ../core/logger.cpp)
+target_include_directories(gdtf_dictionary_color_mode_propagation_test PRIVATE
+                           . ../core ../third_party)
+target_link_libraries(gdtf_dictionary_color_mode_propagation_test PRIVATE
+                      ${wxWidgets_LIBRARIES})
+add_test(NAME GdtfDictionaryColorModePropagation
+         COMMAND gdtf_dictionary_color_mode_propagation_test)
+
 add_executable(layout_template_serializer_test
                layout_template_serializer_test.cpp
                ../core/layouts/LayoutTemplateSerializer.cpp)

--- a/tests/gdtf_dictionary_color_mode_propagation_test.cpp
+++ b/tests/gdtf_dictionary_color_mode_propagation_test.cpp
@@ -77,6 +77,17 @@ int main() {
   assert(dictAfterEntryMode.at("TypeC").color == "#FEDCBA");
   assert(dictAfterEntryMode.at("TypeB").color == "#000002");
 
+  GdtfDictionary::UpdateColorForFile("TypeNotInDictionary", fixtureFile.string(),
+                                     "mode_a", "#123456");
+
+  auto dictAfterNewTypeOpt = GdtfDictionary::Load();
+  assert(dictAfterNewTypeOpt.has_value());
+  const auto &dictAfterNewType = *dictAfterNewTypeOpt;
+  assert(dictAfterNewType.at("TypeA").color == "#123456");
+  assert(dictAfterNewType.at("TypeC").color == "#123456");
+  assert(dictAfterNewType.at("TypeB").color == "#000002");
+  assert(dictAfterNewType.at("TypeNotInDictionary").color == "#123456");
+
   std::filesystem::remove(fixtureFile);
   if (hadOriginal)
     WriteFile(dictPath, originalContent);

--- a/tests/gdtf_dictionary_color_mode_propagation_test.cpp
+++ b/tests/gdtf_dictionary_color_mode_propagation_test.cpp
@@ -113,6 +113,25 @@ int main() {
   assert(dictAfterPathRefresh.at("TypeC").color == "#654321");
   assert(dictAfterPathRefresh.at("TypeB").color == "#200000");
 
+  nlohmann::json inconsistentEntries = nlohmann::json::object();
+  inconsistentEntries["TypeWithColor"] = {{"file", fixtureFileNew.string()},
+                                          {"mode", "Mode A"},
+                                          {"color", "#0F0F0F"}};
+  inconsistentEntries["TypeWithoutColor"] = {{"file", fixtureFileNew.string()},
+                                             {"mode", "mode-a"}};
+  inconsistentEntries["TypeOtherMode"] = {{"file", fixtureFileNew.string()},
+                                          {"mode", "Mode B"}};
+  WriteFile(dictPath,
+            DictionaryJsonContract::MakeRoot("fixtures", std::move(inconsistentEntries))
+                .dump(4));
+
+  auto dictAfterLoadHarmonizationOpt = GdtfDictionary::Load();
+  assert(dictAfterLoadHarmonizationOpt.has_value());
+  const auto &dictAfterLoadHarmonization = *dictAfterLoadHarmonizationOpt;
+  assert(dictAfterLoadHarmonization.at("TypeWithColor").color == "#0F0F0F");
+  assert(dictAfterLoadHarmonization.at("TypeWithoutColor").color == "#0F0F0F");
+  assert(dictAfterLoadHarmonization.at("TypeOtherMode").color.empty());
+
   std::filesystem::remove(fixtureFileNew);
   std::filesystem::remove(fixtureFile);
   if (hadOriginal)

--- a/tests/gdtf_dictionary_color_mode_propagation_test.cpp
+++ b/tests/gdtf_dictionary_color_mode_propagation_test.cpp
@@ -1,0 +1,87 @@
+/*
+ * This file is part of Perastage.
+ */
+#include <cassert>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include <wx/init.h>
+
+#include "dictionary_json_contract.h"
+#include "gdtfdictionary.h"
+#include "json.hpp"
+#include "projectutils.h"
+
+namespace {
+
+std::string ReadFile(const std::filesystem::path &path) {
+  std::ifstream in(path, std::ios::binary);
+  std::ostringstream buffer;
+  buffer << in.rdbuf();
+  return buffer.str();
+}
+
+void WriteFile(const std::filesystem::path &path, const std::string &content) {
+  std::ofstream out(path, std::ios::binary | std::ios::trunc);
+  assert(out.is_open());
+  out << content;
+  assert(out.good());
+}
+
+} // namespace
+
+int main() {
+  wxInitializer initializer;
+  assert(initializer.IsOk());
+
+  const std::filesystem::path fixturesDir =
+      std::filesystem::u8path(ProjectUtils::GetDefaultLibraryPath("fixtures"));
+  std::filesystem::create_directories(fixturesDir);
+  const std::filesystem::path dictPath = fixturesDir / "gdtf_dictionary.json";
+  const bool hadOriginal = std::filesystem::exists(dictPath);
+  const std::string originalContent = hadOriginal ? ReadFile(dictPath) : std::string{};
+
+  const std::filesystem::path fixtureFile = fixturesDir / "mode_shared_fixture.gdtf";
+  WriteFile(fixtureFile, "fixture");
+
+  nlohmann::json entries = nlohmann::json::object();
+  entries["TypeA"] = {{"file", fixtureFile.string()},
+                      {"mode", "Mode A"},
+                      {"color", "#000001"}};
+  entries["TypeB"] = {{"file", fixtureFile.string()},
+                      {"mode", "Mode_B"},
+                      {"color", "#000002"}};
+  entries["TypeC"] = {{"file", fixtureFile.string()},
+                      {"mode", "mode-a"},
+                      {"color", "#000003"}};
+  WriteFile(dictPath,
+            DictionaryJsonContract::MakeRoot("fixtures", std::move(entries)).dump(4));
+
+  GdtfDictionary::UpdateColorForFile("TypeA", fixtureFile.string(), "MODE-A", "#ABCDEF");
+
+  auto dictAfterExplicitModeOpt = GdtfDictionary::Load();
+  assert(dictAfterExplicitModeOpt.has_value());
+  const auto &dictAfterExplicitMode = *dictAfterExplicitModeOpt;
+  assert(dictAfterExplicitMode.at("TypeA").color == "#ABCDEF");
+  assert(dictAfterExplicitMode.at("TypeC").color == "#ABCDEF");
+  assert(dictAfterExplicitMode.at("TypeB").color == "#000002");
+
+  GdtfDictionary::UpdateColorForFile("TypeA", fixtureFile.string(), {}, "#FEDCBA");
+
+  auto dictAfterEntryModeOpt = GdtfDictionary::Load();
+  assert(dictAfterEntryModeOpt.has_value());
+  const auto &dictAfterEntryMode = *dictAfterEntryModeOpt;
+  assert(dictAfterEntryMode.at("TypeA").color == "#FEDCBA");
+  assert(dictAfterEntryMode.at("TypeC").color == "#FEDCBA");
+  assert(dictAfterEntryMode.at("TypeB").color == "#000002");
+
+  std::filesystem::remove(fixtureFile);
+  if (hadOriginal)
+    WriteFile(dictPath, originalContent);
+  else
+    std::filesystem::remove(dictPath);
+
+  return 0;
+}

--- a/tests/gdtf_dictionary_color_mode_propagation_test.cpp
+++ b/tests/gdtf_dictionary_color_mode_propagation_test.cpp
@@ -45,6 +45,8 @@ int main() {
 
   const std::filesystem::path fixtureFile = fixturesDir / "mode_shared_fixture.gdtf";
   WriteFile(fixtureFile, "fixture");
+  const std::filesystem::path fixtureFileNew = fixturesDir / "mode_shared_fixture_new.gdtf";
+  WriteFile(fixtureFileNew, "fixture-new");
 
   nlohmann::json entries = nlohmann::json::object();
   entries["TypeA"] = {{"file", fixtureFile.string()},
@@ -88,6 +90,30 @@ int main() {
   assert(dictAfterNewType.at("TypeB").color == "#000002");
   assert(dictAfterNewType.at("TypeNotInDictionary").color == "#123456");
 
+  nlohmann::json migratedEntries = nlohmann::json::object();
+  migratedEntries["TypeA"] = {{"file", fixtureFile.string()},
+                              {"mode", "Mode A"},
+                              {"color", "#100000"}};
+  migratedEntries["TypeB"] = {{"file", fixtureFile.string()},
+                              {"mode", "Mode_B"},
+                              {"color", "#200000"}};
+  migratedEntries["TypeC"] = {{"file", fixtureFileNew.string()},
+                              {"mode", "Mode A"},
+                              {"color", "#300000"}};
+  WriteFile(dictPath, DictionaryJsonContract::MakeRoot("fixtures", std::move(migratedEntries))
+                         .dump(4));
+
+  GdtfDictionary::UpdateColorForFile("TypeA", fixtureFileNew.string(), "Mode A",
+                                     "#654321");
+  auto dictAfterPathRefreshOpt = GdtfDictionary::Load();
+  assert(dictAfterPathRefreshOpt.has_value());
+  const auto &dictAfterPathRefresh = *dictAfterPathRefreshOpt;
+  assert(dictAfterPathRefresh.at("TypeA").path == fixtureFileNew.string());
+  assert(dictAfterPathRefresh.at("TypeA").color == "#654321");
+  assert(dictAfterPathRefresh.at("TypeC").color == "#654321");
+  assert(dictAfterPathRefresh.at("TypeB").color == "#200000");
+
+  std::filesystem::remove(fixtureFileNew);
   std::filesystem::remove(fixtureFile);
   if (hadOriginal)
     WriteFile(dictPath, originalContent);


### PR DESCRIPTION
### Motivation
- Prevent accidental color propagation between entries that share the same GDTF file but represent different fixture modes by including `mode` in the propagation equivalence check. 

### Description
- Add a normalized mode helper (`NormalizeModeKey` / `ModesMatchForDictionaryEntries`) and require mode equivalence when propagating colors in `core/gdtfdictionary.cpp`. 
- Change `UpdateColorForFile(...)` signature to accept an explicit `mode` parameter and use it (or fall back to the entry's stored `mode`) when selecting targets for propagation, and update `UpdateColor(...)` to call the new signature. 
- Ensure the entry being updated stores the provided `mode` when present. 
- Add a new test `tests/gdtf_dictionary_color_mode_propagation_test.cpp` and register it in `tests/CMakeLists.txt` to cover: same file + different mode (no propagation) and same file + same normalized mode (propagation occurs).

### Testing
- Ran repository checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both succeeded. 
- Attempted to configure the test build with `cmake --preset wsl-x64-debug`, but configuration failed in this environment due to missing `wxWidgets` (`wxWidgets_LIBRARIES` / `wxWidgets_INCLUDE_DIRS`), so C++ tests were not compiled/executed here. 
- Added the new unit test and wired it into `tests/CMakeLists.txt` so it will run in CI once the build environment provides `wxWidgets`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d584465524832489146e6f64f05e4b)