### PR TITLE
Refresh layout legend when loading identical layout definition

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -485,6 +485,12 @@ void LayoutViewerPanel::SetLayoutDefinition(
     const layouts::LayoutDefinition &layout) {
   if (IsSameRenderableLayout(currentLayout, layout)) {
     currentLayout.name = layout.name;
+    legendDataDirty_ = true;
+    RefreshLegendData();
+    InvalidateRenderIfFrameChanged(true);
+    if (NeedsRenderRebuild())
+      RequestRenderRebuild();
+    Refresh();
     NotifyRenderReady();
     return;
   }


### PR DESCRIPTION
### Motivation
- When a layout definition identical in renderable fields is reloaded the previous early-return in `LayoutViewerPanel::SetLayoutDefinition` skipped legend synchronization which could leave the layout legend empty after project open/import.

### Description
- In `gui/layoutviewerpanel.cpp` inside `LayoutViewerPanel::SetLayoutDefinition` the early-return path now marks legend data dirty and forces a rebuild by setting `legendDataDirty_ = true` and calling `RefreshLegendData()` so legend rows are recalculated when the layout frames are unchanged.
- That path also calls `InvalidateRenderIfFrameChanged(true)` and conditionally triggers `RequestRenderRebuild()` when `NeedsRenderRebuild()` to ensure cached view/legend textures are invalidated when scene content changed, then calls `Refresh()` to update the UI.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d817601ba083248aeb04bc92fa2273)