### PR TITLE
Refine fixture table scene update types and routing

### DIFF
--- a/gui/fixtureeditdialog.cpp
+++ b/gui/fixtureeditdialog.cpp
@@ -959,18 +959,17 @@ void FixtureEditDialog::ApplyChanges() {
     }
   }
   panel->ResyncRows(oldOrder, selectedUuids);
-  bool renamedOnly = modifiedColumns.size() > 1 && modifiedColumns[1];
-  if (renamedOnly) {
-    for (size_t i = 0; i < modifiedColumns.size(); ++i) {
-      if (i == 1 || !modifiedColumns[i])
-        continue;
-      renamedOnly = false;
-      break;
-    }
+  auto updateType = FixtureTablePanel::SceneDataUpdateType::kVisualLabelOnly;
+  bool hasAnyChange = false;
+  for (size_t i = 0; i < modifiedColumns.size(); ++i) {
+    if (!modifiedColumns[i])
+      continue;
+    hasAnyChange = true;
+    updateType = FixtureTablePanel::CombineUpdateTypes(
+        updateType, FixtureTablePanel::UpdateTypeForColumn(static_cast<int>(i)));
   }
-  const auto updateType =
-      renamedOnly ? FixtureTablePanel::SceneDataUpdateType::kVisualLabelOnly
-                  : FixtureTablePanel::SceneDataUpdateType::kGeneral;
+  if (!hasAnyChange)
+    updateType = FixtureTablePanel::SceneDataUpdateType::kGeneral;
   panel->UpdateSceneData(true, updateType);
   applied = true;
   if (Viewer3DPanel::Instance()) {

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -106,6 +106,56 @@ void RefreshViewersForFixtureUpdate(
   }
 }
 
+FixtureTablePanel::SceneDataUpdateType UpdateTypeForColumnImpl(int column) {
+  using SceneDataUpdateType = FixtureTablePanel::SceneDataUpdateType;
+  switch (column) {
+  case 1:
+    return SceneDataUpdateType::kVisualLabelOnly;
+  case 5:
+  case 6:
+  case 8:
+    return SceneDataUpdateType::kPatchOnly;
+  case 10:
+  case 11:
+  case 12:
+  case 13:
+  case 14:
+  case 15:
+    return SceneDataUpdateType::kTransformOnly;
+  case 16:
+  case 17:
+    return SceneDataUpdateType::kWeightOrPosition;
+  case 18:
+    return SceneDataUpdateType::kCategoryOnly;
+  case 19:
+    return SceneDataUpdateType::kAppearanceOnly;
+  case 0:
+  case 2:
+  case 3:
+  case 4:
+  case 7:
+  case 9:
+    return SceneDataUpdateType::kMetadataOnly;
+  default:
+    return SceneDataUpdateType::kGeneral;
+  }
+}
+
+FixtureTablePanel::SceneDataUpdateType CombineUpdateTypesImpl(
+    FixtureTablePanel::SceneDataUpdateType lhs,
+    FixtureTablePanel::SceneDataUpdateType rhs) {
+  using SceneDataUpdateType = FixtureTablePanel::SceneDataUpdateType;
+  if (lhs == rhs)
+    return lhs;
+  if (lhs == SceneDataUpdateType::kGeneral || rhs == SceneDataUpdateType::kGeneral)
+    return SceneDataUpdateType::kGeneral;
+  if (lhs == SceneDataUpdateType::kVisualLabelOnly)
+    return rhs;
+  if (rhs == SceneDataUpdateType::kVisualLabelOnly)
+    return lhs;
+  return SceneDataUpdateType::kGeneral;
+}
+
 bool IsRedCell(const ColorfulDataViewListStore *store, int row, int col) {
   if (!store || row < 0 || col < 0)
     return false;
@@ -545,13 +595,10 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
       }
     }
     ResyncRows(oldOrder, selectedUuids);
-    UpdateSceneData();
-    if (Viewer3DPanel::Instance()) {
-      Viewer3DPanel::Instance()->UpdateScene();
-      Viewer3DPanel::Instance()->Refresh();
-    } else if (Viewer2DPanel::Instance()) {
-      Viewer2DPanel::Instance()->UpdateScene();
-    }
+    const auto updateType = CombineUpdateTypes(
+        UpdateTypeForColumn(9), UpdateTypeForColumn(16));
+    UpdateSceneData(true, updateType);
+    RefreshViewersForFixtureUpdate(updateType);
     if (MainWindow::Instance()) {
       MainWindow::Instance()->RequestFixtureSymbolAutoUpdate();
     }
@@ -609,13 +656,10 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
     ApplyModeForGdtf(gdtfPath, sel);
 
     ResyncRows(oldOrder, selectedUuids);
-    UpdateSceneData();
-    if (Viewer3DPanel::Instance()) {
-      Viewer3DPanel::Instance()->UpdateScene();
-      Viewer3DPanel::Instance()->Refresh();
-    } else if (Viewer2DPanel::Instance()) {
-      Viewer2DPanel::Instance()->UpdateScene();
-    }
+    const auto updateType = CombineUpdateTypes(
+        UpdateTypeForColumn(7), UpdateTypeForColumn(8));
+    UpdateSceneData(true, updateType);
+    RefreshViewersForFixtureUpdate(updateType);
     return;
   }
 
@@ -638,13 +682,9 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
     }
     PropagateTypeValues(selections, col);
     ResyncRows(oldOrder, selectedUuids);
-    UpdateSceneData();
-    if (Viewer3DPanel::Instance()) {
-      Viewer3DPanel::Instance()->UpdateScene();
-      Viewer3DPanel::Instance()->Refresh();
-    } else if (Viewer2DPanel::Instance()) {
-      Viewer2DPanel::Instance()->UpdateScene();
-    }
+    const auto updateType = UpdateTypeForColumn(col);
+    UpdateSceneData(true, updateType);
+    RefreshViewersForFixtureUpdate(updateType);
     return;
   }
 
@@ -705,13 +745,10 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
     }
 
     ResyncRows(oldOrder, selectedUuids);
-    UpdateSceneData();
-    if (Viewer3DPanel::Instance()) {
-      Viewer3DPanel::Instance()->UpdateScene();
-      Viewer3DPanel::Instance()->Refresh();
-    } else if (Viewer2DPanel::Instance()) {
-      Viewer2DPanel::Instance()->UpdateScene();
-    }
+    const auto updateType = CombineUpdateTypes(
+        UpdateTypeForColumn(5), UpdateTypeForColumn(6));
+    UpdateSceneData(true, updateType);
+    RefreshViewersForFixtureUpdate(updateType);
     return;
   }
 
@@ -757,13 +794,9 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
         manualCategoryUuidsPending.insert(rowUuids[row]);
     }
     ResyncRows(oldOrder, selectedUuids);
-    UpdateSceneData();
-    if (Viewer3DPanel::Instance()) {
-      Viewer3DPanel::Instance()->UpdateScene();
-      Viewer3DPanel::Instance()->Refresh();
-    } else if (Viewer2DPanel::Instance()) {
-      Viewer2DPanel::Instance()->UpdateScene();
-    }
+    const auto updateType = UpdateTypeForColumn(col);
+    UpdateSceneData(true, updateType);
+    RefreshViewersForFixtureUpdate(updateType);
     return;
   }
 
@@ -795,13 +828,9 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
     }
     PropagateTypeValues(selections, col);
     ResyncRows(oldOrder, selectedUuids);
-    UpdateSceneData();
-    if (Viewer3DPanel::Instance()) {
-      Viewer3DPanel::Instance()->UpdateScene();
-      Viewer3DPanel::Instance()->Refresh();
-    } else if (Viewer2DPanel::Instance()) {
-      Viewer2DPanel::Instance()->UpdateScene();
-    }
+    const auto updateType = UpdateTypeForColumn(col);
+    UpdateSceneData(true, updateType);
+    RefreshViewersForFixtureUpdate(updateType);
     return;
   }
 
@@ -994,9 +1023,7 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
     }
   }
   FixtureTableEditService::PropagateTypeValues(table, selections, col);
-  const SceneDataUpdateType updateType =
-      (col == 1) ? SceneDataUpdateType::kVisualLabelOnly
-                 : SceneDataUpdateType::kGeneral;
+  const SceneDataUpdateType updateType = UpdateTypeForColumn(col);
   ResyncRows(oldOrder, selectedUuids);
   if (col == 1) {
     std::vector<int> selectedRows;
@@ -1021,6 +1048,16 @@ FixtureTablePanel *FixtureTablePanel::Instance() { return s_instance; }
 
 void FixtureTablePanel::SetInstance(FixtureTablePanel *panel) {
   s_instance = panel;
+}
+
+FixtureTablePanel::SceneDataUpdateType
+FixtureTablePanel::UpdateTypeForColumn(int column) {
+  return UpdateTypeForColumnImpl(column);
+}
+
+FixtureTablePanel::SceneDataUpdateType FixtureTablePanel::CombineUpdateTypes(
+    SceneDataUpdateType lhs, SceneDataUpdateType rhs) {
+  return CombineUpdateTypesImpl(lhs, rhs);
 }
 
 bool FixtureTablePanel::IsActivePage() const {

--- a/gui/fixturetablepanel.h
+++ b/gui/fixturetablepanel.h
@@ -32,9 +32,24 @@ class IGuiConfigServices;
 class FixtureTablePanel : public wxPanel
 {
 public:
+    // SceneDataUpdateType groups edits by likely subsystem impact:
+    // - kVisualLabelOnly: fixture naming/labels (viewer refresh, no scene rebuild).
+    // - kPatchOnly: DMX addressing/patching (patch conflict checks, scene + rigging refresh).
+    // - kAppearanceOnly: visual look (fixture color/swatch and related rendering refresh).
+    // - kCategoryOnly: fixture classification/category-dependent UI summaries.
+    // - kTransformOnly: orientation/transform values (viewer scene transforms).
+    // - kWeightOrPosition: physical load/position values (hoist/rigging recalculation).
+    // - kMetadataOnly: fixture descriptive metadata (type, mode, layer, model, hang position).
+    // - kGeneral: mixed or broad edits spanning multiple categories.
     enum class SceneDataUpdateType {
         kGeneral,
-        kVisualLabelOnly
+        kVisualLabelOnly,
+        kPatchOnly,
+        kAppearanceOnly,
+        kCategoryOnly,
+        kTransformOnly,
+        kWeightOrPosition,
+        kMetadataOnly
     };
 
     explicit FixtureTablePanel(wxWindow* parent, IGuiConfigServices* services = nullptr);
@@ -53,6 +68,9 @@ public:
 
     static FixtureTablePanel* Instance();
     static void SetInstance(FixtureTablePanel* panel);
+    static SceneDataUpdateType UpdateTypeForColumn(int column);
+    static SceneDataUpdateType CombineUpdateTypes(SceneDataUpdateType lhs,
+                                                  SceneDataUpdateType rhs);
 
     void UpdateSceneData(
         bool logChanges = true,


### PR DESCRIPTION
### Motivation
- Reduce unnecessary full scene rebuilds and make viewer/rigging updates proportional to the real impact of fixture-table edits.
- Map table columns and edit actions to granular impact categories so downstream subsystems (2D/3D viewers, rigging/hoist prompts, patch checks) receive appropriate updates.
- Make the edit→update decision reusable and deterministic across `OnContextMenu` flows and the fixture editor dialog.

### Description
- Expanded `FixtureTablePanel::SceneDataUpdateType` with impact-oriented categories and documented the likely affected subsystems next to the enum in `gui/fixturetablepanel.h` (added `kPatchOnly`, `kAppearanceOnly`, `kCategoryOnly`, `kTransformOnly`, `kWeightOrPosition`, `kMetadataOnly`).
- Added helpers `FixtureTablePanel::UpdateTypeForColumn(int)` and `FixtureTablePanel::CombineUpdateTypes(...)` and internal implementations in `gui/fixturetablepanel.cpp` to map columns to update types and to combine multiple types into a single effective type.
- Replaced generic `UpdateSceneData()` calls in `gui/fixturetablepanel.cpp` (`OnContextMenu` / cell-edit flows) with calls that pass the specific `SceneDataUpdateType` for the edited column(s) and used `RefreshViewersForFixtureUpdate(...)` to centralize viewer refresh logic.
- Updated `FixtureEditDialog::ApplyChanges()` in `gui/fixtureeditdialog.cpp` to aggregate update types from all modified columns (instead of the previous rename-only vs general heuristic) and pass the aggregated type to `UpdateSceneData`.

Files changed: `gui/fixturetablepanel.h`, `gui/fixturetablepanel.cpp`, `gui/fixtureeditdialog.cpp`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both returned OK and passed.
- No additional automated tests were added or required for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa7a6b76083249d1779c18c6203f5)