### PR TITLE
cmake: exclude additional Windows system DLLs from runtime dependency staging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,6 +317,10 @@ if(WIN32)
                 ".*ext-ms-win-.*\\.dll$"
                 ".*api-ms-.*\\.dll$"
                 ".*ext-ms-.*\\.dll$"
+                "(?i).*AzureAttest.*\\.dll$"
+                "(?i).*HvsiFileTrust.*\\.dll$"
+                "(?i).*PdmUtilities.*\\.dll$"
+                "(?i).*WTDSENSOR.*\\.dll$"
                 ".*[Ww]paxholder\\.dll$"
                 ".*[Ww]tdccm\\.dll$"
             POST_EXCLUDE_REGEXES
@@ -338,6 +342,10 @@ if(WIN32)
                 ".*ext-ms-win-.*\\.dll$"
                 ".*api-ms-.*\\.dll$"
                 ".*ext-ms-.*\\.dll$"
+                "(?i).*AzureAttest.*\\.dll$"
+                "(?i).*HvsiFileTrust.*\\.dll$"
+                "(?i).*PdmUtilities.*\\.dll$"
+                "(?i).*WTDSENSOR.*\\.dll$"
                 ".*[Ww]paxholder\\.dll$"
                 ".*[Ww]tdccm\\.dll$"
             POST_EXCLUDE_REGEXES


### PR DESCRIPTION
### Motivation
- The Windows packaging step failed when CMake attempted to stage system/virtualization DLLs that should not be redistributed, producing unresolved runtime dependency errors for several OS components. 
- Adding exclusion patterns for these known system DLL families prevents false unresolved-runtime failures during the `perastage_stage` CI step.

### Description
- Added case-insensitive `PRE_EXCLUDE_REGEXES` entries to ignore `AzureAttest`, `HvsiFileTrust`, `PdmUtilities`, and `WTDSENSOR` DLLs by adding the patterns `(?i).*AzureAttest.*\.dll$`, `(?i).*HvsiFileTrust.*\.dll$`, `(?i).*PdmUtilities.*\.dll$`, and `(?i).*WTDSENSOR.*\.dll$`.
- Applied these additions in both Windows `install(RUNTIME_DEPENDENCY_SET ...)` blocks (the multi-configuration `Release/RelWithDebInfo/MinSizeRel` block and the single-configuration non-`Debug` block).
- Kept all existing exclusion patterns (API-set and the prior `Wpaxholder`/`Wtdccm` filters) and did not change install destinations or any other install logic.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef3f7a18f8832493c3fd427cac276a)