### PR TITLE
Fix macOS .mvr double-click open/import routing during startup

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1172,6 +1172,7 @@ void MainWindow::SyncLayerVisibilityPanels() {
   }
 }
 
+// Handles startup project-load completion and queues deferred external file opens when needed.
 void MainWindow::OnProjectLoaded(wxCommandEvent &event) {
   bool loaded = event.GetInt() != 0;
   bool clearLastProject = event.GetExtraLong() != 0;
@@ -1239,13 +1240,16 @@ void MainWindow::OnProjectLoaded(wxCommandEvent &event) {
   } else {
     ResetProject(true);
     if (!path.empty()) {
-      deferredStartupOpenPath = path;
+      QueueDeferredStartupOpenPath(path);
       // When launched by double-click/file association, some platforms may
       // delay idle processing. Schedule an explicit startup completion pass so
       // deferred command-line open does not depend exclusively on idle timing.
       CallAfter([this]() { CompleteStartupSplashInitialization(); });
     }
+    SetStartupProjectLoadPending(false);
+    ProcessDeferredStartupOpenPath();
     RequestStartupSplashCompletion();
+    return;
   }
   SetStartupProjectLoadPending(false);
 }

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -250,6 +250,8 @@ private:
   void ClearBlockingProjectLoadUi();
   void CompleteStartupSplashInitialization();
   void RequestStartupSplashCompletion();
+  void QueueDeferredStartupOpenPath(const std::string &path);
+  void ProcessDeferredStartupOpenPath();
   void OnStartupSplashCloseIdle(wxIdleEvent &event);
   void FlushPendingFixtureSymbolLibraryUpdates();
   std::string BuildFixtureSymbolAutoUpdateSummary() const;

--- a/gui/mainwindow/controllers/mainwindow_io_controller.cpp
+++ b/gui/mainwindow/controllers/mainwindow_io_controller.cpp
@@ -24,6 +24,7 @@
 #include "layerpanel.h"
 #include "LayoutManager.h"
 #include "layoutpanel.h"
+#include "logger.h"
 #include "mvrimporter.h"
 #include "projectutils.h"
 #include "sceneobjecttablepanel.h"
@@ -275,7 +276,17 @@ bool MainWindowIoController::OpenPathFromCommandLine(
   }
 
   if (extension == "mvr")
-    return ImportMvrWithOfficialPolicy(pathUtf8);
+  {
+    Logger::Instance().Log("Opening MVR from external request: " + pathUtf8);
+    const bool imported = ImportMvrWithOfficialPolicy(pathUtf8);
+    wxFileName fileInfo(wxString::FromUTF8(pathUtf8));
+    if (imported) {
+      Logger::Instance().Log("MVR imported: " + fileInfo.GetFullName().ToStdString());
+    } else {
+      Logger::Instance().Log("MVR import failed: " + pathUtf8);
+    }
+    return imported;
+  }
 
   if (owner->GetStatusBar())
     owner->SetStatusText("Unsupported startup file format.", 0);

--- a/gui/mainwindow_fixture_symbol_autoupdate.cpp
+++ b/gui/mainwindow_fixture_symbol_autoupdate.cpp
@@ -334,15 +334,14 @@ void MainWindow::FlushPendingFixtureSymbolLibraryUpdates() {
   }
   fixtureSymbolPendingLibrarySyncUuids.clear();
 }
-
-
-
+// Requests deferred closure of the startup splash once initialization prerequisites are complete.
 void MainWindow::RequestStartupSplashCompletion() {
   if (!startupSplashInitializationPending)
     return;
   startupSplashCloseRequested = true;
 }
 
+// Processes startup splash closure during idle once a close request has been queued.
 void MainWindow::OnStartupSplashCloseIdle(wxIdleEvent &event) {
   event.Skip();
   if (!startupSplashCloseRequested)
@@ -352,6 +351,7 @@ void MainWindow::OnStartupSplashCloseIdle(wxIdleEvent &event) {
   CompleteStartupSplashInitialization();
 }
 
+// Completes startup splash teardown and then processes any deferred startup open path.
 void MainWindow::CompleteStartupSplashInitialization() {
   if (!startupSplashInitializationPending)
     return;
@@ -359,10 +359,22 @@ void MainWindow::CompleteStartupSplashInitialization() {
   startupSplashInitializationPending = false;
   SplashScreen::SetMessage("Ready");
   SplashScreen::Hide();
+  ProcessDeferredStartupOpenPath();
+}
 
-  if (deferredStartupOpenPath && !deferredStartupOpenPath->empty()) {
-    const std::string startupPath = *deferredStartupOpenPath;
-    deferredStartupOpenPath.reset();
-    CallAfter([this, startupPath]() { OpenPathFromCommandLine(startupPath); });
-  }
+// Stores a deferred startup-open path that must be processed after startup pending state clears.
+void MainWindow::QueueDeferredStartupOpenPath(const std::string &path) {
+  if (path.empty())
+    return;
+  deferredStartupOpenPath = path;
+}
+
+// Dispatches any deferred startup-open path through the shared command-line open workflow.
+void MainWindow::ProcessDeferredStartupOpenPath() {
+  if (!deferredStartupOpenPath || deferredStartupOpenPath->empty())
+    return;
+
+  const std::string startupPath = *deferredStartupOpenPath;
+  deferredStartupOpenPath.reset();
+  CallAfter([this, startupPath]() { OpenPathFromCommandLine(startupPath); });
 }

--- a/main.cpp
+++ b/main.cpp
@@ -48,9 +48,15 @@ public:
   int FilterEvent(wxEvent &event) override;
   bool OnExceptionInMainLoop() override;
   void OnUnhandledException() override;
+#if defined(__WXOSX__)
+  void MacOpenFiles(const wxArrayString &fileNames) override;
+  void MacOpenFile(const wxString &fileName) override;
+  void MacOpenURL(const wxString &url) override;
+#else
   void MacOpenFiles(const wxArrayString &fileNames);
   void MacOpenFile(const wxString &fileName);
   void MacOpenURL(const wxString &url);
+#endif
 
 private:
   void HandleExternalOpenPath(const std::string &pathUtf8);
@@ -88,9 +94,13 @@ std::string NormalizeExternalOpenPath(const std::string &rawPathUtf8) {
   }
 
   wxCharBuffer utf8 = wxPath.ToUTF8();
-  if (utf8)
-    return std::string(utf8.data());
-  return rawPathUtf8;
+  const std::string normalizedPath =
+      utf8 ? std::string(utf8.data()) : rawPathUtf8;
+  if (normalizedPath != rawPathUtf8) {
+    Logger::Instance().Log("NormalizeExternalOpenPath normalized '" +
+                           rawPathUtf8 + "' -> '" + normalizedPath + "'");
+  }
+  return normalizedPath;
 }
 
 // Converts an ASCII string to lowercase.
@@ -263,11 +273,14 @@ void MyApp::MacOpenFile(const wxString &fileName) {
   const wxCharBuffer utf8 = fileName.ToUTF8();
   const std::string rawPathUtf8 =
       utf8 ? std::string(utf8.data()) : fileName.ToStdString();
+  Logger::Instance().Log("MacOpenFile received: " + rawPathUtf8);
   HandleExternalOpenPath(NormalizeExternalOpenPath(rawPathUtf8));
 }
 
 // Routes macOS multi-file open requests to the external open pipeline in order.
 void MyApp::MacOpenFiles(const wxArrayString &fileNames) {
+  Logger::Instance().Log("MacOpenFiles received count: " +
+                         std::to_string(fileNames.GetCount()));
   for (const wxString &fileName : fileNames) {
     MacOpenFile(fileName);
   }
@@ -279,6 +292,7 @@ void MyApp::MacOpenURL(const wxString &url) {
   const wxCharBuffer utf8 = url.ToUTF8();
   const std::string rawUrlUtf8 =
       utf8 ? std::string(utf8.data()) : url.ToStdString();
+  Logger::Instance().Log("MacOpenURL received: " + rawUrlUtf8);
   HandleExternalOpenPath(NormalizeExternalOpenPath(rawUrlUtf8));
 }
 
@@ -289,6 +303,8 @@ void MyApp::HandleExternalOpenPath(const std::string &pathUtf8) {
 
   MainWindow *mainWindow = wxDynamicCast(GetTopWindow(), MainWindow);
   if (!mainWindow) {
+    Logger::Instance().Log(
+        "HandleExternalOpenPath queued: MainWindow is not ready.");
     pending_external_open_paths_.push_back(pathUtf8);
     return;
   }
@@ -299,11 +315,15 @@ void MyApp::HandleExternalOpenPath(const std::string &pathUtf8) {
         pending_external_open_paths_.back() == pathUtf8) {
       return;
     }
+    Logger::Instance().Log(
+        "HandleExternalOpenPath queued: startup load is pending.");
     pending_external_open_paths_.push_back(pathUtf8);
     SchedulePendingExternalOpenProcessing(wxWeakRef<MainWindow>(mainWindow));
     return;
   }
 
+  Logger::Instance().Log(
+      "HandleExternalOpenPath dispatching to OpenPathFromCommandLine().");
   mainWindow->CallAfter([windowRef = wxWeakRef<MainWindow>(mainWindow),
                          pathUtf8]() {
     if (!windowRef)
@@ -329,6 +349,8 @@ void MyApp::SchedulePendingExternalOpenProcessing(
     auto pendingPath = ConsumePendingExternalOpenPath();
     if (!pendingPath)
       return;
+    Logger::Instance().Log(
+        "SchedulePendingExternalOpenProcessing consuming queued path.");
     mainWindowRef->OpenPathFromCommandLine(*pendingPath);
     if (!pending_external_open_paths_.empty())
       SchedulePendingExternalOpenProcessing(mainWindowRef);


### PR DESCRIPTION
### Motivation
- Finder on macOS delivers document-open requests via app callbacks rather than argv and the existing `MyApp::MacOpen*` declarations could silently fail to bind, causing launched Perastage to ignore double-clicked `.mvr` files.
- There is a startup deferral race where external-open events can arrive while the app is still in a startup project-load pending state, which can leave `.mvr` imports unprocessed or re-queued indefinitely.
- The goal is to harden macOS routing so double-click / Open With behavior imports `.mvr` packages the same way Windows does while preserving existing Windows behavior and the official import policy.

### Description
- Marked macOS callbacks in `MyApp` as explicit `override` on macOS builds (`MacOpenFile`, `MacOpenFiles`, `MacOpenURL`) while keeping non-macOS declarations as a fallback to force compile-time signature correctness where supported.
- Added concise diagnostic logging for external-open flow including `MacOpenFile`/`MacOpenFiles`/`MacOpenURL` receipt, `NormalizeExternalOpenPath` normalization changes, `HandleExternalOpenPath` queuing reasons, direct dispatching to `OpenPathFromCommandLine()`, and queued-path consumption in `SchedulePendingExternalOpenProcessing()`.
- Made startup-deferred external-open processing explicit by introducing `MainWindow::QueueDeferredStartupOpenPath()` and `MainWindow::ProcessDeferredStartupOpenPath()` and adjusted `MainWindow::OnProjectLoaded()` to queue/process deferred opens only after `SetStartupProjectLoadPending(false)` to avoid re-queue loops.
- Preserved the official MVR import policy and added logging around MVR imports in `MainWindowIoController::OpenPathFromCommandLine()` that call `ImportMvrWithOfficialPolicy()` and log success/failure and filename.
- Added short, one-line English comments above modified function definitions in affected files to describe each function's primary purpose as requested.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed locally.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc6993ecd883249aecabe1192b5f4a)