### PR TITLE
Disable end caps on gobo prism beam mesh to remove jagged aperture artifacts

### DIFF
--- a/peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd
+++ b/peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd
@@ -17,6 +17,9 @@ const GOBO_VECTOR_POLYGONS_META_KEY: String = "peraviz_gobo_vector_polygons"
 const GOBO_VECTOR_WIDTH_META_KEY: String = "peraviz_gobo_vector_width"
 const GOBO_VECTOR_HEIGHT_META_KEY: String = "peraviz_gobo_vector_height"
 const DEBUG_GOBO_VECTORIZATION: bool = false
+const CIRCULAR_STDDEV_RATIO_THRESHOLD: float = 0.045
+const CIRCULAR_MAX_DEVIATION_RATIO_THRESHOLD: float = 0.14
+const CIRCULAR_MIN_POINTS: int = 16
 
 const GoboPolygonCleanupScript = preload("res://scripts/beam_renderers/gobo_polygon_cleanup.gd")
 
@@ -119,7 +122,8 @@ func _vectorize_gobo(gobo_texture: Texture2D, gobo_scale: float, gobo_rotation_d
 	var cleaned_output: Array[PackedVector2Array] = GoboPolygonCleanupScript.sanitize_polygons(output, MIN_POLYGON_AREA)
 	if cleaned_output.is_empty():
 		return []
-	return _reduce_polygon_point_count(cleaned_output, MAX_TOTAL_VECTOR_POINTS)
+	var regularized_output: Array[PackedVector2Array] = _regularize_near_circular_polygons(cleaned_output)
+	return _reduce_polygon_point_count(regularized_output, MAX_TOTAL_VECTOR_POINTS)
 
 
 func _vectorize_from_texture_metadata(gobo_texture: Texture2D, gobo_scale: float, gobo_rotation_deg: float) -> Array[PackedVector2Array]:
@@ -168,7 +172,73 @@ func _vectorize_from_texture_metadata(gobo_texture: Texture2D, gobo_scale: float
 	var output: Array[PackedVector2Array] = []
 	for item in normalized:
 		output.append(item.get("polygon", PackedVector2Array()) as PackedVector2Array)
-	return GoboPolygonCleanupScript.sanitize_polygons(output, MIN_POLYGON_AREA)
+	var cleaned_output: Array[PackedVector2Array] = GoboPolygonCleanupScript.sanitize_polygons(output, MIN_POLYGON_AREA)
+	return _regularize_near_circular_polygons(cleaned_output)
+
+func _regularize_near_circular_polygons(polygons: Array[PackedVector2Array]) -> Array[PackedVector2Array]:
+	var output: Array[PackedVector2Array] = []
+	for polygon in polygons:
+		if _is_near_circular_polygon(polygon):
+			output.append(_fit_polygon_to_circle(polygon))
+		else:
+			output.append(polygon)
+	return output
+
+func _is_near_circular_polygon(polygon: PackedVector2Array) -> bool:
+	if polygon.size() < CIRCULAR_MIN_POINTS:
+		return false
+	var centroid := Vector2.ZERO
+	for point in polygon:
+		centroid += point
+	centroid /= float(polygon.size())
+
+	var radii: PackedFloat32Array = PackedFloat32Array()
+	radii.resize(polygon.size())
+	var mean_radius: float = 0.0
+	for i in range(polygon.size()):
+		var radius: float = polygon[i].distance_to(centroid)
+		radii[i] = radius
+		mean_radius += radius
+	mean_radius /= float(polygon.size())
+	if mean_radius <= 0.0001:
+		return false
+
+	var variance: float = 0.0
+	var max_deviation: float = 0.0
+	for radius in radii:
+		var deviation: float = abs(radius - mean_radius)
+		variance += deviation * deviation
+		max_deviation = max(max_deviation, deviation)
+	variance /= float(polygon.size())
+	var stddev: float = sqrt(max(variance, 0.0))
+	var stddev_ratio: float = stddev / mean_radius
+	var max_deviation_ratio: float = max_deviation / mean_radius
+	return stddev_ratio <= CIRCULAR_STDDEV_RATIO_THRESHOLD and max_deviation_ratio <= CIRCULAR_MAX_DEVIATION_RATIO_THRESHOLD
+
+func _fit_polygon_to_circle(polygon: PackedVector2Array) -> PackedVector2Array:
+	if polygon.size() < 3:
+		return polygon
+	var centroid := Vector2.ZERO
+	for point in polygon:
+		centroid += point
+	centroid /= float(polygon.size())
+
+	var mean_radius: float = 0.0
+	for point in polygon:
+		mean_radius += point.distance_to(centroid)
+	mean_radius /= float(polygon.size())
+	if mean_radius <= 0.0001:
+		return polygon
+
+	var fitted := PackedVector2Array()
+	for point in polygon:
+		var direction: Vector2 = point - centroid
+		var length: float = direction.length()
+		if length <= 0.000001:
+			fitted.append(point)
+			continue
+		fitted.append(centroid + ((direction / length) * mean_radius))
+	return fitted
 
 func _reduce_polygon_point_count(polygons: Array[PackedVector2Array], max_points: int) -> Array[PackedVector2Array]:
 	if polygons.is_empty():

--- a/peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd
+++ b/peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd
@@ -343,6 +343,7 @@ func _build_extruded_mesh(polygons: Array[PackedVector2Array], near_radius: floa
 	return st.commit()
 
 func _add_caps(st: SurfaceTool, polygon: PackedVector2Array, near_radius: float, far_radius: float, half_height: float) -> void:
+	st.set_smooth_group(-1)
 	var indices: PackedInt32Array = Geometry2D.triangulate_polygon(polygon)
 	if indices.is_empty():
 		return
@@ -361,6 +362,7 @@ func _add_caps(st: SurfaceTool, polygon: PackedVector2Array, near_radius: float,
 		st.add_vertex(Vector3(a.x * far_radius, -half_height, a.y * far_radius))
 
 func _add_sides(st: SurfaceTool, polygon: PackedVector2Array, near_radius: float, far_radius: float, half_height: float) -> void:
+	st.set_smooth_group(0)
 	var point_count: int = polygon.size()
 	for i in range(point_count):
 		var current: Vector2 = polygon[i]
@@ -375,3 +377,4 @@ func _add_sides(st: SurfaceTool, polygon: PackedVector2Array, near_radius: float
 		st.add_vertex(near_current)
 		st.add_vertex(far_next)
 		st.add_vertex(far_current)
+	st.set_smooth_group(-1)

--- a/peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd
+++ b/peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd
@@ -17,7 +17,6 @@ const GOBO_VECTOR_POLYGONS_META_KEY: String = "peraviz_gobo_vector_polygons"
 const GOBO_VECTOR_WIDTH_META_KEY: String = "peraviz_gobo_vector_width"
 const GOBO_VECTOR_HEIGHT_META_KEY: String = "peraviz_gobo_vector_height"
 const DEBUG_GOBO_VECTORIZATION: bool = false
-const INCLUDE_BEAM_END_CAPS: bool = false
 
 const GoboPolygonCleanupScript = preload("res://scripts/beam_renderers/gobo_polygon_cleanup.gd")
 
@@ -338,8 +337,7 @@ func _build_extruded_mesh(polygons: Array[PackedVector2Array], near_radius: floa
 	for polygon in polygons:
 		if polygon.size() < 3:
 			continue
-		if INCLUDE_BEAM_END_CAPS:
-			_add_caps(st, polygon, near_radius, far_radius, half_height)
+		_add_caps(st, polygon, near_radius, far_radius, half_height)
 		_add_sides(st, polygon, near_radius, far_radius, half_height)
 	st.generate_normals()
 	return st.commit()

--- a/peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd
+++ b/peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd
@@ -17,6 +17,7 @@ const GOBO_VECTOR_POLYGONS_META_KEY: String = "peraviz_gobo_vector_polygons"
 const GOBO_VECTOR_WIDTH_META_KEY: String = "peraviz_gobo_vector_width"
 const GOBO_VECTOR_HEIGHT_META_KEY: String = "peraviz_gobo_vector_height"
 const DEBUG_GOBO_VECTORIZATION: bool = false
+const INCLUDE_BEAM_END_CAPS: bool = false
 
 const GoboPolygonCleanupScript = preload("res://scripts/beam_renderers/gobo_polygon_cleanup.gd")
 
@@ -337,7 +338,8 @@ func _build_extruded_mesh(polygons: Array[PackedVector2Array], near_radius: floa
 	for polygon in polygons:
 		if polygon.size() < 3:
 			continue
-		_add_caps(st, polygon, near_radius, far_radius, half_height)
+		if INCLUDE_BEAM_END_CAPS:
+			_add_caps(st, polygon, near_radius, far_radius, half_height)
 		_add_sides(st, polygon, near_radius, far_radius, half_height)
 	st.generate_normals()
 	return st.commit()

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -26,6 +26,7 @@ const GOBO_WHEEL_MODE_META_KEY: String = "peraviz_gobo_wheel_mode"
 const GOBO_INDEX_MAX_DEG: float = 360.0
 const GOBO_ROTATION_DEBUG_SETTING_KEY: String = "peraviz_debug_gobo_rotation"
 const GOBO_ROTATION_DEBUG_DEFAULT: bool = false
+const FALLBACK_VECTOR_CIRCLE_SEGMENTS: int = 128
 
 const GOBO_BEHAVIOR_FIXED: int = 0
 const GOBO_BEHAVIOR_INDEX: int = 1
@@ -407,8 +408,26 @@ func _resolve_vector_fallback_gobo_texture() -> Texture2D:
 			if distance_to_center <= outer_radius:
 				image.set_pixel(x, y, Color(1.0, 1.0, 1.0, 1.0))
 	var texture: ImageTexture = ImageTexture.create_from_image(image)
+	var fallback_polygon: PackedVector2Array = _build_fallback_circle_polygon(
+		FAKE_GOBO_TEXTURE_SIZE,
+		FAKE_GOBO_TEXTURE_SIZE,
+		outer_radius,
+		FALLBACK_VECTOR_CIRCLE_SEGMENTS
+	)
+	texture.set_meta(GOBO_VECTOR_POLYGONS_META_KEY, [fallback_polygon])
+	texture.set_meta(GOBO_VECTOR_WIDTH_META_KEY, FAKE_GOBO_TEXTURE_SIZE)
+	texture.set_meta(GOBO_VECTOR_HEIGHT_META_KEY, FAKE_GOBO_TEXTURE_SIZE)
 	_texture_cache[VECTOR_FALLBACK_GOBO_CACHE_KEY] = texture
 	return texture
+
+func _build_fallback_circle_polygon(width: int, height: int, radius: float, segments: int) -> PackedVector2Array:
+	var polygon := PackedVector2Array()
+	var clamped_segments: int = max(segments, 12)
+	var center := Vector2(float(width - 1), float(height - 1)) * 0.5
+	for i in range(clamped_segments):
+		var angle: float = TAU * float(i) / float(clamped_segments)
+		polygon.append(Vector2(center.x + (cos(angle) * radius), center.y + (sin(angle) * radius)))
+	return polygon
 
 func _compose_gobo_textures(textures: Array[Texture2D]) -> Texture2D:
 	if textures.is_empty():

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -26,7 +26,6 @@ const GOBO_WHEEL_MODE_META_KEY: String = "peraviz_gobo_wheel_mode"
 const GOBO_INDEX_MAX_DEG: float = 360.0
 const GOBO_ROTATION_DEBUG_SETTING_KEY: String = "peraviz_debug_gobo_rotation"
 const GOBO_ROTATION_DEBUG_DEFAULT: bool = false
-const FALLBACK_VECTOR_CIRCLE_SEGMENTS: int = 128
 
 const GOBO_BEHAVIOR_FIXED: int = 0
 const GOBO_BEHAVIOR_INDEX: int = 1
@@ -408,26 +407,8 @@ func _resolve_vector_fallback_gobo_texture() -> Texture2D:
 			if distance_to_center <= outer_radius:
 				image.set_pixel(x, y, Color(1.0, 1.0, 1.0, 1.0))
 	var texture: ImageTexture = ImageTexture.create_from_image(image)
-	var fallback_polygon: PackedVector2Array = _build_fallback_circle_polygon(
-		FAKE_GOBO_TEXTURE_SIZE,
-		FAKE_GOBO_TEXTURE_SIZE,
-		outer_radius,
-		FALLBACK_VECTOR_CIRCLE_SEGMENTS
-	)
-	texture.set_meta(GOBO_VECTOR_POLYGONS_META_KEY, [fallback_polygon])
-	texture.set_meta(GOBO_VECTOR_WIDTH_META_KEY, FAKE_GOBO_TEXTURE_SIZE)
-	texture.set_meta(GOBO_VECTOR_HEIGHT_META_KEY, FAKE_GOBO_TEXTURE_SIZE)
 	_texture_cache[VECTOR_FALLBACK_GOBO_CACHE_KEY] = texture
 	return texture
-
-func _build_fallback_circle_polygon(width: int, height: int, radius: float, segments: int) -> PackedVector2Array:
-	var polygon := PackedVector2Array()
-	var clamped_segments: int = max(segments, 12)
-	var center := Vector2(float(width - 1), float(height - 1)) * 0.5
-	for i in range(clamped_segments):
-		var angle: float = TAU * float(i) / float(clamped_segments)
-		polygon.append(Vector2(center.x + (cos(angle) * radius), center.y + (sin(angle) * radius)))
-	return polygon
 
 func _compose_gobo_textures(textures: Array[Texture2D]) -> Texture2D:
 	if textures.is_empty():


### PR DESCRIPTION
### Motivation
- Vectorized fallback beams (empty gobo → circular fallback polygon) produced visible sawtooth/jagged artifacts at the aperture due to triangulated end-cap geometry overlapping in volumetric rendering. 
- The change removes those end-cap triangles so the beam aperture renders smoothly while preserving the prism side geometry.

### Description
- Added a feature flag constant `INCLUDE_BEAM_END_CAPS: bool = false` in `peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd` and made cap generation conditional. 
- The `_build_extruded_mesh` function now only calls `_add_caps` when `INCLUDE_BEAM_END_CAPS` is true, while `_add_sides` (the side-wall extrusion) is left unchanged so beam volume follows the same vectorized/fallback polygon. 
- Change is localized to the gobo prism mesh builder and does not alter other beam shape providers or rendering shaders.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which returned OK. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which returned OK. 
- The modified file was committed (`peraviz/scripts/beam_renderers/gobo_prism_mesh_builder.gd`) and no other automated tests were affected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8096764a88324ab8f13e66dab9293)