### PR TITLE
Fix docs markdown routing and expand shortcuts/commands page

### DIFF
--- a/docs/assets/js/docs-shell.js
+++ b/docs/assets/js/docs-shell.js
@@ -9,7 +9,9 @@ const docsPages = [
   { md: 'faq.md', html: 'faq.html', title: 'FAQ', icon: '❓' },
   { md: 'features.md', html: 'features.html', title: 'Feature overview', icon: '✨' },
   { md: 'build.md', html: 'build.html', title: 'Build guide', icon: '🏗️' },
-  { md: 'repository_layout.md', html: 'repository_layout.html', title: 'Repository layout', icon: '🧩' }
+  { md: 'repository_layout.md', html: 'repository_layout.html', title: 'Repository layout', icon: '🧩' },
+  { md: 'architecture.md', html: 'doc.html?md=architecture.md', title: 'Architecture', icon: '🏛️' },
+  { md: 'shortcuts-and-command-bar.md', html: 'doc.html?md=shortcuts-and-command-bar.md', title: 'Shortcuts and commands', icon: '⌨️' }
 ];
 
 const mdToHtmlMap = new Map(docsPages.map((page) => [page.md, page.html]));
@@ -50,6 +52,18 @@ function renderDocShell(activeHtml) {
   });
 }
 
+// Resolves a markdown file name from either explicit mapping or a generic .md to doc shell route.
+function resolveMarkdownHref(markdownName) {
+  const mappedTarget = mdToHtmlMap.get(markdownName);
+  if (mappedTarget) {
+    return mappedTarget;
+  }
+  if (markdownName && markdownName.endsWith('.md')) {
+    return `doc.html?md=${encodeURIComponent(markdownName)}`;
+  }
+  return null;
+}
+
 // Converts documentation Markdown links to their HTML shell counterparts.
 function rewriteMarkdownLinks(contentElement) {
   const links = contentElement.querySelectorAll('a[href]');
@@ -61,8 +75,12 @@ function rewriteMarkdownLinks(contentElement) {
     try {
       const parsed = new URL(href, window.location.href);
       const markdownName = parsed.pathname.split('/').pop();
-      const htmlTarget = mdToHtmlMap.get(markdownName);
+      const htmlTarget = resolveMarkdownHref(markdownName);
       if (!htmlTarget) {
+        return;
+      }
+      if (htmlTarget.includes('?')) {
+        link.setAttribute('href', htmlTarget);
         return;
       }
       parsed.pathname = parsed.pathname.replace(/[^/]+$/, htmlTarget);

--- a/docs/doc.html
+++ b/docs/doc.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Perastage Documentation</title>
+    <link rel="stylesheet" href="assets/css/style.css" />
+  </head>
+  <body id="top">
+    <div id="app"></div>
+
+    <script src="assets/js/marked.min.js"></script>
+    <script src="assets/js/docs-shell.js"></script>
+    <script>
+      // Selects the markdown source from the URL query and falls back to quick-start.
+      function getMarkdownFromQuery() {
+        const params = new URLSearchParams(window.location.search);
+        const requested = params.get('md');
+        return requested && requested.endsWith('.md') ? requested : 'quick-start.md';
+      }
+
+      const mdFile = getMarkdownFromQuery();
+      const page = docsPages.find((entry) => entry.md === mdFile);
+      const activeHtml = page ? page.html : `doc.html?md=${encodeURIComponent(mdFile)}`;
+      renderDocShell(activeHtml);
+      loadMarkdown(mdFile);
+    </script>
+  </body>
+</html>

--- a/docs/shortcuts-and-command-bar.md
+++ b/docs/shortcuts-and-command-bar.md
@@ -1,46 +1,111 @@
 # Shortcuts and Command Bar
 
-This page summarizes keyboard shortcuts and command-bar workflows available to end users.
+This reference page consolidates the most practical keyboard, mouse, and command-bar workflows from the in-app help so you can work faster without leaving the docs shell.
 
-## Global and viewer shortcuts
+## Global shortcuts
 
-The current shortcut map includes:
+| Shortcut | Action |
+| --- | --- |
+| `Ctrl+N` | New project |
+| `Ctrl+L` | Load project |
+| `Ctrl+S` | Save project |
+| `Ctrl+Q` | Close application |
+| `Ctrl+Z / Ctrl+Y` | Undo / Redo |
+| `Del` | Delete selection |
+| `F1` | Open help |
+| `F` | Focus CLI and prefill `fixture ` (outside editable widgets) |
+| `1 / 2 / 3 / 4` | Switch to Fixtures / Trusses / Hoists / Objects |
 
-- `Z` → Fit view (2D/3D, depending on focused viewer)
-- `P` → Prefill position command in the command bar
-- `R` → Prefill rotation command in the command bar
-- `F` → Prefill fixture command in the command bar
-- `1` → Open Fixtures tab
-- `2` → Open Trusses tab
-- `3` → Open Supports/Hoists tab
-- `4` → Open Objects tab
-- `NumPad1` → Front view (2D/3D)
-- `NumPad3` → Side view (2D/3D)
-- `NumPad7` → Top view (2D/3D)
-- `NumPad5` → Reset 3D viewport
+## Viewer shortcuts
 
-## Command bar workflow
+| Shortcut | Action |
+| --- | --- |
+| `Z` | Fit view (focused 2D/3D viewer) |
+| `NumPad1` | Front view |
+| `NumPad3` | Side/Right view |
+| `NumPad7` | Top view |
+| `NumPad5` | Reset 3D camera orientation |
+| `Arrow keys` (3D) | Orbit camera |
+| `Shift + Arrow keys` (3D) | Pan camera |
+| `Alt + Arrow keys` (2D/3D) | Zoom in/out |
+| `Arrow keys` (2D) | Pan view |
 
-Perastage includes a command-bar/console workflow for fast scene operations.
+## Console input shortcuts
 
-Practical use:
+| Shortcut | Action |
+| --- | --- |
+| `Esc` | Exit prompt and re-enable app shortcuts |
+| `Up / Down` | Navigate command history |
+| `Home` | Move to start of input (after prompt) |
+| `Left / Backspace` | Cannot move before prompt |
+
+## Mouse shortcuts (3D viewer)
+
+| Action | Result |
+| --- | --- |
+| Left drag | Orbit camera |
+| Shift + left drag or middle drag | Pan camera |
+| Mouse wheel | Zoom in/out |
+| Left click | Select fixture/truss/object under cursor |
+| Shift/Ctrl + left click | Toggle selection |
+| Ctrl + left drag | Rectangle select |
+| Double click fixture label | Open fixture patch dialog |
+
+## Command bar quick workflow
 
 1. Focus the command bar.
-2. Use shortcut prefill (`P`, `R`, `F`) when helpful.
+2. Optionally prefill with `P`, `R`, or `F`.
 3. Edit the command text.
-4. Execute and review the result in tables and viewers.
-5. Reuse command history for repetitive tasks.
+4. Execute and verify the result in tables/viewers.
+5. Reuse command history for repetitive changes.
 
-## Focus behavior and priority
+## Console commands (frequent and useful)
+
+### Selection commands
+
+| Command | Description |
+| --- | --- |
+| `clear` | Clear fixtures, trusses, and objects selections |
+| `f ...` | Select fixtures by ID |
+| `t ...` | Select trusses by unit number (clears truss selection first) |
+
+Selection syntax examples:
+
+- Single ID: `f 12`
+- Range: `f 1-5`, `f 1 thru 5`, `f 1 t 5`
+- Add/remove: `f + 10 - 3`
+- Mixed: `f 1 3 5 7-9`
+
+### Position and rotation commands
+
+| Command | Description |
+| --- | --- |
+| `pos x <values>` | Set X positions |
+| `pos y <values>` | Set Y positions |
+| `pos z <values>` | Set Z positions |
+| `pos <x>,<y>,<z>` | Set X/Y/Z together |
+| `x <values>` / `y <values>` / `z <values>` | Axis shortcuts for `pos` |
+| `rot x <values>` / `rot y <values>` / `rot z <values>` | Set roll/pitch/yaw |
+| `rot x\|y\|z <values> --group` or `--g` | Rotate full selection as one group |
+
+Notes:
+
+- One value applies to all selected items.
+- Two values distribute linearly from start to end across selection.
+- Use `++` / `--` for relative offsets (for example `pos x ++ 1.5`).
+- Group rotation pivot defaults to selection bounding-box center.
+- You can override pivot with a trailing `x,y,z` triplet, for example `rot y ++45 --g -2.5,0,0`.
+
+## Focus and priority behavior
 
 - Shortcuts are blocked while typing in editable text fields/cells.
-- Viewer shortcuts run in the currently focused viewer context.
-- Dialog-local shortcuts (for example, Create from text autocomplete) stay local to that dialog.
+- Viewer shortcuts run in the currently focused viewer.
+- Dialog-local shortcuts remain local to that dialog.
 
-## Create from text local shortcuts
+## Create from text dialog local shortcuts
 
-Inside **Tools → Create from text**, the editor autocomplete supports:
-
-- `↑` / `↓` to move through suggestions
-- `Enter` or `Tab` to accept the selected suggestion
-- `Esc` to close suggestions (without closing the dialog)
+| Shortcut | Action |
+| --- | --- |
+| `↑` / `↓` | Move through suggestions |
+| `Enter` or `Tab` | Accept selected suggestion |
+| `Esc` | Close suggestions without closing dialog |


### PR DESCRIPTION
### Motivation
- Fix cases where clicking a second `.md` link opened the raw markdown/plain text instead of rendering inside the docs shell. 
- Ensure navigation between documentation pages keeps the shared shell layout and styling. 
- Provide a richer, more comprehensive shortcuts/command-bar reference to match the in-app help content.

### Description
- Added a generic markdown host page `docs/doc.html` that renders any `?md=<file>.md` target inside the shared documentation shell. 
- Updated `docs/assets/js/docs-shell.js` to add `resolveMarkdownHref(...)` and to rewrite `.md` links to either explicit mapped HTML targets or `doc.html?md=...`, preserving existing mapped pages. 
- Expanded and replaced `docs/shortcuts-and-command-bar.md` with a fuller reference (keyboard, mouse, command-bar workflow, and console command examples). 
- Added navigation entries for `architecture.md` and `shortcuts-and-command-bar.md` to the `docsPages` list so they appear in the site nav and landing grid.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed successfully. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d94bf8e948324ba8c28f798d8cd93)