### PR TITLE
Limit rigging refresh to structural fixture updates

### DIFF
--- a/gui/fixtureeditdialog.cpp
+++ b/gui/fixtureeditdialog.cpp
@@ -960,16 +960,12 @@ void FixtureEditDialog::ApplyChanges() {
   }
   panel->ResyncRows(oldOrder, selectedUuids);
   auto updateType = FixtureTablePanel::SceneDataUpdateType::kVisualLabelOnly;
-  bool hasAnyChange = false;
   for (size_t i = 0; i < modifiedColumns.size(); ++i) {
     if (!modifiedColumns[i])
       continue;
-    hasAnyChange = true;
     updateType = FixtureTablePanel::CombineUpdateTypes(
         updateType, FixtureTablePanel::UpdateTypeForColumn(static_cast<int>(i)));
   }
-  if (!hasAnyChange)
-    updateType = FixtureTablePanel::SceneDataUpdateType::kGeneral;
   panel->UpdateSceneData(true, updateType);
   applied = true;
   if (Viewer3DPanel::Instance()) {

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -106,6 +106,24 @@ void RefreshViewersForFixtureUpdate(
   }
 }
 
+bool RequiresRiggingRefresh(
+    FixtureTablePanel::SceneDataUpdateType updateType) {
+  using SceneDataUpdateType = FixtureTablePanel::SceneDataUpdateType;
+  switch (updateType) {
+  case SceneDataUpdateType::kWeightOrPosition:
+  case SceneDataUpdateType::kGeneral:
+    return true;
+  case SceneDataUpdateType::kVisualLabelOnly:
+  case SceneDataUpdateType::kPatchOnly:
+  case SceneDataUpdateType::kAppearanceOnly:
+  case SceneDataUpdateType::kCategoryOnly:
+  case SceneDataUpdateType::kTransformOnly:
+  case SceneDataUpdateType::kMetadataOnly:
+    return false;
+  }
+  return true;
+}
+
 FixtureTablePanel::SceneDataUpdateType UpdateTypeForColumnImpl(int column) {
   using SceneDataUpdateType = FixtureTablePanel::SceneDataUpdateType;
   switch (column) {
@@ -1525,7 +1543,7 @@ void FixtureTablePanel::UpdateSceneData(bool logChanges,
   if (updateType != SceneDataUpdateType::kVisualLabelOnly)
     HighlightDuplicateFixtureIds();
 
-  if (updateType != SceneDataUpdateType::kVisualLabelOnly &&
+  if (RequiresRiggingRefresh(updateType) &&
       RiggingPanel::Instance())
     RiggingPanel::Instance()->RefreshData();
 


### PR DESCRIPTION
### Motivation
- Avoid unnecessary `RiggingPanel::RefreshData()` calls for edits that don't affect physical mass or structural hang position. 
- Ensure rigging is refreshed only when updates can change hoist/rigging calculations (weight/position) or when broad/mixed changes occur. 
- Keep the change small and localized to the fixture table edit/apply flow to reduce UI churn and preserve performance.

### Description
- Added a helper `RequiresRiggingRefresh(...)` in `gui/fixturetablepanel.cpp` that returns true only for `kWeightOrPosition` and `kGeneral` update types. 
- Replaced the direct condition in `FixtureTablePanel::UpdateSceneData(...)` with the new helper so `RiggingPanel::RefreshData()` is skipped for `kPatchOnly`, `kAppearanceOnly`, `kCategoryOnly`, and other non-structural update types. 
- Simplified `FixtureEditDialog::ApplyChanges()` in `gui/fixtureeditdialog.cpp` to always use the combined column-derived `updateType` (removed the unreachable fallback to `kGeneral`) so the dialog sends the correct update kind when confirming changes. 
- All changes are local and do not alter public APIs or cross-module boundaries.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaab2c04008324af410232e5fe19b0)