### PR TITLE
Extract pure menu helpers from mainwindow_menu.cpp

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -67,6 +67,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_fixture_replace.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_gdtf_credentials.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_menu.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_menu_helpers.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_menu_builders.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_menu_text_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_print.cpp

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -20,6 +20,7 @@
 #include "mainwindow_view_controller.h"
 #include "mainwindow_menu_builders.h"
 #include "mainwindow_menu_text_utils.h"
+#include "mainwindow_menu_helpers.h"
 
 #include <algorithm>
 #include <chrono>
@@ -91,63 +92,6 @@
 #include "update/app_update_service.h"
 #include "viewer2dpanel.h"
 #include "viewer3dpanel.h"
-
-namespace {
-
-struct HelpMarkdown {
-  std::string english;
-  std::string spanish;
-  bool hasSections = false;
-};
-
-// Splits help markdown into English and Spanish sections when markers are present.
-HelpMarkdown SplitHelpMarkdown(const std::string &markdown) {
-  constexpr const char *kEnglishMarker = "<!-- LANG:en -->";
-  constexpr const char *kSpanishMarker = "<!-- LANG:es -->";
-  HelpMarkdown result;
-
-  const auto enPos = markdown.find(kEnglishMarker);
-  const auto esPos = markdown.find(kSpanishMarker);
-  if (enPos == std::string::npos && esPos == std::string::npos) {
-    result.english = markdown;
-    result.spanish = markdown;
-    return result;
-  }
-
-  result.hasSections = true;
-  auto extract = [&](size_t start, size_t end, const char *marker) {
-    if (start == std::string::npos)
-      return std::string();
-    start += std::strlen(marker);
-    if (end == std::string::npos || end < start)
-      end = markdown.size();
-    return TrimLeadingWhitespace(markdown.substr(start, end - start));
-  };
-
-  if (enPos != std::string::npos && esPos != std::string::npos) {
-    if (enPos < esPos) {
-      result.english = extract(enPos, esPos, kEnglishMarker);
-      result.spanish = extract(esPos, std::string::npos, kSpanishMarker);
-    } else {
-      result.spanish = extract(esPos, enPos, kSpanishMarker);
-      result.english = extract(enPos, std::string::npos, kEnglishMarker);
-    }
-  } else {
-    result.english =
-        extract(enPos, std::string::npos, kEnglishMarker);
-    result.spanish =
-        extract(esPos, std::string::npos, kSpanishMarker);
-  }
-
-  if (result.english.empty())
-    result.english = markdown;
-  if (result.spanish.empty())
-    result.spanish = markdown;
-
-  return result;
-}
-
-} // namespace
 
 // Builds and registers the main application toolbars.
 void MainWindow::CreateToolBars() {
@@ -972,7 +916,7 @@ void MainWindow::OnShowHelp(wxCommandEvent &WXUNUSED(event)) {
     std::ifstream in(WxToUtf8(helpPath.GetFullPath()));
     std::string markdown((std::istreambuf_iterator<char>(in)),
                          std::istreambuf_iterator<char>());
-    HelpMarkdown help = SplitHelpMarkdown(markdown);
+    menu::HelpMarkdown help = menu::SplitHelpMarkdown(markdown);
 
     // Create a resizable dialog containing a wxHtmlWindow to render the
     // generated HTML.

--- a/gui/mainwindow_menu_helpers.cpp
+++ b/gui/mainwindow_menu_helpers.cpp
@@ -1,0 +1,56 @@
+#include "mainwindow_menu_helpers.h"
+
+#include <cstring>
+
+#include "mainwindow_menu_text_utils.h"
+
+namespace menu {
+
+// Splits help markdown using language markers while preserving a safe fallback for missing sections.
+HelpMarkdown SplitHelpMarkdown(const std::string &markdown) {
+  constexpr const char *kEnglishMarker = "<!-- LANG:en -->";
+  constexpr const char *kSpanishMarker = "<!-- LANG:es -->";
+  HelpMarkdown result;
+
+  const auto enPos = markdown.find(kEnglishMarker);
+  const auto esPos = markdown.find(kSpanishMarker);
+  if (enPos == std::string::npos && esPos == std::string::npos) {
+    result.english = markdown;
+    result.spanish = markdown;
+    return result;
+  }
+
+  result.hasSections = true;
+  auto extract = [&](size_t start, size_t end, const char *marker) {
+    if (start == std::string::npos)
+      return std::string();
+    start += std::strlen(marker);
+    if (end == std::string::npos || end < start)
+      end = markdown.size();
+    return TrimLeadingWhitespace(markdown.substr(start, end - start));
+  };
+
+  if (enPos != std::string::npos && esPos != std::string::npos) {
+    if (enPos < esPos) {
+      result.english = extract(enPos, esPos, kEnglishMarker);
+      result.spanish = extract(esPos, std::string::npos, kSpanishMarker);
+    } else {
+      result.spanish = extract(esPos, enPos, kSpanishMarker);
+      result.english = extract(enPos, std::string::npos, kEnglishMarker);
+    }
+  } else {
+    result.english =
+        extract(enPos, std::string::npos, kEnglishMarker);
+    result.spanish =
+        extract(esPos, std::string::npos, kSpanishMarker);
+  }
+
+  if (result.english.empty())
+    result.english = markdown;
+  if (result.spanish.empty())
+    result.spanish = markdown;
+
+  return result;
+}
+
+} // namespace menu

--- a/gui/mainwindow_menu_helpers.h
+++ b/gui/mainwindow_menu_helpers.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+
+namespace menu {
+
+struct HelpMarkdown {
+  std::string english;
+  std::string spanish;
+  bool hasSections = false;
+};
+
+// Splits markdown into language-specific sections and falls back to full content when needed.
+HelpMarkdown SplitHelpMarkdown(const std::string &markdown);
+
+} // namespace menu


### PR DESCRIPTION
### Motivation
- Reduce logic in the `gui/mainwindow_menu.cpp` hotspot by extracting pure, side-effect-free helpers into adjacent files to improve modularity and follow the repository code-health rules. 
- Keep UI command handlers and side-effectful code in place while isolating deterministic text-processing logic for easier reuse and testing.

### Description
- Added `gui/mainwindow_menu_helpers.h` and `gui/mainwindow_menu_helpers.cpp` to host the `HelpMarkdown` struct and the `SplitHelpMarkdown` helper in the `menu` namespace. 
- Updated `gui/mainwindow_menu.cpp` to `#include "mainwindow_menu_helpers.h"` and to call `menu::SplitHelpMarkdown(...)` at the existing `OnShowHelp` call site without changing parameters or behavior. 
- Registered `gui/mainwindow_menu_helpers.cpp` explicitly in `gui/CMakeLists.txt` under the target sources (no globbing). 
- Added concise one-line English comments above the moved helper declaration and definition to document the functions' primary purpose as requested.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed successfully. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a121ebf957c83249b00f4b479c7c3cb)