### PR TITLE
Fix startup MVR path normalization for file association launches

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -64,11 +64,24 @@ std::string ToLowerAscii(std::string text) {
   return text;
 }
 
-std::optional<std::string> GetStartupPathFromArgs(int argc, wxChar **argv) {
+std::optional<std::string> GetStartupPathFromArgs(
+    int argc, wxChar **argv, const std::string &launchWorkingDirectoryUtf8) {
   namespace fs = std::filesystem;
   const std::string projectExtension = ToLowerAscii(ProjectUtils::PROJECT_EXTENSION);
+  const fs::path launchWorkingDirectory =
+      launchWorkingDirectoryUtf8.empty()
+          ? fs::path()
+          : fs::u8path(launchWorkingDirectoryUtf8);
+
+  auto toUtf8 = [](const wxString &text) {
+    wxCharBuffer utf8 = text.ToUTF8();
+    if (!utf8)
+      return text.ToStdString();
+    return std::string(utf8.data());
+  };
+
   for (int i = 1; i < argc; ++i) {
-    const std::string rawPath = wxString(argv[i]).ToStdString();
+    const std::string rawPath = toUtf8(wxString(argv[i]));
     if (rawPath.empty())
       continue;
 
@@ -80,7 +93,12 @@ std::optional<std::string> GetStartupPathFromArgs(int argc, wxChar **argv) {
       continue;
 
     std::error_code ec;
-    fs::path absolutePath = fs::absolute(candidate, ec);
+    fs::path absolutePath;
+    if (!candidate.is_absolute() && !launchWorkingDirectory.empty()) {
+      absolutePath = fs::absolute(launchWorkingDirectory / candidate, ec);
+    } else {
+      absolutePath = fs::absolute(candidate, ec);
+    }
     if (ec)
       return rawPath;
     const std::u8string absoluteU8 = absolutePath.u8string();
@@ -115,6 +133,12 @@ bool MyApp::OnInit() {
 #if defined(_MSC_VER) && defined(_DEBUG)
   ConfigureWindowsDebugHeapLeakCheck();
 #endif
+
+  const wxString launchCwdWx = wxFileName::GetCwd();
+  const wxCharBuffer launchCwdUtf8Buffer = launchCwdWx.ToUTF8();
+  const std::string launchWorkingDirectoryUtf8 =
+      launchCwdUtf8Buffer ? std::string(launchCwdUtf8Buffer.data())
+                          : launchCwdWx.ToStdString();
 
   SetAppName(app::kName);
   SetVendorName("Perasoft");
@@ -151,8 +175,8 @@ bool MyApp::OnInit() {
   // Start maximized so minimize and restore buttons remain available
   mainWindow->Maximize(true);
 
-  const std::optional<std::string> startupPathOpt =
-      GetStartupPathFromArgs(argc, argv);
+  const std::optional<std::string> startupPathOpt = GetStartupPathFromArgs(
+      argc, argv, launchWorkingDirectoryUtf8);
 
   SplashScreen::SetMessage("Loading last project...");
   wxWeakRef<MainWindow> mainWindowRef(mainWindow);


### PR DESCRIPTION
### Motivation
- Fix a discrepancy when launching the app by double-clicking a `.mvr` (file association) where relative/startup paths could be resolved incorrectly after the app changes CWD to the executable folder, causing hangs or failed imports.
- Ensure startup-open behavior matches the safe, robust path resolution used by in-app `Import`/`Open` flows.

### Description
- Capture the process launch working directory before the app sets CWD to the executable and pass it into the startup-argument parser via a new parameter `launchWorkingDirectoryUtf8`.
- Convert startup `wxString` arguments to UTF-8 using `ToUTF8()` when building `rawPath` to avoid locale-dependent `ToStdString()` behavior and preserve non-ASCII characters.
- When resolving a startup path, resolve relative paths against the original launch working directory instead of the post-init CWD by updating `GetStartupPathFromArgs(...)` logic.
- Change was applied only to `main.cpp` (startup argument parsing and `OnInit()` sequence adjustments).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (OK).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8e37a17148324a1060e87fdfeeec7)