### PR TITLE
Extract menu text and fixture update-type helpers from GUI hotspots

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/fixturetable/fixture_table_edit_service.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fixturetable/fixture_table_parser.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fixturetablepanel.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/fixturetablepanel_update_types.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtfsearchdialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/hoist_load_limit_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/hoist_load_recalculation_prompt.cpp
@@ -65,6 +66,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_gdtf_credentials.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_menu.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_menu_builders.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_menu_text_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_print.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/preferencesdialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/preferences/gdtf_credentials_panel.cpp

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "fixturetablepanel.h"
+#include "fixturetablepanel_update_types.h"
 #include "addressdialog.h"
 #include "configmanager.h"
 #include "selection_origin_token.h"
@@ -139,57 +140,6 @@ bool ShouldRefreshFixtureSummary(
     return false;
   }
   return true;
-}
-
-FixtureTablePanel::SceneDataUpdateType UpdateTypeForColumnImpl(int column) {
-  using SceneDataUpdateType = FixtureTablePanel::SceneDataUpdateType;
-  switch (column) {
-  case 1:
-    return SceneDataUpdateType::kVisualLabelOnly;
-  case 5:
-  case 6:
-  case 8:
-    return SceneDataUpdateType::kPatchOnly;
-  case 10:
-  case 11:
-  case 12:
-  case 13:
-  case 14:
-  case 15:
-    return SceneDataUpdateType::kTransformOnly;
-  case 16:
-  case 17:
-    return SceneDataUpdateType::kWeightOrPosition;
-  case 18:
-    return SceneDataUpdateType::kCategoryOnly;
-  case 19:
-    return SceneDataUpdateType::kAppearanceOnly;
-  case 0:
-    return SceneDataUpdateType::kFixtureIdOnly;
-  case 2:
-  case 3:
-  case 4:
-  case 7:
-  case 9:
-    return SceneDataUpdateType::kMetadataOnly;
-  default:
-    return SceneDataUpdateType::kGeneral;
-  }
-}
-
-FixtureTablePanel::SceneDataUpdateType CombineUpdateTypesImpl(
-    FixtureTablePanel::SceneDataUpdateType lhs,
-    FixtureTablePanel::SceneDataUpdateType rhs) {
-  using SceneDataUpdateType = FixtureTablePanel::SceneDataUpdateType;
-  if (lhs == rhs)
-    return lhs;
-  if (lhs == SceneDataUpdateType::kGeneral || rhs == SceneDataUpdateType::kGeneral)
-    return SceneDataUpdateType::kGeneral;
-  if (lhs == SceneDataUpdateType::kVisualLabelOnly)
-    return rhs;
-  if (rhs == SceneDataUpdateType::kVisualLabelOnly)
-    return lhs;
-  return SceneDataUpdateType::kGeneral;
 }
 
 bool IsRedCell(const ColorfulDataViewListStore *store, int row, int col) {
@@ -1153,11 +1103,13 @@ void FixtureTablePanel::SetInstance(FixtureTablePanel *panel) {
   s_instance = panel;
 }
 
+// Maps a table column index to its corresponding scene update category.
 FixtureTablePanel::SceneDataUpdateType
 FixtureTablePanel::UpdateTypeForColumn(int column) {
   return UpdateTypeForColumnImpl(column);
 }
 
+// Combines two scene update categories into a safe aggregate update.
 FixtureTablePanel::SceneDataUpdateType FixtureTablePanel::CombineUpdateTypes(
     SceneDataUpdateType lhs, SceneDataUpdateType rhs) {
   return CombineUpdateTypesImpl(lhs, rhs);

--- a/gui/fixturetablepanel_update_types.cpp
+++ b/gui/fixturetablepanel_update_types.cpp
@@ -1,0 +1,56 @@
+#include "fixturetablepanel_update_types.h"
+
+#include "fixturetablepanel.h"
+
+// Resolves the minimal scene update category for a fixture table column.
+FixtureTablePanel::SceneDataUpdateType UpdateTypeForColumnImpl(int column) {
+  using SceneDataUpdateType = FixtureTablePanel::SceneDataUpdateType;
+  switch (column) {
+  case 1:
+    return SceneDataUpdateType::kVisualLabelOnly;
+  case 5:
+  case 6:
+  case 8:
+    return SceneDataUpdateType::kPatchOnly;
+  case 10:
+  case 11:
+  case 12:
+  case 13:
+  case 14:
+  case 15:
+    return SceneDataUpdateType::kTransformOnly;
+  case 16:
+  case 17:
+    return SceneDataUpdateType::kWeightOrPosition;
+  case 18:
+    return SceneDataUpdateType::kCategoryOnly;
+  case 19:
+    return SceneDataUpdateType::kAppearanceOnly;
+  case 0:
+    return SceneDataUpdateType::kFixtureIdOnly;
+  case 2:
+  case 3:
+  case 4:
+  case 7:
+  case 9:
+    return SceneDataUpdateType::kMetadataOnly;
+  default:
+    return SceneDataUpdateType::kGeneral;
+  }
+}
+
+// Merges two update categories into the most conservative required update.
+FixtureTablePanel::SceneDataUpdateType CombineUpdateTypesImpl(
+    FixtureTablePanel::SceneDataUpdateType lhs,
+    FixtureTablePanel::SceneDataUpdateType rhs) {
+  using SceneDataUpdateType = FixtureTablePanel::SceneDataUpdateType;
+  if (lhs == rhs)
+    return lhs;
+  if (lhs == SceneDataUpdateType::kGeneral || rhs == SceneDataUpdateType::kGeneral)
+    return SceneDataUpdateType::kGeneral;
+  if (lhs == SceneDataUpdateType::kVisualLabelOnly)
+    return rhs;
+  if (rhs == SceneDataUpdateType::kVisualLabelOnly)
+    return lhs;
+  return SceneDataUpdateType::kGeneral;
+}

--- a/gui/fixturetablepanel_update_types.h
+++ b/gui/fixturetablepanel_update_types.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "fixturetablepanel.h"
+
+// Resolves the minimal scene update category for a fixture table column.
+FixtureTablePanel::SceneDataUpdateType UpdateTypeForColumnImpl(int column);
+
+// Merges two update categories into the most conservative required update.
+FixtureTablePanel::SceneDataUpdateType CombineUpdateTypesImpl(
+    FixtureTablePanel::SceneDataUpdateType lhs,
+    FixtureTablePanel::SceneDataUpdateType rhs);

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -19,6 +19,7 @@
 #include "mainwindow/controllers/mainwindow_io_controller.h"
 #include "mainwindow_view_controller.h"
 #include "mainwindow_menu_builders.h"
+#include "mainwindow_menu_text_utils.h"
 
 #include <algorithm>
 #include <chrono>
@@ -90,27 +91,11 @@
 
 namespace {
 
-// Converts a wxString value to a UTF-8 std::string.
-std::string WxToUtf8(const wxString &value) {
-  const wxScopedCharBuffer utf8 = value.ToUTF8();
-  if (utf8)
-    return std::string(utf8.data(), utf8.length());
-  return value.ToStdString();
-}
-
 struct HelpMarkdown {
   std::string english;
   std::string spanish;
   bool hasSections = false;
 };
-
-// Removes leading blank-line whitespace from a text block.
-std::string TrimLeadingWhitespace(const std::string &text) {
-  const auto start = text.find_first_not_of("\r\n");
-  if (start == std::string::npos)
-    return std::string();
-  return text.substr(start);
-}
 
 // Splits help markdown into English and Spanish sections when markers are present.
 HelpMarkdown SplitHelpMarkdown(const std::string &markdown) {
@@ -159,11 +144,6 @@ HelpMarkdown SplitHelpMarkdown(const std::string &markdown) {
   return result;
 }
 
-// Wraps HTML body content in a UTF-8 HTML document shell.
-std::string WrapHelpHtml(const std::string &body) {
-  return "<html><head><meta charset=\"UTF-8\"></head><body>" + body +
-         "</body></html>";
-}
 } // namespace
 
 // Builds and registers the main application toolbars.

--- a/gui/mainwindow_menu_text_utils.cpp
+++ b/gui/mainwindow_menu_text_utils.cpp
@@ -1,0 +1,25 @@
+#include "mainwindow_menu_text_utils.h"
+
+#include <wx/string.h>
+
+// Converts a wxString value to a UTF-8 std::string.
+std::string WxToUtf8(const wxString &value) {
+  const wxScopedCharBuffer utf8 = value.ToUTF8();
+  if (utf8)
+    return std::string(utf8.data(), utf8.length());
+  return value.ToStdString();
+}
+
+// Removes leading blank-line whitespace from a text block.
+std::string TrimLeadingWhitespace(const std::string &text) {
+  const auto start = text.find_first_not_of("\r\n");
+  if (start == std::string::npos)
+    return std::string();
+  return text.substr(start);
+}
+
+// Wraps HTML body content in a UTF-8 HTML document shell.
+std::string WrapHelpHtml(const std::string &body) {
+  return "<html><head><meta charset=\"UTF-8\"></head><body>" + body +
+         "</body></html>";
+}

--- a/gui/mainwindow_menu_text_utils.h
+++ b/gui/mainwindow_menu_text_utils.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <string>
+
+class wxString;
+
+// Converts a wxString value to a UTF-8 std::string.
+std::string WxToUtf8(const wxString &value);
+
+// Removes leading blank-line whitespace from a text block.
+std::string TrimLeadingWhitespace(const std::string &text);
+
+// Wraps HTML body content in a UTF-8 HTML document shell.
+std::string WrapHelpHtml(const std::string &body);


### PR DESCRIPTION
### Motivation
- Reduce logic density in GUI hotspot files by extracting small, well-scoped helper responsibilities into adjacent modules to improve modularity and readability.
- Keep explicit source ownership in CMake and avoid reintroducing new responsibilities into `mainwindow_menu.cpp`.
- Add concise one-line comments above touched function definitions to document purpose as part of the requested code hygiene changes.

### Description
- Moved UTF-8 / help text helper functions out of `gui/mainwindow_menu.cpp` into `gui/mainwindow_menu_text_utils.h` and `gui/mainwindow_menu_text_utils.cpp`, and updated `mainwindow_menu.cpp` to include the new header and use the helpers.
- Extracted fixture table update-type mapping and merge logic from `gui/fixturetablepanel.cpp` into `gui/fixturetablepanel_update_types.h` and `gui/fixturetablepanel_update_types.cpp`, while keeping thin wrapper calls in `fixturetablepanel.cpp` and adding one-line comments above the wrappers.
- Registered the two new implementation files in `gui/CMakeLists.txt` to maintain explicit source listing and build correctness.
- Added concise, one-line English comments above each extracted function definition and above the `FixtureTablePanel` wrapper methods to satisfy the comment/exit criteria.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded.
- No further automated tests were added or modified in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ca3dff7208324bea69bf2e7a338a7)