### PR TITLE
Rename DMX fixture binding entrypoints to neutral terminology (with deprecation alias)

### DIFF
--- a/peraviz/native/src/dmx/fixture_dmx_binding.cpp
+++ b/peraviz/native/src/dmx/fixture_dmx_binding.cpp
@@ -41,7 +41,7 @@ void sanitize_channel_binding(FixtureAttributeChannel &channel) {
 
 } // namespace
 
-FixtureBindingBuildResult build_dimmer_bindings(
+FixtureBindingBuildResult build_fixture_control_bindings(
     const std::vector<FixturePatch> &patches,
     int universe_offset,
     std::unordered_map<std::string, FixtureControlBinding> &fixture_lookup) {
@@ -263,6 +263,14 @@ FixtureBindingBuildResult build_dimmer_bindings(
     }
 
     return result;
+}
+
+
+FixtureBindingBuildResult build_dimmer_bindings(
+    const std::vector<FixturePatch> &patches,
+    int universe_offset,
+    std::unordered_map<std::string, FixtureControlBinding> &fixture_lookup) {
+    return build_fixture_control_bindings(patches, universe_offset, fixture_lookup);
 }
 
 } // namespace peraviz::dmx

--- a/peraviz/native/src/dmx/fixture_dmx_binding.h
+++ b/peraviz/native/src/dmx/fixture_dmx_binding.h
@@ -180,6 +180,12 @@ bool resolve_fixture_control_offsets(const std::string &gdtf_path,
                                      FixtureControlOffsets &out_offsets,
                                      std::string &out_debug_reason);
 
+FixtureBindingBuildResult build_fixture_control_bindings(
+    const std::vector<FixturePatch> &patches,
+    int universe_offset,
+    std::unordered_map<std::string, FixtureControlBinding> &fixture_lookup);
+
+// Deprecated alias kept for temporary backward compatibility.
 FixtureBindingBuildResult build_dimmer_bindings(
     const std::vector<FixturePatch> &patches,
     int universe_offset,

--- a/peraviz/native/src/peraviz_loader.cpp
+++ b/peraviz/native/src/peraviz_loader.cpp
@@ -43,6 +43,10 @@ void PeravizLoader::_bind_methods() {
     ClassDB::bind_method(D_METHOD("load_mvr", "path", "peraviz_debug_baseline", "peraviz_debug_coords"), &PeravizLoader::load_mvr);
     ClassDB::bind_method(D_METHOD("load_3ds_mesh_data", "path"), &PeravizLoader::load_3ds_mesh_data);
     ClassDB::bind_method(D_METHOD("get_fixtures_patch"), &PeravizLoader::get_fixtures_patch);
+    ClassDB::bind_method(D_METHOD("build_fixture_dmx_bindings", "universe_offset"),
+                         &PeravizLoader::build_fixture_dmx_bindings,
+                         DEFVAL(-1));
+    // Deprecated alias kept for one release to avoid breaking existing scripts/scenes.
     ClassDB::bind_method(D_METHOD("build_fixture_dimmer_bindings", "universe_offset"),
                          &PeravizLoader::build_fixture_dimmer_bindings,
                          DEFVAL(-1));
@@ -150,7 +154,7 @@ Array PeravizLoader::get_fixtures_patch() const {
     return serialize_fixture_patches(last_scene_model_);
 }
 
-Dictionary PeravizLoader::build_fixture_dimmer_bindings(int universe_offset) const {
+Dictionary PeravizLoader::build_fixture_dmx_bindings(int universe_offset) const {
     Dictionary out;
     out["universe_offset"] = universe_offset;
 
@@ -169,7 +173,7 @@ Dictionary PeravizLoader::build_fixture_dimmer_bindings(int universe_offset) con
 
     std::unordered_map<std::string, peraviz::dmx::FixtureControlBinding> lookup;
     const peraviz::dmx::FixtureBindingBuildResult result =
-        peraviz::dmx::build_dimmer_bindings(patches, universe_offset, lookup);
+        peraviz::dmx::build_fixture_control_bindings(patches, universe_offset, lookup);
 
     Array bindings;
     bindings.resize(static_cast<int64_t>(result.bindings.size()));
@@ -347,6 +351,11 @@ Dictionary PeravizLoader::build_fixture_dimmer_bindings(int universe_offset) con
     out["unbound"] = Array();
 #endif
     return out;
+}
+
+Dictionary PeravizLoader::build_fixture_dimmer_bindings(int universe_offset) const {
+    UtilityFunctions::push_warning("[PeravizNative] build_fixture_dimmer_bindings is deprecated; use build_fixture_dmx_bindings instead.");
+    return build_fixture_dmx_bindings(universe_offset);
 }
 
 } // namespace godot

--- a/peraviz/native/src/peraviz_loader.h
+++ b/peraviz/native/src/peraviz_loader.h
@@ -21,6 +21,7 @@ public:
                    bool peraviz_debug_coords = false);
     Dictionary load_3ds_mesh_data(const String &path) const;
     Array get_fixtures_patch() const;
+    Dictionary build_fixture_dmx_bindings(int universe_offset = -1) const;
     Dictionary build_fixture_dimmer_bindings(int universe_offset = -1) const;
 
 private:

--- a/peraviz/scripts/dmx_fixture_runtime.gd
+++ b/peraviz/scripts/dmx_fixture_runtime.gd
@@ -42,7 +42,7 @@ func rebuild(universe_offset: int) -> Dictionary:
 			"unbound_preview": PackedStringArray(),
 		}
 
-	var result: Dictionary = _loader.build_fixture_dimmer_bindings(universe_offset)
+	var result: Dictionary = _loader.build_fixture_dmx_bindings(universe_offset)
 	_bindings = result.get("bindings", [])
 	_unbound = result.get("unbound", [])
 


### PR DESCRIPTION
### Motivation
- Move away from fixture-specific term `dimmer` in the public APIs to neutral, descriptive names for control/DMX binding builders to better reflect multi-control fixtures.
- Keep temporary aliases to avoid breaking existing scenes/scripts during the transition.

### Description
- Introduced `build_fixture_control_bindings(...)` in `peraviz/native/src/dmx/fixture_dmx_binding.{h,cpp}` and retained `build_dimmer_bindings(...)` as a deprecated forwarding alias.
- Added `PeravizLoader::build_fixture_dmx_bindings(int)` and exposed it to Godot via `_bind_methods()` in `peraviz/native/src/peraviz_loader.cpp` and declared it in `peraviz/native/src/peraviz_loader.h`.
- Kept `PeravizLoader::build_fixture_dimmer_bindings(int)` as a deprecated compatibility wrapper that emits a runtime warning and forwards to `build_fixture_dmx_bindings(...)`.
- Updated runtime script `peraviz/scripts/dmx_fixture_runtime.gd` to call `_loader.build_fixture_dmx_bindings(...)` instead of the old entrypoint.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df67669e58832486bfa8c696008965)