### PR TITLE
Guard 2D viewer GLEW initialization

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -17,6 +17,7 @@ Changes since `v1.3.0`.
 
 ## Stability and reliability
 
+- Improved 2D viewer startup reliability by validating GLEW initialization before enabling 2D OpenGL rendering.
 - Improved 2D viewer interaction stability by safely skipping selection and hover picking when the OpenGL context is not available.
 - Improved 3D viewer interaction stability by safely skipping picking and resource synchronization when the OpenGL context cannot be activated.
 - Improved 3D viewer paint stability by skipping rendering and GL-dependent overlay work until OpenGL initialization completes successfully.

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -29,6 +29,7 @@
 #endif
 
 #include <GL/glew.h>
+#include "glew_init_utils.h"
 // macOS uses the OpenGL framework headers; guard includes for cross-platform builds.
 #ifdef __APPLE__
 #define GL_SILENCE_DEPRECATION
@@ -863,16 +864,26 @@ void Viewer2DPanel::InitGL() {
     return;
   }
 #endif
-  if (!SetCurrent(*m_glContext)) {
-    return;
-  }
   if (!m_glInitialized) {
-    glewExperimental = GL_TRUE;
-    glewInit();
+    const GLEWInitResult initResult =
+        InitializeGlewForCurrentContext(*this, *m_glContext, "Viewer2DPanel");
+    if (!initResult.success) {
+      wxLogError("%s", initResult.message);
+      return;
+    }
+    if (initResult.isWarningOnly) {
+      wxLogDebug("%s", initResult.message);
+    }
+
     m_controller.InitializeGL();
     glEnable(GL_DEPTH_TEST);
     glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
     m_glInitialized = true;
+    return;
+  }
+
+  if (!SetCurrent(*m_glContext)) {
+    return;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Align the 2D viewer OpenGL startup with the centralized GLEW/context validation used by other panels to reduce platform-specific GLEW/Wayland/GLX issues and unify logging behavior.
- Ensure the 2D controller is only initialized and the `m_glInitialized` flag set after GLEW/context validation succeeds to avoid rendering or GL-dependent work when the GL context is not usable.

### Description
- Added `#include "glew_init_utils.h"` and replaced the raw `glewExperimental = GL_TRUE; glewInit();` sequence in `Viewer2DPanel::InitGL()` with `InitializeGlewForCurrentContext(*this, *m_glContext, "Viewer2DPanel")`.
- Only call `m_controller.InitializeGL()` and set `m_glInitialized = true` when `initResult.success` is true, and log warning-only GLEW messages with `wxLogDebug(...)` while reporting failures with `wxLogError(...)`, matching the 3D/fixture preview panels.
- Preserved the existing context-binding behavior for already-initialized GL state and kept post-init GL setup (`glEnable(GL_DEPTH_TEST)`, `glClearColor`) unchanged.
- Updated `docs/release-notes-draft.md` with a short entry describing improved 2D viewer startup reliability.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed (OK).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (OK).
- Verified the code change with a targeted search (`rg`) to ensure the direct `glewInit()` usage was removed and the helper is used (`InitializeGlewForCurrentContext` found).
- Ran `git diff --check` to ensure no whitespace/diff issues (OK).
- Attempted a full CMake build (`cmake && cmake --build`) but configure failed in this environment because wxWidgets development libraries are not available, so a full build/test could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26914a04cc832487296764830ff14e)