### PR TITLE
Optimize legend redraw path for move/scale operations

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -1996,15 +1996,26 @@ void LayoutViewerPanel::RebuildCachedTexture() {
       }
     }
     bool needsLegendProcessing = false;
+    bool needsLegendSymbolCapture = false;
     for (const auto &legend : currentLayout.legendViews) {
       const auto cacheIt = legendCaches_.find(legend.id);
-      if (cacheIt == legendCaches_.end() || cacheIt->second.renderDirty ||
-          cacheIt->second.contentHash != legendDataHash) {
+      const bool cacheMissing = cacheIt == legendCaches_.end();
+      const bool contentChanged =
+          !cacheMissing && cacheIt->second.contentHash != legendDataHash;
+      const bool needsTextureRebuild =
+          cacheMissing || cacheIt->second.renderDirty || contentChanged;
+      if (needsTextureRebuild) {
         needsLegendProcessing = true;
+        const bool needsSymbols =
+            cacheMissing || !cacheIt->second.symbols || contentChanged;
+        if (needsSymbols)
+          needsLegendSymbolCapture = true;
+      }
+      if (needsLegendProcessing && needsLegendSymbolCapture) {
         break;
       }
     }
-    const bool needsCapturePanel = hasDirtyViewCache || needsLegendProcessing;
+    const bool needsCapturePanel = hasDirtyViewCache || needsLegendSymbolCapture;
     if (needsCapturePanel) {
       if (auto *mw = MainWindow::Instance()) {
         offscreenRenderer = mw->GetOffscreenRenderer();
@@ -2017,7 +2028,7 @@ void LayoutViewerPanel::RebuildCachedTexture() {
 
     ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
     std::shared_ptr<const SymbolDefinitionSnapshot> legendSymbols;
-    if (needsLegendProcessing) {
+    if (needsLegendSymbolCapture) {
       legendSymbols = CaptureLegendSymbolSnapshot(capturePanel, cfg, true);
     }
     std::vector<unsigned char> legendPixels;
@@ -2104,11 +2115,13 @@ void LayoutViewerPanel::RebuildCachedTexture() {
   
     for (const auto &legend : currentLayout.legendViews) {
       LegendCache &cache = GetLegendCache(legend.id);
-      if (legendSymbols && cache.symbols != legendSymbols) {
+      const bool contentChanged = cache.contentHash != legendDataHash;
+      const bool requiresSymbolRefresh = !cache.symbols || contentChanged;
+      if (requiresSymbolRefresh && legendSymbols && cache.symbols != legendSymbols) {
         cache.symbols = legendSymbols;
         cache.renderDirty = true;
       }
-      if (cache.contentHash != legendDataHash) {
+      if (contentChanged) {
         cache.renderDirty = true;
       }
       if (!cache.renderDirty)

--- a/gui/layoutviewerpanel_render_invalidation.cpp
+++ b/gui/layoutviewerpanel_render_invalidation.cpp
@@ -213,6 +213,7 @@ void LayoutViewerPanel::InvalidateRenderIfFrameChanged(bool includeSceneContent)
   for (const auto &legend : currentLayout.legendViews) {
     LegendCache &cache = GetLegendCache(legend.id);
     if (sceneContentChanged) {
+      cache.symbols.reset();
       markDirty(cache.renderDirty);
     }
     wxRect frameRect;
@@ -314,8 +315,10 @@ void LayoutViewerPanel::RefreshAfterSceneContentUpdate() {
     cache.renderDirty = true;
   }
 
-  for (auto &entry : legendCaches_)
+  for (auto &entry : legendCaches_) {
     entry.second.renderDirty = true;
+    entry.second.symbols.reset();
+  }
 
   renderDirty = true;
   RequestRenderRebuild();


### PR DESCRIPTION
### Motivation
- Moving or scaling layout legends was triggering expensive offscreen symbol snapshot captures even when the legend content and symbols did not change.
- Reuse of cached legend symbol snapshots can avoid unnecessary work and improve UI responsiveness during frame-only changes (move/scale).
- Scene changes must still force symbol recapture to remain correct when symbols/definitions may have changed.

### Description
- Added a `needsLegendSymbolCapture` decision branch in `RebuildCachedTexture` to separate texture rebuild needs from symbol-snapshot recapture needs and to only request the offscreen capture panel when a symbol snapshot is actually required (`gui/layoutviewerpanel.cpp`).
- Introduced `contentChanged`, `cacheMissing`, and `needsTextureRebuild` checks so we only call `CaptureLegendSymbolSnapshot` when needed and reuse cached `cache.symbols` for frame-driven redraws.
- Conditioned per-legend symbol refresh so `cache.symbols` is only updated when missing or when legend content hash differs, and avoided symbol recapture for simple move/scale cases (`gui/layoutviewerpanel.cpp`).
- Invalidation changes ensure correctness by clearing `cache.symbols` when scene content changes and during `RefreshAfterSceneContentUpdate`, forcing recapture only when necessary (`gui/layoutviewerpanel_render_invalidation.cpp`).
- Modified files: `gui/layoutviewerpanel.cpp` and `gui/layoutviewerpanel_render_invalidation.cpp`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (`OK`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da9c5509108324950c552c959d481a)