### PR TITLE
cmake: ignore Windows vcpkg prefixes on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,20 @@ if(NOT DEFINED PERAVIZ_ENABLE_DMX)
     set(PERAVIZ_ENABLE_DMX ON CACHE BOOL "Enable DMX input (Art-Net RX) for Peraviz native")
 endif()
 
+if(UNIX AND NOT APPLE)
+    # Prevent WSL/Linux builds from accidentally loading Windows vcpkg packages
+    # through CMAKE_PREFIX_PATH (for example: /mnt/c/vcpkg/installed/x64-windows).
+    set(_perastage_filtered_prefixes "")
+    foreach(_prefix IN LISTS CMAKE_PREFIX_PATH)
+        if(_prefix MATCHES ".*[\\\\/]vcpkg[\\\\/]installed[\\\\/].*-windows($|[\\\\/].*)")
+            message(STATUS "Ignoring Windows vcpkg prefix on Linux: ${_prefix}")
+        else()
+            list(APPEND _perastage_filtered_prefixes "${_prefix}")
+        endif()
+    endforeach()
+    set(CMAKE_PREFIX_PATH "${_perastage_filtered_prefixes}")
+endif()
+
 # wxWidgets chooses different binary sets based on wxWidgets_USE_DEBUG.
 # - Single-config: we can select debug libs based on CMAKE_BUILD_TYPE.
 # - Multi-config (Visual Studio): do not force wxWidgets_USE_DEBUG unless explicitly requested.


### PR DESCRIPTION
### Motivation
- CMake in WSL/Linux environments can pick up Windows vcpkg prefixes (e.g. `/mnt/c/vcpkg/installed/x64-windows`) from `CMAKE_PREFIX_PATH`, causing `find_package` to load incompatible Windows package config files and break the Linux configure/build.

### Description
- Add a filtering block in `CMakeLists.txt` under `if(UNIX AND NOT APPLE)` that iterates `CMAKE_PREFIX_PATH` and removes entries matching vcpkg Windows triplet patterns before continuing configure. 
- Emit a `message(STATUS ...)` for each ignored Windows vcpkg prefix so misconfiguration is visible during configure. 
- Keep behavior unchanged on Windows and preserve other package discovery semantics.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which succeeded. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which succeeded. 
- Ran `cmake -S . -B build-test -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=/mnt/c/vcpkg/installed/x64-windows` which printed the `Ignoring Windows vcpkg prefix on Linux` status messages and confirmed the Windows vcpkg prefix is not used during configure, while full project configure still fails in the container due to missing native Linux `wxWidgets` dev packages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbfddbfed08324a2acb862c5edab60)