### PR TITLE
Fix GDTF mode channel count to use DMX footprint

### DIFF
--- a/tests/gdtfloader_channel_modes_test.cpp
+++ b/tests/gdtfloader_channel_modes_test.cpp
@@ -43,6 +43,13 @@ std::string MakeGdtf()
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
         "<GDTF DataVersion=\"1.2\">"
         "<FixtureType Name=\"ModeSummaryFixture\">"
+        "<Geometries>"
+        "<Geometry Name=\"Base\">"
+        "<GeometryReference Name=\"Set 1\" Geometry=\"Pixel\"><Break DMXBreak=\"1\" DMXOffset=\"5\"/></GeometryReference>"
+        "<GeometryReference Name=\"Set 2\" Geometry=\"Pixel\"><Break DMXBreak=\"1\" DMXOffset=\"15\"/></GeometryReference>"
+        "</Geometry>"
+        "<Beam Name=\"Pixel\"/>"
+        "</Geometries>"
         "<DMXModes>"
         "<DMXMode Name=\"Standard\">"
         "<DMXChannels>"
@@ -71,6 +78,12 @@ std::string MakeGdtf()
         "<DMXChannel Offset=\"None\">"
         "<LogicalChannel Attribute=\"Dimmer\"/>"
         "</DMXChannel>"
+        "</DMXChannels>"
+        "</DMXMode>"
+        "<DMXMode Name=\"GeometryExpanded\" Geometry=\"Base\">"
+        "<DMXChannels>"
+        "<DMXChannel Offset=\"1\" Geometry=\"Pixel\"><LogicalChannel Attribute=\"ColorAdd_R\"/></DMXChannel>"
+        "<DMXChannel Offset=\"2\" Geometry=\"Pixel\"><LogicalChannel Attribute=\"ColorAdd_G\"/></DMXChannel>"
         "</DMXChannels>"
         "</DMXMode>"
         "</DMXModes>"
@@ -104,6 +117,15 @@ int main()
     const std::string& dedicatedSummary = channels[1].function;
     assert(dedicatedSummary.find("Gobo2PosRotate") != std::string::npos);
     assert(dedicatedSummary.find("mode master: Gobo2 128-255") != std::string::npos);
+
+    const std::vector<GdtfChannelInfo> expandedChannels =
+        GetGdtfModeChannels(gdtfPath, "GeometryExpanded");
+    assert(GetGdtfModeChannelCount(gdtfPath, "GeometryExpanded") == 16);
+    assert(expandedChannels.size() == 4);
+    assert(expandedChannels[0].channel == 5);
+    assert(expandedChannels[1].channel == 6);
+    assert(expandedChannels[2].channel == 15);
+    assert(expandedChannels[3].channel == 16);
 
     std::error_code ec;
     std::filesystem::remove(gdtfPath, ec);

--- a/tests/gdtfloader_channel_modes_test.cpp
+++ b/tests/gdtfloader_channel_modes_test.cpp
@@ -65,6 +65,9 @@ std::string MakeGdtf()
         "ModeMaster=\"Gobo2Rotate\" ModeFrom=\"128/1\" ModeTo=\"255/1\"/>"
         "</LogicalChannel>"
         "</DMXChannel>"
+        "<DMXChannel Offset=\"5\">"
+        "<LogicalChannel Attribute=\"Prism1\"/>"
+        "</DMXChannel>"
         "<DMXChannel Offset=\"None\">"
         "<LogicalChannel Attribute=\"Dimmer\"/>"
         "</DMXChannel>"
@@ -85,12 +88,13 @@ int main()
     const std::string gdtfPath = MakeGdtf();
     const std::vector<GdtfChannelInfo> channels =
         GetGdtfModeChannels(gdtfPath, "Standard");
-    assert(GetGdtfModeChannelCount(gdtfPath, "Standard") == 2);
-    assert(channels.size() == 3);
+    assert(GetGdtfModeChannelCount(gdtfPath, "Standard") == 5);
+    assert(channels.size() == 4);
     assert(channels[0].channel == 1);
     assert(channels[1].channel == 2);
-    assert(channels[2].isVirtual);
-    assert(channels[2].channel == 0);
+    assert(channels[2].channel == 5);
+    assert(channels[3].isVirtual);
+    assert(channels[3].channel == 0);
 
     const std::string& goboSummary = channels[0].function;
     assert(goboSummary.find("Gobo2") != std::string::npos);

--- a/viewer3d/gdtfloader.cpp
+++ b/viewer3d/gdtfloader.cpp
@@ -493,7 +493,7 @@ static void ParseModes(tinyxml2::XMLElement* ft,
         modes.push_back(name);
 
         std::vector<GdtfChannelInfo> channelsVec;
-        int count = 0;
+        int footprint = 0;
         if (tinyxml2::XMLElement* channels = m->FirstChildElement("DMXChannels")) {
             auto trim = [](std::string& value) {
                 value.erase(0, value.find_first_not_of(" \t\r\n"));
@@ -753,7 +753,8 @@ static void ParseModes(tinyxml2::XMLElement* ft,
                         if (!info.function.empty() && i > 0)
                             info.function += suffixForByte(i);
                         channelsVec.push_back(std::move(info));
-                        ++count;
+                        if (offsets[i] > footprint)
+                            footprint = offsets[i];
                     }
                     continue;
                 }
@@ -767,7 +768,7 @@ static void ParseModes(tinyxml2::XMLElement* ft,
         }
 
         modeChannels.emplace(name, std::move(channelsVec));
-        modeChannelCounts[name] = count;
+        modeChannelCounts[name] = footprint;
     }
 }
 

--- a/viewer3d/gdtfloader.cpp
+++ b/viewer3d/gdtfloader.cpp
@@ -483,6 +483,84 @@ static void ParseModes(tinyxml2::XMLElement* ft,
     tinyxml2::XMLElement* modesNode = ft->FirstChildElement("DMXModes");
     if (!modesNode)
         return;
+    tinyxml2::XMLElement* geometriesNode = ft->FirstChildElement("Geometries");
+
+    auto parseIntAttribute = [](tinyxml2::XMLElement* element,
+                                const char* attributeName,
+                                int fallback) {
+        if (!element || !attributeName)
+            return fallback;
+        int parsed = fallback;
+        const char* raw = element->Attribute(attributeName);
+        if (!raw)
+            return fallback;
+        if (!TryParseInt(raw, parsed))
+            return fallback;
+        return parsed;
+    };
+    auto collectGeometryReferenceOffsets =
+        [&](const std::string& modeRootGeometryName) {
+            std::unordered_map<std::string, std::vector<int>> offsetsByGeometry;
+            if (!geometriesNode || modeRootGeometryName.empty())
+                return offsetsByGeometry;
+
+            auto findGeometryByName =
+                [&](auto&& self, tinyxml2::XMLElement* node,
+                    const std::string& wantedName) -> tinyxml2::XMLElement* {
+                    if (!node)
+                        return nullptr;
+                    const char* name = node->Attribute("Name");
+                    if (name && wantedName == name)
+                        return node;
+                    for (tinyxml2::XMLElement* child = node->FirstChildElement();
+                         child; child = child->NextSiblingElement()) {
+                        if (tinyxml2::XMLElement* found = self(self, child, wantedName))
+                            return found;
+                    }
+                    return nullptr;
+                };
+
+            tinyxml2::XMLElement* modeRootGeometry = nullptr;
+            for (tinyxml2::XMLElement* geometry = geometriesNode->FirstChildElement();
+                 geometry && !modeRootGeometry;
+                 geometry = geometry->NextSiblingElement()) {
+                modeRootGeometry = findGeometryByName(findGeometryByName, geometry,
+                                                      modeRootGeometryName);
+            }
+            if (!modeRootGeometry)
+                return offsetsByGeometry;
+
+            auto walkGeometry =
+                [&](auto&& self, tinyxml2::XMLElement* node) -> void {
+                    if (!node)
+                        return;
+
+                    if (std::string(node->Name()) == "GeometryReference") {
+                        const char* referencedGeometry = node->Attribute("Geometry");
+                        if (referencedGeometry && *referencedGeometry) {
+                            std::vector<int>& shifts =
+                                offsetsByGeometry[referencedGeometry];
+                            bool hadBreak = false;
+                            for (tinyxml2::XMLElement* br = node->FirstChildElement("Break");
+                                 br; br = br->NextSiblingElement("Break")) {
+                                hadBreak = true;
+                                int dmxOffset = parseIntAttribute(br, "DMXOffset", 1);
+                                shifts.push_back(std::max(0, dmxOffset - 1));
+                            }
+                            if (!hadBreak)
+                                shifts.push_back(0);
+                        }
+                    }
+
+                    for (tinyxml2::XMLElement* child = node->FirstChildElement();
+                         child; child = child->NextSiblingElement()) {
+                        self(self, child);
+                    }
+                };
+
+            walkGeometry(walkGeometry, modeRootGeometry);
+            return offsetsByGeometry;
+        };
 
     for (tinyxml2::XMLElement* m = modesNode->FirstChildElement("DMXMode");
          m; m = m->NextSiblingElement("DMXMode"))
@@ -491,6 +569,10 @@ static void ParseModes(tinyxml2::XMLElement* ft,
         if (!name)
             continue;
         modes.push_back(name);
+        const std::string modeRootGeometryName =
+            m->Attribute("Geometry") ? m->Attribute("Geometry") : "";
+        const std::unordered_map<std::string, std::vector<int>> geometryOffsetShifts =
+            collectGeometryReferenceOffsets(modeRootGeometryName);
 
         std::vector<GdtfChannelInfo> channelsVec;
         int footprint = 0;
@@ -744,17 +826,38 @@ static void ParseModes(tinyxml2::XMLElement* ft,
             {
                 const std::vector<int> offsets = parseOffsets(c->Attribute("Offset"));
                 const std::string baseFunction = buildFunctionSummary(c);
+                const std::string geometryName =
+                    c->Attribute("Geometry") ? c->Attribute("Geometry") : "";
+
+                auto emitChannelByte = [&](int channelNumber, size_t byteIndex) {
+                    if (channelNumber <= 0)
+                        return;
+                    GdtfChannelInfo info;
+                    info.channel = channelNumber;
+                    info.function = baseFunction;
+                    if (!info.function.empty() && byteIndex > 0)
+                        info.function += suffixForByte(byteIndex);
+                    channelsVec.push_back(std::move(info));
+                    if (channelNumber > footprint)
+                        footprint = channelNumber;
+                };
 
                 if (!offsets.empty()) {
-                    for (size_t i = 0; i < offsets.size(); ++i) {
-                        GdtfChannelInfo info;
-                        info.channel = offsets[i];
-                        info.function = baseFunction;
-                        if (!info.function.empty() && i > 0)
-                            info.function += suffixForByte(i);
-                        channelsVec.push_back(std::move(info));
-                        if (offsets[i] > footprint)
-                            footprint = offsets[i];
+                    bool expandedWithGeometryReference = false;
+                    auto geometryShiftIt = geometryOffsetShifts.find(geometryName);
+                    if (!geometryName.empty() &&
+                        geometryShiftIt != geometryOffsetShifts.end() &&
+                        !geometryShiftIt->second.empty()) {
+                        expandedWithGeometryReference = true;
+                        for (int shift : geometryShiftIt->second) {
+                            for (size_t i = 0; i < offsets.size(); ++i)
+                                emitChannelByte(offsets[i] + shift, i);
+                        }
+                    }
+
+                    if (!expandedWithGeometryReference) {
+                        for (size_t i = 0; i < offsets.size(); ++i)
+                            emitChannelByte(offsets[i], i);
                     }
                     continue;
                 }
@@ -766,6 +869,13 @@ static void ParseModes(tinyxml2::XMLElement* ft,
                 channelsVec.push_back(std::move(info));
             }
         }
+
+        std::stable_sort(channelsVec.begin(), channelsVec.end(),
+                         [](const GdtfChannelInfo& lhs, const GdtfChannelInfo& rhs) {
+                             if (lhs.isVirtual != rhs.isVirtual)
+                                 return !lhs.isVirtual;
+                             return lhs.channel < rhs.channel;
+                         });
 
         modeChannels.emplace(name, std::move(channelsVec));
         modeChannelCounts[name] = footprint;

--- a/viewer3d/gdtfloader.h
+++ b/viewer3d/gdtfloader.h
@@ -82,10 +82,9 @@ bool LoadGdtfGeometryTree(const std::string& gdtfPath,
                           GdtfGeometryTree& outTree,
                           std::string* outError = nullptr);
 
-// Returns the number of DMX addresses used by the given mode in a GDTF file.
-// Channels using more than one byte contribute multiple addresses to this
-// count. Returns -1 when the mode cannot be found or the file cannot be
-// parsed.
+// Returns the DMX footprint (highest occupied offset) of the given mode in a
+// GDTF file for DMX break 1 style addressing. Returns -1 when the mode cannot
+// be found or the file cannot be parsed.
 int GetGdtfModeChannelCount(const std::string& gdtfPath,
                             const std::string& modeName);
 


### PR DESCRIPTION
### Motivation
- GDTF `DMXChannel Offset` values can be sparse or multi-byte and the previous implementation counted parsed offset tokens, which underreports the real DMX footprint (Ch Count) for modes with gaps. 
- The intended behavior for consoles/patching is to expose the highest occupied DMX offset (the DMX footprint) so sparse definitions do not produce incorrect channel counts. 
- Align internal API comment and behavior with GDTF semantics so UI and patching logic use the correct channel footprint.

### Description
- Changed mode counting in `viewer3d/gdtfloader.cpp` to compute the DMX footprint (maximum offset) instead of incrementing a token count when parsing `DMXChannel Offset` values. 
- Updated the public API comment in `viewer3d/gdtfloader.h` to document that `GetGdtfModeChannelCount` returns the DMX footprint for DMX break 1 style addressing. 
- Updated `tests/gdtfloader_channel_modes_test.cpp` to include a sparse-offset sample (`Offset="1"`, `Offset="2"`, `Offset="5"`) and adjusted asserts to expect a footprint of `5` and the corresponding channel vector layout. 

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed. 
- Inspected `library/fixtures/impression X4 Bar 20.gdtf` via a Python XML check to validate sparse offsets in the `High Resolution` mode (inspection succeeded). 
- Attempted to configure/build and run `gdtfloader_channel_modes_test` locally but the CMake configuration failed due to missing `wxWidgets` in this environment, so the updated unit test was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea4e131ab88324ac00d237a15c5f52)