### PR TITLE
Fix Windows runtime dependency exclusion patterns during install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,12 +313,12 @@ if(WIN32)
             CONFIGURATIONS Release RelWithDebInfo MinSizeRel
             DIRECTORIES ${PERASTAGE_VCPKG_BIN_DIRS}
             PRE_EXCLUDE_REGEXES
-                ".*api-ms-win-.*\\.dll$"
-                ".*ext-ms-win-.*\\.dll$"
-                ".*api-ms-.*\\.dll$"
-                ".*ext-ms-.*\\.dll$"
-                ".*[Ww]paxholder\\.dll$"
-                ".*[Ww]tdccm\\.dll$"
+                "api-ms-win-.*"
+                "ext-ms-win-.*"
+                "api-ms-.*"
+                "ext-ms-.*"
+                ".*wpaxholder.*"
+                ".*wtdccm.*"
             POST_EXCLUDE_REGEXES
                 ".*[Ww]indows[\\/].*"
                 ".*[Ss]ystem32[\\/].*"
@@ -334,12 +334,12 @@ if(WIN32)
             DESTINATION .
             DIRECTORIES ${PERASTAGE_VCPKG_BIN_DIRS}
             PRE_EXCLUDE_REGEXES
-                ".*api-ms-win-.*\\.dll$"
-                ".*ext-ms-win-.*\\.dll$"
-                ".*api-ms-.*\\.dll$"
-                ".*ext-ms-.*\\.dll$"
-                ".*[Ww]paxholder\\.dll$"
-                ".*[Ww]tdccm\\.dll$"
+                "api-ms-win-.*"
+                "ext-ms-win-.*"
+                "api-ms-.*"
+                "ext-ms-.*"
+                ".*wpaxholder.*"
+                ".*wtdccm.*"
             POST_EXCLUDE_REGEXES
                 ".*[Ww]indows[\\/].*"
                 ".*[Ss]ystem32[\\/].*"


### PR DESCRIPTION
### Motivation
- CMake install was failing on Windows during runtime dependency resolution because system API shim DLL names (e.g. `api-ms-*`, `ext-ms-*`) and some runtime entries were not being matched by the existing exclusion regexes in the install rules. 
- The intent is to exclude system-provided DLLs from `install(RUNTIME_DEPENDENCY_SET ...)` so CMake does not try to resolve or copy them into the application bundle.

### Description
- Broadened the `PRE_EXCLUDE_REGEXES` in `CMakeLists.txt` for both multi-config (`CMAKE_CONFIGURATION_TYPES`) and single-config non-Debug branches to use patterns `api-ms-win-.*`, `ext-ms-win-.*`, `api-ms-.*`, `ext-ms-.*`, `.*wpaxholder.*`, and `.*wtdccm.*` instead of the previous suffix-anchored forms. 
- This removes strict `\.dll$` anchors that prevented matching Windows API shim names and simplifies matching for `wpaxholder` and `wtdccm` entries. 
- Left existing `POST_EXCLUDE_REGEXES` (path-based filters for `Windows`, `System32`, and debug-suffixed DLLs) unchanged as a secondary safeguard. 
- Changes are localized to the install-time runtime dependency exclusion block in `CMakeLists.txt` (around lines 306–350). 

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eefe3b36348324a3fc6763abd97830)