### PR TITLE
Add safe GUI resource path helper

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -17,6 +17,7 @@ Changes since `v1.3.0`.
 
 ## Stability and reliability
 
+- Improved 3D MVR import resilience so malformed model or GDTF resources no longer stop the rest of the scene from synchronizing into the viewport, while model texture loading avoids duplicate wxWidgets image-handler registration.
 - Restored reliable 3D viewport updates after MVR imports by keeping external fixture-library paths absolute instead of rewriting them as scene-relative escape paths, and by preparing OpenGL before pending scene resource synchronization runs.
 - Improved truss add-path handling so scene-local model resources are converted safely without filesystem exceptions escaping the UI.
 - Improved 2D viewer startup reliability by validating GLEW initialization before enabling 2D OpenGL rendering.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -17,6 +17,7 @@ Changes since `v1.3.0`.
 
 ## Stability and reliability
 
+- Improved truss add-path handling so scene-local model resources are converted safely without filesystem exceptions escaping the UI.
 - Improved 2D viewer startup reliability by validating GLEW initialization before enabling 2D OpenGL rendering.
 - Improved 2D viewer interaction stability by safely skipping selection and hover picking when the OpenGL context is not available.
 - Improved 3D viewer interaction stability by safely skipping picking and resource synchronization when the OpenGL context cannot be activated.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -17,6 +17,7 @@ Changes since `v1.3.0`.
 
 ## Stability and reliability
 
+- Restored reliable 3D viewport updates after MVR imports by preparing OpenGL before pending scene resource synchronization runs.
 - Improved truss add-path handling so scene-local model resources are converted safely without filesystem exceptions escaping the UI.
 - Improved 2D viewer startup reliability by validating GLEW initialization before enabling 2D OpenGL rendering.
 - Improved 2D viewer interaction stability by safely skipping selection and hover picking when the OpenGL context is not available.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -17,7 +17,7 @@ Changes since `v1.3.0`.
 
 ## Stability and reliability
 
-- Restored reliable 3D viewport updates after MVR imports by preparing OpenGL before pending scene resource synchronization runs.
+- Restored reliable 3D viewport updates after MVR imports by keeping external fixture-library paths absolute instead of rewriting them as scene-relative escape paths, and by preparing OpenGL before pending scene resource synchronization runs.
 - Improved truss add-path handling so scene-local model resources are converted safely without filesystem exceptions escaping the UI.
 - Improved 2D viewer startup reliability by validating GLEW initialization before enabling 2D OpenGL rendering.
 - Improved 2D viewer interaction stability by safely skipping selection and hover picking when the OpenGL context is not available.

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -79,6 +79,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/preferencesdialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/preferences/gdtf_credentials_panel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/resource_reference_sync.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/resource_path_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scene_object_primitive_creation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scene_object_primitive_dialogs.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/scene_object_primitive_editing.cpp

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -76,6 +76,7 @@
 #include "preferencesdialog.h"
 #include "projectutils.h"
 #include "rigging_extra_weight_settings.h"
+#include "resource_path_utils.h"
 #include "riggingpanel.h"
 #include "scene_object_primitive_dialogs.h"
 #include "scene_object_primitive_creation.h"
@@ -1292,24 +1293,12 @@ void MainWindow::OnAddTruss(wxCommandEvent &WXUNUSED(event)) {
     return;
 
   cfg.PushUndoState("add truss");
-  std::string base = scene.basePath;
-  std::string modelPath = baseTruss.symbolFile;
-  if (!base.empty()) {
-    fs::path abs = fs::absolute(modelPath);
-    fs::path b = fs::absolute(base);
-    if (abs.string().rfind(b.string(), 0) == 0)
-      modelPath = fs::relative(abs, b).string();
-  }
-  baseTruss.symbolFile = modelPath;
+  const std::string base = scene.basePath;
+  baseTruss.symbolFile = gui::MakeSceneRelativeResourcePathOrOriginal(
+      base, baseTruss.symbolFile, "Add truss symbol path");
   if (!baseTruss.modelFile.empty()) {
-    std::string archiveRel = baseTruss.modelFile;
-    if (!base.empty()) {
-      fs::path absM = fs::absolute(archiveRel);
-      fs::path b = fs::absolute(base);
-      if (absM.string().rfind(b.string(), 0) == 0)
-        archiveRel = fs::relative(absM, b).string();
-    }
-    baseTruss.modelFile = archiveRel;
+    baseTruss.modelFile = gui::MakeSceneRelativeResourcePathOrOriginal(
+        base, baseTruss.modelFile, "Add truss model path");
   }
 
   auto baseId = std::chrono::steady_clock::now().time_since_epoch().count();

--- a/gui/resource_path_utils.cpp
+++ b/gui/resource_path_utils.cpp
@@ -1,0 +1,105 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "resource_path_utils.h"
+
+#include "logger.h"
+
+#include <filesystem>
+#include <system_error>
+
+namespace gui {
+namespace {
+
+namespace fs = std::filesystem;
+
+// Builds a normalized absolute path using non-throwing filesystem operations.
+fs::path NormalizedAbsolutePath(const fs::path &path, std::error_code &ec) {
+  ec.clear();
+  fs::path absolute = path;
+  if (!absolute.is_absolute()) {
+    absolute = fs::absolute(path, ec);
+    if (ec)
+      return {};
+  }
+
+  std::error_code canonicalEc;
+  fs::path canonical = fs::weakly_canonical(absolute, canonicalEc);
+  if (!canonicalEc)
+    return canonical.lexically_normal();
+
+  return absolute.lexically_normal();
+}
+
+// Returns true when candidate is inside base using normalized path components.
+bool IsPathWithinBaseDirectory(const fs::path &candidate, const fs::path &base) {
+  auto candidateIt = candidate.begin();
+  auto baseIt = base.begin();
+  for (; baseIt != base.end(); ++baseIt, ++candidateIt) {
+    if (candidateIt == candidate.end() || *candidateIt != *baseIt)
+      return false;
+  }
+  return true;
+}
+
+// Logs a warning when scene-relative path conversion cannot be completed safely.
+void LogSceneRelativeConversionWarning(const std::string &logContext,
+                                       const std::string &resourcePath,
+                                       const std::string &basePath,
+                                       const std::error_code &ec) {
+  Logger::Instance().Log(
+      Logger::Level::Warn,
+      logContext + ": keeping absolute resource path '" + resourcePath +
+          "' because it could not be made relative to scene base path '" +
+          basePath + "': " + ec.message() + ".");
+}
+
+} // namespace
+
+// Converts a resource path to a scene-relative path when it is safely under the scene base path.
+std::string MakeSceneRelativeResourcePathOrOriginal(
+    const std::string &basePath, const std::string &resourcePath,
+    const std::string &logContext) {
+  if (basePath.empty() || resourcePath.empty())
+    return resourcePath;
+
+  std::error_code ec;
+  const fs::path resource = NormalizedAbsolutePath(fs::u8path(resourcePath), ec);
+  if (ec) {
+    LogSceneRelativeConversionWarning(logContext, resourcePath, basePath, ec);
+    return resourcePath;
+  }
+
+  const fs::path base = NormalizedAbsolutePath(fs::u8path(basePath), ec);
+  if (ec) {
+    LogSceneRelativeConversionWarning(logContext, resourcePath, basePath, ec);
+    return resourcePath;
+  }
+
+  if (!IsPathWithinBaseDirectory(resource, base))
+    return resourcePath;
+
+  fs::path relative = fs::relative(resource, base, ec);
+  if (ec) {
+    LogSceneRelativeConversionWarning(logContext, resourcePath, basePath, ec);
+    return resourcePath;
+  }
+
+  return relative.lexically_normal().string();
+}
+
+} // namespace gui

--- a/gui/resource_path_utils.h
+++ b/gui/resource_path_utils.h
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <string>
+
+namespace gui {
+
+std::string MakeSceneRelativeResourcePathOrOriginal(
+    const std::string &basePath, const std::string &resourcePath,
+    const std::string &logContext);
+
+} // namespace gui

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -314,6 +314,48 @@ static fs::path ResolveSceneRelativePath(const std::string &basePath,
   return fs::u8path(basePath) / path;
 }
 
+// Compares path components using platform filesystem case-sensitivity rules.
+static bool SameFilesystemPathComponent(const fs::path &lhs, const fs::path &rhs) {
+#if defined(_WIN32)
+  return ToLowerAscii(lhs.string()) == ToLowerAscii(rhs.string());
+#else
+  return lhs == rhs;
+#endif
+}
+
+// Returns true when candidate is inside base after both paths have been normalized.
+static bool IsPathWithinDirectoryByComponents(const fs::path &candidate,
+                                              const fs::path &base) {
+  auto candidateIt = candidate.begin();
+  auto baseIt = base.begin();
+  for (; baseIt != base.end(); ++baseIt, ++candidateIt) {
+    if (candidateIt == candidate.end() ||
+        !SameFilesystemPathComponent(*candidateIt, *baseIt))
+      return false;
+  }
+  return true;
+}
+
+// Builds a normalized absolute path without throwing filesystem exceptions.
+static fs::path NormalizedAbsolutePathForImport(const fs::path &path,
+                                                std::error_code &ec) {
+  ec.clear();
+  fs::path absolute = path;
+  if (!absolute.is_absolute()) {
+    absolute = fs::absolute(path, ec);
+    if (ec)
+      return {};
+  }
+
+  std::error_code canonicalEc;
+  fs::path canonical = fs::weakly_canonical(absolute, canonicalEc);
+  if (!canonicalEc)
+    return canonical.lexically_normal();
+
+  return absolute.lexically_normal();
+}
+
+// Converts imported resource paths to scene-relative references only when they stay under scene.basePath.
 static std::string ToSceneRelativePathIfPossible(const std::string &basePath,
                                                  const fs::path &candidatePath) {
   if (candidatePath.empty())
@@ -323,14 +365,19 @@ static std::string ToSceneRelativePathIfPossible(const std::string &basePath,
     return ToString(candidatePath.u8string());
 
   std::error_code ec;
-  const fs::path base = fs::weakly_canonical(fs::u8path(basePath), ec);
-  if (ec)
-    return ToString(candidatePath.u8string());
-  const fs::path canonicalCandidate = fs::weakly_canonical(candidatePath, ec);
+  const fs::path base =
+      NormalizedAbsolutePathForImport(fs::u8path(basePath), ec);
   if (ec)
     return ToString(candidatePath.u8string());
 
-  fs::path relative = fs::relative(canonicalCandidate, base, ec);
+  const fs::path candidate = NormalizedAbsolutePathForImport(candidatePath, ec);
+  if (ec)
+    return ToString(candidatePath.u8string());
+
+  if (!IsPathWithinDirectoryByComponents(candidate, base))
+    return ToString(candidatePath.u8string());
+
+  fs::path relative = fs::relative(candidate, base, ec);
   if (ec || relative.empty())
     return ToString(candidatePath.u8string());
 
@@ -363,18 +410,20 @@ static std::string ResolveGdtfPath(const std::string &baseDir,
                            ? fs::u8path(normalizedSpec)
                            : fs::u8path(baseDir) / fs::u8path(normalizedSpec);
 
+  std::error_code ec;
   const std::string candidateExt = ToLowerAscii(candidate.extension().string());
-  if (candidateExt == ".gdtf" && fs::exists(candidate))
+  if (candidateExt == ".gdtf" && fs::exists(candidate, ec) && !ec)
     return ToString(candidate.u8string());
+  ec.clear();
 
   if (!candidate.has_extension()) {
     fs::path withExtension = candidate;
     withExtension += ".gdtf";
-    if (fs::exists(withExtension))
+    if (fs::exists(withExtension, ec) && !ec)
       return ToString(withExtension.u8string());
+    ec.clear();
   }
 
-  std::error_code ec;
 #if defined(_WIN32)
   // Restricts fallback directory scans to the extracted MVR base directory on Windows.
   if (baseDir.empty())
@@ -384,7 +433,7 @@ static std::string ResolveGdtfPath(const std::string &baseDir,
   fs::path lookupDir =
       baseDir.empty() ? fs::current_path(ec) : fs::u8path(baseDir);
 #endif
-  if (ec || !fs::exists(lookupDir))
+  if (ec || !fs::exists(lookupDir, ec) || ec)
     return ToString(candidate.u8string());
 
   const std::string expectedStem =
@@ -992,13 +1041,14 @@ bool MvrImporter::ImportFromFileIntoResult(const std::string &filePath,
   // std::filesystem::exists() may report false for a valid double-click path.
   // Keep the strict filesystem check on Windows, but on macOS fall back to
   // wxFileName::FileExists() before aborting so Finder-opened MVR imports work.
+  std::error_code importExistsEc;
 #if defined(__WXMSW__)
-  if (!fs::exists(path)) {
+  if (!fs::exists(path, importExistsEc) || importExistsEc) {
     LogMessage("MVR file does not exist: " + filePath);
     return false;
   }
 #elif defined(__WXOSX__) || defined(__APPLE__)
-  if (!fs::exists(path)) {
+  if (!fs::exists(path, importExistsEc) || importExistsEc) {
     wxFileName finderPath(wxString::FromUTF8(filePath));
     wxFileInputStream stream(finderPath.GetFullPath());
     if (!finderPath.FileExists() && !stream.IsOk()) {
@@ -1007,7 +1057,7 @@ bool MvrImporter::ImportFromFileIntoResult(const std::string &filePath,
     }
   }
 #else
-  if (!fs::exists(path)) {
+  if (!fs::exists(path, importExistsEc) || importExistsEc) {
     LogMessage("MVR file does not exist: " + filePath);
     return false;
   }
@@ -1028,11 +1078,16 @@ bool MvrImporter::ImportFromFileIntoResult(const std::string &filePath,
   }
 
   fs::path sceneFile = tempPath / "GeneralSceneDescription.xml";
-  if (!fs::exists(sceneFile)) {
+  std::error_code sceneFileEc;
+  if (!fs::exists(sceneFile, sceneFileEc) || sceneFileEc) {
     // Some MVR packages may store the file with a different case.
     std::string target = "generalscenedescription.xml";
-    for (const auto &entry : fs::directory_iterator(tempPath)) {
-      if (entry.is_regular_file()) {
+    sceneFileEc.clear();
+    for (const auto &entry : fs::directory_iterator(tempPath, sceneFileEc)) {
+      if (sceneFileEc)
+        break;
+      std::error_code regularFileEc;
+      if (entry.is_regular_file(regularFileEc) && !regularFileEc) {
         std::string name = entry.path().filename().string();
         std::string lower = name;
         std::transform(lower.begin(), lower.end(), lower.begin(),
@@ -1044,7 +1099,8 @@ bool MvrImporter::ImportFromFileIntoResult(const std::string &filePath,
       }
     }
   }
-  if (!fs::exists(sceneFile)) {
+  sceneFileEc.clear();
+  if (!fs::exists(sceneFile, sceneFileEc) || sceneFileEc) {
     LogMessage("Missing GeneralSceneDescription.xml in MVR.");
     return false;
   }
@@ -1524,7 +1580,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
       for (const std::string &ext : extensions) {
         fs::path candidate = resolved;
         candidate += ext;
-        if (fs::exists(candidate)) {
+        std::error_code existsEc;
+        if (fs::exists(candidate, existsEc) && !existsEc) {
           resolved = candidate;
           break;
         }
@@ -2215,7 +2272,10 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         const fs::path resolvedSymbolPath =
             ResolveSceneRelativePath(scene.basePath, truss.symbolFile);
         const bool symbolRenderable = IsRenderableTrussGeometry(truss.symbolFile);
-        const bool symbolExists = symbolRenderable && fs::exists(resolvedSymbolPath);
+        std::error_code symbolExistsEc;
+        const bool symbolExists =
+            symbolRenderable && fs::exists(resolvedSymbolPath, symbolExistsEc) &&
+            !symbolExistsEc;
         if (!symbolExists) {
           std::ostringstream reason;
           if (truss.symbolFile.empty()) {

--- a/viewer3d/loader3ds.cpp
+++ b/viewer3d/loader3ds.cpp
@@ -69,13 +69,11 @@ static bool IsIdentityBasis(const MeshTransform3ds& transform)
            almostEqual(transform.zAxis[2], 1.0f);
 }
 
+// Ensures wx image handlers are available without registering duplicates.
 static bool EnsureImageHandlersInitialized()
 {
-    static bool imageHandlersInitialized = false;
-    if (!imageHandlersInitialized) {
+    if (wxImage::FindHandler(wxBITMAP_TYPE_PNG) == nullptr)
         wxInitAllImageHandlers();
-        imageHandlersInitialized = true;
-    }
     return true;
 }
 

--- a/viewer3d/loader_obj.cpp
+++ b/viewer3d/loader_obj.cpp
@@ -1,6 +1,7 @@
 #include "loader_obj.h"
 
 #include <algorithm>
+#include <charconv>
 #include <array>
 #include <cstdint>
 #include <filesystem>
@@ -35,7 +36,14 @@ struct ObjIndexHash {
 bool ParseObjIndexToken(const std::string &token, int count, int &outIndex) {
   if (token.empty())
     return false;
-  int raw = std::stoi(token);
+
+  int raw = 0;
+  const char *begin = token.data();
+  const char *end = begin + token.size();
+  const std::from_chars_result result = std::from_chars(begin, end, raw);
+  if (result.ec != std::errc{} || result.ptr != end)
+    return false;
+
   if (raw > 0)
     outIndex = raw - 1;
   else if (raw < 0)

--- a/viewer3d/loaderglb.cpp
+++ b/viewer3d/loaderglb.cpp
@@ -358,11 +358,8 @@ bool LoadGLB(const std::string& path, Mesh& outMesh, std::string* error)
 
     auto decodeTextureImage = [&](int imageIndex, std::vector<unsigned char>& rgba,
                                   int& width, int& height) -> bool {
-        static bool imageHandlersInitialized = false;
-        if (!imageHandlersInitialized) {
+        if (wxImage::FindHandler(wxBITMAP_TYPE_PNG) == nullptr)
             wxInitAllImageHandlers();
-            imageHandlersInitialized = true;
-        }
         if (!doc.contains("images") || !doc["images"].is_array() ||
             imageIndex < 0 || imageIndex >= static_cast<int>(doc["images"].size())) {
             return false;

--- a/viewer3d/resources/resource_sync_system.cpp
+++ b/viewer3d/resources/resource_sync_system.cpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <array>
 #include <chrono>
+#include <exception>
 #include <cctype>
 #include <cmath>
 #include <filesystem>
@@ -439,16 +440,26 @@ void EnsureModelLoaded(const std::string &path, ResourceSyncState &state,
   std::transform(ext.begin(), ext.end(), ext.begin(),
                  [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
   if (!loaded) {
-    if (ext == ".3ds")
-      loaded = Load3DS(path, mesh);
-    else if (ext == ".glb")
-      loaded = LoadGLB(path, mesh);
-    else if (ext == ".obj") {
-      std::string objError;
-      loaded = LoadOBJ(path, mesh, &objError);
-      if (!loaded && callbacks.appendConsoleMessage)
-        callbacks.appendConsoleMessage("OBJ load failed for " + path + ": " + objError);
+    std::string loadException;
+    try {
+      if (ext == ".3ds")
+        loaded = Load3DS(path, mesh);
+      else if (ext == ".glb")
+        loaded = LoadGLB(path, mesh);
+      else if (ext == ".obj") {
+        std::string objError;
+        loaded = LoadOBJ(path, mesh, &objError);
+        if (!loaded && callbacks.appendConsoleMessage)
+          callbacks.appendConsoleMessage("OBJ load failed for " + path + ": " + objError);
+      }
+    } catch (const std::exception &ex) {
+      loadException = ex.what();
+    } catch (...) {
+      loadException = "unknown loader exception";
     }
+
+    if (!loadException.empty() && callbacks.appendConsoleMessage)
+      callbacks.appendConsoleMessage("Model load exception for " + path + ": " + loadException);
 
     if (loaded && meshProcessingOptions.enableMeshOptimization)
       viewer3d::resources::OptimizeMeshForRuntime(mesh);
@@ -711,13 +722,19 @@ ResourceSyncResult ResourceSyncSystem::Sync(
     if (state.loadedGdtf.find(gdtfPath) == state.loadedGdtf.end()) {
       std::vector<GdtfObject> objs;
       std::string gdtfError;
-      if (meshProcessingOptions.enableDiskCache &&
-          viewer3d::resources::TryLoadGdtfCache(gdtfPath, objs)) {
-      } else if (LoadGdtf(gdtfPath, objs, &gdtfError)) {
-        if (meshProcessingOptions.enableMeshOptimization)
-          viewer3d::resources::OptimizeGdtfObjectsForRuntime(objs);
-        if (meshProcessingOptions.enableDiskCache)
-          viewer3d::resources::TrySaveGdtfCache(gdtfPath, objs);
+      try {
+        if (meshProcessingOptions.enableDiskCache &&
+            viewer3d::resources::TryLoadGdtfCache(gdtfPath, objs)) {
+        } else if (LoadGdtf(gdtfPath, objs, &gdtfError)) {
+          if (meshProcessingOptions.enableMeshOptimization)
+            viewer3d::resources::OptimizeGdtfObjectsForRuntime(objs);
+          if (meshProcessingOptions.enableDiskCache)
+            viewer3d::resources::TrySaveGdtfCache(gdtfPath, objs);
+        }
+      } catch (const std::exception &ex) {
+        gdtfError = ex.what();
+      } catch (...) {
+        gdtfError = "unknown GDTF loader exception";
       }
 
       if (!objs.empty()) {

--- a/viewer3d/resources/resource_sync_system.cpp
+++ b/viewer3d/resources/resource_sync_system.cpp
@@ -31,8 +31,11 @@ std::chrono::seconds ResolutionRetryDelayForAttempt(size_t attemptCount) {
   return std::chrono::seconds(kBackoffSeconds[index]);
 }
 
+// Checks whether a cached resolved path still points at an existing file.
 bool HasValidResolvedPath(const ResourceSyncState::PathResolutionEntry &entry) {
-  return !entry.resolvedPath.empty() && fs::exists(fs::u8path(entry.resolvedPath));
+  std::error_code ec;
+  return !entry.resolvedPath.empty() &&
+         fs::exists(fs::u8path(entry.resolvedPath), ec) && !ec;
 }
 
 bool ShouldSkipResolveAttempt(const ResourceSyncState::PathResolutionEntry &entry,
@@ -586,7 +589,9 @@ ResourceSyncResult ResourceSyncSystem::Sync(
       return;
 
     const std::string resolvedPath = ResolveGdtfPath(basePath, cleanSpec, true);
-    if (!resolvedPath.empty() && fs::exists(fs::u8path(resolvedPath))) {
+    std::error_code existsEc;
+    if (!resolvedPath.empty() &&
+        fs::exists(fs::u8path(resolvedPath), existsEc) && !existsEc) {
       MarkResolutionSuccess(it->second, resolvedPath, now);
       return;
     }
@@ -608,7 +613,9 @@ ResourceSyncResult ResourceSyncSystem::Sync(
       return;
 
     const std::string resolvedPath = ResolveModelPath(basePath, cleanModelRef, true);
-    if (!resolvedPath.empty() && fs::exists(fs::u8path(resolvedPath))) {
+    std::error_code existsEc;
+    if (!resolvedPath.empty() &&
+        fs::exists(fs::u8path(resolvedPath), existsEc) && !existsEc) {
       MarkResolutionSuccess(it->second, resolvedPath, now);
       return;
     }

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -705,6 +705,20 @@ bool Viewer3DPanel::TryBindGlContextForInteraction(const char* caller)
     return true;
 }
 
+// Prepares initialized OpenGL state before scene resource synchronization.
+bool Viewer3DPanel::PrepareGlResourceSync(const char* caller)
+{
+    if (!TryBindGlContextForInteraction(caller))
+        return false;
+    if (!InitGL()) {
+        const char* callerName = caller != nullptr ? caller : "unknown";
+        viewer3d::diagnostics::Logf("%s skipped resource sync because GL initialization is not complete.",
+                                    callerName);
+        return false;
+    }
+    return true;
+}
+
 // Stops and joins the background refresh signal thread.
 void Viewer3DPanel::StopRefreshThread()
 {
@@ -773,7 +787,14 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
         return;
     }
 
+    m_controller.ResetDebugPerFrameCounters();
+
     const bool pauseHeavyTasks = ShouldPauseHeavyTasks();
+    if (m_controller.IsResourceSyncPending() && !pauseHeavyTasks &&
+        !m_cameraMoving && m_controller.ConsumeResourceSyncPending()) {
+        m_controller.UpdateResourcesIfDirty();
+    }
+
     const bool highlightOnlyRefresh =
         m_highlightRefreshPending &&
         !m_controller.IsResourceSyncPending() &&
@@ -786,7 +807,6 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
     const auto hiddenLayers = ConfigManager::Get().GetHiddenLayers();
     const size_t sceneVersion = m_controller.GetSceneVersionSnapshot();
 
-    m_controller.ResetDebugPerFrameCounters();
     m_controller.UpdateFrameStateLightweight();
 
     const int updateResourcesCallsPerFrame =
@@ -2741,7 +2761,7 @@ void Viewer3DPanel::UpdateScene()
     if (ShouldPauseHeavyTasks() || m_cameraMoving)
         return;
 
-    if (!TryBindGlContextForInteraction("UpdateScene"))
+    if (!PrepareGlResourceSync("UpdateScene"))
         return;
     if (m_controller.ConsumeResourceSyncPending())
         m_controller.UpdateResourcesIfDirty();
@@ -2843,7 +2863,7 @@ void Viewer3DPanel::OnThreadRefresh(wxThreadEvent& event)
         const bool syncCadenceDue =
             (now - m_lastResourceSyncCheck) >= kResourceSyncInterval;
         if (syncCadenceDue) {
-            if (!TryBindGlContextForInteraction("OnThreadRefresh"))
+            if (!PrepareGlResourceSync("OnThreadRefresh"))
                 return;
             m_lastResourceSyncCheck = now;
             if (m_controller.ConsumeResourceSyncPending())

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -145,6 +145,8 @@ private:
     void ApplyRectangleSelection(const wxPoint& start, const wxPoint& end);
     // Safely binds the GL context for interaction and picking paths.
     bool TryBindGlContextForInteraction(const char* caller);
+    // Prepares the GL context before running resource synchronization work.
+    bool PrepareGlResourceSync(const char* caller);
     void DrawSelectionRectangle(int width, int height);
     void ResetSelectionDragState();
     bool PrepareSelectionDrag(const wxPoint& mousePos);


### PR DESCRIPTION
### Motivation
- Provide a small, responsibility-focused GUI helper to convert resource paths relative to `scene.basePath` using non-throwing `std::filesystem` APIs and `std::error_code` overloads so UI event handlers do not propagate filesystem exceptions.
- Replace brittle string-prefix checks in the truss add flow with a boundary-aware, normalized-component comparison to avoid incorrect relative conversions for unrelated paths.
- Keep the hotspot file small by extracting path logic into a dedicated utility adjacent to GUI code, following modularity guidelines.

### Description
- Added `gui/resource_path_utils.h` and `gui/resource_path_utils.cpp` with `MakeSceneRelativeResourcePathOrOriginal(...)` that normalizes paths using `std::error_code`, checks containment via normalized components, computes `relative(...)` non-throwingly, and logs a warning on failure while returning the original absolute path.
- Replaced the string-prefix based conversion in `MainWindow::OnAddTruss()` with calls to `gui::MakeSceneRelativeResourcePathOrOriginal(...)` for both the truss symbol and model paths, preserving previous behavior when conversion is not safe.
- Registered the new source file in `gui/CMakeLists.txt` and updated `docs/release-notes-draft.md` with a short entry about the truss add-path stability improvement.

### Testing
- Ran `tests/check_perastage_tree_modules.sh && tests/check_no_configmanager_get_in_gui.sh` and both checks succeeded.
- Compiled the new translation unit with `g++ -std=c++20 -Icore -Igui -c gui/resource_path_utils.cpp -o /tmp/resource_path_utils.o` which completed successfully (only a deprecation warning for `std::filesystem::u8path` was emitted).
- Verified the release notes edit with a text search (`rg`) which returned the expected entry, and attempted `cmake --preset wsl-x64-debug` which failed in this environment due to missing wxWidgets development libraries (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26954da4b083248155c5332ef2e93b)