### PR TITLE
Sync dictionary fixture colors when mode changes

### DIFF
--- a/gui/dictionaryeditdialog.cpp
+++ b/gui/dictionaryeditdialog.cpp
@@ -1482,6 +1482,51 @@ void DictionaryEditDialog::UpdateFixtureColorForFileAndMode(
   }
 }
 
+void DictionaryEditDialog::SyncFixtureColorForFileAndMode(int row) {
+  if (!fixtureTable || row < 0 || static_cast<size_t>(row) >= fixturePaths.size())
+    return;
+
+  const std::string &targetPath = fixturePaths[static_cast<size_t>(row)];
+  if (targetPath.empty())
+    return;
+
+  wxVariant targetModeVar;
+  fixtureTable->GetValue(targetModeVar, row, kFixtureModeColumn);
+  const std::string targetModeKey =
+      NormalizeFixtureModeKey(std::string(targetModeVar.GetString().ToUTF8()));
+  if (targetModeKey.empty())
+    return;
+
+  const int rowCount = fixtureTable->GetItemCount();
+  for (int i = 0; i < rowCount; ++i) {
+    if (i == row)
+      continue;
+    if (static_cast<size_t>(i) >= fixturePaths.size())
+      continue;
+    if (!FixturePathsMatchForColorFamily(fixturePaths[static_cast<size_t>(i)],
+                                         targetPath)) {
+      continue;
+    }
+
+    wxVariant modeVar;
+    fixtureTable->GetValue(modeVar, i, kFixtureModeColumn);
+    const std::string modeKey =
+        NormalizeFixtureModeKey(std::string(modeVar.GetString().ToUTF8()));
+    if (modeKey != targetModeKey)
+      continue;
+
+    wxVariant colorVar;
+    fixtureTable->GetValue(colorVar, i, kFixtureColorColumn);
+    const std::string color = ExtractFixtureColorText(colorVar);
+    const auto normalizedColor = NormalizeFixtureHexColor(color);
+    if (!normalizedColor.has_value() || normalizedColor->empty())
+      continue;
+
+    SetFixtureColorCell(fixtureTable, row, *normalizedColor);
+    return;
+  }
+}
+
 void DictionaryEditDialog::UpdateFixtureCategoryForFile(
     int row, const std::string &category) {
   if (!fixtureTable || row < 0 || static_cast<size_t>(row) >= fixturePaths.size())
@@ -1980,6 +2025,7 @@ void DictionaryEditDialog::OnItemActivated(wxDataViewEvent &event) {
         std::string mode = std::string(dlg.GetStringSelection().ToUTF8());
         table->SetValue(wxVariant(wxString::FromUTF8(mode)), row,
                         kFixtureModeColumn);
+        SyncFixtureColorForFileAndMode(row);
       }
       return;
     }
@@ -2054,6 +2100,7 @@ void DictionaryEditDialog::OnItemActivated(wxDataViewEvent &event) {
     }
     table->SetValue(wxVariant(wxString::FromUTF8(mode)), row,
                     kFixtureModeColumn);
+    SyncFixtureColorForFileAndMode(row);
   } else {
     if (col != 1)
       return;

--- a/gui/dictionaryeditdialog.h
+++ b/gui/dictionaryeditdialog.h
@@ -42,6 +42,7 @@ private:
   bool HasTrussChanges() const;
   void ShowDictionaryLoadStatusMessages();
   bool IsFixturesPage() const;
+  void SyncFixtureColorForFileAndMode(int row);
   void UpdateFixtureCategoryForFile(int row, const std::string &category);
   void UpdateFixtureColorForFileAndMode(int row, const std::string &colorHex);
   void OnFixtureTableMouseMove(wxMouseEvent &event);


### PR DESCRIPTION
### Motivation
- Improve dictionary editor UX by reusing existing color assignments when a fixture row changes mode or file so users don't have to re-enter colors for the same file+mode.

### Description
- Added `SyncFixtureColorForFileAndMode(int row)` to `DictionaryEditDialog` to find another row with the same fixture file (or file family) and the same normalized mode and copy its normalized hex color into the edited row.
- Wire `SyncFixtureColorForFileAndMode` to run after the user picks a DMX mode in the mode editor and after the user changes the fixture file and an initial mode is selected.
- Reused existing helpers: `NormalizeFixtureModeKey`, `FixturePathsMatchForColorFamily`, `NormalizeFixtureHexColor`, and `SetFixtureColorCell` to ensure normalized comparisons and proper cell rendering.
- Modified files: `gui/dictionaryeditdialog.h` and `gui/dictionaryeditdialog.cpp`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbcacc503483248a847528db586810)