### PR TITLE
viewer3d: use dedicated hover UUID picking path for highlight/click

### DIFF
--- a/viewer3d/picking/selectionsystem.cpp
+++ b/viewer3d/picking/selectionsystem.cpp
@@ -305,6 +305,73 @@ void CacheProjectionSnapshot(const ProjectionSnapshot &projection,
   cache.visibleSet = nullptr;
 }
 
+bool IsUuidValidForTarget(const std::string &uuid,
+                          SelectionSystem::HoverPickTarget target,
+                          const std::unordered_set<std::string> &hiddenLayers,
+                          const ISelectionContext &controller,
+                          const ISelectionContext::BoundingBox **outBounds) {
+  switch (target) {
+  case SelectionSystem::HoverPickTarget::Fixture: {
+    const auto &fixtures = SceneDataManager::Instance().GetFixtures();
+    auto fixtureIt = fixtures.find(uuid);
+    if (fixtureIt == fixtures.end() ||
+        !IsLayerVisibleCached(hiddenLayers, fixtureIt->second.layer)) {
+      return false;
+    }
+    const ISelectionContext::BoundingBox *bbPtr =
+        controller.FindFixtureBounds(uuid);
+    if (!bbPtr)
+      return false;
+    if (outBounds)
+      *outBounds = bbPtr;
+    return true;
+  }
+  case SelectionSystem::HoverPickTarget::Truss: {
+    const auto &trusses = SceneDataManager::Instance().GetTrusses();
+    auto trussIt = trusses.find(uuid);
+    if (trussIt == trusses.end() ||
+        !IsLayerVisibleCached(hiddenLayers, trussIt->second.layer)) {
+      return false;
+    }
+    const ISelectionContext::BoundingBox *bbPtr = controller.FindTrussBounds(uuid);
+    if (!bbPtr)
+      return false;
+    if (outBounds)
+      *outBounds = bbPtr;
+    return true;
+  }
+  case SelectionSystem::HoverPickTarget::SceneObject: {
+    const auto &objects = SceneDataManager::Instance().GetSceneObjects();
+    auto objectIt = objects.find(uuid);
+    if (objectIt == objects.end() ||
+        !IsLayerVisibleCached(hiddenLayers, objectIt->second.layer)) {
+      return false;
+    }
+    const ISelectionContext::BoundingBox *bbPtr = controller.FindObjectBounds(uuid);
+    if (!bbPtr)
+      return false;
+    if (outBounds)
+      *outBounds = bbPtr;
+    return true;
+  }
+  }
+  return false;
+}
+
+const std::vector<std::string> &VisibleUuidsForTarget(
+    const ISelectionContext::VisibleSet &visibleSet,
+    SelectionSystem::HoverPickTarget target) {
+  switch (target) {
+  case SelectionSystem::HoverPickTarget::Fixture:
+    return visibleSet.fixtureUuids;
+  case SelectionSystem::HoverPickTarget::Truss:
+    return visibleSet.trussUuids;
+  case SelectionSystem::HoverPickTarget::SceneObject:
+    return visibleSet.objectUuids;
+  }
+  return visibleSet.fixtureUuids;
+}
+
 void LogQueryMetrics(const char *label, const SelectionSystem::QueryMetrics &metrics,
                      const SelectionSystem::QueryTelemetry &telemetry,
                      int queryCounter) {
@@ -335,6 +402,133 @@ void SelectionSystem::SetHighlightUuid(const std::string &uuid) {
 
 void SelectionSystem::SetSelectedUuids(const std::vector<std::string> &uuids) {
   m_controller.ReplaceSelectedUuids(uuids);
+}
+
+bool SelectionSystem::GetHoverUuidAt(int mouseX, int mouseY, int width,
+                                     int height, HoverPickTarget target,
+                                     std::string &outUuid,
+                                     bool confirmDepth) {
+  const auto queryStart = std::chrono::steady_clock::now();
+  ConfigManager &cfg = ConfigManager::Get();
+  if (m_controller.IsCameraMoving() && IsFastInteractionModeEnabled(cfg))
+    return false;
+
+  const bool cameraMoving = m_controller.IsCameraMoving();
+  const bool useIdBuffer = IsIdBufferPickingEnabled(cfg);
+  const auto hiddenLayers = SnapshotHiddenLayers(cfg);
+  QueryMetrics metrics;
+  std::string bestUuid;
+
+  if (useIdBuffer) {
+    std::string pickedUuid;
+    if (m_controller.ReadPickUuidAt(mouseX, mouseY, width, height, hiddenLayers,
+                                    pickedUuid) &&
+        IsUuidValidForTarget(pickedUuid, target, hiddenLayers, m_controller,
+                             nullptr)) {
+      metrics.usedIdPath = true;
+      if (cameraMoving || !IsAmbiguousDepthConfirmEnabled(cfg) || !confirmDepth) {
+        outUuid = pickedUuid;
+        metrics.total = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - queryStart);
+        LogQueryMetrics("hover_uuid(id)", metrics, m_queryTelemetry,
+                        ++m_queryCounter);
+        return true;
+      }
+    }
+  }
+
+  const auto projectionStart = std::chrono::steady_clock::now();
+  const ProjectionSnapshot projection = CaptureProjectionSnapshot();
+  const bool projectionChanged = !ProjectionMatchesCache(projection, m_queryCache);
+  if (projectionChanged) {
+    CacheProjectionSnapshot(projection, m_queryCache);
+    m_queryCache.hiddenLayers.clear();
+  }
+  metrics.reprojected = projectionChanged;
+  metrics.projection = std::chrono::duration_cast<std::chrono::microseconds>(
+      std::chrono::steady_clock::now() - projectionStart);
+
+  Ray mouseRay;
+  if (!BuildMouseRay(mouseX, mouseY, height, projection, mouseRay))
+    return false;
+
+  if (projectionChanged || hiddenLayers != m_queryCache.hiddenLayers) {
+    m_queryCache.hiddenLayers = hiddenLayers;
+    m_queryCache.visibleSet = nullptr;
+  }
+
+  const auto depthReadStart = std::chrono::steady_clock::now();
+  bool hasDepthWorldPoint = false;
+  std::array<double, 3> depthWorldPoint{};
+  const bool shouldReadDepth = confirmDepth &&
+                               (projectionChanged || m_queryCache.depthMouseX != mouseX ||
+                                m_queryCache.depthMouseY != mouseY ||
+                                m_queryCache.depthHeight != height);
+  if (shouldReadDepth) {
+    m_queryCache.hasDepthWorldPoint =
+        ReadWorldPointFromDepth(mouseX, mouseY, height, projection,
+                                m_queryCache.depthWorldPoint);
+    m_queryCache.depthMouseX = mouseX;
+    m_queryCache.depthMouseY = mouseY;
+    m_queryCache.depthHeight = height;
+  }
+  if (confirmDepth) {
+    hasDepthWorldPoint = m_queryCache.hasDepthWorldPoint;
+    depthWorldPoint = m_queryCache.depthWorldPoint;
+  }
+  metrics.depthRead = std::chrono::duration_cast<std::chrono::microseconds>(
+      std::chrono::steady_clock::now() - depthReadStart);
+
+  if (!m_queryCache.visibleSet) {
+    m_queryCache.visibleSet =
+        &m_controller.GetVisibleSet(m_queryCache.frustum, m_queryCache.hiddenLayers,
+                                    true, 0.0f);
+  }
+  const ISelectionContext::VisibleSet &visibleSet = *m_queryCache.visibleSet;
+  const std::vector<std::string> &candidateUuids =
+      VisibleUuidsForTarget(visibleSet, target);
+
+  double bestHitDistance = DBL_MAX;
+  bool found = false;
+  const auto candidateLoopStart = std::chrono::steady_clock::now();
+  for (const auto &uuid : candidateUuids) {
+    const ISelectionContext::BoundingBox *bbPtr = nullptr;
+    if (!IsUuidValidForTarget(uuid, target, hiddenLayers, m_controller, &bbPtr))
+      continue;
+
+    const bool depthContainsPoint =
+        hasDepthWorldPoint && PointInAabb(depthWorldPoint, *bbPtr);
+    if (hasDepthWorldPoint && !depthContainsPoint)
+      continue;
+
+    double hitDistance = DBL_MAX;
+    if (!IntersectRayWithAabb(mouseRay, *bbPtr, hitDistance))
+      continue;
+
+    const double candidateScore = hasDepthWorldPoint
+                                      ? DistanceSquaredToAabbCenter(depthWorldPoint,
+                                                                    *bbPtr)
+                                      : hitDistance;
+    if (candidateScore < bestHitDistance) {
+      bestHitDistance = candidateScore;
+      bestUuid = uuid;
+      found = true;
+    }
+  }
+  metrics.candidateLoop = std::chrono::duration_cast<std::chrono::microseconds>(
+      std::chrono::steady_clock::now() - candidateLoopStart);
+  metrics.usedFallbackPath = true;
+  metrics.total = std::chrono::duration_cast<std::chrono::microseconds>(
+      std::chrono::steady_clock::now() - queryStart);
+  LogQueryMetrics("hover_uuid(fallback)", metrics, m_queryTelemetry,
+                  ++m_queryCounter);
+
+  if (found) {
+    outUuid = bestUuid;
+    return true;
+  }
+  outUuid.clear();
+  return false;
 }
 
 bool SelectionSystem::GetFixtureLabelAt(int mouseX, int mouseY, int width,

--- a/viewer3d/picking/selectionsystem.h
+++ b/viewer3d/picking/selectionsystem.h
@@ -11,6 +11,8 @@
 
 class SelectionSystem {
 public:
+  enum class HoverPickTarget { Fixture, Truss, SceneObject };
+
   explicit SelectionSystem(ISelectionContext &controller) : m_controller(controller) {}
 
   void SetHighlightUuid(const std::string &uuid);
@@ -27,6 +29,9 @@ public:
                              wxString &outLabel, wxPoint &outPos,
                              std::string *outUuid = nullptr,
                              bool confirmDepth = false);
+  bool GetHoverUuidAt(int mouseX, int mouseY, int width, int height,
+                      HoverPickTarget target, std::string &outUuid,
+                      bool confirmDepth = false);
   std::vector<std::string> GetFixturesInScreenRect(int x1, int y1, int x2,
                                                    int y2, int width,
                                                    int height) const;

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1825,6 +1825,28 @@ bool Viewer3DController::GetSceneObjectLabelAt(int mouseX, int mouseY,
                                                          outUuid, confirmDepth);
 }
 
+bool Viewer3DController::GetHoverUuidAt(int mouseX, int mouseY, int width,
+                                        int height, HoverPickTarget target,
+                                        std::string &outUuid,
+                                        bool confirmDepth) {
+  SelectionSystem::HoverPickTarget selectionTarget =
+      SelectionSystem::HoverPickTarget::Fixture;
+  switch (target) {
+  case HoverPickTarget::Fixture:
+    selectionTarget = SelectionSystem::HoverPickTarget::Fixture;
+    break;
+  case HoverPickTarget::Truss:
+    selectionTarget = SelectionSystem::HoverPickTarget::Truss;
+    break;
+  case HoverPickTarget::SceneObject:
+    selectionTarget = SelectionSystem::HoverPickTarget::SceneObject;
+    break;
+  }
+  return m_impl->selectionSystem->GetHoverUuidAt(mouseX, mouseY, width, height,
+                                                  selectionTarget, outUuid,
+                                                  confirmDepth);
+}
+
 bool Viewer3DController::GetPickUuidAt(
     int mouseX, int mouseY, int width, int height,
     const std::unordered_set<std::string> &hiddenLayers, std::string &outUuid) {

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -73,6 +73,7 @@ public:
   using VisibleSet = Viewer3DVisibleSet;
   using ViewFrustumSnapshot = Viewer3DViewFrustumSnapshot;
   using BoundingBox = Viewer3DBoundingBox;
+  enum class HoverPickTarget { Fixture, Truss, SceneObject };
 
   Viewer3DController();
   ~Viewer3DController();
@@ -126,6 +127,9 @@ public:
                              wxString &outLabel, wxPoint &outPos,
                              std::string *outUuid = nullptr,
                              bool confirmDepth = false);
+  bool GetHoverUuidAt(int mouseX, int mouseY, int width, int height,
+                      HoverPickTarget target, std::string &outUuid,
+                      bool confirmDepth = false);
   bool GetPickUuidAt(int mouseX, int mouseY, int width, int height,
                      const std::unordered_set<std::string> &hiddenLayers,
                      std::string &outUuid);

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -384,6 +384,45 @@ void ApplyFixtureSelectionToUi(const std::vector<std::string>& selection,
     }
 }
 
+Viewer3DPanel::HoverTargetTable ResolveActiveHoverTargetTable()
+{
+    if (FixtureTablePanel::Instance() && FixtureTablePanel::Instance()->IsActivePage())
+        return Viewer3DPanel::HoverTargetTable::Fixtures;
+    if (TrussTablePanel::Instance() && TrussTablePanel::Instance()->IsActivePage())
+        return Viewer3DPanel::HoverTargetTable::Trusses;
+    if (SceneObjectTablePanel::Instance() && SceneObjectTablePanel::Instance()->IsActivePage())
+        return Viewer3DPanel::HoverTargetTable::SceneObjects;
+    return Viewer3DPanel::HoverTargetTable::None;
+}
+
+Viewer3DController::HoverPickTarget ToHoverPickTarget(Viewer3DPanel::HoverTargetTable target)
+{
+    switch (target) {
+    case Viewer3DPanel::HoverTargetTable::Fixtures:
+        return Viewer3DController::HoverPickTarget::Fixture;
+    case Viewer3DPanel::HoverTargetTable::Trusses:
+        return Viewer3DController::HoverPickTarget::Truss;
+    case Viewer3DPanel::HoverTargetTable::SceneObjects:
+        return Viewer3DController::HoverPickTarget::SceneObject;
+    case Viewer3DPanel::HoverTargetTable::None:
+    default:
+        return Viewer3DController::HoverPickTarget::Fixture;
+    }
+}
+
+bool QueryHoverUuid(Viewer3DController& controller,
+                    Viewer3DPanel::HoverTargetTable target,
+                    int mouseX, int mouseY, int width, int height,
+                    std::string& outUuid,
+                    bool confirmDepth = false)
+{
+    if (target == Viewer3DPanel::HoverTargetTable::None)
+        return false;
+    return controller.GetHoverUuidAt(mouseX, mouseY, width, height,
+                                     ToHoverPickTarget(target), outUuid,
+                                     confirmDepth);
+}
+
 struct GlCanvasSelection {
     const int* attribs = nullptr;
 };
@@ -585,13 +624,7 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
         m_lastHiddenLayersFingerprint = hiddenLayersFingerprint;
     }
 
-    HoverTargetTable activeTable = HoverTargetTable::None;
-    if (FixtureTablePanel::Instance() && FixtureTablePanel::Instance()->IsActivePage())
-        activeTable = HoverTargetTable::Fixtures;
-    else if (TrussTablePanel::Instance() && TrussTablePanel::Instance()->IsActivePage())
-        activeTable = HoverTargetTable::Trusses;
-    else if (SceneObjectTablePanel::Instance() && SceneObjectTablePanel::Instance()->IsActivePage())
-        activeTable = HoverTargetTable::SceneObjects;
+    const HoverTargetTable activeTable = ResolveActiveHoverTargetTable();
 
     if (activeTable != m_lastHoverTargetTable) {
         m_forceHoverQuery = true;
@@ -621,37 +654,41 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
         activeTable != HoverTargetTable::None &&
         (m_forceHoverQuery || hoverStateChanged);
 
-    if (shouldRunHoverQuery && activeTable == HoverTargetTable::Fixtures) {
-        found = m_controller.GetFixtureLabelAt(pickPos.x, pickPos.y,
-            w, h, newLabel, newPos, &newUuid);
+    if (shouldRunHoverQuery) {
+        found = QueryHoverUuid(m_controller, activeTable, pickPos.x, pickPos.y,
+                               w, h, newUuid);
         hoverQueryRan = true;
         if (found) {
-            if (TrussTablePanel::Instance())
-                TrussTablePanel::Instance()->HighlightTruss(std::string());
-            if (SceneObjectTablePanel::Instance())
-                SceneObjectTablePanel::Instance()->HighlightObject(std::string());
-        }
-    }
-    else if (shouldRunHoverQuery && activeTable == HoverTargetTable::Trusses) {
-        found = m_controller.GetTrussLabelAt(pickPos.x, pickPos.y,
-            w, h, newLabel, newPos, &newUuid);
-        hoverQueryRan = true;
-        if (found) {
-            if (FixtureTablePanel::Instance())
+            if (activeTable != HoverTargetTable::Fixtures &&
+                FixtureTablePanel::Instance()) {
                 FixtureTablePanel::Instance()->HighlightFixture(std::string());
-            if (SceneObjectTablePanel::Instance())
-                SceneObjectTablePanel::Instance()->HighlightObject(std::string());
-        }
-    }
-    else if (shouldRunHoverQuery && activeTable == HoverTargetTable::SceneObjects) {
-        found = m_controller.GetSceneObjectLabelAt(pickPos.x, pickPos.y,
-            w, h, newLabel, newPos, &newUuid);
-        hoverQueryRan = true;
-        if (found) {
-            if (FixtureTablePanel::Instance())
-                FixtureTablePanel::Instance()->HighlightFixture(std::string());
-            if (TrussTablePanel::Instance())
+            }
+            if (activeTable != HoverTargetTable::Trusses &&
+                TrussTablePanel::Instance()) {
                 TrussTablePanel::Instance()->HighlightTruss(std::string());
+            }
+            if (activeTable != HoverTargetTable::SceneObjects &&
+                SceneObjectTablePanel::Instance()) {
+                SceneObjectTablePanel::Instance()->HighlightObject(std::string());
+            }
+            if (!skipLabelWork) {
+                wxString tooltipLabel;
+                wxPoint tooltipPos;
+                if (activeTable == HoverTargetTable::Fixtures) {
+                    m_controller.GetFixtureLabelAt(pickPos.x, pickPos.y,
+                        w, h, tooltipLabel, tooltipPos, nullptr);
+                } else if (activeTable == HoverTargetTable::Trusses) {
+                    m_controller.GetTrussLabelAt(pickPos.x, pickPos.y,
+                        w, h, tooltipLabel, tooltipPos, nullptr);
+                } else if (activeTable == HoverTargetTable::SceneObjects) {
+                    m_controller.GetSceneObjectLabelAt(pickPos.x, pickPos.y,
+                        w, h, tooltipLabel, tooltipPos, nullptr);
+                }
+                newLabel = tooltipLabel;
+                newPos = tooltipPos;
+            } else {
+                newLabel.clear();
+            }
         }
     }
 
@@ -971,24 +1008,19 @@ void Viewer3DPanel::OnMouseUp(wxMouseEvent& event)
         if (!renderSize.IsValid())
             return;
         SetCurrent(*m_glContext);
-        wxString label;
-        wxPoint pos;
         std::string uuid;
         const wxPoint pickPos = ToFramebufferPoint(this, event.GetPosition());
-        bool found = false;
-        if (FixtureTablePanel::Instance() && FixtureTablePanel::Instance()->IsActivePage())
-            found = m_controller.GetFixtureLabelAt(pickPos.x, pickPos.y, w, h, label, pos, &uuid);
-        else if (TrussTablePanel::Instance() && TrussTablePanel::Instance()->IsActivePage())
-            found = m_controller.GetTrussLabelAt(pickPos.x, pickPos.y, w, h, label, pos, &uuid);
-        else if (SceneObjectTablePanel::Instance() && SceneObjectTablePanel::Instance()->IsActivePage())
-            found = m_controller.GetSceneObjectLabelAt(pickPos.x, pickPos.y, w, h, label, pos, &uuid);
+        const HoverTargetTable activeTable = ResolveActiveHoverTargetTable();
+        const bool found = QueryHoverUuid(m_controller, activeTable, pickPos.x,
+                                          pickPos.y, w, h, uuid, true);
 
         ConfigManager& cfg = ConfigManager::Get();
         if (found)
         {
             bool additive = event.ShiftDown() || event.ControlDown();
             std::vector<std::string> selection;
-            if (FixtureTablePanel::Instance() && FixtureTablePanel::Instance()->IsActivePage())
+            if (activeTable == HoverTargetTable::Fixtures &&
+                FixtureTablePanel::Instance())
             {
                 if (additive)
                     selection = FixtureTablePanel::Instance()->GetSelectedUuids();
@@ -1009,7 +1041,8 @@ void Viewer3DPanel::OnMouseUp(wxMouseEvent& event)
                 SetSelectedFixtures(selection);
                 FixtureTablePanel::Instance()->SelectByUuid(selection, false);
             }
-            else if (TrussTablePanel::Instance() && TrussTablePanel::Instance()->IsActivePage())
+            else if (activeTable == HoverTargetTable::Trusses &&
+                     TrussTablePanel::Instance())
             {
                 if (additive)
                     selection = TrussTablePanel::Instance()->GetSelectedUuids();
@@ -1030,7 +1063,8 @@ void Viewer3DPanel::OnMouseUp(wxMouseEvent& event)
                 SetSelectedFixtures(selection);
                 TrussTablePanel::Instance()->SelectByUuid(selection, false);
             }
-            else if (SceneObjectTablePanel::Instance() && SceneObjectTablePanel::Instance()->IsActivePage())
+            else if (activeTable == HoverTargetTable::SceneObjects &&
+                     SceneObjectTablePanel::Instance())
             {
                 if (additive)
                     selection = SceneObjectTablePanel::Instance()->GetSelectedUuids();
@@ -1109,12 +1143,10 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent& event)
     bool showSelectionSubmenus = false;
     if (fixturePageActive && !scene.fixtures.empty()) {
         SetCurrent(*m_glContext);
-        wxString label;
-        wxPoint pos;
         std::string hitUuid;
         const wxPoint pickPos = ToFramebufferPoint(this, event.GetPosition());
-        if (!m_controller.GetFixtureLabelAt(pickPos.x, pickPos.y, w, h, label, pos,
-                                            &hitUuid)) {
+        if (!QueryHoverUuid(m_controller, HoverTargetTable::Fixtures, pickPos.x,
+                            pickPos.y, w, h, hitUuid)) {
             for (const auto& [uuid, fixture] : scene.fixtures) {
                 if (!fixture.typeName.empty())
                     typeNames.insert(fixture.typeName);
@@ -1543,8 +1575,6 @@ void Viewer3DPanel::OnMouseDClick(wxMouseEvent& event)
     if (!renderSize.IsValid())
         return;
     SetCurrent(*m_glContext);
-    wxString label;
-    wxPoint pos;
     std::string uuid;
     const wxPoint pickPos = ToFramebufferPoint(this, event.GetPosition());
     const bool cameraWasMoving = m_cameraMoving;
@@ -1556,13 +1586,13 @@ void Viewer3DPanel::OnMouseDClick(wxMouseEvent& event)
         SceneObjectTablePanel::Instance()->IsActivePage();
 
     const bool foundSceneObject = sceneObjectsActive &&
-        m_controller.GetSceneObjectLabelAt(pickPos.x, pickPos.y, w, h,
-                                           label, pos, &uuid);
+        QueryHoverUuid(m_controller, HoverTargetTable::SceneObjects,
+                       pickPos.x, pickPos.y, w, h, uuid);
 
     bool found = foundSceneObject;
     if (!found)
-        found = m_controller.GetFixtureLabelAt(pickPos.x, pickPos.y, w, h,
-                                               label, pos, &uuid);
+        found = QueryHoverUuid(m_controller, HoverTargetTable::Fixtures,
+                               pickPos.x, pickPos.y, w, h, uuid);
 
     if (cameraWasMoving)
         m_controller.SetCameraMoving(true);

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -73,6 +73,8 @@ public:
     bool ResetCameraToIsometric();
     void SetModalDialogActive(bool active);
 
+    enum class HoverTargetTable { None, Fixtures, Trusses, SceneObjects };
+
 private:
     wxGLContext* m_glContext;
     Viewer3DCamera m_camera;
@@ -132,7 +134,6 @@ private:
     wxString m_hoverText;
     std::string m_hoverUuid;
 
-    enum class HoverTargetTable { None, Fixtures, Trusses, SceneObjects };
     struct HoverQueryState {
         wxPoint mouseFramebufferPos;
         uint64_t cameraRevision = 0;


### PR DESCRIPTION
### Motivation
- Reduce work done for hover/highlight/click by resolving a UUID-only path that avoids constructing `wxString` labels, projecting centers and formatting metadata when the caller only needs the UUID. 
- Share per-target validation (type, layer visibility, bounds existence) so fixture/truss/object checks are not duplicated across hover/click code paths. 
- Make it easy to compare costs of ID-buffer vs fallback ray/AABB queries by reusing the existing `QueryMetrics` telemetry.

### Description
- Added `GetHoverUuidAt(...)` API to `SelectionSystem` and exposed it through `Viewer3DController::GetHoverUuidAt(...)` to perform UUID-only picking that first attempts `ReadPickUuidAt(...)` and falls back to ray/AABB candidate selection when needed. 
- Implemented shared helpers in `selectionsystem.cpp`: `IsUuidValidForTarget(...)` to validate target-specific type/layer/bounds and `VisibleUuidsForTarget(...)` to pick the right visible UUID list per target. 
- Refactored `Viewer3DPanel` to resolve active target with `ResolveActiveHoverTargetTable()` and to use `QueryHoverUuid(...)` (which calls `GetHoverUuidAt(...)`) for highlight/hover, click selection, context hit-tests and double-click; left `Get*LabelAt(...)` calls only for tooltip/overlay text construction when `skipLabelWork` is false. 
- Instrumented the new UUID-only queries using the existing `QueryMetrics` logging with labels `hover_uuid(id)` and `hover_uuid(fallback)` to allow cost comparison in logs.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed. 
- Attempted a full build with `cmake -S . -B build && cmake --build build -j2` which failed in this environment due to missing `wxWidgets` development packages (environmental dependency), not due to the patch itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eacf8f154c8324bee35ba0291dabe1)