### PR TITLE
Throttle hover hit-testing and cache 3D selection queries

### DIFF
--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -337,6 +337,8 @@ std::vector<std::string> BuildCombinedSelection(const ConfigManager &cfg) {
 
 namespace {
 Viewer2DPanel *g_instance = nullptr;
+constexpr int kInteractionPauseTimerId = wxID_HIGHEST + 220;
+constexpr int kHoverHitTestTimerId = wxID_HIGHEST + 221;
 }
 
 wxBEGIN_EVENT_TABLE(Viewer2DPanel, wxGLCanvas) EVT_PAINT(Viewer2DPanel::OnPaint)
@@ -349,7 +351,10 @@ wxBEGIN_EVENT_TABLE(Viewer2DPanel, wxGLCanvas) EVT_PAINT(Viewer2DPanel::OnPaint)
                 EVT_ENTER_WINDOW(Viewer2DPanel::OnMouseEnter)
                     EVT_LEAVE_WINDOW(Viewer2DPanel::OnMouseLeave)
                         EVT_MOUSE_CAPTURE_LOST(Viewer2DPanel::OnCaptureLost)
-                            EVT_TIMER(wxID_ANY, Viewer2DPanel::OnInteractionPauseTimer)
+                            EVT_TIMER(kInteractionPauseTimerId,
+                                      Viewer2DPanel::OnInteractionPauseTimer)
+                            EVT_TIMER(kHoverHitTestTimerId,
+                                      Viewer2DPanel::OnHoverHitTestTimer)
                             EVT_SIZE(Viewer2DPanel::OnResize) wxEND_EVENT_TABLE()
 
 Viewer2DPanel::Viewer2DPanel(wxWindow *parent, bool allowOffscreenRender,
@@ -357,7 +362,8 @@ Viewer2DPanel::Viewer2DPanel(wxWindow *parent, bool allowOffscreenRender,
     : wxGLCanvas(parent, wxID_ANY, nullptr, wxDefaultPosition, wxDefaultSize,
                  wxFULL_REPAINT_ON_RESIZE),
       m_allowOffscreenRender(allowOffscreenRender),
-      m_interactionResumeTimer(this),
+      m_interactionResumeTimer(this, kInteractionPauseTimerId),
+      m_hoverHitTestTimer(this, kHoverHitTestTimerId),
       m_persistViewState(persistViewState),
       m_enableSelection(enableSelection) {
   SetBackgroundStyle(wxBG_STYLE_CUSTOM);
@@ -380,6 +386,7 @@ Viewer2DPanel::~Viewer2DPanel() {
   m_dragSelectionMoved = false;
   m_rectSelecting = false;
   m_interactionResumeTimer.Stop();
+  m_hoverHitTestTimer.Stop();
   StopDragTableUpdateWorker();
   delete m_glContext;
 }
@@ -1054,115 +1061,6 @@ void Viewer2DPanel::OnPaint(wxPaintEvent &WXUNUSED(event)) {
   }
 
   Render();
-
-  if (!m_enableSelection || !IsShownOnScreen())
-    return;
-
-  // Ensure the OpenGL context is current before hit-testing selections.
-  SetCurrent(*m_glContext);
-
-  const RenderSize renderSize = ResolveRenderSize(this);
-  const int w = renderSize.width;
-  const int h = renderSize.height;
-  if (!renderSize.IsValid())
-    return;
-  const wxPoint pickPos = ToFramebufferPoint(this, m_lastMousePos);
-
-  wxString newLabel;
-  wxPoint newPos;
-  std::string newUuid;
-  bool found = false;
-  const bool skipLabelWork =
-      wasInteracting && (m_dragMode == DragMode::View || m_dragMode == DragMode::None);
-
-  if (!skipLabelWork && FixtureTablePanel::Instance() &&
-      FixtureTablePanel::Instance()->IsActivePage()) {
-    found = m_controller.GetFixtureLabelAt(pickPos.x, pickPos.y, w, h, newLabel,
-                                           newPos, &newUuid);
-    if (found) {
-      if (TrussTablePanel::Instance())
-        TrussTablePanel::Instance()->HighlightTruss(std::string());
-      if (SceneObjectTablePanel::Instance())
-        SceneObjectTablePanel::Instance()->HighlightObject(std::string());
-    }
-  } else if (!skipLabelWork && TrussTablePanel::Instance() &&
-             TrussTablePanel::Instance()->IsActivePage()) {
-    found = m_controller.GetTrussLabelAt(pickPos.x, pickPos.y, w, h, newLabel,
-                                         newPos, &newUuid);
-    if (found) {
-      if (FixtureTablePanel::Instance())
-        FixtureTablePanel::Instance()->HighlightFixture(std::string());
-      if (SceneObjectTablePanel::Instance())
-        SceneObjectTablePanel::Instance()->HighlightObject(std::string());
-    }
-  } else if (!skipLabelWork && HoistTablePanel::Instance() &&
-             HoistTablePanel::Instance()->IsActivePage()) {
-    const auto hiddenLayers = ConfigManager::Get().GetHiddenLayers();
-    found = Viewer2DSupportSelection::FindHoistAtScreenPoint(
-        pickPos.x, pickPos.y, h, ConfigManager::Get().GetScene(), hiddenLayers,
-        newUuid, newPos, newLabel);
-    if (found) {
-      if (FixtureTablePanel::Instance())
-        FixtureTablePanel::Instance()->HighlightFixture(std::string());
-      if (TrussTablePanel::Instance())
-        TrussTablePanel::Instance()->HighlightTruss(std::string());
-      if (SceneObjectTablePanel::Instance())
-        SceneObjectTablePanel::Instance()->HighlightObject(std::string());
-    }
-  } else if (!skipLabelWork && SceneObjectTablePanel::Instance() &&
-             SceneObjectTablePanel::Instance()->IsActivePage()) {
-    found = m_controller.GetSceneObjectLabelAt(pickPos.x,
-                                               pickPos.y, w, h, newLabel,
-                                               newPos, &newUuid);
-    if (found) {
-      if (FixtureTablePanel::Instance())
-        FixtureTablePanel::Instance()->HighlightFixture(std::string());
-      if (TrussTablePanel::Instance())
-        TrussTablePanel::Instance()->HighlightTruss(std::string());
-    }
-  }
-
-  bool highlightChanged = false;
-  if (found) {
-    highlightChanged = (m_hoverUuid != newUuid);
-    m_hasHover = true;
-    m_hoverUuid = newUuid;
-    m_controller.SetHighlightUuid(m_hoverUuid);
-    if (FixtureTablePanel::Instance() &&
-        FixtureTablePanel::Instance()->IsActivePage())
-      FixtureTablePanel::Instance()->HighlightFixture(std::string(m_hoverUuid));
-    else if (TrussTablePanel::Instance() &&
-             TrussTablePanel::Instance()->IsActivePage())
-      TrussTablePanel::Instance()->HighlightTruss(std::string(m_hoverUuid));
-    else if (HoistTablePanel::Instance() &&
-             HoistTablePanel::Instance()->IsActivePage())
-      HoistTablePanel::Instance()->HighlightHoist(std::string(m_hoverUuid));
-    else if (SceneObjectTablePanel::Instance() &&
-             SceneObjectTablePanel::Instance()->IsActivePage())
-      SceneObjectTablePanel::Instance()->HighlightObject(std::string(m_hoverUuid));
-  } else if (!skipLabelWork && (!m_hasHover || m_mouseMoved)) {
-    highlightChanged = m_hasHover;
-    m_hasHover = false;
-    m_hoverUuid.clear();
-    m_controller.SetHighlightUuid("");
-    if (FixtureTablePanel::Instance())
-      FixtureTablePanel::Instance()->HighlightFixture(std::string());
-    if (TrussTablePanel::Instance())
-      TrussTablePanel::Instance()->HighlightTruss(std::string());
-    if (HoistTablePanel::Instance())
-      HoistTablePanel::Instance()->HighlightHoist(std::string());
-    if (SceneObjectTablePanel::Instance())
-      SceneObjectTablePanel::Instance()->HighlightObject(std::string());
-  } else if (skipLabelWork) {
-    highlightChanged = m_hasHover;
-    m_hasHover = false;
-    m_hoverUuid.clear();
-    m_controller.SetHighlightUuid("");
-  }
-  m_mouseMoved = false;
-
-  if (highlightChanged)
-    RequestRepaint();
 }
 
 std::array<float, 3> Viewer2DPanel::MapDragDelta(float dxMeters,
@@ -1653,6 +1551,155 @@ void Viewer2DPanel::OnInteractionPauseTimer(wxTimerEvent &WXUNUSED(event)) {
     RequestRepaint();
 }
 
+void Viewer2DPanel::OnHoverHitTestTimer(wxTimerEvent &WXUNUSED(event)) {
+  if (!m_hoverHitTestPending)
+    return;
+  RunHoverHitTest(m_pendingHoverScreenPos);
+}
+
+void Viewer2DPanel::ScheduleHoverHitTest(const wxPoint &screenPos, bool forceNow) {
+  if (!m_enableSelection || !IsShownOnScreen() || m_dragMode != DragMode::None)
+    return;
+
+  m_pendingHoverScreenPos = screenPos;
+  m_hoverHitTestPending = true;
+
+  const auto now = std::chrono::steady_clock::now();
+  if (!forceNow && m_hoverQueryHasPos) {
+    const int manhattanMoved =
+        std::abs(screenPos.x - m_lastHoverQueryScreenPos.x) +
+        std::abs(screenPos.y - m_lastHoverQueryScreenPos.y);
+    const auto elapsedMs =
+        std::chrono::duration_cast<std::chrono::milliseconds>(now -
+                                                              m_lastHoverHitTestTime)
+            .count();
+    if (manhattanMoved < kHoverMoveThresholdPx && elapsedMs < kHoverHitTestIntervalMs)
+      return;
+  }
+
+  const auto elapsedMs =
+      std::chrono::duration_cast<std::chrono::milliseconds>(now - m_lastHoverHitTestTime)
+          .count();
+  if (forceNow || elapsedMs >= kHoverHitTestIntervalMs) {
+    m_hoverHitTestTimer.Stop();
+    RunHoverHitTest(screenPos);
+    return;
+  }
+
+  const int delayMs = std::max(1, kHoverHitTestIntervalMs - static_cast<int>(elapsedMs));
+  m_hoverHitTestTimer.StartOnce(delayMs);
+}
+
+void Viewer2DPanel::ClearHoverState(bool requestRepaint) {
+  const bool hadHover = m_hasHover;
+  m_hasHover = false;
+  m_hoverUuid.clear();
+  m_controller.SetHighlightUuid("");
+  if (FixtureTablePanel::Instance())
+    FixtureTablePanel::Instance()->HighlightFixture(std::string());
+  if (TrussTablePanel::Instance())
+    TrussTablePanel::Instance()->HighlightTruss(std::string());
+  if (HoistTablePanel::Instance())
+    HoistTablePanel::Instance()->HighlightHoist(std::string());
+  if (SceneObjectTablePanel::Instance())
+    SceneObjectTablePanel::Instance()->HighlightObject(std::string());
+  if (requestRepaint && hadHover)
+    RequestRepaint();
+}
+
+void Viewer2DPanel::RunHoverHitTest(const wxPoint &screenPos) {
+  if (!m_enableSelection || !IsShownOnScreen())
+    return;
+
+  m_hoverHitTestPending = false;
+  m_lastHoverHitTestTime = std::chrono::steady_clock::now();
+  m_lastHoverQueryScreenPos = screenPos;
+  m_hoverQueryHasPos = true;
+
+  const bool skipLabelWork = ShouldPauseHeavyTasks();
+  if (skipLabelWork) {
+    ClearHoverState(true);
+    return;
+  }
+
+  const RenderSize renderSize = ResolveRenderSize(this);
+  const int w = renderSize.width;
+  const int h = renderSize.height;
+  if (!renderSize.IsValid())
+    return;
+
+  SetCurrent(*m_glContext);
+  const wxPoint pickPos = ToFramebufferPoint(this, screenPos);
+  wxString newLabel;
+  wxPoint newPos;
+  std::string newUuid;
+  bool found = false;
+
+  if (FixtureTablePanel::Instance() && FixtureTablePanel::Instance()->IsActivePage()) {
+    found = m_controller.GetFixtureLabelAt(pickPos.x, pickPos.y, w, h, newLabel,
+                                           newPos, &newUuid, false);
+    if (found) {
+      if (TrussTablePanel::Instance())
+        TrussTablePanel::Instance()->HighlightTruss(std::string());
+      if (SceneObjectTablePanel::Instance())
+        SceneObjectTablePanel::Instance()->HighlightObject(std::string());
+    }
+  } else if (TrussTablePanel::Instance() && TrussTablePanel::Instance()->IsActivePage()) {
+    found = m_controller.GetTrussLabelAt(pickPos.x, pickPos.y, w, h, newLabel, newPos,
+                                         &newUuid, false);
+    if (found) {
+      if (FixtureTablePanel::Instance())
+        FixtureTablePanel::Instance()->HighlightFixture(std::string());
+      if (SceneObjectTablePanel::Instance())
+        SceneObjectTablePanel::Instance()->HighlightObject(std::string());
+    }
+  } else if (HoistTablePanel::Instance() && HoistTablePanel::Instance()->IsActivePage()) {
+    const auto hiddenLayers = ConfigManager::Get().GetHiddenLayers();
+    found = Viewer2DSupportSelection::FindHoistAtScreenPoint(
+        pickPos.x, pickPos.y, h, ConfigManager::Get().GetScene(), hiddenLayers, newUuid,
+        newPos, newLabel);
+    if (found) {
+      if (FixtureTablePanel::Instance())
+        FixtureTablePanel::Instance()->HighlightFixture(std::string());
+      if (TrussTablePanel::Instance())
+        TrussTablePanel::Instance()->HighlightTruss(std::string());
+      if (SceneObjectTablePanel::Instance())
+        SceneObjectTablePanel::Instance()->HighlightObject(std::string());
+    }
+  } else if (SceneObjectTablePanel::Instance() &&
+             SceneObjectTablePanel::Instance()->IsActivePage()) {
+    found = m_controller.GetSceneObjectLabelAt(pickPos.x, pickPos.y, w, h, newLabel,
+                                               newPos, &newUuid, false);
+    if (found) {
+      if (FixtureTablePanel::Instance())
+        FixtureTablePanel::Instance()->HighlightFixture(std::string());
+      if (TrussTablePanel::Instance())
+        TrussTablePanel::Instance()->HighlightTruss(std::string());
+    }
+  }
+
+  const std::string oldHoverUuid = m_hoverUuid;
+  if (found) {
+    m_hasHover = true;
+    m_hoverUuid = newUuid;
+    m_controller.SetHighlightUuid(m_hoverUuid);
+    if (FixtureTablePanel::Instance() && FixtureTablePanel::Instance()->IsActivePage())
+      FixtureTablePanel::Instance()->HighlightFixture(std::string(m_hoverUuid));
+    else if (TrussTablePanel::Instance() && TrussTablePanel::Instance()->IsActivePage())
+      TrussTablePanel::Instance()->HighlightTruss(std::string(m_hoverUuid));
+    else if (HoistTablePanel::Instance() && HoistTablePanel::Instance()->IsActivePage())
+      HoistTablePanel::Instance()->HighlightHoist(std::string(m_hoverUuid));
+    else if (SceneObjectTablePanel::Instance() &&
+             SceneObjectTablePanel::Instance()->IsActivePage())
+      SceneObjectTablePanel::Instance()->HighlightObject(std::string(m_hoverUuid));
+  } else {
+    ClearHoverState(false);
+  }
+
+  if (oldHoverUuid != m_hoverUuid)
+    RequestRepaint();
+}
+
 void Viewer2DPanel::OnMouseDown(wxMouseEvent &event) {
   if (event.LeftDown()) {
     CaptureMouse();
@@ -1671,6 +1718,8 @@ void Viewer2DPanel::OnMouseDown(wxMouseEvent &event) {
     m_rectSelectionAcrossAllTables = false;
     m_lastMousePos = event.GetPosition();
     MarkInteractionActivity();
+    m_hoverHitTestTimer.Stop();
+    m_hoverHitTestPending = false;
 
     if (!m_enableSelection || !IsShownOnScreen())
       return;
@@ -1914,11 +1963,11 @@ void Viewer2DPanel::OnMouseUp(wxMouseEvent &event) {
     if (FixtureTablePanel::Instance() &&
         FixtureTablePanel::Instance()->IsActivePage())
       found = m_controller.GetFixtureLabelAt(pickPos.x, pickPos.y, w, h,
-                                             label, pos, &uuid);
+                                             label, pos, &uuid, true);
     else if (TrussTablePanel::Instance() &&
              TrussTablePanel::Instance()->IsActivePage())
       found = m_controller.GetTrussLabelAt(pickPos.x, pickPos.y, w, h,
-                                           label, pos, &uuid);
+                                           label, pos, &uuid, true);
     else if (HoistTablePanel::Instance() &&
              HoistTablePanel::Instance()->IsActivePage())
       found = Viewer2DSupportSelection::FindHoistAtScreenPoint(
@@ -1927,7 +1976,7 @@ void Viewer2DPanel::OnMouseUp(wxMouseEvent &event) {
     else if (SceneObjectTablePanel::Instance() &&
              SceneObjectTablePanel::Instance()->IsActivePage())
       found = m_controller.GetSceneObjectLabelAt(pickPos.x, pickPos.y, w,
-                                                 h, label, pos, &uuid);
+                                                 h, label, pos, &uuid, true);
 
     ConfigManager &cfg = ConfigManager::Get();
     bool selectionChanged = false;
@@ -2083,7 +2132,7 @@ void Viewer2DPanel::OnRightUp(wxMouseEvent &event) {
   std::string hitUuid;
   const wxPoint pickPos = ToFramebufferPoint(this, event.GetPosition());
   if (m_controller.GetFixtureLabelAt(pickPos.x, pickPos.y, w, h, label,
-                                     pos, &hitUuid)) {
+                                     pos, &hitUuid, true)) {
     event.Skip();
     return;
   }
@@ -2273,11 +2322,8 @@ void Viewer2DPanel::OnMouseMove(wxMouseEvent &event) {
   if (m_enableSelection) {
     if (pos == m_lastMousePos)
       return;
-    const wxRect dirtyRect =
-        BuildPointDirtyRegion(m_lastMousePos, 24).Union(BuildPointDirtyRegion(pos, 24));
-    m_mouseMoved = true;
     m_lastMousePos = pos;
-    RequestRepaint(dirtyRect);
+    ScheduleHoverHitTest(pos, false);
   }
 }
 
@@ -2369,18 +2415,9 @@ void Viewer2DPanel::OnMouseLeave(wxMouseEvent &event) {
   m_mouseInside = false;
   ClearCursorWorldPosition();
   if (m_enableSelection) {
-    m_hasHover = false;
-    m_hoverUuid.clear();
-    m_controller.SetHighlightUuid("");
-    if (FixtureTablePanel::Instance())
-      FixtureTablePanel::Instance()->HighlightFixture(std::string());
-    if (TrussTablePanel::Instance())
-      TrussTablePanel::Instance()->HighlightTruss(std::string());
-    if (HoistTablePanel::Instance())
-      HoistTablePanel::Instance()->HighlightHoist(std::string());
-    if (SceneObjectTablePanel::Instance())
-      SceneObjectTablePanel::Instance()->HighlightObject(std::string());
-    RequestRepaint(BuildPointDirtyRegion(m_lastMousePos, 24));
+    m_hoverHitTestTimer.Stop();
+    m_hoverHitTestPending = false;
+    ClearHoverState(true);
   }
   event.Skip();
 }

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -188,6 +188,10 @@ private:
   bool ShouldPauseHeavyTasks();
   void MarkInteractionActivity();
   void OnInteractionPauseTimer(wxTimerEvent &event);
+  void OnHoverHitTestTimer(wxTimerEvent &event);
+  void ScheduleHoverHitTest(const wxPoint &screenPos, bool forceNow = false);
+  void RunHoverHitTest(const wxPoint &screenPos);
+  void ClearHoverState(bool requestRepaint);
 
   struct DragTablePositionSnapshot {
     std::string uuid;
@@ -204,6 +208,8 @@ private:
 
   static constexpr long kSelectionDragDelayMs = 150;
   static constexpr int kDragTableUpdateIntervalMs = 50;
+  static constexpr int kHoverHitTestIntervalMs = 40;
+  static constexpr int kHoverMoveThresholdPx = 3;
   static constexpr std::chrono::milliseconds kPauseDelay{200};
 
   DragMode m_dragMode = DragMode::None;
@@ -227,12 +233,17 @@ private:
   float m_offsetY = 0.0f;
   float m_zoom = 1.0f;
   bool m_mouseInside = false;
-  bool m_mouseMoved = false;
   bool m_hasHover = false;
   std::chrono::steady_clock::time_point m_lastInteractionTime{};
   bool m_isInteracting = false;
   bool m_interactiveLabelMode = false;
   wxTimer m_interactionResumeTimer;
+  wxTimer m_hoverHitTestTimer;
+  wxPoint m_pendingHoverScreenPos;
+  wxPoint m_lastHoverQueryScreenPos;
+  bool m_hoverQueryHasPos = false;
+  bool m_hoverHitTestPending = false;
+  std::chrono::steady_clock::time_point m_lastHoverHitTestTime{};
   bool m_enableSelection = true;
   std::string m_hoverUuid;
   CursorWorldPositionCallback m_cursorWorldPositionCallback;

--- a/viewer3d/picking/selectionsystem.cpp
+++ b/viewer3d/picking/selectionsystem.cpp
@@ -23,7 +23,9 @@
 #include <cfloat>
 #include <cmath>
 #include <cstdio>
+#include <cstring>
 #include <unordered_set>
+#include <wx/log.h>
 
 namespace {
 
@@ -266,6 +268,52 @@ std::string FormatMeters(float mm) {
   return std::string(buffer);
 }
 
+bool ProjectionMatchesCache(const ProjectionSnapshot &projection,
+                            const SelectionSystem::QueryCache &cache) {
+  if (!cache.valid)
+    return false;
+  if (!std::equal(std::begin(projection.viewport), std::end(projection.viewport),
+                  std::begin(cache.viewport))) {
+    return false;
+  }
+  if (!std::equal(std::begin(projection.model), std::end(projection.model),
+                  cache.model.begin())) {
+    return false;
+  }
+  return std::equal(std::begin(projection.projection),
+                    std::end(projection.projection), cache.projection.begin());
+}
+
+void CacheProjectionSnapshot(const ProjectionSnapshot &projection,
+                             SelectionSystem::QueryCache &cache) {
+  cache.valid = true;
+  std::copy(std::begin(projection.viewport), std::end(projection.viewport),
+            std::begin(cache.viewport));
+  std::copy(std::begin(projection.model), std::end(projection.model),
+            cache.model.begin());
+  std::copy(std::begin(projection.projection), std::end(projection.projection),
+            cache.projection.begin());
+  cache.frustum = BuildFrustumSnapshot(projection);
+  cache.visibleSet = nullptr;
+}
+
+void LogQueryMetrics(const char *label, const SelectionSystem::QueryMetrics &metrics,
+                     int queryCounter) {
+#ifndef NDEBUG
+  if (queryCounter % 60 == 0) {
+    wxLogDebug(
+        "SelectionSystem metrics [%s] projection=%lldus depth=%lldus candidate=%lldus",
+        label, static_cast<long long>(metrics.projection.count()),
+        static_cast<long long>(metrics.depthRead.count()),
+        static_cast<long long>(metrics.candidateLoop.count()));
+  }
+#else
+  (void)label;
+  (void)metrics;
+  (void)queryCounter;
+#endif
+}
+
 } // namespace
 
 void SelectionSystem::SetHighlightUuid(const std::string &uuid) {
@@ -279,19 +327,52 @@ void SelectionSystem::SetSelectedUuids(const std::vector<std::string> &uuids) {
 bool SelectionSystem::GetFixtureLabelAt(int mouseX, int mouseY, int width,
                                         int height, wxString &outLabel,
                                         wxPoint &outPos,
-                                        std::string *outUuid) {
+                                        std::string *outUuid,
+                                        bool confirmDepth) {
   ConfigManager &cfg = ConfigManager::Get();
   if (m_controller.IsCameraMoving() && IsFastInteractionModeEnabled(cfg))
     return false;
 
+  QueryMetrics metrics;
+  const auto projectionStart = std::chrono::steady_clock::now();
   const ProjectionSnapshot projection = CaptureProjectionSnapshot();
+  const bool projectionChanged = !ProjectionMatchesCache(projection, m_queryCache);
+  if (projectionChanged) {
+    CacheProjectionSnapshot(projection, m_queryCache);
+    m_queryCache.hiddenLayers.clear();
+  }
+  metrics.projection = std::chrono::duration_cast<std::chrono::microseconds>(
+      std::chrono::steady_clock::now() - projectionStart);
+
   Ray mouseRay;
   if (!BuildMouseRay(mouseX, mouseY, height, projection, mouseRay))
     return false;
-  std::array<double, 3> depthWorldPoint{};
-  const bool hasDepthWorldPoint =
-      ReadWorldPointFromDepth(mouseX, mouseY, height, projection, depthWorldPoint);
   const auto hiddenLayers = SnapshotHiddenLayers(cfg);
+  if (projectionChanged || hiddenLayers != m_queryCache.hiddenLayers) {
+    m_queryCache.hiddenLayers = hiddenLayers;
+    m_queryCache.visibleSet = nullptr;
+  }
+  const auto depthReadStart = std::chrono::steady_clock::now();
+  bool hasDepthWorldPoint = false;
+  std::array<double, 3> depthWorldPoint{};
+  const bool shouldReadDepth = confirmDepth &&
+                               (projectionChanged || m_queryCache.depthMouseX != mouseX ||
+                                m_queryCache.depthMouseY != mouseY ||
+                                m_queryCache.depthHeight != height);
+  if (shouldReadDepth) {
+    m_queryCache.hasDepthWorldPoint =
+        ReadWorldPointFromDepth(mouseX, mouseY, height, projection,
+                                m_queryCache.depthWorldPoint);
+    m_queryCache.depthMouseX = mouseX;
+    m_queryCache.depthMouseY = mouseY;
+    m_queryCache.depthHeight = height;
+  }
+  if (confirmDepth) {
+    hasDepthWorldPoint = m_queryCache.hasDepthWorldPoint;
+    depthWorldPoint = m_queryCache.depthWorldPoint;
+  }
+  metrics.depthRead = std::chrono::duration_cast<std::chrono::microseconds>(
+      std::chrono::steady_clock::now() - depthReadStart);
   bool showName = cfg.GetFloat("label_show_name") != 0.0f;
   bool showId = cfg.GetFloat("label_show_id") != 0.0f;
   bool showDmx = cfg.GetFloat("label_show_dmx") != 0.0f;
@@ -304,11 +385,14 @@ bool SelectionSystem::GetFixtureLabelAt(int mouseX, int mouseY, int width,
   wxPoint bestPos;
   std::string bestUuid;
 
-  const ISelectionContext::ViewFrustumSnapshot frustum =
-      BuildFrustumSnapshot(projection);
-  const ISelectionContext::VisibleSet &visibleSet =
-      m_controller.GetVisibleSet(frustum, hiddenLayers, true, 0.0f);
+  if (!m_queryCache.visibleSet) {
+    m_queryCache.visibleSet =
+        &m_controller.GetVisibleSet(m_queryCache.frustum, m_queryCache.hiddenLayers,
+                                    true, 0.0f);
+  }
+  const ISelectionContext::VisibleSet &visibleSet = *m_queryCache.visibleSet;
 
+  const auto candidateLoopStart = std::chrono::steady_clock::now();
   for (const auto &uuid : visibleSet.fixtureUuids) {
     auto fixtureIt = fixtures.find(uuid);
     if (fixtureIt == fixtures.end())
@@ -364,6 +448,9 @@ bool SelectionSystem::GetFixtureLabelAt(int mouseX, int mouseY, int width,
       found = true;
     }
   }
+  metrics.candidateLoop = std::chrono::duration_cast<std::chrono::microseconds>(
+      std::chrono::steady_clock::now() - candidateLoopStart);
+  LogQueryMetrics("fixture", metrics, ++m_queryCounter);
 
   if (found) {
     outPos = bestPos;
@@ -377,30 +464,64 @@ bool SelectionSystem::GetFixtureLabelAt(int mouseX, int mouseY, int width,
 bool SelectionSystem::GetTrussLabelAt(int mouseX, int mouseY, int width,
                                       int height, wxString &outLabel,
                                       wxPoint &outPos,
-                                      std::string *outUuid) {
+                                      std::string *outUuid,
+                                      bool confirmDepth) {
   ConfigManager &cfg = ConfigManager::Get();
   if (m_controller.IsCameraMoving() && IsFastInteractionModeEnabled(cfg))
     return false;
 
+  QueryMetrics metrics;
+  const auto projectionStart = std::chrono::steady_clock::now();
   const ProjectionSnapshot projection = CaptureProjectionSnapshot();
+  const bool projectionChanged = !ProjectionMatchesCache(projection, m_queryCache);
+  if (projectionChanged) {
+    CacheProjectionSnapshot(projection, m_queryCache);
+    m_queryCache.hiddenLayers.clear();
+  }
+  metrics.projection = std::chrono::duration_cast<std::chrono::microseconds>(
+      std::chrono::steady_clock::now() - projectionStart);
   Ray mouseRay;
   if (!BuildMouseRay(mouseX, mouseY, height, projection, mouseRay))
     return false;
-  std::array<double, 3> depthWorldPoint{};
-  const bool hasDepthWorldPoint =
-      ReadWorldPointFromDepth(mouseX, mouseY, height, projection, depthWorldPoint);
-
   const auto hiddenLayers = SnapshotHiddenLayers(cfg);
+  if (projectionChanged || hiddenLayers != m_queryCache.hiddenLayers) {
+    m_queryCache.hiddenLayers = hiddenLayers;
+    m_queryCache.visibleSet = nullptr;
+  }
+  const auto depthReadStart = std::chrono::steady_clock::now();
+  bool hasDepthWorldPoint = false;
+  std::array<double, 3> depthWorldPoint{};
+  const bool shouldReadDepth = confirmDepth &&
+                               (projectionChanged || m_queryCache.depthMouseX != mouseX ||
+                                m_queryCache.depthMouseY != mouseY ||
+                                m_queryCache.depthHeight != height);
+  if (shouldReadDepth) {
+    m_queryCache.hasDepthWorldPoint =
+        ReadWorldPointFromDepth(mouseX, mouseY, height, projection,
+                                m_queryCache.depthWorldPoint);
+    m_queryCache.depthMouseX = mouseX;
+    m_queryCache.depthMouseY = mouseY;
+    m_queryCache.depthHeight = height;
+  }
+  if (confirmDepth) {
+    hasDepthWorldPoint = m_queryCache.hasDepthWorldPoint;
+    depthWorldPoint = m_queryCache.depthWorldPoint;
+  }
+  metrics.depthRead = std::chrono::duration_cast<std::chrono::microseconds>(
+      std::chrono::steady_clock::now() - depthReadStart);
   const auto &trusses = SceneDataManager::Instance().GetTrusses();
-  const ISelectionContext::ViewFrustumSnapshot frustum =
-      BuildFrustumSnapshot(projection);
-  const ISelectionContext::VisibleSet &visibleSet =
-      m_controller.GetVisibleSet(frustum, hiddenLayers, true, 0.0f);
+  if (!m_queryCache.visibleSet) {
+    m_queryCache.visibleSet =
+        &m_controller.GetVisibleSet(m_queryCache.frustum, m_queryCache.hiddenLayers,
+                                    true, 0.0f);
+  }
+  const ISelectionContext::VisibleSet &visibleSet = *m_queryCache.visibleSet;
   bool found = false;
   double bestHitDistance = DBL_MAX;
   wxString bestLabel;
   wxPoint bestPos;
   std::string bestUuid;
+  const auto candidateLoopStart = std::chrono::steady_clock::now();
   for (const auto &uuid : visibleSet.trussUuids) {
     auto trussIt = trusses.find(uuid);
     if (trussIt == trusses.end())
@@ -443,6 +564,9 @@ bool SelectionSystem::GetTrussLabelAt(int mouseX, int mouseY, int width,
       found = true;
     }
   }
+  metrics.candidateLoop = std::chrono::duration_cast<std::chrono::microseconds>(
+      std::chrono::steady_clock::now() - candidateLoopStart);
+  LogQueryMetrics("truss", metrics, ++m_queryCounter);
 
   if (found) {
     outPos = bestPos;
@@ -456,30 +580,64 @@ bool SelectionSystem::GetTrussLabelAt(int mouseX, int mouseY, int width,
 bool SelectionSystem::GetSceneObjectLabelAt(int mouseX, int mouseY, int width,
                                             int height, wxString &outLabel,
                                             wxPoint &outPos,
-                                            std::string *outUuid) {
+                                            std::string *outUuid,
+                                            bool confirmDepth) {
   ConfigManager &cfg = ConfigManager::Get();
   if (m_controller.IsCameraMoving() && IsFastInteractionModeEnabled(cfg))
     return false;
 
+  QueryMetrics metrics;
+  const auto projectionStart = std::chrono::steady_clock::now();
   const ProjectionSnapshot projection = CaptureProjectionSnapshot();
+  const bool projectionChanged = !ProjectionMatchesCache(projection, m_queryCache);
+  if (projectionChanged) {
+    CacheProjectionSnapshot(projection, m_queryCache);
+    m_queryCache.hiddenLayers.clear();
+  }
+  metrics.projection = std::chrono::duration_cast<std::chrono::microseconds>(
+      std::chrono::steady_clock::now() - projectionStart);
   Ray mouseRay;
   if (!BuildMouseRay(mouseX, mouseY, height, projection, mouseRay))
     return false;
-  std::array<double, 3> depthWorldPoint{};
-  const bool hasDepthWorldPoint =
-      ReadWorldPointFromDepth(mouseX, mouseY, height, projection, depthWorldPoint);
-
   const auto hiddenLayers = SnapshotHiddenLayers(cfg);
+  if (projectionChanged || hiddenLayers != m_queryCache.hiddenLayers) {
+    m_queryCache.hiddenLayers = hiddenLayers;
+    m_queryCache.visibleSet = nullptr;
+  }
+  const auto depthReadStart = std::chrono::steady_clock::now();
+  bool hasDepthWorldPoint = false;
+  std::array<double, 3> depthWorldPoint{};
+  const bool shouldReadDepth = confirmDepth &&
+                               (projectionChanged || m_queryCache.depthMouseX != mouseX ||
+                                m_queryCache.depthMouseY != mouseY ||
+                                m_queryCache.depthHeight != height);
+  if (shouldReadDepth) {
+    m_queryCache.hasDepthWorldPoint =
+        ReadWorldPointFromDepth(mouseX, mouseY, height, projection,
+                                m_queryCache.depthWorldPoint);
+    m_queryCache.depthMouseX = mouseX;
+    m_queryCache.depthMouseY = mouseY;
+    m_queryCache.depthHeight = height;
+  }
+  if (confirmDepth) {
+    hasDepthWorldPoint = m_queryCache.hasDepthWorldPoint;
+    depthWorldPoint = m_queryCache.depthWorldPoint;
+  }
+  metrics.depthRead = std::chrono::duration_cast<std::chrono::microseconds>(
+      std::chrono::steady_clock::now() - depthReadStart);
   const auto &objs = SceneDataManager::Instance().GetSceneObjects();
-  const ISelectionContext::ViewFrustumSnapshot frustum =
-      BuildFrustumSnapshot(projection);
-  const ISelectionContext::VisibleSet &visibleSet =
-      m_controller.GetVisibleSet(frustum, hiddenLayers, true, 0.0f);
+  if (!m_queryCache.visibleSet) {
+    m_queryCache.visibleSet =
+        &m_controller.GetVisibleSet(m_queryCache.frustum, m_queryCache.hiddenLayers,
+                                    true, 0.0f);
+  }
+  const ISelectionContext::VisibleSet &visibleSet = *m_queryCache.visibleSet;
   bool found = false;
   double bestHitDistance = DBL_MAX;
   wxString bestLabel;
   wxPoint bestPos;
   std::string bestUuid;
+  const auto candidateLoopStart = std::chrono::steady_clock::now();
   for (const auto &uuid : visibleSet.objectUuids) {
     auto objectIt = objs.find(uuid);
     if (objectIt == objs.end())
@@ -519,6 +677,9 @@ bool SelectionSystem::GetSceneObjectLabelAt(int mouseX, int mouseY, int width,
       found = true;
     }
   }
+  metrics.candidateLoop = std::chrono::duration_cast<std::chrono::microseconds>(
+      std::chrono::steady_clock::now() - candidateLoopStart);
+  LogQueryMetrics("object", metrics, ++m_queryCounter);
 
   if (found) {
     outPos = bestPos;

--- a/viewer3d/picking/selectionsystem.h
+++ b/viewer3d/picking/selectionsystem.h
@@ -1,7 +1,10 @@
 #pragma once
 
 #include "iselectioncontext.h"
+#include <array>
+#include <chrono>
 #include <string>
+#include <unordered_set>
 #include <vector>
 #include <wx/gdicmn.h>
 #include <wx/string.h>
@@ -14,13 +17,16 @@ public:
   void SetSelectedUuids(const std::vector<std::string> &uuids);
   bool GetFixtureLabelAt(int mouseX, int mouseY, int width, int height,
                          wxString &outLabel, wxPoint &outPos,
-                         std::string *outUuid = nullptr);
+                         std::string *outUuid = nullptr,
+                         bool confirmDepth = false);
   bool GetTrussLabelAt(int mouseX, int mouseY, int width, int height,
                        wxString &outLabel, wxPoint &outPos,
-                       std::string *outUuid = nullptr);
+                       std::string *outUuid = nullptr,
+                       bool confirmDepth = false);
   bool GetSceneObjectLabelAt(int mouseX, int mouseY, int width, int height,
                              wxString &outLabel, wxPoint &outPos,
-                             std::string *outUuid = nullptr);
+                             std::string *outUuid = nullptr,
+                             bool confirmDepth = false);
   std::vector<std::string> GetFixturesInScreenRect(int x1, int y1, int x2,
                                                    int y2, int width,
                                                    int height) const;
@@ -31,6 +37,31 @@ public:
                                                        int x2, int y2,
                                                        int width,
                                                        int height) const;
+
+public:
+  struct QueryCache {
+    bool valid = false;
+    int viewport[4]{};
+    std::array<double, 16> model{};
+    std::array<double, 16> projection{};
+    ISelectionContext::ViewFrustumSnapshot frustum{};
+    std::unordered_set<std::string> hiddenLayers;
+    const ISelectionContext::VisibleSet *visibleSet = nullptr;
+    bool hasDepthWorldPoint = false;
+    std::array<double, 3> depthWorldPoint{0.0, 0.0, 0.0};
+    int depthMouseX = -1;
+    int depthMouseY = -1;
+    int depthHeight = -1;
+  };
+
+  struct QueryMetrics {
+    std::chrono::microseconds projection{0};
+    std::chrono::microseconds depthRead{0};
+    std::chrono::microseconds candidateLoop{0};
+  };
+
+  mutable QueryCache m_queryCache;
+  mutable int m_queryCounter = 0;
 
 private:
   ISelectionContext &m_controller;

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1782,27 +1782,32 @@ void Viewer3DController::SetupMaterialFromRGB(float r, float g, float b) {
 bool Viewer3DController::GetFixtureLabelAt(int mouseX, int mouseY, int width,
                                            int height, wxString &outLabel,
                                            wxPoint &outPos,
-                                           std::string *outUuid) {
+                                           std::string *outUuid,
+                                           bool confirmDepth) {
   return m_impl->selectionSystem->GetFixtureLabelAt(mouseX, mouseY, width, height,
-                                              outLabel, outPos, outUuid);
+                                                     outLabel, outPos, outUuid,
+                                                     confirmDepth);
 }
 
 bool Viewer3DController::GetTrussLabelAt(int mouseX, int mouseY, int width,
                                          int height, wxString &outLabel,
                                          wxPoint &outPos,
-                                         std::string *outUuid) {
+                                         std::string *outUuid,
+                                         bool confirmDepth) {
   return m_impl->selectionSystem->GetTrussLabelAt(mouseX, mouseY, width, height,
-                                            outLabel, outPos, outUuid);
+                                                   outLabel, outPos, outUuid,
+                                                   confirmDepth);
 }
 
 bool Viewer3DController::GetSceneObjectLabelAt(int mouseX, int mouseY,
                                                 int width, int height,
                                                 wxString &outLabel,
                                                 wxPoint &outPos,
-                                                std::string *outUuid) {
+                                                std::string *outUuid,
+                                                bool confirmDepth) {
   return m_impl->selectionSystem->GetSceneObjectLabelAt(mouseX, mouseY, width,
-                                                  height, outLabel, outPos,
-                                                  outUuid);
+                                                         height, outLabel, outPos,
+                                                         outUuid, confirmDepth);
 }
 
 std::vector<std::string> Viewer3DController::GetFixturesInScreenRect(

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -115,13 +115,16 @@ public:
 
   bool GetFixtureLabelAt(int mouseX, int mouseY, int width, int height,
                          wxString &outLabel, wxPoint &outPos,
-                         std::string *outUuid = nullptr);
+                         std::string *outUuid = nullptr,
+                         bool confirmDepth = false);
   bool GetTrussLabelAt(int mouseX, int mouseY, int width, int height,
                        wxString &outLabel, wxPoint &outPos,
-                       std::string *outUuid = nullptr);
+                       std::string *outUuid = nullptr,
+                       bool confirmDepth = false);
   bool GetSceneObjectLabelAt(int mouseX, int mouseY, int width, int height,
                              wxString &outLabel, wxPoint &outPos,
-                             std::string *outUuid = nullptr);
+                             std::string *outUuid = nullptr,
+                             bool confirmDepth = false);
 
   const VisibleSet &
   GetVisibleSet(const ViewFrustumSnapshot &frustum,


### PR DESCRIPTION
### Motivation
- Reduce expensive per-paint hit-testing in the 2D view to improve interactive performance and avoid repeated `glReadPixels` during hover. 
- Reuse projection/frustum/visible-set state across repeated selection queries when camera/viewport/layers are unchanged to avoid redundant work. 
- Use a lightweight ray/AABB fallback for hover and confirm depth with an explicit final click to minimize depth-buffer reads. 
- Provide per-phase timing metrics to measure and compare hover/selection performance.

### Description
- Move hover hit-testing out of `Viewer2DPanel::OnPaint` into a throttled path driven by mouse movement and a hover timer, with `kHoverHitTestIntervalMs = 40` and a small movement threshold (3 px), and add helpers `ScheduleHoverHitTest`, `RunHoverHitTest`, `OnHoverHitTestTimer`, and `ClearHoverState` in `viewer2d/viewer2dpanel.{h,cpp}`. 
- Replace continuous depth reads during hover with an optional `confirmDepth` flag on selection APIs so hover calls use ray/AABB only (`confirmDepth=false`) while final click/selection uses `confirmDepth=true`; propagate the flag through `viewer3dcontroller.h/.cpp` to `selectionsystem`. 
- Add a per-query `QueryCache` and `QueryMetrics` in `viewer3d/picking/selectionsystem.{h,cpp}` to cache projection/frustum, visible set, and a single depth sample for reuse across repeated queries, and to measure `projection`, `depth read`, and `candidate loop` durations with periodic debug logging. 
- Reuse cached `visibleSet` for the current projection/hidden-layer state and only rebuild it when projection or hidden layers change, and only sample depth when `confirmDepth` requests it or relevant inputs changed. 
- Adjusted hover and click call sites in `viewer2d/viewer2dpanel.cpp` to schedule throttled hover queries and to call selection queries with `confirmDepth=true` on final clicks and context actions.
- Files changed: `viewer2d/viewer2dpanel.cpp/.h`, `viewer3d/picking/selectionsystem.cpp/.h`, `viewer3d/viewer3dcontroller.cpp/.h`.
- Technical note: `viewer2d/viewer2dpanel.cpp` remains a hotspot (~2.3k LOC); next recommended split is extracting hover-selection orchestration into a focused unit (e.g., `viewer2d_hover_selection.{h,cpp}`) to keep the panel smaller (follow file-size guardrail).

### Testing
- `tests/check_perastage_tree_modules.sh` ran and returned OK. 
- `tests/check_no_configmanager_get_in_gui.sh` ran and returned OK. 
- `cmake -S . -B build` was executed in this environment and failed due to missing system `wxWidgets` development packages, so a full build was not verified here (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea64267f6083249b63833ff1c763bc)