### PR TITLE
Fix docs markdown links to open in the documentation shell

### DIFF
--- a/docs/assets/js/docs-shell.js
+++ b/docs/assets/js/docs-shell.js
@@ -12,6 +12,8 @@ const docsPages = [
   { md: 'repository_layout.md', html: 'repository_layout.html', title: 'Repository layout', icon: '🧩' }
 ];
 
+const mdToHtmlMap = new Map(docsPages.map((page) => [page.md, page.html]));
+
 // Builds a shared navigation list and highlights the active HTML page.
 function renderNav(activeHtml) {
   return docsPages
@@ -48,12 +50,37 @@ function renderDocShell(activeHtml) {
   });
 }
 
+// Converts documentation Markdown links to their HTML shell counterparts.
+function rewriteMarkdownLinks(contentElement) {
+  const links = contentElement.querySelectorAll('a[href]');
+  links.forEach((link) => {
+    const href = link.getAttribute('href');
+    if (!href || href.startsWith('#')) {
+      return;
+    }
+    try {
+      const parsed = new URL(href, window.location.href);
+      const markdownName = parsed.pathname.split('/').pop();
+      const htmlTarget = mdToHtmlMap.get(markdownName);
+      if (!htmlTarget) {
+        return;
+      }
+      parsed.pathname = parsed.pathname.replace(/[^/]+$/, htmlTarget);
+      link.setAttribute('href', `${parsed.pathname}${parsed.search}${parsed.hash}`);
+    } catch (_unused) {
+      // Ignores invalid URLs and keeps their original href value.
+    }
+  });
+}
+
 // Loads a markdown document, converts it to HTML, and injects it into the page content area.
 function loadMarkdown(mdFile) {
   fetch(mdFile)
     .then((res) => res.text())
     .then((md) => {
-      document.getElementById('content').innerHTML = marked.parse(md);
+      const contentElement = document.getElementById('content');
+      contentElement.innerHTML = marked.parse(md);
+      rewriteMarkdownLinks(contentElement);
     })
     .catch((err) => {
       document.getElementById('content').innerHTML = `<p>Could not load documentation file: ${mdFile}</p>`;


### PR DESCRIPTION
### Motivation
- In-page documentation links to `*.md` files were opening raw Markdown (plain text) instead of loading inside the shared docs shell, breaking the consistent layout and styling when a second link was clicked.

### Description
- Added a `mdToHtmlMap` mapping of known docs `*.md` names to their `*.html` shell equivalents in `docs/assets/js/docs-shell.js`.
- Implemented `rewriteMarkdownLinks(contentElement)` which walks rendered links and rewrites links that target known `*.md` pages to their corresponding `*.html`, preserving query and hash components.
- Call `rewriteMarkdownLinks` immediately after converting Markdown to HTML so rewrites run on every document load, while non-doc and invalid links are left unchanged.
- Kept existing small, one-line English comments above the file's functions and added a descriptive comment for the new helper to satisfy the code-comment requirement.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed successfully.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d918b61d083248fa43de65b2b4dbe)