### PR TITLE
Apply 3DS local origin translation when basis is identity

### DIFF
--- a/viewer3d/loader3ds.cpp
+++ b/viewer3d/loader3ds.cpp
@@ -68,6 +68,14 @@ static bool IsIdentityBasis(const MeshTransform3ds& transform)
            almostEqual(transform.zAxis[2], 1.0f);
 }
 
+static bool IsZeroVector(const std::array<float, 3>& vector)
+{
+    constexpr float kEpsilon = 1e-5f;
+    return std::abs(vector[0]) <= kEpsilon &&
+           std::abs(vector[1]) <= kEpsilon &&
+           std::abs(vector[2]) <= kEpsilon;
+}
+
 static bool EnsureImageHandlersInitialized()
 {
     static bool imageHandlersInitialized = false;
@@ -373,7 +381,8 @@ static void parseMesh(std::ifstream& file, long endPos, Mesh& mesh, size_t verte
     }
 
     const bool shouldApplyLocalBasis = hasLocalTransform && !IsIdentityBasis(localTransform);
-    if (objectVertexCount > 0 && (shouldApplyLocalBasis || hasPivot)) {
+    const bool hasOriginTranslation = hasLocalTransform && !IsZeroVector(localTransform.origin);
+    if (objectVertexCount > 0 && (shouldApplyLocalBasis || hasOriginTranslation || hasPivot)) {
         for (size_t i = 0; i < objectVertexCount; ++i) {
             const size_t index = (objectVertexStart + i) * 3;
             float x = mesh.vertices[index];
@@ -402,6 +411,10 @@ static void parseMesh(std::ifstream& file, long endPos, Mesh& mesh, size_t verte
                 mesh.vertices[index] = tx;
                 mesh.vertices[index + 1] = ty;
                 mesh.vertices[index + 2] = tz;
+            } else if (hasOriginTranslation) {
+                mesh.vertices[index] = x + localTransform.origin[0];
+                mesh.vertices[index + 1] = y + localTransform.origin[1];
+                mesh.vertices[index + 2] = z + localTransform.origin[2];
             } else {
                 mesh.vertices[index] = x;
                 mesh.vertices[index + 1] = y;


### PR DESCRIPTION
### Motivation
- A regression caused 3DS local `origin` (chunk `0x4160`) to be ignored when the local basis was identity, which can misplace parts in GDTFs exported by WYSIWYG and appear as incorrect primitive handling.  
- The intent is to preserve existing pivot and basis application behavior while ensuring non-zero origin offsets are still applied even if axes are identity.  
- This change targets correct spatial placement of mesh parts so real `.3ds` files are not treated/positioned incorrectly compared to the earlier commit range inspected.

### Description
- Add `IsZeroVector(...)` helper and compute `hasOriginTranslation` to detect non-zero `origin` in `MeshTransform3ds`.  
- Extend the mesh post-processing condition to run when `shouldApplyLocalBasis || hasOriginTranslation || hasPivot`.  
- When basis is identity but `origin` is non-zero, apply translation by adding `localTransform.origin` to vertex positions without changing existing basis/pivot logic.  
- Change is localized to `viewer3d/loader3ds.cpp` and preserves the GDTF loader fallback behavior that prefers real model files over primitives.

### Testing
- Ran the repository guard scripts `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both completed `OK`.  
- No other automated tests were added or modified in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9e9fd5378832484ef6ec5e7984267)