### PR TITLE
Normalize 2D/3D picking to framebuffer coordinates

### DIFF
--- a/core/ui_render_size.h
+++ b/core/ui_render_size.h
@@ -14,6 +14,15 @@ struct RenderSize {
 };
 
 // Resolves framebuffer dimensions (physical pixels) for a wxWindow.
+//
+// Picking convention:
+// - Mouse events arrive in logical client coordinates (DIP).
+// - Any code that calls screen-space picking helpers (Get*LabelAt,
+//   Get*InScreenRect, overlays drawn in framebuffer space) must convert those
+//   logical coordinates to framebuffer pixels first, then use the size from
+//   ResolveRenderSize().
+// Keeping this convention explicit avoids DPI regressions where logical mouse
+// coordinates are mixed with physical render dimensions.
 RenderSize ResolveRenderSize(wxWindow *window);
 
 void ValidateRenderSizeContract(const char *panelName, unsigned long long frameId,

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -133,6 +133,20 @@ CanvasStroke MakeGridStroke(float r, float g, float b) {
   return stroke;
 }
 
+wxPoint ToFramebufferPoint(wxWindow *window, const wxPoint &logicalPoint) {
+  if (window == nullptr)
+    return logicalPoint;
+  const double contentScale =
+      static_cast<double>(window->GetContentScaleFactor());
+  if (!std::isfinite(contentScale) || contentScale <= 0.0)
+    return logicalPoint;
+  return wxPoint(
+      static_cast<int>(
+          std::lround(static_cast<double>(logicalPoint.x) * contentScale)),
+      static_cast<int>(
+          std::lround(static_cast<double>(logicalPoint.y) * contentScale)));
+}
+
 // Emit grid primitives to a canvas so the command buffer records the same
 // visual information shown by the OpenGL renderer. Coordinates are expressed in
 // the 2D world space after the camera orientation has been applied.
@@ -984,8 +998,12 @@ void Viewer2DPanel::OnPaint(wxPaintEvent &WXUNUSED(event)) {
   // Ensure the OpenGL context is current before hit-testing selections.
   SetCurrent(*m_glContext);
 
-  int w, h;
-  GetClientSize(&w, &h);
+  const RenderSize renderSize = ResolveRenderSize(this);
+  const int w = renderSize.width;
+  const int h = renderSize.height;
+  if (!renderSize.IsValid())
+    return;
+  const wxPoint pickPos = ToFramebufferPoint(this, m_lastMousePos);
 
   wxString newLabel;
   wxPoint newPos;
@@ -996,8 +1014,8 @@ void Viewer2DPanel::OnPaint(wxPaintEvent &WXUNUSED(event)) {
 
   if (!skipLabelWork && FixtureTablePanel::Instance() &&
       FixtureTablePanel::Instance()->IsActivePage()) {
-    found = m_controller.GetFixtureLabelAt(m_lastMousePos.x, m_lastMousePos.y,
-                                           w, h, newLabel, newPos, &newUuid);
+    found = m_controller.GetFixtureLabelAt(pickPos.x, pickPos.y, w, h, newLabel,
+                                           newPos, &newUuid);
     if (found) {
       if (TrussTablePanel::Instance())
         TrussTablePanel::Instance()->HighlightTruss(std::string());
@@ -1006,8 +1024,8 @@ void Viewer2DPanel::OnPaint(wxPaintEvent &WXUNUSED(event)) {
     }
   } else if (!skipLabelWork && TrussTablePanel::Instance() &&
              TrussTablePanel::Instance()->IsActivePage()) {
-    found = m_controller.GetTrussLabelAt(m_lastMousePos.x, m_lastMousePos.y, w,
-                                         h, newLabel, newPos, &newUuid);
+    found = m_controller.GetTrussLabelAt(pickPos.x, pickPos.y, w, h, newLabel,
+                                         newPos, &newUuid);
     if (found) {
       if (FixtureTablePanel::Instance())
         FixtureTablePanel::Instance()->HighlightFixture(std::string());
@@ -1018,8 +1036,8 @@ void Viewer2DPanel::OnPaint(wxPaintEvent &WXUNUSED(event)) {
              HoistTablePanel::Instance()->IsActivePage()) {
     const auto hiddenLayers = ConfigManager::Get().GetHiddenLayers();
     found = Viewer2DSupportSelection::FindHoistAtScreenPoint(
-        m_lastMousePos.x, m_lastMousePos.y, h, ConfigManager::Get().GetScene(),
-        hiddenLayers, newUuid, newPos, newLabel);
+        pickPos.x, pickPos.y, h, ConfigManager::Get().GetScene(), hiddenLayers,
+        newUuid, newPos, newLabel);
     if (found) {
       if (FixtureTablePanel::Instance())
         FixtureTablePanel::Instance()->HighlightFixture(std::string());
@@ -1030,8 +1048,8 @@ void Viewer2DPanel::OnPaint(wxPaintEvent &WXUNUSED(event)) {
     }
   } else if (!skipLabelWork && SceneObjectTablePanel::Instance() &&
              SceneObjectTablePanel::Instance()->IsActivePage()) {
-    found = m_controller.GetSceneObjectLabelAt(m_lastMousePos.x,
-                                               m_lastMousePos.y, w, h, newLabel,
+    found = m_controller.GetSceneObjectLabelAt(pickPos.x,
+                                               pickPos.y, w, h, newLabel,
                                                newPos, &newUuid);
     if (found) {
       if (FixtureTablePanel::Instance())
@@ -1176,25 +1194,29 @@ void Viewer2DPanel::ApplyRectangleSelection(const wxPoint &start,
   if (!IsShownOnScreen())
     return;
 
-  int w = 0;
-  int h = 0;
-  GetClientSize(&w, &h);
+  const RenderSize renderSize = ResolveRenderSize(this);
+  const int w = renderSize.width;
+  const int h = renderSize.height;
   if (w <= 0 || h <= 0)
     return;
 
   SetCurrent(*m_glContext);
+  const wxPoint pickStart = ToFramebufferPoint(this, start);
+  const wxPoint pickEnd = ToFramebufferPoint(this, end);
 
   ConfigManager &cfg = ConfigManager::Get();
   if (selectAcrossAllTables) {
     const auto fixtures =
-        m_controller.GetFixturesInScreenRect(start.x, start.y, end.x, end.y, w, h);
+        m_controller.GetFixturesInScreenRect(pickStart.x, pickStart.y, pickEnd.x,
+                                             pickEnd.y, w, h);
     const auto trusses =
-        m_controller.GetTrussesInScreenRect(start.x, start.y, end.x, end.y, w, h);
+        m_controller.GetTrussesInScreenRect(pickStart.x, pickStart.y, pickEnd.x,
+                                            pickEnd.y, w, h);
     const auto supports = Viewer2DSupportSelection::GetHoistsInScreenRect(
-        start.x, start.y, end.x, end.y, w, h, cfg.GetScene(),
+        pickStart.x, pickStart.y, pickEnd.x, pickEnd.y, w, h, cfg.GetScene(),
         cfg.GetHiddenLayers());
     const auto sceneObjects = m_controller.GetSceneObjectsInScreenRect(
-        start.x, start.y, end.x, end.y, w, h);
+        pickStart.x, pickStart.y, pickEnd.x, pickEnd.y, w, h);
 
     const bool selectionChanged =
         fixtures != cfg.GetSelectedFixtures() ||
@@ -1249,7 +1271,7 @@ void Viewer2DPanel::ApplyRectangleSelection(const wxPoint &start,
   if (FixtureTablePanel::Instance() &&
       FixtureTablePanel::Instance()->IsActivePage()) {
     auto selection = m_controller.GetFixturesInScreenRect(
-        start.x, start.y, end.x, end.y, w, h);
+        pickStart.x, pickStart.y, pickEnd.x, pickEnd.y, w, h);
     if (selection != cfg.GetSelectedFixtures()) {
       cfg.PushUndoState("fixture selection");
       cfg.SetSelectedFixtures(selection);
@@ -1264,7 +1286,8 @@ void Viewer2DPanel::ApplyRectangleSelection(const wxPoint &start,
   } else if (TrussTablePanel::Instance() &&
              TrussTablePanel::Instance()->IsActivePage()) {
     auto selection =
-        m_controller.GetTrussesInScreenRect(start.x, start.y, end.x, end.y, w,
+        m_controller.GetTrussesInScreenRect(pickStart.x, pickStart.y, pickEnd.x,
+                                            pickEnd.y, w,
                                             h);
     if (selection != cfg.GetSelectedTrusses()) {
       cfg.PushUndoState("truss selection");
@@ -1278,7 +1301,7 @@ void Viewer2DPanel::ApplyRectangleSelection(const wxPoint &start,
   } else if (HoistTablePanel::Instance() &&
              HoistTablePanel::Instance()->IsActivePage()) {
     auto selection = Viewer2DSupportSelection::GetHoistsInScreenRect(
-        start.x, start.y, end.x, end.y, w, h, cfg.GetScene(),
+        pickStart.x, pickStart.y, pickEnd.x, pickEnd.y, w, h, cfg.GetScene(),
         cfg.GetHiddenLayers());
     if (selection != cfg.GetSelectedSupports()) {
       cfg.PushUndoState("support selection");
@@ -1292,7 +1315,7 @@ void Viewer2DPanel::ApplyRectangleSelection(const wxPoint &start,
   } else if (SceneObjectTablePanel::Instance() &&
              SceneObjectTablePanel::Instance()->IsActivePage()) {
     auto selection = m_controller.GetSceneObjectsInScreenRect(
-        start.x, start.y, end.x, end.y, w, h);
+        pickStart.x, pickStart.y, pickEnd.x, pickEnd.y, w, h);
     if (selection != cfg.GetSelectedSceneObjects()) {
       cfg.PushUndoState("scene object selection");
       cfg.SetSelectedSceneObjects(selection);
@@ -1314,11 +1337,14 @@ void Viewer2DPanel::DrawSelectionRectangle(int width, int height,
   int right = std::max(m_rectSelectStart.x, m_rectSelectEnd.x);
   int top = std::min(m_rectSelectStart.y, m_rectSelectEnd.y);
   int bottom = std::max(m_rectSelectStart.y, m_rectSelectEnd.y);
+  const wxPoint physicalTopLeft = ToFramebufferPoint(this, wxPoint(left, top));
+  const wxPoint physicalBottomRight =
+      ToFramebufferPoint(this, wxPoint(right, bottom));
 
-  float glLeft = static_cast<float>(left);
-  float glRight = static_cast<float>(right);
-  float glBottom = static_cast<float>(height - bottom);
-  float glTop = static_cast<float>(height - top);
+  float glLeft = static_cast<float>(physicalTopLeft.x);
+  float glRight = static_cast<float>(physicalBottomRight.x);
+  float glBottom = static_cast<float>(height - physicalBottomRight.y);
+  float glTop = static_cast<float>(height - physicalTopLeft.y);
 
   GLboolean depthEnabled = glIsEnabled(GL_DEPTH_TEST);
   if (depthEnabled)
@@ -1591,8 +1617,9 @@ void Viewer2DPanel::OnMouseDown(wxMouseEvent &event) {
       return;
     }
 
-    int w, h;
-    GetClientSize(&w, &h);
+    const RenderSize renderSize = ResolveRenderSize(this);
+    const int w = renderSize.width;
+    const int h = renderSize.height;
     if (w <= 0 || h <= 0)
       return;
 
@@ -1600,27 +1627,28 @@ void Viewer2DPanel::OnMouseDown(wxMouseEvent &event) {
     wxString label;
     wxPoint pos;
     std::string uuid;
+    const wxPoint pickPos = ToFramebufferPoint(this, event.GetPosition());
     bool found = false;
     DragTarget target = DragTarget::None;
     if (FixtureTablePanel::Instance() &&
         FixtureTablePanel::Instance()->IsActivePage()) {
-      found = m_controller.GetFixtureLabelAt(event.GetX(), event.GetY(), w, h,
+      found = m_controller.GetFixtureLabelAt(pickPos.x, pickPos.y, w, h,
                                              label, pos, &uuid);
       target = DragTarget::Fixtures;
     } else if (TrussTablePanel::Instance() &&
                TrussTablePanel::Instance()->IsActivePage()) {
-      found = m_controller.GetTrussLabelAt(event.GetX(), event.GetY(), w, h,
+      found = m_controller.GetTrussLabelAt(pickPos.x, pickPos.y, w, h,
                                            label, pos, &uuid);
       target = DragTarget::Trusses;
     } else if (HoistTablePanel::Instance() &&
                HoistTablePanel::Instance()->IsActivePage()) {
       found = Viewer2DSupportSelection::FindHoistAtScreenPoint(
-          event.GetX(), event.GetY(), h, ConfigManager::Get().GetScene(),
+          pickPos.x, pickPos.y, h, ConfigManager::Get().GetScene(),
           ConfigManager::Get().GetHiddenLayers(), uuid, pos, label);
       target = DragTarget::Supports;
     } else if (SceneObjectTablePanel::Instance() &&
                SceneObjectTablePanel::Instance()->IsActivePage()) {
-      found = m_controller.GetSceneObjectLabelAt(event.GetX(), event.GetY(), w,
+      found = m_controller.GetSceneObjectLabelAt(pickPos.x, pickPos.y, w,
                                                  h, label, pos, &uuid);
       target = DragTarget::SceneObjects;
     }
@@ -1687,8 +1715,9 @@ void Viewer2DPanel::OnMouseDown(wxMouseEvent &event) {
 }
 
 void Viewer2DPanel::OnMouseDClick(wxMouseEvent &event) {
-  int w, h;
-  GetClientSize(&w, &h);
+  const RenderSize renderSize = ResolveRenderSize(this);
+  const int w = renderSize.width;
+  const int h = renderSize.height;
   if (w <= 0 || h <= 0 || !IsShownOnScreen())
     return;
 
@@ -1696,13 +1725,14 @@ void Viewer2DPanel::OnMouseDClick(wxMouseEvent &event) {
   wxString label;
   wxPoint pos;
   std::string uuid;
+  const wxPoint pickPos = ToFramebufferPoint(this, event.GetPosition());
   ConfigManager &cfg = ConfigManager::Get();
 
   const bool sceneObjectsActive =
       SceneObjectTablePanel::Instance() &&
       SceneObjectTablePanel::Instance()->IsActivePage();
   if (sceneObjectsActive &&
-      m_controller.GetSceneObjectLabelAt(event.GetX(), event.GetY(), w, h,
+      m_controller.GetSceneObjectLabelAt(pickPos.x, pickPos.y, w, h,
                                          label, pos, &uuid)) {
     const bool edited = scene_object_primitives::EditPrimitiveObjectByUuid(
         this, cfg, uuid);
@@ -1723,7 +1753,7 @@ void Viewer2DPanel::OnMouseDClick(wxMouseEvent &event) {
     return;
   }
 
-  if (!m_controller.GetFixtureLabelAt(event.GetX(), event.GetY(), w, h, label,
+  if (!m_controller.GetFixtureLabelAt(pickPos.x, pickPos.y, w, h, label,
                                       pos, &uuid))
     return;
 
@@ -1796,32 +1826,36 @@ void Viewer2DPanel::OnMouseUp(wxMouseEvent &event) {
   }
 
   if (event.LeftUp() && !m_draggedSincePress) {
-    int w, h;
-    GetClientSize(&w, &h);
+    const RenderSize renderSize = ResolveRenderSize(this);
+    const int w = renderSize.width;
+    const int h = renderSize.height;
     if (!IsShownOnScreen()) {
       return;
     }
+    if (!renderSize.IsValid())
+      return;
     SetCurrent(*m_glContext);
     wxString label;
     wxPoint pos;
     std::string uuid;
+    const wxPoint pickPos = ToFramebufferPoint(this, event.GetPosition());
     bool found = false;
     if (FixtureTablePanel::Instance() &&
         FixtureTablePanel::Instance()->IsActivePage())
-      found = m_controller.GetFixtureLabelAt(event.GetX(), event.GetY(), w, h,
+      found = m_controller.GetFixtureLabelAt(pickPos.x, pickPos.y, w, h,
                                              label, pos, &uuid);
     else if (TrussTablePanel::Instance() &&
              TrussTablePanel::Instance()->IsActivePage())
-      found = m_controller.GetTrussLabelAt(event.GetX(), event.GetY(), w, h,
+      found = m_controller.GetTrussLabelAt(pickPos.x, pickPos.y, w, h,
                                            label, pos, &uuid);
     else if (HoistTablePanel::Instance() &&
              HoistTablePanel::Instance()->IsActivePage())
       found = Viewer2DSupportSelection::FindHoistAtScreenPoint(
-          event.GetX(), event.GetY(), h, ConfigManager::Get().GetScene(),
+          pickPos.x, pickPos.y, h, ConfigManager::Get().GetScene(),
           ConfigManager::Get().GetHiddenLayers(), uuid, pos, label);
     else if (SceneObjectTablePanel::Instance() &&
              SceneObjectTablePanel::Instance()->IsActivePage())
-      found = m_controller.GetSceneObjectLabelAt(event.GetX(), event.GetY(), w,
+      found = m_controller.GetSceneObjectLabelAt(pickPos.x, pickPos.y, w,
                                                  h, label, pos, &uuid);
 
     ConfigManager &cfg = ConfigManager::Get();
@@ -1949,8 +1983,9 @@ void Viewer2DPanel::OnRightUp(wxMouseEvent &event) {
     return;
   }
 
-  int w, h;
-  GetClientSize(&w, &h);
+  const RenderSize renderSize = ResolveRenderSize(this);
+  const int w = renderSize.width;
+  const int h = renderSize.height;
   if (w <= 0 || h <= 0 || !IsShownOnScreen()) {
     event.Skip();
     return;
@@ -1960,7 +1995,8 @@ void Viewer2DPanel::OnRightUp(wxMouseEvent &event) {
   wxString label;
   wxPoint pos;
   std::string hitUuid;
-  if (m_controller.GetFixtureLabelAt(event.GetX(), event.GetY(), w, h, label,
+  const wxPoint pickPos = ToFramebufferPoint(this, event.GetPosition());
+  if (m_controller.GetFixtureLabelAt(pickPos.x, pickPos.y, w, h, label,
                                      pos, &hitUuid)) {
     event.Skip();
     return;

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -120,6 +120,19 @@ bool Is2DDarkModeEnabled() {
     return ConfigManager::Get().GetFloat("view2d_dark_mode") >= 0.5f;
 }
 
+wxPoint ToFramebufferPoint(wxWindow* window, const wxPoint& logicalPoint) {
+    if (window == nullptr)
+        return logicalPoint;
+    const double contentScale =
+        static_cast<double>(window->GetContentScaleFactor());
+    if (!std::isfinite(contentScale) || contentScale <= 0.0)
+        return logicalPoint;
+    return wxPoint(static_cast<int>(std::lround(
+                       static_cast<double>(logicalPoint.x) * contentScale)),
+                   static_cast<int>(std::lround(
+                       static_cast<double>(logicalPoint.y) * contentScale)));
+}
+
 Viewer3DRenderStyle ResolveRenderStyleFromPreferences() {
     return ResolveViewer3DRenderStyle(ConfigManager::Get());
 }
@@ -540,7 +553,8 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
 
     if (!skipLabelWork && shouldUpdateHoverQuery &&
         FixtureTablePanel::Instance() && FixtureTablePanel::Instance()->IsActivePage()) {
-        found = m_controller.GetFixtureLabelAt(m_lastMousePos.x, m_lastMousePos.y,
+        const wxPoint pickPos = ToFramebufferPoint(this, m_lastMousePos);
+        found = m_controller.GetFixtureLabelAt(pickPos.x, pickPos.y,
             w, h, newLabel, newPos, &newUuid);
         hoverQueryRan = true;
         if (found) {
@@ -552,7 +566,8 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
     }
     else if (!skipLabelWork && shouldUpdateHoverQuery &&
              TrussTablePanel::Instance() && TrussTablePanel::Instance()->IsActivePage()) {
-        found = m_controller.GetTrussLabelAt(m_lastMousePos.x, m_lastMousePos.y,
+        const wxPoint pickPos = ToFramebufferPoint(this, m_lastMousePos);
+        found = m_controller.GetTrussLabelAt(pickPos.x, pickPos.y,
             w, h, newLabel, newPos, &newUuid);
         hoverQueryRan = true;
         if (found) {
@@ -564,7 +579,8 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
     }
     else if (!skipLabelWork && shouldUpdateHoverQuery &&
              SceneObjectTablePanel::Instance() && SceneObjectTablePanel::Instance()->IsActivePage()) {
-        found = m_controller.GetSceneObjectLabelAt(m_lastMousePos.x, m_lastMousePos.y,
+        const wxPoint pickPos = ToFramebufferPoint(this, m_lastMousePos);
+        found = m_controller.GetSceneObjectLabelAt(pickPos.x, pickPos.y,
             w, h, newLabel, newPos, &newUuid);
         hoverQueryRan = true;
         if (found) {
@@ -872,22 +888,26 @@ void Viewer3DPanel::OnMouseUp(wxMouseEvent& event)
 
     if (event.LeftUp() && !m_draggedSincePress)
     {
-        int w, h;
-        GetClientSize(&w, &h);
+        const RenderSize renderSize = ResolveRenderSize(this);
+        const int w = renderSize.width;
+        const int h = renderSize.height;
         if (!IsShownOnScreen()) {
             return;
         }
+        if (!renderSize.IsValid())
+            return;
         SetCurrent(*m_glContext);
         wxString label;
         wxPoint pos;
         std::string uuid;
+        const wxPoint pickPos = ToFramebufferPoint(this, event.GetPosition());
         bool found = false;
         if (FixtureTablePanel::Instance() && FixtureTablePanel::Instance()->IsActivePage())
-            found = m_controller.GetFixtureLabelAt(event.GetX(), event.GetY(), w, h, label, pos, &uuid);
+            found = m_controller.GetFixtureLabelAt(pickPos.x, pickPos.y, w, h, label, pos, &uuid);
         else if (TrussTablePanel::Instance() && TrussTablePanel::Instance()->IsActivePage())
-            found = m_controller.GetTrussLabelAt(event.GetX(), event.GetY(), w, h, label, pos, &uuid);
+            found = m_controller.GetTrussLabelAt(pickPos.x, pickPos.y, w, h, label, pos, &uuid);
         else if (SceneObjectTablePanel::Instance() && SceneObjectTablePanel::Instance()->IsActivePage())
-            found = m_controller.GetSceneObjectLabelAt(event.GetX(), event.GetY(), w, h, label, pos, &uuid);
+            found = m_controller.GetSceneObjectLabelAt(pickPos.x, pickPos.y, w, h, label, pos, &uuid);
 
         ConfigManager& cfg = ConfigManager::Get();
         if (found)
@@ -998,8 +1018,9 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent& event)
     if (m_draggedSincePress)
         return;
 
-    int w, h;
-    GetClientSize(&w, &h);
+    const RenderSize renderSize = ResolveRenderSize(this);
+    const int w = renderSize.width;
+    const int h = renderSize.height;
     if (w <= 0 || h <= 0 || !IsShownOnScreen()) {
         event.Skip();
         return;
@@ -1017,7 +1038,8 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent& event)
         wxString label;
         wxPoint pos;
         std::string hitUuid;
-        if (!m_controller.GetFixtureLabelAt(event.GetX(), event.GetY(), w, h, label, pos,
+        const wxPoint pickPos = ToFramebufferPoint(this, event.GetPosition());
+        if (!m_controller.GetFixtureLabelAt(pickPos.x, pickPos.y, w, h, label, pos,
                                             &hitUuid)) {
             for (const auto& [uuid, fixture] : scene.fixtures) {
                 if (!fixture.typeName.empty())
@@ -1213,8 +1235,9 @@ void Viewer3DPanel::OnCaptureLost(wxMouseCaptureLostEvent& WXUNUSED(event))
 void Viewer3DPanel::ApplyRectangleSelection(const wxPoint& start,
                                             const wxPoint& end)
 {
-    int w, h;
-    GetClientSize(&w, &h);
+    const RenderSize renderSize = ResolveRenderSize(this);
+    const int w = renderSize.width;
+    const int h = renderSize.height;
     if (w <= 0 || h <= 0 || !IsShownOnScreen()) {
         return;
     }
@@ -1222,14 +1245,16 @@ void Viewer3DPanel::ApplyRectangleSelection(const wxPoint& start,
     SetCurrent(*m_glContext);
 
     ConfigManager& cfg = ConfigManager::Get();
+    const wxPoint pickStart = ToFramebufferPoint(this, start);
+    const wxPoint pickEnd = ToFramebufferPoint(this, end);
     if (m_rectSelectionAcrossAllTables)
     {
         const auto fixtures = m_controller.GetFixturesInScreenRect(
-            start.x, start.y, end.x, end.y, w, h);
+            pickStart.x, pickStart.y, pickEnd.x, pickEnd.y, w, h);
         const auto trusses = m_controller.GetTrussesInScreenRect(
-            start.x, start.y, end.x, end.y, w, h);
+            pickStart.x, pickStart.y, pickEnd.x, pickEnd.y, w, h);
         const auto sceneObjects = m_controller.GetSceneObjectsInScreenRect(
-            start.x, start.y, end.x, end.y, w, h);
+            pickStart.x, pickStart.y, pickEnd.x, pickEnd.y, w, h);
 
         const bool selectionChanged =
             fixtures != cfg.GetSelectedFixtures() ||
@@ -1272,7 +1297,8 @@ void Viewer3DPanel::ApplyRectangleSelection(const wxPoint& start,
 
     if (FixtureTablePanel::Instance() && FixtureTablePanel::Instance()->IsActivePage())
     {
-        auto selection = m_controller.GetFixturesInScreenRect(start.x, start.y, end.x, end.y, w, h);
+        auto selection = m_controller.GetFixturesInScreenRect(
+            pickStart.x, pickStart.y, pickEnd.x, pickEnd.y, w, h);
         if (selection != cfg.GetSelectedFixtures()) {
             cfg.PushUndoState("fixture selection");
             cfg.SetSelectedFixtures(selection);
@@ -1285,7 +1311,8 @@ void Viewer3DPanel::ApplyRectangleSelection(const wxPoint& start,
     }
     else if (TrussTablePanel::Instance() && TrussTablePanel::Instance()->IsActivePage())
     {
-        auto selection = m_controller.GetTrussesInScreenRect(start.x, start.y, end.x, end.y, w, h);
+        auto selection = m_controller.GetTrussesInScreenRect(
+            pickStart.x, pickStart.y, pickEnd.x, pickEnd.y, w, h);
         if (selection != cfg.GetSelectedTrusses()) {
             cfg.PushUndoState("truss selection");
             cfg.SetSelectedTrusses(selection);
@@ -1299,7 +1326,8 @@ void Viewer3DPanel::ApplyRectangleSelection(const wxPoint& start,
     else if (SceneObjectTablePanel::Instance() && SceneObjectTablePanel::Instance()->IsActivePage())
     {
         auto selection =
-            m_controller.GetSceneObjectsInScreenRect(start.x, start.y, end.x, end.y, w, h);
+            m_controller.GetSceneObjectsInScreenRect(
+                pickStart.x, pickStart.y, pickEnd.x, pickEnd.y, w, h);
         if (selection != cfg.GetSelectedSceneObjects()) {
             cfg.PushUndoState("scene object selection");
             cfg.SetSelectedSceneObjects(selection);
@@ -1318,11 +1346,14 @@ void Viewer3DPanel::DrawSelectionRectangle(int width, int height)
     int right = std::max(m_rectSelectStart.x, m_rectSelectEnd.x);
     int top = std::min(m_rectSelectStart.y, m_rectSelectEnd.y);
     int bottom = std::max(m_rectSelectStart.y, m_rectSelectEnd.y);
+    const wxPoint physicalTopLeft = ToFramebufferPoint(this, wxPoint(left, top));
+    const wxPoint physicalBottomRight =
+        ToFramebufferPoint(this, wxPoint(right, bottom));
 
-    float glLeft = static_cast<float>(left);
-    float glRight = static_cast<float>(right);
-    float glBottom = static_cast<float>(height - bottom);
-    float glTop = static_cast<float>(height - top);
+    float glLeft = static_cast<float>(physicalTopLeft.x);
+    float glRight = static_cast<float>(physicalBottomRight.x);
+    float glBottom = static_cast<float>(height - physicalBottomRight.y);
+    float glTop = static_cast<float>(height - physicalTopLeft.y);
 
     GLboolean depthEnabled = glIsEnabled(GL_DEPTH_TEST);
     if (depthEnabled)
@@ -1431,12 +1462,16 @@ void Viewer3DPanel::OnMouseWheel(wxMouseEvent& event)
 
 void Viewer3DPanel::OnMouseDClick(wxMouseEvent& event)
 {
-    int w, h;
-    GetClientSize(&w, &h);
+    const RenderSize renderSize = ResolveRenderSize(this);
+    const int w = renderSize.width;
+    const int h = renderSize.height;
+    if (!renderSize.IsValid())
+        return;
     SetCurrent(*m_glContext);
     wxString label;
     wxPoint pos;
     std::string uuid;
+    const wxPoint pickPos = ToFramebufferPoint(this, event.GetPosition());
     const bool cameraWasMoving = m_cameraMoving;
     if (cameraWasMoving)
         m_controller.SetCameraMoving(false);
@@ -1446,12 +1481,12 @@ void Viewer3DPanel::OnMouseDClick(wxMouseEvent& event)
         SceneObjectTablePanel::Instance()->IsActivePage();
 
     const bool foundSceneObject = sceneObjectsActive &&
-        m_controller.GetSceneObjectLabelAt(event.GetX(), event.GetY(), w, h,
+        m_controller.GetSceneObjectLabelAt(pickPos.x, pickPos.y, w, h,
                                            label, pos, &uuid);
 
     bool found = foundSceneObject;
     if (!found)
-        found = m_controller.GetFixtureLabelAt(event.GetX(), event.GetY(), w, h,
+        found = m_controller.GetFixtureLabelAt(pickPos.x, pickPos.y, w, h,
                                                label, pos, &uuid);
 
     if (cameraWasMoving)


### PR DESCRIPTION
### Motivation
- Fix incorrect mixing of logical (DIP) mouse coordinates and physical/framebuffer pixels that caused hit-testing and selection to be misaligned on high-DPI displays.
- Make the picking convention explicit near `ResolveRenderSize` to avoid future regressions and to standardize how mouse coordinates are mapped for all picking helpers.

### Description
- Introduced a small helper `ToFramebufferPoint` and converted all picking call sites in `viewer3d/viewer3dpanel.cpp` (hover, click, double-click, right-click hit tests, and rectangle selection) to use framebuffer coordinates and `ResolveRenderSize()` dimensions before calling `Get*LabelAt` / `Get*InScreenRect`.
- Applied the same physical-pixel conversion in `viewer2d/viewer2dpanel.cpp` for hover, click, drag-start hit-tests, double-click, right-click, support selection, and rectangle selection, and updated selection-rectangle overlays to draw using framebuffer-converted corners.
- Documented the new picking convention as a comment near `ResolveRenderSize` in `core/ui_render_size.h` so callers know to convert logical mouse coordinates to framebuffer pixels before hit-testing.
- Technical note: these panels are large; the next recommended split is to extract picking helpers (coordinate conversion and rectangle-to-pick-rect logic) into a small `picking/` or `ui/picking.{h,cpp}` module to keep the viewer panels focused and smaller in scope.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.
- Performed whitespace/diff checks and static consistency checks with no reported issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e492f8438c8324b35892ebcc9240f3)