### PR TITLE
Fix startup MVR path UTF-8 decoding in project-loaded event

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1153,7 +1153,13 @@ void MainWindow::SyncLayerVisibilityPanels() {
 void MainWindow::OnProjectLoaded(wxCommandEvent &event) {
   bool loaded = event.GetInt() != 0;
   bool clearLastProject = event.GetExtraLong() != 0;
-  std::string path = event.GetString().ToStdString();
+  std::string path;
+  {
+    const wxString eventPath = event.GetString();
+    const wxCharBuffer eventPathUtf8 = eventPath.ToUTF8();
+    path = eventPathUtf8 ? std::string(eventPathUtf8.data())
+                         : eventPath.ToStdString();
+  }
   Ensure3DViewport();
   if (clearLastProject)
     ProjectUtils::SaveLastProjectPath("");


### PR DESCRIPTION
### Motivation
- Some MVR files failed to open when the app was launched by double-click because the startup path passed through `EVT_PROJECT_LOADED` was decoded with a locale-dependent conversion and could be corrupted for non-ASCII paths. 
- In-app imports used UTF-8 decoding, so the two entry paths were inconsistent and led to intermittent failures only for certain files/locations.

### Description
- Decode the `EVT_PROJECT_LOADED` event path using `wxString::ToUTF8()` with a `ToStdString()` fallback to preserve non-ASCII characters when building `path` in `MainWindow::OnProjectLoaded` (file `gui/mainwindow.cpp`).
- This makes external startup/double-click open routes produce the same UTF-8-safe path that in-app `wxFileDialog`-based imports already use, so the import/open pipeline receives a lossless path.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92433a1e4832490babbc16fc52640)