### PR TITLE
Add contextual and recency-based ranking to Rider autocomplete and update docs

### DIFF
--- a/docs/gui_shortcut_architecture.md
+++ b/docs/gui_shortcut_architecture.md
@@ -123,8 +123,13 @@ is visible in the multiline text box:
 - `Enter` or `Tab`: accept the selected suggestion and replace the active token.
 - `Esc`: close suggestions without inserting.
 
+The dialog also shows this shortcut help inline under the editor so users can
+discover the local autocomplete controls without leaving the workflow.
+
 Priority and focus impact:
 
 - These keys are consumed only when the dropdown is open.
 - Outside that state, the text box keeps its standard free-text editing behavior.
 - Global shortcut routing is unchanged because the dialog key handling stays local.
+- Suggestion ordering uses local relevance ranking (exact/prefix/fuzzy + recent
+  usage + syntax context), but key routing/priority rules above remain unchanged.

--- a/docs/text_to_scene_rules.md
+++ b/docs/text_to_scene_rules.md
@@ -64,6 +64,39 @@ After applying the filter, users can manually adjust the filtered text and then
 press **Create**; the same normalization rules are still applied at creation
 time.
 
+## Autocomplete keywords and ranking in "Create from text"
+
+The multiline editor in **Tools → Create from text** exposes autocomplete to
+speed up rider authoring/editing before import.
+
+Supported built-in keywords currently include:
+
+- Position/section terms: `RIGGING`, `LX1`, `LX2`, `LX3`, `LX4`, `SIDES`,
+  `FLOOR`, `SCREEN`, `BACKDROP`.
+- Rigging/object terms: `TRUSS`, `PIPE`, `MOTOR`, `FOR`, `KG`, `M`,
+  `LED SCREEN`, `PRIMITIVE:CUBE`, `PRIMITIVE:CYLINDER`.
+- Utility terms used by the dialog flow: `APPLY FILTER`, `HAZER`, `FAN`.
+
+Autocomplete also includes dynamic dictionary terms loaded from:
+
+- Fixture dictionary type names (GDTF dictionary entries).
+- Truss dictionary model names.
+
+Ranking order is relevance-based (not alphabetical-only):
+
+1. Exact token match.
+2. Prefix match.
+3. Substring/fuzzy match.
+4. Recent accepted suggestions get a recency boost.
+5. Context boost:
+   - after `FOR`, position labels (`LX*`, `SIDES`, `FLOOR`, `SCREEN`) are
+     prioritized.
+   - after a numeric token (for example `8`), type/model terms are prioritized.
+
+Ranking is configurable through autocomplete ranking weights in code
+(`RiderTextAutocompleteProvider::RankingWeights`), allowing score tuning
+without changing matching logic.
+
 ## Input normalization
 
 1. File type:

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -304,9 +304,9 @@ void MainWindow::CreateToolBars() {
   toolsToolBar->AddTool(ID_Tools_DownloadGdtf, "Download GDTF",
                         loadToolbarIcon("cloud-download", wxART_MISSING_IMAGE),
                         "Download GDTF");
-  toolsToolBar->AddTool(ID_Tools_ImportRiderText, "Create by text",
+  toolsToolBar->AddTool(ID_Tools_ImportRiderText, "Create from text",
                         loadToolbarIcon("notepad-text", wxART_TIP),
-                        "Create by text");
+                        "Create from text");
   toolsToolBar->Realize();
   auiManager->AddPane(
       toolsToolBar, wxAuiPaneInfo()

--- a/gui/ridertext_autocomplete_provider.cpp
+++ b/gui/ridertext_autocomplete_provider.cpp
@@ -33,6 +33,18 @@ constexpr std::array<const char *, 21> kRiderKeywords = {
     "for",     "kg",    "m",      "primitive:cube",
     "primitive:cylinder", "led screen", "apply filter", "hazer", "fan"};
 
+constexpr std::array<const char *, 7> kPositionKeywords = {
+    "lx1", "lx2", "lx3", "lx4", "sides", "floor", "screen"};
+
+constexpr std::array<const char *, 6> kTypeKeywords = {
+    "truss", "pipe", "motor", "primitive:cube", "primitive:cylinder", "led screen"};
+
+template <size_t N>
+bool ArrayContains(const std::array<const char *, N> &items,
+                   const std::string &needle) {
+  return std::find(items.begin(), items.end(), needle) != items.end();
+}
+
 int ComputeSubsequenceGapScore(std::string_view text, std::string_view needle) {
   if (needle.empty())
     return 0;
@@ -62,12 +74,18 @@ void RiderTextAutocompleteProvider::BuildStaticEntries() {
   staticEntries.clear();
 
   for (const char *keyword : kRiderKeywords) {
+    const std::string normalized = ToLower(keyword);
     Entry entry;
     entry.displayText = keyword;
     entry.insertText = keyword;
-    entry.normalizedToken = ToLower(keyword);
+    entry.normalizedToken = normalized;
     entry.kind = SuggestionKind::Keyword;
     entry.baseScore = 10;
+    if (ArrayContains(kPositionKeywords, normalized)) {
+      entry.semantic = EntrySemantic::Position;
+    } else if (ArrayContains(kTypeKeywords, normalized)) {
+      entry.semantic = EntrySemantic::Type;
+    }
     staticEntries.push_back(std::move(entry));
   }
 }
@@ -90,6 +108,7 @@ void RiderTextAutocompleteProvider::RefreshDynamicTerms() {
       entry.normalizedToken = normalized;
       entry.kind = SuggestionKind::Dictionary;
       entry.baseScore = 25;
+      entry.semantic = EntrySemantic::Type;
       dynamicEntries.push_back(std::move(entry));
     }
   }
@@ -108,9 +127,28 @@ void RiderTextAutocompleteProvider::RefreshDynamicTerms() {
       entry.normalizedToken = normalized;
       entry.kind = SuggestionKind::Dictionary;
       entry.baseScore = 23;
+      entry.semantic = EntrySemantic::Type;
       dynamicEntries.push_back(std::move(entry));
     }
   }
+}
+
+void RiderTextAutocompleteProvider::RegisterAcceptedSuggestion(
+    const std::string &insertText) {
+  const std::string normalized = ToLower(insertText);
+  if (normalized.empty())
+    return;
+  ++recentUseTickCounter;
+  recentUseTicksByToken[normalized] = recentUseTickCounter;
+}
+
+void RiderTextAutocompleteProvider::SetRankingWeights(const RankingWeights &newWeights) {
+  weights = newWeights;
+}
+
+const RiderTextAutocompleteProvider::RankingWeights &
+RiderTextAutocompleteProvider::GetRankingWeights() const {
+  return weights;
 }
 
 std::vector<RiderTextAutocompleteProvider::Suggestion>
@@ -119,6 +157,7 @@ RiderTextAutocompleteProvider::Query(const std::string &fullText,
                                      const size_t maxItems) const {
   const std::string currentToken =
       ToLower(ExtractCurrentToken(fullText, cursorByteOffset));
+  const QueryContext context = DetectContext(fullText, cursorByteOffset);
 
   if (currentToken.empty())
     return {};
@@ -129,16 +168,33 @@ RiderTextAutocompleteProvider::Query(const std::string &fullText,
   auto matchEntry = [&](const Entry &entry) {
     int score = entry.baseScore;
     if (entry.normalizedToken == currentToken) {
-      score += 300;
+      score += weights.exactMatch;
     } else if (entry.normalizedToken.rfind(currentToken, 0) == 0) {
-      score += 220;
+      score += weights.prefixMatch;
     } else if (entry.normalizedToken.find(currentToken) != std::string::npos) {
-      score += 130;
+      score += weights.substringMatch;
     } else {
       const int fuzzy = ComputeSubsequenceGapScore(entry.normalizedToken, currentToken);
       if (fuzzy <= 0)
         return;
-      score += fuzzy;
+      score += (fuzzy * std::max(0, weights.fuzzyScale));
+    }
+
+    if (context == QueryContext::ExpectPosition &&
+        entry.semantic == EntrySemantic::Position) {
+      score += weights.contextPositionBoost;
+    } else if (context == QueryContext::ExpectType &&
+               entry.semantic == EntrySemantic::Type) {
+      score += weights.contextTypeBoost;
+    }
+
+    const auto recentIt = recentUseTicksByToken.find(entry.normalizedToken);
+    if (recentIt != recentUseTicksByToken.end()) {
+      const uint64_t age = recentUseTickCounter - recentIt->second;
+      if (age < 1024) {
+        const int decay = static_cast<int>(age / 4);
+        score += std::max(0, weights.recentUseBoost - decay);
+      }
     }
 
     matches.push_back({entry.displayText, entry.insertText, entry.kind, score});
@@ -168,6 +224,68 @@ RiderTextAutocompleteProvider::Query(const std::string &fullText,
   }
 
   return unique;
+}
+
+RiderTextAutocompleteProvider::QueryContext
+RiderTextAutocompleteProvider::DetectContext(const std::string &fullText,
+                                             const size_t cursorByteOffset) {
+  const std::string previousToken = ToLower(ExtractPreviousToken(fullText, cursorByteOffset));
+  if (previousToken == "for")
+    return QueryContext::ExpectPosition;
+  if (IsNumericToken(previousToken))
+    return QueryContext::ExpectType;
+  return QueryContext::Generic;
+}
+
+std::string RiderTextAutocompleteProvider::ExtractPreviousToken(
+    const std::string &text, const size_t cursorByteOffset) {
+  if (text.empty() || cursorByteOffset == 0)
+    return {};
+
+  const size_t clampedCursor = std::min(cursorByteOffset, text.size());
+  size_t pos = clampedCursor;
+  while (pos > 0 && IsTokenDelimiter(text[pos - 1]))
+    --pos;
+  if (pos == 0)
+    return {};
+
+  size_t tokenStart = pos;
+  while (tokenStart > 0 && !IsTokenDelimiter(text[tokenStart - 1]))
+    --tokenStart;
+
+  const std::string currentToken = ExtractCurrentToken(text, clampedCursor);
+  if (tokenStart < clampedCursor && !currentToken.empty()) {
+    const std::string candidate = text.substr(tokenStart, pos - tokenStart);
+    if (candidate == currentToken) {
+      size_t previousEnd = tokenStart;
+      while (previousEnd > 0 && IsTokenDelimiter(text[previousEnd - 1]))
+        --previousEnd;
+      if (previousEnd == 0)
+        return {};
+      size_t previousStart = previousEnd;
+      while (previousStart > 0 && !IsTokenDelimiter(text[previousStart - 1]))
+        --previousStart;
+      return text.substr(previousStart, previousEnd - previousStart);
+    }
+  }
+
+  return text.substr(tokenStart, pos - tokenStart);
+}
+
+bool RiderTextAutocompleteProvider::IsNumericToken(const std::string &token) {
+  if (token.empty())
+    return false;
+  bool sawDigit = false;
+  for (const unsigned char ch : token) {
+    if (std::isdigit(ch) != 0) {
+      sawDigit = true;
+      continue;
+    }
+    if (ch == '.' || ch == ',')
+      continue;
+    return false;
+  }
+  return sawDigit;
 }
 
 std::string RiderTextAutocompleteProvider::ToLower(std::string value) {

--- a/gui/ridertext_autocomplete_provider.h
+++ b/gui/ridertext_autocomplete_provider.h
@@ -18,12 +18,24 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 class RiderTextAutocompleteProvider {
 public:
   enum class SuggestionKind { Keyword, Dictionary };
+
+  struct RankingWeights {
+    int exactMatch = 300;
+    int prefixMatch = 220;
+    int substringMatch = 130;
+    int fuzzyScale = 1;
+    int recentUseBoost = 36;
+    int contextPositionBoost = 95;
+    int contextTypeBoost = 70;
+  };
 
   struct Suggestion {
     std::string displayText;
@@ -35,24 +47,37 @@ public:
   RiderTextAutocompleteProvider();
 
   void RefreshDynamicTerms();
+  void RegisterAcceptedSuggestion(const std::string &insertText);
+  void SetRankingWeights(const RankingWeights &weights);
+  const RankingWeights &GetRankingWeights() const;
   std::vector<Suggestion> Query(const std::string &fullText,
                                 size_t cursorByteOffset,
                                 size_t maxItems = 10) const;
 
 private:
+  enum class EntrySemantic { Generic, Position, Type };
+  enum class QueryContext { Generic, ExpectPosition, ExpectType };
+
   struct Entry {
     std::string displayText;
     std::string insertText;
     std::string normalizedToken;
     SuggestionKind kind = SuggestionKind::Keyword;
     int baseScore = 0;
+    EntrySemantic semantic = EntrySemantic::Generic;
   };
 
   void BuildStaticEntries();
+  static QueryContext DetectContext(const std::string &fullText, size_t cursorByteOffset);
+  static std::string ExtractPreviousToken(const std::string &text, size_t cursorByteOffset);
+  static bool IsNumericToken(const std::string &token);
   static std::string ToLower(std::string value);
   static bool IsTokenDelimiter(char c);
   static std::string ExtractCurrentToken(const std::string &text, size_t cursorByteOffset);
 
   std::vector<Entry> staticEntries;
   std::vector<Entry> dynamicEntries;
+  RankingWeights weights;
+  std::unordered_map<std::string, uint64_t> recentUseTicksByToken;
+  uint64_t recentUseTickCounter = 0;
 };

--- a/gui/ridertextdialog.cpp
+++ b/gui/ridertextdialog.cpp
@@ -24,9 +24,12 @@
 #include <wx/popupwin.h>
 #include <wx/sizer.h>
 #include <wx/stattext.h>
+#include <wx/statline.h>
 #include <wx/strconv.h>
 #include <wx/textctrl.h>
 #include <wx/listbox.h>
+#include <wx/settings.h>
+#include <wx/font.h>
 #include <exception>
 #include <filesystem>
 
@@ -55,32 +58,55 @@ RiderTextDialog::RiderTextDialog(wxWindow *parent,
                wxDefaultPosition, wxSize(720, 520),
                wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
       sourceLabel(initialSource) {
+  SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW));
+
   wxBoxSizer *mainSizer = new wxBoxSizer(wxVERTICAL);
 
-  wxBoxSizer *headerSizer = new wxBoxSizer(wxHORIZONTAL);
+  wxStaticText *titleText = new wxStaticText(this, wxID_ANY, "Create scene from text");
+  wxFont titleFont = titleText->GetFont();
+  titleFont.MakeBold();
+  titleFont.SetPointSize(titleFont.GetPointSize() + 2);
+  titleText->SetFont(titleFont);
+  mainSizer->Add(titleText, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, 12);
+
+  wxStaticText *subtitleText = new wxStaticText(
+      this, wxID_ANY,
+      "Paste rider content or load a .txt/.pdf file, then refine before creating the scene.");
+  subtitleText->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
+  mainSizer->Add(subtitleText, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, 6);
+  mainSizer->Add(new wxStaticLine(this, wxID_ANY), 0,
+                 wxEXPAND | wxLEFT | wxRIGHT | wxTOP, 10);
+
+  wxStaticBoxSizer *sourceSizer =
+      new wxStaticBoxSizer(wxHORIZONTAL, this, "Source");
   const wxString sourceTextLabel =
       sourceLabel.empty() ? wxString("No source loaded.")
                           : wxString("Loaded: ") + sourceLabel;
-  sourceText = new wxStaticText(this, wxID_ANY, sourceTextLabel);
-  headerSizer->Add(sourceText, 1, wxALIGN_CENTER_VERTICAL | wxRIGHT, 8);
+  sourceText = new wxStaticText(sourceSizer->GetStaticBox(), wxID_ANY, sourceTextLabel);
+  sourceSizer->Add(sourceText, 1, wxALIGN_CENTER_VERTICAL | wxRIGHT, 8);
   wxButton *loadButton = new wxButton(this, ID_RiderText_Load, "Load rider...");
-  headerSizer->Add(loadButton, 0);
+  sourceSizer->Add(loadButton, 0);
   wxButton *exampleButton =
       new wxButton(this, ID_RiderText_Example, "Use example");
-  headerSizer->Add(exampleButton, 0, wxLEFT, 8);
-  mainSizer->Add(headerSizer, 0, wxEXPAND | wxALL, 8);
+  sourceSizer->Add(exampleButton, 0, wxLEFT, 8);
+  mainSizer->Add(sourceSizer, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, 10);
 
-  textCtrl = new wxTextCtrl(this, wxID_ANY, initialText,
+  wxStaticBoxSizer *editorSizer =
+      new wxStaticBoxSizer(wxVERTICAL, this, "Rider text");
+  textCtrl = new wxTextCtrl(editorSizer->GetStaticBox(), wxID_ANY, initialText,
                             wxDefaultPosition, wxDefaultSize,
                             wxTE_MULTILINE | wxTE_RICH2);
   textCtrl->SetMinSize(wxSize(680, 360));
-  mainSizer->Add(textCtrl, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 8);
+  editorSizer->Add(textCtrl, 1, wxEXPAND | wxALL, 8);
 
   wxStaticText *autocompleteHelp = new wxStaticText(
-      this, wxID_ANY,
-      "Autocomplete: ↑/↓ move, Enter/Tab accept, Esc close. "
+      editorSizer->GetStaticBox(), wxID_ANY,
+      "Autocomplete: Up/Down move, Enter/Tab accept, Esc closes suggestions. "
       "Ranking: exact > prefix > fuzzy + recent use + context.");
-  mainSizer->Add(autocompleteHelp, 0, wxLEFT | wxRIGHT | wxBOTTOM, 8);
+  autocompleteHelp->SetForegroundColour(
+      wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
+  editorSizer->Add(autocompleteHelp, 0, wxLEFT | wxRIGHT | wxBOTTOM, 8);
+  mainSizer->Add(editorSizer, 1, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, 10);
 
   suggestionPopup = new wxPopupTransientWindow(this, wxBORDER_SIMPLE);
   wxBoxSizer *popupSizer = new wxBoxSizer(wxVERTICAL);
@@ -99,6 +125,7 @@ RiderTextDialog::RiderTextDialog(wxWindow *parent,
   }
   autocompleteTimer.SetOwner(this);
   Bind(wxEVT_TIMER, &RiderTextDialog::OnAutocompleteTimer, this);
+  Bind(wxEVT_CHAR_HOOK, &RiderTextDialog::OnDialogCharHook, this);
 
   wxBoxSizer *buttonSizer = new wxBoxSizer(wxHORIZONTAL);
   wxButton *filterButton =
@@ -109,9 +136,10 @@ RiderTextDialog::RiderTextDialog(wxWindow *parent,
   buttonSizer->Add(filterButton, 0, wxRIGHT, 8);
   buttonSizer->Add(applyButton, 0, wxRIGHT, 8);
   buttonSizer->Add(cancelButton, 0);
-  mainSizer->Add(buttonSizer, 0, wxEXPAND | wxALL, 8);
+  mainSizer->Add(buttonSizer, 0, wxEXPAND | wxALL, 10);
 
   SetSizer(mainSizer);
+  SetMinSize(wxSize(720, 520));
   Layout();
   Centre();
 }
@@ -341,6 +369,14 @@ void RiderTextDialog::OnAutocompleteTimer(wxTimerEvent &WXUNUSED(event)) {
 
 void RiderTextDialog::OnSuggestionClick(wxCommandEvent &WXUNUSED(event)) {
   AcceptCurrentSuggestion();
+}
+
+void RiderTextDialog::OnDialogCharHook(wxKeyEvent &event) {
+  if (event.GetKeyCode() == WXK_ESCAPE && IsSuggestionPopupVisible()) {
+    HideSuggestionPopup();
+    return;
+  }
+  event.Skip();
 }
 
 void RiderTextDialog::RefreshAutocompleteSuggestions() {

--- a/gui/ridertextdialog.cpp
+++ b/gui/ridertextdialog.cpp
@@ -76,6 +76,12 @@ RiderTextDialog::RiderTextDialog(wxWindow *parent,
   textCtrl->SetMinSize(wxSize(680, 360));
   mainSizer->Add(textCtrl, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 8);
 
+  wxStaticText *autocompleteHelp = new wxStaticText(
+      this, wxID_ANY,
+      "Autocomplete: ↑/↓ move, Enter/Tab accept, Esc close. "
+      "Ranking: exact > prefix > fuzzy + recent use + context.");
+  mainSizer->Add(autocompleteHelp, 0, wxLEFT | wxRIGHT | wxBOTTOM, 8);
+
   suggestionPopup = new wxPopupTransientWindow(this, wxBORDER_SIMPLE);
   wxBoxSizer *popupSizer = new wxBoxSizer(wxVERTICAL);
   suggestionList = new wxListBox(suggestionPopup, wxID_ANY);
@@ -401,6 +407,8 @@ bool RiderTextDialog::AcceptCurrentSuggestion() {
   }
 
   ReplaceCurrentToken(currentSuggestions[static_cast<size_t>(selection)].insertText);
+  autocompleteProvider.RegisterAcceptedSuggestion(
+      currentSuggestions[static_cast<size_t>(selection)].insertText);
   HideSuggestionPopup();
   return true;
 }

--- a/gui/ridertextdialog.cpp
+++ b/gui/ridertextdialog.cpp
@@ -58,6 +58,7 @@ RiderTextDialog::RiderTextDialog(wxWindow *parent,
                wxDefaultPosition, wxSize(900, 700),
                wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
       sourceLabel(initialSource) {
+  SetTitle("Create from text");
   SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW));
 
   wxBoxSizer *mainSizer = new wxBoxSizer(wxVERTICAL);

--- a/gui/ridertextdialog.cpp
+++ b/gui/ridertextdialog.cpp
@@ -55,7 +55,7 @@ RiderTextDialog::RiderTextDialog(wxWindow *parent,
                                  const wxString &initialText,
                                  const wxString &initialSource)
     : wxDialog(parent, wxID_ANY, "Create scene from text",
-               wxDefaultPosition, wxSize(720, 520),
+               wxDefaultPosition, wxSize(900, 700),
                wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
       sourceLabel(initialSource) {
   SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW));
@@ -84,10 +84,11 @@ RiderTextDialog::RiderTextDialog(wxWindow *parent,
                           : wxString("Loaded: ") + sourceLabel;
   sourceText = new wxStaticText(sourceSizer->GetStaticBox(), wxID_ANY, sourceTextLabel);
   sourceSizer->Add(sourceText, 1, wxALIGN_CENTER_VERTICAL | wxRIGHT, 8);
-  wxButton *loadButton = new wxButton(this, ID_RiderText_Load, "Load rider...");
+  wxButton *loadButton =
+      new wxButton(sourceSizer->GetStaticBox(), ID_RiderText_Load, "Load rider...");
   sourceSizer->Add(loadButton, 0);
   wxButton *exampleButton =
-      new wxButton(this, ID_RiderText_Example, "Use example");
+      new wxButton(sourceSizer->GetStaticBox(), ID_RiderText_Example, "Use example");
   sourceSizer->Add(exampleButton, 0, wxLEFT, 8);
   mainSizer->Add(sourceSizer, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, 10);
 
@@ -105,6 +106,7 @@ RiderTextDialog::RiderTextDialog(wxWindow *parent,
       "Ranking: exact > prefix > fuzzy + recent use + context.");
   autocompleteHelp->SetForegroundColour(
       wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
+  autocompleteHelp->Wrap(820);
   editorSizer->Add(autocompleteHelp, 0, wxLEFT | wxRIGHT | wxBOTTOM, 8);
   mainSizer->Add(editorSizer, 1, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, 10);
 
@@ -139,9 +141,9 @@ RiderTextDialog::RiderTextDialog(wxWindow *parent,
   mainSizer->Add(buttonSizer, 0, wxEXPAND | wxALL, 10);
 
   SetSizer(mainSizer);
-  SetMinSize(wxSize(720, 520));
+  SetMinSize(wxSize(900, 700));
   Layout();
-  Centre();
+  CentreOnScreen();
 }
 
 const std::string &RiderTextDialog::GetRiderTextUtf8() const {

--- a/gui/ridertextdialog.h
+++ b/gui/ridertextdialog.h
@@ -48,6 +48,7 @@ private:
   void OnTextKeyDown(wxKeyEvent &event);
   void OnAutocompleteTimer(wxTimerEvent &event);
   void OnSuggestionClick(wxCommandEvent &event);
+  void OnDialogCharHook(wxKeyEvent &event);
   void RefreshAutocompleteSuggestions();
   void HideSuggestionPopup();
   bool AcceptCurrentSuggestion();


### PR DESCRIPTION
### Motivation
- Improve Rider "Create from text" autocomplete ordering from alphabetic to relevance-based so expected terms surface higher (exact > prefix > fuzzy). 
- Factor in recent usage and syntactic context (position vs. type) to make suggestions more useful during interactive editing. 
- Expose tunable ranking weights and document the behavior so the ordering can be adjusted without changing matching logic.

### Description
- Added configurable scoring via `RiderTextAutocompleteProvider::RankingWeights` and applied those weights to exact, prefix, substring/fuzzy, and context boosts in `gui/ridertext_autocomplete_provider.{h,cpp}`. 
- Implemented recent-use learning (`RegisterAcceptedSuggestion`) with a simple tick counter and decay-based boost so accepted suggestions rank higher shortly afterwards. 
- Added lightweight syntax detection to prefer position keywords after `for` and type/model keywords after numeric tokens, and annotated static/dynamic entries with semantic tags (Position/Type). 
- Integrated UI/help changes and docs updates by adding inline shortcut/help text in `gui/ridertextdialog.cpp` and documenting supported keywords, ranking rules and shortcut behavior in `docs/text_to_scene_rules.md` and `docs/gui_shortcut_architecture.md`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded. 
- Attempted a CMake configure (`cmake --preset wsl-x64-debug`) which failed in the local environment due to missing `wxWidgets` development packages, not due to the change itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e551258b5c8324b20438d94945b0dc)