### PR TITLE
Add OBJ loader and integrate .obj support into model loading and UI

### DIFF
--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -83,6 +83,7 @@
 #include "mainwindow_gdtf_credentials.h"
 #include "support.h"
 #include "trussloader.h"
+#include "loader_obj.h"
 #include "tools/fixture_symbol_generation_tool.h"
 #include "tools/fixture_category_assignment_tool.h"
 #include "trusstablepanel.h"
@@ -144,6 +145,18 @@ HelpMarkdown SplitHelpMarkdown(const std::string &markdown) {
   return result;
 }
 
+
+// Builds the scene-object file filter based on currently available runtime loaders.
+std::string BuildSceneObjectFileFilter() {
+  std::string filter = "3D files (*.glb;*.gltf;*.3ds";
+  std::string patterns = "*.glb;*.gltf;*.3ds";
+  if (IsObjLoaderAvailable()) {
+    filter += ";*.obj";
+    patterns += ";*.obj";
+  }
+  filter += ")|" + patterns + "|All files|*.*";
+  return filter;
+}
 } // namespace
 
 // Builds and registers the main application toolbars.
@@ -1378,7 +1391,7 @@ void MainWindow::OnAddSceneObject(wxCommandEvent &WXUNUSED(event)) {
       wxString objDir = wxString::FromUTF8(
           ProjectUtils::GetWritableLibraryPath("scene_objects"));
       wxFileDialog fdlg(this, "Select Object file", objDir, wxEmptyString,
-                        "*.*", wxFD_OPEN | wxFD_FILE_MUST_EXIST);
+                        wxString::FromUTF8(BuildSceneObjectFileFilter()), wxFD_OPEN | wxFD_FILE_MUST_EXIST);
       if (fdlg.ShowModal() != wxID_OK)
         return;
       wxFileName fn(fdlg.GetPath());
@@ -1394,8 +1407,8 @@ void MainWindow::OnAddSceneObject(wxCommandEvent &WXUNUSED(event)) {
   } else {
     wxString objDir = wxString::FromUTF8(
         ProjectUtils::GetWritableLibraryPath("scene_objects"));
-    wxFileDialog fdlg(this, "Select Object file", objDir, wxEmptyString, "*.*",
-                      wxFD_OPEN | wxFD_FILE_MUST_EXIST);
+    wxFileDialog fdlg(this, "Select Object file", objDir, wxEmptyString,
+                      wxString::FromUTF8(BuildSceneObjectFileFilter()), wxFD_OPEN | wxFD_FILE_MUST_EXIST);
     if (fdlg.ShowModal() != wxID_OK)
       return;
     wxFileName fn(fdlg.GetPath());

--- a/viewer3d/CMakeLists.txt
+++ b/viewer3d/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/labels/label_render_system.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/loader3ds.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/loaderglb.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/loader_obj.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/meshprimitives.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/picking/selectionsystem.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/picking/id_pick_pass.cpp

--- a/viewer3d/loader_obj.cpp
+++ b/viewer3d/loader_obj.cpp
@@ -1,0 +1,140 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "loader_obj.h"
+
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+// Converts OBJ index tokens into absolute zero-based indexes while supporting negative OBJ indexes.
+bool ParseObjIndex(const std::string &token, size_t valueCount, int &outIndex) {
+  if (token.empty())
+    return false;
+  int rawIndex = 0;
+  try {
+    rawIndex = std::stoi(token);
+  } catch (...) {
+    return false;
+  }
+
+  if (rawIndex > 0)
+    outIndex = rawIndex - 1;
+  else if (rawIndex < 0)
+    outIndex = static_cast<int>(valueCount) + rawIndex;
+  else
+    return false;
+
+  return outIndex >= 0 && static_cast<size_t>(outIndex) < valueCount;
+}
+
+} // namespace
+
+// Loads OBJ geometry, preserves provided normals/UVs when valid, and computes fallback normals when missing.
+bool LoadOBJ(const std::string &path, Mesh &outMesh, std::string *errorMessage) {
+  auto setError = [&](const std::string &message) {
+    if (errorMessage)
+      *errorMessage = message;
+    return false;
+  };
+
+  std::ifstream file(path);
+  if (!file.is_open())
+    return setError("Cannot open OBJ file");
+
+  outMesh = Mesh{};
+  outMesh.hasMaterialBaseColor = true;
+  outMesh.materialBaseColor = {0.85f, 0.85f, 0.85f};
+
+  std::vector<float> normals;
+  std::vector<float> texcoords;
+
+  std::string line;
+  size_t lineNumber = 0;
+  while (std::getline(file, line)) {
+    ++lineNumber;
+    if (line.empty() || line[0] == '#')
+      continue;
+
+    std::istringstream ss(line);
+    std::string keyword;
+    ss >> keyword;
+    if (keyword == "v") {
+      float x = 0.0f, y = 0.0f, z = 0.0f;
+      if (!(ss >> x >> y >> z))
+        return setError("Invalid vertex at line " + std::to_string(lineNumber));
+      outMesh.vertices.push_back(x * 1000.0f);
+      outMesh.vertices.push_back(y * 1000.0f);
+      outMesh.vertices.push_back(z * 1000.0f);
+    } else if (keyword == "vn") {
+      float nx = 0.0f, ny = 0.0f, nz = 0.0f;
+      if (!(ss >> nx >> ny >> nz))
+        return setError("Invalid normal at line " + std::to_string(lineNumber));
+      normals.push_back(nx);
+      normals.push_back(ny);
+      normals.push_back(nz);
+    } else if (keyword == "vt") {
+      float u = 0.0f, v = 0.0f;
+      if (!(ss >> u >> v))
+        return setError("Invalid UV at line " + std::to_string(lineNumber));
+      texcoords.push_back(u);
+      texcoords.push_back(v);
+    } else if (keyword == "f") {
+      std::vector<uint32_t> polygon;
+      std::string vertexToken;
+      while (ss >> vertexToken) {
+        const size_t firstSlash = vertexToken.find('/');
+        const std::string vertexIndexToken = vertexToken.substr(0, firstSlash);
+        int vertexIndex = -1;
+        if (!ParseObjIndex(vertexIndexToken, outMesh.vertices.size() / 3, vertexIndex))
+          return setError("Invalid face vertex index at line " + std::to_string(lineNumber));
+        polygon.push_back(static_cast<uint32_t>(vertexIndex));
+      }
+
+      if (polygon.size() < 3)
+        return setError("Face with less than 3 vertices at line " + std::to_string(lineNumber));
+
+      for (size_t i = 1; i + 1 < polygon.size(); ++i) {
+        outMesh.indices.push_back(polygon[0]);
+        outMesh.indices.push_back(polygon[i]);
+        outMesh.indices.push_back(polygon[i + 1]);
+      }
+    }
+  }
+
+  if (outMesh.vertices.empty() || outMesh.indices.empty())
+    return setError("OBJ file has no usable mesh geometry");
+
+  if (!normals.empty() && normals.size() == outMesh.vertices.size())
+    outMesh.normals = normals;
+  else
+    ComputeNormals(outMesh);
+
+  if (!texcoords.empty() && texcoords.size() == (outMesh.vertices.size() / 3) * 2)
+    outMesh.texcoords = texcoords;
+  else
+    outMesh.texcoords.clear();
+
+  return true;
+}
+
+// Returns true because OBJ loading is compiled into this build.
+bool IsObjLoaderAvailable() { return true; }

--- a/viewer3d/loader_obj.h
+++ b/viewer3d/loader_obj.h
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <string>
+
+#include "mesh.h"
+
+// Loads a Wavefront OBJ mesh into the runtime mesh format and reports a clear error when parsing fails.
+bool LoadOBJ(const std::string &path, Mesh &outMesh, std::string *errorMessage = nullptr);
+
+// Indicates whether OBJ support is compiled and available for UI file filters.
+bool IsObjLoaderAvailable();

--- a/viewer3d/resources/resource_sync_system.cpp
+++ b/viewer3d/resources/resource_sync_system.cpp
@@ -3,6 +3,7 @@
 
 #include "loader3ds.h"
 #include "loaderglb.h"
+#include "loader_obj.h"
 #include "matrixutils.h"
 #include "projectutils.h"
 
@@ -439,6 +440,12 @@ void EnsureModelLoaded(const std::string &path, ResourceSyncState &state,
       loaded = Load3DS(path, mesh);
     else if (ext == ".glb")
       loaded = LoadGLB(path, mesh);
+    else if (ext == ".obj") {
+      std::string objError;
+      loaded = LoadOBJ(path, mesh, &objError);
+      if (!loaded && callbacks.appendConsoleMessage)
+        callbacks.appendConsoleMessage("Failed to load OBJ model: " + path + " (" + objError + ")");
+    }
 
     if (loaded && meshProcessingOptions.enableMeshOptimization)
       viewer3d::resources::OptimizeMeshForRuntime(mesh);
@@ -452,7 +459,7 @@ void EnsureModelLoaded(const std::string &path, ResourceSyncState &state,
       callbacks.setupMeshBuffers(mesh);
     state.loadedMeshes[path] = std::move(mesh);
     assetsChanged = true;
-  } else if (callbacks.appendConsoleMessage) {
+  } else if (callbacks.appendConsoleMessage && ext != ".obj") {
     callbacks.appendConsoleMessage("Failed to load model: " + path);
   }
 }


### PR DESCRIPTION
### Motivation
- Provide native support for Wavefront `.obj` scene-object files so users can add simple OBJ models directly without requiring external conversion to GLB. 
- Surface clear, actionable console errors when an OBJ fails to parse or load so users understand why a model import failed. 
- Expose `.obj` in the "Add scene object..." file dialog only when a loader implementation is available to avoid offering unsupported choices in the UI.

### Description
- Added a new dedicated loader module `viewer3d/loader_obj.h` and `viewer3d/loader_obj.cpp` implementing `LoadOBJ(...)` and `IsObjLoaderAvailable()`, which triangulates polygon faces, imports positions (converted to millimeters), preserves normals/UVs when valid, computes fallback normals when missing, and assigns a neutral default material color. 
- Extended `viewer3d/resources/resource_sync_system.cpp` (`EnsureModelLoaded`) to include an `.obj` branch that calls `LoadOBJ(...)` and reports specific parse/load failure messages through the provided `appendConsoleMessage` callback. 
- Updated `gui/mainwindow_menu.cpp` to add `BuildSceneObjectFileFilter()` and use it for the "Add scene object..." file dialogs so `*.obj` is included only when `IsObjLoaderAvailable()` returns true. 
- Registered the new source in `viewer3d/CMakeLists.txt` so the OBJ loader is compiled into the viewer. 
- Added concise one-line English comments above the new/updated function definitions introduced in this change to document each function's purpose while keeping existing logic and formatting intact.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed (`OK`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d5a1b7e7083248f711f0ecbdb0529)