### PR TITLE
Extract help-markdown splitter into mainwindow_menu_helpers

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -67,6 +67,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_fixture_replace.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_gdtf_credentials.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_menu.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_menu_helpers.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_menu_builders.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_menu_text_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_print.cpp

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -20,6 +20,7 @@
 #include "mainwindow_view_controller.h"
 #include "mainwindow_menu_builders.h"
 #include "mainwindow_menu_text_utils.h"
+#include "mainwindow_menu_helpers.h"
 
 #include <algorithm>
 #include <chrono>
@@ -91,64 +92,6 @@
 #include "update/app_update_service.h"
 #include "viewer2dpanel.h"
 #include "viewer3dpanel.h"
-
-namespace {
-
-struct HelpMarkdown {
-  std::string english;
-  std::string spanish;
-  bool hasSections = false;
-};
-
-// Splits help markdown into English and Spanish sections when markers are present.
-// Splits bilingual help markdown into per-language content blocks.
-HelpMarkdown SplitHelpMarkdown(const std::string &markdown) {
-  constexpr const char *kEnglishMarker = "<!-- LANG:en -->";
-  constexpr const char *kSpanishMarker = "<!-- LANG:es -->";
-  HelpMarkdown result;
-
-  const auto enPos = markdown.find(kEnglishMarker);
-  const auto esPos = markdown.find(kSpanishMarker);
-  if (enPos == std::string::npos && esPos == std::string::npos) {
-    result.english = markdown;
-    result.spanish = markdown;
-    return result;
-  }
-
-  result.hasSections = true;
-  auto extract = [&](size_t start, size_t end, const char *marker) {
-    if (start == std::string::npos)
-      return std::string();
-    start += std::strlen(marker);
-    if (end == std::string::npos || end < start)
-      end = markdown.size();
-    return TrimLeadingWhitespace(markdown.substr(start, end - start));
-  };
-
-  if (enPos != std::string::npos && esPos != std::string::npos) {
-    if (enPos < esPos) {
-      result.english = extract(enPos, esPos, kEnglishMarker);
-      result.spanish = extract(esPos, std::string::npos, kSpanishMarker);
-    } else {
-      result.spanish = extract(esPos, enPos, kSpanishMarker);
-      result.english = extract(enPos, std::string::npos, kEnglishMarker);
-    }
-  } else {
-    result.english =
-        extract(enPos, std::string::npos, kEnglishMarker);
-    result.spanish =
-        extract(esPos, std::string::npos, kSpanishMarker);
-  }
-
-  if (result.english.empty())
-    result.english = markdown;
-  if (result.spanish.empty())
-    result.spanish = markdown;
-
-  return result;
-}
-
-} // namespace
 
 // Builds and registers the main application toolbars.
 void MainWindow::CreateToolBars() {

--- a/gui/mainwindow_menu_helpers.cpp
+++ b/gui/mainwindow_menu_helpers.cpp
@@ -1,0 +1,52 @@
+#include "mainwindow_menu_helpers.h"
+
+#include "mainwindow_menu_text_utils.h"
+
+#include <cstring>
+
+// Splits help markdown into English and Spanish sections when language markers exist.
+HelpMarkdown SplitHelpMarkdown(const std::string &markdown) {
+  constexpr const char *kEnglishMarker = "<!-- LANG:en -->";
+  constexpr const char *kSpanishMarker = "<!-- LANG:es -->";
+  HelpMarkdown result;
+
+  const auto enPos = markdown.find(kEnglishMarker);
+  const auto esPos = markdown.find(kSpanishMarker);
+  if (enPos == std::string::npos && esPos == std::string::npos) {
+    result.english = markdown;
+    result.spanish = markdown;
+    return result;
+  }
+
+  result.hasSections = true;
+  auto extract = [&](size_t start, size_t end, const char *marker) {
+    if (start == std::string::npos)
+      return std::string();
+    start += std::strlen(marker);
+    if (end == std::string::npos || end < start)
+      end = markdown.size();
+    return TrimLeadingWhitespace(markdown.substr(start, end - start));
+  };
+
+  if (enPos != std::string::npos && esPos != std::string::npos) {
+    if (enPos < esPos) {
+      result.english = extract(enPos, esPos, kEnglishMarker);
+      result.spanish = extract(esPos, std::string::npos, kSpanishMarker);
+    } else {
+      result.spanish = extract(esPos, enPos, kSpanishMarker);
+      result.english = extract(enPos, std::string::npos, kEnglishMarker);
+    }
+  } else {
+    result.english =
+        extract(enPos, std::string::npos, kEnglishMarker);
+    result.spanish =
+        extract(esPos, std::string::npos, kSpanishMarker);
+  }
+
+  if (result.english.empty())
+    result.english = markdown;
+  if (result.spanish.empty())
+    result.spanish = markdown;
+
+  return result;
+}

--- a/gui/mainwindow_menu_helpers.h
+++ b/gui/mainwindow_menu_helpers.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+
+// Stores per-language help markdown fragments and section metadata.
+struct HelpMarkdown {
+  std::string english;
+  std::string spanish;
+  bool hasSections = false;
+};
+
+// Splits bilingual help markdown into per-language content blocks.
+HelpMarkdown SplitHelpMarkdown(const std::string &markdown);


### PR DESCRIPTION
### Motivation
- Reduce growth of the `gui/mainwindow_menu.cpp` hotspot by moving pure, side-effect-free helpers to an adjacent helper file to improve modularity and readability.
- Make the bilingual help-markdown splitting logic reusable and easier to maintain without changing call-site semantics.
- Follow project guardrails to avoid moving command handlers or UI side-effect logic out of the original file.

### Description
- Added new helper files `gui/mainwindow_menu_helpers.h` and `gui/mainwindow_menu_helpers.cpp` that contain the `HelpMarkdown` struct and the `SplitHelpMarkdown` function.
- Moved only the pure markdown language-splitting logic out of `gui/mainwindow_menu.cpp` and updated that file to `#include "mainwindow_menu_helpers.h"` so call sites remain unchanged.
- Inserted concise one-line English comments above the helper declaration and definition to describe each function's purpose as requested.
- Registered `gui/mainwindow_menu_helpers.cpp` explicitly in `gui/CMakeLists.txt` (no globbing) to ensure the new translation unit is built.

### Testing
- Ran module and GUI checks via `tests/check_perastage_tree_modules.sh` which succeeded (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` which also succeeded (`OK`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1222b41c988324beb45407c1f5ad63)