### PR TITLE
Use conservative fallback dimensions for direct GLB/3DS trusses and viewer fallbacks

### DIFF
--- a/core/trussloader.cpp
+++ b/core/trussloader.cpp
@@ -19,6 +19,7 @@
 
 #include "truss_gdtf_builder.h"
 #include "logger.h"
+#include "truss_defaults.h"
 
 #include <tinyxml2.h>
 #include <wx/filename.h>
@@ -37,9 +38,6 @@ namespace fs = std::filesystem;
 
 namespace {
 
-constexpr float kDefaultDirectModelLengthMm = 1000.0f;
-constexpr float kDefaultDirectModelWidthMm = 400.0f;
-constexpr float kDefaultDirectModelHeightMm = 400.0f;
 constexpr const char *kSupportedTrussFileDialogWildcard =
     "Truss files (*.gdtf;*.gtruss;*.glb;*.3ds)|*.gdtf;*.gtruss;*.glb;*.3ds";
 
@@ -290,9 +288,9 @@ bool LoadTrussDefinition(const std::string &path, Truss &outTruss) {
       outTruss = Truss{};
       outTruss.symbolFile = ToUtf8String(inputPath);
       outTruss.modelFile = ToUtf8String(inputPath);
-      outTruss.lengthMm = kDefaultDirectModelLengthMm;
-      outTruss.widthMm = kDefaultDirectModelWidthMm;
-      outTruss.heightMm = kDefaultDirectModelHeightMm;
+      outTruss.lengthMm = TrussDefaults::kFallbackLengthMm;
+      outTruss.widthMm = TrussDefaults::kFallbackWidthMm;
+      outTruss.heightMm = TrussDefaults::kFallbackHeightMm;
       success = true;
     }
     LogTrussDefinitionLoadResult(inputPath, ext, success, outTruss);

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -13,6 +13,7 @@ Changes since `v1.3.0`.
 ## Fixes
 
 - Improved truss file validation so unsupported model formats are rejected clearly, while direct GLB and 3DS truss models now load only when the selected file exists.
+- Improved fallback dimensions for direct truss model files so GLB and 3DS trusses remain visible and selectable even when model metadata or mesh loading is unavailable.
 
 ## Stability and reliability
 

--- a/models/truss_defaults.h
+++ b/models/truss_defaults.h
@@ -1,0 +1,26 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+namespace TrussDefaults {
+
+inline constexpr float kFallbackLengthMm = 1000.0f;
+inline constexpr float kFallbackWidthMm = 400.0f;
+inline constexpr float kFallbackHeightMm = 400.0f;
+
+} // namespace TrussDefaults

--- a/viewer3d/culling/bounds_cache_system.cpp
+++ b/viewer3d/culling/bounds_cache_system.cpp
@@ -11,6 +11,7 @@
 #include "projectutils.h"
 #include "types.h"
 #include "logger.h"
+#include "truss_defaults.h"
 #include "matrixutils.h"
 
 #include <algorithm>
@@ -22,6 +23,7 @@ namespace fs = std::filesystem;
 
 namespace {
 
+// Normalizes a model reference path for cache lookups.
 static std::string NormalizePath(const std::string &p) {
   std::string out = p;
   char sep = static_cast<char>(fs::path::preferred_separator);
@@ -29,10 +31,12 @@ static std::string NormalizePath(const std::string &p) {
   return out;
 }
 
+// Resolves a resource reference to the cache key used by synchronization state.
 static std::string ResolveCacheKey(const std::string &pathRef) {
   return NormalizePath(pathRef);
 }
 
+// Reports whether a layer is visible using the cached hidden-layer set.
 static bool IsLayerVisibleCached(const std::unordered_set<std::string> &hidden,
                                  const std::string &layer) {
   if (layer.empty())
@@ -40,6 +44,7 @@ static bool IsLayerVisibleCached(const std::unordered_set<std::string> &hidden,
   return hidden.find(layer) == hidden.end();
 }
 
+// Transforms a point by the provided matrix.
 static std::array<float, 3> TransformPoint(const Matrix &m,
                                            const std::array<float, 3> &p) {
   return {m.u[0] * p[0] + m.v[0] * p[1] + m.w[0] * p[2] + m.o[0],
@@ -47,6 +52,7 @@ static std::array<float, 3> TransformPoint(const Matrix &m,
           m.u[2] * p[0] + m.v[2] * p[1] + m.w[2] * p[2] + m.o[2]};
 }
 
+// Transforms a local bounding box into world-space bounds.
 static Viewer3DBoundingBox TransformBounds(const Viewer3DBoundingBox &local,
                                            const Matrix &m) {
   Viewer3DBoundingBox world;
@@ -77,6 +83,7 @@ static Viewer3DBoundingBox TransformBounds(const Viewer3DBoundingBox &local,
 
 } // namespace
 
+// Rebuilds cached object bounds when scene, asset, or visibility state changes.
 void BoundsCacheSystem::RebuildIfDirty(
     Context &context,
     const std::unordered_set<std::string> &hiddenLayers,
@@ -248,9 +255,12 @@ void BoundsCacheSystem::RebuildIfDirty(
     }
 
     if (!found) {
-      float len = (t.lengthMm > 0 ? t.lengthMm * RENDER_SCALE : 0.3f);
-      float halfy = (t.widthMm > 0 ? t.widthMm * RENDER_SCALE * 0.5f : 0.15f);
-      float z1 = (t.heightMm > 0 ? t.heightMm * RENDER_SCALE : 0.3f);
+      float len = (t.lengthMm > 0 ? t.lengthMm : TrussDefaults::kFallbackLengthMm) *
+                  RENDER_SCALE;
+      float halfy = (t.widthMm > 0 ? t.widthMm : TrussDefaults::kFallbackWidthMm) *
+                    RENDER_SCALE * 0.5f;
+      float z1 = (t.heightMm > 0 ? t.heightMm : TrussDefaults::kFallbackHeightMm) *
+                 RENDER_SCALE;
       std::array<std::array<float, 3>, 8> corners = {
           std::array<float, 3>{0.0f, -halfy, 0.0f},
           {len, -halfy, 0.0f},

--- a/viewer3d/render/opaque_truss_pass.cpp
+++ b/viewer3d/render/opaque_truss_pass.cpp
@@ -18,6 +18,7 @@
 #include "matrixutils.h"
 #include "opaque_pass_utils.h"
 #include "scenedatamanager.h"
+#include "truss_defaults.h"
 #include "viewer3dcontroller.h"
 
 #include <algorithm>
@@ -25,6 +26,7 @@
 #include <vector>
 
 namespace {
+// Draws a solid bounding box for ID-only truss picking.
 void DrawBoundsSolid(const Viewer3DBoundingBox &bb) {
   glBegin(GL_QUADS);
   glVertex3f(bb.min[0], bb.min[1], bb.min[2]);
@@ -55,6 +57,7 @@ void DrawBoundsSolid(const Viewer3DBoundingBox &bb) {
 }
 } // namespace
 
+// Renders visible trusses using loaded meshes or conservative fallback boxes.
 void OpaqueTrussPass::Render(
     Viewer3DController &controller, const RenderFrameContext &context,
     const Viewer3DVisibleSet &visibleSet,
@@ -155,11 +158,12 @@ void OpaqueTrussPass::Render(
       }
     }
 
-    float trussLen = t.lengthMm * RENDER_SCALE;
-    float trussWid = (t.widthMm > 0 ? t.widthMm : 400.0f) * RENDER_SCALE;
-    float trussHei = (t.heightMm > 0 ? t.heightMm : 400.0f) * RENDER_SCALE;
-    float trussWidthMm = (t.widthMm > 0 ? t.widthMm : 400.0f);
-    float trussHeightMm = (t.heightMm > 0 ? t.heightMm : 400.0f);
+    float trussLengthMm = (t.lengthMm > 0 ? t.lengthMm : TrussDefaults::kFallbackLengthMm);
+    float trussWidthMm = (t.widthMm > 0 ? t.widthMm : TrussDefaults::kFallbackWidthMm);
+    float trussHeightMm = (t.heightMm > 0 ? t.heightMm : TrussDefaults::kFallbackHeightMm);
+    float trussLen = trussLengthMm * RENDER_SCALE;
+    float trussWid = trussWidthMm * RENDER_SCALE;
+    float trussHei = trussHeightMm * RENDER_SCALE;
 
     auto drawTrussGeometry =
         [&](const std::function<std::array<float, 3>(
@@ -194,7 +198,7 @@ void OpaqueTrussPass::Render(
         modelKey = NormalizeModelKey(t.symbolFile);
       if (modelKey.empty() && !trussMesh) {
         std::ostringstream boxKey;
-        boxKey << "box:" << t.lengthMm << "x" << trussWidthMm << "x"
+        boxKey << "box:" << trussLengthMm << "x" << trussWidthMm << "x"
                << trussHeightMm;
         modelKey = boxKey.str();
       }


### PR DESCRIPTION
### Motivation
- Ensure trusses loaded directly from `.glb` or `.3ds` remain visible and selectable when no metadata or mesh bounds are available by providing conservative non-zero fallback dimensions. 
- Make viewer rendering and bounds caching consistently use the same fallback values so fallback geometry and culling behave predictably when mesh loading fails.

### Description
- Added `models/truss_defaults.h` with shared conservative fallback constants `kFallbackLengthMm`, `kFallbackWidthMm`, and `kFallbackHeightMm` (1000 x 400 x 400 mm).
- Updated `core/trussloader.cpp` to initialize direct `.glb` and `.3ds` truss `lengthMm`, `widthMm`, and `heightMm` from `TrussDefaults` when the selected file exists but no other metadata is available.
- Updated `viewer3d/render/opaque_truss_pass.cpp` to use the shared fallback dimensions when drawing fallback wireframe/box geometry and to include the resolved length in the symbol cache key; also added concise one-line comments above internal helpers and the `Render` function.
- Updated `viewer3d/culling/bounds_cache_system.cpp` to use the shared fallback dimensions when computing truss bounds for culling if model bounds are unavailable, and added short comments for a few helper functions and the `RebuildIfDirty` entry point.
- Updated `docs/release-notes-draft.md` to mention the improved fallback dimensions for direct truss model files.

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which succeeded.
- Ran `git diff --cached --check` and code-style checks included in that step succeeded.
- Attempted a `cmake` configure/build to validate compilation but configuration was blocked in this environment due to missing `wxWidgets` development files, so a full build was not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24a65067808324971877f5234b1faf)