### PR TITLE
Migrate ConfigManager project save flow to buffer-based scene callback

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -458,24 +458,8 @@ bool ConfigManager::SaveProject(const std::string &path) {
         return true;
       },
       [](std::vector<uint8_t> &sceneBytes) {
-        std::error_code ec;
-        const auto stamp =
-            std::chrono::system_clock::now().time_since_epoch().count();
-        const std::filesystem::path scenePath =
-            std::filesystem::temp_directory_path(ec) /
-            ("psp_scene_" + std::to_string(stamp) + ".mvr");
-        if (ec)
-          return false;
         MvrExporter exporter;
-        if (!exporter.ExportToFile(scenePath.string()))
-          return false;
-        std::ifstream in(scenePath, std::ios::binary);
-        if (!in.is_open())
-          return false;
-        sceneBytes.assign(std::istreambuf_iterator<char>(in),
-                          std::istreambuf_iterator<char>());
-        std::filesystem::remove(scenePath, ec);
-        return in.good() || in.eof();
+        return exporter.ExportToBuffer(sceneBytes);
       });
   if (ok)
     projectSession.MarkSaved();

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -2679,3 +2679,25 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
           .ToStdString());
   return true;
 }
+
+// Exports the current scene into an in-memory MVR package buffer.
+bool MvrExporter::ExportToBuffer(std::vector<uint8_t> &outputBuffer) {
+  std::error_code ec;
+  const auto stamp = std::chrono::system_clock::now().time_since_epoch().count();
+  const fs::path scenePath =
+      fs::temp_directory_path(ec) / ("psp_scene_" + std::to_string(stamp) + ".mvr");
+  if (ec)
+    return false;
+  if (!ExportToFile(scenePath.string()))
+    return false;
+  std::ifstream in(scenePath, std::ios::binary);
+  if (!in.is_open()) {
+    fs::remove(scenePath, ec);
+    return false;
+  }
+  outputBuffer.assign(std::istreambuf_iterator<char>(in),
+                      std::istreambuf_iterator<char>());
+  const bool readOk = in.good() || in.eof();
+  fs::remove(scenePath, ec);
+  return readOk;
+}

--- a/mvr/mvrexporter.h
+++ b/mvr/mvrexporter.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 // Convert a 1-based universe and channel into the MVR absolute DMX address.
 int ComputeAbsoluteDmx(int universe1Based, int address1Based);
@@ -28,4 +29,6 @@ class MvrExporter
 public:
     // Serialize the scene and write a .mvr archive at the given path
     bool ExportToFile(const std::string& filePath);
+    // Serialize the scene into an in-memory .mvr archive buffer.
+    bool ExportToBuffer(std::vector<uint8_t>& outputBuffer);
 };


### PR DESCRIPTION
### Motivation
- Stop saving the scene via ad-hoc temp-file plumbing inside `ConfigManager::SaveProject` and move to a buffer-based callback so the project session can package payloads directly.
- Provide an exporter API that can produce an in-memory MVR payload so save logic can avoid exposing paths and temporary files at the call site.

### Description
- Updated `ConfigManager::SaveProject` to pass two buffer lambdas into `ProjectSession::SaveProject`: the config lambda serializes `preferencesStore` into a `std::vector<uint8_t>`, and the scene lambda calls `MvrExporter::ExportToBuffer(sceneBytes)` to obtain the scene bytes. 
- Added `MvrExporter::ExportToBuffer(std::vector<uint8_t>&)` to `mvr/mvrexporter.h` and implemented it in `mvr/mvrexporter.cpp` to produce an in-memory archive buffer (implementation currently delegates to `ExportToFile` and reads the resulting file into the buffer). 
- Preserved the original `SaveProject` success/failure semantics and left `projectSession.MarkSaved()` behavior unchanged (only called when the project save returns success).

### Testing
- Ran the architecture guard scripts `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both returned OK.
- Performed a code search for remaining production save-path usage of the legacy path-based overload and confirmed the save path now uses the buffer-based `ProjectSession::SaveProject` call.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fae958b2308324a88ab149eb2b01cd)