### PR TITLE
Annotate PDF exporter functions and confirm symbol XObject instancing flow

### DIFF
--- a/viewer2d/pdf/layout_pdf_exporter.cpp
+++ b/viewer2d/pdf/layout_pdf_exporter.cpp
@@ -374,6 +374,7 @@ std::string RenderCommandsToStream(
   return content.str();
 }
 
+// Converts an arbitrary key into a PDF-safe resource name token.
 std::string MakePdfName(const std::string &key) {
   std::string name = "X";
   for (char ch : key) {
@@ -387,16 +388,19 @@ std::string MakePdfName(const std::string &key) {
   return name;
 }
 
+// Builds the PDF resource name used for key-based symbol XObjects.
 std::string MakeSymbolKeyName(const std::string &key) {
   return "K" + MakePdfName(key);
 }
 
+// Builds the PDF resource name used for id-based symbol XObjects.
 std::string MakeSymbolIdName(uint32_t symbolId) {
   return "S" + std::to_string(symbolId);
 }
 
 } // namespace
 
+// Exports a single Viewer2D command buffer into a PDF file with shared symbol XObjects.
 Viewer2DExportResult ExportViewer2DToPdf(
     const CommandBuffer &buffer, const Viewer2DViewState &viewState,
     const Viewer2DPrintOptions &options,
@@ -759,6 +763,7 @@ Viewer2DExportResult ExportViewer2DToPdf(
   return result;
 }
 
+// Exports a full layout (views, legends, tables, text, and images) into a composed PDF.
 Viewer2DExportResult ExportLayoutToPdf(
     const std::vector<LayoutViewExportData> &views,
     const std::vector<LayoutLegendExportData> &legends,


### PR DESCRIPTION
### Motivation
- Investigate a user report that exported layout PDFs were very large and might be re-drawing symbol geometry instead of instancing shared SVG/XObject symbols.
- Add concise one-line English comments above key functions to satisfy the requested code-review annotation policy without changing logic.

### Description
- Added one-line comments above `MakePdfName`, `MakeSymbolKeyName`, `MakeSymbolIdName`, `ExportViewer2DToPdf`, and `ExportLayoutToPdf` to document each function's purpose.
- Reviewed the `viewer2d/pdf/layout_pdf_exporter.cpp` export pipeline and confirmed symbol definitions are captured via `BeginSymbolCommand`/`EndSymbolCommand`, usage is tracked with `usedSymbolKeys`/`usedSymbolIds`, and name maps are injected into render options so instances call `AppendSymbolInstance(...)` rather than re-emitting full geometry.
- No rendering logic or behavior was changed; this PR only adds comments and documents the existing symbol XObject instancing flow.

### Testing
- Ran module/architecture checks: `tests/check_perastage_tree_modules.sh` (passed) and `tests/check_no_configmanager_get_in_gui.sh` (passed).
- No unit tests were modified or added in this change and no test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff947cf91083249177896babf77875)