### PR TITLE
Prioritize fixture-name tiers for automatic GDTF downloads

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -28,6 +28,7 @@ Changes since `v1.2.0`.
 - Improved project symbol-cache persistence so verified or newly generated fixture symbols in project GDTF files are recorded and saved, reducing repeated symbol regeneration on later opens.
 - Improved layout render progress feedback with clearer status-bar messages during symbol capture, texture rebuilds, legend preparation, and rendering.
 - Improved GDTF model loading with better lookup ordering, GLB fallback handling, and diagnostics for missing or difficult-to-load models.
+- Improved automatic GDTF selection during MVR import so stronger fixture-name matches are preferred before footprint, manufacturer, recency, and rating tie-breakers.
 - Improved fixture symbol alignment so generated layout symbols better match each fixture's local axes.
 - Improved 3D textured mesh lighting and mirrored geometry handling so dark/light patterns, ink normals, face orientation, and textured surfaces render more consistently.
 - Improved release asset handling so GitHub Draft Releases include the Arch Linux package alongside the Windows installer, Linux AppImage, and macOS DMG downloads.

--- a/mvr/gdtf_import_matching.h
+++ b/mvr/gdtf_import_matching.h
@@ -18,8 +18,11 @@
 #pragma once
 
 #include <algorithm>
+#include <array>
+#include <cctype>
 #include <filesystem>
 #include <string>
+#include <vector>
 
 namespace mvr {
 namespace gdtf_import_matching {
@@ -32,6 +35,208 @@ inline std::string TrimFixtureIdentity(const std::string &value) {
     return {};
   const size_t end = value.find_last_not_of(whitespace);
   return value.substr(start, end - start + 1);
+}
+
+// Lowercases ASCII text for fixture and manufacturer comparisons.
+inline std::string ToLowerAscii(std::string text) {
+  std::transform(text.begin(), text.end(), text.begin(), [](unsigned char ch) {
+    return static_cast<char>(std::tolower(ch));
+  });
+  return text;
+}
+
+// Extracts ordered digits to reject ambiguous partial matches.
+inline std::string ExtractDigitSignature(const std::string &text) {
+  std::string digits;
+  for (unsigned char ch : text) {
+    if (std::isdigit(ch))
+      digits.push_back(static_cast<char>(ch));
+  }
+  return digits;
+}
+
+// Normalizes a GDTF catalog or request value into a compact comparison key.
+inline std::string NormalizeForGdtfMatch(const std::string &text) {
+  static const std::array<std::string, 16> kSuffixes = {
+      " lighting", " light", " gmbh",   " ltd",         " inc", " corp",
+      " co",       " llc",   " electronics", " ag",     " sa",  " sl",
+      " bv",       " nv",    " s.a.",   " s.l."};
+  std::string normalized = ToLowerAscii(TrimFixtureIdentity(text));
+  bool removed = false;
+  do {
+    removed = false;
+    for (const auto &suffix : kSuffixes) {
+      if (normalized.size() >= suffix.size() &&
+          normalized.rfind(suffix) == normalized.size() - suffix.size()) {
+        normalized = TrimFixtureIdentity(normalized.substr(0, normalized.size() - suffix.size()));
+        removed = true;
+      }
+    }
+  } while (removed);
+
+  std::string compact;
+  compact.reserve(normalized.size());
+  for (unsigned char ch : normalized) {
+    if (std::isalnum(ch))
+      compact.push_back(static_cast<char>(ch));
+  }
+  return compact;
+}
+
+// Removes parenthesized variant suffixes from fixture names.
+inline std::string StripParenthesizedSections(const std::string &text) {
+  std::string stripped;
+  stripped.reserve(text.size());
+  int depth = 0;
+  for (char ch : text) {
+    if (ch == '(') {
+      ++depth;
+      continue;
+    }
+    if (ch == ')') {
+      if (depth > 0)
+        --depth;
+      continue;
+    }
+    if (depth == 0)
+      stripped.push_back(ch);
+  }
+  return TrimFixtureIdentity(stripped);
+}
+
+// Detects version-like fixture-name tokens.
+inline bool IsLikelyVersionToken(const std::string &token) {
+  if (token.empty())
+    return false;
+  const bool allDigits = std::all_of(token.begin(), token.end(),
+                                     [](unsigned char ch) { return std::isdigit(ch); });
+  if (allDigits)
+    return true;
+
+  if (token.size() <= 6) {
+    const std::string roman = ToLowerAscii(token);
+    const bool allRoman = std::all_of(roman.begin(), roman.end(), [](unsigned char ch) {
+      return ch == 'i' || ch == 'v' || ch == 'x' || ch == 'l' || ch == 'c' ||
+             ch == 'd' || ch == 'm';
+    });
+    if (allRoman)
+      return true;
+  }
+  return false;
+}
+
+// Builds a core fixture-name key without variant tokens.
+inline std::string BuildCoreFixtureNameKey(const std::string &text) {
+  const std::string stripped = StripParenthesizedSections(text);
+  const std::string lower = ToLowerAscii(stripped);
+  std::vector<std::string> tokens;
+  std::string current;
+  for (unsigned char ch : lower) {
+    if (std::isalnum(ch)) {
+      current.push_back(static_cast<char>(ch));
+    } else if (!current.empty()) {
+      tokens.push_back(current);
+      current.clear();
+    }
+  }
+  if (!current.empty())
+    tokens.push_back(current);
+
+  std::string compact;
+  for (const auto &token : tokens) {
+    if (IsLikelyVersionToken(token))
+      continue;
+    compact += token;
+  }
+  return compact;
+}
+
+enum class FixtureNameMatchTier {
+  None = 0,
+  Partial = 1,
+  CoreName = 2,
+  ParenthesisStripped = 3,
+  ExactNormalized = 4
+};
+
+// Classifies fixture-name confidence before tie-breakers.
+inline FixtureNameMatchTier ComputeFixtureNameMatchTier(
+    const std::string &catalogFixtureName,
+    const std::string &requestedFixtureName) {
+  const std::string catalogNormalized = NormalizeForGdtfMatch(catalogFixtureName);
+  const std::string requestedNormalized = NormalizeForGdtfMatch(requestedFixtureName);
+
+  if (catalogNormalized.empty() || requestedNormalized.empty())
+    return FixtureNameMatchTier::None;
+  if (catalogNormalized == requestedNormalized)
+    return FixtureNameMatchTier::ExactNormalized;
+
+  const std::string catalogNoParentheses =
+      NormalizeForGdtfMatch(StripParenthesizedSections(catalogFixtureName));
+  const std::string requestedNoParentheses =
+      NormalizeForGdtfMatch(StripParenthesizedSections(requestedFixtureName));
+  if (!catalogNoParentheses.empty() && !requestedNoParentheses.empty() &&
+      catalogNoParentheses == requestedNoParentheses) {
+    return FixtureNameMatchTier::ParenthesisStripped;
+  }
+
+  const std::string catalogCoreName = BuildCoreFixtureNameKey(catalogFixtureName);
+  const std::string requestedCoreName = BuildCoreFixtureNameKey(requestedFixtureName);
+  if (!catalogCoreName.empty() && !requestedCoreName.empty() &&
+      catalogCoreName == requestedCoreName) {
+    return FixtureNameMatchTier::CoreName;
+  }
+
+  const auto hasContainsMatch = [](const std::string &lhs,
+                                   const std::string &rhs) -> bool {
+    if (lhs.empty() || rhs.empty())
+      return false;
+    return (lhs.size() >= 4 && rhs.find(lhs) != std::string::npos) ||
+           (rhs.size() >= 4 && lhs.find(rhs) != std::string::npos);
+  };
+
+  const bool containsMatch =
+      (catalogNormalized.size() >= 5 &&
+       requestedNormalized.find(catalogNormalized) != std::string::npos) ||
+      (requestedNormalized.size() >= 5 &&
+       catalogNormalized.find(requestedNormalized) != std::string::npos) ||
+      hasContainsMatch(catalogCoreName, requestedCoreName) ||
+      hasContainsMatch(catalogNoParentheses, requestedNoParentheses) ||
+      hasContainsMatch(catalogNormalized, requestedNoParentheses) ||
+      hasContainsMatch(catalogNoParentheses, requestedNormalized);
+  if (!containsMatch)
+    return FixtureNameMatchTier::None;
+
+  const std::string catalogDigits = ExtractDigitSignature(catalogNormalized);
+  const std::string requestedDigits = ExtractDigitSignature(requestedNormalized);
+  if (!catalogDigits.empty() && !requestedDigits.empty() &&
+      catalogDigits != requestedDigits) {
+    return FixtureNameMatchTier::None;
+  }
+
+  return FixtureNameMatchTier::Partial;
+}
+
+struct DownloadCandidateRank {
+  FixtureNameMatchTier nameTier = FixtureNameMatchTier::None;
+  bool footprintMatch = false;
+  bool manufacturerMatch = false;
+  long long recency = 0;
+  float rating = 0.0f;
+};
+
+// Compares download candidates by tier and tie-breakers.
+inline bool IsBetterDownloadCandidate(const DownloadCandidateRank &candidate,
+                                      const DownloadCandidateRank &currentBest) {
+  if (candidate.nameTier != currentBest.nameTier)
+    return static_cast<int>(candidate.nameTier) > static_cast<int>(currentBest.nameTier);
+  if (candidate.footprintMatch != currentBest.footprintMatch)
+    return candidate.footprintMatch;
+  if (candidate.manufacturerMatch != currentBest.manufacturerMatch)
+    return candidate.manufacturerMatch;
+  if (candidate.recency != currentBest.recency)
+    return candidate.recency > currentBest.recency;
+  return candidate.rating > currentBest.rating;
 }
 
 // Normalizes path separators before deriving a fixture identity from GDTFSpec.

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -661,157 +661,7 @@ struct GdtfDownloadMatch {
   std::string selectionReason;
 };
 
-static std::string NormalizeForGdtfMatch(const std::string &text) {
-  static const std::array<std::string, 16> kSuffixes = {
-      " lighting", " light", " gmbh",   " ltd",         " inc", " corp",
-      " co",       " llc",   " electronics", " ag",     " sa",  " sl",
-      " bv",       " nv",    " s.a.",   " s.l."};
-  std::string normalized = ToLowerAscii(Trim(text));
-  bool removed = false;
-  do {
-    removed = false;
-    for (const auto &suffix : kSuffixes) {
-      if (normalized.size() >= suffix.size() &&
-          normalized.rfind(suffix) == normalized.size() - suffix.size()) {
-        normalized = Trim(normalized.substr(0, normalized.size() - suffix.size()));
-        removed = true;
-      }
-    }
-  } while (removed);
-
-  std::string compact;
-  compact.reserve(normalized.size());
-  for (unsigned char ch : normalized) {
-    if (std::isalnum(ch))
-      compact.push_back(static_cast<char>(ch));
-  }
-  return compact;
-}
-
-static std::string StripParenthesizedSections(const std::string &text) {
-  std::string stripped;
-  stripped.reserve(text.size());
-  int depth = 0;
-  for (char ch : text) {
-    if (ch == '(') {
-      ++depth;
-      continue;
-    }
-    if (ch == ')') {
-      if (depth > 0)
-        --depth;
-      continue;
-    }
-    if (depth == 0)
-      stripped.push_back(ch);
-  }
-  return Trim(stripped);
-}
-
-static bool IsLikelyVersionToken(const std::string &token) {
-  if (token.empty())
-    return false;
-  const bool allDigits = std::all_of(token.begin(), token.end(),
-                                     [](unsigned char ch) { return std::isdigit(ch); });
-  if (allDigits)
-    return true;
-
-  if (token.size() <= 6) {
-    const std::string roman = ToLowerAscii(token);
-    const bool allRoman = std::all_of(roman.begin(), roman.end(), [](unsigned char ch) {
-      return ch == 'i' || ch == 'v' || ch == 'x' || ch == 'l' || ch == 'c' ||
-             ch == 'd' || ch == 'm';
-    });
-    if (allRoman)
-      return true;
-  }
-  return false;
-}
-
-static std::string BuildCoreFixtureNameKey(const std::string &text) {
-  const std::string stripped = StripParenthesizedSections(text);
-  const std::string lower = ToLowerAscii(stripped);
-  std::vector<std::string> tokens;
-  std::string current;
-  for (unsigned char ch : lower) {
-    if (std::isalnum(ch)) {
-      current.push_back(static_cast<char>(ch));
-    } else if (!current.empty()) {
-      tokens.push_back(current);
-      current.clear();
-    }
-  }
-  if (!current.empty())
-    tokens.push_back(current);
-
-  std::string compact;
-  for (const auto &token : tokens) {
-    if (IsLikelyVersionToken(token))
-      continue;
-    compact += token;
-  }
-  return compact;
-}
-
-static int ComputeFixtureNameMatchScore(const std::string &catalogFixtureName,
-                                        const std::string &requestedFixtureName) {
-  const std::string catalogNormalized =
-      NormalizeForGdtfMatch(catalogFixtureName);
-  const std::string requestedNormalized =
-      NormalizeForGdtfMatch(requestedFixtureName);
-
-  if (catalogNormalized.empty() || requestedNormalized.empty())
-    return 0;
-  if (catalogNormalized == requestedNormalized)
-    return 10000;
-
-  const std::string catalogNoParentheses =
-      NormalizeForGdtfMatch(StripParenthesizedSections(catalogFixtureName));
-  const std::string requestedNoParentheses =
-      NormalizeForGdtfMatch(StripParenthesizedSections(requestedFixtureName));
-  if (!catalogNoParentheses.empty() && !requestedNoParentheses.empty() &&
-      catalogNoParentheses == requestedNoParentheses) {
-    return 9000;
-  }
-
-  const std::string catalogCoreName = BuildCoreFixtureNameKey(catalogFixtureName);
-  const std::string requestedCoreName =
-      BuildCoreFixtureNameKey(requestedFixtureName);
-  if (!catalogCoreName.empty() && !requestedCoreName.empty() &&
-      catalogCoreName == requestedCoreName) {
-    return 8500;
-  }
-
-  const auto hasContainsMatch = [](const std::string &lhs,
-                                   const std::string &rhs) -> bool {
-    if (lhs.empty() || rhs.empty())
-      return false;
-    return (lhs.size() >= 4 && rhs.find(lhs) != std::string::npos) ||
-           (rhs.size() >= 4 && lhs.find(rhs) != std::string::npos);
-  };
-
-  const bool containsMatch =
-      (catalogNormalized.size() >= 5 &&
-       requestedNormalized.find(catalogNormalized) != std::string::npos) ||
-      (requestedNormalized.size() >= 5 &&
-       catalogNormalized.find(requestedNormalized) != std::string::npos) ||
-      hasContainsMatch(catalogCoreName, requestedCoreName) ||
-      hasContainsMatch(catalogNoParentheses, requestedNoParentheses) ||
-      hasContainsMatch(catalogNormalized, requestedNoParentheses) ||
-      hasContainsMatch(catalogNoParentheses, requestedNormalized);
-  if (!containsMatch)
-    return 0;
-
-  const std::string catalogDigits = ExtractDigitSignature(catalogNormalized);
-  const std::string requestedDigits = ExtractDigitSignature(requestedNormalized);
-  if (!catalogDigits.empty() && !requestedDigits.empty() &&
-      catalogDigits != requestedDigits) {
-    return 0;
-  }
-
-  return 8000;
-}
-
+// Parses GDTF catalog JSON into normalized entries used by automatic downloads.
 static std::vector<GdtfCatalogEntry>
 ParseGdtfCatalogEntries(const std::string &listData) {
   using json = nlohmann::json;
@@ -3318,18 +3168,15 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                   if (req.footprint <= 0)
                     req.footprint = inferFootprintFromAddresses(req.type);
                   GdtfDownloadMatch bestMatch;
-                  int bestPrimaryScore = std::numeric_limits<int>::min();
-                  long long bestRecency = std::numeric_limits<long long>::min();
-                  bool bestManufacturerMatch = false;
-                  float bestRating = -1.0f;
-                  bool bestUsedRecencyTiebreak = false;
+                  mvr::gdtf_import_matching::DownloadCandidateRank bestPrimaryScore;
                   for (const auto &entry : catalogEntries) {
                     const std::string requestedFixtureName =
                         mvr::gdtf_import_matching::SelectDownloadSearchFixtureName(
                             req.requestedFixtureName, req.type);
-                    const int nameScore = ComputeFixtureNameMatchScore(
-                        entry.fixtureName, requestedFixtureName);
-                    if (nameScore <= 0) {
+                    const auto nameTier =
+                        mvr::gdtf_import_matching::ComputeFixtureNameMatchTier(
+                            entry.fixtureName, requestedFixtureName);
+                    if (nameTier == mvr::gdtf_import_matching::FixtureNameMatchTier::None) {
                       continue;
                     }
                     std::string matchedMode;
@@ -3345,49 +3192,30 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                     }
                     const bool manufacturerMatch =
                         !req.manufacturer.empty() && !entry.manufacturer.empty() &&
-                        NormalizeForGdtfMatch(req.manufacturer) ==
-                            NormalizeForGdtfMatch(entry.manufacturer);
-                    const int footprintBonus = footprintMatch ? 3000 : 0;
-                    const int manufacturerBonus = manufacturerMatch ? 40 : 0;
-                    const int primaryScore =
-                        nameScore + footprintBonus + manufacturerBonus;
-
-                    bool isBetter = false;
-                    bool decidedByRecency = false;
-                    if (primaryScore > bestPrimaryScore) {
-                      isBetter = true;
-                    } else if (primaryScore == bestPrimaryScore) {
-                      if (entry.lastModifiedUnix > bestRecency) {
-                        isBetter = true;
-                        decidedByRecency = true;
-                      } else if (entry.lastModifiedUnix == bestRecency) {
-                        if (manufacturerMatch && !bestManufacturerMatch) {
-                          isBetter = true;
-                        } else if (manufacturerMatch == bestManufacturerMatch &&
-                                   entry.rating > bestRating) {
-                          isBetter = true;
-                        }
-                      }
+                        mvr::gdtf_import_matching::NormalizeForGdtfMatch(req.manufacturer) ==
+                            mvr::gdtf_import_matching::NormalizeForGdtfMatch(entry.manufacturer);
+                    const mvr::gdtf_import_matching::DownloadCandidateRank candidateRank{
+                        nameTier, footprintMatch, manufacturerMatch,
+                        entry.lastModifiedUnix, entry.rating};
+                    const bool hadPreviousBest = bestMatch.found;
+                    if (!mvr::gdtf_import_matching::IsBetterDownloadCandidate(
+                            candidateRank, bestPrimaryScore)) {
+                      continue;
                     }
 
-                    if (isBetter) {
-                      bestPrimaryScore = primaryScore;
-                      bestRecency = entry.lastModifiedUnix;
-                      bestManufacturerMatch = manufacturerMatch;
-                      bestRating = entry.rating;
-                      bestUsedRecencyTiebreak = decidedByRecency;
-                      std::string selectionReason = "name";
-                      if (footprintMatch) {
-                        selectionReason = "name+footprint";
-                      } else if (bestUsedRecencyTiebreak) {
-                        selectionReason = "name+recency";
-                      } else if (manufacturerMatch) {
-                        selectionReason = "name+manufacturer";
-                      } else if (entry.rating > 0.0f) {
-                        selectionReason = "name+rating";
-                      }
-                      bestMatch = {true, entry.rid, matchedMode, selectionReason};
+                    std::string selectionReason = "name";
+                    if (footprintMatch) {
+                      selectionReason = "name+footprint";
+                    } else if (manufacturerMatch) {
+                      selectionReason = "name+manufacturer";
+                    } else if (hadPreviousBest &&
+                               entry.lastModifiedUnix > bestPrimaryScore.recency) {
+                      selectionReason = "name+recency";
+                    } else if (hadPreviousBest && entry.rating > bestPrimaryScore.rating) {
+                      selectionReason = "name+rating";
                     }
+                    bestPrimaryScore = candidateRank;
+                    bestMatch = {true, entry.rid, matchedMode, selectionReason};
                   }
 
                   if (!bestMatch.found || bestMatch.rid.empty()) {

--- a/tests/mvr_gdtf_import_matching_test.cpp
+++ b/tests/mvr_gdtf_import_matching_test.cpp
@@ -51,10 +51,43 @@ static void VerifyResolvedTypeFallback() {
          "BLED Standard mode 12CH");
 }
 
+// Verifies name confidence outranks footprint matches.
+static void VerifyExactNameWithoutFootprintBeatsPartialNameWithFootprint() {
+  const auto exactTier = matching::ComputeFixtureNameMatchTier("My Beam 200",
+                                                              "My Beam 200");
+  const auto partialTier = matching::ComputeFixtureNameMatchTier("My Beam 200 Extended",
+                                                                "My Beam 200");
+  const matching::DownloadCandidateRank exactNoFootprint{
+      exactTier, false, false, 100, 0.0f};
+  const matching::DownloadCandidateRank partialWithFootprint{
+      partialTier, true, false, 200, 5.0f};
+
+  assert(exactTier == matching::FixtureNameMatchTier::ExactNormalized);
+  assert(partialTier == matching::FixtureNameMatchTier::Partial);
+  assert(matching::IsBetterDownloadCandidate(exactNoFootprint, partialWithFootprint));
+  assert(!matching::IsBetterDownloadCandidate(partialWithFootprint, exactNoFootprint));
+}
+
+// Verifies manufacturer matches outrank recency ties.
+static void VerifyManufacturerMatchBeatsRecencyInsideSameNameAndFootprintTier() {
+  const auto tier = matching::ComputeFixtureNameMatchTier("My Beam 200", "My Beam 200");
+  const matching::DownloadCandidateRank manufacturerMatch{
+      tier, true, true, 100, 0.0f};
+  const matching::DownloadCandidateRank newerWithoutManufacturer{
+      tier, true, false, 200, 5.0f};
+
+  assert(matching::IsBetterDownloadCandidate(manufacturerMatch,
+                                             newerWithoutManufacturer));
+  assert(!matching::IsBetterDownloadCandidate(newerWithoutManufacturer,
+                                              manufacturerMatch));
+}
+
 // Runs focused coverage for MVR-requested GDTF import matching identity selection.
 int main() {
   VerifyDistinctOriginalNamesBeatSharedPlaceholderMetadata();
   VerifySpecBasenameFallback();
   VerifyResolvedTypeFallback();
+  VerifyExactNameWithoutFootprintBeatsPartialNameWithFootprint();
+  VerifyManufacturerMatchBeatsRecencyInsideSameNameAndFootprintTier();
   return 0;
 }


### PR DESCRIPTION
### Motivation
- Improve automatic GDTF selection so fixture-name confidence is the primary decision tier and prevents lower-confidence name matches boosted by footprint from outranking stronger name matches.
- Ensure footprint is used only as a tie-breaker inside the same name-confidence tier and prefer manufacturer match before recency when other factors are equal.
- Add focused unit coverage for the new ranking guarantees and update release notes to reflect the user-visible behavior change.

### Description
- Introduced helper utilities and a tiered name-confidence model in `mvr/gdtf_import_matching.h`, including `ToLowerAscii`, `ExtractDigitSignature`, `NormalizeForGdtfMatch`, `StripParenthesizedSections`, `BuildCoreFixtureNameKey`, the `FixtureNameMatchTier` enum, `ComputeFixtureNameMatchTier`, `DownloadCandidateRank`, and `IsBetterDownloadCandidate` to encapsulate name-tier classification and candidate comparison.
- Replaced the previous raw numeric primary scoring in `mvr/mvrimporter.cpp` with the new tiered ranking by using `ComputeFixtureNameMatchTier` and `DownloadCandidateRank`, so footprint provides a tie-breaker only within the same name tier and manufacturer is preferred over recency and rating when tier and footprint are equal.
- Adjusted selection-reason logic to avoid allowing recency/rating to overtake higher name-confidence tiers and guard recency/rating usage to cases where a previous best existed at the same tier.
- Added unit tests in `tests/mvr_gdtf_import_matching_test.cpp` that assert an exact normalized name without footprint beats a partial name with footprint and that manufacturer matches outrank recency inside the same name/footprint tier, and updated `docs/release-notes-draft.md` with a short user-facing entry describing the improvement.

### Testing
- Built and ran the focused matcher unit tests with `g++ -std=c++17 -I mvr tests/mvr_gdtf_import_matching_test.cpp -o /tmp/mvr_gdtf_import_matching_test && /tmp/mvr_gdtf_import_matching_test`, which completed successfully.
- Ran project quality checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both of which returned OK.
- Verified formatting with `clang-format` and ensured the new test and helper functions compile in the test harness (successful run shown above).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a219f3b48148324a050dca7e2e551a8)