### PR TITLE
ci: add experimental Arch Linux package workflow

### DIFF
--- a/.github/workflows/arch-package.yml
+++ b/.github/workflows/arch-package.yml
@@ -1,0 +1,151 @@
+# Arch Linux package workflow for Perastage.
+# Builds an experimental pacman package without changing the AppImage workflow.
+
+name: Arch Linux Package Build
+
+on:
+  workflow_call:
+    inputs:
+      source_ref:
+        description: Git ref to build from when called as a reusable workflow.
+        required: false
+        type: string
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: Optional git ref to build from.
+        required: false
+        type: string
+        default: ""
+  push:
+    branches:
+      - ci/arch-package
+
+jobs:
+  build-arch-package:
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:base-devel
+
+    env:
+      VCPKG_ROOT: ${{ github.workspace }}/vcpkg
+      VCPKG_INSTALLED: ${{ github.workspace }}/.vcpkg-cache/installed
+      VCPKG_DOWNLOADS: ${{ github.workspace }}/.vcpkg-cache/downloads
+      VCPKG_PACKAGES: ${{ github.workspace }}/.vcpkg-cache/packages
+      VCPKG_TARGET_TRIPLET: x64-linux
+
+    steps:
+      - name: Prepare Arch base tools
+        run: |
+          pacman -Syu --noconfirm --needed git ca-certificates
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_ref != '' && inputs.source_ref || github.ref }}
+
+      - name: Install Arch build dependencies
+        run: |
+          pacman -S --noconfirm --needed \
+            autoconf \
+            automake \
+            cmake \
+            curl \
+            desktop-file-utils \
+            file \
+            gcc \
+            glew \
+            glu \
+            gtk3 \
+            hicolor-icon-theme \
+            libglvnd \
+            libtool \
+            m4 \
+            make \
+            ninja \
+            patch \
+            pkgconf \
+            shared-mime-info \
+            tar \
+            unzip \
+            zip \
+            zlib
+
+      - name: Prepare vcpkg folders
+        run: |
+          mkdir -p "$VCPKG_DOWNLOADS" "$VCPKG_INSTALLED" "$VCPKG_PACKAGES"
+
+      - name: Bootstrap vcpkg
+        run: |
+          if [ -d "$VCPKG_ROOT/.git" ]; then
+            git -C "$VCPKG_ROOT" fetch --depth 1 origin master
+            git -C "$VCPKG_ROOT" checkout --force FETCH_HEAD
+          else
+            rm -rf "$VCPKG_ROOT"
+            git clone --depth 1 https://github.com/microsoft/vcpkg.git "$VCPKG_ROOT"
+          fi
+          "$VCPKG_ROOT/bootstrap-vcpkg.sh" -disableMetrics
+
+      - name: Install vcpkg packages
+        run: |
+          # Perastage still uses vcpkg for Linux CI because nanovg, PoDoFo, and
+          # meshoptimizer availability can vary across distro repositories.
+          "$VCPKG_ROOT/vcpkg" install \
+            wxwidgets:x64-linux \
+            tinyxml2:x64-linux \
+            glew:x64-linux \
+            curl:x64-linux \
+            zlib:x64-linux \
+            nanovg:x64-linux \
+            podofo:x64-linux \
+            meshoptimizer:x64-linux \
+            --x-install-root="$VCPKG_INSTALLED" \
+            --x-packages-root="$VCPKG_PACKAGES" \
+            --downloads-root="$VCPKG_DOWNLOADS"
+
+      - name: Create makepkg user
+        run: |
+          useradd --create-home --shell /bin/bash builder
+          chown -R builder:builder "$GITHUB_WORKSPACE"
+
+      - name: Build Arch package
+        run: |
+          su builder -c "export VCPKG_ROOT='$VCPKG_ROOT' VCPKG_INSTALLED='$VCPKG_INSTALLED' VCPKG_TARGET_TRIPLET='$VCPKG_TARGET_TRIPLET'; cd '$GITHUB_WORKSPACE/packaging/arch' && makepkg --force --noconfirm --nodeps"
+
+      - name: Collect Arch package
+        run: |
+          set -euo pipefail
+
+          VERSION="$(tr -d '[:space:]' < VERSION)"
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "VERSION must be MAJOR.MINOR.PATCH, got: '$VERSION'"
+            exit 1
+          fi
+
+          mapfile -t PACKAGE_FILES < <(find packaging/arch -maxdepth 1 -type f -name 'perastage-*-x86_64.pkg.tar.zst' | sort)
+          if [ "${#PACKAGE_FILES[@]}" -ne 1 ]; then
+            echo "Expected exactly one Arch package, found ${#PACKAGE_FILES[@]}"
+            printf '%s\n' "${PACKAGE_FILES[@]:-none}"
+            exit 1
+          fi
+
+          OUTPUT_NAME="Perastage-${VERSION}-arch-x86_64.pkg.tar.zst"
+          cp "${PACKAGE_FILES[0]}" "$OUTPUT_NAME"
+          test -f "$OUTPUT_NAME" || { echo "Arch package was not created"; exit 1; }
+          file "$OUTPUT_NAME"
+          tar -tf "$OUTPUT_NAME" | tee arch-package-contents.txt
+          grep -q '^opt/perastage/Perastage$' arch-package-contents.txt
+          grep -q '^opt/perastage/resources/' arch-package-contents.txt
+          grep -q '^opt/perastage/library/' arch-package-contents.txt
+          grep -q '^opt/perastage/licenses/' arch-package-contents.txt
+          grep -q '^opt/perastage/help.md$' arch-package-contents.txt
+          grep -q '^usr/share/applications/perastage.desktop$' arch-package-contents.txt
+          grep -q '^usr/share/mime/packages/perastage-mime.xml$' arch-package-contents.txt
+          grep -q '^usr/share/icons/hicolor/1024x1024/apps/perastage.png$' arch-package-contents.txt
+
+      - name: Upload Arch package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Perastage-arch-package
+          path: Perastage-*-arch-x86_64.pkg.tar.zst

--- a/.github/workflows/minor-draft-release.yml
+++ b/.github/workflows/minor-draft-release.yml
@@ -145,6 +145,13 @@ jobs:
     with:
       source_ref: ${{ needs.prepare-release.outputs.new_tag }}
 
+  arch-package:
+    if: ${{ needs.prepare-release.outputs.dry_run != 'true' }}
+    needs: prepare-release
+    uses: ./.github/workflows/arch-package.yml
+    with:
+      source_ref: ${{ needs.prepare-release.outputs.new_tag }}
+
   create-draft-release:
     if: ${{ needs.prepare-release.outputs.dry_run != 'true' }}
     needs:
@@ -152,6 +159,7 @@ jobs:
       - windows-installer
       - linux-installer
       - macos-installer
+      - arch-package
     runs-on: ubuntu-latest
 
     steps:
@@ -196,18 +204,21 @@ jobs:
           mapfile -t WIN_MATCHES < <(find release-assets -type f -name 'Perastage_*_Setup.exe' | sort)
           mapfile -t LINUX_MATCHES < <(find release-assets -type f -name 'Perastage-*-x86_64.AppImage' | sort)
           mapfile -t MAC_MATCHES < <(find release-assets -type f -name 'Perastage-*-macos-arm64.dmg' | sort)
+          mapfile -t ARCH_MATCHES < <(find release-assets -type f -name 'Perastage-*-arch-x86_64.pkg.tar.zst' | sort)
 
-          if [ "${#WIN_MATCHES[@]}" -ne 1 ] || [ "${#LINUX_MATCHES[@]}" -ne 1 ] || [ "${#MAC_MATCHES[@]}" -ne 1 ]; then
-            echo "Expected exactly one installer per platform"
+          if [ "${#WIN_MATCHES[@]}" -ne 1 ] || [ "${#LINUX_MATCHES[@]}" -ne 1 ] || [ "${#MAC_MATCHES[@]}" -ne 1 ] || [ "${#ARCH_MATCHES[@]}" -ne 1 ]; then
+            echo "Expected exactly one installer per platform plus one experimental Arch package"
             echo "Windows matches (${#WIN_MATCHES[@]}): ${WIN_MATCHES[*]:-none}"
-            echo "Linux matches (${#LINUX_MATCHES[@]}): ${LINUX_MATCHES[*]:-none}"
+            echo "Linux AppImage matches (${#LINUX_MATCHES[@]}): ${LINUX_MATCHES[*]:-none}"
             echo "macOS matches (${#MAC_MATCHES[@]}): ${MAC_MATCHES[*]:-none}"
+            echo "Arch package matches (${#ARCH_MATCHES[@]}): ${ARCH_MATCHES[*]:-none}"
             exit 1
           fi
 
           cp "${WIN_MATCHES[0]}" "$FINAL_DIR/"
           cp "${LINUX_MATCHES[0]}" "$FINAL_DIR/"
           cp "${MAC_MATCHES[0]}" "$FINAL_DIR/"
+          cp "${ARCH_MATCHES[0]}" "$FINAL_DIR/"
 
           if find "$FINAL_DIR" -type f -name '*.zip' | grep -q .; then
             echo "Final asset directory must not contain zip files"
@@ -217,6 +228,7 @@ jobs:
           WIN_ASSET="$FINAL_DIR/$(basename "${WIN_MATCHES[0]}")"
           LINUX_ASSET="$FINAL_DIR/$(basename "${LINUX_MATCHES[0]}")"
           MAC_ASSET="$FINAL_DIR/$(basename "${MAC_MATCHES[0]}")"
+          ARCH_ASSET="$FINAL_DIR/$(basename "${ARCH_MATCHES[0]}")"
 
           echo "Final release assets (release-assets/final):"
           find "$FINAL_DIR" -mindepth 1 -maxdepth 1 -type f -print | sort
@@ -224,6 +236,7 @@ jobs:
           echo "win_asset=$WIN_ASSET" >> "$GITHUB_OUTPUT"
           echo "linux_asset=$LINUX_ASSET" >> "$GITHUB_OUTPUT"
           echo "mac_asset=$MAC_ASSET" >> "$GITHUB_OUTPUT"
+          echo "arch_asset=$ARCH_ASSET" >> "$GITHUB_OUTPUT"
 
       - name: Create draft release with curated notes
         env:
@@ -235,6 +248,7 @@ jobs:
           WIN_ASSET: ${{ steps.assets.outputs.win_asset }}
           LINUX_ASSET: ${{ steps.assets.outputs.linux_asset }}
           MAC_ASSET: ${{ steps.assets.outputs.mac_asset }}
+          ARCH_ASSET: ${{ steps.assets.outputs.arch_asset }}
         run: |
           set -euo pipefail
 
@@ -242,7 +256,7 @@ jobs:
 
           echo "Creating draft release in $GH_REPO"
 
-          cmd=(gh release create "$TAG_NAME" "$WIN_ASSET" "$LINUX_ASSET" "$MAC_ASSET" --draft --title "$RELEASE_TITLE")
+          cmd=(gh release create "$TAG_NAME" "$WIN_ASSET" "$LINUX_ASSET" "$MAC_ASSET" "$ARCH_ASSET" --draft --title "$RELEASE_TITLE")
           if [ -s "$RELEASE_NOTES_FILE" ]; then
             echo "Using curated release notes from $RELEASE_NOTES_FILE"
             cmd+=(--notes-file "$RELEASE_NOTES_FILE")

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The goal is simple: make MVR files easy to open, understand, review, and present
 The recommended way to install Perastage is to download the latest release from GitHub:
 
 - Go to the **latest release** in this repository and download the package for your platform.
+- On Linux, the AppImage remains the recommended generic package. Experimental Arch Linux packages may also be attached for Arch-based distributions and should be tested on real Arch, Manjaro, or EndeavourOS systems.
 
 If you want to build from source, setup and dependency notes are available in the documentation under `docs/`.
 

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -86,6 +86,21 @@ values without aggressively deleting global extension ownership.
 - Uninstall behavior is conservative and avoids aggressive global extension ownership cleanup.
 - Legacy CPack/NSIS wiring exists for compatibility but is not the primary path.
 
+## Linux Packaging
+
+The official generic Linux release asset remains the AppImage produced by `.github/workflows/linux-installer.yml`. This is the recommended download for general Linux distribution because it keeps the existing staged application layout and bundles the runtime pieces expected by the AppImage flow.
+
+Perastage also generates an experimental Arch Linux pacman package from `.github/workflows/arch-package.yml`:
+
+- Artifact name: `Perastage-<version>-arch-x86_64.pkg.tar.zst`
+- Packaging recipe: `packaging/arch/PKGBUILD`
+- Build environment: `archlinux:base-devel` in GitHub Actions
+- Intended audience: Arch-based distributions such as Arch Linux, Manjaro, and EndeavourOS
+
+The Arch package uses the project CMake install target, keeps runtime assets under `/opt/perastage` so resource lookup matches the current Linux application layout, and exposes a `/usr/bin/Perastage` launcher symlink. Desktop metadata, MIME metadata, and the application icon are installed into standard `/usr/share` locations.
+
+This Arch package is experimental until it receives broader runtime testing on real Arch-based desktop systems. If a user only needs the most portable Linux release asset, use the AppImage.
+
 ## Linux Desktop Integration
 
 Install layouts include desktop and MIME metadata:

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -27,7 +27,7 @@ Changes since `v1.2.0`.
 - Improved GDTF model loading with better lookup ordering, GLB fallback handling, and diagnostics for missing or difficult-to-load models.
 - Improved fixture symbol alignment so generated layout symbols better match each fixture's local axes.
 - Improved 3D textured mesh lighting and mirrored geometry handling so dark/light patterns, ink normals, face orientation, and textured surfaces render more consistently.
-- Improved release asset handling so GitHub Draft Releases can include direct Windows installer, Linux AppImage, and macOS DMG downloads.
+- Improved release asset handling so GitHub Draft Releases can include direct Windows installer, Linux AppImage, macOS DMG, and experimental Arch Linux package downloads.
 
 ## Fixes
 
@@ -52,7 +52,7 @@ Changes since `v1.2.0`.
 ## Documentation
 
 - Updated user documentation for update preferences, MVR export warnings, quick-start guidance, feature descriptions, and GDTF mutation policy notes.
-- Updated packaging documentation to clarify preferred release asset distribution and macOS unsigned build behavior.
+- Updated packaging documentation to clarify preferred release asset distribution, experimental Arch Linux package availability, and macOS unsigned build behavior.
 - Added a curated release-notes workflow so future public release notes can be prepared from user-friendly entries instead of raw commit lists.
 
 ## Internal changes
@@ -61,4 +61,4 @@ Changes since `v1.2.0`.
 - Refactored layout render invalidation, selected element z-order mapping, label builders, and status notification plumbing without changing the intended user workflow.
 - Added internal resource-reference synchronization and layout image resource registry support used by project save/export paths.
 - Added symbol cache manifest infrastructure and tests to improve project cache consistency.
-- Added and adjusted CI/release workflow plumbing for installer artifact handling, curated release notes, and version-bump safety.
+- Added and adjusted CI/release workflow plumbing for installer artifact handling, experimental Arch Linux package generation, curated release notes, and version-bump safety.

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,0 +1,114 @@
+# Maintainer: Perastage maintainers
+
+pkgname=perastage
+pkgver=$(tr -d '[:space:]' < "$(realpath "$(dirname "${BASH_SOURCE[0]}")/../..")/VERSION")
+pkgrel=1
+pkgdesc='Lighting plot editor and MVR viewer'
+arch=('x86_64')
+url='https://github.com/PeramatoG/Perastage'
+license=('GPL-3.0-or-later')
+depends=(
+  'curl'
+  'gcc-libs'
+  'glew'
+  'glibc'
+  'glu'
+  'gtk3'
+  'hicolor-icon-theme'
+  'libglvnd'
+  'shared-mime-info'
+  'zlib'
+)
+makedepends=(
+  'base-devel'
+  'cmake'
+  'desktop-file-utils'
+  'git'
+  'ninja'
+  'pkgconf'
+)
+source=()
+sha256sums=()
+
+# Validates that makepkg is running from the repository packaging/arch directory.
+_resolve_repo_root() {
+  local repo_root
+  repo_root="$(realpath "$startdir/../..")"
+
+  if [[ ! -f "$repo_root/VERSION" || ! -f "$repo_root/CMakeLists.txt" ]]; then
+    echo "Unable to resolve Perastage repository root from $startdir" >&2
+    return 1
+  fi
+
+  printf '%s\n' "$repo_root"
+}
+
+# Configures and builds Perastage with CMake and the project Linux dependency strategy.
+build() {
+  local repo_root
+  repo_root="$(_resolve_repo_root)"
+
+  local cmake_args=(
+    -S "$repo_root"
+    -B "$srcdir/build"
+    -G Ninja
+    -DCMAKE_BUILD_TYPE=Release
+    -DCMAKE_INSTALL_PREFIX=/opt/perastage
+    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+    -DCMAKE_CXX_STANDARD=20
+    -DCMAKE_CXX_STANDARD_REQUIRED=ON
+    -DCMAKE_CXX_EXTENSIONS=OFF
+    -DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF
+    -DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF
+    -DCMAKE_FIND_PACKAGE_PREFER_CONFIG=OFF
+    -DCURL_NO_CURL_CMAKE=ON
+  )
+
+  if [[ -n "${VCPKG_ROOT:-}" ]]; then
+    cmake_args+=("-DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake")
+  fi
+  if [[ -n "${VCPKG_TARGET_TRIPLET:-}" ]]; then
+    cmake_args+=("-DVCPKG_TARGET_TRIPLET=$VCPKG_TARGET_TRIPLET")
+  fi
+  if [[ -n "${VCPKG_INSTALLED:-}" ]]; then
+    cmake_args+=("-DVCPKG_INSTALLED_DIR=$VCPKG_INSTALLED")
+  fi
+
+  cmake "${cmake_args[@]}"
+  cmake --build "$srcdir/build" --config Release
+}
+
+# Installs the built application into the Arch package root and exposes desktop metadata system-wide.
+package() {
+  DESTDIR="$pkgdir" cmake --install "$srcdir/build" --config Release
+
+  install -d "$pkgdir/usr/bin"
+  ln -s /opt/perastage/Perastage "$pkgdir/usr/bin/Perastage"
+
+  # The project install rules keep Linux runtime assets beside the executable,
+  # which is appropriate for the current application resource lookup behavior.
+  install -d "$pkgdir/usr/share/applications" "$pkgdir/usr/share/mime/packages" "$pkgdir/usr/share/icons/hicolor/1024x1024/apps"
+  if [[ -f "$pkgdir/opt/perastage/share/applications/perastage.desktop" ]]; then
+    mv "$pkgdir/opt/perastage/share/applications/perastage.desktop" "$pkgdir/usr/share/applications/perastage.desktop"
+  fi
+  if [[ -f "$pkgdir/opt/perastage/share/mime/packages/perastage-mime.xml" ]]; then
+    mv "$pkgdir/opt/perastage/share/mime/packages/perastage-mime.xml" "$pkgdir/usr/share/mime/packages/perastage-mime.xml"
+  fi
+  if [[ -f "$pkgdir/opt/perastage/share/icons/hicolor/1024x1024/apps/perastage.png" ]]; then
+    mv "$pkgdir/opt/perastage/share/icons/hicolor/1024x1024/apps/perastage.png" "$pkgdir/usr/share/icons/hicolor/1024x1024/apps/perastage.png"
+  fi
+  rm -rf "$pkgdir/opt/perastage/share"
+
+  install -d "$pkgdir/usr/share/licenses/$pkgname"
+  ln -s /opt/perastage/LICENSE.txt "$pkgdir/usr/share/licenses/$pkgname/LICENSE.txt"
+  ln -s /opt/perastage/THIRD_PARTY_LICENSES.md "$pkgdir/usr/share/licenses/$pkgname/THIRD_PARTY_LICENSES.md"
+
+  test -x "$pkgdir/opt/perastage/Perastage"
+  test -d "$pkgdir/opt/perastage/resources"
+  test -d "$pkgdir/opt/perastage/library"
+  test -d "$pkgdir/opt/perastage/licenses"
+  test -f "$pkgdir/opt/perastage/help.md"
+  test -f "$pkgdir/usr/share/applications/perastage.desktop"
+  test -f "$pkgdir/usr/share/mime/packages/perastage-mime.xml"
+  test -f "$pkgdir/usr/share/icons/hicolor/1024x1024/apps/perastage.png"
+}


### PR DESCRIPTION
### Motivation

- Provide an experimental Arch Linux packaging path in CI while preserving the existing AppImage build as the recommended generic Linux asset.
- Build an Arch pacman package in an Arch environment to produce a `.pkg.tar.zst` suitable for Arch-based distributions without changing application install logic.
- Integrate the Arch artifact into the curated draft-release flow so release assets include the experimental Arch package alongside Windows, macOS and the unchanged AppImage.

### Description

- Add a reusable and manually runnable workflow ` .github/workflows/arch-package.yml` that runs in an `archlinux:base-devel` container, bootstraps `vcpkg`, installs Arch build dependencies, runs `makepkg`, validates the generated package contents, and uploads `Perastage-<version>-arch-x86_64.pkg.tar.zst` as the `Perastage-arch-package` artifact; the workflow supports `workflow_call` and `workflow_dispatch`.
- Add `packaging/arch/PKGBUILD` that uses the repository `VERSION`, drives a CMake+Ninja Release build, installs into `/opt/perastage`, symlinks `/usr/bin/Perastage`, and installs desktop/MIME/icon files into standard `/usr/share` locations, while documenting runtime/dependency choices in comments.
- Wire the new Arch reusable workflow into the release pipeline by updating ` .github/workflows/minor-draft-release.yml` so the draft-release job downloads and attaches the Arch package together with Windows, AppImage and macOS assets.
- Update user-facing docs: `docs/packaging.md` and `README.md` now mention the Arch package is experimental and that the AppImage remains the recommended generic Linux artifact, and `docs/release-notes-draft.md` was updated to note the Arch package change.

### Testing

- Syntax and static checks: `bash -n packaging/arch/PKGBUILD` succeeded, and the workflow YAMLs were YAML-load-checked with a short Ruby YAML loader (succeeded).
- Project quality checks required by repository policy: `tests/check_perastage_tree_modules.sh` passed and `tests/check_no_configmanager_get_in_gui.sh` passed.
- Repository validation: `git diff --check` produced no warnings.
- Note: `makepkg` is not available in the local Ubuntu workspace, so a full package build was not executed locally; the full Arch package build and artifact production are intended to run inside the new `archlinux:base-devel` GitHub Actions container (the workflow includes validation steps that assert the `.pkg.tar.zst` contents and expected naming).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ebff5bbb8832492fc5327764ebb32)