### PR TITLE
Skip 3D rendering and GL-dependent work until GL initialization succeeds

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -19,6 +19,7 @@ Changes since `v1.3.0`.
 
 - Improved 2D viewer interaction stability by safely skipping selection and hover picking when the OpenGL context is not available.
 - Improved 3D viewer interaction stability by safely skipping picking and resource synchronization when the OpenGL context cannot be activated.
+- Improved 3D viewer paint stability by skipping rendering and GL-dependent overlay work until OpenGL initialization completes successfully.
 
 ## Documentation
 

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -714,17 +714,17 @@ void Viewer3DPanel::StopRefreshThread()
 }
 
 // Initializes 3D OpenGL state only after centralized GLEW/context validation.
-void Viewer3DPanel::InitGL()
+bool Viewer3DPanel::InitGL()
 {
     if (!IsShownOnScreen()) {
-        return;
+        return false;
     }
     if (!m_glInitialized) {
         const GLEWInitResult initResult =
             InitializeGlewForCurrentContext(*this, *m_glContext, "Viewer3DPanel");
         if (!initResult.success) {
             wxLogError("%s", initResult.message);
-            return;
+            return false;
         }
         if (initResult.isWarningOnly) {
             wxLogDebug("%s", initResult.message);
@@ -744,6 +744,7 @@ void Viewer3DPanel::InitGL()
     else
         glDisable(GL_MULTISAMPLE);
     ApplyViewer3DClearColorForStyle(ResolveRenderStyleFromPreferences());
+    return m_glInitialized;
 }
 
 // Paint event handler
@@ -767,7 +768,10 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
         wxASSERT_MSG(false, "Viewer3DPanel has no GL context during paint.");
         return;
     }
-    InitGL();
+    if (!InitGL() || !m_glInitialized) {
+        viewer3d::diagnostics::Log("OpenGL render frame skipped because GL initialization is not complete.");
+        return;
+    }
 
     const bool pauseHeavyTasks = ShouldPauseHeavyTasks();
     const bool highlightOnlyRefresh =
@@ -1123,8 +1127,7 @@ bool Viewer3DPanel::ExportCurrentViewToPng() {
         return false;
 
     SetCurrent(*m_glContext);
-    InitGL();
-    if (!m_glInitialized) {
+    if (!InitGL() || !m_glInitialized) {
         wxMessageBox("OpenGL is not initialized yet.", "Export image",
                      wxOK | wxICON_ERROR, this);
         return false;

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -120,7 +120,7 @@ private:
     std::vector<std::string> m_lastAppliedSelectionUuids;
 
     // Initializes OpenGL settings
-    void InitGL();
+    bool InitGL();
 
     // Handles paint events
     void OnPaint(wxPaintEvent& event);


### PR DESCRIPTION
### Motivation

- Prevent calling `Render()` or performing GL-dependent overlay/hover/framebuffer work when OpenGL/GLEW initialization fails or remains incomplete to avoid crashes and spurious GL calls.  
- Preserve existing diagnostic logging while adding an explicit runtime gate so paint/export paths skip heavy GL paths until initialization is ready.  
- Keep user-visible behavior unchanged except that paint/export are safely skipped when GL is not available.  

### Description

- Changed `Viewer3DPanel::InitGL()` signature from `void` to `bool` and made it return `false` for hidden panels or when `InitializeGlewForCurrentContext` fails, and return the final `m_glInitialized` state after applying GL state; the existing initialization logging is preserved (`viewer3d/viewer3dpanel.cpp`, `viewer3d/viewer3dpanel.h`).  
- Added an early guard in `Viewer3DPanel::OnPaint()` that checks `InitGL()` and `m_glInitialized` and logs/skips the entire paint cycle (render, base-pass cache capture/restore, hover queries, label drawing, overlays, and `SwapBuffers`) when initialization is not complete.  
- Updated `ExportCurrentViewToPng()` to check `InitGL()` and `m_glInitialized` after making the GL context current and to show the existing error dialog if initialization is not ready.  
- Updated `docs/release-notes-draft.md` with a release-ready entry describing the 3D paint initialization guard.  

### Testing

- Ran mandatory checks `tests/check_perastage_tree_modules.sh && tests/check_no_configmanager_get_in_gui.sh`, which both passed.  
- Ran `git diff --check` with no issues detected.  
- Ran `cmake -S . -B /tmp/perastage-build` to validate configuration, which failed in this environment due to missing `wxWidgets` development files (environment limitation), not due to the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a268fedc6808324b7fad88fc528a868)