### PR TITLE
Context-aware autocomplete ranking, color chips and color validation for "Create scene from text"

### DIFF
--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -64,6 +64,32 @@ After applying the filter, users can manually adjust the filtered text and then
 press **Create**; the same normalization rules are still applied at creation
 time.
 
+### Autocomplete and color validation behavior in the text dialog
+
+The `Create scene from text` editor includes predictive autocomplete with
+context-aware ranking:
+
+- Ranking priority: exact match > prefix > contains > fuzzy subsequence.
+- Suggestions accepted frequently in the current dialog session are boosted.
+- Context boosts:
+  - color suggestions after `color`, `colour`, `col`, `#...`, `rgb...`
+  - position suggestions after `for`
+  - dictionary fixture type suggestions after quantity tokens.
+
+When users confirm **Create**, the dialog validates explicit color directives
+written as `color ...`, `colour ...`, or `col ...`:
+
+- Accepted formats:
+  - `#RRGGBB`
+  - `rgb(r,g,b)` with `0..255`
+  - supported named colors from autocomplete.
+- Accepted values are normalized to lowercase `#rrggbb` before parsing.
+- Invalid values show a clear line-numbered error and scene creation is
+  cancelled until fixed.
+
+This validation is intentionally scoped to explicit color directives so legacy
+rider text without color directives keeps previous behavior.
+
 ## Input normalization
 
 1. File type:

--- a/gui/ridertext_autocomplete_provider.cpp
+++ b/gui/ridertext_autocomplete_provider.cpp
@@ -20,6 +20,8 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <cmath>
+#include <optional>
 #include <string_view>
 #include <unordered_set>
 
@@ -61,6 +63,9 @@ constexpr std::array<NamedColor, 20> kNamedColors = {{
     {"cto", "#FFB347"},
 }};
 
+constexpr std::array<const char *, 8> kPositionTokens = {
+    "lx1", "lx2", "lx3", "lx4", "sides", "floor", "screen", "backdrop"};
+
 int ComputeSubsequenceGapScore(std::string_view text, std::string_view needle) {
   if (needle.empty())
     return 0;
@@ -77,6 +82,19 @@ int ComputeSubsequenceGapScore(std::string_view text, std::string_view needle) {
 
   const int penalty = static_cast<int>(std::min<size_t>(gap, 80));
   return std::max(0, 80 - penalty);
+}
+
+bool IsPositionToken(const std::string &token) {
+  return std::find(kPositionTokens.begin(), kPositionTokens.end(), token) !=
+         kPositionTokens.end();
+}
+
+bool LooksLikeFixtureCountToken(const std::string &token) {
+  if (token.empty())
+    return false;
+  return std::all_of(token.begin(), token.end(), [](unsigned char c) {
+    return std::isdigit(c) != 0;
+  });
 }
 
 } // namespace
@@ -171,6 +189,24 @@ void RiderTextAutocompleteProvider::RefreshDynamicTerms() {
   }
 }
 
+void RiderTextAutocompleteProvider::RecordSuggestionAccepted(
+    const std::string &insertText) {
+  const std::string key = ToLower(insertText);
+  if (key.empty())
+    return;
+  usageCountByToken[key] += 1;
+}
+
+void RiderTextAutocompleteProvider::SetRankingWeights(
+    const RankingWeights &weights) {
+  rankingWeights = weights;
+}
+
+RiderTextAutocompleteProvider::RankingWeights
+RiderTextAutocompleteProvider::GetRankingWeights() const {
+  return rankingWeights;
+}
+
 std::vector<RiderTextAutocompleteProvider::Suggestion>
 RiderTextAutocompleteProvider::Query(const std::string &fullText,
                                      const size_t cursorByteOffset,
@@ -185,6 +221,8 @@ RiderTextAutocompleteProvider::Query(const std::string &fullText,
       !currentToken.empty() &&
       (currentToken[0] == '#' || currentToken.rfind("rgb", 0) == 0 ||
        currentToken.rfind("col", 0) == 0 || currentToken.rfind("red", 0) == 0);
+  const std::optional<std::string> contextToken =
+      DetectContextToken(fullText, cursorByteOffset);
 
   std::vector<Suggestion> matches;
   matches.reserve(24);
@@ -192,11 +230,11 @@ RiderTextAutocompleteProvider::Query(const std::string &fullText,
   auto matchEntry = [&](const Entry &entry) {
     int score = entry.baseScore;
     if (entry.normalizedToken == currentToken) {
-      score += 300;
+      score += rankingWeights.exactMatchBoost;
     } else if (entry.normalizedToken.rfind(currentToken, 0) == 0) {
-      score += 220;
+      score += rankingWeights.prefixBoost;
     } else if (entry.normalizedToken.find(currentToken) != std::string::npos) {
-      score += 130;
+      score += rankingWeights.containsBoost;
     } else {
       const int fuzzy = ComputeSubsequenceGapScore(entry.normalizedToken, currentToken);
       if (fuzzy <= 0)
@@ -208,10 +246,32 @@ RiderTextAutocompleteProvider::Query(const std::string &fullText,
         (entry.kind == SuggestionKind::ColorName ||
          entry.kind == SuggestionKind::ColorHex ||
          entry.kind == SuggestionKind::ColorRgb)) {
-      score += 90;
+      score += rankingWeights.colorContextBoost;
     }
 
-    matches.push_back({entry.displayText, entry.insertText, entry.kind, score});
+    if (contextToken.has_value()) {
+      if (*contextToken == "for" && IsPositionToken(entry.normalizedToken))
+        score += rankingWeights.positionContextBoost;
+      if (LooksLikeFixtureCountToken(*contextToken) &&
+          entry.kind == SuggestionKind::Dictionary) {
+        score += rankingWeights.fixtureContextBoost;
+      }
+      if ((*contextToken == "color" || *contextToken == "colour" ||
+           *contextToken == "col") &&
+          (entry.kind == SuggestionKind::ColorName ||
+           entry.kind == SuggestionKind::ColorHex ||
+           entry.kind == SuggestionKind::ColorRgb)) {
+        score += rankingWeights.colorContextBoost;
+      }
+    }
+
+    const auto usageIt = usageCountByToken.find(ToLower(entry.insertText));
+    if (usageIt != usageCountByToken.end())
+      score += usageIt->second * rankingWeights.recentUseMultiplier;
+
+    matches.push_back(
+        {entry.displayText, entry.insertText, entry.kind, score,
+         ParseColorHexFromToken(entry).value_or(std::string())});
   };
 
   for (const Entry &entry : dynamicEntries)
@@ -287,4 +347,56 @@ std::string RiderTextAutocompleteProvider::ExtractCurrentToken(
     return {};
 
   return text.substr(start, end - start);
+}
+
+std::optional<std::string>
+RiderTextAutocompleteProvider::ParseColorHexFromToken(const Entry &entry) {
+  if (entry.kind != SuggestionKind::ColorName &&
+      entry.kind != SuggestionKind::ColorHex &&
+      entry.kind != SuggestionKind::ColorRgb) {
+    return std::nullopt;
+  }
+
+  if (entry.kind == SuggestionKind::ColorHex)
+    return entry.insertText;
+
+  const size_t hashPos = entry.displayText.find('#');
+  if (hashPos == std::string::npos)
+    return std::nullopt;
+
+  if (hashPos + 7 > entry.displayText.size())
+    return std::nullopt;
+
+  const std::string hex = entry.displayText.substr(hashPos, 7);
+  if (hex.size() != 7 || hex[0] != '#')
+    return std::nullopt;
+
+  for (size_t i = 1; i < hex.size(); ++i) {
+    if (!std::isxdigit(static_cast<unsigned char>(hex[i])))
+      return std::nullopt;
+  }
+  return ToLower(hex);
+}
+
+std::optional<std::string> RiderTextAutocompleteProvider::DetectContextToken(
+    const std::string &fullText, const size_t cursorByteOffset) {
+  const size_t clampedCursor = std::min(cursorByteOffset, fullText.size());
+  if (clampedCursor == 0)
+    return std::nullopt;
+
+  size_t index = clampedCursor;
+  while (index > 0 && IsTokenDelimiter(fullText[index - 1]))
+    --index;
+
+  if (index == 0)
+    return std::nullopt;
+
+  size_t end = index;
+  while (end > 0 && !IsTokenDelimiter(fullText[end - 1]))
+    --end;
+
+  if (end >= index)
+    return std::nullopt;
+
+  return ToLower(fullText.substr(end, index - end));
 }

--- a/gui/ridertext_autocomplete_provider.h
+++ b/gui/ridertext_autocomplete_provider.h
@@ -18,7 +18,9 @@
 #pragma once
 
 #include <cstddef>
+#include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 class RiderTextAutocompleteProvider {
@@ -30,11 +32,25 @@ public:
     std::string insertText;
     SuggestionKind kind = SuggestionKind::Keyword;
     int score = 0;
+    std::string colorHex;
+  };
+
+  struct RankingWeights {
+    int exactMatchBoost = 300;
+    int prefixBoost = 220;
+    int containsBoost = 130;
+    int colorContextBoost = 90;
+    int positionContextBoost = 80;
+    int fixtureContextBoost = 60;
+    int recentUseMultiplier = 25;
   };
 
   RiderTextAutocompleteProvider();
 
   void RefreshDynamicTerms();
+  void RecordSuggestionAccepted(const std::string &insertText);
+  void SetRankingWeights(const RankingWeights &weights);
+  RankingWeights GetRankingWeights() const;
   std::vector<Suggestion> Query(const std::string &fullText,
                                 size_t cursorByteOffset,
                                 size_t maxItems = 10) const;
@@ -52,7 +68,12 @@ private:
   static std::string ToLower(std::string value);
   static bool IsTokenDelimiter(char c);
   static std::string ExtractCurrentToken(const std::string &text, size_t cursorByteOffset);
+  static std::optional<std::string> ParseColorHexFromToken(const Entry &entry);
+  static std::optional<std::string> DetectContextToken(const std::string &fullText,
+                                                       size_t cursorByteOffset);
 
   std::vector<Entry> staticEntries;
   std::vector<Entry> dynamicEntries;
+  std::unordered_map<std::string, int> usageCountByToken;
+  RankingWeights rankingWeights;
 };

--- a/gui/ridertextdialog.cpp
+++ b/gui/ridertextdialog.cpp
@@ -20,15 +20,23 @@
 #include <wx/button.h>
 #include <wx/filedlg.h>
 #include <wx/filename.h>
+#include <wx/dataview.h>
 #include <wx/msgdlg.h>
 #include <wx/popupwin.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
 #include <wx/strconv.h>
 #include <wx/textctrl.h>
-#include <wx/listbox.h>
+#include <wx/bitmap.h>
+#include <wx/dcmemory.h>
+#include <algorithm>
+#include <cstdio>
 #include <exception>
 #include <filesystem>
+#include <optional>
+#include <regex>
+#include <sstream>
+#include <unordered_map>
 
 #include "projectutils.h"
 #include "consolepanel.h"
@@ -78,7 +86,13 @@ RiderTextDialog::RiderTextDialog(wxWindow *parent,
 
   suggestionPopup = new wxPopupTransientWindow(this, wxBORDER_SIMPLE);
   wxBoxSizer *popupSizer = new wxBoxSizer(wxVERTICAL);
-  suggestionList = new wxListBox(suggestionPopup, wxID_ANY);
+  suggestionList = new wxDataViewListCtrl(
+      suggestionPopup, wxID_ANY, wxDefaultPosition, wxDefaultSize,
+      wxDV_ROW_LINES | wxDV_NO_HEADER);
+  suggestionList->AppendIconTextColumn("Suggestion", wxDATAVIEW_CELL_INERT, 220,
+                                       wxALIGN_LEFT, wxDATAVIEW_COL_RESIZABLE);
+  suggestionList->AppendTextColumn("Value", wxDATAVIEW_CELL_INERT, 120,
+                                   wxALIGN_LEFT, wxDATAVIEW_COL_RESIZABLE);
   popupSizer->Add(suggestionList, 1, wxEXPAND);
   suggestionPopup->SetSizerAndFit(popupSizer);
   suggestionPopup->Hide();
@@ -88,7 +102,7 @@ RiderTextDialog::RiderTextDialog(wxWindow *parent,
     textCtrl->Bind(wxEVT_KEY_DOWN, &RiderTextDialog::OnTextKeyDown, this);
   }
   if (suggestionList) {
-    suggestionList->Bind(wxEVT_LISTBOX_DCLICK,
+    suggestionList->Bind(wxEVT_DATAVIEW_ITEM_ACTIVATED,
                          &RiderTextDialog::OnSuggestionClick, this);
   }
   autocompleteTimer.SetOwner(this);
@@ -282,6 +296,11 @@ void RiderTextDialog::OnApply(wxCommandEvent &WXUNUSED(event)) {
     wxMessageBox("Rider text is empty.", "Error", wxICON_ERROR);
     return;
   }
+  if (!ValidateAndNormalizeText(text)) {
+    wxMessageBox(wxString::FromUTF8(lastValidationError), "Validation error",
+                 wxICON_ERROR | wxOK, this);
+    return;
+  }
   selectedRiderTextUtf8 = std::move(text);
   EndModal(wxID_OK);
 }
@@ -296,19 +315,20 @@ void RiderTextDialog::OnTextKeyDown(wxKeyEvent &event) {
   if (IsSuggestionPopupVisible()) {
     switch (event.GetKeyCode()) {
     case WXK_UP:
-      if (suggestionList && suggestionList->GetCount() > 0) {
-        const int nextSelection =
-            std::max(0, suggestionList->GetSelection() - 1);
-        suggestionList->SetSelection(nextSelection);
+      if (suggestionList && suggestionList->GetItemCount() > 0) {
+        const int nextSelection = std::max(
+            0, static_cast<int>(suggestionList->GetSelectedRow()) - 1);
+        suggestionList->SelectRow(nextSelection);
         return;
       }
       break;
     case WXK_DOWN:
-      if (suggestionList && suggestionList->GetCount() > 0) {
-        const int maxIndex = static_cast<int>(suggestionList->GetCount()) - 1;
+      if (suggestionList && suggestionList->GetItemCount() > 0) {
+        const int maxIndex =
+            static_cast<int>(suggestionList->GetItemCount()) - 1;
         const int nextSelection =
-            std::min(maxIndex, suggestionList->GetSelection() + 1);
-        suggestionList->SetSelection(nextSelection);
+            std::min(maxIndex, static_cast<int>(suggestionList->GetSelectedRow()) + 1);
+        suggestionList->SelectRow(nextSelection);
         return;
       }
       break;
@@ -333,7 +353,7 @@ void RiderTextDialog::OnAutocompleteTimer(wxTimerEvent &WXUNUSED(event)) {
   RefreshAutocompleteSuggestions();
 }
 
-void RiderTextDialog::OnSuggestionClick(wxCommandEvent &WXUNUSED(event)) {
+void RiderTextDialog::OnSuggestionClick(wxDataViewEvent &WXUNUSED(event)) {
   AcceptCurrentSuggestion();
 }
 
@@ -362,12 +382,35 @@ void RiderTextDialog::RefreshAutocompleteSuggestions() {
     return;
   }
 
-  suggestionList->Clear();
+  suggestionList->DeleteAllItems();
   for (const RiderTextAutocompleteProvider::Suggestion &suggestion :
        currentSuggestions) {
-    suggestionList->Append(wxString::FromUTF8(suggestion.displayText));
+    wxVector<wxVariant> row;
+    wxBitmap chip(14, 14);
+    if (!suggestion.colorHex.empty()) {
+      const wxString hex = wxString::FromUTF8(suggestion.colorHex);
+      wxColour fill(hex);
+      if (!fill.IsOk())
+        fill = *wxLIGHT_GREY;
+      const double luminance =
+          0.299 * fill.Red() + 0.587 * fill.Green() + 0.114 * fill.Blue();
+      const wxColour border =
+          luminance < 85.0 ? wxColour(220, 220, 220) : wxColour(60, 60, 60);
+      wxMemoryDC dc(chip);
+      dc.SetBackground(*wxTRANSPARENT_BRUSH);
+      dc.Clear();
+      dc.SetBrush(wxBrush(fill));
+      dc.SetPen(wxPen(border, 1));
+      dc.DrawRectangle(1, 1, 12, 12);
+      dc.SelectObject(wxNullBitmap);
+    }
+
+    row.push_back(wxVariant(wxDataViewIconText(
+        wxString::FromUTF8(suggestion.displayText), chip)));
+    row.push_back(wxVariant(wxString::FromUTF8(suggestion.insertText)));
+    suggestionList->AppendItem(row);
   }
-  suggestionList->SetSelection(0);
+  suggestionList->SelectRow(0);
 
   wxPoint popupAnchor = textCtrl->ClientToScreen(wxPoint(8, 8));
   const wxPoint cursorPos = textCtrl->PositionToCoords(insertionPoint);
@@ -376,7 +419,7 @@ void RiderTextDialog::RefreshAutocompleteSuggestions() {
         wxPoint(cursorPos.x, cursorPos.y + textCtrl->GetCharHeight() + 6));
   }
 
-  const int visibleRows = std::min<int>(6, suggestionList->GetCount());
+  const int visibleRows = std::min<int>(6, static_cast<int>(suggestionList->GetItemCount()));
   const wxSize popupSize(std::max(280, textCtrl->GetSize().GetWidth() / 2),
                          std::max(120, visibleRows * (textCtrl->GetCharHeight() + 8)));
   suggestionPopup->SetSize(popupAnchor.x, popupAnchor.y, popupSize.GetWidth(),
@@ -393,14 +436,17 @@ bool RiderTextDialog::AcceptCurrentSuggestion() {
   if (!suggestionList || !IsSuggestionPopupVisible())
     return false;
 
-  const int selection = suggestionList->GetSelection();
+  const int selection = static_cast<int>(suggestionList->GetSelectedRow());
   if (selection == wxNOT_FOUND || selection < 0 ||
       static_cast<size_t>(selection) >= currentSuggestions.size()) {
     HideSuggestionPopup();
     return false;
   }
 
-  ReplaceCurrentToken(currentSuggestions[static_cast<size_t>(selection)].insertText);
+  const RiderTextAutocompleteProvider::Suggestion &selected =
+      currentSuggestions[static_cast<size_t>(selection)];
+  ReplaceCurrentToken(selected.insertText);
+  autocompleteProvider.RecordSuggestionAccepted(selected.insertText);
   HideSuggestionPopup();
   return true;
 }
@@ -454,4 +500,107 @@ bool RiderTextDialog::IsTokenDelimiter(wxUniChar c) {
   default:
     return false;
   }
+}
+
+bool RiderTextDialog::TryNormalizeColorToken(const std::string &token,
+                                             std::string &normalizedHex) {
+  const auto toLower = [](std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(),
+                   [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    return value;
+  };
+  const auto trim = [](const std::string &value) {
+    const size_t start = value.find_first_not_of(" \t\r\n");
+    if (start == std::string::npos)
+      return std::string();
+    const size_t end = value.find_last_not_of(" \t\r\n");
+    return value.substr(start, end - start + 1);
+  };
+
+  const std::string trimmed = trim(token);
+  if (trimmed.empty())
+    return false;
+
+  static const std::unordered_map<std::string, std::string> kColorAliases = {
+      {"red", "#ff0000"},       {"green", "#00ff00"},    {"blue", "#0000ff"},
+      {"amber", "#ffbf00"},     {"warm white", "#ffd7a3"},{"cool white", "#f3f8ff"},
+      {"white", "#ffffff"},     {"cyan", "#00ffff"},     {"magenta", "#ff00ff"},
+      {"yellow", "#ffff00"},    {"orange", "#ff7f00"},   {"pink", "#ff69b4"},
+      {"purple", "#8f00ff"},    {"lavender", "#c7a3c7"}, {"lime", "#bfff00"},
+      {"indigo", "#4b0082"},    {"teal", "#008080"},     {"gold", "#ffd700"},
+      {"ctb", "#b8d8ff"},       {"cto", "#ffb347"}};
+
+  if (trimmed.size() == 7 && trimmed[0] == '#') {
+    if (std::all_of(trimmed.begin() + 1, trimmed.end(), [](unsigned char c) {
+          return std::isxdigit(c) != 0;
+        })) {
+      normalizedHex = toLower(trimmed);
+      return true;
+    }
+    return false;
+  }
+
+  std::smatch rgbMatch;
+  if (std::regex_match(trimmed, rgbMatch,
+                       std::regex("^rgb\\(\\s*(\\d{1,3})\\s*,\\s*(\\d{1,3})\\s*,\\s*(\\d{1,3})\\s*\\)$",
+                                  std::regex::icase))) {
+    const int r = std::stoi(rgbMatch[1].str());
+    const int g = std::stoi(rgbMatch[2].str());
+    const int b = std::stoi(rgbMatch[3].str());
+    if (r < 0 || r > 255 || g < 0 || g > 255 || b < 0 || b > 255)
+      return false;
+    char hexBuffer[8];
+    std::snprintf(hexBuffer, sizeof(hexBuffer), "#%02x%02x%02x", r, g, b);
+    normalizedHex = hexBuffer;
+    return true;
+  }
+
+  const auto aliasIt = kColorAliases.find(toLower(trimmed));
+  if (aliasIt != kColorAliases.end()) {
+    normalizedHex = aliasIt->second;
+    return true;
+  }
+
+  return false;
+}
+
+bool RiderTextDialog::ValidateAndNormalizeText(std::string &text) {
+  lastValidationError.clear();
+  if (text.empty())
+    return true;
+
+  const std::regex colorDirectiveRe(
+      "\\b(?:colou?r|col)\\s*[:=]?\\s*([^,;\\n]+)", std::regex::icase);
+
+  std::stringstream input(text);
+  std::string line;
+  std::vector<std::string> normalizedLines;
+  int lineNumber = 0;
+  while (std::getline(input, line)) {
+    ++lineNumber;
+    line = std::regex_replace(line, std::regex("\\s+"), " ");
+    std::smatch match;
+    if (std::regex_search(line, match, colorDirectiveRe) && match.size() > 1) {
+      const std::string colorToken = match[1].str();
+      std::string normalizedHex;
+      if (!TryNormalizeColorToken(colorToken, normalizedHex)) {
+        lastValidationError = "Invalid color format on line " +
+                              std::to_string(lineNumber) + ": '" + colorToken +
+                              "'. Use #RRGGBB, rgb(r,g,b), or a supported name.";
+        return false;
+      }
+      const std::string replacement = "color " + normalizedHex;
+      line.replace(static_cast<size_t>(match.position(0)),
+                   static_cast<size_t>(match.length(0)), replacement);
+    }
+    normalizedLines.push_back(line);
+  }
+
+  text.clear();
+  for (size_t i = 0; i < normalizedLines.size(); ++i) {
+    text.append(normalizedLines[i]);
+    if (i + 1 < normalizedLines.size())
+      text.push_back('\n');
+  }
+  return true;
 }

--- a/gui/ridertextdialog.h
+++ b/gui/ridertextdialog.h
@@ -20,13 +20,14 @@
 #include <string>
 #include <vector>
 
+#include <wx/dataview.h>
 #include <wx/dialog.h>
 #include <wx/timer.h>
 
 class wxTextCtrl;
 class wxStaticText;
-class wxListBox;
 class wxPopupTransientWindow;
+class wxDataViewListCtrl;
 
 #include "ridertext_autocomplete_provider.h"
 
@@ -47,18 +48,20 @@ private:
   void OnTextChanged(wxCommandEvent &event);
   void OnTextKeyDown(wxKeyEvent &event);
   void OnAutocompleteTimer(wxTimerEvent &event);
-  void OnSuggestionClick(wxCommandEvent &event);
+  void OnSuggestionClick(wxDataViewEvent &event);
   void RefreshAutocompleteSuggestions();
   void HideSuggestionPopup();
   bool AcceptCurrentSuggestion();
   bool IsSuggestionPopupVisible() const;
   void ReplaceCurrentToken(const std::string &replacement);
+  bool ValidateAndNormalizeText(std::string &text);
+  static bool TryNormalizeColorToken(const std::string &token, std::string &normalizedHex);
   static bool IsTokenDelimiter(wxUniChar c);
 
   wxTextCtrl *textCtrl = nullptr;
   wxStaticText *sourceText = nullptr;
   wxPopupTransientWindow *suggestionPopup = nullptr;
-  wxListBox *suggestionList = nullptr;
+  wxDataViewListCtrl *suggestionList = nullptr;
   wxString sourceLabel;
   bool sourceLoadedFromFile = false;
   std::string selectedRiderTextUtf8;
@@ -66,6 +69,7 @@ private:
   std::vector<RiderTextAutocompleteProvider::Suggestion> currentSuggestions;
   wxTimer autocompleteTimer;
   bool suppressAutocompleteTextEvent = false;
+  std::string lastValidationError;
 
   wxDECLARE_EVENT_TABLE();
 };


### PR DESCRIPTION
### Motivation

- Improve suggestion relevance by implementing contextual ranking signals and configurable weights (Task 3).
- Improve color UX by showing a color preview chip in suggestions and making chips readable on light/dark themes (Task 5).
- Prevent invalid color inputs and normalize accepted color directives before scene creation (Task 6).

### Description

- Enhanced `RiderTextAutocompleteProvider` to add context-aware ranking (exact/prefix/contains/fuzzy), configurable `RankingWeights`, recent-use tracking via `RecordSuggestionAccepted`, and context detection for tokens such as `for`, quantity and color hints; suggestion payloads now include `colorHex` metadata (files changed: `gui/ridertext_autocomplete_provider.h/cpp`).
- Added `ParseColorHexFromToken` and `DetectContextToken` helpers and integrated usage-count boosting into final score computation to surface relevant items first (in `ridertext_autocomplete_provider.cpp`).
- Replaced the popup `wxListBox` with a `wxDataViewListCtrl` in the dialog to render a color chip + textual suggestion/value, added contrast-aware chip borders, preserved keyboard navigation and selection behavior, and wire up acceptance to record usage (files changed: `gui/ridertextdialog.h/cpp`).
- Implemented validation and normalization for explicit color directives (`color`, `colour`, `col`) on Create via `ValidateAndNormalizeText` and `TryNormalizeColorToken`, supporting `#RRGGBB`, `rgb(r,g,b)` and named aliases and normalizing to lowercase `#rrggbb` (in `ridertextdialog.cpp`), while keeping legacy behavior for lines without explicit color directives.
- Updated documentation `docs/text_to_scene_rules.md` to describe autocomplete ranking, context boosts and the scoped color-validation behavior for the text dialog.

### Testing

- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both completed successfully.
- Attempted local configure/build (`cmake -S . -B build && cmake --build build`), which failed due to missing `wxWidgets` dev packages in the environment and not because of code errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e54d013a048324a4b6263725828339)