### PR TITLE
Align orthographic symbol capture and calibration to fixture physical aspect ratios

### DIFF
--- a/gui/tools/scene_model_symbol_capture_service.cpp
+++ b/gui/tools/scene_model_symbol_capture_service.cpp
@@ -1,11 +1,14 @@
 #include "tools/scene_model_symbol_capture_service.h"
 
 #include <array>
+#include <cfloat>
 #include <string>
 #include <unordered_map>
 
 #include "configmanager.h"
 #include "fixture.h"
+#include "fixtures/fixture_gdtf_resolution.h"
+#include "gdtfloader.h"
 #include "matrixutils.h"
 #include "sceneobject.h"
 #include "support.h"
@@ -20,6 +23,31 @@ namespace {
 
 constexpr float kSymbolRdpEpsilon = 1.0f;
 
+struct Bounds3D {
+  std::array<float, 3> min = {FLT_MAX, FLT_MAX, FLT_MAX};
+  std::array<float, 3> max = {-FLT_MAX, -FLT_MAX, -FLT_MAX};
+  bool valid = false;
+};
+
+// Transforms a point by a Matrix using local-space basis vectors and translation.
+std::array<float, 3> TransformPoint(const Matrix &m, const std::array<float, 3> &p) {
+  return {m.u[0] * p[0] + m.v[0] * p[1] + m.w[0] * p[2] + m.o[0],
+          m.u[1] * p[0] + m.v[1] * p[1] + m.w[1] * p[2] + m.o[1],
+          m.u[2] * p[0] + m.v[2] * p[1] + m.w[2] * p[2] + m.o[2]};
+}
+
+// Expands 3D bounds to include a single transformed point.
+void ExtendBounds(Bounds3D &bounds, const std::array<float, 3> &p) {
+  bounds.min[0] = std::min(bounds.min[0], p[0]);
+  bounds.min[1] = std::min(bounds.min[1], p[1]);
+  bounds.min[2] = std::min(bounds.min[2], p[2]);
+  bounds.max[0] = std::max(bounds.max[0], p[0]);
+  bounds.max[1] = std::max(bounds.max[1], p[1]);
+  bounds.max[2] = std::max(bounds.max[2], p[2]);
+  bounds.valid = true;
+}
+
+// Temporarily overrides a fixture color during symbol capture and restores it afterward.
 class ScopedFixtureColorOverride {
 public:
   ScopedFixtureColorOverride(ConfigManager &cfg, const std::string &fixtureUuid,
@@ -49,6 +77,7 @@ private:
   std::vector<std::pair<std::string, std::string>> previous_;
 };
 
+// Temporarily isolates the scene to a single model target for deterministic capture.
 class ScopedSingleModelSceneOverride {
 public:
   ScopedSingleModelSceneOverride(ConfigManager &cfg,
@@ -109,6 +138,7 @@ public:
   }
 
 private:
+  // Rebuilds a transform with identity rotation while preserving scale and translation.
   static Matrix AlignRotationToIdentityKeepingScale(const Matrix &source) {
     Matrix identity = MatrixUtils::Identity();
     return MatrixUtils::ApplyRotationPreservingScale(source, identity, source.o);
@@ -121,6 +151,7 @@ private:
   std::unordered_map<std::string, Support> originalSupports_;
 };
 
+// Saves and restores 2D viewer state so capture does not affect interactive UI state.
 class ScopedViewer2DCaptureState {
 public:
   explicit ScopedViewer2DCaptureState(Viewer2DPanel &panel) : panel_(panel) {
@@ -155,6 +186,7 @@ private:
   bool preferPerastageSvgSymbolsForLayouts_ = false;
 };
 
+// Applies temporary render overrides tailored for high-contrast symbol extraction.
 class ScopedViewer2DRenderOverrides {
 public:
   ScopedViewer2DRenderOverrides(Viewer2DPanel &panel,
@@ -169,6 +201,7 @@ private:
   Viewer2DPanel &panel_;
 };
 
+// Mirrors a rendered RGBA symbol image horizontally in-place.
 void MirrorImageHorizontally(symbols::RenderedSymbolImage &render) {
   if (render.width <= 0 || render.height <= 0)
     return;
@@ -189,8 +222,59 @@ void MirrorImageHorizontally(symbols::RenderedSymbolImage &render) {
   }
 }
 
+// Resolves fixture GDTF geometry bounds for aspect-driven symbol viewport sizing.
+bool TryResolveFixtureBoundsMmForCapture(ConfigManager &cfg,
+                                         const SceneModelSymbolTarget &target,
+                                         Bounds3D &bounds) {
+  if (target.kind != SceneModelKind::Fixture || target.uuid.empty())
+    return false;
+  const auto &fixtures = cfg.GetScene().fixtures;
+  const auto fixtureIt = fixtures.find(target.uuid);
+  if (fixtureIt == fixtures.end())
+    return false;
+
+  gui::fixtures::FixtureGdtfResolution resolution;
+  std::string error;
+  if (!gui::fixtures::ResolveFixtureGdtfDeterministic(fixtureIt->second, cfg.GetScene(),
+                                                       resolution, error))
+    return false;
+
+  std::vector<GdtfObject> objects;
+  if (!LoadGdtf(resolution.selectedPath, objects, &error))
+    return false;
+
+  for (const auto &object : objects) {
+    if (object.isLens)
+      continue;
+    for (size_t vi = 0; vi + 2 < object.mesh.vertices.size(); vi += 3) {
+      const std::array<float, 3> local = {
+          object.mesh.vertices[vi], object.mesh.vertices[vi + 1], object.mesh.vertices[vi + 2]};
+      ExtendBounds(bounds, TransformPoint(object.transform, local));
+    }
+  }
+  return bounds.valid;
+}
+
+// Returns the expected projected width/height ratio for a symbol view from physical bounds.
+float ComputeCaptureAspectForView(const Bounds3D &bounds, symbols::SymbolView view) {
+  const float x = std::max(1e-3f, bounds.max[0] - bounds.min[0]);
+  const float y = std::max(1e-3f, bounds.max[1] - bounds.min[1]);
+  const float z = std::max(1e-3f, bounds.max[2] - bounds.min[2]);
+  switch (view) {
+  case symbols::SymbolView::Top:
+  case symbols::SymbolView::Bottom:
+    return x / y;
+  case symbols::SymbolView::Front:
+    return x / z;
+  case symbols::SymbolView::Left:
+    return y / z;
+  }
+  return 1.0f;
+}
+
 } // namespace
 
+// Captures top/front/side/bottom orthographic renders and converts them into vector symbols.
 SceneModelSymbolCaptureResult
 CaptureSceneModelOrthographicSymbols(Viewer2DOffscreenRenderer &renderer,
                                      ConfigManager &cfg,
@@ -248,8 +332,21 @@ CaptureSceneModelOrthographicSymbols(Viewer2DOffscreenRenderer &renderer,
 
   std::vector<symbols::RenderedSymbolImage> renders;
   renders.reserve(requests.size());
+  Bounds3D fixtureBounds;
+  const bool hasFixtureBounds =
+      TryResolveFixtureBoundsMmForCapture(cfg, target, fixtureBounds);
 
   for (const auto &request : requests) {
+    if (hasFixtureBounds) {
+      const float aspect = ComputeCaptureAspectForView(fixtureBounds, request.symbolView);
+      const int base = std::max(256, std::max(options.viewportSize.GetWidth(),
+                                              options.viewportSize.GetHeight()));
+      const int width = std::max(256, static_cast<int>(aspect >= 1.0f ? base : base * aspect));
+      const int height = std::max(256, static_cast<int>(aspect >= 1.0f ? base / aspect : base));
+      renderer.SetViewportSize(wxSize(width, height));
+    } else {
+      renderer.SetViewportSize(options.viewportSize);
+    }
     renderOverrides.forceBottomViewForTopFixtures =
         request.forceBottomViewForTopFixtures;
     capturePanel->SetRenderOverrides(renderOverrides);

--- a/gui/tools/symbol_physical_calibration.cpp
+++ b/gui/tools/symbol_physical_calibration.cpp
@@ -43,6 +43,7 @@ void ExtendBounds(Bounds3D &bounds, const std::array<float, 3> &p) {
   bounds.valid = true;
 }
 
+// Computes world-space fixture mesh bounds in millimeters from a GDTF file.
 bool ComputeFixtureBoundsMm(const std::string &gdtfPath, Bounds3D &bounds,
                             std::string &errorMessage) {
   std::vector<GdtfObject> objects;
@@ -50,6 +51,8 @@ bool ComputeFixtureBoundsMm(const std::string &gdtfPath, Bounds3D &bounds,
     return false;
 
   for (const auto &object : objects) {
+    if (object.isLens)
+      continue;
     for (size_t vi = 0; vi + 2 < object.mesh.vertices.size(); vi += 3) {
       const std::array<float, 3> local = {
           object.mesh.vertices[vi], object.mesh.vertices[vi + 1], object.mesh.vertices[vi + 2]};
@@ -65,6 +68,7 @@ bool ComputeFixtureBoundsMm(const std::string &gdtfPath, Bounds3D &bounds,
   return true;
 }
 
+// Projects 3D fixture bounds onto the 2D plane associated with a symbol view.
 Bounds2D BuildTargetBounds(const Bounds3D &bounds, symbols::SymbolView view) {
   Bounds2D projected;
   switch (view) {
@@ -82,6 +86,7 @@ Bounds2D BuildTargetBounds(const Bounds3D &bounds, symbols::SymbolView view) {
   return projected;
 }
 
+// Uniformly scales and centers a symbol into the requested physical target bounds.
 bool RemapSymbolToBounds(symbols::Symbol2D &symbol, const Bounds2D &target) {
   if (!symbol.bounds.valid || !target.valid)
     return false;
@@ -99,10 +104,15 @@ bool RemapSymbolToBounds(symbols::Symbol2D &symbol, const Bounds2D &target) {
 
   const float scaleX = targetWidth / sourceWidth;
   const float scaleY = targetHeight / sourceHeight;
+  const float uniformScale = std::min(scaleX, scaleY);
+  const float remappedWidth = sourceWidth * uniformScale;
+  const float remappedHeight = sourceHeight * uniformScale;
+  const float offsetX = target.minX + (targetWidth - remappedWidth) * 0.5f;
+  const float offsetY = target.minY + (targetHeight - remappedHeight) * 0.5f;
 
   auto remapPoint = [&](symbols::Point2D &point) {
-    point.x = target.minX + (point.x - sourceMinX) * scaleX;
-    point.y = target.minY + (point.y - sourceMinY) * scaleY;
+    point.x = offsetX + (point.x - sourceMinX) * uniformScale;
+    point.y = offsetY + (point.y - sourceMinY) * uniformScale;
   };
 
   for (auto &polygon : symbol.fill) {
@@ -129,6 +139,7 @@ bool RemapSymbolToBounds(symbols::Symbol2D &symbol, const Bounds2D &target) {
 
 } // namespace
 
+// Maps generated symbol coordinates to fixture physical dimensions from its GDTF.
 bool CalibrateFixtureSymbolsToPhysicalUnits(ConfigManager &cfg,
                                             const std::string &fixtureUuid,
                                             std::vector<symbols::Symbol2D> &symbols,


### PR DESCRIPTION
### Motivation
- Prevent symbols from being non-uniformly stretched or squashed when captured/ remapped by aligning capture orientation and calibration to physical fixture dimensions.
- Avoid inflating physical bounds with non-visible or non-body geometry (lens/aux parts) so target boxes reflect the emitting/body geometry only.

### Description
- Compute world-space fixture bounds from GDTF while skipping `isLens` geometry and add small helper functions (`Bounds3D`, `TransformPoint`, `ExtendBounds`) used by both capture and calibration.
- In the capture pipeline (`CaptureSceneModelOrthographicSymbols`) resolve the fixture GDTF, compute per-view physical aspect ratios (Top X/Y, Front X/Z, Left Y/Z), and size the offscreen viewport per-view so each orthographic capture uses the correct axis pair.
- In calibration (`RemapSymbolToBounds`) replace independent X/Y scaling with a uniform scale chosen as `min(scaleX, scaleY)` and center (letterbox/pillarbox) the remapped symbol inside the target bounds to avoid distortion.
- Add concise one-line English comments above the modified functions and new helpers to document purpose and behavior.

### Testing
- Ran mandatory architecture/quality checks: `tests/check_perastage_tree_modules.sh` (passed) and `tests/check_no_configmanager_get_in_gui.sh` (passed).
- No new automated symbol/regression tests were added in this change; further GDTF-viewBox ratio regression tests should be added in a follow-up per the requested test plan.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d6907e3f8832481271aa36be6970f)