### PR TITLE
Fix stale 3D empty-space deselection

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -52,6 +52,7 @@ Changes since `v1.2.0`.
 - Fixed MVR import and GDTF download progress UI races that could update UI from the wrong thread or after dialogs were already closed.
 - Fixed MVR exports with missing non-critical resources so users receive warnings instead of failing the entire export when possible.
 - Fixed 2D scene-object depth sorting so objects draw in the expected order.
+- Fixed 3D empty-space deselection so fixtures, trusses, hoists, and scene objects are cleared consistently across the viewer and object tables.
 
 ## Stability and reliability
 

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -45,6 +45,7 @@
 #include "consolepanel.h"
 #include "fixturetablepanel.h"
 #include "trusstablepanel.h"
+#include "hoisttablepanel.h"
 #include "sceneobjecttablepanel.h"
 #include "scene_object_primitive_editing.h"
 #include "../gui/selection_origin_token.h"
@@ -1614,38 +1615,41 @@ void Viewer3DPanel::OnMouseUp(wxMouseEvent& event)
         }
         else
         {
-            if (FixtureTablePanel::Instance() && FixtureTablePanel::Instance()->IsActivePage()) {
-                if (!cfg.GetSelectedFixtures().empty()) {
-                    cfg.PushUndoState("fixture selection");
-                    cfg.SetSelectedFixtures({});
-                }
-                SetSelectedFixtures({});
-                FixtureTablePanel::Instance()->ClearSelection();
-            }
-            else if (TrussTablePanel::Instance() && TrussTablePanel::Instance()->IsActivePage()) {
-                if (!cfg.GetSelectedTrusses().empty()) {
-                    cfg.PushUndoState("truss selection");
-                    cfg.SetSelectedTrusses({});
-                }
-                SetSelectedFixtures({});
-                TrussTablePanel::Instance()->ClearSelection();
-            }
-            else if (SceneObjectTablePanel::Instance() && SceneObjectTablePanel::Instance()->IsActivePage()) {
-                if (!cfg.GetSelectedSceneObjects().empty()) {
-                    cfg.PushUndoState("scene object selection");
-                    cfg.SetSelectedSceneObjects({});
-                }
-                SetSelectedFixtures({});
-                SceneObjectTablePanel::Instance()->ClearSelection();
-            }
-            else {
-                SetSelectedFixtures({});
-            }
+            ClearAllObjectSelections("clear selection");
         }
     }
     m_draggedSincePress = false;
 }
 
+
+// Clears every object-selection store and synchronizes table and viewport highlights.
+void Viewer3DPanel::ClearAllObjectSelections(const char* undoLabel)
+{
+    ConfigManager& cfg = ConfigManager::Get();
+    const bool hasAnySelection =
+        !cfg.GetSelectedFixtures().empty() || !cfg.GetSelectedTrusses().empty() ||
+        !cfg.GetSelectedSupports().empty() || !cfg.GetSelectedSceneObjects().empty();
+
+    if (hasAnySelection) {
+        cfg.PushUndoState(undoLabel);
+        cfg.SetSelectedFixtures({});
+        cfg.SetSelectedTrusses({});
+        cfg.SetSelectedSupports({});
+        cfg.SetSelectedSceneObjects({});
+    }
+
+    SetSelectedFixtures({});
+    if (Viewer2DPanel::Instance())
+        Viewer2DPanel::Instance()->SetSelectedUuids({});
+    if (FixtureTablePanel::Instance())
+        FixtureTablePanel::Instance()->ClearSelection();
+    if (TrussTablePanel::Instance())
+        TrussTablePanel::Instance()->ClearSelection();
+    if (HoistTablePanel::Instance())
+        HoistTablePanel::Instance()->ClearSelection();
+    if (SceneObjectTablePanel::Instance())
+        SceneObjectTablePanel::Instance()->ClearSelection();
+}
 
 // Opens the right-click selection and render-style context menu.
 void Viewer3DPanel::OnRightUp(wxMouseEvent& event)

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -138,6 +138,9 @@ private:
     void OnKeyDown(wxKeyEvent& event);
     void OnMouseEnter(wxMouseEvent& event);
     void OnMouseLeave(wxMouseEvent& event);
+
+    // Clear all selected scene object types and refresh related UI state.
+    void ClearAllObjectSelections(const char* undoLabel);
     void OnCaptureLost(wxMouseCaptureLostEvent& event);
     void ApplyRectangleSelection(const wxPoint& start, const wxPoint& end);
     void DrawSelectionRectangle(int width, int height);


### PR DESCRIPTION
### Motivation
- Clicking empty space in the 3D viewer did not reliably clear all object-type selections, leaving stale truss/hoist/scene-object selections in memory and causing operations (rotate/move) to affect invisible selections. 
- Make empty-space deselection robust and consistent across the 3D viewport, 2D viewport, and all object tables.

### Description
- Replace the previous per-path clearing logic with a centralized helper `Viewer3DPanel::ClearAllObjectSelections(const char* undoLabel)` that clears fixtures, trusses, supports/hoists, and scene objects in `ConfigManager` and synchronizes table highlights and 2D/3D viewport selection states. 
- Call `ClearAllObjectSelections("clear selection")` from the 3D empty-space click path and add the helper declaration to `viewer3d/viewer3dpanel.h`. 
- Include `hoisttablepanel.h` so hoist/support table selection is also cleared, and update `docs/release-notes-draft.md` with a user-facing fix entry describing the change.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which passed. 
- Ran `git diff --check` which reported no issues. 
- Attempted `cmake --preset wsl-x64-debug` and `cmake --build --preset wsl-debug-build` but these could not complete in this environment due to missing system wxWidgets development libraries (configuration/build not executed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21ac606ddc8324a938e48669f2769f)