### PR TITLE
Guard Viewer3DPanel::UpdateScene to avoid GL SetCurrent assertion on Linux

### DIFF
--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -2316,7 +2316,7 @@ void Viewer3DPanel::OnMouseLeave(wxMouseEvent& event)
     event.Skip();
 }
 
-// Updates the controller with current scene data
+// Updates scene resources only when the 3D canvas is fully shown and its GL context can be safely activated.
 void Viewer3DPanel::UpdateScene()
 {
     ++m_sceneRevision;
@@ -2324,10 +2324,11 @@ void Viewer3DPanel::UpdateScene()
 
     if (ShouldPauseHeavyTasks() || m_cameraMoving)
         return;
-    if (!IsShown())
+    if (!IsShownOnScreen())
         return;
 
-    SetCurrent(*m_glContext);
+    if (!SetCurrent(*m_glContext))
+        return;
     if (m_controller.ConsumeResourceSyncPending())
         m_controller.UpdateResourcesIfDirty();
     if (Viewer2DPanel::Instance())


### PR DESCRIPTION
### Motivation
- Prevent a wxGLContext `SetCurrent()` assertion during early Linux startup when the 3D canvas may not yet have a shown native window (xid). 

### Description
- Replace `IsShown()` with `IsShownOnScreen()`, add a defensive `if (!SetCurrent(*m_glContext)) return;` before doing GL work, and add a one-line comment above `Viewer3DPanel::UpdateScene()` describing its purpose. 

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05affbd6148324876b949b66ed51fc)