### PR TITLE
Add MVR fixture type merge conflict handling

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -32,7 +32,7 @@ Perastage is designed for lighting designers, programmers, and technicians who n
 - Imports MVR 1.6 scenes with fixtures, trusses, hoists/supports, and generic objects.
 - `.mvr` opening from startup, command-line, or OS association uses a clean-scene reset plus import flow for deterministic behavior.
 - Menu import lets you choose between opening the selected MVR as a new project or merging it into the current project.
-- Merged MVR content preserves existing scene content and resolves imported UUID collisions so both scenes can coexist.
+- Merged MVR content preserves existing scene content, resolves imported UUID collisions so both scenes can coexist, and blocks fixture type name conflicts until the user chooses whether to reuse the current GDTF definition, rename the imported definition, or cancel.
 
 ### MVR export
 

--- a/docs/opening-mvr-files.md
+++ b/docs/opening-mvr-files.md
@@ -9,7 +9,7 @@ Use one of these methods:
 - Open an existing `.mvr` file directly.
 - Use **File → Import MVR...**. After choosing a file, select **Open as new project** to replace the current scene or **Merge into current project** to add the selected MVR content to the current scene.
 
-When merging, Perastage checks imported object UUIDs against the current project and gives colliding imported objects stable replacement UUIDs by default. If collisions are found, you can instead choose to replace existing project objects or skip incoming colliding objects. References inside the imported content, such as positions, group children, layers, and hoist motor links, are updated so the merged scene remains connected while existing project objects are preserved.
+When merging, Perastage checks imported object UUIDs against the current project and gives colliding imported objects stable replacement UUIDs by default. If collisions are found, you can instead choose to replace existing project objects or skip incoming colliding objects. Perastage also compares fixture type names against their resolved GDTF definitions before applying the merge. If the imported MVR uses the same fixture type name for a different GDTF file or mode, Perastage asks whether to use the current project definition for those imported fixtures, keep the imported definition under a renamed fixture type, or cancel the merge. References inside the imported content, such as positions, group children, layers, and hoist motor links, are updated so the merged scene remains connected while existing project objects are preserved.
 
 Opening an `.mvr` file directly from the command line, operating system file association, or startup path uses the clean **Open as new project** behavior.
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -19,6 +19,7 @@ Changes since `v1.2.0`.
 - Added support for packaging referenced layout images into project archives, making `.pstg` project files more portable when shared or reopened elsewhere.
 - Added an MVR import choice so users can open a selected MVR as a new project or merge it into the current project.
 - Improved MVR merge safety so imported objects with UUIDs that already exist in the current project receive stable replacement UUIDs while their internal references stay connected.
+- Added MVR merge protection for fixture type name conflicts, prompting users to reuse the current GDTF definition, keep the imported definition under a renamed type, or cancel before mixed definitions can enter the scene.
 
 ## Improvements
 

--- a/gui/mainwindow/controllers/mainwindow_io_controller.cpp
+++ b/gui/mainwindow/controllers/mainwindow_io_controller.cpp
@@ -71,6 +71,59 @@ ShowMvrMergeUuidCollisionDialog(wxWindow *parent, std::size_t collisionCount) {
   return mvr::MvrMergeUuidCollisionBehavior::GenerateStableUuid;
 }
 
+// Formats a fixture type identity for the MVR merge conflict dialog.
+wxString FormatFixtureTypeIdentityForDialog(
+    const mvr::MvrFixtureTypeIdentity &identity) {
+  wxString text = wxString::Format(
+      "Type: %s\nGDTF: %s\nMode: %s",
+      wxString::FromUTF8(identity.typeName).c_str(),
+      wxString::FromUTF8(identity.gdtfSpec.empty() ? "(none)"
+                                                   : identity.gdtfSpec)
+          .c_str(),
+      wxString::FromUTF8(identity.gdtfMode.empty() ? "(default)"
+                                                   : identity.gdtfMode)
+          .c_str());
+  if (!identity.gdtfSha256.empty()) {
+    text += wxString::Format(
+        "\nSHA-256: %s",
+        wxString::FromUTF8(identity.gdtfSha256.substr(0, 16) + "...").c_str());
+  }
+  return text;
+}
+
+// Shows fixture type conflict choices before an MVR merge is applied.
+std::optional<mvr::MvrMergeFixtureTypeDecision>
+ShowMvrFixtureTypeConflictDialog(wxWindow *parent,
+                                 const mvr::MvrFixtureTypeConflict &conflict) {
+  wxArrayString choices;
+  choices.Add("Use current project definition for imported fixtures");
+  choices.Add(wxString::Format(
+      "Keep imported definition by renaming it to \"%s\"",
+      wxString::FromUTF8(conflict.suggestedIncomingTypeName).c_str()));
+  choices.Add("Cancel merge");
+
+  wxString message = wxString::Format(
+      "The imported MVR uses fixture type \"%s\" with a different GDTF "
+      "definition than the current project. Choose how Perastage should "
+      "resolve all incoming fixtures of this type.\n\nCurrent project "
+      "definition:\n%s\n\n"
+      "Imported definition:\n%s",
+      wxString::FromUTF8(conflict.currentIdentity.typeName).c_str(),
+      FormatFixtureTypeIdentityForDialog(conflict.currentIdentity).c_str(),
+      FormatFixtureTypeIdentityForDialog(conflict.incomingIdentity).c_str());
+
+  wxSingleChoiceDialog dialog(parent, message,
+                              "MVR Merge Fixture Type Conflict", choices);
+  dialog.SetSelection(0);
+  if (dialog.ShowModal() != wxID_OK)
+    return std::nullopt;
+  if (dialog.GetSelection() == 1)
+    return mvr::MvrMergeFixtureTypeDecision::RenameIncomingType;
+  if (dialog.GetSelection() == 2)
+    return mvr::MvrMergeFixtureTypeDecision::CancelMerge;
+  return mvr::MvrMergeFixtureTypeDecision::UseCurrentDefinition;
+}
+
 // Shows the user-facing MVR import mode selection dialog.
 MvrImportChoice ShowMvrImportChoiceDialog(wxWindow *parent) {
   wxArrayString choices;
@@ -90,13 +143,11 @@ MvrImportChoice ShowMvrImportChoiceDialog(wxWindow *parent) {
 
 } // namespace
 
-// Stores the owning MainWindow pointer for IO operations during the controller
-// lifetime.
+// Stores the owning MainWindow pointer for IO operations.
 MainWindowIoController::MainWindowIoController(MainWindow &owner)
     : ownerRef_(&owner) {}
 
-// Imports an MVR file while keeping import progress and UI panel refreshes
-// synchronized on the main thread.
+// Imports an MVR file and synchronizes UI refreshes.
 bool MainWindowIoController::ImportMvrFromPath(const std::string &pathUtf8) {
   constexpr const char *kLayoutsConfigKey = "layouts_collection";
   constexpr const char *kViewer3DRenderStyleConfigKey = "viewer3d_render_style";
@@ -288,8 +339,7 @@ void MainWindowIoController::RefreshPanelsAfterMvrSceneChange() {
     owner->layoutViewerPanel->RefreshAfterSceneContentUpdate();
 }
 
-// Opens a file picker and imports the selected MVR file using the selected
-// import mode.
+// Opens a file picker and imports the selected MVR file.
 void MainWindowIoController::OnImportMVR(wxCommandEvent &) {
   wxString miscDir =
       wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("misc"));
@@ -388,10 +438,33 @@ bool MainWindowIoController::MergeMvrFromPath(const std::string &pathUtf8) {
     }
     mergeOptions.uuidCollisionBehavior = *collisionBehavior;
   }
+  for (const auto &conflict : preflightAnalysis.fixtureTypeConflicts) {
+    const auto decision = ShowMvrFixtureTypeConflictDialog(owner, conflict);
+    if (!decision.has_value() ||
+        *decision == mvr::MvrMergeFixtureTypeDecision::CancelMerge) {
+      restorePreservedConfig();
+      owner->mvrImportPipelineActive = false;
+      if (owner->GetStatusBar())
+        owner->SetStatusText("MVR merge cancelled.", 0);
+      return false;
+    }
+    mergeOptions.fixtureTypeDecisions[conflict.normalizedTypeName] = *decision;
+  }
   cfg.PushUndoState("merge MVR");
   const mvr::MvrSceneMergeResult mergeResult =
       mvr::MergeImportedSceneIntoCurrent(cfg.GetScene(), importResult.scene,
                                          mergeOptions);
+  if (mergeResult.fixtureTypeConflictsBlocked > 0) {
+    cfg.GetScene() = currentScene;
+    restorePreservedConfig();
+    owner->mvrImportPipelineActive = false;
+    if (owner->GetStatusBar())
+      owner->SetStatusText("MVR merge cancelled.", 0);
+    wxMessageBox("The MVR merge was cancelled because fixture type definition "
+                 "conflicts were not resolved.",
+                 "MVR Merge Cancelled", wxOK | wxICON_WARNING, owner);
+    return false;
+  }
   cfg.MarkDirty();
   restorePreservedConfig();
   viewer2d::ReconcileFixtureLabelOverridesWithScene(cfg);

--- a/mvr/mvr_merge_analyzer.cpp
+++ b/mvr/mvr_merge_analyzer.cpp
@@ -17,14 +17,105 @@
  */
 #include "mvr_merge_analyzer.h"
 
+#include "file_import_utils.h"
 #include "uuidutils.h"
 
 #include <algorithm>
+#include <cctype>
+#include <filesystem>
 #include <string_view>
 #include <vector>
 
 namespace mvr {
 namespace {
+
+// Trims leading and trailing ASCII whitespace from a value.
+std::string TrimAscii(std::string value) {
+  auto isSpace = [](unsigned char ch) { return std::isspace(ch) != 0; };
+  while (!value.empty() && isSpace(static_cast<unsigned char>(value.front())))
+    value.erase(value.begin());
+  while (!value.empty() && isSpace(static_cast<unsigned char>(value.back())))
+    value.pop_back();
+  return value;
+}
+
+// Converts a string to lowercase ASCII for stable comparisons.
+std::string ToLowerAscii(std::string value) {
+  std::transform(
+      value.begin(), value.end(), value.begin(),
+      [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+  return value;
+}
+
+// Normalizes fixture type names for merge identity comparisons.
+std::string NormalizeFixtureTypeName(const std::string &typeName) {
+  return ToLowerAscii(TrimAscii(typeName));
+}
+
+// Resolves a scene resource path to the best available local filesystem path.
+std::filesystem::path
+ResolveSceneResourcePath(const MvrScene &scene,
+                         const std::string &resourcePath) {
+  if (resourcePath.empty())
+    return {};
+
+  std::filesystem::path path = std::filesystem::path(resourcePath);
+  if (path.is_absolute())
+    return path;
+  if (!scene.basePath.empty())
+    return std::filesystem::path(scene.basePath) / path;
+  return path;
+}
+
+// Normalizes a resolved path token for case-insensitive identity comparisons.
+std::string NormalizeResolvedPathToken(const std::filesystem::path &path,
+                                       const std::string &fallback) {
+  std::error_code ec;
+  const std::filesystem::path absolute = std::filesystem::absolute(path, ec);
+  if (!ec)
+    return ToLowerAscii(absolute.lexically_normal().string());
+  return ToLowerAscii(TrimAscii(fallback));
+}
+
+// Creates an identity descriptor for a fixture type in the supplied scene.
+MvrFixtureTypeIdentity BuildFixtureTypeIdentity(const MvrScene &scene,
+                                                const Fixture &fixture,
+                                                const std::string &normalized) {
+  MvrFixtureTypeIdentity identity;
+  identity.normalizedTypeName = normalized;
+  identity.typeName = fixture.typeName;
+  identity.gdtfSpec = fixture.gdtfSpec;
+  identity.gdtfMode = fixture.gdtfMode;
+
+  const std::filesystem::path resolvedPath =
+      ResolveSceneResourcePath(scene, fixture.gdtfSpec);
+  if (!resolvedPath.empty()) {
+    identity.resolvedGdtfSpec =
+        NormalizeResolvedPathToken(resolvedPath, fixture.gdtfSpec);
+    std::error_code ec;
+    if (std::filesystem::is_regular_file(resolvedPath, ec) && !ec) {
+      if (const auto hash = FileImportUtils::ComputeFileSha256(resolvedPath))
+        identity.gdtfSha256 = *hash;
+    }
+  } else {
+    identity.resolvedGdtfSpec = ToLowerAscii(TrimAscii(fixture.gdtfSpec));
+  }
+  return identity;
+}
+
+// Chooses a stable display name for an imported conflicting fixture type.
+std::string BuildUniqueImportedTypeName(
+    const MvrFixtureTypeIdentity &incoming,
+    const std::unordered_set<std::string> &reservedNormalizedNames) {
+  const std::string base = !TrimAscii(incoming.typeName).empty()
+                               ? TrimAscii(incoming.typeName)
+                               : "Imported fixture type";
+  std::string candidate = base + " (Imported)";
+  int suffix = 2;
+  while (reservedNormalizedNames.contains(NormalizeFixtureTypeName(candidate)))
+    candidate = base + " (Imported " + std::to_string(suffix++) + ")";
+  return candidate;
+}
 
 // Collects every UUID already owned by a scene across object and lookup tables.
 std::unordered_set<std::string> CollectUsedUuids(const MvrScene &scene) {
@@ -117,15 +208,104 @@ void PrepareObjectTable(const std::unordered_map<std::string, T> &imported,
     (void)ResolveImportedUuid(uuid, tableName, usedUuids, analysis, options);
 }
 
+// Adds fixture type conflict metadata and rename decisions to the analysis.
+void AnalyzeFixtureTypeConflicts(const MvrMergeOptions &options,
+                                 MvrMergeAnalysis &analysis) {
+  std::unordered_set<std::string> reservedNames;
+  for (const auto &[normalized, identity] : analysis.currentFixtureTypes)
+    reservedNames.insert(normalized);
+  for (const auto &[normalized, identity] : analysis.incomingFixtureTypes)
+    reservedNames.insert(normalized);
+
+  for (const auto &[normalized, incoming] : analysis.incomingFixtureTypes) {
+    const auto currentIt = analysis.currentFixtureTypes.find(normalized);
+    if (currentIt == analysis.currentFixtureTypes.end() ||
+        !FixtureTypeIdentitiesConflict(currentIt->second, incoming))
+      continue;
+
+    MvrFixtureTypeConflict conflict;
+    conflict.normalizedTypeName = normalized;
+    conflict.currentIdentity = currentIt->second;
+    conflict.incomingIdentity = incoming;
+    conflict.suggestedIncomingTypeName =
+        BuildUniqueImportedTypeName(incoming, reservedNames);
+    reservedNames.insert(
+        NormalizeFixtureTypeName(conflict.suggestedIncomingTypeName));
+    analysis.fixtureTypeConflicts.push_back(conflict);
+
+    const auto decisionIt = options.fixtureTypeDecisions.find(normalized);
+    if (decisionIt == options.fixtureTypeDecisions.end())
+      continue;
+    analysis.fixtureTypeDecisions[normalized] = decisionIt->second;
+    if (decisionIt->second == MvrMergeFixtureTypeDecision::RenameIncomingType)
+      analysis.incomingFixtureTypeRenames[normalized] =
+          conflict.suggestedIncomingTypeName;
+  }
+}
+
 } // namespace
+
+// Builds a fixture type identity map keyed by normalized fixture type name.
+std::unordered_map<std::string, MvrFixtureTypeIdentity>
+BuildFixtureTypeIdentityMap(const MvrScene &scene) {
+  std::unordered_map<std::string, MvrFixtureTypeIdentity> types;
+  std::vector<std::string> fixtureUuids;
+  fixtureUuids.reserve(scene.fixtures.size());
+  for (const auto &[uuid, fixture] : scene.fixtures)
+    fixtureUuids.push_back(uuid);
+  std::sort(fixtureUuids.begin(), fixtureUuids.end());
+
+  for (const auto &uuid : fixtureUuids) {
+    const Fixture &fixture = scene.fixtures.at(uuid);
+    const std::string normalized = NormalizeFixtureTypeName(fixture.typeName);
+    if (normalized.empty())
+      continue;
+    const MvrFixtureTypeIdentity identity =
+        BuildFixtureTypeIdentity(scene, fixture, normalized);
+    const auto existingIt = types.find(normalized);
+    if (existingIt == types.end()) {
+      types.emplace(normalized, identity);
+      continue;
+    }
+  }
+  return types;
+}
+
+// Reports whether two fixture identities resolve to different definitions.
+bool FixtureTypeIdentitiesConflict(const MvrFixtureTypeIdentity &current,
+                                   const MvrFixtureTypeIdentity &incoming) {
+  if (TrimAscii(current.gdtfMode) != TrimAscii(incoming.gdtfMode))
+    return true;
+  if (!current.gdtfSha256.empty() && !incoming.gdtfSha256.empty())
+    return current.gdtfSha256 != incoming.gdtfSha256;
+  if (!current.resolvedGdtfSpec.empty() || !incoming.resolvedGdtfSpec.empty())
+    return current.resolvedGdtfSpec != incoming.resolvedGdtfSpec;
+  return ToLowerAscii(TrimAscii(current.gdtfSpec)) !=
+         ToLowerAscii(TrimAscii(incoming.gdtfSpec));
+}
+
+// Reports whether unresolved fixture type conflicts prevent merge application.
+bool HasBlockingFixtureTypeConflicts(const MvrMergeAnalysis &analysis) {
+  for (const auto &conflict : analysis.fixtureTypeConflicts) {
+    const auto decisionIt =
+        analysis.fixtureTypeDecisions.find(conflict.normalizedTypeName);
+    if (decisionIt == analysis.fixtureTypeDecisions.end() ||
+        decisionIt->second == MvrMergeFixtureTypeDecision::CancelMerge)
+      return true;
+  }
+  return false;
+}
 
 // Analyzes imported scene UUIDs and prepares collision-safe reference remaps.
 MvrMergeAnalysis AnalyzeImportedSceneMerge(const MvrScene &target,
                                            const MvrScene &imported,
                                            const MvrMergeOptions &options) {
   MvrMergeAnalysis analysis;
-  std::unordered_set<std::string> usedUuids = CollectUsedUuids(target);
+  analysis.currentFixtureTypes = BuildFixtureTypeIdentityMap(target);
+  analysis.incomingFixtureTypes = BuildFixtureTypeIdentityMap(imported);
+  AnalyzeFixtureTypeConflicts(options, analysis);
 
+  std::unordered_set<std::string> usedUuids = CollectUsedUuids(target);
   PrepareObjectTable(imported.positions, "positions", usedUuids, analysis,
                      options);
   PrepareObjectTable(imported.symdefFiles, "symdefFiles", usedUuids, analysis,

--- a/mvr/mvr_merge_analyzer.h
+++ b/mvr/mvr_merge_analyzer.h
@@ -21,6 +21,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 #include "mvrscene.h"
 
@@ -34,7 +35,30 @@ struct MvrSceneMergeResult {
   std::size_t groupObjectsAdded = 0;
   std::size_t layersAdded = 0;
   std::size_t uuidCollisionsResolved = 0;
+  std::size_t fixtureTypeConflictsBlocked = 0;
   std::unordered_map<std::string, std::string> fixtureUuidRemap;
+};
+
+enum class MvrMergeFixtureTypeDecision {
+  UseCurrentDefinition,
+  RenameIncomingType,
+  CancelMerge,
+};
+
+struct MvrFixtureTypeIdentity {
+  std::string normalizedTypeName;
+  std::string typeName;
+  std::string gdtfSpec;
+  std::string resolvedGdtfSpec;
+  std::string gdtfMode;
+  std::string gdtfSha256;
+};
+
+struct MvrFixtureTypeConflict {
+  std::string normalizedTypeName;
+  MvrFixtureTypeIdentity currentIdentity;
+  MvrFixtureTypeIdentity incomingIdentity;
+  std::string suggestedIncomingTypeName;
 };
 
 enum class MvrMergeUuidCollisionBehavior {
@@ -46,15 +70,35 @@ enum class MvrMergeUuidCollisionBehavior {
 struct MvrMergeOptions {
   MvrMergeUuidCollisionBehavior uuidCollisionBehavior =
       MvrMergeUuidCollisionBehavior::GenerateStableUuid;
+  std::unordered_map<std::string, MvrMergeFixtureTypeDecision>
+      fixtureTypeDecisions;
 };
 
 struct MvrMergeAnalysis {
   std::unordered_map<std::string, std::string> uuidMap;
   std::unordered_map<std::string, std::string> fixtureUuidRemap;
   std::unordered_set<std::string> skippedIncomingUuids;
+  std::unordered_map<std::string, MvrFixtureTypeIdentity> currentFixtureTypes;
+  std::unordered_map<std::string, MvrFixtureTypeIdentity> incomingFixtureTypes;
+  std::vector<MvrFixtureTypeConflict> fixtureTypeConflicts;
+  std::unordered_map<std::string, MvrMergeFixtureTypeDecision>
+      fixtureTypeDecisions;
+  std::unordered_map<std::string, std::string> incomingFixtureTypeRenames;
   std::size_t uuidCollisionsDetected = 0;
   std::size_t uuidCollisionsResolved = 0;
 };
+
+// Builds a fixture type identity map keyed by normalized fixture type name.
+std::unordered_map<std::string, MvrFixtureTypeIdentity>
+BuildFixtureTypeIdentityMap(const MvrScene &scene);
+
+// Reports whether the two fixture type identities resolve to different
+// definitions.
+bool FixtureTypeIdentitiesConflict(const MvrFixtureTypeIdentity &current,
+                                   const MvrFixtureTypeIdentity &incoming);
+
+// Reports whether unresolved fixture type conflicts prevent merge application.
+bool HasBlockingFixtureTypeConflicts(const MvrMergeAnalysis &analysis);
 
 // Analyzes imported scene UUIDs and prepares collision-safe reference remaps.
 MvrMergeAnalysis

--- a/mvr/mvr_merge_applier.cpp
+++ b/mvr/mvr_merge_applier.cpp
@@ -17,10 +17,35 @@
  */
 #include "mvr_merge_applier.h"
 
+#include <algorithm>
+#include <cctype>
 #include <utility>
 
 namespace mvr {
 namespace {
+
+// Trims leading and trailing ASCII whitespace from a value.
+std::string TrimAscii(std::string value) {
+  auto isSpace = [](unsigned char ch) { return std::isspace(ch) != 0; };
+  while (!value.empty() && isSpace(static_cast<unsigned char>(value.front())))
+    value.erase(value.begin());
+  while (!value.empty() && isSpace(static_cast<unsigned char>(value.back())))
+    value.pop_back();
+  return value;
+}
+
+// Converts a string to lowercase ASCII for stable comparisons.
+std::string ToLowerAscii(std::string value) {
+  std::transform(
+      value.begin(), value.end(), value.begin(),
+      [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+  return value;
+}
+
+// Normalizes fixture type names for merge decision lookup.
+std::string NormalizeFixtureTypeName(const std::string &typeName) {
+  return ToLowerAscii(TrimAscii(typeName));
+}
 
 // Adds imported lookup-table entries with prepared UUID remaps.
 template <typename T>
@@ -50,6 +75,32 @@ std::size_t MergeObjectTable(std::unordered_map<std::string, T> &target,
     ++added;
   }
   return added;
+}
+
+// Applies selected fixture type conflict decisions to imported fixtures.
+void ApplyFixtureTypeDecisions(MvrScene &scene,
+                               const MvrMergeAnalysis &analysis) {
+  for (auto &[uuid, fixture] : scene.fixtures) {
+    const std::string normalized = NormalizeFixtureTypeName(fixture.typeName);
+    const auto decisionIt = analysis.fixtureTypeDecisions.find(normalized);
+    if (decisionIt == analysis.fixtureTypeDecisions.end())
+      continue;
+    if (decisionIt->second ==
+        MvrMergeFixtureTypeDecision::UseCurrentDefinition) {
+      const auto currentIt = analysis.currentFixtureTypes.find(normalized);
+      if (currentIt == analysis.currentFixtureTypes.end())
+        continue;
+      fixture.typeName = currentIt->second.typeName;
+      fixture.gdtfSpec = currentIt->second.gdtfSpec;
+      fixture.gdtfMode = currentIt->second.gdtfMode;
+    } else if (decisionIt->second ==
+               MvrMergeFixtureTypeDecision::RenameIncomingType) {
+      const auto renameIt =
+          analysis.incomingFixtureTypeRenames.find(normalized);
+      if (renameIt != analysis.incomingFixtureTypeRenames.end())
+        fixture.typeName = renameIt->second;
+    }
+  }
 }
 
 // Updates imported scene references after building the UUID remap table.
@@ -95,9 +146,14 @@ MvrSceneMergeResult ApplyImportedSceneMerge(MvrScene &target,
                                             const MvrMergeAnalysis &analysis) {
   MvrSceneMergeResult result;
   result.uuidCollisionsResolved = analysis.uuidCollisionsResolved;
+  if (HasBlockingFixtureTypeConflicts(analysis)) {
+    result.fixtureTypeConflictsBlocked = analysis.fixtureTypeConflicts.size();
+    return result;
+  }
   result.fixtureUuidRemap = analysis.fixtureUuidRemap;
 
   MvrScene importedCopy = imported;
+  ApplyFixtureTypeDecisions(importedCopy, analysis);
   RemapImportedReferences(importedCopy, analysis);
 
   MergeLookupTable(target.positions, importedCopy.positions, analysis);

--- a/tests/mvr_merge_analyzer_applier_test.cpp
+++ b/tests/mvr_merge_analyzer_applier_test.cpp
@@ -2,6 +2,8 @@
 #include "mvr_merge_applier.h"
 
 #include <cassert>
+#include <filesystem>
+#include <fstream>
 #include <string>
 
 // Builds a fixture with the requested UUID and position reference.
@@ -13,8 +15,27 @@ static Fixture MakeFixture(const std::string &uuid,
   return fixture;
 }
 
-// Builds a support with the requested UUID, position reference, and motor
-// fixture reference.
+// Builds a fixture with a user-visible type name and GDTF identity.
+static Fixture MakeTypedFixture(const std::string &uuid,
+                                const std::string &typeName,
+                                const std::string &gdtfSpec,
+                                const std::string &gdtfMode) {
+  Fixture fixture = MakeFixture(uuid, "");
+  fixture.typeName = typeName;
+  fixture.gdtfSpec = gdtfSpec;
+  fixture.gdtfMode = gdtfMode;
+  return fixture;
+}
+
+// Writes a small GDTF placeholder file for SHA-256 identity tests.
+static void WriteGdtfFile(const std::filesystem::path &path,
+                          const std::string &content) {
+  std::filesystem::create_directories(path.parent_path());
+  std::ofstream out(path, std::ios::binary);
+  out << content;
+}
+
+// Builds a support with requested references.
 static Support MakeSupport(const std::string &uuid, const std::string &position,
                            const std::string &motorFixtureUuid) {
   Support support;
@@ -63,8 +84,7 @@ static void VerifyFixtureUuidCollisionUsesStableReplacement() {
   assert(target.fixtures.count(firstAnalysis.uuidMap.at("fixture-a")) == 1);
 }
 
-// Verifies group child references follow UUID remaps for colliding imported
-// children.
+// Verifies group child references follow UUID remaps.
 static void VerifyGroupChildRemapping() {
   MvrScene target;
   target.fixtures["fixture-a"] = MakeFixture("fixture-a", "");
@@ -85,8 +105,7 @@ static void VerifyGroupChildRemapping() {
          remappedFixtureUuid);
 }
 
-// Verifies support position and linked motor fixture references follow remapped
-// UUIDs.
+// Verifies support references follow remapped UUIDs.
 static void VerifySupportPositionReferenceRemapping() {
   MvrScene target;
   target.positions["position-a"] = "Existing position";
@@ -111,11 +130,102 @@ static void VerifySupportPositionReferenceRemapping() {
          remappedFixtureUuid);
 }
 
-// Verifies merge analysis resolves collisions before applying imported scene
-// data.
+// Verifies fixture type conflicts block automatic merge.
+static void VerifyFixtureTypeGdtfConflictBlocksAutomaticMerge() {
+  const std::filesystem::path tempDir = std::filesystem::temp_directory_path() /
+                                        "perastage_mvr_merge_identity_test";
+  std::filesystem::remove_all(tempDir);
+  WriteGdtfFile(tempDir / "current" / "spot.gdtf", "current gdtf");
+  WriteGdtfFile(tempDir / "incoming" / "spot.gdtf", "incoming gdtf");
+
+  MvrScene target;
+  target.basePath = (tempDir / "current").string();
+  target.fixtures["current-fixture"] =
+      MakeTypedFixture("current-fixture", "Spot", "spot.gdtf", "Mode A");
+
+  MvrScene imported;
+  imported.basePath = (tempDir / "incoming").string();
+  imported.fixtures["incoming-fixture"] =
+      MakeTypedFixture("incoming-fixture", "spot", "spot.gdtf", "Mode A");
+
+  const mvr::MvrMergeAnalysis analysis =
+      mvr::AnalyzeImportedSceneMerge(target, imported);
+  assert(analysis.currentFixtureTypes.at("spot").typeName == "Spot");
+  assert(analysis.incomingFixtureTypes.at("spot").typeName == "spot");
+  assert(!analysis.currentFixtureTypes.at("spot").gdtfSha256.empty());
+  assert(!analysis.incomingFixtureTypes.at("spot").gdtfSha256.empty());
+  assert(analysis.currentFixtureTypes.at("spot").gdtfSha256 !=
+         analysis.incomingFixtureTypes.at("spot").gdtfSha256);
+  assert(analysis.fixtureTypeConflicts.size() == 1);
+  assert(mvr::HasBlockingFixtureTypeConflicts(analysis));
+
+  const mvr::MvrSceneMergeResult result =
+      mvr::ApplyImportedSceneMerge(target, imported, analysis);
+  assert(result.fixtureTypeConflictsBlocked == 1);
+  assert(target.fixtures.count("incoming-fixture") == 0);
+}
+
+// Verifies current-definition decisions update incoming fixtures.
+static void VerifyUseCurrentDefinitionDecisionAppliesToIncomingFixtures() {
+  MvrScene target;
+  target.fixtures["current-fixture"] =
+      MakeTypedFixture("current-fixture", "Spot", "current.gdtf", "Mode A");
+
+  MvrScene imported;
+  imported.fixtures["incoming-a"] =
+      MakeTypedFixture("incoming-a", "spot", "incoming.gdtf", "Mode B");
+  imported.fixtures["incoming-b"] =
+      MakeTypedFixture("incoming-b", "SPOT", "incoming.gdtf", "Mode B");
+
+  mvr::MvrMergeOptions options;
+  options.fixtureTypeDecisions["spot"] =
+      mvr::MvrMergeFixtureTypeDecision::UseCurrentDefinition;
+  const mvr::MvrMergeAnalysis analysis =
+      mvr::AnalyzeImportedSceneMerge(target, imported, options);
+  assert(!mvr::HasBlockingFixtureTypeConflicts(analysis));
+  mvr::ApplyImportedSceneMerge(target, imported, analysis);
+
+  assert(target.fixtures.at("incoming-a").typeName == "Spot");
+  assert(target.fixtures.at("incoming-a").gdtfSpec == "current.gdtf");
+  assert(target.fixtures.at("incoming-a").gdtfMode == "Mode A");
+  assert(target.fixtures.at("incoming-b").typeName == "Spot");
+  assert(target.fixtures.at("incoming-b").gdtfSpec == "current.gdtf");
+}
+
+// Verifies rename decisions preserve imported definitions.
+static void VerifyRenameIncomingDefinitionDecisionAppliesToIncomingFixtures() {
+  MvrScene target;
+  target.fixtures["current-fixture"] =
+      MakeTypedFixture("current-fixture", "Spot", "current.gdtf", "Mode A");
+
+  MvrScene imported;
+  imported.fixtures["incoming-a"] =
+      MakeTypedFixture("incoming-a", "Spot", "incoming.gdtf", "Mode B");
+  imported.fixtures["incoming-b"] =
+      MakeTypedFixture("incoming-b", "spot", "incoming.gdtf", "Mode B");
+
+  mvr::MvrMergeOptions options;
+  options.fixtureTypeDecisions["spot"] =
+      mvr::MvrMergeFixtureTypeDecision::RenameIncomingType;
+  const mvr::MvrMergeAnalysis analysis =
+      mvr::AnalyzeImportedSceneMerge(target, imported, options);
+  assert(!mvr::HasBlockingFixtureTypeConflicts(analysis));
+  assert(analysis.incomingFixtureTypeRenames.at("spot") == "Spot (Imported)");
+  mvr::ApplyImportedSceneMerge(target, imported, analysis);
+
+  assert(target.fixtures.at("incoming-a").typeName == "Spot (Imported)");
+  assert(target.fixtures.at("incoming-a").gdtfSpec == "incoming.gdtf");
+  assert(target.fixtures.at("incoming-a").gdtfMode == "Mode B");
+  assert(target.fixtures.at("incoming-b").typeName == "Spot (Imported)");
+}
+
+// Verifies merge analysis resolves collisions before applying imported data.
 int main() {
   VerifyFixtureUuidCollisionUsesStableReplacement();
   VerifyGroupChildRemapping();
   VerifySupportPositionReferenceRemapping();
+  VerifyFixtureTypeGdtfConflictBlocksAutomaticMerge();
+  VerifyUseCurrentDefinitionDecisionAppliesToIncomingFixtures();
+  VerifyRenameIncomingDefinitionDecisionAppliesToIncomingFixtures();
   return 0;
 }


### PR DESCRIPTION
### Motivation
- Avoid silently merging fixtures that share the same normalized type name but resolve to different GDTF definitions, which can produce mixed/ambiguous fixture types in the final scene.
- Give users a clear, consistent choice (reuse current, keep imported under a new name, or cancel) and apply that decision consistently to all incoming fixtures of the same normalized type.

### Description
- Added fixture-type identity structures and analysis in `mvr/mvr_merge_analyzer.h` and `mvr/mvr_merge_analyzer.cpp` capturing `Fixture::typeName`, `Fixture::gdtfSpec`, `Fixture::gdtfMode`, resolved GDTF path, and optional SHA-256 via `FileImportUtils::ComputeFileSha256` for stronger identity checks.
- Built a normalized fixture-type identity map with `BuildFixtureTypeIdentityMap(...)` and conflict detection (`FixtureTypeIdentitiesConflict(...)`) and collected `MvrFixtureTypeConflict` entries plus suggested imported-type names.
- Extended `MvrMergeOptions`/`MvrMergeAnalysis` to carry fixture-type decisions, incoming renames and conflict lists, and blocked-merge reporting when conflicts are not resolved.
- Updated the applier (`mvr/mvr_merge_applier.cpp`) to block merge application when unresolved fixture-type conflicts exist and to apply decisions consistently before insertion using `ApplyFixtureTypeDecisions(...)` (either rewrite incoming fixtures to the current definition or rename incoming fixture type names uniformly).
- Added a GUI choice dialog `ShowMvrFixtureTypeConflictDialog(...)` in `gui/mainwindow/controllers/mainwindow_io_controller.cpp` to present current vs incoming identities and let the user pick `UseCurrentDefinition`, `RenameIncomingType`, or `CancelMerge`; merge flow uses the selected decision for all fixtures of that normalized type.
- Added regression tests in `tests/mvr_merge_analyzer_applier_test.cpp` covering: detection/blocking of conflicting same-name fixture types that resolve to different GDTF SHA256s, the `UseCurrentDefinition` decision, and the `RenameIncomingType` decision.
- Updated user docs: `docs/opening-mvr-files.md`, `docs/features.md`, and `docs/release-notes-draft.md` to describe the new merge behavior.

### Testing
- Built and ran the analyzer/applier unit test with: `g++ -std=c++20 -Itests -Icore -Imodels -Imvr tests/mvr_merge_analyzer_applier_test.cpp mvr/mvr_merge_analyzer.cpp mvr/mvr_merge_applier.cpp core/uuidutils.cpp models/mvrscene.cpp -o /tmp/mvr_merge_analyzer_applier_test && /tmp/mvr_merge_analyzer_applier_test`, which succeeded.
- Ran project checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both of which succeeded.
- Ran `git diff --check` with no problems.
- Attempted `cmake -S tests -B build-tests` but host container lacks `wxWidgets` development files so CMake configuration could not complete (this environment limitation did not block the unit-test compilation and run used above).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a214c5857708324b9b2da3f025ff4a5)