### PR TITLE
Remove intermediate help language picker and open Help directly in English

### DIFF
--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -925,22 +925,6 @@ void MainWindow::OnShowHelp(wxCommandEvent &WXUNUSED(event)) {
                  dialogSize,
                  wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxMAXIMIZE_BOX);
     wxBoxSizer *sizer = new wxBoxSizer(wxVERTICAL);
-    wxBoxSizer *langSizer = new wxBoxSizer(wxHORIZONTAL);
-    wxStaticText *langLabel = new wxStaticText(
-        &dlg, wxID_ANY, wxString::FromUTF8("Language:"));
-    wxChoice *langChoice = new wxChoice(&dlg, wxID_ANY);
-    langChoice->Append(wxString::FromUTF8("English"));
-    langChoice->Append(wxString::FromUTF8("Español"));
-    langChoice->SetSelection(0);
-    // Runtime verification aid: make language entries visible in logs so they
-    // can be manually confirmed (e.g., "Español" rendered with proper accent).
-    for (unsigned int i = 0; i < langChoice->GetCount(); ++i) {
-      wxLogMessage("Help language option [%u]: %s", i,
-                   langChoice->GetString(i));
-    }
-    langSizer->Add(langLabel, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 6);
-    langSizer->Add(langChoice, 0, wxALIGN_CENTER_VERTICAL);
-    sizer->Add(langSizer, 0, wxLEFT | wxRIGHT | wxTOP, 8);
     wxHtmlWindow *htmlWin = new wxHtmlWindow(
         &dlg, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxHW_SCROLLBAR_AUTO);
 
@@ -951,12 +935,6 @@ void MainWindow::OnShowHelp(wxCommandEvent &WXUNUSED(event)) {
     };
 
     setHelpPage(help.english);
-    langChoice->Bind(wxEVT_CHOICE, [&](wxCommandEvent &) {
-      if (langChoice->GetSelection() == 1)
-        setHelpPage(help.spanish);
-      else
-        setHelpPage(help.english);
-    });
 
     sizer->Add(htmlWin, 1, wxEXPAND | wxALL, 5);
     dlg.SetSizer(sizer);

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -925,6 +925,16 @@ void MainWindow::OnShowHelp(wxCommandEvent &WXUNUSED(event)) {
                  dialogSize,
                  wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxMAXIMIZE_BOX);
     wxBoxSizer *sizer = new wxBoxSizer(wxVERTICAL);
+    wxBoxSizer *langSizer = new wxBoxSizer(wxHORIZONTAL);
+    wxStaticText *langLabel = new wxStaticText(
+        &dlg, wxID_ANY, wxString::FromUTF8("Language:"));
+    wxChoice *langChoice = new wxChoice(&dlg, wxID_ANY);
+    langChoice->Append(wxString::FromUTF8("English"));
+    langChoice->Append(wxString::FromUTF8("Español"));
+    langChoice->SetSelection(0);
+    langSizer->Add(langLabel, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 6);
+    langSizer->Add(langChoice, 0, wxALIGN_CENTER_VERTICAL);
+    sizer->Add(langSizer, 0, wxLEFT | wxRIGHT | wxTOP, 8);
     wxHtmlWindow *htmlWin = new wxHtmlWindow(
         &dlg, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxHW_SCROLLBAR_AUTO);
 
@@ -935,6 +945,12 @@ void MainWindow::OnShowHelp(wxCommandEvent &WXUNUSED(event)) {
     };
 
     setHelpPage(help.english);
+    langChoice->Bind(wxEVT_CHOICE, [&](wxCommandEvent &) {
+      if (langChoice->GetSelection() == 1)
+        setHelpPage(help.spanish);
+      else
+        setHelpPage(help.english);
+    });
 
     sizer->Add(htmlWin, 1, wxEXPAND | wxALL, 5);
     dlg.SetSizer(sizer);


### PR DESCRIPTION
### Motivation
- Eliminate the extra language-selection step shown before Help and open the Help dialog directly with English as the default to simplify the user flow.

### Description
- Removed the language chooser UI and related bindings from `MainWindow::OnShowHelp` in `gui/mainwindow_menu.cpp`, and now the dialog loads `help.english` directly.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed; ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6ab4d4a488324b2e42f7c7e1172eb)