### PR TITLE
Refine GDTF catalog matching to prioritize name and footprint

### DIFF
--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -708,11 +708,22 @@ static int ComputeFixtureNameMatchScore(const std::string &catalogFixtureName,
     return 9000;
   }
 
+  const auto hasContainsMatch = [](const std::string &lhs,
+                                   const std::string &rhs) -> bool {
+    if (lhs.empty() || rhs.empty())
+      return false;
+    return (lhs.size() >= 4 && rhs.find(lhs) != std::string::npos) ||
+           (rhs.size() >= 4 && lhs.find(rhs) != std::string::npos);
+  };
+
   const bool containsMatch =
       (catalogNormalized.size() >= 5 &&
        requestedNormalized.find(catalogNormalized) != std::string::npos) ||
       (requestedNormalized.size() >= 5 &&
-       catalogNormalized.find(requestedNormalized) != std::string::npos);
+       catalogNormalized.find(requestedNormalized) != std::string::npos) ||
+      hasContainsMatch(catalogNoParentheses, requestedNoParentheses) ||
+      hasContainsMatch(catalogNormalized, requestedNoParentheses) ||
+      hasContainsMatch(catalogNoParentheses, requestedNormalized);
   if (!containsMatch)
     return 0;
 

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -56,6 +56,7 @@
 #include <functional>
 #include <iomanip>
 #include <iostream>
+#include <limits>
 #include <optional>
 #include <random>
 #include <set>
@@ -636,6 +637,7 @@ struct GdtfDownloadMatch {
   bool found = false;
   std::string rid;
   std::string modeName;
+  std::string selectionReason;
 };
 
 static std::string NormalizeForGdtfMatch(const std::string &text) {
@@ -685,17 +687,17 @@ static std::string StripParenthesizedSections(const std::string &text) {
   return Trim(stripped);
 }
 
-static bool IsLikelyFixtureNameMatch(const std::string &catalogFixtureName,
-                                     const std::string &requestedFixtureName) {
+static int ComputeFixtureNameMatchScore(const std::string &catalogFixtureName,
+                                        const std::string &requestedFixtureName) {
   const std::string catalogNormalized =
       NormalizeForGdtfMatch(catalogFixtureName);
   const std::string requestedNormalized =
       NormalizeForGdtfMatch(requestedFixtureName);
 
   if (catalogNormalized.empty() || requestedNormalized.empty())
-    return false;
+    return 0;
   if (catalogNormalized == requestedNormalized)
-    return true;
+    return 10000;
 
   const std::string catalogNoParentheses =
       NormalizeForGdtfMatch(StripParenthesizedSections(catalogFixtureName));
@@ -703,7 +705,7 @@ static bool IsLikelyFixtureNameMatch(const std::string &catalogFixtureName,
       NormalizeForGdtfMatch(StripParenthesizedSections(requestedFixtureName));
   if (!catalogNoParentheses.empty() && !requestedNoParentheses.empty() &&
       catalogNoParentheses == requestedNoParentheses) {
-    return true;
+    return 9000;
   }
 
   const bool containsMatch =
@@ -712,16 +714,16 @@ static bool IsLikelyFixtureNameMatch(const std::string &catalogFixtureName,
       (requestedNormalized.size() >= 5 &&
        catalogNormalized.find(requestedNormalized) != std::string::npos);
   if (!containsMatch)
-    return false;
+    return 0;
 
   const std::string catalogDigits = ExtractDigitSignature(catalogNormalized);
   const std::string requestedDigits = ExtractDigitSignature(requestedNormalized);
   if (!catalogDigits.empty() && !requestedDigits.empty() &&
       catalogDigits != requestedDigits) {
-    return false;
+    return 0;
   }
 
-  return true;
+  return 8000;
 }
 
 static std::vector<GdtfCatalogEntry>
@@ -3032,33 +3034,74 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                   if (req.footprint <= 0)
                     req.footprint = inferFootprintFromAddresses(req.type);
                   GdtfDownloadMatch bestMatch;
-                  double bestScore = -1.0;
+                  int bestPrimaryScore = std::numeric_limits<int>::min();
+                  long long bestRecency = std::numeric_limits<long long>::min();
+                  bool bestManufacturerMatch = false;
+                  float bestRating = -1.0f;
+                  bool bestUsedRecencyTiebreak = false;
                   for (const auto &entry : catalogEntries) {
                     const std::string requestedFixtureName =
                         req.fixtureName.empty() ? req.type : req.fixtureName;
-                    if (!IsLikelyFixtureNameMatch(entry.fixtureName,
-                                                  requestedFixtureName)) {
+                    const int nameScore = ComputeFixtureNameMatchScore(
+                        entry.fixtureName, requestedFixtureName);
+                    if (nameScore <= 0) {
                       continue;
                     }
-                    int baseScore = 50;
                     std::string matchedMode;
+                    bool footprintMatch = false;
                     if (req.footprint > 0) {
-                      baseScore = 0;
                       for (const auto &mode : entry.modes) {
                         if (mode.footprint == req.footprint) {
-                          baseScore = 100;
+                          footprintMatch = true;
                           matchedMode = mode.name;
                           break;
                         }
                       }
                     }
-                    const double total = static_cast<double>(baseScore) +
-                                         static_cast<double>(entry.rating) * 2.0 +
-                                         static_cast<double>(entry.lastModifiedUnix) /
-                                             (86400.0 * 30.0);
-                    if (total > bestScore) {
-                      bestScore = total;
-                      bestMatch = {true, entry.rid, matchedMode};
+                    const bool manufacturerMatch =
+                        !req.manufacturer.empty() && !entry.manufacturer.empty() &&
+                        NormalizeForGdtfMatch(req.manufacturer) ==
+                            NormalizeForGdtfMatch(entry.manufacturer);
+                    const int footprintBonus = footprintMatch ? 3000 : 0;
+                    const int manufacturerBonus = manufacturerMatch ? 40 : 0;
+                    const int primaryScore =
+                        nameScore + footprintBonus + manufacturerBonus;
+
+                    bool isBetter = false;
+                    bool decidedByRecency = false;
+                    if (primaryScore > bestPrimaryScore) {
+                      isBetter = true;
+                    } else if (primaryScore == bestPrimaryScore) {
+                      if (entry.lastModifiedUnix > bestRecency) {
+                        isBetter = true;
+                        decidedByRecency = true;
+                      } else if (entry.lastModifiedUnix == bestRecency) {
+                        if (manufacturerMatch && !bestManufacturerMatch) {
+                          isBetter = true;
+                        } else if (manufacturerMatch == bestManufacturerMatch &&
+                                   entry.rating > bestRating) {
+                          isBetter = true;
+                        }
+                      }
+                    }
+
+                    if (isBetter) {
+                      bestPrimaryScore = primaryScore;
+                      bestRecency = entry.lastModifiedUnix;
+                      bestManufacturerMatch = manufacturerMatch;
+                      bestRating = entry.rating;
+                      bestUsedRecencyTiebreak = decidedByRecency;
+                      std::string selectionReason = "name";
+                      if (footprintMatch) {
+                        selectionReason = "name+footprint";
+                      } else if (bestUsedRecencyTiebreak) {
+                        selectionReason = "name+recency";
+                      } else if (manufacturerMatch) {
+                        selectionReason = "name+manufacturer";
+                      } else if (entry.rating > 0.0f) {
+                        selectionReason = "name+rating";
+                      }
+                      bestMatch = {true, entry.rid, matchedMode, selectionReason};
                     }
                   }
 
@@ -3111,6 +3154,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                     wxString details = "Downloaded and assigned";
                     if (!bestMatch.modeName.empty())
                       details += " (Mode: " + wxString::FromUTF8(bestMatch.modeName) + ")";
+                    if (!bestMatch.selectionReason.empty())
+                      details += " [" + wxString::FromUTF8(bestMatch.selectionReason) + "]";
                     updateStatusRow(req.type, selectedFixtureName, "Success", details,
                                     DownloadRowState::Downloaded);
                   } else {

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -687,6 +687,51 @@ static std::string StripParenthesizedSections(const std::string &text) {
   return Trim(stripped);
 }
 
+static bool IsLikelyVersionToken(const std::string &token) {
+  if (token.empty())
+    return false;
+  const bool allDigits = std::all_of(token.begin(), token.end(),
+                                     [](unsigned char ch) { return std::isdigit(ch); });
+  if (allDigits)
+    return true;
+
+  if (token.size() <= 6) {
+    const std::string roman = ToLowerAscii(token);
+    const bool allRoman = std::all_of(roman.begin(), roman.end(), [](unsigned char ch) {
+      return ch == 'i' || ch == 'v' || ch == 'x' || ch == 'l' || ch == 'c' ||
+             ch == 'd' || ch == 'm';
+    });
+    if (allRoman)
+      return true;
+  }
+  return false;
+}
+
+static std::string BuildCoreFixtureNameKey(const std::string &text) {
+  const std::string stripped = StripParenthesizedSections(text);
+  const std::string lower = ToLowerAscii(stripped);
+  std::vector<std::string> tokens;
+  std::string current;
+  for (unsigned char ch : lower) {
+    if (std::isalnum(ch)) {
+      current.push_back(static_cast<char>(ch));
+    } else if (!current.empty()) {
+      tokens.push_back(current);
+      current.clear();
+    }
+  }
+  if (!current.empty())
+    tokens.push_back(current);
+
+  std::string compact;
+  for (const auto &token : tokens) {
+    if (IsLikelyVersionToken(token))
+      continue;
+    compact += token;
+  }
+  return compact;
+}
+
 static int ComputeFixtureNameMatchScore(const std::string &catalogFixtureName,
                                         const std::string &requestedFixtureName) {
   const std::string catalogNormalized =
@@ -708,6 +753,14 @@ static int ComputeFixtureNameMatchScore(const std::string &catalogFixtureName,
     return 9000;
   }
 
+  const std::string catalogCoreName = BuildCoreFixtureNameKey(catalogFixtureName);
+  const std::string requestedCoreName =
+      BuildCoreFixtureNameKey(requestedFixtureName);
+  if (!catalogCoreName.empty() && !requestedCoreName.empty() &&
+      catalogCoreName == requestedCoreName) {
+    return 8500;
+  }
+
   const auto hasContainsMatch = [](const std::string &lhs,
                                    const std::string &rhs) -> bool {
     if (lhs.empty() || rhs.empty())
@@ -721,6 +774,7 @@ static int ComputeFixtureNameMatchScore(const std::string &catalogFixtureName,
        requestedNormalized.find(catalogNormalized) != std::string::npos) ||
       (requestedNormalized.size() >= 5 &&
        catalogNormalized.find(requestedNormalized) != std::string::npos) ||
+      hasContainsMatch(catalogCoreName, requestedCoreName) ||
       hasContainsMatch(catalogNoParentheses, requestedNoParentheses) ||
       hasContainsMatch(catalogNormalized, requestedNoParentheses) ||
       hasContainsMatch(catalogNoParentheses, requestedNormalized);


### PR DESCRIPTION
### Motivation
- Align the GDTF catalog matching behavior with the agreed priority: normalized fixture name is the primary signal, footprint match is a strong bonus, `lastModified` is the main tiebreaker, manufacturer is a weak secondary signal, and `rating` is a tertiary tie-breaker. 
- Improve traceability by recording the selection reason shown in the download dialog for easier debugging and audits.

### Description
- Introduced `ComputeFixtureNameMatchScore` to replace the boolean name filter and produce a numeric name-quality score used as the primary matching signal. 
- Reworked the catalog candidate evaluation to compute a `primaryScore = nameScore + footprintBonus + manufacturerBonus`, with a strong footprint bonus (`+3000`) when `req.footprint > 0` and a small manufacturer bonus (`+40`), and to prefer `lastModifiedUnix` as the first tie-breaker followed by manufacturer and then `rating`. 
- Added `selectionReason` to `GdtfDownloadMatch` and append user-visible tags (for example `name+footprint`, `name+recency`, `name+manufacturer`, `name+rating`, `name`) into the status `Details` string for the selected download. 
- Added `#include <limits>` to support safe initialization of comparison baselines. 
- Technical note: this change keeps logic inside `mvr/mvrimporter.cpp`; to keep responsibilities smaller it is recommended to extract the matching/scoring logic into a helper module (for example `mvr/gdtf_matcher.{h,cpp}`) in a follow-up PR. 

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e65d1e6a608324940cc76e7456f946)