### PR TITLE
Fix truss center anchoring in 3D measure overlay

### DIFF
--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -1190,7 +1190,9 @@ std::optional<std::array<float, 3>> Viewer3DPanel::ResolveMeasureWorldFromUuid(
     if (target == HoverTargetTable::Fixtures)
         return extract(scene.fixtures);
     if (target == HoverTargetTable::Trusses) {
-        if (const auto* trussBounds = m_controller.FindTrussBounds(uuid)) {
+        const auto& selectionContext =
+            static_cast<const ISelectionContext&>(m_controller);
+        if (const auto* trussBounds = selectionContext.FindTrussBounds(uuid)) {
             return std::array<float, 3>{
                 0.5f * (trussBounds->min[0] + trussBounds->max[0]),
                 0.5f * (trussBounds->min[1] + trussBounds->max[1]),

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -1189,8 +1189,15 @@ std::optional<std::array<float, 3>> Viewer3DPanel::ResolveMeasureWorldFromUuid(
     };
     if (target == HoverTargetTable::Fixtures)
         return extract(scene.fixtures);
-    if (target == HoverTargetTable::Trusses)
+    if (target == HoverTargetTable::Trusses) {
+        if (const auto* trussBounds = m_controller.FindTrussBounds(uuid)) {
+            return std::array<float, 3>{
+                0.5f * (trussBounds->min[0] + trussBounds->max[0]),
+                0.5f * (trussBounds->min[1] + trussBounds->max[1]),
+                0.5f * (trussBounds->min[2] + trussBounds->max[2])};
+        }
         return extract(scene.trusses);
+    }
     if (target == HoverTargetTable::SceneObjects)
         return extract(scene.sceneObjects);
     return std::nullopt;


### PR DESCRIPTION
### Motivation
- Measurements between trusses were drawn with endpoints offset outside the visible truss geometry because the measure anchor used the truss transform origin rather than the rendered bounding-box center. This caused dimension labels to appear in the wrong place even when distances were numerically correct.

### Description
- Update `Viewer3DPanel::ResolveMeasureWorldFromUuid` so that when `target == HoverTargetTable::Trusses` it queries `m_controller.FindTrussBounds(uuid)` and returns the world-space center computed as `(min+max)/2` from the `Viewer3DBoundingBox` when available.
- Preserve the existing `extract(scene.trusses)` behavior as a fallback when truss bounds are not available, and keep fixture and scene-object resolution unchanged.
- Change is scoped to `viewer3d/viewer3dpanel.cpp` and does not alter measurement logic beyond the truss center resolution.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed (`OK`).
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed (`OK`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17397230708324b9ae621119379935)