### PR TITLE
Fix multi-word autocomplete replacement in Create from text

### DIFF
--- a/gui/ridertextdialog.cpp
+++ b/gui/ridertextdialog.cpp
@@ -37,6 +37,14 @@
 #include "consolepanel.h"
 #include "riderimporter.h"
 
+namespace {
+
+bool StartsWithInsensitive(const wxString &text, const wxString &prefix) {
+  return text.Lower().StartsWith(prefix.Lower());
+}
+
+} // namespace
+
 enum {
   ID_RiderText_Load = wxID_HIGHEST + 4200,
   ID_RiderText_Example,
@@ -462,12 +470,42 @@ void RiderTextDialog::ReplaceCurrentToken(const std::string &replacement) {
     return;
 
   const wxString text = textCtrl->GetValue();
+  const wxString replacementText = wxString::FromUTF8(replacement);
   long insertionPoint = textCtrl->GetInsertionPoint();
   insertionPoint = std::max<long>(0, std::min<long>(insertionPoint, text.length()));
 
   long tokenStart = insertionPoint;
   while (tokenStart > 0 && !IsTokenDelimiter(text[tokenStart - 1]))
     --tokenStart;
+
+  if (replacementText.Find(' ') != wxNOT_FOUND) {
+    long bestStart = tokenStart;
+    long candidateStart = tokenStart;
+    while (candidateStart > 0) {
+      long previousTokenEnd = candidateStart;
+      while (previousTokenEnd > 0 && IsTokenDelimiter(text[previousTokenEnd - 1]))
+        --previousTokenEnd;
+      if (previousTokenEnd == 0)
+        break;
+
+      long previousTokenStart = previousTokenEnd;
+      while (previousTokenStart > 0 &&
+             !IsTokenDelimiter(text[previousTokenStart - 1])) {
+        --previousTokenStart;
+      }
+
+      const wxString typedFragment =
+          text.Mid(previousTokenStart, insertionPoint - previousTokenStart);
+      if (typedFragment.empty() ||
+          !StartsWithInsensitive(replacementText, typedFragment)) {
+        break;
+      }
+
+      bestStart = previousTokenStart;
+      candidateStart = previousTokenStart;
+    }
+    tokenStart = bestStart;
+  }
 
   long tokenEnd = insertionPoint;
   while (tokenEnd < static_cast<long>(text.length()) &&
@@ -476,7 +514,6 @@ void RiderTextDialog::ReplaceCurrentToken(const std::string &replacement) {
   }
 
   suppressAutocompleteTextEvent = true;
-  const wxString replacementText = wxString::FromUTF8(replacement);
   textCtrl->Replace(tokenStart, tokenEnd, replacementText);
   textCtrl->SetInsertionPoint(tokenStart + replacementText.length());
   suppressAutocompleteTextEvent = false;


### PR DESCRIPTION
### Motivation
- Accepting multi-word autocomplete suggestions in the "Create from text" dialog could append the suggestion to a partially typed multi-word fragment (e.g. producing `Mac AxMac Axiom`) instead of replacing the whole typed fragment, so the replacement logic needed to expand to cover preceding partial tokens when appropriate.

### Description
- Updated `RiderTextDialog::ReplaceCurrentToken` in `gui/ridertextdialog.cpp` to detect multi-word suggestions, walk backwards across prior tokens while the typed fragment is a case-insensitive prefix of the suggestion, and expand `tokenStart` accordingly, and added a small helper `StartsWithInsensitive` to perform case-insensitive prefix checks.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef544be544832488d26617329f87bc)