### PR TITLE
Add persistent dictionary file selection in dictionary editor

### DIFF
--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "gdtfdictionary.h"
+#include "configmanager.h"
 #include "dictionary_json_contract.h"
 #include "file_import_utils.h"
 #include "json.hpp"
@@ -35,6 +36,68 @@ namespace GdtfDictionary {
 namespace {
 
 LoadStatus g_lastLoadStatus;
+
+
+constexpr const char *kFixturesDictionaryPathConfigKey =
+    "fixtures_dictionary_active_path";
+
+std::string TrimAsciiWhitespace(const std::string &text) {
+  const size_t start = text.find_first_not_of(" \t\r\n");
+  if (start == std::string::npos)
+    return {};
+  const size_t end = text.find_last_not_of(" \t\r\n");
+  return text.substr(start, end - start + 1);
+}
+
+bool IsSupportedDictionaryFile(const fs::path &path) {
+  return path.has_extension() && path.extension() == ".json";
+}
+
+fs::path ResolveConfiguredDictionaryPath(const fs::path &defaultPath,
+                                         const std::string &rawConfiguredPath,
+                                         std::string *warningOut = nullptr) {
+  if (warningOut)
+    warningOut->clear();
+  const std::string trimmedPath = TrimAsciiWhitespace(rawConfiguredPath);
+  if (trimmedPath.empty())
+    return defaultPath;
+
+  fs::path configuredPath = fs::u8path(trimmedPath);
+  if (configuredPath.is_relative()) {
+    configuredPath = defaultPath.parent_path() / configuredPath;
+  }
+
+  if (configuredPath.has_filename() && IsSupportedDictionaryFile(configuredPath)) {
+    std::error_code ec;
+    fs::create_directories(configuredPath.parent_path(), ec);
+    if (!ec)
+      return configuredPath;
+    if (warningOut)
+      *warningOut = "Could not create dictionary directory for configured path: " +
+                    configuredPath.parent_path().string();
+    return defaultPath;
+  }
+
+  if (warningOut)
+    *warningOut = "Configured fixtures dictionary path is invalid. Expected a .json file path.";
+  return defaultPath;
+}
+
+fs::path GetConfiguredUserDictFile(std::string *warningOut = nullptr) {
+  const fs::path defaultPath = GetUserDictFile();
+  if (defaultPath.empty()) {
+    if (warningOut)
+      *warningOut = "Default fixtures dictionary path is empty";
+    return {};
+  }
+
+  const auto configured =
+      ConfigManager::Get().GetValue(kFixturesDictionaryPathConfigKey);
+  if (!configured)
+    return defaultPath;
+  return ResolveConfiguredDictionaryPath(defaultPath, *configured, warningOut);
+}
+
 
 bool PathsMatchForDictionaryEntries(const std::string &lhs,
                                     const std::string &rhs) {
@@ -455,11 +518,99 @@ DictionaryImportSummary MergeDictionaryEntries(
 
 } // namespace
 
+
+std::string GetActiveDictionaryFilePath() {
+  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
+  return GetConfiguredUserDictFile().string();
+}
+
+std::string GetActiveDictionaryFileName() {
+  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
+  const fs::path path = GetConfiguredUserDictFile();
+  if (path.empty())
+    return {};
+  return path.filename().string();
+}
+
+bool SetActiveDictionaryFilePath(const std::string &path, std::string *errorOut) {
+  if (errorOut)
+    errorOut->clear();
+  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
+
+  const fs::path defaultPath = GetUserDictFile();
+  if (defaultPath.empty()) {
+    if (errorOut)
+      *errorOut = "Default fixtures dictionary path is empty";
+    return false;
+  }
+
+  std::string warning;
+  const fs::path resolvedPath =
+      ResolveConfiguredDictionaryPath(defaultPath, path, &warning);
+  if (!warning.empty() && TrimAsciiWhitespace(path) != TrimAsciiWhitespace(defaultPath.string())) {
+    if (errorOut)
+      *errorOut = warning;
+    return false;
+  }
+
+  const auto previousValue = ConfigManager::Get().GetValue(kFixturesDictionaryPathConfigKey);
+
+  const std::string trimmedInput = TrimAsciiWhitespace(path);
+  if (trimmedInput.empty() || resolvedPath == defaultPath) {
+    ConfigManager::Get().RemoveKey(kFixturesDictionaryPathConfigKey);
+  } else {
+    ConfigManager::Get().SetValue(kFixturesDictionaryPathConfigKey,
+                                  resolvedPath.string());
+  }
+
+  if (!ConfigManager::Get().SaveUserConfig()) {
+    if (previousValue)
+      ConfigManager::Get().SetValue(kFixturesDictionaryPathConfigKey, *previousValue);
+    else
+      ConfigManager::Get().RemoveKey(kFixturesDictionaryPathConfigKey);
+    if (errorOut)
+      *errorOut = "Could not persist dictionary selection in user config";
+    return false;
+  }
+
+  if (!fs::exists(resolvedPath)) {
+    if (!RecreateUserDictionaryFromBase(resolvedPath, GetBaseDictFile())) {
+      std::string createError;
+      if (!Save({}, &createError)) {
+        if (previousValue)
+          ConfigManager::Get().SetValue(kFixturesDictionaryPathConfigKey, *previousValue);
+        else
+          ConfigManager::Get().RemoveKey(kFixturesDictionaryPathConfigKey);
+        ConfigManager::Get().SaveUserConfig();
+        if (errorOut)
+          *errorOut = "Could not create selected fixtures dictionary file: " +
+                      createError;
+        return false;
+      }
+    }
+  }
+
+  std::string loadError;
+  if (!LoadFromFile(resolvedPath, loadError)) {
+    if (previousValue)
+      ConfigManager::Get().SetValue(kFixturesDictionaryPathConfigKey, *previousValue);
+    else
+      ConfigManager::Get().RemoveKey(kFixturesDictionaryPathConfigKey);
+    ConfigManager::Get().SaveUserConfig();
+    if (errorOut)
+      *errorOut = "Could not load selected fixtures dictionary: " + loadError;
+    return false;
+  }
+
+
+  return true;
+}
+
 std::optional<std::unordered_map<std::string, Entry>> Load() {
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
   g_lastLoadStatus = {};
 
-  const fs::path userFile = GetUserDictFile();
+  const fs::path userFile = GetConfiguredUserDictFile(&g_lastLoadStatus.error);
   const fs::path baseFile = GetBaseDictFile();
 
   std::string userError;
@@ -505,7 +656,7 @@ bool Save(const std::unordered_map<std::string, Entry> &dict,
   if (errorOut)
     errorOut->clear();
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
-  fs::path file = GetUserDictFile();
+  fs::path file = GetConfiguredUserDictFile(errorOut);
   if (file.empty()) {
     if (errorOut)
       *errorOut = "User fixtures dictionary path is empty";
@@ -635,7 +786,7 @@ void Update(const std::string &type, const std::string &gdtfPath, const std::str
   const fs::path src = fs::u8path(gdtfPath);
   if (!fs::exists(src))
     return;
-  const fs::path file = GetUserDictFile();
+  const fs::path file = GetConfiguredUserDictFile();
   if (file.empty())
     return;
 

--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -36,6 +36,7 @@ namespace GdtfDictionary {
 namespace {
 
 LoadStatus g_lastLoadStatus;
+fs::path GetUserDictFile();
 
 
 constexpr const char *kFixturesDictionaryPathConfigKey =

--- a/core/gdtfdictionary.h
+++ b/core/gdtfdictionary.h
@@ -42,6 +42,11 @@ namespace GdtfDictionary {
     // Loads the dictionary file into a map of type -> {gdtf path in library, default mode}
     std::optional<std::unordered_map<std::string, Entry>> Load();
     LoadStatus GetLastLoadStatus();
+
+    std::string GetActiveDictionaryFilePath();
+    std::string GetActiveDictionaryFileName();
+    bool SetActiveDictionaryFilePath(const std::string &path,
+                                     std::string *errorOut = nullptr);
     // Saves the dictionary map back to disk.
     // Returns false and optionally fills errorOut when writing fails.
     bool Save(const std::unordered_map<std::string, Entry>& dict,

--- a/core/trussdictionary.cpp
+++ b/core/trussdictionary.cpp
@@ -17,6 +17,7 @@
  */
 #include "trussdictionary.h"
 
+#include "configmanager.h"
 #include "dictionary_json_contract.h"
 #include "file_import_utils.h"
 #include "json.hpp"
@@ -40,6 +41,8 @@ namespace TrussDictionary {
 namespace {
 
 LoadStatus g_lastLoadStatus;
+constexpr const char *kTrussDictionaryPathConfigKey =
+    "trusses_dictionary_active_path";
 
 static std::string ToUtf8String(const fs::path &path) {
   std::u8string utf8 = path.u8string();
@@ -78,6 +81,10 @@ static std::string CollapseAsciiWhitespace(const std::string &text) {
   return collapsed;
 }
 
+static bool IsSupportedDictionaryFile(const fs::path &path) {
+  return path.has_extension() && path.extension() == ".json";
+}
+
 static fs::path GetUserDictFile() {
   fs::path dir = fs::u8path(ProjectUtils::GetWritableLibraryPath("trusses"));
   if (dir.empty())
@@ -87,6 +94,53 @@ static fs::path GetUserDictFile() {
   if (ec)
     return {};
   return dir / "truss_dictionary.json";
+}
+
+static fs::path ResolveConfiguredDictionaryPath(
+    const fs::path &defaultPath, const std::string &rawConfiguredPath,
+    std::string *warningOut = nullptr) {
+  if (warningOut)
+    warningOut->clear();
+  const std::string trimmedPath = TrimAsciiWhitespace(rawConfiguredPath);
+  if (trimmedPath.empty())
+    return defaultPath;
+
+  fs::path configuredPath = fs::u8path(trimmedPath);
+  if (configuredPath.is_relative())
+    configuredPath = defaultPath.parent_path() / configuredPath;
+
+  if (configuredPath.has_filename() && IsSupportedDictionaryFile(configuredPath)) {
+    std::error_code ec;
+    fs::create_directories(configuredPath.parent_path(), ec);
+    if (!ec)
+      return configuredPath;
+    if (warningOut) {
+      *warningOut =
+          "Could not create dictionary directory for configured path: " +
+          configuredPath.parent_path().string();
+    }
+    return defaultPath;
+  }
+
+  if (warningOut)
+    *warningOut =
+        "Configured trusses dictionary path is invalid. Expected a .json file path.";
+  return defaultPath;
+}
+
+static fs::path GetConfiguredUserDictFile(std::string *warningOut = nullptr) {
+  const fs::path defaultPath = GetUserDictFile();
+  if (defaultPath.empty()) {
+    if (warningOut)
+      *warningOut = "Default trusses dictionary path is empty";
+    return {};
+  }
+
+  const auto configured =
+      ConfigManager::Get().GetValue(kTrussDictionaryPathConfigKey);
+  if (!configured)
+    return defaultPath;
+  return ResolveConfiguredDictionaryPath(defaultPath, *configured, warningOut);
 }
 
 static fs::path GetBaseDictFile() {
@@ -398,7 +452,7 @@ bool ImportTrussFile(const std::string &inputPath, std::string &storedPath,
     return false;
   }
 
-  fs::path dictFile = GetUserDictFile();
+  fs::path dictFile = GetConfiguredUserDictFile();
   if (dictFile.empty()) {
     error = "Truss dictionary is not available";
     return false;
@@ -421,11 +475,98 @@ bool ImportTrussFile(const std::string &inputPath, std::string &storedPath,
   return true;
 }
 
+std::string GetActiveDictionaryFilePath() {
+  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
+  return GetConfiguredUserDictFile().string();
+}
+
+std::string GetActiveDictionaryFileName() {
+  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
+  const fs::path path = GetConfiguredUserDictFile();
+  if (path.empty())
+    return {};
+  return path.filename().string();
+}
+
+bool SetActiveDictionaryFilePath(const std::string &path, std::string *errorOut) {
+  if (errorOut)
+    errorOut->clear();
+  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
+
+  const fs::path defaultPath = GetUserDictFile();
+  if (defaultPath.empty()) {
+    if (errorOut)
+      *errorOut = "Default trusses dictionary path is empty";
+    return false;
+  }
+
+  std::string warning;
+  const fs::path resolvedPath =
+      ResolveConfiguredDictionaryPath(defaultPath, path, &warning);
+  if (!warning.empty() &&
+      TrimAsciiWhitespace(path) != TrimAsciiWhitespace(defaultPath.string())) {
+    if (errorOut)
+      *errorOut = warning;
+    return false;
+  }
+
+  const auto previousValue =
+      ConfigManager::Get().GetValue(kTrussDictionaryPathConfigKey);
+  const std::string trimmedInput = TrimAsciiWhitespace(path);
+  if (trimmedInput.empty() || resolvedPath == defaultPath) {
+    ConfigManager::Get().RemoveKey(kTrussDictionaryPathConfigKey);
+  } else {
+    ConfigManager::Get().SetValue(kTrussDictionaryPathConfigKey,
+                                  resolvedPath.string());
+  }
+
+  if (!ConfigManager::Get().SaveUserConfig()) {
+    if (previousValue)
+      ConfigManager::Get().SetValue(kTrussDictionaryPathConfigKey, *previousValue);
+    else
+      ConfigManager::Get().RemoveKey(kTrussDictionaryPathConfigKey);
+    if (errorOut)
+      *errorOut = "Could not persist dictionary selection in user config";
+    return false;
+  }
+
+  if (!fs::exists(resolvedPath)) {
+    if (!RecreateUserDictionaryFromBase(resolvedPath, GetBaseDictFile())) {
+      std::string createError;
+      if (!Save({}, &createError)) {
+        if (previousValue)
+          ConfigManager::Get().SetValue(kTrussDictionaryPathConfigKey, *previousValue);
+        else
+          ConfigManager::Get().RemoveKey(kTrussDictionaryPathConfigKey);
+        ConfigManager::Get().SaveUserConfig();
+        if (errorOut)
+          *errorOut = "Could not create selected trusses dictionary file: " +
+                      createError;
+        return false;
+      }
+    }
+  }
+
+  std::string loadError;
+  if (!LoadFromFile(resolvedPath, loadError)) {
+    if (previousValue)
+      ConfigManager::Get().SetValue(kTrussDictionaryPathConfigKey, *previousValue);
+    else
+      ConfigManager::Get().RemoveKey(kTrussDictionaryPathConfigKey);
+    ConfigManager::Get().SaveUserConfig();
+    if (errorOut)
+      *errorOut = "Could not load selected trusses dictionary: " + loadError;
+    return false;
+  }
+
+  return true;
+}
+
 std::optional<std::unordered_map<std::string, std::string>> Load() {
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
   g_lastLoadStatus = {};
 
-  const fs::path userFile = GetUserDictFile();
+  const fs::path userFile = GetConfiguredUserDictFile(&g_lastLoadStatus.error);
   const fs::path baseFile = GetBaseDictFile();
   std::string userError;
   if (auto userDict = LoadFromFile(userFile, userError)) {
@@ -470,7 +611,7 @@ bool Save(const std::unordered_map<std::string, std::string> &dict,
   if (errorOut)
     errorOut->clear();
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
-  fs::path file = GetUserDictFile();
+  fs::path file = GetConfiguredUserDictFile(errorOut);
   if (file.empty()) {
     if (errorOut)
       *errorOut = "User trusses dictionary path is empty";

--- a/core/trussdictionary.h
+++ b/core/trussdictionary.h
@@ -32,6 +32,11 @@ struct LoadStatus {
 std::string NormalizeModelKey(const std::string &model);
 std::optional<std::unordered_map<std::string, std::string>> Load();
 LoadStatus GetLastLoadStatus();
+
+std::string GetActiveDictionaryFilePath();
+std::string GetActiveDictionaryFileName();
+bool SetActiveDictionaryFilePath(const std::string &path,
+                                 std::string *errorOut = nullptr);
 bool Save(const std::unordered_map<std::string, std::string> &dict,
           std::string *errorOut = nullptr);
 std::optional<std::string> Get(const std::string &model);

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -5,6 +5,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/consolepanel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ui_feature_flags.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dictionaryeditdialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/dictionary_selection_controls.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dictionary_export_conflict_dialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dataview_edit_commit.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/editable_focus_utils.cpp

--- a/gui/dictionary_selection_controls.cpp
+++ b/gui/dictionary_selection_controls.cpp
@@ -35,12 +35,14 @@ void UpdateDictionarySelectionControls(const DictionarySelectionControls &contro
                                        const wxString &fileName,
                                        const wxString &fullPath) {
   if (controls.activeFileLabel) {
-    controls.activeFileLabel->SetLabel(fileName.IsEmpty() ? "Dictionary: -"
-                                                          : "Dictionary: " + fileName);
+    controls.activeFileLabel->SetLabel(
+        fileName.IsEmpty() ? wxString("Dictionary: -")
+                           : wxString("Dictionary: ") + fileName);
   }
   if (controls.activePathLabel) {
-    controls.activePathLabel->SetLabel(fullPath.IsEmpty() ? "Path: -"
-                                                          : "Path: " + fullPath);
+    controls.activePathLabel->SetLabel(
+        fullPath.IsEmpty() ? wxString("Path: -")
+                           : wxString("Path: ") + fullPath);
     controls.activePathLabel->SetToolTip(fullPath);
   }
 }

--- a/gui/dictionary_selection_controls.cpp
+++ b/gui/dictionary_selection_controls.cpp
@@ -1,0 +1,46 @@
+#include "dictionary_selection_controls.h"
+
+#include <wx/button.h>
+
+DictionarySelectionControls BuildDictionarySelectionControls(
+    wxWindow *parent, wxSizer *parentSizer, const wxString &title,
+    const wxString &buttonLabel, const std::function<void()> &onSelect) {
+  DictionarySelectionControls controls;
+  if (!parent || !parentSizer)
+    return controls;
+
+  auto *wrapper = new wxStaticBoxSizer(wxVERTICAL, parent, title);
+  auto *row = new wxBoxSizer(wxHORIZONTAL);
+
+  controls.activeFileLabel = new wxStaticText(parent, wxID_ANY, "Dictionary: -");
+  controls.activePathLabel = new wxStaticText(parent, wxID_ANY, "Path: -");
+  controls.selectButton = new wxButton(parent, wxID_ANY, buttonLabel);
+
+  row->Add(controls.activeFileLabel, 1, wxALIGN_CENTER_VERTICAL | wxRIGHT, 10);
+  row->Add(controls.selectButton, 0, wxALIGN_CENTER_VERTICAL);
+
+  wrapper->Add(row, 0, wxEXPAND | wxALL, 6);
+  wrapper->Add(controls.activePathLabel, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM,
+               6);
+  parentSizer->Add(wrapper, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, 8);
+
+  if (controls.selectButton && onSelect) {
+    controls.selectButton->Bind(wxEVT_BUTTON,
+                                [onSelect](wxCommandEvent &) { onSelect(); });
+  }
+  return controls;
+}
+
+void UpdateDictionarySelectionControls(const DictionarySelectionControls &controls,
+                                       const wxString &fileName,
+                                       const wxString &fullPath) {
+  if (controls.activeFileLabel) {
+    controls.activeFileLabel->SetLabel(fileName.IsEmpty() ? "Dictionary: -"
+                                                          : "Dictionary: " + fileName);
+  }
+  if (controls.activePathLabel) {
+    controls.activePathLabel->SetLabel(fullPath.IsEmpty() ? "Path: -"
+                                                          : "Path: " + fullPath);
+    controls.activePathLabel->SetToolTip(fullPath);
+  }
+}

--- a/gui/dictionary_selection_controls.h
+++ b/gui/dictionary_selection_controls.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <functional>
+
+#include <wx/sizer.h>
+#include <wx/stattext.h>
+#include <wx/window.h>
+
+struct DictionarySelectionControls {
+  wxStaticText *activeFileLabel = nullptr;
+  wxStaticText *activePathLabel = nullptr;
+  wxButton *selectButton = nullptr;
+};
+
+DictionarySelectionControls BuildDictionarySelectionControls(
+    wxWindow *parent, wxSizer *parentSizer, const wxString &title,
+    const wxString &buttonLabel, const std::function<void()> &onSelect);
+
+void UpdateDictionarySelectionControls(const DictionarySelectionControls &controls,
+                                       const wxString &fileName,
+                                       const wxString &fullPath);

--- a/gui/dictionaryeditdialog.cpp
+++ b/gui/dictionaryeditdialog.cpp
@@ -19,10 +19,11 @@
 
 #include "columnutils.h"
 #include "colorfulrenderers.h"
-#include "dictionary_export_conflict_dialog.h"
 #include "colorstore.h"
 #include "dictionary_bundle.h"
+#include "dictionary_export_conflict_dialog.h"
 #include "dictionary_json_contract.h"
+#include "dictionary_selection_controls.h"
 #include "file_import_utils.h"
 #include "gdtfdictionary.h"
 #include "gdtf_fixture_category.h"
@@ -894,6 +895,7 @@ DictionaryEditDialog::DictionaryEditDialog(wxWindow *parent)
     : wxDialog(parent, wxID_ANY, "Dictionary editor", wxDefaultPosition,
                wxSize(1100, 620), wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER) {
   BuildLayout();
+  RefreshDictionarySelectionLabels();
   LoadFixtures();
   LoadTrusses();
   ShowDictionaryLoadStatusMessages();
@@ -933,6 +935,13 @@ void DictionaryEditDialog::BuildLayout() {
   fixtureTable->AppendColumn(new wxDataViewColumn(
       "Color", colorRenderer, kFixtureColorColumn, 110, wxALIGN_LEFT, flags));
   ColumnUtils::EnforceMinColumnWidth(fixtureTable);
+  fixturesSelection = BuildDictionarySelectionControls(
+      fixturePanel, fixtureSizer, "Active fixtures dictionary",
+      "Select dictionary...",
+      [this]() {
+        wxCommandEvent dummy;
+        OnSelectFixturesDictionary(dummy);
+      });
   fixtureSizer->Add(fixtureTable, 1, wxEXPAND | wxALL, 8);
   fixturePanel->SetSizer(fixtureSizer);
 
@@ -956,6 +965,13 @@ void DictionaryEditDialog::BuildLayout() {
   trussTable->AppendTextColumn("File", wxDATAVIEW_CELL_INERT, 260,
                                wxALIGN_LEFT, flags);
   ColumnUtils::EnforceMinColumnWidth(trussTable);
+  trussesSelection = BuildDictionarySelectionControls(
+      trussPanel, trussSizer, "Active trusses dictionary",
+      "Select dictionary...",
+      [this]() {
+        wxCommandEvent dummy;
+        OnSelectTrussesDictionary(dummy);
+      });
   trussSizer->Add(trussTable, 1, wxEXPAND | wxALL, 8);
   trussPanel->SetSizer(trussSizer);
 
@@ -1067,6 +1083,7 @@ void DictionaryEditDialog::UpdateMissingFileTooltip(wxDataViewListCtrl *table,
 }
 
 void DictionaryEditDialog::LoadFixtures() {
+  RefreshDictionarySelectionLabels();
   fixtureStore->DeleteAllItems();
   fixturePaths.clear();
   activeFixtureHoverTooltip.clear();
@@ -1107,6 +1124,7 @@ void DictionaryEditDialog::LoadFixtures() {
 }
 
 void DictionaryEditDialog::LoadTrusses() {
+  RefreshDictionarySelectionLabels();
   trussStore->DeleteAllItems();
   trussPaths.clear();
   activeTrussHoverTooltip.clear();
@@ -1241,6 +1259,85 @@ void DictionaryEditDialog::ShowDictionaryLoadStatusMessages() {
         wxICON_WARNING | wxOK,
         this);
   }
+}
+
+void DictionaryEditDialog::RefreshDictionarySelectionLabels() {
+  UpdateDictionarySelectionControls(
+      fixturesSelection,
+      wxString::FromUTF8(GdtfDictionary::GetActiveDictionaryFileName()),
+      wxString::FromUTF8(GdtfDictionary::GetActiveDictionaryFilePath()));
+  UpdateDictionarySelectionControls(
+      trussesSelection,
+      wxString::FromUTF8(TrussDictionary::GetActiveDictionaryFileName()),
+      wxString::FromUTF8(TrussDictionary::GetActiveDictionaryFilePath()));
+}
+
+void DictionaryEditDialog::OnSelectFixturesDictionary(
+    wxCommandEvent &WXUNUSED(event)) {
+  const std::filesystem::path currentPath =
+      std::filesystem::u8path(GdtfDictionary::GetActiveDictionaryFilePath());
+  const wxString initialDir = wxString::FromUTF8(
+      (currentPath.empty() ? std::filesystem::u8path(
+                                 ProjectUtils::GetWritableLibraryPath("fixtures"))
+                           : currentPath.parent_path())
+          .string());
+  const wxString initialFile = currentPath.empty()
+                                   ? wxString("gdtf_dictionary.json")
+                                   : wxString::FromUTF8(currentPath.filename().string());
+  wxFileDialog dialog(this, "Select fixtures dictionary file", initialDir,
+                      initialFile, "JSON files (*.json)|*.json",
+                      wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+  if (dialog.ShowModal() != wxID_OK)
+    return;
+
+  std::string error;
+  std::filesystem::path selectedPath =
+      std::filesystem::u8path(std::string(dialog.GetPath().ToUTF8()));
+  if (!selectedPath.has_extension())
+    selectedPath += ".json";
+  const std::string selected = selectedPath.string();
+  if (!GdtfDictionary::SetActiveDictionaryFilePath(selected, &error)) {
+    wxMessageBox("Could not select fixtures dictionary.\n\n" +
+                     wxString::FromUTF8(error),
+                 "Dictionary selection", wxOK | wxICON_ERROR, this);
+    RefreshDictionarySelectionLabels();
+    return;
+  }
+  LoadFixtures();
+}
+
+void DictionaryEditDialog::OnSelectTrussesDictionary(
+    wxCommandEvent &WXUNUSED(event)) {
+  const std::filesystem::path currentPath =
+      std::filesystem::u8path(TrussDictionary::GetActiveDictionaryFilePath());
+  const wxString initialDir = wxString::FromUTF8(
+      (currentPath.empty() ? std::filesystem::u8path(
+                                 ProjectUtils::GetWritableLibraryPath("trusses"))
+                           : currentPath.parent_path())
+          .string());
+  const wxString initialFile = currentPath.empty()
+                                   ? wxString("truss_dictionary.json")
+                                   : wxString::FromUTF8(currentPath.filename().string());
+  wxFileDialog dialog(this, "Select trusses dictionary file", initialDir,
+                      initialFile, "JSON files (*.json)|*.json",
+                      wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+  if (dialog.ShowModal() != wxID_OK)
+    return;
+
+  std::string error;
+  std::filesystem::path selectedPath =
+      std::filesystem::u8path(std::string(dialog.GetPath().ToUTF8()));
+  if (!selectedPath.has_extension())
+    selectedPath += ".json";
+  const std::string selected = selectedPath.string();
+  if (!TrussDictionary::SetActiveDictionaryFilePath(selected, &error)) {
+    wxMessageBox("Could not select trusses dictionary.\n\n" +
+                     wxString::FromUTF8(error),
+                 "Dictionary selection", wxOK | wxICON_ERROR, this);
+    RefreshDictionarySelectionLabels();
+    return;
+  }
+  LoadTrusses();
 }
 
 bool DictionaryEditDialog::SaveFixtures() {

--- a/gui/dictionaryeditdialog.h
+++ b/gui/dictionaryeditdialog.h
@@ -21,6 +21,8 @@
 #include <wx/notebook.h>
 #include <wx/wx.h>
 
+#include "dictionary_selection_controls.h"
+
 #include <string>
 #include <vector>
 
@@ -53,6 +55,9 @@ private:
                                 ColorfulDataViewListStore *store,
                                 wxString &activeTooltip,
                                 const wxPoint &position);
+  void RefreshDictionarySelectionLabels();
+  void OnSelectFixturesDictionary(wxCommandEvent &event);
+  void OnSelectTrussesDictionary(wxCommandEvent &event);
 
   void OnAdd(wxCommandEvent &event);
   void OnDelete(wxCommandEvent &event);
@@ -86,6 +91,8 @@ private:
   wxButton *resetBtn = nullptr;
   wxButton *okBtn = nullptr;
   wxButton *cancelBtn = nullptr;
+  DictionarySelectionControls fixturesSelection;
+  DictionarySelectionControls trussesSelection;
 
   std::vector<std::string> fixturePaths;
   std::vector<std::string> trussPaths;


### PR DESCRIPTION
### Motivation
- Provide a visible label and selector in the Dictionary editor so users can see and choose the active fixtures/trusses dictionary file (filename only in UI) to allow multiple dictionaries to coexist and be switched safely.
- Persist the selected dictionary across runs and handle common error cases (invalid paths, missing files, creation failures) with robust fallbacks to avoid losing the working dictionary.

### Description
- Added public API to `GdtfDictionary` and `TrussDictionary`: `GetActiveDictionaryFilePath()`, `GetActiveDictionaryFileName()`, and `SetActiveDictionaryFilePath(...)`, plus logic to resolve, validate and persist configured dictionary paths using config keys `fixtures_dictionary_active_path` and `trusses_dictionary_active_path`.
- Implemented resolution/validation helpers (relative path resolution, `.json` extension check, parent-directory creation) and safe change semantics that persist configuration, attempt to create the target file (copy base seed or create empty snapshot), validate load, and roll back on failure.
- Updated all dictionary load/save/update paths to use the configured active dictionary when present while preserving the existing default/base fallback behavior and file-name contract.
- Added a small, modular UI component `gui/dictionary_selection_controls.{h,cpp}` and wired it into the dictionary editor (`gui/dictionaryeditdialog.*`) to show the active dictionary filename/path and a button to select another file; registered the new source in `gui/CMakeLists.txt` to keep the dialog file small and responsibilities separated.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed, confirming GUI code did not introduce direct `ConfigManager::Get()` usages.
- Ran `tests/check_dictionary_paths.sh` and it passed, confirming the dictionary file path contract remains intact.
- Attempted a full CMake build (`cmake -S . -B build && cmake --build build -j2`) which failed in the container due to missing system dependency `wxWidgets` (environment issue), not due to the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbd00374ec8324a20cda554eab5b35)