### PR TITLE
Fix Windows API-set DLL exclusions in runtime dependency staging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,12 +313,12 @@ if(WIN32)
             CONFIGURATIONS Release RelWithDebInfo MinSizeRel
             DIRECTORIES ${PERASTAGE_VCPKG_BIN_DIRS}
             PRE_EXCLUDE_REGEXES
-                "api-ms-win-.*"
-                "ext-ms-win-.*"
-                "api-ms-.*"
-                "ext-ms-.*"
-                ".*wpaxholder.*"
-                ".*wtdccm.*"
+                ".*api-ms-win-.*\\.dll$"
+                ".*ext-ms-win-.*\\.dll$"
+                ".*api-ms-.*\\.dll$"
+                ".*ext-ms-.*\\.dll$"
+                ".*[Ww]paxholder\\.dll$"
+                ".*[Ww]tdccm\\.dll$"
             POST_EXCLUDE_REGEXES
                 ".*[Ww]indows[\\/].*"
                 ".*[Ss]ystem32[\\/].*"
@@ -334,12 +334,12 @@ if(WIN32)
             DESTINATION .
             DIRECTORIES ${PERASTAGE_VCPKG_BIN_DIRS}
             PRE_EXCLUDE_REGEXES
-                "api-ms-win-.*"
-                "ext-ms-win-.*"
-                "api-ms-.*"
-                "ext-ms-.*"
-                ".*wpaxholder.*"
-                ".*wtdccm.*"
+                ".*api-ms-win-.*\\.dll$"
+                ".*ext-ms-win-.*\\.dll$"
+                ".*api-ms-.*\\.dll$"
+                ".*ext-ms-.*\\.dll$"
+                ".*[Ww]paxholder\\.dll$"
+                ".*[Ww]tdccm\\.dll$"
             POST_EXCLUDE_REGEXES
                 ".*[Ww]indows[\\/].*"
                 ".*[Ss]ystem32[\\/].*"


### PR DESCRIPTION
### Motivation
- CMake's `file(GET_RUNTIME_DEPENDENCIES)` can attempt to resolve Windows API-set pseudo-DLL names (e.g. `api-ms-win-*`, `ext-ms-win-*`) which are not real files and cause staging failures in CI. 
- The previous `PRE_EXCLUDE_REGEXES` did not robustly match full paths or the `.dll` suffix, so some API-set entries were not excluded.

### Description
- Updated the `PRE_EXCLUDE_REGEXES` in both Windows `install(RUNTIME_DEPENDENCY_SET ...)` blocks in `CMakeLists.txt` to use full-path-safe, DLL-anchored regexes that exclude `api-ms-win-*`, `ext-ms-win-*`, `api-ms-*`, `ext-ms-*`, and case-tolerant `wpaxholder.dll` / `wtdccm.dll` matches. 
- Left `POST_EXCLUDE_REGEXES`, install destinations, staging logic, and target wiring unchanged. 
- Only the regex lists were modified and comments remain in English.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef110a95008324b4eec50fa3c0a3f8)