### PR TITLE
Harden unsigned macOS DMG packaging workflow

### DIFF
--- a/.github/workflows/macos-installer.yml
+++ b/.github/workflows/macos-installer.yml
@@ -111,20 +111,66 @@ jobs:
           test -f out/install/Release/Perastage.app/Contents/Resources/PerastageProject.icns
           test -f out/install/Release/Perastage.app/Contents/Resources/PerastageMVR.icns
 
-      # ── 10. Upload staged build ─────────────────────────────────────────────
+      # ── 10. Validate and prepare staged macOS app bundle ─────────────────────
+      - name: Validate staged app bundle
+        run: |
+          test -d out/install/Release/Perastage.app
+          test -f out/install/Release/Perastage.app/Contents/Info.plist
+          test -f out/install/Release/Perastage.app/Contents/MacOS/Perastage
+          test -x out/install/Release/Perastage.app/Contents/MacOS/Perastage
+          test -f out/install/Release/Perastage.app/Contents/Resources/Perastage.icns
+          test -f out/install/Release/Perastage.app/Contents/Resources/PerastageProject.icns
+          test -f out/install/Release/Perastage.app/Contents/Resources/PerastageMVR.icns
+          ls -l out/install/Release/Perastage.app/Contents/MacOS/
+          plutil -lint out/install/Release/Perastage.app/Contents/Info.plist
+          codesign -dv --verbose=4 out/install/Release/Perastage.app || true
+
+      - name: Remove quarantine from staged app bundle
+        run: |
+          xattr -cr "out/install/Release/Perastage.app" || true
+
+      - name: Ad-hoc sign staged app bundle
+        run: |
+          codesign --force --deep --sign - "out/install/Release/Perastage.app"
+          codesign --verify --deep --strict --verbose=2 "out/install/Release/Perastage.app"
+
+      # ── 11. Upload staged build ─────────────────────────────────────────────
       - name: Upload staged distribution
         uses: actions/upload-artifact@v4
         with:
           name: Perastage-macos-staged
           path: out/install/Release
 
-      # ── 11. Build DMG package ───────────────────────────────────────────────
+      # ── 12. Build DMG package ───────────────────────────────────────────────
       - name: Build macOS DMG
         run: |
           cmake --build build --config Release --target package --verbose
           find build -name "*.dmg" -print || true
 
-      # ── 12. Collect DMG package ─────────────────────────────────────────────
+      # ── 13. Validate generated DMG ───────────────────────────────────────────
+      - name: Validate generated DMG
+        run: |
+          DMG_FILE="$(find build -name "*.dmg" -print -quit)"
+          if [ -z "$DMG_FILE" ]; then
+            echo "DMG not found"
+            exit 1
+          fi
+
+          MOUNT_DIR="$(mktemp -d)"
+          cleanup() {
+            hdiutil detach "$MOUNT_DIR" >/dev/null 2>&1 || true
+            rmdir "$MOUNT_DIR" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+
+          hdiutil attach "$DMG_FILE" -mountpoint "$MOUNT_DIR" -nobrowse -readonly
+
+          test -d "$MOUNT_DIR/Perastage.app"
+          test -x "$MOUNT_DIR/Perastage.app/Contents/MacOS/Perastage"
+          plutil -lint "$MOUNT_DIR/Perastage.app/Contents/Info.plist"
+          codesign --verify --deep --strict --verbose=2 "$MOUNT_DIR/Perastage.app" || true
+
+      # ── 14. Collect DMG package ─────────────────────────────────────────────
       - name: Collect macOS DMG
         run: |
           mkdir -p out/installer
@@ -135,9 +181,10 @@ jobs:
           fi
           echo "Using DMG: $dmg_file"
           cp "$dmg_file" out/installer/
+          xattr -c out/installer/*.dmg || true
           find out/installer -maxdepth 2 -name "*.dmg" -print
 
-      # ── 13. Upload DMG package ──────────────────────────────────────────────
+      # ── 15. Upload DMG package ──────────────────────────────────────────────
       - name: Upload macOS DMG
         uses: actions/upload-artifact@v4
         with:

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -100,6 +100,56 @@ During `cmake --install`, cache refresh commands may run to expose new associati
 
 Perastage app bundles declare `.mvr` document type metadata through bundle settings so Finder can route files to the application.
 
+## macOS DMG Packaging (Unsigned Builds)
+
+Perastage macOS CI currently produces an unsigned/not-notarized `.app` and `.dmg` because there is no Apple Developer ID certificate configured for this project.
+
+### What CI validates
+
+The macOS installer workflow validates that:
+
+- `Perastage.app` is staged with expected bundle layout (`Contents/Info.plist`, executable, and `.icns` files).
+- The executable keeps its executable bit.
+- `Info.plist` passes `plutil -lint`.
+- The app is ad-hoc signed (`codesign --sign -`) and verified for internal signature consistency.
+- Quarantine metadata is cleared from the staged app and collected DMG in CI.
+- The generated DMG mounts successfully and contains a launchable `Perastage.app` bundle.
+
+### Expected first-run behavior on end-user macOS systems
+
+When users download builds from the internet, macOS can add quarantine metadata again, even if CI removed it during packaging.
+
+Because the app is unsigned/not notarized, users may see messages such as:
+
+- `"Perastage" is damaged and can't be opened.`
+- `"Perastage" cannot be opened because the developer cannot be verified.`
+
+This is expected for non-notarized internet downloads. The long-term production fix is Developer ID signing + notarization.
+
+### User workaround for quarantine blocking
+
+If the app is copied to `/Applications`:
+
+```bash
+xattr -dr com.apple.quarantine /Applications/Perastage.app
+```
+
+If running from Downloads:
+
+```bash
+xattr -dr com.apple.quarantine ~/Downloads/Perastage.app
+```
+
+GUI alternative:
+
+1. Open **System Settings**.
+2. Go to **Privacy & Security**.
+3. Use the **Allow/Open anyway** option shown for the blocked app.
+
+### Distribution note
+
+GitHub Actions artifacts are downloaded as ZIP files, which may preserve or add quarantine metadata. For public releases, prefer attaching the `.dmg` directly as a GitHub Release asset.
+
 ## Related Documents
 
 - [Build and dependency guide](build.md)


### PR DESCRIPTION
### Motivation

- Prevent macOS from reporting the app as "damaged" by ensuring the CI-staged bundle is internally consistent and preserves executable permissions even when no Apple Developer certificate is available.
- Remove avoidable quarantine metadata added during CI packaging and validate the DMG contents to catch packaging regressions early in the macOS pipeline.
- Provide concise user-facing guidance for handling Gatekeeper/quarantine for unsigned builds until Developer ID signing and notarization are possible.

### Description

- Update `.github/workflows/macos-installer.yml` to validate the staged bundle with checks for `Contents/Info.plist`, the `Contents/MacOS/Perastage` executable (presence and `-x`), and `.icns` resources, and to print diagnostics with `ls` / `plutil` / `codesign -dv`.
- Clear quarantine metadata from the staged app with `xattr -cr`, perform an ad-hoc sign using `codesign --force --deep --sign -`, and verify the signature with `codesign --verify --deep --strict` before building the DMG.
- After CPack produces the DMG, validate the image by locating the `.dmg`, mounting it read-only with `hdiutil`, asserting that `Perastage.app` exists and the executable bit is present, linting the mounted `Info.plist`, running a best-effort `codesign --verify`, and ensuring the DMG is detached cleanly via `trap`.
- Clear quarantine metadata from the collected DMG with `xattr -c` before upload, keep both existing artifacts (`Perastage-macos-staged` and `Perastage-macos-dmg`) intact, and add a new `## macOS DMG Packaging (Unsigned Builds)` section in `docs/packaging.md` documenting limitations and user workarounds (including `xattr -dr com.apple.quarantine …` and GUI steps).

### Testing

- Ran `tests/check_perastage_tree_modules.sh` which passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb678e2c988324bd4b0f566f163628)