### PR TITLE
Use fixture dictionary defaults when auto-coloring selected fixtures

### DIFF
--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -508,6 +508,39 @@ std::optional<Entry> Get(const std::string &type) {
   return it->second;
 }
 
+std::optional<std::string> GetDefaultColorForFixture(
+    const std::string &type, const std::string &gdtfPath,
+    const std::string &mode) {
+  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
+  auto dictOpt = Load();
+  if (!dictOpt)
+    return std::nullopt;
+  const auto &dict = *dictOpt;
+
+  const std::string normalizedType = NormalizeTypeKey(type);
+  if (!normalizedType.empty()) {
+    if (auto keyOpt = FindEquivalentTypeKey(dict, normalizedType)) {
+      auto byType = dict.find(*keyOpt);
+      if (byType != dict.end() && !byType->second.color.empty())
+        return byType->second.color;
+    }
+  }
+
+  std::optional<std::string> matchedColor;
+  std::string matchedKey;
+  for (const auto &[entryType, entry] : dict) {
+    if (entry.color.empty())
+      continue;
+    if (!EntriesShareFixtureFamily(entry, gdtfPath, mode))
+      continue;
+    if (!matchedColor || entryType < matchedKey) {
+      matchedColor = entry.color;
+      matchedKey = entryType;
+    }
+  }
+  return matchedColor;
+}
+
 void Update(const std::string &type, const std::string &gdtfPath, const std::string &mode, const std::string &category) {
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
   const std::string normalizedType = NormalizeTypeKey(type);

--- a/core/gdtfdictionary.h
+++ b/core/gdtfdictionary.h
@@ -49,6 +49,13 @@ namespace GdtfDictionary {
     // Returns the stored entry for a given type if it exists and file exists.
     // If the file is missing, the entry is removed and std::nullopt returned.
     std::optional<Entry> Get(const std::string& type);
+    // Returns the default color for a fixture when present in dictionary.
+    // Lookup priority:
+    // 1) Explicit fixture type entry.
+    // 2) Any entry sharing the same GDTF file + mode fixture family.
+    std::optional<std::string> GetDefaultColorForFixture(
+        const std::string& type, const std::string& gdtfPath,
+        const std::string& mode);
     // Copies the gdtf file into the fixtures library and updates the dictionary
     void Update(const std::string& type, const std::string& gdtfPath, const std::string& mode = {}, const std::string& category = {});
     void UpdateCategory(const std::string& type, const std::string& category);

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -701,20 +701,40 @@ void MainWindow::OnAutoColor(wxCommandEvent &WXUNUSED(event)) {
   std::set<std::string> selectedFixtureSet(selectedFixtureIds.begin(),
                                            selectedFixtureIds.end());
 
-  std::map<std::string, std::string> typeColors;
+  auto buildFixtureGroupKey = [](const auto &fixture) {
+    return fixture.gdtfSpec + "\n" + fixture.gdtfMode;
+  };
+
+  std::map<std::string, std::string> fixtureGroupColors;
   for (auto &[uuid, f] : scene.fixtures) {
     if (hasFixtureSelection && selectedFixtureSet.find(uuid) == selectedFixtureSet.end())
       continue;
 
+    if (hasFixtureSelection) {
+      if (f.gdtfSpec.empty()) {
+        f.color = randHex();
+        continue;
+      }
+      const std::string groupKey = buildFixtureGroupKey(f);
+      auto existing = fixtureGroupColors.find(groupKey);
+      if (existing == fixtureGroupColors.end()) {
+        const auto dictColor = GdtfDictionary::GetDefaultColorForFixture(
+            f.typeName, f.gdtfSpec, f.gdtfMode);
+        const std::string chosenColor = dictColor ? *dictColor : randHex();
+        fixtureGroupColors[groupKey] = chosenColor;
+        f.color = chosenColor;
+      } else {
+        f.color = existing->second;
+      }
+      continue;
+    }
+
     if (!f.gdtfSpec.empty()) {
-      auto it = typeColors.find(f.gdtfSpec);
-      if (it == typeColors.end()) {
-        std::string c =
-            hasFixtureSelection ? randHex()
-                                : ((f.color.empty() || isWhiteColor(f.color))
-                                       ? randHex()
-                                       : f.color);
-        typeColors[f.gdtfSpec] = c;
+      auto it = fixtureGroupColors.find(buildFixtureGroupKey(f));
+      if (it == fixtureGroupColors.end()) {
+        const std::string c =
+            (f.color.empty() || isWhiteColor(f.color)) ? randHex() : f.color;
+        fixtureGroupColors[buildFixtureGroupKey(f)] = c;
         f.color = c;
       } else {
         f.color = it->second;


### PR DESCRIPTION
### Motivation
- When assigning auto-colors for selected fixtures the system should consult the fixtures dictionary and prefer any configured default color instead of always using a random fallback. 
- Keep consistency so fixtures that belong to the same GDTF+mode group receive the same color within a single operation. 

### Description
- Added `GdtfDictionary::GetDefaultColorForFixture(type, gdtfPath, mode)` which returns a color by priority: explicit type entry first, then any entry that shares the same GDTF file+mode fixture family (added to `core/gdtfdictionary.h` / `core/gdtfdictionary.cpp`).
- Updated `MainWindow::OnAutoColor` to consult the new dictionary API when fixtures are selected and to group fixtures by `gdtfSpec + gdtfMode` so a group gets a consistent chosen color while falling back to the existing random color logic when no dictionary color is available (`gui/mainwindow_menu.cpp`).
- Kept existing behavior for the non-selected (full-scan) path while reusing the same grouping key for consistent grouping behavior.
- Hotspot note: this change touches `gui/mainwindow_menu.cpp` which is above the soft file-size guardrail and should be split in a follow-up into a dedicated helper pair (for example `gui/mainwindow_auto_color.{h,cpp}`) to isolate color-assignment policy from menu routing. 

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d623eea2588324894dd9f14e8652e9)