### PR TITLE
ci: publish only final installer binaries in minor draft release

### DIFF
--- a/.github/workflows/minor-draft-release.yml
+++ b/.github/workflows/minor-draft-release.yml
@@ -164,22 +164,60 @@ jobs:
           path: release-assets
           pattern: Perastage-*
 
-      - name: Validate installer assets
+      - name: Prepare final installer assets
         id: assets
         run: |
           set -euo pipefail
 
-          WIN_ASSET="$(find release-assets -type f -name 'Perastage_*_Setup.exe' -print -quit)"
-          LINUX_ASSET="$(find release-assets -type f -name 'Perastage-*-x86_64.AppImage' -print -quit)"
-          MAC_ASSET="$(find release-assets -type f -name 'Perastage-*-macos-arm64.dmg' -print -quit)"
+          FINAL_DIR="release-assets/final"
+          EXTRACT_DIR="release-assets/.extracted-zips"
 
-          if [ -z "$WIN_ASSET" ] || [ -z "$LINUX_ASSET" ] || [ -z "$MAC_ASSET" ]; then
-            echo "Missing one or more installer assets"
-            echo "Windows: $WIN_ASSET"
-            echo "Linux: $LINUX_ASSET"
-            echo "macOS: $MAC_ASSET"
+          rm -rf "$FINAL_DIR" "$EXTRACT_DIR"
+          mkdir -p "$FINAL_DIR" "$EXTRACT_DIR"
+
+          echo "Downloaded artifact tree (release-assets):"
+          find release-assets -mindepth 1 -maxdepth 4 -print | sort
+
+          mapfile -t ZIP_FILES < <(find release-assets -type f -name '*.zip' | sort)
+          if [ "${#ZIP_FILES[@]}" -gt 0 ]; then
+            echo "Found zip files in release-assets; extracting to temporary directory"
+            for zip_file in "${ZIP_FILES[@]}"; do
+              zip_base="$(basename "$zip_file" .zip)"
+              target_dir="$EXTRACT_DIR/$zip_base"
+              mkdir -p "$target_dir"
+              unzip -q "$zip_file" -d "$target_dir"
+            done
+          else
+            echo "No zip files found in release-assets"
+          fi
+
+          mapfile -t WIN_MATCHES < <(find release-assets -type f -name 'Perastage_*_Setup.exe' | sort)
+          mapfile -t LINUX_MATCHES < <(find release-assets -type f -name 'Perastage-*-x86_64.AppImage' | sort)
+          mapfile -t MAC_MATCHES < <(find release-assets -type f -name 'Perastage-*-macos-arm64.dmg' | sort)
+
+          if [ "${#WIN_MATCHES[@]}" -ne 1 ] || [ "${#LINUX_MATCHES[@]}" -ne 1 ] || [ "${#MAC_MATCHES[@]}" -ne 1 ]; then
+            echo "Expected exactly one installer per platform"
+            echo "Windows matches (${#WIN_MATCHES[@]}): ${WIN_MATCHES[*]:-none}"
+            echo "Linux matches (${#LINUX_MATCHES[@]}): ${LINUX_MATCHES[*]:-none}"
+            echo "macOS matches (${#MAC_MATCHES[@]}): ${MAC_MATCHES[*]:-none}"
             exit 1
           fi
+
+          cp "${WIN_MATCHES[0]}" "$FINAL_DIR/"
+          cp "${LINUX_MATCHES[0]}" "$FINAL_DIR/"
+          cp "${MAC_MATCHES[0]}" "$FINAL_DIR/"
+
+          if find "$FINAL_DIR" -type f -name '*.zip' | grep -q .; then
+            echo "Final asset directory must not contain zip files"
+            exit 1
+          fi
+
+          WIN_ASSET="$FINAL_DIR/$(basename "${WIN_MATCHES[0]}")"
+          LINUX_ASSET="$FINAL_DIR/$(basename "${LINUX_MATCHES[0]}")"
+          MAC_ASSET="$FINAL_DIR/$(basename "${MAC_MATCHES[0]}")"
+
+          echo "Final release assets (release-assets/final):"
+          find "$FINAL_DIR" -mindepth 1 -maxdepth 1 -type f -print | sort
 
           echo "win_asset=$WIN_ASSET" >> "$GITHUB_OUTPUT"
           echo "linux_asset=$LINUX_ASSET" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### Motivation
- Ensure the manually-triggered `Minor Draft Release` workflow attaches only the uncompressed final installer binaries (`.exe`, `.AppImage`, `.dmg`) to the draft release and never attaches `.zip` files.
- Make artifact discovery robust when downloaded artifacts may include nested `.zip` files while preserving existing installer workflows, tagging, and `dry_run` behavior.

### Description
- Replaced the `Validate installer assets` step with `Prepare final installer assets` which creates and cleans `release-assets/final` and a temporary extraction dir `release-assets/.extracted-zips`.
- Log the downloaded artifact tree, extract any found `.zip` files to the temporary directory for discovery, and search recursively for the exact installer patterns `Perastage_*_Setup.exe`, `Perastage-*-x86_64.AppImage`, and `Perastage-*-macos-arm64.dmg`.
- Require exactly one installer per platform, copy those three files into `release-assets/final`, validate no `.zip` exists in the final directory, and emit outputs `win_asset`, `linux_asset`, and `mac_asset` that point to the files inside `release-assets/final`.
- Preserve all other behaviour: individual platform workflows, version bumping, tagging, draft creation, generated notes, and `dry_run` semantics remain unchanged, and `gh release create` receives exactly the three explicit asset paths.

### Testing
- Ran repository inspections and file checks: `rg --files -g 'AGENTS.md'`, `sed -n '1,260p' .github/workflows/minor-draft-release.yml`, and `nl -ba .github/workflows/minor-draft-release.yml | sed -n '155,245p'`, all succeeding locally.
- Verified the diff with `git diff -- .github/workflows/minor-draft-release.yml` and committed the change with `git commit`, which succeeded.
- Created the PR metadata using the repository helper, and the change was committed with message `ci: publish uncompressed installer assets in draft release`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ee018c3088324b99c92794963c74b)