### PR TITLE
Document scene-object model loader responsibility

### DIFF
--- a/viewer3d/resources/resource_sync_system.cpp
+++ b/viewer3d/resources/resource_sync_system.cpp
@@ -415,6 +415,7 @@ FixtureSceneNode BuildInstancedFixtureNode(const GdtfNode3D &templateNode,
   return node;
 }
 
+// Loads a scene-object model from disk based on its file extension and caches GPU-ready data.
 void EnsureModelLoaded(const std::string &path, ResourceSyncState &state,
                        const ResourceSyncCallbacks &callbacks,
                        const viewer3d::resources::MeshProcessingOptions &meshProcessingOptions,


### PR DESCRIPTION
### Motivation
- Clarify the runtime responsibility of the scene-object model loader and make it explicit which formats are actually handled by the resource sync path. 

### Description
- Add a concise one-line English comment above `EnsureModelLoaded` in `viewer3d/resources/resource_sync_system.cpp` to document that it loads scene-object models by file extension and prepares GPU-ready data; note that the runtime path currently attempts `Load3DS` for `.3ds` and `LoadGLB` for `.glb` while UI dialogs may present additional extensions. 

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cbe53d4508324b5fc9b2f1c22cb22)