### PR TITLE
Cache layout selection index for SelectElementAtPosition

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -493,6 +493,7 @@ void LayoutViewerPanel::SetLayoutDefinition(
   const bool sameLayoutName =
       !previousLayout.name.empty() && previousLayout.name == layout.name;
   currentLayout = layout;
+  InvalidateSelectionIndexCache();
   auto selectDefaultElement = [this]() {
     if (!currentLayout.view2dViews.empty()) {
       selectedElementType = SelectedElementType::View2D;
@@ -620,6 +621,49 @@ void LayoutViewerPanel::NotifyRenderReady() {
     event.SetEventObject(panel);
     wxPostEvent(panel, event);
   });
+}
+
+void LayoutViewerPanel::InvalidateSelectionIndexCache() {
+  selectionIndexCache_.dirty = true;
+}
+
+void LayoutViewerPanel::EnsureSelectionIndexCache() {
+  if (!selectionIndexCache_.dirty) {
+    return;
+  }
+
+  selectionIndexCache_.zOrderedElements = BuildZOrderedElements();
+
+  auto &viewById = selectionIndexCache_.viewById;
+  auto &legendById = selectionIndexCache_.legendById;
+  auto &eventTableById = selectionIndexCache_.eventTableById;
+  auto &textById = selectionIndexCache_.textById;
+  auto &imageById = selectionIndexCache_.imageById;
+
+  viewById.clear();
+  legendById.clear();
+  eventTableById.clear();
+  textById.clear();
+  imageById.clear();
+
+  viewById.reserve(currentLayout.view2dViews.size());
+  legendById.reserve(currentLayout.legendViews.size());
+  eventTableById.reserve(currentLayout.eventTables.size());
+  textById.reserve(currentLayout.textViews.size());
+  imageById.reserve(currentLayout.imageViews.size());
+
+  for (const auto &view : currentLayout.view2dViews)
+    viewById.emplace(view.id, &view);
+  for (const auto &legend : currentLayout.legendViews)
+    legendById.emplace(legend.id, &legend);
+  for (const auto &table : currentLayout.eventTables)
+    eventTableById.emplace(table.id, &table);
+  for (const auto &text : currentLayout.textViews)
+    textById.emplace(text.id, &text);
+  for (const auto &image : currentLayout.imageViews)
+    imageById.emplace(image.id, &image);
+
+  selectionIndexCache_.dirty = false;
 }
 
 std::vector<LayoutViewerPanel::ZOrderedElement>
@@ -1674,6 +1718,7 @@ void LayoutViewerPanel::OnBringToFront(wxCommandEvent &) {
     return;
   }
   layoutVersion++;
+  InvalidateSelectionIndexCache();
   renderDirty = true;
   RequestRenderRebuild();
   Refresh();
@@ -1764,6 +1809,7 @@ void LayoutViewerPanel::OnSendToBack(wxCommandEvent &) {
     return;
   }
   layoutVersion++;
+  InvalidateSelectionIndexCache();
   renderDirty = true;
   RequestRenderRebuild();
   Refresh();
@@ -2730,28 +2776,13 @@ bool LayoutViewerPanel::SelectElementAtPosition(const wxPoint &pos) {
     Refresh();
   };
 
-  const auto elements = BuildZOrderedElements();
-  std::unordered_map<int, const layouts::Layout2DViewDefinition *> viewById;
-  std::unordered_map<int, const layouts::LayoutLegendDefinition *> legendById;
-  std::unordered_map<int, const layouts::LayoutEventTableDefinition *>
-      eventTableById;
-  std::unordered_map<int, const layouts::LayoutTextDefinition *> textById;
-  std::unordered_map<int, const layouts::LayoutImageDefinition *> imageById;
-  viewById.reserve(currentLayout.view2dViews.size());
-  legendById.reserve(currentLayout.legendViews.size());
-  eventTableById.reserve(currentLayout.eventTables.size());
-  textById.reserve(currentLayout.textViews.size());
-  imageById.reserve(currentLayout.imageViews.size());
-  for (const auto &view : currentLayout.view2dViews)
-    viewById.emplace(view.id, &view);
-  for (const auto &legend : currentLayout.legendViews)
-    legendById.emplace(legend.id, &legend);
-  for (const auto &table : currentLayout.eventTables)
-    eventTableById.emplace(table.id, &table);
-  for (const auto &text : currentLayout.textViews)
-    textById.emplace(text.id, &text);
-  for (const auto &image : currentLayout.imageViews)
-    imageById.emplace(image.id, &image);
+  EnsureSelectionIndexCache();
+  const auto &elements = selectionIndexCache_.zOrderedElements;
+  const auto &viewById = selectionIndexCache_.viewById;
+  const auto &legendById = selectionIndexCache_.legendById;
+  const auto &eventTableById = selectionIndexCache_.eventTableById;
+  const auto &textById = selectionIndexCache_.textById;
+  const auto &imageById = selectionIndexCache_.imageById;
   for (auto it = elements.rbegin(); it != elements.rend(); ++it) {
     if (it->type == SelectedElementType::Legend) {
       auto legendIt = legendById.find(it->id);

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -269,6 +269,20 @@ private:
     size_t order = 0;
   };
 
+  struct SelectionIndexCache {
+    bool dirty = true;
+    std::vector<ZOrderedElement> zOrderedElements;
+    std::unordered_map<int, const layouts::Layout2DViewDefinition *> viewById;
+    std::unordered_map<int, const layouts::LayoutLegendDefinition *>
+        legendById;
+    std::unordered_map<int, const layouts::LayoutEventTableDefinition *>
+        eventTableById;
+    std::unordered_map<int, const layouts::LayoutTextDefinition *> textById;
+    std::unordered_map<int, const layouts::LayoutImageDefinition *> imageById;
+  };
+
+  void InvalidateSelectionIndexCache();
+  void EnsureSelectionIndexCache();
   std::vector<ZOrderedElement> BuildZOrderedElements() const;
   std::pair<int, int> GetZIndexRange() const;
   bool IsLayoutEmpty() const;
@@ -318,6 +332,7 @@ private:
   bool legendDataDirty_ = true;
   bool pendingFitOnResize = true;
   bool pendingFrameCommit_ = false;
+  SelectionIndexCache selectionIndexCache_;
 
   wxDECLARE_EVENT_TABLE();
 };

--- a/gui/layoutviewerpanel_eventtable.cpp
+++ b/gui/layoutviewerpanel_eventtable.cpp
@@ -162,6 +162,7 @@ void LayoutViewerPanel::OnDeleteEventTable(wxCommandEvent &) {
                                     return entry.id == tableId;
                                   }),
                    tables.end());
+      InvalidateSelectionIndexCache();
       if (selectedElementId == tableId) {
         if (!currentLayout.view2dViews.empty()) {
           selectedElementType = SelectedElementType::View2D;

--- a/gui/layoutviewerpanel_image.cpp
+++ b/gui/layoutviewerpanel_image.cpp
@@ -186,6 +186,7 @@ void LayoutViewerPanel::OnDeleteImage(wxCommandEvent &) {
                                     return entry.id == imageId;
                                   }),
                    images.end());
+      InvalidateSelectionIndexCache();
       if (selectedElementId == imageId) {
         if (!currentLayout.view2dViews.empty()) {
           selectedElementType = SelectedElementType::View2D;

--- a/gui/layoutviewerpanel_legend.cpp
+++ b/gui/layoutviewerpanel_legend.cpp
@@ -631,6 +631,7 @@ void LayoutViewerPanel::OnDeleteLegend(wxCommandEvent &) {
                                      return entry.id == legendId;
                                    }),
                     legends.end());
+      InvalidateSelectionIndexCache();
       if (selectedElementId == legendId) {
         if (!currentLayout.view2dViews.empty()) {
           selectedElementType = SelectedElementType::View2D;

--- a/gui/layoutviewerpanel_text.cpp
+++ b/gui/layoutviewerpanel_text.cpp
@@ -176,6 +176,7 @@ void LayoutViewerPanel::OnDeleteText(wxCommandEvent &) {
                                    return entry.id == textId;
                                  }),
                   texts.end());
+      InvalidateSelectionIndexCache();
       if (selectedElementId == textId) {
         if (!currentLayout.view2dViews.empty()) {
           selectedElementType = SelectedElementType::View2D;

--- a/gui/layoutviewerpanel_view.cpp
+++ b/gui/layoutviewerpanel_view.cpp
@@ -96,6 +96,7 @@ void LayoutViewerPanel::OnDeleteView(wxCommandEvent &) {
                                    return entry.id == viewId;
                                  }),
                   views.end());
+      InvalidateSelectionIndexCache();
       if (selectedElementType == SelectedElementType::View2D &&
           selectedElementId == viewId) {
         if (!views.empty()) {


### PR DESCRIPTION
### Motivation
- Avoid rebuilding five id/type lookup maps on every hit-test to reduce CPU work during frequent `SelectElementAtPosition` calls.
- Preserve existing topmost selection semantics while making hit-testing cheaper by precomputing z-order and id lookups.

### Description
- Added a `SelectionIndexCache` in `LayoutViewerPanel` to store precomputed z-ordered elements and per-type id->definition maps and two helpers `InvalidateSelectionIndexCache()` and `EnsureSelectionIndexCache()`.
- Updated `SelectElementAtPosition` to call `EnsureSelectionIndexCache()` and reuse the cached z-order and maps instead of reconstructing maps per call.
- Invalidate the cache on layout structural or z-index changes from `SetLayoutDefinition`, `OnBringToFront`, `OnSendToBack`, and in delete handlers for views/legends/event tables/text/images so the cache is rebuilt on next hit-test.
- Changes touch `gui/layoutviewerpanel.h`, `gui/layoutviewerpanel.cpp`, and the per-element files `gui/layoutviewerpanel_view.cpp`, `gui/layoutviewerpanel_legend.cpp`, `gui/layoutviewerpanel_eventtable.cpp`, `gui/layoutviewerpanel_text.cpp`, and `gui/layoutviewerpanel_image.cpp` to trigger invalidation where appropriate.

### Testing
- Ran `./tests/check_perastage_tree_modules.sh` which returned OK.
- Ran `./tests/check_no_configmanager_get_in_gui.sh` which returned OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d81468a2d48324a74e08e48b667cdd)