### PR TITLE
Split Viewer3D base render from highlight/selection overlay to avoid full redraw on hover

### DIFF
--- a/viewer3d/CMakeLists.txt
+++ b/viewer3d/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/render/perastage_svg_symbol_builder.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/opaque_truss_pass.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/render_pipeline.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/render/selection_overlay_pass.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/viewer3d_render_style.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/scenerenderer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/resources/resource_sync_system.cpp

--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -434,7 +434,7 @@ void OpaqueFixturePass::Render(
       glDisable(GL_DEPTH_TEST);
   }
   std::vector<std::string> drawFixtureUuids = visibleSet.fixtureUuids;
-  if (!controller.m_highlightUuid.empty()) {
+  if (!context.suppressSelectionEmphasis && !controller.m_highlightUuid.empty()) {
     const bool highlightAlreadyVisible =
         std::find(drawFixtureUuids.begin(), drawFixtureUuids.end(),
                   controller.m_highlightUuid) != drawFixtureUuids.end();
@@ -459,9 +459,11 @@ void OpaqueFixturePass::Render(
       controller.m_captureCanvas->SetSourceKey(fixtureCaptureKey);
     }
 
-    bool highlight = (!controller.m_highlightUuid.empty() &&
+    bool highlight = !context.suppressSelectionEmphasis &&
+                     (!controller.m_highlightUuid.empty() &&
                       uuid == controller.m_highlightUuid);
-    bool selected = (controller.m_selectedUuids.find(uuid) !=
+    bool selected = !context.suppressSelectionEmphasis &&
+                    (controller.m_selectedUuids.find(uuid) !=
                      controller.m_selectedUuids.end());
 
     float matrix[16];

--- a/viewer3d/render/opaque_object_pass.cpp
+++ b/viewer3d/render/opaque_object_pass.cpp
@@ -221,7 +221,7 @@ void OpaqueObjectPass::Render(
 
   glShadeModel((context.texturedStyle && !wireframe) ? GL_SMOOTH : GL_FLAT);
   std::vector<std::string> drawObjectUuids = visibleSet.objectUuids;
-  if (!controller.m_highlightUuid.empty()) {
+  if (!context.suppressSelectionEmphasis && !controller.m_highlightUuid.empty()) {
     const bool highlightAlreadyVisible =
         std::find(drawObjectUuids.begin(), drawObjectUuids.end(),
                   controller.m_highlightUuid) != drawObjectUuids.end();
@@ -246,9 +246,11 @@ void OpaqueObjectPass::Render(
       controller.m_captureCanvas->SetSourceKey(objectCaptureKey);
     }
 
-    bool highlight = (!controller.m_highlightUuid.empty() &&
+    bool highlight = !context.suppressSelectionEmphasis &&
+                     (!controller.m_highlightUuid.empty() &&
                       uuid == controller.m_highlightUuid);
-    bool selected = (controller.m_selectedUuids.find(uuid) !=
+    bool selected = !context.suppressSelectionEmphasis &&
+                    (controller.m_selectedUuids.find(uuid) !=
                      controller.m_selectedUuids.end());
 
     float matrix[16];

--- a/viewer3d/render/opaque_truss_pass.cpp
+++ b/viewer3d/render/opaque_truss_pass.cpp
@@ -82,7 +82,7 @@ void OpaqueTrussPass::Render(
 
   glShadeModel(GL_SMOOTH);
   std::vector<std::string> drawTrussUuids = visibleSet.trussUuids;
-  if (!controller.m_highlightUuid.empty()) {
+  if (!context.suppressSelectionEmphasis && !controller.m_highlightUuid.empty()) {
     const bool highlightAlreadyVisible =
         std::find(drawTrussUuids.begin(), drawTrussUuids.end(),
                   controller.m_highlightUuid) != drawTrussUuids.end();
@@ -107,9 +107,11 @@ void OpaqueTrussPass::Render(
       controller.m_captureCanvas->SetSourceKey(trussCaptureKey);
     }
 
-    bool highlight = (!controller.m_highlightUuid.empty() &&
+    bool highlight = !context.suppressSelectionEmphasis &&
+                     (!controller.m_highlightUuid.empty() &&
                       uuid == controller.m_highlightUuid);
-    bool selected = (controller.m_selectedUuids.find(uuid) !=
+    bool selected = !context.suppressSelectionEmphasis &&
+                    (controller.m_selectedUuids.find(uuid) !=
                      controller.m_selectedUuids.end());
 
     float matrix[16];

--- a/viewer3d/render/selection_overlay_pass.cpp
+++ b/viewer3d/render/selection_overlay_pass.cpp
@@ -1,7 +1,5 @@
 #include "selection_overlay_pass.h"
 
-#include "configmanager.h"
-#include "opaque_pass_utils.h"
 #include "opaque_fixture_pass.h"
 #include "opaque_object_pass.h"
 #include "opaque_truss_pass.h"
@@ -21,11 +19,12 @@ namespace {
 Viewer3DVisibleSet BuildOverlayVisibleSet(const Viewer3DController &controller,
                                           const Viewer3DVisibleSet &visibleSet) {
   Viewer3DVisibleSet overlayVisibleSet;
-  const std::string &highlightUuid = controller.GetHighlightUuid();
+  const std::string &highlightUuid = controller.GetOverlayHighlightUuid();
+  const auto &selectedUuids = controller.GetOverlaySelectedUuids();
 
   auto appendIfTarget = [&](const std::string &uuid,
                             std::vector<std::string> &output) {
-    if (controller.IsUuidSelected(uuid) ||
+    if (selectedUuids.find(uuid) != selectedUuids.end() ||
         (!highlightUuid.empty() && uuid == highlightUuid)) {
       output.push_back(uuid);
     }
@@ -51,9 +50,7 @@ void SelectionOverlayPass::Render(Viewer3DController &controller,
     return;
 
   if (context.useLighting)
-    controller.SetupBasicLighting(context.useAmbientOcclusion,
-                                  context.ambientOcclusionStrength,
-                                  context.whiteModelStyle);
+    glEnable(GL_LIGHTING);
   else
     glDisable(GL_LIGHTING);
 
@@ -61,26 +58,11 @@ void SelectionOverlayPass::Render(Viewer3DController &controller,
   glGetBooleanv(GL_DEPTH_WRITEMASK, &depthMaskEnabled);
   glDepthMask(GL_FALSE);
 
-  auto getTypeColor = [&](const std::string &key, const std::string &hex) {
-    std::array<float, 3> c;
-    if (!hex.empty() && HexToRGB(hex, c[0], c[1], c[2])) {
-      controller.m_typeColors[key] = c;
-      return c;
-    }
-    c = MakeDeterministicColor("type:" + key);
-    controller.m_typeColors[key] = c;
-    return c;
+  auto getTypeColor = [](const std::string &, const std::string &) {
+    return std::array<float, 3>{1.0f, 1.0f, 1.0f};
   };
-  auto getLayerColor = [&](const std::string &key) {
-    std::array<float, 3> c;
-    auto opt = ConfigManager::Get().GetLayerColor(key);
-    if (opt && HexToRGB(*opt, c[0], c[1], c[2])) {
-      controller.m_layerColors[key] = c;
-      return c;
-    }
-    c = MakeDeterministicColor("layer:" + key);
-    controller.m_layerColors[key] = c;
-    return c;
+  auto getLayerColor = [](const std::string &) {
+    return std::array<float, 3>{1.0f, 1.0f, 1.0f};
   };
   auto resolveSymbolView = [](Viewer2DView viewKind) {
     switch (viewKind) {

--- a/viewer3d/render/selection_overlay_pass.cpp
+++ b/viewer3d/render/selection_overlay_pass.cpp
@@ -1,0 +1,114 @@
+#include "selection_overlay_pass.h"
+
+#include "configmanager.h"
+#include "opaque_pass_utils.h"
+#include "opaque_fixture_pass.h"
+#include "opaque_object_pass.h"
+#include "opaque_truss_pass.h"
+#include "viewer3dcontroller.h"
+
+#include <GL/glew.h>
+#ifdef __APPLE__
+#define GL_SILENCE_DEPRECATION
+#include <OpenGL/gl.h>
+#else
+#include <GL/gl.h>
+#endif
+
+#include <array>
+
+namespace {
+Viewer3DVisibleSet BuildOverlayVisibleSet(const Viewer3DController &controller,
+                                          const Viewer3DVisibleSet &visibleSet) {
+  Viewer3DVisibleSet overlayVisibleSet;
+  const std::string &highlightUuid = controller.GetHighlightUuid();
+
+  auto appendIfTarget = [&](const std::string &uuid,
+                            std::vector<std::string> &output) {
+    if (controller.IsUuidSelected(uuid) ||
+        (!highlightUuid.empty() && uuid == highlightUuid)) {
+      output.push_back(uuid);
+    }
+  };
+
+  for (const std::string &uuid : visibleSet.fixtureUuids)
+    appendIfTarget(uuid, overlayVisibleSet.fixtureUuids);
+  for (const std::string &uuid : visibleSet.trussUuids)
+    appendIfTarget(uuid, overlayVisibleSet.trussUuids);
+  for (const std::string &uuid : visibleSet.objectUuids)
+    appendIfTarget(uuid, overlayVisibleSet.objectUuids);
+
+  return overlayVisibleSet;
+}
+} // namespace
+
+void SelectionOverlayPass::Render(Viewer3DController &controller,
+                                  const RenderFrameContext &context,
+                                  const Viewer3DVisibleSet &visibleSet) {
+  const Viewer3DVisibleSet overlayVisibleSet =
+      BuildOverlayVisibleSet(controller, visibleSet);
+  if (overlayVisibleSet.Empty())
+    return;
+
+  if (context.useLighting)
+    controller.SetupBasicLighting(context.useAmbientOcclusion,
+                                  context.ambientOcclusionStrength,
+                                  context.whiteModelStyle);
+  else
+    glDisable(GL_LIGHTING);
+
+  GLboolean depthMaskEnabled = GL_TRUE;
+  glGetBooleanv(GL_DEPTH_WRITEMASK, &depthMaskEnabled);
+  glDepthMask(GL_FALSE);
+
+  auto getTypeColor = [&](const std::string &key, const std::string &hex) {
+    std::array<float, 3> c;
+    if (!hex.empty() && HexToRGB(hex, c[0], c[1], c[2])) {
+      controller.m_typeColors[key] = c;
+      return c;
+    }
+    c = MakeDeterministicColor("type:" + key);
+    controller.m_typeColors[key] = c;
+    return c;
+  };
+  auto getLayerColor = [&](const std::string &key) {
+    std::array<float, 3> c;
+    auto opt = ConfigManager::Get().GetLayerColor(key);
+    if (opt && HexToRGB(*opt, c[0], c[1], c[2])) {
+      controller.m_layerColors[key] = c;
+      return c;
+    }
+    c = MakeDeterministicColor("layer:" + key);
+    controller.m_layerColors[key] = c;
+    return c;
+  };
+  auto resolveSymbolView = [](Viewer2DView viewKind) {
+    switch (viewKind) {
+    case Viewer2DView::Top:
+      return SymbolViewKind::Top;
+    case Viewer2DView::Front:
+      return SymbolViewKind::Front;
+    case Viewer2DView::Side:
+      return SymbolViewKind::Left;
+    case Viewer2DView::Bottom:
+    default:
+      return SymbolViewKind::Bottom;
+    }
+  };
+  auto getPickColor = [](const std::string &) {
+    return std::array<float, 3>{1.0f, 1.0f, 1.0f};
+  };
+
+  RenderFrameContext overlayContext = context;
+  overlayContext.skipCapture = true;
+
+  OpaqueObjectPass::Render(controller, overlayContext, overlayVisibleSet,
+                           getLayerColor, resolveSymbolView, getPickColor);
+  OpaqueTrussPass::Render(controller, overlayContext, overlayVisibleSet,
+                          getLayerColor, resolveSymbolView, getPickColor);
+  OpaqueFixturePass::Render(controller, overlayContext, overlayVisibleSet,
+                            getTypeColor, getLayerColor, resolveSymbolView,
+                            getPickColor);
+
+  glDepthMask(depthMaskEnabled == GL_TRUE ? GL_TRUE : GL_FALSE);
+}

--- a/viewer3d/render/selection_overlay_pass.h
+++ b/viewer3d/render/selection_overlay_pass.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "viewer3d_types.h"
+
+class Viewer3DController;
+
+class SelectionOverlayPass {
+public:
+  static void Render(Viewer3DController &controller,
+                     const RenderFrameContext &context,
+                     const Viewer3DVisibleSet &visibleSet);
+};

--- a/viewer3d/viewer3d_types.h
+++ b/viewer3d/viewer3d_types.h
@@ -76,6 +76,7 @@ struct RenderFrameContext {
   bool skipCapture = false;
   bool skipOutlinesForCurrentFrame = false;
   bool idOnlyPass = false;
+  bool suppressSelectionEmphasis = false;
 
   bool colorByFixtureType = false;
   bool colorByLayer = false;

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1193,7 +1193,7 @@ const Viewer3DController::VisibleSet &Viewer3DController::PrepareRenderFrame(
 void Viewer3DController::RenderOpaqueFrame(const RenderFrameContext &context,
                                            const VisibleSet &visibleSet) {
   RenderFrameContext baseContext = context;
-  baseContext.suppressSelectionEmphasis = true;
+  baseContext.suppressSelectionEmphasis = !context.is2DViewer;
 
   const bool wireframe = baseContext.wireframe;
   const Viewer2DRenderMode mode = baseContext.mode;
@@ -1259,7 +1259,8 @@ void Viewer3DController::RenderOpaqueFrame(const RenderFrameContext &context,
 
 void Viewer3DController::RenderOverlayFrame(const RenderFrameContext &context,
                                             const VisibleSet &visibleSet) {
-  SelectionOverlayPass::Render(*this, context, visibleSet);
+  if (!context.is2DViewer)
+    SelectionOverlayPass::Render(*this, context, visibleSet);
   if (context.drawGridAfterScene) {
     glDisable(GL_DEPTH_TEST);
     DrawGrid(context.gridStyle, context.gridR, context.gridG, context.gridB,

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -755,6 +755,15 @@ void Viewer3DController::SetSelectedUuids(
   m_impl->selectionSystem->SetSelectedUuids(uuids);
 }
 
+const std::string &Viewer3DController::GetOverlayHighlightUuid() const {
+  return m_impl->highlightUuid;
+}
+
+const std::unordered_set<std::string> &
+Viewer3DController::GetOverlaySelectedUuids() const {
+  return m_impl->selectedUuids;
+}
+
 void Viewer3DController::ApplyHighlightUuid(const std::string &uuid) {
   m_impl->highlightUuid = uuid;
 }

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -55,7 +55,7 @@
 #include "logger.h"
 #include "projectutils.h"
 #include "scenerenderer.h"
-#include "render_pipeline.h"
+#include "selection_overlay_pass.h"
 #include "opaque_fixture_pass.h"
 #include "hoist_symbol_renderer.h"
 #include "opaque_object_pass.h"
@@ -1052,8 +1052,38 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
   const auto hiddenLayers = SnapshotHiddenLayers(cfg);
   context.hiddenLayers = hiddenLayers;
 
-  RenderPipeline pipeline(*this);
-  pipeline.Execute(context);
+  ViewFrustumSnapshot frustum{};
+  const auto &visibleSet = PrepareRenderFrame(context, frustum);
+  RenderOpaqueFrame(context, visibleSet);
+  RenderOverlayFrame(context, visibleSet);
+  FinalizeRenderFrame();
+}
+
+void Viewer3DController::RenderHighlightOverlayScene(bool wireframe,
+                                                     Viewer2DRenderMode mode,
+                                                     Viewer2DView view) {
+  ConfigManager &cfg = ConfigManager::Get();
+  RenderFrameContext context;
+  context.wireframe = wireframe;
+  context.mode = mode;
+  context.view = view;
+  context.showGrid = false;
+  context.gridOnTop = false;
+  context.showAxes = false;
+  context.is2DViewer = false;
+  context.hiddenLayers = SnapshotHiddenLayers(cfg);
+  context.useFrustumCulling = false;
+  context.minCullingPixels = 0.0f;
+  context.useLighting = !context.wireframe;
+  context.useAmbientOcclusion =
+      cfg.GetFloat("viewer3d_ambient_occlusion") >= 0.5f;
+  context.ambientOcclusionStrength =
+      cfg.GetFloat("viewer3d_ambient_occlusion_strength");
+
+  ViewFrustumSnapshot frustum{};
+  const auto &visibleSet = PrepareRenderFrame(context, frustum);
+  RenderOverlayFrame(context, visibleSet);
+  FinalizeRenderFrame();
 }
 
 const Viewer3DController::VisibleSet &Viewer3DController::PrepareRenderFrame(
@@ -1153,19 +1183,22 @@ const Viewer3DController::VisibleSet &Viewer3DController::PrepareRenderFrame(
 
 void Viewer3DController::RenderOpaqueFrame(const RenderFrameContext &context,
                                            const VisibleSet &visibleSet) {
-  const bool wireframe = context.wireframe;
-  const Viewer2DRenderMode mode = context.mode;
-  const Viewer2DView view = context.view;
+  RenderFrameContext baseContext = context;
+  baseContext.suppressSelectionEmphasis = true;
 
-  if (context.useLighting)
-    SetupBasicLighting(context.useAmbientOcclusion,
-                      context.ambientOcclusionStrength,
-                      context.whiteModelStyle);
+  const bool wireframe = baseContext.wireframe;
+  const Viewer2DRenderMode mode = baseContext.mode;
+  const Viewer2DView view = baseContext.view;
+
+  if (baseContext.useLighting)
+    SetupBasicLighting(baseContext.useAmbientOcclusion,
+                      baseContext.ambientOcclusionStrength,
+                      baseContext.whiteModelStyle);
   else
     glDisable(GL_LIGHTING);
 
-  if (context.drawGridBeforeScene)
-    DrawGrid(context.gridStyle, context.gridR, context.gridG, context.gridB,
+  if (baseContext.drawGridBeforeScene)
+    DrawGrid(baseContext.gridStyle, baseContext.gridR, baseContext.gridG, baseContext.gridB,
              view);
 
   auto getTypeColor = [&](const std::string &key, const std::string &hex) {
@@ -1206,18 +1239,18 @@ void Viewer3DController::RenderOpaqueFrame(const RenderFrameContext &context,
     return std::array<float, 3>{1.0f, 1.0f, 1.0f};
   };
 
-  OpaqueObjectPass::Render(*this, context, visibleSet, getLayerColor,
+  OpaqueObjectPass::Render(*this, baseContext, visibleSet, getLayerColor,
                            resolveSymbolView, getPickColor);
-  OpaqueTrussPass::Render(*this, context, visibleSet, getLayerColor,
+  OpaqueTrussPass::Render(*this, baseContext, visibleSet, getLayerColor,
                           resolveSymbolView, getPickColor);
-  OpaqueFixturePass::Render(*this, context, visibleSet, getTypeColor,
+  OpaqueFixturePass::Render(*this, baseContext, visibleSet, getTypeColor,
                             getLayerColor, resolveSymbolView, getPickColor);
-  HoistSymbolRenderer::Render(*this, context);
+  HoistSymbolRenderer::Render(*this, baseContext);
 }
 
 void Viewer3DController::RenderOverlayFrame(const RenderFrameContext &context,
                                             const VisibleSet &visibleSet) {
-  (void)visibleSet;
+  SelectionOverlayPass::Render(*this, context, visibleSet);
   if (context.drawGridAfterScene) {
     glDisable(GL_DEPTH_TEST);
     DrawGrid(context.gridStyle, context.gridR, context.gridG, context.gridB,

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -112,6 +112,8 @@ public:
 
   void SetHighlightUuid(const std::string &uuid);
   void SetSelectedUuids(const std::vector<std::string> &uuids);
+  const std::string &GetOverlayHighlightUuid() const;
+  const std::unordered_set<std::string> &GetOverlaySelectedUuids() const;
 
   void DrawFixtureLabels(int width, int height);
   void DrawTrussLabels(int width, int height);

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -99,6 +99,10 @@ public:
                    bool gridOnTop = false,
                    bool is2DViewer = false,
                    bool preferPerastageSvgSymbolsForLayouts = false);
+  void RenderHighlightOverlayScene(
+      bool wireframe = false,
+      Viewer2DRenderMode mode = Viewer2DRenderMode::White,
+      Viewer2DView view = Viewer2DView::Top);
 
   void SetDarkMode(bool enabled);
   void SetInteracting(bool interacting);

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -825,11 +825,28 @@ void Viewer3DPanel::Render(const RenderSize& renderSize, bool highlightOnlyRefre
     const auto overlayStart = std::chrono::steady_clock::now();
     if (!highlightOnlyRefresh || !IsBaseCacheValidForCurrentFrame()) {
         const auto baseStart = std::chrono::steady_clock::now();
-        RenderBasePassToCache(renderSize);
+        const bool renderedToCache = RenderBasePassToCache(renderSize);
         const auto baseEnd = std::chrono::steady_clock::now();
         m_basePassTimeAccum +=
             std::chrono::duration_cast<std::chrono::microseconds>(baseEnd - baseStart);
         ++m_basePassSamplesInCurrentWindow;
+        if (!renderedToCache) {
+            glstate::ApplyKnownBaseOnscreenState(width, height);
+            const Viewer3DRenderStyle renderStyle = ResolveRenderStyleFromPreferences();
+            ApplyViewer3DClearColorForStyle(renderStyle);
+            glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+            ApplyCameraMatrices(renderSize);
+            if (renderStyle == Viewer3DRenderStyle::Textured) {
+                DrawTexturedStyleBackgroundGradient(ComputeGridPlaneHorizonNdcY());
+                DrawTexturedGroundPlaneBackdrop();
+            }
+            m_controller.SetCameraMoving(m_cameraMoving);
+            m_controller.RenderScene(IsWireframeRenderStyle(renderStyle),
+                                     ToSceneRenderMode(renderStyle));
+            glFlush();
+            ValidateGlStateAfterRender("Viewer3DPanel::RenderFallback", width, height);
+            return;
+        }
     }
 
     BlitBaseCacheToDefaultFramebuffer(renderSize);
@@ -842,12 +859,12 @@ void Viewer3DPanel::Render(const RenderSize& renderSize, bool highlightOnlyRefre
     ValidateGlStateAfterRender("Viewer3DPanel::Render", width, height);
 }
 
-void Viewer3DPanel::RenderBasePassToCache(const RenderSize& renderSize)
+bool Viewer3DPanel::RenderBasePassToCache(const RenderSize& renderSize)
 {
     const int width = renderSize.width;
     const int height = renderSize.height;
     if (!EnsureBaseCacheFramebuffer(renderSize))
-        return;
+        return false;
 
     glBindFramebuffer(GL_FRAMEBUFFER, m_baseCacheFbo);
     glstate::ApplyKnownBaseOnscreenState(width, height);
@@ -880,6 +897,7 @@ void Viewer3DPanel::RenderBasePassToCache(const RenderSize& renderSize)
     m_baseCacheCameraRevision = m_cameraRevision;
     m_baseCacheHiddenLayersRevision = m_hiddenLayersRevision;
     m_baseCacheSceneRevision = m_sceneRevision;
+    return true;
 }
 
 void Viewer3DPanel::RenderHighlightOverlayPass(const RenderSize& renderSize)

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -516,7 +516,7 @@ Viewer3DPanel::~Viewer3DPanel()
     if (HasCapture())
         ReleaseMouse();
     StopRefreshThread();
-    if (m_glContext) {
+    if (m_glContext && m_glInitialized) {
         SetCurrent(*m_glContext);
         DestroyBaseCacheFramebuffer();
     }
@@ -819,7 +819,6 @@ void Viewer3DPanel::Render(const RenderSize& renderSize, bool highlightOnlyRefre
     }
     SetCurrent(*m_glContext);
 
-    static unsigned long long s_renderFrameId = 0;
     const int width = renderSize.width;
     const int height = renderSize.height;
     const auto overlayStart = std::chrono::steady_clock::now();
@@ -927,18 +926,30 @@ bool Viewer3DPanel::EnsureBaseCacheFramebuffer(const RenderSize& renderSize)
     glGenFramebuffers(1, &m_baseCacheFbo);
     glBindFramebuffer(GL_FRAMEBUFFER, m_baseCacheFbo);
 
-    glGenTextures(1, &m_baseCacheColorTex);
-    glBindTexture(GL_TEXTURE_2D, m_baseCacheColorTex);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA,
-                 GL_UNSIGNED_BYTE, nullptr);
-    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
-                           m_baseCacheColorTex, 0);
+    glGenRenderbuffers(1, &m_baseCacheColorRb);
+    glBindRenderbuffer(GL_RENDERBUFFER, m_baseCacheColorRb);
+    if (m_hasSampleBuffers) {
+        GLint defaultSamples = 0;
+        glGetIntegerv(GL_SAMPLES, &defaultSamples);
+        const GLint samples = std::max(1, defaultSamples);
+        glRenderbufferStorageMultisample(GL_RENDERBUFFER, samples, GL_RGBA8, width, height);
+    } else {
+        glRenderbufferStorage(GL_RENDERBUFFER, GL_RGBA8, width, height);
+    }
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER,
+                              m_baseCacheColorRb);
 
     glGenRenderbuffers(1, &m_baseCacheDepthRb);
     glBindRenderbuffer(GL_RENDERBUFFER, m_baseCacheDepthRb);
-    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, width, height);
+    if (m_hasSampleBuffers) {
+        GLint defaultSamples = 0;
+        glGetIntegerv(GL_SAMPLES, &defaultSamples);
+        const GLint samples = std::max(1, defaultSamples);
+        glRenderbufferStorageMultisample(GL_RENDERBUFFER, samples, GL_DEPTH_COMPONENT24,
+                                         width, height);
+    } else {
+        glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, width, height);
+    }
     glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER,
                               m_baseCacheDepthRb);
 
@@ -991,12 +1002,12 @@ void Viewer3DPanel::DestroyBaseCacheFramebuffer()
 {
     if (m_baseCacheDepthRb != 0)
         glDeleteRenderbuffers(1, &m_baseCacheDepthRb);
-    if (m_baseCacheColorTex != 0)
-        glDeleteTextures(1, &m_baseCacheColorTex);
+    if (m_baseCacheColorRb != 0)
+        glDeleteRenderbuffers(1, &m_baseCacheColorRb);
     if (m_baseCacheFbo != 0)
         glDeleteFramebuffers(1, &m_baseCacheFbo);
     m_baseCacheDepthRb = 0;
-    m_baseCacheColorTex = 0;
+    m_baseCacheColorRb = 0;
     m_baseCacheFbo = 0;
     m_baseCacheWidth = 0;
     m_baseCacheHeight = 0;

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -516,6 +516,10 @@ Viewer3DPanel::~Viewer3DPanel()
     if (HasCapture())
         ReleaseMouse();
     StopRefreshThread();
+    if (m_glContext) {
+        SetCurrent(*m_glContext);
+        DestroyBaseCacheFramebuffer();
+    }
     delete m_glContext;
     m_glContext = nullptr;
     SetInstance(nullptr);
@@ -600,7 +604,7 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
         return;
     }
 
-    Render(renderSize);
+    Render(renderSize, highlightOnlyRefresh);
 
     // Ensure the OpenGL context is current before drawing overlays
     SetCurrent(*m_glContext);
@@ -745,7 +749,7 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
     m_mouseMoved = false;
 
     // Draw labels before swapping buffers to avoid losing them.
-    if (!highlightOnlyRefresh && !pauseHeavyTasks && !skipLabelWork) {
+    if (!pauseHeavyTasks && !skipLabelWork) {
         if (FixtureTablePanel::Instance() && FixtureTablePanel::Instance()->IsActivePage())
             m_controller.DrawFixtureLabels(w, h);
         else if (TrussTablePanel::Instance() && TrussTablePanel::Instance()->IsActivePage())
@@ -767,12 +771,29 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
         m_refreshTelemetryWindowStart = telemetryNow;
     const auto telemetryElapsed = telemetryNow - m_refreshTelemetryWindowStart;
     if (telemetryElapsed >= std::chrono::seconds(1)) {
+        const double baseMs =
+            std::chrono::duration<double, std::milli>(m_basePassTimeAccum).count();
+        const double overlayMs =
+            std::chrono::duration<double, std::milli>(m_overlayPassTimeAccum).count();
+        const double baseAvgMs = m_basePassSamplesInCurrentWindow > 0
+            ? baseMs / static_cast<double>(m_basePassSamplesInCurrentWindow)
+            : 0.0;
+        const double overlayAvgMs = m_overlayPassSamplesInCurrentWindow > 0
+            ? overlayMs / static_cast<double>(m_overlayPassSamplesInCurrentWindow)
+            : 0.0;
         wxLogDebug("Viewer3DPanel refreshes/s full=%d highlight=%d",
                    m_fullRefreshesInCurrentWindow,
                    m_highlightRefreshesInCurrentWindow);
+        wxLogTrace("viewer3d_perf",
+                   "Viewer3DPanel pass timings avg_ms base=%.3f overlay=%.3f",
+                   baseAvgMs, overlayAvgMs);
         m_refreshTelemetryWindowStart = telemetryNow;
         m_fullRefreshesInCurrentWindow = 0;
         m_highlightRefreshesInCurrentWindow = 0;
+        m_basePassTimeAccum = std::chrono::microseconds{0};
+        m_overlayPassTimeAccum = std::chrono::microseconds{0};
+        m_basePassSamplesInCurrentWindow = 0;
+        m_overlayPassSamplesInCurrentWindow = 0;
     }
 
     if (highlightOnlyRefresh)
@@ -786,11 +807,12 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
 // Resize event handler
 void Viewer3DPanel::OnResize(wxSizeEvent& event)
 {
+    InvalidateBaseCache();
     Refresh();
 }
 
 // Renders the full 3D scene
-void Viewer3DPanel::Render(const RenderSize& renderSize)
+void Viewer3DPanel::Render(const RenderSize& renderSize, bool highlightOnlyRefresh)
 {
     if (!IsShownOnScreen()) {
         return;
@@ -800,6 +822,34 @@ void Viewer3DPanel::Render(const RenderSize& renderSize)
     static unsigned long long s_renderFrameId = 0;
     const int width = renderSize.width;
     const int height = renderSize.height;
+    const auto overlayStart = std::chrono::steady_clock::now();
+    if (!highlightOnlyRefresh || !IsBaseCacheValidForCurrentFrame()) {
+        const auto baseStart = std::chrono::steady_clock::now();
+        RenderBasePassToCache(renderSize);
+        const auto baseEnd = std::chrono::steady_clock::now();
+        m_basePassTimeAccum +=
+            std::chrono::duration_cast<std::chrono::microseconds>(baseEnd - baseStart);
+        ++m_basePassSamplesInCurrentWindow;
+    }
+
+    BlitBaseCacheToDefaultFramebuffer(renderSize);
+    RenderHighlightOverlayPass(renderSize);
+
+    const auto overlayEnd = std::chrono::steady_clock::now();
+    m_overlayPassTimeAccum +=
+        std::chrono::duration_cast<std::chrono::microseconds>(overlayEnd - overlayStart);
+    ++m_overlayPassSamplesInCurrentWindow;
+    ValidateGlStateAfterRender("Viewer3DPanel::Render", width, height);
+}
+
+void Viewer3DPanel::RenderBasePassToCache(const RenderSize& renderSize)
+{
+    const int width = renderSize.width;
+    const int height = renderSize.height;
+    if (!EnsureBaseCacheFramebuffer(renderSize))
+        return;
+
+    glBindFramebuffer(GL_FRAMEBUFFER, m_baseCacheFbo);
     glstate::ApplyKnownBaseOnscreenState(width, height);
     const RenderSize viewportSize{width, height, "glstate::ApplyKnownBaseOnscreenState(framebuffer-px)"};
 
@@ -809,6 +859,7 @@ void Viewer3DPanel::Render(const RenderSize& renderSize)
     ApplyCameraMatrices(renderSize);
     const RenderSize projectionSize{width, height, "ApplyCameraMatrices::projection(framebuffer-px)"};
 
+    static unsigned long long s_renderFrameId = 0;
     ++s_renderFrameId;
     ValidateRenderSizeContract("Viewer3DPanel", s_renderFrameId, renderSize,
                                viewportSize, projectionSize, &renderSize);
@@ -820,9 +871,118 @@ void Viewer3DPanel::Render(const RenderSize& renderSize)
     m_controller.SetCameraMoving(m_cameraMoving);
     m_controller.RenderScene(IsWireframeRenderStyle(renderStyle),
                              ToSceneRenderMode(renderStyle));
-
     glFlush();
-    ValidateGlStateAfterRender("Viewer3DPanel::Render", width, height);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    glstate::ApplyKnownBaseOnscreenState(width, height);
+
+    m_baseCacheValid = true;
+    m_baseCacheCameraRevision = m_cameraRevision;
+    m_baseCacheHiddenLayersRevision = m_hiddenLayersRevision;
+    m_baseCacheSceneRevision = m_sceneRevision;
+}
+
+void Viewer3DPanel::RenderHighlightOverlayPass(const RenderSize& renderSize)
+{
+    const int width = renderSize.width;
+    const int height = renderSize.height;
+    glstate::ApplyKnownBaseOnscreenState(width, height);
+    ApplyCameraMatrices(renderSize);
+
+    const Viewer3DRenderStyle renderStyle = ResolveRenderStyleFromPreferences();
+    m_controller.SetCameraMoving(m_cameraMoving);
+    m_controller.RenderHighlightOverlayScene(
+        IsWireframeRenderStyle(renderStyle), ToSceneRenderMode(renderStyle));
+}
+
+bool Viewer3DPanel::EnsureBaseCacheFramebuffer(const RenderSize& renderSize)
+{
+    const int width = renderSize.width;
+    const int height = renderSize.height;
+    if (width <= 0 || height <= 0)
+        return false;
+    if (m_baseCacheFbo != 0 && m_baseCacheWidth == width && m_baseCacheHeight == height)
+        return true;
+
+    DestroyBaseCacheFramebuffer();
+
+    glGenFramebuffers(1, &m_baseCacheFbo);
+    glBindFramebuffer(GL_FRAMEBUFFER, m_baseCacheFbo);
+
+    glGenTextures(1, &m_baseCacheColorTex);
+    glBindTexture(GL_TEXTURE_2D, m_baseCacheColorTex);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA,
+                 GL_UNSIGNED_BYTE, nullptr);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+                           m_baseCacheColorTex, 0);
+
+    glGenRenderbuffers(1, &m_baseCacheDepthRb);
+    glBindRenderbuffer(GL_RENDERBUFFER, m_baseCacheDepthRb);
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, width, height);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER,
+                              m_baseCacheDepthRb);
+
+    const GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    if (status != GL_FRAMEBUFFER_COMPLETE) {
+        wxLogTrace("viewer3d_perf",
+                   "Viewer3DPanel base cache framebuffer incomplete: 0x%x",
+                   static_cast<unsigned int>(status));
+        DestroyBaseCacheFramebuffer();
+        return false;
+    }
+
+    m_baseCacheWidth = width;
+    m_baseCacheHeight = height;
+    m_baseCacheValid = false;
+    return true;
+}
+
+void Viewer3DPanel::BlitBaseCacheToDefaultFramebuffer(const RenderSize& renderSize)
+{
+    if (m_baseCacheFbo == 0)
+        return;
+    const int width = renderSize.width;
+    const int height = renderSize.height;
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, m_baseCacheFbo);
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+    glBlitFramebuffer(0, 0, width, height, 0, 0, width, height,
+                      GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT, GL_NEAREST);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    glstate::ApplyKnownBaseOnscreenState(width, height);
+}
+
+void Viewer3DPanel::InvalidateBaseCache()
+{
+    m_baseCacheValid = false;
+}
+
+bool Viewer3DPanel::IsBaseCacheValidForCurrentFrame() const
+{
+    return m_baseCacheValid &&
+           m_baseCacheWidth > 0 &&
+           m_baseCacheHeight > 0 &&
+           m_baseCacheCameraRevision == m_cameraRevision &&
+           m_baseCacheHiddenLayersRevision == m_hiddenLayersRevision &&
+           m_baseCacheSceneRevision == m_sceneRevision;
+}
+
+void Viewer3DPanel::DestroyBaseCacheFramebuffer()
+{
+    if (m_baseCacheDepthRb != 0)
+        glDeleteRenderbuffers(1, &m_baseCacheDepthRb);
+    if (m_baseCacheColorTex != 0)
+        glDeleteTextures(1, &m_baseCacheColorTex);
+    if (m_baseCacheFbo != 0)
+        glDeleteFramebuffers(1, &m_baseCacheFbo);
+    m_baseCacheDepthRb = 0;
+    m_baseCacheColorTex = 0;
+    m_baseCacheFbo = 0;
+    m_baseCacheWidth = 0;
+    m_baseCacheHeight = 0;
+    m_baseCacheValid = false;
 }
 
 bool Viewer3DPanel::ExportCurrentViewToPng() {

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -550,6 +550,7 @@ void Viewer3DPanel::InitGL()
         GLint sampleBuffers = 0;
         glGetIntegerv(GL_SAMPLE_BUFFERS, &sampleBuffers);
         m_hasSampleBuffers = sampleBuffers > 0;
+        glGetIntegerv(GL_SAMPLES, &m_defaultFramebufferSamples);
 
         m_controller.InitializeGL();
         m_glInitialized = true;
@@ -929,9 +930,7 @@ bool Viewer3DPanel::EnsureBaseCacheFramebuffer(const RenderSize& renderSize)
     glGenRenderbuffers(1, &m_baseCacheColorRb);
     glBindRenderbuffer(GL_RENDERBUFFER, m_baseCacheColorRb);
     if (m_hasSampleBuffers) {
-        GLint defaultSamples = 0;
-        glGetIntegerv(GL_SAMPLES, &defaultSamples);
-        const GLint samples = std::max(1, defaultSamples);
+        const GLint samples = std::max(1, m_defaultFramebufferSamples);
         glRenderbufferStorageMultisample(GL_RENDERBUFFER, samples, GL_RGBA8, width, height);
     } else {
         glRenderbufferStorage(GL_RENDERBUFFER, GL_RGBA8, width, height);
@@ -942,9 +941,7 @@ bool Viewer3DPanel::EnsureBaseCacheFramebuffer(const RenderSize& renderSize)
     glGenRenderbuffers(1, &m_baseCacheDepthRb);
     glBindRenderbuffer(GL_RENDERBUFFER, m_baseCacheDepthRb);
     if (m_hasSampleBuffers) {
-        GLint defaultSamples = 0;
-        glGetIntegerv(GL_SAMPLES, &defaultSamples);
-        const GLint samples = std::max(1, defaultSamples);
+        const GLint samples = std::max(1, m_defaultFramebufferSamples);
         glRenderbufferStorageMultisample(GL_RENDERBUFFER, samples, GL_DEPTH_COMPONENT24,
                                          width, height);
     } else {

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -123,7 +123,7 @@ private:
 
     // Renders the full scene
     void Render(const RenderSize& renderSize, bool highlightOnlyRefresh);
-    void RenderBasePassToCache(const RenderSize& renderSize);
+    bool RenderBasePassToCache(const RenderSize& renderSize);
     void RenderHighlightOverlayPass(const RenderSize& renderSize);
     bool EnsureBaseCacheFramebuffer(const RenderSize& renderSize);
     void BlitBaseCacheToDefaultFramebuffer(const RenderSize& renderSize);

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -186,6 +186,7 @@ private:
 
     // Multisample anti-aliasing availability negotiated at context creation.
     bool m_hasSampleBuffers = false;
+    int m_defaultFramebufferSamples = 0;
 
     Viewer3DController m_controller;
 

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -175,7 +175,7 @@ private:
     uint64_t m_baseCacheHiddenLayersRevision = 0;
     uint64_t m_baseCacheSceneRevision = 0;
     unsigned int m_baseCacheFbo = 0;
-    unsigned int m_baseCacheColorTex = 0;
+    unsigned int m_baseCacheColorRb = 0;
     unsigned int m_baseCacheDepthRb = 0;
 
     // True when the mouse moved since the last paint

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -122,7 +122,14 @@ private:
     void DrawSelectionRectangle(int width, int height);
 
     // Renders the full scene
-    void Render(const RenderSize& renderSize);
+    void Render(const RenderSize& renderSize, bool highlightOnlyRefresh);
+    void RenderBasePassToCache(const RenderSize& renderSize);
+    void RenderHighlightOverlayPass(const RenderSize& renderSize);
+    bool EnsureBaseCacheFramebuffer(const RenderSize& renderSize);
+    void BlitBaseCacheToDefaultFramebuffer(const RenderSize& renderSize);
+    void InvalidateBaseCache();
+    bool IsBaseCacheValidForCurrentFrame() const;
+    void DestroyBaseCacheFramebuffer();
     void ApplyCameraMatrices(const RenderSize& renderSize, double fovYDegrees = 45.0);
     bool ExportCurrentViewToPng();
 
@@ -157,6 +164,19 @@ private:
     std::chrono::steady_clock::time_point m_refreshTelemetryWindowStart{};
     int m_fullRefreshesInCurrentWindow = 0;
     int m_highlightRefreshesInCurrentWindow = 0;
+    std::chrono::microseconds m_basePassTimeAccum{0};
+    std::chrono::microseconds m_overlayPassTimeAccum{0};
+    int m_basePassSamplesInCurrentWindow = 0;
+    int m_overlayPassSamplesInCurrentWindow = 0;
+    bool m_baseCacheValid = false;
+    int m_baseCacheWidth = 0;
+    int m_baseCacheHeight = 0;
+    uint64_t m_baseCacheCameraRevision = 0;
+    uint64_t m_baseCacheHiddenLayersRevision = 0;
+    uint64_t m_baseCacheSceneRevision = 0;
+    unsigned int m_baseCacheFbo = 0;
+    unsigned int m_baseCacheColorTex = 0;
+    unsigned int m_baseCacheDepthRb = 0;
 
     // True when the mouse moved since the last paint
     bool m_mouseMoved = false;


### PR DESCRIPTION
### Motivation
- Hover/highlight currently forced a full opaque scene render, making simple hover updates slow in scenes with heavy meshes.  
- Introduce a cheap hover path that reuses a valid base color+depth buffer and draws only selection/highlight overlays and labels.  
- Keep the change modular by extracting overlay duties to a dedicated render unit and minimizing changes in the existing opaque passes.  

### Description
- Add a new overlay pass `SelectionOverlayPass` (`viewer3d/render/selection_overlay_pass.{h,cpp}`) that builds a minimal visible set (selected + highlighted UUIDs) and renders only that subset using existing depth.  
- Add `RenderFrameContext::suppressSelectionEmphasis` to allow the base opaque pass to render deterministically without transient highlight/selection tint.  
- Change opaque passes (`opaque_fixture_pass`, `opaque_truss_pass`, `opaque_object_pass`) to respect `suppressSelectionEmphasis` so the cached base buffer is not contaminated by highlight/selection rendering.  
- Update `Viewer3DController` to expose an overlay-only entry point `RenderHighlightOverlayScene(...)` and to invoke the new `SelectionOverlayPass` from its overlay phase.  
- Modify `Viewer3DPanel` to maintain a cached base color+depth framebuffer and to branch `Render(...)` into: full base pass (written to cache) + overlay pass, or hover-only path that blits the cached base and runs only the overlay and labels; added lifecycle helpers (`EnsureBaseCacheFramebuffer`, `BlitBaseCacheToDefaultFramebuffer`, `InvalidateBaseCache`, `DestroyBaseCacheFramebuffer`).  
- Add per-window telemetry counters (microsecond accumulators) and `viewer3d_perf` traces that report average base vs overlay pass times to validate performance improvements.  
- Register the new source in `viewer3d/CMakeLists.txt`.  
- Technical note: `viewer3d/viewer3dpanel.cpp` remains a large hotspot; a recommended next split is to move base-cache framebuffer lifecycle and invalidation policy into a focused helper (e.g. `viewer3d/render/base_frame_cache.{h,cpp}`) to keep the panel logic slimmer.  

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed (`OK`).  
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed (`OK`).  
- Attempted to configure/build with `cmake -S . -B build && cmake --build build -j2` but configure failed in this environment due to missing system `wxWidgets` development libraries (reported `Could NOT find wxWidgets (missing: wxWidgets_LIBRARIES wxWidgets_INCLUDE_DIRS)`), so a full build could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb21af7ef08324b30a91bf5258849a)