### PR TITLE
3DS importer: use 32-bit indices and apply local coordinate/pivot chunks

### DIFF
--- a/viewer3d/loader3ds.cpp
+++ b/viewer3d/loader3ds.cpp
@@ -43,6 +43,13 @@ struct FaceColorAccum {
     double weight = 0.0;
 };
 
+struct MeshTransform3ds {
+    std::array<float, 3> xAxis = {1.0f, 0.0f, 0.0f};
+    std::array<float, 3> yAxis = {0.0f, 1.0f, 0.0f};
+    std::array<float, 3> zAxis = {0.0f, 0.0f, 1.0f};
+    std::array<float, 3> origin = {0.0f, 0.0f, 0.0f};
+};
+
 static bool EnsureImageHandlersInitialized()
 {
     static bool imageHandlersInitialized = false;
@@ -240,6 +247,10 @@ static void parseMesh(std::ifstream& file, long endPos, Mesh& mesh, size_t verte
 {
     size_t objectVertexStart = vertexBase;
     size_t objectVertexCount = 0;
+    MeshTransform3ds localTransform;
+    bool hasLocalTransform = false;
+    std::array<float, 3> pivot = {0.0f, 0.0f, 0.0f};
+    bool hasPivot = false;
     while(file.tellg() < endPos) {
         Chunk ch; if(!readChunk(file, ch)) return;
         long dataStart = file.tellg();
@@ -272,9 +283,9 @@ static void parseMesh(std::ifstream& file, long endPos, Mesh& mesh, size_t verte
                     file.read(reinterpret_cast<char*>(&c), 2);
                     file.read(reinterpret_cast<char*>(&flag), 2);
 
-                    mesh.indices[start + i * 3] = static_cast<unsigned short>(a + vertexBase);
-                    mesh.indices[start + i * 3 + 1] = static_cast<unsigned short>(b + vertexBase);
-                    mesh.indices[start + i * 3 + 2] = static_cast<unsigned short>(c + vertexBase);
+                    mesh.indices[start + i * 3] = static_cast<uint32_t>(a + vertexBase);
+                    mesh.indices[start + i * 3 + 1] = static_cast<uint32_t>(b + vertexBase);
+                    mesh.indices[start + i * 3 + 2] = static_cast<uint32_t>(c + vertexBase);
                 }
                 while (file.tellg() < next) {
                     Chunk sub;
@@ -321,8 +332,62 @@ static void parseMesh(std::ifstream& file, long endPos, Mesh& mesh, size_t verte
                 }
                 break;
             }
+            case 0x4160: {
+                // Local coordinates system (3DS 0x4160): x/y/z axes and origin.
+                // We apply it after optional pivot compensation so object parts
+                // are positioned/oriented correctly in world/object space.
+                file.read(reinterpret_cast<char*>(localTransform.xAxis.data()), sizeof(float) * 3);
+                file.read(reinterpret_cast<char*>(localTransform.yAxis.data()), sizeof(float) * 3);
+                file.read(reinterpret_cast<char*>(localTransform.zAxis.data()), sizeof(float) * 3);
+                file.read(reinterpret_cast<char*>(localTransform.origin.data()), sizeof(float) * 3);
+                hasLocalTransform = true;
+                break;
+            }
+            case 0x4165: {
+                // Pivot point (3DS 0x4165): subtract before local transform.
+                file.read(reinterpret_cast<char*>(pivot.data()), sizeof(float) * 3);
+                hasPivot = true;
+                break;
+            }
             default:
                 file.seekg(next);
+        }
+    }
+
+    if (objectVertexCount > 0 && (hasLocalTransform || hasPivot)) {
+        for (size_t i = 0; i < objectVertexCount; ++i) {
+            const size_t index = (objectVertexStart + i) * 3;
+            float x = mesh.vertices[index];
+            float y = mesh.vertices[index + 1];
+            float z = mesh.vertices[index + 2];
+
+            if (hasPivot) {
+                x -= pivot[0];
+                y -= pivot[1];
+                z -= pivot[2];
+            }
+
+            if (hasLocalTransform) {
+                const float tx = localTransform.origin[0] +
+                                 localTransform.xAxis[0] * x +
+                                 localTransform.yAxis[0] * y +
+                                 localTransform.zAxis[0] * z;
+                const float ty = localTransform.origin[1] +
+                                 localTransform.xAxis[1] * x +
+                                 localTransform.yAxis[1] * y +
+                                 localTransform.zAxis[1] * z;
+                const float tz = localTransform.origin[2] +
+                                 localTransform.xAxis[2] * x +
+                                 localTransform.yAxis[2] * y +
+                                 localTransform.zAxis[2] * z;
+                mesh.vertices[index] = tx;
+                mesh.vertices[index + 1] = ty;
+                mesh.vertices[index + 2] = tz;
+            } else {
+                mesh.vertices[index] = x;
+                mesh.vertices[index + 1] = y;
+                mesh.vertices[index + 2] = z;
+            }
         }
     }
 }

--- a/viewer3d/loaderglb.cpp
+++ b/viewer3d/loaderglb.cpp
@@ -22,6 +22,7 @@
 #include <fstream>
 #include <vector>
 #include <algorithm>
+#include <cstdint>
 #include <functional>
 #include <wx/wx.h>
 #include <wx/image.h>
@@ -587,7 +588,7 @@ bool LoadGLB(const std::string& path, Mesh& outMesh)
             } else {
                 return false;
             }
-            outMesh.indices[outMesh.indices.size()-idxCount+i] = static_cast<unsigned short>(v + base);
+            outMesh.indices[outMesh.indices.size()-idxCount+i] = static_cast<uint32_t>(v + base);
         }
         applyPrimitiveBaseColorTexture(prim);
         return true;

--- a/viewer3d/mesh.h
+++ b/viewer3d/mesh.h
@@ -24,7 +24,9 @@
 
 struct Mesh {
     std::vector<float> vertices; // x,y,z order in mm
-    std::vector<unsigned short> indices; // 3 indices per triangle
+    // 32-bit indices avoid overflow when concatenated 3DS objects exceed
+    // 65,535 vertices in total.
+    std::vector<uint32_t> indices; // 3 indices per triangle
     std::vector<float> normals;  // optional per-vertex normals
     std::vector<float> texcoords; // optional per-vertex UVs (u,v)
     std::vector<unsigned char> textureRgba; // optional texture pixels RGBA8
@@ -48,7 +50,7 @@ struct Mesh {
     int lineIndexCount = 0;
     bool buffersReady = false;
     // Optional cached triangle index order for mirrored instances.
-    mutable std::vector<unsigned short> flippedIndicesCache;
+    mutable std::vector<uint32_t> flippedIndicesCache;
     // True once we have evaluated/fixed triangle winding for compatibility
     // with assets coming from heterogeneous DCC/export pipelines.
     bool windingChecked = false;
@@ -91,9 +93,9 @@ inline void EnsureOutwardWinding(Mesh& mesh)
     double totalArea = 0.0;
 
     for (size_t i = 0; i + 2 < mesh.indices.size(); i += 3) {
-        const unsigned short i0 = mesh.indices[i];
-        const unsigned short i1 = mesh.indices[i + 1];
-        const unsigned short i2 = mesh.indices[i + 2];
+        const uint32_t i0 = mesh.indices[i];
+        const uint32_t i1 = mesh.indices[i + 1];
+        const uint32_t i2 = mesh.indices[i + 2];
 
         const float v0x = mesh.vertices[i0 * 3];
         const float v0y = mesh.vertices[i0 * 3 + 1];
@@ -163,9 +165,9 @@ inline void ComputeNormals(Mesh& mesh)
     mesh.normals.assign(vcount * 3, 0.0f);
 
     for (size_t i = 0; i + 2 < mesh.indices.size(); i += 3) {
-        unsigned short i0 = mesh.indices[i];
-        unsigned short i1 = mesh.indices[i + 1];
-        unsigned short i2 = mesh.indices[i + 2];
+        uint32_t i0 = mesh.indices[i];
+        uint32_t i1 = mesh.indices[i + 1];
+        uint32_t i2 = mesh.indices[i + 2];
 
         float v0x = mesh.vertices[i0 * 3];
         float v0y = mesh.vertices[i0 * 3 + 1];
@@ -231,9 +233,9 @@ inline void BuildFlatShadingBuffers(Mesh& mesh)
     mesh.flatNormals.reserve(mesh.indices.size() * 3);
 
     for (size_t i = 0; i + 2 < mesh.indices.size(); i += 3) {
-        const unsigned short i0 = mesh.indices[i];
-        const unsigned short i1 = mesh.indices[i + 1];
-        const unsigned short i2 = mesh.indices[i + 2];
+        const uint32_t i0 = mesh.indices[i];
+        const uint32_t i1 = mesh.indices[i + 1];
+        const uint32_t i2 = mesh.indices[i + 2];
 
         const float v0x = mesh.vertices[i0 * 3];
         const float v0y = mesh.vertices[i0 * 3 + 1];

--- a/viewer3d/meshprimitives.cpp
+++ b/viewer3d/meshprimitives.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cmath>
+#include <cstdint>
 #include <string_view>
 
 namespace {
@@ -85,8 +86,8 @@ Mesh BuildCylinderMesh(float topRadius, float bottomRadius, float height, int se
     bottomRadius = std::max(bottomRadius, 0.0f);
 
     const float halfH = height * 0.5f;
-    const unsigned short topCenter = 0;
-    const unsigned short bottomCenter = 1;
+    const uint32_t topCenter = 0;
+    const uint32_t bottomCenter = 1;
     AddVertex(mesh, 0.0f, 0.0f, halfH);
     AddVertex(mesh, 0.0f, 0.0f, -halfH);
 
@@ -99,10 +100,10 @@ Mesh BuildCylinderMesh(float topRadius, float bottomRadius, float height, int se
     }
 
     for (int i = 0; i < segments; ++i) {
-        unsigned short top0 = static_cast<unsigned short>(2 + i * 2);
-        unsigned short bot0 = static_cast<unsigned short>(top0 + 1);
-        unsigned short top1 = static_cast<unsigned short>(2 + ((i + 1) % segments) * 2);
-        unsigned short bot1 = static_cast<unsigned short>(top1 + 1);
+        uint32_t top0 = static_cast<uint32_t>(2 + i * 2);
+        uint32_t bot0 = static_cast<uint32_t>(top0 + 1);
+        uint32_t top1 = static_cast<uint32_t>(2 + ((i + 1) % segments) * 2);
+        uint32_t bot1 = static_cast<uint32_t>(top1 + 1);
 
         mesh.indices.push_back(topCenter);
         mesh.indices.push_back(top0);
@@ -145,10 +146,10 @@ Mesh BuildSphereMesh(float radius, int rings, int segments)
 
     for (int r = 0; r < rings; ++r) {
         for (int s = 0; s < segments; ++s) {
-            unsigned short i0 = static_cast<unsigned short>(r * (segments + 1) + s);
-            unsigned short i1 = static_cast<unsigned short>(i0 + segments + 1);
-            unsigned short i2 = static_cast<unsigned short>(i0 + 1);
-            unsigned short i3 = static_cast<unsigned short>(i1 + 1);
+            uint32_t i0 = static_cast<uint32_t>(r * (segments + 1) + s);
+            uint32_t i1 = static_cast<uint32_t>(i0 + segments + 1);
+            uint32_t i2 = static_cast<uint32_t>(i0 + 1);
+            uint32_t i3 = static_cast<uint32_t>(i1 + 1);
 
             mesh.indices.push_back(i0);
             mesh.indices.push_back(i1);

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include "configmanager.h"
 
 namespace {
@@ -362,7 +363,7 @@ bool DrawMeshThreeToneInkGpu(const Mesh &mesh, float scale) {
                         GL_FALSE, 0, nullptr);
 
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mesh.eboTriangles);
-  glDrawElements(GL_TRIANGLES, mesh.triangleIndexCount, GL_UNSIGNED_SHORT,
+  glDrawElements(GL_TRIANGLES, mesh.triangleIndexCount, GL_UNSIGNED_INT,
                  nullptr);
 
   glDisableVertexAttribArray(static_cast<GLuint>(program.normalAttrib));
@@ -391,9 +392,9 @@ void EnsureFlippedFlatCache(const Mesh &mesh) {
   mesh.flippedFlatNormals.reserve(mesh.indices.size() * 3);
 
   for (size_t i = 0; i + 2 < mesh.indices.size(); i += 3) {
-    const unsigned short i0 = mesh.indices[i];
-    const unsigned short i1 = mesh.indices[i + 2];
-    const unsigned short i2 = mesh.indices[i + 1];
+    const uint32_t i0 = mesh.indices[i];
+    const uint32_t i1 = mesh.indices[i + 2];
+    const uint32_t i2 = mesh.indices[i + 1];
 
     const float v0x = mesh.vertices[i0 * 3];
     const float v0y = mesh.vertices[i0 * 3 + 1];
@@ -433,7 +434,7 @@ void DrawMeshThreeToneInkImmediate(const Mesh &mesh, float scale,
   const bool hasNormals = mesh.normals.size() >= mesh.vertices.size();
   const bool flipWinding =
       (modelMatrix != nullptr) && TransformDeterminant(modelMatrix) < 0.0f;
-  const std::vector<unsigned short> *triangleIndices = &mesh.indices;
+  const std::vector<uint32_t> *triangleIndices = &mesh.indices;
   if (flipWinding) {
     if (mesh.flippedIndicesCache.size() != mesh.indices.size()) {
       mesh.flippedIndicesCache = mesh.indices;
@@ -450,7 +451,7 @@ void DrawMeshThreeToneInkImmediate(const Mesh &mesh, float scale,
 
   glBegin(GL_TRIANGLES);
   for (size_t i = 0; i + 2 < triangleIndices->size(); i += 3) {
-    const unsigned short tri[3] = {(*triangleIndices)[i], (*triangleIndices)[i + 1],
+    const uint32_t tri[3] = {(*triangleIndices)[i], (*triangleIndices)[i + 1],
                                    (*triangleIndices)[i + 2]};
     const float v0x = mesh.vertices[tri[0] * 3];
     const float v0y = mesh.vertices[tri[0] * 3 + 1];
@@ -485,7 +486,7 @@ void DrawMeshThreeToneInkImmediate(const Mesh &mesh, float scale,
             (p1World[1] - p0World[1]) * (p2World[0] - p0World[0]));
 
     for (int v = 0; v < 3; ++v) {
-      const unsigned short idx = tri[v];
+      const uint32_t idx = tri[v];
       const float vx = mesh.vertices[idx * 3] * scale;
       const float vy = mesh.vertices[idx * 3 + 1] * scale;
       const float vz = mesh.vertices[idx * 3 + 2] * scale;
@@ -615,9 +616,9 @@ void SceneRenderer::DrawMeshWithOutline(
       CanvasFill fill;
       fill.color = {r, g, b, 1.0f};
       for (size_t i = 0; i + 2 < mesh.indices.size(); i += 3) {
-        unsigned short i0 = mesh.indices[i];
-        unsigned short i1 = mesh.indices[i + 1];
-        unsigned short i2 = mesh.indices[i + 2];
+        uint32_t i0 = mesh.indices[i];
+        uint32_t i1 = mesh.indices[i + 1];
+        uint32_t i2 = mesh.indices[i + 2];
         std::vector<std::array<float, 3>> pts = {
             {mesh.vertices[i0 * 3] * scale, mesh.vertices[i0 * 3 + 1] * scale,
              mesh.vertices[i0 * 3 + 2] * scale},
@@ -792,9 +793,9 @@ void SceneRenderer::DrawMeshWithOutline(
     CanvasFill fill;
     fill.color = {r, g, b, 1.0f};
     for (size_t i = 0; i + 2 < mesh.indices.size(); i += 3) {
-      unsigned short i0 = mesh.indices[i];
-      unsigned short i1 = mesh.indices[i + 1];
-      unsigned short i2 = mesh.indices[i + 2];
+      uint32_t i0 = mesh.indices[i];
+      uint32_t i1 = mesh.indices[i + 1];
+      uint32_t i2 = mesh.indices[i + 2];
       std::vector<std::array<float, 3>> pts = {
           {mesh.vertices[i0 * 3] * scale, mesh.vertices[i0 * 3 + 1] * scale,
            mesh.vertices[i0 * 3 + 2] * scale},
@@ -837,7 +838,7 @@ void SceneRenderer::DrawMeshWireframe(
     glVertexPointer(3, GL_FLOAT, 0, nullptr);
 
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mesh.eboLines);
-    glDrawElements(GL_LINES, mesh.lineIndexCount, GL_UNSIGNED_SHORT, nullptr);
+    glDrawElements(GL_LINES, mesh.lineIndexCount, GL_UNSIGNED_INT, nullptr);
 
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mesh.eboTriangles);
 
@@ -847,9 +848,9 @@ void SceneRenderer::DrawMeshWireframe(
   } else if (!m_controller.IsCaptureOnly()) {
     glBegin(GL_LINES);
     for (size_t i = 0; i + 2 < mesh.indices.size(); i += triangleAdvance) {
-      const unsigned short i0 = mesh.indices[i];
-      const unsigned short i1 = mesh.indices[i + 1];
-      const unsigned short i2 = mesh.indices[i + 2];
+      const uint32_t i0 = mesh.indices[i];
+      const uint32_t i1 = mesh.indices[i + 1];
+      const uint32_t i2 = mesh.indices[i + 2];
 
       glVertex3f(mesh.vertices[i0 * 3] * scale, mesh.vertices[i0 * 3 + 1] * scale,
                  mesh.vertices[i0 * 3 + 2] * scale);
@@ -875,9 +876,9 @@ void SceneRenderer::DrawMeshWireframe(
       stroke.width = 1.0f;
     }
     for (size_t i = 0; i + 2 < mesh.indices.size(); i += triangleAdvance) {
-      unsigned short i0 = mesh.indices[i];
-      unsigned short i1 = mesh.indices[i + 1];
-      unsigned short i2 = mesh.indices[i + 2];
+      uint32_t i0 = mesh.indices[i];
+      uint32_t i1 = mesh.indices[i + 1];
+      uint32_t i2 = mesh.indices[i + 2];
 
       std::array<float, 3> p0 = {mesh.vertices[i0 * 3] * scale,
                                  mesh.vertices[i0 * 3 + 1] * scale,
@@ -910,7 +911,7 @@ void SceneRenderer::DrawMesh(const Mesh &mesh, float scale, const float *modelMa
   const bool flipWinding =
       (modelMatrix != nullptr) && TransformDeterminant(modelMatrix) < 0.0f;
 
-  const std::vector<unsigned short> *triangleIndices = &mesh.indices;
+  const std::vector<uint32_t> *triangleIndices = &mesh.indices;
   if (flipWinding) {
     if (mesh.flippedIndicesCache.size() != mesh.indices.size()) {
       mesh.flippedIndicesCache = mesh.indices;
@@ -1004,10 +1005,10 @@ void SceneRenderer::DrawMesh(const Mesh &mesh, float scale, const float *modelMa
       glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
       glDrawElements(
           GL_TRIANGLES, static_cast<GLsizei>(triangleIndices->size()),
-          GL_UNSIGNED_SHORT, triangleIndices->data());
+          GL_UNSIGNED_INT, triangleIndices->data());
     } else {
       glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mesh.eboTriangles);
-      glDrawElements(GL_TRIANGLES, mesh.triangleIndexCount, GL_UNSIGNED_SHORT,
+      glDrawElements(GL_TRIANGLES, mesh.triangleIndexCount, GL_UNSIGNED_INT,
                      nullptr);
     }
 
@@ -1031,9 +1032,9 @@ void SceneRenderer::DrawMesh(const Mesh &mesh, float scale, const float *modelMa
     }
     glBegin(GL_TRIANGLES);
     for (size_t i = 0; i + 2 < triangleIndices->size(); i += 3) {
-      const unsigned short i0 = (*triangleIndices)[i];
-      const unsigned short i1 = (*triangleIndices)[i + 1];
-      const unsigned short i2 = (*triangleIndices)[i + 2];
+      const uint32_t i0 = (*triangleIndices)[i];
+      const uint32_t i1 = (*triangleIndices)[i + 1];
+      const uint32_t i2 = (*triangleIndices)[i + 2];
 
       const float v0x = mesh.vertices[i0 * 3] * scale;
       const float v0y = mesh.vertices[i0 * 3 + 1] * scale;

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -224,8 +224,8 @@ static std::string NormalizeModelKey(const std::string &p) {
 }
 
 struct EdgeKey {
-  unsigned short a = 0;
-  unsigned short b = 0;
+  uint32_t a = 0;
+  uint32_t b = 0;
 
   bool operator==(const EdgeKey &other) const {
     return a == other.a && b == other.b;
@@ -234,7 +234,7 @@ struct EdgeKey {
 
 struct EdgeKeyHash {
   size_t operator()(const EdgeKey &key) const {
-    return (static_cast<size_t>(key.a) << 16u) ^ static_cast<size_t>(key.b);
+    return (static_cast<size_t>(key.a) << 32u) ^ static_cast<size_t>(key.b);
   }
 };
 
@@ -245,9 +245,9 @@ struct EdgeInfo {
 };
 
 static std::array<float, 3> BuildFaceNormal(const std::vector<float> &vertices,
-                                            unsigned short i0,
-                                            unsigned short i1,
-                                            unsigned short i2) {
+                                            uint32_t i0,
+                                            uint32_t i1,
+                                            uint32_t i2) {
   const size_t p0 = static_cast<size_t>(i0) * 3u;
   const size_t p1 = static_cast<size_t>(i1) * 3u;
   const size_t p2 = static_cast<size_t>(i2) * 3u;
@@ -275,9 +275,9 @@ static std::array<float, 3> BuildFaceNormal(const std::vector<float> &vertices,
   return {nx, ny, nz};
 }
 
-static std::vector<unsigned short>
+static std::vector<uint32_t>
 BuildWireframeIndices(const std::vector<float> &vertices,
-                      const std::vector<unsigned short> &triangleIndices,
+                      const std::vector<uint32_t> &triangleIndices,
                       bool includeCoplanarEdges) {
   static constexpr float kCreaseAngleDeg = 5.0f;
   static constexpr float kPi = 3.14159265358979323846f;
@@ -287,7 +287,7 @@ BuildWireframeIndices(const std::vector<float> &vertices,
   std::unordered_map<EdgeKey, EdgeInfo, EdgeKeyHash> edges;
   edges.reserve(triangleIndices.size());
 
-  auto registerEdge = [&](unsigned short i, unsigned short j,
+  auto registerEdge = [&](uint32_t i, uint32_t j,
                           const std::array<float, 3> &faceNormal) {
     const EdgeKey key = {std::min(i, j), std::max(i, j)};
     EdgeInfo &info = edges[key];
@@ -299,9 +299,9 @@ BuildWireframeIndices(const std::vector<float> &vertices,
   };
 
   for (size_t i = 0; i + 2 < triangleIndices.size(); i += 3) {
-    const unsigned short i0 = triangleIndices[i];
-    const unsigned short i1 = triangleIndices[i + 1];
-    const unsigned short i2 = triangleIndices[i + 2];
+    const uint32_t i0 = triangleIndices[i];
+    const uint32_t i1 = triangleIndices[i + 1];
+    const uint32_t i2 = triangleIndices[i + 2];
     const std::array<float, 3> faceNormal = BuildFaceNormal(vertices, i0, i1, i2);
 
     registerEdge(i0, i1, faceNormal);
@@ -309,7 +309,7 @@ BuildWireframeIndices(const std::vector<float> &vertices,
     registerEdge(i2, i0, faceNormal);
   }
 
-  std::vector<unsigned short> lineIndices;
+  std::vector<uint32_t> lineIndices;
   lineIndices.reserve(edges.size() * 2u);
   for (const auto &[edge, info] : edges) {
     if (info.count == 1) {
@@ -1443,7 +1443,7 @@ void Viewer3DController::SetupMeshBuffers(Mesh &mesh) {
     includeCoplanarEdgesForCapture =
         m_impl->symbolCaptureIncludeCoplanarEdgesOverride.value();
   }
-  std::vector<unsigned short> lineIndices = BuildWireframeIndices(
+  std::vector<uint32_t> lineIndices = BuildWireframeIndices(
       mesh.vertices, mesh.indices, includeCoplanarEdgesForCapture);
 
   glGenVertexArrays(1, &mesh.vao);
@@ -1481,13 +1481,13 @@ void Viewer3DController::SetupMeshBuffers(Mesh &mesh) {
   glGenBuffers(1, &mesh.eboTriangles);
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mesh.eboTriangles);
   glBufferData(GL_ELEMENT_ARRAY_BUFFER,
-               mesh.indices.size() * sizeof(unsigned short),
+               mesh.indices.size() * sizeof(uint32_t),
                mesh.indices.data(), GL_STATIC_DRAW);
 
   glGenBuffers(1, &mesh.eboLines);
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mesh.eboLines);
   glBufferData(GL_ELEMENT_ARRAY_BUFFER,
-               lineIndices.size() * sizeof(unsigned short),
+               lineIndices.size() * sizeof(uint32_t),
                lineIndices.data(), GL_STATIC_DRAW);
 
   // Restore the triangle index buffer while the VAO is bound so the VAO keeps


### PR DESCRIPTION
### Motivation
- Fix corrupted/shifted meshes produced when concatenating multiple 3DS objects that push total vertex count above 65,535 due to 16-bit index truncation. 
- Honor 3DS object-local transform information (`0x4160`) and pivot (`0x4165`) so sub-objects keep correct orientation and origin when imported. 
- Keep existing API/behavior for small meshes while preventing regressions in rendering and index handling.

### Description
- Changed `Mesh::indices` and related caches from 16-bit to 32-bit (`std::vector<uint32_t>`) and updated all affected consumer code paths (mesh utilities, primitive builders, wireframe index builder). 
- Updated 3DS parser in `viewer3d/loader3ds.cpp` to write faces into 32-bit indices and to read/apply chunk `0x4160` (local coordinate system matrix: three 3-vectors + origin) and `0x4165` (pivot vector), applying pivot subtraction first and then the local transform to the object's vertices. 
- Switched GPU uploads and draw calls to use 32-bit element indices (`sizeof(uint32_t)` and `GL_UNSIGNED_INT`) for EBOs and wireframe buffers, and adjusted CPU draw paths to consume `uint32_t` indices. 
- Kept other loaders consistent by changing GLB loader index assignment to `uint32_t`, and adjusted hash/edge key logic to avoid collisions when keys store 32-bit indices.

### Testing
- Ran repository checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both succeeded. 
- Attempted full configure/build with `cmake -S . -B build && cmake --build build -j2`, which failed in this environment due to missing `wxWidgets` development libraries (configure error), so binary build/run tests were not executed here. 
- No automated visual tests were available in the headless environment; model verification with `head.3ds`, `Head(2).3ds` and `Yoke(2).3ds` should be performed locally to confirm the fixes visually.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee8199f7dc8324b81e475e777f1903)