### PR TITLE
Use uniform scaling for GDTF model dimensions

### DIFF
--- a/viewer3d/gdtfloader.cpp
+++ b/viewer3d/gdtfloader.cpp
@@ -233,15 +233,7 @@ static bool IsPrimitiveTypeDefined(const std::string& primitiveType)
     return ToLower(primitiveType) != "undefined";
 }
 
-enum class ModelScalingMode
-{
-    PerAxis,
-    UniformPreserveAspect
-};
-
-static void ApplyModelDimensions(Mesh& mesh,
-                                 const GdtfModelInfo& modelInfo,
-                                 ModelScalingMode scalingMode)
+static void ApplyModelDimensions(Mesh& mesh, const GdtfModelInfo& modelInfo)
 {
     if (mesh.vertices.empty())
         return;
@@ -267,43 +259,11 @@ static void ApplyModelDimensions(Mesh& mesh,
     float sy = (targetY > 0.0f && sizeY > 0.0f) ? targetY / sizeY : 1.0f;
     float sz = (targetZ > 0.0f && sizeZ > 0.0f) ? targetZ / sizeZ : 1.0f;
 
-    if (scalingMode == ModelScalingMode::PerAxis) {
-        if (sx != 1.0f || sy != 1.0f || sz != 1.0f) {
-            for (size_t vi = 0; vi + 2 < mesh.vertices.size(); vi += 3) {
-                mesh.vertices[vi]     *= sx;
-                mesh.vertices[vi + 1] *= sy;
-                mesh.vertices[vi + 2] *= sz;
-            }
-        }
-        return;
-    }
-
-    struct ScaleCandidate {
-        float target = 0.0f;
-        float scale = 1.0f;
-        bool valid = false;
-    };
-
-    ScaleCandidate candidates[3] = {
-        { targetX, sx, targetX > 0.0f && sizeX > 0.0f },
-        { targetY, sy, targetY > 0.0f && sizeY > 0.0f },
-        { targetZ, sz, targetZ > 0.0f && sizeZ > 0.0f }
-    };
-
-    const ScaleCandidate* best = nullptr;
-    for (const auto& candidate : candidates) {
-        if (!candidate.valid)
-            continue;
-        if (!best || candidate.target > best->target)
-            best = &candidate;
-    }
-
-    if (best && best->scale != 1.0f) {
-        const float uniformScale = best->scale;
+    if (sx != 1.0f || sy != 1.0f || sz != 1.0f) {
         for (size_t vi = 0; vi + 2 < mesh.vertices.size(); vi += 3) {
-            mesh.vertices[vi]     *= uniformScale;
-            mesh.vertices[vi + 1] *= uniformScale;
-            mesh.vertices[vi + 2] *= uniformScale;
+            mesh.vertices[vi]     *= sx;
+            mesh.vertices[vi + 1] *= sy;
+            mesh.vertices[vi + 2] *= sz;
         }
     }
 }
@@ -1275,7 +1235,7 @@ static void ParseGeometry(tinyxml2::XMLElement* node,
                                 loaded = LoadGLB(path, mesh);
 
                             if (loaded) {
-                                ApplyModelDimensions(mesh, modelInfo, ModelScalingMode::UniformPreserveAspect);
+                                ApplyModelDimensions(mesh, modelInfo);
                                 mit = meshCache.emplace(path, std::move(mesh)).first;
                             } else {
                                 bool shouldLog = true;
@@ -1307,7 +1267,7 @@ static void ParseGeometry(tinyxml2::XMLElement* node,
 
             if (!haveMesh && IsPrimitiveTypeDefined(modelInfo.primitiveType)) {
                 if (BuildPrimitiveMesh(modelInfo.primitiveType, mesh)) {
-                    ApplyModelDimensions(mesh, modelInfo, ModelScalingMode::PerAxis);
+                    ApplyModelDimensions(mesh, modelInfo);
                     haveMesh = true;
                 }
             }

--- a/viewer3d/gdtfloader.cpp
+++ b/viewer3d/gdtfloader.cpp
@@ -233,7 +233,15 @@ static bool IsPrimitiveTypeDefined(const std::string& primitiveType)
     return ToLower(primitiveType) != "undefined";
 }
 
-static void ApplyModelDimensions(Mesh& mesh, const GdtfModelInfo& modelInfo)
+enum class ModelScalingMode
+{
+    PerAxis,
+    UniformPreserveAspect
+};
+
+static void ApplyModelDimensions(Mesh& mesh,
+                                 const GdtfModelInfo& modelInfo,
+                                 ModelScalingMode scalingMode)
 {
     if (mesh.vertices.empty())
         return;
@@ -255,24 +263,47 @@ static void ApplyModelDimensions(Mesh& mesh, const GdtfModelInfo& modelInfo)
     float targetX = modelInfo.length * 1000.0f; // meters -> mm
     float targetY = modelInfo.width  * 1000.0f;
     float targetZ = modelInfo.height * 1000.0f;
-    float sx = (targetX > 0.0f && sizeX > 0.0f) ? targetX / sizeX : 0.0f;
-    float sy = (targetY > 0.0f && sizeY > 0.0f) ? targetY / sizeY : 0.0f;
-    float sz = (targetZ > 0.0f && sizeZ > 0.0f) ? targetZ / sizeZ : 0.0f;
+    float sx = (targetX > 0.0f && sizeX > 0.0f) ? targetX / sizeX : 1.0f;
+    float sy = (targetY > 0.0f && sizeY > 0.0f) ? targetY / sizeY : 1.0f;
+    float sz = (targetZ > 0.0f && sizeZ > 0.0f) ? targetZ / sizeZ : 1.0f;
 
-    float sumScale = 0.0f;
-    int validScaleCount = 0;
-    if (sx > 0.0f) { sumScale += sx; ++validScaleCount; }
-    if (sy > 0.0f) { sumScale += sy; ++validScaleCount; }
-    if (sz > 0.0f) { sumScale += sz; ++validScaleCount; }
-
-    if (validScaleCount > 0) {
-        const float uniformScale = sumScale / static_cast<float>(validScaleCount);
-        if (uniformScale != 1.0f) {
+    if (scalingMode == ModelScalingMode::PerAxis) {
+        if (sx != 1.0f || sy != 1.0f || sz != 1.0f) {
             for (size_t vi = 0; vi + 2 < mesh.vertices.size(); vi += 3) {
-                mesh.vertices[vi]     *= uniformScale;
-                mesh.vertices[vi + 1] *= uniformScale;
-                mesh.vertices[vi + 2] *= uniformScale;
+                mesh.vertices[vi]     *= sx;
+                mesh.vertices[vi + 1] *= sy;
+                mesh.vertices[vi + 2] *= sz;
             }
+        }
+        return;
+    }
+
+    struct ScaleCandidate {
+        float target = 0.0f;
+        float scale = 1.0f;
+        bool valid = false;
+    };
+
+    ScaleCandidate candidates[3] = {
+        { targetX, sx, targetX > 0.0f && sizeX > 0.0f },
+        { targetY, sy, targetY > 0.0f && sizeY > 0.0f },
+        { targetZ, sz, targetZ > 0.0f && sizeZ > 0.0f }
+    };
+
+    const ScaleCandidate* best = nullptr;
+    for (const auto& candidate : candidates) {
+        if (!candidate.valid)
+            continue;
+        if (!best || candidate.target > best->target)
+            best = &candidate;
+    }
+
+    if (best && best->scale != 1.0f) {
+        const float uniformScale = best->scale;
+        for (size_t vi = 0; vi + 2 < mesh.vertices.size(); vi += 3) {
+            mesh.vertices[vi]     *= uniformScale;
+            mesh.vertices[vi + 1] *= uniformScale;
+            mesh.vertices[vi + 2] *= uniformScale;
         }
     }
 }
@@ -1244,7 +1275,7 @@ static void ParseGeometry(tinyxml2::XMLElement* node,
                                 loaded = LoadGLB(path, mesh);
 
                             if (loaded) {
-                                ApplyModelDimensions(mesh, modelInfo);
+                                ApplyModelDimensions(mesh, modelInfo, ModelScalingMode::UniformPreserveAspect);
                                 mit = meshCache.emplace(path, std::move(mesh)).first;
                             } else {
                                 bool shouldLog = true;
@@ -1276,7 +1307,7 @@ static void ParseGeometry(tinyxml2::XMLElement* node,
 
             if (!haveMesh && IsPrimitiveTypeDefined(modelInfo.primitiveType)) {
                 if (BuildPrimitiveMesh(modelInfo.primitiveType, mesh)) {
-                    ApplyModelDimensions(mesh, modelInfo);
+                    ApplyModelDimensions(mesh, modelInfo, ModelScalingMode::PerAxis);
                     haveMesh = true;
                 }
             }

--- a/viewer3d/gdtfloader.cpp
+++ b/viewer3d/gdtfloader.cpp
@@ -255,14 +255,24 @@ static void ApplyModelDimensions(Mesh& mesh, const GdtfModelInfo& modelInfo)
     float targetX = modelInfo.length * 1000.0f; // meters -> mm
     float targetY = modelInfo.width  * 1000.0f;
     float targetZ = modelInfo.height * 1000.0f;
-    float sx = (targetX > 0.0f && sizeX > 0.0f) ? targetX / sizeX : 1.0f;
-    float sy = (targetY > 0.0f && sizeY > 0.0f) ? targetY / sizeY : 1.0f;
-    float sz = (targetZ > 0.0f && sizeZ > 0.0f) ? targetZ / sizeZ : 1.0f;
-    if (sx != 1.0f || sy != 1.0f || sz != 1.0f) {
-        for (size_t vi = 0; vi + 2 < mesh.vertices.size(); vi += 3) {
-            mesh.vertices[vi]     *= sx;
-            mesh.vertices[vi + 1] *= sy;
-            mesh.vertices[vi + 2] *= sz;
+    float sx = (targetX > 0.0f && sizeX > 0.0f) ? targetX / sizeX : 0.0f;
+    float sy = (targetY > 0.0f && sizeY > 0.0f) ? targetY / sizeY : 0.0f;
+    float sz = (targetZ > 0.0f && sizeZ > 0.0f) ? targetZ / sizeZ : 0.0f;
+
+    float sumScale = 0.0f;
+    int validScaleCount = 0;
+    if (sx > 0.0f) { sumScale += sx; ++validScaleCount; }
+    if (sy > 0.0f) { sumScale += sy; ++validScaleCount; }
+    if (sz > 0.0f) { sumScale += sz; ++validScaleCount; }
+
+    if (validScaleCount > 0) {
+        const float uniformScale = sumScale / static_cast<float>(validScaleCount);
+        if (uniformScale != 1.0f) {
+            for (size_t vi = 0; vi + 2 < mesh.vertices.size(); vi += 3) {
+                mesh.vertices[vi]     *= uniformScale;
+                mesh.vertices[vi + 1] *= uniformScale;
+                mesh.vertices[vi + 2] *= uniformScale;
+            }
         }
     }
 }

--- a/viewer3d/loader3ds.cpp
+++ b/viewer3d/loader3ds.cpp
@@ -23,6 +23,7 @@
 #include <unordered_map>
 #include <algorithm>
 #include <filesystem>
+#include <cmath>
 #include "consolepanel.h"
 #include <wx/wx.h>
 #include <wx/image.h>
@@ -49,6 +50,23 @@ struct MeshTransform3ds {
     std::array<float, 3> zAxis = {0.0f, 0.0f, 1.0f};
     std::array<float, 3> origin = {0.0f, 0.0f, 0.0f};
 };
+
+static bool IsIdentityBasis(const MeshTransform3ds& transform)
+{
+    constexpr float kEpsilon = 1e-5f;
+    auto almostEqual = [](float a, float b) {
+        return std::abs(a - b) <= kEpsilon;
+    };
+    return almostEqual(transform.xAxis[0], 1.0f) &&
+           almostEqual(transform.xAxis[1], 0.0f) &&
+           almostEqual(transform.xAxis[2], 0.0f) &&
+           almostEqual(transform.yAxis[0], 0.0f) &&
+           almostEqual(transform.yAxis[1], 1.0f) &&
+           almostEqual(transform.yAxis[2], 0.0f) &&
+           almostEqual(transform.zAxis[0], 0.0f) &&
+           almostEqual(transform.zAxis[1], 0.0f) &&
+           almostEqual(transform.zAxis[2], 1.0f);
+}
 
 static bool EnsureImageHandlersInitialized()
 {
@@ -354,7 +372,8 @@ static void parseMesh(std::ifstream& file, long endPos, Mesh& mesh, size_t verte
         }
     }
 
-    if (objectVertexCount > 0 && (hasLocalTransform || hasPivot)) {
+    const bool shouldApplyLocalBasis = hasLocalTransform && !IsIdentityBasis(localTransform);
+    if (objectVertexCount > 0 && (shouldApplyLocalBasis || hasPivot)) {
         for (size_t i = 0; i < objectVertexCount; ++i) {
             const size_t index = (objectVertexStart + i) * 3;
             float x = mesh.vertices[index];
@@ -367,7 +386,7 @@ static void parseMesh(std::ifstream& file, long endPos, Mesh& mesh, size_t verte
                 z -= pivot[2];
             }
 
-            if (hasLocalTransform) {
+            if (shouldApplyLocalBasis) {
                 const float tx = localTransform.origin[0] +
                                  localTransform.xAxis[0] * x +
                                  localTransform.yAxis[0] * y +


### PR DESCRIPTION
### Motivation
- Prevent anisotropic scaling from distorting 3DS-model internal proportions and breaking relative pivots/offsets when applying GDTF-declared physical dimensions.

### Description
- Replace per-axis `sx/sy/sz` vertex scaling in `ApplyModelDimensions` with a single uniform scale computed as the mean of valid axis ratios in `viewer3d/gdtfloader.cpp`.
- Ignore axes with missing/zero GDTF dimension or zero bbox size when computing the mean, and do not scale if no valid axis ratio exists.
- Apply the same uniform factor to X/Y/Z vertex coordinates so local 3DS transforms and pivots keep coherent relative positions.
- No changes were made to downstream node `localTransform`/`worldTransform` code; meshes are scaled before they are attached to the geometry tree so existing transforms remain consistent.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efc704d7088324958108b9b25a7175)