### PR TITLE
Improve Peraviz MVR geometry and primitive resolution

### DIFF
--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -521,3 +521,16 @@ Perastage parses rider text by identifying sections, hang positions, fixture lin
 ## Peraviz MVR/GDTF visual fallback rule
 
 When loading MVR/GDTF content in Peraviz, dummy placeholder meshes must only be rendered if no real visual geometry exists for that node subtree. If a valid model (mesh/scene) is present in descendants, placeholder cubes/cones are removed to avoid double drawing.
+
+## Peraviz MVR geometry resolution rule
+
+When loading MVR content in Peraviz:
+
+1. Model references are resolved from the ZIP in a case-insensitive way using
+   normalized slash-separated paths.
+2. If a model has no extension, Peraviz now prefers `.glb`, then `.gltf`, and
+   finally `.3ds`.
+3. Primitive references (`primitive:*`) are treated as real geometry and mapped
+   to `asset_kind="primitive"` instead of forcing a file lookup.
+4. SymDef symbol geometry can emit primitives as well as file-backed
+   geometries, preserving symbol/local matrix composition.

--- a/peraviz/native/src/asset_cache.cpp
+++ b/peraviz/native/src/asset_cache.cpp
@@ -100,6 +100,19 @@ bool is_supported_model_extension(const std::string &extension_lower) {
            extension_lower == ".gltf";
 }
 
+int model_extension_priority(const std::string &extension_lower) {
+    if (extension_lower == ".glb") {
+        return 0;
+    }
+    if (extension_lower == ".gltf") {
+        return 1;
+    }
+    if (extension_lower == ".3ds") {
+        return 2;
+    }
+    return 100;
+}
+
 std::string gdtf_lookup_key(const std::string &archive_path) {
     const std::string normalized = trim_ascii(normalize_archive_path(archive_path));
     if (normalized.empty()) {
@@ -339,12 +352,12 @@ std::string ZipAssetCache::ensure_mvr_model_extracted(const std::string &model_r
         candidates.push_back(normalized);
         candidates.push_back("models/" + ext.substr(1) + "/" + stem + ext);
     } else {
-        candidates.push_back(normalized + ".3ds");
         candidates.push_back(normalized + ".glb");
         candidates.push_back(normalized + ".gltf");
-        candidates.push_back("models/3ds/" + stem + ".3ds");
+        candidates.push_back(normalized + ".3ds");
         candidates.push_back("models/glb/" + stem + ".glb");
         candidates.push_back("models/gltf/" + stem + ".gltf");
+        candidates.push_back("models/3ds/" + stem + ".3ds");
     }
 
     for (const std::string &candidate : candidates) {
@@ -362,6 +375,7 @@ std::string ZipAssetCache::ensure_mvr_model_extracted(const std::string &model_r
     wxZipInputStream zip(input);
     std::unique_ptr<wxZipEntry> entry;
     std::optional<std::string> best_entry;
+    int best_priority = 100;
     while ((entry.reset(zip.GetNextEntry())), entry) {
         const std::string entry_name = normalize_archive_path(entry->GetName().ToUTF8().data());
         if (path_stem_lower(entry_name) != stem_lower) {
@@ -373,9 +387,11 @@ std::string ZipAssetCache::ensure_mvr_model_extracted(const std::string &model_r
             continue;
         }
 
-        if (!best_entry.has_value() || entry_ext == ".3ds") {
+        const int priority = model_extension_priority(entry_ext);
+        if (!best_entry.has_value() || priority < best_priority) {
             best_entry = entry_name;
-            if (entry_ext == ".3ds") {
+            best_priority = priority;
+            if (priority == 0) {
                 break;
             }
         }

--- a/peraviz/native/src/mvr_scene_loader.cpp
+++ b/peraviz/native/src/mvr_scene_loader.cpp
@@ -28,8 +28,17 @@ using peraviz::SceneModel;
 using peraviz::SceneNode;
 
 struct SymdefGeometry {
-    std::string file_name;
+    std::string geometry_reference;
+    std::string primitive_type;
+    float primitive_size_x_m = 0.1F;
+    float primitive_size_y_m = 0.1F;
+    float primitive_size_z_m = 0.1F;
     Matrix transform = MatrixUtils::Identity();
+};
+
+struct PrimitiveToken {
+    bool valid = false;
+    std::string primitive_type;
 };
 
 std::string lower_ascii(std::string text) {
@@ -169,18 +178,12 @@ std::string parse_model_filename(tinyxml2::XMLElement *geo_node) {
     return {};
 }
 
-std::string normalize_geometry_file_name(const std::string &file_name) {
-    if (file_name.empty()) {
-        return {};
+std::string infer_asset_kind_from_path(const std::string &asset_path,
+                                       const PrimitiveToken &primitive_token = {}) {
+    if (primitive_token.valid) {
+        return "primitive";
     }
-    std::filesystem::path path = std::filesystem::u8path(file_name);
-    if (!path.has_extension()) {
-        path += ".3ds";
-    }
-    return path.u8string();
-}
 
-std::string infer_asset_kind_from_path(const std::string &asset_path) {
     if (asset_path.empty()) {
         return "none";
     }
@@ -236,6 +239,101 @@ int parse_int_text(const char *value) {
         return -1;
     }
     return static_cast<int>(parsed);
+}
+
+std::string normalize_geometry_reference(const std::string &reference) {
+    std::string normalized = trim_ascii(reference);
+    if (normalized.empty()) {
+        return {};
+    }
+
+    std::replace(normalized.begin(), normalized.end(), '\\', '/');
+    while (!normalized.empty() && (normalized.front() == '/' || normalized.front() == '.')) {
+        normalized.erase(normalized.begin());
+    }
+    return normalized;
+}
+
+PrimitiveToken parse_primitive_token(const std::string &reference) {
+    const std::string normalized = lower_ascii(trim_ascii(reference));
+    if (normalized.rfind("primitive:", 0) != 0) {
+        return {};
+    }
+
+    PrimitiveToken token;
+    token.valid = true;
+    token.primitive_type = normalized.substr(std::string("primitive:").size());
+    if (token.primitive_type.empty()) {
+        token.primitive_type = "cube";
+    }
+    return token;
+}
+
+bool parse_float_attribute_mm(tinyxml2::XMLElement *node,
+                              std::initializer_list<const char *> names,
+                              float &out_value_mm) {
+    if (!node) {
+        return false;
+    }
+
+    for (const char *name : names) {
+        if (const char *raw = node->Attribute(name)) {
+            char *end = nullptr;
+            const float parsed = std::strtof(raw, &end);
+            if (end != raw) {
+                out_value_mm = parsed;
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+void fill_primitive_dimensions_from_node(tinyxml2::XMLElement *node,
+                                         SceneNode &scene_node) {
+    float size_x_mm = 100.0F;
+    float size_y_mm = 100.0F;
+    float size_z_mm = 100.0F;
+
+    parse_float_attribute_mm(node, {"SizeX", "sizeX", "Length", "length", "X", "x"}, size_x_mm);
+    parse_float_attribute_mm(node, {"SizeY", "sizeY", "Width", "width", "Y", "y"}, size_y_mm);
+    parse_float_attribute_mm(node, {"SizeZ", "sizeZ", "Height", "height", "Z", "z"}, size_z_mm);
+
+    float radius_mm = 0.0F;
+    if (parse_float_attribute_mm(node, {"Radius", "radius"}, radius_mm) && radius_mm > 0.0F) {
+        const float diameter_mm = radius_mm * 2.0F;
+        size_x_mm = diameter_mm;
+        size_y_mm = diameter_mm;
+    }
+
+    float diameter_mm = 0.0F;
+    if (parse_float_attribute_mm(node, {"Diameter", "diameter"}, diameter_mm) &&
+        diameter_mm > 0.0F) {
+        size_x_mm = diameter_mm;
+        size_y_mm = diameter_mm;
+    }
+
+    scene_node.primitive_size_x = std::max(size_x_mm / 1000.0F, 0.001F);
+    scene_node.primitive_size_y = std::max(size_y_mm / 1000.0F, 0.001F);
+    scene_node.primitive_size_z = std::max(size_z_mm / 1000.0F, 0.001F);
+}
+
+std::string parse_geometry_reference(tinyxml2::XMLElement *geo_node) {
+    if (!geo_node) {
+        return {};
+    }
+
+    const std::string direct_reference = normalize_geometry_reference(parse_model_filename(geo_node));
+    if (!direct_reference.empty()) {
+        return direct_reference;
+    }
+
+    const std::string tag_name = lower_ascii(geo_node->Name() ? geo_node->Name() : "");
+    if (tag_name == "cube" || tag_name == "box" || tag_name == "sphere" ||
+        tag_name == "cone" || tag_name == "cylinder") {
+        return "primitive:" + tag_name;
+    }
+    return {};
 }
 
 bool try_parse_fixture_address_text(const std::string &text,
@@ -425,11 +523,20 @@ std::unordered_map<std::string, std::vector<SymdefGeometry>> parse_symdefs(tinyx
                 Matrix local = parse_matrix_node(child);
                 Matrix world = MatrixUtils::Multiply(parent_world, local);
 
-                if (is_element_name(child, "geometry3d")) {
-                    const std::string model_name = normalize_geometry_file_name(parse_model_filename(child));
-                    if (!model_name.empty()) {
+                if (is_element_name(child, "geometry3d") || is_element_name(child, "cube") ||
+                    is_element_name(child, "box") || is_element_name(child, "sphere") ||
+                    is_element_name(child, "cone") || is_element_name(child, "cylinder")) {
+                    const std::string geometry_reference = parse_geometry_reference(child);
+                    const PrimitiveToken primitive_token = parse_primitive_token(geometry_reference);
+                    if (!geometry_reference.empty() || primitive_token.valid) {
                         SymdefGeometry geometry;
-                        geometry.file_name = model_name;
+                        geometry.geometry_reference = geometry_reference;
+                        geometry.primitive_type = primitive_token.primitive_type;
+                        SceneNode primitive_node;
+                        fill_primitive_dimensions_from_node(child, primitive_node);
+                        geometry.primitive_size_x_m = primitive_node.primitive_size_x;
+                        geometry.primitive_size_y_m = primitive_node.primitive_size_y;
+                        geometry.primitive_size_z_m = primitive_node.primitive_size_z;
                         geometry.transform = world;
                         geometries.push_back(std::move(geometry));
                     }
@@ -467,7 +574,15 @@ int append_single_geometry(SceneModel &scene, tinyxml2::XMLElement *geo,
                            const std::string &parent_id, const Matrix &parent_world,
                            peraviz::ZipAssetCache &mvr_cache, const std::string &prefix,
                            int &serial) {
-    if (!geo || !is_element_name(geo, "geometry3d")) {
+    if (!geo) {
+        return 0;
+    }
+
+    const bool supported_geometry =
+        is_element_name(geo, "geometry3d") || is_element_name(geo, "cube") ||
+        is_element_name(geo, "box") || is_element_name(geo, "sphere") ||
+        is_element_name(geo, "cone") || is_element_name(geo, "cylinder");
+    if (!supported_geometry) {
         return 0;
     }
 
@@ -481,11 +596,18 @@ int append_single_geometry(SceneModel &scene, tinyxml2::XMLElement *geo,
     geo_node.type = "model_part";
     geo_node.node_class = "model_part";
     geo_node.local_transform = peraviz::coordinate_mapper::to_godot_transform(local);
-    const std::string model_name = normalize_geometry_file_name(parse_model_filename(geo));
-    if (!model_name.empty()) {
-        geo_node.asset_path = mvr_cache.ensure_mvr_model_extracted(model_name);
+    const std::string geometry_reference = parse_geometry_reference(geo);
+    const PrimitiveToken primitive_token = parse_primitive_token(geometry_reference);
+    if (primitive_token.valid) {
+        geo_node.primitive_type = primitive_token.primitive_type;
+        fill_primitive_dimensions_from_node(geo, geo_node);
+    } else if (!geometry_reference.empty()) {
+        geo_node.asset_path = mvr_cache.ensure_mvr_model_extracted(geometry_reference);
     }
-    geo_node.asset_kind = infer_asset_kind_from_path(geo_node.asset_path);
+    geo_node.asset_kind = infer_asset_kind_from_path(geo_node.asset_path, primitive_token);
+    if (geo_node.asset_kind == "none") {
+        return 0;
+    }
     scene.nodes.push_back(std::move(geo_node));
     (void)world;
     return 1;
@@ -530,10 +652,19 @@ void append_geometry_children(SceneModel &scene, tinyxml2::XMLElement *node, con
                     Matrix local = MatrixUtils::Multiply(symbol_local, sym_geo.transform);
                     symbol_node.local_transform = peraviz::coordinate_mapper::to_godot_transform(local);
 
-                    if (!sym_geo.file_name.empty()) {
-                        symbol_node.asset_path = mvr_cache.ensure_mvr_model_extracted(sym_geo.file_name);
+                    const PrimitiveToken primitive_token =
+                        parse_primitive_token(sym_geo.geometry_reference);
+                    if (primitive_token.valid) {
+                        symbol_node.primitive_type = primitive_token.primitive_type;
+                        symbol_node.primitive_size_x = sym_geo.primitive_size_x_m;
+                        symbol_node.primitive_size_y = sym_geo.primitive_size_y_m;
+                        symbol_node.primitive_size_z = sym_geo.primitive_size_z_m;
+                    } else if (!sym_geo.geometry_reference.empty()) {
+                        symbol_node.asset_path =
+                            mvr_cache.ensure_mvr_model_extracted(sym_geo.geometry_reference);
                     }
-                    symbol_node.asset_kind = infer_asset_kind_from_path(symbol_node.asset_path);
+                    symbol_node.asset_kind =
+                        infer_asset_kind_from_path(symbol_node.asset_path, primitive_token);
                     scene.nodes.push_back(std::move(symbol_node));
                     ++appended_count;
                 }
@@ -542,9 +673,9 @@ void append_geometry_children(SceneModel &scene, tinyxml2::XMLElement *node, con
 
             // Compatibility fallback for exports that attach a direct model to
             // Symbol without an AUXData Symdef definition.
-            const std::string fallback_model =
-                normalize_geometry_file_name(parse_model_filename(symbol));
-            if (!fallback_model.empty()) {
+            const std::string fallback_model = parse_geometry_reference(symbol);
+            const PrimitiveToken primitive_token = parse_primitive_token(fallback_model);
+            if (!fallback_model.empty() || primitive_token.valid) {
                 SceneNode symbol_node;
                 symbol_node.node_id = prefix + "/symbol#" + std::to_string(serial++);
                 symbol_node.parent_id = parent_id;
@@ -553,8 +684,14 @@ void append_geometry_children(SceneModel &scene, tinyxml2::XMLElement *node, con
                 symbol_node.node_class = "model_part";
                 symbol_node.local_transform =
                     peraviz::coordinate_mapper::to_godot_transform(symbol_local);
-                symbol_node.asset_path = mvr_cache.ensure_mvr_model_extracted(fallback_model);
-                symbol_node.asset_kind = infer_asset_kind_from_path(symbol_node.asset_path);
+                if (primitive_token.valid) {
+                    symbol_node.primitive_type = primitive_token.primitive_type;
+                    fill_primitive_dimensions_from_node(symbol, symbol_node);
+                } else {
+                    symbol_node.asset_path = mvr_cache.ensure_mvr_model_extracted(fallback_model);
+                }
+                symbol_node.asset_kind =
+                    infer_asset_kind_from_path(symbol_node.asset_path, primitive_token);
                 scene.nodes.push_back(std::move(symbol_node));
                 ++appended_count;
             }
@@ -565,15 +702,18 @@ void append_geometry_children(SceneModel &scene, tinyxml2::XMLElement *node, con
     // wrapping them in Geometries.
     for (tinyxml2::XMLElement *child = node->FirstChildElement(); child;
          child = child->NextSiblingElement()) {
-        if (is_element_name(child, "geometry3d")) {
+        if (is_element_name(child, "geometry3d") || is_element_name(child, "cube") ||
+            is_element_name(child, "box") || is_element_name(child, "sphere") ||
+            is_element_name(child, "cone") || is_element_name(child, "cylinder")) {
             appended_count += append_single_geometry(scene, child, parent_id, parent_world,
                                                      mvr_cache, prefix, serial);
         }
     }
 
     if (appended_count == 0) {
-        const std::string direct_model = normalize_geometry_file_name(parse_model_filename(node));
-        if (!direct_model.empty()) {
+        const std::string direct_model = parse_geometry_reference(node);
+        const PrimitiveToken primitive_token = parse_primitive_token(direct_model);
+        if (!direct_model.empty() || primitive_token.valid) {
             SceneNode node_model;
             node_model.node_id = prefix + "/geometry#" + std::to_string(serial++);
             node_model.parent_id = parent_id;
@@ -582,8 +722,14 @@ void append_geometry_children(SceneModel &scene, tinyxml2::XMLElement *node, con
             node_model.node_class = "model_part";
             node_model.local_transform =
                 peraviz::coordinate_mapper::to_godot_transform(MatrixUtils::Identity());
-            node_model.asset_path = mvr_cache.ensure_mvr_model_extracted(direct_model);
-            node_model.asset_kind = infer_asset_kind_from_path(node_model.asset_path);
+            if (primitive_token.valid) {
+                node_model.primitive_type = primitive_token.primitive_type;
+                fill_primitive_dimensions_from_node(node, node_model);
+            } else {
+                node_model.asset_path = mvr_cache.ensure_mvr_model_extracted(direct_model);
+            }
+            node_model.asset_kind =
+                infer_asset_kind_from_path(node_model.asset_path, primitive_token);
             scene.nodes.push_back(std::move(node_model));
         }
     }

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -1129,6 +1129,14 @@ func _create_gdtf_primitive_mesh(data: Dictionary) -> Node3D:
 	var sx: float = max(float(data.get("primitive_size_x", 0.1)), 0.001)
 	var sy: float = max(float(data.get("primitive_size_y", 0.1)), 0.001)
 	var sz: float = max(float(data.get("primitive_size_z", 0.1)), 0.001)
+	var primitive_axis: String = ""
+	if primitive_type.ends_with("_x"):
+		primitive_axis = "x"
+	elif primitive_type.ends_with("_y"):
+		primitive_axis = "y"
+	elif primitive_type.ends_with("_z"):
+		primitive_axis = "z"
+
 	var mesh_instance := MeshInstance3D.new()
 	if primitive_type.contains("sphere"):
 		var sphere := SphereMesh.new()
@@ -1137,9 +1145,20 @@ func _create_gdtf_primitive_mesh(data: Dictionary) -> Node3D:
 		mesh_instance.mesh = sphere
 	elif primitive_type.contains("cylinder"):
 		var cylinder := CylinderMesh.new()
-		cylinder.top_radius = max(sx, sy) * 0.5
-		cylinder.bottom_radius = max(sx, sy) * 0.5
-		cylinder.height = sz
+		if primitive_axis == "x":
+			cylinder.top_radius = max(sy, sz) * 0.5
+			cylinder.bottom_radius = max(sy, sz) * 0.5
+			cylinder.height = sx
+			mesh_instance.rotation_degrees.z = -90.0
+		elif primitive_axis == "z":
+			cylinder.top_radius = max(sx, sy) * 0.5
+			cylinder.bottom_radius = max(sx, sy) * 0.5
+			cylinder.height = sz
+			mesh_instance.rotation_degrees.x = 90.0
+		else:
+			cylinder.top_radius = max(sx, sz) * 0.5
+			cylinder.bottom_radius = max(sx, sz) * 0.5
+			cylinder.height = sy
 		mesh_instance.mesh = cylinder
 	elif primitive_type.contains("cone"):
 		var cone := CylinderMesh.new()


### PR DESCRIPTION
### Motivation

- Bring the Peraviz MVR importer closer to Perastage behavior by resolving model references more flexibly and supporting primitive geometry tokens so scenes like `Demoshow_grandMA3.mvr` import correctly. 
- Prefer modern container formats that preserve materials (`.glb`/`.gltf`) when a model reference lacks an extension and perform case-insensitive ZIP lookups to match files inside MVR archives. 
- Treat `primitive:*` tokens and inline primitive tags as first-class geometry so placeholders are not left duplicated and primitives are sized/oriented correctly when instantiated.

### Description

- Update `ZipAssetCache::ensure_mvr_model_extracted` to try `.glb` then `.gltf` before `.3ds` for extension-less references, add `model_extension_priority(...)` to prefer GLB/GLTF during ZIP scanning, and keep case-insensitive normalized path lookup (`peraviz/native/src/asset_cache.cpp`).
- Extend MVR parsing to detect geometry references and primitive tokens by adding `parse_geometry_reference`, `parse_primitive_token`, `normalize_geometry_reference`, `fill_primitive_dimensions_from_node`, and related helpers, and propagate primitive metadata through SymDef expansion and symbol fallbacks (`peraviz/native/src/mvr_scene_loader.cpp`).
- Change asset-kind inference to return `asset_kind="primitive"` when a primitive token is present and avoid trying to extract files for primitives, while still extracting file-backed models when available (`peraviz/native/src/mvr_scene_loader.cpp`).
- Broaden accepted MVR geometry nodes to include inline primitive tags (`cube`, `box`, `sphere`, `cone`, `cylinder`) when scanning Geometries/SymDef and when scanning direct child nodes, preserving matrix composition when composing symbol transforms (`peraviz/native/src/mvr_scene_loader.cpp`).
- Fix runtime primitive instantiation to orient axis-suffixed cylinders (`_x`, `_y`, `_z`) correctly and preserve primitive sizing when creating Godot meshes (`peraviz/scripts/load_scene.gd`).
- Document the behavior changes in `docs/text_to_scene_rules.md` as required by the repo policy for scene-generation rules.

### Testing

- Ran `tests/check_perastage_tree_modules.sh` which passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de137138448324afeebb9a151792ad)