### PR TITLE
docs: document meshoptimizer as required build dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ The recommended way to install Perastage is to download the latest release from 
 
 If you want to build from source, setup and dependency notes are available in the documentation under `docs/`.
 
+Recent 3D optimization updates depend on `meshoptimizer`; if you prepare dependencies manually, include it in your toolchain setup (see `docs/build.md` and `setup_windows.ps1`).
+
 ## Basic usage
 
 - Open an existing `.mvr` file to inspect its content quickly.

--- a/docs/build.md
+++ b/docs/build.md
@@ -6,7 +6,11 @@ This document covers baseline and advanced build behavior for Perastage. It is t
 
 - CMake 3.21 or newer.
 - C++20-capable compiler/toolchain.
-- Required libraries include wxWidgets, tinyxml2, OpenGL/GLU, GLEW, CURL, nanovg, and PoDoFo.
+- Required libraries include wxWidgets, tinyxml2, OpenGL/GLU, GLEW, CURL, nanovg, PoDoFo, and meshoptimizer.
+
+### Dependency note for vcpkg users
+
+If you install dependencies with vcpkg (classic mode), make sure `meshoptimizer` is included in the package list together with the existing Perastage dependencies.
 
 ## Quick Build (All Platforms)
 

--- a/setup_windows.ps1
+++ b/setup_windows.ps1
@@ -12,7 +12,7 @@ if (-Not (Test-Path '.\vcpkg.exe')) {
 cd ..
 
 # Install required libraries
-.\vcpkg\vcpkg.exe install wxwidgets:x64-windows tinyxml2:x64-windows opengl nanovg:x64-windows podofo:x64-windows
+.\vcpkg\vcpkg.exe install wxwidgets:x64-windows tinyxml2:x64-windows opengl nanovg:x64-windows podofo:x64-windows meshoptimizer:x64-windows
 
 # Configure and build with CMake
 if (-Not (Test-Path 'build')) {


### PR DESCRIPTION
### Motivation
- The new 3D optimization code depends on `meshoptimizer`, so build instructions and install helpers must list it to prevent missing-dependency build failures.
- There is no `vcpkg.json` manifest in the repository root, so documentation and platform setup scripts must be updated to guide classic-mode vcpkg/manual installs.

### Description
- Added `meshoptimizer` to the required libraries list and a short vcpkg classic-mode note in `docs/build.md`.
- Added a concise build-from-source note in `README.md` that recent 3D optimizations require `meshoptimizer`.
- Updated `setup_windows.ps1` to install `meshoptimizer:x64-windows` via vcpkg alongside existing packages.

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which completed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0f16c1e948324b9df4442a21c358d)