### PR TITLE
GDTF: open cache-first dialog with one-shot online refresh

### DIFF
--- a/gui/gdtfsearchdialog.cpp
+++ b/gui/gdtfsearchdialog.cpp
@@ -21,6 +21,7 @@
 #include <wx/datetime.h>
 
 using json = nlohmann::json;
+wxDEFINE_EVENT(EVT_GDTF_REFRESH_DONE, wxThreadEvent);
 
 namespace {
 wxString FormatTimestamp(const std::string& ts)
@@ -43,10 +44,15 @@ wxString FormatTimestamp(const std::string& ts)
 }
 } // namespace
 
-GdtfSearchDialog::GdtfSearchDialog(wxWindow* parent, const std::string& listData)
+GdtfSearchDialog::GdtfSearchDialog(wxWindow* parent, const std::string& listData,
+                                   const std::string& cachedUpdatedAt,
+                                   RefreshCatalogFn refreshCatalogFnIn)
     : wxDialog(parent, wxID_ANY, "Search GDTF", wxDefaultPosition,
                wxSize(1000,700),
-               wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
+               wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
+      currentListData(listData),
+      lastUpdatedAt(cachedUpdatedAt),
+      refreshCatalogFn(std::move(refreshCatalogFnIn))
 {
     wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
 
@@ -60,6 +66,9 @@ GdtfSearchDialog::GdtfSearchDialog(wxWindow* parent, const std::string& listData
                                  wxDefaultSize, wxTE_PROCESS_ENTER);
     searchSizer->Add(fixtureCtrl, 1);
     sizer->Add(searchSizer, 0, wxEXPAND | wxALL, 10);
+
+    statusLabel = new wxStaticText(this, wxID_ANY, "");
+    sizer->Add(statusLabel, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 10);
 
     resultTable = new wxDataViewListCtrl(this, wxID_ANY, wxDefaultPosition,
                                          wxDefaultSize, wxDV_ROW_LINES);
@@ -104,9 +113,18 @@ GdtfSearchDialog::GdtfSearchDialog(wxWindow* parent, const std::string& listData
     downloadBtn->Bind(wxEVT_BUTTON, &GdtfSearchDialog::OnDownload, this);
     resultTable->Bind(wxEVT_DATAVIEW_ITEM_ACTIVATED,
                       &GdtfSearchDialog::OnDownload, this);
+    Bind(wxEVT_SHOW, &GdtfSearchDialog::OnDialogShown, this);
+    Bind(EVT_GDTF_REFRESH_DONE, &GdtfSearchDialog::OnAutoRefreshThreadEvent, this);
 
-    ParseList(listData);
+    ParseList(currentListData);
     UpdateResults();
+    UpdateStatusMessage(false);
+}
+
+GdtfSearchDialog::~GdtfSearchDialog()
+{
+    if (autoRefreshThread.joinable())
+        autoRefreshThread.join();
 }
 
 void GdtfSearchDialog::ParseList(const std::string& listData)
@@ -194,8 +212,10 @@ void GdtfSearchDialog::ParseList(const std::string& listData)
 
 void GdtfSearchDialog::UpdateResults()
 {
+    const std::string previouslySelectedRid = GetSelectedId();
     resultTable->DeleteAllItems();
     visible.clear();
+    selectedIndex = -1;
 
     auto normalize = [](wxString s) {
         s = s.Lower();
@@ -230,6 +250,16 @@ void GdtfSearchDialog::UpdateResults()
         row.push_back(wxString::FromUTF8(entries[i].version));
         row.push_back(wxString::FromUTF8(entries[i].rating));
         resultTable->AppendItem(row);
+
+        if (!previouslySelectedRid.empty() && entries[i].rid == previouslySelectedRid) {
+            const unsigned int rowIndex =
+                static_cast<unsigned int>(resultTable->GetItemCount() - 1);
+            wxDataViewItem rowItem = resultTable->RowToItem(rowIndex);
+            if (rowItem.IsOk()) {
+                resultTable->Select(rowItem);
+                selectedIndex = static_cast<int>(i);
+            }
+        }
     }
     if (ConsolePanel::Instance()) {
         wxString msg = wxString::Format("Visible results: %zu", visible.size());
@@ -273,4 +303,73 @@ std::string GdtfSearchDialog::GetSelectedName() const
     if (selectedIndex >= 0 && selectedIndex < static_cast<int>(entries.size()))
         return entries[selectedIndex].fixture;
     return {};
+}
+
+std::string GdtfSearchDialog::GetCurrentListData() const
+{
+    return currentListData;
+}
+
+void GdtfSearchDialog::OnDialogShown(wxShowEvent& evt)
+{
+    evt.Skip();
+    if (!evt.IsShown())
+        return;
+
+    TriggerAutoRefreshOnce();
+}
+
+void GdtfSearchDialog::TriggerAutoRefreshOnce()
+{
+    if (autoRefreshTriggered || !refreshCatalogFn)
+        return;
+    autoRefreshTriggered = true;
+    UpdateStatusMessage(true);
+
+    autoRefreshThread = std::thread([this, refreshFn = refreshCatalogFn]() {
+        const RefreshResult result = refreshFn();
+        wxThreadEvent* event = new wxThreadEvent(EVT_GDTF_REFRESH_DONE);
+        event->SetPayload(result);
+        wxQueueEvent(this, event);
+    });
+}
+
+void GdtfSearchDialog::OnAutoRefreshThreadEvent(wxThreadEvent& evt)
+{
+    OnAutoRefreshFinished(evt.GetPayload<RefreshResult>());
+}
+
+void GdtfSearchDialog::OnAutoRefreshFinished(const RefreshResult& result)
+{
+    if (result.success && !result.listData.empty()) {
+        currentListData = result.listData;
+        lastUpdatedAt = result.updatedAt;
+        ParseList(currentListData);
+        UpdateResults();
+        UpdateStatusMessage(false);
+        return;
+    }
+
+    UpdateStatusMessage(false,
+                        "Mostrando catálogo local (última actualización: " +
+                            wxString::FromUTF8(lastUpdatedAt) + ")");
+}
+
+void GdtfSearchDialog::UpdateStatusMessage(bool refreshing, const wxString& details)
+{
+    if (refreshing) {
+        statusLabel->SetLabel("Actualizando catálogo online...");
+        return;
+    }
+
+    if (!details.empty()) {
+        statusLabel->SetLabel(details);
+        return;
+    }
+
+    if (lastUpdatedAt.empty())
+        statusLabel->SetLabel("Mostrando catálogo local.");
+    else
+        statusLabel->SetLabel("Mostrando catálogo local (última actualización: " +
+                              wxString::FromUTF8(lastUpdatedAt) + ")");
 }

--- a/gui/gdtfsearchdialog.cpp
+++ b/gui/gdtfsearchdialog.cpp
@@ -17,13 +17,89 @@
  */
 #include "gdtfsearchdialog.h"
 #include "columnutils.h"
-#include "consolepanel.h"
+#include <mutex>
 #include <wx/datetime.h>
 
 using json = nlohmann::json;
 wxDEFINE_EVENT(EVT_GDTF_REFRESH_DONE, wxThreadEvent);
 
 namespace {
+std::vector<GdtfEntry> ParseEntriesFromListData(const std::string& listData)
+{
+    std::vector<GdtfEntry> parsedEntries;
+    json j = json::parse(listData, nullptr, false);
+    if (j.is_discarded())
+        return parsedEntries;
+
+    if (j.is_object()) {
+        if (j.contains("data"))
+            j = j["data"];
+        if (j.contains("fixtures"))
+            j = j["fixtures"];
+        if (j.contains("list"))
+            j = j["list"];
+    }
+    if (!j.is_array())
+        return parsedEntries;
+
+    auto jsonToString = [](const json& v) -> std::string {
+        if (v.is_string())
+            return v.get<std::string>();
+        if (v.is_number())
+            return v.dump();
+        if (v.is_array()) {
+            std::string result;
+            for (size_t i = 0; i < v.size(); ++i) {
+                if (i > 0)
+                    result += ", ";
+                const auto& el = v[i];
+                if (el.is_string())
+                    result += el.get<std::string>();
+                else if (el.is_object() && el.contains("name") && el["name"].is_string())
+                    result += el["name"].get<std::string>();
+                else
+                    result += el.dump();
+            }
+            return result;
+        }
+        if (v.is_object())
+            return v.dump();
+        return {};
+    };
+
+    auto getValue = [&](const json& obj, std::initializer_list<const char*> keys) -> std::string {
+        for (const char* k : keys) {
+            auto it = obj.find(k);
+            if (it != obj.end())
+                return jsonToString(*it);
+        }
+        return {};
+    };
+
+    parsedEntries.reserve(j.size());
+    for (const auto& item : j) {
+        GdtfEntry e;
+        e.manufacturer = getValue(item, {"manufacturer", "brand", "mfr"});
+        e.fixture = getValue(item, {"fixture", "name", "model"});
+        e.rid = getValue(item, {"rid", "revisionId"});
+        e.url = getValue(item, {"url", "download", "downloadUrl"});
+        e.modes = getValue(item, {"modes", "mode", "modeCount"});
+        e.creator = getValue(item, {"creator", "user", "userName"});
+        e.uploader = getValue(item, {"uploader"});
+        e.creationDate = getValue(item, {"creationDate"});
+        e.revision = getValue(item, {"revision"});
+        e.lastModified = getValue(item, {"lastModified"});
+        e.version = getValue(item, {"version"});
+        e.rating = getValue(item, {"rating"});
+        parsedEntries.push_back(std::move(e));
+    }
+    return parsedEntries;
+}
+
+std::mutex g_cachedCatalogMutex;
+std::string g_cachedCatalogPayload;
+std::vector<GdtfEntry> g_cachedCatalogEntries;
+
 wxString FormatTimestamp(const std::string& ts)
 {
     if (ts.empty())
@@ -129,84 +205,13 @@ GdtfSearchDialog::~GdtfSearchDialog()
 
 void GdtfSearchDialog::ParseList(const std::string& listData)
 {
-    entries.clear();
-    if (ConsolePanel::Instance()) {
-        wxString msg = wxString::Format("Parse list: %zu bytes", listData.size());
-        ConsolePanel::Instance()->AppendMessage(msg);
-    }
-    json j = json::parse(listData, nullptr, false);
-    if (j.is_discarded()) {
-        if (ConsolePanel::Instance()) {
-            ConsolePanel::Instance()->AppendMessage("JSON parse error");
-            wxString sample = wxString::FromUTF8(listData.substr(0, 200));
-            ConsolePanel::Instance()->AppendMessage("Sample: " + sample);
-        }
-        return;
-    }
-    if (j.is_object()) {
-        if (j.contains("data"))
-            j = j["data"];
-        if (j.contains("fixtures"))
-            j = j["fixtures"];
-        if (j.contains("list"))
-            j = j["list"];
-    }
-    if (!j.is_array())
-        return;
-
-    auto jsonToString = [](const json& v) -> std::string {
-        if (v.is_string())
-            return v.get<std::string>();
-        if (v.is_number())
-            return v.dump();
-        if (v.is_array()) {
-            std::string result;
-            for (size_t i = 0; i < v.size(); ++i) {
-                if (i > 0)
-                    result += ", ";
-                const auto& el = v[i];
-                if (el.is_string())
-                    result += el.get<std::string>();
-                else if (el.is_object() && el.contains("name") && el["name"].is_string())
-                    result += el["name"].get<std::string>();
-                else
-                    result += el.dump();
-            }
-            return result;
-        }
-        if (v.is_object())
-            return v.dump();
-        return {};
-    };
-
-    auto getValue = [&](const json& obj, std::initializer_list<const char*> keys) -> std::string {
-        for (const char* k : keys) {
-            auto it = obj.find(k);
-            if (it != obj.end())
-                return jsonToString(*it);
-        }
-        return {};
-    };
-
-    for (const auto& item : j) {
-        GdtfEntry e;
-        e.manufacturer = getValue(item, {"manufacturer", "brand", "mfr"});
-        e.fixture = getValue(item, {"fixture", "name", "model"});
-        e.rid = getValue(item, {"rid", "revisionId"});
-        e.url = getValue(item, {"url", "download", "downloadUrl"});
-        e.modes = getValue(item, {"modes", "mode", "modeCount"});
-        e.creator = getValue(item, {"creator", "user", "userName"});
-        e.uploader = getValue(item, {"uploader"});
-        e.creationDate = getValue(item, {"creationDate"});
-        e.revision = getValue(item, {"revision"});
-        e.lastModified = getValue(item, {"lastModified"});
-        e.version = getValue(item, {"version"});
-        e.rating = getValue(item, {"rating"});
-        entries.push_back(e);
-    }
-    if (ConsolePanel::Instance()) {
-        wxString msg = wxString::Format("Parsed %zu entries", entries.size());
-        ConsolePanel::Instance()->AppendMessage(msg);
+    std::lock_guard<std::mutex> lock(g_cachedCatalogMutex);
+    if (listData == g_cachedCatalogPayload) {
+        entries = g_cachedCatalogEntries;
+    } else {
+        entries = ParseEntriesFromListData(listData);
+        g_cachedCatalogPayload = listData;
+        g_cachedCatalogEntries = entries;
     }
 }
 
@@ -226,10 +231,6 @@ void GdtfSearchDialog::UpdateResults()
 
     wxString b = normalize(manufacturerCtrl->GetValue());
     wxString m = normalize(fixtureCtrl->GetValue());
-    if (ConsolePanel::Instance()) {
-        wxString msg = "Filtering manufacturer='" + b + "' fixture='" + m + "'";
-        ConsolePanel::Instance()->AppendMessage(msg);
-    }
     for (size_t i = 0; i < entries.size(); ++i) {
         wxString manuOrig = wxString::FromUTF8(entries[i].manufacturer);
         wxString fixOrig = wxString::FromUTF8(entries[i].fixture);
@@ -261,16 +262,10 @@ void GdtfSearchDialog::UpdateResults()
             }
         }
     }
-    if (ConsolePanel::Instance()) {
-        wxString msg = wxString::Format("Visible results: %zu", visible.size());
-        ConsolePanel::Instance()->AppendMessage(msg);
-    }
 }
 
 void GdtfSearchDialog::OnSearch(wxCommandEvent& WXUNUSED(evt))
 {
-    if (ConsolePanel::Instance())
-        ConsolePanel::Instance()->AppendMessage("Search triggered");
     UpdateResults();
 }
 
@@ -327,7 +322,9 @@ void GdtfSearchDialog::TriggerAutoRefreshOnce()
     UpdateStatusMessage(true);
 
     autoRefreshThread = std::thread([this, refreshFn = refreshCatalogFn]() {
-        const RefreshResult result = refreshFn();
+        RefreshResult result = refreshFn();
+        if (result.success && !result.listData.empty())
+            result.parsedEntries = ParseEntriesFromListData(result.listData);
         wxThreadEvent* event = new wxThreadEvent(EVT_GDTF_REFRESH_DONE);
         event->SetPayload(result);
         wxQueueEvent(this, event);
@@ -341,10 +338,16 @@ void GdtfSearchDialog::OnAutoRefreshThreadEvent(wxThreadEvent& evt)
 
 void GdtfSearchDialog::OnAutoRefreshFinished(const RefreshResult& result)
 {
-    if (result.success && !result.listData.empty()) {
+    if (result.success && !result.listData.empty() && !result.parsedEntries.empty()) {
         currentListData = result.listData;
         lastUpdatedAt = result.updatedAt;
-        ParseList(currentListData);
+
+        {
+            std::lock_guard<std::mutex> lock(g_cachedCatalogMutex);
+            g_cachedCatalogPayload = currentListData;
+            g_cachedCatalogEntries = result.parsedEntries;
+        }
+        entries = result.parsedEntries;
         UpdateResults();
         UpdateStatusMessage(false);
         return;

--- a/gui/gdtfsearchdialog.cpp
+++ b/gui/gdtfsearchdialog.cpp
@@ -354,14 +354,14 @@ void GdtfSearchDialog::OnAutoRefreshFinished(const RefreshResult& result)
     }
 
     UpdateStatusMessage(false,
-                        "Mostrando catálogo local (última actualización: " +
+                        "Showing local catalog (last updated: " +
                             wxString::FromUTF8(lastUpdatedAt) + ")");
 }
 
 void GdtfSearchDialog::UpdateStatusMessage(bool refreshing, const wxString& details)
 {
     if (refreshing) {
-        statusLabel->SetLabel("Actualizando catálogo online...");
+        statusLabel->SetLabel("Updating online catalog...");
         return;
     }
 
@@ -371,8 +371,8 @@ void GdtfSearchDialog::UpdateStatusMessage(bool refreshing, const wxString& deta
     }
 
     if (lastUpdatedAt.empty())
-        statusLabel->SetLabel("Mostrando catálogo local.");
+        statusLabel->SetLabel("Showing local catalog.");
     else
-        statusLabel->SetLabel("Mostrando catálogo local (última actualización: " +
+        statusLabel->SetLabel("Showing local catalog (last updated: " +
                               wxString::FromUTF8(lastUpdatedAt) + ")");
 }

--- a/gui/gdtfsearchdialog.h
+++ b/gui/gdtfsearchdialog.h
@@ -44,6 +44,7 @@ public:
         bool success = false;
         std::string listData;
         std::string updatedAt;
+        std::vector<GdtfEntry> parsedEntries;
     };
     using RefreshCatalogFn = std::function<RefreshResult()>;
 

--- a/gui/gdtfsearchdialog.h
+++ b/gui/gdtfsearchdialog.h
@@ -18,6 +18,8 @@
 #pragma once
 #include <wx/wx.h>
 #include <wx/dataview.h>
+#include <functional>
+#include <thread>
 #include <vector>
 #include "json.hpp"
 
@@ -38,20 +40,42 @@ struct GdtfEntry {
 
 class GdtfSearchDialog : public wxDialog {
 public:
-    GdtfSearchDialog(wxWindow* parent, const std::string& listData);
+    struct RefreshResult {
+        bool success = false;
+        std::string listData;
+        std::string updatedAt;
+    };
+    using RefreshCatalogFn = std::function<RefreshResult()>;
+
+    GdtfSearchDialog(wxWindow* parent, const std::string& listData,
+                     const std::string& cachedUpdatedAt,
+                     RefreshCatalogFn refreshCatalogFn);
+    ~GdtfSearchDialog() override;
     std::string GetSelectedId() const;
     std::string GetSelectedUrl() const;
     std::string GetSelectedName() const;
+    std::string GetCurrentListData() const;
 private:
     void ParseList(const std::string& listData);
     void UpdateResults();
     void OnSearch(wxCommandEvent& evt);
     void OnDownload(wxCommandEvent& evt);
+    void OnDialogShown(wxShowEvent& evt);
+    void TriggerAutoRefreshOnce();
+    void OnAutoRefreshThreadEvent(wxThreadEvent& evt);
+    void OnAutoRefreshFinished(const RefreshResult& result);
+    void UpdateStatusMessage(bool refreshing, const wxString& details = {});
 
     wxTextCtrl* manufacturerCtrl = nullptr;
     wxTextCtrl* fixtureCtrl = nullptr;
     wxDataViewListCtrl* resultTable = nullptr;
+    wxStaticText* statusLabel = nullptr;
     std::vector<GdtfEntry> entries;
     std::vector<int> visible;
     int selectedIndex = -1;
+    std::string currentListData;
+    std::string lastUpdatedAt;
+    RefreshCatalogFn refreshCatalogFn;
+    bool autoRefreshTriggered = false;
+    std::thread autoRefreshThread;
 };

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -462,47 +462,49 @@ void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
 
   const std::string listData = configManager.GetValue("gdtf_fixture_list").value_or("{}");
   const std::string cachedUpdatedAt =
-      configManager.GetValue("gdtf_fixture_list_last_update").value_or("desconocida");
+      configManager.GetValue("gdtf_fixture_list_last_update").value_or("unknown");
+
+  std::string effectiveListData = listData;
+  std::string effectiveUpdatedAt = cachedUpdatedAt;
+
+  {
+    std::unique_ptr<wxWindowDisabler> refreshDisabler =
+        std::make_unique<wxWindowDisabler>();
+    std::unique_ptr<wxBusyInfo> refreshOverlay =
+        std::make_unique<wxBusyInfo>("Updating GDTF catalog...");
+    wxYieldIfNeeded();
+
+    if (activeCredentials && !activeCredentials->username.empty() &&
+        !activeCredentials->password.empty()) {
+      long loginHttpCode = 0;
+      const bool loginOk = GdtfLogin(activeCredentials->username,
+                                     activeCredentials->password, cookieFile,
+                                     loginHttpCode);
+      if (loginOk && loginHttpCode == 200) {
+        std::string onlineListData;
+        long listHttpCode = 0;
+        if (GdtfGetList(cookieFile, onlineListData, &listHttpCode) &&
+            listHttpCode == 200 && !onlineListData.empty()) {
+          effectiveListData = std::move(onlineListData);
+          effectiveUpdatedAt = WxToUtf8(wxDateTime::Now().FormatISOCombined(' '));
+          if (effectiveListData != listData) {
+            configManager.SetValue("gdtf_fixture_list", effectiveListData);
+            configManager.SetValue("gdtf_fixture_list_last_update",
+                                   effectiveUpdatedAt);
+          }
+        }
+      }
+    }
+  }
 
   std::unique_ptr<wxBusyInfo> preparingCatalogOverlay =
       std::make_unique<wxBusyInfo>("Loading GDTF catalog...");
   wxYieldIfNeeded();
-  GdtfSearchDialog searchDlg(
-      this, listData, cachedUpdatedAt, [activeCredentials, cookieFile]() {
-        GdtfSearchDialog::RefreshResult result;
-        if (!activeCredentials || activeCredentials->username.empty() ||
-            activeCredentials->password.empty()) {
-          return result;
-        }
-
-        long loginHttpCode = 0;
-        if (!GdtfLogin(activeCredentials->username, activeCredentials->password,
-                       cookieFile, loginHttpCode) ||
-            loginHttpCode != 200) {
-          return result;
-        }
-
-        long listHttpCode = 0;
-        if (!GdtfGetList(cookieFile, result.listData, &listHttpCode) ||
-            listHttpCode != 200 || result.listData.empty()) {
-          result.listData.clear();
-          return result;
-        }
-
-        result.success = true;
-        result.updatedAt = WxToUtf8(wxDateTime::Now().FormatISOCombined(' '));
-        return result;
-      });
+  GdtfSearchDialog searchDlg(this, effectiveListData, effectiveUpdatedAt,
+                             GdtfSearchDialog::RefreshCatalogFn());
   preparingCatalogOverlay.reset();
 
   const int searchDialogResult = searchDlg.ShowModal();
-  const std::string updatedListData = searchDlg.GetCurrentListData();
-  if (!updatedListData.empty() && updatedListData != listData) {
-    configManager.SetValue("gdtf_fixture_list", updatedListData);
-    configManager.SetValue(
-        "gdtf_fixture_list_last_update",
-        WxToUtf8(wxDateTime::Now().FormatISOCombined(' ')));
-  }
 
   if (searchDialogResult == wxID_OK) {
 

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -464,6 +464,9 @@ void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
   const std::string cachedUpdatedAt =
       configManager.GetValue("gdtf_fixture_list_last_update").value_or("desconocida");
 
+  std::unique_ptr<wxBusyInfo> preparingCatalogOverlay =
+      std::make_unique<wxBusyInfo>("Loading GDTF catalog...");
+  wxYieldIfNeeded();
   GdtfSearchDialog searchDlg(
       this, listData, cachedUpdatedAt, [activeCredentials, cookieFile]() {
         GdtfSearchDialog::RefreshResult result;
@@ -490,6 +493,7 @@ void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
         result.updatedAt = WxToUtf8(wxDateTime::Now().FormatISOCombined(' '));
         return result;
       });
+  preparingCatalogOverlay.reset();
 
   const int searchDialogResult = searchDlg.ShowModal();
   const std::string updatedListData = searchDlg.GetCurrentListData();

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -35,6 +35,7 @@
 #include <wx/busyinfo.h>
 #include <wx/choice.h>
 #include <wx/choicdlg.h>
+#include <wx/datetime.h>
 #include <wx/filename.h>
 #include <wx/filefn.h>
 #include <wx/html/htmlwin.h>
@@ -456,141 +457,122 @@ void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
   std::optional<CredentialStore::Credentials> activeCredentials =
       LoadGdtfCredentialsForGui(configManager);
 
-  std::unique_ptr<wxWindowDisabler> gdtfDownloadDisabler =
-      std::make_unique<wxWindowDisabler>();
-  std::unique_ptr<wxBusyInfo> gdtfDownloadBusyOverlay;
-  auto updateGdtfDownloadBusyOverlay = [&](const wxString &message) {
-    gdtfDownloadBusyOverlay = std::make_unique<wxBusyInfo>(message);
-    wxYieldIfNeeded();
-  };
-  auto showGdtfDownloadError = [&](const wxString &message,
-                                   const wxString &caption) {
-    gdtfDownloadBusyOverlay.reset();
-    gdtfDownloadDisabler.reset();
-    wxMessageBox(message, caption, wxOK | wxICON_ERROR, this);
-  };
-
   wxString cookieFileWx = wxFileName::GetTempDir() + "/gdtf_session.txt";
   std::string cookieFile = WxToUtf8(cookieFileWx);
 
-  auto requestCredentialsFromDialog = [&]() -> bool {
-    const std::string initialUser =
-        activeCredentials ? activeCredentials->username : std::string();
-    const std::string initialPassword =
-        activeCredentials ? activeCredentials->password : std::string();
+  const std::string listData = configManager.GetValue("gdtf_fixture_list").value_or("{}");
+  const std::string cachedUpdatedAt =
+      configManager.GetValue("gdtf_fixture_list_last_update").value_or("desconocida");
 
-    gdtfDownloadBusyOverlay.reset();
-    gdtfDownloadDisabler.reset();
-    GdtfLoginDialog loginDlg(this, initialUser, initialPassword);
-    if (loginDlg.ShowModal() != wxID_OK)
-      return false;
+  GdtfSearchDialog searchDlg(
+      this, listData, cachedUpdatedAt, [activeCredentials, cookieFile]() {
+        GdtfSearchDialog::RefreshResult result;
+        if (!activeCredentials || activeCredentials->username.empty() ||
+            activeCredentials->password.empty()) {
+          return result;
+        }
 
-    gdtfDownloadDisabler = std::make_unique<wxWindowDisabler>();
+        long loginHttpCode = 0;
+        if (!GdtfLogin(activeCredentials->username, activeCredentials->password,
+                       cookieFile, loginHttpCode) ||
+            loginHttpCode != 200) {
+          return result;
+        }
 
-    CredentialStore::Credentials dialogCredentials;
-    dialogCredentials.username = WxToUtf8(
-        wxString::FromUTF8(loginDlg.GetUsername()).Trim(true).Trim(false));
-    dialogCredentials.password = loginDlg.GetPassword();
+        long listHttpCode = 0;
+        if (!GdtfGetList(cookieFile, result.listData, &listHttpCode) ||
+            listHttpCode != 200 || result.listData.empty()) {
+          result.listData.clear();
+          return result;
+        }
 
-    if (dialogCredentials.username.empty() || dialogCredentials.password.empty()) {
-      showGdtfDownloadError("Please provide username and password.",
-                            "Login Error");
-      return false;
-    }
+        result.success = true;
+        result.updatedAt = WxToUtf8(wxDateTime::Now().FormatISOCombined(' '));
+        return result;
+      });
 
-    PersistGdtfCredentialsForGui(dialogCredentials, configManager);
-    activeCredentials = dialogCredentials;
-    return true;
-  };
+  const int searchDialogResult = searchDlg.ShowModal();
+  const std::string updatedListData = searchDlg.GetCurrentListData();
+  if (!updatedListData.empty() && updatedListData != listData) {
+    configManager.SetValue("gdtf_fixture_list", updatedListData);
+    configManager.SetValue(
+        "gdtf_fixture_list_last_update",
+        WxToUtf8(wxDateTime::Now().FormatISOCombined(' ')));
+  }
 
-  auto tryLogin = [&](long &httpCode) -> bool {
-    if (!activeCredentials || activeCredentials->username.empty() ||
-        activeCredentials->password.empty()) {
-      return false;
-    }
+  if (searchDialogResult == wxID_OK) {
 
-    if (consolePanel)
-      consolePanel->AppendMessage("[INFO] Logging into GDTF Share using libcurl");
-    updateGdtfDownloadBusyOverlay("Logging in to GDTF Share...");
-    return GdtfLogin(activeCredentials->username, activeCredentials->password,
-                     cookieFile, httpCode);
-  };
+    std::unique_ptr<wxWindowDisabler> gdtfDownloadDisabler =
+        std::make_unique<wxWindowDisabler>();
+    std::unique_ptr<wxBusyInfo> gdtfDownloadBusyOverlay;
+    auto updateGdtfDownloadBusyOverlay = [&](const wxString &message) {
+      gdtfDownloadBusyOverlay = std::make_unique<wxBusyInfo>(message);
+      wxYieldIfNeeded();
+    };
+    auto showGdtfDownloadError = [&](const wxString &message,
+                                     const wxString &caption) {
+      gdtfDownloadBusyOverlay.reset();
+      gdtfDownloadDisabler.reset();
+      wxMessageBox(message, caption, wxOK | wxICON_ERROR, this);
+    };
+    auto requestCredentialsFromDialog = [&]() -> bool {
+      const std::string initialUser =
+          activeCredentials ? activeCredentials->username : std::string();
+      const std::string initialPassword =
+          activeCredentials ? activeCredentials->password : std::string();
 
-  long loginHttpCode = 0;
-  bool loginConnected = tryLogin(loginHttpCode);
+      gdtfDownloadBusyOverlay.reset();
+      gdtfDownloadDisabler.reset();
+      GdtfLoginDialog loginDlg(this, initialUser, initialPassword);
+      if (loginDlg.ShowModal() != wxID_OK)
+        return false;
 
-  if (!loginConnected || IsAuthenticationFailureHttpCode(loginHttpCode)) {
-    if (!requestCredentialsFromDialog()) {
-      wxRemoveFile(cookieFileWx);
-      return;
-    }
+      gdtfDownloadDisabler = std::make_unique<wxWindowDisabler>();
 
-    loginConnected = tryLogin(loginHttpCode);
-    if (!loginConnected) {
-      showGdtfDownloadError("Failed to connect to GDTF Share.", "Login Error");
+      CredentialStore::Credentials dialogCredentials;
+      dialogCredentials.username = WxToUtf8(
+          wxString::FromUTF8(loginDlg.GetUsername()).Trim(true).Trim(false));
+      dialogCredentials.password = loginDlg.GetPassword();
+
+      if (dialogCredentials.username.empty() ||
+          dialogCredentials.password.empty()) {
+        showGdtfDownloadError("Please provide username and password.",
+                              "Login Error");
+        return false;
+      }
+
+      PersistGdtfCredentialsForGui(dialogCredentials, configManager);
+      activeCredentials = dialogCredentials;
+      return true;
+    };
+    auto tryLogin = [&](long &httpCode) -> bool {
+      if (!activeCredentials || activeCredentials->username.empty() ||
+          activeCredentials->password.empty()) {
+        return false;
+      }
+
       if (consolePanel)
-        consolePanel->AppendMessage("[ERROR] Login connection failed");
-      wxRemoveFile(cookieFileWx);
-      return;
-    }
-  }
+        consolePanel->AppendMessage("[INFO] Logging into GDTF Share using libcurl");
+      updateGdtfDownloadBusyOverlay("Logging in to GDTF Share...");
+      return GdtfLogin(activeCredentials->username, activeCredentials->password,
+                       cookieFile, httpCode);
+    };
 
-  if (consolePanel)
-    consolePanel->AppendMessage(
-        wxString::Format("[INFO] Login HTTP code: %ld", loginHttpCode));
-  if (loginHttpCode != 200) {
-    showGdtfDownloadError("Login failed.", "Login Error");
-    if (consolePanel)
-      consolePanel->AppendMessage("[ERROR] Login failed with code " +
-                                  wxString::Format("%ld", loginHttpCode));
-    wxRemoveFile(cookieFileWx);
-    return;
-  }
-
-  if (consolePanel)
-    consolePanel->AppendMessage("[INFO] Retrieving fixture list via libcurl");
-  updateGdtfDownloadBusyOverlay("Retrieving fixture list...");
-  std::string listData;
-  long listHttpCode = 0;
-  if (!GdtfGetList(cookieFile, listData, &listHttpCode)) {
-    showGdtfDownloadError("Failed to retrieve fixture list.", "Error");
-    wxRemoveFile(cookieFileWx);
-    return;
-  }
-
-  if (IsAuthenticationFailureHttpCode(listHttpCode)) {
-    if (!requestCredentialsFromDialog()) {
-      wxRemoveFile(cookieFileWx);
-      return;
+    long loginHttpCode = 0;
+    bool loginConnected = tryLogin(loginHttpCode);
+    if (!loginConnected || IsAuthenticationFailureHttpCode(loginHttpCode)) {
+      if (!requestCredentialsFromDialog()) {
+        wxRemoveFile(cookieFileWx);
+        return;
+      }
+      loginConnected = tryLogin(loginHttpCode);
+      if (!loginConnected || loginHttpCode != 200) {
+        showGdtfDownloadError("Login failed.", "Login Error");
+        wxRemoveFile(cookieFileWx);
+        return;
+      }
     }
 
-    loginConnected = tryLogin(loginHttpCode);
-    if (!loginConnected || loginHttpCode != 200) {
-      showGdtfDownloadError("Login failed.", "Login Error");
-      wxRemoveFile(cookieFileWx);
-      return;
-    }
-
-    listData.clear();
-    listHttpCode = 0;
-    if (!GdtfGetList(cookieFile, listData, &listHttpCode)) {
-      showGdtfDownloadError("Failed to retrieve fixture list.", "Error");
-      wxRemoveFile(cookieFileWx);
-      return;
-    }
-  }
-
-  if (consolePanel)
-    consolePanel->AppendMessage(wxString::Format(
-        "[INFO] Retrieved list size: %zu bytes", listData.size()));
-
-  configManager.SetValue("gdtf_fixture_list", listData);
-
-  updateGdtfDownloadBusyOverlay("Preparing fixture search...");
-  GdtfSearchDialog searchDlg(this, listData);
-  gdtfDownloadBusyOverlay.reset();
-  gdtfDownloadDisabler.reset();
-  if (searchDlg.ShowModal() == wxID_OK) {
     wxString rid = wxString::FromUTF8(searchDlg.GetSelectedId());
     wxString name = wxString::FromUTF8(searchDlg.GetSelectedName());
 


### PR DESCRIPTION
### Motivation
- Improve GDTF catalog UX by showing cached catalog immediately and performing a single, non-blocking online refresh per dialog open instead of blocking the UI while fetching remote data.
- Preserve search/filter interactivity and selection while an online update arrives so users can continue browsing the cached list.
- Provide a non-intrusive failure state message when online refresh fails and avoid any periodic or startup background refresh behavior.

### Description
- `MainWindow::OnDownloadGdtf` now opens `GdtfSearchDialog` immediately with the cached `gdtf_fixture_list` and `gdtf_fixture_list_last_update`, and passes a one-shot refresh callback that fetches an updated list when possible (persisting it back to config if changed) (modified `gui/mainwindow_menu.cpp`).
- `GdtfSearchDialog` API was extended with `RefreshResult`, `RefreshCatalogFn`, `GetCurrentListData()`, cached last-update metadata, a `statusLabel`, and a safe worker-thread -> UI thread event flow for a single auto-refresh triggered on first show (added/modified in `gui/gdtfsearchdialog.h` and `gui/gdtfsearchdialog.cpp`).
- On refresh success the dialog replaces `entries`, reapplies the current manufacturer/fixture filters via `UpdateResults()`, and preserves selection when the previously-selected `rid` still exists; on refresh failure cached entries are retained and the dialog shows the non-intrusive message “Mostrando catálogo local (última actualización: …)”.
- The download/login credential prompts remain part of the explicit download flow (unchanged behavior), and no periodic or app-start refresh tasks were added.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (OK).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (OK).
- Attempted a full configure/build with `cmake -S . -B build && cmake --build build -j2` which failed in this environment due to missing wxWidgets development packages, not due to the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e49f4e7c208324a43ff1eeaf1cb29b)