### PR TITLE
Add stream/memory MVR export and use it in project save

### DIFF
--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -18,6 +18,7 @@
 #include "configmanager.h"
 #include "json.hpp"
 #include "LayoutManager.h"
+#include "logger.h"
 #include "mvrexporter.h"
 #include "mvrimporter.h"
 #include <filesystem>
@@ -458,8 +459,18 @@ bool ConfigManager::SaveProject(const std::string &path) {
         return true;
       },
       [](std::vector<uint8_t> &sceneBytes) {
+        const auto sceneExportStart = std::chrono::steady_clock::now();
         MvrExporter exporter;
-        return exporter.ExportToBuffer(sceneBytes);
+        const bool exported = exporter.ExportToBuffer(sceneBytes);
+        const auto sceneExportEnd = std::chrono::steady_clock::now();
+        Logger::Instance().Log(
+            Logger::Level::Info,
+            "Project save scene serialization duration_ms=" +
+                std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(
+                                   sceneExportEnd - sceneExportStart)
+                                   .count()) +
+                " scene_bytes=" + std::to_string(sceneBytes.size()));
+        return exported;
       });
   if (ok)
     projectSession.MarkSaved();

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -29,6 +29,7 @@
 #include "truss_gdtf_builder.h"
 
 #include <wx/wfstream.h>
+#include <wx/mstream.h>
 #include <wx/wx.h>
 class wxZipStreamLink;
 #include <wx/filename.h>
@@ -1191,8 +1192,9 @@ static std::string CreatePatchedGdtf(const std::string &gdtfPath,
   return outPath;
 }
 
-// Exports the current scene into an MVR package with resolved and validated resources.
-bool MvrExporter::ExportToFile(const std::string &filePath) {
+// Serializes the current scene into an MVR archive written to the provided output stream.
+static bool ExportMvrArchiveToStream(wxOutputStream &output,
+                                     const std::string *archiveFilePath = nullptr) {
   const auto exportStart = std::chrono::steady_clock::now();
   const auto &scene = ConfigManager::Get().GetScene();
   const TrussGeometryAuthority trussGeometryAuthority = GetTrussGeometryAuthoritySetting();
@@ -1316,10 +1318,6 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
     }
     return {};
   };
-
-  wxFileOutputStream output(filePath);
-  if (!output.IsOk())
-    return false;
 
   wxZipOutputStream zip(output);
 
@@ -2659,7 +2657,14 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
   zip.Close();
   const auto exportEnd = std::chrono::steady_clock::now();
   std::error_code archiveEc;
-  const auto archiveSize = fs::file_size(filePath, archiveEc);
+  std::uintmax_t archiveSize = 0;
+  if (archiveFilePath != nullptr) {
+    archiveSize = fs::file_size(*archiveFilePath, archiveEc);
+  } else {
+    const wxFileOffset streamPos = output.TellO();
+    if (streamPos != wxInvalidOffset)
+      archiveSize = static_cast<std::uintmax_t>(streamPos);
+  }
   std::uintmax_t sourceBytes = xmlData.size();
   for (const auto &resource : resourceEntries) {
     if (!fs::exists(resource.sourcePath))
@@ -2680,24 +2685,25 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
   return true;
 }
 
+// Exports the current scene into an MVR package with resolved and validated resources.
+bool MvrExporter::ExportToFile(const std::string &filePath) {
+  wxFileOutputStream output(filePath);
+  if (!output.IsOk())
+    return false;
+  return ExportMvrArchiveToStream(output, &filePath);
+}
+
 // Exports the current scene into an in-memory MVR package byte buffer.
 bool MvrExporter::ExportToBuffer(std::vector<unsigned char> &outputBuffer) {
-  std::error_code ec;
-  const auto stamp = std::chrono::system_clock::now().time_since_epoch().count();
-  const fs::path scenePath =
-      fs::temp_directory_path(ec) / ("psp_scene_" + std::to_string(stamp) + ".mvr");
-  if (ec)
+  wxMemoryOutputStream memoryStream;
+  if (!ExportMvrArchiveToStream(memoryStream))
     return false;
-  if (!ExportToFile(scenePath.string()))
-    return false;
-  std::ifstream in(scenePath, std::ios::binary);
-  if (!in.is_open()) {
-    fs::remove(scenePath, ec);
-    return false;
-  }
-  outputBuffer.assign(std::istreambuf_iterator<char>(in),
-                      std::istreambuf_iterator<char>());
-  const bool readOk = in.good() || in.eof();
-  fs::remove(scenePath, ec);
-  return readOk;
+
+  const size_t archiveSize = memoryStream.GetSize();
+  outputBuffer.resize(archiveSize);
+  if (archiveSize == 0)
+    return true;
+
+  memoryStream.CopyTo(outputBuffer.data(), archiveSize);
+  return true;
 }


### PR DESCRIPTION
### Motivation
- Provide an in-memory/stream export API for MVR to avoid temp-file roundtrips during project saves and reduce save latency.
- Preserve existing file-based `ExportToFile` API for backwards compatibility while enabling direct memory exports for integration with project packaging.
- Keep error propagation identical (return `false` on failures) and leave `projectSession.MarkSaved()` behavior unchanged.

### Description
- Introduced a shared stream-targeted helper `ExportMvrArchiveToStream(wxOutputStream&, const std::string*)` that contains the MVR serialization and ZIP packaging logic and writes to any `wxOutputStream` target, implemented in `mvr/mvrexporter.cpp`.
- Made `MvrExporter::ExportToFile` delegate to the new stream helper and kept its contract intact by opening a `wxFileOutputStream` and passing the file path to the helper.
- Reworked `MvrExporter::ExportToBuffer` to write directly into a `wxMemoryOutputStream` and copy bytes into the provided buffer, removing temporary file creation and readback logic in `mvr/mvrexporter.cpp`.
- Wired the in-memory exporter into project save by calling `exporter.ExportToBuffer(sceneBytes)` in `ConfigManager::SaveProject`, added `#include "logger.h"`, and added timing logs around scene serialization to log `duration_ms` and `scene_bytes` for save latency measurements in `core/configmanager.cpp`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faee7ddf588324b113cc97c12f66bf)