### PR TITLE
Fix layout-mode crash path when creating a new project

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -862,7 +862,12 @@ void MainWindow::LoadStartupProjectFromPath(const std::string &path) {
   SetStartupProjectLoadPending(false);
 }
 
+// Resets project state, UI-bound data, and active layout context for a fresh session.
 void MainWindow::ResetProject(bool applyLayoutDefaultsForNewProject) {
+  activeLayoutName.clear();
+  if (layoutViewerPanel)
+    layoutViewerPanel->SetLayoutDefinition(layouts::LayoutDefinition{});
+
   auto &guiConfigServices = GetDefaultGuiConfigServices();
   auto &preferences = guiConfigServices.Preferences();
   const auto preservedPreferences = CapturePreferencesDialogValues(preferences);


### PR DESCRIPTION
### Motivation
- Prevent stale layout viewer state from surviving a project reset which could lead to invalid UI references and access violations when creating a new project while layout mode is active.

### Description
- Clear `activeLayoutName`, reset the `layoutViewerPanel` via `SetLayoutDefinition(layouts::LayoutDefinition{})`, and add a one-line English comment above `MainWindow::ResetProject` to explain its purpose.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14c0ebc2388324b5d6315b72f9035a)