### PR TITLE
Feature-flagged VBO/VAO batched textured-quad rendering for layout views

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -150,102 +150,6 @@ bool TryGetImageFileMtime(const std::string &imagePath,
   return !ec;
 }
 
-// Queues a textured quad for deferred VBO/VAO submission while preserving draw order by texture runs.
-void LayoutViewerPanel::QueueTexturedQuad(GLuint texture,
-                                          const wxRect &frameRect) {
-  if (texture == 0)
-    return;
-  const int frameRight = frameRect.GetLeft() + frameRect.GetWidth();
-  const int frameBottom = frameRect.GetTop() + frameRect.GetHeight();
-  TexturedQuadBatch *batch = nullptr;
-  if (!texturedQuadBatches_.empty() &&
-      texturedQuadBatches_.back().texture == texture) {
-    batch = &texturedQuadBatches_.back();
-  } else {
-    texturedQuadBatches_.push_back(TexturedQuadBatch{});
-    texturedQuadBatches_.back().texture = texture;
-    batch = &texturedQuadBatches_.back();
-  }
-  batch->vertices.push_back(
-      {static_cast<float>(frameRect.GetLeft()), static_cast<float>(frameRect.GetTop()), 0.0f, 1.0f});
-  batch->vertices.push_back(
-      {static_cast<float>(frameRight), static_cast<float>(frameRect.GetTop()), 1.0f, 1.0f});
-  batch->vertices.push_back(
-      {static_cast<float>(frameRight), static_cast<float>(frameBottom), 1.0f, 0.0f});
-  batch->vertices.push_back(
-      {static_cast<float>(frameRect.GetLeft()), static_cast<float>(frameRect.GetBottom()), 0.0f, 0.0f});
-}
-
-// Draws one textured quad using legacy immediate mode as the compatibility fallback path.
-void LayoutViewerPanel::DrawTexturedQuadImmediate(GLuint texture,
-                                                  const wxRect &frameRect) const {
-  const int frameRight = frameRect.GetLeft() + frameRect.GetWidth();
-  const int frameBottom = frameRect.GetTop() + frameRect.GetHeight();
-  glEnable(GL_TEXTURE_2D);
-  glBindTexture(GL_TEXTURE_2D, texture);
-  glColor4ub(255, 255, 255, 255);
-  glBegin(GL_QUADS);
-  glTexCoord2f(0.0f, 1.0f);
-  glVertex2f(static_cast<float>(frameRect.GetLeft()),
-             static_cast<float>(frameRect.GetTop()));
-  glTexCoord2f(1.0f, 1.0f);
-  glVertex2f(static_cast<float>(frameRight), static_cast<float>(frameRect.GetTop()));
-  glTexCoord2f(1.0f, 0.0f);
-  glVertex2f(static_cast<float>(frameRight), static_cast<float>(frameBottom));
-  glTexCoord2f(0.0f, 0.0f);
-  glVertex2f(static_cast<float>(frameRect.GetLeft()),
-             static_cast<float>(frameRect.GetBottom()));
-  glEnd();
-  glDisable(GL_TEXTURE_2D);
-}
-
-// Flushes queued textured quads using a VBO/VAO path and falls back to immediate mode when unavailable.
-void LayoutViewerPanel::FlushQueuedTexturedQuads() {
-  if (texturedQuadBatches_.empty())
-    return;
-  if (texturedQuadVao_ == 0)
-    glGenVertexArrays(1, &texturedQuadVao_);
-  if (texturedQuadVbo_ == 0)
-    glGenBuffers(1, &texturedQuadVbo_);
-  const bool canUseVboVao = texturedQuadVao_ != 0 && texturedQuadVbo_ != 0;
-  if (!canUseVboVao) {
-    for (const auto &batch : texturedQuadBatches_) {
-      for (size_t i = 0; i + 3 < batch.vertices.size(); i += 4) {
-        wxRect r(static_cast<int>(batch.vertices[i].x),
-                 static_cast<int>(batch.vertices[i].y),
-                 static_cast<int>(batch.vertices[i + 1].x - batch.vertices[i].x),
-                 static_cast<int>(batch.vertices[i + 2].y - batch.vertices[i].y));
-        DrawTexturedQuadImmediate(batch.texture, r);
-      }
-    }
-    texturedQuadBatches_.clear();
-    return;
-  }
-  glEnable(GL_TEXTURE_2D);
-  glColor4ub(255, 255, 255, 255);
-  glBindVertexArray(texturedQuadVao_);
-  glBindBuffer(GL_ARRAY_BUFFER, texturedQuadVbo_);
-  glEnableClientState(GL_VERTEX_ARRAY);
-  glEnableClientState(GL_TEXTURE_COORD_ARRAY);
-  for (const auto &batch : texturedQuadBatches_) {
-    glBindTexture(GL_TEXTURE_2D, batch.texture);
-    glBufferData(GL_ARRAY_BUFFER,
-                 static_cast<GLsizeiptr>(batch.vertices.size() *
-                                         sizeof(TexturedQuadVertex)),
-                 batch.vertices.data(), GL_STREAM_DRAW);
-    glVertexPointer(2, GL_FLOAT, sizeof(TexturedQuadVertex),
-                    reinterpret_cast<const void *>(offsetof(TexturedQuadVertex, x)));
-    glTexCoordPointer(2, GL_FLOAT, sizeof(TexturedQuadVertex),
-                      reinterpret_cast<const void *>(offsetof(TexturedQuadVertex, u)));
-    glDrawArrays(GL_QUADS, 0, static_cast<GLsizei>(batch.vertices.size()));
-  }
-  glDisableClientState(GL_TEXTURE_COORD_ARRAY);
-  glDisableClientState(GL_VERTEX_ARRAY);
-  glBindBuffer(GL_ARRAY_BUFFER, 0);
-  glBindVertexArray(0);
-  glDisable(GL_TEXTURE_2D);
-  texturedQuadBatches_.clear();
-}
 
 // Estimates the RGBA memory footprint used by a scaled image cache entry.
 size_t EstimateImageCacheEntryBytes(const wxImage &image) {
@@ -718,6 +622,111 @@ int SnapToGrid(int value) {
       kLayoutGridStep);
 }
 } // namespace
+
+// Queues a textured quad for deferred VBO/VAO submission while preserving draw order by texture runs.
+void LayoutViewerPanel::QueueTexturedQuad(GLuint texture,
+                                          const wxRect &frameRect) {
+  if (texture == 0)
+    return;
+  const int frameRight = frameRect.GetLeft() + frameRect.GetWidth();
+  const int frameBottom = frameRect.GetTop() + frameRect.GetHeight();
+  TexturedQuadBatch *batch = nullptr;
+  if (!texturedQuadBatches_.empty() &&
+      texturedQuadBatches_.back().texture == texture) {
+    batch = &texturedQuadBatches_.back();
+  } else {
+    texturedQuadBatches_.push_back(TexturedQuadBatch{});
+    texturedQuadBatches_.back().texture = texture;
+    batch = &texturedQuadBatches_.back();
+  }
+  batch->vertices.push_back({static_cast<float>(frameRect.GetLeft()),
+                             static_cast<float>(frameRect.GetTop()), 0.0f,
+                             1.0f});
+  batch->vertices.push_back({static_cast<float>(frameRight),
+                             static_cast<float>(frameRect.GetTop()), 1.0f,
+                             1.0f});
+  batch->vertices.push_back({static_cast<float>(frameRight),
+                             static_cast<float>(frameBottom), 1.0f, 0.0f});
+  batch->vertices.push_back({static_cast<float>(frameRect.GetLeft()),
+                             static_cast<float>(frameRect.GetBottom()), 0.0f,
+                             0.0f});
+}
+
+// Draws one textured quad using legacy immediate mode as the compatibility fallback path.
+void LayoutViewerPanel::DrawTexturedQuadImmediate(GLuint texture,
+                                                  const wxRect &frameRect) const {
+  const int frameRight = frameRect.GetLeft() + frameRect.GetWidth();
+  const int frameBottom = frameRect.GetTop() + frameRect.GetHeight();
+  glEnable(GL_TEXTURE_2D);
+  glBindTexture(GL_TEXTURE_2D, texture);
+  glColor4ub(255, 255, 255, 255);
+  glBegin(GL_QUADS);
+  glTexCoord2f(0.0f, 1.0f);
+  glVertex2f(static_cast<float>(frameRect.GetLeft()),
+             static_cast<float>(frameRect.GetTop()));
+  glTexCoord2f(1.0f, 1.0f);
+  glVertex2f(static_cast<float>(frameRight),
+             static_cast<float>(frameRect.GetTop()));
+  glTexCoord2f(1.0f, 0.0f);
+  glVertex2f(static_cast<float>(frameRight), static_cast<float>(frameBottom));
+  glTexCoord2f(0.0f, 0.0f);
+  glVertex2f(static_cast<float>(frameRect.GetLeft()),
+             static_cast<float>(frameRect.GetBottom()));
+  glEnd();
+  glDisable(GL_TEXTURE_2D);
+}
+
+// Flushes queued textured quads using a VBO/VAO path and falls back to immediate mode when unavailable.
+void LayoutViewerPanel::FlushQueuedTexturedQuads() {
+  if (texturedQuadBatches_.empty())
+    return;
+  if (texturedQuadVao_ == 0)
+    glGenVertexArrays(1, &texturedQuadVao_);
+  if (texturedQuadVbo_ == 0)
+    glGenBuffers(1, &texturedQuadVbo_);
+  const bool canUseVboVao = texturedQuadVao_ != 0 && texturedQuadVbo_ != 0;
+  if (!canUseVboVao) {
+    for (const auto &batch : texturedQuadBatches_) {
+      for (size_t i = 0; i + 3 < batch.vertices.size(); i += 4) {
+        wxRect r(static_cast<int>(batch.vertices[i].x),
+                 static_cast<int>(batch.vertices[i].y),
+                 static_cast<int>(batch.vertices[i + 1].x -
+                                  batch.vertices[i].x),
+                 static_cast<int>(batch.vertices[i + 2].y -
+                                  batch.vertices[i].y));
+        DrawTexturedQuadImmediate(batch.texture, r);
+      }
+    }
+    texturedQuadBatches_.clear();
+    return;
+  }
+  glEnable(GL_TEXTURE_2D);
+  glColor4ub(255, 255, 255, 255);
+  glBindVertexArray(texturedQuadVao_);
+  glBindBuffer(GL_ARRAY_BUFFER, texturedQuadVbo_);
+  glEnableClientState(GL_VERTEX_ARRAY);
+  glEnableClientState(GL_TEXTURE_COORD_ARRAY);
+  for (const auto &batch : texturedQuadBatches_) {
+    glBindTexture(GL_TEXTURE_2D, batch.texture);
+    glBufferData(GL_ARRAY_BUFFER,
+                 static_cast<GLsizeiptr>(batch.vertices.size() *
+                                         sizeof(TexturedQuadVertex)),
+                 batch.vertices.data(), GL_STREAM_DRAW);
+    glVertexPointer(2, GL_FLOAT, sizeof(TexturedQuadVertex),
+                    reinterpret_cast<const void *>(
+                        offsetof(TexturedQuadVertex, x)));
+    glTexCoordPointer(2, GL_FLOAT, sizeof(TexturedQuadVertex),
+                      reinterpret_cast<const void *>(
+                          offsetof(TexturedQuadVertex, u)));
+    glDrawArrays(GL_QUADS, 0, static_cast<GLsizei>(batch.vertices.size()));
+  }
+  glDisableClientState(GL_TEXTURE_COORD_ARRAY);
+  glDisableClientState(GL_VERTEX_ARRAY);
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+  glBindVertexArray(0);
+  glDisable(GL_TEXTURE_2D);
+  texturedQuadBatches_.clear();
+}
 
 wxDEFINE_EVENT(EVT_LAYOUT_VIEW_EDIT, wxCommandEvent);
 

--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -74,6 +74,7 @@
 #include "viewer2doffscreenrenderer.h"
 #include "viewer2dstate.h"
 #include "ui_render_size.h"
+#include "ui_feature_flags.h"
 
 namespace {
 constexpr double kMinZoom = 0.25;
@@ -147,6 +148,103 @@ bool TryGetImageFileMtime(const std::string &imagePath,
   std::error_code ec;
   outMtime = std::filesystem::last_write_time(std::filesystem::path(imagePath), ec);
   return !ec;
+}
+
+// Queues a textured quad for deferred VBO/VAO submission while preserving draw order by texture runs.
+void LayoutViewerPanel::QueueTexturedQuad(GLuint texture,
+                                          const wxRect &frameRect) {
+  if (texture == 0)
+    return;
+  const int frameRight = frameRect.GetLeft() + frameRect.GetWidth();
+  const int frameBottom = frameRect.GetTop() + frameRect.GetHeight();
+  TexturedQuadBatch *batch = nullptr;
+  if (!texturedQuadBatches_.empty() &&
+      texturedQuadBatches_.back().texture == texture) {
+    batch = &texturedQuadBatches_.back();
+  } else {
+    texturedQuadBatches_.push_back(TexturedQuadBatch{});
+    texturedQuadBatches_.back().texture = texture;
+    batch = &texturedQuadBatches_.back();
+  }
+  batch->vertices.push_back(
+      {static_cast<float>(frameRect.GetLeft()), static_cast<float>(frameRect.GetTop()), 0.0f, 1.0f});
+  batch->vertices.push_back(
+      {static_cast<float>(frameRight), static_cast<float>(frameRect.GetTop()), 1.0f, 1.0f});
+  batch->vertices.push_back(
+      {static_cast<float>(frameRight), static_cast<float>(frameBottom), 1.0f, 0.0f});
+  batch->vertices.push_back(
+      {static_cast<float>(frameRect.GetLeft()), static_cast<float>(frameRect.GetBottom()), 0.0f, 0.0f});
+}
+
+// Draws one textured quad using legacy immediate mode as the compatibility fallback path.
+void LayoutViewerPanel::DrawTexturedQuadImmediate(GLuint texture,
+                                                  const wxRect &frameRect) const {
+  const int frameRight = frameRect.GetLeft() + frameRect.GetWidth();
+  const int frameBottom = frameRect.GetTop() + frameRect.GetHeight();
+  glEnable(GL_TEXTURE_2D);
+  glBindTexture(GL_TEXTURE_2D, texture);
+  glColor4ub(255, 255, 255, 255);
+  glBegin(GL_QUADS);
+  glTexCoord2f(0.0f, 1.0f);
+  glVertex2f(static_cast<float>(frameRect.GetLeft()),
+             static_cast<float>(frameRect.GetTop()));
+  glTexCoord2f(1.0f, 1.0f);
+  glVertex2f(static_cast<float>(frameRight), static_cast<float>(frameRect.GetTop()));
+  glTexCoord2f(1.0f, 0.0f);
+  glVertex2f(static_cast<float>(frameRight), static_cast<float>(frameBottom));
+  glTexCoord2f(0.0f, 0.0f);
+  glVertex2f(static_cast<float>(frameRect.GetLeft()),
+             static_cast<float>(frameRect.GetBottom()));
+  glEnd();
+  glDisable(GL_TEXTURE_2D);
+}
+
+// Flushes queued textured quads using a VBO/VAO path and falls back to immediate mode when unavailable.
+void LayoutViewerPanel::FlushQueuedTexturedQuads() {
+  if (texturedQuadBatches_.empty())
+    return;
+  if (texturedQuadVao_ == 0)
+    glGenVertexArrays(1, &texturedQuadVao_);
+  if (texturedQuadVbo_ == 0)
+    glGenBuffers(1, &texturedQuadVbo_);
+  const bool canUseVboVao = texturedQuadVao_ != 0 && texturedQuadVbo_ != 0;
+  if (!canUseVboVao) {
+    for (const auto &batch : texturedQuadBatches_) {
+      for (size_t i = 0; i + 3 < batch.vertices.size(); i += 4) {
+        wxRect r(static_cast<int>(batch.vertices[i].x),
+                 static_cast<int>(batch.vertices[i].y),
+                 static_cast<int>(batch.vertices[i + 1].x - batch.vertices[i].x),
+                 static_cast<int>(batch.vertices[i + 2].y - batch.vertices[i].y));
+        DrawTexturedQuadImmediate(batch.texture, r);
+      }
+    }
+    texturedQuadBatches_.clear();
+    return;
+  }
+  glEnable(GL_TEXTURE_2D);
+  glColor4ub(255, 255, 255, 255);
+  glBindVertexArray(texturedQuadVao_);
+  glBindBuffer(GL_ARRAY_BUFFER, texturedQuadVbo_);
+  glEnableClientState(GL_VERTEX_ARRAY);
+  glEnableClientState(GL_TEXTURE_COORD_ARRAY);
+  for (const auto &batch : texturedQuadBatches_) {
+    glBindTexture(GL_TEXTURE_2D, batch.texture);
+    glBufferData(GL_ARRAY_BUFFER,
+                 static_cast<GLsizeiptr>(batch.vertices.size() *
+                                         sizeof(TexturedQuadVertex)),
+                 batch.vertices.data(), GL_STREAM_DRAW);
+    glVertexPointer(2, GL_FLOAT, sizeof(TexturedQuadVertex),
+                    reinterpret_cast<const void *>(offsetof(TexturedQuadVertex, x)));
+    glTexCoordPointer(2, GL_FLOAT, sizeof(TexturedQuadVertex),
+                      reinterpret_cast<const void *>(offsetof(TexturedQuadVertex, u)));
+    glDrawArrays(GL_QUADS, 0, static_cast<GLsizei>(batch.vertices.size()));
+  }
+  glDisableClientState(GL_TEXTURE_COORD_ARRAY);
+  glDisableClientState(GL_VERTEX_ARRAY);
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+  glBindVertexArray(0);
+  glDisable(GL_TEXTURE_2D);
+  texturedQuadBatches_.clear();
 }
 
 // Estimates the RGBA memory footprint used by a scaled image cache entry.

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -124,6 +124,16 @@ private:
     bool renderDirty = true;
     size_t contentHash = 0;
   };
+  struct TexturedQuadVertex {
+    float x;
+    float y;
+    float u;
+    float v;
+  };
+  struct TexturedQuadBatch {
+    GLuint texture = 0;
+    std::vector<TexturedQuadVertex> vertices;
+  };
 
   void NotifyRenderReady();
   void OnPaint(wxPaintEvent &event);
@@ -165,6 +175,9 @@ private:
                        int activeTextId);
   void DrawImageElement(const layouts::LayoutImageDefinition &image,
                         int activeImageId);
+  void QueueTexturedQuad(GLuint texture, const wxRect &frameRect);
+  void FlushQueuedTexturedQuads();
+  void DrawTexturedQuadImmediate(GLuint texture, const wxRect &frameRect) const;
   void DrawDeferredResizeOverlay();
   void DrawLoadingOverlay(const wxSize &size);
   void EnsureLoadingTextTexture();
@@ -368,6 +381,9 @@ private:
   std::unordered_map<int, EventTableCache> eventTableCaches_;
   std::unordered_map<int, TextCache> textCaches_;
   std::unordered_map<int, ImageCache> imageCaches_;
+  std::vector<TexturedQuadBatch> texturedQuadBatches_;
+  GLuint texturedQuadVao_ = 0;
+  GLuint texturedQuadVbo_ = 0;
   std::vector<LegendItem> legendItems_;
   size_t legendDataHash = 0;
   bool legendDataDirty_ = true;

--- a/gui/layoutviewerpanel_view.cpp
+++ b/gui/layoutviewerpanel_view.cpp
@@ -40,7 +40,9 @@
 #include "LayoutManager.h"
 #include "viewer2doffscreenrenderer.h"
 #include "viewer2dstate.h"
+#include "ui_feature_flags.h"
 
+// Returns the selected editable 2D view and keeps selection consistent.
 layouts::Layout2DViewDefinition *LayoutViewerPanel::GetEditableView() {
   if (currentLayout.view2dViews.empty())
     return nullptr;
@@ -56,6 +58,7 @@ layouts::Layout2DViewDefinition *LayoutViewerPanel::GetEditableView() {
   return &currentLayout.view2dViews.front();
 }
 
+// Returns the selected editable 2D view as a read-only pointer.
 const layouts::Layout2DViewDefinition *LayoutViewerPanel::GetEditableView()
     const {
   if (currentLayout.view2dViews.empty())
@@ -72,12 +75,14 @@ const layouts::Layout2DViewDefinition *LayoutViewerPanel::GetEditableView()
   return nullptr;
 }
 
+// Emits the edit-view action when the current selection is a 2D view.
 void LayoutViewerPanel::OnEditView(wxCommandEvent &) {
   if (selectedElementType != SelectedElementType::View2D)
     return;
   EmitEditViewRequest();
 }
 
+// Removes the selected 2D view from the current layout and updates selection.
 void LayoutViewerPanel::OnDeleteView(wxCommandEvent &) {
   if (selectedElementType != SelectedElementType::View2D)
     return;
@@ -129,6 +134,7 @@ void LayoutViewerPanel::OnDeleteView(wxCommandEvent &) {
   Refresh();
 }
 
+// Toggles the visibility of the selected 2D view frame and persists the change.
 void LayoutViewerPanel::OnToggleViewFrame(wxCommandEvent &) {
   if (selectedElementType != SelectedElementType::View2D)
     return;
@@ -146,6 +152,7 @@ void LayoutViewerPanel::OnToggleViewFrame(wxCommandEvent &) {
   Refresh();
 }
 
+// Updates the selected 2D view frame and triggers the needed render refresh path.
 void LayoutViewerPanel::UpdateFrame(const layouts::Layout2DViewFrame &frame,
                                     bool updatePosition) {
   layouts::Layout2DViewDefinition *view = GetEditableView();
@@ -187,6 +194,7 @@ void LayoutViewerPanel::UpdateFrame(const layouts::Layout2DViewFrame &frame,
   Refresh();
 }
 
+// Draws the 2D view cache texture and frame while refreshing stale captures asynchronously.
 void LayoutViewerPanel::DrawViewElement(
     const layouts::Layout2DViewDefinition &view, Viewer2DPanel *capturePanel,
     Viewer2DOffscreenRenderer *offscreenRenderer, int activeViewId) {
@@ -266,24 +274,12 @@ void LayoutViewerPanel::DrawViewElement(
   const wxSize renderSize = GetFrameSizeForZoom(view.frame, cache.renderZoom);
   if (cache.texture != 0 && renderSize.GetWidth() > 0 &&
       renderSize.GetHeight() > 0 && cache.textureSize == renderSize) {
-    glEnable(GL_TEXTURE_2D);
-    glBindTexture(GL_TEXTURE_2D, cache.texture);
-    glColor4ub(255, 255, 255, 255);
-    glBegin(GL_QUADS);
-    glTexCoord2f(0.0f, 1.0f);
-    glVertex2f(static_cast<float>(frameRect.GetLeft()),
-               static_cast<float>(frameRect.GetTop()));
-    glTexCoord2f(1.0f, 1.0f);
-    glVertex2f(static_cast<float>(frameRight),
-               static_cast<float>(frameRect.GetTop()));
-    glTexCoord2f(1.0f, 0.0f);
-    glVertex2f(static_cast<float>(frameRight),
-               static_cast<float>(frameBottom));
-    glTexCoord2f(0.0f, 0.0f);
-    glVertex2f(static_cast<float>(frameRect.GetLeft()),
-               static_cast<float>(frameRect.GetBottom()));
-    glEnd();
-    glDisable(GL_TEXTURE_2D);
+    if (ui::IsFeatureEnabled(ui::FeatureFlag::LayoutViewerVboQuadBatch)) {
+      QueueTexturedQuad(cache.texture, frameRect);
+      FlushQueuedTexturedQuads();
+    } else {
+      DrawTexturedQuadImmediate(cache.texture, frameRect);
+    }
   } else {
     glColor4ub(240, 240, 240, 255);
     glBegin(GL_QUADS);

--- a/gui/ui_feature_flags.cpp
+++ b/gui/ui_feature_flags.cpp
@@ -35,6 +35,7 @@ namespace ui {
 bool IsFeatureEnabled(FeatureFlag flag) {
   switch (flag) {
   case FeatureFlag::GenerateFixtureSymbols:
+  case FeatureFlag::LayoutViewerVboQuadBatch:
     return true;
   case FeatureFlag::PrintViewer2DDialog:
   case FeatureFlag::PrintViewer2DElementsDetail:

--- a/gui/ui_feature_flags.h
+++ b/gui/ui_feature_flags.h
@@ -29,6 +29,7 @@ enum class FeatureFlag {
   GenerateFixtureSymbols,
   AssignSelectedFixtureCategory,
   GdtfVerboseCatalogLogs,
+  LayoutViewerVboQuadBatch,
 };
 
 bool IsFeatureEnabled(FeatureFlag flag);


### PR DESCRIPTION
### Motivation
- Reduce driver overhead when drawing many textured layout view quads by batching draws into a VBO/VAO path while keeping the existing immediate-mode code as a safe fallback. 
- Keep visible output and draw ordering unchanged and gate the new path behind a UI feature flag so rollout and rollback are simple. 

### Description
- Added a new feature flag `ui::FeatureFlag::LayoutViewerVboQuadBatch` and enabled it by default to gate the new rendering path. 
- Extended `LayoutViewerPanel` with `TexturedQuadVertex`/`TexturedQuadBatch` types and private APIs `QueueTexturedQuad`, `FlushQueuedTexturedQuads`, and `DrawTexturedQuadImmediate` to collect runs by texture and submit them via a VBO/VAO path with automatic fallback to immediate mode. 
- Updated `DrawViewElement` in `gui/layoutviewerpanel_view.cpp` to route textured view draws through the feature-flagged batching path while leaving frame fill, border, and selection rendering unchanged. 
- Added concise one-line English comments above touched function definitions in `layoutviewerpanel_view.cpp` per code-style instructions. 

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb27b48a088324acb464849de38ca3)