### PR TITLE
viewer3d: add BasePassFramebufferCache to reuse base color+depth for hover refresh

### DIFF
--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -316,7 +316,11 @@ HoistTablePanel::HoistTablePanel(wxWindow *parent, IGuiConfigServices *services)
   SetSizer(sizer);
 }
 
-HoistTablePanel::~HoistTablePanel() { store = nullptr; }
+HoistTablePanel::~HoistTablePanel() {
+  if (s_instance == this)
+    s_instance = nullptr;
+  store = nullptr;
+}
 
 void HoistTablePanel::InitializeTable() {
   const auto distanceUnit = ResolveDistanceUnitSystem();
@@ -1144,8 +1148,20 @@ HoistTablePanel *HoistTablePanel::Instance() { return s_instance; }
 void HoistTablePanel::SetInstance(HoistTablePanel *panel) { s_instance = panel; }
 
 bool HoistTablePanel::IsActivePage() const {
-  auto *nb = dynamic_cast<wxNotebook *>(GetParent());
-  return nb && nb->GetPage(nb->GetSelection()) == this;
+  if (IsBeingDeleted())
+    return false;
+  wxWindow *parent = GetParent();
+  if (!parent || parent->IsBeingDeleted())
+    return false;
+  auto *nb = dynamic_cast<wxNotebook *>(parent);
+  if (!nb || nb->IsBeingDeleted())
+    return false;
+  const int selection = nb->GetSelection();
+  if (selection == wxNOT_FOUND ||
+      selection < 0 ||
+      selection >= static_cast<int>(nb->GetPageCount()))
+    return false;
+  return nb->GetPage(static_cast<size_t>(selection)) == this;
 }
 
 void HoistTablePanel::HighlightHoist(const std::string &uuid) {

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -59,7 +59,6 @@
 #include <wx/textctrl.h>
 #include <wx/tokenzr.h>
 #include <wx/utils.h>
-#include <wx/weakref.h>
 #include <wx/wfstream.h>
 class wxZipStreamLink;
 #include <wx/log.h>
@@ -383,6 +382,7 @@ MainWindow::MainWindow(const wxString &title, IGuiConfigServices *services)
 }
 
 MainWindow::~MainWindow() {
+  cursorStatusCallbackLifetimeToken.reset();
   if (viewport2DPanel)
     viewport2DPanel->SetCursorWorldPositionCallback({});
   if (layout2DViewEditPanel)
@@ -394,6 +394,7 @@ MainWindow::~MainWindow() {
     delete auiManager;
     auiManager = nullptr;
   }
+  SetInstance(nullptr);
   ProjectUtils::SaveLastProjectPath(currentProjectPath);
 }
 
@@ -427,15 +428,13 @@ void MainWindow::Ensure2DViewport() {
     return;
   int halfWidth = GetClientSize().GetWidth() / 2;
   viewport2DPanel = new Viewer2DPanel(this);
-  wxWeakRef<MainWindow> weakWindow(this);
+  std::weak_ptr<int> lifetimeToken = cursorStatusCallbackLifetimeToken;
   viewport2DPanel->SetCursorWorldPositionCallback(
-      [weakWindow](const std::optional<std::array<float, 3>> &positionMeters) {
-        if (!weakWindow)
+      [this, lifetimeToken](
+          const std::optional<std::array<float, 3>> &positionMeters) {
+        if (lifetimeToken.expired() || !GetStatusBar())
           return;
-        MainWindow *window = weakWindow.get();
-        if (!window || !window->GetStatusBar())
-          return;
-        window->UpdateCursorWorldPositionInStatusBar(positionMeters);
+        UpdateCursorWorldPositionInStatusBar(positionMeters);
       });
   Viewer2DPanel::SetInstance(viewport2DPanel);
   viewport2DPanel->LoadViewFromConfig();

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -59,6 +59,7 @@
 #include <wx/textctrl.h>
 #include <wx/tokenzr.h>
 #include <wx/utils.h>
+#include <wx/weakref.h>
 #include <wx/wfstream.h>
 class wxZipStreamLink;
 #include <wx/log.h>
@@ -382,6 +383,10 @@ MainWindow::MainWindow(const wxString &title, IGuiConfigServices *services)
 }
 
 MainWindow::~MainWindow() {
+  if (viewport2DPanel)
+    viewport2DPanel->SetCursorWorldPositionCallback({});
+  if (layout2DViewEditPanel)
+    layout2DViewEditPanel->SetCursorWorldPositionCallback({});
   if (!userConfigPersistedOnClose)
     SaveUserConfigWithViewport2DState();
   if (auiManager) {
@@ -422,9 +427,15 @@ void MainWindow::Ensure2DViewport() {
     return;
   int halfWidth = GetClientSize().GetWidth() / 2;
   viewport2DPanel = new Viewer2DPanel(this);
+  wxWeakRef<MainWindow> weakWindow(this);
   viewport2DPanel->SetCursorWorldPositionCallback(
-      [this](const std::optional<std::array<float, 3>> &positionMeters) {
-        UpdateCursorWorldPositionInStatusBar(positionMeters);
+      [weakWindow](const std::optional<std::array<float, 3>> &positionMeters) {
+        if (!weakWindow)
+          return;
+        MainWindow *window = weakWindow.get();
+        if (!window || !window->GetStatusBar())
+          return;
+        window->UpdateCursorWorldPositionInStatusBar(positionMeters);
       });
   Viewer2DPanel::SetInstance(viewport2DPanel);
   viewport2DPanel->LoadViewFromConfig();

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -134,6 +134,8 @@ private:
   std::unique_ptr<MainWindowLayoutController> layoutController;
   std::unique_ptr<MainWindowPrintController> printController;
   std::unique_ptr<MainWindowViewController> viewController;
+  std::shared_ptr<int> cursorStatusCallbackLifetimeToken =
+      std::make_shared<int>(0);
 
   void OnNew(wxCommandEvent &event);    // Start new project
   void OnLoad(wxCommandEvent &event);   // Load project

--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -22,7 +22,6 @@
 #include <unordered_set>
 
 #include <wx/notebook.h>
-#include <wx/weakref.h>
 
 #include "app_version.h"
 #include "configmanager.h"
@@ -913,15 +912,13 @@ void MainWindow::BeginLayout2DViewEdit() {
   layout2DViewEditPanel = dialog.GetViewerPanel();
   layout2DViewEditRenderPanel = dialog.GetRenderPanel();
   if (layout2DViewEditPanel) {
-    wxWeakRef<MainWindow> weakWindow(this);
+    std::weak_ptr<int> lifetimeToken = cursorStatusCallbackLifetimeToken;
     layout2DViewEditPanel->SetCursorWorldPositionCallback(
-        [weakWindow](const std::optional<std::array<float, 3>> &positionMeters) {
-          if (!weakWindow)
+        [this, lifetimeToken](
+            const std::optional<std::array<float, 3>> &positionMeters) {
+          if (lifetimeToken.expired() || !GetStatusBar())
             return;
-          MainWindow *window = weakWindow.get();
-          if (!window || !window->GetStatusBar())
-            return;
-          window->UpdateCursorWorldPositionInStatusBar(positionMeters);
+          UpdateCursorWorldPositionInStatusBar(positionMeters);
         });
   }
 

--- a/gui/mainwindow_layout.cpp
+++ b/gui/mainwindow_layout.cpp
@@ -22,6 +22,7 @@
 #include <unordered_set>
 
 #include <wx/notebook.h>
+#include <wx/weakref.h>
 
 #include "app_version.h"
 #include "configmanager.h"
@@ -912,9 +913,15 @@ void MainWindow::BeginLayout2DViewEdit() {
   layout2DViewEditPanel = dialog.GetViewerPanel();
   layout2DViewEditRenderPanel = dialog.GetRenderPanel();
   if (layout2DViewEditPanel) {
+    wxWeakRef<MainWindow> weakWindow(this);
     layout2DViewEditPanel->SetCursorWorldPositionCallback(
-        [this](const std::optional<std::array<float, 3>> &positionMeters) {
-          UpdateCursorWorldPositionInStatusBar(positionMeters);
+        [weakWindow](const std::optional<std::array<float, 3>> &positionMeters) {
+          if (!weakWindow)
+            return;
+          MainWindow *window = weakWindow.get();
+          if (!window || !window->GetStatusBar())
+            return;
+          window->UpdateCursorWorldPositionInStatusBar(positionMeters);
         });
   }
 

--- a/viewer3d/CMakeLists.txt
+++ b/viewer3d/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/picking/selectionsystem.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/picking/id_pick_pass.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/gl_primitive_renderer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/render/base_pass_framebuffer_cache.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/hoist_symbol_renderer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/lighting_profile.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/opaque_fixture_pass.cpp

--- a/viewer3d/render/base_pass_framebuffer_cache.cpp
+++ b/viewer3d/render/base_pass_framebuffer_cache.cpp
@@ -1,0 +1,99 @@
+#include "base_pass_framebuffer_cache.h"
+
+#include <GL/glew.h>
+#ifdef __APPLE__
+#define GL_SILENCE_DEPRECATION
+#include <OpenGL/gl.h>
+#else
+#include <GL/gl.h>
+#endif
+
+BasePassFramebufferCache::~BasePassFramebufferCache() {
+  if (m_depthRenderbuffer != 0)
+    glDeleteRenderbuffers(1, &m_depthRenderbuffer);
+  if (m_colorTexture != 0)
+    glDeleteTextures(1, &m_colorTexture);
+  if (m_fbo != 0)
+    glDeleteFramebuffers(1, &m_fbo);
+}
+
+void BasePassFramebufferCache::Invalidate() { m_hasSnapshot = false; }
+
+void BasePassFramebufferCache::EnsureFramebufferSize(int width, int height) {
+  if (width <= 0 || height <= 0)
+    return;
+  if (m_fbo != 0 && m_width == width && m_height == height)
+    return;
+
+  if (m_depthRenderbuffer != 0)
+    glDeleteRenderbuffers(1, &m_depthRenderbuffer);
+  if (m_colorTexture != 0)
+    glDeleteTextures(1, &m_colorTexture);
+  if (m_fbo == 0)
+    glGenFramebuffers(1, &m_fbo);
+
+  glBindFramebuffer(GL_FRAMEBUFFER, m_fbo);
+
+  glGenTextures(1, &m_colorTexture);
+  glBindTexture(GL_TEXTURE_2D, m_colorTexture);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA,
+               GL_UNSIGNED_BYTE, nullptr);
+  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+                         m_colorTexture, 0);
+
+  glGenRenderbuffers(1, &m_depthRenderbuffer);
+  glBindRenderbuffer(GL_RENDERBUFFER, m_depthRenderbuffer);
+  glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, width, height);
+  glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT,
+                            GL_RENDERBUFFER, m_depthRenderbuffer);
+
+  m_width = width;
+  m_height = height;
+  m_hasSnapshot = false;
+}
+
+bool BasePassFramebufferCache::RestoreToDefaultFramebuffer(
+    int width, int height, size_t cameraFingerprint,
+    const std::unordered_set<std::string> &hiddenLayers,
+    size_t sceneVersion) const {
+  if (!m_hasSnapshot || m_fbo == 0 || width <= 0 || height <= 0)
+    return false;
+
+  const bool viewportChanged = m_width != width || m_height != height;
+  const bool cameraChanged = m_lastCameraFingerprint != cameraFingerprint;
+  const bool layersChanged = m_lastHiddenLayers != hiddenLayers;
+  const bool sceneChanged = m_lastSceneVersion != sceneVersion;
+  if (viewportChanged || cameraChanged || layersChanged || sceneChanged)
+    return false;
+
+  glBindFramebuffer(GL_READ_FRAMEBUFFER, m_fbo);
+  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+  glBlitFramebuffer(0, 0, width, height, 0, 0, width, height,
+                    GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT, GL_NEAREST);
+  glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+  return true;
+}
+
+void BasePassFramebufferCache::CaptureFromDefaultFramebuffer(
+    int width, int height, size_t cameraFingerprint,
+    const std::unordered_set<std::string> &hiddenLayers,
+    size_t sceneVersion) {
+  EnsureFramebufferSize(width, height);
+  if (m_fbo == 0 || width <= 0 || height <= 0)
+    return;
+
+  glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, m_fbo);
+  glBlitFramebuffer(0, 0, width, height, 0, 0, width, height,
+                    GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT, GL_NEAREST);
+  glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+
+  m_lastCameraFingerprint = cameraFingerprint;
+  m_lastHiddenLayers = hiddenLayers;
+  m_lastSceneVersion = sceneVersion;
+  m_hasSnapshot = true;
+}

--- a/viewer3d/render/base_pass_framebuffer_cache.cpp
+++ b/viewer3d/render/base_pass_framebuffer_cache.cpp
@@ -19,6 +19,15 @@ BasePassFramebufferCache::~BasePassFramebufferCache() {
 
 void BasePassFramebufferCache::Invalidate() { m_hasSnapshot = false; }
 
+void BasePassFramebufferCache::AbandonResources() {
+  m_fbo = 0;
+  m_colorTexture = 0;
+  m_depthRenderbuffer = 0;
+  m_width = 0;
+  m_height = 0;
+  m_hasSnapshot = false;
+}
+
 void BasePassFramebufferCache::EnsureFramebufferSize(int width, int height) {
   if (width <= 0 || height <= 0)
     return;

--- a/viewer3d/render/base_pass_framebuffer_cache.h
+++ b/viewer3d/render/base_pass_framebuffer_cache.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <unordered_set>
+
+class BasePassFramebufferCache {
+public:
+  BasePassFramebufferCache() = default;
+  ~BasePassFramebufferCache();
+
+  bool RestoreToDefaultFramebuffer(
+      int width, int height, size_t cameraFingerprint,
+      const std::unordered_set<std::string> &hiddenLayers,
+      size_t sceneVersion) const;
+  void CaptureFromDefaultFramebuffer(
+      int width, int height, size_t cameraFingerprint,
+      const std::unordered_set<std::string> &hiddenLayers,
+      size_t sceneVersion);
+  void Invalidate();
+
+private:
+  void EnsureFramebufferSize(int width, int height);
+
+  unsigned int m_fbo = 0;
+  unsigned int m_colorTexture = 0;
+  unsigned int m_depthRenderbuffer = 0;
+  int m_width = 0;
+  int m_height = 0;
+
+  bool m_hasSnapshot = false;
+  size_t m_lastCameraFingerprint = 0;
+  std::unordered_set<std::string> m_lastHiddenLayers;
+  size_t m_lastSceneVersion = static_cast<size_t>(-1);
+};

--- a/viewer3d/render/base_pass_framebuffer_cache.h
+++ b/viewer3d/render/base_pass_framebuffer_cache.h
@@ -18,6 +18,7 @@ public:
       const std::unordered_set<std::string> &hiddenLayers,
       size_t sceneVersion);
   void Invalidate();
+  void AbandonResources();
 
 private:
   void EnsureFramebufferSize(int width, int height);

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1820,6 +1820,10 @@ bool Viewer3DController::GetPickUuidAt(
   return ReadPickUuidAt(mouseX, mouseY, width, height, hiddenLayers, outUuid);
 }
 
+size_t Viewer3DController::GetSceneVersionSnapshot() const {
+  return m_impl->sceneVersion;
+}
+
 std::vector<std::string> Viewer3DController::GetFixturesInScreenRect(
     int x1, int y1, int x2, int y2, int width, int height) const {
   return m_impl->selectionSystem->GetFixturesInScreenRect(x1, y1, x2, y2, width,

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -136,6 +136,7 @@ public:
   bool GetPickUuidAt(int mouseX, int mouseY, int width, int height,
                      const std::unordered_set<std::string> &hiddenLayers,
                      std::string &outUuid);
+  size_t GetSceneVersionSnapshot() const;
 
   const VisibleSet &
   GetVisibleSet(const ViewFrustumSnapshot &frustum,

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -585,7 +585,7 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
         !m_forceHoverQuery;
     const size_t cameraFingerprint = ComputeCameraFingerprint(m_camera);
     const auto hiddenLayers = ConfigManager::Get().GetHiddenLayers();
-    const size_t sceneVersion = m_controller.GetSceneVersion();
+    const size_t sceneVersion = m_controller.GetSceneVersionSnapshot();
 
     m_controller.ResetDebugPerFrameCounters();
     m_controller.UpdateFrameStateLightweight();

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -52,6 +52,7 @@
 #include "viewer2dpanel.h"
 #include "viewer3dviewfit.h"
 #include "viewer3d_render_style.h"
+#include "base_pass_framebuffer_cache.h"
 #include "gl_state_guard.h"
 #include "ui_render_size.h"
 #include <wx/dcclient.h>
@@ -505,6 +506,7 @@ Viewer3DPanel::Viewer3DPanel(wxWindow* parent)
     Bind(wxEVT_THREAD, &Viewer3DPanel::OnThreadRefresh, this, wxEVT_VIEWER_REFRESH);
     m_threadRunning = true;
     m_lastResourceSyncCheck = std::chrono::steady_clock::now();
+    m_basePassCache = std::make_unique<BasePassFramebufferCache>();
     m_refreshThread = std::thread(&Viewer3DPanel::RefreshLoop, this);
 }
 
@@ -516,6 +518,10 @@ Viewer3DPanel::~Viewer3DPanel()
     if (HasCapture())
         ReleaseMouse();
     StopRefreshThread();
+    if (m_glContext) {
+        SetCurrent(*m_glContext);
+        m_basePassCache.reset();
+    }
     delete m_glContext;
     m_glContext = nullptr;
     SetInstance(nullptr);
@@ -577,6 +583,9 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
         !m_isInteracting &&
         !m_mouseMoved &&
         !m_forceHoverQuery;
+    const size_t cameraFingerprint = ComputeCameraFingerprint(m_camera);
+    const auto hiddenLayers = ConfigManager::Get().GetHiddenLayers();
+    const size_t sceneVersion = m_controller.GetSceneVersion();
 
     m_controller.ResetDebugPerFrameCounters();
     m_controller.UpdateFrameStateLightweight();
@@ -600,10 +609,14 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
         return;
     }
 
-    if (highlightOnlyRefresh) {
-        // Keep the previously rendered scene and apply only lightweight
-        // highlight/overlay updates before swapping buffers.
-    } else {
+    bool reusedBasePass = false;
+    if (highlightOnlyRefresh && m_basePassCache) {
+        reusedBasePass = m_basePassCache->RestoreToDefaultFramebuffer(
+            renderSize.width, renderSize.height, cameraFingerprint,
+            hiddenLayers, sceneVersion);
+    }
+
+    if (!reusedBasePass) {
         const auto fullRenderStart = std::chrono::steady_clock::now();
         Render(renderSize);
         const auto fullRenderElapsedMs =
@@ -612,6 +625,11 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
                 .count();
         m_fullRenderMsAccumInCurrentWindow += fullRenderElapsedMs;
         ++m_fullRenderSamplesInCurrentWindow;
+        if (m_basePassCache) {
+            m_basePassCache->CaptureFromDefaultFramebuffer(
+                renderSize.width, renderSize.height, cameraFingerprint,
+                hiddenLayers, sceneVersion);
+        }
     }
 
     // Ensure the OpenGL context is current before drawing overlays
@@ -633,13 +651,11 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
     const bool skipLabelWork = m_cameraMoving &&
         (IsFastInteractionModeEnabled() || skipLabelsWhenMoving);
 
-    const size_t cameraFingerprint = ComputeCameraFingerprint(m_camera);
     if (cameraFingerprint != m_lastCameraFingerprint) {
         ++m_cameraRevision;
         m_lastCameraFingerprint = cameraFingerprint;
     }
 
-    const auto hiddenLayers = ConfigManager::Get().GetHiddenLayers();
     size_t hiddenLayersFingerprint = 0;
     for (const std::string& layer : hiddenLayers)
         HashCombine(hiddenLayersFingerprint, layer);
@@ -783,7 +799,7 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
     if (m_rectSelecting)
         DrawSelectionRectangle(w, h);
 
-    if (highlightOnlyRefresh)
+    if (reusedBasePass)
         ++m_highlightRefreshesInCurrentWindow;
     else
         ++m_fullRefreshesInCurrentWindow;
@@ -824,7 +840,7 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
         m_highlightUpdateSamplesInCurrentWindow = 0;
     }
 
-    if (highlightOnlyRefresh)
+    if (reusedBasePass)
         m_highlightRefreshPending = false;
     if (m_selectionRefreshPending)
         m_selectionRefreshPending = false;

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -518,8 +518,11 @@ Viewer3DPanel::~Viewer3DPanel()
     if (HasCapture())
         ReleaseMouse();
     StopRefreshThread();
-    if (m_glContext) {
+    if (m_basePassCache && m_glContext && IsShownOnScreen()) {
         SetCurrent(*m_glContext);
+        m_basePassCache.reset();
+    } else if (m_basePassCache) {
+        m_basePassCache->AbandonResources();
         m_basePassCache.reset();
     }
     delete m_glContext;

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -174,6 +174,7 @@ private:
     bool m_hasSampleBuffers = false;
 
     Viewer3DController m_controller;
+    std::unique_ptr<class BasePassFramebufferCache> m_basePassCache;
 
     std::atomic<bool> m_threadRunning{false};
     std::atomic<bool> m_shuttingDown{false};


### PR DESCRIPTION
### Motivation
- Reduce expensive full 3D renders during hover/highlight-only refreshes by caching the base color+depth pass and reusing it when the scene/camera/state hasn't changed.
- Keep `viewer3d` controller/panel files small by adding a dedicated module for framebuffer caching instead of embedding the logic in `viewer3dpanel.cpp` or `viewer3dcontroller.cpp`.

### Description
- Added a new module `BasePassFramebufferCache` (`viewer3d/render/base_pass_framebuffer_cache.{h,cpp}`) that encapsulates an offscreen FBO, color texture and depth renderbuffer and provides `CaptureFromDefaultFramebuffer`, `RestoreToDefaultFramebuffer` and `Invalidate` operations.
- Integrated the cache into `Viewer3DPanel::OnPaint` so highlight-only refreshes attempt `BasePassFramebufferCache::RestoreToDefaultFramebuffer(...)` and fall back to a full `Render(...)` if the snapshot is invalid, and full renders call `CaptureFromDefaultFramebuffer(...)` afterwards.
- The cache snapshot key and invalidation rules track viewport size, camera fingerprint (`ComputeCameraFingerprint`), `ConfigManager::GetHiddenLayers()` and `Viewer3DController::GetSceneVersion()`, matching the requested criteria (camera change, hidden layers, scene version, resize).
- Registered the new source in `viewer3d/CMakeLists.txt` and added a `std::unique_ptr<BasePassFramebufferCache>` member to `Viewer3DPanel` with GL-context-safe construction and destruction.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (OK).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (OK).
- Attempted `cmake -S . -B build` in this environment which failed to configure because the `wxWidgets` development packages are not available here, so a full build could not be completed in the CI-like sandbox (environment issue, not code error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebdef7b94483248fa0b03c6308936c)