### PR TITLE
Use centralized framebuffer size resolution in FixturePreviewPanel

### DIFF
--- a/gui/fixturepreviewpanel.cpp
+++ b/gui/fixturepreviewpanel.cpp
@@ -34,6 +34,7 @@
 
 #include <wx/wx.h>
 #include "fixturepreviewpanel.h"
+#include "ui_render_size.h"
 #include <cfloat>
 #include <array>
 #include <algorithm>
@@ -236,12 +237,18 @@ void FixturePreviewPanel::LoadFixture(const std::string& gdtfPath)
 
 void FixturePreviewPanel::Render()
 {
-    int w,h; GetClientSize(&w,&h);
+    const RenderSize renderSize = ResolveRenderSize(this);
+    const int w = renderSize.width;
+    const int h = renderSize.height;
+    if (!renderSize.IsValid()) {
+        return;
+    }
+
     glViewport(0,0,w,h);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
-    gluPerspective(45.0,(double)w/h,0.1,100.0);
+    gluPerspective(45.0, static_cast<double>(w) / static_cast<double>(h), 0.1, 100.0);
     glMatrixMode(GL_MODELVIEW);
     glLoadIdentity();
     m_camera.Update(0.0f);


### PR DESCRIPTION
### Motivation
- Replace the ad-hoc `GetClientSize` usage with the shared framebuffer-size resolver so viewport and projection use physical (framebuffer) pixels and behave correctly on high-DPI and minimized/init states.

### Description
- Added `#include "ui_render_size.h"` and changed `FixturePreviewPanel::Render()` to call `ResolveRenderSize(this)`, use `renderSize.width`/`renderSize.height` for `glViewport` and the `gluPerspective` aspect, and early-return when `RenderSize::IsValid()` is false while keeping the aspect calculation platform-agnostic.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e491c983a08324b02d5aabb5c84bcf)