### PR TITLE
Fix GDTF model discovery: support models/gltf LOD folders, prefer GLB, and fallback from 3DS to GLB

### DIFF
--- a/viewer3d/gdtfloader.cpp
+++ b/viewer3d/gdtfloader.cpp
@@ -275,6 +275,24 @@ static void ApplyModelDimensions(Mesh& mesh, const GdtfModelInfo& modelInfo)
 }
 
 // Locates a model file using spec-compliant preferred folders and cached recursive fallback lookups.
+
+// Builds a box primitive scaled from model dimensions using visible defaults for missing size components.
+static bool BuildDimensionFallbackMesh(const GdtfModelInfo& modelInfo, Mesh& mesh)
+{
+    GdtfModelInfo adjusted = modelInfo;
+    constexpr float kDefaultMeters = 0.1f;
+    if (adjusted.length <= 0.0f)
+        adjusted.length = kDefaultMeters;
+    if (adjusted.width <= 0.0f)
+        adjusted.width = kDefaultMeters;
+    if (adjusted.height <= 0.0f)
+        adjusted.height = kDefaultMeters;
+
+    if (!BuildPrimitiveMesh("Cube", mesh))
+        return false;
+    ApplyModelDimensions(mesh, adjusted);
+    return true;
+}
 static std::string FindModelFile(const std::string& baseDir,
                                  const std::string& fileName)
 {
@@ -1264,19 +1282,22 @@ static void ParseGeometry(tinyxml2::XMLElement* node,
 
                             if (HasExtension(loadedPath, ".3ds")) {
                                 tried3ds = true;
-                                loaded = Load3DS(path, mesh, false);
+                                std::string loadError3ds;
+                                loaded = Load3DS(path, mesh, false, &loadError3ds);
                                 if (!loaded) {
                                     fallbackGlbPath = FindModelFile(baseDir, loadedPath.stem().string());
                                     if (!fallbackGlbPath.empty() && HasExtension(fs::u8path(fallbackGlbPath), ".glb")) {
                                         triedGlb = true;
-                                        loaded = LoadGLB(fallbackGlbPath, mesh);
+                                        std::string loadErrorGlbFallback;
+                                        loaded = LoadGLB(fallbackGlbPath, mesh, &loadErrorGlbFallback);
                                         if (loaded)
                                             path = fallbackGlbPath;
                                     }
                                 }
                             } else if (HasExtension(loadedPath, ".glb")) {
                                 triedGlb = true;
-                                loaded = LoadGLB(path, mesh);
+                                std::string loadErrorGlb;
+                                loaded = LoadGLB(path, mesh, &loadErrorGlb);
                             }
 
                             if (loaded) {
@@ -1291,11 +1312,11 @@ static void ParseGeometry(tinyxml2::XMLElement* node,
                                     wxString msg;
                                     if (tried3ds && triedGlb) {
                                         msg = wxString::Format(
-                                            "GDTF: failed to load model %s and fallback %s",
+                                            "GDTF: failed to load model %s and fallback %s (unsupported or empty geometry)",
                                             wxString::FromUTF8(path),
                                             wxString::FromUTF8(fallbackGlbPath));
                                     } else {
-                                        msg = wxString::Format("GDTF: failed to load model %s", wxString::FromUTF8(path));
+                                        msg = wxString::Format("GDTF: failed to load model %s (unsupported or empty geometry)", wxString::FromUTF8(path));
                                     }
                                     ConsolePanel::Instance()->AppendMessage(msg);
                                 }
@@ -1319,9 +1340,27 @@ static void ParseGeometry(tinyxml2::XMLElement* node,
             }
 
             if (!haveMesh && IsPrimitiveTypeDefined(modelInfo.primitiveType)) {
+                GdtfModelInfo adjusted = modelInfo;
+                constexpr float kDefaultMeters = 0.1f;
+                if (adjusted.length <= 0.0f)
+                    adjusted.length = kDefaultMeters;
+                if (adjusted.width <= 0.0f)
+                    adjusted.width = kDefaultMeters;
+                if (adjusted.height <= 0.0f)
+                    adjusted.height = kDefaultMeters;
                 if (BuildPrimitiveMesh(modelInfo.primitiveType, mesh)) {
-                    ApplyModelDimensions(mesh, modelInfo);
+                    ApplyModelDimensions(mesh, adjusted);
                     haveMesh = true;
+                    if (ConsolePanel::Instance())
+                        ConsolePanel::Instance()->AppendMessage(wxString::Format("GDTF: using primitive fallback for model %s", wxString::FromUTF8(modelInfo.file)));
+                }
+            }
+
+            if (!haveMesh && (modelInfo.length > 0.0f || modelInfo.width > 0.0f || modelInfo.height > 0.0f)) {
+                if (BuildDimensionFallbackMesh(modelInfo, mesh)) {
+                    haveMesh = true;
+                    if (ConsolePanel::Instance())
+                        ConsolePanel::Instance()->AppendMessage(wxString::Format("GDTF: using dimension box fallback for model %s", wxString::FromUTF8(modelInfo.file)));
                 }
             }
 

--- a/viewer3d/gdtfloader.cpp
+++ b/viewer3d/gdtfloader.cpp
@@ -81,6 +81,7 @@ bool TryParseFloat(const std::string& text, float& out)
     return false;
 }
 
+// Parses a trimmed integer token and succeeds only when the whole token is numeric.
 bool TryParseInt(std::string_view text, int& out)
 {
     if (text.empty())
@@ -217,6 +218,7 @@ struct MissingModelLog
 
 static bool ExtractZip(const std::string& zipPath, const std::string& destDir);
 
+// Returns a lowercase copy of the provided string for case-insensitive comparisons.
 static std::string ToLower(const std::string& s)
 {
     std::string t = s;
@@ -224,6 +226,7 @@ static std::string ToLower(const std::string& s)
     return t;
 }
 
+// Checks whether a path ends with the requested extension using case-insensitive matching.
 static bool HasExtension(const fs::path& p, const std::string& ext)
 {
     return ToLower(p.extension().string()) == ToLower(ext);
@@ -271,46 +274,68 @@ static void ApplyModelDimensions(Mesh& mesh, const GdtfModelInfo& modelInfo)
     }
 }
 
+// Locates a model file using spec-compliant preferred folders and cached recursive fallback lookups.
 static std::string FindModelFile(const std::string& baseDir,
                                  const std::string& fileName)
 {
-    fs::path modelsDir = fs::path(baseDir) / "models";
+    const fs::path modelsDir = fs::u8path(baseDir) / "models";
     if (!fs::exists(modelsDir))
         return {};
 
-    fs::path namePath = fileName;
-    std::string stem = namePath.stem().string();
-    std::string ext = ToLower(namePath.extension().string());
+    const fs::path requested = fs::u8path(fileName);
+    const std::string requestedName = requested.filename().string();
+    const bool hasExtension = requested.has_extension();
 
-    auto tryExt = [&](const std::string& e) -> std::string {
-        fs::path d = modelsDir / e.substr(1) / (stem + e);
-        if(fs::exists(d))
-            return d.string();
+    auto tryCandidate = [&](const fs::path& candidate) -> std::string {
+        if (fs::exists(candidate) && fs::is_regular_file(candidate))
+            return candidate.string();
         return {};
     };
 
-    if(!ext.empty()) {
-        std::string res = tryExt(ext);
-        if(!res.empty()) return res;
+    if (hasExtension) {
+        const fs::path direct = modelsDir / requested;
+        if (std::string resolved = tryCandidate(direct); !resolved.empty())
+            return resolved;
     } else {
-        std::string res = tryExt(".3ds");
-        if(!res.empty()) return res;
-        res = tryExt(".glb");
-        if(!res.empty()) return res;
-    }
-
-    for (auto& p : fs::recursive_directory_iterator(modelsDir)) {
-        if (!p.is_regular_file())
-            continue;
-        if (p.path().stem() != stem)
-            continue;
-        if(ext.empty()) {
-            if(HasExtension(p.path(), ".3ds") || HasExtension(p.path(), ".glb"))
-                return p.path().string();
-        } else if(HasExtension(p.path(), ext)) {
-            return p.path().string();
+        const std::vector<std::pair<std::string, std::string>> preferredFolders = {
+            {"gltf_low", ".glb"},
+            {"gltf", ".glb"},
+            {"gltf_high", ".glb"},
+            {"glb", ".glb"},
+            {"3ds_low", ".3ds"},
+            {"3ds", ".3ds"},
+            {"3ds_high", ".3ds"},
+        };
+        for (const auto& [folder, extension] : preferredFolders) {
+            const fs::path candidate = modelsDir / folder / (requestedName + extension);
+            if (std::string resolved = tryCandidate(candidate); !resolved.empty())
+                return resolved;
         }
     }
+
+    static std::unordered_map<std::string, std::vector<fs::path>> modelFileIndexCache;
+    auto indexIt = modelFileIndexCache.find(modelsDir.string());
+    if (indexIt == modelFileIndexCache.end()) {
+        std::vector<fs::path> indexedPaths;
+        for (const auto& entry : fs::recursive_directory_iterator(modelsDir)) {
+            if (entry.is_regular_file())
+                indexedPaths.push_back(entry.path());
+        }
+        indexIt = modelFileIndexCache.emplace(modelsDir.string(), std::move(indexedPaths)).first;
+    }
+
+    for (const fs::path& path : indexIt->second) {
+        if (hasExtension) {
+            if (ToLower(path.filename().string()) == ToLower(requestedName))
+                return path.string();
+            continue;
+        }
+        if (ToLower(path.stem().string()) != ToLower(requestedName))
+            continue;
+        if (HasExtension(path, ".glb") || HasExtension(path, ".3ds"))
+            return path.string();
+    }
+
     return {};
 }
 
@@ -1232,10 +1257,27 @@ static void ParseGeometry(tinyxml2::XMLElement* node,
                         bool alreadyFailed = failedModelLoads && failedModelLoads->find(path) != failedModelLoads->end();
                         if (!alreadyFailed) {
                             bool loaded = false;
-                            if (HasExtension(path, ".3ds"))
+                            bool tried3ds = false;
+                            bool triedGlb = false;
+                            const fs::path loadedPath = fs::u8path(path);
+                            std::string fallbackGlbPath;
+
+                            if (HasExtension(loadedPath, ".3ds")) {
+                                tried3ds = true;
                                 loaded = Load3DS(path, mesh, false);
-                            else if (HasExtension(path, ".glb"))
+                                if (!loaded) {
+                                    fallbackGlbPath = FindModelFile(baseDir, loadedPath.stem().string());
+                                    if (!fallbackGlbPath.empty() && HasExtension(fs::u8path(fallbackGlbPath), ".glb")) {
+                                        triedGlb = true;
+                                        loaded = LoadGLB(fallbackGlbPath, mesh);
+                                        if (loaded)
+                                            path = fallbackGlbPath;
+                                    }
+                                }
+                            } else if (HasExtension(loadedPath, ".glb")) {
+                                triedGlb = true;
                                 loaded = LoadGLB(path, mesh);
+                            }
 
                             if (loaded) {
                                 ApplyModelDimensions(mesh, modelInfo);
@@ -1246,7 +1288,15 @@ static void ParseGeometry(tinyxml2::XMLElement* node,
                                     shouldLog = failedModelLoads->insert(path).second;
 
                                 if (shouldLog && ConsolePanel::Instance()) {
-                                    wxString msg = wxString::Format("GDTF: failed to load model %s", wxString::FromUTF8(path));
+                                    wxString msg;
+                                    if (tried3ds && triedGlb) {
+                                        msg = wxString::Format(
+                                            "GDTF: failed to load model %s and fallback %s",
+                                            wxString::FromUTF8(path),
+                                            wxString::FromUTF8(fallbackGlbPath));
+                                    } else {
+                                        msg = wxString::Format("GDTF: failed to load model %s", wxString::FromUTF8(path));
+                                    }
                                     ConsolePanel::Instance()->AppendMessage(msg);
                                 }
                             }

--- a/viewer3d/loader3ds.cpp
+++ b/viewer3d/loader3ds.cpp
@@ -416,14 +416,17 @@ static void parseMesh(std::ifstream& file, long endPos, Mesh& mesh, size_t verte
 }
 
 // Loads mesh/object data from a 3DS file, with optional local transform application.
-bool Load3DS(const std::string& path, Mesh& outMesh, bool applyObjectLocalTransform)
+// Loads a 3DS file into a mesh and reports failure details when geometry cannot be produced.
+bool Load3DS(const std::string& path, Mesh& outMesh, bool applyObjectLocalTransform, std::string* error)
 {
     std::ifstream file(path, std::ios::binary);
-    if(!file.is_open())
+    if(!file.is_open()) {
+        if (error) *error = "cannot open file";
         return false;
+    }
 
-    Chunk root; if(!readChunk(file, root)) return false;
-    if(root.id != 0x4D4D) return false;
+    Chunk root; if(!readChunk(file, root)) { if (error) *error = "invalid 3DS root chunk"; return false; }
+    if(root.id != 0x4D4D) { if (error) *error = "unexpected 3DS root chunk id"; return false; }
     long rootEnd = root.length;
 
     std::unordered_map<std::string, std::array<float, 3>> materials;
@@ -504,6 +507,8 @@ bool Load3DS(const std::string& path, Mesh& outMesh, bool applyObjectLocalTransf
     }
 
     bool ok = !outMesh.vertices.empty() && !outMesh.indices.empty();
+    if (!ok && error)
+        *error = "no vertices or faces found";
     if (ok && colorAccum.weight > 0.0) {
         outMesh.materialBaseColor = {
             static_cast<float>(colorAccum.r / colorAccum.weight),

--- a/viewer3d/loader3ds.h
+++ b/viewer3d/loader3ds.h
@@ -20,4 +20,4 @@
 #include "mesh.h"
 
 // Loads a 3DS mesh and optionally applies per-object local pivot/basis transforms.
-bool Load3DS(const std::string& path, Mesh& outMesh, bool applyObjectLocalTransform = true);
+bool Load3DS(const std::string& path, Mesh& outMesh, bool applyObjectLocalTransform = true, std::string* error = nullptr);

--- a/viewer3d/loaderglb.cpp
+++ b/viewer3d/loaderglb.cpp
@@ -170,7 +170,8 @@ static std::optional<GLBFile> ParseGLBFile(const std::string& path, std::string&
     return result;
 }
 
-bool LoadGLB(const std::string& path, Mesh& outMesh)
+// Loads a GLB file into a mesh by concatenating all available primitives across scene nodes.
+bool LoadGLB(const std::string& path, Mesh& outMesh, std::string* error)
 {
     outMesh.vertices.clear();
     outMesh.indices.clear();
@@ -184,14 +185,18 @@ bool LoadGLB(const std::string& path, Mesh& outMesh)
                                  wxString::FromUTF8(path),
                                  wxString::FromUTF8(parseError)));
         }
+        if (error)
+            *error = parseError;
         return false;
     }
 
     const json& doc = glbFile->doc;
     const auto& binData = glbFile->binData;
 
-    if(!doc.contains("meshes"))
+    if(!doc.contains("meshes")) {
+        if (error) *error = "no meshes in glTF document";
         return false;
+    }
 
     auto readInt = [](const json& j, int& out) {
         if(!j.is_number_integer())
@@ -258,7 +263,8 @@ bool LoadGLB(const std::string& path, Mesh& outMesh)
         size_t bufferIdx = 0;
         if(view.contains("buffer") && !readSize(view["buffer"], bufferIdx))
             return false;
-        if(bufferIdx != 0) return false; // only single embedded buffer supported
+        if(!doc.contains("buffers") || !doc["buffers"].is_array() || bufferIdx >= doc["buffers"].size())
+            return false;
         return true;
     };
 
@@ -670,6 +676,8 @@ bool LoadGLB(const std::string& path, Mesh& outMesh)
 
     if (ok)
         ComputeNormals(outMesh);
+    if (!ok && error)
+        *error = "unsupported glTF structure or missing positions/indices";
 
     if(kLogGlbMessages && ConsolePanel::Instance()) {
         wxString msg;

--- a/viewer3d/loaderglb.h
+++ b/viewer3d/loaderglb.h
@@ -22,4 +22,4 @@
 // Minimal loader for GLB (glTF 2.0 binary) files. The loader parses all nodes
 // and primitives of the file and applies the node transforms so that compound
 // models are assembled correctly.
-bool LoadGLB(const std::string& path, Mesh& outMesh);
+bool LoadGLB(const std::string& path, Mesh& outMesh, std::string* error = nullptr);


### PR DESCRIPTION
### Motivation
- GDTF archives place glTF/GLB models under `models/gltf` and can provide LOD folders, so the loader must follow the spec and prefer GLB when available.
- The previous lookup and load order caused valid GLB models to be missed or only found by expensive recursion, and a failed `.3ds` load would not fall back to a `.glb` with the same stem.
- Model filenames may include spaces or non-ASCII bytes and repeated directory scans are wasteful, so path construction and caching should be improved.

### Description
- Updated `FindModelFile` in `viewer3d/gdtfloader.cpp` to use `fs::u8path` and to probe spec-compliant folders (`gltf_low`, `gltf`, `gltf_high`) first, then legacy `glb`, and then `3ds_low`/`3ds`/`3ds_high`, with a cached recursive-index fallback for compatibility.
- Changed extension handling so extensionless `File=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a168680eb108324a1c5452f16c58d5f)