### PR TITLE
Unify effective GDTF path resolution between apply and legend reads

### DIFF
--- a/gui/fixtures/fixture_gdtf_resolution.cpp
+++ b/gui/fixtures/fixture_gdtf_resolution.cpp
@@ -1,7 +1,10 @@
 #include "fixtures/fixture_gdtf_resolution.h"
 
+#include <algorithm>
+#include <cctype>
 #include <filesystem>
 #include <sstream>
+#include <string>
 
 #include <wx/log.h>
 
@@ -14,12 +17,54 @@ namespace {
 
 std::string BuildLogPrefix(const Fixture &fixture,
                            const MvrScene &scene,
-                           const fs::path &specPath) {
+                           const fs::path &specPath,
+                           const std::string &traceContext) {
   std::ostringstream out;
-  out << "[FixtureGdtfResolution] uuid='" << fixture.uuid << "'"
+  out << "[FixtureGdtfResolution]";
+  if (!traceContext.empty())
+    out << " context='" << traceContext << "'";
+  out << " uuid='" << fixture.uuid << "'"
       << " scene.basePath='" << scene.basePath << "'"
       << " gdtfSpec='" << specPath.string() << "'";
   return out.str();
+}
+
+std::string DecodePathEscapes(const std::string &value) {
+  std::string out;
+  out.reserve(value.size());
+  for (size_t i = 0; i < value.size(); ++i) {
+    if (i + 2 < value.size() && value[i] == '%' && value[i + 1] == '2' &&
+        value[i + 2] == '0') {
+      out.push_back(' ');
+      i += 2;
+      continue;
+    }
+    out.push_back(value[i]);
+  }
+  return out;
+}
+
+std::string TrimPathRef(std::string value) {
+  auto isTrim = [](unsigned char c) {
+    return std::isspace(c) != 0 || c == '\r' || c == '\n' || c == '\t';
+  };
+
+  while (!value.empty() && isTrim(static_cast<unsigned char>(value.front())))
+    value.erase(value.begin());
+  while (!value.empty() && isTrim(static_cast<unsigned char>(value.back())))
+    value.pop_back();
+
+  if (value.size() >= 2 && value.front() == '"' && value.back() == '"')
+    return value.substr(1, value.size() - 2);
+  return value;
+}
+
+std::string NormalizePathSeparators(std::string value) {
+  std::replace(value.begin(), value.end(), '\\',
+               static_cast<char>(fs::path::preferred_separator));
+  std::replace(value.begin(), value.end(), '/',
+               static_cast<char>(fs::path::preferred_separator));
+  return value;
 }
 
 void LogDiscardReason(const std::string &prefix,
@@ -35,11 +80,15 @@ void LogDiscardReason(const std::string &prefix,
 bool ResolveFixtureGdtfDeterministic(const Fixture &fixture,
                                      const MvrScene &scene,
                                      FixtureGdtfResolution &resolution,
-                                     std::string &errorMessage) {
+                                     std::string &errorMessage,
+                                     const std::string &traceContext) {
   resolution = {};
 
-  const fs::path specPath = fs::path(fixture.gdtfSpec);
-  const std::string logPrefix = BuildLogPrefix(fixture, scene, specPath);
+  const std::string sanitizedSpec =
+      NormalizePathSeparators(DecodePathEscapes(TrimPathRef(fixture.gdtfSpec)));
+  const fs::path specPath = fs::path(sanitizedSpec);
+  const std::string logPrefix =
+      BuildLogPrefix(fixture, scene, specPath, traceContext);
 
   if (specPath.empty()) {
     errorMessage = "Fixture gdtfSpec is empty; deterministic resolution requires a valid path or file name.";

--- a/gui/fixtures/fixture_gdtf_resolution.h
+++ b/gui/fixtures/fixture_gdtf_resolution.h
@@ -16,6 +16,7 @@ struct FixtureGdtfResolution {
 bool ResolveFixtureGdtfDeterministic(const Fixture &fixture,
                                      const MvrScene &scene,
                                      FixtureGdtfResolution &resolution,
-                                     std::string &errorMessage);
+                                     std::string &errorMessage,
+                                     const std::string &traceContext = {});
 
 } // namespace gui::fixtures

--- a/gui/legendutils.cpp
+++ b/gui/legendutils.cpp
@@ -16,102 +16,20 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "legendutils.h"
-#include "projectutils.h"
+#include "fixtures/fixture_gdtf_resolution.h"
 
 #include <algorithm>
-#include <array>
-#include <cctype>
-#include <string_view>
 #include <filesystem>
 
 namespace fs = std::filesystem;
 
 namespace {
-std::string DecodePathEscapes(const std::string &input) {
-  std::string out;
-  out.reserve(input.size());
-  for (size_t i = 0; i < input.size(); ++i) {
-    if (i + 2 < input.size() && input[i] == '%' && input[i + 1] == '2' &&
-        input[i + 2] == '0') {
-      out.push_back(' ');
-      i += 2;
-      continue;
-    }
-    out.push_back(input[i]);
-  }
-  return out;
-}
-
-bool EqualIgnoreCaseAscii(std::string_view lhs, std::string_view rhs) {
-  if (lhs.size() != rhs.size())
-    return false;
-  for (size_t i = 0; i < lhs.size(); ++i) {
-    const unsigned char a = static_cast<unsigned char>(lhs[i]);
-    const unsigned char b = static_cast<unsigned char>(rhs[i]);
-    if (std::tolower(a) != std::tolower(b))
-      return false;
-  }
-  return true;
-}
-
-bool MatchesFileNameWithExtensionTolerance(const fs::path &candidate,
-                                           const std::string &fileName) {
-  if (candidate.filename().string() == fileName)
-    return true;
-  const fs::path target(fileName);
-  if (candidate.stem().string() != target.stem().string())
-    return false;
-  return EqualIgnoreCaseAscii(candidate.extension().string(),
-                              target.extension().string());
-}
-
-std::string FindFileRecursive(const std::string &baseDir,
-                              const std::string &fileName) {
-  if (baseDir.empty())
-    return {};
-  std::error_code ec;
-  fs::recursive_directory_iterator it(
-      baseDir, fs::directory_options::skip_permission_denied, ec);
-  fs::recursive_directory_iterator end;
-  if (ec)
-    return {};
-  for (; it != end; it.increment(ec)) {
-    if (ec) {
-      ec.clear();
-      continue;
-    }
-    if (!it->is_regular_file(ec) || ec) {
-      ec.clear();
-      continue;
-    }
-    if (MatchesFileNameWithExtensionTolerance(it->path(), fileName))
-      return it->path().string();
-  }
-  return {};
-}
-
 std::string NormalizePath(const std::string &path) {
   std::string out = path;
   char sep = static_cast<char>(fs::path::preferred_separator);
   std::replace(out.begin(), out.end(), '\\', sep);
   std::replace(out.begin(), out.end(), '/', sep);
   return out;
-}
-
-std::string TrimPathRef(std::string value) {
-  auto isTrim = [](unsigned char c) {
-    return std::isspace(c) != 0 || c == '\r' || c == '\n' || c == '\t';
-  };
-
-  while (!value.empty() && isTrim(static_cast<unsigned char>(value.front())))
-    value.erase(value.begin());
-  while (!value.empty() && isTrim(static_cast<unsigned char>(value.back())))
-    value.pop_back();
-
-  if (value.size() >= 2 && value.front() == '"' && value.back() == '"')
-    return value.substr(1, value.size() - 2);
-
-  return value;
 }
 
 std::string NormalizeModelKey(const std::string &path) {
@@ -121,69 +39,17 @@ std::string NormalizeModelKey(const std::string &path) {
   p = p.lexically_normal();
   return NormalizePath(p.string());
 }
-
-std::string ResolveExistingPath(const fs::path &path) {
-  if (path.empty())
-    return {};
-  std::error_code ec;
-  if (fs::exists(path, ec))
-    return path.string();
-
-  const fs::path parent = path.parent_path();
-  const fs::path filename = path.filename();
-  if (parent.empty() || filename.empty())
-    return {};
-
-  for (const auto &entry : fs::directory_iterator(parent, ec)) {
-    if (ec)
-      break;
-    if (!entry.is_regular_file(ec) || ec) {
-      ec.clear();
-      continue;
-    }
-    if (MatchesFileNameWithExtensionTolerance(entry.path(), filename.string()))
-      return entry.path().string();
-  }
-  return {};
-}
-
-std::string ResolveGdtfPath(const std::string &base,
-                            const std::string &spec) {
-  if (spec.empty())
-    return {};
-  const std::string cleanSpec = DecodePathEscapes(TrimPathRef(spec));
-  const std::string norm = NormalizePath(cleanSpec);
-
-  fs::path absolute = fs::path(norm);
-  if (absolute.is_absolute()) {
-    const std::string resolved = ResolveExistingPath(absolute);
-    if (!resolved.empty())
-      return resolved;
-  }
-
-  const std::string relative = ResolveExistingPath(fs::path(base) / absolute);
-  if (!relative.empty())
-    return relative;
-
-  const std::string fileName = fs::path(norm).filename().string();
-  const std::array<std::string, 1> librarySubdirs = {"fixtures"};
-  for (const std::string &subdir : librarySubdirs) {
-    const fs::path root = fs::u8path(ProjectUtils::GetDefaultLibraryPath(subdir));
-    const std::string direct = ResolveExistingPath(root / fileName);
-    if (!direct.empty())
-      return direct;
-    const std::string recursive = FindFileRecursive(root.string(), fileName);
-    if (!recursive.empty())
-      return recursive;
-  }
-
-  return FindFileRecursive(base, fileName);
-}
 } // namespace
 
 std::string BuildFixtureSymbolKey(const Fixture &fixture,
                                   const std::string &basePath) {
-  std::string gdtfPath = ResolveGdtfPath(basePath, fixture.gdtfSpec);
+  MvrScene scene;
+  scene.basePath = basePath;
+  gui::fixtures::FixtureGdtfResolution resolution;
+  std::string resolutionError;
+  gui::fixtures::ResolveFixtureGdtfDeterministic(
+      fixture, scene, resolution, resolutionError, "read-layout-legend");
+  std::string gdtfPath = resolution.selectedPath;
   std::string modelKey = NormalizeModelKey(gdtfPath);
   if (modelKey.empty() && !fixture.gdtfSpec.empty())
     modelKey = NormalizeModelKey(fixture.gdtfSpec);

--- a/gui/windows/symbol_fixture_applier.cpp
+++ b/gui/windows/symbol_fixture_applier.cpp
@@ -591,7 +591,8 @@ bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
 
   gui::fixtures::FixtureGdtfResolution resolution;
   if (!gui::fixtures::ResolveFixtureGdtfDeterministic(fixtureIt->second, scene,
-                                                      resolution, errorMessage)) {
+                                                      resolution, errorMessage,
+                                                      "apply")) {
     return false;
   }
   const std::string scenePath = resolution.scenePath;
@@ -696,7 +697,7 @@ bool InspectFixtureSymbolState(const Fixture &fixture,
 
   gui::fixtures::FixtureGdtfResolution resolution;
   if (!gui::fixtures::ResolveFixtureGdtfDeterministic(fixture, scene, resolution,
-                                                      errorMessage)) {
+                                                      errorMessage, "inspect")) {
     result.scenePath = resolution.scenePath;
     result.libraryPath = resolution.libraryPath;
     return false;
@@ -795,7 +796,7 @@ bool SyncFixtureGdtfToLibrary(const Fixture &fixture,
                               std::string &errorMessage) {
   gui::fixtures::FixtureGdtfResolution resolution;
   if (!gui::fixtures::ResolveFixtureGdtfDeterministic(fixture, scene, resolution,
-                                                      errorMessage)) {
+                                                      errorMessage, "sync")) {
     return false;
   }
   const std::string scenePath = resolution.scenePath;


### PR DESCRIPTION
### Motivation
- Centralize and deduplicate GDTF effective-path resolution so all symbol-loading call sites use a single deterministic policy (scene-local > fixtures library > error).
- Ensure all call sites see the same normalized `gdtfSpec` interpretation (trim, quoted values, `%20`, path-separator normalization) to avoid mismatches between “apply” and “read for layout/legend”.
- Add lightweight trace context to make path-selection logs directly comparable across flows.

### Description
- Added an optional `traceContext` parameter to `ResolveFixtureGdtfDeterministic` in `gui::fixtures` and defaulted it in the header via `const std::string &traceContext = {}` to allow contextual log tags for callers using `"apply"`, `"inspect"`, `"sync"`, and `"read-layout-legend"`.
- Normalization helpers (`DecodePathEscapes`, `TrimPathRef`, `NormalizePathSeparators`) were implemented in `gui/fixtures/fixture_gdtf_resolution.cpp` and the resolver now runs these on `fixture.gdtfSpec` before applying the deterministic selection logic.
- Replaced duplicated path-resolution logic in `gui/legendutils.cpp` by calling `ResolveFixtureGdtfDeterministic` from `BuildFixtureSymbolKey` (context `"read-layout-legend"`), so symbol key construction uses the same effective path as apply/inspection flows.
- Updated `gui/windows/symbol_fixture_applier.cpp` to call the resolver with explicit contexts (`"apply"`, `"inspect"`, `"sync"`) and preserved existing behavior for writing/syncing; removed redundant resolution code paths.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (`OK: perastage_tree.md keeps module sections and scope note aligned`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (`OK: no direct ConfigManager::Get() usages in gui/`).
- Attempted CMake configure/build with `cmake -S . -B build && cmake --build build -j2` but it failed in this environment due to missing system dependency (`wxWidgets` development package), so full build verification was not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa38fad0c83249113ecdc3f99a5b5)