### PR TITLE
Require writable installed library in GetDefaultLibraryPath

### DIFF
--- a/core/projectutils.cpp
+++ b/core/projectutils.cpp
@@ -295,8 +295,11 @@ std::string GetWritableLibraryPath(const std::string& subdir)
 
 std::string GetDefaultLibraryPath(const std::string& subdir)
 {
-    if (std::string installedPath = GetInstalledLibraryPath(subdir); !installedPath.empty())
-        return installedPath;
+    if (std::string installedPath = GetInstalledLibraryPath(subdir); !installedPath.empty()) {
+        const fs::path installed = fs::u8path(installedPath);
+        if (IsDirectoryWritable(installed))
+            return installedPath;
+    }
 
     if (std::string writablePath = GetWritableLibraryPath(subdir); !writablePath.empty())
         return writablePath;

--- a/core/projectutils.h
+++ b/core/projectutils.h
@@ -45,5 +45,6 @@ namespace ProjectUtils {
     bool IsDirectoryWritable(const std::filesystem::path& dir);
 
     // Legacy default path resolver kept for compatibility with existing call sites.
+    // Returns installed path only when writable; otherwise falls back to writable resolver.
     std::string GetDefaultLibraryPath(const std::string& subdir);
 }


### PR DESCRIPTION
### Motivation

- Fix a bug where `GetDefaultLibraryPath(...)` could return the installed library directory (e.g. under `Program Files`) even when that location was not writable, which broke import/edit flows that require a writable library without elevation.

### Description

- Update `ProjectUtils::GetDefaultLibraryPath` in `core/projectutils.cpp` to only return the installed library path when `IsDirectoryWritable(installed)` is true, otherwise fall back to `GetWritableLibraryPath(...)`, and update `core/projectutils.h` documentation to describe the new fallback behavior.

### Testing

- Executed `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both checks passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db8747e62883248418a00d777b0fad)