### PR TITLE
Fix Linux CI vcpkg prerequisites for gtk3

### DIFF
--- a/.github/workflows/linux-installer.yml
+++ b/.github/workflows/linux-installer.yml
@@ -55,6 +55,15 @@ jobs:
             libxi-dev \
             libxtst-dev \
             libxrender-dev \
+            libgtk-3-dev \
+            libglib2.0-dev \
+            libpango1.0-dev \
+            libatk1.0-dev \
+            libcairo2-dev \
+            libgdk-pixbuf-2.0-dev \
+            libxkbcommon-dev \
+            libwayland-dev \
+            libegl1-mesa-dev \
             libgl1-mesa-dev \
             libglu1-mesa-dev
 
@@ -66,7 +75,7 @@ jobs:
             .vcpkg-cache/downloads
             .vcpkg-cache/installed
             .vcpkg-cache/packages
-          key: ${{ runner.os }}-vcpkg-x64-linux-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', '.github/workflows/linux-appimage.yml') }}
+          key: ${{ runner.os }}-vcpkg-x64-linux-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', '.github/workflows/linux-installer.yml') }}
           restore-keys: |
             ${{ runner.os }}-vcpkg-x64-linux-
             ${{ runner.os }}-vcpkg-


### PR DESCRIPTION
### Motivation
- Linux CI was failing during `vcpkg install` with `error: building gtk3:x64-linux failed with: BUILD_FAILED` because required GTK3 development packages were not installed on the runner.
- The vcpkg cache key pointed at the wrong workflow file which prevented cache invalidation for this workflow.

### Description
- Add GTK3 and related system development packages to the `sudo apt-get install` step in `.github/workflows/linux-installer.yml`, including `libgtk-3-dev`, `libglib2.0-dev`, `libpango1.0-dev`, `libatk1.0-dev`, `libcairo2-dev`, `libgdk-pixbuf-2.0-dev`, `libxkbcommon-dev`, `libwayland-dev`, and `libegl1-mesa-dev`.
- Fix the vcpkg cache `hashFiles(...)` entry to reference `.github/workflows/linux-installer.yml` so changes to this workflow correctly invalidate the cache.

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fca094ff8c83249c90af97129fc2b9)