### PR TITLE
Add non-destructive bootstrap for user library defaults

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/guiconfigservices.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/hoistpresetlibrary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/hoist_weight_distribution.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/library/library_bootstrap.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layouts/LayoutCollection.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layouts/LayoutDefaultsLoader.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layouts/LayoutManager.cpp

--- a/core/library/library_bootstrap.cpp
+++ b/core/library/library_bootstrap.cpp
@@ -1,0 +1,116 @@
+#include "library/library_bootstrap.h"
+
+#include <fstream>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace LibraryBootstrap {
+namespace {
+
+constexpr const char *kBootstrapVersion = "1";
+constexpr const char *kBootstrapStampFilename = ".bootstrap_version";
+
+bool CopyMissingFilesRecursively(const fs::path &sourceRoot, const fs::path &destinationRoot) {
+  std::error_code ec;
+  if (!fs::exists(sourceRoot, ec) || ec || !fs::is_directory(sourceRoot, ec) || ec)
+    return false;
+
+  fs::create_directories(destinationRoot, ec);
+  if (ec)
+    return false;
+
+  for (const fs::directory_entry &entry :
+       fs::recursive_directory_iterator(sourceRoot, fs::directory_options::skip_permission_denied,
+                                        ec)) {
+    if (ec)
+      return false;
+
+    const fs::path relative = fs::relative(entry.path(), sourceRoot, ec);
+    if (ec)
+      return false;
+
+    const fs::path destinationPath = destinationRoot / relative;
+    if (entry.is_directory()) {
+      fs::create_directories(destinationPath, ec);
+      if (ec)
+        return false;
+      continue;
+    }
+
+    if (!entry.is_regular_file())
+      continue;
+
+    if (fs::exists(destinationPath, ec)) {
+      if (ec)
+        return false;
+      continue;
+    }
+
+    fs::create_directories(destinationPath.parent_path(), ec);
+    if (ec)
+      return false;
+
+    fs::copy_file(entry.path(), destinationPath, fs::copy_options::none, ec);
+    if (ec)
+      return false;
+  }
+
+  return true;
+}
+
+std::string ReadBootstrapStamp(const fs::path &stampPath) {
+  std::ifstream input(stampPath);
+  if (!input.is_open())
+    return {};
+
+  std::string version;
+  std::getline(input, version);
+  return version;
+}
+
+bool WriteBootstrapStamp(const fs::path &stampPath) {
+  std::ofstream output(stampPath, std::ios::out | std::ios::trunc);
+  if (!output.is_open())
+    return false;
+
+  output << kBootstrapVersion;
+  return true;
+}
+
+} // namespace
+
+BootstrapResult BootstrapUserLibrary(const fs::path &installedLibraryRoot,
+                                     const fs::path &userDataDir) {
+  BootstrapResult result;
+
+  std::error_code ec;
+  if (installedLibraryRoot.empty() || userDataDir.empty())
+    return result;
+
+  if (!fs::exists(installedLibraryRoot, ec) || ec || !fs::is_directory(installedLibraryRoot, ec) ||
+      ec)
+    return result;
+
+  const fs::path userLibraryRoot = userDataDir / "library";
+  fs::create_directories(userLibraryRoot, ec);
+  if (ec)
+    return result;
+
+  const fs::path stampPath = userLibraryRoot / kBootstrapStampFilename;
+  const bool needsBootstrap = ReadBootstrapStamp(stampPath) != kBootstrapVersion;
+  if (!needsBootstrap)
+    return result;
+
+  result.attempted = true;
+  if (!CopyMissingFilesRecursively(installedLibraryRoot, userLibraryRoot))
+    return result;
+
+  if (!WriteBootstrapStamp(stampPath))
+    return result;
+
+  result.completed = true;
+  return result;
+}
+
+} // namespace LibraryBootstrap

--- a/core/library/library_bootstrap.h
+++ b/core/library/library_bootstrap.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <filesystem>
+
+namespace LibraryBootstrap {
+
+struct BootstrapResult {
+  bool attempted = false;
+  bool completed = false;
+};
+
+// Bootstraps userData/library from the installed library tree.
+// The operation is non-destructive and copies only missing files.
+BootstrapResult BootstrapUserLibrary(const std::filesystem::path &installedLibraryRoot,
+                                     const std::filesystem::path &userDataDir);
+
+} // namespace LibraryBootstrap

--- a/core/projectutils.cpp
+++ b/core/projectutils.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "projectutils.h"
+#include "library/library_bootstrap.h"
 #include <cstdlib>
 #include <iostream>
 #include <filesystem>
@@ -44,29 +45,6 @@ fs::path WxStringToPath(const wxString& value)
         return fs::u8path(std::string(utf8.data(), utf8.length()));
 
     return fs::path(value.ToStdString());
-}
-
-void CopyLibrarySubdir(const fs::path& source, const fs::path& destination)
-{
-    std::error_code ec;
-    bool sourceExists = fs::exists(source, ec);
-    if (ec || !sourceExists)
-        return;
-
-    bool destinationExists = fs::exists(destination, ec);
-    if (ec || !ProjectUtils::IsDirectoryWritable(destination))
-        return;
-
-    ec.clear();
-    bool destinationEmpty = destinationExists ? fs::is_empty(destination, ec) : true;
-    if (ec)
-        return;
-
-    if (destinationEmpty || !destinationExists) {
-        ec.clear();
-        fs::copy(source, destination,
-                 fs::copy_options::recursive | fs::copy_options::update_existing, ec);
-    }
 }
 
 std::optional<fs::path> FindExistingPath(const fs::path& start,
@@ -117,6 +95,11 @@ std::string ToAbsoluteUtf8(const fs::path& path)
     if (ec)
         return {};
     return ToUtf8String(absolutePath);
+}
+
+fs::path GetBaseLibraryRoot()
+{
+    return GetBaseLibraryPath("");
 }
 
 } // namespace
@@ -277,12 +260,10 @@ std::string GetWritableLibraryPath(const std::string& subdir)
         }
     }
 
-    const fs::path installedPath = GetBaseLibraryPath(subdir);
-
     if (const auto dataDir = ResolveWritableUserDataDir()) {
+        LibraryBootstrap::BootstrapUserLibrary(GetBaseLibraryRoot(), *dataDir);
         fs::path userLib = *dataDir / "library" / subdir;
         if (IsDirectoryWritable(userLib)) {
-            CopyLibrarySubdir(installedPath, userLib);
             return ToAbsoluteUtf8(userLib);
         }
     }


### PR DESCRIPTION
### Motivation
- Provide sensible defaults for new users by populating `userData/library` from the installed `library` tree while avoiding destructive changes to existing user data.
- Allow controlled re-initialization on upgrades by tracking a bootstrap version stamp so the operation can be re-run when needed.

### Description
- Added a new module `core/library/library_bootstrap.{h,cpp}` that implements recursive copy-if-missing behavior and writes a `.bootstrap_version` stamp to `userData/library` after a successful run.
- Wired the bootstrap into `ProjectUtils::GetWritableLibraryPath(...)` so `userData/library/<subdir>` is initialized before writable paths are returned, and added a `GetBaseLibraryRoot()` helper.
- Removed the previous `CopyLibrarySubdir` ad-hoc logic from `projectutils.cpp` and registered the new `library_bootstrap.cpp` in `core/CMakeLists.txt`.
- The bootstrap is explicitly non-destructive: it only copies files that are missing in the user tree and never deletes or overwrites user files.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it completed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db885823508324867d4311809e7237)