### PR TITLE
Install libltdl-dev in Linux CI and document LabelWithUnit helper

### DIFF
--- a/.github/workflows/linux-installer.yml
+++ b/.github/workflows/linux-installer.yml
@@ -39,6 +39,7 @@ jobs:
             autoconf-archive \
             automake \
             libtool \
+            libltdl-dev \
             gettext \
             autopoint \
             m4 \

--- a/core/units/unit_label_utils.cpp
+++ b/core/units/unit_label_utils.cpp
@@ -2,6 +2,7 @@
 
 namespace Units {
 
+// Builds a display label by appending the unit suffix in parentheses.
 std::string LabelWithUnit(const std::string &label, const std::string &unitSuffix) {
   return label + " (" + unitSuffix + ")";
 }


### PR DESCRIPTION
### Motivation
- Provide the `libltdl-dev` system package in the Linux CI image to satisfy linker/loader dependencies and add a brief clarifying comment for the `LabelWithUnit` helper.

### Description
- Add `libltdl-dev` to the `apt-get install` list in `.github/workflows/linux-installer.yml` and insert a documenting comment above `Units::LabelWithUnit` in `core/units/unit_label_utils.cpp`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc5570cbac8324885d614dbe0edf45)