### PR TITLE
Screen-space selection outline pass with mask rendering and fallback flag

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -194,6 +194,8 @@ ConfigManager::ConfigManager() {
                    1.0f);
   RegisterVariable("viewer3d_ambient_occlusion_strength", "float", 1.0f,
                    0.0f, 1.0f);
+  RegisterVariable("viewer3d_selection_outline_screenspace", "float", 1.0f,
+                   0.0f, 1.0f);
   RegisterVariable("render_culling_enabled", "float", 1.0f, 0.0f, 1.0f);
   RegisterVariable("render_culling_min_pixels_3d", "float", 2.0f, 0.0f,
                    64.0f);

--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -708,7 +708,8 @@ void OpaqueFixturePass::Render(
           controller.DrawMeshWithOutline(obj.mesh, partR, partG, partB,
                                          RENDER_SCALE, highlight, selected, cx,
                                          cy, cz, wireframe, mode, applyCapture,
-                                         drawUnlit, partMatrix);
+                                         drawUnlit, partMatrix,
+                                         context.selectionMaskPass);
           glPopMatrix();
         }
       } else {
@@ -722,7 +723,7 @@ void OpaqueFixturePass::Render(
                                        highlight, selected, cx, cy, cz,
                                        fallbackWireframe, mode,
                                        applyFixtureCapture, fallbackUnlit,
-                                       matrix);
+                                       matrix, context.selectionMaskPass);
       }
     };
 

--- a/viewer3d/render/opaque_object_pass.cpp
+++ b/viewer3d/render/opaque_object_pass.cpp
@@ -384,7 +384,7 @@ void OpaqueObjectPass::Render(
                                              isHighlighted, isSelected, cx, cy,
                                              cz, wireframe, mode,
                                              partCaptureTransform, false,
-                                             partMatrix,
+                                             partMatrix, context.selectionMaskPass,
                                              disableDepthBias);
               glPopMatrix();
             }
@@ -403,7 +403,7 @@ void OpaqueObjectPass::Render(
             controller.DrawMeshWithOutline(
                 fallbackMesh, r, g, b, 0.3f, isHighlighted, isSelected, cx, cy,
                 cz, fallbackWireframe, mode, captureTransformFn,
-                useUnlitFallbackFill, matrix,
+                useUnlitFallbackFill, matrix, context.selectionMaskPass,
                 disableDepthBias);
           }
         };

--- a/viewer3d/render/opaque_truss_pass.cpp
+++ b/viewer3d/render/opaque_truss_pass.cpp
@@ -169,7 +169,8 @@ void OpaqueTrussPass::Render(
             controller.DrawMeshWithOutline(*trussMesh, r, g, b, RENDER_SCALE,
                                            isHighlighted, isSelected, cx, cy,
                                            cz, wireframe, mode,
-                                           captureTransformFn, false, matrix);
+                                           captureTransformFn, false, matrix,
+                                           context.selectionMaskPass);
           } else {
             controller.DrawWireframeBox(trussLen, trussHei, trussWid, r, g, b,
                                         isHighlighted, isSelected, wireframe,

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -236,7 +236,12 @@ void SceneRenderer::DrawMeshWithOutline(
       const GLboolean lightingWasEnabled = glIsEnabled(GL_LIGHTING);
       if (lightingWasEnabled)
         glDisable(GL_LIGHTING);
-      m_controller.SetGLColor(1.0f, 1.0f, 1.0f);
+      if (highlight)
+        m_controller.SetGLColor(0.0f, 1.0f, 0.0f);
+      else if (selected)
+        m_controller.SetGLColor(0.0f, 1.0f, 1.0f);
+      else
+        m_controller.SetGLColor(1.0f, 1.0f, 1.0f);
       DrawMesh(mesh, scale, modelMatrix);
       if (lightingWasEnabled)
         glEnable(GL_LIGHTING);

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -213,7 +213,8 @@ void SceneRenderer::DrawMeshWithOutline(
     Viewer2DRenderMode mode,
     const std::function<std::array<float, 3>(const std::array<float, 3> &)> &
         captureTransform,
-    bool unlit, const float *modelMatrix, bool disableDepthBias) {
+    bool unlit, const float *modelMatrix, bool selectionMaskPass,
+    bool disableDepthBias) {
   (void)cx;
   (void)cy;
   (void)cz;
@@ -229,6 +230,20 @@ void SceneRenderer::DrawMeshWithOutline(
     if (forceDisableTexture && texture2DWasEnabled)
       glEnable(GL_TEXTURE_2D);
   };
+
+  if (selectionMaskPass) {
+    if (!m_controller.IsCaptureOnly()) {
+      const GLboolean lightingWasEnabled = glIsEnabled(GL_LIGHTING);
+      if (lightingWasEnabled)
+        glDisable(GL_LIGHTING);
+      m_controller.SetGLColor(1.0f, 1.0f, 1.0f);
+      DrawMesh(mesh, scale, modelMatrix);
+      if (lightingWasEnabled)
+        glEnable(GL_LIGHTING);
+    }
+    restoreTextureState();
+    return;
+  }
 
   if (wireframe) {
     float lineWidth =

--- a/viewer3d/render/scenerenderer.h
+++ b/viewer3d/render/scenerenderer.h
@@ -14,7 +14,7 @@ public:
       bool selected, float cx, float cy, float cz, bool wireframe,
       Viewer2DRenderMode mode,
       const std::function<std::array<float, 3>(const std::array<float, 3> &)> &captureTransform,
-      bool unlit, const float *modelMatrix,
+      bool unlit, const float *modelMatrix, bool selectionMaskPass = false,
       bool disableDepthBias = false);
   void DrawMeshWireframe(
       const Mesh &mesh, float scale,

--- a/viewer3d/render/selection_overlay_pass.cpp
+++ b/viewer3d/render/selection_overlay_pass.cpp
@@ -10,11 +10,13 @@
 
 #include <algorithm>
 #include <array>
+#include <string>
 #include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 
 #include "configmanager.h"
+#include "logger.h"
 #include "opaque_fixture_pass.h"
 #include "opaque_object_pass.h"
 #include "opaque_truss_pass.h"
@@ -160,6 +162,16 @@ struct ScreenSpaceOutlineResources {
     if (compileOk == GL_TRUE)
       return shader;
 
+    GLint infoLogLength = 0;
+    glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &infoLogLength);
+    if (infoLogLength > 1) {
+      std::string infoLog(static_cast<size_t>(infoLogLength), '\0');
+      glGetShaderInfoLog(shader, infoLogLength, nullptr, infoLog.data());
+      Logger::Instance().Log(Logger::Level::Warn,
+                             std::string("Selection outline shader compilation failed: ") +
+                                 infoLog);
+    }
+
     glDeleteShader(shader);
     return 0;
   }
@@ -223,6 +235,15 @@ struct ScreenSpaceOutlineResources {
     GLint linkOk = GL_FALSE;
     glGetProgramiv(program, GL_LINK_STATUS, &linkOk);
     if (linkOk != GL_TRUE) {
+      GLint infoLogLength = 0;
+      glGetProgramiv(program, GL_INFO_LOG_LENGTH, &infoLogLength);
+      if (infoLogLength > 1) {
+        std::string infoLog(static_cast<size_t>(infoLogLength), '\0');
+        glGetProgramInfoLog(program, infoLogLength, nullptr, infoLog.data());
+        Logger::Instance().Log(Logger::Level::Warn,
+                               std::string("Selection outline shader link failed: ") +
+                                   infoLog);
+      }
       glDeleteProgram(program);
       program = 0;
       return false;
@@ -333,6 +354,9 @@ bool UseScreenSpaceOverlay() {
 void RenderScreenSpaceOverlay(Viewer3DController &controller,
                               const RenderFrameContext &context,
                               const Viewer3DVisibleSet &overlaySet) {
+  static bool loggedFramebufferFallback = false;
+  static bool loggedShaderFallback = false;
+
   GLint viewport[4] = {0, 0, 0, 0};
   glGetIntegerv(GL_VIEWPORT, viewport);
   const int width = viewport[2];
@@ -343,7 +367,23 @@ void RenderScreenSpaceOverlay(Viewer3DController &controller,
   }
 
   auto &resources = OutlineResources();
-  if (!resources.EnsureFramebuffer(width, height) || !resources.EnsureProgram()) {
+  if (!resources.EnsureFramebuffer(width, height)) {
+    if (!loggedFramebufferFallback) {
+      Logger::Instance().Log(
+          Logger::Level::Warn,
+          "Selection outline screen-space disabled: failed to initialize mask framebuffer; using legacy fallback");
+      loggedFramebufferFallback = true;
+    }
+    RenderLegacyOverlay(controller, context, overlaySet);
+    return;
+  }
+  if (!resources.EnsureProgram()) {
+    if (!loggedShaderFallback) {
+      Logger::Instance().Log(
+          Logger::Level::Warn,
+          "Selection outline screen-space disabled: failed to initialize shader program; using legacy fallback");
+      loggedShaderFallback = true;
+    }
     RenderLegacyOverlay(controller, context, overlaySet);
     return;
   }

--- a/viewer3d/render/selection_overlay_pass.cpp
+++ b/viewer3d/render/selection_overlay_pass.cpp
@@ -63,7 +63,8 @@ bool HexToRGB(const std::string &hex, float &r, float &g, float &b) {
   return true;
 }
 
-bool ContainsUuid(const std::vector<std::string> &uuids, const std::string &uuid) {
+bool ContainsUuid(const std::vector<std::string> &uuids,
+                  const std::string &uuid) {
   return std::find(uuids.begin(), uuids.end(), uuid) != uuids.end();
 }
 
@@ -75,15 +76,18 @@ void AppendUuidIfRenderable(const std::string &uuid,
   if (uuid.empty())
     return;
 
-  if (fixtures.find(uuid) != fixtures.end() && !ContainsUuid(overlaySet.fixtureUuids, uuid)) {
+  if (fixtures.find(uuid) != fixtures.end() &&
+      !ContainsUuid(overlaySet.fixtureUuids, uuid)) {
     overlaySet.fixtureUuids.push_back(uuid);
     return;
   }
-  if (trusses.find(uuid) != trusses.end() && !ContainsUuid(overlaySet.trussUuids, uuid)) {
+  if (trusses.find(uuid) != trusses.end() &&
+      !ContainsUuid(overlaySet.trussUuids, uuid)) {
     overlaySet.trussUuids.push_back(uuid);
     return;
   }
-  if (objects.find(uuid) != objects.end() && !ContainsUuid(overlaySet.objectUuids, uuid)) {
+  if (objects.find(uuid) != objects.end() &&
+      !ContainsUuid(overlaySet.objectUuids, uuid)) {
     overlaySet.objectUuids.push_back(uuid);
     return;
   }
@@ -96,6 +100,8 @@ struct ScreenSpaceOutlineResources {
   GLuint program = 0;
   GLint texelSizeUniform = -1;
   GLint outlineColorUniform = -1;
+  GLint fillAlphaUniform = -1;
+  GLint outlineAlphaUniform = -1;
   int width = 0;
   int height = 0;
 
@@ -130,8 +136,8 @@ struct ScreenSpaceOutlineResources {
     glBindTexture(GL_TEXTURE_2D, colorTexture);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA,
                  GL_UNSIGNED_BYTE, nullptr);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
@@ -167,9 +173,9 @@ struct ScreenSpaceOutlineResources {
     if (infoLogLength > 1) {
       std::string infoLog(static_cast<size_t>(infoLogLength), '\0');
       glGetShaderInfoLog(shader, infoLogLength, nullptr, infoLog.data());
-      Logger::Instance().Log(Logger::Level::Warn,
-                             std::string("Selection outline shader compilation failed: ") +
-                                 infoLog);
+      Logger::Instance().Log(
+          Logger::Level::Warn,
+          std::string("Selection outline shader compilation failed: ") + infoLog);
     }
 
     glDeleteShader(shader);
@@ -193,6 +199,8 @@ struct ScreenSpaceOutlineResources {
         "uniform sampler2D uMask;\n"
         "uniform vec2 uTexelSize;\n"
         "uniform vec3 uOutlineColor;\n"
+        "uniform float uFillAlpha;\n"
+        "uniform float uOutlineAlpha;\n"
         "varying vec2 vTexCoord;\n"
         "float sampleMask(vec2 uv) {\n"
         "  return texture2D(uMask, uv).r;\n"
@@ -209,9 +217,10 @@ struct ScreenSpaceOutlineResources {
         "  edge = max(edge, sampleMask(vTexCoord + vec2(uTexelSize.x, -uTexelSize.y)));\n"
         "  edge = max(edge, sampleMask(vTexCoord + vec2(-uTexelSize.x, uTexelSize.y)));\n"
         "  float outline = max(0.0, edge - center);\n"
-        "  if (outline <= 0.001)\n"
+        "  float alpha = max(center * uFillAlpha, outline * uOutlineAlpha);\n"
+        "  if (alpha <= 0.001)\n"
         "    discard;\n"
-        "  gl_FragColor = vec4(uOutlineColor, outline);\n"
+        "  gl_FragColor = vec4(uOutlineColor, alpha);\n"
         "}\n";
 
     const GLuint vertex = CompileShader(GL_VERTEX_SHADER, kVertexShader);
@@ -240,9 +249,9 @@ struct ScreenSpaceOutlineResources {
       if (infoLogLength > 1) {
         std::string infoLog(static_cast<size_t>(infoLogLength), '\0');
         glGetProgramInfoLog(program, infoLogLength, nullptr, infoLog.data());
-        Logger::Instance().Log(Logger::Level::Warn,
-                               std::string("Selection outline shader link failed: ") +
-                                   infoLog);
+        Logger::Instance().Log(
+            Logger::Level::Warn,
+            std::string("Selection outline shader link failed: ") + infoLog);
       }
       glDeleteProgram(program);
       program = 0;
@@ -251,7 +260,10 @@ struct ScreenSpaceOutlineResources {
 
     texelSizeUniform = glGetUniformLocation(program, "uTexelSize");
     outlineColorUniform = glGetUniformLocation(program, "uOutlineColor");
-    return texelSizeUniform >= 0 && outlineColorUniform >= 0;
+    fillAlphaUniform = glGetUniformLocation(program, "uFillAlpha");
+    outlineAlphaUniform = glGetUniformLocation(program, "uOutlineAlpha");
+    return texelSizeUniform >= 0 && outlineColorUniform >= 0 &&
+           fillAlphaUniform >= 0 && outlineAlphaUniform >= 0;
   }
 };
 
@@ -260,8 +272,17 @@ ScreenSpaceOutlineResources &OutlineResources() {
   return resources;
 }
 
-Viewer3DVisibleSet BuildOverlaySet(Viewer3DController &controller,
-                                   const Viewer3DVisibleSet &visibleSet) {
+struct OverlaySelectionSets {
+  Viewer3DVisibleSet highlightSet;
+  Viewer3DVisibleSet selectedSet;
+
+  bool Empty() const {
+    return highlightSet.Empty() && selectedSet.Empty();
+  }
+};
+
+OverlaySelectionSets BuildOverlaySets(Viewer3DController &controller,
+                                      const Viewer3DVisibleSet &visibleSet) {
   const auto &fixtures = SceneDataManager::Instance().GetFixtures();
   const auto &trusses = SceneDataManager::Instance().GetTrusses();
   const auto &objects = SceneDataManager::Instance().GetSceneObjects();
@@ -269,27 +290,34 @@ Viewer3DVisibleSet BuildOverlaySet(Viewer3DController &controller,
   const std::string &highlightUuid = controller.GetOverlayHighlightUuid();
   const auto &selectedUuids = controller.GetOverlaySelectedUuids();
 
-  Viewer3DVisibleSet overlaySet;
-  const auto appendFromVisibility = [&](const std::vector<std::string> &sourceUuids,
-                                        std::vector<std::string> &targetUuids) {
-    for (const auto &uuid : sourceUuids) {
-      if (uuid == highlightUuid ||
-          selectedUuids.find(uuid) != selectedUuids.end()) {
-        targetUuids.push_back(uuid);
-      }
-    }
-  };
+  OverlaySelectionSets sets;
+  const auto appendFromVisibility =
+      [&](const std::vector<std::string> &sourceUuids,
+          std::vector<std::string> &highlightTarget,
+          std::vector<std::string> &selectedTarget) {
+        for (const auto &uuid : sourceUuids) {
+          if (uuid == highlightUuid)
+            highlightTarget.push_back(uuid);
+          else if (selectedUuids.find(uuid) != selectedUuids.end())
+            selectedTarget.push_back(uuid);
+        }
+      };
 
-  appendFromVisibility(visibleSet.fixtureUuids, overlaySet.fixtureUuids);
-  appendFromVisibility(visibleSet.trussUuids, overlaySet.trussUuids);
-  appendFromVisibility(visibleSet.objectUuids, overlaySet.objectUuids);
+  appendFromVisibility(visibleSet.fixtureUuids, sets.highlightSet.fixtureUuids,
+                       sets.selectedSet.fixtureUuids);
+  appendFromVisibility(visibleSet.trussUuids, sets.highlightSet.trussUuids,
+                       sets.selectedSet.trussUuids);
+  appendFromVisibility(visibleSet.objectUuids, sets.highlightSet.objectUuids,
+                       sets.selectedSet.objectUuids);
 
-  AppendUuidIfRenderable(highlightUuid, fixtures, trusses, objects, overlaySet);
+  AppendUuidIfRenderable(highlightUuid, fixtures, trusses, objects,
+                         sets.highlightSet);
+  for (const auto &uuid : selectedUuids) {
+    if (uuid != highlightUuid)
+      AppendUuidIfRenderable(uuid, fixtures, trusses, objects, sets.selectedSet);
+  }
 
-  for (const auto &uuid : selectedUuids)
-    AppendUuidIfRenderable(uuid, fixtures, trusses, objects, overlaySet);
-
-  return overlaySet;
+  return sets;
 }
 
 void RenderSelectedGeometry(Viewer3DController &controller,
@@ -336,6 +364,8 @@ void RenderSelectedGeometry(Viewer3DController &controller,
 void RenderLegacyOverlay(Viewer3DController &controller,
                          const RenderFrameContext &context,
                          const Viewer3DVisibleSet &overlaySet) {
+  if (overlaySet.Empty())
+    return;
   RenderFrameContext overlayContext = context;
   overlayContext.skipCapture = true;
   overlayContext.selectionOverlayPass = true;
@@ -346,60 +376,19 @@ void RenderLegacyOverlay(Viewer3DController &controller,
   glDepthFunc(static_cast<GLenum>(previousDepthFunc));
 }
 
-bool UseScreenSpaceOverlay() {
+bool UseScreenSpaceOverlay(const RenderFrameContext &context) {
+  if (context.is2DViewer)
+    return false;
   return ConfigManager::Get().GetFloat("viewer3d_selection_outline_screenspace") >=
          0.5f;
 }
 
-void RenderScreenSpaceOverlay(Viewer3DController &controller,
-                              const RenderFrameContext &context,
-                              const Viewer3DVisibleSet &overlaySet) {
-  static bool loggedFramebufferFallback = false;
-  static bool loggedShaderFallback = false;
-
-  GLint viewport[4] = {0, 0, 0, 0};
-  glGetIntegerv(GL_VIEWPORT, viewport);
-  const int width = viewport[2];
-  const int height = viewport[3];
-  if (width <= 0 || height <= 0) {
-    RenderLegacyOverlay(controller, context, overlaySet);
+void RenderMask(Viewer3DController &controller, const RenderFrameContext &context,
+                const Viewer3DVisibleSet &overlaySet, int width, int height) {
+  if (overlaySet.Empty())
     return;
-  }
 
-  auto &resources = OutlineResources();
-  if (!resources.EnsureFramebuffer(width, height)) {
-    if (!loggedFramebufferFallback) {
-      Logger::Instance().Log(
-          Logger::Level::Warn,
-          "Selection outline screen-space disabled: failed to initialize mask framebuffer; using legacy fallback");
-      loggedFramebufferFallback = true;
-    }
-    RenderLegacyOverlay(controller, context, overlaySet);
-    return;
-  }
-  if (!resources.EnsureProgram()) {
-    if (!loggedShaderFallback) {
-      Logger::Instance().Log(
-          Logger::Level::Warn,
-          "Selection outline screen-space disabled: failed to initialize shader program; using legacy fallback");
-      loggedShaderFallback = true;
-    }
-    RenderLegacyOverlay(controller, context, overlaySet);
-    return;
-  }
-
-  GLint drawFramebuffer = 0;
-  glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &drawFramebuffer);
-
-  glBindFramebuffer(GL_READ_FRAMEBUFFER, drawFramebuffer);
-  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, resources.fbo);
-  glBlitFramebuffer(0, 0, width, height, 0, 0, width, height,
-                    GL_DEPTH_BUFFER_BIT, GL_NEAREST);
-
-  glBindFramebuffer(GL_FRAMEBUFFER, resources.fbo);
   glViewport(0, 0, width, height);
-  glDisable(GL_BLEND);
-  glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
   glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
   glClear(GL_COLOR_BUFFER_BIT);
 
@@ -411,35 +400,25 @@ void RenderScreenSpaceOverlay(Viewer3DController &controller,
   maskContext.selectionOverlayPass = false;
   maskContext.selectionMaskPass = true;
   maskContext.wireframe = false;
+
   glDepthFunc(GL_LEQUAL);
   RenderSelectedGeometry(controller, maskContext, overlaySet);
   glDepthFunc(static_cast<GLenum>(previousDepthFunc));
+}
 
-  glBindFramebuffer(GL_FRAMEBUFFER, drawFramebuffer);
-  glViewport(viewport[0], viewport[1], width, height);
-
-  const GLboolean depthWasEnabled = glIsEnabled(GL_DEPTH_TEST);
-  const GLboolean blendWasEnabled = glIsEnabled(GL_BLEND);
-  const GLboolean textureWasEnabled = glIsEnabled(GL_TEXTURE_2D);
-  GLint activeProgram = 0;
-  glGetIntegerv(GL_CURRENT_PROGRAM, &activeProgram);
-
-  glDisable(GL_DEPTH_TEST);
-  glEnable(GL_BLEND);
-  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-  glDisable(GL_LIGHTING);
-  glDisable(GL_CULL_FACE);
-
+void CompositeMaskToCurrentFramebuffer(const ScreenSpaceOutlineResources &resources,
+                                       int width, int height, float colorR,
+                                       float colorG, float colorB,
+                                       float fillAlpha, float outlineAlpha) {
   glUseProgram(resources.program);
   glActiveTexture(GL_TEXTURE0);
   glBindTexture(GL_TEXTURE_2D, resources.colorTexture);
   glUniform1i(glGetUniformLocation(resources.program, "uMask"), 0);
   glUniform2f(resources.texelSizeUniform, 1.0f / static_cast<float>(width),
               1.0f / static_cast<float>(height));
-  glUniform3f(resources.outlineColorUniform, 0.0f, 1.0f, 1.0f);
-
-  if (!textureWasEnabled)
-    glEnable(GL_TEXTURE_2D);
+  glUniform3f(resources.outlineColorUniform, colorR, colorG, colorB);
+  glUniform1f(resources.fillAlphaUniform, fillAlpha);
+  glUniform1f(resources.outlineAlphaUniform, outlineAlpha);
 
   glBegin(GL_QUADS);
   glTexCoord2f(0.0f, 0.0f);
@@ -451,8 +430,92 @@ void RenderScreenSpaceOverlay(Viewer3DController &controller,
   glTexCoord2f(0.0f, 1.0f);
   glVertex2f(-1.0f, 1.0f);
   glEnd();
+}
+
+void RenderScreenSpaceOverlay(Viewer3DController &controller,
+                              const RenderFrameContext &context,
+                              const OverlaySelectionSets &overlaySets) {
+  static bool loggedFramebufferFallback = false;
+  static bool loggedShaderFallback = false;
+
+  GLint viewport[4] = {0, 0, 0, 0};
+  glGetIntegerv(GL_VIEWPORT, viewport);
+  const int width = viewport[2];
+  const int height = viewport[3];
+  if (width <= 0 || height <= 0) {
+    RenderLegacyOverlay(controller, context, overlaySets.selectedSet);
+    RenderLegacyOverlay(controller, context, overlaySets.highlightSet);
+    return;
+  }
+
+  auto &resources = OutlineResources();
+  if (!resources.EnsureFramebuffer(width, height)) {
+    if (!loggedFramebufferFallback) {
+      Logger::Instance().Log(
+          Logger::Level::Warn,
+          "Selection outline screen-space disabled: failed to initialize mask framebuffer; using legacy fallback");
+      loggedFramebufferFallback = true;
+    }
+    RenderLegacyOverlay(controller, context, overlaySets.selectedSet);
+    RenderLegacyOverlay(controller, context, overlaySets.highlightSet);
+    return;
+  }
+  if (!resources.EnsureProgram()) {
+    if (!loggedShaderFallback) {
+      Logger::Instance().Log(
+          Logger::Level::Warn,
+          "Selection outline screen-space disabled: failed to initialize shader program; using legacy fallback");
+      loggedShaderFallback = true;
+    }
+    RenderLegacyOverlay(controller, context, overlaySets.selectedSet);
+    RenderLegacyOverlay(controller, context, overlaySets.highlightSet);
+    return;
+  }
+
+  GLint drawFramebuffer = 0;
+  glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &drawFramebuffer);
+
+  glBindFramebuffer(GL_READ_FRAMEBUFFER, drawFramebuffer);
+  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, resources.fbo);
+  glBlitFramebuffer(0, 0, width, height, 0, 0, width, height,
+                    GL_DEPTH_BUFFER_BIT, GL_NEAREST);
+
+  glBindFramebuffer(GL_FRAMEBUFFER, drawFramebuffer);
+  glViewport(viewport[0], viewport[1], width, height);
+
+  const GLboolean depthWasEnabled = glIsEnabled(GL_DEPTH_TEST);
+  const GLboolean blendWasEnabled = glIsEnabled(GL_BLEND);
+  const GLboolean cullWasEnabled = glIsEnabled(GL_CULL_FACE);
+  const GLboolean lightingWasEnabled = glIsEnabled(GL_LIGHTING);
+  const GLboolean textureWasEnabled = glIsEnabled(GL_TEXTURE_2D);
+  GLint activeProgram = 0;
+  glGetIntegerv(GL_CURRENT_PROGRAM, &activeProgram);
+
+  glDisable(GL_DEPTH_TEST);
+  glEnable(GL_BLEND);
+  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+  glDisable(GL_LIGHTING);
+  glDisable(GL_CULL_FACE);
+  if (!textureWasEnabled)
+    glEnable(GL_TEXTURE_2D);
+
+  glBindFramebuffer(GL_FRAMEBUFFER, resources.fbo);
+  glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+  RenderMask(controller, context, overlaySets.selectedSet, width, height);
+
+  glBindFramebuffer(GL_FRAMEBUFFER, drawFramebuffer);
+  CompositeMaskToCurrentFramebuffer(resources, width, height, 0.0f, 1.0f, 1.0f,
+                                    0.20f, 1.0f);
+
+  glBindFramebuffer(GL_FRAMEBUFFER, resources.fbo);
+  RenderMask(controller, context, overlaySets.highlightSet, width, height);
+
+  glBindFramebuffer(GL_FRAMEBUFFER, drawFramebuffer);
+  CompositeMaskToCurrentFramebuffer(resources, width, height, 0.0f, 1.0f, 0.0f,
+                                    0.32f, 1.0f);
 
   glUseProgram(activeProgram);
+  glBindTexture(GL_TEXTURE_2D, 0);
 
   if (!textureWasEnabled)
     glDisable(GL_TEXTURE_2D);
@@ -464,20 +527,29 @@ void RenderScreenSpaceOverlay(Viewer3DController &controller,
     glEnable(GL_BLEND);
   else
     glDisable(GL_BLEND);
+  if (cullWasEnabled)
+    glEnable(GL_CULL_FACE);
+  else
+    glDisable(GL_CULL_FACE);
+  if (lightingWasEnabled)
+    glEnable(GL_LIGHTING);
+  else
+    glDisable(GL_LIGHTING);
 }
 } // namespace
 
 void SelectionOverlayPass::Render(Viewer3DController &controller,
                                   const RenderFrameContext &context,
                                   const Viewer3DVisibleSet &visibleSet) {
-  Viewer3DVisibleSet overlaySet = BuildOverlaySet(controller, visibleSet);
-  if (overlaySet.Empty())
+  OverlaySelectionSets overlaySets = BuildOverlaySets(controller, visibleSet);
+  if (overlaySets.Empty())
     return;
 
-  if (UseScreenSpaceOverlay()) {
-    RenderScreenSpaceOverlay(controller, context, overlaySet);
+  if (UseScreenSpaceOverlay(context)) {
+    RenderScreenSpaceOverlay(controller, context, overlaySets);
     return;
   }
 
-  RenderLegacyOverlay(controller, context, overlaySet);
+  RenderLegacyOverlay(controller, context, overlaySets.selectedSet);
+  RenderLegacyOverlay(controller, context, overlaySets.highlightSet);
 }

--- a/viewer3d/render/selection_overlay_pass.cpp
+++ b/viewer3d/render/selection_overlay_pass.cpp
@@ -63,8 +63,7 @@ bool HexToRGB(const std::string &hex, float &r, float &g, float &b) {
   return true;
 }
 
-bool ContainsUuid(const std::vector<std::string> &uuids,
-                  const std::string &uuid) {
+bool ContainsUuid(const std::vector<std::string> &uuids, const std::string &uuid) {
   return std::find(uuids.begin(), uuids.end(), uuid) != uuids.end();
 }
 
@@ -76,18 +75,15 @@ void AppendUuidIfRenderable(const std::string &uuid,
   if (uuid.empty())
     return;
 
-  if (fixtures.find(uuid) != fixtures.end() &&
-      !ContainsUuid(overlaySet.fixtureUuids, uuid)) {
+  if (fixtures.find(uuid) != fixtures.end() && !ContainsUuid(overlaySet.fixtureUuids, uuid)) {
     overlaySet.fixtureUuids.push_back(uuid);
     return;
   }
-  if (trusses.find(uuid) != trusses.end() &&
-      !ContainsUuid(overlaySet.trussUuids, uuid)) {
+  if (trusses.find(uuid) != trusses.end() && !ContainsUuid(overlaySet.trussUuids, uuid)) {
     overlaySet.trussUuids.push_back(uuid);
     return;
   }
-  if (objects.find(uuid) != objects.end() &&
-      !ContainsUuid(overlaySet.objectUuids, uuid)) {
+  if (objects.find(uuid) != objects.end() && !ContainsUuid(overlaySet.objectUuids, uuid)) {
     overlaySet.objectUuids.push_back(uuid);
     return;
   }
@@ -99,7 +95,6 @@ struct ScreenSpaceOutlineResources {
   GLuint depthBuffer = 0;
   GLuint program = 0;
   GLint texelSizeUniform = -1;
-  GLint outlineColorUniform = -1;
   GLint fillAlphaUniform = -1;
   GLint outlineAlphaUniform = -1;
   int width = 0;
@@ -173,9 +168,9 @@ struct ScreenSpaceOutlineResources {
     if (infoLogLength > 1) {
       std::string infoLog(static_cast<size_t>(infoLogLength), '\0');
       glGetShaderInfoLog(shader, infoLogLength, nullptr, infoLog.data());
-      Logger::Instance().Log(
-          Logger::Level::Warn,
-          std::string("Selection outline shader compilation failed: ") + infoLog);
+      Logger::Instance().Log(Logger::Level::Warn,
+                             std::string("Selection outline shader compilation failed: ") +
+                                 infoLog);
     }
 
     glDeleteShader(shader);
@@ -198,29 +193,40 @@ struct ScreenSpaceOutlineResources {
         "#version 120\n"
         "uniform sampler2D uMask;\n"
         "uniform vec2 uTexelSize;\n"
-        "uniform vec3 uOutlineColor;\n"
         "uniform float uFillAlpha;\n"
         "uniform float uOutlineAlpha;\n"
         "varying vec2 vTexCoord;\n"
-        "float sampleMask(vec2 uv) {\n"
-        "  return texture2D(uMask, uv).r;\n"
+        "float maskStrength(vec3 c) {\n"
+        "  return max(c.r, max(c.g, c.b));\n"
         "}\n"
         "void main() {\n"
-        "  float center = sampleMask(vTexCoord);\n"
-        "  float edge = 0.0;\n"
-        "  edge = max(edge, sampleMask(vTexCoord + vec2(uTexelSize.x, 0.0)));\n"
-        "  edge = max(edge, sampleMask(vTexCoord - vec2(uTexelSize.x, 0.0)));\n"
-        "  edge = max(edge, sampleMask(vTexCoord + vec2(0.0, uTexelSize.y)));\n"
-        "  edge = max(edge, sampleMask(vTexCoord - vec2(0.0, uTexelSize.y)));\n"
-        "  edge = max(edge, sampleMask(vTexCoord + uTexelSize));\n"
-        "  edge = max(edge, sampleMask(vTexCoord - uTexelSize));\n"
-        "  edge = max(edge, sampleMask(vTexCoord + vec2(uTexelSize.x, -uTexelSize.y)));\n"
-        "  edge = max(edge, sampleMask(vTexCoord + vec2(-uTexelSize.x, uTexelSize.y)));\n"
-        "  float outline = max(0.0, edge - center);\n"
+        "  vec3 centerColor = texture2D(uMask, vTexCoord).rgb;\n"
+        "  float center = maskStrength(centerColor);\n"
+        "  float neighborMax = 0.0;\n"
+        "  vec3 neighborColor = vec3(0.0);\n"
+        "  vec2 offsets[8];\n"
+        "  offsets[0] = vec2(uTexelSize.x, 0.0);\n"
+        "  offsets[1] = vec2(-uTexelSize.x, 0.0);\n"
+        "  offsets[2] = vec2(0.0, uTexelSize.y);\n"
+        "  offsets[3] = vec2(0.0, -uTexelSize.y);\n"
+        "  offsets[4] = vec2(uTexelSize.x, uTexelSize.y);\n"
+        "  offsets[5] = vec2(-uTexelSize.x, -uTexelSize.y);\n"
+        "  offsets[6] = vec2(uTexelSize.x, -uTexelSize.y);\n"
+        "  offsets[7] = vec2(-uTexelSize.x, uTexelSize.y);\n"
+        "  for (int i = 0; i < 8; ++i) {\n"
+        "    vec3 sampleColor = texture2D(uMask, vTexCoord + offsets[i]).rgb;\n"
+        "    float sampleMask = maskStrength(sampleColor);\n"
+        "    if (sampleMask > neighborMax) {\n"
+        "      neighborMax = sampleMask;\n"
+        "      neighborColor = sampleColor;\n"
+        "    }\n"
+        "  }\n"
+        "  float outline = max(0.0, neighborMax - center);\n"
         "  float alpha = max(center * uFillAlpha, outline * uOutlineAlpha);\n"
         "  if (alpha <= 0.001)\n"
         "    discard;\n"
-        "  gl_FragColor = vec4(uOutlineColor, alpha);\n"
+        "  vec3 color = center > 0.01 ? centerColor : neighborColor;\n"
+        "  gl_FragColor = vec4(color, alpha);\n"
         "}\n";
 
     const GLuint vertex = CompileShader(GL_VERTEX_SHADER, kVertexShader);
@@ -249,9 +255,9 @@ struct ScreenSpaceOutlineResources {
       if (infoLogLength > 1) {
         std::string infoLog(static_cast<size_t>(infoLogLength), '\0');
         glGetProgramInfoLog(program, infoLogLength, nullptr, infoLog.data());
-        Logger::Instance().Log(
-            Logger::Level::Warn,
-            std::string("Selection outline shader link failed: ") + infoLog);
+        Logger::Instance().Log(Logger::Level::Warn,
+                               std::string("Selection outline shader link failed: ") +
+                                   infoLog);
       }
       glDeleteProgram(program);
       program = 0;
@@ -259,11 +265,10 @@ struct ScreenSpaceOutlineResources {
     }
 
     texelSizeUniform = glGetUniformLocation(program, "uTexelSize");
-    outlineColorUniform = glGetUniformLocation(program, "uOutlineColor");
     fillAlphaUniform = glGetUniformLocation(program, "uFillAlpha");
     outlineAlphaUniform = glGetUniformLocation(program, "uOutlineAlpha");
-    return texelSizeUniform >= 0 && outlineColorUniform >= 0 &&
-           fillAlphaUniform >= 0 && outlineAlphaUniform >= 0;
+    return texelSizeUniform >= 0 && fillAlphaUniform >= 0 &&
+           outlineAlphaUniform >= 0;
   }
 };
 
@@ -272,17 +277,8 @@ ScreenSpaceOutlineResources &OutlineResources() {
   return resources;
 }
 
-struct OverlaySelectionSets {
-  Viewer3DVisibleSet highlightSet;
-  Viewer3DVisibleSet selectedSet;
-
-  bool Empty() const {
-    return highlightSet.Empty() && selectedSet.Empty();
-  }
-};
-
-OverlaySelectionSets BuildOverlaySets(Viewer3DController &controller,
-                                      const Viewer3DVisibleSet &visibleSet) {
+Viewer3DVisibleSet BuildOverlaySet(Viewer3DController &controller,
+                                   const Viewer3DVisibleSet &visibleSet) {
   const auto &fixtures = SceneDataManager::Instance().GetFixtures();
   const auto &trusses = SceneDataManager::Instance().GetTrusses();
   const auto &objects = SceneDataManager::Instance().GetSceneObjects();
@@ -290,34 +286,26 @@ OverlaySelectionSets BuildOverlaySets(Viewer3DController &controller,
   const std::string &highlightUuid = controller.GetOverlayHighlightUuid();
   const auto &selectedUuids = controller.GetOverlaySelectedUuids();
 
-  OverlaySelectionSets sets;
-  const auto appendFromVisibility =
-      [&](const std::vector<std::string> &sourceUuids,
-          std::vector<std::string> &highlightTarget,
-          std::vector<std::string> &selectedTarget) {
-        for (const auto &uuid : sourceUuids) {
-          if (uuid == highlightUuid)
-            highlightTarget.push_back(uuid);
-          else if (selectedUuids.find(uuid) != selectedUuids.end())
-            selectedTarget.push_back(uuid);
-        }
-      };
+  Viewer3DVisibleSet overlaySet;
+  const auto appendFromVisibility = [&](const std::vector<std::string> &sourceUuids,
+                                        std::vector<std::string> &targetUuids) {
+    for (const auto &uuid : sourceUuids) {
+      if (uuid == highlightUuid ||
+          selectedUuids.find(uuid) != selectedUuids.end()) {
+        targetUuids.push_back(uuid);
+      }
+    }
+  };
 
-  appendFromVisibility(visibleSet.fixtureUuids, sets.highlightSet.fixtureUuids,
-                       sets.selectedSet.fixtureUuids);
-  appendFromVisibility(visibleSet.trussUuids, sets.highlightSet.trussUuids,
-                       sets.selectedSet.trussUuids);
-  appendFromVisibility(visibleSet.objectUuids, sets.highlightSet.objectUuids,
-                       sets.selectedSet.objectUuids);
+  appendFromVisibility(visibleSet.fixtureUuids, overlaySet.fixtureUuids);
+  appendFromVisibility(visibleSet.trussUuids, overlaySet.trussUuids);
+  appendFromVisibility(visibleSet.objectUuids, overlaySet.objectUuids);
 
-  AppendUuidIfRenderable(highlightUuid, fixtures, trusses, objects,
-                         sets.highlightSet);
-  for (const auto &uuid : selectedUuids) {
-    if (uuid != highlightUuid)
-      AppendUuidIfRenderable(uuid, fixtures, trusses, objects, sets.selectedSet);
-  }
+  AppendUuidIfRenderable(highlightUuid, fixtures, trusses, objects, overlaySet);
+  for (const auto &uuid : selectedUuids)
+    AppendUuidIfRenderable(uuid, fixtures, trusses, objects, overlaySet);
 
-  return sets;
+  return overlaySet;
 }
 
 void RenderSelectedGeometry(Viewer3DController &controller,
@@ -376,19 +364,15 @@ void RenderLegacyOverlay(Viewer3DController &controller,
   glDepthFunc(static_cast<GLenum>(previousDepthFunc));
 }
 
-bool UseScreenSpaceOverlay(const RenderFrameContext &context) {
-  if (context.is2DViewer)
-    return false;
+bool UseScreenSpaceOverlay() {
   return ConfigManager::Get().GetFloat("viewer3d_selection_outline_screenspace") >=
          0.5f;
 }
 
 void RenderMask(Viewer3DController &controller, const RenderFrameContext &context,
                 const Viewer3DVisibleSet &overlaySet, int width, int height) {
-  if (overlaySet.Empty())
-    return;
-
   glViewport(0, 0, width, height);
+  glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
   glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
   glClear(GL_COLOR_BUFFER_BIT);
 
@@ -397,7 +381,7 @@ void RenderMask(Viewer3DController &controller, const RenderFrameContext &contex
 
   RenderFrameContext maskContext = context;
   maskContext.skipCapture = true;
-  maskContext.selectionOverlayPass = false;
+  maskContext.selectionOverlayPass = true;
   maskContext.selectionMaskPass = true;
   maskContext.wireframe = false;
 
@@ -407,18 +391,15 @@ void RenderMask(Viewer3DController &controller, const RenderFrameContext &contex
 }
 
 void CompositeMaskToCurrentFramebuffer(const ScreenSpaceOutlineResources &resources,
-                                       int width, int height, float colorR,
-                                       float colorG, float colorB,
-                                       float fillAlpha, float outlineAlpha) {
+                                       int width, int height) {
   glUseProgram(resources.program);
   glActiveTexture(GL_TEXTURE0);
   glBindTexture(GL_TEXTURE_2D, resources.colorTexture);
   glUniform1i(glGetUniformLocation(resources.program, "uMask"), 0);
   glUniform2f(resources.texelSizeUniform, 1.0f / static_cast<float>(width),
               1.0f / static_cast<float>(height));
-  glUniform3f(resources.outlineColorUniform, colorR, colorG, colorB);
-  glUniform1f(resources.fillAlphaUniform, fillAlpha);
-  glUniform1f(resources.outlineAlphaUniform, outlineAlpha);
+  glUniform1f(resources.fillAlphaUniform, 0.24f);
+  glUniform1f(resources.outlineAlphaUniform, 1.0f);
 
   glBegin(GL_QUADS);
   glTexCoord2f(0.0f, 0.0f);
@@ -434,7 +415,7 @@ void CompositeMaskToCurrentFramebuffer(const ScreenSpaceOutlineResources &resour
 
 void RenderScreenSpaceOverlay(Viewer3DController &controller,
                               const RenderFrameContext &context,
-                              const OverlaySelectionSets &overlaySets) {
+                              const Viewer3DVisibleSet &overlaySet) {
   static bool loggedFramebufferFallback = false;
   static bool loggedShaderFallback = false;
 
@@ -443,8 +424,7 @@ void RenderScreenSpaceOverlay(Viewer3DController &controller,
   const int width = viewport[2];
   const int height = viewport[3];
   if (width <= 0 || height <= 0) {
-    RenderLegacyOverlay(controller, context, overlaySets.selectedSet);
-    RenderLegacyOverlay(controller, context, overlaySets.highlightSet);
+    RenderLegacyOverlay(controller, context, overlaySet);
     return;
   }
 
@@ -456,8 +436,7 @@ void RenderScreenSpaceOverlay(Viewer3DController &controller,
           "Selection outline screen-space disabled: failed to initialize mask framebuffer; using legacy fallback");
       loggedFramebufferFallback = true;
     }
-    RenderLegacyOverlay(controller, context, overlaySets.selectedSet);
-    RenderLegacyOverlay(controller, context, overlaySets.highlightSet);
+    RenderLegacyOverlay(controller, context, overlaySet);
     return;
   }
   if (!resources.EnsureProgram()) {
@@ -467,8 +446,7 @@ void RenderScreenSpaceOverlay(Viewer3DController &controller,
           "Selection outline screen-space disabled: failed to initialize shader program; using legacy fallback");
       loggedShaderFallback = true;
     }
-    RenderLegacyOverlay(controller, context, overlaySets.selectedSet);
-    RenderLegacyOverlay(controller, context, overlaySets.highlightSet);
+    RenderLegacyOverlay(controller, context, overlaySet);
     return;
   }
 
@@ -479,6 +457,9 @@ void RenderScreenSpaceOverlay(Viewer3DController &controller,
   glBindFramebuffer(GL_DRAW_FRAMEBUFFER, resources.fbo);
   glBlitFramebuffer(0, 0, width, height, 0, 0, width, height,
                     GL_DEPTH_BUFFER_BIT, GL_NEAREST);
+
+  glBindFramebuffer(GL_FRAMEBUFFER, resources.fbo);
+  RenderMask(controller, context, overlaySet, width, height);
 
   glBindFramebuffer(GL_FRAMEBUFFER, drawFramebuffer);
   glViewport(viewport[0], viewport[1], width, height);
@@ -499,20 +480,7 @@ void RenderScreenSpaceOverlay(Viewer3DController &controller,
   if (!textureWasEnabled)
     glEnable(GL_TEXTURE_2D);
 
-  glBindFramebuffer(GL_FRAMEBUFFER, resources.fbo);
-  glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-  RenderMask(controller, context, overlaySets.selectedSet, width, height);
-
-  glBindFramebuffer(GL_FRAMEBUFFER, drawFramebuffer);
-  CompositeMaskToCurrentFramebuffer(resources, width, height, 0.0f, 1.0f, 1.0f,
-                                    0.20f, 1.0f);
-
-  glBindFramebuffer(GL_FRAMEBUFFER, resources.fbo);
-  RenderMask(controller, context, overlaySets.highlightSet, width, height);
-
-  glBindFramebuffer(GL_FRAMEBUFFER, drawFramebuffer);
-  CompositeMaskToCurrentFramebuffer(resources, width, height, 0.0f, 1.0f, 0.0f,
-                                    0.32f, 1.0f);
+  CompositeMaskToCurrentFramebuffer(resources, width, height);
 
   glUseProgram(activeProgram);
   glBindTexture(GL_TEXTURE_2D, 0);
@@ -541,15 +509,14 @@ void RenderScreenSpaceOverlay(Viewer3DController &controller,
 void SelectionOverlayPass::Render(Viewer3DController &controller,
                                   const RenderFrameContext &context,
                                   const Viewer3DVisibleSet &visibleSet) {
-  OverlaySelectionSets overlaySets = BuildOverlaySets(controller, visibleSet);
-  if (overlaySets.Empty())
+  Viewer3DVisibleSet overlaySet = BuildOverlaySet(controller, visibleSet);
+  if (overlaySet.Empty())
     return;
 
-  if (UseScreenSpaceOverlay(context)) {
-    RenderScreenSpaceOverlay(controller, context, overlaySets);
+  if (UseScreenSpaceOverlay()) {
+    RenderScreenSpaceOverlay(controller, context, overlaySet);
     return;
   }
 
-  RenderLegacyOverlay(controller, context, overlaySets.selectedSet);
-  RenderLegacyOverlay(controller, context, overlaySets.highlightSet);
+  RenderLegacyOverlay(controller, context, overlaySet);
 }

--- a/viewer3d/render/selection_overlay_pass.cpp
+++ b/viewer3d/render/selection_overlay_pass.cpp
@@ -86,11 +86,161 @@ void AppendUuidIfRenderable(const std::string &uuid,
     return;
   }
 }
-} // namespace
 
-void SelectionOverlayPass::Render(Viewer3DController &controller,
-                                  const RenderFrameContext &context,
-                                  const Viewer3DVisibleSet &visibleSet) {
+struct ScreenSpaceOutlineResources {
+  GLuint fbo = 0;
+  GLuint colorTexture = 0;
+  GLuint depthBuffer = 0;
+  GLuint program = 0;
+  GLint texelSizeUniform = -1;
+  GLint outlineColorUniform = -1;
+  int width = 0;
+  int height = 0;
+
+  ~ScreenSpaceOutlineResources() {
+    if (program != 0)
+      glDeleteProgram(program);
+    if (depthBuffer != 0)
+      glDeleteRenderbuffers(1, &depthBuffer);
+    if (colorTexture != 0)
+      glDeleteTextures(1, &colorTexture);
+    if (fbo != 0)
+      glDeleteFramebuffers(1, &fbo);
+  }
+
+  bool EnsureFramebuffer(int targetWidth, int targetHeight) {
+    if (targetWidth <= 0 || targetHeight <= 0)
+      return false;
+
+    if (fbo == 0)
+      glGenFramebuffers(1, &fbo);
+    if (colorTexture == 0)
+      glGenTextures(1, &colorTexture);
+    if (depthBuffer == 0)
+      glGenRenderbuffers(1, &depthBuffer);
+
+    if (width == targetWidth && height == targetHeight)
+      return true;
+
+    width = targetWidth;
+    height = targetHeight;
+
+    glBindTexture(GL_TEXTURE_2D, colorTexture);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA,
+                 GL_UNSIGNED_BYTE, nullptr);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+    glBindRenderbuffer(GL_RENDERBUFFER, depthBuffer);
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, width, height);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+                           colorTexture, 0);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+                              GL_RENDERBUFFER, depthBuffer);
+
+    const bool complete =
+        glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE;
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    glBindRenderbuffer(GL_RENDERBUFFER, 0);
+    glBindTexture(GL_TEXTURE_2D, 0);
+    return complete;
+  }
+
+  static GLuint CompileShader(GLenum shaderType, const char *source) {
+    const GLuint shader = glCreateShader(shaderType);
+    glShaderSource(shader, 1, &source, nullptr);
+    glCompileShader(shader);
+
+    GLint compileOk = GL_FALSE;
+    glGetShaderiv(shader, GL_COMPILE_STATUS, &compileOk);
+    if (compileOk == GL_TRUE)
+      return shader;
+
+    glDeleteShader(shader);
+    return 0;
+  }
+
+  bool EnsureProgram() {
+    if (program != 0)
+      return true;
+
+    static const char *kVertexShader =
+        "#version 120\n"
+        "varying vec2 vTexCoord;\n"
+        "void main() {\n"
+        "  vTexCoord = gl_MultiTexCoord0.xy;\n"
+        "  gl_Position = gl_Vertex;\n"
+        "}\n";
+
+    static const char *kFragmentShader =
+        "#version 120\n"
+        "uniform sampler2D uMask;\n"
+        "uniform vec2 uTexelSize;\n"
+        "uniform vec3 uOutlineColor;\n"
+        "varying vec2 vTexCoord;\n"
+        "float sampleMask(vec2 uv) {\n"
+        "  return texture2D(uMask, uv).r;\n"
+        "}\n"
+        "void main() {\n"
+        "  float center = sampleMask(vTexCoord);\n"
+        "  float edge = 0.0;\n"
+        "  edge = max(edge, sampleMask(vTexCoord + vec2(uTexelSize.x, 0.0)));\n"
+        "  edge = max(edge, sampleMask(vTexCoord - vec2(uTexelSize.x, 0.0)));\n"
+        "  edge = max(edge, sampleMask(vTexCoord + vec2(0.0, uTexelSize.y)));\n"
+        "  edge = max(edge, sampleMask(vTexCoord - vec2(0.0, uTexelSize.y)));\n"
+        "  edge = max(edge, sampleMask(vTexCoord + uTexelSize));\n"
+        "  edge = max(edge, sampleMask(vTexCoord - uTexelSize));\n"
+        "  edge = max(edge, sampleMask(vTexCoord + vec2(uTexelSize.x, -uTexelSize.y)));\n"
+        "  edge = max(edge, sampleMask(vTexCoord + vec2(-uTexelSize.x, uTexelSize.y)));\n"
+        "  float outline = max(0.0, edge - center);\n"
+        "  if (outline <= 0.001)\n"
+        "    discard;\n"
+        "  gl_FragColor = vec4(uOutlineColor, outline);\n"
+        "}\n";
+
+    const GLuint vertex = CompileShader(GL_VERTEX_SHADER, kVertexShader);
+    const GLuint fragment = CompileShader(GL_FRAGMENT_SHADER, kFragmentShader);
+    if (vertex == 0 || fragment == 0) {
+      if (vertex != 0)
+        glDeleteShader(vertex);
+      if (fragment != 0)
+        glDeleteShader(fragment);
+      return false;
+    }
+
+    program = glCreateProgram();
+    glAttachShader(program, vertex);
+    glAttachShader(program, fragment);
+    glLinkProgram(program);
+
+    glDeleteShader(vertex);
+    glDeleteShader(fragment);
+
+    GLint linkOk = GL_FALSE;
+    glGetProgramiv(program, GL_LINK_STATUS, &linkOk);
+    if (linkOk != GL_TRUE) {
+      glDeleteProgram(program);
+      program = 0;
+      return false;
+    }
+
+    texelSizeUniform = glGetUniformLocation(program, "uTexelSize");
+    outlineColorUniform = glGetUniformLocation(program, "uOutlineColor");
+    return texelSizeUniform >= 0 && outlineColorUniform >= 0;
+  }
+};
+
+ScreenSpaceOutlineResources &OutlineResources() {
+  static ScreenSpaceOutlineResources resources;
+  return resources;
+}
+
+Viewer3DVisibleSet BuildOverlaySet(Viewer3DController &controller,
+                                   const Viewer3DVisibleSet &visibleSet) {
   const auto &fixtures = SceneDataManager::Instance().GetFixtures();
   const auto &trusses = SceneDataManager::Instance().GetTrusses();
   const auto &objects = SceneDataManager::Instance().GetSceneObjects();
@@ -113,13 +263,15 @@ void SelectionOverlayPass::Render(Viewer3DController &controller,
   AppendUuidIfRenderable(controller.m_highlightUuid, fixtures, trusses, objects,
                          overlaySet);
 
-  for (const auto &uuid : controller.m_selectedUuids) {
+  for (const auto &uuid : controller.m_selectedUuids)
     AppendUuidIfRenderable(uuid, fixtures, trusses, objects, overlaySet);
-  }
 
-  if (overlaySet.Empty())
-    return;
+  return overlaySet;
+}
 
+void RenderSelectedGeometry(Viewer3DController &controller,
+                            const RenderFrameContext &context,
+                            const Viewer3DVisibleSet &overlaySet) {
   auto getTypeColor = [&](const std::string &key, const std::string &hex) {
     std::array<float, 3> c;
     if (!hex.empty() && HexToRGB(hex, c[0], c[1], c[2]))
@@ -150,17 +302,140 @@ void SelectionOverlayPass::Render(Viewer3DController &controller,
     return std::array<float, 3>{1.0f, 1.0f, 1.0f};
   };
 
+  OpaqueObjectPass::Render(controller, context, overlaySet, getLayerColor,
+                           resolveSymbolView, getPickColor);
+  OpaqueTrussPass::Render(controller, context, overlaySet, getLayerColor,
+                          resolveSymbolView, getPickColor);
+  OpaqueFixturePass::Render(controller, context, overlaySet, getTypeColor,
+                            getLayerColor, resolveSymbolView, getPickColor);
+}
+
+void RenderLegacyOverlay(Viewer3DController &controller,
+                         const RenderFrameContext &context,
+                         const Viewer3DVisibleSet &overlaySet) {
   RenderFrameContext overlayContext = context;
   overlayContext.skipCapture = true;
   overlayContext.selectionOverlayPass = true;
   GLint previousDepthFunc = GL_LESS;
   glGetIntegerv(GL_DEPTH_FUNC, &previousDepthFunc);
   glDepthFunc(GL_LEQUAL);
-  OpaqueObjectPass::Render(controller, overlayContext, overlaySet, getLayerColor,
-                           resolveSymbolView, getPickColor);
-  OpaqueTrussPass::Render(controller, overlayContext, overlaySet, getLayerColor,
-                          resolveSymbolView, getPickColor);
-  OpaqueFixturePass::Render(controller, overlayContext, overlaySet, getTypeColor,
-                            getLayerColor, resolveSymbolView, getPickColor);
+  RenderSelectedGeometry(controller, overlayContext, overlaySet);
   glDepthFunc(static_cast<GLenum>(previousDepthFunc));
+}
+
+bool UseScreenSpaceOverlay() {
+  return ConfigManager::Get().GetFloat("viewer3d_selection_outline_screenspace") >=
+         0.5f;
+}
+
+void RenderScreenSpaceOverlay(Viewer3DController &controller,
+                              const RenderFrameContext &context,
+                              const Viewer3DVisibleSet &overlaySet) {
+  GLint viewport[4] = {0, 0, 0, 0};
+  glGetIntegerv(GL_VIEWPORT, viewport);
+  const int width = viewport[2];
+  const int height = viewport[3];
+  if (width <= 0 || height <= 0) {
+    RenderLegacyOverlay(controller, context, overlaySet);
+    return;
+  }
+
+  auto &resources = OutlineResources();
+  if (!resources.EnsureFramebuffer(width, height) || !resources.EnsureProgram()) {
+    RenderLegacyOverlay(controller, context, overlaySet);
+    return;
+  }
+
+  GLint drawFramebuffer = 0;
+  glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &drawFramebuffer);
+
+  glBindFramebuffer(GL_READ_FRAMEBUFFER, drawFramebuffer);
+  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, resources.fbo);
+  glBlitFramebuffer(0, 0, width, height, 0, 0, width, height,
+                    GL_DEPTH_BUFFER_BIT, GL_NEAREST);
+
+  glBindFramebuffer(GL_FRAMEBUFFER, resources.fbo);
+  glViewport(0, 0, width, height);
+  glDisable(GL_BLEND);
+  glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+  glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+  glClear(GL_COLOR_BUFFER_BIT);
+
+  GLint previousDepthFunc = GL_LESS;
+  glGetIntegerv(GL_DEPTH_FUNC, &previousDepthFunc);
+
+  RenderFrameContext maskContext = context;
+  maskContext.skipCapture = true;
+  maskContext.selectionOverlayPass = false;
+  maskContext.selectionMaskPass = true;
+  maskContext.wireframe = false;
+  glDepthFunc(GL_LEQUAL);
+  RenderSelectedGeometry(controller, maskContext, overlaySet);
+  glDepthFunc(static_cast<GLenum>(previousDepthFunc));
+
+  glBindFramebuffer(GL_FRAMEBUFFER, drawFramebuffer);
+  glViewport(viewport[0], viewport[1], width, height);
+
+  const GLboolean depthWasEnabled = glIsEnabled(GL_DEPTH_TEST);
+  const GLboolean blendWasEnabled = glIsEnabled(GL_BLEND);
+  const GLboolean textureWasEnabled = glIsEnabled(GL_TEXTURE_2D);
+  GLint activeProgram = 0;
+  glGetIntegerv(GL_CURRENT_PROGRAM, &activeProgram);
+
+  glDisable(GL_DEPTH_TEST);
+  glEnable(GL_BLEND);
+  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+  glDisable(GL_LIGHTING);
+  glDisable(GL_CULL_FACE);
+
+  glUseProgram(resources.program);
+  glActiveTexture(GL_TEXTURE0);
+  glBindTexture(GL_TEXTURE_2D, resources.colorTexture);
+  glUniform1i(glGetUniformLocation(resources.program, "uMask"), 0);
+  glUniform2f(resources.texelSizeUniform, 1.0f / static_cast<float>(width),
+              1.0f / static_cast<float>(height));
+  glUniform3f(resources.outlineColorUniform, 0.0f, 1.0f, 1.0f);
+
+  if (!textureWasEnabled)
+    glEnable(GL_TEXTURE_2D);
+
+  glBegin(GL_QUADS);
+  glTexCoord2f(0.0f, 0.0f);
+  glVertex2f(-1.0f, -1.0f);
+  glTexCoord2f(1.0f, 0.0f);
+  glVertex2f(1.0f, -1.0f);
+  glTexCoord2f(1.0f, 1.0f);
+  glVertex2f(1.0f, 1.0f);
+  glTexCoord2f(0.0f, 1.0f);
+  glVertex2f(-1.0f, 1.0f);
+  glEnd();
+
+  glUseProgram(activeProgram);
+
+  if (!textureWasEnabled)
+    glDisable(GL_TEXTURE_2D);
+  if (depthWasEnabled)
+    glEnable(GL_DEPTH_TEST);
+  else
+    glDisable(GL_DEPTH_TEST);
+  if (blendWasEnabled)
+    glEnable(GL_BLEND);
+  else
+    glDisable(GL_BLEND);
+}
+} // namespace
+
+void SelectionOverlayPass::Render(Viewer3DController &controller,
+                                  const RenderFrameContext &context,
+                                  const Viewer3DVisibleSet &visibleSet) {
+  Viewer3DVisibleSet overlaySet = BuildOverlaySet(controller, visibleSet);
+  if (overlaySet.Empty())
+    return;
+
+  if (UseScreenSpaceOverlay()) {
+    RenderScreenSpaceOverlay(controller, context, overlaySet);
+    return;
+  }
+
+  RenderLegacyOverlay(controller, context, overlaySet);
 }

--- a/viewer3d/render/selection_overlay_pass.cpp
+++ b/viewer3d/render/selection_overlay_pass.cpp
@@ -364,7 +364,11 @@ void RenderLegacyOverlay(Viewer3DController &controller,
   glDepthFunc(static_cast<GLenum>(previousDepthFunc));
 }
 
-bool UseScreenSpaceOverlay() {
+bool UseScreenSpaceOverlay(const RenderFrameContext &context) {
+  // Keep 2D on legacy until a dedicated screen-space path is tuned for it.
+  // Current priority is stable and clear highlight behavior in the 3D viewer.
+  if (context.is2DViewer)
+    return false;
   return ConfigManager::Get().GetFloat("viewer3d_selection_outline_screenspace") >=
          0.5f;
 }
@@ -398,8 +402,8 @@ void CompositeMaskToCurrentFramebuffer(const ScreenSpaceOutlineResources &resour
   glUniform1i(glGetUniformLocation(resources.program, "uMask"), 0);
   glUniform2f(resources.texelSizeUniform, 1.0f / static_cast<float>(width),
               1.0f / static_cast<float>(height));
-  glUniform1f(resources.fillAlphaUniform, 0.24f);
-  glUniform1f(resources.outlineAlphaUniform, 1.0f);
+  glUniform1f(resources.fillAlphaUniform, 0.80f);
+  glUniform1f(resources.outlineAlphaUniform, 0.20f);
 
   glBegin(GL_QUADS);
   glTexCoord2f(0.0f, 0.0f);
@@ -513,7 +517,7 @@ void SelectionOverlayPass::Render(Viewer3DController &controller,
   if (overlaySet.Empty())
     return;
 
-  if (UseScreenSpaceOverlay()) {
+  if (UseScreenSpaceOverlay(context)) {
     RenderScreenSpaceOverlay(controller, context, overlaySet);
     return;
   }

--- a/viewer3d/render/selection_overlay_pass.cpp
+++ b/viewer3d/render/selection_overlay_pass.cpp
@@ -245,12 +245,15 @@ Viewer3DVisibleSet BuildOverlaySet(Viewer3DController &controller,
   const auto &trusses = SceneDataManager::Instance().GetTrusses();
   const auto &objects = SceneDataManager::Instance().GetSceneObjects();
 
+  const std::string &highlightUuid = controller.GetHighlightUuid();
+  const auto &selectedUuids = controller.GetSelectedUuids();
+
   Viewer3DVisibleSet overlaySet;
   const auto appendFromVisibility = [&](const std::vector<std::string> &sourceUuids,
                                         std::vector<std::string> &targetUuids) {
     for (const auto &uuid : sourceUuids) {
-      if (uuid == controller.m_highlightUuid ||
-          controller.m_selectedUuids.find(uuid) != controller.m_selectedUuids.end()) {
+      if (uuid == highlightUuid ||
+          selectedUuids.find(uuid) != selectedUuids.end()) {
         targetUuids.push_back(uuid);
       }
     }
@@ -260,10 +263,9 @@ Viewer3DVisibleSet BuildOverlaySet(Viewer3DController &controller,
   appendFromVisibility(visibleSet.trussUuids, overlaySet.trussUuids);
   appendFromVisibility(visibleSet.objectUuids, overlaySet.objectUuids);
 
-  AppendUuidIfRenderable(controller.m_highlightUuid, fixtures, trusses, objects,
-                         overlaySet);
+  AppendUuidIfRenderable(highlightUuid, fixtures, trusses, objects, overlaySet);
 
-  for (const auto &uuid : controller.m_selectedUuids)
+  for (const auto &uuid : selectedUuids)
     AppendUuidIfRenderable(uuid, fixtures, trusses, objects, overlaySet);
 
   return overlaySet;

--- a/viewer3d/render/selection_overlay_pass.cpp
+++ b/viewer3d/render/selection_overlay_pass.cpp
@@ -245,8 +245,8 @@ Viewer3DVisibleSet BuildOverlaySet(Viewer3DController &controller,
   const auto &trusses = SceneDataManager::Instance().GetTrusses();
   const auto &objects = SceneDataManager::Instance().GetSceneObjects();
 
-  const std::string &highlightUuid = controller.GetHighlightUuid();
-  const auto &selectedUuids = controller.GetSelectedUuids();
+  const std::string &highlightUuid = controller.GetOverlayHighlightUuid();
+  const auto &selectedUuids = controller.GetOverlaySelectedUuids();
 
   Viewer3DVisibleSet overlaySet;
   const auto appendFromVisibility = [&](const std::vector<std::string> &sourceUuids,

--- a/viewer3d/viewer3d_types.h
+++ b/viewer3d/viewer3d_types.h
@@ -77,6 +77,7 @@ struct RenderFrameContext {
   bool skipOutlinesForCurrentFrame = false;
   bool idOnlyPass = false;
   bool selectionOverlayPass = false;
+  bool selectionMaskPass = false;
 
   bool colorByFixtureType = false;
   bool colorByLayer = false;

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1735,10 +1735,12 @@ void Viewer3DController::DrawMeshWithOutline(
     Viewer2DRenderMode mode,
     const std::function<std::array<float, 3>(const std::array<float, 3> &)> &
         captureTransform,
-    bool unlit, const float *modelMatrix, bool disableDepthBias) {
+    bool unlit, const float *modelMatrix, bool selectionMaskPass,
+    bool disableDepthBias) {
   m_impl->sceneRenderer->DrawMeshWithOutline(mesh, r, g, b, scale, highlight,
                                        selected, cx, cy, cz, wireframe, mode,
                                        captureTransform, unlit, modelMatrix,
+                                       selectionMaskPass,
                                        disableDepthBias);
 }
 

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1729,6 +1729,15 @@ void Viewer3DController::ClearBottomSymbolCache() {
   m_impl->bottomSymbolCache.Clear();
 }
 
+const std::string &Viewer3DController::GetOverlayHighlightUuid() const {
+  return m_impl->highlightUuid;
+}
+
+const std::unordered_set<std::string> &
+Viewer3DController::GetOverlaySelectedUuids() const {
+  return m_impl->selectedUuids;
+}
+
 void Viewer3DController::DrawMeshWithOutline(
     const Mesh &mesh, float r, float g, float b, float scale, bool highlight,
     bool selected, float cx, float cy, float cz, bool wireframe,

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -228,6 +228,7 @@ private:
                                {},
                            bool unlit = false,
                            const float *modelMatrix = nullptr,
+                           bool selectionMaskPass = false,
                            bool disableDepthBias = false);
   void DrawMeshWireframe(
       const Mesh &mesh, float scale = RENDER_SCALE,

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -160,6 +160,8 @@ public:
   std::shared_ptr<const SymbolDefinitionSnapshot>
   GetBottomSymbolCacheSnapshot() const;
   void ClearBottomSymbolCache();
+  const std::string &GetOverlayHighlightUuid() const;
+  const std::unordered_set<std::string> &GetOverlaySelectedUuids() const;
 
   void SetCaptureCanvas(ICanvas2D *canvas, Viewer2DView view,
                         bool includeGrid = true,


### PR DESCRIPTION
### Motivation
- Reduce the cost of selection outlines for complex meshes by moving from per-mesh geometric outlines to a cheap screen-space postprocess while preserving the legacy geometry path as a fallback.
- Provide a mask-only rendering path so selected/highlighted objects can be drawn as a clean white ID/mask for robust edge extraction in the postprocess.

### Description
- Added a new screen-space outline pipeline in `SelectionOverlayPass` that renders a selection mask into an offscreen FBO, blits the depth buffer from the main framebuffer, and composites a thin outline using a small GLSL shader; the behavior is enabled by the config flag `viewer3d_selection_outline_screenspace` and falls back to the legacy geometry overlay when unavailable or disabled.
- Introduced `selectionMaskPass` to `RenderFrameContext` and propagated it through `DrawMeshWithOutline` (controller/scenerenderer) and the opaque passes so the same geometry code can render a solid white mask without selection shading or geometric outlines.
- Implemented a lightweight `ScreenSpaceOutlineResources` helper in `selection_overlay_pass.cpp` to manage the mask FBO, texture, and shader, and added early-return mask handling in `scenerenderer.cpp` when `selectionMaskPass` is set.

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which passed.
- Attempted `cmake -S . -B build`, which failed in this environment due to missing system development dependency (`wxWidgets_LIBRARIES` / `wxWidgets_INCLUDE_DIRS`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec0dfdd0cc8324b02d33ad0fa349e2)