### PR TITLE
Unify Perastage MVR metadata version semantics

### DIFF
--- a/docs/mvr-spec.md
+++ b/docs/mvr-spec.md
@@ -146,6 +146,8 @@ The second XML node is the mandatory GeneralSceneDescription node. The attribute
 
 The current version of MVR reflected by this document is 1.6.
 
+Perastage exporter policy: `providerVersion` maps to the Perastage app version (`app::kVersion`), while custom `UserData/Data@ver` values version Perastage-owned payload schemas.
+
 
 ##### Table 3 — *GeneralSceneDescription Node Children*
 
@@ -181,6 +183,8 @@ Node name: `Data`
 | -------------- | --------------------------------------- | --------------------------- | ------------------------------------------------------------------------- |
 | provider       | [String](#user-content-attrtype-string) | Not Optional                | Specifies the name of the provider application that created this data.    |
 | ver            | [String](#user-content-attrtype-string) | 1                           | Version information of the data as specified by the provider application. |
+
+Perastage exporter policy: for Perastage-owned metadata blocks, `ver` is a schema version (currently `1.0`) and does not track application releases.
 
 
 ## Node Definition: Scene
@@ -1790,4 +1794,3 @@ UUIDs are randomly generated numbers which are, practically speaking, unique and
 One of the most important aspects of UUIDs in MVR is that they are persistent. A UUID should identify an item throughout its entire life cycle. This means that if a document is exported, then objects should have the same UUID every time an export is performed.
 One use case for UUIDs is importing or merging MVRs into an existing document. This is one reason that persistent UUIDs are valuable. If you export an MVR from one program, open it in another, and make modifications, then you may want to incorporate those changes into the original document. By cross referencing UUIDs, you can avoid creating duplicate objects and instead update existing ones.
 UUIDs are also used inside of the MVR file format as a form of reference. For example, a symbol instance shall refer to a symbol definition. Because the symbol definition is given a UUID, the symbol instance can reference its symbol through the use of this UUID.
-

--- a/docs/mvr_hoistinfo_schema.md
+++ b/docs/mvr_hoistinfo_schema.md
@@ -6,7 +6,7 @@ This document defines the canonical Perastage payload for support hoist metadata
 
 - `Support/UserData/Data` with attributes:
   - `provider="Perastage"`
-  - `ver="1.0"`
+  - `ver="1.0"` (Perastage user-data schema version, not the app version)
 - Canonical payload node: `HoistInfo`
 - Legacy payload node accepted on import: `MotorInfo`
 
@@ -39,3 +39,8 @@ On import, Perastage reads both canonical and compatibility aliases with this pr
 2. `ValueSource`, fallback `DataSource`
 
 Legacy `MotorInfo` payload blocks are still parsed and migrated internally to the canonical support fields.
+
+## Versioning policy
+
+- `GeneralSceneDescription@providerVersion` is exported from `app::kVersion` and identifies the Perastage application build that created the MVR file.
+- `UserData/Data@ver` stays on the Perastage user-data schema version (`1.0`) and only changes when the Perastage custom payload schema changes.

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "mvrexporter.h"
+#include "app_version.h"
 #include "configmanager.h"
 #include "dummyprofilelibrary.h"
 #include "gdtf_mutation_audit.h"
@@ -102,7 +103,7 @@ static bool IsCanonicalUuidString(const std::string &value);
 static void LogLegacyPositionUuidWarning(const std::string &message);
 
 static constexpr const char *kMvrProvider = "Perastage";
-static constexpr const char *kMvrProviderVersion = "1.0";
+static constexpr const char *kPerastageUserDataSchemaVersion = "1.0";
 static constexpr const char *kDummyFallbackFixtureGdtfFileName = "Dummy 1ch.gdtf";
 static constexpr const char *kLegacyFallbackFixtureGdtfFileName = "Generic 1ch.gdtf";
 
@@ -896,7 +897,7 @@ static tinyxml2::XMLElement *FindOrCreatePerastageDataNode(tinyxml2::XMLDocument
 
   tinyxml2::XMLElement *data = doc.NewElement("Data");
   data->SetAttribute("provider", kMvrProvider);
-  data->SetAttribute("ver", kMvrProviderVersion);
+  data->SetAttribute("ver", kPerastageUserDataSchemaVersion);
   ud->InsertEndChild(data);
   return data;
 }
@@ -1536,7 +1537,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
   root->SetAttribute("verMinor", 6);
   root->SetAttribute("provider", scene.provider.empty() ? kMvrProvider : scene.provider.c_str());
   root->SetAttribute("providerVersion",
-                     scene.providerVersion.empty() ? kMvrProviderVersion
+                     scene.providerVersion.empty() ? app::kVersion
                                                    : scene.providerVersion.c_str());
   doc.InsertEndChild(root);
 
@@ -1771,8 +1772,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
 
     tinyxml2::XMLElement *ud = doc.NewElement("UserData");
     tinyxml2::XMLElement *data = doc.NewElement("Data");
-    data->SetAttribute("provider", "Perastage");
-    data->SetAttribute("ver", "1.0");
+    data->SetAttribute("provider", kMvrProvider);
+    data->SetAttribute("ver", kPerastageUserDataSchemaVersion);
     tinyxml2::XMLElement *info = doc.NewElement("FixtureInfo");
     info->SetAttribute("uuid", stableUuid.c_str());
 
@@ -1965,8 +1966,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
     if (hasMeta) {
       tinyxml2::XMLElement *ud = doc.NewElement("UserData");
       tinyxml2::XMLElement *data = doc.NewElement("Data");
-      data->SetAttribute("provider", "Perastage");
-      data->SetAttribute("ver", "1.0");
+      data->SetAttribute("provider", kMvrProvider);
+      data->SetAttribute("ver", kPerastageUserDataSchemaVersion);
       tinyxml2::XMLElement *info = doc.NewElement("TrussInfo");
       info->SetAttribute("uuid", t.uuid.c_str());
       auto addTxt = [&](const char *n, const std::string &v) {
@@ -2234,7 +2235,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
       if (!primitiveGeometryModelRefs.empty()) {
         tinyxml2::XMLElement *ud = doc.NewElement("UserData");
         tinyxml2::XMLElement *data = doc.NewElement("Data");
-        data->SetAttribute("provider", "Perastage");
+        data->SetAttribute("provider", kMvrProvider);
         tinyxml2::XMLElement *map = doc.NewElement("PrimitiveGeometryMap");
         for (const auto &[archiveFileName, modelRef] : primitiveGeometryModelRefs) {
           tinyxml2::XMLElement *entry = doc.NewElement("Entry");
@@ -2501,8 +2502,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
   if (!trussArchiveByTypeKey.empty()) {
     tinyxml2::XMLElement *rootUserData = doc.NewElement("UserData");
     tinyxml2::XMLElement *data = doc.NewElement("Data");
-    data->SetAttribute("provider", "Perastage");
-    data->SetAttribute("ver", "1.0");
+    data->SetAttribute("provider", kMvrProvider);
+    data->SetAttribute("ver", kPerastageUserDataSchemaVersion);
     tinyxml2::XMLElement *manifest = doc.NewElement("TrussSidecarManifest");
     for (const auto &[typeKey, archivePath] : trussArchiveByTypeKey) {
       tinyxml2::XMLElement *typeNode = doc.NewElement("Type");

--- a/tests/mvr_exporter_compliance_test.cpp
+++ b/tests/mvr_exporter_compliance_test.cpp
@@ -17,6 +17,7 @@
 #include <wx/zipstrm.h>
 
 #include "configmanager.h"
+#include "app_version.h"
 #include "fixture.h"
 #include "matrixutils.h"
 #include "mvrexporter.h"
@@ -27,6 +28,7 @@
 #include "uuidutils.h"
 
 namespace fs = std::filesystem;
+static constexpr const char *kPerastageUserDataSchemaVersion = "1.0";
 
 static std::string ReadCurrentZipEntry(wxZipInputStream &zip) {
   std::string content;
@@ -307,7 +309,7 @@ int main() {
   assert(root->IntAttribute("verMajor") == 1);
   assert(root->IntAttribute("verMinor") == 6);
   assert(std::string(root->Attribute("provider")) == "Perastage");
-  assert(std::string(root->Attribute("providerVersion")) == "1.0");
+  assert(std::string(root->Attribute("providerVersion")) == app::kVersion);
 
   std::unordered_set<int> numericIds;
   std::unordered_map<std::string, int> gdtfCount;
@@ -723,8 +725,11 @@ int main() {
     wxZipOutputStream legacyZip(legacyOut);
     const std::string legacyXml =
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-        "<GeneralSceneDescription verMajor=\"1\" verMinor=\"6\" provider=\"Perastage\" providerVersion=\"1.0\">"
-        "<UserData><Data provider=\"Perastage\" ver=\"1.0\"><TrussSidecarManifest/></Data></UserData>"
+        "<GeneralSceneDescription verMajor=\"1\" verMinor=\"6\" provider=\"Perastage\" providerVersion=\"" +
+        std::string(app::kVersion) + "\">"
+        "<UserData><Data provider=\"Perastage\" ver=\"" +
+        std::string(kPerastageUserDataSchemaVersion) +
+        "\"><TrussSidecarManifest/></Data></UserData>"
         "<Scene>"
         "<AUXData><Position uuid=\"LX1\" name=\"LX 1\"/></AUXData>"
         "<Layers><Layer name=\"Default\"><ChildList>"


### PR DESCRIPTION
### Motivation
- Remove duplicated string literals for MVR metadata and make the semantics explicit: `GeneralSceneDescription@providerVersion` should reflect the Perastage application build, while `UserData/Data@ver` is a Perastage-owned user-data schema version.

### Description
- Add `#include "app_version.h"` and use `app::kVersion` as the default value for `GeneralSceneDescription@providerVersion` in `mvr/mvrexporter.cpp`.
- Introduce a semantic constant `kPerastageUserDataSchemaVersion = "1.0"` and replace all Perastage `UserData/Data@ver` write-sites to use this constant instead of repeated `"1.0"` literals in `mvr/mvrexporter.cpp`.
- Update `tests/mvr_exporter_compliance_test.cpp` to assert `providerVersion == app::kVersion` and to construct the legacy XML using `app::kVersion` and `kPerastageUserDataSchemaVersion` instead of hardcoded literals.
- Document the versioning distinction in `docs/mvr_hoistinfo_schema.md` and `docs/mvr-spec.md` so the exporter policy is explicit.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed successfully.
- Attempted to configure the test build with `cmake --preset wsl-x64-debug` but the configure step failed in this environment due to missing `wxWidgets` development files, so the compiled `MvrExporterCompliance` test was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec204b84308324a600a4c670d123ca)