### PR TITLE
Load default layout templates when layout config is empty

### DIFF
--- a/core/layouts/LayoutManager.cpp
+++ b/core/layouts/LayoutManager.cpp
@@ -399,22 +399,29 @@ void LayoutManager::EndBatchUpdate() {
 }
 
 void LayoutManager::LoadFromConfig(ConfigManager &cfg) {
-  auto value = cfg.GetValue(kLayoutsConfigKey);
-  if (!value.has_value()) {
+  auto loadDefaultsOrFallback = [&cfg, this]() {
     if (!LoadDefaultsForNewProject(cfg))
       SaveToConfig(cfg);
+  };
+
+  auto value = cfg.GetValue(kLayoutsConfigKey);
+  if (!value.has_value()) {
+    loadDefaultsOrFallback();
     return;
   }
   nlohmann::json parsed;
   try {
     parsed = nlohmann::json::parse(*value);
   } catch (...) {
+    loadDefaultsOrFallback();
     return;
   }
   std::vector<LayoutDefinition> loaded;
   std::string parseError;
-  if (!FromTemplateDocument(parsed, loaded, &parseError))
+  if (!FromTemplateDocument(parsed, loaded, &parseError) || loaded.empty()) {
+    loadDefaultsOrFallback();
     return;
+  }
 
   for (auto &layout : loaded) {
     EnsureUniqueViewIds(layout);

--- a/core/layouts/LayoutManager.cpp
+++ b/core/layouts/LayoutManager.cpp
@@ -401,7 +401,8 @@ void LayoutManager::EndBatchUpdate() {
 void LayoutManager::LoadFromConfig(ConfigManager &cfg) {
   auto value = cfg.GetValue(kLayoutsConfigKey);
   if (!value.has_value()) {
-    SaveToConfig(cfg);
+    if (!LoadDefaultsForNewProject(cfg))
+      SaveToConfig(cfg);
     return;
   }
   nlohmann::json parsed;

--- a/docs/default_layout_templates.md
+++ b/docs/default_layout_templates.md
@@ -1,6 +1,6 @@
-# Default layout templates for new projects
+# Default layout templates
 
-Perastage can preload layout templates when creating a **new** project.
+Perastage can preload layout templates from `library/default_layouts/`.
 
 ## Folder
 
@@ -35,5 +35,10 @@ At load time, relative paths are resolved to absolute paths when the file exists
 
 ## Scope
 
-Template loading is only applied when the user uses **New Project**.
-It does not alter loading of existing project files.
+Template loading is applied when:
+
+- The user uses **New Project**.
+- The active config has no stored `layouts_collection` yet (for example first
+  launch with an empty config).
+
+If a project already has stored layouts, template files are ignored.

--- a/docs/default_layout_templates.md
+++ b/docs/default_layout_templates.md
@@ -40,5 +40,6 @@ Template loading is applied when:
 - The user uses **New Project**.
 - The active config has no stored `layouts_collection` yet (for example first
   launch with an empty config).
+- The stored `layouts_collection` value exists but is empty/invalid.
 
 If a project already has stored layouts, template files are ignored.

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -764,7 +764,7 @@ void MainWindow::LoadStartupProjectFromPath(const std::string &path) {
   const fs::path projectPath = fs::u8path(path);
   if (!fs::is_regular_file(projectPath, ec)) {
     ProjectUtils::SaveLastProjectPath("");
-    ResetProject();
+    ResetProject(true);
     SetStartupProjectLoadPending(false);
     RequestStartupSplashCompletion();
     return;
@@ -779,7 +779,7 @@ void MainWindow::LoadStartupProjectFromPath(const std::string &path) {
   if (!LoadProjectFromPath(path, false)) {
     fixtureSymbolAutoUpdateCompletionCallback = nullptr;
     ProjectUtils::SaveLastProjectPath("");
-    ResetProject();
+    ResetProject(true);
     RequestStartupSplashCompletion();
   }
 
@@ -1209,7 +1209,7 @@ void MainWindow::OnProjectLoaded(wxCommandEvent &event) {
     StartFixtureSymbolAutoUpdateForLoadedScene();
     UpdateTitle();
   } else {
-    ResetProject();
+    ResetProject(true);
     RequestStartupSplashCompletion();
     if (!path.empty()) {
       CallAfter([this, startupPath = path]() {

--- a/help.md
+++ b/help.md
@@ -21,6 +21,8 @@ Perastage projects (`.pstg`) store the scene, layouts, and user settings.
 - **New** creates a new project. If default layout templates are available in
   `library/default_layouts/`, they are loaded; otherwise Perastage keeps the
   built-in blank layout.
+- On first launch (or any empty config without stored layouts), Perastage also
+  attempts to preload `library/default_layouts/`.
 - **Load** opens an existing `.pstg` file.
 - **Save** stores changes in the current project file.
 - **Save As...** writes the project under a new name or location.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -145,6 +145,19 @@ target_link_libraries(layout_template_import_name_collision_test
 add_test(NAME LayoutTemplateImportNameCollision
          COMMAND layout_template_import_name_collision_test)
 
+add_executable(layout_defaults_load_from_empty_config_test
+               layout_defaults_load_from_empty_config_test.cpp
+               configmanager_layoutmanager_stub.cpp
+               ../core/layouts/LayoutManager.cpp
+               ../core/layouts/LayoutDefaultsLoader.cpp
+               ../core/projectutils.cpp
+               ../core/layouts/LayoutCollection.cpp
+               ../core/layouts/LayoutTemplateSerializer.cpp)
+target_link_libraries(layout_defaults_load_from_empty_config_test
+                      PRIVATE ${wxWidgets_LIBRARIES})
+add_test(NAME LayoutDefaultsLoadFromEmptyConfig
+         COMMAND layout_defaults_load_from_empty_config_test)
+
 function(set_library_env TEST_NAME)
     set_tests_properties(${TEST_NAME} PROPERTIES ENVIRONMENT "PERASTAGE_LIBRARY_PATH=${CMAKE_SOURCE_DIR}/library")
 endfunction()

--- a/tests/layout_defaults_load_from_empty_config_test.cpp
+++ b/tests/layout_defaults_load_from_empty_config_test.cpp
@@ -30,6 +30,31 @@ void WriteTemplateFile(const std::filesystem::path &filePath) {
   assert(out.good());
 }
 
+void SetLibraryEnv(const std::string &value) {
+#ifdef _WIN32
+  const int result = _putenv_s("PERASTAGE_LIBRARY_PATH", value.c_str());
+  assert(result == 0);
+#else
+  const int result = setenv("PERASTAGE_LIBRARY_PATH", value.c_str(), 1);
+  assert(result == 0);
+#endif
+}
+
+void RestoreLibraryEnv(const std::string &previousValue) {
+#ifdef _WIN32
+  const int result = _putenv_s("PERASTAGE_LIBRARY_PATH", previousValue.c_str());
+  assert(result == 0);
+#else
+  if (previousValue.empty()) {
+    const int result = unsetenv("PERASTAGE_LIBRARY_PATH");
+    assert(result == 0);
+    return;
+  }
+  const int result = setenv("PERASTAGE_LIBRARY_PATH", previousValue.c_str(), 1);
+  assert(result == 0);
+#endif
+}
+
 } // namespace
 
 int main() {
@@ -56,19 +81,23 @@ int main() {
       std::getenv("PERASTAGE_LIBRARY_PATH")
           ? std::getenv("PERASTAGE_LIBRARY_PATH")
           : "";
-  setenv("PERASTAGE_LIBRARY_PATH", tempRoot.c_str(), 1);
+  SetLibraryEnv(tempRoot.string());
 
   manager.LoadFromConfig(cfg);
 
-  const auto &layouts = manager.GetLayouts().Items();
+  auto layouts = manager.GetLayouts().Items();
   assert(layouts.size() == 1);
   assert(layouts.front().name == "Plan View");
   assert(cfg.HasKey(kLayoutsConfigKey));
 
-  if (previousEnv.empty())
-    unsetenv("PERASTAGE_LIBRARY_PATH");
-  else
-    setenv("PERASTAGE_LIBRARY_PATH", previousEnv.c_str(), 1);
+  manager.ResetToDefault(cfg);
+  cfg.SetValue(kLayoutsConfigKey, "");
+  manager.LoadFromConfig(cfg);
+  layouts = manager.GetLayouts().Items();
+  assert(layouts.size() == 1);
+  assert(layouts.front().name == "Plan View");
+
+  RestoreLibraryEnv(previousEnv);
 
   std::filesystem::remove_all(tempRoot, ec);
 

--- a/tests/layout_defaults_load_from_empty_config_test.cpp
+++ b/tests/layout_defaults_load_from_empty_config_test.cpp
@@ -1,0 +1,76 @@
+#include "LayoutManager.h"
+#include "configmanager.h"
+
+#include <cassert>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+
+namespace {
+
+constexpr const char *kLayoutsConfigKey = "layouts_collection";
+
+void WriteTemplateFile(const std::filesystem::path &filePath) {
+  std::ofstream out(filePath, std::ios::binary);
+  assert(out.is_open());
+  out << "{\n"
+         "  \"schemaVersion\": 1,\n"
+         "  \"layouts\": [\n"
+         "    {\n"
+         "      \"name\": \"Plan View\",\n"
+         "      \"view2dViews\": [\n"
+         "        {\n"
+         "          \"id\": 1,\n"
+         "          \"frame\": {\"x\": 0, \"y\": 0, \"width\": 100, \"height\": 100}\n"
+         "        }\n"
+         "      ]\n"
+         "    }\n"
+         "  ]\n"
+         "}\n";
+  assert(out.good());
+}
+
+} // namespace
+
+int main() {
+  auto &cfg = ConfigManager::Get();
+  cfg.ClearValues();
+
+  auto &manager = layouts::LayoutManager::Get();
+  manager.ResetToDefault(cfg);
+  cfg.RemoveKey(kLayoutsConfigKey);
+
+  const std::filesystem::path tempRoot =
+      std::filesystem::temp_directory_path() /
+      "perastage_layout_defaults_from_empty_config_test";
+  const std::filesystem::path defaultsDir = tempRoot / "default_layouts";
+  std::error_code ec;
+  std::filesystem::remove_all(tempRoot, ec);
+  std::filesystem::create_directories(defaultsDir, ec);
+  assert(!ec);
+
+  const std::filesystem::path templatePath = defaultsDir / "plan_view.json";
+  WriteTemplateFile(templatePath);
+
+  const std::string previousEnv =
+      std::getenv("PERASTAGE_LIBRARY_PATH")
+          ? std::getenv("PERASTAGE_LIBRARY_PATH")
+          : "";
+  setenv("PERASTAGE_LIBRARY_PATH", tempRoot.c_str(), 1);
+
+  manager.LoadFromConfig(cfg);
+
+  const auto &layouts = manager.GetLayouts().Items();
+  assert(layouts.size() == 1);
+  assert(layouts.front().name == "Plan View");
+  assert(cfg.HasKey(kLayoutsConfigKey));
+
+  if (previousEnv.empty())
+    unsetenv("PERASTAGE_LIBRARY_PATH");
+  else
+    setenv("PERASTAGE_LIBRARY_PATH", previousEnv.c_str(), 1);
+
+  std::filesystem::remove_all(tempRoot, ec);
+
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- Ensure default layout templates from `library/default_layouts/` are applied on first launch or when the active config has no stored `layouts_collection`, matching user expectations that shipped layouts appear without pressing New.

### Description
- Change `LayoutManager::LoadFromConfig` to call `LoadDefaultsForNewProject(cfg)` when `layouts_collection` is missing and only fall back to the built-in blank layout if no templates are found (file: `core/layouts/LayoutManager.cpp`).
- Add an automated test `layout_defaults_load_from_empty_config_test` that creates a temporary `default_layouts/plan_view.json`, sets `PERASTAGE_LIBRARY_PATH`, calls `LoadFromConfig` with an empty config and asserts the `Plan View` layout is loaded and `layouts_collection` is persisted (file: `tests/layout_defaults_load_from_empty_config_test.cpp`).
- Register the new test target in `tests/CMakeLists.txt` so it runs with the test suite.
- Update documentation to state that default templates are applied on `New Project` and when the config has no stored layouts (files: `docs/default_layout_templates.md`, `help.md`).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which succeeded (OK).
- Ran `tests/check_no_configmanager_get_in_gui.sh` which succeeded (OK).
- Attempted to configure, build and run the new test with `cmake -S . -B build && cmake --build build -j2 --target layout_defaults_load_from_empty_config_test && ./build/tests/layout_defaults_load_from_empty_config_test`, but CMake configuration failed in this environment due to missing `wxWidgets` development packages (missing `wxWidgets_LIBRARIES` / `wxWidgets_INCLUDE_DIRS`), so the new test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9260076c08324879554cb73ec430b)