### PR TITLE
Optimize DMX time-tick updates to time-dependent fixtures only

### DIFF
--- a/peraviz/scripts/controllers/dmx_controller.gd
+++ b/peraviz/scripts/controllers/dmx_controller.gd
@@ -250,7 +250,7 @@ func _apply_fixture_time_tick(delta_sec: float) -> void:
 		return
 	if _dmx_fixture_runtime == null or not _apply_dmx_controls_callback.is_valid():
 		return
-	for fixture_uuid in _dmx_fixture_runtime.get_bound_fixture_ids():
+	for fixture_uuid in _dmx_fixture_runtime.get_time_tick_fixture_ids():
 		_apply_dmx_controls_callback.call(str(fixture_uuid), {
 			"frame_delta_sec": delta_sec,
 			"time_tick_only": true,

--- a/peraviz/scripts/dmx_fixture_runtime.gd
+++ b/peraviz/scripts/dmx_fixture_runtime.gd
@@ -22,6 +22,8 @@ var _fixture_nodes: Dictionary = {}
 var _fixture_channel_offsets: Dictionary = {}
 var _fixture_snapshot_cache: Dictionary = {}
 var _used_universes: Dictionary = {}
+var _fixture_time_tick_flags: Dictionary = {}
+var _time_tick_fixture_ids := PackedStringArray()
 var _gobo_vectorization_cache: GoboVectorizationCache = null
 var _debug_force_full_apply: bool = false
 
@@ -37,6 +39,8 @@ func rebuild(universe_offset: int) -> Dictionary:
 	_fixture_channel_offsets.clear()
 	_fixture_snapshot_cache.clear()
 	_used_universes.clear()
+	_fixture_time_tick_flags.clear()
+	_time_tick_fixture_ids = PackedStringArray()
 
 	if _loader == null or _scene_registry == null:
 		return {
@@ -67,6 +71,10 @@ func rebuild(universe_offset: int) -> Dictionary:
 			continue
 		_fixture_nodes[fixture_uuid] = fixture_node
 		_fixture_channel_offsets[fixture_uuid] = _collect_used_channel_offsets(binding)
+		var requires_time_tick: bool = _binding_requires_time_tick(binding)
+		_fixture_time_tick_flags[fixture_uuid] = requires_time_tick
+		if requires_time_tick:
+			_time_tick_fixture_ids.append(fixture_uuid)
 		var universe_id: int = int(binding.get("artnet_universe_id", -1))
 		if universe_id >= 0:
 			_used_universes[universe_id] = true
@@ -81,6 +89,53 @@ func get_bound_fixture_ids() -> PackedStringArray:
 	for fixture_uuid in _fixture_nodes.keys():
 		fixture_ids.append(str(fixture_uuid))
 	return fixture_ids
+
+
+func get_time_tick_fixture_ids() -> PackedStringArray:
+	return _time_tick_fixture_ids
+
+func _binding_requires_time_tick(binding: Dictionary) -> bool:
+	var channel_bindings: Array = binding.get("channel_bindings", [])
+	for channel_binding in channel_bindings:
+		if _value_contains_time_tick_signal(channel_binding):
+			return true
+	if _value_contains_time_tick_signal(binding.get("capabilities", [])):
+		return true
+	return false
+
+func _value_contains_time_tick_signal(value: Variant) -> bool:
+	if value is Dictionary:
+		var row: Dictionary = value
+		for key in row.keys():
+			if _string_requires_time_tick(str(key)):
+				return true
+			if _value_contains_time_tick_signal(row.get(key, null)):
+				return true
+		return false
+	if value is Array:
+		for item in value:
+			if _value_contains_time_tick_signal(item):
+				return true
+		return false
+	if value is String:
+		return _string_requires_time_tick(str(value))
+	return false
+
+func _string_requires_time_tick(value: String) -> bool:
+	var normalized: String = value.to_lower()
+	if normalized.find("strobe") >= 0:
+		return true
+	if normalized.find("shake") >= 0:
+		return true
+	if normalized.find("rotation") >= 0:
+		return true
+	if normalized.find("rotate") >= 0:
+		return true
+	if normalized.find("continuous") >= 0:
+		return true
+	if normalized.find("speed") >= 0:
+		return true
+	return false
 
 func apply_dmx(receiver, apply_fixture_callback: Callable) -> Dictionary:
 	if receiver == null or not receiver.is_running():


### PR DESCRIPTION
### Motivation
- Reduce per-frame work by avoiding sending time-tick updates to fixtures that have no time-dependent capabilities (strobe, shake, rotation, continuous speed, etc.).
- Cache the set of fixtures that actually require time ticks during `rebuild()` so the runtime does not re-evaluate bindings each frame.

### Description
- Added per-fixture state in `DmxFixtureRuntime`: `_fixture_time_tick_flags` and a cached `PackedStringArray` `_time_tick_fixture_ids` that are cleared and rebuilt inside `rebuild()`.
- During `rebuild()` each binding is analyzed and a `requires_time_tick` flag is computed and stored, and fixtures requiring ticks are appended to `_time_tick_fixture_ids`.
- Added `get_time_tick_fixture_ids()` plus helper detection functions ` _binding_requires_time_tick `, ` _value_contains_time_tick_signal `, and ` _string_requires_time_tick ` to inspect `channel_bindings` and `capabilities` for keywords like `strobe`, `shake`, `rotation`, `continuous`, and `speed`.
- Updated `DmxController._apply_fixture_time_tick()` to iterate `DmxFixtureRuntime.get_time_tick_fixture_ids()` instead of `get_bound_fixture_ids()` so only time-dependent fixtures receive tick-only updates.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f50bee9a088324ae60219dc880490d)