### PR TITLE
Handle virtual GDTF channels (Offset=None) and show 'V' in fixture editor

### DIFF
--- a/gui/fixtureeditdialog.cpp
+++ b/gui/fixtureeditdialog.cpp
@@ -778,7 +778,10 @@ void FixtureEditDialog::UpdateChannels(bool markChannelCountDirty) {
     func.Trim(true).Trim(false);
     if (func.empty())
       func = "-";
-    msg += wxString::Format("%d: ", ch.channel) + func + "\n";
+    const wxString channelLabel = ch.isVirtual
+                                   ? wxString("V")
+                                   : wxString::Format("%d", ch.channel);
+    msg += channelLabel + ": " + func + "\n";
   }
   channelList->SetValue(msg);
   int chCount = GetGdtfModeChannelCount(std::string(gdtfPath.ToUTF8()),

--- a/tests/gdtfloader.h
+++ b/tests/gdtfloader.h
@@ -24,6 +24,7 @@ struct GdtfObject { Mesh mesh; Matrix transform; };
 struct GdtfChannelInfo {
     int channel = 0;
     std::string function;
+    bool isVirtual = false;
 };
 bool LoadGdtf(const std::string&, std::vector<GdtfObject>&, std::string* outError = nullptr);
 int GetGdtfModeChannelCount(const std::string&, const std::string&);

--- a/tests/gdtfloader_channel_modes_test.cpp
+++ b/tests/gdtfloader_channel_modes_test.cpp
@@ -65,6 +65,9 @@ std::string MakeGdtf()
         "ModeMaster=\"Gobo2Rotate\" ModeFrom=\"128/1\" ModeTo=\"255/1\"/>"
         "</LogicalChannel>"
         "</DMXChannel>"
+        "<DMXChannel Offset=\"None\">"
+        "<LogicalChannel Attribute=\"Dimmer\"/>"
+        "</DMXChannel>"
         "</DMXChannels>"
         "</DMXMode>"
         "</DMXModes>"
@@ -82,9 +85,12 @@ int main()
     const std::string gdtfPath = MakeGdtf();
     const std::vector<GdtfChannelInfo> channels =
         GetGdtfModeChannels(gdtfPath, "Standard");
-    assert(channels.size() == 2);
+    assert(GetGdtfModeChannelCount(gdtfPath, "Standard") == 2);
+    assert(channels.size() == 3);
     assert(channels[0].channel == 1);
     assert(channels[1].channel == 2);
+    assert(channels[2].isVirtual);
+    assert(channels[2].channel == 0);
 
     const std::string& goboSummary = channels[0].function;
     assert(goboSummary.find("Gobo2") != std::string::npos);

--- a/tests/gdtfloader_onech_stub.cpp
+++ b/tests/gdtfloader_onech_stub.cpp
@@ -24,6 +24,7 @@ struct GdtfObject { Mesh mesh; Matrix transform; };
 struct GdtfChannelInfo {
     int channel = 0;
     std::string function;
+    bool isVirtual = false;
 };
 
 bool LoadGdtf(const std::string&, std::vector<GdtfObject>&, std::string*) {

--- a/tests/gdtfloader_stub.cpp
+++ b/tests/gdtfloader_stub.cpp
@@ -25,6 +25,7 @@ struct GdtfObject { Mesh mesh; Matrix transform; };
 struct GdtfChannelInfo {
     int channel = 0;
     std::string function;
+    bool isVirtual = false;
 };
 
 bool LoadGdtf(const std::string&, std::vector<GdtfObject>&, std::string*) {

--- a/viewer3d/gdtfloader.cpp
+++ b/viewer3d/gdtfloader.cpp
@@ -505,7 +505,17 @@ static void ParseModes(tinyxml2::XMLElement* ft,
                     return parsedOffsets;
                 std::string offStr = rawOffset;
                 trim(offStr);
-                if (offStr.empty() || offStr == "None")
+                if (offStr.empty())
+                    return parsedOffsets;
+                auto toLower = [](std::string value) {
+                    std::transform(value.begin(), value.end(), value.begin(),
+                                   [](unsigned char ch) {
+                                       return static_cast<char>(std::tolower(ch));
+                                   });
+                    return value;
+                };
+                const std::string offStrLower = toLower(offStr);
+                if (offStrLower == "none")
                     return parsedOffsets;
                 for (char& ch : offStr) {
                     if (ch == ';' || ch == '|' || ch == '/')
@@ -515,14 +525,14 @@ static void ParseModes(tinyxml2::XMLElement* ft,
                 std::string group;
                 while (std::getline(ss, group, ',')) {
                     trim(group);
-                    if (group.empty() || group == "None")
+                    if (group.empty() || toLower(group) == "none")
                         continue;
 
                     std::stringstream groupStream(group);
                     std::string token;
                     while (groupStream >> token) {
                         trim(token);
-                        if (token.empty() || token == "None")
+                        if (token.empty() || toLower(token) == "none")
                             continue;
                         int parsed = 0;
                         if (TryParseInt(token, parsed)) {
@@ -749,10 +759,10 @@ static void ParseModes(tinyxml2::XMLElement* ft,
                 }
 
                 GdtfChannelInfo info;
-                info.channel = static_cast<int>(channelsVec.size()) + 1;
+                info.channel = 0;
                 info.function = baseFunction;
+                info.isVirtual = true;
                 channelsVec.push_back(std::move(info));
-                ++count;
             }
         }
 

--- a/viewer3d/gdtfloader.h
+++ b/viewer3d/gdtfloader.h
@@ -67,6 +67,7 @@ struct GdtfModelInfo {
 struct GdtfChannelInfo {
     int channel = 0;           // DMX channel number (coarse)
     std::string function;      // Associated function/attribute
+    bool isVirtual = false;    // True when Offset is omitted/None in GDTF
 };
 
 // Loads the models defined in a GDTF file. Returns true on success.
@@ -89,8 +90,8 @@ int GetGdtfModeChannelCount(const std::string& gdtfPath,
                             const std::string& modeName);
 
 // Returns the list of DMX channels and their functions for a mode in a GDTF
-// file. The channel number corresponds to the first Offset value when
-// available, otherwise the sequential index is used.
+// file. Real channels use the first Offset value as channel number. Virtual
+// channels (Offset=None/missing) set isVirtual=true and channel=0.
 std::vector<GdtfChannelInfo> GetGdtfModeChannels(
     const std::string& gdtfPath,
     const std::string& modeName);


### PR DESCRIPTION
### Motivation

- GDTF DMX channels can omit an `Offset` (or use `None`) to represent virtual channels that shouldn't consume DMX addresses, and the loader and UI must distinguish those from real channels.
- The code previously assigned sequential channel numbers for missing offsets and treated `None` case-sensitively, causing incorrect channel counts and unclear UI labels.

### Description

- Added a `bool isVirtual` member to `GdtfChannelInfo` in headers and stubs to mark channels whose `Offset` is missing or `None`.
- Updated `viewer3d/gdtfloader.cpp` to treat `Offset` values case-insensitively (e.g., `None`, `none`) and to parse groups/tokens accordingly, and to set `info.channel = 0` and `info.isVirtual = true` for virtual channels while leaving real-channel address counting unchanged.
- Changed `gui/fixtureeditdialog.cpp` to display `V: ` for virtual channels instead of a numeric channel index so the UI clearly indicates virtual channels.
- Updated tests and test stubs (`tests/gdtfloader*.cpp` and `tests/gdtfloader.h`) to include the `isVirtual` field and adjusted `gdtfloader_channel_modes_test.cpp` to assert the presence of a virtual channel and verify `GetGdtfModeChannelCount` remains correct.

### Testing

- Built the project with the updated headers and sources using the normal build system without errors.
- Ran the GDTF unit test for mode/channel parsing via the changed test binary `gdtfloader_channel_modes_test` and it passed.
- Ran the related test stubs (`gdtfloader_onech_stub` and `gdtfloader_stub`) to verify compilation and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3df1bf27c832485efca9a5351103f)