### PR TITLE
Align fixture symbol captures to local axes

### DIFF
--- a/gui/mainwindow_fixture_symbol_autoupdate.cpp
+++ b/gui/mainwindow_fixture_symbol_autoupdate.cpp
@@ -187,6 +187,7 @@ void MainWindow::StartFixtureSymbolAutoUpdateForLoadedScene() {
   CallAfter([this]() { ProcessNextFixtureSymbolAutoUpdate(); });
 }
 
+// Processes queued fixture entries and auto-generates missing fixture symbols.
 void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
   if (!fixtureSymbolAutoUpdateRunning)
     return;
@@ -279,11 +280,14 @@ void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
   const std::string forcedFixtureColor = "#3FA9F5";
   tools::SceneModelSymbolCaptureOptions captureOptions;
   captureOptions.forcedFixtureColor = forcedFixtureColor;
+  // Captured symbols must be orientation-neutral so per-instance rotation can be applied later in rendering/printing.
+  captureOptions.alignToLocalAxes = true;
 
   auto capture = tools::CaptureSceneModelOrthographicSymbols(
       *offscreenRenderer, cfg,
       tools::SceneModelSymbolTarget{tools::SceneModelKind::Fixture, fixtureUuid},
       captureOptions);
+  captureOptions.alignToLocalAxes = false;
   if (!capture.ok) {
     ReportFixtureAutoUpdate(
         *this, consolePanel,

--- a/gui/tools/fixture_symbol_generation_tool.cpp
+++ b/gui/tools/fixture_symbol_generation_tool.cpp
@@ -83,6 +83,7 @@ std::vector<FixtureSymbolTypeOption> BuildFixtureOptions() {
 
 } // namespace
 
+// Generates and previews orthographic symbols for the selected fixture type.
 void RunFixtureSymbolGeneration(MainWindow &window) {
   auto options = BuildFixtureOptions();
   if (options.empty()) {
@@ -119,10 +120,13 @@ void RunFixtureSymbolGeneration(MainWindow &window) {
   const std::string forcedFixtureColor = "#3FA9F5";
   SceneModelSymbolCaptureOptions captureOptions;
   captureOptions.forcedFixtureColor = forcedFixtureColor;
+  // Captured symbols must be orientation-neutral so per-instance rotation can be applied later in rendering/printing.
+  captureOptions.alignToLocalAxes = true;
   auto capture = CaptureSceneModelOrthographicSymbols(
       *offscreenRenderer, cfg,
       SceneModelSymbolTarget{SceneModelKind::Fixture, selectedFixtureUuid},
       captureOptions);
+  captureOptions.alignToLocalAxes = false;
   if (!capture.ok) {
     wxMessageBox(capture.error, "Generate Fixture Symbols", wxOK | wxICON_ERROR,
                  &window);


### PR DESCRIPTION
### Motivation
- Ensure captured fixture symbols are orientation-neutral so per-instance rotation can be applied later during rendering/printing. 
- Apply the behavior consistently for both manual generation and the auto-update flow to avoid mismatches between symbol creation paths. 
- Keep the change scoped to symbol creation so normal rendering state is unchanged outside capture calls. 

### Description
- In `gui/tools/fixture_symbol_generation_tool.cpp` set `captureOptions.alignToLocalAxes = true` immediately before calling `CaptureSceneModelOrthographicSymbols(...)`, add an inline comment explaining orientation-neutral capture intent, and reset `captureOptions.alignToLocalAxes = false` right after the capture. 
- In `gui/mainwindow_fixture_symbol_autoupdate.cpp` mirror the same change for the auto-update capture path by setting `captureOptions.alignToLocalAxes = true` before capture, adding the same inline comment, and resetting it to `false` after capture. 
- Added concise one-line comments above the touched function definitions (`RunFixtureSymbolGeneration` and `MainWindow::ProcessNextFixtureSymbolAutoUpdate`) describing each function's primary purpose. 

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1364c64d188324aaa2a939b4a34647)