### PR TITLE
Refactor DMX attribute mapping into descriptor tables and add native tests

### DIFF
--- a/peraviz/native/CMakeLists.txt
+++ b/peraviz/native/CMakeLists.txt
@@ -5,6 +5,7 @@ project(PeravizNative LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+include(CTest)
 
 set(GODOT_CPP_DIR "" CACHE PATH "Path to a local godot-cpp checkout")
 option(PERAVIZ_FETCH_GODOT_CPP "Fetch godot-cpp automatically when GODOT_CPP_DIR is not provided" ON)
@@ -119,6 +120,19 @@ target_link_libraries(peraviz_native PRIVATE
 set_target_properties(peraviz_native PROPERTIES
     OUTPUT_NAME "peraviz_native"
 )
+
+if(BUILD_TESTING)
+    add_executable(peraviz_native_dmx_tests
+        tests/gdtf_attribute_classifier_test.cpp
+        src/dmx/gdtf_attribute_classifier.cpp
+        src/dmx/gdtf_xml_reader.cpp
+    )
+    target_include_directories(peraviz_native_dmx_tests PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/src"
+    )
+    target_link_libraries(peraviz_native_dmx_tests PRIVATE tinyxml2::tinyxml2)
+    add_test(NAME peraviz_native_dmx_tests COMMAND peraviz_native_dmx_tests)
+endif()
 
 if(PERAVIZ_GODOT_PROJECT_DIR)
     set(_peraviz_bin_dir "${PERAVIZ_GODOT_PROJECT_DIR}/bin")

--- a/peraviz/native/src/dmx/gdtf_attribute_classifier.cpp
+++ b/peraviz/native/src/dmx/gdtf_attribute_classifier.cpp
@@ -5,6 +5,7 @@
 #include <array>
 #include <cctype>
 #include <cstdlib>
+#include <string_view>
 #include <sstream>
 
 namespace peraviz::dmx {
@@ -176,6 +177,84 @@ bool matches_gobo_rotation_attribute(const std::string &leaf) {
            leaf.find("rotate") != std::string::npos;
 }
 
+struct AttributeNameDescriptor {
+    AttributeRole role;
+    std::initializer_list<std::string_view> tokens;
+};
+
+bool match_descriptor_tokens(const std::string &leaf,
+                             const AttributeNameDescriptor &descriptor,
+                             int &out_byte_index) {
+    for (const std::string_view token : descriptor.tokens) {
+        int candidate_byte_index = 1;
+        if (starts_with_role_token(leaf, std::string(token), candidate_byte_index)) {
+            out_byte_index = candidate_byte_index;
+            return true;
+        }
+    }
+    return false;
+}
+
+const std::array<AttributeNameDescriptor, 7> &attribute_name_descriptors() {
+    static const std::array<AttributeNameDescriptor, 7> descriptors = {{
+        {AttributeRole::kDimmer, {"dimmer", "intensity"}},
+        {AttributeRole::kPan, {"pan"}},
+        {AttributeRole::kTilt, {"tilt"}},
+        {AttributeRole::kZoom, {"zoom", "digitalzoom"}},
+        {AttributeRole::kCyan, {"cyan",
+                                "coloradd_c",
+                                "coloradd_cyan",
+                                "coloradd_coarse",
+                                "colorsub_c",
+                                "colorsub_cyan",
+                                "colorsub_coarse",
+                                "colorrgb_c",
+                                "colorrgb_cyan"}},
+        {AttributeRole::kMagenta, {"magenta",
+                                   "coloradd_m",
+                                   "coloradd_magenta",
+                                   "colorsub_m",
+                                   "colorsub_magenta",
+                                   "colorrgb_m",
+                                   "colorrgb_magenta"}},
+        {AttributeRole::kYellow, {"yellow",
+                                  "coloradd_y",
+                                  "coloradd_yellow",
+                                  "colorsub_y",
+                                  "colorsub_yellow",
+                                  "colorrgb_y",
+                                  "colorrgb_yellow"}},
+    }};
+    return descriptors;
+}
+
+bool parse_standard_attribute(const std::string &leaf, ParsedAttribute &parsed) {
+    for (const AttributeNameDescriptor &descriptor : attribute_name_descriptors()) {
+        int byte_index = 1;
+        if (!match_descriptor_tokens(leaf, descriptor, byte_index)) {
+            continue;
+        }
+        parsed.role = descriptor.role;
+        parsed.byte_index = byte_index;
+        return true;
+    }
+    return false;
+}
+
+void parse_gobo_attribute(const std::string &leaf, ParsedAttribute &parsed) {
+    if (matches_gobo_rotation_attribute(leaf)) {
+        parsed.role = AttributeRole::kGoboRotation;
+    } else if (matches_gobo_index_attribute(leaf)) {
+        parsed.role = AttributeRole::kGoboIndex;
+    } else if (matches_gobo_attribute(leaf)) {
+        parsed.role = AttributeRole::kGobo;
+    } else {
+        return;
+    }
+    parsed.byte_index = 1;
+    parsed.gobo_wheel_number = parse_gobo_wheel_number(leaf);
+}
+
 } // namespace
 
 std::vector<int> parse_offsets(const char *raw_offset) {
@@ -218,62 +297,8 @@ ParsedAttribute parse_attribute_name(const std::string &raw_attribute) {
 
     const std::string leaf = last_attribute_segment(lower);
 
-    int byte_index = 1;
-    if (starts_with_role_token(leaf, "dimmer", byte_index) ||
-        starts_with_role_token(leaf, "intensity", byte_index)) {
-        parsed.role = AttributeRole::kDimmer;
-        parsed.byte_index = byte_index;
-    } else if (starts_with_role_token(leaf, "pan", byte_index)) {
-        parsed.role = AttributeRole::kPan;
-        parsed.byte_index = byte_index;
-    } else if (starts_with_role_token(leaf, "tilt", byte_index)) {
-        parsed.role = AttributeRole::kTilt;
-        parsed.byte_index = byte_index;
-    } else if (starts_with_role_token(leaf, "zoom", byte_index) ||
-               starts_with_role_token(leaf, "digitalzoom", byte_index)) {
-        parsed.role = AttributeRole::kZoom;
-        parsed.byte_index = byte_index;
-    } else if (starts_with_role_token(leaf, "cyan", byte_index) ||
-               starts_with_role_token(leaf, "coloradd_c", byte_index) ||
-               starts_with_role_token(leaf, "coloradd_cyan", byte_index) ||
-               starts_with_role_token(leaf, "coloradd_coarse", byte_index) ||
-               starts_with_role_token(leaf, "colorsub_c", byte_index) ||
-               starts_with_role_token(leaf, "colorsub_cyan", byte_index) ||
-               starts_with_role_token(leaf, "colorsub_coarse", byte_index) ||
-               starts_with_role_token(leaf, "colorrgb_c", byte_index) ||
-               starts_with_role_token(leaf, "colorrgb_cyan", byte_index)) {
-        parsed.role = AttributeRole::kCyan;
-        parsed.byte_index = byte_index;
-    } else if (starts_with_role_token(leaf, "magenta", byte_index) ||
-               starts_with_role_token(leaf, "coloradd_m", byte_index) ||
-               starts_with_role_token(leaf, "coloradd_magenta", byte_index) ||
-               starts_with_role_token(leaf, "colorsub_m", byte_index) ||
-               starts_with_role_token(leaf, "colorsub_magenta", byte_index) ||
-               starts_with_role_token(leaf, "colorrgb_m", byte_index) ||
-               starts_with_role_token(leaf, "colorrgb_magenta", byte_index)) {
-        parsed.role = AttributeRole::kMagenta;
-        parsed.byte_index = byte_index;
-    } else if (starts_with_role_token(leaf, "yellow", byte_index) ||
-               starts_with_role_token(leaf, "coloradd_y", byte_index) ||
-               starts_with_role_token(leaf, "coloradd_yellow", byte_index) ||
-               starts_with_role_token(leaf, "colorsub_y", byte_index) ||
-               starts_with_role_token(leaf, "colorsub_yellow", byte_index) ||
-               starts_with_role_token(leaf, "colorrgb_y", byte_index) ||
-               starts_with_role_token(leaf, "colorrgb_yellow", byte_index)) {
-        parsed.role = AttributeRole::kYellow;
-        parsed.byte_index = byte_index;
-    } else if (matches_gobo_rotation_attribute(leaf)) {
-        parsed.role = AttributeRole::kGoboRotation;
-        parsed.byte_index = byte_index;
-        parsed.gobo_wheel_number = parse_gobo_wheel_number(leaf);
-    } else if (matches_gobo_index_attribute(leaf)) {
-        parsed.role = AttributeRole::kGoboIndex;
-        parsed.byte_index = byte_index;
-        parsed.gobo_wheel_number = parse_gobo_wheel_number(leaf);
-    } else if (matches_gobo_attribute(leaf)) {
-        parsed.role = AttributeRole::kGobo;
-        parsed.byte_index = byte_index;
-        parsed.gobo_wheel_number = parse_gobo_wheel_number(leaf);
+    if (!parse_standard_attribute(leaf, parsed)) {
+        parse_gobo_attribute(leaf, parsed);
     }
 
     if (parsed.role == AttributeRole::kUnknown) {

--- a/peraviz/native/src/dmx/gdtf_control_offsets_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_control_offsets_resolver.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <array>
 #include <mutex>
 #include <unordered_map>
 #include <utility>
@@ -120,6 +121,195 @@ peraviz::dmx::FixtureGoboWheelOffset *find_or_create_gobo_wheel_offset(
     wheel.wheel_name = wheel_name;
     out_offsets.gobo_wheels.push_back(std::move(wheel));
     return &out_offsets.gobo_wheels.back();
+}
+
+struct OffsetWriteTarget {
+    int peraviz::dmx::FixtureControlOffsets::*coarse;
+    int peraviz::dmx::FixtureControlOffsets::*fine;
+    int peraviz::dmx::FixtureControlOffsets::*ultra_fine;
+};
+
+using PhysicalRangeConsumer = void (*)(tinyxml2::XMLElement *, peraviz::dmx::FixtureControlOffsets &);
+
+struct AttributeOffsetDescriptor {
+    peraviz::dmx::AttributeRole role;
+    OffsetWriteTarget target;
+    PhysicalRangeConsumer consume_physical_range = nullptr;
+};
+
+const std::array<AttributeOffsetDescriptor, 7> &attribute_offset_descriptors() {
+    static const std::array<AttributeOffsetDescriptor, 7> descriptors = {{
+        {peraviz::dmx::AttributeRole::kDimmer,
+         {&peraviz::dmx::FixtureControlOffsets::dimmer_coarse_offset_1_based,
+          &peraviz::dmx::FixtureControlOffsets::dimmer_fine_offset_1_based,
+          &peraviz::dmx::FixtureControlOffsets::dimmer_ultra_fine_offset_1_based}},
+        {peraviz::dmx::AttributeRole::kPan,
+         {&peraviz::dmx::FixtureControlOffsets::pan_coarse_offset_1_based,
+          &peraviz::dmx::FixtureControlOffsets::pan_fine_offset_1_based,
+          &peraviz::dmx::FixtureControlOffsets::pan_ultra_fine_offset_1_based}},
+        {peraviz::dmx::AttributeRole::kTilt,
+         {&peraviz::dmx::FixtureControlOffsets::tilt_coarse_offset_1_based,
+          &peraviz::dmx::FixtureControlOffsets::tilt_fine_offset_1_based,
+          &peraviz::dmx::FixtureControlOffsets::tilt_ultra_fine_offset_1_based}},
+        {peraviz::dmx::AttributeRole::kZoom,
+         {&peraviz::dmx::FixtureControlOffsets::zoom_coarse_offset_1_based,
+          &peraviz::dmx::FixtureControlOffsets::zoom_fine_offset_1_based,
+          &peraviz::dmx::FixtureControlOffsets::zoom_ultra_fine_offset_1_based},
+         &peraviz::dmx::consume_zoom_physical_range},
+        {peraviz::dmx::AttributeRole::kCyan,
+         {&peraviz::dmx::FixtureControlOffsets::cyan_coarse_offset_1_based,
+          &peraviz::dmx::FixtureControlOffsets::cyan_fine_offset_1_based,
+          &peraviz::dmx::FixtureControlOffsets::cyan_ultra_fine_offset_1_based}},
+        {peraviz::dmx::AttributeRole::kMagenta,
+         {&peraviz::dmx::FixtureControlOffsets::magenta_coarse_offset_1_based,
+          &peraviz::dmx::FixtureControlOffsets::magenta_fine_offset_1_based,
+          &peraviz::dmx::FixtureControlOffsets::magenta_ultra_fine_offset_1_based}},
+        {peraviz::dmx::AttributeRole::kYellow,
+         {&peraviz::dmx::FixtureControlOffsets::yellow_coarse_offset_1_based,
+          &peraviz::dmx::FixtureControlOffsets::yellow_fine_offset_1_based,
+          &peraviz::dmx::FixtureControlOffsets::yellow_ultra_fine_offset_1_based}},
+    }};
+    return descriptors;
+}
+
+bool apply_descriptor_offsets(const peraviz::dmx::ParsedAttribute &parsed_attribute,
+                              const std::vector<int> &offsets,
+                              tinyxml2::XMLElement *channel_function,
+                              peraviz::dmx::FixtureControlOffsets &out_offsets) {
+    for (const AttributeOffsetDescriptor &descriptor : attribute_offset_descriptors()) {
+        if (descriptor.role != parsed_attribute.role) {
+            continue;
+        }
+        consume_offsets(offsets, parsed_attribute.is_fine, parsed_attribute.byte_index,
+                        out_offsets.*(descriptor.target.coarse),
+                        out_offsets.*(descriptor.target.fine),
+                        out_offsets.*(descriptor.target.ultra_fine));
+        if (descriptor.consume_physical_range) {
+            descriptor.consume_physical_range(channel_function, out_offsets);
+        }
+        return true;
+    }
+    return false;
+}
+
+peraviz::dmx::FixtureGoboWheelOffset *resolve_gobo_wheel(peraviz::dmx::FixtureControlOffsets &out_offsets,
+                                                          const peraviz::dmx::ParsedAttribute &parsed_attribute,
+                                                          tinyxml2::XMLElement *channel_function) {
+    const std::string wheel_name =
+        peraviz::dmx::lower_ascii(peraviz::dmx::read_attr_ci(channel_function, "Wheel", "wheel"));
+    int wheel_number = parsed_attribute.gobo_wheel_number;
+    if (wheel_number <= 0) {
+        wheel_number = parse_last_number_token(wheel_name);
+    }
+    return find_or_create_gobo_wheel_offset(out_offsets, wheel_number, wheel_name);
+}
+
+void handle_gobo_attribute(const peraviz::dmx::ParsedAttribute &parsed_attribute,
+                           const std::vector<int> &offsets,
+                           tinyxml2::XMLElement *channel_function,
+                           const peraviz::dmx::GoboWheelCatalog &wheel_catalog,
+                           int function_dmx_from,
+                           int function_dmx_to,
+                           int function_mode_from,
+                           int function_mode_to,
+                           peraviz::dmx::FixtureControlOffsets &out_offsets) {
+    peraviz::dmx::FixtureGoboWheelOffset *wheel =
+        resolve_gobo_wheel(out_offsets, parsed_attribute, channel_function);
+    if (!wheel) {
+        return;
+    }
+    consume_offsets(offsets, parsed_attribute.is_fine, parsed_attribute.byte_index,
+                    wheel->coarse_offset_1_based,
+                    wheel->fine_offset_1_based,
+                    wheel->ultra_fine_offset_1_based);
+    peraviz::dmx::consume_gobo_channel_sets(channel_function, wheel_catalog, *wheel,
+                                            function_dmx_from, function_dmx_to,
+                                            function_mode_from, function_mode_to);
+}
+
+void handle_gobo_index_attribute(const peraviz::dmx::ParsedAttribute &parsed_attribute,
+                                 const std::vector<int> &offsets,
+                                 tinyxml2::XMLElement *channel_function,
+                                 peraviz::dmx::FixtureControlOffsets &out_offsets) {
+    peraviz::dmx::FixtureGoboWheelOffset *wheel =
+        resolve_gobo_wheel(out_offsets, parsed_attribute, channel_function);
+    if (!wheel) {
+        return;
+    }
+    wheel->supports_index = true;
+    consume_offsets(offsets, parsed_attribute.is_fine, parsed_attribute.byte_index,
+                    wheel->index_coarse_offset_1_based,
+                    wheel->index_fine_offset_1_based,
+                    wheel->index_ultra_fine_offset_1_based);
+    peraviz::dmx::consume_gobo_physical_range(channel_function,
+                                              wheel->has_index_physical_limits,
+                                              wheel->index_physical_min,
+                                              wheel->index_physical_max);
+}
+
+void handle_gobo_rotation_attribute(const peraviz::dmx::ParsedAttribute &parsed_attribute,
+                                    const std::vector<int> &offsets,
+                                    const char *attribute,
+                                    tinyxml2::XMLElement *channel_function,
+                                    int function_dmx_from,
+                                    int function_dmx_to,
+                                    int function_mode_from,
+                                    int function_mode_to,
+                                    peraviz::dmx::FixtureControlOffsets &out_offsets) {
+    peraviz::dmx::FixtureGoboWheelOffset *wheel =
+        resolve_gobo_wheel(out_offsets, parsed_attribute, channel_function);
+    if (!wheel) {
+        return;
+    }
+
+    wheel->supports_rotation = true;
+    int candidate_rotation_coarse = -1;
+    int candidate_rotation_fine = -1;
+    int candidate_rotation_ultra_fine = -1;
+    consume_offsets(offsets, parsed_attribute.is_fine, parsed_attribute.byte_index,
+                    candidate_rotation_coarse,
+                    candidate_rotation_fine,
+                    candidate_rotation_ultra_fine);
+
+    const std::string attribute_lower = peraviz::dmx::lower_ascii(peraviz::dmx::trim_ascii(attribute));
+    const bool has_mode_master =
+        channel_function->Attribute("ModeMaster") != nullptr ||
+        channel_function->Attribute("modemaster") != nullptr;
+    const bool prefers_position_rotation_channel =
+        attribute_lower.find("posrotate") != std::string::npos ||
+        attribute_lower.find("posrotation") != std::string::npos ||
+        (attribute_lower.find("gobo") != std::string::npos &&
+         attribute_lower.find("pos") != std::string::npos &&
+         attribute_lower.find("rotate") != std::string::npos);
+    int candidate_priority = 0;
+    if (has_mode_master && prefers_position_rotation_channel) {
+        candidate_priority = 3;
+    } else if (has_mode_master) {
+        candidate_priority = 2;
+    } else if (prefers_position_rotation_channel) {
+        candidate_priority = 1;
+    }
+
+    const bool has_valid_candidate_channel = candidate_rotation_coarse > 0;
+    const bool should_replace_rotation_channel =
+        has_valid_candidate_channel &&
+        (wheel->rotation_coarse_offset_1_based <= 0 ||
+         candidate_priority > wheel->rotation_channel_priority ||
+         (candidate_priority == wheel->rotation_channel_priority &&
+          candidate_rotation_coarse < wheel->rotation_coarse_offset_1_based));
+    if (should_replace_rotation_channel) {
+        wheel->rotation_coarse_offset_1_based = candidate_rotation_coarse;
+        wheel->rotation_fine_offset_1_based = candidate_rotation_fine;
+        wheel->rotation_ultra_fine_offset_1_based = candidate_rotation_ultra_fine;
+        wheel->rotation_channel_priority = candidate_priority;
+    }
+
+    peraviz::dmx::consume_gobo_rotation_channel_sets(channel_function,
+                                                     wheel->rotation_ranges,
+                                                     function_dmx_from,
+                                                     function_dmx_to,
+                                                     function_mode_from,
+                                                     function_mode_to);
 }
 
 void consume_channel_offsets(tinyxml2::XMLElement *dmx_channel,
@@ -237,159 +427,33 @@ void consume_channel_offsets(tinyxml2::XMLElement *dmx_channel,
             }
 
             const peraviz::dmx::ParsedAttribute parsed_attribute = peraviz::dmx::parse_attribute_name(attribute);
+            if (apply_descriptor_offsets(parsed_attribute, offsets, channel_function, out_offsets)) {
+                continue;
+            }
+
             switch (parsed_attribute.role) {
-            case peraviz::dmx::AttributeRole::kDimmer:
-                consume_offsets(offsets, parsed_attribute.is_fine, parsed_attribute.byte_index,
-                                out_offsets.dimmer_coarse_offset_1_based,
-                                out_offsets.dimmer_fine_offset_1_based,
-                                out_offsets.dimmer_ultra_fine_offset_1_based);
+            case peraviz::dmx::AttributeRole::kGobo:
+                handle_gobo_attribute(parsed_attribute, offsets, channel_function, wheel_catalog,
+                                      function_dmx_from, function_dmx_to, function_mode_from, function_mode_to,
+                                      out_offsets);
                 break;
-            case peraviz::dmx::AttributeRole::kPan:
-                consume_offsets(offsets, parsed_attribute.is_fine, parsed_attribute.byte_index,
-                                out_offsets.pan_coarse_offset_1_based,
-                                out_offsets.pan_fine_offset_1_based,
-                                out_offsets.pan_ultra_fine_offset_1_based);
+            case peraviz::dmx::AttributeRole::kGoboIndex:
+                handle_gobo_index_attribute(parsed_attribute, offsets, channel_function, out_offsets);
                 break;
-            case peraviz::dmx::AttributeRole::kTilt:
-                consume_offsets(offsets, parsed_attribute.is_fine, parsed_attribute.byte_index,
-                                out_offsets.tilt_coarse_offset_1_based,
-                                out_offsets.tilt_fine_offset_1_based,
-                                out_offsets.tilt_ultra_fine_offset_1_based);
+            case peraviz::dmx::AttributeRole::kGoboRotation:
+                handle_gobo_rotation_attribute(parsed_attribute, offsets, attribute, channel_function,
+                                               function_dmx_from, function_dmx_to,
+                                               function_mode_from, function_mode_to, out_offsets);
                 break;
             case peraviz::dmx::AttributeRole::kUnknown:
-                break;
+            case peraviz::dmx::AttributeRole::kDimmer:
+            case peraviz::dmx::AttributeRole::kPan:
+            case peraviz::dmx::AttributeRole::kTilt:
             case peraviz::dmx::AttributeRole::kZoom:
-                consume_offsets(offsets, parsed_attribute.is_fine, parsed_attribute.byte_index,
-                                out_offsets.zoom_coarse_offset_1_based,
-                                out_offsets.zoom_fine_offset_1_based,
-                                out_offsets.zoom_ultra_fine_offset_1_based);
-                peraviz::dmx::consume_zoom_physical_range(channel_function, out_offsets);
-                break;
             case peraviz::dmx::AttributeRole::kCyan:
-                consume_offsets(offsets, parsed_attribute.is_fine, parsed_attribute.byte_index,
-                                out_offsets.cyan_coarse_offset_1_based,
-                                out_offsets.cyan_fine_offset_1_based,
-                                out_offsets.cyan_ultra_fine_offset_1_based);
-                break;
             case peraviz::dmx::AttributeRole::kMagenta:
-                consume_offsets(offsets, parsed_attribute.is_fine, parsed_attribute.byte_index,
-                                out_offsets.magenta_coarse_offset_1_based,
-                                out_offsets.magenta_fine_offset_1_based,
-                                out_offsets.magenta_ultra_fine_offset_1_based);
-                break;
             case peraviz::dmx::AttributeRole::kYellow:
-                consume_offsets(offsets, parsed_attribute.is_fine, parsed_attribute.byte_index,
-                                out_offsets.yellow_coarse_offset_1_based,
-                                out_offsets.yellow_fine_offset_1_based,
-                                out_offsets.yellow_ultra_fine_offset_1_based);
                 break;
-            case peraviz::dmx::AttributeRole::kGobo: {
-                const std::string wheel_name =
-                    peraviz::dmx::lower_ascii(peraviz::dmx::read_attr_ci(channel_function, "Wheel", "wheel"));
-                int wheel_number = parsed_attribute.gobo_wheel_number;
-                if (wheel_number <= 0) {
-                    wheel_number = parse_last_number_token(wheel_name);
-                }
-                peraviz::dmx::FixtureGoboWheelOffset *wheel =
-                    find_or_create_gobo_wheel_offset(out_offsets, wheel_number, wheel_name);
-                if (!wheel) {
-                    break;
-                }
-                consume_offsets(offsets, parsed_attribute.is_fine, parsed_attribute.byte_index,
-                                wheel->coarse_offset_1_based,
-                                wheel->fine_offset_1_based,
-                                wheel->ultra_fine_offset_1_based);
-                peraviz::dmx::consume_gobo_channel_sets(channel_function, wheel_catalog, *wheel,
-                                                        function_dmx_from, function_dmx_to,
-                                                        function_mode_from, function_mode_to);
-                break;
-            }
-            case peraviz::dmx::AttributeRole::kGoboIndex: {
-                const std::string wheel_name =
-                    peraviz::dmx::lower_ascii(peraviz::dmx::read_attr_ci(channel_function, "Wheel", "wheel"));
-                int wheel_number = parsed_attribute.gobo_wheel_number;
-                if (wheel_number <= 0) {
-                    wheel_number = parse_last_number_token(wheel_name);
-                }
-                peraviz::dmx::FixtureGoboWheelOffset *wheel =
-                    find_or_create_gobo_wheel_offset(out_offsets, wheel_number, wheel_name);
-                if (!wheel) {
-                    break;
-                }
-                wheel->supports_index = true;
-                consume_offsets(offsets, parsed_attribute.is_fine, parsed_attribute.byte_index,
-                                wheel->index_coarse_offset_1_based,
-                                wheel->index_fine_offset_1_based,
-                                wheel->index_ultra_fine_offset_1_based);
-                peraviz::dmx::consume_gobo_physical_range(channel_function,
-                                                          wheel->has_index_physical_limits,
-                                                          wheel->index_physical_min,
-                                                          wheel->index_physical_max);
-                break;
-            }
-            case peraviz::dmx::AttributeRole::kGoboRotation: {
-                const std::string wheel_name =
-                    peraviz::dmx::lower_ascii(peraviz::dmx::read_attr_ci(channel_function, "Wheel", "wheel"));
-                int wheel_number = parsed_attribute.gobo_wheel_number;
-                if (wheel_number <= 0) {
-                    wheel_number = parse_last_number_token(wheel_name);
-                }
-                peraviz::dmx::FixtureGoboWheelOffset *wheel =
-                    find_or_create_gobo_wheel_offset(out_offsets, wheel_number, wheel_name);
-                if (!wheel) {
-                    break;
-                }
-
-                wheel->supports_rotation = true;
-                int candidate_rotation_coarse = -1;
-                int candidate_rotation_fine = -1;
-                int candidate_rotation_ultra_fine = -1;
-                consume_offsets(offsets, parsed_attribute.is_fine, parsed_attribute.byte_index,
-                                candidate_rotation_coarse,
-                                candidate_rotation_fine,
-                                candidate_rotation_ultra_fine);
-
-                const std::string attribute_lower = peraviz::dmx::lower_ascii(peraviz::dmx::trim_ascii(attribute));
-                const bool has_mode_master =
-                    channel_function->Attribute("ModeMaster") != nullptr ||
-                    channel_function->Attribute("modemaster") != nullptr;
-                const bool prefers_position_rotation_channel =
-                    attribute_lower.find("posrotate") != std::string::npos ||
-                    attribute_lower.find("posrotation") != std::string::npos ||
-                    (attribute_lower.find("gobo") != std::string::npos &&
-                     attribute_lower.find("pos") != std::string::npos &&
-                     attribute_lower.find("rotate") != std::string::npos);
-                int candidate_priority = 0;
-                if (has_mode_master && prefers_position_rotation_channel) {
-                    candidate_priority = 3;
-                } else if (has_mode_master) {
-                    candidate_priority = 2;
-                } else if (prefers_position_rotation_channel) {
-                    candidate_priority = 1;
-                }
-
-                const bool has_valid_candidate_channel = candidate_rotation_coarse > 0;
-                const bool should_replace_rotation_channel =
-                    has_valid_candidate_channel &&
-                    (wheel->rotation_coarse_offset_1_based <= 0 ||
-                     candidate_priority > wheel->rotation_channel_priority ||
-                     (candidate_priority == wheel->rotation_channel_priority &&
-                      candidate_rotation_coarse < wheel->rotation_coarse_offset_1_based));
-                if (should_replace_rotation_channel) {
-                    wheel->rotation_coarse_offset_1_based = candidate_rotation_coarse;
-                    wheel->rotation_fine_offset_1_based = candidate_rotation_fine;
-                    wheel->rotation_ultra_fine_offset_1_based = candidate_rotation_ultra_fine;
-                    wheel->rotation_channel_priority = candidate_priority;
-                }
-
-                peraviz::dmx::consume_gobo_rotation_channel_sets(channel_function,
-                                                                 wheel->rotation_ranges,
-                                                                 function_dmx_from,
-                                                                 function_dmx_to,
-                                                                 function_mode_from,
-                                                                 function_mode_to);
-                break;
-            }
             }
         }
     }

--- a/peraviz/native/tests/gdtf_attribute_classifier_test.cpp
+++ b/peraviz/native/tests/gdtf_attribute_classifier_test.cpp
@@ -1,0 +1,63 @@
+#include "dmx/gdtf_attribute_classifier.h"
+
+#include <iostream>
+#include <string>
+
+namespace {
+
+int fail(const std::string &message) {
+    std::cerr << message << std::endl;
+    return 1;
+}
+
+int expect_parsed(const std::string &attribute,
+                  peraviz::dmx::AttributeRole expected_role,
+                  bool expected_is_fine,
+                  int expected_byte_index,
+                  int expected_gobo_wheel_number) {
+    const peraviz::dmx::ParsedAttribute parsed = peraviz::dmx::parse_attribute_name(attribute);
+    if (parsed.role != expected_role) {
+        return fail("Unexpected role for '" + attribute + "'");
+    }
+    if (parsed.is_fine != expected_is_fine) {
+        return fail("Unexpected fine flag for '" + attribute + "'");
+    }
+    if (parsed.byte_index != expected_byte_index) {
+        return fail("Unexpected byte index for '" + attribute + "'");
+    }
+    if (parsed.gobo_wheel_number != expected_gobo_wheel_number) {
+        return fail("Unexpected gobo wheel number for '" + attribute + "'");
+    }
+    return 0;
+}
+
+} // namespace
+
+int main() {
+    if (const int rc = expect_parsed("pan", peraviz::dmx::AttributeRole::kPan, false, 1, 0); rc != 0) {
+        return rc;
+    }
+    if (const int rc = expect_parsed("tilt", peraviz::dmx::AttributeRole::kTilt, false, 1, 0); rc != 0) {
+        return rc;
+    }
+    if (const int rc = expect_parsed("zoom", peraviz::dmx::AttributeRole::kZoom, false, 1, 0); rc != 0) {
+        return rc;
+    }
+    if (const int rc = expect_parsed("coloradd_cyan", peraviz::dmx::AttributeRole::kCyan, false, 1, 0); rc != 0) {
+        return rc;
+    }
+    if (const int rc = expect_parsed("panfine", peraviz::dmx::AttributeRole::kPan, true, 1, 0); rc != 0) {
+        return rc;
+    }
+    if (const int rc = expect_parsed("gobo1posrotate", peraviz::dmx::AttributeRole::kGoboRotation, false, 1, 1); rc != 0) {
+        return rc;
+    }
+    if (const int rc = expect_parsed("gobo2index", peraviz::dmx::AttributeRole::kGoboIndex, false, 1, 2); rc != 0) {
+        return rc;
+    }
+    if (const int rc = expect_parsed("gobo1", peraviz::dmx::AttributeRole::kGobo, false, 1, 1); rc != 0) {
+        return rc;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
### Motivation

- Replace a long `if/else` + `switch` mapping with data-driven descriptor tables to make attribute -> offsets resolution clearer and easier to extend. 
- Keep gobo-specific semantics isolated so special-case logic remains readable and maintainable. 
- Provide small native unit tests exercising representative attribute name parsing to catch regressions early. 

### Description

- Introduced `AttributeNameDescriptor` and a descriptor table in `peraviz/native/src/dmx/gdtf_attribute_classifier.cpp` and replaced the large `starts_with_role_token` cascade with `parse_standard_attribute` and `parse_gobo_attribute` helpers. 
- Added `AttributeOffsetDescriptor`, `OffsetWriteTarget` and `apply_descriptor_offsets` to `peraviz/native/src/dmx/gdtf_control_offsets_resolver.cpp` and removed the big role-to-offset `switch` for standard attributes. 
- Kept gobo-related behavior in dedicated handlers: `handle_gobo_attribute`, `handle_gobo_index_attribute` and `handle_gobo_rotation_attribute` to preserve their special processing. 
- Added a native unit test `tests/gdtf_attribute_classifier_test.cpp` and a CTest target `peraviz_native_dmx_tests` in `peraviz/native/CMakeLists.txt` to run the parser checks on `pan`, `tilt`, `zoom`, `coloradd_cyan`, `gobo1posrotate`, `gobo2index`, etc. 

### Testing

- Ran `tests/check_perastage_tree_modules.sh`, which succeeded. 
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which succeeded. 
- Attempted to configure native tests with CMake (`-DBUILD_TESTING=ON`) but configuration failed in this environment due to a missing/invalid `GODOT_CPP_DIR` bootstrap path. 
- Attempted direct compilation of the test binary with `g++` but it failed here because `tinyxml2.h` is not available in the container include paths; the CTest target is present and should run in a normal dev/build environment with dependencies available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df61650ca08324b6163b7930e4a8d0)