### PR TITLE
Docs: add Create-from-text and shortcuts pages; expand user guide, FAQ, and AGENTS policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,10 @@ Keep Perastage clean and modular while continuing to deliver new features, follo
    - If shortcut scope/priority/focus behavior changes, document the
      resolution and precedence impact in that file.
 
+9. **User documentation sync policy**
+   - Whenever future Codex tasks add, remove, rename, or significantly change a user-facing feature, workflow, preference, supported file type, installer behavior, import/export behavior, or visible UI behavior, update documentation under `docs/` in the same task.
+   - This is required for meaningful feature changes, and not required for minor internal refactors, small bug fixes, formatting-only changes, build-system maintenance, or invisible technical changes that do not affect user experience.
+
 ## Current hotspots (watch for growth)
 - `gui/layoutviewerpanel.cpp`
 - `viewer2d/viewer2dpanel.cpp`

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Recent 3D optimization updates depend on `meshoptimizer`; if you prepare depende
 
 ## User Guide
 
-**User Guide:** [`/docs/index.md`](docs/index.md)
+**User Guide (GitHub Pages entry):** [docs/index.md](docs/index.md)
 
 ## Documentation
 

--- a/docs/create-from-text.md
+++ b/docs/create-from-text.md
@@ -1,0 +1,55 @@
+# Create from Text
+
+Use **Tools → Create from text** to build scene content from rider-style text.
+
+## Supported inputs
+
+- Pasted text
+- `.txt` files
+- `.pdf` files (text extracted before parsing)
+
+## Typical workflow
+
+1. Open **Tools → Create from text**.
+2. Paste text or load a rider file.
+3. Click **Apply filter** to normalize and clean candidate lines.
+4. Review and optionally edit the filtered text.
+5. Click **Create** to generate scene elements.
+
+## What gets created
+
+Depending on parsed content, Perastage can create:
+
+- Fixtures
+- Trusses
+- Hoists/motors
+- Scene objects (for example, screen-like entries)
+
+## Parsing highlights
+
+Current parser behavior includes:
+
+- Quantity + type fixture lines (for example, `12 Spot`)
+- Compound lines split by `+` (for example, `8 Wash + 4 Beam`)
+- Hang/position detection (`LX1`, `LX2`, `FLOOR`, `SIDES`, `SCREEN`, `BACKDROP`)
+- Truss/pipe parsing with optional hang target
+- Hoist/motor extraction from rigging lines
+- Optional coordinate and margin hints in rigging targets
+
+## Autocomplete in the editor
+
+The dialog includes autocomplete for common workflow keywords and local dictionary terms.
+
+Local editor shortcuts:
+
+- `↑` / `↓` to navigate suggestions
+- `Enter` or `Tab` to insert the selected suggestion
+- `Esc` to close suggestions only
+
+## After creation
+
+- Validate results in Fixtures, Trusses, Hoists, and Objects tables.
+- Cross-check placement in both 2D and 3D views.
+- Save the project, then export MVR when exchange is needed.
+
+For full parser detail and normalization rules, see [Text-to-scene rules](text_to_scene_rules.md).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,20 +2,40 @@
 
 ## Is Perastage a real-time DMX visualizer?
 
-No. Perastage is mainly a practical MVR viewer and scene workflow tool.
+No. Perastage is focused on practical MVR viewing and scene workflow tasks.
 
-## What file type does Perastage focus on?
+## What file type is the main focus?
 
 MVR (`.mvr`).
 
-## Can I export to MVR?
+## Can I import and export MVR?
 
-Yes. Use **File → Export MVR...**.
+Yes. Use **File → Import MVR...** and **File → Export MVR...**.
+
+## Does Perastage support project-based work?
+
+Yes. You can save project progress and continue editing before final export.
 
 ## Can I work in both 2D and 3D?
 
-Yes. Perastage includes both views for scene review.
+Yes. Perastage includes both views and they are intended to be used together.
 
-## Can I download GDTF files from inside the app?
+## Is PDF output available for layouts?
 
-Yes, if you have a GDTF Share account. Use **Tools → Download GDTF**.
+Yes. 2D layout workflows include PDF export for print/share use.
+
+## Can I download GDTF files inside the app?
+
+Yes, with a valid GDTF Share account, using **Tools → Download GDTF**.
+
+## Where is my user library folder?
+
+Use **Tools → Open user library folder**. On Windows, it is typically `%APPDATA%\Perastage\library\`.
+
+## Are keyboard shortcuts available?
+
+Yes. Perastage includes global and viewer shortcuts (fit view, tabs, viewport presets) plus local shortcuts in **Create from text** autocomplete. See [Shortcuts and command bar](shortcuts-and-command-bar.md).
+
+## Is there a command bar or console workflow?
+
+Yes. Perastage supports command-bar workflows, including shortcut-prefill actions for faster command entry.

--- a/docs/gdtf-download.md
+++ b/docs/gdtf-download.md
@@ -4,14 +4,21 @@ Perastage can download fixture profiles from GDTF Share.
 
 ## Before you start
 
-- You need a valid GDTF Share account.
+- You need an active GDTF Share account.
+- Internet access is required for login and downloads.
 
-## Steps
+## Download workflow
 
-1. In Perastage, open **Tools → Download GDTF**.
-2. Log in with your GDTF Share account when prompted.
-3. Search and download the fixture profile you need.
+1. Open **Tools → Download GDTF**.
+2. Sign in when prompted.
+3. Search for the fixture profile you need.
+4. Download and store it in your local user library.
 
-If needed, you can manage local dictionary entries from:
+## Related tools
 
-- **Tools → Edit dictionaries**
+- **Tools → Edit dictionaries** to manage local mapping and dictionary entries.
+- **Tools → Open user library folder** to inspect downloaded files directly.
+
+## When to use this
+
+Use GDTF download when fixtures appear generic, missing, or visually incorrect after opening/importing MVR content.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,25 +1,38 @@
 # Perastage User Guide
 
-Welcome! This guide helps you get started with Perastage as a user.
+Welcome to the Perastage user documentation.
 
-Perastage is a desktop app for opening, reviewing, and working with MVR lighting files.
+Perastage is a desktop application focused on opening, reviewing, editing, and exporting MVR lighting projects with practical 2D and 3D workflows.
 
-## Navigation
+## Start here
 
 - [Installation](installation.md)
 - [Quick Start](quick-start.md)
 - [Opening MVR Files](opening-mvr-files.md)
 - [Download GDTF Files](gdtf-download.md)
 - [Views (2D and 3D)](views.md)
+- [Create from text](create-from-text.md)
+- [Shortcuts and command bar](shortcuts-and-command-bar.md)
 - [Preferences](preferences.md)
 - [Troubleshooting](troubleshooting.md)
 - [FAQ](faq.md)
 
 ## What you can do in Perastage
 
-- Open and inspect `.mvr` scenes.
-- Review fixtures, trusses, hoists, and objects.
-- Use 3D and plan-focused 2D views.
-- Import and export MVR.
-- Use **Tools → Create from text** to build scene content from text.
-- Download GDTF profiles with a GDTF Share account.
+- Open and review `.mvr` scene files.
+- Save work as Perastage project files and continue later.
+- Import and export MVR for exchange with other tools.
+- Inspect scenes in both 3D and layout-focused 2D views.
+- Work with fixture, truss, hoist, and object tables.
+- Export 2D layouts to PDF for sharing and print workflows.
+- Download missing fixture profiles from GDTF Share.
+- Build scene content from text with **Tools → Create from text**.
+- Speed up setup with **Auto patch** and **Auto color** tools.
+- Open and manage your local user library folder.
+
+## Recommended learning path
+
+1. Install Perastage from the latest release.
+2. Follow [Quick Start](quick-start.md) with a sample MVR file.
+3. Learn [Views](views.md) and table workflows.
+4. Review [Troubleshooting](troubleshooting.md) and [FAQ](faq.md) for common issues.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,18 +4,23 @@ Perastage is a cross-platform desktop application.
 
 ## Recommended method
 
-1. Open the project's GitHub releases page.
-2. Download the latest package for your platform.
-3. Install and launch Perastage.
+1. Open the latest release page in this repository.
+2. Download the package for your operating system.
+3. Install the app and launch Perastage.
 
-## Windows user library location
+## First-run library location
 
-Perastage stores editable library data in your user profile, not inside Program Files.
+Perastage stores editable user library data in your user profile folder.
 
-Default location:
+On Windows, the default location is:
 
 - `%APPDATA%\Perastage\library\`
 
-You can also open this folder from inside the app:
+You can open the folder directly from inside the app:
 
 - **Tools → Open user library folder**
+
+## Notes
+
+- Keep your user library folder backed up if you maintain custom dictionary entries or downloaded fixture profiles.
+- If installation succeeds but content looks incomplete, review [Download GDTF Files](gdtf-download.md).

--- a/docs/opening-mvr-files.md
+++ b/docs/opening-mvr-files.md
@@ -1,18 +1,32 @@
 # Opening MVR Files
 
-Perastage is focused on MVR workflows.
+Perastage is built for MVR-centered workflows.
 
-## Open or import an MVR
+## Open an MVR file
 
 Use one of these methods:
 
-- Open an existing `.mvr` file from the file workflow.
+- Open an existing `.mvr` file directly.
 - Use **File → Import MVR...**.
 
-After import, Perastage loads the scene so you can review fixtures, trusses, hoists, and objects.
+After import, review fixtures, trusses, hoists, objects, and layout information in the available views and tables.
 
-## Export back to MVR
+## Perastage project files
 
-When you finish changes, you can export the scene using:
+In addition to MVR exchange, Perastage supports project-based work so you can:
 
-- **File → Export MVR...**
+- Save in-progress work.
+- Reopen and continue edits later.
+- Keep iterative scene revisions while preparing a final export.
+
+## Export MVR
+
+When your changes are ready for exchange:
+
+1. Open **File → Export MVR...**.
+2. Choose destination and file name.
+3. Export the updated scene.
+
+## Practical tip
+
+If imported fixtures appear incomplete, download the required GDTF profiles first, then reopen or refresh your scene review workflow.

--- a/docs/preferences.md
+++ b/docs/preferences.md
@@ -1,15 +1,21 @@
 # Preferences
 
-Perastage includes a Preferences dialog for user settings.
+Perastage includes a Preferences dialog for user-level behavior and display settings.
 
-## What you can configure
+## Common settings
 
 Current user-facing preferences include:
 
-- Distance units.
-- Weight units.
-- GDTF-related settings.
+- Distance units
+- Weight units
+- GDTF-related settings
 
-## Why this matters
+## Why preferences matter
 
-Changing units affects how values are shown in the UI while the app keeps a consistent internal scene model.
+- Unit settings affect how values are shown in the interface.
+- GDTF-related options affect fixture profile handling and lookup behavior.
+- Preferences help keep the app aligned with your workflow without changing scene data intent.
+
+## Good practice
+
+After changing preferences, recheck your scene in both 2D and 3D and verify table values display as expected.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,12 +1,46 @@
 # Quick Start
 
-Use these steps for a fast first session.
+Use this short workflow for your first productive session.
 
-1. Launch Perastage.
-2. Open an MVR file (see [Opening MVR Files](opening-mvr-files.md)).
-3. Explore the scene in 3D and 2D views.
-4. Check fixtures, trusses, hoists, and objects in the panels/tables.
-5. (Optional) Use **Tools → Create from text** to create elements from rider-style notes.
-6. Save your work and export to MVR when needed.
+## 1) Open a scene
 
-Tip: If fixture definitions are missing, use GDTF download (see [Download GDTF Files](gdtf-download.md)).
+1. Start Perastage.
+2. Open an existing `.mvr` file.
+3. Confirm scene elements load in the main views.
+
+For file-open options, see [Opening MVR Files](opening-mvr-files.md).
+
+## 2) Inspect in 3D and 2D
+
+1. Review positions and structure in 3D.
+2. Switch to 2D for plan-style layout checks.
+3. Compare the same selected elements across both views.
+
+For details, see [Views (2D and 3D)](views.md).
+
+For text-based scene generation, see [Create from text](create-from-text.md).
+
+## 3) Review tables
+
+Use the scene tables to validate and organize data:
+
+- Fixtures
+- Trusses
+- Hoists
+- Objects
+
+## 4) Use productivity tools (optional)
+
+When needed, use:
+
+- **Tools → Create from text** to generate scene content from structured text notes.
+- **Auto patch** to assign addresses faster.
+- **Auto color** to quickly apply color grouping.
+
+## 5) Save and export
+
+1. Save your working project file to continue later.
+2. Export to `.mvr` when you need to exchange the scene.
+3. Export layouts to PDF when you need print/share output.
+
+If fixtures are missing or generic, continue with [Download GDTF Files](gdtf-download.md).

--- a/docs/shortcuts-and-command-bar.md
+++ b/docs/shortcuts-and-command-bar.md
@@ -1,0 +1,46 @@
+# Shortcuts and Command Bar
+
+This page summarizes keyboard shortcuts and command-bar workflows available to end users.
+
+## Global and viewer shortcuts
+
+The current shortcut map includes:
+
+- `Z` → Fit view (2D/3D, depending on focused viewer)
+- `P` → Prefill position command in the command bar
+- `R` → Prefill rotation command in the command bar
+- `F` → Prefill fixture command in the command bar
+- `1` → Open Fixtures tab
+- `2` → Open Trusses tab
+- `3` → Open Supports/Hoists tab
+- `4` → Open Objects tab
+- `NumPad1` → Front view (2D/3D)
+- `NumPad3` → Side view (2D/3D)
+- `NumPad7` → Top view (2D/3D)
+- `NumPad5` → Reset 3D viewport
+
+## Command bar workflow
+
+Perastage includes a command-bar/console workflow for fast scene operations.
+
+Practical use:
+
+1. Focus the command bar.
+2. Use shortcut prefill (`P`, `R`, `F`) when helpful.
+3. Edit the command text.
+4. Execute and review the result in tables and viewers.
+5. Reuse command history for repetitive tasks.
+
+## Focus behavior and priority
+
+- Shortcuts are blocked while typing in editable text fields/cells.
+- Viewer shortcuts run in the currently focused viewer context.
+- Dialog-local shortcuts (for example, Create from text autocomplete) stay local to that dialog.
+
+## Create from text local shortcuts
+
+Inside **Tools → Create from text**, the editor autocomplete supports:
+
+- `↑` / `↓` to move through suggestions
+- `Enter` or `Tab` to accept the selected suggestion
+- `Esc` to close suggestions (without closing the dialog)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,31 +1,37 @@
 # Troubleshooting
 
-If something does not work as expected, try these quick checks.
+If Perastage does not behave as expected, use these quick checks.
 
-## MVR file will not open
+## MVR file does not open
 
-- Confirm the file is a valid `.mvr`.
-- Try opening a different MVR file to compare behavior.
-- Restart Perastage and open again.
+- Confirm the file extension is `.mvr`.
+- Try a different MVR file to isolate whether the issue is file-specific.
+- Restart Perastage and retry import/open.
 
-## Missing or incorrect fixture appearance
+## Fixtures look missing or incorrect
 
-- Check whether the required GDTF profile is available.
-- Download the profile from **Tools → Download GDTF**.
-- Review dictionary mappings in **Tools → Edit dictionaries**.
+- Download required profiles in **Tools → Download GDTF**.
+- Check local mappings in **Tools → Edit dictionaries**.
+- Reopen the scene after downloading missing profiles.
 
-## Cannot find your local library files
+## Cannot find local library content
 
-Open:
+Open the location from:
 
 - **Tools → Open user library folder**
 
-On Windows, library files are typically under:
+On Windows, the default path is:
 
 - `%APPDATA%\Perastage\library\`
 
-## App feels out of sync after many edits
+## Layout or print output is not as expected
 
-- Save your project.
-- Close and reopen the file.
-- Recheck the scene in both 2D and 3D views.
+- Recheck the scene in 2D before exporting.
+- Verify table values for fixtures/trusses/hoists/objects.
+- Export PDF again after confirming layout adjustments.
+
+## Scene seems inconsistent after many edits
+
+- Save the project.
+- Close and reopen it.
+- Revalidate critical items in both 2D and 3D views.

--- a/docs/views.md
+++ b/docs/views.md
@@ -1,25 +1,33 @@
 # Views (2D and 3D)
 
-Perastage includes both 3D and plan-style 2D viewing.
+Perastage combines 3D scene inspection with 2D layout-oriented review.
 
-## 3D View
+## 3D view
 
-Use the 3D view to inspect geometry and scene structure.
+Use 3D when you need spatial understanding.
 
-Typical use cases:
+Typical checks:
 
-- Check placement and orientation.
-- Review fixture/truss/object relationships.
+- Position and orientation.
+- Relationships between fixtures, trusses, hoists, and objects.
+- General scene structure before export.
 
-## 2D View
+## 2D view and layouts
 
-Use the 2D view for plan-focused checks and layout-style review.
+Use 2D when you need plan-oriented validation and output.
 
-Typical use cases:
+Typical checks:
 
-- Quick top/plan reading.
-- Preparing printable view outputs.
+- Top/plan readability.
+- Layout alignment and coverage.
+- Print-ready preparation.
 
-## Helpful workflow
+You can export layout-oriented output as PDF for sharing or printing.
 
-Switch between 3D and 2D while selecting the same scene items to validate both spatial and plan representation.
+## Tables and views together
+
+Best practice is to combine visual review with table review:
+
+- Validate elements in Fixtures, Trusses, Hoists, and Objects tables.
+- Cross-check selected elements in 2D and 3D.
+- Confirm updates before saving or exporting MVR.


### PR DESCRIPTION
### Motivation
- Provide missing end-user documentation for new and visible features such as the Create from text tool and the command-bar/shortcut workflows and to improve overall user guidance. 
- Make the README and user guide clearer about project and file workflows, GDTF download, and PDF/layout capabilities. 
- Ensure an explicit documentation sync policy is recorded so future user-facing changes update `docs/` accordingly.

### Description
- Add `docs/create-from-text.md` which documents the Create from text dialog, supported inputs, parsing highlights, and workflow. 
- Add `docs/shortcuts-and-command-bar.md` which documents global/viewer shortcuts and the command-bar workflow and focus behavior. 
- Update multiple user docs (`docs/index.md`, `docs/faq.md`, `docs/gdtf-download.md`, `docs/installation.md`, `docs/opening-mvr-files.md`, `docs/preferences.md`, `docs/quick-start.md`, `docs/troubleshooting.md`, `docs/views.md`) to expand guidance, clarify workflows, and surface practical tips (PDF export, project files, GDTF download, etc.). 
- Adjust `README.md` wording for the user guide link and minor clarifications. 
- Update `AGENTS.md` to add a new "User documentation sync policy" item that requires updating `docs/` for meaningful user-visible changes.

### Testing
- Built the documentation site locally with `mkdocs build` to validate the new/updated pages and the build completed successfully. 
- No code-level unit tests were modified or required for these documentation-only changes and CI doc-build/lint checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cd420343c8324b2f8e3b7c1df9ea6)