### PR TITLE
ci: automate main PATCH bump and dispatch installer test builds

### DIFF
--- a/.github/workflows/linux-installer.yml
+++ b/.github/workflows/linux-installer.yml
@@ -141,9 +141,9 @@ jobs:
           APPDIR="Perastage.AppDir"
           STAGE_DIR="out/install/Release"
 
-          VERSION="$(sed -nE 's/^project\(Perastage VERSION ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' CMakeLists.txt | head -n1)"
-          if [ -z "$VERSION" ]; then
-            echo "Failed to extract project version from CMakeLists.txt"
+          VERSION="$(tr -d '[:space:]' < VERSION)"
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "VERSION must be MAJOR.MINOR.PATCH, got: '$VERSION'"
             exit 1
           fi
 
@@ -210,6 +210,7 @@ jobs:
             cp -L "$LIB_PATH" "$APPDIR/usr/lib/$LIB_NAME"
           done
 
+          # Download a file and fail if it appears empty or unexpectedly small.
           download_checked() {
             local url="$1"
             local output="$2"

--- a/.github/workflows/main-patch-test-build.yml
+++ b/.github/workflows/main-patch-test-build.yml
@@ -1,0 +1,78 @@
+# Main branch patch version bump and test installer dispatch workflow.
+
+name: Main Patch Version and Test Installer Builds
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  actions: write
+
+concurrency:
+  group: main-patch-version-bump
+  cancel-in-progress: false
+
+jobs:
+  bump-and-dispatch:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.ref == 'refs/heads/main' &&
+        github.actor != 'github-actions[bot]' &&
+        !contains(github.event.head_commit.message, '[skip version-bump]')
+      )
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Bump patch version in VERSION
+        id: bump
+        run: |
+          set -euo pipefail
+
+          VERSION_RAW="$(tr -d '[:space:]' < VERSION)"
+          if ! [[ "$VERSION_RAW" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "VERSION must be MAJOR.MINOR.PATCH, got: '$VERSION_RAW'"
+            exit 1
+          fi
+
+          IFS='.' read -r major minor patch <<< "$VERSION_RAW"
+          next_patch=$((patch + 1))
+          NEW_VERSION="${major}.${minor}.${next_patch}"
+
+          printf '%s\n' "$NEW_VERSION" > VERSION
+
+          echo "previous_version=$VERSION_RAW" >> "$GITHUB_OUTPUT"
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push VERSION bump
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.new_version }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add VERSION
+          git commit -m "chore: bump patch version to ${NEW_VERSION} [skip version-bump]"
+          git push origin HEAD:main
+
+      - name: Dispatch installer workflows
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          gh workflow run windows-installer.yml --ref main
+          gh workflow run linux-installer.yml --ref main
+          gh workflow run macos-installer.yml --ref main

--- a/docs/versioning-policy.md
+++ b/docs/versioning-policy.md
@@ -93,10 +93,22 @@ Suggested labels:
 - `ci`
 - `internal`
 
-## Recommended Future Automation
+## Main Branch PATCH Automation
 
-A future workflow may increment PATCH automatically after successful merges to `main` and upload test installers as workflow artifacts.
+PATCH is automatically incremented after normal updates to `main` by the `Main Patch Version and Test Installer Builds` workflow.
 
-A future manual workflow may increment MINOR, reset PATCH to `0`, build installers for Windows/Linux/macOS, create a tag, create a GitHub Release, generate release notes, and upload installers.
+The workflow validates `VERSION` using `MAJOR.MINOR.PATCH`, increments only PATCH, and commits the result back to `main`.
 
-A future manual MAJOR workflow may increment MAJOR, reset MINOR and PATCH to `0`, and create a draft release for manual review.
+The automated commit message includes `[skip version-bump]`, and the workflow skips commits that include this marker to prevent bump loops.
+
+The same workflow dispatches these existing installer workflows on `main` for test artifacts:
+
+- `windows-installer.yml`
+- `linux-installer.yml`
+- `macos-installer.yml`
+
+This automation does not create Git tags and does not create GitHub Releases.
+
+## Future Official Release Automation
+
+Official releases should continue to use a separate manual release workflow that increments MINOR or MAJOR as needed, creates an official tag, and creates a GitHub Release.


### PR DESCRIPTION
### Motivation

- Ensure main branch receives an automated, safe PATCH increment for continuous test builds without creating tags or releases.  
- Run existing installer build workflows against the new main snapshot to produce test artifacts for verification.  
- Prevent infinite workflow loops by making the bump commit self-skipping and refusing to run for automated bot pushes.

### Description

- Add `.github/workflows/main-patch-test-build.yml` which triggers on `push` to `main` (and `workflow_dispatch`), validates `VERSION`, increments only the PATCH field, writes the new `VERSION` back to the repo, and dispatches the three installer workflows on `main` using `gh workflow run`.  
- Implement loop-prevention guards in the new workflow by skipping push-triggered runs when `github.actor` is `github-actions[bot]` or when the head commit message contains the skip marker `[skip version-bump]`, and use a concurrency group to avoid racing bumps.  
- Update `.github/workflows/linux-installer.yml` to read and validate the root `VERSION` file (MAJOR.MINOR.PATCH) instead of parsing `CMakeLists.txt`, and add a one-line English comment above the `download_checked` function.  
- Update `docs/versioning-policy.md` with a new section documenting the automated PATCH bump behavior, the `[skip version-bump]` marker, that installer workflows are dispatched for test artifacts, and that tags/releases remain manual official-release steps.

### Testing

- Ran `tests/check_perastage_tree_modules.sh`, which succeeded.  
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a047efdb3e48324a8ecf4186a119d35)