### PR TITLE
Guard startup file-open callbacks during MainWindow shutdown

### DIFF
--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -163,8 +163,9 @@ void MainWindow::OnLoad(wxCommandEvent &event) {
                  this);
 }
 
+// Delegates startup/open-file requests to the IO controller when it is still available.
 bool MainWindow::OpenPathFromCommandLine(const std::string &path) {
-  if (!ioController)
+  if (!ioController || IsBeingDeleted())
     return false;
   return ioController->OpenPathFromCommandLine(path);
 }

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "mainwindow.h"
+#include "mainwindow/controllers/mainwindow_io_controller.h"
 #include "mainwindow_view_controller.h"
 
 #include <algorithm>

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -936,6 +936,7 @@ void MainWindow::OnClose(wxCommandEvent &event) {
   Close(false);
 }
 
+// Persists state, stops live workers, and detaches IO callbacks before destroying the main window.
 void MainWindow::OnCloseWindow(wxCloseEvent &event) {
   SaveUserConfigWithViewport2DState();
   if (!ConfirmSaveIfDirty("exiting", "Exit")) {
@@ -948,6 +949,7 @@ void MainWindow::OnCloseWindow(wxCloseEvent &event) {
   if (viewportPanel)
     viewportPanel->StopRefreshThread();
   viewportPanel = nullptr;
+  ioController.reset();
 
   Destroy();
 }


### PR DESCRIPTION
### Motivation
- A macOS crash (SIGSEGV) was observed when deferred file-open callbacks routed to `MainWindowIoController::OpenPathFromCommandLine` ran while the main window was shutting down, so incoming open-path events must not dereference torn-down window/controller state.

### Description
- Add a teardown guard to `MainWindow::OpenPathFromCommandLine` so it returns early if `ioController` is missing or the window `IsBeingDeleted()` to avoid delegating during destruction.  
- Reset `ioController` in `MainWindow::OnCloseWindow` before calling `Destroy()` to detach IO callbacks and reduce the window-teardown race.  
- Add concise one-line English comments above the two modified function definitions to describe their purpose.  

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which completed successfully.  
- Ran `tests/check_no_configmanager_get_in_gui.sh` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc5436d8488324ac64256a9b15a98e)