### PR TITLE
Add DMX Quick Panel (sidebar) and Technical Monitor active-channel filter

### DIFF
--- a/peraviz/scripts/controllers/dmx_controller.gd
+++ b/peraviz/scripts/controllers/dmx_controller.gd
@@ -3,6 +3,7 @@ class_name DmxController
 
 const DmxMonitorWindowScript = preload("res://scripts/dmx_monitor_window.gd")
 const DmxFixtureRuntimeScript = preload("res://scripts/dmx_fixture_runtime.gd")
+const DmxQuickPanelScript = preload("res://scripts/ui/dmx_quick_panel.gd")
 
 var _owner: Node
 var _get_controls_host_callback: Callable
@@ -12,6 +13,7 @@ var _dmx_receiver = null
 var _dmx_toggle_button: Button
 var _dmx_monitor_button: Button
 var _dmx_monitor_window: Window
+var _dmx_quick_panel: DmxQuickPanel
 var _dmx_timer: Timer
 var _dmx_universe_offset_input: SpinBox
 var _dmx_unbound_preview_label: Label
@@ -20,6 +22,7 @@ var _dmx_fixture_runtime = null
 var _last_dmx_tick_msec: int = 0
 var _dmx_status_changed_callback: Callable
 var _dmx_start_failed_callback: Callable
+var _fixture_binding_summary: Dictionary = {}
 
 func configure(owner: Node, get_controls_host_callback: Callable, apply_dmx_controls_callback: Callable) -> void:
 	_owner = owner
@@ -60,7 +63,7 @@ func setup_controls() -> void:
 	_update_dmx_toggle_color(false, false)
 
 	_dmx_monitor_button = Button.new()
-	_dmx_monitor_button.text = "DMX Monitor"
+	_dmx_monitor_button.text = "Open Technical Monitor"
 	_dmx_monitor_button.disabled = true
 	controls_row.add_child(_dmx_monitor_button)
 	_dmx_monitor_button.pressed.connect(_on_dmx_monitor_pressed)
@@ -79,6 +82,11 @@ func setup_controls() -> void:
 	_dmx_unbound_preview_label.visible = false
 	controls_vbox.add_child(_dmx_unbound_preview_label)
 
+	_dmx_quick_panel = DmxQuickPanelScript.new()
+	controls_vbox.add_child(_dmx_quick_panel)
+	_dmx_quick_panel.open_technical_monitor_requested.connect(_on_dmx_monitor_pressed)
+	_dmx_quick_panel.set_monitor_available(false)
+
 	_dmx_timer = Timer.new()
 	_dmx_timer.wait_time = 0.03
 	_dmx_timer.autostart = true
@@ -88,9 +96,13 @@ func setup_controls() -> void:
 	if ClassDB.class_exists("PeravizDmxReceiver"):
 		_dmx_receiver = ClassDB.instantiate("PeravizDmxReceiver")
 		_dmx_monitor_button.disabled = false
+		_dmx_quick_panel.set_monitor_available(true)
 	else:
 		_dmx_toggle_button.disabled = true
 		_dmx_toggle_button.tooltip_text = "DMX unavailable (build without PERAVIZ_ENABLE_DMX)"
+		_dmx_quick_panel.set_monitor_available(false)
+
+	_refresh_dmx_quick_panel(false, false, PackedInt32Array(), -1)
 
 func setup_fixture_runtime(loader: Variant, scene_registry: SceneRegistry) -> void:
 	_dmx_fixture_runtime = DmxFixtureRuntimeScript.new()
@@ -100,9 +112,11 @@ func refresh_fixture_bindings() -> Dictionary:
 	if _dmx_fixture_runtime == null or _dmx_universe_offset_input == null:
 		return {}
 	var summary: Dictionary = _dmx_fixture_runtime.rebuild(int(_dmx_universe_offset_input.value))
+	_fixture_binding_summary = summary
 	var unbound_preview: PackedStringArray = summary.get("unbound_preview", PackedStringArray())
 	_dmx_unbound_preview_label.visible = unbound_preview.size() > 0
 	_dmx_unbound_preview_label.text = "Unbound fixtures:\n" + "\n".join(unbound_preview)
+	_refresh_dmx_quick_panel(false, false, PackedInt32Array(), -1)
 	return summary
 
 func resolve_controls_host() -> Control:
@@ -137,6 +151,7 @@ func _on_dmx_toggle_pressed() -> void:
 				startup_error = str(_dmx_receiver.get_last_error())
 			_dmx_toggle_button.tooltip_text = "DMX failed to start" if startup_error.is_empty() else "DMX failed to start: %s" % startup_error
 			_emit_dmx_start_failed(startup_error)
+			_refresh_dmx_quick_panel(false, false, PackedInt32Array(), -1)
 			_emit_dmx_status(false, false)
 			return
 		_dmx_toggle_button.text = "DMX ON"
@@ -147,6 +162,7 @@ func _on_dmx_toggle_pressed() -> void:
 		_dmx_toggle_button.text = "DMX OFF"
 		_update_dmx_toggle_color(false, false)
 		_refresh_dmx_monitor_window(false)
+		_refresh_dmx_quick_panel(false, false, PackedInt32Array(), -1)
 		_emit_dmx_status(false, false)
 
 func _on_dmx_monitor_pressed() -> void:
@@ -166,6 +182,7 @@ func _on_dmx_timer_timeout() -> void:
 		if _dmx_toggle_button != null and not _dmx_toggle_button.button_pressed:
 			_update_dmx_toggle_color(false, false)
 		_refresh_dmx_monitor_window(false)
+		_refresh_dmx_quick_panel(false, false, PackedInt32Array(), -1)
 		return
 
 	var now_msec: int = Time.get_ticks_msec()
@@ -186,6 +203,7 @@ func _on_dmx_timer_timeout() -> void:
 	var receiving: bool = active_universes.size() > 0 and last_ms >= 0 and last_ms <= 2000
 	_update_dmx_toggle_color(true, receiving)
 	_refresh_dmx_monitor_window(true)
+	_refresh_dmx_quick_panel(true, receiving, active_universes, last_ms)
 	_emit_dmx_status(true, receiving)
 
 func _update_dmx_toggle_color(enabled: bool, receiving_signal: bool) -> void:
@@ -200,6 +218,13 @@ func _refresh_dmx_monitor_window(running: bool) -> void:
 	if _dmx_monitor_window == null or not is_instance_valid(_dmx_monitor_window):
 		return
 	_dmx_monitor_window.refresh(running)
+
+func _refresh_dmx_quick_panel(running: bool, receiving_signal: bool, active_universes: PackedInt32Array, last_packet_ms: int) -> void:
+	if _dmx_quick_panel == null or not is_instance_valid(_dmx_quick_panel):
+		return
+	var linked_fixtures: int = int(_fixture_binding_summary.get("bound", 0))
+	var unlinked_fixtures: int = int(_fixture_binding_summary.get("unbound", 0))
+	_dmx_quick_panel.refresh(running, receiving_signal, active_universes, last_packet_ms, linked_fixtures, unlinked_fixtures)
 
 func _emit_dmx_status(running: bool, receiving_signal: bool) -> void:
 	if _dmx_status_changed_callback.is_valid():

--- a/peraviz/scripts/dmx_monitor_window.gd
+++ b/peraviz/scripts/dmx_monitor_window.gd
@@ -9,12 +9,14 @@ var _selected_universe: int = -1
 var _universe_buttons: Dictionary = {}
 var _channel_panels: Array[PanelContainer] = []
 var _channel_labels: Array[Label] = []
+var _channel_values: PackedInt32Array = PackedInt32Array()
+var _show_only_active_channels: bool = false
 
 var _state_label: Label
 var _universes_flow: FlowContainer
 
 func _init() -> void:
-	title = "DMX Monitor"
+	title = "Technical Monitor"
 	size = Vector2i(1040, 680)
 	unresizable = false
 
@@ -31,6 +33,15 @@ func _ready() -> void:
 	_state_label = Label.new()
 	_state_label.text = "DMX monitor inactive"
 	root.add_child(_state_label)
+
+	var filters_row: HBoxContainer = HBoxContainer.new()
+	filters_row.add_theme_constant_override("separation", 8)
+	root.add_child(filters_row)
+
+	var active_channels_toggle: CheckBox = CheckBox.new()
+	active_channels_toggle.text = "Show only active channels"
+	active_channels_toggle.toggled.connect(_on_active_channels_toggled)
+	filters_row.add_child(active_channels_toggle)
 
 	var universe_scroll: ScrollContainer = ScrollContainer.new()
 	universe_scroll.custom_minimum_size = Vector2(0, 100)
@@ -70,6 +81,7 @@ func _ready() -> void:
 
 		_channel_panels.append(panel)
 		_channel_labels.append(label)
+		_channel_values.append(0)
 
 		_update_channel_cell(channel_idx, 0)
 
@@ -152,7 +164,15 @@ func _update_channel_cell(channel_idx: int, channel_value: int) -> void:
 
 	_channel_panels[channel_idx].add_theme_stylebox_override("panel", style)
 	_channel_labels[channel_idx].text = "%03d:%03d" % [channel_idx + 1, channel_value]
+	_channel_values[channel_idx] = channel_value
+	_channel_panels[channel_idx].visible = (channel_value > 0) if _show_only_active_channels else true
 
 
 func _on_close_requested() -> void:
 	hide()
+
+func _on_active_channels_toggled(enabled: bool) -> void:
+	_show_only_active_channels = enabled
+	for channel_idx in range(CHANNEL_COUNT):
+		var channel_value: int = int(_channel_values[channel_idx])
+		_channel_panels[channel_idx].visible = (channel_value > 0) if _show_only_active_channels else true

--- a/peraviz/scripts/ui/app_shell.gd
+++ b/peraviz/scripts/ui/app_shell.gd
@@ -33,15 +33,15 @@ func is_side_panel_open() -> bool:
 func get_modules_container() -> Control:
 	return _modules_container
 
-func register_section(name: StringName, section_node: CanvasItem) -> void:
-	_sections[name] = section_node
+func register_section(section_id: StringName, section_node: CanvasItem) -> void:
+	_sections[section_id] = section_node
 	if _active_section == &"":
-		set_active_section(name)
+		set_active_section(section_id)
 	else:
-		section_node.visible = (name == _active_section)
+		section_node.visible = (section_id == _active_section)
 
-func set_active_section(name: StringName) -> void:
-	_active_section = name
+func set_active_section(section_id: StringName) -> void:
+	_active_section = section_id
 	for section_name in _sections.keys():
 		var section_node: CanvasItem = _sections[section_name]
 		if section_node != null:

--- a/peraviz/scripts/ui/dmx_quick_panel.gd
+++ b/peraviz/scripts/ui/dmx_quick_panel.gd
@@ -1,0 +1,96 @@
+extends PanelContainer
+
+class_name DmxQuickPanel
+
+signal open_technical_monitor_requested
+
+var _status_value_label: Label
+var _universes_value_label: Label
+var _last_packet_value_label: Label
+var _fixtures_value_label: Label
+var _open_monitor_button: Button
+var _monitor_available: bool = false
+var _running: bool = false
+var _receiving_signal: bool = false
+var _active_universes: PackedInt32Array = PackedInt32Array()
+var _last_packet_ms: int = -1
+var _linked_fixtures: int = 0
+var _unlinked_fixtures: int = 0
+
+func _ready() -> void:
+	var margin := MarginContainer.new()
+	margin.add_theme_constant_override("margin_left", 8)
+	margin.add_theme_constant_override("margin_top", 8)
+	margin.add_theme_constant_override("margin_right", 8)
+	margin.add_theme_constant_override("margin_bottom", 8)
+	add_child(margin)
+
+	var layout := VBoxContainer.new()
+	layout.add_theme_constant_override("separation", 6)
+	margin.add_child(layout)
+
+	var title := Label.new()
+	title.text = "DMX Quick Panel"
+	layout.add_child(title)
+
+	_status_value_label = _add_metric_row(layout, "State", "OFF")
+	_universes_value_label = _add_metric_row(layout, "Active universes", "0")
+	_last_packet_value_label = _add_metric_row(layout, "Last packet", "n/a")
+	_fixtures_value_label = _add_metric_row(layout, "Fixtures", "0 linked / 0 unlinked")
+
+	_open_monitor_button = Button.new()
+	_open_monitor_button.text = "Open Technical Monitor"
+	_open_monitor_button.pressed.connect(_on_open_monitor_pressed)
+	layout.add_child(_open_monitor_button)
+	_apply_state()
+
+func set_monitor_available(available: bool) -> void:
+	_monitor_available = available
+	_apply_state()
+
+func refresh(running: bool, receiving_signal: bool, active_universes: PackedInt32Array, last_packet_ms: int, linked_fixtures: int, unlinked_fixtures: int) -> void:
+	_running = running
+	_receiving_signal = receiving_signal
+	_active_universes = active_universes
+	_last_packet_ms = last_packet_ms
+	_linked_fixtures = max(linked_fixtures, 0)
+	_unlinked_fixtures = max(unlinked_fixtures, 0)
+	_apply_state()
+
+func _add_metric_row(parent: VBoxContainer, label_text: String, initial_value: String) -> Label:
+	var row := HBoxContainer.new()
+	row.add_theme_constant_override("separation", 6)
+	parent.add_child(row)
+	var label := Label.new()
+	label.text = "%s:" % label_text
+	row.add_child(label)
+	var value := Label.new()
+	value.text = initial_value
+	row.add_child(value)
+	return value
+
+func _format_universes(active_universes: PackedInt32Array) -> String:
+	if active_universes.is_empty():
+		return "0"
+	var values := PackedStringArray()
+	for universe in active_universes:
+		values.append(str(universe))
+	return "%d (%s)" % [active_universes.size(), ", ".join(values)]
+
+func _on_open_monitor_pressed() -> void:
+	emit_signal("open_technical_monitor_requested")
+
+func _apply_state() -> void:
+	if _status_value_label == null:
+		return
+	_open_monitor_button.disabled = not _monitor_available
+	if not _monitor_available:
+		_status_value_label.text = "Unavailable"
+	elif not _running:
+		_status_value_label.text = "OFF"
+	else:
+		_status_value_label.text = "ON" if _receiving_signal else "ON (no signal)"
+
+	_universes_value_label.text = _format_universes(_active_universes)
+	_last_packet_value_label.text = "%d ms" % _last_packet_ms if _last_packet_ms >= 0 else "n/a"
+	_fixtures_value_label.text = "%d linked / %d unlinked" % [_linked_fixtures, _unlinked_fixtures]

--- a/peraviz/scripts/ui/dmx_quick_panel.gd.uid
+++ b/peraviz/scripts/ui/dmx_quick_panel.gd.uid
@@ -1,0 +1,1 @@
+uid://k2lecuagritm


### PR DESCRIPTION
### Motivation
- Keep the existing `dmx_monitor_window.gd` as the full technical monitor while adding a compact, embeddable DMX summary for the sidebar so users can see DMX state at a glance.
- Provide quick access to key runtime metrics (ON/OFF state, active universes, last packet ms, linked/unlinked fixture counts) without opening the full monitor.
- Reduce visual noise in the Technical Monitor by adding an optional filter to hide zero-value channels.

### Description
- Added a new `DmxQuickPanel` in `peraviz/scripts/ui/dmx_quick_panel.gd` that exposes a compact sidebar view with state, active universes, last packet latency, linked/unlinked fixture counts, and an `open_technical_monitor_requested` signal linked to an "Open Technical Monitor" button.
- Wired `DmxQuickPanel` into `peraviz/scripts/controllers/dmx_controller.gd` (preload, creation, availability state, and periodic `refresh` updates), and added `_fixture_binding_summary` bookkeeping so the quick panel shows linked/unlinked counts.
- Kept the full monitor in `peraviz/scripts/dmx_monitor_window.gd` (renamed window title to "Technical Monitor") and added an active-channel filter toggle (`Show only active channels`) with `_channel_values` tracking and visibility logic to hide channels that are zero when enabled.
- UI integration preserves the existing control-row button (now labeled `Open Technical Monitor`) and also provides the same access from the quick panel while keeping the new quick-summary responsibility isolated in a new file.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0c43783c883249c71c031bc6a6ad7)