### PR TITLE
Aggregate MVR fixture category fallback telemetry

### DIFF
--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -3494,6 +3494,9 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
   reportProgress("Applying fixture categories...");
   const int totalFixturesForCategoryApply = static_cast<int>(scene.fixtures.size());
   int appliedFixturesForCategoryApply = 0;
+  int autoFallbackAppliedCount = 0;
+  std::unordered_map<std::string, int> autoFallbackReasons;
+  std::unordered_map<std::string, int> autoFallbackCategories;
   categoryByTypeKey.clear();
   std::unordered_map<std::string, std::string> pendingCategoryUpdatesByType;
   for (auto &[uid, fixture] : scene.fixtures) {
@@ -3561,11 +3564,14 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         fixture.category = GdtfFixtureCategory::kUnknown;
       fixture.categorySource = GdtfFixtureCategory::kAutoFallbackSource;
       fixture.categorySourceReason = inferred.reason;
+      ++autoFallbackAppliedCount;
+      ++autoFallbackReasons[inferred.reason.empty() ? "unknown" : inferred.reason];
+      ++autoFallbackCategories[fixture.category];
       if (!categoryKey.empty()) {
         categoryByTypeKey[categoryKey] =
             {fixture.category, fixture.categorySource, inferred.reason};
       }
-      LogMessage(Logger::Level::Info,
+      LogMessage(Logger::Level::Debug,
                  "Auto category fallback: " + fixture.instanceName + " -> " +
                      fixture.category + " [" + inferred.reason + "]");
     } else if (!fixture.category.empty() && !categoryKey.empty()) {
@@ -3582,6 +3588,32 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
       pendingCategoryUpdatesByType[fixture.typeName] = fixture.category;
     }
   }
+  auto formatBreakdown = [](const std::unordered_map<std::string, int> &counts) {
+    if (counts.empty())
+      return std::string("none");
+    std::vector<std::pair<std::string, int>> sortedCounts(counts.begin(), counts.end());
+    std::sort(sortedCounts.begin(), sortedCounts.end(),
+              [](const auto &lhs, const auto &rhs) {
+                if (lhs.second != rhs.second)
+                  return lhs.second > rhs.second;
+                return lhs.first < rhs.first;
+              });
+
+    std::ostringstream oss;
+    bool first = true;
+    for (const auto &[label, count] : sortedCounts) {
+      if (!first)
+        oss << ", ";
+      first = false;
+      oss << label << "=" << count;
+    }
+    return oss.str();
+  };
+  LogMessage(Logger::Level::Info,
+             "Auto category fallback applied to " +
+                 std::to_string(autoFallbackAppliedCount) + " fixtures; reasons: " +
+                 formatBreakdown(autoFallbackReasons) + "; categories: " +
+                 formatBreakdown(autoFallbackCategories));
   GdtfDictionary::UpdateCategoriesBulk(pendingCategoryUpdatesByType);
 
   reportProgress("Building fixtures, trusses, and objects...");


### PR DESCRIPTION
### Motivation
- Reduce noisy per-fixture `Info` logs in the "Applying fixture categories..." loop and provide concise aggregated telemetry (counts by reason and by resulting category).
- Preserve full traceability behind a higher-verbosity channel so detailed diagnostics remain available without spamming `Info` logs.
- The change is telemetry-only and must not alter category assignment behavior or caching logic.
- Note: `mvr/mvrimporter.cpp` is a large file; consider extracting telemetry/metrics helpers (e.g. a small `mvr/telemetry_*` helper) in a follow-up to keep responsibilities modular.

### Description
- Added integer counter `autoFallbackAppliedCount` and maps `autoFallbackReasons` and `autoFallbackCategories` to accumulate telemetry during the auto-fallback branch.  
- Switched per-fixture `LogMessage(Logger::Level::Info, ...)` to `LogMessage(Logger::Level::Debug, ...)` so detailed per-fixture messages are available under debug verbosity only.  
- Added a single `Info` summary after the loop with total auto-fallback count and sorted breakdowns for reasons and categories using a `formatBreakdown` lambda that returns `none` when empty.  
- Kept all category assignment, normalization, source/reason propagation, and caching logic unchanged; only logging/telemetry was modified.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.  
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea4900c27c83249eeb6a9a19b566bd)