### PR TITLE
Unify deterministic fixture GDTF path resolution

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/dictionary_export_conflict_dialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dataview_edit_commit.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/editable_focus_utils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/fixtures/fixture_gdtf_resolution.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tools/fixture_symbol_generation_tool.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tools/fixture_category_assignment_tool.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tools/scene_model_symbol_capture_service.cpp

--- a/gui/fixtures/fixture_gdtf_resolution.cpp
+++ b/gui/fixtures/fixture_gdtf_resolution.cpp
@@ -1,0 +1,115 @@
+#include "fixtures/fixture_gdtf_resolution.h"
+
+#include <filesystem>
+#include <sstream>
+
+#include <wx/log.h>
+
+#include "projectutils.h"
+
+namespace fs = std::filesystem;
+
+namespace gui::fixtures {
+namespace {
+
+std::string BuildLogPrefix(const Fixture &fixture,
+                           const MvrScene &scene,
+                           const fs::path &specPath) {
+  std::ostringstream out;
+  out << "[FixtureGdtfResolution] uuid='" << fixture.uuid << "'"
+      << " scene.basePath='" << scene.basePath << "'"
+      << " gdtfSpec='" << specPath.string() << "'";
+  return out.str();
+}
+
+void LogDiscardReason(const std::string &prefix,
+                      const std::string &candidateLabel,
+                      const fs::path &candidatePath,
+                      const std::string &reason) {
+  wxLogDebug("%s discarded %s candidate '%s': %s", prefix.c_str(),
+             candidateLabel.c_str(), candidatePath.string().c_str(), reason.c_str());
+}
+
+} // namespace
+
+bool ResolveFixtureGdtfDeterministic(const Fixture &fixture,
+                                     const MvrScene &scene,
+                                     FixtureGdtfResolution &resolution,
+                                     std::string &errorMessage) {
+  resolution = {};
+
+  const fs::path specPath = fs::path(fixture.gdtfSpec);
+  const std::string logPrefix = BuildLogPrefix(fixture, scene, specPath);
+
+  if (specPath.empty()) {
+    errorMessage = "Fixture gdtfSpec is empty; deterministic resolution requires a valid path or file name.";
+    wxLogDebug("%s failed: %s", logPrefix.c_str(), errorMessage.c_str());
+    return false;
+  }
+
+  std::error_code ec;
+  if (specPath.is_absolute()) {
+    ec.clear();
+    if (fs::exists(specPath, ec) && !ec) {
+      resolution.selectedPath = specPath.string();
+      wxLogDebug("%s selected absolute candidate '%s'.", logPrefix.c_str(),
+                 resolution.selectedPath.c_str());
+      return true;
+    }
+    LogDiscardReason(logPrefix, "absolute", specPath,
+                     ec ? ec.message() : "path does not exist");
+  }
+
+  if (!scene.basePath.empty() && !specPath.is_absolute()) {
+    const fs::path sceneCandidate = fs::path(scene.basePath) / specPath;
+    ec.clear();
+    if (fs::exists(sceneCandidate, ec) && !ec) {
+      resolution.scenePath = sceneCandidate.string();
+      resolution.selectedPath = resolution.scenePath;
+      wxLogDebug("%s selected scene candidate '%s'.", logPrefix.c_str(),
+                 resolution.selectedPath.c_str());
+      return true;
+    }
+    LogDiscardReason(logPrefix, "scene", sceneCandidate,
+                     ec ? ec.message() : "path does not exist");
+  } else if (scene.basePath.empty()) {
+    LogDiscardReason(logPrefix, "scene", {}, "scene.basePath is empty");
+  } else {
+    LogDiscardReason(logPrefix, "scene", specPath,
+                     "gdtfSpec is absolute, scene-relative resolution skipped");
+  }
+
+  const std::string fileName = specPath.filename().string();
+  if (fileName.empty()) {
+    errorMessage =
+        "Fixture gdtfSpec has no file name; cannot resolve fixtures library candidate.";
+    wxLogDebug("%s failed: %s", logPrefix.c_str(), errorMessage.c_str());
+    return false;
+  }
+
+  const fs::path fixturesLibrary =
+      fs::path(ProjectUtils::GetDefaultLibraryPath("fixtures"));
+  const fs::path libraryCandidate = fixturesLibrary / fileName;
+  ec.clear();
+  if (fs::exists(libraryCandidate, ec) && !ec) {
+    resolution.libraryPath = libraryCandidate.string();
+    resolution.selectedPath = resolution.libraryPath;
+    wxLogDebug("%s selected library candidate '%s'.", logPrefix.c_str(),
+               resolution.selectedPath.c_str());
+    return true;
+  }
+
+  LogDiscardReason(logPrefix, "library", libraryCandidate,
+                   ec ? ec.message() : "path does not exist");
+
+  std::ostringstream out;
+  out << "Could not resolve fixture GDTF path deterministically for fixture uuid '"
+      << fixture.uuid << "'."
+      << " scene.basePath='" << scene.basePath << "'"
+      << " gdtfSpec='" << fixture.gdtfSpec << "'.";
+  errorMessage = out.str();
+  wxLogDebug("%s failed: %s", logPrefix.c_str(), errorMessage.c_str());
+  return false;
+}
+
+} // namespace gui::fixtures

--- a/gui/fixtures/fixture_gdtf_resolution.h
+++ b/gui/fixtures/fixture_gdtf_resolution.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <string>
+
+#include "fixture.h"
+#include "mvrscene.h"
+
+namespace gui::fixtures {
+
+struct FixtureGdtfResolution {
+  std::string scenePath;
+  std::string libraryPath;
+  std::string selectedPath;
+};
+
+bool ResolveFixtureGdtfDeterministic(const Fixture &fixture,
+                                     const MvrScene &scene,
+                                     FixtureGdtfResolution &resolution,
+                                     std::string &errorMessage);
+
+} // namespace gui::fixtures

--- a/gui/tools/symbol_physical_calibration.cpp
+++ b/gui/tools/symbol_physical_calibration.cpp
@@ -3,16 +3,12 @@
 #include <algorithm>
 #include <array>
 #include <cfloat>
-#include <filesystem>
 #include <unordered_map>
 
 #include "configmanager.h"
-#include "gdtfdictionary.h"
-#include "projectutils.h"
+#include "fixtures/fixture_gdtf_resolution.h"
 #include "types.h"
 #include "gdtfloader.h"
-
-namespace fs = std::filesystem;
 
 namespace tools {
 namespace {
@@ -45,74 +41,6 @@ void ExtendBounds(Bounds3D &bounds, const std::array<float, 3> &p) {
   bounds.max[1] = std::max(bounds.max[1], p[1]);
   bounds.max[2] = std::max(bounds.max[2], p[2]);
   bounds.valid = true;
-}
-
-std::string ResolveFixtureGdtfPath(const Fixture &fixture, const MvrScene &scene) {
-  const fs::path specPath = fs::path(fixture.gdtfSpec);
-  if (specPath.empty())
-    return {};
-
-  std::error_code ec;
-  if (specPath.is_absolute() && fs::exists(specPath, ec) && !ec)
-    return specPath.string();
-
-  if (!scene.basePath.empty()) {
-    ec.clear();
-    const fs::path fromScene = fs::path(scene.basePath) / specPath;
-    if (fs::exists(fromScene, ec) && !ec)
-      return fromScene.string();
-  }
-
-  ec.clear();
-  const fs::path fromCwd = fs::current_path(ec) / specPath;
-  if (!ec && fs::exists(fromCwd, ec) && !ec)
-    return fromCwd.string();
-
-  const std::string specFileName = specPath.filename().string();
-  const fs::path fixturesLibrary =
-      fs::path(ProjectUtils::GetDefaultLibraryPath("fixtures"));
-
-  auto dictOpt = GdtfDictionary::Load();
-  if (dictOpt) {
-    const auto &dict = *dictOpt;
-    auto findByKey = [&](const std::string &key) -> std::string {
-      if (key.empty())
-        return {};
-      auto it = dict.find(key);
-      if (it == dict.end() || it->second.path.empty())
-        return {};
-      std::error_code localEc;
-      if (!fs::exists(it->second.path, localEc) || localEc)
-        return {};
-      return it->second.path;
-    };
-
-    if (std::string byType = findByKey(fixture.typeName); !byType.empty())
-      return byType;
-
-    if (!specFileName.empty()) {
-      for (const auto &[type, entry] : dict) {
-        (void)type;
-        if (entry.path.empty())
-          continue;
-        const fs::path entryPath = fs::path(entry.path);
-        if (entryPath.filename() != specFileName)
-          continue;
-        std::error_code localEc;
-        if (fs::exists(entryPath, localEc) && !localEc)
-          return entryPath.string();
-      }
-    }
-  }
-
-  if (!specFileName.empty()) {
-    ec.clear();
-    const fs::path exactPath = fixturesLibrary / specFileName;
-    if (fs::exists(exactPath, ec) && !ec)
-      return exactPath.string();
-  }
-
-  return {};
 }
 
 bool ComputeFixtureBoundsMm(const std::string &gdtfPath, Bounds3D &bounds,
@@ -212,11 +140,12 @@ bool CalibrateFixtureSymbolsToPhysicalUnits(ConfigManager &cfg,
     return false;
   }
 
-  const std::string gdtfPath = ResolveFixtureGdtfPath(fixtureIt->second, cfg.GetScene());
-  if (gdtfPath.empty()) {
-    errorMessage = "Could not resolve fixture GDTF path for symbol calibration.";
+  gui::fixtures::FixtureGdtfResolution resolution;
+  if (!gui::fixtures::ResolveFixtureGdtfDeterministic(
+          fixtureIt->second, cfg.GetScene(), resolution, errorMessage)) {
     return false;
   }
+  const std::string gdtfPath = resolution.selectedPath;
 
   Bounds3D fixtureBounds;
   if (!ComputeFixtureBoundsMm(gdtfPath, fixtureBounds, errorMessage))

--- a/gui/windows/symbol_fixture_applier.cpp
+++ b/gui/windows/symbol_fixture_applier.cpp
@@ -22,10 +22,10 @@
 #include <wx/zipstrm.h>
 
 #include "configmanager.h"
+#include "fixtures/fixture_gdtf_resolution.h"
 #include "guiconfigservices.h"
 #include "gdtfdictionary.h"
 #include "gdtf_mutation_audit.h"
-#include "projectutils.h"
 #include "windows/symbol_preview_exporter.h"
 
 namespace fs = std::filesystem;
@@ -195,93 +195,6 @@ bool EnsureSceneLocalGdtfCopy(const fs::path &sourcePath,
   fixture.gdtfSpec = relativeSpec;
   scenePathOut = targetPath.string();
   return true;
-}
-
-std::string ResolveSceneGdtfPath(const Fixture &fixture, const MvrScene &scene) {
-  const fs::path specPath = fs::path(fixture.gdtfSpec);
-  if (specPath.empty())
-    return {};
-
-  std::error_code ec;
-  if (specPath.is_absolute() && fs::exists(specPath, ec) && !ec)
-    return specPath.string();
-
-  if (!scene.basePath.empty()) {
-    ec.clear();
-    const fs::path fromScene = fs::path(scene.basePath) / specPath;
-    if (fs::exists(fromScene, ec) && !ec)
-      return fromScene.string();
-  }
-
-  ec.clear();
-  const fs::path fromCwd = fs::current_path(ec) / specPath;
-  if (!ec && fs::exists(fromCwd, ec) && !ec)
-    return fromCwd.string();
-
-  return {};
-}
-
-std::string ResolveLibraryGdtfPath(const Fixture &fixture) {
-  const fs::path specPath = fs::path(fixture.gdtfSpec);
-  const std::string specFileName = specPath.filename().string();
-
-  std::error_code ec;
-  const fs::path fixturesLibrary =
-      fs::path(ProjectUtils::GetDefaultLibraryPath("fixtures"));
-
-  if (specPath.is_absolute()) {
-    ec.clear();
-    if (fs::exists(specPath, ec) && !ec)
-      return specPath.string();
-  }
-
-  if (!specFileName.empty()) {
-    ec.clear();
-    const fs::path exactPath = fixturesLibrary / specFileName;
-    if (fs::exists(exactPath, ec) && !ec)
-      return exactPath.string();
-  }
-
-  auto dictOpt = GdtfDictionary::Load();
-  if (dictOpt) {
-    const auto &dict = *dictOpt;
-    auto findByKey = [&](const std::string &key) -> std::string {
-      if (key.empty())
-        return {};
-      auto it = dict.find(key);
-      if (it == dict.end() || it->second.path.empty())
-        return {};
-      std::error_code localEc;
-      if (!fs::exists(it->second.path, localEc) || localEc)
-        return {};
-      return it->second.path;
-    };
-
-    if (std::string byType = findByKey(fixture.typeName); !byType.empty()) {
-      if (specFileName.empty())
-        return byType;
-      if (fs::path(byType).filename() == specFileName)
-        return byType;
-    }
-
-    if (!specFileName.empty()) {
-      for (const auto &[type, entry] : dict) {
-        (void)type;
-        if (entry.path.empty())
-          continue;
-
-        const fs::path entryPath = fs::path(entry.path);
-        if (entryPath.filename() != specFileName)
-          continue;
-
-        std::error_code localEc;
-        if (fs::exists(entryPath, localEc) && !localEc)
-          return entryPath.string();
-      }
-    }
-  }
-
-  return {};
 }
 
 
@@ -676,14 +589,15 @@ bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
     return false;
   }
 
-  const std::string scenePath = ResolveSceneGdtfPath(fixtureIt->second, scene);
-  const std::string libraryPath = ResolveLibraryGdtfPath(fixtureIt->second);
-  if (scenePath.empty() && libraryPath.empty()) {
-    errorMessage = "Could not resolve fixture GDTF path in scene or fixtures library.";
+  gui::fixtures::FixtureGdtfResolution resolution;
+  if (!gui::fixtures::ResolveFixtureGdtfDeterministic(fixtureIt->second, scene,
+                                                      resolution, errorMessage)) {
     return false;
   }
+  const std::string scenePath = resolution.scenePath;
+  const std::string libraryPath = resolution.libraryPath;
 
-  const std::string inspectPath = scenePath.empty() ? libraryPath : scenePath;
+  const std::string inspectPath = resolution.selectedPath;
   std::string modelSvgBase = ResolveModelSvgBasename(inspectPath, errorMessage);
   if (modelSvgBase.empty())
     return false;
@@ -780,14 +694,16 @@ bool InspectFixtureSymbolState(const Fixture &fixture,
                                std::string &errorMessage) {
   result = {};
 
-  const std::string scenePath = ResolveSceneGdtfPath(fixture, scene);
-  const std::string libraryPath = ResolveLibraryGdtfPath(fixture);
-  result.scenePath = scenePath;
-  result.libraryPath = libraryPath;
-
-  std::string inspectPath = scenePath.empty() ? libraryPath : scenePath;
-  if (inspectPath.empty())
-    return true;
+  gui::fixtures::FixtureGdtfResolution resolution;
+  if (!gui::fixtures::ResolveFixtureGdtfDeterministic(fixture, scene, resolution,
+                                                      errorMessage)) {
+    result.scenePath = resolution.scenePath;
+    result.libraryPath = resolution.libraryPath;
+    return false;
+  }
+  result.scenePath = resolution.scenePath;
+  result.libraryPath = resolution.libraryPath;
+  std::string inspectPath = resolution.selectedPath;
 
   result.hasResolvableGdtf = true;
 
@@ -877,8 +793,13 @@ bool InspectFixtureSymbolState(const Fixture &fixture,
 bool SyncFixtureGdtfToLibrary(const Fixture &fixture,
                               const MvrScene &scene,
                               std::string &errorMessage) {
-  const std::string scenePath = ResolveSceneGdtfPath(fixture, scene);
-  const std::string libraryPath = ResolveLibraryGdtfPath(fixture);
+  gui::fixtures::FixtureGdtfResolution resolution;
+  if (!gui::fixtures::ResolveFixtureGdtfDeterministic(fixture, scene, resolution,
+                                                      errorMessage)) {
+    return false;
+  }
+  const std::string scenePath = resolution.scenePath;
+  const std::string libraryPath = resolution.libraryPath;
   if (scenePath.empty() || libraryPath.empty() || scenePath == libraryPath)
     return true;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1073,6 +1073,7 @@ set_library_env(GdtfLoaderSetPropertiesMutation)
 
 add_executable(symbol_fixture_applier_gdtf_test symbol_fixture_applier_gdtf_test.cpp
                ../gui/windows/symbol_fixture_applier.cpp
+               ../gui/fixtures/fixture_gdtf_resolution.cpp
                ../gui/windows/symbol_preview_exporter.cpp
                ../core/configmanager.cpp
                ../core/configservices.cpp


### PR DESCRIPTION
### Motivation
- Remove ad-hoc `fs::current_path()` fallback and make `fixture.gdtfSpec` resolution deterministic and auditable.
- Ensure symbol generation, inspection and calibration consistently pick the same GDTF file and emit explicit errors when none of the deterministic candidates exist.

### Description
- Add a shared resolver `gui::fixtures::ResolveFixtureGdtfDeterministic` with the exact candidate order: absolute existing path → scene-relative using `scene.basePath` → fixtures library by file name via `ProjectUtils::GetDefaultLibraryPath("fixtures")` → explicit error if none match, and expose `FixtureGdtfResolution` with `scenePath`, `libraryPath` and `selectedPath`.
- Replace local resolution logic in `gui/windows/symbol_fixture_applier.cpp` and `gui/tools/symbol_physical_calibration.cpp` to use the shared resolver and remove the `fs::current_path()` fallback.
- Add diagnostic `wxLogDebug` traces that include fixture `uuid`, `scene.basePath`, `gdtfSpec`, the final selected path, and discard reasons for each candidate.
- Register the new source file in `gui/CMakeLists.txt` and keep behavior unchanged elsewhere (only resolution and logging changed).

### Testing
- Ran architecture and hygiene checks: `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both returned OK.
- Attempted project configuration with `cmake -S . -B build`, which failed in this environment because `wxWidgets` development packages are not available (expected in CI/dev machines with deps installed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea9d619f2883249babb8f288a406d5)