### PR TITLE
Fix Windows startup MVR open stall on GDTF fallback scan

### DIFF
--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -371,7 +371,15 @@ static std::string ResolveGdtfPath(const std::string &baseDir,
   }
 
   std::error_code ec;
-  fs::path lookupDir = baseDir.empty() ? fs::current_path(ec) : fs::u8path(baseDir);
+#if defined(_WIN32)
+  // Restricts fallback directory scans to the extracted MVR base directory on Windows.
+  if (baseDir.empty())
+    return ToString(candidate.u8string());
+  fs::path lookupDir = fs::u8path(baseDir);
+#else
+  fs::path lookupDir =
+      baseDir.empty() ? fs::current_path(ec) : fs::u8path(baseDir);
+#endif
   if (ec || !fs::exists(lookupDir))
     return ToString(candidate.u8string());
 


### PR DESCRIPTION
### Motivation
- Opening an `.mvr` via Explorer on Windows could inherit a problematic process CWD (for example `Downloads`) and cause long or stalled directory scans inside `ResolveGdtfPath`; the change prevents that platform-specific startup hang.

### Description
- Modify `mvr/mvrimporter.cpp` to add a Windows-only guard in `ResolveGdtfPath` so that when `baseDir` is empty on Windows the function returns the candidate path immediately, and when `baseDir` is present the fallback scan is restricted to the extracted MVR `baseDir`; non-Windows behavior still falls back to `current_path()`.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both succeeded (OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ee32da5ec832492286a68fa76b591)