### PR TITLE
Add MvrExporter::ExportToBuffer test stubs and function comments

### DIFF
--- a/tests/mvr_io_stubs.cpp
+++ b/tests/mvr_io_stubs.cpp
@@ -19,10 +19,17 @@
 #include "mvrimporter.h"
 #include "mvrexporter.h"
 
+// Returns false because MVR import is intentionally disabled in this stub.
 bool MvrImporter::ImportAndRegister(const std::string &, bool, bool, ProgressCallback) {
   return false;
 }
 
+// Returns false because file-based MVR export is intentionally disabled in this stub.
 bool MvrExporter::ExportToFile(const std::string &) {
+  return false;
+}
+
+// Returns false because buffer-based MVR export is intentionally disabled in this stub.
+bool MvrExporter::ExportToBuffer(std::vector<unsigned char> &) {
   return false;
 }

--- a/tests/riderimporter_stubs.cpp
+++ b/tests/riderimporter_stubs.cpp
@@ -29,36 +29,61 @@
 #include "mvrexporter.h"
 #include "truss.h"
 
+// Returns an empty string because PDF extraction is intentionally stubbed.
 std::string ExtractPdfText(const std::string &) { return {}; }
 
 namespace GdtfDictionary {
+// Returns an empty dictionary because loading is intentionally stubbed.
 std::optional<std::unordered_map<std::string, Entry>> Load() { return std::unordered_map<std::string, Entry>(); }
+// Returns true to simulate successful dictionary persistence in tests.
 bool Save(const std::unordered_map<std::string, Entry> &, std::string *) { return true; }
+// Returns no entry because lookup is intentionally stubbed.
 std::optional<Entry> Get(const std::string &) { return std::nullopt; }
+// Performs no operation because dictionary updates are intentionally stubbed.
 void Update(const std::string &, const std::string &, const std::string &, const std::string &) {}
+// Performs no operation because category updates are intentionally stubbed.
 void UpdateCategory(const std::string &, const std::string &) {}
+// Performs no operation because bulk category updates are intentionally stubbed.
 void UpdateCategoriesBulk(const std::unordered_map<std::string, std::string> &) {}
+// Returns zero because save-call tracking is intentionally stubbed.
 size_t GetSaveCallCountForTesting() { return 0; }
+// Performs no operation because save-call reset is intentionally stubbed.
 void ResetSaveCallCountForTesting() {}
 }
 
 namespace TrussDictionary {
+// Returns the input model unchanged because normalization is intentionally stubbed.
 std::string NormalizeModelKey(const std::string &model) { return model; }
+// Returns an empty dictionary because loading is intentionally stubbed.
 std::optional<std::unordered_map<std::string, std::string>> Load() { return std::unordered_map<std::string, std::string>(); }
+// Performs no operation because dictionary saving is intentionally stubbed.
 void Save(const std::unordered_map<std::string, std::string> &) {}
+// Returns no value because lookup is intentionally stubbed.
 std::optional<std::string> Get(const std::string &) { return std::nullopt; }
+// Performs no operation because dictionary updates are intentionally stubbed.
 void Update(const std::string &, const std::string &) {}
+// Returns false because truss-file import is intentionally disabled in this stub.
 bool ImportTrussFile(const std::string &, std::string &, std::string &) { return false; }
 }
 
+// Returns false because truss-archive loading is intentionally disabled in this stub.
 bool LoadTrussArchive(const std::string &, Truss &) { return false; }
 
+// Returns false because file-based MVR import is intentionally disabled in this stub.
 bool MvrImporter::ImportFromFile(const std::string &, bool, bool, ProgressCallback) { return false; }
+// Returns false because register-based MVR import is intentionally disabled in this stub.
 bool MvrImporter::ImportAndRegister(const std::string &, bool, bool, ProgressCallback) { return false; }
+// Returns false because file-based MVR export is intentionally disabled in this stub.
 bool MvrExporter::ExportToFile(const std::string &) { return false; }
+// Returns false because buffer-based MVR export is intentionally disabled in this stub.
+bool MvrExporter::ExportToBuffer(std::vector<unsigned char> &) { return false; }
 
 
+// Returns false because truss GDTF loading is intentionally disabled in this stub.
 bool LoadTrussGdtf(const std::string &, Truss &) { return false; }
+// Returns false because truss-definition loading is intentionally disabled in this stub.
 bool LoadTrussDefinition(const std::string &, Truss &) { return false; }
+// Returns false because legacy conversion is intentionally disabled in this stub.
 bool ConvertLegacyGtrussToGdtf(const std::filesystem::path &, const std::filesystem::path &, std::string *) { return false; }
+// Returns false because GDTF building is intentionally disabled in this stub.
 bool BuildTrussGdtfFromInstance(const Truss &, const std::filesystem::path &, std::string *) { return false; }


### PR DESCRIPTION
### Motivation
- Fix linker failure caused by an unresolved external for `MvrExporter::ExportToBuffer` referenced by `ConfigManager::SaveProject` by providing test-stub implementations.
- Keep test-only translation units coherent and documented by adding concise one-line English comments above each function definition per repository guidelines.

### Description
- Added `bool MvrExporter::ExportToBuffer(std::vector<unsigned char>&)` stubs that return `false` to `tests/mvr_io_stubs.cpp` and `tests/riderimporter_stubs.cpp` to satisfy linker references.
- Inserted one-line English comments above each touched function in both stub files to describe each function's primary purpose without changing behavior.
- Updated several existing stub functions in `tests/riderimporter_stubs.cpp` to include short explanatory comments for clarity.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which completed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faec25235c8324a36c9eff7a3ee998)