### PR TITLE
viewer3d: move selection/highlight drawing to dedicated overlay pass

### DIFF
--- a/viewer3d/CMakeLists.txt
+++ b/viewer3d/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/render/opaque_pass_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/perastage_svg_symbol_builder.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/opaque_truss_pass.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/render/selection_overlay_pass.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/render_pipeline.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/viewer3d_render_style.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/scenerenderer.cpp

--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -433,18 +433,7 @@ void OpaqueFixturePass::Render(
     if (depthEnabled)
       glDisable(GL_DEPTH_TEST);
   }
-  std::vector<std::string> drawFixtureUuids = visibleSet.fixtureUuids;
-  if (!controller.m_highlightUuid.empty()) {
-    const bool highlightAlreadyVisible =
-        std::find(drawFixtureUuids.begin(), drawFixtureUuids.end(),
-                  controller.m_highlightUuid) != drawFixtureUuids.end();
-    if (!highlightAlreadyVisible &&
-        fixtures.find(controller.m_highlightUuid) != fixtures.end()) {
-      drawFixtureUuids.push_back(controller.m_highlightUuid);
-    }
-  }
-
-  for (const auto &uuid : drawFixtureUuids) {
+  for (const auto &uuid : visibleSet.fixtureUuids) {
     auto fixtureIt = fixtures.find(uuid);
     if (fixtureIt == fixtures.end())
       continue;
@@ -459,10 +448,8 @@ void OpaqueFixturePass::Render(
       controller.m_captureCanvas->SetSourceKey(fixtureCaptureKey);
     }
 
-    bool highlight = (!controller.m_highlightUuid.empty() &&
-                      uuid == controller.m_highlightUuid);
-    bool selected = (controller.m_selectedUuids.find(uuid) !=
-                     controller.m_selectedUuids.end());
+    const bool highlight = false;
+    const bool selected = false;
 
     float matrix[16];
     MatrixToArray(f.transform, matrix);

--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -448,8 +448,12 @@ void OpaqueFixturePass::Render(
       controller.m_captureCanvas->SetSourceKey(fixtureCaptureKey);
     }
 
-    const bool highlight = false;
-    const bool selected = false;
+    const bool highlight =
+        context.selectionOverlayPass && !controller.m_highlightUuid.empty() &&
+        uuid == controller.m_highlightUuid;
+    const bool selected = context.selectionOverlayPass &&
+                          controller.m_selectedUuids.find(uuid) !=
+                              controller.m_selectedUuids.end();
 
     float matrix[16];
     MatrixToArray(f.transform, matrix);

--- a/viewer3d/render/opaque_object_pass.cpp
+++ b/viewer3d/render/opaque_object_pass.cpp
@@ -235,8 +235,12 @@ void OpaqueObjectPass::Render(
       controller.m_captureCanvas->SetSourceKey(objectCaptureKey);
     }
 
-    const bool highlight = false;
-    const bool selected = false;
+    const bool highlight =
+        context.selectionOverlayPass && !controller.m_highlightUuid.empty() &&
+        uuid == controller.m_highlightUuid;
+    const bool selected = context.selectionOverlayPass &&
+                          controller.m_selectedUuids.find(uuid) !=
+                              controller.m_selectedUuids.end();
 
     float matrix[16];
     MatrixToArray(m.transform, matrix);

--- a/viewer3d/render/opaque_object_pass.cpp
+++ b/viewer3d/render/opaque_object_pass.cpp
@@ -220,18 +220,7 @@ void OpaqueObjectPass::Render(
   const auto &sceneObjects = SceneDataManager::Instance().GetSceneObjects();
 
   glShadeModel((context.texturedStyle && !wireframe) ? GL_SMOOTH : GL_FLAT);
-  std::vector<std::string> drawObjectUuids = visibleSet.objectUuids;
-  if (!controller.m_highlightUuid.empty()) {
-    const bool highlightAlreadyVisible =
-        std::find(drawObjectUuids.begin(), drawObjectUuids.end(),
-                  controller.m_highlightUuid) != drawObjectUuids.end();
-    if (!highlightAlreadyVisible &&
-        sceneObjects.find(controller.m_highlightUuid) != sceneObjects.end()) {
-      drawObjectUuids.push_back(controller.m_highlightUuid);
-    }
-  }
-
-  for (const auto &uuid : drawObjectUuids) {
+  for (const auto &uuid : visibleSet.objectUuids) {
     auto sceneIt = sceneObjects.find(uuid);
     if (sceneIt == sceneObjects.end())
       continue;
@@ -246,10 +235,8 @@ void OpaqueObjectPass::Render(
       controller.m_captureCanvas->SetSourceKey(objectCaptureKey);
     }
 
-    bool highlight = (!controller.m_highlightUuid.empty() &&
-                      uuid == controller.m_highlightUuid);
-    bool selected = (controller.m_selectedUuids.find(uuid) !=
-                     controller.m_selectedUuids.end());
+    const bool highlight = false;
+    const bool selected = false;
 
     float matrix[16];
     MatrixToArray(m.transform, matrix);

--- a/viewer3d/render/opaque_truss_pass.cpp
+++ b/viewer3d/render/opaque_truss_pass.cpp
@@ -81,18 +81,7 @@ void OpaqueTrussPass::Render(
   const auto &trusses = SceneDataManager::Instance().GetTrusses();
 
   glShadeModel(GL_SMOOTH);
-  std::vector<std::string> drawTrussUuids = visibleSet.trussUuids;
-  if (!controller.m_highlightUuid.empty()) {
-    const bool highlightAlreadyVisible =
-        std::find(drawTrussUuids.begin(), drawTrussUuids.end(),
-                  controller.m_highlightUuid) != drawTrussUuids.end();
-    if (!highlightAlreadyVisible &&
-        trusses.find(controller.m_highlightUuid) != trusses.end()) {
-      drawTrussUuids.push_back(controller.m_highlightUuid);
-    }
-  }
-
-  for (const auto &uuid : drawTrussUuids) {
+  for (const auto &uuid : visibleSet.trussUuids) {
     auto trussIt = trusses.find(uuid);
     if (trussIt == trusses.end())
       continue;
@@ -107,10 +96,8 @@ void OpaqueTrussPass::Render(
       controller.m_captureCanvas->SetSourceKey(trussCaptureKey);
     }
 
-    bool highlight = (!controller.m_highlightUuid.empty() &&
-                      uuid == controller.m_highlightUuid);
-    bool selected = (controller.m_selectedUuids.find(uuid) !=
-                     controller.m_selectedUuids.end());
+    const bool highlight = false;
+    const bool selected = false;
 
     float matrix[16];
     MatrixToArray(t.transform, matrix);

--- a/viewer3d/render/opaque_truss_pass.cpp
+++ b/viewer3d/render/opaque_truss_pass.cpp
@@ -96,8 +96,12 @@ void OpaqueTrussPass::Render(
       controller.m_captureCanvas->SetSourceKey(trussCaptureKey);
     }
 
-    const bool highlight = false;
-    const bool selected = false;
+    const bool highlight =
+        context.selectionOverlayPass && !controller.m_highlightUuid.empty() &&
+        uuid == controller.m_highlightUuid;
+    const bool selected = context.selectionOverlayPass &&
+                          controller.m_selectedUuids.find(uuid) !=
+                              controller.m_selectedUuids.end();
 
     float matrix[16];
     MatrixToArray(t.transform, matrix);

--- a/viewer3d/render/selection_overlay_pass.cpp
+++ b/viewer3d/render/selection_overlay_pass.cpp
@@ -1,5 +1,13 @@
 #include "selection_overlay_pass.h"
 
+#include <GL/glew.h>
+#ifdef __APPLE__
+#define GL_SILENCE_DEPRECATION
+#include <OpenGL/gl.h>
+#else
+#include <GL/gl.h>
+#endif
+
 #include <algorithm>
 #include <array>
 #include <string_view>
@@ -145,10 +153,14 @@ void SelectionOverlayPass::Render(Viewer3DController &controller,
   RenderFrameContext overlayContext = context;
   overlayContext.skipCapture = true;
   overlayContext.selectionOverlayPass = true;
+  GLint previousDepthFunc = GL_LESS;
+  glGetIntegerv(GL_DEPTH_FUNC, &previousDepthFunc);
+  glDepthFunc(GL_LEQUAL);
   OpaqueObjectPass::Render(controller, overlayContext, overlaySet, getLayerColor,
                            resolveSymbolView, getPickColor);
   OpaqueTrussPass::Render(controller, overlayContext, overlaySet, getLayerColor,
                           resolveSymbolView, getPickColor);
   OpaqueFixturePass::Render(controller, overlayContext, overlaySet, getTypeColor,
                             getLayerColor, resolveSymbolView, getPickColor);
+  glDepthFunc(static_cast<GLenum>(previousDepthFunc));
 }

--- a/viewer3d/render/selection_overlay_pass.cpp
+++ b/viewer3d/render/selection_overlay_pass.cpp
@@ -1,0 +1,153 @@
+#include "selection_overlay_pass.h"
+
+#include <algorithm>
+#include <array>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "configmanager.h"
+#include "opaque_fixture_pass.h"
+#include "opaque_object_pass.h"
+#include "opaque_truss_pass.h"
+#include "scenedatamanager.h"
+#include "viewer3dcontroller.h"
+
+namespace {
+std::array<float, 3> MakeDeterministicColor(std::string_view key) {
+  const uint64_t hash = std::hash<std::string_view>{}(key);
+  const uint8_t r = static_cast<uint8_t>(64u + (hash & 0x7Fu));
+  const uint8_t g = static_cast<uint8_t>(64u + ((hash >> 8) & 0x7Fu));
+  const uint8_t b = static_cast<uint8_t>(64u + ((hash >> 16) & 0x7Fu));
+  return {static_cast<float>(r) / 255.0f, static_cast<float>(g) / 255.0f,
+          static_cast<float>(b) / 255.0f};
+}
+
+bool HexToRGB(const std::string &hex, float &r, float &g, float &b) {
+  auto hexNibble = [](char ch) -> int {
+    if (ch >= '0' && ch <= '9')
+      return ch - '0';
+    if (ch >= 'a' && ch <= 'f')
+      return 10 + (ch - 'a');
+    if (ch >= 'A' && ch <= 'F')
+      return 10 + (ch - 'A');
+    return -1;
+  };
+  auto hexPairToInt = [&](char hi, char lo) -> int {
+    const int hiNibble = hexNibble(hi);
+    const int loNibble = hexNibble(lo);
+    if (hiNibble < 0 || loNibble < 0)
+      return -1;
+    return (hiNibble << 4) | loNibble;
+  };
+  if (hex.size() != 7 || hex[0] != '#')
+    return false;
+  const int ri = hexPairToInt(hex[1], hex[2]);
+  const int gi = hexPairToInt(hex[3], hex[4]);
+  const int bi = hexPairToInt(hex[5], hex[6]);
+  if (ri < 0 || gi < 0 || bi < 0)
+    return false;
+  r = static_cast<float>(ri) / 255.0f;
+  g = static_cast<float>(gi) / 255.0f;
+  b = static_cast<float>(bi) / 255.0f;
+  return true;
+}
+
+bool ContainsUuid(const std::vector<std::string> &uuids, const std::string &uuid) {
+  return std::find(uuids.begin(), uuids.end(), uuid) != uuids.end();
+}
+
+void AppendUuidIfRenderable(const std::string &uuid,
+                            const std::unordered_map<std::string, Fixture> &fixtures,
+                            const std::unordered_map<std::string, Truss> &trusses,
+                            const std::unordered_map<std::string, SceneObject> &objects,
+                            Viewer3DVisibleSet &overlaySet) {
+  if (uuid.empty())
+    return;
+
+  if (fixtures.find(uuid) != fixtures.end() && !ContainsUuid(overlaySet.fixtureUuids, uuid)) {
+    overlaySet.fixtureUuids.push_back(uuid);
+    return;
+  }
+  if (trusses.find(uuid) != trusses.end() && !ContainsUuid(overlaySet.trussUuids, uuid)) {
+    overlaySet.trussUuids.push_back(uuid);
+    return;
+  }
+  if (objects.find(uuid) != objects.end() && !ContainsUuid(overlaySet.objectUuids, uuid)) {
+    overlaySet.objectUuids.push_back(uuid);
+    return;
+  }
+}
+} // namespace
+
+void SelectionOverlayPass::Render(Viewer3DController &controller,
+                                  const RenderFrameContext &context,
+                                  const Viewer3DVisibleSet &visibleSet) {
+  const auto &fixtures = SceneDataManager::Instance().GetFixtures();
+  const auto &trusses = SceneDataManager::Instance().GetTrusses();
+  const auto &objects = SceneDataManager::Instance().GetSceneObjects();
+
+  Viewer3DVisibleSet overlaySet;
+  const auto appendFromVisibility = [&](const std::vector<std::string> &sourceUuids,
+                                        std::vector<std::string> &targetUuids) {
+    for (const auto &uuid : sourceUuids) {
+      if (uuid == controller.m_highlightUuid ||
+          controller.m_selectedUuids.find(uuid) != controller.m_selectedUuids.end()) {
+        targetUuids.push_back(uuid);
+      }
+    }
+  };
+
+  appendFromVisibility(visibleSet.fixtureUuids, overlaySet.fixtureUuids);
+  appendFromVisibility(visibleSet.trussUuids, overlaySet.trussUuids);
+  appendFromVisibility(visibleSet.objectUuids, overlaySet.objectUuids);
+
+  AppendUuidIfRenderable(controller.m_highlightUuid, fixtures, trusses, objects,
+                         overlaySet);
+
+  for (const auto &uuid : controller.m_selectedUuids) {
+    AppendUuidIfRenderable(uuid, fixtures, trusses, objects, overlaySet);
+  }
+
+  if (overlaySet.Empty())
+    return;
+
+  auto getTypeColor = [&](const std::string &key, const std::string &hex) {
+    std::array<float, 3> c;
+    if (!hex.empty() && HexToRGB(hex, c[0], c[1], c[2]))
+      return c;
+    return MakeDeterministicColor("type:" + key);
+  };
+  auto getLayerColor = [&](const std::string &key) {
+    std::array<float, 3> c;
+    auto opt = ConfigManager::Get().GetLayerColor(key);
+    if (opt && HexToRGB(*opt, c[0], c[1], c[2]))
+      return c;
+    return MakeDeterministicColor("layer:" + key);
+  };
+  auto resolveSymbolView = [](Viewer2DView viewKind) {
+    switch (viewKind) {
+    case Viewer2DView::Top:
+      return SymbolViewKind::Top;
+    case Viewer2DView::Front:
+      return SymbolViewKind::Front;
+    case Viewer2DView::Side:
+      return SymbolViewKind::Left;
+    case Viewer2DView::Bottom:
+    default:
+      return SymbolViewKind::Bottom;
+    }
+  };
+  auto getPickColor = [](const std::string &) {
+    return std::array<float, 3>{1.0f, 1.0f, 1.0f};
+  };
+
+  RenderFrameContext overlayContext = context;
+  overlayContext.skipCapture = true;
+  OpaqueObjectPass::Render(controller, overlayContext, overlaySet, getLayerColor,
+                           resolveSymbolView, getPickColor);
+  OpaqueTrussPass::Render(controller, overlayContext, overlaySet, getLayerColor,
+                          resolveSymbolView, getPickColor);
+  OpaqueFixturePass::Render(controller, overlayContext, overlaySet, getTypeColor,
+                            getLayerColor, resolveSymbolView, getPickColor);
+}

--- a/viewer3d/render/selection_overlay_pass.cpp
+++ b/viewer3d/render/selection_overlay_pass.cpp
@@ -144,6 +144,7 @@ void SelectionOverlayPass::Render(Viewer3DController &controller,
 
   RenderFrameContext overlayContext = context;
   overlayContext.skipCapture = true;
+  overlayContext.selectionOverlayPass = true;
   OpaqueObjectPass::Render(controller, overlayContext, overlaySet, getLayerColor,
                            resolveSymbolView, getPickColor);
   OpaqueTrussPass::Render(controller, overlayContext, overlaySet, getLayerColor,

--- a/viewer3d/render/selection_overlay_pass.h
+++ b/viewer3d/render/selection_overlay_pass.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "viewer3d_types.h"
+
+class Viewer3DController;
+
+class SelectionOverlayPass {
+public:
+  static void Render(Viewer3DController &controller,
+                     const RenderFrameContext &context,
+                     const Viewer3DVisibleSet &visibleSet);
+};

--- a/viewer3d/viewer3d_types.h
+++ b/viewer3d/viewer3d_types.h
@@ -76,6 +76,7 @@ struct RenderFrameContext {
   bool skipCapture = false;
   bool skipOutlinesForCurrentFrame = false;
   bool idOnlyPass = false;
+  bool selectionOverlayPass = false;
 
   bool colorByFixtureType = false;
   bool colorByLayer = false;

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -60,6 +60,7 @@
 #include "hoist_symbol_renderer.h"
 #include "opaque_object_pass.h"
 #include "opaque_truss_pass.h"
+#include "selection_overlay_pass.h"
 #include "bounds_cache_system.h"
 #include "visibilitysystem.h"
 #include "label_render_system.h"
@@ -1212,6 +1213,7 @@ void Viewer3DController::RenderOpaqueFrame(const RenderFrameContext &context,
                           resolveSymbolView, getPickColor);
   OpaqueFixturePass::Render(*this, context, visibleSet, getTypeColor,
                             getLayerColor, resolveSymbolView, getPickColor);
+  SelectionOverlayPass::Render(*this, context, visibleSet);
   HoistSymbolRenderer::Render(*this, context);
 }
 

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -50,6 +50,7 @@ class LabelRenderSystem;
 class OpaqueFixturePass;
 class OpaqueTrussPass;
 class OpaqueObjectPass;
+class SelectionOverlayPass;
 class RenderPipeline;
 
 struct OverlayTextLabel {
@@ -341,6 +342,7 @@ private:
   friend class OpaqueFixturePass;
   friend class OpaqueTrussPass;
   friend class OpaqueObjectPass;
+  friend class SelectionOverlayPass;
   friend class IdPickPass;
   friend class RenderPipeline;
 };


### PR DESCRIPTION
### Motivation
- Reduce cost and responsibility mixing by moving highlight/selection drawing out of the heavy opaque passes into a small, cheap overlay pass that only redraws the highlighted/selected UUIDs.
- Keep the opaque passes focused on base geometry and simplify per-item logic for selection/highlight.
- Technical note: `viewer3dcontroller.cpp` remains a hotspot; next split should extract render orchestration (pipeline/phase wiring) into a `render/` orchestrator module if further growth occurs. 

### Description
- Added `SelectionOverlayPass` in `viewer3d/render/selection_overlay_pass.h` and `viewer3d/render/selection_overlay_pass.cpp` which builds a minimal `Viewer3DVisibleSet` containing only highlighted/selected UUIDs and re-renders those items with capture disabled.
- Integrated the new pass into the render orchestration by calling `SelectionOverlayPass::Render(...)` from `Viewer3DController::RenderOpaqueFrame` immediately after the base opaque passes.
- Simplified base opaque passes by removing their per-item highlight/selection handling so `opaque_fixture_pass`, `opaque_truss_pass` and `opaque_object_pass` render only the provided `visibleSet` without selection flags.
- Registered the new source in `viewer3d/CMakeLists.txt` and added the `SelectionOverlayPass` forward-declaration and friendship in `viewer3d/viewer3dcontroller.h` to allow the overlay to access controller internals where necessary.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (OK).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (OK).
- Attempted full project configure/build with `cmake -S . -B build && cmake --build build -j4` but configuration failed in this environment because `wxWidgets` was not found by CMake (build not completed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebea00b1c88324be8f17fc2eaf5702)