### PR TITLE
Deterministic handling of Perastage GDTF filenames and copy policy

### DIFF
--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -22,12 +22,14 @@
 #include "json.hpp"
 #include "projectutils.h"
 #include "startup_file_access_gate.h"
+#include <wx/wfstream.h>
+#include <wx/zipstrm.h>
+#include <tinyxml2.h>
 #include <algorithm>
 #include <cctype>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
-#include <regex>
 #include <vector>
 
 namespace fs = std::filesystem;
@@ -251,16 +253,73 @@ bool IsPerastageNamedGdtfFile(const std::filesystem::path &path) {
   return normalized == "perastage";
 }
 
-// Builds a canonical Perastage export filename using the GDTF naming convention.
+// Loads manufacturer and fixture type from a GDTF description.xml payload when available.
+bool TryReadGdtfIdentityFromDescription(const std::filesystem::path &sourcePath,
+                                        std::string &manufacturerOut,
+                                        std::string &fixtureTypeOut) {
+  manufacturerOut.clear();
+  fixtureTypeOut.clear();
+  wxFileInputStream input(wxString::FromUTF8(sourcePath.string()));
+  if (!input.IsOk())
+    return false;
+
+  wxZipInputStream zipInput(input);
+  std::unique_ptr<wxZipEntry> entry;
+  std::string descriptionXml;
+  while ((entry.reset(zipInput.GetNextEntry())), entry) {
+    if (entry->GetName().CmpNoCase("description.xml") != 0)
+      continue;
+    char buffer[4096];
+    while (true) {
+      zipInput.Read(buffer, sizeof(buffer));
+      const size_t count = zipInput.LastRead();
+      if (count == 0)
+        break;
+      descriptionXml.append(buffer, buffer + count);
+    }
+    break;
+  }
+  if (descriptionXml.empty())
+    return false;
+
+  tinyxml2::XMLDocument doc;
+  if (doc.Parse(descriptionXml.c_str(), descriptionXml.size()) != tinyxml2::XML_SUCCESS)
+    return false;
+
+  tinyxml2::XMLElement *root = doc.FirstChildElement("GDTF");
+  tinyxml2::XMLElement *fixtureType =
+      root ? root->FirstChildElement("FixtureType") : doc.FirstChildElement("FixtureType");
+  if (!fixtureType)
+    return false;
+
+  const char *manufacturer = fixtureType->Attribute("Manufacturer");
+  const char *fixtureName = fixtureType->Attribute("Name");
+  manufacturerOut = TrimAsciiWhitespace(manufacturer ? manufacturer : "");
+  fixtureTypeOut = TrimAsciiWhitespace(fixtureName ? fixtureName : "");
+  return !manufacturerOut.empty() || !fixtureTypeOut.empty();
+}
+
+// Builds a canonical Perastage export filename using parsed GDTF identity values.
 std::string BuildPerastageCanonicalGdtfFileName(const std::filesystem::path &sourcePath) {
-  std::string fixtureTypeName = sourcePath.stem().string();
+  std::string manufacturerName;
+  std::string fixtureTypeName;
+  TryReadGdtfIdentityFromDescription(sourcePath, manufacturerName, fixtureTypeName);
+
+  if (manufacturerName.empty())
+    manufacturerName = "Unknow";
+  if (fixtureTypeName.empty())
+    fixtureTypeName = sourcePath.stem().string();
+
+  std::replace(manufacturerName.begin(), manufacturerName.end(), '@', '_');
+  std::replace(manufacturerName.begin(), manufacturerName.end(), ' ', '_');
   std::replace(fixtureTypeName.begin(), fixtureTypeName.end(), '@', '_');
   std::replace(fixtureTypeName.begin(), fixtureTypeName.end(), ' ', '_');
+  manufacturerName = TrimAsciiWhitespace(manufacturerName);
   fixtureTypeName = TrimAsciiWhitespace(fixtureTypeName);
+  if (manufacturerName.empty())
+    manufacturerName = "Unknow";
   if (fixtureTypeName.empty())
-    fixtureTypeName = "Fixture";
-
-  const std::string manufacturerName = "Unknow";
+    fixtureTypeName = sourcePath.stem().string();
   return manufacturerName + "@" + fixtureTypeName + "@Perastage.gdtf";
 }
 

--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -27,6 +27,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <regex>
 #include <vector>
 
 namespace fs = std::filesystem;
@@ -234,6 +235,33 @@ std::string NormalizeTypeKey(const std::string &type) {
     normalized.push_back(static_cast<char>(std::toupper(ch)));
   }
   return normalized;
+}
+
+// Returns true when the filename optional-comment segment marks a Perastage-authored GDTF.
+bool IsPerastageNamedGdtfFile(const std::filesystem::path &path) {
+  const std::string stem = path.stem().string();
+  const size_t firstAt = stem.find('@');
+  if (firstAt == std::string::npos)
+    return false;
+  const size_t secondAt = stem.find('@', firstAt + 1);
+  if (secondAt == std::string::npos)
+    return false;
+  const std::string comment = stem.substr(secondAt + 1);
+  std::string normalized = NormalizeAsciiKey(comment);
+  return normalized == "perastage";
+}
+
+// Builds a canonical Perastage export filename using the GDTF naming convention.
+std::string BuildPerastageCanonicalGdtfFileName(const std::filesystem::path &sourcePath) {
+  std::string fixtureTypeName = sourcePath.stem().string();
+  std::replace(fixtureTypeName.begin(), fixtureTypeName.end(), '@', '_');
+  std::replace(fixtureTypeName.begin(), fixtureTypeName.end(), ' ', '_');
+  fixtureTypeName = TrimAsciiWhitespace(fixtureTypeName);
+  if (fixtureTypeName.empty())
+    fixtureTypeName = "Fixture";
+
+  const std::string manufacturerName = "Unknow";
+  return manufacturerName + "@" + fixtureTypeName + "@Perastage.gdtf";
 }
 
 std::optional<std::string>
@@ -809,6 +837,7 @@ std::optional<std::string> GetDefaultColorForFixture(
   return matchedColor;
 }
 
+// Updates a fixture dictionary entry and applies deterministic GDTF copy/overwrite rules.
 void Update(const std::string &type, const std::string &gdtfPath, const std::string &mode, const std::string &category) {
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
   const std::string normalizedType = NormalizeTypeKey(type);
@@ -823,9 +852,15 @@ void Update(const std::string &type, const std::string &gdtfPath, const std::str
   if (file.empty())
     return;
 
-  const fs::path dest = file.parent_path() / src.filename();
-  const auto copyResult = FileImportUtils::CopyWithConflictPolicy(
-      src, dest, FileImportUtils::ConflictPolicy::Rename);
+  const bool sourceIsPerastageNamed = IsPerastageNamedGdtfFile(src);
+  const fs::path defaultDest = file.parent_path() / src.filename();
+  const fs::path perastageDest =
+      file.parent_path() / BuildPerastageCanonicalGdtfFileName(src);
+  const fs::path dest = sourceIsPerastageNamed ? defaultDest : perastageDest;
+  const FileImportUtils::ConflictPolicy policy = sourceIsPerastageNamed
+                                                     ? FileImportUtils::ConflictPolicy::Overwrite
+                                                     : FileImportUtils::ConflictPolicy::Rename;
+  const auto copyResult = FileImportUtils::CopyWithConflictPolicy(src, dest, policy);
   if (!copyResult.success)
     return;
 


### PR DESCRIPTION
### Motivation

- Ensure Perastage-exported GDTF files are detected and handled with a deterministic filename and conflict policy to avoid accidental overwrites and preserve Perastage-author metadata.

### Description

- Add `IsPerastageNamedGdtfFile` to detect filename comment segments like `Manufacturer@Fixture@Perastage.gdtf` and include `<regex>` header. 
- Add `BuildPerastageCanonicalGdtfFileName` to construct a canonical Perastage export filename from a source path. 
- Update `Update` to choose destination filename and `FileImportUtils::ConflictPolicy` based on whether the source is Perastage-named: Perastage-named sources use the source filename and `Overwrite`, other sources are copied into a canonical Perastage filename and use `Rename` to avoid collisions. 
- Add a short function comment describing the updated behavior in `Update`.

### Testing

- Ran the project automated test suite with `ctest` and the existing unit tests; all tests passed. 
- No new automated tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04634d9c7c8324b1494f28a6c823d5)