### PR TITLE
Refactor Peraviz scene loading into dedicated services

### DIFF
--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -121,7 +121,6 @@ var _beam_renderers: Dictionary = {}
 var _active_beam_renderer: BeamRendererBase
 var _active_beam_mode: int = -1
 
-
 const DmxMonitorWindowScript = preload("res://scripts/dmx_monitor_window.gd")
 const DmxFixtureRuntimeScript = preload("res://scripts/dmx_fixture_runtime.gd")
 
@@ -130,6 +129,16 @@ const LegacyConeBeamRendererScript = preload("res://scripts/beam_renderers/legac
 const VolumetricBeamRendererScript = preload("res://scripts/beam_renderers/volumetric_beam_renderer.gd")
 const FixtureGoboProjectorScript = preload("res://scripts/fixture_gobo_projector.gd")
 const BeamOpticsControllerScript = preload("res://scripts/beam_optics_controller.gd")
+
+const SceneImportServiceScript = preload("res://scripts/scene_loading/scene_import_service.gd")
+const NodeFactoryScript = preload("res://scripts/scene_loading/node_factory.gd")
+const FixtureBindingServiceScript = preload("res://scripts/scene_loading/fixture_binding_service.gd")
+const DebugOverlayServiceScript = preload("res://scripts/scene_loading/debug_overlay_service.gd")
+
+var _scene_import_service := SceneImportServiceScript.new()
+var _node_factory := NodeFactoryScript.new()
+var _fixture_binding_service := FixtureBindingServiceScript.new()
+var _debug_overlay_service := DebugOverlayServiceScript.new()
 
 const DEBUG_TOGGLE_KEY: Key = KEY_C
 const MANUAL_TEST_FLAG: String = "--peraviz_manual_fixture_test"
@@ -469,33 +478,29 @@ func _on_load_pressed() -> void:
 
 func _on_file_selected(path: String) -> void:
 	_clear_scene()
-	var native_path: String = ProjectSettings.globalize_path(path)
-	var peraviz_debug_baseline: bool = bool(ProjectSettings.get_setting("peraviz_debug_baseline", false))
-	var nodes: Array = _loader.load_mvr(native_path, peraviz_debug_baseline, _debug_coords_enabled)
-	print("[Peraviz] Loaded render nodes: ", nodes.size(), " baseline_debug=", peraviz_debug_baseline, " coords_debug=", _debug_coords_enabled)
-	_has_loaded_bounds = false
-	_clear_debug_gizmos()
-
-	_build_node_tree(nodes)
-	_register_fixture_registry(nodes)
-	_refresh_dmx_fixture_bindings()
-	_populate_fixture_list()
-	_sync_selection_state("scene_reload")
-	_rebuild_debug_gizmos()
-	_focus_loaded_scene()
-	if _debug_asset_cache_enabled:
-		var cache_summary: Dictionary = _asset_cache.debug_summary()
-		var hit_by_kind: Dictionary = cache_summary.get("hits_by_kind", {})
-		var miss_by_kind: Dictionary = cache_summary.get("misses_by_kind", {})
-		print("[PeravizAssetCache] summary hits=", cache_summary.get("hits", 0),
-			" misses=", cache_summary.get("misses", 0),
-			" unique=", cache_summary.get("unique_resources", 0),
-			" mesh(hit/miss)=", hit_by_kind.get("mesh", 0), "/", miss_by_kind.get("mesh", 0),
-			" scene(hit/miss)=", hit_by_kind.get("scene", 0), "/", miss_by_kind.get("scene", 0),
-			" material(hit/miss)=", hit_by_kind.get("material", 0), "/", miss_by_kind.get("material", 0))
-	status_label.text = "Nodes: %d (press F to focus, C debug coords)" % nodes.size()
-	_update_debug_legend()
-	_refresh_emitter_light_scalars()
+	_scene_import_service.import_scene(
+		path,
+		_loader,
+		_node_factory,
+		_fixture_binding_service,
+		status_label,
+		_asset_cache,
+		proxies_root,
+		_node_index,
+		Callable(self, "_refresh_dmx_fixture_bindings"),
+		Callable(self, "_populate_fixture_list"),
+		Callable(self, "_sync_selection_state"),
+		Callable(self, "_rebuild_debug_gizmos"),
+		Callable(self, "_focus_loaded_scene"),
+		Callable(self, "_update_debug_legend"),
+		Callable(self, "_refresh_emitter_light_scalars"),
+		Callable(self, "_extract_emitter_photometrics"),
+		Callable(self, "_rebuild_loaded_bounds"),
+		Callable(self, "_set_has_loaded_bounds"),
+		_debug_coords_enabled,
+		_debug_asset_cache_enabled,
+		_scene_registry
+	)
 
 func _on_manual_fixture_toggle(enabled: bool) -> void:
 	_manual_fixture_test_enabled = enabled
@@ -533,38 +538,13 @@ func _unhandled_input(event: InputEvent) -> void:
 
 
 func _ensure_debug_gizmo_root() -> void:
-	if _debug_gizmos_root != null and is_instance_valid(_debug_gizmos_root):
-		return
-	_debug_gizmos_root = Node3D.new()
-	_debug_gizmos_root.name = "DebugGizmos"
-	_debug_gizmos_root.top_level = true
-	add_child(_debug_gizmos_root)
+	_debug_overlay_service.ensure_debug_gizmo_root(self)
 
 func _clear_debug_gizmos() -> void:
-	_ensure_debug_gizmo_root()
-	for child in _debug_gizmos_root.get_children():
-		child.queue_free()
+	_debug_overlay_service.clear_debug_gizmos(self)
 
 func _rebuild_debug_gizmos() -> void:
-	_clear_debug_gizmos()
-	if not _debug_coords_enabled:
-		return
-
-	_add_debug_gizmo_for_target(proxies_root, "scene_root", Color(1.0, 0.25, 1.0), 0.75)
-	for node in _node_index.values():
-		if node is not Node3D:
-			continue
-		var node3d: Node3D = node
-		var metadata_type: String = str(node3d.get_meta("peraviz_type", ""))
-		var is_axis: bool = bool(node3d.get_meta("peraviz_is_axis", false))
-		var is_emitter: bool = bool(node3d.get_meta("peraviz_is_emitter", false))
-
-		if metadata_type in ["fixture", "truss", "support", "scene_object"]:
-			_add_debug_gizmo_for_target(node3d, "mvr_instance_root", Color(1.0, 0.9, 0.2), 0.55)
-		if is_axis:
-			_add_debug_gizmo_for_target(node3d, "gdtf_axis", Color(0.0, 1.0, 1.0), 0.35)
-		if is_emitter:
-			_add_debug_gizmo_for_target(node3d, "emitter", Color(1.0, 0.55, 0.15), 0.30)
+	_debug_overlay_service.rebuild_debug_gizmos(self, _debug_coords_enabled, proxies_root, _node_index)
 
 
 func _is_basis_valid(candidate_basis: Basis) -> bool:
@@ -686,36 +666,10 @@ func _create_axes_gizmo_node(origin_color: Color, length: float) -> Node3D:
 	return container
 
 func _update_debug_legend() -> void:
-	if not _debug_coords_enabled:
-		print("[PeravizCoordDebugLegend] disabled (press C to enable)")
-		return
-
-	print("[PeravizCoordDebugLegend] X=Red Y=Green Z=Blue scene_root_origin=Magenta mvr_instance_root_origin=Yellow gdtf_axis_origin=Cyan emitter_origin=Orange beam_expected_local=-Y")
+	_debug_overlay_service.print_debug_legend(_debug_coords_enabled)
 
 func _build_node_tree(nodes: Array) -> void:
-	_node_index.clear()
-	for item in nodes:
-		if item is Dictionary:
-			var node_id: String = str(item.get("node_id", ""))
-			if node_id.is_empty():
-				continue
-			_node_index[node_id] = _create_scene_node(item)
-
-	for item in nodes:
-		if item is Dictionary:
-			var node_id: String = str(item.get("node_id", ""))
-			var parent_id: String = str(item.get("parent_id", ""))
-			var node: Node3D = _node_index.get(node_id)
-			if node == null:
-				continue
-			var parent_node: Node3D = proxies_root
-			if not parent_id.is_empty() and _node_index.has(parent_id):
-				parent_node = _node_index[parent_id]
-			parent_node.add_child(node)
-
-	_apply_mesh_orientation_corrections(proxies_root, false)
-	_remove_redundant_dummy_meshes(proxies_root)
-	_rebuild_loaded_bounds()
+	_node_factory.build_node_tree(nodes, proxies_root, _node_index, Callable(self, "_rebuild_loaded_bounds"), _loader, _asset_cache)
 
 func _apply_mesh_orientation_corrections(node: Node3D, inherited_flip: bool) -> void:
 	if node == null:
@@ -800,6 +754,9 @@ func _node_has_real_visual_descendants(root: Node, ignored_nodes: Array[Node]) -
 
 	return false
 
+func _set_has_loaded_bounds(value: bool) -> void:
+	_has_loaded_bounds = value
+
 func _rebuild_loaded_bounds() -> void:
 	_has_loaded_bounds = false
 	for child in proxies_root.get_children():
@@ -807,53 +764,7 @@ func _rebuild_loaded_bounds() -> void:
 			_expand_loaded_bounds_from_node(child)
 
 func _create_scene_node(data: Dictionary) -> Node3D:
-	var item_type: String = str(data.get("type", "scene_object"))
-	var item_class: String = _extract_node_class(data, item_type)
-	var is_fixture: bool = bool(data.get("is_fixture", false))
-	var is_axis: bool = bool(data.get("is_axis", false))
-	var is_emitter: bool = bool(data.get("is_emitter", false))
-	var is_lens: bool = bool(data.get("is_lens", false))
-	var node_name: String = str(data.get("name", item_type))
-	var flip_orientation: bool = false
-
-	var root := Node3D.new()
-	root.name = "%s_%s" % [item_class, node_name]
-	root.set_meta("peraviz_type", item_type)
-	root.set_meta("peraviz_is_axis", is_axis)
-	root.set_meta("peraviz_is_emitter", is_emitter)
-	root.set_meta("peraviz_is_lens", is_lens)
-	var node_position: Vector3 = _safe_position(data.get("pos", Vector3.ZERO), "create_scene_node:" + root.name)
-	if bool(data.get("has_basis", false)):
-		var node_basis: Basis = _safe_basis_from_data(data)
-		if not _is_basis_valid(node_basis):
-			print("[PeravizCoordDebug] event=basis_invalid_fallback node=", root.name)
-			node_basis = Basis.IDENTITY
-		flip_orientation = node_basis.determinant() < 0.0
-		root.transform = Transform3D(node_basis, node_position)
-	else:
-		root.position = node_position
-		root.rotation_degrees = data.get("rot", Vector3.ZERO)
-		root.scale = _safe_scale_from_data(data, "create_scene_node_euler:" + root.name)
-		flip_orientation = root.transform.basis.determinant() < 0.0
-
-	if is_axis:
-		var pivot := Node3D.new()
-		pivot.name = "AxisPivot"
-		root.add_child(pivot)
-
-	if is_emitter:
-		var emitter := Node3D.new()
-		emitter.name = "EmitterMarker"
-		root.add_child(emitter)
-
-	var visual_scale_hint: float = _extract_visual_scale_hint(data)
-	var model_node: Node3D = _build_visual_node(data, item_type, item_class, is_fixture, visual_scale_hint, flip_orientation)
-	if model_node != null:
-		root.add_child(model_node)
-		if item_type == "fixture_geometry":
-			_reparent_fixture_visual_children(root, model_node)
-
-	return root
+	return _node_factory.create_scene_node(data, _loader, _asset_cache)
 
 func _reparent_fixture_visual_children(geometry_node: Node3D, model_root: Node3D) -> void:
 	if geometry_node == null or model_root == null:
@@ -1226,94 +1137,22 @@ func _classify_gdtf_primitive_shape(primitive_type: String) -> String:
 	return "box"
 
 func _clear_scene() -> void:
-	_scene_registry.clear("scene_reload")
-	_clear_selected_fixture("scene_clear")
-	for child in proxies_root.get_children():
-		child.queue_free()
-	_node_index.clear()
-	_asset_cache.clear()
-	_fixture_emissive_cache.clear()
-	_fixture_emitter_light_cache.clear()
-	_fixture_emitter_photometrics.clear()
-	if _fixture_gobo_projector != null:
-		_fixture_gobo_projector.clear_cache()
-	_has_loaded_bounds = false
-	_clear_debug_gizmos()
+	_scene_import_service.clear_scene(
+		_scene_registry,
+		proxies_root,
+		_node_index,
+		_asset_cache,
+		_fixture_emissive_cache,
+		_fixture_emitter_light_cache,
+		_fixture_emitter_photometrics,
+		_fixture_gobo_projector,
+		Callable(self, "_clear_selected_fixture"),
+		Callable(self, "_clear_debug_gizmos"),
+		Callable(self, "_set_has_loaded_bounds")
+	)
 
 func _register_fixture_registry(nodes: Array) -> void:
-	if nodes.is_empty():
-		return
-
-	var parent_lookup: Dictionary = {}
-	var type_lookup: Dictionary = {}
-	for item in nodes:
-		if item is not Dictionary:
-			continue
-		var node_id: String = str(item.get("node_id", ""))
-		if node_id.is_empty():
-			continue
-		parent_lookup[node_id] = str(item.get("parent_id", ""))
-		type_lookup[node_id] = str(item.get("type", ""))
-
-	var fixture_anchors: Dictionary = {}
-	for node_id in type_lookup.keys():
-		if str(type_lookup.get(node_id, "")) != "fixture":
-			continue
-		fixture_anchors[node_id] = {
-			"axis": [],
-			"emitters": [],
-			"lens": [],
-			"geometry_nodes": [],
-		}
-
-	for item in nodes:
-		if item is not Dictionary:
-			continue
-		var node_id: String = str(item.get("node_id", ""))
-		if node_id.is_empty():
-			continue
-
-		var fixture_uuid: String = _resolve_fixture_uuid(node_id, parent_lookup, type_lookup, {})
-		if fixture_uuid.is_empty() or not fixture_anchors.has(fixture_uuid):
-			continue
-
-		if node_id == fixture_uuid:
-			continue
-
-		var node: Node3D = _node_index.get(node_id)
-		if node == null:
-			continue
-
-		var anchors: Dictionary = fixture_anchors[fixture_uuid]
-		if bool(item.get("is_axis", false)):
-			var axis_nodes: Array = anchors.get("axis", [])
-			axis_nodes.append(node)
-			anchors["axis"] = axis_nodes
-		if bool(item.get("is_emitter", false)):
-			var emitter_nodes: Array = anchors.get("emitters", [])
-			emitter_nodes.append(node)
-			anchors["emitters"] = emitter_nodes
-		if str(item.get("type", "")) == "fixture_geometry":
-			var geometry_nodes: Array = anchors.get("geometry_nodes", [])
-			geometry_nodes.append(node)
-			anchors["geometry_nodes"] = geometry_nodes
-			if bool(item.get("is_lens", false)):
-				var lens_nodes: Array = anchors.get("lens", [])
-				lens_nodes.append(node)
-				anchors["lens"] = lens_nodes
-			if bool(item.get("is_emitter", false)):
-				var photometric_entries: Array = anchors.get("emitter_photometrics", [])
-				photometric_entries.append(_extract_emitter_photometrics(item))
-				anchors["emitter_photometrics"] = photometric_entries
-
-	for fixture_uuid in fixture_anchors.keys():
-		var fixture_node: Node3D = _node_index.get(fixture_uuid)
-		if fixture_node == null:
-			print("[PeravizSceneRegistry] register_fixture skipped: fixture node missing uuid=", fixture_uuid)
-			continue
-		var anchors: Dictionary = fixture_anchors[fixture_uuid]
-		_scene_registry.register_fixture(fixture_uuid, fixture_node, anchors)
-		_attach_fixture_pick_colliders(fixture_uuid, fixture_node)
+	_fixture_binding_service.register_fixture_registry(nodes, _node_index, _scene_registry, Callable(self, "_extract_emitter_photometrics"))
 
 func _read_manual_fixture_test_setting() -> bool:
 	var setting_enabled: bool = bool(ProjectSettings.get_setting("peraviz_manual_fixture_test", false))
@@ -1364,19 +1203,10 @@ func _try_select_fixture_from_mouse(mouse_position: Vector2) -> void:
 	_select_fixture_by_uuid(fixture_uuid, "raycast")
 
 func _resolve_fixture_uuid_from_node(node: Node) -> String:
-	var current: Node = node
-	while current != null:
-		if current.has_meta("peraviz_fixture_uuid"):
-			return str(current.get_meta("peraviz_fixture_uuid", ""))
-		current = current.get_parent()
-	return ""
+	return _fixture_binding_service.resolve_fixture_uuid_from_node(node)
 
 func _attach_fixture_pick_colliders(fixture_uuid: String, fixture_node: Node3D) -> void:
-	if fixture_node == null:
-		return
-	fixture_node.set_meta("peraviz_fixture_uuid", fixture_uuid)
-	for child in fixture_node.get_children():
-		_attach_fixture_pick_colliders_recursive(fixture_uuid, child)
+	_fixture_binding_service.attach_fixture_pick_colliders(fixture_uuid, fixture_node)
 
 func _attach_fixture_pick_colliders_recursive(fixture_uuid: String, node: Node) -> void:
 	if node is MeshInstance3D:

--- a/peraviz/scripts/scene_loading/debug_overlay_service.gd
+++ b/peraviz/scripts/scene_loading/debug_overlay_service.gd
@@ -1,0 +1,120 @@
+extends RefCounted
+class_name DebugOverlayService
+
+func ensure_debug_gizmo_root(owner: Node3D) -> Node3D:
+	var existing: Variant = owner.get("_debug_gizmos_root")
+	if existing != null and is_instance_valid(existing):
+		return existing
+	var root := Node3D.new()
+	root.name = "DebugGizmos"
+	root.top_level = true
+	owner.add_child(root)
+	owner.set("_debug_gizmos_root", root)
+	return root
+
+func clear_debug_gizmos(owner: Node3D) -> void:
+	var root: Node3D = ensure_debug_gizmo_root(owner)
+	for child in root.get_children():
+		child.queue_free()
+
+func rebuild_debug_gizmos(owner: Node3D, debug_enabled: bool, proxies_root: Node3D, node_index: Dictionary) -> void:
+	clear_debug_gizmos(owner)
+	if not debug_enabled:
+		return
+
+	_add_debug_gizmo_for_target(owner, proxies_root, "scene_root", Color(1.0, 0.25, 1.0), 0.75)
+	for node in node_index.values():
+		if node is not Node3D:
+			continue
+		var node3d: Node3D = node
+		var metadata_type: String = str(node3d.get_meta("peraviz_type", ""))
+		var is_axis: bool = bool(node3d.get_meta("peraviz_is_axis", false))
+		var is_emitter: bool = bool(node3d.get_meta("peraviz_is_emitter", false))
+
+		if metadata_type in ["fixture", "truss", "support", "scene_object"]:
+			_add_debug_gizmo_for_target(owner, node3d, "mvr_instance_root", Color(1.0, 0.9, 0.2), 0.55)
+		if is_axis:
+			_add_debug_gizmo_for_target(owner, node3d, "gdtf_axis", Color(0.0, 1.0, 1.0), 0.35)
+		if is_emitter:
+			_add_debug_gizmo_for_target(owner, node3d, "emitter", Color(1.0, 0.55, 0.15), 0.30)
+
+func print_debug_legend(debug_enabled: bool) -> void:
+	if not debug_enabled:
+		print("[PeravizCoordDebugLegend] disabled (press C to enable)")
+		return
+	print("[PeravizCoordDebugLegend] X=Red Y=Green Z=Blue scene_root_origin=Magenta mvr_instance_root_origin=Yellow gdtf_axis_origin=Cyan emitter_origin=Orange beam_expected_local=-Y")
+
+func _safe_target_global_position(target: Node3D) -> Vector3:
+	if target == null:
+		return Vector3.ZERO
+	var origin: Vector3 = target.global_position
+	if not is_finite(origin.x) or not is_finite(origin.y) or not is_finite(origin.z):
+		print("[PeravizCoordDebug] event=invalid_target_origin_fallback node=", target.name, " origin=", origin)
+		return Vector3.ZERO
+	return origin
+
+func _add_debug_gizmo_for_target(owner: Node3D, target: Node3D, kind: String, origin_color: Color, length: float) -> void:
+	if target == null:
+		return
+	var root: Node3D = ensure_debug_gizmo_root(owner)
+	var holder := Node3D.new()
+	holder.name = "Gizmo_%s" % kind
+	root.add_child(holder)
+	holder.global_transform = Transform3D(target.global_basis, _safe_target_global_position(target))
+	holder.add_child(_create_axes_gizmo_node(origin_color, length))
+	if kind == "emitter":
+		holder.add_child(_create_emitter_direction_gizmo(length))
+
+func _create_emitter_direction_gizmo(length: float) -> MeshInstance3D:
+	var immediate := ImmediateMesh.new()
+	var beam_material := ORMMaterial3D.new()
+	beam_material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
+	beam_material.albedo_color = Color(1.0, 0.55, 0.15)
+	beam_material.emission_enabled = true
+	beam_material.emission = Color(1.0, 0.55, 0.15)
+	beam_material.emission_energy_multiplier = 2.0
+	immediate.surface_begin(Mesh.PRIMITIVE_LINES, beam_material)
+	immediate.surface_add_vertex(Vector3.ZERO)
+	immediate.surface_add_vertex(Vector3.DOWN * (length * 1.8))
+	immediate.surface_end()
+
+	var beam := MeshInstance3D.new()
+	beam.mesh = immediate
+	beam.material_override = beam_material
+	return beam
+
+func _create_axes_gizmo_node(origin_color: Color, length: float) -> Node3D:
+	var immediate := ImmediateMesh.new()
+	var line_material := ORMMaterial3D.new()
+	line_material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
+	line_material.vertex_color_use_as_albedo = true
+	immediate.surface_begin(Mesh.PRIMITIVE_LINES, line_material)
+	immediate.surface_set_color(Color(1, 0, 0))
+	immediate.surface_add_vertex(Vector3.ZERO)
+	immediate.surface_add_vertex(Vector3.RIGHT * length)
+	immediate.surface_set_color(Color(0, 1, 0))
+	immediate.surface_add_vertex(Vector3.ZERO)
+	immediate.surface_add_vertex(Vector3.UP * length)
+	immediate.surface_set_color(Color(0, 0.4, 1))
+	immediate.surface_add_vertex(Vector3.ZERO)
+	immediate.surface_add_vertex(Vector3.BACK * length)
+	immediate.surface_end()
+
+	var axes_instance := MeshInstance3D.new()
+	axes_instance.mesh = immediate
+	axes_instance.material_override = line_material
+
+	var marker := SphereMesh.new()
+	marker.radius = max(length * 0.08, 0.01)
+	marker.height = marker.radius * 2.0
+	var marker_material := StandardMaterial3D.new()
+	marker_material.albedo_color = origin_color
+	marker_material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
+	var marker_instance := MeshInstance3D.new()
+	marker_instance.mesh = marker
+	marker_instance.material_override = marker_material
+
+	var container := Node3D.new()
+	container.add_child(axes_instance)
+	container.add_child(marker_instance)
+	return container

--- a/peraviz/scripts/scene_loading/fixture_binding_service.gd
+++ b/peraviz/scripts/scene_loading/fixture_binding_service.gd
@@ -1,0 +1,132 @@
+extends RefCounted
+class_name FixtureBindingService
+
+func register_fixture_registry(nodes: Array, node_index: Dictionary, scene_registry: SceneRegistry, extract_emitter_photometrics: Callable) -> void:
+	if nodes.is_empty():
+		return
+
+	var parent_lookup: Dictionary = {}
+	var type_lookup: Dictionary = {}
+	for item in nodes:
+		if item is not Dictionary:
+			continue
+		var node_id: String = str(item.get("node_id", ""))
+		if node_id.is_empty():
+			continue
+		parent_lookup[node_id] = str(item.get("parent_id", ""))
+		type_lookup[node_id] = str(item.get("type", ""))
+
+	var fixture_anchors: Dictionary = {}
+	for node_id in type_lookup.keys():
+		if str(type_lookup.get(node_id, "")) != "fixture":
+			continue
+		fixture_anchors[node_id] = {
+			"axis": [],
+			"emitters": [],
+			"lens": [],
+			"geometry_nodes": [],
+		}
+
+	for item in nodes:
+		if item is not Dictionary:
+			continue
+		var node_id: String = str(item.get("node_id", ""))
+		if node_id.is_empty():
+			continue
+
+		var fixture_uuid: String = resolve_fixture_uuid(node_id, parent_lookup, type_lookup, {})
+		if fixture_uuid.is_empty() or not fixture_anchors.has(fixture_uuid):
+			continue
+		if node_id == fixture_uuid:
+			continue
+
+		var node: Node3D = node_index.get(node_id)
+		if node == null:
+			continue
+
+		var anchors: Dictionary = fixture_anchors[fixture_uuid]
+		if bool(item.get("is_axis", false)):
+			var axis_nodes: Array = anchors.get("axis", [])
+			axis_nodes.append(node)
+			anchors["axis"] = axis_nodes
+		if bool(item.get("is_emitter", false)):
+			var emitter_nodes: Array = anchors.get("emitters", [])
+			emitter_nodes.append(node)
+			anchors["emitters"] = emitter_nodes
+		if str(item.get("type", "")) == "fixture_geometry":
+			var geometry_nodes: Array = anchors.get("geometry_nodes", [])
+			geometry_nodes.append(node)
+			anchors["geometry_nodes"] = geometry_nodes
+			if bool(item.get("is_lens", false)):
+				var lens_nodes: Array = anchors.get("lens", [])
+				lens_nodes.append(node)
+				anchors["lens"] = lens_nodes
+			if bool(item.get("is_emitter", false)):
+				var photometric_entries: Array = anchors.get("emitter_photometrics", [])
+				photometric_entries.append(extract_emitter_photometrics.call(item))
+				anchors["emitter_photometrics"] = photometric_entries
+
+	for fixture_uuid in fixture_anchors.keys():
+		var fixture_node: Node3D = node_index.get(fixture_uuid)
+		if fixture_node == null:
+			print("[PeravizSceneRegistry] register_fixture skipped: fixture node missing uuid=", fixture_uuid)
+			continue
+		var anchors: Dictionary = fixture_anchors[fixture_uuid]
+		scene_registry.register_fixture(fixture_uuid, fixture_node, anchors)
+		attach_fixture_pick_colliders(fixture_uuid, fixture_node)
+
+func resolve_fixture_uuid(node_id: String, parent_lookup: Dictionary, type_lookup: Dictionary, cache: Dictionary) -> String:
+	if cache.has(node_id):
+		return str(cache[node_id])
+
+	var current_id: String = node_id
+	while not current_id.is_empty():
+		if str(type_lookup.get(current_id, "")) == "fixture":
+			cache[node_id] = current_id
+			return current_id
+		current_id = str(parent_lookup.get(current_id, ""))
+
+	cache[node_id] = ""
+	return ""
+
+func resolve_fixture_uuid_from_node(node: Node) -> String:
+	var current: Node = node
+	while current != null:
+		if current.has_meta("peraviz_fixture_uuid"):
+			return str(current.get_meta("peraviz_fixture_uuid", ""))
+		current = current.get_parent()
+	return ""
+
+func attach_fixture_pick_colliders(fixture_uuid: String, fixture_node: Node3D) -> void:
+	if fixture_node == null:
+		return
+	fixture_node.set_meta("peraviz_fixture_uuid", fixture_uuid)
+	for child in fixture_node.get_children():
+		_attach_fixture_pick_colliders_recursive(fixture_uuid, child)
+
+func _attach_fixture_pick_colliders_recursive(fixture_uuid: String, node: Node) -> void:
+	if node is MeshInstance3D:
+		_attach_pick_collider_to_mesh(node as MeshInstance3D, fixture_uuid)
+	if node is Node:
+		node.set_meta("peraviz_fixture_uuid", fixture_uuid)
+	for child in node.get_children():
+		_attach_fixture_pick_colliders_recursive(fixture_uuid, child)
+
+func _attach_pick_collider_to_mesh(mesh_instance: MeshInstance3D, fixture_uuid: String) -> void:
+	if mesh_instance == null or mesh_instance.mesh == null:
+		return
+	var mesh_bounds: AABB = mesh_instance.get_aabb()
+	if mesh_bounds.size == Vector3.ZERO:
+		return
+
+	var static_body := StaticBody3D.new()
+	static_body.name = "FixturePickBody"
+	static_body.set_meta("peraviz_fixture_uuid", fixture_uuid)
+	mesh_instance.add_child(static_body)
+
+	var shape := BoxShape3D.new()
+	shape.size = mesh_bounds.size
+	var collision := CollisionShape3D.new()
+	collision.shape = shape
+	collision.position = mesh_bounds.get_center()
+	static_body.add_child(collision)

--- a/peraviz/scripts/scene_loading/node_factory.gd
+++ b/peraviz/scripts/scene_loading/node_factory.gd
@@ -1,0 +1,524 @@
+extends RefCounted
+class_name NodeFactory
+
+func build_node_tree(nodes: Array, proxies_root: Node3D, node_index: Dictionary, rebuild_loaded_bounds: Callable, loader: PeravizLoader, asset_cache: PeravizRuntimeAssetCache) -> void:
+	node_index.clear()
+	for item in nodes:
+		if item is Dictionary:
+			var node_id: String = str(item.get("node_id", ""))
+			if node_id.is_empty():
+				continue
+			node_index[node_id] = create_scene_node(item, loader, asset_cache)
+
+	for item in nodes:
+		if item is Dictionary:
+			var node_id: String = str(item.get("node_id", ""))
+			var parent_id: String = str(item.get("parent_id", ""))
+			var node: Node3D = node_index.get(node_id)
+			if node == null:
+				continue
+			var parent_node: Node3D = proxies_root
+			if not parent_id.is_empty() and node_index.has(parent_id):
+				parent_node = node_index[parent_id]
+			parent_node.add_child(node)
+
+	_apply_mesh_orientation_corrections(proxies_root, false, loader, asset_cache)
+	_remove_redundant_dummy_meshes(proxies_root)
+	rebuild_loaded_bounds.call()
+
+func create_scene_node(data: Dictionary, loader: PeravizLoader, asset_cache: PeravizRuntimeAssetCache) -> Node3D:
+	var item_type: String = str(data.get("type", "scene_object"))
+	var item_class: String = _extract_node_class(data, item_type)
+	var is_fixture: bool = bool(data.get("is_fixture", false))
+	var is_axis: bool = bool(data.get("is_axis", false))
+	var is_emitter: bool = bool(data.get("is_emitter", false))
+	var is_lens: bool = bool(data.get("is_lens", false))
+	var node_name: String = str(data.get("name", item_type))
+	var flip_orientation: bool = false
+
+	var root := Node3D.new()
+	root.name = "%s_%s" % [item_class, node_name]
+	root.set_meta("peraviz_type", item_type)
+	root.set_meta("peraviz_is_axis", is_axis)
+	root.set_meta("peraviz_is_emitter", is_emitter)
+	root.set_meta("peraviz_is_lens", is_lens)
+	var node_position: Vector3 = _safe_position(data.get("pos", Vector3.ZERO), "create_scene_node:" + root.name)
+	if bool(data.get("has_basis", false)):
+		var node_basis: Basis = _safe_basis_from_data(data)
+		if not _is_basis_valid(node_basis):
+			print("[PeravizCoordDebug] event=basis_invalid_fallback node=", root.name)
+			node_basis = Basis.IDENTITY
+		flip_orientation = node_basis.determinant() < 0.0
+		root.transform = Transform3D(node_basis, node_position)
+	else:
+		root.position = node_position
+		root.rotation_degrees = data.get("rot", Vector3.ZERO)
+		root.scale = _safe_scale_from_data(data, "create_scene_node_euler:" + root.name)
+		flip_orientation = root.transform.basis.determinant() < 0.0
+
+	if is_axis:
+		var pivot := Node3D.new()
+		pivot.name = "AxisPivot"
+		root.add_child(pivot)
+
+	if is_emitter:
+		var emitter := Node3D.new()
+		emitter.name = "EmitterMarker"
+		root.add_child(emitter)
+
+	var visual_scale_hint: float = _extract_visual_scale_hint(data)
+	var model_node: Node3D = _build_visual_node(data, item_type, item_class, is_fixture, visual_scale_hint, loader, asset_cache, flip_orientation)
+	if model_node != null:
+		root.add_child(model_node)
+		if item_type == "fixture_geometry":
+			_reparent_fixture_visual_children(root, model_node)
+
+	return root
+
+func _is_basis_valid(candidate_basis: Basis) -> bool:
+	var determinant: float = candidate_basis.determinant()
+	if is_zero_approx(determinant):
+		return false
+	return is_finite(determinant)
+
+func _safe_basis_from_data(data: Dictionary) -> Basis:
+	var basis_x: Vector3 = data.get("basis_x", Vector3.RIGHT)
+	var basis_y: Vector3 = data.get("basis_y", Vector3.UP)
+	var basis_z: Vector3 = data.get("basis_z", Vector3.BACK)
+	var candidate_basis := Basis(basis_x, basis_y, basis_z)
+	if _is_basis_valid(candidate_basis):
+		return candidate_basis
+
+	print("[PeravizCoordDebug] event=invalid_basis_fallback basis_x=", basis_x, " basis_y=", basis_y, " basis_z=", basis_z)
+	return Basis.IDENTITY
+
+func _safe_position(value: Vector3, context: String) -> Vector3:
+	if is_finite(value.x) and is_finite(value.y) and is_finite(value.z):
+		return value
+	print("[PeravizCoordDebug] event=invalid_position_fallback context=", context, " pos=", value)
+	return Vector3.ZERO
+
+func _safe_scale_from_data(data: Dictionary, context: String) -> Vector3:
+	var raw_scale: Vector3 = data.get("scale", Vector3.ONE)
+	if not is_finite(raw_scale.x) or not is_finite(raw_scale.y) or not is_finite(raw_scale.z):
+		print("[PeravizCoordDebug] event=invalid_scale_fallback context=", context, " scale=", raw_scale)
+		return Vector3.ONE
+
+	var min_axis: float = 0.0001
+	var sx: float = raw_scale.x
+	var sy: float = raw_scale.y
+	var sz: float = raw_scale.z
+	if is_zero_approx(sx):
+		sx = min_axis
+	if is_zero_approx(sy):
+		sy = min_axis
+	if is_zero_approx(sz):
+		sz = min_axis
+
+	if not is_equal_approx(sx, raw_scale.x) or not is_equal_approx(sy, raw_scale.y) or not is_equal_approx(sz, raw_scale.z):
+		print("[PeravizCoordDebug] event=zero_scale_sanitized context=", context, " raw_scale=", raw_scale, " sanitized_scale=", Vector3(sx, sy, sz))
+	return Vector3(sx, sy, sz)
+
+func _apply_mesh_orientation_corrections(node: Node3D, inherited_flip: bool, loader: PeravizLoader, asset_cache: PeravizRuntimeAssetCache) -> void:
+	if node == null:
+		return
+
+	var node_flip: bool = node.transform.basis.determinant() < 0.0
+	var global_flip: bool = inherited_flip != node_flip
+	if node is MeshInstance3D:
+		_rebuild_mesh_instance_for_orientation(node as MeshInstance3D, global_flip, loader, asset_cache)
+
+	for child in node.get_children():
+		if child is Node3D:
+			_apply_mesh_orientation_corrections(child as Node3D, global_flip, loader, asset_cache)
+
+func _rebuild_mesh_instance_for_orientation(mesh_instance: MeshInstance3D, flip_orientation: bool, loader: PeravizLoader, asset_cache: PeravizRuntimeAssetCache) -> void:
+	if mesh_instance == null:
+		return
+	if not mesh_instance.has_meta("peraviz_asset_path"):
+		return
+	var asset_path: String = str(mesh_instance.get_meta("peraviz_asset_path", ""))
+	if asset_path.is_empty():
+		return
+
+	var mesh_cache_key: String = asset_path
+	if flip_orientation:
+		mesh_cache_key = "%s#flipped" % asset_path
+
+	var cached_mesh: Mesh = asset_cache.get_mesh(mesh_cache_key)
+	if cached_mesh == null:
+		var mesh_data: Dictionary = loader.load_3ds_mesh_data(asset_path)
+		if not bool(mesh_data.get("ok", false)):
+			return
+		var rebuilt_mesh: ArrayMesh = _build_3ds_mesh(mesh_data, flip_orientation)
+		if rebuilt_mesh == null:
+			return
+		asset_cache.store_mesh(mesh_cache_key, rebuilt_mesh)
+		cached_mesh = rebuilt_mesh
+
+	mesh_instance.mesh = cached_mesh
+	mesh_instance.set_meta("peraviz_flip_orientation_applied", flip_orientation)
+
+func _remove_redundant_dummy_meshes(root: Node) -> void:
+	if root == null:
+		return
+	for child in root.get_children():
+		_remove_redundant_dummy_meshes(child)
+	if root is not Node3D:
+		return
+	var root_node: Node3D = root
+	var placeholders_to_remove: Array[Node] = []
+	for child in root_node.get_children():
+		if child is MeshInstance3D and bool(child.get_meta("peraviz_dummy_placeholder", false)):
+			placeholders_to_remove.push_back(child)
+	if placeholders_to_remove.is_empty():
+		return
+	if not _node_has_real_visual_descendants(root_node, placeholders_to_remove):
+		return
+	for placeholder in placeholders_to_remove:
+		placeholder.queue_free()
+
+func _node_has_real_visual_descendants(root: Node, ignored_nodes: Array[Node]) -> bool:
+	if root is MeshInstance3D:
+		if not bool(root.get_meta("peraviz_dummy_placeholder", false)):
+			return true
+	elif root is MultiMeshInstance3D:
+		return true
+	for child in root.get_children():
+		if ignored_nodes.has(child):
+			continue
+		if _node_has_real_visual_descendants(child, ignored_nodes):
+			return true
+	return false
+
+func _reparent_fixture_visual_children(geometry_node: Node3D, model_root: Node3D) -> void:
+	if geometry_node == null or model_root == null:
+		return
+	if model_root is MeshInstance3D:
+		return
+	var model_root_local: Transform3D = model_root.transform
+	var moved_any_child: bool = false
+	for child in model_root.get_children():
+		if child is not Node3D:
+			continue
+		var child_node: Node3D = child
+		var child_local_before: Transform3D = child_node.transform
+		var child_local_after: Transform3D = model_root_local * child_local_before
+		model_root.remove_child(child_node)
+		child_node.owner = null
+		geometry_node.add_child(child_node)
+		child_node.transform = child_local_after
+		moved_any_child = true
+	if moved_any_child:
+		model_root.queue_free()
+
+func _build_visual_node(data: Dictionary, item_type: String, item_class: String, is_fixture: bool, visual_scale_hint: float, loader: PeravizLoader, asset_cache: PeravizRuntimeAssetCache, flip_orientation: bool = false) -> Node3D:
+	var asset_path: String = str(data.get("asset_path", ""))
+	var asset_kind: String = _extract_asset_kind(data, asset_path)
+	if not asset_path.is_empty():
+		var loaded: Variant = _load_3d_asset(asset_path, loader, asset_cache, asset_kind, flip_orientation)
+		if loaded is Node3D:
+			var loaded_node: Node3D = loaded
+			_force_double_sided_materials(loaded_node)
+			return loaded_node
+		print("[Peraviz] Asset fallback for missing/invalid model: ", asset_path, " type=", item_type, " class=", item_class, " asset_kind=", asset_kind)
+
+	if item_type == "fixture" or item_type == "fixture_geometry":
+		if asset_kind == "primitive":
+			var primitive_mesh: Node3D = _create_gdtf_primitive_mesh(data)
+			_force_double_sided_materials(primitive_mesh)
+			return primitive_mesh
+		return null
+
+	var dummy_mesh: Node3D = _create_dummy_mesh(is_fixture, visual_scale_hint, asset_cache)
+	_force_double_sided_materials(dummy_mesh)
+	return dummy_mesh
+
+func _force_double_sided_materials(root: Node) -> void:
+	if root == null:
+		return
+	if root is MeshInstance3D:
+		_apply_double_sided_to_mesh_instance(root as MeshInstance3D)
+	elif root is MultiMeshInstance3D:
+		_apply_double_sided_to_multimesh_instance(root as MultiMeshInstance3D)
+	for child in root.get_children():
+		_force_double_sided_materials(child)
+
+func _apply_double_sided_to_mesh_instance(mesh_instance: MeshInstance3D) -> void:
+	if mesh_instance == null:
+		return
+	if mesh_instance.material_override != null:
+		mesh_instance.material_override = _duplicate_as_double_sided(mesh_instance.material_override)
+	_apply_double_sided_to_mesh_surfaces(mesh_instance, mesh_instance.mesh)
+
+func _apply_double_sided_to_multimesh_instance(multimesh_instance: MultiMeshInstance3D) -> void:
+	if multimesh_instance == null:
+		return
+	if multimesh_instance.material_override != null:
+		multimesh_instance.material_override = _duplicate_as_double_sided(multimesh_instance.material_override)
+	var mesh: Mesh = multimesh_instance.multimesh.mesh if multimesh_instance.multimesh != null else null
+	_apply_double_sided_to_mesh_surfaces(multimesh_instance, mesh)
+
+func _apply_double_sided_to_mesh_surfaces(geometry_instance: GeometryInstance3D, mesh: Mesh) -> void:
+	if geometry_instance == null or mesh == null:
+		return
+	var surface_count: int = mesh.get_surface_count()
+	for surface_index in range(surface_count):
+		var override_material: Material = geometry_instance.get_surface_override_material(surface_index)
+		if override_material != null:
+			geometry_instance.set_surface_override_material(surface_index, _duplicate_as_double_sided(override_material))
+			continue
+		var surface_material: Material = mesh.surface_get_material(surface_index)
+		if surface_material != null:
+			geometry_instance.set_surface_override_material(surface_index, _duplicate_as_double_sided(surface_material))
+		else:
+			geometry_instance.set_surface_override_material(surface_index, _create_default_double_sided_material())
+
+func _duplicate_as_double_sided(material: Material) -> Material:
+	if material is not BaseMaterial3D:
+		return material
+	var base_material: BaseMaterial3D = material as BaseMaterial3D
+	if base_material.cull_mode == BaseMaterial3D.CULL_DISABLED:
+		return material
+	var duplicated_material: BaseMaterial3D = base_material.duplicate(true)
+	duplicated_material.cull_mode = BaseMaterial3D.CULL_DISABLED
+	return duplicated_material
+
+func _create_default_double_sided_material() -> StandardMaterial3D:
+	var material := StandardMaterial3D.new()
+	material.cull_mode = BaseMaterial3D.CULL_DISABLED
+	return material
+
+func _extract_visual_scale_hint(data: Dictionary) -> float:
+	if bool(data.get("has_basis", false)):
+		var basis_x: Vector3 = data.get("basis_x", Vector3.RIGHT)
+		var basis_y: Vector3 = data.get("basis_y", Vector3.UP)
+		var basis_z: Vector3 = data.get("basis_z", Vector3.BACK)
+		var average_basis_length: float = (basis_x.length() + basis_y.length() + basis_z.length()) / 3.0
+		return max(average_basis_length, 0.0001)
+	var node_scale: Vector3 = data.get("scale", Vector3.ONE)
+	var average_scale: float = (abs(node_scale.x) + abs(node_scale.y) + abs(node_scale.z)) / 3.0
+	if not is_finite(average_scale):
+		return 1.0
+	return max(average_scale, 0.0001)
+
+func _load_3d_asset(asset_path: String, loader: PeravizLoader, asset_cache: PeravizRuntimeAssetCache, asset_kind_hint: String = "", flip_orientation: bool = false) -> Variant:
+	var resolved_asset_kind: String = asset_kind_hint.to_lower()
+	if resolved_asset_kind.is_empty() or resolved_asset_kind == "none":
+		resolved_asset_kind = _infer_asset_kind_from_extension(asset_path)
+	var extension: String = asset_path.get_extension().to_lower()
+	if resolved_asset_kind == "mesh" or extension == "3ds":
+		var mesh_cache_key: String = asset_path
+		if flip_orientation:
+			mesh_cache_key = "%s#flipped" % asset_path
+		var cached_mesh: Mesh = asset_cache.get_mesh(mesh_cache_key)
+		if cached_mesh != null:
+			var cached_mesh_instance := MeshInstance3D.new()
+			cached_mesh_instance.mesh = cached_mesh
+			cached_mesh_instance.set_meta("peraviz_asset_path", asset_path)
+			cached_mesh_instance.set_meta("peraviz_asset_kind", "mesh")
+			cached_mesh_instance.set_meta("peraviz_flip_orientation_applied", flip_orientation)
+			return cached_mesh_instance
+		var mesh_data: Dictionary = loader.load_3ds_mesh_data(asset_path)
+		if not bool(mesh_data.get("ok", false)):
+			asset_cache.mark_failed(asset_path)
+			return null
+		var mesh: ArrayMesh = _build_3ds_mesh(mesh_data, flip_orientation)
+		if mesh == null:
+			asset_cache.mark_failed(asset_path)
+			return null
+		asset_cache.store_mesh(mesh_cache_key, mesh)
+		var mesh_instance := MeshInstance3D.new()
+		mesh_instance.mesh = mesh
+		mesh_instance.set_meta("peraviz_asset_path", asset_path)
+		mesh_instance.set_meta("peraviz_asset_kind", "mesh")
+		mesh_instance.set_meta("peraviz_flip_orientation_applied", flip_orientation)
+		return mesh_instance
+	if resolved_asset_kind == "scene" or extension == "glb" or extension == "gltf":
+		var cached_scene_instance: Node3D = asset_cache.instantiate_scene(asset_path)
+		if cached_scene_instance != null:
+			return cached_scene_instance
+		var gltf := GLTFDocument.new()
+		var state := GLTFState.new()
+		var err: int = gltf.append_from_file(asset_path, state)
+		if err != OK:
+			asset_cache.mark_failed(asset_path)
+			return null
+		var generated: Node = gltf.generate_scene(state)
+		if generated is Node3D:
+			var packed_scene := PackedScene.new()
+			if packed_scene.pack(generated) == OK:
+				asset_cache.store_scene(asset_path, packed_scene)
+				generated.free()
+				return asset_cache.instantiate_scene(asset_path)
+		if generated != null:
+			generated.free()
+		asset_cache.mark_failed(asset_path)
+		return null
+	var scene_instance: Node3D = asset_cache.instantiate_scene(asset_path)
+	if scene_instance != null:
+		return scene_instance
+	var resource: Resource = load(asset_path)
+	if resource is PackedScene:
+		asset_cache.store_scene(asset_path, resource)
+		return asset_cache.instantiate_scene(asset_path)
+	asset_cache.mark_failed(asset_path)
+	return null
+
+func _extract_node_class(data: Dictionary, item_type: String) -> String:
+	var node_class: String = str(data.get("class", ""))
+	if node_class.is_empty():
+		node_class = item_type
+	return node_class
+
+func _extract_asset_kind(data: Dictionary, asset_path: String) -> String:
+	var kind: String = str(data.get("asset_kind", "")).to_lower()
+	if kind.is_empty() or kind == "none":
+		kind = _infer_asset_kind_from_extension(asset_path)
+	return kind
+
+func _infer_asset_kind_from_extension(asset_path: String) -> String:
+	var extension: String = asset_path.get_extension().to_lower()
+	if extension == "3ds":
+		return "mesh"
+	if extension == "glb" or extension == "gltf" or extension == "obj" or extension == "dae" or extension == "fbx" or extension == "stl":
+		return "scene"
+	return "none"
+
+func _build_3ds_mesh(mesh_data: Dictionary, flip_orientation: bool = false) -> ArrayMesh:
+	var vertices: PackedVector3Array = mesh_data.get("vertices", PackedVector3Array())
+	var normals: PackedVector3Array = mesh_data.get("normals", PackedVector3Array())
+	var texcoords: PackedVector2Array = mesh_data.get("texcoords", PackedVector2Array())
+	var indices: PackedInt32Array = mesh_data.get("indices", PackedInt32Array())
+	var texture_path: String = str(mesh_data.get("texture_path", ""))
+	var has_material_base_color: bool = bool(mesh_data.get("has_material_base_color", false))
+	var material_base_color_vec: Vector3 = mesh_data.get("material_base_color", Vector3.ONE)
+	var material_base_color: Color = Color(material_base_color_vec.x, material_base_color_vec.y, material_base_color_vec.z, 1.0)
+	if vertices.is_empty() or indices.is_empty():
+		return null
+	if flip_orientation:
+		if (indices.size() % 3) != 0:
+			push_warning("[Peraviz] 3DS mesh index count is not divisible by 3; skipping orientation flip.")
+		else:
+			for i in range(0, indices.size(), 3):
+				var tmp: int = indices[i + 1]
+				indices[i + 1] = indices[i + 2]
+				indices[i + 2] = tmp
+	var arrays: Array = []
+	arrays.resize(Mesh.ARRAY_MAX)
+	arrays[Mesh.ARRAY_VERTEX] = vertices
+	arrays[Mesh.ARRAY_NORMAL] = normals
+	if texcoords.size() == vertices.size():
+		arrays[Mesh.ARRAY_TEX_UV] = texcoords
+	arrays[Mesh.ARRAY_INDEX] = indices
+	var array_mesh := ArrayMesh.new()
+	array_mesh.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, arrays)
+	if not texture_path.is_empty() and texcoords.size() == vertices.size():
+		var image := Image.new()
+		var image_error: Error = image.load(texture_path)
+		if image_error == OK:
+			if image.get_format() != Image.FORMAT_RGBA8:
+				image.convert(Image.FORMAT_RGBA8)
+			var texture: ImageTexture = ImageTexture.create_from_image(image)
+			var material := StandardMaterial3D.new()
+			material.albedo_color = Color(1.0, 1.0, 1.0, 1.0)
+			material.albedo_texture = texture
+			material.cull_mode = BaseMaterial3D.CULL_DISABLED
+			array_mesh.surface_set_material(0, material)
+		else:
+			push_warning("[Peraviz] Failed to load 3DS texture image: %s (error=%d)" % [texture_path, image_error])
+	elif has_material_base_color:
+		var base_color_material := StandardMaterial3D.new()
+		base_color_material.albedo_color = material_base_color
+		base_color_material.cull_mode = BaseMaterial3D.CULL_DISABLED
+		array_mesh.surface_set_material(0, base_color_material)
+	else:
+		var textured_fallback_material := StandardMaterial3D.new()
+		textured_fallback_material.albedo_color = Color(0.2, 0.2, 0.2, 1.0)
+		textured_fallback_material.cull_mode = BaseMaterial3D.CULL_DISABLED
+		array_mesh.surface_set_material(0, textured_fallback_material)
+	return array_mesh
+
+func _create_dummy_mesh(is_fixture: bool, visual_scale_hint: float, asset_cache: PeravizRuntimeAssetCache) -> Node3D:
+	var mesh_instance := MeshInstance3D.new()
+	mesh_instance.set_meta("peraviz_dummy_placeholder", true)
+	var world_target_size: float = 0.35
+	var normalized_scale: float = max(visual_scale_hint, 0.0001)
+	var local_size_multiplier: float = world_target_size / normalized_scale
+	if is_fixture:
+		var cone := CylinderMesh.new()
+		cone.top_radius = 0.0
+		cone.bottom_radius = 0.15 * local_size_multiplier
+		cone.height = 0.4 * local_size_multiplier
+		mesh_instance.mesh = cone
+	else:
+		var box := BoxMesh.new()
+		box.size = Vector3.ONE * (0.3 * local_size_multiplier)
+		mesh_instance.mesh = box
+	var material_key: String = "builtin://material/dummy_fixture" if is_fixture else "builtin://material/dummy_object"
+	var material: Material = asset_cache.get_material(material_key, true)
+	if material == null:
+		var base_material := StandardMaterial3D.new()
+		base_material.albedo_color = Color(1.0, 0.5, 0.1) if is_fixture else Color(0.2, 0.8, 1.0)
+		asset_cache.store_material(material_key, base_material)
+		material = asset_cache.get_material(material_key, true)
+	mesh_instance.material_override = material
+	return mesh_instance
+
+func _create_gdtf_primitive_mesh(data: Dictionary) -> Node3D:
+	var primitive_type: String = str(data.get("primitive_type", "")).to_lower()
+	var primitive_shape: String = _classify_gdtf_primitive_shape(primitive_type)
+	var source_size_x: float = max(float(data.get("primitive_size_x", 0.1)), 0.001)
+	var source_size_y: float = max(float(data.get("primitive_size_y", 0.1)), 0.001)
+	var source_size_z: float = max(float(data.get("primitive_size_z", 0.1)), 0.001)
+	var sx: float = source_size_x
+	var sy: float = source_size_z
+	var sz: float = source_size_y
+	var primitive_scale: Vector3 = Vector3(sx, sy, sz)
+	var mesh_instance := MeshInstance3D.new()
+	if primitive_shape == "sphere":
+		var sphere := SphereMesh.new()
+		sphere.radius = 0.5
+		sphere.height = 1.0
+		mesh_instance.mesh = sphere
+	elif primitive_shape == "cylinder":
+		var cylinder := CylinderMesh.new()
+		cylinder.top_radius = 0.5
+		cylinder.bottom_radius = 0.5
+		cylinder.height = 1.0
+		mesh_instance.mesh = cylinder
+	elif primitive_shape == "cone":
+		var cone := CylinderMesh.new()
+		cone.top_radius = 0.0
+		cone.bottom_radius = 0.5
+		cone.height = 1.0
+		mesh_instance.mesh = cone
+	else:
+		var box := BoxMesh.new()
+		box.size = Vector3.ONE
+		mesh_instance.mesh = box
+	mesh_instance.scale = primitive_scale
+	var material := StandardMaterial3D.new()
+	material.albedo_color = Color(0.2, 0.2, 0.22, 1.0)
+	material.roughness = 0.3
+	material.cull_mode = BaseMaterial3D.CULL_DISABLED
+	mesh_instance.material_override = material
+	return mesh_instance
+
+func _classify_gdtf_primitive_shape(primitive_type: String) -> String:
+	var normalized: String = primitive_type.strip_edges().to_lower()
+	if normalized.is_empty() or normalized == "undefined":
+		return "box"
+	if normalized.contains("cone"):
+		return "cone"
+	if normalized.contains("cylinder"):
+		return "cylinder"
+	if normalized.contains("sphere"):
+		return "sphere"
+	if normalized in ["yoke", "scanner", "scanner1_1", "pigtail"]:
+		return "cylinder"
+	if normalized in ["head"]:
+		return "sphere"
+	if normalized in ["base", "base1_1", "conventional", "conventional1_1", "cube"]:
+		return "box"
+	return "box"

--- a/peraviz/scripts/scene_loading/scene_import_service.gd
+++ b/peraviz/scripts/scene_loading/scene_import_service.gd
@@ -1,0 +1,78 @@
+extends RefCounted
+class_name SceneImportService
+
+func clear_scene(scene_registry: SceneRegistry,
+		proxies_root: Node3D,
+		node_index: Dictionary,
+		asset_cache: PeravizRuntimeAssetCache,
+		fixture_emissive_cache: Dictionary,
+		fixture_emitter_light_cache: Dictionary,
+		fixture_emitter_photometrics: Dictionary,
+		fixture_gobo_projector: FixtureGoboProjector,
+		clear_selected_fixture: Callable,
+		clear_debug_gizmos: Callable,
+		set_has_loaded_bounds: Callable) -> void:
+	scene_registry.clear("scene_reload")
+	clear_selected_fixture.call("scene_clear")
+	for child in proxies_root.get_children():
+		child.queue_free()
+	node_index.clear()
+	asset_cache.clear()
+	fixture_emissive_cache.clear()
+	fixture_emitter_light_cache.clear()
+	fixture_emitter_photometrics.clear()
+	if fixture_gobo_projector != null:
+		fixture_gobo_projector.clear_cache()
+	set_has_loaded_bounds.call(false)
+	clear_debug_gizmos.call()
+
+func import_scene(path: String,
+		loader: PeravizLoader,
+		node_factory: NodeFactory,
+		fixture_binding_service: FixtureBindingService,
+		status_label: Label,
+		asset_cache: PeravizRuntimeAssetCache,
+		proxies_root: Node3D,
+		node_index: Dictionary,
+		refresh_dmx_fixture_bindings: Callable,
+		populate_fixture_list: Callable,
+		sync_selection_state: Callable,
+		rebuild_debug_gizmos: Callable,
+		focus_loaded_scene: Callable,
+		update_debug_legend: Callable,
+		refresh_emitter_light_scalars: Callable,
+		extract_emitter_photometrics: Callable,
+		rebuild_loaded_bounds: Callable,
+		set_has_loaded_bounds: Callable,
+		debug_coords_enabled: bool,
+		debug_asset_cache_enabled: bool,
+		scene_registry: SceneRegistry) -> void:
+	var native_path: String = ProjectSettings.globalize_path(path)
+	var peraviz_debug_baseline: bool = bool(ProjectSettings.get_setting("peraviz_debug_baseline", false))
+	var nodes: Array = loader.load_mvr(native_path, peraviz_debug_baseline, debug_coords_enabled)
+	print("[Peraviz] Loaded render nodes: ", nodes.size(), " baseline_debug=", peraviz_debug_baseline, " coords_debug=", debug_coords_enabled)
+	set_has_loaded_bounds.call(false)
+
+	node_factory.build_node_tree(nodes, proxies_root, node_index, rebuild_loaded_bounds, loader, asset_cache)
+	fixture_binding_service.register_fixture_registry(nodes, node_index, scene_registry, extract_emitter_photometrics)
+	refresh_dmx_fixture_bindings.call()
+	populate_fixture_list.call()
+	sync_selection_state.call("scene_reload")
+	rebuild_debug_gizmos.call()
+	focus_loaded_scene.call()
+	if debug_asset_cache_enabled:
+		_print_asset_cache_summary(asset_cache)
+	status_label.text = "Nodes: %d (press F to focus, C debug coords)" % nodes.size()
+	update_debug_legend.call()
+	refresh_emitter_light_scalars.call()
+
+func _print_asset_cache_summary(asset_cache: PeravizRuntimeAssetCache) -> void:
+	var cache_summary: Dictionary = asset_cache.debug_summary()
+	var hit_by_kind: Dictionary = cache_summary.get("hits_by_kind", {})
+	var miss_by_kind: Dictionary = cache_summary.get("misses_by_kind", {})
+	print("[PeravizAssetCache] summary hits=", cache_summary.get("hits", 0),
+		" misses=", cache_summary.get("misses", 0),
+		" unique=", cache_summary.get("unique_resources", 0),
+		" mesh(hit/miss)=", hit_by_kind.get("mesh", 0), "/", miss_by_kind.get("mesh", 0),
+		" scene(hit/miss)=", hit_by_kind.get("scene", 0), "/", miss_by_kind.get("scene", 0),
+		" material(hit/miss)=", hit_by_kind.get("material", 0), "/", miss_by_kind.get("material", 0))


### PR DESCRIPTION
### Motivation
- Reduce the size and responsibilities of `peraviz/scripts/load_scene.gd` by extracting scene import, node creation, fixture binding and debug overlay logic into focused service modules to improve modularity and testability.
- Preserve existing runtime behavior and scene API while making the main loader act as an orchestrator that wires small services together.

### Description
- Added four new service modules under `peraviz/scripts/scene_loading/`: `scene_import_service.gd`, `node_factory.gd`, `fixture_binding_service.gd`, and `debug_overlay_service.gd`, each owning import, node instantiation/orientation, fixture-node binding and debug overlay logic respectively.
- Updated `peraviz/scripts/load_scene.gd` to `preload(...)` the new service scripts, instantiate them (e.g. `_scene_import_service`, `_node_factory`, `_fixture_binding_service`, `_debug_overlay_service`) and delegate original responsibilities to the new services while keeping helper functions used elsewhere.
- Replaced the inline scene import and tree rebuild steps in `_on_file_selected`, `_build_node_tree`, `_clear_scene`, debug-gizmo management and fixture registration with calls into the new services, and added a `_set_has_loaded_bounds` setter so bounds state can be controlled via `Callable` by `SceneImportService`.
- New files: `peraviz/scripts/scene_loading/scene_import_service.gd`, `node_factory.gd`, `fixture_binding_service.gd`, `debug_overlay_service.gd`; Modified file: `peraviz/scripts/load_scene.gd`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded. (OK)
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded. (OK)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df63396cb48324a6bc149f6d7aa4d3)