### PR TITLE
Document Windows user-library model and add Tools shortcut to open it

### DIFF
--- a/docs/installation_windows.md
+++ b/docs/installation_windows.md
@@ -22,6 +22,42 @@ cmake --build out/build/x64-Release --config Release
 - Launch `Perastage.exe` from the generated build output.
 - Use `perastage_stage` when preparing a packaging-ready runtime folder.
 
+## Installed binaries vs editable user library
+
+Perastage keeps executable binaries in the installation directory (for example,
+`C:\Program Files\Perastage` when installed by Inno Setup), but editable
+library data is stored in the per-user data directory.
+
+### Editable library location (Windows)
+
+- Default writable root: `%APPDATA%\Perastage\library\`
+- Typical subfolders used by the app:
+  - `%APPDATA%\Perastage\library\fixtures\`
+  - `%APPDATA%\Perastage\library\trusses\`
+  - `%APPDATA%\Perastage\library\scene_objects\`
+  - `%APPDATA%\Perastage\library\misc\`
+  - `%APPDATA%\Perastage\library\projects\`
+  - `%APPDATA%\Perastage\library\default_layouts\`
+
+Support note: users can open this location directly from
+**Tools → Open user library folder** in the application.
+
+### Bootstrap / migration behavior
+
+At startup, Perastage runs a non-destructive bootstrap migration:
+
+1. It reads bundled seed library content from the installed app directory.
+2. It copies missing files into `%APPDATA%\Perastage\library\`.
+3. It never overwrites existing user files during this bootstrap.
+
+This lets installers update bundled defaults while preserving user-edited
+library content.
+
+### Permissions expectation
+
+Editing library content does **not** require administrator privileges because
+writes happen in the user profile tree, not inside `Program Files`.
+
 ## If Configuration Fails
 
 - Verify compiler tools from `x64 Native Tools Command Prompt` or Developer PowerShell.

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -10,6 +10,25 @@ The official Windows installer workflow uses Inno Setup:
 - Build Release and run `perastage_stage` first.
 - Compile the installer script in Inno Setup.
 - Optional associations can include `.pstg` and `.mvr`.
+- Installer binaries target `DefaultDirName={autopf}\Perastage` (standard Program Files install).
+
+### Writable data model for support
+
+Windows packaging follows a split model:
+
+- **Installed tree (`{autopf}\Perastage`)**: binaries and bundled base assets.
+- **User-data tree (`%APPDATA%\Perastage\library`)**: editable fixtures, trusses, scene objects, dictionaries, and related user library content.
+
+Perastage bootstrap/migration behavior on startup is non-destructive:
+
+1. Seed content from the installed library is used as source.
+2. Missing files are copied into the user library.
+3. Existing files in user-data are kept (no overwrite).
+
+Operationally, this means support can tell users:
+
+- “You do not need admin rights to edit your library.”
+- “Use **Tools → Open user library folder** to jump to the editable location.”
 
 ### Recommended End-to-End Windows Installer Flow
 

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -308,6 +308,7 @@ EVT_MENU(ID_Tools_ConvertToHoist, MainWindow::OnConvertToHoist)
 EVT_MENU(ID_Tools_GenerateFixtureSymbols, MainWindow::OnGenerateFixtureSymbols)
 EVT_MENU(ID_Tools_AssignSelectedFixtureCategory,
          MainWindow::OnAssignSelectedFixtureCategory)
+EVT_MENU(ID_Tools_OpenUserLibraryFolder, MainWindow::OnOpenUserLibraryFolder)
 EVT_MENU(ID_Tools_ImportRiderText, MainWindow::OnImportRiderText)
 EVT_MENU(ID_Tools_DistributeHoistWeights, MainWindow::OnDistributeHoistWeights)
 EVT_MENU(ID_Help_Help, MainWindow::OnShowHelp)

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -161,6 +161,7 @@ private:
   void
   OnDownloadGdtf(wxCommandEvent &event);   // Download fixture from GDTF Share
   void OnEditDictionaries(wxCommandEvent &event); // Edit fixture/truss dictionaries
+  void OnOpenUserLibraryFolder(wxCommandEvent &event); // Open writable library folder
   void OnClose(wxCommandEvent &event);     // Handle the Close action
   void OnCloseWindow(wxCloseEvent &event); // Handle window close
   void OnToggleConsole(wxCommandEvent &event);        // Toggle console panel

--- a/gui/mainwindow/ids/tools_ids.h
+++ b/gui/mainwindow/ids/tools_ids.h
@@ -17,3 +17,5 @@ constexpr int ID_Tools_ConvertToHoist = ID_Tools_AutoColor + 1;
 constexpr int ID_Tools_GenerateFixtureSymbols = ID_Tools_ConvertToHoist + 1;
 constexpr int ID_Tools_AssignSelectedFixtureCategory =
     ID_Tools_GenerateFixtureSymbols + 1;
+constexpr int ID_Tools_OpenUserLibraryFolder =
+    ID_Tools_AssignSelectedFixtureCategory + 1;

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -408,6 +408,7 @@ void MainWindow::CreateMenuBar() {
   wxMenu *toolsMenu = new wxMenu();
   toolsMenu->Append(ID_Tools_DownloadGdtf, "Download GDTF fixture...");
   toolsMenu->Append(ID_Tools_EditDictionaries, "Edit dictionaries...");
+  toolsMenu->Append(ID_Tools_OpenUserLibraryFolder, "Open user library folder");
   toolsMenu->Append(ID_Tools_ImportRiderText, "Create from text...");
   toolsMenu->Append(ID_Tools_DistributeHoistWeights,
                     "Distribute hoist weights...");
@@ -577,6 +578,25 @@ void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
 void MainWindow::OnEditDictionaries(wxCommandEvent &WXUNUSED(event)) {
   DictionaryEditDialog dlg(this);
   dlg.ShowModal();
+}
+
+void MainWindow::OnOpenUserLibraryFolder(wxCommandEvent &WXUNUSED(event)) {
+  const std::string fixturesPath = ProjectUtils::GetWritableLibraryPath("fixtures");
+  if (fixturesPath.empty()) {
+    wxMessageBox("Could not resolve writable user library path.",
+                 "Open user library folder", wxOK | wxICON_ERROR);
+    return;
+  }
+
+  const std::filesystem::path libraryRoot =
+      std::filesystem::u8path(fixturesPath).parent_path();
+  const std::u8string folderPathUtf8 = libraryRoot.u8string();
+  const std::string folderPathBytes(folderPathUtf8.begin(), folderPathUtf8.end());
+  const wxString folderPath = wxString::FromUTF8(folderPathBytes.c_str());
+  if (!wxLaunchDefaultApplication(folderPath)) {
+    wxMessageBox("Could not open the user library folder.",
+                 "Open user library folder", wxOK | wxICON_ERROR);
+  }
 }
 
 void MainWindow::OnAutoPatch(wxCommandEvent &WXUNUSED(event)) {

--- a/packaging/windows/Perastage.iss
+++ b/packaging/windows/Perastage.iss
@@ -34,6 +34,8 @@ AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}
 AppUpdatesURL={#MyAppURL}
 DefaultDirName={autopf}\{#MyAppName}
+; Editable library/configuration data is stored per-user under %APPDATA%\Perastage
+; by the application runtime (not inside {app}).
 UninstallDisplayIcon={app}\{#MyAppExeName}
 ArchitecturesAllowed=x64compatible
 ArchitecturesInstallIn64BitMode=x64compatible


### PR DESCRIPTION
### Motivation
- Clarify Windows installer/runtime expectations so support can quickly direct users to editable library data instead of installation binaries and avoid admin-privilege confusion.
- Provide a one-click UI entry so support can open the per-user writable library folder in under 10 seconds.

### Description
- Added a new Tools menu action `Open user library folder` with a new ID in `gui/mainwindow/ids/tools_ids.h`, a handler declaration in `gui/mainwindow.h`, and an event binding in `gui/mainwindow.cpp`.
- Implemented the handler in `gui/mainwindow_menu.cpp` which resolves the writable library root via `ProjectUtils::GetWritableLibraryPath("fixtures")`, derives the user library folder, and opens it with `wxLaunchDefaultApplication(...)`, including error reporting dialogs.
- Updated `docs/installation_windows.md` and `docs/packaging.md` to document the split storage model (`{autopf}` for binaries vs `%APPDATA%\Perastage\library` for editable data), the non-destructive bootstrap/migration behavior, and the “no admin required to edit library” expectation.
- Annotated `packaging/windows/Perastage.iss` with a comment clarifying that editable library/config data is stored per-user under `%APPDATA%` and not inside `{app}`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which succeeded.
- Performed a whitespace/format check via `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db903060bc83249828b0863b9fc2bc)