### PR TITLE
Scope Esc to suggestions in Create-from-text dialog

### DIFF
--- a/docs/gui_shortcut_architecture.md
+++ b/docs/gui_shortcut_architecture.md
@@ -116,19 +116,22 @@ represent equivalent actions:
 
 ## Local shortcuts in "Create scene from text" autocomplete
 
-`RiderTextDialog` adds local key handling only while the autocomplete dropdown
-is visible in the multiline text box:
+`RiderTextDialog` adds local key handling in the multiline text box for
+autocomplete navigation, and keeps `Esc` scoped to autocomplete behavior:
 
 - `↑` / `↓`: move the active suggestion.
 - `Enter` or `Tab`: accept the selected suggestion and replace the active token.
-- `Esc`: close suggestions without inserting.
+- `Esc`: if suggestions are open, close them without inserting; if suggestions
+  are closed, keep focus in the dialog editor (do not close the dialog).
 
 The dialog also shows this shortcut help inline under the editor so users can
 discover the local autocomplete controls without leaving the workflow.
 
 Priority and focus impact:
 
-- These keys are consumed only when the dropdown is open.
+- `Esc` is always consumed by the dialog to avoid accidental window close while
+  editing rider text.
+- Navigation/accept keys are consumed only when the dropdown is open.
 - Outside that state, the text box keeps its standard free-text editing behavior.
 - Global shortcut routing is unchanged because the dialog key handling stays local.
 - Suggestion ordering uses local relevance ranking (exact/prefix/fuzzy + recent

--- a/gui/ridertextdialog.cpp
+++ b/gui/ridertextdialog.cpp
@@ -375,8 +375,9 @@ void RiderTextDialog::OnSuggestionClick(wxCommandEvent &WXUNUSED(event)) {
 }
 
 void RiderTextDialog::OnDialogCharHook(wxKeyEvent &event) {
-  if (event.GetKeyCode() == WXK_ESCAPE && IsSuggestionPopupVisible()) {
-    HideSuggestionPopup();
+  if (event.GetKeyCode() == WXK_ESCAPE) {
+    if (IsSuggestionPopupVisible())
+      HideSuggestionPopup();
     return;
   }
   event.Skip();


### PR DESCRIPTION
### Motivation
- Prevent accidental closing of the "Create from text" dialog when users press `Esc` while editing; `Esc` should only dismiss the autocomplete suggestions popup when it is open.

### Description
- Change `RiderTextDialog::OnDialogCharHook` so `WXK_ESCAPE` is always consumed by the dialog and only calls `HideSuggestionPopup()` when the suggestion popup is visible, avoiding closing the dialog when suggestions are not shown (`gui/ridertextdialog.cpp`).
- Update `docs/gui_shortcut_architecture.md` to document the new `Esc` precedence and local handling in the Create-from-text autocomplete UI.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef4e4cccbc8324b25312d4df3435b5)