### PR TITLE
Fix GDTF 3DS loading to avoid double local transforms

### DIFF
--- a/viewer3d/gdtfloader.cpp
+++ b/viewer3d/gdtfloader.cpp
@@ -1230,7 +1230,7 @@ static void ParseGeometry(tinyxml2::XMLElement* node,
                         if (!alreadyFailed) {
                             bool loaded = false;
                             if (HasExtension(path, ".3ds"))
-                                loaded = Load3DS(path, mesh);
+                                loaded = Load3DS(path, mesh, false);
                             else if (HasExtension(path, ".glb"))
                                 loaded = LoadGLB(path, mesh);
 

--- a/viewer3d/loader3ds.cpp
+++ b/viewer3d/loader3ds.cpp
@@ -51,6 +51,7 @@ struct MeshTransform3ds {
     std::array<float, 3> origin = {0.0f, 0.0f, 0.0f};
 };
 
+// Returns whether a 3DS local basis is effectively an identity basis.
 static bool IsIdentityBasis(const MeshTransform3ds& transform)
 {
     constexpr float kEpsilon = 1e-5f;
@@ -259,9 +260,10 @@ static std::array<float, 3> readColorChunk(std::ifstream& file, long endPos, boo
     return c;
 }
 
+// Parses one TRIANGULAR MESH chunk and appends its geometry into the output mesh.
 static void parseMesh(std::ifstream& file, long endPos, Mesh& mesh, size_t vertexBase,
                       const std::unordered_map<std::string, std::array<float, 3>>& materials,
-                      FaceColorAccum& colorAccum)
+                      FaceColorAccum& colorAccum, bool applyObjectLocalTransform)
 {
     size_t objectVertexStart = vertexBase;
     size_t objectVertexCount = 0;
@@ -372,15 +374,17 @@ static void parseMesh(std::ifstream& file, long endPos, Mesh& mesh, size_t verte
         }
     }
 
-    const bool shouldApplyLocalBasis = hasLocalTransform && !IsIdentityBasis(localTransform);
-    if (objectVertexCount > 0 && (shouldApplyLocalBasis || hasPivot)) {
+    const bool shouldApplyLocalBasis = applyObjectLocalTransform &&
+                                       hasLocalTransform &&
+                                       !IsIdentityBasis(localTransform);
+    if (objectVertexCount > 0 && (shouldApplyLocalBasis || (applyObjectLocalTransform && hasPivot))) {
         for (size_t i = 0; i < objectVertexCount; ++i) {
             const size_t index = (objectVertexStart + i) * 3;
             float x = mesh.vertices[index];
             float y = mesh.vertices[index + 1];
             float z = mesh.vertices[index + 2];
 
-            if (hasPivot) {
+            if (applyObjectLocalTransform && hasPivot) {
                 x -= pivot[0];
                 y -= pivot[1];
                 z -= pivot[2];
@@ -411,7 +415,8 @@ static void parseMesh(std::ifstream& file, long endPos, Mesh& mesh, size_t verte
     }
 }
 
-bool Load3DS(const std::string& path, Mesh& outMesh)
+// Loads mesh/object data from a 3DS file, with optional local transform application.
+bool Load3DS(const std::string& path, Mesh& outMesh, bool applyObjectLocalTransform)
 {
     std::ifstream file(path, std::ios::binary);
     if(!file.is_open())
@@ -446,7 +451,8 @@ bool Load3DS(const std::string& path, Mesh& outMesh)
                         long me = md + mc.length - 6;
                         if(mc.id == 0x4100) {
                             size_t base = outMesh.vertices.size() / 3;
-                            parseMesh(file, me, outMesh, base, materials, colorAccum);
+                            parseMesh(file, me, outMesh, base, materials, colorAccum,
+                                      applyObjectLocalTransform);
                         } else {
                             file.seekg(me);
                         }

--- a/viewer3d/loader3ds.h
+++ b/viewer3d/loader3ds.h
@@ -19,5 +19,5 @@
 #include <string>
 #include "mesh.h"
 
-// Very small parser for Discreet 3DS files loading only vertex and face data.
-bool Load3DS(const std::string& path, Mesh& outMesh);
+// Loads a 3DS mesh and optionally applies per-object local pivot/basis transforms.
+bool Load3DS(const std::string& path, Mesh& outMesh, bool applyObjectLocalTransform = true);


### PR DESCRIPTION
### Motivation
- Recent changes began applying 3DS per-object local basis/pivot chunks (0x4160/0x4165) during 3DS import which, when combined with GDTF XML hierarchy transforms, can double-apply transforms and produce separated/mis-rotated parts for some WYSIWYG-generated GDTFs. 
- The loader should preserve richer 3DS behavior for general use while keeping GDTF imports compatible with GDTF hierarchy transforms.
- Also verified that primitive selection is not done by filename alone; GDTF falls back to PrimitiveType only when a model file is missing or fails to load.

### Description
- Added an optional `applyObjectLocalTransform` parameter to `Load3DS` (`viewer3d/loader3ds.h`) defaulting to `true` so callers can control whether 3DS object local pivot/basis transforms are baked into vertices. 
- Modified the `parseMesh` implementation in `viewer3d/loader3ds.cpp` to accept the new flag and only apply pivot (0x4165) and local-basis (0x4160) adjustments when the flag is enabled. 
- Updated `viewer3d/gdtfloader.cpp` to call `Load3DS(path, mesh, false)` for GDTF model loading, preserving the previous behavior where the GDTF XML hierarchy is the single source of per-part transforms. 
- Kept the default `Load3DS` behavior as `true` to avoid regressions for non-GDTF users, and added concise one-line English comments above the modified functions (`IsIdentityBasis`, `parseMesh`, and `Load3DS`) per repository guidelines.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa4ff5122883249e1e72cbf52e3780)