### PR TITLE
Fix Windows installer CI to pass unified project version to Inno Setup

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -97,7 +97,13 @@ jobs:
         run: |
           # Ensure the output directory exists before ISCC runs
           New-Item -ItemType Directory -Path "$env:GITHUB_WORKSPACE\out\installer" -Force | Out-Null
-          ISCC "$env:GITHUB_WORKSPACE\packaging\windows\Perastage.iss"
+          $version = (cmake -P "$env:GITHUB_WORKSPACE\packaging\windows\get_project_version.cmake" |
+            Select-String -Pattern '-- ([0-9]+\.[0-9]+\.[0-9]+)$').Matches[0].Groups[1].Value
+          if ([string]::IsNullOrWhiteSpace($version)) {
+            throw "Could not determine PROJECT_VERSION from CMakeLists.txt"
+          }
+          Write-Host "Using installer version: $version"
+          ISCC "/DMyAppVersion=$version" "$env:GITHUB_WORKSPACE\packaging\windows\Perastage.iss"
 
       # Copy installer into a dedicated folder for upload
       - name: Collect Windows installer


### PR DESCRIPTION
### Motivation
- The Inno Setup script `packaging/windows/Perastage.iss` requires `MyAppVersion` to be defined via `/DMyAppVersion=...`, and the workflow previously called `ISCC` without passing that define which caused CI to fail; the canonical version is declared in `CMakeLists.txt` via `project(... VERSION ...)`.

### Description
- Update `.github/workflows/windows-installer.yml` to extract `PROJECT_VERSION` by running `cmake -P packaging/windows/get_project_version.cmake`, validate it, log it, and invoke `ISCC` with `"/DMyAppVersion=$version"` so the installer receives the unified project version.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which succeeded and `tests/check_no_configmanager_get_in_gui.sh` which also succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0fdd628c08324bb650979354dfef2)