### PR TITLE
Batch fixture category dictionary persistence in ApplyCategoryChanges

### DIFF
--- a/gui/fixturetable/fixture_table_edit_service.cpp
+++ b/gui/fixturetable/fixture_table_edit_service.cpp
@@ -372,6 +372,7 @@ void ApplyCategoryChanges(
   auto &scene = adapter.GetScene();
   SceneUpdateTracking tracking;
   const auto targetRows = ResolveTargetRows(table, rowUuids);
+  std::unordered_map<std::string, std::string> manualCategoriesByType;
 
   for (size_t row : targetRows) {
     auto it = scene.fixtures.find(rowUuids[row]);
@@ -406,12 +407,12 @@ void ApplyCategoryChanges(
     it->second.categorySourceReason = next.categorySourceReason;
     if (!next.typeName.empty() && !next.category.empty() &&
         next.categorySource == GdtfFixtureCategory::kManualSource) {
-      GdtfDictionary::UpdateCategoryForFile(next.typeName, next.gdtfSpec,
-                                            next.category);
+      manualCategoriesByType[next.typeName] = next.category;
     }
     TrackUpdatedFixture(it->second, tracking, logChanges);
   }
 
+  GdtfDictionary::UpdateCategoriesBulk(manualCategoriesByType);
   AppendChangeLogIfNeeded(tracking, logChanges);
 }
 }


### PR DESCRIPTION
### Motivation
- Reduce repeated dictionary writes during fixture category edits by batching manual category updates per fixture type and performing a single bulk dictionary update.

### Description
- In `ApplyCategoryChanges(...)` add a `std::unordered_map<std::string, std::string> manualCategoriesByType` and collect manual per-type category updates during the row loop instead of calling `GdtfDictionary::UpdateCategoryForFile` per-row, then call `GdtfDictionary::UpdateCategoriesBulk(manualCategoriesByType)` once after the loop while preserving per-fixture scene updates and undo tracking.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab8a4cce483249b1a775ff66ea221)