### PR TITLE
docs: define storage source-of-truth policy

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,3 +34,4 @@ This document defines the expected directory conventions for Perastage.
 ## GUI architecture references
 
 - Keyboard shortcut routing and scope rules are documented in `docs/gui_shortcut_architecture.md`.
+- Storage source-of-truth and runtime precedence are documented in `docs/storage_policy.md`.

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -72,4 +72,5 @@ Perastage app bundles declare `.mvr` document type metadata through bundle setti
 ## Related Documents
 
 - [Build and dependency guide](build.md)
+- [Storage policy (installation vs user profile)](storage_policy.md)
 - [Troubleshooting](troubleshooting.md)

--- a/docs/storage_policy.md
+++ b/docs/storage_policy.md
@@ -1,0 +1,64 @@
+# Storage Policy (Source of Truth)
+
+This document defines where Perastage stores data at runtime and which locations are writable.
+
+## Intent
+
+Perastage uses a split storage model:
+
+- **Installation tree** is the immutable base content distributed with the application.
+- **User profile tree** is the writable source of truth for user-specific and editable data.
+
+A developer should be able to answer, without ambiguity: **Perastage stores user data in the user profile tree, not in the installation tree.**
+
+## Installation tree (read-only at runtime)
+
+The installation tree contains application-owned assets that ship with Perastage.
+
+Typical contents:
+
+- Executables and runtime binaries.
+- Base resources required for the application to start.
+- A seed library used as bundled defaults.
+
+Runtime policy:
+
+- Treat installation files as **read-only**.
+- Do not persist user edits or generated artifacts into installation paths.
+
+## User profile tree (read/write at runtime)
+
+The user profile tree is Perastage's writable storage and user-data source of truth.
+
+It contains:
+
+- Editable library content:
+  - `fixtures/`
+  - `trusses/`
+  - `scene_objects/`
+  - `misc/`
+  - `projects/`
+  - `default_layouts/`
+- Dictionaries.
+- Configuration.
+- Logs.
+- Credentials/secrets.
+
+Runtime policy:
+
+- User-created or user-modified data is stored here.
+- Application updates must not assume this content can be replaced.
+
+## Runtime resolution order
+
+When loading runtime data that may exist in both locations, Perastage resolves in this order:
+
+1. **User profile tree first**.
+2. **Installed base content second (fallback only)**.
+
+This guarantees user overrides are respected while still allowing bundled defaults to work when user copies do not exist.
+
+## Practical rule of thumb
+
+- If data is shipped by the installer and expected to be static: keep it in installation content.
+- If data can be edited, generated, personalized, or is operational state: keep it in user profile storage.


### PR DESCRIPTION
### Motivation

- Make the storage contract explicit so developers know which files are installation-owned (read-only) and which are user-owned (read/write).
- Ensure a deterministic runtime precedence so user overrides are respected and bundled defaults act only as fallbacks.
- Surface the policy in repository-level docs so packaging and architecture guidance reference a single source of truth.

### Description

- Add `docs/storage_policy.md` describing the split model: installation tree as read-only (executables, base resources, seed library) and user profile tree as read/write (editable library folders `fixtures`, `trusses`, `scene_objects`, `misc`, `projects`, `default_layouts`, dictionaries, config, logs, credentials).
- Specify runtime resolution order as `user profile` first and `installed base` second (fallback only).
- Link the new policy from `docs/architecture.md` and `docs/packaging.md`.
- This is a documentation-only change and does not alter runtime code paths.

### Testing

- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.
- No build or runtime tests were required for this docs-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db7ebf918c832484a71abffd0511e9)