### PR TITLE
Refactor fixture table validation highlight routing

### DIFF
--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -119,6 +119,7 @@ bool RequiresRiggingRefresh(
   case SceneDataUpdateType::kCategoryOnly:
   case SceneDataUpdateType::kTransformOnly:
   case SceneDataUpdateType::kMetadataOnly:
+  case SceneDataUpdateType::kFixtureIdOnly:
     return false;
   }
   return true;
@@ -148,6 +149,7 @@ FixtureTablePanel::SceneDataUpdateType UpdateTypeForColumnImpl(int column) {
   case 19:
     return SceneDataUpdateType::kAppearanceOnly;
   case 0:
+    return SceneDataUpdateType::kFixtureIdOnly;
   case 2:
   case 3:
   case 4:
@@ -496,7 +498,7 @@ void FixtureTablePanel::ReloadData() {
   if (Viewer3DPanel::Instance())
     Viewer3DPanel::Instance()->SetSelectedFixtures({});
 
-  HighlightDuplicateFixtureIds();
+  RunValidationHighlights(SceneDataUpdateType::kGeneral);
 
   // Let wxDataViewListCtrl manage column headers and sorting
   if (LayerPanel::Instance())
@@ -1249,7 +1251,7 @@ void FixtureTablePanel::DeleteSelected(bool pushUndoState) {
     }
   }
 
-  HighlightDuplicateFixtureIds();
+  RunValidationHighlights(SceneDataUpdateType::kGeneral);
 
   std::vector<std::string> mergedSelection;
   const auto appendSelection = [&](const std::vector<std::string> &source) {
@@ -1541,7 +1543,7 @@ void FixtureTablePanel::UpdateSceneData(bool logChanges,
       guiConfigServices->LegacyConfigManager(), this, changedWeightPositions);
 
   if (updateType != SceneDataUpdateType::kVisualLabelOnly)
-    HighlightDuplicateFixtureIds();
+    RunValidationHighlights(updateType);
 
   if (RequiresRiggingRefresh(updateType) &&
       RiggingPanel::Instance())
@@ -1633,9 +1635,32 @@ void FixtureTablePanel::HighlightDuplicateFixtureIds() {
         store->SetCellTextColour(r, 0, *wxRED);
     }
   }
+}
 
-  HighlightPatchConflicts();
-  HighlightAutoFallbackCategories();
+void FixtureTablePanel::RunValidationHighlights(SceneDataUpdateType updateType) {
+  switch (updateType) {
+  case SceneDataUpdateType::kPatchOnly:
+    HighlightPatchConflicts();
+    break;
+  case SceneDataUpdateType::kCategoryOnly:
+    HighlightAutoFallbackCategories();
+    break;
+  case SceneDataUpdateType::kFixtureIdOnly:
+    HighlightDuplicateFixtureIds();
+    break;
+  case SceneDataUpdateType::kVisualLabelOnly:
+    return;
+  case SceneDataUpdateType::kAppearanceOnly:
+  case SceneDataUpdateType::kTransformOnly:
+  case SceneDataUpdateType::kWeightOrPosition:
+  case SceneDataUpdateType::kMetadataOnly:
+  case SceneDataUpdateType::kGeneral:
+    HighlightDuplicateFixtureIds();
+    HighlightPatchConflicts();
+    HighlightAutoFallbackCategories();
+    break;
+  }
+
   table->Refresh();
 }
 

--- a/gui/fixturetablepanel.h
+++ b/gui/fixturetablepanel.h
@@ -49,7 +49,8 @@ public:
         kCategoryOnly,
         kTransformOnly,
         kWeightOrPosition,
-        kMetadataOnly
+        kMetadataOnly,
+        kFixtureIdOnly
     };
 
     explicit FixtureTablePanel(wxWindow* parent, IGuiConfigServices* services = nullptr);
@@ -112,6 +113,7 @@ private:
     void HighlightDuplicateFixtureIds();
     void HighlightPatchConflicts();
     void HighlightAutoFallbackCategories();
+    void RunValidationHighlights(SceneDataUpdateType updateType);
 
     wxString activeHoverTooltip;
 };


### PR DESCRIPTION
### Motivation
- Reduce implicit coupling between validation helpers so each `Highlight*` function only performs its own responsibility and can be invoked independently.
- Provide an explicit validation routing path by update type so callers can request only the necessary validations and avoid redundant work and refreshes.
- Ensure `table->Refresh()` is called exactly once after the chosen validation operations to minimize unnecessary GUI refreshes.

### Description
- Decoupled `HighlightDuplicateFixtureIds()`, `HighlightPatchConflicts()`, and `HighlightAutoFallbackCategories()` so `HighlightDuplicateFixtureIds()` no longer calls the other two functions implicitly.
- Added `kFixtureIdOnly` to `SceneDataUpdateType` and mapped column 0 (fixture ID) edits to return `kFixtureIdOnly` from `UpdateTypeForColumn` so ID-only edits route to the dedicated validation.
- Introduced `RunValidationHighlights(SceneDataUpdateType updateType)` which routes validations as follows: `kPatchOnly` → `HighlightPatchConflicts()`, `kCategoryOnly` → `HighlightAutoFallbackCategories()`, `kFixtureIdOnly` → `HighlightDuplicateFixtureIds()`, and runs all validations for broader update types; `table->Refresh()` is now executed once at the end of this routine.
- Replaced direct calls to `HighlightDuplicateFixtureIds()` at validation entry points with `RunValidationHighlights(...)` in `ReloadData`, `DeleteSelected` and `UpdateSceneData`, and treated `kFixtureIdOnly` as a non-rigging-refresh type in `RequiresRiggingRefresh()`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded (OK).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded (OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaad0c9fdc8324bd9946d5d4033f6e)