### PR TITLE
Block selection-changed events while resyncing fixture table rows

### DIFF
--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -1615,11 +1615,14 @@ void FixtureTablePanel::ResyncRows(
   rowUuids.swap(newOrder);
   gdtfPaths.swap(newPaths);
 
-  table->UnselectAll();
-  for (const auto &uuid : selectedUuids) {
-    auto pos = std::find(rowUuids.begin(), rowUuids.end(), uuid);
-    if (pos != rowUuids.end())
-      table->SelectRow(static_cast<int>(pos - rowUuids.begin()));
+  {
+    wxEventBlocker selectionBlocker(table, wxEVT_DATAVIEW_SELECTION_CHANGED);
+    table->UnselectAll();
+    for (const auto &uuid : selectedUuids) {
+      auto pos = std::find(rowUuids.begin(), rowUuids.end(), uuid);
+      if (pos != rowUuids.end())
+        table->SelectRow(static_cast<int>(pos - rowUuids.begin()));
+    }
   }
   UpdateSelectionHighlight();
 }


### PR DESCRIPTION
### Motivation
- Prevent spurious `wxEVT_DATAVIEW_SELECTION_CHANGED` events (which can push undo states and cause selection side effects) when restoring selection during row resynchronization so the user’s final selection remains intact.

### Description
- In `gui/fixturetablepanel.cpp` wrapped the `UnselectAll()` / `SelectRow(...)` restore sequence inside a `wxEventBlocker(table, wxEVT_DATAVIEW_SELECTION_CHANGED)` so selection-changed handlers are suppressed during the resync, and kept the `UpdateSelectionHighlight()` call afterwards to refresh local visual state without triggering selection undo logic.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both returned OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8af07bb208324b9b3f5f12d285db9)