### PR TITLE
Add label-only visual refresh path for fixture renames

### DIFF
--- a/gui/fixtureeditdialog.cpp
+++ b/gui/fixtureeditdialog.cpp
@@ -25,6 +25,7 @@
 #include "gdtf_fixture_category.h"
 #include "symbolcache.h"
 #include "symbols/PerastageSvgSymbol.h"
+#include "viewer2dpanel.h"
 #include "viewer3dpanel.h"
 #include <wx/datetime.h>
 #include <wx/filedlg.h>
@@ -958,12 +959,32 @@ void FixtureEditDialog::ApplyChanges() {
     }
   }
   panel->ResyncRows(oldOrder, selectedUuids);
-  panel->UpdateSceneData();
-  panel->HighlightDuplicateFixtureIds();
+  bool renamedOnly = modifiedColumns.size() > 1 && modifiedColumns[1];
+  if (renamedOnly) {
+    for (size_t i = 0; i < modifiedColumns.size(); ++i) {
+      if (i == 1 || !modifiedColumns[i])
+        continue;
+      renamedOnly = false;
+      break;
+    }
+  }
+  const auto updateType =
+      renamedOnly ? FixtureTablePanel::SceneDataUpdateType::kVisualLabelOnly
+                  : FixtureTablePanel::SceneDataUpdateType::kGeneral;
+  panel->UpdateSceneData(true, updateType);
   applied = true;
   if (Viewer3DPanel::Instance()) {
-    Viewer3DPanel::Instance()->UpdateScene();
-    Viewer3DPanel::Instance()->Refresh();
+    if (updateType == FixtureTablePanel::SceneDataUpdateType::kVisualLabelOnly) {
+      Viewer3DPanel::Instance()->Refresh();
+    } else {
+      Viewer3DPanel::Instance()->UpdateScene();
+      Viewer3DPanel::Instance()->Refresh();
+    }
+  } else if (Viewer2DPanel::Instance()) {
+    if (updateType == FixtureTablePanel::SceneDataUpdateType::kVisualLabelOnly)
+      Viewer2DPanel::Instance()->UpdateScene(false);
+    else
+      Viewer2DPanel::Instance()->UpdateScene();
   }
   std::fill(modifiedColumns.begin(), modifiedColumns.end(), false);
 }

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -86,6 +86,25 @@ public:
   }
 };
 
+void RefreshViewersForFixtureUpdate(
+    FixtureTablePanel::SceneDataUpdateType updateType) {
+  const bool labelOnlyUpdate =
+      updateType == FixtureTablePanel::SceneDataUpdateType::kVisualLabelOnly;
+  if (Viewer3DPanel::Instance()) {
+    if (labelOnlyUpdate) {
+      Viewer3DPanel::Instance()->Refresh();
+    } else {
+      Viewer3DPanel::Instance()->UpdateScene();
+      Viewer3DPanel::Instance()->Refresh();
+    }
+  } else if (Viewer2DPanel::Instance()) {
+    if (labelOnlyUpdate)
+      Viewer2DPanel::Instance()->UpdateScene(false);
+    else
+      Viewer2DPanel::Instance()->UpdateScene();
+  }
+}
+
 bool IsRedCell(const ColorfulDataViewListStore *store, int row, int col) {
   if (!store || row < 0 || col < 0)
     return false;
@@ -981,18 +1000,11 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
   }
   FixtureTableEditService::PropagateTypeValues(table, selections, col);
   const SceneDataUpdateType updateType =
-      (col == 1) ? SceneDataUpdateType::kNameOnly
+      (col == 1) ? SceneDataUpdateType::kVisualLabelOnly
                  : SceneDataUpdateType::kGeneral;
   ResyncRows(oldOrder, selectedUuids);
   UpdateSceneData(true, updateType);
-  if (updateType != SceneDataUpdateType::kNameOnly)
-    HighlightDuplicateFixtureIds();
-  if (Viewer3DPanel::Instance()) {
-    Viewer3DPanel::Instance()->UpdateScene();
-    Viewer3DPanel::Instance()->Refresh();
-  } else if (Viewer2DPanel::Instance()) {
-    Viewer2DPanel::Instance()->UpdateScene();
-  }
+  RefreshViewersForFixtureUpdate(updateType);
 }
 
 static FixtureTablePanel *s_instance = nullptr;
@@ -1452,13 +1464,14 @@ void FixtureTablePanel::UpdateSceneData(bool logChanges,
   HoistLoadRecalculationPrompt::PromptAndApply(
       guiConfigServices->LegacyConfigManager(), this, changedWeightPositions);
 
-  if (updateType != SceneDataUpdateType::kNameOnly)
+  if (updateType != SceneDataUpdateType::kVisualLabelOnly)
     HighlightDuplicateFixtureIds();
 
   if (RiggingPanel::Instance())
     RiggingPanel::Instance()->RefreshData();
 
-  if (SummaryPanel::Instance() && IsActivePage())
+  if (SummaryPanel::Instance() && IsActivePage() &&
+      updateType != SceneDataUpdateType::kVisualLabelOnly)
     SummaryPanel::Instance()->ShowFixtureSummary();
 }
 

--- a/gui/fixturetablepanel.h
+++ b/gui/fixturetablepanel.h
@@ -34,7 +34,7 @@ class FixtureTablePanel : public wxPanel
 public:
     enum class SceneDataUpdateType {
         kGeneral,
-        kNameOnly
+        kVisualLabelOnly
     };
 
     explicit FixtureTablePanel(wxWindow* parent, IGuiConfigServices* services = nullptr);


### PR DESCRIPTION
### Motivation
- Reduce cost of simple instance-name edits by avoiding a full scene rebuild when only labels change, keeping `UpdateScene()` reserved for geometry/resource changes.
- Ensure 3D label updates use a light refresh path and 2D uses the existing lightweight `UpdateScene(false)` path to minimize UI/performance impact.
- Avoid unnecessary recomputation of fixture summary and heavyweight checks for pure rename operations.

### Description
- Added a new lightweight update type `SceneDataUpdateType::kVisualLabelOnly` in `gui/fixturetablepanel.h` to represent label-only edits.
- Implemented `RefreshViewersForFixtureUpdate(...)` in `gui/fixturetablepanel.cpp` that calls `Viewer3DPanel::Refresh()` for label-only updates and calls the full `UpdateScene()` + `Refresh()` for general updates, and that calls `Viewer2DPanel::UpdateScene(false)` for 2D label-only updates.
- Replaced direct post-edit viewer calls in the fixture table edit flow to use the new update type and helper; the table now selects `kVisualLabelOnly` when column 1 (instance name) is the only changed column.
- Updated `FixtureEditDialog::ApplyChanges()` in `gui/fixtureeditdialog.cpp` to detect rename-only edits and invoke `UpdateSceneData(..., kVisualLabelOnly)` and the same lightweight viewer refresh path when applicable.
- Prevent `SummaryPanel::ShowFixtureSummary()` from being triggered on `kVisualLabelOnly` updates because the summary groups by fixture `typeName` and is unaffected by instance-name changes.
- Technical note: `gui/fixturetablepanel.cpp` is a hotspot file; this PR keeps the change compact but recommends extracting viewer-refresh coordination logic into a small helper file next if further growth occurs.

### Testing
- Ran module/architecture checks: `tests/check_perastage_tree_modules.sh` succeeded.
- Ran GUI safety check: `tests/check_no_configmanager_get_in_gui.sh` succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8a5503ef483248209dcb1e05e2be6)