### PR TITLE
Add concise Logger diagnostics for truss loading and Viewer2D picking

### DIFF
--- a/core/trussloader.cpp
+++ b/core/trussloader.cpp
@@ -18,6 +18,7 @@
 #include "trussloader.h"
 
 #include "truss_gdtf_builder.h"
+#include "logger.h"
 
 #include <tinyxml2.h>
 #include <wx/filename.h>
@@ -30,6 +31,7 @@
 #include <functional>
 #include <fstream>
 #include <memory>
+#include <sstream>
 
 namespace fs = std::filesystem;
 
@@ -143,6 +145,19 @@ static fs::path FindFirstExisting(const fs::path &base,
   return {};
 }
 
+// Writes a concise truss definition load diagnostic for add-truss validation.
+static void LogTrussDefinitionLoadResult(const fs::path &path, const std::string &ext,
+                                         bool success, const Truss &truss) {
+  std::ostringstream msg;
+  msg << "Truss definition load: extension='" << ext << "'"
+      << " parsingSucceeded=" << (success ? "true" : "false")
+      << " symbolFile='" << truss.symbolFile << "'"
+      << " dimensionsMm=" << truss.lengthMm << "x" << truss.widthMm
+      << "x" << truss.heightMm << " path='" << ToUtf8String(path) << "'";
+  Logger::Instance().Log(success ? Logger::Level::Info : Logger::Level::Warn,
+                         msg.str());
+}
+
 } // namespace
 
 // Returns the file dialog wildcard matching the supported truss loader inputs.
@@ -248,32 +263,42 @@ bool LoadTrussArchive(const std::string &archivePath, Truss &outTruss) {
 bool LoadTrussDefinition(const std::string &path, Truss &outTruss) {
   fs::path inputPath = FromUtf8String(path);
   std::string ext = LowerExt(inputPath);
-  if (ext == ".gdtf")
-    return LoadTrussGdtf(ToUtf8String(inputPath), outTruss);
+  bool success = false;
+
+  if (ext == ".gdtf") {
+    success = LoadTrussGdtf(ToUtf8String(inputPath), outTruss);
+    LogTrussDefinitionLoadResult(inputPath, ext, success, outTruss);
+    return success;
+  }
 
   if (ext == ".gtruss") {
     fs::path migratedPath = inputPath;
     migratedPath.replace_extension(".gdtf");
     std::string error;
-    if (!fs::exists(migratedPath) &&
-        !ConvertLegacyGtrussToGdtf(inputPath, migratedPath, &error)) {
-      return false;
+    if (fs::exists(migratedPath) ||
+        ConvertLegacyGtrussToGdtf(inputPath, migratedPath, &error)) {
+      success = LoadTrussGdtf(ToUtf8String(migratedPath), outTruss);
     }
-    return LoadTrussGdtf(ToUtf8String(migratedPath), outTruss);
+    LogTrussDefinitionLoadResult(inputPath, ext, success, outTruss);
+    return success;
   }
 
-  if (ext != ".glb" && ext != ".3ds")
-    return false;
+  if (ext == ".glb" || ext == ".3ds") {
+    std::error_code ec;
+    if (fs::exists(inputPath, ec) && !ec && fs::is_regular_file(inputPath, ec) &&
+        !ec) {
+      outTruss = Truss{};
+      outTruss.symbolFile = ToUtf8String(inputPath);
+      outTruss.modelFile = ToUtf8String(inputPath);
+      outTruss.lengthMm = kDefaultDirectModelLengthMm;
+      outTruss.widthMm = kDefaultDirectModelWidthMm;
+      outTruss.heightMm = kDefaultDirectModelHeightMm;
+      success = true;
+    }
+    LogTrussDefinitionLoadResult(inputPath, ext, success, outTruss);
+    return success;
+  }
 
-  std::error_code ec;
-  if (!fs::exists(inputPath, ec) || ec || !fs::is_regular_file(inputPath, ec))
-    return false;
-
-  outTruss = Truss{};
-  outTruss.symbolFile = ToUtf8String(inputPath);
-  outTruss.modelFile = ToUtf8String(inputPath);
-  outTruss.lengthMm = kDefaultDirectModelLengthMm;
-  outTruss.widthMm = kDefaultDirectModelWidthMm;
-  outTruss.heightMm = kDefaultDirectModelHeightMm;
-  return true;
+  LogTrussDefinitionLoadResult(inputPath, ext, false, outTruss);
+  return false;
 }

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -21,3 +21,5 @@ Changes since `v1.3.0`.
 ## Documentation
 
 ## Internal changes
+
+- Added concise diagnostics for truss loading and 2D viewer picking to make validation and interaction issues easier to troubleshoot.

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -70,6 +70,7 @@
 #include "layoutpanel.h"
 #include "layoutviewerpanel.h"
 #include "loader_obj.h"
+#include "logger.h"
 #include "logindialog.h"
 #include "markdown.h"
 #include "preferencesdialog.h"
@@ -1263,7 +1264,20 @@ void MainWindow::OnAddTruss(wxCommandEvent &WXUNUSED(event)) {
 
   Truss baseTruss;
   namespace fs = std::filesystem;
+  fs::path selectedTrussPath = fs::u8path(path);
+  std::string selectedExtension = selectedTrussPath.extension().string();
+  std::transform(selectedExtension.begin(), selectedExtension.end(),
+                 selectedExtension.begin(), [](unsigned char c) {
+                   return static_cast<char>(std::tolower(c));
+                 });
+  Logger::Instance().Log(Logger::Level::Info,
+                         "Add truss: selected extension='" + selectedExtension +
+                             "' path='" + path + "'.");
   if (!LoadTrussDefinition(path, baseTruss)) {
+    Logger::Instance().Log(
+        Logger::Level::Warn,
+        "Add truss validation failed: extension='" + selectedExtension +
+            "' path='" + path + "'.");
     wxMessageBox("Unsupported or unreadable truss file. Supported formats are "
                  "GDTF, GTruss, GLB, and 3DS.",
                  "Error", wxOK | wxICON_ERROR);
@@ -1329,6 +1343,17 @@ void MainWindow::OnAddTruss(wxCommandEvent &WXUNUSED(event)) {
 
   if (trussPanel)
     trussPanel->ReloadData();
+  const bool updateSceneRequested = viewportPanel != nullptr;
+  Logger::Instance().Log(
+      Logger::Level::Info,
+      "Add truss complete: extension='" + selectedExtension +
+          "' parsingSucceeded=true symbolFile='" + baseTruss.symbolFile +
+          "' dimensionsMm=" + std::to_string(baseTruss.lengthMm) + "x" +
+          std::to_string(baseTruss.widthMm) + "x" +
+          std::to_string(baseTruss.heightMm) +
+          " updateSceneRequested=" +
+          (updateSceneRequested ? std::string("true") : std::string("false")) +
+          ".");
   if (viewportPanel) {
     viewportPanel->UpdateScene();
     viewportPanel->Refresh();

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -525,10 +525,13 @@ void Viewer2DPanel::TrackRefreshTelemetry() {
 #endif
 }
 
+// Updates cached 2D scene data, selection state, and repaint scheduling.
 void Viewer2DPanel::UpdateScene(bool reload) {
   if (reload && m_enableSelection && ShouldPauseHeavyTasks())
     return;
 
+  m_logFirstPickAfterSceneUpdate = true;
+  m_lastUpdateSceneReloadRequested = reload;
   if (reload)
     m_controller.Update();
   if (m_enableSelection) {
@@ -841,7 +844,7 @@ bool Viewer2DPanel::TryBindGlContextForInteraction() {
   if (!SetCurrent(*m_glContext)) {
     Logger::Instance().Log(
         Logger::Level::Warn,
-        "Viewer2DPanel: skipping interaction picking because the OpenGL context could not be bound.");
+        "Viewer2DPanel: interaction picking context-bind failure; glContextBindFailed=true.");
     return false;
   }
 
@@ -1935,11 +1938,13 @@ void Viewer2DPanel::ClearHoverState(bool requestRepaint) {
   ApplyHoverUuid("", requestRepaint);
 }
 
+// Invalidates cached picking results after scene, view, or visibility changes.
 void Viewer2DPanel::InvalidatePickCache() {
   m_pickCache.valid = false;
   ++m_pickCacheSceneGeneration;
 }
 
+// Builds a hash for hidden-layer state and invalidates stale pick cache entries.
 size_t Viewer2DPanel::BuildHiddenLayersHash() {
   const size_t hash = HashStringContainer(ConfigManager::Get().GetHiddenLayers());
   if (m_pickCache.valid && m_pickCache.hiddenLayersHash != hash)
@@ -1947,6 +1952,7 @@ size_t Viewer2DPanel::BuildHiddenLayersHash() {
   return hash;
 }
 
+// Returns whether a recent picking query can be reused for the current pointer location.
 bool Viewer2DPanel::IsPickCacheReusable(PickQueryKind queryKind,
                                         const wxPoint &framebufferPos,
                                         int viewportWidth, int viewportHeight,
@@ -1971,6 +1977,7 @@ bool Viewer2DPanel::IsPickCacheReusable(PickQueryKind queryKind,
          (kPickCacheReuseDistancePx * kPickCacheReuseDistancePx);
 }
 
+// Stores a pick result and logs the first interaction pick after a scene update.
 void Viewer2DPanel::StorePickCache(PickQueryKind queryKind,
                                    const wxPoint &framebufferPos,
                                    int viewportWidth, int viewportHeight,
@@ -1989,8 +1996,40 @@ void Viewer2DPanel::StorePickCache(PickQueryKind queryKind,
   m_pickCache.timestamp = std::chrono::steady_clock::now();
   m_pickCache.found = found;
   m_pickCache.uuid = uuid;
+
+  if (m_logFirstPickAfterSceneUpdate) {
+    const char *queryName = "none";
+    switch (queryKind) {
+    case PickQueryKind::FixtureLabel:
+      queryName = "fixture-label";
+      break;
+    case PickQueryKind::TrussLabel:
+      queryName = "truss-label";
+      break;
+    case PickQueryKind::HoistLabel:
+      queryName = "hoist-label";
+      break;
+    case PickQueryKind::SceneObjectLabel:
+      queryName = "scene-object-label";
+      break;
+    case PickQueryKind::PickUuid:
+      queryName = "pick-uuid";
+      break;
+    case PickQueryKind::None:
+      break;
+    }
+    Logger::Instance().Log(
+        Logger::Level::Debug,
+        "Viewer2DPanel: first pick after scene update; updateSceneRequested=true reload=" +
+            std::string(m_lastUpdateSceneReloadRequested ? "true" : "false") +
+            " query='" + queryName + "' found=" +
+            std::string(found ? "true" : "false") + " sceneGeneration=" +
+            std::to_string(m_pickCacheSceneGeneration) + ".");
+    m_logFirstPickAfterSceneUpdate = false;
+  }
 }
 
+// Resolves a picked UUID using the reusable interaction pick cache.
 bool Viewer2DPanel::TryResolvePickUuidWithCache(const wxPoint &framebufferPos,
                                                 int viewportWidth,
                                                 int viewportHeight,
@@ -2015,6 +2054,7 @@ bool Viewer2DPanel::TryResolvePickUuidWithCache(const wxPoint &framebufferPos,
   return found;
 }
 
+// Resolves a picked label using the reusable interaction pick cache.
 bool Viewer2DPanel::TryResolvePickLabelWithCache(PickQueryKind queryKind,
                                                  const wxPoint &framebufferPos,
                                                  int viewportWidth,

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -309,6 +309,8 @@ private:
   bool m_viewMotionSinceLastHoverHitTest = false;
   PickCacheEntry m_pickCache;
   uint64_t m_pickCacheSceneGeneration = 0;
+  bool m_logFirstPickAfterSceneUpdate = false;
+  bool m_lastUpdateSceneReloadRequested = false;
   bool m_enableSelection = true;
   Viewer2DMeasureToolState m_measureToolState;
   std::vector<std::string> m_lastAppliedSelectionUuids;


### PR DESCRIPTION
### Motivation
- Improve observability for truss imports and 2D interaction failures by emitting concise, actionable diagnostics when users add trusses or when picking/GL context binding fails, without adding noisy per-frame logs.
- Provide the minimal information needed to troubleshoot validation and renderer-binding issues: selected extension, parse success, resolved `symbolFile`, dimensions, `UpdateScene()` request, and GL context-bind failures.

### Description
- Added a helper `LogTrussDefinitionLoadResult` in `core/trussloader.cpp` to log extension, parse success, resolved `symbolFile`, dimensions (mm), and source path; integrated calls into `LoadTrussDefinition()` for `.gdtf`, `.gtruss`, `.glb`, and `.3ds` paths.
- Instrumented the Add Truss flow in `gui/mainwindow_menu.cpp::OnAddTruss` to log the selected path extension, log validation failure when `LoadTrussDefinition()` fails, and log a concise success line including resolved `symbolFile`, dimensions, and whether `UpdateScene()` was requested.
- Added Viewer2D diagnostics in `viewer2d/viewer2dpanel.cpp` to: log GL context-bind failures with a clear message, and log the first pick after a scene update using a `m_logFirstPickAfterSceneUpdate` flag to avoid per-frame noise; introduced `m_lastUpdateSceneReloadRequested` to indicate whether the `UpdateScene()` call requested a reload.
- Small API/formatting touches: included `logger.h` where needed, added one-line function comments for updated functions, and updated `docs/release-notes-draft.md` with an internal changes entry describing the diagnostics improvement.

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which succeeded.
- Ran `git diff --check`, which reported no issues.
- Attempted `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`, which could not complete in this environment because `wxWidgets` is not installed (configuration failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24a4211fec8324969576a0f5cf8d4a)