### PR TITLE
Use CMake project version for Inno Setup and add extraction script

### DIFF
--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -43,12 +43,24 @@ cmake --build out/build/x64-Release --config Release --target perastage_stage
 Then compile the Inno Setup script:
 
 ```powershell
-iscc packaging/windows/Perastage.iss
+$version = (cmake -P packaging/windows/get_project_version.cmake |
+  Select-String -Pattern '-- ([0-9]+\.[0-9]+\.[0-9]+)$').Matches[0].Groups[1].Value
+iscc /DMyAppVersion=$version packaging/windows/Perastage.iss
 ```
 
 The generated installer is written to:
 
 - `out/installer/Perastage_<version>_Setup.exe`
+
+### Version Source of Truth
+
+Perastage version is defined in one place:
+
+- `CMakeLists.txt` in the root `project(Perastage VERSION X.Y.Z ...)` declaration.
+
+When you want a new global version for generated artifacts, update that line only.
+The helper script `packaging/windows/get_project_version.cmake` reads that value and
+passes it to Inno Setup (`/DMyAppVersion=...`).
 
 ### Enabling `.mvr` Association in the Installer
 

--- a/packaging/windows/Perastage.iss
+++ b/packaging/windows/Perastage.iss
@@ -4,7 +4,9 @@
 ; generated installer next to the repository folder, not inside it.
 
 #define MyAppName "Perastage"
-#define MyAppVersion "1.0.0"
+#ifndef MyAppVersion
+  #error "MyAppVersion is not defined. Pass /DMyAppVersion=<version> to ISCC using PROJECT_VERSION from CMakeLists.txt."
+#endif
 #define MyAppPublisher "Perasoft"
 #define MyAppURL "https://github.com/PeramatoG/Perastage"
 #define MyAppExeName "Perastage.exe"

--- a/packaging/windows/get_project_version.cmake
+++ b/packaging/windows/get_project_version.cmake
@@ -1,0 +1,25 @@
+set(_repo_root "${CMAKE_CURRENT_LIST_DIR}/../..")
+set(_cmake_lists "${_repo_root}/CMakeLists.txt")
+
+if(NOT EXISTS "${_cmake_lists}")
+  message(FATAL_ERROR "CMakeLists.txt not found at ${_cmake_lists}")
+endif()
+
+file(STRINGS "${_cmake_lists}" _project_line
+     REGEX "^project\\(Perastage VERSION [0-9]+\\.[0-9]+\\.[0-9]+")
+
+if(NOT _project_line)
+  message(FATAL_ERROR "Could not find Perastage project version in ${_cmake_lists}")
+endif()
+
+list(GET _project_line 0 _project_line_value)
+string(REGEX REPLACE "^project\\(Perastage VERSION ([0-9]+\\.[0-9]+\\.[0-9]+).*$"
+                     "\\1"
+                     _project_version
+                     "${_project_line_value}")
+
+if(NOT _project_version MATCHES "^[0-9]+\\.[0-9]+\\.[0-9]+$")
+  message(FATAL_ERROR "Extracted invalid project version: '${_project_version}'")
+endif()
+
+message(STATUS "${_project_version}")


### PR DESCRIPTION
### Motivation

- Centralize the application version in `CMakeLists.txt` and avoid a hardcoded version in the Inno Setup script so generated installers always reflect the project version.
- Provide a simple, repository-local helper to extract the `project(Perastage VERSION ...)` value and pass it to the Inno compiler.

### Description

- Added `packaging/windows/get_project_version.cmake` which reads the root `CMakeLists.txt`, extracts the `Perastage` project version, validates it, and prints it to stdout or errors on failure.
- Updated `packaging/windows/Perastage.iss` to remove the hardcoded `#define MyAppVersion "1.0.0"` and instead require `/DMyAppVersion=<version>` at compile time with a preprocessor `#error` if missing.
- Updated `docs/packaging.md` to document the recommended build flow using `cmake -P packaging/windows/get_project_version.cmake` and the PowerShell pipeline to pass the extracted version to `iscc`, and added a "Version Source of Truth" section pointing to the `project(...)` declaration in `CMakeLists.txt`.

### Testing

- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebea72c9688324aee94ec52ab195b8)