### PR TITLE
ci: add manual MINOR draft release workflow with installer assets

### DIFF
--- a/.github/workflows/linux-installer.yml
+++ b/.github/workflows/linux-installer.yml
@@ -4,7 +4,19 @@
 name: Linux Ubuntu Installer Build
 
 on:
+  workflow_call:
+    inputs:
+      source_ref:
+        description: Git ref to build from when called as a reusable workflow.
+        required: false
+        type: string
   workflow_dispatch:
+    inputs:
+      source_ref:
+        description: Optional git ref to build from.
+        required: false
+        type: string
+        default: ""
   push:
     branches:
       - ci/linux-appimage
@@ -23,6 +35,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_ref != '' && inputs.source_ref || github.ref }}
 
       - name: Install Linux build dependencies
         run: |

--- a/.github/workflows/macos-installer.yml
+++ b/.github/workflows/macos-installer.yml
@@ -4,7 +4,19 @@
 name: macOS Installer Build
 
 on:
+  workflow_call:
+    inputs:
+      source_ref:
+        description: Git ref to build from when called as a reusable workflow.
+        required: false
+        type: string
   workflow_dispatch:
+    inputs:
+      source_ref:
+        description: Optional git ref to build from.
+        required: false
+        type: string
+        default: ""
   push:
     branches:
       - ci/macos-installer
@@ -25,6 +37,8 @@ jobs:
       # ── 1. Checkout ────────────────────────────────────────────────────────
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_ref != '' && inputs.source_ref || github.ref }}
 
       # ── 2. Install macOS build tools ────────────────────────────────────────
       - name: Install macOS build tools

--- a/.github/workflows/minor-draft-release.yml
+++ b/.github/workflows/minor-draft-release.yml
@@ -1,0 +1,202 @@
+name: Minor Draft Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_title:
+        description: Optional release title. Leave empty to use the default title.
+        required: false
+        type: string
+        default: ""
+      prerelease:
+        description: Mark the created draft release as a prerelease.
+        required: false
+        type: boolean
+        default: false
+      dry_run:
+        description: Validate and compute the new version without pushing, tagging, building, or creating a release.
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  actions: read
+  packages: read
+
+concurrency:
+  group: perastage-minor-draft-release
+  cancel-in-progress: false
+
+jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+    outputs:
+      new_version: ${{ steps.bump.outputs.new_version }}
+      new_tag: ${{ steps.bump.outputs.new_tag }}
+      release_title: ${{ steps.bump.outputs.release_title }}
+      prerelease: ${{ steps.bump.outputs.prerelease }}
+      dry_run: ${{ steps.bump.outputs.dry_run }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Compute next minor version
+        id: bump
+        env:
+          RELEASE_TITLE_INPUT: ${{ github.event.inputs.release_title }}
+          PRERELEASE_INPUT: ${{ github.event.inputs.prerelease }}
+          DRY_RUN_INPUT: ${{ github.event.inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
+            echo "This workflow must run from refs/heads/main, got: ${GITHUB_REF}"
+            exit 1
+          fi
+
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "Working tree must be clean before version bump"
+            exit 1
+          fi
+
+          VERSION_RAW="$(tr -d '[:space:]' < VERSION)"
+          if ! [[ "$VERSION_RAW" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "VERSION must be MAJOR.MINOR.PATCH, got: '$VERSION_RAW'"
+            exit 1
+          fi
+
+          IFS='.' read -r major minor patch <<< "$VERSION_RAW"
+          next_minor=$((minor + 1))
+          NEW_VERSION="${major}.${next_minor}.0"
+          NEW_TAG="v${NEW_VERSION}"
+
+          if git rev-parse -q --verify "refs/tags/${NEW_TAG}" >/dev/null; then
+            echo "Tag already exists locally: ${NEW_TAG}"
+            exit 1
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/${NEW_TAG}" >/dev/null 2>&1; then
+            echo "Tag already exists on origin: ${NEW_TAG}"
+            exit 1
+          fi
+
+          RELEASE_TITLE="${RELEASE_TITLE_INPUT}"
+          if [ -z "$RELEASE_TITLE" ]; then
+            RELEASE_TITLE="Perastage ${NEW_TAG}"
+          fi
+
+          printf '%s\n' "$NEW_VERSION" > VERSION
+
+          echo "previous_version=${VERSION_RAW}" >> "$GITHUB_OUTPUT"
+          echo "new_version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "new_tag=${NEW_TAG}" >> "$GITHUB_OUTPUT"
+          echo "release_title=${RELEASE_TITLE}" >> "$GITHUB_OUTPUT"
+          echo "prerelease=${PRERELEASE_INPUT}" >> "$GITHUB_OUTPUT"
+          echo "dry_run=${DRY_RUN_INPUT}" >> "$GITHUB_OUTPUT"
+
+      - name: Commit, push, and tag release version
+        if: ${{ steps.bump.outputs.dry_run != 'true' }}
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.new_version }}
+          NEW_TAG: ${{ steps.bump.outputs.new_tag }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add VERSION
+          git commit -m "chore: prepare minor release ${NEW_TAG} [skip version-bump]"
+          git push origin HEAD:main
+
+          git tag -a "${NEW_TAG}" -m "Perastage ${NEW_TAG}"
+          git push origin "${NEW_TAG}"
+
+      - name: Show dry run result
+        if: ${{ steps.bump.outputs.dry_run == 'true' }}
+        run: |
+          echo "Dry run enabled: computed ${NEW_VERSION} and ${NEW_TAG} without changes"
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.new_version }}
+          NEW_TAG: ${{ steps.bump.outputs.new_tag }}
+
+  windows-installer:
+    if: ${{ needs.prepare-release.outputs.dry_run != 'true' }}
+    needs: prepare-release
+    uses: ./.github/workflows/windows-installer.yml
+    with:
+      source_ref: ${{ needs.prepare-release.outputs.new_tag }}
+
+  linux-installer:
+    if: ${{ needs.prepare-release.outputs.dry_run != 'true' }}
+    needs: prepare-release
+    uses: ./.github/workflows/linux-installer.yml
+    with:
+      source_ref: ${{ needs.prepare-release.outputs.new_tag }}
+
+  macos-installer:
+    if: ${{ needs.prepare-release.outputs.dry_run != 'true' }}
+    needs: prepare-release
+    uses: ./.github/workflows/macos-installer.yml
+    with:
+      source_ref: ${{ needs.prepare-release.outputs.new_tag }}
+
+  create-draft-release:
+    if: ${{ needs.prepare-release.outputs.dry_run != 'true' }}
+    needs:
+      - prepare-release
+      - windows-installer
+      - linux-installer
+      - macos-installer
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download installer artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+          pattern: Perastage-*
+
+      - name: Validate installer assets
+        id: assets
+        run: |
+          set -euo pipefail
+
+          WIN_ASSET="$(find release-assets -type f -name 'Perastage_*_Setup.exe' -print -quit)"
+          LINUX_ASSET="$(find release-assets -type f -name 'Perastage-*-x86_64.AppImage' -print -quit)"
+          MAC_ASSET="$(find release-assets -type f -name 'Perastage-*-macos-arm64.dmg' -print -quit)"
+
+          if [ -z "$WIN_ASSET" ] || [ -z "$LINUX_ASSET" ] || [ -z "$MAC_ASSET" ]; then
+            echo "Missing one or more installer assets"
+            echo "Windows: $WIN_ASSET"
+            echo "Linux: $LINUX_ASSET"
+            echo "macOS: $MAC_ASSET"
+            exit 1
+          fi
+
+          echo "win_asset=$WIN_ASSET" >> "$GITHUB_OUTPUT"
+          echo "linux_asset=$LINUX_ASSET" >> "$GITHUB_OUTPUT"
+          echo "mac_asset=$MAC_ASSET" >> "$GITHUB_OUTPUT"
+
+      - name: Create draft release with generated notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ needs.prepare-release.outputs.new_tag }}
+          RELEASE_TITLE: ${{ needs.prepare-release.outputs.release_title }}
+          PRERELEASE: ${{ needs.prepare-release.outputs.prerelease }}
+          WIN_ASSET: ${{ steps.assets.outputs.win_asset }}
+          LINUX_ASSET: ${{ steps.assets.outputs.linux_asset }}
+          MAC_ASSET: ${{ steps.assets.outputs.mac_asset }}
+        run: |
+          set -euo pipefail
+
+          cmd=(gh release create "$TAG_NAME" "$WIN_ASSET" "$LINUX_ASSET" "$MAC_ASSET" --draft --generate-notes --title "$RELEASE_TITLE")
+          if [ "$PRERELEASE" = "true" ]; then
+            cmd+=(--prerelease)
+          fi
+
+          "${cmd[@]}"

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -4,7 +4,19 @@
 name: Windows Installer Build
 
 on:
+  workflow_call:
+    inputs:
+      source_ref:
+        description: Git ref to build from when called as a reusable workflow.
+        required: false
+        type: string
   workflow_dispatch:
+    inputs:
+      source_ref:
+        description: Optional git ref to build from.
+        required: false
+        type: string
+        default: ""
   push:
     branches:
       - ci/windows-installer
@@ -24,6 +36,8 @@ jobs:
       # ── 1. Checkout ────────────────────────────────────────────────────────
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_ref != '' && inputs.source_ref || github.ref }}
 
       # ── 2. Cache vcpkg installed tree + downloads ───────────────────────────
       # The cache key includes the workflow file itself so a change in the

--- a/docs/versioning-policy.md
+++ b/docs/versioning-policy.md
@@ -109,6 +109,23 @@ The same workflow dispatches these existing installer workflows on `main` for te
 
 This automation does not create Git tags and does not create GitHub Releases.
 
-## Future Official Release Automation
+## Manual MINOR Draft Release Workflow
 
-Official releases should continue to use a separate manual release workflow that increments MINOR or MAJOR as needed, creates an official tag, and creates a GitHub Release.
+Perastage includes a manual workflow named `Minor Draft Release` in `.github/workflows/minor-draft-release.yml`.
+
+This workflow is triggered only by `workflow_dispatch`.
+
+It performs these actions for a MINOR release:
+
+- Validates the root `VERSION` format.
+- Increments MINOR and resets PATCH to `0`.
+- Commits the new `VERSION` to `main` with `[skip version-bump]` to prevent the automatic PATCH bump workflow from running on that commit.
+- Creates and pushes an annotated release tag in the format `vMAJOR.MINOR.0`.
+- Builds Windows, Linux, and macOS installers from the new release tag using the existing installer workflows.
+- Creates a GitHub Draft Release for the new tag.
+- Uses GitHub automatic release-note generation.
+- Attaches the Windows installer, Linux AppImage, and macOS DMG assets to the draft release.
+
+The workflow intentionally leaves the release as a draft so the maintainer can manually review, edit, and publish it.
+
+This workflow does not publish the release automatically and does not create MAJOR releases.


### PR DESCRIPTION
### Motivation

- Provide a safe, manual MINOR release flow that increments MINOR, resets PATCH to 0, and produces a draft GitHub Release containing the three platform installers. 
- Ensure the MINOR release is built from an exact tag and avoid triggering the existing automatic PATCH bump workflow. 
- Keep existing per-platform installer workflows usable while enabling the release workflow to reuse their build logic.

### Description

- Add `.github/workflows/minor-draft-release.yml` which validates `VERSION`, computes `MAJOR.(MINOR+1).0`, enforces safety checks, supports `dry_run`, writes the new `VERSION`, creates an annotated tag `vMAJOR.MINOR.0`, and uses `[skip version-bump]` in the VERSION commit message to avoid the PATCH automation. 
- Make the three installer workflows reusable by adding `workflow_call` support and an optional `source_ref` input and wiring `actions/checkout` to honor `source_ref`, so the release workflow builds installers from the exact release tag; modified files: `.github/workflows/windows-installer.yml`, `.github/workflows/linux-installer.yml`, and `.github/workflows/macos-installer.yml`. 
- Collect and validate produced installer artifacts in the release job and create a Draft GitHub Release with automatic notes and attached installer assets using `gh release create --draft --generate-notes`, honoring an optional `prerelease` flag and leaving the release unpublished for manual review. 
- Update `docs/versioning-policy.md` to document the new manual MINOR draft release workflow and its behavior.

### Testing

- Ran `tests/check_perastage_tree_modules.sh` which passed successfully. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b3b8f8f248324ba48d16cec63cd94)