### PR TITLE
Bounded recursive fallback for 3D resource lookup

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -17,6 +17,7 @@ Changes since `v1.3.0`.
 
 ## Stability and reliability
 
+- Improved 3D resource lookup resilience by bounding recursive fallback scans on the viewport sync path and logging when protected folders are skipped or scan limits are reached.
 - Improved visible 3D resource synchronization so filesystem errors on cached or user-derived GDTF and model paths are handled safely with concise diagnostics instead of interrupting viewport updates.
 - Improved 3D MVR import resilience so malformed model or GDTF resources no longer stop the rest of the scene from synchronizing into the viewport, while model texture loading avoids duplicate wxWidgets image-handler registration.
 - Restored reliable 3D viewport updates after MVR imports by keeping external fixture-library paths absolute instead of rewriting them as scene-relative escape paths, and by preparing OpenGL before pending scene resource synchronization runs.

--- a/viewer3d/CMakeLists.txt
+++ b/viewer3d/CMakeLists.txt
@@ -26,6 +26,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/render/viewer3d_render_style.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/render/scenerenderer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/resources/mesh_processing.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/resources/resource_path_search.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/resources/resource_sync_system.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/viewer3dcamera.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/viewer3dcontroller.cpp

--- a/viewer3d/resources/resource_path_search.cpp
+++ b/viewer3d/resources/resource_path_search.cpp
@@ -1,0 +1,257 @@
+#include "resource_path_search.h"
+
+#include "projectutils.h"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <filesystem>
+#include <string_view>
+#include <system_error>
+
+namespace fs = std::filesystem;
+
+namespace viewer3d::resources {
+namespace {
+using SearchClock = std::chrono::steady_clock;
+
+bool MatchesFileNameWithExtensionTolerance(const fs::path &candidate,
+                                           const std::string &fileName);
+
+// Compares two ASCII strings without considering letter case.
+bool EqualIgnoreCaseAscii(std::string_view lhs, std::string_view rhs) {
+  if (lhs.size() != rhs.size())
+    return false;
+  for (size_t i = 0; i < lhs.size(); ++i) {
+    const unsigned char a = static_cast<unsigned char>(lhs[i]);
+    const unsigned char b = static_cast<unsigned char>(rhs[i]);
+    if (std::tolower(a) != std::tolower(b))
+      return false;
+  }
+  return true;
+}
+
+// Checks whether a path is already present in a path list.
+bool ContainsPath(const std::vector<fs::path> &paths, const fs::path &candidate) {
+  return std::any_of(paths.begin(), paths.end(), [&](const fs::path &p) {
+    return p == candidate;
+  });
+}
+
+// Checks whether a candidate path matches a target file name with case-tolerant extensions.
+bool MatchesFileNameWithExtensionTolerance(const fs::path &candidate,
+                                           const std::string &fileName) {
+  const fs::path target(fileName);
+  const std::string candidateName = candidate.filename().string();
+  if (candidateName == fileName)
+    return true;
+
+  if (candidate.stem().string() != target.stem().string())
+    return false;
+  return EqualIgnoreCaseAscii(candidate.extension().string(),
+                              target.extension().string());
+}
+
+// Detects filesystem roots that should never be recursively scanned on the render path.
+bool IsSkippedRecursiveSearchRoot(const fs::path &root, std::string *reason) {
+  if (root.empty()) {
+    if (reason)
+      *reason = "empty search root";
+    return true;
+  }
+
+  const std::string rootText = root.string();
+  if (rootText.rfind("//", 0) == 0 || rootText.rfind("\\\\", 0) == 0) {
+    if (reason)
+      *reason = "network search root";
+    return true;
+  }
+
+  const std::string rootName = root.filename().string();
+  if (rootName == "Windows" || rootName == "Program Files" ||
+      rootName == "Program Files (x86)" || rootName == "$Recycle.Bin" ||
+      rootName == "System Volume Information" || rootName == "System") {
+    if (reason)
+      *reason = "system folder";
+    return true;
+  }
+
+  std::error_code ec;
+  const fs::path normalized = fs::weakly_canonical(root, ec);
+  const fs::path probe = ec ? root.lexically_normal() : normalized;
+#ifdef _WIN32
+  const std::string probeText = probe.string();
+  if (probeText.size() <= 3 && probe.has_root_directory()) {
+    if (reason)
+      *reason = "system drive root";
+    return true;
+  }
+#else
+  if (probe == fs::path("/")) {
+    if (reason)
+      *reason = "system filesystem root";
+    return true;
+  }
+  static const std::array<fs::path, 4> systemRoots = {
+      fs::path("/dev"), fs::path("/proc"), fs::path("/run"), fs::path("/sys")};
+  for (const fs::path &systemRoot : systemRoots) {
+    if (probe == systemRoot) {
+      if (reason)
+        *reason = "system folder";
+      return true;
+    }
+  }
+#endif
+
+  return false;
+}
+
+// Checks whether a recursive search should avoid descending into a directory.
+bool ShouldSkipRecursiveDirectory(const fs::path &path) {
+  std::error_code ec;
+  const fs::path canonical = fs::weakly_canonical(path, ec);
+  const fs::path probe = ec ? path.lexically_normal() : canonical;
+#ifndef _WIN32
+  static const std::array<fs::path, 4> systemRoots = {
+      fs::path("/dev"), fs::path("/proc"), fs::path("/run"), fs::path("/sys")};
+  for (const fs::path &systemRoot : systemRoots) {
+    if (probe == systemRoot)
+      return true;
+  }
+#endif
+
+  const std::string name = path.filename().string();
+  return name == ".git" || name == ".svn" || name == ".hg" ||
+         name == "node_modules" || name == "__pycache__" ||
+         name == "Windows" || name == "Program Files" ||
+         name == "Program Files (x86)" || name == "$Recycle.Bin" ||
+         name == "System Volume Information" || name == "System";
+}
+
+// Searches recursively for a file while enforcing render-path safety limits.
+BoundedRecursiveSearchResult FindFileRecursiveBounded(
+    const std::string &baseDir, const std::string &fileName,
+    const BoundedRecursiveSearchLimits &limits) {
+  BoundedRecursiveSearchResult result;
+  result.baseDir = baseDir;
+  result.fileName = fileName;
+
+  if (fileName.empty()) {
+    result.skipped = true;
+    result.skipReason = "empty file name";
+    return result;
+  }
+
+  const fs::path root = fs::u8path(baseDir);
+  if (IsSkippedRecursiveSearchRoot(root, &result.skipReason)) {
+    result.skipped = true;
+    return result;
+  }
+
+  const auto startTime = SearchClock::now();
+  std::error_code ec;
+  fs::recursive_directory_iterator it(
+      root, fs::directory_options::skip_permission_denied, ec);
+  if (ec) {
+    result.skipped = true;
+    result.skipReason = ec.message();
+    return result;
+  }
+
+  const fs::recursive_directory_iterator end;
+  for (; it != end; it.increment(ec)) {
+    if (ec) {
+      ec.clear();
+      continue;
+    }
+
+    if (SearchClock::now() - startTime >= limits.maxElapsed) {
+      result.capped = true;
+      result.cappedByTime = true;
+      break;
+    }
+
+    if (it->is_directory(ec)) {
+      if (ec) {
+        ec.clear();
+        continue;
+      }
+      ++result.visitedDirectories;
+      if (ShouldSkipRecursiveDirectory(it->path())) {
+        it.disable_recursion_pending();
+        result.skippedFolder = true;
+        continue;
+      }
+      if (result.visitedDirectories >= limits.maxVisitedDirectories) {
+        result.capped = true;
+        result.cappedByDirectories = true;
+        break;
+      }
+      continue;
+    }
+
+    if (!it->is_regular_file(ec) || ec) {
+      ec.clear();
+      continue;
+    }
+
+    ++result.visitedFiles;
+    if (MatchesFileNameWithExtensionTolerance(it->path(), fileName)) {
+      result.resolvedPath = it->path().string();
+      return result;
+    }
+
+    if (result.visitedFiles >= limits.maxVisitedFiles) {
+      result.capped = true;
+      result.cappedByFiles = true;
+      break;
+    }
+  }
+
+  return result;
+}
+
+// Builds the bounded recursive fallback search roots in priority order.
+std::vector<fs::path> BuildRecursiveFallbackRoots(const std::string &base) {
+  std::vector<fs::path> roots;
+  if (!base.empty())
+    roots.push_back(fs::u8path(base));
+
+  const std::array<std::string, 3> librarySubdirs = {
+      "fixtures", "trusses", "scene_objects"};
+  for (const std::string &subdir : librarySubdirs) {
+    const fs::path root = fs::u8path(ProjectUtils::GetDefaultLibraryPath(subdir));
+    if (!root.empty() && !ContainsPath(roots, root))
+      roots.push_back(root);
+  }
+  return roots;
+}
+
+// Records recursive-search diagnostics that should be logged by the caller.
+void AddRecursiveSearchDiagnostic(
+    BoundedRecursiveSearchDiagnostics *diagnostics,
+    const BoundedRecursiveSearchResult &result) {
+  if (!diagnostics || (!result.skipped && !result.capped && !result.skippedFolder))
+    return;
+  diagnostics->push_back(result);
+}
+
+} // namespace
+
+// Searches fallback roots recursively while preserving configured traversal bounds.
+std::string ResolveFromBoundedRecursiveFallback(
+    const std::string &base, const std::string &fileName,
+    BoundedRecursiveSearchDiagnostics *diagnostics) {
+  const BoundedRecursiveSearchLimits limits;
+  for (const fs::path &root : BuildRecursiveFallbackRoots(base)) {
+    BoundedRecursiveSearchResult result =
+        FindFileRecursiveBounded(root.string(), fileName, limits);
+    const std::string resolvedPath = result.resolvedPath;
+    AddRecursiveSearchDiagnostic(diagnostics, result);
+    if (!resolvedPath.empty())
+      return resolvedPath;
+  }
+  return {};
+}
+
+} // namespace viewer3d::resources

--- a/viewer3d/resources/resource_path_search.h
+++ b/viewer3d/resources/resource_path_search.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace viewer3d::resources {
+
+struct BoundedRecursiveSearchLimits {
+  size_t maxVisitedFiles = 1500;
+  size_t maxVisitedDirectories = 250;
+  std::chrono::milliseconds maxElapsed = std::chrono::milliseconds(25);
+};
+
+struct BoundedRecursiveSearchResult {
+  std::string resolvedPath;
+  std::string baseDir;
+  std::string fileName;
+  std::string skipReason;
+  size_t visitedFiles = 0;
+  size_t visitedDirectories = 0;
+  bool skipped = false;
+  bool capped = false;
+  bool cappedByFiles = false;
+  bool cappedByDirectories = false;
+  bool cappedByTime = false;
+  bool skippedFolder = false;
+};
+
+using BoundedRecursiveSearchDiagnostics =
+    std::vector<BoundedRecursiveSearchResult>;
+
+std::string ResolveFromBoundedRecursiveFallback(
+    const std::string &base, const std::string &fileName,
+    BoundedRecursiveSearchDiagnostics *diagnostics = nullptr);
+
+} // namespace viewer3d::resources

--- a/viewer3d/resources/resource_sync_system.cpp
+++ b/viewer3d/resources/resource_sync_system.cpp
@@ -1,5 +1,6 @@
 #include "resource_sync_system.h"
 #include "mesh_processing.h"
+#include "resource_path_search.h"
 
 #include "loader3ds.h"
 #include "loaderglb.h"
@@ -23,6 +24,7 @@ namespace fs = std::filesystem;
 namespace {
 using RetryClock = std::chrono::steady_clock;
 
+// Returns the current monotonic time used for retry backoff.
 RetryClock::time_point CurrentRetryTime() { return RetryClock::now(); }
 
 struct PathExistenceResult {
@@ -99,6 +101,7 @@ void LogPathValidationDiagnostics(
   }
 }
 
+// Returns the retry delay for a failed path-resolution attempt.
 std::chrono::seconds ResolutionRetryDelayForAttempt(size_t attemptCount) {
   static constexpr std::array<int, 4> kBackoffSeconds = {1, 5, 30, 120};
   if (attemptCount == 0)
@@ -119,11 +122,13 @@ bool HasValidResolvedPath(const ResourceSyncState::PathResolutionEntry &entry,
   return existence.exists && !existence.error;
 }
 
+// Checks whether a cached failed resolution is still inside its backoff window.
 bool ShouldSkipResolveAttempt(const ResourceSyncState::PathResolutionEntry &entry,
                               RetryClock::time_point now) {
   return entry.attempted && entry.attemptCount > 0 && now < entry.nextRetryTime;
 }
 
+// Records a successful resource path resolution in the cache.
 void MarkResolutionSuccess(ResourceSyncState::PathResolutionEntry &entry,
                            const std::string &resolvedPath,
                            RetryClock::time_point now) {
@@ -134,6 +139,7 @@ void MarkResolutionSuccess(ResourceSyncState::PathResolutionEntry &entry,
   entry.nextRetryTime = RetryClock::time_point{};
 }
 
+// Records a failed resource path resolution and schedules the next retry.
 void MarkResolutionFailure(ResourceSyncState::PathResolutionEntry &entry,
                            RetryClock::time_point now) {
   entry.resolvedPath.clear();
@@ -143,6 +149,7 @@ void MarkResolutionFailure(ResourceSyncState::PathResolutionEntry &entry,
   entry.nextRetryTime = now + ResolutionRetryDelayForAttempt(entry.attemptCount);
 }
 
+// Removes failed path-resolution entries so changed scenes can retry immediately.
 void InvalidateNegativeResolutionCache(
     std::unordered_map<std::string, ResourceSyncState::PathResolutionEntry> &cache) {
   for (auto it = cache.begin(); it != cache.end();) {
@@ -157,29 +164,7 @@ void InvalidateNegativeResolutionCache(
 bool MatchesFileNameWithExtensionTolerance(const fs::path &candidate,
                                            const std::string &fileName);
 
-std::string FindFileRecursive(const std::string &baseDir,
-                              const std::string &fileName) {
-  if (baseDir.empty())
-    return {};
-
-  std::error_code ec;
-  fs::recursive_directory_iterator it(baseDir, ec), end;
-  if (ec)
-    return {};
-
-  for (; it != end; it.increment(ec)) {
-    if (ec)
-      break;
-    if (!it->is_regular_file(ec) || ec) {
-      ec.clear();
-      continue;
-    }
-    if (MatchesFileNameWithExtensionTolerance(it->path(), fileName))
-      return it->path().string();
-  }
-  return {};
-}
-
+// Compares two ASCII strings without considering letter case.
 bool EqualIgnoreCaseAscii(std::string_view lhs, std::string_view rhs) {
   if (lhs.size() != rhs.size())
     return false;
@@ -192,12 +177,14 @@ bool EqualIgnoreCaseAscii(std::string_view lhs, std::string_view rhs) {
   return true;
 }
 
+// Checks whether a path is already present in a path list.
 bool ContainsPath(const std::vector<fs::path> &paths, const fs::path &candidate) {
   return std::any_of(paths.begin(), paths.end(), [&](const fs::path &p) {
     return p == candidate;
   });
 }
 
+// Checks whether a candidate path matches a target file name with case-tolerant extensions.
 bool MatchesFileNameWithExtensionTolerance(const fs::path &candidate,
                                            const std::string &fileName) {
   const fs::path target(fileName);
@@ -211,6 +198,46 @@ bool MatchesFileNameWithExtensionTolerance(const fs::path &candidate,
                               target.extension().string());
 }
 
+// Logs recursive-search diagnostics for bounded fallback resolution.
+void LogRecursiveSearchDiagnostics(
+    const ResourceSyncCallbacks &callbacks,
+    const viewer3d::resources::BoundedRecursiveSearchDiagnostics &diagnostics) {
+  if (!callbacks.appendConsoleMessage)
+    return;
+
+  for (const viewer3d::resources::BoundedRecursiveSearchResult &diagnostic : diagnostics) {
+    if (diagnostic.skipped) {
+      callbacks.appendConsoleMessage(
+          "Recursive resource search skipped for " + diagnostic.fileName +
+          " under " + diagnostic.baseDir + ": " + diagnostic.skipReason);
+      continue;
+    }
+
+    if (!diagnostic.capped && diagnostic.skippedFolder) {
+      callbacks.appendConsoleMessage(
+          "Recursive resource search skipped protected folders while looking for " +
+          diagnostic.fileName + " under " + diagnostic.baseDir + ".");
+      continue;
+    }
+
+    std::string reason;
+    if (diagnostic.cappedByFiles)
+      reason = "file limit";
+    else if (diagnostic.cappedByDirectories)
+      reason = "directory limit";
+    else if (diagnostic.cappedByTime)
+      reason = "time limit";
+    else
+      reason = "configured limit";
+    callbacks.appendConsoleMessage(
+        "Recursive resource search capped by " + reason + " for " +
+        diagnostic.fileName + " under " + diagnostic.baseDir + " after visiting " +
+        std::to_string(diagnostic.visitedFiles) + " files and " +
+        std::to_string(diagnostic.visitedDirectories) + " directories.");
+  }
+}
+
+// Decodes simple percent escapes that appear in imported resource paths.
 std::string DecodePathEscapes(const std::string &input) {
   std::string out;
   out.reserve(input.size());
@@ -329,7 +356,7 @@ std::string ResolveFromLibrarySuffix(
   return {};
 }
 
-// Resolves a resource file name from default Perastage library locations.
+// Resolves direct resource file-name matches from default Perastage library locations.
 std::string ResolveFromDefaultLibrary(
     const std::string &fileName,
     std::vector<PathValidationDiagnostic> *diagnostics = nullptr) {
@@ -344,14 +371,11 @@ std::string ResolveFromDefaultLibrary(
         ResolveExistingPath(root / fileName, diagnostics);
     if (!directResolved.empty())
       return directResolved;
-
-    const std::string recursiveResolved = FindFileRecursive(root.string(), fileName);
-    if (!recursiveResolved.empty())
-      return recursiveResolved;
   }
   return {};
 }
 
+// Trims whitespace and wrapping quotes from an imported path reference.
 std::string TrimPathRef(std::string value) {
   auto isTrim = [](unsigned char c) {
     return std::isspace(c) != 0 || c == '\r' || c == '\n' || c == '\t';
@@ -368,6 +392,7 @@ std::string TrimPathRef(std::string value) {
   return value;
 }
 
+// Normalizes path separators to the current platform separator.
 std::string NormalizePath(const std::string &p) {
   std::string out = p;
   char sep = static_cast<char>(fs::path::preferred_separator);
@@ -376,6 +401,7 @@ std::string NormalizePath(const std::string &p) {
   return out;
 }
 
+// Normalizes a model path for cache-key comparisons.
 std::string NormalizeModelKey(const std::string &p) {
   if (p.empty())
     return {};
@@ -384,6 +410,7 @@ std::string NormalizeModelKey(const std::string &p) {
   return NormalizePath(path.string());
 }
 
+// Builds the stable cache key for a resource path reference.
 std::string ResolveCacheKey(const std::string &pathRef) {
   return NormalizeModelKey(TrimPathRef(pathRef));
 }
@@ -392,7 +419,9 @@ std::string ResolveCacheKey(const std::string &pathRef) {
 std::string ResolveGdtfPath(
     const std::string &base, const std::string &spec,
     bool allowRecursiveFallback = false,
-    std::vector<PathValidationDiagnostic> *diagnostics = nullptr) {
+    std::vector<PathValidationDiagnostic> *diagnostics = nullptr,
+    viewer3d::resources::BoundedRecursiveSearchDiagnostics *recursiveDiagnostics =
+        nullptr) {
   const std::string cleanSpec = DecodePathEscapes(TrimPathRef(spec));
   if (cleanSpec.empty())
     return {};
@@ -440,7 +469,8 @@ std::string ResolveGdtfPath(
     return defaultLibraryResolved;
 
   if (allowRecursiveFallback)
-    return FindFileRecursive(base, fileName);
+    return viewer3d::resources::ResolveFromBoundedRecursiveFallback(
+        base, fileName, recursiveDiagnostics);
   return {};
 }
 
@@ -448,20 +478,27 @@ std::string ResolveGdtfPath(
 std::string ResolveModelPath(
     const std::string &base, const std::string &modelRef,
     bool allowRecursiveFallback = false,
-    std::vector<PathValidationDiagnostic> *diagnostics = nullptr) {
-  return ResolveGdtfPath(base, modelRef, allowRecursiveFallback, diagnostics);
+    std::vector<PathValidationDiagnostic> *diagnostics = nullptr,
+    viewer3d::resources::BoundedRecursiveSearchDiagnostics *recursiveDiagnostics =
+        nullptr) {
+  return ResolveGdtfPath(base, modelRef, allowRecursiveFallback, diagnostics,
+                         recursiveDiagnostics);
 }
 
+// Combines two hash values into a stable aggregate hash.
 size_t HashCombine(size_t seed, size_t value) {
   return seed ^ (value + 0x9e3779b97f4a7c15ULL + (seed << 6U) + (seed >> 2U));
 }
 
+// Hashes a string value for scene-signature calculations.
 size_t HashString(const std::string &value) { return std::hash<std::string>{}(value); }
 
+// Hashes a float after quantizing it for stable scene signatures.
 size_t HashFloat(float value) {
   return std::hash<int>{}(std::lround(value * 1000.0f));
 }
 
+// Hashes a transform matrix for scene-signature calculations.
 size_t HashMatrix(const Matrix &m) {
   size_t hash = 0;
   for (float value : m.u)
@@ -475,6 +512,7 @@ size_t HashMatrix(const Matrix &m) {
   return hash;
 }
 
+// Builds a version hash for fixture geometry-tree content.
 size_t HashGeometryTreeVersion(const GdtfGeometryTree &tree) {
   size_t hash = HashCombine(HashString("nodes"), tree.nodes.size());
   for (const GdtfNode3D &node : tree.nodes) {
@@ -498,6 +536,7 @@ size_t HashGeometryTreeVersion(const GdtfGeometryTree &tree) {
   return hash;
 }
 
+// Builds the cache signature for a fixture node registry entry.
 size_t BuildFixtureRegistrySignature(const std::string &uuid,
                                      const std::string &resolvedGdtfPath,
                                      const Matrix &fixtureTransform,
@@ -509,6 +548,7 @@ size_t BuildFixtureRegistrySignature(const std::string &uuid,
   return signature;
 }
 
+// Creates a fixture scene node from a GDTF template node and fixture transform.
 FixtureSceneNode BuildInstancedFixtureNode(const GdtfNode3D &templateNode,
                                           const Matrix &fixtureTransform,
                                           int parentIndexOffset) {
@@ -582,6 +622,7 @@ void EnsureModelLoaded(const std::string &path, ResourceSyncState &state,
   }
 }
 
+// Uploads mesh buffers for all loaded GDTF objects when a setup callback exists.
 void SetupGdtfMeshBuffers(std::vector<GdtfObject> &objects,
                           const ResourceSyncCallbacks &callbacks) {
   if (!callbacks.setupMeshBuffers)
@@ -591,6 +632,7 @@ void SetupGdtfMeshBuffers(std::vector<GdtfObject> &objects,
     callbacks.setupMeshBuffers(object.mesh);
 }
 
+// Releases GPU mesh buffers for all cached GDTF objects when a release callback exists.
 void ReleaseGdtfMeshBuffers(ResourceSyncState &state,
                             const ResourceSyncCallbacks &callbacks) {
   if (!callbacks.releaseMeshBuffers)
@@ -705,12 +747,15 @@ ResourceSyncResult ResourceSyncSystem::Sync(
       return;
 
     std::vector<PathValidationDiagnostic> pathDiagnostics;
+    viewer3d::resources::BoundedRecursiveSearchDiagnostics recursiveDiagnostics;
     const std::string resolvedPath =
-        ResolveGdtfPath(basePath, cleanSpec, true, &pathDiagnostics);
+        ResolveGdtfPath(basePath, cleanSpec, true, &pathDiagnostics,
+                        &recursiveDiagnostics);
     if (!resolvedPath.empty()) {
       const PathExistenceResult existence =
           CheckUtf8PathExistsNoThrow(resolvedPath);
       if (existence.exists && !existence.error) {
+        LogRecursiveSearchDiagnostics(callbacks, recursiveDiagnostics);
         MarkResolutionSuccess(it->second, resolvedPath, now);
         return;
       }
@@ -720,6 +765,7 @@ ResourceSyncResult ResourceSyncSystem::Sync(
         LogPathValidationDiagnostics(callbacks, pathDiagnostics);
     } else {
       LogPathValidationDiagnostics(callbacks, pathDiagnostics);
+      LogRecursiveSearchDiagnostics(callbacks, recursiveDiagnostics);
     }
     MarkResolutionFailure(it->second, now);
   };
@@ -739,12 +785,15 @@ ResourceSyncResult ResourceSyncSystem::Sync(
       return;
 
     std::vector<PathValidationDiagnostic> pathDiagnostics;
+    viewer3d::resources::BoundedRecursiveSearchDiagnostics recursiveDiagnostics;
     const std::string resolvedPath =
-        ResolveModelPath(basePath, cleanModelRef, true, &pathDiagnostics);
+        ResolveModelPath(basePath, cleanModelRef, true, &pathDiagnostics,
+                         &recursiveDiagnostics);
     if (!resolvedPath.empty()) {
       const PathExistenceResult existence =
           CheckUtf8PathExistsNoThrow(resolvedPath);
       if (existence.exists && !existence.error) {
+        LogRecursiveSearchDiagnostics(callbacks, recursiveDiagnostics);
         MarkResolutionSuccess(it->second, resolvedPath, now);
         return;
       }
@@ -754,6 +803,7 @@ ResourceSyncResult ResourceSyncSystem::Sync(
         LogPathValidationDiagnostics(callbacks, pathDiagnostics);
     } else {
       LogPathValidationDiagnostics(callbacks, pathDiagnostics);
+      LogRecursiveSearchDiagnostics(callbacks, recursiveDiagnostics);
     }
     MarkResolutionFailure(it->second, now);
   };


### PR DESCRIPTION
### Motivation
- Prevent unbounded recursive filesystem scans on the 3D render/resource-sync path that can stall or traverse network/system folders. 
- Keep fast-path resolution (direct, relative, library-suffix, default-library) unchanged and use recursive traversal only as a bounded last-resort fallback. 
- Provide concise diagnostics when recursive fallback is skipped or capped so issues are visible without interrupting viewport updates.

### Description
- Added a dedicated bounded recursive-search helper in `viewer3d/resources/resource_path_search.{h,cpp}` that enforces limits for `maxVisitedFiles`, `maxVisitedDirectories`, and `maxElapsed` and returns structured diagnostics for skipped/capped searches.
- Added safe-guards to the bounded search to skip network roots, system roots and protected folders (e.g. `.git`, `node_modules`, `/dev`, `/proc`, Windows system folders). 
- Reworked resource resolution in `viewer3d/resources/resource_sync_system.cpp` to remove the previous unbounded recursive fallback and call the new bounded fallback via `ResolveFromBoundedRecursiveFallback(...)` only when other lookups fail; the fallback now accepts/returns diagnostics which are logged via `LogRecursiveSearchDiagnostics(...)` when skipped/capped.
- Kept existing fast-path checks unchanged: absolute, scene-relative, UTF-8 absolute/relative, library-suffix, and direct default-library matches remain first-line lookups.
- Added per-function concise comments where relevant and moved recursive-search implementation into its own module to keep `resource_sync_system.cpp` smaller and modular.
- Registered the new `resource_path_search.cpp` in `viewer3d/CMakeLists.txt` and updated `docs/release-notes-draft.md` with a release-note entry describing the reliability improvement.

### Testing
- Ran the mandatory repository checks `tests/check_perastage_tree_modules.sh && tests/check_no_configmanager_get_in_gui.sh` and both returned `OK`.
- Performed a compile-time syntax check with `g++ -std=c++20 -fsyntax-only viewer3d/resources/resource_sync_system.cpp viewer3d/resources/resource_path_search.cpp` which passed (noting existing `std::filesystem::u8path` deprecation warnings only).
- Attempted `cmake --preset wsl-x64-debug` in the environment and configure failed due to missing `wxWidgets` development packages (environmental limitation, not code-related).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26a380a1bc83249957ecaba1ae2cb5)