### PR TITLE
Isolate symbol capture render style from 3D preference

### DIFF
--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -17,7 +17,6 @@
 #include <algorithm>
 #include <cmath>
 #include "configmanager.h"
-#include "viewer3d_render_style.h"
 
 namespace {
 struct InkColor {
@@ -37,20 +36,6 @@ LineRenderProfile GetLineRenderProfile(bool isInteracting, bool wireframeMode,
   if (!adaptiveEnabled)
     return {wireframeMode ? 1.0f : 2.0f, false};
   return {wireframeMode ? 1.0f : 2.0f, true};
-}
-
-bool IsTexturedRenderStyleEnabled() {
-  return IsTexturedRenderStyle(ResolveViewer3DRenderStyle(ConfigManager::Get()));
-}
-
-bool IsSketchRenderStyleEnabled() {
-  return ResolveViewer3DRenderStyle(ConfigManager::Get()) ==
-         Viewer3DRenderStyle::WhiteModel;
-}
-
-bool IsPureWhiteRenderStyleEnabled() {
-  return ResolveViewer3DRenderStyle(ConfigManager::Get()) ==
-         Viewer3DRenderStyle::White;
 }
 
 bool IsSymbolCaptureRenderProfileEnabled() {
@@ -347,12 +332,13 @@ void SceneRenderer::DrawMeshWithOutline(
       if (texture2DWhiteModelWasEnabled)
         glDisable(GL_TEXTURE_2D);
       const bool useColorFillInWhiteStyle =
-          !IsSketchRenderStyleEnabled() &&
+          !m_controller.IsSketchRenderStyleEnabled() &&
           (mode == Viewer2DRenderMode::ByFixtureType ||
            mode == Viewer2DRenderMode::ByLayer ||
            mode == Viewer2DRenderMode::ByUniverse);
       const bool usePureWhiteFillInWhiteMode =
-          !IsSketchRenderStyleEnabled() && IsPureWhiteRenderStyleEnabled();
+          !m_controller.IsSketchRenderStyleEnabled() &&
+          m_controller.IsPureWhiteRenderStyleEnabled();
       // Keep 3D white-model aligned with the 2D viewer draw order:
       // stroke pass first, then polygon-offset fill pass.
       const LineRenderProfile lineProfile =
@@ -423,12 +409,12 @@ void SceneRenderer::DrawMeshWithOutline(
       if (texture2DWhiteModelWasEnabled)
         glEnable(GL_TEXTURE_2D);
     } else {
-      const bool useTexture = IsTexturedRenderStyleEnabled() &&
+      const bool useTexture = m_controller.IsTexturedRenderStyleEnabled() &&
                               !highlight && !selected &&
                               mesh.textureId != 0 &&
                               mesh.texcoords.size() >= (mesh.vertices.size() / 3u) * 2u;
       const bool useMaterialColor =
-                                    IsTexturedRenderStyleEnabled() &&
+                                    m_controller.IsTexturedRenderStyleEnabled() &&
                                     !highlight && !selected &&
                                     !useTexture && mesh.hasMaterialBaseColor;
       if (highlight)


### PR DESCRIPTION
### Motivation
- Offscreen fixture symbol generation could be contaminated by the global 3D render style when the app was opened in a non-`Standard` 3D mode, causing incorrect stroke/outline behavior and requiring an app restart to recover.

### Description
- Replaced ad-hoc global render-style reads inside `viewer3d/render/scenerenderer.cpp` with controller-scoped style flags already provided by `Viewer3DController` (e.g. `IsSketchRenderStyleEnabled()`, `IsPureWhiteRenderStyleEnabled()`, `IsTexturedRenderStyleEnabled()`).
- Updated `DrawMeshWithOutline` logic to consult `m_controller` style flags instead of calling `ResolveViewer3DRenderStyle(ConfigManager::Get())` so capture rendering is driven only by the resolved render context.
- Removed the now-unneeded local helpers that read the global style and eliminated the `viewer3d_render_style.h` dependency from `scenerenderer.cpp`.
- Change is limited to `viewer3d/render/scenerenderer.cpp` and keeps 2D/offscreen symbol captures isolated from interactive 3D preferences.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which returned OK.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which returned OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d93d53f44083248543c9191cd26d59)