### PR TITLE
refactor(gui): extract fixture table tooltip and hover helpers

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/fixturetable/fixture_table_edit_service.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fixturetable/fixture_table_parser.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fixturetablepanel.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/fixturetablepanel_ui_helpers.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fixturetablepanel_update_types.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtfsearchdialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/hoist_load_limit_utils.cpp

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -17,6 +17,7 @@
  */
 #include "fixturetablepanel.h"
 #include "fixturetablepanel_update_types.h"
+#include "fixturetablepanel_ui_helpers.h"
 #include "addressdialog.h"
 #include "configmanager.h"
 #include "selection_origin_token.h"
@@ -164,79 +165,6 @@ bool IsRedCell(const ColorfulDataViewListStore *store, int row, int col) {
 
   const wxDataViewItemAttr &attr = store->cellAttrs[rowIndex][colIndex];
   return attr.HasColour() && attr.GetColour() == *wxRED;
-}
-
-// Applies the same tooltip text to the table and its child windows.
-void SetTableAndChildTooltips(wxDataViewListCtrl *table,
-                              const wxString &tooltip) {
-  if (!table)
-    return;
-
-  table->SetToolTip(tooltip);
-  wxWindowList &children = table->GetChildren();
-  for (wxWindowList::compatibility_iterator it = children.GetFirst(); it;
-       it = it->GetNext()) {
-    if (wxWindow *child = it->GetData())
-      child->SetToolTip(tooltip);
-  }
-}
-
-// Converts mouse coordinates from child windows into table client coordinates.
-wxPoint NormalizeMousePositionForTable(wxDataViewListCtrl *table,
-                                       const wxMouseEvent &event) {
-  wxPoint position = event.GetPosition();
-  wxWindow *sourceWindow =
-      dynamic_cast<wxWindow *>(event.GetEventObject());
-  if (!table || !sourceWindow || sourceWindow == table)
-    return position;
-
-  return table->ScreenToClient(sourceWindow->ClientToScreen(position));
-}
-
-template <typename Owner>
-// Binds hover tracking events on the table and all internal child windows.
-void BindTableHoverEvents(wxDataViewListCtrl *table, Owner *owner,
-                          void (Owner::*onMouseMove)(wxMouseEvent &),
-                          void (Owner::*onMouseLeave)(wxMouseEvent &)) {
-  if (!table || !owner)
-    return;
-
-  auto bindEvents = [&](wxWindow *window) {
-    if (!window)
-      return;
-    window->Unbind(wxEVT_MOTION, onMouseMove, owner);
-    window->Unbind(wxEVT_LEAVE_WINDOW, onMouseLeave, owner);
-    window->Bind(wxEVT_MOTION, onMouseMove, owner);
-    window->Bind(wxEVT_LEAVE_WINDOW, onMouseLeave, owner);
-  };
-
-  bindEvents(table);
-  wxWindowList &children = table->GetChildren();
-  for (wxWindowList::compatibility_iterator it = children.GetFirst(); it;
-       it = it->GetNext()) {
-    bindEvents(it->GetData());
-  }
-}
-
-// Returns tooltip text describing known validation conflicts for a column.
-wxString BuildFixtureTooltipForColumn(int modelColumn) {
-  if (modelColumn == 0)
-    return "Duplicate Fixture ID. Each fixture must have a unique ID.";
-  if (modelColumn == 5 || modelColumn == 6)
-    return "DMX patch conflict detected. Universe and channel overlap with another fixture.";
-  return wxString();
-}
-
-// Returns tooltip text when a fixture category was auto-assigned by fallback rules.
-wxString BuildCategoryFallbackTooltip(const Fixture &fixture) {
-  if (fixture.categorySource != GdtfFixtureCategory::kAutoFallbackSource)
-    return wxString();
-  if (!fixture.categorySourceReason.empty()) {
-    return wxString::Format(
-        "Category auto-assigned by fallback: %s.",
-        wxString::FromUTF8(fixture.categorySourceReason).c_str());
-  }
-  return "Category auto-assigned by fallback.";
 }
 
 // Renders and assigns the fixture color swatch cell for a given row.

--- a/gui/fixturetablepanel_ui_helpers.cpp
+++ b/gui/fixturetablepanel_ui_helpers.cpp
@@ -1,0 +1,48 @@
+#include "fixturetablepanel_ui_helpers.h"
+
+// Applies the same tooltip text to the table and its child windows.
+void SetTableAndChildTooltips(wxDataViewListCtrl *table,
+                              const wxString &tooltip) {
+  if (!table)
+    return;
+
+  table->SetToolTip(tooltip);
+  wxWindowList &children = table->GetChildren();
+  for (wxWindowList::compatibility_iterator it = children.GetFirst(); it;
+       it = it->GetNext()) {
+    if (wxWindow *child = it->GetData())
+      child->SetToolTip(tooltip);
+  }
+}
+
+// Converts mouse coordinates from child windows into table client coordinates.
+wxPoint NormalizeMousePositionForTable(wxDataViewListCtrl *table,
+                                       const wxMouseEvent &event) {
+  wxPoint position = event.GetPosition();
+  wxWindow *sourceWindow = dynamic_cast<wxWindow *>(event.GetEventObject());
+  if (!table || !sourceWindow || sourceWindow == table)
+    return position;
+
+  return table->ScreenToClient(sourceWindow->ClientToScreen(position));
+}
+
+// Returns tooltip text describing known validation conflicts for a column.
+wxString BuildFixtureTooltipForColumn(int modelColumn) {
+  if (modelColumn == 0)
+    return "Duplicate Fixture ID. Each fixture must have a unique ID.";
+  if (modelColumn == 5 || modelColumn == 6)
+    return "DMX patch conflict detected. Universe and channel overlap with another fixture.";
+  return wxString();
+}
+
+// Returns tooltip text when a fixture category was auto-assigned by fallback rules.
+wxString BuildCategoryFallbackTooltip(const Fixture &fixture) {
+  if (fixture.categorySource != GdtfFixtureCategory::kAutoFallbackSource)
+    return wxString();
+  if (!fixture.categorySourceReason.empty()) {
+    return wxString::Format(
+        "Category auto-assigned by fallback: %s.",
+        wxString::FromUTF8(fixture.categorySourceReason).c_str());
+  }
+  return "Category auto-assigned by fallback.";
+}

--- a/gui/fixturetablepanel_ui_helpers.cpp
+++ b/gui/fixturetablepanel_ui_helpers.cpp
@@ -1,4 +1,5 @@
 #include "fixturetablepanel_ui_helpers.h"
+#include "gdtf_fixture_category.h"
 
 // Applies the same tooltip text to the table and its child windows.
 void SetTableAndChildTooltips(wxDataViewListCtrl *table,

--- a/gui/fixturetablepanel_ui_helpers.h
+++ b/gui/fixturetablepanel_ui_helpers.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "models/fixture.h"
+#include "fixture.h"
 #include <wx/dataview.h>
 
 // Applies the same tooltip text to the table and all child windows.

--- a/gui/fixturetablepanel_ui_helpers.h
+++ b/gui/fixturetablepanel_ui_helpers.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "scene/fixture.h"
+#include <wx/dataview.h>
+
+// Applies the same tooltip text to the table and all child windows.
+void SetTableAndChildTooltips(wxDataViewListCtrl *table,
+                              const wxString &tooltip);
+
+// Converts event mouse coordinates into the table's client coordinate space.
+wxPoint NormalizeMousePositionForTable(wxDataViewListCtrl *table,
+                                       const wxMouseEvent &event);
+
+// Returns column-specific tooltip text for known fixture validation conflicts.
+wxString BuildFixtureTooltipForColumn(int modelColumn);
+
+// Returns tooltip text for fixture categories assigned by fallback logic.
+wxString BuildCategoryFallbackTooltip(const Fixture &fixture);
+
+// Binds hover-related mouse events to the table and each internal child window.
+template <typename Owner>
+void BindTableHoverEvents(wxDataViewListCtrl *table, Owner *owner,
+                          void (Owner::*onMouseMove)(wxMouseEvent &),
+                          void (Owner::*onMouseLeave)(wxMouseEvent &)) {
+  if (!table || !owner)
+    return;
+
+  auto bindEvents = [&](wxWindow *window) {
+    if (!window)
+      return;
+    window->Unbind(wxEVT_MOTION, onMouseMove, owner);
+    window->Unbind(wxEVT_LEAVE_WINDOW, onMouseLeave, owner);
+    window->Bind(wxEVT_MOTION, onMouseMove, owner);
+    window->Bind(wxEVT_LEAVE_WINDOW, onMouseLeave, owner);
+  };
+
+  bindEvents(table);
+  wxWindowList &children = table->GetChildren();
+  for (wxWindowList::compatibility_iterator it = children.GetFirst(); it;
+       it = it->GetNext()) {
+    bindEvents(it->GetData());
+  }
+}

--- a/gui/fixturetablepanel_ui_helpers.h
+++ b/gui/fixturetablepanel_ui_helpers.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "scene/fixture.h"
+#include "models/fixture.h"
 #include <wx/dataview.h>
 
 // Applies the same tooltip text to the table and all child windows.


### PR DESCRIPTION
### Motivation
- Reduce heat in the `gui/fixturetablepanel.cpp` hotspot by extracting a tightly scoped UI responsibility (tooltip text and hover event helpers). 
- Keep the `FixtureTablePanel` runtime flow and behavior unchanged while improving modularity and explicit source ownership in CMake.

### Description
- Extracted tooltip/hover helpers into `gui/fixturetablepanel_ui_helpers.h` and `gui/fixturetablepanel_ui_helpers.cpp`, moving `SetTableAndChildTooltips`, `NormalizeMousePositionForTable`, `BuildFixtureTooltipForColumn`, `BuildCategoryFallbackTooltip`, and the templated `BindTableHoverEvents` out of `fixturetablepanel.cpp` while preserving signatures and invocation order.  
- Added concise one-line English comments above each moved helper declaration/definition to describe the function's purpose.  
- Included the new header from `fixturetablepanel.cpp` so all call sites remain unchanged.  
- Updated `gui/CMakeLists.txt` to explicitly add `fixturetablepanel_ui_helpers.cpp` to `target_sources` (no globbing) to maintain explicit source registration.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded.  
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cabcda34483249863a56d4b89aad9)