### PR TITLE
Add MVR import choice (Open as new project / Merge) and scene-merge helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,7 @@ add_executable(${PROJECT_NAME} main.cpp
     models/sceneobject.cpp
     models/truss.cpp
     mvr/mvrimporter.cpp
+    mvr/mvrscenemerger.cpp
     mvr/mvrexporter.cpp
     mvr/primitive_model_resources.cpp
 )

--- a/docs/features.md
+++ b/docs/features.md
@@ -30,8 +30,9 @@ Perastage is designed for lighting designers, programmers, and technicians who n
 ### MVR import and open behavior
 
 - Imports MVR 1.6 scenes with fixtures, trusses, hoists/supports, and generic objects.
-- `.mvr` opening uses a clean-scene reset plus import flow for deterministic behavior.
-- Menu import and OS association entry points use the same progress and UI lock strategy.
+- `.mvr` opening from startup, command-line, or OS association uses a clean-scene reset plus import flow for deterministic behavior.
+- Menu import lets you choose between opening the selected MVR as a new project or merging it into the current project.
+- Merged MVR content preserves existing scene content and resolves imported UUID collisions so both scenes can coexist.
 
 ### MVR export
 

--- a/docs/opening-mvr-files.md
+++ b/docs/opening-mvr-files.md
@@ -7,7 +7,9 @@ Perastage is built for MVR-centered workflows.
 Use one of these methods:
 
 - Open an existing `.mvr` file directly.
-- Use **File → Import MVR...**.
+- Use **File → Import MVR...**. After choosing a file, select **Open as new project** to replace the current scene or **Merge into current project** to add the selected MVR content to the current scene.
+
+Opening an `.mvr` file directly from the command line, operating system file association, or startup path uses the clean **Open as new project** behavior.
 
 After import, review fixtures, trusses, hoists, objects, and layout information in the available views and tables.
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -17,6 +17,7 @@ Changes since `v1.2.0`.
 - Added a GUI update-check action and startup update-check preference, making it easier to discover new Perastage versions.
 - Added fixture replacement from the Edit menu, including improved source labeling, transform preservation, selection stability, UUID handling, and color reuse/autocolor behavior.
 - Added support for packaging referenced layout images into project archives, making `.pstg` project files more portable when shared or reopened elsewhere.
+- Added an MVR import choice so users can open a selected MVR as a new project or merge it into the current project.
 
 ## Improvements
 

--- a/gui/mainwindow/controllers/mainwindow_io_controller.cpp
+++ b/gui/mainwindow/controllers/mainwindow_io_controller.cpp
@@ -2,7 +2,9 @@
 
 #include "mainwindow.h"
 
+#include <wx/arrstr.h>
 #include <wx/busyinfo.h>
+#include <wx/choicdlg.h>
 #include <wx/filedlg.h>
 #include <wx/filename.h>
 #include <wx/msgdlg.h>
@@ -12,6 +14,7 @@
 #include <algorithm>
 #include <memory>
 #include <optional>
+#include <sstream>
 #include <string>
 
 #include "consolepanel.h"
@@ -26,6 +29,7 @@
 #include "layoutviewerpanel.h"
 #include "logger.h"
 #include "mvrimporter.h"
+#include "mvrscenemerger.h"
 #include "projectutils.h"
 #include "sceneobjecttablepanel.h"
 #include "splashscreen.h"
@@ -33,6 +37,34 @@
 #include "viewer2dpanel.h"
 #include "viewer2drenderpanel.h"
 #include "viewer3dpanel.h"
+
+namespace {
+
+enum class MvrImportChoice {
+  OpenAsNewProject,
+  MergeIntoCurrentProject,
+  Cancel,
+};
+
+// Shows the user-facing MVR import mode selection dialog after a file has been chosen.
+MvrImportChoice ShowMvrImportChoiceDialog(wxWindow *parent) {
+  wxArrayString choices;
+  choices.Add("Open as new project");
+  choices.Add("Merge into current project");
+  wxSingleChoiceDialog dialog(
+      parent,
+      "Choose how Perastage should import the selected MVR file.",
+      "Import MVR", choices);
+  dialog.SetSelection(0);
+
+  if (dialog.ShowModal() != wxID_OK)
+    return MvrImportChoice::Cancel;
+  if (dialog.GetSelection() == 1)
+    return MvrImportChoice::MergeIntoCurrentProject;
+  return MvrImportChoice::OpenAsNewProject;
+}
+
+} // namespace
 
 // Stores the owning MainWindow pointer for IO operations during the controller lifetime.
 MainWindowIoController::MainWindowIoController(MainWindow &owner)
@@ -170,6 +202,27 @@ bool MainWindowIoController::ImportMvrFromPath(const std::string &pathUtf8) {
     cfg.SetValue(kViewer3DRenderStyleConfigKey, *preservedViewer3DRenderStyle);
   layouts::LayoutManager::Get().LoadFromConfig(cfg);
 
+  RefreshPanelsAfterMvrSceneChange();
+
+  importProgress.reset();
+  importOverlay.reset();
+  importDisabler.reset();
+
+  if (owner->GetStatusBar()) {
+    const wxString fileName = wxFileName(filePath).GetFullName();
+    owner->SetStatusText("MVR imported: " + fileName, 0);
+  }
+  // Re-enables layout rendering only after all import-driven panel updates finish.
+  owner->mvrImportPipelineActive = false;
+  return true;
+}
+
+// Refreshes all scene-dependent UI panels after MVR scene content changes.
+void MainWindowIoController::RefreshPanelsAfterMvrSceneChange() {
+  MainWindow *owner = ownerRef_;
+  if (owner == nullptr)
+    return;
+
   if (owner->layoutPanel)
     owner->layoutPanel->ReloadLayouts();
   if (owner->fixturePanel)
@@ -197,30 +250,15 @@ bool MainWindowIoController::ImportMvrFromPath(const std::string &pathUtf8) {
   owner->RefreshSummary();
   owner->RefreshRigging();
 
-  // Keep import behavior aligned with the existing Tools > Auto color flow:
-  // once the MVR scene is loaded, trigger auto-color so fixture types without
-  // dictionary colors still receive a color by type/group.
+  // Keeps MVR scene updates aligned with the existing Tools > Auto color flow.
   wxCommandEvent autoColorEvent;
   owner->OnAutoColor(autoColorEvent);
 
-  importProgress.reset();
-  importOverlay.reset();
-  importDisabler.reset();
-
-  if (owner->GetStatusBar()) {
-    const wxString fileName = wxFileName(filePath).GetFullName();
-    owner->SetStatusText("MVR imported: " + fileName, 0);
-  }
-  // Re-enables layout rendering only after all import-driven panel updates finish.
-  owner->mvrImportPipelineActive = false;
-  if (owner->layoutPanel)
-    owner->layoutPanel->ReloadLayouts();
   if (owner->layoutViewerPanel)
     owner->layoutViewerPanel->RefreshAfterSceneContentUpdate();
-  return true;
 }
 
-// Opens a file picker and imports the selected MVR file using the official open policy.
+// Opens a file picker and imports the selected MVR file using the selected import mode.
 void MainWindowIoController::OnImportMVR(wxCommandEvent &) {
   wxString miscDir =
       wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("misc"));
@@ -236,9 +274,96 @@ void MainWindowIoController::OnImportMVR(wxCommandEvent &) {
 
   const wxString filePath = openFileDialog.GetPath();
   const std::string pathUtf8 = filePath.ToUTF8().data();
-  (void)ImportMvrWithOfficialPolicy(pathUtf8);
+  switch (ShowMvrImportChoiceDialog(ownerRef_)) {
+  case MvrImportChoice::OpenAsNewProject:
+    (void)ImportMvrWithOfficialPolicy(pathUtf8);
+    return;
+  case MvrImportChoice::MergeIntoCurrentProject:
+    (void)MergeMvrFromPath(pathUtf8);
+    return;
+  case MvrImportChoice::Cancel:
+    return;
+  }
 }
 
+// Merges an MVR file into the current scene while keeping existing project content.
+bool MainWindowIoController::MergeMvrFromPath(const std::string &pathUtf8) {
+  constexpr const char *kLayoutsConfigKey = "layouts_collection";
+  constexpr const char *kViewer3DRenderStyleConfigKey = "viewer3d_render_style";
+  MainWindow *owner = ownerRef_;
+  if (owner == nullptr || owner->guiConfigServices == nullptr)
+    return false;
+
+  ConfigManager &cfg = owner->guiConfigServices->LegacyConfigManager();
+  MvrScene currentScene = cfg.GetScene();
+  const std::optional<std::string> preservedLayoutsConfig =
+      cfg.GetValue(kLayoutsConfigKey);
+  const std::optional<std::string> preservedViewer3DRenderStyle =
+      cfg.GetValue(kViewer3DRenderStyleConfigKey);
+
+  auto restorePreservedConfig = [&cfg, &preservedLayoutsConfig,
+                                 &preservedViewer3DRenderStyle]() {
+    if (preservedLayoutsConfig.has_value())
+      cfg.SetValue(kLayoutsConfigKey, *preservedLayoutsConfig);
+    else
+      cfg.RemoveKey(kLayoutsConfigKey);
+    if (preservedViewer3DRenderStyle.has_value())
+      cfg.SetValue(kViewer3DRenderStyleConfigKey, *preservedViewer3DRenderStyle);
+    else
+      cfg.RemoveKey(kViewer3DRenderStyleConfigKey);
+    layouts::LayoutManager::Get().LoadFromConfig(cfg);
+  };
+
+  owner->mvrImportPipelineActive = true;
+  SplashScreen::Hide();
+  if (owner->GetStatusBar())
+    owner->SetStatusText("MVR merge: importing selected file...", 0);
+
+  MvrScene importedScene;
+  MvrImporter mergeImporter;
+  owner->LockViewportInteraction();
+  const bool imported =
+      mergeImporter.ImportSceneFromFile(pathUtf8, importedScene, true, true);
+  owner->UnlockViewportInteraction();
+
+  if (!imported) {
+    cfg.GetScene() = currentScene;
+    restorePreservedConfig();
+    owner->mvrImportPipelineActive = false;
+    if (owner->GetStatusBar())
+      owner->SetStatusText("MVR merge failed.", 0);
+    wxMessageBox("Failed to import MVR file for merge.", "Error",
+                 wxOK | wxICON_ERROR, owner);
+    if (owner->consolePanel)
+      owner->consolePanel->AppendMessage("Failed to merge " +
+                                           wxString::FromUTF8(pathUtf8));
+    return false;
+  }
+
+  cfg.GetScene() = currentScene;
+  cfg.PushUndoState("merge MVR");
+  const mvr::MvrSceneMergeResult mergeResult =
+      mvr::MergeImportedSceneIntoCurrent(cfg.GetScene(), importedScene);
+  cfg.MarkDirty();
+  restorePreservedConfig();
+  viewer2d::ReconcileFixtureLabelOverridesWithScene(cfg);
+  RefreshPanelsAfterMvrSceneChange();
+  owner->mvrImportPipelineActive = false;
+
+  const wxString fileName =
+      wxFileName(wxString::FromUTF8(pathUtf8)).GetFullName();
+  if (owner->consolePanel) {
+    std::ostringstream summary;
+    summary << "Merged " << pathUtf8 << " (" << mergeResult.fixturesAdded
+            << " fixtures, " << mergeResult.trussesAdded << " trusses, "
+            << mergeResult.supportsAdded << " hoists, "
+            << mergeResult.sceneObjectsAdded << " objects)";
+    owner->consolePanel->AppendMessage(wxString::FromUTF8(summary.str()));
+  }
+  if (owner->GetStatusBar())
+    owner->SetStatusText("MVR merged: " + fileName, 0);
+  return true;
+}
 
 // Applies the official MVR-open policy by confirming unsaved changes before importing the file.
 bool MainWindowIoController::ImportMvrWithOfficialPolicy(
@@ -307,13 +432,13 @@ bool MainWindowIoController::OpenPathFromCommandLine(
     return true;
   }
 
-  if (extension == "mvr")
-  {
+  if (extension == "mvr") {
     Logger::Instance().Log("Opening MVR from external request: " + pathUtf8);
-    const bool imported = ImportMvrFromPath(pathUtf8);
+    const bool imported = ImportMvrWithOfficialPolicy(pathUtf8);
     wxFileName fileInfo(wxString::FromUTF8(pathUtf8));
     if (imported) {
-      Logger::Instance().Log("MVR imported: " + fileInfo.GetFullName().ToStdString());
+      Logger::Instance().Log("MVR imported: " +
+                             fileInfo.GetFullName().ToStdString());
     } else {
       Logger::Instance().Log("MVR import failed: " + pathUtf8);
     }

--- a/gui/mainwindow/controllers/mainwindow_io_controller.h
+++ b/gui/mainwindow/controllers/mainwindow_io_controller.h
@@ -10,6 +10,7 @@ public:
   explicit MainWindowIoController(MainWindow &owner);
   void OnImportMVR(wxCommandEvent &event);
   bool OpenPathFromCommandLine(const std::string &pathUtf8);
+  bool MergeMvrFromPath(const std::string &pathUtf8);
 
 private:
   static constexpr const char *kMvrOpenAction = "importing an MVR file";
@@ -17,5 +18,6 @@ private:
 
   bool ImportMvrFromPath(const std::string &pathUtf8);
   bool ImportMvrWithOfficialPolicy(const std::string &pathUtf8);
+  void RefreshPanelsAfterMvrSceneChange();
   MainWindow *ownerRef_ = nullptr; // Non-owning pointer; MainWindow owns this controller.
 };

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -1091,11 +1091,31 @@ static void ReadSupportHoistInfoFromUserData(tinyxml2::XMLElement *supportNode,
     }
   }
 }
-// Imports an MVR file from disk by validating the path, extracting its package, and parsing the scene XML.
+// Imports an MVR file into the global application scene.
 bool MvrImporter::ImportFromFile(const std::string &filePath,
                                  bool promptConflicts,
                                  bool applyDictionary,
                                  ProgressCallback progressCallback) {
+  return ImportFromFileIntoScene(filePath, nullptr, promptConflicts,
+                                 applyDictionary, progressCallback);
+}
+
+// Imports an MVR file into the provided scene without resetting global configuration.
+bool MvrImporter::ImportSceneFromFile(const std::string &filePath,
+                                      MvrScene &targetScene,
+                                      bool promptConflicts,
+                                      bool applyDictionary,
+                                      ProgressCallback progressCallback) {
+  return ImportFromFileIntoScene(filePath, &targetScene, promptConflicts,
+                                 applyDictionary, progressCallback);
+}
+
+// Extracts an MVR package and parses its scene data into either the global or provided scene.
+bool MvrImporter::ImportFromFileIntoScene(const std::string &filePath,
+                                          MvrScene *targetScene,
+                                          bool promptConflicts,
+                                          bool applyDictionary,
+                                          ProgressCallback progressCallback) {
   auto reportProgress = [&](std::string stage, int completed = 0, int total = 0) {
     if (!progressCallback)
       return;
@@ -1176,7 +1196,8 @@ bool MvrImporter::ImportFromFile(const std::string &filePath,
 
   std::string scenePath = ToString(sceneFile.u8string());
   reportProgress("Parsing scene data...");
-  return ParseSceneXml(scenePath, promptConflicts, applyDictionary, progressCallback);
+  return ParseSceneXml(scenePath, targetScene, promptConflicts, applyDictionary,
+                       progressCallback);
 }
 
 std::string MvrImporter::NormalizeArchivePath(const std::string &archivePath) const {
@@ -1323,9 +1344,9 @@ bool MvrImporter::ExtractMvrZip(const std::string &mvrPath,
   return true;
 }
 
-// Parses GeneralSceneDescription.xml and populates fixtures and trusses into
-// the scene model
+// Parses GeneralSceneDescription.xml and populates the selected scene model.
 bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
+                                MvrScene *targetScene,
                                 bool promptConflicts,
                                 bool applyDictionary,
                                 ProgressCallback progressCallback) {
@@ -1348,8 +1369,11 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
     return false;
   }
 
-  ConfigManager::Get().Reset();
-  auto &scene = ConfigManager::Get().GetScene();
+  if (targetScene == nullptr)
+    ConfigManager::Get().Reset();
+  MvrScene &scene =
+      targetScene != nullptr ? *targetScene : ConfigManager::Get().GetScene();
+  scene.Clear();
   scene.basePath = ToString(fs::u8path(sceneXmlPath).parent_path().u8string());
 
   root->QueryIntAttribute("verMajor", &scene.versionMajor);

--- a/mvr/mvrimporter.h
+++ b/mvr/mvrimporter.h
@@ -21,6 +21,8 @@
 #include <unordered_map>
 #include <string>
 
+class MvrScene;
+
 // Responsible for importing .mvr files into the application's internal data model
 class MvrImporter
 {
@@ -43,6 +45,13 @@ public:
                         bool applyDictionary = true,
                         ProgressCallback progressCallback = {});
 
+    // Imports and parses a .mvr file into the provided scene without resetting ConfigManager.
+    bool ImportSceneFromFile(const std::string& filePath,
+                             MvrScene& targetScene,
+                             bool promptConflicts = true,
+                             bool applyDictionary = true,
+                             ProgressCallback progressCallback = {});
+
     // Static interface for use outside the import module (e.g. GUI)
     // Allows the caller to decide whether dictionary conflicts should prompt
     // or whether the dictionary should be applied at all
@@ -61,10 +70,17 @@ private:
     // Extracts the .mvr (ZIP) contents into the given destination directory
     bool ExtractMvrZip(const std::string& mvrPath, const std::string& destDir);
 
-    // Parses the GeneralSceneDescription.xml file and updates the scene model
-    // When promptConflicts is true, the user is asked to resolve GDTF conflicts
-    // If applyDictionary is false, existing GDTF assignments are kept intact
-    bool ParseSceneXml(const std::string& sceneXmlPath, bool promptConflicts,
+    // Extracts and parses a .mvr file into either the global scene or a provided target scene.
+    bool ImportFromFileIntoScene(const std::string& filePath,
+                                 MvrScene* targetScene,
+                                 bool promptConflicts,
+                                 bool applyDictionary,
+                                 ProgressCallback progressCallback);
+
+    // Parses the GeneralSceneDescription.xml file and updates the selected scene model.
+    bool ParseSceneXml(const std::string& sceneXmlPath,
+                       MvrScene* targetScene,
+                       bool promptConflicts,
                        bool applyDictionary,
                        ProgressCallback progressCallback);
 

--- a/mvr/mvrscenemerger.cpp
+++ b/mvr/mvrscenemerger.cpp
@@ -1,0 +1,208 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "mvrscenemerger.h"
+
+#include "uuidutils.h"
+
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+namespace mvr {
+namespace {
+
+// Returns every UUID already owned by the target scene across all object tables.
+std::unordered_set<std::string> CollectUsedUuids(const MvrScene &scene) {
+  std::unordered_set<std::string> used;
+  auto addKeys = [&used](const auto &objects) {
+    for (const auto &entry : objects)
+      used.insert(entry.first);
+  };
+  addKeys(scene.fixtures);
+  addKeys(scene.trusses);
+  addKeys(scene.supports);
+  addKeys(scene.sceneObjects);
+  addKeys(scene.groupObjects);
+  addKeys(scene.layers);
+  for (const auto &entry : scene.positions)
+    used.insert(entry.first);
+  for (const auto &entry : scene.symdefFiles)
+    used.insert(entry.first);
+  for (const auto &entry : scene.symdefTypes)
+    used.insert(entry.first);
+  for (const auto &entry : scene.symdefMatrices)
+    used.insert(entry.first);
+  for (const auto &entry : scene.symdefGeometries)
+    used.insert(entry.first);
+  return used;
+}
+
+// Returns a collision-free UUID for an imported item and records reference remaps.
+std::string ResolveImportedUuid(
+    const std::string &uuid, std::unordered_set<std::string> &usedUuids,
+    std::unordered_map<std::string, std::string> &uuidMap,
+    MvrSceneMergeResult &result) {
+  if (uuid.empty())
+    return uuid;
+
+  if (usedUuids.insert(uuid).second) {
+    uuidMap.emplace(uuid, uuid);
+    return uuid;
+  }
+
+  std::string replacement;
+  do {
+    replacement = GenerateUuid();
+  } while (!usedUuids.insert(replacement).second);
+
+  uuidMap[uuid] = replacement;
+  ++result.uuidCollisionsResolved;
+  return replacement;
+}
+
+// Returns the remapped UUID when an imported reference points at a remapped object.
+std::string RemapUuidReference(
+    const std::string &uuid,
+    const std::unordered_map<std::string, std::string> &uuidMap) {
+  const auto it = uuidMap.find(uuid);
+  if (it == uuidMap.end())
+    return uuid;
+  return it->second;
+}
+
+// Records UUID remaps for an imported object map without mutating scene content yet.
+template <typename T>
+void PrepareObjectTable(const std::unordered_map<std::string, T> &imported,
+                        std::unordered_set<std::string> &usedUuids,
+                        std::unordered_map<std::string, std::string> &uuidMap,
+                        MvrSceneMergeResult &result) {
+  for (const auto &entry : imported)
+    (void)ResolveImportedUuid(entry.first, usedUuids, uuidMap, result);
+}
+
+// Adds imported lookup-table entries to the target scene using the prepared UUID remap table.
+template <typename T>
+void MergeLookupTable(std::unordered_map<std::string, T> &target,
+                      const std::unordered_map<std::string, T> &imported,
+                      const std::unordered_map<std::string, std::string>
+                          &uuidMap) {
+  for (const auto &[uuid, value] : imported)
+    target[RemapUuidReference(uuid, uuidMap)] = value;
+}
+
+// Adds imported objects with a UUID field to the target object map after updating the object's UUID.
+template <typename T>
+std::size_t MergeObjectTable(std::unordered_map<std::string, T> &target,
+                             const std::unordered_map<std::string, T> &imported,
+                             const std::unordered_map<std::string, std::string>
+                                 &uuidMap) {
+  std::size_t added = 0;
+  for (const auto &[uuid, object] : imported) {
+    const std::string resolvedUuid = RemapUuidReference(uuid, uuidMap);
+    T merged = object;
+    merged.uuid = resolvedUuid;
+    target[resolvedUuid] = std::move(merged);
+    ++added;
+  }
+  return added;
+}
+
+// Updates references inside an imported scene copy after the full UUID remap table has been built.
+void RemapImportedReferences(
+    MvrScene &scene,
+    const std::unordered_map<std::string, std::string> &uuidMap) {
+  for (auto &[uuid, fixture] : scene.fixtures)
+    fixture.position = RemapUuidReference(fixture.position, uuidMap);
+
+  for (auto &[uuid, truss] : scene.trusses) {
+    truss.position = RemapUuidReference(truss.position, uuidMap);
+    truss.sourceSymdefUuid = RemapUuidReference(truss.sourceSymdefUuid, uuidMap);
+    truss.parentGroupUuid = RemapUuidReference(truss.parentGroupUuid, uuidMap);
+  }
+
+  for (auto &[uuid, support] : scene.supports) {
+    support.position = RemapUuidReference(support.position, uuidMap);
+    support.motorFixtureUuid = RemapUuidReference(support.motorFixtureUuid, uuidMap);
+  }
+
+  for (auto &[uuid, group] : scene.groupObjects) {
+    group.parentGroupUuid = RemapUuidReference(group.parentGroupUuid, uuidMap);
+    for (auto &child : group.children)
+      child.uuid = RemapUuidReference(child.uuid, uuidMap);
+  }
+
+  for (auto &[uuid, layer] : scene.layers) {
+    for (auto &childUuid : layer.childUUIDs)
+      childUuid = RemapUuidReference(childUuid, uuidMap);
+  }
+}
+
+} // namespace
+
+// Combines imported MVR scene content into the target while preserving existing objects.
+MvrSceneMergeResult MergeImportedSceneIntoCurrent(MvrScene &target,
+                                                  const MvrScene &imported) {
+  MvrSceneMergeResult result;
+  std::unordered_set<std::string> usedUuids = CollectUsedUuids(target);
+  std::unordered_map<std::string, std::string> uuidMap;
+
+  PrepareObjectTable(imported.positions, usedUuids, uuidMap, result);
+  PrepareObjectTable(imported.symdefFiles, usedUuids, uuidMap, result);
+  PrepareObjectTable(imported.symdefTypes, usedUuids, uuidMap, result);
+  PrepareObjectTable(imported.symdefMatrices, usedUuids, uuidMap, result);
+  PrepareObjectTable(imported.symdefGeometries, usedUuids, uuidMap, result);
+  PrepareObjectTable(imported.fixtures, usedUuids, uuidMap, result);
+  PrepareObjectTable(imported.trusses, usedUuids, uuidMap, result);
+  PrepareObjectTable(imported.supports, usedUuids, uuidMap, result);
+  PrepareObjectTable(imported.sceneObjects, usedUuids, uuidMap, result);
+  PrepareObjectTable(imported.groupObjects, usedUuids, uuidMap, result);
+  PrepareObjectTable(imported.layers, usedUuids, uuidMap, result);
+
+  MvrScene importedCopy = imported;
+  RemapImportedReferences(importedCopy, uuidMap);
+
+  MergeLookupTable(target.positions, importedCopy.positions, uuidMap);
+  MergeLookupTable(target.symdefFiles, importedCopy.symdefFiles, uuidMap);
+  MergeLookupTable(target.symdefTypes, importedCopy.symdefTypes, uuidMap);
+  MergeLookupTable(target.symdefMatrices, importedCopy.symdefMatrices, uuidMap);
+  MergeLookupTable(target.symdefGeometries, importedCopy.symdefGeometries, uuidMap);
+
+  result.fixturesAdded =
+      MergeObjectTable(target.fixtures, importedCopy.fixtures, uuidMap);
+  result.trussesAdded =
+      MergeObjectTable(target.trusses, importedCopy.trusses, uuidMap);
+  result.supportsAdded =
+      MergeObjectTable(target.supports, importedCopy.supports, uuidMap);
+  result.sceneObjectsAdded = MergeObjectTable(
+      target.sceneObjects, importedCopy.sceneObjects, uuidMap);
+  result.groupObjectsAdded = MergeObjectTable(
+      target.groupObjects, importedCopy.groupObjects, uuidMap);
+  result.layersAdded =
+      MergeObjectTable(target.layers, importedCopy.layers, uuidMap);
+
+  if (target.basePath.empty())
+    target.basePath = imported.basePath;
+  if (target.provider.empty())
+    target.provider = imported.provider;
+  if (target.providerVersion.empty())
+    target.providerVersion = imported.providerVersion;
+  return result;
+}
+
+} // namespace mvr

--- a/mvr/mvrscenemerger.h
+++ b/mvr/mvrscenemerger.h
@@ -1,0 +1,40 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <cstddef>
+
+#include "mvrscene.h"
+
+namespace mvr {
+
+struct MvrSceneMergeResult {
+  std::size_t fixturesAdded = 0;
+  std::size_t trussesAdded = 0;
+  std::size_t supportsAdded = 0;
+  std::size_t sceneObjectsAdded = 0;
+  std::size_t groupObjectsAdded = 0;
+  std::size_t layersAdded = 0;
+  std::size_t uuidCollisionsResolved = 0;
+};
+
+// Combines imported MVR scene content into the target while preserving existing objects.
+MvrSceneMergeResult MergeImportedSceneIntoCurrent(MvrScene &target,
+                                                  const MvrScene &imported);
+
+} // namespace mvr


### PR DESCRIPTION
### Motivation
- Let users choose how a selected `.mvr` file is handled after the file picker: open as a new project, merge into the current project, or cancel.
- Keep startup/command-line/OS-association MVR handling on the existing open-as-new-project path for deterministic startup behavior.
- Avoid adding large merge logic inside the GUI controller by delegating scene combination and UUID collision resolution to a new MVR/core helper.

### Description
- Added a post-file-picker choice dialog and routing in `MainWindowIoController::OnImportMVR()` with options `Open as new project`, `Merge into current project`, and `Cancel`, and wired `Open as new project` to `ImportMvrWithOfficialPolicy()`. (file: `gui/mainwindow/controllers/mainwindow_io_controller.cpp`)
- Implemented `MainWindowIoController::MergeMvrFromPath(const std::string &pathUtf8)` which imports the selected MVR into a temporary `MvrScene`, merges it into the live scene, preserves/ restores layout/viewer config keys, pushes an undo state, marks the project dirty, and refreshes panels via a new `RefreshPanelsAfterMvrSceneChange()` helper. (file: `gui/mainwindow/controllers/mainwindow_io_controller.cpp` and header)
- Added a new MVR core helper `mvr::MergeImportedSceneIntoCurrent(...)` that resolves imported UUID collisions, remaps references, and merges all scene tables (fixtures, trusses, supports, scene objects, groups, layers, lookup tables). This logic is implemented in `mvr/mvrscenemerger.h` / `mvr/mvrscenemerger.cpp` and keeps merge behavior out of GUI code.
- Extended the importer API so the importer can parse an `.mvr` into a provided `MvrScene` (non-destructive), by adding `ImportSceneFromFile` / `ImportFromFileIntoScene(...)` and adapting `ParseSceneXml(...)` to accept an optional target scene pointer; this allows merge flows to import into a temporary scene without resetting the global `ConfigManager` scene. (files: `mvr/mvrimporter.h`, `mvr/mvrimporter.cpp`)
- Registered the new merger source in the top-level build list (`CMakeLists.txt`) and updated user-facing documentation to describe the new import choice and merge behavior (`docs/opening-mvr-files.md`, `docs/features.md`, `docs/release-notes-draft.md`).

### Testing
- Compiled the new merger translation unit: `g++ -std=c++20 -Wall -Wextra -Imodels -Icore -Imvr -c mvr/mvrscenemerger.cpp -o /tmp/mvrscenemerger.o` (succeeded).
- Ran repository checks: `./tests/check_perastage_tree_modules.sh` and `./tests/check_no_configmanager_get_in_gui.sh` (both returned OK).
- Attempted full CMake configure `cmake -S . -B /tmp/perastage-build -DCMAKE_BUILD_TYPE=Debug` inside the container but configure failed due to missing wxWidgets development files in the environment (expected in this container; GUI build requires wxWidgets).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a213cc26d448324a73af5c3062202c1)