### PR TITLE
Retry macOS external-open when OpenPathFromCommandLine fails during startup

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -324,11 +324,18 @@ void MyApp::HandleExternalOpenPath(const std::string &pathUtf8) {
 
   Logger::Instance().Log(
       "HandleExternalOpenPath dispatching to OpenPathFromCommandLine().");
-  mainWindow->CallAfter([windowRef = wxWeakRef<MainWindow>(mainWindow),
+  mainWindow->CallAfter([this, windowRef = wxWeakRef<MainWindow>(mainWindow),
                          pathUtf8]() {
     if (!windowRef)
       return;
-    windowRef->OpenPathFromCommandLine(pathUtf8);
+    if (windowRef->OpenPathFromCommandLine(pathUtf8))
+      return;
+
+    Logger::Instance().Log(
+        "HandleExternalOpenPath deferred retry: OpenPathFromCommandLine() "
+        "returned false.");
+    pending_external_open_paths_.push_back(pathUtf8);
+    SchedulePendingExternalOpenProcessing(windowRef);
   });
 }
 


### PR DESCRIPTION
### Motivation
- macOS can deliver `MacOpenFile` while the application startup or project-load wiring is still pending, causing `OpenPathFromCommandLine()` to fail and the double-clicked `.mvr` to be effectively dropped. 
- The intent is to ensure external `.mvr` open requests are retried instead of silently lost so macOS behavior matches Windows startup routing.

### Description
- Changed `MyApp::HandleExternalOpenPath` to check the return value of `OpenPathFromCommandLine()` when dispatching via `CallAfter` and to treat a `false` result as a transient failure. 
- When `OpenPathFromCommandLine()` returns `false` the path is now logged, enqueued into `pending_external_open_paths_`, and scheduled for retry via `SchedulePendingExternalOpenProcessing()`. 
- The change is minimal and localized to `main.cpp`'s external-open dispatch path and adds explicit logging for deferred retries.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcb71033a48324bf79cd6780957440)