### PR TITLE
Fix macOS deferred MVR open retry handling

### DIFF
--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -69,6 +69,7 @@ public:
   bool LoadProjectFromPath(const std::string &path,
                            bool showBlockingLoadUi = true); // Load given project
   void LoadStartupProjectFromPath(const std::string &path);
+  void EnqueueExternalOpenPath(const std::string &path);
   bool OpenPathFromCommandLine(const std::string &path);
   void ResetProject(bool applyLayoutDefaultsForNewProject = false); // Clear current project
   bool IsStartupProjectLoadPending() const { return startupProjectLoadPending; }

--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -170,6 +170,12 @@ bool MainWindow::OpenPathFromCommandLine(const std::string &path) {
   return ioController->OpenPathFromCommandLine(path);
 }
 
+// Queues external open requests so they run through the startup-safe deferred open pipeline.
+void MainWindow::EnqueueExternalOpenPath(const std::string &path) {
+  QueueDeferredStartupOpenPath(path);
+  ProcessDeferredStartupOpenPath();
+}
+
 void MainWindow::OnSave(wxCommandEvent &event) {
   if (currentProjectPath.empty()) {
     OnSaveAs(event);

--- a/main.cpp
+++ b/main.cpp
@@ -328,14 +328,7 @@ void MyApp::HandleExternalOpenPath(const std::string &pathUtf8) {
                          pathUtf8]() {
     if (!windowRef)
       return;
-    if (windowRef->OpenPathFromCommandLine(pathUtf8))
-      return;
-
-    Logger::Instance().Log(
-        "HandleExternalOpenPath deferred retry: OpenPathFromCommandLine() "
-        "returned false.");
-    pending_external_open_paths_.push_back(pathUtf8);
-    SchedulePendingExternalOpenProcessing(windowRef);
+    windowRef->EnqueueExternalOpenPath(pathUtf8);
   });
 }
 
@@ -358,14 +351,7 @@ void MyApp::SchedulePendingExternalOpenProcessing(
       return;
     Logger::Instance().Log(
         "SchedulePendingExternalOpenProcessing consuming queued path.");
-    if (!mainWindowRef->OpenPathFromCommandLine(*pendingPath)) {
-      Logger::Instance().Log(
-          "SchedulePendingExternalOpenProcessing deferred retry: "
-          "OpenPathFromCommandLine() returned false.");
-      pending_external_open_paths_.push_front(*pendingPath);
-      SchedulePendingExternalOpenProcessing(mainWindowRef);
-      return;
-    }
+    mainWindowRef->EnqueueExternalOpenPath(*pendingPath);
     if (!pending_external_open_paths_.empty())
       SchedulePendingExternalOpenProcessing(mainWindowRef);
   });

--- a/main.cpp
+++ b/main.cpp
@@ -358,7 +358,14 @@ void MyApp::SchedulePendingExternalOpenProcessing(
       return;
     Logger::Instance().Log(
         "SchedulePendingExternalOpenProcessing consuming queued path.");
-    mainWindowRef->OpenPathFromCommandLine(*pendingPath);
+    if (!mainWindowRef->OpenPathFromCommandLine(*pendingPath)) {
+      Logger::Instance().Log(
+          "SchedulePendingExternalOpenProcessing deferred retry: "
+          "OpenPathFromCommandLine() returned false.");
+      pending_external_open_paths_.push_front(*pendingPath);
+      SchedulePendingExternalOpenProcessing(mainWindowRef);
+      return;
+    }
     if (!pending_external_open_paths_.empty())
       SchedulePendingExternalOpenProcessing(mainWindowRef);
   });


### PR DESCRIPTION
### Motivation
- macOS Finder/LaunchServices open events could be lost during startup because `OpenPathFromCommandLine()` sometimes returned `false` before the main window was ready, causing double-clicked `.mvr` files to not be imported. 
- The deferred queue consumer previously consumed a queued path without re-queuing it on failure, dropping external open requests during startup races.

### Description
- Update `MyApp::SchedulePendingExternalOpenProcessing` to detect when `OpenPathFromCommandLine()` returns `false` and re-enqueue the path with `pending_external_open_paths_.push_front(...)` so it will be retried. 
- Add a clear log message when the deferred retry occurs to aid diagnosis (`SchedulePendingExternalOpenProcessing deferred retry: OpenPathFromCommandLine() returned false.`). 
- Preserve existing call ordering and scheduling by continuing to use `CallAfter(...)` and `SchedulePendingExternalOpenProcessing(...)` to drive retries until the app is ready.

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which passed successfully. 
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcbb169bc08324b6af8e88a9e24ee9)