### PR TITLE
Fix macOS help/icon resource lookup from bundle root

### DIFF
--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -1032,10 +1032,12 @@ void MainWindow::OnToggleRigging(wxCommandEvent &event) {
     viewController->OnToggleRigging(event);
 }
 
+// Opens the help dialog by loading and rendering help.md from the resolved runtime resource root.
 void MainWindow::OnShowHelp(wxCommandEvent &WXUNUSED(event)) {
-  // Attempt to load the Markdown help file located alongside the executable.
-  wxFileName helpPath(wxStandardPaths::Get().GetExecutablePath());
-  helpPath.SetFullName("help.md");
+  const std::filesystem::path resourceRoot = ProjectUtils::GetResourceRoot();
+  const wxString helpFullPath =
+      wxString::FromUTF8((resourceRoot / "help.md").u8string());
+  wxFileName helpPath(helpFullPath);
   if (helpPath.Exists()) {
     // Read the file contents.
     std::ifstream in(WxToUtf8(helpPath.GetFullPath()));
@@ -1091,6 +1093,7 @@ void MainWindow::OnShowHelp(wxCommandEvent &WXUNUSED(event)) {
   }
 }
 
+// Displays the About dialog with app metadata and an icon resolved from the runtime resource root.
 void MainWindow::OnShowAbout(wxCommandEvent &WXUNUSED(event)) {
   wxAboutDialogInfo info;
   info.SetName(app::kName);
@@ -1109,14 +1112,19 @@ void MainWindow::OnShowAbout(wxCommandEvent &WXUNUSED(event)) {
   info.SetLicence(
       "This software is licensed under the GNU General Public License v3.0.");
 
-  // Load the largest available icon
+  // Load the largest available icon.
   wxIconBundle bundle;
-  const wxString iconPaths[] = {"resources/Perastage.ico",
-                                "../resources/Perastage.ico",
-                                "../../resources/Perastage.ico"};
+  const std::filesystem::path resourceRoot = ProjectUtils::GetResourceRoot();
+  const wxString iconPaths[] = {
+      wxString::FromUTF8((resourceRoot / "Perastage.ico").u8string()),
+      wxString::FromUTF8((resourceRoot / "Perastage_logo.png").u8string())};
   for (const wxString &path : iconPaths) {
-    if (wxFileExists(path))
-      bundle.AddIcon(path, wxBITMAP_TYPE_ICO);
+    if (wxFileExists(path)) {
+      if (path.EndsWith(".ico"))
+        bundle.AddIcon(path, wxBITMAP_TYPE_ICO);
+      else
+        bundle.AddIcon(path, wxBITMAP_TYPE_PNG);
+    }
   }
   wxIcon icon = bundle.GetIcon(wxSize(256, 256));
   if (icon.IsOk())

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -1036,7 +1036,7 @@ void MainWindow::OnToggleRigging(wxCommandEvent &event) {
 void MainWindow::OnShowHelp(wxCommandEvent &WXUNUSED(event)) {
   const std::filesystem::path resourceRoot = ProjectUtils::GetResourceRoot();
   const wxString helpFullPath =
-      wxString::FromUTF8((resourceRoot / "help.md").u8string());
+      wxString::FromUTF8((resourceRoot / "help.md").string());
   wxFileName helpPath(helpFullPath);
   if (helpPath.Exists()) {
     // Read the file contents.
@@ -1116,8 +1116,8 @@ void MainWindow::OnShowAbout(wxCommandEvent &WXUNUSED(event)) {
   wxIconBundle bundle;
   const std::filesystem::path resourceRoot = ProjectUtils::GetResourceRoot();
   const wxString iconPaths[] = {
-      wxString::FromUTF8((resourceRoot / "Perastage.ico").u8string()),
-      wxString::FromUTF8((resourceRoot / "Perastage_logo.png").u8string())};
+      wxString::FromUTF8((resourceRoot / "Perastage.ico").string()),
+      wxString::FromUTF8((resourceRoot / "Perastage_logo.png").string())};
   for (const wxString &path : iconPaths) {
     if (wxFileExists(path)) {
       if (path.EndsWith(".ico"))


### PR DESCRIPTION
### Motivation
- Recent CMake changes stage runtime assets inside macOS app bundle `Contents/Resources`, which breaks code that assumed assets live next to the executable. 
- Help text and About icons were not found at runtime on macOS when resources are packaged into the bundle, causing missing UI assets.

### Description
- Updated `MainWindow::OnShowHelp` to resolve `help.md` using `ProjectUtils::GetResourceRoot()` instead of assuming the file is next to the executable. 
- Updated `MainWindow::OnShowAbout` to resolve icon assets from `ProjectUtils::GetResourceRoot()` and to accept both `.ico` and `.png` sources when building the `wxIconBundle`. 
- Added concise one-line English comments above the modified function definitions to describe their purpose. 
- Changes are confined to `gui/mainwindow_menu.cpp` and are consistent with existing `ProjectUtils` resource resolution logic.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which succeeded. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdcaa51cf08324ba18b993b36eae5a)