### PR TITLE
Add dismissible startup update reminders

### DIFF
--- a/docs/preferences.md
+++ b/docs/preferences.md
@@ -19,8 +19,8 @@ Current user-facing preferences include:
 
 ## Update check behavior
 
-- **Check on startup (recommended)**: checks on launch, limited to at most once every 24 hours.
-- **Manual only**: does not run startup checks; use **Help → Check for Updates** on demand.
+- **Check on startup (recommended)**: checks on launch, limited to at most once every 24 hours. When a newer version is found, you can choose **Do not remind me again for this version** to suppress future startup reminders for that same version.
+- **Manual only**: does not run startup checks; use **Help → Check for Updates** on demand. Manual checks still show the current result even if a startup reminder was previously dismissed.
 
 ## Good practice
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -15,6 +15,7 @@ Changes since `v1.2.0`.
 - Added a 2D measurement tool with live preview, active-plane distance calculation, HiDPI-aware cursor mapping, and synchronized tool state when leaving the tool.
 - Added a 3D measurement tool with euclidean distance display, clearer preview behavior, readable labels, restart handling, and status-bar reporting.
 - Added a GUI update-check action and startup update-check preference, making it easier to discover new Perastage versions.
+- Added a startup update reminder checkbox so users can stop seeing repeated prompts for the same available version while keeping manual update checks available.
 - Added fixture replacement from the Edit menu, including improved source labeling, transform preservation, selection stability, UUID handling, and color reuse/autocolor behavior.
 - Added support for packaging referenced layout images into project archives, making `.pstg` project files more portable when shared or reopened elsewhere.
 - Added an MVR import choice so users can open a selected MVR as a new project or merge it into the current project.

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -95,6 +95,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/trusstablepanel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/update/app_update_service.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/update/update_check_preferences.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/update/update_notification_dialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/viewer2dprintdialog.cpp
 )
 

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -125,6 +125,7 @@ using json = nlohmann::json;
 #include "support.h"
 #include "update/update_check_preferences.h"
 #include "update/app_update_service.h"
+#include "update/update_notification_dialog.h"
 #include "units/units.h"
 #include "trussloader.h"
 #include "trusstablepanel.h"
@@ -282,7 +283,7 @@ void RestorePreferencesDialogValues(
     preferences.SetValue(key, value);
 }
 
-// Runs a silent update check and only opens the browser when an update is found.
+// Runs a startup update check and prompts for newer versions that were not dismissed.
 void RunSilentStartupUpdateCheck(MainWindow *window) {
   if (!window)
     return;
@@ -292,15 +293,19 @@ void RunSilentStartupUpdateCheck(MainWindow *window) {
     if (result.status != gui::update::CheckStatus::UpdateAvailable)
       return;
     window->CallAfter([window, result]() {
-      wxString message =
-          "A newer Perastage version is available.\nCurrent version: " +
-          wxString::FromUTF8(result.currentVersion) +
-          "\nLatest version: " + wxString::FromUTF8(result.latestVersion) +
-          "\n\nOpen release page now?";
-      const int response = wxMessageBox(
-          message, "Perastage Updates",
-          wxYES_NO | wxYES_DEFAULT | wxICON_INFORMATION, window);
-      if (response == wxYES)
+      auto &preferences = GetDefaultGuiConfigServices().Preferences();
+      if (!gui::update::ShouldShowStartupUpdateReminder(preferences,
+                                                        result.latestVersion))
+        return;
+
+      const gui::update::UpdateNotificationChoice choice =
+          gui::update::ShowAvailableUpdateDialog(window, result, true);
+      if (choice.suppressVersionReminder) {
+        gui::update::WriteDismissedStartupReminderVersion(preferences,
+                                                          result.latestVersion);
+        preferences.SaveUserConfig();
+      }
+      if (choice.openReleasePage)
         wxLaunchDefaultBrowser(wxString::FromUTF8(result.releaseUrl));
     });
   }).detach();

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -88,6 +88,7 @@
 #include "tools/fixture_category_assignment_tool.h"
 #include "trusstablepanel.h"
 #include "update/app_update_service.h"
+#include "update/update_notification_dialog.h"
 #include "viewer2dpanel.h"
 #include "viewer3dpanel.h"
 
@@ -1007,10 +1008,9 @@ void MainWindow::OnCheckForUpdates(wxCommandEvent &WXUNUSED(event)) {
         return;
       }
 
-      message += "A newer version is available.\nOpen release page now?";
-      const int response = wxMessageBox(message, title,
-                                        wxYES_NO | wxYES_DEFAULT | wxICON_INFORMATION, this);
-      if (response == wxYES) {
+      const gui::update::UpdateNotificationChoice choice =
+          gui::update::ShowAvailableUpdateDialog(this, result, false);
+      if (choice.openReleasePage) {
         wxLaunchDefaultBrowser(wxString::FromUTF8(result.releaseUrl));
       }
     });

--- a/gui/update/update_check_preferences.cpp
+++ b/gui/update/update_check_preferences.cpp
@@ -12,6 +12,8 @@ namespace {
 constexpr const char *kUpdateModeKey = "app_update_startup_mode";
 constexpr const char *kUpdateLastCheckEpochSecondsKey =
     "app_update_last_startup_check_epoch_seconds";
+constexpr const char *kDismissedStartupReminderVersionKey =
+    "app_update_dismissed_startup_reminder_version";
 
 // Normalizes persisted mode tokens to lowercase for robust parsing.
 std::string ToLowerCopy(std::string value) {
@@ -88,6 +90,23 @@ void MarkStartupCheckRun(IGuiPreferencesService &preferences,
           .count();
   preferences.SetValue(kUpdateLastCheckEpochSecondsKey,
                        std::to_string(secondsSinceEpoch));
+}
+
+// Returns true when startup should show a reminder for the discovered version.
+bool ShouldShowStartupUpdateReminder(const IGuiPreferencesService &preferences,
+                                     const std::string &latestVersion) {
+  if (latestVersion.empty())
+    return true;
+
+  const auto dismissedVersion =
+      preferences.GetValue(kDismissedStartupReminderVersionKey);
+  return !dismissedVersion.has_value() || *dismissedVersion != latestVersion;
+}
+
+// Persists the latest version dismissed from an automatic startup reminder.
+void WriteDismissedStartupReminderVersion(IGuiPreferencesService &preferences,
+                                          const std::string &latestVersion) {
+  preferences.SetValue(kDismissedStartupReminderVersionKey, latestVersion);
 }
 
 } // namespace gui::update

--- a/gui/update/update_check_preferences.h
+++ b/gui/update/update_check_preferences.h
@@ -27,4 +27,12 @@ bool ShouldRunStartupCheckNow(const IGuiPreferencesService &preferences,
 void MarkStartupCheckRun(IGuiPreferencesService &preferences,
                          std::chrono::system_clock::time_point now);
 
+// Returns true when startup should show a reminder for the discovered version.
+bool ShouldShowStartupUpdateReminder(const IGuiPreferencesService &preferences,
+                                     const std::string &latestVersion);
+
+// Persists the latest version dismissed from an automatic startup reminder.
+void WriteDismissedStartupReminderVersion(IGuiPreferencesService &preferences,
+                                          const std::string &latestVersion);
+
 } // namespace gui::update

--- a/gui/update/update_notification_dialog.cpp
+++ b/gui/update/update_notification_dialog.cpp
@@ -1,0 +1,65 @@
+#include "update/update_notification_dialog.h"
+
+#include <wx/button.h>
+#include <wx/checkbox.h>
+#include <wx/dialog.h>
+#include <wx/sizer.h>
+#include <wx/stattext.h>
+#include <wx/string.h>
+
+namespace gui::update {
+namespace {
+
+// Builds the message shown when a newer application version is available.
+wxString BuildAvailableUpdateMessage(const CheckResult &result) {
+  return "A newer Perastage version is available.\nCurrent version: " +
+         wxString::FromUTF8(result.currentVersion) +
+         "\nLatest version: " + wxString::FromUTF8(result.latestVersion) +
+         "\n\nOpen release page now?";
+}
+
+} // namespace
+
+// Shows an available-update prompt and optionally lets the user suppress this version.
+UpdateNotificationChoice ShowAvailableUpdateDialog(
+    wxWindow *parent, const CheckResult &result,
+    const bool allowVersionSuppression) {
+  UpdateNotificationChoice choice;
+
+  wxDialog dialog(parent, wxID_ANY, "Perastage Updates", wxDefaultPosition,
+                  wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER);
+  wxBoxSizer *topSizer = new wxBoxSizer(wxVERTICAL);
+
+  wxStaticText *message = new wxStaticText(&dialog, wxID_ANY,
+                                           BuildAvailableUpdateMessage(result));
+  message->Wrap(420);
+  topSizer->Add(message, 0, wxALL | wxEXPAND, 12);
+
+  wxCheckBox *suppressReminderCheck = nullptr;
+  if (allowVersionSuppression) {
+    suppressReminderCheck = new wxCheckBox(
+        &dialog, wxID_ANY,
+        "Do not remind me again for this version");
+    topSizer->Add(suppressReminderCheck, 0, wxLEFT | wxRIGHT | wxBOTTOM, 12);
+  }
+
+  wxBoxSizer *buttonSizer = new wxBoxSizer(wxHORIZONTAL);
+  buttonSizer->AddStretchSpacer(1);
+  wxButton *yesButton = new wxButton(&dialog, wxID_YES, "Yes");
+  wxButton *noButton = new wxButton(&dialog, wxID_NO, "No");
+  buttonSizer->Add(yesButton, 0, wxRIGHT, 8);
+  buttonSizer->Add(noButton, 0);
+  topSizer->Add(buttonSizer, 0, wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND, 12);
+
+  dialog.SetSizerAndFit(topSizer);
+  dialog.CentreOnParent();
+  yesButton->SetDefault();
+
+  const int response = dialog.ShowModal();
+  choice.openReleasePage = response == wxID_YES;
+  choice.suppressVersionReminder =
+      suppressReminderCheck && suppressReminderCheck->GetValue();
+  return choice;
+}
+
+} // namespace gui::update

--- a/gui/update/update_notification_dialog.h
+++ b/gui/update/update_notification_dialog.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "update/app_update_service.h"
+
+#include <wx/window.h>
+
+namespace gui::update {
+
+// Describes the user's choice from an available-update prompt.
+struct UpdateNotificationChoice {
+  bool openReleasePage = false;
+  bool suppressVersionReminder = false;
+};
+
+// Shows an available-update prompt and optionally lets the user suppress this version.
+UpdateNotificationChoice ShowAvailableUpdateDialog(wxWindow *parent,
+                                                   const CheckResult &result,
+                                                   bool allowVersionSuppression);
+
+} // namespace gui::update


### PR DESCRIPTION
### Motivation
- Prevent repeated startup update prompts by letting the application remember when the user chooses not to be reminded for a specific available version. 
- Keep automatic checks useful while preserving the ability to run manual checks from `Help → Check for Updates` that always show the current result. 
- Provide a small, focused UI element (checkbox) and persistent preference to suppress only the chosen version rather than disabling update checks entirely.

### Description
- Added a reusable update notification dialog (`gui/update/update_notification_dialog.{h,cpp}`) that shows an available-update message and an optional `Do not remind me again for this version` checkbox. 
- Persisted dismissed-version state via new functions `ShouldShowStartupUpdateReminder(...)` and `WriteDismissedStartupReminderVersion(...)` in `gui/update/update_check_preferences.{h,cpp}` and a new config key `app_update_dismissed_startup_reminder_version`. 
- Wired startup update flow in `RunSilentStartupUpdateCheck(...)` (in `gui/mainwindow.cpp`) to skip showing reminders for dismissed versions and to save the dismissal when the checkbox is used. 
- Kept manual checks (`MainWindow::OnCheckForUpdates` in `gui/mainwindow_menu.cpp`) using the same dialog but without the suppression checkbox so manual checks always show results. 
- Registered the new source file in `gui/CMakeLists.txt` and updated `docs/preferences.md` and `docs/release-notes-draft.md` to document the new behavior.

### Testing
- ✅ Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both returned OK. 
- ✅ Ran `git diff --cached --check` as part of staging verification and it passed with no whitespace or index issues. 
- ⚠️ Attempted `cmake -S . -B /tmp/perastage-build -DCMAKE_BUILD_TYPE=Debug` but configuration failed in this environment due to missing `wxWidgets` development libraries/includes, not due to the introduced changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21cc8fbe888324b945e4c4c593f4b1)