### PR TITLE
Batch GDTF category updates during MVR import

### DIFF
--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -36,6 +36,7 @@ namespace GdtfDictionary {
 namespace {
 
 LoadStatus g_lastLoadStatus;
+size_t g_saveCallCountForTesting = 0;
 fs::path GetUserDictFile();
 
 
@@ -247,6 +248,40 @@ FindEquivalentTypeKey(const std::unordered_map<std::string, Entry> &dict,
       return existingType;
   }
   return std::nullopt;
+}
+
+bool ApplyCategoryUpdateForFile(
+    std::unordered_map<std::string, Entry> &dict, const std::string &type,
+    const std::string &gdtfPath, const std::string &category) {
+  const std::string normalizedType = NormalizeTypeKey(type);
+  if (normalizedType.empty())
+    return false;
+
+  std::string keyToUse = type;
+  if (auto existingKey = FindEquivalentTypeKey(dict, normalizedType))
+    keyToUse = *existingKey;
+  auto it = dict.find(keyToUse);
+  if (it == dict.end()) {
+    Entry e;
+    e.category = category;
+    dict[keyToUse] = e;
+    return true;
+  }
+
+  std::string sharedPath = it->second.path;
+  if (sharedPath.empty() && !gdtfPath.empty())
+    sharedPath = gdtfPath;
+  it->second.category = category;
+  for (auto &[entryType, entry] : dict) {
+    if (entryType == keyToUse)
+      continue;
+    const bool samePath = PathsMatchForDictionaryEntries(entry.path, sharedPath);
+    const bool sameFileName = PathsShareFileName(entry.path, sharedPath);
+    if (!samePath && !sameFileName)
+      continue;
+    entry.category = category;
+  }
+  return true;
 }
 
 fs::path GetUserDictFile() {
@@ -716,6 +751,7 @@ bool Save(const std::unordered_map<std::string, Entry> &dict,
                   file.string();
     return false;
   }
+  ++g_saveCallCountForTesting;
   return true;
 }
 
@@ -825,36 +861,32 @@ void UpdateCategory(const std::string &type, const std::string &category) {
 void UpdateCategoryForFile(const std::string &type, const std::string &gdtfPath,
                            const std::string &category) {
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
-  const std::string normalizedType = NormalizeTypeKey(type);
-  if (normalizedType.empty())
+  auto dictOpt = Load();
+  if (!dictOpt)
+    return;
+  auto &dict = *dictOpt;
+  if (!ApplyCategoryUpdateForFile(dict, type, gdtfPath, category))
+    return;
+  Save(dict);
+}
+
+void UpdateCategoriesBulk(
+    const std::unordered_map<std::string, std::string> &categoriesByType) {
+  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
+  if (categoriesByType.empty())
     return;
   auto dictOpt = Load();
   if (!dictOpt)
     return;
   auto &dict = *dictOpt;
-  std::string keyToUse = type;
-  if (auto existingKey = FindEquivalentTypeKey(dict, normalizedType))
-    keyToUse = *existingKey;
-  auto it = dict.find(keyToUse);
-  if (it == dict.end()) {
-    Entry e;
-    e.category = category;
-    dict[keyToUse] = e;
-  } else {
-    std::string sharedPath = it->second.path;
-    if (sharedPath.empty() && !gdtfPath.empty())
-      sharedPath = gdtfPath;
-    it->second.category = category;
-    for (auto &[entryType, entry] : dict) {
-      if (entryType == keyToUse)
-        continue;
-      const bool samePath = PathsMatchForDictionaryEntries(entry.path, sharedPath);
-      const bool sameFileName = PathsShareFileName(entry.path, sharedPath);
-      if (!samePath && !sameFileName)
-        continue;
-      entry.category = category;
-    }
+  bool hasValidUpdate = false;
+  for (const auto &[type, category] : categoriesByType) {
+    if (!ApplyCategoryUpdateForFile(dict, type, {}, category))
+      continue;
+    hasValidUpdate = true;
   }
+  if (!hasValidUpdate)
+    return;
   Save(dict);
 }
 
@@ -967,6 +999,16 @@ DictionaryImportSummary ApplyImportFromFile(const std::string &filePath,
   if (!Save(current, &saveError))
     summary.errors.push_back("Failed to save current dictionary: " + saveError);
   return summary;
+}
+
+size_t GetSaveCallCountForTesting() {
+  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
+  return g_saveCallCountForTesting;
+}
+
+void ResetSaveCallCountForTesting() {
+  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
+  g_saveCallCountForTesting = 0;
 }
 
 } // namespace GdtfDictionary

--- a/core/gdtfdictionary.h
+++ b/core/gdtfdictionary.h
@@ -19,6 +19,7 @@
 
 #include "dictionary_import.h"
 
+#include <cstddef>
 #include <string>
 #include <optional>
 #include <unordered_map>
@@ -65,6 +66,8 @@ namespace GdtfDictionary {
     void UpdateCategory(const std::string& type, const std::string& category);
     void UpdateCategoryForFile(const std::string& type, const std::string& gdtfPath,
                                const std::string& category);
+    void UpdateCategoriesBulk(
+        const std::unordered_map<std::string, std::string>& categoriesByType);
     void UpdateColor(const std::string& type, const std::string& color);
     void UpdateColorForFile(const std::string& type, const std::string& gdtfPath,
                             const std::string& mode,
@@ -73,4 +76,7 @@ namespace GdtfDictionary {
         const std::string &filePath, DictionaryImportPolicy policy);
     DictionaryImportSummary ApplyImportFromFile(
         const std::string &filePath, DictionaryImportPolicy policy);
+
+    size_t GetSaveCallCountForTesting();
+    void ResetSaveCallCountForTesting();
 }

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -3493,6 +3493,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
   const int totalFixturesForCategoryApply = static_cast<int>(scene.fixtures.size());
   int appliedFixturesForCategoryApply = 0;
   categoryByTypeKey.clear();
+  std::unordered_map<std::string, std::string> pendingCategoryUpdatesByType;
   for (auto &[uid, fixture] : scene.fixtures) {
     (void)uid;
     ++appliedFixturesForCategoryApply;
@@ -3555,9 +3556,10 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
 
     if (!fixture.category.empty() && !fixture.typeName.empty() &&
         fixture.categorySource == GdtfFixtureCategory::kManualSource) {
-      GdtfDictionary::UpdateCategory(fixture.typeName, fixture.category);
+      pendingCategoryUpdatesByType[fixture.typeName] = fixture.category;
     }
   }
+  GdtfDictionary::UpdateCategoriesBulk(pendingCategoryUpdatesByType);
 
   reportProgress("Building fixtures, trusses, and objects...");
 

--- a/tests/mvr_fixture_category_roundtrip_test.cpp
+++ b/tests/mvr_fixture_category_roundtrip_test.cpp
@@ -48,25 +48,38 @@ int main() {
   fixture.categorySource = "Manual";
   scene.fixtures[fixture.uuid] = fixture;
 
+  Fixture fixtureTwo = fixture;
+  fixtureTwo.uuid = "fx2";
+  fixtureTwo.instanceName = "Fixture Two";
+  fixtureTwo.typeName = "FixtureType2";
+  scene.fixtures[fixtureTwo.uuid] = fixtureTwo;
+
   GdtfDictionary::Update("FixtureType", fixturePath.string(), "ModeA", "Wash");
+  GdtfDictionary::Update("FixtureType2", fixturePath.string(), "ModeA", "Beam");
 
   const std::filesystem::path mvrPath = tempDir / "fixture_category.mvr";
   MvrExporter exporter;
   assert(exporter.ExportToFile(mvrPath.string()));
 
   cfg.Reset();
+  GdtfDictionary::ResetSaveCallCountForTesting();
   MvrImporter importer;
   assert(importer.ImportFromFile(mvrPath.string(), false, false));
+  assert(GdtfDictionary::GetSaveCallCountForTesting() == 1);
 
   const auto &loaded = cfg.GetScene().fixtures;
-  assert(loaded.size() == 1);
+  assert(loaded.size() == 2);
   const Fixture &loadedFixture = loaded.at("fx1");
   assert(loadedFixture.category == "Spot");
+  assert(loaded.at("fx2").category == "Spot");
 
   // Dictionary should be updated with scene (MVR) priority category.
   auto entry = GdtfDictionary::Get("FixtureType");
   assert(entry.has_value());
   assert(entry->category == "Spot");
+  auto secondEntry = GdtfDictionary::Get("FixtureType2");
+  assert(secondEntry.has_value());
+  assert(secondEntry->category == "Spot");
 
   cfg.Reset();
   MvrScene &scene2 = cfg.GetScene();
@@ -75,6 +88,10 @@ int main() {
   fixtureWithoutCategory.category.clear();
   fixtureWithoutCategory.categorySource.clear();
   scene2.fixtures[fixtureWithoutCategory.uuid] = fixtureWithoutCategory;
+  Fixture fixtureTwoWithoutCategory = fixtureTwo;
+  fixtureTwoWithoutCategory.category.clear();
+  fixtureTwoWithoutCategory.categorySource.clear();
+  scene2.fixtures[fixtureTwoWithoutCategory.uuid] = fixtureTwoWithoutCategory;
 
   const std::filesystem::path noCategoryMvrPath = tempDir / "fixture_no_category.mvr";
   assert(exporter.ExportToFile(noCategoryMvrPath.string()));
@@ -83,6 +100,7 @@ int main() {
   assert(importer.ImportFromFile(noCategoryMvrPath.string(), false, false));
   const auto &loadedNoCategory = cfg.GetScene().fixtures;
   assert(loadedNoCategory.at("fx1").category == "Spot");
+  assert(loadedNoCategory.at("fx2").category == "Spot");
 
   std::filesystem::remove_all(tempDir);
   std::filesystem::remove(ProjectUtils::GetDefaultLibraryPath("fixtures") +

--- a/tests/riderimporter_stubs.cpp
+++ b/tests/riderimporter_stubs.cpp
@@ -33,10 +33,13 @@ std::string ExtractPdfText(const std::string &) { return {}; }
 
 namespace GdtfDictionary {
 std::optional<std::unordered_map<std::string, Entry>> Load() { return std::unordered_map<std::string, Entry>(); }
-void Save(const std::unordered_map<std::string, Entry> &) {}
+bool Save(const std::unordered_map<std::string, Entry> &, std::string *) { return true; }
 std::optional<Entry> Get(const std::string &) { return std::nullopt; }
 void Update(const std::string &, const std::string &, const std::string &, const std::string &) {}
 void UpdateCategory(const std::string &, const std::string &) {}
+void UpdateCategoriesBulk(const std::unordered_map<std::string, std::string> &) {}
+size_t GetSaveCallCountForTesting() { return 0; }
+void ResetSaveCallCountForTesting() {}
 }
 
 namespace TrussDictionary {

--- a/tests/save_load_roundtrip_test.cpp
+++ b/tests/save_load_roundtrip_test.cpp
@@ -72,6 +72,19 @@ int main() {
     assert(textOnlyEntry.has_value());
     assert(textOnlyEntry->category == "Spot");
     assert(textOnlyEntry->path.empty());
+    std::unordered_map<std::string, GdtfDictionary::Entry> categoryPropagationDict;
+    categoryPropagationDict["Type A"] = {
+        (tempDir / "shared.gdtf").string(), "Mode A", "OldA", "", "", ""};
+    categoryPropagationDict["Type B"] = {
+        (tempDir / "subdir" / "shared.gdtf").string(), "Mode B", "OldB", "", "", ""};
+    assert(GdtfDictionary::Save(categoryPropagationDict));
+    GdtfDictionary::UpdateCategoriesBulk({{"Type A", "Wash"}});
+    const auto categoryPropagationA = GdtfDictionary::Get("Type A");
+    const auto categoryPropagationB = GdtfDictionary::Get("Type B");
+    assert(categoryPropagationA.has_value());
+    assert(categoryPropagationB.has_value());
+    assert(categoryPropagationA->category == "Wash");
+    assert(categoryPropagationB->category == "Wash");
 
     Fixture f; f.uuid = "fx1"; f.instanceName = "Fixture"; f.layer = layer.name; f.typeName = "FixtureType"; f.gdtfSpec = "orig.gdtf"; f.color = "#445566"; f.fixtureIdText = "S101A"; f.fixtureIdNumeric = 101; f.fixtureId = 101; scene.fixtures[f.uuid] = f;
     Fixture f2; f2.uuid = "fx2"; f2.instanceName = "Fixture 2"; f2.layer = layer.name; f2.typeName = "FixtureType"; f2.gdtfSpec = "orig.gdtf"; f2.fixtureIdText = "S101B"; f2.fixtureIdNumeric = 101; f2.fixtureId = 101; scene.fixtures[f2.uuid] = f2;


### PR DESCRIPTION
### Motivation
- Reduce repeated dictionary writes during MVR import by batching manual fixture category updates and keep final category propagation semantics unchanged.

### Description
- In `mvr/mvrimporter.cpp` replaced per-fixture `GdtfDictionary::UpdateCategory(...)` calls with an in-memory accumulator `pendingCategoryUpdatesByType` and call `GdtfDictionary::UpdateCategoriesBulk(...)` once after the category pass.
- Added `GdtfDictionary::UpdateCategoriesBulk(...)` and a shared helper `ApplyCategoryUpdateForFile(...)` in `core/gdtfdictionary.{h,cpp}` to apply updates in-memory and preserve the existing propagation-by-path/file-name behavior.
- Added test instrumentation (`GetSaveCallCountForTesting()` / `ResetSaveCallCountForTesting()`) and increment the counter inside `Save()` to allow verifying the number of physical writes.
- Updated tests and stubs: `tests/mvr_fixture_category_roundtrip_test.cpp` now validates multiple fixtures and asserts a single dictionary write per import; `tests/save_load_roundtrip_test.cpp` validates propagation behavior for same-family fixtures; `tests/riderimporter_stubs.cpp` updated to match the new dictionary API.

### Testing
- Ran `bash tests/check_perastage_tree_modules.sh` and it passed.
- Ran `bash tests/check_no_configmanager_get_in_gui.sh` and it passed.
- Attempted `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` but configuration failed in this environment due to missing `wxWidgets` development packages (environment dependency, not a code failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea41053e388324ae72dd334bccdb7f)