### PR TITLE
Add CI guardrails for dictionary write policy and dictionary path contracts

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,12 @@ find_program(BASH_EXECUTABLE bash)
 if(BASH_EXECUTABLE)
     add_test(NAME DocsPerastageTreeModules
              COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_perastage_tree_modules.sh)
+    add_test(NAME GuiNoConfigManagerGet
+             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_no_configmanager_get_in_gui.sh)
+    add_test(NAME LibraryUserDataPolicy
+             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_library_user_data_policy.sh)
+    add_test(NAME DictionaryPathsPolicy
+             COMMAND ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_dictionary_paths.sh)
 endif()
 
 include_directories(

--- a/tests/check_dictionary_paths.sh
+++ b/tests/check_dictionary_paths.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if ! rg -q 'return dir / "gdtf_dictionary\.json";' core/gdtfdictionary.cpp; then
+  echo "ERROR: fixtures dictionary file name contract changed unexpectedly." >&2
+  exit 1
+fi
+
+if ! rg -q 'return dir / "truss_dictionary\.json";' core/trussdictionary.cpp; then
+  echo "ERROR: trusses dictionary file name contract changed unexpectedly." >&2
+  exit 1
+fi
+
+if ! rg -q 'return ProjectUtils::GetBaseLibraryPath\("fixtures"\) / "gdtf_dictionary\.json";' core/gdtfdictionary.cpp; then
+  echo "ERROR: fixtures base dictionary fallback path is missing." >&2
+  exit 1
+fi
+
+if ! rg -q 'return ProjectUtils::GetBaseLibraryPath\("trusses"\) / "truss_dictionary\.json";' core/trussdictionary.cpp; then
+  echo "ERROR: trusses base dictionary fallback path is missing." >&2
+  exit 1
+fi
+
+echo "OK: dictionary file path contracts (user + base fallback) are intact."

--- a/tests/check_library_user_data_policy.sh
+++ b/tests/check_library_user_data_policy.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cd "$ROOT_DIR"
+
+# Guardrail: runtime writes must not target installation paths.
+# We enforce this on dictionary write entry points where a past regression happened.
+for file in core/gdtfdictionary.cpp core/trussdictionary.cpp; do
+  if rg -n 'Get(Default|Installed|Base)LibraryPath\("(fixtures|trusses)"\)' "$file" \
+      | rg -v 'GetBaseLibraryPath\("(fixtures|trusses)"\) / "(gdtf|truss)_dictionary\.json"'; then
+    echo "ERROR: $file contains non-user-data dictionary path resolution." >&2
+    exit 1
+  fi
+
+done
+
+if ! rg -q 'ProjectUtils::GetWritableLibraryPath\("fixtures"\)' core/gdtfdictionary.cpp; then
+  echo "ERROR: core/gdtfdictionary.cpp must resolve editable fixtures data via GetWritableLibraryPath()." >&2
+  exit 1
+fi
+
+if ! rg -q 'ProjectUtils::GetWritableLibraryPath\("trusses"\)' core/trussdictionary.cpp; then
+  echo "ERROR: core/trussdictionary.cpp must resolve editable trusses data via GetWritableLibraryPath()." >&2
+  exit 1
+fi
+
+echo "OK: dictionary write flows resolve user-data paths and avoid installation writes."


### PR DESCRIPTION
### Motivation
- Prevent regressions that would cause editable dictionary writes to target installation paths instead of the user-data library. 
- Ensure dictionary filename and base-fallback path contracts for `fixtures` and `trusses` remain stable and detectable by CI.

### Description
- Add `tests/check_library_user_data_policy.sh` to enforce that dictionary write flows resolve via `ProjectUtils::GetWritableLibraryPath(...)` and do not use install-target resolvers. 
- Add `tests/check_dictionary_paths.sh` to lock the expected `gdtf_dictionary.json` and `truss_dictionary.json` filename contracts and base-fallback `GetBaseLibraryPath(...)` returns. 
- Register both shell checks in `tests/CMakeLists.txt` so CTest/CI runs `check_library_user_data_policy.sh` and `check_dictionary_paths.sh` alongside existing checks. 
- Mark the new scripts executable so they run in CI (`chmod +x` applied to the added files). 

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded. 
- Ran `tests/check_library_user_data_policy.sh` and it succeeded. 
- Ran `tests/check_dictionary_paths.sh` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db9509bf40832490ef0297e4803e42)