### PR TITLE
Remove support for double-parenthesis rider annotations

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -138,8 +138,6 @@ std::string StripRiderAnnotations(const std::string &line) {
     return {};
 
   std::string stripped = line;
-  stripped =
-      std::regex_replace(stripped, std::regex("\\(\\([^\\)]*\\)\\)"), " ");
   stripped = std::regex_replace(stripped, std::regex("\\*\\([^\\)]*\\)\\*"),
                                 " ");
   return Trim(stripped);

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -71,9 +71,8 @@ time.
    - `.pdf` is converted to text before parsing.
 2. Parsing is line-based.
 3. Windows carriage returns (`\r`) are removed from each line.
-4. Inline annotations wrapped as `((...))` are ignored during parsing.
-5. Inline annotations wrapped as `*(...)*` are ignored during parsing.
-6. Most keyword matches are case-insensitive.
+4. Inline annotations wrapped as `*(...)*` are ignored during parsing.
+5. Most keyword matches are case-insensitive.
 
 ## Section detection rules
 

--- a/gui/ridertextdialog.cpp
+++ b/gui/ridertextdialog.cpp
@@ -175,9 +175,9 @@ void RiderTextDialog::OnLoadFromFile(wxCommandEvent &WXUNUSED(event)) {
 
 void RiderTextDialog::OnLoadExample(wxCommandEvent &WXUNUSED(event)) {
   const wxString exampleText =
-      "((Example notes wrapped with ((...)) are ignored))\n"
+      "*(Example notes wrapped with *(...)* are ignored)*\n"
       "\n"
-      "LX1 (0, -2.0, 10.5) [0.6] ((Position and margin override))\n"
+      "LX1 (0, -2.0, 10.5) [0.6] *(Position and margin override)*\n"
       "8 Blinder 2 *(Front blinders)*\n"
       "8 Spiider\n"
       "6 Megapointe\n"
@@ -197,7 +197,7 @@ void RiderTextDialog::OnLoadExample(wxCommandEvent &WXUNUSED(event)) {
       "RIGGING\n"
       "1 TRUSS 40X40 14 m PARA LX1\n"
       "1 TRUSS 40X40 12 m PARA LX2 (0, 2.5, 10.0)\n"
-      "1 PIPE 12 m PARA LX3 ((Pipe as scene object))\n"
+      "1 PIPE 12 m PARA LX3 *(Pipe as scene object)*\n"
       "3 MOTOR 500Kg PARA PUENTES LX *(Auto-distribute across LX targets)*\n";
   textCtrl->ChangeValue(exampleText);
   sourceLabel = "Example text";

--- a/tests/rider_comments_test.cpp
+++ b/tests/rider_comments_test.cpp
@@ -13,11 +13,11 @@ int main() {
   cfg.Reset();
 
   const std::string riderText =
-      "((Example with inline annotations))\n"
-      "LX1 ((Main front truss))\n"
+      "*(Example with inline annotations)*\n"
+      "LX1 *(Main front truss)*\n"
       "4 Spot *(Main spots)*\n"
       "RIGGING\n"
-      "1 TRUSS 40X40 12m PARA LX1 ((Truss definition))\n";
+      "1 TRUSS 40X40 12m PARA LX1 *(Truss definition)*\n";
 
   const std::string expectedPreview =
       "LX1\n"


### PR DESCRIPTION
### Motivation

- The importer previously supported two inline annotation syntaxes (`((...))` and `*(...)*`), which is redundant and confusing for authors. 
- Simplify parsing and documentation by keeping a single inline annotation format.

### Description

- Removed the `((...))` stripping from `StripRiderAnnotations` in `core/riderimporter.cpp` so only `*(...)*` comments are removed at parse time. 
- Updated the rider example text in `gui/ridertextdialog.cpp` to use only `*(...)*` annotations. 
- Adjusted the regression fixture in `tests/rider_comments_test.cpp` to expect `*(...)*` behavior. 
- Updated `docs/text_to_scene_rules.md` to document only the `*(...)*` inline annotation format.

### Testing

- Ran `tests/check_perastage_tree_modules.sh` which passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed. 
- Ran `ctest --output-on-failure -R RiderComments` in this environment which reported no tests were discovered (no failures reported by the check scripts).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbe18072108324b837ee28164eef8c)