### PR TITLE
Handle non-fatal GLEW GLX errors on Linux centrally

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf_catalog_service.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf_mutation_audit.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtfnet.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/glew_init_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/geometry/RdpSimplifier.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/guiconfigservices.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/hoistpresetlibrary.cpp

--- a/core/glew_init_utils.cpp
+++ b/core/glew_init_utils.cpp
@@ -1,0 +1,10 @@
+#include "glew_init_utils.h"
+
+// Converts the non-fatal Wayland GLX probe error into success so OpenGL setup can continue.
+GLenum NormalizeGlewInitResultForLinux(GLenum glewResult) {
+#if defined(__linux__)
+  if (glewResult == GLEW_ERROR_NO_GLX_DISPLAY)
+    return GLEW_OK;
+#endif
+  return glewResult;
+}

--- a/core/glew_init_utils.h
+++ b/core/glew_init_utils.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <GL/glew.h>
+
+// Normalizes GLEW initialization results for Linux platforms with Wayland/EGL contexts.
+GLenum NormalizeGlewInitResultForLinux(GLenum glewResult);

--- a/gui/fixturepreviewpanel.cpp
+++ b/gui/fixturepreviewpanel.cpp
@@ -22,6 +22,7 @@
 #endif
 
 #include <GL/glew.h>
+#include "core/glew_init_utils.h"
 // macOS ships OpenGL headers via the framework; use conditional includes for portability.
 #ifdef __APPLE__
 #define GL_SILENCE_DEPRECATION
@@ -186,11 +187,7 @@ void FixturePreviewPanel::InitGL()
     SetCurrent(*m_glContext);
     if(!m_glInitialized){
         glewExperimental = GL_TRUE;
-        GLenum err = glewInit();
-        // On Wayland/WSLg, GLX probing can fail even when the active OpenGL context is valid.
-        if (err == GLEW_ERROR_NO_GLX_DISPLAY) {
-            err = GLEW_OK;
-        }
+        GLenum err = NormalizeGlewInitResultForLinux(glewInit());
         if (err != GLEW_OK) {
             wxLogError("GLEW initialization failed: %s",
                        reinterpret_cast<const char*>(glewGetErrorString(err)));

--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -36,6 +36,7 @@
 #endif
 
 #include <GL/glew.h>
+#include "core/glew_init_utils.h"
 // Include GLEW or other OpenGL loader first if present
 #ifdef __APPLE__
 #  define GL_SILENCE_DEPRECATION
@@ -2371,10 +2372,7 @@ bool LayoutViewerPanel::InitGL() {
 
   if (!glInitialized_) {
     glewExperimental = GL_TRUE;
-    GLenum glewResult = glewInit();
-    // On Wayland/WSLg, GLX probing can fail even when the active OpenGL context is valid.
-    if (glewResult == GLEW_ERROR_NO_GLX_DISPLAY)
-      glewResult = GLEW_OK;
+    GLenum glewResult = NormalizeGlewInitResultForLinux(glewInit());
     if (glewResult != GLEW_OK) {
       Logger::Instance().Log(
           std::string("LayoutViewerPanel: GLEW init failed: ") +

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -29,6 +29,7 @@
 #endif
 
 #include <GL/glew.h>
+#include "core/glew_init_utils.h"
 // macOS uses the OpenGL framework headers; guard includes for cross-platform builds.
 #ifdef __APPLE__
 #define GL_SILENCE_DEPRECATION
@@ -740,10 +741,7 @@ void Viewer2DPanel::InitGL() {
   }
   if (!m_glInitialized) {
     glewExperimental = GL_TRUE;
-    GLenum err = glewInit();
-    // On Wayland/WSLg, GLX probing can fail even when the active OpenGL context is valid.
-    if (err == GLEW_ERROR_NO_GLX_DISPLAY)
-      err = GLEW_OK;
+    GLenum err = NormalizeGlewInitResultForLinux(glewInit());
     if (err != GLEW_OK) {
       wxLogError("GLEW initialization failed: %s",
                  reinterpret_cast<const char *>(glewGetErrorString(err)));

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -28,6 +28,7 @@
 #include <windows.h>
 #endif
 #include <GL/glew.h>
+#include "core/glew_init_utils.h"
 // macOS ships OpenGL headers in the framework; include them conditionally.
 #ifdef __APPLE__
 #define GL_SILENCE_DEPRECATION
@@ -612,11 +613,7 @@ void Viewer3DPanel::InitGL()
     SetCurrent(*m_glContext);
     if (!m_glInitialized) {
         glewExperimental = GL_TRUE;
-        GLenum err = glewInit();
-        // On Wayland/WSLg, GLX probing can fail even when the active OpenGL context is valid.
-        if (err == GLEW_ERROR_NO_GLX_DISPLAY) {
-            err = GLEW_OK;
-        }
+        GLenum err = NormalizeGlewInitResultForLinux(glewInit());
         if (err != GLEW_OK) {
             wxLogError("GLEW initialization failed: %s",
                        reinterpret_cast<const char*>(glewGetErrorString(err)));


### PR DESCRIPTION
### Motivation
- Linux systems running Wayland/WSLg can cause `glewInit()` to return `GLEW_ERROR_NO_GLX_DISPLAY` even when a valid OpenGL context exists, producing the user-facing error “GLEW initialization failed: No GLX display”.
- The intent is to treat this probe-only error as non-fatal on Linux so rendering initialization continues and the application starts reliably under Wayland/EGL setups.

### Description
- Added a shared helper `NormalizeGlewInitResultForLinux()` in `core/glew_init_utils.{h,cpp}` that converts `GLEW_ERROR_NO_GLX_DISPLAY` to `GLEW_OK` on Linux and leaves other platforms unchanged.  
- Updated all OpenGL initialization sites to use the helper: `viewer3d/viewer3dpanel.cpp`, `viewer2d/viewer2dpanel.cpp`, `gui/layoutviewerpanel.cpp`, and `gui/fixturepreviewpanel.cpp`.  
- Registered the new source `core/glew_init_utils.cpp` in `core/CMakeLists.txt` to ensure it is built into the project.  
- Added a concise one-line English comment above the new helper function to describe its purpose.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which completed successfully.  
- Ran `tests/check_no_configmanager_get_in_gui.sh` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd9773c6f48324b7615aea62d17422)