### PR TITLE
Handle missing offscreen capture without blocking layout texture rebuild

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -2489,7 +2489,7 @@ void LayoutViewerPanel::LogRebuildStageMetrics(const char *stageName, int proces
   Logger::Instance().Log(std::string("LayoutViewerPanel rebuild stage ") + stageName + ": count=" + std::to_string(processedCount) + ", ms=" + std::to_string(elapsedMs));
 }
 
-// Collects rebuild prerequisites and best-effort resolves offscreen rendering dependencies.
+// Collects rebuild prerequisites and lazily resolves offscreen rendering dependencies.
 bool LayoutViewerPanel::EnsureRebuildResourcesReady(bool &needsLegendProcessing, bool &needsLegendSymbolCapture, Viewer2DOffscreenRenderer *&offscreenRenderer, Viewer2DPanel *&capturePanel) {
   bool hasDirtyViewCache = false;
   for (const auto &view : currentLayout.view2dViews) {
@@ -2507,13 +2507,13 @@ bool LayoutViewerPanel::EnsureRebuildResourcesReady(bool &needsLegendProcessing,
   const bool needsCapturePanel = hasDirtyViewCache || needsLegendSymbolCapture;
   if (!needsCapturePanel) return true;
   if (auto *mw = MainWindow::Instance()) { offscreenRenderer = mw->GetOffscreenRenderer(); capturePanel = offscreenRenderer ? offscreenRenderer->GetPanel() : nullptr; }
-  return true;
+  return capturePanel && offscreenRenderer;
 }
 
-// Captures legend symbol snapshots when possible and gracefully skips if capture resources are unavailable.
+// Captures legend symbol snapshots only when required by dirty legend caches.
 bool LayoutViewerPanel::PrepareLegendSymbolsIfNeeded(bool needsLegendSymbolCapture, Viewer2DPanel *capturePanel, ConfigManager &cfg, std::shared_ptr<const SymbolDefinitionSnapshot> &legendSymbols) {
   if (!needsLegendSymbolCapture) return true;
-  if (!capturePanel) return true;
+  if (!capturePanel) return false;
   legendSymbols = CaptureLegendSymbolSnapshot(capturePanel, cfg, true);
   return true;
 }

--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -2487,7 +2487,7 @@ void LayoutViewerPanel::LogRebuildStageMetrics(const char *stageName, int proces
   Logger::Instance().Log(std::string("LayoutViewerPanel rebuild stage ") + stageName + ": count=" + std::to_string(processedCount) + ", ms=" + std::to_string(elapsedMs));
 }
 
-// Collects rebuild prerequisites and lazily resolves offscreen rendering dependencies.
+// Collects rebuild prerequisites and best-effort resolves offscreen rendering dependencies.
 bool LayoutViewerPanel::EnsureRebuildResourcesReady(bool &needsLegendProcessing, bool &needsLegendSymbolCapture, Viewer2DOffscreenRenderer *&offscreenRenderer, Viewer2DPanel *&capturePanel) {
   bool hasDirtyViewCache = false;
   for (const auto &view : currentLayout.view2dViews) {
@@ -2505,13 +2505,13 @@ bool LayoutViewerPanel::EnsureRebuildResourcesReady(bool &needsLegendProcessing,
   const bool needsCapturePanel = hasDirtyViewCache || needsLegendSymbolCapture;
   if (!needsCapturePanel) return true;
   if (auto *mw = MainWindow::Instance()) { offscreenRenderer = mw->GetOffscreenRenderer(); capturePanel = offscreenRenderer ? offscreenRenderer->GetPanel() : nullptr; }
-  return capturePanel && offscreenRenderer;
+  return true;
 }
 
-// Captures legend symbol snapshots only when required by dirty legend caches.
+// Captures legend symbol snapshots when possible and gracefully skips if capture resources are unavailable.
 bool LayoutViewerPanel::PrepareLegendSymbolsIfNeeded(bool needsLegendSymbolCapture, Viewer2DPanel *capturePanel, ConfigManager &cfg, std::shared_ptr<const SymbolDefinitionSnapshot> &legendSymbols) {
   if (!needsLegendSymbolCapture) return true;
-  if (!capturePanel) return false;
+  if (!capturePanel) return true;
   legendSymbols = CaptureLegendSymbolSnapshot(capturePanel, cfg, true);
   return true;
 }

--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -2362,6 +2362,8 @@ bool LayoutViewerPanel::InitGL() {
     return false;
   if (!IsShownOnScreen())
     return false;
+  if (!SetCurrent(*glContext_))
+    return false;
   if (!glInitialized_) {
     const GLEWInitResult initResult =
         InitializeGlewForCurrentContext(*this, *glContext_, "LayoutViewerPanel");


### PR DESCRIPTION
### Motivation
- Fix a regression where layout elements rendered their frames but remained visually empty because the progressive texture rebuild aborted when offscreen capture resources were unavailable.

### Description
- Make `EnsureRebuildResourcesReady(...)` best-effort so it does not block the rebuild when `offscreenRenderer`/`capturePanel` are missing, allowing non-capture stages to continue.
- Make `PrepareLegendSymbolsIfNeeded(...)` gracefully skip symbol capture when `capturePanel` is absent instead of failing the pipeline.
- Add brief English comments above the modified functions in `gui/layoutviewerpanel.cpp` to describe their purposes.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed (OK).
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed (OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff8d2793d48324abc224cb5d676218)