### PR TITLE
Separate Gobo wheel-spin vs slot-rotation: parser, bindings, runtime and projector

### DIFF
--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -521,3 +521,32 @@ Perastage parses rider text by identifying sections, hang positions, fixture lin
 ## Peraviz MVR/GDTF visual fallback rule
 
 When loading MVR/GDTF content in Peraviz, dummy placeholder meshes must only be rendered if no real visual geometry exists for that node subtree. If a valid model (mesh/scene) is present in descendants, placeholder cubes/cones are removed to avoid double drawing.
+
+## Peraviz gobo wheel spin vs slot rotation semantics
+
+Peraviz now keeps separate semantics for:
+
+- `Gobo(n)WheelSpin`: wheel-level spin (physical wheel movement speed/direction).
+- `Gobo(n)PosRotate`: slot/pattern rotation for the selected gobo slot.
+
+Compatibility behavior:
+
+- Legacy gobo rotation attributes are still accepted through the existing
+  compatibility lane.
+- If a fixture provides only one of the two controls, runtime mirrors that
+  value so older fixtures remain functional.
+
+Runtime precedence:
+
+1. Resolve gobo slot selection/index first.
+2. Resolve wheel spin independently (`wheel_spin_*` fields).
+3. Resolve slot rotation independently (`slot_rotation_*` fields).
+4. Fallback to legacy `rotation_*` fields when explicit split controls are not
+   available.
+
+Physical step behavior:
+
+- In indexed/step mode, wheel movement advances with continuous angle until the
+  target slot is reached (no instant jump).
+- Visible slot selection is resolved from the current wheel angle window.
+- Open/hole slots (slot index `0`) are treated as open windows when present.

--- a/peraviz/native/CMakeLists.txt
+++ b/peraviz/native/CMakeLists.txt
@@ -157,18 +157,27 @@ if(PERAVIZ_GODOT_PROJECT_DIR)
     set(_peraviz_bin_dir "${PERAVIZ_GODOT_PROJECT_DIR}/bin")
     file(MAKE_DIRECTORY "${_peraviz_bin_dir}")
 
-    set_target_properties(peraviz_native PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${_peraviz_bin_dir}"
-        LIBRARY_OUTPUT_DIRECTORY "${_peraviz_bin_dir}"
-    )
-
-    foreach(config Debug Release RelWithDebInfo MinSizeRel)
-        string(TOUPPER "${config}" config_upper)
-        set_target_properties(peraviz_native PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY_${config_upper} "${_peraviz_bin_dir}"
-            LIBRARY_OUTPUT_DIRECTORY_${config_upper} "${_peraviz_bin_dir}"
+    if(WIN32)
+        add_custom_command(TARGET peraviz_native POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                $<TARGET_FILE:peraviz_native>
+                "${_peraviz_bin_dir}/$<TARGET_FILE_NAME:peraviz_native>"
+            COMMENT "Copying peraviz_native to ${_peraviz_bin_dir}"
         )
-    endforeach()
+    else()
+        set_target_properties(peraviz_native PROPERTIES
+            RUNTIME_OUTPUT_DIRECTORY "${_peraviz_bin_dir}"
+            LIBRARY_OUTPUT_DIRECTORY "${_peraviz_bin_dir}"
+        )
+
+        foreach(config Debug Release RelWithDebInfo MinSizeRel)
+            string(TOUPPER "${config}" config_upper)
+            set_target_properties(peraviz_native PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY_${config_upper} "${_peraviz_bin_dir}"
+                LIBRARY_OUTPUT_DIRECTORY_${config_upper} "${_peraviz_bin_dir}"
+            )
+        endforeach()
+    endif()
 
     if(WIN32)
         add_custom_command(TARGET peraviz_native POST_BUILD

--- a/peraviz/native/src/dmx/fixture_dmx_binding.cpp
+++ b/peraviz/native/src/dmx/fixture_dmx_binding.cpp
@@ -186,6 +186,18 @@ FixtureBindingBuildResult build_fixture_control_bindings(
             to_channel_index_0(patch, offsets.gobo_rotation_fine_offset_1_based);
         binding.gobo_rotation.ultra_fine_dmx_channel_index_0 =
             to_channel_index_0(patch, offsets.gobo_rotation_ultra_fine_offset_1_based);
+        binding.gobo_wheel_spin.coarse_dmx_channel_index_0 =
+            to_channel_index_0(patch, offsets.gobo_wheel_spin_coarse_offset_1_based);
+        binding.gobo_wheel_spin.fine_dmx_channel_index_0 =
+            to_channel_index_0(patch, offsets.gobo_wheel_spin_fine_offset_1_based);
+        binding.gobo_wheel_spin.ultra_fine_dmx_channel_index_0 =
+            to_channel_index_0(patch, offsets.gobo_wheel_spin_ultra_fine_offset_1_based);
+        binding.gobo_slot_rotation.coarse_dmx_channel_index_0 =
+            to_channel_index_0(patch, offsets.gobo_slot_rotation_coarse_offset_1_based);
+        binding.gobo_slot_rotation.fine_dmx_channel_index_0 =
+            to_channel_index_0(patch, offsets.gobo_slot_rotation_fine_offset_1_based);
+        binding.gobo_slot_rotation.ultra_fine_dmx_channel_index_0 =
+            to_channel_index_0(patch, offsets.gobo_slot_rotation_ultra_fine_offset_1_based);
         binding.gobo_wheel_number = offsets.gobo_wheel_number;
         binding.gobo_wheel_name = offsets.gobo_wheel_name;
         binding.gobo_slots = offsets.gobo_slots;
@@ -205,13 +217,25 @@ FixtureBindingBuildResult build_fixture_control_bindings(
                                                                 wheel.rotation_coarse_offset_1_based,
                                                                 wheel.rotation_fine_offset_1_based,
                                                                 wheel.rotation_ultra_fine_offset_1_based);
+            wheel_binding.wheel_spin_channel = to_channel_binding(patch,
+                                                                  wheel.wheel_spin_coarse_offset_1_based,
+                                                                  wheel.wheel_spin_fine_offset_1_based,
+                                                                  wheel.wheel_spin_ultra_fine_offset_1_based);
+            wheel_binding.slot_rotation_channel = to_channel_binding(patch,
+                                                                     wheel.slot_rotation_coarse_offset_1_based,
+                                                                     wheel.slot_rotation_fine_offset_1_based,
+                                                                     wheel.slot_rotation_ultra_fine_offset_1_based);
             wheel_binding.supports_index = wheel.supports_index;
             wheel_binding.supports_rotation = wheel.supports_rotation;
             wheel_binding.supports_spin_rotation = wheel.supports_spin_rotation;
+            wheel_binding.supports_wheel_spin = wheel.supports_wheel_spin;
+            wheel_binding.supports_slot_rotation = wheel.supports_slot_rotation;
             wheel_binding.supports_shake = wheel.supports_shake;
             wheel_binding.has_index_physical_limits = wheel.has_index_physical_limits;
             wheel_binding.index_physical_min = wheel.index_physical_min;
             wheel_binding.index_physical_max = wheel.index_physical_max;
+            wheel_binding.wheel_spin_ranges = wheel.wheel_spin_ranges;
+            wheel_binding.slot_rotation_ranges = wheel.slot_rotation_ranges;
             wheel_binding.rotation_ranges = wheel.rotation_ranges;
             wheel_binding.shake_ranges = wheel.shake_ranges;
             wheel_binding.wheel_number = wheel.wheel_number;
@@ -325,10 +349,14 @@ FixtureBindingBuildResult build_fixture_control_bindings(
         sanitize_channel_binding(binding.gobo);
         sanitize_channel_binding(binding.gobo_index);
         sanitize_channel_binding(binding.gobo_rotation);
+        sanitize_channel_binding(binding.gobo_wheel_spin);
+        sanitize_channel_binding(binding.gobo_slot_rotation);
         for (FixtureGoboWheelBinding &wheel_binding : binding.gobo_wheels) {
             sanitize_channel_binding(wheel_binding.channel);
             sanitize_channel_binding(wheel_binding.index_channel);
             sanitize_channel_binding(wheel_binding.rotation_channel);
+            sanitize_channel_binding(wheel_binding.wheel_spin_channel);
+            sanitize_channel_binding(wheel_binding.slot_rotation_channel);
         }
 
         result.bindings.push_back(binding);

--- a/peraviz/native/src/dmx/fixture_dmx_binding.h
+++ b/peraviz/native/src/dmx/fixture_dmx_binding.h
@@ -75,13 +75,19 @@ struct FixtureGoboWheelBinding {
     FixtureAttributeChannel channel;
     FixtureAttributeChannel index_channel;
     FixtureAttributeChannel rotation_channel;
+    FixtureAttributeChannel wheel_spin_channel;
+    FixtureAttributeChannel slot_rotation_channel;
     bool supports_index = false;
     bool supports_rotation = false;
     bool supports_spin_rotation = false;
+    bool supports_wheel_spin = false;
+    bool supports_slot_rotation = false;
     bool supports_shake = false;
     bool has_index_physical_limits = false;
     float index_physical_min = 0.0F;
     float index_physical_max = 0.0F;
+    std::vector<FixtureGoboRotationRange> wheel_spin_ranges;
+    std::vector<FixtureGoboRotationRange> slot_rotation_ranges;
     std::vector<FixtureGoboRotationRange> rotation_ranges;
     std::vector<FixtureGoboShakeRange> shake_ranges;
     int wheel_number = 0;
@@ -111,6 +117,8 @@ struct FixtureControlBinding {
     FixtureAttributeChannel gobo;
     FixtureAttributeChannel gobo_index;
     FixtureAttributeChannel gobo_rotation;
+    FixtureAttributeChannel gobo_wheel_spin;
+    FixtureAttributeChannel gobo_slot_rotation;
     int gobo_wheel_number = 0;
     std::string gobo_wheel_name;
     std::vector<FixtureGoboSlot> gobo_slots;
@@ -143,13 +151,25 @@ struct FixtureGoboWheelOffset {
     int rotation_fine_offset_1_based = -1;
     int rotation_ultra_fine_offset_1_based = -1;
     int rotation_channel_priority = -1;
+    int wheel_spin_coarse_offset_1_based = -1;
+    int wheel_spin_fine_offset_1_based = -1;
+    int wheel_spin_ultra_fine_offset_1_based = -1;
+    int slot_rotation_coarse_offset_1_based = -1;
+    int slot_rotation_fine_offset_1_based = -1;
+    int slot_rotation_ultra_fine_offset_1_based = -1;
+    int wheel_spin_channel_priority = -1;
+    int slot_rotation_channel_priority = -1;
     bool supports_index = false;
     bool supports_rotation = false;
     bool supports_spin_rotation = false;
+    bool supports_wheel_spin = false;
+    bool supports_slot_rotation = false;
     bool supports_shake = false;
     bool has_index_physical_limits = false;
     float index_physical_min = 0.0F;
     float index_physical_max = 0.0F;
+    std::vector<FixtureGoboRotationRange> wheel_spin_ranges;
+    std::vector<FixtureGoboRotationRange> slot_rotation_ranges;
     std::vector<FixtureGoboRotationRange> rotation_ranges;
     std::vector<FixtureGoboShakeRange> shake_ranges;
     int wheel_number = 0;
@@ -213,6 +233,12 @@ struct FixtureControlOffsets {
     int gobo_rotation_coarse_offset_1_based = -1;
     int gobo_rotation_fine_offset_1_based = -1;
     int gobo_rotation_ultra_fine_offset_1_based = -1;
+    int gobo_wheel_spin_coarse_offset_1_based = -1;
+    int gobo_wheel_spin_fine_offset_1_based = -1;
+    int gobo_wheel_spin_ultra_fine_offset_1_based = -1;
+    int gobo_slot_rotation_coarse_offset_1_based = -1;
+    int gobo_slot_rotation_fine_offset_1_based = -1;
+    int gobo_slot_rotation_ultra_fine_offset_1_based = -1;
     int gobo_wheel_number = 0;
     std::string gobo_wheel_name;
     std::vector<FixtureGoboSlot> gobo_slots;
@@ -232,7 +258,8 @@ struct FixtureControlOffsets {
                animation_wheel_coarse_offset_1_based > 0 ||
                animation_wheel_rotation_coarse_offset_1_based > 0 ||
                gobo_coarse_offset_1_based > 0 || gobo_index_coarse_offset_1_based > 0 ||
-               gobo_rotation_coarse_offset_1_based > 0 || yellow_coarse_offset_1_based > 0 ||
+               gobo_rotation_coarse_offset_1_based > 0 || gobo_wheel_spin_coarse_offset_1_based > 0 ||
+               gobo_slot_rotation_coarse_offset_1_based > 0 || yellow_coarse_offset_1_based > 0 ||
                !gobo_wheels.empty();
     }
 };

--- a/peraviz/native/src/dmx/gdtf_attribute_classifier.cpp
+++ b/peraviz/native/src/dmx/gdtf_attribute_classifier.cpp
@@ -179,6 +179,35 @@ bool matches_gobo_rotation_attribute(const std::string &leaf) {
            leaf.find("rotate") != std::string::npos;
 }
 
+bool matches_gobo_wheel_spin_attribute(const std::string &leaf) {
+    if (leaf.find("gobo") == std::string::npos) {
+        return false;
+    }
+    if (matches_gobo_select_with_embedded_motion(leaf)) {
+        return false;
+    }
+    return leaf.find("wheelspin") != std::string::npos ||
+           leaf.find("wheelrotation") != std::string::npos ||
+           (leaf.find("wheel") != std::string::npos &&
+            (leaf.find("spin") != std::string::npos || leaf.find("rotate") != std::string::npos));
+}
+
+bool matches_gobo_slot_rotation_attribute(const std::string &leaf) {
+    if (leaf.find("gobo") == std::string::npos) {
+        return false;
+    }
+    if (matches_gobo_select_with_embedded_motion(leaf)) {
+        return false;
+    }
+    return leaf.find("posrotate") != std::string::npos ||
+           leaf.find("posrot") != std::string::npos ||
+           leaf.find("posrotation") != std::string::npos ||
+           (leaf.find("slot") != std::string::npos &&
+            (leaf.find("spin") != std::string::npos || leaf.find("rotate") != std::string::npos)) ||
+           (leaf.find("index") != std::string::npos &&
+            (leaf.find("spin") != std::string::npos || leaf.find("rotate") != std::string::npos));
+}
+
 struct AttributeNameDescriptor {
     AttributeRole role;
     std::initializer_list<std::string_view> tokens;
@@ -305,7 +334,11 @@ void parse_wheel_and_prism_attributes(const std::string &leaf, ParsedAttribute &
 }
 
 void parse_gobo_attribute(const std::string &leaf, ParsedAttribute &parsed) {
-    if (matches_gobo_rotation_attribute(leaf)) {
+    if (matches_gobo_wheel_spin_attribute(leaf)) {
+        parsed.role = AttributeRole::kGoboWheelSpin;
+    } else if (matches_gobo_slot_rotation_attribute(leaf)) {
+        parsed.role = AttributeRole::kGoboSlotRotation;
+    } else if (matches_gobo_rotation_attribute(leaf)) {
         parsed.role = AttributeRole::kGoboRotation;
     } else if (matches_gobo_index_attribute(leaf)) {
         parsed.role = AttributeRole::kGoboIndex;

--- a/peraviz/native/src/dmx/gdtf_attribute_classifier.h
+++ b/peraviz/native/src/dmx/gdtf_attribute_classifier.h
@@ -25,6 +25,8 @@ enum class AttributeRole {
     kGobo,
     kGoboIndex,
     kGoboRotation,
+    kGoboWheelSpin,
+    kGoboSlotRotation,
 };
 
 struct ParsedAttribute {

--- a/peraviz/native/src/dmx/gdtf_control_offsets_resolver.cpp
+++ b/peraviz/native/src/dmx/gdtf_control_offsets_resolver.cpp
@@ -318,6 +318,12 @@ void handle_gobo_index_attribute(const peraviz::dmx::ParsedAttribute &parsed_att
                                               wheel->index_physical_max);
 }
 
+enum class GoboRotationKind {
+    kLegacy = 0,
+    kWheelSpin = 1,
+    kSlotRotation = 2,
+};
+
 void handle_gobo_rotation_attribute(const peraviz::dmx::ParsedAttribute &parsed_attribute,
                                     const std::vector<int> &offsets,
                                     const char *attribute,
@@ -326,6 +332,7 @@ void handle_gobo_rotation_attribute(const peraviz::dmx::ParsedAttribute &parsed_
                                     int function_dmx_to,
                                     int function_mode_from,
                                     int function_mode_to,
+                                    GoboRotationKind rotation_kind,
                                     peraviz::dmx::FixtureControlOffsets &out_offsets) {
     peraviz::dmx::FixtureGoboWheelOffset *wheel =
         resolve_gobo_wheel(out_offsets, parsed_attribute, channel_function);
@@ -340,6 +347,12 @@ void handle_gobo_rotation_attribute(const peraviz::dmx::ParsedAttribute &parsed_
     } else {
         wheel->supports_rotation = true;
         wheel->supports_spin_rotation = true;
+        if (rotation_kind == GoboRotationKind::kWheelSpin || rotation_kind == GoboRotationKind::kLegacy) {
+            wheel->supports_wheel_spin = true;
+        }
+        if (rotation_kind == GoboRotationKind::kSlotRotation || rotation_kind == GoboRotationKind::kLegacy) {
+            wheel->supports_slot_rotation = true;
+        }
     }
     int candidate_rotation_coarse = -1;
     int candidate_rotation_fine = -1;
@@ -370,17 +383,37 @@ void handle_gobo_rotation_attribute(const peraviz::dmx::ParsedAttribute &parsed_
     }
 
     const bool has_valid_candidate_channel = candidate_rotation_coarse > 0;
+    int &resolved_coarse = rotation_kind == GoboRotationKind::kWheelSpin
+        ? wheel->wheel_spin_coarse_offset_1_based
+        : (rotation_kind == GoboRotationKind::kSlotRotation
+            ? wheel->slot_rotation_coarse_offset_1_based
+            : wheel->rotation_coarse_offset_1_based);
+    int &resolved_fine = rotation_kind == GoboRotationKind::kWheelSpin
+        ? wheel->wheel_spin_fine_offset_1_based
+        : (rotation_kind == GoboRotationKind::kSlotRotation
+            ? wheel->slot_rotation_fine_offset_1_based
+            : wheel->rotation_fine_offset_1_based);
+    int &resolved_ultra_fine = rotation_kind == GoboRotationKind::kWheelSpin
+        ? wheel->wheel_spin_ultra_fine_offset_1_based
+        : (rotation_kind == GoboRotationKind::kSlotRotation
+            ? wheel->slot_rotation_ultra_fine_offset_1_based
+            : wheel->rotation_ultra_fine_offset_1_based);
+    int &resolved_priority = rotation_kind == GoboRotationKind::kWheelSpin
+        ? wheel->wheel_spin_channel_priority
+        : (rotation_kind == GoboRotationKind::kSlotRotation
+            ? wheel->slot_rotation_channel_priority
+            : wheel->rotation_channel_priority);
     const bool should_replace_rotation_channel =
         has_valid_candidate_channel &&
-        (wheel->rotation_coarse_offset_1_based <= 0 ||
-         candidate_priority > wheel->rotation_channel_priority ||
-         (candidate_priority == wheel->rotation_channel_priority &&
-          candidate_rotation_coarse < wheel->rotation_coarse_offset_1_based));
+        (resolved_coarse <= 0 ||
+         candidate_priority > resolved_priority ||
+         (candidate_priority == resolved_priority &&
+          candidate_rotation_coarse < resolved_coarse));
     if (should_replace_rotation_channel) {
-        wheel->rotation_coarse_offset_1_based = candidate_rotation_coarse;
-        wheel->rotation_fine_offset_1_based = candidate_rotation_fine;
-        wheel->rotation_ultra_fine_offset_1_based = candidate_rotation_ultra_fine;
-        wheel->rotation_channel_priority = candidate_priority;
+        resolved_coarse = candidate_rotation_coarse;
+        resolved_fine = candidate_rotation_fine;
+        resolved_ultra_fine = candidate_rotation_ultra_fine;
+        resolved_priority = candidate_priority;
     }
 
     std::vector<peraviz::dmx::FixtureGoboRotationRange> parsed_ranges;
@@ -417,9 +450,13 @@ void handle_gobo_rotation_attribute(const peraviz::dmx::ParsedAttribute &parsed_
             wheel->shake_ranges.push_back(shake_range);
         }
     } else {
-        wheel->rotation_ranges.insert(wheel->rotation_ranges.end(),
-                                      parsed_ranges.begin(),
-                                      parsed_ranges.end());
+        wheel->rotation_ranges.insert(wheel->rotation_ranges.end(), parsed_ranges.begin(), parsed_ranges.end());
+        if (rotation_kind == GoboRotationKind::kWheelSpin || rotation_kind == GoboRotationKind::kLegacy) {
+            wheel->wheel_spin_ranges.insert(wheel->wheel_spin_ranges.end(), parsed_ranges.begin(), parsed_ranges.end());
+        }
+        if (rotation_kind == GoboRotationKind::kSlotRotation || rotation_kind == GoboRotationKind::kLegacy) {
+            wheel->slot_rotation_ranges.insert(wheel->slot_rotation_ranges.end(), parsed_ranges.begin(), parsed_ranges.end());
+        }
     }
 }
 
@@ -473,8 +510,16 @@ bool handle_gobo_index_descriptor(const AttributeContext &context) {
 }
 
 bool handle_gobo_rotation_descriptor(const AttributeContext &context) {
-    if (context.parsed_attribute.role != peraviz::dmx::AttributeRole::kGoboRotation) {
+    if (context.parsed_attribute.role != peraviz::dmx::AttributeRole::kGoboRotation &&
+        context.parsed_attribute.role != peraviz::dmx::AttributeRole::kGoboWheelSpin &&
+        context.parsed_attribute.role != peraviz::dmx::AttributeRole::kGoboSlotRotation) {
         return false;
+    }
+    GoboRotationKind rotation_kind = GoboRotationKind::kLegacy;
+    if (context.parsed_attribute.role == peraviz::dmx::AttributeRole::kGoboWheelSpin) {
+        rotation_kind = GoboRotationKind::kWheelSpin;
+    } else if (context.parsed_attribute.role == peraviz::dmx::AttributeRole::kGoboSlotRotation) {
+        rotation_kind = GoboRotationKind::kSlotRotation;
     }
     handle_gobo_rotation_attribute(context.parsed_attribute,
                                    context.offsets,
@@ -484,6 +529,7 @@ bool handle_gobo_rotation_descriptor(const AttributeContext &context) {
                                    context.function_dmx_to,
                                    context.function_mode_from,
                                    context.function_mode_to,
+                                   rotation_kind,
                                    context.out_offsets);
     return true;
 }
@@ -716,6 +762,42 @@ DimmerResolveCacheEntry resolve_uncached(const std::string &gdtf_path,
 
     for (auto &wheel : out.offsets.gobo_wheels) {
         peraviz::dmx::dedupe_and_sort_gobo_wheel(wheel);
+        if (wheel.wheel_spin_coarse_offset_1_based <= 0 && wheel.rotation_coarse_offset_1_based > 0) {
+            wheel.wheel_spin_coarse_offset_1_based = wheel.rotation_coarse_offset_1_based;
+            wheel.wheel_spin_fine_offset_1_based = wheel.rotation_fine_offset_1_based;
+            wheel.wheel_spin_ultra_fine_offset_1_based = wheel.rotation_ultra_fine_offset_1_based;
+        }
+        if (wheel.slot_rotation_coarse_offset_1_based <= 0 && wheel.rotation_coarse_offset_1_based > 0) {
+            wheel.slot_rotation_coarse_offset_1_based = wheel.rotation_coarse_offset_1_based;
+            wheel.slot_rotation_fine_offset_1_based = wheel.rotation_fine_offset_1_based;
+            wheel.slot_rotation_ultra_fine_offset_1_based = wheel.rotation_ultra_fine_offset_1_based;
+        }
+        if (wheel.wheel_spin_ranges.empty()) {
+            wheel.wheel_spin_ranges = wheel.rotation_ranges;
+        }
+        if (wheel.slot_rotation_ranges.empty()) {
+            wheel.slot_rotation_ranges = wheel.rotation_ranges;
+        }
+        if (wheel.rotation_coarse_offset_1_based <= 0) {
+            wheel.rotation_coarse_offset_1_based = wheel.slot_rotation_coarse_offset_1_based > 0
+                ? wheel.slot_rotation_coarse_offset_1_based
+                : wheel.wheel_spin_coarse_offset_1_based;
+            wheel.rotation_fine_offset_1_based = wheel.slot_rotation_fine_offset_1_based > 0
+                ? wheel.slot_rotation_fine_offset_1_based
+                : wheel.wheel_spin_fine_offset_1_based;
+            wheel.rotation_ultra_fine_offset_1_based = wheel.slot_rotation_ultra_fine_offset_1_based > 0
+                ? wheel.slot_rotation_ultra_fine_offset_1_based
+                : wheel.wheel_spin_ultra_fine_offset_1_based;
+        }
+        if (wheel.rotation_ranges.empty()) {
+            wheel.rotation_ranges = !wheel.slot_rotation_ranges.empty()
+                ? wheel.slot_rotation_ranges
+                : wheel.wheel_spin_ranges;
+        }
+        wheel.supports_wheel_spin = wheel.supports_wheel_spin || wheel.wheel_spin_coarse_offset_1_based > 0 ||
+                                    !wheel.wheel_spin_ranges.empty();
+        wheel.supports_slot_rotation = wheel.supports_slot_rotation || wheel.slot_rotation_coarse_offset_1_based > 0 ||
+                                       !wheel.slot_rotation_ranges.empty();
     }
     out.offsets.gobo_wheels.erase(
         std::remove_if(out.offsets.gobo_wheels.begin(), out.offsets.gobo_wheels.end(),
@@ -747,15 +829,36 @@ DimmerResolveCacheEntry resolve_uncached(const std::string &gdtf_path,
         primary_wheel = &out.offsets.gobo_wheels.front();
     }
     if (primary_wheel) {
+        const int legacy_rotation_coarse = primary_wheel->rotation_coarse_offset_1_based > 0
+            ? primary_wheel->rotation_coarse_offset_1_based
+            : (primary_wheel->slot_rotation_coarse_offset_1_based > 0
+                ? primary_wheel->slot_rotation_coarse_offset_1_based
+                : primary_wheel->wheel_spin_coarse_offset_1_based);
+        const int legacy_rotation_fine = primary_wheel->rotation_fine_offset_1_based > 0
+            ? primary_wheel->rotation_fine_offset_1_based
+            : (primary_wheel->slot_rotation_fine_offset_1_based > 0
+                ? primary_wheel->slot_rotation_fine_offset_1_based
+                : primary_wheel->wheel_spin_fine_offset_1_based);
+        const int legacy_rotation_ultra_fine = primary_wheel->rotation_ultra_fine_offset_1_based > 0
+            ? primary_wheel->rotation_ultra_fine_offset_1_based
+            : (primary_wheel->slot_rotation_ultra_fine_offset_1_based > 0
+                ? primary_wheel->slot_rotation_ultra_fine_offset_1_based
+                : primary_wheel->wheel_spin_ultra_fine_offset_1_based);
         out.offsets.gobo_coarse_offset_1_based = primary_wheel->coarse_offset_1_based;
         out.offsets.gobo_fine_offset_1_based = primary_wheel->fine_offset_1_based;
         out.offsets.gobo_ultra_fine_offset_1_based = primary_wheel->ultra_fine_offset_1_based;
         out.offsets.gobo_index_coarse_offset_1_based = primary_wheel->index_coarse_offset_1_based;
         out.offsets.gobo_index_fine_offset_1_based = primary_wheel->index_fine_offset_1_based;
         out.offsets.gobo_index_ultra_fine_offset_1_based = primary_wheel->index_ultra_fine_offset_1_based;
-        out.offsets.gobo_rotation_coarse_offset_1_based = primary_wheel->rotation_coarse_offset_1_based;
-        out.offsets.gobo_rotation_fine_offset_1_based = primary_wheel->rotation_fine_offset_1_based;
-        out.offsets.gobo_rotation_ultra_fine_offset_1_based = primary_wheel->rotation_ultra_fine_offset_1_based;
+        out.offsets.gobo_rotation_coarse_offset_1_based = legacy_rotation_coarse;
+        out.offsets.gobo_rotation_fine_offset_1_based = legacy_rotation_fine;
+        out.offsets.gobo_rotation_ultra_fine_offset_1_based = legacy_rotation_ultra_fine;
+        out.offsets.gobo_wheel_spin_coarse_offset_1_based = primary_wheel->wheel_spin_coarse_offset_1_based;
+        out.offsets.gobo_wheel_spin_fine_offset_1_based = primary_wheel->wheel_spin_fine_offset_1_based;
+        out.offsets.gobo_wheel_spin_ultra_fine_offset_1_based = primary_wheel->wheel_spin_ultra_fine_offset_1_based;
+        out.offsets.gobo_slot_rotation_coarse_offset_1_based = primary_wheel->slot_rotation_coarse_offset_1_based;
+        out.offsets.gobo_slot_rotation_fine_offset_1_based = primary_wheel->slot_rotation_fine_offset_1_based;
+        out.offsets.gobo_slot_rotation_ultra_fine_offset_1_based = primary_wheel->slot_rotation_ultra_fine_offset_1_based;
         out.offsets.gobo_wheel_number = primary_wheel->wheel_number;
         out.offsets.gobo_wheel_name = primary_wheel->wheel_name;
         out.offsets.gobo_slots = primary_wheel->slots;

--- a/peraviz/native/src/dmx/gdtf_gobo_catalog.cpp
+++ b/peraviz/native/src/dmx/gdtf_gobo_catalog.cpp
@@ -552,6 +552,8 @@ void consume_gobo_channel_sets(tinyxml2::XMLElement *channel_function,
                 } else {
                     out_wheel.supports_rotation = true;
                     out_wheel.supports_spin_rotation = true;
+                    out_wheel.supports_wheel_spin = true;
+                    out_wheel.supports_slot_rotation = true;
                     FixtureGoboRotationRange rotation_range;
                     rotation_range.dmx_from = row.dmx_from;
                     rotation_range.dmx_to = row.dmx_to;
@@ -624,6 +626,12 @@ void dedupe_and_sort_gobo_wheel(FixtureGoboWheelOffset &wheel) {
                                a.is_rotation_channel_range == b.is_rotation_channel_range;
                     }),
         wheel.rotation_ranges.end());
+    if (wheel.wheel_spin_ranges.empty()) {
+        wheel.wheel_spin_ranges = wheel.rotation_ranges;
+    }
+    if (wheel.slot_rotation_ranges.empty()) {
+        wheel.slot_rotation_ranges = wheel.rotation_ranges;
+    }
 
     std::stable_sort(wheel.shake_ranges.begin(), wheel.shake_ranges.end(),
                      [](const FixtureGoboShakeRange &a,

--- a/peraviz/native/src/peraviz_loader.cpp
+++ b/peraviz/native/src/peraviz_loader.cpp
@@ -212,6 +212,12 @@ Dictionary PeravizLoader::build_fixture_dmx_bindings(int universe_offset) const 
         item["gobo_rotation_channel_index_0"] = binding.gobo_rotation.coarse_dmx_channel_index_0;
         item["gobo_rotation_fine_channel_index_0"] = binding.gobo_rotation.fine_dmx_channel_index_0;
         item["gobo_rotation_ultra_fine_channel_index_0"] = binding.gobo_rotation.ultra_fine_dmx_channel_index_0;
+        item["gobo_wheel_spin_channel_index_0"] = binding.gobo_wheel_spin.coarse_dmx_channel_index_0;
+        item["gobo_wheel_spin_fine_channel_index_0"] = binding.gobo_wheel_spin.fine_dmx_channel_index_0;
+        item["gobo_wheel_spin_ultra_fine_channel_index_0"] = binding.gobo_wheel_spin.ultra_fine_dmx_channel_index_0;
+        item["gobo_slot_rotation_channel_index_0"] = binding.gobo_slot_rotation.coarse_dmx_channel_index_0;
+        item["gobo_slot_rotation_fine_channel_index_0"] = binding.gobo_slot_rotation.fine_dmx_channel_index_0;
+        item["gobo_slot_rotation_ultra_fine_channel_index_0"] = binding.gobo_slot_rotation.ultra_fine_dmx_channel_index_0;
         item["gobo_wheel_number"] = binding.gobo_wheel_number;
         item["gobo_wheel_name"] = String(binding.gobo_wheel_name.c_str());
 
@@ -264,9 +270,17 @@ Dictionary PeravizLoader::build_fixture_dmx_bindings(int universe_offset) const 
             wheel_item["rotation_channel_index_0"] = wheel.rotation_channel.coarse_dmx_channel_index_0;
             wheel_item["rotation_fine_channel_index_0"] = wheel.rotation_channel.fine_dmx_channel_index_0;
             wheel_item["rotation_ultra_fine_channel_index_0"] = wheel.rotation_channel.ultra_fine_dmx_channel_index_0;
+            wheel_item["wheel_spin_channel_index_0"] = wheel.wheel_spin_channel.coarse_dmx_channel_index_0;
+            wheel_item["wheel_spin_fine_channel_index_0"] = wheel.wheel_spin_channel.fine_dmx_channel_index_0;
+            wheel_item["wheel_spin_ultra_fine_channel_index_0"] = wheel.wheel_spin_channel.ultra_fine_dmx_channel_index_0;
+            wheel_item["slot_rotation_channel_index_0"] = wheel.slot_rotation_channel.coarse_dmx_channel_index_0;
+            wheel_item["slot_rotation_fine_channel_index_0"] = wheel.slot_rotation_channel.fine_dmx_channel_index_0;
+            wheel_item["slot_rotation_ultra_fine_channel_index_0"] = wheel.slot_rotation_channel.ultra_fine_dmx_channel_index_0;
             wheel_item["supports_index"] = wheel.supports_index;
             wheel_item["supports_rotation"] = wheel.supports_rotation;
             wheel_item["supports_spin_rotation"] = wheel.supports_spin_rotation;
+            wheel_item["supports_wheel_spin"] = wheel.supports_wheel_spin;
+            wheel_item["supports_slot_rotation"] = wheel.supports_slot_rotation;
             wheel_item["supports_shake"] = wheel.supports_shake;
             wheel_item["has_index_physical_limits"] = wheel.has_index_physical_limits;
             wheel_item["index_physical_min"] = wheel.index_physical_min;
@@ -299,6 +313,40 @@ Dictionary PeravizLoader::build_fixture_dmx_bindings(int universe_offset) const 
                 rotation_ranges[rotation_range_index] = rotation_range_item;
             }
             wheel_item["rotation_ranges"] = rotation_ranges;
+
+            Array wheel_spin_ranges;
+            wheel_spin_ranges.resize(static_cast<int64_t>(wheel.wheel_spin_ranges.size()));
+            for (int64_t rotation_range_index = 0; rotation_range_index < static_cast<int64_t>(wheel.wheel_spin_ranges.size()); ++rotation_range_index) {
+                const auto &rotation_range = wheel.wheel_spin_ranges[static_cast<size_t>(rotation_range_index)];
+                Dictionary rotation_range_item;
+                rotation_range_item["dmx_from"] = rotation_range.dmx_from;
+                rotation_range_item["dmx_to"] = rotation_range.dmx_to;
+                rotation_range_item["mode_from_8bit"] = rotation_range.mode_from_8bit;
+                rotation_range_item["mode_to_8bit"] = rotation_range.mode_to_8bit;
+                rotation_range_item["physical_from"] = rotation_range.physical_from;
+                rotation_range_item["physical_to"] = rotation_range.physical_to;
+                rotation_range_item["is_stop_range"] = rotation_range.is_stop_range;
+                rotation_range_item["is_rotation_channel_range"] = rotation_range.is_rotation_channel_range;
+                wheel_spin_ranges[rotation_range_index] = rotation_range_item;
+            }
+            wheel_item["wheel_spin_ranges"] = wheel_spin_ranges;
+
+            Array slot_rotation_ranges;
+            slot_rotation_ranges.resize(static_cast<int64_t>(wheel.slot_rotation_ranges.size()));
+            for (int64_t rotation_range_index = 0; rotation_range_index < static_cast<int64_t>(wheel.slot_rotation_ranges.size()); ++rotation_range_index) {
+                const auto &rotation_range = wheel.slot_rotation_ranges[static_cast<size_t>(rotation_range_index)];
+                Dictionary rotation_range_item;
+                rotation_range_item["dmx_from"] = rotation_range.dmx_from;
+                rotation_range_item["dmx_to"] = rotation_range.dmx_to;
+                rotation_range_item["mode_from_8bit"] = rotation_range.mode_from_8bit;
+                rotation_range_item["mode_to_8bit"] = rotation_range.mode_to_8bit;
+                rotation_range_item["physical_from"] = rotation_range.physical_from;
+                rotation_range_item["physical_to"] = rotation_range.physical_to;
+                rotation_range_item["is_stop_range"] = rotation_range.is_stop_range;
+                rotation_range_item["is_rotation_channel_range"] = rotation_range.is_rotation_channel_range;
+                slot_rotation_ranges[rotation_range_index] = rotation_range_item;
+            }
+            wheel_item["slot_rotation_ranges"] = slot_rotation_ranges;
 
             Array shake_ranges;
             shake_ranges.resize(static_cast<int64_t>(wheel.shake_ranges.size()));

--- a/peraviz/native/tests/fixture_dmx_binding_e2e_test.cpp
+++ b/peraviz/native/tests/fixture_dmx_binding_e2e_test.cpp
@@ -612,6 +612,48 @@ int run_test() {
         }
     }
 
+    if (mega_pointe_gobo1->wheel_spin_ranges.empty() || mega_pointe_gobo2->wheel_spin_ranges.empty()) {
+        return fail("Expected canonical MegaPointe wheel spin ranges for both gobo wheels");
+    }
+    const auto validate_wheel_spin_ranges = [](const peraviz::dmx::FixtureGoboWheelOffset &wheel,
+                                               const std::string &wheel_label) -> int {
+        bool has_high_window_range = false;
+        bool has_negative_segment = false;
+        bool has_positive_segment = false;
+        bool has_center_stop = false;
+        for (const peraviz::dmx::FixtureGoboRotationRange &range : wheel.wheel_spin_ranges) {
+            if (range.dmx_from >= 202 || range.dmx_to >= 202) {
+                has_high_window_range = true;
+            }
+            if (range.physical_from < 0.0F || range.physical_to < 0.0F) {
+                has_negative_segment = true;
+            }
+            if (range.physical_from > 0.0F || range.physical_to > 0.0F) {
+                has_positive_segment = true;
+            }
+            if (range.is_stop_range && range.dmx_from <= 128 && range.dmx_to >= 127) {
+                has_center_stop = true;
+            }
+        }
+        if (!has_high_window_range) {
+            return fail("Expected " + wheel_label + " wheel-spin ranges to include DMX window 202+");
+        }
+        if (!has_negative_segment || !has_positive_segment) {
+            return fail("Expected " + wheel_label + " wheel-spin ranges to include negative and positive physical values");
+        }
+        if (!has_center_stop) {
+            return fail("Expected " + wheel_label + " wheel-spin ranges to include near-center stop window");
+        }
+        return 0;
+    };
+
+    if (const int rc = validate_wheel_spin_ranges(*mega_pointe_gobo1, "gobo1"); rc != 0) {
+        return rc;
+    }
+    if (const int rc = validate_wheel_spin_ranges(*mega_pointe_gobo2, "gobo2"); rc != 0) {
+        return rc;
+    }
+
     return 0;
 }
 

--- a/peraviz/native/tests/gdtf_attribute_classifier_test.cpp
+++ b/peraviz/native/tests/gdtf_attribute_classifier_test.cpp
@@ -49,7 +49,13 @@ int main() {
     if (const int rc = expect_parsed("panfine", peraviz::dmx::AttributeRole::kPan, true, 1, 0); rc != 0) {
         return rc;
     }
-    if (const int rc = expect_parsed("gobo1posrotate", peraviz::dmx::AttributeRole::kGoboRotation, false, 1, 1); rc != 0) {
+    if (const int rc = expect_parsed("gobo1posrotate", peraviz::dmx::AttributeRole::kGoboSlotRotation, false, 1, 1); rc != 0) {
+        return rc;
+    }
+    if (const int rc = expect_parsed("gobo2wheelspin", peraviz::dmx::AttributeRole::kGoboWheelSpin, false, 1, 2); rc != 0) {
+        return rc;
+    }
+    if (const int rc = expect_parsed("gobo2wheelrotate", peraviz::dmx::AttributeRole::kGoboWheelSpin, false, 1, 2); rc != 0) {
         return rc;
     }
     if (const int rc = expect_parsed("gobo2index", peraviz::dmx::AttributeRole::kGoboIndex, false, 1, 2); rc != 0) {

--- a/peraviz/scripts/dmx_capabilities/gobo_capability_handler.gd
+++ b/peraviz/scripts/dmx_capabilities/gobo_capability_handler.gd
@@ -95,6 +95,8 @@ static func _build_runtime_gobo_bindings(binding: Dictionary,
 		var range_behavior: int = int(active_range.get("behavior", GOBO_BEHAVIOR_FIXED))
 		var has_index_channel: bool = control_reader.has_control_channel(item, "index_channel_index_0", "index_fine_channel_index_0", "index_ultra_fine_channel_index_0")
 		var has_rotation_channel: bool = control_reader.has_control_channel(item, "rotation_channel_index_0", "rotation_fine_channel_index_0", "rotation_ultra_fine_channel_index_0")
+		var has_wheel_spin_channel: bool = control_reader.has_control_channel(item, "wheel_spin_channel_index_0", "wheel_spin_fine_channel_index_0", "wheel_spin_ultra_fine_channel_index_0")
+		var has_slot_rotation_channel: bool = control_reader.has_control_channel(item, "slot_rotation_channel_index_0", "slot_rotation_fine_channel_index_0", "slot_rotation_ultra_fine_channel_index_0")
 		var is_rotation_behavior: bool = range_behavior == GOBO_BEHAVIOR_ROTATION or range_behavior == GOBO_BEHAVIOR_SHAKE
 		var uses_range_rotation: bool = is_rotation_behavior and not has_rotation_channel
 		var supports_index: bool = (range_behavior == GOBO_BEHAVIOR_INDEX) or (has_index_channel and not is_rotation_behavior)
@@ -112,7 +114,11 @@ static func _build_runtime_gobo_bindings(binding: Dictionary,
 		var rotation_source_channel: String = "select"
 		var rotation_has_value: bool = false
 		var rotation_ranges: Array = item.get("rotation_ranges", [])
+		var wheel_spin_ranges: Array = item.get("wheel_spin_ranges", rotation_ranges)
+		var slot_rotation_ranges: Array = item.get("slot_rotation_ranges", rotation_ranges)
 		var resolved_rotation: Dictionary = {}
+		var resolved_wheel_spin: Dictionary = {}
+		var resolved_slot_rotation: Dictionary = {}
 		var resolved_shake: Dictionary = {}
 		var mode_master_value_8bit: int = raw_8bit
 		var rotation_control_norm: float = -1.0
@@ -139,6 +145,14 @@ static func _build_runtime_gobo_bindings(binding: Dictionary,
 
 		var rotation_value_available: bool = false
 		var rotation_value_norm: float = -1.0
+		var wheel_spin_raw_8bit: int = -1
+		var wheel_spin_raw_coarse: int = -1
+		var wheel_spin_raw_fine: int = -1
+		var wheel_spin_control_norm: float = -1.0
+		var slot_rotation_raw_8bit: int = -1
+		var slot_rotation_raw_coarse: int = -1
+		var slot_rotation_raw_fine: int = -1
+		var slot_rotation_control_norm: float = -1.0
 		if has_rotation_channel and (supports_rotation or (supports_index and not has_index_channel)):
 			var rotation_coarse_index: int = int(item.get("rotation_channel_index_0", -1))
 			var rotation_fine_index: int = int(item.get("rotation_fine_channel_index_0", -1))
@@ -158,6 +172,32 @@ static func _build_runtime_gobo_bindings(binding: Dictionary,
 				rotation_raw_coarse = int(frame[rotation_coarse_index]) if control_reader.is_valid_channel_index(frame, rotation_coarse_index) else rotation_raw_8bit
 				rotation_raw_fine = int(frame[rotation_fine_index]) if control_reader.is_valid_channel_index(frame, rotation_fine_index) else -1
 				rotation_control_norm = rotation_value_norm
+		if has_wheel_spin_channel:
+			var wheel_spin_value: Dictionary = control_reader.read_optional_control_value(
+				frame,
+				int(item.get("wheel_spin_channel_index_0", -1)),
+				int(item.get("wheel_spin_fine_channel_index_0", -1)),
+				int(item.get("wheel_spin_ultra_fine_channel_index_0", -1)),
+				force_coarse_only
+			)
+			if not wheel_spin_value.is_empty():
+				wheel_spin_control_norm = normalizer.clamp_norm(float(wheel_spin_value.get("norm", 0.0)))
+				wheel_spin_raw_8bit = normalizer.raw_to_8bit(int(wheel_spin_value.get("raw", 0)), int(wheel_spin_value.get("resolution_bits", 8)))
+				wheel_spin_raw_coarse = wheel_spin_raw_8bit
+				wheel_spin_raw_fine = -1
+		if has_slot_rotation_channel:
+			var slot_rotation_value: Dictionary = control_reader.read_optional_control_value(
+				frame,
+				int(item.get("slot_rotation_channel_index_0", -1)),
+				int(item.get("slot_rotation_fine_channel_index_0", -1)),
+				int(item.get("slot_rotation_ultra_fine_channel_index_0", -1)),
+				force_coarse_only
+			)
+			if not slot_rotation_value.is_empty():
+				slot_rotation_control_norm = normalizer.clamp_norm(float(slot_rotation_value.get("norm", 0.0)))
+				slot_rotation_raw_8bit = normalizer.raw_to_8bit(int(slot_rotation_value.get("raw", 0)), int(slot_rotation_value.get("resolution_bits", 8)))
+				slot_rotation_raw_coarse = slot_rotation_raw_8bit
+				slot_rotation_raw_fine = -1
 
 		if supports_index and index_norm < 0.0 and range_behavior == GOBO_BEHAVIOR_INDEX:
 			if not has_index_channel and rotation_value_available:
@@ -213,6 +253,32 @@ static func _build_runtime_gobo_bindings(binding: Dictionary,
 				resolver_ranges,
 				mode_master_value_8bit,
 				prefer_rotation_channel_ranges
+			)
+		if wheel_spin_raw_8bit < 0:
+			wheel_spin_raw_8bit = rotation_raw_8bit
+			wheel_spin_raw_coarse = rotation_raw_coarse
+			wheel_spin_raw_fine = rotation_raw_fine
+			wheel_spin_control_norm = rotation_control_norm
+		if slot_rotation_raw_8bit < 0:
+			slot_rotation_raw_8bit = rotation_raw_8bit
+			slot_rotation_raw_coarse = rotation_raw_coarse
+			slot_rotation_raw_fine = rotation_raw_fine
+			slot_rotation_control_norm = rotation_control_norm
+		if not wheel_spin_ranges.is_empty() and wheel_spin_raw_8bit >= 0:
+			resolved_wheel_spin = _resolve_rotation_runtime(
+				wheel_spin_raw_8bit,
+				wheel_spin_control_norm,
+				wheel_spin_ranges,
+				mode_master_value_8bit,
+				has_wheel_spin_channel
+			)
+		if not slot_rotation_ranges.is_empty() and slot_rotation_raw_8bit >= 0:
+			resolved_slot_rotation = _resolve_rotation_runtime(
+				slot_rotation_raw_8bit,
+				slot_rotation_control_norm,
+				slot_rotation_ranges,
+				mode_master_value_8bit,
+				has_slot_rotation_channel
 			)
 		if supports_shake and not shake_ranges.is_empty():
 			var slot_index_for_shake: int = int(active_range.get("slot_index", -1))
@@ -312,6 +378,22 @@ static func _build_runtime_gobo_bindings(binding: Dictionary,
 			"rotation_raw_value": rotation_raw,
 			"rotation_active_range": active_range,
 			"rotation_ranges": rotation_ranges,
+			"wheel_spin_ranges": wheel_spin_ranges,
+			"slot_rotation_ranges": slot_rotation_ranges,
+			"wheel_spin_has_physical_value": bool(resolved_wheel_spin.get("has_range", false)),
+			"wheel_spin_speed_deg_per_sec": float(resolved_wheel_spin.get("rotation_speed_deg_per_sec", float(resolved_rotation.get("rotation_speed_deg_per_sec", 0.0)))),
+			"wheel_spin_direction_sign": int(resolved_wheel_spin.get("direction_sign", int(resolved_rotation.get("direction_sign", 0)))),
+			"wheel_spin_is_stop": bool(resolved_wheel_spin.get("is_stop", bool(resolved_rotation.get("is_stop", true)))),
+			"wheel_spin_raw_8bit": wheel_spin_raw_8bit,
+			"wheel_spin_raw_coarse": wheel_spin_raw_coarse,
+			"wheel_spin_raw_fine": wheel_spin_raw_fine,
+			"slot_rotation_has_physical_value": bool(resolved_slot_rotation.get("has_range", false)),
+			"slot_rotation_speed_deg_per_sec": float(resolved_slot_rotation.get("rotation_speed_deg_per_sec", float(resolved_rotation.get("rotation_speed_deg_per_sec", 0.0)))),
+			"slot_rotation_direction_sign": int(resolved_slot_rotation.get("direction_sign", int(resolved_rotation.get("direction_sign", 0)))),
+			"slot_rotation_is_stop": bool(resolved_slot_rotation.get("is_stop", bool(resolved_rotation.get("is_stop", true)))),
+			"slot_rotation_raw_8bit": slot_rotation_raw_8bit,
+			"slot_rotation_raw_coarse": slot_rotation_raw_coarse,
+			"slot_rotation_raw_fine": slot_rotation_raw_fine,
 			"shake_ranges": shake_ranges,
 			"has_shake_runtime_range": bool(resolved_shake.get("has_range", false)),
 			"shake_active": shake_active,

--- a/peraviz/scripts/dmx_capabilities/gobo_capability_handler.gd
+++ b/peraviz/scripts/dmx_capabilities/gobo_capability_handler.gd
@@ -97,6 +97,8 @@ static func _build_runtime_gobo_bindings(binding: Dictionary,
 		var has_rotation_channel: bool = control_reader.has_control_channel(item, "rotation_channel_index_0", "rotation_fine_channel_index_0", "rotation_ultra_fine_channel_index_0")
 		var has_wheel_spin_channel: bool = control_reader.has_control_channel(item, "wheel_spin_channel_index_0", "wheel_spin_fine_channel_index_0", "wheel_spin_ultra_fine_channel_index_0")
 		var has_slot_rotation_channel: bool = control_reader.has_control_channel(item, "slot_rotation_channel_index_0", "slot_rotation_fine_channel_index_0", "slot_rotation_ultra_fine_channel_index_0")
+		var supports_wheel_spin_control: bool = has_wheel_spin_channel or bool(item.get("supports_wheel_spin", false))
+		var supports_slot_rotation_control: bool = has_slot_rotation_channel or bool(item.get("supports_slot_rotation", false))
 		var is_rotation_behavior: bool = range_behavior == GOBO_BEHAVIOR_ROTATION or range_behavior == GOBO_BEHAVIOR_SHAKE
 		var uses_range_rotation: bool = is_rotation_behavior and not has_rotation_channel
 		var supports_index: bool = (range_behavior == GOBO_BEHAVIOR_INDEX) or (has_index_channel and not is_rotation_behavior)
@@ -254,17 +256,17 @@ static func _build_runtime_gobo_bindings(binding: Dictionary,
 				mode_master_value_8bit,
 				prefer_rotation_channel_ranges
 			)
-		if wheel_spin_raw_8bit < 0:
+		if wheel_spin_raw_8bit < 0 and supports_wheel_spin_control:
 			wheel_spin_raw_8bit = rotation_raw_8bit
 			wheel_spin_raw_coarse = rotation_raw_coarse
 			wheel_spin_raw_fine = rotation_raw_fine
 			wheel_spin_control_norm = rotation_control_norm
-		if slot_rotation_raw_8bit < 0:
+		if slot_rotation_raw_8bit < 0 and supports_slot_rotation_control:
 			slot_rotation_raw_8bit = rotation_raw_8bit
 			slot_rotation_raw_coarse = rotation_raw_coarse
 			slot_rotation_raw_fine = rotation_raw_fine
 			slot_rotation_control_norm = rotation_control_norm
-		if not wheel_spin_ranges.is_empty() and wheel_spin_raw_8bit >= 0:
+		if supports_wheel_spin_control and not wheel_spin_ranges.is_empty() and wheel_spin_raw_8bit >= 0:
 			resolved_wheel_spin = _resolve_rotation_runtime(
 				wheel_spin_raw_8bit,
 				wheel_spin_control_norm,
@@ -272,7 +274,7 @@ static func _build_runtime_gobo_bindings(binding: Dictionary,
 				mode_master_value_8bit,
 				has_wheel_spin_channel
 			)
-		if not slot_rotation_ranges.is_empty() and slot_rotation_raw_8bit >= 0:
+		if supports_slot_rotation_control and not slot_rotation_ranges.is_empty() and slot_rotation_raw_8bit >= 0:
 			resolved_slot_rotation = _resolve_rotation_runtime(
 				slot_rotation_raw_8bit,
 				slot_rotation_control_norm,
@@ -380,14 +382,14 @@ static func _build_runtime_gobo_bindings(binding: Dictionary,
 			"rotation_ranges": rotation_ranges,
 			"wheel_spin_ranges": wheel_spin_ranges,
 			"slot_rotation_ranges": slot_rotation_ranges,
-			"wheel_spin_has_physical_value": bool(resolved_wheel_spin.get("has_range", false)),
+			"wheel_spin_has_physical_value": supports_wheel_spin_control and bool(resolved_wheel_spin.get("has_range", false)),
 			"wheel_spin_speed_deg_per_sec": float(resolved_wheel_spin.get("rotation_speed_deg_per_sec", float(resolved_rotation.get("rotation_speed_deg_per_sec", 0.0)))),
 			"wheel_spin_direction_sign": int(resolved_wheel_spin.get("direction_sign", int(resolved_rotation.get("direction_sign", 0)))),
 			"wheel_spin_is_stop": bool(resolved_wheel_spin.get("is_stop", bool(resolved_rotation.get("is_stop", true)))),
 			"wheel_spin_raw_8bit": wheel_spin_raw_8bit,
 			"wheel_spin_raw_coarse": wheel_spin_raw_coarse,
 			"wheel_spin_raw_fine": wheel_spin_raw_fine,
-			"slot_rotation_has_physical_value": bool(resolved_slot_rotation.get("has_range", false)),
+			"slot_rotation_has_physical_value": supports_slot_rotation_control and bool(resolved_slot_rotation.get("has_range", false)),
 			"slot_rotation_speed_deg_per_sec": float(resolved_slot_rotation.get("rotation_speed_deg_per_sec", float(resolved_rotation.get("rotation_speed_deg_per_sec", 0.0)))),
 			"slot_rotation_direction_sign": int(resolved_slot_rotation.get("direction_sign", int(resolved_rotation.get("direction_sign", 0)))),
 			"slot_rotation_is_stop": bool(resolved_slot_rotation.get("is_stop", bool(resolved_rotation.get("is_stop", true)))),

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -17,6 +17,7 @@ const GOBO_DEFAULT_SCALE: float = 1.0
 const GOBO_DEFAULT_ROTATION_DEG: float = 0.0
 const GOBO_WHEEL_TRANSITION_STEPS: int = 32
 const GOBO_SPIN_STOP_EPSILON_DPS: float = 0.5
+const GOBO_NO_GOBO_TEXTURE_CACHE_KEY: String = "__nogobo_slot_texture"
 const VECTOR_FALLBACK_GOBO_CACHE_KEY: String = "__vector_fallback_gobo"
 const GOBO_VECTOR_POLYGONS_META_KEY: String = "peraviz_gobo_vector_polygons"
 const GOBO_VECTOR_WIDTH_META_KEY: String = "peraviz_gobo_vector_width"
@@ -560,21 +561,14 @@ func _resolve_visible_slot_index(light: SpotLight3D, wheel: Dictionary, target_s
 
 func _collect_renderable_slot_indices_from_slots(slots: Array) -> Array:
 	var renderable_indices: Array = []
-	var fallback_indices: Array = []
 	for slot_item in slots:
 		if slot_item is not Dictionary:
 			continue
 		var slot_index: int = int(slot_item.get("slot_index", -1))
 		if slot_index <= 0:
 			continue
-		fallback_indices.append(slot_index)
-		var image_path: String = str(slot_item.get("image_path", ""))
-		if image_path.is_empty():
-			continue
 		renderable_indices.append(slot_index)
-	if not renderable_indices.is_empty():
-		return renderable_indices
-	return fallback_indices
+	return renderable_indices
 
 func _slot_index_position(slot_index: int, renderable_slot_indices: Array) -> int:
 	var fallback_position: int = 0
@@ -931,7 +925,13 @@ func _resolve_gobo_texture_entry_for_slot(controls: Dictionary, slot_index: int)
 			continue
 		var image_path: String = str(item.get("image_path", ""))
 		if image_path.is_empty():
-			return {}
+			var no_gobo_texture: Texture2D = _resolve_no_gobo_slot_texture()
+			if no_gobo_texture == null:
+				return {}
+			return {
+				"texture": no_gobo_texture,
+				"cache_key": "%s_%d" % [GOBO_NO_GOBO_TEXTURE_CACHE_KEY, slot_index],
+			}
 		if _texture_cache.has(image_path):
 			return {
 				"texture": _texture_cache[image_path] as Texture2D,
@@ -951,6 +951,14 @@ func _resolve_gobo_texture_entry_for_slot(controls: Dictionary, slot_index: int)
 			"cache_key": image_path,
 		}
 	return {}
+
+func _resolve_no_gobo_slot_texture() -> Texture2D:
+	if _texture_cache.has(GOBO_NO_GOBO_TEXTURE_CACHE_KEY):
+		return _texture_cache[GOBO_NO_GOBO_TEXTURE_CACHE_KEY] as Texture2D
+	var no_gobo_texture: Texture2D = _resolve_vector_fallback_gobo_texture()
+	if no_gobo_texture != null:
+		_texture_cache[GOBO_NO_GOBO_TEXTURE_CACHE_KEY] = no_gobo_texture
+	return no_gobo_texture
 
 
 

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -96,8 +96,6 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 			if wheel is not Dictionary:
 				continue
 			var slot_index: int = int(wheel.get("slot_index", 0))
-			if slot_index <= 0:
-				continue
 			var wheel_key: String = _resolve_wheel_cache_key(wheel)
 			var slot_resolution: Dictionary = _resolve_visible_slot_index(light, wheel, slot_index, delta_sec)
 			var visible_slot_index: int = int(slot_resolution.get("visible_slot_index", slot_index))
@@ -449,21 +447,44 @@ func _resolve_visible_slot_index(light: SpotLight3D, wheel: Dictionary, target_s
 	if slot_count <= 0:
 		return {"visible_slot_index": target_slot_index}
 	var current_angle_deg: float = float(wheel_angle_state.get(wheel_key, 0.0))
-	var normalized_target_slot: int = clampi(target_slot_index, 1, slot_count)
+	var previous_target_slot: int = int(target_slot_state.get(wheel_key, 1))
+	var normalized_target_slot: int = clampi(target_slot_index, 1, slot_count) if target_slot_index > 0 else clampi(previous_target_slot, 1, slot_count)
 	var target_center_deg: float = (float(normalized_target_slot - 1) + 0.5) * (360.0 / float(slot_count))
-	var wheel_spin_speed_deg_per_sec: float = absf(float(wheel.get("wheel_spin_speed_deg_per_sec", 0.0)))
+	var signed_wheel_spin_speed_deg_per_sec: float = float(wheel.get("wheel_spin_speed_deg_per_sec", 0.0))
+	var wheel_spin_speed_deg_per_sec: float = absf(signed_wheel_spin_speed_deg_per_sec)
+	var has_active_spin: bool = bool(wheel.get("wheel_spin_has_physical_value", false)) and not bool(wheel.get("wheel_spin_is_stop", false)) and wheel_spin_speed_deg_per_sec > 0.0001
+	if target_slot_index <= 0 and not has_active_spin:
+		target_slot_state[wheel_key] = clampi(previous_target_slot, 1, slot_count)
+		movement_state[wheel_key] = "open"
+		light.set_meta(GOBO_WHEEL_TARGET_SLOT_META_KEY, target_slot_state)
+		light.set_meta(GOBO_WHEEL_MOVEMENT_STATE_META_KEY, movement_state)
+		return {
+			"visible_slot_index": -1,
+			"wheel_angle_deg": current_angle_deg,
+			"target_slot_index": int(target_slot_state[wheel_key]),
+			"movement_state": "open",
+			"movement_direction_sign": 0,
+			"outgoing_slot_index": -1,
+			"incoming_slot_index": -1,
+			"motion_progress": 0.0,
+		}
 	var step_speed_deg_per_sec: float = maxf(wheel_spin_speed_deg_per_sec, 180.0)
 	var stepping_sign: float = 0.0
 	if delta_sec > 0.0:
-		var delta_to_target_deg: float = wrapf(target_center_deg - current_angle_deg, -180.0, 180.0)
-		stepping_sign = signf(delta_to_target_deg)
-		var max_step_deg: float = step_speed_deg_per_sec * delta_sec
-		if absf(delta_to_target_deg) <= max_step_deg:
-			current_angle_deg = target_center_deg
-			movement_state[wheel_key] = "aligned"
+		if has_active_spin:
+			current_angle_deg = wrapf(current_angle_deg + (signed_wheel_spin_speed_deg_per_sec * delta_sec), 0.0, 360.0)
+			stepping_sign = signf(signed_wheel_spin_speed_deg_per_sec)
+			movement_state[wheel_key] = "spinning"
 		else:
-			current_angle_deg = wrapf(current_angle_deg + signf(delta_to_target_deg) * max_step_deg, 0.0, 360.0)
-			movement_state[wheel_key] = "stepping"
+			var delta_to_target_deg: float = wrapf(target_center_deg - current_angle_deg, -180.0, 180.0)
+			stepping_sign = signf(delta_to_target_deg)
+			var max_step_deg: float = step_speed_deg_per_sec * delta_sec
+			if absf(delta_to_target_deg) <= max_step_deg:
+				current_angle_deg = target_center_deg
+				movement_state[wheel_key] = "aligned"
+			else:
+				current_angle_deg = wrapf(current_angle_deg + signf(delta_to_target_deg) * max_step_deg, 0.0, 360.0)
+				movement_state[wheel_key] = "stepping"
 	wheel_angle_state[wheel_key] = current_angle_deg
 	target_slot_state[wheel_key] = normalized_target_slot
 	light.set_meta(GOBO_WHEEL_ANGLE_META_KEY, wheel_angle_state)
@@ -475,7 +496,7 @@ func _resolve_visible_slot_index(light: SpotLight3D, wheel: Dictionary, target_s
 	var fractional_progress: float = normalized_position - floor(normalized_position)
 	base_slot_zero_index = posmod(base_slot_zero_index, slot_count)
 	var movement_direction_sign: int = 0
-	var spin_speed_signed: float = float(wheel.get("wheel_spin_speed_deg_per_sec", 0.0))
+	var spin_speed_signed: float = signed_wheel_spin_speed_deg_per_sec
 	if absf(spin_speed_signed) > 0.0001:
 		movement_direction_sign = 1 if spin_speed_signed > 0.0 else -1
 	elif absf(stepping_sign) > 0.0001:

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -463,8 +463,7 @@ func _resolve_visible_slot_index(light: SpotLight3D, wheel: Dictionary, target_s
 	if movement_state is not Dictionary:
 		movement_state = {}
 
-	var slots: Array = wheel.get("slots", [])
-	var renderable_slot_indices: Array = _collect_renderable_slot_indices_from_slots(slots)
+	var renderable_slot_indices: Array = _collect_ordered_slot_indices_from_wheel(wheel)
 	var slot_count: int = renderable_slot_indices.size()
 	if slot_count <= 0:
 		return {"visible_slot_index": target_slot_index}
@@ -559,16 +558,30 @@ func _resolve_visible_slot_index(light: SpotLight3D, wheel: Dictionary, target_s
 		"motion_progress": motion_progress,
 	}
 
-func _collect_renderable_slot_indices_from_slots(slots: Array) -> Array:
-	var renderable_indices: Array = []
+func _collect_ordered_slot_indices_from_wheel(wheel: Dictionary) -> Array:
+	var ordered_indices: Array = []
+	var seen: Dictionary = {}
+	var ranges: Array = wheel.get("ranges", [])
+	var sorted_ranges: Array = ranges.duplicate(true)
+	sorted_ranges.sort_custom(func(a, b): return int(a.get("dmx_from", 0)) < int(b.get("dmx_from", 0)))
+	for range_item in sorted_ranges:
+		if range_item is not Dictionary:
+			continue
+		var slot_index: int = int(range_item.get("slot_index", -1))
+		if slot_index <= 0 or seen.has(slot_index):
+			continue
+		seen[slot_index] = true
+		ordered_indices.append(slot_index)
+	var slots: Array = wheel.get("slots", [])
 	for slot_item in slots:
 		if slot_item is not Dictionary:
 			continue
 		var slot_index: int = int(slot_item.get("slot_index", -1))
-		if slot_index <= 0:
+		if slot_index <= 0 or seen.has(slot_index):
 			continue
-		renderable_indices.append(slot_index)
-	return renderable_indices
+		seen[slot_index] = true
+		ordered_indices.append(slot_index)
+	return ordered_indices
 
 func _slot_index_position(slot_index: int, renderable_slot_indices: Array) -> int:
 	var fallback_position: int = 0
@@ -955,9 +968,10 @@ func _resolve_gobo_texture_entry_for_slot(controls: Dictionary, slot_index: int)
 func _resolve_no_gobo_slot_texture() -> Texture2D:
 	if _texture_cache.has(GOBO_NO_GOBO_TEXTURE_CACHE_KEY):
 		return _texture_cache[GOBO_NO_GOBO_TEXTURE_CACHE_KEY] as Texture2D
-	var no_gobo_texture: Texture2D = _resolve_vector_fallback_gobo_texture()
-	if no_gobo_texture != null:
-		_texture_cache[GOBO_NO_GOBO_TEXTURE_CACHE_KEY] = no_gobo_texture
+	var image := Image.create(FAKE_GOBO_TEXTURE_SIZE, FAKE_GOBO_TEXTURE_SIZE, false, Image.FORMAT_RGBA8)
+	image.fill(Color(1.0, 1.0, 1.0, 1.0))
+	var no_gobo_texture: ImageTexture = ImageTexture.create_from_image(image)
+	_texture_cache[GOBO_NO_GOBO_TEXTURE_CACHE_KEY] = no_gobo_texture
 	return no_gobo_texture
 
 

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -23,6 +23,7 @@ const GOBO_VECTOR_POLYGONS_META_KEY: String = "peraviz_gobo_vector_polygons"
 const GOBO_VECTOR_WIDTH_META_KEY: String = "peraviz_gobo_vector_width"
 const GOBO_VECTOR_HEIGHT_META_KEY: String = "peraviz_gobo_vector_height"
 const GOBO_WHEEL_SPIN_META_KEY: String = "peraviz_gobo_wheel_spin"
+const GOBO_SLOT_ROTATION_META_KEY: String = "peraviz_gobo_slot_rotation_deg"
 const GOBO_WHEEL_ANGLE_META_KEY: String = "peraviz_gobo_wheel_angle_deg"
 const GOBO_WHEEL_TARGET_SLOT_META_KEY: String = "peraviz_gobo_target_slot"
 const GOBO_WHEEL_MOVEMENT_STATE_META_KEY: String = "peraviz_gobo_wheel_movement_state"
@@ -84,6 +85,7 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 
 	var delta_sec: float = _resolve_elapsed_seconds(light, controls)
 	var source_textures: Array[Texture2D] = []
+	var source_secondary_textures: Array[Texture2D] = []
 	var source_texture_cache_keys: PackedStringArray = PackedStringArray()
 	var wheel_slot_state: Dictionary = {}
 	var wheel_transition_state: Dictionary = {}
@@ -95,13 +97,31 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 	var has_bound_wheel_rotation: bool = false
 
 	if has_runtime_gobo:
-		var can_use_shader_transition: bool = runtime_bindings.size() == 1
+		var wheel_runtime_records: Array = []
+		var active_transition_count: int = 0
 		for wheel in runtime_bindings:
 			if wheel is not Dictionary:
 				continue
 			var slot_index: int = int(wheel.get("slot_index", 0))
 			var wheel_key: String = _resolve_wheel_cache_key(wheel)
 			var slot_resolution: Dictionary = _resolve_visible_slot_index(light, wheel, slot_index, delta_sec)
+			var has_transition_motion: bool = int(slot_resolution.get("movement_direction_sign", 0)) != 0 \
+				and int(slot_resolution.get("incoming_slot_index", -1)) != int(slot_resolution.get("outgoing_slot_index", -1)) \
+				and float(slot_resolution.get("motion_progress", 0.0)) > 0.001
+			if has_transition_motion:
+				active_transition_count += 1
+			wheel_runtime_records.append({
+				"wheel": wheel,
+				"wheel_key": wheel_key,
+				"slot_index": slot_index,
+				"slot_resolution": slot_resolution,
+			})
+		var can_use_shader_transition: bool = active_transition_count == 1
+		for record in wheel_runtime_records:
+			var wheel: Dictionary = record.get("wheel", {})
+			var wheel_key: String = str(record.get("wheel_key", ""))
+			var slot_index: int = int(record.get("slot_index", 0))
+			var slot_resolution: Dictionary = record.get("slot_resolution", {})
 			var visible_slot_index: int = int(slot_resolution.get("visible_slot_index", slot_index))
 			wheel_slot_state[wheel_key] = visible_slot_index
 			var wheel_controls := {
@@ -111,11 +131,13 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 			var gobo_texture: Texture2D = texture_entry.get("texture", null) as Texture2D
 			if gobo_texture == null:
 				continue
+			var secondary_texture: Texture2D = texture_entry.get("secondary_texture", gobo_texture) as Texture2D
+			if secondary_texture == null:
+				secondary_texture = gobo_texture
 			wheel_transition_state[wheel_key] = texture_entry.get("transition_key", "")
 			if bool(texture_entry.get("shader_transition_enabled", false)):
 				shader_transition_state = {
 					"enabled": true,
-					"secondary_texture": texture_entry.get("secondary_texture", null),
 					"progress": float(texture_entry.get("shader_transition_progress", 0.0)),
 					"direction": float(texture_entry.get("shader_transition_direction", 1.0)),
 				}
@@ -136,6 +158,7 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 				projected_rotation_deg = wheel_rotation_deg
 				projected_shake_tilt_deg = wheel_shake_tilt_deg
 			source_textures.append(gobo_texture)
+			source_secondary_textures.append(secondary_texture)
 
 	var composed_texture_cache_key: String = _build_composed_gobo_cache_key(source_texture_cache_keys)
 	var prefer_native_fog_projector: bool = bool(controls.get("prefer_native_fog_projector", true))
@@ -170,8 +193,15 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 		var projected_gobo: Texture2D = _compose_gobo_textures(source_textures, composed_texture_cache_key)
 		var visual_controls: Dictionary = gobo_controls.duplicate(true)
 		if bool(shader_transition_state.get("enabled", false)):
+			var secondary_cache_keys: PackedStringArray = PackedStringArray()
+			for key in source_texture_cache_keys:
+				secondary_cache_keys.append("secondary_%s" % str(key))
+			var projected_gobo_secondary: Texture2D = _compose_gobo_textures(
+				source_secondary_textures,
+				_build_composed_gobo_cache_key(secondary_cache_keys)
+			)
 			visual_controls["gobo_shader_transition_enabled"] = true
-			visual_controls["gobo_shader_transition_secondary_texture"] = shader_transition_state.get("secondary_texture", null)
+			visual_controls["gobo_shader_transition_secondary_texture"] = projected_gobo_secondary
 			visual_controls["gobo_shader_transition_progress"] = float(shader_transition_state.get("progress", 0.0))
 			visual_controls["gobo_shader_transition_direction"] = float(shader_transition_state.get("direction", 1.0))
 			visual_controls["prefer_native_fog_projector"] = false
@@ -201,6 +231,9 @@ func _resolve_wheel_rotation_deg(light: SpotLight3D, controls: Dictionary, wheel
 	var wheel_spin_state: Dictionary = light.get_meta(GOBO_WHEEL_SPIN_META_KEY, {})
 	if wheel_spin_state is not Dictionary:
 		wheel_spin_state = {}
+	var slot_rotation_state: Dictionary = light.get_meta(GOBO_SLOT_ROTATION_META_KEY, {})
+	if slot_rotation_state is not Dictionary:
+		slot_rotation_state = {}
 	var shake_phase_state: Dictionary = light.get_meta(GOBO_WHEEL_SHAKE_PHASE_META_KEY, {})
 	if shake_phase_state is not Dictionary:
 		shake_phase_state = {}
@@ -230,10 +263,10 @@ func _resolve_wheel_rotation_deg(light: SpotLight3D, controls: Dictionary, wheel
 		else:
 			base_rotation_deg = lerp(0.0, GOBO_INDEX_MAX_DEG, clamp(index_norm, 0.0, 1.0))
 
-	var spin_angle_deg: float = float(wheel_spin_state.get(wheel_key, 0.0))
-	var has_native_speed: bool = bool(wheel.get("wheel_spin_has_physical_value", wheel.get("has_rotation_physical_value", false)))
-	var native_speed_deg_per_sec: float = float(wheel.get("wheel_spin_speed_deg_per_sec", wheel.get("rotation_speed_deg_per_sec", wheel.get("rotation_physical", 0.0))))
-	var native_is_stop: bool = bool(wheel.get("wheel_spin_is_stop", wheel.get("is_stop", false)))
+	var slot_rotation_angle_deg: float = float(slot_rotation_state.get(wheel_key, 0.0))
+	var has_native_speed: bool = bool(wheel.get("slot_rotation_has_physical_value", wheel.get("has_rotation_physical_value", false)))
+	var native_speed_deg_per_sec: float = float(wheel.get("slot_rotation_speed_deg_per_sec", wheel.get("rotation_speed_deg_per_sec", wheel.get("rotation_physical", 0.0))))
+	var native_is_stop: bool = bool(wheel.get("slot_rotation_is_stop", wheel.get("is_stop", false)))
 	var has_active_rotation_command: bool = supports_rotation and has_native_speed and not native_is_stop and absf(native_speed_deg_per_sec) > 0.0001
 	var shake_offset_deg: float = 0.0
 	var debug_override: Dictionary = _resolve_debug_rotation_override(controls)
@@ -257,7 +290,9 @@ func _resolve_wheel_rotation_deg(light: SpotLight3D, controls: Dictionary, wheel
 
 	if index_norm >= 0.0 and not has_active_rotation_command:
 		wheel_spin_state[wheel_key] = 0.0
+		slot_rotation_state[wheel_key] = 0.0
 		light.set_meta(GOBO_WHEEL_SPIN_META_KEY, wheel_spin_state)
+		light.set_meta(GOBO_SLOT_ROTATION_META_KEY, slot_rotation_state)
 		if not should_apply_shake_effect:
 			shake_phase_state[wheel_key] = 0.0
 			shake_range_state[wheel_key] = ""
@@ -268,7 +303,9 @@ func _resolve_wheel_rotation_deg(light: SpotLight3D, controls: Dictionary, wheel
 	if supports_rotation and delta_sec > 0.0:
 		if not has_native_speed:
 			wheel_spin_state[wheel_key] = 0.0
+			slot_rotation_state[wheel_key] = 0.0
 			light.set_meta(GOBO_WHEEL_SPIN_META_KEY, wheel_spin_state)
+			light.set_meta(GOBO_SLOT_ROTATION_META_KEY, slot_rotation_state)
 			if not should_apply_shake_effect:
 				shake_phase_state[wheel_key] = 0.0
 				shake_range_state[wheel_key] = ""
@@ -281,17 +318,21 @@ func _resolve_wheel_rotation_deg(light: SpotLight3D, controls: Dictionary, wheel
 				speed_deg_per_sec = 0.0
 			elif bool(debug_override.get("force_rotation_speed", false)):
 				speed_deg_per_sec = float(debug_override.get("rotation_speed_deg_per_sec", native_speed_deg_per_sec))
-		var is_stop: bool = bool(wheel.get("is_stop", false))
+		var is_stop: bool = native_is_stop
 		if is_stop:
-			spin_angle_deg = 0.0
+			slot_rotation_angle_deg = 0.0
 		else:
-			spin_angle_deg = wrapf(spin_angle_deg + (speed_deg_per_sec * delta_sec), -360000.0, 360000.0)
-		wheel_spin_state[wheel_key] = spin_angle_deg
+			slot_rotation_angle_deg = wrapf(slot_rotation_angle_deg + (speed_deg_per_sec * delta_sec), -360000.0, 360000.0)
+		wheel_spin_state[wheel_key] = 0.0
+		slot_rotation_state[wheel_key] = slot_rotation_angle_deg
 		light.set_meta(GOBO_WHEEL_SPIN_META_KEY, wheel_spin_state)
+		light.set_meta(GOBO_SLOT_ROTATION_META_KEY, slot_rotation_state)
 
 	if not supports_rotation:
 		wheel_spin_state[wheel_key] = 0.0
+		slot_rotation_state[wheel_key] = 0.0
 		light.set_meta(GOBO_WHEEL_SPIN_META_KEY, wheel_spin_state)
+		light.set_meta(GOBO_SLOT_ROTATION_META_KEY, slot_rotation_state)
 		if not should_apply_shake_effect:
 			shake_phase_state[wheel_key] = 0.0
 			shake_range_state[wheel_key] = ""
@@ -299,10 +340,7 @@ func _resolve_wheel_rotation_deg(light: SpotLight3D, controls: Dictionary, wheel
 			light.set_meta(GOBO_WHEEL_SHAKE_RANGE_META_KEY, shake_range_state)
 			return {"rotation_deg": base_rotation_deg, "shake_tilt_deg": shake_offset_deg}
 
-	var slot_rotation_deg: float = 0.0
-	if bool(wheel.get("slot_rotation_has_physical_value", false)) and not bool(wheel.get("slot_rotation_is_stop", false)):
-		slot_rotation_deg = float(wheel.get("slot_rotation_speed_deg_per_sec", 0.0)) * max(delta_sec, 0.0)
-	base_rotation_deg += spin_angle_deg + slot_rotation_deg
+	base_rotation_deg += slot_rotation_angle_deg
 	if should_apply_shake_effect:
 		var current_shake_range_signature: String = _resolve_shake_range_signature(wheel)
 		var previous_shake_range_signature: String = str(shake_range_state.get(wheel_key, ""))
@@ -817,6 +855,7 @@ func _clear_gobo_visuals(light: SpotLight3D) -> void:
 	light.set_meta(GOBO_APPLIED_ROTATION_DEG_META_KEY, GOBO_DEFAULT_ROTATION_DEG)
 	light.remove_meta(GOBO_APPLIED_STATE_META_KEY)
 	light.remove_meta(GOBO_WHEEL_SPIN_META_KEY)
+	light.remove_meta(GOBO_SLOT_ROTATION_META_KEY)
 	light.remove_meta(GOBO_WHEEL_ANGLE_META_KEY)
 	light.remove_meta(GOBO_WHEEL_TARGET_SLOT_META_KEY)
 	light.remove_meta(GOBO_WHEEL_MOVEMENT_STATE_META_KEY)

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -15,6 +15,7 @@ const GOBO_MAX_SCALE: float = 6.4
 const GOBO_APERTURE_SCALE: float = 1.05
 const GOBO_DEFAULT_SCALE: float = 1.0
 const GOBO_DEFAULT_ROTATION_DEG: float = 0.0
+const GOBO_WHEEL_TRANSITION_STEPS: int = 16
 const VECTOR_FALLBACK_GOBO_CACHE_KEY: String = "__vector_fallback_gobo"
 const GOBO_VECTOR_POLYGONS_META_KEY: String = "peraviz_gobo_vector_polygons"
 const GOBO_VECTOR_WIDTH_META_KEY: String = "peraviz_gobo_vector_width"
@@ -83,6 +84,7 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 	var source_textures: Array[Texture2D] = []
 	var source_texture_cache_keys: PackedStringArray = PackedStringArray()
 	var wheel_slot_state: Dictionary = {}
+	var wheel_transition_state: Dictionary = {}
 	var wheel_mode_state: Dictionary = {}
 	var global_rotation_deg: float = float(controls.get("gobo_rotation_deg", GOBO_DEFAULT_ROTATION_DEG))
 	var projected_rotation_deg: float = global_rotation_deg
@@ -103,10 +105,11 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 			var wheel_controls := {
 				"gobo_slots": wheel.get("slots", []),
 			}
-			var texture_entry: Dictionary = _resolve_gobo_texture_entry_for_slot(wheel_controls, visible_slot_index)
+			var texture_entry: Dictionary = _resolve_wheel_motion_texture_entry(wheel_controls, slot_resolution)
 			var gobo_texture: Texture2D = texture_entry.get("texture", null) as Texture2D
 			if gobo_texture == null:
 				continue
+			wheel_transition_state[wheel_key] = texture_entry.get("transition_key", "")
 			source_texture_cache_keys.append(str(texture_entry.get("cache_key", "")))
 
 			var wheel_motion: Dictionary = _resolve_wheel_rotation_deg(light, gobo_controls, wheel, global_rotation_deg, delta_sec)
@@ -135,6 +138,7 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 		"mode": mode,
 		"has_gobo": has_runtime_gobo,
 		"wheel_slot_index_by_wheel": wheel_slot_state,
+		"wheel_transition_by_wheel": wheel_transition_state,
 		"wheel_mode_by_wheel": wheel_mode_state,
 		"texture_cache_key": composed_texture_cache_key,
 		"gobo_scale": float(controls.get("gobo_scale", GOBO_DEFAULT_SCALE)),
@@ -449,8 +453,10 @@ func _resolve_visible_slot_index(light: SpotLight3D, wheel: Dictionary, target_s
 	var target_center_deg: float = (float(normalized_target_slot - 1) + 0.5) * (360.0 / float(slot_count))
 	var wheel_spin_speed_deg_per_sec: float = absf(float(wheel.get("wheel_spin_speed_deg_per_sec", 0.0)))
 	var step_speed_deg_per_sec: float = maxf(wheel_spin_speed_deg_per_sec, 180.0)
+	var stepping_sign: float = 0.0
 	if delta_sec > 0.0:
 		var delta_to_target_deg: float = wrapf(target_center_deg - current_angle_deg, -180.0, 180.0)
+		stepping_sign = signf(delta_to_target_deg)
 		var max_step_deg: float = step_speed_deg_per_sec * delta_sec
 		if absf(delta_to_target_deg) <= max_step_deg:
 			current_angle_deg = target_center_deg
@@ -464,15 +470,113 @@ func _resolve_visible_slot_index(light: SpotLight3D, wheel: Dictionary, target_s
 	light.set_meta(GOBO_WHEEL_TARGET_SLOT_META_KEY, target_slot_state)
 	light.set_meta(GOBO_WHEEL_MOVEMENT_STATE_META_KEY, movement_state)
 	var slot_window_deg: float = 360.0 / float(slot_count)
-	var visible_slot_index: int = int(floor(current_angle_deg / slot_window_deg)) + 1
-	if visible_slot_index > slot_count:
-		visible_slot_index = 1
+	var normalized_position: float = current_angle_deg / slot_window_deg
+	var base_slot_zero_index: int = int(floor(normalized_position))
+	var fractional_progress: float = normalized_position - floor(normalized_position)
+	base_slot_zero_index = posmod(base_slot_zero_index, slot_count)
+	var movement_direction_sign: int = 0
+	var spin_speed_signed: float = float(wheel.get("wheel_spin_speed_deg_per_sec", 0.0))
+	if absf(spin_speed_signed) > 0.0001:
+		movement_direction_sign = 1 if spin_speed_signed > 0.0 else -1
+	elif absf(stepping_sign) > 0.0001:
+		movement_direction_sign = 1 if stepping_sign > 0.0 else -1
+	var outgoing_slot_index: int = base_slot_zero_index + 1
+	var incoming_slot_index: int = outgoing_slot_index
+	var motion_progress: float = 0.0
+	if movement_direction_sign > 0:
+		incoming_slot_index = ((base_slot_zero_index + 1) % slot_count) + 1
+		motion_progress = clamp(fractional_progress, 0.0, 1.0)
+	elif movement_direction_sign < 0:
+		incoming_slot_index = ((base_slot_zero_index - 1 + slot_count) % slot_count) + 1
+		motion_progress = clamp(1.0 - fractional_progress, 0.0, 1.0)
+	var visible_slot_index: int = outgoing_slot_index if motion_progress < 0.5 else incoming_slot_index
 	return {
 		"visible_slot_index": clampi(visible_slot_index, 1, slot_count),
 		"wheel_angle_deg": current_angle_deg,
 		"target_slot_index": normalized_target_slot,
 		"movement_state": str(movement_state.get(wheel_key, "")),
+		"movement_direction_sign": movement_direction_sign,
+		"outgoing_slot_index": outgoing_slot_index,
+		"incoming_slot_index": incoming_slot_index,
+		"motion_progress": motion_progress,
 	}
+
+func _resolve_wheel_motion_texture_entry(controls: Dictionary, slot_resolution: Dictionary) -> Dictionary:
+	var outgoing_slot_index: int = int(slot_resolution.get("outgoing_slot_index", slot_resolution.get("visible_slot_index", -1)))
+	var incoming_slot_index: int = int(slot_resolution.get("incoming_slot_index", outgoing_slot_index))
+	var movement_direction_sign: int = int(slot_resolution.get("movement_direction_sign", 0))
+	var motion_progress: float = clamp(float(slot_resolution.get("motion_progress", 0.0)), 0.0, 1.0)
+	var outgoing_entry: Dictionary = _resolve_gobo_texture_entry_for_slot(controls, outgoing_slot_index)
+	if outgoing_entry.is_empty():
+		return {}
+	if movement_direction_sign == 0 or incoming_slot_index == outgoing_slot_index or motion_progress <= 0.001:
+		outgoing_entry["transition_key"] = "slot_%d_static" % outgoing_slot_index
+		return outgoing_entry
+	var incoming_entry: Dictionary = _resolve_gobo_texture_entry_for_slot(controls, incoming_slot_index)
+	if incoming_entry.is_empty():
+		outgoing_entry["transition_key"] = "slot_%d_no_incoming" % outgoing_slot_index
+		return outgoing_entry
+	var quantized_step: int = clampi(int(round(motion_progress * float(GOBO_WHEEL_TRANSITION_STEPS))), 0, GOBO_WHEEL_TRANSITION_STEPS)
+	var cache_key: String = "__wheel_motion_%s_%s_%d_%d" % [
+		str(outgoing_entry.get("cache_key", "")),
+		str(incoming_entry.get("cache_key", "")),
+		movement_direction_sign,
+		quantized_step,
+	]
+	var quantized_progress: float = float(quantized_step) / float(max(GOBO_WHEEL_TRANSITION_STEPS, 1))
+	var transition_texture: Texture2D = _compose_wheel_motion_texture(
+		outgoing_entry.get("texture", null) as Texture2D,
+		incoming_entry.get("texture", null) as Texture2D,
+		quantized_progress,
+		movement_direction_sign,
+		cache_key
+	)
+	if transition_texture == null:
+		outgoing_entry["transition_key"] = "slot_%d_transition_fallback" % outgoing_slot_index
+		return outgoing_entry
+	return {
+		"texture": transition_texture,
+		"cache_key": cache_key,
+		"transition_key": "slot_%d_to_%d_dir_%d_step_%d" % [outgoing_slot_index, incoming_slot_index, movement_direction_sign, quantized_step],
+	}
+
+func _compose_wheel_motion_texture(outgoing_texture: Texture2D, incoming_texture: Texture2D, progress: float, movement_direction_sign: int, cache_key: String) -> Texture2D:
+	if outgoing_texture == null:
+		return null
+	if incoming_texture == null or movement_direction_sign == 0 or progress <= 0.001:
+		return outgoing_texture
+	if _texture_cache.has(cache_key):
+		return _texture_cache[cache_key] as Texture2D
+	var outgoing_image: Image = outgoing_texture.get_image()
+	var incoming_image: Image = incoming_texture.get_image()
+	if outgoing_image == null or incoming_image == null:
+		return outgoing_texture
+	if outgoing_image.get_width() != FAKE_GOBO_TEXTURE_SIZE or outgoing_image.get_height() != FAKE_GOBO_TEXTURE_SIZE:
+		outgoing_image.resize(FAKE_GOBO_TEXTURE_SIZE, FAKE_GOBO_TEXTURE_SIZE, Image.INTERPOLATE_LANCZOS)
+	if incoming_image.get_width() != FAKE_GOBO_TEXTURE_SIZE or incoming_image.get_height() != FAKE_GOBO_TEXTURE_SIZE:
+		incoming_image.resize(FAKE_GOBO_TEXTURE_SIZE, FAKE_GOBO_TEXTURE_SIZE, Image.INTERPOLATE_LANCZOS)
+	var result_image: Image = Image.create(FAKE_GOBO_TEXTURE_SIZE, FAKE_GOBO_TEXTURE_SIZE, false, Image.FORMAT_RGBA8)
+	result_image.fill(Color(0.0, 0.0, 0.0, 1.0))
+	var signed_direction: float = float(movement_direction_sign)
+	var outgoing_offset_px: float = progress * float(FAKE_GOBO_TEXTURE_SIZE) * signed_direction
+	var incoming_offset_px: float = (progress - 1.0) * float(FAKE_GOBO_TEXTURE_SIZE) * signed_direction
+	for y in range(FAKE_GOBO_TEXTURE_SIZE):
+		for x in range(FAKE_GOBO_TEXTURE_SIZE):
+			var outgoing_sample_x: int = int(round(float(x) - outgoing_offset_px))
+			var incoming_sample_x: int = int(round(float(x) - incoming_offset_px))
+			var outgoing_luma: float = 0.0
+			var incoming_luma: float = 0.0
+			if outgoing_sample_x >= 0 and outgoing_sample_x < FAKE_GOBO_TEXTURE_SIZE:
+				var outgoing_color: Color = outgoing_image.get_pixel(outgoing_sample_x, y)
+				outgoing_luma = ((outgoing_color.r + outgoing_color.g + outgoing_color.b) / 3.0) * outgoing_color.a
+			if incoming_sample_x >= 0 and incoming_sample_x < FAKE_GOBO_TEXTURE_SIZE:
+				var incoming_color: Color = incoming_image.get_pixel(incoming_sample_x, y)
+				incoming_luma = ((incoming_color.r + incoming_color.g + incoming_color.b) / 3.0) * incoming_color.a
+			var output_luma: float = clamp(maxf(outgoing_luma, incoming_luma), 0.0, 1.0)
+			result_image.set_pixel(x, y, Color(output_luma, output_luma, output_luma, output_luma))
+	var result_texture: ImageTexture = ImageTexture.create_from_image(result_image)
+	_texture_cache[cache_key] = result_texture
+	return result_texture
 
 func _triangle_wave_centered_zero(phase: float) -> float:
 	var wrapped_phase: float = wrapf(phase, 0.0, 1.0)

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -85,6 +85,7 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 	var source_texture_cache_keys: PackedStringArray = PackedStringArray()
 	var wheel_slot_state: Dictionary = {}
 	var wheel_transition_state: Dictionary = {}
+	var shader_transition_state: Dictionary = {}
 	var wheel_mode_state: Dictionary = {}
 	var global_rotation_deg: float = float(controls.get("gobo_rotation_deg", GOBO_DEFAULT_ROTATION_DEG))
 	var projected_rotation_deg: float = global_rotation_deg
@@ -92,6 +93,7 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 	var has_bound_wheel_rotation: bool = false
 
 	if has_runtime_gobo:
+		var can_use_shader_transition: bool = runtime_bindings.size() == 1
 		for wheel in runtime_bindings:
 			if wheel is not Dictionary:
 				continue
@@ -103,11 +105,18 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 			var wheel_controls := {
 				"gobo_slots": wheel.get("slots", []),
 			}
-			var texture_entry: Dictionary = _resolve_wheel_motion_texture_entry(wheel_controls, slot_resolution)
+			var texture_entry: Dictionary = _resolve_wheel_motion_texture_entry(wheel_controls, slot_resolution, can_use_shader_transition)
 			var gobo_texture: Texture2D = texture_entry.get("texture", null) as Texture2D
 			if gobo_texture == null:
 				continue
 			wheel_transition_state[wheel_key] = texture_entry.get("transition_key", "")
+			if bool(texture_entry.get("shader_transition_enabled", false)):
+				shader_transition_state = {
+					"enabled": true,
+					"secondary_texture": texture_entry.get("secondary_texture", null),
+					"progress": float(texture_entry.get("shader_transition_progress", 0.0)),
+					"direction": float(texture_entry.get("shader_transition_direction", 1.0)),
+				}
 			source_texture_cache_keys.append(str(texture_entry.get("cache_key", "")))
 
 			var wheel_motion: Dictionary = _resolve_wheel_rotation_deg(light, gobo_controls, wheel, global_rotation_deg, delta_sec)
@@ -128,6 +137,8 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 
 	var composed_texture_cache_key: String = _build_composed_gobo_cache_key(source_texture_cache_keys)
 	var prefer_native_fog_projector: bool = bool(controls.get("prefer_native_fog_projector", true))
+	if bool(shader_transition_state.get("enabled", false)):
+		prefer_native_fog_projector = false
 	var has_composed_texture: bool = not source_textures.is_empty()
 	var mode: String = "fallback_vector"
 	if has_runtime_gobo and has_composed_texture:
@@ -137,6 +148,7 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 		"has_gobo": has_runtime_gobo,
 		"wheel_slot_index_by_wheel": wheel_slot_state,
 		"wheel_transition_by_wheel": wheel_transition_state,
+		"shader_transition": shader_transition_state,
 		"wheel_mode_by_wheel": wheel_mode_state,
 		"texture_cache_key": composed_texture_cache_key,
 		"gobo_scale": float(controls.get("gobo_scale", GOBO_DEFAULT_SCALE)),
@@ -154,7 +166,14 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 		_apply_vector_fallback_gobo(light, previous_meta_texture, gobo_controls)
 	else:
 		var projected_gobo: Texture2D = _compose_gobo_textures(source_textures, composed_texture_cache_key)
-		_apply_gobo_visuals(light, projected_gobo, gobo_controls)
+		var visual_controls: Dictionary = gobo_controls.duplicate(true)
+		if bool(shader_transition_state.get("enabled", false)):
+			visual_controls["gobo_shader_transition_enabled"] = true
+			visual_controls["gobo_shader_transition_secondary_texture"] = shader_transition_state.get("secondary_texture", null)
+			visual_controls["gobo_shader_transition_progress"] = float(shader_transition_state.get("progress", 0.0))
+			visual_controls["gobo_shader_transition_direction"] = float(shader_transition_state.get("direction", 1.0))
+			visual_controls["prefer_native_fog_projector"] = false
+		_apply_gobo_visuals(light, projected_gobo, visual_controls)
 		light.set_meta(GOBO_TEXTURE_META_KEY, projected_gobo)
 		light.set_meta(FALLBACK_GOBO_META_KEY, false)
 
@@ -468,6 +487,24 @@ func _resolve_visible_slot_index(light: SpotLight3D, wheel: Dictionary, target_s
 			"incoming_slot_index": -1,
 			"motion_progress": 0.0,
 		}
+	if not has_active_spin:
+		current_angle_deg = target_center_deg
+		wheel_angle_state[wheel_key] = current_angle_deg
+		target_slot_state[wheel_key] = normalized_target_slot
+		movement_state[wheel_key] = "aligned"
+		light.set_meta(GOBO_WHEEL_ANGLE_META_KEY, wheel_angle_state)
+		light.set_meta(GOBO_WHEEL_TARGET_SLOT_META_KEY, target_slot_state)
+		light.set_meta(GOBO_WHEEL_MOVEMENT_STATE_META_KEY, movement_state)
+		return {
+			"visible_slot_index": normalized_target_slot,
+			"wheel_angle_deg": current_angle_deg,
+			"target_slot_index": normalized_target_slot,
+			"movement_state": "aligned",
+			"movement_direction_sign": 0,
+			"outgoing_slot_index": normalized_target_slot,
+			"incoming_slot_index": normalized_target_slot,
+			"motion_progress": 0.0,
+		}
 	var step_speed_deg_per_sec: float = maxf(wheel_spin_speed_deg_per_sec, 180.0)
 	var stepping_sign: float = 0.0
 	if delta_sec > 0.0:
@@ -527,7 +564,7 @@ func _resolve_visible_slot_index(light: SpotLight3D, wheel: Dictionary, target_s
 		"motion_progress": motion_progress,
 	}
 
-func _resolve_wheel_motion_texture_entry(controls: Dictionary, slot_resolution: Dictionary) -> Dictionary:
+func _resolve_wheel_motion_texture_entry(controls: Dictionary, slot_resolution: Dictionary, allow_shader_transition: bool) -> Dictionary:
 	var outgoing_slot_index: int = int(slot_resolution.get("outgoing_slot_index", slot_resolution.get("visible_slot_index", -1)))
 	var incoming_slot_index: int = int(slot_resolution.get("incoming_slot_index", outgoing_slot_index))
 	var movement_direction_sign: int = int(slot_resolution.get("movement_direction_sign", 0))
@@ -542,6 +579,16 @@ func _resolve_wheel_motion_texture_entry(controls: Dictionary, slot_resolution: 
 	if incoming_entry.is_empty():
 		outgoing_entry["transition_key"] = "slot_%d_no_incoming" % outgoing_slot_index
 		return outgoing_entry
+	if allow_shader_transition:
+		return {
+			"texture": outgoing_entry.get("texture", null),
+			"secondary_texture": incoming_entry.get("texture", null),
+			"cache_key": str(outgoing_entry.get("cache_key", "")),
+			"transition_key": "shader_%d_to_%d_%d_%.4f" % [outgoing_slot_index, incoming_slot_index, movement_direction_sign, motion_progress],
+			"shader_transition_enabled": true,
+			"shader_transition_progress": motion_progress,
+			"shader_transition_direction": float(movement_direction_sign),
+		}
 	var quantized_step: int = clampi(int(round(motion_progress * float(GOBO_WHEEL_TRANSITION_STEPS))), 0, GOBO_WHEEL_TRANSITION_STEPS)
 	var cache_key: String = "__wheel_motion_%s_%s_%d_%d" % [
 		str(outgoing_entry.get("cache_key", "")),
@@ -663,6 +710,25 @@ func _apply_gobo_visuals(light: SpotLight3D, gobo_texture: Texture2D, controls: 
 	if gobo_plane.material_override is ShaderMaterial:
 		var gobo_material: ShaderMaterial = gobo_plane.material_override as ShaderMaterial
 		gobo_material.set_shader_parameter("gobo_texture", gobo_texture)
+		var transition_enabled: bool = bool(controls.get("gobo_shader_transition_enabled", false))
+		gobo_material.set_shader_parameter("gobo_transition_enabled", transition_enabled)
+		if transition_enabled:
+			gobo_material.set_shader_parameter(
+				"gobo_texture_secondary",
+				controls.get("gobo_shader_transition_secondary_texture", gobo_texture)
+			)
+			gobo_material.set_shader_parameter(
+				"gobo_transition_progress",
+				clamp(float(controls.get("gobo_shader_transition_progress", 0.0)), 0.0, 1.0)
+			)
+			gobo_material.set_shader_parameter(
+				"gobo_transition_direction",
+				1.0 if float(controls.get("gobo_shader_transition_direction", 1.0)) >= 0.0 else -1.0
+			)
+		else:
+			gobo_material.set_shader_parameter("gobo_texture_secondary", gobo_texture)
+			gobo_material.set_shader_parameter("gobo_transition_progress", 0.0)
+			gobo_material.set_shader_parameter("gobo_transition_direction", 1.0)
 	_update_gobo_plane_scale(light, gobo_plane)
 
 

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -20,6 +20,9 @@ const GOBO_VECTOR_POLYGONS_META_KEY: String = "peraviz_gobo_vector_polygons"
 const GOBO_VECTOR_WIDTH_META_KEY: String = "peraviz_gobo_vector_width"
 const GOBO_VECTOR_HEIGHT_META_KEY: String = "peraviz_gobo_vector_height"
 const GOBO_WHEEL_SPIN_META_KEY: String = "peraviz_gobo_wheel_spin"
+const GOBO_WHEEL_ANGLE_META_KEY: String = "peraviz_gobo_wheel_angle_deg"
+const GOBO_WHEEL_TARGET_SLOT_META_KEY: String = "peraviz_gobo_target_slot"
+const GOBO_WHEEL_MOVEMENT_STATE_META_KEY: String = "peraviz_gobo_wheel_movement_state"
 const GOBO_WHEEL_SHAKE_PHASE_META_KEY: String = "peraviz_gobo_wheel_shake_phase"
 const GOBO_WHEEL_SHAKE_RANGE_META_KEY: String = "peraviz_gobo_wheel_shake_range"
 const GOBO_LAST_UPDATE_MSEC_META_KEY: String = "peraviz_gobo_last_update_msec"
@@ -94,11 +97,13 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 			if slot_index <= 0:
 				continue
 			var wheel_key: String = _resolve_wheel_cache_key(wheel)
-			wheel_slot_state[wheel_key] = slot_index
+			var slot_resolution: Dictionary = _resolve_visible_slot_index(light, wheel, slot_index, delta_sec)
+			var visible_slot_index: int = int(slot_resolution.get("visible_slot_index", slot_index))
+			wheel_slot_state[wheel_key] = visible_slot_index
 			var wheel_controls := {
 				"gobo_slots": wheel.get("slots", []),
 			}
-			var texture_entry: Dictionary = _resolve_gobo_texture_entry_for_slot(wheel_controls, slot_index)
+			var texture_entry: Dictionary = _resolve_gobo_texture_entry_for_slot(wheel_controls, visible_slot_index)
 			var gobo_texture: Texture2D = texture_entry.get("texture", null) as Texture2D
 			if gobo_texture == null:
 				continue
@@ -203,9 +208,9 @@ func _resolve_wheel_rotation_deg(light: SpotLight3D, controls: Dictionary, wheel
 			base_rotation_deg = lerp(0.0, GOBO_INDEX_MAX_DEG, clamp(index_norm, 0.0, 1.0))
 
 	var spin_angle_deg: float = float(wheel_spin_state.get(wheel_key, 0.0))
-	var has_native_speed: bool = bool(wheel.get("has_rotation_physical_value", false))
-	var native_speed_deg_per_sec: float = float(wheel.get("rotation_speed_deg_per_sec", wheel.get("rotation_physical", 0.0)))
-	var native_is_stop: bool = bool(wheel.get("is_stop", false))
+	var has_native_speed: bool = bool(wheel.get("wheel_spin_has_physical_value", wheel.get("has_rotation_physical_value", false)))
+	var native_speed_deg_per_sec: float = float(wheel.get("wheel_spin_speed_deg_per_sec", wheel.get("rotation_speed_deg_per_sec", wheel.get("rotation_physical", 0.0))))
+	var native_is_stop: bool = bool(wheel.get("wheel_spin_is_stop", wheel.get("is_stop", false)))
 	var has_active_rotation_command: bool = supports_rotation and has_native_speed and not native_is_stop and absf(native_speed_deg_per_sec) > 0.0001
 	var shake_offset_deg: float = 0.0
 	var debug_override: Dictionary = _resolve_debug_rotation_override(controls)
@@ -271,7 +276,10 @@ func _resolve_wheel_rotation_deg(light: SpotLight3D, controls: Dictionary, wheel
 			light.set_meta(GOBO_WHEEL_SHAKE_RANGE_META_KEY, shake_range_state)
 			return {"rotation_deg": base_rotation_deg, "shake_tilt_deg": shake_offset_deg}
 
-	base_rotation_deg += spin_angle_deg
+	var slot_rotation_deg: float = 0.0
+	if bool(wheel.get("slot_rotation_has_physical_value", false)) and not bool(wheel.get("slot_rotation_is_stop", false)):
+		slot_rotation_deg = float(wheel.get("slot_rotation_speed_deg_per_sec", 0.0)) * max(delta_sec, 0.0)
+	base_rotation_deg += spin_angle_deg + slot_rotation_deg
 	if should_apply_shake_effect:
 		var current_shake_range_signature: String = _resolve_shake_range_signature(wheel)
 		var previous_shake_range_signature: String = str(shake_range_state.get(wheel_key, ""))
@@ -420,6 +428,52 @@ func _handle_wheel_mode_transition(light: SpotLight3D, wheel_key: String, effect
 		light.set_meta(GOBO_WHEEL_SPIN_META_KEY, wheel_spin_state)
 	return true
 
+func _resolve_visible_slot_index(light: SpotLight3D, wheel: Dictionary, target_slot_index: int, delta_sec: float) -> Dictionary:
+	var wheel_key: String = _resolve_wheel_cache_key(wheel)
+	var wheel_angle_state: Dictionary = light.get_meta(GOBO_WHEEL_ANGLE_META_KEY, {})
+	if wheel_angle_state is not Dictionary:
+		wheel_angle_state = {}
+	var target_slot_state: Dictionary = light.get_meta(GOBO_WHEEL_TARGET_SLOT_META_KEY, {})
+	if target_slot_state is not Dictionary:
+		target_slot_state = {}
+	var movement_state: Dictionary = light.get_meta(GOBO_WHEEL_MOVEMENT_STATE_META_KEY, {})
+	if movement_state is not Dictionary:
+		movement_state = {}
+
+	var slots: Array = wheel.get("slots", [])
+	var slot_count: int = slots.size()
+	if slot_count <= 0:
+		return {"visible_slot_index": target_slot_index}
+	var current_angle_deg: float = float(wheel_angle_state.get(wheel_key, 0.0))
+	var normalized_target_slot: int = clampi(target_slot_index, 1, slot_count)
+	var target_center_deg: float = (float(normalized_target_slot - 1) + 0.5) * (360.0 / float(slot_count))
+	var wheel_spin_speed_deg_per_sec: float = absf(float(wheel.get("wheel_spin_speed_deg_per_sec", 0.0)))
+	var step_speed_deg_per_sec: float = maxf(wheel_spin_speed_deg_per_sec, 180.0)
+	if delta_sec > 0.0:
+		var delta_to_target_deg: float = wrapf(target_center_deg - current_angle_deg, -180.0, 180.0)
+		var max_step_deg: float = step_speed_deg_per_sec * delta_sec
+		if absf(delta_to_target_deg) <= max_step_deg:
+			current_angle_deg = target_center_deg
+			movement_state[wheel_key] = "aligned"
+		else:
+			current_angle_deg = wrapf(current_angle_deg + signf(delta_to_target_deg) * max_step_deg, 0.0, 360.0)
+			movement_state[wheel_key] = "stepping"
+	wheel_angle_state[wheel_key] = current_angle_deg
+	target_slot_state[wheel_key] = normalized_target_slot
+	light.set_meta(GOBO_WHEEL_ANGLE_META_KEY, wheel_angle_state)
+	light.set_meta(GOBO_WHEEL_TARGET_SLOT_META_KEY, target_slot_state)
+	light.set_meta(GOBO_WHEEL_MOVEMENT_STATE_META_KEY, movement_state)
+	var slot_window_deg: float = 360.0 / float(slot_count)
+	var visible_slot_index: int = int(floor(current_angle_deg / slot_window_deg)) + 1
+	if visible_slot_index > slot_count:
+		visible_slot_index = 1
+	return {
+		"visible_slot_index": clampi(visible_slot_index, 1, slot_count),
+		"wheel_angle_deg": current_angle_deg,
+		"target_slot_index": normalized_target_slot,
+		"movement_state": str(movement_state.get(wheel_key, "")),
+	}
+
 func _triangle_wave_centered_zero(phase: float) -> float:
 	var wrapped_phase: float = wrapf(phase, 0.0, 1.0)
 	return 1.0 - (4.0 * absf(wrapped_phase - 0.5))
@@ -524,6 +578,9 @@ func _clear_gobo_visuals(light: SpotLight3D) -> void:
 	light.set_meta(GOBO_APPLIED_ROTATION_DEG_META_KEY, GOBO_DEFAULT_ROTATION_DEG)
 	light.remove_meta(GOBO_APPLIED_STATE_META_KEY)
 	light.remove_meta(GOBO_WHEEL_SPIN_META_KEY)
+	light.remove_meta(GOBO_WHEEL_ANGLE_META_KEY)
+	light.remove_meta(GOBO_WHEEL_TARGET_SLOT_META_KEY)
+	light.remove_meta(GOBO_WHEEL_MOVEMENT_STATE_META_KEY)
 	light.remove_meta(GOBO_WHEEL_MODE_META_KEY)
 	light.remove_meta(GOBO_WHEEL_SHAKE_PHASE_META_KEY)
 	light.remove_meta(GOBO_WHEEL_SHAKE_RANGE_META_KEY)

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -16,6 +16,7 @@ const GOBO_APERTURE_SCALE: float = 1.05
 const GOBO_DEFAULT_SCALE: float = 1.0
 const GOBO_DEFAULT_ROTATION_DEG: float = 0.0
 const GOBO_WHEEL_TRANSITION_STEPS: int = 32
+const GOBO_SPIN_STOP_EPSILON_DPS: float = 0.5
 const VECTOR_FALLBACK_GOBO_CACHE_KEY: String = "__vector_fallback_gobo"
 const GOBO_VECTOR_POLYGONS_META_KEY: String = "peraviz_gobo_vector_polygons"
 const GOBO_VECTOR_WIDTH_META_KEY: String = "peraviz_gobo_vector_width"
@@ -462,16 +463,22 @@ func _resolve_visible_slot_index(light: SpotLight3D, wheel: Dictionary, target_s
 		movement_state = {}
 
 	var slots: Array = wheel.get("slots", [])
-	var slot_count: int = slots.size()
+	var renderable_slot_indices: Array = _collect_renderable_slot_indices_from_slots(slots)
+	var slot_count: int = renderable_slot_indices.size()
 	if slot_count <= 0:
 		return {"visible_slot_index": target_slot_index}
 	var current_angle_deg: float = float(wheel_angle_state.get(wheel_key, 0.0))
-	var previous_target_slot: int = int(target_slot_state.get(wheel_key, 1))
-	var normalized_target_slot: int = clampi(target_slot_index, 1, slot_count) if target_slot_index > 0 else clampi(previous_target_slot, 1, slot_count)
-	var target_center_deg: float = (float(normalized_target_slot - 1) + 0.5) * (360.0 / float(slot_count))
+	var previous_target_slot: int = int(target_slot_state.get(wheel_key, renderable_slot_indices[0]))
+	var normalized_target_slot: int = _resolve_renderable_target_slot_index(
+		target_slot_index,
+		previous_target_slot,
+		renderable_slot_indices
+	)
+	var target_position_index: int = _slot_index_position(normalized_target_slot, renderable_slot_indices)
+	var target_center_deg: float = (float(target_position_index) + 0.5) * (360.0 / float(slot_count))
 	var signed_wheel_spin_speed_deg_per_sec: float = float(wheel.get("wheel_spin_speed_deg_per_sec", 0.0))
 	var wheel_spin_speed_deg_per_sec: float = absf(signed_wheel_spin_speed_deg_per_sec)
-	var has_active_spin: bool = bool(wheel.get("wheel_spin_has_physical_value", false)) and not bool(wheel.get("wheel_spin_is_stop", false)) and wheel_spin_speed_deg_per_sec > 0.0001
+	var has_active_spin: bool = bool(wheel.get("wheel_spin_has_physical_value", false)) and not bool(wheel.get("wheel_spin_is_stop", false)) and wheel_spin_speed_deg_per_sec > GOBO_SPIN_STOP_EPSILON_DPS
 	if target_slot_index <= 0 and not has_active_spin:
 		target_slot_state[wheel_key] = clampi(previous_target_slot, 1, slot_count)
 		movement_state[wheel_key] = "open"
@@ -505,23 +512,11 @@ func _resolve_visible_slot_index(light: SpotLight3D, wheel: Dictionary, target_s
 			"incoming_slot_index": normalized_target_slot,
 			"motion_progress": 0.0,
 		}
-	var step_speed_deg_per_sec: float = maxf(wheel_spin_speed_deg_per_sec, 180.0)
 	var stepping_sign: float = 0.0
 	if delta_sec > 0.0:
-		if has_active_spin:
-			current_angle_deg = wrapf(current_angle_deg + (signed_wheel_spin_speed_deg_per_sec * delta_sec), 0.0, 360.0)
-			stepping_sign = signf(signed_wheel_spin_speed_deg_per_sec)
-			movement_state[wheel_key] = "spinning"
-		else:
-			var delta_to_target_deg: float = wrapf(target_center_deg - current_angle_deg, -180.0, 180.0)
-			stepping_sign = signf(delta_to_target_deg)
-			var max_step_deg: float = step_speed_deg_per_sec * delta_sec
-			if absf(delta_to_target_deg) <= max_step_deg:
-				current_angle_deg = target_center_deg
-				movement_state[wheel_key] = "aligned"
-			else:
-				current_angle_deg = wrapf(current_angle_deg + signf(delta_to_target_deg) * max_step_deg, 0.0, 360.0)
-				movement_state[wheel_key] = "stepping"
+		current_angle_deg = wrapf(current_angle_deg + (signed_wheel_spin_speed_deg_per_sec * delta_sec), 0.0, 360.0)
+		stepping_sign = signf(signed_wheel_spin_speed_deg_per_sec)
+		movement_state[wheel_key] = "spinning"
 	wheel_angle_state[wheel_key] = current_angle_deg
 	target_slot_state[wheel_key] = normalized_target_slot
 	light.set_meta(GOBO_WHEEL_ANGLE_META_KEY, wheel_angle_state)
@@ -529,16 +524,15 @@ func _resolve_visible_slot_index(light: SpotLight3D, wheel: Dictionary, target_s
 	light.set_meta(GOBO_WHEEL_MOVEMENT_STATE_META_KEY, movement_state)
 	var slot_window_deg: float = 360.0 / float(slot_count)
 	var normalized_position: float = current_angle_deg / slot_window_deg
-	var base_slot_zero_index: int = int(floor(normalized_position))
+	var base_slot_zero_index: int = posmod(int(floor(normalized_position)), slot_count)
 	var fractional_progress: float = normalized_position - floor(normalized_position)
-	base_slot_zero_index = posmod(base_slot_zero_index, slot_count)
 	var movement_direction_sign: int = 0
 	var spin_speed_signed: float = signed_wheel_spin_speed_deg_per_sec
 	if has_active_spin and absf(spin_speed_signed) > 0.0001:
 		movement_direction_sign = 1 if spin_speed_signed > 0.0 else -1
 	elif absf(stepping_sign) > 0.0001:
 		movement_direction_sign = 1 if stepping_sign > 0.0 else -1
-	var outgoing_slot_index: int = base_slot_zero_index + 1
+	var outgoing_slot_index: int = int(renderable_slot_indices[base_slot_zero_index])
 	var incoming_slot_index: int = outgoing_slot_index
 	var motion_progress: float = 0.0
 	if not has_active_spin and str(movement_state.get(wheel_key, "")) == "aligned":
@@ -547,10 +541,10 @@ func _resolve_visible_slot_index(light: SpotLight3D, wheel: Dictionary, target_s
 		movement_direction_sign = 0
 		motion_progress = 0.0
 	if movement_direction_sign > 0:
-		incoming_slot_index = ((base_slot_zero_index + 1) % slot_count) + 1
+		incoming_slot_index = int(renderable_slot_indices[(base_slot_zero_index + 1) % slot_count])
 		motion_progress = clamp(fractional_progress, 0.0, 1.0)
 	elif movement_direction_sign < 0:
-		incoming_slot_index = ((base_slot_zero_index - 1 + slot_count) % slot_count) + 1
+		incoming_slot_index = int(renderable_slot_indices[(base_slot_zero_index - 1 + slot_count) % slot_count])
 		motion_progress = clamp(1.0 - fractional_progress, 0.0, 1.0)
 	var visible_slot_index: int = outgoing_slot_index if motion_progress < 0.5 else incoming_slot_index
 	return {
@@ -563,6 +557,47 @@ func _resolve_visible_slot_index(light: SpotLight3D, wheel: Dictionary, target_s
 		"incoming_slot_index": incoming_slot_index,
 		"motion_progress": motion_progress,
 	}
+
+func _collect_renderable_slot_indices_from_slots(slots: Array) -> Array:
+	var renderable_indices: Array = []
+	var fallback_indices: Array = []
+	for slot_item in slots:
+		if slot_item is not Dictionary:
+			continue
+		var slot_index: int = int(slot_item.get("slot_index", -1))
+		if slot_index <= 0:
+			continue
+		fallback_indices.append(slot_index)
+		var image_path: String = str(slot_item.get("image_path", ""))
+		if image_path.is_empty():
+			continue
+		renderable_indices.append(slot_index)
+	if not renderable_indices.is_empty():
+		return renderable_indices
+	return fallback_indices
+
+func _slot_index_position(slot_index: int, renderable_slot_indices: Array) -> int:
+	var fallback_position: int = 0
+	for index in range(renderable_slot_indices.size()):
+		var candidate: int = int(renderable_slot_indices[index])
+		if candidate == slot_index:
+			return index
+		if candidate <= slot_index:
+			fallback_position = index
+	return fallback_position
+
+func _resolve_renderable_target_slot_index(target_slot_index: int, previous_target_slot: int, renderable_slot_indices: Array) -> int:
+	if renderable_slot_indices.is_empty():
+		return target_slot_index
+	if target_slot_index > 0:
+		for candidate in renderable_slot_indices:
+			if int(candidate) == target_slot_index:
+				return target_slot_index
+	var safe_previous: int = previous_target_slot if previous_target_slot > 0 else int(renderable_slot_indices[0])
+	for candidate in renderable_slot_indices:
+		if int(candidate) == safe_previous:
+			return safe_previous
+	return int(renderable_slot_indices[0])
 
 func _resolve_wheel_motion_texture_entry(controls: Dictionary, slot_resolution: Dictionary, allow_shader_transition: bool) -> Dictionary:
 	var outgoing_slot_index: int = int(slot_resolution.get("outgoing_slot_index", slot_resolution.get("visible_slot_index", -1)))

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -15,7 +15,7 @@ const GOBO_MAX_SCALE: float = 6.4
 const GOBO_APERTURE_SCALE: float = 1.05
 const GOBO_DEFAULT_SCALE: float = 1.0
 const GOBO_DEFAULT_ROTATION_DEG: float = 0.0
-const GOBO_WHEEL_TRANSITION_STEPS: int = 16
+const GOBO_WHEEL_TRANSITION_STEPS: int = 32
 const VECTOR_FALLBACK_GOBO_CACHE_KEY: String = "__vector_fallback_gobo"
 const GOBO_VECTOR_POLYGONS_META_KEY: String = "peraviz_gobo_vector_polygons"
 const GOBO_VECTOR_WIDTH_META_KEY: String = "peraviz_gobo_vector_width"
@@ -497,7 +497,7 @@ func _resolve_visible_slot_index(light: SpotLight3D, wheel: Dictionary, target_s
 	base_slot_zero_index = posmod(base_slot_zero_index, slot_count)
 	var movement_direction_sign: int = 0
 	var spin_speed_signed: float = signed_wheel_spin_speed_deg_per_sec
-	if absf(spin_speed_signed) > 0.0001:
+	if has_active_spin and absf(spin_speed_signed) > 0.0001:
 		movement_direction_sign = 1 if spin_speed_signed > 0.0 else -1
 	elif absf(stepping_sign) > 0.0001:
 		movement_direction_sign = 1 if stepping_sign > 0.0 else -1
@@ -581,23 +581,24 @@ func _compose_wheel_motion_texture(outgoing_texture: Texture2D, incoming_texture
 	var signed_direction: float = float(movement_direction_sign)
 	var outgoing_offset_px: float = progress * float(FAKE_GOBO_TEXTURE_SIZE) * signed_direction
 	var incoming_offset_px: float = (progress - 1.0) * float(FAKE_GOBO_TEXTURE_SIZE) * signed_direction
-	for y in range(FAKE_GOBO_TEXTURE_SIZE):
-		for x in range(FAKE_GOBO_TEXTURE_SIZE):
-			var outgoing_sample_x: int = int(round(float(x) - outgoing_offset_px))
-			var incoming_sample_x: int = int(round(float(x) - incoming_offset_px))
-			var outgoing_luma: float = 0.0
-			var incoming_luma: float = 0.0
-			if outgoing_sample_x >= 0 and outgoing_sample_x < FAKE_GOBO_TEXTURE_SIZE:
-				var outgoing_color: Color = outgoing_image.get_pixel(outgoing_sample_x, y)
-				outgoing_luma = ((outgoing_color.r + outgoing_color.g + outgoing_color.b) / 3.0) * outgoing_color.a
-			if incoming_sample_x >= 0 and incoming_sample_x < FAKE_GOBO_TEXTURE_SIZE:
-				var incoming_color: Color = incoming_image.get_pixel(incoming_sample_x, y)
-				incoming_luma = ((incoming_color.r + incoming_color.g + incoming_color.b) / 3.0) * incoming_color.a
-			var output_luma: float = clamp(maxf(outgoing_luma, incoming_luma), 0.0, 1.0)
-			result_image.set_pixel(x, y, Color(output_luma, output_luma, output_luma, output_luma))
+	_blend_shifted_gobo_image(result_image, outgoing_image, int(round(outgoing_offset_px)))
+	_blend_shifted_gobo_image(result_image, incoming_image, int(round(incoming_offset_px)))
 	var result_texture: ImageTexture = ImageTexture.create_from_image(result_image)
 	_texture_cache[cache_key] = result_texture
 	return result_texture
+
+func _blend_shifted_gobo_image(destination: Image, source: Image, offset_x: int) -> void:
+	if destination == null or source == null:
+		return
+	if offset_x >= FAKE_GOBO_TEXTURE_SIZE or offset_x <= -FAKE_GOBO_TEXTURE_SIZE:
+		return
+	var src_from_x: int = max(0, -offset_x)
+	var dst_from_x: int = max(0, offset_x)
+	var copy_width: int = FAKE_GOBO_TEXTURE_SIZE - abs(offset_x)
+	if copy_width <= 0:
+		return
+	var src_rect: Rect2i = Rect2i(src_from_x, 0, copy_width, FAKE_GOBO_TEXTURE_SIZE)
+	destination.blend_rect(source, src_rect, Vector2i(dst_from_x, 0))
 
 func _triangle_wave_centered_zero(phase: float) -> float:
 	var wrapped_phase: float = wrapf(phase, 0.0, 1.0)

--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -504,6 +504,11 @@ func _resolve_visible_slot_index(light: SpotLight3D, wheel: Dictionary, target_s
 	var outgoing_slot_index: int = base_slot_zero_index + 1
 	var incoming_slot_index: int = outgoing_slot_index
 	var motion_progress: float = 0.0
+	if not has_active_spin and str(movement_state.get(wheel_key, "")) == "aligned":
+		outgoing_slot_index = normalized_target_slot
+		incoming_slot_index = normalized_target_slot
+		movement_direction_sign = 0
+		motion_progress = 0.0
 	if movement_direction_sign > 0:
 		incoming_slot_index = ((base_slot_zero_index + 1) % slot_count) + 1
 		motion_progress = clamp(fractional_progress, 0.0, 1.0)

--- a/peraviz/scripts/shaders/gobo_alpha_projector.gdshader
+++ b/peraviz/scripts/shaders/gobo_alpha_projector.gdshader
@@ -2,10 +2,38 @@ shader_type spatial;
 render_mode blend_mix, depth_prepass_alpha, cull_disabled, diffuse_lambert, specular_schlick_ggx;
 
 uniform sampler2D gobo_texture;
+uniform sampler2D gobo_texture_secondary;
+uniform bool gobo_transition_enabled = false;
+uniform float gobo_transition_progress = 0.0;
+uniform float gobo_transition_direction = 1.0;
+
+vec4 sample_masked_texture(sampler2D tex, vec2 uv) {
+	if (uv.x < 0.0 || uv.x > 1.0 || uv.y < 0.0 || uv.y > 1.0) {
+		return vec4(0.0, 0.0, 0.0, 1.0);
+	}
+	return texture(tex, uv);
+}
 
 void fragment() {
-	vec4 gobo_sample = texture(gobo_texture, UV);
-	float alpha_mask = mix(1.0, 0.0, clamp(gobo_sample.r, 0.0, 1.0));
+	vec4 primary_sample = texture(gobo_texture, UV);
+	float primary_luma = clamp(primary_sample.r, 0.0, 1.0);
+	float final_luma = primary_luma;
+
+	if (gobo_transition_enabled) {
+		float progress = clamp(gobo_transition_progress, 0.0, 1.0);
+		float dir = gobo_transition_direction >= 0.0 ? 1.0 : -1.0;
+		vec2 uv_primary = UV;
+		vec2 uv_secondary = UV;
+		uv_primary.x -= progress * dir;
+		uv_secondary.x -= (progress - 1.0) * dir;
+		vec4 shifted_primary = sample_masked_texture(gobo_texture, uv_primary);
+		vec4 shifted_secondary = sample_masked_texture(gobo_texture_secondary, uv_secondary);
+		float shifted_primary_luma = clamp(shifted_primary.r, 0.0, 1.0);
+		float shifted_secondary_luma = clamp(shifted_secondary.r, 0.0, 1.0);
+		final_luma = max(shifted_primary_luma, shifted_secondary_luma);
+	}
+
+	float alpha_mask = mix(1.0, 0.0, final_luma);
 	ALBEDO = vec3(1.0);
 	ALPHA = alpha_mask;
 	ALPHA_SCISSOR_THRESHOLD = 0.5;


### PR DESCRIPTION
### Motivation
- Disambiguate two different rotation intents that were previously conflated (`wheel spin` vs `slot/pos rotate`) so fixtures can expose and runtime can consume them independently.  
- Preserve backward compatibility for fixtures that only expose legacy rotation naming while enabling a clean migration path.  
- Surface physical wheel motion (continuous angle/step behavior) in the projector so indexed/step wheels move realistically without forcing expensive texture recomposition each frame.  

### Description
- Added explicit attribute roles `kGoboWheelSpin` and `kGoboSlotRotation` and extended `parse_attribute_name` to classify them (`peraviz/native/src/dmx/gdtf_attribute_classifier.*`).  
- Extended the offsets and binding models with separate wheel-spin and slot-rotation channel/range fields and kept legacy `rotation_*` fields as a compatibility lane (`peraviz/native/src/dmx/fixture_dmx_binding.{h,cpp}` and `peraviz/native/src/dmx/gdtf_control_offsets_resolver.cpp`).  
- Updated the offsets resolver to detect/prioritize wheel-spin vs slot-rotation, populate per-wheel `wheel_spin_ranges`/`slot_rotation_ranges`, and mirror into legacy rotation fields when needed (compat fallback).  
- Exported the new fields through the native loader into runtime dictionaries and updated the runtime capability builder to emit independent `wheel_spin_*` and `slot_rotation_*` values (with fallback to legacy `rotation_*`) (`peraviz/native/src/peraviz_loader.cpp`, `peraviz/scripts/dmx_capabilities/gobo_capability_handler.gd`).  
- Implemented a physical wheel model in the projector: per-wheel `wheel_angle_deg`, `target_slot_index`, `movement_state`, continuous stepping towards target, and visible-slot resolution by angle to avoid unnecessary texture composition (`peraviz/scripts/fixture_gobo_projector.gd`).  
- Added/updated tests and docs: parser test updated to cover `GoboWheelSpin`/`GoboSlotRotation`, MegaPointe e2e checks extended to validate wheel-spin ranges/sign/stop windows, and `docs/text_to_scene_rules.md` updated to document the new gobo semantics.  

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.  
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.  
- Attempted `cmake -S peraviz/native -B peraviz/native/build -DCMAKE_BUILD_TYPE=Release` which failed in this environment due to a missing `tinyxml2` development package/config, so full compilation and unit/e2e execution were not performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e28c8a871c8324a8c6e7fbc3d8033c)