### PR TITLE
Auto-apply fixture auto-color at end of MVR import

### DIFF
--- a/gui/mainwindow/controllers/mainwindow_io_controller.cpp
+++ b/gui/mainwindow/controllers/mainwindow_io_controller.cpp
@@ -111,7 +111,12 @@ bool MainWindowIoController::ImportMvrFromPath(const std::string &pathUtf8) {
   ownerRef->currentProjectDisplayName = wxFileName(filePath).GetName();
   ProjectUtils::SaveLastProjectPath("");
   ownerRef->UpdateTitle();
-  ownerRef->RefreshAfterSceneChange();
+
+  // Keep import behavior aligned with the existing Tools > Auto color flow:
+  // once the MVR scene is loaded, trigger auto-color so fixture types without
+  // dictionary colors still receive a color by type/group.
+  wxCommandEvent autoColorEvent;
+  ownerRef->OnAutoColor(autoColorEvent);
 
   importProgress.reset();
   importOverlay.reset();


### PR DESCRIPTION
### Motivation
- Ensure that after a successful MVR import any fixture types that did not receive a color from the dictionary are assigned a deterministic/group color using the existing Auto color flow.

### Description
- Invoke the existing `MainWindow::OnAutoColor` flow at the end of `MainWindowIoController::ImportMvrFromPath` by calling `ownerRef->OnAutoColor(...)` so auto-coloring runs as the final import step.

### Testing
- Ran the mandatory checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7f3cbf30c8324a6637d75c7647bc2)