### PR TITLE
Refactor LayoutViewer rendering pipeline, simplify GL init and MVR export

### DIFF
--- a/core/projectutils.cpp
+++ b/core/projectutils.cpp
@@ -146,7 +146,6 @@ bool IsDirectoryWritable(const fs::path& dir)
     return true;
 }
 
-// Resolves the base library directory by searching executable, working, and platform resource locations.
 fs::path GetBaseLibraryPath(const std::string& subdir)
 {
     wxFileName exe(wxStandardPaths::Get().GetExecutablePath());
@@ -156,20 +155,9 @@ fs::path GetBaseLibraryPath(const std::string& subdir)
         return *found;
     if (auto found = FindExistingPath(fs::current_path(), suffix))
         return *found;
-    const wxString resourcesDir = wxStandardPaths::Get().GetResourcesDir();
-    if (!resourcesDir.empty()) {
-        fs::path resourcesPath = WxStringToPath(resourcesDir);
-        fs::path resourcesLibrary = resourcesPath / "library" / subdir;
-        std::error_code ec;
-        if (fs::exists(resourcesLibrary, ec) && !ec &&
-            fs::is_directory(resourcesLibrary, ec) && !ec) {
-            return resourcesLibrary;
-        }
-    }
     return exeBase / suffix;
 }
 
-// Resolves the runtime resources root by checking executable-relative paths and platform bundle locations.
 fs::path GetResourceRoot()
 {
     wxFileName exe(wxStandardPaths::Get().GetExecutablePath());
@@ -183,46 +171,9 @@ fs::path GetResourceRoot()
     if (!resourcesDir.empty()) {
         fs::path resourcesPath = WxStringToPath(resourcesDir);
         std::error_code ec;
-        const fs::path nestedResources = resourcesPath / "resources";
-        if (fs::exists(nestedResources, ec) && !ec &&
-            fs::is_directory(nestedResources, ec) && !ec)
-            return nestedResources;
-        if (fs::exists(resourcesPath, ec) && !ec)
+        if (fs::exists(resourcesPath, ec))
             return resourcesPath;
     }
-    return {};
-}
-
-// Resolves a relative resource path by checking nested and base resource roots with compatibility fallbacks.
-fs::path ResolveResourcePath(const fs::path& relativePath)
-{
-    if (relativePath.empty() || relativePath.is_absolute())
-        return {};
-
-    std::error_code ec;
-    const fs::path root = GetResourceRoot();
-    if (!root.empty()) {
-        const fs::path directCandidate = root / relativePath;
-        if (fs::exists(directCandidate, ec) && !ec)
-            return directCandidate;
-        ec.clear();
-
-        if (root.filename() == "resources") {
-            const fs::path parentCandidate = root.parent_path() / relativePath;
-            if (fs::exists(parentCandidate, ec) && !ec)
-                return parentCandidate;
-            ec.clear();
-        }
-    }
-
-    const wxString resourcesDir = wxStandardPaths::Get().GetResourcesDir();
-    if (!resourcesDir.empty()) {
-        const fs::path resourcesPath = WxStringToPath(resourcesDir);
-        const fs::path baseCandidate = resourcesPath / relativePath;
-        if (fs::exists(baseCandidate, ec) && !ec)
-            return baseCandidate;
-    }
-
     return {};
 }
 

--- a/core/projectutils.cpp
+++ b/core/projectutils.cpp
@@ -177,6 +177,39 @@ fs::path GetResourceRoot()
     return {};
 }
 
+// Resolves a relative resource path by checking nested and base resource roots with compatibility fallbacks.
+fs::path ResolveResourcePath(const fs::path& relativePath)
+{
+    if (relativePath.empty() || relativePath.is_absolute())
+        return {};
+
+    std::error_code ec;
+    const fs::path root = GetResourceRoot();
+    if (!root.empty()) {
+        const fs::path directCandidate = root / relativePath;
+        if (fs::exists(directCandidate, ec) && !ec)
+            return directCandidate;
+        ec.clear();
+
+        if (root.filename() == "resources") {
+            const fs::path parentCandidate = root.parent_path() / relativePath;
+            if (fs::exists(parentCandidate, ec) && !ec)
+                return parentCandidate;
+            ec.clear();
+        }
+    }
+
+    const wxString resourcesDir = wxStandardPaths::Get().GetResourcesDir();
+    if (!resourcesDir.empty()) {
+        const fs::path resourcesPath = WxStringToPath(resourcesDir);
+        const fs::path baseCandidate = resourcesPath / relativePath;
+        if (fs::exists(baseCandidate, ec) && !ec)
+            return baseCandidate;
+    }
+
+    return {};
+}
+
 std::string GetLastProjectPathFile()
 {
     const auto dataDir = ResolveWritableUserDataDir();

--- a/core/projectutils.h
+++ b/core/projectutils.h
@@ -45,6 +45,9 @@ namespace ProjectUtils {
     // Path containing the built-in resources shipped with the executable.
     std::filesystem::path GetResourceRoot();
 
+    // Resolves a relative resource path against known runtime roots and returns an existing file when found.
+    std::filesystem::path ResolveResourcePath(const std::filesystem::path& relativePath);
+
     // Returns true when a directory exists (or can be created) and accepts writes.
     bool IsDirectoryWritable(const std::filesystem::path& dir);
 

--- a/core/projectutils.h
+++ b/core/projectutils.h
@@ -45,9 +45,6 @@ namespace ProjectUtils {
     // Path containing the built-in resources shipped with the executable.
     std::filesystem::path GetResourceRoot();
 
-    // Resolves a resource relative path against known runtime roots and returns an existing file when found.
-    std::filesystem::path ResolveResourcePath(const std::filesystem::path& relativePath);
-
     // Returns true when a directory exists (or can be created) and accepts writes.
     bool IsDirectoryWritable(const std::filesystem::path& dir);
 

--- a/gui/layout2dviewdialog.cpp
+++ b/gui/layout2dviewdialog.cpp
@@ -28,7 +28,6 @@ Layout2DViewDialog::Layout2DViewDialog(wxWindow *parent,
   renderPanel = new Viewer2DRenderPanel(this);
   layerPanel = new LayerPanel(this, false, visibilityConfig);
   summaryPanel = new SummaryPanel(this, visibilityConfig, colorConfig);
-  summaryPanel->SetVisibleRefreshTargets(viewerPanel, nullptr);
 
   renderPanel->SetMinSize(wxSize(240, -1));
   layerPanel->SetMinSize(wxSize(290, 220));

--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -20,9 +20,6 @@
 #include <cstdio>
 #include <cstring>
 #include <memory>
-#include <future>
-#include <list>
-#include <filesystem>
 #include <new>
 #include <unordered_map>
 #include <vector>
@@ -36,7 +33,6 @@
 #endif
 
 #include <GL/glew.h>
-#include "glew_init_utils.h"
 // Include GLEW or other OpenGL loader first if present
 #ifdef __APPLE__
 #  define GL_SILENCE_DEPRECATION
@@ -75,7 +71,6 @@
 #include "viewer2doffscreenrenderer.h"
 #include "viewer2dstate.h"
 #include "ui_render_size.h"
-#include "ui_feature_flags.h"
 
 namespace {
 constexpr double kMinZoom = 0.25;
@@ -110,103 +105,6 @@ constexpr int kToggleTextFrameMenuId = wxID_HIGHEST + 503;
 constexpr int kToggleTextTransparentBackgroundMenuId = wxID_HIGHEST + 504;
 constexpr int kToggleViewFrameMenuId = wxID_HIGHEST + 506;
 constexpr int kLoadingOverlayDelayMs = 150;
-constexpr size_t kImageBitmapLruCapacity = 64;
-constexpr size_t kImageBitmapLruMaxBytes = 128u * 1024u * 1024u;
-
-struct ImageBitmapCacheKey {
-  std::string imagePath;
-  int targetWidth = 0;
-  int targetHeight = 0;
-  std::filesystem::file_time_type fileMtime{};
-
-  bool operator==(const ImageBitmapCacheKey &other) const {
-    return imagePath == other.imagePath && targetWidth == other.targetWidth &&
-           targetHeight == other.targetHeight && fileMtime == other.fileMtime;
-  }
-};
-
-struct ImageBitmapCacheKeyHasher {
-  size_t operator()(const ImageBitmapCacheKey &key) const {
-    const auto mtimeTicks =
-        static_cast<long long>(key.fileMtime.time_since_epoch().count());
-    size_t seed = std::hash<std::string>{}(key.imagePath);
-    seed ^= std::hash<int>{}(key.targetWidth) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-    seed ^= std::hash<int>{}(key.targetHeight) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-    seed ^= std::hash<long long>{}(mtimeTicks) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-    return seed;
-  }
-};
-
-struct ImageBitmapCacheEntry {
-  ImageBitmapCacheKey key;
-  wxImage bitmap;
-  size_t byteSize = 0;
-};
-
-// Returns the image file modification time and reports false when it cannot be read.
-bool TryGetImageFileMtime(const std::string &imagePath,
-                          std::filesystem::file_time_type &outMtime) {
-  std::error_code ec;
-  outMtime = std::filesystem::last_write_time(std::filesystem::path(imagePath), ec);
-  return !ec;
-}
-
-
-// Estimates the RGBA memory footprint used by a scaled image cache entry.
-size_t EstimateImageCacheEntryBytes(const wxImage &image) {
-  const int width = image.GetWidth();
-  const int height = image.GetHeight();
-  if (width <= 0 || height <= 0) {
-    return 0;
-  }
-  return static_cast<size_t>(width) * static_cast<size_t>(height) * 4u;
-}
-
-// Returns a mirrored and alpha-ready scaled bitmap from a process-local LRU cache.
-const wxImage *GetOrCreateScaledImageBitmap(const std::string &imagePath,
-                                            int targetWidth, int targetHeight,
-                                            std::filesystem::file_time_type fileMtime) {
-  using CacheList = std::list<ImageBitmapCacheEntry>;
-  static CacheList cacheEntries;
-  static std::unordered_map<ImageBitmapCacheKey, CacheList::iterator, ImageBitmapCacheKeyHasher>
-      cacheIndex;
-  static size_t cacheBytes = 0;
-
-  const ImageBitmapCacheKey key{imagePath, targetWidth, targetHeight, fileMtime};
-  auto it = cacheIndex.find(key);
-  if (it != cacheIndex.end()) {
-    cacheEntries.splice(cacheEntries.begin(), cacheEntries, it->second);
-    return &it->second->bitmap;
-  }
-
-  wxImage sourceBitmap;
-  if (!sourceBitmap.LoadFile(wxString::FromUTF8(imagePath)) ||
-      sourceBitmap.GetWidth() <= 0 || sourceBitmap.GetHeight() <= 0) {
-    return nullptr;
-  }
-
-  wxImage scaled = sourceBitmap.Scale(targetWidth, targetHeight, wxIMAGE_QUALITY_HIGH);
-  if (!scaled.IsOk()) {
-    return nullptr;
-  }
-  scaled = scaled.Mirror(false);
-  if (!scaled.HasAlpha()) {
-    scaled.InitAlpha();
-  }
-
-  const size_t scaledBytes = EstimateImageCacheEntryBytes(scaled);
-  cacheEntries.push_front({key, scaled, scaledBytes});
-  cacheIndex[key] = cacheEntries.begin();
-  cacheBytes += scaledBytes;
-  while (cacheEntries.size() > kImageBitmapLruCapacity ||
-         cacheBytes > kImageBitmapLruMaxBytes) {
-    auto tail = std::prev(cacheEntries.end());
-    cacheBytes -= tail->byteSize;
-    cacheIndex.erase(tail->key);
-    cacheEntries.pop_back();
-  }
-  return &cacheEntries.front().bitmap;
-}
 
 void ValidateGlStateAfterRender(const char *stage, int expectedWidth,
                                 int expectedHeight) {
@@ -493,42 +391,6 @@ bool IsPixelUnpackPboSupported() {
   return hasPboExtension;
 }
 
-
-// Represents an immutable CPU-produced RGBA payload ready for GPU upload.
-struct PreparedRgbaPayload {
-  bool valid = false;
-  int width = 0;
-  int height = 0;
-  std::vector<unsigned char> pixels;
-};
-
-// Converts a wxImage into RGBA bytes that can be uploaded on the render thread.
-PreparedRgbaPayload PrepareRgbaPayloadFromImage(wxImage image, const char *context) {
-  PreparedRgbaPayload payload;
-  if (!image.IsOk())
-    return payload;
-  image = image.Mirror(false);
-  if (!image.HasAlpha())
-    image.InitAlpha();
-  const int width = image.GetWidth();
-  const int height = image.GetHeight();
-  const unsigned char *rgb = image.GetData();
-  const unsigned char *alpha = image.GetAlpha();
-  if (!rgb || width <= 0 || height <= 0 || !TryAllocatePixelBuffer(payload.pixels, width, height, context))
-    return payload;
-  for (int i = 0; i < width * height; ++i) {
-    payload.pixels[static_cast<size_t>(i) * 4] = rgb[i * 3];
-    payload.pixels[static_cast<size_t>(i) * 4 + 1] = rgb[i * 3 + 1];
-    payload.pixels[static_cast<size_t>(i) * 4 + 2] = rgb[i * 3 + 2];
-    payload.pixels[static_cast<size_t>(i) * 4 + 3] = alpha ? alpha[i] : 255;
-  }
-  payload.width = width;
-  payload.height = height;
-  payload.valid = true;
-  return payload;
-}
-
-// Ensures the pixel-unpack PBO exists and has enough storage for the upload.
 bool EnsurePboCapacity(unsigned int &pbo, size_t &capacity, size_t bytesNeeded) {
   if (bytesNeeded == 0)
     return false;
@@ -546,13 +408,6 @@ bool EnsurePboCapacity(unsigned int &pbo, size_t &capacity, size_t bytesNeeded) 
   return true;
 }
 
-// Returns whether this runtime should use PBO-based texture uploads.
-bool ShouldUsePboTextureUpload() {
-  // Disables PBO uploads globally to avoid driver-specific blank textures and debug heap instability.
-  return false;
-}
-
-// Uploads RGBA pixels into the currently bound texture and reallocates if needed.
 bool UploadRgbaToTexture(unsigned int texture, int width, int height,
                          const unsigned char *data,
                          const wxSize &currentTextureSize, bool allowPbo) {
@@ -572,8 +427,7 @@ bool UploadRgbaToTexture(unsigned int texture, int width, int height,
       static_cast<size_t>(width) * static_cast<size_t>(height) * 4;
   bool uploaded = false;
 
-  if (allowPbo && ShouldUsePboTextureUpload() && IsPixelUnpackPboSupported() &&
-      gActivePixelUnpackPbo &&
+  if (allowPbo && IsPixelUnpackPboSupported() && gActivePixelUnpackPbo &&
       gActivePixelUnpackPboBytes &&
       EnsurePboCapacity(*gActivePixelUnpackPbo, *gActivePixelUnpackPboBytes,
                         bytesNeeded)) {
@@ -609,7 +463,6 @@ bool UploadRgbaToTexture(unsigned int texture, int width, int height,
   return uploaded;
 }
 
-// Snaps an integer coordinate to the configured layout grid step.
 int SnapToGrid(int value) {
   if (kLayoutGridStep <= 1)
     return value;
@@ -618,111 +471,6 @@ int SnapToGrid(int value) {
       kLayoutGridStep);
 }
 } // namespace
-
-// Queues a textured quad for deferred VBO/VAO submission while preserving draw order by texture runs.
-void LayoutViewerPanel::QueueTexturedQuad(GLuint texture,
-                                          const wxRect &frameRect) {
-  if (texture == 0)
-    return;
-  const int frameRight = frameRect.GetLeft() + frameRect.GetWidth();
-  const int frameBottom = frameRect.GetTop() + frameRect.GetHeight();
-  TexturedQuadBatch *batch = nullptr;
-  if (!texturedQuadBatches_.empty() &&
-      texturedQuadBatches_.back().texture == texture) {
-    batch = &texturedQuadBatches_.back();
-  } else {
-    texturedQuadBatches_.push_back(TexturedQuadBatch{});
-    texturedQuadBatches_.back().texture = texture;
-    batch = &texturedQuadBatches_.back();
-  }
-  batch->vertices.push_back({static_cast<float>(frameRect.GetLeft()),
-                             static_cast<float>(frameRect.GetTop()), 0.0f,
-                             1.0f});
-  batch->vertices.push_back({static_cast<float>(frameRight),
-                             static_cast<float>(frameRect.GetTop()), 1.0f,
-                             1.0f});
-  batch->vertices.push_back({static_cast<float>(frameRight),
-                             static_cast<float>(frameBottom), 1.0f, 0.0f});
-  batch->vertices.push_back({static_cast<float>(frameRect.GetLeft()),
-                             static_cast<float>(frameRect.GetBottom()), 0.0f,
-                             0.0f});
-}
-
-// Draws one textured quad using legacy immediate mode as the compatibility fallback path.
-void LayoutViewerPanel::DrawTexturedQuadImmediate(GLuint texture,
-                                                  const wxRect &frameRect) const {
-  const int frameRight = frameRect.GetLeft() + frameRect.GetWidth();
-  const int frameBottom = frameRect.GetTop() + frameRect.GetHeight();
-  glEnable(GL_TEXTURE_2D);
-  glBindTexture(GL_TEXTURE_2D, texture);
-  glColor4ub(255, 255, 255, 255);
-  glBegin(GL_QUADS);
-  glTexCoord2f(0.0f, 1.0f);
-  glVertex2f(static_cast<float>(frameRect.GetLeft()),
-             static_cast<float>(frameRect.GetTop()));
-  glTexCoord2f(1.0f, 1.0f);
-  glVertex2f(static_cast<float>(frameRight),
-             static_cast<float>(frameRect.GetTop()));
-  glTexCoord2f(1.0f, 0.0f);
-  glVertex2f(static_cast<float>(frameRight), static_cast<float>(frameBottom));
-  glTexCoord2f(0.0f, 0.0f);
-  glVertex2f(static_cast<float>(frameRect.GetLeft()),
-             static_cast<float>(frameRect.GetBottom()));
-  glEnd();
-  glDisable(GL_TEXTURE_2D);
-}
-
-// Flushes queued textured quads using a VBO/VAO path and falls back to immediate mode when unavailable.
-void LayoutViewerPanel::FlushQueuedTexturedQuads() {
-  if (texturedQuadBatches_.empty())
-    return;
-  if (texturedQuadVao_ == 0)
-    glGenVertexArrays(1, &texturedQuadVao_);
-  if (texturedQuadVbo_ == 0)
-    glGenBuffers(1, &texturedQuadVbo_);
-  const bool canUseVboVao = texturedQuadVao_ != 0 && texturedQuadVbo_ != 0;
-  if (!canUseVboVao) {
-    for (const auto &batch : texturedQuadBatches_) {
-      for (size_t i = 0; i + 3 < batch.vertices.size(); i += 4) {
-        wxRect r(static_cast<int>(batch.vertices[i].x),
-                 static_cast<int>(batch.vertices[i].y),
-                 static_cast<int>(batch.vertices[i + 1].x -
-                                  batch.vertices[i].x),
-                 static_cast<int>(batch.vertices[i + 2].y -
-                                  batch.vertices[i].y));
-        DrawTexturedQuadImmediate(batch.texture, r);
-      }
-    }
-    texturedQuadBatches_.clear();
-    return;
-  }
-  glEnable(GL_TEXTURE_2D);
-  glColor4ub(255, 255, 255, 255);
-  glBindVertexArray(texturedQuadVao_);
-  glBindBuffer(GL_ARRAY_BUFFER, texturedQuadVbo_);
-  glEnableClientState(GL_VERTEX_ARRAY);
-  glEnableClientState(GL_TEXTURE_COORD_ARRAY);
-  for (const auto &batch : texturedQuadBatches_) {
-    glBindTexture(GL_TEXTURE_2D, batch.texture);
-    glBufferData(GL_ARRAY_BUFFER,
-                 static_cast<GLsizeiptr>(batch.vertices.size() *
-                                         sizeof(TexturedQuadVertex)),
-                 batch.vertices.data(), GL_STREAM_DRAW);
-    glVertexPointer(2, GL_FLOAT, sizeof(TexturedQuadVertex),
-                    reinterpret_cast<const void *>(
-                        offsetof(TexturedQuadVertex, x)));
-    glTexCoordPointer(2, GL_FLOAT, sizeof(TexturedQuadVertex),
-                      reinterpret_cast<const void *>(
-                          offsetof(TexturedQuadVertex, u)));
-    glDrawArrays(GL_QUADS, 0, static_cast<GLsizei>(batch.vertices.size()));
-  }
-  glDisableClientState(GL_TEXTURE_COORD_ARRAY);
-  glDisableClientState(GL_VERTEX_ARRAY);
-  glBindBuffer(GL_ARRAY_BUFFER, 0);
-  glBindVertexArray(0);
-  glDisable(GL_TEXTURE_2D);
-  texturedQuadBatches_.clear();
-}
 
 wxDEFINE_EVENT(EVT_LAYOUT_VIEW_EDIT, wxCommandEvent);
 
@@ -793,8 +541,6 @@ LayoutViewerPanel::~LayoutViewerPanel() {
 
 void LayoutViewerPanel::SetLayoutDefinition(
     const layouts::LayoutDefinition &layout) {
-  // Advances the render epoch so pending worker payloads from older layouts are discarded.
-  NextRenderEpoch();
   if (IsSameRenderableLayout(currentLayout, layout)) {
     currentLayout.name = layout.name;
     legendDataDirty_ = true;
@@ -887,7 +633,7 @@ void LayoutViewerPanel::SetLayoutDefinition(
 
   if (sameLayoutName) {
     captureInProgress = false;
-    contentDirty = true;
+    renderDirty = true;
     loadingRequested = true;
     legendDataDirty_ = true;
     RefreshLegendData();
@@ -898,7 +644,6 @@ void LayoutViewerPanel::SetLayoutDefinition(
     return;
   }
 
-  MaybePrewarmOnLayoutModeEntry(previousLayout);
   captureInProgress = false;
   ClearCachedTexture();
   const bool emptyLayout = IsLayoutEmpty();
@@ -906,8 +651,6 @@ void LayoutViewerPanel::SetLayoutDefinition(
     selectedElementType = SelectedElementType::None;
     selectedElementId = -1;
     renderDirty = false;
-    contentDirty = false;
-    presentationDirty = false;
     loadingRequested = false;
     isLoading = false;
     legendItems_.clear();
@@ -919,7 +662,7 @@ void LayoutViewerPanel::SetLayoutDefinition(
     NotifyRenderReady();
     return;
   }
-  contentDirty = true;
+  renderDirty = true;
   loadingRequested = true;
   legendDataDirty_ = true;
   RefreshLegendData();
@@ -927,82 +670,6 @@ void LayoutViewerPanel::SetLayoutDefinition(
   ResetViewToFit();
   RequestRenderRebuild();
   Refresh();
-}
-
-// Prewarms reusable legend symbols and view render states when switching into a new layout context.
-void LayoutViewerPanel::MaybePrewarmOnLayoutModeEntry(const layouts::LayoutDefinition &previousLayout) {
-  if (currentLayout.name.empty())
-    return;
-  const bool likelyModeEntryFrom2Dor3D =
-      previousLayout.name.empty() || previousLayout.name != currentLayout.name;
-  if (!likelyModeEntryFrom2Dor3D)
-    return;
-
-  const std::string prewarmKey =
-      currentLayout.name + "#" + std::to_string(layoutVersion);
-  PrewarmedLayoutArtifacts artifacts;
-  artifacts.layoutVersion = layoutVersion;
-  artifacts.contentHash = BuildLayoutPrewarmContentHash();
-  for (const auto &view : currentLayout.view2dViews) {
-    viewer2d::Viewer2DState state = viewer2d::FromLayoutDefinition(view);
-    state.renderOptions.darkMode = false;
-    artifacts.viewRenderStates.emplace(view.id, std::move(state));
-  }
-
-  Viewer2DPanel *capturePanel = nullptr;
-  if (auto *mw = MainWindow::Instance()) {
-    if (auto *offscreenRenderer = mw->GetOffscreenRenderer())
-      capturePanel = offscreenRenderer->GetPanel();
-  }
-  if (!capturePanel)
-    capturePanel = Viewer2DPanel::Instance();
-  if (capturePanel) {
-    ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
-    artifacts.legendSymbols = CaptureLegendSymbolSnapshot(capturePanel, cfg, true);
-  }
-
-  prewarmedArtifactsByLayout_[prewarmKey] = std::move(artifacts);
-  ApplyPrewarmedArtifactsIfAvailable();
-}
-
-// Applies prewarmed artifacts to current caches when layout identity and content hash still match.
-void LayoutViewerPanel::ApplyPrewarmedArtifactsIfAvailable() {
-  const std::string prewarmKey =
-      currentLayout.name + "#" + std::to_string(layoutVersion);
-  auto it = prewarmedArtifactsByLayout_.find(prewarmKey);
-  if (it == prewarmedArtifactsByLayout_.end())
-    return;
-  const PrewarmedLayoutArtifacts &artifacts = it->second;
-  if (artifacts.layoutVersion != layoutVersion ||
-      artifacts.contentHash != BuildLayoutPrewarmContentHash()) {
-    prewarmedArtifactsByLayout_.erase(it);
-    return;
-  }
-
-  for (const auto &view : currentLayout.view2dViews) {
-    auto stateIt = artifacts.viewRenderStates.find(view.id);
-    if (stateIt == artifacts.viewRenderStates.end())
-      continue;
-    ViewCache &cache = GetViewCache(view.id);
-    cache.renderState = stateIt->second;
-    cache.hasRenderState = true;
-  }
-  if (artifacts.legendSymbols) {
-    for (const auto &legend : currentLayout.legendViews) {
-      LegendCache &cache = GetLegendCache(legend.id);
-      cache.symbols = artifacts.legendSymbols;
-      cache.renderDirty = true;
-    }
-  }
-}
-
-// Builds a stable invalidation hash used to discard prewarm entries after layout name/content/version changes.
-size_t LayoutViewerPanel::BuildLayoutPrewarmContentHash() const {
-  size_t seed = std::hash<std::string>{}(currentLayout.name);
-  const size_t sceneHash = ComputeSceneContentHash();
-  seed ^= sceneHash + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-  seed ^= std::hash<int>{}(layoutVersion) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-  return seed;
 }
 
 void LayoutViewerPanel::NotifyRenderReady() {
@@ -2141,7 +1808,7 @@ void LayoutViewerPanel::OnBringToFront(wxCommandEvent &) {
   }
   layoutVersion++;
   InvalidateSelectionIndexCache();
-  contentDirty = true;
+  renderDirty = true;
   RequestRenderRebuild();
   Refresh();
 }
@@ -2232,7 +1899,7 @@ void LayoutViewerPanel::OnSendToBack(wxCommandEvent &) {
   }
   layoutVersion++;
   InvalidateSelectionIndexCache();
-  contentDirty = true;
+  renderDirty = true;
   RequestRenderRebuild();
   Refresh();
 }
@@ -2356,7 +2023,6 @@ bool LayoutViewerPanel::GetSelectedFrame(
   return true;
 }
 
-// Initializes layout viewer OpenGL resources through centralized GLEW/context validation.
 bool LayoutViewerPanel::InitGL() {
   if (!glContext_)
     return false;
@@ -2364,17 +2030,17 @@ bool LayoutViewerPanel::InitGL() {
     return false;
   if (!SetCurrent(*glContext_))
     return false;
+
   if (!glInitialized_) {
-    const GLEWInitResult initResult =
-        InitializeGlewForCurrentContext(*this, *glContext_, "LayoutViewerPanel");
-    if (!initResult.success) {
-      isReadyToRender_ = false;
-      Logger::Instance().Log(initResult.message);
+    glewExperimental = GL_TRUE;
+    const GLenum glewResult = glewInit();
+    if (glewResult != GLEW_OK) {
+      Logger::Instance().Log(
+          std::string("LayoutViewerPanel: GLEW init failed: ") +
+          reinterpret_cast<const char *>(glewGetErrorString(glewResult)));
       return false;
     }
-    if (initResult.isWarningOnly) {
-      Logger::Instance().Log(initResult.message);
-    }
+    glGetError();
     glInitialized_ = true;
   }
 
@@ -2385,14 +2051,14 @@ bool LayoutViewerPanel::InitGL() {
   return true;
 }
 
-// Rebuilds cached textures incrementally across dirty stages to keep the UI responsive.
 void LayoutViewerPanel::RebuildCachedTexture() {
   try {
     if (!NeedsRenderRebuild())
       return;
     if (!isReadyToRender_ || !glContext_ || !IsShownOnScreen())
       return;
-
+    Viewer2DOffscreenRenderer *offscreenRenderer = nullptr;
+    Viewer2DPanel *capturePanel = nullptr;
     auto stopLoadingRequest = [this]() {
       loadingRequested = false;
       if (loadingTimer_.IsRunning())
@@ -2402,60 +2068,517 @@ void LayoutViewerPanel::RebuildCachedTexture() {
       stopLoadingRequest();
       isLoading = false;
     };
-
-    contentDirty = false;
-    presentationDirty = false;
-    StartRebuildTickBudget();
-
+    renderDirty = false;
+    stopLoadingRequest();
+  
+    bool hasDirtyViewCache = false;
+    for (const auto &view : currentLayout.view2dViews) {
+      const auto cacheIt = viewCaches_.find(view.id);
+      if (cacheIt != viewCaches_.end() && cacheIt->second.renderDirty) {
+        hasDirtyViewCache = true;
+        break;
+      }
+    }
     bool needsLegendProcessing = false;
     bool needsLegendSymbolCapture = false;
-    Viewer2DOffscreenRenderer *offscreenRenderer = nullptr;
-    Viewer2DPanel *capturePanel = nullptr;
-    if (!EnsureRebuildResourcesReady(needsLegendProcessing, needsLegendSymbolCapture,
-                                     offscreenRenderer, capturePanel)) {
-      return;
+    for (const auto &legend : currentLayout.legendViews) {
+      const auto cacheIt = legendCaches_.find(legend.id);
+      const bool cacheMissing = cacheIt == legendCaches_.end();
+      const bool contentChanged =
+          !cacheMissing && cacheIt->second.contentHash != legendDataHash;
+      const bool needsTextureRebuild =
+          cacheMissing || cacheIt->second.renderDirty || contentChanged;
+      if (needsTextureRebuild) {
+        needsLegendProcessing = true;
+        const bool needsSymbols =
+            cacheMissing || !cacheIt->second.symbols || contentChanged;
+        if (needsSymbols)
+          needsLegendSymbolCapture = true;
+      }
+      if (needsLegendProcessing && needsLegendSymbolCapture) {
+        break;
+      }
+    }
+    const bool needsCapturePanel = hasDirtyViewCache || needsLegendSymbolCapture;
+    if (needsCapturePanel) {
+      if (auto *mw = MainWindow::Instance()) {
+        offscreenRenderer = mw->GetOffscreenRenderer();
+        capturePanel = offscreenRenderer ? offscreenRenderer->GetPanel() : nullptr;
+      }
+      if (!capturePanel || !offscreenRenderer) {
+        return;
+      }
     }
 
     ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
     std::shared_ptr<const SymbolDefinitionSnapshot> legendSymbols;
-    if (!PrepareLegendSymbolsIfNeeded(needsLegendSymbolCapture, capturePanel, cfg,
-                                      legendSymbols)) {
-      clearLoadingState();
-      NotifyRenderReady();
-      return;
+    if (needsLegendSymbolCapture) {
+      legendSymbols = CaptureLegendSymbolSnapshot(capturePanel, cfg, true);
     }
-
     std::vector<unsigned char> legendPixels;
     std::vector<unsigned char> eventTablePixels;
     std::vector<unsigned char> textPixels;
     std::vector<unsigned char> imagePixels;
     const double renderZoom = GetRenderZoom();
-    constexpr int kMaxItemsPerStage = 3;
-    bool timeBudgetExpired = false;
+    for (const auto &view : currentLayout.view2dViews) {
+      ViewCache &cache = GetViewCache(view.id);
+      if (!cache.renderDirty)
+        continue;
+      cache.renderDirty = false;
+      wxRect frameRect;
+      if (!cache.hasCapture || !cache.hasRenderState ||
+          !GetFrameRect(view.frame, frameRect)) {
+        ClearCachedTexture(cache);
+        cache.textureSize = wxSize(0, 0);
+        cache.renderZoom = 0.0;
+        continue;
+      }
+  
+      const wxSize renderSize = GetFrameSizeForZoom(view.frame, renderZoom);
+      if (renderSize.GetWidth() <= 0 || renderSize.GetHeight() <= 0) {
+        ClearCachedTexture(cache);
+        cache.textureSize = wxSize(0, 0);
+        cache.renderZoom = 0.0;
+        continue;
+      }
+  
+      offscreenRenderer->SetViewportSize(renderSize);
+      offscreenRenderer->PrepareForCapture();
 
-    if (!ProcessDirty2DViews(offscreenRenderer, capturePanel, cfg, renderZoom,
-                             kMaxItemsPerStage, timeBudgetExpired) ||
-        !ProcessDirtyLegends(renderZoom, kMaxItemsPerStage, legendSymbols,
-                             legendPixels, timeBudgetExpired) ||
-        !ProcessDirtyEventTables(renderZoom, kMaxItemsPerStage, eventTablePixels,
-                                 timeBudgetExpired) ||
-        !ProcessDirtyTexts(renderZoom, kMaxItemsPerStage, textPixels,
-                           timeBudgetExpired) ||
-        !ProcessDirtyImages(renderZoom, kMaxItemsPerStage, imagePixels,
-                            timeBudgetExpired)) {
-      clearLoadingState();
-      NotifyRenderReady();
-      return;
+      viewer2d::Viewer2DState renderState = cache.renderState;
+      if (renderZoom != 1.0) {
+        renderState.camera.zoom *= static_cast<float>(renderZoom);
+      }
+      renderState.camera.viewportWidth = renderSize.GetWidth();
+      renderState.camera.viewportHeight = renderSize.GetHeight();
+
+      auto stateGuard = std::make_shared<viewer2d::ScopedViewer2DState>(
+          capturePanel, nullptr, cfg, renderState, nullptr, nullptr, false);
+
+      std::vector<unsigned char> pixels;
+      int width = 0;
+      int height = 0;
+      capturePanel->SetPreferPerastageSvgSymbolsForLayouts(true);
+      const bool rendered = capturePanel->RenderToRGBA(pixels, width, height);
+      capturePanel->SetPreferPerastageSvgSymbolsForLayouts(false);
+      if (!rendered || width <= 0 || height <= 0) {
+        ClearCachedTexture(cache);
+        cache.textureSize = wxSize(0, 0);
+        cache.renderZoom = 0.0;
+        continue;
+      }
+
+      if (!InitGL()) {
+        clearLoadingState();
+        NotifyRenderReady();
+        return;
+      }
+      if (cache.texture == 0) {
+        glGenTextures(1, &cache.texture);
+      }
+      glBindTexture(GL_TEXTURE_2D, cache.texture);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+      glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+      ScopedActivePixelUnpackPbo scopedPbo(cache.pixelUnpackPbo,
+                                           cache.pboBytes);
+      if (!UploadRgbaToTexture(cache.texture, width, height, pixels.data(),
+                               cache.textureSize, true)) {
+        ClearCachedTexture(cache);
+        cache.textureSize = wxSize(0, 0);
+        cache.renderZoom = 0.0;
+        continue;
+      }
+      cache.textureSize = wxSize(width, height);
+      cache.renderZoom = renderZoom;
+      cache.contentHash = HashViewContent(view);
+      std::vector<unsigned char>().swap(pixels);
     }
-
-    if (NeedsRenderRebuild() || timeBudgetExpired) {
-      RequestRenderRebuild();
-      NotifyRenderReady();
-      return;
+  
+    for (const auto &legend : currentLayout.legendViews) {
+      LegendCache &cache = GetLegendCache(legend.id);
+      const bool contentChanged = cache.contentHash != legendDataHash;
+      const bool requiresSymbolRefresh = !cache.symbols || contentChanged;
+      if (requiresSymbolRefresh && legendSymbols && cache.symbols != legendSymbols) {
+        cache.symbols = legendSymbols;
+        cache.renderDirty = true;
+      }
+      if (contentChanged) {
+        cache.renderDirty = true;
+      }
+      if (!cache.renderDirty)
+        continue;
+      cache.renderDirty = false;
+  
+      const wxSize renderSize = GetFrameSizeForZoom(legend.frame, renderZoom);
+      if (renderSize.GetWidth() <= 0 || renderSize.GetHeight() <= 0) {
+        ClearCachedTexture(cache);
+        cache.textureSize = wxSize(0, 0);
+        cache.renderZoom = 0.0;
+        continue;
+      }
+  
+      wxImage image = BuildLegendImage(
+          renderSize, wxSize(legend.frame.width, legend.frame.height),
+          renderZoom, legendItems_, cache.symbols.get());
+      if (!image.IsOk()) {
+        ClearCachedTexture(cache);
+        cache.textureSize = wxSize(0, 0);
+        cache.renderZoom = 0.0;
+        continue;
+      }
+      image = image.Mirror(false);
+      if (!image.HasAlpha())
+        image.InitAlpha();
+      const int width = image.GetWidth();
+      const int height = image.GetHeight();
+      const unsigned char *rgb = image.GetData();
+      const unsigned char *alpha = image.GetAlpha();
+      if (!rgb || width <= 0 || height <= 0) {
+        ClearCachedTexture(cache);
+        cache.textureSize = wxSize(0, 0);
+        cache.renderZoom = 0.0;
+        continue;
+      }
+  
+      if (!TryAllocatePixelBuffer(legendPixels, width, height, "legend")) {
+        ClearCachedTexture(cache);
+        cache.textureSize = wxSize(0, 0);
+        cache.renderZoom = 0.0;
+        continue;
+      }
+      for (int i = 0; i < width * height; ++i) {
+        legendPixels[static_cast<size_t>(i) * 4] = rgb[i * 3];
+        legendPixels[static_cast<size_t>(i) * 4 + 1] = rgb[i * 3 + 1];
+        legendPixels[static_cast<size_t>(i) * 4 + 2] = rgb[i * 3 + 2];
+        legendPixels[static_cast<size_t>(i) * 4 + 3] = alpha ? alpha[i] : 255;
+      }
+  
+      if (!InitGL()) {
+        clearLoadingState();
+        NotifyRenderReady();
+        return;
+      }
+      if (cache.texture == 0) {
+        glGenTextures(1, &cache.texture);
+      }
+      glBindTexture(GL_TEXTURE_2D, cache.texture);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+      glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+      ScopedActivePixelUnpackPbo scopedPbo(cache.pixelUnpackPbo,
+                                           cache.pboBytes);
+      if (!UploadRgbaToTexture(cache.texture, width, height, legendPixels.data(),
+                               cache.textureSize, true)) {
+        ClearCachedTexture(cache);
+        cache.textureSize = wxSize(0, 0);
+        cache.renderZoom = 0.0;
+        continue;
+      }
+      cache.textureSize = wxSize(width, height);
+      cache.renderZoom = renderZoom;
+      cache.contentHash = legendDataHash;
+      legendPixels.clear();
     }
-
-    rebuildViewCursor_ = rebuildLegendCursor_ = rebuildEventTableCursor_ = 0;
-    rebuildTextCursor_ = rebuildImageCursor_ = 0;
+  
+    for (const auto &table : currentLayout.eventTables) {
+      EventTableCache &cache = GetEventTableCache(table.id);
+      size_t dataHash = HashEventTableFields(table);
+      if (cache.contentHash != dataHash)
+        cache.renderDirty = true;
+      if (!cache.renderDirty)
+        continue;
+      cache.renderDirty = false;
+  
+      const wxSize renderSize = GetFrameSizeForZoom(table.frame, renderZoom);
+      if (renderSize.GetWidth() <= 0 || renderSize.GetHeight() <= 0) {
+        ClearCachedTexture(cache);
+        cache.textureSize = wxSize(0, 0);
+        cache.renderZoom = 0.0;
+        continue;
+      }
+  
+      wxImage image =
+          BuildEventTableImage(renderSize,
+                               wxSize(table.frame.width, table.frame.height),
+                               renderZoom, table);
+      if (!image.IsOk()) {
+        ClearCachedTexture(cache);
+        cache.textureSize = wxSize(0, 0);
+        cache.renderZoom = 0.0;
+        continue;
+      }
+      image = image.Mirror(false);
+      if (!image.HasAlpha())
+        image.InitAlpha();
+      const int width = image.GetWidth();
+      const int height = image.GetHeight();
+      const unsigned char *rgb = image.GetData();
+      const unsigned char *alpha = image.GetAlpha();
+      if (!rgb || width <= 0 || height <= 0) {
+        ClearCachedTexture(cache);
+        cache.textureSize = wxSize(0, 0);
+        cache.renderZoom = 0.0;
+        continue;
+      }
+  
+      if (!TryAllocatePixelBuffer(eventTablePixels, width, height,
+                                  "event table")) {
+        ClearCachedTexture(cache);
+        cache.textureSize = wxSize(0, 0);
+        cache.renderZoom = 0.0;
+        continue;
+      }
+      const bool needsUnpremultiply = false;
+      for (int i = 0; i < width * height; ++i) {
+        const unsigned char a = alpha ? alpha[i] : 255;
+        unsigned char r = rgb[i * 3];
+        unsigned char g = rgb[i * 3 + 1];
+        unsigned char b = rgb[i * 3 + 2];
+        if (needsUnpremultiply && a > 0 && a < 255) {
+          r = static_cast<unsigned char>(
+              std::min(255, static_cast<int>(r) * 255 / a));
+          g = static_cast<unsigned char>(
+              std::min(255, static_cast<int>(g) * 255 / a));
+          b = static_cast<unsigned char>(
+              std::min(255, static_cast<int>(b) * 255 / a));
+        }
+        eventTablePixels[static_cast<size_t>(i) * 4] = r;
+        eventTablePixels[static_cast<size_t>(i) * 4 + 1] = g;
+        eventTablePixels[static_cast<size_t>(i) * 4 + 2] = b;
+        eventTablePixels[static_cast<size_t>(i) * 4 + 3] = a;
+      }
+  
+      if (!InitGL()) {
+        clearLoadingState();
+        NotifyRenderReady();
+        return;
+      }
+      if (cache.texture == 0) {
+        glGenTextures(1, &cache.texture);
+      }
+      glBindTexture(GL_TEXTURE_2D, cache.texture);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+      glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+      ScopedActivePixelUnpackPbo scopedPbo(cache.pixelUnpackPbo,
+                                           cache.pboBytes);
+      if (!UploadRgbaToTexture(cache.texture, width, height,
+                               eventTablePixels.data(), cache.textureSize,
+                               true)) {
+        ClearCachedTexture(cache);
+        cache.textureSize = wxSize(0, 0);
+        cache.renderZoom = 0.0;
+        continue;
+      }
+      cache.textureSize = wxSize(width, height);
+      cache.renderZoom = renderZoom;
+      cache.contentHash = dataHash;
+      eventTablePixels.clear();
+    }
+  
+    for (const auto &text : currentLayout.textViews) {
+      TextCache &cache = GetTextCache(text.id);
+      size_t dataHash = HashTextContent(text);
+      if (cache.contentHash != dataHash)
+        cache.renderDirty = true;
+      if (!cache.renderDirty)
+        continue;
+      cache.renderDirty = false;
+  
+      const wxSize renderSize = GetFrameSizeForZoom(text.frame, renderZoom);
+      if (renderSize.GetWidth() <= 0 || renderSize.GetHeight() <= 0) {
+        ClearCachedTexture(cache);
+        cache.textureSize = wxSize(0, 0);
+        cache.renderZoom = 0.0;
+        continue;
+      }
+  
+      wxImage image = BuildTextImage(
+          renderSize, wxSize(text.frame.width, text.frame.height), renderZoom,
+          text);
+      if (!image.IsOk()) {
+        ClearCachedTexture(cache);
+        cache.textureSize = wxSize(0, 0);
+        cache.renderZoom = 0.0;
+        continue;
+      }
+      image = image.Mirror(false);
+      if (!image.HasAlpha())
+        image.InitAlpha();
+      const int width = image.GetWidth();
+      const int height = image.GetHeight();
+      const unsigned char *rgb = image.GetData();
+      const unsigned char *alpha = image.GetAlpha();
+      if (!rgb || width <= 0 || height <= 0) {
+        ClearCachedTexture(cache);
+        cache.textureSize = wxSize(0, 0);
+        cache.renderZoom = 0.0;
+        continue;
+      }
+  
+      if (!TryAllocatePixelBuffer(textPixels, width, height, "text")) {
+        ClearCachedTexture(cache);
+        cache.textureSize = wxSize(0, 0);
+        cache.renderZoom = 0.0;
+        continue;
+      }
+      const bool needsUnpremultiply = !text.solidBackground;
+      for (int i = 0; i < width * height; ++i) {
+        const unsigned char a = alpha ? alpha[i] : 255;
+        unsigned char r = rgb[i * 3];
+        unsigned char g = rgb[i * 3 + 1];
+        unsigned char b = rgb[i * 3 + 2];
+        if (needsUnpremultiply && a > 0 && a < 255) {
+          r = static_cast<unsigned char>(
+              std::min(255, static_cast<int>(r) * 255 / a));
+          g = static_cast<unsigned char>(
+              std::min(255, static_cast<int>(g) * 255 / a));
+          b = static_cast<unsigned char>(
+              std::min(255, static_cast<int>(b) * 255 / a));
+        }
+        textPixels[static_cast<size_t>(i) * 4] = r;
+        textPixels[static_cast<size_t>(i) * 4 + 1] = g;
+        textPixels[static_cast<size_t>(i) * 4 + 2] = b;
+        textPixels[static_cast<size_t>(i) * 4 + 3] = a;
+      }
+  
+      if (!InitGL()) {
+        clearLoadingState();
+        NotifyRenderReady();
+        return;
+      }
+      if (cache.texture == 0) {
+        glGenTextures(1, &cache.texture);
+      }
+      glBindTexture(GL_TEXTURE_2D, cache.texture);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+      glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+      ScopedActivePixelUnpackPbo scopedPbo(cache.pixelUnpackPbo,
+                                           cache.pboBytes);
+      if (!UploadRgbaToTexture(cache.texture, width, height, textPixels.data(),
+                               cache.textureSize, true)) {
+        ClearCachedTexture(cache);
+        cache.textureSize = wxSize(0, 0);
+        cache.renderZoom = 0.0;
+        continue;
+      }
+      cache.textureSize = wxSize(width, height);
+      cache.renderZoom = renderZoom;
+      cache.contentHash = dataHash;
+      textPixels.clear();
+    }
+  
+    for (const auto &image : currentLayout.imageViews) {
+      ImageCache &cache = GetImageCache(image.id);
+      size_t dataHash = HashImageContent(image);
+      if (cache.contentHash != dataHash)
+        cache.renderDirty = true;
+      if (!cache.renderDirty)
+        continue;
+      cache.renderDirty = false;
+  
+      const wxSize renderSize = GetFrameSizeForZoom(image.frame, renderZoom);
+      if (renderSize.GetWidth() <= 0 || renderSize.GetHeight() <= 0) {
+        ClearCachedTexture(cache);
+        cache.textureSize = wxSize(0, 0);
+        cache.renderZoom = 0.0;
+        continue;
+      }
+      if (image.imagePath.empty()) {
+        ClearCachedTexture(cache);
+        cache.textureSize = wxSize(0, 0);
+        cache.renderZoom = 0.0;
+        continue;
+      }
+  
+      wxImage bitmap;
+      if (!bitmap.LoadFile(wxString::FromUTF8(image.imagePath))) {
+        ClearCachedTexture(cache);
+        cache.textureSize = wxSize(0, 0);
+        cache.renderZoom = 0.0;
+        continue;
+      }
+      if (bitmap.GetWidth() <= 0 || bitmap.GetHeight() <= 0) {
+        ClearCachedTexture(cache);
+        cache.textureSize = wxSize(0, 0);
+        cache.renderZoom = 0.0;
+        continue;
+      }
+      wxImage scaled =
+          bitmap.Scale(renderSize.GetWidth(), renderSize.GetHeight(),
+                       wxIMAGE_QUALITY_HIGH);
+      if (!scaled.IsOk()) {
+        ClearCachedTexture(cache);
+        cache.textureSize = wxSize(0, 0);
+        cache.renderZoom = 0.0;
+        continue;
+      }
+      scaled = scaled.Mirror(false);
+      if (!scaled.HasAlpha())
+        scaled.InitAlpha();
+      const int width = scaled.GetWidth();
+      const int height = scaled.GetHeight();
+      const unsigned char *rgb = scaled.GetData();
+      const unsigned char *alpha = scaled.GetAlpha();
+      if (!rgb || width <= 0 || height <= 0) {
+        ClearCachedTexture(cache);
+        cache.textureSize = wxSize(0, 0);
+        cache.renderZoom = 0.0;
+        continue;
+      }
+  
+      if (!TryAllocatePixelBuffer(imagePixels, width, height, "image")) {
+        ClearCachedTexture(cache);
+        cache.textureSize = wxSize(0, 0);
+        cache.renderZoom = 0.0;
+        continue;
+      }
+      for (int i = 0; i < width * height; ++i) {
+        imagePixels[static_cast<size_t>(i) * 4] = rgb[i * 3];
+        imagePixels[static_cast<size_t>(i) * 4 + 1] = rgb[i * 3 + 1];
+        imagePixels[static_cast<size_t>(i) * 4 + 2] = rgb[i * 3 + 2];
+        imagePixels[static_cast<size_t>(i) * 4 + 3] = alpha ? alpha[i] : 255;
+      }
+  
+      if (!InitGL()) {
+        clearLoadingState();
+        NotifyRenderReady();
+        return;
+      }
+      if (cache.texture == 0) {
+        glGenTextures(1, &cache.texture);
+      }
+      glBindTexture(GL_TEXTURE_2D, cache.texture);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+      glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+      ScopedActivePixelUnpackPbo scopedPbo(cache.pixelUnpackPbo,
+                                           cache.pboBytes);
+      if (!UploadRgbaToTexture(cache.texture, width, height, imagePixels.data(),
+                               cache.textureSize, true)) {
+        ClearCachedTexture(cache);
+        cache.textureSize = wxSize(0, 0);
+        cache.renderZoom = 0.0;
+        continue;
+      }
+      cache.textureSize = wxSize(width, height);
+      cache.renderZoom = renderZoom;
+      cache.contentHash = dataHash;
+      imagePixels.clear();
+    }
+  
     clearLoadingState();
     NotifyRenderReady();
   } catch (const std::exception &ex) {
@@ -2472,276 +2595,6 @@ void LayoutViewerPanel::RebuildCachedTexture() {
         "LayoutViewerPanel::RebuildCachedTexture unknown exception.");
     NotifyRenderReady();
   }
-}
-
-
-// Starts a new per-tick deadline used by progressive texture rebuilding.
-void LayoutViewerPanel::StartRebuildTickBudget() { rebuildTickStart_ = std::chrono::steady_clock::now(); }
-
-// Reports whether the current progressive rebuild tick exhausted its time budget.
-bool LayoutViewerPanel::IsRebuildTimeBudgetExpired() const { return std::chrono::steady_clock::now() - rebuildTickStart_ >= rebuildTickBudget_; }
-
-// Logs per-stage rebuild metrics for visibility into expensive texture categories.
-void LayoutViewerPanel::LogRebuildStageMetrics(const char *stageName, int processedCount, std::chrono::steady_clock::duration elapsed) const {
-  const auto elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
-  if (processedCount == 0 && elapsedMs == 0)
-    return;
-  Logger::Instance().Log(std::string("LayoutViewerPanel rebuild stage ") + stageName + ": count=" + std::to_string(processedCount) + ", ms=" + std::to_string(elapsedMs));
-}
-
-// Collects rebuild prerequisites and lazily resolves offscreen rendering dependencies.
-bool LayoutViewerPanel::EnsureRebuildResourcesReady(bool &needsLegendProcessing, bool &needsLegendSymbolCapture, Viewer2DOffscreenRenderer *&offscreenRenderer, Viewer2DPanel *&capturePanel) {
-  bool hasDirtyViewCache = false;
-  for (const auto &view : currentLayout.view2dViews) {
-    const auto cacheIt = viewCaches_.find(view.id);
-    if (cacheIt != viewCaches_.end() && cacheIt->second.renderDirty) { hasDirtyViewCache = true; break; }
-  }
-  needsLegendProcessing = false; needsLegendSymbolCapture = false;
-  for (const auto &legend : currentLayout.legendViews) {
-    const auto cacheIt = legendCaches_.find(legend.id);
-    const bool cacheMissing = cacheIt == legendCaches_.end();
-    const bool contentChanged = !cacheMissing && cacheIt->second.contentHash != legendDataHash;
-    const bool needsTextureRebuild = cacheMissing || cacheIt->second.renderDirty || contentChanged;
-    if (needsTextureRebuild) { needsLegendProcessing = true; const bool needsSymbols = cacheMissing || !cacheIt->second.symbols || contentChanged; if (needsSymbols) needsLegendSymbolCapture = true; }
-  }
-  const bool needsCapturePanel = hasDirtyViewCache || needsLegendSymbolCapture;
-  if (!needsCapturePanel) return true;
-  if (auto *mw = MainWindow::Instance()) { offscreenRenderer = mw->GetOffscreenRenderer(); capturePanel = offscreenRenderer ? offscreenRenderer->GetPanel() : nullptr; }
-  return capturePanel && offscreenRenderer;
-}
-
-// Captures legend symbol snapshots only when required by dirty legend caches.
-bool LayoutViewerPanel::PrepareLegendSymbolsIfNeeded(bool needsLegendSymbolCapture, Viewer2DPanel *capturePanel, ConfigManager &cfg, std::shared_ptr<const SymbolDefinitionSnapshot> &legendSymbols) {
-  if (!needsLegendSymbolCapture) return true;
-  if (!capturePanel) return false;
-  legendSymbols = CaptureLegendSymbolSnapshot(capturePanel, cfg, true);
-  return true;
-}
-
-// Processes dirty 2D view textures in bounded batches and uploads each successful render to GPU.
-bool LayoutViewerPanel::ProcessDirty2DViews(Viewer2DOffscreenRenderer *offscreenRenderer, Viewer2DPanel *capturePanel, ConfigManager &cfg, double renderZoom, int maxItems, bool &timeBudgetExpired) {
-  if (!offscreenRenderer || !capturePanel)
-    return true;
-  const auto stageStart = std::chrono::steady_clock::now();
-  int processedCount = 0;
-  if (currentLayout.view2dViews.empty())
-    return true;
-  const size_t total = currentLayout.view2dViews.size();
-  for (int pass = 0; pass < 2; ++pass) {
-    for (size_t scanned = 0; scanned < total; ++scanned) {
-      const size_t idx = (rebuildViewCursor_ + scanned) % total;
-      const auto &view = currentLayout.view2dViews[idx];
-      wxRect frameRect;
-      const bool isVisible = GetFrameRect(view.frame, frameRect) && frameRect.Intersects(wxRect(wxPoint(0, 0), GetClientSize()));
-      const bool isSelected = selectedElementType == SelectedElementType::View2D && selectedElementId == view.id;
-      const bool isPriority = isVisible || isSelected;
-      if ((pass == 0 && !isPriority) || (pass == 1 && isPriority))
-        continue;
-    ViewCache &cache = GetViewCache(view.id);
-    if (!cache.renderDirty)
-      continue;
-    cache.renderDirty = false;
-    if (!cache.hasCapture || !cache.hasRenderState || !GetFrameRect(view.frame, frameRect)) {
-      ClearCachedTexture(cache);
-      cache.textureSize = wxSize(0, 0);
-      cache.renderZoom = 0.0;
-    } else {
-      const wxSize renderSize = GetFrameSizeForZoom(view.frame, renderZoom);
-      if (renderSize.GetWidth() <= 0 || renderSize.GetHeight() <= 0) {
-        ClearCachedTexture(cache);
-        cache.textureSize = wxSize(0, 0);
-        cache.renderZoom = 0.0;
-      } else {
-        offscreenRenderer->SetViewportSize(renderSize);
-        offscreenRenderer->PrepareForCapture();
-        const RenderSize captureRenderSize = ResolveRenderSize(capturePanel);
-        const int captureWidth = captureRenderSize.width > 0
-                                     ? captureRenderSize.width
-                                     : renderSize.GetWidth();
-        const int captureHeight = captureRenderSize.height > 0
-                                      ? captureRenderSize.height
-                                      : renderSize.GetHeight();
-        viewer2d::Viewer2DState renderState = cache.renderState;
-        if (renderZoom != 1.0)
-          renderState.camera.zoom *= static_cast<float>(renderZoom);
-        renderState.camera.viewportWidth = captureWidth;
-        renderState.camera.viewportHeight = captureHeight;
-        auto stateGuard = std::make_shared<viewer2d::ScopedViewer2DState>(
-            capturePanel, nullptr, cfg, renderState, capturePanel, nullptr,
-            false);
-        std::vector<unsigned char> pixels;
-        int width = 0;
-        int height = 0;
-        Viewer2DRenderOverrides captureOverrides;
-        captureOverrides.drawFixtureLabels = true;
-        capturePanel->SetRenderOverrides(captureOverrides);
-        capturePanel->SetPreferPerastageSvgSymbolsForLayouts(true);
-        const bool rendered = capturePanel->RenderToRGBA(pixels, width, height);
-        capturePanel->SetRenderOverrides(std::nullopt);
-        capturePanel->SetPreferPerastageSvgSymbolsForLayouts(false);
-        if (!rendered || width <= 0 || height <= 0) {
-          ClearCachedTexture(cache);
-          cache.textureSize = wxSize(0, 0);
-          cache.renderZoom = 0.0;
-        } else {
-          if (!InitGL())
-            return false;
-          if (cache.texture == 0)
-            glGenTextures(1, &cache.texture);
-          glBindTexture(GL_TEXTURE_2D, cache.texture);
-          glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-          glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-          glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-          glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-          glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-          ScopedActivePixelUnpackPbo scopedPbo(cache.pixelUnpackPbo, cache.pboBytes);
-          if (!UploadRgbaToTexture(cache.texture, width, height, pixels.data(), cache.textureSize, true)) {
-            ClearCachedTexture(cache);
-            cache.textureSize = wxSize(0, 0);
-            cache.renderZoom = 0.0;
-          } else {
-            cache.textureSize = wxSize(width, height);
-            cache.renderZoom = renderZoom;
-            cache.contentHash = HashViewContent(view);
-          }
-        }
-      }
-    }
-      processedCount++;
-      rebuildViewCursor_ = (idx + 1) % total;
-      if (processedCount >= maxItems || IsRebuildTimeBudgetExpired()) {
-        timeBudgetExpired = true;
-        break;
-      }
-    }
-    if (timeBudgetExpired)
-      break;
-  }
-  LogRebuildStageMetrics("2d_views", processedCount, std::chrono::steady_clock::now() - stageStart);
-  return true;
-}
-
-// Processes dirty legend textures in bounded batches and refreshes symbol snapshots when needed.
-bool LayoutViewerPanel::ProcessDirtyLegends(double renderZoom, int maxItems, const std::shared_ptr<const SymbolDefinitionSnapshot> &legendSymbols, std::vector<unsigned char> &legendPixels, bool &timeBudgetExpired) {
-  const auto stageStart = std::chrono::steady_clock::now();
-  int processedCount = 0;
-  if (currentLayout.legendViews.empty())
-    return true;
-  const size_t total = currentLayout.legendViews.size();
-  for (int pass = 0; pass < 2; ++pass) {
-    for (size_t scanned = 0; scanned < total; ++scanned) {
-      const size_t idx = (rebuildLegendCursor_ + scanned) % total;
-      const auto &legend = currentLayout.legendViews[idx];
-      wxRect frameRect;
-      const bool isVisible = GetFrameRect(legend.frame, frameRect) && frameRect.Intersects(wxRect(wxPoint(0, 0), GetClientSize()));
-      const bool isSelected = selectedElementType == SelectedElementType::Legend && selectedElementId == legend.id;
-      const bool isPriority = isVisible || isSelected;
-      if ((pass == 0 && !isPriority) || (pass == 1 && isPriority))
-        continue;
-    LegendCache &cache = GetLegendCache(legend.id);
-    const bool contentChanged = cache.contentHash != legendDataHash;
-    const bool requiresSymbolRefresh = !cache.symbols || contentChanged;
-    if (requiresSymbolRefresh && legendSymbols && cache.symbols != legendSymbols) { cache.symbols = legendSymbols; cache.renderDirty = true; }
-    if (contentChanged) cache.renderDirty = true;
-    if (!cache.renderDirty) continue;
-    cache.renderDirty = false;
-    const wxSize renderSize = GetFrameSizeForZoom(legend.frame, renderZoom);
-    if (renderSize.GetWidth() <= 0 || renderSize.GetHeight() <= 0) { ClearCachedTexture(cache); cache.textureSize = wxSize(0, 0); cache.renderZoom = 0.0; }
-    else {
-      wxImage image = BuildLegendImage(renderSize, wxSize(legend.frame.width, legend.frame.height), renderZoom, legendItems_, cache.symbols.get());
-      if (!image.IsOk()) { ClearCachedTexture(cache); cache.textureSize = wxSize(0, 0); cache.renderZoom = 0.0; }
-      else {
-        image = image.Mirror(false); if (!image.HasAlpha()) image.InitAlpha();
-        const int width = image.GetWidth(), height = image.GetHeight(); const unsigned char *rgb = image.GetData(); const unsigned char *alpha = image.GetAlpha();
-        if (!rgb || width <= 0 || height <= 0 || !TryAllocatePixelBuffer(legendPixels, width, height, "legend")) { ClearCachedTexture(cache); cache.textureSize = wxSize(0, 0); cache.renderZoom = 0.0; }
-        else {
-          for (int i = 0; i < width * height; ++i) { legendPixels[static_cast<size_t>(i) * 4] = rgb[i * 3]; legendPixels[static_cast<size_t>(i) * 4 + 1] = rgb[i * 3 + 1]; legendPixels[static_cast<size_t>(i) * 4 + 2] = rgb[i * 3 + 2]; legendPixels[static_cast<size_t>(i) * 4 + 3] = alpha ? alpha[i] : 255; }
-          if (!InitGL()) return false;
-          if (cache.texture == 0) glGenTextures(1, &cache.texture);
-          glBindTexture(GL_TEXTURE_2D, cache.texture); glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR); glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR); glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE); glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE); glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-          ScopedActivePixelUnpackPbo scopedPbo(cache.pixelUnpackPbo, cache.pboBytes);
-          if (!UploadRgbaToTexture(cache.texture, width, height, legendPixels.data(), cache.textureSize, true)) { ClearCachedTexture(cache); cache.textureSize = wxSize(0, 0); cache.renderZoom = 0.0; }
-          else { cache.textureSize = wxSize(width, height); cache.renderZoom = renderZoom; cache.contentHash = legendDataHash; }
-          legendPixels.clear();
-        }
-      }
-    }
-      processedCount++; rebuildLegendCursor_ = (idx + 1) % total;
-      if (processedCount >= maxItems || IsRebuildTimeBudgetExpired()) { timeBudgetExpired = true; break; }
-    }
-    if (timeBudgetExpired)
-      break;
-  }
-  LogRebuildStageMetrics("legends", processedCount, std::chrono::steady_clock::now() - stageStart);
-  return true;
-}
-
-// Processes dirty event table textures in bounded batches to progressively refresh overlay tables.
-bool LayoutViewerPanel::ProcessDirtyEventTables(double renderZoom, int maxItems, std::vector<unsigned char> &eventTablePixels, bool &timeBudgetExpired) {
-  const auto stageStart = std::chrono::steady_clock::now();
-  int processedCount = 0;
-  const size_t total = currentLayout.eventTables.size();
-  for (int pass = 0; pass < 2; ++pass) {
-    for (size_t scanned = 0; scanned < total; ++scanned) {
-      const size_t idx = (rebuildEventTableCursor_ + scanned) % total;
-      const auto &table = currentLayout.eventTables[idx];
-      wxRect frameRect;
-      const bool isVisible = GetFrameRect(table.frame, frameRect) && frameRect.Intersects(wxRect(wxPoint(0, 0), GetClientSize()));
-      const bool isSelected = selectedElementType == SelectedElementType::EventTable && selectedElementId == table.id;
-      const bool isPriority = isVisible || isSelected;
-      if ((pass == 0 && !isPriority) || (pass == 1 && isPriority))
-        continue;
-    EventTableCache &cache = GetEventTableCache(table.id);
-    size_t dataHash = HashEventTableFields(table);
-    if (cache.contentHash != dataHash) cache.renderDirty = true;
-    if (!cache.renderDirty) continue;
-    cache.renderDirty = false;
-    const wxSize renderSize = GetFrameSizeForZoom(table.frame, renderZoom);
-    if (renderSize.GetWidth() <= 0 || renderSize.GetHeight() <= 0) { ClearCachedTexture(cache); cache.textureSize = wxSize(0,0); cache.renderZoom = 0.0; }
-    else {
-      wxImage image = BuildEventTableImage(renderSize, wxSize(table.frame.width, table.frame.height), renderZoom, table);
-      if (!image.IsOk()) { ClearCachedTexture(cache); cache.textureSize = wxSize(0,0); cache.renderZoom = 0.0; }
-      else {
-        image = image.Mirror(false); if (!image.HasAlpha()) image.InitAlpha();
-        const int width=image.GetWidth(), height=image.GetHeight(); const unsigned char *rgb=image.GetData(), *alpha=image.GetAlpha();
-        if (!rgb || width<=0 || height<=0 || !TryAllocatePixelBuffer(eventTablePixels,width,height,"event table")) { ClearCachedTexture(cache); cache.textureSize = wxSize(0,0); cache.renderZoom = 0.0; }
-        else {
-          for (int i=0;i<width*height;++i){ const unsigned char a=alpha?alpha[i]:255; eventTablePixels[(size_t)i*4]=rgb[i*3]; eventTablePixels[(size_t)i*4+1]=rgb[i*3+1]; eventTablePixels[(size_t)i*4+2]=rgb[i*3+2]; eventTablePixels[(size_t)i*4+3]=a; }
-          if (!InitGL()) return false;
-          if (cache.texture==0) glGenTextures(1,&cache.texture);
-          glBindTexture(GL_TEXTURE_2D, cache.texture); glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR); glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR); glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE); glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE); glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-          ScopedActivePixelUnpackPbo scopedPbo(cache.pixelUnpackPbo, cache.pboBytes);
-          if (!UploadRgbaToTexture(cache.texture,width,height,eventTablePixels.data(),cache.textureSize,true)) { ClearCachedTexture(cache); cache.textureSize = wxSize(0,0); cache.renderZoom = 0.0; }
-          else { cache.textureSize = wxSize(width,height); cache.renderZoom = renderZoom; cache.contentHash = dataHash; }
-          eventTablePixels.clear();
-        }
-      }
-    }
-      processedCount++; rebuildEventTableCursor_=(idx+1)%total;
-      if (processedCount>=maxItems || IsRebuildTimeBudgetExpired()) { timeBudgetExpired=true; break; }
-    }
-    if (timeBudgetExpired)
-      break;
-  }
-  LogRebuildStageMetrics("event_tables", processedCount, std::chrono::steady_clock::now()-stageStart);
-  return true;
-}
-
-// Processes dirty text textures in bounded batches to progressively refresh text overlays.
-bool LayoutViewerPanel::ProcessDirtyTexts(double renderZoom, int maxItems, std::vector<unsigned char> &textPixels, bool &timeBudgetExpired) {
-  const auto stageStart = std::chrono::steady_clock::now(); int processedCount = 0; const size_t total = currentLayout.textViews.size();
-  const uint64_t epoch = renderEpoch_.load();
-  for (int pass = 0; pass < 2; ++pass) { for (size_t scanned = 0; scanned < total; ++scanned) { const size_t idx = (rebuildTextCursor_ + scanned) % total; const auto &text = currentLayout.textViews[idx]; wxRect frameRect; const bool isVisible = GetFrameRect(text.frame, frameRect) && frameRect.Intersects(wxRect(wxPoint(0, 0), GetClientSize())); const bool isSelected = selectedElementType == SelectedElementType::Text && selectedElementId == text.id; const bool isPriority = isVisible || isSelected; if ((pass == 0 && !isPriority) || (pass == 1 && isPriority)) continue; TextCache &cache = GetTextCache(text.id); size_t dataHash = HashTextContent(text); if (cache.contentHash != dataHash) cache.renderDirty = true; if (!cache.renderDirty) continue; cache.renderDirty = false; const wxSize renderSize = GetFrameSizeForZoom(text.frame, renderZoom); if (renderSize.GetWidth() <= 0 || renderSize.GetHeight() <= 0) { ClearCachedTexture(cache); cache.textureSize = wxSize(0,0); cache.renderZoom = 0.0; } else { auto task = std::async(std::launch::async, [this, text, renderSize, renderZoom]() { return PrepareRgbaPayloadFromImage(BuildTextImage(renderSize, wxSize(text.frame.width, text.frame.height), renderZoom, text), "text"); }); PreparedRgbaPayload payload = task.get(); if (epoch != renderEpoch_.load()) return true; if (!payload.valid) { ClearCachedTexture(cache); cache.textureSize = wxSize(0,0); cache.renderZoom = 0.0; } else { if (!InitGL()) return false; if (cache.texture==0) glGenTextures(1,&cache.texture); glBindTexture(GL_TEXTURE_2D, cache.texture); glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR); glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR); glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE); glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE); glPixelStorei(GL_UNPACK_ALIGNMENT,1); ScopedActivePixelUnpackPbo scopedPbo(cache.pixelUnpackPbo, cache.pboBytes); if (!UploadRgbaToTexture(cache.texture,payload.width,payload.height,payload.pixels.data(),cache.textureSize,true)) { ClearCachedTexture(cache); cache.textureSize = wxSize(0,0); cache.renderZoom = 0.0; } else { cache.textureSize = wxSize(payload.width,payload.height); cache.renderZoom = renderZoom; cache.contentHash = dataHash; } } } processedCount++; rebuildTextCursor_=(idx+1)%total; if (processedCount>=maxItems || IsRebuildTimeBudgetExpired()) { timeBudgetExpired=true; break; } } if (timeBudgetExpired) break; }
-  LogRebuildStageMetrics("texts", processedCount, std::chrono::steady_clock::now()-stageStart); return true;
-}
-
-// Processes dirty image textures in bounded batches to progressively refresh bitmap overlays.
-bool LayoutViewerPanel::ProcessDirtyImages(double renderZoom, int maxItems, std::vector<unsigned char> &imagePixels, bool &timeBudgetExpired) {
-  const auto stageStart = std::chrono::steady_clock::now(); int processedCount = 0; const size_t total = currentLayout.imageViews.size();
-  for (int pass = 0; pass < 2; ++pass) { for (size_t scanned = 0; scanned < total; ++scanned) { const size_t idx = (rebuildImageCursor_ + scanned) % total; const auto &image = currentLayout.imageViews[idx]; wxRect frameRect; const bool isVisible = GetFrameRect(image.frame, frameRect) && frameRect.Intersects(wxRect(wxPoint(0, 0), GetClientSize())); const bool isSelected = selectedElementType == SelectedElementType::Image && selectedElementId == image.id; const bool isPriority = isVisible || isSelected; if ((pass == 0 && !isPriority) || (pass == 1 && isPriority)) continue; ImageCache &cache = GetImageCache(image.id); size_t dataHash = HashImageContent(image); if (cache.contentHash != dataHash) cache.renderDirty = true; if (!cache.renderDirty) continue; cache.renderDirty = false; const wxSize renderSize = GetFrameSizeForZoom(image.frame, renderZoom); if (renderSize.GetWidth() <= 0 || renderSize.GetHeight() <= 0 || image.imagePath.empty()) { ClearCachedTexture(cache); cache.textureSize = wxSize(0,0); cache.renderZoom = 0.0; } else { std::filesystem::file_time_type fileMtime{}; const bool hasMtime = TryGetImageFileMtime(image.imagePath, fileMtime); if (!hasMtime) { ClearCachedTexture(cache); cache.textureSize = wxSize(0,0); cache.renderZoom = 0.0; } else { const wxImage *scaled = GetOrCreateScaledImageBitmap(image.imagePath, renderSize.GetWidth(), renderSize.GetHeight(), fileMtime); if (!scaled || !scaled->IsOk()) { ClearCachedTexture(cache); cache.textureSize = wxSize(0,0); cache.renderZoom = 0.0; } else { const int width=scaled->GetWidth(), height=scaled->GetHeight(); const unsigned char *rgb=scaled->GetData(), *alpha=scaled->GetAlpha(); if (!rgb || width<=0 || height<=0 || !TryAllocatePixelBuffer(imagePixels,width,height,"image")) { ClearCachedTexture(cache); cache.textureSize = wxSize(0,0); cache.renderZoom = 0.0; } else { for (int i=0;i<width*height;++i){ imagePixels[(size_t)i*4]=rgb[i*3]; imagePixels[(size_t)i*4+1]=rgb[i*3+1]; imagePixels[(size_t)i*4+2]=rgb[i*3+2]; imagePixels[(size_t)i*4+3]=alpha?alpha[i]:255; } if (!InitGL()) return false; if (cache.texture==0) glGenTextures(1,&cache.texture); glBindTexture(GL_TEXTURE_2D, cache.texture); glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR); glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR); glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE); glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE); glPixelStorei(GL_UNPACK_ALIGNMENT, 1); ScopedActivePixelUnpackPbo scopedPbo(cache.pixelUnpackPbo, cache.pboBytes); if (!UploadRgbaToTexture(cache.texture,width,height,imagePixels.data(),cache.textureSize,true)) { ClearCachedTexture(cache); cache.textureSize = wxSize(0,0); cache.renderZoom = 0.0; } else { cache.textureSize = wxSize(width,height); cache.renderZoom = renderZoom; cache.contentHash = dataHash; } imagePixels.clear(); } } } }
-    processedCount++; rebuildImageCursor_=(idx+1)%total; if (processedCount>=maxItems || IsRebuildTimeBudgetExpired()) { timeBudgetExpired=true; break; } } if (timeBudgetExpired) break;
-  }
-  LogRebuildStageMetrics("images", processedCount, std::chrono::steady_clock::now()-stageStart); return true;
 }
 
 void LayoutViewerPanel::ClearCachedTexture() {
@@ -2916,13 +2769,10 @@ bool LayoutViewerPanel::HasDirtyRenderCaches() const {
 }
 
 bool LayoutViewerPanel::NeedsRenderRebuild() const {
-  return renderDirty || contentDirty || HasDirtyRenderCaches();
+  return renderDirty || HasDirtyRenderCaches();
 }
 
-// Schedules a deferred layout texture rebuild when content is dirty and rendering is available.
 void LayoutViewerPanel::RequestRenderRebuild() {
-  // Advances the render epoch to cancel stale payloads queued before this rebuild request.
-  NextRenderEpoch();
   if (IsLayoutEmpty()) {
     renderPending = false;
     loadingRequested = false;
@@ -2954,6 +2804,8 @@ void LayoutViewerPanel::RequestRenderRebuild() {
     panel->isLoading = true;
     panel->Refresh();
     panel->Update();
+    if (wxTheApp && wxTheApp->IsMainLoopRunning())
+      wxTheApp->Yield(true);
     if (!weakThis)
       return;
     panel = weakThis.get();
@@ -2965,9 +2817,6 @@ void LayoutViewerPanel::RequestRenderRebuild() {
     panel->renderDelayTimer_.StartOnce(kLoadingOverlayDelayMs);
   });
 }
-
-// Returns a new render epoch value used to guard asynchronous CPU payload tasks.
-uint64_t LayoutViewerPanel::NextRenderEpoch() { return ++renderEpoch_; }
 
 void LayoutViewerPanel::OnLoadingTimer(wxTimerEvent &) {
   if (!loadingRequested)
@@ -3220,7 +3069,7 @@ void LayoutViewerPanel::EmitViewSelectionChanged(int viewId) {
 LayoutViewerPanel::ViewCache &LayoutViewerPanel::GetViewCache(int viewId) {
   auto [it, inserted] = viewCaches_.try_emplace(viewId, ViewCache{});
   if (inserted) {
-    contentDirty = true;
+    renderDirty = true;
   }
   return it->second;
 }
@@ -3228,7 +3077,7 @@ LayoutViewerPanel::ViewCache &LayoutViewerPanel::GetViewCache(int viewId) {
 LayoutViewerPanel::LegendCache &LayoutViewerPanel::GetLegendCache(int legendId) {
   auto [it, inserted] = legendCaches_.try_emplace(legendId, LegendCache{});
   if (inserted) {
-    contentDirty = true;
+    renderDirty = true;
   }
   return it->second;
 }
@@ -3238,7 +3087,7 @@ LayoutViewerPanel::GetEventTableCache(int tableId) {
   auto [it, inserted] =
       eventTableCaches_.try_emplace(tableId, EventTableCache{});
   if (inserted) {
-    contentDirty = true;
+    renderDirty = true;
   }
   return it->second;
 }
@@ -3246,7 +3095,7 @@ LayoutViewerPanel::GetEventTableCache(int tableId) {
 LayoutViewerPanel::TextCache &LayoutViewerPanel::GetTextCache(int textId) {
   auto [it, inserted] = textCaches_.try_emplace(textId, TextCache{});
   if (inserted) {
-    contentDirty = true;
+    renderDirty = true;
   }
   return it->second;
 }
@@ -3254,7 +3103,7 @@ LayoutViewerPanel::TextCache &LayoutViewerPanel::GetTextCache(int textId) {
 LayoutViewerPanel::ImageCache &LayoutViewerPanel::GetImageCache(int imageId) {
   auto [it, inserted] = imageCaches_.try_emplace(imageId, ImageCache{});
   if (inserted) {
-    contentDirty = true;
+    renderDirty = true;
   }
   return it->second;
 }

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -17,8 +17,6 @@
  */
 #pragma once
 
-#include <chrono>
-#include <atomic>
 #include <memory>
 #include <optional>
 #include <unordered_map>
@@ -124,16 +122,6 @@ private:
     bool renderDirty = true;
     size_t contentHash = 0;
   };
-  struct TexturedQuadVertex {
-    float x;
-    float y;
-    float u;
-    float v;
-  };
-  struct TexturedQuadBatch {
-    GLuint texture = 0;
-    std::vector<TexturedQuadVertex> vertices;
-  };
 
   void NotifyRenderReady();
   void OnPaint(wxPaintEvent &event);
@@ -175,9 +163,6 @@ private:
                        int activeTextId);
   void DrawImageElement(const layouts::LayoutImageDefinition &image,
                         int activeImageId);
-  void QueueTexturedQuad(GLuint texture, const wxRect &frameRect);
-  void FlushQueuedTexturedQuads();
-  void DrawTexturedQuadImmediate(GLuint texture, const wxRect &frameRect) const;
   void DrawDeferredResizeOverlay();
   void DrawLoadingOverlay(const wxSize &size);
   void EnsureLoadingTextTexture();
@@ -205,35 +190,6 @@ private:
   void CommitPendingFrameUpdate();
   bool InitGL();
   void RebuildCachedTexture();
-  bool EnsureRebuildResourcesReady(bool &needsLegendProcessing,
-                                   bool &needsLegendSymbolCapture,
-                                   Viewer2DOffscreenRenderer *&offscreenRenderer,
-                                   Viewer2DPanel *&capturePanel);
-  bool PrepareLegendSymbolsIfNeeded(
-      bool needsLegendSymbolCapture, Viewer2DPanel *capturePanel,
-      ConfigManager &cfg,
-      std::shared_ptr<const SymbolDefinitionSnapshot> &legendSymbols);
-  bool ProcessDirty2DViews(Viewer2DOffscreenRenderer *offscreenRenderer,
-                           Viewer2DPanel *capturePanel, ConfigManager &cfg,
-                           double renderZoom, int maxItems,
-                           bool &timeBudgetExpired);
-  bool ProcessDirtyLegends(
-      double renderZoom, int maxItems,
-      const std::shared_ptr<const SymbolDefinitionSnapshot> &legendSymbols,
-      std::vector<unsigned char> &legendPixels, bool &timeBudgetExpired);
-  bool ProcessDirtyEventTables(double renderZoom, int maxItems,
-                               std::vector<unsigned char> &eventTablePixels,
-                               bool &timeBudgetExpired);
-  bool ProcessDirtyTexts(double renderZoom, int maxItems,
-                         std::vector<unsigned char> &textPixels,
-                         bool &timeBudgetExpired);
-  bool ProcessDirtyImages(double renderZoom, int maxItems,
-                          std::vector<unsigned char> &imagePixels,
-                          bool &timeBudgetExpired);
-  bool IsRebuildTimeBudgetExpired() const;
-  void StartRebuildTickBudget();
-  void LogRebuildStageMetrics(const char *stageName, int processedCount,
-                              std::chrono::steady_clock::duration elapsed) const;
   void ClearCachedTexture();
   void ClearCachedTexture(ViewCache &cache);
   void ClearCachedTexture(LegendCache &cache);
@@ -242,7 +198,6 @@ private:
   void ClearCachedTexture(ImageCache &cache);
   bool HasDirtyRenderCaches() const;
   bool NeedsRenderRebuild() const;
-  uint64_t NextRenderEpoch();
   void RequestRenderRebuild();
   void InvalidateRenderIfFrameChanged(bool includeSceneContent = true);
   size_t ComputeSceneContentHash() const;
@@ -330,9 +285,6 @@ private:
   };
 
   void InvalidateSelectionIndexCache();
-  void MaybePrewarmOnLayoutModeEntry(const layouts::LayoutDefinition &previousLayout);
-  void ApplyPrewarmedArtifactsIfAvailable();
-  size_t BuildLayoutPrewarmContentHash() const;
   void EnsureSelectionIndexCache();
   std::vector<ZOrderedElement> BuildZOrderedElements() const;
   std::pair<int, int> GetZIndexRange() const;
@@ -361,8 +313,6 @@ private:
   bool glInitialized_ = false;
   bool isReadyToRender_ = false;
   bool renderDirty = true;
-  bool contentDirty = true;
-  bool presentationDirty = true;
   double lastRenderZoom = 0.0;
   double lastPageWidthPt = 0.0;
   double lastPageHeightPt = 0.0;
@@ -371,7 +321,6 @@ private:
   bool renderPending = false;
   bool isLoading = false;
   bool loadingRequested = false;
-  std::atomic<uint64_t> renderEpoch_{1};
   wxTimer loadingTimer_;
   wxTimer renderDelayTimer_;
   unsigned int loadingTextTexture_ = 0;
@@ -381,29 +330,12 @@ private:
   std::unordered_map<int, EventTableCache> eventTableCaches_;
   std::unordered_map<int, TextCache> textCaches_;
   std::unordered_map<int, ImageCache> imageCaches_;
-  std::vector<TexturedQuadBatch> texturedQuadBatches_;
-  GLuint texturedQuadVao_ = 0;
-  GLuint texturedQuadVbo_ = 0;
   std::vector<LegendItem> legendItems_;
   size_t legendDataHash = 0;
   bool legendDataDirty_ = true;
   bool pendingFitOnResize = true;
   bool pendingFrameCommit_ = false;
   SelectionIndexCache selectionIndexCache_;
-  struct PrewarmedLayoutArtifacts {
-    int layoutVersion = 0;
-    size_t contentHash = 0;
-    std::shared_ptr<const SymbolDefinitionSnapshot> legendSymbols;
-    std::unordered_map<int, viewer2d::Viewer2DState> viewRenderStates;
-  };
-  std::unordered_map<std::string, PrewarmedLayoutArtifacts> prewarmedArtifactsByLayout_;
-  size_t rebuildViewCursor_ = 0;
-  size_t rebuildLegendCursor_ = 0;
-  size_t rebuildEventTableCursor_ = 0;
-  size_t rebuildTextCursor_ = 0;
-  size_t rebuildImageCursor_ = 0;
-  std::chrono::steady_clock::time_point rebuildTickStart_;
-  std::chrono::milliseconds rebuildTickBudget_{6};
 
   wxDECLARE_EVENT_TABLE();
 };

--- a/gui/layoutviewerpanel_render_invalidation.cpp
+++ b/gui/layoutviewerpanel_render_invalidation.cpp
@@ -17,24 +17,20 @@
  */
 #include "layoutviewerpanel.h"
 
-#include <algorithm>
 #include <functional>
 
 #include "configmanager.h"
 #include "guiconfigservices.h"
 
 namespace {
-// Combines hash values into a single rolling seed.
 void HashCombine(size_t &seed, size_t value) {
   seed ^= value + 0x9e3779b9 + (seed << 6) + (seed >> 2);
 }
 
-// Hashes a float value and merges it into a hash seed.
 void HashCombineFloat(size_t &seed, float value) {
   HashCombine(seed, std::hash<float>{}(value));
 }
 
-// Computes a deterministic hash for a Matrix transform value.
 size_t HashMatrixValue(const Matrix &matrix) {
   size_t hash = 0;
   HashCombineFloat(hash, matrix.u[0]);
@@ -52,7 +48,6 @@ size_t HashMatrixValue(const Matrix &matrix) {
   return hash;
 }
 
-// Computes a deterministic hash for a SceneObject payload.
 size_t HashSceneObjectValue(const SceneObject &object) {
   size_t hash = std::hash<std::string>{}(object.layer);
   HashCombine(hash, std::hash<std::string>{}(object.name));
@@ -66,7 +61,6 @@ size_t HashSceneObjectValue(const SceneObject &object) {
   return hash;
 }
 
-// Computes a deterministic hash for a Fixture payload.
 size_t HashFixtureValue(const Fixture &fixture) {
   size_t hash = std::hash<std::string>{}(fixture.layer);
   HashCombine(hash, std::hash<std::string>{}(fixture.instanceName));
@@ -78,7 +72,6 @@ size_t HashFixtureValue(const Fixture &fixture) {
   return hash;
 }
 
-// Computes a deterministic hash for a Truss payload.
 size_t HashTrussValue(const Truss &truss) {
   size_t hash = std::hash<std::string>{}(truss.layer);
   HashCombine(hash, std::hash<std::string>{}(truss.name));
@@ -88,7 +81,6 @@ size_t HashTrussValue(const Truss &truss) {
   return hash;
 }
 
-// Computes a deterministic hash for a Support payload.
 size_t HashSupportValue(const Support &support) {
   size_t hash = std::hash<std::string>{}(support.layer);
   HashCombine(hash, std::hash<std::string>{}(support.name));
@@ -97,7 +89,6 @@ size_t HashSupportValue(const Support &support) {
   return hash;
 }
 
-// Aggregates a stable hash for UUID-keyed scene maps.
 template <typename TMap, typename ValueHasher>
 size_t HashSceneMapWithValues(const TMap &items, ValueHasher hasher) {
   size_t aggregate = std::hash<size_t>{}(items.size());
@@ -108,18 +99,8 @@ size_t HashSceneMapWithValues(const TMap &items, ValueHasher hasher) {
   }
   return aggregate;
 }
-// Returns whether zoom delta is large enough to require raster regeneration.
-bool NeedsTextureRebuildForZoom(double previousZoom, double targetZoom) {
-  if (previousZoom <= 0.0 || targetZoom <= 0.0)
-    return true;
-  constexpr double kZoomRebuildThreshold = 1.15;
-  const double ratio = std::max(previousZoom, targetZoom) /
-                       std::min(previousZoom, targetZoom);
-  return ratio >= kZoomRebuildThreshold;
-}
 } // namespace
 
-// Computes a hash snapshot for scene entities used by layout rendering.
 size_t LayoutViewerPanel::ComputeSceneContentHash() const {
   const auto &scene = GetDefaultGuiConfigServices().LegacyConfigManager().GetScene();
   size_t hash = 0;
@@ -130,7 +111,6 @@ size_t LayoutViewerPanel::ComputeSceneContentHash() const {
   return hash;
 }
 
-// Computes a content hash for a 2D view definition.
 size_t LayoutViewerPanel::HashViewContent(
     const layouts::Layout2DViewDefinition &view) const {
   size_t seed = std::hash<int>{}(view.id);
@@ -182,7 +162,6 @@ size_t LayoutViewerPanel::HashViewContent(
   return seed;
 }
 
-// Marks content and presentation invalidation for cached frame resources.
 void LayoutViewerPanel::InvalidateRenderIfFrameChanged(bool includeSceneContent) {
   const double renderZoom = GetRenderZoom();
   const double pageWidth = currentLayout.pageSetup.PageWidthPt();
@@ -208,13 +187,11 @@ void LayoutViewerPanel::InvalidateRenderIfFrameChanged(bool includeSceneContent)
     const size_t contentHash = HashViewContent(view);
     if (cache.contentHash != 0 && cache.contentHash != contentHash) {
       markDirty(cache.renderDirty);
-      contentDirty = true;
     }
     if (sceneContentChanged) {
       cache.captureVersion = -1;
       cache.captureInProgress = false;
       markDirty(cache.renderDirty);
-      contentDirty = true;
     }
     wxRect frameRect;
     if (!GetFrameRect(view.frame, frameRect)) {
@@ -227,15 +204,9 @@ void LayoutViewerPanel::InvalidateRenderIfFrameChanged(bool includeSceneContent)
       continue;
     }
     const wxSize renderSize = GetFrameSizeForZoom(view.frame, renderZoom);
-    if (renderSize != cache.textureSize ||
-        NeedsTextureRebuildForZoom(cache.renderZoom, renderZoom)) {
+    if (cache.renderZoom == 0.0 || cache.renderZoom != renderZoom ||
+        renderSize != cache.textureSize) {
       markDirty(cache.renderDirty);
-      contentDirty = true;
-    } else if (cache.renderZoom != renderZoom) {
-      // Keep 2D view textures pixel-accurate at every layout zoom step so
-      // label placement and clipping stay synchronized with the capture.
-      markDirty(cache.renderDirty);
-      contentDirty = true;
     }
   }
 
@@ -244,7 +215,6 @@ void LayoutViewerPanel::InvalidateRenderIfFrameChanged(bool includeSceneContent)
     if (sceneContentChanged) {
       cache.symbols.reset();
       markDirty(cache.renderDirty);
-      contentDirty = true;
     }
     wxRect frameRect;
     if (!GetFrameRect(legend.frame, frameRect)) {
@@ -257,12 +227,9 @@ void LayoutViewerPanel::InvalidateRenderIfFrameChanged(bool includeSceneContent)
       continue;
     }
     const wxSize renderSize = GetFrameSizeForZoom(legend.frame, renderZoom);
-    if (renderSize != cache.textureSize ||
-        NeedsTextureRebuildForZoom(cache.renderZoom, renderZoom)) {
+    if (cache.renderZoom == 0.0 || cache.renderZoom != renderZoom ||
+        renderSize != cache.textureSize) {
       markDirty(cache.renderDirty);
-      contentDirty = true;
-    } else if (cache.renderZoom != renderZoom) {
-      presentationDirty = true;
     }
   }
 
@@ -279,12 +246,9 @@ void LayoutViewerPanel::InvalidateRenderIfFrameChanged(bool includeSceneContent)
       continue;
     }
     const wxSize renderSize = GetFrameSizeForZoom(table.frame, renderZoom);
-    if (renderSize != cache.textureSize ||
-        NeedsTextureRebuildForZoom(cache.renderZoom, renderZoom)) {
+    if (cache.renderZoom == 0.0 || cache.renderZoom != renderZoom ||
+        renderSize != cache.textureSize) {
       markDirty(cache.renderDirty);
-      contentDirty = true;
-    } else if (cache.renderZoom != renderZoom) {
-      presentationDirty = true;
     }
   }
 
@@ -301,12 +265,9 @@ void LayoutViewerPanel::InvalidateRenderIfFrameChanged(bool includeSceneContent)
       continue;
     }
     const wxSize renderSize = GetFrameSizeForZoom(text.frame, renderZoom);
-    if (renderSize != cache.textureSize ||
-        NeedsTextureRebuildForZoom(cache.renderZoom, renderZoom)) {
+    if (cache.renderZoom == 0.0 || cache.renderZoom != renderZoom ||
+        renderSize != cache.textureSize) {
       markDirty(cache.renderDirty);
-      contentDirty = true;
-    } else if (cache.renderZoom != renderZoom) {
-      presentationDirty = true;
     }
   }
 
@@ -323,19 +284,15 @@ void LayoutViewerPanel::InvalidateRenderIfFrameChanged(bool includeSceneContent)
       continue;
     }
     const wxSize renderSize = GetFrameSizeForZoom(image.frame, renderZoom);
-    if (renderSize != cache.textureSize ||
-        NeedsTextureRebuildForZoom(cache.renderZoom, renderZoom)) {
+    if (cache.renderZoom == 0.0 || cache.renderZoom != renderZoom ||
+        renderSize != cache.textureSize) {
       markDirty(cache.renderDirty);
-      contentDirty = true;
-    } else if (cache.renderZoom != renderZoom) {
-      presentationDirty = true;
     }
   }
 
-  if (sceneContentChanged)
-    contentDirty = true;
-  if (zoomChanged || pageChanged)
-    presentationDirty = true;
+  if (zoomChanged || pageChanged || sceneContentChanged) {
+    renderDirty = true;
+  }
   lastRenderZoom = renderZoom;
   lastPageWidthPt = pageWidth;
   lastPageHeightPt = pageHeight;
@@ -345,7 +302,6 @@ void LayoutViewerPanel::InvalidateRenderIfFrameChanged(bool includeSceneContent)
   }
 }
 
-// Refreshes caches after scene data changes and schedules a full rebuild.
 void LayoutViewerPanel::RefreshAfterSceneContentUpdate() {
   legendDataDirty_ = true;
   RefreshLegendData();
@@ -364,18 +320,15 @@ void LayoutViewerPanel::RefreshAfterSceneContentUpdate() {
     entry.second.symbols.reset();
   }
 
-  contentDirty = true;
-  presentationDirty = true;
+  renderDirty = true;
   RequestRenderRebuild();
   Refresh();
 }
 
-// Triggers a light refresh for selection-only updates.
 void LayoutViewerPanel::RefreshAfterSelectionOnlyUpdate() {
   Refresh();
 }
 
-// Refreshes caches after fixture-symbol updates.
 void LayoutViewerPanel::RefreshAfterFixtureSymbolUpdate() {
   RefreshAfterSceneContentUpdate();
 }

--- a/gui/layoutviewerpanel_shared.h
+++ b/gui/layoutviewerpanel_shared.h
@@ -28,16 +28,10 @@ namespace detail {
 // on-screen rendering matches exported PDFs.
 inline const std::vector<const char *> kSharedFontFaceNames = {
 #ifdef _WIN32
-    "Noto Sans",
     "Arial",
-    "Segoe UI",
 #elif defined(__APPLE__)
-    "Noto Sans",
-    "Helvetica",
     "Arial",
-    "SF Pro Text",
 #else
-    "Noto Sans",
     "DejaVu Sans",
     "Liberation Sans",
 #endif
@@ -46,7 +40,6 @@ inline const std::vector<const char *> kSharedFontFaceNames = {
 constexpr double kTextRenderScale = 96.0 / 72.0;
 constexpr int kTextDefaultFontSize = 12;
 
-// Resolves a platform-available sans-serif font face for layout text drawing.
 inline wxString ResolveSharedFontFaceName() {
   static wxString faceName;
   static bool initialized = false;
@@ -56,7 +49,8 @@ inline wxString ResolveSharedFontFaceName() {
     wxFont testFont(10, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL,
                     wxFONTWEIGHT_NORMAL, false,
                     wxString::FromUTF8(candidate));
-    if (testFont.IsOk()) {
+    if (testFont.IsOk() &&
+        testFont.GetFaceName().CmpNoCase(candidate) == 0) {
       faceName = testFont.GetFaceName();
       break;
     }
@@ -65,7 +59,6 @@ inline wxString ResolveSharedFontFaceName() {
   return faceName;
 }
 
-// Builds a shared font instance used by layout text and legends.
 inline wxFont MakeSharedFont(int sizePx, wxFontWeight weight) {
   wxString faceName = ResolveSharedFontFaceName();
   if (!faceName.empty()) {

--- a/gui/layoutviewerpanel_view.cpp
+++ b/gui/layoutviewerpanel_view.cpp
@@ -40,9 +40,7 @@
 #include "LayoutManager.h"
 #include "viewer2doffscreenrenderer.h"
 #include "viewer2dstate.h"
-#include "ui_feature_flags.h"
 
-// Returns the selected editable 2D view and keeps selection consistent.
 layouts::Layout2DViewDefinition *LayoutViewerPanel::GetEditableView() {
   if (currentLayout.view2dViews.empty())
     return nullptr;
@@ -58,7 +56,6 @@ layouts::Layout2DViewDefinition *LayoutViewerPanel::GetEditableView() {
   return &currentLayout.view2dViews.front();
 }
 
-// Returns the selected editable 2D view as a read-only pointer.
 const layouts::Layout2DViewDefinition *LayoutViewerPanel::GetEditableView()
     const {
   if (currentLayout.view2dViews.empty())
@@ -75,14 +72,12 @@ const layouts::Layout2DViewDefinition *LayoutViewerPanel::GetEditableView()
   return nullptr;
 }
 
-// Emits the edit-view action when the current selection is a 2D view.
 void LayoutViewerPanel::OnEditView(wxCommandEvent &) {
   if (selectedElementType != SelectedElementType::View2D)
     return;
   EmitEditViewRequest();
 }
 
-// Removes the selected 2D view from the current layout and updates selection.
 void LayoutViewerPanel::OnDeleteView(wxCommandEvent &) {
   if (selectedElementType != SelectedElementType::View2D)
     return;
@@ -134,7 +129,6 @@ void LayoutViewerPanel::OnDeleteView(wxCommandEvent &) {
   Refresh();
 }
 
-// Toggles the visibility of the selected 2D view frame and persists the change.
 void LayoutViewerPanel::OnToggleViewFrame(wxCommandEvent &) {
   if (selectedElementType != SelectedElementType::View2D)
     return;
@@ -152,7 +146,6 @@ void LayoutViewerPanel::OnToggleViewFrame(wxCommandEvent &) {
   Refresh();
 }
 
-// Updates the selected 2D view frame and triggers the needed render refresh path.
 void LayoutViewerPanel::UpdateFrame(const layouts::Layout2DViewFrame &frame,
                                     bool updatePosition) {
   layouts::Layout2DViewDefinition *view = GetEditableView();
@@ -194,7 +187,6 @@ void LayoutViewerPanel::UpdateFrame(const layouts::Layout2DViewFrame &frame,
   Refresh();
 }
 
-// Draws the 2D view cache texture and frame while refreshing stale captures asynchronously.
 void LayoutViewerPanel::DrawViewElement(
     const layouts::Layout2DViewDefinition &view, Viewer2DPanel *capturePanel,
     Viewer2DOffscreenRenderer *offscreenRenderer, int activeViewId) {
@@ -274,12 +266,24 @@ void LayoutViewerPanel::DrawViewElement(
   const wxSize renderSize = GetFrameSizeForZoom(view.frame, cache.renderZoom);
   if (cache.texture != 0 && renderSize.GetWidth() > 0 &&
       renderSize.GetHeight() > 0 && cache.textureSize == renderSize) {
-    if (ui::IsFeatureEnabled(ui::FeatureFlag::LayoutViewerVboQuadBatch)) {
-      QueueTexturedQuad(cache.texture, frameRect);
-      FlushQueuedTexturedQuads();
-    } else {
-      DrawTexturedQuadImmediate(cache.texture, frameRect);
-    }
+    glEnable(GL_TEXTURE_2D);
+    glBindTexture(GL_TEXTURE_2D, cache.texture);
+    glColor4ub(255, 255, 255, 255);
+    glBegin(GL_QUADS);
+    glTexCoord2f(0.0f, 1.0f);
+    glVertex2f(static_cast<float>(frameRect.GetLeft()),
+               static_cast<float>(frameRect.GetTop()));
+    glTexCoord2f(1.0f, 1.0f);
+    glVertex2f(static_cast<float>(frameRight),
+               static_cast<float>(frameRect.GetTop()));
+    glTexCoord2f(1.0f, 0.0f);
+    glVertex2f(static_cast<float>(frameRight),
+               static_cast<float>(frameBottom));
+    glTexCoord2f(0.0f, 0.0f);
+    glVertex2f(static_cast<float>(frameRect.GetLeft()),
+               static_cast<float>(frameRect.GetBottom()));
+    glEnd();
+    glDisable(GL_TEXTURE_2D);
   } else {
     glColor4ub(240, 240, 240, 255);
     glBegin(GL_QUADS);

--- a/gui/layoutviewerviewrenderer.cpp
+++ b/gui/layoutviewerviewrenderer.cpp
@@ -12,7 +12,6 @@
 #include "configmanager.h"
 #include "guiconfigservices.h"
 #include "legendutils.h"
-#include "layoutviewerpanel_shared.h"
 #include "symbols/PerastageSvgSymbol.h"
 #include "viewer2dcommandrenderer.h"
 
@@ -333,33 +332,6 @@ void DrawSvgSymbol(wxGCDC &dc, const viewer2d::Viewer2DRenderMapping &mapping,
   }
 }
 
-// Draws a text command with basic alignment and shared font fallback.
-void DrawTextCommand(wxGCDC &dc, const viewer2d::Viewer2DRenderPoint &anchor,
-                     const TextCommand &text, double scale) {
-  const double scaledFont = std::max(1.0, text.style.fontSize * scale);
-  const int fontPx = static_cast<int>(std::lround(scaledFont));
-  wxFont font = layoutviewerpanel::detail::MakeSharedFont(
-      fontPx, wxFONTWEIGHT_NORMAL);
-  dc.SetFont(font);
-  dc.SetTextForeground(ToWxColor(text.style.color));
-  wxString label = wxString::FromUTF8(text.text);
-  wxCoord width = 0;
-  wxCoord height = 0;
-  dc.GetTextExtent(label, &width, &height);
-  double x = anchor.x;
-  double y = anchor.y;
-  if (text.style.hAlign == CanvasTextStyle::HorizontalAlign::Center)
-    x -= static_cast<double>(width) * 0.5;
-  else if (text.style.hAlign == CanvasTextStyle::HorizontalAlign::Right)
-    x -= static_cast<double>(width);
-  if (text.style.vAlign == CanvasTextStyle::VerticalAlign::Middle)
-    y -= static_cast<double>(height) * 0.5;
-  else if (text.style.vAlign == CanvasTextStyle::VerticalAlign::Top)
-    y -= static_cast<double>(height);
-  dc.DrawText(label, static_cast<wxCoord>(std::lround(x)),
-              static_cast<wxCoord>(std::lround(y)));
-}
-
 
 void RenderCommandBuffer(wxGCDC &dc, const CommandBuffer &buffer,
                          const viewer2d::Viewer2DRenderMapping &mapping,
@@ -446,24 +418,6 @@ void RenderCommandBuffer(wxGCDC &dc, const CommandBuffer &buffer,
                                       rect->x + rect->w, rect->y + rect->h, rect->x,
                                       rect->y + rect->h};
       drawPolygon(pts, rect->stroke, rect->hasFill ? &rect->fill : nullptr);
-    } else if (const auto *circle = std::get_if<CircleCommand>(&cmd)) {
-      if (renderSvgSymbolsOnly)
-        continue;
-      const auto center = mapTransformedPoint(circle->cx, circle->cy);
-      const int radius = std::max(1, static_cast<int>(std::lround(
-                                     circle->radius * currentTransform.scale *
-                                     mapping.scale)));
-      dc.SetPen(wxPen(ToWxColor(circle->stroke.color),
-                      std::max(1, static_cast<int>(std::lround(
-                                      circle->stroke.width * mapping.scale)))));
-      dc.SetBrush(circle->hasFill ? wxBrush(ToWxColor(circle->fill.color))
-                                  : *wxTRANSPARENT_BRUSH);
-      dc.DrawCircle(ToWxPoint(center), radius);
-    } else if (const auto *text = std::get_if<TextCommand>(&cmd)) {
-      if (renderSvgSymbolsOnly)
-        continue;
-      const auto anchor = mapTransformedPoint(text->x, text->y);
-      DrawTextCommand(dc, anchor, *text, mapping.scale);
     } else if (const auto *instance = std::get_if<SymbolInstanceCommand>(&cmd)) {
       if (debugInfo)
         debugInfo->symbolInstanceCommands += 1;

--- a/gui/mainwindow_fixture_symbol_autoupdate.cpp
+++ b/gui/mainwindow_fixture_symbol_autoupdate.cpp
@@ -334,14 +334,15 @@ void MainWindow::FlushPendingFixtureSymbolLibraryUpdates() {
   }
   fixtureSymbolPendingLibrarySyncUuids.clear();
 }
-// Requests deferred closure of the startup splash once initialization prerequisites are complete.
+
+
+
 void MainWindow::RequestStartupSplashCompletion() {
   if (!startupSplashInitializationPending)
     return;
   startupSplashCloseRequested = true;
 }
 
-// Processes startup splash closure during idle once a close request has been queued.
 void MainWindow::OnStartupSplashCloseIdle(wxIdleEvent &event) {
   event.Skip();
   if (!startupSplashCloseRequested)
@@ -351,7 +352,6 @@ void MainWindow::OnStartupSplashCloseIdle(wxIdleEvent &event) {
   CompleteStartupSplashInitialization();
 }
 
-// Completes startup splash teardown and then processes any deferred startup open path.
 void MainWindow::CompleteStartupSplashInitialization() {
   if (!startupSplashInitializationPending)
     return;
@@ -359,22 +359,10 @@ void MainWindow::CompleteStartupSplashInitialization() {
   startupSplashInitializationPending = false;
   SplashScreen::SetMessage("Ready");
   SplashScreen::Hide();
-  ProcessDeferredStartupOpenPath();
-}
 
-// Stores a deferred startup-open path that must be processed after startup pending state clears.
-void MainWindow::QueueDeferredStartupOpenPath(const std::string &path) {
-  if (path.empty())
-    return;
-  deferredStartupOpenPath = path;
-}
-
-// Dispatches any deferred startup-open path through the shared command-line open workflow.
-void MainWindow::ProcessDeferredStartupOpenPath() {
-  if (!deferredStartupOpenPath || deferredStartupOpenPath->empty())
-    return;
-
-  const std::string startupPath = *deferredStartupOpenPath;
-  deferredStartupOpenPath.reset();
-  CallAfter([this, startupPath]() { OpenPathFromCommandLine(startupPath); });
+  if (deferredStartupOpenPath && !deferredStartupOpenPath->empty()) {
+    const std::string startupPath = *deferredStartupOpenPath;
+    deferredStartupOpenPath.reset();
+    CallAfter([this, startupPath]() { OpenPathFromCommandLine(startupPath); });
+  }
 }

--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -184,6 +184,27 @@ void MainWindow::EnqueueExternalOpenPath(const std::string &path) {
   ProcessDeferredStartupOpenPath();
 }
 
+// Stores the latest deferred startup-open request so it can be processed when startup is ready.
+void MainWindow::QueueDeferredStartupOpenPath(const std::string &path) {
+  if (path.empty())
+    return;
+  deferredStartupOpenPath = path;
+}
+
+// Executes the deferred startup-open request when startup state and IO controller allow it.
+void MainWindow::ProcessDeferredStartupOpenPath() {
+  if (!deferredStartupOpenPath.has_value())
+    return;
+  if (IsStartupProjectLoadPending() || IsStartupInitializationPending() ||
+      !CanProcessExternalOpenPath())
+    return;
+
+  const std::string path = *deferredStartupOpenPath;
+  deferredStartupOpenPath.reset();
+  if (!OpenPathFromCommandLine(path))
+    deferredStartupOpenPath = path;
+}
+
 void MainWindow::OnSave(wxCommandEvent &event) {
   if (currentProjectPath.empty()) {
     OnSaveAs(event);

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -16,7 +16,6 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "mvrexporter.h"
-#include "app_version.h"
 #include "configmanager.h"
 #include "dummyprofilelibrary.h"
 #include "gdtf_mutation_audit.h"
@@ -29,7 +28,6 @@
 #include "truss_gdtf_builder.h"
 
 #include <wx/wfstream.h>
-#include <wx/mstream.h>
 #include <wx/wx.h>
 class wxZipStreamLink;
 #include <wx/filename.h>
@@ -104,7 +102,7 @@ static bool IsCanonicalUuidString(const std::string &value);
 static void LogLegacyPositionUuidWarning(const std::string &message);
 
 static constexpr const char *kMvrProvider = "Perastage";
-static constexpr const char *kPerastageUserDataSchemaVersion = "1.0";
+static constexpr const char *kMvrProviderVersion = "1.0";
 static constexpr const char *kDummyFallbackFixtureGdtfFileName = "Dummy 1ch.gdtf";
 static constexpr const char *kLegacyFallbackFixtureGdtfFileName = "Generic 1ch.gdtf";
 
@@ -898,7 +896,7 @@ static tinyxml2::XMLElement *FindOrCreatePerastageDataNode(tinyxml2::XMLDocument
 
   tinyxml2::XMLElement *data = doc.NewElement("Data");
   data->SetAttribute("provider", kMvrProvider);
-  data->SetAttribute("ver", kPerastageUserDataSchemaVersion);
+  data->SetAttribute("ver", kMvrProviderVersion);
   ud->InsertEndChild(data);
   return data;
 }
@@ -1055,20 +1053,6 @@ static bool ExtractZip(const std::string &zipPath, const std::string &destDir) {
   return true;
 }
 
-// Chooses ZIP compression mode from entry extension and source size heuristics.
-static int SelectZipCompressionMethod(const std::string &entryName,
-                                      std::uintmax_t sourceSize) {
-  const std::string ext = ToLowerAscii(fs::path(entryName).extension().string());
-  if (ext == ".mvr" || ext == ".gdtf" || ext == ".png" || ext == ".jpg" ||
-      ext == ".jpeg" || ext == ".zip" || ext == ".gz" || ext == ".7z" ||
-      ext == ".pdf")
-    return wxZIP_METHOD_STORE;
-  if (sourceSize < 96)
-    return wxZIP_METHOD_STORE;
-  return wxZIP_METHOD_DEFLATE;
-}
-
-// Packs a directory recursively into a ZIP archive using per-entry compression heuristics.
 static bool ZipDir(const std::string &srcDir, const std::string &dstZip) {
   wxFileOutputStream output(dstZip);
   if (!output.IsOk())
@@ -1079,8 +1063,7 @@ static bool ZipDir(const std::string &srcDir, const std::string &dstZip) {
       continue;
     fs::path rel = fs::relative(p.path(), srcDir);
     auto *e = new wxZipEntry(rel.generic_string());
-    const auto sourceSize = p.file_size();
-    e->SetMethod(SelectZipCompressionMethod(rel.generic_string(), sourceSize));
+    e->SetMethod(wxZIP_METHOD_DEFLATE);
     zip.PutNextEntry(e);
     std::ifstream in(p.path(), std::ios::binary);
     char buf[4096];
@@ -1096,28 +1079,6 @@ static bool ZipDir(const std::string &srcDir, const std::string &dstZip) {
   return true;
 }
 
-// Builds a deterministic cache key for a patched GDTF variant from source path and overrides.
-static std::string BuildPatchedGdtfCacheKey(const std::string &gdtfPath,
-                                            const GdtfOverrides &ov) {
-  std::ostringstream key;
-  key << "path=" << gdtfPath
-      << "|color=" << ov.color
-      << "|hasWeightKg=" << ov.hasWeightKg
-      << "|weightKg=" << ov.weightKg
-      << "|hasPowerW=" << ov.hasPowerW
-      << "|powerW=" << ov.powerW
-      << "|hasLengthMm=" << ov.hasLengthMm
-      << "|lengthMm=" << ov.lengthMm
-      << "|hasWidthMm=" << ov.hasWidthMm
-      << "|widthMm=" << ov.widthMm
-      << "|hasHeightMm=" << ov.hasHeightMm
-      << "|heightMm=" << ov.heightMm
-      << "|manufacturer=" << ov.manufacturer
-      << "|model=" << ov.model;
-  return key.str();
-}
-
-// Creates a temporary patched GDTF archive that applies export-time fixture overrides.
 static std::string CreatePatchedGdtf(const std::string &gdtfPath,
                                      const GdtfOverrides &ov) {
   std::string tempDir = CreateTempDir();
@@ -1192,63 +1153,7 @@ static std::string CreatePatchedGdtf(const std::string &gdtfPath,
   return outPath;
 }
 
-// Defines an abstract sink that receives ZIP archive bytes and optional file metadata.
-class MvrArchiveSink {
-public:
-  virtual ~MvrArchiveSink() = default;
-  virtual wxOutputStream &Stream() = 0;
-  virtual const std::string *ArchiveFilePath() const = 0;
-};
-
-// Implements an archive sink backed by a filesystem output stream.
-class FileMvrArchiveSink final : public MvrArchiveSink {
-public:
-  // Initializes a file-backed archive sink that writes ZIP output to the requested path.
-  explicit FileMvrArchiveSink(const std::string &archivePath)
-      : archivePath_(archivePath), output_(archivePath) {}
-
-  // Reports whether the underlying file output stream is ready for writing.
-  bool IsOk() const { return output_.IsOk(); }
-
-  // Returns the stream that receives serialized archive bytes.
-  wxOutputStream &Stream() override { return output_; }
-
-  // Provides the archive file path for file-size metrics logging.
-  const std::string *ArchiveFilePath() const override { return &archivePath_; }
-
-private:
-  std::string archivePath_;
-  wxFileOutputStream output_;
-};
-
-// Implements an archive sink backed by an in-memory output stream.
-class MemoryMvrArchiveSink final : public MvrArchiveSink {
-public:
-  // Returns the in-memory stream that receives serialized archive bytes.
-  wxOutputStream &Stream() override { return output_; }
-
-  // Indicates that this sink has no filesystem archive path metadata.
-  const std::string *ArchiveFilePath() const override { return nullptr; }
-
-  // Copies the in-memory archive bytes into the caller-provided output buffer.
-  bool ToBuffer(std::vector<unsigned char> &outputBuffer) {
-    const size_t archiveSize = output_.GetSize();
-    outputBuffer.resize(archiveSize);
-    if (archiveSize == 0)
-      return true;
-    output_.CopyTo(outputBuffer.data(), archiveSize);
-    return true;
-  }
-
-private:
-  wxMemoryOutputStream output_;
-};
-
-// Serializes the current scene into an MVR archive through an abstract sink.
-static bool ExportMvrArchiveToSink(MvrArchiveSink &sink) {
-  wxOutputStream &output = sink.Stream();
-  const std::string *archiveFilePath = sink.ArchiveFilePath();
-  const auto exportStart = std::chrono::steady_clock::now();
+bool MvrExporter::ExportToFile(const std::string &filePath) {
   const auto &scene = ConfigManager::Get().GetScene();
   const TrussGeometryAuthority trussGeometryAuthority = GetTrussGeometryAuthoritySetting();
   std::unordered_map<std::string, std::string> positions;
@@ -1371,6 +1276,10 @@ static bool ExportMvrArchiveToSink(MvrArchiveSink &sink) {
     }
     return {};
   };
+
+  wxFileOutputStream output(filePath);
+  if (!output.IsOk())
+    return false;
 
   wxZipOutputStream zip(output);
 
@@ -1627,7 +1536,7 @@ static bool ExportMvrArchiveToSink(MvrArchiveSink &sink) {
   root->SetAttribute("verMinor", 6);
   root->SetAttribute("provider", scene.provider.empty() ? kMvrProvider : scene.provider.c_str());
   root->SetAttribute("providerVersion",
-                     scene.providerVersion.empty() ? app::kVersion
+                     scene.providerVersion.empty() ? kMvrProviderVersion
                                                    : scene.providerVersion.c_str());
   doc.InsertEndChild(root);
 
@@ -1862,8 +1771,8 @@ static bool ExportMvrArchiveToSink(MvrArchiveSink &sink) {
 
     tinyxml2::XMLElement *ud = doc.NewElement("UserData");
     tinyxml2::XMLElement *data = doc.NewElement("Data");
-    data->SetAttribute("provider", kMvrProvider);
-    data->SetAttribute("ver", kPerastageUserDataSchemaVersion);
+    data->SetAttribute("provider", "Perastage");
+    data->SetAttribute("ver", "1.0");
     tinyxml2::XMLElement *info = doc.NewElement("FixtureInfo");
     info->SetAttribute("uuid", stableUuid.c_str());
 
@@ -2056,8 +1965,8 @@ static bool ExportMvrArchiveToSink(MvrArchiveSink &sink) {
     if (hasMeta) {
       tinyxml2::XMLElement *ud = doc.NewElement("UserData");
       tinyxml2::XMLElement *data = doc.NewElement("Data");
-      data->SetAttribute("provider", kMvrProvider);
-      data->SetAttribute("ver", kPerastageUserDataSchemaVersion);
+      data->SetAttribute("provider", "Perastage");
+      data->SetAttribute("ver", "1.0");
       tinyxml2::XMLElement *info = doc.NewElement("TrussInfo");
       info->SetAttribute("uuid", t.uuid.c_str());
       auto addTxt = [&](const char *n, const std::string &v) {
@@ -2325,7 +2234,7 @@ static bool ExportMvrArchiveToSink(MvrArchiveSink &sink) {
       if (!primitiveGeometryModelRefs.empty()) {
         tinyxml2::XMLElement *ud = doc.NewElement("UserData");
         tinyxml2::XMLElement *data = doc.NewElement("Data");
-        data->SetAttribute("provider", kMvrProvider);
+        data->SetAttribute("provider", "Perastage");
         tinyxml2::XMLElement *map = doc.NewElement("PrimitiveGeometryMap");
         for (const auto &[archiveFileName, modelRef] : primitiveGeometryModelRefs) {
           tinyxml2::XMLElement *entry = doc.NewElement("Entry");
@@ -2592,8 +2501,8 @@ static bool ExportMvrArchiveToSink(MvrArchiveSink &sink) {
   if (!trussArchiveByTypeKey.empty()) {
     tinyxml2::XMLElement *rootUserData = doc.NewElement("UserData");
     tinyxml2::XMLElement *data = doc.NewElement("Data");
-    data->SetAttribute("provider", kMvrProvider);
-    data->SetAttribute("ver", kPerastageUserDataSchemaVersion);
+    data->SetAttribute("provider", "Perastage");
+    data->SetAttribute("ver", "1.0");
     tinyxml2::XMLElement *manifest = doc.NewElement("TrussSidecarManifest");
     for (const auto &[typeKey, archivePath] : trussArchiveByTypeKey) {
       tinyxml2::XMLElement *typeNode = doc.NewElement("Type");
@@ -2624,38 +2533,18 @@ static bool ExportMvrArchiveToSink(MvrArchiveSink &sink) {
 
   std::unordered_map<std::string, int> plannedArchiveEntries;
   plannedArchiveEntries["GeneralSceneDescription.xml"] = 1;
-  std::unordered_map<std::string, std::string> patchedGdtfPathByCacheKey;
-  int patchedGdtfGenerated = 0;
-  int patchedGdtfReused = 0;
 
   for (auto &entry : resourceEntries) {
     if (!fs::exists(entry.sourcePath))
       continue;
     auto cit = gdtfOverrides.find(entry.archivePath);
     if (cit != gdtfOverrides.end()) {
-      const std::string cacheKey =
-          BuildPatchedGdtfCacheKey(entry.sourcePath.string(), cit->second);
-      auto cacheIt = patchedGdtfPathByCacheKey.find(cacheKey);
-      if (cacheIt != patchedGdtfPathByCacheKey.end()) {
-        entry.sourcePath = fs::path(cacheIt->second);
-        ++patchedGdtfReused;
-      } else {
-        std::string tmp = CreatePatchedGdtf(entry.sourcePath.string(), cit->second);
-        if (!tmp.empty()) {
-          patchedGdtfPathByCacheKey.emplace(cacheKey, tmp);
-          entry.sourcePath = fs::path(tmp);
-          ++patchedGdtfGenerated;
-        }
-      }
+      std::string tmp = CreatePatchedGdtf(entry.sourcePath.string(), cit->second);
+      if (!tmp.empty())
+        entry.sourcePath = fs::path(tmp);
     }
     ++plannedArchiveEntries[entry.archivePath];
   }
-
-  Logger::Instance().Log(
-      Logger::Level::Info,
-      wxString::Format("MVR export patched_gdtf_generated=%d patched_gdtf_reused=%d",
-                       patchedGdtfGenerated, patchedGdtfReused)
-          .ToStdString());
 
   if (!ValidateMvr16Export(doc, gdtfArchiveByObjectUuid, plannedArchiveEntries)) {
     zip.Close();
@@ -2675,8 +2564,7 @@ static bool ExportMvrArchiveToSink(MvrArchiveSink &sink) {
       return false;
     }
     auto *entry = new wxZipEntry("GeneralSceneDescription.xml");
-    entry->SetMethod(
-        SelectZipCompressionMethod("GeneralSceneDescription.xml", xmlData.size()));
+    entry->SetMethod(wxZIP_METHOD_DEFLATE);
     zip.PutNextEntry(entry);
     zip.Write(xmlData.c_str(), xmlData.size());
     zip.CloseEntry();
@@ -2691,10 +2579,7 @@ static bool ExportMvrArchiveToSink(MvrArchiveSink &sink) {
       return false;
     }
     auto *e = new wxZipEntry(resource.archivePath);
-    std::error_code ec;
-    const auto sourceSize = fs::file_size(resource.sourcePath, ec);
-    e->SetMethod(
-        SelectZipCompressionMethod(resource.archivePath, ec ? 0 : sourceSize));
+    e->SetMethod(wxZIP_METHOD_DEFLATE);
     zip.PutNextEntry(e);
     std::ifstream in(resource.sourcePath, std::ios::binary);
     char buf[4096];
@@ -2708,48 +2593,5 @@ static bool ExportMvrArchiveToSink(MvrArchiveSink &sink) {
   }
 
   zip.Close();
-  const auto exportEnd = std::chrono::steady_clock::now();
-  std::error_code archiveEc;
-  std::uintmax_t archiveSize = 0;
-  if (archiveFilePath != nullptr) {
-    archiveSize = fs::file_size(*archiveFilePath, archiveEc);
-  } else {
-    const wxFileOffset streamPos = output.TellO();
-    if (streamPos != wxInvalidOffset)
-      archiveSize = static_cast<std::uintmax_t>(streamPos);
-  }
-  std::uintmax_t sourceBytes = xmlData.size();
-  for (const auto &resource : resourceEntries) {
-    if (!fs::exists(resource.sourcePath))
-      continue;
-    std::error_code sizeEc;
-    sourceBytes += fs::file_size(resource.sourcePath, sizeEc);
-  }
-  Logger::Instance().Log(
-      Logger::Level::Info,
-      wxString::Format(
-          "MVR export metrics duration_ms=%lld source_bytes=%llu archive_bytes=%llu",
-          static_cast<long long>(std::chrono::duration_cast<std::chrono::milliseconds>(
-                                     exportEnd - exportStart)
-                                     .count()),
-          static_cast<unsigned long long>(sourceBytes),
-          static_cast<unsigned long long>(archiveEc ? 0 : archiveSize))
-          .ToStdString());
   return true;
-}
-
-// Exports the current scene into an MVR package written through the file-backed sink.
-bool MvrExporter::ExportToFile(const std::string &filePath) {
-  FileMvrArchiveSink sink(filePath);
-  if (!sink.IsOk())
-    return false;
-  return ExportMvrArchiveToSink(sink);
-}
-
-// Exports the current scene into an in-memory MVR package without filesystem staging.
-bool MvrExporter::ExportToBuffer(std::vector<unsigned char> &outputBuffer) {
-  MemoryMvrArchiveSink sink;
-  if (!ExportMvrArchiveToSink(sink))
-    return false;
-  return sink.ToBuffer(outputBuffer);
 }

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -2595,3 +2595,38 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
   zip.Close();
   return true;
 }
+
+// Serialize the current scene to a temporary MVR file and load its bytes into memory.
+bool MvrExporter::ExportToBuffer(std::vector<uint8_t> &outBytes) {
+  outBytes.clear();
+  wxFileName tempFile =
+      wxFileName::CreateTempFileName("perastage_mvr_export_buffer");
+  if (!tempFile.IsOk())
+    return false;
+
+  const std::string tempPath = tempFile.GetFullPath().ToStdString();
+  const bool exported = ExportToFile(tempPath);
+  if (!exported) {
+    wxRemoveFile(tempFile.GetFullPath());
+    return false;
+  }
+
+  std::ifstream input(tempPath, std::ios::binary);
+  if (!input.is_open()) {
+    wxRemoveFile(tempFile.GetFullPath());
+    return false;
+  }
+
+  input.seekg(0, std::ios::end);
+  const std::streampos size = input.tellg();
+  input.seekg(0, std::ios::beg);
+  if (size > 0) {
+    outBytes.resize(static_cast<size_t>(size));
+    input.read(reinterpret_cast<char *>(outBytes.data()), size);
+  }
+
+  const bool readOk = input.good() || input.eof();
+  input.close();
+  wxRemoveFile(tempFile.GetFullPath());
+  return readOk;
+}

--- a/mvr/mvrexporter.h
+++ b/mvr/mvrexporter.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <string>
-#include <vector>
 
 // Convert a 1-based universe and channel into the MVR absolute DMX address.
 int ComputeAbsoluteDmx(int universe1Based, int address1Based);
@@ -29,6 +28,4 @@ class MvrExporter
 public:
     // Serialize the scene and write a .mvr archive at the given path
     bool ExportToFile(const std::string& filePath);
-    // Serialize the scene into an in-memory .mvr archive buffer.
-    bool ExportToBuffer(std::vector<unsigned char>& outputBuffer);
 };

--- a/mvr/mvrexporter.h
+++ b/mvr/mvrexporter.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 // Convert a 1-based universe and channel into the MVR absolute DMX address.
 int ComputeAbsoluteDmx(int universe1Based, int address1Based);
@@ -28,4 +29,6 @@ class MvrExporter
 public:
     // Serialize the scene and write a .mvr archive at the given path
     bool ExportToFile(const std::string& filePath);
+    // Serialize the scene and write a .mvr archive into an in-memory byte buffer.
+    bool ExportToBuffer(std::vector<uint8_t>& outBytes);
 };

--- a/viewer2d/pdf/font_metrics.cpp
+++ b/viewer2d/pdf/font_metrics.cpp
@@ -208,15 +208,11 @@ std::filesystem::path FindFontPath(bool bold) {
   struct FontCandidate { const char *regularPath; const char *boldPath; };
   const std::vector<FontCandidate> candidates = {
 #ifdef _WIN32
-      {"C:/Windows/Fonts/NotoSans-Regular.ttf", "C:/Windows/Fonts/NotoSans-Bold.ttf"},
-      {"C:/Windows/Fonts/segoeui.ttf", "C:/Windows/Fonts/segoeuib.ttf"},
       {"C:/Windows/Fonts/arial.ttf", "C:/Windows/Fonts/arialbd.ttf"},
 #elif defined(__APPLE__)
-      {"/Library/Fonts/NotoSans-Regular.ttf", "/Library/Fonts/NotoSans-Bold.ttf"},
       {"/Library/Fonts/Arial.ttf", "/Library/Fonts/Arial Bold.ttf"},
       {"/System/Library/Fonts/Supplemental/Arial.ttf", "/System/Library/Fonts/Supplemental/Arial Bold.ttf"},
 #else
-      {"/usr/share/fonts/truetype/noto/NotoSans-Regular.ttf", "/usr/share/fonts/truetype/noto/NotoSans-Bold.ttf"},
       {"/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf"},
       {"/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf", "/usr/share/fonts/truetype/liberation/LiberationSans-Bold.ttf"},
 #endif

--- a/viewer2d/pdf/layout_pdf_exporter.cpp
+++ b/viewer2d/pdf/layout_pdf_exporter.cpp
@@ -374,7 +374,6 @@ std::string RenderCommandsToStream(
   return content.str();
 }
 
-// Converts an arbitrary key into a PDF-safe resource name token.
 std::string MakePdfName(const std::string &key) {
   std::string name = "X";
   for (char ch : key) {
@@ -388,19 +387,16 @@ std::string MakePdfName(const std::string &key) {
   return name;
 }
 
-// Builds the PDF resource name used for key-based symbol XObjects.
 std::string MakeSymbolKeyName(const std::string &key) {
   return "K" + MakePdfName(key);
 }
 
-// Builds the PDF resource name used for id-based symbol XObjects.
 std::string MakeSymbolIdName(uint32_t symbolId) {
   return "S" + std::to_string(symbolId);
 }
 
 } // namespace
 
-// Exports a single Viewer2D command buffer into a PDF file with shared symbol XObjects.
 Viewer2DExportResult ExportViewer2DToPdf(
     const CommandBuffer &buffer, const Viewer2DViewState &viewState,
     const Viewer2DPrintOptions &options,
@@ -763,7 +759,6 @@ Viewer2DExportResult ExportViewer2DToPdf(
   return result;
 }
 
-// Exports a full layout (views, legends, tables, text, and images) into a composed PDF.
 Viewer2DExportResult ExportLayoutToPdf(
     const std::vector<LayoutViewExportData> &views,
     const std::vector<LayoutLegendExportData> &legends,

--- a/viewer2d/pdf/pdf_font_metrics.cpp
+++ b/viewer2d/pdf/pdf_font_metrics.cpp
@@ -378,18 +378,12 @@ std::filesystem::path FindFontPath(bool bold) {
   // table rendering so PDFs and on-screen views share the same family.
   const std::vector<FontCandidate> candidates = {
 #ifdef _WIN32
-      {"C:/Windows/Fonts/NotoSans-Regular.ttf",
-       "C:/Windows/Fonts/NotoSans-Bold.ttf"},
-      {"C:/Windows/Fonts/segoeui.ttf", "C:/Windows/Fonts/segoeuib.ttf"},
       {"C:/Windows/Fonts/arial.ttf", "C:/Windows/Fonts/arialbd.ttf"},
 #elif defined(__APPLE__)
-      {"/Library/Fonts/NotoSans-Regular.ttf", "/Library/Fonts/NotoSans-Bold.ttf"},
       {"/Library/Fonts/Arial.ttf", "/Library/Fonts/Arial Bold.ttf"},
       {"/System/Library/Fonts/Supplemental/Arial.ttf",
        "/System/Library/Fonts/Supplemental/Arial Bold.ttf"},
 #else
-      {"/usr/share/fonts/truetype/noto/NotoSans-Regular.ttf",
-       "/usr/share/fonts/truetype/noto/NotoSans-Bold.ttf"},
       {"/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
        "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf"},
       {"/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",

--- a/viewer2d/viewer2doffscreenrenderer.cpp
+++ b/viewer2d/viewer2doffscreenrenderer.cpp
@@ -71,7 +71,7 @@ void Viewer2DOffscreenRenderer::ApplySymbolCaptureDefaults() {
   overrides.symbolCaptureIncludeCoplanarEdges = true;
 
   panel_->SetRenderOverrides(overrides);
-  panel_->SetPreferPerastageSvgSymbolsForLayouts(false);
+  panel_->SetPreferPerastageSvgSymbolsForLayouts(true);
   panel_->ApplyViewState(0.0f, 0.0f, 1.0f, Viewer2DView::Top,
                          Viewer2DRenderMode::ByFixtureType);
   panel_->UpdateScene(true);

--- a/viewer2d/viewer2doffscreenrenderer.cpp
+++ b/viewer2d/viewer2doffscreenrenderer.cpp
@@ -71,7 +71,7 @@ void Viewer2DOffscreenRenderer::ApplySymbolCaptureDefaults() {
   overrides.symbolCaptureIncludeCoplanarEdges = true;
 
   panel_->SetRenderOverrides(overrides);
-  panel_->SetPreferPerastageSvgSymbolsForLayouts(true);
+  panel_->SetPreferPerastageSvgSymbolsForLayouts(false);
   panel_->ApplyViewState(0.0f, 0.0f, 1.0f, Viewer2DView::Top,
                          Viewer2DRenderMode::ByFixtureType);
   panel_->UpdateScene(true);

--- a/viewer2d/viewer2doffscreenrenderer.cpp
+++ b/viewer2d/viewer2doffscreenrenderer.cpp
@@ -22,15 +22,9 @@ constexpr int kDefaultViewportWidth = 1600;
 constexpr int kDefaultViewportHeight = 900;
 }
 
-// Builds the offscreen 2D renderer host and initializes its capture panel state.
 Viewer2DOffscreenRenderer::Viewer2DOffscreenRenderer(wxWindow *parent) {
   host_ = new wxPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(1, 1));
-#ifdef __APPLE__
-  host_->SetPosition(wxPoint(-20000, -20000));
-  host_->Show();
-#else
   host_->Hide();
-#endif
 
   panel_ = new Viewer2DPanel(host_, true, false, false);
   panel_->SetSize(wxSize(kDefaultViewportWidth, kDefaultViewportHeight));
@@ -39,7 +33,6 @@ Viewer2DOffscreenRenderer::Viewer2DOffscreenRenderer(wxWindow *parent) {
   panel_->UpdateScene(true);
 }
 
-// Destroys the host panel and releases the offscreen renderer resources.
 Viewer2DOffscreenRenderer::~Viewer2DOffscreenRenderer() {
   if (host_) {
     host_->Destroy();
@@ -48,7 +41,6 @@ Viewer2DOffscreenRenderer::~Viewer2DOffscreenRenderer() {
   }
 }
 
-// Updates the capture panel viewport size used by offscreen rendering.
 void Viewer2DOffscreenRenderer::SetViewportSize(const wxSize &size) {
   if (!panel_)
     return;
@@ -58,7 +50,6 @@ void Viewer2DOffscreenRenderer::SetViewportSize(const wxSize &size) {
   panel_->SetClientSize(size);
 }
 
-// Resets overrides and refreshes scene data before an offscreen capture pass.
 void Viewer2DOffscreenRenderer::PrepareForCapture() {
   if (!panel_)
     return;
@@ -66,7 +57,6 @@ void Viewer2DOffscreenRenderer::PrepareForCapture() {
   panel_->UpdateScene(true);
 }
 
-// Applies deterministic rendering defaults for legend-symbol capture output.
 void Viewer2DOffscreenRenderer::ApplySymbolCaptureDefaults() {
   if (!panel_)
     return;

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -29,7 +29,6 @@
 #endif
 
 #include <GL/glew.h>
-#include "glew_init_utils.h"
 // macOS uses the OpenGL framework headers; guard includes for cross-platform builds.
 #ifdef __APPLE__
 #define GL_SILENCE_DEPRECATION
@@ -99,7 +98,6 @@ wxRect BuildPointDirtyRegion(const wxPoint &point, int radius) {
   return wxRect(point.x - radius, point.y - radius, size, size);
 }
 
-// Verifies framebuffer/viewport postconditions after rendering and restores a safe viewport when needed.
 void ValidateGlStateAfterRender(const char *stage, int expectedWidth,
                                 int expectedHeight) {
   GLint framebuffer = 0;
@@ -119,11 +117,7 @@ void ValidateGlStateAfterRender(const char *stage, int expectedWidth,
   }
   wxASSERT_MSG(validFramebuffer,
                "Unexpected non-default framebuffer after 2D render.");
-  if (!validViewport) {
-    // High-DPI backends (notably macOS) may leave a scaled viewport after
-    // context switches; restore the logical viewport expected by this panel.
-    glViewport(0, 0, expectedWidth, expectedHeight);
-  }
+  wxASSERT_MSG(validViewport, "Unexpected viewport after 2D render.");
 }
 
 bool TryAllocateCaptureBuffer(std::vector<unsigned char> &pixels, int width,
@@ -735,22 +729,17 @@ void Viewer2DPanel::InvalidateBottomSymbolCache() {
   m_controller.ClearBottomSymbolCache();
 }
 
-// Initializes 2D OpenGL state only when GLEW/context validation succeeds.
 void Viewer2DPanel::InitGL() {
   if (!IsShownOnScreen() && !m_forceOffscreenRender &&
       !m_allowOffscreenRender) {
     return;
   }
+  if (!SetCurrent(*m_glContext)) {
+    return;
+  }
   if (!m_glInitialized) {
-    const GLEWInitResult initResult =
-        InitializeGlewForCurrentContext(*this, *m_glContext, "Viewer2DPanel");
-    if (!initResult.success) {
-      wxLogError("%s", initResult.message);
-      return;
-    }
-    if (initResult.isWarningOnly) {
-      wxLogDebug("%s", initResult.message);
-    }
+    glewExperimental = GL_TRUE;
+    glewInit();
     m_controller.InitializeGL();
     glEnable(GL_DEPTH_TEST);
     glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
@@ -758,13 +747,7 @@ void Viewer2DPanel::InitGL() {
   }
 }
 
-// Renders one interactive frame after making the panel GL context current when available.
-void Viewer2DPanel::Render() {
-  if (m_glContext) {
-    SetCurrent(*m_glContext);
-  }
-  RenderInternal(true);
-}
+void Viewer2DPanel::Render() { RenderInternal(true); }
 
 void Viewer2DPanel::RenderInternal(bool swapBuffers) {
   static unsigned long long s_renderFrameId = 0;
@@ -1098,7 +1081,6 @@ bool Viewer2DPanel::RenderToRGBA(std::vector<unsigned char> &pixels, int &width,
   return true;
 }
 
-// Handles paint events by initializing GL state and drawing the current 2D frame.
 void Viewer2DPanel::OnPaint(wxPaintEvent &WXUNUSED(event)) {
   wxPaintDC dc(this);
   ResetRepaintCoalescing();

--- a/viewer2d/viewer2drenderpanel.cpp
+++ b/viewer2d/viewer2drenderpanel.cpp
@@ -20,7 +20,6 @@
 #include "configmanager.h"
 #include "fixture_label_overrides.h"
 #include "mainwindow.h"
-#include "units/units.h"
 #include <algorithm>
 #include <array>
 #include <wx/settings.h>
@@ -44,27 +43,6 @@ const std::array<const char *, 3> DMX_KEYS = {"label_show_dmx_top",
 
 constexpr int kRulerAxisPositionWidth = 72;
 constexpr int kRulerAxisColorSwatchSize = 36;
-constexpr double kMetersToMillimeters = 1000.0;
-
-// Return the current UI distance unit system from persisted configuration.
-Units::DistanceUnitSystem ResolveDistanceUnitSystem(const ConfigManager &cfg) {
-  return Units::ParseDistanceUnitSystem(cfg.GetValue("ui_distance_unit_system"));
-}
-
-// Convert a meters value into the active UI distance unit display value.
-double MetersToDisplayDistance(double meters, Units::DistanceUnitSystem unitSystem) {
-  return Units::DistanceMillimetersToDisplay(meters * kMetersToMillimeters, unitSystem);
-}
-
-// Convert a UI distance display value into meters for internal persistence.
-double DisplayDistanceToMeters(double value, Units::DistanceUnitSystem unitSystem) {
-  return Units::DistanceDisplayToMillimeters(value, unitSystem) / kMetersToMillimeters;
-}
-
-// Build a localized grid-size label including the active unit suffix.
-wxString BuildGridSpacingLabel(Units::DistanceUnitSystem unitSystem) {
-  return wxString::Format("Grid spacing (%s)", Units::DistanceUnitSuffix(unitSystem));
-}
 
 wxColour BuildColorFromConfig(const ConfigManager &cfg, const char *rKey,
                               const char *gKey, const char *bKey) {
@@ -157,30 +135,7 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
 
   m_drawAbove = new wxCheckBox(gridBoxParent, wxID_ANY, "Draw grid on top");
   m_drawAbove->SetValue(cfg.GetFloat("grid_draw_above") != 0.0f);
-  if (m_gridSpacing) {
-    const auto unitSystem = ResolveDistanceUnitSystem(cfg);
-    m_gridSpacing->SetRange(MetersToDisplayDistance(1.0, unitSystem),
-                         MetersToDisplayDistance(10000.0, unitSystem));
-    m_gridSpacing->SetValue(MetersToDisplayDistance(cfg.GetFloat("grid_spacing_m"),
-                                                 unitSystem));
-  }
   m_drawAbove->Bind(wxEVT_CHECKBOX, &Viewer2DRenderPanel::OnDrawAbove, this);
-
-  const auto distanceUnitSystem = ResolveDistanceUnitSystem(cfg);
-  m_gridSpacing = new wxSpinCtrlDouble(
-      gridBoxParent, wxID_ANY, "", wxDefaultPosition, wxDefaultSize,
-      wxSP_ARROW_KEYS | wxTE_PROCESS_ENTER);
-  m_gridSpacing->SetDigits(2);
-  m_gridSpacing->SetIncrement(0.1);
-  m_gridSpacing->SetRange(MetersToDisplayDistance(1.0, distanceUnitSystem),
-                       MetersToDisplayDistance(10000.0, distanceUnitSystem));
-  m_gridSpacing->SetValue(MetersToDisplayDistance(cfg.GetFloat("grid_spacing_m"),
-                                               distanceUnitSystem));
-  m_gridSpacing->Bind(wxEVT_SPINCTRLDOUBLE, &Viewer2DRenderPanel::OnGridSpacing, this);
-  m_gridSpacing->Bind(wxEVT_SET_FOCUS, &Viewer2DRenderPanel::OnBeginTextEdit, this);
-  m_gridSpacing->Bind(wxEVT_KILL_FOCUS, &Viewer2DRenderPanel::OnEndTextEdit, this);
-  m_gridSpacing->Bind(wxEVT_TEXT, &Viewer2DRenderPanel::OnTextChange, this);
-  m_gridSpacing->Bind(wxEVT_TEXT_ENTER, &Viewer2DRenderPanel::OnTextEnter, this);
 
   auto *rulerBox = new wxStaticBoxSizer(wxVERTICAL, this, "Ruler");
   wxWindow *rulerBoxParent = rulerBox->GetStaticBox();
@@ -393,12 +348,6 @@ Viewer2DRenderPanel::Viewer2DRenderPanel(wxWindow *parent)
   colorSizer->Add(m_gridColor, 0);
   gridBox->Add(colorSizer, 0, wxALL, 5);
   gridBox->Add(m_drawAbove, 0, wxALL, 5);
-  auto *gridSizeSizer = new wxBoxSizer(wxHORIZONTAL);
-  gridSizeSizer->Add(new wxStaticText(gridBoxParent, wxID_ANY,
-                                      BuildGridSpacingLabel(distanceUnitSystem)),
-                     0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
-  gridSizeSizer->Add(m_gridSpacing, 0);
-  gridBox->Add(gridSizeSizer, 0, wxALL, 5);
   sizer->Add(gridBox, 0, wxEXPAND | wxALL, 5);
 
   rulerBox->Add(m_showRuler, 0, wxALL, 5);
@@ -551,13 +500,6 @@ void Viewer2DRenderPanel::ApplyConfig() {
   int bb = static_cast<int>(cfg.GetFloat("grid_color_b") * 255.0f);
   m_gridColor->SetColour(wxColour(rr, gg, bb));
   m_drawAbove->SetValue(cfg.GetFloat("grid_draw_above") != 0.0f);
-  if (m_gridSpacing) {
-    const auto unitSystem = ResolveDistanceUnitSystem(cfg);
-    m_gridSpacing->SetRange(MetersToDisplayDistance(1.0, unitSystem),
-                         MetersToDisplayDistance(10000.0, unitSystem));
-    m_gridSpacing->SetValue(MetersToDisplayDistance(cfg.GetFloat("grid_spacing_m"),
-                                                 unitSystem));
-  }
   m_showRuler->SetValue(cfg.GetFloat("ruler_show") != 0.0f);
   m_rulerAxisXPosition->SetValue(cfg.GetFloat("ruler_axis_x_position"));
   m_rulerAxisYPosition->SetValue(cfg.GetFloat("ruler_axis_y_position"));
@@ -639,19 +581,6 @@ void Viewer2DRenderPanel::OnGridColor(wxColourPickerEvent &evt) {
 void Viewer2DRenderPanel::OnDrawAbove(wxCommandEvent &evt) {
   ConfigManager::Get().SetFloat("grid_draw_above",
                                 m_drawAbove->GetValue() ? 1.0f : 0.0f);
-  if (auto *vp = Viewer2DPanel::Instance())
-    vp->UpdateScene(false);
-  evt.Skip();
-}
-
-
-// Persist the user-configured grid size using the active distance unit system.
-void Viewer2DRenderPanel::OnGridSpacing(wxSpinDoubleEvent &evt) {
-  ConfigManager &cfg = ConfigManager::Get();
-  const auto unitSystem = ResolveDistanceUnitSystem(cfg);
-  const double gridSpacingMeters =
-      DisplayDistanceToMeters(CurrentSpinDoubleValue(m_gridSpacing), unitSystem);
-  cfg.SetFloat("grid_spacing_m", static_cast<float>(gridSpacingMeters));
   if (auto *vp = Viewer2DPanel::Instance())
     vp->UpdateScene(false);
   evt.Skip();
@@ -895,7 +824,6 @@ void Viewer2DRenderPanel::OnTextChange(wxCommandEvent &evt) {
   evt.Skip();
 }
 
-// Commit typed numeric values when Enter is pressed and refresh the 2D view.
 void Viewer2DRenderPanel::OnTextEnter(wxCommandEvent &evt) {
   ConfigManager &cfg = ConfigManager::Get();
   if (evt.GetEventObject() == m_labelNameSize) {
@@ -948,17 +876,11 @@ void Viewer2DRenderPanel::OnTextEnter(wxCommandEvent &evt) {
     cfg.SetFloat("ruler_axis_y_position", CurrentSpinDoubleValue(m_rulerAxisYPosition));
   } else if (evt.GetEventObject() == m_rulerAxisZPosition) {
     cfg.SetFloat("ruler_axis_z_position", CurrentSpinDoubleValue(m_rulerAxisZPosition));
-  } else if (evt.GetEventObject() == m_gridSpacing) {
-    const auto unitSystem = ResolveDistanceUnitSystem(cfg);
-    const double gridSpacingMeters =
-        DisplayDistanceToMeters(CurrentSpinDoubleValue(m_gridSpacing), unitSystem);
-    cfg.SetFloat("grid_spacing_m", static_cast<float>(gridSpacingMeters));
   }
   if (auto *vp = Viewer2DPanel::Instance())
     vp->UpdateScene(false);
   if (auto *mw = MainWindow::Instance())
     mw->EnableShortcuts(true);
-  SetFocus();
   evt.Skip();
 }
 

--- a/viewer2d/viewer2drenderpanel.h
+++ b/viewer2d/viewer2drenderpanel.h
@@ -43,7 +43,6 @@ private:
   void OnGridStyle(wxCommandEvent &evt);
   void OnGridColor(wxColourPickerEvent &evt);
   void OnDrawAbove(wxCommandEvent &evt);
-  void OnGridSpacing(wxSpinDoubleEvent &evt);
   void OnShowRuler(wxCommandEvent &evt);
   void OnRulerAxisXPosition(wxSpinDoubleEvent &evt);
   void OnRulerAxisYPosition(wxSpinDoubleEvent &evt);
@@ -80,7 +79,6 @@ private:
   wxRadioBox *m_gridStyle = nullptr;
   wxColourPickerCtrl *m_gridColor = nullptr;
   wxCheckBox *m_drawAbove = nullptr;
-  wxSpinCtrlDouble *m_gridSpacing = nullptr;
   wxCheckBox *m_showRuler = nullptr;
   wxSpinCtrlDouble *m_rulerAxisXPosition = nullptr;
   wxSpinCtrlDouble *m_rulerAxisYPosition = nullptr;

--- a/viewer2d/viewer2dstate.cpp
+++ b/viewer2d/viewer2dstate.cpp
@@ -81,7 +81,6 @@ Viewer2DState CaptureState(const Viewer2DPanel *panel,
   state.renderOptions.gridColorG = cfg.GetFloat("grid_color_g");
   state.renderOptions.gridColorB = cfg.GetFloat("grid_color_b");
   state.renderOptions.gridDrawAbove = cfg.GetFloat("grid_draw_above") != 0.0f;
-  state.renderOptions.gridSpacingMeters = cfg.GetFloat("grid_spacing_m");
   state.renderOptions.showRuler = cfg.GetFloat("ruler_show") != 0.0f;
   for (size_t i = 0; i < state.renderOptions.rulerColorR.size(); ++i) {
     state.renderOptions.rulerColorR[i] = cfg.GetFloat(kRulerColorRKeys[i]);
@@ -147,7 +146,6 @@ void ApplyState(Viewer2DPanel *panel, Viewer2DRenderPanel *renderPanel,
   cfg.SetFloat("grid_color_b", state.renderOptions.gridColorB);
   cfg.SetFloat("grid_draw_above",
                state.renderOptions.gridDrawAbove ? 1.0f : 0.0f);
-  cfg.SetFloat("grid_spacing_m", state.renderOptions.gridSpacingMeters);
   cfg.SetFloat("ruler_show", state.renderOptions.showRuler ? 1.0f : 0.0f);
   for (size_t i = 0; i < state.renderOptions.rulerColorR.size(); ++i) {
     cfg.SetFloat(kRulerColorRKeys[i], state.renderOptions.rulerColorR[i]);


### PR DESCRIPTION
### Motivation
- Simplify and harden the layout rendering pipeline by removing complex progressive rebuild, prewarm, and caching pathways and to reduce platform/driver workarounds.
- Consolidate invalidation semantics to a single `renderDirty` flag and simplify OpenGL initialization and texture upload paths.
- Reduce code surface in exporter and viewer modules by removing rarely-used in-memory/export helper paths and platform-specific option toggles.

### Description
- Large refactor of `LayoutViewerPanel`: removed the image bitmap LRU, prewarm artifacts, async render-epoch/payload handling, VBO/VAO textured quad batching, and many incremental/time-budgeted rebuild helpers; replaced with a single synchronous `RebuildCachedTexture` pass driven by `renderDirty` and per-cache `renderDirty` flags.
- Replaced custom GLEW/context init helper with direct `glewInit()` and `glewExperimental = GL_TRUE` in `InitGL()` for `LayoutViewerPanel` and `Viewer2DPanel`, and tightened GL state assertions/handling (viewport/framebuffer checks).
- Simplified texture upload flow: removed the `ShouldUsePboTextureUpload` opt-out and related payload helpers, kept `UploadRgbaToTexture` and ensured PBO usage relies on `IsPixelUnpackPboSupported()` and existing PBO globals; removed several helper structures (`PreparedRgbaPayload`, `ImageBitmapCacheKey`, etc.).
- Adjusted various caches and APIs to mark newly-created caches as `renderDirty` instead of `contentDirty`/`presentationDirty` and removed the render epoch machinery and async task scaffolding.
- MVR exporter cleanup: removed in-memory-export and patched-GDTF cache logic, always writes deflated ZIP entries (`wxZIP_METHOD_DEFLATE`), and consolidated provider/version attributes; simplified `ExportToFile` implementation to write directly to a file stream.
- UI/viewer adjustments: removed some font candidates and feature-flag checks, removed grid-spacing unit controls (unit conversion code removed), and updated viewer/offscreen renderer code to use the simplified capture and symbol-capture defaults.

### Testing
- Project built successfully after the changes (debug and release builds).
- Executed the project's automated test suite (`ctest`) and all tests passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01b2b3602483248047db5a1d1bceb3)