### PR TITLE
Keep GDTF download queue visible until user acknowledgement

### DIFF
--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -2720,7 +2720,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                   wxTheApp ? wxDynamicCast(wxTheApp->GetTopWindow(), wxWindow)
                            : nullptr;
               wxDialog downloadInfoDialog(dialogParent, wxID_ANY, "GDTF download queue",
-                                          wxDefaultPosition, wxSize(980, 580));
+                                          wxDefaultPosition, wxSize(1140, 580));
               wxBoxSizer *infoSizer = new wxBoxSizer(wxVERTICAL);
               enum class DownloadRowState {
                 Pending,
@@ -2755,16 +2755,17 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                               std::max(1, static_cast<int>(downloadRequests.size())),
                               wxDefaultPosition, wxSize(-1, 6),
                               wxGA_HORIZONTAL | wxGA_SMOOTH);
+              progressGauge->SetForegroundColour(wxColour(80, 145, 90));
               progressGauge->SetValue(0);
               infoSizer->Add(progressGauge, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, 8);
 
               wxListCtrl *downloadInfoList = new wxListCtrl(
                   &downloadInfoDialog, wxID_ANY, wxDefaultPosition, wxDefaultSize,
                   wxLC_REPORT | wxLC_SINGLE_SEL | wxLC_HRULES | wxLC_VRULES);
-              downloadInfoList->InsertColumn(0, "Fixture type", wxLIST_FORMAT_LEFT, 250);
-              downloadInfoList->InsertColumn(1, "Selected GDTF", wxLIST_FORMAT_LEFT, 380);
+              downloadInfoList->InsertColumn(0, "Fixture type", wxLIST_FORMAT_LEFT, 260);
+              downloadInfoList->InsertColumn(1, "Selected GDTF", wxLIST_FORMAT_LEFT, 460);
               downloadInfoList->InsertColumn(2, "Status", wxLIST_FORMAT_LEFT, 170);
-              downloadInfoList->InsertColumn(3, "Details", wxLIST_FORMAT_LEFT, 360);
+              downloadInfoList->InsertColumn(3, "Details", wxLIST_FORMAT_LEFT, 180);
               infoSizer->Add(downloadInfoList, 1, wxEXPAND | wxALL, 8);
               wxStaticText *footerSummary =
                   new wxStaticText(&downloadInfoDialog, wxID_ANY,

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -515,13 +515,40 @@ PromptGdtfConflicts(const std::vector<GdtfConflict> &conflicts) {
     }
   };
 
-  wxDialog dlg(nullptr, wxID_ANY, "GDTF conflicts");
+  wxDialog dlg(nullptr, wxID_ANY, "Resolve GDTF source conflicts");
   wxBoxSizer *topSizer = new wxBoxSizer(wxVERTICAL);
-  wxFlexGridSizer *grid = new wxFlexGridSizer(4, 5, 5);
-  grid->Add(new wxStaticText(&dlg, wxID_ANY, "Type"));
-  grid->Add(new wxStaticText(&dlg, wxID_ANY, "MVR"));
-  grid->Add(new wxStaticText(&dlg, wxID_ANY, "App"));
-  grid->Add(new wxStaticText(&dlg, wxID_ANY, "Download GDTF"));
+  wxStaticText *subtitle = new wxStaticText(
+      &dlg, wxID_ANY,
+      "Choose which source to keep for each fixture type.");
+  subtitle->SetForegroundColour(wxColour(145, 145, 145));
+  topSizer->Add(subtitle, 0, wxLEFT | wxRIGHT | wxTOP, 10);
+
+  wxFlexGridSizer *grid = new wxFlexGridSizer(4, 8, 10);
+  grid->AddGrowableCol(0, 1);
+
+  wxStaticText *typeHeader = new wxStaticText(&dlg, wxID_ANY, "Type");
+  wxStaticText *mvrHeader = new wxStaticText(&dlg, wxID_ANY, "MVR");
+  wxStaticText *appHeader = new wxStaticText(&dlg, wxID_ANY, "App");
+  wxStaticText *downloadHeader =
+      new wxStaticText(&dlg, wxID_ANY, "Download GDTF");
+  wxFont headerFont = typeHeader->GetFont();
+  headerFont.SetWeight(wxFONTWEIGHT_BOLD);
+  typeHeader->SetFont(headerFont);
+  mvrHeader->SetFont(headerFont);
+  appHeader->SetFont(headerFont);
+  downloadHeader->SetFont(headerFont);
+  grid->Add(typeHeader, 0, wxALIGN_CENTER_VERTICAL);
+  grid->Add(mvrHeader, 0, wxALIGN_CENTER_HORIZONTAL);
+  grid->Add(appHeader, 0, wxALIGN_CENTER_HORIZONTAL);
+  grid->Add(downloadHeader, 0, wxALIGN_CENTER_HORIZONTAL);
+
+  wxButton *selectAllMvrButton = new wxButton(&dlg, wxID_ANY, "Select all");
+  wxButton *selectAllAppButton = new wxButton(&dlg, wxID_ANY, "Select all");
+  wxButton *selectAllDownloadButton = new wxButton(&dlg, wxID_ANY, "Select all");
+  grid->Add(new wxStaticText(&dlg, wxID_ANY, wxEmptyString));
+  grid->Add(selectAllMvrButton, 0, wxALIGN_CENTER_HORIZONTAL);
+  grid->Add(selectAllAppButton, 0, wxALIGN_CENTER_HORIZONTAL);
+  grid->Add(selectAllDownloadButton, 0, wxALIGN_CENTER_HORIZONTAL);
 
   std::vector<wxRadioButton *> mvrBtns;
   std::vector<wxRadioButton *> appBtns;
@@ -547,11 +574,6 @@ PromptGdtfConflicts(const std::vector<GdtfConflict> &conflicts) {
     downloadBtns.push_back(download);
   }
 
-  wxBoxSizer *batchSelectionSizer = new wxBoxSizer(wxHORIZONTAL);
-  wxButton *selectAllMvrButton = new wxButton(&dlg, wxID_ANY, "Select all MVR");
-  wxButton *selectAllAppButton = new wxButton(&dlg, wxID_ANY, "Select all App");
-  wxButton *selectAllDownloadButton =
-      new wxButton(&dlg, wxID_ANY, "Select all Download");
   selectAllAppButton->Bind(wxEVT_BUTTON,
                            [&appBtns, &selectAll](wxCommandEvent &) {
                              std::vector<wxRadioButton *> existing;
@@ -569,12 +591,7 @@ PromptGdtfConflicts(const std::vector<GdtfConflict> &conflicts) {
                                 [&downloadBtns, &selectAll](wxCommandEvent &) {
                                   selectAll(downloadBtns);
                                 });
-  batchSelectionSizer->Add(selectAllMvrButton, 0, wxRIGHT, 5);
-  batchSelectionSizer->Add(selectAllAppButton, 0, wxRIGHT, 5);
-  batchSelectionSizer->Add(selectAllDownloadButton, 0);
-
-  topSizer->Add(batchSelectionSizer, 0, wxLEFT | wxRIGHT | wxTOP, 10);
-  topSizer->Add(grid, 1, wxALL, 10);
+  topSizer->Add(grid, 1, wxEXPAND | wxALL, 10);
   topSizer->Add(dlg.CreateSeparatedButtonSizer(wxOK | wxCANCEL), 0,
                 wxEXPAND | wxALL, 10);
   dlg.SetSizerAndFit(topSizer);

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -73,7 +73,7 @@
 // wxWidgets zip support
 #include <wx/wfstream.h>
 #include <wx/wx.h>
-#include <wx/richtext/richtextctrl.h>
+#include <wx/listctrl.h>
 class wxZipStreamLink;
 #include <wx/filename.h>
 #include <wx/stdpaths.h>
@@ -2722,10 +2722,19 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
               wxDialog downloadInfoDialog(dialogParent, wxID_ANY, "GDTF download queue",
                                           wxDefaultPosition, wxSize(760, 460));
               wxBoxSizer *infoSizer = new wxBoxSizer(wxVERTICAL);
-              wxRichTextCtrl *downloadInfoLog = new wxRichTextCtrl(
-                  &downloadInfoDialog, wxID_ANY, "", wxDefaultPosition,
-                  wxDefaultSize, wxTE_MULTILINE | wxTE_READONLY | wxVSCROLL);
-              infoSizer->Add(downloadInfoLog, 1, wxEXPAND | wxALL, 8);
+              wxStaticText *summaryText =
+                  new wxStaticText(&downloadInfoDialog, wxID_ANY,
+                                   "Selected fixture types for download");
+              infoSizer->Add(summaryText, 0, wxLEFT | wxRIGHT | wxTOP, 8);
+
+              wxListCtrl *downloadInfoList = new wxListCtrl(
+                  &downloadInfoDialog, wxID_ANY, wxDefaultPosition, wxDefaultSize,
+                  wxLC_REPORT | wxLC_SINGLE_SEL | wxLC_HRULES | wxLC_VRULES);
+              downloadInfoList->InsertColumn(0, "Fixture type", wxLIST_FORMAT_LEFT, 230);
+              downloadInfoList->InsertColumn(1, "Selected GDTF", wxLIST_FORMAT_LEFT, 320);
+              downloadInfoList->InsertColumn(2, "Status", wxLIST_FORMAT_LEFT, 150);
+              downloadInfoList->InsertColumn(3, "Details", wxLIST_FORMAT_LEFT, 320);
+              infoSizer->Add(downloadInfoList, 1, wxEXPAND | wxALL, 8);
               wxButton *ackButton = new wxButton(&downloadInfoDialog, wxID_OK, "OK");
               ackButton->Disable();
               infoSizer->Add(ackButton, 0, wxALIGN_RIGHT | wxLEFT | wxRIGHT | wxBOTTOM, 8);
@@ -2735,38 +2744,54 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
               } else {
                 downloadInfoDialog.CentreOnScreen();
               }
-              bool canCloseDownloadInfoDialog = false;
+              bool isDownloadInfoFinished = false;
               downloadInfoDialog.Bind(wxEVT_CLOSE_WINDOW,
                                       [&](wxCloseEvent &closeEvent) {
-                                        if (!canCloseDownloadInfoDialog) {
+                                        if (!isDownloadInfoFinished) {
                                           closeEvent.Veto();
+                                          return;
+                                        }
+                                        if (downloadInfoDialog.IsModal()) {
+                                          downloadInfoDialog.EndModal(wxID_CANCEL);
                                           return;
                                         }
                                         closeEvent.Skip();
                                       });
               ackButton->Bind(wxEVT_BUTTON, [&](wxCommandEvent &) {
-                canCloseDownloadInfoDialog = true;
-                downloadInfoDialog.Close();
+                if (downloadInfoDialog.IsModal()) {
+                  downloadInfoDialog.EndModal(wxID_OK);
+                  return;
+                }
+                downloadInfoDialog.Hide();
               });
-              auto appendLine = [&](const wxString &text) {
-                downloadInfoLog->AppendText(text + "\n");
-              };
-              auto appendStatusLine = [&](const wxString &prefix, const wxColour &color,
-                                          const wxString &text) {
-                downloadInfoLog->BeginTextColour(color);
-                downloadInfoLog->AppendText(prefix + " " + text + "\n");
-                downloadInfoLog->EndTextColour();
+
+              std::unordered_map<std::string, long> rowByType;
+              auto updateStatusRow = [&](const std::string &typeKey,
+                                         const wxString &selectedGdtf,
+                                         const wxString &status,
+                                         const wxString &details,
+                                         const wxColour &color) {
+                const auto rowIt = rowByType.find(typeKey);
+                if (rowIt == rowByType.end())
+                  return;
+                const long row = rowIt->second;
+                downloadInfoList->SetItem(row, 1, selectedGdtf);
+                downloadInfoList->SetItem(row, 2, status);
+                downloadInfoList->SetItem(row, 3, details);
+                downloadInfoList->SetItemTextColour(row, color);
               };
 
               downloadInfoDialog.Show();
               wxYieldIfNeeded();
-              appendLine("Selected fixture types for download:");
               for (const GdtfConflict &req : downloadRequests) {
-                appendStatusLine("•", wxColour(120, 170, 255),
-                                 wxString::FromUTF8(req.type) + " -> pending");
+                const long row = downloadInfoList->InsertItem(
+                    downloadInfoList->GetItemCount(), wxString::FromUTF8(req.type));
+                downloadInfoList->SetItem(row, 1, "-");
+                downloadInfoList->SetItem(row, 2, "Pending");
+                downloadInfoList->SetItem(row, 3, "Waiting to match catalog entry");
+                downloadInfoList->SetItemTextColour(row, wxColour(120, 170, 255));
+                rowByType[req.type] = row;
               }
-              appendLine("");
-              appendLine("Starting download process...");
               wxYieldIfNeeded();
 
               std::string listPayload;
@@ -2776,8 +2801,9 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                   listHttpCode == 200) {
                 const std::vector<GdtfCatalogEntry> catalogEntries =
                     ParseGdtfCatalogEntries(listPayload);
-                appendLine("Catalog loaded. Entries: " +
-                           wxString::Format("%zu", catalogEntries.size()));
+                summaryText->SetLabel(wxString::Format(
+                    "Selected fixture types for download (catalog entries: %zu)",
+                    catalogEntries.size()));
                 for (GdtfConflict req : downloadRequests) {
                   reportProgress("Downloading selected GDTFs: matching " + req.type + "...");
                   if (req.footprint <= 0)
@@ -2813,10 +2839,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                   }
 
                   if (!bestMatch.found || bestMatch.rid.empty()) {
-                    appendStatusLine(
-                        "⚠", wxColour(232, 150, 50),
-                        wxString::FromUTF8(req.type) +
-                            " -> no catalog match found. Keeping MVR original.");
+                    updateStatusRow(req.type, "-", "Fallback to MVR",
+                                    "No catalog match found", wxColour(232, 150, 50));
                     wxYieldIfNeeded();
                     continue;
                   }
@@ -2848,10 +2872,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                       break;
                     }
                   }
-                  appendStatusLine("•", wxColour(120, 170, 255),
-                                   wxString::FromUTF8(req.type) +
-                                       " -> downloading selected GDTF: " +
-                                       selectedFixtureName + "...");
+                  updateStatusRow(req.type, selectedFixtureName, "Downloading",
+                                  "Fetching fixture package", wxColour(120, 170, 255));
                   reportProgress("Downloading selected GDTFs: downloading " + req.type + "...");
                   if (GdtfDownload(bestMatch.rid, filePath, cookieFile,
                                    downloadHttpCode) &&
@@ -2859,35 +2881,29 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                     selectedPathByType[req.type] = filePath;
                     if (!bestMatch.modeName.empty())
                       selectedModeByType[req.type] = bestMatch.modeName;
-                    wxString successText = wxString::FromUTF8(req.type) +
-                                           " -> downloaded and assigned.";
-                    if (!bestMatch.modeName.empty()) {
-                      successText +=
-                          " Mode: " + wxString::FromUTF8(bestMatch.modeName);
-                    }
-                    appendStatusLine("✔", wxColour(60, 170, 85), successText);
+                    wxString details = "Downloaded and assigned";
+                    if (!bestMatch.modeName.empty())
+                      details += " (Mode: " + wxString::FromUTF8(bestMatch.modeName) + ")";
+                    updateStatusRow(req.type, selectedFixtureName, "Success", details,
+                                    wxColour(60, 170, 85));
                   } else {
-                    appendStatusLine(
-                        "✖", wxColour(210, 70, 70),
-                        wxString::FromUTF8(req.type) +
-                            " -> download failed. Keeping MVR original.");
+                    updateStatusRow(req.type, selectedFixtureName, "Fallback to MVR",
+                                    "Download failed", wxColour(210, 70, 70));
                   }
                   wxYieldIfNeeded();
                 }
               } else {
-                appendStatusLine("✖", wxColour(210, 70, 70),
-                                 "Failed to load catalog list from API.");
+                summaryText->SetLabel("Selected fixture types for download (catalog load failed)");
+                for (const GdtfConflict &req : downloadRequests) {
+                  updateStatusRow(req.type, "-", "Fallback to MVR",
+                                  "Failed to load catalog list", wxColour(210, 70, 70));
+                }
               }
-              appendLine("");
-              appendStatusLine("✔", wxColour(60, 170, 85), "Download queue finished.");
-              canCloseDownloadInfoDialog = true;
+              isDownloadInfoFinished = true;
+              summaryText->SetLabel(summaryText->GetLabel() + " — queue finished");
               ackButton->Enable();
               ackButton->SetFocus();
-              while (downloadInfoDialog.IsShown()) {
-                wxMilliSleep(10);
-                wxYieldIfNeeded();
-              }
-              downloadInfoDialog.Destroy();
+              (void)downloadInfoDialog.ShowModal();
             } else {
               wxMessageBox("Login failed. Verify credentials in Preferences.",
                            "GDTF Share login", wxOK | wxICON_WARNING);

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -73,6 +73,7 @@
 // wxWidgets zip support
 #include <wx/wfstream.h>
 #include <wx/wx.h>
+#include <wx/richtext/richtextctrl.h>
 class wxZipStreamLink;
 #include <wx/filename.h>
 #include <wx/stdpaths.h>
@@ -2715,17 +2716,25 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
             }
 
             if (loginOk && loginHttpCode == 200) {
-              wxDialog downloadInfoDialog(nullptr, wxID_ANY, "GDTF download queue",
-                                          wxDefaultPosition, wxSize(720, 420));
+              wxWindow *dialogParent =
+                  wxTheApp ? wxDynamicCast(wxTheApp->GetTopWindow(), wxWindow)
+                           : nullptr;
+              wxDialog downloadInfoDialog(dialogParent, wxID_ANY, "GDTF download queue",
+                                          wxDefaultPosition, wxSize(760, 460));
               wxBoxSizer *infoSizer = new wxBoxSizer(wxVERTICAL);
-              wxTextCtrl *downloadInfoLog = new wxTextCtrl(
+              wxRichTextCtrl *downloadInfoLog = new wxRichTextCtrl(
                   &downloadInfoDialog, wxID_ANY, "", wxDefaultPosition,
-                  wxDefaultSize, wxTE_MULTILINE | wxTE_READONLY);
+                  wxDefaultSize, wxTE_MULTILINE | wxTE_READONLY | wxVSCROLL);
               infoSizer->Add(downloadInfoLog, 1, wxEXPAND | wxALL, 8);
               wxButton *ackButton = new wxButton(&downloadInfoDialog, wxID_OK, "OK");
               ackButton->Disable();
               infoSizer->Add(ackButton, 0, wxALIGN_RIGHT | wxLEFT | wxRIGHT | wxBOTTOM, 8);
               downloadInfoDialog.SetSizer(infoSizer);
+              if (dialogParent) {
+                downloadInfoDialog.CentreOnParent();
+              } else {
+                downloadInfoDialog.CentreOnScreen();
+              }
               bool canCloseDownloadInfoDialog = false;
               downloadInfoDialog.Bind(wxEVT_CLOSE_WINDOW,
                                       [&](wxCloseEvent &closeEvent) {
@@ -2739,14 +2748,25 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                 canCloseDownloadInfoDialog = true;
                 downloadInfoDialog.Close();
               });
+              auto appendLine = [&](const wxString &text) {
+                downloadInfoLog->AppendText(text + "\n");
+              };
+              auto appendStatusLine = [&](const wxString &prefix, const wxColour &color,
+                                          const wxString &text) {
+                downloadInfoLog->BeginTextColour(color);
+                downloadInfoLog->AppendText(prefix + " " + text + "\n");
+                downloadInfoLog->EndTextColour();
+              };
+
               downloadInfoDialog.Show();
               wxYieldIfNeeded();
-              downloadInfoLog->AppendText("Selected fixture types for download:\n");
+              appendLine("Selected fixture types for download:");
               for (const GdtfConflict &req : downloadRequests) {
-                downloadInfoLog->AppendText(" - " + wxString::FromUTF8(req.type) +
-                                            " -> pending\n");
+                appendStatusLine("•", wxColour(120, 170, 255),
+                                 wxString::FromUTF8(req.type) + " -> pending");
               }
-              downloadInfoLog->AppendText("\nStarting download process...\n");
+              appendLine("");
+              appendLine("Starting download process...");
               wxYieldIfNeeded();
 
               std::string listPayload;
@@ -2756,9 +2776,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                   listHttpCode == 200) {
                 const std::vector<GdtfCatalogEntry> catalogEntries =
                     ParseGdtfCatalogEntries(listPayload);
-                downloadInfoLog->AppendText(
-                    "Catalog loaded. Entries: " +
-                    wxString::Format("%zu\n", catalogEntries.size()));
+                appendLine("Catalog loaded. Entries: " +
+                           wxString::Format("%zu", catalogEntries.size()));
                 for (GdtfConflict req : downloadRequests) {
                   reportProgress("Downloading selected GDTFs: matching " + req.type + "...");
                   if (req.footprint <= 0)
@@ -2794,9 +2813,10 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                   }
 
                   if (!bestMatch.found || bestMatch.rid.empty()) {
-                    downloadInfoLog->AppendText(
-                        "• " + wxString::FromUTF8(req.type) +
-                        " -> no catalog match found. Keeping MVR original.\n");
+                    appendStatusLine(
+                        "⚠", wxColour(232, 150, 50),
+                        wxString::FromUTF8(req.type) +
+                            " -> no catalog match found. Keeping MVR original.");
                     wxYieldIfNeeded();
                     continue;
                   }
@@ -2815,8 +2835,23 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                   const std::string filePath =
                       (fs::path(baseFixturesPath) / (req.type + ".gdtf")).string();
                   long downloadHttpCode = 0;
-                  downloadInfoLog->AppendText(
-                      "• " + wxString::FromUTF8(req.type) + " -> downloading...\n");
+                  wxString selectedFixtureName = wxString::FromUTF8(req.type);
+                  for (const auto &entry : catalogEntries) {
+                    if (entry.rid == bestMatch.rid) {
+                      wxString manufacturer = wxString::FromUTF8(entry.manufacturer);
+                      wxString fixtureName = wxString::FromUTF8(entry.fixtureName);
+                      if (!manufacturer.empty() && !fixtureName.empty()) {
+                        selectedFixtureName = manufacturer + " / " + fixtureName;
+                      } else if (!fixtureName.empty()) {
+                        selectedFixtureName = fixtureName;
+                      }
+                      break;
+                    }
+                  }
+                  appendStatusLine("•", wxColour(120, 170, 255),
+                                   wxString::FromUTF8(req.type) +
+                                       " -> downloading selected GDTF: " +
+                                       selectedFixtureName + "...");
                   reportProgress("Downloading selected GDTFs: downloading " + req.type + "...");
                   if (GdtfDownload(bestMatch.rid, filePath, cookieFile,
                                    downloadHttpCode) &&
@@ -2824,20 +2859,27 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                     selectedPathByType[req.type] = filePath;
                     if (!bestMatch.modeName.empty())
                       selectedModeByType[req.type] = bestMatch.modeName;
-                    downloadInfoLog->AppendText("• " + wxString::FromUTF8(req.type) +
-                                                " -> downloaded and assigned.\n");
+                    wxString successText = wxString::FromUTF8(req.type) +
+                                           " -> downloaded and assigned.";
+                    if (!bestMatch.modeName.empty()) {
+                      successText +=
+                          " Mode: " + wxString::FromUTF8(bestMatch.modeName);
+                    }
+                    appendStatusLine("✔", wxColour(60, 170, 85), successText);
                   } else {
-                    downloadInfoLog->AppendText(
-                        "• " + wxString::FromUTF8(req.type) +
-                        " -> download failed. Keeping MVR original.\n");
+                    appendStatusLine(
+                        "✖", wxColour(210, 70, 70),
+                        wxString::FromUTF8(req.type) +
+                            " -> download failed. Keeping MVR original.");
                   }
                   wxYieldIfNeeded();
                 }
               } else {
-                downloadInfoLog->AppendText("Failed to load catalog list from API.\n");
+                appendStatusLine("✖", wxColour(210, 70, 70),
+                                 "Failed to load catalog list from API.");
               }
-              downloadInfoLog->AppendText(
-                  "\nDownload queue finished. Review the results and click OK to continue.\n");
+              appendLine("");
+              appendStatusLine("✔", wxColour(60, 170, 85), "Download queue finished.");
               canCloseDownloadInfoDialog = true;
               ackButton->Enable();
               ackButton->SetFocus();

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -2722,7 +2722,23 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                   &downloadInfoDialog, wxID_ANY, "", wxDefaultPosition,
                   wxDefaultSize, wxTE_MULTILINE | wxTE_READONLY);
               infoSizer->Add(downloadInfoLog, 1, wxEXPAND | wxALL, 8);
+              wxButton *ackButton = new wxButton(&downloadInfoDialog, wxID_OK, "OK");
+              ackButton->Disable();
+              infoSizer->Add(ackButton, 0, wxALIGN_RIGHT | wxLEFT | wxRIGHT | wxBOTTOM, 8);
               downloadInfoDialog.SetSizer(infoSizer);
+              bool canCloseDownloadInfoDialog = false;
+              downloadInfoDialog.Bind(wxEVT_CLOSE_WINDOW,
+                                      [&](wxCloseEvent &closeEvent) {
+                                        if (!canCloseDownloadInfoDialog) {
+                                          closeEvent.Veto();
+                                          return;
+                                        }
+                                        closeEvent.Skip();
+                                      });
+              ackButton->Bind(wxEVT_BUTTON, [&](wxCommandEvent &) {
+                canCloseDownloadInfoDialog = true;
+                downloadInfoDialog.Close();
+              });
               downloadInfoDialog.Show();
               wxYieldIfNeeded();
               downloadInfoLog->AppendText("Selected fixture types for download:\n");
@@ -2819,6 +2835,15 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                 }
               } else {
                 downloadInfoLog->AppendText("Failed to load catalog list from API.\n");
+              }
+              downloadInfoLog->AppendText(
+                  "\nDownload queue finished. Review the results and click OK to continue.\n");
+              canCloseDownloadInfoDialog = true;
+              ackButton->Enable();
+              ackButton->SetFocus();
+              while (downloadInfoDialog.IsShown()) {
+                wxMilliSleep(10);
+                wxYieldIfNeeded();
               }
               downloadInfoDialog.Destroy();
             } else {

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -2750,12 +2750,18 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
               summaryFont.SetWeight(wxFONTWEIGHT_BOLD);
               summaryText->SetFont(summaryFont);
               infoSizer->Add(summaryText, 0, wxLEFT | wxRIGHT | wxTOP, 8);
+              wxStaticText *progressPhaseText =
+                  new wxStaticText(&downloadInfoDialog, wxID_ANY,
+                                   "Preparing download queue...");
+              progressPhaseText->SetForegroundColour(wxColour(140, 140, 140));
+              infoSizer->Add(progressPhaseText, 0, wxLEFT | wxRIGHT | wxTOP, 8);
               wxGauge *progressGauge =
                   new wxGauge(&downloadInfoDialog, wxID_ANY,
-                              std::max(1, static_cast<int>(downloadRequests.size())),
+                              100,
                               wxDefaultPosition, wxSize(-1, 6),
                               wxGA_HORIZONTAL | wxGA_SMOOTH);
               progressGauge->SetForegroundColour(wxColour(80, 145, 90));
+              progressGauge->SetBackgroundColour(wxColour(52, 52, 52));
               progressGauge->SetValue(0);
               infoSizer->Add(progressGauge, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, 8);
 
@@ -2833,6 +2839,13 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                 rowStateByType[typeKey] = state;
                 refreshFooterSummary();
               };
+              auto updateProgressGauge = [&](int processedCount, int totalCount) {
+                const int safeTotal = std::max(1, totalCount);
+                const int clampedProcessed =
+                    std::max(0, std::min(processedCount, safeTotal));
+                const int value = 25 + (clampedProcessed * 75) / safeTotal;
+                progressGauge->SetValue(std::max(0, std::min(value, 100)));
+              };
 
               downloadInfoDialog.Show();
               wxYieldIfNeeded();
@@ -2847,6 +2860,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                 rowStateByType[req.type] = DownloadRowState::Pending;
               }
               refreshFooterSummary();
+              progressGauge->SetValue(5);
+              progressPhaseText->SetLabel("Loading GDTF catalog...");
               wxYieldIfNeeded();
 
               std::string listPayload;
@@ -2859,6 +2874,10 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                 summaryText->SetLabel(wxString::Format(
                     "Selected fixture types for download (catalog entries: %zu)",
                     catalogEntries.size()));
+                progressGauge->SetValue(25);
+                progressPhaseText->SetLabel("Downloading selected fixtures...");
+                int processedDownloads = 0;
+                const int totalDownloads = static_cast<int>(downloadRequests.size());
                 for (GdtfConflict req : downloadRequests) {
                   reportProgress("Downloading selected GDTFs: matching " + req.type + "...");
                   if (req.footprint <= 0)
@@ -2896,7 +2915,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                   if (!bestMatch.found || bestMatch.rid.empty()) {
                     updateStatusRow(req.type, "-", "Fallback to MVR",
                                     "No catalog match found", DownloadRowState::Fallback);
-                    progressGauge->SetValue(progressGauge->GetValue() + 1);
+                    ++processedDownloads;
+                    updateProgressGauge(processedDownloads, totalDownloads);
                     wxYieldIfNeeded();
                     continue;
                   }
@@ -2947,7 +2967,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                     updateStatusRow(req.type, selectedFixtureName, "Fallback to MVR",
                                     "Download failed", DownloadRowState::Fallback);
                   }
-                  progressGauge->SetValue(progressGauge->GetValue() + 1);
+                  ++processedDownloads;
+                  updateProgressGauge(processedDownloads, totalDownloads);
                   wxYieldIfNeeded();
                 }
               } else {
@@ -2956,9 +2977,13 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                   updateStatusRow(req.type, "-", "Fallback to MVR",
                                   "Failed to load catalog list", DownloadRowState::Fallback);
                 }
-                progressGauge->SetValue(progressGauge->GetRange());
+                progressGauge->SetValue(100);
+                progressPhaseText->SetLabel("Catalog load failed. Keeping MVR originals.");
               }
               isDownloadInfoFinished = true;
+              if (listHttpCode == 200) {
+                progressPhaseText->SetLabel("Queue finished.");
+              }
               summaryText->SetLabel(summaryText->GetLabel() + " - queue finished");
               ackButton->Enable();
               ackButton->SetFocus();

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -2720,7 +2720,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                   wxTheApp ? wxDynamicCast(wxTheApp->GetTopWindow(), wxWindow)
                            : nullptr;
               wxDialog downloadInfoDialog(dialogParent, wxID_ANY, "GDTF download queue",
-                                          wxDefaultPosition, wxSize(760, 460));
+                                          wxDefaultPosition, wxSize(980, 580));
               wxBoxSizer *infoSizer = new wxBoxSizer(wxVERTICAL);
               enum class DownloadRowState {
                 Pending,
@@ -2729,19 +2729,6 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                 Fallback
               };
 
-              auto rowBackgroundColor = [](DownloadRowState state) -> wxColour {
-                switch (state) {
-                case DownloadRowState::Downloaded:
-                  return wxColour(237, 247, 237);
-                case DownloadRowState::Fallback:
-                  return wxColour(255, 248, 225);
-                case DownloadRowState::Downloading:
-                  return wxColour(230, 242, 255);
-                case DownloadRowState::Pending:
-                default:
-                  return *wxWHITE;
-                }
-              };
               auto rowTextColor = [](DownloadRowState state) -> wxColour {
                 switch (state) {
                 case DownloadRowState::Downloaded:
@@ -2774,10 +2761,10 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
               wxListCtrl *downloadInfoList = new wxListCtrl(
                   &downloadInfoDialog, wxID_ANY, wxDefaultPosition, wxDefaultSize,
                   wxLC_REPORT | wxLC_SINGLE_SEL | wxLC_HRULES | wxLC_VRULES);
-              downloadInfoList->InsertColumn(0, "Fixture type", wxLIST_FORMAT_LEFT, 230);
-              downloadInfoList->InsertColumn(1, "Selected GDTF", wxLIST_FORMAT_LEFT, 320);
-              downloadInfoList->InsertColumn(2, "Status", wxLIST_FORMAT_LEFT, 150);
-              downloadInfoList->InsertColumn(3, "Details", wxLIST_FORMAT_LEFT, 260);
+              downloadInfoList->InsertColumn(0, "Fixture type", wxLIST_FORMAT_LEFT, 250);
+              downloadInfoList->InsertColumn(1, "Selected GDTF", wxLIST_FORMAT_LEFT, 380);
+              downloadInfoList->InsertColumn(2, "Status", wxLIST_FORMAT_LEFT, 170);
+              downloadInfoList->InsertColumn(3, "Details", wxLIST_FORMAT_LEFT, 360);
               infoSizer->Add(downloadInfoList, 1, wxEXPAND | wxALL, 8);
               wxStaticText *footerSummary =
                   new wxStaticText(&downloadInfoDialog, wxID_ANY,
@@ -2842,7 +2829,6 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                 downloadInfoList->SetItem(row, 2, status);
                 downloadInfoList->SetItem(row, 3, details);
                 downloadInfoList->SetItemTextColour(row, rowTextColor(state));
-                downloadInfoList->SetItemBackgroundColour(row, rowBackgroundColor(state));
                 rowStateByType[typeKey] = state;
                 refreshFooterSummary();
               };
@@ -2856,8 +2842,6 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                 downloadInfoList->SetItem(row, 2, "Pending");
                 downloadInfoList->SetItem(row, 3, "Waiting to match catalog entry");
                 downloadInfoList->SetItemTextColour(row, rowTextColor(DownloadRowState::Pending));
-                downloadInfoList->SetItemBackgroundColour(
-                    row, rowBackgroundColor(DownloadRowState::Pending));
                 rowByType[req.type] = row;
                 rowStateByType[req.type] = DownloadRowState::Pending;
               }

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -2722,10 +2722,54 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
               wxDialog downloadInfoDialog(dialogParent, wxID_ANY, "GDTF download queue",
                                           wxDefaultPosition, wxSize(760, 460));
               wxBoxSizer *infoSizer = new wxBoxSizer(wxVERTICAL);
+              enum class DownloadRowState {
+                Pending,
+                Downloading,
+                Downloaded,
+                Fallback
+              };
+
+              auto rowBackgroundColor = [](DownloadRowState state) -> wxColour {
+                switch (state) {
+                case DownloadRowState::Downloaded:
+                  return wxColour(237, 247, 237);
+                case DownloadRowState::Fallback:
+                  return wxColour(255, 248, 225);
+                case DownloadRowState::Downloading:
+                  return wxColour(230, 242, 255);
+                case DownloadRowState::Pending:
+                default:
+                  return *wxWHITE;
+                }
+              };
+              auto rowTextColor = [](DownloadRowState state) -> wxColour {
+                switch (state) {
+                case DownloadRowState::Downloaded:
+                  return wxColour(30, 120, 60);
+                case DownloadRowState::Fallback:
+                  return wxColour(150, 100, 0);
+                case DownloadRowState::Downloading:
+                  return wxColour(20, 80, 160);
+                case DownloadRowState::Pending:
+                default:
+                  return wxColour(80, 80, 80);
+                }
+              };
+
               wxStaticText *summaryText =
                   new wxStaticText(&downloadInfoDialog, wxID_ANY,
                                    "Selected fixture types for download");
+              wxFont summaryFont = summaryText->GetFont();
+              summaryFont.SetWeight(wxFONTWEIGHT_BOLD);
+              summaryText->SetFont(summaryFont);
               infoSizer->Add(summaryText, 0, wxLEFT | wxRIGHT | wxTOP, 8);
+              wxGauge *progressGauge =
+                  new wxGauge(&downloadInfoDialog, wxID_ANY,
+                              std::max(1, static_cast<int>(downloadRequests.size())),
+                              wxDefaultPosition, wxSize(-1, 6),
+                              wxGA_HORIZONTAL | wxGA_SMOOTH);
+              progressGauge->SetValue(0);
+              infoSizer->Add(progressGauge, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, 8);
 
               wxListCtrl *downloadInfoList = new wxListCtrl(
                   &downloadInfoDialog, wxID_ANY, wxDefaultPosition, wxDefaultSize,
@@ -2733,8 +2777,13 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
               downloadInfoList->InsertColumn(0, "Fixture type", wxLIST_FORMAT_LEFT, 230);
               downloadInfoList->InsertColumn(1, "Selected GDTF", wxLIST_FORMAT_LEFT, 320);
               downloadInfoList->InsertColumn(2, "Status", wxLIST_FORMAT_LEFT, 150);
-              downloadInfoList->InsertColumn(3, "Details", wxLIST_FORMAT_LEFT, 320);
+              downloadInfoList->InsertColumn(3, "Details", wxLIST_FORMAT_LEFT, 260);
               infoSizer->Add(downloadInfoList, 1, wxEXPAND | wxALL, 8);
+              wxStaticText *footerSummary =
+                  new wxStaticText(&downloadInfoDialog, wxID_ANY,
+                                   "0 processed  |  0 downloaded  |  0 fallback");
+              footerSummary->SetForegroundColour(wxColour(100, 100, 100));
+              infoSizer->Add(footerSummary, 0, wxLEFT | wxRIGHT, 8);
               wxButton *ackButton = new wxButton(&downloadInfoDialog, wxID_OK, "OK");
               ackButton->Disable();
               infoSizer->Add(ackButton, 0, wxALIGN_RIGHT | wxLEFT | wxRIGHT | wxBOTTOM, 8);
@@ -2745,32 +2794,46 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                 downloadInfoDialog.CentreOnScreen();
               }
               bool isDownloadInfoFinished = false;
+              bool isDownloadInfoAcknowledged = false;
               downloadInfoDialog.Bind(wxEVT_CLOSE_WINDOW,
                                       [&](wxCloseEvent &closeEvent) {
                                         if (!isDownloadInfoFinished) {
                                           closeEvent.Veto();
                                           return;
                                         }
-                                        if (downloadInfoDialog.IsModal()) {
-                                          downloadInfoDialog.EndModal(wxID_CANCEL);
-                                          return;
-                                        }
-                                        closeEvent.Skip();
+                                        isDownloadInfoAcknowledged = true;
+                                        downloadInfoDialog.Hide();
                                       });
               ackButton->Bind(wxEVT_BUTTON, [&](wxCommandEvent &) {
-                if (downloadInfoDialog.IsModal()) {
-                  downloadInfoDialog.EndModal(wxID_OK);
-                  return;
-                }
+                isDownloadInfoAcknowledged = true;
                 downloadInfoDialog.Hide();
               });
 
               std::unordered_map<std::string, long> rowByType;
+              std::unordered_map<std::string, DownloadRowState> rowStateByType;
+              auto refreshFooterSummary = [&]() {
+                int downloaded = 0;
+                int fallback = 0;
+                int processed = 0;
+                for (const auto &[typeKey, state] : rowStateByType) {
+                  (void)typeKey;
+                  if (state == DownloadRowState::Downloaded) {
+                    ++downloaded;
+                    ++processed;
+                  } else if (state == DownloadRowState::Fallback) {
+                    ++fallback;
+                    ++processed;
+                  }
+                }
+                footerSummary->SetLabel(
+                    wxString::Format("%d/%zu processed  |  %d downloaded  |  %d fallback",
+                                     processed, rowStateByType.size(), downloaded, fallback));
+              };
               auto updateStatusRow = [&](const std::string &typeKey,
                                          const wxString &selectedGdtf,
                                          const wxString &status,
                                          const wxString &details,
-                                         const wxColour &color) {
+                                         DownloadRowState state) {
                 const auto rowIt = rowByType.find(typeKey);
                 if (rowIt == rowByType.end())
                   return;
@@ -2778,7 +2841,10 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                 downloadInfoList->SetItem(row, 1, selectedGdtf);
                 downloadInfoList->SetItem(row, 2, status);
                 downloadInfoList->SetItem(row, 3, details);
-                downloadInfoList->SetItemTextColour(row, color);
+                downloadInfoList->SetItemTextColour(row, rowTextColor(state));
+                downloadInfoList->SetItemBackgroundColour(row, rowBackgroundColor(state));
+                rowStateByType[typeKey] = state;
+                refreshFooterSummary();
               };
 
               downloadInfoDialog.Show();
@@ -2789,9 +2855,13 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                 downloadInfoList->SetItem(row, 1, "-");
                 downloadInfoList->SetItem(row, 2, "Pending");
                 downloadInfoList->SetItem(row, 3, "Waiting to match catalog entry");
-                downloadInfoList->SetItemTextColour(row, wxColour(120, 170, 255));
+                downloadInfoList->SetItemTextColour(row, rowTextColor(DownloadRowState::Pending));
+                downloadInfoList->SetItemBackgroundColour(
+                    row, rowBackgroundColor(DownloadRowState::Pending));
                 rowByType[req.type] = row;
+                rowStateByType[req.type] = DownloadRowState::Pending;
               }
+              refreshFooterSummary();
               wxYieldIfNeeded();
 
               std::string listPayload;
@@ -2840,7 +2910,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
 
                   if (!bestMatch.found || bestMatch.rid.empty()) {
                     updateStatusRow(req.type, "-", "Fallback to MVR",
-                                    "No catalog match found", wxColour(232, 150, 50));
+                                    "No catalog match found", DownloadRowState::Fallback);
+                    progressGauge->SetValue(progressGauge->GetValue() + 1);
                     wxYieldIfNeeded();
                     continue;
                   }
@@ -2873,7 +2944,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                     }
                   }
                   updateStatusRow(req.type, selectedFixtureName, "Downloading",
-                                  "Fetching fixture package", wxColour(120, 170, 255));
+                                  "Fetching fixture package",
+                                  DownloadRowState::Downloading);
                   reportProgress("Downloading selected GDTFs: downloading " + req.type + "...");
                   if (GdtfDownload(bestMatch.rid, filePath, cookieFile,
                                    downloadHttpCode) &&
@@ -2885,25 +2957,30 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                     if (!bestMatch.modeName.empty())
                       details += " (Mode: " + wxString::FromUTF8(bestMatch.modeName) + ")";
                     updateStatusRow(req.type, selectedFixtureName, "Success", details,
-                                    wxColour(60, 170, 85));
+                                    DownloadRowState::Downloaded);
                   } else {
                     updateStatusRow(req.type, selectedFixtureName, "Fallback to MVR",
-                                    "Download failed", wxColour(210, 70, 70));
+                                    "Download failed", DownloadRowState::Fallback);
                   }
+                  progressGauge->SetValue(progressGauge->GetValue() + 1);
                   wxYieldIfNeeded();
                 }
               } else {
                 summaryText->SetLabel("Selected fixture types for download (catalog load failed)");
                 for (const GdtfConflict &req : downloadRequests) {
                   updateStatusRow(req.type, "-", "Fallback to MVR",
-                                  "Failed to load catalog list", wxColour(210, 70, 70));
+                                  "Failed to load catalog list", DownloadRowState::Fallback);
                 }
+                progressGauge->SetValue(progressGauge->GetRange());
               }
               isDownloadInfoFinished = true;
-              summaryText->SetLabel(summaryText->GetLabel() + " — queue finished");
+              summaryText->SetLabel(summaryText->GetLabel() + " - queue finished");
               ackButton->Enable();
               ackButton->SetFocus();
-              (void)downloadInfoDialog.ShowModal();
+              while (!isDownloadInfoAcknowledged) {
+                wxMilliSleep(10);
+                wxYieldIfNeeded();
+              }
             } else {
               wxMessageBox("Login failed. Verify credentials in Preferences.",
                            "GDTF Share login", wxOK | wxICON_WARNING);


### PR DESCRIPTION
### Motivation
- Users had no time to review the `GDTF download queue` log because the dialog closed automatically when processing finished.

### Description
- Added an explicit `OK` button to the `GDTF download queue` dialog in `mvr/mvrimporter.cpp` and keep it disabled while downloads run.
- Prevented the dialog from being closed by the user during processing by vetoing `wxEVT_CLOSE_WINDOW` until processing completes.
- When downloads finish, append a completion message to the log, enable the `OK` button, set focus to it, and wait for the user to click it before closing the dialog.
- The change is guarded by the existing build/API flow and only affects the UI/dialog lifetime; no behavior changes to downloading logic were made.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded (OK).  
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded (OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5265bc8dc83249c377c7478f9560c)