### PR TITLE
Add name-only scene update path in FixtureTablePanel context edits

### DIFF
--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -980,9 +980,13 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
     }
   }
   FixtureTableEditService::PropagateTypeValues(table, selections, col);
+  const SceneDataUpdateType updateType =
+      (col == 1) ? SceneDataUpdateType::kNameOnly
+                 : SceneDataUpdateType::kGeneral;
   ResyncRows(oldOrder, selectedUuids);
-  UpdateSceneData();
-  HighlightDuplicateFixtureIds();
+  UpdateSceneData(true, updateType);
+  if (updateType != SceneDataUpdateType::kNameOnly)
+    HighlightDuplicateFixtureIds();
   if (Viewer3DPanel::Instance()) {
     Viewer3DPanel::Instance()->UpdateScene();
     Viewer3DPanel::Instance()->Refresh();
@@ -1435,7 +1439,8 @@ void FixtureTablePanel::PropagateTypeValues(
   FixtureTableEditService::PropagateTypeValues(table, selections, col);
 }
 
-void FixtureTablePanel::UpdateSceneData(bool logChanges) {
+void FixtureTablePanel::UpdateSceneData(bool logChanges,
+                                        SceneDataUpdateType updateType) {
   ConfigManagerSceneAdapter adapter;
   std::unordered_set<std::string> changedWeightPositions;
   FixtureTableEditService::UpdateSceneData(adapter, table, rowUuids, gdtfPaths,
@@ -1447,7 +1452,8 @@ void FixtureTablePanel::UpdateSceneData(bool logChanges) {
   HoistLoadRecalculationPrompt::PromptAndApply(
       guiConfigServices->LegacyConfigManager(), this, changedWeightPositions);
 
-  HighlightDuplicateFixtureIds();
+  if (updateType != SceneDataUpdateType::kNameOnly)
+    HighlightDuplicateFixtureIds();
 
   if (RiggingPanel::Instance())
     RiggingPanel::Instance()->RefreshData();

--- a/gui/fixturetablepanel.h
+++ b/gui/fixturetablepanel.h
@@ -32,6 +32,11 @@ class IGuiConfigServices;
 class FixtureTablePanel : public wxPanel
 {
 public:
+    enum class SceneDataUpdateType {
+        kGeneral,
+        kNameOnly
+    };
+
     explicit FixtureTablePanel(wxWindow* parent, IGuiConfigServices* services = nullptr);
     ~FixtureTablePanel();
     void ReloadData(); // Refresh content from ConfigManager
@@ -49,7 +54,9 @@ public:
     static FixtureTablePanel* Instance();
     static void SetInstance(FixtureTablePanel* panel);
 
-    void UpdateSceneData(bool logChanges = true);
+    void UpdateSceneData(
+        bool logChanges = true,
+        SceneDataUpdateType updateType = SceneDataUpdateType::kGeneral);
 
 private:
     friend class FixtureEditDialog; // allow dialog to access internals


### PR DESCRIPTION
### Motivation
- Reduce unnecessary highlight/validation work when only the fixture name (column 1) is edited so name edits do not trigger patch/ID/category conflict highlighting logic.

### Description
- Added `FixtureTablePanel::SceneDataUpdateType` and extended `UpdateSceneData(...)` to accept an `updateType` context (`kGeneral` or `kNameOnly`).
- In `OnContextMenu(...)` the generic edit flow now detects `col == 1` (name column) and passes `SceneDataUpdateType::kNameOnly` to `UpdateSceneData(...)`.
- When `updateType == kNameOnly`, `UpdateSceneData(...)` skips calling `HighlightDuplicateFixtureIds()`, which in turn avoids `HighlightPatchConflicts()` and `HighlightAutoFallbackCategories()`; all other edit contexts keep the original validation/highlight behavior.
- Changes are localized to `gui/fixturetablepanel.h` and `gui/fixturetablepanel.cpp` to keep the change small and focused.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8a25ab098832492b641e3ddf4c4ab)