### PR TITLE
Decouple layout viewer zoom cache invalidation

### DIFF
--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -106,6 +106,7 @@ constexpr int kToggleTextFrameMenuId = wxID_HIGHEST + 503;
 constexpr int kToggleTextTransparentBackgroundMenuId = wxID_HIGHEST + 504;
 constexpr int kToggleViewFrameMenuId = wxID_HIGHEST + 506;
 constexpr int kLoadingOverlayDelayMs = 150;
+constexpr int kZoomRenderDebounceMs = 180;
 
 void ValidateGlStateAfterRender(const char *stage, int expectedWidth,
                                 int expectedHeight) {
@@ -1561,6 +1562,7 @@ void LayoutViewerPanel::OnMouseMove(wxMouseEvent &event) {
   Refresh();
 }
 
+// Updates visual zoom around the cursor and defers high-quality cache rendering.
 void LayoutViewerPanel::OnMouseWheel(wxMouseEvent &event) {
   if (dragMode != FrameDragMode::None)
     return;
@@ -1588,8 +1590,9 @@ void LayoutViewerPanel::OnMouseWheel(wxMouseEvent &event) {
 
   panOffset += relative - newRelative;
   zoom = newZoom;
-  InvalidateRenderIfFrameChanged();
-  RequestRenderRebuild();
+  if (renderDelayTimer_.IsRunning())
+    renderDelayTimer_.Stop();
+  renderDelayTimer_.StartOnce(kZoomRenderDebounceMs);
   Refresh();
 }
 
@@ -1985,8 +1988,32 @@ wxSize LayoutViewerPanel::GetFrameSizeForZoom(
   return wxSize(scaledWidth, scaledHeight);
 }
 
+// Quantizes the current visual zoom into a stable raster-cache LOD bucket.
 double LayoutViewerPanel::GetRenderZoom() const {
-  return zoom;
+  if (zoom <= 0.0)
+    return kMinZoom;
+
+  const double safeMaxZoom = GetLayoutSafeMaxZoom(currentLayout);
+  const double zoomSteps = std::log(zoom) / std::log(kZoomStep);
+  const double bucketSteps =
+      std::round(zoomSteps / kZoomCacheStepsPerLevel) *
+      kZoomCacheStepsPerLevel;
+  const double bucketZoom = std::pow(kZoomStep, bucketSteps);
+  return std::clamp(bucketZoom, kMinZoom, safeMaxZoom);
+}
+
+// Determines whether a cached raster is far enough from the target LOD to rebuild.
+bool LayoutViewerPanel::ShouldRebuildCacheForRenderZoom(
+    double cachedRenderZoom, double targetRenderZoom) const {
+  if (cachedRenderZoom <= 0.0)
+    return true;
+  if (targetRenderZoom <= 0.0)
+    return true;
+
+  const double levelRatio = std::pow(kZoomStep, kZoomCacheStepsPerLevel);
+  const double halfLevelRatio = std::sqrt(levelRatio);
+  return targetRenderZoom >= cachedRenderZoom * halfLevelRatio ||
+         targetRenderZoom <= cachedRenderZoom / halfLevelRatio;
 }
 
 bool LayoutViewerPanel::GetSelectedFrame(
@@ -3042,7 +3069,8 @@ void LayoutViewerPanel::ProcessDeferredRenderRebuild() {
 
 // Rebuilds stale cached textures when the delayed render timer callback fires.
 void LayoutViewerPanel::OnRenderDelayTimer(wxTimerEvent &) {
-  ProcessDeferredRenderRebuild();
+  InvalidateRenderIfFrameChanged();
+  RequestRenderRebuild();
 }
 
 bool LayoutViewerPanel::AreTexturesReady() const {

--- a/gui/layoutviewerpanel.h
+++ b/gui/layoutviewerpanel.h
@@ -177,6 +177,8 @@ private:
   wxSize GetFrameSizeForZoom(const layouts::Layout2DViewFrame &frame,
                              double targetZoom) const;
   double GetRenderZoom() const;
+  bool ShouldRebuildCacheForRenderZoom(double cachedRenderZoom,
+                                       double targetRenderZoom) const;
   void UpdateFrame(const layouts::Layout2DViewFrame &frame,
                    bool updatePosition);
   void UpdateLegendFrame(const layouts::Layout2DViewFrame &frame,

--- a/gui/layoutviewerpanel_render_invalidation.cpp
+++ b/gui/layoutviewerpanel_render_invalidation.cpp
@@ -23,14 +23,17 @@
 #include "guiconfigservices.h"
 
 namespace {
+// Mixes a value into an aggregate hash seed.
 void HashCombine(size_t &seed, size_t value) {
   seed ^= value + 0x9e3779b9 + (seed << 6) + (seed >> 2);
 }
 
+// Mixes a floating-point value into an aggregate hash seed.
 void HashCombineFloat(size_t &seed, float value) {
   HashCombine(seed, std::hash<float>{}(value));
 }
 
+// Hashes a transform matrix for scene-content change detection.
 size_t HashMatrixValue(const Matrix &matrix) {
   size_t hash = 0;
   HashCombineFloat(hash, matrix.u[0]);
@@ -48,6 +51,7 @@ size_t HashMatrixValue(const Matrix &matrix) {
   return hash;
 }
 
+// Hashes a scene object and its nested geometry data.
 size_t HashSceneObjectValue(const SceneObject &object) {
   size_t hash = std::hash<std::string>{}(object.layer);
   HashCombine(hash, std::hash<std::string>{}(object.name));
@@ -61,6 +65,7 @@ size_t HashSceneObjectValue(const SceneObject &object) {
   return hash;
 }
 
+// Hashes fixture fields that affect layout rendering output.
 size_t HashFixtureValue(const Fixture &fixture) {
   size_t hash = std::hash<std::string>{}(fixture.layer);
   HashCombine(hash, std::hash<std::string>{}(fixture.instanceName));
@@ -72,6 +77,7 @@ size_t HashFixtureValue(const Fixture &fixture) {
   return hash;
 }
 
+// Hashes truss fields that affect layout rendering output.
 size_t HashTrussValue(const Truss &truss) {
   size_t hash = std::hash<std::string>{}(truss.layer);
   HashCombine(hash, std::hash<std::string>{}(truss.name));
@@ -81,6 +87,7 @@ size_t HashTrussValue(const Truss &truss) {
   return hash;
 }
 
+// Hashes support fields that affect layout rendering output.
 size_t HashSupportValue(const Support &support) {
   size_t hash = std::hash<std::string>{}(support.layer);
   HashCombine(hash, std::hash<std::string>{}(support.name));
@@ -89,6 +96,7 @@ size_t HashSupportValue(const Support &support) {
   return hash;
 }
 
+// Aggregates a scene map into an order-stable content hash.
 template <typename TMap, typename ValueHasher>
 size_t HashSceneMapWithValues(const TMap &items, ValueHasher hasher) {
   size_t aggregate = std::hash<size_t>{}(items.size());
@@ -101,6 +109,7 @@ size_t HashSceneMapWithValues(const TMap &items, ValueHasher hasher) {
 }
 } // namespace
 
+// Computes a scene-wide hash for data that can affect layout previews.
 size_t LayoutViewerPanel::ComputeSceneContentHash() const {
   const auto &scene = GetDefaultGuiConfigServices().LegacyConfigManager().GetScene();
   size_t hash = 0;
@@ -111,6 +120,7 @@ size_t LayoutViewerPanel::ComputeSceneContentHash() const {
   return hash;
 }
 
+// Computes a view-specific hash for camera, render options, and layer filters.
 size_t LayoutViewerPanel::HashViewContent(
     const layouts::Layout2DViewDefinition &view) const {
   size_t seed = std::hash<int>{}(view.id);
@@ -162,11 +172,13 @@ size_t LayoutViewerPanel::HashViewContent(
   return seed;
 }
 
+// Marks cached layout rasters dirty only when content or LOD changes require it.
 void LayoutViewerPanel::InvalidateRenderIfFrameChanged(bool includeSceneContent) {
   const double renderZoom = GetRenderZoom();
   const double pageWidth = currentLayout.pageSetup.PageWidthPt();
   const double pageHeight = currentLayout.pageSetup.PageHeightPt();
-  const bool zoomChanged = lastRenderZoom != renderZoom;
+  const bool zoomChanged =
+      ShouldRebuildCacheForRenderZoom(lastRenderZoom, renderZoom);
   const bool pageChanged =
       lastPageWidthPt != pageWidth || lastPageHeightPt != pageHeight;
   size_t sceneContentHash = lastSceneContentHash;
@@ -204,7 +216,8 @@ void LayoutViewerPanel::InvalidateRenderIfFrameChanged(bool includeSceneContent)
       continue;
     }
     const wxSize renderSize = GetFrameSizeForZoom(view.frame, renderZoom);
-    if (cache.renderZoom == 0.0 || cache.renderZoom != renderZoom ||
+    if (cache.texture == 0 ||
+        ShouldRebuildCacheForRenderZoom(cache.renderZoom, renderZoom) ||
         renderSize != cache.textureSize) {
       markDirty(cache.renderDirty);
     }
@@ -227,7 +240,8 @@ void LayoutViewerPanel::InvalidateRenderIfFrameChanged(bool includeSceneContent)
       continue;
     }
     const wxSize renderSize = GetFrameSizeForZoom(legend.frame, renderZoom);
-    if (cache.renderZoom == 0.0 || cache.renderZoom != renderZoom ||
+    if (cache.texture == 0 ||
+        ShouldRebuildCacheForRenderZoom(cache.renderZoom, renderZoom) ||
         renderSize != cache.textureSize) {
       markDirty(cache.renderDirty);
     }
@@ -246,7 +260,8 @@ void LayoutViewerPanel::InvalidateRenderIfFrameChanged(bool includeSceneContent)
       continue;
     }
     const wxSize renderSize = GetFrameSizeForZoom(table.frame, renderZoom);
-    if (cache.renderZoom == 0.0 || cache.renderZoom != renderZoom ||
+    if (cache.texture == 0 ||
+        ShouldRebuildCacheForRenderZoom(cache.renderZoom, renderZoom) ||
         renderSize != cache.textureSize) {
       markDirty(cache.renderDirty);
     }
@@ -265,7 +280,8 @@ void LayoutViewerPanel::InvalidateRenderIfFrameChanged(bool includeSceneContent)
       continue;
     }
     const wxSize renderSize = GetFrameSizeForZoom(text.frame, renderZoom);
-    if (cache.renderZoom == 0.0 || cache.renderZoom != renderZoom ||
+    if (cache.texture == 0 ||
+        ShouldRebuildCacheForRenderZoom(cache.renderZoom, renderZoom) ||
         renderSize != cache.textureSize) {
       markDirty(cache.renderDirty);
     }
@@ -284,7 +300,8 @@ void LayoutViewerPanel::InvalidateRenderIfFrameChanged(bool includeSceneContent)
       continue;
     }
     const wxSize renderSize = GetFrameSizeForZoom(image.frame, renderZoom);
-    if (cache.renderZoom == 0.0 || cache.renderZoom != renderZoom ||
+    if (cache.texture == 0 ||
+        ShouldRebuildCacheForRenderZoom(cache.renderZoom, renderZoom) ||
         renderSize != cache.textureSize) {
       markDirty(cache.renderDirty);
     }
@@ -302,6 +319,7 @@ void LayoutViewerPanel::InvalidateRenderIfFrameChanged(bool includeSceneContent)
   }
 }
 
+// Invalidates render data after scene content changes and queues a rebuild.
 void LayoutViewerPanel::RefreshAfterSceneContentUpdate() {
   legendDataDirty_ = true;
   RefreshLegendData();
@@ -325,10 +343,12 @@ void LayoutViewerPanel::RefreshAfterSceneContentUpdate() {
   Refresh();
 }
 
+// Refreshes the layout viewer after selection-only updates.
 void LayoutViewerPanel::RefreshAfterSelectionOnlyUpdate() {
   Refresh();
 }
 
+// Invalidates render data after fixture symbol changes.
 void LayoutViewerPanel::RefreshAfterFixtureSymbolUpdate() {
   RefreshAfterSceneContentUpdate();
 }


### PR DESCRIPTION
### Motivation
- Improve interactive zoom responsiveness by separating the visual zoom used for immediate UI feedback from the rasterization LOD used for cached GPU textures.
- Avoid rebuilding heavy offscreen textures on every mouse-wheel tick and instead perform a deferred high-quality render once user scrolling stops.

### Description
- On mouse-wheel events `OnMouseWheel` now only updates `zoom` and `panOffset`, starts a debounce timer (`kZoomRenderDebounceMs`) and calls `Refresh()` so existing textures are scaled for immediate feedback.
- Introduced LOD quantization in `GetRenderZoom()` using the existing `kZoomCacheStepsPerLevel` to map visual zoom into stable cache buckets, and added `ShouldRebuildCacheForRenderZoom()` to decide when a cached raster needs regeneration.
- Updated `InvalidateRenderIfFrameChanged()` to stop using exact `cache.renderZoom != renderZoom` checks and instead mark caches dirty only when a texture is missing, content/frame/size changed, or `ShouldRebuildCacheForRenderZoom()` indicates a significant LOD crossing.
- Changed the delayed-render timer handler to call `InvalidateRenderIfFrameChanged()` and `RequestRenderRebuild()` so high-quality texture rebuilds occur after the debounce period without blocking UI interaction.
- Added concise one-line English comments above the modified function definitions and helper utilities to explain primary purpose.

### Testing
- Ran layout quality/sanity checks: `tests/check_perastage_tree_modules.sh && tests/check_no_configmanager_get_in_gui.sh` — OK.
- Ran `git diff --check` for whitespace/patch issues — OK.
- Attempted a Debug configure/build: `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug && cmake --build build --target Perastage -j2` — configuration failed due to missing wxWidgets development files in the environment (expected in this CI/dev environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1af545369c832492a08241aa190ed4)