### PR TITLE
Centralize duplicate fixture ID highlighting in UpdateSceneData

### DIFF
--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -545,7 +545,6 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
     }
     ResyncRows(oldOrder, selectedUuids);
     UpdateSceneData();
-    HighlightDuplicateFixtureIds();
     if (Viewer3DPanel::Instance()) {
       Viewer3DPanel::Instance()->UpdateScene();
       Viewer3DPanel::Instance()->Refresh();
@@ -610,7 +609,6 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
 
     ResyncRows(oldOrder, selectedUuids);
     UpdateSceneData();
-    HighlightDuplicateFixtureIds();
     if (Viewer3DPanel::Instance()) {
       Viewer3DPanel::Instance()->UpdateScene();
       Viewer3DPanel::Instance()->Refresh();
@@ -640,7 +638,6 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
     PropagateTypeValues(selections, col);
     ResyncRows(oldOrder, selectedUuids);
     UpdateSceneData();
-    HighlightDuplicateFixtureIds();
     if (Viewer3DPanel::Instance()) {
       Viewer3DPanel::Instance()->UpdateScene();
       Viewer3DPanel::Instance()->Refresh();
@@ -708,7 +705,6 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
 
     ResyncRows(oldOrder, selectedUuids);
     UpdateSceneData();
-    HighlightDuplicateFixtureIds();
     if (Viewer3DPanel::Instance()) {
       Viewer3DPanel::Instance()->UpdateScene();
       Viewer3DPanel::Instance()->Refresh();
@@ -761,7 +757,6 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
     }
     ResyncRows(oldOrder, selectedUuids);
     UpdateSceneData();
-    HighlightDuplicateFixtureIds();
     if (Viewer3DPanel::Instance()) {
       Viewer3DPanel::Instance()->UpdateScene();
       Viewer3DPanel::Instance()->Refresh();
@@ -800,7 +795,6 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
     PropagateTypeValues(selections, col);
     ResyncRows(oldOrder, selectedUuids);
     UpdateSceneData();
-    HighlightDuplicateFixtureIds();
     if (Viewer3DPanel::Instance()) {
       Viewer3DPanel::Instance()->UpdateScene();
       Viewer3DPanel::Instance()->Refresh();


### PR DESCRIPTION
### Motivation
- Remove duplicated UI highlighting after inline edits by centralizing `HighlightDuplicateFixtureIds()` in `FixtureTablePanel::UpdateSceneData(...)` so duplicate-ID and patch-conflict highlighting runs from a single, well-defined point after scene updates.

### Description
- Deleted redundant `HighlightDuplicateFixtureIds()` calls from multiple branches inside `FixtureTablePanel::OnContextMenu(...)` where `UpdateSceneData()` is already called, leaving the highlight responsibility to `UpdateSceneData()` (which skips highlighting for `SceneDataUpdateType::kVisualLabelOnly`).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8b0db4ca08324866d9b61fa5b88cf)