### PR TITLE
Use physical framebuffer size in Viewer2D RenderToRGBA

### DIFF
--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -950,9 +950,9 @@ void Viewer2DPanel::RenderInternal(bool swapBuffers) {
 
 bool Viewer2DPanel::RenderToRGBA(std::vector<unsigned char> &pixels, int &width,
                                  int &height) {
-  int w = 0;
-  int h = 0;
-  GetClientSize(&w, &h);
+  const RenderSize renderSize = ResolveRenderSize(this);
+  const int w = renderSize.width;
+  const int h = renderSize.height;
   if (w <= 0 || h <= 0)
     return false;
 


### PR DESCRIPTION
### Motivation
- Ensure captures use the physical framebuffer (device pixels) rather than logical client size so DPI/content-scale does not produce wrong-sized readbacks or buffer allocations by replacing `GetClientSize` with `ResolveRenderSize(this)`.

### Description
- In `viewer2d/viewer2dpanel.cpp` updated `Viewer2DPanel::RenderToRGBA` to obtain `RenderSize` via `ResolveRenderSize(this)`, set `w/h` from `renderSize.width/height`, and use those `w/h` values for `TryAllocateCaptureBuffer`, the output `width/height`, and the `glReadPixels` call while keeping the existing `w/h > 0` guard.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e499c2a6ec8324b898cd254cf29765)