### PR TITLE
Fix Ubuntu package name in Linux installer workflow

### DIFF
--- a/.github/workflows/linux-installer.yml
+++ b/.github/workflows/linux-installer.yml
@@ -50,7 +50,7 @@ jobs:
             libx11-dev \
             libxau-dev \
             libxdmcp-dev \
-            xorgproto
+            xorgproto-dev
 
 
       # ── 3. Cache vcpkg installed tree + downloads ─────────────────────────


### PR DESCRIPTION
### Motivation
- Fix CI failure on Ubuntu 24.04 where `apt` could not find package `xorgproto` during the workflow dependency installation.

### Description
- Replace `xorgproto` with `xorgproto-dev` in the install step of `.github/workflows/linux-installer.yml` so the dependency can be resolved on Ubuntu `noble`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc5c8b4f988324ac438752bf320bf6)