### PR TITLE
viewer3d: add ID picking pass and wire hover by pixel-id

### DIFF
--- a/viewer3d/CMakeLists.txt
+++ b/viewer3d/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/loaderglb.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/meshprimitives.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/picking/selectionsystem.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/picking/id_pick_pass.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/gl_primitive_renderer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/hoist_symbol_renderer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/lighting_profile.cpp

--- a/viewer3d/interfaces/iselectioncontext.h
+++ b/viewer3d/interfaces/iselectioncontext.h
@@ -2,6 +2,7 @@
 
 #include "viewer3d_types.h"
 #include "canvas2d.h"
+#include <cstdint>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -45,4 +46,7 @@ public:
   virtual ICanvas2D *GetCaptureCanvas() const = 0;
   virtual void RecordText(float x, float y, const std::string &text,
                           const CanvasTextStyle &style) const = 0;
+  virtual bool ReadPickUuidAt(int mouseX, int mouseY, int width, int height,
+                              const std::unordered_set<std::string> &hiddenLayers,
+                              std::string &outUuid) = 0;
 };

--- a/viewer3d/picking/id_pick_pass.cpp
+++ b/viewer3d/picking/id_pick_pass.cpp
@@ -1,0 +1,210 @@
+#include "id_pick_pass.h"
+
+#include <GL/glew.h>
+#ifdef __APPLE__
+#define GL_SILENCE_DEPRECATION
+#include <OpenGL/gl.h>
+#else
+#include <GL/gl.h>
+#endif
+
+#include "opaque_fixture_pass.h"
+#include "opaque_object_pass.h"
+#include "opaque_truss_pass.h"
+#include "scenedatamanager.h"
+#include "viewer3dcontroller.h"
+
+#include <algorithm>
+
+namespace {
+bool MatricesEqual(const std::array<double, 16> &a,
+                   const std::array<double, 16> &b) {
+  return std::equal(a.begin(), a.end(), b.begin());
+}
+} // namespace
+
+IdPickPass::IdPickPass(Viewer3DController &controller) : m_controller(controller) {}
+
+IdPickPass::~IdPickPass() {
+  if (m_depthRenderbuffer != 0)
+    glDeleteRenderbuffers(1, &m_depthRenderbuffer);
+  if (m_colorTexture != 0)
+    glDeleteTextures(1, &m_colorTexture);
+  if (m_fbo != 0)
+    glDeleteFramebuffers(1, &m_fbo);
+}
+
+uint32_t IdPickPass::GetOrCreatePickId(const std::string &uuid) {
+  auto it = m_uuidToPickId.find(uuid);
+  if (it != m_uuidToPickId.end())
+    return it->second;
+  const uint32_t pickId = m_nextPickId++;
+  m_uuidToPickId[uuid] = pickId;
+  m_pickIdToUuid[pickId] = uuid;
+  return pickId;
+}
+
+std::array<float, 3> IdPickPass::GetPickColor(const std::string &uuid) {
+  const uint32_t pickId = GetOrCreatePickId(uuid);
+  const float r = static_cast<float>((pickId >> 16) & 0xFF) / 255.0f;
+  const float g = static_cast<float>((pickId >> 8) & 0xFF) / 255.0f;
+  const float b = static_cast<float>(pickId & 0xFF) / 255.0f;
+  return {r, g, b};
+}
+
+void IdPickPass::EnsureFramebufferSize(int width, int height) {
+  if (width <= 0 || height <= 0)
+    return;
+  if (m_fbo != 0 && m_width == width && m_height == height)
+    return;
+
+  if (m_depthRenderbuffer != 0)
+    glDeleteRenderbuffers(1, &m_depthRenderbuffer);
+  if (m_colorTexture != 0)
+    glDeleteTextures(1, &m_colorTexture);
+  if (m_fbo == 0)
+    glGenFramebuffers(1, &m_fbo);
+
+  glBindFramebuffer(GL_FRAMEBUFFER, m_fbo);
+
+  glGenTextures(1, &m_colorTexture);
+  glBindTexture(GL_TEXTURE_2D, m_colorTexture);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB8, width, height, 0, GL_RGB,
+               GL_UNSIGNED_BYTE, nullptr);
+  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+                         m_colorTexture, 0);
+
+  glGenRenderbuffers(1, &m_depthRenderbuffer);
+  glBindRenderbuffer(GL_RENDERBUFFER, m_depthRenderbuffer);
+  glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, width, height);
+  glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+                            GL_RENDERBUFFER, m_depthRenderbuffer);
+
+  m_width = width;
+  m_height = height;
+  m_dirty = true;
+}
+
+void IdPickPass::RebuildIfNeeded(
+    int width, int height,
+    const std::unordered_set<std::string> &hiddenLayers) {
+  EnsureFramebufferSize(width, height);
+  if (m_fbo == 0 || width <= 0 || height <= 0)
+    return;
+
+  int viewport[4] = {0, 0, 0, 0};
+  double model[16] = {0.0};
+  double projection[16] = {0.0};
+  glGetIntegerv(GL_VIEWPORT, viewport);
+  glGetDoublev(GL_MODELVIEW_MATRIX, model);
+  glGetDoublev(GL_PROJECTION_MATRIX, projection);
+
+  std::array<int, 4> currentViewport = {viewport[0], viewport[1], viewport[2],
+                                        viewport[3]};
+  std::array<double, 16> currentModel = {};
+  std::array<double, 16> currentProjection = {};
+  std::copy(std::begin(model), std::end(model), currentModel.begin());
+  std::copy(std::begin(projection), std::end(projection),
+            currentProjection.begin());
+
+  const bool cameraChanged = currentViewport != m_lastViewport ||
+                             !MatricesEqual(currentModel, m_lastModel) ||
+                             !MatricesEqual(currentProjection, m_lastProjection);
+  const bool layersChanged = hiddenLayers != m_lastHiddenLayers;
+  const bool sceneChanged = m_lastSceneVersion != m_controller.GetSceneVersion();
+  if (!m_dirty && !cameraChanged && !layersChanged && !sceneChanged)
+    return;
+
+  glBindFramebuffer(GL_FRAMEBUFFER, m_fbo);
+  glViewport(0, 0, width, height);
+  glDisable(GL_BLEND);
+  glEnable(GL_DEPTH_TEST);
+  glDisable(GL_LIGHTING);
+  glDisable(GL_TEXTURE_2D);
+  glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+  glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+  glMatrixMode(GL_PROJECTION);
+  glPushMatrix();
+  glLoadMatrixd(projection);
+  glMatrixMode(GL_MODELVIEW);
+  glPushMatrix();
+  glLoadMatrixd(model);
+
+  Viewer3DViewFrustumSnapshot frustum{};
+  std::copy(std::begin(viewport), std::end(viewport), std::begin(frustum.viewport));
+  std::copy(std::begin(model), std::end(model), std::begin(frustum.model));
+  std::copy(std::begin(projection), std::end(projection),
+            std::begin(frustum.projection));
+
+  RenderFrameContext context;
+  context.hiddenLayers = hiddenLayers;
+  context.useFrustumCulling = true;
+  context.idOnlyPass = true;
+  context.skipCapture = true;
+  const auto &visibleSet =
+      m_controller.GetVisibleSet(frustum, hiddenLayers, true, 0.0f);
+
+  auto getLayerColor = [](const std::string &) {
+    return std::array<float, 3>{1.0f, 1.0f, 1.0f};
+  };
+  auto getTypeColor = [](const std::string &, const std::string &) {
+    return std::array<float, 3>{1.0f, 1.0f, 1.0f};
+  };
+  auto resolveSymbolView = [](Viewer2DView) { return SymbolViewKind::Top; };
+  auto getPickColor = [this](const std::string &uuid) {
+    return GetPickColor(uuid);
+  };
+
+  OpaqueObjectPass::Render(m_controller, context, visibleSet, getLayerColor,
+                           resolveSymbolView, getPickColor);
+  OpaqueTrussPass::Render(m_controller, context, visibleSet, getLayerColor,
+                          resolveSymbolView, getPickColor);
+  OpaqueFixturePass::Render(m_controller, context, visibleSet, getTypeColor,
+                            getLayerColor, resolveSymbolView, getPickColor);
+
+  glPopMatrix();
+  glMatrixMode(GL_PROJECTION);
+  glPopMatrix();
+  glMatrixMode(GL_MODELVIEW);
+
+  glBindFramebuffer(GL_FRAMEBUFFER, 0);
+  glViewport(viewport[0], viewport[1], viewport[2], viewport[3]);
+
+  m_lastViewport = currentViewport;
+  m_lastModel = currentModel;
+  m_lastProjection = currentProjection;
+  m_lastHiddenLayers = hiddenLayers;
+  m_lastSceneVersion = m_controller.GetSceneVersion();
+  m_dirty = false;
+}
+
+bool IdPickPass::ReadUuidAt(int mouseX, int mouseY, int width, int height,
+                            const std::unordered_set<std::string> &hiddenLayers,
+                            std::string &outUuid) {
+  RebuildIfNeeded(width, height, hiddenLayers);
+  if (m_fbo == 0 || mouseX < 0 || mouseY < 0 || mouseX >= width ||
+      mouseY >= height)
+    return false;
+
+  const int sampleY = height - mouseY;
+  unsigned char pixel[3] = {0, 0, 0};
+  glBindFramebuffer(GL_FRAMEBUFFER, m_fbo);
+  glReadPixels(mouseX, sampleY, 1, 1, GL_RGB, GL_UNSIGNED_BYTE, pixel);
+  glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+  const uint32_t pickId = (static_cast<uint32_t>(pixel[0]) << 16) |
+                          (static_cast<uint32_t>(pixel[1]) << 8) |
+                          static_cast<uint32_t>(pixel[2]);
+  if (pickId == 0)
+    return false;
+
+  auto it = m_pickIdToUuid.find(pickId);
+  if (it == m_pickIdToUuid.end())
+    return false;
+
+  outUuid = it->second;
+  return true;
+}

--- a/viewer3d/picking/id_pick_pass.h
+++ b/viewer3d/picking/id_pick_pass.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "viewer3d_types.h"
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+class Viewer3DController;
+
+class IdPickPass {
+public:
+  explicit IdPickPass(Viewer3DController &controller);
+  ~IdPickPass();
+
+  bool ReadUuidAt(int mouseX, int mouseY, int width, int height,
+                  const std::unordered_set<std::string> &hiddenLayers,
+                  std::string &outUuid);
+
+private:
+  void EnsureFramebufferSize(int width, int height);
+  void RebuildIfNeeded(int width, int height,
+                       const std::unordered_set<std::string> &hiddenLayers);
+  uint32_t GetOrCreatePickId(const std::string &uuid);
+  std::array<float, 3> GetPickColor(const std::string &uuid);
+
+  Viewer3DController &m_controller;
+  unsigned int m_fbo = 0;
+  unsigned int m_colorTexture = 0;
+  unsigned int m_depthRenderbuffer = 0;
+  int m_width = 0;
+  int m_height = 0;
+  bool m_dirty = true;
+  size_t m_lastSceneVersion = static_cast<size_t>(-1);
+  std::unordered_set<std::string> m_lastHiddenLayers;
+  std::array<int, 4> m_lastViewport = {0, 0, 0, 0};
+  std::array<double, 16> m_lastModel = {};
+  std::array<double, 16> m_lastProjection = {};
+
+  uint32_t m_nextPickId = 1;
+  std::unordered_map<std::string, uint32_t> m_uuidToPickId;
+  std::unordered_map<uint32_t, std::string> m_pickIdToUuid;
+};

--- a/viewer3d/picking/selectionsystem.cpp
+++ b/viewer3d/picking/selectionsystem.cpp
@@ -349,11 +349,12 @@ bool SelectionSystem::GetFixtureLabelAt(int mouseX, int mouseY, int width,
           bool showDmx = cfg.GetFloat("label_show_dmx") != 0.0f;
           wxString label;
           if (showName)
-            label += wxString::FromUTF8(f.name);
-          if (showId && !f.fixtureId.empty()) {
+            label = f.instanceName.empty() ? wxString::FromUTF8(pickedUuid)
+                                           : wxString::FromUTF8(f.instanceName);
+          if (showId) {
             if (!label.empty())
               label += "\n";
-            label += wxString::FromUTF8(f.fixtureId);
+            label += "ID: " + wxString::Format("%d", f.fixtureId);
           }
           if (showDmx && !f.address.empty()) {
             if (!label.empty())

--- a/viewer3d/picking/selectionsystem.cpp
+++ b/viewer3d/picking/selectionsystem.cpp
@@ -332,6 +332,42 @@ bool SelectionSystem::GetFixtureLabelAt(int mouseX, int mouseY, int width,
   ConfigManager &cfg = ConfigManager::Get();
   if (m_controller.IsCameraMoving() && IsFastInteractionModeEnabled(cfg))
     return false;
+  const auto hiddenLayers = SnapshotHiddenLayers(cfg);
+  std::string pickedUuid;
+  if (m_controller.ReadPickUuidAt(mouseX, mouseY, width, height, hiddenLayers,
+                                  pickedUuid)) {
+    const auto &fixtures = SceneDataManager::Instance().GetFixtures();
+    auto fixtureIt = fixtures.find(pickedUuid);
+    if (fixtureIt != fixtures.end()) {
+      const auto bbIt = m_controller.GetFixtureBoundsMap().find(pickedUuid);
+      if (bbIt != m_controller.GetFixtureBoundsMap().end()) {
+        const ProjectionSnapshot projection = CaptureProjectionSnapshot();
+        if (ProjectBoundingBoxCenter(bbIt->second, projection, height, outPos)) {
+          const auto &f = fixtureIt->second;
+          bool showName = cfg.GetFloat("label_show_name") != 0.0f;
+          bool showId = cfg.GetFloat("label_show_id") != 0.0f;
+          bool showDmx = cfg.GetFloat("label_show_dmx") != 0.0f;
+          wxString label;
+          if (showName)
+            label += wxString::FromUTF8(f.name);
+          if (showId && !f.fixtureId.empty()) {
+            if (!label.empty())
+              label += "\n";
+            label += wxString::FromUTF8(f.fixtureId);
+          }
+          if (showDmx && !f.address.empty()) {
+            if (!label.empty())
+              label += "\n";
+            label += wxString::FromUTF8(f.address);
+          }
+          outLabel = label;
+          if (outUuid)
+            *outUuid = pickedUuid;
+          return true;
+        }
+      }
+    }
+  }
 
   QueryMetrics metrics;
   const auto projectionStart = std::chrono::steady_clock::now();
@@ -347,7 +383,6 @@ bool SelectionSystem::GetFixtureLabelAt(int mouseX, int mouseY, int width,
   Ray mouseRay;
   if (!BuildMouseRay(mouseX, mouseY, height, projection, mouseRay))
     return false;
-  const auto hiddenLayers = SnapshotHiddenLayers(cfg);
   if (projectionChanged || hiddenLayers != m_queryCache.hiddenLayers) {
     m_queryCache.hiddenLayers = hiddenLayers;
     m_queryCache.visibleSet = nullptr;
@@ -469,6 +504,27 @@ bool SelectionSystem::GetTrussLabelAt(int mouseX, int mouseY, int width,
   ConfigManager &cfg = ConfigManager::Get();
   if (m_controller.IsCameraMoving() && IsFastInteractionModeEnabled(cfg))
     return false;
+  const auto hiddenLayers = SnapshotHiddenLayers(cfg);
+  std::string pickedUuid;
+  if (m_controller.ReadPickUuidAt(mouseX, mouseY, width, height, hiddenLayers,
+                                  pickedUuid)) {
+    const auto &trusses = SceneDataManager::Instance().GetTrusses();
+    auto trussIt = trusses.find(pickedUuid);
+    if (trussIt != trusses.end()) {
+      const auto bbIt = m_controller.GetTrussBoundsMap().find(pickedUuid);
+      if (bbIt != m_controller.GetTrussBoundsMap().end()) {
+        const ProjectionSnapshot projection = CaptureProjectionSnapshot();
+        if (ProjectBoundingBoxCenter(bbIt->second, projection, height, outPos)) {
+          const auto &t = trussIt->second;
+          wxString label = wxString::FromUTF8(t.name);
+          outLabel = label;
+          if (outUuid)
+            *outUuid = pickedUuid;
+          return true;
+        }
+      }
+    }
+  }
 
   QueryMetrics metrics;
   const auto projectionStart = std::chrono::steady_clock::now();
@@ -483,7 +539,6 @@ bool SelectionSystem::GetTrussLabelAt(int mouseX, int mouseY, int width,
   Ray mouseRay;
   if (!BuildMouseRay(mouseX, mouseY, height, projection, mouseRay))
     return false;
-  const auto hiddenLayers = SnapshotHiddenLayers(cfg);
   if (projectionChanged || hiddenLayers != m_queryCache.hiddenLayers) {
     m_queryCache.hiddenLayers = hiddenLayers;
     m_queryCache.visibleSet = nullptr;
@@ -585,6 +640,25 @@ bool SelectionSystem::GetSceneObjectLabelAt(int mouseX, int mouseY, int width,
   ConfigManager &cfg = ConfigManager::Get();
   if (m_controller.IsCameraMoving() && IsFastInteractionModeEnabled(cfg))
     return false;
+  const auto hiddenLayers = SnapshotHiddenLayers(cfg);
+  std::string pickedUuid;
+  if (m_controller.ReadPickUuidAt(mouseX, mouseY, width, height, hiddenLayers,
+                                  pickedUuid)) {
+    const auto &sceneObjects = SceneDataManager::Instance().GetSceneObjects();
+    auto objectIt = sceneObjects.find(pickedUuid);
+    if (objectIt != sceneObjects.end()) {
+      const auto bbIt = m_controller.GetObjectBoundsMap().find(pickedUuid);
+      if (bbIt != m_controller.GetObjectBoundsMap().end()) {
+        const ProjectionSnapshot projection = CaptureProjectionSnapshot();
+        if (ProjectBoundingBoxCenter(bbIt->second, projection, height, outPos)) {
+          outLabel = wxString::FromUTF8(objectIt->second.name);
+          if (outUuid)
+            *outUuid = pickedUuid;
+          return true;
+        }
+      }
+    }
+  }
 
   QueryMetrics metrics;
   const auto projectionStart = std::chrono::steady_clock::now();
@@ -599,7 +673,6 @@ bool SelectionSystem::GetSceneObjectLabelAt(int mouseX, int mouseY, int width,
   Ray mouseRay;
   if (!BuildMouseRay(mouseX, mouseY, height, projection, mouseRay))
     return false;
-  const auto hiddenLayers = SnapshotHiddenLayers(cfg);
   if (projectionChanged || hiddenLayers != m_queryCache.hiddenLayers) {
     m_queryCache.hiddenLayers = hiddenLayers;
     m_queryCache.visibleSet = nullptr;

--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -437,6 +437,35 @@ void CancelFixtureRotationForLayoutSvg(const Matrix &fixtureTransform,
   };
   glMultMatrixf(inverseRotation);
 }
+
+void DrawBoundsSolid(const Viewer3DBoundingBox &bb) {
+  glBegin(GL_QUADS);
+  glVertex3f(bb.min[0], bb.min[1], bb.min[2]);
+  glVertex3f(bb.max[0], bb.min[1], bb.min[2]);
+  glVertex3f(bb.max[0], bb.max[1], bb.min[2]);
+  glVertex3f(bb.min[0], bb.max[1], bb.min[2]);
+  glVertex3f(bb.min[0], bb.min[1], bb.max[2]);
+  glVertex3f(bb.max[0], bb.min[1], bb.max[2]);
+  glVertex3f(bb.max[0], bb.max[1], bb.max[2]);
+  glVertex3f(bb.min[0], bb.max[1], bb.max[2]);
+  glVertex3f(bb.min[0], bb.min[1], bb.min[2]);
+  glVertex3f(bb.max[0], bb.min[1], bb.min[2]);
+  glVertex3f(bb.max[0], bb.min[1], bb.max[2]);
+  glVertex3f(bb.min[0], bb.min[1], bb.max[2]);
+  glVertex3f(bb.min[0], bb.max[1], bb.min[2]);
+  glVertex3f(bb.max[0], bb.max[1], bb.min[2]);
+  glVertex3f(bb.max[0], bb.max[1], bb.max[2]);
+  glVertex3f(bb.min[0], bb.max[1], bb.max[2]);
+  glVertex3f(bb.min[0], bb.min[1], bb.min[2]);
+  glVertex3f(bb.min[0], bb.max[1], bb.min[2]);
+  glVertex3f(bb.min[0], bb.max[1], bb.max[2]);
+  glVertex3f(bb.min[0], bb.min[1], bb.max[2]);
+  glVertex3f(bb.max[0], bb.min[1], bb.min[2]);
+  glVertex3f(bb.max[0], bb.max[1], bb.min[2]);
+  glVertex3f(bb.max[0], bb.max[1], bb.max[2]);
+  glVertex3f(bb.max[0], bb.min[1], bb.max[2]);
+  glEnd();
+}
 } // namespace
 
 void OpaqueFixturePass::Render(
@@ -444,7 +473,20 @@ void OpaqueFixturePass::Render(
     const Viewer3DVisibleSet &visibleSet,
     const std::function<std::array<float, 3>(const std::string &, const std::string &)> &getTypeColor,
     const std::function<std::array<float, 3>(const std::string &)> &getLayerColor,
-    const std::function<SymbolViewKind(Viewer2DView)> &resolveSymbolView) {
+    const std::function<SymbolViewKind(Viewer2DView)> &resolveSymbolView,
+    const std::function<std::array<float, 3>(const std::string &)> &getPickColor) {
+  if (context.idOnlyPass) {
+    glShadeModel(GL_FLAT);
+    for (const auto &uuid : visibleSet.fixtureUuids) {
+      auto bbIt = controller.m_fixtureBounds.find(uuid);
+      if (bbIt == controller.m_fixtureBounds.end())
+        continue;
+      const auto pickColor = getPickColor(uuid);
+      glColor3f(pickColor[0], pickColor[1], pickColor[2]);
+      DrawBoundsSolid(bbIt->second);
+    }
+    return;
+  }
   const bool wireframe = context.wireframe;
   const Viewer2DRenderMode mode = context.mode;
   const bool skipCapture = context.skipCapture;

--- a/viewer3d/render/opaque_fixture_pass.h
+++ b/viewer3d/render/opaque_fixture_pass.h
@@ -15,5 +15,6 @@ public:
       const Viewer3DVisibleSet &visibleSet,
       const std::function<std::array<float, 3>(const std::string &, const std::string &)> &getTypeColor,
       const std::function<std::array<float, 3>(const std::string &)> &getLayerColor,
-      const std::function<SymbolViewKind(Viewer2DView)> &resolveSymbolView);
+      const std::function<SymbolViewKind(Viewer2DView)> &resolveSymbolView,
+      const std::function<std::array<float, 3>(const std::string &)> &getPickColor);
 };

--- a/viewer3d/render/opaque_object_pass.cpp
+++ b/viewer3d/render/opaque_object_pass.cpp
@@ -32,6 +32,34 @@
 #include <vector>
 
 namespace {
+void DrawBoundsSolid(const Viewer3DBoundingBox &bb) {
+  glBegin(GL_QUADS);
+  glVertex3f(bb.min[0], bb.min[1], bb.min[2]);
+  glVertex3f(bb.max[0], bb.min[1], bb.min[2]);
+  glVertex3f(bb.max[0], bb.max[1], bb.min[2]);
+  glVertex3f(bb.min[0], bb.max[1], bb.min[2]);
+  glVertex3f(bb.min[0], bb.min[1], bb.max[2]);
+  glVertex3f(bb.max[0], bb.min[1], bb.max[2]);
+  glVertex3f(bb.max[0], bb.max[1], bb.max[2]);
+  glVertex3f(bb.min[0], bb.max[1], bb.max[2]);
+  glVertex3f(bb.min[0], bb.min[1], bb.min[2]);
+  glVertex3f(bb.max[0], bb.min[1], bb.min[2]);
+  glVertex3f(bb.max[0], bb.min[1], bb.max[2]);
+  glVertex3f(bb.min[0], bb.min[1], bb.max[2]);
+  glVertex3f(bb.min[0], bb.max[1], bb.min[2]);
+  glVertex3f(bb.max[0], bb.max[1], bb.min[2]);
+  glVertex3f(bb.max[0], bb.max[1], bb.max[2]);
+  glVertex3f(bb.min[0], bb.max[1], bb.max[2]);
+  glVertex3f(bb.min[0], bb.min[1], bb.min[2]);
+  glVertex3f(bb.min[0], bb.max[1], bb.min[2]);
+  glVertex3f(bb.min[0], bb.max[1], bb.max[2]);
+  glVertex3f(bb.min[0], bb.min[1], bb.max[2]);
+  glVertex3f(bb.max[0], bb.min[1], bb.min[2]);
+  glVertex3f(bb.max[0], bb.max[1], bb.min[2]);
+  glVertex3f(bb.max[0], bb.max[1], bb.max[2]);
+  glVertex3f(bb.max[0], bb.min[1], bb.max[2]);
+  glEnd();
+}
 
 const Mesh &FallbackSceneObjectCubeMesh() {
   static const Mesh mesh = []() {
@@ -167,7 +195,20 @@ void OpaqueObjectPass::Render(
     Viewer3DController &controller, const RenderFrameContext &context,
     const Viewer3DVisibleSet &visibleSet,
     const std::function<std::array<float, 3>(const std::string &)> &getLayerColor,
-    const std::function<SymbolViewKind(Viewer2DView)> &resolveSymbolView) {
+    const std::function<SymbolViewKind(Viewer2DView)> &resolveSymbolView,
+    const std::function<std::array<float, 3>(const std::string &)> &getPickColor) {
+  if (context.idOnlyPass) {
+    glShadeModel(GL_FLAT);
+    for (const auto &uuid : visibleSet.objectUuids) {
+      auto bbIt = controller.m_objectBounds.find(uuid);
+      if (bbIt == controller.m_objectBounds.end())
+        continue;
+      const auto pickColor = getPickColor(uuid);
+      glColor3f(pickColor[0], pickColor[1], pickColor[2]);
+      DrawBoundsSolid(bbIt->second);
+    }
+    return;
+  }
   const bool wireframe = context.wireframe;
   const Viewer2DRenderMode mode = context.mode;
   const bool skipCapture = context.skipCapture;

--- a/viewer3d/render/opaque_object_pass.h
+++ b/viewer3d/render/opaque_object_pass.h
@@ -14,5 +14,6 @@ public:
       Viewer3DController &controller, const RenderFrameContext &context,
       const Viewer3DVisibleSet &visibleSet,
       const std::function<std::array<float, 3>(const std::string &)> &getLayerColor,
-      const std::function<SymbolViewKind(Viewer2DView)> &resolveSymbolView);
+      const std::function<SymbolViewKind(Viewer2DView)> &resolveSymbolView,
+      const std::function<std::array<float, 3>(const std::string &)> &getPickColor);
 };

--- a/viewer3d/render/opaque_truss_pass.cpp
+++ b/viewer3d/render/opaque_truss_pass.cpp
@@ -24,11 +24,55 @@
 #include <sstream>
 #include <vector>
 
+namespace {
+void DrawBoundsSolid(const Viewer3DBoundingBox &bb) {
+  glBegin(GL_QUADS);
+  glVertex3f(bb.min[0], bb.min[1], bb.min[2]);
+  glVertex3f(bb.max[0], bb.min[1], bb.min[2]);
+  glVertex3f(bb.max[0], bb.max[1], bb.min[2]);
+  glVertex3f(bb.min[0], bb.max[1], bb.min[2]);
+  glVertex3f(bb.min[0], bb.min[1], bb.max[2]);
+  glVertex3f(bb.max[0], bb.min[1], bb.max[2]);
+  glVertex3f(bb.max[0], bb.max[1], bb.max[2]);
+  glVertex3f(bb.min[0], bb.max[1], bb.max[2]);
+  glVertex3f(bb.min[0], bb.min[1], bb.min[2]);
+  glVertex3f(bb.max[0], bb.min[1], bb.min[2]);
+  glVertex3f(bb.max[0], bb.min[1], bb.max[2]);
+  glVertex3f(bb.min[0], bb.min[1], bb.max[2]);
+  glVertex3f(bb.min[0], bb.max[1], bb.min[2]);
+  glVertex3f(bb.max[0], bb.max[1], bb.min[2]);
+  glVertex3f(bb.max[0], bb.max[1], bb.max[2]);
+  glVertex3f(bb.min[0], bb.max[1], bb.max[2]);
+  glVertex3f(bb.min[0], bb.min[1], bb.min[2]);
+  glVertex3f(bb.min[0], bb.max[1], bb.min[2]);
+  glVertex3f(bb.min[0], bb.max[1], bb.max[2]);
+  glVertex3f(bb.min[0], bb.min[1], bb.max[2]);
+  glVertex3f(bb.max[0], bb.min[1], bb.min[2]);
+  glVertex3f(bb.max[0], bb.max[1], bb.min[2]);
+  glVertex3f(bb.max[0], bb.max[1], bb.max[2]);
+  glVertex3f(bb.max[0], bb.min[1], bb.max[2]);
+  glEnd();
+}
+} // namespace
+
 void OpaqueTrussPass::Render(
     Viewer3DController &controller, const RenderFrameContext &context,
     const Viewer3DVisibleSet &visibleSet,
     const std::function<std::array<float, 3>(const std::string &)> &getLayerColor,
-    const std::function<SymbolViewKind(Viewer2DView)> &resolveSymbolView) {
+    const std::function<SymbolViewKind(Viewer2DView)> &resolveSymbolView,
+    const std::function<std::array<float, 3>(const std::string &)> &getPickColor) {
+  if (context.idOnlyPass) {
+    glShadeModel(GL_FLAT);
+    for (const auto &uuid : visibleSet.trussUuids) {
+      auto bbIt = controller.m_trussBounds.find(uuid);
+      if (bbIt == controller.m_trussBounds.end())
+        continue;
+      const auto pickColor = getPickColor(uuid);
+      glColor3f(pickColor[0], pickColor[1], pickColor[2]);
+      DrawBoundsSolid(bbIt->second);
+    }
+    return;
+  }
   const bool wireframe = context.wireframe;
   const Viewer2DRenderMode mode = context.mode;
   const bool skipCapture = context.skipCapture;

--- a/viewer3d/render/opaque_truss_pass.h
+++ b/viewer3d/render/opaque_truss_pass.h
@@ -14,5 +14,6 @@ public:
       Viewer3DController &controller, const RenderFrameContext &context,
       const Viewer3DVisibleSet &visibleSet,
       const std::function<std::array<float, 3>(const std::string &)> &getLayerColor,
-      const std::function<SymbolViewKind(Viewer2DView)> &resolveSymbolView);
+      const std::function<SymbolViewKind(Viewer2DView)> &resolveSymbolView,
+      const std::function<std::array<float, 3>(const std::string &)> &getPickColor);
 };

--- a/viewer3d/viewer3d_types.h
+++ b/viewer3d/viewer3d_types.h
@@ -75,6 +75,7 @@ struct RenderFrameContext {
   bool skipOptionalWork = false;
   bool skipCapture = false;
   bool skipOutlinesForCurrentFrame = false;
+  bool idOnlyPass = false;
 
   bool colorByFixtureType = false;
   bool colorByLayer = false;

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -64,6 +64,7 @@
 #include "visibilitysystem.h"
 #include "label_render_system.h"
 #include "selectionsystem.h"
+#include "id_pick_pass.h"
 #include "gl_primitive_renderer.h"
 #include "lighting_profile.h"
 #include "viewer3d_render_style.h"
@@ -155,6 +156,7 @@ struct Viewer3DController::Impl {
   std::unique_ptr<SceneRenderer> sceneRenderer;
   std::unique_ptr<VisibilitySystem> visibilitySystem;
   std::unique_ptr<SelectionSystem> selectionSystem;
+  std::unique_ptr<IdPickPass> idPickPass;
   std::unique_ptr<LabelRenderSystem> labelRenderSystem;
   size_t logicalSceneSignature = 0;
   bool hasLogicalSceneSignature = false;
@@ -672,6 +674,15 @@ void Viewer3DController::RecordText(float x, float y, const std::string &text,
   m_impl->captureCanvas->DrawText(x, y, text, style);
 }
 
+bool Viewer3DController::ReadPickUuidAt(
+    int mouseX, int mouseY, int width, int height,
+    const std::unordered_set<std::string> &hiddenLayers, std::string &outUuid) {
+  if (!m_impl->idPickPass)
+    return false;
+  return m_impl->idPickPass->ReadUuidAt(mouseX, mouseY, width, height,
+                                        hiddenLayers, outUuid);
+}
+
 Viewer3DController::Viewer3DController()
     : m_impl(std::make_unique<Impl>()),
       m_resourceSyncState(m_impl->resourceSyncState),
@@ -689,6 +700,7 @@ Viewer3DController::Viewer3DController()
   m_impl->sceneRenderer = std::make_unique<SceneRenderer>(*this);
   m_impl->visibilitySystem = std::make_unique<VisibilitySystem>(*this);
   m_impl->selectionSystem = std::make_unique<SelectionSystem>(*this);
+  m_impl->idPickPass = std::make_unique<IdPickPass>(*this);
   m_impl->labelRenderSystem = std::make_unique<LabelRenderSystem>(*this);
   // Actual initialization of OpenGL-dependent resources is delayed
   // until a valid context is available.
@@ -1221,13 +1233,16 @@ void Viewer3DController::RenderOpaqueFrame(const RenderFrameContext &context,
       return SymbolViewKind::Bottom;
     }
   };
+  auto getPickColor = [](const std::string &) {
+    return std::array<float, 3>{1.0f, 1.0f, 1.0f};
+  };
 
   OpaqueObjectPass::Render(*this, context, visibleSet, getLayerColor,
-                           resolveSymbolView);
+                           resolveSymbolView, getPickColor);
   OpaqueTrussPass::Render(*this, context, visibleSet, getLayerColor,
-                          resolveSymbolView);
+                          resolveSymbolView, getPickColor);
   OpaqueFixturePass::Render(*this, context, visibleSet, getTypeColor,
-                            getLayerColor, resolveSymbolView);
+                            getLayerColor, resolveSymbolView, getPickColor);
   HoistSymbolRenderer::Render(*this, context);
 }
 

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -330,5 +330,6 @@ private:
   friend class OpaqueFixturePass;
   friend class OpaqueTrussPass;
   friend class OpaqueObjectPass;
+  friend class IdPickPass;
   friend class RenderPipeline;
 };

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -45,6 +45,7 @@ class Mesh;
 class SceneRenderer;
 class VisibilitySystem;
 class SelectionSystem;
+class IdPickPass;
 class LabelRenderSystem;
 class OpaqueFixturePass;
 class OpaqueTrussPass;
@@ -249,6 +250,9 @@ private:
                      const CanvasFill *fill) const override;
   void RecordText(float x, float y, const std::string &text,
                   const CanvasTextStyle &style) const override;
+  bool ReadPickUuidAt(int mouseX, int mouseY, int width, int height,
+                      const std::unordered_set<std::string> &hiddenLayers,
+                      std::string &outUuid) override;
   void SetupMeshBuffers(Mesh &mesh);
   void ReleaseMeshBuffers(Mesh &mesh);
   void DrawMesh(const Mesh &mesh, float scale = RENDER_SCALE,


### PR DESCRIPTION
### Motivation
- Reduce growth of `viewer3dcontroller.cpp` by moving picking/framebuffer responsibilities into a dedicated module and add a robust, GPU-based hit test path using a stable color-ID buffer.
- Provide a fast, deterministic hover/label lookup via a pixel read of an ID buffer while keeping the existing ray/AABB search as a fallback.

### Description
- Added a new picking module `viewer3d/picking/id_pick_pass.{h,cpp}` that owns an offscreen framebuffer (RGB ID texture + depth renderbuffer), a stable `uuid <-> pickId` bi-directional map, and logic to rebuild the ID buffer only when camera/viewport matrices, hidden layers or scene version change. The pick color encodes a 24-bit pickId. (`IdPickPass`)
- Extended `RenderFrameContext` with `idOnlyPass` and added an ID-only rendering route in the opaque passes so they can render ID colors without shading/labels; the fixture/truss/object passes now accept a `getPickColor` callback and early-return when `idOnlyPass` is set. (`viewer3d_types.h`, `opaque_*_pass.{h,cpp}`)
- Exposed pixel-ID lookup from selection context via `ISelectionContext::ReadPickUuidAt(...)` and implemented `Viewer3DController::ReadPickUuidAt(...)` forwarding to the new pass; `IdPickPass` is owned by the controller. (`iselectioncontext.h`, `viewer3dcontroller.{h,cpp}`)
- Updated `SelectionSystem` to prefer `ReadPickUuidAt(mouseX,mouseY,...)` for hover/label queries (fixtures, trusses, scene objects) and fall back to the existing ray/AABB logic when pixel-ID lookup fails; label projection/formatting remains unchanged. (`picking/selectionsystem.cpp`)
- Registered the new source in `viewer3d/CMakeLists.txt` and kept ID-only rendering intentionally simple by drawing world-space bounding boxes for stable picks (future improvement: optional half-resolution buffer).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed (`OK`).
- Attempted to configure/build with `cmake -S . -B build && cmake --build build -j2`, but configure failed in this environment because the system is missing `wxWidgets` development files (so no full build result is available here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eac23727048324b4ef41a6bc9dbba4)