### PR TITLE
Improve mode-aware GDTF download matching

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -36,6 +36,7 @@ Changes since `v1.2.0`.
 ## Fixes
 
 - Fixed automatic GDTF download matching during MVR import so fixtures with generic embedded GDTF metadata can still match the original fixture names from the MVR file.
+- Fixed automatic GDTF download matching during MVR import so requested fixture modes are matched against catalog mode names and channel signatures before relying on footprint alone.
 - Fixed an About dialog startup assertion when locating the Perastage logo on wxWidgets debug builds.
 - Fixed MVR export before saving a project so resource references are synchronized before export.
 - Fixed MVR merge resource handling so imported fixture, truss, symbol, and model files remain available after saving and reopening the project.

--- a/mvr/gdtf_import_matching.h
+++ b/mvr/gdtf_import_matching.h
@@ -217,12 +217,83 @@ inline FixtureNameMatchTier ComputeFixtureNameMatchTier(
   return FixtureNameMatchTier::Partial;
 }
 
+
+enum class GdtfModeMatchTier {
+  None = 0,
+  Footprint = 1,
+  DigitSignature = 2,
+  ExactNormalized = 3
+};
+
+struct GdtfModeMatchScore {
+  GdtfModeMatchTier tier = GdtfModeMatchTier::None;
+  bool footprintMatch = false;
+  std::string modeName;
+};
+
+// Scores how well a requested GDTF mode aligns with catalog modes and footprint evidence.
+template <typename CatalogModes>
+inline GdtfModeMatchScore ComputeGdtfModeMatchScore(
+    const std::string &requestedMode,
+    const CatalogModes &catalogModes,
+    int requestedFootprint) {
+  GdtfModeMatchScore bestScore;
+  const std::string requestedNormalized = NormalizeForGdtfMatch(requestedMode);
+  const std::string requestedDigits = ExtractDigitSignature(requestedNormalized);
+  std::string footprintModeName;
+  bool selectedModeHasFootprint = false;
+
+  for (const auto &mode : catalogModes) {
+    const bool footprintMatch = requestedFootprint > 0 && mode.footprint == requestedFootprint;
+    if (footprintMatch) {
+      bestScore.footprintMatch = true;
+      if (footprintModeName.empty())
+        footprintModeName = mode.name;
+    }
+
+    const std::string modeNormalized = NormalizeForGdtfMatch(mode.name);
+    GdtfModeMatchTier candidateTier = GdtfModeMatchTier::None;
+    if (!requestedNormalized.empty() && !modeNormalized.empty() &&
+        requestedNormalized == modeNormalized) {
+      candidateTier = GdtfModeMatchTier::ExactNormalized;
+    } else {
+      const std::string modeDigits = ExtractDigitSignature(modeNormalized);
+      if (!requestedDigits.empty() && !modeDigits.empty() && requestedDigits == modeDigits)
+        candidateTier = GdtfModeMatchTier::DigitSignature;
+    }
+
+    if (candidateTier == GdtfModeMatchTier::None)
+      continue;
+    if (static_cast<int>(candidateTier) > static_cast<int>(bestScore.tier) ||
+        (candidateTier == bestScore.tier && footprintMatch && !selectedModeHasFootprint)) {
+      bestScore.tier = candidateTier;
+      bestScore.modeName = mode.name;
+      selectedModeHasFootprint = footprintMatch;
+    }
+  }
+
+  if (bestScore.tier == GdtfModeMatchTier::None && bestScore.footprintMatch) {
+    bestScore.tier = GdtfModeMatchTier::Footprint;
+    bestScore.modeName = footprintModeName;
+  }
+  return bestScore;
+}
+
+// Scores requested mode names against catalog modes without footprint evidence.
+template <typename CatalogModes>
+inline GdtfModeMatchScore ComputeGdtfModeMatchScore(
+    const std::string &requestedMode,
+    const CatalogModes &catalogModes) {
+  return ComputeGdtfModeMatchScore(requestedMode, catalogModes, 0);
+}
+
 struct DownloadCandidateRank {
   FixtureNameMatchTier nameTier = FixtureNameMatchTier::None;
   bool footprintMatch = false;
   bool manufacturerMatch = false;
   long long recency = 0;
   float rating = 0.0f;
+  GdtfModeMatchTier modeTier = GdtfModeMatchTier::None;
 };
 
 // Compares download candidates by tier and tie-breakers.
@@ -230,6 +301,8 @@ inline bool IsBetterDownloadCandidate(const DownloadCandidateRank &candidate,
                                       const DownloadCandidateRank &currentBest) {
   if (candidate.nameTier != currentBest.nameTier)
     return static_cast<int>(candidate.nameTier) > static_cast<int>(currentBest.nameTier);
+  if (candidate.modeTier != currentBest.modeTier)
+    return static_cast<int>(candidate.modeTier) > static_cast<int>(currentBest.modeTier);
   if (candidate.footprintMatch != currentBest.footprintMatch)
     return candidate.footprintMatch;
   if (candidate.manufacturerMatch != currentBest.manufacturerMatch)

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -661,6 +661,15 @@ struct GdtfDownloadMatch {
   std::string selectionReason;
 };
 
+// Scores requested mode names against a catalog entry and preserves the best catalog mode name.
+static mvr::gdtf_import_matching::GdtfModeMatchScore ComputeGdtfModeMatchScore(
+    const std::string &requestedMode,
+    const std::vector<GdtfCatalogModeCandidate> &catalogModes,
+    int requestedFootprint) {
+  return mvr::gdtf_import_matching::ComputeGdtfModeMatchScore(
+      requestedMode, catalogModes, requestedFootprint);
+}
+
 // Parses GDTF catalog JSON into normalized entries used by automatic downloads.
 static std::vector<GdtfCatalogEntry>
 ParseGdtfCatalogEntries(const std::string &listData) {
@@ -3179,24 +3188,18 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                     if (nameTier == mvr::gdtf_import_matching::FixtureNameMatchTier::None) {
                       continue;
                     }
-                    std::string matchedMode;
-                    bool footprintMatch = false;
-                    if (req.footprint > 0) {
-                      for (const auto &mode : entry.modes) {
-                        if (mode.footprint == req.footprint) {
-                          footprintMatch = true;
-                          matchedMode = mode.name;
-                          break;
-                        }
-                      }
-                    }
+                    const auto modeScore =
+                        ComputeGdtfModeMatchScore(req.modeName, entry.modes, req.footprint);
+                    const std::string matchedMode = modeScore.modeName;
+                    const bool footprintMatch = modeScore.footprintMatch;
                     const bool manufacturerMatch =
                         !req.manufacturer.empty() && !entry.manufacturer.empty() &&
                         mvr::gdtf_import_matching::NormalizeForGdtfMatch(req.manufacturer) ==
                             mvr::gdtf_import_matching::NormalizeForGdtfMatch(entry.manufacturer);
-                    const mvr::gdtf_import_matching::DownloadCandidateRank candidateRank{
+                    mvr::gdtf_import_matching::DownloadCandidateRank candidateRank{
                         nameTier, footprintMatch, manufacturerMatch,
                         entry.lastModifiedUnix, entry.rating};
+                    candidateRank.modeTier = modeScore.tier;
                     const bool hadPreviousBest = bestMatch.found;
                     if (!mvr::gdtf_import_matching::IsBetterDownloadCandidate(
                             candidateRank, bestPrimaryScore)) {
@@ -3204,7 +3207,13 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                     }
 
                     std::string selectionReason = "name";
-                    if (footprintMatch) {
+                    if (modeScore.tier ==
+                        mvr::gdtf_import_matching::GdtfModeMatchTier::ExactNormalized) {
+                      selectionReason = "name+mode";
+                    } else if (modeScore.tier ==
+                               mvr::gdtf_import_matching::GdtfModeMatchTier::DigitSignature) {
+                      selectionReason = "name+mode-digits";
+                    } else if (footprintMatch) {
                       selectionReason = "name+footprint";
                     } else if (manufacturerMatch) {
                       selectionReason = "name+manufacturer";

--- a/tests/mvr_gdtf_import_matching_test.cpp
+++ b/tests/mvr_gdtf_import_matching_test.cpp
@@ -82,6 +82,94 @@ static void VerifyManufacturerMatchBeatsRecencyInsideSameNameAndFootprintTier() 
                                               manufacturerMatch));
 }
 
+struct CatalogModeProbe {
+  std::string name;
+  int footprint = 0;
+};
+
+struct DownloadCandidateProbe {
+  std::string rid;
+  std::string fixtureName;
+  std::vector<CatalogModeProbe> modes;
+  long long recency = 0;
+  float rating = 0.0f;
+};
+
+struct SelectedDownloadProbe {
+  std::string rid;
+  std::string modeName;
+};
+
+// Selects the best probe download candidate using the same matching rank used by downloads.
+static SelectedDownloadProbe SelectBestDownloadCandidateProbe(
+    const std::string &requestedFixtureName,
+    const std::string &requestedMode,
+    int requestedFootprint,
+    const std::vector<DownloadCandidateProbe> &candidates) {
+  SelectedDownloadProbe selected;
+  matching::DownloadCandidateRank bestRank;
+  for (const auto &candidate : candidates) {
+    const auto nameTier = matching::ComputeFixtureNameMatchTier(candidate.fixtureName,
+                                                               requestedFixtureName);
+    if (nameTier == matching::FixtureNameMatchTier::None)
+      continue;
+
+    const auto modeScore = matching::ComputeGdtfModeMatchScore(
+        requestedMode, candidate.modes, requestedFootprint);
+    matching::DownloadCandidateRank rank{nameTier, modeScore.footprintMatch, false,
+                                         candidate.recency, candidate.rating};
+    rank.modeTier = modeScore.tier;
+    if (!matching::IsBetterDownloadCandidate(rank, bestRank))
+      continue;
+
+    bestRank = rank;
+    selected = {candidate.rid, modeScore.modeName};
+  }
+  return selected;
+}
+
+// Verifies 12CH digit signatures keep Standard mode requests aligned with mode-aware fixtures.
+static void VerifyStandardModeDigitSignatureBeatsNewerFootprintOnlyMatch() {
+  const std::vector<DownloadCandidateProbe> candidates = {
+      {"fixture-standard", "BLED", {{"Basic", 8}, {"Touring 12CH", 24}}, 100, 3.0f},
+      {"fixture-newer", "BLED", {{"Economy", 12}}, 200, 5.0f},
+  };
+
+  const auto selected = SelectBestDownloadCandidateProbe(
+      "BLED", "Standard mode 12CH", 12, candidates);
+
+  assert(selected.rid == "fixture-standard");
+  assert(selected.modeName == "Touring 12CH");
+}
+
+// Verifies simple named modes without digits outrank footprint-only alternatives.
+static void VerifyBasicModeNameBeatsFootprintOnlyMatch() {
+  const std::vector<DownloadCandidateProbe> candidates = {
+      {"fixture-basic", "Wash 600", {{"Basic", 16}, {"Extended", 24}}, 100, 3.0f},
+      {"fixture-footprint", "Wash 600", {{"Arc Layout", 16}}, 250, 5.0f},
+  };
+
+  const auto selected = SelectBestDownloadCandidateProbe(
+      "Wash 600", "Basic", 16, candidates);
+
+  assert(selected.rid == "fixture-basic");
+  assert(selected.modeName == "Basic");
+}
+
+// Verifies fixture-specific named modes stay paired with the matching catalog mode.
+static void VerifyFixtureSpecificNamedModeStaysAligned() {
+  const std::vector<DownloadCandidateProbe> candidates = {
+      {"fixture-shapes", "Aleda K10 B-EYE", {{"B-EYE Shapes", 35}, {"Standard", 21}}, 100, 3.0f},
+      {"fixture-digits", "Aleda K10 B-EYE", {{"Pixel 35CH", 35}, {"Standard", 21}}, 300, 5.0f},
+  };
+
+  const auto selected = SelectBestDownloadCandidateProbe(
+      "Aleda K10 B-EYE", "B-EYE Shapes", 35, candidates);
+
+  assert(selected.rid == "fixture-shapes");
+  assert(selected.modeName == "B-EYE Shapes");
+}
+
 // Runs focused coverage for MVR-requested GDTF import matching identity selection.
 int main() {
   VerifyDistinctOriginalNamesBeatSharedPlaceholderMetadata();
@@ -89,5 +177,8 @@ int main() {
   VerifyResolvedTypeFallback();
   VerifyExactNameWithoutFootprintBeatsPartialNameWithFootprint();
   VerifyManufacturerMatchBeatsRecencyInsideSameNameAndFootprintTier();
+  VerifyStandardModeDigitSignatureBeatsNewerFootprintOnlyMatch();
+  VerifyBasicModeNameBeatsFootprintOnlyMatch();
+  VerifyFixtureSpecificNamedModeStaysAligned();
   return 0;
 }


### PR DESCRIPTION
### Motivation
- Improve automatic GDTF downloads so requested mode names (e.g. `Standard mode 12CH`, `Basic`, fixture-specific names) are compared against catalog `dmxModes` instead of relying on footprint-only matching.
- Reduce wrong fixture/mode pairings caused by newer catalog entries with matching footprints but different mode names or channel signatures.

### Description
- Add a mode-scoring helper `ComputeGdtfModeMatchScore` (in `mvr/gdtf_import_matching.h`) that normalizes mode names, extracts digit/channel signatures, prioritizes exact normalized matches, then digit signatures, and treats footprint as supporting evidence while returning the selected catalog mode name.
- Add a thin wrapper `ComputeGdtfModeMatchScore` in `mvr/mvrimporter.cpp` and wire the download loop to score `req.modeName` against `GdtfCatalogEntry::modes`, preserve the chosen mode in `bestMatch.modeName`, and include mode-based `selectionReason` values such as `name+mode` and `name+mode-digits`.
- Extend `DownloadCandidateRank` with a `modeTier` field and update `IsBetterDownloadCandidate` ordering so mode match quality is considered before footprint-only evidence.
- Add focused tests in `tests/mvr_gdtf_import_matching_test.cpp` covering `Standard mode 12CH`, `Basic`, and fixture-specific named modes to ensure the selected fixture and mode remain aligned.
- Update `docs/release-notes-draft.md` with a concise user-facing fix entry describing the improved mode-aware GDTF downloads.

### Testing
- Built and ran the focused unit test with `g++ -std=c++17 -I mvr tests/mvr_gdtf_import_matching_test.cpp -o /tmp/mvr_gdtf_import_matching_test && /tmp/mvr_gdtf_import_matching_test`, and it completed successfully (exit code 0).
- Ran repository checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both returned `OK`.
- No other automated tests were modified; the change is localized to `mvr/` and added unit coverage for the new mode-matching behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21a60afcc4832486de85fd2569059b)