### PR TITLE
Fix Windows startup path normalization for shell-opened MVR files

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -98,7 +98,7 @@ wxString DecodeFileUriToPath(const wxString &fileUri) {
   return fileUri;
 }
 
-// Converts macOS file URLs or raw paths into a normalized UTF-8 filesystem path when possible.
+// Converts external open input into a UTF-8 path while avoiding Windows shell-folder normalization stalls.
 std::string NormalizeExternalOpenPath(const std::string &rawPathUtf8) {
   if (rawPathUtf8.empty())
     return {};
@@ -107,11 +107,15 @@ std::string NormalizeExternalOpenPath(const std::string &rawPathUtf8) {
   if (wxPath.StartsWith("file://"))
     wxPath = DecodeFileUriToPath(wxPath);
 
+#if defined(__WXMSW__)
+  wxPath.Replace("/", "\\");
+#else
   wxFileName fileName(wxPath);
   if (fileName.Normalize(wxPATH_NORM_DOTS | wxPATH_NORM_TILDE |
                          wxPATH_NORM_ABSOLUTE)) {
     wxPath = fileName.GetFullPath();
   }
+#endif
 
   wxCharBuffer utf8 = wxPath.ToUTF8();
   const std::string normalizedPath =


### PR DESCRIPTION
### Motivation
- Opening associated `.mvr` files by double-click from some Windows shell folders (for example Downloads) could cause the app to stall during startup due to expensive or blocking `wxFileName::Normalize(...)` calls. 
- The fix must be surgical to Windows-only startup/external-open handling so other platforms keep existing normalization behavior.

### Description
- Changed `NormalizeExternalOpenPath` in `main.cpp` to avoid calling `wxFileName::Normalize(...)` on Windows and instead perform a lightweight path-separator normalization (`/` -> `\`).
- Kept the existing `wxFileName::Normalize(...)` logic for non-Windows platforms to preserve normalization behavior elsewhere.
- Added a concise one-line English comment above the modified function describing its purpose.
- No other startup routing or project-loading logic was changed.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eda4901d88324b38eea05ff08fdba)