### PR TITLE
Ensure open/import warning dialogs are modal to main window

### DIFF
--- a/gui/mainwindow/controllers/mainwindow_io_controller.cpp
+++ b/gui/mainwindow/controllers/mainwindow_io_controller.cpp
@@ -57,7 +57,8 @@ bool MainWindowIoController::ImportMvrFromPath(const std::string &pathUtf8) {
     importDisabler.reset();
     if (owner_.GetStatusBar())
       owner_.SetStatusText("MVR import failed.", 0);
-    wxMessageBox("Failed to import MVR file.", "Error", wxICON_ERROR);
+    wxMessageBox("Failed to import MVR file.", "Error", wxOK | wxICON_ERROR,
+                 &owner_);
     if (owner_.consolePanel)
       owner_.consolePanel->AppendMessage("Failed to import " + filePath);
     return false;
@@ -124,7 +125,8 @@ bool MainWindowIoController::OpenPathFromCommandLine(
       return false;
 
     if (!owner_.LoadProjectFromPath(pathUtf8)) {
-      wxMessageBox("Failed to load project.", "Error", wxICON_ERROR);
+      wxMessageBox("Failed to load project.", "Error", wxOK | wxICON_ERROR,
+                   &owner_);
       if (owner_.GetStatusBar())
         owner_.SetStatusText("Project load failed.", 0);
       if (owner_.consolePanel) {
@@ -153,6 +155,6 @@ bool MainWindowIoController::OpenPathFromCommandLine(
   wxMessageBox("Unsupported startup file. Use " +
                    wxString::FromUTF8(ProjectUtils::PROJECT_EXTENSION) +
                    " or .mvr files.",
-               "Unsupported file", wxICON_WARNING);
+               "Unsupported file", wxOK | wxICON_WARNING, &owner_);
   return false;
 }

--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -156,7 +156,8 @@ void MainWindow::OnLoad(wxCommandEvent &event) {
   wxString path = dlg.GetPath();
   const std::filesystem::path selectedPath(path.ToStdWstring());
   if (!LoadProjectFromPath(Utf8StringFromPath(selectedPath)))
-    wxMessageBox("Failed to load project.", "Error", wxICON_ERROR);
+    wxMessageBox("Failed to load project.", "Error", wxOK | wxICON_ERROR,
+                 this);
 }
 
 bool MainWindow::OpenPathFromCommandLine(const std::string &path) {
@@ -183,7 +184,8 @@ void MainWindow::OnSave(wxCommandEvent &event) {
   FlushPendingFixtureSymbolLibraryUpdates();
   SaveUserConfigWithViewport2DState();
   if (!cfg.SaveProject(currentProjectPath))
-    wxMessageBox("Failed to save project.", "Error", wxICON_ERROR);
+    wxMessageBox("Failed to save project.", "Error", wxOK | wxICON_ERROR,
+                 this);
   else {
     ProjectUtils::SaveLastProjectPath(currentProjectPath);
     if (consolePanel)


### PR DESCRIPTION
### Motivation
- Prevent a reported UX failure where error/warning dialogs shown during project open/import or startup could be created without a parent and end up placed behind the main window while still blocking input, making the app appear frozen.

### Description
- Make `wxMessageBox` calls use an explicit parent and include `wxOK` in the flags in `MainWindow::OnLoad` and `MainWindow::OnSave` by updating `gui/mainwindow_io.cpp` so failures are shown with `this` as the parent.
- Make `wxMessageBox` calls in the IO controller use the main window owner by passing `&owner_` for MVR import failures, project load failures and unsupported-startup-file warnings in `gui/mainwindow/controllers/mainwindow_io_controller.cpp`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6aae310408324bd9fb5e5b272023a)