### PR TITLE
Fix GDTF busy overlay blocking result dialogs

### DIFF
--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -511,14 +511,17 @@ void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
     std::unique_ptr<wxWindowDisabler> gdtfDownloadDisabler =
         std::make_unique<wxWindowDisabler>();
     std::unique_ptr<wxBusyInfo> gdtfDownloadBusyOverlay;
+    auto clearGdtfDownloadBlockingUi = [&]() {
+      gdtfDownloadBusyOverlay.reset();
+      gdtfDownloadDisabler.reset();
+    };
     auto updateGdtfDownloadBusyOverlay = [&](const wxString &message) {
       gdtfDownloadBusyOverlay = std::make_unique<wxBusyInfo>(message);
       wxYieldIfNeeded();
     };
     auto showGdtfDownloadError = [&](const wxString &message,
                                      const wxString &caption) {
-      gdtfDownloadBusyOverlay.reset();
-      gdtfDownloadDisabler.reset();
+      clearGdtfDownloadBlockingUi();
       wxMessageBox(message, caption, wxOK | wxICON_ERROR, this);
     };
     auto requestCredentialsFromDialog = [&]() -> bool {
@@ -527,8 +530,7 @@ void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
       const std::string initialPassword =
           activeCredentials ? activeCredentials->password : std::string();
 
-      gdtfDownloadBusyOverlay.reset();
-      gdtfDownloadDisabler.reset();
+      clearGdtfDownloadBlockingUi();
       GdtfLoginDialog loginDlg(this, initialUser, initialPassword);
       if (loginDlg.ShowModal() != wxID_OK)
         return false;
@@ -586,13 +588,17 @@ void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
         wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("fixtures"));
     wxFileDialog saveDlg(this, "Save GDTF file", fixDir, name + ".gdtf",
                          "*.gdtf", wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+    clearGdtfDownloadBlockingUi();
     if (saveDlg.ShowModal() == wxID_OK) {
       wxString dest = saveDlg.GetPath();
       if (!rid.empty()) {
+        gdtfDownloadDisabler = std::make_unique<wxWindowDisabler>();
+        updateGdtfDownloadBusyOverlay("Downloading GDTF from GDTF Share...");
         if (consolePanel)
           consolePanel->AppendMessage("[INFO] Downloading via libcurl rid=" + rid);
         long dlCode = 0;
         bool ok = GdtfDownload(WxToUtf8(rid), WxToUtf8(dest), cookieFile, dlCode);
+        clearGdtfDownloadBlockingUi();
         if (consolePanel)
           consolePanel->AppendMessage(
               wxString::Format("[INFO] Download HTTP code: %ld", dlCode));


### PR DESCRIPTION
### Motivation
- Modal result dialogs (e.g. "GDTF downloaded successfully..." and login/save prompts) could appear behind the "Logging in to GDTF Share..." busy overlay and window disabler, preventing the user from seeing or interacting with them.

### Description
- Add a local helper `clearGdtfDownloadBlockingUi()` to centralize cleanup of the GDTF busy overlay and `wxWindowDisabler` in `MainWindow::OnDownloadGdtf` in `gui/mainwindow_menu.cpp`.
- Replace direct `reset()` calls with the helper at points where modal dialogs are shown so overlays are removed before opening login/save/message boxes.
- Ensure the blocking UI is cleared before showing the `Save GDTF file` dialog and show a dedicated busy overlay (`"Downloading GDTF from GDTF Share..."`) during the actual download, clearing it immediately after the download finishes.
- Adjusted control flow so success/error message boxes are presented only after the busy overlay/disabler are removed.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4aa0960d48324848e48e809f0ef4f)