### PR TITLE
docs: mark Peraviz as experimental and move to Future/Experimental in feature/build guides

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -34,9 +34,9 @@ ctest --test-dir build
 - `perastage_stage`: stages runtime files in `out/install/<CONFIG>` for packaging.
 - `perastage_symbols`: collects symbol artifacts on supported Windows environments.
 
-## Optional Peraviz and DMX/Art-Net Integration
+## Future/Experimental: Optional Peraviz and DMX/Art-Net Integration
 
-Perastage can build optional Peraviz components when dependencies are present.
+Perastage can build optional Peraviz components when dependencies are present. This area is **experimental**, in an **early phase**, and **not part of the recommended main Perastage workflow**.
 
 ```bash
 cmake -S . -B build -DPERAVIZ_ENABLE_NATIVE=ON -DPERAVIZ_ENABLE_DMX=ON
@@ -45,7 +45,11 @@ cmake -S . -B build -DPERAVIZ_ENABLE_NATIVE=ON -DPERAVIZ_ENABLE_DMX=ON
 ### Notes
 
 - These options are not required for core Perastage workflows.
+- Treat Peraviz/DMX behavior as experimental and subject to change between revisions.
 - Ensure Python 3 and dependent toolchain pieces are discoverable when enabling native Peraviz builds.
+- See the dedicated docs for details (with the same maturity warning):
+  - [Peraviz DMX Input (Art-Net RX)](DMX_ARTNET.md)
+  - [DMX patch from MVR + Dimmer mapping from GDTF](DMX_PATCH_MVR_GDTF.md)
 
 ## Project File Format
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -143,10 +143,14 @@ Additional safeguards include:
 - Keyboard/mouse interaction includes viewer navigation, selection, and layout editing actions.
 - Detailed precedence and scope are tracked in [GUI shortcut architecture](gui_shortcut_architecture.md).
 
-## Build-Gated and Experimental Areas
+## Future/Experimental
 
 - Some tools remain Debug-only for production safety in Release builds.
-- Optional Peraviz and DMX/Art-Net integrations are available for advanced setups.
+- **Peraviz (including DMX/Art-Net integration) is experimental and in an early phase.**
+- **Peraviz is not part of the recommended main Perastage production workflow today.**
+- For teams evaluating this area, see:
+  - [Peraviz DMX Input (Art-Net RX)](DMX_ARTNET.md) *(experimental maturity; subject to change)*.
+  - [DMX patch from MVR + Dimmer mapping from GDTF](DMX_PATCH_MVR_GDTF.md) *(experimental maturity; subject to change)*.
 - Large-scene performance and selected advanced workflows continue to be iterated.
 
 ## Related Documents


### PR DESCRIPTION
### Motivation
- Move Peraviz/DMX messaging out of the main feature set and clearly label it experimental and early-phase so it is not presented as a stable part of the recommended Perastage workflow.

### Description
- Updated `docs/features.md` to add a `Future/Experimental` section that explicitly flags Peraviz (including DMX/Art‑Net) as experimental and links to `DMX_ARTNET.md` and `DMX_PATCH_MVR_GDTF.md`, and updated `docs/build.md` to rename the Peraviz section to `Future/Experimental: Optional Peraviz and DMX/Art-Net Integration` and add maturity warnings.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d69f3cbfdc83249187c29cb0c6aa0f)