### PR TITLE
Fix macOS MVR import path existence validation

### DIFF
--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -1111,7 +1111,8 @@ bool MvrImporter::ImportFromFile(const std::string &filePath,
 #elif defined(__WXOSX__) || defined(__APPLE__)
   if (!fs::exists(path)) {
     wxFileName finderPath(wxString::FromUTF8(filePath));
-    if (!finderPath.FileExists()) {
+    wxFileInputStream stream(finderPath.GetFullPath());
+    if (!finderPath.FileExists() && !stream.IsOk()) {
       LogMessage("MVR file does not exist: " + filePath);
       return false;
     }

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -1077,6 +1077,7 @@ static void ReadSupportHoistInfoFromUserData(tinyxml2::XMLElement *supportNode,
     }
   }
 }
+// Imports an MVR file from disk by validating the path, extracting its package, and parsing the scene XML.
 bool MvrImporter::ImportFromFile(const std::string &filePath,
                                  bool promptConflicts,
                                  bool applyDictionary,
@@ -1098,10 +1099,29 @@ bool MvrImporter::ImportFromFile(const std::string &filePath,
 
   reportProgress("Preparing import...");
 
+  // macOS Finder can treat .mvr ZIP archives as packages, and in that case
+  // std::filesystem::exists() may report false for a valid double-click path.
+  // Keep the strict filesystem check on Windows, but on macOS fall back to
+  // wxFileName::FileExists() before aborting so Finder-opened MVR imports work.
+#if defined(__WXMSW__)
   if (!fs::exists(path)) {
     LogMessage("MVR file does not exist: " + filePath);
     return false;
   }
+#elif defined(__WXOSX__) || defined(__APPLE__)
+  if (!fs::exists(path)) {
+    wxFileName finderPath(wxString::FromUTF8(filePath));
+    if (!finderPath.FileExists()) {
+      LogMessage("MVR file does not exist: " + filePath);
+      return false;
+    }
+  }
+#else
+  if (!fs::exists(path)) {
+    LogMessage("MVR file does not exist: " + filePath);
+    return false;
+  }
+#endif
   if (ext != ".mvr") {
     LogMessage("MVR file has invalid extension: " + ext);
     return false;


### PR DESCRIPTION
## Summary
- Updated `MvrImporter::ImportFromFile` to keep the strict `std::filesystem::exists` guard on Windows while adding macOS-specific fallback behavior.
- On macOS, when `std::filesystem::exists` returns false for `.mvr` package-like paths, the importer now verifies with `wxFileName::FileExists()` before aborting.
- Added explanatory comments documenting why `std::filesystem::exists` can be unreliable for Finder-opened `.mvr` files on macOS.
- Added a concise one-line function comment above `ImportFromFile` describing its primary purpose.

## Why
- Finder may treat `.mvr` archives as packages on macOS, causing false negatives from `std::filesystem::exists` and preventing double-click imports.
- This change aligns macOS behavior with Windows user expectations without altering the Windows import path logic.

## Scope
- File changed: `mvr/mvrimporter.cpp`
- No pipeline changes outside importer path validation logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc73dcdaa0832491821f8d846103fe)