### PR TITLE
Decouple GL_FLAT look from triangle backend selection

### DIFF
--- a/viewer3d/mesh.h
+++ b/viewer3d/mesh.h
@@ -55,6 +55,9 @@ struct Mesh {
     // Optional CPU cache for flat-shading ready triangle streams.
     std::vector<float> flatVertices;
     std::vector<float> flatNormals;
+    // Optional CPU cache for mirrored instances rendered in flat mode.
+    mutable std::vector<float> flippedFlatVertices;
+    mutable std::vector<float> flippedFlatNormals;
 };
 
 // Attempts to detect meshes whose triangle winding is globally inverted and
@@ -218,6 +221,8 @@ inline void BuildFlatShadingBuffers(Mesh& mesh)
 {
     mesh.flatVertices.clear();
     mesh.flatNormals.clear();
+    mesh.flippedFlatVertices.clear();
+    mesh.flippedFlatNormals.clear();
 
     if (mesh.vertices.empty() || mesh.indices.empty())
         return;

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -106,6 +106,49 @@ InkColor QuantizeInkTone(float diffuseFactor) {
   return {1.0f, 1.0f, 1.0f};
 }
 
+void EnsureFlippedFlatCache(const Mesh &mesh) {
+  if (!mesh.flippedFlatVertices.empty() && !mesh.flippedFlatNormals.empty())
+    return;
+
+  mesh.flippedFlatVertices.clear();
+  mesh.flippedFlatNormals.clear();
+  if (mesh.vertices.empty() || mesh.indices.empty())
+    return;
+
+  mesh.flippedFlatVertices.reserve(mesh.indices.size() * 3);
+  mesh.flippedFlatNormals.reserve(mesh.indices.size() * 3);
+
+  for (size_t i = 0; i + 2 < mesh.indices.size(); i += 3) {
+    const unsigned short i0 = mesh.indices[i];
+    const unsigned short i1 = mesh.indices[i + 2];
+    const unsigned short i2 = mesh.indices[i + 1];
+
+    const float v0x = mesh.vertices[i0 * 3];
+    const float v0y = mesh.vertices[i0 * 3 + 1];
+    const float v0z = mesh.vertices[i0 * 3 + 2];
+    const float v1x = mesh.vertices[i1 * 3];
+    const float v1y = mesh.vertices[i1 * 3 + 1];
+    const float v1z = mesh.vertices[i1 * 3 + 2];
+    const float v2x = mesh.vertices[i2 * 3];
+    const float v2y = mesh.vertices[i2 * 3 + 1];
+    const float v2z = mesh.vertices[i2 * 3 + 2];
+
+    const std::array<float, 3> faceNormal = NormalizeVector(
+        (v1y - v0y) * (v2z - v0z) - (v1z - v0z) * (v2y - v0y),
+        (v1z - v0z) * (v2x - v0x) - (v1x - v0x) * (v2z - v0z),
+        (v1x - v0x) * (v2y - v0y) - (v1y - v0y) * (v2x - v0x));
+
+    mesh.flippedFlatVertices.insert(
+        mesh.flippedFlatVertices.end(),
+        {v0x, v0y, v0z, v1x, v1y, v1z, v2x, v2y, v2z});
+    for (int v = 0; v < 3; ++v) {
+      mesh.flippedFlatNormals.push_back(faceNormal[0]);
+      mesh.flippedFlatNormals.push_back(faceNormal[1]);
+      mesh.flippedFlatNormals.push_back(faceNormal[2]);
+    }
+  }
+}
+
 void DrawMeshThreeToneInk(const Mesh &mesh, float scale, const float *modelMatrix) {
   std::array<float, 3> lightDir = NormalizeVector(0.35f, -0.55f, 1.0f);
   const bool hasNormals = mesh.normals.size() >= mesh.vertices.size();
@@ -582,11 +625,10 @@ void SceneRenderer::DrawMesh(const Mesh &mesh, float scale, const float *modelMa
   const bool flatGpuHandlesValid =
       glIsBuffer(mesh.vboFlatVertices) == GL_TRUE &&
       glIsBuffer(mesh.vboFlatNormals) == GL_TRUE;
-  const bool requiresCpuDrawPath = flipWinding;
   const bool canUseGpuTriangles =
       mesh.buffersReady && mesh.vao != 0 && mesh.vboVertices != 0 &&
       mesh.vboNormals != 0 && mesh.eboTriangles != 0 && gpuHandlesValid &&
-      !requiresCpuDrawPath;
+      mesh.triangleIndexCount > 0;
 
   GLint shadeModel = GL_SMOOTH;
   glGetIntegerv(GL_SHADE_MODEL, &shadeModel);
@@ -595,12 +637,29 @@ void SceneRenderer::DrawMesh(const Mesh &mesh, float scale, const float *modelMa
   const bool canUseGpuFlatTriangles =
       mesh.buffersReady && mesh.vao != 0 && mesh.vboFlatVertices != 0 &&
       mesh.vboFlatNormals != 0 && mesh.flatVertexCount > 0 &&
-      flatGpuHandlesValid && !requiresCpuDrawPath;
+      flatGpuHandlesValid;
 
-  const bool allowGpuTriangles = canUseGpuTriangles && !useFaceNormals;
+  const bool canUseGpuVertexArrays =
+      mesh.buffersReady && mesh.vao != 0 && mesh.vboVertices != 0 &&
+      mesh.vboNormals != 0 && gpuHandlesValid;
+
+  const bool hasFlippedFlatCache = [&]() {
+    if (!flipWinding)
+      return false;
+    EnsureFlippedFlatCache(mesh);
+    return !mesh.flippedFlatVertices.empty() && !mesh.flippedFlatNormals.empty();
+  }();
+
+  const bool allowGpuTriangles =
+      canUseGpuTriangles && (!useFaceNormals || !canUseGpuFlatTriangles);
   const bool allowGpuFlatTriangles = canUseGpuFlatTriangles && useFaceNormals;
+  const bool allowCachedFlatTriangles = useFaceNormals && hasFlippedFlatCache;
+  const bool allowDrawElementsWithCpuIndices =
+      canUseGpuVertexArrays && !useFaceNormals && flipWinding;
 
-  if (!m_controller.IsCaptureOnly() && (allowGpuTriangles || allowGpuFlatTriangles)) {
+  if (!m_controller.IsCaptureOnly() &&
+      (allowGpuTriangles || allowGpuFlatTriangles || allowCachedFlatTriangles ||
+       allowDrawElementsWithCpuIndices)) {
     const bool textureEnabled =
         allowGpuTriangles && useTexture && mesh.textureId != 0 &&
         mesh.vboTexCoords != 0 &&
@@ -627,9 +686,22 @@ void SceneRenderer::DrawMesh(const Mesh &mesh, float scale, const float *modelMa
       glTexCoordPointer(2, GL_FLOAT, 0, nullptr);
     }
 
-    if (allowGpuFlatTriangles) {
+    if (allowCachedFlatTriangles) {
+      glBindBuffer(GL_ARRAY_BUFFER, 0);
+      glVertexPointer(3, GL_FLOAT, 0, mesh.flippedFlatVertices.data());
+      glNormalPointer(GL_FLOAT, 0, mesh.flippedFlatNormals.data());
+      glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+      glDrawArrays(
+          GL_TRIANGLES, 0,
+          static_cast<GLsizei>(mesh.flippedFlatVertices.size() / 3));
+    } else if (allowGpuFlatTriangles) {
       glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
       glDrawArrays(GL_TRIANGLES, 0, mesh.flatVertexCount);
+    } else if (allowDrawElementsWithCpuIndices) {
+      glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+      glDrawElements(
+          GL_TRIANGLES, static_cast<GLsizei>(triangleIndices->size()),
+          GL_UNSIGNED_SHORT, triangleIndices->data());
     } else {
       glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mesh.eboTriangles);
       glDrawElements(GL_TRIANGLES, mesh.triangleIndexCount, GL_UNSIGNED_SHORT,


### PR DESCRIPTION
### Motivation
- Allow the GL_FLAT shading appearance to be kept while avoiding forcing a CPU/`glBegin` triangle path just because `GL_FLAT` is active. 
- Keep GPU-backed drawing paths available for both smooth and flat modes and support mirrored instances without regressing performance. 
- Provide a safe immediate-mode fallback only when GPU/client-array approaches are not possible.

### Description
- Added per-mesh mirrored flat caches `flippedFlatVertices` and `flippedFlatNormals` to `Mesh` and clear them from `BuildFlatShadingBuffers` to avoid stale data. (`viewer3d/mesh.h`).
- Implemented `EnsureFlippedFlatCache` to build a flat-ready CPU triangle stream with inverted winding and per-face normals for mirrored instances. (`viewer3d/render/scenerenderer.cpp`).
- Updated `SceneRenderer::DrawMesh` to decouple the `GL_FLAT` aesthetic from backend selection so GPU draw paths remain available: keep GPU vertex/normal buffers active for smooth shading, use `vboFlat*` and `glDrawArrays` for GPU flat triangles, use the newly added flipped-flat CPU cache with client arrays for mirrored flat draws, and use `glDrawElements` with CPU-provided indices for mirrored smooth draws while keeping vertex buffers on GPU. `glBegin`/`glEnd` is preserved as a fallback safety path. (`viewer3d/render/scenerenderer.cpp`).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee7098d9548324aeb35a0a91ff9984)