### PR TITLE
docs: refine landing page copy and card summaries

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -21,7 +21,7 @@
       <section class="hero-panel">
         <h2>Perastage User Guide</h2>
         <p>
-          Perastage is a fast, cross-platform desktop viewer for lighting and rigging workflows, helping you inspect, review, and present scenes without heavy setup.
+          Perastage is a fast, cross-platform desktop viewer focused on MVR and GDTF workflows, helping you inspect, review, and present lighting scenes without heavy setup.
         </p>
         <div class="doc-grid" aria-label="Documentation sections" id="docGrid"></div>
       </section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -21,10 +21,8 @@
       <section class="hero-panel">
         <h2>Perastage User Guide</h2>
         <p>
-          Perastage is a fast, cross-platform desktop viewer focused on MVR v1.6 and GDTF v1.1 workflows,
-          helping you inspect, review, and present lighting scenes without heavy setup.
+          Perastage is a fast, cross-platform desktop viewer for lighting and rigging workflows, helping you inspect, review, and present scenes without heavy setup.
         </p>
-        <p><strong>For the latest documentation, visit <a href="https://perastage.luismaperamato.com/">perastage.luismaperamato.com</a>.</strong></p>
         <div class="doc-grid" aria-label="Documentation sections" id="docGrid"></div>
       </section>
 
@@ -37,11 +35,11 @@
 
     <script src="assets/js/docs-shell.js"></script>
     <script>
-      // Renders the landing-page card grid from the shared documentation page list.
+      // Renders landing cards with section-specific preview text for each documentation entry.
       function renderLandingGrid() {
         const grid = document.getElementById('docGrid');
         grid.innerHTML = docsPages
-          .map((p) => `<a class="doc-card" href="${p.html}">${p.icon} ${p.title}<span>${p.summary || `Read ${p.title}`}</span></a>`)
+          .map((p) => `<a class="doc-card" href="${p.html}">${p.icon} ${p.title}<span>${p.summary}</span></a>`)
           .join('');
       }
       renderLandingGrid();


### PR DESCRIPTION
### Motivation
- Make the docs landing page copy future-proof and remove a redundant external pointer, and ensure landing cards show specific, hand-written section summaries instead of a generic fallback label.

### Description
- Updated `docs/index.html` to adjust the hero text (removed explicit MVR/GDTF version mentions), removed the "For the latest documentation" sentence, and changed the `renderLandingGrid` card renderer to use `p.summary` only and added a concise one-line English comment above the `renderLandingGrid` function.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d9f37c0008324b1097a5cf7d48381)