### PR TITLE
mvr: document archive sink methods and confirm in-memory export path

### DIFF
--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -1203,13 +1203,17 @@ public:
 // Implements an archive sink backed by a filesystem output stream.
 class FileMvrArchiveSink final : public MvrArchiveSink {
 public:
+  // Initializes a file-backed archive sink that writes ZIP output to the requested path.
   explicit FileMvrArchiveSink(const std::string &archivePath)
       : archivePath_(archivePath), output_(archivePath) {}
 
+  // Reports whether the underlying file output stream is ready for writing.
   bool IsOk() const { return output_.IsOk(); }
 
+  // Returns the stream that receives serialized archive bytes.
   wxOutputStream &Stream() override { return output_; }
 
+  // Provides the archive file path for file-size metrics logging.
   const std::string *ArchiveFilePath() const override { return &archivePath_; }
 
 private:
@@ -1220,10 +1224,13 @@ private:
 // Implements an archive sink backed by an in-memory output stream.
 class MemoryMvrArchiveSink final : public MvrArchiveSink {
 public:
+  // Returns the in-memory stream that receives serialized archive bytes.
   wxOutputStream &Stream() override { return output_; }
 
+  // Indicates that this sink has no filesystem archive path metadata.
   const std::string *ArchiveFilePath() const override { return nullptr; }
 
+  // Copies the in-memory archive bytes into the caller-provided output buffer.
   bool ToBuffer(std::vector<unsigned char> &outputBuffer) {
     const size_t archiveSize = output_.GetSize();
     outputBuffer.resize(archiveSize);


### PR DESCRIPTION
### Motivation
- Clarify the responsibilities of the archive sink helpers so readers can reason about the in-memory vs file-backed export path without changing implementation details.
- Preserve the existing shared export pipeline (`ExportMvrArchiveToSink`) so both `ExportToFile` and `ExportToBuffer` continue to use identical validation, compression selection, and logging.

### Description
- Added concise one-line English comments above `FileMvrArchiveSink` methods (`FileMvrArchiveSink` ctor, `IsOk`, `Stream`, `ArchiveFilePath`) to document their primary purpose and return semantics.
- Added concise one-line English comments above `MemoryMvrArchiveSink` methods (`Stream`, `ArchiveFilePath`, `ToBuffer`) to document the in-memory sink behavior and buffer copying.
- Left `ExportMvrArchiveToSink`, `MvrExporter::ExportToFile`, and `MvrExporter::ExportToBuffer` logic unchanged so the shared archive-building routine is still used for both file and in-memory outputs.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faf32bc878832494e28b53a9735935)