### PR TITLE
Refine interaction-driven label behavior in 2D/3D viewers

### DIFF
--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -738,12 +738,13 @@ void Viewer2DPanel::RenderInternal(bool swapBuffers) {
     return;
   }
   // Interaction policy:
-  // - Keep throttling expensive synchronization while the user is dragging,
-  //   panning or selecting.
-  // - Keep fixture labels visible using an explicit interactive mode so the
-  //   overlay does not flicker/disappear during interaction.
+  // - Keep throttling expensive synchronization while recent interaction is
+  //   active.
+  // - Use interactive label mode only for visually expensive interaction
+  //   paths. Simple selection clicks must not toggle it.
   const bool pauseHeavyTasks = m_enableSelection && ShouldPauseHeavyTasks();
-  m_interactiveLabelMode = m_enableSelection && pauseHeavyTasks;
+  m_interactiveLabelMode =
+      m_enableSelection && IsExpensiveVisualInteractionActive();
   const RenderSize resolvedSize = ResolveRenderSize(this);
   const int w = resolvedSize.width;
   const int h = resolvedSize.height;
@@ -1542,6 +1543,19 @@ bool Viewer2DPanel::ShouldPauseHeavyTasks() {
 
   m_isInteracting = false;
   return false;
+}
+
+bool Viewer2DPanel::IsExpensiveVisualInteractionActive() const {
+  if (!m_enableSelection)
+    return false;
+
+  if (m_rectSelecting || m_dragMode == DragMode::RectSelection)
+    return true;
+
+  if (m_dragMode == DragMode::View)
+    return true;
+
+  return m_dragMode == DragMode::Selection && m_dragSelectionMoved;
 }
 
 void Viewer2DPanel::MarkInteractionActivity() {

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -192,6 +192,7 @@ private:
   void ScheduleHoverHitTest(const wxPoint &screenPos, bool forceNow = false);
   void RunHoverHitTest(const wxPoint &screenPos);
   void ClearHoverState(bool requestRepaint);
+  bool IsExpensiveVisualInteractionActive() const;
 
   struct DragTablePositionSnapshot {
     std::string uuid;

--- a/viewer3d/labels/label_render_system.cpp
+++ b/viewer3d/labels/label_render_system.cpp
@@ -79,7 +79,6 @@ struct FixtureLayoutKey {
   float labelDist = 0.0f;
   float labelAngle = 0.0f;
   Viewer2DView view = Viewer2DView::Top;
-  bool interactive = false;
 
   bool operator==(const FixtureLayoutKey &other) const {
     return uuid == other.uuid && instanceName == other.instanceName &&
@@ -88,7 +87,7 @@ struct FixtureLayoutKey {
            showDmx == other.showDmx && nameSize == other.nameSize &&
            idSize == other.idSize && dmxSize == other.dmxSize &&
            labelDist == other.labelDist && labelAngle == other.labelAngle &&
-           view == other.view && interactive == other.interactive;
+           view == other.view;
   }
 };
 
@@ -166,24 +165,18 @@ FixtureLayoutCacheEntry BuildFixtureLayoutEntry(const FixtureLayoutKey &layoutKe
   }
 
   if (layoutKey.showName) {
+    // selection must not alter label text layout.
     wxString baseName = layoutKey.instanceName.empty()
                             ? wxString::FromUTF8(layoutKey.uuid)
                             : wxString::FromUTF8(layoutKey.instanceName);
-    if (layoutKey.interactive) {
-      auto utf8 = baseName.ToUTF8();
+    wxString wrapped = WrapEveryTwoWords(baseName);
+    wxStringTokenizer nameLines(wrapped, "\n");
+    while (nameLines.HasMoreTokens()) {
+      wxString line = nameLines.GetNextToken();
+      auto utf8 = line.ToUTF8();
       entry.lines.push_back(
           {std::string(utf8.data(), utf8.length()), layoutKey.nameSize,
            kRegularFamily, false});
-    } else {
-      wxString wrapped = WrapEveryTwoWords(baseName);
-      wxStringTokenizer nameLines(wrapped, "\n");
-      while (nameLines.HasMoreTokens()) {
-        wxString line = nameLines.GetNextToken();
-        auto utf8 = line.ToUTF8();
-        entry.lines.push_back(
-            {std::string(utf8.data(), utf8.length()), layoutKey.nameSize,
-             kRegularFamily, false});
-      }
     }
   }
 
@@ -762,8 +755,6 @@ void LabelRenderSystem::DrawAllFixtureLabels(int width, int height,
     desiredKey.labelAngle =
         viewer2d::ResolveLabelOffsetAngle(cfg, overrideSettings, viewIdx);
     desiredKey.view = view;
-    desiredKey.interactive = interactiveLabelMode;
-
     auto cacheIt = layoutCacheState.fixtureLayoutByUuid.find(uuid);
     const bool needsRebuild =
         cacheIt == layoutCacheState.fixtureLayoutByUuid.end() ||


### PR DESCRIPTION
### Motivation
- Avoid toggling text layout during cheap interactions so a simple click selection does not change other fixtures' label formatting between frames.
- Make `m_interactiveLabelMode` reflect visually expensive interactions only, so heavy-task throttling and label rendering optimizations are decoupled.
- Keep interactive degradations limited to culling/limits rather than changing text wrapping or layout.

### Description
- Replaced direct derivation of `m_interactiveLabelMode` from `ShouldPauseHeavyTasks()` and added `Viewer2DPanel::IsExpensiveVisualInteractionActive()` to enable interactive label mode only for expensive visual paths such as view dragging, rectangle selection, or a selection drag that has moved, while excluding simple click selection (`viewer2d/viewer2dpanel.h` and `viewer2d/viewer2dpanel.cpp`).
- Implemented the expensive-interaction predicate to check `DragMode::View`, `DragMode::RectSelection`/`m_rectSelecting`, and `DragMode::Selection` with `m_dragSelectionMoved`.
- Removed the interactive-based wrapping branch in `viewer3d/labels/label_render_system.cpp` so fixture names always use `WrapEveryTwoWords`, and added the explicit comment: "selection must not alter label text layout".
- Dropped `interactive` from `FixtureLayoutKey` and its equality comparison so the text layout cache key no longer depends on transient interactive state; interactive degradation remains implemented via culling/label-count limits rather than text formatting.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed (`OK`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea8a2fa1808324a2525d17c0e57a12)