### PR TITLE
Use Refresh for selection-only changes in SelectElementAtPosition

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -2708,6 +2708,28 @@ bool LayoutViewerPanel::AreTexturesReady() const {
 }
 
 bool LayoutViewerPanel::SelectElementAtPosition(const wxPoint &pos) {
+  const auto applySelectionChange = [&](SelectedElementType newType, int newId,
+                                        bool emitViewSelectionChanged) {
+    const bool selectionOnlyChange =
+        selectedElementType != newType || selectedElementId != newId;
+    const bool renderableContentChanged = false;
+
+    selectedElementType = newType;
+    selectedElementId = newId;
+
+    if (emitViewSelectionChanged) {
+      EmitViewSelectionChanged(newId);
+    }
+
+    if (selectionOnlyChange && !renderableContentChanged) {
+      Refresh();
+      return;
+    }
+
+    RequestRenderRebuild();
+    Refresh();
+  };
+
   const auto elements = BuildZOrderedElements();
   std::unordered_map<int, const layouts::Layout2DViewDefinition *> viewById;
   std::unordered_map<int, const layouts::LayoutLegendDefinition *> legendById;
@@ -2745,10 +2767,8 @@ bool LayoutViewerPanel::SelectElementAtPosition(const wxPoint &pos) {
           selectedElementId == legend->id) {
         return true;
       }
-      selectedElementType = SelectedElementType::Legend;
-      selectedElementId = legend->id;
-      RequestRenderRebuild();
-      Refresh();
+      applySelectionChange(SelectedElementType::Legend, legend->id,
+                           /*emitViewSelectionChanged=*/false);
       return true;
     }
 
@@ -2766,10 +2786,8 @@ bool LayoutViewerPanel::SelectElementAtPosition(const wxPoint &pos) {
           selectedElementId == table->id) {
         return true;
       }
-      selectedElementType = SelectedElementType::EventTable;
-      selectedElementId = table->id;
-      RequestRenderRebuild();
-      Refresh();
+      applySelectionChange(SelectedElementType::EventTable, table->id,
+                           /*emitViewSelectionChanged=*/false);
       return true;
     }
 
@@ -2787,10 +2805,8 @@ bool LayoutViewerPanel::SelectElementAtPosition(const wxPoint &pos) {
           selectedElementId == text->id) {
         return true;
       }
-      selectedElementType = SelectedElementType::Text;
-      selectedElementId = text->id;
-      RequestRenderRebuild();
-      Refresh();
+      applySelectionChange(SelectedElementType::Text, text->id,
+                           /*emitViewSelectionChanged=*/false);
       return true;
     }
 
@@ -2808,10 +2824,8 @@ bool LayoutViewerPanel::SelectElementAtPosition(const wxPoint &pos) {
           selectedElementId == image->id) {
         return true;
       }
-      selectedElementType = SelectedElementType::Image;
-      selectedElementId = image->id;
-      RequestRenderRebuild();
-      Refresh();
+      applySelectionChange(SelectedElementType::Image, image->id,
+                           /*emitViewSelectionChanged=*/false);
       return true;
     }
 
@@ -2829,11 +2843,8 @@ bool LayoutViewerPanel::SelectElementAtPosition(const wxPoint &pos) {
           selectedElementId == view->id) {
         return true;
       }
-      selectedElementType = SelectedElementType::View2D;
-      selectedElementId = view->id;
-      EmitViewSelectionChanged(view->id);
-      RequestRenderRebuild();
-      Refresh();
+      applySelectionChange(SelectedElementType::View2D, view->id,
+                           /*emitViewSelectionChanged=*/true);
       return true;
     }
   }


### PR DESCRIPTION
### Motivation
- Reduce unnecessary expensive render rebuilds when the user only changes the active selection in the layout viewer by distinguishing selection-only changes from changes that require re-rendering.  
- Preserve existing 2D view selection signaling so view selection events are still emitted without forcing a render cache rebuild.  

### Description
- Introduced a local helper `applySelectionChange` in `LayoutViewerPanel::SelectElementAtPosition` to centralize selection updates and signaling.  
- Added an explicit `selectionOnlyChange` condition and a `renderableContentChanged` flag (currently `false`) and call only `Refresh()` for selection-only transitions.  
- Kept `RequestRenderRebuild()` as the fallback path when `renderableContentChanged` is true so renderable content changes still trigger a rebuild.  
- Continued to call `EmitViewSelectionChanged` when a `View2D` element is selected so 2D view behavior is preserved; recommend extracting selection-handling into a small helper file if further logic is added because `gui/layoutviewerpanel.cpp` is a hotspot.  

### Testing
- Ran the mandatory module checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both succeeded.  
- No other automated tests were modified or run in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8128d1788832484ee59db1478ccf9)