### PR TITLE
viewer3d: skip full render on highlight-only refresh

### DIFF
--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -600,9 +600,12 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
         return;
     }
 
-    const auto fullRenderStart = std::chrono::steady_clock::now();
-    Render(renderSize);
-    if (!highlightOnlyRefresh) {
+    if (highlightOnlyRefresh) {
+        // Keep the previously rendered scene and apply only lightweight
+        // highlight/overlay updates before swapping buffers.
+    } else {
+        const auto fullRenderStart = std::chrono::steady_clock::now();
+        Render(renderSize);
         const auto fullRenderElapsedMs =
             std::chrono::duration<double, std::milli>(
                 std::chrono::steady_clock::now() - fullRenderStart)


### PR DESCRIPTION
### Motivation
- Reduce unnecessary full-scene renders when only highlight/overlay updates are required by preventing `Render(renderSize)` from running for highlight-only refresh frames.

### Description
- Modified `viewer3d/viewer3dpanel.cpp` to add an explicit `highlightOnlyRefresh` branch inside `Viewer3DPanel::OnPaint` that skips calling `Render(renderSize)` when the lightweight highlight path applies while keeping overlay/highlight drawing and `SwapBuffers()` behavior and preserving full-render timing telemetry for non-highlight frames.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both checks completed successfully (OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebdd0235b483248ada33b67d0b7368)