### PR TITLE
Refactor GDTF catalog to dedicated cache, add timing metrics and gated verbose logs

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/fixturetable/fixture_table_parser.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fixturetablepanel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtfsearchdialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gdtf_catalog_cache.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/hoist_load_limit_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/hoist_load_recalculation_prompt.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/hoisttablepanel.cpp

--- a/gui/gdtf_catalog_cache.cpp
+++ b/gui/gdtf_catalog_cache.cpp
@@ -1,0 +1,72 @@
+#include "gdtf_catalog_cache.h"
+
+#include <filesystem>
+#include <fstream>
+
+#include <wx/filename.h>
+#include <wx/stdpaths.h>
+
+#include "json.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+
+fs::path GetCachePath() {
+  const wxString userDataDir = wxStandardPaths::Get().GetUserDataDir();
+  const fs::path rootPath = userDataDir.ToStdString();
+  return rootPath / "gdtf_catalog_cache.json";
+}
+
+} // namespace
+
+std::optional<GdtfCatalogCacheEntry> LoadGdtfCatalogCache() {
+  const fs::path cachePath = GetCachePath();
+  if (!fs::exists(cachePath))
+    return std::nullopt;
+
+  std::ifstream input(cachePath, std::ios::binary);
+  if (!input)
+    return std::nullopt;
+
+  std::string payload((std::istreambuf_iterator<char>(input)),
+                      std::istreambuf_iterator<char>());
+  if (payload.empty())
+    return std::nullopt;
+
+  nlohmann::json root = nlohmann::json::parse(payload, nullptr, false);
+  if (root.is_discarded() || !root.is_object())
+    return std::nullopt;
+
+  GdtfCatalogCacheEntry entry;
+  if (root.contains("list_data") && root["list_data"].is_string())
+    entry.listData = root["list_data"].get<std::string>();
+  if (root.contains("updated_at") && root["updated_at"].is_string())
+    entry.updatedAt = root["updated_at"].get<std::string>();
+  if (root.contains("compressed") && root["compressed"].is_boolean())
+    entry.compressed = root["compressed"].get<bool>();
+
+  if (entry.listData.empty())
+    return std::nullopt;
+
+  return entry;
+}
+
+bool SaveGdtfCatalogCache(const GdtfCatalogCacheEntry &entry) {
+  const fs::path cachePath = GetCachePath();
+  std::error_code mkdirError;
+  fs::create_directories(cachePath.parent_path(), mkdirError);
+
+  nlohmann::json root;
+  root["version"] = 1;
+  root["updated_at"] = entry.updatedAt;
+  root["compressed"] = entry.compressed;
+  root["list_data"] = entry.listData;
+
+  std::ofstream output(cachePath, std::ios::binary | std::ios::trunc);
+  if (!output)
+    return false;
+
+  output << root.dump();
+  return output.good();
+}

--- a/gui/gdtf_catalog_cache.h
+++ b/gui/gdtf_catalog_cache.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+struct GdtfCatalogCacheEntry {
+  std::string listData;
+  std::string updatedAt;
+  bool compressed = false;
+};
+
+std::optional<GdtfCatalogCacheEntry> LoadGdtfCatalogCache();
+bool SaveGdtfCatalogCache(const GdtfCatalogCacheEntry &entry);

--- a/gui/gdtfsearchdialog.cpp
+++ b/gui/gdtfsearchdialog.cpp
@@ -17,9 +17,12 @@
  */
 #include "gdtfsearchdialog.h"
 #include "columnutils.h"
+#include "ui_feature_flags.h"
 #include <algorithm>
+#include <chrono>
 #include <mutex>
 #include <wx/datetime.h>
+#include <wx/log.h>
 
 using json = nlohmann::json;
 wxDEFINE_EVENT(EVT_GDTF_REFRESH_DONE, wxThreadEvent);
@@ -241,6 +244,7 @@ GdtfSearchDialog::~GdtfSearchDialog()
 
 void GdtfSearchDialog::ParseList(const std::string& listData)
 {
+    const auto parseStart = std::chrono::steady_clock::now();
     std::lock_guard<std::mutex> lock(g_cachedCatalogMutex);
     if (listData == g_cachedCatalogPayload) {
         entries = g_cachedCatalogEntries;
@@ -249,10 +253,18 @@ void GdtfSearchDialog::ParseList(const std::string& listData)
         g_cachedCatalogPayload = listData;
         g_cachedCatalogEntries = entries;
     }
+    lastParseMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                      std::chrono::steady_clock::now() - parseStart)
+                      .count();
+    MaybeLogVerboseCatalogTrace(
+        wxString::Format("ParseList size=%zu parsed_entries=%zu parse_ms=%lld",
+                         listData.size(), entries.size(),
+                         static_cast<long long>(lastParseMs)));
 }
 
 void GdtfSearchDialog::UpdateResults()
 {
+    const auto filterStart = std::chrono::steady_clock::now();
     if (searchDebounceTimer.IsRunning())
         searchDebounceTimer.Stop();
 
@@ -274,6 +286,14 @@ void GdtfSearchDialog::UpdateResults()
             continue;
         filteredIndices.push_back(static_cast<int>(i));
     }
+
+    lastFilterMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                       std::chrono::steady_clock::now() - filterStart)
+                       .count();
+    MaybeLogVerboseCatalogTrace(wxString::Format(
+        "Filtering manufacturer='%s' fixture='%s' matches=%zu filter_ms=%lld",
+        manufacturerCtrl->GetValue(), fixtureCtrl->GetValue(),
+        filteredIndices.size(), static_cast<long long>(lastFilterMs)));
 
     currentPage = 0;
     RenderCurrentPage(previouslySelectedRid);
@@ -297,6 +317,7 @@ void GdtfSearchDialog::OnSearchDebounceTimer(wxTimerEvent& WXUNUSED(evt))
 
 void GdtfSearchDialog::RenderCurrentPage(const std::string& previouslySelectedRid)
 {
+    const auto renderStart = std::chrono::steady_clock::now();
     resultTable->Freeze();
     resultTable->DeleteAllItems();
     visible.clear();
@@ -333,6 +354,12 @@ void GdtfSearchDialog::RenderCurrentPage(const std::string& previouslySelectedRi
         }
     }
     resultTable->Thaw();
+    lastRenderMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                       std::chrono::steady_clock::now() - renderStart)
+                       .count();
+    MaybeLogVerboseCatalogTrace(wxString::Format(
+        "Visible results page=%zu visible=%zu render_ms=%lld",
+        currentPage + 1, visible.size(), static_cast<long long>(lastRenderMs)));
     UpdatePaginationControls();
 }
 
@@ -420,9 +447,19 @@ void GdtfSearchDialog::TriggerAutoRefreshOnce()
     UpdateStatusMessage(true);
 
     autoRefreshThread = std::thread([this, refreshFn = refreshCatalogFn]() {
+        const auto refreshStart = std::chrono::steady_clock::now();
         RefreshResult result = refreshFn();
+        result.refreshMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                               std::chrono::steady_clock::now() - refreshStart)
+                               .count();
         if (result.success && !result.listData.empty())
+        {
+            const auto parseStart = std::chrono::steady_clock::now();
             result.parsedEntries = ParseEntriesFromListData(result.listData);
+            result.parseMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                 std::chrono::steady_clock::now() - parseStart)
+                                 .count();
+        }
         wxThreadEvent* event = new wxThreadEvent(EVT_GDTF_REFRESH_DONE);
         event->SetPayload(result);
         wxQueueEvent(this, event);
@@ -436,6 +473,12 @@ void GdtfSearchDialog::OnAutoRefreshThreadEvent(wxThreadEvent& evt)
 
 void GdtfSearchDialog::OnAutoRefreshFinished(const RefreshResult& result)
 {
+    wxLogMessage("GDTF metrics: refresh_ms=%lld parse_ms=%lld ui_parse_ms=%lld filter_ms=%lld render_ms=%lld",
+                 static_cast<long long>(result.refreshMs),
+                 static_cast<long long>(result.parseMs),
+                 static_cast<long long>(lastParseMs),
+                 static_cast<long long>(lastFilterMs),
+                 static_cast<long long>(lastRenderMs));
     if (result.success && !result.listData.empty() && !result.parsedEntries.empty()) {
         currentListData = result.listData;
         lastUpdatedAt = result.updatedAt;
@@ -454,6 +497,13 @@ void GdtfSearchDialog::OnAutoRefreshFinished(const RefreshResult& result)
     UpdateStatusMessage(false,
                         "Showing local catalog (last updated: " +
                             wxString::FromUTF8(lastUpdatedAt) + ")");
+}
+
+void GdtfSearchDialog::MaybeLogVerboseCatalogTrace(const wxString& message) const
+{
+    if (!ui::IsFeatureEnabled(ui::FeatureFlag::GdtfVerboseCatalogLogs))
+        return;
+    wxLogDebug("[GDTF] %s", message);
 }
 
 void GdtfSearchDialog::UpdateStatusMessage(bool refreshing, const wxString& details)

--- a/gui/gdtfsearchdialog.h
+++ b/gui/gdtfsearchdialog.h
@@ -50,6 +50,8 @@ public:
         std::string listData;
         std::string updatedAt;
         std::vector<GdtfEntry> parsedEntries;
+        long long refreshMs = 0;
+        long long parseMs = 0;
     };
     using RefreshCatalogFn = std::function<RefreshResult()>;
 
@@ -77,6 +79,7 @@ private:
     void OnAutoRefreshThreadEvent(wxThreadEvent& evt);
     void OnAutoRefreshFinished(const RefreshResult& result);
     void UpdateStatusMessage(bool refreshing, const wxString& details = {});
+    void MaybeLogVerboseCatalogTrace(const wxString& message) const;
 
     wxTextCtrl* manufacturerCtrl = nullptr;
     wxTextCtrl* fixtureCtrl = nullptr;
@@ -97,4 +100,7 @@ private:
     bool autoRefreshTriggered = false;
     std::thread autoRefreshThread;
     wxTimer searchDebounceTimer;
+    long long lastParseMs = 0;
+    long long lastFilterMs = 0;
+    long long lastRenderMs = 0;
 };

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -59,6 +59,7 @@
 #include "gdtfdictionary.h"
 #include "gdtfloader.h"
 #include "gdtfnet.h"
+#include "gdtf_catalog_cache.h"
 #include "gdtfsearchdialog.h"
 #include "hoist_weight_distribution.h"
 #include "hoisttablepanel.h"
@@ -460,14 +461,24 @@ void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
   wxString cookieFileWx = wxFileName::GetTempDir() + "/gdtf_session.txt";
   std::string cookieFile = WxToUtf8(cookieFileWx);
 
-  const std::string listData = configManager.GetValue("gdtf_fixture_list").value_or("{}");
-  const std::string cachedUpdatedAt =
-      configManager.GetValue("gdtf_fixture_list_last_update").value_or("unknown");
+  const auto cacheLoadStart = std::chrono::steady_clock::now();
+  const std::optional<GdtfCatalogCacheEntry> cachedCatalog =
+      LoadGdtfCatalogCache();
+  const auto cacheLoadElapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::now() - cacheLoadStart)
+                                      .count();
+
+  const std::string listData =
+      cachedCatalog ? cachedCatalog->listData : std::string("{}");
+  const std::string cachedUpdatedAt = cachedCatalog
+                                          ? cachedCatalog->updatedAt
+                                          : std::string("unknown");
 
   std::string effectiveListData = listData;
   std::string effectiveUpdatedAt = cachedUpdatedAt;
 
   {
+    const auto onlineRefreshStart = std::chrono::steady_clock::now();
     std::unique_ptr<wxWindowDisabler> refreshDisabler =
         std::make_unique<wxWindowDisabler>();
     std::unique_ptr<wxBusyInfo> refreshOverlay =
@@ -488,12 +499,25 @@ void MainWindow::OnDownloadGdtf(wxCommandEvent &WXUNUSED(event)) {
           effectiveListData = std::move(onlineListData);
           effectiveUpdatedAt = WxToUtf8(wxDateTime::Now().FormatISOCombined(' '));
           if (effectiveListData != listData) {
-            configManager.SetValue("gdtf_fixture_list", effectiveListData);
-            configManager.SetValue("gdtf_fixture_list_last_update",
-                                   effectiveUpdatedAt);
+            GdtfCatalogCacheEntry cacheEntry;
+            cacheEntry.listData = effectiveListData;
+            cacheEntry.updatedAt = effectiveUpdatedAt;
+            cacheEntry.compressed = false;
+            SaveGdtfCatalogCache(cacheEntry);
           }
         }
       }
+    }
+
+    const auto onlineRefreshElapsedMs =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - onlineRefreshStart)
+            .count();
+    if (consolePanel) {
+      consolePanel->AppendMessage(wxString::Format(
+          "[METRIC] GDTF cache_load_ms=%lld online_refresh_ms=%lld",
+          static_cast<long long>(cacheLoadElapsedMs),
+          static_cast<long long>(onlineRefreshElapsedMs)));
     }
   }
 

--- a/gui/ui_feature_flags.cpp
+++ b/gui/ui_feature_flags.cpp
@@ -39,6 +39,7 @@ bool IsFeatureEnabled(FeatureFlag flag) {
   case FeatureFlag::PrintViewer2DDialog:
   case FeatureFlag::PrintViewer2DElementsDetail:
   case FeatureFlag::AssignSelectedFixtureCategory:
+  case FeatureFlag::GdtfVerboseCatalogLogs:
     return kIsDebugBuild;
   }
 

--- a/gui/ui_feature_flags.h
+++ b/gui/ui_feature_flags.h
@@ -28,6 +28,7 @@ enum class FeatureFlag {
   PrintViewer2DElementsDetail,
   GenerateFixtureSymbols,
   AssignSelectedFixtureCategory,
+  GdtfVerboseCatalogLogs,
 };
 
 bool IsFeatureEnabled(FeatureFlag flag);


### PR DESCRIPTION
### Motivation
- Remove direct persistence of the GDTF fixture list via `LegacyConfigManager().SetValue(...)` and centralize catalog IO into a dedicated cache to keep GUI code cleaner and prepare for future compression support.
- Avoid high-volume parsing/filtering/render logs in release builds so the UI is not penalized by verbose traces.
- Add simple timing metrics (cache load, online refresh, parse, filter, render) to be able to validate performance improvements empirically.

### Description
- Added a small cache module `gui/gdtf_catalog_cache.{h,cpp}` that reads/writes `gdtf_catalog_cache.json` under the user data dir and carries `updated_at` and `compressed` metadata.
- Replaced direct `gdtf_fixture_list` writes in `MainWindow::OnDownloadGdtf` with reads/writes through `LoadGdtfCatalogCache()` / `SaveGdtfCatalogCache()` and emit console metrics `GDTF cache_load_ms` and `online_refresh_ms`.
- Extended `GdtfSearchDialog` to record parse/filter/render timing and auto-refresh timing, to log aggregate metrics, and to cache parsed entries in-memory for faster reuse.
- Added a debug-only UI feature flag `ui::FeatureFlag::GdtfVerboseCatalogLogs` and put high-volume traces (`ParseList`, filtering, visible page rendering) behind that flag; registered the new source file in `gui/CMakeLists.txt`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed and confirms no direct `ConfigManager::Get()` usage was reintroduced.
- Attempted `cmake -S . -B build && cmake --build build -j2` in this environment but configure/build failed due to missing wxWidgets development libraries, so full compilation was not validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4ab53d418832489814db4fc4ed927)