### PR TITLE
Add MVR IO stubs for dictionary_seed_merge_backup_test linking

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -139,6 +139,7 @@ add_test(NAME GdtfDictionaryColorModePropagation
 
 add_executable(dictionary_seed_merge_backup_test
                dictionary_seed_merge_backup_test.cpp
+               mvr_io_stubs.cpp
                ../core/configmanager.cpp
                ../core/projectutils.cpp
                ../core/library/library_bootstrap.cpp

--- a/tests/mvr_io_stubs.cpp
+++ b/tests/mvr_io_stubs.cpp
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2026 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "mvrimporter.h"
+#include "mvrexporter.h"
+
+bool MvrImporter::ImportAndRegister(const std::string &, bool, bool, ProgressCallback) {
+  return false;
+}
+
+bool MvrExporter::ExportToFile(const std::string &) {
+  return false;
+}


### PR DESCRIPTION
### Motivation
- `core/configmanager.cpp` was wired to call `MvrImporter::ImportAndRegister(...)` and `MvrExporter::ExportToFile(...)`, causing unresolved externals in isolated unit-test targets that do not link the full MVR implementation. This change provides lightweight test-only implementations so dictionary-focused tests can link without pulling MVR dependencies.

### Description
- Added a test-only translation unit `tests/mvr_io_stubs.cpp` that implements `MvrImporter::ImportAndRegister(...)` and `MvrExporter::ExportToFile(...)` as simple stubs returning `false`.
- Updated `tests/CMakeLists.txt` to include `mvr_io_stubs.cpp` in the `dictionary_seed_merge_backup_test` target source list so the test target links successfully without the full MVR sources.
- The stubs keep the test target small and avoid adding MVR subsystem dependencies to dictionary-focused tests.

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which passed (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which passed (`OK`).
- Ran `cmake --preset wsl-x64-debug`, which failed in this environment due to missing `wxWidgets` development packages and is unrelated to the added stubs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbe64d9c308324bfe08950940851aa)