### PR TITLE
Improve rider text import feedback during line parsing

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -1538,7 +1538,12 @@ bool RiderImporter::ImportText(const std::string &text,
         std::count(textToImport.begin(), textToImport.end(), '\n'));
     return newlineCount + 1;
   }();
-  constexpr int kParsingProgressReportEveryLines = 40;
+  const int parsingProgressReportEveryLines = [&]() {
+    if (totalInputLines <= 0)
+      return 1;
+    // Keep parsing feedback visibly active by targeting about 30 updates.
+    return std::max(1, totalInputLines / 30);
+  }();
 
   ConfigManager &cfg = ConfigManager::Get();
   cfg.PushUndoState("import rider");
@@ -1810,7 +1815,7 @@ bool RiderImporter::ImportText(const std::string &text,
     ++parsedInputLineCount;
     if (totalInputLines > 0 &&
         (parsedInputLineCount == 1 ||
-         parsedInputLineCount % kParsingProgressReportEveryLines == 0 ||
+         parsedInputLineCount % parsingProgressReportEveryLines == 0 ||
          parsedInputLineCount == totalInputLines)) {
       reportProgress("Parsing lines... (" + std::to_string(parsedInputLineCount) +
                          "/" + std::to_string(totalInputLines) + ")",

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -1531,6 +1531,14 @@ bool RiderImporter::ImportText(const std::string &text,
   const std::string filteredText = BuildFixtureFilterPreview(text);
   const std::string &textToImport = filteredText.empty() ? text : filteredText;
   reportProgress("Parsing lines...", 2, 6);
+  const int totalInputLines = [&]() {
+    if (textToImport.empty())
+      return 0;
+    const int newlineCount = static_cast<int>(
+        std::count(textToImport.begin(), textToImport.end(), '\n'));
+    return newlineCount + 1;
+  }();
+  constexpr int kParsingProgressReportEveryLines = 40;
 
   ConfigManager &cfg = ConfigManager::Get();
   cfg.PushUndoState("import rider");
@@ -1704,6 +1712,7 @@ bool RiderImporter::ImportText(const std::string &text,
   bool havePending = false;
   std::unordered_map<std::string, TrussCoordinateOverride>
       hangCoordinateOverrides;
+  int parsedInputLineCount = 0;
 
   auto addFixtures = [&](int baseQuantity, const std::string &desc) {
     auto parts = SplitPlus(desc);
@@ -1798,6 +1807,15 @@ bool RiderImporter::ImportText(const std::string &text,
     }
   };
   while (std::getline(iss, line)) {
+    ++parsedInputLineCount;
+    if (totalInputLines > 0 &&
+        (parsedInputLineCount == 1 ||
+         parsedInputLineCount % kParsingProgressReportEveryLines == 0 ||
+         parsedInputLineCount == totalInputLines)) {
+      reportProgress("Parsing lines... (" + std::to_string(parsedInputLineCount) +
+                         "/" + std::to_string(totalInputLines) + ")",
+                     2, 6);
+    }
     // Remove Windows carriage returns to allow regexes anchored with '$' to
     // match lines extracted from external tools.
     line.erase(std::remove(line.begin(), line.end(), '\r'), line.end());


### PR DESCRIPTION
### Motivation
- Users reported a long pause while the import stage showed a static `Text import: Parsing lines... (2/6)` message, which made the app appear frozen during large text imports. 
- The intent is to improve perceived responsiveness by providing incremental, visible feedback without changing the import stages or scene-generation behavior. 

### Description
- Calculate the total number of input lines and add a `totalInputLines` heuristic to `RiderImporter::ImportText` in `core/riderimporter.cpp` so the parser can report progress relative to the input size. 
- Add a `parsedInputLineCount` counter and a reporting cadence constant `kParsingProgressReportEveryLines` to avoid per-line updates and limit UI churn. 
- Emit periodic `reportProgress` calls with the stage text `Parsing lines... (current/total)` during the `while (std::getline(...))` loop to update status and progress dialog intermittently. 
- Keep the existing 6-stage progress model intact and do not change parsing or scene construction logic. 

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbf55eec2483248967742965ef9862)