### PR TITLE
Normalize macOS external-open paths so associated .mvr files import correctly

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -35,6 +35,7 @@
 #endif
 #include <wx/stackwalk.h>
 #include <wx/sysopt.h>
+#include <wx/uri.h>
 #include <wx/weakref.h>
 #include <wx/wx.h>
 #include <wx/filename.h>
@@ -64,6 +65,34 @@ private:
 };
 
 namespace {
+// Converts macOS file URLs or raw paths into a normalized UTF-8 filesystem path when possible.
+std::string NormalizeExternalOpenPath(const std::string &rawPathUtf8) {
+  if (rawPathUtf8.empty())
+    return {};
+
+  wxString wxPath = wxString::FromUTF8(rawPathUtf8);
+  if (wxPath.StartsWith("file://")) {
+    wxURI uri(wxPath);
+    if (uri.IsReference() && uri.HasPath()) {
+      wxString unescaped = wxURI::Unescape(uri.GetPath());
+      if (!unescaped.empty())
+        wxPath = unescaped;
+    }
+  }
+
+  wxFileName fileName(wxPath);
+  if (fileName.Normalize(wxPATH_NORM_DOTS | wxPATH_NORM_TILDE |
+                         wxPATH_NORM_ABSOLUTE)) {
+    wxPath = fileName.GetFullPath();
+  }
+
+  wxCharBuffer utf8 = wxPath.ToUTF8();
+  if (utf8)
+    return std::string(utf8.data());
+  return rawPathUtf8;
+}
+
+// Converts an ASCII string to lowercase.
 std::string ToLowerAscii(std::string text) {
   std::transform(text.begin(), text.end(), text.begin(), [](unsigned char c) {
     return static_cast<char>(std::tolower(c));
@@ -219,12 +248,12 @@ bool MyApp::OnInit() {
   return true;
 }
 
-// Routes macOS single-file open requests to the external open pipeline.
+// Routes a single macOS file-open request to the shared external-open handler.
 void MyApp::MacOpenFile(const wxString &fileName) {
   const wxCharBuffer utf8 = fileName.ToUTF8();
-  const std::string pathUtf8 =
+  const std::string rawPathUtf8 =
       utf8 ? std::string(utf8.data()) : fileName.ToStdString();
-  HandleExternalOpenPath(pathUtf8);
+  HandleExternalOpenPath(NormalizeExternalOpenPath(rawPathUtf8));
 }
 
 // Routes macOS multi-file open requests to the external open pipeline in order.


### PR DESCRIPTION
### Motivation
- macOS can deliver associated-file opens as `file://` URLs or URL-encoded paths which the existing pipeline forwarded raw to the importer, causing .mvr double-click opens to launch the app but not import the file.
- Normalizing the incoming path earlier removes format mismatches between macOS and Windows ingestion and avoids downstream extension-detection failures.
- Keep changes narrowly scoped to the external-open ingestion stage to avoid touching import logic or project loading behavior.

### Description
- Added `NormalizeExternalOpenPath(const std::string &)` to convert `file://` URLs and URL-encoded segments into an unescaped, normalized absolute filesystem UTF-8 path when possible. 
- Updated `MyApp::MacOpenFile(...)` to pass the normalized path into `HandleExternalOpenPath(...)` instead of forwarding the raw Apple-event string. 
- Included `<wx/uri.h>` and used `wxURI::Unescape` and `wxFileName::Normalize(...)` to safely handle URL escapes, `~`, `.` and relative paths. 
- Added concise one-line English comments for the new and updated function definitions introduced in this change.

### Testing
- Ran `./tests/check_perastage_tree_modules.sh` which completed successfully. 
- Ran `./tests/check_no_configmanager_get_in_gui.sh` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc4a7d30f08324bca4d50be1f52730)