### PR TITLE
docs: clarify Windows installer flow and optional .mvr association

### DIFF
--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -11,6 +11,44 @@ The official Windows installer workflow uses Inno Setup:
 - Compile the installer script in Inno Setup.
 - Optional associations can include `.pstg` and `.mvr`.
 
+### Recommended End-to-End Windows Installer Flow
+
+From a Developer PowerShell at repository root:
+
+```powershell
+cmake -S . -B out/build/x64-Release -G "Visual Studio 17 2022" -A x64
+cmake --build out/build/x64-Release --config Release
+cmake --build out/build/x64-Release --config Release --target perastage_stage
+```
+
+Then compile the Inno Setup script:
+
+```powershell
+iscc packaging/windows/Perastage.iss
+```
+
+The generated installer is written to:
+
+- `out/installer/Perastage_<version>_Setup.exe`
+
+### Enabling `.mvr` Association in the Installer
+
+The Inno Setup script already includes an optional task named `assoc_mvr`.
+
+- In interactive installer mode, enable the checkbox:
+  - **Associate .mvr files with Perastage (optional import workflow)**
+- In silent/automated installs, include task selection:
+  - `/TASKS="assoc_pstg,assoc_mvr"` (or only `assoc_mvr` if preferred)
+
+When selected, the installer registers:
+
+- ProgID: `Perastage.MVR`
+- Open command: `"Perastage.exe" "%1"`
+- Extension mapping: `.mvr -> Perastage.MVR`
+
+The uninstall behavior is conservative and removes Perastage-owned registration
+values without aggressively deleting global extension ownership.
+
 ### Association Notes
 
 - Installer writes association entries under `Software\Classes`.


### PR DESCRIPTION
### Motivation

- Clarify the recommended end-to-end Windows packaging workflow so packagers can reliably produce the Release installer and staged runtime bundle. 
- Document how to enable the existing `.mvr` file association from the installer UI and from silent/automated installs to ensure users can register MVR files with Perastage. 

### Description

- Added a `Recommended End-to-End Windows Installer Flow` section to `docs/packaging.md` with the exact `cmake` build commands and `perastage_stage` invocation needed to prepare `out/install/<CONFIG>` for packaging. 
- Documented the `iscc packaging/windows/Perastage.iss` step and the generated installer location `out/installer/Perastage_<version>_Setup.exe`. 
- Added an `Enabling .mvr Association in the Installer` section that explains the optional `assoc_mvr` task, the interactive checkbox, and the silent-install task selection flag `/TASKS="assoc_pstg,assoc_mvr"`. 
- This is a documentation-only change; the installer script `packaging/windows/Perastage.iss` already contains the `assoc_mvr` task and the registry entries (ProgID `Perastage.MVR`, open command, and `.mvr` mapping) so no code or installer script changes were made. 

### Testing

- Ran `tests/check_perastage_tree_modules.sh` which passed (`OK`). 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed (`OK`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d63b9933e0832482d709a919fcff89)