### PR TITLE
GDTF: Preferences panel + credential-store-first auth fallback for downloads

### DIFF
--- a/core/credentialstore.cpp
+++ b/core/credentialstore.cpp
@@ -80,4 +80,17 @@ std::optional<Credentials> Load()
     return c;
 }
 
+
+bool Clear()
+{
+    const std::string credFile = GetCredFile();
+    if (credFile.empty())
+        return false;
+    std::error_code ec;
+    if (!fs::exists(credFile, ec))
+        return true;
+    fs::remove(credFile, ec);
+    return !ec;
+}
+
 } // namespace CredentialStore

--- a/core/credentialstore.h
+++ b/core/credentialstore.h
@@ -27,4 +27,5 @@ namespace CredentialStore {
 
     bool Save(const Credentials& cred);
     std::optional<Credentials> Load();
+    bool Clear();
 }

--- a/core/gdtfnet.cpp
+++ b/core/gdtfnet.cpp
@@ -66,7 +66,8 @@ bool GdtfLogin(const std::string& user,
 }
 
 bool GdtfGetList(const std::string& cookieFile,
-                 std::string& listData)
+                 std::string& listData,
+                 long* httpCode)
 {
     CURL* curl = curl_easy_init();
     if (!curl)
@@ -84,6 +85,9 @@ bool GdtfGetList(const std::string& cookieFile,
         curl_easy_cleanup(curl);
         return false;
     }
+
+    if (httpCode)
+        curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, httpCode);
 
     curl_easy_cleanup(curl);
     return true;

--- a/core/gdtfnet.h
+++ b/core/gdtfnet.h
@@ -26,7 +26,8 @@ bool GdtfLogin(const std::string& user,
                long& httpCode);
 
 bool GdtfGetList(const std::string& cookieFile,
-                 std::string& listData);
+                 std::string& listData,
+                 long* httpCode = nullptr);
 
 bool GdtfDownload(const std::string& rid,
                   const std::string& destFile,

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -61,9 +61,11 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_cli_shortcuts.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_view_shortcuts.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_fixture_add_flow.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_gdtf_credentials.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_menu.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_print.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/preferencesdialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/preferences/gdtf_credentials_panel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scene_object_primitive_creation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scene_object_primitive_dialogs.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scene_object_primitive_editing.cpp

--- a/gui/mainwindow_gdtf_credentials.cpp
+++ b/gui/mainwindow_gdtf_credentials.cpp
@@ -1,0 +1,53 @@
+#include "mainwindow_gdtf_credentials.h"
+
+#include "configmanager.h"
+#include "simplecrypt.h"
+
+namespace {
+
+void ClearLegacyGdtfCredentials(ConfigManager &configManager) {
+  configManager.SetValue("gdtf_username", "");
+  configManager.SetValue("gdtf_password", "");
+}
+
+} // namespace
+
+std::optional<CredentialStore::Credentials>
+LoadGdtfCredentialsForGui(ConfigManager &configManager) {
+  if (auto credentials = CredentialStore::Load()) {
+    return credentials;
+  }
+
+  const std::string legacyUsername =
+      configManager.GetValue("gdtf_username").value_or("");
+  const std::string legacyPasswordEncoded =
+      configManager.GetValue("gdtf_password").value_or("");
+  if (legacyUsername.empty()) {
+    return std::nullopt;
+  }
+
+  CredentialStore::Credentials migratedCredentials;
+  migratedCredentials.username = legacyUsername;
+  migratedCredentials.password = SimpleCrypt::Decode(legacyPasswordEncoded);
+
+  if (CredentialStore::Save(migratedCredentials)) {
+    ClearLegacyGdtfCredentials(configManager);
+  }
+  return migratedCredentials;
+}
+
+void PersistGdtfCredentialsForGui(const CredentialStore::Credentials &credentials,
+                                  ConfigManager &configManager) {
+  if (credentials.username.empty()) {
+    CredentialStore::Clear();
+    ClearLegacyGdtfCredentials(configManager);
+    return;
+  }
+
+  CredentialStore::Save(credentials);
+  ClearLegacyGdtfCredentials(configManager);
+}
+
+bool IsAuthenticationFailureHttpCode(const long httpCode) {
+  return httpCode == 401 || httpCode == 403;
+}

--- a/gui/mainwindow_gdtf_credentials.h
+++ b/gui/mainwindow_gdtf_credentials.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "credentialstore.h"
+
+#include <optional>
+
+class ConfigManager;
+
+std::optional<CredentialStore::Credentials>
+LoadGdtfCredentialsForGui(ConfigManager &configManager);
+
+void PersistGdtfCredentialsForGui(const CredentialStore::Credentials &credentials,
+                                  ConfigManager &configManager);
+
+bool IsAuthenticationFailureHttpCode(long httpCode);

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -75,7 +75,7 @@
 #include "sceneobjecttablepanel.h"
 #include "selectfixturetypedialog.h"
 #include "selectnamedialog.h"
-#include "simplecrypt.h"
+#include "mainwindow_gdtf_credentials.h"
 #include "support.h"
 #include "trussloader.h"
 #include "tools/fixture_symbol_generation_tool.h"
@@ -451,25 +451,10 @@ void MainWindow::OnNew(wxCommandEvent &WXUNUSED(event)) {
 }
 
 void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
-  // Flow overview: reuse stored credentials to reduce friction, authenticate,
-  // and persist the session before requesting the list and downloading.
-  // The order matters because the list needs a valid cookie; we also save
-  // credentials early so a later network failure doesn't discard user input.
-  std::string savedUser;
-  std::string savedPass;
-  if (auto creds = CredentialStore::Load()) {
-    savedUser = creds->username;
-    savedPass = creds->password;
-  } else {
-    std::string savedPassEnc =
-        GetDefaultGuiConfigServices().LegacyConfigManager().GetValue("gdtf_password").value_or("");
-    savedUser = GetDefaultGuiConfigServices().LegacyConfigManager().GetValue("gdtf_username").value_or("");
-    savedPass = SimpleCrypt::Decode(savedPassEnc);
-  }
-
-  GdtfLoginDialog loginDlg(this, savedUser, savedPass);
-  if (loginDlg.ShowModal() != wxID_OK)
-    return;
+  ConfigManager &configManager =
+      GetDefaultGuiConfigServices().LegacyConfigManager();
+  std::optional<CredentialStore::Credentials> activeCredentials =
+      LoadGdtfCredentialsForGui(configManager);
 
   std::unique_ptr<wxWindowDisabler> gdtfDownloadDisabler =
       std::make_unique<wxWindowDisabler>();
@@ -485,41 +470,80 @@ void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
     wxMessageBox(message, caption, wxOK | wxICON_ERROR, this);
   };
 
-  updateGdtfDownloadBusyOverlay("Connecting to GDTF Share...");
-  wxString username =
-      wxString::FromUTF8(loginDlg.GetUsername()).Trim(true).Trim(false);
-  wxString password = wxString::FromUTF8(loginDlg.GetPassword());
-  GetDefaultGuiConfigServices().LegacyConfigManager().SetValue("gdtf_username",
-                                WxToUtf8(username));
-  GetDefaultGuiConfigServices().LegacyConfigManager().SetValue(
-      "gdtf_password", SimpleCrypt::Encode(WxToUtf8(password)));
-  CredentialStore::Save(
-      {WxToUtf8(username), WxToUtf8(password)});
-
-  if (!currentProjectPath.empty())
-    GetDefaultGuiConfigServices().LegacyConfigManager().SaveProject(currentProjectPath);
-
   wxString cookieFileWx = wxFileName::GetTempDir() + "/gdtf_session.txt";
   std::string cookieFile = WxToUtf8(cookieFileWx);
-  long httpCode = 0;
-  if (consolePanel)
-    consolePanel->AppendMessage("[INFO] Logging into GDTF Share using libcurl");
-  updateGdtfDownloadBusyOverlay("Logging in to GDTF Share...");
-  if (!GdtfLogin(WxToUtf8(username), WxToUtf8(password),
-                 cookieFile, httpCode)) {
-    showGdtfDownloadError("Failed to connect to GDTF Share.", "Login Error");
+
+  auto requestCredentialsFromDialog = [&]() -> bool {
+    const std::string initialUser =
+        activeCredentials ? activeCredentials->username : std::string();
+    const std::string initialPassword =
+        activeCredentials ? activeCredentials->password : std::string();
+
+    gdtfDownloadBusyOverlay.reset();
+    gdtfDownloadDisabler.reset();
+    GdtfLoginDialog loginDlg(this, initialUser, initialPassword);
+    if (loginDlg.ShowModal() != wxID_OK)
+      return false;
+
+    gdtfDownloadDisabler = std::make_unique<wxWindowDisabler>();
+
+    CredentialStore::Credentials dialogCredentials;
+    dialogCredentials.username = WxToUtf8(
+        wxString::FromUTF8(loginDlg.GetUsername()).Trim(true).Trim(false));
+    dialogCredentials.password = loginDlg.GetPassword();
+
+    if (dialogCredentials.username.empty() || dialogCredentials.password.empty()) {
+      showGdtfDownloadError("Please provide username and password.",
+                            "Login Error");
+      return false;
+    }
+
+    PersistGdtfCredentialsForGui(dialogCredentials, configManager);
+    activeCredentials = dialogCredentials;
+    return true;
+  };
+
+  auto tryLogin = [&](long &httpCode) -> bool {
+    if (!activeCredentials || activeCredentials->username.empty() ||
+        activeCredentials->password.empty()) {
+      return false;
+    }
+
     if (consolePanel)
-      consolePanel->AppendMessage("[ERROR] Login connection failed");
-    return;
+      consolePanel->AppendMessage("[INFO] Logging into GDTF Share using libcurl");
+    updateGdtfDownloadBusyOverlay("Logging in to GDTF Share...");
+    return GdtfLogin(activeCredentials->username, activeCredentials->password,
+                     cookieFile, httpCode);
+  };
+
+  long loginHttpCode = 0;
+  bool loginConnected = tryLogin(loginHttpCode);
+
+  if (!loginConnected || IsAuthenticationFailureHttpCode(loginHttpCode)) {
+    if (!requestCredentialsFromDialog()) {
+      wxRemoveFile(cookieFileWx);
+      return;
+    }
+
+    loginConnected = tryLogin(loginHttpCode);
+    if (!loginConnected) {
+      showGdtfDownloadError("Failed to connect to GDTF Share.", "Login Error");
+      if (consolePanel)
+        consolePanel->AppendMessage("[ERROR] Login connection failed");
+      wxRemoveFile(cookieFileWx);
+      return;
+    }
   }
+
   if (consolePanel)
-    consolePanel->AppendMessage(wxString::Format("[INFO] Login HTTP code: %ld",
-                                                 httpCode));
-  if (httpCode != 200) {
+    consolePanel->AppendMessage(
+        wxString::Format("[INFO] Login HTTP code: %ld", loginHttpCode));
+  if (loginHttpCode != 200) {
     showGdtfDownloadError("Login failed.", "Login Error");
     if (consolePanel)
       consolePanel->AppendMessage("[ERROR] Login failed with code " +
-                                  wxString::Format("%ld", httpCode));
+                                  wxString::Format("%ld", loginHttpCode));
+    wxRemoveFile(cookieFileWx);
     return;
   }
 
@@ -527,18 +551,41 @@ void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
     consolePanel->AppendMessage("[INFO] Retrieving fixture list via libcurl");
   updateGdtfDownloadBusyOverlay("Retrieving fixture list...");
   std::string listData;
-  if (!GdtfGetList(cookieFile, listData)) {
+  long listHttpCode = 0;
+  if (!GdtfGetList(cookieFile, listData, &listHttpCode)) {
     showGdtfDownloadError("Failed to retrieve fixture list.", "Error");
+    wxRemoveFile(cookieFileWx);
     return;
+  }
+
+  if (IsAuthenticationFailureHttpCode(listHttpCode)) {
+    if (!requestCredentialsFromDialog()) {
+      wxRemoveFile(cookieFileWx);
+      return;
+    }
+
+    loginConnected = tryLogin(loginHttpCode);
+    if (!loginConnected || loginHttpCode != 200) {
+      showGdtfDownloadError("Login failed.", "Login Error");
+      wxRemoveFile(cookieFileWx);
+      return;
+    }
+
+    listData.clear();
+    listHttpCode = 0;
+    if (!GdtfGetList(cookieFile, listData, &listHttpCode)) {
+      showGdtfDownloadError("Failed to retrieve fixture list.", "Error");
+      wxRemoveFile(cookieFileWx);
+      return;
+    }
   }
 
   if (consolePanel)
     consolePanel->AppendMessage(wxString::Format(
         "[INFO] Retrieved list size: %zu bytes", listData.size()));
 
-  GetDefaultGuiConfigServices().LegacyConfigManager().SetValue("gdtf_fixture_list", listData);
+  configManager.SetValue("gdtf_fixture_list", listData);
 
-  // open search dialog
   updateGdtfDownloadBusyOverlay("Preparing fixture search...");
   GdtfSearchDialog searchDlg(this, listData);
   gdtfDownloadBusyOverlay.reset();
@@ -555,11 +602,9 @@ void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
       wxString dest = saveDlg.GetPath();
       if (!rid.empty()) {
         if (consolePanel)
-          consolePanel->AppendMessage("[INFO] Downloading via libcurl rid=" +
-                                      rid);
+          consolePanel->AppendMessage("[INFO] Downloading via libcurl rid=" + rid);
         long dlCode = 0;
-        bool ok = GdtfDownload(WxToUtf8(rid),
-                               WxToUtf8(dest), cookieFile, dlCode);
+        bool ok = GdtfDownload(WxToUtf8(rid), WxToUtf8(dest), cookieFile, dlCode);
         if (consolePanel)
           consolePanel->AppendMessage(
               wxString::Format("[INFO] Download HTTP code: %ld", dlCode));
@@ -570,12 +615,10 @@ void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
           if (addNow == wxYES)
             AddFixtureFromGdtfPath(WxToUtf8(dest));
         } else {
-          wxMessageBox("Failed to download GDTF.", "Error",
-                       wxOK | wxICON_ERROR);
+          wxMessageBox("Failed to download GDTF.", "Error", wxOK | wxICON_ERROR);
         }
       } else {
-        wxMessageBox("Download information missing.", "Error",
-                     wxOK | wxICON_ERROR);
+        wxMessageBox("Download information missing.", "Error", wxOK | wxICON_ERROR);
       }
     }
   }

--- a/gui/preferences/gdtf_credentials_panel.cpp
+++ b/gui/preferences/gdtf_credentials_panel.cpp
@@ -1,0 +1,110 @@
+#include "preferences/gdtf_credentials_panel.h"
+
+#include "configmanager.h"
+#include "credentialstore.h"
+#include "gdtfnet.h"
+#include "guiconfigservices.h"
+#include "mainwindow_gdtf_credentials.h"
+
+#include <wx/button.h>
+#include <wx/filefn.h>
+#include <wx/filename.h>
+#include <wx/msgdlg.h>
+#include <wx/sizer.h>
+#include <wx/stattext.h>
+#include <wx/textctrl.h>
+
+namespace {
+
+CredentialStore::Credentials ReadUiCredentials(const wxTextCtrl *usernameCtrl,
+                                               const wxTextCtrl *passwordCtrl) {
+  CredentialStore::Credentials credentials;
+  credentials.username =
+      std::string(usernameCtrl->GetValue().Trim(true).Trim(false).ToUTF8());
+  credentials.password = std::string(passwordCtrl->GetValue().ToUTF8());
+  return credentials;
+}
+
+} // namespace
+
+GdtfCredentialsPanel::GdtfCredentialsPanel(wxWindow *parent)
+    : wxPanel(parent, wxID_ANY) {
+  wxBoxSizer *topSizer = new wxBoxSizer(wxVERTICAL);
+  wxFlexGridSizer *credentialsGrid = new wxFlexGridSizer(2, 2, 8, 10);
+  credentialsGrid->AddGrowableCol(1, 1);
+
+  credentialsGrid->Add(new wxStaticText(this, wxID_ANY, "Username:"), 0,
+                       wxALIGN_CENTER_VERTICAL);
+  usernameCtrl = new wxTextCtrl(this, wxID_ANY);
+  credentialsGrid->Add(usernameCtrl, 1, wxEXPAND);
+
+  credentialsGrid->Add(new wxStaticText(this, wxID_ANY, "Password:"), 0,
+                       wxALIGN_CENTER_VERTICAL);
+  passwordCtrl =
+      new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition,
+                     wxDefaultSize, wxTE_PASSWORD);
+  credentialsGrid->Add(passwordCtrl, 1, wxEXPAND);
+
+  topSizer->Add(credentialsGrid, 0, wxALL | wxEXPAND, 10);
+
+  validateButton = new wxButton(this, wxID_ANY, "Validate credentials");
+  topSizer->Add(validateButton, 0, wxLEFT | wxRIGHT | wxBOTTOM, 10);
+
+  SetSizer(topSizer);
+
+  validateButton->Bind(wxEVT_BUTTON,
+                       &GdtfCredentialsPanel::OnValidateCredentials, this);
+}
+
+void GdtfCredentialsPanel::LoadCredentials() {
+  ConfigManager &configManager =
+      GetDefaultGuiConfigServices().LegacyConfigManager();
+  if (const auto credentials = LoadGdtfCredentialsForGui(configManager)) {
+    usernameCtrl->SetValue(wxString::FromUTF8(credentials->username));
+    passwordCtrl->SetValue(wxString::FromUTF8(credentials->password));
+  }
+}
+
+bool GdtfCredentialsPanel::ApplyCredentials() {
+  ConfigManager &configManager =
+      GetDefaultGuiConfigServices().LegacyConfigManager();
+  const CredentialStore::Credentials credentials =
+      ReadUiCredentials(usernameCtrl, passwordCtrl);
+  PersistGdtfCredentialsForGui(credentials, configManager);
+  return true;
+}
+
+void GdtfCredentialsPanel::OnValidateCredentials(wxCommandEvent &WXUNUSED(event)) {
+  const CredentialStore::Credentials credentials =
+      ReadUiCredentials(usernameCtrl, passwordCtrl);
+  if (credentials.username.empty() || credentials.password.empty()) {
+    wxMessageBox("Please enter username and password first.",
+                 "Validate credentials", wxOK | wxICON_INFORMATION, this);
+    return;
+  }
+
+  wxString cookieFileWx = wxFileName::GetTempDir() + "/gdtf_validate_session.txt";
+  std::string cookieFile = std::string(cookieFileWx.ToUTF8());
+  long httpCode = 0;
+  const bool connected =
+      GdtfLogin(credentials.username, credentials.password, cookieFile, httpCode);
+  wxRemoveFile(cookieFileWx);
+
+  if (!connected) {
+    wxMessageBox("Failed to connect to GDTF Share.", "Validate credentials",
+                 wxOK | wxICON_ERROR, this);
+    return;
+  }
+
+  if (httpCode == 200) {
+    PersistGdtfCredentialsForGui(
+        credentials, GetDefaultGuiConfigServices().LegacyConfigManager());
+    wxMessageBox("Credentials are valid and were saved.",
+                 "Validate credentials", wxOK | wxICON_INFORMATION, this);
+    return;
+  }
+
+  const wxString message =
+      wxString::Format("Credentials are invalid (HTTP %ld).", httpCode);
+  wxMessageBox(message, "Validate credentials", wxOK | wxICON_WARNING, this);
+}

--- a/gui/preferences/gdtf_credentials_panel.h
+++ b/gui/preferences/gdtf_credentials_panel.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <wx/panel.h>
+
+class wxButton;
+class wxTextCtrl;
+
+class GdtfCredentialsPanel : public wxPanel {
+public:
+  explicit GdtfCredentialsPanel(wxWindow *parent);
+
+  void LoadCredentials();
+  bool ApplyCredentials();
+
+private:
+  void OnValidateCredentials(wxCommandEvent &event);
+
+  wxTextCtrl *usernameCtrl = nullptr;
+  wxTextCtrl *passwordCtrl = nullptr;
+  wxButton *validateButton = nullptr;
+};

--- a/gui/preferencesdialog.cpp
+++ b/gui/preferencesdialog.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "preferencesdialog.h"
+#include "preferences/gdtf_credentials_panel.h"
 #include "configmanager.h"
 #include "guiconfigservices.h"
 #include "units/units.h"
@@ -148,6 +149,11 @@ PreferencesDialog::PreferencesDialog(wxWindow *parent)
   unitsPanel->SetSizer(unitsSizer);
   book->AddPage(unitsPanel, "Units");
 
+  // GDTF page
+  gdtfCredentialsPanel = new GdtfCredentialsPanel(book);
+  gdtfCredentialsPanel->LoadCredentials();
+  book->AddPage(gdtfCredentialsPanel, "GDTF");
+
   // 3D Viewer page
   wxPanel *viewer3dPanel = new wxPanel(book);
   wxBoxSizer *viewer3dSizer = new wxBoxSizer(wxVERTICAL);
@@ -261,6 +267,10 @@ bool PreferencesDialog::ApplyPreferences() {
   else if (viewer3dByUniverseRenderRadio && viewer3dByUniverseRenderRadio->GetValue())
     renderStyle = Viewer3DRenderStyle::ByUniverse;
   cfg.SetValue("viewer3d_render_style", ToConfigValue(renderStyle));
+
+  if (gdtfCredentialsPanel)
+    gdtfCredentialsPanel->ApplyCredentials();
+
   return cfg.SaveUserConfig();
 }
 

--- a/gui/preferencesdialog.h
+++ b/gui/preferencesdialog.h
@@ -22,6 +22,8 @@
 
 wxDECLARE_EVENT(EVT_UI_UNITS_CHANGED, wxCommandEvent);
 
+class GdtfCredentialsPanel;
+
 class PreferencesDialog : public wxDialog {
 public:
   PreferencesDialog(wxWindow *parent);
@@ -53,4 +55,5 @@ private:
   wxChoice *weightUnitChoice = nullptr;
   wxString initialDistanceUnit;
   wxString initialWeightUnit;
+  GdtfCredentialsPanel *gdtfCredentialsPanel = nullptr;
 };


### PR DESCRIPTION
### Motivation
- Avoid prompting the user unnecessarily by reusing persisted GDTF credentials and only showing the login dialog when credentials are missing or authentication fails.  
- Migrate legacy `gdtf_username/gdtf_password` entries into the secure `CredentialStore` and remove duplicate legacy state.  
- Provide an explicit Preferences location for users to view/validate/update GDTF credentials and keep credential handling out of large hotspot files.

### Description
- Added a new Preferences panel `GdtfCredentialsPanel` (`gui/preferences/gdtf_credentials_panel.h/.cpp`) with username/password fields and a `Validate credentials` button that can test login and save valid credentials.  
- Centralized GUI credential migration/persist/cleanup in `gui/mainwindow_gdtf_credentials.{h,cpp}` with `LoadGdtfCredentialsForGui`, `PersistGdtfCredentialsForGui` and `IsAuthenticationFailureHttpCode`; legacy `gdtf_*` config keys are cleared after migration.  
- Extended `CredentialStore` with `Clear()` to allow explicit removal of stored credentials.  
- Updated `MainWindow::OnDownloadGdtf` to try credentials from `CredentialStore` first, call `GdtfLogin` with those credentials, and only display `GdtfLoginDialog` when no credentials exist or when a 401/403 auth failure is detected; successful fallback login is persisted automatically.  
- Modified `GdtfGetList` signature to `GdtfGetList(..., long* httpCode = nullptr)` so the download flow can detect HTTP auth failures and trigger a login fallback.  
- Integrated the new GDTF page into `PreferencesDialog` (load/apply flow) and registered new sources in `gui/CMakeLists.txt` with explicit ownership.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.  
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.  
- Attempted full CMake configure/build with `cmake -S . -B build && cmake --build build -j2`, but configure failed in this environment due to missing `wxWidgets` development packages (no build artifact produced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e49d2c5bb083249928c9bb6394998b)