### PR TITLE
Fix Layout 2D cached capture to use physical framebuffer viewport size

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -2051,6 +2051,7 @@ bool LayoutViewerPanel::InitGL() {
   return true;
 }
 
+// Rebuilds cached layout textures by capturing each dirty view using framebuffer-accurate viewport dimensions.
 void LayoutViewerPanel::RebuildCachedTexture() {
   try {
     if (!NeedsRenderRebuild())
@@ -2144,13 +2145,20 @@ void LayoutViewerPanel::RebuildCachedTexture() {
   
       offscreenRenderer->SetViewportSize(renderSize);
       offscreenRenderer->PrepareForCapture();
+      const RenderSize physicalRenderSize = ResolveRenderSize(capturePanel);
+      const int physicalWidth = physicalRenderSize.IsValid()
+                                    ? physicalRenderSize.width
+                                    : renderSize.GetWidth();
+      const int physicalHeight = physicalRenderSize.IsValid()
+                                     ? physicalRenderSize.height
+                                     : renderSize.GetHeight();
 
       viewer2d::Viewer2DState renderState = cache.renderState;
       if (renderZoom != 1.0) {
         renderState.camera.zoom *= static_cast<float>(renderZoom);
       }
-      renderState.camera.viewportWidth = renderSize.GetWidth();
-      renderState.camera.viewportHeight = renderSize.GetHeight();
+      renderState.camera.viewportWidth = physicalWidth;
+      renderState.camera.viewportHeight = physicalHeight;
 
       auto stateGuard = std::make_shared<viewer2d::ScopedViewer2DState>(
           capturePanel, nullptr, cfg, renderState, nullptr, nullptr, false);


### PR DESCRIPTION
### Motivation
- The layout offscreen capture mixed logical (DIP) sizes with physical framebuffer pixels, causing `ComputeViewBounds` to compute a too-small world region and visually clip 2D view contents at zoom-in on Linux/HiDPI.
- The issue manifested as cropped content in layout 2D view textures when `GetContentScaleFactor()` differed from 1.0 or when logical vs physical sizes diverged.

### Description
- After calling `offscreenRenderer->SetViewportSize(renderSize)` the code now calls `ResolveRenderSize(capturePanel)` and uses that physical framebuffer size for `renderState.camera.viewportWidth` and `viewportHeight` so the camera viewport matches the actual capture dimensions.
- Kept existing logical zoom behavior intact by preserving `renderState.camera.zoom *= static_cast<float>(renderZoom)` and only changing the viewport size source.
- Added a concise one-line English comment above `LayoutViewerPanel::RebuildCachedTexture` describing the function purpose.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which completed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04bcd748b88324a750f4733abfa207)