### PR TITLE
Preserve fixture `color` when exporting dictionary snapshots and bundles

### DIFF
--- a/core/dictionary_bundle.cpp
+++ b/core/dictionary_bundle.cpp
@@ -168,7 +168,8 @@ nlohmann::json BuildFixturesEntriesJson(
 
   for (const auto &name : keys) {
     const auto &entry = dict.at(name);
-    if (entry.path.empty() && entry.mode.empty() && entry.category.empty())
+    if (entry.path.empty() && entry.mode.empty() && entry.category.empty() &&
+        entry.color.empty())
       continue;
 
     nlohmann::json outputEntry = nlohmann::json::object();
@@ -206,6 +207,8 @@ nlohmann::json BuildFixturesEntriesJson(
       outputEntry["mode"] = entry.mode;
     if (!entry.category.empty())
       outputEntry["category"] = entry.category;
+    if (!entry.color.empty())
+      outputEntry["color"] = entry.color;
 
     if (!outputEntry.empty())
       entries[name] = std::move(outputEntry);

--- a/gui/dictionaryeditdialog.cpp
+++ b/gui/dictionaryeditdialog.cpp
@@ -784,7 +784,8 @@ bool SaveFixturesSnapshotToFile(
   nlohmann::json entries = nlohmann::json::object();
   for (const auto &name : keys) {
     const auto &entry = dict.at(name);
-    if (entry.path.empty() && entry.mode.empty() && entry.category.empty())
+    if (entry.path.empty() && entry.mode.empty() && entry.category.empty() &&
+        entry.color.empty())
       continue;
     nlohmann::json obj;
     if (!entry.path.empty()) {
@@ -809,6 +810,8 @@ bool SaveFixturesSnapshotToFile(
       obj["mode"] = entry.mode;
     if (!entry.category.empty())
       obj["category"] = entry.category;
+    if (!entry.color.empty())
+      obj["color"] = entry.color;
     if (!obj.empty())
       entries[name] = obj;
   }


### PR DESCRIPTION
### Motivation
- Exporting fixtures dictionaries dropped `color` metadata and ignored entries that only had a `color`, which caused re-imports to lose colors and appear to overwrite dictionary entries without preserving color information.

### Description
- Serialize `color` when writing fixtures snapshot files in `SaveFixturesSnapshotToFile` (gui/dictionaryeditdialog.cpp) so exported JSON can include `color` for each entry. 
- Include `color` in portable bundle manifest/entries produced by `BuildFixturesEntriesJson` (core/dictionary_bundle.cpp) and allow entries that only contain a `color` to be exported. 
- Adjusted the filtering condition so entries are no longer skipped when they only contain `color`.
- Changes are limited to `gui/dictionaryeditdialog.cpp` and `core/dictionary_bundle.cpp` and are implemented in English with no architecture boundary changes.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.
- Import parsing already supported `color` (no changes required), so this aligns export behavior with existing import support.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d62d42b5e083249cfab586929d1b13)