### PR TITLE
Optimize MVR patched GDTF generation with deterministic export-run cache

### DIFF
--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -1080,6 +1080,28 @@ static bool ZipDir(const std::string &srcDir, const std::string &dstZip) {
   return true;
 }
 
+// Builds a deterministic cache key for a patched GDTF variant from source path and overrides.
+static std::string BuildPatchedGdtfCacheKey(const std::string &gdtfPath,
+                                            const GdtfOverrides &ov) {
+  std::ostringstream key;
+  key << "path=" << gdtfPath
+      << "|color=" << ov.color
+      << "|hasWeightKg=" << ov.hasWeightKg
+      << "|weightKg=" << ov.weightKg
+      << "|hasPowerW=" << ov.hasPowerW
+      << "|powerW=" << ov.powerW
+      << "|hasLengthMm=" << ov.hasLengthMm
+      << "|lengthMm=" << ov.lengthMm
+      << "|hasWidthMm=" << ov.hasWidthMm
+      << "|widthMm=" << ov.widthMm
+      << "|hasHeightMm=" << ov.hasHeightMm
+      << "|heightMm=" << ov.heightMm
+      << "|manufacturer=" << ov.manufacturer
+      << "|model=" << ov.model;
+  return key.str();
+}
+
+// Creates a temporary patched GDTF archive that applies export-time fixture overrides.
 static std::string CreatePatchedGdtf(const std::string &gdtfPath,
                                      const GdtfOverrides &ov) {
   std::string tempDir = CreateTempDir();
@@ -1154,6 +1176,7 @@ static std::string CreatePatchedGdtf(const std::string &gdtfPath,
   return outPath;
 }
 
+// Exports the current scene into an MVR package with resolved and validated resources.
 bool MvrExporter::ExportToFile(const std::string &filePath) {
   const auto &scene = ConfigManager::Get().GetScene();
   const TrussGeometryAuthority trussGeometryAuthority = GetTrussGeometryAuthoritySetting();
@@ -2534,18 +2557,38 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
 
   std::unordered_map<std::string, int> plannedArchiveEntries;
   plannedArchiveEntries["GeneralSceneDescription.xml"] = 1;
+  std::unordered_map<std::string, std::string> patchedGdtfPathByCacheKey;
+  int patchedGdtfGenerated = 0;
+  int patchedGdtfReused = 0;
 
   for (auto &entry : resourceEntries) {
     if (!fs::exists(entry.sourcePath))
       continue;
     auto cit = gdtfOverrides.find(entry.archivePath);
     if (cit != gdtfOverrides.end()) {
-      std::string tmp = CreatePatchedGdtf(entry.sourcePath.string(), cit->second);
-      if (!tmp.empty())
-        entry.sourcePath = fs::path(tmp);
+      const std::string cacheKey =
+          BuildPatchedGdtfCacheKey(entry.sourcePath.string(), cit->second);
+      auto cacheIt = patchedGdtfPathByCacheKey.find(cacheKey);
+      if (cacheIt != patchedGdtfPathByCacheKey.end()) {
+        entry.sourcePath = fs::path(cacheIt->second);
+        ++patchedGdtfReused;
+      } else {
+        std::string tmp = CreatePatchedGdtf(entry.sourcePath.string(), cit->second);
+        if (!tmp.empty()) {
+          patchedGdtfPathByCacheKey.emplace(cacheKey, tmp);
+          entry.sourcePath = fs::path(tmp);
+          ++patchedGdtfGenerated;
+        }
+      }
     }
     ++plannedArchiveEntries[entry.archivePath];
   }
+
+  Logger::Instance().Log(
+      Logger::Level::Info,
+      wxString::Format("MVR export patched_gdtf_generated=%d patched_gdtf_reused=%d",
+                       patchedGdtfGenerated, patchedGdtfReused)
+          .ToStdString());
 
   if (!ValidateMvr16Export(doc, gdtfArchiveByObjectUuid, plannedArchiveEntries)) {
     zip.Close();


### PR DESCRIPTION
### Motivation
- Reduce repeated work during a single MVR export by reusing identical patched GDTF archives instead of regenerating them for every resource entry.
- Provide deterministic cache keys derived from original GDTF path and override fields so identical override sets map to the same patched artifact.
- The change touches `mvr/mvrexporter.cpp` (a large hotspot); per repo guidance, consider extracting patched-GDTF responsibilities into a small helper/source file in a follow-up to keep the file modular.

### Description
- Added `BuildPatchedGdtfCacheKey(...)` to build a deterministic key from the source GDTF path and all relevant `GdtfOverrides` fields.
- Added an in-memory per-export cache (`patchedGdtfPathByCacheKey`) in `MvrExporter::ExportToFile` to map cache key -> patched temp path and reuse patches when the same key is encountered.
- Ensured `CreatePatchedGdtf(...)` is only called on the first encounter of a unique key and preserved fallback behavior (if patching fails, the original resource path is kept).
- Added profiling counters and an info log (`patched_gdtf_generated` / `patched_gdtf_reused`) and brief one-line comments above the newly touched function definitions.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fae47a3e788324805832e24f672b65)