### PR TITLE
Fix blank startup UI by creating missing viewport for saved view mode

### DIFF
--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -562,6 +562,14 @@ void MainWindow::ApplySavedLayout() {
   }
   if (!preset)
     preset = LayoutViewPresetRegistry::GetPreset("3d_layout_view");
+
+  if (preset) {
+    if (preset->name == "2d_layout_view")
+      Ensure2DViewport();
+    else if (preset->name == "3d_layout_view")
+      Ensure3DViewport();
+  }
+
   const bool savedLayoutMode = preset && preset->name == "layout_mode_view";
   bool usedSavedPerspective = false;
   if (preset && perspective) {


### PR DESCRIPTION
### Motivation
- Prevent a blank central UI on first run when a saved `layout_view_mode` (e.g. `2d_layout_view`) is applied but the corresponding viewport has not been created yet, which left the main area empty because `ApplySavedLayout()` only created viewports when the saved perspective string referenced them.

### Description
- In `gui/mainwindow_layout.cpp` inside `MainWindow::ApplySavedLayout()` ensure the required viewport is created from the chosen preset before applying the preset by calling `Ensure2DViewport()` for `2d_layout_view` and `Ensure3DViewport()` for `3d_layout_view` so pane visibility changes do not hide the only central pane present.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e47b46aa6883248ab234f11bcf3c29)