### PR TITLE
Merge seed fixture/truss dictionaries into user dictionaries with backups

### DIFF
--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -36,6 +36,11 @@ namespace {
 
 LoadStatus g_lastLoadStatus;
 
+std::optional<std::unordered_map<std::string, Entry>>
+LoadFromFile(const fs::path &file, std::string &error);
+bool Save(const std::unordered_map<std::string, Entry> &dict,
+          std::string *errorOut = nullptr);
+
 bool PathsMatchForDictionaryEntries(const std::string &lhs,
                                     const std::string &rhs) {
   if (lhs.empty() || rhs.empty())
@@ -214,6 +219,53 @@ bool RecreateUserDictionaryFromBase(const fs::path &userFile,
   create << DictionaryJsonContract::MakeRoot("fixtures",
                                              nlohmann::json::object())
                 .dump(4);
+  return true;
+}
+
+bool WriteDictionaryBackup(const fs::path &sourceFile) {
+  if (sourceFile.empty() || !fs::exists(sourceFile))
+    return false;
+  fs::path backupFile = sourceFile;
+  backupFile += ".bak";
+  std::error_code ec;
+  fs::copy_file(sourceFile, backupFile, fs::copy_options::overwrite_existing, ec);
+  return !ec;
+}
+
+bool MergeSeedEntriesIntoUserDictionary(const fs::path &userFile,
+                                        const fs::path &baseFile,
+                                        std::unordered_map<std::string, Entry> &userDict,
+                                        bool *changedOut = nullptr) {
+  if (changedOut)
+    *changedOut = false;
+  if (userFile.empty() || baseFile.empty())
+    return false;
+
+  std::string baseError;
+  auto baseDictOpt = LoadFromFile(baseFile, baseError);
+  if (!baseDictOpt)
+    return false;
+
+  bool changed = false;
+  for (const auto &[seedKey, seedEntry] : *baseDictOpt) {
+    if (userDict.find(seedKey) != userDict.end())
+      continue;
+    userDict[seedKey] = seedEntry;
+    changed = true;
+  }
+
+  if (!changed) {
+    if (changedOut)
+      *changedOut = false;
+    return true;
+  }
+
+  WriteDictionaryBackup(userFile);
+  std::string saveError;
+  if (!Save(userDict, &saveError))
+    return false;
+  if (changedOut)
+    *changedOut = true;
   return true;
 }
 
@@ -433,8 +485,11 @@ std::optional<std::unordered_map<std::string, Entry>> Load() {
   const fs::path baseFile = GetBaseDictFile();
 
   std::string userError;
-  if (auto userDict = LoadFromFile(userFile, userError))
+  if (auto userDict = LoadFromFile(userFile, userError)) {
+    bool mergedSeedEntries = false;
+    MergeSeedEntriesIntoUserDictionary(userFile, baseFile, *userDict, &mergedSeedEntries);
     return userDict;
+  }
 
   std::cerr << "Warning: failed to load user fixtures dictionary '"
             << userFile.string() << "': " << userError

--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -36,11 +36,6 @@ namespace {
 
 LoadStatus g_lastLoadStatus;
 
-std::optional<std::unordered_map<std::string, Entry>>
-LoadFromFile(const fs::path &file, std::string &error);
-bool Save(const std::unordered_map<std::string, Entry> &dict,
-          std::string *errorOut = nullptr);
-
 bool PathsMatchForDictionaryEntries(const std::string &lhs,
                                     const std::string &rhs) {
   if (lhs.empty() || rhs.empty())
@@ -232,40 +227,23 @@ bool WriteDictionaryBackup(const fs::path &sourceFile) {
   return !ec;
 }
 
-bool MergeSeedEntriesIntoUserDictionary(const fs::path &userFile,
-                                        const fs::path &baseFile,
-                                        std::unordered_map<std::string, Entry> &userDict,
-                                        bool *changedOut = nullptr) {
+bool MergeSeedEntriesIntoUserDictionary(
+    std::unordered_map<std::string, Entry> &userDict,
+    const std::unordered_map<std::string, Entry> &baseDict,
+    bool *changedOut = nullptr) {
   if (changedOut)
     *changedOut = false;
-  if (userFile.empty() || baseFile.empty())
-    return false;
-
-  std::string baseError;
-  auto baseDictOpt = LoadFromFile(baseFile, baseError);
-  if (!baseDictOpt)
-    return false;
 
   bool changed = false;
-  for (const auto &[seedKey, seedEntry] : *baseDictOpt) {
+  for (const auto &[seedKey, seedEntry] : baseDict) {
     if (userDict.find(seedKey) != userDict.end())
       continue;
     userDict[seedKey] = seedEntry;
     changed = true;
   }
 
-  if (!changed) {
-    if (changedOut)
-      *changedOut = false;
-    return true;
-  }
-
-  WriteDictionaryBackup(userFile);
-  std::string saveError;
-  if (!Save(userDict, &saveError))
-    return false;
   if (changedOut)
-    *changedOut = true;
+    *changedOut = changed;
   return true;
 }
 
@@ -487,7 +465,14 @@ std::optional<std::unordered_map<std::string, Entry>> Load() {
   std::string userError;
   if (auto userDict = LoadFromFile(userFile, userError)) {
     bool mergedSeedEntries = false;
-    MergeSeedEntriesIntoUserDictionary(userFile, baseFile, *userDict, &mergedSeedEntries);
+    std::string baseError;
+    if (auto baseDict = LoadFromFile(baseFile, baseError)) {
+      MergeSeedEntriesIntoUserDictionary(*userDict, *baseDict, &mergedSeedEntries);
+      if (mergedSeedEntries) {
+        WriteDictionaryBackup(userFile);
+        Save(*userDict);
+      }
+    }
     return userDict;
   }
 

--- a/core/trussdictionary.cpp
+++ b/core/trussdictionary.cpp
@@ -41,11 +41,6 @@ namespace {
 
 LoadStatus g_lastLoadStatus;
 
-std::optional<std::unordered_map<std::string, std::string>>
-LoadFromFile(const fs::path &file, std::string &error);
-bool Save(const std::unordered_map<std::string, std::string> &dict,
-          std::string *errorOut = nullptr);
-
 static std::string ToUtf8String(const fs::path &path) {
   std::u8string utf8 = path.u8string();
   return std::string(utf8.begin(), utf8.end());
@@ -125,39 +120,22 @@ static bool WriteDictionaryBackup(const fs::path &sourceFile) {
 }
 
 static bool MergeSeedEntriesIntoUserDictionary(
-    const fs::path &userFile, const fs::path &baseFile,
     std::unordered_map<std::string, std::string> &userDict,
+    const std::unordered_map<std::string, std::string> &baseDict,
     bool *changedOut = nullptr) {
   if (changedOut)
     *changedOut = false;
-  if (userFile.empty() || baseFile.empty())
-    return false;
-
-  std::string baseError;
-  auto baseDictOpt = LoadFromFile(baseFile, baseError);
-  if (!baseDictOpt)
-    return false;
 
   bool changed = false;
-  for (const auto &[seedKey, seedPath] : *baseDictOpt) {
+  for (const auto &[seedKey, seedPath] : baseDict) {
     if (userDict.find(seedKey) != userDict.end())
       continue;
     userDict[seedKey] = seedPath;
     changed = true;
   }
 
-  if (!changed) {
-    if (changedOut)
-      *changedOut = false;
-    return true;
-  }
-
-  WriteDictionaryBackup(userFile);
-  std::string saveError;
-  if (!Save(userDict, &saveError))
-    return false;
   if (changedOut)
-    *changedOut = true;
+    *changedOut = changed;
   return true;
 }
 
@@ -452,7 +430,14 @@ std::optional<std::unordered_map<std::string, std::string>> Load() {
   std::string userError;
   if (auto userDict = LoadFromFile(userFile, userError)) {
     bool mergedSeedEntries = false;
-    MergeSeedEntriesIntoUserDictionary(userFile, baseFile, *userDict, &mergedSeedEntries);
+    std::string baseError;
+    if (auto baseDict = LoadFromFile(baseFile, baseError)) {
+      MergeSeedEntriesIntoUserDictionary(*userDict, *baseDict, &mergedSeedEntries);
+      if (mergedSeedEntries) {
+        WriteDictionaryBackup(userFile);
+        Save(*userDict);
+      }
+    }
     return userDict;
   }
 

--- a/core/trussdictionary.cpp
+++ b/core/trussdictionary.cpp
@@ -41,6 +41,11 @@ namespace {
 
 LoadStatus g_lastLoadStatus;
 
+std::optional<std::unordered_map<std::string, std::string>>
+LoadFromFile(const fs::path &file, std::string &error);
+bool Save(const std::unordered_map<std::string, std::string> &dict,
+          std::string *errorOut = nullptr);
+
 static std::string ToUtf8String(const fs::path &path) {
   std::u8string utf8 = path.u8string();
   return std::string(utf8.begin(), utf8.end());
@@ -106,6 +111,53 @@ static bool RecreateUserDictionaryFromBase(const fs::path &userFile,
     return false;
   create << DictionaryJsonContract::MakeRoot("trusses", nlohmann::json::object())
                 .dump(4);
+  return true;
+}
+
+static bool WriteDictionaryBackup(const fs::path &sourceFile) {
+  if (sourceFile.empty() || !fs::exists(sourceFile))
+    return false;
+  fs::path backupFile = sourceFile;
+  backupFile += ".bak";
+  std::error_code ec;
+  fs::copy_file(sourceFile, backupFile, fs::copy_options::overwrite_existing, ec);
+  return !ec;
+}
+
+static bool MergeSeedEntriesIntoUserDictionary(
+    const fs::path &userFile, const fs::path &baseFile,
+    std::unordered_map<std::string, std::string> &userDict,
+    bool *changedOut = nullptr) {
+  if (changedOut)
+    *changedOut = false;
+  if (userFile.empty() || baseFile.empty())
+    return false;
+
+  std::string baseError;
+  auto baseDictOpt = LoadFromFile(baseFile, baseError);
+  if (!baseDictOpt)
+    return false;
+
+  bool changed = false;
+  for (const auto &[seedKey, seedPath] : *baseDictOpt) {
+    if (userDict.find(seedKey) != userDict.end())
+      continue;
+    userDict[seedKey] = seedPath;
+    changed = true;
+  }
+
+  if (!changed) {
+    if (changedOut)
+      *changedOut = false;
+    return true;
+  }
+
+  WriteDictionaryBackup(userFile);
+  std::string saveError;
+  if (!Save(userDict, &saveError))
+    return false;
+  if (changedOut)
+    *changedOut = true;
   return true;
 }
 
@@ -280,8 +332,10 @@ LoadFromFile(const fs::path &file, std::string &error) {
     }
   }
 
-  if (changed)
+  if (changed) {
+    WriteDictionaryBackup(file);
     Save(dict);
+  }
   return dict;
 }
 
@@ -396,8 +450,11 @@ std::optional<std::unordered_map<std::string, std::string>> Load() {
   const fs::path userFile = GetUserDictFile();
   const fs::path baseFile = GetBaseDictFile();
   std::string userError;
-  if (auto userDict = LoadFromFile(userFile, userError))
+  if (auto userDict = LoadFromFile(userFile, userError)) {
+    bool mergedSeedEntries = false;
+    MergeSeedEntriesIntoUserDictionary(userFile, baseFile, *userDict, &mergedSeedEntries);
     return userDict;
+  }
 
   std::cerr << "Warning: failed to load user truss dictionary '" << userFile.string()
             << "': " << userError << ". Falling back to base dictionary."

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -127,6 +127,21 @@ target_link_libraries(gdtf_dictionary_color_mode_propagation_test PRIVATE
 add_test(NAME GdtfDictionaryColorModePropagation
          COMMAND gdtf_dictionary_color_mode_propagation_test)
 
+add_executable(dictionary_seed_merge_backup_test
+               dictionary_seed_merge_backup_test.cpp
+               ../core/projectutils.cpp
+               ../core/gdtfdictionary.cpp
+               ../core/trussdictionary.cpp
+               ../core/trussloader.cpp
+               ../core/truss_gdtf_builder.cpp
+               ../core/logger.cpp
+               ../models/truss.cpp)
+target_include_directories(dictionary_seed_merge_backup_test PRIVATE
+                           . ../core ../models ../third_party)
+target_link_libraries(dictionary_seed_merge_backup_test PRIVATE
+                      ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
+add_test(NAME DictionarySeedMergeBackup COMMAND dictionary_seed_merge_backup_test)
+
 add_executable(layout_template_serializer_test
                layout_template_serializer_test.cpp
                ../core/layouts/LayoutTemplateSerializer.cpp)

--- a/tests/dictionary_seed_merge_backup_test.cpp
+++ b/tests/dictionary_seed_merge_backup_test.cpp
@@ -1,0 +1,138 @@
+/*
+ * This file is part of Perastage.
+ */
+#include <cassert>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include <wx/init.h>
+
+#include "dictionary_json_contract.h"
+#include "gdtfdictionary.h"
+#include "json.hpp"
+#include "projectutils.h"
+#include "trussdictionary.h"
+
+namespace fs = std::filesystem;
+
+namespace {
+
+std::string ReadFile(const fs::path &path) {
+  std::ifstream in(path, std::ios::binary);
+  assert(in.is_open());
+  return std::string((std::istreambuf_iterator<char>(in)),
+                     std::istreambuf_iterator<char>());
+}
+
+void WriteFile(const fs::path &path, const std::string &content) {
+  std::ofstream out(path, std::ios::binary | std::ios::trunc);
+  assert(out.is_open());
+  out << content;
+  assert(out.good());
+}
+
+void SetLibraryPathEnv(const std::string &value) {
+#ifdef _WIN32
+  _putenv_s("PERASTAGE_LIBRARY_PATH", value.c_str());
+#else
+  setenv("PERASTAGE_LIBRARY_PATH", value.c_str(), 1);
+#endif
+}
+
+std::string FirstEntryKeyFromBase(const fs::path &baseDictionaryPath,
+                                  const std::string &dictionaryType) {
+  nlohmann::json root;
+  {
+    std::ifstream in(baseDictionaryPath);
+    assert(in.is_open());
+    in >> root;
+  }
+  std::string error;
+  auto entriesOpt = DictionaryJsonContract::GetEntriesForType(root, dictionaryType, error);
+  assert(entriesOpt.has_value());
+  const nlohmann::json &entries = **entriesOpt;
+  assert(entries.is_object());
+  assert(!entries.empty());
+  return entries.begin().key();
+}
+
+void VerifyFixturesMergeAndBackup(const fs::path &writableRoot) {
+  const fs::path writableFixturesDir = writableRoot / "fixtures";
+  fs::create_directories(writableFixturesDir);
+  const fs::path userPath = writableFixturesDir / "gdtf_dictionary.json";
+
+  nlohmann::json userEntries = nlohmann::json::object();
+  userEntries["CUSTOM FIXTURE KEEP"] = { {"color", "#112233"} };
+  WriteFile(userPath,
+            DictionaryJsonContract::MakeRoot("fixtures", std::move(userEntries)).dump(2));
+  const std::string before = ReadFile(userPath);
+
+  const fs::path basePath =
+      ProjectUtils::GetBaseLibraryPath("fixtures") / "gdtf_dictionary.json";
+  const std::string seedKey = FirstEntryKeyFromBase(basePath, "fixtures");
+  assert(seedKey != "CUSTOM FIXTURE KEEP");
+
+  auto loadedOpt = GdtfDictionary::Load();
+  assert(loadedOpt.has_value());
+  const auto &loaded = *loadedOpt;
+  assert(loaded.find("CUSTOM FIXTURE KEEP") != loaded.end());
+  assert(loaded.find(seedKey) != loaded.end());
+
+  const fs::path backupPath = userPath.string() + ".bak";
+  assert(fs::exists(backupPath));
+  const std::string backupText = ReadFile(backupPath);
+  assert(backupText == before);
+}
+
+void VerifyTrussesMergeAndBackup(const fs::path &writableRoot) {
+  const fs::path writableTrussesDir = writableRoot / "trusses";
+  fs::create_directories(writableTrussesDir);
+  const fs::path userPath = writableTrussesDir / "truss_dictionary.json";
+
+  const fs::path customAsset = writableTrussesDir / "custom.gdtf";
+  WriteFile(customAsset, "custom");
+
+  nlohmann::json userEntries = nlohmann::json::object();
+  userEntries["CUSTOM TRUSS KEEP"] = { {"file", customAsset.filename().string()} };
+  WriteFile(userPath,
+            DictionaryJsonContract::MakeRoot("trusses", std::move(userEntries)).dump(2));
+  const std::string before = ReadFile(userPath);
+
+  const fs::path basePath =
+      ProjectUtils::GetBaseLibraryPath("trusses") / "truss_dictionary.json";
+  const std::string seedKey = FirstEntryKeyFromBase(basePath, "trusses");
+  assert(seedKey != "CUSTOM TRUSS KEEP");
+
+  auto loadedOpt = TrussDictionary::Load();
+  assert(loadedOpt.has_value());
+  const auto &loaded = *loadedOpt;
+  assert(loaded.find(TrussDictionary::NormalizeModelKey("CUSTOM TRUSS KEEP")) != loaded.end());
+  assert(loaded.find(TrussDictionary::NormalizeModelKey(seedKey)) != loaded.end());
+
+  const fs::path backupPath = userPath.string() + ".bak";
+  assert(fs::exists(backupPath));
+  const std::string backupText = ReadFile(backupPath);
+  assert(backupText == before);
+}
+
+} // namespace
+
+int main() {
+  wxInitializer initializer;
+  assert(initializer.IsOk());
+
+  const fs::path tempRoot = fs::temp_directory_path() /
+                            fs::u8path("perastage_dictionary_seed_merge_backup_test");
+  std::error_code ec;
+  fs::remove_all(tempRoot, ec);
+  fs::create_directories(tempRoot);
+
+  SetLibraryPathEnv(tempRoot.string());
+  VerifyFixturesMergeAndBackup(tempRoot);
+  VerifyTrussesMergeAndBackup(tempRoot);
+
+  fs::remove_all(tempRoot, ec);
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- Ensure bundled seed entries for fixtures and trusses grow user dictionaries without overwriting user work. 
- Preserve existing user/custom keys while adding missing seed entries and avoid accidental deletions during dictionary migrations.
- Create a safe rollback point by saving a `*.bak` snapshot before any automatic dictionary rewrite.

### Description
- Added seed-merge + backup helpers in `core/gdtfdictionary.cpp` and `core/trussdictionary.cpp`: `WriteDictionaryBackup(...)` and `MergeSeedEntriesIntoUserDictionary(...)` and call the merge from `Load()` to add missing seed entries while preserving user entries.
- Backups are written as `(<user file>).bak` prior to persisting any automatic changes (seed merge and truss migration/normalization writes).
- Merge policy implemented: preserve existing user entries, add missing entries from the base (seed) dictionary, and do not remove or overwrite custom keys unless an explicit overwrite policy is chosen elsewhere.
- Added unit-style test `tests/dictionary_seed_merge_backup_test.cpp` and registered it in `tests/CMakeLists.txt` to validate preservation of user entries, addition of seed entries, and creation of `.bak` files.

### Testing
- Ran mandatory architecture checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both reported `OK`.
- Added and compiled-targeted new test `DictionarySeedMergeBackup` (CMake entry added), but building the new test in this environment failed due to missing `wxWidgets` development packages when running `cmake -S . -B build && cmake --build build --target dictionary_seed_merge_backup_test -j4` (CMake reported missing `wxWidgets_LIBRARIES` / `wxWidgets_INCLUDE_DIRS`).
- The change set includes the new test source and CMake registration so it will run in CI/maintainer environments with `wxWidgets` available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db8987f4188324849bca582c449aa9)