### PR TITLE
Support GDTF gobo shake frequency & amplitude (SubPhysicalUnit) and runtime fallback

### DIFF
--- a/docs/DMX_PATCH_MVR_GDTF.md
+++ b/docs/DMX_PATCH_MVR_GDTF.md
@@ -53,3 +53,14 @@ Fixtures are listed as unbound when one of these happens:
 - Missing GDTF reference/path.
 - Dimmer/Pan/Tilt attributes not found for the selected mode.
 - Resolved control channel indices outside the 1..512 frame.
+
+## Gobo shake physical mapping (runtime)
+
+- For shake-capable gobo attributes (`...SelectShake`, `...PosShake`, `...WheelShake`), `ChannelSet PhysicalFrom/PhysicalTo` is interpreted as shake **frequency in Hz** (slow→fast or fast→slow).
+- If the attribute definition contains `SubPhysicalUnit Type="Amplitude"`, Peraviz captures it and uses it as runtime shake amplitude.
+  - `PhysicalUnit="Angle"` is used directly in degrees.
+  - `PhysicalUnit="Percent"` is converted to degrees as `% * 360`.
+- If no explicit amplitude exists, runtime uses configurable fallback amplitude limits:
+  - `peraviz/gobo_shake_fallback_amplitude_min_deg` (default `0.5`)
+  - `peraviz/gobo_shake_fallback_amplitude_max_deg` (default `3.0`)
+- Frequency and amplitude are clamped defensively at runtime for malformed/extreme values.

--- a/peraviz/native/src/dmx/fixture_dmx_binding.h
+++ b/peraviz/native/src/dmx/fixture_dmx_binding.h
@@ -64,6 +64,9 @@ struct FixtureGoboShakeRange {
     int mode_to_8bit = 255;
     float physical_from = 0.0F;
     float physical_to = 0.0F;
+    bool has_explicit_amplitude = false;
+    float amplitude_from_degrees = 0.0F;
+    float amplitude_to_degrees = 0.0F;
     int slot_index = -1;
     FixtureGoboShakeControlType control_type = FixtureGoboShakeControlType::kSameChannelSelect;
 };

--- a/peraviz/native/src/dmx/gdtf_control_offsets_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_control_offsets_resolver.cpp
@@ -391,6 +391,13 @@ void handle_gobo_rotation_attribute(const peraviz::dmx::ParsedAttribute &parsed_
                                                      function_mode_from,
                                                      function_mode_to);
     if (is_shake_attribute) {
+        float shake_attribute_amplitude_from_degrees = 0.0F;
+        float shake_attribute_amplitude_to_degrees = 0.0F;
+        const bool has_shake_attribute_amplitude =
+            peraviz::dmx::resolve_shake_attribute_amplitude_degrees(
+                channel_function,
+                shake_attribute_amplitude_from_degrees,
+                shake_attribute_amplitude_to_degrees);
         wheel->shake_ranges.reserve(wheel->shake_ranges.size() + parsed_ranges.size());
         for (const peraviz::dmx::FixtureGoboRotationRange &range : parsed_ranges) {
             peraviz::dmx::FixtureGoboShakeRange shake_range;
@@ -400,6 +407,11 @@ void handle_gobo_rotation_attribute(const peraviz::dmx::ParsedAttribute &parsed_
             shake_range.mode_to_8bit = range.mode_to_8bit;
             shake_range.physical_from = range.physical_from;
             shake_range.physical_to = range.physical_to;
+            shake_range.has_explicit_amplitude = has_shake_attribute_amplitude;
+            if (has_shake_attribute_amplitude) {
+                shake_range.amplitude_from_degrees = shake_attribute_amplitude_from_degrees;
+                shake_range.amplitude_to_degrees = shake_attribute_amplitude_to_degrees;
+            }
             shake_range.slot_index = -1;
             shake_range.control_type = peraviz::dmx::FixtureGoboShakeControlType::kDedicatedShakeChannel;
             wheel->shake_ranges.push_back(shake_range);

--- a/peraviz/native/src/dmx/gdtf_gobo_catalog.cpp
+++ b/peraviz/native/src/dmx/gdtf_gobo_catalog.cpp
@@ -165,6 +165,67 @@ int normalize_gobo_slot_index(int slot_index,
     return -1;
 }
 
+bool parse_float_attr_ci(tinyxml2::XMLElement *node,
+                         const char *name_a,
+                         const char *name_b,
+                         float &out_value) {
+    if (!node) {
+        return false;
+    }
+    return node->QueryFloatAttribute(name_a, &out_value) == tinyxml2::XML_SUCCESS ||
+           node->QueryFloatAttribute(name_b, &out_value) == tinyxml2::XML_SUCCESS;
+}
+
+tinyxml2::XMLElement *find_document_root_element(tinyxml2::XMLElement *node) {
+    if (!node) {
+        return nullptr;
+    }
+    tinyxml2::XMLNode *root = node;
+    while (root->Parent() != nullptr) {
+        root = root->Parent();
+    }
+    tinyxml2::XMLDocument *document = root->ToDocument();
+    return document ? document->RootElement() : nullptr;
+}
+
+bool parse_amplitude_from_attribute_definition(tinyxml2::XMLElement *attribute_definition,
+                                               float &out_amplitude_from_degrees,
+                                               float &out_amplitude_to_degrees) {
+    if (!attribute_definition) {
+        return false;
+    }
+
+    for (tinyxml2::XMLElement *child = attribute_definition->FirstChildElement(); child;
+         child = child->NextSiblingElement()) {
+        if (lower_ascii(child->Name()) != "subphysicalunit") {
+            continue;
+        }
+        if (lower_ascii(read_attr_ci(child, "Type", "type")) != "amplitude") {
+            continue;
+        }
+
+        float raw_from = 0.0F;
+        float raw_to = 0.0F;
+        if (!parse_float_attr_ci(child, "PhysicalFrom", "physicalfrom", raw_from) ||
+            !parse_float_attr_ci(child, "PhysicalTo", "physicalto", raw_to)) {
+            continue;
+        }
+
+        const std::string physical_unit =
+            lower_ascii(read_attr_ci(child, "PhysicalUnit", "physicalunit"));
+        if (physical_unit == "percent") {
+            out_amplitude_from_degrees = std::max(0.0F, raw_from) * 0.01F * 360.0F;
+            out_amplitude_to_degrees = std::max(0.0F, raw_to) * 0.01F * 360.0F;
+        } else {
+            out_amplitude_from_degrees = std::max(0.0F, raw_from);
+            out_amplitude_to_degrees = std::max(0.0F, raw_to);
+        }
+        return true;
+    }
+
+    return false;
+}
+
 } // namespace
 
 GoboWheelCatalog build_gobo_wheel_catalog(const std::string &gdtf_path, tinyxml2::XMLElement *root) {
@@ -216,6 +277,40 @@ GoboWheelCatalog build_gobo_wheel_catalog(const std::string &gdtf_path, tinyxml2
     }
 
     return out;
+}
+
+bool resolve_shake_attribute_amplitude_degrees(tinyxml2::XMLElement *channel_function,
+                                               float &out_amplitude_from_degrees,
+                                               float &out_amplitude_to_degrees) {
+    out_amplitude_from_degrees = 0.0F;
+    out_amplitude_to_degrees = 0.0F;
+    if (!channel_function) {
+        return false;
+    }
+
+    const std::string attribute_name = read_attr_ci(channel_function, "Attribute", "attribute");
+    if (attribute_name.empty()) {
+        return false;
+    }
+
+    tinyxml2::XMLElement *root = find_document_root_element(channel_function);
+    if (!root) {
+        return false;
+    }
+
+    for (tinyxml2::XMLElement *attribute_definition : collect_elements_by_name(root, "attribute")) {
+        if (!attribute_definition) {
+            continue;
+        }
+        if (read_attr_ci(attribute_definition, "Name", "name") != attribute_name) {
+            continue;
+        }
+        return parse_amplitude_from_attribute_definition(attribute_definition,
+                                                         out_amplitude_from_degrees,
+                                                         out_amplitude_to_degrees);
+    }
+
+    return false;
 }
 
 void consume_gobo_channel_sets(tinyxml2::XMLElement *channel_function,
@@ -279,6 +374,12 @@ void consume_gobo_channel_sets(tinyxml2::XMLElement *channel_function,
         channel_function->QueryFloatAttribute("PhysicalTo", &function_physical_to) == tinyxml2::XML_SUCCESS ||
         channel_function->QueryFloatAttribute("physicalto", &function_physical_to) == tinyxml2::XML_SUCCESS;
     const bool has_function_physical = has_function_physical_from && has_function_physical_to;
+    float shake_attribute_amplitude_from_degrees = 0.0F;
+    float shake_attribute_amplitude_to_degrees = 0.0F;
+    const bool has_shake_attribute_amplitude = resolve_shake_attribute_amplitude_degrees(
+        channel_function,
+        shake_attribute_amplitude_from_degrees,
+        shake_attribute_amplitude_to_degrees);
 
     const auto resolve_channel_set_dmx =
         [clamped_function_from, clamped_function_to](int raw_value) -> int {
@@ -425,6 +526,11 @@ void consume_gobo_channel_sets(tinyxml2::XMLElement *channel_function,
                     shake_range.mode_to_8bit = clamped_mode_to;
                     shake_range.physical_from = rotation_physical_from;
                     shake_range.physical_to = rotation_physical_to;
+                    shake_range.has_explicit_amplitude = has_shake_attribute_amplitude;
+                    if (has_shake_attribute_amplitude) {
+                        shake_range.amplitude_from_degrees = shake_attribute_amplitude_from_degrees;
+                        shake_range.amplitude_to_degrees = shake_attribute_amplitude_to_degrees;
+                    }
                     shake_range.slot_index = row.slot_index;
                     shake_range.control_type = FixtureGoboShakeControlType::kSameChannelSelect;
                     out_wheel.shake_ranges.push_back(shake_range);
@@ -524,6 +630,9 @@ void dedupe_and_sort_gobo_wheel(FixtureGoboWheelOffset &wheel) {
                                a.mode_to_8bit == b.mode_to_8bit &&
                                a.physical_from == b.physical_from &&
                                a.physical_to == b.physical_to &&
+                               a.has_explicit_amplitude == b.has_explicit_amplitude &&
+                               a.amplitude_from_degrees == b.amplitude_from_degrees &&
+                               a.amplitude_to_degrees == b.amplitude_to_degrees &&
                                a.slot_index == b.slot_index &&
                                a.control_type == b.control_type;
                     }),

--- a/peraviz/native/src/dmx/gdtf_gobo_catalog.h
+++ b/peraviz/native/src/dmx/gdtf_gobo_catalog.h
@@ -29,6 +29,10 @@ void consume_gobo_channel_sets(tinyxml2::XMLElement *channel_function,
                                int mode_window_from,
                                int mode_window_to);
 
+bool resolve_shake_attribute_amplitude_degrees(tinyxml2::XMLElement *channel_function,
+                                               float &out_amplitude_from_degrees,
+                                               float &out_amplitude_to_degrees);
+
 void dedupe_and_sort_gobo_wheel(FixtureGoboWheelOffset &wheel);
 
 } // namespace peraviz::dmx

--- a/peraviz/native/src/peraviz_loader.cpp
+++ b/peraviz/native/src/peraviz_loader.cpp
@@ -311,6 +311,9 @@ Dictionary PeravizLoader::build_fixture_dmx_bindings(int universe_offset) const 
                 shake_range_item["mode_to_8bit"] = shake_range.mode_to_8bit;
                 shake_range_item["physical_from"] = shake_range.physical_from;
                 shake_range_item["physical_to"] = shake_range.physical_to;
+                shake_range_item["has_explicit_amplitude"] = shake_range.has_explicit_amplitude;
+                shake_range_item["amplitude_from_degrees"] = shake_range.amplitude_from_degrees;
+                shake_range_item["amplitude_to_degrees"] = shake_range.amplitude_to_degrees;
                 shake_range_item["slot_index"] = shake_range.slot_index;
                 shake_range_item["control_type"] = static_cast<int>(shake_range.control_type);
                 shake_ranges[shake_range_index] = shake_range_item;

--- a/peraviz/native/tests/fixture_dmx_binding_e2e_test.cpp
+++ b/peraviz/native/tests/fixture_dmx_binding_e2e_test.cpp
@@ -203,6 +203,16 @@ int run_test() {
 
     const std::string mega_pointe_like_xml = R"(<?xml version="1.0" encoding="UTF-8"?>
 <GDTF>
+  <AttributeDefinitions>
+    <Attributes>
+      <Attribute Name="Gobo2SelectShake">
+        <SubPhysicalUnit Type="Amplitude" PhysicalUnit="Angle" PhysicalFrom="2.0" PhysicalTo="2.0" />
+      </Attribute>
+      <Attribute Name="Gobo2ShakeIndex">
+        <SubPhysicalUnit Type="Amplitude" PhysicalUnit="Percent" PhysicalFrom="1.0" PhysicalTo="2.0" />
+      </Attribute>
+    </Attributes>
+  </AttributeDefinitions>
   <Wheels>
     <Wheel Name="Gobo2">
       <Slot WheelSlotIndex="1" />
@@ -281,16 +291,24 @@ int run_test() {
         return fail("Expected select-channel shake fallback ranges in dedicated shake mode");
     }
     bool has_slot_bound_select_shake = false;
+    bool has_amplitude_from_attribute = false;
     for (const peraviz::dmx::FixtureGoboShakeRange &range : with_dedicated_wheel->shake_ranges) {
         if (range.control_type == peraviz::dmx::FixtureGoboShakeControlType::kSameChannelSelect &&
             range.slot_index > 0 &&
             range.physical_to > range.physical_from) {
             has_slot_bound_select_shake = true;
-            break;
+        }
+        if (range.has_explicit_amplitude &&
+            range.amplitude_from_degrees > 3.5F &&
+            range.amplitude_to_degrees > range.amplitude_from_degrees) {
+            has_amplitude_from_attribute = true;
         }
     }
     if (!has_slot_bound_select_shake) {
         return fail("Expected slot-bound select-shake ranges with physical windows");
+    }
+    if (!has_amplitude_from_attribute) {
+        return fail("Expected shake ranges to include amplitude from SubPhysicalUnit");
     }
 
     peraviz::dmx::FixtureControlOffsets without_dedicated_offsets;

--- a/peraviz/scripts/dmx_capabilities/gobo_capability_handler.gd
+++ b/peraviz/scripts/dmx_capabilities/gobo_capability_handler.gd
@@ -5,6 +5,12 @@ const GOBO_BEHAVIOR_FIXED: int = 0
 const GOBO_BEHAVIOR_INDEX: int = 1
 const GOBO_BEHAVIOR_ROTATION: int = 2
 const GOBO_BEHAVIOR_SHAKE: int = 3
+const GOBO_SHAKE_CONTROL_TYPE_SAME_CHANNEL_SELECT: int = 0
+const GOBO_SHAKE_CONTROL_TYPE_DEDICATED_CHANNEL: int = 1
+const GOBO_DEFAULT_SHAKE_FALLBACK_AMPLITUDE_MIN_DEG: float = 0.5
+const GOBO_DEFAULT_SHAKE_FALLBACK_AMPLITUDE_MAX_DEG: float = 3.0
+const GOBO_MAX_SHAKE_FREQUENCY_HZ: float = 120.0
+const GOBO_MAX_SHAKE_AMPLITUDE_DEG: float = 45.0
 
 const DmxGoboRangeResolverScript = preload("res://scripts/dmx_gobo_range_resolver.gd")
 
@@ -102,6 +108,7 @@ static func _build_runtime_gobo_bindings(binding: Dictionary,
 		var rotation_has_value: bool = false
 		var rotation_ranges: Array = item.get("rotation_ranges", [])
 		var resolved_rotation: Dictionary = {}
+		var resolved_shake: Dictionary = {}
 		var mode_master_value_8bit: int = raw_8bit
 		var rotation_control_norm: float = -1.0
 
@@ -198,7 +205,17 @@ static func _build_runtime_gobo_bindings(binding: Dictionary,
 				mode_master_value_8bit,
 				prefer_rotation_channel_ranges
 			)
+		var shake_ranges: Array = item.get("shake_ranges", [])
+		if range_behavior == GOBO_BEHAVIOR_SHAKE and not shake_ranges.is_empty():
+			resolved_shake = _resolve_shake_runtime(
+				rotation_raw_8bit,
+				rotation_control_norm,
+				shake_ranges,
+				mode_master_value_8bit,
+				rotation_source_channel == "rotation"
+			)
 		var matched_range: Dictionary = resolved_rotation.get("range", {})
+		var matched_shake_range: Dictionary = resolved_shake.get("range", {})
 		runtime_bindings.append({
 			"wheel_number": int(item.get("wheel_number", 0)),
 			"wheel_name": str(item.get("wheel_name", "")),
@@ -235,6 +252,12 @@ static func _build_runtime_gobo_bindings(binding: Dictionary,
 			"rotation_raw_value": rotation_raw,
 			"rotation_active_range": active_range,
 			"rotation_ranges": rotation_ranges,
+			"shake_ranges": shake_ranges,
+			"has_shake_runtime_range": bool(resolved_shake.get("has_range", false)),
+			"shake_frequency_hz": float(resolved_shake.get("shake_frequency_hz", -1.0)),
+			"shake_amplitude_deg": float(resolved_shake.get("shake_amplitude_deg", -1.0)),
+			"shake_matched_range_start": int(matched_shake_range.get("dmx_from", -1)),
+			"shake_matched_range_end": int(matched_shake_range.get("dmx_to", -1)),
 			"index_norm": index_norm,
 			"slots": item.get("slots", []),
 			"ranges": ranges,
@@ -313,3 +336,87 @@ static func _resolve_rotation_runtime(raw_8bit: int, control_norm: float, ranges
 
 static func _resolve_gobo_range(raw_8bit: int, ranges: Array) -> Dictionary:
 	return DmxGoboRangeResolverScript.resolve_active_range(raw_8bit, ranges)
+
+static func _resolve_shake_runtime(raw_8bit: int, control_norm: float, ranges: Array, mode_master_value_8bit: int, prefer_dedicated_shake_ranges: bool) -> Dictionary:
+	var fallback_amplitude_min: float = _resolve_shake_fallback_min_amplitude()
+	var fallback_amplitude_max: float = _resolve_shake_fallback_max_amplitude(fallback_amplitude_min)
+
+	for pass_index in range(2):
+		for item in ranges:
+			if item is not Dictionary:
+				continue
+			var range_data: Dictionary = item
+			var control_type: int = int(range_data.get("control_type", GOBO_SHAKE_CONTROL_TYPE_SAME_CHANNEL_SELECT))
+			var is_dedicated_shake_range: bool = control_type == GOBO_SHAKE_CONTROL_TYPE_DEDICATED_CHANNEL
+			if pass_index == 0 and is_dedicated_shake_range != prefer_dedicated_shake_ranges:
+				continue
+			if pass_index == 1 and is_dedicated_shake_range == prefer_dedicated_shake_ranges:
+				continue
+
+			var range_mode_from: int = int(range_data.get("mode_from_8bit", 0))
+			var range_mode_to: int = int(range_data.get("mode_to_8bit", 255))
+			if range_mode_to < range_mode_from:
+				var mode_swap: int = range_mode_from
+				range_mode_from = range_mode_to
+				range_mode_to = mode_swap
+			if mode_master_value_8bit < range_mode_from or mode_master_value_8bit > range_mode_to:
+				continue
+
+			var dmx_from: int = int(range_data.get("dmx_from", 0))
+			var dmx_to: int = int(range_data.get("dmx_to", dmx_from))
+			if dmx_to < dmx_from:
+				var swap_value: int = dmx_from
+				dmx_from = dmx_to
+				dmx_to = swap_value
+			if raw_8bit < dmx_from or raw_8bit > dmx_to:
+				continue
+
+			var ratio: float = 0.0
+			if dmx_to > dmx_from:
+				ratio = float(raw_8bit - dmx_from) / float(dmx_to - dmx_from)
+				if control_norm >= 0.0:
+					var range_norm_from: float = float(dmx_from) / 255.0
+					var range_norm_to: float = float(dmx_to) / 255.0
+					var range_norm_span: float = range_norm_to - range_norm_from
+					if range_norm_span > 0.0:
+						ratio = clamp((control_norm - range_norm_from) / range_norm_span, 0.0, 1.0)
+
+			var shake_frequency_hz: float = lerp(float(range_data.get("physical_from", 0.0)), float(range_data.get("physical_to", 0.0)), ratio)
+			shake_frequency_hz = clamp(absf(shake_frequency_hz), 0.0, GOBO_MAX_SHAKE_FREQUENCY_HZ)
+
+			var shake_amplitude_deg: float = 0.0
+			if bool(range_data.get("has_explicit_amplitude", false)):
+				shake_amplitude_deg = lerp(float(range_data.get("amplitude_from_degrees", 0.0)), float(range_data.get("amplitude_to_degrees", 0.0)), ratio)
+				shake_amplitude_deg = clamp(absf(shake_amplitude_deg), 0.0, GOBO_MAX_SHAKE_AMPLITUDE_DEG)
+			else:
+				var frequency_edge_a: float = clamp(absf(float(range_data.get("physical_from", 0.0))), 0.0, GOBO_MAX_SHAKE_FREQUENCY_HZ)
+				var frequency_edge_b: float = clamp(absf(float(range_data.get("physical_to", 0.0))), 0.0, GOBO_MAX_SHAKE_FREQUENCY_HZ)
+				var min_frequency_edge: float = minf(frequency_edge_a, frequency_edge_b)
+				var max_frequency_edge: float = maxf(frequency_edge_a, frequency_edge_b)
+				var frequency_ratio: float = 0.0
+				if max_frequency_edge > min_frequency_edge + 0.0001:
+					frequency_ratio = clamp((shake_frequency_hz - min_frequency_edge) / (max_frequency_edge - min_frequency_edge), 0.0, 1.0)
+				elif max_frequency_edge > 0.0001:
+					frequency_ratio = 1.0
+				shake_amplitude_deg = lerp(fallback_amplitude_min, fallback_amplitude_max, frequency_ratio)
+
+			return {
+				"has_range": true,
+				"range": range_data,
+				"shake_frequency_hz": shake_frequency_hz,
+				"shake_amplitude_deg": shake_amplitude_deg,
+			}
+
+	return {
+		"has_range": false,
+		"range": {},
+		"shake_frequency_hz": -1.0,
+		"shake_amplitude_deg": -1.0,
+	}
+
+static func _resolve_shake_fallback_min_amplitude() -> float:
+	return maxf(float(ProjectSettings.get_setting("peraviz/gobo_shake_fallback_amplitude_min_deg", GOBO_DEFAULT_SHAKE_FALLBACK_AMPLITUDE_MIN_DEG)), 0.0)
+
+static func _resolve_shake_fallback_max_amplitude(fallback_amplitude_min: float) -> float:
+	var configured_max: float = float(ProjectSettings.get_setting("peraviz/gobo_shake_fallback_amplitude_max_deg", GOBO_DEFAULT_SHAKE_FALLBACK_AMPLITUDE_MAX_DEG))
+	return maxf(configured_max, fallback_amplitude_min)


### PR DESCRIPTION
### Motivation
- Improve handling of GDTF-authored gobo "shake" attributes so `ChannelSet PhysicalFrom/PhysicalTo` map to runtime shake frequency (preserving slow→fast and fast→slow ramps).
- Capture authored shake amplitude when present in `AttributeDefinitions` via `SubPhysicalUnit Type="Amplitude"` so runtime visuals use fixture-provided amplitude where available.
- Provide a safe, configurable fallback amplitude and defensive clamping for malformed or missing metadata so runtime behavior is stable across fixtures.

### Description
- Interpret `ChannelSet PhysicalFrom/PhysicalTo` for shake-capable attributes as shake frequency (Hz) and preserve ramp direction when building `FixtureGoboShakeRange` in `gdtf_gobo_catalog` and resolver paths.
- Add amplitude extraction: new helper `resolve_shake_attribute_amplitude_degrees(...)` walks `AttributeDefinitions` looking for `SubPhysicalUnit Type="Amplitude"`, converts `Percent`→degrees, and returns explicit amplitude bounds to native parsing.
- Extend data model with `FixtureGoboShakeRange` fields `has_explicit_amplitude`, `amplitude_from_degrees`, and `amplitude_to_degrees`, propagate these through `gdtf_control_offsets_resolver`, `peraviz_loader` export, and Godot runtime glue.
- Implement runtime resolution in `peraviz/scripts/dmx_capabilities/gobo_capability_handler.gd` to use explicit amplitude when present, otherwise synthesize amplitude from configurable fallback bounds (`peraviz/gobo_shake_fallback_amplitude_min_deg`, `peraviz/gobo_shake_fallback_amplitude_max_deg`), and clamp frequency/amplitude to safe limits.

### Testing
- `tests/check_perastage_tree_modules.sh` succeeded. 
- `tests/check_no_configmanager_get_in_gui.sh` succeeded.
- `cmake --preset wsl-x64-debug -DPERAVIZ_ENABLE_DMX=ON -DBUILD_TESTING=ON` could not complete in this environment due to missing `wxWidgets` development package, so native test binaries were not built here; an updated MegaPointe-like e2e test was added but not executed in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfce3eed9083249e12bc23282aa1aa)