### PR TITLE
Harden macOS bundle resource fallback and add function intent comments

### DIFF
--- a/core/projectutils.cpp
+++ b/core/projectutils.cpp
@@ -33,6 +33,7 @@ namespace ProjectUtils {
 
 namespace {
 
+// Converts a filesystem path to a UTF-8 encoded std::string.
 std::string ToUtf8String(const fs::path& path)
 {
     std::u8string utf8 = path.u8string();
@@ -40,6 +41,7 @@ std::string ToUtf8String(const fs::path& path)
 }
 
 
+// Converts a wxString value into a filesystem path preserving UTF-8 characters.
 fs::path WxStringToPath(const wxString& value)
 {
     const wxScopedCharBuffer utf8 = value.ToUTF8();
@@ -49,6 +51,7 @@ fs::path WxStringToPath(const wxString& value)
     return fs::path(value.ToStdString());
 }
 
+// Searches for an existing suffix path while walking parent directories up to maxDepth.
 std::optional<fs::path> FindExistingPath(const fs::path& start,
                                          const fs::path& suffix,
                                          int maxDepth = 3)
@@ -67,6 +70,7 @@ std::optional<fs::path> FindExistingPath(const fs::path& start,
     return std::nullopt;
 }
 
+// Resolves a writable user data directory with a temp-directory fallback.
 std::optional<fs::path> ResolveWritableUserDataDir()
 {
     wxString dir = wxStandardPaths::Get().GetUserDataDir();
@@ -90,6 +94,7 @@ std::optional<fs::path> ResolveWritableUserDataDir()
     return fs::absolute(fallback, ec);
 }
 
+// Returns an absolute UTF-8 path string when path canonicalization succeeds.
 std::string ToAbsoluteUtf8(const fs::path& path)
 {
     std::error_code ec;
@@ -99,11 +104,13 @@ std::string ToAbsoluteUtf8(const fs::path& path)
     return ToUtf8String(absolutePath);
 }
 
+// Returns the discovered root folder for installed library content.
 fs::path GetBaseLibraryRoot()
 {
     return GetBaseLibraryPath("");
 }
 
+// Logs a summary of library bootstrap migration results and collected errors.
 void LogBootstrapSummary(const LibraryBootstrap::BootstrapResult& result,
                          const fs::path& installedRoot,
                          const fs::path& userDataDir)
@@ -125,6 +132,7 @@ void LogBootstrapSummary(const LibraryBootstrap::BootstrapResult& result,
 
 } // namespace
 
+// Checks whether a directory can be created and written to by creating a probe file.
 bool IsDirectoryWritable(const fs::path& dir)
 {
     if (dir.empty())
@@ -166,6 +174,15 @@ fs::path GetBaseLibraryPath(const std::string& subdir)
             return resourcesLibrary;
         }
     }
+#ifdef __APPLE__
+    const fs::path bundleResources = exeBase.parent_path() / "Resources";
+    std::error_code ec;
+    const fs::path bundleLibrary = bundleResources / "library" / subdir;
+    if (fs::exists(bundleLibrary, ec) && !ec &&
+        fs::is_directory(bundleLibrary, ec) && !ec) {
+        return bundleLibrary;
+    }
+#endif
     return exeBase / suffix;
 }
 
@@ -190,9 +207,21 @@ fs::path GetResourceRoot()
         if (fs::exists(resourcesPath, ec) && !ec)
             return resourcesPath;
     }
+#ifdef __APPLE__
+    const fs::path bundleResources = exeBase.parent_path() / "Resources";
+    std::error_code ec;
+    const fs::path nestedResources = bundleResources / "resources";
+    if (fs::exists(nestedResources, ec) && !ec &&
+        fs::is_directory(nestedResources, ec) && !ec)
+        return nestedResources;
+    if (fs::exists(bundleResources, ec) && !ec &&
+        fs::is_directory(bundleResources, ec) && !ec)
+        return bundleResources;
+#endif
     return {};
 }
 
+// Returns the persistent file path used to store the last opened project path.
 std::string GetLastProjectPathFile()
 {
     const auto dataDir = ResolveWritableUserDataDir();
@@ -207,6 +236,7 @@ std::string GetLastProjectPathFile()
     return p.string();
 }
 
+// Stores the last opened project path as an absolute UTF-8 path when possible.
 bool SaveLastProjectPath(const std::string& path)
 {
     const std::string pathFile = GetLastProjectPathFile();
@@ -228,6 +258,7 @@ bool SaveLastProjectPath(const std::string& path)
     return true;
 }
 
+// Loads the last opened project path and validates that the referenced file still exists.
 std::optional<std::string> LoadLastProjectPath()
 {
     const std::string pathFile = GetLastProjectPathFile();
@@ -268,6 +299,7 @@ std::optional<std::string> LoadLastProjectPath()
     return std::nullopt;
 }
 
+// Returns the installed library subdirectory path when it exists on disk.
 std::string GetInstalledLibraryPath(const std::string& subdir)
 {
     const fs::path installedPath = GetBaseLibraryPath(subdir);
@@ -277,6 +309,7 @@ std::string GetInstalledLibraryPath(const std::string& subdir)
     return {};
 }
 
+// Resolves a writable library subdirectory preferring environment override then user-data bootstrap.
 std::string GetWritableLibraryPath(const std::string& subdir)
 {
     if (const char* envPath = std::getenv("PERASTAGE_LIBRARY_PATH")) {
@@ -311,6 +344,7 @@ std::string GetWritableLibraryPath(const std::string& subdir)
     return {};
 }
 
+// Returns the best available library path using installed, writable, then executable-relative fallback.
 std::string GetDefaultLibraryPath(const std::string& subdir)
 {
     if (std::string installedPath = GetInstalledLibraryPath(subdir); !installedPath.empty()) {
@@ -333,6 +367,7 @@ std::string GetDefaultLibraryPath(const std::string& subdir)
     return ToUtf8String(absolutePath);
 }
 
+// Runs startup migration to bootstrap user library content from installed assets.
 void RunStartupLibraryBootstrap()
 {
     const auto dataDir = ResolveWritableUserDataDir();


### PR DESCRIPTION
### Motivation
- Packaged macOS apps sometimes fail to resolve runtime assets even when files are present in the app bundle's `Contents/Resources`, causing missing splash and icons at startup. 
- Strengthen path resolution to prefer explicit app-bundle `Resources` locations on macOS so runtime assets are discovered reliably. 
- Improve code clarity by adding concise one-line English comments above each function to document intent without changing logic.

### Description
- Added Apple-specific fallback checks in `GetBaseLibraryPath` to probe `../Resources/library/...` when executable-relative and `wxStandardPaths` probes do not find the library. 
- Added Apple-specific fallback checks in `GetResourceRoot` to probe `../Resources/resources` and then `../Resources` as additional runtime resource roots. 
- Inserted short, single-line English comments above function definitions throughout `core/projectutils.cpp` to describe each function's primary purpose without altering behavior. 
- Only `core/projectutils.cpp` was modified; no other code paths or behavior were changed beyond the added fallback checks and comments.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which succeeded. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which succeeded. 
- No other automated tests were changed or required for this update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdb9dad7fc832480edd3726036af0b)