### PR TITLE
cmake: make Windows runtime exclusion regexes path-safe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,10 +313,10 @@ if(WIN32)
             CONFIGURATIONS Release RelWithDebInfo MinSizeRel
             DIRECTORIES ${PERASTAGE_VCPKG_BIN_DIRS}
             PRE_EXCLUDE_REGEXES
-                "^[Aa]pi-[Mm]s-.*\\.dll$"
-                "^[Ee]xt-[Mm]s-.*\\.dll$"
-                "^[Ww]paxholder\\.dll$"
-                "^[Ww]tdccm\\.dll$"
+                ".*[Aa]pi-[Mm]s-[^/\\\\]*\\.dll$"
+                ".*[Ee]xt-[Mm]s-[^/\\\\]*\\.dll$"
+                ".*[Ww]paxholder\\.dll$"
+                ".*[Ww]tdccm\\.dll$"
             POST_EXCLUDE_REGEXES
                 ".*[Ww]indows[\\/].*"
                 ".*[Ss]ystem32[\\/].*"
@@ -332,10 +332,10 @@ if(WIN32)
             DESTINATION .
             DIRECTORIES ${PERASTAGE_VCPKG_BIN_DIRS}
             PRE_EXCLUDE_REGEXES
-                "^[Aa]pi-[Mm]s-.*\\.dll$"
-                "^[Ee]xt-[Mm]s-.*\\.dll$"
-                "^[Ww]paxholder\\.dll$"
-                "^[Ww]tdccm\\.dll$"
+                ".*[Aa]pi-[Mm]s-[^/\\\\]*\\.dll$"
+                ".*[Ee]xt-[Mm]s-[^/\\\\]*\\.dll$"
+                ".*[Ww]paxholder\\.dll$"
+                ".*[Ww]tdccm\\.dll$"
             POST_EXCLUDE_REGEXES
                 ".*[Ww]indows[\\/].*"
                 ".*[Ss]ystem32[\\/].*"


### PR DESCRIPTION
### Motivation
- Fix Windows runtime dependency exclusion patterns that were anchored to filenames and therefore failed to match full-path DLL entries produced by CI, by using path-safe regexes that match both full paths and bare filenames.

### Description
- Replace `PRE_EXCLUDE_REGEXES` entries in both Windows `install(RUNTIME_DEPENDENCY_SET perastage_runtime_deps_release ...)` blocks in `CMakeLists.txt` with path-safe patterns, changing the four entries to `.*[Aa]pi-[Mm]s-[^/\\]*\.dll$`, `.*[Ee]xt-[Mm]s-[^/\\]*\.dll$`, `.*[Ww]paxholder\.dll$`, and `.*[Ww]tdccm\.dll$`, and leave `DESTINATION`, installer logic, and output paths unchanged.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee705a96688324bad0e7a48f10d7b6)