### PR TITLE
Only refresh fixture summary for impactful scene updates

### DIFF
--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -125,6 +125,25 @@ bool RequiresRiggingRefresh(
   return true;
 }
 
+bool ShouldRefreshFixtureSummary(
+    FixtureTablePanel::SceneDataUpdateType updateType) {
+  using SceneDataUpdateType = FixtureTablePanel::SceneDataUpdateType;
+  switch (updateType) {
+  case SceneDataUpdateType::kGeneral:
+  case SceneDataUpdateType::kCategoryOnly:
+  case SceneDataUpdateType::kWeightOrPosition:
+  case SceneDataUpdateType::kMetadataOnly:
+    return true;
+  case SceneDataUpdateType::kVisualLabelOnly:
+  case SceneDataUpdateType::kPatchOnly:
+  case SceneDataUpdateType::kAppearanceOnly:
+  case SceneDataUpdateType::kTransformOnly:
+  case SceneDataUpdateType::kFixtureIdOnly:
+    return false;
+  }
+  return true;
+}
+
 FixtureTablePanel::SceneDataUpdateType UpdateTypeForColumnImpl(int column) {
   using SceneDataUpdateType = FixtureTablePanel::SceneDataUpdateType;
   switch (column) {
@@ -1566,7 +1585,7 @@ void FixtureTablePanel::UpdateSceneData(bool logChanges,
     RiggingPanel::Instance()->RefreshData();
 
   if (SummaryPanel::Instance() && IsActivePage() &&
-      updateType != SceneDataUpdateType::kVisualLabelOnly)
+      ShouldRefreshFixtureSummary(updateType))
     SummaryPanel::Instance()->ShowFixtureSummary();
 }
 


### PR DESCRIPTION
### Motivation
- Avoid unnecessary `SummaryPanel::ShowFixtureSummary()` calls by only refreshing the fixture summary when the scene change can affect the summary content (type/category/weight/position/metadata), and exclude patch/appearance-only changes that don't alter summary data.

### Description
- Add `ShouldRefreshFixtureSummary(...)` in `gui/fixturetablepanel.cpp` and use it from `UpdateSceneData(...)` so only `SceneDataUpdateType` values `kGeneral`, `kCategoryOnly`, `kWeightOrPosition`, and `kMetadataOnly` trigger `SummaryPanel::ShowFixtureSummary()` while `kPatchOnly` and `kAppearanceOnly` (and other non-summary-impacting types) do not.
- Note: `gui/fixturetablepanel.cpp` is a hotspot file that is already large; consider extracting summary/refresh policy or related responsibilities into a small helper file in a follow-up change if additional logic accumulates.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab46acaa083249c4b1a8ab9311834)