### PR TITLE
Centralize GLEW init, force X11 in AppImage, and bundle GTK resources

### DIFF
--- a/.github/workflows/linux-installer.yml
+++ b/.github/workflows/linux-installer.yml
@@ -232,8 +232,9 @@ jobs:
           curl -L -o linuxdeploy-x86_64.AppImage \
             https://github.com/linuxdeploy/linuxdeploy/releases/latest/download/linuxdeploy-x86_64.AppImage
           chmod +x linuxdeploy-x86_64.AppImage
-          ./linuxdeploy-x86_64.AppImage --appimage-extract
-          mv squashfs-root linuxdeploy-root
+          curl -L -o linuxdeploy-plugin-gtk.sh \
+            https://github.com/linuxdeploy/linuxdeploy-plugin-gtk/releases/latest/download/linuxdeploy-plugin-gtk.sh
+          chmod +x linuxdeploy-plugin-gtk.sh
 
           curl -L -o appimagetool-x86_64.AppImage \
             https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
@@ -241,7 +242,7 @@ jobs:
           ./appimagetool-x86_64.AppImage --appimage-extract
           mv squashfs-root appimagetool-root
 
-          ./linuxdeploy-root/AppRun --appdir "$APPDIR" --desktop-file "$APPDIR/Perastage.desktop" --icon-file "$APPDIR/Perastage.png"
+          ./linuxdeploy-x86_64.AppImage --appimage-extract-and-run --appdir "$APPDIR" --plugin gtk --desktop-file "$APPDIR/Perastage.desktop" --icon-file "$APPDIR/Perastage.png"
 
           export ARCH=x86_64
           export APPIMAGE_EXTRACT_AND_RUN=1

--- a/gui/fixturepreviewpanel.cpp
+++ b/gui/fixturepreviewpanel.cpp
@@ -22,6 +22,7 @@
 #endif
 
 #include <GL/glew.h>
+#include "glew_init_utils.h"
 // macOS ships OpenGL headers via the framework; use conditional includes for portability.
 #ifdef __APPLE__
 #define GL_SILENCE_DEPRECATION
@@ -177,24 +178,21 @@ FixturePreviewPanel::~FixturePreviewPanel()
     delete m_glContext;
 }
 
-// Initializes the fixture preview OpenGL state while ignoring Wayland-only GLX probe failures.
+// Initializes fixture preview OpenGL state only after centralized GLEW/context validation.
 void FixturePreviewPanel::InitGL()
 {
     if(!IsShownOnScreen()){
         return;
     }
-    SetCurrent(*m_glContext);
     if(!m_glInitialized){
-        glewExperimental = GL_TRUE;
-        GLenum err = glewInit();
-        // On Wayland/WSLg, GLX probing can fail even when the active OpenGL context is valid.
-        if (err == GLEW_ERROR_NO_GLX_DISPLAY) {
-            err = GLEW_OK;
-        }
-        if (err != GLEW_OK) {
-            wxLogError("GLEW initialization failed: %s",
-                       reinterpret_cast<const char*>(glewGetErrorString(err)));
+        const GLEWInitResult initResult =
+            InitializeGlewForCurrentContext(*this, *m_glContext, "FixturePreviewPanel");
+        if (!initResult.success) {
+            wxLogError("%s", initResult.message);
             return;
+        }
+        if (initResult.isWarningOnly) {
+            wxLogWarning("%s", initResult.message);
         }
         m_glInitialized = true;
     }

--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -36,6 +36,7 @@
 #endif
 
 #include <GL/glew.h>
+#include "glew_init_utils.h"
 // Include GLEW or other OpenGL loader first if present
 #ifdef __APPLE__
 #  define GL_SILENCE_DEPRECATION
@@ -2360,28 +2361,23 @@ bool LayoutViewerPanel::GetSelectedFrame(
   return true;
 }
 
-// Initializes layout-viewer OpenGL resources and filters non-fatal Wayland GLX probing errors.
+// Initializes layout viewer OpenGL resources through centralized GLEW/context validation.
 bool LayoutViewerPanel::InitGL() {
   if (!glContext_)
     return false;
   if (!IsShownOnScreen())
     return false;
-  if (!SetCurrent(*glContext_))
-    return false;
-
   if (!glInitialized_) {
-    glewExperimental = GL_TRUE;
-    GLenum glewResult = glewInit();
-    // On Wayland/WSLg, GLX probing can fail even when the active OpenGL context is valid.
-    if (glewResult == GLEW_ERROR_NO_GLX_DISPLAY)
-      glewResult = GLEW_OK;
-    if (glewResult != GLEW_OK) {
-      Logger::Instance().Log(
-          std::string("LayoutViewerPanel: GLEW init failed: ") +
-          reinterpret_cast<const char *>(glewGetErrorString(glewResult)));
+    const GLEWInitResult initResult =
+        InitializeGlewForCurrentContext(*this, *glContext_, "LayoutViewerPanel");
+    if (!initResult.success) {
+      isReadyToRender_ = false;
+      Logger::Instance().Log(initResult.message);
       return false;
     }
-    glGetError();
+    if (initResult.isWarningOnly) {
+      Logger::Instance().Log(initResult.message);
+    }
     glInitialized_ = true;
   }
 

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -29,6 +29,7 @@
 #endif
 
 #include <GL/glew.h>
+#include "glew_init_utils.h"
 // macOS uses the OpenGL framework headers; guard includes for cross-platform builds.
 #ifdef __APPLE__
 #define GL_SILENCE_DEPRECATION
@@ -729,25 +730,21 @@ void Viewer2DPanel::InvalidateBottomSymbolCache() {
   m_controller.ClearBottomSymbolCache();
 }
 
-// Initializes the 2D OpenGL context and tolerates Wayland GLX probing failures.
+// Initializes 2D OpenGL state only when GLEW/context validation succeeds.
 void Viewer2DPanel::InitGL() {
   if (!IsShownOnScreen() && !m_forceOffscreenRender &&
       !m_allowOffscreenRender) {
     return;
   }
-  if (!SetCurrent(*m_glContext)) {
-    return;
-  }
   if (!m_glInitialized) {
-    glewExperimental = GL_TRUE;
-    GLenum err = glewInit();
-    // On Wayland/WSLg, GLX probing can fail even when the active OpenGL context is valid.
-    if (err == GLEW_ERROR_NO_GLX_DISPLAY)
-      err = GLEW_OK;
-    if (err != GLEW_OK) {
-      wxLogError("GLEW initialization failed: %s",
-                 reinterpret_cast<const char *>(glewGetErrorString(err)));
+    const GLEWInitResult initResult =
+        InitializeGlewForCurrentContext(*this, *m_glContext, "Viewer2DPanel");
+    if (!initResult.success) {
+      wxLogError("%s", initResult.message);
       return;
+    }
+    if (initResult.isWarningOnly) {
+      wxLogWarning("%s", initResult.message);
     }
     m_controller.InitializeGL();
     glEnable(GL_DEPTH_TEST);

--- a/viewer3d/CMakeLists.txt
+++ b/viewer3d/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/picking/selectionsystem.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/picking/id_pick_pass.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/gl_primitive_renderer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/render/glew_init_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/base_pass_framebuffer_cache.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/hoist_symbol_renderer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/lighting_profile.cpp

--- a/viewer3d/render/glew_init_utils.cpp
+++ b/viewer3d/render/glew_init_utils.cpp
@@ -1,6 +1,5 @@
-#include "glew_init_utils.h"
-
 #include <GL/glew.h>
+#include "glew_init_utils.h"
 
 #include <cstdlib>
 #include <string>
@@ -21,7 +20,7 @@ void LogLinuxBackendDiagnosticsOnce(const char *panelName) {
   const char *display = std::getenv("DISPLAY");
   const char *sessionType = std::getenv("XDG_SESSION_TYPE");
   const char *qtQpaPlatform = std::getenv("QT_QPA_PLATFORM");
-  wxLogMessage(
+  wxLogDebug(
       "%s backend diagnostics: GDK_BACKEND=%s WAYLAND_DISPLAY=%s DISPLAY=%s "
       "XDG_SESSION_TYPE=%s QT_QPA_PLATFORM=%s",
       panelName, gdkBackend ? gdkBackend : "<unset>",
@@ -50,8 +49,8 @@ GLEWInitResult InitializeGlewForCurrentContext(wxGLCanvas &canvas,
   const GLenum glewResult = glewInit();
   const GLubyte *glVersionRaw = glGetString(GL_VERSION);
   const bool hasGlVersion = glVersionRaw != nullptr;
-  wxLogMessage("%s GL context status: GL_VERSION %s", panelName,
-               hasGlVersion ? "available" : "missing");
+  wxLogDebug("%s GL context status: GL_VERSION %s", panelName,
+             hasGlVersion ? "available" : "missing");
 
   if (glewResult == GLEW_OK) {
     result.success = true;

--- a/viewer3d/render/glew_init_utils.cpp
+++ b/viewer3d/render/glew_init_utils.cpp
@@ -1,0 +1,71 @@
+#include "glew_init_utils.h"
+
+#include <GL/glew.h>
+
+#include <cstdlib>
+#include <string>
+
+#include <wx/log.h>
+
+namespace {
+// Logs Linux backend environment details once per process for diagnostics.
+void LogLinuxBackendDiagnosticsOnce(const char *panelName) {
+#ifdef __linux__
+  static bool logged = false;
+  if (logged) {
+    return;
+  }
+  logged = true;
+  const char *gdkBackend = std::getenv("GDK_BACKEND");
+  const char *waylandDisplay = std::getenv("WAYLAND_DISPLAY");
+  const char *display = std::getenv("DISPLAY");
+  const char *sessionType = std::getenv("XDG_SESSION_TYPE");
+  const char *qtQpaPlatform = std::getenv("QT_QPA_PLATFORM");
+  wxLogMessage(
+      "%s backend diagnostics: GDK_BACKEND=%s WAYLAND_DISPLAY=%s DISPLAY=%s "
+      "XDG_SESSION_TYPE=%s QT_QPA_PLATFORM=%s",
+      panelName, gdkBackend ? gdkBackend : "<unset>",
+      waylandDisplay ? waylandDisplay : "<unset>",
+      display ? display : "<unset>", sessionType ? sessionType : "<unset>",
+      qtQpaPlatform ? qtQpaPlatform : "<unset>");
+#else
+  (void)panelName;
+#endif
+}
+} // namespace
+
+// Initializes GLEW and handles Wayland GLX probing only when OpenGL is usable.
+GLEWInitResult InitializeGlewForCurrentContext(wxGLCanvas &canvas,
+                                               wxGLContext &context,
+                                               const char *panelName) {
+  GLEWInitResult result{};
+  if (!canvas.SetCurrent(context)) {
+    result.message = std::string(panelName) + ": SetCurrent failed";
+    return result;
+  }
+
+  LogLinuxBackendDiagnosticsOnce(panelName);
+
+  glewExperimental = GL_TRUE;
+  const GLenum glewResult = glewInit();
+  const GLubyte *glVersionRaw = glGetString(GL_VERSION);
+  const bool hasGlVersion = glVersionRaw != nullptr;
+  wxLogMessage("%s GL context status: GL_VERSION %s", panelName,
+               hasGlVersion ? "available" : "missing");
+
+  if (glewResult == GLEW_OK) {
+    result.success = true;
+    result.message = std::string(panelName) + ": GLEW initialized";
+  } else if (glewResult == GLEW_ERROR_NO_GLX_DISPLAY && hasGlVersion) {
+    result.success = true;
+    result.isWarningOnly = true;
+    result.message = std::string(panelName) +
+                     ": GLEW reported NO_GLX_DISPLAY but GL context is valid";
+  } else {
+    result.message = std::string(panelName) + ": GLEW init failed: " +
+                     reinterpret_cast<const char *>(glewGetErrorString(glewResult));
+  }
+
+  glGetError();
+  return result;
+}

--- a/viewer3d/render/glew_init_utils.h
+++ b/viewer3d/render/glew_init_utils.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+
+#include <wx/glcanvas.h>
+
+// Stores the result of a guarded GLEW initialization attempt.
+struct GLEWInitResult {
+  bool success = false;
+  bool isWarningOnly = false;
+  std::string message;
+};
+
+// Initializes GLEW for a current context and validates OpenGL availability.
+GLEWInitResult InitializeGlewForCurrentContext(wxGLCanvas &canvas,
+                                               wxGLContext &context,
+                                               const char *panelName);

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -28,6 +28,7 @@
 #include <windows.h>
 #endif
 #include <GL/glew.h>
+#include "glew_init_utils.h"
 // macOS ships OpenGL headers in the framework; include them conditionally.
 #ifdef __APPLE__
 #define GL_SILENCE_DEPRECATION
@@ -603,23 +604,21 @@ void Viewer3DPanel::StopRefreshThread()
         m_refreshThread.join();
 }
 
-// Initializes the 3D OpenGL state and ignores non-fatal Wayland GLX probing failures.
+// Initializes 3D OpenGL state only after centralized GLEW/context validation.
 void Viewer3DPanel::InitGL()
 {
     if (!IsShownOnScreen()) {
         return;
     }
-    SetCurrent(*m_glContext);
     if (!m_glInitialized) {
-        glewExperimental = GL_TRUE;
-        GLenum err = glewInit();
-        // On Wayland/WSLg, GLX probing can fail even when the active OpenGL context is valid.
-        if (err == GLEW_ERROR_NO_GLX_DISPLAY) {
-            err = GLEW_OK;
+        const GLEWInitResult initResult =
+            InitializeGlewForCurrentContext(*this, *m_glContext, "Viewer3DPanel");
+        if (!initResult.success) {
+            wxLogError("%s", initResult.message);
+            return;
         }
-        if (err != GLEW_OK) {
-            wxLogError("GLEW initialization failed: %s",
-                       reinterpret_cast<const char*>(glewGetErrorString(err)));
+        if (initResult.isWarningOnly) {
+            wxLogWarning("%s", initResult.message);
         }
 
         GLint sampleBuffers = 0;


### PR DESCRIPTION
### Motivation
- Fix the AppImage runtime failure (`GLEW initialization failed: No GLX display`) by making the AppImage run with a consistent X11/GLX backend and eliminate the root cause instead of only silencing the symptom. 
- Centralize GLEW initialization to avoid duplicated, slightly-different handling across panels and to make initialization robust in Wayland/WSLg environments by validating the actual GL availability.
- Ensure GTK resources (pixbuf loaders, GLib schemas, etc.) are bundled into the AppImage so runtime GTK warnings are resolved.

### Description
- Added a new shared helper `viewer3d/render/glew_init_utils.{h,cpp}` that provides `GLEWInitResult` and `InitializeGlewForCurrentContext(...)`, which sets `glewExperimental`, calls `glewInit()`, treats `GLEW_ERROR_NO_GLX_DISPLAY` as a non-fatal warning only when `glGetString(GL_VERSION)` is present, clears leftover GL error with `glGetError()`, and logs Linux backend diagnostics (`GDK_BACKEND`, `WAYLAND_DISPLAY`, `DISPLAY`, `XDG_SESSION_TYPE`, `QT_QPA_PLATFORM`).
- Replaced all direct `glewInit()` usages in panels (`viewer2d/viewer2dpanel.cpp`, `viewer3d/viewer3dpanel.cpp`, `gui/fixturepreviewpanel.cpp`, `gui/layoutviewerpanel.cpp`) with calls to `InitializeGlewForCurrentContext(...)` and made panels abort/mark not-ready-to-render when initialization fails so no GL calls occur after a failed init.
- Registered the new helper implementation explicitly in `viewer3d/CMakeLists.txt` to keep explicit source ownership.
- Updated AppImage packaging in `.github/workflows/linux-installer.yml` to download/use the linuxdeploy GTK plugin and run linuxdeploy with `--plugin gtk`, and preserved the AppRun X11 forcing lines (`export GDK_BACKEND=x11` / `export QT_QPA_PLATFORM=xcb`) so the packaged AppImage runs with X11/GLX configuration and bundles GTK resources correctly.
- Kept the previous defensive warning behavior as a Linux-only harmless fallback while making the runtime backend the primary fix path.
- Added concise comments for the new helper and updated function header comments around modified InitGL() locations to document intent.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded (`OK`).
- Verified `rg "glewInit\(" -n` now only reports the centralized helper implementation (no scattered direct calls remain).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd9b352d6083249a9cca8b2ea0f3f4)