### PR TITLE
Support group rotation in console `rot` command with pivot override and docs

### DIFF
--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -470,6 +470,23 @@ After a successful **Tools → Create from text** import:
 - `rider_lx1_pos` .. `rider_lx6_pos`
 - `rider_lx1_margin` .. `rider_lx6_margin`
 
+## Console transform command rule contract
+
+The console transform parser also defines user-visible behavior that must stay
+stable across releases:
+
+1. `rot x|y|z <values>` keeps per-element rotation behavior (existing contract).
+2. `rot x|y|z <values> --group` and `rot x|y|z <values> --g` rotate the full
+   current selection as one rigid group.
+3. Group rotation default pivot is the center of the selected elements'
+   axis-aligned bounding box (bbox center), computed from selected fixtures,
+   trusses, supports, and scene objects.
+4. If the command ends with `x,y,z`, that triplet is used as pivot override.
+   Coordinates are interpreted in meters (same user-facing unit convention as
+   other console position inputs) and converted to internal millimeters.
+5. For group rotation, element orientation and position are both updated so the
+   selection behaves as a single transformed block around the chosen pivot.
+
 ## Maintenance protocol (mandatory when rules change)
 
 When changing any text-to-scene parsing or placement behavior:

--- a/gui/consolepanel.cpp
+++ b/gui/consolepanel.cpp
@@ -31,6 +31,7 @@
 #include <charconv>
 #include <cctype>
 #include <exception>
+#include <optional>
 #include <sstream>
 #include <vector>
 #include <wx/filename.h>
@@ -167,11 +168,12 @@ wxString BuildConsoleHelpContent() {
          "- pos x|y|z <values>\n"
          "- pos <x>,<y>,<z>\n"
          "- x|y|z <values>\n"
-         "- rot x|y|z <values>\n"
+         "- rot x|y|z <values> [--group|--g] [pivotX,pivotY,pivotZ]\n"
          "Examples:\n"
          "- f 1-5\n"
          "- pos x 1 4\n"
-         "- rot z -- 10";
+         "- rot z -- 10\n"
+         "- rot y ++45 --g -2.5,0,0";
 }
 
 } // namespace
@@ -752,6 +754,128 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
       }
     };
 
+    auto parsePivotToken = [&](const std::string &token,
+                               std::array<float, 3> &pivotMm) {
+      auto parts = split(token, ',');
+      if (parts.size() != 3)
+        return false;
+      for (size_t idx = 0; idx < 3; ++idx) {
+        std::string part = trim(parts[idx]);
+        if (part.empty())
+          return false;
+        std::stringstream parser(part);
+        float valueMeters = 0.0f;
+        parser >> valueMeters;
+        if (!parser || !parser.eof())
+          return false;
+        pivotMm[idx] = valueMeters * 1000.0f;
+      }
+      return true;
+    };
+
+    auto computeSelectionBoundsCenterMm = [&]() -> std::optional<std::array<float, 3>> {
+      auto &scene = cfg.GetScene();
+      bool hasAny = false;
+      std::array<float, 3> minCorner{};
+      std::array<float, 3> maxCorner{};
+      auto expandBounds = [&](const std::array<float, 3> &positionMm) {
+        if (!hasAny) {
+          minCorner = positionMm;
+          maxCorner = positionMm;
+          hasAny = true;
+          return;
+        }
+        for (size_t axis = 0; axis < 3; ++axis) {
+          minCorner[axis] = std::min(minCorner[axis], positionMm[axis]);
+          maxCorner[axis] = std::max(maxCorner[axis], positionMm[axis]);
+        }
+      };
+      for (const auto &uuid : cfg.GetSelectedFixtures()) {
+        auto it = scene.fixtures.find(uuid);
+        if (it != scene.fixtures.end())
+          expandBounds(it->second.transform.o);
+      }
+      for (const auto &uuid : cfg.GetSelectedTrusses()) {
+        auto it = scene.trusses.find(uuid);
+        if (it != scene.trusses.end())
+          expandBounds(it->second.transform.o);
+      }
+      for (const auto &uuid : cfg.GetSelectedSupports()) {
+        auto it = scene.supports.find(uuid);
+        if (it != scene.supports.end())
+          expandBounds(it->second.transform.o);
+      }
+      for (const auto &uuid : cfg.GetSelectedSceneObjects()) {
+        auto it = scene.sceneObjects.find(uuid);
+        if (it != scene.sceneObjects.end())
+          expandBounds(it->second.transform.o);
+      }
+      if (!hasAny)
+        return std::nullopt;
+      return std::array<float, 3>{
+          (minCorner[0] + maxCorner[0]) * 0.5f,
+          (minCorner[1] + maxCorner[1]) * 0.5f,
+          (minCorner[2] + maxCorner[2]) * 0.5f,
+      };
+    };
+
+    auto rotateAroundPivot = [&](const std::vector<std::string> &sel,
+                                 TransformTarget target, int axis,
+                                 float angleDeg,
+                                 const std::array<float, 3> &pivotMm) {
+      if (sel.empty())
+        return;
+      auto &scene = cfg.GetScene();
+      Matrix rotation = MatrixUtils::Identity();
+      if (axis == 0)
+        rotation = MatrixUtils::EulerToMatrix(0.0f, 0.0f, angleDeg);
+      else if (axis == 1)
+        rotation = MatrixUtils::EulerToMatrix(0.0f, angleDeg, 0.0f);
+      else
+        rotation = MatrixUtils::EulerToMatrix(angleDeg, 0.0f, 0.0f);
+
+      auto rotatePosition = [&](std::array<float, 3> &positionMm) {
+        const std::array<float, 3> relative = {
+            positionMm[0] - pivotMm[0],
+            positionMm[1] - pivotMm[1],
+            positionMm[2] - pivotMm[2],
+        };
+        const std::array<float, 3> rotated = {
+            rotation.u[0] * relative[0] + rotation.v[0] * relative[1] +
+                rotation.w[0] * relative[2],
+            rotation.u[1] * relative[0] + rotation.v[1] * relative[1] +
+                rotation.w[1] * relative[2],
+            rotation.u[2] * relative[0] + rotation.v[2] * relative[1] +
+                rotation.w[2] * relative[2],
+        };
+        positionMm = {
+            rotated[0] + pivotMm[0],
+            rotated[1] + pivotMm[1],
+            rotated[2] + pivotMm[2],
+        };
+      };
+
+      for (const auto &uuid : sel) {
+        if (target == TransformTarget::Fixtures) {
+          auto it = scene.fixtures.find(uuid);
+          if (it != scene.fixtures.end())
+            rotatePosition(it->second.transform.o);
+        } else if (target == TransformTarget::Trusses) {
+          auto it = scene.trusses.find(uuid);
+          if (it != scene.trusses.end())
+            rotatePosition(it->second.transform.o);
+        } else if (target == TransformTarget::Supports) {
+          auto it = scene.supports.find(uuid);
+          if (it != scene.supports.end())
+            rotatePosition(it->second.transform.o);
+        } else {
+          auto it = scene.sceneObjects.find(uuid);
+          if (it != scene.sceneObjects.end())
+            rotatePosition(it->second.transform.o);
+        }
+      }
+    };
+
     auto parseVals = [&](const std::string &s, bool &relative) {
       relative = false;
       std::string str = trim(s);
@@ -870,11 +994,37 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
       } else if (lw == "pos" || lw == "rot") {
         bool isRot = (lw == "rot");
         cfg.PushUndoState(std::string("cli ") + lw);
+        std::vector<std::string> segmentTokens;
+        for (size_t k = i + 1; k < j; ++k)
+          segmentTokens.push_back(tokens[k]);
+
+        bool useGroupRotation = false;
+        if (isRot) {
+          std::vector<std::string> filteredTokens;
+          filteredTokens.reserve(segmentTokens.size());
+          for (const auto &segmentToken : segmentTokens) {
+            if (segmentToken == "--group" || segmentToken == "--g")
+              useGroupRotation = true;
+            else
+              filteredTokens.push_back(segmentToken);
+          }
+          segmentTokens = std::move(filteredTokens);
+        }
+
+        std::optional<std::array<float, 3>> explicitPivotMm;
+        if (isRot && useGroupRotation && segmentTokens.size() > 1) {
+          std::array<float, 3> parsedPivotMm{};
+          if (parsePivotToken(segmentTokens.back(), parsedPivotMm)) {
+            explicitPivotMm = parsedPivotMm;
+            segmentTokens.pop_back();
+          }
+        }
+
         std::string rest;
-        for (size_t k = i + 1; k < j; ++k) {
-          if (k > i + 1)
+        for (size_t k = 0; k < segmentTokens.size(); ++k) {
+          if (k > 0)
             rest += ' ';
-          rest += tokens[k];
+          rest += segmentTokens[k];
         }
         const auto selFixtures = cfg.GetSelectedFixtures();
         const auto selTrusses = cfg.GetSelectedTrusses();
@@ -924,7 +1074,30 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
           valsStr = trim(valsStr);
           bool rel = false;
           auto vals = parseVals(valsStr, rel);
-          if (isRot) {
+          if (isRot && useGroupRotation) {
+            if (!vals.empty()) {
+              const auto pivotMm =
+                  explicitPivotMm.value_or(computeSelectionBoundsCenterMm().value_or(
+                      std::array<float, 3>{0.0f, 0.0f, 0.0f}));
+              const float angleDeg = vals[0];
+              rotateAroundPivot(selFixtures, TransformTarget::Fixtures, axis,
+                                angleDeg, pivotMm);
+              rotateAroundPivot(selTrusses, TransformTarget::Trusses, axis,
+                                angleDeg, pivotMm);
+              rotateAroundPivot(selSupports, TransformTarget::Supports, axis,
+                                angleDeg, pivotMm);
+              rotateAroundPivot(selSceneObjects, TransformTarget::SceneObjects,
+                                axis, angleDeg, pivotMm);
+              applyRot(selFixtures, TransformTarget::Fixtures, axis,
+                       {angleDeg}, true);
+              applyRot(selTrusses, TransformTarget::Trusses, axis, {angleDeg},
+                       true);
+              applyRot(selSupports, TransformTarget::Supports, axis, {angleDeg},
+                       true);
+              applyRot(selSceneObjects, TransformTarget::SceneObjects, axis,
+                       {angleDeg}, true);
+            }
+          } else if (isRot) {
             applyRot(selFixtures, TransformTarget::Fixtures, axis, vals, rel);
             applyRot(selTrusses, TransformTarget::Trusses, axis, vals, rel);
             applyRot(selSupports, TransformTarget::Supports, axis, vals, rel);

--- a/help.md
+++ b/help.md
@@ -120,6 +120,8 @@ Selection syntax supports:
 | `rot x <values>` | Set rotation around X (roll). |
 | `rot y <values>` | Set rotation around Y (pitch). |
 | `rot z <values>` | Set rotation around Z (yaw). |
+| `rot x|y|z <values> --group` | Rotate the full selection as one group around a pivot. |
+| `rot x|y|z <values> --g` | Alias of `--group`. |
 
 Notes:
 
@@ -127,6 +129,8 @@ Notes:
 - Provide **two values** to linearly distribute from start to end across the selection.
 - Use `++` / `--` to apply relative offsets (example: `pos x ++ 1.5`, `rot z -- 10`).
 - You can also type a comma-separated triplet like `1, 2, 3` as a shortcut for `pos`.
+- Group rotation (`--group`/`--g`) uses the current selection **bbox center** as default pivot.
+- Add a trailing `x,y,z` triplet (in meters) to override pivot, for example: `rot y ++45 --g -2.5,0,0`.
 
 ## Keyboard Shortcuts (complete)
 
@@ -348,6 +352,8 @@ La sintaxis de selección admite:
 | `rot x <valores>` | Rota alrededor de X (roll). |
 | `rot y <valores>` | Rota alrededor de Y (pitch). |
 | `rot z <valores>` | Rota alrededor de Z (yaw). |
+| `rot x|y|z <valores> --group` | Rota toda la selección como un grupo alrededor de un pivote. |
+| `rot x|y|z <valores> --g` | Alias de `--group`. |
 
 Notas:
 
@@ -355,6 +361,8 @@ Notas:
 - **Dos valores** se distribuyen linealmente de inicio a fin.
 - Usa `++` / `--` para aplicar incrementos relativos (ej.: `pos x ++ 1.5`, `rot z -- 10`).
 - También puedes escribir un triplete separado por comas como `1, 2, 3`.
+- La rotación de grupo (`--group`/`--g`) usa por defecto el **centro del bbox** de la selección.
+- Puedes añadir al final un triplete `x,y,z` (en metros) para forzar pivote, por ejemplo: `rot y ++45 --g -2.5,0,0`.
 
 ## Atajos de teclado (completo)
 


### PR DESCRIPTION
### Motivation

- Allow rotating the entire current selection as a rigid group from the console, using a sensible default pivot (selection bbox center) and an optional explicit pivot triplet. 

### Description

- Add a new rule entry to `docs/text_to_scene_rules.md` describing the console transform contract for `rot` group behavior and pivot semantics. 
- Implement `--group`/`--g` parsing and optional pivot triplet handling in `ConsolePanel::ProcessCommand` by adding `parsePivotToken`, `computeSelectionBoundsCenterMm`, and `rotateAroundPivot` helpers and integrating them into the existing rotation flow. 
- Update help text in `ConsolePanel::BuildConsoleHelpContent` and `help.md` to document the new `--group`/`--g` options and pivot syntax (meters converted to internal millimeters). 
- Ensure group rotation updates both element positions (around pivot) and orientations so the selection behaves as a single transformed block while preserving existing per-element rotation semantics.

### Testing

- No new automated tests were added for this change. 
- The existing automated test suite was executed and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da7f5e2cbc83249a544aa19344b0ef)