### PR TITLE
Add Peraviz UI architecture docs and UI Growth Checklist

### DIFF
--- a/peraviz/README.md
+++ b/peraviz/README.md
@@ -145,4 +145,6 @@ More detailed notes live under `peraviz/docs/`:
 - `BASELINE_MVR_RENDER.md` – baseline comparison workflow
 - `BEAM_RENDERING_MODES.md` – beam modes and performance guidance
 - `LIGHT_INTENSITY_INTERPRETATION.md` – interpreting intensity/exposure in the viewer
+- `UI_ARCHITECTURE.md` – UI module map, visibility tiers, naming, and ownership rules
+- `UI_GROWTH_CHECKLIST.md` – pre-feature UI checklist, including clean-screen default gate
 - `README_gobos.md` – gobo parsing and runtime projection notes

--- a/peraviz/docs/UI_ARCHITECTURE.md
+++ b/peraviz/docs/UI_ARCHITECTURE.md
@@ -1,0 +1,122 @@
+# UI Architecture
+
+## Purpose
+
+This document defines how Peraviz UI responsibilities are split so that new features can grow without turning the viewer into a monolithic script.
+
+## Module map
+
+The UI is organized into five module families.
+
+### 1. Shell
+
+**Responsibility**
+- Own app-level startup and top-level composition.
+- Instantiate and wire major UI modules.
+- Keep global state transitions explicit and minimal.
+
+**Typical contents**
+- Main scene root and top-level startup scripts.
+- High-level routing between windows/panels.
+
+### 2. Panels
+
+**Responsibility**
+- Own focused, embedded UI blocks that live inside a parent surface.
+- Render controls and status views for one bounded concern.
+
+**Typical contents**
+- Fixture test panel.
+- DMX monitor panel.
+- Small reusable controls grouped by workflow.
+
+### 3. Windows
+
+**Responsibility**
+- Own detachable or standalone dialogs/windows.
+- Group settings that are not required in the always-visible flow.
+
+**Typical contents**
+- Visual Settings window.
+- Future advanced diagnostics windows.
+
+### 4. Controllers
+
+**Responsibility**
+- Translate UI intent into runtime actions.
+- Orchestrate calls to scene loading, selection, DMX runtime, and rendering services.
+
+**Typical contents**
+- Scene load controller.
+- Fixture interaction controller.
+- Settings apply/reset controller.
+
+### 5. Policies
+
+**Responsibility**
+- Hold decision logic that must stay stable and testable.
+- Define defaults, gating rules, and visibility levels.
+
+**Typical contents**
+- Feature-level visibility policy (User/Advanced/Debug).
+- "Clean screen by default" gating logic.
+- Safe defaults and opt-in behavior policies.
+
+## Visibility tiers: User / Advanced / Debug
+
+Every new UI surface must be assigned to one of these tiers.
+
+### User
+- Visible by default.
+- Required for core viewer workflow.
+- Must minimize cognitive load and visual noise.
+
+### Advanced
+- Hidden behind explicit opt-in (toggle, menu action, or advanced section).
+- Useful for power users but not required to load and inspect scenes.
+- Must preserve simple defaults when disabled.
+
+### Debug
+- Intended for development/validation only.
+- Must never block normal end-user workflow.
+- Should be isolated from User-tier paths and controlled through policy gates.
+
+## Naming conventions
+
+### Files and scripts
+- Use clear, responsibility-first names.
+- Prefer suffixes by role:
+  - `*_panel.gd` for embedded panels.
+  - `*_window.gd` for standalone windows.
+  - `*_controller.gd` for orchestration logic.
+  - `*_policy.gd` for visibility/default rules.
+
+### Node names
+- Use stable, explicit names matching responsibility.
+- Avoid ambiguous generic names such as `Manager`, `Helper`, or `UIStuff`.
+
+### Public methods
+- Start with intent verbs (`show_*`, `hide_*`, `apply_*`, `reset_*`, `update_*`).
+- Keep ownership obvious: a panel updates panel widgets; a controller applies runtime effects.
+
+## Script ownership rules
+
+- A script owns exactly one primary responsibility.
+- Panel scripts should not directly implement cross-module business logic.
+- Controllers coordinate modules; they should not render widget-level details.
+- Policies provide decisions; they should be free of scene-tree side effects whenever possible.
+- Shared helpers must live close to the module that owns the behavior, not in a global dump file.
+
+## UX requirement: clean screen by default
+
+"Clean screen by default" is a mandatory UX requirement.
+
+### Requirement definition
+- On first launch (or after reset), the default UI must prioritize scene readability over controls density.
+- Only User-tier essentials remain visible by default.
+- Advanced and Debug surfaces must be opt-in.
+
+### Acceptance criteria
+- A new user can load and inspect an MVR scene without dismissing intrusive overlays.
+- Debug instrumentation is not shown unless explicitly enabled.
+- Enabling advanced/debug views does not permanently pollute default startup state.

--- a/peraviz/docs/UI_GROWTH_CHECKLIST.md
+++ b/peraviz/docs/UI_GROWTH_CHECKLIST.md
@@ -1,0 +1,35 @@
+# UI Growth Checklist
+
+Use this checklist before implementing any new UI feature in Peraviz.
+
+## 1) User value and visibility tier
+
+- [ ] Is this feature for end users (User tier) or for diagnostics (Debug tier)?
+- [ ] If it is not essential for the core workflow, should it be Advanced instead of User?
+- [ ] Does the default startup remain clean when this feature is disabled?
+
+## 2) Module placement
+
+- [ ] Can this feature be added to an existing module without overloading its responsibility?
+- [ ] If not, should a new module be introduced (Panel, Window, Controller, or Policy)?
+- [ ] Is script ownership explicit (single primary responsibility per script)?
+- [ ] Are names consistent with architecture conventions (`*_panel`, `*_window`, `*_controller`, `*_policy`)?
+
+## 3) Main layout impact
+
+- [ ] Does this feature change the main viewer layout or persistent visible controls?
+- [ ] If yes, is the change justified by core user workflow value?
+- [ ] Could the same function be delivered as opt-in Advanced/Debug UI instead?
+- [ ] Has the team confirmed that scene readability remains the top priority?
+
+## 4) Clean screen by default gate (mandatory)
+
+- [ ] After implementing the feature, default startup still shows only User-tier essentials.
+- [ ] Advanced and Debug surfaces remain hidden until explicitly enabled.
+- [ ] No new overlay/panel/window appears by default unless required for base flow.
+
+## 5) Integration quality checks
+
+- [ ] Architecture docs are updated when module boundaries or visibility decisions change.
+- [ ] The new feature respects existing module boundaries and does not create unnecessary coupling.
+- [ ] Any follow-up extraction/refactor is recorded if the touched module is growing too large.


### PR DESCRIPTION
### Motivation
- Provide clear, discoverable guidance to keep Peraviz UI modular and to gate new UI features by visibility tiers and ownership rules.
- Introduce a mandatory UX requirement ("clean screen by default") so new UI surfaces do not degrade scene readability by default.

### Description
- Add `peraviz/docs/UI_ARCHITECTURE.md` defining the UI module map (Shell, Panels, Windows, Controllers, Policies), visibility tiers (User/Advanced/Debug), naming conventions, script ownership rules, and the "clean screen by default" acceptance criteria.
- Add `peraviz/docs/UI_GROWTH_CHECKLIST.md` containing a pre-feature checklist that covers user vs debug intent, module placement decisions, main layout impact, and the mandatory clean-screen gate.
- Update `peraviz/README.md` to link the two new documents from the Additional documentation section.

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e285b6e7a8832492c72136f500986a)