### PR TITLE
Aggregate MVR GroupObject preservation logs into a single count

### DIFF
--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -1388,6 +1388,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
   };
 
   // ---- Helper lambdas for object parsing ----
+  int preservedGroupObjectCount = 0;
   std::function<void(tinyxml2::XMLElement *, const std::string &, const Matrix &, const std::string &)>
       parseChildList;
 
@@ -2245,8 +2246,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
           scene.groupObjects[parentGroupUuid].children.push_back(
               {MvrNodeType::GroupObject, group.uuid});
         }
-        LogMessage(Logger::Level::Info,
-                   "MVR import preserved GroupObject uuid='" + group.uuid + "'");
+        ++preservedGroupObjectCount;
         if (tinyxml2::XMLElement *inner = child->FirstChildElement("ChildList"))
           parseChildList(inner, layerName, nodeTransform, group.uuid);
         continue;
@@ -2285,6 +2285,12 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
       }
       scene.layers[l.uuid] = l;
     }
+  }
+
+  if (preservedGroupObjectCount > 0) {
+    LogMessage(Logger::Level::Info,
+               "MVR import preserved GroupObject count=" +
+                   std::to_string(preservedGroupObjectCount));
   }
 
   auto resolveFixtureGdtfPathForRead = [&](const std::string &spec) {


### PR DESCRIPTION
### Motivation
- Reduce noisy per-object info logs during large MVR imports while retaining visibility into how many GroupObjects were preserved.

### Description
- Replace per-`GroupObject` `LogMessage` with a `preservedGroupObjectCount` accumulator in `mvr/mvrimporter.cpp` and emit a single final info log `MVR import preserved GroupObject count=<N>` when `N > 0`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both reported OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8fa6050ac8324812764787befa8d9)