### PR TITLE
Optimize DMX apply loop with per-fixture snapshot caching and tick diagnostics

### DIFF
--- a/peraviz/scripts/controllers/dmx_controller.gd
+++ b/peraviz/scripts/controllers/dmx_controller.gd
@@ -23,6 +23,9 @@ var _last_dmx_tick_msec: int = 0
 var _dmx_status_changed_callback: Callable
 var _dmx_start_failed_callback: Callable
 var _fixture_binding_summary: Dictionary = {}
+var _last_updated_fixtures: int = 0
+var _last_skipped_fixtures: int = 0
+var _debug_force_full_apply: bool = false
 
 func configure(owner: Node, get_controls_host_callback: Callable, apply_dmx_controls_callback: Callable) -> void:
 	_owner = owner
@@ -107,6 +110,12 @@ func setup_controls() -> void:
 func setup_fixture_runtime(loader: Variant, scene_registry: SceneRegistry) -> void:
 	_dmx_fixture_runtime = DmxFixtureRuntimeScript.new()
 	_dmx_fixture_runtime.configure(loader, scene_registry)
+	_dmx_fixture_runtime.set_debug_force_full_apply(_debug_force_full_apply)
+
+func set_debug_force_full_apply(enabled: bool) -> void:
+	_debug_force_full_apply = enabled
+	if _dmx_fixture_runtime != null:
+		_dmx_fixture_runtime.set_debug_force_full_apply(enabled)
 
 func refresh_fixture_bindings() -> Dictionary:
 	if _dmx_fixture_runtime == null or _dmx_universe_offset_input == null:
@@ -162,6 +171,8 @@ func _on_dmx_toggle_pressed() -> void:
 		_dmx_toggle_button.text = "DMX OFF"
 		_update_dmx_toggle_color(false, false)
 		_refresh_dmx_monitor_window(false)
+		_last_updated_fixtures = 0
+		_last_skipped_fixtures = 0
 		_refresh_dmx_quick_panel(false, false, PackedInt32Array(), -1)
 		_emit_dmx_status(false, false)
 
@@ -182,6 +193,8 @@ func _on_dmx_timer_timeout() -> void:
 		if _dmx_toggle_button != null and not _dmx_toggle_button.button_pressed:
 			_update_dmx_toggle_color(false, false)
 		_refresh_dmx_monitor_window(false)
+		_last_updated_fixtures = 0
+		_last_skipped_fixtures = 0
 		_refresh_dmx_quick_panel(false, false, PackedInt32Array(), -1)
 		return
 
@@ -192,10 +205,13 @@ func _on_dmx_timer_timeout() -> void:
 	_last_dmx_tick_msec = now_msec
 
 	if _dmx_fixture_runtime != null and _apply_dmx_controls_callback.is_valid():
-		_dmx_fixture_runtime.apply_dmx(_dmx_receiver, func(fixture_uuid: String, controls: Dictionary) -> void:
+		var apply_stats: Dictionary = _dmx_fixture_runtime.apply_dmx(_dmx_receiver, func(fixture_uuid: String, controls: Dictionary) -> void:
 			controls["frame_delta_sec"] = delta_sec
 			_apply_dmx_controls_callback.call(fixture_uuid, controls)
 		)
+		_last_updated_fixtures = int(apply_stats.get("updated", 0))
+		_last_skipped_fixtures = int(apply_stats.get("skipped", 0))
+		_apply_fixture_time_tick(delta_sec)
 
 	var stats: Dictionary = _dmx_receiver.get_stats()
 	var active_universes: PackedInt32Array = _dmx_receiver.get_active_universes(2000)
@@ -224,7 +240,18 @@ func _refresh_dmx_quick_panel(running: bool, receiving_signal: bool, active_univ
 		return
 	var linked_fixtures: int = int(_fixture_binding_summary.get("bound", 0))
 	var unlinked_fixtures: int = int(_fixture_binding_summary.get("unbound", 0))
-	_dmx_quick_panel.refresh(running, receiving_signal, active_universes, last_packet_ms, linked_fixtures, unlinked_fixtures)
+	_dmx_quick_panel.refresh(running, receiving_signal, active_universes, last_packet_ms, linked_fixtures, unlinked_fixtures, _last_updated_fixtures, _last_skipped_fixtures)
+
+func _apply_fixture_time_tick(delta_sec: float) -> void:
+	if delta_sec <= 0.0:
+		return
+	if _dmx_fixture_runtime == null or not _apply_dmx_controls_callback.is_valid():
+		return
+	for fixture_uuid in _dmx_fixture_runtime.get_bound_fixture_ids():
+		_apply_dmx_controls_callback.call(str(fixture_uuid), {
+			"frame_delta_sec": delta_sec,
+			"time_tick_only": true,
+		})
 
 func _emit_dmx_status(running: bool, receiving_signal: bool) -> void:
 	if _dmx_status_changed_callback.is_valid():

--- a/peraviz/scripts/dmx_fixture_runtime.gd
+++ b/peraviz/scripts/dmx_fixture_runtime.gd
@@ -106,6 +106,13 @@ func apply_dmx(receiver, apply_fixture_callback: Callable) -> Dictionary:
 		if frame.is_empty():
 			continue
 		var snapshot: PackedByteArray = _extract_snapshot_for_fixture(fixture_uuid, frame)
+		if snapshot.is_empty():
+			var controls_without_cache: Dictionary = _build_controls(binding, frame)
+			if not _has_any_capability(controls_without_cache):
+				continue
+			apply_fixture_callback.call(fixture_uuid, controls_without_cache)
+			updated += 1
+			continue
 		var snapshot_hash: int = _compute_snapshot_hash(snapshot)
 		var previous_state: Dictionary = _fixture_snapshot_cache.get(fixture_uuid, {})
 		if not _debug_force_full_apply and _snapshot_is_unchanged(previous_state, snapshot_hash, snapshot):

--- a/peraviz/scripts/dmx_fixture_runtime.gd
+++ b/peraviz/scripts/dmx_fixture_runtime.gd
@@ -106,7 +106,7 @@ func apply_dmx(receiver, apply_fixture_callback: Callable) -> Dictionary:
 		if frame.is_empty():
 			continue
 		var snapshot: PackedByteArray = _extract_snapshot_for_fixture(fixture_uuid, frame)
-		var snapshot_hash: int = snapshot.hash()
+		var snapshot_hash: int = _compute_snapshot_hash(snapshot)
 		var previous_state: Dictionary = _fixture_snapshot_cache.get(fixture_uuid, {})
 		if not _debug_force_full_apply and _snapshot_is_unchanged(previous_state, snapshot_hash, snapshot):
 			skipped += 1
@@ -140,6 +140,12 @@ func _extract_snapshot_for_fixture(fixture_uuid: String, frame: PackedByteArray)
 		else:
 			snapshot.append(frame[offset])
 	return snapshot
+
+func _compute_snapshot_hash(snapshot: PackedByteArray) -> int:
+	var hash_value: int = 2166136261
+	for value in snapshot:
+		hash_value = int((hash_value ^ int(value)) * 16777619)
+	return hash_value
 
 func _collect_used_channel_offsets(binding: Dictionary) -> PackedInt32Array:
 	var offsets := PackedInt32Array()

--- a/peraviz/scripts/dmx_fixture_runtime.gd
+++ b/peraviz/scripts/dmx_fixture_runtime.gd
@@ -19,8 +19,11 @@ var _scene_registry: SceneRegistry = null
 var _bindings: Array = []
 var _unbound: Array = []
 var _fixture_nodes: Dictionary = {}
+var _fixture_channel_offsets: Dictionary = {}
+var _fixture_snapshot_cache: Dictionary = {}
 var _used_universes: Dictionary = {}
 var _gobo_vectorization_cache: GoboVectorizationCache = null
+var _debug_force_full_apply: bool = false
 
 func configure(loader, scene_registry: SceneRegistry) -> void:
 	_loader = loader
@@ -31,6 +34,8 @@ func rebuild(universe_offset: int) -> Dictionary:
 	_bindings.clear()
 	_unbound.clear()
 	_fixture_nodes.clear()
+	_fixture_channel_offsets.clear()
+	_fixture_snapshot_cache.clear()
 	_used_universes.clear()
 
 	if _loader == null or _scene_registry == null:
@@ -61,23 +66,35 @@ func rebuild(universe_offset: int) -> Dictionary:
 			})
 			continue
 		_fixture_nodes[fixture_uuid] = fixture_node
+		_fixture_channel_offsets[fixture_uuid] = _collect_used_channel_offsets(binding)
 		var universe_id: int = int(binding.get("artnet_universe_id", -1))
 		if universe_id >= 0:
 			_used_universes[universe_id] = true
 
 	return _build_summary(universe_offset)
 
-func apply_dmx(receiver, apply_fixture_callback: Callable) -> void:
+func set_debug_force_full_apply(enabled: bool) -> void:
+	_debug_force_full_apply = enabled
+
+func get_bound_fixture_ids() -> PackedStringArray:
+	var fixture_ids := PackedStringArray()
+	for fixture_uuid in _fixture_nodes.keys():
+		fixture_ids.append(str(fixture_uuid))
+	return fixture_ids
+
+func apply_dmx(receiver, apply_fixture_callback: Callable) -> Dictionary:
 	if receiver == null or not receiver.is_running():
-		return
+		return {"updated": 0, "skipped": 0}
 	if apply_fixture_callback.is_null():
-		return
+		return {"updated": 0, "skipped": 0}
 
 	var universe_frames: Dictionary = {}
 	for universe_key in _used_universes.keys():
 		var universe_id: int = int(universe_key)
 		universe_frames[universe_id] = receiver.get_universe_data(universe_id)
 
+	var updated: int = 0
+	var skipped: int = 0
 	for binding in _bindings:
 		if binding is not Dictionary:
 			continue
@@ -88,11 +105,60 @@ func apply_dmx(receiver, apply_fixture_callback: Callable) -> void:
 		var frame: PackedByteArray = universe_frames.get(universe_id, PackedByteArray())
 		if frame.is_empty():
 			continue
+		var snapshot: PackedByteArray = _extract_snapshot_for_fixture(fixture_uuid, frame)
+		var snapshot_hash: int = snapshot.hash()
+		var previous_state: Dictionary = _fixture_snapshot_cache.get(fixture_uuid, {})
+		if not _debug_force_full_apply and _snapshot_is_unchanged(previous_state, snapshot_hash, snapshot):
+			skipped += 1
+			continue
 
 		var controls: Dictionary = _build_controls(binding, frame)
 		if not _has_any_capability(controls):
 			continue
+		_fixture_snapshot_cache[fixture_uuid] = {
+			"hash": snapshot_hash,
+			"snapshot": snapshot,
+		}
 		apply_fixture_callback.call(fixture_uuid, controls)
+		updated += 1
+	return {"updated": updated, "skipped": skipped}
+
+func _snapshot_is_unchanged(previous_state: Dictionary, snapshot_hash: int, snapshot: PackedByteArray) -> bool:
+	if previous_state.is_empty():
+		return false
+	if int(previous_state.get("hash", -1)) != snapshot_hash:
+		return false
+	var previous_snapshot: PackedByteArray = previous_state.get("snapshot", PackedByteArray())
+	return previous_snapshot == snapshot
+
+func _extract_snapshot_for_fixture(fixture_uuid: String, frame: PackedByteArray) -> PackedByteArray:
+	var offsets: PackedInt32Array = _fixture_channel_offsets.get(fixture_uuid, PackedInt32Array())
+	var snapshot := PackedByteArray()
+	for offset in offsets:
+		if offset < 0 or offset >= frame.size():
+			snapshot.append(0)
+		else:
+			snapshot.append(frame[offset])
+	return snapshot
+
+func _collect_used_channel_offsets(binding: Dictionary) -> PackedInt32Array:
+	var offsets := PackedInt32Array()
+	var used_offsets := {}
+	var channel_bindings: Array = binding.get("channel_bindings", [])
+	for channel_binding in channel_bindings:
+		if channel_binding is not Dictionary:
+			continue
+		var offset: int = int(channel_binding.get("dmx_offset", -1))
+		var fine_offset: int = int(channel_binding.get("dmx_fine_offset", -1))
+		if offset >= 0:
+			used_offsets[offset] = true
+		if fine_offset >= 0:
+			used_offsets[fine_offset] = true
+	var sorted_offsets: Array = used_offsets.keys()
+	sorted_offsets.sort()
+	for offset in sorted_offsets:
+		offsets.append(int(offset))
+	return offsets
 
 func _build_controls(binding: Dictionary, frame: PackedByteArray) -> Dictionary:
 	var capabilities := {

--- a/peraviz/scripts/ui/dmx_quick_panel.gd
+++ b/peraviz/scripts/ui/dmx_quick_panel.gd
@@ -8,6 +8,7 @@ var _status_value_label: Label
 var _universes_value_label: Label
 var _last_packet_value_label: Label
 var _fixtures_value_label: Label
+var _dmx_tick_value_label: Label
 var _open_monitor_button: Button
 var _monitor_available: bool = false
 var _running: bool = false
@@ -16,6 +17,8 @@ var _active_universes: PackedInt32Array = PackedInt32Array()
 var _last_packet_ms: int = -1
 var _linked_fixtures: int = 0
 var _unlinked_fixtures: int = 0
+var _updated_fixtures: int = 0
+var _skipped_fixtures: int = 0
 
 func _ready() -> void:
 	var margin := MarginContainer.new()
@@ -37,6 +40,7 @@ func _ready() -> void:
 	_universes_value_label = _add_metric_row(layout, "Active universes", "0")
 	_last_packet_value_label = _add_metric_row(layout, "Last packet", "n/a")
 	_fixtures_value_label = _add_metric_row(layout, "Fixtures", "0 linked / 0 unlinked")
+	_dmx_tick_value_label = _add_metric_row(layout, "DMX tick", "0 updated / 0 skipped")
 
 	_open_monitor_button = Button.new()
 	_open_monitor_button.text = "Open Technical Monitor"
@@ -48,13 +52,15 @@ func set_monitor_available(available: bool) -> void:
 	_monitor_available = available
 	_apply_state()
 
-func refresh(running: bool, receiving_signal: bool, active_universes: PackedInt32Array, last_packet_ms: int, linked_fixtures: int, unlinked_fixtures: int) -> void:
+func refresh(running: bool, receiving_signal: bool, active_universes: PackedInt32Array, last_packet_ms: int, linked_fixtures: int, unlinked_fixtures: int, updated_fixtures: int, skipped_fixtures: int) -> void:
 	_running = running
 	_receiving_signal = receiving_signal
 	_active_universes = active_universes
 	_last_packet_ms = last_packet_ms
 	_linked_fixtures = max(linked_fixtures, 0)
 	_unlinked_fixtures = max(unlinked_fixtures, 0)
+	_updated_fixtures = max(updated_fixtures, 0)
+	_skipped_fixtures = max(skipped_fixtures, 0)
 	_apply_state()
 
 func _add_metric_row(parent: VBoxContainer, label_text: String, initial_value: String) -> Label:
@@ -94,3 +100,5 @@ func _apply_state() -> void:
 	_universes_value_label.text = _format_universes(_active_universes)
 	_last_packet_value_label.text = "%d ms" % _last_packet_ms if _last_packet_ms >= 0 else "n/a"
 	_fixtures_value_label.text = "%d linked / %d unlinked" % [_linked_fixtures, _unlinked_fixtures]
+	if _dmx_tick_value_label != null:
+		_dmx_tick_value_label.text = "%d updated / %d skipped" % [_updated_fixtures, _skipped_fixtures]


### PR DESCRIPTION
### Motivation
- Reduce wasted per-tick work by avoiding control reconstruction and fixture apply when DMX bytes relevant to a fixture did not change.
- Preserve continuous time-driven effects (rotation/shake/etc.) even when DMX values are unchanged.
- Provide observability for how many fixtures were updated vs skipped each DMX tick and allow a debug mode to force full apply for comparison.

### Description
- Added per-fixture DMX channel offset collection and snapshot cache to `peraviz/scripts/dmx_fixture_runtime.gd`, with a simple snapshot hash and `set_debug_force_full_apply` to force full behavior.
- Changed `apply_dmx(...)` to extract only fixture-relevant bytes, compare with cached snapshot, skip `_build_controls` and callback when unchanged, and return `{"updated", "skipped"}` counts; added `get_bound_fixture_ids()` helper.
- Kept DMX tick in `peraviz/scripts/controllers/dmx_controller.gd`, added propagation of the debug flag, captured apply metrics per tick, and added a separated per-tick time-only update path (`time_tick_only`) to keep time-dependent effects active even for skipped fixtures.
- Extended `peraviz/scripts/ui/dmx_quick_panel.gd` to show a new "DMX tick" metric with `updated / skipped` counts and adjusted the `refresh` signature to accept the new stats.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e13775988324871f7efc693264cb)