### PR TITLE
Integrate startup library bootstrap migration with detailed logging

### DIFF
--- a/core/library/library_bootstrap.cpp
+++ b/core/library/library_bootstrap.cpp
@@ -1,6 +1,6 @@
 #include "library/library_bootstrap.h"
 
-#include <fstream>
+#include <sstream>
 #include <string>
 
 namespace fs = std::filesystem;
@@ -8,73 +8,101 @@ namespace fs = std::filesystem;
 namespace LibraryBootstrap {
 namespace {
 
-constexpr const char *kBootstrapVersion = "1";
-constexpr const char *kBootstrapStampFilename = ".bootstrap_version";
-
-bool CopyMissingFilesRecursively(const fs::path &sourceRoot, const fs::path &destinationRoot) {
+bool CopyMissingFilesRecursively(const fs::path &sourceRoot, const fs::path &destinationRoot,
+                                 BootstrapResult &result) {
   std::error_code ec;
-  if (!fs::exists(sourceRoot, ec) || ec || !fs::is_directory(sourceRoot, ec) || ec)
+  if (!fs::exists(sourceRoot, ec) || ec || !fs::is_directory(sourceRoot, ec) || ec) {
+    std::ostringstream oss;
+    oss << "Installed library root is not available: " << sourceRoot.string();
+    result.errors.push_back(oss.str());
     return false;
+  }
 
-  fs::create_directories(destinationRoot, ec);
-  if (ec)
+  ec.clear();
+  const bool createdRoot = fs::create_directories(destinationRoot, ec);
+  if (ec) {
+    std::ostringstream oss;
+    oss << "Could not create destination root '" << destinationRoot.string()
+        << "': " << ec.message();
+    result.errors.push_back(oss.str());
     return false;
+  }
+  if (createdRoot)
+    ++result.directoriesCreated;
 
   for (const fs::directory_entry &entry :
        fs::recursive_directory_iterator(sourceRoot, fs::directory_options::skip_permission_denied,
                                         ec)) {
-    if (ec)
+    if (ec) {
+      std::ostringstream oss;
+      oss << "Failed while traversing '" << sourceRoot.string() << "': " << ec.message();
+      result.errors.push_back(oss.str());
       return false;
+    }
 
     const fs::path relative = fs::relative(entry.path(), sourceRoot, ec);
-    if (ec)
+    if (ec) {
+      std::ostringstream oss;
+      oss << "Failed to compute relative path for '" << entry.path().string()
+          << "': " << ec.message();
+      result.errors.push_back(oss.str());
       return false;
+    }
 
     const fs::path destinationPath = destinationRoot / relative;
     if (entry.is_directory()) {
-      fs::create_directories(destinationPath, ec);
-      if (ec)
+      ec.clear();
+      const bool createdDirectory = fs::create_directories(destinationPath, ec);
+      if (ec) {
+        std::ostringstream oss;
+        oss << "Could not create directory '" << destinationPath.string()
+            << "': " << ec.message();
+        result.errors.push_back(oss.str());
         return false;
+      }
+      if (createdDirectory)
+        ++result.directoriesCreated;
       continue;
     }
 
     if (!entry.is_regular_file())
       continue;
 
+    ec.clear();
     if (fs::exists(destinationPath, ec)) {
-      if (ec)
+      if (ec) {
+        std::ostringstream oss;
+        oss << "Could not check existing destination '" << destinationPath.string()
+            << "': " << ec.message();
+        result.errors.push_back(oss.str());
         return false;
+      }
+      ++result.filesSkippedExisting;
       continue;
     }
 
+    ec.clear();
     fs::create_directories(destinationPath.parent_path(), ec);
-    if (ec)
+    if (ec) {
+      std::ostringstream oss;
+      oss << "Could not create parent directory '" << destinationPath.parent_path().string()
+          << "': " << ec.message();
+      result.errors.push_back(oss.str());
       return false;
+    }
 
+    ec.clear();
     fs::copy_file(entry.path(), destinationPath, fs::copy_options::none, ec);
-    if (ec)
+    if (ec) {
+      std::ostringstream oss;
+      oss << "Could not copy '" << entry.path().string() << "' to '" << destinationPath.string()
+          << "': " << ec.message();
+      result.errors.push_back(oss.str());
       return false;
+    }
+    ++result.filesCopied;
   }
 
-  return true;
-}
-
-std::string ReadBootstrapStamp(const fs::path &stampPath) {
-  std::ifstream input(stampPath);
-  if (!input.is_open())
-    return {};
-
-  std::string version;
-  std::getline(input, version);
-  return version;
-}
-
-bool WriteBootstrapStamp(const fs::path &stampPath) {
-  std::ofstream output(stampPath, std::ios::out | std::ios::trunc);
-  if (!output.is_open())
-    return false;
-
-  output << kBootstrapVersion;
   return true;
 }
 
@@ -83,30 +111,32 @@ bool WriteBootstrapStamp(const fs::path &stampPath) {
 BootstrapResult BootstrapUserLibrary(const fs::path &installedLibraryRoot,
                                      const fs::path &userDataDir) {
   BootstrapResult result;
+  result.attempted = true;
 
   std::error_code ec;
-  if (installedLibraryRoot.empty() || userDataDir.empty())
+  if (installedLibraryRoot.empty() || userDataDir.empty()) {
+    result.errors.emplace_back("Bootstrap skipped because installed or user-data path is empty.");
     return result;
+  }
 
   if (!fs::exists(installedLibraryRoot, ec) || ec || !fs::is_directory(installedLibraryRoot, ec) ||
-      ec)
+      ec) {
+    result.errors.emplace_back("Bootstrap skipped because installed library root is missing.");
     return result;
+  }
 
   const fs::path userLibraryRoot = userDataDir / "library";
+  ec.clear();
   fs::create_directories(userLibraryRoot, ec);
-  if (ec)
+  if (ec) {
+    std::ostringstream oss;
+    oss << "Could not create user library root '" << userLibraryRoot.string()
+        << "': " << ec.message();
+    result.errors.push_back(oss.str());
     return result;
+  }
 
-  const fs::path stampPath = userLibraryRoot / kBootstrapStampFilename;
-  const bool needsBootstrap = ReadBootstrapStamp(stampPath) != kBootstrapVersion;
-  if (!needsBootstrap)
-    return result;
-
-  result.attempted = true;
-  if (!CopyMissingFilesRecursively(installedLibraryRoot, userLibraryRoot))
-    return result;
-
-  if (!WriteBootstrapStamp(stampPath))
+  if (!CopyMissingFilesRecursively(installedLibraryRoot, userLibraryRoot, result))
     return result;
 
   result.completed = true;

--- a/core/library/library_bootstrap.h
+++ b/core/library/library_bootstrap.h
@@ -1,12 +1,19 @@
 #pragma once
 
+#include <cstddef>
 #include <filesystem>
+#include <string>
+#include <vector>
 
 namespace LibraryBootstrap {
 
 struct BootstrapResult {
   bool attempted = false;
   bool completed = false;
+  size_t filesCopied = 0;
+  size_t filesSkippedExisting = 0;
+  size_t directoriesCreated = 0;
+  std::vector<std::string> errors;
 };
 
 // Bootstraps userData/library from the installed library tree.

--- a/core/projectutils.cpp
+++ b/core/projectutils.cpp
@@ -17,11 +17,13 @@
  */
 #include "projectutils.h"
 #include "library/library_bootstrap.h"
+#include "logger.h"
 #include <cstdlib>
 #include <iostream>
 #include <filesystem>
 #include <fstream>
 #include <optional>
+#include <sstream>
 #include <wx/filename.h>
 #include <wx/stdpaths.h>
 
@@ -100,6 +102,25 @@ std::string ToAbsoluteUtf8(const fs::path& path)
 fs::path GetBaseLibraryRoot()
 {
     return GetBaseLibraryPath("");
+}
+
+void LogBootstrapSummary(const LibraryBootstrap::BootstrapResult& result,
+                         const fs::path& installedRoot,
+                         const fs::path& userDataDir)
+{
+    std::ostringstream summary;
+    summary << "Library bootstrap migration (installed='" << installedRoot.string()
+            << "', userData='" << userDataDir.string()
+            << "') completed=" << (result.completed ? "true" : "false")
+            << ", copied=" << result.filesCopied
+            << ", skipped_existing=" << result.filesSkippedExisting
+            << ", dirs_created=" << result.directoriesCreated
+            << ", errors=" << result.errors.size();
+    Logger::Instance().Log(Logger::Level::Info, summary.str());
+
+    for (const std::string& error : result.errors) {
+        Logger::Instance().Log(Logger::Level::Error, "Library bootstrap migration error: " + error);
+    }
 }
 
 } // namespace
@@ -294,6 +315,21 @@ std::string GetDefaultLibraryPath(const std::string& subdir)
         return {};
     }
     return ToUtf8String(absolutePath);
+}
+
+void RunStartupLibraryBootstrap()
+{
+    const auto dataDir = ResolveWritableUserDataDir();
+    if (!dataDir) {
+        Logger::Instance().Log(Logger::Level::Warn,
+                               "Library bootstrap migration skipped: no writable user-data directory.");
+        return;
+    }
+
+    const fs::path installedRoot = GetBaseLibraryRoot();
+    const LibraryBootstrap::BootstrapResult result =
+        LibraryBootstrap::BootstrapUserLibrary(installedRoot, *dataDir);
+    LogBootstrapSummary(result, installedRoot, *dataDir);
 }
 
 } // namespace ProjectUtils

--- a/core/projectutils.h
+++ b/core/projectutils.h
@@ -38,6 +38,10 @@ namespace ProjectUtils {
     // Uses PERASTAGE_LIBRARY_PATH/<subdir> when writable, otherwise user-data/library/<subdir>.
     std::string GetWritableLibraryPath(const std::string& subdir);
 
+    // Runs non-destructive startup bootstrap/migration from installed library
+    // into the user-data library and logs copied/skipped/error details.
+    void RunStartupLibraryBootstrap();
+
     // Path containing the built-in resources shipped with the executable.
     std::filesystem::path GetResourceRoot();
 

--- a/main.cpp
+++ b/main.cpp
@@ -174,6 +174,9 @@ bool MyApp::OnInit() {
   // Initialize logging system (overwrites log file each launch)
   Logger::Instance();
 
+  SplashScreen::SetMessage("Running library bootstrap...");
+  ProjectUtils::RunStartupLibraryBootstrap();
+
   SplashScreen::SetMessage("Creating main window...");
   MainWindow *mainWindow = new MainWindow(app::kName);
   mainWindow->Show(true);


### PR DESCRIPTION
### Motivation
- Ensure library bootstrap/migration runs automatically at app startup (not relying on installer or manual actions) and before dictionaries/layout defaults are loaded by the UI. 
- Make the process safe to run repeatedly (idempotent) and produce actionable logs for auditing/coping errors.

### Description
- Call `ProjectUtils::RunStartupLibraryBootstrap()` from `MyApp::OnInit` (before creating the main window) so bootstrap runs early in startup. 
- Add `ProjectUtils::RunStartupLibraryBootstrap()` which invokes `LibraryBootstrap::BootstrapUserLibrary` and emits a concise summary and per-error entries to the `Logger`. 
- Extend `LibraryBootstrap::BootstrapResult` to include `filesCopied`, `filesSkippedExisting`, `directoriesCreated` and an `errors` vector, and propagate these counters from the copy routine. 
- Refactor bootstrap implementation to always perform a non-destructive copy-missing-files pass (no destructive overwrite and no dependency on a stamp/version gate), collecting metrics and detailed error messages.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed. 
- Manual verification: startup code path updated to log a bootstrap summary and per-error lines via `Logger` during app initialization.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db8df4307c8324b2984bbdc5354ff8)