### PR TITLE
Restrict scene object picker to explicit 3D model filter

### DIFF
--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -1378,7 +1378,8 @@ void MainWindow::OnAddSceneObject(wxCommandEvent &WXUNUSED(event)) {
       wxString objDir = wxString::FromUTF8(
           ProjectUtils::GetWritableLibraryPath("scene_objects"));
       wxFileDialog fdlg(this, "Select Object file", objDir, wxEmptyString,
-                        "*.*", wxFD_OPEN | wxFD_FILE_MUST_EXIST);
+                        "3D Models (*.3ds;*.glb)|*.3ds;*.glb",
+                        wxFD_OPEN | wxFD_FILE_MUST_EXIST);
       if (fdlg.ShowModal() != wxID_OK)
         return;
       wxFileName fn(fdlg.GetPath());
@@ -1394,7 +1395,8 @@ void MainWindow::OnAddSceneObject(wxCommandEvent &WXUNUSED(event)) {
   } else {
     wxString objDir = wxString::FromUTF8(
         ProjectUtils::GetWritableLibraryPath("scene_objects"));
-    wxFileDialog fdlg(this, "Select Object file", objDir, wxEmptyString, "*.*",
+    wxFileDialog fdlg(this, "Select Object file", objDir, wxEmptyString,
+                      "3D Models (*.3ds;*.glb)|*.3ds;*.glb",
                       wxFD_OPEN | wxFD_FILE_MUST_EXIST);
     if (fdlg.ShowModal() != wxID_OK)
       return;


### PR DESCRIPTION
### Motivation
- Limit the file chooser in the scene-object add flow to explicit 3D model types instead of a broad wildcard to avoid exposing irrelevant files to users.
- Keep the initial `scene_objects` library path behavior unchanged while narrowing the selectable file types.

### Description
- Updated `gui/mainwindow_menu.cpp` inside `MainWindow::OnAddSceneObject` to replace the `"*.*"` wildcard with the explicit filter `"3D Models (*.3ds;*.glb)|*.3ds;*.glb"` in both dialog creation branches.
- The change affects two `wxFileDialog` constructors (existing-objects branch and empty-scene branch) and does not modify any other logic or UI behavior.
- Preserved the original starting folder obtained from `ProjectUtils::GetWritableLibraryPath("scene_objects")` and left existing function comments and formatting intact.

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ce64199c08324b2e88ce4c78d7ac2)