### PR TITLE
Persist Peraviz main-scene UI preferences with safe defaults

### DIFF
--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -135,6 +135,7 @@ const UiControllerScript = preload("res://scripts/controllers/ui_controller.gd")
 const DmxControllerScript = preload("res://scripts/controllers/dmx_controller.gd")
 const FixtureDebugControllerScript = preload("res://scripts/controllers/fixture_debug_controller.gd")
 const StatusPresenterScript = preload("res://scripts/ui/status_presenter.gd")
+const UserPreferencesScript = preload("res://scripts/ui/user_preferences.gd")
 
 const SceneImportServiceScript = preload("res://scripts/scene_loading/scene_import_service.gd")
 const NodeFactoryScript = preload("res://scripts/scene_loading/node_factory.gd")
@@ -146,6 +147,7 @@ var _node_factory := NodeFactoryScript.new()
 var _fixture_binding_service := FixtureBindingServiceScript.new()
 var _debug_overlay_service := DebugOverlayServiceScript.new()
 var _status_presenter: StatusPresenter
+var _user_preferences: UserPreferences
 
 const DEBUG_TOGGLE_KEY: Key = KEY_C
 const MANUAL_TEST_FLAG: String = "--peraviz_manual_fixture_test"
@@ -293,7 +295,7 @@ func _ready() -> void:
 	_debug_asset_cache_enabled = bool(ProjectSettings.get_setting("peraviz_debug_asset_cache", false))
 	var manual_fixture_test_enabled: bool = _read_manual_fixture_test_setting()
 	_fixture_debug_controller.set_manual_fixture_test_enabled(manual_fixture_test_enabled)
-	show_advanced_controls_toggle.button_pressed = UiVisibilityPolicyScript.is_advanced_controls_enabled()
+	_load_user_preferences()
 	_refresh_ui_module_visibility()
 	_asset_cache.configure_debug_logging(_debug_asset_cache_enabled, 100)
 	_ensure_debug_gizmo_root()
@@ -311,6 +313,7 @@ func _ready() -> void:
 		visual_settings_window.call("configure", _visual_settings)
 		if visual_settings_window.has_method("set_ui_visibility_policy"):
 			visual_settings_window.call("set_ui_visibility_policy", UiVisibilityPolicyScript)
+		_apply_visual_settings_preferences_to_window()
 	else:
 		push_warning("VisualSettingsWindow is not ready for configure(); initial visual settings not pushed.")
 	_apply_visual_settings(_visual_settings)
@@ -545,21 +548,60 @@ func _on_file_selected(path: String) -> void:
 			var error_message: String = str(import_result.get("error", "unknown error"))
 			_status_presenter.set_scene_state_load_error(error_message)
 
+func _load_user_preferences() -> void:
+	_user_preferences = UserPreferencesScript.new()
+	_user_preferences.load_from_disk()
+	UiVisibilityPolicyScript.set_advanced_controls_enabled(_user_preferences.advanced_mode)
+	if show_advanced_controls_toggle != null:
+		show_advanced_controls_toggle.button_pressed = _user_preferences.advanced_mode
+	if app_shell != null:
+		app_shell.set_side_panel_open(_user_preferences.sidebar_open)
+
+func _apply_visual_settings_preferences_to_window() -> void:
+	if _user_preferences == null or visual_settings_window == null:
+		return
+	if visual_settings_window.has_method("set_advanced_mode_enabled"):
+		visual_settings_window.call("set_advanced_mode_enabled", _user_preferences.advanced_mode)
+	if visual_settings_window.has_method("set_active_tab_index"):
+		visual_settings_window.call("set_active_tab_index", _user_preferences.last_settings_tab)
+
+func _save_user_preferences() -> void:
+	if _user_preferences == null:
+		return
+	if app_shell != null:
+		_user_preferences.sidebar_open = app_shell.is_side_panel_open()
+	_user_preferences.advanced_mode = UiVisibilityPolicyScript.is_advanced_controls_enabled()
+	if visual_settings_window != null and visual_settings_window.has_method("get_active_tab_index"):
+		_user_preferences.last_settings_tab = int(visual_settings_window.call("get_active_tab_index"))
+	_user_preferences.set_module_visible(UiVisibilityPolicyScript.MODULE_USER, user_module != null and user_module.visible)
+	_user_preferences.set_module_visible(UiVisibilityPolicyScript.MODULE_ADVANCED, advanced_module != null and advanced_module.visible)
+	_user_preferences.set_module_visible(UiVisibilityPolicyScript.MODULE_DEBUG, debug_module != null and debug_module.visible)
+	_user_preferences.save_to_disk()
+
 func _on_manual_fixture_toggle(enabled: bool) -> void:
 	ProjectSettings.set_setting("peraviz_manual_fixture_test", enabled)
 	_refresh_fixture_debug_panel()
 
 func _on_show_advanced_controls_toggled(enabled: bool) -> void:
 	UiVisibilityPolicyScript.set_advanced_controls_enabled(enabled)
+	if visual_settings_window != null and visual_settings_window.has_method("set_advanced_mode_enabled"):
+		visual_settings_window.call("set_advanced_mode_enabled", enabled)
 	_refresh_ui_module_visibility()
 
 func _refresh_ui_module_visibility() -> void:
+	var user_visible: bool = UiVisibilityPolicyScript.is_module_visible(UiVisibilityPolicyScript.MODULE_USER)
+	var advanced_visible: bool = UiVisibilityPolicyScript.is_module_visible(UiVisibilityPolicyScript.MODULE_ADVANCED)
+	var debug_visible: bool = UiVisibilityPolicyScript.is_module_visible(UiVisibilityPolicyScript.MODULE_DEBUG)
+	if _user_preferences != null:
+		user_visible = user_visible and _user_preferences.get_module_visible(UiVisibilityPolicyScript.MODULE_USER, true)
+		advanced_visible = advanced_visible and _user_preferences.get_module_visible(UiVisibilityPolicyScript.MODULE_ADVANCED, false)
+		debug_visible = debug_visible and _user_preferences.get_module_visible(UiVisibilityPolicyScript.MODULE_DEBUG, false)
 	if user_module != null:
-		user_module.visible = UiVisibilityPolicyScript.is_module_visible(UiVisibilityPolicyScript.MODULE_USER)
+		user_module.visible = user_visible
 	if advanced_module != null:
-		advanced_module.visible = UiVisibilityPolicyScript.is_module_visible(UiVisibilityPolicyScript.MODULE_ADVANCED)
+		advanced_module.visible = advanced_visible
 	if debug_module != null:
-		debug_module.visible = UiVisibilityPolicyScript.is_module_visible(UiVisibilityPolicyScript.MODULE_DEBUG)
+		debug_module.visible = debug_visible
 	if show_advanced_controls_toggle != null:
 		show_advanced_controls_toggle.button_pressed = UiVisibilityPolicyScript.is_advanced_controls_enabled()
 
@@ -2232,6 +2274,7 @@ func _refresh_dmx_fixture_bindings() -> void:
 		_status_presenter.set_scene_state_warning_unbound(unbound_count)
 
 func _exit_tree() -> void:
+	_save_user_preferences()
 	if _dmx_controller != null:
 		_dmx_controller.exit_tree()
 

--- a/peraviz/scripts/ui/ui_visibility_policy.gd
+++ b/peraviz/scripts/ui/ui_visibility_policy.gd
@@ -7,9 +7,9 @@ const MODULE_DEBUG: StringName = &"Debug"
 
 const SETTINGS_FILE_PATH: String = "user://ui_visibility_policy.cfg"
 const SETTINGS_SECTION: String = "ui_visibility"
-const SETTING_SHOW_ADVANCED: String = "show_advanced_controls"
 const SETTING_FORCE_DEBUG: String = "force_debug_controls"
 
+static var _advanced_controls_enabled: bool = false
 static var _cached_settings: Dictionary = {}
 
 static func is_module_visible(module_name: StringName) -> bool:
@@ -24,10 +24,10 @@ static func is_module_visible(module_name: StringName) -> bool:
 			return false
 
 static func is_advanced_controls_enabled() -> bool:
-	return bool(_get_setting(SETTING_SHOW_ADVANCED, false))
+	return _advanced_controls_enabled
 
 static func set_advanced_controls_enabled(enabled: bool) -> void:
-	_set_setting(SETTING_SHOW_ADVANCED, enabled)
+	_advanced_controls_enabled = enabled
 
 static func is_debug_controls_forced() -> bool:
 	return bool(_get_setting(SETTING_FORCE_DEBUG, false))
@@ -51,7 +51,6 @@ static func _ensure_settings_loaded() -> void:
 	if config.load(SETTINGS_FILE_PATH) != OK:
 		_cached_settings = {}
 		return
-	_cached_settings[SETTING_SHOW_ADVANCED] = bool(config.get_value(SETTINGS_SECTION, SETTING_SHOW_ADVANCED, false))
 	_cached_settings[SETTING_FORCE_DEBUG] = bool(config.get_value(SETTINGS_SECTION, SETTING_FORCE_DEBUG, false))
 
 static func _save_settings() -> void:

--- a/peraviz/scripts/ui/user_preferences.gd
+++ b/peraviz/scripts/ui/user_preferences.gd
@@ -1,0 +1,66 @@
+extends RefCounted
+class_name UserPreferences
+
+const SETTINGS_FILE_PATH: String = "user://user_preferences.cfg"
+const SETTINGS_SECTION: String = "ui"
+
+const KEY_SIDEBAR_OPEN: String = "sidebar_open"
+const KEY_ADVANCED_MODE: String = "advanced_mode"
+const KEY_LAST_SETTINGS_TAB: String = "last_settings_tab"
+const KEY_MODULE_USER_VISIBLE: String = "module_user_visible"
+const KEY_MODULE_ADVANCED_VISIBLE: String = "module_advanced_visible"
+const KEY_MODULE_DEBUG_VISIBLE: String = "module_debug_visible"
+
+const DEFAULT_SIDEBAR_OPEN: bool = false
+const DEFAULT_ADVANCED_MODE: bool = false
+const DEFAULT_LAST_SETTINGS_TAB: int = 0
+const DEFAULT_MODULE_VISIBILITY := {
+	"User": true,
+	"Advanced": false,
+	"Debug": false,
+}
+
+var sidebar_open: bool = DEFAULT_SIDEBAR_OPEN
+var advanced_mode: bool = DEFAULT_ADVANCED_MODE
+var last_settings_tab: int = DEFAULT_LAST_SETTINGS_TAB
+var module_visibility: Dictionary = DEFAULT_MODULE_VISIBILITY.duplicate(true)
+
+func load_from_disk() -> void:
+	var config := ConfigFile.new()
+	if config.load(SETTINGS_FILE_PATH) != OK:
+		_apply_defaults()
+		return
+
+	sidebar_open = bool(config.get_value(SETTINGS_SECTION, KEY_SIDEBAR_OPEN, DEFAULT_SIDEBAR_OPEN))
+	advanced_mode = bool(config.get_value(SETTINGS_SECTION, KEY_ADVANCED_MODE, DEFAULT_ADVANCED_MODE))
+	last_settings_tab = max(0, int(config.get_value(SETTINGS_SECTION, KEY_LAST_SETTINGS_TAB, DEFAULT_LAST_SETTINGS_TAB)))
+
+	module_visibility = DEFAULT_MODULE_VISIBILITY.duplicate(true)
+	module_visibility["User"] = bool(config.get_value(SETTINGS_SECTION, KEY_MODULE_USER_VISIBLE, DEFAULT_MODULE_VISIBILITY["User"]))
+	module_visibility["Advanced"] = bool(config.get_value(SETTINGS_SECTION, KEY_MODULE_ADVANCED_VISIBLE, DEFAULT_MODULE_VISIBILITY["Advanced"]))
+	module_visibility["Debug"] = bool(config.get_value(SETTINGS_SECTION, KEY_MODULE_DEBUG_VISIBLE, DEFAULT_MODULE_VISIBILITY["Debug"]))
+
+func save_to_disk() -> void:
+	var config := ConfigFile.new()
+	config.set_value(SETTINGS_SECTION, KEY_SIDEBAR_OPEN, sidebar_open)
+	config.set_value(SETTINGS_SECTION, KEY_ADVANCED_MODE, advanced_mode)
+	config.set_value(SETTINGS_SECTION, KEY_LAST_SETTINGS_TAB, max(0, last_settings_tab))
+	config.set_value(SETTINGS_SECTION, KEY_MODULE_USER_VISIBLE, bool(module_visibility.get("User", DEFAULT_MODULE_VISIBILITY["User"])))
+	config.set_value(SETTINGS_SECTION, KEY_MODULE_ADVANCED_VISIBLE, bool(module_visibility.get("Advanced", DEFAULT_MODULE_VISIBILITY["Advanced"])))
+	config.set_value(SETTINGS_SECTION, KEY_MODULE_DEBUG_VISIBLE, bool(module_visibility.get("Debug", DEFAULT_MODULE_VISIBILITY["Debug"])))
+
+	var save_result: int = config.save(SETTINGS_FILE_PATH)
+	if save_result != OK:
+		push_warning("Failed to save user preferences to %s (error=%d)" % [SETTINGS_FILE_PATH, save_result])
+
+func get_module_visible(module_name: StringName, default_value: bool) -> bool:
+	return bool(module_visibility.get(str(module_name), default_value))
+
+func set_module_visible(module_name: StringName, visible: bool) -> void:
+	module_visibility[str(module_name)] = visible
+
+func _apply_defaults() -> void:
+	sidebar_open = DEFAULT_SIDEBAR_OPEN
+	advanced_mode = DEFAULT_ADVANCED_MODE
+	last_settings_tab = DEFAULT_LAST_SETTINGS_TAB
+	module_visibility = DEFAULT_MODULE_VISIBILITY.duplicate(true)

--- a/peraviz/scripts/ui/user_preferences.gd.uid
+++ b/peraviz/scripts/ui/user_preferences.gd.uid
@@ -1,0 +1,1 @@
+uid://buw8l18ncew3p

--- a/peraviz/scripts/visual_settings_window.gd
+++ b/peraviz/scripts/visual_settings_window.gd
@@ -218,6 +218,28 @@ func _apply_mode_to_panels() -> void:
 	if _debug_panel != null:
 		_debug_panel.set_advanced_mode(advanced_enabled)
 
+
+func set_advanced_mode_enabled(enabled: bool) -> void:
+	if _advanced_mode_toggle == null:
+		return
+	_advanced_mode_toggle.button_pressed = enabled
+	_apply_mode_to_panels()
+
+func is_advanced_mode_enabled() -> bool:
+	return _advanced_mode_toggle != null and _advanced_mode_toggle.button_pressed
+
+func set_active_tab_index(tab_index: int) -> void:
+	if _tabs == null:
+		return
+	if _tabs.get_tab_count() <= 0:
+		return
+	_tabs.current_tab = clampi(tab_index, 0, _tabs.get_tab_count() - 1)
+
+func get_active_tab_index() -> int:
+	if _tabs == null:
+		return 0
+	return _tabs.current_tab
+
 func _apply_quick_preset(preset_name: String) -> void:
 	if not QUICK_PRESETS.has(preset_name):
 		return


### PR DESCRIPTION
### Motivation
- Provide durable user-visible UI preferences for the main Peraviz scene so users keep a predictable, minimal UI between runs. 
- Keep developer/debug flags separate from user preferences to avoid leaking development toggles into user state.

### Description
- Added `peraviz/scripts/ui/user_preferences.gd` to persist sidebar open/closed, Basic/Advanced mode, last visual settings tab, and per-module visibility into `user://user_preferences.cfg` with safe defaults (sidebar closed, basic mode, tab 0, only `User` module visible). 
- Integrated load/save lifecycle in `peraviz/scripts/load_scene.gd` by calling `_load_user_preferences()` during `_ready()` and `_save_user_preferences()` in `_exit_tree()`, and applied preferences to `AppShell` and `VisualSettingsWindow`. 
- Updated UI visibility handling to combine policy and user preferences in `_refresh_ui_module_visibility()` so runtime debug/policy and per-user visibility are respected together. 
- Refactored `peraviz/scripts/ui/ui_visibility_policy.gd` to stop persisting the Advanced toggle and only persist the debug-force flag, preserving separation between user prefs and development flags. 
- Added helper API to `peraviz/scripts/visual_settings_window.gd` (`set_advanced_mode_enabled`, `is_advanced_mode_enabled`, `set_active_tab_index`, `get_active_tab_index`) to allow external persistence without coupling storage logic to the window. 

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed (OK). 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed (OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2815bb8148324830ec71d9cbf814b)