### PR TITLE
Rider import: switch to linear L→R placement for repeated fixture sequences and center single fixtures

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -1672,6 +1672,11 @@ bool RiderImporter::ImportText(const std::string &text,
   std::unordered_set<std::string> seenTypes;
   std::vector<std::string> importedTrussUuids;
   std::vector<std::string> importedFixtureUuids;
+  std::unordered_map<std::string, size_t> importedFixtureOrderByUuid;
+  size_t nextImportedFixtureOrder = 0;
+  std::unordered_map<std::string, std::unordered_set<std::string>>
+      seenFixtureTypesByHangInListing;
+  std::unordered_set<std::string> linearPlacementHangs;
   struct PipeSpanInfo {
     std::string positionName;
     float startX = 0.0f;
@@ -1711,6 +1716,16 @@ bool RiderImporter::ImportText(const std::string &text,
           quantity = baseQuantity;
         part = Trim(pm[2]);
       }
+      std::string placementKey = Trim(part);
+      std::transform(placementKey.begin(), placementKey.end(), placementKey.begin(),
+                     [](unsigned char c) {
+                       return static_cast<char>(std::tolower(c));
+                     });
+      auto &seenTypesForHang = seenFixtureTypesByHangInListing[currentHang];
+      if (!placementKey.empty() && seenTypesForHang.count(placementKey) > 0)
+        linearPlacementHangs.insert(currentHang);
+      else if (!placementKey.empty())
+        seenTypesForHang.insert(placementKey);
       const bool isScreenHang = NormalizeHangName(currentHang) == "SCREEN";
       const bool isScreenDescription =
           ContainsCaseInsensitive(part, "pantalla") ||
@@ -1777,6 +1792,7 @@ bool RiderImporter::ImportText(const std::string &text,
         f.transform.o[2] = getHangHeight(currentHang);
         scene.fixtures[f.uuid] = f;
         importedFixtureUuids.push_back(f.uuid);
+        importedFixtureOrderByUuid[f.uuid] = nextImportedFixtureOrder++;
         addToLayer(f.layer, f.uuid);
       }
     }
@@ -3154,6 +3170,22 @@ bool RiderImporter::ImportText(const std::string &text,
     return ordered;
   };
 
+  auto buildLinearOrder = [&](const std::vector<Fixture *> &fixturesVec) {
+    std::vector<Fixture *> ordered = fixturesVec;
+    std::sort(ordered.begin(), ordered.end(), [&](Fixture *a, Fixture *b) {
+      const size_t orderA = importedFixtureOrderByUuid.count(a->uuid) > 0
+                                ? importedFixtureOrderByUuid.at(a->uuid)
+                                : std::numeric_limits<size_t>::max();
+      const size_t orderB = importedFixtureOrderByUuid.count(b->uuid) > 0
+                                ? importedFixtureOrderByUuid.at(b->uuid)
+                                : std::numeric_limits<size_t>::max();
+      if (orderA != orderB)
+        return orderA < orderB;
+      return a->uuid < b->uuid;
+    });
+    return ordered;
+  };
+
   auto placeFixtureGroup = [&](const std::string &pos,
                                const std::vector<Fixture *> &fixturesVec,
                                const std::function<void(Fixture &, float, float,
@@ -3161,7 +3193,11 @@ bool RiderImporter::ImportText(const std::string &text,
     if (fixturesVec.empty())
       return;
 
-    const std::vector<Fixture *> ordered = buildSymmetricOrder(fixturesVec);
+    const bool useLinearPlacement =
+        linearPlacementHangs.count(pos) > 0 && !fixturesVec.empty();
+    const std::vector<Fixture *> ordered =
+        useLinearPlacement ? buildLinearOrder(fixturesVec)
+                           : buildSymmetricOrder(fixturesVec);
     const int total = static_cast<int>(ordered.size());
     if (total <= 0)
       return;
@@ -3178,8 +3214,17 @@ bool RiderImporter::ImportText(const std::string &text,
     float baseY = info.found ? info.y : getHangPos(pos);
     float baseZ = info.found ? info.z : getHangHeight(pos);
     float width = info.found ? info.width : 400.0f;
-    float step = (total > 1) ? (endX - startX) / (total - 1) : 0.0f;
+    if (total == 1) {
+      Fixture *fixture = ordered.front();
+      if (fixture) {
+        const float centeredX =
+            info.found ? 0.5f * (startX + endX) : 0.0f;
+        applyPlacement(*fixture, centeredX, baseY, baseZ, width);
+      }
+      return;
+    }
 
+    float step = (endX - startX) / static_cast<float>(total - 1);
     for (int i = 0; i < total; ++i) {
       Fixture *f = ordered[static_cast<size_t>(i)];
       if (!f)

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -400,19 +400,27 @@ After parsing, imported fixtures are distributed per hang:
    - Exception for `LX SIDES`: fixtures are still split into left/right groups
      as if side trusses existed, with fallback anchors at `Y = 1.0 m`
      and `500 mm` spacing moving upstage (positive Y).
-4. Ordering alternates fixture types symmetrically:
-   - odd counts place a center fixture,
-   - remaining fixtures are paired left/right.
+4. Ordering mode per hang:
+   - Default mode is **symmetric by type**:
+     - odd counts place a center fixture,
+     - remaining fixtures are paired left/right.
+   - If a fixture type is listed more than once for the same hang in the rider
+     fixture list (for example `MegaPointe ... Spiider ... MegaPointe`), that
+     hang switches to **linear left-to-right mode** and keeps rider list order.
 5. Fixtures are split into placement groups:
    - **Bottom group**: all categories except `Wash`, `Blinder`, `Strobe`.
    - **Bottom-back override**: `Wash` is placed on the back side.
    - **Top-front group**: `Blinder` and `Strobe` are placed on top-front.
    - **Smoke side-floor group**: `Smoke` fixtures are placed using side-style
      mirroring (left/right split along `Y`) at floor level.
-6. `x` spacing is computed independently per group:
+6. `x` spacing is computed independently per group and per ordering mode:
    - Bottom fixtures share one spacing/order pass.
    - Top-front fixtures use a separate spacing/order pass and do not affect bottom spacing.
-7. Final fixture transform by group:
+   - This means bottom and top-front groups can each resolve symmetric vs
+     linear behavior independently while keeping their own list order.
+7. If a group has exactly one fixture, it is placed at the horizontal center of
+   the usable hang span (instead of at a lateral edge).
+8. Final fixture transform by group:
    - Bottom-front:
      - `x`: evenly spaced from start to end (bottom group),
      - `y`: `baseY - trussWidth/2`,
@@ -425,11 +433,11 @@ After parsing, imported fixtures are distributed per hang:
      - `x`: evenly spaced from start to end (top group),
      - `y`: `baseY - trussWidth/2`,
      - `z`: `baseZ + trussWidth/2`.
-8. `LX SIDES` fixture distribution:
+9. `LX SIDES` fixture distribution:
    - Fixtures are split into two symmetric groups (left/right side).
    - Each side group is distributed along `Y` (matching side truss direction).
    - `X` anchors match side-truss anchors (or fallback anchors when no side truss exists).
-9. `Smoke` fixture distribution (all non-`LX SIDES` hangs):
+10. `Smoke` fixture distribution (all non-`LX SIDES` hangs):
    - `Smoke` fixtures are split into two symmetric groups (left/right side),
      distributed along `Y` using side-truss extents when available.
    - Without side trusses, each side uses fallback `Y = 1.0 m` with `500 mm`

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -631,6 +631,34 @@ add_test(NAME RiderImportOrder COMMAND rider_import_order_test
          ${CMAKE_CURRENT_SOURCE_DIR}/data/rider_fixture_order.txt)
 set_library_env(RiderImportOrder)
 
+add_executable(rider_import_linear_order_test rider_import_linear_order_test.cpp
+               riderimporter_stubs.cpp
+               gdtfloader_stub.cpp
+               ../core/riderimporter.cpp
+               ../core/units/units.cpp
+               ../core/gdtf_fixture_category.cpp
+               ../core/hoist_weight_distribution.cpp
+               ../core/uuidutils.cpp
+               ../core/autopatcher.cpp
+               ../core/patchmanager.cpp
+               ../core/configmanager.cpp
+               ../core/configservices.cpp
+               ../core/projectutils.cpp
+               ../core/library/library_bootstrap.cpp
+               ../core/logger.cpp
+               ../models/mvrscene.cpp
+               ../models/fixture.cpp
+               ../models/truss.cpp
+               ../models/sceneobject.cpp
+               ../models/layer.cpp
+               ${LAYOUT_SOURCES})
+target_include_directories(rider_import_linear_order_test PRIVATE
+                           . ../core ../models ../mvr ../gui ../third_party)
+target_link_libraries(rider_import_linear_order_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
+add_test(NAME RiderImportLinearOrder COMMAND rider_import_linear_order_test
+         ${CMAKE_CURRENT_SOURCE_DIR}/data/rider_fixture_linear_order.txt)
+set_library_env(RiderImportLinearOrder)
+
 add_executable(rider_import_preserve_existing_test rider_import_preserve_existing_test.cpp
                riderimporter_stubs.cpp
                gdtfloader_stub.cpp

--- a/tests/data/rider_fixture_linear_order.txt
+++ b/tests/data/rider_fixture_linear_order.txt
@@ -1,0 +1,9 @@
+Iluminacion
+LX1:
+1 MegaPointe
+2 Spiider
+2 MegaPointe
+2 Spiider
+1 MegaPointe
+LX2:
+1 SoloSpot

--- a/tests/rider_import_linear_order_test.cpp
+++ b/tests/rider_import_linear_order_test.cpp
@@ -1,0 +1,57 @@
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <vector>
+#include <wx/init.h>
+
+#include "configmanager.h"
+#include "fixture.h"
+#include "riderimporter.h"
+
+int main(int argc, char **argv) {
+  wxInitializer initializer;
+  assert(initializer.IsOk());
+  assert(argc >= 2);
+
+  auto &cfg = ConfigManager::Get();
+  cfg.Reset();
+
+  RiderImporter importer;
+  assert(importer.Import(argv[1]));
+
+  const auto &scene = cfg.GetScene();
+
+  std::vector<const Fixture *> lx1Fixtures;
+  std::vector<const Fixture *> lx2Fixtures;
+  for (const auto &[uuid, fixture] : scene.fixtures) {
+    (void)uuid;
+    if (fixture.positionName == "LX1")
+      lx1Fixtures.push_back(&fixture);
+    if (fixture.positionName == "LX2")
+      lx2Fixtures.push_back(&fixture);
+  }
+
+  assert(lx1Fixtures.size() == 8);
+  assert(lx2Fixtures.size() == 1);
+
+  std::sort(lx1Fixtures.begin(), lx1Fixtures.end(),
+            [](const Fixture *a, const Fixture *b) {
+              return a->transform.o[0] < b->transform.o[0];
+            });
+
+  const std::vector<std::string> expectedTypes = {
+      "MegaPointe", "Spiider", "Spiider", "MegaPointe",
+      "MegaPointe", "Spiider", "Spiider", "MegaPointe"};
+  for (size_t i = 0; i < expectedTypes.size(); ++i)
+    assert(lx1Fixtures[i]->typeName == expectedTypes[i]);
+
+  const std::vector<float> expectedYOffsets = {-200.0f, -200.0f, -200.0f, -200.0f,
+                                               -200.0f, -200.0f, -200.0f, -200.0f};
+  for (size_t i = 0; i < expectedYOffsets.size(); ++i)
+    assert(std::abs(lx1Fixtures[i]->transform.o[1] - expectedYOffsets[i]) < 1e-3f);
+
+  const Fixture *single = lx2Fixtures.front();
+  assert(std::abs(single->transform.o[0]) < 1e-3f);
+
+  return 0;
+}


### PR DESCRIPTION
### Motivation

- Ensure "create from text" places fixtures in the rider-intended left-to-right order when a device type repeats in the same hang instead of forcing symmetric interleaving. 
- Preserve existing per-zone behavior (top/front vs bottom/back and LX sides) while allowing each placement group to independently use symmetric or linear ordering. 
- Place single fixtures centered in the usable hang span to match user expectations instead of pushing them to an edge.

### Description

- Detect repeated fixture type tokens per hang during import and record the hang as requiring linear placement by tracking `seenFixtureTypesByHangInListing` and `linearPlacementHangs` in `core/riderimporter.cpp`.
- Record import order using `importedFixtureOrderByUuid` and `nextImportedFixtureOrder` and add a `buildLinearOrder` function that sorts fixtures by import order for linear placement.
- Switch `placeFixtureGroup` to choose between the existing symmetric ordering (`buildSymmetricOrder`) and the new linear ordering and center a single fixture (`total == 1`) on the usable hang span instead of placing it at an edge, keeping group placement (bottom/top-front/smoke/LX SIDES) unchanged.
- Update text-to-scene documentation in `docs/text_to_scene_rules.md` to describe the new per-hang ordering mode and single-fixture centering behavior.
- Add a regression test and input data: `tests/rider_import_linear_order_test.cpp` and `tests/data/rider_fixture_linear_order.txt`, and register the test in `tests/CMakeLists.txt`.

### Testing

- Ran `tests/check_perastage_tree_modules.sh`, which passed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which passed successfully.
- Attempted `cmake --preset wsl-x64-debug` to build tests, but the configure step failed in this environment due to missing `wxWidgets` development dependencies so unit tests could not be compiled here (the new test is added and registered in CMake).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbeec94f04832495ad19e60c9f2900)