### PR TITLE
Fix inverted face lighting in standard 3D render mode

### DIFF
--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -658,7 +658,27 @@ void SceneRenderer::DrawMesh(const Mesh &mesh, float scale, const float *modelMa
         float nz = (v1x - v0x) * (v2y - v0y) - (v1y - v0y) * (v2x - v0x);
         const float len = std::sqrt(nx * nx + ny * ny + nz * nz);
         if (len > 0.0f) {
-          glNormal3f(nx / len, ny / len, nz / len);
+          nx /= len;
+          ny /= len;
+          nz /= len;
+          if (hasNormals) {
+            const float avgNx =
+                (normalData[i0 * 3] + normalData[i1 * 3] + normalData[i2 * 3]) /
+                3.0f;
+            const float avgNy = (normalData[i0 * 3 + 1] + normalData[i1 * 3 + 1] +
+                                 normalData[i2 * 3 + 1]) /
+                                3.0f;
+            const float avgNz = (normalData[i0 * 3 + 2] + normalData[i1 * 3 + 2] +
+                                 normalData[i2 * 3 + 2]) /
+                                3.0f;
+            const float alignment = nx * avgNx + ny * avgNy + nz * avgNz;
+            if (alignment < 0.0f) {
+              nx = -nx;
+              ny = -ny;
+              nz = -nz;
+            }
+          }
+          glNormal3f(nx, ny, nz);
         } else {
           glNormal3f(0.0f, 0.0f, 1.0f);
         }


### PR DESCRIPTION
### Motivation
- Some meshes rendered in the standard (non-textured) flat-shading mode showed inverted lighting on faces when source tools produced mirrored/cloned geometry or inconsistent winding, while textured mode appeared correct. 
- The change aims to make flat-face normals consistent with the mesh vertex-normal orientation so lighting is stable across models that may have flipped triangle winding.

### Description
- In `viewer3d/render/scenerenderer.cpp` inside `SceneRenderer::DrawMesh` the `GL_FLAT` (face-normal) path now computes the geometric face normal, normalizes it, and then compares it to the averaged per-vertex normal for the triangle. 
- If the averaged per-vertex normal points opposite the geometric face normal (dot < 0) the face normal is flipped before calling `glNormal3f`, avoiding reversed lighting. 
- The change is confined to the flat-shading path and does not alter textured/smooth shading behavior or other drawing paths.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and the script completed successfully. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da7baa8cbc8324a24194814c209bec)