### PR TITLE
ci: fix repository context in minor draft release job

### DIFF
--- a/.github/workflows/minor-draft-release.yml
+++ b/.github/workflows/minor-draft-release.yml
@@ -155,6 +155,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Download installer artifacts
         uses: actions/download-artifact@v4
         with:
@@ -185,6 +188,7 @@ jobs:
       - name: Create draft release with generated notes
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           TAG_NAME: ${{ needs.prepare-release.outputs.new_tag }}
           RELEASE_TITLE: ${{ needs.prepare-release.outputs.release_title }}
           PRERELEASE: ${{ needs.prepare-release.outputs.prerelease }}
@@ -193,6 +197,8 @@ jobs:
           MAC_ASSET: ${{ steps.assets.outputs.mac_asset }}
         run: |
           set -euo pipefail
+
+          echo "Creating draft release in $GH_REPO"
 
           cmd=(gh release create "$TAG_NAME" "$WIN_ASSET" "$LINUX_ASSET" "$MAC_ASSET" --draft --generate-notes --title "$RELEASE_TITLE")
           if [ "$PRERELEASE" = "true" ]; then


### PR DESCRIPTION
### Motivation
- The `create-draft-release` job previously failed with `fatal: not a git repository` when invoking `gh release create` because the job had no local checkout and no explicit repository context for the GitHub CLI.

### Description
- Add a `Checkout repository` step (`actions/checkout@v4`) at the start of the `create-draft-release` job, add `GH_REPO: ${{ github.repository }}` to the release step environment, and print a short diagnostic `echo "Creating draft release in $GH_REPO"` before calling `gh release create`, while keeping the existing tag/asset/dry-run behavior unchanged.

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b5da590e483249c0cd2b4c4e0c341)