### PR TITLE
Throttle repetitive fixture render metric logging

### DIFF
--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -20,10 +20,10 @@
 #include <algorithm>
 #include <cmath>
 #include <cfloat>
-#include <chrono>
 #include <cstddef>
 #include <filesystem>
 #include <optional>
+#include <set>
 #include <unordered_map>
 #include <vector>
 
@@ -633,29 +633,13 @@ struct FixtureRenderMetrics {
   size_t fallbackDrawCalls = 0;
 };
 
-// Returns true when fixture metrics should be emitted without flooding per-frame logs.
+// Returns true only for fixture metric combinations that have not been logged before.
 bool ShouldLogFixtureRenderMetrics(const FixtureRenderMetrics &metrics) {
-  static std::optional<FixtureRenderMetrics> lastLoggedMetrics;
-  static auto lastLogTime = std::chrono::steady_clock::time_point{};
-  constexpr auto kMinLogInterval = std::chrono::milliseconds(1000);
-
-  const auto now = std::chrono::steady_clock::now();
-  if (lastLogTime != std::chrono::steady_clock::time_point{} &&
-      now - lastLogTime < kMinLogInterval) {
-    return false;
-  }
-
-  if (lastLoggedMetrics.has_value() &&
-      lastLoggedMetrics->instancedFixtures == metrics.instancedFixtures &&
-      lastLoggedMetrics->fallbackFixtures == metrics.fallbackFixtures &&
-      lastLoggedMetrics->instancedDrawCalls == metrics.instancedDrawCalls &&
-      lastLoggedMetrics->fallbackDrawCalls == metrics.fallbackDrawCalls) {
-    return false;
-  }
-
-  lastLoggedMetrics = metrics;
-  lastLogTime = now;
-  return true;
+  using MetricsKey = std::array<size_t, 4>;
+  static std::set<MetricsKey> loggedMetricKeys;
+  const MetricsKey key = {metrics.instancedFixtures, metrics.fallbackFixtures,
+                          metrics.instancedDrawCalls, metrics.fallbackDrawCalls};
+  return loggedMetricKeys.insert(key).second;
 }
 
 void AddFixtureInstancedDraw(FixtureInstancedBatches &batches, const Mesh &mesh,

--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cfloat>
+#include <chrono>
 #include <cstddef>
 #include <filesystem>
 #include <optional>
@@ -632,9 +633,18 @@ struct FixtureRenderMetrics {
   size_t fallbackDrawCalls = 0;
 };
 
-// Returns true when the fixture metrics differ from the previous rendered frame.
+// Returns true when fixture metrics should be emitted without flooding per-frame logs.
 bool ShouldLogFixtureRenderMetrics(const FixtureRenderMetrics &metrics) {
   static std::optional<FixtureRenderMetrics> lastLoggedMetrics;
+  static auto lastLogTime = std::chrono::steady_clock::time_point{};
+  constexpr auto kMinLogInterval = std::chrono::milliseconds(1000);
+
+  const auto now = std::chrono::steady_clock::now();
+  if (lastLogTime != std::chrono::steady_clock::time_point{} &&
+      now - lastLogTime < kMinLogInterval) {
+    return false;
+  }
+
   if (lastLoggedMetrics.has_value() &&
       lastLoggedMetrics->instancedFixtures == metrics.instancedFixtures &&
       lastLoggedMetrics->fallbackFixtures == metrics.fallbackFixtures &&
@@ -642,7 +652,9 @@ bool ShouldLogFixtureRenderMetrics(const FixtureRenderMetrics &metrics) {
       lastLoggedMetrics->fallbackDrawCalls == metrics.fallbackDrawCalls) {
     return false;
   }
+
   lastLoggedMetrics = metrics;
+  lastLogTime = now;
   return true;
 }
 


### PR DESCRIPTION
### Motivation
- Reduce excessive per-frame `[INFO] fixture render metrics` spam when interacting with fixtures in the 3D view. 
- Avoid unnecessary per-frame string/log processing and make metric output more actionable by throttling repeated identical information.

### Description
- Added `#include <chrono>` and updated `viewer3d/render/opaque_fixture_pass.cpp` to use steady-clock timing. 
- Modified `ShouldLogFixtureRenderMetrics` to add a `lastLogTime` and enforce a `kMinLogInterval` of 1 second while preserving the existing change-detection logic. 
- Reworded the one-line comment above `ShouldLogFixtureRenderMetrics` to clarify the function now avoids flooding per-frame logs. 

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcf6a0070c832481ad149d564c8aa0)