### PR TITLE
FitView: frame selected items first in 2D and 3D viewers

### DIFF
--- a/docs/gui_shortcut_architecture.md
+++ b/docs/gui_shortcut_architecture.md
@@ -75,7 +75,9 @@ This makes shortcut behavior deterministic and keeps one single decision point f
      active `wxGrid` cell editors.
 2. The hook asks `ResolveShortcut(...)` for one decision.
 3. `MainWindow::ApplyShortcutDecision(...)` executes the routed action:
-   - `ApplyFitShortcut()` for focused viewer fit,
+   - `ApplyFitShortcut()` for focused viewer fit (selection-aware: when there is
+     an active selection, fit targets selected fixtures/trusses/scene objects;
+     otherwise it falls back to fitting the full scene),
    - `FocusConsoleForQuickCommand(...)` for CLI-prefill actions,
    - notebook-tab selection commands for `1..4`,
    - `ApplyViewportShortcut(...)` for top/front/side numpad view actions in the active viewer,

--- a/viewer2d/viewer2dviewfit.cpp
+++ b/viewer2d/viewer2dviewfit.cpp
@@ -3,6 +3,7 @@
 #include "iselectioncontext.h"
 #include <algorithm>
 #include <limits>
+#include <unordered_set>
 
 namespace {
 constexpr float kPixelsPerMeter = 25.0f;
@@ -63,16 +64,38 @@ bool ComputeViewFit(const ISelectionContext &selectionContext, Viewer2DView view
   float minB = std::numeric_limits<float>::max();
   float maxB = std::numeric_limits<float>::lowest();
 
-  auto accumulate = [&](const auto &map) {
+  bool hasBounds = false;
+  auto accumulateAll = [&](const auto &map) {
     for (const auto &[uuid, bounds] : map) {
       (void)uuid;
       ExpandProjectedBounds(bounds, view, minA, maxA, minB, maxB);
+      hasBounds = true;
     }
   };
 
-  accumulate(selectionContext.GetFixtureBoundsMap());
-  accumulate(selectionContext.GetTrussBoundsMap());
-  accumulate(selectionContext.GetObjectBoundsMap());
+  auto accumulateSelected = [&](const auto &map,
+                                const std::unordered_set<std::string> &selected) {
+    for (const auto &uuid : selected) {
+      const auto it = map.find(uuid);
+      if (it == map.end())
+        continue;
+      ExpandProjectedBounds(it->second, view, minA, maxA, minB, maxB);
+      hasBounds = true;
+    }
+  };
+
+  const auto &selected = selectionContext.GetSelectedUuids();
+  if (!selected.empty()) {
+    accumulateSelected(selectionContext.GetFixtureBoundsMap(), selected);
+    accumulateSelected(selectionContext.GetTrussBoundsMap(), selected);
+    accumulateSelected(selectionContext.GetObjectBoundsMap(), selected);
+  }
+
+  if (!hasBounds) {
+    accumulateAll(selectionContext.GetFixtureBoundsMap());
+    accumulateAll(selectionContext.GetTrussBoundsMap());
+    accumulateAll(selectionContext.GetObjectBoundsMap());
+  }
 
   if (minA > maxA || minB > maxB)
     return false;

--- a/viewer3d/interfaces/iselectioncontext.h
+++ b/viewer3d/interfaces/iselectioncontext.h
@@ -31,6 +31,7 @@ public:
                 bool useFrustumCulling, float minPixels) const = 0;
 
   virtual const std::string &GetHighlightUuid() const = 0;
+  virtual const std::unordered_set<std::string> &GetSelectedUuids() const = 0;
   virtual const std::unordered_map<std::string, BoundingBox> &
   GetFixtureBoundsMap() const = 0;
   virtual const std::unordered_map<std::string, BoundingBox> &

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1874,6 +1874,11 @@ const std::string &Viewer3DController::GetHighlightUuid() const {
   return m_impl->highlightUuid;
 }
 
+const std::unordered_set<std::string> &
+Viewer3DController::GetSelectedUuids() const {
+  return m_impl->selectedUuids;
+}
+
 const std::unordered_map<std::string, Viewer3DController::BoundingBox> &
 Viewer3DController::GetFixtureBoundsMap() const {
   return m_impl->fixtureBounds;

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -281,6 +281,7 @@ private:
   const BoundingBox *FindTrussBounds(const std::string &uuid) const override;
   const BoundingBox *FindObjectBounds(const std::string &uuid) const override;
   const std::string &GetHighlightUuid() const override;
+  const std::unordered_set<std::string> &GetSelectedUuids() const override;
   const std::unordered_map<std::string, BoundingBox> &
   GetFixtureBoundsMap() const override;
   const std::unordered_map<std::string, BoundingBox> &

--- a/viewer3d/viewer3dviewfit.cpp
+++ b/viewer3d/viewer3dviewfit.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <cmath>
 #include <limits>
+#include <unordered_set>
 
 namespace {
 constexpr float kFitPaddingScale = 1.03f;
@@ -38,7 +39,8 @@ bool FrameSceneInCamera(const ISelectionContext &selectionContext,
   float maxY = std::numeric_limits<float>::lowest();
   float maxZ = std::numeric_limits<float>::lowest();
 
-  auto accumulate = [&](const auto &map) {
+  bool hasBounds = false;
+  auto accumulateAll = [&](const auto &map) {
     for (const auto &[uuid, bounds] : map) {
       (void)uuid;
       minX = std::min(minX, bounds.min[0]);
@@ -47,12 +49,39 @@ bool FrameSceneInCamera(const ISelectionContext &selectionContext,
       maxX = std::max(maxX, bounds.max[0]);
       maxY = std::max(maxY, bounds.max[1]);
       maxZ = std::max(maxZ, bounds.max[2]);
+      hasBounds = true;
     }
   };
 
-  accumulate(selectionContext.GetFixtureBoundsMap());
-  accumulate(selectionContext.GetTrussBoundsMap());
-  accumulate(selectionContext.GetObjectBoundsMap());
+  auto accumulateSelected = [&](const auto &map,
+                                const std::unordered_set<std::string> &selected) {
+    for (const auto &uuid : selected) {
+      const auto it = map.find(uuid);
+      if (it == map.end())
+        continue;
+      const auto &bounds = it->second;
+      minX = std::min(minX, bounds.min[0]);
+      minY = std::min(minY, bounds.min[1]);
+      minZ = std::min(minZ, bounds.min[2]);
+      maxX = std::max(maxX, bounds.max[0]);
+      maxY = std::max(maxY, bounds.max[1]);
+      maxZ = std::max(maxZ, bounds.max[2]);
+      hasBounds = true;
+    }
+  };
+
+  const auto &selected = selectionContext.GetSelectedUuids();
+  if (!selected.empty()) {
+    accumulateSelected(selectionContext.GetFixtureBoundsMap(), selected);
+    accumulateSelected(selectionContext.GetTrussBoundsMap(), selected);
+    accumulateSelected(selectionContext.GetObjectBoundsMap(), selected);
+  }
+
+  if (!hasBounds) {
+    accumulateAll(selectionContext.GetFixtureBoundsMap());
+    accumulateAll(selectionContext.GetTrussBoundsMap());
+    accumulateAll(selectionContext.GetObjectBoundsMap());
+  }
 
   if (minX > maxX || minY > maxY || minZ > maxZ)
     return false;


### PR DESCRIPTION
### Motivation
- Improve the `Z` / `FitView` shortcut so that when there is an active selection (one or many UUIDs, possibly from different tables) the fit centers and zooms to the selected items instead of always fitting the whole scene.
- Preserve current behavior by falling back to the full-scene fit when there is no valid selected bounds.

### Description
- Added `GetSelectedUuids()` to `ISelectionContext` and implemented the accessor in `Viewer3DController` to expose current selection for shared fit logic.
- Updated `viewer2d::ComputeViewFit` (`viewer2d/viewer2dviewfit.cpp`) to first accumulate bounds from `GetSelectedUuids()` and compute the 2D fit from that set, and to fall back to full-scene bounds when no selected bounds exist.
- Updated `viewer3d::FrameSceneInCamera` (`viewer3d/viewer3dviewfit.cpp`) with the same selected-first accumulation logic for 3D camera framing.
- Documented the new selection-aware behavior in `docs/gui_shortcut_architecture.md` so `ApplyFitShortcut()` is noted as selection-aware without changing shortcut routing.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which succeeded. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db9b8abc54832489ea5ce3bf0cdf45)