### PR TITLE
Gate legend data refresh behind dirty flag in LayoutViewerPanel

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -571,6 +571,7 @@ void LayoutViewerPanel::SetLayoutDefinition(
     captureInProgress = false;
     renderDirty = true;
     loadingRequested = true;
+    legendDataDirty_ = true;
     RefreshLegendData();
     InvalidateRenderIfFrameChanged(false);
     if (NeedsRenderRebuild())
@@ -590,6 +591,7 @@ void LayoutViewerPanel::SetLayoutDefinition(
     isLoading = false;
     legendItems_.clear();
     legendDataHash = 0;
+    legendDataDirty_ = false;
     pendingFitOnResize = true;
     ResetViewToFit();
     Refresh();
@@ -598,6 +600,7 @@ void LayoutViewerPanel::SetLayoutDefinition(
   }
   renderDirty = true;
   loadingRequested = true;
+  legendDataDirty_ = true;
   RefreshLegendData();
   pendingFitOnResize = true;
   ResetViewToFit();
@@ -735,7 +738,8 @@ void LayoutViewerPanel::OnPaint(wxPaintEvent &) {
       return;
     }
     SetCurrent(*glContext_);
-    RefreshLegendData();
+    if (legendDataDirty_)
+      RefreshLegendData();
     if (!renderPending && NeedsRenderRebuild()) {
       RequestRenderRebuild();
     }

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -315,6 +315,7 @@ private:
   std::unordered_map<int, ImageCache> imageCaches_;
   std::vector<LegendItem> legendItems_;
   size_t legendDataHash = 0;
+  bool legendDataDirty_ = true;
   bool pendingFitOnResize = true;
   bool pendingFrameCommit_ = false;
 

--- a/gui/layoutviewerpanel_legend.cpp
+++ b/gui/layoutviewerpanel_legend.cpp
@@ -680,6 +680,7 @@ void LayoutViewerPanel::OnEditLegend(wxCommandEvent &) {
   legend->showChannelColumn = dialog.GetShowChannelColumn();
   legend->itemSettings = dialog.GetItemSettings();
   layouts::LayoutManager::Get().UpdateLayoutLegend(currentLayout.name, *legend);
+  legendDataDirty_ = true;
   RefreshLegendData();
   RequestRenderRebuild();
   Refresh();
@@ -752,14 +753,23 @@ void LayoutViewerPanel::DrawLegendElement(
 }
 
 void LayoutViewerPanel::RefreshLegendData() {
-  if (currentLayout.legendViews.empty())
+  if (!legendDataDirty_)
     return;
+  if (currentLayout.legendViews.empty()) {
+    legendItems_.clear();
+    legendDataHash = 0;
+    legendDataDirty_ = false;
+    return;
+  }
   std::vector<LegendItem> items = BuildLegendItems();
   size_t newHash = HashLegendItems(items);
-  if (newHash == legendDataHash)
+  if (newHash == legendDataHash) {
+    legendDataDirty_ = false;
     return;
+  }
   legendItems_ = std::move(items);
   legendDataHash = newHash;
+  legendDataDirty_ = false;
   if (legendItems_.size() == 1 &&
       legendItems_.front().typeName == "No fixtures") {
     return;

--- a/gui/layoutviewerpanel_render_invalidation.cpp
+++ b/gui/layoutviewerpanel_render_invalidation.cpp
@@ -302,6 +302,8 @@ void LayoutViewerPanel::InvalidateRenderIfFrameChanged(bool includeSceneContent)
 }
 
 void LayoutViewerPanel::RefreshAfterSceneContentUpdate() {
+  legendDataDirty_ = true;
+  RefreshLegendData();
   viewRenderVersion++;
   captureInProgress = false;
 


### PR DESCRIPTION
### Motivation
- Avoid recomputing legend data on every paint by running `RefreshLegendData()` only when legend-related information actually changed.
- Reduce unnecessary work during repaints and ensure legend updates happen only after scene/layout/legend edits.
- Keep changes localized to layout viewer legend handling without expanding file responsibilities.

### Description
- Added a `bool legendDataDirty_` field to `LayoutViewerPanel` and initialized it to `true` in the panel state (`gui/layoutviewerpanel.h`).
- Replaced the unconditional call to `RefreshLegendData()` in `OnPaint` with a gated call that only runs when `legendDataDirty_` is set (`gui/layoutviewerpanel.cpp`).
- Marked and consumed the dirty flag at the places that change legend-affecting data: `SetLayoutDefinition` (layout changes and empty-layout handling), `RefreshAfterSceneContentUpdate` (scene updates), and `OnEditLegend` (legend edits) (`gui/layoutviewerpanel.cpp`, `gui/layoutviewerpanel_render_invalidation.cpp`, `gui/layoutviewerpanel_legend.cpp`).
- Updated `RefreshLegendData()` to return early if the flag is not set, to clear `legendItems_`/`legendDataHash` for empty legend lists, and to clear `legendDataDirty_` after applying updates (`gui/layoutviewerpanel_legend.cpp`).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8100d0bf48324a09131a24d5bf9d9)