### PR TITLE
Align PDF legend SVG loading with on-screen symbol lookup

### DIFF
--- a/viewer2d/pdf/layout_pdf_exporter.cpp
+++ b/viewer2d/pdf/layout_pdf_exporter.cpp
@@ -990,6 +990,16 @@ Viewer2DExportResult ExportLayoutToPdf(
     }
     return it->second ? &it->second.value() : nullptr;
   };
+  auto findLegendSvgForItem = [&](const std::string &itemKey,
+                                 const SymbolDefinition *definition,
+                                 SymbolViewKind viewKind)
+      -> const PerastageSvgSymbolData * {
+    if (const PerastageSvgSymbolData *svg = findLegendSvg(itemKey, viewKind))
+      return svg;
+    if (!definition)
+      return nullptr;
+    return findLegendSvg(definition->key.modelKey, viewKind);
+  };
   // Legend symbols rendered from local command buffers use meter-based
   // coordinates. Apply the same screen-match reduction used for layout/view
   // command buffers so visual stroke weight stays consistent.
@@ -1663,13 +1673,6 @@ Viewer2DExportResult ExportLayoutToPdf(
     for (const auto &item : legend.items) {
       if (item.symbolKey.empty())
         continue;
-      const PerastageSvgSymbolData *topSvg =
-          item.showBottomSymbol
-              ? findLegendSvg(item.symbolKey, SymbolViewKind::Bottom)
-              : nullptr;
-      const PerastageSvgSymbolData *frontSvg =
-          item.showFrontSymbol ? findLegendSvg(item.symbolKey, SymbolViewKind::Front)
-                               : nullptr;
       const SymbolDefinition *topSymbol =
           (item.showBottomSymbol && legendSymbolsForSizing)
               ? FindSymbolDefinitionPreferred(legendSymbolsForSizing, item.symbolKey,
@@ -1679,7 +1682,16 @@ Viewer2DExportResult ExportLayoutToPdf(
           (item.showFrontSymbol && legendSymbolsForSizing)
               ? FindSymbolDefinitionExact(legendSymbolsForSizing, item.symbolKey,
                                           SymbolViewKind::Front)
-          : nullptr;
+              : nullptr;
+      const PerastageSvgSymbolData *topSvg =
+          item.showBottomSymbol
+              ? findLegendSvgForItem(item.symbolKey, topSymbol, SymbolViewKind::Bottom)
+              : nullptr;
+      const PerastageSvgSymbolData *frontSvg =
+          item.showFrontSymbol
+              ? findLegendSvgForItem(item.symbolKey, frontSymbol,
+                                     SymbolViewKind::Front)
+              : nullptr;
       maxTopSymbolColumnWidth = std::max(
           maxTopSymbolColumnWidth,
           topSvg ? symbolDrawWidthSvg(topSvg) : symbolDrawWidth(topSymbol));
@@ -1709,12 +1721,6 @@ Viewer2DExportResult ExportLayoutToPdf(
         continue;
       const bool topVisible = item.showBottomSymbol;
       const bool frontVisible = item.showFrontSymbol;
-      const PerastageSvgSymbolData *topSvg =
-          topVisible ? findLegendSvg(item.symbolKey, SymbolViewKind::Bottom)
-                     : nullptr;
-      const PerastageSvgSymbolData *frontSvg =
-          frontVisible ? findLegendSvg(item.symbolKey, SymbolViewKind::Front)
-                       : nullptr;
       const SymbolDefinition *topSymbol = legendSymbolsForSizing
           ? FindSymbolDefinitionPreferred(legendSymbolsForSizing, item.symbolKey,
                                           SymbolViewKind::Bottom)
@@ -1723,6 +1729,15 @@ Viewer2DExportResult ExportLayoutToPdf(
           ? FindSymbolDefinitionExact(legendSymbolsForSizing, item.symbolKey,
                                       SymbolViewKind::Front)
           : nullptr;
+      const PerastageSvgSymbolData *topSvg =
+          topVisible
+              ? findLegendSvgForItem(item.symbolKey, topSymbol, SymbolViewKind::Bottom)
+              : nullptr;
+      const PerastageSvgSymbolData *frontSvg =
+          frontVisible
+              ? findLegendSvgForItem(item.symbolKey, frontSymbol,
+                                     SymbolViewKind::Front)
+              : nullptr;
       if ((topVisible && topSvg) || (frontVisible && frontSvg)) {
         hasSvgSymbols = true;
       }
@@ -1841,14 +1856,6 @@ Viewer2DExportResult ExportLayoutToPdf(
         const SymbolDefinitionSnapshot *legendSymbols =
             legend.symbolSnapshot ? legend.symbolSnapshot.get()
                                   : symbolSnapshot.get();
-        const PerastageSvgSymbolData *topSvg =
-            item.showBottomSymbol
-                ? findLegendSvg(item.symbolKey, SymbolViewKind::Bottom)
-                : nullptr;
-        const PerastageSvgSymbolData *frontSvg =
-            item.showFrontSymbol
-                ? findLegendSvg(item.symbolKey, SymbolViewKind::Front)
-                : nullptr;
         const SymbolDefinition *topSymbol =
             (item.showBottomSymbol && legendSymbols)
                 ? FindSymbolDefinitionPreferred(legendSymbols, item.symbolKey,
@@ -1858,6 +1865,16 @@ Viewer2DExportResult ExportLayoutToPdf(
             (item.showFrontSymbol && legendSymbols)
                 ? FindSymbolDefinitionExact(legendSymbols, item.symbolKey,
                                             SymbolViewKind::Front)
+                : nullptr;
+        const PerastageSvgSymbolData *topSvg =
+            item.showBottomSymbol
+                ? findLegendSvgForItem(item.symbolKey, topSymbol,
+                                       SymbolViewKind::Bottom)
+                : nullptr;
+        const PerastageSvgSymbolData *frontSvg =
+            item.showFrontSymbol
+                ? findLegendSvgForItem(item.symbolKey, frontSymbol,
+                                       SymbolViewKind::Front)
                 : nullptr;
 
         const double topDrawW =

--- a/viewer2d/pdf/layout_pdf_exporter.cpp
+++ b/viewer2d/pdf/layout_pdf_exporter.cpp
@@ -74,15 +74,11 @@ static bool ShouldTraceLabelOrder() {
 
 
 
+// Returns whether a legend symbol key is eligible for lazy GDTF SVG loading.
 bool ShouldLoadLegendSvgFromKey(const std::string &symbolKey) {
-  if (symbolKey.empty())
-    return false;
-
-  std::filesystem::path symbolPath(symbolKey);
-  std::string extension = symbolPath.extension().string();
-  std::transform(extension.begin(), extension.end(), extension.begin(),
-                 [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
-  return extension == ".gdtf";
+  // Keep PDF legend SVG lookup aligned with on-screen legend rendering, which
+  // accepts both absolute GDTF paths and model-key aliases cached in symbol snapshots.
+  return !symbolKey.empty();
 }
 std::array<double, 3> ResolveLegendSvgFillRgb(
     const std::optional<std::string> &hexColor) {


### PR DESCRIPTION
### Motivation
- PDF export was skipping Perastage SVG legend symbols when a legend item used a cached model-key alias (not an explicit `.gdtf` path), causing fixture symbols to be missing from exported PDFs; the on-screen legend pipeline accepts non-empty keys and succeeds in these cases.

### Description
- Change `ShouldLoadLegendSvgFromKey` in `viewer2d/pdf/layout_pdf_exporter.cpp` to return `!symbolKey.empty()` (remove the strict `.gdtf` extension gate) and add a one-line comment above the function to document its purpose, restoring parity with the on-screen legend symbol lookup.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01c3c51c188324827d5576eea77636)