### PR TITLE
Add explicit MVR lookup merge rules

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -36,6 +36,7 @@ Changes since `v1.2.0`.
 
 - Fixed MVR export before saving a project so resource references are synchronized before export.
 - Fixed MVR merge resource handling so imported fixture, truss, symbol, and model files remain available after saving and reopening the project.
+- Fixed MVR merge handling for layer, position, and symbol-definition lookup collisions so imported references remain connected without overwriting current project state.
 - Fixed Windows startup behavior for shell-opened MVR files, including path normalization and startup stalls while scanning for GDTF fallbacks.
 - Fixed layout view freezes and busy-cursor issues caused by reentrant GUI work, render timeouts, mode changes, new project creation, and 2D view edit commits.
 - Fixed layout 2D view editing so edits apply to the intended target view and reliably refresh the layout viewer afterward.

--- a/gui/mainwindow/controllers/mainwindow_io_controller.cpp
+++ b/gui/mainwindow/controllers/mainwindow_io_controller.cpp
@@ -16,6 +16,7 @@
 #include <optional>
 #include <sstream>
 #include <string>
+#include <unordered_set>
 
 #include "LayoutManager.h"
 #include "configmanager.h"
@@ -381,9 +382,15 @@ bool MainWindowIoController::MergeMvrFromPath(const std::string &pathUtf8) {
       cfg.GetValue(kLayoutsConfigKey);
   const std::optional<std::string> preservedViewer3DRenderStyle =
       cfg.GetValue(kViewer3DRenderStyleConfigKey);
+  const std::unordered_set<std::string> preservedHiddenLayers =
+      cfg.GetHiddenLayers();
+  const std::string preservedCurrentLayer = cfg.GetCurrentLayer();
 
+  // Restores merge-preserved project configuration and layer UI state.
   auto restorePreservedConfig = [&cfg, &preservedLayoutsConfig,
-                                 &preservedViewer3DRenderStyle]() {
+                                 &preservedViewer3DRenderStyle,
+                                 &preservedHiddenLayers,
+                                 &preservedCurrentLayer]() {
     if (preservedLayoutsConfig.has_value())
       cfg.SetValue(kLayoutsConfigKey, *preservedLayoutsConfig);
     else
@@ -393,6 +400,8 @@ bool MainWindowIoController::MergeMvrFromPath(const std::string &pathUtf8) {
                    *preservedViewer3DRenderStyle);
     else
       cfg.RemoveKey(kViewer3DRenderStyleConfigKey);
+    cfg.SetHiddenLayers(preservedHiddenLayers);
+    cfg.SetCurrentLayer(preservedCurrentLayer);
     layouts::LayoutManager::Get().LoadFromConfig(cfg);
   };
 
@@ -478,7 +487,11 @@ bool MainWindowIoController::MergeMvrFromPath(const std::string &pathUtf8) {
     summary << "Merged " << pathUtf8 << " (" << mergeResult.fixturesAdded
             << " fixtures, " << mergeResult.trussesAdded << " trusses, "
             << mergeResult.supportsAdded << " hoists, "
-            << mergeResult.sceneObjectsAdded << " objects)";
+            << mergeResult.sceneObjectsAdded << " objects";
+    if (mergeResult.nonObjectLookupConflictsResolved > 0)
+      summary << ", " << mergeResult.nonObjectLookupConflictsResolved
+              << " lookup conflicts resolved";
+    summary << ")";
     owner->consolePanel->AppendMessage(wxString::FromUTF8(summary.str()));
   }
   if (owner->GetStatusBar())

--- a/mvr/mvr_merge_analyzer.cpp
+++ b/mvr/mvr_merge_analyzer.cpp
@@ -150,6 +150,90 @@ SortedUuidKeys(const std::unordered_map<std::string, T> &objects) {
   return keys;
 }
 
+// Returns sorted UUID keys from all maps in a lookup family.
+template <typename... Maps>
+std::vector<std::string> SortedUnionUuidKeys(const Maps &...maps) {
+  std::unordered_set<std::string> seen;
+  auto collect = [&seen](const auto &map) {
+    for (const auto &entry : map)
+      seen.insert(entry.first);
+  };
+  (collect(maps), ...);
+  std::vector<std::string> keys(seen.begin(), seen.end());
+  std::sort(keys.begin(), keys.end());
+  return keys;
+}
+
+// Reports whether two matrices contain identical transform components.
+bool MatrixValuesEqual(const Matrix &current, const Matrix &incoming) {
+  return current.u == incoming.u && current.v == incoming.v &&
+         current.w == incoming.w && current.o == incoming.o;
+}
+
+// Reports whether two Symdef geometry entries describe the same geometry.
+bool SymdefGeometryValuesEqual(const SymdefGeometry &current,
+                               const SymdefGeometry &incoming) {
+  return current.file == incoming.file &&
+         current.geometryType == incoming.geometryType &&
+         MatrixValuesEqual(current.transform, incoming.transform);
+}
+
+// Reports whether two Symdef geometry lists have identical entries.
+bool SymdefGeometryListsEqual(const std::vector<SymdefGeometry> &current,
+                              const std::vector<SymdefGeometry> &incoming) {
+  if (current.size() != incoming.size())
+    return false;
+  for (std::size_t i = 0; i < current.size(); ++i) {
+    if (!SymdefGeometryValuesEqual(current[i], incoming[i]))
+      return false;
+  }
+  return true;
+}
+
+// Looks up a value from a map or returns the supplied fallback.
+template <typename T>
+T LookupOrDefault(const std::unordered_map<std::string, T> &values,
+                  const std::string &uuid, const T &fallback = T{}) {
+  const auto it = values.find(uuid);
+  if (it == values.end())
+    return fallback;
+  return it->second;
+}
+
+// Reports whether two Symdef UUID entries describe the same definition.
+bool SymdefDefinitionsEqual(const MvrScene &target, const MvrScene &imported,
+                            const std::string &uuid) {
+  return LookupOrDefault(target.symdefFiles, uuid) ==
+             LookupOrDefault(imported.symdefFiles, uuid) &&
+         LookupOrDefault(target.symdefTypes, uuid) ==
+             LookupOrDefault(imported.symdefTypes, uuid) &&
+         MatrixValuesEqual(LookupOrDefault(target.symdefMatrices, uuid),
+                           LookupOrDefault(imported.symdefMatrices, uuid)) &&
+         SymdefGeometryListsEqual(
+             LookupOrDefault(target.symdefGeometries, uuid),
+             LookupOrDefault(imported.symdefGeometries, uuid));
+}
+
+// Reports whether two layer entries share the same merge-visible content.
+bool LayerValuesEqual(const Layer &current, const Layer &incoming) {
+  return current.name == incoming.name && current.color == incoming.color &&
+         current.childUUIDs == incoming.childUUIDs;
+}
+
+// Builds an imported layer name that does not shadow current layer state.
+std::string BuildUniqueImportedLayerName(
+    const std::string &layerName,
+    const std::unordered_set<std::string> &reservedLayerNames) {
+  const std::string base = !TrimAscii(layerName).empty()
+                               ? TrimAscii(layerName)
+                               : "Imported layer";
+  std::string candidate = base + " (Imported)";
+  int suffix = 2;
+  while (reservedLayerNames.contains(candidate))
+    candidate = base + " (Imported " + std::to_string(suffix++) + ")";
+  return candidate;
+}
+
 // Derives an unused deterministic replacement UUID.
 std::string
 DeriveStableReplacementUuid(std::string_view tableName, const std::string &uuid,
@@ -206,6 +290,115 @@ void PrepareObjectTable(const std::unordered_map<std::string, T> &imported,
                         const MvrMergeOptions &options) {
   for (const auto &uuid : SortedUuidKeys(imported))
     (void)ResolveImportedUuid(uuid, tableName, usedUuids, analysis, options);
+}
+
+// Prepares position UUID remaps while preserving current names on conflicts.
+void PreparePositionLookupTable(const MvrScene &target, const MvrScene &imported,
+                                std::unordered_set<std::string> &usedUuids,
+                                MvrMergeAnalysis &analysis,
+                                const MvrMergeOptions &options) {
+  for (const auto &uuid : SortedUuidKeys(imported.positions)) {
+    const auto targetIt = target.positions.find(uuid);
+    const auto importedIt = imported.positions.find(uuid);
+    if (targetIt != target.positions.end() &&
+        importedIt != imported.positions.end() &&
+        targetIt->second == importedIt->second) {
+      analysis.uuidMap[uuid] = uuid;
+      continue;
+    }
+    if (targetIt != target.positions.end() &&
+        importedIt != imported.positions.end() &&
+        targetIt->second != importedIt->second) {
+      ++analysis.uuidCollisionsDetected;
+      const std::string replacement =
+          DeriveStableReplacementUuid("positions", uuid, usedUuids);
+      analysis.uuidMap[uuid] = replacement;
+      ++analysis.uuidCollisionsResolved;
+      ++analysis.nonObjectLookupConflictsResolved;
+      continue;
+    }
+    (void)ResolveImportedUuid(uuid, "positions", usedUuids, analysis, options);
+  }
+}
+
+// Prepares Symdef UUID remaps as one logical definition across lookup maps.
+void PrepareSymdefLookupTables(const MvrScene &target, const MvrScene &imported,
+                               std::unordered_set<std::string> &usedUuids,
+                               MvrMergeAnalysis &analysis,
+                               const MvrMergeOptions &options) {
+  for (const auto &uuid : SortedUnionUuidKeys(
+           imported.symdefFiles, imported.symdefTypes, imported.symdefMatrices,
+           imported.symdefGeometries)) {
+    const bool targetHasSymdef = target.symdefFiles.contains(uuid) ||
+                                 target.symdefTypes.contains(uuid) ||
+                                 target.symdefMatrices.contains(uuid) ||
+                                 target.symdefGeometries.contains(uuid);
+    if (targetHasSymdef && SymdefDefinitionsEqual(target, imported, uuid)) {
+      analysis.uuidMap[uuid] = uuid;
+      continue;
+    }
+    if (targetHasSymdef && !SymdefDefinitionsEqual(target, imported, uuid)) {
+      ++analysis.uuidCollisionsDetected;
+      const std::string replacement =
+          DeriveStableReplacementUuid("symdefs", uuid, usedUuids);
+      analysis.uuidMap[uuid] = replacement;
+      ++analysis.uuidCollisionsResolved;
+      ++analysis.nonObjectLookupConflictsResolved;
+      continue;
+    }
+    (void)ResolveImportedUuid(uuid, "symdefs", usedUuids, analysis, options);
+  }
+}
+
+// Prepares layer UUID and name remaps without changing current layer names.
+void PrepareLayerTable(const MvrScene &target, const MvrScene &imported,
+                       std::unordered_set<std::string> &usedUuids,
+                       MvrMergeAnalysis &analysis,
+                       const MvrMergeOptions &options) {
+  std::unordered_set<std::string> reservedLayerNames;
+  for (const auto &[uuid, layer] : target.layers)
+    reservedLayerNames.insert(layer.name);
+
+  for (const auto &uuid : SortedUuidKeys(imported.layers)) {
+    const Layer &incoming = imported.layers.at(uuid);
+    std::string resolvedUuid = uuid;
+    bool keepIncoming = true;
+    const auto targetIt = target.layers.find(uuid);
+    if (uuid.empty()) {
+      resolvedUuid = DeriveStableReplacementUuid("layers", incoming.name,
+                                                 usedUuids);
+      ++analysis.uuidCollisionsResolved;
+    } else if (targetIt != target.layers.end()) {
+      ++analysis.uuidCollisionsDetected;
+      if (LayerValuesEqual(targetIt->second, incoming)) {
+        analysis.skippedIncomingLayerUuids.insert(uuid);
+        keepIncoming = false;
+      } else {
+        resolvedUuid = DeriveStableReplacementUuid("layers", uuid, usedUuids);
+        ++analysis.uuidCollisionsResolved;
+        ++analysis.nonObjectLookupConflictsResolved;
+      }
+    } else if (!usedUuids.insert(uuid).second) {
+      resolvedUuid = ResolveImportedUuid(uuid, "layers", usedUuids, analysis,
+                                         options);
+    }
+
+    if (keepIncoming)
+      analysis.layerUuidMap[uuid] = resolvedUuid;
+
+    if (!keepIncoming)
+      continue;
+    if (reservedLayerNames.contains(incoming.name) &&
+        (targetIt == target.layers.end() || resolvedUuid != uuid)) {
+      const std::string renamed =
+          BuildUniqueImportedLayerName(incoming.name, reservedLayerNames);
+      analysis.incomingLayerNameRenames[incoming.name] = renamed;
+      reservedLayerNames.insert(renamed);
+      ++analysis.nonObjectLookupConflictsResolved;
+    } else {
+      reservedLayerNames.insert(incoming.name);
+    }
+  }
 }
 
 // Adds fixture type conflict metadata and rename decisions to the analysis.
@@ -306,16 +499,8 @@ MvrMergeAnalysis AnalyzeImportedSceneMerge(const MvrScene &target,
   AnalyzeFixtureTypeConflicts(options, analysis);
 
   std::unordered_set<std::string> usedUuids = CollectUsedUuids(target);
-  PrepareObjectTable(imported.positions, "positions", usedUuids, analysis,
-                     options);
-  PrepareObjectTable(imported.symdefFiles, "symdefFiles", usedUuids, analysis,
-                     options);
-  PrepareObjectTable(imported.symdefTypes, "symdefTypes", usedUuids, analysis,
-                     options);
-  PrepareObjectTable(imported.symdefMatrices, "symdefMatrices", usedUuids,
-                     analysis, options);
-  PrepareObjectTable(imported.symdefGeometries, "symdefGeometries", usedUuids,
-                     analysis, options);
+  PreparePositionLookupTable(target, imported, usedUuids, analysis, options);
+  PrepareSymdefLookupTables(target, imported, usedUuids, analysis, options);
   PrepareObjectTable(imported.fixtures, "fixtures", usedUuids, analysis,
                      options);
   PrepareObjectTable(imported.trusses, "trusses", usedUuids, analysis, options);
@@ -325,7 +510,7 @@ MvrMergeAnalysis AnalyzeImportedSceneMerge(const MvrScene &target,
                      options);
   PrepareObjectTable(imported.groupObjects, "groupObjects", usedUuids, analysis,
                      options);
-  PrepareObjectTable(imported.layers, "layers", usedUuids, analysis, options);
+  PrepareLayerTable(target, imported, usedUuids, analysis, options);
 
   for (const auto &[oldUuid, newUuid] : analysis.uuidMap) {
     if (oldUuid != newUuid && imported.fixtures.contains(oldUuid))

--- a/mvr/mvr_merge_analyzer.h
+++ b/mvr/mvr_merge_analyzer.h
@@ -36,6 +36,7 @@ struct MvrSceneMergeResult {
   std::size_t layersAdded = 0;
   std::size_t uuidCollisionsResolved = 0;
   std::size_t fixtureTypeConflictsBlocked = 0;
+  std::size_t nonObjectLookupConflictsResolved = 0;
   std::unordered_map<std::string, std::string> fixtureUuidRemap;
 };
 
@@ -84,8 +85,12 @@ struct MvrMergeAnalysis {
   std::unordered_map<std::string, MvrMergeFixtureTypeDecision>
       fixtureTypeDecisions;
   std::unordered_map<std::string, std::string> incomingFixtureTypeRenames;
+  std::unordered_map<std::string, std::string> layerUuidMap;
+  std::unordered_map<std::string, std::string> incomingLayerNameRenames;
+  std::unordered_set<std::string> skippedIncomingLayerUuids;
   std::size_t uuidCollisionsDetected = 0;
   std::size_t uuidCollisionsResolved = 0;
+  std::size_t nonObjectLookupConflictsResolved = 0;
 };
 
 // Builds a fixture type identity map keyed by normalized fixture type name.

--- a/mvr/mvr_merge_applier.cpp
+++ b/mvr/mvr_merge_applier.cpp
@@ -79,6 +79,41 @@ std::size_t MergeObjectTable(std::unordered_map<std::string, T> &target,
   return added;
 }
 
+// Applies imported layer name remaps to object layer references.
+template <typename T>
+void RemapObjectLayerNames(std::unordered_map<std::string, T> &objects,
+                           const MvrMergeAnalysis &analysis) {
+  for (auto &[uuid, object] : objects) {
+    const auto renameIt = analysis.incomingLayerNameRenames.find(object.layer);
+    if (renameIt != analysis.incomingLayerNameRenames.end())
+      object.layer = renameIt->second;
+  }
+}
+
+// Adds imported layers after applying layer-specific UUID and name rules.
+std::size_t
+MergeLayerTable(std::unordered_map<std::string, Layer> &target,
+                const std::unordered_map<std::string, Layer> &imported,
+                const MvrMergeAnalysis &analysis) {
+  std::size_t added = 0;
+  for (const auto &[uuid, layer] : imported) {
+    if (analysis.skippedIncomingLayerUuids.contains(uuid))
+      continue;
+    const auto uuidIt = analysis.layerUuidMap.find(uuid);
+    const std::string resolvedUuid = uuidIt == analysis.layerUuidMap.end()
+                                         ? uuid
+                                         : uuidIt->second;
+    Layer merged = layer;
+    merged.uuid = resolvedUuid;
+    const auto renameIt = analysis.incomingLayerNameRenames.find(merged.name);
+    if (renameIt != analysis.incomingLayerNameRenames.end())
+      merged.name = renameIt->second;
+    target[resolvedUuid] = std::move(merged);
+    ++added;
+  }
+  return added;
+}
+
 // Applies selected fixture type conflict decisions to imported fixtures.
 void ApplyFixtureTypeDecisions(MvrScene &scene,
                                const MvrMergeAnalysis &analysis) {
@@ -134,6 +169,12 @@ void RemapImportedReferences(MvrScene &scene,
       child.uuid = RemapImportedUuidReference(child.uuid, analysis);
   }
 
+  RemapObjectLayerNames(scene.fixtures, analysis);
+  RemapObjectLayerNames(scene.trusses, analysis);
+  RemapObjectLayerNames(scene.supports, analysis);
+  RemapObjectLayerNames(scene.sceneObjects, analysis);
+  RemapObjectLayerNames(scene.groupObjects, analysis);
+
   for (auto &[uuid, layer] : scene.layers) {
     for (auto &childUuid : layer.childUUIDs)
       childUuid = RemapImportedUuidReference(childUuid, analysis);
@@ -148,6 +189,8 @@ MvrSceneMergeResult ApplyImportedSceneMerge(MvrScene &target,
                                             const MvrMergeAnalysis &analysis) {
   MvrSceneMergeResult result;
   result.uuidCollisionsResolved = analysis.uuidCollisionsResolved;
+  result.nonObjectLookupConflictsResolved =
+      analysis.nonObjectLookupConflictsResolved;
   if (HasBlockingFixtureTypeConflicts(analysis)) {
     result.fixtureTypeConflictsBlocked = analysis.fixtureTypeConflicts.size();
     return result;
@@ -178,7 +221,7 @@ MvrSceneMergeResult ApplyImportedSceneMerge(MvrScene &target,
   result.groupObjectsAdded = MergeObjectTable(
       target.groupObjects, importedCopy.groupObjects, analysis);
   result.layersAdded =
-      MergeObjectTable(target.layers, importedCopy.layers, analysis);
+      MergeLayerTable(target.layers, importedCopy.layers, analysis);
 
   if (target.provider.empty())
     target.provider = imported.provider;

--- a/tests/mvr_merge_analyzer_applier_test.cpp
+++ b/tests/mvr_merge_analyzer_applier_test.cpp
@@ -5,6 +5,8 @@
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include <utility>
+#include <vector>
 
 // Builds a fixture with the requested UUID and position reference.
 static Fixture MakeFixture(const std::string &uuid,
@@ -13,6 +15,18 @@ static Fixture MakeFixture(const std::string &uuid,
   fixture.uuid = uuid;
   fixture.position = position;
   return fixture;
+}
+
+// Builds a layer with the requested UUID, name, color, and child list.
+static Layer MakeLayer(const std::string &uuid, const std::string &name,
+                       const std::string &color,
+                       std::vector<std::string> childUuids = {}) {
+  Layer layer;
+  layer.uuid = uuid;
+  layer.name = name;
+  layer.color = color;
+  layer.childUUIDs = std::move(childUuids);
+  return layer;
 }
 
 // Builds a fixture with a user-visible type name and GDTF identity.
@@ -225,6 +239,84 @@ static void VerifyRenameIncomingDefinitionDecisionAppliesToIncomingFixtures() {
   assert(target.fixtures.at("incoming-b").typeName == "Spot (Imported)");
 }
 
+// Verifies imported layers without UUIDs receive generated merge UUIDs.
+static void VerifyEmptyLayerUuidReceivesGeneratedUuid() {
+  MvrScene target;
+
+  MvrScene imported;
+  imported.layers[""] = MakeLayer("", "Incoming empty UUID", "#123456");
+
+  const mvr::MvrMergeAnalysis analysis =
+      mvr::AnalyzeImportedSceneMerge(target, imported);
+  assert(analysis.layerUuidMap.contains(""));
+  assert(!analysis.layerUuidMap.at("").empty());
+  const mvr::MvrSceneMergeResult result =
+      mvr::ApplyImportedSceneMerge(target, imported, analysis);
+
+  const std::string generatedUuid = analysis.layerUuidMap.at("");
+  assert(result.layersAdded == 1);
+  assert(target.layers.count("") == 0);
+  assert(target.layers.count(generatedUuid) == 1);
+  assert(target.layers.at(generatedUuid).uuid == generatedUuid);
+  assert(target.layers.at(generatedUuid).name == "Incoming empty UUID");
+}
+
+// Verifies same-name layers with different UUIDs keep current layer state names.
+static void VerifySameLayerNameWithDifferentUuidRenamesIncomingLayer() {
+  MvrScene target;
+  target.layers["current-layer"] =
+      MakeLayer("current-layer", "Rig", "#0000FF");
+
+  MvrScene imported;
+  imported.layers["incoming-layer"] =
+      MakeLayer("incoming-layer", "Rig", "#FF0000");
+  imported.fixtures["incoming-fixture"] = MakeFixture("incoming-fixture", "");
+  imported.fixtures["incoming-fixture"].layer = "Rig";
+
+  const mvr::MvrMergeAnalysis analysis =
+      mvr::AnalyzeImportedSceneMerge(target, imported);
+  assert(analysis.incomingLayerNameRenames.at("Rig") == "Rig (Imported)");
+  const mvr::MvrSceneMergeResult result =
+      mvr::ApplyImportedSceneMerge(target, imported, analysis);
+
+  assert(result.layersAdded == 1);
+  assert(target.layers.at("current-layer").name == "Rig");
+  assert(target.layers.at("incoming-layer").name == "Rig (Imported)");
+  assert(target.fixtures.at("incoming-fixture").layer == "Rig (Imported)");
+}
+
+// Verifies Symdef UUID collisions remap Symbol-derived object references.
+static void VerifySymdefUuidCollisionWithDifferentGeometryFilesRemapsSymbol() {
+  MvrScene target;
+  target.symdefFiles["symdef-a"] = "symbols/current.3ds";
+  target.symdefTypes["symdef-a"] = "Mesh";
+  target.symdefGeometries["symdef-a"] = {
+      SymdefGeometry{"symbols/current.3ds", "Mesh", Matrix{}}};
+
+  MvrScene imported;
+  imported.symdefFiles["symdef-a"] = "symbols/incoming.3ds";
+  imported.symdefTypes["symdef-a"] = "Mesh";
+  imported.symdefGeometries["symdef-a"] = {
+      SymdefGeometry{"symbols/incoming.3ds", "Mesh", Matrix{}}};
+  Truss truss;
+  truss.uuid = "incoming-truss";
+  truss.sourceSymdefUuid = "symdef-a";
+  imported.trusses[truss.uuid] = truss;
+
+  const mvr::MvrMergeAnalysis analysis =
+      mvr::AnalyzeImportedSceneMerge(target, imported);
+  const std::string remappedSymdefUuid = analysis.uuidMap.at("symdef-a");
+  assert(remappedSymdefUuid != "symdef-a");
+  const mvr::MvrSceneMergeResult result =
+      mvr::ApplyImportedSceneMerge(target, imported, analysis);
+
+  assert(result.nonObjectLookupConflictsResolved == 1);
+  assert(target.symdefFiles.at("symdef-a") == "symbols/current.3ds");
+  assert(target.symdefFiles.at(remappedSymdefUuid) == "symbols/incoming.3ds");
+  assert(target.trusses.at("incoming-truss").sourceSymdefUuid ==
+         remappedSymdefUuid);
+}
+
 // Verifies imported resource copying preserves target basePath.
 static void VerifyImportedResourcesAreRewrittenIntoTargetBasePath() {
   const std::filesystem::path tempDir = std::filesystem::temp_directory_path() /
@@ -322,6 +414,9 @@ int main() {
   VerifyFixtureTypeGdtfConflictBlocksAutomaticMerge();
   VerifyUseCurrentDefinitionDecisionAppliesToIncomingFixtures();
   VerifyRenameIncomingDefinitionDecisionAppliesToIncomingFixtures();
+  VerifyEmptyLayerUuidReceivesGeneratedUuid();
+  VerifySameLayerNameWithDifferentUuidRenamesIncomingLayer();
+  VerifySymdefUuidCollisionWithDifferentGeometryFilesRemapsSymbol();
   VerifyImportedResourcesAreRewrittenIntoTargetBasePath();
   return 0;
 }


### PR DESCRIPTION
### Motivation
- Prevent lookup-table collisions (layers, positions, symdefs) from silently overwriting current project state during MVR merges by applying explicit remap/rename rules and preserving UI layer state.
- Keep internal merge behavior deterministic and report non-object lookup conflict resolution so callers and UI can show a clear summary.

### Description
- Extend `MvrMergeAnalysis` and `MvrSceneMergeResult` with fields to record layer remaps, incoming-layer renames, skipped incoming layers, and `nonObjectLookupConflictsResolved` for reporting.
- Add deterministic helpers and equality checks in `mvr_merge_analyzer.cpp` (`SortedUnionUuidKeys`, `MatrixValuesEqual`, `SymdefGeometry*Equal`, `SymdefDefinitionsEqual`, `LayerValuesEqual`, and `BuildUniqueImportedLayerName`) and implement `PreparePositionLookupTable`, `PrepareSymdefLookupTables`, and `PrepareLayerTable` to emit computed remaps and rename decisions without mutating the imported scene.
- Update merge application in `mvr_merge_applier.cpp` to remap imported references, apply layer-name renames to object `layer` fields, and add `MergeLayerTable` to materialize layer UUID/name rules when applying the merge; propagate `nonObjectLookupConflictsResolved` into the result.
- Preserve UI layer state during interactive merges by saving/restoring hidden-layer and current-layer state in `MergeMvrFromPath` and include lookup-conflict counts in the import summary; also add focused unit tests for empty-layer-UUID generation, same-layer-name but different-UUID renaming, and symdef UUID collision remapping, and update `docs/release-notes-draft.md` with the fix.

### Testing
- Built and ran the focused unit test binary with: `g++ -std=c++20 -Itests -Imvr -Imodels -Icore -Ithird_party tests/mvr_merge_analyzer_applier_test.cpp mvr/mvr_merge_analyzer.cpp mvr/mvr_merge_applier.cpp mvr/mvr_merge_resource_rewriter.cpp core/uuidutils.cpp models/mvrscene.cpp -o /tmp/mvr_merge_analyzer_applier_test && /tmp/mvr_merge_analyzer_applier_test`, and the test executable completed with all assertions passing.
- Ran repository checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both succeeded.
- Ran `git diff --check` and verified no whitespace or trivial diff errors; note that `cmake` test configuration in this environment could not configure due to missing system `wxWidgets` packages, so the CMake-based test build was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21544c04fc8324bc1f1d18fb6af9fc)