### PR TITLE
Ignore inline rider annotations in text importer; docs, GUI example, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ If you want to build from source, setup and dependency notes are available in th
 - Open an existing `.mvr` file to inspect its content quickly.
 - Review fixtures, trusses, hoists, objects, and scene structure.
 - Use **Tools → Create from text** to generate elements from rider-style notes.
+- In **Tools → Create from text**, you can annotate templates with comments
+  using inline markers `((...))` or `*(...)*` (ignored by the parser).
 - Use the available tools to adjust and organize scene data more comfortably.
 
 ## Documentation

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -133,6 +133,18 @@ std::string Trim(const std::string &s) {
   return s.substr(start, end - start + 1);
 }
 
+std::string StripRiderAnnotations(const std::string &line) {
+  if (line.empty())
+    return {};
+
+  std::string stripped = line;
+  stripped =
+      std::regex_replace(stripped, std::regex("\\(\\([^\\)]*\\)\\)"), " ");
+  stripped = std::regex_replace(stripped, std::regex("\\*\\([^\\)]*\\)\\*"),
+                                " ");
+  return Trim(stripped);
+}
+
 enum class RiggingLineKind { Truss, Pipe };
 
 RiggingLineKind DetectRiggingLineKind(const std::string &line) {
@@ -1107,6 +1119,11 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
 
   while (std::getline(iss, line)) {
     line.erase(std::remove(line.begin(), line.end(), '\r'), line.end());
+    line = StripRiderAnnotations(line);
+    if (line.empty()) {
+      havePending = false;
+      continue;
+    }
     if (ContainsCaseInsensitive(line, "sonido") ||
         ContainsCaseInsensitive(line, "audio") ||
         ContainsCaseInsensitive(line, "control de p.a.") ||
@@ -1737,6 +1754,11 @@ bool RiderImporter::ImportText(const std::string &text,
     // Remove Windows carriage returns to allow regexes anchored with '$' to
     // match lines extracted from external tools.
     line.erase(std::remove(line.begin(), line.end(), '\r'), line.end());
+    line = StripRiderAnnotations(line);
+    if (line.empty()) {
+      havePending = false;
+      continue;
+    }
     if (ContainsCaseInsensitive(line, "sonido") ||
         ContainsCaseInsensitive(line, "audio") ||
         ContainsCaseInsensitive(line, "control de p.a.") ||

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -71,7 +71,9 @@ time.
    - `.pdf` is converted to text before parsing.
 2. Parsing is line-based.
 3. Windows carriage returns (`\r`) are removed from each line.
-4. Most keyword matches are case-insensitive.
+4. Inline annotations wrapped as `((...))` are ignored during parsing.
+5. Inline annotations wrapped as `*(...)*` are ignored during parsing.
+6. Most keyword matches are case-insensitive.
 
 ## Section detection rules
 

--- a/gui/ridertextdialog.cpp
+++ b/gui/ridertextdialog.cpp
@@ -175,27 +175,30 @@ void RiderTextDialog::OnLoadFromFile(wxCommandEvent &WXUNUSED(event)) {
 
 void RiderTextDialog::OnLoadExample(wxCommandEvent &WXUNUSED(event)) {
   const wxString exampleText =
-      "Lx1\n"
-      "8 Blinder 2\n"
+      "((Example notes wrapped with ((...)) are ignored))\n"
+      "\n"
+      "LX1 (0, -2.0, 10.5) [0.6] ((Position and margin override))\n"
+      "8 Blinder 2 *(Front blinders)*\n"
       "8 Spiider\n"
       "6 Megapointe\n"
       "\n"
-      "lx2\n"
+      "LX2 [0.8]\n"
       "6 Megapointe\n"
       "6 Mac Viper Profile\n"
       "6 Spiider\n"
       "4 Q-7\n"
       "\n"
-      "lx3\n"
+      "LX3\n"
       "6 Megapointe\n"
       "6 Mac Viper Profile\n"
       "6 Spiider\n"
       "4 Q-7\n"
       "\n"
-      "rigging\n"
-      "1 truss lx1 14 m\n"
-      "1 truss lx2 12 m\n"
-      "1 truss lx3 12 m\n";
+      "RIGGING\n"
+      "1 TRUSS 40X40 14 m PARA LX1\n"
+      "1 TRUSS 40X40 12 m PARA LX2 (0, 2.5, 10.0)\n"
+      "1 PIPE 12 m PARA LX3 ((Pipe as scene object))\n"
+      "3 MOTOR 500Kg PARA PUENTES LX *(Auto-distribute across LX targets)*\n";
   textCtrl->ChangeValue(exampleText);
   sourceLabel = "Example text";
   sourceLoadedFromFile = false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -755,6 +755,33 @@ target_link_libraries(rider_filter_preview_test PRIVATE ${wxWidgets_LIBRARIES} t
 add_test(NAME RiderFilterPreview COMMAND rider_filter_preview_test)
 set_library_env(RiderFilterPreview)
 
+add_executable(rider_comments_test rider_comments_test.cpp
+               riderimporter_stubs.cpp
+               gdtfloader_stub.cpp
+               ../core/riderimporter.cpp
+               ../core/units/units.cpp
+               ../core/gdtf_fixture_category.cpp
+               ../core/hoist_weight_distribution.cpp
+               ../core/uuidutils.cpp
+               ../core/autopatcher.cpp
+               ../core/patchmanager.cpp
+               ../core/configmanager.cpp
+               ../core/configservices.cpp
+               ../core/projectutils.cpp
+               ../core/library/library_bootstrap.cpp
+               ../core/logger.cpp
+               ../models/mvrscene.cpp
+               ../models/fixture.cpp
+               ../models/truss.cpp
+               ../models/sceneobject.cpp
+               ../models/layer.cpp
+               ${LAYOUT_SOURCES})
+target_include_directories(rider_comments_test PRIVATE
+                           . ../core ../models ../mvr ../gui ../third_party)
+target_link_libraries(rider_comments_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
+add_test(NAME RiderComments COMMAND rider_comments_test)
+set_library_env(RiderComments)
+
 add_executable(rider_floor_default_hang_test rider_floor_default_hang_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp

--- a/tests/rider_comments_test.cpp
+++ b/tests/rider_comments_test.cpp
@@ -1,0 +1,38 @@
+#include <cassert>
+#include <string>
+#include <wx/init.h>
+
+#include "configmanager.h"
+#include "riderimporter.h"
+
+int main() {
+  wxInitializer initializer;
+  assert(initializer.IsOk());
+
+  auto &cfg = ConfigManager::Get();
+  cfg.Reset();
+
+  const std::string riderText =
+      "((Example with inline annotations))\n"
+      "LX1 ((Main front truss))\n"
+      "4 Spot *(Main spots)*\n"
+      "RIGGING\n"
+      "1 TRUSS 40X40 12m PARA LX1 ((Truss definition))\n";
+
+  const std::string expectedPreview =
+      "LX1\n"
+      "4 Spot\n"
+      "\n"
+      "\n"
+      "RIGGING\n"
+      "1 TRUSS 40X40 12m LX1";
+  const std::string preview = RiderImporter::BuildFixtureFilterPreview(riderText);
+  assert(preview == expectedPreview);
+
+  assert(RiderImporter::ImportText(riderText));
+  const auto &scene = cfg.GetScene();
+  assert(scene.fixtures.size() == 4);
+  assert(scene.trusses.size() == 4);
+
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- Allow rider-style notes and template comments to be embedded inline using `((...))` or `*(...)*` without affecting parsing or scene creation.
- Make the text-to-scene filter and importer more tolerant of human-readable annotations common in rider text.
- Provide examples and automated coverage to avoid regressions when comments are present.

### Description
- Add `StripRiderAnnotations` and apply it to input lines in `RiderImporter::BuildFixtureFilterPreview` and `RiderImporter::ImportText` so tokens wrapped as `((...))` or `*(...)*` are removed before parsing.
- Update `README.md` and `docs/text_to_scene_rules.md` to document the new inline annotation behavior and update the `RiderTextDialog` example text in `gui/ridertextdialog.cpp` to demonstrate usage.
- Add a new test executable `rider_comments_test` and its source `tests/rider_comments_test.cpp`, and register the test in `tests/CMakeLists.txt` to validate filtered preview output and imported scene counts.

### Testing
- Ran the new test `rider_comments_test`, which verifies `RiderImporter::BuildFixtureFilterPreview` output and `RiderImporter::ImportText` behavior, and it passed.
- Ran the existing `rider_filter_preview_test` alongside the new test to check for regressions, and both tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbd4ee50e08324aec1bb2a4cd7537b)