### PR TITLE
Refactor main window menu construction into builders

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -64,6 +64,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_fixture_add_flow.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_gdtf_credentials.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_menu.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_menu_builders.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_print.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/preferencesdialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/preferences/gdtf_credentials_panel.cpp

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -18,6 +18,7 @@
 #include "mainwindow.h"
 #include "mainwindow/controllers/mainwindow_io_controller.h"
 #include "mainwindow_view_controller.h"
+#include "mainwindow_menu_builders.h"
 
 #include <algorithm>
 #include <chrono>
@@ -352,101 +353,7 @@ void MainWindow::CreateToolBars() {
 
 // Builds and assigns the main application menu bar.
 void MainWindow::CreateMenuBar() {
-  wxMenuBar *menuBar = new wxMenuBar();
-
-  // File menu
-  wxMenu *fileMenu = new wxMenu();
-  fileMenu->Append(ID_File_New, "New\tCtrl+N");
-  fileMenu->AppendSeparator();
-  fileMenu->Append(ID_File_Load, "Load\tCtrl+L");
-  fileMenu->Append(ID_File_Save, "Save\tCtrl+S");
-  fileMenu->Append(ID_File_SaveAs, "Save As...");
-  fileMenu->AppendSeparator();
-  fileMenu->Append(ID_File_ImportMVR, "Import MVR...");
-  fileMenu->Append(ID_File_ExportMVR, "Export MVR...");
-  fileMenu->Append(ID_File_PrintViewer2D, "Print Viewer 2D...");
-  fileMenu->Append(ID_File_PrintLayout, "Print Layout...");
-  fileMenu->Append(ID_File_PrintTable, "Print Table...");
-  fileMenu->Append(ID_File_ExportCSV, "Export CSV...");
-  fileMenu->AppendSeparator();
-  fileMenu->Append(ID_File_Close, "Close\tCtrl+Q");
-
-  menuBar->Append(fileMenu, "&File");
-
-  // Edit menu
-  wxMenu *editMenu = new wxMenu();
-  editMenu->Append(ID_Edit_Undo, "Undo\tCtrl+Z");
-  editMenu->Append(ID_Edit_Redo, "Redo\tCtrl+Y");
-  editMenu->AppendSeparator();
-  editMenu->Append(ID_Edit_AddFixture, "Add fixture...");
-  editMenu->Append(ID_Edit_AddTruss, "Add truss...");
-  editMenu->Append(ID_Edit_AddSceneObject, "Add scene object...");
-  wxMenu *primitiveMenu = new wxMenu();
-  primitiveMenu->Append(ID_Edit_AddPrimitiveSphere, "Sphere...");
-  primitiveMenu->Append(ID_Edit_AddPrimitiveCube, "Cube...");
-  primitiveMenu->Append(ID_Edit_AddPrimitiveCylinder, "Cylinder...");
-  editMenu->AppendSubMenu(primitiveMenu, "Add basic geometry");
-  editMenu->AppendSeparator();
-  editMenu->Append(ID_Edit_Delete, "Delete\tDel");
-  editMenu->AppendSeparator();
-  editMenu->Append(ID_Edit_Preferences, "Preferences...");
-
-  menuBar->Append(editMenu, "&Edit");
-
-  // View menu for toggling panels
-  wxMenu *viewMenu = new wxMenu();
-  viewMenu->AppendCheckItem(ID_View_ToggleConsole, "Console");
-  viewMenu->AppendCheckItem(ID_View_ToggleFixtures, "Fixtures");
-  viewMenu->AppendCheckItem(ID_View_ToggleViewport, "3D Viewport");
-  viewMenu->AppendCheckItem(ID_View_ToggleViewport2D, "2D Viewport");
-  viewMenu->AppendCheckItem(ID_View_ToggleRender2D, "2D Render Options");
-  viewMenu->AppendCheckItem(ID_View_ToggleLayers, "Layers");
-  viewMenu->AppendCheckItem(ID_View_ToggleLayouts, "Layouts");
-  viewMenu->AppendCheckItem(ID_View_ToggleSummary, "Summary");
-  viewMenu->AppendCheckItem(ID_View_ToggleRigging, "Rigging");
-
-  wxMenu *layoutMenu = new wxMenu();
-  layoutMenu->Append(ID_View_Layout_Default, "3D Layout View");
-  layoutMenu->Append(ID_View_Layout_2D, "2D Layout View");
-  layoutMenu->Append(ID_View_Layout_Mode, "Layout Mode View");
-  viewMenu->AppendSubMenu(layoutMenu, "Layout Views");
-
-  menuBar->Append(viewMenu, "&View");
-
-  // Tools menu
-  wxMenu *toolsMenu = new wxMenu();
-  toolsMenu->Append(ID_Tools_DownloadGdtf, "Download GDTF fixture...");
-  toolsMenu->Append(ID_Tools_EditDictionaries, "Edit dictionaries...");
-  toolsMenu->Append(ID_Tools_OpenUserLibraryFolder, "Open user library folder");
-  toolsMenu->Append(ID_Tools_ImportRiderText, "Create from text...");
-  toolsMenu->Append(ID_Tools_DistributeHoistWeights,
-                    "Distribute hoist weights...");
-  toolsMenu->Append(ID_Tools_ExportFixture, "Export Fixture...");
-  toolsMenu->Append(ID_Tools_ExportTruss, "Export Truss...");
-  toolsMenu->Append(ID_Tools_ExportSceneObject, "Export Scene Object...");
-  toolsMenu->Append(ID_Tools_AutoPatch, "Auto patch");
-  toolsMenu->Append(ID_Tools_AutoColor, "Auto color");
-  toolsMenu->Append(ID_Tools_ConvertToHoist, "Convert to Hoist");
-  if (ui::IsFeatureEnabled(ui::FeatureFlag::GenerateFixtureSymbols)) {
-    toolsMenu->Append(ID_Tools_GenerateFixtureSymbols,
-                      "Generate Fixture Symbols...");
-  }
-  if (ui::IsFeatureEnabled(
-          ui::FeatureFlag::AssignSelectedFixtureCategory)) {
-    toolsMenu->Append(ID_Tools_AssignSelectedFixtureCategory,
-                      "Auto-assign categories to selected fixtures...");
-  }
-
-  menuBar->Append(toolsMenu, "&Tools");
-
-  // Help menu
-  wxMenu *helpMenu = new wxMenu();
-  helpMenu->Append(ID_Help_Help, "Help\tF1");
-  helpMenu->Append(ID_Help_About, "About");
-
-  menuBar->Append(helpMenu, "&Help");
-
-  SetMenuBar(menuBar);
+  SetMenuBar(BuildMainWindowMenuBar());
 }
 
 // Starts a new project after guarding startup and save state.

--- a/gui/mainwindow_menu_builders.cpp
+++ b/gui/mainwindow_menu_builders.cpp
@@ -1,0 +1,122 @@
+#include "mainwindow_menu_builders.h"
+
+#include "ui_feature_flags.h"
+#include "mainwindow.h"
+
+namespace {
+
+// Builds the File menu with project and import/export actions.
+wxMenu *BuildFileMenu() {
+  wxMenu *fileMenu = new wxMenu();
+  fileMenu->Append(ID_File_New, "New\tCtrl+N");
+  fileMenu->AppendSeparator();
+  fileMenu->Append(ID_File_Load, "Load\tCtrl+L");
+  fileMenu->Append(ID_File_Save, "Save\tCtrl+S");
+  fileMenu->Append(ID_File_SaveAs, "Save As...");
+  fileMenu->AppendSeparator();
+  fileMenu->Append(ID_File_ImportMVR, "Import MVR...");
+  fileMenu->Append(ID_File_ExportMVR, "Export MVR...");
+  fileMenu->Append(ID_File_PrintViewer2D, "Print Viewer 2D...");
+  fileMenu->Append(ID_File_PrintLayout, "Print Layout...");
+  fileMenu->Append(ID_File_PrintTable, "Print Table...");
+  fileMenu->Append(ID_File_ExportCSV, "Export CSV...");
+  fileMenu->AppendSeparator();
+  fileMenu->Append(ID_File_Close, "Close\tCtrl+Q");
+  return fileMenu;
+}
+
+// Builds the primitive submenu used by edit actions.
+wxMenu *BuildPrimitiveMenu() {
+  wxMenu *primitiveMenu = new wxMenu();
+  primitiveMenu->Append(ID_Edit_AddPrimitiveSphere, "Sphere...");
+  primitiveMenu->Append(ID_Edit_AddPrimitiveCube, "Cube...");
+  primitiveMenu->Append(ID_Edit_AddPrimitiveCylinder, "Cylinder...");
+  return primitiveMenu;
+}
+
+// Builds the Edit menu including add and preference actions.
+wxMenu *BuildEditMenu() {
+  wxMenu *editMenu = new wxMenu();
+  editMenu->Append(ID_Edit_Undo, "Undo\tCtrl+Z");
+  editMenu->Append(ID_Edit_Redo, "Redo\tCtrl+Y");
+  editMenu->AppendSeparator();
+  editMenu->Append(ID_Edit_AddFixture, "Add fixture...");
+  editMenu->Append(ID_Edit_AddTruss, "Add truss...");
+  editMenu->Append(ID_Edit_AddSceneObject, "Add scene object...");
+  editMenu->AppendSubMenu(BuildPrimitiveMenu(), "Add basic geometry");
+  editMenu->AppendSeparator();
+  editMenu->Append(ID_Edit_Delete, "Delete\tDel");
+  editMenu->AppendSeparator();
+  editMenu->Append(ID_Edit_Preferences, "Preferences...");
+  return editMenu;
+}
+
+// Builds the layout view submenu for switching layout visualizations.
+wxMenu *BuildLayoutViewsMenu() {
+  wxMenu *layoutMenu = new wxMenu();
+  layoutMenu->Append(ID_View_Layout_Default, "3D Layout View");
+  layoutMenu->Append(ID_View_Layout_2D, "2D Layout View");
+  layoutMenu->Append(ID_View_Layout_Mode, "Layout Mode View");
+  return layoutMenu;
+}
+
+// Builds the View menu with panel visibility and layout view entries.
+wxMenu *BuildViewMenu() {
+  wxMenu *viewMenu = new wxMenu();
+  viewMenu->AppendCheckItem(ID_View_ToggleConsole, "Console");
+  viewMenu->AppendCheckItem(ID_View_ToggleFixtures, "Fixtures");
+  viewMenu->AppendCheckItem(ID_View_ToggleViewport, "3D Viewport");
+  viewMenu->AppendCheckItem(ID_View_ToggleViewport2D, "2D Viewport");
+  viewMenu->AppendCheckItem(ID_View_ToggleRender2D, "2D Render Options");
+  viewMenu->AppendCheckItem(ID_View_ToggleLayers, "Layers");
+  viewMenu->AppendCheckItem(ID_View_ToggleLayouts, "Layouts");
+  viewMenu->AppendCheckItem(ID_View_ToggleSummary, "Summary");
+  viewMenu->AppendCheckItem(ID_View_ToggleRigging, "Rigging");
+  viewMenu->AppendSubMenu(BuildLayoutViewsMenu(), "Layout Views");
+  return viewMenu;
+}
+
+// Builds the Tools menu and adds feature-flagged utility entries.
+wxMenu *BuildToolsMenu() {
+  wxMenu *toolsMenu = new wxMenu();
+  toolsMenu->Append(ID_Tools_DownloadGdtf, "Download GDTF fixture...");
+  toolsMenu->Append(ID_Tools_EditDictionaries, "Edit dictionaries...");
+  toolsMenu->Append(ID_Tools_OpenUserLibraryFolder, "Open user library folder");
+  toolsMenu->Append(ID_Tools_ImportRiderText, "Create from text...");
+  toolsMenu->Append(ID_Tools_DistributeHoistWeights, "Distribute hoist weights...");
+  toolsMenu->Append(ID_Tools_ExportFixture, "Export Fixture...");
+  toolsMenu->Append(ID_Tools_ExportTruss, "Export Truss...");
+  toolsMenu->Append(ID_Tools_ExportSceneObject, "Export Scene Object...");
+  toolsMenu->Append(ID_Tools_AutoPatch, "Auto patch");
+  toolsMenu->Append(ID_Tools_AutoColor, "Auto color");
+  toolsMenu->Append(ID_Tools_ConvertToHoist, "Convert to Hoist");
+  if (ui::IsFeatureEnabled(ui::FeatureFlag::GenerateFixtureSymbols)) {
+    toolsMenu->Append(ID_Tools_GenerateFixtureSymbols, "Generate Fixture Symbols...");
+  }
+  if (ui::IsFeatureEnabled(ui::FeatureFlag::AssignSelectedFixtureCategory)) {
+    toolsMenu->Append(ID_Tools_AssignSelectedFixtureCategory,
+                      "Auto-assign categories to selected fixtures...");
+  }
+  return toolsMenu;
+}
+
+// Builds the Help menu with user guidance and about entries.
+wxMenu *BuildHelpMenu() {
+  wxMenu *helpMenu = new wxMenu();
+  helpMenu->Append(ID_Help_Help, "Help\tF1");
+  helpMenu->Append(ID_Help_About, "About");
+  return helpMenu;
+}
+
+} // namespace
+
+// Builds the complete main window menu bar structure with all top-level menus.
+wxMenuBar *BuildMainWindowMenuBar() {
+  wxMenuBar *menuBar = new wxMenuBar();
+  menuBar->Append(BuildFileMenu(), "&File");
+  menuBar->Append(BuildEditMenu(), "&Edit");
+  menuBar->Append(BuildViewMenu(), "&View");
+  menuBar->Append(BuildToolsMenu(), "&Tools");
+  menuBar->Append(BuildHelpMenu(), "&Help");
+  return menuBar;
+}

--- a/gui/mainwindow_menu_builders.h
+++ b/gui/mainwindow_menu_builders.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <wx/menu.h>
+
+namespace ui {
+enum class FeatureFlag;
+}
+
+// Builds the complete main window menu bar structure with all top-level menus.
+wxMenuBar *BuildMainWindowMenuBar();


### PR DESCRIPTION
### Motivation
- Reduce size and responsibility of `gui/mainwindow_menu.cpp` by extracting menu-building helpers into a focused unit. 
- Keep runtime handlers, signal/slot wiring, and business logic in place in `mainwindow_menu.cpp` for this incremental refactor. 
- Follow the project convention of adjacent files with explicit responsibilities and explicit CMake source registration (no globbing). 

### Description
- Added `gui/mainwindow_menu_builders.h` and `gui/mainwindow_menu_builders.cpp` which contain small helper functions that construct `File`, `Edit`, `View`, `Tools`, `Help` menus and the top-level `wxMenuBar`. 
- Updated `MainWindow::CreateMenuBar()` in `gui/mainwindow_menu.cpp` to delegate to `BuildMainWindowMenuBar()` (i.e. `SetMenuBar(BuildMainWindowMenuBar());`) and kept all runtime handlers and logic in the original file unchanged. 
- Preserved all action IDs, labels, menu ordering, and feature-flagged entries (uses `ui::IsFeatureEnabled(...)`) so external behavior and wiring entry points remain identical. 
- Updated `gui/CMakeLists.txt` to explicitly register `mainwindow_menu_builders.cpp` in the `target_sources` list. 
- Added concise one-line English comments above each new builder function definition in `mainwindow_menu_builders.cpp` describing the function purpose. 

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which returned OK. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which returned OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c9be232388324878c08126ab64d23)