### PR TITLE
Apply pending dictionary edits before export and harden fixture color/key parsing on import

### DIFF
--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -71,6 +71,41 @@ std::string NormalizeAsciiKey(std::string value) {
   return value;
 }
 
+std::optional<std::string> NormalizeHexColor(std::string raw) {
+  raw.erase(std::remove_if(raw.begin(), raw.end(),
+                           [](unsigned char ch) {
+                             return std::isspace(ch) != 0;
+                           }),
+            raw.end());
+  if (raw.empty())
+    return std::string();
+  if (raw.front() == '#')
+    raw.erase(raw.begin());
+  if (raw.size() != 6)
+    return std::nullopt;
+  for (char &ch : raw) {
+    if (!std::isxdigit(static_cast<unsigned char>(ch)))
+      return std::nullopt;
+    ch = static_cast<char>(std::toupper(static_cast<unsigned char>(ch)));
+  }
+  return "#" + raw;
+}
+
+std::optional<std::string> GetObjectStringByNormalizedKey(
+    const nlohmann::json &value, const std::string &key) {
+  if (!value.is_object())
+    return std::nullopt;
+  const std::string normalizedTarget = NormalizeAsciiKey(key);
+  for (auto it = value.begin(); it != value.end(); ++it) {
+    if (!it.value().is_string())
+      continue;
+    if (NormalizeAsciiKey(it.key()) != normalizedTarget)
+      continue;
+    return it.value().get<std::string>();
+  }
+  return std::nullopt;
+}
+
 std::string NormalizeModeKey(const std::string &mode) {
   return NormalizeAsciiKey(mode);
 }
@@ -253,10 +288,11 @@ LoadFromFile(const fs::path &file, std::string &error) {
     }
 
     std::string fname;
-    if (value.contains("file") && value["file"].is_string())
-      fname = value["file"].get<std::string>();
-    else if (value.contains("path") && value["path"].is_string())
-      fname = value["path"].get<std::string>();
+    if (const auto fileName = GetObjectStringByNormalizedKey(value, "file"))
+      fname = *fileName;
+    else if (const auto pathName =
+                 GetObjectStringByNormalizedKey(value, "path"))
+      fname = *pathName;
 
     if (!fname.empty()) {
       fs::path p = ResolveImportedPath(file, fname);
@@ -267,18 +303,26 @@ LoadFromFile(const fs::path &file, std::string &error) {
       }
       entry.path = p.string();
     }
-    if (value.contains("mode") && value["mode"].is_string())
-      entry.mode = value["mode"].get<std::string>();
-    if (value.contains("category") && value["category"].is_string())
-      entry.category = value["category"].get<std::string>();
-    if (value.contains("color") && value["color"].is_string())
-      entry.color = value["color"].get<std::string>();
-    if (value.contains("source") && value["source"].is_string())
-      entry.source = value["source"].get<std::string>();
-    if (value.contains("imported_at") && value["imported_at"].is_string())
-      entry.importedAt = value["imported_at"].get<std::string>();
-    if (value.contains("sha256") && value["sha256"].is_string())
-      entry.sha256 = value["sha256"].get<std::string>();
+    if (const auto modeText = GetObjectStringByNormalizedKey(value, "mode"))
+      entry.mode = *modeText;
+    if (const auto categoryText =
+            GetObjectStringByNormalizedKey(value, "category"))
+      entry.category = *categoryText;
+    if (const auto colorText = GetObjectStringByNormalizedKey(value, "color")) {
+      const auto normalizedColor = NormalizeHexColor(*colorText);
+      if (!normalizedColor.has_value()) {
+        entryError = "color must be #RRGGBB when provided";
+        return false;
+      }
+      entry.color = *normalizedColor;
+    }
+    if (const auto sourceText = GetObjectStringByNormalizedKey(value, "source"))
+      entry.source = *sourceText;
+    if (const auto importedAtText =
+            GetObjectStringByNormalizedKey(value, "imported_at"))
+      entry.importedAt = *importedAtText;
+    if (const auto shaText = GetObjectStringByNormalizedKey(value, "sha256"))
+      entry.sha256 = *shaText;
     if (entry.path.empty() && entry.mode.empty() && entry.category.empty() &&
         entry.color.empty()) {
       entryError =

--- a/gui/dictionaryeditdialog.cpp
+++ b/gui/dictionaryeditdialog.cpp
@@ -1722,6 +1722,9 @@ void DictionaryEditDialog::OnResetDictionary(wxCommandEvent &WXUNUSED(event)) {
 }
 
 bool DictionaryEditDialog::ExportFixturesDictionary() {
+  if (HasFixtureChanges() && !SaveFixtures())
+    return false;
+
   auto dictOpt = GdtfDictionary::Load();
   if (!dictOpt) {
     wxMessageBox("Could not load fixtures dictionary for export.",
@@ -1774,6 +1777,9 @@ bool DictionaryEditDialog::ExportFixturesDictionary() {
 }
 
 bool DictionaryEditDialog::ExportTrussesDictionary() {
+  if (HasTrussChanges() && !SaveTrusses())
+    return false;
+
   auto dictOpt = TrussDictionary::Load();
   if (!dictOpt) {
     wxMessageBox("Could not load trusses dictionary for export.",
@@ -1826,6 +1832,9 @@ bool DictionaryEditDialog::ExportTrussesDictionary() {
 }
 
 bool DictionaryEditDialog::ExportFixturesPortableBundle() {
+  if (HasFixtureChanges() && !SaveFixtures())
+    return false;
+
   auto dictOpt = GdtfDictionary::Load();
   if (!dictOpt) {
     wxMessageBox("Could not load fixtures dictionary for portable export.",
@@ -1857,6 +1866,9 @@ bool DictionaryEditDialog::ExportFixturesPortableBundle() {
 }
 
 bool DictionaryEditDialog::ExportTrussesPortableBundle() {
+  if (HasTrussChanges() && !SaveTrusses())
+    return false;
+
   auto dictOpt = TrussDictionary::Load();
   if (!dictOpt) {
     wxMessageBox("Could not load trusses dictionary for portable export.",


### PR DESCRIPTION
### Motivation
- Ensure exported dictionary snapshots/bundles include any pending edits made in the dictionary UI so users don't accidentally export stale data.
- Make import robust to minor JSON key variations (case, spaces, `_`, `-`) so third-party or hand-edited snapshots don't drop fields.
- Normalize and validate imported color values to prevent empty/invalid color propagation and to surface clear validation errors.

### Description
- In `gui/dictionaryeditdialog.cpp` call `SaveFixtures()` / `SaveTrusses()` when there are pending changes before any export action so exports always reflect the latest UI state (snapshot and portable bundle exports).
- In `core/gdtfdictionary.cpp` add `NormalizeHexColor()` to trim/validate/canonicalize hex colors into `#RRGGBB` uppercase format and reject malformed colors during import.
- In `core/gdtfdictionary.cpp` add `GetObjectStringByNormalizedKey()` and use normalized key lookup when parsing entry objects so keys like `Color`, `imported-at`, or `Imported At` are accepted.
- Update parsing flow to validate `color` fields and to return a clear entry-level error for invalid colors instead of silently accepting bad data.

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which passed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6344060508324a6081861b7fdbceb)