### PR TITLE
Optimize layout 2D view recapture to avoid full-layout refreshes

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -569,7 +569,6 @@ void LayoutViewerPanel::SetLayoutDefinition(
   }
   layoutVersion++;
   if (!AreEqual(previousLayout.view2dViews, currentLayout.view2dViews)) {
-    viewRenderVersion++;
     captureInProgress = false;
   }
   pendingFrameCommit_ = false;

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -69,6 +69,8 @@ private:
     Viewer2DViewState viewState;
     viewer2d::Viewer2DState renderState;
     bool hasRenderState = false;
+    size_t captureContentHash = 0;
+    bool hasCaptureContentHash = false;
     std::shared_ptr<const SymbolDefinitionSnapshot> symbols;
     unsigned int texture = 0;
     unsigned int pixelUnpackPbo = 0;

--- a/gui/layoutviewerpanel_view.cpp
+++ b/gui/layoutviewerpanel_view.cpp
@@ -224,7 +224,8 @@ void LayoutViewerPanel::DrawViewElement(
         capturePanel, nullptr, cfg, layoutState, nullptr, nullptr, false);
     capturePanel->CaptureFrameNow(
         [this, viewId, stateGuard, fallbackViewportWidth, fallbackViewportHeight,
-         capturePanel](CommandBuffer buffer, Viewer2DViewState state) {
+         capturePanel, captureContentHash](CommandBuffer buffer,
+                                           Viewer2DViewState state) {
           ViewCache &cache = GetViewCache(viewId);
           cache.buffer = std::move(buffer);
           cache.viewState = state;

--- a/gui/layoutviewerpanel_view.cpp
+++ b/gui/layoutviewerpanel_view.cpp
@@ -192,14 +192,16 @@ void LayoutViewerPanel::DrawViewElement(
     Viewer2DOffscreenRenderer *offscreenRenderer, int activeViewId) {
   ViewCache &cache = GetViewCache(view.id);
   const size_t viewContentHash = HashViewContent(view);
-  const bool needsCapture = !cache.hasCapture || !cache.hasRenderState ||
-                            cache.captureVersion != viewRenderVersion ||
-                            cache.contentHash != viewContentHash;
+  const bool needsCapture =
+      !cache.hasCapture || !cache.hasRenderState ||
+      cache.captureVersion != viewRenderVersion ||
+      !cache.hasCaptureContentHash || cache.captureContentHash != viewContentHash;
   if (!captureInProgress && !cache.captureInProgress && needsCapture &&
       capturePanel) {
     captureInProgress = true;
     cache.captureInProgress = true;
     const int viewId = view.id;
+    const size_t captureContentHash = viewContentHash;
     const int fallbackViewportWidth = view.camera.viewportWidth > 0
                                           ? view.camera.viewportWidth
                                           : view.frame.width;
@@ -239,6 +241,8 @@ void LayoutViewerPanel::DrawViewElement(
             cache.symbols = capturePanel->GetBottomSymbolCacheSnapshot();
           }
           cache.hasCapture = !cache.buffer.commands.empty();
+          cache.captureContentHash = captureContentHash;
+          cache.hasCaptureContentHash = true;
           cache.captureVersion = viewRenderVersion;
           cache.captureInProgress = false;
           captureInProgress = false;

--- a/gui/layoutviewerpanel_view.cpp
+++ b/gui/layoutviewerpanel_view.cpp
@@ -170,7 +170,6 @@ void LayoutViewerPanel::UpdateFrame(const layouts::Layout2DViewFrame &frame,
     } else {
       view->camera.viewportHeight = 0;
     }
-    viewRenderVersion++;
   }
   if (updatePosition) {
     pendingFrameCommit_ = true;
@@ -192,8 +191,12 @@ void LayoutViewerPanel::DrawViewElement(
     const layouts::Layout2DViewDefinition &view, Viewer2DPanel *capturePanel,
     Viewer2DOffscreenRenderer *offscreenRenderer, int activeViewId) {
   ViewCache &cache = GetViewCache(view.id);
-  if (!captureInProgress && !cache.captureInProgress &&
-      cache.captureVersion != viewRenderVersion && capturePanel) {
+  const size_t viewContentHash = HashViewContent(view);
+  const bool needsCapture = !cache.hasCapture || !cache.hasRenderState ||
+                            cache.captureVersion != viewRenderVersion ||
+                            cache.contentHash != viewContentHash;
+  if (!captureInProgress && !cache.captureInProgress && needsCapture &&
+      capturePanel) {
     captureInProgress = true;
     cache.captureInProgress = true;
     const int viewId = view.id;


### PR DESCRIPTION
### Motivation
- Editing one 2D view in a layout currently caused recapture/refresh work for all 2D views, slowing interactive updates.
- The intent is to narrow recapture work to only views that actually changed while preserving identical visual output for unchanged views.

### Description
- Removed the global bump of `viewRenderVersion` when replacing layout view definitions in `SetLayoutDefinition`, leaving only `captureInProgress` resets to avoid forcing all views to recapture (`gui/layoutviewerpanel.cpp`).
- Stopped incrementing `viewRenderVersion` on single-view resize in `UpdateFrame` so changing one view size does not trigger recapture for other views (`gui/layoutviewerpanel_view.cpp`).
- Added a per-view recapture check in `DrawViewElement` that computes `HashViewContent(view)` and uses it (together with existing checks like missing capture/state or global `viewRenderVersion`) to decide whether a view needs capture, so only modified views are recaptured (`gui/layoutviewerpanel_view.cpp`).
- Changes touch `gui/layoutviewerpanel.cpp` and `gui/layoutviewerpanel_view.cpp`; left existing global recapture behavior in place for real scene-content updates (via `viewRenderVersion`).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded (OK).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded (OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da943583c08324a3f362058d28d097)