### PR TITLE
Centralize Peraviz UI visibility policy and gate debug/advanced controls

### DIFF
--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -7,30 +7,34 @@ extends Node3D
 @onready var camera: Camera3D = $Camera3D
 @onready var world_environment: WorldEnvironment = $WorldEnvironment
 @onready var day_night_environment_controller: DayNightEnvironmentController = $DayNightEnvironmentController
-@onready var manual_fixture_toggle: CheckButton = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/ManualFixtureToggle
-@onready var fixture_debug_panel: PanelContainer = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel
-@onready var fixture_list: ItemList = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/FixtureList
-@onready var fixture_selected_label: Label = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/SelectedFixtureLabel
-@onready var fixture_axis_label: Label = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/AxisAnchorsLabel
-@onready var fixture_emitter_label: Label = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/EmitterAnchorsLabel
-@onready var pan_min_input: SpinBox = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid/PanMin
-@onready var pan_max_input: SpinBox = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid/PanMax
-@onready var pan_value_input: SpinBox = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid/PanValue
-@onready var tilt_min_input: SpinBox = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid/TiltMin
-@onready var tilt_max_input: SpinBox = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid/TiltMax
-@onready var tilt_value_input: SpinBox = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid/TiltValue
-@onready var dimmer_min_input: SpinBox = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid/DimmerMin
-@onready var dimmer_max_input: SpinBox = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid/DimmerMax
-@onready var dimmer_value_input: SpinBox = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid/DimmerValue
-@onready var pan_slider: HSlider = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/PanSlider
-@onready var tilt_slider: HSlider = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/TiltSlider
-@onready var dimmer_slider: HSlider = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/DimmerSlider
-@onready var quick_reset_button: Button = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/QuickResetButton
+@onready var user_module: VBoxContainer = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/User
+@onready var advanced_module: VBoxContainer = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Advanced
+@onready var debug_module: VBoxContainer = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug
+@onready var manual_fixture_toggle: CheckButton = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/ManualFixtureToggle
+@onready var fixture_debug_panel: PanelContainer = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel
+@onready var fixture_list: ItemList = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox/FixtureList
+@onready var fixture_selected_label: Label = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox/SelectedFixtureLabel
+@onready var fixture_axis_label: Label = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox/AxisAnchorsLabel
+@onready var fixture_emitter_label: Label = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox/EmitterAnchorsLabel
+@onready var pan_min_input: SpinBox = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox/LimitsGrid/PanMin
+@onready var pan_max_input: SpinBox = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox/LimitsGrid/PanMax
+@onready var pan_value_input: SpinBox = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox/LimitsGrid/PanValue
+@onready var tilt_min_input: SpinBox = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox/LimitsGrid/TiltMin
+@onready var tilt_max_input: SpinBox = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox/LimitsGrid/TiltMax
+@onready var tilt_value_input: SpinBox = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox/LimitsGrid/TiltValue
+@onready var dimmer_min_input: SpinBox = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox/LimitsGrid/DimmerMin
+@onready var dimmer_max_input: SpinBox = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox/LimitsGrid/DimmerMax
+@onready var dimmer_value_input: SpinBox = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox/LimitsGrid/DimmerValue
+@onready var pan_slider: HSlider = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox/PanSlider
+@onready var tilt_slider: HSlider = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox/TiltSlider
+@onready var dimmer_slider: HSlider = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox/DimmerSlider
+@onready var quick_reset_button: Button = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox/QuickResetButton
 @onready var visual_settings_button: Button = $UIRoot/RootVBox/TopBar/TopBarMargin/TopBarRow/VisualSettingsButton
+@onready var show_advanced_controls_toggle: CheckButton = $UIRoot/RootVBox/TopBar/TopBarMargin/TopBarRow/ShowAdvancedControlsToggle
 @onready var visual_settings_window: VisualSettingsWindow = $UIRoot/VisualSettingsWindow
 @onready var app_shell: AppShell = $UIRoot/AppShell
 @onready var load_button: Button = $UIRoot/RootVBox/TopBar/TopBarMargin/TopBarRow/LoadButton
-@onready var dmx_controls_mount: VBoxContainer = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/DMXControlsMount
+@onready var dmx_controls_mount: VBoxContainer = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/User/DMXControlsMount
 
 var _loader := PeravizLoader.new()
 var _scene_registry := SceneRegistry.new()
@@ -139,6 +143,7 @@ const LegacyConeBeamRendererScript = preload("res://scripts/beam_renderers/legac
 const VolumetricBeamRendererScript = preload("res://scripts/beam_renderers/volumetric_beam_renderer.gd")
 const FixtureGoboProjectorScript = preload("res://scripts/fixture_gobo_projector.gd")
 const BeamOpticsControllerScript = preload("res://scripts/beam_optics_controller.gd")
+const UiVisibilityPolicyScript = preload("res://scripts/ui/ui_visibility_policy.gd")
 
 const SceneImportServiceScript = preload("res://scripts/scene_loading/scene_import_service.gd")
 const NodeFactoryScript = preload("res://scripts/scene_loading/node_factory.gd")
@@ -261,6 +266,7 @@ func _ready() -> void:
 	dimmer_max_input.value_changed.connect(_on_limit_changed)
 	quick_reset_button.pressed.connect(_on_quick_reset_pressed)
 	visual_settings_button.pressed.connect(_on_visual_settings_pressed)
+	show_advanced_controls_toggle.toggled.connect(_on_show_advanced_controls_toggled)
 	if visual_settings_window != null and visual_settings_window.has_signal("settings_changed"):
 		visual_settings_window.connect("settings_changed", Callable(self, "_on_visual_settings_changed"))
 	else:
@@ -271,6 +277,8 @@ func _ready() -> void:
 	_debug_asset_cache_enabled = bool(ProjectSettings.get_setting("peraviz_debug_asset_cache", false))
 	_manual_fixture_test_enabled = _read_manual_fixture_test_setting()
 	manual_fixture_toggle.button_pressed = _manual_fixture_test_enabled
+	show_advanced_controls_toggle.button_pressed = UiVisibilityPolicyScript.is_advanced_controls_enabled()
+	_refresh_ui_module_visibility()
 	_asset_cache.configure_debug_logging(_debug_asset_cache_enabled, 100)
 	_ensure_debug_gizmo_root()
 	_update_debug_legend()
@@ -285,6 +293,8 @@ func _ready() -> void:
 	_fixture_gobo_projector = FixtureGoboProjectorScript.new()
 	if visual_settings_window != null and visual_settings_window.has_method("configure"):
 		visual_settings_window.call("configure", _visual_settings)
+		if visual_settings_window.has_method("set_ui_visibility_policy"):
+			visual_settings_window.call("set_ui_visibility_policy", UiVisibilityPolicyScript)
 	else:
 		push_warning("VisualSettingsWindow is not ready for configure(); initial visual settings not pushed.")
 	_apply_visual_settings(_visual_settings)
@@ -516,6 +526,20 @@ func _on_manual_fixture_toggle(enabled: bool) -> void:
 	_manual_fixture_test_enabled = enabled
 	ProjectSettings.set_setting("peraviz_manual_fixture_test", _manual_fixture_test_enabled)
 	_refresh_fixture_debug_panel()
+
+func _on_show_advanced_controls_toggled(enabled: bool) -> void:
+	UiVisibilityPolicyScript.set_advanced_controls_enabled(enabled)
+	_refresh_ui_module_visibility()
+
+func _refresh_ui_module_visibility() -> void:
+	if user_module != null:
+		user_module.visible = UiVisibilityPolicyScript.is_module_visible(UiVisibilityPolicyScript.MODULE_USER)
+	if advanced_module != null:
+		advanced_module.visible = UiVisibilityPolicyScript.is_module_visible(UiVisibilityPolicyScript.MODULE_ADVANCED)
+	if debug_module != null:
+		debug_module.visible = UiVisibilityPolicyScript.is_module_visible(UiVisibilityPolicyScript.MODULE_DEBUG)
+	if show_advanced_controls_toggle != null:
+		show_advanced_controls_toggle.button_pressed = UiVisibilityPolicyScript.is_advanced_controls_enabled()
 
 func _on_fixture_list_item_selected(index: int) -> void:
 	if index < 0 or index >= fixture_list.get_item_count():

--- a/peraviz/scripts/ui/ui_visibility_policy.gd
+++ b/peraviz/scripts/ui/ui_visibility_policy.gd
@@ -1,0 +1,63 @@
+extends RefCounted
+class_name UiVisibilityPolicy
+
+const MODULE_USER: StringName = &"User"
+const MODULE_ADVANCED: StringName = &"Advanced"
+const MODULE_DEBUG: StringName = &"Debug"
+
+const SETTINGS_FILE_PATH: String = "user://ui_visibility_policy.cfg"
+const SETTINGS_SECTION: String = "ui_visibility"
+const SETTING_SHOW_ADVANCED: String = "show_advanced_controls"
+const SETTING_FORCE_DEBUG: String = "force_debug_controls"
+
+static var _cached_settings: Dictionary = {}
+
+static func is_module_visible(module_name: StringName) -> bool:
+	match module_name:
+		MODULE_USER:
+			return true
+		MODULE_ADVANCED:
+			return is_advanced_controls_enabled()
+		MODULE_DEBUG:
+			return OS.is_debug_build() or is_debug_controls_forced()
+		_:
+			return false
+
+static func is_advanced_controls_enabled() -> bool:
+	return bool(_get_setting(SETTING_SHOW_ADVANCED, false))
+
+static func set_advanced_controls_enabled(enabled: bool) -> void:
+	_set_setting(SETTING_SHOW_ADVANCED, enabled)
+
+static func is_debug_controls_forced() -> bool:
+	return bool(_get_setting(SETTING_FORCE_DEBUG, false))
+
+static func set_debug_controls_forced(enabled: bool) -> void:
+	_set_setting(SETTING_FORCE_DEBUG, enabled)
+
+static func _get_setting(key: String, default_value: Variant) -> Variant:
+	_ensure_settings_loaded()
+	return _cached_settings.get(key, default_value)
+
+static func _set_setting(key: String, value: Variant) -> void:
+	_ensure_settings_loaded()
+	_cached_settings[key] = value
+	_save_settings()
+
+static func _ensure_settings_loaded() -> void:
+	if not _cached_settings.is_empty():
+		return
+	var config := ConfigFile.new()
+	if config.load(SETTINGS_FILE_PATH) != OK:
+		_cached_settings = {}
+		return
+	_cached_settings[SETTING_SHOW_ADVANCED] = bool(config.get_value(SETTINGS_SECTION, SETTING_SHOW_ADVANCED, false))
+	_cached_settings[SETTING_FORCE_DEBUG] = bool(config.get_value(SETTINGS_SECTION, SETTING_FORCE_DEBUG, false))
+
+static func _save_settings() -> void:
+	var config := ConfigFile.new()
+	for key in _cached_settings.keys():
+		config.set_value(SETTINGS_SECTION, key, _cached_settings[key])
+	var save_result: int = config.save(SETTINGS_FILE_PATH)
+	if save_result != OK:
+		push_warning("Failed to save UI visibility settings to %s (error=%d)" % [SETTINGS_FILE_PATH, save_result])

--- a/peraviz/scripts/visual_settings_window.gd
+++ b/peraviz/scripts/visual_settings_window.gd
@@ -6,6 +6,7 @@ class_name VisualSettingsWindow
 signal settings_changed(settings: Dictionary)
 
 const GoboShakeLimitsScript = preload("res://scripts/gobo_shake_limits.gd")
+const UiVisibilityPolicyScript = preload("res://scripts/ui/ui_visibility_policy.gd")
 
 const DEFAULT_SETTINGS := {
 	"ambient_multiplier": 0.08,
@@ -87,6 +88,7 @@ var _gobo_debug_shake_frequency_value_label: Label
 var _gobo_debug_comparison_option: OptionButton
 var _gobo_debug_waveform_option: OptionButton
 var _toggle_controls: Dictionary = {}
+var _ui_visibility_policy = UiVisibilityPolicyScript
 
 func _init() -> void:
 	title = "Visual Settings"
@@ -106,6 +108,10 @@ func configure(initial_settings: Dictionary) -> void:
 			_settings[key] = initial_settings[key]
 	if is_node_ready():
 		_apply_settings_to_controls()
+
+func set_ui_visibility_policy(policy_script: Variant) -> void:
+	if policy_script != null:
+		_ui_visibility_policy = policy_script
 
 func popup_settings() -> void:
 	popup_centered()
@@ -275,7 +281,9 @@ func _add_toggle_row(parent: VBoxContainer, label_text: String, key: String) -> 
 
 
 func _add_debug_gobo_section(parent: VBoxContainer) -> void:
-	if not OS.is_debug_build():
+	if _ui_visibility_policy == null:
+		return
+	if not _ui_visibility_policy.is_module_visible(_ui_visibility_policy.MODULE_DEBUG):
 		return
 	_add_section_label(parent, "Debug · Gobo rotation/shake")
 	_add_toggle_row(parent, "Enable gobo debug overrides", "gobo_debug_override_enabled")

--- a/peraviz/test.tscn
+++ b/peraviz/test.tscn
@@ -129,6 +129,10 @@ text = "Load MVR"
 layout_mode = 2
 text = "Visual settings"
 
+[node name="ShowAdvancedControlsToggle" type="CheckButton" parent="UIRoot/RootVBox/TopBar/TopBarMargin/TopBarRow"]
+layout_mode = 2
+text = "Show advanced controls"
+
 [node name="TopSpacer" type="Control" parent="UIRoot/RootVBox/TopBar/TopBarMargin/TopBarRow"]
 layout_mode = 2
 size_flags_horizontal = 3
@@ -159,50 +163,59 @@ theme_override_constants/margin_bottom = 8
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="ManualFixtureToggle" type="CheckButton" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox" unique_id=1323885867]
+[node name="User" type="VBoxContainer" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox"]
+layout_mode = 2
+
+[node name="Advanced" type="VBoxContainer" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox"]
+layout_mode = 2
+
+[node name="Debug" type="VBoxContainer" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox"]
+layout_mode = 2
+
+[node name="ManualFixtureToggle" type="CheckButton" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug" unique_id=1323885867]
 layout_mode = 2
 text = "Manual fixture test"
 
-[node name="FixtureDebugPanel" type="PanelContainer" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox" unique_id=876760691]
+[node name="FixtureDebugPanel" type="PanelContainer" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug" unique_id=876760691]
 visible = false
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="Margin" type="MarginContainer" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel" unique_id=12487456]
+[node name="Margin" type="MarginContainer" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel" unique_id=12487456]
 layout_mode = 2
 theme_override_constants/margin_left = 8
 theme_override_constants/margin_top = 8
 theme_override_constants/margin_right = 8
 theme_override_constants/margin_bottom = 8
 
-[node name="VBox" type="VBoxContainer" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin" unique_id=2055359984]
+[node name="VBox" type="VBoxContainer" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin" unique_id=2055359984]
 layout_mode = 2
 
-[node name="DebugTitle" type="Label" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox" unique_id=1787848800]
+[node name="DebugTitle" type="Label" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox" unique_id=1787848800]
 layout_mode = 2
 text = "Fixture Test Debug"
 
-[node name="SelectedFixtureLabel" type="Label" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox" unique_id=673346627]
+[node name="SelectedFixtureLabel" type="Label" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox" unique_id=673346627]
 layout_mode = 2
 text = "Selected fixture: <none>"
 
-[node name="AxisAnchorsLabel" type="Label" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox" unique_id=2044624671]
+[node name="AxisAnchorsLabel" type="Label" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox" unique_id=2044624671]
 layout_mode = 2
 text = "Axis anchors: 0"
 
-[node name="EmitterAnchorsLabel" type="Label" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox" unique_id=2018033234]
+[node name="EmitterAnchorsLabel" type="Label" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox" unique_id=2018033234]
 layout_mode = 2
 text = "Emitter anchors: 0"
 
-[node name="ControlLimitsLabel" type="Label" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox" unique_id=94290169]
+[node name="ControlLimitsLabel" type="Label" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox" unique_id=94290169]
 layout_mode = 2
 text = "Test limits (Pan/Tilt/Dimmer)"
 
-[node name="LimitsGrid" type="GridContainer" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox" unique_id=1903357191]
+[node name="LimitsGrid" type="GridContainer" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox" unique_id=1903357191]
 layout_mode = 2
 columns = 3
 
-[node name="PanMin" type="SpinBox" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=1517741601]
+[node name="PanMin" type="SpinBox" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=1517741601]
 custom_minimum_size = Vector2(80, 0)
 layout_mode = 2
 min_value = -720.0
@@ -210,7 +223,7 @@ max_value = 720.0
 value = -270.0
 suffix = "°"
 
-[node name="PanMax" type="SpinBox" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=2143963791]
+[node name="PanMax" type="SpinBox" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=2143963791]
 custom_minimum_size = Vector2(80, 0)
 layout_mode = 2
 min_value = -720.0
@@ -218,14 +231,14 @@ max_value = 720.0
 value = 270.0
 suffix = "°"
 
-[node name="PanValue" type="SpinBox" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=746740405]
+[node name="PanValue" type="SpinBox" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=746740405]
 custom_minimum_size = Vector2(80, 0)
 layout_mode = 2
 min_value = -720.0
 max_value = 720.0
 suffix = "°"
 
-[node name="TiltMin" type="SpinBox" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=1938060436]
+[node name="TiltMin" type="SpinBox" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=1938060436]
 custom_minimum_size = Vector2(80, 0)
 layout_mode = 2
 min_value = -720.0
@@ -233,7 +246,7 @@ max_value = 720.0
 value = -135.0
 suffix = "°"
 
-[node name="TiltMax" type="SpinBox" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=102676363]
+[node name="TiltMax" type="SpinBox" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=102676363]
 custom_minimum_size = Vector2(80, 0)
 layout_mode = 2
 min_value = -720.0
@@ -241,54 +254,54 @@ max_value = 720.0
 value = 135.0
 suffix = "°"
 
-[node name="TiltValue" type="SpinBox" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=1978744316]
+[node name="TiltValue" type="SpinBox" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=1978744316]
 custom_minimum_size = Vector2(80, 0)
 layout_mode = 2
 min_value = -720.0
 max_value = 720.0
 suffix = "°"
 
-[node name="DimmerMin" type="SpinBox" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=1339851247]
+[node name="DimmerMin" type="SpinBox" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=1339851247]
 custom_minimum_size = Vector2(80, 0)
 layout_mode = 2
 
-[node name="DimmerMax" type="SpinBox" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=1145489119]
-custom_minimum_size = Vector2(80, 0)
-layout_mode = 2
-value = 100.0
-
-[node name="DimmerValue" type="SpinBox" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=1339016213]
+[node name="DimmerMax" type="SpinBox" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=1145489119]
 custom_minimum_size = Vector2(80, 0)
 layout_mode = 2
 value = 100.0
 
-[node name="PanSlider" type="HSlider" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox" unique_id=79651204]
+[node name="DimmerValue" type="SpinBox" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox/LimitsGrid" unique_id=1339016213]
+custom_minimum_size = Vector2(80, 0)
+layout_mode = 2
+value = 100.0
+
+[node name="PanSlider" type="HSlider" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox" unique_id=79651204]
 layout_mode = 2
 min_value = -270.0
 max_value = 270.0
 
-[node name="TiltSlider" type="HSlider" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox" unique_id=1046553958]
+[node name="TiltSlider" type="HSlider" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox" unique_id=1046553958]
 layout_mode = 2
 min_value = -135.0
 max_value = 135.0
 
-[node name="DimmerSlider" type="HSlider" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox" unique_id=835185574]
+[node name="DimmerSlider" type="HSlider" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox" unique_id=835185574]
 layout_mode = 2
 value = 100.0
 
-[node name="QuickResetButton" type="Button" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox" unique_id=306389611]
+[node name="QuickResetButton" type="Button" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox" unique_id=306389611]
 layout_mode = 2
 text = "Reset Pan/Tilt/Dimmer"
 
-[node name="FixtureListLabel" type="Label" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox" unique_id=1304235882]
+[node name="FixtureListLabel" type="Label" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox" unique_id=1304235882]
 layout_mode = 2
 text = "Fixtures by UUID"
 
-[node name="FixtureList" type="ItemList" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/FixtureDebugPanel/Margin/VBox" unique_id=841801337]
+[node name="FixtureList" type="ItemList" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/Debug/FixtureDebugPanel/Margin/VBox" unique_id=841801337]
 custom_minimum_size = Vector2(0, 180)
 layout_mode = 2
 
-[node name="DMXControlsMount" type="VBoxContainer" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox"]
+[node name="DMXControlsMount" type="VBoxContainer" parent="UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/User"]
 layout_mode = 2
 
 [node name="MainViewportArea" type="Control" parent="UIRoot/RootVBox/ContentRow"]


### PR DESCRIPTION
### Motivation
- Centralize UI visibility rules for side-panel modules so visibility logic for `User`, `Advanced` and `Debug` is consistent and persistable.
- Provide a persistent, user-facing toggle for advanced controls so power-users can opt-in without relying on build flags.
- Move debug-only UI (manual fixture test + fixture debug panel) under an explicit `Debug` module so debug controls are isolated and can be globally gated.

### Description
- Added a new visibility policy helper `peraviz/scripts/ui/ui_visibility_policy.gd` which exposes `MODULE_USER`, `MODULE_ADVANCED`, `MODULE_DEBUG` and provides persisted settings for `show_advanced_controls` and `force_debug_controls` as well as helper functions `is_module_visible(...)`, `is_advanced_controls_enabled()`, and setters.
- Updated `peraviz/test.tscn` to introduce explicit module containers `User`, `Advanced`, `Debug`, added a top-bar `ShowAdvancedControlsToggle` `CheckButton`, moved `ManualFixtureToggle` and `FixtureDebugPanel` under the `Debug` container, and placed `DMXControlsMount` under `User`.
- Updated `peraviz/scripts/load_scene.gd` to use the new node paths, preload and use the `UiVisibilityPolicy` script, wire the `ShowAdvancedControlsToggle` to persist and toggle the advanced controls preference, and expose the policy to `VisualSettingsWindow` via a `set_ui_visibility_policy` call when available; also added `_refresh_ui_module_visibility()` to apply the policy at runtime.
- Updated `peraviz/scripts/visual_settings_window.gd` to accept a visibility policy via `set_ui_visibility_policy(...)` and gate the debug gobo section with the central policy instead of calling `OS.is_debug_build()` directly.
- Kept changes localized and did not attempt a large refactor of `load_scene.gd` (noted as a follow-up extraction candidate to reduce hotspot size). Files added/modified: `peraviz/scripts/ui/ui_visibility_policy.gd`, `peraviz/test.tscn`, `peraviz/scripts/load_scene.gd`, `peraviz/scripts/visual_settings_window.gd`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (OK).  
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (OK).  
- Verified scene node path changes in `peraviz/test.tscn` and that `load_scene.gd` preloads and calls the policy where appropriate; no automated UI integration tests were run in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0b614eb7c83248bd7ecebcdd631fe)