### PR TITLE
viewer3d: add per-frame baseline telemetry and stress scenario

### DIFF
--- a/docs/viewer3d_performance_stress_scenario.md
+++ b/docs/viewer3d_performance_stress_scenario.md
@@ -1,0 +1,40 @@
+# Viewer3D stress scenario (baseline telemetry)
+
+This scenario is the baseline used before architecture/performance changes in
+Viewer3D. It is intentionally simple and reproducible so telemetry deltas can
+be compared between PRs.
+
+## Goal
+
+Capture a stable telemetry window with:
+
+- a **heavy geometry load** (many polygons from many fixtures), and
+- one **lightweight isolated object** (small scene object far from the dense
+  fixture cluster) to keep hover/highlight transitions measurable.
+
+## Input assets
+
+- Rider file: `tests/data/rider_large.txt`.
+- One lightweight object created in-scene (recommended primitive: cube).
+
+## Repro steps
+
+1. Start the app with a clean session.
+2. Import `tests/data/rider_large.txt`.
+3. Open **Viewer3D** and wait until resource sync is idle.
+4. Add one small scene object (cube) and place it far from the fixture block
+   (for example +20 m on X).
+5. Move the camera so both zones are reachable with short mouse moves:
+   - dense fixture region (heavy polygon load),
+   - isolated cube (light object).
+6. Perform 20-30 seconds of interaction:
+   - orbit/pan/zoom around dense fixtures,
+   - move cursor across fixtures (trigger hover),
+   - move cursor to isolated cube and back (trigger highlight changes).
+7. Collect `Viewer3DPanel` debug lines for at least 10 one-second windows.
+
+## Telemetry line to compare
+
+`Viewer3DPanel refreshes/s full=... highlight=... full_render_ms=... hover_query_ms=... highlight_update_ms=...`
+
+Use medians across captured windows when comparing branches/hardware sessions.

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -600,7 +600,16 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
         return;
     }
 
+    const auto fullRenderStart = std::chrono::steady_clock::now();
     Render(renderSize);
+    if (!highlightOnlyRefresh) {
+        const auto fullRenderElapsedMs =
+            std::chrono::duration<double, std::milli>(
+                std::chrono::steady_clock::now() - fullRenderStart)
+                .count();
+        m_fullRenderMsAccumInCurrentWindow += fullRenderElapsedMs;
+        ++m_fullRenderSamplesInCurrentWindow;
+    }
 
     // Ensure the OpenGL context is current before drawing overlays
     SetCurrent(*m_glContext);
@@ -667,8 +676,15 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
         (m_forceHoverQuery || hoverStateChanged);
 
     if (shouldRunHoverQuery) {
+        const auto hoverQueryStart = std::chrono::steady_clock::now();
         found = QueryHoverUuid(m_controller, activeTable, pickPos.x, pickPos.y,
                                w, h, newUuid);
+        const auto hoverQueryElapsedMs =
+            std::chrono::duration<double, std::milli>(
+                std::chrono::steady_clock::now() - hoverQueryStart)
+                .count();
+        m_hoverQueryMsAccumInCurrentWindow += hoverQueryElapsedMs;
+        ++m_hoverQuerySamplesInCurrentWindow;
         hoverQueryRan = true;
         if (found) {
             if (!skipLabelWork) {
@@ -720,6 +736,7 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
     }
 
     if (oldHoverUuid != m_hoverUuid || oldHasHover != m_hasHover) {
+        const auto highlightUpdateStart = std::chrono::steady_clock::now();
         ++m_highlightRevision;
         m_highlightRefreshPending = true;
         m_controller.SetHighlightUuid(m_hoverUuid);
@@ -741,6 +758,12 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
                     ? std::string(m_hoverUuid)
                     : std::string());
         }
+        const auto highlightUpdateElapsedMs =
+            std::chrono::duration<double, std::milli>(
+                std::chrono::steady_clock::now() - highlightUpdateStart)
+                .count();
+        m_highlightUpdateMsAccumInCurrentWindow += highlightUpdateElapsedMs;
+        ++m_highlightUpdateSamplesInCurrentWindow;
     }
     m_mouseMoved = false;
 
@@ -767,12 +790,35 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
         m_refreshTelemetryWindowStart = telemetryNow;
     const auto telemetryElapsed = telemetryNow - m_refreshTelemetryWindowStart;
     if (telemetryElapsed >= std::chrono::seconds(1)) {
-        wxLogDebug("Viewer3DPanel refreshes/s full=%d highlight=%d",
+        const double avgFullRenderMs = m_fullRenderSamplesInCurrentWindow > 0
+            ? (m_fullRenderMsAccumInCurrentWindow /
+               static_cast<double>(m_fullRenderSamplesInCurrentWindow))
+            : 0.0;
+        const double avgHoverQueryMs = m_hoverQuerySamplesInCurrentWindow > 0
+            ? (m_hoverQueryMsAccumInCurrentWindow /
+               static_cast<double>(m_hoverQuerySamplesInCurrentWindow))
+            : 0.0;
+        const double avgHighlightUpdateMs =
+            m_highlightUpdateSamplesInCurrentWindow > 0
+                ? (m_highlightUpdateMsAccumInCurrentWindow /
+                   static_cast<double>(m_highlightUpdateSamplesInCurrentWindow))
+                : 0.0;
+        wxLogDebug(
+            "Viewer3DPanel refreshes/s full=%d highlight=%d full_render_ms=%.3f hover_query_ms=%.3f highlight_update_ms=%.3f hover_samples=%d highlight_samples=%d",
                    m_fullRefreshesInCurrentWindow,
-                   m_highlightRefreshesInCurrentWindow);
+                   m_highlightRefreshesInCurrentWindow, avgFullRenderMs,
+                   avgHoverQueryMs, avgHighlightUpdateMs,
+                   m_hoverQuerySamplesInCurrentWindow,
+                   m_highlightUpdateSamplesInCurrentWindow);
         m_refreshTelemetryWindowStart = telemetryNow;
         m_fullRefreshesInCurrentWindow = 0;
         m_highlightRefreshesInCurrentWindow = 0;
+        m_fullRenderMsAccumInCurrentWindow = 0.0;
+        m_fullRenderSamplesInCurrentWindow = 0;
+        m_hoverQueryMsAccumInCurrentWindow = 0.0;
+        m_hoverQuerySamplesInCurrentWindow = 0;
+        m_highlightUpdateMsAccumInCurrentWindow = 0.0;
+        m_highlightUpdateSamplesInCurrentWindow = 0;
     }
 
     if (highlightOnlyRefresh)

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -157,6 +157,12 @@ private:
     std::chrono::steady_clock::time_point m_refreshTelemetryWindowStart{};
     int m_fullRefreshesInCurrentWindow = 0;
     int m_highlightRefreshesInCurrentWindow = 0;
+    double m_fullRenderMsAccumInCurrentWindow = 0.0;
+    int m_fullRenderSamplesInCurrentWindow = 0;
+    double m_hoverQueryMsAccumInCurrentWindow = 0.0;
+    int m_hoverQuerySamplesInCurrentWindow = 0;
+    double m_highlightUpdateMsAccumInCurrentWindow = 0.0;
+    int m_highlightUpdateSamplesInCurrentWindow = 0;
 
     // True when the mouse moved since the last paint
     bool m_mouseMoved = false;


### PR DESCRIPTION
### Motivation
- Establish a stable, pre-architecture-change performance baseline for the 3D viewer so future changes can be measured reliably.
- Keep telemetry directly comparable with the existing `refreshes/s` 1-second window while adding millisecond metrics for common per-frame operations.

### Description
- Added accumulators and sample counters to `Viewer3DPanel` (`viewer3d/viewer3dpanel.h`) to collect timing samples for full renders, hover queries and highlight updates per 1-second telemetry window.
- Measured and recorded `full_render_ms` for non-highlight-only frames by timing `Render(...)`, `hover_query_ms` around `QueryHoverUuid(...)`, and `highlight_update_ms` around the sequence that updates highlight state and notifies panels; averages are logged alongside the existing `refreshes/s` line in `viewer3d/viewer3dpanel.cpp`.
- Reset accumulators and sample counters after each telemetry window to preserve the existing 1-second reporting cadence and added sample counts (`hover_samples`, `highlight_samples`) to help evaluate sample stability.
- Added a reproducible stress scenario document at `docs/viewer3d_performance_stress_scenario.md` that prescribes using `tests/data/rider_large.txt` plus a small isolated object and the exact telemetry line to collect for comparisons.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.
- Verified that existing `Viewer3DPanel` refresh logging remains present and now includes the added average-ms and sample fields.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebdb1ee7a48324b2a98221c43e0685)