### PR TITLE
Prioritize visible/selected staged texture rebuilds in LayoutViewerPanel

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -2212,7 +2212,7 @@ void LayoutViewerPanel::RebuildCachedTexture() {
       return;
     }
 
-    if (NeedsRenderRebuild()) {
+    if (NeedsRenderRebuild() || timeBudgetExpired) {
       RequestRenderRebuild();
       NotifyRenderReady();
       return;
@@ -2237,6 +2237,7 @@ void LayoutViewerPanel::RebuildCachedTexture() {
     NotifyRenderReady();
   }
 }
+
 
 // Starts a new per-tick deadline used by progressive texture rebuilding.
 void LayoutViewerPanel::StartRebuildTickBudget() { rebuildTickStart_ = std::chrono::steady_clock::now(); }
@@ -2288,9 +2289,16 @@ bool LayoutViewerPanel::ProcessDirty2DViews(Viewer2DOffscreenRenderer *offscreen
   if (currentLayout.view2dViews.empty())
     return true;
   const size_t total = currentLayout.view2dViews.size();
-  for (size_t scanned = 0; scanned < total; ++scanned) {
-    const size_t idx = (rebuildViewCursor_ + scanned) % total;
-    const auto &view = currentLayout.view2dViews[idx];
+  for (int pass = 0; pass < 2; ++pass) {
+    for (size_t scanned = 0; scanned < total; ++scanned) {
+      const size_t idx = (rebuildViewCursor_ + scanned) % total;
+      const auto &view = currentLayout.view2dViews[idx];
+      wxRect frameRect;
+      const bool isVisible = GetFrameRect(view.frame, frameRect) && frameRect.Intersects(wxRect(wxPoint(0, 0), GetClientSize()));
+      const bool isSelected = selectedElementType == SelectedElementType::View2D && selectedElementId == view.id;
+      const bool isPriority = isVisible || isSelected;
+      if ((pass == 0 && !isPriority) || (pass == 1 && isPriority))
+        continue;
     ViewCache &cache = GetViewCache(view.id);
     if (!cache.renderDirty)
       continue;
@@ -2350,12 +2358,15 @@ bool LayoutViewerPanel::ProcessDirty2DViews(Viewer2DOffscreenRenderer *offscreen
         }
       }
     }
-    processedCount++;
-    rebuildViewCursor_ = (idx + 1) % total;
-    if (processedCount >= maxItems || IsRebuildTimeBudgetExpired()) {
-      timeBudgetExpired = true;
-      break;
+      processedCount++;
+      rebuildViewCursor_ = (idx + 1) % total;
+      if (processedCount >= maxItems || IsRebuildTimeBudgetExpired()) {
+        timeBudgetExpired = true;
+        break;
+      }
     }
+    if (timeBudgetExpired)
+      break;
   }
   LogRebuildStageMetrics("2d_views", processedCount, std::chrono::steady_clock::now() - stageStart);
   return true;
@@ -2368,9 +2379,16 @@ bool LayoutViewerPanel::ProcessDirtyLegends(double renderZoom, int maxItems, con
   if (currentLayout.legendViews.empty())
     return true;
   const size_t total = currentLayout.legendViews.size();
-  for (size_t scanned = 0; scanned < total; ++scanned) {
-    const size_t idx = (rebuildLegendCursor_ + scanned) % total;
-    const auto &legend = currentLayout.legendViews[idx];
+  for (int pass = 0; pass < 2; ++pass) {
+    for (size_t scanned = 0; scanned < total; ++scanned) {
+      const size_t idx = (rebuildLegendCursor_ + scanned) % total;
+      const auto &legend = currentLayout.legendViews[idx];
+      wxRect frameRect;
+      const bool isVisible = GetFrameRect(legend.frame, frameRect) && frameRect.Intersects(wxRect(wxPoint(0, 0), GetClientSize()));
+      const bool isSelected = selectedElementType == SelectedElementType::Legend && selectedElementId == legend.id;
+      const bool isPriority = isVisible || isSelected;
+      if ((pass == 0 && !isPriority) || (pass == 1 && isPriority))
+        continue;
     LegendCache &cache = GetLegendCache(legend.id);
     const bool contentChanged = cache.contentHash != legendDataHash;
     const bool requiresSymbolRefresh = !cache.symbols || contentChanged;
@@ -2399,8 +2417,11 @@ bool LayoutViewerPanel::ProcessDirtyLegends(double renderZoom, int maxItems, con
         }
       }
     }
-    processedCount++; rebuildLegendCursor_ = (idx + 1) % total;
-    if (processedCount >= maxItems || IsRebuildTimeBudgetExpired()) { timeBudgetExpired = true; break; }
+      processedCount++; rebuildLegendCursor_ = (idx + 1) % total;
+      if (processedCount >= maxItems || IsRebuildTimeBudgetExpired()) { timeBudgetExpired = true; break; }
+    }
+    if (timeBudgetExpired)
+      break;
   }
   LogRebuildStageMetrics("legends", processedCount, std::chrono::steady_clock::now() - stageStart);
   return true;
@@ -2411,9 +2432,16 @@ bool LayoutViewerPanel::ProcessDirtyEventTables(double renderZoom, int maxItems,
   const auto stageStart = std::chrono::steady_clock::now();
   int processedCount = 0;
   const size_t total = currentLayout.eventTables.size();
-  for (size_t scanned = 0; scanned < total; ++scanned) {
-    const size_t idx = (rebuildEventTableCursor_ + scanned) % total;
-    const auto &table = currentLayout.eventTables[idx];
+  for (int pass = 0; pass < 2; ++pass) {
+    for (size_t scanned = 0; scanned < total; ++scanned) {
+      const size_t idx = (rebuildEventTableCursor_ + scanned) % total;
+      const auto &table = currentLayout.eventTables[idx];
+      wxRect frameRect;
+      const bool isVisible = GetFrameRect(table.frame, frameRect) && frameRect.Intersects(wxRect(wxPoint(0, 0), GetClientSize()));
+      const bool isSelected = selectedElementType == SelectedElementType::EventTable && selectedElementId == table.id;
+      const bool isPriority = isVisible || isSelected;
+      if ((pass == 0 && !isPriority) || (pass == 1 && isPriority))
+        continue;
     EventTableCache &cache = GetEventTableCache(table.id);
     size_t dataHash = HashEventTableFields(table);
     if (cache.contentHash != dataHash) cache.renderDirty = true;
@@ -2440,8 +2468,11 @@ bool LayoutViewerPanel::ProcessDirtyEventTables(double renderZoom, int maxItems,
         }
       }
     }
-    processedCount++; rebuildEventTableCursor_=(idx+1)%total;
-    if (processedCount>=maxItems || IsRebuildTimeBudgetExpired()) { timeBudgetExpired=true; break; }
+      processedCount++; rebuildEventTableCursor_=(idx+1)%total;
+      if (processedCount>=maxItems || IsRebuildTimeBudgetExpired()) { timeBudgetExpired=true; break; }
+    }
+    if (timeBudgetExpired)
+      break;
   }
   LogRebuildStageMetrics("event_tables", processedCount, std::chrono::steady_clock::now()-stageStart);
   return true;
@@ -2450,15 +2481,15 @@ bool LayoutViewerPanel::ProcessDirtyEventTables(double renderZoom, int maxItems,
 // Processes dirty text textures in bounded batches to progressively refresh text overlays.
 bool LayoutViewerPanel::ProcessDirtyTexts(double renderZoom, int maxItems, std::vector<unsigned char> &textPixels, bool &timeBudgetExpired) {
   const auto stageStart = std::chrono::steady_clock::now(); int processedCount = 0; const size_t total = currentLayout.textViews.size();
-  for (size_t scanned = 0; scanned < total; ++scanned) { const size_t idx = (rebuildTextCursor_ + scanned) % total; const auto &text = currentLayout.textViews[idx]; TextCache &cache = GetTextCache(text.id); size_t dataHash = HashTextContent(text); if (cache.contentHash != dataHash) cache.renderDirty = true; if (!cache.renderDirty) continue; cache.renderDirty = false; const wxSize renderSize = GetFrameSizeForZoom(text.frame, renderZoom); if (renderSize.GetWidth() <= 0 || renderSize.GetHeight() <= 0) { ClearCachedTexture(cache); cache.textureSize = wxSize(0,0); cache.renderZoom = 0.0; } else { wxImage image = BuildTextImage(renderSize, wxSize(text.frame.width, text.frame.height), renderZoom, text); if (!image.IsOk()) { ClearCachedTexture(cache); cache.textureSize = wxSize(0,0); cache.renderZoom = 0.0; } else { image = image.Mirror(false); if (!image.HasAlpha()) image.InitAlpha(); const int width=image.GetWidth(), height=image.GetHeight(); const unsigned char *rgb=image.GetData(), *alpha=image.GetAlpha(); if (!rgb || width<=0 || height<=0 || !TryAllocatePixelBuffer(textPixels,width,height,"text")) { ClearCachedTexture(cache); cache.textureSize = wxSize(0,0); cache.renderZoom = 0.0; } else { for (int i=0;i<width*height;++i){ const unsigned char a=alpha?alpha[i]:255; textPixels[(size_t)i*4]=rgb[i*3]; textPixels[(size_t)i*4+1]=rgb[i*3+1]; textPixels[(size_t)i*4+2]=rgb[i*3+2]; textPixels[(size_t)i*4+3]=a; } if (!InitGL()) return false; if (cache.texture==0) glGenTextures(1,&cache.texture); glBindTexture(GL_TEXTURE_2D, cache.texture); glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR); glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR); glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE); glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE); glPixelStorei(GL_UNPACK_ALIGNMENT,1); ScopedActivePixelUnpackPbo scopedPbo(cache.pixelUnpackPbo, cache.pboBytes); if (!UploadRgbaToTexture(cache.texture,width,height,textPixels.data(),cache.textureSize,true)) { ClearCachedTexture(cache); cache.textureSize = wxSize(0,0); cache.renderZoom = 0.0; } else { cache.textureSize = wxSize(width,height); cache.renderZoom = renderZoom; cache.contentHash = dataHash; } textPixels.clear(); } } } processedCount++; rebuildTextCursor_=(idx+1)%total; if (processedCount>=maxItems || IsRebuildTimeBudgetExpired()) { timeBudgetExpired=true; break; } }
+  for (int pass = 0; pass < 2; ++pass) { for (size_t scanned = 0; scanned < total; ++scanned) { const size_t idx = (rebuildTextCursor_ + scanned) % total; const auto &text = currentLayout.textViews[idx]; wxRect frameRect; const bool isVisible = GetFrameRect(text.frame, frameRect) && frameRect.Intersects(wxRect(wxPoint(0, 0), GetClientSize())); const bool isSelected = selectedElementType == SelectedElementType::Text && selectedElementId == text.id; const bool isPriority = isVisible || isSelected; if ((pass == 0 && !isPriority) || (pass == 1 && isPriority)) continue; TextCache &cache = GetTextCache(text.id); size_t dataHash = HashTextContent(text); if (cache.contentHash != dataHash) cache.renderDirty = true; if (!cache.renderDirty) continue; cache.renderDirty = false; const wxSize renderSize = GetFrameSizeForZoom(text.frame, renderZoom); if (renderSize.GetWidth() <= 0 || renderSize.GetHeight() <= 0) { ClearCachedTexture(cache); cache.textureSize = wxSize(0,0); cache.renderZoom = 0.0; } else { wxImage image = BuildTextImage(renderSize, wxSize(text.frame.width, text.frame.height), renderZoom, text); if (!image.IsOk()) { ClearCachedTexture(cache); cache.textureSize = wxSize(0,0); cache.renderZoom = 0.0; } else { image = image.Mirror(false); if (!image.HasAlpha()) image.InitAlpha(); const int width=image.GetWidth(), height=image.GetHeight(); const unsigned char *rgb=image.GetData(), *alpha=image.GetAlpha(); if (!rgb || width<=0 || height<=0 || !TryAllocatePixelBuffer(textPixels,width,height,"text")) { ClearCachedTexture(cache); cache.textureSize = wxSize(0,0); cache.renderZoom = 0.0; } else { for (int i=0;i<width*height;++i){ const unsigned char a=alpha?alpha[i]:255; textPixels[(size_t)i*4]=rgb[i*3]; textPixels[(size_t)i*4+1]=rgb[i*3+1]; textPixels[(size_t)i*4+2]=rgb[i*3+2]; textPixels[(size_t)i*4+3]=a; } if (!InitGL()) return false; if (cache.texture==0) glGenTextures(1,&cache.texture); glBindTexture(GL_TEXTURE_2D, cache.texture); glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR); glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR); glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE); glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE); glPixelStorei(GL_UNPACK_ALIGNMENT,1); ScopedActivePixelUnpackPbo scopedPbo(cache.pixelUnpackPbo, cache.pboBytes); if (!UploadRgbaToTexture(cache.texture,width,height,textPixels.data(),cache.textureSize,true)) { ClearCachedTexture(cache); cache.textureSize = wxSize(0,0); cache.renderZoom = 0.0; } else { cache.textureSize = wxSize(width,height); cache.renderZoom = renderZoom; cache.contentHash = dataHash; } textPixels.clear(); } } } processedCount++; rebuildTextCursor_=(idx+1)%total; if (processedCount>=maxItems || IsRebuildTimeBudgetExpired()) { timeBudgetExpired=true; break; } } if (timeBudgetExpired) break; }
   LogRebuildStageMetrics("texts", processedCount, std::chrono::steady_clock::now()-stageStart); return true;
 }
 
 // Processes dirty image textures in bounded batches to progressively refresh bitmap overlays.
 bool LayoutViewerPanel::ProcessDirtyImages(double renderZoom, int maxItems, std::vector<unsigned char> &imagePixels, bool &timeBudgetExpired) {
   const auto stageStart = std::chrono::steady_clock::now(); int processedCount = 0; const size_t total = currentLayout.imageViews.size();
-  for (size_t scanned = 0; scanned < total; ++scanned) { const size_t idx = (rebuildImageCursor_ + scanned) % total; const auto &image = currentLayout.imageViews[idx]; ImageCache &cache = GetImageCache(image.id); size_t dataHash = HashImageContent(image); if (cache.contentHash != dataHash) cache.renderDirty = true; if (!cache.renderDirty) continue; cache.renderDirty = false; const wxSize renderSize = GetFrameSizeForZoom(image.frame, renderZoom); if (renderSize.GetWidth() <= 0 || renderSize.GetHeight() <= 0 || image.imagePath.empty()) { ClearCachedTexture(cache); cache.textureSize = wxSize(0,0); cache.renderZoom = 0.0; } else { std::filesystem::file_time_type fileMtime{}; const bool hasMtime = TryGetImageFileMtime(image.imagePath, fileMtime); if (!hasMtime) { ClearCachedTexture(cache); cache.textureSize = wxSize(0,0); cache.renderZoom = 0.0; } else { const wxImage *scaled = GetOrCreateScaledImageBitmap(image.imagePath, renderSize.GetWidth(), renderSize.GetHeight(), fileMtime); if (!scaled || !scaled->IsOk()) { ClearCachedTexture(cache); cache.textureSize = wxSize(0,0); cache.renderZoom = 0.0; } else { const int width=scaled->GetWidth(), height=scaled->GetHeight(); const unsigned char *rgb=scaled->GetData(), *alpha=scaled->GetAlpha(); if (!rgb || width<=0 || height<=0 || !TryAllocatePixelBuffer(imagePixels,width,height,"image")) { ClearCachedTexture(cache); cache.textureSize = wxSize(0,0); cache.renderZoom = 0.0; } else { for (int i=0;i<width*height;++i){ imagePixels[(size_t)i*4]=rgb[i*3]; imagePixels[(size_t)i*4+1]=rgb[i*3+1]; imagePixels[(size_t)i*4+2]=rgb[i*3+2]; imagePixels[(size_t)i*4+3]=alpha?alpha[i]:255; } if (!InitGL()) return false; if (cache.texture==0) glGenTextures(1,&cache.texture); glBindTexture(GL_TEXTURE_2D, cache.texture); glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR); glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR); glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE); glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE); glPixelStorei(GL_UNPACK_ALIGNMENT, 1); ScopedActivePixelUnpackPbo scopedPbo(cache.pixelUnpackPbo, cache.pboBytes); if (!UploadRgbaToTexture(cache.texture,width,height,imagePixels.data(),cache.textureSize,true)) { ClearCachedTexture(cache); cache.textureSize = wxSize(0,0); cache.renderZoom = 0.0; } else { cache.textureSize = wxSize(width,height); cache.renderZoom = renderZoom; cache.contentHash = dataHash; } imagePixels.clear(); } } } }
-    processedCount++; rebuildImageCursor_=(idx+1)%total; if (processedCount>=maxItems || IsRebuildTimeBudgetExpired()) { timeBudgetExpired=true; break; }
+  for (int pass = 0; pass < 2; ++pass) { for (size_t scanned = 0; scanned < total; ++scanned) { const size_t idx = (rebuildImageCursor_ + scanned) % total; const auto &image = currentLayout.imageViews[idx]; wxRect frameRect; const bool isVisible = GetFrameRect(image.frame, frameRect) && frameRect.Intersects(wxRect(wxPoint(0, 0), GetClientSize())); const bool isSelected = selectedElementType == SelectedElementType::Image && selectedElementId == image.id; const bool isPriority = isVisible || isSelected; if ((pass == 0 && !isPriority) || (pass == 1 && isPriority)) continue; ImageCache &cache = GetImageCache(image.id); size_t dataHash = HashImageContent(image); if (cache.contentHash != dataHash) cache.renderDirty = true; if (!cache.renderDirty) continue; cache.renderDirty = false; const wxSize renderSize = GetFrameSizeForZoom(image.frame, renderZoom); if (renderSize.GetWidth() <= 0 || renderSize.GetHeight() <= 0 || image.imagePath.empty()) { ClearCachedTexture(cache); cache.textureSize = wxSize(0,0); cache.renderZoom = 0.0; } else { std::filesystem::file_time_type fileMtime{}; const bool hasMtime = TryGetImageFileMtime(image.imagePath, fileMtime); if (!hasMtime) { ClearCachedTexture(cache); cache.textureSize = wxSize(0,0); cache.renderZoom = 0.0; } else { const wxImage *scaled = GetOrCreateScaledImageBitmap(image.imagePath, renderSize.GetWidth(), renderSize.GetHeight(), fileMtime); if (!scaled || !scaled->IsOk()) { ClearCachedTexture(cache); cache.textureSize = wxSize(0,0); cache.renderZoom = 0.0; } else { const int width=scaled->GetWidth(), height=scaled->GetHeight(); const unsigned char *rgb=scaled->GetData(), *alpha=scaled->GetAlpha(); if (!rgb || width<=0 || height<=0 || !TryAllocatePixelBuffer(imagePixels,width,height,"image")) { ClearCachedTexture(cache); cache.textureSize = wxSize(0,0); cache.renderZoom = 0.0; } else { for (int i=0;i<width*height;++i){ imagePixels[(size_t)i*4]=rgb[i*3]; imagePixels[(size_t)i*4+1]=rgb[i*3+1]; imagePixels[(size_t)i*4+2]=rgb[i*3+2]; imagePixels[(size_t)i*4+3]=alpha?alpha[i]:255; } if (!InitGL()) return false; if (cache.texture==0) glGenTextures(1,&cache.texture); glBindTexture(GL_TEXTURE_2D, cache.texture); glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR); glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR); glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE); glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE); glPixelStorei(GL_UNPACK_ALIGNMENT, 1); ScopedActivePixelUnpackPbo scopedPbo(cache.pixelUnpackPbo, cache.pboBytes); if (!UploadRgbaToTexture(cache.texture,width,height,imagePixels.data(),cache.textureSize,true)) { ClearCachedTexture(cache); cache.textureSize = wxSize(0,0); cache.renderZoom = 0.0; } else { cache.textureSize = wxSize(width,height); cache.renderZoom = renderZoom; cache.contentHash = dataHash; } imagePixels.clear(); } } } }
+    processedCount++; rebuildImageCursor_=(idx+1)%total; if (processedCount>=maxItems || IsRebuildTimeBudgetExpired()) { timeBudgetExpired=true; break; } } if (timeBudgetExpired) break;
   }
   LogRebuildStageMetrics("images", processedCount, std::chrono::steady_clock::now()-stageStart); return true;
 }


### PR DESCRIPTION
### Motivation
- Avoid long frozen transitions when opening layouts by updating high-value on-screen and selected elements first.
- Keep progressive rendering alive across ticks so users see incremental results instead of a long pause while the full rebuild completes.
- Preserve visibility into first-open performance by keeping per-stage timing metrics for identifying dominant cost categories.

### Description
- Modified `LayoutViewerPanel::RebuildCachedTexture()` to re-queue work (`RequestRenderRebuild()`) not only when dirty items remain but also when the per-tick time budget (`timeBudgetExpired`) is hit.
- Split each dirty-stage processor (2D views, legends, event tables, texts, images) into two passes per tick so visible/selected elements are handled first and remaining background elements are handled second, while preserving existing cursor advancement and `kMaxItemsPerStage` limits.
- Retained and reused `LogRebuildStageMetrics` for `2d_views`, `legends`, `event_tables`, `texts`, and `images` so rebuild timing remains measurable.
- All changes are localized to `gui/layoutviewerpanel.cpp` and keep existing GL initialisation, texture upload, and error handling logic intact.

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb206d955083248e9bc705f04c867b)