### PR TITLE
CI: install X11 dev packages for Linux AppImage build

### DIFF
--- a/.github/workflows/linux-installer.yml
+++ b/.github/workflows/linux-installer.yml
@@ -46,7 +46,11 @@ jobs:
             curl \
             unzip \
             zip \
-            patchelf
+            patchelf \
+            libx11-dev \
+            libxau-dev \
+            libxdmcp-dev \
+            xorgproto
 
 
       # ── 3. Cache vcpkg installed tree + downloads ─────────────────────────


### PR DESCRIPTION
### Motivation
- The Linux CI job failed during vcpkg's build of `cairo` because Meson's runtime probe couldn't find the `x11` dependency on the Ubuntu runner.

### Description
- Add `libx11-dev`, `libxau-dev`, `libxdmcp-dev`, and `xorgproto` to the apt install step in `.github/workflows/linux-installer.yml` to provide headers/pkg-config data required by the `x11` probe.

### Testing
- Executed `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc5a65209c83249e68bef2aa08571b)