### PR TITLE
Update Windows installer workflow wording to reference root VERSION

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -126,11 +126,11 @@ jobs:
         run: |
           New-Item -ItemType Directory -Path "$env:GITHUB_WORKSPACE\out\installer" -Force | Out-Null
 
-          # Extract version from CMakeLists.txt via the helper cmake script
+          # Extract version from the repository root VERSION file via the helper CMake script
           $versionRaw = cmake -P "$env:GITHUB_WORKSPACE\packaging\windows\get_project_version.cmake" 2>&1
           $version = ($versionRaw | Select-String -Pattern '(\d+\.\d+\.\d+)').Matches[0].Groups[1].Value
           if ([string]::IsNullOrWhiteSpace($version)) {
-            throw "Could not determine PROJECT_VERSION from CMakeLists.txt"
+            throw "Could not determine Perastage version from VERSION"
           }
           Write-Host "Using installer version: $version"
           ISCC "/DMyAppVersion=$version" "$env:GITHUB_WORKSPACE\packaging\windows\Perastage.iss"


### PR DESCRIPTION
### Motivation
- Replace outdated comments and error messaging in the Windows installer workflow so the wording reflects that the version is sourced from the repository root `VERSION` file via the existing helper CMake script.

### Description
- In `.github/workflows/windows-installer.yml` replaced `# Extract version from CMakeLists.txt via the helper cmake script` with `# Extract version from the repository root VERSION file via the helper CMake script` and replaced the error text `Could not determine PROJECT_VERSION from CMakeLists.txt` with `Could not determine Perastage version from VERSION`.
- Behavior was not changed: the workflow still invokes `packaging/windows/get_project_version.cmake` and still passes the resolved version into the installer with `ISCC "/DMyAppVersion=$version"`.
- No source code function definitions were modified in this change, so no one-line function comments were added.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a047dc08aa88324a2d561b91d51b69c)