### PR TITLE
Add MVR merge UUID preflight and collision policy

### DIFF
--- a/docs/opening-mvr-files.md
+++ b/docs/opening-mvr-files.md
@@ -9,6 +9,8 @@ Use one of these methods:
 - Open an existing `.mvr` file directly.
 - Use **File → Import MVR...**. After choosing a file, select **Open as new project** to replace the current scene or **Merge into current project** to add the selected MVR content to the current scene.
 
+When merging, Perastage checks imported object UUIDs against the current project and gives colliding imported objects stable replacement UUIDs by default. If collisions are found, you can instead choose to replace existing project objects or skip incoming colliding objects. References inside the imported content, such as positions, group children, layers, and hoist motor links, are updated so the merged scene remains connected while existing project objects are preserved.
+
 Opening an `.mvr` file directly from the command line, operating system file association, or startup path uses the clean **Open as new project** behavior.
 
 After import, review fixtures, trusses, hoists, objects, and layout information in the available views and tables.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -18,6 +18,7 @@ Changes since `v1.2.0`.
 - Added fixture replacement from the Edit menu, including improved source labeling, transform preservation, selection stability, UUID handling, and color reuse/autocolor behavior.
 - Added support for packaging referenced layout images into project archives, making `.pstg` project files more portable when shared or reopened elsewhere.
 - Added an MVR import choice so users can open a selected MVR as a new project or merge it into the current project.
+- Improved MVR merge safety so imported objects with UUIDs that already exist in the current project receive stable replacement UUIDs while their internal references stay connected.
 
 ## Improvements
 

--- a/gui/mainwindow/controllers/mainwindow_io_controller.cpp
+++ b/gui/mainwindow/controllers/mainwindow_io_controller.cpp
@@ -17,14 +17,14 @@
 #include <sstream>
 #include <string>
 
-#include "consolepanel.h"
+#include "LayoutManager.h"
 #include "configmanager.h"
-#include "fixturetablepanel.h"
+#include "consolepanel.h"
 #include "fixture_label_overrides.h"
+#include "fixturetablepanel.h"
 #include "guiconfigservices.h"
 #include "hoisttablepanel.h"
 #include "layerpanel.h"
-#include "LayoutManager.h"
 #include "layoutpanel.h"
 #include "layoutviewerpanel.h"
 #include "logger.h"
@@ -46,14 +46,38 @@ enum class MvrImportChoice {
   Cancel,
 };
 
-// Shows the user-facing MVR import mode selection dialog after a file has been chosen.
+// Shows merge UUID collision policy choices.
+std::optional<mvr::MvrMergeUuidCollisionBehavior>
+ShowMvrMergeUuidCollisionDialog(wxWindow *parent, std::size_t collisionCount) {
+  wxArrayString choices;
+  choices.Add("Create new UUIDs for imported objects");
+  choices.Add("Replace existing project objects");
+  choices.Add("Skip incoming colliding objects");
+  wxSingleChoiceDialog dialog(
+      parent,
+      wxString::Format("The selected MVR contains %zu UUIDs that already exist "
+                       "in the current project. Choose how Perastage should "
+                       "handle those incoming objects.",
+                       collisionCount),
+      "MVR Merge UUID Collisions", choices);
+  dialog.SetSelection(0);
+
+  if (dialog.ShowModal() != wxID_OK)
+    return std::nullopt;
+  if (dialog.GetSelection() == 1)
+    return mvr::MvrMergeUuidCollisionBehavior::ReplaceExisting;
+  if (dialog.GetSelection() == 2)
+    return mvr::MvrMergeUuidCollisionBehavior::SkipIncoming;
+  return mvr::MvrMergeUuidCollisionBehavior::GenerateStableUuid;
+}
+
+// Shows the user-facing MVR import mode selection dialog.
 MvrImportChoice ShowMvrImportChoiceDialog(wxWindow *parent) {
   wxArrayString choices;
   choices.Add("Open as new project");
   choices.Add("Merge into current project");
   wxSingleChoiceDialog dialog(
-      parent,
-      "Choose how Perastage should import the selected MVR file.",
+      parent, "Choose how Perastage should import the selected MVR file.",
       "Import MVR", choices);
   dialog.SetSelection(0);
 
@@ -66,18 +90,21 @@ MvrImportChoice ShowMvrImportChoiceDialog(wxWindow *parent) {
 
 } // namespace
 
-// Stores the owning MainWindow pointer for IO operations during the controller lifetime.
+// Stores the owning MainWindow pointer for IO operations during the controller
+// lifetime.
 MainWindowIoController::MainWindowIoController(MainWindow &owner)
     : ownerRef_(&owner) {}
 
-// Imports an MVR file while keeping import progress and UI panel refreshes synchronized on the main thread.
+// Imports an MVR file while keeping import progress and UI panel refreshes
+// synchronized on the main thread.
 bool MainWindowIoController::ImportMvrFromPath(const std::string &pathUtf8) {
   constexpr const char *kLayoutsConfigKey = "layouts_collection";
   constexpr const char *kViewer3DRenderStyleConfigKey = "viewer3d_render_style";
   MainWindow *owner = ownerRef_;
   if (owner == nullptr || owner->guiConfigServices == nullptr)
     return false;
-  // Marks the full MVR import pipeline as active to defer layout rendering until data is stable.
+  // Marks the full MVR import pipeline as active to defer layout rendering
+  // until data is stable.
   owner->mvrImportPipelineActive = true;
   const wxString filePath = wxString::FromUTF8(pathUtf8);
   ConfigManager &cfg = owner->guiConfigServices->LegacyConfigManager();
@@ -110,7 +137,8 @@ bool MainWindowIoController::ImportMvrFromPath(const std::string &pathUtf8) {
   owner->LockViewportInteraction();
   const bool imported = MvrImporter::ImportAndRegister(
       pathUtf8, true, true, [&](const MvrImporter::ProgressState &progress) {
-        // Ignores worker-thread progress callbacks to keep UI mutation strictly main-thread only.
+        // Ignores worker-thread progress callbacks to keep UI mutation strictly
+        // main-thread only.
         if (!wxThread::IsMain())
           return;
         if (owner == nullptr)
@@ -138,7 +166,8 @@ bool MainWindowIoController::ImportMvrFromPath(const std::string &pathUtf8) {
           const wxString title = "MVR import progress";
           const wxString stageText = wxString::FromUTF8(stage);
           const int safeTotal = std::max(progress.total, 1);
-          const int clampedCompleted = std::clamp(progress.completed, 0, safeTotal);
+          const int clampedCompleted =
+              std::clamp(progress.completed, 0, safeTotal);
 
           if (shouldShowBlockingImportUi && shouldUseProgressDialog &&
               !importProgress) {
@@ -212,7 +241,8 @@ bool MainWindowIoController::ImportMvrFromPath(const std::string &pathUtf8) {
     const wxString fileName = wxFileName(filePath).GetFullName();
     owner->SetStatusText("MVR imported: " + fileName, 0);
   }
-  // Re-enables layout rendering only after all import-driven panel updates finish.
+  // Re-enables layout rendering only after all import-driven panel updates
+  // finish.
   owner->mvrImportPipelineActive = false;
   return true;
 }
@@ -258,7 +288,8 @@ void MainWindowIoController::RefreshPanelsAfterMvrSceneChange() {
     owner->layoutViewerPanel->RefreshAfterSceneContentUpdate();
 }
 
-// Opens a file picker and imports the selected MVR file using the selected import mode.
+// Opens a file picker and imports the selected MVR file using the selected
+// import mode.
 void MainWindowIoController::OnImportMVR(wxCommandEvent &) {
   wxString miscDir =
       wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("misc"));
@@ -286,7 +317,7 @@ void MainWindowIoController::OnImportMVR(wxCommandEvent &) {
   }
 }
 
-// Merges an MVR file into the current scene while keeping existing project content.
+// Merges an MVR file into the current scene.
 bool MainWindowIoController::MergeMvrFromPath(const std::string &pathUtf8) {
   constexpr const char *kLayoutsConfigKey = "layouts_collection";
   constexpr const char *kViewer3DRenderStyleConfigKey = "viewer3d_render_style";
@@ -308,7 +339,8 @@ bool MainWindowIoController::MergeMvrFromPath(const std::string &pathUtf8) {
     else
       cfg.RemoveKey(kLayoutsConfigKey);
     if (preservedViewer3DRenderStyle.has_value())
-      cfg.SetValue(kViewer3DRenderStyleConfigKey, *preservedViewer3DRenderStyle);
+      cfg.SetValue(kViewer3DRenderStyleConfigKey,
+                   *preservedViewer3DRenderStyle);
     else
       cfg.RemoveKey(kViewer3DRenderStyleConfigKey);
     layouts::LayoutManager::Get().LoadFromConfig(cfg);
@@ -336,14 +368,30 @@ bool MainWindowIoController::MergeMvrFromPath(const std::string &pathUtf8) {
                  wxOK | wxICON_ERROR, owner);
     if (owner->consolePanel)
       owner->consolePanel->AppendMessage("Failed to merge " +
-                                           wxString::FromUTF8(pathUtf8));
+                                         wxString::FromUTF8(pathUtf8));
     return false;
   }
 
   cfg.GetScene() = currentScene;
+  mvr::MvrMergeOptions mergeOptions;
+  const mvr::MvrMergeAnalysis preflightAnalysis =
+      mvr::AnalyzeImportedSceneMerge(currentScene, importResult.scene);
+  if (preflightAnalysis.uuidCollisionsDetected > 0) {
+    const auto collisionBehavior = ShowMvrMergeUuidCollisionDialog(
+        owner, preflightAnalysis.uuidCollisionsDetected);
+    if (!collisionBehavior.has_value()) {
+      restorePreservedConfig();
+      owner->mvrImportPipelineActive = false;
+      if (owner->GetStatusBar())
+        owner->SetStatusText("MVR merge cancelled.", 0);
+      return false;
+    }
+    mergeOptions.uuidCollisionBehavior = *collisionBehavior;
+  }
   cfg.PushUndoState("merge MVR");
   const mvr::MvrSceneMergeResult mergeResult =
-      mvr::MergeImportedSceneIntoCurrent(cfg.GetScene(), importResult.scene);
+      mvr::MergeImportedSceneIntoCurrent(cfg.GetScene(), importResult.scene,
+                                         mergeOptions);
   cfg.MarkDirty();
   restorePreservedConfig();
   viewer2d::ReconcileFixtureLabelOverridesWithScene(cfg);
@@ -365,7 +413,7 @@ bool MainWindowIoController::MergeMvrFromPath(const std::string &pathUtf8) {
   return true;
 }
 
-// Applies the official MVR-open policy by confirming unsaved changes before importing the file.
+// Applies the official MVR-open policy after dirty checks.
 bool MainWindowIoController::ImportMvrWithOfficialPolicy(
     const std::string &pathUtf8) {
   if (!ownerRef_)
@@ -394,13 +442,13 @@ bool MainWindowIoController::OpenPathFromCommandLine(
   MainWindow *owner = ownerRef_;
   if (owner == nullptr)
     return false;
-  std::string extension = wxFileName(wxString::FromUTF8(pathUtf8)).GetExt()
-                              .Lower()
-                              .ToStdString();
-  std::string projectExtension = wxString::FromUTF8(ProjectUtils::PROJECT_EXTENSION)
-                                     .AfterFirst('.')
-                                     .Lower()
-                                     .ToStdString();
+  std::string extension =
+      wxFileName(wxString::FromUTF8(pathUtf8)).GetExt().Lower().ToStdString();
+  std::string projectExtension =
+      wxString::FromUTF8(ProjectUtils::PROJECT_EXTENSION)
+          .AfterFirst('.')
+          .Lower()
+          .ToStdString();
 
   if (extension == projectExtension) {
     const bool shouldSkipDirtyConfirmation =

--- a/mvr/mvr_merge_analyzer.cpp
+++ b/mvr/mvr_merge_analyzer.cpp
@@ -19,7 +19,9 @@
 
 #include "uuidutils.h"
 
-#include <unordered_set>
+#include <algorithm>
+#include <string_view>
+#include <vector>
 
 namespace mvr {
 namespace {
@@ -37,23 +39,45 @@ std::unordered_set<std::string> CollectUsedUuids(const MvrScene &scene) {
   addKeys(scene.sceneObjects);
   addKeys(scene.groupObjects);
   addKeys(scene.layers);
-  for (const auto &entry : scene.positions)
-    used.insert(entry.first);
-  for (const auto &entry : scene.symdefFiles)
-    used.insert(entry.first);
-  for (const auto &entry : scene.symdefTypes)
-    used.insert(entry.first);
-  for (const auto &entry : scene.symdefMatrices)
-    used.insert(entry.first);
-  for (const auto &entry : scene.symdefGeometries)
-    used.insert(entry.first);
+  addKeys(scene.positions);
+  addKeys(scene.symdefFiles);
+  addKeys(scene.symdefTypes);
+  addKeys(scene.symdefMatrices);
+  addKeys(scene.symdefGeometries);
   return used;
 }
 
-// Resolves a collision-free UUID for an imported item and records reference remaps.
+// Returns sorted UUID keys so merge analysis is deterministic across platforms.
+template <typename T>
+std::vector<std::string>
+SortedUuidKeys(const std::unordered_map<std::string, T> &objects) {
+  std::vector<std::string> keys;
+  keys.reserve(objects.size());
+  for (const auto &entry : objects)
+    keys.push_back(entry.first);
+  std::sort(keys.begin(), keys.end());
+  return keys;
+}
+
+// Derives an unused deterministic replacement UUID.
+std::string
+DeriveStableReplacementUuid(std::string_view tableName, const std::string &uuid,
+                            std::unordered_set<std::string> &usedUuids) {
+  std::string seed = "mvr:merge:" + std::string(tableName) + ":" + uuid;
+  std::string replacement = DeriveDeterministicUuid(seed);
+  size_t suffix = 1;
+  while (!usedUuids.insert(replacement).second)
+    replacement =
+        DeriveDeterministicUuid(seed + "#" + std::to_string(suffix++));
+  return replacement;
+}
+
+// Resolves an imported UUID and records reference remaps.
 std::string ResolveImportedUuid(const std::string &uuid,
+                                std::string_view tableName,
                                 std::unordered_set<std::string> &usedUuids,
-                                MvrMergeAnalysis &analysis) {
+                                MvrMergeAnalysis &analysis,
+                                const MvrMergeOptions &options) {
   if (uuid.empty())
     return uuid;
 
@@ -62,45 +86,78 @@ std::string ResolveImportedUuid(const std::string &uuid,
     return uuid;
   }
 
-  std::string replacement;
-  do {
-    replacement = GenerateUuid();
-  } while (!usedUuids.insert(replacement).second);
+  ++analysis.uuidCollisionsDetected;
+  if (options.uuidCollisionBehavior ==
+      MvrMergeUuidCollisionBehavior::ReplaceExisting) {
+    analysis.uuidMap[uuid] = uuid;
+    return uuid;
+  }
+  if (options.uuidCollisionBehavior ==
+      MvrMergeUuidCollisionBehavior::SkipIncoming) {
+    analysis.uuidMap[uuid] = uuid;
+    analysis.skippedIncomingUuids.insert(uuid);
+    return uuid;
+  }
 
+  const std::string replacement =
+      DeriveStableReplacementUuid(tableName, uuid, usedUuids);
   analysis.uuidMap[uuid] = replacement;
   ++analysis.uuidCollisionsResolved;
   return replacement;
 }
 
-// Records UUID remaps for an imported object map without mutating scene content.
+// Records UUID remaps without mutating imported scene content.
 template <typename T>
 void PrepareObjectTable(const std::unordered_map<std::string, T> &imported,
+                        std::string_view tableName,
                         std::unordered_set<std::string> &usedUuids,
-                        MvrMergeAnalysis &analysis) {
-  for (const auto &entry : imported)
-    (void)ResolveImportedUuid(entry.first, usedUuids, analysis);
+                        MvrMergeAnalysis &analysis,
+                        const MvrMergeOptions &options) {
+  for (const auto &uuid : SortedUuidKeys(imported))
+    (void)ResolveImportedUuid(uuid, tableName, usedUuids, analysis, options);
 }
 
 } // namespace
 
 // Analyzes imported scene UUIDs and prepares collision-safe reference remaps.
 MvrMergeAnalysis AnalyzeImportedSceneMerge(const MvrScene &target,
-                                           const MvrScene &imported) {
+                                           const MvrScene &imported,
+                                           const MvrMergeOptions &options) {
   MvrMergeAnalysis analysis;
   std::unordered_set<std::string> usedUuids = CollectUsedUuids(target);
 
-  PrepareObjectTable(imported.positions, usedUuids, analysis);
-  PrepareObjectTable(imported.symdefFiles, usedUuids, analysis);
-  PrepareObjectTable(imported.symdefTypes, usedUuids, analysis);
-  PrepareObjectTable(imported.symdefMatrices, usedUuids, analysis);
-  PrepareObjectTable(imported.symdefGeometries, usedUuids, analysis);
-  PrepareObjectTable(imported.fixtures, usedUuids, analysis);
-  PrepareObjectTable(imported.trusses, usedUuids, analysis);
-  PrepareObjectTable(imported.supports, usedUuids, analysis);
-  PrepareObjectTable(imported.sceneObjects, usedUuids, analysis);
-  PrepareObjectTable(imported.groupObjects, usedUuids, analysis);
-  PrepareObjectTable(imported.layers, usedUuids, analysis);
+  PrepareObjectTable(imported.positions, "positions", usedUuids, analysis,
+                     options);
+  PrepareObjectTable(imported.symdefFiles, "symdefFiles", usedUuids, analysis,
+                     options);
+  PrepareObjectTable(imported.symdefTypes, "symdefTypes", usedUuids, analysis,
+                     options);
+  PrepareObjectTable(imported.symdefMatrices, "symdefMatrices", usedUuids,
+                     analysis, options);
+  PrepareObjectTable(imported.symdefGeometries, "symdefGeometries", usedUuids,
+                     analysis, options);
+  PrepareObjectTable(imported.fixtures, "fixtures", usedUuids, analysis,
+                     options);
+  PrepareObjectTable(imported.trusses, "trusses", usedUuids, analysis, options);
+  PrepareObjectTable(imported.supports, "supports", usedUuids, analysis,
+                     options);
+  PrepareObjectTable(imported.sceneObjects, "sceneObjects", usedUuids, analysis,
+                     options);
+  PrepareObjectTable(imported.groupObjects, "groupObjects", usedUuids, analysis,
+                     options);
+  PrepareObjectTable(imported.layers, "layers", usedUuids, analysis, options);
+
+  for (const auto &[oldUuid, newUuid] : analysis.uuidMap) {
+    if (oldUuid != newUuid && imported.fixtures.contains(oldUuid))
+      analysis.fixtureUuidRemap.emplace(oldUuid, newUuid);
+  }
   return analysis;
+}
+
+// Reports whether an imported object UUID should be skipped during merge apply.
+bool ShouldSkipImportedUuid(const std::string &uuid,
+                            const MvrMergeAnalysis &analysis) {
+  return analysis.skippedIncomingUuids.contains(uuid);
 }
 
 // Resolves an imported UUID reference using the prepared merge analysis.

--- a/mvr/mvr_merge_analyzer.h
+++ b/mvr/mvr_merge_analyzer.h
@@ -20,6 +20,7 @@
 #include <cstddef>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "mvrscene.h"
 
@@ -33,16 +34,36 @@ struct MvrSceneMergeResult {
   std::size_t groupObjectsAdded = 0;
   std::size_t layersAdded = 0;
   std::size_t uuidCollisionsResolved = 0;
+  std::unordered_map<std::string, std::string> fixtureUuidRemap;
+};
+
+enum class MvrMergeUuidCollisionBehavior {
+  GenerateStableUuid,
+  ReplaceExisting,
+  SkipIncoming,
+};
+
+struct MvrMergeOptions {
+  MvrMergeUuidCollisionBehavior uuidCollisionBehavior =
+      MvrMergeUuidCollisionBehavior::GenerateStableUuid;
 };
 
 struct MvrMergeAnalysis {
   std::unordered_map<std::string, std::string> uuidMap;
+  std::unordered_map<std::string, std::string> fixtureUuidRemap;
+  std::unordered_set<std::string> skippedIncomingUuids;
+  std::size_t uuidCollisionsDetected = 0;
   std::size_t uuidCollisionsResolved = 0;
 };
 
 // Analyzes imported scene UUIDs and prepares collision-safe reference remaps.
-MvrMergeAnalysis AnalyzeImportedSceneMerge(const MvrScene &target,
-                                           const MvrScene &imported);
+MvrMergeAnalysis
+AnalyzeImportedSceneMerge(const MvrScene &target, const MvrScene &imported,
+                          const MvrMergeOptions &options = MvrMergeOptions{});
+
+// Reports whether an imported object UUID should be skipped during merge apply.
+bool ShouldSkipImportedUuid(const std::string &uuid,
+                            const MvrMergeAnalysis &analysis);
 
 // Resolves an imported UUID reference using the prepared merge analysis.
 std::string RemapImportedUuidReference(const std::string &uuid,

--- a/mvr/mvr_merge_applier.cpp
+++ b/mvr/mvr_merge_applier.cpp
@@ -22,22 +22,27 @@
 namespace mvr {
 namespace {
 
-// Adds imported lookup-table entries to the target scene using prepared UUID remaps.
+// Adds imported lookup-table entries with prepared UUID remaps.
 template <typename T>
 void MergeLookupTable(std::unordered_map<std::string, T> &target,
                       const std::unordered_map<std::string, T> &imported,
                       const MvrMergeAnalysis &analysis) {
-  for (const auto &[uuid, value] : imported)
+  for (const auto &[uuid, value] : imported) {
+    if (ShouldSkipImportedUuid(uuid, analysis))
+      continue;
     target[RemapImportedUuidReference(uuid, analysis)] = value;
+  }
 }
 
-// Adds imported objects with UUID fields to the target after updating each object's UUID.
+// Adds imported objects after updating each object UUID.
 template <typename T>
 std::size_t MergeObjectTable(std::unordered_map<std::string, T> &target,
                              const std::unordered_map<std::string, T> &imported,
                              const MvrMergeAnalysis &analysis) {
   std::size_t added = 0;
   for (const auto &[uuid, object] : imported) {
+    if (ShouldSkipImportedUuid(uuid, analysis))
+      continue;
     const std::string resolvedUuid = RemapImportedUuidReference(uuid, analysis);
     T merged = object;
     merged.uuid = resolvedUuid;
@@ -47,10 +52,13 @@ std::size_t MergeObjectTable(std::unordered_map<std::string, T> &target,
   return added;
 }
 
-// Updates references inside an imported scene copy after the full UUID remap table has been built.
-void RemapImportedReferences(MvrScene &scene, const MvrMergeAnalysis &analysis) {
-  for (auto &[uuid, fixture] : scene.fixtures)
+// Updates imported scene references after building the UUID remap table.
+void RemapImportedReferences(MvrScene &scene,
+                             const MvrMergeAnalysis &analysis) {
+  for (auto &[uuid, fixture] : scene.fixtures) {
     fixture.position = RemapImportedUuidReference(fixture.position, analysis);
+    fixture.focus = RemapImportedUuidReference(fixture.focus, analysis);
+  }
 
   for (auto &[uuid, truss] : scene.trusses) {
     truss.position = RemapImportedUuidReference(truss.position, analysis);
@@ -87,6 +95,7 @@ MvrSceneMergeResult ApplyImportedSceneMerge(MvrScene &target,
                                             const MvrMergeAnalysis &analysis) {
   MvrSceneMergeResult result;
   result.uuidCollisionsResolved = analysis.uuidCollisionsResolved;
+  result.fixtureUuidRemap = analysis.fixtureUuidRemap;
 
   MvrScene importedCopy = imported;
   RemapImportedReferences(importedCopy, analysis);
@@ -94,7 +103,8 @@ MvrSceneMergeResult ApplyImportedSceneMerge(MvrScene &target,
   MergeLookupTable(target.positions, importedCopy.positions, analysis);
   MergeLookupTable(target.symdefFiles, importedCopy.symdefFiles, analysis);
   MergeLookupTable(target.symdefTypes, importedCopy.symdefTypes, analysis);
-  MergeLookupTable(target.symdefMatrices, importedCopy.symdefMatrices, analysis);
+  MergeLookupTable(target.symdefMatrices, importedCopy.symdefMatrices,
+                   analysis);
   MergeLookupTable(target.symdefGeometries, importedCopy.symdefGeometries,
                    analysis);
 
@@ -104,10 +114,10 @@ MvrSceneMergeResult ApplyImportedSceneMerge(MvrScene &target,
       MergeObjectTable(target.trusses, importedCopy.trusses, analysis);
   result.supportsAdded =
       MergeObjectTable(target.supports, importedCopy.supports, analysis);
-  result.sceneObjectsAdded =
-      MergeObjectTable(target.sceneObjects, importedCopy.sceneObjects, analysis);
-  result.groupObjectsAdded =
-      MergeObjectTable(target.groupObjects, importedCopy.groupObjects, analysis);
+  result.sceneObjectsAdded = MergeObjectTable(
+      target.sceneObjects, importedCopy.sceneObjects, analysis);
+  result.groupObjectsAdded = MergeObjectTable(
+      target.groupObjects, importedCopy.groupObjects, analysis);
   result.layersAdded =
       MergeObjectTable(target.layers, importedCopy.layers, analysis);
 

--- a/mvr/mvrscenemerger.cpp
+++ b/mvr/mvrscenemerger.cpp
@@ -21,10 +21,12 @@
 
 namespace mvr {
 
-// Combines imported MVR scene content into the target while preserving existing objects.
-MvrSceneMergeResult MergeImportedSceneIntoCurrent(MvrScene &target,
-                                                  const MvrScene &imported) {
-  const MvrMergeAnalysis analysis = AnalyzeImportedSceneMerge(target, imported);
+// Combines imported MVR content while preserving existing objects.
+MvrSceneMergeResult
+MergeImportedSceneIntoCurrent(MvrScene &target, const MvrScene &imported,
+                              const MvrMergeOptions &options) {
+  const MvrMergeAnalysis analysis =
+      AnalyzeImportedSceneMerge(target, imported, options);
   return ApplyImportedSceneMerge(target, imported, analysis);
 }
 

--- a/mvr/mvrscenemerger.h
+++ b/mvr/mvrscenemerger.h
@@ -21,8 +21,9 @@
 
 namespace mvr {
 
-// Combines imported MVR scene content into the target while preserving existing objects.
-MvrSceneMergeResult MergeImportedSceneIntoCurrent(MvrScene &target,
-                                                  const MvrScene &imported);
+// Combines imported MVR content while preserving existing objects.
+MvrSceneMergeResult MergeImportedSceneIntoCurrent(
+    MvrScene &target, const MvrScene &imported,
+    const MvrMergeOptions &options = MvrMergeOptions{});
 
 } // namespace mvr

--- a/tests/mvr_merge_analyzer_applier_test.cpp
+++ b/tests/mvr_merge_analyzer_applier_test.cpp
@@ -5,36 +5,117 @@
 #include <string>
 
 // Builds a fixture with the requested UUID and position reference.
-static Fixture MakeFixture(const std::string &uuid, const std::string &position) {
+static Fixture MakeFixture(const std::string &uuid,
+                           const std::string &position) {
   Fixture fixture;
   fixture.uuid = uuid;
   fixture.position = position;
   return fixture;
 }
 
-// Verifies merge analysis resolves collisions before applying imported scene data.
-int main() {
+// Builds a support with the requested UUID, position reference, and motor
+// fixture reference.
+static Support MakeSupport(const std::string &uuid, const std::string &position,
+                           const std::string &motorFixtureUuid) {
+  Support support;
+  support.uuid = uuid;
+  support.position = position;
+  support.motorFixtureUuid = motorFixtureUuid;
+  return support;
+}
+
+// Builds a group object that references one child UUID.
+static GroupObject MakeGroup(const std::string &uuid, MvrNodeType childType,
+                             const std::string &childUuid) {
+  GroupObject group;
+  group.uuid = uuid;
+  group.children.push_back(GroupObjectChildRef{childType, childUuid});
+  return group;
+}
+
+// Verifies fixture UUID collisions use deterministic replacement UUIDs.
+static void VerifyFixtureUuidCollisionUsesStableReplacement() {
+  MvrScene target;
+  target.fixtures["fixture-a"] = MakeFixture("fixture-a", "position-a");
+
+  MvrScene imported;
+  imported.fixtures["fixture-a"] = MakeFixture("fixture-a", "");
+
+  const mvr::MvrMergeAnalysis firstAnalysis =
+      mvr::AnalyzeImportedSceneMerge(target, imported);
+  const mvr::MvrMergeAnalysis secondAnalysis =
+      mvr::AnalyzeImportedSceneMerge(target, imported);
+  assert(firstAnalysis.uuidCollisionsDetected == 1);
+  assert(firstAnalysis.uuidCollisionsResolved == 1);
+  assert(firstAnalysis.uuidMap.at("fixture-a") != "fixture-a");
+  assert(firstAnalysis.uuidMap.at("fixture-a") ==
+         secondAnalysis.uuidMap.at("fixture-a"));
+  assert(firstAnalysis.fixtureUuidRemap.at("fixture-a") ==
+         firstAnalysis.uuidMap.at("fixture-a"));
+
+  const mvr::MvrSceneMergeResult result =
+      mvr::ApplyImportedSceneMerge(target, imported, firstAnalysis);
+  assert(result.uuidCollisionsResolved == 1);
+  assert(result.fixturesAdded == 1);
+  assert(result.fixtureUuidRemap.at("fixture-a") ==
+         firstAnalysis.uuidMap.at("fixture-a"));
+  assert(target.fixtures.count("fixture-a") == 1);
+  assert(target.fixtures.count(firstAnalysis.uuidMap.at("fixture-a")) == 1);
+}
+
+// Verifies group child references follow UUID remaps for colliding imported
+// children.
+static void VerifyGroupChildRemapping() {
+  MvrScene target;
+  target.fixtures["fixture-a"] = MakeFixture("fixture-a", "");
+
+  MvrScene imported;
+  imported.fixtures["fixture-a"] = MakeFixture("fixture-a", "");
+  imported.groupObjects["group-a"] =
+      MakeGroup("group-a", MvrNodeType::Fixture, "fixture-a");
+
+  const mvr::MvrMergeAnalysis analysis =
+      mvr::AnalyzeImportedSceneMerge(target, imported);
+  const std::string remappedFixtureUuid = analysis.uuidMap.at("fixture-a");
+  mvr::ApplyImportedSceneMerge(target, imported, analysis);
+
+  assert(target.groupObjects.count("group-a") == 1);
+  assert(target.groupObjects.at("group-a").children.size() == 1);
+  assert(target.groupObjects.at("group-a").children.front().uuid ==
+         remappedFixtureUuid);
+}
+
+// Verifies support position and linked motor fixture references follow remapped
+// UUIDs.
+static void VerifySupportPositionReferenceRemapping() {
   MvrScene target;
   target.positions["position-a"] = "Existing position";
   target.fixtures["fixture-a"] = MakeFixture("fixture-a", "position-a");
 
   MvrScene imported;
   imported.positions["position-a"] = "Imported position";
-  imported.fixtures["fixture-b"] = MakeFixture("fixture-b", "position-a");
+  imported.fixtures["fixture-a"] = MakeFixture("fixture-a", "position-a");
+  imported.supports["support-a"] =
+      MakeSupport("support-a", "position-a", "fixture-a");
 
   const mvr::MvrMergeAnalysis analysis =
       mvr::AnalyzeImportedSceneMerge(target, imported);
-  assert(analysis.uuidCollisionsResolved == 1);
-  assert(analysis.uuidMap.at("position-a") != "position-a");
+  const std::string remappedPositionUuid = analysis.uuidMap.at("position-a");
+  const std::string remappedFixtureUuid = analysis.uuidMap.at("fixture-a");
+  mvr::ApplyImportedSceneMerge(target, imported, analysis);
 
-  const mvr::MvrSceneMergeResult result =
-      mvr::ApplyImportedSceneMerge(target, imported, analysis);
-  assert(result.uuidCollisionsResolved == 1);
-  assert(result.fixturesAdded == 1);
-  assert(target.fixtures.count("fixture-a") == 1);
-  assert(target.fixtures.count("fixture-b") == 1);
-  assert(target.fixtures.at("fixture-b").position ==
-         analysis.uuidMap.at("position-a"));
-  assert(target.positions.count(analysis.uuidMap.at("position-a")) == 1);
+  assert(target.positions.count(remappedPositionUuid) == 1);
+  assert(target.supports.count("support-a") == 1);
+  assert(target.supports.at("support-a").position == remappedPositionUuid);
+  assert(target.supports.at("support-a").motorFixtureUuid ==
+         remappedFixtureUuid);
+}
+
+// Verifies merge analysis resolves collisions before applying imported scene
+// data.
+int main() {
+  VerifyFixtureUuidCollisionUsesStableReplacement();
+  VerifyGroupChildRemapping();
+  VerifySupportPositionReferenceRemapping();
   return 0;
 }


### PR DESCRIPTION
### Motivation
- Prevent accidental identifier collisions when merging an external MVR into an open project by detecting incoming UUIDs that already exist in the current `MvrScene` and avoiding silent overwrites.
- Preserve referential integrity for imported content by remapping inbound references (positions, fixture focus, hoist motor links, group children, layer children, symdef entries, etc.) after any UUID changes so the merged scene remains connected.
- Give users explicit control when collisions are found by offering a small preflight policy so they can accept deterministic remapping (default), replace existing project objects, or skip incoming colliding objects.

### Description
- Added `MvrMergeOptions` and collision behaviors (`GenerateStableUuid`, `ReplaceExisting`, `SkipIncoming`) and extended `AnalyzeImportedSceneMerge` to build a deterministic `uuidMap` and collision metadata for a preflight pass, using `DeriveDeterministicUuid` seeds for stable replacements. (`mvr/mvr_merge_analyzer.{h,cpp}`)
- Implemented deterministic replacement and preflight bookkeeping including `fixtureUuidRemap` and `skippedIncomingUuids`, plus helper functions to produce stable replacement UUIDs and a deterministic key ordering for analysis. (`mvr/mvr_merge_analyzer.cpp`, `mvr/mvr_merge_analyzer.h`)
- Updated merge application to honor preflight results by skipping incoming objects when requested, remapping lookup tables and object UUIDs, and updating all inbound references: fixture `position` and `focus`, truss `position`, `sourceSymdefUuid`, and `parentGroupUuid`, support `position` and `motorFixtureUuid`, group children in `groupObjects`, and `layer.childUUIDs`; the `ApplyImportedSceneMerge` result now returns `fixtureUuidRemap` for downstream consumers. (`mvr/mvr_merge_applier.cpp`, `mvr/mvr_merge_analyzer.h`)
- Added a GUI preflight flow and dialog so when the merge preflight detects collisions `MainWindowIoController::MergeMvrFromPath` shows `ShowMvrMergeUuidCollisionDialog` and passes the chosen `MvrMergeOptions` into `MergeImportedSceneIntoCurrent`; this preserves the default stable-remap behavior but allows replace/skip choices. (`gui/mainwindow/controllers/mainwindow_io_controller.cpp`, `mvr/mvrscenemerger.{h,cpp}`)
- Added and expanded tests to cover fixture UUID collision remapping, group child remapping, and support/position + motor fixture reference remapping, and updated user-visible docs and release notes to mention safer MVR merge behavior and the available collision choices. (`tests/mvr_merge_analyzer_applier_test.cpp`, `docs/opening-mvr-files.md`, `docs/release-notes-draft.md`)

### Testing
- Built and ran the focused merge analyzer/applier test binary with `g++ -std=c++20 -Icore -Imodels -Imvr tests/mvr_merge_analyzer_applier_test.cpp mvr/mvr_merge_analyzer.cpp mvr/mvr_merge_applier.cpp core/uuidutils.cpp models/mvrscene.cpp -o /tmp/mvr_merge_analyzer_applier_test && /tmp/mvr_merge_analyzer_applier_test`, which completed successfully.
- Ran the repository policy checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both returned `OK`. 
- Ran repository sanity checks (`git diff --check`) and ensured no style errors were reported by the local formatting/compilation checks used in the rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21493a655c83249836f3deec54b314)