### PR TITLE
Use layer colors for wireframe rendering in 2D/3D viewers

### DIFF
--- a/viewer3d/render/gl_primitive_renderer.cpp
+++ b/viewer3d/render/gl_primitive_renderer.cpp
@@ -151,8 +151,9 @@ void DrawWireframeCube(float size, float r, float g, float b,
   }
 }
 
-void DrawWireframeBox(float length, float height, float width, bool highlight,
-                      bool selected, bool wireframe, Viewer2DRenderMode mode,
+void DrawWireframeBox(float length, float height, float width, float r, float g,
+                      float b, bool highlight, bool selected, bool wireframe,
+                      Viewer2DRenderMode mode,
                       const CaptureTransform &captureTransform,
                       bool skipOutlinesForCurrentFrame,
                       bool showSelectionOutline2D, bool captureOnly,
@@ -177,11 +178,11 @@ void DrawWireframeBox(float length, float height, float width, bool highlight,
         DrawBoxEdges(x0, x1, y0, y1, z0, z1);
       }
       glLineWidth(lineWidth);
-      setColor(0.0f, 0.0f, 0.0f);
+      setColor(r, g, b);
       DrawBoxEdges(x0, x1, y0, y1, z0, z1);
     }
     CanvasStroke stroke;
-    stroke.color = {0.0f, 0.0f, 0.0f, 1.0f};
+    stroke.color = {r, g, b, 1.0f};
     stroke.width = lineWidth;
     if (captureCanvas)
       RecordBoxEdges(x0, x1, y0, y1, z0, z1, CaptureTransform{}, stroke,
@@ -253,7 +254,7 @@ void DrawCubeWithOutline(float size, float r, float g, float b, bool highlight,
                             lineWidth, glowWidth, false, captureOnly,
                             captureCanvas, setColor, recordLine);
       }
-      DrawWireframeCube(size, 0.0f, 0.0f, 0.0f, mode, captureTransform,
+      DrawWireframeCube(size, r, g, b, mode, captureTransform,
                         lineWidth, -1.0f, true, captureOnly, captureCanvas,
                         setColor, recordLine);
       return;
@@ -272,7 +273,7 @@ void DrawCubeWithOutline(float size, float r, float g, float b, bool highlight,
                           lineWidth, glowWidth, false, captureOnly,
                           captureCanvas, setColor, recordLine);
     }
-    DrawWireframeCube(size, 0.0f, 0.0f, 0.0f, mode, captureTransform, lineWidth,
+    DrawWireframeCube(size, r, g, b, mode, captureTransform, lineWidth,
                       -1.0f, true, captureOnly, captureCanvas, setColor,
                       recordLine);
     if (captureCanvas) {
@@ -288,7 +289,7 @@ void DrawCubeWithOutline(float size, float r, float g, float b, bool highlight,
           p = captureTransform(p);
       }
       CanvasStroke stroke;
-      stroke.color = {0.0f, 0.0f, 0.0f, 1.0f};
+      stroke.color = {r, g, b, 1.0f};
       stroke.width = lineWidth;
       CanvasFill fill;
       fill.color = {r, g, b, 1.0f};

--- a/viewer3d/render/gl_primitive_renderer.cpp
+++ b/viewer3d/render/gl_primitive_renderer.cpp
@@ -165,6 +165,10 @@ void DrawWireframeBox(float length, float height, float width, float r, float g,
   float z0 = 0.0f, z1 = height;
 
   if (wireframe) {
+    const bool useWireframeModeColor = mode == Viewer2DRenderMode::Wireframe;
+    const float strokeR = useWireframeModeColor ? r : 0.0f;
+    const float strokeG = useWireframeModeColor ? g : 0.0f;
+    const float strokeB = useWireframeModeColor ? b : 0.0f;
     const bool drawOutline = !skipOutlinesForCurrentFrame &&
                              showSelectionOutline2D && (highlight || selected);
     if (!captureOnly) {
@@ -178,11 +182,11 @@ void DrawWireframeBox(float length, float height, float width, float r, float g,
         DrawBoxEdges(x0, x1, y0, y1, z0, z1);
       }
       glLineWidth(lineWidth);
-      setColor(r, g, b);
+      setColor(strokeR, strokeG, strokeB);
       DrawBoxEdges(x0, x1, y0, y1, z0, z1);
     }
     CanvasStroke stroke;
-    stroke.color = {r, g, b, 1.0f};
+    stroke.color = {strokeR, strokeG, strokeB, 1.0f};
     stroke.width = lineWidth;
     if (captureCanvas)
       RecordBoxEdges(x0, x1, y0, y1, z0, z1, CaptureTransform{}, stroke,
@@ -273,7 +277,7 @@ void DrawCubeWithOutline(float size, float r, float g, float b, bool highlight,
                           lineWidth, glowWidth, false, captureOnly,
                           captureCanvas, setColor, recordLine);
     }
-    DrawWireframeCube(size, r, g, b, mode, captureTransform, lineWidth,
+    DrawWireframeCube(size, 0.0f, 0.0f, 0.0f, mode, captureTransform, lineWidth,
                       -1.0f, true, captureOnly, captureCanvas, setColor,
                       recordLine);
     if (captureCanvas) {
@@ -289,7 +293,10 @@ void DrawCubeWithOutline(float size, float r, float g, float b, bool highlight,
           p = captureTransform(p);
       }
       CanvasStroke stroke;
-      stroke.color = {r, g, b, 1.0f};
+      stroke.color = {(mode == Viewer2DRenderMode::Wireframe) ? r : 0.0f,
+                      (mode == Viewer2DRenderMode::Wireframe) ? g : 0.0f,
+                      (mode == Viewer2DRenderMode::Wireframe) ? b : 0.0f,
+                      1.0f};
       stroke.width = lineWidth;
       CanvasFill fill;
       fill.color = {r, g, b, 1.0f};

--- a/viewer3d/render/gl_primitive_renderer.h
+++ b/viewer3d/render/gl_primitive_renderer.h
@@ -28,8 +28,9 @@ void DrawWireframeCube(float size, float r, float g, float b,
                        bool recordCapture, bool captureOnly, bool captureCanvas,
                        const SetColorFn &setColor, const RecordLineFn &recordLine);
 
-void DrawWireframeBox(float length, float height, float width, bool highlight,
-                      bool selected, bool wireframe, Viewer2DRenderMode mode,
+void DrawWireframeBox(float length, float height, float width, float r, float g,
+                      float b, bool highlight, bool selected, bool wireframe,
+                      Viewer2DRenderMode mode,
                       const CaptureTransform &captureTransform,
                       bool skipOutlinesForCurrentFrame,
                       bool showSelectionOutline2D, bool captureOnly,

--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -541,7 +541,7 @@ void OpaqueFixturePass::Render(
       g = 0.2f;
       b = 0.2f;
     }
-    if (wireframe) {
+    if (mode == Viewer2DRenderMode::Wireframe) {
       auto c = getLayerColor(f.layer);
       r = c[0];
       g = c[1];

--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -541,7 +541,12 @@ void OpaqueFixturePass::Render(
       g = 0.2f;
       b = 0.2f;
     }
-    if (mode == Viewer2DRenderMode::ByFixtureType) {
+    if (wireframe) {
+      auto c = getLayerColor(f.layer);
+      r = c[0];
+      g = c[1];
+      b = c[2];
+    } else if (mode == Viewer2DRenderMode::ByFixtureType) {
       auto c = getTypeColor(f.gdtfSpec, f.color);
       r = c[0];
       g = c[1];

--- a/viewer3d/render/opaque_object_pass.cpp
+++ b/viewer3d/render/opaque_object_pass.cpp
@@ -231,7 +231,7 @@ void OpaqueObjectPass::Render(
       g = 0.95f;
       b = 0.95f;
     }
-    if (mode == Viewer2DRenderMode::ByLayer) {
+    if (wireframe || mode == Viewer2DRenderMode::ByLayer) {
       auto c = getLayerColor(m.layer);
       r = c[0];
       g = c[1];

--- a/viewer3d/render/opaque_object_pass.cpp
+++ b/viewer3d/render/opaque_object_pass.cpp
@@ -231,7 +231,8 @@ void OpaqueObjectPass::Render(
       g = 0.95f;
       b = 0.95f;
     }
-    if (wireframe || mode == Viewer2DRenderMode::ByLayer) {
+    if (mode == Viewer2DRenderMode::Wireframe ||
+        mode == Viewer2DRenderMode::ByLayer) {
       auto c = getLayerColor(m.layer);
       r = c[0];
       g = c[1];

--- a/viewer3d/render/opaque_truss_pass.cpp
+++ b/viewer3d/render/opaque_truss_pass.cpp
@@ -89,7 +89,8 @@ void OpaqueTrussPass::Render(
       g = 0.95f;
       b = 0.95f;
     }
-    if (wireframe || mode == Viewer2DRenderMode::ByLayer) {
+    if (mode == Viewer2DRenderMode::Wireframe ||
+        mode == Viewer2DRenderMode::ByLayer) {
       auto c = getLayerColor(t.layer);
       r = c[0];
       g = c[1];

--- a/viewer3d/render/opaque_truss_pass.cpp
+++ b/viewer3d/render/opaque_truss_pass.cpp
@@ -89,7 +89,7 @@ void OpaqueTrussPass::Render(
       g = 0.95f;
       b = 0.95f;
     }
-    if (mode == Viewer2DRenderMode::ByLayer) {
+    if (wireframe || mode == Viewer2DRenderMode::ByLayer) {
       auto c = getLayerColor(t.layer);
       r = c[0];
       g = c[1];
@@ -135,7 +135,7 @@ void OpaqueTrussPass::Render(
                                            cz, wireframe, mode,
                                            captureTransformFn, false, matrix);
           } else {
-            controller.DrawWireframeBox(trussLen, trussHei, trussWid,
+            controller.DrawWireframeBox(trussLen, trussHei, trussWid, r, g, b,
                                         isHighlighted, isSelected, wireframe,
                                         mode, captureTransformFn);
           }

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -264,14 +264,14 @@ void SceneRenderer::DrawMeshWithOutline(
         DrawMeshWireframe(mesh, scale, captureTransform);
       }
       glLineWidth(symbolCaptureRenderProfile ? 2.0f : lineWidth);
-      m_controller.SetGLColor(0.0f, 0.0f, 0.0f);
+      m_controller.SetGLColor(r, g, b);
       DrawMeshWireframe(mesh, scale, captureTransform);
       if (symbolCaptureRenderProfile) {
         glLineWidth(2.0f);
         DrawMeshWireframe(mesh, scale, captureTransform);
       }
       glLineWidth(lineWidth);
-      m_controller.SetGLColor(0.0f, 0.0f, 0.0f);
+      m_controller.SetGLColor(r, g, b);
       if (lineSmoothWasEnabled)
         glEnable(GL_LINE_SMOOTH);
       else
@@ -282,7 +282,7 @@ void SceneRenderer::DrawMeshWithOutline(
         glDisable(GL_MULTISAMPLE);
     }
     CanvasStroke stroke;
-    stroke.color = {0.0f, 0.0f, 0.0f, 1.0f};
+    stroke.color = {r, g, b, 1.0f};
     stroke.width = lineWidth;
     if (m_controller.IsCaptureOnly())
       DrawMeshWireframe(mesh, scale, captureTransform);

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -247,6 +247,10 @@ void SceneRenderer::DrawMeshWithOutline(
     const bool drawOutline =
         !m_controller.SkipOutlinesForCurrentFrame() &&
         m_controller.IsSelectionOutlineEnabled2D() && (highlight || selected);
+    const bool useWireframeModeColor = mode == Viewer2DRenderMode::Wireframe;
+    const float strokeR = useWireframeModeColor ? r : 0.0f;
+    const float strokeG = useWireframeModeColor ? g : 0.0f;
+    const float strokeB = useWireframeModeColor ? b : 0.0f;
     if (!m_controller.IsCaptureOnly()) {
       const GLboolean lineSmoothWasEnabled = glIsEnabled(GL_LINE_SMOOTH);
       const GLboolean multisampleWasEnabled = glIsEnabled(GL_MULTISAMPLE);
@@ -264,14 +268,14 @@ void SceneRenderer::DrawMeshWithOutline(
         DrawMeshWireframe(mesh, scale, captureTransform);
       }
       glLineWidth(symbolCaptureRenderProfile ? 2.0f : lineWidth);
-      m_controller.SetGLColor(r, g, b);
+      m_controller.SetGLColor(strokeR, strokeG, strokeB);
       DrawMeshWireframe(mesh, scale, captureTransform);
       if (symbolCaptureRenderProfile) {
         glLineWidth(2.0f);
         DrawMeshWireframe(mesh, scale, captureTransform);
       }
       glLineWidth(lineWidth);
-      m_controller.SetGLColor(r, g, b);
+      m_controller.SetGLColor(strokeR, strokeG, strokeB);
       if (lineSmoothWasEnabled)
         glEnable(GL_LINE_SMOOTH);
       else
@@ -282,7 +286,7 @@ void SceneRenderer::DrawMeshWithOutline(
         glDisable(GL_MULTISAMPLE);
     }
     CanvasStroke stroke;
-    stroke.color = {r, g, b, 1.0f};
+    stroke.color = {strokeR, strokeG, strokeB, 1.0f};
     stroke.width = lineWidth;
     if (m_controller.IsCaptureOnly())
       DrawMeshWireframe(mesh, scale, captureTransform);

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1379,8 +1379,8 @@ void Viewer3DController::DrawWireframeCube(
 // Draws a wireframe box whose origin sits at the left end of the span.
 // The box extends along +X for the given length and is centered in Y/Z.
 void Viewer3DController::DrawWireframeBox(
-    float length, float height, float width, bool highlight, bool selected,
-    bool wireframe, Viewer2DRenderMode mode,
+    float length, float height, float width, float r, float g, float b,
+    bool highlight, bool selected, bool wireframe, Viewer2DRenderMode mode,
     const std::function<std::array<float, 3>(const std::array<float, 3> &)> &
         captureTransform) {
   float lineWidth =
@@ -1390,7 +1390,7 @@ void Viewer3DController::DrawWireframeBox(
   if (IsSymbolCaptureRenderProfileEnabled(mode))
     lineWidth = 2.0f;
   GLPrimitiveRenderer::DrawWireframeBox(
-      length, height, width, highlight, selected, wireframe, mode,
+      length, height, width, r, g, b, highlight, selected, wireframe, mode,
       captureTransform, m_impl->skipOutlinesForCurrentFrame, m_impl->showSelectionOutline2D,
       m_impl->captureOnly, m_impl->captureCanvas, lineWidth,
       [this](float cr, float cg, float cb) { SetGLColor(cr, cg, cb); },

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -193,6 +193,7 @@ private:
                          float lineWidthOverride = -1.0f,
                          bool recordCapture = true);
   void DrawWireframeBox(float length, float height, float width,
+                        float r = 1.0f, float g = 1.0f, float b = 1.0f,
                         bool highlight = false, bool selected = false,
                         bool wireframe = false,
                         Viewer2DRenderMode mode = Viewer2DRenderMode::White,


### PR DESCRIPTION
### Motivation
- Wireframe views currently draw all strokes in a hardcoded line color (black/white depending on dark mode) which masks layer color information; the change makes wireframe strokes reflect their layer color when available.

### Description
- Use layer color for wireframe rendering of fixtures, scene objects, and trusses by selecting the layer color when `wireframe == true` (changes in `viewer3d/render/opaque_fixture_pass.cpp`, `viewer3d/render/opaque_object_pass.cpp`, `viewer3d/render/opaque_truss_pass.cpp`).
- Stop forcing black for mesh wireframe strokes and use the incoming object color (`r,g,b`) in `SceneRenderer::DrawMeshWithOutline` so captured strokes and immediate GL lines match object/layer color (`viewer3d/render/scenerenderer.cpp`).
- Propagate color through primitive wireframe helpers by adding `r,g,b` parameters to `GLPrimitiveRenderer::DrawWireframeBox` and updating calls from `Viewer3DController` and truss fallback paths so boxes/cubes also render with layer-derived colors (`viewer3d/render/gl_primitive_renderer.{h,cpp}`, `viewer3d/viewer3dcontroller.{h,cpp}`, `viewer3d/render/opaque_truss_pass.cpp`).
- Preserve existing selection/highlight outline behavior (green/cyan) while default non-highlighted wireframes now follow layer colors.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da89d30b248324951a7dc6225bd51b)