### PR TITLE
Exclude Windows API-set DLLs from CMake runtime dependency scanning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,8 +313,10 @@ if(WIN32)
             CONFIGURATIONS Release RelWithDebInfo MinSizeRel
             DIRECTORIES ${PERASTAGE_VCPKG_BIN_DIRS}
             PRE_EXCLUDE_REGEXES
-                ".*[Aa]pi-[Mm]s-[^/\\\\]*\\.dll$"
-                ".*[Ee]xt-[Mm]s-[^/\\\\]*\\.dll$"
+                ".*api-ms-win-.*\\.dll$"
+                ".*ext-ms-win-.*\\.dll$"
+                ".*api-ms-.*\\.dll$"
+                ".*ext-ms-.*\\.dll$"
                 ".*[Ww]paxholder\\.dll$"
                 ".*[Ww]tdccm\\.dll$"
             POST_EXCLUDE_REGEXES
@@ -332,8 +334,10 @@ if(WIN32)
             DESTINATION .
             DIRECTORIES ${PERASTAGE_VCPKG_BIN_DIRS}
             PRE_EXCLUDE_REGEXES
-                ".*[Aa]pi-[Mm]s-[^/\\\\]*\\.dll$"
-                ".*[Ee]xt-[Mm]s-[^/\\\\]*\\.dll$"
+                ".*api-ms-win-.*\\.dll$"
+                ".*ext-ms-win-.*\\.dll$"
+                ".*api-ms-.*\\.dll$"
+                ".*ext-ms-.*\\.dll$"
                 ".*[Ww]paxholder\\.dll$"
                 ".*[Ww]tdccm\\.dll$"
             POST_EXCLUDE_REGEXES


### PR DESCRIPTION
### Motivation
- CMake's `file(GET_RUNTIME_DEPENDENCIES)` can attempt to resolve Windows API-set pseudo-DLL names (like `api-ms-win-*.dll`), causing GitHub Actions `perastage_stage` to fail when those names are treated as real files.
- The previous `PRE_EXCLUDE_REGEXES` did not robustly match full paths for all API-set variants and must be tightened to avoid resolution attempts.

### Description
- Updated `PRE_EXCLUDE_REGEXES` in both Windows `install(RUNTIME_DEPENDENCY_SET ...)` blocks in `CMakeLists.txt` to use the provided full-path-compatible exclusions: `".*api-ms-win-.*\\.dll$"`, `".*ext-ms-win-.*\\.dll$"`, `".*api-ms-.*\\.dll$"`, `".*ext-ms-.*\\.dll$"`, `".*[Ww]paxholder\\.dll$"`, and `".*[Ww]tdccm\\.dll$"`.
- Applied the change in the multi-config block (`CONFIGURATIONS Release RelWithDebInfo MinSizeRel`) and the single-config non-Debug block.
- Left `POST_EXCLUDE_REGEXES`, install destinations, staging logic, and targets unchanged, and kept comments in English.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee8585f44083248d82b0630a3e1899)