### PR TITLE
Guard MainWindow lifetime in IO controller to fix macOS MVR open crash

### DIFF
--- a/gui/mainwindow/controllers/mainwindow_io_controller.cpp
+++ b/gui/mainwindow/controllers/mainwindow_io_controller.cpp
@@ -33,16 +33,20 @@
 #include "viewer2drenderpanel.h"
 #include "viewer3dpanel.h"
 
+// Stores a weak owner reference to prevent dereferencing MainWindow after destruction.
+MainWindowIoController::MainWindowIoController(MainWindow &owner)
+    : ownerRef_(&owner) {}
+
 // Imports an MVR file from disk, preserving selected UI config keys and refreshing dependent panels.
 bool MainWindowIoController::ImportMvrFromPath(const std::string &pathUtf8) {
   constexpr const char *kLayoutsConfigKey = "layouts_collection";
   constexpr const char *kViewer3DRenderStyleConfigKey = "viewer3d_render_style";
-  wxWeakRef<MainWindow> ownerRef(&owner_);
+  wxWeakRef<MainWindow> ownerRef = ownerRef_;
   if (!ownerRef || ownerRef->guiConfigServices == nullptr)
     return false;
   const wxString filePath = wxString::FromUTF8(pathUtf8);
   ConfigManager &cfg =
-      owner_.guiConfigServices->LegacyConfigManager();
+      ownerRef->guiConfigServices->LegacyConfigManager();
   const std::optional<std::string> preservedLayoutsConfig =
       cfg.GetValue(kLayoutsConfigKey);
   const std::optional<std::string> preservedViewer3DRenderStyle =
@@ -204,7 +208,10 @@ bool MainWindowIoController::ImportMvrFromPath(const std::string &pathUtf8) {
 void MainWindowIoController::OnImportMVR(wxCommandEvent &) {
   wxString miscDir =
       wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("misc"));
-  wxFileDialog openFileDialog(&owner_, "Import MVR file", miscDir, "",
+  if (!ownerRef_)
+    return;
+
+  wxFileDialog openFileDialog(ownerRef_.get(), "Import MVR file", miscDir, "",
                               "MVR files (*.mvr)|*.mvr",
                               wxFD_OPEN | wxFD_FILE_MUST_EXIST);
 
@@ -220,7 +227,7 @@ void MainWindowIoController::OnImportMVR(wxCommandEvent &) {
 // Applies the official MVR-open policy by confirming unsaved changes before importing the file.
 bool MainWindowIoController::ImportMvrWithOfficialPolicy(
     const std::string &pathUtf8) {
-  if (!owner_.ConfirmSaveIfDirty(kMvrOpenAction, kMvrOpenTitle))
+  if (!ownerRef_ || !ownerRef_->ConfirmSaveIfDirty(kMvrOpenAction, kMvrOpenTitle))
     return false;
 
   // Official policy for .mvr open/import actions:
@@ -232,6 +239,10 @@ bool MainWindowIoController::ImportMvrWithOfficialPolicy(
 // Routes startup file paths to the corresponding project or MVR open workflow.
 bool MainWindowIoController::OpenPathFromCommandLine(
     const std::string &pathUtf8) {
+  if (!ownerRef_)
+    return false;
+
+  MainWindow *owner = ownerRef_.get();
   std::string extension = wxFileName(wxString::FromUTF8(pathUtf8)).GetExt()
                               .Lower()
                               .ToStdString();
@@ -241,24 +252,24 @@ bool MainWindowIoController::OpenPathFromCommandLine(
                                      .ToStdString();
 
   if (extension == projectExtension) {
-    if (!owner_.ConfirmSaveIfDirty("loading a project", "Open Project"))
+    if (!owner->ConfirmSaveIfDirty("loading a project", "Open Project"))
       return false;
 
-    if (!owner_.LoadProjectFromPath(pathUtf8)) {
+    if (!owner->LoadProjectFromPath(pathUtf8)) {
       wxMessageBox("Failed to load project.", "Error", wxOK | wxICON_ERROR,
-                   &owner_);
-      if (owner_.GetStatusBar())
-        owner_.SetStatusText("Project load failed.", 0);
-      if (owner_.consolePanel) {
-        owner_.consolePanel->AppendMessage("Failed to load " +
+                   owner);
+      if (owner->GetStatusBar())
+        owner->SetStatusText("Project load failed.", 0);
+      if (owner->consolePanel) {
+        owner->consolePanel->AppendMessage("Failed to load " +
                                            wxString::FromUTF8(pathUtf8));
       }
       return false;
     }
 
-    if (owner_.GetStatusBar()) {
+    if (owner->GetStatusBar()) {
       wxFileName fileInfo(wxString::FromUTF8(pathUtf8));
-      owner_.SetStatusText("Project loaded: " + fileInfo.GetFullName(), 0);
+      owner->SetStatusText("Project loaded: " + fileInfo.GetFullName(), 0);
     }
     return true;
   }
@@ -266,15 +277,15 @@ bool MainWindowIoController::OpenPathFromCommandLine(
   if (extension == "mvr")
     return ImportMvrWithOfficialPolicy(pathUtf8);
 
-  if (owner_.GetStatusBar())
-    owner_.SetStatusText("Unsupported startup file format.", 0);
-  if (owner_.consolePanel) {
-    owner_.consolePanel->AppendMessage("Unsupported startup file: " +
+  if (owner->GetStatusBar())
+    owner->SetStatusText("Unsupported startup file format.", 0);
+  if (owner->consolePanel) {
+    owner->consolePanel->AppendMessage("Unsupported startup file: " +
                                        wxString::FromUTF8(pathUtf8));
   }
   wxMessageBox("Unsupported startup file. Use " +
                    wxString::FromUTF8(ProjectUtils::PROJECT_EXTENSION) +
                    " or .mvr files.",
-               "Unsupported file", wxOK | wxICON_WARNING, &owner_);
+               "Unsupported file", wxOK | wxICON_WARNING, owner);
   return false;
 }

--- a/gui/mainwindow/controllers/mainwindow_io_controller.h
+++ b/gui/mainwindow/controllers/mainwindow_io_controller.h
@@ -2,12 +2,14 @@
 
 #include <string>
 
+#include <wx/weakref.h>
+
 class MainWindow;
 class wxCommandEvent;
 
 class MainWindowIoController {
 public:
-  explicit MainWindowIoController(MainWindow &owner) : owner_(owner) {}
+  explicit MainWindowIoController(MainWindow &owner);
   void OnImportMVR(wxCommandEvent &event);
   bool OpenPathFromCommandLine(const std::string &pathUtf8);
 
@@ -17,5 +19,5 @@ private:
 
   bool ImportMvrFromPath(const std::string &pathUtf8);
   bool ImportMvrWithOfficialPolicy(const std::string &pathUtf8);
-  MainWindow &owner_;
+  wxWeakRef<MainWindow> ownerRef_;
 };


### PR DESCRIPTION
### Motivation
- A macOS crash (SIGSEGV) was traced to `MainWindowIoController::ImportMvrFromPath` dereferencing a stale `MainWindow` during startup/open-file flows. 
- Prevent dereferencing a destroyed window when deferred startup or Finder double-click events race with window lifetime. 

### Description
- Replace the raw `MainWindow& owner_` with `wxWeakRef<MainWindow> ownerRef_` in `gui/mainwindow/controllers/mainwindow_io_controller.{h,cpp}`. 
- Add an out-of-line constructor `MainWindowIoController::MainWindowIoController(MainWindow &owner)` that initializes the weak reference and a short comment above it. 
- Add defensive owner existence checks and switch internal uses to the validated weak reference in `ImportMvrFromPath`, `OnImportMVR`, `ImportMvrWithOfficialPolicy`, and `OpenPathFromCommandLine` so operations bail out safely when the owner is gone. 
- Keep import behavior and UI updates unchanged apart from accessing `guiConfigServices` and other members through the guarded weak owner. 

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb9e7f16f4832493e80ad5aebee392)