### PR TITLE
Use writable library paths across edit/import/save UI flows

### DIFF
--- a/gui/fixtureeditdialog.cpp
+++ b/gui/fixtureeditdialog.cpp
@@ -547,7 +547,7 @@ void FixtureEditDialog::MarkColumnModified(size_t index) {
 
 void FixtureEditDialog::OnBrowse(wxCommandEvent &) {
   wxString fixDir =
-      wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("fixtures"));
+      wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("fixtures"));
   wxFileDialog fdlg(this, "Select GDTF file", fixDir, wxEmptyString, "*.gdtf",
                     wxFD_OPEN | wxFD_FILE_MUST_EXIST);
   if (fdlg.ShowModal() != wxID_OK)

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -439,7 +439,7 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
   // Model file column opens file dialog
   if (col == 9) {
     wxString fixDir =
-        wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("fixtures"));
+        wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("fixtures"));
     wxFileDialog fdlg(this, "Select GDTF file", fixDir, wxEmptyString, "*.gdtf",
                       wxFD_OPEN | wxFD_FILE_MUST_EXIST);
     if (fdlg.ShowModal() == wxID_OK) {

--- a/gui/mainwindow/controllers/mainwindow_io_controller.cpp
+++ b/gui/mainwindow/controllers/mainwindow_io_controller.cpp
@@ -131,7 +131,7 @@ bool MainWindowIoController::ImportMvrFromPath(const std::string &pathUtf8) {
 
 void MainWindowIoController::OnImportMVR(wxCommandEvent &) {
   wxString miscDir =
-      wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("misc"));
+      wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("misc"));
   wxFileDialog openFileDialog(&owner_, "Import MVR file", miscDir, "",
                               "MVR files (*.mvr)|*.mvr",
                               wxFD_OPEN | wxFD_FILE_MUST_EXIST);

--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -149,7 +149,7 @@ void MainWindow::OnLoad(wxCommandEvent &event) {
         wxString::FromUTF8(std::filesystem::path(*last).parent_path().string());
   else
     projDir =
-        wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("projects"));
+        wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("projects"));
   wxFileDialog dlg(this, "Open Project", projDir, "", filter,
                    wxFD_OPEN | wxFD_FILE_MUST_EXIST);
   if (dlg.ShowModal() == wxID_CANCEL)
@@ -210,7 +210,7 @@ void MainWindow::OnSaveAs(wxCommandEvent &event) {
         wxString::FromUTF8(std::filesystem::path(*last).parent_path().string());
   else
     projDir =
-        wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("projects"));
+        wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("projects"));
 
   wxString suggestedProjectName;
   if (!currentProjectPath.empty()) {
@@ -257,7 +257,7 @@ void MainWindow::OnSaveAs(wxCommandEvent &event) {
 // Import fixtures and trusses from a rider (.txt/.pdf)
 void MainWindow::OnImportRider(wxCommandEvent &event) {
   wxString miscDir =
-      wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("misc"));
+      wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("misc"));
   wxFileDialog dlg(this, "Import Rider", miscDir, "",
                    "Rider files (*.txt;*.pdf)|*.txt;*.pdf",
                    wxFD_OPEN | wxFD_FILE_MUST_EXIST);
@@ -376,7 +376,7 @@ void MainWindow::OnImportMVR(wxCommandEvent &event) {
 
 void MainWindow::OnExportMVR(wxCommandEvent &event) {
   wxString miscDir =
-      wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("misc"));
+      wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("misc"));
   wxFileDialog saveFileDialog(this, "Export MVR file", miscDir, "",
                               "MVR files (*.mvr)|*.mvr",
                               wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
@@ -426,7 +426,7 @@ void MainWindow::OnExportTruss(wxCommandEvent &WXUNUSED(event)) {
     return;
 
   wxString trussDir =
-      wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("trusses"));
+      wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("trusses"));
   wxFileDialog saveDlg(this, "Save Truss", trussDir,
                        wxString::FromUTF8(sel) + ".gdtf",
                        "GDTF files (*.gdtf)|*.gdtf",
@@ -547,7 +547,7 @@ void MainWindow::OnExportFixture(wxCommandEvent &WXUNUSED(event)) {
   }
 
   wxString fixDir =
-      wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("fixtures"));
+      wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("fixtures"));
   wxFileDialog saveDlg(this, "Save Fixture", fixDir,
                        wxString::FromUTF8(sel) + ".gdtf", "*.gdtf",
                        wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
@@ -661,7 +661,7 @@ void MainWindow::OnExportSceneObject(wxCommandEvent &WXUNUSED(event)) {
   wxString defName =
       wxString::FromUTF8(sel) + wxString(src.extension().string());
   wxString objDir =
-      wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("scene_objects"));
+      wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("scene_objects"));
   wxFileDialog saveDlg(this, "Save Object", objDir, defName,
                        wxString("*") + wxString(src.extension().string()),
                        wxFD_SAVE | wxFD_OVERWRITE_PROMPT);

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -544,7 +544,7 @@ void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
     wxString name = wxString::FromUTF8(searchDlg.GetSelectedName());
 
     wxString fixDir =
-        wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("fixtures"));
+        wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("fixtures"));
     wxFileDialog saveDlg(this, "Save GDTF file", fixDir, name + ".gdtf",
                          "*.gdtf", wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
     if (saveDlg.ShowModal() == wxID_OK) {
@@ -1162,7 +1162,7 @@ void MainWindow::OnAddFixture(wxCommandEvent &WXUNUSED(event)) {
       return;
     if (dlgRes == wxID_OPEN) {
       wxString fixDir =
-          wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("fixtures"));
+          wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("fixtures"));
       wxFileDialog fdlg(this, "Select GDTF file", fixDir, wxEmptyString,
                         "*.gdtf", wxFD_OPEN | wxFD_FILE_MUST_EXIST);
       if (fdlg.ShowModal() != wxID_OK)
@@ -1186,7 +1186,7 @@ void MainWindow::OnAddFixture(wxCommandEvent &WXUNUSED(event)) {
     }
   } else {
     wxString fixDir =
-        wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("fixtures"));
+        wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("fixtures"));
     wxFileDialog fdlg(this, "Select GDTF file", fixDir, wxEmptyString, "*.gdtf",
                       wxFD_OPEN | wxFD_FILE_MUST_EXIST);
     if (fdlg.ShowModal() != wxID_OK)
@@ -1300,7 +1300,7 @@ void MainWindow::OnAddTruss(wxCommandEvent &WXUNUSED(event)) {
       return;
     if (dlgRes == wxID_OPEN) {
       wxString trussDir =
-          wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("trusses"));
+          wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("trusses"));
       wxFileDialog fdlg(this, "Select Truss file", trussDir, wxEmptyString,
                         "Truss files (*.gdtf;*.gtruss;*.3ds;*.glb)|*.gdtf;*.gtruss;*.3ds;*.glb|All files|*.*", wxFD_OPEN | wxFD_FILE_MUST_EXIST);
       if (fdlg.ShowModal() != wxID_OK)
@@ -1317,7 +1317,7 @@ void MainWindow::OnAddTruss(wxCommandEvent &WXUNUSED(event)) {
     }
   } else {
     wxString trussDir =
-        wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("trusses"));
+        wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("trusses"));
     wxFileDialog fdlg(this, "Select Truss file", trussDir, wxEmptyString,
                       "Truss files (*.gdtf;*.gtruss;*.3ds;*.glb)|*.gdtf;*.gtruss;*.3ds;*.glb|All files|*.*", wxFD_OPEN | wxFD_FILE_MUST_EXIST);
     if (fdlg.ShowModal() != wxID_OK)
@@ -1424,7 +1424,7 @@ void MainWindow::OnAddSceneObject(wxCommandEvent &WXUNUSED(event)) {
       return;
     if (dlgRes == wxID_OPEN) {
       wxString objDir = wxString::FromUTF8(
-          ProjectUtils::GetDefaultLibraryPath("scene_objects"));
+          ProjectUtils::GetWritableLibraryPath("scene_objects"));
       wxFileDialog fdlg(this, "Select Object file", objDir, wxEmptyString,
                         "*.*", wxFD_OPEN | wxFD_FILE_MUST_EXIST);
       if (fdlg.ShowModal() != wxID_OK)
@@ -1441,7 +1441,7 @@ void MainWindow::OnAddSceneObject(wxCommandEvent &WXUNUSED(event)) {
     }
   } else {
     wxString objDir = wxString::FromUTF8(
-        ProjectUtils::GetDefaultLibraryPath("scene_objects"));
+        ProjectUtils::GetWritableLibraryPath("scene_objects"));
     wxFileDialog fdlg(this, "Select Object file", objDir, wxEmptyString, "*.*",
                       wxFD_OPEN | wxFD_FILE_MUST_EXIST);
     if (fdlg.ShowModal() != wxID_OK)

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -400,7 +400,7 @@ void SceneObjectTablePanel::OnContextMenu(wxDataViewEvent& event)
 
     if (col == 2)
     {
-        wxString initialDir = wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("objects"));
+        wxString initialDir = wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("objects"));
         if (row >= 0 && static_cast<size_t>(row) < modelPaths.size() && !modelPaths[static_cast<size_t>(row)].IsEmpty()) {
             wxFileName current(modelPaths[static_cast<size_t>(row)]);
             if (current.DirExists())

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -423,7 +423,7 @@ void TrussTablePanel::OnContextMenu(wxDataViewEvent& event)
     if (col == 2)
     {
         wxString trussDir =
-            wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("trusses"));
+            wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("trusses"));
         wxFileDialog fdlg(this, "Select Truss Model", trussDir, wxEmptyString,
                           "Truss files (*.gdtf;*.gtruss;*.3ds;*.glb)|*.gdtf;*.gtruss;*.3ds;*.glb|All files|*.*",
                           wxFD_OPEN | wxFD_FILE_MUST_EXIST);


### PR DESCRIPTION
### Motivation

- Ensure UI flows for creating, editing, importing and saving resolve to writable user-data library locations instead of the legacy default/installed path so user actions land in `user-data/library` when appropriate. 
- Eliminate inconsistent call-sites that could direct user-initiated file dialogs or exports to read-only installation roots while keeping dictionary read-fallback behavior unchanged. 

### Description

- Replaced `ProjectUtils::GetDefaultLibraryPath(...)` with `ProjectUtils::GetWritableLibraryPath(...)` in UI entry points for edit/import/save/export dialogs and context-menu browse actions. 
- Updated the following UI source files: `gui/mainwindow_menu.cpp`, `gui/mainwindow_io.cpp`, `gui/mainwindow/controllers/mainwindow_io_controller.cpp`, `gui/fixturetablepanel.cpp`, `gui/trusstablepanel.cpp`, `gui/fixtureeditdialog.cpp`, and `gui/sceneobjecttablepanel.cpp`. 
- Confirmed dictionary modules continue to use `GetWritableLibraryPath(...)` for user-writeable dictionary files and `GetBaseLibraryPath(...)` only as a read-only fallback (see `core/gdtfdictionary.cpp` and `core/trussdictionary.cpp`), and that `gui/dictionaryeditdialog.cpp` already targets writable locations. 

### Testing

- Ran `tests/check_perastage_tree_modules.sh` which passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed. 
- Performed a local scan of modified UI call-sites to verify dialogs now default to `GetWritableLibraryPath(...)` for fixtures, trusses, scene objects, rider/MVR import, and project open/save flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db91ddfeb483248e657a62839214fe)