### PR TITLE
Refactor gobo/emitter state tracking and add update counters

### DIFF
--- a/peraviz/scripts/fixture_gobo_projector.gd
+++ b/peraviz/scripts/fixture_gobo_projector.gd
@@ -27,6 +27,7 @@ const GOBO_APPLIED_ROTATION_DEG_META_KEY: String = "peraviz_gobo_applied_rotatio
 const GOBO_APPLIED_SHAKE_TILT_DEG_META_KEY: String = "peraviz_gobo_applied_shake_tilt_deg"
 const GOBO_WHEEL_MODE_META_KEY: String = "peraviz_gobo_wheel_mode"
 const GOBO_APPLIED_STATE_META_KEY: String = "peraviz_gobo_applied_state"
+const GOBO_APPLIED_STATE_KEY_META_KEY: String = "peraviz_gobo_applied_state_key"
 const GOBO_DEBUG_OVERRIDE_STATE_META_KEY: String = "peraviz_gobo_debug_override_state"
 const GOBO_INDEX_MAX_DEG: float = 360.0
 const GOBO_ROTATION_DEBUG_SETTING_KEY: String = "peraviz_debug_gobo_rotation"
@@ -51,13 +52,22 @@ const GOBO_BEHAVIOR_SHAKE: int = 3
 const DmxGoboRangeResolverScript = preload("res://scripts/dmx_gobo_range_resolver.gd")
 
 var _texture_cache: Dictionary = {}
+var _texture_composition_count: int = 0
+var _parametric_update_count: int = 0
 
 func clear_cache() -> void:
 	_texture_cache.clear()
 
+func get_debug_counters() -> Dictionary:
+	return {
+		"texture_compositions": _texture_composition_count,
+		"parametric_updates": _parametric_update_count,
+	}
+
 func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 	if light == null or not is_instance_valid(light):
 		return false
+	var previous_applied_state_key: String = str(light.get_meta(GOBO_APPLIED_STATE_KEY_META_KEY, ""))
 	var previous_applied_state: Dictionary = light.get_meta(GOBO_APPLIED_STATE_META_KEY, {})
 	if previous_applied_state is not Dictionary:
 		previous_applied_state = {}
@@ -126,19 +136,26 @@ func apply_gobo_projection(light: SpotLight3D, controls: Dictionary) -> bool:
 	var mode: String = "fallback_vector"
 	if has_runtime_gobo and has_composed_texture:
 		mode = "runtime_slots"
-	var next_applied_state: Dictionary = {
+	var topology_state: Dictionary = {
 		"mode": mode,
-		"has_gobo": has_runtime_gobo,
-		"wheel_slot_index_by_wheel": wheel_slot_state,
-		"wheel_mode_by_wheel": wheel_mode_state,
-		"texture_cache_key": composed_texture_cache_key,
-		"gobo_scale": float(controls.get("gobo_scale", GOBO_DEFAULT_SCALE)),
-		"gobo_shake_tilt_deg": projected_shake_tilt_deg,
 		"prefer_native_fog_projector": prefer_native_fog_projector,
 		"has_composed_texture": has_composed_texture,
+		"texture_cache_key": composed_texture_cache_key,
+		"wheel_slot_index_by_wheel": wheel_slot_state,
+		"wheel_mode_by_wheel": wheel_mode_state,
 	}
-	var selection_or_composition_changed: bool = previous_applied_state != next_applied_state
+	var parametric_state: Dictionary = {
+		"gobo_scale": float(controls.get("gobo_scale", GOBO_DEFAULT_SCALE)),
+		"gobo_shake_tilt_deg": projected_shake_tilt_deg,
+	}
+	var next_applied_state: Dictionary = {
+		"topology": topology_state,
+		"parametric": parametric_state,
+	}
+	var next_applied_state_key: String = _build_applied_state_key(topology_state)
+	var selection_or_composition_changed: bool = previous_applied_state_key != next_applied_state_key
 	if not selection_or_composition_changed:
+		_parametric_update_count += 1
 		_apply_gobo_rotation_only(light, projected_rotation_deg, next_applied_state)
 		return false
 
@@ -523,6 +540,7 @@ func _clear_gobo_visuals(light: SpotLight3D) -> void:
 	_apply_gobo_shake_tilt_to_light(light, 0.0)
 	light.set_meta(GOBO_APPLIED_ROTATION_DEG_META_KEY, GOBO_DEFAULT_ROTATION_DEG)
 	light.remove_meta(GOBO_APPLIED_STATE_META_KEY)
+	light.remove_meta(GOBO_APPLIED_STATE_KEY_META_KEY)
 	light.remove_meta(GOBO_WHEEL_SPIN_META_KEY)
 	light.remove_meta(GOBO_WHEEL_MODE_META_KEY)
 	light.remove_meta(GOBO_WHEEL_SHAKE_PHASE_META_KEY)
@@ -532,17 +550,35 @@ func _clear_gobo_visuals(light: SpotLight3D) -> void:
 
 func _apply_gobo_rotation_only(light: SpotLight3D, projected_rotation_deg: float, applied_state: Dictionary) -> void:
 	_apply_gobo_rotation_to_light(light, projected_rotation_deg)
-	_apply_gobo_shake_tilt_to_light(light, float(applied_state.get("gobo_shake_tilt_deg", 0.0)))
+	var parametric_state: Dictionary = applied_state.get("parametric", {})
+	_apply_gobo_shake_tilt_to_light(light, float(parametric_state.get("gobo_shake_tilt_deg", 0.0)))
 	light.set_meta(GOBO_APPLIED_ROTATION_DEG_META_KEY, projected_rotation_deg)
-	light.set_meta(GOBO_APPLIED_STATE_META_KEY, applied_state.duplicate(true))
+	light.set_meta(GOBO_APPLIED_STATE_META_KEY, applied_state)
+	var topology_state: Dictionary = applied_state.get("topology", {})
+	light.set_meta(GOBO_APPLIED_STATE_KEY_META_KEY, _build_applied_state_key(topology_state))
 
 func _topology_signature_from_state(applied_state: Dictionary) -> String:
 	if applied_state.is_empty():
 		return ""
+	var topology_state: Dictionary = applied_state.get("topology", {})
+	if topology_state.is_empty():
+		return ""
 	return "%s|%s|%s" % [
-		str(applied_state.get("mode", "")),
-		str(bool(applied_state.get("prefer_native_fog_projector", true))),
-		str(bool(applied_state.get("has_composed_texture", false))),
+		str(topology_state.get("mode", "")),
+		str(bool(topology_state.get("prefer_native_fog_projector", true))),
+		str(bool(topology_state.get("has_composed_texture", false))),
+	]
+
+func _build_applied_state_key(topology_state: Dictionary) -> String:
+	var texture_key: String = str(topology_state.get("texture_cache_key", ""))
+	var wheel_slot_key: String = JSON.stringify(topology_state.get("wheel_slot_index_by_wheel", {}))
+	var wheel_mode_key: String = JSON.stringify(topology_state.get("wheel_mode_by_wheel", {}))
+	return "%s|%s|%s|%s|%s" % [
+		str(topology_state.get("mode", "")),
+		str(bool(topology_state.get("prefer_native_fog_projector", true))),
+		str(bool(topology_state.get("has_composed_texture", false))),
+		texture_key,
+		wheel_slot_key + "|" + wheel_mode_key,
 	]
 
 func _ensure_gobo_plane(light: SpotLight3D) -> MeshInstance3D:
@@ -736,6 +772,7 @@ func _compose_gobo_textures(textures: Array[Texture2D], composed_cache_key: Stri
 				composed.set_pixel(x, y, Color(out_luma, out_luma, out_luma, out_luma))
 
 	var out_texture: ImageTexture = ImageTexture.create_from_image(composed)
+	_texture_composition_count += 1
 	if textures.size() == 1:
 		_copy_vector_metadata(out_texture, textures[0])
 	_texture_cache[cache_key] = out_texture

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -152,6 +152,8 @@ var _user_preferences: UserPreferences
 var _debug_properties_applied: int = 0
 var _debug_properties_skipped: int = 0
 var _selected_fixture_badge_uuid: String = ""
+var _emitter_mesh_rebuild_count: int = 0
+var _emitter_parametric_update_count: int = 0
 
 const DEBUG_TOGGLE_KEY: Key = KEY_C
 const MANUAL_TEST_FLAG: String = "--peraviz_manual_fixture_test"
@@ -1808,17 +1810,46 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 	beam_params["intensity_max"] = BEAM_INTENSITY_MAX
 	var gobo_topology_changed: bool = false
 	if _fixture_gobo_projector != null:
-		var gobo_source_controls: Dictionary = controls
-		gobo_source_controls.merge(_resolve_gobo_controls(controls), true)
+		var resolved_gobo_controls: Dictionary = _resolve_gobo_controls(controls)
+		var gobo_source_controls: Dictionary = {
+			"capabilities": controls.get("capabilities", {}),
+			"gobo_norm": controls.get("gobo_norm", 0.0),
+			"gobo_raw_value": controls.get("gobo_raw_value", 0),
+			"gobo_resolution_bits": controls.get("gobo_resolution_bits", 8),
+			"gobo_index_norm": controls.get("gobo_index_norm", 0.0),
+			"has_gobo_index": controls.get("has_gobo_index", false),
+			"gobo_rotation_deg": controls.get("gobo_rotation_deg", 0.0),
+			"gobo_debug_override_enabled": controls.get("gobo_debug_override_enabled", false),
+			"gobo_debug_comparison_mode": controls.get("gobo_debug_comparison_mode", 0),
+			"gobo_debug_shake_enabled": controls.get("gobo_debug_shake_enabled", false),
+			"gobo_debug_shake_amplitude_deg": controls.get("gobo_debug_shake_amplitude_deg", 0.0),
+			"gobo_debug_shake_frequency_hz": controls.get("gobo_debug_shake_frequency_hz", 0.0),
+			"gobo_debug_shake_waveform": controls.get("gobo_debug_shake_waveform", 0),
+			"frame_delta_sec": controls.get("frame_delta_sec", 0.0),
+			"prefer_native_fog_projector": controls.get("prefer_native_fog_projector", true),
+			"gobo_scale": controls.get("gobo_scale", GOBO_DEFAULT_SCALE),
+			"gobo_slots": resolved_gobo_controls.get("gobo_slots", []),
+			"gobo_runtime_bindings": resolved_gobo_controls.get("gobo_runtime_bindings", []),
+			"has_gobo": resolved_gobo_controls.get("has_gobo", false),
+			"gobo_ranges": resolved_gobo_controls.get("gobo_ranges", controls.get("gobo_ranges", [])),
+		}
 		var gobo_controls: Dictionary = BeamOpticsControllerScript.BuildGoboControls(gobo_source_controls, _visual_settings, beam_defaults)
 		gobo_topology_changed = _fixture_gobo_projector.apply_gobo_projection(light, gobo_controls)
 		_set_light_meta_variant(light, "peraviz_last_gobo_key", str(gobo_controls.get("key", "")), last_state)
 		var applied_gobo_rotation_deg: float = float(light.get_meta("peraviz_gobo_applied_rotation_deg", beam_params.get("gobo_rotation_deg", 0.0)))
 		beam_params["gobo_rotation_deg"] = applied_gobo_rotation_deg
 	if gobo_topology_changed:
+		_emitter_mesh_rebuild_count += 1
 		_cleanup_light_beam_renderers(light)
 	_set_light_property_float(light, "light_volumetric_fog_energy", float(_visual_settings.get("light_volumetric_fog_energy", 12.0)) * float(_visual_settings.get("haze_density_multiplier", 0.22)), last_state)
 	_update_beam_for_light(light, beam_params)
+	_emitter_parametric_update_count += 1
+	if _fixture_gobo_projector != null:
+		light.set_meta("peraviz_gobo_debug_counters", _fixture_gobo_projector.get_debug_counters())
+	light.set_meta("peraviz_emitter_debug_counters", {
+		"mesh_rebuilds": _emitter_mesh_rebuild_count,
+		"parametric_updates": _emitter_parametric_update_count,
+	})
 
 func _get_or_create_emitter_last_state(light: SpotLight3D) -> Dictionary:
 	var key: int = light.get_instance_id()

--- a/peraviz/scripts/load_scene.gd
+++ b/peraviz/scripts/load_scene.gd
@@ -1827,7 +1827,7 @@ func _apply_emitter_light_state(light: SpotLight3D, photometric: Dictionary, nor
 			"gobo_debug_shake_waveform": controls.get("gobo_debug_shake_waveform", 0),
 			"frame_delta_sec": controls.get("frame_delta_sec", 0.0),
 			"prefer_native_fog_projector": controls.get("prefer_native_fog_projector", true),
-			"gobo_scale": controls.get("gobo_scale", GOBO_DEFAULT_SCALE),
+			"gobo_scale": controls.get("gobo_scale", 1.0),
 			"gobo_slots": resolved_gobo_controls.get("gobo_slots", []),
 			"gobo_runtime_bindings": resolved_gobo_controls.get("gobo_runtime_bindings", []),
 			"has_gobo": resolved_gobo_controls.get("has_gobo", false),


### PR DESCRIPTION
### Motivation
- Prevent accidental merging of arbitrary control dictionaries and make gobo inputs explicit to avoid hidden state coupling by replacing `merge` with a minimal `gobo_source_controls` payload in `_apply_emitter_light_state`.
- Distinguish changes that require expensive topology recomposition from cheap parametric updates so the renderer can avoid unnecessary rebuilds.
- Provide runtime counters to measure how often texture composition, mesh rebuilds and parametric updates occur for diagnostics and tuning.

### Description
- Replaced the generic `merge` usage in `_apply_emitter_light_state` and construct a minimal `gobo_source_controls` dictionary with only required keys before calling `BuildGoboControls` in `peraviz/scripts/load_scene.gd`.
- Split the applied gobo state into `topology` and `parametric` sections and switched to a compact, hashable topology key via `GOBO_APPLIED_STATE_KEY_META_KEY` and `_build_applied_state_key` in `peraviz/scripts/fixture_gobo_projector.gd` to detect rebuild-triggering changes instead of deep equality on duplicated dictionaries.
- Added fast-path parametric detection (rotation/shake/scale) that increments a parametric counter and avoids full recomposition when only uniforms/transforms change.
- Added counters and debug metadata: `_texture_composition_count` and `_parametric_update_count` in `fixture_gobo_projector.gd`, and `_emitter_mesh_rebuild_count` and `_emitter_parametric_update_count` in `load_scene.gd`; counters are exposed on lights as `peraviz_gobo_debug_counters` and `peraviz_emitter_debug_counters` and `get_debug_counters()` is provided.
- Incremented `_texture_composition_count` in `_compose_gobo_textures`, incremented emitter rebuild/parametric counts at appropriate points, and removed redundant deep-duplication of applied state.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5038a42288324971c5a710895f2c2)