### PR TITLE
Fix layout z-order persistence and prevent 2D view state cross-contamination

### DIFF
--- a/core/layouts/LayoutCollection.cpp
+++ b/core/layouts/LayoutCollection.cpp
@@ -233,7 +233,15 @@ bool LayoutCollection::MoveLayout2DView(const std::string &name, int viewId,
                              });
       if (it == views.end())
         return false;
-      it->zIndex = toFront ? (MaxZIndex(layout) + 1) : (MinZIndex(layout) - 1);
+      if (toFront) {
+        const int maxZ = MaxZIndex(layout);
+        if (it->zIndex < maxZ)
+          it->zIndex = maxZ + 1;
+      } else {
+        const int minZ = MinZIndex(layout);
+        if (it->zIndex > minZ)
+          it->zIndex = minZ - 1;
+      }
       return true;
     }
   }
@@ -473,7 +481,15 @@ bool LayoutCollection::MoveLayoutLegend(const std::string &name, int legendId,
                              });
       if (it == legends.end())
         return false;
-      it->zIndex = toFront ? (MaxZIndex(layout) + 1) : (MinZIndex(layout) - 1);
+      if (toFront) {
+        const int maxZ = MaxZIndex(layout);
+        if (it->zIndex < maxZ)
+          it->zIndex = maxZ + 1;
+      } else {
+        const int minZ = MinZIndex(layout);
+        if (it->zIndex > minZ)
+          it->zIndex = minZ - 1;
+      }
       return true;
     }
   }
@@ -491,7 +507,15 @@ bool LayoutCollection::MoveLayoutText(const std::string &name, int textId,
                              });
       if (it == texts.end())
         return false;
-      it->zIndex = toFront ? (MaxZIndex(layout) + 1) : (MinZIndex(layout) - 1);
+      if (toFront) {
+        const int maxZ = MaxZIndex(layout);
+        if (it->zIndex < maxZ)
+          it->zIndex = maxZ + 1;
+      } else {
+        const int minZ = MinZIndex(layout);
+        if (it->zIndex > minZ)
+          it->zIndex = minZ - 1;
+      }
       return true;
     }
   }
@@ -509,7 +533,15 @@ bool LayoutCollection::MoveLayoutImage(const std::string &name, int imageId,
                              });
       if (it == images.end())
         return false;
-      it->zIndex = toFront ? (MaxZIndex(layout) + 1) : (MinZIndex(layout) - 1);
+      if (toFront) {
+        const int maxZ = MaxZIndex(layout);
+        if (it->zIndex < maxZ)
+          it->zIndex = maxZ + 1;
+      } else {
+        const int minZ = MinZIndex(layout);
+        if (it->zIndex > minZ)
+          it->zIndex = minZ - 1;
+      }
       return true;
     }
   }
@@ -527,7 +559,15 @@ bool LayoutCollection::MoveLayoutEventTable(const std::string &name, int tableId
                              });
       if (it == tables.end())
         return false;
-      it->zIndex = toFront ? (MaxZIndex(layout) + 1) : (MinZIndex(layout) - 1);
+      if (toFront) {
+        const int maxZ = MaxZIndex(layout);
+        if (it->zIndex < maxZ)
+          it->zIndex = maxZ + 1;
+      } else {
+        const int minZ = MinZIndex(layout);
+        if (it->zIndex > minZ)
+          it->zIndex = minZ - 1;
+      }
       return true;
     }
   }

--- a/core/layouts/LayoutCollection.cpp
+++ b/core/layouts/LayoutCollection.cpp
@@ -66,6 +66,52 @@ int MaxZIndex(const LayoutDefinition &layout) {
   }
   return hasValue ? maxZ : 0;
 }
+
+int MinZIndex(const LayoutDefinition &layout) {
+  bool hasValue = false;
+  int minZ = 0;
+  for (const auto &view : layout.view2dViews) {
+    if (!hasValue) {
+      minZ = view.zIndex;
+      hasValue = true;
+    } else {
+      minZ = std::min(minZ, view.zIndex);
+    }
+  }
+  for (const auto &legend : layout.legendViews) {
+    if (!hasValue) {
+      minZ = legend.zIndex;
+      hasValue = true;
+    } else {
+      minZ = std::min(minZ, legend.zIndex);
+    }
+  }
+  for (const auto &table : layout.eventTables) {
+    if (!hasValue) {
+      minZ = table.zIndex;
+      hasValue = true;
+    } else {
+      minZ = std::min(minZ, table.zIndex);
+    }
+  }
+  for (const auto &text : layout.textViews) {
+    if (!hasValue) {
+      minZ = text.zIndex;
+      hasValue = true;
+    } else {
+      minZ = std::min(minZ, text.zIndex);
+    }
+  }
+  for (const auto &image : layout.imageViews) {
+    if (!hasValue) {
+      minZ = image.zIndex;
+      hasValue = true;
+    } else {
+      minZ = std::min(minZ, image.zIndex);
+    }
+  }
+  return hasValue ? minZ : 0;
+}
 } // namespace
 
 LayoutCollection::LayoutCollection() { layouts.push_back(DefaultLayout()); }
@@ -187,19 +233,7 @@ bool LayoutCollection::MoveLayout2DView(const std::string &name, int viewId,
                              });
       if (it == views.end())
         return false;
-      if (toFront) {
-        if (std::next(it) != views.end()) {
-          auto moved = std::move(*it);
-          views.erase(it);
-          views.push_back(std::move(moved));
-        }
-      } else {
-        if (it != views.begin()) {
-          auto moved = std::move(*it);
-          views.erase(it);
-          views.insert(views.begin(), std::move(moved));
-        }
-      }
+      it->zIndex = toFront ? (MaxZIndex(layout) + 1) : (MinZIndex(layout) - 1);
       return true;
     }
   }
@@ -439,19 +473,7 @@ bool LayoutCollection::MoveLayoutLegend(const std::string &name, int legendId,
                              });
       if (it == legends.end())
         return false;
-      if (toFront) {
-        if (std::next(it) != legends.end()) {
-          auto moved = std::move(*it);
-          legends.erase(it);
-          legends.push_back(std::move(moved));
-        }
-      } else {
-        if (it != legends.begin()) {
-          auto moved = std::move(*it);
-          legends.erase(it);
-          legends.insert(legends.begin(), std::move(moved));
-        }
-      }
+      it->zIndex = toFront ? (MaxZIndex(layout) + 1) : (MinZIndex(layout) - 1);
       return true;
     }
   }
@@ -469,19 +491,7 @@ bool LayoutCollection::MoveLayoutText(const std::string &name, int textId,
                              });
       if (it == texts.end())
         return false;
-      if (toFront) {
-        if (std::next(it) != texts.end()) {
-          auto moved = std::move(*it);
-          texts.erase(it);
-          texts.push_back(std::move(moved));
-        }
-      } else {
-        if (it != texts.begin()) {
-          auto moved = std::move(*it);
-          texts.erase(it);
-          texts.insert(texts.begin(), std::move(moved));
-        }
-      }
+      it->zIndex = toFront ? (MaxZIndex(layout) + 1) : (MinZIndex(layout) - 1);
       return true;
     }
   }
@@ -499,19 +509,7 @@ bool LayoutCollection::MoveLayoutImage(const std::string &name, int imageId,
                              });
       if (it == images.end())
         return false;
-      if (toFront) {
-        if (std::next(it) != images.end()) {
-          auto moved = std::move(*it);
-          images.erase(it);
-          images.push_back(std::move(moved));
-        }
-      } else {
-        if (it != images.begin()) {
-          auto moved = std::move(*it);
-          images.erase(it);
-          images.insert(images.begin(), std::move(moved));
-        }
-      }
+      it->zIndex = toFront ? (MaxZIndex(layout) + 1) : (MinZIndex(layout) - 1);
       return true;
     }
   }
@@ -529,19 +527,7 @@ bool LayoutCollection::MoveLayoutEventTable(const std::string &name, int tableId
                              });
       if (it == tables.end())
         return false;
-      if (toFront) {
-        if (std::next(it) != tables.end()) {
-          auto moved = std::move(*it);
-          tables.erase(it);
-          tables.push_back(std::move(moved));
-        }
-      } else {
-        if (it != tables.begin()) {
-          auto moved = std::move(*it);
-          tables.erase(it);
-          tables.insert(tables.begin(), std::move(moved));
-        }
-      }
+      it->zIndex = toFront ? (MaxZIndex(layout) + 1) : (MinZIndex(layout) - 1);
       return true;
     }
   }

--- a/core/layouts/LayoutCollection.cpp
+++ b/core/layouts/LayoutCollection.cpp
@@ -112,6 +112,15 @@ int MinZIndex(const LayoutDefinition &layout) {
   }
   return hasValue ? minZ : 0;
 }
+
+bool IsExplicitBoundaryZChange(const LayoutDefinition &layout, int currentZ,
+                               int requestedZ) {
+  if (requestedZ == currentZ)
+    return false;
+  const int maxZ = MaxZIndex(layout);
+  const int minZ = MinZIndex(layout);
+  return requestedZ > maxZ || requestedZ < minZ;
+}
 } // namespace
 
 LayoutCollection::LayoutCollection() { layouts.push_back(DefaultLayout()); }
@@ -182,8 +191,10 @@ bool LayoutCollection::UpdateLayout2DView(const std::string &name,
       bool replaced = false;
       for (auto &entry : layout.view2dViews) {
         if (entry.id == updatedView.id && updatedView.id > 0) {
-          if (updatedView.zIndex == 0 && entry.zIndex != 0)
+          if (!IsExplicitBoundaryZChange(layout, entry.zIndex,
+                                         updatedView.zIndex)) {
             updatedView.zIndex = entry.zIndex;
+          }
           entry = updatedView;
           replaced = true;
           break;
@@ -263,8 +274,10 @@ bool LayoutCollection::UpdateLayoutLegend(
       bool replaced = false;
       for (auto &entry : layout.legendViews) {
         if (entry.id == updatedLegend.id && updatedLegend.id > 0) {
-          if (updatedLegend.zIndex == 0 && entry.zIndex != 0)
+          if (!IsExplicitBoundaryZChange(layout, entry.zIndex,
+                                         updatedLegend.zIndex)) {
             updatedLegend.zIndex = entry.zIndex;
+          }
           entry = updatedLegend;
           replaced = true;
           break;
@@ -300,8 +313,10 @@ bool LayoutCollection::UpdateLayoutEventTable(
       bool replaced = false;
       for (auto &entry : layout.eventTables) {
         if (entry.id == updatedTable.id && updatedTable.id > 0) {
-          if (updatedTable.zIndex == 0 && entry.zIndex != 0)
+          if (!IsExplicitBoundaryZChange(layout, entry.zIndex,
+                                         updatedTable.zIndex)) {
             updatedTable.zIndex = entry.zIndex;
+          }
           entry = updatedTable;
           replaced = true;
           break;
@@ -337,8 +352,10 @@ bool LayoutCollection::UpdateLayoutText(const std::string &name,
       bool replaced = false;
       for (auto &entry : layout.textViews) {
         if (entry.id == updatedText.id && updatedText.id > 0) {
-          if (updatedText.zIndex == 0 && entry.zIndex != 0)
+          if (!IsExplicitBoundaryZChange(layout, entry.zIndex,
+                                         updatedText.zIndex)) {
             updatedText.zIndex = entry.zIndex;
+          }
           entry = updatedText;
           replaced = true;
           break;
@@ -374,8 +391,10 @@ bool LayoutCollection::UpdateLayoutImage(const std::string &name,
       bool replaced = false;
       for (auto &entry : layout.imageViews) {
         if (entry.id == updatedImage.id && updatedImage.id > 0) {
-          if (updatedImage.zIndex == 0 && entry.zIndex != 0)
+          if (!IsExplicitBoundaryZChange(layout, entry.zIndex,
+                                         updatedImage.zIndex)) {
             updatedImage.zIndex = entry.zIndex;
+          }
           entry = updatedImage;
           replaced = true;
           break;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -132,6 +132,11 @@ add_executable(layout_template_serializer_test
                ../core/layouts/LayoutTemplateSerializer.cpp)
 add_test(NAME LayoutTemplateSerializer COMMAND layout_template_serializer_test)
 
+add_executable(layout_collection_zorder_test
+               layout_collection_zorder_test.cpp
+               ../core/layouts/LayoutCollection.cpp)
+add_test(NAME LayoutCollectionZOrder COMMAND layout_collection_zorder_test)
+
 add_executable(layout_template_import_name_collision_test
                layout_template_import_name_collision_test.cpp
                configmanager_layoutmanager_stub.cpp

--- a/tests/layout_collection_zorder_test.cpp
+++ b/tests/layout_collection_zorder_test.cpp
@@ -84,10 +84,40 @@ void TestMoveEventTableUpdatesZIndex() {
   assert(updated->eventTables.front().zIndex == 11);
 }
 
+void TestRegularUpdateKeepsExistingZIndex() {
+  layouts::LayoutCollection collection;
+  layouts::LayoutDefinition layout;
+  layout.name = "Persist z";
+
+  layouts::Layout2DViewDefinition view;
+  view.id = 10;
+  view.zIndex = 1;
+  view.frame = {0, 0, 100, 100};
+  layout.view2dViews.push_back(view);
+
+  layouts::LayoutTextDefinition text;
+  text.id = 11;
+  text.zIndex = 5;
+  layout.textViews.push_back(text);
+
+  assert(collection.AddLayout(layout));
+
+  layouts::Layout2DViewDefinition editedView = view;
+  editedView.frame.width = 120;
+  editedView.zIndex = 0; // Typical non-z edit payload should preserve current z.
+  assert(collection.UpdateLayout2DView("Persist z", editedView));
+
+  const layouts::LayoutDefinition *updated = FindLayout(collection, "Persist z");
+  assert(updated != nullptr);
+  assert(updated->view2dViews.size() == 1);
+  assert(updated->view2dViews.front().zIndex == 1);
+}
+
 } // namespace
 
 int main() {
   TestMoveUpdatesZIndexForCrossElementOrdering();
   TestMoveEventTableUpdatesZIndex();
+  TestRegularUpdateKeepsExistingZIndex();
   return 0;
 }

--- a/tests/layout_collection_zorder_test.cpp
+++ b/tests/layout_collection_zorder_test.cpp
@@ -1,0 +1,85 @@
+#include "LayoutCollection.h"
+
+#include <cassert>
+
+namespace {
+
+layouts::LayoutDefinition BuildLayout() {
+  layouts::LayoutDefinition layout;
+  layout.name = "Z order";
+
+  layouts::Layout2DViewDefinition view;
+  view.id = 1;
+  view.zIndex = 1;
+  layout.view2dViews.push_back(view);
+
+  layouts::LayoutLegendDefinition legend;
+  legend.id = 2;
+  legend.zIndex = 5;
+  layout.legendViews.push_back(legend);
+
+  layouts::LayoutTextDefinition text;
+  text.id = 3;
+  text.zIndex = -3;
+  layout.textViews.push_back(text);
+
+  return layout;
+}
+
+const layouts::LayoutDefinition *FindLayout(const layouts::LayoutCollection &collection,
+                                            const char *name) {
+  for (const auto &layout : collection.Items()) {
+    if (layout.name == name)
+      return &layout;
+  }
+  return nullptr;
+}
+
+void TestMoveUpdatesZIndexForCrossElementOrdering() {
+  layouts::LayoutCollection collection;
+  assert(collection.AddLayout(BuildLayout()));
+
+  assert(collection.MoveLayout2DView("Z order", 1, true));
+  assert(collection.MoveLayoutLegend("Z order", 2, false));
+
+  const layouts::LayoutDefinition *layout = FindLayout(collection, "Z order");
+  assert(layout != nullptr);
+  assert(layout->view2dViews.size() == 1);
+  assert(layout->legendViews.size() == 1);
+
+  // Bringing the view to front should place it above every element.
+  assert(layout->view2dViews.front().zIndex == 6);
+  // Sending the legend to back should place it below every element.
+  assert(layout->legendViews.front().zIndex == -4);
+}
+
+void TestMoveEventTableUpdatesZIndex() {
+  layouts::LayoutCollection collection;
+  layouts::LayoutDefinition layout;
+  layout.name = "Events";
+
+  layouts::LayoutEventTableDefinition table;
+  table.id = 9;
+  table.zIndex = 2;
+  layout.eventTables.push_back(table);
+
+  layouts::LayoutImageDefinition image;
+  image.id = 4;
+  image.zIndex = 10;
+  layout.imageViews.push_back(image);
+
+  assert(collection.AddLayout(layout));
+  assert(collection.MoveLayoutEventTable("Events", 9, true));
+
+  const layouts::LayoutDefinition *updated = FindLayout(collection, "Events");
+  assert(updated != nullptr);
+  assert(updated->eventTables.front().zIndex == 11);
+}
+
+} // namespace
+
+int main() {
+  TestMoveUpdatesZIndexForCrossElementOrdering();
+  TestMoveEventTableUpdatesZIndex();
+  return 0;
+}

--- a/tests/layout_collection_zorder_test.cpp
+++ b/tests/layout_collection_zorder_test.cpp
@@ -51,6 +51,14 @@ void TestMoveUpdatesZIndexForCrossElementOrdering() {
   assert(layout->view2dViews.front().zIndex == 6);
   // Sending the legend to back should place it below every element.
   assert(layout->legendViews.front().zIndex == -4);
+
+  // Re-applying move to front/back should be stable when already at boundary.
+  assert(collection.MoveLayout2DView("Z order", 1, true));
+  assert(collection.MoveLayoutLegend("Z order", 2, false));
+  layout = FindLayout(collection, "Z order");
+  assert(layout != nullptr);
+  assert(layout->view2dViews.front().zIndex == 6);
+  assert(layout->legendViews.front().zIndex == -4);
 }
 
 void TestMoveEventTableUpdatesZIndex() {

--- a/viewer2d/viewer2dstate.cpp
+++ b/viewer2d/viewer2dstate.cpp
@@ -265,13 +265,9 @@ Viewer2DState FromLayoutDefinition(const layouts::Layout2DViewDefinition &view) 
 }
 
 void ApplyEditorRenderOptions(Viewer2DState &state, const ConfigManager &cfg) {
-  const std::optional<bool> preservedForceBottomSetting =
-      state.renderOptions.forceBottomViewForTopFixtures;
-  Viewer2DState editorState = CaptureState(nullptr, cfg);
-  state.renderOptions = editorState.renderOptions;
-  if (preservedForceBottomSetting.has_value()) {
+  if (!state.renderOptions.forceBottomViewForTopFixtures.has_value()) {
     state.renderOptions.forceBottomViewForTopFixtures =
-        preservedForceBottomSetting;
+        cfg.GetFloat("view2d_top_fixtures_inverted") != 0.0f;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Persist and respect element stacking (front/back) across mixed layout element types so bring-to-front / send-to-back operations survive save/load and do not rely on vector order alone. 
- Prevent accidental cross-contamination of per-view 2D render settings when editing/persisting a single view by avoiding wholesale replacement from global editor config.

### Description
- Update `core/layouts/LayoutCollection.cpp` to compute `MinZIndex(...)` and to update an element's `zIndex` when moving it front/back relative to the global layout z-range instead of reordering vectors. 
- Change move helpers for views/legends/tables/text/images to set `it->zIndex = MaxZIndex(layout) + 1` or `MinZIndex(layout) - 1` as appropriate. 
- Modify `viewer2d/viewer2dstate.cpp::ApplyEditorRenderOptions()` to only backfill the optional `forceBottomViewForTopFixtures` when missing rather than replacing the entire `renderOptions` from the global editor config. 
- Add a unit test `tests/layout_collection_zorder_test.cpp` and register it in `tests/CMakeLists.txt` to validate cross-element z-order mutation behavior.

### Testing
- Ran architecture checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both succeeded. 
- Added `layout_collection_zorder_test` to the test CMake setup but full test binary build/run was not executed in this environment because `cmake -S . -B build -DBUILD_TESTING=ON` failed due to missing system `wxWidgets` development packages. 
- New unit test is present and ready to run in CI or a developer environment with the test toolchain available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dab04152fc8324806f793127eb21c7)