### PR TITLE
docs(peraviz): clarify gobo shake layering, priority, and limits

### DIFF
--- a/peraviz/docs/GDTF_GOBO_CONTROL.md
+++ b/peraviz/docs/GDTF_GOBO_CONTROL.md
@@ -1,4 +1,4 @@
-# GDTF gobo index and rotation mapping in Peraviz
+# GDTF gobo index, rotation, and shake mapping in Peraviz
 
 This note summarizes the GDTF attributes used for gobo wheel control and
 how they are mapped into Peraviz DMX runtime controls.
@@ -11,25 +11,28 @@ For this implementation, the relevant attributes are:
 - `Gobo(n)` for wheel slot selection.
 - `Gobo(n)Pos` for indexed gobo angle.
 - `Gobo(n)PosRotate` for continuous gobo rotation speed/direction.
+- `Gobo(n)SelectShake` or dedicated shake attributes for gobo shake behavior.
 
 ## Runtime mapping
 
-Peraviz now exposes three independent gobo channels when present in the GDTF
-mode:
+Peraviz exposes gobo controls when present in the fixture mode:
 
 - `gobo_*` for slot selection.
 - `gobo_index_*` for indexed angle.
 - `gobo_rotation_*` for continuous rotation.
+- shake metadata (`supports_shake`, `shake_active`, `shake_amplitude_deg`,
+  `shake_frequency_hz`) per wheel when shake-capable functions are detected.
 
 For multi-wheel fixtures, each wheel in `gobo_wheels` also includes:
 
 - `index_*` channels.
 - `rotation_*` channels.
+- shake ranges tied to parsed DMX windows.
 
 When the GDTF channel functions define `PhysicalFrom`/`PhysicalTo`, those
-limits are also propagated for index and rotation controls. Runtime uses these
-physical ranges to interpret values with fixture-accurate behavior instead of a
-generic normalization.
+limits are propagated for index/rotation and shake interpretation when
+available. Runtime uses these physical ranges to interpret values with
+fixture-accurate behavior instead of a generic normalization.
 
 ## Control interpretation in Godot
 
@@ -40,12 +43,59 @@ Peraviz runtime applies gobo controls with this behavior:
    **fixed angular position** relative to initial orientation.
 3. If `gobo_rotation`/`rotation` is present (`Gobo(n)PosRotate`), map DMX value
    to **angular speed** (including direction) and integrate over time.
+4. If shake is active, apply shake as an **additional tilt modulation layer**
+   on top of the resulting rotation.
 
-Index and rotation are treated as different semantics:
+Shake is therefore **not mutually exclusive** with rotation:
 
-- **Index**: target angle (static position).
-- **Rotation/Spin**: speed command (continuous motion).
+- Rotation defines the wheel spin/index orientation over time.
+- Shake adds oscillation amplitude/frequency on top of that state.
 
-This keeps backward compatibility for fixtures without explicit
-`Gobo(n)Pos`/`Gobo(n)PosRotate` channels while enabling dedicated controls when
-present.
+## Shake control priority
+
+Per-wheel shake source priority is:
+
+1. **Dedicated shake channel** (highest priority).
+2. **Same-channel select-shake window** (`Gobo(n)SelectShake`).
+3. **Fallback** from rotation speed (frequency inferred from
+   `abs(rotation_speed_deg_per_sec) / 360.0` if no explicit shake frequency is
+   available).
+
+Debug override behavior:
+
+- Debug override affects shake only when explicitly enabled in debug controls.
+- If debug override is disabled (or running in non-debug builds), runtime uses
+  fixture/runtime shake sources only.
+
+## Real fixture example: `Robin MegaPointe.gdtf`
+
+The fixture file `library/fixtures/Robin MegaPointe.gdtf` provides a concrete
+same-channel select-shake example:
+
+- `Gobo1SelectShake` appears on one DMX channel and defines select-shake windows
+  (for static gobo shake selection).
+- `Gobo2SelectShake` appears on one DMX channel with separate windows for
+  shake-index and shake-rotation behavior.
+
+Observed DMX windows (8-bit values) in the provided fixture modes:
+
+- `Gobo1SelectShake` starts at `88` with slot windows stepping by `8`
+  (`88..95`, `96..103`, ...).
+- `Gobo2SelectShake` shake-index region starts at `60` with slot windows stepping
+  by `8` (`60..67`, `68..75`, ...).
+- `Gobo2SelectShake` shake-rotation region starts at `130` with slot windows
+  stepping by `8` (`130..137`, `138..145`, ...).
+
+In this specific fixture, select-shake windows are the active runtime source;
+if a dedicated shake channel existed for the same wheel, it would take
+precedence by design.
+
+## Approved operational limits
+
+Peraviz enforces the following shake safety limits at runtime:
+
+- `max amplitude = 1.0º`
+- `max frequency = 7.0 Hz`
+
+Any resolved or debug-provided shake values are clamped to these limits before
+being applied.


### PR DESCRIPTION
### Motivation

- Make the runtime semantics of gobo "shake" explicit by documenting that shake is applied as an additional modulation layer on top of rotation rather than as a mutually exclusive mode.
- Clarify which DMX sources win when multiple shake inputs exist so implementers and fixture authors understand control precedence.
- Provide a real fixture example and record approved operational safety limits so users and integrators can validate behavior against an actual GDTF file.

### Description

- Updated `peraviz/docs/GDTF_GOBO_CONTROL.md` to include `Gobo(n)SelectShake` and dedicated shake attributes in the GDTF reference and runtime mapping.
- Documented runtime semantics showing rotation/index vs. shake layering and made explicit that shake is applied on top of the resulting rotation.
- Added a control-priority section specifying the order: dedicated shake channel > same-channel select-shake window > rotation-based fallback, and clarified that debug override only applies when explicitly enabled.  
- Included a concrete example using `library/fixtures/Robin MegaPointe.gdtf` showing `Gobo1SelectShake` and `Gobo2SelectShake` DMX windows, and recorded the approved operational limits `max amplitude = 1.0º` and `max frequency = 7.0 Hz` (these values are enforced/clamped at runtime).

### Testing

- `tests/check_perastage_tree_modules.sh` was run and completed successfully.  
- `tests/check_no_configmanager_get_in_gui.sh` was run and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0aba87e888324af059788370f10c8)