### PR TITLE
Fix Windows runtime dependency staging filters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,14 +292,9 @@ if(WIN32)
         endif()
     endif()
 
-    foreach(_prefix IN LISTS CMAKE_PREFIX_PATH)
-        if(EXISTS "${_prefix}/bin")
-            list(APPEND PERASTAGE_VCPKG_BIN_DIRS "${_prefix}/bin")
-        endif()
-        if(EXISTS "${_prefix}/debug/bin")
-            list(APPEND PERASTAGE_VCPKG_DEBUG_BIN_DIRS "${_prefix}/debug/bin")
-        endif()
-    endforeach()
+    # Do not append CMAKE_PREFIX_PATH directories on Windows.
+    # They may include Visual Studio and Windows SDK paths that introduce
+    # API-set/system DLLs that must not be staged as runtime dependencies.
     list(REMOVE_DUPLICATES PERASTAGE_VCPKG_BIN_DIRS)
     list(REMOVE_DUPLICATES PERASTAGE_VCPKG_DEBUG_BIN_DIRS)
 
@@ -313,16 +308,14 @@ if(WIN32)
             CONFIGURATIONS Release RelWithDebInfo MinSizeRel
             DIRECTORIES ${PERASTAGE_VCPKG_BIN_DIRS}
             PRE_EXCLUDE_REGEXES
-                ".*api-ms-win-.*\\.dll$"
-                ".*ext-ms-win-.*\\.dll$"
-                ".*api-ms-.*\\.dll$"
-                ".*ext-ms-.*\\.dll$"
-                "(?i).*AzureAttest.*\\.dll$"
-                "(?i).*HvsiFileTrust.*\\.dll$"
-                "(?i).*PdmUtilities.*\\.dll$"
-                "(?i).*WTDSENSOR.*\\.dll$"
-                ".*[Ww]paxholder\\.dll$"
-                ".*[Ww]tdccm\\.dll$"
+                "(?i).*api-ms-.*\\.dll$"
+                "(?i).*ext-ms-.*\\.dll$"
+                "(?i).*azureattest.*\\.dll$"
+                "(?i).*hvsifiletrust.*\\.dll$"
+                "(?i).*pdmutilities.*\\.dll$"
+                "(?i).*wtdsensor.*\\.dll$"
+                "(?i).*wpaxholder\\.dll$"
+                "(?i).*wtdccm\\.dll$"
             POST_EXCLUDE_REGEXES
                 ".*[Ww]indows[\\/].*"
                 ".*[Ss]ystem32[\\/].*"
@@ -338,16 +331,14 @@ if(WIN32)
             DESTINATION .
             DIRECTORIES ${PERASTAGE_VCPKG_BIN_DIRS}
             PRE_EXCLUDE_REGEXES
-                ".*api-ms-win-.*\\.dll$"
-                ".*ext-ms-win-.*\\.dll$"
-                ".*api-ms-.*\\.dll$"
-                ".*ext-ms-.*\\.dll$"
-                "(?i).*AzureAttest.*\\.dll$"
-                "(?i).*HvsiFileTrust.*\\.dll$"
-                "(?i).*PdmUtilities.*\\.dll$"
-                "(?i).*WTDSENSOR.*\\.dll$"
-                ".*[Ww]paxholder\\.dll$"
-                ".*[Ww]tdccm\\.dll$"
+                "(?i).*api-ms-.*\\.dll$"
+                "(?i).*ext-ms-.*\\.dll$"
+                "(?i).*azureattest.*\\.dll$"
+                "(?i).*hvsifiletrust.*\\.dll$"
+                "(?i).*pdmutilities.*\\.dll$"
+                "(?i).*wtdsensor.*\\.dll$"
+                "(?i).*wpaxholder\\.dll$"
+                "(?i).*wtdccm\\.dll$"
             POST_EXCLUDE_REGEXES
                 ".*[Ww]indows[\\/].*"
                 ".*[Ss]ystem32[\\/].*"


### PR DESCRIPTION
### Motivation
- `install(RUNTIME_DEPENDENCY_SET ...)` was resolving Windows API-set and system DLLs because `CMAKE_PREFIX_PATH` bin/debug-bin entries (including Visual Studio and Windows SDK folders) were being added to the vcpkg search directories, causing unresolved dependency errors during `perastage_stage` on Windows. 
- The goal is to restrict dependency scanning to vcpkg-provided bins and robustly exclude API-set/system DLL name patterns so staging completes successfully in CI without changing staging layout or installers.

### Description
- Removed the loop that appended `CMAKE_PREFIX_PATH` bin/debug-bin directories to `PERASTAGE_VCPKG_BIN_DIRS`/`PERASTAGE_VCPKG_DEBUG_BIN_DIRS` on Windows and added an explanatory comment to prevent scanning Visual Studio/Windows SDK paths. 
- Replaced the Windows `PRE_EXCLUDE_REGEXES` entries in both `install(RUNTIME_DEPENDENCY_SET perastage_runtime_deps_release ...)` blocks with case-insensitive, robust patterns using `(?i)` to match `api-ms-*`, `ext-ms-*` and the listed problematic DLL families (`azureattest`, `hvsifiletrust`, `pdmutilities`, `wtdsensor`, `wpaxholder`, `wtdccm`). 
- Kept `POST_EXCLUDE_REGEXES` and the staging output directory structure unchanged, and left comments in English.

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which succeeded. 
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef4d06227c8324866568ebfffcf23a)