### PR TITLE
Disable symbol substitution for 2D wireframe layout renders

### DIFF
--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -590,7 +590,7 @@ void OpaqueFixturePass::Render(
     const bool captureRecordingActive = controller.m_captureCanvas && !skipCapture;
     const bool preferLayoutSvg =
         context.preferPerastageSvgSymbolsForLayouts && is2DViewer &&
-        !captureRecordingActive;
+        !captureRecordingActive && !wireframe;
     if (preferLayoutSvg && !svgSourcePath.empty()) {
       const Viewer2DView fixtureView =
           isTopView2D && forceBottomViewForTopFixtures ? Viewer2DView::Bottom
@@ -624,6 +624,7 @@ void OpaqueFixturePass::Render(
           controller.m_captureView == Viewer2DView::Top ||
           controller.m_captureView == Viewer2DView::Front ||
           controller.m_captureView == Viewer2DView::Side) &&
+         !wireframe &&
          !highlight && !selected);
     bool placedInstance = false;
     if (useSymbolInstancing && controller.m_captureCanvas && !skipCapture) {

--- a/viewer3d/render/opaque_object_pass.cpp
+++ b/viewer3d/render/opaque_object_pass.cpp
@@ -382,6 +382,7 @@ void OpaqueObjectPass::Render(
           captureView == Viewer2DView::Top ||
           captureView == Viewer2DView::Front ||
           captureView == Viewer2DView::Side) &&
+         !wireframe &&
          CanUseAffineSymbolInstance(captureTransform, captureView) &&
          !highlight && !selected);
     bool placedInstance = false;

--- a/viewer3d/render/opaque_truss_pass.cpp
+++ b/viewer3d/render/opaque_truss_pass.cpp
@@ -148,6 +148,7 @@ void OpaqueTrussPass::Render(
           captureView == Viewer2DView::Top ||
           captureView == Viewer2DView::Front ||
           captureView == Viewer2DView::Side) &&
+         !wireframe &&
          !highlight && !selected);
     bool placedInstance = false;
     if (useSymbolInstancing && controller.m_captureCanvas && !skipCapture) {


### PR DESCRIPTION
### Motivation
- Ensure that when the 2D layout viewer is in `Wireframe` render mode it shows the real wireframe geometry instead of substituted SVG symbols, and have the same behavior when capturing/printing layouts.

### Description
- Added a `!wireframe` guard to the layout-SVG substitution decision so `preferLayoutSvg` is false in wireframe mode, preventing per-fixture SVG substitution in `viewer3d/render/opaque_fixture_pass.cpp`.
- Disabled capture-time symbol instancing in wireframe mode by adding `!wireframe` to the `useSymbolInstancing` checks for fixtures, scene objects, and trusses in `viewer3d/render/opaque_fixture_pass.cpp`, `viewer3d/render/opaque_object_pass.cpp`, and `viewer3d/render/opaque_truss_pass.cpp` respectively.
- This change affects the same capture path used for print/PDF export, so printed/layout captures in wireframe mode will also use real wireframe geometry while leaving all other render modes unchanged.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da91b31d8c8324aa817b7f8fe16eb4)