### PR TITLE
Optimize fixture viewer refresh by SceneDataUpdateType

### DIFF
--- a/gui/fixtureeditdialog.cpp
+++ b/gui/fixtureeditdialog.cpp
@@ -968,18 +968,18 @@ void FixtureEditDialog::ApplyChanges() {
   }
   panel->UpdateSceneData(true, updateType);
   applied = true;
+  const bool requiresFullSceneUpdate =
+      FixtureTablePanel::RequiresFullViewerSceneUpdate(updateType);
   if (Viewer3DPanel::Instance()) {
-    if (updateType == FixtureTablePanel::SceneDataUpdateType::kVisualLabelOnly) {
-      Viewer3DPanel::Instance()->Refresh();
-    } else {
+    if (requiresFullSceneUpdate) {
       Viewer3DPanel::Instance()->UpdateScene();
-      Viewer3DPanel::Instance()->Refresh();
     }
+    Viewer3DPanel::Instance()->Refresh();
   } else if (Viewer2DPanel::Instance()) {
-    if (updateType == FixtureTablePanel::SceneDataUpdateType::kVisualLabelOnly)
-      Viewer2DPanel::Instance()->UpdateScene(false);
-    else
+    if (requiresFullSceneUpdate)
       Viewer2DPanel::Instance()->UpdateScene();
+    else
+      Viewer2DPanel::Instance()->UpdateScene(false);
   }
   std::fill(modifiedColumns.begin(), modifiedColumns.end(), false);
 }

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -89,20 +89,18 @@ public:
 
 void RefreshViewersForFixtureUpdate(
     FixtureTablePanel::SceneDataUpdateType updateType) {
-  const bool labelOnlyUpdate =
-      updateType == FixtureTablePanel::SceneDataUpdateType::kVisualLabelOnly;
+  const bool requiresFullSceneUpdate =
+      FixtureTablePanel::RequiresFullViewerSceneUpdate(updateType);
   if (Viewer3DPanel::Instance()) {
-    if (labelOnlyUpdate) {
-      Viewer3DPanel::Instance()->Refresh();
-    } else {
+    if (requiresFullSceneUpdate) {
       Viewer3DPanel::Instance()->UpdateScene();
-      Viewer3DPanel::Instance()->Refresh();
     }
+    Viewer3DPanel::Instance()->Refresh();
   } else if (Viewer2DPanel::Instance()) {
-    if (labelOnlyUpdate)
-      Viewer2DPanel::Instance()->UpdateScene(false);
-    else
+    if (requiresFullSceneUpdate)
       Viewer2DPanel::Instance()->UpdateScene();
+    else
+      Viewer2DPanel::Instance()->UpdateScene(false);
   }
 }
 
@@ -1097,6 +1095,24 @@ FixtureTablePanel::UpdateTypeForColumn(int column) {
 FixtureTablePanel::SceneDataUpdateType FixtureTablePanel::CombineUpdateTypes(
     SceneDataUpdateType lhs, SceneDataUpdateType rhs) {
   return CombineUpdateTypesImpl(lhs, rhs);
+}
+
+bool FixtureTablePanel::RequiresFullViewerSceneUpdate(
+    SceneDataUpdateType updateType) {
+  switch (updateType) {
+  case SceneDataUpdateType::kPatchOnly:
+  case SceneDataUpdateType::kTransformOnly:
+  case SceneDataUpdateType::kWeightOrPosition:
+  case SceneDataUpdateType::kGeneral:
+    return true;
+  case SceneDataUpdateType::kVisualLabelOnly:
+  case SceneDataUpdateType::kAppearanceOnly:
+  case SceneDataUpdateType::kCategoryOnly:
+  case SceneDataUpdateType::kMetadataOnly:
+  case SceneDataUpdateType::kFixtureIdOnly:
+    return false;
+  }
+  return true;
 }
 
 bool FixtureTablePanel::IsActivePage() const {

--- a/gui/fixturetablepanel.h
+++ b/gui/fixturetablepanel.h
@@ -72,6 +72,7 @@ public:
     static SceneDataUpdateType UpdateTypeForColumn(int column);
     static SceneDataUpdateType CombineUpdateTypes(SceneDataUpdateType lhs,
                                                   SceneDataUpdateType rhs);
+    static bool RequiresFullViewerSceneUpdate(SceneDataUpdateType updateType);
 
     void UpdateSceneData(
         bool logChanges = true,


### PR DESCRIPTION
### Motivation
- Reduce unnecessary full scene rebuilds when fixture edits only affect labels, appearance or category to keep the UI responsive and avoid expensive visual-engine updates.
- Centralize the decision logic so table edits and dialog commits use the same lightweight vs full-refresh criteria.

### Description
- Added `FixtureTablePanel::RequiresFullViewerSceneUpdate(SceneDataUpdateType)` and exposed it in `gui/fixturetablepanel.h` as a small API to decide whether a change requires a full viewer scene rebuild.
- Updated `RefreshViewersForFixtureUpdate(SceneDataUpdateType)` in `gui/fixturetablepanel.cpp` to call `RequiresFullViewerSceneUpdate(...)` and route updates to the lightweight path when appropriate (3D: `Refresh()`, 2D: `UpdateScene(false)`), and use the full `UpdateScene()` only for update types that affect geometry/transform/patch/rigging.
- Applied the same decision logic in `gui/fixtureeditdialog.cpp` when applying dialog changes so commits behave consistently with the table flow.
- Full-scene updates are limited to `kPatchOnly`, `kTransformOnly`, `kWeightOrPosition`, and `kGeneral`, while `kCategoryOnly`, `kAppearanceOnly`, `kVisualLabelOnly`, `kMetadataOnly`, and `kFixtureIdOnly` follow the lightweight refresh path.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab7a3074c8324a5474cba1223bb68)