### PR TITLE
Preserve original MVR fixture identity for GDTF download matching

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -34,6 +34,7 @@ Changes since `v1.2.0`.
 
 ## Fixes
 
+- Fixed automatic GDTF download matching during MVR import so fixtures with generic embedded GDTF metadata can still match the original fixture names from the MVR file.
 - Fixed an About dialog startup assertion when locating the Perastage logo on wxWidgets debug builds.
 - Fixed MVR export before saving a project so resource references are synchronized before export.
 - Fixed MVR merge resource handling so imported fixture, truss, symbol, and model files remain available after saving and reopening the project.

--- a/models/fixture.h
+++ b/models/fixture.h
@@ -25,6 +25,7 @@ struct Fixture {
     std::string uuid;             // Unique identifier from the MVR file
     std::string instanceName;     // Name of this fixture instance (from MVR)
     std::string typeName;         // GDTF fixture type name
+    std::string requestedFixtureName; // Original MVR fixture name used for matching
     std::string gdtfSpec;         // GDTF file name
     std::string gdtfMode;         // GDTF mode name (optional)
     std::string focus;            // Focus reference UUID (optional)

--- a/mvr/gdtf_import_matching.h
+++ b/mvr/gdtf_import_matching.h
@@ -1,0 +1,72 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <algorithm>
+#include <filesystem>
+#include <string>
+
+namespace mvr {
+namespace gdtf_import_matching {
+
+// Trims whitespace from an MVR fixture identity candidate.
+inline std::string TrimFixtureIdentity(const std::string &value) {
+  const char *whitespace = " \t\r\n";
+  const size_t start = value.find_first_not_of(whitespace);
+  if (start == std::string::npos)
+    return {};
+  const size_t end = value.find_last_not_of(whitespace);
+  return value.substr(start, end - start + 1);
+}
+
+// Normalizes path separators before deriving a fixture identity from GDTFSpec.
+inline std::string NormalizeGdtfSpecSeparators(std::string gdtfSpec) {
+  std::replace(gdtfSpec.begin(), gdtfSpec.end(), '\\', '/');
+  return gdtfSpec;
+}
+
+// Extracts the most useful fixture name candidate from an MVR GDTFSpec value.
+inline std::string ExtractFixtureNameFromGdtfSpec(const std::string &gdtfSpec) {
+  const std::string normalized = TrimFixtureIdentity(NormalizeGdtfSpecSeparators(gdtfSpec));
+  if (normalized.empty())
+    return {};
+  const std::filesystem::path specPath(normalized);
+  std::string stem = specPath.filename().stem().string();
+  return TrimFixtureIdentity(stem);
+}
+
+// Selects the original MVR fixture identity to use for automatic GDTF matching.
+inline std::string SelectRequestedFixtureName(const std::string &rawFixtureNodeName,
+                                              const std::string &rawGdtfSpec) {
+  const std::string fixtureNodeName = TrimFixtureIdentity(rawFixtureNodeName);
+  if (!fixtureNodeName.empty())
+    return fixtureNodeName;
+  return ExtractFixtureNameFromGdtfSpec(rawGdtfSpec);
+}
+
+// Selects the fixture name searched in the GDTF catalog, falling back to type.
+inline std::string SelectDownloadSearchFixtureName(const std::string &requestedFixtureName,
+                                                   const std::string &fixtureTypeName) {
+  const std::string requested = TrimFixtureIdentity(requestedFixtureName);
+  if (!requested.empty())
+    return requested;
+  return TrimFixtureIdentity(fixtureTypeName);
+}
+
+} // namespace gdtf_import_matching
+} // namespace mvr

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -27,6 +27,7 @@
 #endif
 #include "gdtfloader.h"
 #include "gdtf_catalog_service.h"
+#include "gdtf_import_matching.h"
 #include "gdtf_fixture_category.h"
 #include "matrixutils.h"
 #include "primitive_model_resources.h"
@@ -503,6 +504,7 @@ static void LogMessage(const std::string &msg) {
 
 struct GdtfConflict {
   std::string type;
+  std::string requestedFixtureName;
   std::string mvrPath;
   std::string appPath;
   std::string manufacturer;
@@ -2024,6 +2026,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
   int trussSymbolSymdefPreservedCount = 0;
   std::unordered_map<std::string, int> trussSymbolSymdefPreservedBySymdef;
 
+  // Parses a Fixture XML node into scene data while preserving its original matching identity.
   std::function<void(tinyxml2::XMLElement *, const std::string &, const Matrix &)>
       parseFixture = [&](tinyxml2::XMLElement *node,
                          const std::string &layerName,
@@ -2039,8 +2042,11 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         fixture.layer = layerName;
         fixture.transform = nodeTransform;
 
-        if (const char *nameAttr = node->Attribute("name"))
-          fixture.instanceName = nameAttr;
+        const char *nameAttr = node->Attribute("name");
+        const std::string rawFixtureNodeName =
+            nameAttr ? Trim(nameAttr) : std::string{};
+        if (!rawFixtureNodeName.empty())
+          fixture.instanceName = rawFixtureNodeName;
 
         fixtureIdOf(node, fixture.fixtureIdText, fixture.fixtureIdNumeric);
         fixture.fixtureId = fixture.fixtureIdNumeric;
@@ -2049,7 +2055,11 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         intOf(node, "CustomIdType", fixture.customIdType);
 
         fixture.gdtfSpec = textOf(node, "GDTFSpec");
+        const std::string rawGdtfSpec = fixture.gdtfSpec;
         fixture.gdtfMode = textOf(node, "GDTFMode");
+        fixture.requestedFixtureName =
+            mvr::gdtf_import_matching::SelectRequestedFixtureName(rawFixtureNodeName,
+                                                                 rawGdtfSpec);
         fixture.focus = textOf(node, "Focus");
         fixture.function = textOf(node, "Function");
         fixture.position = CanonicalizeUuid(textOf(node, "Position"));
@@ -2155,6 +2165,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
           pendingGdtfConflictByType.try_emplace(
               fixture.typeName,
               GdtfConflict{fixture.typeName,
+                           fixture.requestedFixtureName,
                            fixture.gdtfSpec,
                            dictionaryEntry->path,
                            "",
@@ -2815,6 +2826,13 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
       conflict.type = f.typeName;
       if (conflict.mvrPath.empty())
         conflict.mvrPath = f.gdtfSpec;
+      if (conflict.requestedFixtureName.empty()) {
+        conflict.requestedFixtureName =
+            f.requestedFixtureName.empty()
+                ? mvr::gdtf_import_matching::ExtractFixtureNameFromGdtfSpec(
+                      f.gdtfSpec)
+                : f.requestedFixtureName;
+      }
       if (conflict.fixtureName.empty())
         conflict.fixtureName = f.typeName;
       if (conflict.modeName.empty())
@@ -3307,7 +3325,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                   bool bestUsedRecencyTiebreak = false;
                   for (const auto &entry : catalogEntries) {
                     const std::string requestedFixtureName =
-                        req.fixtureName.empty() ? req.type : req.fixtureName;
+                        mvr::gdtf_import_matching::SelectDownloadSearchFixtureName(
+                            req.requestedFixtureName, req.type);
                     const int nameScore = ComputeFixtureNameMatchScore(
                         entry.fixtureName, requestedFixtureName);
                     if (nameScore <= 0) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -418,6 +418,10 @@ target_include_directories(rider_truss_dictionary_normalization_test PRIVATE
 target_link_libraries(rider_truss_dictionary_normalization_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
 add_test(NAME RiderTrussDictionaryNormalization COMMAND rider_truss_dictionary_normalization_test)
 
+add_executable(mvr_gdtf_import_matching_test mvr_gdtf_import_matching_test.cpp)
+target_include_directories(mvr_gdtf_import_matching_test PRIVATE ../mvr)
+add_test(NAME MvrGdtfImportMatching COMMAND mvr_gdtf_import_matching_test)
+
 add_executable(mvr_dmx_address_test mvr_dmx_address_test.cpp
                ../mvr/mvrexporter.cpp
                ../mvr/primitive_model_resources.cpp

--- a/tests/mvr_gdtf_import_matching_test.cpp
+++ b/tests/mvr_gdtf_import_matching_test.cpp
@@ -1,0 +1,60 @@
+#include "gdtf_import_matching.h"
+
+#include <cassert>
+#include <string>
+#include <vector>
+
+namespace matching = mvr::gdtf_import_matching;
+
+struct DownloadRequestProbe {
+  std::string requestedFixtureName;
+  std::string resolvedFixtureTypeName;
+};
+
+// Verifies that original MVR fixture names drive download matching when embedded metadata is generic.
+static void VerifyDistinctOriginalNamesBeatSharedPlaceholderMetadata() {
+  const std::string placeholderType = "BLED Standard mode 12CH";
+  const std::vector<DownloadRequestProbe> requests = {
+      {matching::SelectRequestedFixtureName("Aleda K10 B-EYE",
+                                            "Fixtures/BLED Standard mode 12CH.gdtf"),
+       placeholderType},
+      {matching::SelectRequestedFixtureName("Super Storm 1500",
+                                            "Fixtures/BLED Standard mode 12CH.gdtf"),
+       placeholderType},
+  };
+
+  assert(matching::SelectDownloadSearchFixtureName(requests[0].requestedFixtureName,
+                                                   requests[0].resolvedFixtureTypeName) ==
+         "Aleda K10 B-EYE");
+  assert(matching::SelectDownloadSearchFixtureName(requests[1].requestedFixtureName,
+                                                   requests[1].resolvedFixtureTypeName) ==
+         "Super Storm 1500");
+  assert(matching::SelectDownloadSearchFixtureName(requests[0].requestedFixtureName,
+                                                   requests[0].resolvedFixtureTypeName) !=
+         placeholderType);
+  assert(matching::SelectDownloadSearchFixtureName(requests[1].requestedFixtureName,
+                                                   requests[1].resolvedFixtureTypeName) !=
+         placeholderType);
+}
+
+// Verifies that the GDTFSpec basename is used when the fixture node name is unavailable.
+static void VerifySpecBasenameFallback() {
+  assert(matching::SelectRequestedFixtureName("", "Folder/Super Storm 1500.gdtf") ==
+         "Super Storm 1500");
+  assert(matching::SelectRequestedFixtureName("\t\n", "Folder\\Aleda K10 B-EYE.gdtf") ==
+         "Aleda K10 B-EYE");
+}
+
+// Verifies that resolved metadata remains the final fallback when no original MVR identity exists.
+static void VerifyResolvedTypeFallback() {
+  assert(matching::SelectDownloadSearchFixtureName("", "BLED Standard mode 12CH") ==
+         "BLED Standard mode 12CH");
+}
+
+// Runs focused coverage for MVR-requested GDTF import matching identity selection.
+int main() {
+  VerifyDistinctOriginalNamesBeatSharedPlaceholderMetadata();
+  VerifySpecBasenameFallback();
+  VerifyResolvedTypeFallback();
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- Automatic GDTF download matching used only the resolved embedded GDTF metadata (`fixture.typeName`), which causes incorrect catalog searches when many fixtures share a generic embedded name.
- Preserve and prefer the original/requested MVR fixture identity so matching uses the most reliable MVR source (node `name`, spec basename, or fallback) instead of overwritten metadata.

### Description
- Add a small helper header `mvr/gdtf_import_matching.h` with functions to trim fixture identities, derive a basename from a `GDTFSpec`, select the requested MVR fixture name, and pick the catalog search name with fallback to the resolved type.
- Extend `models::Fixture` with `requestedFixtureName` to hold the original MVR identity used for matching.
- Record `requestedFixtureName` during `parseFixture` before embedded GDTF metadata is applied, using the node `name` attribute or the `GDTFSpec` basename when needed.
- Add `requestedFixtureName` to `GdtfConflict` and populate it both when creating pending conflicts (`pendingGdtfConflictByType.try_emplace(...)`) and during the later conflict scan that builds `gdtfConflictByType`.
- Prefer the new `requestedFixtureName` in the download matching loop by using `SelectDownloadSearchFixtureName(req.requestedFixtureName, req.type)` when computing `ComputeFixtureNameMatchScore(...)` and only fall back to the resolved type when no requested identity exists.
- Add a focused unit test `tests/mvr_gdtf_import_matching_test.cpp` that verifies distinct original names (e.g. `Aleda K10 B-EYE`, `Super Storm 1500`) are searched instead of a shared placeholder (`BLED Standard mode 12CH`), and register the test in `tests/CMakeLists.txt`.
- Update `docs/release-notes-draft.md` with a user-facing fix entry describing improved automatic GDTF matching during MVR import.

### Testing
- Ran the focused unit probe by compiling and executing the test: `g++ -std=c++20 -I mvr tests/mvr_gdtf_import_matching_test.cpp -o /tmp/mvr_gdtf_import_matching_test && /tmp/mvr_gdtf_import_matching_test`, which completed successfully (exit 0).
- Ran repository policy checks `./tests/check_perastage_tree_modules.sh` and `./tests/check_no_configmanager_get_in_gui.sh`, both reported OK.
- Ran `git diff --check` and `git diff --stat` to ensure no whitespace or index issues, which passed.
- Note: `cmake -S . -B build -DBUILD_TESTING=ON` could not finish in this environment due to missing wxWidgets development files (`wxWidgets_LIBRARIES` and `wxWidgets_INCLUDE_DIRS`), so full test-suite CMake build was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a219d0143bc8324b88f2551a1d56768)