### PR TITLE
Move three-tone ink sketch shading to GPU in SceneRenderer

### DIFF
--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -106,6 +106,248 @@ InkColor QuantizeInkTone(float diffuseFactor) {
   return {1.0f, 1.0f, 1.0f};
 }
 
+struct ThreeToneInkProgram {
+  GLuint program = 0;
+  GLint positionAttrib = -1;
+  GLint normalAttrib = -1;
+  GLint modelViewUniform = -1;
+  GLint projectionUniform = -1;
+  GLint normalMatrixUniform = -1;
+  GLint lightDirUniform = -1;
+  GLint darkToneUniform = -1;
+  GLint midToneUniform = -1;
+  GLint lightToneUniform = -1;
+  GLint darkThresholdUniform = -1;
+  GLint lightThresholdUniform = -1;
+};
+
+GLuint CompileShader(GLenum shaderType, const char *source) {
+  const GLuint shader = glCreateShader(shaderType);
+  if (shader == 0)
+    return 0;
+  glShaderSource(shader, 1, &source, nullptr);
+  glCompileShader(shader);
+  GLint compiled = GL_FALSE;
+  glGetShaderiv(shader, GL_COMPILE_STATUS, &compiled);
+  if (compiled == GL_TRUE)
+    return shader;
+  glDeleteShader(shader);
+  return 0;
+}
+
+bool LinkProgram(GLuint program) {
+  glLinkProgram(program);
+  GLint linked = GL_FALSE;
+  glGetProgramiv(program, GL_LINK_STATUS, &linked);
+  return linked == GL_TRUE;
+}
+
+ThreeToneInkProgram CreateThreeToneInkProgram() {
+  static constexpr const char *kVertexShader = R"glsl(
+    #version 120
+    attribute vec3 aPosition;
+    attribute vec3 aNormal;
+    uniform mat4 uModelView;
+    uniform mat4 uProjection;
+    uniform mat3 uNormalMatrix;
+    varying vec3 vNormal;
+    void main() {
+      vNormal = normalize(uNormalMatrix * aNormal);
+      gl_Position = uProjection * uModelView * vec4(aPosition, 1.0);
+    }
+  )glsl";
+  static constexpr const char *kFragmentShader = R"glsl(
+    #version 120
+    uniform vec3 uLightDir;
+    uniform vec3 uDarkTone;
+    uniform vec3 uMidTone;
+    uniform vec3 uLightTone;
+    uniform float uDarkThreshold;
+    uniform float uLightThreshold;
+    varying vec3 vNormal;
+    void main() {
+      float ndotl = max(dot(normalize(vNormal), normalize(uLightDir)), 0.0);
+      vec3 tone = uLightTone;
+      if (ndotl <= uDarkThreshold)
+        tone = uDarkTone;
+      else if (ndotl <= uLightThreshold)
+        tone = uMidTone;
+      gl_FragColor = vec4(tone, 1.0);
+    }
+  )glsl";
+
+  ThreeToneInkProgram result;
+  const GLuint vs = CompileShader(GL_VERTEX_SHADER, kVertexShader);
+  const GLuint fs = CompileShader(GL_FRAGMENT_SHADER, kFragmentShader);
+  if (vs == 0 || fs == 0) {
+    if (vs != 0)
+      glDeleteShader(vs);
+    if (fs != 0)
+      glDeleteShader(fs);
+    return result;
+  }
+
+  result.program = glCreateProgram();
+  if (result.program == 0) {
+    glDeleteShader(vs);
+    glDeleteShader(fs);
+    return result;
+  }
+  glAttachShader(result.program, vs);
+  glAttachShader(result.program, fs);
+  glBindAttribLocation(result.program, 0, "aPosition");
+  glBindAttribLocation(result.program, 1, "aNormal");
+  const bool linked = LinkProgram(result.program);
+  glDeleteShader(vs);
+  glDeleteShader(fs);
+  if (!linked) {
+    glDeleteProgram(result.program);
+    result.program = 0;
+    return result;
+  }
+
+  result.positionAttrib = glGetAttribLocation(result.program, "aPosition");
+  result.normalAttrib = glGetAttribLocation(result.program, "aNormal");
+  result.modelViewUniform = glGetUniformLocation(result.program, "uModelView");
+  result.projectionUniform = glGetUniformLocation(result.program, "uProjection");
+  result.normalMatrixUniform =
+      glGetUniformLocation(result.program, "uNormalMatrix");
+  result.lightDirUniform = glGetUniformLocation(result.program, "uLightDir");
+  result.darkToneUniform = glGetUniformLocation(result.program, "uDarkTone");
+  result.midToneUniform = glGetUniformLocation(result.program, "uMidTone");
+  result.lightToneUniform = glGetUniformLocation(result.program, "uLightTone");
+  result.darkThresholdUniform =
+      glGetUniformLocation(result.program, "uDarkThreshold");
+  result.lightThresholdUniform =
+      glGetUniformLocation(result.program, "uLightThreshold");
+  return result;
+}
+
+const ThreeToneInkProgram &GetThreeToneInkProgram() {
+  static const ThreeToneInkProgram program = CreateThreeToneInkProgram();
+  return program;
+}
+
+void ComputeNormalMatrix3x3(const float *modelView, float *normalMatrix3x3) {
+  const float m00 = modelView[0];
+  const float m01 = modelView[4];
+  const float m02 = modelView[8];
+  const float m10 = modelView[1];
+  const float m11 = modelView[5];
+  const float m12 = modelView[9];
+  const float m20 = modelView[2];
+  const float m21 = modelView[6];
+  const float m22 = modelView[10];
+
+  const float c00 = m11 * m22 - m12 * m21;
+  const float c01 = m12 * m20 - m10 * m22;
+  const float c02 = m10 * m21 - m11 * m20;
+  const float c10 = m02 * m21 - m01 * m22;
+  const float c11 = m00 * m22 - m02 * m20;
+  const float c12 = m01 * m20 - m00 * m21;
+  const float c20 = m01 * m12 - m02 * m11;
+  const float c21 = m02 * m10 - m00 * m12;
+  const float c22 = m00 * m11 - m01 * m10;
+  const float det = m00 * c00 + m01 * c01 + m02 * c02;
+  if (std::fabs(det) <= 1e-8f) {
+    normalMatrix3x3[0] = 1.0f;
+    normalMatrix3x3[1] = 0.0f;
+    normalMatrix3x3[2] = 0.0f;
+    normalMatrix3x3[3] = 0.0f;
+    normalMatrix3x3[4] = 1.0f;
+    normalMatrix3x3[5] = 0.0f;
+    normalMatrix3x3[6] = 0.0f;
+    normalMatrix3x3[7] = 0.0f;
+    normalMatrix3x3[8] = 1.0f;
+    return;
+  }
+  const float invDet = 1.0f / det;
+  normalMatrix3x3[0] = c00 * invDet;
+  normalMatrix3x3[1] = c10 * invDet;
+  normalMatrix3x3[2] = c20 * invDet;
+  normalMatrix3x3[3] = c01 * invDet;
+  normalMatrix3x3[4] = c11 * invDet;
+  normalMatrix3x3[5] = c21 * invDet;
+  normalMatrix3x3[6] = c02 * invDet;
+  normalMatrix3x3[7] = c12 * invDet;
+  normalMatrix3x3[8] = c22 * invDet;
+}
+
+bool DrawMeshThreeToneInkGpu(const Mesh &mesh, float scale) {
+  const bool gpuHandlesValid = glIsBuffer(mesh.vboVertices) == GL_TRUE &&
+                               glIsBuffer(mesh.vboNormals) == GL_TRUE &&
+                               glIsBuffer(mesh.eboTriangles) == GL_TRUE;
+  const bool canUseGpuPath =
+      mesh.buffersReady && mesh.vao != 0 && mesh.vboVertices != 0 &&
+      mesh.vboNormals != 0 && mesh.eboTriangles != 0 && gpuHandlesValid &&
+      mesh.triangleIndexCount > 0;
+  if (!canUseGpuPath)
+    return false;
+
+  const ThreeToneInkProgram &program = GetThreeToneInkProgram();
+  if (program.program == 0 || program.positionAttrib < 0 ||
+      program.normalAttrib < 0 || program.modelViewUniform < 0 ||
+      program.projectionUniform < 0 || program.normalMatrixUniform < 0 ||
+      program.lightDirUniform < 0 || program.darkToneUniform < 0 ||
+      program.midToneUniform < 0 || program.lightToneUniform < 0 ||
+      program.darkThresholdUniform < 0 || program.lightThresholdUniform < 0) {
+    return false;
+  }
+
+  GLint priorProgram = 0;
+  glGetIntegerv(GL_CURRENT_PROGRAM, &priorProgram);
+
+  glBindVertexArray(mesh.vao);
+  glPushMatrix();
+  glScalef(scale, scale, scale);
+
+  float modelView[16];
+  float projection[16];
+  glGetFloatv(GL_MODELVIEW_MATRIX, modelView);
+  glGetFloatv(GL_PROJECTION_MATRIX, projection);
+
+  float normalMatrix[9];
+  ComputeNormalMatrix3x3(modelView, normalMatrix);
+
+  glUseProgram(program.program);
+  glUniformMatrix4fv(program.modelViewUniform, 1, GL_FALSE, modelView);
+  glUniformMatrix4fv(program.projectionUniform, 1, GL_FALSE, projection);
+  glUniformMatrix3fv(program.normalMatrixUniform, 1, GL_FALSE, normalMatrix);
+  const std::array<float, 3> lightDir = NormalizeVector(0.35f, -0.55f, 1.0f);
+  glUniform3f(program.lightDirUniform, lightDir[0], lightDir[1], lightDir[2]);
+  glUniform3f(program.darkToneUniform, 0.62f, 0.62f, 0.62f);
+  glUniform3f(program.midToneUniform, 0.84f, 0.84f, 0.84f);
+  glUniform3f(program.lightToneUniform, 1.0f, 1.0f, 1.0f);
+  glUniform1f(program.darkThresholdUniform, 0.10f);
+  glUniform1f(program.lightThresholdUniform, 0.30f);
+
+  glBindBuffer(GL_ARRAY_BUFFER, mesh.vboVertices);
+  glEnableVertexAttribArray(static_cast<GLuint>(program.positionAttrib));
+  glVertexAttribPointer(static_cast<GLuint>(program.positionAttrib), 3, GL_FLOAT,
+                        GL_FALSE, 0, nullptr);
+
+  glBindBuffer(GL_ARRAY_BUFFER, mesh.vboNormals);
+  glEnableVertexAttribArray(static_cast<GLuint>(program.normalAttrib));
+  glVertexAttribPointer(static_cast<GLuint>(program.normalAttrib), 3, GL_FLOAT,
+                        GL_FALSE, 0, nullptr);
+
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mesh.eboTriangles);
+  glDrawElements(GL_TRIANGLES, mesh.triangleIndexCount, GL_UNSIGNED_SHORT,
+                 nullptr);
+
+  glDisableVertexAttribArray(static_cast<GLuint>(program.normalAttrib));
+  glDisableVertexAttribArray(static_cast<GLuint>(program.positionAttrib));
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+  glUseProgram(static_cast<GLuint>(priorProgram));
+  glPopMatrix();
+
+  return true;
+}
+
+void DrawMeshThreeToneInkImmediate(const Mesh &mesh, float scale,
+                                   const float *modelMatrix);
+
 void EnsureFlippedFlatCache(const Mesh &mesh) {
   if (!mesh.flippedFlatVertices.empty() && !mesh.flippedFlatNormals.empty())
     return;
@@ -150,11 +392,17 @@ void EnsureFlippedFlatCache(const Mesh &mesh) {
 }
 
 void DrawMeshThreeToneInk(const Mesh &mesh, float scale, const float *modelMatrix) {
+  if (DrawMeshThreeToneInkGpu(mesh, scale))
+    return;
+  DrawMeshThreeToneInkImmediate(mesh, scale, modelMatrix);
+}
+
+void DrawMeshThreeToneInkImmediate(const Mesh &mesh, float scale,
+                                   const float *modelMatrix) {
   std::array<float, 3> lightDir = NormalizeVector(0.35f, -0.55f, 1.0f);
   const bool hasNormals = mesh.normals.size() >= mesh.vertices.size();
   const bool flipWinding =
       (modelMatrix != nullptr) && TransformDeterminant(modelMatrix) < 0.0f;
-
   const std::vector<unsigned short> *triangleIndices = &mesh.indices;
   if (flipWinding) {
     if (mesh.flippedIndicesCache.size() != mesh.indices.size()) {


### PR DESCRIPTION
### Motivation
- Reduce CPU cost of the sketch/three-tone white-model fill by moving the main `N·L` quantization and color selection to the GPU while preserving the sketch aesthetic.
- Use existing GPU mesh resources to accelerate common paths and keep an immediate-mode fallback for compatibility.

### Description
- Added a small GLSL 1.20 program (vertex + fragment) that quantizes the dot `N·L` into three bands and outputs the corresponding tone, with program creation helpers `CompileShader` and `LinkProgram` and a cached `CreateThreeToneInkProgram`/`GetThreeToneInkProgram` instance.
- Implemented `DrawMeshThreeToneInkGpu` which uses existing mesh GPU handles (`vboVertices`, `vboNormals`, `eboTriangles`) and renders with `glDrawElements(GL_TRIANGLES, ...)`, enabling a GPU-first path when buffers and shader are available.
- Compute and upload the 3x3 normal matrix once per draw using `ComputeNormalMatrix3x3` (from the current `GL_MODELVIEW_MATRIX`) and set uniforms (`uModelView`, `uProjection`, `uNormalMatrix`, light and tone thresholds) to avoid per-vertex inverse-transpose on CPU.
- Kept the original immediate-mode logic as `DrawMeshThreeToneInkImmediate` and made `DrawMeshThreeToneInk` try the GPU path first and fall back to the immediate path when prerequisites are missing, preserving compatibility.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee770715c8832498283526ef796ef2)