### PR TITLE
Disable PBO texture uploads on Linux to fix blank 2D layout previews

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -391,6 +391,7 @@ bool IsPixelUnpackPboSupported() {
   return hasPboExtension;
 }
 
+// Ensures the pixel-unpack PBO exists and has enough storage for the upload.
 bool EnsurePboCapacity(unsigned int &pbo, size_t &capacity, size_t bytesNeeded) {
   if (bytesNeeded == 0)
     return false;
@@ -408,6 +409,18 @@ bool EnsurePboCapacity(unsigned int &pbo, size_t &capacity, size_t bytesNeeded) 
   return true;
 }
 
+// Returns whether this runtime should use PBO-based texture uploads.
+bool ShouldUsePboTextureUpload() {
+#if defined(__linux__)
+  // Linux AppImage GPU/driver combinations have shown intermittent blank
+  // layout view textures when PBO uploads are enabled, so prefer direct uploads.
+  return false;
+#else
+  return true;
+#endif
+}
+
+// Uploads RGBA pixels into the currently bound texture and reallocates if needed.
 bool UploadRgbaToTexture(unsigned int texture, int width, int height,
                          const unsigned char *data,
                          const wxSize &currentTextureSize, bool allowPbo) {
@@ -427,7 +440,8 @@ bool UploadRgbaToTexture(unsigned int texture, int width, int height,
       static_cast<size_t>(width) * static_cast<size_t>(height) * 4;
   bool uploaded = false;
 
-  if (allowPbo && IsPixelUnpackPboSupported() && gActivePixelUnpackPbo &&
+  if (allowPbo && ShouldUsePboTextureUpload() && IsPixelUnpackPboSupported() &&
+      gActivePixelUnpackPbo &&
       gActivePixelUnpackPboBytes &&
       EnsurePboCapacity(*gActivePixelUnpackPbo, *gActivePixelUnpackPboBytes,
                         bytesNeeded)) {
@@ -463,6 +477,7 @@ bool UploadRgbaToTexture(unsigned int texture, int width, int height,
   return uploaded;
 }
 
+// Snaps an integer coordinate to the configured layout grid step.
 int SnapToGrid(int value) {
   if (kLayoutGridStep <= 1)
     return value;


### PR DESCRIPTION
### Motivation
- Fix intermittent blank/white 2D layout preview textures observed on Linux/AppImage builds that are consistent with PBO-based texture upload failures.

### Description
- Add `ShouldUsePboTextureUpload()` to prefer direct uploads on Linux and consult it from `UploadRgbaToTexture` so the code can avoid the PBO path at runtime.
- Keep the existing PBO upload implementation and the direct `glTexSubImage2D` fallback intact so non-Linux platforms continue to use PBOs when available.
- Add concise one-line English comments above the helper functions `EnsurePboCapacity`, `ShouldUsePboTextureUpload`, `UploadRgbaToTexture`, and `SnapToGrid` to document their primary purpose.
- All changes are confined to `gui/layoutviewerpanel.cpp` and do not alter rendering logic beyond selecting the upload path.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb039da2248324958fce26aa1306ca)