### PR TITLE
Use correct tools constant for `ID_Help_Help`

### DIFF
--- a/gui/mainwindow/ids/edit_ids.h
+++ b/gui/mainwindow/ids/edit_ids.h
@@ -2,7 +2,7 @@
 
 #include "tools_ids.h"
 
-constexpr int ID_Help_Help = ID_Tools_AssignSelectedFixtureCategory + 1;
+constexpr int ID_Help_Help = ID_Tools_OpenUserLibraryFolder + 1;
 constexpr int ID_Help_About = ID_Help_Help + 1;
 constexpr int ID_Select_Fixtures = ID_Help_About + 1;
 constexpr int ID_Select_Trusses = ID_Select_Fixtures + 1;


### PR DESCRIPTION
### Motivation
- Correct the base constant used to define `ID_Help_Help` so the help menu ID aligns with the intended tools ID range and avoids ID collisions.

### Description
- Replace the initializer for `ID_Help_Help` in `gui/mainwindow/ids/edit_ids.h` from `ID_Tools_AssignSelectedFixtureCategory + 1` to `ID_Tools_OpenUserLibraryFolder + 1`.

### Testing
- No automated tests were run for this header-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ccc7337bc832497f7c4805e8e7093)