### PR TITLE
Avoid caching textured base pass during camera interaction

### DIFF
--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -635,7 +635,7 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
                 .count();
         m_fullRenderMsAccumInCurrentWindow += fullRenderElapsedMs;
         ++m_fullRenderSamplesInCurrentWindow;
-        if (m_basePassCache) {
+        if (m_basePassCache && !m_cameraMoving && !m_isInteracting) {
             m_basePassCache->CaptureFromDefaultFramebuffer(
                 renderSize.width, renderSize.height, cameraFingerprint,
                 hiddenLayers, sceneVersion);

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -267,8 +267,11 @@ void DrawTexturedStyleBackgroundGradient(float horizonNdcY) {
     const GLboolean lightingWasEnabled = glIsEnabled(GL_LIGHTING);
     const GLboolean cullFaceWasEnabled = glIsEnabled(GL_CULL_FACE);
     const GLboolean texture2DWasEnabled = glIsEnabled(GL_TEXTURE_2D);
+    GLint shadeModel = GL_SMOOTH;
+    glGetIntegerv(GL_SHADE_MODEL, &shadeModel);
 
     glDisable(GL_DEPTH_TEST);
+    glShadeModel(GL_SMOOTH);
     glDisable(GL_LIGHTING);
     glDisable(GL_CULL_FACE);
     glDisable(GL_TEXTURE_2D);
@@ -313,6 +316,7 @@ void DrawTexturedStyleBackgroundGradient(float horizonNdcY) {
         glEnable(GL_CULL_FACE);
     if (texture2DWasEnabled)
         glEnable(GL_TEXTURE_2D);
+    glShadeModel(shadeModel);
 }
 
 void DrawTexturedGroundPlaneBackdrop() {
@@ -320,8 +324,11 @@ void DrawTexturedGroundPlaneBackdrop() {
     const GLboolean lightingWasEnabled = glIsEnabled(GL_LIGHTING);
     const GLboolean cullFaceWasEnabled = glIsEnabled(GL_CULL_FACE);
     const GLboolean texture2DWasEnabled = glIsEnabled(GL_TEXTURE_2D);
+    GLint shadeModel = GL_SMOOTH;
+    glGetIntegerv(GL_SHADE_MODEL, &shadeModel);
 
     glDisable(GL_DEPTH_TEST);
+    glShadeModel(GL_SMOOTH);
     glDisable(GL_LIGHTING);
     glDisable(GL_CULL_FACE);
     glDisable(GL_TEXTURE_2D);
@@ -351,6 +358,7 @@ void DrawTexturedGroundPlaneBackdrop() {
         glEnable(GL_CULL_FACE);
     if (texture2DWasEnabled)
         glEnable(GL_TEXTURE_2D);
+    glShadeModel(shadeModel);
 }
 
 std::vector<std::string> BuildFixtureSelectionByType(


### PR DESCRIPTION
### Motivation
- Prevent highlight-only refreshes from restoring a base-pass image captured while the camera was moving or interacting, which caused transient visual artifacts in the Textured render style (sky/ground/lighting looked wrong after a mouse drag).

### Description
- Modify `viewer3d/viewer3dpanel.cpp` to only call `m_basePassCache->CaptureFromDefaultFramebuffer(...)` when `m_basePassCache` is present and both `!m_cameraMoving` and `!m_isInteracting`, so frames captured during interaction are not cached for later reuse.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef48dbbe348324a72bd354819525b2)