### PR TITLE
Fix 2D scene object depth sorting

### DIFF
--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -1106,6 +1106,7 @@ const Viewer3DController::VisibleSet &Viewer3DController::PrepareRenderFrame(
         (context.is2DViewer && m_impl->sortedListsLastView != context.view);
     if ((m_impl->sortedListsDirty || viewSortChanged) &&
         !context.skipOptionalWork) {
+      // Computes the transform-origin depth used by fixtures, trusses, and fallback object sorting.
       const auto sortDepthKey = [&](const Matrix &transform) {
         if (!context.is2DViewer)
           return transform.o[2];
@@ -1122,14 +1123,51 @@ const Viewer3DController::VisibleSet &Viewer3DController::PrepareRenderFrame(
           return transform.o[2];
         }
       };
+      // Computes scene-object 2D sort depth from cached world bounds when available.
+      const auto sceneObjectSortDepthKey = [&](const auto *entry) {
+        const auto &transform = entry->second.transform;
+        if (!context.is2DViewer)
+          return sortDepthKey(transform);
+
+        const auto &uuid = entry->first;
+        EnsureBoundsComputed(uuid, ItemType::SceneObject, context.hiddenLayers);
+        const auto boundsIt = m_impl->objectBounds.find(uuid);
+        if (boundsIt == m_impl->objectBounds.end())
+          return sortDepthKey(transform);
+
+        const auto &bounds = boundsIt->second;
+        switch (context.view) {
+        case Viewer2DView::Top:
+          return bounds.max[2];
+        case Viewer2DView::Bottom:
+          return -bounds.min[2];
+        case Viewer2DView::Front:
+          return -bounds.max[1];
+        case Viewer2DView::Side:
+          return -bounds.max[0];
+        default:
+          return sortDepthKey(transform);
+        }
+      };
+      std::unordered_map<std::string, float> sceneObjectSortDepthKeys;
+      sceneObjectSortDepthKeys.reserve(sceneObjects.size());
       m_impl->sortedObjects.clear();
       m_impl->sortedObjects.reserve(sceneObjects.size());
-      for (const auto &obj : sceneObjects)
+      for (const auto &obj : sceneObjects) {
         m_impl->sortedObjects.push_back(&obj);
+        sceneObjectSortDepthKeys.emplace(obj.first,
+                                         sceneObjectSortDepthKey(&obj));
+      }
+      // Returns the precomputed scene-object sort depth for a sorted-list entry.
+      const auto sceneObjectSortDepth = [&](const auto *entry) {
+        const auto keyIt = sceneObjectSortDepthKeys.find(entry->first);
+        if (keyIt != sceneObjectSortDepthKeys.end())
+          return keyIt->second;
+        return sortDepthKey(entry->second.transform);
+      };
       std::sort(m_impl->sortedObjects.begin(), m_impl->sortedObjects.end(),
                 [&](const auto *a, const auto *b) {
-                  return sortDepthKey(a->second.transform) <
-                         sortDepthKey(b->second.transform);
+                  return sceneObjectSortDepth(a) < sceneObjectSortDepth(b);
                 });
 
       m_impl->sortedTrusses.clear();


### PR DESCRIPTION
### Motivation
- The 2D viewer z-sorting used the transform origin for all items, causing scene objects with taller geometry to be drawn beneath lower structures when their transform origins matched.
- Scene objects should be sorted by their world-space bounds in 2D views (Top/Bottom/Front/Side) so taller geometry renders above lower geometry like in 3D.
- Fixtures and trusses must keep the existing transform-origin-based sort behavior to avoid changing established draw order for those types.

### Description
- In `Viewer3DController::PrepareRenderFrame` (`viewer3d/viewer3dcontroller.cpp`), added `sceneObjectSortDepthKey` which calls `EnsureBoundsComputed(uuid, ItemType::SceneObject, context.hiddenLayers)` and uses `m_impl->objectBounds` to derive per-view depth keys (`bounds.max.z`, `-bounds.min.z`, `-bounds.max.y`, `-bounds.max.x`) with fallbacks to the original `sortDepthKey` when bounds are unavailable.
- Precompute scene-object sort depths (cached per-frame in a `std::unordered_map`) and use the precomputed keys in the sort comparator to avoid repeated lookups inside the comparator.
- Left fixtures and trusses unchanged by continuing to use the original `sortDepthKey(transform)` behavior for those lists.
- Technical note: this change touches the hotspot `viewer3d/viewer3dcontroller.cpp`; extraction of the sorted-list preparation to a dedicated helper/module is recommended as a follow-up split to keep the controller smaller.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.
- Ran `git diff --check` and it returned no problems.
- Ran `cmake -S . -B build` and `cmake --build build --config Release` and the project configured and built successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dcf9cb07883248e3292aa01d7f0fd)