### PR TITLE
Refactor Peraviz UI shell and move DMX controls into sidebar

### DIFF
--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -2,32 +2,35 @@
 extends Node3D
 
 @onready var proxies_root: Node3D = $Proxies
-@onready var status_label: Label = $HUD/StatusLabel
-@onready var picker: FileDialog = $HUD/FileDialog
+@onready var status_label: Label = $UIRoot/RootVBox/TopBar/TopBarMargin/TopBarRow/StatusLabel
+@onready var picker: FileDialog = $UIRoot/FileDialog
 @onready var camera: Camera3D = $Camera3D
 @onready var world_environment: WorldEnvironment = $WorldEnvironment
 @onready var day_night_environment_controller: DayNightEnvironmentController = $DayNightEnvironmentController
-@onready var manual_fixture_toggle: CheckButton = $HUD/ManualFixtureToggle
-@onready var fixture_debug_panel: PanelContainer = $HUD/FixtureDebugPanel
-@onready var fixture_list: ItemList = $HUD/FixtureDebugPanel/Margin/VBox/FixtureList
-@onready var fixture_selected_label: Label = $HUD/FixtureDebugPanel/Margin/VBox/SelectedFixtureLabel
-@onready var fixture_axis_label: Label = $HUD/FixtureDebugPanel/Margin/VBox/AxisAnchorsLabel
-@onready var fixture_emitter_label: Label = $HUD/FixtureDebugPanel/Margin/VBox/EmitterAnchorsLabel
-@onready var pan_min_input: SpinBox = $HUD/FixtureDebugPanel/Margin/VBox/LimitsGrid/PanMin
-@onready var pan_max_input: SpinBox = $HUD/FixtureDebugPanel/Margin/VBox/LimitsGrid/PanMax
-@onready var pan_value_input: SpinBox = $HUD/FixtureDebugPanel/Margin/VBox/LimitsGrid/PanValue
-@onready var tilt_min_input: SpinBox = $HUD/FixtureDebugPanel/Margin/VBox/LimitsGrid/TiltMin
-@onready var tilt_max_input: SpinBox = $HUD/FixtureDebugPanel/Margin/VBox/LimitsGrid/TiltMax
-@onready var tilt_value_input: SpinBox = $HUD/FixtureDebugPanel/Margin/VBox/LimitsGrid/TiltValue
-@onready var dimmer_min_input: SpinBox = $HUD/FixtureDebugPanel/Margin/VBox/LimitsGrid/DimmerMin
-@onready var dimmer_max_input: SpinBox = $HUD/FixtureDebugPanel/Margin/VBox/LimitsGrid/DimmerMax
-@onready var dimmer_value_input: SpinBox = $HUD/FixtureDebugPanel/Margin/VBox/LimitsGrid/DimmerValue
-@onready var pan_slider: HSlider = $HUD/FixtureDebugPanel/Margin/VBox/PanSlider
-@onready var tilt_slider: HSlider = $HUD/FixtureDebugPanel/Margin/VBox/TiltSlider
-@onready var dimmer_slider: HSlider = $HUD/FixtureDebugPanel/Margin/VBox/DimmerSlider
-@onready var quick_reset_button: Button = $HUD/FixtureDebugPanel/Margin/VBox/QuickResetButton
-@onready var visual_settings_button: Button = $HUD/VisualSettingsButton
-@onready var visual_settings_window: VisualSettingsWindow = $HUD/VisualSettingsWindow
+@onready var manual_fixture_toggle: CheckButton = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/ManualFixtureToggle
+@onready var fixture_debug_panel: PanelContainer = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel
+@onready var fixture_list: ItemList = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/FixtureList
+@onready var fixture_selected_label: Label = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/SelectedFixtureLabel
+@onready var fixture_axis_label: Label = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/AxisAnchorsLabel
+@onready var fixture_emitter_label: Label = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/EmitterAnchorsLabel
+@onready var pan_min_input: SpinBox = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid/PanMin
+@onready var pan_max_input: SpinBox = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid/PanMax
+@onready var pan_value_input: SpinBox = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid/PanValue
+@onready var tilt_min_input: SpinBox = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid/TiltMin
+@onready var tilt_max_input: SpinBox = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid/TiltMax
+@onready var tilt_value_input: SpinBox = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid/TiltValue
+@onready var dimmer_min_input: SpinBox = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid/DimmerMin
+@onready var dimmer_max_input: SpinBox = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid/DimmerMax
+@onready var dimmer_value_input: SpinBox = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid/DimmerValue
+@onready var pan_slider: HSlider = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/PanSlider
+@onready var tilt_slider: HSlider = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/TiltSlider
+@onready var dimmer_slider: HSlider = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/DimmerSlider
+@onready var quick_reset_button: Button = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/QuickResetButton
+@onready var visual_settings_button: Button = $UIRoot/RootVBox/TopBar/TopBarMargin/TopBarRow/VisualSettingsButton
+@onready var visual_settings_window: VisualSettingsWindow = $UIRoot/VisualSettingsWindow
+@onready var app_shell: AppShell = $UIRoot/AppShell
+@onready var load_button: Button = $UIRoot/RootVBox/TopBar/TopBarMargin/TopBarRow/LoadButton
+@onready var dmx_controls_mount: VBoxContainer = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/DMXControlsMount
 
 var _loader := PeravizLoader.new()
 var _scene_registry := SceneRegistry.new()
@@ -120,6 +123,7 @@ var _dmx_monitor_window: Window
 var _dmx_timer: Timer
 var _dmx_universe_offset_input: SpinBox
 var _dmx_unbound_preview_label: Label
+var _dmx_controls_panel: PanelContainer
 var _dmx_fixture_runtime = null
 var _last_dmx_tick_msec: int = 0
 
@@ -239,7 +243,7 @@ const ENVIRONMENT_QUALITY_PRESETS := {
 func _ready() -> void:
 	_apply_imported_content_scale()
 	_scene_registry.configure(proxies_root)
-	$HUD/LoadButton.pressed.connect(_on_load_pressed)
+	load_button.pressed.connect(_on_load_pressed)
 	picker.file_selected.connect(_on_file_selected)
 	manual_fixture_toggle.toggled.connect(_on_manual_fixture_toggle)
 	fixture_list.item_selected.connect(_on_fixture_list_item_selected)
@@ -2359,43 +2363,56 @@ func _focus_loaded_scene() -> void:
 func _setup_dmx_controls() -> void:
 	if _dmx_toggle_button != null and is_instance_valid(_dmx_toggle_button):
 		return
-	var hud_root: CanvasLayer = $HUD
+	var controls_host: Control = _resolve_dmx_controls_host()
+	if controls_host == null:
+		return
+	_dmx_controls_panel = PanelContainer.new()
+	_dmx_controls_panel.name = "DMXControlsPanel"
+	controls_host.add_child(_dmx_controls_panel)
+	var controls_margin := MarginContainer.new()
+	controls_margin.add_theme_constant_override("margin_left", 8)
+	controls_margin.add_theme_constant_override("margin_top", 8)
+	controls_margin.add_theme_constant_override("margin_right", 8)
+	controls_margin.add_theme_constant_override("margin_bottom", 8)
+	_dmx_controls_panel.add_child(controls_margin)
+	var controls_vbox := VBoxContainer.new()
+	controls_margin.add_child(controls_vbox)
+	var controls_header := Label.new()
+	controls_header.text = "DMX"
+	controls_vbox.add_child(controls_header)
+	var controls_row := HBoxContainer.new()
+	controls_vbox.add_child(controls_row)
 	_dmx_toggle_button = Button.new()
 	_dmx_toggle_button.text = "DMX OFF"
 	_dmx_toggle_button.toggle_mode = true
-	_dmx_toggle_button.position = Vector2(540, 20)
-	hud_root.add_child(_dmx_toggle_button)
+	controls_row.add_child(_dmx_toggle_button)
 	_dmx_toggle_button.pressed.connect(_on_dmx_toggle_pressed)
 	_update_dmx_toggle_color(false, false)
 
 	_dmx_monitor_button = Button.new()
 	_dmx_monitor_button.text = "DMX Monitor"
-	_dmx_monitor_button.position = Vector2(650, 20)
 	_dmx_monitor_button.disabled = true
-	hud_root.add_child(_dmx_monitor_button)
+	controls_row.add_child(_dmx_monitor_button)
 	_dmx_monitor_button.pressed.connect(_on_dmx_monitor_pressed)
 
 	_dmx_universe_offset_input = SpinBox.new()
-	_dmx_universe_offset_input.position = Vector2(770, 20)
 	_dmx_universe_offset_input.custom_minimum_size = Vector2(90, 24)
 	_dmx_universe_offset_input.min_value = -32
 	_dmx_universe_offset_input.max_value = 32
 	_dmx_universe_offset_input.step = 1
 	_dmx_universe_offset_input.value = -1
-	hud_root.add_child(_dmx_universe_offset_input)
+	controls_row.add_child(_dmx_universe_offset_input)
 	_dmx_universe_offset_input.value_changed.connect(_on_dmx_universe_offset_changed)
 
 	_dmx_unbound_preview_label = Label.new()
-	_dmx_unbound_preview_label.position = Vector2(540, 50)
-	_dmx_unbound_preview_label.size = Vector2(500, 120)
 	_dmx_unbound_preview_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 	_dmx_unbound_preview_label.visible = false
-	hud_root.add_child(_dmx_unbound_preview_label)
+	controls_vbox.add_child(_dmx_unbound_preview_label)
 
 	_dmx_timer = Timer.new()
 	_dmx_timer.wait_time = 0.03
 	_dmx_timer.autostart = true
-	hud_root.add_child(_dmx_timer)
+	add_child(_dmx_timer)
 	_dmx_timer.timeout.connect(_on_dmx_timer_timeout)
 
 	if ClassDB.class_exists("PeravizDmxReceiver"):
@@ -2404,6 +2421,31 @@ func _setup_dmx_controls() -> void:
 	else:
 		_dmx_toggle_button.disabled = true
 		_dmx_toggle_button.tooltip_text = "DMX unavailable (build without PERAVIZ_ENABLE_DMX)"
+
+func _resolve_dmx_controls_host() -> Control:
+	if dmx_controls_mount != null and is_instance_valid(dmx_controls_mount):
+		return dmx_controls_mount
+	if app_shell != null and app_shell.has_method("get_modules_container"):
+		return app_shell.get_modules_container() as Control
+	return null
+
+func bridge_set_side_panel_open(is_open: bool) -> void:
+	if app_shell != null:
+		app_shell.set_side_panel_open(is_open)
+
+func bridge_set_active_section(section_name: StringName) -> void:
+	if app_shell != null:
+		app_shell.set_active_section(section_name)
+
+func bridge_register_section(section_name: StringName, section_node: CanvasItem) -> void:
+	if app_shell != null:
+		app_shell.register_section(section_name, section_node)
+
+func bridge_get_dmx_controls_host() -> Control:
+	return _resolve_dmx_controls_host()
+
+func bridge_setup_dmx_controls() -> void:
+	_setup_dmx_controls()
 
 func _setup_dmx_fixture_runtime() -> void:
 	_dmx_fixture_runtime = DmxFixtureRuntimeScript.new()

--- a/peraviz/scripts/ui/app_shell.gd
+++ b/peraviz/scripts/ui/app_shell.gd
@@ -1,0 +1,57 @@
+extends Node
+class_name AppShell
+
+@export var side_panel_path: NodePath
+@export var side_toggle_button_path: NodePath
+@export var modules_container_path: NodePath
+
+var _side_panel: Control
+var _side_toggle_button: Button
+var _modules_container: Control
+var _is_side_panel_open: bool = true
+var _active_section: StringName = &""
+var _sections: Dictionary = {}
+
+func _ready() -> void:
+	_side_panel = get_node_or_null(side_panel_path) as Control
+	_side_toggle_button = get_node_or_null(side_toggle_button_path) as Button
+	_modules_container = get_node_or_null(modules_container_path) as Control
+	if _side_toggle_button != null:
+		_side_toggle_button.pressed.connect(toggle_side_panel)
+	_refresh_side_panel_state()
+
+func toggle_side_panel() -> void:
+	set_side_panel_open(not _is_side_panel_open)
+
+func set_side_panel_open(is_open: bool) -> void:
+	_is_side_panel_open = is_open
+	_refresh_side_panel_state()
+
+func is_side_panel_open() -> bool:
+	return _is_side_panel_open
+
+func get_modules_container() -> Control:
+	return _modules_container
+
+func register_section(name: StringName, section_node: CanvasItem) -> void:
+	_sections[name] = section_node
+	if _active_section == &"":
+		set_active_section(name)
+	else:
+		section_node.visible = (name == _active_section)
+
+func set_active_section(name: StringName) -> void:
+	_active_section = name
+	for section_name in _sections.keys():
+		var section_node: CanvasItem = _sections[section_name]
+		if section_node != null:
+			section_node.visible = (section_name == _active_section)
+
+func get_active_section() -> StringName:
+	return _active_section
+
+func _refresh_side_panel_state() -> void:
+	if _side_panel != null:
+		_side_panel.visible = _is_side_panel_open
+	if _side_toggle_button != null:
+		_side_toggle_button.text = "☰" if not _is_side_panel_open else "×"

--- a/peraviz/scripts/ui/app_shell.gd.uid
+++ b/peraviz/scripts/ui/app_shell.gd.uid
@@ -1,0 +1,1 @@
+uid://dxh7qphl4cgob

--- a/peraviz/test.tscn
+++ b/peraviz/test.tscn
@@ -4,6 +4,7 @@
 [ext_resource type="Script" uid="uid://c1syjijru4ah" path="res://scripts/editor_camera.gd" id="2_camera_script"]
 [ext_resource type="Script" uid="uid://bq8n5oubm8j8u" path="res://scripts/visual_settings_window.gd" id="3_visual_settings"]
 [ext_resource type="Script" uid="uid://cqjoqw1c2pare" path="res://scripts/day_night_environment_controller.gd" id="4_day_night_environment"]
+[ext_resource type="Script" path="res://scripts/ui/app_shell.gd" id="5_app_shell"]
 
 [sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_ppyta"]
 sky_top_color = Color(0.3, 0.52, 0.83, 1)
@@ -78,98 +79,126 @@ mesh = SubResource("PlaneMesh_ground")
 
 [node name="Proxies" type="Node3D" parent="." unique_id=747662263]
 
-[node name="HUD" type="CanvasLayer" parent="." unique_id=1180011651]
-
-[node name="LoadButton" type="Button" parent="HUD" unique_id=788175590]
-offset_left = 16.0
-offset_top = 16.0
-offset_right = 164.0
-offset_bottom = 48.0
-size_flags_horizontal = 8
-size_flags_vertical = 8
-text = "Load MVR"
-
-[node name="StatusLabel" type="Label" parent="HUD" unique_id=496411274]
-anchors_preset = 3
-anchor_left = 1.0
-anchor_top = 1.0
+[node name="UIRoot" type="Control" parent="." unique_id=1180011651]
+layout_mode = 3
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = -608.0
-offset_top = -48.0
-offset_right = -20.0
-offset_bottom = -20.0
-grow_horizontal = 0
-grow_vertical = 0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="AppShell" type="Node" parent="UIRoot"]
+script = ExtResource("5_app_shell")
+side_panel_path = NodePath("../RootVBox/ContentRow/SidePanel")
+side_toggle_button_path = NodePath("../RootVBox/TopBar/TopBarMargin/TopBarRow/SidePanelToggleButton")
+modules_container_path = NodePath("../RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox")
+
+[node name="RootVBox" type="VBoxContainer" parent="UIRoot"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="TopBar" type="PanelContainer" parent="UIRoot/RootVBox"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="TopBarMargin" type="MarginContainer" parent="UIRoot/RootVBox/TopBar"]
+layout_mode = 2
+theme_override_constants/margin_left = 8
+theme_override_constants/margin_top = 6
+theme_override_constants/margin_right = 8
+theme_override_constants/margin_bottom = 6
+
+[node name="TopBarRow" type="HBoxContainer" parent="UIRoot/RootVBox/TopBar/TopBarMargin"]
+layout_mode = 2
+
+[node name="SidePanelToggleButton" type="Button" parent="UIRoot/RootVBox/TopBar/TopBarMargin/TopBarRow"]
+layout_mode = 2
+text = "×"
+
+[node name="LoadButton" type="Button" parent="UIRoot/RootVBox/TopBar/TopBarMargin/TopBarRow" unique_id=788175590]
+layout_mode = 2
+text = "Load MVR"
+
+[node name="VisualSettingsButton" type="Button" parent="UIRoot/RootVBox/TopBar/TopBarMargin/TopBarRow" unique_id=1846608382]
+layout_mode = 2
+text = "Visual settings"
+
+[node name="TopSpacer" type="Control" parent="UIRoot/RootVBox/TopBar/TopBarMargin/TopBarRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="StatusLabel" type="Label" parent="UIRoot/RootVBox/TopBar/TopBarMargin/TopBarRow" unique_id=496411274]
+layout_mode = 2
 text = "Select a .mvr file"
 horizontal_alignment = 2
 
-[node name="ManualFixtureToggle" type="CheckButton" parent="HUD" unique_id=1323885867]
-offset_left = 24.0
-offset_top = 48.0
-offset_right = 274.0
-offset_bottom = 80.0
-text = "Manual fixture test"
+[node name="ContentRow" type="HBoxContainer" parent="UIRoot/RootVBox"]
+layout_mode = 2
+size_flags_vertical = 3
 
-[node name="VisualSettingsButton" type="Button" parent="HUD" unique_id=1846608382]
-offset_left = 176.0
-offset_top = 16.0
-offset_right = 356.0
-offset_bottom = 48.0
-size_flags_horizontal = 8
-size_flags_vertical = 8
-text = "Visual settings"
+[node name="SidePanel" type="PanelContainer" parent="UIRoot/RootVBox/ContentRow"]
+custom_minimum_size = Vector2(360, 0)
+layout_mode = 2
 
-[node name="VisualSettingsWindow" type="Window" parent="HUD" unique_id=362544277]
-oversampling_override = 1.0
-mode = 1
-title = "Visual Settings"
-position = Vector2i(0, 36)
-size = Vector2i(560, 760)
-script = ExtResource("3_visual_settings")
-
-[node name="FixtureDebugPanel" type="PanelContainer" parent="HUD" unique_id=876760691]
-visible = false
-offset_left = 12.0
-offset_top = 92.0
-offset_right = 360.0
-offset_bottom = 380.0
-
-[node name="Margin" type="MarginContainer" parent="HUD/FixtureDebugPanel" unique_id=12487456]
+[node name="SidePanelMargin" type="MarginContainer" parent="UIRoot/RootVBox/ContentRow/SidePanel"]
 layout_mode = 2
 theme_override_constants/margin_left = 8
 theme_override_constants/margin_top = 8
 theme_override_constants/margin_right = 8
 theme_override_constants/margin_bottom = 8
 
-[node name="VBox" type="VBoxContainer" parent="HUD/FixtureDebugPanel/Margin" unique_id=2055359984]
+[node name="ModulesVBox" type="VBoxContainer" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin"]
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="ManualFixtureToggle" type="CheckButton" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox" unique_id=1323885867]
+layout_mode = 2
+text = "Manual fixture test"
+
+[node name="FixtureDebugPanel" type="PanelContainer" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox" unique_id=876760691]
+visible = false
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="Margin" type="MarginContainer" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel" unique_id=12487456]
+layout_mode = 2
+theme_override_constants/margin_left = 8
+theme_override_constants/margin_top = 8
+theme_override_constants/margin_right = 8
+theme_override_constants/margin_bottom = 8
+
+[node name="VBox" type="VBoxContainer" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin" unique_id=2055359984]
 layout_mode = 2
 
-[node name="DebugTitle" type="Label" parent="HUD/FixtureDebugPanel/Margin/VBox" unique_id=1787848800]
+[node name="DebugTitle" type="Label" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox" unique_id=1787848800]
 layout_mode = 2
 text = "Fixture Test Debug"
 
-[node name="SelectedFixtureLabel" type="Label" parent="HUD/FixtureDebugPanel/Margin/VBox" unique_id=673346627]
+[node name="SelectedFixtureLabel" type="Label" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox" unique_id=673346627]
 layout_mode = 2
 text = "Selected fixture: <none>"
 
-[node name="AxisAnchorsLabel" type="Label" parent="HUD/FixtureDebugPanel/Margin/VBox" unique_id=2044624671]
+[node name="AxisAnchorsLabel" type="Label" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox" unique_id=2044624671]
 layout_mode = 2
 text = "Axis anchors: 0"
 
-[node name="EmitterAnchorsLabel" type="Label" parent="HUD/FixtureDebugPanel/Margin/VBox" unique_id=2018033234]
+[node name="EmitterAnchorsLabel" type="Label" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox" unique_id=2018033234]
 layout_mode = 2
 text = "Emitter anchors: 0"
 
-[node name="ControlLimitsLabel" type="Label" parent="HUD/FixtureDebugPanel/Margin/VBox" unique_id=94290169]
+[node name="ControlLimitsLabel" type="Label" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox" unique_id=94290169]
 layout_mode = 2
 text = "Test limits (Pan/Tilt/Dimmer)"
 
-[node name="LimitsGrid" type="GridContainer" parent="HUD/FixtureDebugPanel/Margin/VBox" unique_id=1903357191]
+[node name="LimitsGrid" type="GridContainer" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox" unique_id=1903357191]
 layout_mode = 2
 columns = 3
 
-[node name="PanMin" type="SpinBox" parent="HUD/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=1517741601]
+[node name="PanMin" type="SpinBox" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=1517741601]
 custom_minimum_size = Vector2(80, 0)
 layout_mode = 2
 min_value = -720.0
@@ -177,7 +206,7 @@ max_value = 720.0
 value = -270.0
 suffix = "°"
 
-[node name="PanMax" type="SpinBox" parent="HUD/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=2143963791]
+[node name="PanMax" type="SpinBox" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=2143963791]
 custom_minimum_size = Vector2(80, 0)
 layout_mode = 2
 min_value = -720.0
@@ -185,14 +214,14 @@ max_value = 720.0
 value = 270.0
 suffix = "°"
 
-[node name="PanValue" type="SpinBox" parent="HUD/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=746740405]
+[node name="PanValue" type="SpinBox" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=746740405]
 custom_minimum_size = Vector2(80, 0)
 layout_mode = 2
 min_value = -720.0
 max_value = 720.0
 suffix = "°"
 
-[node name="TiltMin" type="SpinBox" parent="HUD/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=1938060436]
+[node name="TiltMin" type="SpinBox" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=1938060436]
 custom_minimum_size = Vector2(80, 0)
 layout_mode = 2
 min_value = -720.0
@@ -200,7 +229,7 @@ max_value = 720.0
 value = -135.0
 suffix = "°"
 
-[node name="TiltMax" type="SpinBox" parent="HUD/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=102676363]
+[node name="TiltMax" type="SpinBox" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=102676363]
 custom_minimum_size = Vector2(80, 0)
 layout_mode = 2
 min_value = -720.0
@@ -208,54 +237,71 @@ max_value = 720.0
 value = 135.0
 suffix = "°"
 
-[node name="TiltValue" type="SpinBox" parent="HUD/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=1978744316]
+[node name="TiltValue" type="SpinBox" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=1978744316]
 custom_minimum_size = Vector2(80, 0)
 layout_mode = 2
 min_value = -720.0
 max_value = 720.0
 suffix = "°"
 
-[node name="DimmerMin" type="SpinBox" parent="HUD/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=1339851247]
+[node name="DimmerMin" type="SpinBox" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=1339851247]
 custom_minimum_size = Vector2(80, 0)
 layout_mode = 2
 
-[node name="DimmerMax" type="SpinBox" parent="HUD/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=1145489119]
-custom_minimum_size = Vector2(80, 0)
-layout_mode = 2
-value = 100.0
-
-[node name="DimmerValue" type="SpinBox" parent="HUD/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=1339016213]
+[node name="DimmerMax" type="SpinBox" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=1145489119]
 custom_minimum_size = Vector2(80, 0)
 layout_mode = 2
 value = 100.0
 
-[node name="PanSlider" type="HSlider" parent="HUD/FixtureDebugPanel/Margin/VBox" unique_id=79651204]
+[node name="DimmerValue" type="SpinBox" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=1339016213]
+custom_minimum_size = Vector2(80, 0)
+layout_mode = 2
+value = 100.0
+
+[node name="PanSlider" type="HSlider" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox" unique_id=79651204]
 layout_mode = 2
 min_value = -270.0
 max_value = 270.0
 
-[node name="TiltSlider" type="HSlider" parent="HUD/FixtureDebugPanel/Margin/VBox" unique_id=1046553958]
+[node name="TiltSlider" type="HSlider" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox" unique_id=1046553958]
 layout_mode = 2
 min_value = -135.0
 max_value = 135.0
 
-[node name="DimmerSlider" type="HSlider" parent="HUD/FixtureDebugPanel/Margin/VBox" unique_id=835185574]
+[node name="DimmerSlider" type="HSlider" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox" unique_id=835185574]
 layout_mode = 2
 value = 100.0
 
-[node name="QuickResetButton" type="Button" parent="HUD/FixtureDebugPanel/Margin/VBox" unique_id=306389611]
+[node name="QuickResetButton" type="Button" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox" unique_id=306389611]
 layout_mode = 2
 text = "Reset Pan/Tilt/Dimmer"
 
-[node name="FixtureListLabel" type="Label" parent="HUD/FixtureDebugPanel/Margin/VBox" unique_id=1304235882]
+[node name="FixtureListLabel" type="Label" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox" unique_id=1304235882]
 layout_mode = 2
 text = "Fixtures by UUID"
 
-[node name="FixtureList" type="ItemList" parent="HUD/FixtureDebugPanel/Margin/VBox" unique_id=841801337]
+[node name="FixtureList" type="ItemList" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox" unique_id=841801337]
 custom_minimum_size = Vector2(0, 180)
 layout_mode = 2
 
-[node name="FileDialog" type="FileDialog" parent="HUD" unique_id=2124310720]
+[node name="DMXControlsMount" type="VBoxContainer" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox"]
+layout_mode = 2
+
+[node name="MainViewportArea" type="Control" parent="UIRoot/RootVBox/ContentRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+mouse_filter = 2
+
+[node name="VisualSettingsWindow" type="Window" parent="UIRoot" unique_id=362544277]
+oversampling_override = 1.0
+mode = 1
+title = "Visual Settings"
+position = Vector2i(0, 36)
+size = Vector2i(560, 760)
+script = ExtResource("3_visual_settings")
+
+[node name="FileDialog" type="FileDialog" parent="UIRoot" unique_id=2124310720]
 title = "Open a File"
 file_mode = 0
 access = 2

--- a/peraviz/test.tscn
+++ b/peraviz/test.tscn
@@ -86,6 +86,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+mouse_filter = 2
 
 [node name="AppShell" type="Node" parent="UIRoot"]
 script = ExtResource("5_app_shell")
@@ -100,6 +101,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+mouse_filter = 2
 
 [node name="TopBar" type="PanelContainer" parent="UIRoot/RootVBox"]
 layout_mode = 2
@@ -130,6 +132,7 @@ text = "Visual settings"
 [node name="TopSpacer" type="Control" parent="UIRoot/RootVBox/TopBar/TopBarMargin/TopBarRow"]
 layout_mode = 2
 size_flags_horizontal = 3
+mouse_filter = 2
 
 [node name="StatusLabel" type="Label" parent="UIRoot/RootVBox/TopBar/TopBarMargin/TopBarRow" unique_id=496411274]
 layout_mode = 2
@@ -139,6 +142,7 @@ horizontal_alignment = 2
 [node name="ContentRow" type="HBoxContainer" parent="UIRoot/RootVBox"]
 layout_mode = 2
 size_flags_vertical = 3
+mouse_filter = 2
 
 [node name="SidePanel" type="PanelContainer" parent="UIRoot/RootVBox/ContentRow"]
 custom_minimum_size = Vector2(360, 0)


### PR DESCRIPTION
### Motivation
- Replace the old HUD layout with a modular, Control-based UI shell to separate top-bar, collapsible left module panel and main 3D viewport responsibilities. 
- Move DMX/fixture controls into the sidebar module area so modules own their own UI instead of using absolute CanvasLayer placement. 
- Preserve existing loading and DMX workflows during the incremental migration by exposing temporary bridge methods. 

### Description
- Replaced the HUD node in `peraviz/test.tscn` with a `UIRoot` control tree that includes a top bar, a collapsible left `SidePanel`, `ModulesVBox` and a `MainViewportArea` (changes in `peraviz/test.tscn`).
- Added `peraviz/scripts/ui/app_shell.gd` which manages side-panel open/close state and registered sections (register/activate sections and provide `get_modules_container()`).
- Updated `peraviz/scripts/load_scene.gd` to use the new `UIRoot` node paths and to hook the existing load button into the new top bar; introduced `dmx_controls_mount` binding for module mounts.
- Migrated `_setup_dmx_controls()` to instantiate a `DMXControlsPanel` under the sidebar module mount (`DMXControlsMount`) and removed absolute `position = Vector2(...)` placements in favor of container-based layout.
- Added `_resolve_dmx_controls_host()` and temporary bridge functions (`bridge_set_side_panel_open`, `bridge_set_active_section`, `bridge_register_section`, `bridge_get_dmx_controls_host`, `bridge_setup_dmx_controls`) in `load_scene.gd` to preserve existing call sites while the UI is migrated incrementally.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0af507740832482b16f8a29dbbfb5)