### PR TITLE
Add OBJ loader and import-time OBJ→GLB conversion

### DIFF
--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cctype>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -69,6 +70,7 @@
 #include "layerpanel.h"
 #include "layoutpanel.h"
 #include "layoutviewerpanel.h"
+#include "loader_obj.h"
 #include "logindialog.h"
 #include "markdown.h"
 #include "preferencesdialog.h"
@@ -1351,6 +1353,44 @@ void MainWindow::OnAddTruss(wxCommandEvent &WXUNUSED(event)) {
   RefreshSummary();
 }
 
+
+// Converts imported OBJ files into GLB assets so MVR exports always reference official GLB resources.
+std::string NormalizeImportedObjectModelPathToGlb(const std::string &selectedPath,
+                                                  const std::string &sceneBasePath,
+                                                  std::string &consoleError) {
+  namespace fs = std::filesystem;
+  fs::path sourcePath = fs::u8path(selectedPath);
+  std::string ext = sourcePath.extension().string();
+  std::transform(ext.begin(), ext.end(), ext.begin(), [](unsigned char c) {
+    return static_cast<char>(std::tolower(c));
+  });
+  if (ext != ".obj")
+    return selectedPath;
+
+  const fs::path writableObjectsDir =
+      fs::u8path(ProjectUtils::GetWritableLibraryPath("scene_objects"));
+  const std::string targetName = sourcePath.stem().string() + ".glb";
+  const fs::path targetPath = writableObjectsDir / targetName;
+
+  std::string conversionError;
+  if (!ConvertObjFileToGlb(sourcePath.string(), targetPath.string(), &conversionError)) {
+    consoleError = "Failed converting OBJ to GLB: " + conversionError;
+    return selectedPath;
+  }
+
+  if (!sceneBasePath.empty()) {
+    std::error_code ec;
+    const fs::path absTarget = fs::weakly_canonical(targetPath, ec);
+    const fs::path absBase = fs::weakly_canonical(fs::u8path(sceneBasePath), ec);
+    if (!ec && !absTarget.empty() && !absBase.empty() &&
+        absTarget.string().rfind(absBase.string(), 0) == 0) {
+      return fs::relative(absTarget, absBase, ec).string();
+    }
+  }
+
+  return targetPath.string();
+}
+
 // Adds one or more scene objects to the scene from a selected model file.
 void MainWindow::OnAddSceneObject(wxCommandEvent &WXUNUSED(event)) {
   ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
@@ -1378,7 +1418,7 @@ void MainWindow::OnAddSceneObject(wxCommandEvent &WXUNUSED(event)) {
       wxString objDir = wxString::FromUTF8(
           ProjectUtils::GetWritableLibraryPath("scene_objects"));
       wxFileDialog fdlg(this, "Select Object file", objDir, wxEmptyString,
-                        "3D Models (*.3ds;*.glb)|*.3ds;*.glb",
+                        "3D Models (*.3ds;*.glb;*.obj)|*.3ds;*.glb;*.obj",
                         wxFD_OPEN | wxFD_FILE_MUST_EXIST);
       if (fdlg.ShowModal() != wxID_OK)
         return;
@@ -1396,7 +1436,7 @@ void MainWindow::OnAddSceneObject(wxCommandEvent &WXUNUSED(event)) {
     wxString objDir = wxString::FromUTF8(
         ProjectUtils::GetWritableLibraryPath("scene_objects"));
     wxFileDialog fdlg(this, "Select Object file", objDir, wxEmptyString,
-                      "3D Models (*.3ds;*.glb)|*.3ds;*.glb",
+                      "3D Models (*.3ds;*.glb;*.obj)|*.3ds;*.glb;*.obj",
                       wxFD_OPEN | wxFD_FILE_MUST_EXIST);
     if (fdlg.ShowModal() != wxID_OK)
       return;
@@ -1413,6 +1453,10 @@ void MainWindow::OnAddSceneObject(wxCommandEvent &WXUNUSED(event)) {
   namespace fs = std::filesystem;
   cfg.PushUndoState("add scene object");
   std::string base = scene.basePath;
+  std::string conversionError;
+  path = NormalizeImportedObjectModelPathToGlb(path, base, conversionError);
+  if (!conversionError.empty() && ConsolePanel::Instance())
+    ConsolePanel::Instance()->AppendMessage(wxString::FromUTF8(conversionError));
   if (!base.empty()) {
     fs::path abs = fs::absolute(path);
     fs::path b = fs::absolute(base);

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -1367,10 +1367,20 @@ std::string NormalizeImportedObjectModelPathToGlb(const std::string &selectedPat
   if (ext != ".obj")
     return selectedPath;
 
-  const fs::path writableObjectsDir =
-      fs::u8path(ProjectUtils::GetWritableLibraryPath("scene_objects"));
-  const std::string targetName = sourcePath.stem().string() + ".glb";
-  const fs::path targetPath = writableObjectsDir / targetName;
+  std::error_code ec;
+  const fs::path tempRoot = fs::temp_directory_path(ec);
+  const fs::path importTempDir = tempRoot / "perastage_imported_objects";
+  fs::create_directories(importTempDir, ec);
+  if (ec) {
+    consoleError = "Failed preparing temporary directory for OBJ import conversion";
+    return selectedPath;
+  }
+
+  const std::string uniqueSuffix = std::to_string(
+      static_cast<long long>(std::chrono::steady_clock::now().time_since_epoch().count()));
+  const std::string targetName =
+      sourcePath.stem().string() + "_" + uniqueSuffix + ".glb";
+  const fs::path targetPath = importTempDir / targetName;
 
   std::string conversionError;
   if (!ConvertObjFileToGlb(sourcePath.string(), targetPath.string(), &conversionError)) {
@@ -1379,7 +1389,6 @@ std::string NormalizeImportedObjectModelPathToGlb(const std::string &selectedPat
   }
 
   if (!sceneBasePath.empty()) {
-    std::error_code ec;
     const fs::path absTarget = fs::weakly_canonical(targetPath, ec);
     const fs::path absBase = fs::weakly_canonical(fs::u8path(sceneBasePath), ec);
     if (!ec && !absTarget.empty() && !absBase.empty() &&

--- a/viewer3d/CMakeLists.txt
+++ b/viewer3d/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/labels/label_render_system.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/loader3ds.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/loaderglb.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/loader_obj.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/meshprimitives.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/picking/selectionsystem.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/picking/id_pick_pass.cpp

--- a/viewer3d/loader_obj.cpp
+++ b/viewer3d/loader_obj.cpp
@@ -1,0 +1,266 @@
+#include "loader_obj.h"
+
+#include "matrixutils.h"
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <unordered_map>
+#include <vector>
+
+namespace {
+
+struct ObjIndex {
+  int v = -1;
+  int vt = -1;
+  int vn = -1;
+
+  bool operator==(const ObjIndex &other) const {
+    return v == other.v && vt == other.vt && vn == other.vn;
+  }
+};
+
+struct ObjIndexHash {
+  size_t operator()(const ObjIndex &idx) const {
+    return (static_cast<size_t>(idx.v + 1) * 73856093u) ^
+           (static_cast<size_t>(idx.vt + 1) * 19349663u) ^
+           (static_cast<size_t>(idx.vn + 1) * 83492791u);
+  }
+};
+
+// Parses a signed OBJ index token and resolves it to a zero-based absolute index.
+bool ParseObjIndexToken(const std::string &token, int count, int &outIndex) {
+  if (token.empty())
+    return false;
+  int raw = std::stoi(token);
+  if (raw > 0)
+    outIndex = raw - 1;
+  else if (raw < 0)
+    outIndex = count + raw;
+  else
+    return false;
+  return outIndex >= 0 && outIndex < count;
+}
+
+// Parses one OBJ face vertex entry in the form v, v/vt, v//vn, or v/vt/vn.
+bool ParseFaceVertexToken(const std::string &token, int vCount, int vtCount,
+                          int vnCount, ObjIndex &outIndex) {
+  std::array<std::string, 3> parts;
+  size_t partIndex = 0;
+  size_t start = 0;
+  for (size_t i = 0; i <= token.size() && partIndex < parts.size(); ++i) {
+    if (i == token.size() || token[i] == '/') {
+      parts[partIndex++] = token.substr(start, i - start);
+      start = i + 1;
+    }
+  }
+  if (parts[0].empty() || !ParseObjIndexToken(parts[0], vCount, outIndex.v))
+    return false;
+  if (!parts[1].empty() && !ParseObjIndexToken(parts[1], vtCount, outIndex.vt))
+    return false;
+  if (!parts[2].empty() && !ParseObjIndexToken(parts[2], vnCount, outIndex.vn))
+    return false;
+  return true;
+}
+
+// Writes little-endian uint32 values into a binary output buffer.
+void AppendU32(std::vector<uint8_t> &out, uint32_t value) {
+  out.push_back(static_cast<uint8_t>(value & 0xffu));
+  out.push_back(static_cast<uint8_t>((value >> 8u) & 0xffu));
+  out.push_back(static_cast<uint8_t>((value >> 16u) & 0xffu));
+  out.push_back(static_cast<uint8_t>((value >> 24u) & 0xffu));
+}
+
+// Appends arbitrary raw bytes into a binary output buffer.
+void AppendBytes(std::vector<uint8_t> &out, const void *data, size_t size) {
+  const uint8_t *begin = static_cast<const uint8_t *>(data);
+  out.insert(out.end(), begin, begin + size);
+}
+
+// Pads a binary chunk to the required 4-byte alignment.
+void PadTo4(std::vector<uint8_t> &out, uint8_t fillByte) {
+  while ((out.size() % 4u) != 0u)
+    out.push_back(fillByte);
+}
+
+} // namespace
+
+// Loads an OBJ mesh and guarantees usable normals/UVs/material defaults for runtime rendering.
+bool LoadOBJ(const std::string &path, Mesh &outMesh, std::string *errorMessage) {
+  outMesh.vertices.clear();
+  outMesh.indices.clear();
+  outMesh.normals.clear();
+  outMesh.uvs.clear();
+  outMesh.vertexColors.clear();
+  outMesh.textureRgba.clear();
+  outMesh.textureWidth = 0;
+  outMesh.textureHeight = 0;
+
+  std::ifstream file(path);
+  if (!file.is_open()) {
+    if (errorMessage)
+      *errorMessage = "could not open OBJ file";
+    return false;
+  }
+
+  std::vector<std::array<float, 3>> positions;
+  std::vector<std::array<float, 3>> normals;
+  std::vector<std::array<float, 2>> texcoords;
+
+  std::unordered_map<ObjIndex, uint32_t, ObjIndexHash> uniqueMap;
+  std::string line;
+  while (std::getline(file, line)) {
+    if (line.empty() || line[0] == '#')
+      continue;
+    std::istringstream iss(line);
+    std::string cmd;
+    iss >> cmd;
+    if (cmd == "v") {
+      std::array<float, 3> p{};
+      if (!(iss >> p[0] >> p[1] >> p[2]))
+        continue;
+      positions.push_back(p);
+    } else if (cmd == "vn") {
+      std::array<float, 3> n{};
+      if (!(iss >> n[0] >> n[1] >> n[2]))
+        continue;
+      normals.push_back(n);
+    } else if (cmd == "vt") {
+      std::array<float, 2> t{};
+      if (!(iss >> t[0] >> t[1]))
+        continue;
+      texcoords.push_back(t);
+    } else if (cmd == "f") {
+      std::vector<ObjIndex> face;
+      std::string token;
+      while (iss >> token) {
+        ObjIndex idx;
+        if (!ParseFaceVertexToken(token, static_cast<int>(positions.size()),
+                                  static_cast<int>(texcoords.size()),
+                                  static_cast<int>(normals.size()), idx)) {
+          if (errorMessage)
+            *errorMessage = "invalid face index in OBJ";
+          return false;
+        }
+        face.push_back(idx);
+      }
+      if (face.size() < 3)
+        continue;
+      for (size_t i = 1; i + 1 < face.size(); ++i) {
+        const ObjIndex tri[3] = {face[0], face[i], face[i + 1]};
+        for (const ObjIndex &corner : tri) {
+          auto it = uniqueMap.find(corner);
+          if (it == uniqueMap.end()) {
+            const uint32_t newIndex = static_cast<uint32_t>(outMesh.vertices.size() / 3);
+            uniqueMap.emplace(corner, newIndex);
+            const auto &p = positions[static_cast<size_t>(corner.v)];
+            outMesh.vertices.insert(outMesh.vertices.end(), {p[0], p[1], p[2]});
+            if (corner.vn >= 0) {
+              const auto &n = normals[static_cast<size_t>(corner.vn)];
+              outMesh.normals.insert(outMesh.normals.end(), {n[0], n[1], n[2]});
+            }
+            if (corner.vt >= 0) {
+              const auto &t = texcoords[static_cast<size_t>(corner.vt)];
+              outMesh.uvs.insert(outMesh.uvs.end(), {t[0], 1.0f - t[1]});
+            }
+            outMesh.indices.push_back(newIndex);
+          } else {
+            outMesh.indices.push_back(it->second);
+          }
+        }
+      }
+    }
+  }
+
+  if (outMesh.vertices.empty() || outMesh.indices.empty()) {
+    if (errorMessage)
+      *errorMessage = "OBJ does not contain triangulatable geometry";
+    return false;
+  }
+
+  const size_t vertexCount = outMesh.vertices.size() / 3;
+  if (outMesh.normals.size() != outMesh.vertices.size())
+    ComputeVertexNormals(outMesh.vertices, outMesh.indices, outMesh.normals);
+  if (outMesh.uvs.size() != vertexCount * 2)
+    outMesh.uvs.assign(vertexCount * 2, 0.0f);
+
+  outMesh.color = {0.85f, 0.85f, 0.85f};
+  outMesh.opacity = 1.0f;
+  return true;
+}
+
+// Converts an OBJ mesh into a compact GLB file that can be embedded into MVR exports.
+bool ConvertObjFileToGlb(const std::string &objPath, const std::string &glbPath,
+                         std::string *errorMessage) {
+  Mesh mesh;
+  if (!LoadOBJ(objPath, mesh, errorMessage))
+    return false;
+
+  std::vector<uint8_t> bin;
+  const auto appendAligned = [&](const void *ptr, size_t bytes) -> uint32_t {
+    const uint32_t offset = static_cast<uint32_t>(bin.size());
+    AppendBytes(bin, ptr, bytes);
+    PadTo4(bin, 0);
+    return offset;
+  };
+
+  const uint32_t posOffset = appendAligned(mesh.vertices.data(), mesh.vertices.size() * sizeof(float));
+  const uint32_t normOffset = appendAligned(mesh.normals.data(), mesh.normals.size() * sizeof(float));
+  const uint32_t uvOffset = appendAligned(mesh.uvs.data(), mesh.uvs.size() * sizeof(float));
+  const uint32_t idxOffset = appendAligned(mesh.indices.data(), mesh.indices.size() * sizeof(uint32_t));
+
+  const size_t vertexCount = mesh.vertices.size() / 3;
+  std::ostringstream json;
+  json << "{\"asset\":{\"version\":\"2.0\"},"
+       << "\"buffers\":[{\"byteLength\":" << bin.size() << "}],"
+       << "\"bufferViews\":["
+       << "{\"buffer\":0,\"byteOffset\":" << posOffset << ",\"byteLength\":" << mesh.vertices.size() * sizeof(float) << "},"
+       << "{\"buffer\":0,\"byteOffset\":" << normOffset << ",\"byteLength\":" << mesh.normals.size() * sizeof(float) << "},"
+       << "{\"buffer\":0,\"byteOffset\":" << uvOffset << ",\"byteLength\":" << mesh.uvs.size() * sizeof(float) << "},"
+       << "{\"buffer\":0,\"byteOffset\":" << idxOffset << ",\"byteLength\":" << mesh.indices.size() * sizeof(uint32_t) << "}"],"
+       << "\"accessors\":["
+       << "{\"bufferView\":0,\"componentType\":5126,\"count\":" << vertexCount << ",\"type\":\"VEC3\"},"
+       << "{\"bufferView\":1,\"componentType\":5126,\"count\":" << vertexCount << ",\"type\":\"VEC3\"},"
+       << "{\"bufferView\":2,\"componentType\":5126,\"count\":" << vertexCount << ",\"type\":\"VEC2\"},"
+       << "{\"bufferView\":3,\"componentType\":5125,\"count\":" << mesh.indices.size() << ",\"type\":\"SCALAR\"}],"
+       << "\"materials\":[{\"pbrMetallicRoughness\":{\"baseColorFactor\":[0.85,0.85,0.85,1.0],\"metallicFactor\":0.0,\"roughnessFactor\":1.0}}],"
+       << "\"meshes\":[{\"primitives\":[{\"attributes\":{\"POSITION\":0,\"NORMAL\":1,\"TEXCOORD_0\":2},\"indices\":3,\"material\":0}]}],"
+       << "\"nodes\":[{\"mesh\":0}],\"scenes\":[{\"nodes\":[0]}],\"scene\":0}";
+
+  std::string jsonText = json.str();
+  while ((jsonText.size() % 4u) != 0u)
+    jsonText.push_back(' ');
+
+  std::vector<uint8_t> glb;
+  const uint32_t totalLen = static_cast<uint32_t>(12u + 8u + jsonText.size() + 8u + bin.size());
+  AppendU32(glb, 0x46546C67u);
+  AppendU32(glb, 2u);
+  AppendU32(glb, totalLen);
+  AppendU32(glb, static_cast<uint32_t>(jsonText.size()));
+  AppendU32(glb, 0x4E4F534Au);
+  AppendBytes(glb, jsonText.data(), jsonText.size());
+  AppendU32(glb, static_cast<uint32_t>(bin.size()));
+  AppendU32(glb, 0x004E4942u);
+  AppendBytes(glb, bin.data(), bin.size());
+
+  std::filesystem::path outPath(glbPath);
+  std::error_code ec;
+  std::filesystem::create_directories(outPath.parent_path(), ec);
+
+  std::ofstream out(glbPath, std::ios::binary);
+  if (!out.is_open()) {
+    if (errorMessage)
+      *errorMessage = "could not create output GLB file";
+    return false;
+  }
+  out.write(reinterpret_cast<const char *>(glb.data()), static_cast<std::streamsize>(glb.size()));
+  if (!out.good()) {
+    if (errorMessage)
+      *errorMessage = "failed while writing GLB file";
+    return false;
+  }
+  return true;
+}

--- a/viewer3d/loader_obj.cpp
+++ b/viewer3d/loader_obj.cpp
@@ -1,7 +1,5 @@
 #include "loader_obj.h"
 
-#include "matrixutils.h"
-
 #include <algorithm>
 #include <array>
 #include <cstdint>
@@ -18,12 +16,14 @@ struct ObjIndex {
   int vt = -1;
   int vn = -1;
 
+  // Compares two OBJ vertex index tuples to support hash-map deduplication.
   bool operator==(const ObjIndex &other) const {
     return v == other.v && vt == other.vt && vn == other.vn;
   }
 };
 
 struct ObjIndexHash {
+  // Produces a stable hash for combined OBJ position/UV/normal indices.
   size_t operator()(const ObjIndex &idx) const {
     return (static_cast<size_t>(idx.v + 1) * 73856093u) ^
            (static_cast<size_t>(idx.vt + 1) * 19349663u) ^
@@ -93,8 +93,7 @@ bool LoadOBJ(const std::string &path, Mesh &outMesh, std::string *errorMessage) 
   outMesh.vertices.clear();
   outMesh.indices.clear();
   outMesh.normals.clear();
-  outMesh.uvs.clear();
-  outMesh.vertexColors.clear();
+  outMesh.texcoords.clear();
   outMesh.textureRgba.clear();
   outMesh.textureWidth = 0;
   outMesh.textureHeight = 0;
@@ -164,7 +163,7 @@ bool LoadOBJ(const std::string &path, Mesh &outMesh, std::string *errorMessage) 
             }
             if (corner.vt >= 0) {
               const auto &t = texcoords[static_cast<size_t>(corner.vt)];
-              outMesh.uvs.insert(outMesh.uvs.end(), {t[0], 1.0f - t[1]});
+              outMesh.texcoords.insert(outMesh.texcoords.end(), {t[0], 1.0f - t[1]});
             }
             outMesh.indices.push_back(newIndex);
           } else {
@@ -183,12 +182,12 @@ bool LoadOBJ(const std::string &path, Mesh &outMesh, std::string *errorMessage) 
 
   const size_t vertexCount = outMesh.vertices.size() / 3;
   if (outMesh.normals.size() != outMesh.vertices.size())
-    ComputeVertexNormals(outMesh.vertices, outMesh.indices, outMesh.normals);
-  if (outMesh.uvs.size() != vertexCount * 2)
-    outMesh.uvs.assign(vertexCount * 2, 0.0f);
+    ComputeNormals(outMesh);
+  if (outMesh.texcoords.size() != vertexCount * 2)
+    outMesh.texcoords.assign(vertexCount * 2, 0.0f);
 
-  outMesh.color = {0.85f, 0.85f, 0.85f};
-  outMesh.opacity = 1.0f;
+  outMesh.materialBaseColor = {0.85f, 0.85f, 0.85f};
+  outMesh.hasMaterialBaseColor = true;
   return true;
 }
 
@@ -209,7 +208,7 @@ bool ConvertObjFileToGlb(const std::string &objPath, const std::string &glbPath,
 
   const uint32_t posOffset = appendAligned(mesh.vertices.data(), mesh.vertices.size() * sizeof(float));
   const uint32_t normOffset = appendAligned(mesh.normals.data(), mesh.normals.size() * sizeof(float));
-  const uint32_t uvOffset = appendAligned(mesh.uvs.data(), mesh.uvs.size() * sizeof(float));
+  const uint32_t uvOffset = appendAligned(mesh.texcoords.data(), mesh.texcoords.size() * sizeof(float));
   const uint32_t idxOffset = appendAligned(mesh.indices.data(), mesh.indices.size() * sizeof(uint32_t));
 
   const size_t vertexCount = mesh.vertices.size() / 3;
@@ -219,8 +218,8 @@ bool ConvertObjFileToGlb(const std::string &objPath, const std::string &glbPath,
        << "\"bufferViews\":["
        << "{\"buffer\":0,\"byteOffset\":" << posOffset << ",\"byteLength\":" << mesh.vertices.size() * sizeof(float) << "},"
        << "{\"buffer\":0,\"byteOffset\":" << normOffset << ",\"byteLength\":" << mesh.normals.size() * sizeof(float) << "},"
-       << "{\"buffer\":0,\"byteOffset\":" << uvOffset << ",\"byteLength\":" << mesh.uvs.size() * sizeof(float) << "},"
-       << "{\"buffer\":0,\"byteOffset\":" << idxOffset << ",\"byteLength\":" << mesh.indices.size() * sizeof(uint32_t) << "}"],"
+       << "{\"buffer\":0,\"byteOffset\":" << uvOffset << ",\"byteLength\":" << mesh.texcoords.size() * sizeof(float) << "},"
+       << "{\"buffer\":0,\"byteOffset\":" << idxOffset << ",\"byteLength\":" << mesh.indices.size() * sizeof(uint32_t) << "}],"
        << "\"accessors\":["
        << "{\"bufferView\":0,\"componentType\":5126,\"count\":" << vertexCount << ",\"type\":\"VEC3\"},"
        << "{\"bufferView\":1,\"componentType\":5126,\"count\":" << vertexCount << ",\"type\":\"VEC3\"},"

--- a/viewer3d/loader_obj.h
+++ b/viewer3d/loader_obj.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "mesh.h"
+
+#include <string>
+
+// Loads an OBJ mesh with positions/normals/UVs and computes missing attributes when needed.
+bool LoadOBJ(const std::string &path, Mesh &outMesh, std::string *errorMessage = nullptr);
+
+// Converts an OBJ file to a minimal GLB file used as the official persisted model format.
+bool ConvertObjFileToGlb(const std::string &objPath, const std::string &glbPath,
+                         std::string *errorMessage = nullptr);

--- a/viewer3d/resources/resource_sync_system.cpp
+++ b/viewer3d/resources/resource_sync_system.cpp
@@ -3,6 +3,7 @@
 
 #include "loader3ds.h"
 #include "loaderglb.h"
+#include "loader_obj.h"
 #include "matrixutils.h"
 #include "projectutils.h"
 
@@ -439,6 +440,12 @@ void EnsureModelLoaded(const std::string &path, ResourceSyncState &state,
       loaded = Load3DS(path, mesh);
     else if (ext == ".glb")
       loaded = LoadGLB(path, mesh);
+    else if (ext == ".obj") {
+      std::string objError;
+      loaded = LoadOBJ(path, mesh, &objError);
+      if (!loaded && callbacks.appendConsoleMessage)
+        callbacks.appendConsoleMessage("OBJ load failed for " + path + ": " + objError);
+    }
 
     if (loaded && meshProcessingOptions.enableMeshOptimization)
       viewer3d::resources::OptimizeMeshForRuntime(mesh);


### PR DESCRIPTION
### Motivation

- Support importing `.obj` scene-object models and ensure they normalize into the project's official GLB format for MVR exports.
- Provide predictable runtime geometry by defining minimal behavior for normals, UVs and material defaults and surface clear load errors to the console.

### Description

- Added a dedicated OBJ loader module with `LoadOBJ` and `ConvertObjFileToGlb` in `viewer3d/loader_obj.h` and `viewer3d/loader_obj.cpp` that parses `v/vt/vn` data, triangulates polygons, generates normals when missing, fills missing UVs with `0,0`, and applies a neutral default material (light gray, opaque).
- Extended `EnsureModelLoaded` in `viewer3d/resources/resource_sync_system.cpp` to handle `.obj` via `LoadOBJ` and emit OBJ-specific failures via `appendConsoleMessage` when parsing fails.
- Updated import UI flow in `gui/mainwindow_menu.cpp` to include `.obj` in the file filter and added `NormalizeImportedObjectModelPathToGlb` which converts selected `.obj` files to GLB on import and returns a scene-relative path when applicable, logging conversion errors to `ConsolePanel`.
- Registered the new source file in `viewer3d/CMakeLists.txt` to keep explicit source ownership.

### Testing

- Ran mandatory repository checks `tests/check_perastage_tree_modules.sh` which passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d5f544244832485160dbc3af73691)