### PR TITLE
Fix macOS app bundle runtime asset installation paths

### DIFF
--- a/.github/workflows/macos-installer.yml
+++ b/.github/workflows/macos-installer.yml
@@ -110,6 +110,8 @@ jobs:
           test -f out/install/Release/Perastage.app/Contents/Resources/Perastage.icns
           test -f out/install/Release/Perastage.app/Contents/Resources/PerastageProject.icns
           test -f out/install/Release/Perastage.app/Contents/Resources/PerastageMVR.icns
+          test -f out/install/Release/Perastage.app/Contents/Resources/resources/Perastage_logo.png
+          test -d out/install/Release/Perastage.app/Contents/Resources/resources/icons
 
       # ── 10. Validate and prepare staged macOS app bundle ─────────────────────
       - name: Validate staged app bundle
@@ -121,6 +123,8 @@ jobs:
           test -f out/install/Release/Perastage.app/Contents/Resources/Perastage.icns
           test -f out/install/Release/Perastage.app/Contents/Resources/PerastageProject.icns
           test -f out/install/Release/Perastage.app/Contents/Resources/PerastageMVR.icns
+          test -f out/install/Release/Perastage.app/Contents/Resources/resources/Perastage_logo.png
+          test -d out/install/Release/Perastage.app/Contents/Resources/resources/icons
           ls -l out/install/Release/Perastage.app/Contents/MacOS/
           plutil -lint out/install/Release/Perastage.app/Contents/Info.plist
           codesign -dv --verbose=4 out/install/Release/Perastage.app || true
@@ -230,6 +234,8 @@ jobs:
 
           test -d "$MOUNT_DIR/Perastage.app"
           test -x "$MOUNT_DIR/Perastage.app/Contents/MacOS/Perastage"
+          test -f "$MOUNT_DIR/Perastage.app/Contents/Resources/resources/Perastage_logo.png"
+          test -d "$MOUNT_DIR/Perastage.app/Contents/Resources/resources/icons"
           plutil -lint "$MOUNT_DIR/Perastage.app/Contents/Info.plist"
           codesign --verify --deep --verbose=2 "$MOUNT_DIR/Perastage.app"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,19 +265,27 @@ if(BUILD_TESTING)
     add_subdirectory(tests)
 endif()
 
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/resources DESTINATION .)
+if(APPLE)
+    # Keep runtime assets inside the app bundle so packaged macOS builds resolve resources correctly.
+    set(PERASTAGE_INSTALL_ASSET_DEST "${PROJECT_NAME}.app/Contents/Resources")
+else()
+    # Keep runtime assets next to the executable on non-macOS platforms.
+    set(PERASTAGE_INSTALL_ASSET_DEST ".")
+endif()
+
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/resources DESTINATION ${PERASTAGE_INSTALL_ASSET_DEST})
 if(EXISTS "${CMAKE_SOURCE_DIR}/library")
-    install(DIRECTORY ${CMAKE_SOURCE_DIR}/library DESTINATION .)
+    install(DIRECTORY ${CMAKE_SOURCE_DIR}/library DESTINATION ${PERASTAGE_INSTALL_ASSET_DEST})
 endif()
 if(EXISTS "${CMAKE_SOURCE_DIR}/licenses")
-    install(DIRECTORY ${CMAKE_SOURCE_DIR}/licenses DESTINATION .)
+    install(DIRECTORY ${CMAKE_SOURCE_DIR}/licenses DESTINATION ${PERASTAGE_INSTALL_ASSET_DEST})
 endif()
 
 install(FILES
     ${CMAKE_SOURCE_DIR}/LICENSE.txt
     ${CMAKE_SOURCE_DIR}/THIRD_PARTY_LICENSES.md
     ${CMAKE_SOURCE_DIR}/help.md
-    DESTINATION .
+    DESTINATION ${PERASTAGE_INSTALL_ASSET_DEST}
     OPTIONAL
 )
 

--- a/core/projectutils.cpp
+++ b/core/projectutils.cpp
@@ -169,6 +169,7 @@ fs::path GetBaseLibraryPath(const std::string& subdir)
     return exeBase / suffix;
 }
 
+// Resolves the runtime resources root by checking executable-relative paths and platform bundle locations.
 fs::path GetResourceRoot()
 {
     wxFileName exe(wxStandardPaths::Get().GetExecutablePath());
@@ -182,7 +183,11 @@ fs::path GetResourceRoot()
     if (!resourcesDir.empty()) {
         fs::path resourcesPath = WxStringToPath(resourcesDir);
         std::error_code ec;
-        if (fs::exists(resourcesPath, ec))
+        const fs::path nestedResources = resourcesPath / "resources";
+        if (fs::exists(nestedResources, ec) && !ec &&
+            fs::is_directory(nestedResources, ec) && !ec)
+            return nestedResources;
+        if (fs::exists(resourcesPath, ec) && !ec)
             return resourcesPath;
     }
     return {};


### PR DESCRIPTION
### Motivation
- Packaged macOS builds were launching without splash and icons because runtime assets were installed outside the application bundle while the app resolves resources from the bundle, so the CMake install destinations need to be platform-aware and place assets inside the macOS app bundle.

### Description
- Add an `APPLE` conditional that sets `PERASTAGE_INSTALL_ASSET_DEST` to `"${PROJECT_NAME}.app/Contents/Resources"` on macOS and to `"."` elsewhere, and update `install(DIRECTORY ...)` and `install(FILES ...)` to use that variable with short explanatory comments.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdab4ab5288324bf2843524fdde466)