### PR TITLE
Improve 3DS fallback diagnostics for large GDTF fixtures

### DIFF
--- a/peraviz/native/src/mesh_3ds_loader.cpp
+++ b/peraviz/native/src/mesh_3ds_loader.cpp
@@ -479,14 +479,16 @@ void parse_mesh_chunk(std::ifstream &file, std::streampos mesh_end, MeshData &me
     }
 }
 
-bool load_3ds(const std::string &path, MeshData &mesh) {
+bool load_3ds(const std::string &path, MeshData &mesh, std::string &error_message) {
     std::ifstream file(path, std::ios::binary);
     if (!file.is_open()) {
+        error_message = "Could not open file";
         return false;
     }
 
     Chunk root;
     if (!read_chunk(file, root) || root.id != 0x4D4D) {
+        error_message = "Invalid 3DS root chunk";
         return false;
     }
 
@@ -549,6 +551,7 @@ bool load_3ds(const std::string &path, MeshData &mesh) {
     }
 
     if (mesh.vertices.empty() || mesh.indices.empty()) {
+        error_message = "3DS parsed but mesh had no triangles";
         return false;
     }
 
@@ -580,6 +583,7 @@ bool load_3ds(const std::string &path, MeshData &mesh) {
 
     ensure_godot_clockwise_winding(mesh);
     compute_normals(mesh);
+    error_message.clear();
     return true;
 }
 
@@ -598,8 +602,12 @@ bool load_3ds_mesh_data(const godot::String &path,
                         godot::String &out_error) {
     MeshData mesh;
     const std::string utf8_path(path.utf8().get_data());
-    if (!load_3ds(utf8_path, mesh)) {
-        out_error = godot::String("Failed to parse 3DS mesh");
+    std::string parse_error;
+    if (!load_3ds(utf8_path, mesh, parse_error)) {
+        if (parse_error.empty()) {
+            parse_error = "Failed to parse 3DS mesh";
+        }
+        out_error = godot::String(parse_error.c_str());
         return false;
     }
 

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -1006,10 +1006,15 @@ func _load_3d_asset(asset_path: String, asset_kind_hint: String = "", flip_orien
 
 		var mesh_data: Dictionary = _loader.load_3ds_mesh_data(asset_path)
 		if not bool(mesh_data.get("ok", false)):
+			var parse_error: String = str(mesh_data.get("error", "unknown 3DS parse error"))
+			push_warning("[Peraviz] Failed to parse 3DS mesh: %s (%s)" % [asset_path, parse_error])
 			_asset_cache.mark_failed(asset_path)
 			return null
 		var mesh: ArrayMesh = _build_3ds_mesh(mesh_data, flip_orientation)
 		if mesh == null:
+			var vertex_count: int = int((mesh_data.get("vertices", PackedVector3Array()) as PackedVector3Array).size())
+			var index_count: int = int((mesh_data.get("indices", PackedInt32Array()) as PackedInt32Array).size())
+			push_warning("[Peraviz] Failed to build ArrayMesh from 3DS data: %s (vertices=%d indices=%d)" % [asset_path, vertex_count, index_count])
 			_asset_cache.mark_failed(asset_path)
 			return null
 		_asset_cache.store_mesh(mesh_cache_key, mesh)

--- a/peraviz/scripts/scene_loading/node_factory.gd
+++ b/peraviz/scripts/scene_loading/node_factory.gd
@@ -321,10 +321,15 @@ func _load_3d_asset(asset_path: String, loader: PeravizLoader, asset_cache: Pera
 			return cached_mesh_instance
 		var mesh_data: Dictionary = loader.load_3ds_mesh_data(asset_path)
 		if not bool(mesh_data.get("ok", false)):
+			var parse_error: String = str(mesh_data.get("error", "unknown 3DS parse error"))
+			push_warning("[Peraviz] Failed to parse 3DS mesh: %s (%s)" % [asset_path, parse_error])
 			asset_cache.mark_failed(asset_path)
 			return null
 		var mesh: ArrayMesh = _build_3ds_mesh(mesh_data, flip_orientation)
 		if mesh == null:
+			var vertex_count: int = int((mesh_data.get("vertices", PackedVector3Array()) as PackedVector3Array).size())
+			var index_count: int = int((mesh_data.get("indices", PackedInt32Array()) as PackedInt32Array).size())
+			push_warning("[Peraviz] Failed to build ArrayMesh from 3DS data: %s (vertices=%d indices=%d)" % [asset_path, vertex_count, index_count])
 			asset_cache.mark_failed(asset_path)
 			return null
 		asset_cache.store_mesh(mesh_cache_key, mesh)


### PR DESCRIPTION
### Motivation
- Large or complex GDTF payloads using legacy .3ds models can silently fall back to proxy/dummy visuals when parsing or ArrayMesh construction fails, making triage difficult. 
- The change aims to make failures actionable by surfacing parser-side reasons and mesh cardinality in runtime logs so we can determine whether a mesh failed to load or a proxy was intentionally used.

### Description
- Changed `peraviz/native/src/mesh_3ds_loader.cpp` to propagate explicit parse error messages from the low-level `.3ds` loader (e.g. `Could not open file`, `Invalid 3DS root chunk`, `3DS parsed but mesh had no triangles`) by extending `load_3ds(...)` to return an error string and returning that from `load_3ds_mesh_data(...)` when parsing fails. 
- Added runtime warnings in `peraviz/scripts/scene_loading/node_factory.gd` that log the parser-provided error when `load_3ds_mesh_data` fails and log vertex/index counts when `ArrayMesh` construction fails. 
- Added the same diagnostic warnings in the legacy loader path `peraviz/scripts/load_scene.gd` so both scene-loading code paths report the parse reason and mesh cardinality on failure. 
- During investigation I inspected `library/fixtures/impression X4 Bar 20.gdtf` and observed heavy `.3ds` payloads (`models/3ds/Head(2).3ds`, `models/3ds/Yoke(2).3ds`) with large vertex counts, motivating the need for clearer diagnostics (no behavioral change to fallback logic was introduced).

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which succeeded. 
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef05f702d883248dc8043e790a1211)