### PR TITLE
Modernize About dialog

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -22,6 +22,7 @@ Changes since `v1.2.0`.
 
 ## Improvements
 
+- Modernized the About dialog with clearer product information, a project website link, license details, author attribution, and a concise open-source notice.
 - Improved 2D layout performance when opening projects, zooming, navigating views, resizing legends, rebuilding render caches, and working with fixture labels or image-heavy layouts.
 - Improved first-load layout startup by reusing validated selected-layout cache data and bounded CPU-side raster snapshots across the visible 2D views, restoring the saved active layout before the layout list refreshes, suppressing pre-project fallback layout draws, and reducing intermediate placeholder redraws while keeping packaged GDTF, MVR, and SVG assets authoritative.
 - Improved project symbol-cache persistence so verified or newly generated fixture symbols in project GDTF files are recorded and saved, reducing repeated symbol regeneration on later opens.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -34,6 +34,7 @@ Changes since `v1.2.0`.
 
 ## Fixes
 
+- Fixed an About dialog startup assertion when locating the Perastage logo on wxWidgets debug builds.
 - Fixed MVR export before saving a project so resource references are synchronized before export.
 - Fixed MVR merge resource handling so imported fixture, truss, symbol, and model files remain available after saving and reopening the project.
 - Fixed MVR merge handling for layer, position, and symbol-definition lookup collisions so imported references remain connected without overwriting current project state.

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(${PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/about_dialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/addfixturedialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/addressdialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/columnselectiondialog.cpp

--- a/gui/about_dialog.cpp
+++ b/gui/about_dialog.cpp
@@ -55,7 +55,9 @@ FindRuntimeAsset(const std::initializer_list<wxString> &relativePaths) {
 
   for (const wxString &root : roots) {
     for (const wxString &relativePath : relativePaths) {
-      wxFileName candidate(root, relativePath);
+      const wxString fullPath =
+          wxFileName(root, wxEmptyString).GetPathWithSep() + relativePath;
+      wxFileName candidate(fullPath);
       candidate.Normalize(wxPATH_NORM_DOTS | wxPATH_NORM_ABSOLUTE);
       if (candidate.FileExists()) {
         return candidate.GetFullPath();

--- a/gui/about_dialog.cpp
+++ b/gui/about_dialog.cpp
@@ -1,0 +1,186 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "about_dialog.h"
+
+#include "app_version.h"
+
+#include <initializer_list>
+
+#include <wx/arrstr.h>
+#include <wx/artprov.h>
+#include <wx/button.h>
+#include <wx/dialog.h>
+#include <wx/filefn.h>
+#include <wx/filename.h>
+#include <wx/hyperlink.h>
+#include <wx/image.h>
+#include <wx/sizer.h>
+#include <wx/statbmp.h>
+#include <wx/statline.h>
+#include <wx/stattext.h>
+#include <wx/stdpaths.h>
+
+namespace {
+
+constexpr const char *kProjectWebsiteUrl =
+    "https://perastage.luismaperamato.com/";
+constexpr int kLogoSizeDip = 128;
+constexpr int kDialogWidthDip = 620;
+
+// Finds the first existing runtime asset path.
+wxString
+FindRuntimeAsset(const std::initializer_list<wxString> &relativePaths) {
+  wxArrayString roots;
+  roots.Add(wxGetCwd());
+
+  wxFileName executable(wxStandardPaths::Get().GetExecutablePath());
+  roots.Add(executable.GetPath());
+  roots.Add(executable.GetPathWithSep() + "resources");
+  roots.Add(executable.GetPathWithSep() + "../Resources");
+
+  for (const wxString &root : roots) {
+    for (const wxString &relativePath : relativePaths) {
+      wxFileName candidate(root, relativePath);
+      candidate.Normalize(wxPATH_NORM_DOTS | wxPATH_NORM_ABSOLUTE);
+      if (candidate.FileExists()) {
+        return candidate.GetFullPath();
+      }
+    }
+  }
+
+  for (const wxString &relativePath : relativePaths) {
+    if (wxFileExists(relativePath)) {
+      return relativePath;
+    }
+  }
+
+  return wxString();
+}
+
+// Loads the Perastage logo bitmap at the requested device-independent size.
+wxBitmap LoadLogoBitmap(wxWindow *parent) {
+  const wxString logoPath =
+      FindRuntimeAsset({"resources/Perastage_logo.png", "Perastage_logo.png"});
+  const int logoSize = parent->FromDIP(kLogoSizeDip);
+  if (logoPath.empty()) {
+    return wxArtProvider::GetBitmap(wxART_INFORMATION, wxART_OTHER,
+                                    wxSize(logoSize, logoSize));
+  }
+
+  wxImage logoImage;
+  if (!logoImage.LoadFile(logoPath, wxBITMAP_TYPE_PNG) || !logoImage.IsOk()) {
+    return wxArtProvider::GetBitmap(wxART_INFORMATION, wxART_OTHER,
+                                    wxSize(logoSize, logoSize));
+  }
+
+  logoImage.Rescale(logoSize, logoSize, wxIMAGE_QUALITY_HIGH);
+  return wxBitmap(logoImage);
+}
+
+// Creates a bold static text control used for section headings.
+wxStaticText *CreateSectionLabel(wxWindow *parent, const wxString &label) {
+  auto *text = new wxStaticText(parent, wxID_ANY, label);
+  wxFont font = text->GetFont();
+  font.SetWeight(wxFONTWEIGHT_BOLD);
+  text->SetFont(font);
+  return text;
+}
+
+// Adds a labeled text block to the dialog content column.
+void AddSection(wxWindow *parent, wxBoxSizer *sizer, const wxString &label,
+                const wxString &body) {
+  sizer->Add(CreateSectionLabel(parent, label), 0, wxTOP, parent->FromDIP(10));
+  auto *bodyText = new wxStaticText(parent, wxID_ANY, body);
+  bodyText->Wrap(parent->FromDIP(380));
+  sizer->Add(bodyText, 0, wxEXPAND | wxTOP, parent->FromDIP(3));
+}
+
+// Builds and returns the user-facing About dialog content panel.
+wxSizer *CreateAboutContent(wxDialog *dialog) {
+  auto *rootSizer = new wxBoxSizer(wxHORIZONTAL);
+  rootSizer->Add(new wxStaticBitmap(dialog, wxID_ANY, LoadLogoBitmap(dialog)),
+                 0, wxALIGN_TOP | wxRIGHT, dialog->FromDIP(24));
+
+  auto *contentSizer = new wxBoxSizer(wxVERTICAL);
+
+  const wxString titleText = wxString::FromUTF8(app::kName) + " " +
+                             wxString::FromUTF8(app::kVersionDisplay);
+  auto *title = new wxStaticText(dialog, wxID_ANY, titleText);
+  wxFont titleFont = title->GetFont();
+  titleFont.MakeBold();
+  titleFont.SetPointSize(titleFont.GetPointSize() + 4);
+  title->SetFont(titleFont);
+  contentSizer->Add(title, 0, wxEXPAND);
+
+  auto *description = new wxStaticText(
+      dialog, wxID_ANY,
+      "Free and open-source MVR viewer/editor for lighting and stage projects, "
+      "with integrated 2D/3D visualization, MVR import/export, and Create from "
+      "Text tools.");
+  description->Wrap(dialog->FromDIP(380));
+  contentSizer->Add(description, 0, wxEXPAND | wxTOP, dialog->FromDIP(8));
+
+  contentSizer->Add(new wxStaticLine(dialog), 0, wxEXPAND | wxTOP | wxBOTTOM,
+                    dialog->FromDIP(12));
+
+  contentSizer->Add(CreateSectionLabel(dialog, "Website"), 0, wxBOTTOM,
+                    dialog->FromDIP(3));
+  contentSizer->Add(new wxHyperlinkCtrl(dialog, wxID_ANY, kProjectWebsiteUrl,
+                                        kProjectWebsiteUrl),
+                    0, wxEXPAND);
+
+  AddSection(
+      dialog, contentSizer, "License",
+      "This software is licensed under the GNU General Public License v3.0.");
+  AddSection(dialog, contentSizer, "Author", "Luisma Peramato");
+  AddSection(
+      dialog, contentSizer, "Open-source software notice",
+      "Perastage is built with open-source technologies. Full dependency "
+      "and license details are available in the project repository.");
+
+  rootSizer->Add(contentSizer, 1, wxEXPAND);
+  return rootSizer;
+}
+
+} // namespace
+
+// Shows the modern Perastage About dialog.
+void gui::ShowAboutDialog(wxWindow *parent) {
+  wxDialog dialog(parent, wxID_ANY, "About Perastage", wxDefaultPosition,
+                  wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER);
+
+  auto *dialogSizer = new wxBoxSizer(wxVERTICAL);
+  dialogSizer->Add(CreateAboutContent(&dialog), 1, wxEXPAND | wxALL,
+                   dialog.FromDIP(18));
+
+  auto *buttonSizer = dialog.CreateSeparatedButtonSizer(wxOK);
+  if (buttonSizer) {
+    dialogSizer->Add(buttonSizer, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM,
+                     dialog.FromDIP(12));
+  }
+
+  dialog.SetSizerAndFit(dialogSizer);
+  const wxSize fittedSize = dialog.GetSize();
+  const int minimumWidth = dialog.FromDIP(kDialogWidthDip);
+  dialog.SetMinSize(wxSize(minimumWidth, fittedSize.GetHeight()));
+  if (fittedSize.GetWidth() < minimumWidth) {
+    dialog.SetSize(wxSize(minimumWidth, fittedSize.GetHeight()));
+  }
+  dialog.CentreOnParent();
+  dialog.ShowModal();
+}

--- a/gui/about_dialog.h
+++ b/gui/about_dialog.h
@@ -1,0 +1,27 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+class wxWindow;
+
+namespace gui {
+
+// Shows the modern Perastage About dialog.
+void ShowAboutDialog(wxWindow *parent);
+
+} // namespace gui

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
+#include "about_dialog.h"
 #include "mainwindow.h"
 #include "mainwindow/controllers/mainwindow_io_controller.h"
 #include "mainwindow_view_controller.h"
@@ -35,7 +36,6 @@
 #include <thread>
 #include <vector>
 
-#include <wx/aboutdlg.h>
 #include <wx/artprov.h>
 #include <wx/busyinfo.h>
 #include <wx/choice.h>
@@ -44,7 +44,6 @@
 #include <wx/filename.h>
 #include <wx/filefn.h>
 #include <wx/html/htmlwin.h>
-#include <wx/iconbndl.h>
 #include <wx/numdlg.h>
 #include <wx/stdpaths.h>
 #include <wx/utils.h>
@@ -53,7 +52,6 @@
 #include "addfixturedialog.h"
 #include "autopatcher.h"
 #include "ui_feature_flags.h"
-#include "app_version.h"
 #include "configmanager.h"
 #include "guiconfigservices.h"
 #include "consolepanel.h"
@@ -1021,37 +1019,7 @@ void MainWindow::OnCheckForUpdates(wxCommandEvent &WXUNUSED(event)) {
 
 // Displays the application About dialog.
 void MainWindow::OnShowAbout(wxCommandEvent &WXUNUSED(event)) {
-  wxAboutDialogInfo info;
-  info.SetName(app::kName);
-  info.SetVersion(app::kVersionDisplay);
-  wxString description =
-      "MVR viewer/editor with integrated 2D/3D workflows, MVR import/export, "
-      "and Create from text tools.\n\n"
-      "This application makes use of the following open-source libraries:\n"
-      "  - wxWidgets\n"
-      "  - tinyxml2\n"
-      "  - nlohmann-json\n"
-      "  - OpenGL-based 3D rendering";
-  info.SetDescription(description);
-  info.SetWebSite("https://perastage.luismaperamato.com/");
-  info.AddDeveloper("Luisma Peramato");
-  info.SetLicence(
-      "This software is licensed under the GNU General Public License v3.0.");
-
-  // Load the largest available icon
-  wxIconBundle bundle;
-  const wxString iconPaths[] = {"resources/Perastage.ico",
-                                "../resources/Perastage.ico",
-                                "../../resources/Perastage.ico"};
-  for (const wxString &path : iconPaths) {
-    if (wxFileExists(path))
-      bundle.AddIcon(path, wxBITMAP_TYPE_ICO);
-  }
-  wxIcon icon = bundle.GetIcon(wxSize(256, 256));
-  if (icon.IsOk())
-    info.SetIcon(icon);
-
-  wxAboutBox(info, this);
+  gui::ShowAboutDialog(this);
 }
 
 // Switches the notebook to the fixtures tab.


### PR DESCRIPTION
### Motivation
- Refresh the About dialog to present a professional, readable UI that keeps the logo at the left and avoids a raw dependency list while preserving user-facing license and author information.
- Make the dialog modular and easier to maintain by moving UI construction out of the large `mainwindow_menu.cpp` hotspot and into a focused component.

### Description
- Added a new modular About dialog implementation in `gui/about_dialog.h` and `gui/about_dialog.cpp` that builds a left-aligned logo, product title using the existing `app::kName`/`app::kVersionDisplay` constants, a short description, a clickable website link, `GPL v3.0` license text, `Author`, and a concise open-source software notice.
- Implemented reusable helpers for runtime asset lookup (`FindRuntimeAsset`), scaled logo loading (`LoadLogoBitmap`), section headings and content (`CreateSectionLabel`, `AddSection`), and composed the dialog via `CreateAboutContent` and `gui::ShowAboutDialog`.
- Rewired the existing `MainWindow::OnShowAbout` to call `gui::ShowAboutDialog(this)` so the large menu file no longer constructs About content inline, and added the new source explicitly to `gui/CMakeLists.txt`.
- Updated `docs/release-notes-draft.md` with a short user-facing entry about the modernized About dialog and added concise English one-line comments above each new function as requested.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (OK).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (OK).
- Verified `git diff --check` (no issues reported) and used `clang-format` on added files where applicable.
- Attempted `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug` but configuration is blocked in this environment because wxWidgets development files are not available; the change only adds a GUI source file and should build in a normal development environment with wxWidgets installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a218d0fa22483248bfbef5ead1349bf)