### PR TITLE
ci: fix Ubuntu installer build by adding missing autoreconf dependencies

### DIFF
--- a/.github/workflows/linux-installer.yml
+++ b/.github/workflows/linux-installer.yml
@@ -39,6 +39,9 @@ jobs:
             autoconf-archive \
             automake \
             libtool \
+            gettext \
+            autopoint \
+            m4 \
             curl \
             unzip \
             zip \


### PR DESCRIPTION
### Motivation
- The Ubuntu runner was failing during `vcpkg`'s `vcpkg_run_autoreconf` for `libxcrypt:x64-linux` because required GNU autotools helper packages were not installed.

### Description
- Install `gettext`, `autopoint`, and `m4` in the `Install Linux build dependencies` step of `.github/workflows/linux-installer.yml` to satisfy autotools/autoreconf prerequisites.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc5342a2508324bdeba79d73a35bc3)