### PR TITLE
viewer3d: defer resource sync to invalidation-driven trigger

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -86,6 +86,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+#include <atomic>
 
 namespace fs = std::filesystem;
 
@@ -108,6 +109,7 @@ struct Viewer3DController::Impl {
   std::vector<const std::pair<const std::string, Truss> *> visibleSortedTrusses;
   std::vector<const std::pair<const std::string, SceneObject> *> visibleSortedObjects;
   std::unordered_set<std::string> lastHiddenLayers;
+  std::unordered_set<std::string> lastHiddenFixtureTypes;
   size_t hiddenLayersVersion = 0;
   bool sortedListsDirty = true;
   bool sortedListsLastWas2D = false;
@@ -141,6 +143,7 @@ struct Viewer3DController::Impl {
   bool useAdaptiveLineProfile = true;
   bool skipOutlinesForCurrentFrame = false;
   int updateResourcesCallsPerFrame = 0;
+  std::atomic<bool> resourceSyncPending{true};
   mutable VisibleSet cachedVisibleSet;
   mutable VisibleSet cachedLayerVisibleCandidates;
   mutable size_t layerVisibleCandidatesSceneVersion = static_cast<size_t>(-1);
@@ -797,10 +800,29 @@ void Viewer3DController::Update() {
 void Viewer3DController::UpdateFrameStateLightweight() {
   ConfigManager &cfg = ConfigManager::Get();
   const auto hiddenLayers = SnapshotHiddenLayers(cfg);
+  const auto hiddenFixtureTypes = cfg.GetHiddenFixtureTypes();
   if (hiddenLayers != m_impl->lastHiddenLayers) {
     Logger::Instance().Log("visibility dirty reason: hidden layers changed vs last frame snapshot");
     m_impl->visibilityChangedDirty = true;
+    MarkResourceSyncPending();
   }
+  if (hiddenFixtureTypes != m_impl->lastHiddenFixtureTypes) {
+    Logger::Instance().Log("visibility dirty reason: hidden fixture types changed vs last frame snapshot");
+    m_impl->visibilityChangedDirty = true;
+    MarkResourceSyncPending();
+  }
+}
+
+void Viewer3DController::MarkResourceSyncPending() {
+  m_impl->resourceSyncPending.store(true, std::memory_order_relaxed);
+}
+
+bool Viewer3DController::IsResourceSyncPending() const {
+  return m_impl->resourceSyncPending.load(std::memory_order_relaxed);
+}
+
+bool Viewer3DController::ConsumeResourceSyncPending() {
+  return m_impl->resourceSyncPending.exchange(false, std::memory_order_relaxed);
 }
 
 void Viewer3DController::ResetDebugPerFrameCounters() {
@@ -891,6 +913,7 @@ void Viewer3DController::UpdateResourcesIfDirty() {
   BoundsCacheSystem::RebuildIfDirty(boundsContext, hiddenLayers, trusses,
                                     objects, fixtures);
   m_impl->lastHiddenLayers = hiddenLayers;
+  m_impl->lastHiddenFixtureTypes = cfg.GetHiddenFixtureTypes();
 }
 
 
@@ -1216,10 +1239,7 @@ void Viewer3DController::FinalizeRenderFrame() {
 void Viewer3DController::SetDarkMode(bool enabled) { m_impl->darkMode = enabled; }
 
 void Viewer3DController::SetInteracting(bool interacting) {
-  const bool wasInteracting = m_impl->isInteracting;
   m_impl->isInteracting = interacting;
-  if (wasInteracting && !m_impl->isInteracting)
-    UpdateResourcesIfDirty();
 }
 
 void Viewer3DController::SetCameraMoving(bool moving) { m_impl->cameraMoving = moving; }
@@ -1269,6 +1289,7 @@ void Viewer3DController::SetSymbolCaptureIncludeCoplanarEdgesOverride(
         ReleaseMeshBuffers(node.mesh);
     }
   }
+  MarkResourceSyncPending();
 }
 
 std::optional<bool>

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -82,6 +82,9 @@ public:
   void Update();
   void UpdateResourcesIfDirty();
   void UpdateFrameStateLightweight();
+  void MarkResourceSyncPending();
+  bool IsResourceSyncPending() const;
+  bool ConsumeResourceSyncPending();
   void ResetDebugPerFrameCounters();
   int GetDebugUpdateResourcesCallsPerFrame() const;
 

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -88,6 +88,7 @@ wxEND_EVENT_TABLE()
 namespace {
 constexpr auto kPauseDelay = std::chrono::milliseconds(200);
 constexpr auto kHoverQueryInterval = std::chrono::milliseconds(40);
+constexpr auto kResourceSyncInterval = std::chrono::milliseconds(250);
 constexpr int kExportImageWidth = 1920;
 constexpr int kExportImageHeight = 1080;
 constexpr double kDefaultFovYDegrees = 45.0;
@@ -503,6 +504,7 @@ Viewer3DPanel::Viewer3DPanel(wxWindow* parent)
     SetBackgroundStyle(wxBG_STYLE_CUSTOM);
     Bind(wxEVT_THREAD, &Viewer3DPanel::OnThreadRefresh, this, wxEVT_VIEWER_REFRESH);
     m_threadRunning = true;
+    m_lastResourceSyncCheck = std::chrono::steady_clock::now();
     m_refreshThread = std::thread(&Viewer3DPanel::RefreshLoop, this);
 }
 
@@ -569,7 +571,7 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
     const bool pauseHeavyTasks = ShouldPauseHeavyTasks();
     const bool highlightOnlyRefresh =
         m_highlightRefreshPending &&
-        !m_sceneSyncPending &&
+        !m_controller.IsResourceSyncPending() &&
         !m_selectionRefreshPending &&
         !m_cameraMoving &&
         !m_isInteracting &&
@@ -578,12 +580,6 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
 
     m_controller.ResetDebugPerFrameCounters();
     m_controller.UpdateFrameStateLightweight();
-    if (m_sceneSyncPending) {
-        m_controller.UpdateResourcesIfDirty();
-        m_sceneSyncPending = false;
-    } else if (!highlightOnlyRefresh && !pauseHeavyTasks && !m_cameraMoving) {
-        m_controller.UpdateResourcesIfDirty();
-    }
 
     const int updateResourcesCallsPerFrame =
         m_controller.GetDebugUpdateResourcesCallsPerFrame();
@@ -1816,13 +1812,14 @@ void Viewer3DPanel::OnMouseLeave(wxMouseEvent& event)
 void Viewer3DPanel::UpdateScene()
 {
     ++m_sceneRevision;
-    m_sceneSyncPending = true;
+    m_controller.MarkResourceSyncPending();
 
     if (ShouldPauseHeavyTasks() || m_cameraMoving)
         return;
 
-    m_controller.UpdateResourcesIfDirty();
-    m_sceneSyncPending = false;
+    SetCurrent(*m_glContext);
+    if (m_controller.ConsumeResourceSyncPending())
+        m_controller.UpdateResourcesIfDirty();
     if (Viewer2DPanel::Instance())
         Viewer2DPanel::Instance()->UpdateScene();
 }
@@ -1894,7 +1891,7 @@ void Viewer3DPanel::OnThreadRefresh(wxThreadEvent& event)
 
     const bool hasRelevantVisualChange =
         cameraChanged ||
-        m_sceneSyncPending ||
+        m_controller.IsResourceSyncPending() ||
         m_selectionRefreshPending ||
         m_highlightRefreshPending ||
         m_mouseMoved ||
@@ -1905,6 +1902,18 @@ void Viewer3DPanel::OnThreadRefresh(wxThreadEvent& event)
         m_cameraMoving;
     if (!hasRelevantVisualChange)
         return;
+
+    if (m_controller.IsResourceSyncPending() && !m_cameraMoving && !m_isInteracting) {
+        const auto now = std::chrono::steady_clock::now();
+        const bool syncCadenceDue =
+            (now - m_lastResourceSyncCheck) >= kResourceSyncInterval;
+        if (syncCadenceDue) {
+            SetCurrent(*m_glContext);
+            m_lastResourceSyncCheck = now;
+            if (m_controller.ConsumeResourceSyncPending())
+                m_controller.UpdateResourcesIfDirty();
+        }
+    }
 
     Refresh();
 }
@@ -1932,8 +1941,7 @@ bool Viewer3DPanel::ShouldPauseHeavyTasks()
     const bool fastInteractionMode = IsFastInteractionModeEnabled();
 
     if (fastInteractionMode) {
-        m_controller.UpdateResourcesIfDirty();
-        m_sceneSyncPending = false;
+        m_controller.MarkResourceSyncPending();
         m_mouseMoved = true;
     }
 

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -95,9 +95,7 @@ private:
     std::chrono::steady_clock::time_point m_lastInteractionTime{};
     bool m_isInteracting = false;
     bool m_cameraMoving = false;
-    // True when scene/resource synchronization must run as soon as possible,
-    // even if the panel is currently in interaction throttling mode.
-    bool m_sceneSyncPending = false;
+    std::chrono::steady_clock::time_point m_lastResourceSyncCheck{};
     std::vector<std::string> m_lastAppliedSelectionUuids;
 
     // Initializes OpenGL settings


### PR DESCRIPTION
### Motivation
- Reduce heavy `UpdateResourcesIfDirty()` work inside the paint/render hot path by making resource synchronization event-driven and decoupled from per-frame rendering. 
- Keep `OnPaint` focused on rendering already-synchronized state and make resource sync occur on a low-frequency invalidation cadence or on explicit user actions. 
- Provide a lightweight, thread-safe flag to mark when a resource sync is required instead of doing synchronous work during frequent interactions.

### Description
- Added a lightweight atomic pending flag and API on `Viewer3DController`: `MarkResourceSyncPending()`, `IsResourceSyncPending()` and `ConsumeResourceSyncPending()` and a `std::atomic<bool> resourceSyncPending` backing field (`viewer3d/viewer3dcontroller.h`, `viewer3d/viewer3dcontroller.cpp`).
- `UpdateFrameStateLightweight()` now detects visibility-impacting changes (hidden layers and hidden fixture types) and calls `MarkResourceSyncPending()` instead of forcing immediate sync (`viewer3d/viewer3dcontroller.cpp`).
- Removed the implicit immediate sync path from render/interaction end by stopping `SetInteracting(false)` from calling `UpdateResourcesIfDirty()` and replaced fast-interaction immediate sync with marking the pending flag (`viewer3d/viewer3dcontroller.cpp`, `viewer3d/viewer3dpanel.cpp`).
- Introduced a low-frequency invalidation trigger (250ms cadence) in the panel refresh thread (`kResourceSyncInterval`) that consumes the pending flag and runs `UpdateResourcesIfDirty()` with a current GL context when safe (`viewer3d/viewer3dpanel.cpp`).
- Kept immediate sync for explicit user actions by having `Viewer3DPanel::UpdateScene()` mark pending and, when appropriate, `ConsumeResourceSyncPending()` + `UpdateResourcesIfDirty()` while the panel has the GL context (`viewer3d/viewer3dpanel.cpp`).
- Minor panel state change: `m_sceneSyncPending` removed in favor of controller-managed pending flag and `m_lastResourceSyncCheck` added to enforce sync cadence (`viewer3d/viewer3dpanel.h`, `viewer3d/viewer3dpanel.cpp`).

Technical note: `viewer3dcontroller.cpp` is a hotspot file; if further responsibilities are added, consider extracting a small `resources/` or `sync/` helper module in a follow-up change per repository modularity guidance.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead87bbd088324a0c27f4b553d5dfd)