### PR TITLE
Document MVR merge import choices and warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ The README is intentionally kept fairly compact. More detailed documentation liv
 
 - [Documentation policy](docs/documentation_policy.md)
 - [Feature overview](docs/features.md)
+- [Opening and merging MVR files](docs/opening-mvr-files.md)
+- [MVR exporter warning behavior](docs/mvr_exporter.md)
 - [Changes since beta 0.1.0](docs/changes_since_beta_0_1_0.md)
 - [Build and dependency guide](docs/build.md)
 - [Windows installation notes](docs/installation_windows.md)

--- a/docs/features.md
+++ b/docs/features.md
@@ -32,7 +32,7 @@ Perastage is designed for lighting designers, programmers, and technicians who n
 - Imports MVR 1.6 scenes with fixtures, trusses, hoists/supports, and generic objects.
 - `.mvr` opening from startup, command-line, or OS association uses a clean-scene reset plus import flow for deterministic behavior.
 - Menu import lets you choose between opening the selected MVR as a new project or merging it into the current project.
-- Merged MVR content preserves existing scene content, resolves imported UUID collisions so both scenes can coexist, and blocks fixture type name conflicts until the user chooses whether to reuse the current GDTF definition, rename the imported definition, or cancel.
+- Merged MVR content preserves existing scene content, resolves imported UUID collisions so both scenes can coexist, prompts before fixture type/GDTF definition conflicts are applied, and reports duplicate DMX patch addresses as non-blocking warnings for post-merge review.
 
 ### MVR export
 

--- a/docs/opening-mvr-files.md
+++ b/docs/opening-mvr-files.md
@@ -7,13 +7,49 @@ Perastage is built for MVR-centered workflows.
 Use one of these methods:
 
 - Open an existing `.mvr` file directly.
-- Use **File → Import MVR...**. After choosing a file, select **Open as new project** to replace the current scene or **Merge into current project** to add the selected MVR content to the current scene.
-
-When merging, Perastage checks imported object UUIDs against the current project and gives colliding imported objects stable replacement UUIDs by default. If collisions are found, you can instead choose to replace existing project objects or skip incoming colliding objects. Perastage also compares fixture type names against their resolved GDTF definitions before applying the merge. If the imported MVR uses the same fixture type name for a different GDTF file or mode, Perastage asks whether to use the current project definition for those imported fixtures, keep the imported definition under a renamed fixture type, or cancel the merge. References inside the imported content, such as positions, group children, layers, and hoist motor links, are updated so the merged scene remains connected while existing project objects are preserved. Referenced imported resources such as GDTF files, truss archives, symbols, and 3D models are copied into the current project resource area and rewritten when needed, so existing and imported resources still resolve after saving and reopening the project.
+- Use **File → Import MVR...** to choose how the selected MVR should enter the project.
 
 Opening an `.mvr` file directly from the command line, operating system file association, or startup path uses the clean **Open as new project** behavior.
 
 After import, review fixtures, trusses, hoists, objects, and layout information in the available views and tables.
+
+## Import choices
+
+When you import from the **File** menu, Perastage asks which workflow you want to use:
+
+- **Open as new project** replaces the current scene with the selected MVR, after the usual dirty-project checks.
+- **Merge into current project** keeps the current project and adds supported content from the selected MVR.
+- Cancelling the choice leaves the current project unchanged.
+
+## Merge behavior and prompts
+
+Merging is designed to preserve the current project unless you explicitly choose a different conflict policy. Before applying a merge, Perastage imports the selected MVR into a temporary scene, analyzes conflicts, and only then applies the result to the live project. If a merge is cancelled or fails, the current project, layouts, selection, hidden layers, active layer, and dirty state are restored.
+
+### UUID conflicts
+
+If imported objects use UUIDs that already exist in the current project, Perastage prompts you to choose how to continue:
+
+- **Create new UUIDs for imported objects** keeps both scenes by assigning stable replacement UUIDs to the incoming colliding objects. This is the default and safest choice for additive merges.
+- **Replace existing project objects** lets incoming colliding objects take the place of matching current-project objects.
+- **Skip incoming colliding objects** keeps the current objects and ignores incoming objects with the same UUIDs.
+
+Perastage updates references inside the imported content, including positions, group children, layers, symbols, and hoist motor links, so the merged scene remains connected after UUID decisions are applied. Lookup data such as positions, layers, and symbol definitions is also handled without overwriting unrelated current-project state.
+
+### Fixture type and GDTF conflicts
+
+Perastage compares fixture type names against their resolved GDTF definitions before the merge is applied. If the imported MVR uses the same fixture type name as the current project but points to a different GDTF file, GDTF mode, or file content, Perastage prompts you to decide how every incoming fixture of that type should be resolved:
+
+- **Use current project definition for imported fixtures** maps the imported fixtures to the current project's fixture type, GDTF file, and mode.
+- **Keep imported definition by renaming it** preserves the imported GDTF decision under a generated fixture type name, such as `Example Type (Imported)`, so both definitions can coexist.
+- **Cancel merge** stops the merge before any live project changes are applied.
+
+### Non-blocking duplicate patch warnings
+
+Duplicate DMX patch addresses do not block a merge. If incoming fixtures reuse patch addresses that already exist in the current project, Perastage completes the merge and reports a warning summary in the console. The warning tells you how many duplicate DMX address cases were found so you can review and resolve patch conflicts after the merged scene reloads.
+
+### Imported resource handling
+
+Referenced imported resources such as GDTF files, truss archives, symbols, and 3D models are copied into the current project resource area and rewritten when needed. This keeps existing and imported resources resolvable after saving and reopening the project.
 
 ## Perastage project files
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -18,8 +18,7 @@ Changes since `v1.2.0`.
 - Added fixture replacement from the Edit menu, including improved source labeling, transform preservation, selection stability, UUID handling, and color reuse/autocolor behavior.
 - Added support for packaging referenced layout images into project archives, making `.pstg` project files more portable when shared or reopened elsewhere.
 - Added an MVR import choice so users can open a selected MVR as a new project or merge it into the current project.
-- Improved MVR merge safety so imported objects with UUIDs that already exist in the current project receive stable replacement UUIDs while their internal references stay connected.
-- Added MVR merge protection for fixture type name conflicts, prompting users to reuse the current GDTF definition, keep the imported definition under a renamed type, or cancel before mixed definitions can enter the scene.
+- Improved MVR merge safety with user choices for UUID collisions, fixture type and GDTF definition conflicts, stable reference updates, rollback on cancellation, resource preservation, and non-blocking duplicate DMX patch warnings after merge.
 
 ## Improvements
 


### PR DESCRIPTION
### Motivation
- Make the new MVR import/merge UX discoverable by documenting the import-mode choices and their effects for end users. 
- Explain the interactive merge conflict prompts and non-blocking patch warnings introduced by the merge implementation so users know how decisions are applied. 
- Keep release notes and top-level README links in sync with the implemented MVR merge behavior. 

### Description
- Added detailed guidance to `docs/opening-mvr-files.md` describing the `Open as new project` vs `Merge into current project` choices, the preflight analysis/rollback behavior, UUID collision choices, fixture type/GDTF conflict decisions, non-blocking duplicate DMX patch warnings, and imported resource handling. 
- Updated `docs/features.md` to mention fixture type/GDTF conflict prompts and non-blocking duplicate patch warnings in the MVR workflow summary. 
- Refined `docs/release-notes-draft.md` to include a user-facing release-ready entry summarizing MVR merge safety, conflict choices, rollback, resource preservation, and patch warnings for v1.3.0. 
- Updated `README.md` to surface links to the new `Opening and merging MVR files` doc and the `MVR exporter warning behavior` doc. 

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which completed successfully. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which completed successfully. 
- Ran `git diff --check` to ensure no whitespace or diff issues, which returned clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2189cb8dcc8324a02c2006f6f516ed)