### PR TITLE
Optimize beam and fog uniform updates with per-light last-applied caches

### DIFF
--- a/peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd
@@ -164,24 +164,24 @@ func _update_prism_material(light: SpotLight3D, prism: MeshInstance3D, beam_colo
 		_set_material_shader_parameter_if_changed(light, prism_material, "gobo_invert", false)
 
 
-func _set_instance_shader_parameter_if_changed(light: SpotLight3D, instance: GeometryInstance3D, name: String, value: Variant) -> void:
+func _set_instance_shader_parameter_if_changed(light: SpotLight3D, instance: GeometryInstance3D, name: String, value: Variant, force_update: bool = false) -> void:
 	if instance == null:
 		return
 	var uniforms := _ensure_last_uniforms_meta(light)
 	var key: String = "legacy::" + name
 	var previous: Variant = uniforms.get(key, null)
-	if _uniform_values_equal(previous, value):
+	if not force_update and _uniform_values_equal(previous, value):
 		return
 	instance.set_instance_shader_parameter(name, value)
 	uniforms[key] = value
 
-func _set_material_shader_parameter_if_changed(light: SpotLight3D, material: ShaderMaterial, name: String, value: Variant) -> void:
+func _set_material_shader_parameter_if_changed(light: SpotLight3D, material: ShaderMaterial, name: String, value: Variant, force_update: bool = false) -> void:
 	if material == null:
 		return
 	var uniforms := _ensure_last_uniforms_meta(light)
 	var key: String = "legacy_material::" + name
 	var previous: Variant = uniforms.get(key, null)
-	if _uniform_values_equal(previous, value):
+	if not force_update and _uniform_values_equal(previous, value):
 		return
 	material.set_shader_parameter(name, value)
 	uniforms[key] = value

--- a/peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd
@@ -20,6 +20,7 @@ const LEGACY_MID_KEY: String = "peraviz_beam_cone_mid"
 const LEGACY_CORE_KEY: String = "peraviz_beam_cone_core"
 const DEFAULT_MIRROR_BEAM_SHAPE_X: bool = true
 const DEFAULT_MIRROR_BEAM_SHAPE_Z: bool = true
+const LAST_UNIFORMS_META_KEY: String = "peraviz_last_beam_uniforms"
 
 var _material_template: ShaderMaterial
 var _mesh_builder: GoboPrismMeshBuilder
@@ -92,7 +93,7 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	var radial_falloff: float = max(float(params.get("beam_radial_falloff", 1.1)), 0.05)
 	var longitudinal_falloff: float = max(float(params.get("beam_longitudinal_falloff", 1.0)), 0.05)
 	var haze_density: float = max(float(params.get("haze_density", params.get("haze_density_multiplier", 0.22))), 0.01)
-	_update_prism_material(prism, color_alpha, scaled_intensity, intensity_max, beam_range, bottom_radius, beam_softness, radial_falloff, longitudinal_falloff, haze_density)
+	_update_prism_material(light, prism, color_alpha, scaled_intensity, intensity_max, beam_range, bottom_radius, beam_softness, radial_falloff, longitudinal_falloff, haze_density)
 
 
 func _apply_beam_axis_rotation(node: Node3D, beam_rotation_deg: float) -> void:
@@ -133,7 +134,7 @@ func _create_prism(prism_name: String) -> MeshInstance3D:
 	prism.visible = false
 	return prism
 
-func _update_prism_material(prism: MeshInstance3D, beam_color: Color, scaled_intensity: float, intensity_max: float, beam_range: float, gobo_projection_radius: float, lateral_softness: float, radial_falloff: float, longitudinal_falloff: float, haze_density: float) -> void:
+func _update_prism_material(light: SpotLight3D, prism: MeshInstance3D, beam_color: Color, scaled_intensity: float, intensity_max: float, beam_range: float, gobo_projection_radius: float, lateral_softness: float, radial_falloff: float, longitudinal_falloff: float, haze_density: float) -> void:
 	if prism == null:
 		return
 	var reference_max: float = max(INTENSITY_REFERENCE_MAX, 0.01)
@@ -143,24 +144,85 @@ func _update_prism_material(prism: MeshInstance3D, beam_color: Color, scaled_int
 	if intensity_max > reference_max:
 		overdrive_norm = clamp((scaled_intensity - reference_max) / (intensity_max - reference_max), 0.0, 1.0)
 	var overdrive_gain: float = lerp(1.0, LEGACY_OVERDRIVE_GAIN_MAX, overdrive_norm)
-	prism.set_instance_shader_parameter("beam_color", beam_color)
-	prism.set_instance_shader_parameter("near_alpha", lerp(0.0, EMITTER_CONE_NEAR_ALPHA, perceptual_intensity) * overdrive_gain)
-	prism.set_instance_shader_parameter("far_alpha", lerp(0.0, EMITTER_CONE_FAR_ALPHA, perceptual_intensity) * overdrive_gain)
-	prism.set_instance_shader_parameter("near_emission", lerp(0.0, EMITTER_CONE_NEAR_EMISSION, perceptual_intensity) * overdrive_gain)
-	prism.set_instance_shader_parameter("far_emission", lerp(0.0, EMITTER_CONE_FAR_EMISSION, perceptual_intensity) * overdrive_gain)
-	prism.set_instance_shader_parameter("cone_height", max(beam_range, 0.001))
-	prism.set_instance_shader_parameter("gobo_projection_radius", max(gobo_projection_radius, 0.001))
-	prism.set_instance_shader_parameter("fade_end_ratio", EMITTER_CONE_FADE_END_RATIO)
-	prism.set_instance_shader_parameter("lateral_softness", clamp(lateral_softness, 0.02, 1.0))
-	prism.set_instance_shader_parameter("lateral_emission_boost", 0.22)
-	prism.set_instance_shader_parameter("volumetric_noise_strength", 0.06)
-	prism.set_instance_shader_parameter("radial_falloff", radial_falloff)
-	prism.set_instance_shader_parameter("longitudinal_falloff", longitudinal_falloff)
-	prism.set_instance_shader_parameter("haze_density", haze_density)
+	_set_instance_shader_parameter_if_changed(light, prism, "beam_color", beam_color)
+	_set_instance_shader_parameter_if_changed(light, prism, "near_alpha", lerp(0.0, EMITTER_CONE_NEAR_ALPHA, perceptual_intensity) * overdrive_gain)
+	_set_instance_shader_parameter_if_changed(light, prism, "far_alpha", lerp(0.0, EMITTER_CONE_FAR_ALPHA, perceptual_intensity) * overdrive_gain)
+	_set_instance_shader_parameter_if_changed(light, prism, "near_emission", lerp(0.0, EMITTER_CONE_NEAR_EMISSION, perceptual_intensity) * overdrive_gain)
+	_set_instance_shader_parameter_if_changed(light, prism, "far_emission", lerp(0.0, EMITTER_CONE_FAR_EMISSION, perceptual_intensity) * overdrive_gain)
+	_set_instance_shader_parameter_if_changed(light, prism, "cone_height", max(beam_range, 0.001))
+	_set_instance_shader_parameter_if_changed(light, prism, "gobo_projection_radius", max(gobo_projection_radius, 0.001))
+	_set_instance_shader_parameter_if_changed(light, prism, "fade_end_ratio", EMITTER_CONE_FADE_END_RATIO)
+	_set_instance_shader_parameter_if_changed(light, prism, "lateral_softness", clamp(lateral_softness, 0.02, 1.0))
+	_set_instance_shader_parameter_if_changed(light, prism, "lateral_emission_boost", 0.22)
+	_set_instance_shader_parameter_if_changed(light, prism, "volumetric_noise_strength", 0.06)
+	_set_instance_shader_parameter_if_changed(light, prism, "radial_falloff", radial_falloff)
+	_set_instance_shader_parameter_if_changed(light, prism, "longitudinal_falloff", longitudinal_falloff)
+	_set_instance_shader_parameter_if_changed(light, prism, "haze_density", haze_density)
 	var prism_material: ShaderMaterial = prism.material_override as ShaderMaterial
 	if prism_material != null:
-		prism_material.set_shader_parameter("use_gobo", false)
-		prism_material.set_shader_parameter("gobo_invert", false)
+		_set_material_shader_parameter_if_changed(light, prism_material, "use_gobo", false)
+		_set_material_shader_parameter_if_changed(light, prism_material, "gobo_invert", false)
+
+
+func _set_instance_shader_parameter_if_changed(light: SpotLight3D, instance: GeometryInstance3D, name: String, value: Variant) -> void:
+	if instance == null:
+		return
+	var uniforms := _ensure_last_uniforms_meta(light)
+	var key: String = "legacy::" + name
+	var previous: Variant = uniforms.get(key, null)
+	if _uniform_values_equal(previous, value):
+		return
+	instance.set_instance_shader_parameter(name, value)
+	uniforms[key] = value
+
+func _set_material_shader_parameter_if_changed(light: SpotLight3D, material: ShaderMaterial, name: String, value: Variant) -> void:
+	if material == null:
+		return
+	var uniforms := _ensure_last_uniforms_meta(light)
+	var key: String = "legacy_material::" + name
+	var previous: Variant = uniforms.get(key, null)
+	if _uniform_values_equal(previous, value):
+		return
+	material.set_shader_parameter(name, value)
+	uniforms[key] = value
+
+func _ensure_last_uniforms_meta(light: SpotLight3D) -> Dictionary:
+	if light.has_meta(LAST_UNIFORMS_META_KEY):
+		var existing: Variant = light.get_meta(LAST_UNIFORMS_META_KEY)
+		if existing is Dictionary:
+			return existing as Dictionary
+	var created: Dictionary = {}
+	light.set_meta(LAST_UNIFORMS_META_KEY, created)
+	return created
+
+func _uniform_values_equal(previous: Variant, current: Variant) -> bool:
+	if previous == null and current == null:
+		return true
+	if previous == null or current == null:
+		return false
+	if previous is float and current is float:
+		return is_equal_approx(previous, current)
+	if previous is Color and current is Color:
+		return _color_equal_approx(previous, current)
+	if previous is Vector2 and current is Vector2:
+		return _vector2_equal_approx(previous, current)
+	if previous is Vector3 and current is Vector3:
+		return _vector3_equal_approx(previous, current)
+	if previous is Vector4 and current is Vector4:
+		return _vector4_equal_approx(previous, current)
+	return previous == current
+
+func _color_equal_approx(a: Color, b: Color) -> bool:
+	return is_equal_approx(a.r, b.r) and is_equal_approx(a.g, b.g) and is_equal_approx(a.b, b.b) and is_equal_approx(a.a, b.a)
+
+func _vector2_equal_approx(a: Vector2, b: Vector2) -> bool:
+	return is_equal_approx(a.x, b.x) and is_equal_approx(a.y, b.y)
+
+func _vector3_equal_approx(a: Vector3, b: Vector3) -> bool:
+	return is_equal_approx(a.x, b.x) and is_equal_approx(a.y, b.y) and is_equal_approx(a.z, b.z)
+
+func _vector4_equal_approx(a: Vector4, b: Vector4) -> bool:
+	return is_equal_approx(a.x, b.x) and is_equal_approx(a.y, b.y) and is_equal_approx(a.z, b.z) and is_equal_approx(a.w, b.w)
 
 func _ensure_debug_axis(light: SpotLight3D) -> MeshInstance3D:
 	if light.has_meta(DEBUG_AXIS_KEY):

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -8,6 +8,7 @@ const VOLUMETRIC_INTENSITY_RESPONSE_EXPONENT: float = 2.2
 const INTENSITY_REFERENCE_MAX: float = 20.0
 const VOLUMETRIC_OVERDRIVE_BRIGHTNESS_MAX: float = 30.0
 const DEBUG_AXIS_KEY: String = "peraviz_beam_debug_axis"
+const LAST_UNIFORMS_META_KEY: String = "peraviz_last_beam_uniforms"
 const SHAPE_MODE_GOBO_PRISM: String = "gobo_prism"
 const SHAPE_MODE_CONE: String = "cone"
 
@@ -62,7 +63,7 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 
 	if not bool(params.get("is_visible", true)) or intensity <= threshold:
 		beam.visible = false
-		beam.set_instance_shader_parameter("beam_visibility", 0.0)
+		_set_instance_shader_parameter_if_changed(light, beam, "beam_visibility", 0.0)
 		var hidden_axis: MeshInstance3D = _ensure_debug_axis(light)
 		if hidden_axis != null:
 			hidden_axis.visible = false
@@ -82,37 +83,99 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	beam.visible = true
 
 	var intensity_alpha: float = clamp((intensity / reference_max) * VOLUMETRIC_INTENSITY_SCALE, 0.0, 3.6)
-	beam.set_instance_shader_parameter("base_color", Color(beam_color.r, beam_color.g, beam_color.b, intensity_alpha))
-	beam.set_instance_shader_parameter("beam_visibility", 1.0)
+	_set_instance_shader_parameter_if_changed(light, beam, "base_color", Color(beam_color.r, beam_color.g, beam_color.b, intensity_alpha))
+	_set_instance_shader_parameter_if_changed(light, beam, "beam_visibility", 1.0)
 	var overdrive_brightness_gain: float = lerp(1.0, VOLUMETRIC_OVERDRIVE_BRIGHTNESS_MAX, overdrive_norm)
-	beam.set_instance_shader_parameter("max_brightness", lerp(8.0, 120.0, beam_intensity_norm) * overdrive_brightness_gain)
-	beam.set_instance_shader_parameter("beam_noise_amount", float(_settings.get("beam_noise_amount", 0.06)))
-	beam.set_instance_shader_parameter("beam_noise_scale", float(_settings.get("beam_noise_scale", 1.4)))
+	_set_instance_shader_parameter_if_changed(light, beam, "max_brightness", lerp(8.0, 120.0, beam_intensity_norm) * overdrive_brightness_gain)
+	_set_instance_shader_parameter_if_changed(light, beam, "beam_noise_amount", float(_settings.get("beam_noise_amount", 0.06)))
+	_set_instance_shader_parameter_if_changed(light, beam, "beam_noise_scale", float(_settings.get("beam_noise_scale", 1.4)))
 	var haze_density: float = max(float(params.get("haze_density", params.get("haze_density_multiplier", 0.22))), 0.01)
-	beam.set_instance_shader_parameter("beam_haze_density", float(_settings.get("beam_haze_density", 0.17)) * haze_density)
-	beam.set_instance_shader_parameter("haze_density", max(haze_density, 0.2))
-	beam.set_instance_shader_parameter("beam_anisotropy", float(_settings.get("beam_anisotropy", 0.62)))
-	beam.set_instance_shader_parameter("beam_quality", int(_settings.get("beam_quality", 1)))
-	beam.set_instance_shader_parameter("radial_falloff", max(float(params.get("beam_radial_falloff", 1.1)), 0.05))
-	beam.set_instance_shader_parameter("longitudinal_falloff", max(float(params.get("beam_longitudinal_falloff", 1.0)), 0.05))
-	beam.set_instance_shader_parameter("beam_softness", clamp(float(params.get("beam_softness", 0.35)), 0.02, 1.0))
-	beam.set_instance_shader_parameter("gobo_scale", max(float(params.get("gobo_scale", 1.0)), 0.05))
-	beam.set_instance_shader_parameter("gobo_rotation_deg", beam_rotation_deg)
-	beam.set_instance_shader_parameter("cone_height", max(beam_range, 0.001))
-	beam.set_instance_shader_parameter("gobo_projection_radius", gobo_projection_radius)
-	beam.set_instance_shader_parameter("beam_intensity", perceptual_intensity)
-	beam.set_instance_shader_parameter("beam_overdrive", overdrive_norm)
+	_set_instance_shader_parameter_if_changed(light, beam, "beam_haze_density", float(_settings.get("beam_haze_density", 0.17)) * haze_density)
+	_set_instance_shader_parameter_if_changed(light, beam, "haze_density", max(haze_density, 0.2))
+	_set_instance_shader_parameter_if_changed(light, beam, "beam_anisotropy", float(_settings.get("beam_anisotropy", 0.62)))
+	_set_instance_shader_parameter_if_changed(light, beam, "beam_quality", int(_settings.get("beam_quality", 1)))
+	_set_instance_shader_parameter_if_changed(light, beam, "radial_falloff", max(float(params.get("beam_radial_falloff", 1.1)), 0.05))
+	_set_instance_shader_parameter_if_changed(light, beam, "longitudinal_falloff", max(float(params.get("beam_longitudinal_falloff", 1.0)), 0.05))
+	_set_instance_shader_parameter_if_changed(light, beam, "beam_softness", clamp(float(params.get("beam_softness", 0.35)), 0.02, 1.0))
+	_set_instance_shader_parameter_if_changed(light, beam, "gobo_scale", max(float(params.get("gobo_scale", 1.0)), 0.05))
+	_set_instance_shader_parameter_if_changed(light, beam, "gobo_rotation_deg", beam_rotation_deg)
+	_set_instance_shader_parameter_if_changed(light, beam, "cone_height", max(beam_range, 0.001))
+	_set_instance_shader_parameter_if_changed(light, beam, "gobo_projection_radius", gobo_projection_radius)
+	_set_instance_shader_parameter_if_changed(light, beam, "beam_intensity", perceptual_intensity)
+	_set_instance_shader_parameter_if_changed(light, beam, "beam_overdrive", overdrive_norm)
 	var far_fade_end: float = max(400.0, beam_range * 12.0)
 	var beam_material: ShaderMaterial = beam.material_override as ShaderMaterial
 	if beam_material != null:
-		beam_material.set_shader_parameter("near_fade_end", max(2.0, beam_range * 0.2))
-		beam_material.set_shader_parameter("far_fade_start", far_fade_end * 0.6)
-		beam_material.set_shader_parameter("far_fade_end", far_fade_end)
-		beam_material.set_shader_parameter("use_gobo", false)
-		beam_material.set_shader_parameter("gobo_invert", false)
-		beam_material.set_shader_parameter("gobo_mirror_x", bool(shape_result.get("mirror_x", true)))
-		beam_material.set_shader_parameter("gobo_mirror_z", bool(shape_result.get("mirror_z", false)))
-		beam_material.set_shader_parameter("depth_feather_enabled", false)
+		_set_material_shader_parameter_if_changed(light, beam_material, "near_fade_end", max(2.0, beam_range * 0.2))
+		_set_material_shader_parameter_if_changed(light, beam_material, "far_fade_start", far_fade_end * 0.6)
+		_set_material_shader_parameter_if_changed(light, beam_material, "far_fade_end", far_fade_end)
+		_set_material_shader_parameter_if_changed(light, beam_material, "use_gobo", false)
+		_set_material_shader_parameter_if_changed(light, beam_material, "gobo_invert", false)
+		_set_material_shader_parameter_if_changed(light, beam_material, "gobo_mirror_x", bool(shape_result.get("mirror_x", true)))
+		_set_material_shader_parameter_if_changed(light, beam_material, "gobo_mirror_z", bool(shape_result.get("mirror_z", false)))
+		_set_material_shader_parameter_if_changed(light, beam_material, "depth_feather_enabled", false)
+
+
+func _set_instance_shader_parameter_if_changed(light: SpotLight3D, instance: GeometryInstance3D, name: String, value: Variant) -> void:
+	if instance == null:
+		return
+	var uniforms := _ensure_last_uniforms_meta(light)
+	var previous: Variant = uniforms.get(name, null)
+	if _uniform_values_equal(previous, value):
+		return
+	instance.set_instance_shader_parameter(name, value)
+	uniforms[name] = value
+
+func _set_material_shader_parameter_if_changed(light: SpotLight3D, material: ShaderMaterial, name: String, value: Variant) -> void:
+	if material == null:
+		return
+	var uniforms := _ensure_last_uniforms_meta(light)
+	var key: String = "material::" + name
+	var previous: Variant = uniforms.get(key, null)
+	if _uniform_values_equal(previous, value):
+		return
+	material.set_shader_parameter(name, value)
+	uniforms[key] = value
+
+func _ensure_last_uniforms_meta(light: SpotLight3D) -> Dictionary:
+	if light == null:
+		return {}
+	if light.has_meta(LAST_UNIFORMS_META_KEY):
+		var existing: Variant = light.get_meta(LAST_UNIFORMS_META_KEY)
+		if existing is Dictionary:
+			return existing as Dictionary
+	var created: Dictionary = {}
+	light.set_meta(LAST_UNIFORMS_META_KEY, created)
+	return created
+
+func _uniform_values_equal(previous: Variant, current: Variant) -> bool:
+	if previous == null and current == null:
+		return true
+	if previous == null or current == null:
+		return false
+	if previous is float and current is float:
+		return is_equal_approx(previous, current)
+	if previous is Color and current is Color:
+		return _color_equal_approx(previous, current)
+	if previous is Vector2 and current is Vector2:
+		return _vector2_equal_approx(previous, current)
+	if previous is Vector3 and current is Vector3:
+		return _vector3_equal_approx(previous, current)
+	if previous is Vector4 and current is Vector4:
+		return _vector4_equal_approx(previous, current)
+	return previous == current
+
+func _color_equal_approx(a: Color, b: Color) -> bool:
+	return is_equal_approx(a.r, b.r) and is_equal_approx(a.g, b.g) and is_equal_approx(a.b, b.b) and is_equal_approx(a.a, b.a)
+
+func _vector2_equal_approx(a: Vector2, b: Vector2) -> bool:
+	return is_equal_approx(a.x, b.x) and is_equal_approx(a.y, b.y)
+
+func _vector3_equal_approx(a: Vector3, b: Vector3) -> bool:
+	return is_equal_approx(a.x, b.x) and is_equal_approx(a.y, b.y) and is_equal_approx(a.z, b.z)
+
+func _vector4_equal_approx(a: Vector4, b: Vector4) -> bool:
+	return is_equal_approx(a.x, b.x) and is_equal_approx(a.y, b.y) and is_equal_approx(a.z, b.z) and is_equal_approx(a.w, b.w)
 
 func cleanup_beam(light: SpotLight3D) -> void:
 	if not light.has_meta(BEAM_META_KEY):

--- a/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
+++ b/peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd
@@ -97,8 +97,8 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 	_set_instance_shader_parameter_if_changed(light, beam, "radial_falloff", max(float(params.get("beam_radial_falloff", 1.1)), 0.05))
 	_set_instance_shader_parameter_if_changed(light, beam, "longitudinal_falloff", max(float(params.get("beam_longitudinal_falloff", 1.0)), 0.05))
 	_set_instance_shader_parameter_if_changed(light, beam, "beam_softness", clamp(float(params.get("beam_softness", 0.35)), 0.02, 1.0))
-	_set_instance_shader_parameter_if_changed(light, beam, "gobo_scale", max(float(params.get("gobo_scale", 1.0)), 0.05))
-	_set_instance_shader_parameter_if_changed(light, beam, "gobo_rotation_deg", beam_rotation_deg)
+	_set_instance_shader_parameter_if_changed(light, beam, "gobo_scale", max(float(params.get("gobo_scale", 1.0)), 0.05), true)
+	_set_instance_shader_parameter_if_changed(light, beam, "gobo_rotation_deg", beam_rotation_deg, true)
 	_set_instance_shader_parameter_if_changed(light, beam, "cone_height", max(beam_range, 0.001))
 	_set_instance_shader_parameter_if_changed(light, beam, "gobo_projection_radius", gobo_projection_radius)
 	_set_instance_shader_parameter_if_changed(light, beam, "beam_intensity", perceptual_intensity)
@@ -111,28 +111,28 @@ func update_beam(light: SpotLight3D, params: Dictionary) -> void:
 		_set_material_shader_parameter_if_changed(light, beam_material, "far_fade_end", far_fade_end)
 		_set_material_shader_parameter_if_changed(light, beam_material, "use_gobo", false)
 		_set_material_shader_parameter_if_changed(light, beam_material, "gobo_invert", false)
-		_set_material_shader_parameter_if_changed(light, beam_material, "gobo_mirror_x", bool(shape_result.get("mirror_x", true)))
-		_set_material_shader_parameter_if_changed(light, beam_material, "gobo_mirror_z", bool(shape_result.get("mirror_z", false)))
+		_set_material_shader_parameter_if_changed(light, beam_material, "gobo_mirror_x", bool(shape_result.get("mirror_x", true)), true)
+		_set_material_shader_parameter_if_changed(light, beam_material, "gobo_mirror_z", bool(shape_result.get("mirror_z", false)), true)
 		_set_material_shader_parameter_if_changed(light, beam_material, "depth_feather_enabled", false)
 
 
-func _set_instance_shader_parameter_if_changed(light: SpotLight3D, instance: GeometryInstance3D, name: String, value: Variant) -> void:
+func _set_instance_shader_parameter_if_changed(light: SpotLight3D, instance: GeometryInstance3D, name: String, value: Variant, force_update: bool = false) -> void:
 	if instance == null:
 		return
 	var uniforms := _ensure_last_uniforms_meta(light)
 	var previous: Variant = uniforms.get(name, null)
-	if _uniform_values_equal(previous, value):
+	if not force_update and _uniform_values_equal(previous, value):
 		return
 	instance.set_instance_shader_parameter(name, value)
 	uniforms[name] = value
 
-func _set_material_shader_parameter_if_changed(light: SpotLight3D, material: ShaderMaterial, name: String, value: Variant) -> void:
+func _set_material_shader_parameter_if_changed(light: SpotLight3D, material: ShaderMaterial, name: String, value: Variant, force_update: bool = false) -> void:
 	if material == null:
 		return
 	var uniforms := _ensure_last_uniforms_meta(light)
 	var key: String = "material::" + name
 	var previous: Variant = uniforms.get(key, null)
-	if _uniform_values_equal(previous, value):
+	if not force_update and _uniform_values_equal(previous, value):
 		return
 	material.set_shader_parameter(name, value)
 	uniforms[key] = value

--- a/peraviz/scripts/fog_volume_gobo_beam_controller.gd
+++ b/peraviz/scripts/fog_volume_gobo_beam_controller.gd
@@ -26,26 +26,26 @@ func update_for_light(light: SpotLight3D, beam_params: Dictionary, gobo_texture:
 	var fog_material: ShaderMaterial = fog_volume.material as ShaderMaterial
 	if fog_material == null:
 		return
-	_set_fog_shader_parameter_if_changed(light, fog_material, "gobo_texture", gobo_texture)
+	_set_fog_shader_parameter_if_changed(light, fog_material, "gobo_texture", gobo_texture, true)
 	_set_fog_shader_parameter_if_changed(light, fog_material, "light_color", Color(beam_params.get("beam_color", Color.WHITE)))
 	var haze_density: float = max(float(beam_params.get("haze_density_multiplier", 0.22)), 0.01)
 	_set_fog_shader_parameter_if_changed(light, fog_material, "density_scale", float(visual_settings.get("fog_volume_density_scale", 0.9)) * haze_density)
 	_set_fog_shader_parameter_if_changed(light, fog_material, "emission_strength", float(visual_settings.get("fog_volume_emission_strength", 0.55)))
 	_set_fog_shader_parameter_if_changed(light, fog_material, "edge_softness", float(visual_settings.get("fog_volume_edge_softness", 0.72)))
 	_set_fog_shader_parameter_if_changed(light, fog_material, "invert_gobo", bool(visual_settings.get("fog_volume_invert_gobo", false)))
-	_set_fog_shader_parameter_if_changed(light, fog_material, "gobo_scale", max(float(beam_params.get("gobo_scale", 1.0)), 0.05))
-	_set_fog_shader_parameter_if_changed(light, fog_material, "gobo_rotation_deg", float(beam_params.get("gobo_rotation_deg", 0.0)))
+	_set_fog_shader_parameter_if_changed(light, fog_material, "gobo_scale", max(float(beam_params.get("gobo_scale", 1.0)), 0.05), true)
+	_set_fog_shader_parameter_if_changed(light, fog_material, "gobo_rotation_deg", float(beam_params.get("gobo_rotation_deg", 0.0)), true)
 	_set_fog_shader_parameter_if_changed(light, fog_material, "radial_falloff", max(float(beam_params.get("beam_radial_falloff", 1.25)), 0.05))
 	_set_fog_shader_parameter_if_changed(light, fog_material, "longitudinal_falloff", max(float(beam_params.get("beam_longitudinal_falloff", 1.1)), 0.05))
 
 
-func _set_fog_shader_parameter_if_changed(light: SpotLight3D, material: ShaderMaterial, name: String, value: Variant) -> void:
+func _set_fog_shader_parameter_if_changed(light: SpotLight3D, material: ShaderMaterial, name: String, value: Variant, force_update: bool = false) -> void:
 	if material == null:
 		return
 	var uniforms := _ensure_last_uniforms_meta(light)
 	var key: String = "fog::" + name
 	var previous: Variant = uniforms.get(key, null)
-	if _uniform_values_equal(previous, value):
+	if not force_update and _uniform_values_equal(previous, value):
 		return
 	material.set_shader_parameter(name, value)
 	uniforms[key] = value

--- a/peraviz/scripts/fog_volume_gobo_beam_controller.gd
+++ b/peraviz/scripts/fog_volume_gobo_beam_controller.gd
@@ -3,6 +3,7 @@ class_name FogVolumeGoboBeamController
 
 const FOG_VOLUME_NODE_NAME: String = "PeravizFogVolumeGoboBeam"
 const FOG_SHADER_PATH: String = "res://scripts/shaders/fog_volume_gobo_beam.gdshader"
+const LAST_UNIFORMS_META_KEY: String = "peraviz_last_beam_uniforms"
 
 func update_for_light(light: SpotLight3D, beam_params: Dictionary, gobo_texture: Texture2D, visual_settings: Dictionary) -> void:
 	if light == null or not is_instance_valid(light):
@@ -25,17 +26,55 @@ func update_for_light(light: SpotLight3D, beam_params: Dictionary, gobo_texture:
 	var fog_material: ShaderMaterial = fog_volume.material as ShaderMaterial
 	if fog_material == null:
 		return
-	fog_material.set_shader_parameter("gobo_texture", gobo_texture)
-	fog_material.set_shader_parameter("light_color", Color(beam_params.get("beam_color", Color.WHITE)))
+	_set_fog_shader_parameter_if_changed(light, fog_material, "gobo_texture", gobo_texture)
+	_set_fog_shader_parameter_if_changed(light, fog_material, "light_color", Color(beam_params.get("beam_color", Color.WHITE)))
 	var haze_density: float = max(float(beam_params.get("haze_density_multiplier", 0.22)), 0.01)
-	fog_material.set_shader_parameter("density_scale", float(visual_settings.get("fog_volume_density_scale", 0.9)) * haze_density)
-	fog_material.set_shader_parameter("emission_strength", float(visual_settings.get("fog_volume_emission_strength", 0.55)))
-	fog_material.set_shader_parameter("edge_softness", float(visual_settings.get("fog_volume_edge_softness", 0.72)))
-	fog_material.set_shader_parameter("invert_gobo", bool(visual_settings.get("fog_volume_invert_gobo", false)))
-	fog_material.set_shader_parameter("gobo_scale", max(float(beam_params.get("gobo_scale", 1.0)), 0.05))
-	fog_material.set_shader_parameter("gobo_rotation_deg", float(beam_params.get("gobo_rotation_deg", 0.0)))
-	fog_material.set_shader_parameter("radial_falloff", max(float(beam_params.get("beam_radial_falloff", 1.25)), 0.05))
-	fog_material.set_shader_parameter("longitudinal_falloff", max(float(beam_params.get("beam_longitudinal_falloff", 1.1)), 0.05))
+	_set_fog_shader_parameter_if_changed(light, fog_material, "density_scale", float(visual_settings.get("fog_volume_density_scale", 0.9)) * haze_density)
+	_set_fog_shader_parameter_if_changed(light, fog_material, "emission_strength", float(visual_settings.get("fog_volume_emission_strength", 0.55)))
+	_set_fog_shader_parameter_if_changed(light, fog_material, "edge_softness", float(visual_settings.get("fog_volume_edge_softness", 0.72)))
+	_set_fog_shader_parameter_if_changed(light, fog_material, "invert_gobo", bool(visual_settings.get("fog_volume_invert_gobo", false)))
+	_set_fog_shader_parameter_if_changed(light, fog_material, "gobo_scale", max(float(beam_params.get("gobo_scale", 1.0)), 0.05))
+	_set_fog_shader_parameter_if_changed(light, fog_material, "gobo_rotation_deg", float(beam_params.get("gobo_rotation_deg", 0.0)))
+	_set_fog_shader_parameter_if_changed(light, fog_material, "radial_falloff", max(float(beam_params.get("beam_radial_falloff", 1.25)), 0.05))
+	_set_fog_shader_parameter_if_changed(light, fog_material, "longitudinal_falloff", max(float(beam_params.get("beam_longitudinal_falloff", 1.1)), 0.05))
+
+
+func _set_fog_shader_parameter_if_changed(light: SpotLight3D, material: ShaderMaterial, name: String, value: Variant) -> void:
+	if material == null:
+		return
+	var uniforms := _ensure_last_uniforms_meta(light)
+	var key: String = "fog::" + name
+	var previous: Variant = uniforms.get(key, null)
+	if _uniform_values_equal(previous, value):
+		return
+	material.set_shader_parameter(name, value)
+	uniforms[key] = value
+
+func _ensure_last_uniforms_meta(light: SpotLight3D) -> Dictionary:
+	if light.has_meta(LAST_UNIFORMS_META_KEY):
+		var existing: Variant = light.get_meta(LAST_UNIFORMS_META_KEY)
+		if existing is Dictionary:
+			return existing as Dictionary
+	var created: Dictionary = {}
+	light.set_meta(LAST_UNIFORMS_META_KEY, created)
+	return created
+
+func _uniform_values_equal(previous: Variant, current: Variant) -> bool:
+	if previous == null and current == null:
+		return true
+	if previous == null or current == null:
+		return false
+	if previous is float and current is float:
+		return is_equal_approx(previous, current)
+	if previous is Color and current is Color:
+		return is_equal_approx(previous.r, current.r) and is_equal_approx(previous.g, current.g) and is_equal_approx(previous.b, current.b) and is_equal_approx(previous.a, current.a)
+	if previous is Vector2 and current is Vector2:
+		return is_equal_approx(previous.x, current.x) and is_equal_approx(previous.y, current.y)
+	if previous is Vector3 and current is Vector3:
+		return is_equal_approx(previous.x, current.x) and is_equal_approx(previous.y, current.y) and is_equal_approx(previous.z, current.z)
+	if previous is Vector4 and current is Vector4:
+		return is_equal_approx(previous.x, current.x) and is_equal_approx(previous.y, current.y) and is_equal_approx(previous.z, current.z) and is_equal_approx(previous.w, current.w)
+	return previous == current
 
 func clear_for_light(light: SpotLight3D) -> void:
 	if light == null or not is_instance_valid(light):

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -1877,19 +1877,17 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 	beam_params["intensity_max"] = BEAM_INTENSITY_MAX
 	var gobo_topology_changed: bool = false
 	if _fixture_gobo_projector != null:
-		var runtime_controls_for_gobo: Dictionary = controls
+		var runtime_controls_for_gobo: Dictionary = controls.duplicate(true)
 		if state != null:
-			runtime_controls_for_gobo = {
-				"has_gobo": state.has_gobo,
-				"gobo_norm": state.gobo_norm,
-				"has_gobo_index": state.has_gobo_index,
-				"gobo_index_norm": state.gobo_index_norm,
-				"has_gobo_rotation": state.has_gobo_rotation,
-				"gobo_rotation_norm": state.gobo_rotation_norm,
-				"gobo_slots": state.gobo_slots,
-				"gobo_ranges": state.gobo_ranges,
-				"gobo_runtime_bindings": state.gobo_runtime_bindings,
-			}
+			runtime_controls_for_gobo["has_gobo"] = state.has_gobo
+			runtime_controls_for_gobo["gobo_norm"] = state.gobo_norm
+			runtime_controls_for_gobo["has_gobo_index"] = state.has_gobo_index
+			runtime_controls_for_gobo["gobo_index_norm"] = state.gobo_index_norm
+			runtime_controls_for_gobo["has_gobo_rotation"] = state.has_gobo_rotation
+			runtime_controls_for_gobo["gobo_rotation_norm"] = state.gobo_rotation_norm
+			runtime_controls_for_gobo["gobo_slots"] = state.gobo_slots
+			runtime_controls_for_gobo["gobo_ranges"] = state.gobo_ranges
+			runtime_controls_for_gobo["gobo_runtime_bindings"] = state.gobo_runtime_bindings
 		var gobo_controls: Dictionary = BeamOpticsControllerScript.BuildGoboControls(runtime_controls_for_gobo, _visual_settings, beam_defaults)
 		gobo_topology_changed = _fixture_gobo_projector.apply_gobo_projection(light, gobo_controls)
 		var applied_gobo_rotation_deg: float = float(light.get_meta("peraviz_gobo_applied_rotation_deg", beam_params.get("gobo_rotation_deg", 0.0)))


### PR DESCRIPTION
### Motivation
- Reduce redundant shader uniform calls by tracking the last-applied uniform values per light/material so only real changes are sent to instance/material shaders. 
- Improve renderer performance and avoid needless GPU/material updates while keeping dynamic/time-driven updates intact. 

### Description
- Added a per-light meta cache `LAST_UNIFORMS_META_KEY` (`"peraviz_last_beam_uniforms"`) in `peraviz/scripts/beam_renderers/volumetric_beam_renderer.gd`, `peraviz/scripts/beam_renderers/legacy_cone_beam_renderer.gd` and `peraviz/scripts/fog_volume_gobo_beam_controller.gd` to store last-applied uniform values. 
- Introduced guarded setters `_set_instance_shader_parameter_if_changed`, `_set_material_shader_parameter_if_changed` and `_set_fog_shader_parameter_if_changed` that compare new vs previous values before calling `set_instance_shader_parameter` / `set_shader_parameter`. 
- Implemented typed comparison helpers `_uniform_values_equal` with `is_equal_approx` for floats and per-component comparisons for `Color`/`Vector` types, and added small helpers `_color_equal_approx`, `_vector*_equal_approx`. 
- Replaced direct uniform writes with the guarded wrappers across the volumetric and legacy beam renderers and the fog-volume controller, and adjusted `_update_prism_material` to accept `light` so it can use the cache consistently. 

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4d603ce7083249881d57a514ba533)