### PR TITLE
AutoPatch: patch only selected fixtures in selection order

### DIFF
--- a/core/autopatcher.cpp
+++ b/core/autopatcher.cpp
@@ -20,12 +20,73 @@
 #include "patchmanager.h"
 #include <algorithm>
 #include <filesystem>
+#include <optional>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 namespace fs = std::filesystem;
 
 namespace AutoPatcher {
+namespace {
+
+std::optional<PatchManager::PatchAddress>
+ParsePatchAddress(const std::string &address) {
+  const size_t dotPos = address.find('.');
+  if (dotPos == std::string::npos || dotPos == 0 || dotPos + 1 >= address.size())
+    return std::nullopt;
+
+  try {
+    const int universe = std::stoi(address.substr(0, dotPos));
+    const int channel = std::stoi(address.substr(dotPos + 1));
+    if (universe < 1 || channel < 1 || channel > 512)
+      return std::nullopt;
+    return PatchManager::PatchAddress{universe, channel};
+  } catch (...) {
+    return std::nullopt;
+  }
+}
+
+int ResolveFixtureChannelCount(const MvrScene &scene, const Fixture &fixture) {
+  std::string fullPath;
+  if (!fixture.gdtfSpec.empty()) {
+    fs::path p = scene.basePath.empty()
+                     ? fs::path(fixture.gdtfSpec)
+                     : fs::path(scene.basePath) / fixture.gdtfSpec;
+    fullPath = p.string();
+  }
+  int channelCount = GetGdtfModeChannelCount(fullPath, fixture.gdtfMode);
+  return channelCount > 0 ? channelCount : 1;
+}
+
+std::optional<PatchManager::PatchAddress>
+FindNextAddressAfterHighestPatchedFixture(const MvrScene &scene,
+                                          const std::unordered_set<std::string> &ignoredUuids) {
+  int highestAbsoluteEnd = 0;
+
+  for (const auto &[uuid, fixture] : scene.fixtures) {
+    if (ignoredUuids.contains(uuid))
+      continue;
+    const std::optional<PatchManager::PatchAddress> startAddress =
+        ParsePatchAddress(fixture.address);
+    if (!startAddress)
+      continue;
+
+    const int channelCount = ResolveFixtureChannelCount(scene, fixture);
+    const int absoluteStart = (startAddress->universe - 1) * 512 + startAddress->channel;
+    const int absoluteEnd = absoluteStart + channelCount - 1;
+    highestAbsoluteEnd = std::max(highestAbsoluteEnd, absoluteEnd);
+  }
+
+  if (highestAbsoluteEnd <= 0)
+    return PatchManager::PatchAddress{1, 1};
+
+  const int nextAbsolute = highestAbsoluteEnd + 1;
+  const int universe = ((nextAbsolute - 1) / 512) + 1;
+  const int channel = ((nextAbsolute - 1) % 512) + 1;
+  return PatchManager::PatchAddress{universe, channel};
+}
+} // namespace
 
 void AutoPatch(MvrScene &scene, int startUniverse, int startChannel) {
   struct FixtureInfo {
@@ -120,6 +181,57 @@ void AutoPatch(MvrScene &scene, int startUniverse, int startChannel) {
         ch = 1;
       }
     }
+  }
+}
+
+void AutoPatchSelection(MvrScene &scene,
+                        const std::vector<std::string> &selectionOrder) {
+  if (selectionOrder.empty())
+    return;
+
+  std::unordered_set<std::string> uniqueSelection(selectionOrder.begin(),
+                                                  selectionOrder.end());
+
+  for (const auto &uuid : uniqueSelection) {
+    auto fixtureIt = scene.fixtures.find(uuid);
+    if (fixtureIt != scene.fixtures.end())
+      fixtureIt->second.address.clear();
+  }
+
+  const auto nextStart =
+      FindNextAddressAfterHighestPatchedFixture(scene, uniqueSelection);
+  if (!nextStart)
+    return;
+
+  std::vector<int> channelCounts;
+  std::vector<std::string> orderedFixtureUuids;
+  channelCounts.reserve(selectionOrder.size());
+  orderedFixtureUuids.reserve(selectionOrder.size());
+
+  std::unordered_set<std::string> seen;
+  for (const auto &uuid : selectionOrder) {
+    if (!seen.insert(uuid).second)
+      continue;
+
+    const auto fixtureIt = scene.fixtures.find(uuid);
+    if (fixtureIt == scene.fixtures.end())
+      continue;
+
+    orderedFixtureUuids.push_back(uuid);
+    channelCounts.push_back(ResolveFixtureChannelCount(scene, fixtureIt->second));
+  }
+
+  if (orderedFixtureUuids.empty())
+    return;
+
+  const std::vector<PatchManager::PatchAddress> addresses =
+      PatchManager::SequentialPatch(channelCounts, nextStart->universe,
+                                    nextStart->channel);
+
+  for (size_t i = 0; i < orderedFixtureUuids.size() && i < addresses.size(); ++i) {
+    const auto &patch = addresses[i];
+    scene.fixtures[orderedFixtureUuids[i]].address =
+        std::to_string(patch.universe) + "." + std::to_string(patch.channel);
   }
 }
 

--- a/core/autopatcher.h
+++ b/core/autopatcher.h
@@ -18,6 +18,8 @@
 #pragma once
 
 #include "mvrscene.h"
+#include <string>
+#include <vector>
 
 namespace AutoPatcher {
 // Automatically assign DMX addresses to fixtures in the scene.
@@ -27,4 +29,11 @@ namespace AutoPatcher {
 // split. The order is front-to-back (Y axis), then by hang position, then by
 // type, and finally left-to-right (X axis).
 void AutoPatch(MvrScene &scene, int startUniverse = 1, int startChannel = 1);
+
+// Re-patch only the selected fixtures in the exact order provided by
+// selectionOrder. Existing patch values for the selected fixtures are cleared
+// before re-patching. The new patch starts at the next free channel after the
+// highest already-patched fixture that remains in the scene.
+void AutoPatchSelection(MvrScene &scene,
+                        const std::vector<std::string> &selectionOrder);
 } // namespace AutoPatcher

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -1351,13 +1351,10 @@ void FixtureTablePanel::OnSelectionChanged(wxDataViewEvent &evt) {
   table->GetSelections(selections);
   std::vector<int> currentRows;
   currentRows.reserve(selections.size());
-  std::vector<std::string> uuids;
-  uuids.reserve(selections.size());
   for (const auto &it : selections) {
     int r = table->ItemToRow(it);
     if (r != wxNOT_FOUND && (size_t)r < rowUuids.size()) {
       currentRows.push_back(r);
-      uuids.push_back(rowUuids[r]);
     }
   }
   // Preserve existing order but drop unselected rows
@@ -1371,10 +1368,17 @@ void FixtureTablePanel::OnSelectionChanged(wxDataViewEvent &evt) {
     if (std::find(newOrder.begin(), newOrder.end(), r) == newOrder.end())
       newOrder.push_back(r);
   selectionOrder.swap(newOrder);
+
+  std::vector<std::string> orderedUuids;
+  orderedUuids.reserve(selectionOrder.size());
+  for (int rowIndex : selectionOrder) {
+    if (rowIndex >= 0 && static_cast<size_t>(rowIndex) < rowUuids.size())
+      orderedUuids.push_back(rowUuids[static_cast<size_t>(rowIndex)]);
+  }
   ConfigManager &cfg = guiConfigServices->LegacyConfigManager();
-  if (uuids != cfg.GetSelectedFixtures()) {
+  if (orderedUuids != cfg.GetSelectedFixtures()) {
     cfg.PushUndoState("fixture selection");
-    cfg.SetSelectedFixtures(uuids);
+    cfg.SetSelectedFixtures(orderedUuids);
   }
   std::vector<std::string> mergedSelection;
   const auto appendSelection = [&](const std::vector<std::string> &source) {

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -672,7 +672,11 @@ void MainWindow::OnOpenUserLibraryFolder(wxCommandEvent &WXUNUSED(event)) {
 void MainWindow::OnAutoPatch(wxCommandEvent &WXUNUSED(event)) {
   ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
   cfg.PushUndoState("auto patch");
-  AutoPatcher::AutoPatch(cfg.GetScene());
+  const std::vector<std::string> selectedFixtureUuids = cfg.GetSelectedFixtures();
+  if (!selectedFixtureUuids.empty())
+    AutoPatcher::AutoPatchSelection(cfg.GetScene(), selectedFixtureUuids);
+  else
+    AutoPatcher::AutoPatch(cfg.GetScene());
   RefreshAfterSceneChange();
 }
 

--- a/tests/autopatcher_test.cpp
+++ b/tests/autopatcher_test.cpp
@@ -27,35 +27,67 @@ int GetGdtfModeChannelCount(const std::string &, const std::string &mode) {
 }
 
 int main() {
-  MvrScene scene;
+  {
+    MvrScene scene;
 
-  Fixture a;
-  a.uuid = "a";
-  a.typeName = "Spot";
-  a.transform.o[0] = 0.0f;
-  a.transform.o[1] = 0.0f;
-  scene.fixtures[a.uuid] = a;
+    Fixture a;
+    a.uuid = "a";
+    a.typeName = "Spot";
+    a.transform.o[0] = 0.0f;
+    a.transform.o[1] = 0.0f;
+    scene.fixtures[a.uuid] = a;
 
-  Fixture b;
-  b.uuid = "b";
-  b.typeName = "Wash";
-  b.transform.o[0] = 1.0f;
-  b.transform.o[1] = 0.0f;
-  scene.fixtures[b.uuid] = b;
+    Fixture b;
+    b.uuid = "b";
+    b.typeName = "Wash";
+    b.transform.o[0] = 1.0f;
+    b.transform.o[1] = 0.0f;
+    scene.fixtures[b.uuid] = b;
 
-  Fixture c;
-  c.uuid = "c";
-  c.typeName = "Spot";
-  c.transform.o[0] = 2.0f;
-  c.transform.o[1] = 0.0f;
-  scene.fixtures[c.uuid] = c;
+    Fixture c;
+    c.uuid = "c";
+    c.typeName = "Spot";
+    c.transform.o[0] = 2.0f;
+    c.transform.o[1] = 0.0f;
+    scene.fixtures[c.uuid] = c;
 
-  AutoPatcher::AutoPatch(scene);
+    AutoPatcher::AutoPatch(scene);
 
-  // Spot fixtures should be patched first and consecutively
-  assert(scene.fixtures["a"].address == "1.1");
-  assert(scene.fixtures["c"].address == "1.2");
-  assert(scene.fixtures["b"].address == "1.3");
+    // Spot fixtures should be patched first and consecutively
+    assert(scene.fixtures["a"].address == "1.1");
+    assert(scene.fixtures["c"].address == "1.2");
+    assert(scene.fixtures["b"].address == "1.3");
+  }
+
+  {
+    MvrScene scene;
+
+    Fixture base;
+    base.uuid = "base";
+    base.gdtfMode = "5";
+    base.address = "1.10";
+    scene.fixtures[base.uuid] = base;
+
+    Fixture selA;
+    selA.uuid = "selA";
+    selA.gdtfMode = "4";
+    selA.address = "1.100";
+    scene.fixtures[selA.uuid] = selA;
+
+    Fixture selB;
+    selB.uuid = "selB";
+    selB.gdtfMode = "3";
+    selB.address = "1.200";
+    scene.fixtures[selB.uuid] = selB;
+
+    AutoPatcher::AutoPatchSelection(scene, {"selB", "selA"});
+
+    // Selection is patched in user selection order, starting after the
+    // highest non-selected patched fixture.
+    assert(scene.fixtures["base"].address == "1.10");
+    assert(scene.fixtures["selB"].address == "1.15");
+    assert(scene.fixtures["selA"].address == "1.18");
+  }
 
   return 0;
 }


### PR DESCRIPTION
### Motivation
- Allow the AutoPatch tool (when invoked by the user) to operate only on the currently selected fixtures instead of always re-patching the whole scene, honoring the exact interaction order reported by the fixture table selection.
- Ensure selected fixtures are unpatched first and then re-patched starting at the next free DMX channel after the highest already-patched fixture that remains in the scene.

### Description
- Added `AutoPatcher::AutoPatchSelection(MvrScene&, const std::vector<std::string>&)` and helpers in `core/autopatcher.cpp/.h` which clear selected fixtures' patch, compute the next-free start address, resolve each fixture channel count, and apply `PatchManager::SequentialPatch` in selection order.
- Updated `MainWindow::OnAutoPatch` (`gui/mainwindow_menu.cpp`) to call `AutoPatchSelection` when there are selected fixtures and fall back to the existing full-scene `AutoPatch` when there is no selection.
- Persist the fixture selection in interaction order by changing `FixtureTablePanel::OnSelectionChanged` to store `selectionOrder`-derived UUIDs into `ConfigManager` so user selection order is preserved for selection-aware autopatching (`gui/fixturetablepanel.cpp`).
- Extended `tests/autopatcher_test.cpp` with a unit case that validates selection-order patching, clearing of selected fixtures, and starting the new patch after the highest remaining patched fixture.

### Testing
- Ran architectural checks and they passed: `tests/check_perastage_tree_modules.sh` (OK) and `tests/check_no_configmanager_get_in_gui.sh` (OK).
- Attempted to configure/build and run `autopatcher_test` locally but the CMake configure step failed in this environment due to missing `wxWidgets` development packages, so the unit binary could not be executed here (configure error reported by CMake).
- Project compilation and CI-friendly checks remain unchanged by this patch beyond the added unit coverage; further CI or a developer environment with `wxWidgets` is required to build and run the new test binary.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea5b042eb08324953d92231598a124)