### PR TITLE
Silence non-fatal GLEW NO_GLX_DISPLAY warnings in UI

### DIFF
--- a/gui/fixturepreviewpanel.cpp
+++ b/gui/fixturepreviewpanel.cpp
@@ -192,7 +192,7 @@ void FixturePreviewPanel::InitGL()
             return;
         }
         if (initResult.isWarningOnly) {
-            wxLogWarning("%s", initResult.message);
+            wxLogDebug("%s", initResult.message);
         }
         m_glInitialized = true;
     }

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -744,7 +744,7 @@ void Viewer2DPanel::InitGL() {
       return;
     }
     if (initResult.isWarningOnly) {
-      wxLogWarning("%s", initResult.message);
+      wxLogDebug("%s", initResult.message);
     }
     m_controller.InitializeGL();
     glEnable(GL_DEPTH_TEST);

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -618,7 +618,7 @@ void Viewer3DPanel::InitGL()
             return;
         }
         if (initResult.isWarningOnly) {
-            wxLogWarning("%s", initResult.message);
+            wxLogDebug("%s", initResult.message);
         }
 
         GLint sampleBuffers = 0;


### PR DESCRIPTION
### Motivation
- Prevent non-fatal GLEW `NO_GLX_DISPLAY` diagnostics from surfacing as warning-level UI dialogs while preserving the message in logs.

### Description
- Replace `wxLogWarning("%s", initResult.message);` with `wxLogDebug("%s", initResult.message);` in `viewer2d/viewer2dpanel.cpp`, `viewer3d/viewer3dpanel.cpp`, and `gui/fixturepreviewpanel.cpp` so non-fatal `GLEW_ERROR_NO_GLX_DISPLAY` cases are logged at debug level and do not trigger warning UI.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdd43f669883249c33dff21b780916)