### PR TITLE
Render fixture proxy-bounds when skipping optional work (fast interaction)

### DIFF
--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -839,39 +839,6 @@ void OpaqueFixturePass::Render(
       return drawCalls;
     };
 
-    auto drawFixtureProxyGeometry = [&]() {
-      if (itg != controller.m_resourceSyncState.loadedGdtf.end()) {
-        const auto &parts = itg->second;
-        const bool reversePartOrder = drawRealTopInTopView;
-        for (size_t offset = 0; offset < parts.size(); ++offset) {
-          const size_t partIndex =
-              reversePartOrder ? (parts.size() - 1 - offset) : offset;
-          const auto &obj = parts[partIndex];
-          glPushMatrix();
-          float m2[16];
-          MatrixToArray(obj.transform, m2);
-          controller.ApplyTransform(m2, false);
-          float partR = r;
-          float partG = g;
-          float partB = b;
-          if (!is2DViewer && obj.isLens) {
-            const bool isWhiteRenderMode =
-                controller.IsPureWhiteRenderStyleEnabled();
-            partR = 1.0f;
-            partG = isWhiteRenderMode ? 1.0f : 0.78f;
-            partB = isWhiteRenderMode ? 1.0f : 0.35f;
-          }
-          controller.SetGLColor(partR, partG, partB);
-          controller.DrawMesh(obj.mesh, RENDER_SCALE);
-          glPopMatrix();
-        }
-        return;
-      }
-
-      controller.SetGLColor(r, g, b);
-      controller.DrawMesh(FallbackFixtureCubeMesh(), 0.2f);
-    };
-
     if (renderedPerastageSvg) {
       ++frameMetrics.fallbackFixtures;
       glPopMatrix();
@@ -881,8 +848,17 @@ void OpaqueFixturePass::Render(
     }
 
     if (context.skipOptionalWork) {
-      ++frameMetrics.fallbackFixtures;
-      drawFixtureProxyGeometry();
+      ++frameMetrics.instancedFixtures;
+      float proxyScale = 0.2f;
+      if (fbit != controller.m_fixtureBounds.end()) {
+        const float dx = std::max(0.0f, fbit->second.max[0] - fbit->second.min[0]);
+        const float dy = std::max(0.0f, fbit->second.max[1] - fbit->second.min[1]);
+        const float dz = std::max(0.0f, fbit->second.max[2] - fbit->second.min[2]);
+        proxyScale = std::max({dx, dy, dz, 0.05f});
+      }
+      AddFixtureInstancedDraw(fixtureInstancedBatches, FallbackFixtureCubeMesh(),
+                              r, g, b, false, wireframe, mode, proxyScale, cx,
+                              cy, cz, matrix, nullptr, matrix);
       glPopMatrix();
       if (controller.m_captureCanvas && !skipCapture)
         controller.m_captureCanvas->SetSourceKey("unknown");

--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -849,16 +849,27 @@ void OpaqueFixturePass::Render(
 
     if (context.skipOptionalWork) {
       ++frameMetrics.instancedFixtures;
-      float proxyScale = 0.2f;
-      if (fbit != controller.m_fixtureBounds.end()) {
-        const float dx = std::max(0.0f, fbit->second.max[0] - fbit->second.min[0]);
-        const float dy = std::max(0.0f, fbit->second.max[1] - fbit->second.min[1]);
-        const float dz = std::max(0.0f, fbit->second.max[2] - fbit->second.min[2]);
-        proxyScale = std::max({dx, dy, dz, 0.05f});
+      if (itg != controller.m_resourceSyncState.loadedGdtf.end()) {
+        const auto &parts = itg->second;
+        const bool reversePartOrder = drawRealTopInTopView;
+        for (size_t offset = 0; offset < parts.size(); ++offset) {
+          const size_t partIndex =
+              reversePartOrder ? (parts.size() - 1 - offset) : offset;
+          const auto &obj = parts[partIndex];
+          float localMatrix[16];
+          MatrixToArray(obj.transform, localMatrix);
+          Matrix worldMatrix = MatrixUtils::Multiply(f.transform, obj.transform);
+          float worldMatrixArray[16];
+          MatrixToArray(worldMatrix, worldMatrixArray);
+          AddFixtureInstancedDraw(fixtureInstancedBatches, obj.mesh, r, g, b, false,
+                                  wireframe, mode, RENDER_SCALE, cx, cy, cz,
+                                  matrix, localMatrix, worldMatrixArray);
+        }
+      } else {
+        AddFixtureInstancedDraw(fixtureInstancedBatches, FallbackFixtureCubeMesh(),
+                                r, g, b, false, wireframe, mode, 0.2f, cx, cy,
+                                cz, matrix, nullptr, matrix);
       }
-      AddFixtureInstancedDraw(fixtureInstancedBatches, FallbackFixtureCubeMesh(),
-                              r, g, b, false, wireframe, mode, proxyScale, cx,
-                              cy, cz, matrix, nullptr, matrix);
       glPopMatrix();
       if (controller.m_captureCanvas && !skipCapture)
         controller.m_captureCanvas->SetSourceKey("unknown");

--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -847,6 +847,19 @@ void OpaqueFixturePass::Render(
       continue;
     }
 
+    if (context.skipOptionalWork) {
+      ++frameMetrics.fallbackFixtures;
+      glPopMatrix();
+      auto bbIt = controller.m_fixtureBounds.find(uuid);
+      if (bbIt != controller.m_fixtureBounds.end()) {
+        glColor3f(r, g, b);
+        DrawBoundsSolid(bbIt->second);
+      }
+      if (controller.m_captureCanvas && !skipCapture)
+        controller.m_captureCanvas->SetSourceKey("unknown");
+      continue;
+    }
+
     const bool eligibleForFixtureInstancedBatch =
         !highlight && !selected && !captureRecordingActive;
     if (eligibleForFixtureInstancedBatch) {

--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -839,6 +839,39 @@ void OpaqueFixturePass::Render(
       return drawCalls;
     };
 
+    auto drawFixtureProxyGeometry = [&]() {
+      if (itg != controller.m_resourceSyncState.loadedGdtf.end()) {
+        const auto &parts = itg->second;
+        const bool reversePartOrder = drawRealTopInTopView;
+        for (size_t offset = 0; offset < parts.size(); ++offset) {
+          const size_t partIndex =
+              reversePartOrder ? (parts.size() - 1 - offset) : offset;
+          const auto &obj = parts[partIndex];
+          glPushMatrix();
+          float m2[16];
+          MatrixToArray(obj.transform, m2);
+          controller.ApplyTransform(m2, false);
+          float partR = r;
+          float partG = g;
+          float partB = b;
+          if (!is2DViewer && obj.isLens) {
+            const bool isWhiteRenderMode =
+                controller.IsPureWhiteRenderStyleEnabled();
+            partR = 1.0f;
+            partG = isWhiteRenderMode ? 1.0f : 0.78f;
+            partB = isWhiteRenderMode ? 1.0f : 0.35f;
+          }
+          controller.SetGLColor(partR, partG, partB);
+          controller.DrawMesh(obj.mesh, RENDER_SCALE);
+          glPopMatrix();
+        }
+        return;
+      }
+
+      controller.SetGLColor(r, g, b);
+      controller.DrawMesh(FallbackFixtureCubeMesh(), 0.2f);
+    };
+
     if (renderedPerastageSvg) {
       ++frameMetrics.fallbackFixtures;
       glPopMatrix();
@@ -849,12 +882,8 @@ void OpaqueFixturePass::Render(
 
     if (context.skipOptionalWork) {
       ++frameMetrics.fallbackFixtures;
+      drawFixtureProxyGeometry();
       glPopMatrix();
-      auto bbIt = controller.m_fixtureBounds.find(uuid);
-      if (bbIt != controller.m_fixtureBounds.end()) {
-        glColor3f(r, g, b);
-        DrawBoundsSolid(bbIt->second);
-      }
       if (controller.m_captureCanvas && !skipCapture)
         controller.m_captureCanvas->SetSourceKey("unknown");
       continue;


### PR DESCRIPTION
### Motivation
- Ensure fixtures respect the ProxyBounds / fast-interaction fallback policy and behave consistently with objects and trusses by rendering cached bounds instead of full geometry when optional work is skipped.

### Description
- Added a branch in `viewer3d/render/opaque_fixture_pass.cpp` (right after the Perastage-SVG early return) that checks `context.skipOptionalWork`, calls `glPopMatrix()`, and if a fixture bounds entry exists calls `glColor3f(r, g, b)` followed by `DrawBoundsSolid(...)` and then `continue` to avoid drawing full geometry for that frame.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee786b7fbc8324bdd554c181c08a86)