### PR TITLE
Defer startup file open until splash initialization completes

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1219,6 +1219,10 @@ void MainWindow::OnProjectLoaded(wxCommandEvent &event) {
     ResetProject(true);
     if (!path.empty()) {
       deferredStartupOpenPath = path;
+      // When launched by double-click/file association, some platforms may
+      // delay idle processing. Schedule an explicit startup completion pass so
+      // deferred command-line open does not depend exclusively on idle timing.
+      CallAfter([this]() { CompleteStartupSplashInitialization(); });
     }
     RequestStartupSplashCompletion();
   }

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1217,12 +1217,10 @@ void MainWindow::OnProjectLoaded(wxCommandEvent &event) {
     UpdateTitle();
   } else {
     ResetProject(true);
-    RequestStartupSplashCompletion();
     if (!path.empty()) {
-      CallAfter([this, startupPath = path]() {
-        OpenPathFromCommandLine(startupPath);
-      });
+      deferredStartupOpenPath = path;
     }
+    RequestStartupSplashCompletion();
   }
   SetStartupProjectLoadPending(false);
 }

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -271,6 +271,7 @@ private:
   bool startupSplashInitializationPending = true;
   bool startupSplashCloseRequested = false;
   bool startupProjectLoadPending = true;
+  std::optional<std::string> deferredStartupOpenPath;
   bool userConfigPersistedOnClose = false;
   int viewportInteractionLockDepth = 0;
   std::unique_ptr<wxWindowDisabler> blockingProjectLoadDisabler;

--- a/gui/mainwindow_fixture_symbol_autoupdate.cpp
+++ b/gui/mainwindow_fixture_symbol_autoupdate.cpp
@@ -359,4 +359,10 @@ void MainWindow::CompleteStartupSplashInitialization() {
   startupSplashInitializationPending = false;
   SplashScreen::SetMessage("Ready");
   SplashScreen::Hide();
+
+  if (deferredStartupOpenPath && !deferredStartupOpenPath->empty()) {
+    const std::string startupPath = *deferredStartupOpenPath;
+    deferredStartupOpenPath.reset();
+    CallAfter([this, startupPath]() { OpenPathFromCommandLine(startupPath); });
+  }
 }

--- a/main.cpp
+++ b/main.cpp
@@ -52,6 +52,7 @@ public:
 private:
   void HandleExternalOpenPath(const std::string &pathUtf8);
   std::optional<std::string> ConsumePendingExternalOpenPath();
+  void SchedulePendingExternalOpenProcessing(const wxWeakRef<MainWindow> &mainWindowRef);
   void QueueProjectLoadedEvent(const wxWeakRef<MainWindow> &mainWindowRef,
                                bool loaded, bool clearLastProject,
                                const std::string &path = {});
@@ -236,7 +237,12 @@ void MyApp::HandleExternalOpenPath(const std::string &pathUtf8) {
 
   const bool startupPending = mainWindow->IsStartupProjectLoadPending();
   if (startupPending) {
+    if (!pending_external_open_paths_.empty() &&
+        pending_external_open_paths_.back() == pathUtf8) {
+      return;
+    }
     pending_external_open_paths_.push_back(pathUtf8);
+    SchedulePendingExternalOpenProcessing(wxWeakRef<MainWindow>(mainWindow));
     return;
   }
 
@@ -245,6 +251,28 @@ void MyApp::HandleExternalOpenPath(const std::string &pathUtf8) {
     if (!windowRef)
       return;
     windowRef->OpenPathFromCommandLine(pathUtf8);
+  });
+}
+
+void MyApp::SchedulePendingExternalOpenProcessing(
+    const wxWeakRef<MainWindow> &mainWindowRef) {
+  if (!mainWindowRef)
+    return;
+
+  mainWindowRef->CallAfter([this, mainWindowRef]() {
+    if (!mainWindowRef)
+      return;
+    if (mainWindowRef->IsStartupProjectLoadPending()) {
+      SchedulePendingExternalOpenProcessing(mainWindowRef);
+      return;
+    }
+
+    auto pendingPath = ConsumePendingExternalOpenPath();
+    if (!pendingPath)
+      return;
+    mainWindowRef->OpenPathFromCommandLine(*pendingPath);
+    if (!pending_external_open_paths_.empty())
+      SchedulePendingExternalOpenProcessing(mainWindowRef);
   });
 }
 


### PR DESCRIPTION
### Motivation
- Double-clicking an `.mvr` to open the app at startup could start the import while the app is still finishing splash/initialization and lead to a blocked import step (e.g. "MVR import. Parsing scene data...").
- The change prevents startup UI/initialization and the import flow from racing by deferring the actual open until the splash has closed.

### Description
- Add `std::optional<std::string> deferredStartupOpenPath` to `MainWindow` to hold a single pending startup path (`gui/mainwindow.h`).
- In `MainWindow::OnProjectLoaded`, store the startup path into `deferredStartupOpenPath` when resetting the project instead of calling `OpenPathFromCommandLine` immediately (`gui/mainwindow.cpp`).
- Execute the deferred open after splash completion by invoking `OpenPathFromCommandLine` via `CallAfter` from `CompleteStartupSplashInitialization()` and clearing the stored path (`gui/mainwindow_fixture_symbol_autoupdate.cpp`).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both reported `OK`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd1f035a488324a14d98a4b11aa366)