### PR TITLE
Fix macOS installer signing flow to avoid damaged app bundles

### DIFF
--- a/.github/workflows/macos-installer.yml
+++ b/.github/workflows/macos-installer.yml
@@ -129,10 +129,26 @@ jobs:
         run: |
           xattr -cr "out/install/Release/Perastage.app" || true
 
-      - name: Ad-hoc sign staged app bundle
+      - name: Re-sign staged app bundle for Gatekeeper compatibility
         run: |
-          codesign --force --deep --sign - "out/install/Release/Perastage.app"
-          codesign --verify --deep --strict --verbose=2 "out/install/Release/Perastage.app"
+          APP_PATH="out/install/Release/Perastage.app"
+
+          # Re-sign every embedded Mach-O binary to avoid broken nested signatures.
+          while IFS= read -r file_path; do
+            if file "$file_path" | grep -q "Mach-O"; then
+              codesign --force --sign - --timestamp=none "$file_path"
+            fi
+          done < <(find "$APP_PATH" -type f)
+
+          # Re-sign every embedded framework bundle after signing its binaries.
+          while IFS= read -r framework_path; do
+            codesign --force --sign - --timestamp=none "$framework_path"
+          done < <(find "$APP_PATH/Contents/Frameworks" -type d -name "*.framework" 2>/dev/null || true)
+
+          # Re-sign the full .app bundle once all nested content has stable signatures.
+          codesign --force --sign - --timestamp=none "$APP_PATH"
+          codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+          spctl --assess --type execute --verbose=4 "$APP_PATH" || true
 
       # ── 11. Upload staged build ─────────────────────────────────────────────
       - name: Upload staged distribution
@@ -157,6 +173,7 @@ jobs:
           fi
 
           MOUNT_DIR="$(mktemp -d)"
+          # Detach the mounted DMG and remove the temporary mount directory.
           cleanup() {
             hdiutil detach "$MOUNT_DIR" >/dev/null 2>&1 || true
             rmdir "$MOUNT_DIR" >/dev/null 2>&1 || true


### PR DESCRIPTION
### Motivation
- Downloaded macOS DMG artifacts were reported as "damaged" on user machines due to broken nested signatures created by the CI signing step while local builds still launched with only the unidentified-developer warning.

### Description
- Replace the single `codesign --deep` ad-hoc step with a deterministic re-sign sequence that signs embedded Mach-O binaries first, then framework bundles, and finally the `.app` bundle in the CI workflow (`.github/workflows/macos-installer.yml`).
- Add `spctl --assess` to the workflow to capture Gatekeeper assessment details during CI validation.
- Add a one-line English comment above the `cleanup()` function used during DMG validation to satisfy the requested function-commenting guidance.
- Preserve ad-hoc signing (no Developer ID/notarization) and keep existing validation commands such as `plutil` and `codesign --verify` in the workflow.

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which succeeded.
- The CI workflow now includes automated DMG validation steps (`plutil`, `codesign --verify`, `spctl --assess`) that will run on macOS runners during the packaging job for additional diagnostics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb6e39d36083249fb4e99ed5d1cd68)