### PR TITLE
Fix startup external MVR path normalization for macOS and Windows

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -73,7 +73,7 @@ std::string NormalizeExternalOpenPath(const std::string &rawPathUtf8) {
   wxString wxPath = wxString::FromUTF8(rawPathUtf8);
   if (wxPath.StartsWith("file://")) {
     wxURI uri(wxPath);
-    if (uri.IsReference() && uri.HasPath()) {
+    if (uri.HasPath()) {
       wxString unescaped = wxURI::Unescape(uri.GetPath());
       if (!unescaped.empty())
         wxPath = unescaped;
@@ -100,6 +100,7 @@ std::string ToLowerAscii(std::string text) {
   return text;
 }
 
+// Returns the first startup-open candidate from CLI arguments as a normalized absolute UTF-8 path.
 std::optional<std::string> GetStartupPathFromArgs(
     int argc, wxChar **argv, const std::string &launchWorkingDirectoryUtf8) {
   namespace fs = std::filesystem;
@@ -117,11 +118,18 @@ std::optional<std::string> GetStartupPathFromArgs(
   };
 
   for (int i = 1; i < argc; ++i) {
-    const std::string rawPath = toUtf8(wxString(argv[i]));
+    wxString argumentText(argv[i]);
+    if ((argumentText.StartsWith("\"") && argumentText.EndsWith("\"")) ||
+        (argumentText.StartsWith("'") && argumentText.EndsWith("'"))) {
+      argumentText = argumentText.Mid(1, argumentText.length() - 2);
+    }
+
+    const std::string rawPath = toUtf8(argumentText);
     if (rawPath.empty())
       continue;
 
-    const fs::path candidate = fs::u8path(rawPath);
+    const std::string normalizedRawPath = NormalizeExternalOpenPath(rawPath);
+    const fs::path candidate = fs::u8path(normalizedRawPath);
     const std::u8string extensionU8 = candidate.extension().u8string();
     const std::string extension(extensionU8.begin(), extensionU8.end());
     const std::string normalizedExtension = ToLowerAscii(extension);
@@ -136,10 +144,10 @@ std::optional<std::string> GetStartupPathFromArgs(
       absolutePath = fs::absolute(candidate, ec);
     }
     if (ec)
-      return rawPath;
+      return normalizedRawPath;
     const std::u8string absoluteU8 = absolutePath.u8string();
     if (absoluteU8.empty())
-      return rawPath;
+      return normalizedRawPath;
     return std::string(absoluteU8.begin(), absoluteU8.end());
   }
   return std::nullopt;


### PR DESCRIPTION
### Motivation
- Double-click launches of `.mvr` files could leave Perastage open without importing the file on macOS and in some Windows shell-launch cases due to inconsistent startup path normalization and quoted argv variants.

### Description
- Use `wxURI::HasPath()` when decoding `file://` URIs in `NormalizeExternalOpenPath` so macOS Finder `file://` references reliably decode to filesystem paths.
- Strip optional surrounding single/double quotes from startup `argv` entries before processing so shell-quoted paths are handled correctly. 
- Normalize CLI startup paths via `NormalizeExternalOpenPath` before extension checks and absolute-path resolution, and return the normalized raw path on filesystem conversion errors to preserve a usable fallback.
- Add a concise one-line English comment above `GetStartupPathFromArgs` as requested; all edits are contained in `main.cpp`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed successfully. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc5b97abe083248358a96f5dae802f)