### PR TITLE
Remove 'source' provenance field from fixtures and trusses dictionaries

### DIFF
--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -410,8 +410,6 @@ LoadFromFile(const fs::path &file, std::string &error) {
       }
       entry.color = *normalizedColor;
     }
-    if (const auto sourceText = GetObjectStringByNormalizedKey(value, "source"))
-      entry.source = *sourceText;
     if (const auto importedAtText =
             GetObjectStringByNormalizedKey(value, "imported_at"))
       entry.importedAt = *importedAtText;
@@ -687,8 +685,6 @@ bool Save(const std::unordered_map<std::string, Entry> &dict,
       obj["category"] = entry.category;
     if (!entry.color.empty())
       obj["color"] = entry.color;
-    if (!entry.source.empty())
-      obj["source"] = entry.source;
     if (!entry.importedAt.empty())
       obj["imported_at"] = entry.importedAt;
     if (!entry.sha256.empty())
@@ -814,7 +810,6 @@ void Update(const std::string &type, const std::string &gdtfPath, const std::str
     e.mode = mode;
   if (!category.empty())
     e.category = category;
-  e.source = src.string();
   e.importedAt = FileImportUtils::NowUtcIso8601();
   e.sha256 = copyResult.finalSha256;
 

--- a/core/gdtfdictionary.h
+++ b/core/gdtfdictionary.h
@@ -34,7 +34,6 @@ namespace GdtfDictionary {
         std::string mode;
         std::string category;
         std::string color;
-        std::string source; // optional original import path
         std::string importedAt; // optional UTC ISO-8601 timestamp
         std::string sha256; // optional file hash for diagnostics
     };

--- a/core/trussdictionary.cpp
+++ b/core/trussdictionary.cpp
@@ -641,7 +641,6 @@ bool Save(const std::unordered_map<std::string, std::string> &dict,
 
     nlohmann::json entry;
     entry["file"] = forced.filename().string();
-    entry["source"] = p.string();
     entry["imported_at"] = FileImportUtils::NowUtcIso8601();
     if (const auto sha = FileImportUtils::ComputeFileSha256(forced))
       entry["sha256"] = *sha;

--- a/docs/dictionary_portable_bundle.md
+++ b/docs/dictionary_portable_bundle.md
@@ -87,8 +87,8 @@ prompted to choose one policy:
 Fixture and truss dictionary entries may include optional provenance/hash
 metadata to aid diagnostics:
 
-- `source`: source path used during import.
 - `sha256`: content hash stored with the entry.
+- `imported_at`: UTC ISO-8601 timestamp of when the entry was imported.
 
 ## `dictionary.json`
 

--- a/gui/dictionaryeditdialog.cpp
+++ b/gui/dictionaryeditdialog.cpp
@@ -205,7 +205,6 @@ struct FixtureRow {
   std::string mode;
   std::string category;
   std::string color;
-  std::string source;
   std::string sha256;
 };
 
@@ -216,7 +215,6 @@ struct TrussRow {
 
 struct CopiedLibraryAsset {
   std::string path;
-  std::string source;
   std::string sha256;
 };
 
@@ -668,7 +666,7 @@ CopyToLibrary(wxWindow *parent, const std::string &path, const char *libraryName
   if (!copyResult.success)
     return std::nullopt;
 
-  return CopiedLibraryAsset{copyResult.finalPath.string(), src.string(),
+  return CopiedLibraryAsset{copyResult.finalPath.string(),
                             copyResult.finalSha256};
 }
 
@@ -1379,8 +1377,7 @@ bool DictionaryEditDialog::SaveFixtures() {
       return false;
     }
     rows.push_back(
-        {name, copied->path, mode, category, *normalizedColor, copied->source,
-         copied->sha256});
+        {name, copied->path, mode, category, *normalizedColor, copied->sha256});
   }
 
   SortFixtureRows(rows);
@@ -1392,7 +1389,6 @@ bool DictionaryEditDialog::SaveFixtures() {
     entry.mode = row.mode;
     entry.category = row.category;
     entry.color = row.color;
-    entry.source = row.source;
     entry.importedAt = FileImportUtils::NowUtcIso8601();
     if (!row.sha256.empty())
       entry.sha256 = row.sha256;

--- a/gui/dictionaryeditdialog.cpp
+++ b/gui/dictionaryeditdialog.cpp
@@ -645,7 +645,7 @@ CopyToLibrary(wxWindow *parent, const std::string &path, const char *libraryName
   const std::filesystem::path dir =
       std::filesystem::u8path(ProjectUtils::GetWritableLibraryPath(libraryName));
   if (dir.empty())
-    return CopiedLibraryAsset{path, path, {}};
+    return CopiedLibraryAsset{path, {}};
 
   const std::filesystem::path dest = dir / src.filename();
   FileImportUtils::ConflictPolicy policy = FileImportUtils::ConflictPolicy::Overwrite;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -112,6 +112,7 @@ add_test(NAME GdtfFixtureCategoryFallback COMMAND gdtf_fixture_category_test)
 
 add_executable(gdtf_dictionary_color_roundtrip_test
                gdtf_dictionary_color_roundtrip_test.cpp
+               ../core/configmanager.cpp
                ../core/gdtfdictionary.cpp
                ../core/projectutils.cpp
                ../core/library/library_bootstrap.cpp
@@ -124,6 +125,7 @@ add_test(NAME GdtfDictionaryColorRoundtrip COMMAND gdtf_dictionary_color_roundtr
 
 add_executable(gdtf_dictionary_color_mode_propagation_test
                gdtf_dictionary_color_mode_propagation_test.cpp
+               ../core/configmanager.cpp
                ../core/gdtfdictionary.cpp
                ../core/projectutils.cpp
                ../core/library/library_bootstrap.cpp
@@ -137,6 +139,7 @@ add_test(NAME GdtfDictionaryColorModePropagation
 
 add_executable(dictionary_seed_merge_backup_test
                dictionary_seed_merge_backup_test.cpp
+               ../core/configmanager.cpp
                ../core/projectutils.cpp
                ../core/library/library_bootstrap.cpp
                ../core/gdtfdictionary.cpp


### PR DESCRIPTION
### Motivation

- Remove the optional `source` provenance field that stored original importer filesystem paths from fixture and truss dictionary entries to avoid storing user-local paths and simplify the dictionary format.

### Description

- Removed the `source` member from `GdtfDictionary::Entry` in `core/gdtfdictionary.h` and removed all parsing/serialization of `source` in `core/gdtfdictionary.cpp` and `core/trussdictionary.cpp` so dictionaries no longer include or read a `source` property.
- Updated GUI code in `gui/dictionaryeditdialog.cpp` to stop carrying a `source` field through `CopiedLibraryAsset`, `FixtureRow`, and the fixtures save flow, and to stop writing `source` into created entries when saving the dictionary.
- Updated portable bundle documentation `docs/dictionary_portable_bundle.md` to remove `source` from the listed optional metadata and to call out the retained `imported_at` timestamp and `sha256` hash.

### Testing

- Built the project after the changes using the standard build (`cmake`/`make`), and the build completed successfully.
- Ran the project's automated unit tests (`ctest`), and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbd5b94c1883248d2087168c92d6d0)