### PR TITLE
Skip save-confirmation for deferred startup project open

### DIFF
--- a/gui/mainwindow/controllers/mainwindow_io_controller.cpp
+++ b/gui/mainwindow/controllers/mainwindow_io_controller.cpp
@@ -261,7 +261,9 @@ bool MainWindowIoController::OpenPathFromCommandLine(
   if (extension == projectExtension) {
     const bool shouldSkipDirtyConfirmation =
         owner->IsStartupProjectLoadPending() ||
-        owner->IsStartupInitializationPending();
+        owner->IsStartupInitializationPending() ||
+        (owner->deferredStartupOpenPath.has_value() &&
+         owner->currentProjectPath.empty());
     if (!shouldSkipDirtyConfirmation &&
         !owner->ConfirmSaveIfDirty("loading a project", "Open Project"))
       return false;


### PR DESCRIPTION
### Motivation
- Avoid showing a spurious "save changes" prompt when processing a deferred CLI/startup project-open into a pristine in-memory project (common when restoring `layout_mode_view`).

### Description
- In `MainWindowIoController::OpenPathFromCommandLine` the `shouldSkipDirtyConfirmation` check was extended to also skip confirmation when `owner->deferredStartupOpenPath.has_value()` and `owner->currentProjectPath.empty()`, preventing a false positive dirty prompt during deferred startup opens (file: `gui/mainwindow/controllers/mainwindow_io_controller.cpp`).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.  
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cbbab70148324979235659763d91c)