### PR TITLE
Reconcile stale fixture label overrides after scene load/import

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -80,6 +80,7 @@ using json = nlohmann::json;
 #include "exportobjectdialog.h"
 #include "exporttrussdialog.h"
 #include "fixture.h"
+#include "fixture_label_overrides.h"
 #include "fixturetablepanel.h"
 #include "gdtfloader.h"
 #include "gdtfnet.h"
@@ -675,6 +676,8 @@ bool MainWindow::LoadProjectFromPath(const std::string &path,
     finishLoad();
     return false;
   }
+  viewer2d::ReconcileFixtureLabelOverridesWithScene(
+      GetDefaultGuiConfigServices().LegacyConfigManager());
 
   reportProjectLoadProgress("Building scene...", true);
   Ensure3DViewport();

--- a/gui/mainwindow/controllers/mainwindow_io_controller.cpp
+++ b/gui/mainwindow/controllers/mainwindow_io_controller.cpp
@@ -18,6 +18,7 @@
 #include "consolepanel.h"
 #include "configmanager.h"
 #include "fixturetablepanel.h"
+#include "fixture_label_overrides.h"
 #include "guiconfigservices.h"
 #include "hoisttablepanel.h"
 #include "layerpanel.h"
@@ -136,6 +137,7 @@ bool MainWindowIoController::ImportMvrFromPath(const std::string &pathUtf8) {
   }
 
   setImportStatus("MVR import: refreshing panels...");
+  viewer2d::ReconcileFixtureLabelOverridesWithScene(cfg);
   if (ownerRef->consolePanel)
     ownerRef->consolePanel->AppendMessage("Imported " + filePath);
   ownerRef->currentProjectPath.clear();

--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -45,6 +45,7 @@
 #include "exportobjectdialog.h"
 #include "exporttrussdialog.h"
 #include "fixture.h"
+#include "fixture_label_overrides.h"
 #include "fixturetablepanel.h"
 #include "gdtf_mutation_audit.h"
 #include "hoisttablepanel.h"
@@ -280,6 +281,8 @@ void MainWindow::OnImportRider(wxCommandEvent &event) {
     if (consolePanel)
       consolePanel->AppendMessage("[ERROR] Failed to import " + dlg.GetPath());
   } else {
+    viewer2d::ReconcileFixtureLabelOverridesWithScene(
+        GetDefaultGuiConfigServices().LegacyConfigManager());
     importOverlay.reset();
     importDisabler.reset();
     if (consolePanel)
@@ -349,6 +352,8 @@ void MainWindow::OnImportRiderText(wxCommandEvent &WXUNUSED(event)) {
   }
 
   createProgress.reset();
+  viewer2d::ReconcileFixtureLabelOverridesWithScene(
+      GetDefaultGuiConfigServices().LegacyConfigManager());
   if (consolePanel)
     consolePanel->AppendMessage("[INFO] Imported rider from text.");
   // Keep behavior aligned with MVR import: assign deterministic colors after

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,6 +57,27 @@ add_executable(pdf_font_metrics_test
                ../viewer2d/pdf/font_metrics.cpp)
 add_test(NAME PdfFontMetricsEncoding COMMAND pdf_font_metrics_test)
 
+add_executable(fixture_label_overrides_reconcile_test
+               fixture_label_overrides_reconcile_test.cpp
+               ../viewer2d/fixture_label_overrides.cpp
+               ../core/configmanager.cpp
+               ../core/configservices.cpp
+               ../core/layouts/LayoutManager.cpp
+               ../core/layouts/LayoutDefaultsLoader.cpp
+               ../core/layouts/LayoutCollection.cpp
+               ../core/layouts/LayoutTemplateSerializer.cpp
+               ../core/projectutils.cpp
+               ../core/library/library_bootstrap.cpp
+               ../core/logger.cpp
+               ../models/mvrscene.cpp
+               mvr_io_stubs.cpp)
+target_include_directories(fixture_label_overrides_reconcile_test PRIVATE
+                           . ../core ../third_party)
+target_link_libraries(fixture_label_overrides_reconcile_test PRIVATE
+                      ${wxWidgets_LIBRARIES})
+add_test(NAME FixtureLabelOverridesReconcile
+         COMMAND fixture_label_overrides_reconcile_test)
+
 add_executable(pdf_writer_test
                pdf_writer_test.cpp
                ../viewer2d/pdf/pdf_draw_commands.cpp

--- a/tests/fixture_label_overrides_reconcile_test.cpp
+++ b/tests/fixture_label_overrides_reconcile_test.cpp
@@ -1,0 +1,35 @@
+#include "configmanager.h"
+#include "fixture.h"
+#include "fixture_label_overrides.h"
+
+#include <cassert>
+
+int main() {
+  ConfigManager &cfg = ConfigManager::Get();
+  cfg.Reset();
+
+  Fixture validFixture;
+  validFixture.uuid = "fixture-valid";
+  cfg.GetScene().fixtures[validFixture.uuid] = validFixture;
+
+  cfg.SetValue("label_fixture_overrides",
+               R"({
+                 "fixture-valid": {
+                   "showLabelName": [true, null, null]
+                 },
+                 "fixture-missing": {
+                   "showLabelName": [false, null, null]
+                 }
+               })");
+
+  viewer2d::ReconcileFixtureLabelOverridesWithScene(cfg);
+
+  const auto overrides = viewer2d::LoadFixtureLabelOverrides(cfg);
+  assert(overrides.size() == 1);
+  assert(overrides.count("fixture-valid") == 1);
+  assert(overrides.count("fixture-missing") == 0);
+  assert(cfg.HasKey("label_fixture_overrides"));
+
+  cfg.Reset();
+  return 0;
+}

--- a/viewer2d/fixture_label_overrides.cpp
+++ b/viewer2d/fixture_label_overrides.cpp
@@ -164,6 +164,26 @@ void SaveFixtureLabelOverrides(ConfigManager &cfg,
   cfg.SetValue(kFixtureOverridesKey, root.dump());
 }
 
+void ReconcileFixtureLabelOverridesWithScene(ConfigManager &cfg) {
+  FixtureLabelOverrideMap overrides = LoadFixtureLabelOverrides(cfg);
+  if (overrides.empty())
+    return;
+
+  const auto &fixtures = cfg.GetScene().fixtures;
+  bool changed = false;
+  for (auto it = overrides.begin(); it != overrides.end();) {
+    if (fixtures.count(it->first) == 0) {
+      it = overrides.erase(it);
+      changed = true;
+      continue;
+    }
+    ++it;
+  }
+
+  if (changed)
+    SaveFixtureLabelOverrides(cfg, overrides);
+}
+
 float ResolveLabelFontSizeName(const ConfigManager &cfg,
                                const FixtureLabelOverride *overrideSettings) {
   if (overrideSettings && overrideSettings->labelFontSizeName.has_value())

--- a/viewer2d/fixture_label_overrides.h
+++ b/viewer2d/fixture_label_overrides.h
@@ -29,6 +29,7 @@ using FixtureLabelOverrideMap =
 FixtureLabelOverrideMap LoadFixtureLabelOverrides(const ConfigManager &cfg);
 void SaveFixtureLabelOverrides(ConfigManager &cfg,
                                const FixtureLabelOverrideMap &overrides);
+void ReconcileFixtureLabelOverridesWithScene(ConfigManager &cfg);
 
 float ResolveLabelFontSizeName(const ConfigManager &cfg,
                                const FixtureLabelOverride *overrideSettings);


### PR DESCRIPTION
### Motivation
- Prevent stale `label_fixture_overrides` entries from lingering when a loaded/imported scene replaces fixtures, which can cause inconsistencies in 2D label controls and saved config.
- Ensure overrides only reference fixtures that actually exist in the current `ConfigManager::GetScene().fixtures` map to keep configuration clean and predictable.

### Description
- Add `viewer2d::ReconcileFixtureLabelOverridesWithScene(ConfigManager&)` in `viewer2d/fixture_label_overrides.cpp` and declare it in the header, implementing load, prune (remove orphan UUIDs), and save-if-changed logic over the `label_fixture_overrides` key.
- Call the reconciler after major scene-replacement flows: at the end of `MainWindow::LoadProjectFromPath`, after successful Rider file and Rider text imports in `gui/mainwindow_io.cpp`, and after successful MVR import in `mainwindow_io_controller.cpp`.
- Add unit test `tests/fixture_label_overrides_reconcile_test.cpp` that seeds a valid and a missing fixture override, runs `ReconcileFixtureLabelOverridesWithScene`, and asserts only the valid override remains, and register the test in `tests/CMakeLists.txt`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.
- Attempted to configure the test build with `cmake -S . -B build` but configuration failed because `wxWidgets` was not available in the environment, so the new unit test binary could not be built or executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea57c7c0e48324995f90b89ca60caf)