### PR TITLE
Add ConfigManager stub to truss_path_encoding_regression_test to fix linker error

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -302,6 +302,7 @@ set_library_env(ProjectSupportUserDataRoundtrip)
 
 add_executable(truss_path_encoding_regression_test
                truss_path_encoding_regression_test.cpp
+               configmanager_layoutmanager_stub.cpp
                ../core/projectutils.cpp
                ../core/library/library_bootstrap.cpp
                ../core/trussdictionary.cpp


### PR DESCRIPTION
### Motivation
- The `truss_path_encoding_regression_test` target failed to link due to an unresolved `ConfigManager::Get()` symbol used by `core/trussdictionary.cpp`, because the lightweight test target did not include a provider for that symbol.

### Description
- Added `tests/configmanager_layoutmanager_stub.cpp` to the `truss_path_encoding_regression_test` sources in `tests/CMakeLists.txt` so the test binary provides `ConfigManager::Get()` for `trussdictionary.cpp`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which succeeded.
- Attempted `cmake --build build --target truss_path_encoding_regression_test -j2` but the environment had no `build/` directory so the test binary was not built in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbe54820d48324b0a50daf9f2837f4)