### PR TITLE
Handle external .mvr opens correctly at startup and runtime

### DIFF
--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -71,6 +71,7 @@ public:
   void LoadStartupProjectFromPath(const std::string &path);
   bool OpenPathFromCommandLine(const std::string &path);
   void ResetProject(bool applyLayoutDefaultsForNewProject = false); // Clear current project
+  bool IsStartupProjectLoadPending() const { return startupProjectLoadPending; }
 
   static MainWindow *Instance();
   static void SetInstance(MainWindow *inst);

--- a/main.cpp
+++ b/main.cpp
@@ -26,6 +26,7 @@
 #include <atomic>
 #include <cctype>
 #include <cstdlib>
+#include <deque>
 #include <new>
 #include <optional>
 #include <string>
@@ -46,14 +47,18 @@ public:
   int FilterEvent(wxEvent &event) override;
   bool OnExceptionInMainLoop() override;
   void OnUnhandledException() override;
+  void MacOpenFile(const wxString &fileName);
 
 private:
+  void HandleExternalOpenPath(const std::string &pathUtf8);
+  std::optional<std::string> ConsumePendingExternalOpenPath();
   void QueueProjectLoadedEvent(const wxWeakRef<MainWindow> &mainWindowRef,
                                bool loaded, bool clearLastProject,
                                const std::string &path = {});
 
   std::string last_event_summary_;
   std::atomic<bool> project_load_event_sent_{false};
+  std::deque<std::string> pending_external_open_paths_;
 };
 
 namespace {
@@ -175,8 +180,10 @@ bool MyApp::OnInit() {
   // Start maximized so minimize and restore buttons remain available
   mainWindow->Maximize(true);
 
-  const std::optional<std::string> startupPathOpt = GetStartupPathFromArgs(
+  std::optional<std::string> startupPathOpt = GetStartupPathFromArgs(
       argc, argv, launchWorkingDirectoryUtf8);
+  if (!startupPathOpt)
+    startupPathOpt = ConsumePendingExternalOpenPath();
 
   SplashScreen::SetMessage("Loading last project...");
   wxWeakRef<MainWindow> mainWindowRef(mainWindow);
@@ -190,9 +197,13 @@ bool MyApp::OnInit() {
     QueueProjectLoadedEvent(mainWindowRef, false, false, *startupPathOpt);
   } else if (lastPathOpt) {
     std::string lastPath = *lastPathOpt;
-    mainWindow->CallAfter([mainWindowRef, lastPath]() {
+    mainWindow->CallAfter([this, mainWindowRef, lastPath]() {
       if (!mainWindowRef)
         return;
+      if (auto pendingOpenPath = ConsumePendingExternalOpenPath()) {
+        QueueProjectLoadedEvent(mainWindowRef, false, false, *pendingOpenPath);
+        return;
+      }
       mainWindowRef->LoadStartupProjectFromPath(lastPath);
     });
 
@@ -201,6 +212,45 @@ bool MyApp::OnInit() {
   }
 
   return true;
+}
+
+void MyApp::MacOpenFile(const wxString &fileName) {
+  const wxCharBuffer utf8 = fileName.ToUTF8();
+  const std::string pathUtf8 =
+      utf8 ? std::string(utf8.data()) : fileName.ToStdString();
+  HandleExternalOpenPath(pathUtf8);
+}
+
+void MyApp::HandleExternalOpenPath(const std::string &pathUtf8) {
+  if (pathUtf8.empty())
+    return;
+
+  MainWindow *mainWindow = wxDynamicCast(GetTopWindow(), MainWindow);
+  if (!mainWindow) {
+    pending_external_open_paths_.push_back(pathUtf8);
+    return;
+  }
+
+  const bool startupPending = mainWindow->IsStartupProjectLoadPending();
+  if (startupPending) {
+    pending_external_open_paths_.push_back(pathUtf8);
+    return;
+  }
+
+  mainWindow->CallAfter([windowRef = wxWeakRef<MainWindow>(mainWindow),
+                         pathUtf8]() {
+    if (!windowRef)
+      return;
+    windowRef->OpenPathFromCommandLine(pathUtf8);
+  });
+}
+
+std::optional<std::string> MyApp::ConsumePendingExternalOpenPath() {
+  if (pending_external_open_paths_.empty())
+    return std::nullopt;
+  std::string path = pending_external_open_paths_.front();
+  pending_external_open_paths_.pop_front();
+  return path;
 }
 
 int MyApp::OnExit() {


### PR DESCRIPTION
### Motivation
- Ensure OS-level `.mvr` open events follow the same deterministic import/reset policy as in-app `Import MVR`, and avoid prompting to save or loading the previous project when the app is launched by double-clicking a `.mvr` file.
- When Perastage is already running, external `.mvr` opens should behave like an explicit in-app import (including save-confirmation) rather than silently replacing or resetting state.

### Description
- Added OS open-file routing in `MyApp` including `MacOpenFile(...)`, a pending external-open queue, and helpers `HandleExternalOpenPath(...)` and `ConsumePendingExternalOpenPath()` to defer or route external paths safely (`main.cpp`).
- Integrated pending external-path consumption into the startup path selection so a pending external `.mvr` is used instead of automatically loading the last project (`main.cpp`).
- When the main window exists and startup loading is finished, external paths are routed to `MainWindow::OpenPathFromCommandLine(...)` via `CallAfter` to preserve the existing import/save-confirmation behavior (`main.cpp`).
- Added `MainWindow::IsStartupProjectLoadPending()` accessor to let app-level routing avoid dispatching external opens while the startup project load is still pending (`gui/mainwindow.h`).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it completed successfully (OK).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it completed successfully (OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d932bad2fc832492f5b5baa6d4206e)