### PR TITLE
Preserve viewer 3D render style across successful MVR imports

### DIFF
--- a/gui/mainwindow/controllers/mainwindow_io_controller.cpp
+++ b/gui/mainwindow/controllers/mainwindow_io_controller.cpp
@@ -34,12 +34,15 @@
 
 bool MainWindowIoController::ImportMvrFromPath(const std::string &pathUtf8) {
   constexpr const char *kLayoutsConfigKey = "layouts_collection";
+  constexpr const char *kViewer3DRenderStyleConfigKey = "viewer3d_render_style";
   wxWeakRef<MainWindow> ownerRef(&owner_);
   const wxString filePath = wxString::FromUTF8(pathUtf8);
   ConfigManager &cfg =
       owner_.guiConfigServices->LegacyConfigManager();
   const std::optional<std::string> preservedLayoutsConfig =
       cfg.GetValue(kLayoutsConfigKey);
+  const std::optional<std::string> preservedViewer3DRenderStyle =
+      cfg.GetValue(kViewer3DRenderStyleConfigKey);
   auto setImportStatus = [ownerRef](const wxString &message) {
     if (!ownerRef || !ownerRef->GetStatusBar())
       return;
@@ -140,6 +143,8 @@ bool MainWindowIoController::ImportMvrFromPath(const std::string &pathUtf8) {
     cfg.SetValue(kLayoutsConfigKey, *preservedLayoutsConfig);
   else
     cfg.RemoveKey(kLayoutsConfigKey);
+  if (preservedViewer3DRenderStyle.has_value())
+    cfg.SetValue(kViewer3DRenderStyleConfigKey, *preservedViewer3DRenderStyle);
   layouts::LayoutManager::Get().LoadFromConfig(cfg);
 
   if (ownerRef->layoutPanel)


### PR DESCRIPTION
### Motivation
- Importing an MVR performs a `ConfigManager::Reset()` which caused the viewer 3D render style to always fall back to `Standard` even when the import completed successfully, so the user's selected render style should be preserved on success and only fallback on error.

### Description
- Save the current `viewer3d_render_style` from the GUI `ConfigManager` before the import and restore it after a successful import by adding preservation/restoration in `ImportMvrFromPath` (modified file: `gui/mainwindow/controllers/mainwindow_io_controller.cpp`).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5461152c08324a6ffd8b5403281cb)