### PR TITLE
Fix startup MVR open to use same import pipeline as in-app import

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1211,6 +1211,11 @@ void MainWindow::OnProjectLoaded(wxCommandEvent &event) {
   } else {
     ResetProject();
     RequestStartupSplashCompletion();
+    if (!path.empty()) {
+      CallAfter([this, startupPath = path]() {
+        OpenPathFromCommandLine(startupPath);
+      });
+    }
   }
   SetStartupProjectLoadPending(false);
 }

--- a/main.cpp
+++ b/main.cpp
@@ -183,13 +183,11 @@ bool MyApp::OnInit() {
   auto lastPathOpt = ProjectUtils::LoadLastProjectPath();
 
   if (startupPathOpt && mainWindowRef) {
-    QueueProjectLoadedEvent(mainWindowRef, false, false);
-    const std::string startupPath = *startupPathOpt;
-    mainWindow->CallAfter([mainWindowRef, startupPath]() {
-      if (!mainWindowRef)
-        return;
-      mainWindowRef->OpenPathFromCommandLine(startupPath);
-    });
+    // Route startup file opens through EVT_PROJECT_LOADED so startup-reset and
+    // command-line open cannot race each other. The actual open/import is
+    // deferred by MainWindow::OnProjectLoaded() after startup pending state is
+    // cleared.
+    QueueProjectLoadedEvent(mainWindowRef, false, false, *startupPathOpt);
   } else if (lastPathOpt) {
     std::string lastPath = *lastPathOpt;
     mainWindow->CallAfter([mainWindowRef, lastPath]() {


### PR DESCRIPTION
### Motivation
- Opening a `.mvr` by double-click at startup could race with the startup reset and initialization path, causing the app to appear frozen or to run import logic outside the guarded in-app import flow.

### Description
- Stop performing the immediate command-line open from `MyApp::OnInit`; instead enqueue the startup path in `QueueProjectLoadedEvent(...)` so opens are handled via `EVT_PROJECT_LOADED` in `MainWindow`.
- In `MainWindow::OnProjectLoaded`, when arriving at the empty/startup branch (`loaded == false`) defer `OpenPathFromCommandLine(path)` with `CallAfter(...)` after `ResetProject()` to ensure startup state is stable before running the import pipeline.
- This makes startup `.mvr` opens follow the same safe code path used by in-app import (`OpenPathFromCommandLine` -> `ImportMvrWithOfficialPolicy`), preserving existing UI/progress dialogs and conflict handling.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8e9c014e88324a5efdb8b2f7c61e6)