### PR TITLE
Include <cstdint> in mvr/mvrexporter.h to fix Linux build (uint8_t)

### DIFF
--- a/mvr/mvrexporter.h
+++ b/mvr/mvrexporter.h
@@ -17,6 +17,7 @@
  */
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
### Motivation
- Fix a Linux/GCC compile error where `uint8_t` was not defined for the declaration of `ExportToBuffer(std::vector<uint8_t>&)` by making the dependency explicit in the header.

### Description
- Add `#include <cstdint>` to `mvr/mvrexporter.h` so `uint8_t` is always available for the `ExportToBuffer` declaration.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03213044448324a3703b65cf853cfc)