### PR TITLE
docs: add Spanish help localization policy and normalize ES UI terms

### DIFF
--- a/docs/documentation_policy.md
+++ b/docs/documentation_policy.md
@@ -27,6 +27,30 @@ Use dedicated documents for deeper topics:
 - Use fenced code blocks for commands and snippets.
 - Write all documentation and code comments in English.
 
+## Localization Policy for Spanish Help (ES)
+
+When updating the Spanish block in `help.md` (`<!-- LANG:es -->`), keep UI terminology stable and searchable:
+
+- Do **not** translate exact UI labels for menus, panels, dialogs, tabs, and buttons.
+- Translate only explanatory narrative text around those labels.
+- Keep command names and option labels exactly as shown in the application UI.
+- Reuse the same canonical UI terms across all ES help sections.
+
+Minimum glossary of terms that must remain untranslated:
+
+| Keep in English | Notes |
+| --- | --- |
+| `Fixtures` | Tab/panel label. |
+| `Trusses` | Tab/panel label. |
+| `Hoists` | Tab/panel label. |
+| `Objects` | Tab/panel label. |
+| `Render style` | 3D Viewer context-menu entry. |
+| `Create from text` | Tools workflow entry. |
+| `Apply filter` | Create-from-text action button. |
+| `Create` | Create-from-text action button. |
+| `File`, `Edit`, `View`, `Tools` | Menu names. |
+| `Console`, `Layers`, `Layouts`, `Summary`, `Rigging`, `2D Viewer`, `3D Viewer`, `2D Render Options`, `Layout View` | Panel/view names. |
+
 ## Cross-Linking Rules
 
 - Avoid duplicating large sections across files.

--- a/help.md
+++ b/help.md
@@ -263,10 +263,10 @@ Los proyectos de Perastage (`.pstg`) guardan la escena, los layouts y la configu
 
 **File > New / Load / Save / Save As...**
 
-- **Nuevo** crea un proyecto en blanco.
-- **Cargar** abre un `.pstg` existente.
-- **Guardar** guarda los cambios en el proyecto actual.
-- **Guardar como...** guarda el proyecto con otro nombre o en otra ubicación.
+- **New** crea un proyecto en blanco.
+- **Load** abre un `.pstg` existente.
+- **Save** guarda los cambios en el proyecto actual.
+- **Save As...** guarda el proyecto con otro nombre o en otra ubicación.
 
 ## Unidades (Métrico/Imperial)
 
@@ -379,7 +379,7 @@ Notas:
 | Home | Ir al inicio del input (después del prompt) |
 | Izquierda / Retroceso | No permite pasar antes del prompt |
 
-### Visor 3D (teclado)
+### 3D Viewer (teclado)
 
 | Atajo | Acción |
 | --- | --- |
@@ -390,14 +390,14 @@ Notas:
 | Numpad 5 | Resetear cámara |
 | Z | Encuadrar escena (ajustar todo a vista) |
 
-### Visor 2D (teclado)
+### 2D Viewer (teclado)
 
 | Atajo | Acción |
 | --- | --- |
 | Flechas | Desplazar vista |
 | Alt + flechas | Zoom +/- |
 
-### Vista Layout (teclado)
+### Layout View (teclado)
 
 | Atajo | Acción |
 | --- | --- |
@@ -406,7 +406,7 @@ Notas:
 
 ## Atajos de ratón (completo)
 
-### Visor 3D
+### 3D Viewer
 
 | Acción | Resultado |
 | --- | --- |
@@ -420,7 +420,7 @@ Notas:
 
 ## 3D Viewer > Render style
 
-Ábrelo desde el menú contextual del **3D Viewer**: click derecho dentro del visor 3D y luego **Render style**.
+Ábrelo desde el menú contextual del **3D Viewer**: click derecho dentro del **3D Viewer** y luego **Render style**.
 
 Estilos de render actuales:
 
@@ -444,7 +444,7 @@ Uso recomendado por estilo:
 - **By layer**: agrupación por color por capa; útil para validar organización por capas y flujos layer-based.
 - **By universe**: agrupación por color por universo DMX; útil para tareas de patch y depuración de distribución por universos.
 
-### Visor 2D
+### 2D Viewer
 
 | Acción | Resultado |
 | --- | --- |
@@ -455,7 +455,7 @@ Uso recomendado por estilo:
 | Ctrl + arrastrar izquierdo | Selección por rectángulo |
 | Arrastrar selección | Mover selección (se bloquea el eje inicial) |
 
-### Vista Layout
+### Layout View
 
 | Acción | Resultado |
 | --- | --- |


### PR DESCRIPTION
### Motivation

- Ensure the Spanish help block remains consistent, searchable, and aligned with the app UI by preventing accidental translation of exact UI labels. 
- Provide a small glossary and explicit rules so translators and maintainers reuse canonical terms and avoid ambiguity across `help.md` and other docs.

### Description

- Add a new `Localization Policy for Spanish Help (ES)` section to `docs/documentation_policy.md` defining that exact UI labels (menus, panels, dialogs, tabs, buttons, command names) must remain in English and that only explanatory narrative should be translated. 
- Include a minimum glossary of terms that must stay untranslated (for example: `Fixtures`, `Trusses`, `Hoists`, `Objects`, `Render style`, `Create from text`, `Apply filter`, `Create`, `File`, `Edit`, `View`, `Tools`, and key panel names). 
- Apply the policy to the Spanish block in `help.md` by normalizing UI labels/titles to the canonical English forms (e.g. `New / Load / Save / Save As...`, `3D Viewer`, `2D Viewer`, `Layout View`, and preserving `Render style`).

### Testing

- Ran `tests/check_perastage_tree_modules.sh` which completed successfully. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6a96e3c6483249810e976aa24e61b)