### PR TITLE
Reduce wireframe stroke thickness for 2D layout rendering and PDF export

### DIFF
--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -694,7 +694,8 @@ void OpaqueFixturePass::Render(
                   }
                   controller.DrawMeshWithOutline(
                       obj.mesh, partR, partG, partB, RENDER_SCALE, false, false,
-                      0.0f, 0.0f, 0.0f, wireframe, mode, applyCapture, false);
+                      0.0f, 0.0f, 0.0f, wireframe, mode, applyCapture, false,
+                      nullptr, is2DViewer);
                 }
               } else {
                 controller.m_captureCanvas->SetSourceKey(fixtureCaptureKey);
@@ -707,7 +708,7 @@ void OpaqueFixturePass::Render(
                     FallbackFixtureCubeMesh(), r, g, b, 0.2f, false, false,
                     0.0f, 0.0f, 0.0f, fallbackWireframe, mode,
                     [](const std::array<float, 3> &p) { return p; },
-                    fallbackUnlit);
+                    fallbackUnlit, nullptr, is2DViewer);
               }
 
               localCanvas->EndFrame();
@@ -767,7 +768,7 @@ void OpaqueFixturePass::Render(
           controller.DrawMeshWithOutline(obj.mesh, partR, partG, partB,
                                          RENDER_SCALE, highlight, selected, cx,
                                          cy, cz, wireframe, mode, applyCapture,
-                                         drawUnlit, partMatrix);
+                                         drawUnlit, partMatrix, is2DViewer);
           glPopMatrix();
         }
       } else {
@@ -781,7 +782,7 @@ void OpaqueFixturePass::Render(
                                        highlight, selected, cx, cy, cz,
                                        fallbackWireframe, mode,
                                        applyFixtureCapture, fallbackUnlit,
-                                       matrix);
+                                       matrix, is2DViewer);
       }
     };
 

--- a/viewer3d/render/opaque_object_pass.cpp
+++ b/viewer3d/render/opaque_object_pass.cpp
@@ -352,7 +352,7 @@ void OpaqueObjectPass::Render(
                                              isHighlighted, isSelected, cx, cy,
                                              cz, wireframe, mode,
                                              partCaptureTransform, false,
-                                             partMatrix,
+                                             partMatrix, context.is2DViewer,
                                              disableDepthBias);
               glPopMatrix();
             }
@@ -371,7 +371,7 @@ void OpaqueObjectPass::Render(
             controller.DrawMeshWithOutline(
                 fallbackMesh, r, g, b, 0.3f, isHighlighted, isSelected, cx, cy,
                 cz, fallbackWireframe, mode, captureTransformFn,
-                useUnlitFallbackFill, matrix,
+                useUnlitFallbackFill, matrix, context.is2DViewer,
                 disableDepthBias);
           }
         };

--- a/viewer3d/render/opaque_truss_pass.cpp
+++ b/viewer3d/render/opaque_truss_pass.cpp
@@ -134,7 +134,8 @@ void OpaqueTrussPass::Render(
             controller.DrawMeshWithOutline(*trussMesh, r, g, b, RENDER_SCALE,
                                            isHighlighted, isSelected, cx, cy,
                                            cz, wireframe, mode,
-                                           captureTransformFn, false, matrix);
+                                           captureTransformFn, false, matrix,
+                                           context.is2DViewer);
           } else {
             controller.DrawWireframeBox(trussLen, trussHei, trussWid, r, g, b,
                                         isHighlighted, isSelected, wireframe,

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -213,7 +213,8 @@ void SceneRenderer::DrawMeshWithOutline(
     Viewer2DRenderMode mode,
     const std::function<std::array<float, 3>(const std::array<float, 3> &)> &
         captureTransform,
-    bool unlit, const float *modelMatrix, bool disableDepthBias) {
+    bool unlit, const float *modelMatrix, bool is2DViewer,
+    bool disableDepthBias) {
   (void)cx;
   (void)cy;
   (void)cz;
@@ -236,6 +237,8 @@ void SceneRenderer::DrawMeshWithOutline(
                              mode == Viewer2DRenderMode::Wireframe,
                              m_controller.UseAdaptiveLineProfile())
             .lineWidth;
+    if (is2DViewer && mode == Viewer2DRenderMode::Wireframe)
+      lineWidth *= 0.45f;
     bool symbolCaptureRenderProfile =
         mode == Viewer2DRenderMode::ByFixtureType ||
         ConfigManager::Get().GetFloat("viewer3d_symbol_capture_render_profile") >=

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -243,11 +243,6 @@ void SceneRenderer::DrawMeshWithOutline(
         mode == Viewer2DRenderMode::ByFixtureType ||
         ConfigManager::Get().GetFloat("viewer3d_symbol_capture_render_profile") >=
             0.5f;
-    if (is2DViewer && mode == Viewer2DRenderMode::Wireframe) {
-      // Keep 2D layout wireframe strokes thin both on-screen and in captured
-      // command buffers used by PDF export.
-      symbolCaptureRenderProfile = false;
-    }
     if (m_controller.GetSymbolCaptureRenderProfileOverride().has_value()) {
       symbolCaptureRenderProfile =
           m_controller.GetSymbolCaptureRenderProfileOverride().value();
@@ -278,11 +273,18 @@ void SceneRenderer::DrawMeshWithOutline(
           m_controller.SetGLColor(0.0f, 1.0f, 1.0f);
         DrawMeshWireframe(mesh, scale, captureTransform);
       }
-      glLineWidth(symbolCaptureRenderProfile ? 2.0f : lineWidth);
+      const float wireframeDrawWidthBase =
+          symbolCaptureRenderProfile ? 2.0f : lineWidth;
+      const float wireframeDrawWidth =
+          (is2DViewer && mode == Viewer2DRenderMode::Wireframe &&
+           symbolCaptureRenderProfile)
+              ? wireframeDrawWidthBase * 0.45f
+              : wireframeDrawWidthBase;
+      glLineWidth(wireframeDrawWidth);
       m_controller.SetGLColor(strokeR, strokeG, strokeB);
       DrawMeshWireframe(mesh, scale, captureTransform, &stroke);
       if (symbolCaptureRenderProfile) {
-        glLineWidth(2.0f);
+        glLineWidth(wireframeDrawWidth);
         DrawMeshWireframe(mesh, scale, captureTransform, &stroke);
       }
       glLineWidth(lineWidth);

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -243,6 +243,11 @@ void SceneRenderer::DrawMeshWithOutline(
         mode == Viewer2DRenderMode::ByFixtureType ||
         ConfigManager::Get().GetFloat("viewer3d_symbol_capture_render_profile") >=
             0.5f;
+    if (is2DViewer && mode == Viewer2DRenderMode::Wireframe) {
+      // Keep 2D layout wireframe strokes thin both on-screen and in captured
+      // command buffers used by PDF export.
+      symbolCaptureRenderProfile = false;
+    }
     if (m_controller.GetSymbolCaptureRenderProfileOverride().has_value()) {
       symbolCaptureRenderProfile =
           m_controller.GetSymbolCaptureRenderProfileOverride().value();

--- a/viewer3d/render/scenerenderer.h
+++ b/viewer3d/render/scenerenderer.h
@@ -14,7 +14,7 @@ public:
       bool selected, float cx, float cy, float cz, bool wireframe,
       Viewer2DRenderMode mode,
       const std::function<std::array<float, 3>(const std::array<float, 3> &)> &captureTransform,
-      bool unlit, const float *modelMatrix,
+      bool unlit, const float *modelMatrix, bool is2DViewer,
       bool disableDepthBias = false);
   void DrawMeshWireframe(
       const Mesh &mesh, float scale,

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1749,10 +1749,12 @@ void Viewer3DController::DrawMeshWithOutline(
     Viewer2DRenderMode mode,
     const std::function<std::array<float, 3>(const std::array<float, 3> &)> &
         captureTransform,
-    bool unlit, const float *modelMatrix, bool disableDepthBias) {
+    bool unlit, const float *modelMatrix, bool is2DViewer,
+    bool disableDepthBias) {
   m_impl->sceneRenderer->DrawMeshWithOutline(mesh, r, g, b, scale, highlight,
                                        selected, cx, cy, cz, wireframe, mode,
                                        captureTransform, unlit, modelMatrix,
+                                       is2DViewer,
                                        disableDepthBias);
 }
 

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -211,6 +211,7 @@ private:
                                {},
                            bool unlit = false,
                            const float *modelMatrix = nullptr,
+                           bool is2DViewer = false,
                            bool disableDepthBias = false);
   void DrawMeshWireframe(
       const Mesh &mesh, float scale = RENDER_SCALE,


### PR DESCRIPTION
### Motivation
- Wireframe lines in 2D layout views and their captured output (PDF export) are visually too thick and should be noticeably thinner (at least half) while keeping 3D rendering unchanged.
- The adjustment must be contained to the 2D wireframe draw/capture path so only layout rendering and PDF output are affected.

### Description
- Added an explicit `is2DViewer` boolean parameter to `SceneRenderer::DrawMeshWithOutline` and propagated it through `Viewer3DController::DrawMeshWithOutline` so the renderer can distinguish 2D capture/draw contexts without touching 3D paths (`viewer3d/render/scenerenderer.h`, `viewer3d/viewer3dcontroller.h`, `viewer3d/viewer3dcontroller.cpp`).
- When `is2DViewer` is true and `mode == Viewer2DRenderMode::Wireframe`, the calculated wireframe `lineWidth` is scaled by `0.45f` to reduce stroke thickness for on-screen 2D wireframe rendering and captured commands.
- Wired the new parameter through opaque render passes used for fixtures, scene objects and trusses so both the on-screen 2D view and the captured commands used for PDF export remain consistent (`viewer3d/render/opaque_fixture_pass.cpp`, `viewer3d/render/opaque_object_pass.cpp`, `viewer3d/render/opaque_truss_pass.cpp`).
- Change is intentionally local to mesh wireframe outline handling and does not modify GUI logic, parsing, or other rendering modes.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db7077d31483248ab3dd9d23a7793c)