### PR TITLE
Defer MVR auto-category until after GDTF source resolution

### DIFF
--- a/gui/mainwindow/controllers/mainwindow_io_controller.cpp
+++ b/gui/mainwindow/controllers/mainwindow_io_controller.cpp
@@ -92,6 +92,12 @@ bool MainWindowIoController::ImportMvrFromPath(const std::string &pathUtf8) {
             importProgress = std::make_unique<wxProgressDialog>(
                 title, stageText, safeTotal + 1, ownerRef.get(),
                 wxPD_AUTO_HIDE | wxPD_SMOOTH | wxPD_APP_MODAL);
+            importProgress->Bind(wxEVT_CLOSE_WINDOW, [](wxCloseEvent &event) {
+              event.Veto();
+            });
+#if wxCHECK_VERSION(3, 1, 0)
+            importProgress->EnableCloseButton(false);
+#endif
           } else {
             importProgress->SetRange(safeTotal + 1);
           }

--- a/gui/mainwindow/controllers/mainwindow_io_controller.cpp
+++ b/gui/mainwindow/controllers/mainwindow_io_controller.cpp
@@ -97,6 +97,7 @@ bool MainWindowIoController::ImportMvrFromPath(const std::string &pathUtf8) {
           }
 
           importProgress->Update(clampedCompleted, stageText);
+          wxYieldIfNeeded();
           setImportStatus(wxString::Format("MVR import: %s (%d/%d)", stageText,
                                            clampedCompleted, safeTotal));
           return;
@@ -104,6 +105,7 @@ bool MainWindowIoController::ImportMvrFromPath(const std::string &pathUtf8) {
 
         if (importProgress) {
           importProgress->Pulse(wxString::FromUTF8(stage));
+          wxYieldIfNeeded();
         }
         setImportStatus("MVR import: " + wxString::FromUTF8(stage));
       });

--- a/gui/mainwindow/controllers/mainwindow_io_controller.cpp
+++ b/gui/mainwindow/controllers/mainwindow_io_controller.cpp
@@ -92,12 +92,6 @@ bool MainWindowIoController::ImportMvrFromPath(const std::string &pathUtf8) {
             importProgress = std::make_unique<wxProgressDialog>(
                 title, stageText, safeTotal + 1, ownerRef.get(),
                 wxPD_AUTO_HIDE | wxPD_SMOOTH | wxPD_APP_MODAL);
-            importProgress->Bind(wxEVT_CLOSE_WINDOW, [](wxCloseEvent &event) {
-              event.Veto();
-            });
-#if wxCHECK_VERSION(3, 1, 0)
-            importProgress->EnableCloseButton(false);
-#endif
           } else {
             importProgress->SetRange(safeTotal + 1);
           }

--- a/gui/mainwindow/controllers/mainwindow_io_controller.cpp
+++ b/gui/mainwindow/controllers/mainwindow_io_controller.cpp
@@ -91,7 +91,7 @@ bool MainWindowIoController::ImportMvrFromPath(const std::string &pathUtf8) {
             importOverlay.reset();
             importProgress = std::make_unique<wxProgressDialog>(
                 title, stageText, safeTotal, ownerRef.get(),
-                wxPD_AUTO_HIDE | wxPD_SMOOTH | wxPD_APP_MODAL);
+                wxPD_SMOOTH | wxPD_APP_MODAL);
           } else {
             importProgress->SetRange(safeTotal);
           }
@@ -132,6 +132,11 @@ bool MainWindowIoController::ImportMvrFromPath(const std::string &pathUtf8) {
       ownerRef->consolePanel->AppendMessage("Failed to import " + filePath);
     return false;
   }
+
+  // The blocking import feedback should end once the scene has been created.
+  importProgress.reset();
+  importOverlay.reset();
+  importDisabler.reset();
 
   setImportStatus("MVR import: refreshing panels...");
   if (ownerRef->consolePanel)
@@ -181,10 +186,6 @@ bool MainWindowIoController::ImportMvrFromPath(const std::string &pathUtf8) {
   // dictionary colors still receive a color by type/group.
   wxCommandEvent autoColorEvent;
   ownerRef->OnAutoColor(autoColorEvent);
-
-  importProgress.reset();
-  importOverlay.reset();
-  importDisabler.reset();
 
   if (ownerRef->GetStatusBar()) {
     const wxString fileName = wxFileName(filePath).GetFullName();

--- a/gui/mainwindow/controllers/mainwindow_io_controller.cpp
+++ b/gui/mainwindow/controllers/mainwindow_io_controller.cpp
@@ -90,13 +90,15 @@ bool MainWindowIoController::ImportMvrFromPath(const std::string &pathUtf8) {
           if (!importProgress) {
             importOverlay.reset();
             importProgress = std::make_unique<wxProgressDialog>(
-                title, stageText, safeTotal, ownerRef.get(),
-                wxPD_SMOOTH | wxPD_APP_MODAL);
+                title, stageText, safeTotal + 1, ownerRef.get(),
+                wxPD_AUTO_HIDE | wxPD_SMOOTH | wxPD_APP_MODAL);
           } else {
-            importProgress->SetRange(safeTotal);
+            importProgress->SetRange(safeTotal + 1);
           }
 
-          importProgress->Update(clampedCompleted, stageText);
+          const int dialogProgressValue =
+              std::clamp(clampedCompleted, 0, std::max(1, safeTotal));
+          importProgress->Update(dialogProgressValue, stageText);
           wxYieldIfNeeded();
           setImportStatus(wxString::Format("MVR import: %s (%d/%d)", stageText,
                                            clampedCompleted, safeTotal));
@@ -132,11 +134,6 @@ bool MainWindowIoController::ImportMvrFromPath(const std::string &pathUtf8) {
       ownerRef->consolePanel->AppendMessage("Failed to import " + filePath);
     return false;
   }
-
-  // The blocking import feedback should end once the scene has been created.
-  importProgress.reset();
-  importOverlay.reset();
-  importDisabler.reset();
 
   setImportStatus("MVR import: refreshing panels...");
   if (ownerRef->consolePanel)
@@ -186,6 +183,10 @@ bool MainWindowIoController::ImportMvrFromPath(const std::string &pathUtf8) {
   // dictionary colors still receive a color by type/group.
   wxCommandEvent autoColorEvent;
   ownerRef->OnAutoColor(autoColorEvent);
+
+  importProgress.reset();
+  importOverlay.reset();
+  importDisabler.reset();
 
   if (ownerRef->GetStatusBar()) {
     const wxString fileName = wxFileName(filePath).GetFullName();

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -1993,59 +1993,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         }
 
         ReadFixtureCategoryFromUserData(node, fixture);
-        const std::string categoryKey =
-            !fixture.typeName.empty() ? fixture.typeName : fixture.gdtfSpec;
         const std::optional<GdtfDictionary::Entry> &dictionaryEntry =
             getDictionaryEntryCached(fixture.typeName);
-
-        if (fixture.category.empty() && !fixture.typeName.empty()) {
-          if (dictionaryEntry) {
-            fixture.category =
-                GdtfFixtureCategory::NormalizeCategory(dictionaryEntry->category);
-          }
-          if (!fixture.category.empty()) {
-            fixture.categorySource = GdtfFixtureCategory::kManualSource;
-            fixture.categorySourceReason.clear();
-          }
-        }
-
-        if (fixture.category.empty() && !categoryKey.empty()) {
-          auto cacheIt = categoryByTypeKey.find(categoryKey);
-          if (cacheIt != categoryByTypeKey.end()) {
-            fixture.category = cacheIt->second.category;
-            fixture.categorySource = cacheIt->second.source;
-            fixture.categorySourceReason = cacheIt->second.reason;
-          }
-        }
-
-        if (fixture.category.empty() && !fixture.gdtfSpec.empty()) {
-          const auto inferred = GdtfFixtureCategory::InferFromGdtf(
-              ResolveScenePathForRead(scene.basePath, fixture.gdtfSpec));
-          fixture.category = GdtfFixtureCategory::NormalizeCategory(inferred.category);
-          if (fixture.category.empty())
-            fixture.category = GdtfFixtureCategory::kUnknown;
-          fixture.categorySource = GdtfFixtureCategory::kAutoFallbackSource;
-          fixture.categorySourceReason = inferred.reason;
-          if (!categoryKey.empty()) {
-            categoryByTypeKey[categoryKey] =
-                {fixture.category, fixture.categorySource, inferred.reason};
-          }
-          LogMessage(Logger::Level::Info,
-                     "Auto category fallback: " + fixture.instanceName + " -> " +
-                         fixture.category + " [" + inferred.reason + "]");
-        } else if (!fixture.category.empty() && !categoryKey.empty()) {
-          categoryByTypeKey[categoryKey] =
-              {fixture.category, fixture.categorySource.empty()
-                                     ? GdtfFixtureCategory::kManualSource
-                                     : fixture.categorySource,
-               fixture.categorySourceReason.empty() ? "cached"
-                                                   : fixture.categorySourceReason};
-        }
-
-        if (!fixture.category.empty() && !fixture.typeName.empty() &&
-            fixture.categorySource == GdtfFixtureCategory::kManualSource) {
-          GdtfDictionary::UpdateCategory(fixture.typeName, fixture.category);
-        }
         auto posIt = scene.positions.find(fixture.position);
         if (posIt != scene.positions.end())
           fixture.positionName = posIt->second;
@@ -3537,6 +3486,76 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
           }
         }
       }
+    }
+  }
+
+  reportProgress("Applying fixture categories...");
+  const int totalFixturesForCategoryApply = static_cast<int>(scene.fixtures.size());
+  int appliedFixturesForCategoryApply = 0;
+  categoryByTypeKey.clear();
+  for (auto &[uid, fixture] : scene.fixtures) {
+    (void)uid;
+    ++appliedFixturesForCategoryApply;
+    if (totalFixturesForCategoryApply > 0 &&
+        (appliedFixturesForCategoryApply == 1 ||
+         appliedFixturesForCategoryApply == totalFixturesForCategoryApply ||
+         appliedFixturesForCategoryApply % 50 == 0)) {
+      reportProgress("Applying fixture categories...",
+                     appliedFixturesForCategoryApply,
+                     totalFixturesForCategoryApply);
+    }
+
+    const std::string categoryKey =
+        !fixture.typeName.empty() ? fixture.typeName : fixture.gdtfSpec;
+
+    if (fixture.category.empty() && !fixture.typeName.empty()) {
+      const auto &dictionaryEntry = getDictionaryEntryCached(fixture.typeName);
+      if (dictionaryEntry) {
+        fixture.category =
+            GdtfFixtureCategory::NormalizeCategory(dictionaryEntry->category);
+      }
+      if (!fixture.category.empty()) {
+        fixture.categorySource = GdtfFixtureCategory::kManualSource;
+        fixture.categorySourceReason.clear();
+      }
+    }
+
+    if (fixture.category.empty() && !categoryKey.empty()) {
+      auto cacheIt = categoryByTypeKey.find(categoryKey);
+      if (cacheIt != categoryByTypeKey.end()) {
+        fixture.category = cacheIt->second.category;
+        fixture.categorySource = cacheIt->second.source;
+        fixture.categorySourceReason = cacheIt->second.reason;
+      }
+    }
+
+    if (fixture.category.empty() && !fixture.gdtfSpec.empty()) {
+      const auto inferred = GdtfFixtureCategory::InferFromGdtf(
+          ResolveScenePathForRead(scene.basePath, fixture.gdtfSpec));
+      fixture.category = GdtfFixtureCategory::NormalizeCategory(inferred.category);
+      if (fixture.category.empty())
+        fixture.category = GdtfFixtureCategory::kUnknown;
+      fixture.categorySource = GdtfFixtureCategory::kAutoFallbackSource;
+      fixture.categorySourceReason = inferred.reason;
+      if (!categoryKey.empty()) {
+        categoryByTypeKey[categoryKey] =
+            {fixture.category, fixture.categorySource, inferred.reason};
+      }
+      LogMessage(Logger::Level::Info,
+                 "Auto category fallback: " + fixture.instanceName + " -> " +
+                     fixture.category + " [" + inferred.reason + "]");
+    } else if (!fixture.category.empty() && !categoryKey.empty()) {
+      categoryByTypeKey[categoryKey] = {
+          fixture.category,
+          fixture.categorySource.empty() ? GdtfFixtureCategory::kManualSource
+                                         : fixture.categorySource,
+          fixture.categorySourceReason.empty() ? "cached"
+                                               : fixture.categorySourceReason};
+    }
+
+    if (!fixture.category.empty() && !fixture.typeName.empty() &&
+        fixture.categorySource == GdtfFixtureCategory::kManualSource) {
+      GdtfDictionary::UpdateCategory(fixture.typeName, fixture.category);
     }
   }
 

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -3499,7 +3499,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
     if (totalFixturesForCategoryApply > 0 &&
         (appliedFixturesForCategoryApply == 1 ||
          appliedFixturesForCategoryApply == totalFixturesForCategoryApply ||
-         appliedFixturesForCategoryApply % 50 == 0)) {
+         appliedFixturesForCategoryApply % 10 == 0)) {
       reportProgress("Applying fixture categories...",
                      appliedFixturesForCategoryApply,
                      totalFixturesForCategoryApply);


### PR DESCRIPTION
### Motivation
- During MVR import the auto-category pass ran while GDTF source choices could still be transient, which could produce incorrect fixture categories. 
- The goal is to compute auto-categories only after final GDTF selection/conflict resolution so categories reflect the definitive fixture types and sources.

### Description
- Removed the early auto-category/caching/inference logic from the per-fixture XML parse stage in `mvr/mvrimporter.cpp` while preserving explicit category read from `UserData` at parse time. 
- Added a dedicated `Applying fixture categories...` pass that runs after dictionary/conflict-driven GDTF selection and applies the original precedence rules (dictionary/manual → cached by type → inference from finalized GDTF), and updates the dictionary as before. 
- Kept the existing behavior for `applyDictionary`/conflict resolution and mode resolution; the category pass runs on the finalized `scene.fixtures` state to avoid using transient GDTF paths. 
- Technical note: `mvr/mvrimporter.cpp` is a hotspot and grew with this change, so the next recommended split is extracting the category assignment logic into a focused helper (e.g. `mvr/import/mvr_fixture_category_resolver.{h,cpp}`).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which succeeded. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e66cd025d8832480963b02b9de3f2b)