### PR TITLE
Add missing ConfigManager Load/SaveUserConfig stubs to test shim

### DIFF
--- a/tests/configmanager_layoutmanager_stub.cpp
+++ b/tests/configmanager_layoutmanager_stub.cpp
@@ -31,3 +31,7 @@ bool ConfigManager::HasKey(const std::string &key) const {
 void ConfigManager::RemoveKey(const std::string &key) { g_values.erase(key); }
 
 void ConfigManager::ClearValues() { g_values.clear(); }
+
+bool ConfigManager::LoadUserConfig() { return true; }
+
+bool ConfigManager::SaveUserConfig() const { return true; }


### PR DESCRIPTION
### Motivation
- Resolve a Windows link error (LNK2019) caused by `core/trussdictionary.cpp` calling `ConfigManager::SaveUserConfig()` when linking `truss_path_encoding_regression_test` by providing the missing test-stub symbols.

### Description
- Added `bool ConfigManager::LoadUserConfig()` and `bool ConfigManager::SaveUserConfig() const` stub implementations to `tests/configmanager_layoutmanager_stub.cpp` that return `true` so the test target links successfully.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it returned OK.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it returned OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbe81b0ed883248d7488851b6dbeb1)