### PR TITLE
Fix macOS libc++ build break by replacing floating std::from_chars with strtod

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -19,9 +19,11 @@
 
 #include <algorithm>
 #include <array>
+#include <cerrno>
 #include <cctype>
 #include <charconv>
 #include <cmath>
+#include <cstdlib>
 #include <fstream>
 #include <functional>
 #include <iomanip>
@@ -370,6 +372,7 @@ void EnsureFixtureCategoryForImport(const MvrScene &scene, Fixture &fixture) {
     fixture.categorySourceReason.clear();
 }
 
+// Parses a trimmed float token and accepts only full-token numeric input.
 bool TryParseFloat(const std::string &text, float &out) {
   if (text.empty())
     return false;
@@ -386,12 +389,12 @@ bool TryParseFloat(const std::string &text, float &out) {
       }).base();
   std::string_view trimmed(&(*first), static_cast<size_t>(last - first));
 
-  float value = 0.0f;
-  auto begin = trimmed.data();
-  auto end = trimmed.data() + trimmed.size();
-  auto result = std::from_chars(begin, end, value);
-  if (result.ec == std::errc{} && result.ptr == end) {
-    out = value;
+  errno = 0;
+  std::string trimmedText(trimmed);
+  char *endPtr = nullptr;
+  const double parsed = std::strtod(trimmedText.c_str(), &endPtr);
+  if (endPtr == trimmedText.c_str() + trimmedText.size() && errno != ERANGE) {
+    out = static_cast<float>(parsed);
     return true;
   }
   return false;

--- a/core/units/units.cpp
+++ b/core/units/units.cpp
@@ -1,9 +1,10 @@
 #include "units.h"
 
 #include <algorithm>
-#include <charconv>
+#include <cerrno>
 #include <cmath>
 #include <cctype>
+#include <cstdlib>
 #include <iomanip>
 #include <sstream>
 
@@ -53,16 +54,16 @@ std::string ToLower(std::string value) {
   return value;
 }
 
+// Parses a fully-consumed double value from a trimmed string using std::strtod.
 std::optional<double> ParseDouble(const std::string &rawValue) {
   const std::string trimmed = Trim(rawValue);
   if (trimmed.empty())
     return std::nullopt;
 
-  double value = 0.0;
-  const char *start = trimmed.data();
-  const char *finish = trimmed.data() + trimmed.size();
-  const auto result = std::from_chars(start, finish, value);
-  if (result.ec != std::errc() || result.ptr != finish)
+  errno = 0;
+  char *endPtr = nullptr;
+  const double value = std::strtod(trimmed.c_str(), &endPtr);
+  if (endPtr != trimmed.c_str() + trimmed.size() || errno == ERANGE)
     return std::nullopt;
   return value;
 }

--- a/models/support.h
+++ b/models/support.h
@@ -20,7 +20,8 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
-#include <charconv>
+#include <cerrno>
+#include <cstdlib>
 #include <optional>
 #include <string>
 
@@ -73,6 +74,23 @@ inline const std::array<std::string, 5> &GetHoistFunctionOptions() {
     return options;
 }
 
+// Parses a full string as a double using std::strtod and rejects partial parses.
+inline bool TryParseFullDouble(const std::string &text, double &outValue) {
+    if (text.empty())
+        return false;
+
+    errno = 0;
+    char *endPtr = nullptr;
+    const double parsed = std::strtod(text.c_str(), &endPtr);
+    if (endPtr != text.c_str() + text.size())
+        return false;
+    if (errno == ERANGE)
+        return false;
+    outValue = parsed;
+    return true;
+}
+
+// Normalizes hoist function values to canonical options while preserving unknown text.
 inline std::string NormalizeHoistFunction(const std::string &rawValue) {
     auto trimmed = rawValue;
     auto trimSpaces = [](std::string &s) {
@@ -86,10 +104,7 @@ inline std::string NormalizeHoistFunction(const std::string &rawValue) {
         return "Lighting";
 
     double parsed = 0.0;
-    auto begin = trimmed.data();
-    auto end = trimmed.data() + trimmed.size();
-    auto result = std::from_chars(begin, end, parsed);
-    if (result.ec == std::errc{} && result.ptr == end) {
+    if (TryParseFullDouble(trimmed, parsed)) {
         if (parsed == 0.0)
             return "Lighting";
     }

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -48,7 +48,9 @@
 #include <array>
 #include <atomic>
 #include <cctype>
+#include <cerrno>
 #include <charconv>
+#include <cstdlib>
 #include <chrono>
 #include <cmath>
 #include <cstdio>
@@ -261,6 +263,7 @@ static bool IsPathLikelyTooLong(const fs::path &path) {
 #endif
 }
 
+// Parses a trimmed float token and accepts only full-token numeric input.
 static bool TryParseFloat(const std::string &text, float &out) {
   if (text.empty())
     return false;
@@ -277,12 +280,12 @@ static bool TryParseFloat(const std::string &text, float &out) {
       }).base();
   std::string_view trimmed(&(*first), static_cast<size_t>(last - first));
 
-  float value = 0.0f;
-  auto begin = trimmed.data();
-  auto end = trimmed.data() + trimmed.size();
-  auto result = std::from_chars(begin, end, value);
-  if (result.ec == std::errc{} && result.ptr == end) {
-    out = value;
+  errno = 0;
+  std::string trimmedText(trimmed);
+  char *endPtr = nullptr;
+  const double parsed = std::strtod(trimmedText.c_str(), &endPtr);
+  if (endPtr == trimmedText.c_str() + trimmedText.size() && errno != ERANGE) {
+    out = static_cast<float>(parsed);
     return true;
   }
   return false;

--- a/viewer3d/gdtfloader.cpp
+++ b/viewer3d/gdtfloader.cpp
@@ -24,7 +24,9 @@
 #include "consolepanel.h"
 
 #include <cctype>
+#include <cerrno>
 #include <charconv>
+#include <cstdlib>
 #include <string_view>
 #include <tinyxml2.h>
 #include <wx/wx.h>
@@ -52,6 +54,7 @@ class wxZipStreamLink;
 namespace fs = std::filesystem;
 
 namespace {
+// Parses a trimmed float token and succeeds only when the whole token is numeric.
 bool TryParseFloat(const std::string& text, float& out)
 {
     if (text.empty())
@@ -67,12 +70,12 @@ bool TryParseFloat(const std::string& text, float& out)
     }).base();
     std::string_view trimmed(&(*first), static_cast<size_t>(last - first));
 
-    float value = 0.0f;
-    auto begin = trimmed.data();
-    auto end = trimmed.data() + trimmed.size();
-    auto result = std::from_chars(begin, end, value);
-    if (result.ec == std::errc{} && result.ptr == end) {
-        out = value;
+    errno = 0;
+    std::string trimmedText(trimmed);
+    char* endPtr = nullptr;
+    const double parsed = std::strtod(trimmedText.c_str(), &endPtr);
+    if (endPtr == trimmedText.c_str() + trimmedText.size() && errno != ERANGE) {
+        out = static_cast<float>(parsed);
         return true;
     }
     return false;


### PR DESCRIPTION
### Motivation
- AppleClang/libc++ lacks reliable `std::from_chars` overloads for floating-point types, causing macOS builds to fail with "call to deleted function 'from_chars'" errors.
- Ensure parsing of floats/doubles is portable across macOS, Linux and Windows while preserving the original full-token parse semantics and behaviour (e.g. zero -> `"Lighting"` in hoist normalization).
- Keep integer `std::from_chars` usages intact to retain fast, exception-free integer parsing.

### Description
- Added a reusable helper `TryParseFullDouble` in `models/support.h` that parses a full string as `double` using `std::strtod` and rejects partial parses and range errors using `errno`.
- Replaced floating-point `std::from_chars` usage in `NormalizeHoistFunction` with `TryParseFullDouble` so empty/zero handling and name normalization behavior is preserved.
- Replaced other floating-point parsing helpers with `std::strtod`-based implementations in `core/riderimporter.cpp`, `core/units/units.cpp` (`ParseDouble`), `mvr/mvrimporter.cpp`, and `viewer3d/gdtfloader.cpp` to accept only fully-consumed numeric tokens and reject range errors.
- Added `#include <cerrno>` and `#include <cstdlib>` where needed and added concise one-line English comments above each touched function definition describing the function purpose, per repository instruction.
- Left integer `std::from_chars` calls unchanged.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both succeeded.
- Ran `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`, which failed to configure in this environment due to missing `wxWidgets` dependencies, so a full build could not be completed here.
- The change removes floating `std::from_chars` usages and the previous macOS error location in `models/support.h` is addressed; platform builds should be validated on CI with macOS runners that have `wxWidgets` installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb332889348324b96178dcd9a551f8)