### PR TITLE
Add project symbol cache manifest

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -34,6 +34,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/riderimporter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scenedatamanager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/simplecrypt.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/symbol_cache_manifest.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/symbols/Symbol2DImageBuilder.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/symbols/SymbolGeometrySimplifier.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/symbols/Symbol2DBuilder.cpp

--- a/core/configmanager.cpp
+++ b/core/configmanager.cpp
@@ -32,6 +32,7 @@
 #include <algorithm>
 #include <chrono>
 #include <iterator>
+#include <utility>
 #include <wx/stdpaths.h>
 
 
@@ -391,10 +392,22 @@ void ConfigManager::SetCurrentLayer(const std::string &name) {
 
 // -- Scene access --
 
+// Returns the mutable scene owned by the active project session.
 MvrScene &ConfigManager::GetScene() { return projectSession.GetScene(); }
 
+// Returns the read-only scene owned by the active project session.
 const MvrScene &ConfigManager::GetScene() const {
   return projectSession.GetScene();
+}
+
+// Returns mutable project-level fixture symbol cache metadata.
+symbol_cache::SymbolCacheManifest &ConfigManager::GetSymbolCacheManifest() {
+  return symbolCacheManifest;
+}
+
+// Returns read-only project-level fixture symbol cache metadata.
+const symbol_cache::SymbolCacheManifest &ConfigManager::GetSymbolCacheManifest() const {
+  return symbolCacheManifest;
 }
 
 const std::vector<std::string> &ConfigManager::GetSelectedFixtures() const {
@@ -476,11 +489,22 @@ bool ConfigManager::SaveProject(const std::string &path) {
                 " scene_bytes=" + std::to_string(sceneBytes.size()));
         return exported;
       },
-      []() {
+      [this]() {
         std::vector<ProjectSession::ArchiveResource> resources;
         for (const auto &entry :
              layouts::LayoutImageResourceRegistry::Get().UsedResources()) {
           resources.push_back({entry.archivePath, entry.bytes});
+        }
+
+        std::string manifestError;
+        if (auto manifestResource =
+                symbolCacheManifest.ToArchiveResource(manifestError)) {
+          resources.push_back(
+              {manifestResource->entryName, std::move(manifestResource->bytes)});
+        } else if (!manifestError.empty()) {
+          Logger::Instance().Log(Logger::Level::Warning,
+                                 "Could not serialize symbol cache manifest: " +
+                                     manifestError);
         }
         return resources;
       });
@@ -489,8 +513,16 @@ bool ConfigManager::SaveProject(const std::string &path) {
   return ok;
 }
 
+// Loads a project package and restores optional symbol cache metadata.
 bool ConfigManager::LoadProject(const std::string &path,
                                 LoadProjectProgressCallback progressCallback) {
+  std::string manifestError;
+  if (!symbolCacheManifest.LoadFromProjectArchive(path, manifestError)) {
+    Logger::Instance().Log(Logger::Level::Warning,
+                           "Ignoring symbol cache manifest: " + manifestError);
+    symbolCacheManifest.Clear();
+  }
+
   const bool hasUserView2dDarkMode = HasKey("view2d_dark_mode");
   const float userView2dDarkMode = GetFloat("view2d_dark_mode");
   auto restoreUserPreferences = [this, hasUserView2dDarkMode,
@@ -538,13 +570,17 @@ bool ConfigManager::LoadProject(const std::string &path,
     ClearHistory();
     selectionState.Clear();
     projectSession.ResetDirty();
+  } else {
+    symbolCacheManifest.Clear();
   }
   return ok;
 }
 
+// Resets configuration, symbol cache metadata, and scene state for a fresh project.
 void ConfigManager::Reset() {
   RevisionGuard guard(*this);
   preferencesStore.ClearValues();
+  symbolCacheManifest.Clear();
   projectSession.GetScene().Clear();
   if (!HasKey("ui_distance_unit_system"))
     SetValue("ui_distance_unit_system", "metric");

--- a/core/configmanager.h
+++ b/core/configmanager.h
@@ -24,6 +24,7 @@
 #include <vector>
 #include <functional>
 #include "configservices.h"
+#include "symbol_cache_manifest.h"
 
 // Singleton to manage configuration and MVR scene data globally
 class ConfigManager
@@ -55,6 +56,10 @@ public:
     // Access to current MVR scene (modifiable)
     MvrScene& GetScene();
     const MvrScene& GetScene() const;
+
+    // Access project-level fixture symbol cache metadata.
+    symbol_cache::SymbolCacheManifest& GetSymbolCacheManifest();
+    const symbol_cache::SymbolCacheManifest& GetSymbolCacheManifest() const;
 
     // Current selections for different object types
     const std::vector<std::string>& GetSelectedFixtures() const;
@@ -137,6 +142,7 @@ private:
     SelectionState selectionState;
     HistoryManager historyManager;
     LayerVisibilityState layerVisibilityState;
+    symbol_cache::SymbolCacheManifest symbolCacheManifest;
 
     bool suppressRevision = false;
 };

--- a/core/symbol_cache_manifest.cpp
+++ b/core/symbol_cache_manifest.cpp
@@ -1,0 +1,358 @@
+#include "symbol_cache_manifest.h"
+
+#include <array>
+#include <chrono>
+#include <ctime>
+#include <exception>
+#include <fstream>
+#include <iomanip>
+#include <memory>
+#include <sstream>
+#include <utility>
+
+#include <wx/wfstream.h>
+#include <wx/zipstrm.h>
+
+#include "json.hpp"
+
+namespace symbol_cache {
+namespace {
+
+// Finds the manifest entry that belongs to the requested fixture key.
+const FixtureSymbolCacheEntry *FindEntry(
+    const std::vector<FixtureSymbolCacheEntry> &entries,
+    const std::string &fixtureKey) {
+  for (const auto &entry : entries) {
+    if (entry.fixtureKey == fixtureKey)
+      return &entry;
+  }
+  return nullptr;
+}
+
+// Finds the mutable manifest entry that belongs to the requested fixture key.
+FixtureSymbolCacheEntry *FindMutableEntry(
+    std::vector<FixtureSymbolCacheEntry> &entries,
+    const std::string &fixtureKey) {
+  for (auto &entry : entries) {
+    if (entry.fixtureKey == fixtureKey)
+      return &entry;
+  }
+  return nullptr;
+}
+
+// Reads the active ZIP entry into a UTF-8 string buffer.
+bool ReadZipEntryText(wxZipInputStream &zip, std::string &out) {
+  out.clear();
+  std::array<char, 4096> buffer{};
+  while (true) {
+    zip.Read(buffer.data(), buffer.size());
+    const size_t count = zip.LastRead();
+    if (count == 0)
+      break;
+    out.append(buffer.data(), count);
+  }
+  return true;
+}
+
+// Converts a view list JSON array into a stable set of view names.
+std::set<std::string> ParseViews(const nlohmann::json &value) {
+  std::set<std::string> views;
+  if (!value.is_array())
+    return views;
+  for (const auto &view : value) {
+    if (view.is_string())
+      views.insert(view.get<std::string>());
+  }
+  return views;
+}
+
+// Serializes a stable set of view names as a JSON array.
+nlohmann::json SerializeViews(const std::set<std::string> &views) {
+  nlohmann::json output = nlohmann::json::array();
+  for (const std::string &view : views)
+    output.push_back(view);
+  return output;
+}
+
+} // namespace
+
+// Clears all manifest metadata and returns the service to an empty state.
+void SymbolCacheManifest::Clear() {
+  manifestFormatVersion = kCurrentManifestFormatVersion;
+  perastageSymbolFormatVersion = kCurrentPerastageSymbolFormatVersion;
+  loadedManifest = false;
+  entries.clear();
+}
+
+// Reports whether a manifest was loaded from the current project package.
+bool SymbolCacheManifest::HasLoadedManifest() const { return loadedManifest; }
+
+// Reports whether the loaded manifest format can be interpreted safely.
+bool SymbolCacheManifest::IsManifestFormatKnown() const {
+  return manifestFormatVersion == kCurrentManifestFormatVersion;
+}
+
+// Validates whether a fixture can safely skip deep GDTF symbol inspection.
+ValidationResult SymbolCacheManifest::ValidateFixture(
+    const ValidationRequest &request) const {
+  if (request.bypassManifest)
+    return {ValidationStatus::Bypassed, false,
+            "manifest bypass requested for explicit symbol regeneration"};
+  if (!loadedManifest)
+    return {ValidationStatus::MissingManifest, false,
+            "symbol cache manifest is missing"};
+  if (!IsManifestFormatKnown())
+    return {ValidationStatus::UnknownManifestVersion, false,
+            "symbol cache manifest format is unknown"};
+
+  const FixtureSymbolCacheEntry *entry = FindEntry(entries, request.fixtureKey);
+  if (!entry)
+    return {ValidationStatus::MissingEntry, false,
+            "fixture type is not present in the symbol cache manifest"};
+  if (perastageSymbolFormatVersion < kCurrentPerastageSymbolFormatVersion)
+    return {ValidationStatus::OutdatedSymbolFormat, false,
+            "manifest symbol format version is older than the supported format"};
+  if (entry->gdtfSpec != request.gdtfSpec)
+    return {ValidationStatus::GdtfSpecChanged, false,
+            "fixture GDTF path/spec changed since the manifest entry was written"};
+  if (entry->gdtfContentHash != request.gdtfContentHash)
+    return {ValidationStatus::GdtfHashChanged, false,
+            "fixture GDTF content hash changed since the manifest entry was written"};
+  if (!entry->hasPerastageSymbols)
+    return {ValidationStatus::SymbolsNotMarkedAvailable, false,
+            "manifest entry does not mark Perastage symbols as available"};
+
+  for (const std::string &view : request.requiredViews) {
+    if (entry->availableViews.find(view) == entry->availableViews.end()) {
+      return {ValidationStatus::MissingRequiredViews, false,
+              "manifest entry does not list every required symbol view"};
+    }
+  }
+
+  return {ValidationStatus::Valid, true,
+          "manifest entry matches the current fixture GDTF and required views"};
+}
+
+// Records that a fixture type has valid Perastage-generated symbols in its GDTF.
+void SymbolCacheManifest::MarkFixtureSymbolsValid(
+    const ValidationRequest &request, std::string timestampUtc) {
+  if (timestampUtc.empty())
+    timestampUtc = CurrentUtcTimestamp();
+
+  loadedManifest = true;
+  manifestFormatVersion = kCurrentManifestFormatVersion;
+  perastageSymbolFormatVersion = kCurrentPerastageSymbolFormatVersion;
+
+  FixtureSymbolCacheEntry *entry = FindMutableEntry(entries, request.fixtureKey);
+  if (!entry) {
+    entries.push_back({});
+    entry = &entries.back();
+  }
+
+  entry->fixtureKey = request.fixtureKey;
+  entry->fixtureTypeName = request.fixtureTypeName;
+  entry->gdtfSpec = request.gdtfSpec;
+  entry->gdtfContentHash = request.gdtfContentHash;
+  entry->hasPerastageSymbols = true;
+  entry->availableViews = request.requiredViews;
+  entry->lastGenerationTimestampUtc = std::move(timestampUtc);
+}
+
+// Loads manifest metadata from serialized JSON text without reading SVG data.
+bool SymbolCacheManifest::LoadFromJsonText(const std::string &jsonText,
+                                           std::string &errorMessage) {
+  Clear();
+  nlohmann::json root = nlohmann::json::parse(jsonText, nullptr, false);
+  if (root.is_discarded() || !root.is_object()) {
+    errorMessage = "Symbol cache manifest JSON is invalid.";
+    return false;
+  }
+
+  manifestFormatVersion = root.value("manifestFormatVersion", 0);
+  perastageSymbolFormatVersion = root.value("perastageSymbolFormatVersion", 0);
+  loadedManifest = true;
+
+  const nlohmann::json entriesJson =
+      root.value("fixtures", nlohmann::json::array());
+  if (entriesJson.is_array()) {
+    for (const auto &item : entriesJson) {
+      if (!item.is_object())
+        continue;
+      FixtureSymbolCacheEntry entry;
+      entry.fixtureKey = item.value("fixtureKey", std::string{});
+      entry.fixtureTypeName = item.value("fixtureTypeName", std::string{});
+      entry.gdtfSpec = item.value("gdtfSpec", std::string{});
+      entry.gdtfContentHash = item.value("gdtfContentHash", std::string{});
+      entry.hasPerastageSymbols = item.value("hasPerastageSymbols", false);
+      entry.availableViews =
+          ParseViews(item.value("availableViews", nlohmann::json::array()));
+      entry.lastGenerationTimestampUtc =
+          item.value("lastGenerationTimestampUtc", std::string{});
+      if (!entry.fixtureKey.empty())
+        entries.push_back(std::move(entry));
+    }
+  }
+
+  return true;
+}
+
+// Serializes manifest metadata to JSON text suitable for project archive storage.
+bool SymbolCacheManifest::SaveToJsonText(std::string &jsonText,
+                                         std::string &errorMessage) const {
+  nlohmann::json root = nlohmann::json::object();
+  root["manifestFormatVersion"] = kCurrentManifestFormatVersion;
+  root["perastageSymbolFormatVersion"] = kCurrentPerastageSymbolFormatVersion;
+  root["fixtures"] = nlohmann::json::array();
+
+  for (const auto &entry : entries) {
+    if (entry.fixtureKey.empty())
+      continue;
+    root["fixtures"].push_back(nlohmann::json{
+        {"fixtureKey", entry.fixtureKey},
+        {"fixtureTypeName", entry.fixtureTypeName},
+        {"gdtfSpec", entry.gdtfSpec},
+        {"gdtfContentHash", entry.gdtfContentHash},
+        {"hasPerastageSymbols", entry.hasPerastageSymbols},
+        {"availableViews", SerializeViews(entry.availableViews)},
+        {"lastGenerationTimestampUtc", entry.lastGenerationTimestampUtc}});
+  }
+
+  try {
+    jsonText = root.dump(2);
+  } catch (const std::exception &ex) {
+    errorMessage = ex.what();
+    return false;
+  }
+  return true;
+}
+
+// Loads the project-level manifest entry from a .pstg ZIP archive when present.
+bool SymbolCacheManifest::LoadFromProjectArchive(const std::string &projectPath,
+                                                 std::string &errorMessage) {
+  Clear();
+  wxFileInputStream input(projectPath);
+  if (!input.IsOk()) {
+    errorMessage = "Could not open project archive for symbol cache manifest.";
+    return false;
+  }
+
+  wxZipInputStream zip(input);
+  std::unique_ptr<wxZipEntry> entry;
+  while ((entry.reset(zip.GetNextEntry())), entry) {
+    if (entry->IsDir())
+      continue;
+    if (entry->GetName().ToStdString() != kProjectArchiveEntryName)
+      continue;
+    std::string jsonText;
+    if (!ReadZipEntryText(zip, jsonText)) {
+      errorMessage = "Could not read symbol cache manifest from project archive.";
+      return false;
+    }
+    return LoadFromJsonText(jsonText, errorMessage);
+  }
+
+  return true;
+}
+
+// Creates an optional archive resource for persisting the manifest in a .pstg file.
+std::optional<ManifestArchiveResource> SymbolCacheManifest::ToArchiveResource(
+    std::string &errorMessage) const {
+  if (entries.empty())
+    return std::nullopt;
+
+  std::string jsonText;
+  if (!SaveToJsonText(jsonText, errorMessage))
+    return std::nullopt;
+
+  ManifestArchiveResource resource;
+  resource.entryName = kProjectArchiveEntryName;
+  resource.bytes.assign(jsonText.begin(), jsonText.end());
+  return resource;
+}
+
+// Returns the immutable list of fixture entries currently held by the manifest.
+const std::vector<FixtureSymbolCacheEntry> &SymbolCacheManifest::Entries() const {
+  return entries;
+}
+
+// Computes a stable FNV-1a content hash for a GDTF file.
+std::string ComputeFileContentHash(const std::string &path,
+                                   std::string &errorMessage) {
+  std::ifstream input(path, std::ios::binary);
+  if (!input.is_open()) {
+    errorMessage = "Could not open GDTF file for symbol cache hashing.";
+    return {};
+  }
+
+  std::uint64_t hash = 1469598103934665603ull;
+  std::uint64_t size = 0;
+  std::array<char, 8192> buffer{};
+  while (input) {
+    input.read(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+    const std::streamsize count = input.gcount();
+    for (std::streamsize i = 0; i < count; ++i) {
+      hash ^= static_cast<unsigned char>(buffer[static_cast<size_t>(i)]);
+      hash *= 1099511628211ull;
+    }
+    size += static_cast<std::uint64_t>(count);
+  }
+
+  if (!input.eof()) {
+    errorMessage = "Could not read the complete GDTF file for symbol cache hashing.";
+    return {};
+  }
+
+  std::ostringstream out;
+  out << "fnv1a64:" << std::hex << std::setw(16) << std::setfill('0') << hash
+      << ":" << std::dec << size;
+  return out.str();
+}
+
+// Returns the complete set of views required before manifest validation can skip inspection.
+std::set<std::string> RequiredPerastageSymbolViews() {
+  return {"top", "bottom", "front", "side"};
+}
+
+// Returns the current UTC timestamp in a compact ISO-8601 format.
+std::string CurrentUtcTimestamp() {
+  const auto now = std::chrono::system_clock::now();
+  const std::time_t nowTime = std::chrono::system_clock::to_time_t(now);
+  std::tm utc{};
+#if defined(_WIN32)
+  gmtime_s(&utc, &nowTime);
+#else
+  gmtime_r(&nowTime, &utc);
+#endif
+  std::ostringstream out;
+  out << std::put_time(&utc, "%Y-%m-%dT%H:%M:%SZ");
+  return out.str();
+}
+
+// Returns a stable string name for a manifest validation status.
+const char *ValidationStatusName(ValidationStatus status) {
+  switch (status) {
+  case ValidationStatus::Valid:
+    return "valid";
+  case ValidationStatus::Bypassed:
+    return "bypassed";
+  case ValidationStatus::MissingManifest:
+    return "missing_manifest";
+  case ValidationStatus::UnknownManifestVersion:
+    return "unknown_manifest_version";
+  case ValidationStatus::MissingEntry:
+    return "missing_entry";
+  case ValidationStatus::OutdatedSymbolFormat:
+    return "outdated_symbol_format";
+  case ValidationStatus::GdtfSpecChanged:
+    return "gdtf_spec_changed";
+  case ValidationStatus::GdtfHashChanged:
+    return "gdtf_hash_changed";
+  case ValidationStatus::MissingRequiredViews:
+    return "missing_required_views";
+  case ValidationStatus::SymbolsNotMarkedAvailable:
+    return "symbols_not_marked_available";
+  }
+  return "unknown";
+}
+
+} // namespace symbol_cache

--- a/core/symbol_cache_manifest.h
+++ b/core/symbol_cache_manifest.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace symbol_cache {
+
+inline constexpr int kCurrentManifestFormatVersion = 1;
+inline constexpr int kCurrentPerastageSymbolFormatVersion = 1;
+inline constexpr const char *kProjectArchiveEntryName =
+    "perastage_symbol_cache_manifest.json";
+
+struct ManifestArchiveResource {
+  std::string entryName;
+  std::vector<std::uint8_t> bytes;
+};
+
+struct FixtureSymbolCacheEntry {
+  std::string fixtureKey;
+  std::string fixtureTypeName;
+  std::string gdtfSpec;
+  std::string gdtfContentHash;
+  bool hasPerastageSymbols = false;
+  std::set<std::string> availableViews;
+  std::string lastGenerationTimestampUtc;
+};
+
+enum class ValidationStatus {
+  Valid,
+  Bypassed,
+  MissingManifest,
+  UnknownManifestVersion,
+  MissingEntry,
+  OutdatedSymbolFormat,
+  GdtfSpecChanged,
+  GdtfHashChanged,
+  MissingRequiredViews,
+  SymbolsNotMarkedAvailable
+};
+
+struct ValidationRequest {
+  std::string fixtureKey;
+  std::string fixtureTypeName;
+  std::string gdtfSpec;
+  std::string gdtfContentHash;
+  std::set<std::string> requiredViews;
+  bool bypassManifest = false;
+};
+
+struct ValidationResult {
+  ValidationStatus status = ValidationStatus::MissingManifest;
+  bool valid = false;
+  std::string message;
+};
+
+class SymbolCacheManifest {
+public:
+  void Clear();
+  bool HasLoadedManifest() const;
+  bool IsManifestFormatKnown() const;
+
+  ValidationResult ValidateFixture(const ValidationRequest &request) const;
+  void MarkFixtureSymbolsValid(const ValidationRequest &request,
+                               std::string timestampUtc = {});
+
+  bool LoadFromJsonText(const std::string &jsonText, std::string &errorMessage);
+  bool SaveToJsonText(std::string &jsonText, std::string &errorMessage) const;
+
+  bool LoadFromProjectArchive(const std::string &projectPath,
+                              std::string &errorMessage);
+  std::optional<ManifestArchiveResource> ToArchiveResource(
+      std::string &errorMessage) const;
+
+  const std::vector<FixtureSymbolCacheEntry> &Entries() const;
+
+private:
+  int manifestFormatVersion = kCurrentManifestFormatVersion;
+  int perastageSymbolFormatVersion = kCurrentPerastageSymbolFormatVersion;
+  bool loadedManifest = false;
+  std::vector<FixtureSymbolCacheEntry> entries;
+};
+
+std::string ComputeFileContentHash(const std::string &path,
+                                   std::string &errorMessage);
+std::set<std::string> RequiredPerastageSymbolViews();
+std::string CurrentUtcTimestamp();
+const char *ValidationStatusName(ValidationStatus status);
+
+} // namespace symbol_cache

--- a/docs/gdtf_mutation_policy.md
+++ b/docs/gdtf_mutation_policy.md
@@ -10,6 +10,7 @@ Perastage currently mutates GDTF archives at the following integration points.
 |---|---|---|---|
 | Viewer 3D API | `viewer3d/gdtfloader.cpp` | `SetGdtfProperties(...)` | Writes `PhysicalDescriptions/Properties` (`Weight`, `PowerConsumption`), stamps audit metadata, appends `Revision`, rewrites `.gdtf`. |
 | GUI symbol workflow | `gui/windows/symbol_fixture_applier.cpp` | `RewriteGdtf(...)` + `AppendMutationAuditMetadata(...)` (called by `ApplySymbolsToFixtureGdtf(...)`) | Writes/updates SVG symbol assets and model SVG offsets, stamps audit metadata, appends `Revision`, rewrites `.gdtf`. |
+| Project symbol cache manifest | `core/symbol_cache_manifest.cpp` | `SymbolCacheManifest::ValidateFixture(...)`, `MarkFixtureSymbolsValid(...)` | Stores project-level metadata in `.pstg` packages so startup can skip deep GDTF inspection only when the referenced GDTF hash and required view metadata still match. |
 | MVR export patching | `mvr/mvrexporter.cpp` | `CreatePatchedGdtf(...)` | Creates temporary patched GDTF copies for export overrides (manufacturer/model/physical properties/color/dimensions), stamps audit metadata and appends `Revision` when patched. |
 | Shared audit helpers | `core/gdtf_mutation_audit.cpp` | `StampPerastageMutationMetadata(...)`, `AppendRevision(...)`, `ApplyPhysicalPropertiesWithAudit(...)` | Centralizes Perastage-owned mutation metadata and revision-appending semantics used by write flows. |
 
@@ -17,6 +18,7 @@ Perastage currently mutates GDTF archives at the following integration points.
 
 - `core/gdtf_mutation_audit.{h,cpp}` is the single owner of Perastage mutation-audit schema semantics.
 - Write call sites in other modules must use this helper API instead of hand-rolling custom audit XML shapes.
+- Fixture SVG symbols remain stored inside their corresponding GDTF files; the `.pstg` symbol cache manifest stores metadata only and never stores SVG payloads.
 - Fixture display color is no longer persisted by mutating `description.xml` model `Color` values in place. The persisted source of truth for default color selection is the Perastage dictionary/project data layer, while `GetGdtfModelColor(...)` remains read-only for legacy fallback reads.
 
 ## 2) Exact `Revision` format used by Perastage
@@ -38,7 +40,7 @@ Canonical shape:
   <Revision
     Date="2026-04-05T10:20:30Z"
     ModifiedBy="Perastage 0.x.y"
-    Text="Applied fixture SVG symbol views (top, side)"
+    Text="Applied fixture SVG symbol views (top, side, front, bottom)"
     UserID="0"/>
 </Revisions>
 ```
@@ -80,6 +82,7 @@ A GDTF mutation change is accepted only if all conditions below hold:
 
 1. **Mutation correctness**
    - Target payload mutation is present (for example color/properties/SVG view assets+offsets).
+   - Fixture symbol validation requires the Perastage top, bottom, front, and side SVG views before project manifest cache entries can skip deep inspection.
 2. **Audit correctness**
    - `<PerastageMutationAudit>` exists and includes the current schema version.
    - A new `<Revision>` entry is appended with valid `Date`, `ModifiedBy`, `Text`, `UserID`.
@@ -94,7 +97,7 @@ A GDTF mutation change is accepted only if all conditions below hold:
 
 ### Manual checklist
 
-- [ ] Apply fixture symbol generation to a fixture and verify the `.gdtf` receives updated SVG entries and offsets.
+- [ ] Apply fixture symbol generation to a fixture and verify the `.gdtf` receives updated top, bottom, front, and side SVG entries and offsets.
 - [ ] Edit fixture color via dictionary/project workflow and verify fixture color persists after reopening without mutating model `Color` in the source `.gdtf`.
 - [ ] Edit fixture physical properties and verify weight/power values persist after reopening.
 - [ ] Inspect resulting `description.xml` and verify `PerastageMutationAudit` + `Revision` attributes follow the policy format.
@@ -108,6 +111,8 @@ A GDTF mutation change is accepted only if all conditions below hold:
   - validates physical-properties mutation and persisted XML changes.
 - `tests/symbol_fixture_applier_gdtf_test.cpp`
   - validates symbol write path + mutation audit compatibility behavior.
+- `tests/symbol_cache_manifest_test.cpp`
+  - validates project-level symbol cache manifest fallback and update safety behavior.
 - `tests/check_perastage_tree_modules.sh`
   - mandatory architecture/module boundary consistency check.
 - `tests/check_no_configmanager_get_in_gui.sh`

--- a/gui/mainwindow_fixture_symbol_autoupdate.cpp
+++ b/gui/mainwindow_fixture_symbol_autoupdate.cpp
@@ -9,9 +9,11 @@
 #include "configmanager.h"
 #include "consolepanel.h"
 #include "fixture.h"
+#include "fixtures/fixture_gdtf_resolution.h"
 #include "guiconfigservices.h"
 #include "opaque_pass_utils.h"
 #include "splashscreen.h"
+#include "symbol_cache_manifest.h"
 #include "tools/scene_model_symbol_capture_service.h"
 #include "tools/symbol_physical_calibration.h"
 #include "windows/symbol_fixture_applier.h"
@@ -42,6 +44,50 @@ std::string BuildFixtureLabel(const Fixture &fixture) {
   if (!fixture.gdtfSpec.empty())
     return std::filesystem::path(fixture.gdtfSpec).filename().string();
   return "unknown fixture";
+}
+
+
+// Builds a manifest validation request for the current fixture and resolved GDTF path.
+bool BuildFixtureSymbolCacheRequest(
+    const Fixture &fixture, const std::string &key,
+    const gui::fixtures::FixtureGdtfResolution &resolution,
+    symbol_cache::ValidationRequest &request, std::string &errorMessage) {
+  const std::string selectedPath = resolution.selectedPath.empty()
+                                       ? resolution.scenePath
+                                       : resolution.selectedPath;
+  if (selectedPath.empty()) {
+    errorMessage = "fixture GDTF path is empty";
+    return false;
+  }
+
+  std::string hashError;
+  const std::string contentHash =
+      symbol_cache::ComputeFileContentHash(selectedPath, hashError);
+  if (contentHash.empty()) {
+    errorMessage = hashError.empty() ? "could not hash fixture GDTF" : hashError;
+    return false;
+  }
+
+  request.fixtureKey = key;
+  request.fixtureTypeName = fixture.typeName;
+  request.gdtfSpec = fixture.gdtfSpec;
+  request.gdtfContentHash = contentHash;
+  request.requiredViews = symbol_cache::RequiredPerastageSymbolViews();
+  return true;
+}
+
+// Resolves a fixture GDTF and builds the corresponding manifest validation request.
+bool ResolveFixtureSymbolCacheRequest(const Fixture &fixture, const MvrScene &scene,
+                                      const std::string &key,
+                                      symbol_cache::ValidationRequest &request,
+                                      gui::fixtures::FixtureGdtfResolution &resolution,
+                                      std::string &errorMessage) {
+  if (!gui::fixtures::ResolveFixtureGdtfDeterministic(
+          fixture, scene, resolution, errorMessage, "symbol-cache")) {
+    return false;
+  }
+  return BuildFixtureSymbolCacheRequest(fixture, key, resolution, request,
+                                        errorMessage);
 }
 
 // Updates status/console text and maintains a per-window timer that clears transient status messages.
@@ -224,6 +270,40 @@ void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
     return;
   }
 
+  symbol_cache::ValidationRequest cacheRequest;
+  gui::fixtures::FixtureGdtfResolution cacheResolution;
+  std::string cacheError;
+  const bool hasCacheRequest = ResolveFixtureSymbolCacheRequest(
+      fixture, cfg.GetScene(), key, cacheRequest, cacheResolution, cacheError);
+  if (hasCacheRequest) {
+    const auto cacheResult =
+        cfg.GetSymbolCacheManifest().ValidateFixture(cacheRequest);
+    if (cacheResult.valid) {
+      ReportFixtureAutoUpdate(
+          *this, consolePanel,
+          "Fixture symbol auto-update: skipped '" + fixtureLabel +
+              "' because the project symbol cache manifest is valid.",
+          false);
+      CallAfter([this]() { ProcessNextFixtureSymbolAutoUpdate(); });
+      return;
+    }
+    ReportFixtureAutoUpdate(
+        *this, consolePanel,
+        "Fixture symbol auto-update: inspecting '" + fixtureLabel +
+            "' because the project symbol cache manifest was not valid (" +
+            std::string(symbol_cache::ValidationStatusName(cacheResult.status)) +
+            ").",
+        false);
+  } else {
+    ReportFixtureAutoUpdate(
+        *this, consolePanel,
+        "Fixture symbol auto-update: inspecting '" + fixtureLabel +
+            "' because the project symbol cache manifest could not be checked (" +
+            (cacheError.empty() ? std::string("unknown cache error") : cacheError) +
+            ").",
+        false);
+  }
+
   std::string inspectionError;
   symbol_preview::FixtureSymbolInspectionResult inspection;
   if (!symbol_preview::InspectFixtureSymbolState(fixture, cfg.GetScene(), inspection,
@@ -256,7 +336,8 @@ void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
 
   ReportFixtureAutoUpdate(*this, consolePanel,
                           "Fixture symbol auto-update: generating symbols for '" +
-                              fixtureLabel + "'.",
+                              fixtureLabel +
+                              "' because symbols were missing or invalid.",
                           false);
 
   Viewer2DOffscreenRenderer *offscreenRenderer = GetOffscreenRenderer();
@@ -336,6 +417,33 @@ void MainWindow::ProcessNextFixtureSymbolAutoUpdate() {
                                 fixtureLabel + "' and " + locationMessage +
                                 " GDTF updated.",
                             false);
+    symbol_cache::ValidationRequest updatedCacheRequest;
+    gui::fixtures::FixtureGdtfResolution updatedCacheResolution;
+    std::string updatedCacheError;
+    symbol_preview::FixtureSymbolInspectionResult updatedInspection;
+    const auto updatedFixtureIt = cfg.GetScene().fixtures.find(fixtureUuid);
+    if (updatedFixtureIt != cfg.GetScene().fixtures.end() &&
+        ResolveFixtureSymbolCacheRequest(updatedFixtureIt->second, cfg.GetScene(),
+                                         key, updatedCacheRequest,
+                                         updatedCacheResolution,
+                                         updatedCacheError) &&
+        symbol_preview::InspectFixtureSymbolState(updatedFixtureIt->second,
+                                                  cfg.GetScene(),
+                                                  updatedInspection,
+                                                  updatedCacheError) &&
+        !updatedInspection.requiresSymbolGeneration) {
+      cfg.GetSymbolCacheManifest().MarkFixtureSymbolsValid(updatedCacheRequest);
+    } else {
+      ReportFixtureAutoUpdate(
+          *this, consolePanel,
+          "Fixture symbol auto-update: symbols generated for '" + fixtureLabel +
+              "' but the project symbol cache manifest was not updated (" +
+              (updatedCacheError.empty() ? std::string("symbol validation failed")
+                                         : updatedCacheError) +
+              ").",
+          false);
+    }
+
     if (fixtureSymbolAutoUpdateGeneratedTypeSet.insert(fixtureLabel).second)
       fixtureSymbolAutoUpdateGeneratedTypes.push_back(fixtureLabel);
     RefreshAfterFixtureSymbolUpdate();

--- a/gui/windows/symbol_fixture_applier.cpp
+++ b/gui/windows/symbol_fixture_applier.cpp
@@ -689,6 +689,7 @@ bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
 }
 
 
+// Inspects a fixture GDTF to determine whether Perastage SVG symbols must be generated.
 bool InspectFixtureSymbolState(const Fixture &fixture,
                                const MvrScene &scene,
                                FixtureSymbolInspectionResult &result,
@@ -767,6 +768,7 @@ bool InspectFixtureSymbolState(const Fixture &fixture,
 
   const std::unordered_set<std::string> requiredPaths = {
       NormalizeArchivePath("models/svg/" + modelSvgBase + ".svg"),
+      NormalizeArchivePath("models/svg/" + modelSvgBase + "_bottom.svg"),
       NormalizeArchivePath("models/svg_side/" + modelSvgBase + ".svg"),
       NormalizeArchivePath("models/svg_front/" + modelSvgBase + ".svg")};
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1240,3 +1240,13 @@ add_executable(support_resolution_test
                support_resolution_test.cpp)
 target_include_directories(support_resolution_test PRIVATE ../models)
 add_test(NAME SupportResolution COMMAND support_resolution_test)
+
+add_executable(symbol_cache_manifest_test symbol_cache_manifest_test.cpp
+               ../core/symbol_cache_manifest.cpp)
+target_include_directories(symbol_cache_manifest_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/core
+    ${CMAKE_SOURCE_DIR}/models
+    ${CMAKE_SOURCE_DIR}/third_party
+    ${wxWidgets_INCLUDE_DIRS})
+target_link_libraries(symbol_cache_manifest_test PRIVATE ${wxWidgets_LIBRARIES})
+add_test(NAME SymbolCacheManifestValidation COMMAND symbol_cache_manifest_test)

--- a/tests/symbol_cache_manifest_test.cpp
+++ b/tests/symbol_cache_manifest_test.cpp
@@ -1,0 +1,130 @@
+#include "symbol_cache_manifest.h"
+
+#include <cassert>
+#include <string>
+
+#include "json.hpp"
+
+namespace {
+
+// Builds a complete cache validation request used by manifest unit tests.
+symbol_cache::ValidationRequest BuildRequest(const std::string &hash = "hash-a") {
+  symbol_cache::ValidationRequest request;
+  request.fixtureKey = "Fixture Type";
+  request.fixtureTypeName = "Fixture Type";
+  request.gdtfSpec = "fixtures/fixture.gdtf";
+  request.gdtfContentHash = hash;
+  request.requiredViews = symbol_cache::RequiredPerastageSymbolViews();
+  return request;
+}
+
+// Loads serialized manifest JSON into a manifest object and asserts success.
+symbol_cache::SymbolCacheManifest LoadManifest(const nlohmann::json &json) {
+  symbol_cache::SymbolCacheManifest manifest;
+  std::string error;
+  assert(manifest.LoadFromJsonText(json.dump(), error));
+  return manifest;
+}
+
+// Creates a JSON manifest entry with overridable version and hash metadata.
+nlohmann::json BuildManifestJson(int manifestVersion, int symbolVersion,
+                                 const std::string &hash = "hash-a") {
+  return nlohmann::json{
+      {"manifestFormatVersion", manifestVersion},
+      {"perastageSymbolFormatVersion", symbolVersion},
+      {"fixtures",
+       nlohmann::json::array({nlohmann::json{
+           {"fixtureKey", "Fixture Type"},
+           {"fixtureTypeName", "Fixture Type"},
+           {"gdtfSpec", "fixtures/fixture.gdtf"},
+           {"gdtfContentHash", hash},
+           {"hasPerastageSymbols", true},
+           {"availableViews", nlohmann::json::array({"top", "bottom", "front", "side"})},
+           {"lastGenerationTimestampUtc", "2026-06-01T00:00:00Z"}})}}};
+}
+
+// Simulates the generation policy that only successful applies update the manifest.
+void SimulateGeneration(symbol_cache::SymbolCacheManifest &manifest,
+                        const symbol_cache::ValidationRequest &request,
+                        bool generationSucceeded) {
+  if (generationSucceeded)
+    manifest.MarkFixtureSymbolsValid(request, "2026-06-01T00:00:00Z");
+}
+
+// Verifies that a valid manifest allows the caller to skip deep GDTF inspection.
+void TestValidManifestSkipsInspection() {
+  auto manifest = LoadManifest(BuildManifestJson(
+      symbol_cache::kCurrentManifestFormatVersion,
+      symbol_cache::kCurrentPerastageSymbolFormatVersion));
+  const auto result = manifest.ValidateFixture(BuildRequest());
+  assert(result.valid);
+  assert(result.status == symbol_cache::ValidationStatus::Valid);
+}
+
+// Verifies that a missing manifest forces the caller to inspect the GDTF normally.
+void TestMissingManifestFallsBackToInspection() {
+  symbol_cache::SymbolCacheManifest manifest;
+  const auto result = manifest.ValidateFixture(BuildRequest());
+  assert(!result.valid);
+  assert(result.status == symbol_cache::ValidationStatus::MissingManifest);
+}
+
+// Verifies that unsupported manifest or symbol versions do not hide GDTF issues.
+void TestOutdatedManifestFallsBackToInspection() {
+  auto unknownFormat = LoadManifest(BuildManifestJson(
+      symbol_cache::kCurrentManifestFormatVersion + 1,
+      symbol_cache::kCurrentPerastageSymbolFormatVersion));
+  auto unknownResult = unknownFormat.ValidateFixture(BuildRequest());
+  assert(!unknownResult.valid);
+  assert(unknownResult.status ==
+         symbol_cache::ValidationStatus::UnknownManifestVersion);
+
+  auto oldSymbolFormat = LoadManifest(BuildManifestJson(
+      symbol_cache::kCurrentManifestFormatVersion,
+      symbol_cache::kCurrentPerastageSymbolFormatVersion - 1));
+  auto oldResult = oldSymbolFormat.ValidateFixture(BuildRequest());
+  assert(!oldResult.valid);
+  assert(oldResult.status == symbol_cache::ValidationStatus::OutdatedSymbolFormat);
+}
+
+// Verifies that changed GDTF content invalidates the manifest optimization.
+void TestChangedGdtfHashFallsBackToInspection() {
+  auto manifest = LoadManifest(BuildManifestJson(
+      symbol_cache::kCurrentManifestFormatVersion,
+      symbol_cache::kCurrentPerastageSymbolFormatVersion, "hash-a"));
+  const auto result = manifest.ValidateFixture(BuildRequest("hash-b"));
+  assert(!result.valid);
+  assert(result.status == symbol_cache::ValidationStatus::GdtfHashChanged);
+}
+
+// Verifies that successful generation records a valid manifest entry.
+void TestSuccessfulGenerationUpdatesManifest() {
+  symbol_cache::SymbolCacheManifest manifest;
+  const auto request = BuildRequest();
+  SimulateGeneration(manifest, request, true);
+  const auto result = manifest.ValidateFixture(request);
+  assert(result.valid);
+}
+
+// Verifies that failed generation leaves the manifest unable to skip inspection.
+void TestFailedGenerationDoesNotMarkManifestValid() {
+  symbol_cache::SymbolCacheManifest manifest;
+  const auto request = BuildRequest();
+  SimulateGeneration(manifest, request, false);
+  const auto result = manifest.ValidateFixture(request);
+  assert(!result.valid);
+  assert(result.status == symbol_cache::ValidationStatus::MissingManifest);
+}
+
+} // namespace
+
+// Runs symbol cache manifest validation and update-policy unit tests.
+int main() {
+  TestValidManifestSkipsInspection();
+  TestMissingManifestFallsBackToInspection();
+  TestOutdatedManifestFallsBackToInspection();
+  TestChangedGdtfHashFallsBackToInspection();
+  TestSuccessfulGenerationUpdatesManifest();
+  TestFailedGenerationDoesNotMarkManifestValid();
+  return 0;
+}

--- a/tests/symbol_fixture_applier_gdtf_test.cpp
+++ b/tests/symbol_fixture_applier_gdtf_test.cpp
@@ -82,6 +82,8 @@ std::string MakeFixtureGdtfFromFixtureTypeXml(const std::string &fixtureTypeXml)
   const std::string symbolBody = "<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>";
   zipOut.PutNextEntry("models/svg/Body.svg");
   zipOut.Write(symbolBody.data(), symbolBody.size());
+  zipOut.PutNextEntry("models/svg/Body_bottom.svg");
+  zipOut.Write(symbolBody.data(), symbolBody.size());
   zipOut.PutNextEntry("models/svg_side/Body.svg");
   zipOut.Write(symbolBody.data(), symbolBody.size());
   zipOut.PutNextEntry("models/svg_front/Body.svg");
@@ -121,6 +123,7 @@ std::vector<symbols::Symbol2D> BuildSymbols() {
 
   return {
       makeView(symbols::SymbolView::Top),
+      makeView(symbols::SymbolView::Bottom),
       makeView(symbols::SymbolView::Left),
       makeView(symbols::SymbolView::Front),
   };
@@ -177,6 +180,7 @@ int main() {
   }
 
   assert(entries.find("models/svg/Body.svg") != entries.end());
+  assert(entries.find("models/svg/Body_bottom.svg") != entries.end());
   assert(entries.find("models/svg_side/Body.svg") != entries.end());
   assert(entries.find("models/svg_front/Body.svg") != entries.end());
 
@@ -212,7 +216,7 @@ int main() {
   assert(text != nullptr);
   assert(modifiedBy != nullptr);
   assert(std::string(text) ==
-         "Applied fixture SVG symbol views (top, side, front)");
+         "Applied fixture SVG symbol views (top, side, front, bottom)");
   assert(std::string(modifiedBy).rfind("Perastage ", 0) == 0);
 
   symbol_preview::FixtureSymbolInspectionResult after{};


### PR DESCRIPTION
### Motivation

- Speed up startup fixture symbol auto-update by avoiding expensive per-GDTF inspection when a small project-level cache proves Perastage symbols are present and up-to-date.
- Keep existing behavior and storage: SVG payloads remain embedded in each GDTF and the manifest must not contain SVG data.
- Make the optimization safe and reversible so the manifest acts only as an advisory cache and never hides real symbol problems.

### Description

- Add a lightweight service `symbol_cache::SymbolCacheManifest` with JSON serialization, manifest/Perastage symbol format versions, FNV-1a GDTF content hashing, per-fixture entries, required view set (top/bottom/front/side), and helpers to load/save a manifest entry inside `.pstg` archives (`core/symbol_cache_manifest.{h,cpp}`).
- Wire project save/load to persist/restore the manifest into the project ZIP as `perastage_symbol_cache_manifest.json` and to include the manifest in `ProjectSession` archive resources on save (`core/configmanager.{h,cpp}` and `core/CMakeLists.txt`).
- Refactor the startup fixture auto-update path to consult the manifest before running expensive `InspectFixtureSymbolState()`; added clear status messages for skipped/inspected/generated flows and update logic to mark the manifest only after successful apply + verification (`gui/mainwindow_fixture_symbol_autoupdate.cpp`).
- Keep SVG storage unchanged and strengthen validation: `InspectFixtureSymbolState()` and tests now require top, bottom, front and side views; manifest entries store only metadata (no SVG payloads) and validation enforces path/spec and content-hash matches and required views presence (`gui/windows/symbol_fixture_applier.cpp`).
- Add unit tests `tests/symbol_cache_manifest_test.cpp` covering: valid manifest skips inspection, missing manifest falls back, outdated manifest falls back, changed GDTF hash falls back, successful generation updates manifest, failed generation does not mark manifest valid; and register the test in `tests/CMakeLists.txt`.
- Update `docs/gdtf_mutation_policy.md` to document the new project manifest, its metadata-only policy, and the safety requirement for top/bottom/front/side views.

### Testing

- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both returned OK.
- Added `tests/symbol_cache_manifest_test.cpp` (unit tests) and registered it in CMake; test source included in the change (verify in CI where wxWidgets and build tooling are available).
- Attempted CMake configure/build with tests enabled (`cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON`) in this environment, but configure is blocked because system `wxWidgets` dev packages are not installed; CI should build/run full tests where dependencies are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ddb0ed0a88324bd6c57409db00898)