### PR TITLE
Add StatusPresenter: topbar badges and toast feedback for scene/DMX status

### DIFF
--- a/peraviz/scripts/controllers/dmx_controller.gd
+++ b/peraviz/scripts/controllers/dmx_controller.gd
@@ -18,11 +18,17 @@ var _dmx_unbound_preview_label: Label
 var _dmx_controls_panel: PanelContainer
 var _dmx_fixture_runtime = null
 var _last_dmx_tick_msec: int = 0
+var _dmx_status_changed_callback: Callable
+var _dmx_start_failed_callback: Callable
 
 func configure(owner: Node, get_controls_host_callback: Callable, apply_dmx_controls_callback: Callable) -> void:
 	_owner = owner
 	_get_controls_host_callback = get_controls_host_callback
 	_apply_dmx_controls_callback = apply_dmx_controls_callback
+
+func set_status_callbacks(dmx_status_changed_callback: Callable, dmx_start_failed_callback: Callable) -> void:
+	_dmx_status_changed_callback = dmx_status_changed_callback
+	_dmx_start_failed_callback = dmx_start_failed_callback
 
 func setup_controls() -> void:
 	if _dmx_toggle_button != null and is_instance_valid(_dmx_toggle_button):
@@ -90,13 +96,14 @@ func setup_fixture_runtime(loader: Variant, scene_registry: SceneRegistry) -> vo
 	_dmx_fixture_runtime = DmxFixtureRuntimeScript.new()
 	_dmx_fixture_runtime.configure(loader, scene_registry)
 
-func refresh_fixture_bindings() -> void:
+func refresh_fixture_bindings() -> Dictionary:
 	if _dmx_fixture_runtime == null or _dmx_universe_offset_input == null:
-		return
+		return {}
 	var summary: Dictionary = _dmx_fixture_runtime.rebuild(int(_dmx_universe_offset_input.value))
 	var unbound_preview: PackedStringArray = summary.get("unbound_preview", PackedStringArray())
 	_dmx_unbound_preview_label.visible = unbound_preview.size() > 0
 	_dmx_unbound_preview_label.text = "Unbound fixtures:\n" + "\n".join(unbound_preview)
+	return summary
 
 func resolve_controls_host() -> Control:
 	if not _get_controls_host_callback.is_valid():
@@ -113,6 +120,7 @@ func _on_dmx_universe_offset_changed(_value: float) -> void:
 func _on_dmx_toggle_pressed() -> void:
 	if _dmx_receiver == null:
 		_dmx_toggle_button.button_pressed = false
+		_emit_dmx_status(false, false)
 		return
 	if _dmx_toggle_button.button_pressed:
 		_dmx_receiver.stop()
@@ -128,14 +136,18 @@ func _on_dmx_toggle_pressed() -> void:
 			if _dmx_receiver.has_method("get_last_error"):
 				startup_error = str(_dmx_receiver.get_last_error())
 			_dmx_toggle_button.tooltip_text = "DMX failed to start" if startup_error.is_empty() else "DMX failed to start: %s" % startup_error
+			_emit_dmx_start_failed(startup_error)
+			_emit_dmx_status(false, false)
 			return
 		_dmx_toggle_button.text = "DMX ON"
 		_dmx_toggle_button.tooltip_text = ""
+		_emit_dmx_status(true, false)
 	else:
 		_dmx_receiver.stop()
 		_dmx_toggle_button.text = "DMX OFF"
 		_update_dmx_toggle_color(false, false)
 		_refresh_dmx_monitor_window(false)
+		_emit_dmx_status(false, false)
 
 func _on_dmx_monitor_pressed() -> void:
 	if _dmx_receiver == null:
@@ -174,6 +186,7 @@ func _on_dmx_timer_timeout() -> void:
 	var receiving: bool = active_universes.size() > 0 and last_ms >= 0 and last_ms <= 2000
 	_update_dmx_toggle_color(true, receiving)
 	_refresh_dmx_monitor_window(true)
+	_emit_dmx_status(true, receiving)
 
 func _update_dmx_toggle_color(enabled: bool, receiving_signal: bool) -> void:
 	if _dmx_toggle_button == null:
@@ -187,3 +200,11 @@ func _refresh_dmx_monitor_window(running: bool) -> void:
 	if _dmx_monitor_window == null or not is_instance_valid(_dmx_monitor_window):
 		return
 	_dmx_monitor_window.refresh(running)
+
+func _emit_dmx_status(running: bool, receiving_signal: bool) -> void:
+	if _dmx_status_changed_callback.is_valid():
+		_dmx_status_changed_callback.call(running, receiving_signal)
+
+func _emit_dmx_start_failed(error_message: String) -> void:
+	if _dmx_start_failed_callback.is_valid():
+		_dmx_start_failed_callback.call(error_message)

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -35,6 +35,7 @@ extends Node3D
 @onready var app_shell: AppShell = $UIRoot/AppShell
 @onready var load_button: Button = $UIRoot/RootVBox/TopBar/TopBarMargin/TopBarRow/LoadButton
 @onready var dmx_controls_mount: VBoxContainer = $UIRoot/RootVBox/ContentRow/SidePanel/SidePanelMargin/ModulesVBox/User/DMXControlsMount
+@onready var topbar_row: HBoxContainer = $UIRoot/RootVBox/TopBar/TopBarMargin/TopBarRow
 
 var _loader := PeravizLoader.new()
 var _scene_registry := SceneRegistry.new()
@@ -133,6 +134,7 @@ const UiVisibilityPolicyScript = preload("res://scripts/ui/ui_visibility_policy.
 const UiControllerScript = preload("res://scripts/controllers/ui_controller.gd")
 const DmxControllerScript = preload("res://scripts/controllers/dmx_controller.gd")
 const FixtureDebugControllerScript = preload("res://scripts/controllers/fixture_debug_controller.gd")
+const StatusPresenterScript = preload("res://scripts/ui/status_presenter.gd")
 
 const SceneImportServiceScript = preload("res://scripts/scene_loading/scene_import_service.gd")
 const NodeFactoryScript = preload("res://scripts/scene_loading/node_factory.gd")
@@ -143,6 +145,7 @@ var _scene_import_service := SceneImportServiceScript.new()
 var _node_factory := NodeFactoryScript.new()
 var _fixture_binding_service := FixtureBindingServiceScript.new()
 var _debug_overlay_service := DebugOverlayServiceScript.new()
+var _status_presenter: StatusPresenter
 
 const DEBUG_TOGGLE_KEY: Key = KEY_C
 const MANUAL_TEST_FLAG: String = "--peraviz_manual_fixture_test"
@@ -278,8 +281,14 @@ func _ready() -> void:
 		Callable(self, "_resolve_dmx_controls_host"),
 		Callable(self, "_apply_dmx_controls_to_fixture")
 	)
+	_dmx_controller.set_status_callbacks(
+		Callable(self, "_on_dmx_status_changed"),
+		Callable(self, "_on_dmx_start_failed")
+	)
+	_status_presenter = StatusPresenterScript.new()
+	_status_presenter.configure(self, status_label, topbar_row, load_button, show_advanced_controls_toggle)
 	picker.access = FileDialog.ACCESS_FILESYSTEM
-	status_label.text = "Select a .mvr file"
+	_status_presenter.set_scene_state_idle()
 	_debug_coords_enabled = bool(ProjectSettings.get_setting("peraviz_debug_coords", false))
 	_debug_asset_cache_enabled = bool(ProjectSettings.get_setting("peraviz_debug_asset_cache", false))
 	var manual_fixture_test_enabled: bool = _read_manual_fixture_test_setting()
@@ -445,6 +454,9 @@ func _update_beam_renderer_mode(force_refresh: bool) -> void:
 
 	_active_beam_mode = requested_mode
 	_active_beam_renderer = requested_renderer
+	if _status_presenter != null:
+		var render_mode_label: String = "Volumetric" if _active_beam_mode == BEAM_RENDER_MODE_VOLUMETRIC else "Legacy"
+		_status_presenter.set_render_mode_badge(render_mode_label)
 	for renderer in _beam_renderers.values():
 		if renderer is BeamRendererBase:
 			renderer.configure(camera, _visual_settings)
@@ -501,13 +513,14 @@ func _on_visual_settings_changed(settings: Dictionary) -> void:
 	_apply_visual_settings(settings)
 
 func _on_file_selected(path: String) -> void:
+	if _status_presenter != null:
+		_status_presenter.set_scene_state_loading(path)
 	_clear_scene()
-	_scene_import_service.import_scene(
+	var import_result: Dictionary = _scene_import_service.import_scene(
 		path,
 		_loader,
 		_node_factory,
 		_fixture_binding_service,
-		status_label,
 		_asset_cache,
 		proxies_root,
 		_node_index,
@@ -525,6 +538,12 @@ func _on_file_selected(path: String) -> void:
 		_debug_asset_cache_enabled,
 		_scene_registry
 	)
+	if _status_presenter != null:
+		if bool(import_result.get("ok", false)):
+			_status_presenter.set_scene_state_loaded(int(import_result.get("node_count", 0)))
+		else:
+			var error_message: String = str(import_result.get("error", "unknown error"))
+			_status_presenter.set_scene_state_load_error(error_message)
 
 func _on_manual_fixture_toggle(enabled: bool) -> void:
 	ProjectSettings.set_setting("peraviz_manual_fixture_test", enabled)
@@ -546,6 +565,7 @@ func _refresh_ui_module_visibility() -> void:
 
 func _unhandled_input(event: InputEvent) -> void:
 	_sync_selection_state("input")
+	_update_selected_fixture_badge()
 
 	if event is InputEventKey and event.pressed and not event.echo and event.keycode == KEY_F:
 		_focus_loaded_scene()
@@ -2206,8 +2226,32 @@ func _setup_dmx_fixture_runtime() -> void:
 	_dmx_controller.setup_fixture_runtime(_loader, _scene_registry)
 
 func _refresh_dmx_fixture_bindings() -> void:
-	_dmx_controller.refresh_fixture_bindings()
+	var summary: Dictionary = _dmx_controller.refresh_fixture_bindings()
+	var unbound_count: int = int(summary.get("unbound", 0))
+	if _status_presenter != null and unbound_count > 0:
+		_status_presenter.set_scene_state_warning_unbound(unbound_count)
 
 func _exit_tree() -> void:
 	if _dmx_controller != null:
 		_dmx_controller.exit_tree()
+
+func _process(_delta: float) -> void:
+	_update_selected_fixture_badge()
+
+func _update_selected_fixture_badge() -> void:
+	if _status_presenter == null or _fixture_debug_controller == null:
+		return
+	_status_presenter.set_selected_fixture_badge(_fixture_debug_controller.get_selected_fixture_uuid())
+
+func _on_dmx_status_changed(running: bool, receiving_signal: bool) -> void:
+	if _status_presenter == null:
+		return
+	_status_presenter.set_dmx_badge(running, receiving_signal)
+
+func _on_dmx_start_failed(error_message: String) -> void:
+	if _status_presenter == null:
+		return
+	var message: String = "DMX start failed"
+	if not error_message.is_empty():
+		message = "%s (%s)" % [message, error_message]
+	_status_presenter.show_toast(message)

--- a/peraviz/scripts/scene_loading/scene_import_service.gd
+++ b/peraviz/scripts/scene_loading/scene_import_service.gd
@@ -30,7 +30,6 @@ func import_scene(path: String,
 		loader: PeravizLoader,
 		node_factory: NodeFactory,
 		fixture_binding_service: FixtureBindingService,
-		status_label: Label,
 		asset_cache: PeravizRuntimeAssetCache,
 		proxies_root: Node3D,
 		node_index: Dictionary,
@@ -46,10 +45,28 @@ func import_scene(path: String,
 		set_has_loaded_bounds: Callable,
 		debug_coords_enabled: bool,
 		debug_asset_cache_enabled: bool,
-		scene_registry: SceneRegistry) -> void:
+		scene_registry: SceneRegistry) -> Dictionary:
+	if path.is_empty():
+		return {
+			"ok": false,
+			"error": "empty file path",
+			"node_count": 0,
+		}
+	if not FileAccess.file_exists(path):
+		return {
+			"ok": false,
+			"error": "file does not exist",
+			"node_count": 0,
+		}
 	var native_path: String = ProjectSettings.globalize_path(path)
 	var peraviz_debug_baseline: bool = bool(ProjectSettings.get_setting("peraviz_debug_baseline", false))
 	var nodes: Array = loader.load_mvr(native_path, peraviz_debug_baseline, debug_coords_enabled)
+	if nodes.is_empty():
+		return {
+			"ok": false,
+			"error": "MVR returned no nodes",
+			"node_count": 0,
+		}
 	print("[Peraviz] Loaded render nodes: ", nodes.size(), " baseline_debug=", peraviz_debug_baseline, " coords_debug=", debug_coords_enabled)
 	set_has_loaded_bounds.call(false)
 
@@ -62,9 +79,13 @@ func import_scene(path: String,
 	focus_loaded_scene.call()
 	if debug_asset_cache_enabled:
 		_print_asset_cache_summary(asset_cache)
-	status_label.text = "Nodes: %d (press F to focus, C debug coords)" % nodes.size()
 	update_debug_legend.call()
 	refresh_emitter_light_scalars.call()
+	return {
+		"ok": true,
+		"error": "",
+		"node_count": nodes.size(),
+	}
 
 func _print_asset_cache_summary(asset_cache: PeravizRuntimeAssetCache) -> void:
 	var cache_summary: Dictionary = asset_cache.debug_summary()

--- a/peraviz/scripts/ui/status_presenter.gd
+++ b/peraviz/scripts/ui/status_presenter.gd
@@ -1,7 +1,7 @@
 extends RefCounted
 class_name StatusPresenter
 
-enum SceneState {
+enum PresenterState {
 	IDLE,
 	LOADING,
 	LOADED,
@@ -32,23 +32,23 @@ func configure(owner: Node,
 	set_render_mode_badge("Volumetric")
 
 func set_scene_state_idle() -> void:
-	_set_status(SceneState.IDLE, "Idle · Load MVR")
+	_set_status(PresenterState.IDLE, "Idle · Load MVR")
 	_set_badge("MVR", "Idle")
 
 func set_scene_state_loading(path: String) -> void:
-	_set_status(SceneState.LOADING, "Loading · %s" % path.get_file())
+	_set_status(PresenterState.LOADING, "Loading · %s" % path.get_file())
 	_set_badge("MVR", "Loading")
 
 func set_scene_state_loaded(node_count: int) -> void:
-	_set_status(SceneState.LOADED, "Loaded · %d nodes" % node_count)
+	_set_status(PresenterState.LOADED, "Loaded · %d nodes" % node_count)
 	_set_badge("MVR", "Loaded")
 
 func set_scene_state_warning_unbound(unbound_count: int) -> void:
-	_set_status(SceneState.WARNING, "Warning · %d fixtures unbound" % unbound_count)
+	_set_status(PresenterState.WARNING, "Warning · %d fixtures unbound" % unbound_count)
 	_set_badge("MVR", "Warning")
 
 func set_scene_state_load_error(message: String) -> void:
-	_set_status(SceneState.WARNING, "Load error")
+	_set_status(PresenterState.WARNING, "Load error")
 	show_toast("Load failed: %s" % message)
 	_set_badge("MVR", "Error")
 
@@ -77,13 +77,13 @@ func _set_status(state: int, text: String) -> void:
 		return
 	_status_label.text = text
 	match state:
-		SceneState.IDLE:
+		PresenterState.IDLE:
 			_status_label.modulate = Color(0.8, 0.82, 0.86)
-		SceneState.LOADING:
+		PresenterState.LOADING:
 			_status_label.modulate = Color(0.95, 0.85, 0.45)
-		SceneState.LOADED:
+		PresenterState.LOADED:
 			_status_label.modulate = Color(0.7, 0.95, 0.7)
-		SceneState.WARNING:
+		PresenterState.WARNING:
 			_status_label.modulate = Color(1.0, 0.75, 0.45)
 
 func _ensure_badges(load_button: Button, show_advanced_controls_toggle: CheckButton) -> void:

--- a/peraviz/scripts/ui/status_presenter.gd
+++ b/peraviz/scripts/ui/status_presenter.gd
@@ -1,0 +1,171 @@
+extends RefCounted
+class_name StatusPresenter
+
+enum SceneState {
+	IDLE,
+	LOADING,
+	LOADED,
+	WARNING,
+}
+
+const TOAST_DURATION_SEC: float = 2.6
+
+var _status_label: Label
+var _topbar_row: HBoxContainer
+var _badge_row: HBoxContainer
+var _badge_labels: Dictionary = {}
+var _toast_label: Label
+var _toast_timer: Timer
+
+func configure(owner: Node,
+		status_label: Label,
+		topbar_row: HBoxContainer,
+		load_button: Button,
+		show_advanced_controls_toggle: CheckButton) -> void:
+	_status_label = status_label
+	_topbar_row = topbar_row
+	_ensure_badges(load_button, show_advanced_controls_toggle)
+	_ensure_toast(owner)
+	set_scene_state_idle()
+	set_dmx_badge(false, false)
+	set_selected_fixture_badge("")
+	set_render_mode_badge("Volumetric")
+
+func set_scene_state_idle() -> void:
+	_set_status(SceneState.IDLE, "Idle · Load MVR")
+	_set_badge("MVR", "Idle")
+
+func set_scene_state_loading(path: String) -> void:
+	_set_status(SceneState.LOADING, "Loading · %s" % path.get_file())
+	_set_badge("MVR", "Loading")
+
+func set_scene_state_loaded(node_count: int) -> void:
+	_set_status(SceneState.LOADED, "Loaded · %d nodes" % node_count)
+	_set_badge("MVR", "Loaded")
+
+func set_scene_state_warning_unbound(unbound_count: int) -> void:
+	_set_status(SceneState.WARNING, "Warning · %d fixtures unbound" % unbound_count)
+	_set_badge("MVR", "Warning")
+
+func set_scene_state_load_error(message: String) -> void:
+	_set_status(SceneState.WARNING, "Load error")
+	show_toast("Load failed: %s" % message)
+	_set_badge("MVR", "Error")
+
+func set_dmx_badge(is_running: bool, receiving_signal: bool) -> void:
+	if not is_running:
+		_set_badge("DMX", "OFF")
+		return
+	_set_badge("DMX", "Connected" if receiving_signal else "No signal")
+
+func set_selected_fixture_badge(fixture_uuid: String) -> void:
+	_set_badge("Selected Fixture", "None" if fixture_uuid.is_empty() else fixture_uuid)
+
+func set_render_mode_badge(render_mode_label: String) -> void:
+	_set_badge("Render Mode", render_mode_label)
+
+func show_toast(message: String) -> void:
+	if _toast_label == null:
+		return
+	_toast_label.text = message
+	_toast_label.visible = true
+	if _toast_timer != null:
+		_toast_timer.start(TOAST_DURATION_SEC)
+
+func _set_status(state: int, text: String) -> void:
+	if _status_label == null:
+		return
+	_status_label.text = text
+	match state:
+		SceneState.IDLE:
+			_status_label.modulate = Color(0.8, 0.82, 0.86)
+		SceneState.LOADING:
+			_status_label.modulate = Color(0.95, 0.85, 0.45)
+		SceneState.LOADED:
+			_status_label.modulate = Color(0.7, 0.95, 0.7)
+		SceneState.WARNING:
+			_status_label.modulate = Color(1.0, 0.75, 0.45)
+
+func _ensure_badges(load_button: Button, show_advanced_controls_toggle: CheckButton) -> void:
+	if _topbar_row == null:
+		return
+	_badge_row = HBoxContainer.new()
+	_badge_row.name = "StatusBadges"
+	_badge_row.alignment = BoxContainer.ALIGNMENT_END
+	_badge_row.add_theme_constant_override("separation", 6)
+
+	var top_spacer: Control = _topbar_row.get_node_or_null("TopSpacer") as Control
+	if top_spacer != null:
+		_topbar_row.move_child(top_spacer, _topbar_row.get_child_count() - 1)
+	if _status_label != null:
+		_topbar_row.move_child(_status_label, _topbar_row.get_child_count() - 1)
+
+	if _status_label != null:
+		_topbar_row.add_child(_badge_row)
+		_topbar_row.move_child(_badge_row, _status_label.get_index())
+	else:
+		_topbar_row.add_child(_badge_row)
+
+	_create_badge("MVR")
+	_create_badge("DMX")
+	_create_badge("Selected Fixture")
+	_create_badge("Render Mode")
+
+	if load_button != null:
+		load_button.tooltip_text = "Load an MVR file"
+	if show_advanced_controls_toggle != null:
+		show_advanced_controls_toggle.tooltip_text = "Toggle advanced controls"
+
+func _create_badge(name: String) -> void:
+	if _badge_row == null:
+		return
+	var badge := Label.new()
+	badge.name = "%sBadge" % name.replace(" ", "")
+	badge.text = "%s: --" % name
+	badge.clip_text = true
+	badge.custom_minimum_size = Vector2(112, 0)
+	badge.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+	badge.add_theme_font_size_override("font_size", 11)
+	badge.modulate = Color(0.83, 0.86, 0.9)
+	_badge_row.add_child(badge)
+	_badge_labels[name] = badge
+
+func _set_badge(name: String, value: String) -> void:
+	if not _badge_labels.has(name):
+		return
+	var badge: Label = _badge_labels[name]
+	badge.text = "%s: %s" % [name, value]
+
+func _ensure_toast(owner: Node) -> void:
+	if owner == null:
+		return
+	var root_control: Control = owner.get_node_or_null("UIRoot") as Control
+	if root_control == null:
+		return
+	_toast_label = Label.new()
+	_toast_label.name = "ToastLabel"
+	_toast_label.visible = false
+	_toast_label.z_index = 99
+	_toast_label.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_toast_label.anchor_left = 1.0
+	_toast_label.anchor_top = 0.0
+	_toast_label.anchor_right = 1.0
+	_toast_label.anchor_bottom = 0.0
+	_toast_label.offset_left = -360.0
+	_toast_label.offset_right = -16.0
+	_toast_label.offset_top = 44.0
+	_toast_label.offset_bottom = 74.0
+	_toast_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+	_toast_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	_toast_label.modulate = Color(1.0, 0.85, 0.62)
+	_toast_label.add_theme_font_size_override("font_size", 12)
+	root_control.add_child(_toast_label)
+
+	_toast_timer = Timer.new()
+	_toast_timer.one_shot = true
+	_toast_timer.timeout.connect(_on_toast_timeout)
+	owner.add_child(_toast_timer)
+
+func _on_toast_timeout() -> void:
+	if _toast_label != null:
+		_toast_label.visible = false

--- a/peraviz/scripts/ui/status_presenter.gd.uid
+++ b/peraviz/scripts/ui/status_presenter.gd.uid
@@ -1,0 +1,1 @@
+uid://bqquxvwygxo5r


### PR DESCRIPTION
### Motivation
- Centralize UI status messaging and remove scattered direct writes to `status_label.text` so scene and DMX state are presented consistently. 
- Surface small, persistent indicators (badges) for MVR, DMX, selected fixture and render mode in the topbar to improve at-a-glance visibility. 
- Provide brief non-intrusive toast notifications for load failures and DMX start failures so errors are visible without modal dialogs.

### Description
- Added a new UI helper `peraviz/scripts/ui/status_presenter.gd` which implements an explicit scene state model (`Idle`, `Loading`, `Loaded`, `Warning`), topbar badges (`MVR`, `DMX`, `Selected Fixture`, `Render Mode`) and toast support. 
- Replaced direct `status_label.text` usage in `peraviz/scripts/load_scene.gd` with a `StatusPresenter` instance and wired it to scene import lifecycle, render mode changes, fixture selection and DMX status callbacks. 
- Updated `peraviz/scripts/scene_loading/scene_import_service.gd` to return a structured import result (`ok`, `error`, `node_count`) and added basic path/file/nodes-empty guards so the caller can present errors via the presenter. 
- Extended `peraviz/scripts/controllers/dmx_controller.gd` to accept status/error callbacks and return binding summaries from `refresh_fixture_bindings()` so the UI can show DMX connection state and warn about unbound fixtures; left DMX runtime logic unchanged. 
- Architectural note: `peraviz/scripts/load_scene.gd` is already large (above the soft guardrail), so this PR keeps the new UI responsibility in `status_presenter.gd`; the next recommended split is extracting DMX-status orchestration into a small coordinator (e.g. `scripts/controllers/status_bridge_controller.gd`) to further reduce `load_scene.gd` responsibilities.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed. 
- No new automated unit tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0c15fe0d48324a722eac53f0d9d71)