### PR TITLE
Improve Peraviz MVR/GDTF model resolution and primitive orientation (add .obj support)

### DIFF
--- a/peraviz/native/src/asset_cache.cpp
+++ b/peraviz/native/src/asset_cache.cpp
@@ -97,7 +97,23 @@ std::string path_extension_lower(const std::string &normalized_path) {
 
 bool is_supported_model_extension(const std::string &extension_lower) {
     return extension_lower == ".3ds" || extension_lower == ".glb" ||
-           extension_lower == ".gltf";
+           extension_lower == ".gltf" || extension_lower == ".obj";
+}
+
+int model_extension_priority(const std::string &extension_lower) {
+    if (extension_lower == ".glb") {
+        return 0;
+    }
+    if (extension_lower == ".gltf") {
+        return 1;
+    }
+    if (extension_lower == ".obj") {
+        return 2;
+    }
+    if (extension_lower == ".3ds") {
+        return 3;
+    }
+    return 100;
 }
 
 std::string gdtf_lookup_key(const std::string &archive_path) {
@@ -339,12 +355,14 @@ std::string ZipAssetCache::ensure_mvr_model_extracted(const std::string &model_r
         candidates.push_back(normalized);
         candidates.push_back("models/" + ext.substr(1) + "/" + stem + ext);
     } else {
-        candidates.push_back(normalized + ".3ds");
         candidates.push_back(normalized + ".glb");
         candidates.push_back(normalized + ".gltf");
-        candidates.push_back("models/3ds/" + stem + ".3ds");
+        candidates.push_back(normalized + ".obj");
         candidates.push_back("models/glb/" + stem + ".glb");
         candidates.push_back("models/gltf/" + stem + ".gltf");
+        candidates.push_back("models/obj/" + stem + ".obj");
+        candidates.push_back(normalized + ".3ds");
+        candidates.push_back("models/3ds/" + stem + ".3ds");
     }
 
     for (const std::string &candidate : candidates) {
@@ -373,9 +391,11 @@ std::string ZipAssetCache::ensure_mvr_model_extracted(const std::string &model_r
             continue;
         }
 
-        if (!best_entry.has_value() || entry_ext == ".3ds") {
+        if (!best_entry.has_value() ||
+            model_extension_priority(entry_ext) <
+                model_extension_priority(path_extension_lower(*best_entry))) {
             best_entry = entry_name;
-            if (entry_ext == ".3ds") {
+            if (entry_ext == ".glb") {
                 break;
             }
         }
@@ -406,10 +426,14 @@ std::string ZipAssetCache::ensure_gdtf_model_extracted(const std::string &model_
         candidates.push_back(normalized);
         candidates.push_back("models/" + ext.substr(1) + "/" + stem + ext);
     } else {
-        candidates.push_back(normalized + ".3ds");
         candidates.push_back(normalized + ".glb");
+        candidates.push_back(normalized + ".gltf");
+        candidates.push_back(normalized + ".obj");
         candidates.push_back("models/3ds/" + stem + ".3ds");
         candidates.push_back("models/glb/" + stem + ".glb");
+        candidates.push_back("models/gltf/" + stem + ".gltf");
+        candidates.push_back("models/obj/" + stem + ".obj");
+        candidates.push_back(normalized + ".3ds");
     }
 
     for (const std::string &candidate : candidates) {
@@ -435,14 +459,16 @@ std::string ZipAssetCache::ensure_gdtf_model_extracted(const std::string &model_
         }
 
         const std::string entry_ext = path_extension_lower(entry_name);
-        const bool supported = entry_ext == ".3ds" || entry_ext == ".glb";
+        const bool supported = is_supported_model_extension(entry_ext);
         if (!supported) {
             continue;
         }
 
-        if (!best_entry.has_value() || entry_ext == ".3ds") {
+        if (!best_entry.has_value() ||
+            model_extension_priority(entry_ext) <
+                model_extension_priority(path_extension_lower(*best_entry))) {
             best_entry = entry_name;
-            if (entry_ext == ".3ds") {
+            if (entry_ext == ".glb") {
                 break;
             }
         }

--- a/peraviz/native/src/gdtf_scene_builder.cpp
+++ b/peraviz/native/src/gdtf_scene_builder.cpp
@@ -72,7 +72,7 @@ std::string infer_asset_kind_from_path(const std::string &asset_path) {
     if (extension == ".3ds") {
         return "mesh";
     }
-    if (extension == ".glb" || extension == ".gltf") {
+    if (extension == ".glb" || extension == ".gltf" || extension == ".obj") {
         return "scene";
     }
     return "none";

--- a/peraviz/native/src/mvr_scene_loader.cpp
+++ b/peraviz/native/src/mvr_scene_loader.cpp
@@ -190,7 +190,7 @@ std::string infer_asset_kind_from_path(const std::string &asset_path) {
     if (extension == ".3ds") {
         return "mesh";
     }
-    if (extension == ".glb" || extension == ".gltf") {
+    if (extension == ".glb" || extension == ".gltf" || extension == ".obj") {
         return "scene";
     }
     return "none";

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -1013,7 +1013,7 @@ func _load_3d_asset(asset_path: String, asset_kind_hint: String = "", flip_orien
 		mesh_instance.set_meta("peraviz_flip_orientation_applied", flip_orientation)
 		return mesh_instance
 
-	if resolved_asset_kind == "scene" or extension == "glb" or extension == "gltf":
+	if resolved_asset_kind == "scene" or extension == "glb" or extension == "gltf" or extension == "obj":
 		var cached_scene_instance: Node3D = _asset_cache.instantiate_scene(asset_path)
 		if cached_scene_instance != null:
 			return cached_scene_instance
@@ -1065,7 +1065,7 @@ func _infer_asset_kind_from_extension(asset_path: String) -> String:
 	var extension: String = asset_path.get_extension().to_lower()
 	if extension == "3ds":
 		return "mesh"
-	if extension == "glb" or extension == "gltf":
+	if extension == "glb" or extension == "gltf" or extension == "obj":
 		return "scene"
 	return "none"
 
@@ -1129,24 +1129,33 @@ func _create_gdtf_primitive_mesh(data: Dictionary) -> Node3D:
 	var sx: float = max(float(data.get("primitive_size_x", 0.1)), 0.001)
 	var sy: float = max(float(data.get("primitive_size_y", 0.1)), 0.001)
 	var sz: float = max(float(data.get("primitive_size_z", 0.1)), 0.001)
+	var primitive_base: String = primitive_type
+	var separator_index: int = primitive_base.find(";")
+	if separator_index >= 0:
+		primitive_base = primitive_base.substr(0, separator_index)
+
 	var mesh_instance := MeshInstance3D.new()
-	if primitive_type.contains("sphere"):
+	if primitive_base.contains("sphere") or primitive_base.contains("head"):
 		var sphere := SphereMesh.new()
 		sphere.radius = max(sx, max(sy, sz)) * 0.5
 		sphere.height = sphere.radius * 2.0
 		mesh_instance.mesh = sphere
-	elif primitive_type.contains("cylinder"):
+	elif primitive_base.contains("cylinder") or primitive_base.contains("yoke") or primitive_base.contains("scanner") or primitive_base.contains("pigtail"):
 		var cylinder := CylinderMesh.new()
 		cylinder.top_radius = max(sx, sy) * 0.5
 		cylinder.bottom_radius = max(sx, sy) * 0.5
 		cylinder.height = sz
 		mesh_instance.mesh = cylinder
-	elif primitive_type.contains("cone"):
+		# GDTF primitives are defined with height on local Z (same convention used
+		# by Perastage primitive builders). Godot's CylinderMesh is Y-up.
+		mesh_instance.rotation_degrees.x = 90.0
+	elif primitive_base.contains("cone"):
 		var cone := CylinderMesh.new()
 		cone.top_radius = 0.0
 		cone.bottom_radius = max(sx, sy) * 0.5
 		cone.height = sz
 		mesh_instance.mesh = cone
+		mesh_instance.rotation_degrees.x = 90.0
 	else:
 		var box := BoxMesh.new()
 		box.size = Vector3(sx, sy, sz)


### PR DESCRIPTION
### Motivation
- Peraviz was often loading inferior `.3ds` payloads from MVR/GDTF packages and did not treat `.obj` as a first-class scene asset, causing missing textures/material fidelity compared to Perastage. 
- GDTF fixtures that rely on generated primitive geometry (cube/cylinder/cone) were using a mismatched axis convention, producing incorrect visual orientation when pan/tilt is applied.

### Description
- Prefer richer model formats when extracting from MVR/GDTF archives by adding a model extension priority and treating `.glb`/`.gltf` higher than `.obj` and `.3ds` in `peraviz/native/src/asset_cache.cpp`.
- Add `.obj` to supported model extensions and include `.obj` in candidate extraction paths and lookup fallbacks in `ZipAssetCache` (`ensure_mvr_model_extracted` / `ensure_gdtf_model_extracted`).
- Treat `.obj` as a `scene` asset in native loaders (`peraviz/native/src/mvr_scene_loader.cpp` and `peraviz/native/src/gdtf_scene_builder.cpp`) and in Godot loader logic (`peraviz/scripts/load_scene.gd`) so `.obj` payloads are loaded via the scene path instead of being ignored.
- Improve GDTF primitive handling in `peraviz/scripts/load_scene.gd` by normalizing primitive tokens (strip parameter suffix after `;`), recognizing common aliases (`head`, `yoke`, `scanner`, `pigtail`), and rotating generated `Cylinder`/`Cone` primitives so their height aligns with the local Z axis (matching GDTF/Perastage conventions) to fix fixture orientation under pan/tilt.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de16b601cc832489cede0b2511fd68)