### PR TITLE
Refactor GDTF add flow: introduce AddFixtureFromGdtfPath and reuse after download

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -60,6 +60,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_cli_shortcut_router.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_cli_shortcuts.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_view_shortcuts.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_fixture_add_flow.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_menu.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_print.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/preferencesdialog.cpp

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -199,6 +199,8 @@ private:
   void OnUndo(wxCommandEvent &event);           // Undo action placeholder
   void OnRedo(wxCommandEvent &event);           // Redo action placeholder
   void OnAddFixture(wxCommandEvent &event);     // Add fixture from GDTF
+  void AddFixtureFromGdtfPath(const std::string &gdtfPath,
+                              const std::string &suggestedName = "");
   void OnAddTruss(wxCommandEvent &event);       // Add truss from library
   void OnAddSceneObject(wxCommandEvent &event); // Add generic scene object
   void OnAddPrimitiveSphere(wxCommandEvent &event); // Add primitive sphere

--- a/gui/mainwindow_fixture_add_flow.cpp
+++ b/gui/mainwindow_fixture_add_flow.cpp
@@ -1,0 +1,166 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "mainwindow.h"
+
+#include <chrono>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include <wx/msgdlg.h>
+#include <wx/string.h>
+
+#include "addfixturedialog.h"
+#include "configmanager.h"
+#include "consolepanel.h"
+#include "fixture.h"
+#include "fixturetablepanel.h"
+#include "gdtfdictionary.h"
+#include "gdtfloader.h"
+#include "viewer3dpanel.h"
+
+namespace {
+
+std::string Utf8StemFromPath(const std::string &path) {
+  const auto stem = std::filesystem::path(path).stem().u8string();
+  return std::string(stem.begin(), stem.end());
+}
+
+} // namespace
+
+void MainWindow::AddFixtureFromGdtfPath(const std::string &gdtfPath,
+                                        const std::string &suggestedName) {
+  if (gdtfPath.empty()) {
+    wxMessageBox("No GDTF file selected.", "Add fixture", wxOK | wxICON_ERROR);
+    if (consolePanel)
+      consolePanel->AppendMessage("[ERROR] Add fixture failed: empty GDTF path");
+    return;
+  }
+  const wxString gdtfPathWx = wxString::FromUTF8(gdtfPath);
+
+  if (!std::filesystem::exists(std::filesystem::u8path(gdtfPath))) {
+    wxMessageBox("The selected GDTF file does not exist.", "Add fixture",
+                 wxOK | wxICON_ERROR);
+    if (consolePanel)
+      consolePanel->AppendMessage(
+          wxString::Format("[ERROR] Add fixture failed: file not found %s",
+                           gdtfPathWx));
+    return;
+  }
+
+  std::string defaultName = suggestedName;
+  if (defaultName.empty())
+    defaultName = GetGdtfFixtureName(gdtfPath);
+  if (defaultName.empty())
+    defaultName = Utf8StemFromPath(gdtfPath);
+
+  if (consolePanel)
+    consolePanel->AppendMessage(
+        wxString::Format("[INFO] Loading GDTF fixture from: %s", gdtfPathWx));
+
+  std::vector<std::string> modes = GetGdtfModes(gdtfPath);
+  if (modes.empty()) {
+    wxMessageBox("Could not read fixture modes from the selected GDTF file.",
+                 "Add fixture", wxOK | wxICON_ERROR);
+    if (consolePanel)
+      consolePanel->AppendMessage(
+          wxString::Format("[ERROR] Add fixture failed: no modes found in %s",
+                           gdtfPathWx));
+    return;
+  }
+
+  AddFixtureDialog dlg(this, wxString::FromUTF8(defaultName), modes);
+  if (dlg.ShowModal() != wxID_OK)
+    return;
+
+  float weight = 0.0f;
+  float power = 0.0f;
+  GetGdtfProperties(gdtfPath, weight, power);
+  std::string defaultColor = GetGdtfModelColor(gdtfPath);
+  if (auto dictEntry = GdtfDictionary::Get(defaultName)) {
+    if (!dictEntry->color.empty())
+      defaultColor = dictEntry->color;
+  }
+
+  ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+  int count = dlg.GetUnitCount();
+  std::string name = dlg.GetFixtureName();
+  int startId = dlg.GetFixtureId();
+  std::string mode = dlg.GetMode();
+
+  namespace fs = std::filesystem;
+  cfg.PushUndoState("add fixture");
+  auto &sceneRef = cfg.GetScene();
+  std::string base = sceneRef.basePath;
+  std::string spec = gdtfPath;
+  if (!base.empty()) {
+    fs::path abs = fs::absolute(gdtfPath);
+    fs::path b = fs::absolute(base);
+    if (abs.string().rfind(b.string(), 0) == 0)
+      spec = fs::relative(abs, b).string();
+  }
+
+  auto baseId = std::chrono::steady_clock::now().time_since_epoch().count();
+  std::string layerName = cfg.GetCurrentLayer();
+  bool hasLayer = false;
+  for (const auto &[uid, layer] : sceneRef.layers) {
+    if (layer.name == layerName) {
+      hasLayer = true;
+      break;
+    }
+  }
+  if (!hasLayer) {
+    Layer layer;
+    layer.uuid = wxString::Format("layer_%lld", static_cast<long long>(baseId))
+                     .ToStdString();
+    layer.name = layerName;
+    sceneRef.layers[layer.uuid] = layer;
+  }
+
+  int maxId = 0;
+  for (const auto &[uuid, fix] : sceneRef.fixtures) {
+    if (fix.fixtureId > maxId)
+      maxId = fix.fixtureId;
+  }
+  if (startId <= 0)
+    startId = maxId + 1;
+
+  for (int i = 0; i < count; ++i) {
+    Fixture f;
+    f.uuid = wxString::Format("uuid_%lld_%d", static_cast<long long>(baseId), i)
+                 .ToStdString();
+    f.instanceName = name;
+    f.typeName = defaultName;
+    f.fixtureId = startId + i;
+    f.gdtfSpec = spec;
+    f.gdtfMode = mode;
+    f.layer = layerName;
+    f.weightKg = weight;
+    f.powerConsumptionW = power;
+    f.color = defaultColor;
+    sceneRef.fixtures[f.uuid] = f;
+  }
+
+  if (fixturePanel)
+    fixturePanel->ReloadData();
+  if (viewportPanel) {
+    viewportPanel->UpdateScene();
+    viewportPanel->Refresh();
+  }
+  RefreshSummary();
+}

--- a/gui/mainwindow_fixture_add_flow.cpp
+++ b/gui/mainwindow_fixture_add_flow.cpp
@@ -32,6 +32,7 @@
 #include "fixturetablepanel.h"
 #include "gdtfdictionary.h"
 #include "gdtfloader.h"
+#include "guiconfigservices.h"
 #include "viewer3dpanel.h"
 
 namespace {

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -559,12 +559,16 @@ void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
         if (consolePanel)
           consolePanel->AppendMessage(
               wxString::Format("[INFO] Download HTTP code: %ld", dlCode));
-        if (ok && dlCode == 200)
-          wxMessageBox("GDTF downloaded.", "Success",
-                       wxOK | wxICON_INFORMATION);
-        else
+        if (ok && dlCode == 200) {
+          int addNow = wxMessageBox(
+              "GDTF downloaded successfully. Do you want to add it to the project now?",
+              "Success", wxYES_NO | wxICON_QUESTION, this);
+          if (addNow == wxYES)
+            AddFixtureFromGdtfPath(WxToUtf8(dest));
+        } else {
           wxMessageBox("Failed to download GDTF.", "Error",
                        wxOK | wxICON_ERROR);
+        }
       } else {
         wxMessageBox("Download information missing.", "Error",
                      wxOK | wxICON_ERROR);
@@ -1144,7 +1148,6 @@ void MainWindow::OnAddFixture(wxCommandEvent &WXUNUSED(event)) {
   auto &scene = cfg.GetScene();
 
   std::string gdtfPath;
-  std::string defaultName;
 
   if (!scene.fixtures.empty()) {
     std::map<std::string, std::string> typeToSpec;
@@ -1167,22 +1170,21 @@ void MainWindow::OnAddFixture(wxCommandEvent &WXUNUSED(event)) {
                         "*.gdtf", wxFD_OPEN | wxFD_FILE_MUST_EXIST);
       if (fdlg.ShowModal() != wxID_OK)
         return;
-      wxString gdtfPathWx = fdlg.GetPath();
-      gdtfPath = WxToUtf8(gdtfPathWx);
-      defaultName = GetGdtfFixtureName(gdtfPath);
-      if (defaultName.empty())
-        defaultName = WxToUtf8(wxFileName(gdtfPathWx).GetName());
+      AddFixtureFromGdtfPath(WxToUtf8(fdlg.GetPath()));
+      return;
     } else {
       int sel = chooseDlg.GetSelection();
       if (sel < 0 || sel >= static_cast<int>(types.size()))
         return;
-      defaultName = types[sel];
+      std::string defaultName = types[sel];
       std::string spec = typeToSpec[defaultName];
       namespace fs = std::filesystem;
       if (fs::path(spec).is_absolute())
         gdtfPath = spec;
       else
         gdtfPath = (fs::path(scene.basePath) / spec).string();
+      AddFixtureFromGdtfPath(gdtfPath, defaultName);
+      return;
     }
   } else {
     wxString fixDir =
@@ -1191,90 +1193,9 @@ void MainWindow::OnAddFixture(wxCommandEvent &WXUNUSED(event)) {
                       wxFD_OPEN | wxFD_FILE_MUST_EXIST);
     if (fdlg.ShowModal() != wxID_OK)
       return;
-    wxString gdtfPathWx = fdlg.GetPath();
-    gdtfPath = WxToUtf8(gdtfPathWx);
-    defaultName = GetGdtfFixtureName(gdtfPath);
-    if (defaultName.empty())
-      defaultName = WxToUtf8(wxFileName(gdtfPathWx).GetName());
-  }
-
-  std::vector<std::string> modes = GetGdtfModes(gdtfPath);
-  AddFixtureDialog dlg(this, wxString::FromUTF8(defaultName), modes);
-  if (dlg.ShowModal() != wxID_OK)
+    AddFixtureFromGdtfPath(WxToUtf8(fdlg.GetPath()));
     return;
-
-  float weight = 0.0f, power = 0.0f;
-  GetGdtfProperties(gdtfPath, weight, power);
-  std::string defaultColor = GetGdtfModelColor(gdtfPath);
-  if (auto dictEntry = GdtfDictionary::Get(defaultName)) {
-    if (!dictEntry->color.empty())
-      defaultColor = dictEntry->color;
   }
-
-  int count = dlg.GetUnitCount();
-  std::string name = dlg.GetFixtureName();
-  int startId = dlg.GetFixtureId();
-  std::string mode = dlg.GetMode();
-
-  namespace fs = std::filesystem;
-  cfg.PushUndoState("add fixture");
-  auto &sceneRef = cfg.GetScene();
-  std::string base = sceneRef.basePath;
-  std::string spec = gdtfPath;
-  if (!base.empty()) {
-    fs::path abs = fs::absolute(gdtfPath);
-    fs::path b = fs::absolute(base);
-    if (abs.string().rfind(b.string(), 0) == 0)
-      spec = fs::relative(abs, b).string();
-  }
-
-  auto baseId = std::chrono::steady_clock::now().time_since_epoch().count();
-  std::string layerName = cfg.GetCurrentLayer();
-  bool hasLayer = false;
-  for (const auto &[uid, layer] : sceneRef.layers) {
-    if (layer.name == layerName) {
-      hasLayer = true;
-      break;
-    }
-  }
-  if (!hasLayer) {
-    Layer layer;
-    layer.uuid = wxString::Format("layer_%lld", static_cast<long long>(baseId))
-                     .ToStdString();
-    layer.name = layerName;
-    sceneRef.layers[layer.uuid] = layer;
-  }
-
-  int maxId = 0;
-  for (const auto &[uuid, fix] : sceneRef.fixtures)
-    if (fix.fixtureId > maxId)
-      maxId = fix.fixtureId;
-  if (startId <= 0)
-    startId = maxId + 1;
-
-  for (int i = 0; i < count; ++i) {
-    Fixture f;
-    f.uuid = wxString::Format("uuid_%lld_%d", static_cast<long long>(baseId), i)
-                 .ToStdString();
-    f.instanceName = name;
-    f.typeName = defaultName;
-    f.fixtureId = startId + i;
-    f.gdtfSpec = spec;
-    f.gdtfMode = mode;
-    f.layer = layerName;
-    f.weightKg = weight;
-    f.powerConsumptionW = power;
-    f.color = defaultColor;
-    sceneRef.fixtures[f.uuid] = f;
-  }
-
-  if (fixturePanel)
-    fixturePanel->ReloadData();
-  if (viewportPanel) {
-    viewportPanel->UpdateScene();
-    viewportPanel->Refresh();
-  }
-  RefreshSummary();
 }
 
 void MainWindow::OnAddTruss(wxCommandEvent &WXUNUSED(event)) {

--- a/peraviz/native/CMakeLists.txt
+++ b/peraviz/native/CMakeLists.txt
@@ -130,7 +130,10 @@ if(BUILD_TESTING)
     target_include_directories(peraviz_native_dmx_tests PRIVATE
         "${CMAKE_CURRENT_SOURCE_DIR}/src"
     )
-    target_link_libraries(peraviz_native_dmx_tests PRIVATE tinyxml2::tinyxml2)
+    target_link_libraries(peraviz_native_dmx_tests PRIVATE
+        tinyxml2::tinyxml2
+        ${_peraviz_wx_libs}
+    )
     add_test(NAME peraviz_native_dmx_tests COMMAND peraviz_native_dmx_tests)
 
     add_executable(peraviz_native_dmx_e2e_tests


### PR DESCRIPTION
### Motivation

- Reduce duplicated add-from-file logic and keep the large hotspot `mainwindow_menu.cpp` smaller by extracting the full GDTF add flow to a dedicated helper and file. 
- After a successful download from GDTF Share, offer a direct Yes/No prompt to add the downloaded file to the project without reopening a file dialog. 
- Improve error handling for unreadable or invalid GDTF files and keep console logging consistent.

### Description

- Added a private helper `MainWindow::AddFixtureFromGdtfPath(const std::string& gdtfPath, const std::string& suggestedName = "")` (declared in `gui/mainwindow.h`) that encapsulates the entire "add fixture from GDTF" flow (name resolution, `GetGdtfModes`, `AddFixtureDialog`, `GetGdtfProperties`, dictionary color resolution, `PushUndoState`, fixture creation and UI refresh). 
- Implemented the helper in a new file `gui/mainwindow_fixture_add_flow.cpp` and registered it in `gui/CMakeLists.txt` to avoid growing `mainwindow_menu.cpp`. 
- Refactored `MainWindow::OnAddFixture(...)` to route both "Add from file" and the existing-type branch to the new helper, removing duplicated logic. 
- Updated `MainWindow::OnDownloadGdtf(...)` to show a Yes/No confirmation dialog on successful download with the text: "GDTF downloaded successfully. Do you want to add it to the project now?", and to call `AddFixtureFromGdtfPath(dest)` if the user chooses Yes. 
- Added explicit error handling inside the helper to show an error dialog and log to `consolePanel` when the file is missing or `GetGdtfModes` returns empty, ensuring the scene is not modified in those cases.

### Testing

- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`; both returned OK. 
- Attempted a configure/build with `cmake -S . -B build` which failed in this environment due to missing system `wxWidgets` development libraries (build not possible here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3e5cc51e883248d0be2f866559aee)