### PR TITLE
docs: add concise refactor-only PR checklist

### DIFF
--- a/docs/documentation_policy.md
+++ b/docs/documentation_policy.md
@@ -102,6 +102,18 @@ If the change is purely internal and does not alter user-visible behavior, updat
 - [ ] I updated both files in the same PR when both criteria applied.
 - [ ] I added cross-links instead of duplicating long rule sections.
 
+
+## Refactor-Only PR Checklist
+
+Use this short checklist for PRs that claim **no functional change**:
+
+- [ ] No functional change confirmed (behavior, outputs, and user workflows unchanged).
+- [ ] One-line English comments added/maintained above touched function definitions.
+- [ ] CMake source lists updated explicitly when files are split or moved (no implicit source discovery).
+- [ ] If text-to-scene parsing or scene-generation behavior changed, `docs/text_to_scene_rules.md` was updated in the same PR.
+- [ ] If GUI shortcut mappings/scope/precedence changed, `docs/gui_shortcut_architecture.md` was updated in the same PR.
+- [ ] Hotspot growth was avoided by extracting responsibilities when touching near-limit files.
+
 ## Assets and Media
 
 - Store screenshots and diagrams under `docs/` or `resources/` as appropriate.


### PR DESCRIPTION
### Motivation
- Add a short, actionable checklist for refactor-only PRs so contributors explicitly confirm no behavioral change and maintain minimal documentation and build metadata consistency.

### Description
- Insert a new `Refactor-Only PR Checklist` section into `docs/documentation_policy.md` containing six concise items (including `No functional change confirmed`, one-line English comments above touched functions, explicit CMake source updates, and behavior-triggered doc checks for text-to-scene and GUI shortcuts) with no code or runtime changes.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ca2cf8b0c832499f808c87694c0b6)