### PR TITLE
Fix 2D layout offscreen state restoration target

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -2561,7 +2561,8 @@ bool LayoutViewerPanel::ProcessDirty2DViews(Viewer2DOffscreenRenderer *offscreen
         renderState.camera.viewportWidth = renderSize.GetWidth();
         renderState.camera.viewportHeight = renderSize.GetHeight();
         auto stateGuard = std::make_shared<viewer2d::ScopedViewer2DState>(
-            capturePanel, nullptr, cfg, renderState, nullptr, nullptr, false);
+            capturePanel, nullptr, cfg, renderState, capturePanel, nullptr,
+            false);
         std::vector<unsigned char> pixels;
         int width = 0;
         int height = 0;


### PR DESCRIPTION
### Motivation
- Prevent per-layout offscreen 2D render settings from being restored into the global Viewer2D instance when capturing layout view textures.
- The scoped state helper (`ScopedViewer2DState`) falls back to `Viewer2DPanel::Instance()` when no explicit restore panel is provided, which risked contaminating the main viewer state during offscreen captures.

### Description
- Change the `ScopedViewer2DState` instantiation in `gui/layoutviewerpanel.cpp` to pass `capturePanel` as the restore target so the temporary render state is restored to the offscreen capture panel instead of the global `Viewer2DPanel` (updated call to `ScopedViewer2DState(capturePanel, nullptr, cfg, renderState, capturePanel, nullptr, false)`).
- The fix is minimal and localized to the layout offscreen rendering path and does not alter other rendering logic or APIs.

### Testing
- Ran the mandatory architecture checks: `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb2aec3fe08324a1043530ea179922)