### PR TITLE
Add initial end-user documentation site under /docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ Recent 3D optimization updates depend on `meshoptimizer`; if you prepare depende
   using inline markers `((...))` or `*(...)*` (ignored by the parser).
 - Use the available tools to adjust and organize scene data more comfortably.
 
+
+## User Guide
+
+**User Guide:** [`/docs/index.md`](docs/index.md)
+
 ## Documentation
 
 The README is intentionally kept fairly compact. More detailed documentation lives in `docs/`:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,21 @@
+# FAQ
+
+## Is Perastage a real-time DMX visualizer?
+
+No. Perastage is mainly a practical MVR viewer and scene workflow tool.
+
+## What file type does Perastage focus on?
+
+MVR (`.mvr`).
+
+## Can I export to MVR?
+
+Yes. Use **File → Export MVR...**.
+
+## Can I work in both 2D and 3D?
+
+Yes. Perastage includes both views for scene review.
+
+## Can I download GDTF files from inside the app?
+
+Yes, if you have a GDTF Share account. Use **Tools → Download GDTF**.

--- a/docs/gdtf-download.md
+++ b/docs/gdtf-download.md
@@ -1,0 +1,17 @@
+# Download GDTF Files
+
+Perastage can download fixture profiles from GDTF Share.
+
+## Before you start
+
+- You need a valid GDTF Share account.
+
+## Steps
+
+1. In Perastage, open **Tools → Download GDTF**.
+2. Log in with your GDTF Share account when prompted.
+3. Search and download the fixture profile you need.
+
+If needed, you can manage local dictionary entries from:
+
+- **Tools → Edit dictionaries**

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,25 @@
+# Perastage User Guide
+
+Welcome! This guide helps you get started with Perastage as a user.
+
+Perastage is a desktop app for opening, reviewing, and working with MVR lighting files.
+
+## Navigation
+
+- [Installation](installation.md)
+- [Quick Start](quick-start.md)
+- [Opening MVR Files](opening-mvr-files.md)
+- [Download GDTF Files](gdtf-download.md)
+- [Views (2D and 3D)](views.md)
+- [Preferences](preferences.md)
+- [Troubleshooting](troubleshooting.md)
+- [FAQ](faq.md)
+
+## What you can do in Perastage
+
+- Open and inspect `.mvr` scenes.
+- Review fixtures, trusses, hoists, and objects.
+- Use 3D and plan-focused 2D views.
+- Import and export MVR.
+- Use **Tools → Create from text** to build scene content from text.
+- Download GDTF profiles with a GDTF Share account.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,21 @@
+# Installation
+
+Perastage is a cross-platform desktop application.
+
+## Recommended method
+
+1. Open the project's GitHub releases page.
+2. Download the latest package for your platform.
+3. Install and launch Perastage.
+
+## Windows user library location
+
+Perastage stores editable library data in your user profile, not inside Program Files.
+
+Default location:
+
+- `%APPDATA%\Perastage\library\`
+
+You can also open this folder from inside the app:
+
+- **Tools → Open user library folder**

--- a/docs/opening-mvr-files.md
+++ b/docs/opening-mvr-files.md
@@ -1,0 +1,18 @@
+# Opening MVR Files
+
+Perastage is focused on MVR workflows.
+
+## Open or import an MVR
+
+Use one of these methods:
+
+- Open an existing `.mvr` file from the file workflow.
+- Use **File → Import MVR...**.
+
+After import, Perastage loads the scene so you can review fixtures, trusses, hoists, and objects.
+
+## Export back to MVR
+
+When you finish changes, you can export the scene using:
+
+- **File → Export MVR...**

--- a/docs/preferences.md
+++ b/docs/preferences.md
@@ -1,0 +1,15 @@
+# Preferences
+
+Perastage includes a Preferences dialog for user settings.
+
+## What you can configure
+
+Current user-facing preferences include:
+
+- Distance units.
+- Weight units.
+- GDTF-related settings.
+
+## Why this matters
+
+Changing units affects how values are shown in the UI while the app keeps a consistent internal scene model.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,0 +1,12 @@
+# Quick Start
+
+Use these steps for a fast first session.
+
+1. Launch Perastage.
+2. Open an MVR file (see [Opening MVR Files](opening-mvr-files.md)).
+3. Explore the scene in 3D and 2D views.
+4. Check fixtures, trusses, hoists, and objects in the panels/tables.
+5. (Optional) Use **Tools → Create from text** to create elements from rider-style notes.
+6. Save your work and export to MVR when needed.
+
+Tip: If fixture definitions are missing, use GDTF download (see [Download GDTF Files](gdtf-download.md)).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,86 +1,31 @@
-# Build Troubleshooting
+# Troubleshooting
 
-This page collects common build and IDE/tooling failures for current Perastage development environments.
+If something does not work as expected, try these quick checks.
 
-## Windows Linker Error: `LNK1163`
+## MVR file will not open
 
-`LNK1163: invalid selection for COMDAT section` usually indicates stale or incompatible object files from a different MSVC toolset or incompatible linker settings.
+- Confirm the file is a valid `.mvr`.
+- Try opening a different MVR file to compare behavior.
+- Restart Perastage and open again.
 
-### Fix Steps
+## Missing or incorrect fixture appearance
 
-1. Delete the affected build folder (for example `out/build/x64-Debug`).
-2. Reconfigure with your intended generator and toolset.
-3. Rebuild with a clean pass.
+- Check whether the required GDTF profile is available.
+- Download the profile from **Tools → Download GDTF**.
+- Review dictionary mappings in **Tools → Edit dictionaries**.
 
-```powershell
-cmake --build out/build/x64-Debug --config Debug --clean-first
-```
+## Cannot find your local library files
 
-## C++20 Symbols Missing in IntelliSense
+Open:
 
-Typical editor-only symptoms:
+- **Tools → Open user library folder**
 
-- `std has no member filesystem / optional / variant / string_view / bit_cast`
-- structured-binding parse failures
-- cascaded parser errors that do not match real compiler output
+On Windows, library files are typically under:
 
-This usually means the editor is not attached to the active CMake configuration.
+- `%APPDATA%\Perastage\library\`
 
-### Fix Steps
+## App feels out of sync after many edits
 
-1. Remove the current build directory.
-2. Reconfigure from a clean developer shell.
-3. Build from that same directory.
-4. Reopen/reindex IntelliSense.
-
-```powershell
-cmake -S . -B out/build/x64-Debug -G "Visual Studio 17 2022" -A x64
-cmake --build out/build/x64-Debug --config Debug
-```
-
-When editor diagnostics and compiler output disagree, prioritize `cmake --build` output.
-
-## VS Code + CMake Tools Misalignment
-
-If VS Code shows persistent semantic errors while builds succeed:
-
-1. Select the intended configure preset in CMake Tools.
-2. Run **CMake: Configure**.
-3. If needed, delete the selected preset build directory and configure again.
-4. Verify C++ extension and CMake Tools extensions are installed and enabled.
-
-## macOS Toolchain Incomplete (Apple Silicon Common Case)
-
-Common configure failures:
-
-- missing Ninja build program,
-- `CMAKE_CXX_COMPILER not set, after EnableLanguage`.
-
-### Fix Steps
-
-```bash
-xcode-select --install
-brew install cmake ninja
-xcode-select -p
-clang++ --version
-ninja --version
-cmake --version
-```
-
-If you changed kit/generator, delete the previous build directory and configure again.
-
-## Package-Manager and Triplet Mismatch
-
-When using vcpkg or equivalent package managers:
-
-- keep architecture/triplet consistent with your configure command,
-- avoid mixing cached outputs from different triplets/toolchains.
-
-## Reporting Issues Effectively
-
-Include the following when filing a bug report:
-
-- exact configure and build commands,
-- full error output (not only summary lines),
-- platform, compiler version, and generator information,
-- whether the failure is compiler/linker output or editor-only diagnostics.
+- Save your project.
+- Close and reopen the file.
+- Recheck the scene in both 2D and 3D views.

--- a/docs/views.md
+++ b/docs/views.md
@@ -1,0 +1,25 @@
+# Views (2D and 3D)
+
+Perastage includes both 3D and plan-style 2D viewing.
+
+## 3D View
+
+Use the 3D view to inspect geometry and scene structure.
+
+Typical use cases:
+
+- Check placement and orientation.
+- Review fixture/truss/object relationships.
+
+## 2D View
+
+Use the 2D view for plan-focused checks and layout-style review.
+
+Typical use cases:
+
+- Quick top/plan reading.
+- Preparing printable view outputs.
+
+## Helpful workflow
+
+Switch between 3D and 2D while selecting the same scene items to validate both spatial and plan representation.


### PR DESCRIPTION
### Motivation

- Provide a concise, user-focused documentation hub so end users can learn how to install and use Perastage for real workflows that already exist in the codebase. 
- Keep documentation aligned with the repository rule that user docs live under `/docs` and only describe actual implemented user-facing features (MVR viewing, GDTF integration, Tools → Create from text, 2D/3D views, etc.).

### Description

- Added an end-user entry page `docs/index.md` with clear navigation to the new user pages. 
- Added user-focused pages: `docs/installation.md`, `docs/quick-start.md`, `docs/opening-mvr-files.md`, `docs/gdtf-download.md`, `docs/views.md`, `docs/preferences.md`, `docs/troubleshooting.md`, and `docs/faq.md`. 
- Updated `README.md` to include a visible "User Guide" link pointing to `docs/index.md`. 
- Reworked `docs/troubleshooting.md` from developer build-centric guidance into concise, end-user troubleshooting steps that reference existing UI actions such as **Tools → Download GDTF** and **Tools → Open user library folder**.

### Testing

- Ran `tests/check_perastage_tree_modules.sh` which passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cd164d2188324aacab821fbbfbe37)