### PR TITLE
Separate installed vs writable library path APIs

### DIFF
--- a/core/dictionary_bundle.cpp
+++ b/core/dictionary_bundle.cpp
@@ -497,7 +497,7 @@ PreparedImport PrepareBundleImport(const std::string &importPath, Type expectedT
     return result;
   }
 
-  const fs::path libraryDir = fs::u8path(ProjectUtils::GetDefaultLibraryPath(expectedTypeText));
+  const fs::path libraryDir = fs::u8path(ProjectUtils::GetWritableLibraryPath(expectedTypeText));
   std::error_code ec;
   fs::create_directories(libraryDir, ec);
 

--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -186,7 +186,7 @@ FindEquivalentTypeKey(const std::unordered_map<std::string, Entry> &dict,
 }
 
 fs::path GetUserDictFile() {
-  fs::path dir = fs::u8path(ProjectUtils::GetDefaultLibraryPath("fixtures"));
+  fs::path dir = fs::u8path(ProjectUtils::GetWritableLibraryPath("fixtures"));
   if (dir.empty())
     return {};
   std::error_code ec;

--- a/core/projectutils.cpp
+++ b/core/projectutils.cpp
@@ -110,6 +110,15 @@ std::optional<fs::path> ResolveWritableUserDataDir()
     return fs::absolute(fallback, ec);
 }
 
+std::string ToAbsoluteUtf8(const fs::path& path)
+{
+    std::error_code ec;
+    fs::path absolutePath = fs::absolute(path, ec);
+    if (ec)
+        return {};
+    return ToUtf8String(absolutePath);
+}
+
 } // namespace
 
 bool IsDirectoryWritable(const fs::path& dir)
@@ -239,16 +248,17 @@ std::optional<std::string> LoadLastProjectPath()
     return std::nullopt;
 }
 
-std::string GetDefaultLibraryPath(const std::string& subdir)
+std::string GetInstalledLibraryPath(const std::string& subdir)
 {
-    auto absoluteUtf8 = [](const fs::path& path) -> std::string {
-        std::error_code ec;
-        fs::path absolutePath = fs::absolute(path, ec);
-        if (ec)
-            return {};
-        return ToUtf8String(absolutePath);
-    };
+    const fs::path installedPath = GetBaseLibraryPath(subdir);
+    std::error_code ec;
+    if (fs::exists(installedPath, ec) && !ec && fs::is_directory(installedPath, ec) && !ec)
+        return ToAbsoluteUtf8(installedPath);
+    return {};
+}
 
+std::string GetWritableLibraryPath(const std::string& subdir)
+{
     if (const char* envPath = std::getenv("PERASTAGE_LIBRARY_PATH")) {
         if (*envPath != '\0') {
             fs::path envRoot = fs::u8path(envPath);
@@ -258,29 +268,48 @@ std::string GetDefaultLibraryPath(const std::string& subdir)
             if (!ec && envRootExists && envRootIsDir) {
                 fs::path envLibraryPath = envRoot / subdir;
                 if (IsDirectoryWritable(envLibraryPath))
-                    return absoluteUtf8(envLibraryPath);
+                    return ToAbsoluteUtf8(envLibraryPath);
+                std::cerr << "ProjectUtils::GetWritableLibraryPath could not use "
+                             "PERASTAGE_LIBRARY_PATH for subdir '"
+                          << subdir << "' because path is not writable: "
+                          << envLibraryPath.string() << std::endl;
             }
         }
     }
 
-    fs::path baseLib = GetBaseLibraryPath(subdir);
-    std::error_code ec;
-    if (fs::exists(baseLib, ec) && !ec && fs::is_directory(baseLib, ec) && !ec)
-        return absoluteUtf8(baseLib);
+    const fs::path installedPath = GetBaseLibraryPath(subdir);
 
     if (const auto dataDir = ResolveWritableUserDataDir()) {
         fs::path userLib = *dataDir / "library" / subdir;
         if (IsDirectoryWritable(userLib)) {
-            CopyLibrarySubdir(baseLib, userLib);
-            return absoluteUtf8(userLib);
+            CopyLibrarySubdir(installedPath, userLib);
+            return ToAbsoluteUtf8(userLib);
         }
     }
 
-    std::cerr << "ProjectUtils::GetDefaultLibraryPath failed for subdir '" << subdir
-              << "'. Checked PERASTAGE_LIBRARY_PATH, base library path, and user data "
-                 "library fallback."
+    std::cerr << "ProjectUtils::GetWritableLibraryPath failed for subdir '" << subdir
+              << "'. Checked PERASTAGE_LIBRARY_PATH and user-data library fallback."
               << std::endl;
     return {};
+}
+
+std::string GetDefaultLibraryPath(const std::string& subdir)
+{
+    if (std::string installedPath = GetInstalledLibraryPath(subdir); !installedPath.empty())
+        return installedPath;
+
+    if (std::string writablePath = GetWritableLibraryPath(subdir); !writablePath.empty())
+        return writablePath;
+
+    const fs::path fallbackPath = GetBaseLibraryPath(subdir);
+    std::error_code ec;
+    fs::path absolutePath = fs::absolute(fallbackPath, ec);
+    if (ec) {
+        std::cerr << "ProjectUtils::GetDefaultLibraryPath failed for subdir '" << subdir
+                  << "'." << std::endl;
+        return {};
+    }
+    return ToUtf8String(absolutePath);
 }
 
 } // namespace ProjectUtils

--- a/core/projectutils.h
+++ b/core/projectutils.h
@@ -31,12 +31,19 @@ namespace ProjectUtils {
     // Path containing the built-in library shipped with the executable.
     std::filesystem::path GetBaseLibraryPath(const std::string& subdir);
 
+    // Read-only library path shipped with the installation. Returns empty when unavailable.
+    std::string GetInstalledLibraryPath(const std::string& subdir);
+
+    // Writable library path used by editing flows.
+    // Uses PERASTAGE_LIBRARY_PATH/<subdir> when writable, otherwise user-data/library/<subdir>.
+    std::string GetWritableLibraryPath(const std::string& subdir);
+
     // Path containing the built-in resources shipped with the executable.
     std::filesystem::path GetResourceRoot();
 
     // Returns true when a directory exists (or can be created) and accepts writes.
     bool IsDirectoryWritable(const std::filesystem::path& dir);
 
-    // Returns the path to a library subdirectory if it exists, otherwise empty.
+    // Legacy default path resolver kept for compatibility with existing call sites.
     std::string GetDefaultLibraryPath(const std::string& subdir);
 }

--- a/core/trussdictionary.cpp
+++ b/core/trussdictionary.cpp
@@ -79,7 +79,7 @@ static std::string CollapseAsciiWhitespace(const std::string &text) {
 }
 
 static fs::path GetUserDictFile() {
-  fs::path dir = fs::u8path(ProjectUtils::GetDefaultLibraryPath("trusses"));
+  fs::path dir = fs::u8path(ProjectUtils::GetWritableLibraryPath("trusses"));
   if (dir.empty())
     return {};
   std::error_code ec;

--- a/gui/dictionaryeditdialog.cpp
+++ b/gui/dictionaryeditdialog.cpp
@@ -483,7 +483,7 @@ ImportPathValidationSummary ValidateFixtureImportPaths(const std::string &import
 
   const std::filesystem::path importFilePath = std::filesystem::u8path(importPath);
   const std::filesystem::path libraryDir = std::filesystem::u8path(
-      ProjectUtils::GetDefaultLibraryPath("fixtures"));
+      ProjectUtils::GetWritableLibraryPath("fixtures"));
 
   auto checkEntry = [&](const std::string &entryName, const nlohmann::json &entryJson) {
     if (!entryJson.is_object())
@@ -542,7 +542,7 @@ ImportPathValidationSummary ValidateTrussImportPaths(const std::string &importPa
 
   const std::filesystem::path importFilePath = std::filesystem::u8path(importPath);
   const std::filesystem::path libraryDir =
-      std::filesystem::u8path(ProjectUtils::GetDefaultLibraryPath("trusses"));
+      std::filesystem::u8path(ProjectUtils::GetWritableLibraryPath("trusses"));
 
   auto checkEntry = [&](const std::string &entryName, const nlohmann::json &entryJson) {
     if (!entryJson.is_object())
@@ -644,7 +644,7 @@ CopyToLibrary(wxWindow *parent, const std::string &path, const char *libraryName
     return std::nullopt;
 
   const std::filesystem::path dir =
-      std::filesystem::u8path(ProjectUtils::GetDefaultLibraryPath(libraryName));
+      std::filesystem::u8path(ProjectUtils::GetWritableLibraryPath(libraryName));
   if (dir.empty())
     return CopiedLibraryAsset{path, path, {}};
 
@@ -1358,7 +1358,7 @@ bool DictionaryEditDialog::SaveTrusses() {
 void DictionaryEditDialog::OnAdd(wxCommandEvent &WXUNUSED(event)) {
   if (IsFixturesPage()) {
     wxString fixDir =
-        wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("fixtures"));
+        wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("fixtures"));
     wxFileDialog fdlg(this, "Select GDTF file", fixDir, wxEmptyString,
                       "*.gdtf", wxFD_OPEN | wxFD_FILE_MUST_EXIST);
     if (fdlg.ShowModal() != wxID_OK)
@@ -1391,7 +1391,7 @@ void DictionaryEditDialog::OnAdd(wxCommandEvent &WXUNUSED(event)) {
     fixturePaths.push_back(fullPath);
   } else {
     wxString trussDir =
-        wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("trusses"));
+        wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("trusses"));
     wxFileDialog fdlg(this, "Select Truss file", trussDir, wxEmptyString,
                       "Truss files (*.gdtf;*.gtruss;*.3ds;*.glb)|*.gdtf;*.gtruss;*.3ds;*.glb|All files|*.*",
                       wxFD_OPEN | wxFD_FILE_MUST_EXIST);
@@ -1553,7 +1553,7 @@ void DictionaryEditDialog::OnImportDictionary(wxCommandEvent &WXUNUSED(event)) {
 
 bool DictionaryEditDialog::ImportFixturesDictionary() {
   const wxString fixturesDir =
-      wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("fixtures"));
+      wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("fixtures"));
   wxFileDialog fileDialog(this, "Import fixtures dictionary", fixturesDir,
                           wxEmptyString,
                           "Dictionary files (*.json;*.zip)|*.json;*.zip|JSON files (*.json)|*.json|ZIP files (*.zip)|*.zip",
@@ -1626,7 +1626,7 @@ bool DictionaryEditDialog::ImportFixturesDictionary() {
 
 bool DictionaryEditDialog::ImportTrussesDictionary() {
   const wxString trussesDir =
-      wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("trusses"));
+      wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("trusses"));
   wxFileDialog fileDialog(this, "Import trusses dictionary", trussesDir,
                           wxEmptyString,
                           "Dictionary files (*.json;*.zip)|*.json;*.zip|JSON files (*.json)|*.json|ZIP files (*.zip)|*.zip",
@@ -1737,7 +1737,7 @@ bool DictionaryEditDialog::ExportFixturesDictionary() {
     return false;
 
   const wxString fixturesDir =
-      wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("fixtures"));
+      wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("fixtures"));
   wxFileDialog fileDialog(this, "Export fixtures dictionary", fixturesDir,
                           "gdtf_dictionary_snapshot.json",
                           "JSON files (*.json)|*.json",
@@ -1792,7 +1792,7 @@ bool DictionaryEditDialog::ExportTrussesDictionary() {
     return false;
 
   const wxString trussesDir =
-      wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("trusses"));
+      wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("trusses"));
   wxFileDialog fileDialog(this, "Export trusses dictionary", trussesDir,
                           "truss_dictionary_snapshot.json",
                           "JSON files (*.json)|*.json",
@@ -1843,7 +1843,7 @@ bool DictionaryEditDialog::ExportFixturesPortableBundle() {
   }
 
   const wxString fixturesDir =
-      wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("fixtures"));
+      wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("fixtures"));
   wxFileDialog fileDialog(this, "Export portable fixtures bundle", fixturesDir,
                           "gdtf_dictionary_bundle.json",
                           "JSON files (*.json)|*.json",
@@ -1877,7 +1877,7 @@ bool DictionaryEditDialog::ExportTrussesPortableBundle() {
   }
 
   const wxString trussesDir =
-      wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("trusses"));
+      wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("trusses"));
   wxFileDialog fileDialog(this, "Export portable trusses bundle", trussesDir,
                           "truss_dictionary_bundle.json",
                           "JSON files (*.json)|*.json",
@@ -2028,7 +2028,7 @@ void DictionaryEditDialog::OnItemActivated(wxDataViewEvent &event) {
     if (col != kFixtureFileColumn)
       return;
     wxFileDialog fdlg(this, "Select GDTF file",
-                      wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("fixtures")),
+                      wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("fixtures")),
                       wxEmptyString, "*.gdtf", wxFD_OPEN | wxFD_FILE_MUST_EXIST);
     if (fdlg.ShowModal() != wxID_OK)
       return;
@@ -2058,7 +2058,7 @@ void DictionaryEditDialog::OnItemActivated(wxDataViewEvent &event) {
     if (col != 1)
       return;
     wxFileDialog fdlg(this, "Select Truss file",
-                      wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("trusses")),
+                      wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("trusses")),
                       wxEmptyString,
                       "Truss files (*.gdtf;*.gtruss;*.3ds;*.glb)|*.gdtf;*.gtruss;*.3ds;*.glb|All files|*.*",
                       wxFD_OPEN | wxFD_FILE_MUST_EXIST);


### PR DESCRIPTION
### Motivation
- Prevent edit flows from accidentally writing into installed/app-bundle locations by making read-only vs writable library resolution explicit. 
- Provide a clear migration path so code that needs writable library paths uses an API that prefers user-writable locations or `PERASTAGE_LIBRARY_PATH` when safe. 

### Description
- Added `ProjectUtils::GetInstalledLibraryPath(subdir)` (read-only) and `ProjectUtils::GetWritableLibraryPath(subdir)` (write-capable) and kept `GetDefaultLibraryPath(subdir)` as a compatibility resolver that prefers installed then writable paths. 
- Implemented writable resolution to prefer `PERASTAGE_LIBRARY_PATH/<subdir>` only when writable, otherwise fall back to `user-data/library/<subdir>` and copy bundled content there; added `ToAbsoluteUtf8` helper and warning logs when a writable path cannot be used. 
- Migrated editing/write call sites to use `GetWritableLibraryPath(...)` (notably in `core/gdtfdictionary.cpp`, `core/trussdictionary.cpp`, `core/dictionary_bundle.cpp`, and `gui/dictionaryeditdialog.cpp`) so editors/importers operate on user-writable locations. 
- Files changed: `core/projectutils.h`, `core/projectutils.cpp`, `core/gdtfdictionary.cpp`, `core/trussdictionary.cpp`, `core/dictionary_bundle.cpp`, and `gui/dictionaryeditdialog.cpp`. 

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db80ce90f883248bdf936d8e971b61)