### PR TITLE
Refactor MVR importer to return parse-only results and extract merge analyzer/applier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,8 @@ add_executable(${PROJECT_NAME} main.cpp
     models/sceneobject.cpp
     models/truss.cpp
     mvr/mvrimporter.cpp
+    mvr/mvr_merge_analyzer.cpp
+    mvr/mvr_merge_applier.cpp
     mvr/mvrscenemerger.cpp
     mvr/mvrexporter.cpp
     mvr/primitive_model_resources.cpp

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -62,4 +62,5 @@ Changes since `v1.2.0`.
 - Refactored layout render invalidation, selected element z-order mapping, label builders, and status notification plumbing without changing the intended user workflow.
 - Added internal resource-reference synchronization and layout image resource registry support used by project save/export paths.
 - Added symbol cache manifest infrastructure and tests to improve project cache consistency.
+- Refined MVR import internals so merge workflows can parse scene payloads without resetting the active project first.
 - Added and adjusted CI/release workflow plumbing for installer artifact handling, Arch Linux package generation, curated release notes, and version-bump safety.

--- a/gui/mainwindow/controllers/mainwindow_io_controller.cpp
+++ b/gui/mainwindow/controllers/mainwindow_io_controller.cpp
@@ -319,11 +319,11 @@ bool MainWindowIoController::MergeMvrFromPath(const std::string &pathUtf8) {
   if (owner->GetStatusBar())
     owner->SetStatusText("MVR merge: importing selected file...", 0);
 
-  MvrScene importedScene;
+  MvrImportResult importResult;
   MvrImporter mergeImporter;
   owner->LockViewportInteraction();
-  const bool imported =
-      mergeImporter.ImportSceneFromFile(pathUtf8, importedScene, true, true);
+  const bool imported = mergeImporter.ImportFromFile(
+      pathUtf8, importResult, MvrImportMode::ParseOnly, true, true);
   owner->UnlockViewportInteraction();
 
   if (!imported) {
@@ -343,7 +343,7 @@ bool MainWindowIoController::MergeMvrFromPath(const std::string &pathUtf8) {
   cfg.GetScene() = currentScene;
   cfg.PushUndoState("merge MVR");
   const mvr::MvrSceneMergeResult mergeResult =
-      mvr::MergeImportedSceneIntoCurrent(cfg.GetScene(), importedScene);
+      mvr::MergeImportedSceneIntoCurrent(cfg.GetScene(), importResult.scene);
   cfg.MarkDirty();
   restorePreservedConfig();
   viewer2d::ReconcileFixtureLabelOverridesWithScene(cfg);

--- a/mvr/mvr_merge_analyzer.cpp
+++ b/mvr/mvr_merge_analyzer.cpp
@@ -1,0 +1,115 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "mvr_merge_analyzer.h"
+
+#include "uuidutils.h"
+
+#include <unordered_set>
+
+namespace mvr {
+namespace {
+
+// Collects every UUID already owned by a scene across object and lookup tables.
+std::unordered_set<std::string> CollectUsedUuids(const MvrScene &scene) {
+  std::unordered_set<std::string> used;
+  auto addKeys = [&used](const auto &objects) {
+    for (const auto &entry : objects)
+      used.insert(entry.first);
+  };
+  addKeys(scene.fixtures);
+  addKeys(scene.trusses);
+  addKeys(scene.supports);
+  addKeys(scene.sceneObjects);
+  addKeys(scene.groupObjects);
+  addKeys(scene.layers);
+  for (const auto &entry : scene.positions)
+    used.insert(entry.first);
+  for (const auto &entry : scene.symdefFiles)
+    used.insert(entry.first);
+  for (const auto &entry : scene.symdefTypes)
+    used.insert(entry.first);
+  for (const auto &entry : scene.symdefMatrices)
+    used.insert(entry.first);
+  for (const auto &entry : scene.symdefGeometries)
+    used.insert(entry.first);
+  return used;
+}
+
+// Resolves a collision-free UUID for an imported item and records reference remaps.
+std::string ResolveImportedUuid(const std::string &uuid,
+                                std::unordered_set<std::string> &usedUuids,
+                                MvrMergeAnalysis &analysis) {
+  if (uuid.empty())
+    return uuid;
+
+  if (usedUuids.insert(uuid).second) {
+    analysis.uuidMap.emplace(uuid, uuid);
+    return uuid;
+  }
+
+  std::string replacement;
+  do {
+    replacement = GenerateUuid();
+  } while (!usedUuids.insert(replacement).second);
+
+  analysis.uuidMap[uuid] = replacement;
+  ++analysis.uuidCollisionsResolved;
+  return replacement;
+}
+
+// Records UUID remaps for an imported object map without mutating scene content.
+template <typename T>
+void PrepareObjectTable(const std::unordered_map<std::string, T> &imported,
+                        std::unordered_set<std::string> &usedUuids,
+                        MvrMergeAnalysis &analysis) {
+  for (const auto &entry : imported)
+    (void)ResolveImportedUuid(entry.first, usedUuids, analysis);
+}
+
+} // namespace
+
+// Analyzes imported scene UUIDs and prepares collision-safe reference remaps.
+MvrMergeAnalysis AnalyzeImportedSceneMerge(const MvrScene &target,
+                                           const MvrScene &imported) {
+  MvrMergeAnalysis analysis;
+  std::unordered_set<std::string> usedUuids = CollectUsedUuids(target);
+
+  PrepareObjectTable(imported.positions, usedUuids, analysis);
+  PrepareObjectTable(imported.symdefFiles, usedUuids, analysis);
+  PrepareObjectTable(imported.symdefTypes, usedUuids, analysis);
+  PrepareObjectTable(imported.symdefMatrices, usedUuids, analysis);
+  PrepareObjectTable(imported.symdefGeometries, usedUuids, analysis);
+  PrepareObjectTable(imported.fixtures, usedUuids, analysis);
+  PrepareObjectTable(imported.trusses, usedUuids, analysis);
+  PrepareObjectTable(imported.supports, usedUuids, analysis);
+  PrepareObjectTable(imported.sceneObjects, usedUuids, analysis);
+  PrepareObjectTable(imported.groupObjects, usedUuids, analysis);
+  PrepareObjectTable(imported.layers, usedUuids, analysis);
+  return analysis;
+}
+
+// Resolves an imported UUID reference using the prepared merge analysis.
+std::string RemapImportedUuidReference(const std::string &uuid,
+                                       const MvrMergeAnalysis &analysis) {
+  const auto it = analysis.uuidMap.find(uuid);
+  if (it == analysis.uuidMap.end())
+    return uuid;
+  return it->second;
+}
+
+} // namespace mvr

--- a/mvr/mvr_merge_analyzer.h
+++ b/mvr/mvr_merge_analyzer.h
@@ -1,0 +1,51 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <unordered_map>
+
+#include "mvrscene.h"
+
+namespace mvr {
+
+struct MvrSceneMergeResult {
+  std::size_t fixturesAdded = 0;
+  std::size_t trussesAdded = 0;
+  std::size_t supportsAdded = 0;
+  std::size_t sceneObjectsAdded = 0;
+  std::size_t groupObjectsAdded = 0;
+  std::size_t layersAdded = 0;
+  std::size_t uuidCollisionsResolved = 0;
+};
+
+struct MvrMergeAnalysis {
+  std::unordered_map<std::string, std::string> uuidMap;
+  std::size_t uuidCollisionsResolved = 0;
+};
+
+// Analyzes imported scene UUIDs and prepares collision-safe reference remaps.
+MvrMergeAnalysis AnalyzeImportedSceneMerge(const MvrScene &target,
+                                           const MvrScene &imported);
+
+// Resolves an imported UUID reference using the prepared merge analysis.
+std::string RemapImportedUuidReference(const std::string &uuid,
+                                       const MvrMergeAnalysis &analysis);
+
+} // namespace mvr

--- a/mvr/mvr_merge_applier.cpp
+++ b/mvr/mvr_merge_applier.cpp
@@ -1,0 +1,123 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "mvr_merge_applier.h"
+
+#include <utility>
+
+namespace mvr {
+namespace {
+
+// Adds imported lookup-table entries to the target scene using prepared UUID remaps.
+template <typename T>
+void MergeLookupTable(std::unordered_map<std::string, T> &target,
+                      const std::unordered_map<std::string, T> &imported,
+                      const MvrMergeAnalysis &analysis) {
+  for (const auto &[uuid, value] : imported)
+    target[RemapImportedUuidReference(uuid, analysis)] = value;
+}
+
+// Adds imported objects with UUID fields to the target after updating each object's UUID.
+template <typename T>
+std::size_t MergeObjectTable(std::unordered_map<std::string, T> &target,
+                             const std::unordered_map<std::string, T> &imported,
+                             const MvrMergeAnalysis &analysis) {
+  std::size_t added = 0;
+  for (const auto &[uuid, object] : imported) {
+    const std::string resolvedUuid = RemapImportedUuidReference(uuid, analysis);
+    T merged = object;
+    merged.uuid = resolvedUuid;
+    target[resolvedUuid] = std::move(merged);
+    ++added;
+  }
+  return added;
+}
+
+// Updates references inside an imported scene copy after the full UUID remap table has been built.
+void RemapImportedReferences(MvrScene &scene, const MvrMergeAnalysis &analysis) {
+  for (auto &[uuid, fixture] : scene.fixtures)
+    fixture.position = RemapImportedUuidReference(fixture.position, analysis);
+
+  for (auto &[uuid, truss] : scene.trusses) {
+    truss.position = RemapImportedUuidReference(truss.position, analysis);
+    truss.sourceSymdefUuid =
+        RemapImportedUuidReference(truss.sourceSymdefUuid, analysis);
+    truss.parentGroupUuid =
+        RemapImportedUuidReference(truss.parentGroupUuid, analysis);
+  }
+
+  for (auto &[uuid, support] : scene.supports) {
+    support.position = RemapImportedUuidReference(support.position, analysis);
+    support.motorFixtureUuid =
+        RemapImportedUuidReference(support.motorFixtureUuid, analysis);
+  }
+
+  for (auto &[uuid, group] : scene.groupObjects) {
+    group.parentGroupUuid =
+        RemapImportedUuidReference(group.parentGroupUuid, analysis);
+    for (auto &child : group.children)
+      child.uuid = RemapImportedUuidReference(child.uuid, analysis);
+  }
+
+  for (auto &[uuid, layer] : scene.layers) {
+    for (auto &childUuid : layer.childUUIDs)
+      childUuid = RemapImportedUuidReference(childUuid, analysis);
+  }
+}
+
+} // namespace
+
+// Applies an analyzed imported scene merge into the target scene.
+MvrSceneMergeResult ApplyImportedSceneMerge(MvrScene &target,
+                                            const MvrScene &imported,
+                                            const MvrMergeAnalysis &analysis) {
+  MvrSceneMergeResult result;
+  result.uuidCollisionsResolved = analysis.uuidCollisionsResolved;
+
+  MvrScene importedCopy = imported;
+  RemapImportedReferences(importedCopy, analysis);
+
+  MergeLookupTable(target.positions, importedCopy.positions, analysis);
+  MergeLookupTable(target.symdefFiles, importedCopy.symdefFiles, analysis);
+  MergeLookupTable(target.symdefTypes, importedCopy.symdefTypes, analysis);
+  MergeLookupTable(target.symdefMatrices, importedCopy.symdefMatrices, analysis);
+  MergeLookupTable(target.symdefGeometries, importedCopy.symdefGeometries,
+                   analysis);
+
+  result.fixturesAdded =
+      MergeObjectTable(target.fixtures, importedCopy.fixtures, analysis);
+  result.trussesAdded =
+      MergeObjectTable(target.trusses, importedCopy.trusses, analysis);
+  result.supportsAdded =
+      MergeObjectTable(target.supports, importedCopy.supports, analysis);
+  result.sceneObjectsAdded =
+      MergeObjectTable(target.sceneObjects, importedCopy.sceneObjects, analysis);
+  result.groupObjectsAdded =
+      MergeObjectTable(target.groupObjects, importedCopy.groupObjects, analysis);
+  result.layersAdded =
+      MergeObjectTable(target.layers, importedCopy.layers, analysis);
+
+  if (target.basePath.empty())
+    target.basePath = imported.basePath;
+  if (target.provider.empty())
+    target.provider = imported.provider;
+  if (target.providerVersion.empty())
+    target.providerVersion = imported.providerVersion;
+  return result;
+}
+
+} // namespace mvr

--- a/mvr/mvr_merge_applier.h
+++ b/mvr/mvr_merge_applier.h
@@ -15,17 +15,15 @@
  * You should have received a copy of the GNU General Public License
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
-#include "mvrscenemerger.h"
+#pragma once
 
-#include "mvr_merge_applier.h"
+#include "mvr_merge_analyzer.h"
 
 namespace mvr {
 
-// Combines imported MVR scene content into the target while preserving existing objects.
-MvrSceneMergeResult MergeImportedSceneIntoCurrent(MvrScene &target,
-                                                  const MvrScene &imported) {
-  const MvrMergeAnalysis analysis = AnalyzeImportedSceneMerge(target, imported);
-  return ApplyImportedSceneMerge(target, imported, analysis);
-}
+// Applies an analyzed imported scene merge into the target scene.
+MvrSceneMergeResult ApplyImportedSceneMerge(MvrScene &target,
+                                            const MvrScene &imported,
+                                            const MvrMergeAnalysis &analysis);
 
 } // namespace mvr

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -1096,8 +1096,20 @@ bool MvrImporter::ImportFromFile(const std::string &filePath,
                                  bool promptConflicts,
                                  bool applyDictionary,
                                  ProgressCallback progressCallback) {
-  return ImportFromFileIntoScene(filePath, nullptr, promptConflicts,
-                                 applyDictionary, progressCallback);
+  MvrImportResult importResult;
+  return ImportFromFile(filePath, importResult, MvrImportMode::ReplaceProject,
+                        promptConflicts, applyDictionary, progressCallback);
+}
+
+// Imports an MVR file into an import result and optionally replaces the global project.
+bool MvrImporter::ImportFromFile(const std::string &filePath,
+                                 MvrImportResult &importResult,
+                                 MvrImportMode mode,
+                                 bool promptConflicts,
+                                 bool applyDictionary,
+                                 ProgressCallback progressCallback) {
+  return ImportFromFileIntoResult(filePath, importResult, mode, promptConflicts,
+                                  applyDictionary, progressCallback);
 }
 
 // Imports an MVR file into the provided scene without resetting global configuration.
@@ -1106,16 +1118,25 @@ bool MvrImporter::ImportSceneFromFile(const std::string &filePath,
                                       bool promptConflicts,
                                       bool applyDictionary,
                                       ProgressCallback progressCallback) {
-  return ImportFromFileIntoScene(filePath, &targetScene, promptConflicts,
-                                 applyDictionary, progressCallback);
+  MvrImportResult importResult;
+  const bool imported = ImportFromFile(
+      filePath, importResult, MvrImportMode::ParseOnly, promptConflicts,
+      applyDictionary, progressCallback);
+  if (!imported)
+    return false;
+
+  targetScene = std::move(importResult.scene);
+  fixtureUuidRemap = std::move(importResult.fixtureUuidRemap);
+  return true;
 }
 
-// Extracts an MVR package and parses its scene data into either the global or provided scene.
-bool MvrImporter::ImportFromFileIntoScene(const std::string &filePath,
-                                          MvrScene *targetScene,
-                                          bool promptConflicts,
-                                          bool applyDictionary,
-                                          ProgressCallback progressCallback) {
+// Extracts an MVR package and parses its scene data into an import result payload.
+bool MvrImporter::ImportFromFileIntoResult(const std::string &filePath,
+                                           MvrImportResult &importResult,
+                                           MvrImportMode mode,
+                                           bool promptConflicts,
+                                           bool applyDictionary,
+                                           ProgressCallback progressCallback) {
   auto reportProgress = [&](std::string stage, int completed = 0, int total = 0) {
     if (!progressCallback)
       return;
@@ -1124,6 +1145,7 @@ bool MvrImporter::ImportFromFileIntoScene(const std::string &filePath,
 
   pathRemap.clear();
   fixtureUuidRemap.clear();
+  importResult = MvrImportResult{};
   // Treat the incoming path as UTF-8 to preserve any non-ASCII characters
   fs::path path = fs::u8path(filePath);
 
@@ -1196,14 +1218,26 @@ bool MvrImporter::ImportFromFileIntoScene(const std::string &filePath,
 
   std::string scenePath = ToString(sceneFile.u8string());
   reportProgress("Parsing scene data...");
-  return ParseSceneXml(scenePath, targetScene, promptConflicts, applyDictionary,
-                       progressCallback);
+  const bool parsed = ParseSceneXml(scenePath, importResult, promptConflicts,
+                                    applyDictionary, progressCallback);
+  if (!parsed)
+    return false;
+
+  if (mode == MvrImportMode::ReplaceProject) {
+    ConfigManager::Get().Reset();
+    ConfigManager::Get().GetScene() = importResult.scene;
+  }
+
+  fixtureUuidRemap = importResult.fixtureUuidRemap;
+  return true;
 }
 
+// Normalizes an MVR archive path so extracted resources can be found reliably.
 std::string MvrImporter::NormalizeArchivePath(const std::string &archivePath) const {
   return NormalizeArchivePathValue(archivePath);
 }
 
+// Returns a remapped extraction path for long archive entries when one exists.
 std::string MvrImporter::RemapArchivePathIfNeeded(const std::string &archivePath) const {
   const std::string normalized = NormalizeArchivePath(archivePath);
   auto it = pathRemap.find(normalized);
@@ -1212,6 +1246,7 @@ std::string MvrImporter::RemapArchivePathIfNeeded(const std::string &archivePath
   return archivePath;
 }
 
+// Creates a temporary extraction directory for the current MVR import.
 std::string MvrImporter::CreateTemporaryDirectory() {
   fs::path tempBase = fs::temp_directory_path();
   for (int attempt = 0; attempt < 32; ++attempt) {
@@ -1230,6 +1265,7 @@ std::string MvrImporter::CreateTemporaryDirectory() {
   return ToString(fallback.u8string());
 }
 
+// Extracts an MVR zip archive into the destination directory.
 bool MvrImporter::ExtractMvrZip(const std::string &mvrPath,
                                 const std::string &destDir) {
   wxFileInputStream input(wxString::FromUTF8(mvrPath.c_str()));
@@ -1344,9 +1380,9 @@ bool MvrImporter::ExtractMvrZip(const std::string &mvrPath,
   return true;
 }
 
-// Parses GeneralSceneDescription.xml and populates the selected scene model.
+// Parses GeneralSceneDescription.xml and populates the import result scene payload.
 bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
-                                MvrScene *targetScene,
+                                MvrImportResult &importResult,
                                 bool promptConflicts,
                                 bool applyDictionary,
                                 ProgressCallback progressCallback) {
@@ -1369,10 +1405,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
     return false;
   }
 
-  if (targetScene == nullptr)
-    ConfigManager::Get().Reset();
-  MvrScene &scene =
-      targetScene != nullptr ? *targetScene : ConfigManager::Get().GetScene();
+  MvrScene &scene = importResult.scene;
   scene.Clear();
   scene.basePath = ToString(fs::u8path(sceneXmlPath).parent_path().u8string());
 
@@ -3826,9 +3859,11 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
       std::to_string(scene.supports.size()) + " supports, " +
       std::to_string(scene.sceneObjects.size()) + " objects";
   LogMessage(summary);
+  importResult.fixtureUuidRemap = fixtureUuidRemap;
   return true;
 }
 
+// Imports an MVR file and migrates labels after replacing the active project scene.
 bool MvrImporter::ImportAndRegister(const std::string &filePath,
                                     bool promptConflicts,
                                     bool applyDictionary,

--- a/mvr/mvrimporter.h
+++ b/mvr/mvrimporter.h
@@ -18,10 +18,20 @@
 #pragma once
 
 #include <functional>
-#include <unordered_map>
 #include <string>
+#include <unordered_map>
 
-class MvrScene;
+#include "mvrscene.h"
+
+enum class MvrImportMode {
+    ReplaceProject,
+    ParseOnly,
+};
+
+struct MvrImportResult {
+    MvrScene scene;
+    std::unordered_map<std::string, std::string> fixtureUuidRemap;
+};
 
 // Responsible for importing .mvr files into the application's internal data model
 class MvrImporter
@@ -41,6 +51,14 @@ public:
     using ProgressCallback = std::function<void(const ProgressState& state)>;
 
     bool ImportFromFile(const std::string& filePath,
+                        bool promptConflicts = true,
+                        bool applyDictionary = true,
+                        ProgressCallback progressCallback = {});
+
+    // Imports and parses a .mvr file into an import result using the requested import mode.
+    bool ImportFromFile(const std::string& filePath,
+                        MvrImportResult& importResult,
+                        MvrImportMode mode = MvrImportMode::ReplaceProject,
                         bool promptConflicts = true,
                         bool applyDictionary = true,
                         ProgressCallback progressCallback = {});
@@ -70,16 +88,17 @@ private:
     // Extracts the .mvr (ZIP) contents into the given destination directory
     bool ExtractMvrZip(const std::string& mvrPath, const std::string& destDir);
 
-    // Extracts and parses a .mvr file into either the global scene or a provided target scene.
-    bool ImportFromFileIntoScene(const std::string& filePath,
-                                 MvrScene* targetScene,
-                                 bool promptConflicts,
-                                 bool applyDictionary,
-                                 ProgressCallback progressCallback);
+    // Extracts and parses a .mvr file into an import result payload.
+    bool ImportFromFileIntoResult(const std::string& filePath,
+                                  MvrImportResult& importResult,
+                                  MvrImportMode mode,
+                                  bool promptConflicts,
+                                  bool applyDictionary,
+                                  ProgressCallback progressCallback);
 
-    // Parses the GeneralSceneDescription.xml file and updates the selected scene model.
+    // Parses the GeneralSceneDescription.xml file and updates the import result payload.
     bool ParseSceneXml(const std::string& sceneXmlPath,
-                       MvrScene* targetScene,
+                       MvrImportResult& importResult,
                        bool promptConflicts,
                        bool applyDictionary,
                        ProgressCallback progressCallback);

--- a/mvr/mvrscenemerger.h
+++ b/mvr/mvrscenemerger.h
@@ -17,21 +17,9 @@
  */
 #pragma once
 
-#include <cstddef>
-
-#include "mvrscene.h"
+#include "mvr_merge_analyzer.h"
 
 namespace mvr {
-
-struct MvrSceneMergeResult {
-  std::size_t fixturesAdded = 0;
-  std::size_t trussesAdded = 0;
-  std::size_t supportsAdded = 0;
-  std::size_t sceneObjectsAdded = 0;
-  std::size_t groupObjectsAdded = 0;
-  std::size_t layersAdded = 0;
-  std::size_t uuidCollisionsResolved = 0;
-};
 
 // Combines imported MVR scene content into the target while preserving existing objects.
 MvrSceneMergeResult MergeImportedSceneIntoCurrent(MvrScene &target,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,6 +42,15 @@ include_directories(
     ../viewer3d/render
 )
 
+
+add_executable(mvr_merge_analyzer_applier_test
+               mvr_merge_analyzer_applier_test.cpp
+               ../mvr/mvr_merge_analyzer.cpp
+               ../mvr/mvr_merge_applier.cpp
+               ../core/uuidutils.cpp
+               ../models/mvrscene.cpp)
+add_test(NAME MvrMergeAnalyzerApplier COMMAND mvr_merge_analyzer_applier_test)
+
 add_executable(matrixutils_test matrixutils_test.cpp)
 target_include_directories(matrixutils_test PRIVATE ../models)
 add_test(NAME MatrixUtilsParsingAndComposition COMMAND matrixutils_test)

--- a/tests/mvr_merge_analyzer_applier_test.cpp
+++ b/tests/mvr_merge_analyzer_applier_test.cpp
@@ -1,0 +1,40 @@
+#include "mvr_merge_analyzer.h"
+#include "mvr_merge_applier.h"
+
+#include <cassert>
+#include <string>
+
+// Builds a fixture with the requested UUID and position reference.
+static Fixture MakeFixture(const std::string &uuid, const std::string &position) {
+  Fixture fixture;
+  fixture.uuid = uuid;
+  fixture.position = position;
+  return fixture;
+}
+
+// Verifies merge analysis resolves collisions before applying imported scene data.
+int main() {
+  MvrScene target;
+  target.positions["position-a"] = "Existing position";
+  target.fixtures["fixture-a"] = MakeFixture("fixture-a", "position-a");
+
+  MvrScene imported;
+  imported.positions["position-a"] = "Imported position";
+  imported.fixtures["fixture-b"] = MakeFixture("fixture-b", "position-a");
+
+  const mvr::MvrMergeAnalysis analysis =
+      mvr::AnalyzeImportedSceneMerge(target, imported);
+  assert(analysis.uuidCollisionsResolved == 1);
+  assert(analysis.uuidMap.at("position-a") != "position-a");
+
+  const mvr::MvrSceneMergeResult result =
+      mvr::ApplyImportedSceneMerge(target, imported, analysis);
+  assert(result.uuidCollisionsResolved == 1);
+  assert(result.fixturesAdded == 1);
+  assert(target.fixtures.count("fixture-a") == 1);
+  assert(target.fixtures.count("fixture-b") == 1);
+  assert(target.fixtures.at("fixture-b").position ==
+         analysis.uuidMap.at("position-a"));
+  assert(target.positions.count(analysis.uuidMap.at("position-a")) == 1);
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- Allow callers to parse an MVR file into an in-memory scene payload without performing the destructive `ConfigManager::Get().Reset()` or assigning the live project scene. 
- Make the MVR merge workflow non-destructive and testable by returning both a parsed `MvrScene` and fixture-UUID remap information. 
- Reduce complexity and file size in the large `mvrimporter.cpp` by extracting merge-specific analysis and apply logic into focused modules. 

### Description
- Added `MvrImportMode` and `MvrImportResult` and an overload `ImportFromFile(..., MvrImportResult&, MvrImportMode, ...)` so imports can be parsed-only or replace-the-project. 
- Reworked import internals so `ParseSceneXml` populates an `MvrImportResult` and `ConfigManager::Get().Reset()` plus live-scene assignment are executed only when `MvrImportMode::ReplaceProject` is requested. 
- Extracted merge responsibilities into `mvr/mvr_merge_analyzer.{h,cpp}` and `mvr/mvr_merge_applier.{h,cpp}` and kept `mvr/mvrscenemerger.cpp` as a small facade that composes analyzer + applier. 
- Updated GUI merge flow to use the parse-only import result (`MvrImportResult`) and adapted `CMakeLists.txt` and `tests/CMakeLists.txt` to register the new sources and a focused analyzer/applier unit test; updated `docs/release-notes-draft.md` under Internal changes. 

### Testing
- Built and executed the new focused unit test with `g++ -std=c++20` for the analyzer+applier files and the test driver, and the test ran successfully. 
- Ran repository checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh` and both returned OK. 
- Ran `git diff --check` and no whitespace or diff-check errors were reported. 
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug` could not finish in this environment because the container lacked the wxWidgets development libraries, which prevented a full project configure step (this is an environment limitation, not a code failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21429eede08324bcb7f5e59842e553)