### PR TITLE
Optimize Peraviz status badge updates

### DIFF
--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -151,6 +151,7 @@ var _status_presenter: StatusPresenter
 var _user_preferences: UserPreferences
 var _debug_properties_applied: int = 0
 var _debug_properties_skipped: int = 0
+var _selected_fixture_badge_uuid: String = ""
 
 const DEBUG_TOGGLE_KEY: Key = KEY_C
 const MANUAL_TEST_FLAG: String = "--peraviz_manual_fixture_test"
@@ -612,7 +613,7 @@ func _refresh_ui_module_visibility() -> void:
 
 func _unhandled_input(event: InputEvent) -> void:
 	_sync_selection_state("input")
-	_update_selected_fixture_badge()
+	_sync_selected_fixture_badge()
 
 	if event is InputEventKey and event.pressed and not event.echo and event.keycode == KEY_F:
 		_focus_loaded_scene()
@@ -632,6 +633,7 @@ func _unhandled_input(event: InputEvent) -> void:
 		var mouse_event := event as InputEventMouseButton
 		if mouse_event.pressed and mouse_event.button_index == MOUSE_BUTTON_LEFT:
 			_fixture_debug_controller.try_select_fixture_from_mouse(mouse_event.position)
+			_sync_selected_fixture_badge()
 			get_viewport().set_input_as_handled()
 
 
@@ -1296,9 +1298,11 @@ func _attach_pick_collider_to_mesh(mesh_instance: MeshInstance3D, fixture_uuid: 
 
 func _clear_selected_fixture(reason: String) -> void:
 	_fixture_debug_controller.clear_selected_fixture(reason)
+	_sync_selected_fixture_badge()
 
 func _sync_selection_state(reason: String) -> void:
 	_fixture_debug_controller.sync_selection_state(reason)
+	_sync_selected_fixture_badge()
 
 func _refresh_fixture_debug_panel() -> void:
 	_fixture_debug_controller.refresh_fixture_debug_panel()
@@ -2352,13 +2356,14 @@ func _exit_tree() -> void:
 	if _dmx_controller != null:
 		_dmx_controller.exit_tree()
 
-func _process(_delta: float) -> void:
-	_update_selected_fixture_badge()
-
-func _update_selected_fixture_badge() -> void:
+func _sync_selected_fixture_badge() -> void:
 	if _status_presenter == null or _fixture_debug_controller == null:
 		return
-	_status_presenter.set_selected_fixture_badge(_fixture_debug_controller.get_selected_fixture_uuid())
+	var selected_fixture_uuid: String = _fixture_debug_controller.get_selected_fixture_uuid()
+	if selected_fixture_uuid == _selected_fixture_badge_uuid:
+		return
+	_selected_fixture_badge_uuid = selected_fixture_uuid
+	_status_presenter.set_selected_fixture_badge(selected_fixture_uuid)
 
 func _on_dmx_status_changed(running: bool, receiving_signal: bool) -> void:
 	if _status_presenter == null:

--- a/peraviz/scripts/ui/status_presenter.gd
+++ b/peraviz/scripts/ui/status_presenter.gd
@@ -14,8 +14,12 @@ var _status_label: Label
 var _topbar_row: HBoxContainer
 var _badge_row: HBoxContainer
 var _badge_labels: Dictionary = {}
+var _badge_values: Dictionary = {}
 var _toast_label: Label
 var _toast_timer: Timer
+var _last_dmx_running: bool = false
+var _last_dmx_receiving_signal: bool = false
+var _has_dmx_state: bool = false
 
 func configure(owner: Node,
 		status_label: Label,
@@ -53,6 +57,11 @@ func set_scene_state_load_error(message: String) -> void:
 	_set_badge("MVR", "Error")
 
 func set_dmx_badge(is_running: bool, receiving_signal: bool) -> void:
+	if _has_dmx_state and is_running == _last_dmx_running and receiving_signal == _last_dmx_receiving_signal:
+		return
+	_last_dmx_running = is_running
+	_last_dmx_receiving_signal = receiving_signal
+	_has_dmx_state = true
 	if not is_running:
 		_set_badge("DMX", "OFF")
 		return
@@ -133,6 +142,9 @@ func _create_badge(name: String) -> void:
 func _set_badge(name: String, value: String) -> void:
 	if not _badge_labels.has(name):
 		return
+	if str(_badge_values.get(name, "")) == value:
+		return
+	_badge_values[name] = value
 	var badge: Label = _badge_labels[name]
 	badge.text = "%s: %s" % [name, value]
 


### PR DESCRIPTION
### Motivation
- Reduce UI churn by avoiding per-frame badge updates and unnecessary label reassignments that cause frequent repaints.
- Ensure the “Selected Fixture” badge is updated only when the selection actually changes, and limit DMX badge updates to real state transitions.
- Improve perf for high-frequency badges (e.g. DMX/DMX signal, selected fixture) to reduce needless UI work during runtime.

### Description
- Replaced the per-frame selected fixture badge refresh in `peraviz/scripts/load_scene.gd` with an event-driven synchronization function `
_sync_selected_fixture_badge` and call sites from `
_unhandled_input`, `_sync_selection_state`, and `_clear_selected_fixture`.
- Added a cached UUID `_selected_fixture_badge_uuid` in `peraviz/scripts/load_scene.gd` so the badge is only updated when the UUID changes.
- Added `_badge_values` dictionary to `peraviz/scripts/ui/status_presenter.gd` and changed `_set_badge` to skip reassigning the label text when the new value is identical to the current value.
- Added DMX state caching (`_last_dmx_running`, `_last_dmx_receiving_signal`, `_has_dmx_state`) in `peraviz/scripts/ui/status_presenter.gd` so `set_dmx_badge` returns early when there is no state transition.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which completed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e829afdc8324ba0cfc7ebb6edc46)