### PR TITLE
Fix category propagation to use explicit target rows

### DIFF
--- a/gui/fixturetable/fixture_table_edit_service.cpp
+++ b/gui/fixturetable/fixture_table_edit_service.cpp
@@ -98,6 +98,28 @@ std::vector<size_t> ResolveTargetRows(wxDataViewListCtrl *table,
   return rows;
 }
 
+std::vector<size_t> ResolveTargetRows(
+    wxDataViewListCtrl *table, const std::vector<std::string> &rowUuids,
+    const std::vector<unsigned int> *explicitTargetRows) {
+  if (!explicitTargetRows)
+    return ResolveTargetRows(table, rowUuids);
+
+  std::vector<size_t> rows;
+  if (!table)
+    return rows;
+
+  const size_t count = std::min(static_cast<size_t>(table->GetItemCount()),
+                                rowUuids.size());
+  rows.reserve(explicitTargetRows->size());
+  for (const unsigned int row : *explicitTargetRows) {
+    if (static_cast<size_t>(row) < count)
+      rows.push_back(static_cast<size_t>(row));
+  }
+  std::sort(rows.begin(), rows.end());
+  rows.erase(std::unique(rows.begin(), rows.end()), rows.end());
+  return rows;
+}
+
 void ApplyFullRowChanges(
     FixtureTableEditService::ISceneAdapter &adapter, wxDataViewListCtrl *table,
     const std::vector<std::string> &rowUuids, const std::vector<wxString> &gdtfPaths,
@@ -368,10 +390,11 @@ void ApplyAppearanceChanges(FixtureTableEditService::ISceneAdapter &adapter,
 void ApplyCategoryChanges(
     FixtureTableEditService::ISceneAdapter &adapter, wxDataViewListCtrl *table,
     const std::vector<std::string> &rowUuids,
-    const std::unordered_set<std::string> *manualCategoryUuids, bool logChanges) {
+    const std::unordered_set<std::string> *manualCategoryUuids, bool logChanges,
+    const std::vector<unsigned int> *explicitTargetRows = nullptr) {
   auto &scene = adapter.GetScene();
   SceneUpdateTracking tracking;
-  auto targetRows = ResolveTargetRows(table, rowUuids);
+  auto targetRows = ResolveTargetRows(table, rowUuids, explicitTargetRows);
   if (table && manualCategoryUuids) {
     const size_t count =
         std::min(static_cast<size_t>(table->GetItemCount()), rowUuids.size());
@@ -514,6 +537,18 @@ void UpdateCategoryForRows(
     DataViewEditCommit::CommitPendingEdit(table);
   ApplyCategoryChanges(adapter, table, rowUuids, manualCategoryUuids,
                        logChanges);
+}
+
+void UpdateCategoryForRows(
+    ISceneAdapter &adapter, wxDataViewListCtrl *table,
+    const std::vector<std::string> &rowUuids,
+    const std::vector<unsigned int> &targetRows,
+    const std::unordered_set<std::string> *manualCategoryUuids,
+    bool logChanges) {
+  if (table)
+    DataViewEditCommit::CommitPendingEdit(table);
+  ApplyCategoryChanges(adapter, table, rowUuids, manualCategoryUuids,
+                       logChanges, &targetRows);
 }
 
 void UpdateFullRowData(ISceneAdapter &adapter, wxDataViewListCtrl *table,

--- a/gui/fixturetable/fixture_table_edit_service.h
+++ b/gui/fixturetable/fixture_table_edit_service.h
@@ -47,6 +47,13 @@ void UpdateCategoryForRows(
     const std::unordered_set<std::string> *manualCategoryUuids = nullptr,
     bool logChanges = true);
 
+void UpdateCategoryForRows(
+    ISceneAdapter &adapter, wxDataViewListCtrl *table,
+    const std::vector<std::string> &rowUuids,
+    const std::vector<unsigned int> &targetRows,
+    const std::unordered_set<std::string> *manualCategoryUuids = nullptr,
+    bool logChanges = true);
+
 void UpdateFullRowData(ISceneAdapter &adapter, wxDataViewListCtrl *table,
                        const std::vector<std::string> &rowUuids,
                        const std::vector<wxString> &gdtfPaths,

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -852,7 +852,7 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
     }
 
     const auto updateType = UpdateTypeForColumn(col);
-    UpdateSceneData(true, updateType);
+    UpdateSceneData(true, updateType, &affectedRows);
 
     auto &fixtures = guiConfigServices->LegacyConfigManager().GetScene().fixtures;
     for (const auto row : affectedRows) {
@@ -1603,7 +1603,8 @@ void FixtureTablePanel::PropagateTypeValues(
 }
 
 void FixtureTablePanel::UpdateSceneData(bool logChanges,
-                                        SceneDataUpdateType updateType) {
+                                        SceneDataUpdateType updateType,
+                                        const std::vector<unsigned int> *targetRows) {
   ConfigManagerSceneAdapter adapter;
   std::unordered_set<std::string> changedWeightPositions;
 
@@ -1617,8 +1618,14 @@ void FixtureTablePanel::UpdateSceneData(bool logChanges,
                                                      logChanges);
     break;
   case SceneDataUpdateType::kCategoryOnly:
-    FixtureTableEditService::UpdateCategoryForRows(
-        adapter, table, rowUuids, &manualCategoryUuidsPending, logChanges);
+    if (targetRows) {
+      FixtureTableEditService::UpdateCategoryForRows(
+          adapter, table, rowUuids, *targetRows, &manualCategoryUuidsPending,
+          logChanges);
+    } else {
+      FixtureTableEditService::UpdateCategoryForRows(
+          adapter, table, rowUuids, &manualCategoryUuidsPending, logChanges);
+    }
     break;
   default:
     FixtureTableEditService::UpdateFullRowData(

--- a/gui/fixturetablepanel.h
+++ b/gui/fixturetablepanel.h
@@ -76,7 +76,8 @@ public:
 
     void UpdateSceneData(
         bool logChanges = true,
-        SceneDataUpdateType updateType = SceneDataUpdateType::kGeneral);
+        SceneDataUpdateType updateType = SceneDataUpdateType::kGeneral,
+        const std::vector<unsigned int> *targetRows = nullptr);
 
 private:
     friend class FixtureEditDialog; // allow dialog to access internals


### PR DESCRIPTION
### Motivation
- Ensure category-by-type propagation updates exactly the rows computed in the panel instead of relying on an implicit `GetSelections()` resolution, so scene edits and undo state are applied only to intended fixtures.

### Description
- Add a new overload `UpdateCategoryForRows(..., const std::vector<unsigned int>& targetRows, ...)` to `FixtureTableEditService` and wire it in the implementation to accept explicit target row indices.
- Introduce `ResolveTargetRows(..., const std::vector<unsigned int>* explicitTargetRows)` and use it from `ApplyCategoryChanges` to resolve and sanitize explicit row indices before applying changes.
- Extend `FixtureTablePanel::UpdateSceneData(...)` to accept an optional `const std::vector<unsigned int>* targetRows` parameter and dispatch `kCategoryOnly` updates to the new overload when present.
- Capture `affectedRows` in `gui/fixturetablepanel.cpp` when propagating category changes (column 18) and pass that set through `UpdateSceneData`, removing the implicit dependency on `GetSelections()` for this propagation flow.
- Files changed: `gui/fixturetablepanel.cpp`, `gui/fixturetablepanel.h`, `gui/fixturetable/fixture_table_edit_service.cpp`, `gui/fixturetable/fixture_table_edit_service.h`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and the check succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eac0e38b5c8324a73aafb0fce216c3)