### PR TITLE
Add progress feedback during rider text scene creation

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -1030,11 +1030,12 @@ std::string RiderImporter::LoadText(const std::string &path) {
   return {};
 }
 
-bool RiderImporter::Import(const std::string &path) {
+bool RiderImporter::Import(const std::string &path,
+                           ProgressCallback progressCallback) {
   std::string text = LoadText(path);
   if (text.empty())
     return false;
-  return ImportText(text);
+  return ImportText(text, std::move(progressCallback));
 }
 
 std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
@@ -1465,15 +1466,23 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
   return preview.str();
 }
 
-bool RiderImporter::ImportText(const std::string &text) {
+bool RiderImporter::ImportText(const std::string &text,
+                               ProgressCallback progressCallback) {
   if (text.empty())
     return false;
+  auto reportProgress = [&](std::string stage, int completed = 0, int total = 0) {
+    if (!progressCallback)
+      return;
+    progressCallback(ProgressState{std::move(stage), completed, total});
+  };
 
+  reportProgress("Filtering text...", 1, 6);
   // Keep scene creation consistent with the dialog preview flow:
   // import always consumes the same normalized text produced by the
   // filter pass used by "Apply filter".
   const std::string filteredText = BuildFixtureFilterPreview(text);
   const std::string &textToImport = filteredText.empty() ? text : filteredText;
+  reportProgress("Parsing lines...", 2, 6);
 
   ConfigManager &cfg = ConfigManager::Get();
   cfg.PushUndoState("import rider");
@@ -2518,6 +2527,7 @@ bool RiderImporter::ImportText(const std::string &text) {
     }
   }
 
+  reportProgress("Resolving rigging data...", 3, 6);
   for (const std::string &uuid : importedTrussUuids) {
     auto trussIt = scene.trusses.find(uuid);
     if (trussIt == scene.trusses.end())
@@ -2630,6 +2640,7 @@ bool RiderImporter::ImportText(const std::string &text) {
     }
   }
 
+  reportProgress("Placing imported scene objects...", 4, 6);
   // Distribute fixtures along their hang positions using available truss
   // information. Fixtures are arranged symmetrically and alternately by type,
   // leaving a configurable margin at the ends of the truss and placing them on
@@ -2928,6 +2939,7 @@ bool RiderImporter::ImportText(const std::string &text) {
     }
   }
 
+  reportProgress("Assigning fixture identities...", 5, 6);
   std::vector<Support *> importedSupports;
   importedSupports.reserve(importedSupportUuids.size());
   for (const std::string &uuid : importedSupportUuids) {
@@ -3296,5 +3308,6 @@ bool RiderImporter::ImportText(const std::string &text) {
   auto autoPref = cfg.GetValue("rider_autopatch");
   if (!autoPref || *autoPref != "0")
     AutoPatcher::AutoPatch(scene);
+  reportProgress("Completed.", 6, 6);
   return true;
 }

--- a/core/riderimporter.h
+++ b/core/riderimporter.h
@@ -17,18 +17,31 @@
  */
 #pragma once
 
+#include <functional>
 #include <string>
 
 // Parses simple rider files (.txt/.pdf) to create dummy fixtures and trusses
 class RiderImporter {
 public:
+    struct ProgressState {
+        std::string stage;
+        int completed = 0;
+        int total = 0;
+
+        bool HasCount() const { return total > 0; }
+    };
+
+    using ProgressCallback = std::function<void(const ProgressState&)>;
+
     // Import rider located at path. Returns true on success.
-    static bool Import(const std::string& path);
+    static bool Import(const std::string& path,
+                       ProgressCallback progressCallback = {});
     // Load rider file into text. Returns empty string on failure.
     static std::string LoadText(const std::string& path);
     // Build a filtered text preview that keeps only fixture lines that would be
     // considered during text-to-scene import.
     static std::string BuildFixtureFilterPreview(const std::string& text);
     // Import from raw rider text. Returns true on success.
-    static bool ImportText(const std::string& text);
+    static bool ImportText(const std::string& text,
+                           ProgressCallback progressCallback = {});
 };

--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -18,6 +18,7 @@
 #include "mainwindow.h"
 #include "mainwindow_io_controller.h"
 
+#include <algorithm>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
@@ -32,6 +33,7 @@
 #include <wx/busyinfo.h>
 #include <wx/filename.h>
 #include <wx/log.h>
+#include <wx/progdlg.h>
 #include <wx/utils.h>
 #include <wx/wfstream.h>
 #include <wx/zipstrm.h>
@@ -306,15 +308,47 @@ void MainWindow::OnImportRiderText(wxCommandEvent &WXUNUSED(event)) {
       std::make_unique<wxWindowDisabler>();
   std::unique_ptr<wxBusyInfo> createOverlay =
       std::make_unique<wxBusyInfo>("Generating scene from text...");
+  std::unique_ptr<wxProgressDialog> createProgress;
   wxYieldIfNeeded();
 
-  if (!RiderImporter::ImportText(riderText)) {
+  if (!RiderImporter::ImportText(
+          riderText, [&](const RiderImporter::ProgressState &progress) {
+            if (!GetStatusBar())
+              return;
+            const wxString stageText = wxString::FromUTF8(progress.stage);
+            if (progress.HasCount()) {
+              const int safeTotal = std::max(progress.total, 1);
+              const int clampedCompleted =
+                  std::clamp(progress.completed, 0, safeTotal);
+              if (!createProgress) {
+                createOverlay.reset();
+                createProgress = std::make_unique<wxProgressDialog>(
+                    "Text scene creation progress", stageText, safeTotal, this,
+                    wxPD_AUTO_HIDE | wxPD_SMOOTH | wxPD_APP_MODAL);
+              } else {
+                createProgress->SetRange(safeTotal);
+              }
+              createProgress->Update(clampedCompleted, stageText);
+              SetStatusText(
+                  wxString::Format("Text import: %s (%d/%d)", stageText,
+                                   clampedCompleted, safeTotal),
+                  0);
+            } else {
+              if (createProgress)
+                createProgress->Pulse(stageText);
+              SetStatusText("Text import: " + stageText, 0);
+            }
+            GetStatusBar()->Update();
+          })) {
     wxMessageBox("Failed to import rider text.", "Error", wxICON_ERROR);
     if (consolePanel)
       consolePanel->AppendMessage("[ERROR] Failed to import rider from text.");
+    if (GetStatusBar())
+      SetStatusText("Text import failed.", 0);
     return;
   }
 
+  createProgress.reset();
   if (consolePanel)
     consolePanel->AppendMessage("[INFO] Imported rider from text.");
   if (currentProjectPath.empty() && currentProjectDisplayName.IsEmpty()) {
@@ -324,6 +358,8 @@ void MainWindow::OnImportRiderText(wxCommandEvent &WXUNUSED(event)) {
       UpdateTitle();
     }
   }
+  if (GetStatusBar())
+    SetStatusText("Text import completed.", 0);
   RefreshAfterSceneChange();
 }
 


### PR DESCRIPTION
### Motivation
- Creating a scene from rider text can take noticeable time and currently looks like the UI is blocked; the goal is to provide visible progress similar to other long-running imports (MVR/project). 

### Description
- Added a callback-based `ProgressState` API and `ProgressCallback` typedef to `RiderImporter` and made `Import`/`ImportText` accept an optional progress callback while keeping the API backward-compatible. 
- Emitted stage updates at key points of the text import flow (filtering, parsing, rigging resolution, placement, fixture ID assignment and completion) and provided a small helper to report these stages. 
- Updated `MainWindow::OnImportRiderText` to show a modal `wxProgressDialog`, update the status bar with stage text and (x/y) counts when available, and to cleanly replace the previous static busy overlay with real progress feedback. 
- Modified files: `core/riderimporter.h`, `core/riderimporter.cpp`, and `gui/mainwindow_io.cpp`. 

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d91ba40ac48324aec6f850ab6b1a3d)