### PR TITLE
Extract GDTF catalog matching into mvr/gdtf_catalog_matcher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,7 @@ add_executable(${PROJECT_NAME} main.cpp
     models/mvrscene.cpp
     models/sceneobject.cpp
     models/truss.cpp
+    mvr/gdtf_catalog_matcher.cpp
     mvr/mvrimporter.cpp
     mvr/mvr_merge_analyzer.cpp
     mvr/mvr_merge_applier.cpp

--- a/mvr/gdtf_catalog_matcher.cpp
+++ b/mvr/gdtf_catalog_matcher.cpp
@@ -1,0 +1,346 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "gdtf_catalog_matcher.h"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+
+namespace mvr {
+namespace gdtf_catalog_matcher {
+
+// Trims whitespace from an MVR fixture identity candidate.
+std::string TrimFixtureIdentity(const std::string &value) {
+  const char *whitespace = " \t\r\n";
+  const size_t start = value.find_first_not_of(whitespace);
+  if (start == std::string::npos)
+    return {};
+  const size_t end = value.find_last_not_of(whitespace);
+  return value.substr(start, end - start + 1);
+}
+
+// Lowercases ASCII text for fixture and manufacturer comparisons.
+std::string ToLowerAscii(std::string text) {
+  std::transform(text.begin(), text.end(), text.begin(), [](unsigned char ch) {
+    return static_cast<char>(std::tolower(ch));
+  });
+  return text;
+}
+
+// Extracts ordered digits to reject ambiguous partial matches.
+std::string ExtractDigitSignature(const std::string &text) {
+  std::string digits;
+  for (unsigned char ch : text) {
+    if (std::isdigit(ch))
+      digits.push_back(static_cast<char>(ch));
+  }
+  return digits;
+}
+
+// Normalizes a GDTF catalog or request value into a compact comparison key.
+std::string NormalizeForGdtfMatch(const std::string &text) {
+  static const std::array<std::string, 16> kSuffixes = {
+      " lighting", " light", " gmbh",   " ltd",         " inc", " corp",
+      " co",       " llc",   " electronics", " ag",     " sa",  " sl",
+      " bv",       " nv",    " s.a.",   " s.l."};
+  std::string normalized = ToLowerAscii(TrimFixtureIdentity(text));
+  bool removed = false;
+  do {
+    removed = false;
+    for (const auto &suffix : kSuffixes) {
+      if (normalized.size() >= suffix.size() &&
+          normalized.rfind(suffix) == normalized.size() - suffix.size()) {
+        normalized = TrimFixtureIdentity(normalized.substr(0, normalized.size() - suffix.size()));
+        removed = true;
+      }
+    }
+  } while (removed);
+
+  std::string compact;
+  compact.reserve(normalized.size());
+  for (unsigned char ch : normalized) {
+    if (std::isalnum(ch))
+      compact.push_back(static_cast<char>(ch));
+  }
+  return compact;
+}
+
+// Removes parenthesized variant suffixes from fixture names.
+std::string StripParenthesizedSections(const std::string &text) {
+  std::string stripped;
+  stripped.reserve(text.size());
+  int depth = 0;
+  for (char ch : text) {
+    if (ch == '(') {
+      ++depth;
+      continue;
+    }
+    if (ch == ')') {
+      if (depth > 0)
+        --depth;
+      continue;
+    }
+    if (depth == 0)
+      stripped.push_back(ch);
+  }
+  return TrimFixtureIdentity(stripped);
+}
+
+// Detects version-like fixture-name tokens.
+bool IsLikelyVersionToken(const std::string &token) {
+  if (token.empty())
+    return false;
+  const bool allDigits = std::all_of(token.begin(), token.end(),
+                                     [](unsigned char ch) { return std::isdigit(ch); });
+  if (allDigits)
+    return true;
+
+  if (token.size() <= 6) {
+    const std::string roman = ToLowerAscii(token);
+    const bool allRoman = std::all_of(roman.begin(), roman.end(), [](unsigned char ch) {
+      return ch == 'i' || ch == 'v' || ch == 'x' || ch == 'l' || ch == 'c' ||
+             ch == 'd' || ch == 'm';
+    });
+    if (allRoman)
+      return true;
+  }
+  return false;
+}
+
+// Builds a core fixture-name key without variant tokens.
+std::string BuildCoreFixtureNameKey(const std::string &text) {
+  const std::string stripped = StripParenthesizedSections(text);
+  const std::string lower = ToLowerAscii(stripped);
+  std::vector<std::string> tokens;
+  std::string current;
+  for (unsigned char ch : lower) {
+    if (std::isalnum(ch)) {
+      current.push_back(static_cast<char>(ch));
+    } else if (!current.empty()) {
+      tokens.push_back(current);
+      current.clear();
+    }
+  }
+  if (!current.empty())
+    tokens.push_back(current);
+
+  std::string compact;
+  for (const auto &token : tokens) {
+    if (IsLikelyVersionToken(token))
+      continue;
+    compact += token;
+  }
+  return compact;
+}
+
+// Classifies fixture-name confidence before tie-breakers.
+FixtureNameMatchTier ComputeFixtureNameMatchTier(
+    const std::string &catalogFixtureName,
+    const std::string &requestedFixtureName) {
+  const std::string catalogNormalized = NormalizeForGdtfMatch(catalogFixtureName);
+  const std::string requestedNormalized = NormalizeForGdtfMatch(requestedFixtureName);
+
+  if (catalogNormalized.empty() || requestedNormalized.empty())
+    return FixtureNameMatchTier::None;
+  if (catalogNormalized == requestedNormalized)
+    return FixtureNameMatchTier::ExactNormalized;
+
+  const std::string catalogNoParentheses =
+      NormalizeForGdtfMatch(StripParenthesizedSections(catalogFixtureName));
+  const std::string requestedNoParentheses =
+      NormalizeForGdtfMatch(StripParenthesizedSections(requestedFixtureName));
+  if (!catalogNoParentheses.empty() && !requestedNoParentheses.empty() &&
+      catalogNoParentheses == requestedNoParentheses) {
+    return FixtureNameMatchTier::ParenthesisStripped;
+  }
+
+  const std::string catalogCoreName = BuildCoreFixtureNameKey(catalogFixtureName);
+  const std::string requestedCoreName = BuildCoreFixtureNameKey(requestedFixtureName);
+  if (!catalogCoreName.empty() && !requestedCoreName.empty() &&
+      catalogCoreName == requestedCoreName) {
+    return FixtureNameMatchTier::CoreName;
+  }
+
+  const auto hasContainsMatch = [](const std::string &lhs,
+                                   const std::string &rhs) -> bool {
+    if (lhs.empty() || rhs.empty())
+      return false;
+    return (lhs.size() >= 4 && rhs.find(lhs) != std::string::npos) ||
+           (rhs.size() >= 4 && lhs.find(rhs) != std::string::npos);
+  };
+
+  const bool containsMatch =
+      (catalogNormalized.size() >= 5 &&
+       requestedNormalized.find(catalogNormalized) != std::string::npos) ||
+      (requestedNormalized.size() >= 5 &&
+       catalogNormalized.find(requestedNormalized) != std::string::npos) ||
+      hasContainsMatch(catalogCoreName, requestedCoreName) ||
+      hasContainsMatch(catalogNoParentheses, requestedNoParentheses) ||
+      hasContainsMatch(catalogNormalized, requestedNoParentheses) ||
+      hasContainsMatch(catalogNoParentheses, requestedNormalized);
+  if (!containsMatch)
+    return FixtureNameMatchTier::None;
+
+  const std::string catalogDigits = ExtractDigitSignature(catalogNormalized);
+  const std::string requestedDigits = ExtractDigitSignature(requestedNormalized);
+  if (!catalogDigits.empty() && !requestedDigits.empty() &&
+      catalogDigits != requestedDigits) {
+    return FixtureNameMatchTier::None;
+  }
+
+  return FixtureNameMatchTier::Partial;
+}
+
+// Scores how well a requested GDTF mode aligns with catalog modes and footprint evidence.
+GdtfModeMatchScore ComputeGdtfModeMatchScore(
+    const std::string &requestedMode,
+    const std::vector<GdtfCatalogModeCandidate> &catalogModes,
+    int requestedFootprint) {
+  GdtfModeMatchScore bestScore;
+  const std::string requestedNormalized = NormalizeForGdtfMatch(requestedMode);
+  const std::string requestedDigits = ExtractDigitSignature(requestedNormalized);
+  std::string footprintModeName;
+  bool selectedModeHasFootprint = false;
+
+  for (const auto &mode : catalogModes) {
+    const bool footprintMatch = requestedFootprint > 0 && mode.footprint == requestedFootprint;
+    if (footprintMatch) {
+      bestScore.footprintMatch = true;
+      if (footprintModeName.empty())
+        footprintModeName = mode.name;
+    }
+
+    const std::string modeNormalized = NormalizeForGdtfMatch(mode.name);
+    GdtfModeMatchTier candidateTier = GdtfModeMatchTier::None;
+    if (!requestedNormalized.empty() && !modeNormalized.empty() &&
+        requestedNormalized == modeNormalized) {
+      candidateTier = GdtfModeMatchTier::ExactNormalized;
+    } else {
+      const std::string modeDigits = ExtractDigitSignature(modeNormalized);
+      if (!requestedDigits.empty() && !modeDigits.empty() && requestedDigits == modeDigits)
+        candidateTier = GdtfModeMatchTier::DigitSignature;
+    }
+
+    if (candidateTier == GdtfModeMatchTier::None)
+      continue;
+    if (static_cast<int>(candidateTier) > static_cast<int>(bestScore.tier) ||
+        (candidateTier == bestScore.tier && footprintMatch && !selectedModeHasFootprint)) {
+      bestScore.tier = candidateTier;
+      bestScore.modeName = mode.name;
+      selectedModeHasFootprint = footprintMatch;
+    }
+  }
+
+  if (bestScore.tier == GdtfModeMatchTier::None && bestScore.footprintMatch) {
+    bestScore.tier = GdtfModeMatchTier::Footprint;
+    bestScore.modeName = footprintModeName;
+  }
+  return bestScore;
+}
+
+// Compares download candidates by tier and tie-breakers.
+bool IsBetterDownloadCandidate(const DownloadCandidateRank &candidate,
+                               const DownloadCandidateRank &currentBest) {
+  if (candidate.nameTier != currentBest.nameTier)
+    return static_cast<int>(candidate.nameTier) > static_cast<int>(currentBest.nameTier);
+  if (candidate.modeTier != currentBest.modeTier)
+    return static_cast<int>(candidate.modeTier) > static_cast<int>(currentBest.modeTier);
+  if (candidate.footprintMatch != currentBest.footprintMatch)
+    return candidate.footprintMatch;
+  if (candidate.manufacturerMatch != currentBest.manufacturerMatch)
+    return candidate.manufacturerMatch;
+  if (candidate.recency != currentBest.recency)
+    return candidate.recency > currentBest.recency;
+  return candidate.rating > currentBest.rating;
+}
+
+// Selects the fixture name searched in the GDTF catalog, falling back to type.
+std::string SelectDownloadSearchFixtureName(const std::string &requestedFixtureName,
+                                            const std::string &fixtureTypeName) {
+  const std::string requested = TrimFixtureIdentity(requestedFixtureName);
+  if (!requested.empty())
+    return requested;
+  return TrimFixtureIdentity(fixtureTypeName);
+}
+
+// Builds the human-readable reason for the currently selected catalog match.
+static std::string BuildSelectionReason(const GdtfModeMatchScore &modeScore,
+                                        bool footprintMatch,
+                                        bool manufacturerMatch,
+                                        bool hadPreviousBest,
+                                        const GdtfCatalogEntry &entry,
+                                        const DownloadCandidateRank &bestRank) {
+  std::string selectionReason = "name";
+  if (modeScore.tier == GdtfModeMatchTier::ExactNormalized) {
+    selectionReason = "name+mode";
+  } else if (modeScore.tier == GdtfModeMatchTier::DigitSignature) {
+    selectionReason = "name+mode-digits";
+  } else if (footprintMatch) {
+    selectionReason = "name+footprint";
+  } else if (manufacturerMatch) {
+    selectionReason = "name+manufacturer";
+  } else if (hadPreviousBest && entry.lastModifiedUnix > bestRank.recency) {
+    selectionReason = "name+recency";
+  } else if (hadPreviousBest && entry.rating > bestRank.rating) {
+    selectionReason = "name+rating";
+  }
+  return selectionReason;
+}
+
+// Selects the best downloadable catalog entry for an MVR fixture request.
+GdtfDownloadMatch SelectBestDownloadMatch(
+    const std::string &requestedFixtureName,
+    const std::string &fixtureTypeName,
+    const std::string &requestedMode,
+    const std::string &manufacturer,
+    int requestedFootprint,
+    const std::vector<GdtfCatalogEntry> &catalogEntries) {
+  GdtfDownloadMatch bestMatch;
+  DownloadCandidateRank bestRank;
+  const std::string searchFixtureName =
+      SelectDownloadSearchFixtureName(requestedFixtureName, fixtureTypeName);
+
+  for (const auto &entry : catalogEntries) {
+    const auto nameTier = ComputeFixtureNameMatchTier(entry.fixtureName, searchFixtureName);
+    if (nameTier == FixtureNameMatchTier::None)
+      continue;
+
+    const auto modeScore =
+        ComputeGdtfModeMatchScore(requestedMode, entry.modes, requestedFootprint);
+    const bool footprintMatch = modeScore.footprintMatch;
+    const bool manufacturerMatch =
+        !manufacturer.empty() && !entry.manufacturer.empty() &&
+        NormalizeForGdtfMatch(manufacturer) == NormalizeForGdtfMatch(entry.manufacturer);
+    DownloadCandidateRank candidateRank{nameTier, footprintMatch, manufacturerMatch,
+                                        entry.lastModifiedUnix, entry.rating};
+    candidateRank.modeTier = modeScore.tier;
+    const bool hadPreviousBest = bestMatch.found;
+    if (!IsBetterDownloadCandidate(candidateRank, bestRank))
+      continue;
+
+    const std::string selectionReason = BuildSelectionReason(
+        modeScore, footprintMatch, manufacturerMatch, hadPreviousBest, entry, bestRank);
+    bestRank = candidateRank;
+    bestMatch = {true, entry.rid, modeScore.modeName, selectionReason};
+  }
+
+  return bestMatch;
+}
+
+} // namespace gdtf_catalog_matcher
+} // namespace mvr

--- a/mvr/gdtf_catalog_matcher.h
+++ b/mvr/gdtf_catalog_matcher.h
@@ -1,0 +1,104 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace mvr {
+namespace gdtf_catalog_matcher {
+
+struct GdtfCatalogModeCandidate {
+  std::string name;
+  int footprint = 0;
+};
+
+struct GdtfCatalogEntry {
+  std::string rid;
+  std::string manufacturer;
+  std::string fixtureName;
+  std::vector<GdtfCatalogModeCandidate> modes;
+  long long lastModifiedUnix = 0;
+  float rating = 0.0f;
+};
+
+struct GdtfDownloadMatch {
+  bool found = false;
+  std::string rid;
+  std::string modeName;
+  std::string selectionReason;
+};
+
+enum class FixtureNameMatchTier {
+  None = 0,
+  Partial = 1,
+  CoreName = 2,
+  ParenthesisStripped = 3,
+  ExactNormalized = 4
+};
+
+enum class GdtfModeMatchTier {
+  None = 0,
+  Footprint = 1,
+  DigitSignature = 2,
+  ExactNormalized = 3
+};
+
+struct GdtfModeMatchScore {
+  GdtfModeMatchTier tier = GdtfModeMatchTier::None;
+  bool footprintMatch = false;
+  std::string modeName;
+};
+
+struct DownloadCandidateRank {
+  FixtureNameMatchTier nameTier = FixtureNameMatchTier::None;
+  bool footprintMatch = false;
+  bool manufacturerMatch = false;
+  long long recency = 0;
+  float rating = 0.0f;
+  GdtfModeMatchTier modeTier = GdtfModeMatchTier::None;
+};
+
+std::string TrimFixtureIdentity(const std::string &value);
+std::string ToLowerAscii(std::string text);
+std::string ExtractDigitSignature(const std::string &text);
+std::string NormalizeForGdtfMatch(const std::string &text);
+std::string StripParenthesizedSections(const std::string &text);
+bool IsLikelyVersionToken(const std::string &token);
+std::string BuildCoreFixtureNameKey(const std::string &text);
+FixtureNameMatchTier ComputeFixtureNameMatchTier(
+    const std::string &catalogFixtureName,
+    const std::string &requestedFixtureName);
+GdtfModeMatchScore ComputeGdtfModeMatchScore(
+    const std::string &requestedMode,
+    const std::vector<GdtfCatalogModeCandidate> &catalogModes,
+    int requestedFootprint = 0);
+bool IsBetterDownloadCandidate(const DownloadCandidateRank &candidate,
+                               const DownloadCandidateRank &currentBest);
+std::string SelectDownloadSearchFixtureName(const std::string &requestedFixtureName,
+                                            const std::string &fixtureTypeName);
+GdtfDownloadMatch SelectBestDownloadMatch(
+    const std::string &requestedFixtureName,
+    const std::string &fixtureTypeName,
+    const std::string &requestedMode,
+    const std::string &manufacturer,
+    int requestedFootprint,
+    const std::vector<GdtfCatalogEntry> &catalogEntries);
+
+} // namespace gdtf_catalog_matcher
+} // namespace mvr

--- a/mvr/gdtf_import_matching.h
+++ b/mvr/gdtf_import_matching.h
@@ -17,300 +17,14 @@
  */
 #pragma once
 
+#include "gdtf_catalog_matcher.h"
+
 #include <algorithm>
-#include <array>
-#include <cctype>
 #include <filesystem>
 #include <string>
-#include <vector>
 
 namespace mvr {
 namespace gdtf_import_matching {
-
-// Trims whitespace from an MVR fixture identity candidate.
-inline std::string TrimFixtureIdentity(const std::string &value) {
-  const char *whitespace = " \t\r\n";
-  const size_t start = value.find_first_not_of(whitespace);
-  if (start == std::string::npos)
-    return {};
-  const size_t end = value.find_last_not_of(whitespace);
-  return value.substr(start, end - start + 1);
-}
-
-// Lowercases ASCII text for fixture and manufacturer comparisons.
-inline std::string ToLowerAscii(std::string text) {
-  std::transform(text.begin(), text.end(), text.begin(), [](unsigned char ch) {
-    return static_cast<char>(std::tolower(ch));
-  });
-  return text;
-}
-
-// Extracts ordered digits to reject ambiguous partial matches.
-inline std::string ExtractDigitSignature(const std::string &text) {
-  std::string digits;
-  for (unsigned char ch : text) {
-    if (std::isdigit(ch))
-      digits.push_back(static_cast<char>(ch));
-  }
-  return digits;
-}
-
-// Normalizes a GDTF catalog or request value into a compact comparison key.
-inline std::string NormalizeForGdtfMatch(const std::string &text) {
-  static const std::array<std::string, 16> kSuffixes = {
-      " lighting", " light", " gmbh",   " ltd",         " inc", " corp",
-      " co",       " llc",   " electronics", " ag",     " sa",  " sl",
-      " bv",       " nv",    " s.a.",   " s.l."};
-  std::string normalized = ToLowerAscii(TrimFixtureIdentity(text));
-  bool removed = false;
-  do {
-    removed = false;
-    for (const auto &suffix : kSuffixes) {
-      if (normalized.size() >= suffix.size() &&
-          normalized.rfind(suffix) == normalized.size() - suffix.size()) {
-        normalized = TrimFixtureIdentity(normalized.substr(0, normalized.size() - suffix.size()));
-        removed = true;
-      }
-    }
-  } while (removed);
-
-  std::string compact;
-  compact.reserve(normalized.size());
-  for (unsigned char ch : normalized) {
-    if (std::isalnum(ch))
-      compact.push_back(static_cast<char>(ch));
-  }
-  return compact;
-}
-
-// Removes parenthesized variant suffixes from fixture names.
-inline std::string StripParenthesizedSections(const std::string &text) {
-  std::string stripped;
-  stripped.reserve(text.size());
-  int depth = 0;
-  for (char ch : text) {
-    if (ch == '(') {
-      ++depth;
-      continue;
-    }
-    if (ch == ')') {
-      if (depth > 0)
-        --depth;
-      continue;
-    }
-    if (depth == 0)
-      stripped.push_back(ch);
-  }
-  return TrimFixtureIdentity(stripped);
-}
-
-// Detects version-like fixture-name tokens.
-inline bool IsLikelyVersionToken(const std::string &token) {
-  if (token.empty())
-    return false;
-  const bool allDigits = std::all_of(token.begin(), token.end(),
-                                     [](unsigned char ch) { return std::isdigit(ch); });
-  if (allDigits)
-    return true;
-
-  if (token.size() <= 6) {
-    const std::string roman = ToLowerAscii(token);
-    const bool allRoman = std::all_of(roman.begin(), roman.end(), [](unsigned char ch) {
-      return ch == 'i' || ch == 'v' || ch == 'x' || ch == 'l' || ch == 'c' ||
-             ch == 'd' || ch == 'm';
-    });
-    if (allRoman)
-      return true;
-  }
-  return false;
-}
-
-// Builds a core fixture-name key without variant tokens.
-inline std::string BuildCoreFixtureNameKey(const std::string &text) {
-  const std::string stripped = StripParenthesizedSections(text);
-  const std::string lower = ToLowerAscii(stripped);
-  std::vector<std::string> tokens;
-  std::string current;
-  for (unsigned char ch : lower) {
-    if (std::isalnum(ch)) {
-      current.push_back(static_cast<char>(ch));
-    } else if (!current.empty()) {
-      tokens.push_back(current);
-      current.clear();
-    }
-  }
-  if (!current.empty())
-    tokens.push_back(current);
-
-  std::string compact;
-  for (const auto &token : tokens) {
-    if (IsLikelyVersionToken(token))
-      continue;
-    compact += token;
-  }
-  return compact;
-}
-
-enum class FixtureNameMatchTier {
-  None = 0,
-  Partial = 1,
-  CoreName = 2,
-  ParenthesisStripped = 3,
-  ExactNormalized = 4
-};
-
-// Classifies fixture-name confidence before tie-breakers.
-inline FixtureNameMatchTier ComputeFixtureNameMatchTier(
-    const std::string &catalogFixtureName,
-    const std::string &requestedFixtureName) {
-  const std::string catalogNormalized = NormalizeForGdtfMatch(catalogFixtureName);
-  const std::string requestedNormalized = NormalizeForGdtfMatch(requestedFixtureName);
-
-  if (catalogNormalized.empty() || requestedNormalized.empty())
-    return FixtureNameMatchTier::None;
-  if (catalogNormalized == requestedNormalized)
-    return FixtureNameMatchTier::ExactNormalized;
-
-  const std::string catalogNoParentheses =
-      NormalizeForGdtfMatch(StripParenthesizedSections(catalogFixtureName));
-  const std::string requestedNoParentheses =
-      NormalizeForGdtfMatch(StripParenthesizedSections(requestedFixtureName));
-  if (!catalogNoParentheses.empty() && !requestedNoParentheses.empty() &&
-      catalogNoParentheses == requestedNoParentheses) {
-    return FixtureNameMatchTier::ParenthesisStripped;
-  }
-
-  const std::string catalogCoreName = BuildCoreFixtureNameKey(catalogFixtureName);
-  const std::string requestedCoreName = BuildCoreFixtureNameKey(requestedFixtureName);
-  if (!catalogCoreName.empty() && !requestedCoreName.empty() &&
-      catalogCoreName == requestedCoreName) {
-    return FixtureNameMatchTier::CoreName;
-  }
-
-  const auto hasContainsMatch = [](const std::string &lhs,
-                                   const std::string &rhs) -> bool {
-    if (lhs.empty() || rhs.empty())
-      return false;
-    return (lhs.size() >= 4 && rhs.find(lhs) != std::string::npos) ||
-           (rhs.size() >= 4 && lhs.find(rhs) != std::string::npos);
-  };
-
-  const bool containsMatch =
-      (catalogNormalized.size() >= 5 &&
-       requestedNormalized.find(catalogNormalized) != std::string::npos) ||
-      (requestedNormalized.size() >= 5 &&
-       catalogNormalized.find(requestedNormalized) != std::string::npos) ||
-      hasContainsMatch(catalogCoreName, requestedCoreName) ||
-      hasContainsMatch(catalogNoParentheses, requestedNoParentheses) ||
-      hasContainsMatch(catalogNormalized, requestedNoParentheses) ||
-      hasContainsMatch(catalogNoParentheses, requestedNormalized);
-  if (!containsMatch)
-    return FixtureNameMatchTier::None;
-
-  const std::string catalogDigits = ExtractDigitSignature(catalogNormalized);
-  const std::string requestedDigits = ExtractDigitSignature(requestedNormalized);
-  if (!catalogDigits.empty() && !requestedDigits.empty() &&
-      catalogDigits != requestedDigits) {
-    return FixtureNameMatchTier::None;
-  }
-
-  return FixtureNameMatchTier::Partial;
-}
-
-
-enum class GdtfModeMatchTier {
-  None = 0,
-  Footprint = 1,
-  DigitSignature = 2,
-  ExactNormalized = 3
-};
-
-struct GdtfModeMatchScore {
-  GdtfModeMatchTier tier = GdtfModeMatchTier::None;
-  bool footprintMatch = false;
-  std::string modeName;
-};
-
-// Scores how well a requested GDTF mode aligns with catalog modes and footprint evidence.
-template <typename CatalogModes>
-inline GdtfModeMatchScore ComputeGdtfModeMatchScore(
-    const std::string &requestedMode,
-    const CatalogModes &catalogModes,
-    int requestedFootprint) {
-  GdtfModeMatchScore bestScore;
-  const std::string requestedNormalized = NormalizeForGdtfMatch(requestedMode);
-  const std::string requestedDigits = ExtractDigitSignature(requestedNormalized);
-  std::string footprintModeName;
-  bool selectedModeHasFootprint = false;
-
-  for (const auto &mode : catalogModes) {
-    const bool footprintMatch = requestedFootprint > 0 && mode.footprint == requestedFootprint;
-    if (footprintMatch) {
-      bestScore.footprintMatch = true;
-      if (footprintModeName.empty())
-        footprintModeName = mode.name;
-    }
-
-    const std::string modeNormalized = NormalizeForGdtfMatch(mode.name);
-    GdtfModeMatchTier candidateTier = GdtfModeMatchTier::None;
-    if (!requestedNormalized.empty() && !modeNormalized.empty() &&
-        requestedNormalized == modeNormalized) {
-      candidateTier = GdtfModeMatchTier::ExactNormalized;
-    } else {
-      const std::string modeDigits = ExtractDigitSignature(modeNormalized);
-      if (!requestedDigits.empty() && !modeDigits.empty() && requestedDigits == modeDigits)
-        candidateTier = GdtfModeMatchTier::DigitSignature;
-    }
-
-    if (candidateTier == GdtfModeMatchTier::None)
-      continue;
-    if (static_cast<int>(candidateTier) > static_cast<int>(bestScore.tier) ||
-        (candidateTier == bestScore.tier && footprintMatch && !selectedModeHasFootprint)) {
-      bestScore.tier = candidateTier;
-      bestScore.modeName = mode.name;
-      selectedModeHasFootprint = footprintMatch;
-    }
-  }
-
-  if (bestScore.tier == GdtfModeMatchTier::None && bestScore.footprintMatch) {
-    bestScore.tier = GdtfModeMatchTier::Footprint;
-    bestScore.modeName = footprintModeName;
-  }
-  return bestScore;
-}
-
-// Scores requested mode names against catalog modes without footprint evidence.
-template <typename CatalogModes>
-inline GdtfModeMatchScore ComputeGdtfModeMatchScore(
-    const std::string &requestedMode,
-    const CatalogModes &catalogModes) {
-  return ComputeGdtfModeMatchScore(requestedMode, catalogModes, 0);
-}
-
-struct DownloadCandidateRank {
-  FixtureNameMatchTier nameTier = FixtureNameMatchTier::None;
-  bool footprintMatch = false;
-  bool manufacturerMatch = false;
-  long long recency = 0;
-  float rating = 0.0f;
-  GdtfModeMatchTier modeTier = GdtfModeMatchTier::None;
-};
-
-// Compares download candidates by tier and tie-breakers.
-inline bool IsBetterDownloadCandidate(const DownloadCandidateRank &candidate,
-                                      const DownloadCandidateRank &currentBest) {
-  if (candidate.nameTier != currentBest.nameTier)
-    return static_cast<int>(candidate.nameTier) > static_cast<int>(currentBest.nameTier);
-  if (candidate.modeTier != currentBest.modeTier)
-    return static_cast<int>(candidate.modeTier) > static_cast<int>(currentBest.modeTier);
-  if (candidate.footprintMatch != currentBest.footprintMatch)
-    return candidate.footprintMatch;
-  if (candidate.manufacturerMatch != currentBest.manufacturerMatch)
-    return candidate.manufacturerMatch;
-  if (candidate.recency != currentBest.recency)
-    return candidate.recency > currentBest.recency;
-  return candidate.rating > currentBest.rating;
-}
 
 // Normalizes path separators before deriving a fixture identity from GDTFSpec.
 inline std::string NormalizeGdtfSpecSeparators(std::string gdtfSpec) {
@@ -320,30 +34,23 @@ inline std::string NormalizeGdtfSpecSeparators(std::string gdtfSpec) {
 
 // Extracts the most useful fixture name candidate from an MVR GDTFSpec value.
 inline std::string ExtractFixtureNameFromGdtfSpec(const std::string &gdtfSpec) {
-  const std::string normalized = TrimFixtureIdentity(NormalizeGdtfSpecSeparators(gdtfSpec));
+  const std::string normalized =
+      gdtf_catalog_matcher::TrimFixtureIdentity(NormalizeGdtfSpecSeparators(gdtfSpec));
   if (normalized.empty())
     return {};
   const std::filesystem::path specPath(normalized);
   std::string stem = specPath.filename().stem().string();
-  return TrimFixtureIdentity(stem);
+  return gdtf_catalog_matcher::TrimFixtureIdentity(stem);
 }
 
 // Selects the original MVR fixture identity to use for automatic GDTF matching.
 inline std::string SelectRequestedFixtureName(const std::string &rawFixtureNodeName,
                                               const std::string &rawGdtfSpec) {
-  const std::string fixtureNodeName = TrimFixtureIdentity(rawFixtureNodeName);
+  const std::string fixtureNodeName =
+      gdtf_catalog_matcher::TrimFixtureIdentity(rawFixtureNodeName);
   if (!fixtureNodeName.empty())
     return fixtureNodeName;
   return ExtractFixtureNameFromGdtfSpec(rawGdtfSpec);
-}
-
-// Selects the fixture name searched in the GDTF catalog, falling back to type.
-inline std::string SelectDownloadSearchFixtureName(const std::string &requestedFixtureName,
-                                                   const std::string &fixtureTypeName) {
-  const std::string requested = TrimFixtureIdentity(requestedFixtureName);
-  if (!requested.empty())
-    return requested;
-  return TrimFixtureIdentity(fixtureTypeName);
 }
 
 } // namespace gdtf_import_matching

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -28,6 +28,7 @@
 #include "gdtfloader.h"
 #include "gdtf_catalog_service.h"
 #include "gdtf_import_matching.h"
+#include "gdtf_catalog_matcher.h"
 #include "gdtf_fixture_category.h"
 #include "matrixutils.h"
 #include "primitive_model_resources.h"
@@ -88,6 +89,7 @@ class wxZipStreamLink;
 #include <wx/zipstrm.h>
 
 namespace fs = std::filesystem;
+namespace gdtf_catalog_matcher = mvr::gdtf_catalog_matcher;
 
 // Helper to convert between std::u8string and std::string without
 // losing the underlying UTF-8 byte sequence.
@@ -640,41 +642,11 @@ static std::string GetDownloadFallbackPath(const GdtfConflict &conflict) {
   return !conflict.appPath.empty() ? conflict.appPath : conflict.mvrPath;
 }
 
-struct GdtfCatalogModeCandidate {
-  std::string name;
-  int footprint = 0;
-};
-
-struct GdtfCatalogEntry {
-  std::string rid;
-  std::string manufacturer;
-  std::string fixtureName;
-  std::vector<GdtfCatalogModeCandidate> modes;
-  long long lastModifiedUnix = 0;
-  float rating = 0.0f;
-};
-
-struct GdtfDownloadMatch {
-  bool found = false;
-  std::string rid;
-  std::string modeName;
-  std::string selectionReason;
-};
-
-// Scores requested mode names against a catalog entry and preserves the best catalog mode name.
-static mvr::gdtf_import_matching::GdtfModeMatchScore ComputeGdtfModeMatchScore(
-    const std::string &requestedMode,
-    const std::vector<GdtfCatalogModeCandidate> &catalogModes,
-    int requestedFootprint) {
-  return mvr::gdtf_import_matching::ComputeGdtfModeMatchScore(
-      requestedMode, catalogModes, requestedFootprint);
-}
-
 // Parses GDTF catalog JSON into normalized entries used by automatic downloads.
-static std::vector<GdtfCatalogEntry>
+static std::vector<gdtf_catalog_matcher::GdtfCatalogEntry>
 ParseGdtfCatalogEntries(const std::string &listData) {
   using json = nlohmann::json;
-  std::vector<GdtfCatalogEntry> entries;
+  std::vector<gdtf_catalog_matcher::GdtfCatalogEntry> entries;
   json j = json::parse(listData, nullptr, false);
   if (j.is_discarded())
     return entries;
@@ -752,10 +724,10 @@ ParseGdtfCatalogEntries(const std::string &listData) {
   };
 
   auto parseModes = [&](const json &item) {
-    std::vector<GdtfCatalogModeCandidate> modes;
+    std::vector<gdtf_catalog_matcher::GdtfCatalogModeCandidate> modes;
     if (item.contains("dmxModes") && item["dmxModes"].is_array()) {
       for (const auto &mode : item["dmxModes"]) {
-        GdtfCatalogModeCandidate parsed;
+        gdtf_catalog_matcher::GdtfCatalogModeCandidate parsed;
         if (mode.is_object()) {
           parsed.name = jsonToString(mode.value("name", json{}));
           parsed.footprint =
@@ -771,7 +743,7 @@ ParseGdtfCatalogEntries(const std::string &listData) {
   for (const auto &item : j) {
     if (!item.is_object())
       continue;
-    GdtfCatalogEntry entry;
+    gdtf_catalog_matcher::GdtfCatalogEntry entry;
     entry.rid = getValue(item, {"rid", "revisionId"});
     entry.manufacturer = getValue(item, {"manufacturer", "brand", "mfr"});
     entry.fixtureName = getValue(item, {"fixture", "name", "model"});
@@ -3120,7 +3092,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                                    catalogResult.metrics.refreshSucceeded ? 1 : 0)
                       .ToStdString());
 
-              std::vector<GdtfCatalogEntry> catalogEntries;
+              std::vector<gdtf_catalog_matcher::GdtfCatalogEntry> catalogEntries;
               std::string catalogFailureReason;
               if (!listPayload.empty()) {
                 catalogEntries = ParseGdtfCatalogEntries(listPayload);
@@ -3176,56 +3148,9 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                   reportProgress("Downloading selected GDTFs: matching " + req.type + "...");
                   if (req.footprint <= 0)
                     req.footprint = inferFootprintFromAddresses(req.type);
-                  GdtfDownloadMatch bestMatch;
-                  mvr::gdtf_import_matching::DownloadCandidateRank bestPrimaryScore;
-                  for (const auto &entry : catalogEntries) {
-                    const std::string requestedFixtureName =
-                        mvr::gdtf_import_matching::SelectDownloadSearchFixtureName(
-                            req.requestedFixtureName, req.type);
-                    const auto nameTier =
-                        mvr::gdtf_import_matching::ComputeFixtureNameMatchTier(
-                            entry.fixtureName, requestedFixtureName);
-                    if (nameTier == mvr::gdtf_import_matching::FixtureNameMatchTier::None) {
-                      continue;
-                    }
-                    const auto modeScore =
-                        ComputeGdtfModeMatchScore(req.modeName, entry.modes, req.footprint);
-                    const std::string matchedMode = modeScore.modeName;
-                    const bool footprintMatch = modeScore.footprintMatch;
-                    const bool manufacturerMatch =
-                        !req.manufacturer.empty() && !entry.manufacturer.empty() &&
-                        mvr::gdtf_import_matching::NormalizeForGdtfMatch(req.manufacturer) ==
-                            mvr::gdtf_import_matching::NormalizeForGdtfMatch(entry.manufacturer);
-                    mvr::gdtf_import_matching::DownloadCandidateRank candidateRank{
-                        nameTier, footprintMatch, manufacturerMatch,
-                        entry.lastModifiedUnix, entry.rating};
-                    candidateRank.modeTier = modeScore.tier;
-                    const bool hadPreviousBest = bestMatch.found;
-                    if (!mvr::gdtf_import_matching::IsBetterDownloadCandidate(
-                            candidateRank, bestPrimaryScore)) {
-                      continue;
-                    }
-
-                    std::string selectionReason = "name";
-                    if (modeScore.tier ==
-                        mvr::gdtf_import_matching::GdtfModeMatchTier::ExactNormalized) {
-                      selectionReason = "name+mode";
-                    } else if (modeScore.tier ==
-                               mvr::gdtf_import_matching::GdtfModeMatchTier::DigitSignature) {
-                      selectionReason = "name+mode-digits";
-                    } else if (footprintMatch) {
-                      selectionReason = "name+footprint";
-                    } else if (manufacturerMatch) {
-                      selectionReason = "name+manufacturer";
-                    } else if (hadPreviousBest &&
-                               entry.lastModifiedUnix > bestPrimaryScore.recency) {
-                      selectionReason = "name+recency";
-                    } else if (hadPreviousBest && entry.rating > bestPrimaryScore.rating) {
-                      selectionReason = "name+rating";
-                    }
-                    bestPrimaryScore = candidateRank;
-                    bestMatch = {true, entry.rid, matchedMode, selectionReason};
-                  }
+                  const auto bestMatch = gdtf_catalog_matcher::SelectBestDownloadMatch(
+                      req.requestedFixtureName, req.type, req.modeName, req.manufacturer,
+                      req.footprint, catalogEntries);
 
                   if (!bestMatch.found || bestMatch.rid.empty()) {
                     const wxString progressText =

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -311,6 +311,7 @@ add_executable(save_load_roundtrip_test save_load_roundtrip_test.cpp
                ../core/uuidutils.cpp
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
+               ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
                ../mvr/primitive_model_resources.cpp
@@ -344,6 +345,7 @@ add_executable(project_support_userdata_roundtrip_test project_support_userdata_
                ../core/uuidutils.cpp
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
+               ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
                ../mvr/primitive_model_resources.cpp
@@ -402,6 +404,7 @@ add_executable(rider_truss_dictionary_normalization_test
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
+               ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
                ../mvr/primitive_model_resources.cpp
@@ -418,7 +421,8 @@ target_include_directories(rider_truss_dictionary_normalization_test PRIVATE
 target_link_libraries(rider_truss_dictionary_normalization_test PRIVATE ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
 add_test(NAME RiderTrussDictionaryNormalization COMMAND rider_truss_dictionary_normalization_test)
 
-add_executable(mvr_gdtf_import_matching_test mvr_gdtf_import_matching_test.cpp)
+add_executable(mvr_gdtf_import_matching_test mvr_gdtf_import_matching_test.cpp
+               ../mvr/gdtf_catalog_matcher.cpp)
 target_include_directories(mvr_gdtf_import_matching_test PRIVATE ../mvr)
 add_test(NAME MvrGdtfImportMatching COMMAND mvr_gdtf_import_matching_test)
 
@@ -438,6 +442,7 @@ add_executable(mvr_dmx_address_test mvr_dmx_address_test.cpp
                ../core/uuidutils.cpp
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
+               ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../core/logger.cpp
                gdtfloader_stub.cpp
@@ -469,6 +474,7 @@ add_executable(mvr_support_userdata_roundtrip_test mvr_support_userdata_roundtri
                ../core/uuidutils.cpp
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
+               ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
                ../mvr/primitive_model_resources.cpp
@@ -503,6 +509,7 @@ add_executable(mvr_fixture_category_roundtrip_test mvr_fixture_category_roundtri
                ../core/uuidutils.cpp
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
+               ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
                ../mvr/primitive_model_resources.cpp
@@ -536,6 +543,7 @@ add_executable(mvr_truss_roundtrip_structure_test mvr_truss_roundtrip_structure_
                ../core/uuidutils.cpp
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
+               ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
                ../mvr/primitive_model_resources.cpp
@@ -569,6 +577,7 @@ add_executable(mvr_exporter_compliance_test mvr_exporter_compliance_test.cpp
                ../core/uuidutils.cpp
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
+               ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
                ../mvr/primitive_model_resources.cpp
@@ -610,6 +619,7 @@ add_executable(rider_save_roundtrip_test rider_save_roundtrip_test.cpp
                ../core/truss_gdtf_builder.cpp
                ../core/dummyprofilelibrary.cpp
                ../mvr/mvrimporter.cpp
+               ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
                ../mvr/primitive_model_resources.cpp
@@ -1123,6 +1133,7 @@ add_executable(symbol_fixture_applier_gdtf_test symbol_fixture_applier_gdtf_test
                ../viewer3d/loaderglb.cpp
                ../viewer3d/meshprimitives.cpp
                ../mvr/mvrimporter.cpp
+               ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                ../mvr/mvrexporter.cpp
                ../mvr/primitive_model_resources.cpp
@@ -1161,6 +1172,7 @@ add_executable(mvr_patched_gdtf_export_test mvr_patched_gdtf_export_test.cpp
                ../viewer3d/loaderglb.cpp
                ../viewer3d/meshprimitives.cpp
                ../mvr/mvrimporter.cpp
+               ../mvr/gdtf_catalog_matcher.cpp
                ../viewer2d/fixture_label_overrides.cpp
                consolepanel_stub.cpp
                ${LAYOUT_SOURCES})

--- a/tests/mvr_gdtf_import_matching_test.cpp
+++ b/tests/mvr_gdtf_import_matching_test.cpp
@@ -1,10 +1,12 @@
+#include "gdtf_catalog_matcher.h"
 #include "gdtf_import_matching.h"
 
 #include <cassert>
 #include <string>
 #include <vector>
 
-namespace matching = mvr::gdtf_import_matching;
+namespace catalog = mvr::gdtf_catalog_matcher;
+namespace import_matching = mvr::gdtf_import_matching;
 
 struct DownloadRequestProbe {
   std::string requestedFixtureName;
@@ -15,162 +17,134 @@ struct DownloadRequestProbe {
 static void VerifyDistinctOriginalNamesBeatSharedPlaceholderMetadata() {
   const std::string placeholderType = "BLED Standard mode 12CH";
   const std::vector<DownloadRequestProbe> requests = {
-      {matching::SelectRequestedFixtureName("Aleda K10 B-EYE",
-                                            "Fixtures/BLED Standard mode 12CH.gdtf"),
+      {import_matching::SelectRequestedFixtureName("Aleda K10 B-EYE",
+                                                   "Fixtures/BLED Standard mode 12CH.gdtf"),
        placeholderType},
-      {matching::SelectRequestedFixtureName("Super Storm 1500",
-                                            "Fixtures/BLED Standard mode 12CH.gdtf"),
+      {import_matching::SelectRequestedFixtureName("Super Storm 1500",
+                                                   "Fixtures/BLED Standard mode 12CH.gdtf"),
        placeholderType},
   };
 
-  assert(matching::SelectDownloadSearchFixtureName(requests[0].requestedFixtureName,
-                                                   requests[0].resolvedFixtureTypeName) ==
+  assert(catalog::SelectDownloadSearchFixtureName(requests[0].requestedFixtureName,
+                                                  requests[0].resolvedFixtureTypeName) ==
          "Aleda K10 B-EYE");
-  assert(matching::SelectDownloadSearchFixtureName(requests[1].requestedFixtureName,
-                                                   requests[1].resolvedFixtureTypeName) ==
+  assert(catalog::SelectDownloadSearchFixtureName(requests[1].requestedFixtureName,
+                                                  requests[1].resolvedFixtureTypeName) ==
          "Super Storm 1500");
-  assert(matching::SelectDownloadSearchFixtureName(requests[0].requestedFixtureName,
-                                                   requests[0].resolvedFixtureTypeName) !=
+  assert(catalog::SelectDownloadSearchFixtureName(requests[0].requestedFixtureName,
+                                                  requests[0].resolvedFixtureTypeName) !=
          placeholderType);
-  assert(matching::SelectDownloadSearchFixtureName(requests[1].requestedFixtureName,
-                                                   requests[1].resolvedFixtureTypeName) !=
+  assert(catalog::SelectDownloadSearchFixtureName(requests[1].requestedFixtureName,
+                                                  requests[1].resolvedFixtureTypeName) !=
          placeholderType);
 }
 
 // Verifies that the GDTFSpec basename is used when the fixture node name is unavailable.
 static void VerifySpecBasenameFallback() {
-  assert(matching::SelectRequestedFixtureName("", "Folder/Super Storm 1500.gdtf") ==
+  assert(import_matching::SelectRequestedFixtureName("", "Folder/Super Storm 1500.gdtf") ==
          "Super Storm 1500");
-  assert(matching::SelectRequestedFixtureName("\t\n", "Folder\\Aleda K10 B-EYE.gdtf") ==
+  assert(import_matching::SelectRequestedFixtureName("\t\n", "Folder\\Aleda K10 B-EYE.gdtf") ==
          "Aleda K10 B-EYE");
 }
 
 // Verifies that resolved metadata remains the final fallback when no original MVR identity exists.
 static void VerifyResolvedTypeFallback() {
-  assert(matching::SelectDownloadSearchFixtureName("", "BLED Standard mode 12CH") ==
+  assert(catalog::SelectDownloadSearchFixtureName("", "BLED Standard mode 12CH") ==
          "BLED Standard mode 12CH");
 }
 
 // Verifies name confidence outranks footprint matches.
 static void VerifyExactNameWithoutFootprintBeatsPartialNameWithFootprint() {
-  const auto exactTier = matching::ComputeFixtureNameMatchTier("My Beam 200",
-                                                              "My Beam 200");
-  const auto partialTier = matching::ComputeFixtureNameMatchTier("My Beam 200 Extended",
-                                                                "My Beam 200");
-  const matching::DownloadCandidateRank exactNoFootprint{
+  const auto exactTier = catalog::ComputeFixtureNameMatchTier("My Beam 200",
+                                                             "My Beam 200");
+  const auto partialTier = catalog::ComputeFixtureNameMatchTier("My Beam 200 Extended",
+                                                               "My Beam 200");
+  const catalog::DownloadCandidateRank exactNoFootprint{
       exactTier, false, false, 100, 0.0f};
-  const matching::DownloadCandidateRank partialWithFootprint{
+  const catalog::DownloadCandidateRank partialWithFootprint{
       partialTier, true, false, 200, 5.0f};
 
-  assert(exactTier == matching::FixtureNameMatchTier::ExactNormalized);
-  assert(partialTier == matching::FixtureNameMatchTier::Partial);
-  assert(matching::IsBetterDownloadCandidate(exactNoFootprint, partialWithFootprint));
-  assert(!matching::IsBetterDownloadCandidate(partialWithFootprint, exactNoFootprint));
+  assert(exactTier == catalog::FixtureNameMatchTier::ExactNormalized);
+  assert(partialTier == catalog::FixtureNameMatchTier::Partial);
+  assert(catalog::IsBetterDownloadCandidate(exactNoFootprint, partialWithFootprint));
+  assert(!catalog::IsBetterDownloadCandidate(partialWithFootprint, exactNoFootprint));
 }
 
 // Verifies manufacturer matches outrank recency ties.
 static void VerifyManufacturerMatchBeatsRecencyInsideSameNameAndFootprintTier() {
-  const auto tier = matching::ComputeFixtureNameMatchTier("My Beam 200", "My Beam 200");
-  const matching::DownloadCandidateRank manufacturerMatch{
+  const auto tier = catalog::ComputeFixtureNameMatchTier("My Beam 200", "My Beam 200");
+  const catalog::DownloadCandidateRank manufacturerMatch{
       tier, true, true, 100, 0.0f};
-  const matching::DownloadCandidateRank newerWithoutManufacturer{
+  const catalog::DownloadCandidateRank newerWithoutManufacturer{
       tier, true, false, 200, 5.0f};
 
-  assert(matching::IsBetterDownloadCandidate(manufacturerMatch,
-                                             newerWithoutManufacturer));
-  assert(!matching::IsBetterDownloadCandidate(newerWithoutManufacturer,
-                                              manufacturerMatch));
-}
-
-struct CatalogModeProbe {
-  std::string name;
-  int footprint = 0;
-};
-
-struct DownloadCandidateProbe {
-  std::string rid;
-  std::string fixtureName;
-  std::vector<CatalogModeProbe> modes;
-  long long recency = 0;
-  float rating = 0.0f;
-};
-
-struct SelectedDownloadProbe {
-  std::string rid;
-  std::string modeName;
-};
-
-// Selects the best probe download candidate using the same matching rank used by downloads.
-static SelectedDownloadProbe SelectBestDownloadCandidateProbe(
-    const std::string &requestedFixtureName,
-    const std::string &requestedMode,
-    int requestedFootprint,
-    const std::vector<DownloadCandidateProbe> &candidates) {
-  SelectedDownloadProbe selected;
-  matching::DownloadCandidateRank bestRank;
-  for (const auto &candidate : candidates) {
-    const auto nameTier = matching::ComputeFixtureNameMatchTier(candidate.fixtureName,
-                                                               requestedFixtureName);
-    if (nameTier == matching::FixtureNameMatchTier::None)
-      continue;
-
-    const auto modeScore = matching::ComputeGdtfModeMatchScore(
-        requestedMode, candidate.modes, requestedFootprint);
-    matching::DownloadCandidateRank rank{nameTier, modeScore.footprintMatch, false,
-                                         candidate.recency, candidate.rating};
-    rank.modeTier = modeScore.tier;
-    if (!matching::IsBetterDownloadCandidate(rank, bestRank))
-      continue;
-
-    bestRank = rank;
-    selected = {candidate.rid, modeScore.modeName};
-  }
-  return selected;
+  assert(catalog::IsBetterDownloadCandidate(manufacturerMatch,
+                                            newerWithoutManufacturer));
+  assert(!catalog::IsBetterDownloadCandidate(newerWithoutManufacturer,
+                                             manufacturerMatch));
 }
 
 // Verifies 12CH digit signatures keep Standard mode requests aligned with mode-aware fixtures.
 static void VerifyStandardModeDigitSignatureBeatsNewerFootprintOnlyMatch() {
-  const std::vector<DownloadCandidateProbe> candidates = {
-      {"fixture-standard", "BLED", {{"Basic", 8}, {"Touring 12CH", 24}}, 100, 3.0f},
-      {"fixture-newer", "BLED", {{"Economy", 12}}, 200, 5.0f},
+  const std::vector<catalog::GdtfCatalogEntry> candidates = {
+      {"fixture-standard", "", "BLED", {{"Basic", 8}, {"Touring 12CH", 24}}, 100, 3.0f},
+      {"fixture-newer", "", "BLED", {{"Economy", 12}}, 200, 5.0f},
   };
 
-  const auto selected = SelectBestDownloadCandidateProbe(
-      "BLED", "Standard mode 12CH", 12, candidates);
+  const auto selected = catalog::SelectBestDownloadMatch(
+      "BLED", "", "Standard mode 12CH", "", 12, candidates);
 
   assert(selected.rid == "fixture-standard");
   assert(selected.modeName == "Touring 12CH");
+  assert(selected.selectionReason == "name+mode-digits");
 }
 
 // Verifies simple named modes without digits outrank footprint-only alternatives.
 static void VerifyBasicModeNameBeatsFootprintOnlyMatch() {
-  const std::vector<DownloadCandidateProbe> candidates = {
-      {"fixture-basic", "Wash 600", {{"Basic", 16}, {"Extended", 24}}, 100, 3.0f},
-      {"fixture-footprint", "Wash 600", {{"Arc Layout", 16}}, 250, 5.0f},
+  const std::vector<catalog::GdtfCatalogEntry> candidates = {
+      {"fixture-basic", "", "Wash 600", {{"Basic", 16}, {"Extended", 24}}, 100, 3.0f},
+      {"fixture-footprint", "", "Wash 600", {{"Arc Layout", 16}}, 250, 5.0f},
   };
 
-  const auto selected = SelectBestDownloadCandidateProbe(
-      "Wash 600", "Basic", 16, candidates);
+  const auto selected = catalog::SelectBestDownloadMatch(
+      "Wash 600", "", "Basic", "", 16, candidates);
 
   assert(selected.rid == "fixture-basic");
   assert(selected.modeName == "Basic");
+  assert(selected.selectionReason == "name+mode");
 }
 
 // Verifies fixture-specific named modes stay paired with the matching catalog mode.
 static void VerifyFixtureSpecificNamedModeStaysAligned() {
-  const std::vector<DownloadCandidateProbe> candidates = {
-      {"fixture-shapes", "Aleda K10 B-EYE", {{"B-EYE Shapes", 35}, {"Standard", 21}}, 100, 3.0f},
-      {"fixture-digits", "Aleda K10 B-EYE", {{"Pixel 35CH", 35}, {"Standard", 21}}, 300, 5.0f},
+  const std::vector<catalog::GdtfCatalogEntry> candidates = {
+      {"fixture-shapes", "", "Aleda K10 B-EYE", {{"B-EYE Shapes", 35}, {"Standard", 21}}, 100, 3.0f},
+      {"fixture-digits", "", "Aleda K10 B-EYE", {{"Pixel 35CH", 35}, {"Standard", 21}}, 300, 5.0f},
   };
 
-  const auto selected = SelectBestDownloadCandidateProbe(
-      "Aleda K10 B-EYE", "B-EYE Shapes", 35, candidates);
+  const auto selected = catalog::SelectBestDownloadMatch(
+      "Aleda K10 B-EYE", "", "B-EYE Shapes", "", 35, candidates);
 
   assert(selected.rid == "fixture-shapes");
   assert(selected.modeName == "B-EYE Shapes");
+  assert(selected.selectionReason == "name+mode");
 }
 
-// Runs focused coverage for MVR-requested GDTF import matching identity selection.
+// Verifies manufacturer evidence is applied during final catalog selection.
+static void VerifyFinalSelectionUsesManufacturerTieBreaker() {
+  const std::vector<catalog::GdtfCatalogEntry> candidates = {
+      {"wrong-brand", "Other Lighting", "My Beam 200", {{"Basic", 16}}, 300, 5.0f},
+      {"right-brand", "Acme GmbH", "My Beam 200", {{"Basic", 16}}, 100, 3.0f},
+  };
+
+  const auto selected = catalog::SelectBestDownloadMatch(
+      "My Beam 200", "", "Basic", "Acme", 16, candidates);
+
+  assert(selected.rid == "right-brand");
+  assert(selected.modeName == "Basic");
+  assert(selected.selectionReason == "name+mode");
+}
+
+// Runs focused coverage for MVR-requested GDTF import and catalog matching selection.
 int main() {
   VerifyDistinctOriginalNamesBeatSharedPlaceholderMetadata();
   VerifySpecBasenameFallback();
@@ -180,5 +154,6 @@ int main() {
   VerifyStandardModeDigitSignatureBeatsNewerFootprintOnlyMatch();
   VerifyBasicModeNameBeatsFootprintOnlyMatch();
   VerifyFixtureSpecificNamedModeStaysAligned();
+  VerifyFinalSelectionUsesManufacturerTieBreaker();
   return 0;
 }


### PR DESCRIPTION
### Motivation
- Reduce responsibility and complexity inside `mvr/mvrimporter.cpp` by extracting catalog matching logic into a focused module for clearer ownership and easier unit testing. 
- Make fixture-name normalization, mode/footprint scoring, and final candidate selection reusable and easier to maintain. 
- Keep public importer flow, dialogs, and I/O unchanged while centralizing matching rules for future improvements.

### Description
- Added a new matcher module `mvr/gdtf_catalog_matcher.h` and `mvr/gdtf_catalog_matcher.cpp` that own `GdtfCatalogEntry`, `GdtfCatalogModeCandidate`, `GdtfDownloadMatch`, normalization helpers, fixture-name scoring, mode/footprint scoring, candidate ranking (`DownloadCandidateRank`), and `SelectBestDownloadMatch(...)` for final selection. 
- Updated `mvr/gdtf_import_matching.h` to keep only MVR-specific identity helpers and to delegate trimming/normalization to the new matcher for consistency. 
- Refactored `mvr/mvrimporter.cpp` to parse catalog JSON into `gdtf_catalog_matcher::GdtfCatalogEntry` instances and delegate candidate selection to `gdtf_catalog_matcher::SelectBestDownloadMatch(...)`, keeping importer flow, dialogs and download/apply logic unchanged. 
- Registered `mvr/gdtf_catalog_matcher.cpp` explicitly in `CMakeLists.txt` and added the matcher source to relevant test targets in `tests/CMakeLists.txt`. 
- Updated `tests/mvr_gdtf_import_matching_test.cpp` to exercise the extracted matcher (fixture name selection, mode scoring, final best-match selection and manufacturer tie-breaker). 
- Preserved existing behavior; no user-visible changes are included, so `docs/release-notes-draft.md` was not updated.

### Testing
- Built and ran the focused unit test: `g++ -std=c++17 -I mvr tests/mvr_gdtf_import_matching_test.cpp mvr/gdtf_catalog_matcher.cpp -o /tmp/mvr_gdtf_import_matching_test && /tmp/mvr_gdtf_import_matching_test`, which executed and returned success. 
- Ran repository checks `tests/check_perastage_tree_modules.sh && tests/check_no_configmanager_get_in_gui.sh`, both returned `OK`. 
- Ran `git diff --check` to validate whitespace and patch hygiene; it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21a907efdc8324834ba2dc975a92d1)