### PR TITLE
Improve ZIP entry compression policy and add export size/duration metrics

### DIFF
--- a/core/configservices.cpp
+++ b/core/configservices.cpp
@@ -144,6 +144,18 @@ std::string ToLowerCopy(std::string text) {
                  [](unsigned char c) { return std::tolower(c); });
   return text;
 }
+
+// Chooses ZIP compression mode from entry extension and payload size heuristics.
+int SelectZipCompressionMethod(const std::string &entryName, size_t payloadSize) {
+  const std::string ext = fs::path(ToLowerCopy(entryName)).extension().string();
+  if (ext == ".mvr" || ext == ".gdtf" || ext == ".png" || ext == ".jpg" ||
+      ext == ".jpeg" || ext == ".zip" || ext == ".gz" || ext == ".7z" ||
+      ext == ".pdf")
+    return wxZIP_METHOD_STORE;
+  if (payloadSize < 96)
+    return wxZIP_METHOD_STORE;
+  return wxZIP_METHOD_DEFLATE;
+}
 } // namespace
 
 void UserPreferencesStore::SetValue(const std::string &key,
@@ -584,7 +596,8 @@ bool ProjectSession::SaveProject(
   if (!saveConfigToBuffer(configBytes))
     return false;
   auto *configEntry = new wxZipEntry("config.json");
-  configEntry->SetMethod(wxZIP_METHOD_DEFLATE);
+  configEntry->SetMethod(
+      SelectZipCompressionMethod("config.json", configBytes.size()));
   if (!zip.PutNextEntry(configEntry))
     return false;
   if (!configBytes.empty()) {
@@ -603,7 +616,8 @@ bool ProjectSession::SaveProject(
   if (!saveSceneToBuffer(sceneBytes))
     return false;
   auto *sceneEntry = new wxZipEntry("scene.mvr");
-  sceneEntry->SetMethod(wxZIP_METHOD_DEFLATE);
+  sceneEntry->SetMethod(
+      SelectZipCompressionMethod("scene.mvr", sceneBytes.size()));
   if (!zip.PutNextEntry(sceneEntry))
     return false;
   if (!sceneBytes.empty()) {
@@ -621,6 +635,7 @@ bool ProjectSession::SaveProject(
   if (!zip.Close())
     return false;
   const auto finalizeEnd = std::chrono::steady_clock::now();
+  const std::uintmax_t archiveBytes = fs::file_size(PathFromUtf8(path));
 
   auto elapsedMs = [](const auto &start, const auto &end) {
     return std::chrono::duration_cast<std::chrono::milliseconds>(end - start)
@@ -630,7 +645,10 @@ bool ProjectSession::SaveProject(
             << elapsedMs(configStart, configEnd)
             << ", scene=" << elapsedMs(sceneStart, sceneEnd)
             << ", finalize=" << elapsedMs(finalizeStart, finalizeEnd)
-            << ", total=" << elapsedMs(stageStart, finalizeEnd) << std::endl;
+            << ", total=" << elapsedMs(stageStart, finalizeEnd)
+            << " | sizes [bytes] input="
+            << (configBytes.size() + sceneBytes.size())
+            << ", archive=" << archiveBytes << std::endl;
 
   return true;
 }

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -1054,6 +1054,20 @@ static bool ExtractZip(const std::string &zipPath, const std::string &destDir) {
   return true;
 }
 
+// Chooses ZIP compression mode from entry extension and source size heuristics.
+static int SelectZipCompressionMethod(const std::string &entryName,
+                                      std::uintmax_t sourceSize) {
+  const std::string ext = ToLowerAscii(fs::path(entryName).extension().string());
+  if (ext == ".mvr" || ext == ".gdtf" || ext == ".png" || ext == ".jpg" ||
+      ext == ".jpeg" || ext == ".zip" || ext == ".gz" || ext == ".7z" ||
+      ext == ".pdf")
+    return wxZIP_METHOD_STORE;
+  if (sourceSize < 96)
+    return wxZIP_METHOD_STORE;
+  return wxZIP_METHOD_DEFLATE;
+}
+
+// Packs a directory recursively into a ZIP archive using per-entry compression heuristics.
 static bool ZipDir(const std::string &srcDir, const std::string &dstZip) {
   wxFileOutputStream output(dstZip);
   if (!output.IsOk())
@@ -1064,7 +1078,8 @@ static bool ZipDir(const std::string &srcDir, const std::string &dstZip) {
       continue;
     fs::path rel = fs::relative(p.path(), srcDir);
     auto *e = new wxZipEntry(rel.generic_string());
-    e->SetMethod(wxZIP_METHOD_DEFLATE);
+    const auto sourceSize = p.file_size();
+    e->SetMethod(SelectZipCompressionMethod(rel.generic_string(), sourceSize));
     zip.PutNextEntry(e);
     std::ifstream in(p.path(), std::ios::binary);
     char buf[4096];
@@ -1178,6 +1193,7 @@ static std::string CreatePatchedGdtf(const std::string &gdtfPath,
 
 // Exports the current scene into an MVR package with resolved and validated resources.
 bool MvrExporter::ExportToFile(const std::string &filePath) {
+  const auto exportStart = std::chrono::steady_clock::now();
   const auto &scene = ConfigManager::Get().GetScene();
   const TrussGeometryAuthority trussGeometryAuthority = GetTrussGeometryAuthoritySetting();
   std::unordered_map<std::string, std::string> positions;
@@ -2608,7 +2624,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
       return false;
     }
     auto *entry = new wxZipEntry("GeneralSceneDescription.xml");
-    entry->SetMethod(wxZIP_METHOD_DEFLATE);
+    entry->SetMethod(
+        SelectZipCompressionMethod("GeneralSceneDescription.xml", xmlData.size()));
     zip.PutNextEntry(entry);
     zip.Write(xmlData.c_str(), xmlData.size());
     zip.CloseEntry();
@@ -2623,7 +2640,10 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
       return false;
     }
     auto *e = new wxZipEntry(resource.archivePath);
-    e->SetMethod(wxZIP_METHOD_DEFLATE);
+    std::error_code ec;
+    const auto sourceSize = fs::file_size(resource.sourcePath, ec);
+    e->SetMethod(
+        SelectZipCompressionMethod(resource.archivePath, ec ? 0 : sourceSize));
     zip.PutNextEntry(e);
     std::ifstream in(resource.sourcePath, std::ios::binary);
     char buf[4096];
@@ -2637,5 +2657,25 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
   }
 
   zip.Close();
+  const auto exportEnd = std::chrono::steady_clock::now();
+  std::error_code archiveEc;
+  const auto archiveSize = fs::file_size(filePath, archiveEc);
+  std::uintmax_t sourceBytes = xmlData.size();
+  for (const auto &resource : resourceEntries) {
+    if (!fs::exists(resource.sourcePath))
+      continue;
+    std::error_code sizeEc;
+    sourceBytes += fs::file_size(resource.sourcePath, sizeEc);
+  }
+  Logger::Instance().Log(
+      Logger::Level::Info,
+      wxString::Format(
+          "MVR export metrics duration_ms=%lld source_bytes=%llu archive_bytes=%llu",
+          static_cast<long long>(std::chrono::duration_cast<std::chrono::milliseconds>(
+                                     exportEnd - exportStart)
+                                     .count()),
+          static_cast<unsigned long long>(sourceBytes),
+          static_cast<unsigned long long>(archiveEc ? 0 : archiveSize))
+          .ToStdString());
   return true;
 }


### PR DESCRIPTION
### Motivation
- Reduce wasted CPU and avoid re-compressing already-compressed/binary resources when writing project and MVR archives by choosing per-entry compression methods. 
- Provide lightweight instrumentation to measure save/export duration and compare aggregate input bytes vs produced archive size for regression analysis.

### Description
- Added `SelectZipCompressionMethod` in `core/configservices.cpp` and `mvr/mvrexporter.cpp` to pick `STORE` or `DEFLATE` based on entry extension and small-size heuristics (explicitly treating `.mvr`, `.gdtf`, common image and archive extensions, and very small payloads as `STORE`).
- Replaced unconditional `wxZIP_METHOD_DEFLATE` calls with `SelectZipCompressionMethod(...)` when creating `wxZipEntry` for project save entries (`config.json`, `scene.mvr`) and in MVR export for `GeneralSceneDescription.xml` and resource entries, as well as in the helper `ZipDir` used by patched GDTF creation.
- Added logging/instrumentation to `ProjectSession::SaveProject` to print per-stage timings and input-bytes vs archive-bytes, and to `MvrExporter::ExportToFile` to log export duration, summed source bytes, and final archive size.
- Kept archive entry names and archive layout unchanged so import/read paths remain compatible.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it reported OK.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it reported OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fae612a4548324969910d497c616b2)