### PR TITLE
Add curated release-notes draft, PR template, and wire workflow to use it

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## Summary
+
+Briefly describe what this PR changes.
+
+## User-facing impact
+
+- [ ] New feature
+- [ ] Improvement
+- [ ] Bug fix
+- [ ] Performance
+- [ ] Stability / reliability
+- [ ] Documentation
+- [ ] Internal only
+
+User-facing release note:
+
+<!-- Write one short user-friendly sentence suitable for release notes, or write "Internal only". -->
+
+## Testing
+
+- [ ] Built successfully
+- [ ] Tested manually
+- [ ] Not applicable
+
+## Release notes draft
+
+- [ ] Updated `docs/release-notes-draft.md`
+- [ ] Not needed because this change is internal only

--- a/.github/workflows/minor-draft-release.yml
+++ b/.github/workflows/minor-draft-release.yml
@@ -155,8 +155,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
+      - name: Checkout release tag
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare-release.outputs.new_tag }}
 
       - name: Download installer artifacts
         uses: actions/download-artifact@v4
@@ -223,7 +225,7 @@ jobs:
           echo "linux_asset=$LINUX_ASSET" >> "$GITHUB_OUTPUT"
           echo "mac_asset=$MAC_ASSET" >> "$GITHUB_OUTPUT"
 
-      - name: Create draft release with generated notes
+      - name: Create draft release with curated notes
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
@@ -236,9 +238,18 @@ jobs:
         run: |
           set -euo pipefail
 
+          RELEASE_NOTES_FILE="docs/release-notes-draft.md"
+
           echo "Creating draft release in $GH_REPO"
 
-          cmd=(gh release create "$TAG_NAME" "$WIN_ASSET" "$LINUX_ASSET" "$MAC_ASSET" --draft --generate-notes --title "$RELEASE_TITLE")
+          cmd=(gh release create "$TAG_NAME" "$WIN_ASSET" "$LINUX_ASSET" "$MAC_ASSET" --draft --title "$RELEASE_TITLE")
+          if [ -s "$RELEASE_NOTES_FILE" ]; then
+            echo "Using curated release notes from $RELEASE_NOTES_FILE"
+            cmd+=(--notes-file "$RELEASE_NOTES_FILE")
+          else
+            echo "Curated release notes draft is missing or empty; falling back to GitHub generated notes"
+            cmd+=(--generate-notes)
+          fi
           if [ "$PRERELEASE" = "true" ]; then
             cmd+=(--prerelease)
           fi

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -1,0 +1,66 @@
+# Release Notes Draft
+
+This document is a curated working draft for the next Perastage release.
+
+It should be updated whenever a user-facing change is merged. It is not intended to be a raw changelog or a complete commit history.
+
+Base for this draft: changes on `main` after the latest published release tag, `v1.2.0`, reviewed through the current development version `1.2.40`.
+
+## Highlights
+
+- Added practical fixture replacement from the Edit menu, preserving selection, placement, UUID continuity, and project color behavior where possible.
+- Added measurement workflows in both 2D and 3D viewers, with toolbar toggles, live distance previews, readable labels, and status-bar feedback.
+- Added update checking from the GUI with configurable startup preferences, making it easier for users to discover newer Perastage versions.
+- Improved layout viewer responsiveness and reliability during project loading, import, zooming, rendering, legend resizing, and image-heavy workflows.
+- Improved Windows and release packaging so draft releases attach direct installer assets instead of requiring users to unpack workflow ZIP files.
+
+## New features
+
+- Added a 2D measurement tool with selection/measurement toolbar controls, live preview, active-plane distance calculations, HiDPI-aware cursor mapping, and synchronized tool state when leaving the tool.
+- Added a 3D measurement tool with euclidean distance display, clearer preview behavior, readable rotated labels, restart handling, and status-bar reporting.
+- Added a GUI update-check action and startup update-check preference so users can manually check for updates or choose whether Perastage checks automatically.
+- Added fixture replacement from the Edit menu, including improved source labeling, transform preservation, selection stability, UUID handling, and color reuse/autocolor behavior.
+- Added support for packaging referenced layout images into project archives so project files remain more portable when shared or reopened elsewhere.
+
+## Improvements
+
+- Improved 2D layout performance when opening projects, zooming, navigating views, resizing legends, rebuilding render caches, and working with fixture labels or image-heavy layouts.
+- Improved layout render progress feedback by showing clearer status-bar messages during symbol capture, texture rebuilds, legend preparation, and rendering.
+- Improved GDTF model loading with better lookup ordering, GLB fallback handling, and diagnostics for missing or difficult-to-load models.
+- Improved fixture symbol alignment so generated layout symbols better match each fixture's local axes.
+- Improved 3D textured mesh lighting and mirrored geometry handling so dark/light patterns, ink normals, face orientation, and textured surfaces render more consistently.
+- Improved release asset handling so GitHub draft releases can include direct Windows installer, Linux AppImage, and macOS DMG downloads.
+
+## Fixes
+
+- Fixed MVR export before saving a project so resource references are synchronized before export.
+- Fixed Windows startup behavior for shell-opened MVR files, including path normalization and startup stalls while scanning for GDTF fallbacks.
+- Fixed layout view freezes and busy-cursor issues caused by reentrant GUI work, render timeouts, mode changes, new project creation, and 2D view edit commits.
+- Fixed layout 2D view editing so edits apply to the intended target view and reliably refresh the layout viewer afterward.
+- Fixed save-time truss position persistence, including stale inactive-table transforms overwriting updated scene data.
+- Fixed the truss center anchor used by the 3D measurement tool.
+- Fixed GDTF download command ID collisions and added a guard to prevent duplicate MainWindow command IDs.
+- Fixed MVR import and GDTF download progress UI races that could update UI from the wrong thread or after dialogs were torn down.
+- Fixed MVR exports with missing non-critical resources so users receive warnings instead of failing the entire export when possible.
+- Fixed 2D scene-object depth sorting so objects draw in the expected order.
+
+## Stability and reliability
+
+- Hardened layout rendering during MVR import to avoid redraw races, dangling progress UI callbacks, and cache rebuilds while import state is still active.
+- Hardened 3D navigation diagnostics to make random navigation crashes easier to investigate.
+- Added a project symbol cache manifest to reduce unnecessary symbol work and improve cache consistency, after reverting and correcting the initial implementation.
+- Added automated coverage for duplicate command IDs, layout image resource registration, symbol cache manifests, and related serialization paths.
+
+## Documentation
+
+- Updated user documentation for update preferences, MVR export warnings, quick-start guidance, feature descriptions, and GDTF mutation policy notes.
+- Updated packaging documentation to clarify preferred release asset distribution and macOS unsigned build behavior.
+- Added a curated release-notes draft workflow so future public release notes can be prepared from user-friendly entries instead of raw commit lists.
+
+## Internal changes not intended for public release notes
+
+- Extracted several pure helper functions from large GUI and viewer files into adjacent helper modules to keep hotspot files more maintainable.
+- Refactored layout render invalidation, selected element z-order mapping, label builders, and status notification plumbing without changing the intended user workflow.
+- Added internal resource-reference synchronization and layout image resource registry support used by project save/export paths.
+- Added symbol cache manifest infrastructure and tests; mention publicly only if it directly improves user-facing performance or reliability in the final release notes.
+- Added and adjusted CI/release workflow plumbing for installer artifact handling, curated draft release notes, and version-bump safety.

--- a/docs/versioning-policy.md
+++ b/docs/versioning-policy.md
@@ -72,10 +72,14 @@ Examples:
 
 ## Release Notes
 
-Release notes should be generated from merged PRs between the previous official release tag and the new release tag.
+Perastage maintains a curated working draft for the next release in [`release-notes-draft.md`](release-notes-draft.md).
+Update that draft whenever a merged PR includes a meaningful user-facing change, such as a feature, bug fix, performance improvement, stability improvement, packaging change, or documentation update.
+Internal-only changes can be omitted or recorded under the internal section when they may help maintainers review the release.
+
+Before publishing a GitHub Release, review the draft, remove entries that are too technical or temporary, group related items, and convert it into concise public release notes.
 Include the latest documentation link (`https://perastage.luismaperamato.com/`) in each published release note.
 
-PR titles and labels should be clear because they feed release-note quality.
+PR titles, labels, and the PR template release-note field should be clear because they help keep the curated draft accurate.
 
 Suggested labels:
 
@@ -124,7 +128,8 @@ It performs these actions for a MINOR release:
 - Creates and pushes an annotated release tag in the format `vMAJOR.MINOR.0`.
 - Builds Windows, Linux, and macOS installers from the new release tag using the existing installer workflows.
 - Creates a GitHub Draft Release for the new tag.
-- Uses GitHub automatic release-note generation.
+- Uses `docs/release-notes-draft.md` as the release body when the file is present and non-empty.
+- Falls back to GitHub automatic release-note generation only if the curated draft is missing or empty.
 - Attaches the Windows installer, Linux AppImage, and macOS DMG assets to the draft release.
 
 The workflow intentionally leaves the release as a draft so the maintainer can manually review, edit, and publish it.


### PR DESCRIPTION
### Motivation

- Provide a curated, user-friendly working draft for release notes so public GitHub Releases are not composed only from raw commits.  
- Encourage contributors to mark user-facing impact in PRs so the draft stays up-to-date between releases.  
- Make the manual minor-release workflow use the curated draft when available while keeping the existing automation and a safe fallback.

### Description

- Add a populated `docs/release-notes-draft.md` that summarizes user-facing changes on `main` since the latest published tag (`v1.2.0`) up to the current development version (`1.2.40`).  
- Create `.github/pull_request_template.md` to prompt contributors to declare user-facing impact and a short release-note sentence and to remind them to update the draft.  
- Update `.github/workflows/minor-draft-release.yml` to check out the new release tag and prefer `docs/release-notes-draft.md` as the GitHub Release body when the file exists and is non-empty, falling back to GitHub generated notes when it is missing or empty.  
- Update `docs/versioning-policy.md` to document the curated draft workflow and the expected maintainer cleanup step before publishing.

### Testing

- Ran `tests/check_perastage_tree_modules.sh` which passed.  
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed.  
- Verified workflow YAML parses with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/minor-draft-release.yml")'` and performed file sanity checks (non-empty, LF endings); these checks passed.  
- Ran `git diff --check` and basic repository checks (line endings and file presence) which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1de317145483249c9866d4c2188f09)