### PR TITLE
Fix fixture table selection-order remapping after sort/resync

### DIFF
--- a/gui/colorstore.h
+++ b/gui/colorstore.h
@@ -30,21 +30,6 @@ public:
   bool selectionBackgroundEnabled = false;
   bool selectionForegroundEnabled = false;
 
-  int Compare(const wxDataViewItem &item1, const wxDataViewItem &item2,
-              unsigned int col, bool ascending) const override {
-    (void)ascending;
-    const int result =
-        wxDataViewListStore::Compare(item1, item2, col, ascending);
-    if (result != 0)
-      return result;
-
-    const wxUIntPtr key1 = GetItemData(item1);
-    const wxUIntPtr key2 = GetItemData(item2);
-    if (key1 == key2)
-      return 0;
-    return key1 < key2 ? -1 : 1;
-  }
-
   bool GetAttrByRow(unsigned row, unsigned col,
                     wxDataViewItemAttr &attr) const override {
     bool hasAttr = false;
@@ -209,6 +194,7 @@ public:
 
   int Compare(const wxDataViewItem &item1, const wxDataViewItem &item2,
               unsigned int column, bool ascending) const override {
+    int res = 0;
     if (column == 1) {
       wxVariant v1, v2;
       const_cast<ColorfulDataViewListStore *>(this)->GetValue(v1, item1,
@@ -231,7 +217,6 @@ public:
       long n1 = 0, n2 = 0;
       bool ok1 = parse(s1, p1, n1);
       bool ok2 = parse(s2, p2, n2);
-      int res;
       if (ok1 && ok2 && p1 == p2) {
         if (n1 < n2)
           res = -1;
@@ -242,8 +227,19 @@ public:
       } else {
         res = s1.Cmp(s2);
       }
-      return ascending ? res : -res;
+    } else {
+      res = wxDataViewListStore::Compare(item1, item2, column, true);
     }
-    return wxDataViewListStore::Compare(item1, item2, column, ascending);
+
+    if (res == 0) {
+      const wxUIntPtr key1 = GetItemData(item1);
+      const wxUIntPtr key2 = GetItemData(item2);
+      if (key1 < key2)
+        res = -1;
+      else if (key1 > key2)
+        res = 1;
+    }
+
+    return ascending ? res : -res;
   }
 };

--- a/gui/colorstore.h
+++ b/gui/colorstore.h
@@ -30,6 +30,21 @@ public:
   bool selectionBackgroundEnabled = false;
   bool selectionForegroundEnabled = false;
 
+  int Compare(const wxDataViewItem &item1, const wxDataViewItem &item2,
+              unsigned int col, bool ascending) const override {
+    (void)ascending;
+    const int result =
+        wxDataViewListStore::Compare(item1, item2, col, ascending);
+    if (result != 0)
+      return result;
+
+    const wxUIntPtr key1 = GetItemData(item1);
+    const wxUIntPtr key2 = GetItemData(item2);
+    if (key1 == key2)
+      return 0;
+    return key1 < key2 ? -1 : 1;
+  }
+
   bool GetAttrByRow(unsigned row, unsigned col,
                     wxDataViewItemAttr &attr) const override {
     bool hasAttr = false;

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -557,6 +557,7 @@ void FixtureTablePanel::ReloadData() {
 }
 
 void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
+  EnsureRowMappingsSynced();
   wxDataViewItem item = event.GetItem();
   int col = event.GetColumn();
   if (!item.IsOk() || col < 0)
@@ -1283,6 +1284,7 @@ std::vector<std::string> FixtureTablePanel::GetSelectedUuids() const {
 
 void FixtureTablePanel::SelectByUuid(const std::vector<std::string> &uuids,
                                      bool notifySelectionChanged) {
+  EnsureRowMappingsSynced();
   std::unique_ptr<wxEventBlocker> selectionBlocker;
   if (!notifySelectionChanged)
     selectionBlocker = std::make_unique<wxEventBlocker>(table, wxEVT_DATAVIEW_SELECTION_CHANGED);
@@ -1303,6 +1305,7 @@ void FixtureTablePanel::SelectByUuid(const std::vector<std::string> &uuids,
 }
 
 void FixtureTablePanel::DeleteSelected(bool pushUndoState) {
+  EnsureRowMappingsSynced();
   wxDataViewItemArray selections;
   table->GetSelections(selections);
   if (selections.empty())
@@ -1505,6 +1508,7 @@ void FixtureTablePanel::UpdateHoverTooltip(const wxPoint &position) {
 }
 
 void FixtureTablePanel::OnSelectionChanged(wxDataViewEvent &evt) {
+  EnsureRowMappingsSynced();
   const selection::Origin origin = selection::CurrentOrigin();
   if (origin == selection::Origin::Viewer2D ||
       origin == selection::Origin::Viewer3D) {
@@ -1841,6 +1845,34 @@ void FixtureTablePanel::ResyncRows(
     }
   }
   UpdateSelectionHighlight();
+}
+
+void FixtureTablePanel::EnsureRowMappingsSynced() {
+  if (!table || !store)
+    return;
+
+  const unsigned int count = table->GetItemCount();
+  if (count == 0 || rowUuids.empty())
+    return;
+
+  const std::vector<std::string> oldOrder = rowUuids;
+  const std::vector<wxString> oldPaths = gdtfPaths;
+  std::vector<std::string> newOrder(count);
+  std::vector<wxString> newPaths(count);
+
+  for (unsigned int i = 0; i < count; ++i) {
+    const wxDataViewItem it = table->RowToItem(i);
+    const unsigned long idx = store->GetItemData(it);
+    if (idx < oldOrder.size())
+      newOrder[i] = oldOrder[idx];
+    if (idx < oldPaths.size())
+      newPaths[i] = oldPaths[idx];
+    store->SetItemData(it, i);
+  }
+
+  rowUuids.swap(newOrder);
+  gdtfPaths.swap(newPaths);
+  selectionOrder = ReindexSelectionOrder(selectionOrder, oldOrder, rowUuids);
 }
 
 void FixtureTablePanel::OnColumnSorted(wxDataViewEvent &event) {

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -60,38 +60,9 @@
 namespace fs = std::filesystem;
 
 namespace {
-constexpr unsigned int kHiddenUuidColumn = 20;
-constexpr unsigned int kHiddenGdtfPathColumn = 21;
-
 const wxString &DegreeSymbol() {
   static const wxString kDegreeSymbol = wxString::FromUTF8("\xC2\xB0");
   return kDegreeSymbol;
-}
-
-std::vector<int> ReindexSelectionOrder(
-    const std::vector<int> &selectionOrder,
-    const std::vector<std::string> &oldOrder,
-    const std::vector<std::string> &newOrder) {
-  std::unordered_map<std::string, int> rowByUuid;
-  rowByUuid.reserve(newOrder.size());
-  for (size_t row = 0; row < newOrder.size(); ++row) {
-    rowByUuid.emplace(newOrder[row], static_cast<int>(row));
-  }
-
-  std::vector<int> remappedOrder;
-  remappedOrder.reserve(selectionOrder.size());
-  std::unordered_set<int> seenRows;
-  seenRows.reserve(selectionOrder.size());
-  for (const int oldRow : selectionOrder) {
-    if (oldRow < 0 || static_cast<size_t>(oldRow) >= oldOrder.size())
-      continue;
-    const auto itRow = rowByUuid.find(oldOrder[static_cast<size_t>(oldRow)]);
-    if (itRow == rowByUuid.end())
-      continue;
-    if (seenRows.insert(itRow->second).second)
-      remappedOrder.push_back(itRow->second);
-  }
-  return remappedOrder;
 }
 
 class ConfigManagerSceneAdapter : public FixtureTableEditService::ISceneAdapter {
@@ -389,12 +360,6 @@ void FixtureTablePanel::InitializeTable() {
   columnLabels[17] = wxString::FromUTF8(
       Units::LabelWithUnit("Weight", std::string(weightSuffix.ToUTF8())));
   FixtureTableColumns::ConfigureColumns(table, columnLabels);
-  auto *uuidColumn = table->AppendTextColumn("UUID");
-  auto *pathColumn = table->AppendTextColumn("GDTF Path");
-  if (uuidColumn)
-    uuidColumn->SetHidden(true);
-  if (pathColumn)
-    pathColumn->SetHidden(true);
 }
 
 void FixtureTablePanel::ReloadData() {
@@ -428,6 +393,9 @@ void FixtureTablePanel::ReloadData() {
   store->DeleteAllItems();
   gdtfPaths.clear();
   rowUuids.clear();
+  rowUuidByKey.clear();
+  gdtfPathByKey.clear();
+  nextRowKey = 1;
 
   const auto &fixtures = guiConfigServices->LegacyConfigManager().GetScene().fixtures;
 
@@ -546,11 +514,11 @@ void FixtureTablePanel::ReloadData() {
       var << wxDataViewIconText();
       row.push_back(var);
     }
-    row.push_back(wxString::FromUTF8(uuid));
-    row.push_back(gdtfFull);
-
-    store->AppendItem(row, rowUuids.size());
+    const wxUIntPtr rowKey = nextRowKey++;
+    store->AppendItem(row, rowKey);
     rowUuids.push_back(uuid);
+    rowUuidByKey[rowKey] = uuid;
+    gdtfPathByKey[rowKey] = gdtfFull;
   }
 
   if (Viewer3DPanel::Instance())
@@ -621,8 +589,7 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
         if ((size_t)r >= gdtfPaths.size())
           gdtfPaths.resize(table->GetItemCount());
 
-        gdtfPaths[r] = path;
-        table->SetValue(wxVariant(path), r, kHiddenGdtfPathColumn);
+        SetGdtfPathForRow(static_cast<unsigned int>(r), path);
         table->SetValue(wxVariant(fileName), r, 9);
         table->SetValue(wxVariant(typeName), r, 2);
 
@@ -644,8 +611,7 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
         if ((size_t)i >= gdtfPaths.size())
           gdtfPaths.resize(table->GetItemCount());
 
-        gdtfPaths[i] = path;
-        table->SetValue(wxVariant(path), i, kHiddenGdtfPathColumn);
+        SetGdtfPathForRow(i, path);
         table->SetValue(wxVariant(fileName), i, 9);
         table->SetValue(wxVariant(typeName), i, 2);
 
@@ -1295,6 +1261,7 @@ std::vector<std::string> FixtureTablePanel::GetSelectedUuids() const {
 
 void FixtureTablePanel::SelectByUuid(const std::vector<std::string> &uuids,
                                      bool notifySelectionChanged) {
+  RebuildRowCachesFromRowKeys();
   std::unique_ptr<wxEventBlocker> selectionBlocker;
   if (!notifySelectionChanged)
     selectionBlocker = std::make_unique<wxEventBlocker>(table, wxEVT_DATAVIEW_SELECTION_CHANGED);
@@ -1315,6 +1282,7 @@ void FixtureTablePanel::SelectByUuid(const std::vector<std::string> &uuids,
 }
 
 void FixtureTablePanel::DeleteSelected(bool pushUndoState) {
+  RebuildRowCachesFromRowKeys();
   wxDataViewItemArray selections;
   table->GetSelections(selections);
   if (selections.empty())
@@ -1341,10 +1309,14 @@ void FixtureTablePanel::DeleteSelected(bool pushUndoState) {
   auto &scene = guiConfigServices->LegacyConfigManager().GetScene();
   for (int r : rows) {
     if ((size_t)r < rowUuids.size()) {
+      wxDataViewItem rowItem = table->RowToItem(static_cast<unsigned int>(r));
+      const wxUIntPtr rowKey = store->GetItemData(rowItem);
       scene.fixtures.erase(rowUuids[r]);
       rowUuids.erase(rowUuids.begin() + r);
       if ((size_t)r < gdtfPaths.size())
         gdtfPaths.erase(gdtfPaths.begin() + r);
+      rowUuidByKey.erase(rowKey);
+      gdtfPathByKey.erase(rowKey);
       store->DeleteItem(r);
       for (auto itSel = selectionOrder.begin();
            itSel != selectionOrder.end();) {
@@ -1513,7 +1485,7 @@ void FixtureTablePanel::UpdateHoverTooltip(const wxPoint &position) {
 }
 
 void FixtureTablePanel::OnSelectionChanged(wxDataViewEvent &evt) {
-  RebuildRowCachesFromHiddenColumns();
+  RebuildRowCachesFromRowKeys();
   const selection::Origin origin = selection::CurrentOrigin();
   if (origin == selection::Origin::Viewer2D ||
       origin == selection::Origin::Viewer3D) {
@@ -1824,8 +1796,14 @@ void FixtureTablePanel::ResyncRows(
     const std::vector<wxString> *oldPaths) {
   (void)oldOrder;
   (void)oldPaths;
-  RebuildRowCachesFromHiddenColumns();
-  selectionOrder = ReindexSelectionOrder(selectionOrder, oldOrder, rowUuids);
+  RebuildRowCachesFromRowKeys();
+  selectionOrder.clear();
+  selectionOrder.reserve(selectedUuids.size());
+  for (const auto &uuid : selectedUuids) {
+    auto pos = std::find(rowUuids.begin(), rowUuids.end(), uuid);
+    if (pos != rowUuids.end())
+      selectionOrder.push_back(static_cast<int>(pos - rowUuids.begin()));
+  }
 
   {
     wxEventBlocker selectionBlocker(table, wxEVT_DATAVIEW_SELECTION_CHANGED);
@@ -1839,37 +1817,53 @@ void FixtureTablePanel::ResyncRows(
   UpdateSelectionHighlight();
 }
 
-void FixtureTablePanel::RebuildRowCachesFromHiddenColumns() {
-  if (!table)
+void FixtureTablePanel::RebuildRowCachesFromRowKeys() {
+  if (!table || !store)
     return;
 
   const unsigned int count = table->GetItemCount();
   rowUuids.assign(count, std::string());
   gdtfPaths.assign(count, wxString());
   for (unsigned int row = 0; row < count; ++row) {
-    wxVariant uuidValue;
-    table->GetValue(uuidValue, row, kHiddenUuidColumn);
-    rowUuids[row] = std::string(uuidValue.GetString().ToUTF8());
-
-    wxVariant pathValue;
-    table->GetValue(pathValue, row, kHiddenGdtfPathColumn);
-    gdtfPaths[row] = pathValue.GetString();
+    wxDataViewItem item = table->RowToItem(row);
+    const wxUIntPtr rowKey = store->GetItemData(item);
+    auto uuidIt = rowUuidByKey.find(rowKey);
+    if (uuidIt != rowUuidByKey.end())
+      rowUuids[row] = uuidIt->second;
+    auto pathIt = gdtfPathByKey.find(rowKey);
+    if (pathIt != gdtfPathByKey.end())
+      gdtfPaths[row] = pathIt->second;
   }
 }
 
 std::string FixtureTablePanel::UuidForItem(const wxDataViewItem &item) const {
-  if (!table || !item.IsOk())
+  if (!store || !item.IsOk())
     return {};
-  const int row = table->ItemToRow(item);
-  if (row == wxNOT_FOUND)
+  const wxUIntPtr rowKey = store->GetItemData(item);
+  auto it = rowUuidByKey.find(rowKey);
+  if (it == rowUuidByKey.end())
     return {};
-  wxVariant uuidValue;
-  table->GetValue(uuidValue, static_cast<unsigned int>(row), kHiddenUuidColumn);
-  return std::string(uuidValue.GetString().ToUTF8());
+  return it->second;
+}
+
+void FixtureTablePanel::SetGdtfPathForRow(unsigned int row,
+                                          const wxString &path) {
+  if (!table || !store)
+    return;
+  if (row >= table->GetItemCount())
+    return;
+
+  if (row >= gdtfPaths.size())
+    gdtfPaths.resize(table->GetItemCount());
+  gdtfPaths[row] = path;
+
+  wxDataViewItem item = table->RowToItem(row);
+  const wxUIntPtr rowKey = store->GetItemData(item);
+  gdtfPathByKey[rowKey] = path;
 }
 
 void FixtureTablePanel::OnColumnSorted(wxDataViewEvent &event) {
-  RebuildRowCachesFromHiddenColumns();
+  RebuildRowCachesFromRowKeys();
   wxDataViewItemArray selections;
   table->GetSelections(selections);
   std::vector<std::string> selectedUuids;

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -1418,12 +1418,7 @@ void FixtureTablePanel::OnLeftDown(wxMouseEvent &evt) {
   wxDataViewColumn *col;
   table->HitTest(evt.GetPosition(), item, col);
   startRow = table->ItemToRow(item);
-  if (startRow != wxNOT_FOUND) {
-    dragSelecting = true;
-    table->UnselectAll();
-    table->SelectRow(startRow);
-    CaptureMouse();
-  }
+  dragSelecting = false;
   evt.Skip();
 }
 
@@ -1433,17 +1428,19 @@ void FixtureTablePanel::OnLeftUp(wxMouseEvent &evt) {
     if (HasCapture())
       ReleaseMouse();
   }
+  startRow = wxNOT_FOUND;
   evt.Skip();
 }
 
 void FixtureTablePanel::OnCaptureLost(wxMouseCaptureLostEvent &WXUNUSED(evt)) {
   dragSelecting = false;
+  startRow = wxNOT_FOUND;
 }
 
 void FixtureTablePanel::OnMouseMove(wxMouseEvent &evt) {
   UpdateHoverTooltip(NormalizeMousePositionForTable(table, evt));
 
-  if (!dragSelecting || !evt.Dragging()) {
+  if (!evt.Dragging() || startRow == wxNOT_FOUND) {
     evt.Skip();
     return;
   }
@@ -1453,6 +1450,13 @@ void FixtureTablePanel::OnMouseMove(wxMouseEvent &evt) {
   table->HitTest(evt.GetPosition(), item, col);
   int row = table->ItemToRow(item);
   if (row != wxNOT_FOUND) {
+    if (!dragSelecting) {
+      dragSelecting = true;
+      table->UnselectAll();
+      table->SelectRow(startRow);
+      if (!HasCapture())
+        CaptureMouse();
+    }
     int minRow = std::min(startRow, row);
     int maxRow = std::max(startRow, row);
     table->UnselectAll();

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -60,6 +60,8 @@
 namespace fs = std::filesystem;
 
 namespace {
+constexpr unsigned int kHiddenUuidColumn = 20;
+constexpr unsigned int kHiddenGdtfPathColumn = 21;
 
 const wxString &DegreeSymbol() {
   static const wxString kDegreeSymbol = wxString::FromUTF8("\xC2\xB0");
@@ -387,6 +389,12 @@ void FixtureTablePanel::InitializeTable() {
   columnLabels[17] = wxString::FromUTF8(
       Units::LabelWithUnit("Weight", std::string(weightSuffix.ToUTF8())));
   FixtureTableColumns::ConfigureColumns(table, columnLabels);
+  auto *uuidColumn = table->AppendTextColumn("UUID");
+  auto *pathColumn = table->AppendTextColumn("GDTF Path");
+  if (uuidColumn)
+    uuidColumn->SetHidden(true);
+  if (pathColumn)
+    pathColumn->SetHidden(true);
 }
 
 void FixtureTablePanel::ReloadData() {
@@ -538,6 +546,8 @@ void FixtureTablePanel::ReloadData() {
       var << wxDataViewIconText();
       row.push_back(var);
     }
+    row.push_back(wxString::FromUTF8(uuid));
+    row.push_back(gdtfFull);
 
     store->AppendItem(row, rowUuids.size());
     rowUuids.push_back(uuid);
@@ -557,7 +567,6 @@ void FixtureTablePanel::ReloadData() {
 }
 
 void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
-  EnsureRowMappingsSynced();
   wxDataViewItem item = event.GetItem();
   int col = event.GetColumn();
   if (!item.IsOk() || col < 0)
@@ -570,9 +579,9 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
 
   std::vector<std::string> selectedUuids;
   for (const auto &itSel : selections) {
-    int r = table->ItemToRow(itSel);
-    if (r != wxNOT_FOUND && (size_t)r < rowUuids.size())
-      selectedUuids.push_back(rowUuids[r]);
+    const std::string uuid = UuidForItem(itSel);
+    if (!uuid.empty())
+      selectedUuids.push_back(uuid);
   }
   std::vector<std::string> oldOrder = rowUuids;
 
@@ -613,6 +622,7 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
           gdtfPaths.resize(table->GetItemCount());
 
         gdtfPaths[r] = path;
+        table->SetValue(wxVariant(path), r, kHiddenGdtfPathColumn);
         table->SetValue(wxVariant(fileName), r, 9);
         table->SetValue(wxVariant(typeName), r, 2);
 
@@ -635,6 +645,7 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
           gdtfPaths.resize(table->GetItemCount());
 
         gdtfPaths[i] = path;
+        table->SetValue(wxVariant(path), i, kHiddenGdtfPathColumn);
         table->SetValue(wxVariant(fileName), i, 9);
         table->SetValue(wxVariant(typeName), i, 2);
 
@@ -1275,16 +1286,15 @@ std::vector<std::string> FixtureTablePanel::GetSelectedUuids() const {
   std::vector<std::string> uuids;
   uuids.reserve(selections.size());
   for (const auto &it : selections) {
-    int r = table->ItemToRow(it);
-    if (r != wxNOT_FOUND && (size_t)r < rowUuids.size())
-      uuids.push_back(rowUuids[r]);
+    const std::string uuid = UuidForItem(it);
+    if (!uuid.empty())
+      uuids.push_back(uuid);
   }
   return uuids;
 }
 
 void FixtureTablePanel::SelectByUuid(const std::vector<std::string> &uuids,
                                      bool notifySelectionChanged) {
-  EnsureRowMappingsSynced();
   std::unique_ptr<wxEventBlocker> selectionBlocker;
   if (!notifySelectionChanged)
     selectionBlocker = std::make_unique<wxEventBlocker>(table, wxEVT_DATAVIEW_SELECTION_CHANGED);
@@ -1305,7 +1315,6 @@ void FixtureTablePanel::SelectByUuid(const std::vector<std::string> &uuids,
 }
 
 void FixtureTablePanel::DeleteSelected(bool pushUndoState) {
-  EnsureRowMappingsSynced();
   wxDataViewItemArray selections;
   table->GetSelections(selections);
   if (selections.empty())
@@ -1421,7 +1430,12 @@ void FixtureTablePanel::OnLeftDown(wxMouseEvent &evt) {
   wxDataViewColumn *col;
   table->HitTest(evt.GetPosition(), item, col);
   startRow = table->ItemToRow(item);
-  dragSelecting = false;
+  if (startRow != wxNOT_FOUND) {
+    dragSelecting = true;
+    table->UnselectAll();
+    table->SelectRow(startRow);
+    CaptureMouse();
+  }
   evt.Skip();
 }
 
@@ -1431,19 +1445,17 @@ void FixtureTablePanel::OnLeftUp(wxMouseEvent &evt) {
     if (HasCapture())
       ReleaseMouse();
   }
-  startRow = wxNOT_FOUND;
   evt.Skip();
 }
 
 void FixtureTablePanel::OnCaptureLost(wxMouseCaptureLostEvent &WXUNUSED(evt)) {
   dragSelecting = false;
-  startRow = wxNOT_FOUND;
 }
 
 void FixtureTablePanel::OnMouseMove(wxMouseEvent &evt) {
   UpdateHoverTooltip(NormalizeMousePositionForTable(table, evt));
 
-  if (!evt.Dragging() || startRow == wxNOT_FOUND) {
+  if (!dragSelecting || !evt.Dragging()) {
     evt.Skip();
     return;
   }
@@ -1453,13 +1465,6 @@ void FixtureTablePanel::OnMouseMove(wxMouseEvent &evt) {
   table->HitTest(evt.GetPosition(), item, col);
   int row = table->ItemToRow(item);
   if (row != wxNOT_FOUND) {
-    if (!dragSelecting) {
-      dragSelecting = true;
-      table->UnselectAll();
-      table->SelectRow(startRow);
-      if (!HasCapture())
-        CaptureMouse();
-    }
     int minRow = std::min(startRow, row);
     int maxRow = std::max(startRow, row);
     table->UnselectAll();
@@ -1508,7 +1513,7 @@ void FixtureTablePanel::UpdateHoverTooltip(const wxPoint &position) {
 }
 
 void FixtureTablePanel::OnSelectionChanged(wxDataViewEvent &evt) {
-  EnsureRowMappingsSynced();
+  RebuildRowCachesFromHiddenColumns();
   const selection::Origin origin = selection::CurrentOrigin();
   if (origin == selection::Origin::Viewer2D ||
       origin == selection::Origin::Viewer3D) {
@@ -1817,22 +1822,9 @@ void FixtureTablePanel::ResyncRows(
     const std::vector<std::string> &oldOrder,
     const std::vector<std::string> &selectedUuids,
     const std::vector<wxString> *oldPaths) {
-  unsigned int count = table->GetItemCount();
-  std::vector<std::string> newOrder(count);
-  std::vector<wxString> newPaths(count);
-  const auto &paths = oldPaths ? *oldPaths : gdtfPaths;
-  for (unsigned int i = 0; i < count; ++i) {
-    wxDataViewItem it = table->RowToItem(i);
-    unsigned long idx = store->GetItemData(it);
-    if (idx < oldOrder.size()) {
-      newOrder[i] = oldOrder[idx];
-      if (idx < paths.size())
-        newPaths[i] = paths[idx];
-    }
-    store->SetItemData(it, i);
-  }
-  rowUuids.swap(newOrder);
-  gdtfPaths.swap(newPaths);
+  (void)oldOrder;
+  (void)oldPaths;
+  RebuildRowCachesFromHiddenColumns();
   selectionOrder = ReindexSelectionOrder(selectionOrder, oldOrder, rowUuids);
 
   {
@@ -1847,42 +1839,44 @@ void FixtureTablePanel::ResyncRows(
   UpdateSelectionHighlight();
 }
 
-void FixtureTablePanel::EnsureRowMappingsSynced() {
-  if (!table || !store)
+void FixtureTablePanel::RebuildRowCachesFromHiddenColumns() {
+  if (!table)
     return;
 
   const unsigned int count = table->GetItemCount();
-  if (count == 0 || rowUuids.empty())
-    return;
+  rowUuids.assign(count, std::string());
+  gdtfPaths.assign(count, wxString());
+  for (unsigned int row = 0; row < count; ++row) {
+    wxVariant uuidValue;
+    table->GetValue(uuidValue, row, kHiddenUuidColumn);
+    rowUuids[row] = std::string(uuidValue.GetString().ToUTF8());
 
-  const std::vector<std::string> oldOrder = rowUuids;
-  const std::vector<wxString> oldPaths = gdtfPaths;
-  std::vector<std::string> newOrder(count);
-  std::vector<wxString> newPaths(count);
-
-  for (unsigned int i = 0; i < count; ++i) {
-    const wxDataViewItem it = table->RowToItem(i);
-    const unsigned long idx = store->GetItemData(it);
-    if (idx < oldOrder.size())
-      newOrder[i] = oldOrder[idx];
-    if (idx < oldPaths.size())
-      newPaths[i] = oldPaths[idx];
-    store->SetItemData(it, i);
+    wxVariant pathValue;
+    table->GetValue(pathValue, row, kHiddenGdtfPathColumn);
+    gdtfPaths[row] = pathValue.GetString();
   }
+}
 
-  rowUuids.swap(newOrder);
-  gdtfPaths.swap(newPaths);
-  selectionOrder = ReindexSelectionOrder(selectionOrder, oldOrder, rowUuids);
+std::string FixtureTablePanel::UuidForItem(const wxDataViewItem &item) const {
+  if (!table || !item.IsOk())
+    return {};
+  const int row = table->ItemToRow(item);
+  if (row == wxNOT_FOUND)
+    return {};
+  wxVariant uuidValue;
+  table->GetValue(uuidValue, static_cast<unsigned int>(row), kHiddenUuidColumn);
+  return std::string(uuidValue.GetString().ToUTF8());
 }
 
 void FixtureTablePanel::OnColumnSorted(wxDataViewEvent &event) {
+  RebuildRowCachesFromHiddenColumns();
   wxDataViewItemArray selections;
   table->GetSelections(selections);
   std::vector<std::string> selectedUuids;
   for (const auto &it : selections) {
-    int r = table->ItemToRow(it);
-    if (r != wxNOT_FOUND && (size_t)r < rowUuids.size())
-      selectedUuids.push_back(rowUuids[r]);
+    const std::string uuid = UuidForItem(it);
+    if (!uuid.empty())
+      selectedUuids.push_back(uuid);
   }
   std::vector<std::string> oldOrder = rowUuids;
   ResyncRows(oldOrder, selectedUuids);

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -66,6 +66,32 @@ const wxString &DegreeSymbol() {
   return kDegreeSymbol;
 }
 
+std::vector<int> ReindexSelectionOrder(
+    const std::vector<int> &selectionOrder,
+    const std::vector<std::string> &oldOrder,
+    const std::vector<std::string> &newOrder) {
+  std::unordered_map<std::string, int> rowByUuid;
+  rowByUuid.reserve(newOrder.size());
+  for (size_t row = 0; row < newOrder.size(); ++row) {
+    rowByUuid.emplace(newOrder[row], static_cast<int>(row));
+  }
+
+  std::vector<int> remappedOrder;
+  remappedOrder.reserve(selectionOrder.size());
+  std::unordered_set<int> seenRows;
+  seenRows.reserve(selectionOrder.size());
+  for (const int oldRow : selectionOrder) {
+    if (oldRow < 0 || static_cast<size_t>(oldRow) >= oldOrder.size())
+      continue;
+    const auto itRow = rowByUuid.find(oldOrder[static_cast<size_t>(oldRow)]);
+    if (itRow == rowByUuid.end())
+      continue;
+    if (seenRows.insert(itRow->second).second)
+      remappedOrder.push_back(itRow->second);
+  }
+  return remappedOrder;
+}
+
 class ConfigManagerSceneAdapter : public FixtureTableEditService::ISceneAdapter {
 public:
   void PushUndoState(const std::string &description) override {
@@ -1799,6 +1825,7 @@ void FixtureTablePanel::ResyncRows(
   }
   rowUuids.swap(newOrder);
   gdtfPaths.swap(newPaths);
+  selectionOrder = ReindexSelectionOrder(selectionOrder, oldOrder, rowUuids);
 
   {
     wxEventBlocker selectionBlocker(table, wxEVT_DATAVIEW_SELECTION_CHANGED);

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -306,8 +306,6 @@ FixtureTablePanel::FixtureTablePanel(wxWindow *parent, IGuiConfigServices *servi
   const wxColour selectionBackground(0, 255, 255);
   const wxColour selectionForeground(0, 0, 0);
   store->SetSelectionColours(selectionBackground, selectionForeground);
-  table->Bind(wxEVT_LEFT_DOWN, &FixtureTablePanel::OnLeftDown, this);
-  table->Bind(wxEVT_LEFT_UP, &FixtureTablePanel::OnLeftUp, this);
   BindTableHoverEvents(table, this, &FixtureTablePanel::OnMouseMove,
                        &FixtureTablePanel::OnMouseLeave);
   table->CallAfter([this]() {
@@ -323,8 +321,6 @@ FixtureTablePanel::FixtureTablePanel(wxWindow *parent, IGuiConfigServices *servi
               &FixtureTablePanel::OnItemActivated, this);
   table->Bind(wxEVT_DATAVIEW_COLUMN_SORTED, &FixtureTablePanel::OnColumnSorted,
               this);
-
-  Bind(wxEVT_MOUSE_CAPTURE_LOST, &FixtureTablePanel::OnCaptureLost, this);
 
   InitializeTable();
   ReloadData();
@@ -1398,51 +1394,20 @@ void FixtureTablePanel::OnItemActivated(wxDataViewEvent &event) {
 }
 
 void FixtureTablePanel::OnLeftDown(wxMouseEvent &evt) {
-  wxDataViewItem item;
-  wxDataViewColumn *col;
-  table->HitTest(evt.GetPosition(), item, col);
-  startRow = table->ItemToRow(item);
-  if (startRow != wxNOT_FOUND) {
-    dragSelecting = true;
-    table->UnselectAll();
-    table->SelectRow(startRow);
-    CaptureMouse();
-  }
   evt.Skip();
 }
 
 void FixtureTablePanel::OnLeftUp(wxMouseEvent &evt) {
-  if (dragSelecting) {
-    dragSelecting = false;
-    if (HasCapture())
-      ReleaseMouse();
-  }
   evt.Skip();
 }
 
 void FixtureTablePanel::OnCaptureLost(wxMouseCaptureLostEvent &WXUNUSED(evt)) {
   dragSelecting = false;
+  startRow = wxNOT_FOUND;
 }
 
 void FixtureTablePanel::OnMouseMove(wxMouseEvent &evt) {
   UpdateHoverTooltip(NormalizeMousePositionForTable(table, evt));
-
-  if (!dragSelecting || !evt.Dragging()) {
-    evt.Skip();
-    return;
-  }
-
-  wxDataViewItem item;
-  wxDataViewColumn *col;
-  table->HitTest(evt.GetPosition(), item, col);
-  int row = table->ItemToRow(item);
-  if (row != wxNOT_FOUND) {
-    int minRow = std::min(startRow, row);
-    int maxRow = std::max(startRow, row);
-    table->UnselectAll();
-    for (int r = minRow; r <= maxRow; ++r)
-      table->SelectRow(r);
-  }
   evt.Skip();
 }
 

--- a/gui/fixturetablepanel.h
+++ b/gui/fixturetablepanel.h
@@ -99,6 +99,7 @@ private:
     void OnContextMenu(wxDataViewEvent& event);
     void OnItemActivated(wxDataViewEvent& event);
     void OnColumnSorted(wxDataViewEvent& event);
+    void EnsureRowMappingsSynced();
     void ResyncRows(const std::vector<std::string>& oldOrder,
                     const std::vector<std::string>& selectedUuids,
                     const std::vector<wxString>* oldPaths = nullptr);

--- a/gui/fixturetablepanel.h
+++ b/gui/fixturetablepanel.h
@@ -99,7 +99,8 @@ private:
     void OnContextMenu(wxDataViewEvent& event);
     void OnItemActivated(wxDataViewEvent& event);
     void OnColumnSorted(wxDataViewEvent& event);
-    void EnsureRowMappingsSynced();
+    void RebuildRowCachesFromHiddenColumns();
+    std::string UuidForItem(const wxDataViewItem& item) const;
     void ResyncRows(const std::vector<std::string>& oldOrder,
                     const std::vector<std::string>& selectedUuids,
                     const std::vector<wxString>* oldPaths = nullptr);

--- a/gui/fixturetablepanel.h
+++ b/gui/fixturetablepanel.h
@@ -22,6 +22,7 @@
 #include <wx/time.h>
 #include <vector>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include "colorstore.h"
 #include "positionvalueupdate.h"
@@ -87,6 +88,9 @@ private:
     std::vector<wxString> columnLabels;
     std::vector<wxString> gdtfPaths; // Stores full GDTF paths per row
     std::vector<std::string> rowUuids;
+    std::unordered_map<wxUIntPtr, std::string> rowUuidByKey;
+    std::unordered_map<wxUIntPtr, wxString> gdtfPathByKey;
+    wxUIntPtr nextRowKey = 1;
     std::string highlightedUuid;
 
     bool dragSelecting = false;
@@ -99,8 +103,9 @@ private:
     void OnContextMenu(wxDataViewEvent& event);
     void OnItemActivated(wxDataViewEvent& event);
     void OnColumnSorted(wxDataViewEvent& event);
-    void RebuildRowCachesFromHiddenColumns();
+    void RebuildRowCachesFromRowKeys();
     std::string UuidForItem(const wxDataViewItem& item) const;
+    void SetGdtfPathForRow(unsigned int row, const wxString& path);
     void ResyncRows(const std::vector<std::string>& oldOrder,
                     const std::vector<std::string>& selectedUuids,
                     const std::vector<wxString>* oldPaths = nullptr);

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -365,6 +365,9 @@ void HoistTablePanel::ReloadData() {
   table->DeleteAllItems();
   rowUuids.clear();
   rowLoadStates.clear();
+  rowUuidByKey.clear();
+  loadStateByKey.clear();
+  nextRowKey = 1;
   const MvrScene &scene = guiConfigServices->LegacyConfigManager().GetScene();
   auto &supports = guiConfigServices->LegacyConfigManager().GetScene().supports;
 
@@ -460,7 +463,8 @@ void HoistTablePanel::ReloadData() {
     row.push_back(weight);
     row.push_back(load);
 
-    store->AppendItem(row, rowUuids.size());
+    const wxUIntPtr rowKey = nextRowKey++;
+    store->AppendItem(row, rowKey);
     const unsigned int rowIndex = static_cast<unsigned int>(rowUuids.size());
     if (HoistLoadLimitUtils::IsCritical(loadState))
       store->SetCellTextColour(rowIndex, 18, *wxRED);
@@ -468,6 +472,8 @@ void HoistTablePanel::ReloadData() {
       store->ClearCellTextColour(rowIndex, 18);
     rowUuids.push_back(uuid);
     rowLoadStates.push_back(loadState);
+    rowUuidByKey[rowKey] = uuid;
+    loadStateByKey[rowKey] = loadState;
     ++hoistId;
   }
 
@@ -500,9 +506,9 @@ void HoistTablePanel::OnContextMenu(wxDataViewEvent &event) {
 
   std::vector<std::string> selectedUuids;
   for (const auto &it : selections) {
-    int r = table->ItemToRow(it);
-    if (r != wxNOT_FOUND && (size_t)r < rowUuids.size())
-      selectedUuids.push_back(rowUuids[r]);
+    const std::string uuid = UuidForItem(it);
+    if (!uuid.empty())
+      selectedUuids.push_back(uuid);
   }
   std::vector<std::string> oldOrder = rowUuids;
 
@@ -841,6 +847,7 @@ void HoistTablePanel::UpdateHoverTooltip(const wxPoint &position) {
 }
 
 void HoistTablePanel::OnSelectionChanged(wxDataViewEvent &evt) {
+  RebuildRowCachesFromRowKeys();
   const selection::Origin origin = selection::CurrentOrigin();
   if (origin == selection::Origin::Viewer2D ||
       origin == selection::Origin::Viewer3D) {
@@ -854,9 +861,9 @@ void HoistTablePanel::OnSelectionChanged(wxDataViewEvent &evt) {
   std::vector<std::string> uuids;
   uuids.reserve(selections.size());
   for (const auto &it : selections) {
-    int r = table->ItemToRow(it);
-    if (r != wxNOT_FOUND && (size_t)r < rowUuids.size())
-      uuids.push_back(rowUuids[r]);
+    const std::string uuid = UuidForItem(it);
+    if (!uuid.empty())
+      uuids.push_back(uuid);
   }
   ConfigManager &cfg = guiConfigServices->LegacyConfigManager();
   if (uuids != cfg.GetSelectedSupports()) {
@@ -1187,15 +1194,17 @@ std::vector<std::string> HoistTablePanel::GetSelectedUuids() const {
   std::vector<std::string> uuids;
   uuids.reserve(selections.size());
   for (const auto &it : selections) {
-    int r = table->ItemToRow(it);
-    if (r != wxNOT_FOUND && (size_t)r < rowUuids.size())
-      uuids.push_back(rowUuids[r]);
+    const wxUIntPtr rowKey = store->GetItemData(it);
+    auto keyIt = rowUuidByKey.find(rowKey);
+    if (keyIt != rowUuidByKey.end())
+      uuids.push_back(keyIt->second);
   }
   return uuids;
 }
 
 void HoistTablePanel::SelectByUuid(const std::vector<std::string> &uuids,
                                    bool notifySelectionChanged) {
+  RebuildRowCachesFromRowKeys();
   std::unique_ptr<wxEventBlocker> selectionBlocker;
   if (!notifySelectionChanged) {
     selectionBlocker =
@@ -1216,6 +1225,7 @@ void HoistTablePanel::SelectByUuid(const std::vector<std::string> &uuids,
 }
 
 void HoistTablePanel::DeleteSelected(bool pushUndoState) {
+  RebuildRowCachesFromRowKeys();
   wxDataViewItemArray selections;
   table->GetSelections(selections);
   if (selections.empty())
@@ -1239,8 +1249,14 @@ void HoistTablePanel::DeleteSelected(bool pushUndoState) {
   auto &scene = cfg.GetScene();
   for (int r : rows) {
     if ((size_t)r < rowUuids.size()) {
+      wxDataViewItem rowItem = table->RowToItem(static_cast<unsigned int>(r));
+      const wxUIntPtr rowKey = store->GetItemData(rowItem);
       scene.supports.erase(rowUuids[r]);
       rowUuids.erase(rowUuids.begin() + r);
+      if ((size_t)r < rowLoadStates.size())
+        rowLoadStates.erase(rowLoadStates.begin() + r);
+      rowUuidByKey.erase(rowKey);
+      loadStateByKey.erase(rowKey);
       table->DeleteItem(r);
     }
   }
@@ -1275,16 +1291,8 @@ void HoistTablePanel::DeleteSelected(bool pushUndoState) {
 
 void HoistTablePanel::ResyncRows(const std::vector<std::string> &oldOrder,
                                  const std::vector<std::string> &selectedUuids) {
-  unsigned int count = table->GetItemCount();
-  std::vector<std::string> newOrder(count);
-  for (unsigned int i = 0; i < count; ++i) {
-    wxDataViewItem it = table->RowToItem(i);
-    unsigned long idx = store->GetItemData(it);
-    if (idx < oldOrder.size())
-      newOrder[i] = oldOrder[idx];
-    store->SetItemData(it, i);
-  }
-  rowUuids.swap(newOrder);
+  (void)oldOrder;
+  RebuildRowCachesFromRowKeys();
 
   table->UnselectAll();
   for (const auto &uuid : selectedUuids) {
@@ -1295,14 +1303,56 @@ void HoistTablePanel::ResyncRows(const std::vector<std::string> &oldOrder,
   UpdateSelectionHighlight();
 }
 
+void HoistTablePanel::RebuildRowCachesFromRowKeys() {
+  if (!table || !store)
+    return;
+  const unsigned int count = table->GetItemCount();
+  rowUuids.assign(count, std::string());
+  rowLoadStates.assign(count, HoistLoadLimitUtils::LoadLimitState::Normal);
+  for (unsigned int row = 0; row < count; ++row) {
+    wxDataViewItem item = table->RowToItem(row);
+    const wxUIntPtr rowKey = store->GetItemData(item);
+    auto uuidIt = rowUuidByKey.find(rowKey);
+    if (uuidIt != rowUuidByKey.end())
+      rowUuids[row] = uuidIt->second;
+    auto loadIt = loadStateByKey.find(rowKey);
+    if (loadIt != loadStateByKey.end())
+      rowLoadStates[row] = loadIt->second;
+  }
+}
+
+std::string HoistTablePanel::UuidForItem(const wxDataViewItem &item) const {
+  if (!store || !item.IsOk())
+    return {};
+  const wxUIntPtr rowKey = store->GetItemData(item);
+  auto it = rowUuidByKey.find(rowKey);
+  if (it == rowUuidByKey.end())
+    return {};
+  return it->second;
+}
+
+void HoistTablePanel::SetLoadStateForRow(
+    unsigned int row, const HoistLoadLimitUtils::LoadLimitState &state) {
+  if (!table || !store || row >= table->GetItemCount())
+    return;
+  if (row >= rowLoadStates.size())
+    rowLoadStates.resize(table->GetItemCount(),
+                         HoistLoadLimitUtils::LoadLimitState::Normal);
+  rowLoadStates[row] = state;
+  wxDataViewItem item = table->RowToItem(row);
+  const wxUIntPtr rowKey = store->GetItemData(item);
+  loadStateByKey[rowKey] = state;
+}
+
 void HoistTablePanel::OnColumnSorted(wxDataViewEvent &event) {
+  RebuildRowCachesFromRowKeys();
   wxDataViewItemArray selections;
   table->GetSelections(selections);
   std::vector<std::string> selectedUuids;
   for (const auto &it : selections) {
-    int r = table->ItemToRow(it);
-    if (r != wxNOT_FOUND && (size_t)r < rowUuids.size())
-      selectedUuids.push_back(rowUuids[r]);
+    const std::string uuid = UuidForItem(it);
+    if (!uuid.empty())
+      selectedUuids.push_back(uuid);
   }
   std::vector<std::string> oldOrder = rowUuids;
   ResyncRows(oldOrder, selectedUuids);

--- a/gui/hoisttablepanel.h
+++ b/gui/hoisttablepanel.h
@@ -20,6 +20,7 @@
 #include <wx/dataview.h>
 #include <wx/wx.h>
 #include <string>
+#include <unordered_map>
 #include <vector>
 #include "colorstore.h"
 #include "hoist_load_limit_utils.h"
@@ -54,6 +55,9 @@ private:
   std::vector<wxString> columnLabels;
   std::vector<std::string> rowUuids;
   std::vector<HoistLoadLimitUtils::LoadLimitState> rowLoadStates;
+  std::unordered_map<wxUIntPtr, std::string> rowUuidByKey;
+  std::unordered_map<wxUIntPtr, HoistLoadLimitUtils::LoadLimitState> loadStateByKey;
+  wxUIntPtr nextRowKey = 1;
   wxString activeHoverTooltip;
   bool dragSelecting = false;
   int startRow = -1;
@@ -63,6 +67,10 @@ private:
   void OnSelectionChanged(wxDataViewEvent &evt);
   void OnContextMenu(wxDataViewEvent &event);
   void OnColumnSorted(wxDataViewEvent &event);
+  void RebuildRowCachesFromRowKeys();
+  std::string UuidForItem(const wxDataViewItem &item) const;
+  void SetLoadStateForRow(unsigned int row,
+                          const HoistLoadLimitUtils::LoadLimitState &state);
   void ResyncRows(const std::vector<std::string> &oldOrder,
                   const std::vector<std::string> &selectedUuids);
   void OnLeftDown(wxMouseEvent &evt);

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -567,13 +567,7 @@ void SceneObjectTablePanel::OnLeftDown(wxMouseEvent& evt)
     wxDataViewColumn* col;
     table->HitTest(evt.GetPosition(), item, col);
     startRow = table->ItemToRow(item);
-    if (startRow != wxNOT_FOUND)
-    {
-        dragSelecting = true;
-        table->UnselectAll();
-        table->SelectRow(startRow);
-        CaptureMouse();
-    }
+    dragSelecting = false;
     evt.Skip();
 }
 
@@ -612,19 +606,22 @@ void SceneObjectTablePanel::OnLeftUp(wxMouseEvent& evt)
     if (dragSelecting)
     {
         dragSelecting = false;
-        ReleaseMouse();
+        if (HasCapture())
+            ReleaseMouse();
     }
+    startRow = wxNOT_FOUND;
     evt.Skip();
 }
 
 void SceneObjectTablePanel::OnCaptureLost(wxMouseCaptureLostEvent& WXUNUSED(evt))
 {
     dragSelecting = false;
+    startRow = wxNOT_FOUND;
 }
 
 void SceneObjectTablePanel::OnMouseMove(wxMouseEvent& evt)
 {
-    if (!dragSelecting || !evt.Dragging())
+    if (!evt.Dragging() || startRow == wxNOT_FOUND)
     {
         evt.Skip();
         return;
@@ -635,6 +632,14 @@ void SceneObjectTablePanel::OnMouseMove(wxMouseEvent& evt)
     int row = table->ItemToRow(item);
     if (row != wxNOT_FOUND)
     {
+        if (!dragSelecting)
+        {
+            dragSelecting = true;
+            table->UnselectAll();
+            table->SelectRow(startRow);
+            if (!HasCapture())
+                CaptureMouse();
+        }
         int minRow = std::min(startRow, row);
         int maxRow = std::max(startRow, row);
         table->UnselectAll();

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -265,6 +265,9 @@ void SceneObjectTablePanel::ReloadData()
     table->DeleteAllItems();
     modelPaths.clear();
     rowUuids.clear();
+    rowUuidByKey.clear();
+    modelPathByKey.clear();
+    nextRowKey = 1;
     const auto& objs = guiConfigServices->LegacyConfigManager().GetScene().sceneObjects;
 
     // Copy objects into a sortable vector
@@ -326,9 +329,12 @@ void SceneObjectTablePanel::ReloadData()
         row.push_back(pitch);
         row.push_back(yaw);
 
-        store->AppendItem(row, rowUuids.size());
+        const wxUIntPtr rowKey = nextRowKey++;
+        store->AppendItem(row, rowKey);
         modelPaths.push_back(modelFullPath);
         rowUuids.push_back(uuid);
+        rowUuidByKey[rowKey] = uuid;
+        modelPathByKey[rowKey] = modelFullPath;
     }
 
     // Let wxDataViewListCtrl manage column headers and sorting
@@ -360,9 +366,9 @@ void SceneObjectTablePanel::OnContextMenu(wxDataViewEvent& event)
     std::vector<std::string> selectedUuids;
     for (const auto& it : selections)
     {
-        int r = table->ItemToRow(it);
-        if (r != wxNOT_FOUND && (size_t)r < rowUuids.size())
-            selectedUuids.push_back(rowUuids[r]);
+        const std::string uuid = UuidForItem(it);
+        if (!uuid.empty())
+            selectedUuids.push_back(uuid);
     }
     std::vector<std::string> oldOrder = rowUuids;
 
@@ -424,7 +430,7 @@ void SceneObjectTablePanel::OnContextMenu(wxDataViewEvent& event)
             table->SetValue(wxVariant(displayName), r, col);
             if (static_cast<size_t>(r) >= modelPaths.size())
                 modelPaths.resize(table->GetItemCount());
-            modelPaths[static_cast<size_t>(r)] = selectedPath;
+            SetModelPathForRow(static_cast<unsigned int>(r), selectedPath);
         }
 
         ResyncRows(oldOrder, selectedUuids);
@@ -646,6 +652,7 @@ void SceneObjectTablePanel::OnMouseMove(wxMouseEvent& evt)
 
 void SceneObjectTablePanel::OnSelectionChanged(wxDataViewEvent& evt)
 {
+    RebuildRowCachesFromRowKeys();
     const selection::Origin origin = selection::CurrentOrigin();
     if (origin == selection::Origin::Viewer2D ||
         origin == selection::Origin::Viewer3D) {
@@ -660,9 +667,9 @@ void SceneObjectTablePanel::OnSelectionChanged(wxDataViewEvent& evt)
     uuids.reserve(selections.size());
     for (const auto& it : selections)
     {
-        int r = table->ItemToRow(it);
-        if (r != wxNOT_FOUND && (size_t)r < rowUuids.size())
-            uuids.push_back(rowUuids[r]);
+        const std::string uuid = UuidForItem(it);
+        if (!uuid.empty())
+            uuids.push_back(uuid);
     }
     ConfigManager& cfg = guiConfigServices->LegacyConfigManager();
     if (uuids != cfg.GetSelectedSceneObjects()) {
@@ -929,15 +936,17 @@ std::vector<std::string> SceneObjectTablePanel::GetSelectedUuids() const {
     std::vector<std::string> uuids;
     uuids.reserve(selections.size());
     for (const auto& it : selections) {
-        int r = table->ItemToRow(it);
-        if (r != wxNOT_FOUND && (size_t)r < rowUuids.size())
-            uuids.push_back(rowUuids[r]);
+        const wxUIntPtr rowKey = store->GetItemData(it);
+        auto keyIt = rowUuidByKey.find(rowKey);
+        if (keyIt != rowUuidByKey.end())
+            uuids.push_back(keyIt->second);
     }
     return uuids;
 }
 
 void SceneObjectTablePanel::SelectByUuid(const std::vector<std::string>& uuids,
                                          bool notifySelectionChanged) {
+    RebuildRowCachesFromRowKeys();
     std::unique_ptr<wxEventBlocker> selectionBlocker;
     if (!notifySelectionChanged) {
         selectionBlocker = std::make_unique<wxEventBlocker>(
@@ -959,6 +968,7 @@ void SceneObjectTablePanel::SelectByUuid(const std::vector<std::string>& uuids,
 
 void SceneObjectTablePanel::DeleteSelected(bool pushUndoState)
 {
+    RebuildRowCachesFromRowKeys();
     wxDataViewItemArray selections;
     table->GetSelections(selections);
     if (selections.empty())
@@ -992,7 +1002,11 @@ void SceneObjectTablePanel::DeleteSelected(bool pushUndoState)
 
     for (int r : rows) {
         if ((size_t)r < rowUuids.size()) {
+            wxDataViewItem rowItem = table->RowToItem(static_cast<unsigned int>(r));
+            const wxUIntPtr rowKey = store->GetItemData(rowItem);
             rowUuids.erase(rowUuids.begin() + r);
+            rowUuidByKey.erase(rowKey);
+            modelPathByKey.erase(rowKey);
             table->DeleteItem(r);
         }
     }
@@ -1026,22 +1040,8 @@ void SceneObjectTablePanel::DeleteSelected(bool pushUndoState)
 void SceneObjectTablePanel::ResyncRows(const std::vector<std::string>& oldOrder,
                                        const std::vector<std::string>& selectedUuids)
 {
-    unsigned int count = table->GetItemCount();
-    std::vector<std::string> newOrder(count);
-    std::vector<wxString> newPaths(count);
-    for (unsigned int i = 0; i < count; ++i)
-    {
-        wxDataViewItem it = table->RowToItem(i);
-        unsigned long idx = store->GetItemData(it);
-        if (idx < oldOrder.size()) {
-            newOrder[i] = oldOrder[idx];
-            if (idx < modelPaths.size())
-                newPaths[i] = modelPaths[idx];
-        }
-        store->SetItemData(it, i);
-    }
-    rowUuids.swap(newOrder);
-    modelPaths.swap(newPaths);
+    (void)oldOrder;
+    RebuildRowCachesFromRowKeys();
 
     table->UnselectAll();
     for (const auto& uuid : selectedUuids)
@@ -1053,16 +1053,57 @@ void SceneObjectTablePanel::ResyncRows(const std::vector<std::string>& oldOrder,
     UpdateSelectionHighlight();
 }
 
+void SceneObjectTablePanel::RebuildRowCachesFromRowKeys() {
+    if (!table || !store)
+        return;
+    const unsigned int count = table->GetItemCount();
+    rowUuids.assign(count, std::string());
+    modelPaths.assign(count, wxString());
+    for (unsigned int row = 0; row < count; ++row) {
+        wxDataViewItem item = table->RowToItem(row);
+        const wxUIntPtr rowKey = store->GetItemData(item);
+        auto uuidIt = rowUuidByKey.find(rowKey);
+        if (uuidIt != rowUuidByKey.end())
+            rowUuids[row] = uuidIt->second;
+        auto pathIt = modelPathByKey.find(rowKey);
+        if (pathIt != modelPathByKey.end())
+            modelPaths[row] = pathIt->second;
+    }
+}
+
+std::string SceneObjectTablePanel::UuidForItem(const wxDataViewItem& item) const {
+    if (!store || !item.IsOk())
+        return {};
+    const wxUIntPtr rowKey = store->GetItemData(item);
+    auto it = rowUuidByKey.find(rowKey);
+    if (it == rowUuidByKey.end())
+        return {};
+    return it->second;
+}
+
+void SceneObjectTablePanel::SetModelPathForRow(unsigned int row,
+                                               const wxString& modelPath) {
+    if (!table || !store || row >= table->GetItemCount())
+        return;
+    if (row >= modelPaths.size())
+        modelPaths.resize(table->GetItemCount());
+    modelPaths[row] = modelPath;
+    wxDataViewItem item = table->RowToItem(row);
+    const wxUIntPtr rowKey = store->GetItemData(item);
+    modelPathByKey[rowKey] = modelPath;
+}
+
 void SceneObjectTablePanel::OnColumnSorted(wxDataViewEvent& event)
 {
+    RebuildRowCachesFromRowKeys();
     wxDataViewItemArray selections;
     table->GetSelections(selections);
     std::vector<std::string> selectedUuids;
     for (const auto& it : selections)
     {
-        int r = table->ItemToRow(it);
-        if (r != wxNOT_FOUND && (size_t)r < rowUuids.size())
-            selectedUuids.push_back(rowUuids[r]);
+        const std::string uuid = UuidForItem(it);
+        if (!uuid.empty())
+            selectedUuids.push_back(uuid);
     }
     std::vector<std::string> oldOrder = rowUuids;
     ResyncRows(oldOrder, selectedUuids);

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -340,6 +340,7 @@ void SceneObjectTablePanel::ReloadData()
 
 void SceneObjectTablePanel::OnContextMenu(wxDataViewEvent& event)
 {
+    EnsureRowMappingsSynced();
     wxDataViewItem item = event.GetItem();
     int col = event.GetColumn();
     if (!item.IsOk() || col < 0)
@@ -651,6 +652,7 @@ void SceneObjectTablePanel::OnMouseMove(wxMouseEvent& evt)
 
 void SceneObjectTablePanel::OnSelectionChanged(wxDataViewEvent& evt)
 {
+    EnsureRowMappingsSynced();
     const selection::Origin origin = selection::CurrentOrigin();
     if (origin == selection::Origin::Viewer2D ||
         origin == selection::Origin::Viewer3D) {
@@ -943,6 +945,7 @@ std::vector<std::string> SceneObjectTablePanel::GetSelectedUuids() const {
 
 void SceneObjectTablePanel::SelectByUuid(const std::vector<std::string>& uuids,
                                          bool notifySelectionChanged) {
+    EnsureRowMappingsSynced();
     std::unique_ptr<wxEventBlocker> selectionBlocker;
     if (!notifySelectionChanged) {
         selectionBlocker = std::make_unique<wxEventBlocker>(
@@ -964,6 +967,7 @@ void SceneObjectTablePanel::SelectByUuid(const std::vector<std::string>& uuids,
 
 void SceneObjectTablePanel::DeleteSelected(bool pushUndoState)
 {
+    EnsureRowMappingsSynced();
     wxDataViewItemArray selections;
     table->GetSelections(selections);
     if (selections.empty())
@@ -1056,6 +1060,34 @@ void SceneObjectTablePanel::ResyncRows(const std::vector<std::string>& oldOrder,
             table->SelectRow(static_cast<int>(pos - rowUuids.begin()));
     }
     UpdateSelectionHighlight();
+}
+
+void SceneObjectTablePanel::EnsureRowMappingsSynced()
+{
+    if (!table || !store)
+        return;
+
+    const unsigned int count = table->GetItemCount();
+    if (count == 0 || rowUuids.empty())
+        return;
+
+    const std::vector<std::string> oldOrder = rowUuids;
+    const std::vector<wxString> oldPaths = modelPaths;
+    std::vector<std::string> newOrder(count);
+    std::vector<wxString> newPaths(count);
+
+    for (unsigned int i = 0; i < count; ++i) {
+        wxDataViewItem it = table->RowToItem(i);
+        const unsigned long idx = store->GetItemData(it);
+        if (idx < oldOrder.size())
+            newOrder[i] = oldOrder[idx];
+        if (idx < oldPaths.size())
+            newPaths[i] = oldPaths[idx];
+        store->SetItemData(it, i);
+    }
+
+    rowUuids.swap(newOrder);
+    modelPaths.swap(newPaths);
 }
 
 void SceneObjectTablePanel::OnColumnSorted(wxDataViewEvent& event)

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -340,7 +340,6 @@ void SceneObjectTablePanel::ReloadData()
 
 void SceneObjectTablePanel::OnContextMenu(wxDataViewEvent& event)
 {
-    EnsureRowMappingsSynced();
     wxDataViewItem item = event.GetItem();
     int col = event.GetColumn();
     if (!item.IsOk() || col < 0)
@@ -568,7 +567,13 @@ void SceneObjectTablePanel::OnLeftDown(wxMouseEvent& evt)
     wxDataViewColumn* col;
     table->HitTest(evt.GetPosition(), item, col);
     startRow = table->ItemToRow(item);
-    dragSelecting = false;
+    if (startRow != wxNOT_FOUND)
+    {
+        dragSelecting = true;
+        table->UnselectAll();
+        table->SelectRow(startRow);
+        CaptureMouse();
+    }
     evt.Skip();
 }
 
@@ -607,22 +612,19 @@ void SceneObjectTablePanel::OnLeftUp(wxMouseEvent& evt)
     if (dragSelecting)
     {
         dragSelecting = false;
-        if (HasCapture())
-            ReleaseMouse();
+        ReleaseMouse();
     }
-    startRow = wxNOT_FOUND;
     evt.Skip();
 }
 
 void SceneObjectTablePanel::OnCaptureLost(wxMouseCaptureLostEvent& WXUNUSED(evt))
 {
     dragSelecting = false;
-    startRow = wxNOT_FOUND;
 }
 
 void SceneObjectTablePanel::OnMouseMove(wxMouseEvent& evt)
 {
-    if (!evt.Dragging() || startRow == wxNOT_FOUND)
+    if (!dragSelecting || !evt.Dragging())
     {
         evt.Skip();
         return;
@@ -633,14 +635,6 @@ void SceneObjectTablePanel::OnMouseMove(wxMouseEvent& evt)
     int row = table->ItemToRow(item);
     if (row != wxNOT_FOUND)
     {
-        if (!dragSelecting)
-        {
-            dragSelecting = true;
-            table->UnselectAll();
-            table->SelectRow(startRow);
-            if (!HasCapture())
-                CaptureMouse();
-        }
         int minRow = std::min(startRow, row);
         int maxRow = std::max(startRow, row);
         table->UnselectAll();
@@ -652,7 +646,6 @@ void SceneObjectTablePanel::OnMouseMove(wxMouseEvent& evt)
 
 void SceneObjectTablePanel::OnSelectionChanged(wxDataViewEvent& evt)
 {
-    EnsureRowMappingsSynced();
     const selection::Origin origin = selection::CurrentOrigin();
     if (origin == selection::Origin::Viewer2D ||
         origin == selection::Origin::Viewer3D) {
@@ -945,7 +938,6 @@ std::vector<std::string> SceneObjectTablePanel::GetSelectedUuids() const {
 
 void SceneObjectTablePanel::SelectByUuid(const std::vector<std::string>& uuids,
                                          bool notifySelectionChanged) {
-    EnsureRowMappingsSynced();
     std::unique_ptr<wxEventBlocker> selectionBlocker;
     if (!notifySelectionChanged) {
         selectionBlocker = std::make_unique<wxEventBlocker>(
@@ -967,7 +959,6 @@ void SceneObjectTablePanel::SelectByUuid(const std::vector<std::string>& uuids,
 
 void SceneObjectTablePanel::DeleteSelected(bool pushUndoState)
 {
-    EnsureRowMappingsSynced();
     wxDataViewItemArray selections;
     table->GetSelections(selections);
     if (selections.empty())
@@ -1060,34 +1051,6 @@ void SceneObjectTablePanel::ResyncRows(const std::vector<std::string>& oldOrder,
             table->SelectRow(static_cast<int>(pos - rowUuids.begin()));
     }
     UpdateSelectionHighlight();
-}
-
-void SceneObjectTablePanel::EnsureRowMappingsSynced()
-{
-    if (!table || !store)
-        return;
-
-    const unsigned int count = table->GetItemCount();
-    if (count == 0 || rowUuids.empty())
-        return;
-
-    const std::vector<std::string> oldOrder = rowUuids;
-    const std::vector<wxString> oldPaths = modelPaths;
-    std::vector<std::string> newOrder(count);
-    std::vector<wxString> newPaths(count);
-
-    for (unsigned int i = 0; i < count; ++i) {
-        wxDataViewItem it = table->RowToItem(i);
-        const unsigned long idx = store->GetItemData(it);
-        if (idx < oldOrder.size())
-            newOrder[i] = oldOrder[idx];
-        if (idx < oldPaths.size())
-            newPaths[i] = oldPaths[idx];
-        store->SetItemData(it, i);
-    }
-
-    rowUuids.swap(newOrder);
-    modelPaths.swap(newPaths);
 }
 
 void SceneObjectTablePanel::OnColumnSorted(wxDataViewEvent& event)

--- a/gui/sceneobjecttablepanel.h
+++ b/gui/sceneobjecttablepanel.h
@@ -63,7 +63,6 @@ private:
     void OnSelectionChanged(wxDataViewEvent& evt);
     void OnContextMenu(wxDataViewEvent& event);
     void OnColumnSorted(wxDataViewEvent& event);
-    void EnsureRowMappingsSynced();
     void OnItemActivated(wxDataViewEvent& event);
     void ResyncRows(const std::vector<std::string>& oldOrder,
                     const std::vector<std::string>& selectedUuids);

--- a/gui/sceneobjecttablepanel.h
+++ b/gui/sceneobjecttablepanel.h
@@ -22,6 +22,7 @@
 #include <wx/time.h>
 #include <vector>
 #include <string>
+#include <unordered_map>
 #include "colorstore.h"
 #include "positionvalueupdate.h"
 
@@ -55,6 +56,9 @@ private:
     std::vector<wxString> columnLabels;
     std::vector<wxString> modelPaths;
     std::vector<std::string> rowUuids;
+    std::unordered_map<wxUIntPtr, std::string> rowUuidByKey;
+    std::unordered_map<wxUIntPtr, wxString> modelPathByKey;
+    wxUIntPtr nextRowKey = 1;
     std::string highlightedUuid;
     bool dragSelecting = false;
     int startRow = -1;
@@ -63,6 +67,9 @@ private:
     void OnSelectionChanged(wxDataViewEvent& evt);
     void OnContextMenu(wxDataViewEvent& event);
     void OnColumnSorted(wxDataViewEvent& event);
+    void RebuildRowCachesFromRowKeys();
+    std::string UuidForItem(const wxDataViewItem& item) const;
+    void SetModelPathForRow(unsigned int row, const wxString& modelPath);
     void OnItemActivated(wxDataViewEvent& event);
     void ResyncRows(const std::vector<std::string>& oldOrder,
                     const std::vector<std::string>& selectedUuids);

--- a/gui/sceneobjecttablepanel.h
+++ b/gui/sceneobjecttablepanel.h
@@ -63,6 +63,7 @@ private:
     void OnSelectionChanged(wxDataViewEvent& evt);
     void OnContextMenu(wxDataViewEvent& event);
     void OnColumnSorted(wxDataViewEvent& event);
+    void EnsureRowMappingsSynced();
     void OnItemActivated(wxDataViewEvent& event);
     void ResyncRows(const std::vector<std::string>& oldOrder,
                     const std::vector<std::string>& selectedUuids);

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -356,6 +356,7 @@ void TrussTablePanel::ReloadData()
 
 void TrussTablePanel::OnContextMenu(wxDataViewEvent& event)
 {
+    EnsureRowMappingsSynced();
     wxDataViewItem item = event.GetItem();
     int col = event.GetColumn();
     if (!item.IsOk() || col < 0)
@@ -717,6 +718,7 @@ void TrussTablePanel::OnMouseMove(wxMouseEvent& evt)
 
 void TrussTablePanel::OnSelectionChanged(wxDataViewEvent& evt)
 {
+    EnsureRowMappingsSynced();
     const selection::Origin origin = selection::CurrentOrigin();
     if (origin == selection::Origin::Viewer2D ||
         origin == selection::Origin::Viewer3D) {
@@ -1148,6 +1150,7 @@ std::vector<std::string> TrussTablePanel::GetSelectedUuids() const {
 
 void TrussTablePanel::SelectByUuid(const std::vector<std::string>& uuids,
                                    bool notifySelectionChanged) {
+    EnsureRowMappingsSynced();
     std::unique_ptr<wxEventBlocker> selectionBlocker;
     if (!notifySelectionChanged) {
         selectionBlocker = std::make_unique<wxEventBlocker>(
@@ -1169,6 +1172,7 @@ void TrussTablePanel::SelectByUuid(const std::vector<std::string>& uuids,
 
 void TrussTablePanel::DeleteSelected(bool pushUndoState)
 {
+    EnsureRowMappingsSynced();
     wxDataViewItemArray selections;
     table->GetSelections(selections);
     if (selections.empty())
@@ -1265,6 +1269,39 @@ void TrussTablePanel::ResyncRows(const std::vector<std::string>& oldOrder,
             table->SelectRow(static_cast<int>(pos - rowUuids.begin()));
     }
     UpdateSelectionHighlight();
+}
+
+void TrussTablePanel::EnsureRowMappingsSynced()
+{
+    if (!table || !store)
+        return;
+
+    const unsigned int count = table->GetItemCount();
+    if (count == 0 || rowUuids.empty())
+        return;
+
+    const std::vector<std::string> oldOrder = rowUuids;
+    const std::vector<wxString> oldModelPaths = modelPaths;
+    const std::vector<wxString> oldSymbolPaths = symbolPaths;
+    std::vector<std::string> newOrder(count);
+    std::vector<wxString> newPaths(count);
+    std::vector<wxString> newSymPaths(count);
+
+    for (unsigned int i = 0; i < count; ++i) {
+        wxDataViewItem it = table->RowToItem(i);
+        const unsigned long idx = store->GetItemData(it);
+        if (idx < oldOrder.size())
+            newOrder[i] = oldOrder[idx];
+        if (idx < oldModelPaths.size())
+            newPaths[i] = oldModelPaths[idx];
+        if (idx < oldSymbolPaths.size())
+            newSymPaths[i] = oldSymbolPaths[idx];
+        store->SetItemData(it, i);
+    }
+
+    rowUuids.swap(newOrder);
+    modelPaths.swap(newPaths);
+    symbolPaths.swap(newSymPaths);
 }
 
 void TrussTablePanel::OnColumnSorted(wxDataViewEvent& event)

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -248,6 +248,10 @@ void TrussTablePanel::ReloadData()
     rowUuids.clear();
     modelPaths.clear();
     symbolPaths.clear();
+    rowUuidByKey.clear();
+    modelPathByKey.clear();
+    symbolPathByKey.clear();
+    nextRowKey = 1;
     const auto& trusses = guiConfigServices->LegacyConfigManager().GetScene().trusses;
 
     std::vector<std::pair<std::string, const Truss*>> sorted;
@@ -343,8 +347,12 @@ void TrussTablePanel::ReloadData()
         row.push_back(hei);
         row.push_back(weight);
 
-        store->AppendItem(row, rowUuids.size());
+        const wxUIntPtr rowKey = nextRowKey++;
+        store->AppendItem(row, rowKey);
         rowUuids.push_back(uuid);
+        rowUuidByKey[rowKey] = uuid;
+        modelPathByKey[rowKey] = modelFull;
+        symbolPathByKey[rowKey] = wxString::FromUTF8(symbolFullPath);
     }
 
     // Let wxDataViewListCtrl manage column headers and sorting
@@ -375,9 +383,9 @@ void TrussTablePanel::OnContextMenu(wxDataViewEvent& event)
     std::vector<std::string> selectedUuids;
     for (const auto& it : selections)
     {
-        int r = table->ItemToRow(it);
-        if (r != wxNOT_FOUND && (size_t)r < rowUuids.size())
-            selectedUuids.push_back(rowUuids[r]);
+        const std::string uuid = UuidForItem(it);
+        if (!uuid.empty())
+            selectedUuids.push_back(uuid);
     }
     std::vector<std::string> oldOrder = rowUuids;
 
@@ -475,8 +483,9 @@ void TrussTablePanel::OnContextMenu(wxDataViewEvent& event)
                 int r = table->ItemToRow(itSel);
                 if (r == wxNOT_FOUND)
                     continue;
-                modelPaths[r] = wxString::FromUTF8(archivePath);
-                symbolPaths[r] = wxString::FromUTF8(geomPath);
+                SetModelPathsForRow(static_cast<unsigned int>(r),
+                                    wxString::FromUTF8(archivePath),
+                                    wxString::FromUTF8(geomPath));
                 table->SetValue(wxVariant(fileName), r, 2);
                 if (parsedOk)
                 {
@@ -498,8 +507,8 @@ void TrussTablePanel::OnContextMenu(wxDataViewEvent& event)
                 table->GetValue(mv, i, 11);
                 if (mv.GetString() == wxString::FromUTF8(modelKey))
                 {
-                    modelPaths[i] = wxString::FromUTF8(archivePath);
-                    symbolPaths[i] = wxString::FromUTF8(geomPath);
+                    SetModelPathsForRow(i, wxString::FromUTF8(archivePath),
+                                        wxString::FromUTF8(geomPath));
                     table->SetValue(wxVariant(fileName), i, 2);
                     if (parsedOk)
                     {
@@ -712,6 +721,7 @@ void TrussTablePanel::OnMouseMove(wxMouseEvent& evt)
 
 void TrussTablePanel::OnSelectionChanged(wxDataViewEvent& evt)
 {
+    RebuildRowCachesFromRowKeys();
     const selection::Origin origin = selection::CurrentOrigin();
     if (origin == selection::Origin::Viewer2D ||
         origin == selection::Origin::Viewer3D) {
@@ -726,9 +736,9 @@ void TrussTablePanel::OnSelectionChanged(wxDataViewEvent& evt)
     uuids.reserve(selections.size());
     for (const auto& it : selections)
     {
-        int r = table->ItemToRow(it);
-        if (r != wxNOT_FOUND && (size_t)r < rowUuids.size())
-            uuids.push_back(rowUuids[r]);
+        const std::string uuid = UuidForItem(it);
+        if (!uuid.empty())
+            uuids.push_back(uuid);
     }
     ConfigManager& cfg = guiConfigServices->LegacyConfigManager();
     if (uuids != cfg.GetSelectedTrusses()) {
@@ -1134,15 +1144,17 @@ std::vector<std::string> TrussTablePanel::GetSelectedUuids() const {
     std::vector<std::string> uuids;
     uuids.reserve(selections.size());
     for (const auto& it : selections) {
-        int r = table->ItemToRow(it);
-        if (r != wxNOT_FOUND && (size_t)r < rowUuids.size())
-            uuids.push_back(rowUuids[r]);
+        const wxUIntPtr rowKey = store->GetItemData(it);
+        auto keyIt = rowUuidByKey.find(rowKey);
+        if (keyIt != rowUuidByKey.end())
+            uuids.push_back(keyIt->second);
     }
     return uuids;
 }
 
 void TrussTablePanel::SelectByUuid(const std::vector<std::string>& uuids,
                                    bool notifySelectionChanged) {
+    RebuildRowCachesFromRowKeys();
     std::unique_ptr<wxEventBlocker> selectionBlocker;
     if (!notifySelectionChanged) {
         selectionBlocker = std::make_unique<wxEventBlocker>(
@@ -1164,6 +1176,7 @@ void TrussTablePanel::SelectByUuid(const std::vector<std::string>& uuids,
 
 void TrussTablePanel::DeleteSelected(bool pushUndoState)
 {
+    RebuildRowCachesFromRowKeys();
     wxDataViewItemArray selections;
     table->GetSelections(selections);
     if (selections.empty())
@@ -1191,7 +1204,12 @@ void TrussTablePanel::DeleteSelected(bool pushUndoState)
     auto& scene = guiConfigServices->LegacyConfigManager().GetScene();
     for (int r : rows) {
         if ((size_t)r < rowUuids.size()) {
+            wxDataViewItem rowItem = table->RowToItem(static_cast<unsigned int>(r));
+            const wxUIntPtr rowKey = store->GetItemData(rowItem);
             scene.trusses.erase(rowUuids[r]);
+            rowUuidByKey.erase(rowKey);
+            modelPathByKey.erase(rowKey);
+            symbolPathByKey.erase(rowKey);
             table->DeleteItem(r);
         }
     }
@@ -1231,26 +1249,8 @@ void TrussTablePanel::DeleteSelected(bool pushUndoState)
 void TrussTablePanel::ResyncRows(const std::vector<std::string>& oldOrder,
                                  const std::vector<std::string>& selectedUuids)
 {
-    unsigned int count = table->GetItemCount();
-    std::vector<std::string> newOrder(count);
-    std::vector<wxString> newPaths(count);
-    std::vector<wxString> newSymPaths(count);
-    for (unsigned int i = 0; i < count; ++i)
-    {
-        wxDataViewItem it = table->RowToItem(i);
-        unsigned long idx = store->GetItemData(it);
-        if (idx < oldOrder.size()) {
-            newOrder[i] = oldOrder[idx];
-            if (idx < modelPaths.size())
-                newPaths[i] = modelPaths[idx];
-            if (idx < symbolPaths.size())
-                newSymPaths[i] = symbolPaths[idx];
-        }
-        store->SetItemData(it, i);
-    }
-    rowUuids.swap(newOrder);
-    modelPaths.swap(newPaths);
-    symbolPaths.swap(newSymPaths);
+    (void)oldOrder;
+    RebuildRowCachesFromRowKeys();
 
     table->UnselectAll();
     for (const auto& uuid : selectedUuids)
@@ -1262,16 +1262,66 @@ void TrussTablePanel::ResyncRows(const std::vector<std::string>& oldOrder,
     UpdateSelectionHighlight();
 }
 
+void TrussTablePanel::RebuildRowCachesFromRowKeys() {
+    if (!table || !store)
+        return;
+    const unsigned int count = table->GetItemCount();
+    rowUuids.assign(count, std::string());
+    modelPaths.assign(count, wxString());
+    symbolPaths.assign(count, wxString());
+    for (unsigned int row = 0; row < count; ++row) {
+        wxDataViewItem item = table->RowToItem(row);
+        const wxUIntPtr rowKey = store->GetItemData(item);
+        auto uuidIt = rowUuidByKey.find(rowKey);
+        if (uuidIt != rowUuidByKey.end())
+            rowUuids[row] = uuidIt->second;
+        auto modelIt = modelPathByKey.find(rowKey);
+        if (modelIt != modelPathByKey.end())
+            modelPaths[row] = modelIt->second;
+        auto symbolIt = symbolPathByKey.find(rowKey);
+        if (symbolIt != symbolPathByKey.end())
+            symbolPaths[row] = symbolIt->second;
+    }
+}
+
+std::string TrussTablePanel::UuidForItem(const wxDataViewItem& item) const {
+    if (!store || !item.IsOk())
+        return {};
+    const wxUIntPtr rowKey = store->GetItemData(item);
+    auto it = rowUuidByKey.find(rowKey);
+    if (it == rowUuidByKey.end())
+        return {};
+    return it->second;
+}
+
+void TrussTablePanel::SetModelPathsForRow(unsigned int row,
+                                          const wxString& modelPath,
+                                          const wxString& symbolPath) {
+    if (!table || !store || row >= table->GetItemCount())
+        return;
+    if (row >= modelPaths.size())
+        modelPaths.resize(table->GetItemCount());
+    if (row >= symbolPaths.size())
+        symbolPaths.resize(table->GetItemCount());
+    modelPaths[row] = modelPath;
+    symbolPaths[row] = symbolPath;
+    wxDataViewItem item = table->RowToItem(row);
+    const wxUIntPtr rowKey = store->GetItemData(item);
+    modelPathByKey[rowKey] = modelPath;
+    symbolPathByKey[rowKey] = symbolPath;
+}
+
 void TrussTablePanel::OnColumnSorted(wxDataViewEvent& event)
 {
+    RebuildRowCachesFromRowKeys();
     wxDataViewItemArray selections;
     table->GetSelections(selections);
     std::vector<std::string> selectedUuids;
     for (const auto& it : selections)
     {
-        int r = table->ItemToRow(it);
-        if (r != wxNOT_FOUND && (size_t)r < rowUuids.size())
-            selectedUuids.push_back(rowUuids[r]);
+        const std::string uuid = UuidForItem(it);
+        if (!uuid.empty())
+            selectedUuids.push_back(uuid);
     }
     std::vector<std::string> oldOrder = rowUuids;
     ResyncRows(oldOrder, selectedUuids);

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -356,7 +356,6 @@ void TrussTablePanel::ReloadData()
 
 void TrussTablePanel::OnContextMenu(wxDataViewEvent& event)
 {
-    EnsureRowMappingsSynced();
     wxDataViewItem item = event.GetItem();
     int col = event.GetColumn();
     if (!item.IsOk() || col < 0)
@@ -664,7 +663,13 @@ void TrussTablePanel::OnLeftDown(wxMouseEvent& evt)
     wxDataViewColumn* col;
     table->HitTest(evt.GetPosition(), item, col);
     startRow = table->ItemToRow(item);
-    dragSelecting = false;
+    if (startRow != wxNOT_FOUND)
+    {
+        dragSelecting = true;
+        table->UnselectAll();
+        table->SelectRow(startRow);
+        CaptureMouse();
+    }
     evt.Skip();
 }
 
@@ -673,22 +678,19 @@ void TrussTablePanel::OnLeftUp(wxMouseEvent& evt)
     if (dragSelecting)
     {
         dragSelecting = false;
-        if (HasCapture())
-            ReleaseMouse();
+        ReleaseMouse();
     }
-    startRow = wxNOT_FOUND;
     evt.Skip();
 }
 
 void TrussTablePanel::OnCaptureLost(wxMouseCaptureLostEvent& WXUNUSED(evt))
 {
     dragSelecting = false;
-    startRow = wxNOT_FOUND;
 }
 
 void TrussTablePanel::OnMouseMove(wxMouseEvent& evt)
 {
-    if (!evt.Dragging() || startRow == wxNOT_FOUND)
+    if (!dragSelecting || !evt.Dragging())
     {
         evt.Skip();
         return;
@@ -699,14 +701,6 @@ void TrussTablePanel::OnMouseMove(wxMouseEvent& evt)
     int row = table->ItemToRow(item);
     if (row != wxNOT_FOUND)
     {
-        if (!dragSelecting)
-        {
-            dragSelecting = true;
-            table->UnselectAll();
-            table->SelectRow(startRow);
-            if (!HasCapture())
-                CaptureMouse();
-        }
         int minRow = std::min(startRow, row);
         int maxRow = std::max(startRow, row);
         table->UnselectAll();
@@ -718,7 +712,6 @@ void TrussTablePanel::OnMouseMove(wxMouseEvent& evt)
 
 void TrussTablePanel::OnSelectionChanged(wxDataViewEvent& evt)
 {
-    EnsureRowMappingsSynced();
     const selection::Origin origin = selection::CurrentOrigin();
     if (origin == selection::Origin::Viewer2D ||
         origin == selection::Origin::Viewer3D) {
@@ -1150,7 +1143,6 @@ std::vector<std::string> TrussTablePanel::GetSelectedUuids() const {
 
 void TrussTablePanel::SelectByUuid(const std::vector<std::string>& uuids,
                                    bool notifySelectionChanged) {
-    EnsureRowMappingsSynced();
     std::unique_ptr<wxEventBlocker> selectionBlocker;
     if (!notifySelectionChanged) {
         selectionBlocker = std::make_unique<wxEventBlocker>(
@@ -1172,7 +1164,6 @@ void TrussTablePanel::SelectByUuid(const std::vector<std::string>& uuids,
 
 void TrussTablePanel::DeleteSelected(bool pushUndoState)
 {
-    EnsureRowMappingsSynced();
     wxDataViewItemArray selections;
     table->GetSelections(selections);
     if (selections.empty())
@@ -1269,39 +1260,6 @@ void TrussTablePanel::ResyncRows(const std::vector<std::string>& oldOrder,
             table->SelectRow(static_cast<int>(pos - rowUuids.begin()));
     }
     UpdateSelectionHighlight();
-}
-
-void TrussTablePanel::EnsureRowMappingsSynced()
-{
-    if (!table || !store)
-        return;
-
-    const unsigned int count = table->GetItemCount();
-    if (count == 0 || rowUuids.empty())
-        return;
-
-    const std::vector<std::string> oldOrder = rowUuids;
-    const std::vector<wxString> oldModelPaths = modelPaths;
-    const std::vector<wxString> oldSymbolPaths = symbolPaths;
-    std::vector<std::string> newOrder(count);
-    std::vector<wxString> newPaths(count);
-    std::vector<wxString> newSymPaths(count);
-
-    for (unsigned int i = 0; i < count; ++i) {
-        wxDataViewItem it = table->RowToItem(i);
-        const unsigned long idx = store->GetItemData(it);
-        if (idx < oldOrder.size())
-            newOrder[i] = oldOrder[idx];
-        if (idx < oldModelPaths.size())
-            newPaths[i] = oldModelPaths[idx];
-        if (idx < oldSymbolPaths.size())
-            newSymPaths[i] = oldSymbolPaths[idx];
-        store->SetItemData(it, i);
-    }
-
-    rowUuids.swap(newOrder);
-    modelPaths.swap(newPaths);
-    symbolPaths.swap(newSymPaths);
 }
 
 void TrussTablePanel::OnColumnSorted(wxDataViewEvent& event)

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -663,13 +663,7 @@ void TrussTablePanel::OnLeftDown(wxMouseEvent& evt)
     wxDataViewColumn* col;
     table->HitTest(evt.GetPosition(), item, col);
     startRow = table->ItemToRow(item);
-    if (startRow != wxNOT_FOUND)
-    {
-        dragSelecting = true;
-        table->UnselectAll();
-        table->SelectRow(startRow);
-        CaptureMouse();
-    }
+    dragSelecting = false;
     evt.Skip();
 }
 
@@ -678,19 +672,22 @@ void TrussTablePanel::OnLeftUp(wxMouseEvent& evt)
     if (dragSelecting)
     {
         dragSelecting = false;
-        ReleaseMouse();
+        if (HasCapture())
+            ReleaseMouse();
     }
+    startRow = wxNOT_FOUND;
     evt.Skip();
 }
 
 void TrussTablePanel::OnCaptureLost(wxMouseCaptureLostEvent& WXUNUSED(evt))
 {
     dragSelecting = false;
+    startRow = wxNOT_FOUND;
 }
 
 void TrussTablePanel::OnMouseMove(wxMouseEvent& evt)
 {
-    if (!dragSelecting || !evt.Dragging())
+    if (!evt.Dragging() || startRow == wxNOT_FOUND)
     {
         evt.Skip();
         return;
@@ -701,6 +698,14 @@ void TrussTablePanel::OnMouseMove(wxMouseEvent& evt)
     int row = table->ItemToRow(item);
     if (row != wxNOT_FOUND)
     {
+        if (!dragSelecting)
+        {
+            dragSelecting = true;
+            table->UnselectAll();
+            table->SelectRow(startRow);
+            if (!HasCapture())
+                CaptureMouse();
+        }
         int minRow = std::min(startRow, row);
         int maxRow = std::max(startRow, row);
         table->UnselectAll();

--- a/gui/trusstablepanel.h
+++ b/gui/trusstablepanel.h
@@ -64,7 +64,6 @@ private:
     void OnSelectionChanged(wxDataViewEvent& evt);
     void OnContextMenu(wxDataViewEvent& event);
     void OnColumnSorted(wxDataViewEvent& event);
-    void EnsureRowMappingsSynced();
     void ResyncRows(const std::vector<std::string>& oldOrder,
                     const std::vector<std::string>& selectedUuids);
     void OnLeftDown(wxMouseEvent& evt);

--- a/gui/trusstablepanel.h
+++ b/gui/trusstablepanel.h
@@ -22,6 +22,7 @@
 #include <wx/time.h>
 #include <vector>
 #include <string>
+#include <unordered_map>
 #include "colorstore.h"
 #include "positionvalueupdate.h"
 
@@ -54,6 +55,10 @@ private:
     wxDataViewListCtrl* table;
     std::vector<wxString> columnLabels;
     std::vector<std::string> rowUuids;
+    std::unordered_map<wxUIntPtr, std::string> rowUuidByKey;
+    std::unordered_map<wxUIntPtr, wxString> modelPathByKey;
+    std::unordered_map<wxUIntPtr, wxString> symbolPathByKey;
+    wxUIntPtr nextRowKey = 1;
     std::string highlightedUuid;
     std::vector<wxString> modelPaths;  // Displayed model file paths (.gtruss if any)
     std::vector<wxString> symbolPaths; // Resolved geometry file paths
@@ -64,6 +69,10 @@ private:
     void OnSelectionChanged(wxDataViewEvent& evt);
     void OnContextMenu(wxDataViewEvent& event);
     void OnColumnSorted(wxDataViewEvent& event);
+    void RebuildRowCachesFromRowKeys();
+    std::string UuidForItem(const wxDataViewItem& item) const;
+    void SetModelPathsForRow(unsigned int row, const wxString& modelPath,
+                             const wxString& symbolPath);
     void ResyncRows(const std::vector<std::string>& oldOrder,
                     const std::vector<std::string>& selectedUuids);
     void OnLeftDown(wxMouseEvent& evt);

--- a/gui/trusstablepanel.h
+++ b/gui/trusstablepanel.h
@@ -64,6 +64,7 @@ private:
     void OnSelectionChanged(wxDataViewEvent& evt);
     void OnContextMenu(wxDataViewEvent& event);
     void OnColumnSorted(wxDataViewEvent& event);
+    void EnsureRowMappingsSynced();
     void ResyncRows(const std::vector<std::string>& oldOrder,
                     const std::vector<std::string>& selectedUuids);
     void OnLeftDown(wxMouseEvent& evt);


### PR DESCRIPTION
### Motivation
- Sorting or other row reordering caused `selectionOrder` (stored as row indices) to point at different fixtures, producing incorrect multi-row operations and apparent fixture ID swaps.

### Description
- Add `ReindexSelectionOrder(...)` helper in `gui/fixturetablepanel.cpp` to remap a stored `selectionOrder` from old row indices to current row indices by matching fixture UUIDs.
- Call the helper inside `ResyncRows(...)` immediately after rebuilding `rowUuids` so selection ordering remains stable after sorts, deletes, or other row rearrangements.
- Changed file: `gui/fixturetablepanel.cpp` (helper implementation + one-line integration in `ResyncRows`).
- Technical note: this touched a GUI hotspot file that already exceeds the file-size guardrail; recommend extracting selection/row-mapping utilities into a small adjacent module (e.g. `fixturetable/selection_utils.{h,cpp}`) in a follow-up PR.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which completed OK.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which completed OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efd059907083249052435675837337)