### PR TITLE
Use deterministic offscreen defaults for 2D symbol capture

### DIFF
--- a/gui/tools/scene_model_symbol_capture_service.cpp
+++ b/gui/tools/scene_model_symbol_capture_service.cpp
@@ -212,16 +212,15 @@ CaptureSceneModelOrthographicSymbols(Viewer2DOffscreenRenderer &renderer,
   renderOverrides.showGrid = false;
   renderOverrides.showRuler = false;
   renderOverrides.drawFixtureLabels = false;
+  renderOverrides.forceBottomViewForTopFixtures = false;
   renderOverrides.symbolCaptureRenderProfile = true;
   renderOverrides.symbolCaptureIncludeCoplanarEdges = true;
   ScopedViewer2DRenderOverrides scopedRenderOverrides(*capturePanel,
                                                       renderOverrides);
 
   renderer.SetViewportSize(options.viewportSize);
+  renderer.ApplySymbolCaptureDefaults();
   renderer.PrepareForCapture();
-  capturePanel->SetPreferPerastageSvgSymbolsForLayouts(false);
-  capturePanel->SetRenderMode(Viewer2DRenderMode::ByFixtureType);
-  capturePanel->UpdateScene(true);
 
   {
     std::vector<unsigned char> warmupPixels;

--- a/gui/tools/scene_model_symbol_capture_service.cpp
+++ b/gui/tools/scene_model_symbol_capture_service.cpp
@@ -130,6 +130,7 @@ public:
     zoom_ = state.zoom;
     view_ = state.view;
     renderMode_ = panel_.GetRenderMode();
+    renderOverrides_ = panel_.GetRenderOverrides();
     preferPerastageSvgSymbolsForLayouts_ =
         panel_.GetPreferPerastageSvgSymbolsForLayouts();
   }
@@ -137,6 +138,7 @@ public:
   ~ScopedViewer2DCaptureState() {
     panel_.ApplyViewState(offsetXPixels_, offsetYPixels_, zoom_, view_,
                           renderMode_);
+    panel_.SetRenderOverrides(renderOverrides_);
     panel_.SetPreferPerastageSvgSymbolsForLayouts(
         preferPerastageSvgSymbolsForLayouts_);
     panel_.UpdateScene(true);
@@ -149,6 +151,7 @@ private:
   float zoom_ = 1.0f;
   Viewer2DView view_ = Viewer2DView::Top;
   Viewer2DRenderMode renderMode_ = Viewer2DRenderMode::White;
+  std::optional<Viewer2DRenderOverrides> renderOverrides_;
   bool preferPerastageSvgSymbolsForLayouts_ = false;
 };
 
@@ -219,8 +222,8 @@ CaptureSceneModelOrthographicSymbols(Viewer2DOffscreenRenderer &renderer,
                                                       renderOverrides);
 
   renderer.SetViewportSize(options.viewportSize);
-  renderer.ApplySymbolCaptureDefaults();
   renderer.PrepareForCapture();
+  renderer.ApplySymbolCaptureDefaults();
 
   {
     std::vector<unsigned char> warmupPixels;

--- a/viewer2d/viewer2doffscreenrenderer.cpp
+++ b/viewer2d/viewer2doffscreenrenderer.cpp
@@ -29,7 +29,8 @@ Viewer2DOffscreenRenderer::Viewer2DOffscreenRenderer(wxWindow *parent) {
   panel_ = new Viewer2DPanel(host_, true, false, false);
   panel_->SetSize(wxSize(kDefaultViewportWidth, kDefaultViewportHeight));
   panel_->SetClientSize(wxSize(kDefaultViewportWidth, kDefaultViewportHeight));
-  ApplySymbolCaptureDefaults();
+  panel_->SetRenderOverrides(std::nullopt);
+  panel_->UpdateScene(true);
 }
 
 Viewer2DOffscreenRenderer::~Viewer2DOffscreenRenderer() {
@@ -52,6 +53,7 @@ void Viewer2DOffscreenRenderer::SetViewportSize(const wxSize &size) {
 void Viewer2DOffscreenRenderer::PrepareForCapture() {
   if (!panel_)
     return;
+  panel_->SetRenderOverrides(std::nullopt);
   panel_->UpdateScene(true);
 }
 

--- a/viewer2d/viewer2doffscreenrenderer.cpp
+++ b/viewer2d/viewer2doffscreenrenderer.cpp
@@ -29,8 +29,7 @@ Viewer2DOffscreenRenderer::Viewer2DOffscreenRenderer(wxWindow *parent) {
   panel_ = new Viewer2DPanel(host_, true, false, false);
   panel_->SetSize(wxSize(kDefaultViewportWidth, kDefaultViewportHeight));
   panel_->SetClientSize(wxSize(kDefaultViewportWidth, kDefaultViewportHeight));
-  panel_->LoadViewFromConfig();
-  panel_->UpdateScene(true);
+  ApplySymbolCaptureDefaults();
 }
 
 Viewer2DOffscreenRenderer::~Viewer2DOffscreenRenderer() {
@@ -53,6 +52,25 @@ void Viewer2DOffscreenRenderer::SetViewportSize(const wxSize &size) {
 void Viewer2DOffscreenRenderer::PrepareForCapture() {
   if (!panel_)
     return;
-  panel_->LoadViewFromConfig();
+  panel_->UpdateScene(true);
+}
+
+void Viewer2DOffscreenRenderer::ApplySymbolCaptureDefaults() {
+  if (!panel_)
+    return;
+
+  Viewer2DRenderOverrides overrides;
+  overrides.darkMode = false;
+  overrides.showGrid = false;
+  overrides.showRuler = false;
+  overrides.drawFixtureLabels = false;
+  overrides.forceBottomViewForTopFixtures = false;
+  overrides.symbolCaptureRenderProfile = true;
+  overrides.symbolCaptureIncludeCoplanarEdges = true;
+
+  panel_->SetRenderOverrides(overrides);
+  panel_->SetPreferPerastageSvgSymbolsForLayouts(false);
+  panel_->ApplyViewState(0.0f, 0.0f, 1.0f, Viewer2DView::Top,
+                         Viewer2DRenderMode::ByFixtureType);
   panel_->UpdateScene(true);
 }

--- a/viewer2d/viewer2doffscreenrenderer.h
+++ b/viewer2d/viewer2doffscreenrenderer.h
@@ -29,6 +29,7 @@ public:
   Viewer2DPanel *GetPanel() const { return panel_; }
   void SetViewportSize(const wxSize &size);
   void PrepareForCapture();
+  void ApplySymbolCaptureDefaults();
 
 private:
   wxPanel *host_ = nullptr;

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -144,6 +144,9 @@ public:
   void SetCursorWorldPositionCallback(CursorWorldPositionCallback callback);
   void SetRenderOverrides(
       const std::optional<Viewer2DRenderOverrides> &overrides);
+  std::optional<Viewer2DRenderOverrides> GetRenderOverrides() const {
+    return m_renderOverrides;
+  }
 
 private:
   enum class DragMode { None, View, Selection, RectSelection };


### PR DESCRIPTION
### Motivation
- Symbol capture was inheriting user-persisted 2D view state via `LoadViewFromConfig()`, making captures non-deterministic and dependent on user config.
- Captures must be reproducible and independent from interactive viewer state for reliable symbol generation and automated workflows.

### Description
- Removed calls to `LoadViewFromConfig()` from the offscreen renderer initialization and `PrepareForCapture()` and added `Viewer2DOffscreenRenderer::ApplySymbolCaptureDefaults()` to establish a known capture baseline.
- `ApplySymbolCaptureDefaults()` sets explicit `Viewer2DRenderOverrides` (dark mode, grid, ruler, labels, symbol capture profile, coplanar edges, etc.), disables Perastage SVG preference, and applies a fixed view/zoom/render-mode via `ApplyViewState`.
- The scene-model symbol capture flow in `gui/tools/scene_model_symbol_capture_service.cpp` now calls `renderer.ApplySymbolCaptureDefaults()` before preparing and performing captures so the capture does not depend on persisted user config.
- Exposed the new `ApplySymbolCaptureDefaults()` in `viewer2doffscreenrenderer.h` and adjusted render-override initialization in the capture service.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`; both scripts completed successfully (OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea9fa889288324b64821cbaa83cede)