### PR TITLE
viewer3d: use flat-ready GPU buffers when GL_FLAT is active

### DIFF
--- a/viewer3d/mesh.h
+++ b/viewer3d/mesh.h
@@ -38,10 +38,13 @@ struct Mesh {
     uint32_t vboVertices = 0;
     uint32_t vboNormals = 0;
     uint32_t vboTexCoords = 0;
+    uint32_t vboFlatVertices = 0;
+    uint32_t vboFlatNormals = 0;
     uint32_t eboTriangles = 0;
     uint32_t eboLines = 0;
     uint32_t textureId = 0;
     int triangleIndexCount = 0;
+    int flatVertexCount = 0;
     int lineIndexCount = 0;
     bool buffersReady = false;
     // Optional cached triangle index order for mirrored instances.
@@ -49,6 +52,9 @@ struct Mesh {
     // True once we have evaluated/fixed triangle winding for compatibility
     // with assets coming from heterogeneous DCC/export pipelines.
     bool windingChecked = false;
+    // Optional CPU cache for flat-shading ready triangle streams.
+    std::vector<float> flatVertices;
+    std::vector<float> flatNormals;
 };
 
 // Attempts to detect meshes whose triangle winding is globally inverted and
@@ -202,6 +208,66 @@ inline void ComputeNormals(Mesh& mesh)
             mesh.normals[i * 3]     = nx / len;
             mesh.normals[i * 3 + 1] = ny / len;
             mesh.normals[i * 3 + 2] = nz / len;
+        }
+    }
+}
+
+// Builds a triangle stream with duplicated vertices and per-face normals so
+// GL_FLAT can be rendered through the GPU path without immediate mode.
+inline void BuildFlatShadingBuffers(Mesh& mesh)
+{
+    mesh.flatVertices.clear();
+    mesh.flatNormals.clear();
+
+    if (mesh.vertices.empty() || mesh.indices.empty())
+        return;
+
+    mesh.flatVertices.reserve(mesh.indices.size() * 3);
+    mesh.flatNormals.reserve(mesh.indices.size() * 3);
+
+    for (size_t i = 0; i + 2 < mesh.indices.size(); i += 3) {
+        const unsigned short i0 = mesh.indices[i];
+        const unsigned short i1 = mesh.indices[i + 1];
+        const unsigned short i2 = mesh.indices[i + 2];
+
+        const float v0x = mesh.vertices[i0 * 3];
+        const float v0y = mesh.vertices[i0 * 3 + 1];
+        const float v0z = mesh.vertices[i0 * 3 + 2];
+        const float v1x = mesh.vertices[i1 * 3];
+        const float v1y = mesh.vertices[i1 * 3 + 1];
+        const float v1z = mesh.vertices[i1 * 3 + 2];
+        const float v2x = mesh.vertices[i2 * 3];
+        const float v2y = mesh.vertices[i2 * 3 + 1];
+        const float v2z = mesh.vertices[i2 * 3 + 2];
+
+        float nx = (v1y - v0y) * (v2z - v0z) - (v1z - v0z) * (v2y - v0y);
+        float ny = (v1z - v0z) * (v2x - v0x) - (v1x - v0x) * (v2z - v0z);
+        float nz = (v1x - v0x) * (v2y - v0y) - (v1y - v0y) * (v2x - v0x);
+        const float len = std::sqrt(nx * nx + ny * ny + nz * nz);
+        if (len > 0.0f) {
+            nx /= len;
+            ny /= len;
+            nz /= len;
+        } else {
+            nx = 0.0f;
+            ny = 0.0f;
+            nz = 1.0f;
+        }
+
+        mesh.flatVertices.push_back(v0x);
+        mesh.flatVertices.push_back(v0y);
+        mesh.flatVertices.push_back(v0z);
+        mesh.flatVertices.push_back(v1x);
+        mesh.flatVertices.push_back(v1y);
+        mesh.flatVertices.push_back(v1z);
+        mesh.flatVertices.push_back(v2x);
+        mesh.flatVertices.push_back(v2y);
+        mesh.flatVertices.push_back(v2z);
+
+        for (int v = 0; v < 3; ++v) {
+            mesh.flatNormals.push_back(nx);
+            mesh.flatNormals.push_back(ny);
+            mesh.flatNormals.push_back(nz);
         }
     }
 }

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -579,6 +579,9 @@ void SceneRenderer::DrawMesh(const Mesh &mesh, float scale, const float *modelMa
   const bool gpuHandlesValid = glIsBuffer(mesh.vboVertices) == GL_TRUE &&
                                glIsBuffer(mesh.vboNormals) == GL_TRUE &&
                                glIsBuffer(mesh.eboTriangles) == GL_TRUE;
+  const bool flatGpuHandlesValid =
+      glIsBuffer(mesh.vboFlatVertices) == GL_TRUE &&
+      glIsBuffer(mesh.vboFlatNormals) == GL_TRUE;
   const bool requiresCpuDrawPath = flipWinding;
   const bool canUseGpuTriangles =
       mesh.buffersReady && mesh.vao != 0 && mesh.vboVertices != 0 &&
@@ -589,26 +592,30 @@ void SceneRenderer::DrawMesh(const Mesh &mesh, float scale, const float *modelMa
   glGetIntegerv(GL_SHADE_MODEL, &shadeModel);
   const bool useFaceNormals = (shadeModel == GL_FLAT);
 
-  // Flat shading expects per-face normals. The indexed VBO path uses shared
-  // per-vertex normals, which can produce alternating triangle brightness on
-  // coplanar surfaces. Force the immediate path in GL_FLAT so each triangle
-  // emits its own geometric normal.
-  const bool allowGpuTriangles = canUseGpuTriangles && !useFaceNormals;
+  const bool canUseGpuFlatTriangles =
+      mesh.buffersReady && mesh.vao != 0 && mesh.vboFlatVertices != 0 &&
+      mesh.vboFlatNormals != 0 && mesh.flatVertexCount > 0 &&
+      flatGpuHandlesValid && !requiresCpuDrawPath;
 
-  if (!m_controller.IsCaptureOnly() && allowGpuTriangles) {
+  const bool allowGpuTriangles = canUseGpuTriangles && !useFaceNormals;
+  const bool allowGpuFlatTriangles = canUseGpuFlatTriangles && useFaceNormals;
+
+  if (!m_controller.IsCaptureOnly() && (allowGpuTriangles || allowGpuFlatTriangles)) {
     const bool textureEnabled =
-        useTexture && mesh.textureId != 0 &&
+        allowGpuTriangles && useTexture && mesh.textureId != 0 &&
         mesh.vboTexCoords != 0 &&
         mesh.texcoords.size() >= (mesh.vertices.size() / 3u) * 2u;
     glBindVertexArray(mesh.vao);
     glPushMatrix();
     glScalef(scale, scale, scale);
 
-    glBindBuffer(GL_ARRAY_BUFFER, mesh.vboVertices);
+    glBindBuffer(GL_ARRAY_BUFFER,
+                 allowGpuFlatTriangles ? mesh.vboFlatVertices : mesh.vboVertices);
     glEnableClientState(GL_VERTEX_ARRAY);
     glVertexPointer(3, GL_FLOAT, 0, nullptr);
 
-    glBindBuffer(GL_ARRAY_BUFFER, mesh.vboNormals);
+    glBindBuffer(GL_ARRAY_BUFFER,
+                 allowGpuFlatTriangles ? mesh.vboFlatNormals : mesh.vboNormals);
     glEnableClientState(GL_NORMAL_ARRAY);
     glNormalPointer(GL_FLOAT, 0, nullptr);
 
@@ -620,9 +627,14 @@ void SceneRenderer::DrawMesh(const Mesh &mesh, float scale, const float *modelMa
       glTexCoordPointer(2, GL_FLOAT, 0, nullptr);
     }
 
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mesh.eboTriangles);
-    glDrawElements(GL_TRIANGLES, mesh.triangleIndexCount, GL_UNSIGNED_SHORT,
-                   nullptr);
+    if (allowGpuFlatTriangles) {
+      glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+      glDrawArrays(GL_TRIANGLES, 0, mesh.flatVertexCount);
+    } else {
+      glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mesh.eboTriangles);
+      glDrawElements(GL_TRIANGLES, mesh.triangleIndexCount, GL_UNSIGNED_SHORT,
+                     nullptr);
+    }
 
     if (textureEnabled) {
       glDisableClientState(GL_TEXTURE_COORD_ARRAY);
@@ -631,6 +643,7 @@ void SceneRenderer::DrawMesh(const Mesh &mesh, float scale, const float *modelMa
     }
     glDisableClientState(GL_NORMAL_ARRAY);
     glDisableClientState(GL_VERTEX_ARRAY);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     glPopMatrix();
   } else if (!m_controller.IsCaptureOnly()) {

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1434,6 +1434,7 @@ void Viewer3DController::SetupMeshBuffers(Mesh &mesh) {
 
   if (mesh.normals.size() < mesh.vertices.size())
     ComputeNormals(mesh);
+  BuildFlatShadingBuffers(mesh);
 
   bool includeCoplanarEdgesForCapture =
       ConfigManager::Get().GetFloat(
@@ -1465,6 +1466,18 @@ void Viewer3DController::SetupMeshBuffers(Mesh &mesh) {
                  mesh.texcoords.data(), GL_STATIC_DRAW);
   }
 
+  if (!mesh.flatVertices.empty() && !mesh.flatNormals.empty()) {
+    glGenBuffers(1, &mesh.vboFlatVertices);
+    glBindBuffer(GL_ARRAY_BUFFER, mesh.vboFlatVertices);
+    glBufferData(GL_ARRAY_BUFFER, mesh.flatVertices.size() * sizeof(float),
+                 mesh.flatVertices.data(), GL_STATIC_DRAW);
+
+    glGenBuffers(1, &mesh.vboFlatNormals);
+    glBindBuffer(GL_ARRAY_BUFFER, mesh.vboFlatNormals);
+    glBufferData(GL_ARRAY_BUFFER, mesh.flatNormals.size() * sizeof(float),
+                 mesh.flatNormals.data(), GL_STATIC_DRAW);
+  }
+
   glGenBuffers(1, &mesh.eboTriangles);
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mesh.eboTriangles);
   glBufferData(GL_ELEMENT_ARRAY_BUFFER,
@@ -1489,6 +1502,8 @@ void Viewer3DController::SetupMeshBuffers(Mesh &mesh) {
       glIsBuffer(mesh.vboVertices) == GL_TRUE &&
       glIsBuffer(mesh.vboNormals) == GL_TRUE &&
       (mesh.vboTexCoords == 0 || glIsBuffer(mesh.vboTexCoords) == GL_TRUE) &&
+      (mesh.vboFlatVertices == 0 || glIsBuffer(mesh.vboFlatVertices) == GL_TRUE) &&
+      (mesh.vboFlatNormals == 0 || glIsBuffer(mesh.vboFlatNormals) == GL_TRUE) &&
       glIsBuffer(mesh.eboTriangles) == GL_TRUE &&
       glIsBuffer(mesh.eboLines) == GL_TRUE;
 
@@ -1497,6 +1512,8 @@ void Viewer3DController::SetupMeshBuffers(Mesh &mesh) {
     mesh.vboVertices = 0;
     mesh.vboNormals = 0;
     mesh.vboTexCoords = 0;
+    mesh.vboFlatVertices = 0;
+    mesh.vboFlatNormals = 0;
     mesh.eboTriangles = 0;
     mesh.eboLines = 0;
     mesh.triangleIndexCount = 0;
@@ -1506,6 +1523,7 @@ void Viewer3DController::SetupMeshBuffers(Mesh &mesh) {
   }
 
   mesh.triangleIndexCount = static_cast<int>(mesh.indices.size());
+  mesh.flatVertexCount = static_cast<int>(mesh.flatVertices.size() / 3);
   mesh.lineIndexCount = static_cast<int>(lineIndices.size());
   mesh.buffersReady = true;
 
@@ -1544,6 +1562,14 @@ void Viewer3DController::ReleaseMeshBuffers(Mesh &mesh) {
     glDeleteBuffers(1, &mesh.vboTexCoords);
     mesh.vboTexCoords = 0;
   }
+  if (mesh.vboFlatNormals != 0) {
+    glDeleteBuffers(1, &mesh.vboFlatNormals);
+    mesh.vboFlatNormals = 0;
+  }
+  if (mesh.vboFlatVertices != 0) {
+    glDeleteBuffers(1, &mesh.vboFlatVertices);
+    mesh.vboFlatVertices = 0;
+  }
   if (mesh.vboVertices != 0) {
     glDeleteBuffers(1, &mesh.vboVertices);
     mesh.vboVertices = 0;
@@ -1554,6 +1580,7 @@ void Viewer3DController::ReleaseMeshBuffers(Mesh &mesh) {
   }
 
   mesh.triangleIndexCount = 0;
+  mesh.flatVertexCount = 0;
   mesh.lineIndexCount = 0;
   mesh.buffersReady = false;
 }


### PR DESCRIPTION
### Motivation
- Flat shading (`GL_FLAT`) currently forces the CPU immediate path which causes a per-frame CPU bottleneck and mixes visual choice with backend selection. 
- The change separates the visual shading decision (`GL_FLAT` vs `GL_SMOOTH`) from the GPU/CPU backend choice so flat look can be produced efficiently on the GPU when possible. 

### Description
- Added optional flat-ready mesh storage and GPU handles to `Mesh` (`flatVertices`, `flatNormals`, `vboFlatVertices`, `vboFlatNormals`, `flatVertexCount`) so per-face duplicated vertices and normals can be cached. 
- Implemented `BuildFlatShadingBuffers(mesh)` in `viewer3d/mesh.h` to construct duplicated-vertex + per-face-normal streams suitable for flat shading. 
- Populated and uploaded flat-ready buffers during `Viewer3DController::SetupMeshBuffers` so mesh preparation produces both indexed (smooth) and flat-ready GPU data. 
- Updated `SceneRenderer::DrawMesh` to pick between three backends: indexed VBO+EBO (`GL_SMOOTH`), flat-ready GPU `glDrawArrays` (`GL_FLAT` when buffers exist), and immediate-mode fallback only when flat GPU buffers are unavailable or the CPU path is required (e.g. mirrored winding). 
- Kept resource lifecycle and validation consistent by adding new buffer creation/validation and cleanup in `SetupMeshBuffers` / `ReleaseMeshBuffers`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded. 
- Attempted `cmake --build build -j2` but it could not run in this environment because the repository `build/` directory is not present so a full compile was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee6b9052e4832499318c74943c46ca)