### PR TITLE
Keep 2D fixture labels visible while heavy tasks are throttled

### DIFF
--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -671,7 +671,13 @@ void Viewer2DPanel::RenderInternal(bool swapBuffers) {
   if (!m_glInitialized) {
     return;
   }
+  // Interaction policy:
+  // - Keep throttling expensive synchronization while the user is dragging,
+  //   panning or selecting.
+  // - Keep fixture labels visible using an explicit interactive mode so the
+  //   overlay does not flicker/disappear during interaction.
   const bool pauseHeavyTasks = m_enableSelection && ShouldPauseHeavyTasks();
+  m_interactiveLabelMode = m_enableSelection && pauseHeavyTasks;
   const RenderSize resolvedSize = ResolveRenderSize(this);
   const int w = resolvedSize.width;
   const int h = resolvedSize.height;
@@ -906,8 +912,10 @@ void Viewer2DPanel::RenderInternal(bool swapBuffers) {
   bool drawFixtureLabels = true;
   if (m_renderOverrides && m_renderOverrides->drawFixtureLabels.has_value())
     drawFixtureLabels = m_renderOverrides->drawFixtureLabels.value();
-  if (!pauseHeavyTasks && drawFixtureLabels)
-    m_controller.DrawAllFixtureLabels(w, h, m_view, m_zoom);
+  if (drawFixtureLabels) {
+    m_controller.DrawAllFixtureLabels(w, h, m_view, m_zoom,
+                                      m_interactiveLabelMode);
+  }
 
   if (swapBuffers && m_enableSelection && m_rectSelecting)
     DrawSelectionRectangle(w, h, darkMode);
@@ -1563,6 +1571,10 @@ void Viewer2DPanel::QueueDragTableUpdate(DragTarget target,
 }
 
 bool Viewer2DPanel::ShouldPauseHeavyTasks() {
+  // Returns true while recent input activity is still within the debounce
+  // window. Callers should throttle only expensive synchronization work
+  // (scene/resource updates, heavy snapshots). Visual overlays such as labels
+  // should stay on-screen through an interactive lightweight rendering path.
   if (!m_isInteracting)
     return false;
 

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -227,6 +227,7 @@ private:
   bool m_hasHover = false;
   std::chrono::steady_clock::time_point m_lastInteractionTime{};
   bool m_isInteracting = false;
+  bool m_interactiveLabelMode = false;
   wxTimer m_interactionResumeTimer;
   bool m_enableSelection = true;
   std::string m_hoverUuid;

--- a/viewer3d/labels/label_render_system.cpp
+++ b/viewer3d/labels/label_render_system.cpp
@@ -472,7 +472,8 @@ void LabelRenderSystem::DrawFixtureLabels(int width, int height) {
 }
 
 void LabelRenderSystem::DrawAllFixtureLabels(int width, int height,
-                                             Viewer2DView view, float zoom) {
+                                             Viewer2DView view, float zoom,
+                                             bool interactiveLabelMode) {
   ConfigManager &cfg = ConfigManager::Get();
   const auto distanceUnitSystem =
       Units::ParseDistanceUnitSystem(cfg.GetValue("ui_distance_unit_system"));
@@ -488,8 +489,11 @@ void LabelRenderSystem::DrawAllFixtureLabels(int width, int height,
   const CullingSettings culling = GetCullingSettings(cfg);
   const float minLabelPixels = culling.minPixels2D;
   const bool useLabelOptimizations =
-      cfg.GetFloat("label_optimizations_enabled") >= 0.5f;
-  const int maxFixtureLabels = GetLabelLimit(cfg, "label_max_fixtures");
+      !interactiveLabelMode &&
+      (cfg.GetFloat("label_optimizations_enabled") >= 0.5f);
+  const int maxFixtureLabels = interactiveLabelMode
+                                   ? 0
+                                   : GetLabelLimit(cfg, "label_max_fixtures");
 
   struct FixtureLabelCandidate {
     const std::string *uuid = nullptr;
@@ -601,14 +605,21 @@ void LabelRenderSystem::DrawAllFixtureLabels(int width, int height,
     if (showName) {
       wxString baseName = f.instanceName.empty() ? wxString::FromUTF8(uuid)
                                                  : wxString::FromUTF8(f.instanceName);
-      wxString wrapped = WrapEveryTwoWords(baseName);
-      wxStringTokenizer nameLines(wrapped, "\n");
-      while (nameLines.HasMoreTokens()) {
-        wxString line = nameLines.GetNextToken();
-        auto utf8 = line.ToUTF8();
+      if (interactiveLabelMode) {
+        auto utf8 = baseName.ToUTF8();
         lines.push_back({m_controller.GetLabelFont(),
                          std::string(utf8.data(), utf8.length()), nameSize,
                          kRegularFamily});
+      } else {
+        wxString wrapped = WrapEveryTwoWords(baseName);
+        wxStringTokenizer nameLines(wrapped, "\n");
+        while (nameLines.HasMoreTokens()) {
+          wxString line = nameLines.GetNextToken();
+          auto utf8 = line.ToUTF8();
+          lines.push_back({m_controller.GetLabelFont(),
+                           std::string(utf8.data(), utf8.length()), nameSize,
+                           kRegularFamily});
+        }
       }
     }
     if (showId) {
@@ -628,7 +639,7 @@ void LabelRenderSystem::DrawAllFixtureLabels(int width, int height,
     if (lines.empty())
       continue;
 
-    if (m_controller.GetCaptureCanvas()) {
+    if (!interactiveLabelMode && m_controller.GetCaptureCanvas()) {
       std::string labelSourceKey = "label:" + uuid;
       m_controller.GetCaptureCanvas()->SetSourceKey(labelSourceKey);
 

--- a/viewer3d/labels/label_render_system.h
+++ b/viewer3d/labels/label_render_system.h
@@ -12,7 +12,7 @@ public:
   void DrawTrussLabels(int width, int height);
   void DrawSceneObjectLabels(int width, int height);
   void DrawAllFixtureLabels(int width, int height, Viewer2DView view,
-                            float zoom);
+                            float zoom, bool interactiveLabelMode = false);
 
 private:
   ISelectionContext &m_controller;

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1658,8 +1658,10 @@ void Viewer3DController::DrawFixtureLabels(int width, int height) {
 // drawn tag roughly matches the fixture size, and the optional zoom parameter
 // scales the label like regular geometry when zooming the 2D view.
 void Viewer3DController::DrawAllFixtureLabels(int width, int height,
-                                              Viewer2DView view, float zoom) {
-  m_impl->labelRenderSystem->DrawAllFixtureLabels(width, height, view, zoom);
+                                              Viewer2DView view, float zoom,
+                                              bool interactiveLabelMode) {
+  m_impl->labelRenderSystem->DrawAllFixtureLabels(width, height, view, zoom,
+                                                  interactiveLabelMode);
 }
 
 void Viewer3DController::DrawOverlayTextLabels(

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -108,7 +108,8 @@ public:
   void DrawTrussLabels(int width, int height);
   void DrawSceneObjectLabels(int width, int height);
   void DrawAllFixtureLabels(int width, int height, Viewer2DView view,
-                            float zoom = 1.0f);
+                            float zoom = 1.0f,
+                            bool interactiveLabelMode = false);
   void DrawOverlayTextLabels(const std::vector<OverlayTextLabel> &labels,
                              bool darkMode, bool outline = true);
 


### PR DESCRIPTION
### Motivation
- Prevent fixture labels from disappearing or flickering during interactive input (pan/drag/selection) while preserving the existing throttling of expensive synchronization work.
- Provide an explicit interactive label rendering path that is lightweight and avoids heavy culling/metric work so overlays remain visually stable during interaction.

### Description
- Added an explicit `m_interactiveLabelMode` boolean to `Viewer2DPanel` and set it inside `RenderInternal()` based on the existing `ShouldPauseHeavyTasks()` policy, with comments documenting the differentiated behavior.
- Always invoke label rendering from `RenderInternal()` when `drawFixtureLabels` is enabled, passing `m_interactiveLabelMode` to the controller instead of disabling labels entirely during interaction.
- Extended `Viewer3DController::DrawAllFixtureLabels(...)` and `LabelRenderSystem::DrawAllFixtureLabels(...)` with a new `interactiveLabelMode` parameter (default `false`) and threaded it through the call chain.
- Implemented a lightweight interactive label path inside `LabelRenderSystem::DrawAllFixtureLabels(...)` that disables expensive optimizations/limits for interactive mode, emits a simplified single-line name (no multi-line wrapping), and skips capture-canvas text metrics when `interactiveLabelMode` is true.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded (OK).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded (OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea5f330d5c83249362bc3c6579f93a)