### PR TITLE
Avoid unnecessary Data View model-file updates on cancel/unchanged edits

### DIFF
--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -530,6 +530,7 @@ void FixtureTablePanel::ReloadData() {
   table->Thaw();
 }
 
+// Handles context-menu editing actions and only applies scene updates when data actually changes.
 void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
   wxDataViewItem item = event.GetItem();
   int col = event.GetColumn();
@@ -551,6 +552,7 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
 
   // Model file column opens file dialog
   if (col == 9) {
+    bool changed = false;
     wxString fixDir =
         wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("fixtures"));
     wxFileDialog fdlg(this, "Select GDTF file", fixDir, wxEmptyString, "*.gdtf",
@@ -585,6 +587,18 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
         if ((size_t)r >= gdtfPaths.size())
           gdtfPaths.resize(table->GetItemCount());
 
+        wxVariant existingModelFile;
+        table->GetValue(existingModelFile, r, 9);
+        wxVariant existingTypeName;
+        table->GetValue(existingTypeName, r, 2);
+
+        const bool rowChanged =
+            gdtfPaths[static_cast<size_t>(r)] != path ||
+            existingModelFile.GetString() != fileName ||
+            existingTypeName.GetString() != typeName;
+        if (!rowChanged)
+          continue;
+
         SetGdtfPathForRow(static_cast<unsigned int>(r), path);
         table->SetValue(wxVariant(fileName), r, 9);
         table->SetValue(wxVariant(typeName), r, 2);
@@ -595,6 +609,7 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
         table->SetValue(wxVariant(wstr), r, 17);
         if (dictColor && !dictColor->color.empty())
           SetFixtureColorCell(table, r, dictColor->color);
+        changed = true;
       }
 
       for (unsigned int i = 0; i < table->GetItemCount(); ++i) {
@@ -607,6 +622,17 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
         if ((size_t)i >= gdtfPaths.size())
           gdtfPaths.resize(table->GetItemCount());
 
+        wxVariant existingModelFile;
+        table->GetValue(existingModelFile, i, 9);
+        wxVariant existingTypeName;
+        table->GetValue(existingTypeName, i, 2);
+
+        const bool rowChanged = gdtfPaths[static_cast<size_t>(i)] != path ||
+                                existingModelFile.GetString() != fileName ||
+                                existingTypeName.GetString() != typeName;
+        if (!rowChanged)
+          continue;
+
         SetGdtfPathForRow(i, path);
         table->SetValue(wxVariant(fileName), i, 9);
         table->SetValue(wxVariant(typeName), i, 2);
@@ -617,6 +643,7 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
         table->SetValue(wxVariant(wstr), i, 17);
         if (dictColor && !dictColor->color.empty())
           SetFixtureColorCell(table, i, dictColor->color);
+        changed = true;
       }
 
       PropagateTypeValues(selections, 16);
@@ -627,16 +654,20 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
         if (auto entry = GdtfDictionary::Get(prevTypes[0]))
           dictMode = wxString::FromUTF8(entry->mode);
       }
-      ApplyModeForGdtf(path, dictMode);
+      if (changed)
+        ApplyModeForGdtf(path, dictMode);
 
       // Keep dictionary default modes immutable from project table edits.
       for (size_t idx = 0; idx < selections.size(); ++idx) {
         int r = table->ItemToRow(selections[idx]);
         if (r == wxNOT_FOUND)
           continue;
-        GdtfDictionary::Update(prevTypes[idx], pathUtf8);
+        if (changed)
+          GdtfDictionary::Update(prevTypes[idx], pathUtf8);
       }
     }
+    if (!changed)
+      return;
     ResyncRows(oldOrder, selectedUuids);
     const auto updateType = CombineUpdateTypes(
         UpdateTypeForColumn(9), UpdateTypeForColumn(16));

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -344,6 +344,7 @@ void SceneObjectTablePanel::ReloadData()
         SummaryPanel::Instance()->ShowSceneObjectSummary();
 }
 
+// Handles context-menu edits and updates scene/rendering only when an actual table value changes.
 void SceneObjectTablePanel::OnContextMenu(wxDataViewEvent& event)
 {
     wxDataViewItem item = event.GetItem();
@@ -422,17 +423,28 @@ void SceneObjectTablePanel::OnContextMenu(wxDataViewEvent& event)
 
         wxString selectedPath = fdlg.GetPath();
         wxString displayName = wxFileName(selectedPath).GetFullName();
+        bool changed = false;
         for (const auto& itSel : selections)
         {
             int r = table->ItemToRow(itSel);
             if (r == wxNOT_FOUND)
                 continue;
-            table->SetValue(wxVariant(displayName), r, col);
             if (static_cast<size_t>(r) >= modelPaths.size())
                 modelPaths.resize(table->GetItemCount());
+            const wxString previousPath = modelPaths[static_cast<size_t>(r)];
+            wxVariant existingDisplayName;
+            table->GetValue(existingDisplayName, r, col);
+            if (existingDisplayName.GetString() != displayName) {
+                table->SetValue(wxVariant(displayName), r, col);
+                changed = true;
+            }
             SetModelPathForRow(static_cast<unsigned int>(r), selectedPath);
+            if (previousPath != selectedPath)
+                changed = true;
         }
 
+        if (!changed)
+            return;
         ResyncRows(oldOrder, selectedUuids);
         UpdateSceneData();
         if (Viewer3DPanel::Instance()) {

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -362,6 +362,7 @@ void TrussTablePanel::ReloadData()
         SummaryPanel::Instance()->ShowTrussSummary();
 }
 
+// Handles context-menu editing workflows and avoids expensive refreshes when no row values change.
 void TrussTablePanel::OnContextMenu(wxDataViewEvent& event)
 {
     wxDataViewItem item = event.GetItem();
@@ -438,6 +439,7 @@ void TrussTablePanel::OnContextMenu(wxDataViewEvent& event)
                           wxFD_OPEN | wxFD_FILE_MUST_EXIST);
         if (fdlg.ShowModal() == wxID_OK)
         {
+            bool changed = false;
             wxString selPath = fdlg.GetPath();
             std::string archivePath(selPath.ToUTF8());
             std::string geomPath = archivePath;
@@ -483,10 +485,24 @@ void TrussTablePanel::OnContextMenu(wxDataViewEvent& event)
                 int r = table->ItemToRow(itSel);
                 if (r == wxNOT_FOUND)
                     continue;
+                const wxString archivePathWx = wxString::FromUTF8(archivePath);
+                const wxString geomPathWx = wxString::FromUTF8(geomPath);
+                const bool pathChanged =
+                    static_cast<size_t>(r) >= modelPaths.size() ||
+                    static_cast<size_t>(r) >= symbolPaths.size() ||
+                    modelPaths[static_cast<size_t>(r)] != archivePathWx ||
+                    symbolPaths[static_cast<size_t>(r)] != geomPathWx;
+
                 SetModelPathsForRow(static_cast<unsigned int>(r),
-                                    wxString::FromUTF8(archivePath),
-                                    wxString::FromUTF8(geomPath));
-                table->SetValue(wxVariant(fileName), r, 2);
+                                    archivePathWx, geomPathWx);
+                wxVariant existingModelFile;
+                table->GetValue(existingModelFile, r, 2);
+                if (existingModelFile.GetString() != fileName)
+                {
+                    table->SetValue(wxVariant(fileName), r, 2);
+                    changed = true;
+                }
+                changed = changed || pathChanged;
                 if (parsedOk)
                 {
                     table->SetValue(wxVariant(manuf), r, 10);
@@ -519,8 +535,11 @@ void TrussTablePanel::OnContextMenu(wxDataViewEvent& event)
                         table->SetValue(wxVariant(heiStr), i, 14);
                         table->SetValue(wxVariant(weightStr), i, 15);
                     }
+                    changed = true;
                 }
             }
+            if (!changed)
+                return;
             TrussDictionary::Update(modelKey, archivePath);
             ResyncRows(oldOrder, selectedUuids);
             UpdateSceneData();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -148,7 +148,8 @@ add_executable(gdtf_dictionary_color_roundtrip_test
 target_include_directories(gdtf_dictionary_color_roundtrip_test PRIVATE
                            . ../core ../third_party)
 target_link_libraries(gdtf_dictionary_color_roundtrip_test PRIVATE
-                      ${wxWidgets_LIBRARIES})
+                      ${wxWidgets_LIBRARIES}
+                      tinyxml2::tinyxml2)
 add_test(NAME GdtfDictionaryColorRoundtrip COMMAND gdtf_dictionary_color_roundtrip_test)
 
 add_executable(gdtf_dictionary_color_mode_propagation_test
@@ -168,7 +169,8 @@ add_executable(gdtf_dictionary_color_mode_propagation_test
 target_include_directories(gdtf_dictionary_color_mode_propagation_test PRIVATE
                            . ../core ../third_party)
 target_link_libraries(gdtf_dictionary_color_mode_propagation_test PRIVATE
-                      ${wxWidgets_LIBRARIES})
+                      ${wxWidgets_LIBRARIES}
+                      tinyxml2::tinyxml2)
 add_test(NAME GdtfDictionaryColorModePropagation
          COMMAND gdtf_dictionary_color_mode_propagation_test)
 


### PR DESCRIPTION
### Motivation
- Users reported that opening the Model File dialog and cancelling (or reselecting the same file) still triggered expensive scene/update work; the intent is to avoid those unnecessary refreshes in Data Views.
- The change targets the places where file-selection dialogs for model files can cause full resyncs and viewer refreshes even when no table value actually changed.

### Description
- Added change-detection guards in `FixtureTablePanel::OnContextMenu` (Model file column) so `ApplyModeForGdtf`, `GdtfDictionary::Update`, `ResyncRows`, `UpdateSceneData`, and viewer refreshes run only when a row value truly changed.
- Added equivalent `changed` checks in `TrussTablePanel::OnContextMenu` (Model File column) to avoid `TrussDictionary::Update`, `ResyncRows`, and `UpdateSceneData` when nothing was modified, and improved path-change detection for model/symbol paths.
- Added equivalent `changed` checks in `SceneObjectTablePanel::OnContextMenu` (Model File column) to avoid `ResyncRows`/`UpdateSceneData` when the selected file/display name is unchanged.
- Inserted concise one-line English comments above each touched context-menu handler to describe their purpose without changing behavior when actual edits are made.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a046cbf227c8324bdb23e79f2c8044c)