### PR TITLE
Apply auto color after text-based scene creation

### DIFF
--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -452,6 +452,16 @@ At the end of import:
 - Auto-patch runs by default.
 - It is skipped only when config `rider_autopatch = 0`.
 
+## Auto-color behavior after text scene creation
+
+After a successful **Tools → Create from text** import:
+
+- The same **Auto color** routine used after MVR import is executed.
+- Fixture/layer colors are normalized immediately, including fallback random
+  colors for fixture groups with no dictionary color.
+- This runs before the final scene refresh, so users see the colored result as
+  soon as text import completes.
+
 ## Config keys that affect import
 
 - `rider_layer_mode` (`position` or `type`)

--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -351,6 +351,11 @@ void MainWindow::OnImportRiderText(wxCommandEvent &WXUNUSED(event)) {
   createProgress.reset();
   if (consolePanel)
     consolePanel->AppendMessage("[INFO] Imported rider from text.");
+  // Keep behavior aligned with MVR import: assign deterministic colors after
+  // scene creation so fixtures without dictionary colors are still grouped by
+  // fixture type/mode.
+  wxCommandEvent autoColorEvent;
+  OnAutoColor(autoColorEvent);
   if (currentProjectPath.empty() && currentProjectDisplayName.IsEmpty()) {
     const wxString loadedFileTitle = dlg.GetLoadedFileTitle();
     if (!loadedFileTitle.IsEmpty()) {
@@ -360,7 +365,6 @@ void MainWindow::OnImportRiderText(wxCommandEvent &WXUNUSED(event)) {
   }
   if (GetStatusBar())
     SetStatusText("Text import completed.", 0);
-  RefreshAfterSceneChange();
 }
 
 // Handles MVR file selection, import, and updates fixture/truss panels


### PR DESCRIPTION
### Motivation
- Make the visual result of `Tools → Create from text` consistent with MVR imports by assigning fixture and layer colors automatically after scene creation.
- Ensure fixtures without dictionary colors are deterministically grouped and visible with colors immediately after text-based creation.

### Description
- Call `OnAutoColor(...)` after a successful `RiderImporter::ImportText` run in `gui/mainwindow_io.cpp` so the same auto-color routine used for MVR import is executed for text-created scenes.
- Remove the redundant final refresh in the text-import path because `OnAutoColor` already updates the scene state and refreshes the view.
- Document the new post-import behavior in `docs/text_to_scene_rules.md` under a new `Auto-color behavior after text scene creation` section.
- Modified files: `gui/mainwindow_io.cpp` and `docs/text_to_scene_rules.md`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it exited OK.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it exited OK.
- Verified the text-import flow triggers `OnAutoColor` and that scene refresh is not duplicated during the import sequence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9375baf448324b299e8bc4e0f32b8)