### PR TITLE
Fix 3D wireframe fixture depth ordering

### DIFF
--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -469,7 +469,9 @@ void OpaqueFixturePass::Render(
   const bool drawRealTopInTopView = isTopView2D && !forceBottomViewForTopFixtures;
 
   glShadeModel((context.texturedStyle && !wireframe) ? GL_SMOOTH : GL_FLAT);
-  const bool forceFixturesOnTop = wireframe;
+  // Keep 2D wireframe fixture overlays unchanged, but in the real 3D wireframe
+  // viewer fixtures must respect depth like all other geometry.
+  const bool forceFixturesOnTop = wireframe && is2DViewer;
   GLboolean depthEnabled = GL_FALSE;
   if (forceFixturesOnTop) {
     depthEnabled = glIsEnabled(GL_DEPTH_TEST);


### PR DESCRIPTION
### Motivation
- Wireframe mode previously forced fixtures to draw on top by using `forceFixturesOnTop = wireframe`, which produced incorrect depth ordering in the real 3D viewer instead of respecting camera depth.

### Description
- In `viewer3d/render/opaque_fixture_pass.cpp` change `forceFixturesOnTop` to `wireframe && is2DViewer` and add a clarifying comment so only 2D wireframe overlays bypass depth testing.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db9946bf988324bcf78dab04f992d9)