### PR TITLE
Sync 3D wireframe background with 2D Dark mode preference

### DIFF
--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -91,6 +91,10 @@ bool IsFastInteractionModeEnabled()
     return ConfigManager::Get().GetFloat("viewer3d_fast_interaction_mode") >= 0.5f;
 }
 
+bool Is2DDarkModeEnabled() {
+    return ConfigManager::Get().GetFloat("view2d_dark_mode") >= 0.5f;
+}
+
 Viewer3DRenderStyle ResolveRenderStyleFromPreferences() {
     return ResolveViewer3DRenderStyle(ConfigManager::Get());
 }
@@ -144,7 +148,10 @@ void ApplyViewer3DClearColorForStyle(Viewer3DRenderStyle style) {
         return;
     }
     if (style == Viewer3DRenderStyle::Wireframe) {
-        glClearColor(0.95f, 0.95f, 0.95f, 1.0f);
+        if (Is2DDarkModeEnabled())
+            glClearColor(0.08f, 0.08f, 0.08f, 1.0f);
+        else
+            glClearColor(0.95f, 0.95f, 0.95f, 1.0f);
         return;
     }
     if (style == Viewer3DRenderStyle::Textured) {


### PR DESCRIPTION
### Motivation
- Make the 3D viewer's Wireframe render style follow the existing `view2d_dark_mode` setting so the wireframe background matches the 2D "Dark mode" preference without altering other render styles.

### Description
- Added a small helper `Is2DDarkModeEnabled()` and used it in `ApplyViewer3DClearColorForStyle()` in `viewer3d/viewer3dpanel.cpp` to choose a dark or light clear color only when the `Viewer3DRenderStyle` is `Wireframe`.
- No other render styles or UI behavior were changed and the change is scoped to the 3D viewer rendering code.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db967b2c388324839059d938d71985)