### PR TITLE
Cache GDTF category inference by resolved path

### DIFF
--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -1609,6 +1609,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
   std::unordered_map<std::string, std::vector<std::string>> gdtfModesCache;
   std::unordered_map<std::string, std::unordered_map<std::string, int>>
       gdtfModeChannelCountCache;
+  std::unordered_map<std::string, GdtfFixtureCategory::InferenceResult>
+      categoryInferenceByResolvedPath;
   const std::string kEmptyResolvedPath;
   auto resolveGdtfPathCached = [&](const std::string &spec) -> const std::string & {
     const std::string normalized = NormalizeArchivePathValue(spec);
@@ -3531,8 +3533,29 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
     }
 
     if (fixture.category.empty() && !fixture.gdtfSpec.empty()) {
-      const auto inferred = GdtfFixtureCategory::InferFromGdtf(
-          ResolveScenePathForRead(scene.basePath, fixture.gdtfSpec));
+      std::string resolvedCategoryPath = resolveFixtureGdtfPathForRead(fixture.gdtfSpec);
+      if (!resolvedCategoryPath.empty()) {
+        resolvedCategoryPath =
+            ResolveScenePathForRead(scene.basePath, resolvedCategoryPath);
+      } else {
+        resolvedCategoryPath =
+            ResolveScenePathForRead(scene.basePath, fixture.gdtfSpec);
+      }
+
+      GdtfFixtureCategory::InferenceResult inferred;
+      if (!resolvedCategoryPath.empty()) {
+        auto inferenceCacheIt =
+            categoryInferenceByResolvedPath.find(resolvedCategoryPath);
+        if (inferenceCacheIt != categoryInferenceByResolvedPath.end()) {
+          inferred = inferenceCacheIt->second;
+        } else {
+          inferred = GdtfFixtureCategory::InferFromGdtf(resolvedCategoryPath);
+          categoryInferenceByResolvedPath.emplace(resolvedCategoryPath, inferred);
+        }
+      } else {
+        inferred = GdtfFixtureCategory::InferFromGdtf(resolvedCategoryPath);
+      }
+
       fixture.category = GdtfFixtureCategory::NormalizeCategory(inferred.category);
       if (fixture.category.empty())
         fixture.category = GdtfFixtureCategory::kUnknown;


### PR DESCRIPTION
### Motivation
- Avoid repeated expensive calls to `GdtfFixtureCategory::InferFromGdtf` by reusing inference results for the same canonical GDTF path.
- Ensure category inference uses a stable, canonical read path so equivalent specs (archive remaps / scene-relative) share a cached result.

### Description
- Added `std::unordered_map<std::string, GdtfFixtureCategory::InferenceResult> categoryInferenceByResolvedPath` in `mvr/mvrimporter.cpp` alongside existing GDTF caches.
- Compute a canonical path before inference using `resolveFixtureGdtfPathForRead(...)` plus `ResolveScenePathForRead(...)` with a fallback to `ResolveScenePathForRead(scene.basePath, fixture.gdtfSpec)`.
- Reuse a cached `InferenceResult` when available, otherwise call `GdtfFixtureCategory::InferFromGdtf(...)`, store the result in the cache, and apply it to the fixture while preserving existing normalization and fallback behavior.

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea43cdd4c4832486399c519b71d771)