### PR TITLE
Fix Preferences Apply behavior for 3D Viewer render mode

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -321,6 +321,7 @@ EVT_MENU(ID_Select_Objects, MainWindow::OnSelectObjects)
 EVT_MENU(ID_Edit_Preferences, MainWindow::OnPreferences)
 EVT_COMMAND(wxID_ANY, EVT_PROJECT_LOADED, MainWindow::OnProjectLoaded)
 EVT_COMMAND(wxID_ANY, EVT_UI_UNITS_CHANGED, MainWindow::OnUiUnitsChanged)
+EVT_COMMAND(wxID_ANY, EVT_UI_PREFERENCES_APPLIED, MainWindow::OnPreferencesApplied)
 EVT_COMMAND(wxID_ANY, EVT_LAYOUT_SELECTED, MainWindow::OnLayoutSelected)
 EVT_COMMAND(wxID_ANY, EVT_LAYOUT_VIEW_EDIT, MainWindow::OnLayoutViewEdit)
 EVT_COMMAND(wxID_ANY, EVT_LAYOUT_VIEW_SELECTED, MainWindow::OnLayoutViewSelected)
@@ -1244,6 +1245,13 @@ void MainWindow::OnProjectLoaded(wxCommandEvent &event) {
 
 void MainWindow::OnUiUnitsChanged(wxCommandEvent &WXUNUSED(event)) {
   RefreshAfterUnitSystemChange();
+}
+
+void MainWindow::OnPreferencesApplied(wxCommandEvent &WXUNUSED(event)) {
+  if (viewportPanel)
+    viewportPanel->Refresh();
+  if (viewport2DPanel)
+    viewport2DPanel->Refresh();
 }
 
 void MainWindow::OnNotebookPageChanged(wxBookCtrlEvent &event) {

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -102,6 +102,7 @@ private:
   void Ensure2DViewport();
   void OnProjectLoaded(wxCommandEvent &event);
   void OnUiUnitsChanged(wxCommandEvent &event);
+  void OnPreferencesApplied(wxCommandEvent &event);
 
   std::string currentProjectPath;
   wxString currentProjectDisplayName;

--- a/gui/preferencesdialog.cpp
+++ b/gui/preferencesdialog.cpp
@@ -27,6 +27,7 @@
 #include <wx/radiobut.h>
 
 wxDEFINE_EVENT(EVT_UI_UNITS_CHANGED, wxCommandEvent);
+wxDEFINE_EVENT(EVT_UI_PREFERENCES_APPLIED, wxCommandEvent);
 
 namespace {
 
@@ -212,14 +213,23 @@ PreferencesDialog::PreferencesDialog(wxWindow *parent)
 
   SetSizerAndFit(topSizer);
 
-  Bind(wxEVT_BUTTON, [this](wxCommandEvent &evt) {
-    if (evt.GetId() == wxID_OK || evt.GetId() == wxID_APPLY) {
-      if (ApplyPreferences()) {
-        NotifyUnitsChanged();
-      }
-    }
-    evt.Skip();
-  });
+  Bind(wxEVT_BUTTON, &PreferencesDialog::OnApplyButton, this, wxID_APPLY);
+  Bind(wxEVT_BUTTON, &PreferencesDialog::OnOkButton, this, wxID_OK);
+}
+
+void PreferencesDialog::OnApplyButton(wxCommandEvent &WXUNUSED(event)) {
+  if (!ApplyPreferences())
+    return;
+  NotifyUnitsChanged();
+  NotifyPreferencesApplied();
+}
+
+void PreferencesDialog::OnOkButton(wxCommandEvent &WXUNUSED(event)) {
+  if (!ApplyPreferences())
+    return;
+  NotifyUnitsChanged();
+  NotifyPreferencesApplied();
+  EndModal(wxID_OK);
 }
 
 bool PreferencesDialog::ApplyPreferences() {
@@ -322,5 +332,10 @@ void PreferencesDialog::NotifyUnitsChanged() {
   initialDistanceUnit = currentDistanceUnit;
   initialWeightUnit = currentWeightUnit;
   wxCommandEvent event(EVT_UI_UNITS_CHANGED);
+  wxPostEvent(GetParent(), event);
+}
+
+void PreferencesDialog::NotifyPreferencesApplied() {
+  wxCommandEvent event(EVT_UI_PREFERENCES_APPLIED);
   wxPostEvent(GetParent(), event);
 }

--- a/gui/preferencesdialog.h
+++ b/gui/preferencesdialog.h
@@ -21,6 +21,7 @@
 #include <wx/wx.h>
 
 wxDECLARE_EVENT(EVT_UI_UNITS_CHANGED, wxCommandEvent);
+wxDECLARE_EVENT(EVT_UI_PREFERENCES_APPLIED, wxCommandEvent);
 
 class GdtfCredentialsPanel;
 
@@ -29,6 +30,9 @@ public:
   PreferencesDialog(wxWindow *parent);
 
 private:
+  void OnApplyButton(wxCommandEvent &event);
+  void OnOkButton(wxCommandEvent &event);
+  void NotifyPreferencesApplied();
   bool ApplyPreferences();
   void NotifyUnitsChanged();
   void RefreshRiderImportDistanceLabels();


### PR DESCRIPTION
### Motivation
- Users reported that changing the 3D Viewer "Render mode" in Preferences and clicking `Apply` did not take effect until `OK` was pressed, so `Apply` did not behave like `OK` should (apply without closing the dialog). 

### Description
- Wire `Apply` and `OK` to explicit handlers by adding `OnApplyButton` and `OnOkButton` and replace the previous generic lambda binding so both follow the same persistence path (`ApplyPreferences`).
- Introduce a new UI event `EVT_UI_PREFERENCES_APPLIED` and emit it when preferences are successfully applied via `NotifyPreferencesApplied()`.
- Subscribe `MainWindow` to `EVT_UI_PREFERENCES_APPLIED` and add `OnPreferencesApplied` to refresh `viewportPanel` and `viewport2DPanel` so render-mode changes become visible immediately after `Apply`.
- Files changed: `gui/preferencesdialog.h`, `gui/preferencesdialog.cpp`, `gui/mainwindow.h`, and `gui/mainwindow.cpp`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which completed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f05ff533ec8324a212378309e3cb65)