### PR TITLE
Guard rigging refresh for label-only fixture updates

### DIFF
--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -1480,7 +1480,8 @@ void FixtureTablePanel::UpdateSceneData(bool logChanges,
   if (updateType != SceneDataUpdateType::kVisualLabelOnly)
     HighlightDuplicateFixtureIds();
 
-  if (RiggingPanel::Instance())
+  if (updateType != SceneDataUpdateType::kVisualLabelOnly &&
+      RiggingPanel::Instance())
     RiggingPanel::Instance()->RefreshData();
 
   if (SummaryPanel::Instance() && IsActivePage() &&


### PR DESCRIPTION
### Motivation
- Avoid triggering expensive rigging recalculation when only visual labels/names are changed so rename-only edits remain limited to table/visual label updates.

### Description
- Add a guard so `RiggingPanel::RefreshData()` is only invoked when `updateType != SceneDataUpdateType::kVisualLabelOnly` in `FixtureTablePanel` update flows, keeping weight/position/category (general) updates unchanged and scoped rename-only edits limited to the table and visual labels.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8acff8b1c8324917f32f13da3d707)