### PR TITLE
Migrate fixture label overrides when MVR import remaps fixture UUIDs

### DIFF
--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -36,6 +36,7 @@
 #include "groupobject.h"
 #include "uuidutils.h"
 #include "trussloader.h"
+#include "fixture_label_overrides.h"
 
 #include "consolepanel.h"
 #ifdef PERASTAGE_ENABLE_MVR_GDTF_DOWNLOAD_API
@@ -1084,6 +1085,7 @@ bool MvrImporter::ImportFromFile(const std::string &filePath,
   };
 
   pathRemap.clear();
+  fixtureUuidRemap.clear();
   // Treat the incoming path as UTF-8 to preserve any non-ASCII characters
   fs::path path = fs::u8path(filePath);
 
@@ -1932,8 +1934,13 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                          const std::string &layerName,
                          const Matrix &nodeTransform) {
         Fixture fixture;
+        const char *rawUuidAttr = node->Attribute("uuid");
+        const std::string rawFixtureUuid =
+            rawUuidAttr ? Trim(rawUuidAttr) : std::string{};
         fixture.uuid =
             resolveStableUuid("Fixture", node, layerName, nodeTransform);
+        if (!rawFixtureUuid.empty() && rawFixtureUuid != fixture.uuid)
+          fixtureUuidRemap[rawFixtureUuid] = fixture.uuid;
         fixture.layer = layerName;
         fixture.transform = nodeTransform;
 
@@ -3718,6 +3725,22 @@ bool MvrImporter::ImportAndRegister(const std::string &filePath,
                                     bool applyDictionary,
                                     ProgressCallback progressCallback) {
   MvrImporter importer;
-  return importer.ImportFromFile(filePath, promptConflicts, applyDictionary,
-                                 progressCallback);
+  const bool imported = importer.ImportFromFile(
+      filePath, promptConflicts, applyDictionary, progressCallback);
+  if (!imported)
+    return false;
+
+  size_t collisionCount = 0;
+  const size_t migratedCount = viewer2d::RemapFixtureLabelOverrideKeys(
+      ConfigManager::Get(), importer.fixtureUuidRemap, &collisionCount);
+  if (!importer.fixtureUuidRemap.empty()) {
+    std::ostringstream oss;
+    oss << "MVR import fixture label override migration: remapped "
+        << migratedCount << " fixture override entries from "
+        << importer.fixtureUuidRemap.size() << " fixture UUID changes";
+    if (collisionCount > 0)
+      oss << " (" << collisionCount << " collisions skipped)";
+    LogMessage(Logger::Level::Info, oss.str());
+  }
+  return true;
 }

--- a/mvr/mvrimporter.h
+++ b/mvr/mvrimporter.h
@@ -53,6 +53,7 @@ public:
 
 private:
     std::unordered_map<std::string, std::string> pathRemap;
+    std::unordered_map<std::string, std::string> fixtureUuidRemap;
 
     // Creates a temporary directory for extracting the contents of the MVR archive
     std::string CreateTemporaryDirectory();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -270,6 +270,7 @@ add_executable(save_load_roundtrip_test save_load_roundtrip_test.cpp
                ../core/uuidutils.cpp
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
+               ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
                ../mvr/primitive_model_resources.cpp
                ../core/gdtf_mutation_audit.cpp
@@ -302,6 +303,7 @@ add_executable(project_support_userdata_roundtrip_test project_support_userdata_
                ../core/uuidutils.cpp
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
+               ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
                ../mvr/primitive_model_resources.cpp
                ../core/gdtf_mutation_audit.cpp
@@ -359,6 +361,7 @@ add_executable(rider_truss_dictionary_normalization_test
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
+               ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
                ../mvr/primitive_model_resources.cpp
                ../core/gdtf_mutation_audit.cpp
@@ -390,6 +393,7 @@ add_executable(mvr_dmx_address_test mvr_dmx_address_test.cpp
                ../core/uuidutils.cpp
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
+               ../viewer2d/fixture_label_overrides.cpp
                ../core/logger.cpp
                gdtfloader_stub.cpp
                consolepanel_stub.cpp
@@ -420,6 +424,7 @@ add_executable(mvr_support_userdata_roundtrip_test mvr_support_userdata_roundtri
                ../core/uuidutils.cpp
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
+               ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
                ../mvr/primitive_model_resources.cpp
                ../core/gdtf_mutation_audit.cpp
@@ -453,6 +458,7 @@ add_executable(mvr_fixture_category_roundtrip_test mvr_fixture_category_roundtri
                ../core/uuidutils.cpp
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
+               ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
                ../mvr/primitive_model_resources.cpp
                ../core/gdtf_mutation_audit.cpp
@@ -485,6 +491,7 @@ add_executable(mvr_truss_roundtrip_structure_test mvr_truss_roundtrip_structure_
                ../core/uuidutils.cpp
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
+               ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
                ../mvr/primitive_model_resources.cpp
                ../core/gdtf_mutation_audit.cpp
@@ -517,6 +524,7 @@ add_executable(mvr_exporter_compliance_test mvr_exporter_compliance_test.cpp
                ../core/uuidutils.cpp
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
+               ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
                ../mvr/primitive_model_resources.cpp
                ../core/gdtf_mutation_audit.cpp
@@ -557,6 +565,7 @@ add_executable(rider_save_roundtrip_test rider_save_roundtrip_test.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
+               ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
                ../mvr/primitive_model_resources.cpp
                ../core/gdtf_mutation_audit.cpp
@@ -1068,6 +1077,7 @@ add_executable(symbol_fixture_applier_gdtf_test symbol_fixture_applier_gdtf_test
                ../viewer3d/loaderglb.cpp
                ../viewer3d/meshprimitives.cpp
                ../mvr/mvrimporter.cpp
+               ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
                ../mvr/primitive_model_resources.cpp
                ../core/gdtf_mutation_audit.cpp
@@ -1105,6 +1115,7 @@ add_executable(mvr_patched_gdtf_export_test mvr_patched_gdtf_export_test.cpp
                ../viewer3d/loaderglb.cpp
                ../viewer3d/meshprimitives.cpp
                ../mvr/mvrimporter.cpp
+               ../viewer2d/fixture_label_overrides.cpp
                consolepanel_stub.cpp
                ${LAYOUT_SOURCES})
 target_include_directories(mvr_patched_gdtf_export_test PRIVATE

--- a/tests/save_load_roundtrip_test.cpp
+++ b/tests/save_load_roundtrip_test.cpp
@@ -28,6 +28,8 @@
 #include "sceneobject.h"
 #include "layer.h"
 #include "support.h"
+#include "fixture_label_overrides.h"
+#include "uuidutils.h"
 
 int main() {
     wxInitializer initializer;
@@ -88,6 +90,9 @@ int main() {
 
     Fixture f; f.uuid = "fx1"; f.instanceName = "Fixture"; f.layer = layer.name; f.typeName = "FixtureType"; f.gdtfSpec = "orig.gdtf"; f.color = "#445566"; f.fixtureIdText = "S101A"; f.fixtureIdNumeric = 101; f.fixtureId = 101; scene.fixtures[f.uuid] = f;
     Fixture f2; f2.uuid = "fx2"; f2.instanceName = "Fixture 2"; f2.layer = layer.name; f2.typeName = "FixtureType"; f2.gdtfSpec = "orig.gdtf"; f2.fixtureIdText = "S101B"; f2.fixtureIdNumeric = 101; f2.fixtureId = 101; scene.fixtures[f2.uuid] = f2;
+    const std::string nonCanonicalFixtureUuid = "A0B1C2D3-E4F5-4678-9ABC-DEF012345678";
+    Fixture f3; f3.uuid = nonCanonicalFixtureUuid; f3.instanceName = "Fixture 3"; f3.layer = layer.name; f3.typeName = "FixtureType"; f3.gdtfSpec = "orig.gdtf"; f3.fixtureIdText = "S101C"; f3.fixtureIdNumeric = 101; f3.fixtureId = 101; scene.fixtures[f3.uuid] = f3;
+    viewer2d::ApplyShowLabelNameOverride(cfg, {nonCanonicalFixtureUuid}, 0, true);
     Truss t; t.uuid = "tr1"; t.name = "Truss"; t.layer = layer.name; scene.trusses[t.uuid] = t;
     SceneObject o; o.uuid = "obj1"; o.name = "Object"; o.layer = layer.name; scene.sceneObjects[o.uuid] = o;
     SceneObject cylinderObj;
@@ -131,7 +136,7 @@ int main() {
     assert(cfg.LoadProject(temp.string()));
 
     const auto &scene2 = cfg.GetScene();
-    assert(scene2.fixtures.size() == 2);
+    assert(scene2.fixtures.size() == 3);
     assert(scene2.trusses.size() == 1);
     assert(scene2.sceneObjects.size() == 3);
     assert(scene2.supports.size() == 2);
@@ -152,6 +157,14 @@ int main() {
     assert(scene2.fixtures.at("fx1").fixtureIdNumeric == 101);
     assert(scene2.fixtures.at("fx2").fixtureIdText == "S101B");
     assert(scene2.fixtures.at("fx2").fixtureIdNumeric == 101);
+    const std::string canonicalFixtureUuid = CanonicalizeUuid(nonCanonicalFixtureUuid);
+    assert(!canonicalFixtureUuid.empty());
+    assert(scene2.fixtures.count(canonicalFixtureUuid) == 1);
+    const auto fixtureOverrides = viewer2d::LoadFixtureLabelOverrides(cfg);
+    assert(fixtureOverrides.count(canonicalFixtureUuid) == 1);
+    const auto &fixture3Override = fixtureOverrides.at(canonicalFixtureUuid);
+    assert(fixture3Override.showLabelName[0].has_value());
+    assert(*fixture3Override.showLabelName[0]);
     assert(scene2.layers.at("layer1").color == "#112233");
 
     const auto &loadedManual = scene2.supports.at("sup-manual");

--- a/viewer2d/fixture_label_overrides.cpp
+++ b/viewer2d/fixture_label_overrides.cpp
@@ -91,6 +91,49 @@ bool FixtureLabelOverride::HasAnyValue() const {
          labelFontSizeId.has_value() || labelFontSizeDmx.has_value();
 }
 
+size_t RemapFixtureLabelOverrideKeys(
+    ConfigManager &cfg,
+    const std::unordered_map<std::string, std::string> &fixtureUuidRemap,
+    size_t *collisionCount) {
+  if (collisionCount)
+    *collisionCount = 0;
+  if (fixtureUuidRemap.empty())
+    return 0;
+
+  auto overrides = LoadFixtureLabelOverrides(cfg);
+  if (overrides.empty())
+    return 0;
+
+  size_t migratedCount = 0;
+  std::vector<std::pair<std::string, std::string>> remapPairs(
+      fixtureUuidRemap.begin(), fixtureUuidRemap.end());
+  std::sort(remapPairs.begin(), remapPairs.end(),
+            [](const auto &lhs, const auto &rhs) { return lhs.first < rhs.first; });
+
+  for (const auto &[oldUuid, newUuid] : remapPairs) {
+    if (oldUuid.empty() || newUuid.empty() || oldUuid == newUuid)
+      continue;
+
+    auto sourceIt = overrides.find(oldUuid);
+    if (sourceIt == overrides.end())
+      continue;
+
+    if (overrides.contains(newUuid)) {
+      if (collisionCount)
+        ++(*collisionCount);
+      continue;
+    }
+
+    overrides.emplace(newUuid, sourceIt->second);
+    overrides.erase(sourceIt);
+    ++migratedCount;
+  }
+
+  if (migratedCount > 0)
+    SaveFixtureLabelOverrides(cfg, overrides);
+  return migratedCount;
+}
+
 FixtureLabelOverrideMap LoadFixtureLabelOverrides(const ConfigManager &cfg) {
   FixtureLabelOverrideMap overrides;
   const auto raw = cfg.GetValue(kFixtureOverridesKey);

--- a/viewer2d/fixture_label_overrides.h
+++ b/viewer2d/fixture_label_overrides.h
@@ -26,6 +26,11 @@ struct FixtureLabelOverride {
 using FixtureLabelOverrideMap =
     std::unordered_map<std::string, FixtureLabelOverride>;
 
+size_t RemapFixtureLabelOverrideKeys(
+    ConfigManager &cfg,
+    const std::unordered_map<std::string, std::string> &fixtureUuidRemap,
+    size_t *collisionCount = nullptr);
+
 FixtureLabelOverrideMap LoadFixtureLabelOverrides(const ConfigManager &cfg);
 void SaveFixtureLabelOverrides(ConfigManager &cfg,
                                const FixtureLabelOverrideMap &overrides);


### PR DESCRIPTION
### Motivation
- Preserve per-fixture label overrides stored under the `label_fixture_overrides` config key when an MVR import canonicalizes or deterministically remaps fixture UUIDs (old -> new).  
- Avoid silently losing user overrides after import when imported fixture UUID strings change due to canonicalization or controlled fallback.

### Description
- Track fixture UUID remaps during import by adding `fixtureUuidRemap` to `MvrImporter` and recording `rawUuid -> resolvedStableUuid` when a fixture's original UUID differs from the final stable UUID.  
- Add `viewer2d::RemapFixtureLabelOverrideKeys(ConfigManager&, const std::unordered_map<std::string,std::string>&, size_t*)` which remaps keys in the `label_fixture_overrides` JSON using the provided map, preserves existing destination entries, skips collisions, and returns the number of migrated entries.  
- Invoke the migration after a successful `ImportFromFile` in `MvrImporter::ImportAndRegister` and log a diagnostic line with counts of remaps, migrated override entries, and skipped collisions.  
- Make migration a no-op when there is no remap map or when there are no overrides to migrate.  
- Add a regression case in `tests/save_load_roundtrip_test.cpp` that creates a fixture with a non-canonical UUID and an individual override, then `SaveProject`/`LoadProject` and asserts the override is still applied to the fixture's canonical UUID; and update `tests/CMakeLists.txt` to compile `viewer2d/fixture_label_overrides.cpp` into tests that build `mvrimporter.cpp`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.  
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.  
- Attempted to run a CMake configure (`cmake --preset wsl-x64-debug`) in this environment but it failed due to missing system `wxWidgets` development files, so full test build/exec could not be completed here.  
- The new regression test was added to `save_load_roundtrip_test` and test CMake targets were updated so it will be built/run by CI when the build deps are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea4ca08e4883248b5baf77c1720fc1)