### PR TITLE
Add predictive autocomplete to Create scene from text dialog

### DIFF
--- a/docs/gui_shortcut_architecture.md
+++ b/docs/gui_shortcut_architecture.md
@@ -113,3 +113,18 @@ represent equivalent actions:
 - `Ctrl + Shift + Left Drag`:
   transversal rectangle selection across all selectable object tables in both
   `Viewer2D` and `Viewer3D`.
+
+## Local shortcuts in "Create scene from text" autocomplete
+
+`RiderTextDialog` adds local key handling only while the autocomplete dropdown
+is visible in the multiline text box:
+
+- `↑` / `↓`: move the active suggestion.
+- `Enter` or `Tab`: accept the selected suggestion and replace the active token.
+- `Esc`: close suggestions without inserting.
+
+Priority and focus impact:
+
+- These keys are consumed only when the dropdown is open.
+- Outside that state, the text box keeps its standard free-text editing behavior.
+- Global shortcut routing is unchanged because the dialog key handling stays local.

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -71,6 +71,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/scene_object_primitive_dialogs.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scene_object_primitive_editing.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ridertextdialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ridertext_autocomplete_provider.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/riggingpanel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sceneobjecttablepanel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/shortcut_registry.cpp

--- a/gui/ridertext_autocomplete_provider.cpp
+++ b/gui/ridertext_autocomplete_provider.cpp
@@ -1,0 +1,290 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2026 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "ridertext_autocomplete_provider.h"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <string_view>
+#include <unordered_set>
+
+#include "gdtfdictionary.h"
+#include "trussdictionary.h"
+
+namespace {
+struct NamedColor {
+  const char *name;
+  const char *hex;
+};
+
+constexpr std::array<const char *, 21> kRiderKeywords = {
+    "rigging", "lx1",   "lx2",    "lx3",      "lx4",    "sides",
+    "floor",   "screen", "backdrop", "truss",   "pipe",   "motor",
+    "for",     "kg",    "m",      "primitive:cube",
+    "primitive:cylinder", "led screen", "apply filter", "hazer", "fan"};
+
+constexpr std::array<NamedColor, 20> kNamedColors = {{
+    {"red", "#FF0000"},
+    {"green", "#00FF00"},
+    {"blue", "#0000FF"},
+    {"amber", "#FFBF00"},
+    {"warm white", "#FFD7A3"},
+    {"cool white", "#F3F8FF"},
+    {"white", "#FFFFFF"},
+    {"cyan", "#00FFFF"},
+    {"magenta", "#FF00FF"},
+    {"yellow", "#FFFF00"},
+    {"orange", "#FF7F00"},
+    {"pink", "#FF69B4"},
+    {"purple", "#8F00FF"},
+    {"lavender", "#C7A3C7"},
+    {"lime", "#BFFF00"},
+    {"indigo", "#4B0082"},
+    {"teal", "#008080"},
+    {"gold", "#FFD700"},
+    {"ctb", "#B8D8FF"},
+    {"cto", "#FFB347"},
+}};
+
+int ComputeSubsequenceGapScore(std::string_view text, std::string_view needle) {
+  if (needle.empty())
+    return 0;
+
+  size_t position = 0;
+  size_t gap = 0;
+  for (const char ch : needle) {
+    const size_t found = text.find(ch, position);
+    if (found == std::string_view::npos)
+      return -1;
+    gap += found - position;
+    position = found + 1;
+  }
+
+  const int penalty = static_cast<int>(std::min<size_t>(gap, 80));
+  return std::max(0, 80 - penalty);
+}
+
+} // namespace
+
+RiderTextAutocompleteProvider::RiderTextAutocompleteProvider() {
+  BuildStaticEntries();
+  RefreshDynamicTerms();
+}
+
+void RiderTextAutocompleteProvider::BuildStaticEntries() {
+  staticEntries.clear();
+
+  for (const char *keyword : kRiderKeywords) {
+    Entry entry;
+    entry.displayText = keyword;
+    entry.insertText = keyword;
+    entry.normalizedToken = ToLower(keyword);
+    entry.kind = SuggestionKind::Keyword;
+    entry.baseScore = 10;
+    staticEntries.push_back(std::move(entry));
+  }
+
+  for (const NamedColor &namedColor : kNamedColors) {
+    Entry byName;
+    byName.displayText = std::string(namedColor.name) + " (" + namedColor.hex + ")";
+    byName.insertText = namedColor.name;
+    byName.normalizedToken = ToLower(namedColor.name);
+    byName.kind = SuggestionKind::ColorName;
+    byName.baseScore = 18;
+    staticEntries.push_back(std::move(byName));
+
+    Entry byHex;
+    byHex.displayText = std::string(namedColor.name) + " " + namedColor.hex;
+    byHex.insertText = namedColor.hex;
+    byHex.normalizedToken = ToLower(namedColor.hex);
+    byHex.kind = SuggestionKind::ColorHex;
+    byHex.baseScore = 16;
+    staticEntries.push_back(std::move(byHex));
+
+    Entry byRgb;
+    const unsigned int r = std::stoul(std::string(namedColor.hex + 1, 2), nullptr, 16);
+    const unsigned int g = std::stoul(std::string(namedColor.hex + 3, 2), nullptr, 16);
+    const unsigned int b = std::stoul(std::string(namedColor.hex + 5, 2), nullptr, 16);
+    byRgb.displayText = std::string("rgb(") + std::to_string(r) + "," +
+                        std::to_string(g) + "," + std::to_string(b) + ")";
+    byRgb.insertText = byRgb.displayText;
+    byRgb.normalizedToken = ToLower(byRgb.insertText);
+    byRgb.kind = SuggestionKind::ColorRgb;
+    byRgb.baseScore = 12;
+    staticEntries.push_back(std::move(byRgb));
+  }
+}
+
+void RiderTextAutocompleteProvider::RefreshDynamicTerms() {
+  dynamicEntries.clear();
+  std::unordered_set<std::string> seen;
+
+  if (const auto gdtf = GdtfDictionary::Load()) {
+    for (const auto &[typeName, entryData] : *gdtf) {
+      (void)entryData;
+      const std::string trimmed = typeName;
+      const std::string normalized = ToLower(trimmed);
+      if (trimmed.empty() || !seen.insert(normalized).second)
+        continue;
+
+      Entry entry;
+      entry.displayText = trimmed;
+      entry.insertText = trimmed;
+      entry.normalizedToken = normalized;
+      entry.kind = SuggestionKind::Dictionary;
+      entry.baseScore = 25;
+      dynamicEntries.push_back(std::move(entry));
+    }
+  }
+
+  if (const auto truss = TrussDictionary::Load()) {
+    for (const auto &[modelName, filePath] : *truss) {
+      (void)filePath;
+      const std::string trimmed = modelName;
+      const std::string normalized = ToLower(trimmed);
+      if (trimmed.empty() || !seen.insert(normalized).second)
+        continue;
+
+      Entry entry;
+      entry.displayText = trimmed;
+      entry.insertText = trimmed;
+      entry.normalizedToken = normalized;
+      entry.kind = SuggestionKind::Dictionary;
+      entry.baseScore = 23;
+      dynamicEntries.push_back(std::move(entry));
+    }
+  }
+}
+
+std::vector<RiderTextAutocompleteProvider::Suggestion>
+RiderTextAutocompleteProvider::Query(const std::string &fullText,
+                                     const size_t cursorByteOffset,
+                                     const size_t maxItems) const {
+  const std::string currentToken =
+      ToLower(ExtractCurrentToken(fullText, cursorByteOffset));
+
+  if (currentToken.empty())
+    return {};
+
+  const bool colorLikeToken =
+      !currentToken.empty() &&
+      (currentToken[0] == '#' || currentToken.rfind("rgb", 0) == 0 ||
+       currentToken.rfind("col", 0) == 0 || currentToken.rfind("red", 0) == 0);
+
+  std::vector<Suggestion> matches;
+  matches.reserve(24);
+
+  auto matchEntry = [&](const Entry &entry) {
+    int score = entry.baseScore;
+    if (entry.normalizedToken == currentToken) {
+      score += 300;
+    } else if (entry.normalizedToken.rfind(currentToken, 0) == 0) {
+      score += 220;
+    } else if (entry.normalizedToken.find(currentToken) != std::string::npos) {
+      score += 130;
+    } else {
+      const int fuzzy = ComputeSubsequenceGapScore(entry.normalizedToken, currentToken);
+      if (fuzzy <= 0)
+        return;
+      score += fuzzy;
+    }
+
+    if (colorLikeToken &&
+        (entry.kind == SuggestionKind::ColorName ||
+         entry.kind == SuggestionKind::ColorHex ||
+         entry.kind == SuggestionKind::ColorRgb)) {
+      score += 90;
+    }
+
+    matches.push_back({entry.displayText, entry.insertText, entry.kind, score});
+  };
+
+  for (const Entry &entry : dynamicEntries)
+    matchEntry(entry);
+  for (const Entry &entry : staticEntries)
+    matchEntry(entry);
+
+  std::sort(matches.begin(), matches.end(), [](const Suggestion &lhs, const Suggestion &rhs) {
+    if (lhs.score != rhs.score)
+      return lhs.score > rhs.score;
+    return lhs.displayText < rhs.displayText;
+  });
+
+  std::vector<Suggestion> unique;
+  unique.reserve(matches.size());
+  std::unordered_set<std::string> emitted;
+  for (const Suggestion &match : matches) {
+    const std::string dedupeKey = ToLower(match.insertText);
+    if (!emitted.insert(dedupeKey).second)
+      continue;
+    unique.push_back(match);
+    if (unique.size() >= maxItems)
+      break;
+  }
+
+  return unique;
+}
+
+std::string RiderTextAutocompleteProvider::ToLower(std::string value) {
+  std::transform(value.begin(), value.end(), value.begin(),
+                 [](const unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return value;
+}
+
+bool RiderTextAutocompleteProvider::IsTokenDelimiter(const char c) {
+  switch (c) {
+  case ' ':
+  case '\t':
+  case '\r':
+  case '\n':
+  case ',':
+  case ';':
+  case '(':
+  case ')':
+  case '[':
+  case ']':
+  case '{':
+  case '}':
+  case ':':
+  case '"':
+    return true;
+  default:
+    return false;
+  }
+}
+
+std::string RiderTextAutocompleteProvider::ExtractCurrentToken(
+    const std::string &text, const size_t cursorByteOffset) {
+  if (text.empty())
+    return {};
+
+  const size_t clampedCursor = std::min(cursorByteOffset, text.size());
+
+  size_t start = clampedCursor;
+  while (start > 0 && !IsTokenDelimiter(text[start - 1]))
+    --start;
+
+  size_t end = clampedCursor;
+  while (end < text.size() && !IsTokenDelimiter(text[end]))
+    ++end;
+
+  if (end <= start)
+    return {};
+
+  return text.substr(start, end - start);
+}

--- a/gui/ridertext_autocomplete_provider.h
+++ b/gui/ridertext_autocomplete_provider.h
@@ -1,0 +1,58 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2026 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+class RiderTextAutocompleteProvider {
+public:
+  enum class SuggestionKind { Keyword, Dictionary, ColorName, ColorHex, ColorRgb };
+
+  struct Suggestion {
+    std::string displayText;
+    std::string insertText;
+    SuggestionKind kind = SuggestionKind::Keyword;
+    int score = 0;
+  };
+
+  RiderTextAutocompleteProvider();
+
+  void RefreshDynamicTerms();
+  std::vector<Suggestion> Query(const std::string &fullText,
+                                size_t cursorByteOffset,
+                                size_t maxItems = 10) const;
+
+private:
+  struct Entry {
+    std::string displayText;
+    std::string insertText;
+    std::string normalizedToken;
+    SuggestionKind kind = SuggestionKind::Keyword;
+    int baseScore = 0;
+  };
+
+  void BuildStaticEntries();
+  static std::string ToLower(std::string value);
+  static bool IsTokenDelimiter(char c);
+  static std::string ExtractCurrentToken(const std::string &text, size_t cursorByteOffset);
+
+  std::vector<Entry> staticEntries;
+  std::vector<Entry> dynamicEntries;
+};

--- a/gui/ridertextdialog.cpp
+++ b/gui/ridertextdialog.cpp
@@ -21,10 +21,12 @@
 #include <wx/filedlg.h>
 #include <wx/filename.h>
 #include <wx/msgdlg.h>
+#include <wx/popupwin.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
 #include <wx/strconv.h>
 #include <wx/textctrl.h>
+#include <wx/listbox.h>
 #include <exception>
 #include <filesystem>
 
@@ -73,6 +75,24 @@ RiderTextDialog::RiderTextDialog(wxWindow *parent,
                             wxTE_MULTILINE | wxTE_RICH2);
   textCtrl->SetMinSize(wxSize(680, 360));
   mainSizer->Add(textCtrl, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 8);
+
+  suggestionPopup = new wxPopupTransientWindow(this, wxBORDER_SIMPLE);
+  wxBoxSizer *popupSizer = new wxBoxSizer(wxVERTICAL);
+  suggestionList = new wxListBox(suggestionPopup, wxID_ANY);
+  popupSizer->Add(suggestionList, 1, wxEXPAND);
+  suggestionPopup->SetSizerAndFit(popupSizer);
+  suggestionPopup->Hide();
+
+  if (textCtrl) {
+    textCtrl->Bind(wxEVT_TEXT, &RiderTextDialog::OnTextChanged, this);
+    textCtrl->Bind(wxEVT_KEY_DOWN, &RiderTextDialog::OnTextKeyDown, this);
+  }
+  if (suggestionList) {
+    suggestionList->Bind(wxEVT_LISTBOX_DCLICK,
+                         &RiderTextDialog::OnSuggestionClick, this);
+  }
+  autocompleteTimer.SetOwner(this);
+  Bind(wxEVT_TIMER, &RiderTextDialog::OnAutocompleteTimer, this);
 
   wxBoxSizer *buttonSizer = new wxBoxSizer(wxHORIZONTAL);
   wxButton *filterButton =
@@ -171,6 +191,7 @@ void RiderTextDialog::OnLoadFromFile(wxCommandEvent &WXUNUSED(event)) {
   if (sourceText)
     sourceText->SetLabel(wxString("Loaded: ") + sourceLabel);
   textCtrl->ChangeValue(loadedText);
+  autocompleteProvider.RefreshDynamicTerms();
 }
 
 void RiderTextDialog::OnLoadExample(wxCommandEvent &WXUNUSED(event)) {
@@ -225,6 +246,7 @@ void RiderTextDialog::OnLoadExample(wxCommandEvent &WXUNUSED(event)) {
   sourceLoadedFromFile = false;
   if (sourceText)
     sourceText->SetLabel(wxString("Loaded: ") + sourceLabel);
+  autocompleteProvider.RefreshDynamicTerms();
 }
 
 void RiderTextDialog::OnApplyFilter(wxCommandEvent &WXUNUSED(event)) {
@@ -251,6 +273,7 @@ void RiderTextDialog::OnApplyFilter(wxCommandEvent &WXUNUSED(event)) {
     return;
   }
   textCtrl->ChangeValue(filteredText);
+  autocompleteProvider.RefreshDynamicTerms();
 }
 
 void RiderTextDialog::OnApply(wxCommandEvent &WXUNUSED(event)) {
@@ -261,4 +284,174 @@ void RiderTextDialog::OnApply(wxCommandEvent &WXUNUSED(event)) {
   }
   selectedRiderTextUtf8 = std::move(text);
   EndModal(wxID_OK);
+}
+
+void RiderTextDialog::OnTextChanged(wxCommandEvent &event) {
+  if (!suppressAutocompleteTextEvent)
+    autocompleteTimer.StartOnce(35);
+  event.Skip();
+}
+
+void RiderTextDialog::OnTextKeyDown(wxKeyEvent &event) {
+  if (IsSuggestionPopupVisible()) {
+    switch (event.GetKeyCode()) {
+    case WXK_UP:
+      if (suggestionList && suggestionList->GetCount() > 0) {
+        const int nextSelection =
+            std::max(0, suggestionList->GetSelection() - 1);
+        suggestionList->SetSelection(nextSelection);
+        return;
+      }
+      break;
+    case WXK_DOWN:
+      if (suggestionList && suggestionList->GetCount() > 0) {
+        const int maxIndex = static_cast<int>(suggestionList->GetCount()) - 1;
+        const int nextSelection =
+            std::min(maxIndex, suggestionList->GetSelection() + 1);
+        suggestionList->SetSelection(nextSelection);
+        return;
+      }
+      break;
+    case WXK_ESCAPE:
+      HideSuggestionPopup();
+      return;
+    case WXK_TAB:
+    case WXK_RETURN:
+    case WXK_NUMPAD_ENTER:
+      if (AcceptCurrentSuggestion())
+        return;
+      break;
+    default:
+      break;
+    }
+  }
+
+  event.Skip();
+}
+
+void RiderTextDialog::OnAutocompleteTimer(wxTimerEvent &WXUNUSED(event)) {
+  RefreshAutocompleteSuggestions();
+}
+
+void RiderTextDialog::OnSuggestionClick(wxCommandEvent &WXUNUSED(event)) {
+  AcceptCurrentSuggestion();
+}
+
+void RiderTextDialog::RefreshAutocompleteSuggestions() {
+  if (!textCtrl || !suggestionPopup || !suggestionList)
+    return;
+
+  autocompleteProvider.RefreshDynamicTerms();
+  const wxString currentText = textCtrl->GetValue();
+  const wxScopedCharBuffer utf8Text = currentText.ToUTF8();
+  const std::string textUtf8 =
+      utf8Text ? std::string(utf8Text.data(), utf8Text.length())
+               : currentText.ToStdString();
+  const long insertionPoint = textCtrl->GetInsertionPoint();
+  const wxString leftText = currentText.Left(insertionPoint);
+  const wxScopedCharBuffer leftUtf8 = leftText.ToUTF8();
+  const std::string leftUtf8Text =
+      leftUtf8 ? std::string(leftUtf8.data(), leftUtf8.length())
+               : leftText.ToStdString();
+
+  currentSuggestions =
+      autocompleteProvider.Query(textUtf8, leftUtf8Text.size(), 10);
+
+  if (currentSuggestions.empty()) {
+    HideSuggestionPopup();
+    return;
+  }
+
+  suggestionList->Clear();
+  for (const RiderTextAutocompleteProvider::Suggestion &suggestion :
+       currentSuggestions) {
+    suggestionList->Append(wxString::FromUTF8(suggestion.displayText));
+  }
+  suggestionList->SetSelection(0);
+
+  wxPoint popupAnchor = textCtrl->ClientToScreen(wxPoint(8, 8));
+  const wxPoint cursorPos = textCtrl->PositionToCoords(insertionPoint);
+  if (cursorPos != wxDefaultPosition) {
+    popupAnchor = textCtrl->ClientToScreen(
+        wxPoint(cursorPos.x, cursorPos.y + textCtrl->GetCharHeight() + 6));
+  }
+
+  const int visibleRows = std::min<int>(6, suggestionList->GetCount());
+  const wxSize popupSize(std::max(280, textCtrl->GetSize().GetWidth() / 2),
+                         std::max(120, visibleRows * (textCtrl->GetCharHeight() + 8)));
+  suggestionPopup->SetSize(popupAnchor.x, popupAnchor.y, popupSize.GetWidth(),
+                           popupSize.GetHeight());
+  suggestionPopup->Popup(textCtrl);
+}
+
+void RiderTextDialog::HideSuggestionPopup() {
+  if (suggestionPopup && suggestionPopup->IsShown())
+    suggestionPopup->Dismiss();
+}
+
+bool RiderTextDialog::AcceptCurrentSuggestion() {
+  if (!suggestionList || !IsSuggestionPopupVisible())
+    return false;
+
+  const int selection = suggestionList->GetSelection();
+  if (selection == wxNOT_FOUND || selection < 0 ||
+      static_cast<size_t>(selection) >= currentSuggestions.size()) {
+    HideSuggestionPopup();
+    return false;
+  }
+
+  ReplaceCurrentToken(currentSuggestions[static_cast<size_t>(selection)].insertText);
+  HideSuggestionPopup();
+  return true;
+}
+
+bool RiderTextDialog::IsSuggestionPopupVisible() const {
+  return suggestionPopup && suggestionPopup->IsShown();
+}
+
+void RiderTextDialog::ReplaceCurrentToken(const std::string &replacement) {
+  if (!textCtrl)
+    return;
+
+  const wxString text = textCtrl->GetValue();
+  long insertionPoint = textCtrl->GetInsertionPoint();
+  insertionPoint = std::max<long>(0, std::min<long>(insertionPoint, text.length()));
+
+  long tokenStart = insertionPoint;
+  while (tokenStart > 0 && !IsTokenDelimiter(text[tokenStart - 1]))
+    --tokenStart;
+
+  long tokenEnd = insertionPoint;
+  while (tokenEnd < static_cast<long>(text.length()) &&
+         !IsTokenDelimiter(text[tokenEnd])) {
+    ++tokenEnd;
+  }
+
+  suppressAutocompleteTextEvent = true;
+  const wxString replacementText = wxString::FromUTF8(replacement);
+  textCtrl->Replace(tokenStart, tokenEnd, replacementText);
+  textCtrl->SetInsertionPoint(tokenStart + replacementText.length());
+  suppressAutocompleteTextEvent = false;
+}
+
+bool RiderTextDialog::IsTokenDelimiter(wxUniChar c) {
+  switch (c.GetValue()) {
+  case ' ':
+  case '\t':
+  case '\r':
+  case '\n':
+  case ',':
+  case ';':
+  case ':':
+  case '(':
+  case ')':
+  case '[':
+  case ']':
+  case '{':
+  case '}':
+  case '"':
+    return true;
+  default:
+    return false;
+  }
 }

--- a/gui/ridertextdialog.h
+++ b/gui/ridertextdialog.h
@@ -18,11 +18,17 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 #include <wx/dialog.h>
+#include <wx/timer.h>
 
 class wxTextCtrl;
 class wxStaticText;
+class wxListBox;
+class wxPopupTransientWindow;
+
+#include "ridertext_autocomplete_provider.h"
 
 class RiderTextDialog : public wxDialog {
 public:
@@ -38,12 +44,28 @@ private:
   void OnLoadExample(wxCommandEvent &event);
   void OnApplyFilter(wxCommandEvent &event);
   void OnApply(wxCommandEvent &event);
+  void OnTextChanged(wxCommandEvent &event);
+  void OnTextKeyDown(wxKeyEvent &event);
+  void OnAutocompleteTimer(wxTimerEvent &event);
+  void OnSuggestionClick(wxCommandEvent &event);
+  void RefreshAutocompleteSuggestions();
+  void HideSuggestionPopup();
+  bool AcceptCurrentSuggestion();
+  bool IsSuggestionPopupVisible() const;
+  void ReplaceCurrentToken(const std::string &replacement);
+  static bool IsTokenDelimiter(wxUniChar c);
 
   wxTextCtrl *textCtrl = nullptr;
   wxStaticText *sourceText = nullptr;
+  wxPopupTransientWindow *suggestionPopup = nullptr;
+  wxListBox *suggestionList = nullptr;
   wxString sourceLabel;
   bool sourceLoadedFromFile = false;
   std::string selectedRiderTextUtf8;
+  RiderTextAutocompleteProvider autocompleteProvider;
+  std::vector<RiderTextAutocompleteProvider::Suggestion> currentSuggestions;
+  wxTimer autocompleteTimer;
+  bool suppressAutocompleteTextEvent = false;
 
   wxDECLARE_EVENT_TABLE();
 };


### PR DESCRIPTION
### Motivation

- Improve authoring speed and accuracy in the "Create scene from text" dialog by offering prefix/contains/fuzzy suggestions and project dictionary terms.
- Provide color suggestions (names, hex, rgb) and integrate suggestions without blocking UI or changing existing free-text behavior.

### Description

- Added a new `RiderTextAutocompleteProvider` that merges static rider keywords with dynamic terms from `GdtfDictionary` and `TrussDictionary`, and produces ranked suggestions (exact > prefix > contains > fuzzy) with deduplication. (`gui/ridertext_autocomplete_provider.{h,cpp}`)
- Implemented color support in the provider with canonical names, `#RRGGBB` entries and `rgb(r,g,b)` forms and a color-context scoring boost. (`ridertext_autocomplete_provider.cpp`)
- Integrated a popup suggestion UI inside `RiderTextDialog` with a transient `wxPopupTransientWindow` + `wxListBox`, debounce timer for fast non-blocking updates, and safe token replacement on accept. (`gui/ridertextdialog.{h,cpp}`)
- Added local keyboard handling while the dropdown is visible (`Up`/`Down`/`Enter`/`Tab`/`Esc`) and ensured the dialog preserves normal free-text editing otherwise. (doc note updated in `docs/gui_shortcut_architecture.md`)
- Registered the new provider source in `gui/CMakeLists.txt`.

### Testing

- Ran `tests/check_perastage_tree_modules.sh` which succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which succeeded.
- Attempted `cmake -S . -B build` to validate project configure but it failed in the current environment due to missing system `wxWidgets` development packages (environment limitation, not a code error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e54a24b618832496a404eee3e75336)