### PR TITLE
Standardize Linux installer workflow naming in GitHub Actions

### DIFF
--- a/.github/workflows/linux-installer.yml
+++ b/.github/workflows/linux-installer.yml
@@ -1,4 +1,4 @@
-name: Linux AppImage Build
+name: Linux Ubuntu Installer Build
 
 on:
   workflow_dispatch:
@@ -44,7 +44,7 @@ jobs:
             .vcpkg-cache/downloads
             .vcpkg-cache/installed
             .vcpkg-cache/packages
-          key: ${{ runner.os }}-vcpkg-x64-linux-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', '.github/workflows/linux-appimage.yml') }}
+          key: ${{ runner.os }}-vcpkg-x64-linux-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', '.github/workflows/linux-installer.yml') }}
           restore-keys: |
             ${{ runner.os }}-vcpkg-x64-linux-
             ${{ runner.os }}-vcpkg-


### PR DESCRIPTION
### Motivation
- Ensure all installer workflows follow a consistent naming pattern in GitHub Actions and avoid cache key mismatches when the workflow file is renamed.

### Description
- Renamed `.github/workflows/linux-appimage.yml` to `.github/workflows/linux-installer.yml`, updated the workflow `name` to `Linux Ubuntu Installer Build`, and adjusted the `hashFiles(...)` entry used in the vcpkg cache key to reference the new file path.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc4f4bde148324aec13bb0ad84aaaa)