### PR TITLE
Fix Windows runtime dependency exclusions for perastage_stage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,8 +313,10 @@ if(WIN32)
             CONFIGURATIONS Release RelWithDebInfo MinSizeRel
             DIRECTORIES ${PERASTAGE_VCPKG_BIN_DIRS}
             PRE_EXCLUDE_REGEXES
-                "api-ms-.*"
-                "ext-ms-.*"
+                "^[Aa]pi-[Mm]s-.*\\.dll$"
+                "^[Ee]xt-[Mm]s-.*\\.dll$"
+                "^[Ww]paxholder\\.dll$"
+                "^[Ww]tdccm\\.dll$"
             POST_EXCLUDE_REGEXES
                 ".*[Ww]indows[\\/].*"
                 ".*[Ss]ystem32[\\/].*"
@@ -330,8 +332,10 @@ if(WIN32)
             DESTINATION .
             DIRECTORIES ${PERASTAGE_VCPKG_BIN_DIRS}
             PRE_EXCLUDE_REGEXES
-                "api-ms-.*"
-                "ext-ms-.*"
+                "^[Aa]pi-[Mm]s-.*\\.dll$"
+                "^[Ee]xt-[Mm]s-.*\\.dll$"
+                "^[Ww]paxholder\\.dll$"
+                "^[Ww]tdccm\\.dll$"
             POST_EXCLUDE_REGEXES
                 ".*[Ww]indows[\\/].*"
                 ".*[Ss]ystem32[\\/].*"


### PR DESCRIPTION
### Motivation
- Windows CI hit failures during `install(RUNTIME_DEPENDENCY_SET ...)` dependency resolution when staging `perastage_stage` because internal/pseudo Windows DLLs were being considered.
- The change aims to exclude those pseudo/internal DLLs before dependency resolution to avoid install-time errors.
- The staging destination, installer script, and application code are intentionally not changed.

### Description
- Updated `CMakeLists.txt` to use anchored, case-insensitive DLL name regexes in `PRE_EXCLUDE_REGEXES` instead of the previous broad patterns.
- Added explicit exclusions for `wpaxholder.dll` and `wtdccm.dll` and replaced `api-ms-.*` / `ext-ms-.*` with `^[Aa]pi-[Mm]s-.*\.dll$` and `^[Ee]xt-[Mm]s-.*\.dll$` to robustly skip Windows pseudo DLLs.
- Applied the same edits to both install blocks: the multi-config block (`Release`, `RelWithDebInfo`, `MinSizeRel`) and the single-config non-`Debug` block for `perastage_runtime_deps_release`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (OK).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee61d45b7c83248d499984465354ff)