### PR TITLE
Use framebuffer-scaled render size for GL viewport/projection

### DIFF
--- a/core/ui_render_size.cpp
+++ b/core/ui_render_size.cpp
@@ -4,14 +4,44 @@
 
 #include <wx/log.h>
 
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
 RenderSize ResolveRenderSize(wxWindow *window) {
   if (window == nullptr) {
     return RenderSize{0, 0, "null-window"};
   }
 
-  const wxSize clientSize = window->GetClientSize();
-  return RenderSize{clientSize.GetWidth(), clientSize.GetHeight(),
-                    "window-client-size"};
+  const wxSize logicalClientSize = window->GetClientSize();
+  const int logicalWidth = std::max(0, logicalClientSize.GetWidth());
+  const int logicalHeight = std::max(0, logicalClientSize.GetHeight());
+
+  const double contentScale =
+      static_cast<double>(window->GetContentScaleFactor());
+  if (!std::isfinite(contentScale) || contentScale <= 0.0) {
+    return RenderSize{0, 0, "invalid-content-scale"};
+  }
+
+  const double physicalWidthDouble =
+      static_cast<double>(logicalWidth) * contentScale;
+  const double physicalHeightDouble =
+      static_cast<double>(logicalHeight) * contentScale;
+  if (!std::isfinite(physicalWidthDouble) ||
+      !std::isfinite(physicalHeightDouble)) {
+    return RenderSize{0, 0, "invalid-framebuffer-size"};
+  }
+
+  const long roundedWidth = std::lround(physicalWidthDouble);
+  const long roundedHeight = std::lround(physicalHeightDouble);
+  const long clampedWidth =
+      std::clamp(roundedWidth, 0L, static_cast<long>(std::numeric_limits<int>::max()));
+  const long clampedHeight =
+      std::clamp(roundedHeight, 0L, static_cast<long>(std::numeric_limits<int>::max()));
+
+  return RenderSize{static_cast<int>(clampedWidth),
+                    static_cast<int>(clampedHeight),
+                    "window-framebuffer-scaled"};
 }
 
 void ValidateRenderSizeContract(const char *panelName, unsigned long long frameId,

--- a/core/ui_render_size.h
+++ b/core/ui_render_size.h
@@ -2,14 +2,18 @@
 
 class wxWindow;
 
+// Render size used by OpenGL paths. Dimensions are framebuffer pixels
+// (physical pixels), not logical/window client coordinates.
 struct RenderSize {
   int width = 0;
   int height = 0;
+  // Trace/debug string describing the framebuffer-size source.
   const char *source = "";
 
   bool IsValid() const { return width > 0 && height > 0; }
 };
 
+// Resolves framebuffer dimensions (physical pixels) for a wxWindow.
 RenderSize ResolveRenderSize(wxWindow *window);
 
 void ValidateRenderSizeContract(const char *panelName, unsigned long long frameId,

--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -834,12 +834,12 @@ void LayoutViewerPanel::OnPaint(wxPaintEvent &) {
     const wxSize size(resolvedSize.width, resolvedSize.height);
     glstate::ApplyKnownBaseOnscreenState(size.GetWidth(), size.GetHeight());
     const RenderSize viewportSize{size.GetWidth(), size.GetHeight(),
-                                  "glstate::ApplyKnownBaseOnscreenState"};
+                                  "glstate::ApplyKnownBaseOnscreenState(framebuffer-px)"};
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
     glOrtho(0.0, size.GetWidth(), size.GetHeight(), 0.0, -1.0, 1.0);
     const RenderSize projectionSize{size.GetWidth(), size.GetHeight(),
-                                    "LayoutViewerPanel::OnPaint::ortho"};
+                                    "LayoutViewerPanel::OnPaint::ortho(framebuffer-px)"};
     ++s_renderFrameId;
     ValidateRenderSizeContract("LayoutViewerPanel", s_renderFrameId,
                                resolvedSize, viewportSize, projectionSize);

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -665,7 +665,7 @@ void Viewer2DPanel::RenderInternal(bool swapBuffers) {
     return;
 
   glstate::ApplyKnownBaseOnscreenState(w, h);
-  const RenderSize viewportSize{w, h, "glstate::ApplyKnownBaseOnscreenState"};
+  const RenderSize viewportSize{w, h, "glstate::ApplyKnownBaseOnscreenState(framebuffer-px)"};
 
   glMatrixMode(GL_PROJECTION);
   glLoadIdentity();
@@ -676,7 +676,7 @@ void Viewer2DPanel::RenderInternal(bool swapBuffers) {
   float offY = m_offsetY / PIXELS_PER_METER;
   glOrtho(-halfW - offX, halfW - offX, -halfH - offY, halfH - offY, -100.0f,
           100.0f);
-  const RenderSize projectionSize{w, h, "RenderInternal::world-projection"};
+  const RenderSize projectionSize{w, h, "RenderInternal::world-projection(framebuffer-px)"};
 
   ++s_renderFrameId;
   ValidateRenderSizeContract("Viewer2DPanel", s_renderFrameId, resolvedSize,

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -641,13 +641,13 @@ void Viewer3DPanel::Render(const RenderSize& renderSize)
     const int width = renderSize.width;
     const int height = renderSize.height;
     glstate::ApplyKnownBaseOnscreenState(width, height);
-    const RenderSize viewportSize{width, height, "glstate::ApplyKnownBaseOnscreenState"};
+    const RenderSize viewportSize{width, height, "glstate::ApplyKnownBaseOnscreenState(framebuffer-px)"};
 
     const Viewer3DRenderStyle renderStyle = ResolveRenderStyleFromPreferences();
     ApplyViewer3DClearColorForStyle(renderStyle);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     ApplyCameraMatrices(renderSize);
-    const RenderSize projectionSize{width, height, "ApplyCameraMatrices::projection"};
+    const RenderSize projectionSize{width, height, "ApplyCameraMatrices::projection(framebuffer-px)"};
 
     ++s_renderFrameId;
     ValidateRenderSizeContract("Viewer3DPanel", s_renderFrameId, renderSize,


### PR DESCRIPTION
### Motivation
- Ensure GL viewport and projection use physical framebuffer pixels (HiDPI-aware) so viewports, projections and hit-queries are coherent and avoid scaling artifacts on high-DPI displays.

### Description
- Update `ResolveRenderSize(wxWindow*)` to compute framebuffer size by reading logical client size with `GetClientSize()` and scaling by `GetContentScaleFactor()`, rounding with `std::lround` and clamping to valid `int` ranges, and tag the source as `window-framebuffer-scaled` when valid.
- Add finite/positive guards for content scale and intermediate calculations and return explicit error sources (`null-window`, `invalid-content-scale`, `invalid-framebuffer-size`) for invalid cases, and add required includes (`<algorithm>`, `<cmath>`, `<limits>`).
- Clarify `RenderSize` comments in `core/ui_render_size.h` to state that dimensions are framebuffer (physical) pixels and that `source` is a trace/debug string, and update the declaration comment for `ResolveRenderSize`.
- Adjust call-site trace/provenance strings in `viewer3d/viewer3dpanel.cpp`, `viewer2d/viewer2dpanel.cpp`, and `gui/layoutviewerpanel.cpp` so viewport/projection trace entries explicitly indicate they are framebuffer pixels (append `(framebuffer-px)`).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded (OK).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded (OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4903e5dcc8324bca52d99d8e63aa7)