### PR TITLE
Enable Generate Fixture Symbols in release builds

### DIFF
--- a/gui/ui_feature_flags.cpp
+++ b/gui/ui_feature_flags.cpp
@@ -34,9 +34,10 @@ namespace ui {
 
 bool IsFeatureEnabled(FeatureFlag flag) {
   switch (flag) {
+  case FeatureFlag::GenerateFixtureSymbols:
+    return true;
   case FeatureFlag::PrintViewer2DDialog:
   case FeatureFlag::PrintViewer2DElementsDetail:
-  case FeatureFlag::GenerateFixtureSymbols:
   case FeatureFlag::AssignSelectedFixtureCategory:
     return kIsDebugBuild;
   }


### PR DESCRIPTION
### Motivation
- Allow the "Generate Fixture Symbols" menu item to be visible in Release by enabling its feature flag at the centralized gating point `ui::IsFeatureEnabled(...)`.

### Description
- Updated `gui/ui_feature_flags.cpp` so `ui::IsFeatureEnabled(FeatureFlag::GenerateFixtureSymbols)` returns `true` unconditionally while keeping other flags (`PrintViewer2DDialog`, `PrintViewer2DElementsDetail`, `AssignSelectedFixtureCategory`) gated by `kIsDebugBuild`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d93977db288324a2cbf1f35aa89b10)