### PR TITLE
Fix mixed-table selection restoration after CLI transforms

### DIFF
--- a/gui/consolepanel.cpp
+++ b/gui/consolepanel.cpp
@@ -897,44 +897,45 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
     };
 
     auto refreshSelectionAfterTransform = [&]() {
-          const auto selFixtures = cfg.GetSelectedFixtures();
-          const auto selTrusses = cfg.GetSelectedTrusses();
-          const auto selSupports = cfg.GetSelectedSupports();
-          const auto selSceneObjects = cfg.GetSelectedSceneObjects();
+      const auto selFixtures = cfg.GetSelectedFixtures();
+      const auto selTrusses = cfg.GetSelectedTrusses();
+      const auto selSupports = cfg.GetSelectedSupports();
+      const auto selSceneObjects = cfg.GetSelectedSceneObjects();
 
-          if (!selFixtures.empty() && FixtureTablePanel::Instance()) {
-            FixtureTablePanel::Instance()->ReloadData();
-            FixtureTablePanel::Instance()->SelectByUuid(selFixtures);
-          }
-          if (!selTrusses.empty() && TrussTablePanel::Instance()) {
-            TrussTablePanel::Instance()->ReloadData();
-            TrussTablePanel::Instance()->SelectByUuid(selTrusses);
-          }
-          if (!selSupports.empty() && HoistTablePanel::Instance()) {
-            HoistTablePanel::Instance()->ReloadData();
-            HoistTablePanel::Instance()->SelectByUuid(selSupports);
-          }
-          if (!selSceneObjects.empty() && SceneObjectTablePanel::Instance()) {
-            SceneObjectTablePanel::Instance()->ReloadData();
-            SceneObjectTablePanel::Instance()->SelectByUuid(selSceneObjects);
-          }
+      if (!selFixtures.empty() && FixtureTablePanel::Instance()) {
+        FixtureTablePanel::Instance()->ReloadData();
+        FixtureTablePanel::Instance()->SelectByUuid(selFixtures, false);
+      }
+      if (!selTrusses.empty() && TrussTablePanel::Instance()) {
+        TrussTablePanel::Instance()->ReloadData();
+        TrussTablePanel::Instance()->SelectByUuid(selTrusses, false);
+      }
+      if (!selSupports.empty() && HoistTablePanel::Instance()) {
+        HoistTablePanel::Instance()->ReloadData();
+        HoistTablePanel::Instance()->SelectByUuid(selSupports, false);
+      }
+      if (!selSceneObjects.empty() && SceneObjectTablePanel::Instance()) {
+        SceneObjectTablePanel::Instance()->ReloadData();
+        SceneObjectTablePanel::Instance()->SelectByUuid(selSceneObjects, false);
+      }
 
-          std::vector<std::string> primarySelection = selFixtures;
-          if (primarySelection.empty())
-            primarySelection = selTrusses;
-          if (primarySelection.empty())
-            primarySelection = selSupports;
-          if (primarySelection.empty())
-            primarySelection = selSceneObjects;
+      std::vector<std::string> mergedSelection;
+      const auto appendSelection = [&](const std::vector<std::string> &source) {
+        mergedSelection.insert(mergedSelection.end(), source.begin(), source.end());
+      };
+      appendSelection(selFixtures);
+      appendSelection(selTrusses);
+      appendSelection(selSupports);
+      appendSelection(selSceneObjects);
 
-          if (Viewer3DPanel::Instance()) {
-            Viewer3DPanel::Instance()->SetSelectedFixtures(primarySelection);
-            Viewer3DPanel::Instance()->UpdateScene();
-            Viewer3DPanel::Instance()->Refresh();
-          }
-          if (Viewer2DPanel::Instance())
-            Viewer2DPanel::Instance()->SetSelectedUuids(primarySelection);
-        };
+      if (Viewer3DPanel::Instance()) {
+        Viewer3DPanel::Instance()->SetSelectedFixtures(mergedSelection);
+        Viewer3DPanel::Instance()->UpdateScene();
+        Viewer3DPanel::Instance()->Refresh();
+      }
+      if (Viewer2DPanel::Instance())
+        Viewer2DPanel::Instance()->SetSelectedUuids(mergedSelection);
+    };
 
     auto isCmd = [](const std::string &tok, bool allowAxis,
                     bool allowRangeSeparator) {


### PR DESCRIPTION
### Motivation
- CLI transform commands (`pos`, `rot`, axis shortcuts) could collapse a mixed selection across fixtures/trusses/supports/scene objects to a single “primary” type after the transform, losing the original cross-table selection.
- Restoring selection also triggered selection-change side effects in table panels; the restore should be stable and preserve the full selection set.

### Description
- Replace the old `primarySelection` logic in `refreshSelectionAfterTransform` with a combined selection that appends `cfg.GetSelectedFixtures()`, `cfg.GetSelectedTrusses()`, `cfg.GetSelectedSupports()` and `cfg.GetSelectedSceneObjects()` into a single `mergedSelection` vector.
- When re-selecting rows in each table after a transform, call `SelectByUuid(..., false)` to avoid firing selection-change events during restoration, and call `ReloadData()` before reselection when appropriate.
- After restoring per-table selections, synchronize the 2D/3D viewers using the `mergedSelection` so the visual selection matches the original mixed selection.

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, result: OK.
- Ran `tests/check_no_configmanager_get_in_gui.sh`, result: OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da84832b548324a0ffa6ee8043f82f)