### PR TITLE
Replace truss FixtureTypeID popup with logger-only output

### DIFF
--- a/core/truss_gdtf_builder.cpp
+++ b/core/truss_gdtf_builder.cpp
@@ -18,6 +18,7 @@
 #include "truss_gdtf_builder.h"
 
 #include "json.hpp"
+#include "logger.h"
 
 #include <tinyxml2.h>
 #include <wx/filename.h>
@@ -246,6 +247,7 @@ static bool ReadLegacyGtruss(const fs::path &gtrussPath, TrussSourceData &out,
   return true;
 }
 
+// Builds a deterministic fixture type UUID for generated truss GDTF data and logs the generated mapping.
 static std::string BuildStableFixtureTypeId(const TrussSourceData &data) {
   std::ostringstream seed;
   seed << "perastage-truss-type:v2|" << data.typeKey << '|'
@@ -258,8 +260,10 @@ static std::string BuildStableFixtureTypeId(const TrussSourceData &data) {
        << std::fixed << std::setprecision(3) << data.heightMm << '|'
        << std::fixed << std::setprecision(3) << data.weightKg;
   const std::string fixtureTypeId = BuildDeterministicUuid(seed.str());
-  wxLogMessage("Truss GDTF FixtureTypeID generated typeKey='%s' fixtureTypeId='%s'",
-               data.typeKey.c_str(), fixtureTypeId.c_str());
+  Logger::Instance().Log(
+      Logger::Level::Info,
+      "Truss GDTF FixtureTypeID generated typeKey='" + data.typeKey +
+          "' fixtureTypeId='" + fixtureTypeId + "'");
   return fixtureTypeId;
 }
 


### PR DESCRIPTION
### Motivation
- Prevent showing a wxWidgets info popup when generating truss GDTF `FixtureTypeID` and keep the message only in the application log.

### Description
- In `core/truss_gdtf_builder.cpp` replaced the `wxLogMessage(...)` call with `Logger::Instance().Log(...)`, and added `#include "logger.h"` and a one-line English comment above `BuildStableFixtureTypeId` to document its purpose.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both returning OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0616a6f2748324a29300217fac66bf)