### PR TITLE
Validate and restrict truss model file types; align dialog and add tests

### DIFF
--- a/core/trussloader.cpp
+++ b/core/trussloader.cpp
@@ -35,11 +35,19 @@ namespace fs = std::filesystem;
 
 namespace {
 
+constexpr float kDefaultDirectModelLengthMm = 1000.0f;
+constexpr float kDefaultDirectModelWidthMm = 400.0f;
+constexpr float kDefaultDirectModelHeightMm = 400.0f;
+constexpr const char *kSupportedTrussFileDialogWildcard =
+    "Truss files (*.gdtf;*.gtruss;*.glb;*.3ds)|*.gdtf;*.gtruss;*.glb;*.3ds";
+
+// Converts a filesystem path to a UTF-8 string for storage and UI handoff.
 static std::string ToUtf8String(const fs::path &path) {
   std::u8string utf8 = path.u8string();
   return std::string(utf8.begin(), utf8.end());
 }
 
+// Converts a UTF-8 string into a filesystem path without losing non-ASCII characters.
 static fs::path FromUtf8String(const std::string &text) {
 #if defined(__cpp_lib_char8_t)
   const char8_t *begin = reinterpret_cast<const char8_t *>(text.data());
@@ -49,6 +57,7 @@ static fs::path FromUtf8String(const std::string &text) {
 #endif
 }
 
+// Returns a lowercase file extension for extension-based loader dispatch.
 static std::string LowerExt(fs::path path) {
   std::string ext = path.extension().string();
   std::transform(ext.begin(), ext.end(), ext.begin(),
@@ -56,6 +65,7 @@ static std::string LowerExt(fs::path path) {
   return ext;
 }
 
+// Parses a floating-point XML attribute into the provided output value.
 static bool ParseFloatAttr(tinyxml2::XMLElement *node, const char *name, float &out) {
   if (!node)
     return false;
@@ -67,6 +77,7 @@ static bool ParseFloatAttr(tinyxml2::XMLElement *node, const char *name, float &
   return false;
 }
 
+// Extracts a ZIP-based archive into the requested destination directory.
 static bool ExtractArchive(const fs::path &archivePath, const fs::path &destination) {
   wxFileInputStream input(archivePath.string());
   if (!input.IsOk())
@@ -100,6 +111,7 @@ static bool ExtractArchive(const fs::path &archivePath, const fs::path &destinat
 }
 
 
+// Builds a stable extraction cache path for a GDTF archive.
 static fs::path BuildGdtfExtractionCacheDir(const fs::path &gdtfPath) {
   std::error_code ec;
   fs::path normalized = fs::weakly_canonical(gdtfPath, ec);
@@ -119,6 +131,8 @@ static fs::path BuildGdtfExtractionCacheDir(const fs::path &gdtfPath) {
   fs::path cacheRoot = fs::temp_directory_path() / "perastage-truss-gdtf-cache";
   return cacheRoot / std::to_string(hashValue);
 }
+
+// Finds the first candidate path that exists below the provided base directory.
 static fs::path FindFirstExisting(const fs::path &base,
                                   std::initializer_list<fs::path> candidates) {
   for (const auto &candidate : candidates) {
@@ -131,6 +145,18 @@ static fs::path FindFirstExisting(const fs::path &base,
 
 } // namespace
 
+// Returns the file dialog wildcard matching the supported truss loader inputs.
+std::string GetTrussDefinitionFileDialogWildcard() {
+  return kSupportedTrussFileDialogWildcard;
+}
+
+// Reports whether the path extension is supported by the truss loader and renderer.
+bool IsSupportedTrussDefinitionExtension(const std::string &path) {
+  const std::string ext = LowerExt(FromUtf8String(path));
+  return ext == ".gdtf" || ext == ".gtruss" || ext == ".glb" || ext == ".3ds";
+}
+
+// Loads a GDTF truss archive and resolves its renderable model metadata.
 bool LoadTrussGdtf(const std::string &gdtfPath, Truss &outTruss) {
   fs::path inputPath = FromUtf8String(gdtfPath);
   if (!fs::exists(inputPath))
@@ -213,10 +239,12 @@ bool LoadTrussGdtf(const std::string &gdtfPath, Truss &outTruss) {
   return !outTruss.symbolFile.empty();
 }
 
+// Loads a truss archive through the general truss definition loader.
 bool LoadTrussArchive(const std::string &archivePath, Truss &outTruss) {
   return LoadTrussDefinition(archivePath, outTruss);
 }
 
+// Loads a supported truss definition or direct renderable model file.
 bool LoadTrussDefinition(const std::string &path, Truss &outTruss) {
   fs::path inputPath = FromUtf8String(path);
   std::string ext = LowerExt(inputPath);
@@ -234,8 +262,18 @@ bool LoadTrussDefinition(const std::string &path, Truss &outTruss) {
     return LoadTrussGdtf(ToUtf8String(migratedPath), outTruss);
   }
 
+  if (ext != ".glb" && ext != ".3ds")
+    return false;
+
+  std::error_code ec;
+  if (!fs::exists(inputPath, ec) || ec || !fs::is_regular_file(inputPath, ec))
+    return false;
+
   outTruss = Truss{};
   outTruss.symbolFile = ToUtf8String(inputPath);
   outTruss.modelFile = ToUtf8String(inputPath);
+  outTruss.lengthMm = kDefaultDirectModelLengthMm;
+  outTruss.widthMm = kDefaultDirectModelWidthMm;
+  outTruss.heightMm = kDefaultDirectModelHeightMm;
   return true;
 }

--- a/core/trussloader.h
+++ b/core/trussloader.h
@@ -21,6 +21,8 @@
 
 #include "truss.h"
 
+std::string GetTrussDefinitionFileDialogWildcard();
+bool IsSupportedTrussDefinitionExtension(const std::string &path);
 bool LoadTrussGdtf(const std::string &gdtfPath, Truss &outTruss);
 bool LoadTrussArchive(const std::string &archivePath, Truss &outTruss);
 bool LoadTrussDefinition(const std::string &path, Truss &outTruss);

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -12,6 +12,8 @@ Changes since `v1.3.0`.
 
 ## Fixes
 
+- Improved truss file validation so unsupported model formats are rejected clearly, while direct GLB and 3DS truss models now load only when the selected file exists.
+
 ## Stability and reliability
 
 - Improved 2D viewer interaction stability by safely skipping selection and hover picking when the OpenGL context is not available.

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -1234,7 +1234,8 @@ void MainWindow::OnAddTruss(wxCommandEvent &WXUNUSED(event)) {
       wxString trussDir =
           wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("trusses"));
       wxFileDialog fdlg(this, "Select Truss file", trussDir, wxEmptyString,
-                        "Truss files (*.gdtf;*.gtruss;*.3ds;*.glb)|*.gdtf;*.gtruss;*.3ds;*.glb|All files|*.*", wxFD_OPEN | wxFD_FILE_MUST_EXIST);
+                        wxString::FromUTF8(GetTrussDefinitionFileDialogWildcard()),
+                        wxFD_OPEN | wxFD_FILE_MUST_EXIST);
       if (fdlg.ShowModal() != wxID_OK)
         return;
       wxFileName fn(fdlg.GetPath());
@@ -1251,7 +1252,8 @@ void MainWindow::OnAddTruss(wxCommandEvent &WXUNUSED(event)) {
     wxString trussDir =
         wxString::FromUTF8(ProjectUtils::GetWritableLibraryPath("trusses"));
     wxFileDialog fdlg(this, "Select Truss file", trussDir, wxEmptyString,
-                      "Truss files (*.gdtf;*.gtruss;*.3ds;*.glb)|*.gdtf;*.gtruss;*.3ds;*.glb|All files|*.*", wxFD_OPEN | wxFD_FILE_MUST_EXIST);
+                      wxString::FromUTF8(GetTrussDefinitionFileDialogWildcard()),
+                      wxFD_OPEN | wxFD_FILE_MUST_EXIST);
     if (fdlg.ShowModal() != wxID_OK)
       return;
     wxFileName fn(fdlg.GetPath());
@@ -1262,7 +1264,9 @@ void MainWindow::OnAddTruss(wxCommandEvent &WXUNUSED(event)) {
   Truss baseTruss;
   namespace fs = std::filesystem;
   if (!LoadTrussDefinition(path, baseTruss)) {
-    wxMessageBox("Failed to read truss file.", "Error", wxOK | wxICON_ERROR);
+    wxMessageBox("Unsupported or unreadable truss file. Supported formats are "
+                 "GDTF, GTruss, GLB, and 3DS.",
+                 "Error", wxOK | wxICON_ERROR);
     return;
   }
   if (!baseTruss.name.empty())

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,6 +42,18 @@ include_directories(
     ../viewer3d/render
 )
 
+add_executable(trussloader_validation_test
+               trussloader_validation_test.cpp
+               ../core/trussloader.cpp
+               ../core/truss_gdtf_builder.cpp
+               ../core/logger.cpp
+               ../models/truss.cpp)
+target_include_directories(trussloader_validation_test PRIVATE
+                           . ../core ../models ../third_party)
+target_link_libraries(trussloader_validation_test PRIVATE
+                      ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
+add_test(NAME TrussLoaderValidation COMMAND trussloader_validation_test)
+
 
 add_executable(mvr_merge_analyzer_applier_test
                mvr_merge_analyzer_applier_test.cpp

--- a/tests/trussloader_validation_test.cpp
+++ b/tests/trussloader_validation_test.cpp
@@ -1,0 +1,75 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <cassert>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include "trussloader.h"
+
+namespace fs = std::filesystem;
+
+namespace {
+
+// Converts a filesystem path to a UTF-8 string for loader calls.
+std::string ToUtf8String(const fs::path &path) {
+  std::u8string utf8 = path.u8string();
+  return std::string(utf8.begin(), utf8.end());
+}
+
+} // namespace
+
+// Verifies truss loader extension validation and direct model defaults.
+int main() {
+  const fs::path tempRoot = fs::temp_directory_path() /
+                            fs::u8path("perastage_trussloader_validation_test");
+  std::error_code ec;
+  fs::remove_all(tempRoot, ec);
+  fs::create_directories(tempRoot);
+
+  const fs::path glbPath = tempRoot / "direct_model.GLB";
+  {
+    std::ofstream glb(glbPath, std::ios::binary);
+    glb << "glTF";
+  }
+
+  Truss truss;
+  assert(IsSupportedTrussDefinitionExtension(ToUtf8String(glbPath)));
+  assert(LoadTrussDefinition(ToUtf8String(glbPath), truss));
+  assert(truss.symbolFile == ToUtf8String(glbPath));
+  assert(truss.modelFile == ToUtf8String(glbPath));
+  assert(truss.lengthMm > 0.0f);
+  assert(truss.widthMm > 0.0f);
+  assert(truss.heightMm > 0.0f);
+
+  Truss missingModel;
+  assert(!LoadTrussDefinition(ToUtf8String(tempRoot / "missing.glb"),
+                              missingModel));
+
+  Truss unsupportedModel;
+  assert(!IsSupportedTrussDefinitionExtension(
+      ToUtf8String(tempRoot / "mesh.obj")));
+  assert(!LoadTrussDefinition(ToUtf8String(tempRoot / "mesh.obj"),
+                              unsupportedModel));
+
+  assert(GetTrussDefinitionFileDialogWildcard().find(
+             "*.gdtf;*.gtruss;*.glb;*.3ds") != std::string::npos);
+
+  fs::remove_all(tempRoot, ec);
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- Ensure the truss loader only accepts formats the renderer can handle and fail fast for unsupported inputs.
- For direct model files (GLB/3DS) guarantee the file exists and provide safe default geometry dimensions when metadata is missing.
- Keep the Add Truss UI in sync with loader-supported formats and give a clear user-facing error when validation fails.

### Description
- Restrict `LoadTrussDefinition` to accept only `.gdtf`, `.gtruss`, `.glb`, and `.3ds`, reject other extensions and return `false` for unsupported types.
- For direct model files (`.glb`/`.3ds`) validate file existence with filesystem checks and set safe defaults `kDefaultDirectModelLengthMm/WidthMm/HeightMm` when metadata is not available.
- Add `GetTrussDefinitionFileDialogWildcard()` and `IsSupportedTrussDefinitionExtension()` helpers and expose them in `core/trussloader.h` so the GUI can reuse the same wildcard/validation logic.
- Update `gui/mainwindow_menu.cpp::OnAddTruss` to use the shared wildcard for the file dialog and replace the generic failure message with a user-facing validation error listing the supported formats.
- Add concise one-line English comments above changed/new helper and loader functions to document their primary purpose as requested.
- Add `tests/trussloader_validation_test.cpp` and register it in `tests/CMakeLists.txt` to cover supported-extension checks, missing direct-model files, direct-model defaults, and the dialog wildcard.
- Update `docs/release-notes-draft.md` with a short entry describing the truss validation improvement.

### Testing
- Ran `git diff --check` and fixed whitespace issues (passed).
- Ran repository quality checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh` (both passed).
- Attempted `cmake -S tests -B build-tests -DCMAKE_BUILD_TYPE=Debug` to build the new validation test, but configuration failed in this environment due to missing `wxWidgets` (`wxWidgets_LIBRARIES` and `wxWidgets_INCLUDE_DIRS`), so the test binary could not be built here (environment limitation, not a code failure).
- The change was committed locally and the PR prepared including the new test source and CMake registration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24a1cb4d948324b0a627961301d065)