### PR TITLE
Fix LX SIDES hoist distribution and add SIDE L/R naming

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -686,6 +686,7 @@ void AssignImportedHoistNames(std::vector<Support *> &supports) {
   };
 
   std::map<std::string, std::vector<Support *>> lxByPosition;
+  std::vector<Support *> lxSidesSupports;
   std::vector<Support *> screenSupports;
   std::vector<Support *> backdropSupports;
   std::vector<Support *> sidefillSupports;
@@ -698,6 +699,8 @@ void AssignImportedHoistNames(std::vector<Support *> &supports) {
     const std::string position = NormalizeHangName(support->positionName);
     if (IsLxHangName(position)) {
       lxByPosition[position].push_back(support);
+    } else if (IsLxSidesHangName(position)) {
+      lxSidesSupports.push_back(support);
     } else if (position == "SCREEN") {
       screenSupports.push_back(support);
     } else if (position == "BACKDROP") {
@@ -722,6 +725,36 @@ void AssignImportedHoistNames(std::vector<Support *> &supports) {
       support->name = position + " " + std::to_string(i + 1);
       support->motorName = support->name;
     }
+  }
+
+  auto sortByYThenX = [](Support *a, Support *b) {
+    if (a->transform.o[1] != b->transform.o[1])
+      return a->transform.o[1] < b->transform.o[1];
+    if (a->transform.o[0] != b->transform.o[0])
+      return a->transform.o[0] < b->transform.o[0];
+    return a->uuid < b->uuid;
+  };
+  std::vector<Support *> sideLeftSupports;
+  std::vector<Support *> sideRightSupports;
+  for (Support *support : lxSidesSupports) {
+    if (!support)
+      continue;
+    if (support->transform.o[0] <= 0.0f)
+      sideLeftSupports.push_back(support);
+    else
+      sideRightSupports.push_back(support);
+  }
+  std::sort(sideLeftSupports.begin(), sideLeftSupports.end(), sortByYThenX);
+  std::sort(sideRightSupports.begin(), sideRightSupports.end(), sortByYThenX);
+  for (size_t i = 0; i < sideLeftSupports.size(); ++i) {
+    Support *support = sideLeftSupports[i];
+    support->name = "SIDE L " + std::to_string(i + 1);
+    support->motorName = support->name;
+  }
+  for (size_t i = 0; i < sideRightSupports.size(); ++i) {
+    Support *support = sideRightSupports[i];
+    support->name = "SIDE R " + std::to_string(i + 1);
+    support->motorName = support->name;
   }
 
   std::sort(screenSupports.begin(), screenSupports.end(), sortByX);
@@ -2684,12 +2717,39 @@ bool RiderImporter::ImportText(const std::string &text,
     bool found = false;
   };
   SideTrussInfo sideTrussInfo;
+  struct SideHoistSpanInfo {
+    float x = 0.0f;
+    float startY = 0.0f;
+    float endY = 0.0f;
+    float z = 0.0f;
+    bool found = false;
+  };
+  SideHoistSpanInfo leftSideHoistSpan;
+  SideHoistSpanInfo rightSideHoistSpan;
   for (const auto &[uuid, t] : scene.trusses) {
     (void)uuid;
     if (IsLxSidesHangName(t.positionName)) {
       const float sideX = t.transform.o[0];
       const float startY = t.transform.o[1];
       const float endY = startY + t.lengthMm;
+      SideHoistSpanInfo &sideSpan =
+          sideX <= 0.0f ? leftSideHoistSpan : rightSideHoistSpan;
+      if (!sideSpan.found) {
+        sideSpan.x = sideX;
+        sideSpan.startY = startY;
+        sideSpan.endY = endY;
+        sideSpan.z = t.transform.o[2];
+        sideSpan.found = true;
+      } else {
+        sideSpan.x = sideX <= 0.0f ? std::min(sideSpan.x, sideX)
+                                   : std::max(sideSpan.x, sideX);
+        const float currentStart = std::min(sideSpan.startY, sideSpan.endY);
+        const float currentEnd = std::max(sideSpan.startY, sideSpan.endY);
+        const float candidateStart = std::min(startY, endY);
+        const float candidateEnd = std::max(startY, endY);
+        sideSpan.startY = std::min(currentStart, candidateStart);
+        sideSpan.endY = std::max(currentEnd, candidateEnd);
+      }
       if (!sideTrussInfo.found) {
         sideTrussInfo.leftX = sideX;
         sideTrussInfo.rightX = sideX;
@@ -2875,6 +2935,47 @@ bool RiderImporter::ImportText(const std::string &text,
                  hoistFunction);
   };
 
+  auto distributeAcrossSides = [&](int quantity, float capacityKg,
+                                   const std::string &hoistFunction) {
+    if (quantity <= 0)
+      return;
+
+    const int leftCount = quantity / 2 + quantity % 2;
+    const int rightCount = quantity / 2;
+    const float sideMarginMm = 1000.0f;
+
+    auto placeOnSide = [&](const SideHoistSpanInfo &sideInfo, int count,
+                           float fallbackX) {
+      if (count <= 0)
+        return;
+      const float sideX = sideInfo.found ? sideInfo.x : fallbackX;
+      float startY = sideInfo.found ? sideInfo.startY : sideTrussInfo.startY;
+      float endY = sideInfo.found ? sideInfo.endY : sideTrussInfo.endY;
+      const float z = sideInfo.found ? sideInfo.z
+                                     : (sideTrussInfo.found ? sideTrussInfo.z
+                                                            : getHangHeight("LX SIDES"));
+      const float direction = endY >= startY ? 1.0f : -1.0f;
+      startY += direction * sideMarginMm;
+      endY -= direction * sideMarginMm;
+      if ((direction > 0.0f && endY < startY) ||
+          (direction < 0.0f && endY > startY)) {
+        const float center = sideInfo.found ? (sideInfo.startY + sideInfo.endY) * 0.5f
+                                            : (startY + endY) * 0.5f;
+        startY = center;
+        endY = center;
+      }
+      const float step =
+          count > 1 ? (endY - startY) / static_cast<float>(count - 1) : 0.0f;
+      for (int i = 0; i < count; ++i) {
+        const float y = startY + step * static_cast<float>(i);
+        placeHoist(sideX, y, z, capacityKg, "LX SIDES", hoistFunction);
+      }
+    };
+
+    placeOnSide(leftSideHoistSpan, leftCount, sideTrussInfo.leftX);
+    placeOnSide(rightSideHoistSpan, rightCount, sideTrussInfo.rightX);
+  };
+
   auto distributePaOrSidefill = [&](const std::string &positionName, int quantity,
                                      float capacityKg, bool sidefill,
                                      const std::string &hoistFunction) {
@@ -2953,6 +3054,10 @@ bool RiderImporter::ImportText(const std::string &text,
         placeHoist(x, y, z, request.capacityKg, "SCREEN", hoistFunction);
       }
     } else {
+      if (IsLxSidesHangName(request.target)) {
+        distributeAcrossSides(request.quantity, request.capacityKg, hoistFunction);
+        continue;
+      }
       const float marginMm = IsLxHangName(request.target) ? 1000.0f : 2000.0f;
       distributeAcrossTruss(request.target, request.quantity, request.capacityKg,
                             marginMm, hoistFunction);

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -324,7 +324,14 @@ Placement defaults:
    - Each per-LX set is placed on that truss at the same `Y/Z`, using a 1 m
      margin from truss ends in `X`.
    - Direct `LX<number>` hoist targets also use a 1 m margin from truss ends.
-4. **SCREEN hoists**
+4. **`LX SIDES` hoists (`SIDES`, `CALLES`)**
+   - Quantity is split between left/right side trusses (`left = ceil(N/2)`,
+     `right = floor(N/2)`).
+   - Each side set is distributed along the side truss length on `Y`, preserving
+     the truss direction (`startY -> endY`) and using a 1 m margin from both ends.
+   - Hoists use each side truss own `X` anchor and `Z` height.
+   - If side trusses are missing, importer falls back to side fixture anchors.
+5. **SCREEN hoists**
    - Distributed using internal truss divisions (for `N` hoists, truss span is
      split into `N+1` equal parts and hoists are placed on internal cuts).
 
@@ -342,6 +349,8 @@ Created hoists:
   - `LX*` targets => `<position> <index>` (`LX1 1`, `LX1 2`, ...).
   - `SCREEN`/video targets => `SCR <index>`.
   - `BACKDROP` targets => `BACKDROP <index>`.
+  - `LX SIDES` targets => `SIDE L <index>`, `SIDE R <index>` (ordered by `Y`
+    inside each side).
   - `SIDEFILL` => `SF L`, `SF R` (adds index when side has more than one hoist).
   - `PA`/`P.A.` => `PA L <index>`, `PA R <index>`.
   - Fallback targets => `RP <index>` (Rigging Point).

--- a/tests/rider_hoist_import_test.cpp
+++ b/tests/rider_hoist_import_test.cpp
@@ -3,6 +3,7 @@
 #include <map>
 #include <algorithm>
 #include <string>
+#include <set>
 #include <vector>
 #include <wx/init.h>
 
@@ -261,6 +262,44 @@ int main() {
   assert(lx1SupportCount == 2);
   assert(lx2SupportCount == 2);
   assert(!pollutedLayerNameFound);
+
+  cfg.Reset();
+  const std::string sideHoistsText =
+      "RIGGING\n"
+      "1 TRUSS 40X40 14m FOR LX1\n"
+      "1 TRUSS 40X40 6m FOR SIDES (1, 4)\n"
+      "4 MOTOR 1000Kg FOR SIDES\n";
+  assert(RiderImporter::ImportText(sideHoistsText));
+  const auto &sideHoistsScene = cfg.GetScene();
+  std::map<std::string, int> sideHoistNameCounts;
+  std::vector<float> sideLeftY;
+  std::vector<float> sideRightY;
+  std::set<float> sideXAnchors;
+  for (const auto &[uuid, support] : sideHoistsScene.supports) {
+    (void)uuid;
+    assert(support.positionName == "LX SIDES");
+    sideHoistNameCounts[support.name]++;
+    sideXAnchors.insert(support.transform.o[0]);
+    if (support.transform.o[0] <= 0.0f)
+      sideLeftY.push_back(support.transform.o[1]);
+    else
+      sideRightY.push_back(support.transform.o[1]);
+    assert(std::abs(support.transform.o[2] - 4000.0f) < 0.001f);
+  }
+  assert(sideHoistsScene.supports.size() == 4);
+  assert(sideXAnchors.size() == 2);
+  assert(sideLeftY.size() == 2);
+  assert(sideRightY.size() == 2);
+  std::sort(sideLeftY.begin(), sideLeftY.end());
+  std::sort(sideRightY.begin(), sideRightY.end());
+  assert(std::abs(sideLeftY[0] - 2000.0f) < 0.001f);
+  assert(std::abs(sideLeftY[1] - 6000.0f) < 0.001f);
+  assert(std::abs(sideRightY[0] - 2000.0f) < 0.001f);
+  assert(std::abs(sideRightY[1] - 6000.0f) < 0.001f);
+  assert(sideHoistNameCounts["SIDE L 1"] == 1);
+  assert(sideHoistNameCounts["SIDE L 2"] == 1);
+  assert(sideHoistNameCounts["SIDE R 1"] == 1);
+  assert(sideHoistNameCounts["SIDE R 2"] == 1);
 
   return 0;
 }


### PR DESCRIPTION
### Motivation
- Correct hoist placement for `LX SIDES` targets so motors are split between left/right side trusses and distributed along each side length instead of being placed incorrectly on a single anchor.  
- Provide predictable, side-specific motor names to match placement and operator expectations.

### Description
- Add dedicated side-hoist span tracking and placement logic in `core/riderimporter.cpp` (`SideHoistSpanInfo`, `distributeAcrossSides`) that splits quantity into `left = ceil(N/2)` / `right = floor(N/2)` and distributes each group along the truss `Y` axis with a 1 m margin and correct `X`/`Z` anchors.  
- Implement side-specific naming in `AssignImportedHoistNames` so side hoists are named `SIDE L <n>` and `SIDE R <n>` ordered by `Y` on each side.  
- Add a regression scenario to `tests/rider_hoist_import_test.cpp` validating side hoist counts, `X` anchors, `Y` distribution and `SIDE L/R` names.  
- Update `docs/text_to_scene_rules.md` to document `LX SIDES` hoist distribution and the new `SIDE L <index>` / `SIDE R <index>` naming rules.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it returned OK.  
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it returned OK.  
- Attempted to configure a local build via `cmake --preset wsl-x64-debug` but configuration failed in this environment due to missing system development libraries for `wxWidgets` (so the new unit test could not be built/run here).  
- A new unit test was added (`tests/rider_hoist_import_test.cpp`) to cover the `SIDES` hoist behavior and should be executed in CI or an environment with the build dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbeb06f1b083249594226d939e8849)