### PR TITLE
Update About dialog text to remove Vulkan mention

### DIFF
--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -965,12 +965,13 @@ void MainWindow::OnShowAbout(wxCommandEvent &WXUNUSED(event)) {
   info.SetName(app::kName);
   info.SetVersion(app::kVersionDisplay);
   wxString description =
-      "High-performance MVR scene viewer with 3D rendering support.\n\n"
+      "MVR viewer/editor with integrated 2D/3D workflows, MVR import/export, "
+      "and Create from text tools.\n\n"
       "This application makes use of the following open-source libraries:\n"
       "  - wxWidgets\n"
       "  - tinyxml2\n"
       "  - nlohmann-json\n"
-      "  - OpenGL (or Vulkan backend)";
+      "  - OpenGL-based 3D rendering";
   info.SetDescription(description);
   info.SetWebSite("https://luismaperamato.com");
   info.AddDeveloper("Luisma Peramato");


### PR DESCRIPTION
### Motivation
- Remove an outdated Vulkan mention from the About dialog and update the product blurb to better reflect the current product (MVR viewer/editor with integrated 2D/3D workflows, MVR import/export and Create from text).

### Description
- Change is limited to `MainWindow::OnShowAbout` in `gui/mainwindow_menu.cpp`, replacing the description text and changing the rendering line from "OpenGL (or Vulkan backend)" to "OpenGL-based 3D rendering".

### Testing
- Ran a global search for `Vulkan` (`rg -n "Vulkan" /workspace/Perastage`) with no remaining matches, and executed `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d69a57757483249a05ace5e768e1b3)