### PR TITLE
Warn on duplicate DMX patch addresses during MVR merge (non-blocking)

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -38,6 +38,7 @@ Changes since `v1.2.0`.
 - Fixed MVR merge resource handling so imported fixture, truss, symbol, and model files remain available after saving and reopening the project.
 - Fixed MVR merge handling for layer, position, and symbol-definition lookup collisions so imported references remain connected without overwriting current project state.
 - Fixed MVR merge rollback so cancelled or failed merges leave the current project, layouts, selection, and dirty state unchanged.
+- Fixed MVR merge feedback so duplicate DMX patch addresses are reported as warnings while the merge still completes.
 - Fixed Windows startup behavior for shell-opened MVR files, including path normalization and startup stalls while scanning for GDTF fallbacks.
 - Fixed layout view freezes and busy-cursor issues caused by reentrant GUI work, render timeouts, mode changes, new project creation, and 2D view edit commits.
 - Fixed layout 2D view editing so edits apply to the intended target view and reliably refresh the layout viewer afterward.

--- a/gui/mainwindow/controllers/mainwindow_io_controller.cpp
+++ b/gui/mainwindow/controllers/mainwindow_io_controller.cpp
@@ -126,6 +126,20 @@ ShowMvrFixtureTypeConflictDialog(wxWindow *parent,
   return mvr::MvrMergeFixtureTypeDecision::UseCurrentDefinition;
 }
 
+// Formats non-blocking duplicate patch warnings for the merge summary.
+std::string FormatMvrMergePatchAddressWarningSummary(
+    const mvr::MvrMergeAnalysis &analysis) {
+  const std::size_t warningCount = analysis.patchAddressWarnings.size();
+  if (warningCount == 0)
+    return {};
+
+  return std::to_string(warningCount) +
+         (warningCount == 1
+              ? " duplicate DMX address warning"
+              : " duplicate DMX address warnings") +
+         "; duplicate patches will be highlighted after reload";
+}
+
 // Shows the user-facing MVR import mode selection dialog.
 MvrImportChoice ShowMvrImportChoiceDialog(wxWindow *parent) {
   wxArrayString choices;
@@ -528,6 +542,10 @@ bool MainWindowIoController::MergeMvrFromPath(const std::string &pathUtf8) {
     if (mergeResult.nonObjectLookupConflictsResolved > 0)
       summary << ", " << mergeResult.nonObjectLookupConflictsResolved
               << " lookup conflicts resolved";
+    const std::string patchWarningSummary =
+        FormatMvrMergePatchAddressWarningSummary(applyAnalysis);
+    if (!patchWarningSummary.empty())
+      summary << "; Warning: " << patchWarningSummary;
     summary << ")";
     owner->consolePanel->AppendMessage(wxString::FromUTF8(summary.str()));
   }

--- a/mvr/mvr_merge_analyzer.cpp
+++ b/mvr/mvr_merge_analyzer.cpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <cctype>
 #include <filesystem>
+#include <optional>
 #include <string_view>
 #include <vector>
 
@@ -148,6 +149,80 @@ SortedUuidKeys(const std::unordered_map<std::string, T> &objects) {
     keys.push_back(entry.first);
   std::sort(keys.begin(), keys.end());
   return keys;
+}
+
+struct ParsedPatchAddress {
+  int universe = 0;
+  int channel = 0;
+};
+
+// Parses a fixture DMX address token into a valid universe and channel pair.
+std::optional<ParsedPatchAddress> ParseFixturePatchAddress(
+    const std::string &address) {
+  const std::string trimmed = TrimAscii(address);
+  if (trimmed.empty())
+    return std::nullopt;
+
+  const size_t dot = trimmed.find('.');
+  if (dot == std::string::npos)
+    return std::nullopt;
+
+  try {
+    const int universe = std::stoi(trimmed.substr(0, dot));
+    const int channel = std::stoi(trimmed.substr(dot + 1));
+    if (universe < 1 || channel < 1 || channel > 512)
+      return std::nullopt;
+    return ParsedPatchAddress{universe, channel};
+  } catch (...) {
+    return std::nullopt;
+  }
+}
+
+// Builds a stable string key for a parsed DMX patch address.
+std::string BuildPatchAddressKey(const ParsedPatchAddress &address) {
+  return std::to_string(address.universe) + "." +
+         std::to_string(address.channel);
+}
+
+// Adds non-blocking warnings for incoming fixtures that reuse current patches.
+void AnalyzePatchAddressWarnings(const MvrScene &target,
+                                 const MvrScene &imported,
+                                 MvrMergeAnalysis &analysis) {
+  std::unordered_map<std::string, std::vector<std::string>> currentByAddress;
+  const std::vector<std::string> currentFixtureUuids =
+      SortedUuidKeys(target.fixtures);
+  for (const std::string &uuid : currentFixtureUuids) {
+    const auto parsedAddress =
+        ParseFixturePatchAddress(target.fixtures.at(uuid).address);
+    if (!parsedAddress.has_value())
+      continue;
+    currentByAddress[BuildPatchAddressKey(*parsedAddress)].push_back(uuid);
+  }
+
+  const std::vector<std::string> incomingFixtureUuids =
+      SortedUuidKeys(imported.fixtures);
+  for (const std::string &incomingUuid : incomingFixtureUuids) {
+    if (analysis.skippedIncomingUuids.contains(incomingUuid))
+      continue;
+    const auto parsedAddress =
+        ParseFixturePatchAddress(imported.fixtures.at(incomingUuid).address);
+    if (!parsedAddress.has_value())
+      continue;
+
+    const auto currentIt =
+        currentByAddress.find(BuildPatchAddressKey(*parsedAddress));
+    if (currentIt == currentByAddress.end())
+      continue;
+    const std::string resolvedIncomingUuid =
+        RemapImportedUuidReference(incomingUuid, analysis);
+    for (const std::string &currentUuid : currentIt->second) {
+      if (currentUuid == resolvedIncomingUuid)
+        continue;
+      analysis.patchAddressWarnings.push_back(MvrMergePatchAddressWarning{
+          parsedAddress->universe, parsedAddress->channel, currentUuid,
+          incomingUuid});
+    }
+  }
 }
 
 // Returns sorted UUID keys from all maps in a lookup family.
@@ -511,6 +586,7 @@ MvrMergeAnalysis AnalyzeImportedSceneMerge(const MvrScene &target,
   PrepareObjectTable(imported.groupObjects, "groupObjects", usedUuids, analysis,
                      options);
   PrepareLayerTable(target, imported, usedUuids, analysis, options);
+  AnalyzePatchAddressWarnings(target, imported, analysis);
 
   for (const auto &[oldUuid, newUuid] : analysis.uuidMap) {
     if (oldUuid != newUuid && imported.fixtures.contains(oldUuid))

--- a/mvr/mvr_merge_analyzer.h
+++ b/mvr/mvr_merge_analyzer.h
@@ -62,6 +62,15 @@ struct MvrFixtureTypeConflict {
   std::string suggestedIncomingTypeName;
 };
 
+// Describes a non-blocking duplicate DMX patch address found during merge
+// analysis.
+struct MvrMergePatchAddressWarning {
+  int universe = 0;
+  int channel = 0;
+  std::string currentFixtureUuid;
+  std::string incomingFixtureUuid;
+};
+
 enum class MvrMergeUuidCollisionBehavior {
   GenerateStableUuid,
   ReplaceExisting,
@@ -82,6 +91,7 @@ struct MvrMergeAnalysis {
   std::unordered_map<std::string, MvrFixtureTypeIdentity> currentFixtureTypes;
   std::unordered_map<std::string, MvrFixtureTypeIdentity> incomingFixtureTypes;
   std::vector<MvrFixtureTypeConflict> fixtureTypeConflicts;
+  std::vector<MvrMergePatchAddressWarning> patchAddressWarnings;
   std::unordered_map<std::string, MvrMergeFixtureTypeDecision>
       fixtureTypeDecisions;
   std::unordered_map<std::string, std::string> incomingFixtureTypeRenames;

--- a/tests/mvr_merge_analyzer_applier_test.cpp
+++ b/tests/mvr_merge_analyzer_applier_test.cpp
@@ -407,6 +407,37 @@ static void VerifyImportedResourcesAreRewrittenIntoTargetBasePath() {
       ResourceExists(reloadedBase, mergedObject.geometries.front().modelFile));
 }
 
+// Verifies duplicate patch addresses are warnings and do not block apply.
+static void VerifyDuplicatePatchAddressWarningDoesNotBlockMerge() {
+  MvrScene target;
+  target.fixtures["current-fixture"] =
+      MakeFixture("current-fixture", "current-position");
+  target.fixtures.at("current-fixture").address = "1.25";
+
+  MvrScene imported;
+  imported.fixtures["incoming-fixture"] =
+      MakeFixture("incoming-fixture", "incoming-position");
+  imported.fixtures.at("incoming-fixture").address = "1.25";
+
+  const mvr::MvrMergeAnalysis analysis =
+      mvr::AnalyzeImportedSceneMerge(target, imported);
+  assert(analysis.patchAddressWarnings.size() == 1);
+  assert(analysis.patchAddressWarnings.front().universe == 1);
+  assert(analysis.patchAddressWarnings.front().channel == 25);
+  assert(analysis.patchAddressWarnings.front().currentFixtureUuid ==
+         "current-fixture");
+  assert(analysis.patchAddressWarnings.front().incomingFixtureUuid ==
+         "incoming-fixture");
+  assert(!mvr::HasBlockingFixtureTypeConflicts(analysis));
+
+  const mvr::MvrSceneMergeResult result =
+      mvr::ApplyImportedSceneMerge(target, imported, analysis);
+  assert(result.fixtureTypeConflictsBlocked == 0);
+  assert(result.fixturesAdded == 1);
+  assert(target.fixtures.count("incoming-fixture") == 1);
+  assert(target.fixtures.at("incoming-fixture").address == "1.25");
+}
+
 // Verifies a cancelled merge leaves the target scene untouched before apply.
 static void VerifyCancelBeforeApplyLeavesTargetUnchanged() {
   MvrScene target;
@@ -477,6 +508,7 @@ int main() {
   VerifySameLayerNameWithDifferentUuidRenamesIncomingLayer();
   VerifySymdefUuidCollisionWithDifferentGeometryFilesRemapsSymbol();
   VerifyImportedResourcesAreRewrittenIntoTargetBasePath();
+  VerifyDuplicatePatchAddressWarningDoesNotBlockMerge();
   VerifyCancelBeforeApplyLeavesTargetUnchanged();
   VerifyFailureDuringApplyLeavesTargetUnchanged();
   return 0;


### PR DESCRIPTION
### Motivation
- Prevent imported fixtures from being blocked by DMX patch overlaps while still informing users when incoming fixtures reuse existing DMX addresses. 
- Surface the duplicate-patch count in the merge summary so users know the fixture table will visually highlight the rows after UI reload. 
- Add regression coverage to ensure duplicate patch detection is treated as a warning and does not stop merge application.

### Description
- Add a non-blocking `MvrMergePatchAddressWarning` record to `MvrMergeAnalysis` and detect duplicate DMX patch addresses during `AnalyzeImportedSceneMerge` via a new `AnalyzePatchAddressWarnings` helper. 
- Implement address parsing and stable address-key building with `ParseFixturePatchAddress` and `BuildPatchAddressKey`, and avoid reporting warnings when an incoming fixture UUID resolves to the same remapped UUID. 
- Append a small formatter `FormatMvrMergePatchAddressWarningSummary` to `MainWindowIoController` and include the warning summary text in the merge confirmation console message so users are informed that duplicate patches exist and will be highlighted after reload. 
- Add a test `VerifyDuplicatePatchAddressWarningDoesNotBlockMerge` to `tests/mvr_merge_analyzer_applier_test.cpp` that asserts a detected duplicate patch creates a warning entry but still allows `ApplyImportedSceneMerge` to add the incoming fixture. 
- Update `docs/release-notes-draft.md` with a short user-facing entry describing the new non-blocking duplicate-patch warning behavior.

### Testing
- Ran project checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both reported `OK` in this environment. 
- Built and executed the standalone merge analyzer/applier test binary via a direct `g++` invocation and ran the test suite (`mvr_merge_analyzer_applier_test`), which completed successfully (all assertions passed). 
- Attempted a full `cmake` + `ctest` build of the test target but configuration failed in this environment due to missing `wxWidgets` (`wxWidgets_LIBRARIES` / `wxWidgets_INCLUDE_DIRS`), so full CMake-based test invocation was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a218675e10083249c2f1ef207fcd464)