### PR TITLE
Aggregate Symbol/Symdef truss import logs into summary

### DIFF
--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -1504,6 +1504,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
   };
 
   std::unordered_map<std::string, GdtfConflict> pendingGdtfConflictByType;
+  int trussSymbolSymdefPreservedCount = 0;
+  std::unordered_map<std::string, int> trussSymbolSymdefPreservedBySymdef;
 
   std::function<void(tinyxml2::XMLElement *, const std::string &, const Matrix &)>
       parseFixture = [&](tinyxml2::XMLElement *node,
@@ -1776,9 +1778,11 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                                                symGeometries.front().transform);
             }
             truss.transform = MatrixUtils::Multiply(nodeTransform, symLocal);
-            LogMessage(Logger::Level::Info,
-                       "MVR import truss preserves Symbol/Symdef representation for uuid='" +
-                           truss.uuid + "', symdef='" + truss.sourceSymdefUuid + "'");
+            ++trussSymbolSymdefPreservedCount;
+            const std::string symdefKey = truss.sourceSymdefUuid.empty()
+                                              ? std::string{"(empty)"}
+                                              : truss.sourceSymdefUuid;
+            ++trussSymbolSymdefPreservedBySymdef[symdefKey];
           }
         }
 
@@ -2477,6 +2481,31 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
 
     for (const std::string &example : matrixScaleAggregation.suspiciousExamples)
       LogMessage(Logger::Level::Warn, "MVR import suspicious matrix example: " + example);
+  }
+
+  if (trussSymbolSymdefPreservedCount > 0) {
+    std::vector<std::pair<std::string, int>> sortedSymdefCounts(
+        trussSymbolSymdefPreservedBySymdef.begin(),
+        trussSymbolSymdefPreservedBySymdef.end());
+    std::sort(sortedSymdefCounts.begin(), sortedSymdefCounts.end(),
+              [](const auto &lhs, const auto &rhs) {
+                if (lhs.second != rhs.second)
+                  return lhs.second > rhs.second;
+                return lhs.first < rhs.first;
+              });
+
+    std::ostringstream oss;
+    oss << "MVR import truss Symbol/Symdef representation preserved for "
+        << trussSymbolSymdefPreservedCount << " trusses";
+    if (!sortedSymdefCounts.empty()) {
+      oss << ". Symdef counts: ";
+      for (size_t i = 0; i < sortedSymdefCounts.size(); ++i) {
+        if (i > 0)
+          oss << ", ";
+        oss << "'" << sortedSymdefCounts[i].first << "'=" << sortedSymdefCounts[i].second;
+      }
+    }
+    LogMessage(Logger::Level::Info, oss.str());
   }
 
   std::string summary =


### PR DESCRIPTION
### Motivation
- Reduce noisy per-truss info log lines emitted during MVR import when a truss preserves a Symbol/Symdef representation by providing a single aggregated summary instead.

### Description
- Added `trussSymbolSymdefPreservedCount` and `trussSymbolSymdefPreservedBySymdef` counters in `mvr/mvrimporter.cpp`.
- Replaced the per-truss `LogMessage(... "MVR import truss preserves Symbol/Symdef representation ...")` with increments to those counters during truss parsing.
- At the end of `ParseSceneXml` emit one `Logger::Level::Info` message with the total preserved truss count and a per-`symdef` breakdown sorted by frequency.
- No changes were made to import logic, geometry resolution, or transforms; this only reduces log noise.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da78c15f388324977924f55f6b5015)