### PR TITLE
Improve layout preview startup rendering

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -52,6 +52,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/layoutviewerpanel_view.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layoutviewerpanel_helpers.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layout_render_status_notifier.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/layout_render_profiler.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/layoutviewerviewrenderer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/legendutils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/legendsymbolcapture.cpp

--- a/gui/layout_render_profiler.cpp
+++ b/gui/layout_render_profiler.cpp
@@ -1,0 +1,136 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "layout_render_profiler.h"
+
+#include <sstream>
+#include <utility>
+
+#include "LayoutCollection.h"
+#include "logger.h"
+
+namespace gui::layoutperf {
+namespace {
+
+// Reports whether debug-only layout performance traces should be emitted.
+bool IsLayoutPerformanceLoggingEnabled() {
+#ifndef NDEBUG
+  return true;
+#else
+  return false;
+#endif
+}
+
+// Converts a steady-clock duration to whole milliseconds for compact logs.
+long long ToMilliseconds(std::chrono::steady_clock::duration duration) {
+  return std::chrono::duration_cast<std::chrono::milliseconds>(duration)
+      .count();
+}
+
+} // namespace
+
+// Creates a profiler for one layout loading or rendering operation.
+LayoutRenderProfiler::LayoutRenderProfiler(std::string operationName)
+    : enabled_(IsLayoutPerformanceLoggingEnabled()),
+      operationName_(std::move(operationName)),
+      operationStart_(std::chrono::steady_clock::now()) {}
+
+// Stores the active layout and project-wide layout count for later logging.
+void LayoutRenderProfiler::SetLayoutContext(
+    size_t projectLayoutCount, const layouts::LayoutDefinition &layout) {
+  LayoutElementCounts counts;
+  counts.projectLayouts = projectLayoutCount;
+  counts.view2d = layout.view2dViews.size();
+  counts.legends = layout.legendViews.size();
+  counts.eventTables = layout.eventTables.size();
+  counts.textBlocks = layout.textViews.size();
+  counts.images = layout.imageViews.size();
+  SetLayoutContext(counts, layout.name);
+}
+
+// Stores precomputed layout element counts for later logging.
+void LayoutRenderProfiler::SetLayoutContext(LayoutElementCounts counts,
+                                            std::string activeLayoutName) {
+  if (!enabled_)
+    return;
+  counts_ = counts;
+  activeLayoutName_ = std::move(activeLayoutName);
+}
+
+// Starts timing a named phase, closing any previous phase first.
+void LayoutRenderProfiler::BeginPhase(std::string phaseName) {
+  if (!enabled_)
+    return;
+  EndPhase();
+  currentPhase_ = std::move(phaseName);
+  phaseStart_ = std::chrono::steady_clock::now();
+}
+
+// Stops timing the current phase and stores its duration.
+void LayoutRenderProfiler::EndPhase() {
+  if (!enabled_ || currentPhase_.empty())
+    return;
+  phases_.push_back({currentPhase_, ToMilliseconds(
+                                        std::chrono::steady_clock::now() -
+                                        phaseStart_)});
+  currentPhase_.clear();
+}
+
+// Counts a layout element whose texture or capture was rebuilt in this operation.
+void LayoutRenderProfiler::RecordRenderedElement() {
+  if (!enabled_)
+    return;
+  ++renderedElements_;
+}
+
+// Counts a layout element whose existing cache was reused in this operation.
+void LayoutRenderProfiler::RecordReusedElement() {
+  if (!enabled_)
+    return;
+  ++reusedElements_;
+}
+
+// Emits one compact debug log line with counts and phase timings.
+void LayoutRenderProfiler::Finish(const std::string &result) {
+  if (!enabled_)
+    return;
+  EndPhase();
+  std::ostringstream phaseStream;
+  for (size_t i = 0; i < phases_.size(); ++i) {
+    if (i > 0)
+      phaseStream << ',';
+    phaseStream << phases_[i].name << '=' << phases_[i].durationMs << "ms";
+  }
+
+  std::ostringstream message;
+  message << "Layout performance: operation=" << operationName_
+          << " result=" << result
+          << " project_layouts=" << counts_.projectLayouts
+          << " active_layout=\"" << activeLayoutName_ << '"'
+          << " views=" << counts_.view2d << " legends=" << counts_.legends
+          << " event_tables=" << counts_.eventTables
+          << " text_blocks=" << counts_.textBlocks
+          << " images=" << counts_.images
+          << " rendered_elements=" << renderedElements_
+          << " reused_cached_elements=" << reusedElements_
+          << " total_ms="
+          << ToMilliseconds(std::chrono::steady_clock::now() - operationStart_)
+          << " phases=[" << phaseStream.str() << ']';
+  Logger::Instance().Log(Logger::Level::Debug, message.str());
+}
+
+} // namespace gui::layoutperf

--- a/gui/layout_render_profiler.h
+++ b/gui/layout_render_profiler.h
@@ -1,0 +1,71 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace layouts {
+struct LayoutDefinition;
+}
+
+namespace gui::layoutperf {
+
+struct LayoutElementCounts {
+  size_t projectLayouts = 0;
+  size_t view2d = 0;
+  size_t legends = 0;
+  size_t eventTables = 0;
+  size_t textBlocks = 0;
+  size_t images = 0;
+};
+
+class LayoutRenderProfiler {
+public:
+  explicit LayoutRenderProfiler(std::string operationName);
+
+  void SetLayoutContext(size_t projectLayoutCount,
+                        const layouts::LayoutDefinition &layout);
+  void SetLayoutContext(LayoutElementCounts counts, std::string activeLayoutName);
+  void BeginPhase(std::string phaseName);
+  void EndPhase();
+  void RecordRenderedElement();
+  void RecordReusedElement();
+  void Finish(const std::string &result);
+
+private:
+  struct PhaseTiming {
+    std::string name;
+    long long durationMs = 0;
+  };
+
+  bool enabled_ = false;
+  std::string operationName_;
+  LayoutElementCounts counts_;
+  std::string activeLayoutName_;
+  size_t renderedElements_ = 0;
+  size_t reusedElements_ = 0;
+  std::chrono::steady_clock::time_point operationStart_;
+  std::chrono::steady_clock::time_point phaseStart_;
+  std::string currentPhase_;
+  std::vector<PhaseTiming> phases_;
+};
+
+} // namespace gui::layoutperf

--- a/gui/layoutviewerpanel.cpp
+++ b/gui/layoutviewerpanel.cpp
@@ -46,6 +46,7 @@
 #include "layoutviewerpanel.h"
 #include "layoutviewerpanel_helpers.h"
 #include "layout_render_status_notifier.h"
+#include "layout_render_profiler.h"
 #include "gl_state_guard.h"
 #include <wx/debug.h>
 #include <wx/log.h>
@@ -2085,13 +2086,22 @@ bool LayoutViewerPanel::InitGL() {
   return true;
 }
 
-// Rebuilds the next dirty layout element texture and reports whether more work remains.
+// Rebuilds one stale layout element texture per call so the viewer can update progressively.
 bool LayoutViewerPanel::RebuildCachedTexture() {
   try {
-    if (!NeedsRenderRebuild())
+    gui::layoutperf::LayoutRenderProfiler profiler("layout_render_rebuild");
+    profiler.SetLayoutContext(
+        layouts::LayoutManager::Get().GetLayouts().Count(), currentLayout);
+    profiler.BeginPhase("preflight");
+    if (!NeedsRenderRebuild()) {
+      profiler.Finish("clean");
       return false;
-    if (!isReadyToRender_ || !glContext_ || !IsShownOnScreen())
+    }
+    if (!isReadyToRender_ || !glContext_ || !IsShownOnScreen()) {
+      profiler.Finish("not_ready");
       return false;
+    }
+    profiler.EndPhase();
     Viewer2DOffscreenRenderer *offscreenRenderer = nullptr;
     Viewer2DPanel *capturePanel = nullptr;
     auto stopLoadingRequest = [this]() {
@@ -2164,6 +2174,7 @@ bool LayoutViewerPanel::RebuildCachedTexture() {
                          currentLayout.legendViews.size(),
                          needsLegendSymbolCapture ? "yes" : "no"));
     const bool needsCapturePanel = hasDirtyViewCache || needsLegendSymbolCapture;
+    profiler.BeginPhase("prepare_capture_panel");
     if (needsCapturePanel) {
       gui::layoutstatus::PostLayoutRenderStatus(
           this, wxTheApp ? wxTheApp->GetTopWindow() : nullptr,
@@ -2173,12 +2184,15 @@ bool LayoutViewerPanel::RebuildCachedTexture() {
         capturePanel = offscreenRenderer ? offscreenRenderer->GetPanel() : nullptr;
       }
       if (!capturePanel || !offscreenRenderer) {
+        profiler.Finish("capture_panel_unavailable");
         return false;
       }
     }
+    profiler.EndPhase();
 
     ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
     std::shared_ptr<const SymbolDefinitionSnapshot> legendSymbols;
+    profiler.BeginPhase("legend_symbol_capture");
     if (needsLegendSymbolCapture) {
       gui::layoutstatus::PostLayoutRenderStatus(
           this, wxTheApp ? wxTheApp->GetTopWindow() : nullptr,
@@ -2189,6 +2203,7 @@ bool LayoutViewerPanel::RebuildCachedTexture() {
           this, wxTheApp ? wxTheApp->GetTopWindow() : nullptr,
           "Legend symbol capture completed.");
     }
+    profiler.EndPhase();
     std::vector<unsigned char> legendPixels;
     std::vector<unsigned char> eventTablePixels;
     std::vector<unsigned char> textPixels;
@@ -2201,6 +2216,7 @@ bool LayoutViewerPanel::RebuildCachedTexture() {
       glReady = InitGL();
       return glReady;
     };
+    profiler.BeginPhase("2d_views");
     gui::layoutstatus::PostLayoutRenderStatus(
         this, wxTheApp ? wxTheApp->GetTopWindow() : nullptr,
         wxString::Format("Rendering 2D views (%zu)...",
@@ -2210,8 +2226,10 @@ bool LayoutViewerPanel::RebuildCachedTexture() {
       postRenderProgressStatus("Rendering 2D views", processedRenderItems,
                                currentLayout.view2dViews.size());
       ViewCache &cache = GetViewCache(view.id);
-      if (!cache.renderDirty)
+      if (!cache.renderDirty) {
+        profiler.RecordReusedElement();
         continue;
+      }
       cache.renderDirty = false;
       wxRect frameRect;
       if (!cache.hasCapture || !cache.hasRenderState ||
@@ -2312,10 +2330,14 @@ bool LayoutViewerPanel::RebuildCachedTexture() {
       cache.textureSize = wxSize(width, height);
       cache.renderZoom = renderZoom;
       cache.contentHash = HashViewContent(view);
+      profiler.RecordRenderedElement();
       std::vector<unsigned char>().swap(pixels);
-      return NeedsRenderRebuild();
+      const bool hasMoreWork = NeedsRenderRebuild();
+      profiler.Finish(hasMoreWork ? "incremental_pending" : "completed");
+      return hasMoreWork;
     }
   
+    profiler.BeginPhase("legends");
     gui::layoutstatus::PostLayoutRenderStatus(
         this, wxTheApp ? wxTheApp->GetTopWindow() : nullptr,
         wxString::Format("Rendering legends (%zu)...",
@@ -2336,8 +2358,10 @@ bool LayoutViewerPanel::RebuildCachedTexture() {
       if (contentChanged) {
         cache.renderDirty = true;
       }
-      if (!cache.renderDirty)
+      if (!cache.renderDirty) {
+        profiler.RecordReusedElement();
         continue;
+      }
       cache.renderDirty = false;
   
       const wxSize renderSize = GetFrameSizeForZoom(legend.frame, renderZoom);
@@ -2419,10 +2443,14 @@ bool LayoutViewerPanel::RebuildCachedTexture() {
       cache.textureSize = wxSize(width, height);
       cache.renderZoom = renderZoom;
       cache.contentHash = legendDataHash;
+      profiler.RecordRenderedElement();
       legendPixels.clear();
-      return NeedsRenderRebuild();
+      const bool hasMoreWork = NeedsRenderRebuild();
+      profiler.Finish(hasMoreWork ? "incremental_pending" : "completed");
+      return hasMoreWork;
     }
   
+    profiler.BeginPhase("event_tables");
     gui::layoutstatus::PostLayoutRenderStatus(
         this, wxTheApp ? wxTheApp->GetTopWindow() : nullptr,
         wxString::Format("Rendering event tables (%zu)...",
@@ -2437,8 +2465,10 @@ bool LayoutViewerPanel::RebuildCachedTexture() {
       size_t dataHash = HashEventTableFields(table);
       if (cache.contentHash != dataHash)
         cache.renderDirty = true;
-      if (!cache.renderDirty)
+      if (!cache.renderDirty) {
+        profiler.RecordReusedElement();
         continue;
+      }
       cache.renderDirty = false;
   
       const wxSize renderSize = GetFrameSizeForZoom(table.frame, renderZoom);
@@ -2537,10 +2567,14 @@ bool LayoutViewerPanel::RebuildCachedTexture() {
       cache.textureSize = wxSize(width, height);
       cache.renderZoom = renderZoom;
       cache.contentHash = dataHash;
+      profiler.RecordRenderedElement();
       eventTablePixels.clear();
-      return NeedsRenderRebuild();
+      const bool hasMoreWork = NeedsRenderRebuild();
+      profiler.Finish(hasMoreWork ? "incremental_pending" : "completed");
+      return hasMoreWork;
     }
   
+    profiler.BeginPhase("text_blocks");
     gui::layoutstatus::PostLayoutRenderStatus(
         this, wxTheApp ? wxTheApp->GetTopWindow() : nullptr,
         wxString::Format("Rendering text blocks (%zu)...",
@@ -2556,8 +2590,10 @@ bool LayoutViewerPanel::RebuildCachedTexture() {
       size_t dataHash = HashTextContent(text);
       if (cache.contentHash != dataHash)
         cache.renderDirty = true;
-      if (!cache.renderDirty)
+      if (!cache.renderDirty) {
+        profiler.RecordReusedElement();
         continue;
+      }
       cache.renderDirty = false;
   
       const wxSize renderSize = GetFrameSizeForZoom(text.frame, renderZoom);
@@ -2652,10 +2688,14 @@ bool LayoutViewerPanel::RebuildCachedTexture() {
       cache.textureSize = wxSize(width, height);
       cache.renderZoom = renderZoom;
       cache.contentHash = dataHash;
+      profiler.RecordRenderedElement();
       textPixels.clear();
-      return NeedsRenderRebuild();
+      const bool hasMoreWork = NeedsRenderRebuild();
+      profiler.Finish(hasMoreWork ? "incremental_pending" : "completed");
+      return hasMoreWork;
     }
   
+    profiler.BeginPhase("images");
     gui::layoutstatus::PostLayoutRenderStatus(
         this, wxTheApp ? wxTheApp->GetTopWindow() : nullptr,
         wxString::Format("Rendering images (%zu)...",
@@ -2672,8 +2712,10 @@ bool LayoutViewerPanel::RebuildCachedTexture() {
       size_t dataHash = HashImageContent(image);
       if (cache.contentHash != dataHash)
         cache.renderDirty = true;
-      if (!cache.renderDirty)
+      if (!cache.renderDirty) {
+        profiler.RecordReusedElement();
         continue;
+      }
       cache.renderDirty = false;
   
       const wxSize renderSize = GetFrameSizeForZoom(image.frame, renderZoom);
@@ -2773,12 +2815,16 @@ bool LayoutViewerPanel::RebuildCachedTexture() {
       cache.textureSize = wxSize(width, height);
       cache.renderZoom = renderZoom;
       cache.contentHash = dataHash;
+      profiler.RecordRenderedElement();
       imagePixels.clear();
-      return NeedsRenderRebuild();
+      const bool hasMoreWork = NeedsRenderRebuild();
+      profiler.Finish(hasMoreWork ? "incremental_pending" : "completed");
+      return hasMoreWork;
     }
   
     clearLoadingState();
     NotifyRenderReady();
+    profiler.Finish("completed");
     return false;
   } catch (const std::exception &ex) {
     loadingRequested = false;
@@ -3014,11 +3060,12 @@ void LayoutViewerPanel::RequestRenderRebuild() {
   const bool alreadyPending = renderPending || loadingRequested;
   renderPending = true;
   loadingRequested = true;
-  if (!alreadyPending) {
-    gui::layoutstatus::PostLayoutRenderStatus(
-        this, wxTheApp ? wxTheApp->GetTopWindow() : nullptr,
-        "Layout render queued...");
-  }
+  if (alreadyPending)
+    return;
+
+  gui::layoutstatus::PostLayoutRenderStatus(
+      this, wxTheApp ? wxTheApp->GetTopWindow() : nullptr,
+      "Layout render queued...");
   if (renderDelayTimer_.IsRunning())
     renderDelayTimer_.Stop();
   renderDelayTimer_.StartOnce(kZoomRenderDebounceMs);

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -93,6 +93,7 @@ using json = nlohmann::json;
 #include "mainwindow_print_controller.h"
 #include "mainwindow_view_controller.h"
 #include "layoutpanel.h"
+#include "layout_render_profiler.h"
 #include "layoutviewerpanel.h"
 #include "layout_render_status_notifier.h"
 #include "layouttextutils.h"
@@ -691,6 +692,7 @@ bool MainWindow::GuardStartupProjectLoadAction(const wxString &actionLabel) {
   return false;
 }
 
+// Loads a project archive and refreshes only the active layout preview during startup.
 bool MainWindow::LoadProjectFromPath(const std::string &path,
                                      bool showBlockingLoadUi) {
   constexpr int kProjectLoadProgressSteps = 10;
@@ -725,6 +727,10 @@ bool MainWindow::LoadProjectFromPath(const std::string &path,
     }
   };
 
+  gui::layoutperf::LayoutRenderProfiler loadProfiler(
+      "project_load_layout_startup");
+  loadProfiler.BeginPhase("project_archive_load");
+
   if (showBlockingLoadUi) {
     blockingProjectLoadDisabler = std::make_unique<wxWindowDisabler>();
     blockingProjectLoadOverlay.reset();
@@ -746,23 +752,43 @@ bool MainWindow::LoadProjectFromPath(const std::string &path,
     projectLoadProgressDialog.reset();
     ClearBlockingProjectLoadUi();
     finishLoad();
+    loadProfiler.Finish("project_load_failed");
     return false;
   }
+  loadProfiler.EndPhase();
   viewer2d::ReconcileFixtureLabelOverridesWithScene(
       GetDefaultGuiConfigServices().LegacyConfigManager());
 
+  loadProfiler.BeginPhase("scene_setup");
   reportProjectLoadProgress("Building scene...", true);
   Ensure3DViewport();
+  loadProfiler.EndPhase();
 
   currentProjectPath = path;
   currentProjectDisplayName.clear();
   ProjectUtils::SaveLastProjectPath(currentProjectPath);
 
+  loadProfiler.BeginPhase("layout_selection_reload");
   reportProjectLoadProgress("Applying saved layout...", true);
   ApplySavedLayout();
   if (layoutPanel)
     layoutPanel->ReloadLayouts();
+  // Inactive layouts stay in LayoutManager, but preview caches build lazily when selected.
+  if (const auto &loadedLayouts =
+          layouts::LayoutManager::Get().GetLayouts().Items();
+      !loadedLayouts.empty()) {
+    const layouts::LayoutDefinition *profiledLayout = &loadedLayouts.front();
+    for (const auto &layout : loadedLayouts) {
+      if (layout.name == activeLayoutName) {
+        profiledLayout = &layout;
+        break;
+      }
+    }
+    loadProfiler.SetLayoutContext(loadedLayouts.size(), *profiledLayout);
+  }
+  loadProfiler.EndPhase();
 
+  loadProfiler.BeginPhase("data_panels_reload");
   reportProjectLoadProgress("Reloading fixture/truss/support tables...", true);
   if (consolePanel)
     consolePanel->AppendMessage("Loaded " + wxString::FromUTF8(path));
@@ -775,6 +801,8 @@ bool MainWindow::LoadProjectFromPath(const std::string &path,
   if (sceneObjPanel)
     sceneObjPanel->ReloadData();
 
+  loadProfiler.EndPhase();
+  loadProfiler.BeginPhase("viewport_refresh");
   reportProjectLoadProgress("Updating 3D viewport...", true);
   if (viewportPanel) {
     ConfigManager &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
@@ -801,11 +829,15 @@ bool MainWindow::LoadProjectFromPath(const std::string &path,
   if (layerPanel)
     layerPanel->ReloadLayers();
 
+  loadProfiler.EndPhase();
+  loadProfiler.BeginPhase("summary_rigging_refresh");
   reportProjectLoadProgress("Refreshing panels...", true);
   RefreshSummary();
   reportProjectLoadProgress("Refreshing rigging...", true);
   RefreshRigging();
   GetDefaultGuiConfigServices().LegacyConfigManager().MarkSaved();
+  loadProfiler.EndPhase();
+  loadProfiler.BeginPhase("fixture_symbol_startup");
   reportProjectLoadProgress("Creating fixture symbols...", true);
 
   if (showBlockingLoadUi) {
@@ -819,12 +851,15 @@ bool MainWindow::LoadProjectFromPath(const std::string &path,
   }
 
   StartFixtureSymbolAutoUpdateForLoadedScene();
+  loadProfiler.EndPhase();
+  loadProfiler.BeginPhase("finalize_project_load");
   reportProjectLoadProgress("Updating window title...", true);
   UpdateTitle();
   projectLoadProgressStep = kProjectLoadProgressSteps;
   reportProjectLoadProgress("Finalizing project load...");
   projectLoadProgressDialog.reset();
   finishLoad();
+  loadProfiler.Finish("project_load_completed");
   return true;
 }
 


### PR DESCRIPTION
### Motivation
- Opening large projects was slow because layout previews were rebuilt eagerly and the first render passed triggered duplicate invalidations and heavyweight recaptures.
- The goal is to ensure the active layout renders quickly, avoid building previews for inactive layouts at startup, and add lightweight diagnostics to measure where time is spent.

### Description
- Add a small debug-only `LayoutRenderProfiler` (`gui/layout_render_profiler.{h,cpp}`) and register it in `gui/CMakeLists.txt` to emit compact performance traces (project layout count, active layout name, element counts, reused vs rendered elements, phase timings) in `Logger::Level::Debug` only in non-release builds.
- Instrument `LayoutViewerPanel::RebuildCachedTexture()` with the profiler and per-phase markings (`preflight`, `prepare_capture_panel`, `legend_symbol_capture`, `2d_views`, `legends`, `event_tables`, `text_blocks`, `images`) and record whether elements were reused or rebuilt while preserving the existing per-element cache types (`ViewCache`, `LegendCache`, etc.).
- Instrument project startup in `MainWindow::LoadProjectFromPath()` with the profiler around logical phases (archive load, scene setup, layout selection/reload, data panels reload, viewport refresh, summary/rigging refresh, fixture symbol startup, finalization) and add an explicit comment documenting that inactive layouts remain in `LayoutManager` but their preview caches are rendered lazily when selected.
- Prevent duplicate early rebuild scheduling by coalescing `RequestRenderRebuild()` so subsequent calls during an already-pending rebuild return early instead of restarting the debounce timer, reducing repeated invalidations on startup.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (module boundaries unchanged).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (no direct ConfigManager::Get() usage introduced in GUI).
- Performed a syntax-only compilation of the new profiler translation unit with `g++ -std=c++17 -Igui -Icore -Icore/layouts -Icore/print -fsyntax-only gui/layout_render_profiler.cpp` which succeeded.
- Attempted a full CMake configure/build (`cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug && cmake --build build`) but it could not complete in the environment due to missing wxWidgets development files (`wxWidgets_LIBRARIES` and `wxWidgets_INCLUDE_DIRS`), so full integration build was not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1de72704788324bd98f55aff16c012)