### PR TITLE
Avoid blocking import UI on macOS startup to fix MVR double-click crash

### DIFF
--- a/gui/mainwindow/controllers/mainwindow_io_controller.cpp
+++ b/gui/mainwindow/controllers/mainwindow_io_controller.cpp
@@ -62,11 +62,14 @@ bool MainWindowIoController::ImportMvrFromPath(const std::string &pathUtf8) {
   setImportStatus("MVR import: preparing...");
   SplashScreen::Hide();
 
-  std::unique_ptr<wxWindowDisabler> importDisabler =
-      std::make_unique<wxWindowDisabler>();
-  std::unique_ptr<wxBusyInfo> importOverlay =
-      std::make_unique<wxBusyInfo>("Importing MVR file...");
+  const bool shouldShowBlockingImportUi = !ownerRef->IsStartupProjectLoadPending();
+  std::unique_ptr<wxWindowDisabler> importDisabler;
+  std::unique_ptr<wxBusyInfo> importOverlay;
   std::unique_ptr<wxProgressDialog> importProgress;
+  if (shouldShowBlockingImportUi) {
+    importDisabler = std::make_unique<wxWindowDisabler>();
+    importOverlay = std::make_unique<wxBusyInfo>("Importing MVR file...");
+  }
 
   if (!ownerRef)
     return false;
@@ -84,8 +87,11 @@ bool MainWindowIoController::ImportMvrFromPath(const std::string &pathUtf8) {
         }
 
         if (stage == "Conflict dialog:hide") {
-          importDisabler = std::make_unique<wxWindowDisabler>();
-          importOverlay = std::make_unique<wxBusyInfo>("Importing MVR file...");
+          if (shouldShowBlockingImportUi) {
+            importDisabler = std::make_unique<wxWindowDisabler>();
+            importOverlay =
+                std::make_unique<wxBusyInfo>("Importing MVR file...");
+          }
           importProgress.reset();
           return;
         }
@@ -96,28 +102,26 @@ bool MainWindowIoController::ImportMvrFromPath(const std::string &pathUtf8) {
           const int safeTotal = std::max(progress.total, 1);
           const int clampedCompleted = std::clamp(progress.completed, 0, safeTotal);
 
-          if (!importProgress) {
+          if (shouldShowBlockingImportUi && !importProgress) {
             importOverlay.reset();
             importProgress = std::make_unique<wxProgressDialog>(
                 title, stageText, safeTotal + 1, ownerRef.get(),
                 wxPD_AUTO_HIDE | wxPD_SMOOTH | wxPD_APP_MODAL);
-          } else {
+          } else if (importProgress) {
             importProgress->SetRange(safeTotal + 1);
           }
 
           const int dialogProgressValue =
               std::clamp(clampedCompleted, 0, std::max(1, safeTotal));
-          importProgress->Update(dialogProgressValue, stageText);
-          wxYieldIfNeeded();
+          if (importProgress)
+            importProgress->Update(dialogProgressValue, stageText);
           setImportStatus(wxString::Format("MVR import: %s (%d/%d)", stageText,
                                            clampedCompleted, safeTotal));
           return;
         }
 
-        if (importProgress) {
+        if (importProgress)
           importProgress->Pulse(wxString::FromUTF8(stage));
-          wxYieldIfNeeded();
-        }
         setImportStatus("MVR import: " + wxString::FromUTF8(stage));
       });
   if (ownerRef)


### PR DESCRIPTION
### Motivation
- The app could crash when a Finder double-click open arrived early in startup because `ImportMvrFromPath` created modal/blocking import UI while startup state was still pending. 
- The change aims to avoid creating re-entrant/modal UI during the startup-open pipeline while preserving the official MVR import semantics. 
- This targets the EXC_BAD_ACCESS observed in `MainWindowIoController::ImportMvrFromPath` during macOS external-open handling. 

### Description
- Made `MainWindowIoController::ImportMvrFromPath` (in `gui/mainwindow/controllers/mainwindow_io_controller.cpp`) check `ownerRef->IsStartupProjectLoadPending()` and compute `shouldShowBlockingImportUi` to decide whether to create `wxWindowDisabler` and `wxBusyInfo`. 
- Deferred creation of the `wxProgressDialog` until `shouldShowBlockingImportUi` is true and guarded progress updates so they are only called when the dialog exists. 
- Kept existing conflict-dialog (`Conflict dialog:show` / `Conflict dialog:hide`) handling and the overall `MvrImporter::ImportAndRegister` callback flow unchanged, with only the modal/feedback UI wrapped in the new condition. 
- Minor responsiveness changes: removed unconditional `wxYieldIfNeeded()` calls around progress updates to avoid extra main-loop re-entrancy when blocking UI is not active. 

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc7c46299c8324abe102a02b39e75d)