### PR TITLE
Add Layout Mode prewarm cache for legend symbols and view render states

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -778,6 +778,7 @@ void LayoutViewerPanel::SetLayoutDefinition(
     return;
   }
 
+  MaybePrewarmOnLayoutModeEntry(previousLayout);
   captureInProgress = false;
   ClearCachedTexture();
   const bool emptyLayout = IsLayoutEmpty();
@@ -806,6 +807,82 @@ void LayoutViewerPanel::SetLayoutDefinition(
   ResetViewToFit();
   RequestRenderRebuild();
   Refresh();
+}
+
+// Prewarms reusable legend symbols and view render states when switching into a new layout context.
+void LayoutViewerPanel::MaybePrewarmOnLayoutModeEntry(const layouts::LayoutDefinition &previousLayout) {
+  if (currentLayout.name.empty())
+    return;
+  const bool likelyModeEntryFrom2Dor3D =
+      previousLayout.name.empty() || previousLayout.name != currentLayout.name;
+  if (!likelyModeEntryFrom2Dor3D)
+    return;
+
+  const std::string prewarmKey =
+      currentLayout.name + "#" + std::to_string(layoutVersion);
+  PrewarmedLayoutArtifacts artifacts;
+  artifacts.layoutVersion = layoutVersion;
+  artifacts.contentHash = BuildLayoutPrewarmContentHash();
+  for (const auto &view : currentLayout.view2dViews) {
+    viewer2d::Viewer2DState state = viewer2d::FromLayoutDefinition(view);
+    state.renderOptions.darkMode = false;
+    artifacts.viewRenderStates.emplace(view.id, std::move(state));
+  }
+
+  Viewer2DPanel *capturePanel = nullptr;
+  if (auto *mw = MainWindow::Instance()) {
+    if (auto *offscreenRenderer = mw->GetOffscreenRenderer())
+      capturePanel = offscreenRenderer->GetPanel();
+  }
+  if (!capturePanel)
+    capturePanel = Viewer2DPanel::Instance();
+  if (capturePanel) {
+    ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+    artifacts.legendSymbols = CaptureLegendSymbolSnapshot(capturePanel, cfg, true);
+  }
+
+  prewarmedArtifactsByLayout_[prewarmKey] = std::move(artifacts);
+  ApplyPrewarmedArtifactsIfAvailable();
+}
+
+// Applies prewarmed artifacts to current caches when layout identity and content hash still match.
+void LayoutViewerPanel::ApplyPrewarmedArtifactsIfAvailable() {
+  const std::string prewarmKey =
+      currentLayout.name + "#" + std::to_string(layoutVersion);
+  auto it = prewarmedArtifactsByLayout_.find(prewarmKey);
+  if (it == prewarmedArtifactsByLayout_.end())
+    return;
+  const PrewarmedLayoutArtifacts &artifacts = it->second;
+  if (artifacts.layoutVersion != layoutVersion ||
+      artifacts.contentHash != BuildLayoutPrewarmContentHash()) {
+    prewarmedArtifactsByLayout_.erase(it);
+    return;
+  }
+
+  for (const auto &view : currentLayout.view2dViews) {
+    auto stateIt = artifacts.viewRenderStates.find(view.id);
+    if (stateIt == artifacts.viewRenderStates.end())
+      continue;
+    ViewCache &cache = GetViewCache(view.id);
+    cache.renderState = stateIt->second;
+    cache.hasRenderState = true;
+  }
+  if (artifacts.legendSymbols) {
+    for (const auto &legend : currentLayout.legendViews) {
+      LegendCache &cache = GetLegendCache(legend.id);
+      cache.symbols = artifacts.legendSymbols;
+      cache.renderDirty = true;
+    }
+  }
+}
+
+// Builds a stable invalidation hash used to discard prewarm entries after layout name/content/version changes.
+size_t LayoutViewerPanel::BuildLayoutPrewarmContentHash() const {
+  size_t seed = std::hash<std::string>{}(currentLayout.name);
+  const size_t sceneHash = ComputeSceneContentHash();
+  seed ^= sceneHash + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+  seed ^= std::hash<int>{}(layoutVersion) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+  return seed;
 }
 
 void LayoutViewerPanel::NotifyRenderReady() {

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -317,6 +317,9 @@ private:
   };
 
   void InvalidateSelectionIndexCache();
+  void MaybePrewarmOnLayoutModeEntry(const layouts::LayoutDefinition &previousLayout);
+  void ApplyPrewarmedArtifactsIfAvailable();
+  size_t BuildLayoutPrewarmContentHash() const;
   void EnsureSelectionIndexCache();
   std::vector<ZOrderedElement> BuildZOrderedElements() const;
   std::pair<int, int> GetZIndexRange() const;
@@ -371,6 +374,13 @@ private:
   bool pendingFitOnResize = true;
   bool pendingFrameCommit_ = false;
   SelectionIndexCache selectionIndexCache_;
+  struct PrewarmedLayoutArtifacts {
+    int layoutVersion = 0;
+    size_t contentHash = 0;
+    std::shared_ptr<const SymbolDefinitionSnapshot> legendSymbols;
+    std::unordered_map<int, viewer2d::Viewer2DState> viewRenderStates;
+  };
+  std::unordered_map<std::string, PrewarmedLayoutArtifacts> prewarmedArtifactsByLayout_;
   size_t rebuildViewCursor_ = 0;
   size_t rebuildLegendCursor_ = 0;
   size_t rebuildEventTableCursor_ = 0;


### PR DESCRIPTION
### Motivation
- Reduce visible cold-frame latency when entering Layout Mode from 2D/3D by precomputing reusable assets before the full texture rebuild.  
- Precompute legend symbol snapshots and initial per-view render states to avoid expensive first-frame captures and speed first visible render.  
- Persist prewarmed artifacts keyed by layout identity/version so a repeated entry to the same layout can reuse work and avoid full cold misses.

### Description
- Added private API and storage in `LayoutViewerPanel` (`MaybePrewarmOnLayoutModeEntry`, `ApplyPrewarmedArtifactsIfAvailable`, `BuildLayoutPrewarmContentHash`, and `prewarmedArtifactsByLayout_`) to manage prewarm artifacts.  
- Invoke `MaybePrewarmOnLayoutModeEntry` from `SetLayoutDefinition` when switching into a new layout context so prewarm runs before cold cache rebuilds.  
- Reuse existing primitives by capturing legend snapshots via `CaptureLegendSymbolSnapshot(...)` and deriving per-view `viewer2d::Viewer2DState` via `viewer2d::FromLayoutDefinition(...)`, then persist these into `PrewarmedLayoutArtifacts`.  
- Hydrate `ViewCache` and `LegendCache` from prewarmed artifacts and invalidate prewarm entries when the layout name, the computed content hash (`ComputeSceneContentHash` + `layoutVersion`), or the layout version changes.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it returned OK.  
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it returned OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb24c2bc988324a92f20a574f01681)