### PR TITLE
Stabilize truss table reload selection

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -31,4 +31,5 @@ Changes since `v1.3.0`.
 
 ## Internal changes
 
+- Improved truss table reload stability so rebuilding rows preserves existing truss selection without triggering transient selection side effects.
 - Added concise diagnostics for truss loading and 2D viewer picking to make validation and interaction issues easier to troubleshoot.

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -229,8 +229,11 @@ void TrussTablePanel::InitializeTable()
     ColumnUtils::EnforceMinColumnWidth(table);
 }
 
+// Refreshes truss table rows from the current project data.
 void TrussTablePanel::ReloadData()
 {
+    ConfigManager& cfg = guiConfigServices->LegacyConfigManager();
+    const std::vector<std::string> selectedTrusses = cfg.GetSelectedTrusses();
     const auto distanceUnit = ResolveDistanceUnitSystem();
     const auto weightUnit = ResolveWeightUnitSystem();
     const wxString distanceSuffix =
@@ -249,6 +252,9 @@ void TrussTablePanel::ReloadData()
             column->SetTitle(columnLabels[i]);
     }
 
+    std::unique_ptr<wxEventBlocker> selectionBlocker = std::make_unique<wxEventBlocker>(
+        table, wxEVT_DATAVIEW_SELECTION_CHANGED);
+
     table->DeleteAllItems();
     rowUuids.clear();
     modelPaths.clear();
@@ -257,7 +263,7 @@ void TrussTablePanel::ReloadData()
     modelPathByKey.clear();
     symbolPathByKey.clear();
     nextRowKey = 1;
-    const auto& trusses = guiConfigServices->LegacyConfigManager().GetScene().trusses;
+    const auto& trusses = cfg.GetScene().trusses;
 
     std::vector<std::pair<std::string, const Truss*>> sorted;
     sorted.reserve(trusses.size());
@@ -285,7 +291,7 @@ void TrussTablePanel::ReloadData()
                                                             : wxString::FromUTF8(truss.layer);
         std::string displayPath;
         std::string symbolFullPath;
-        const std::string &base = guiConfigServices->LegacyConfigManager().GetScene().basePath;
+        const std::string &base = cfg.GetScene().basePath;
         if (!truss.modelFile.empty()) {
             fs::path p = base.empty() ? fs::path(truss.modelFile)
                                      : fs::path(base) / truss.modelFile;
@@ -359,6 +365,11 @@ void TrussTablePanel::ReloadData()
         modelPathByKey[rowKey] = modelFull;
         symbolPathByKey[rowKey] = wxString::FromUTF8(symbolFullPath);
     }
+
+    selectionBlocker.reset();
+    if (!selectedTrusses.empty())
+        SelectByUuid(selectedTrusses, false);
+    UpdateSelectionHighlight();
 
     // Let wxDataViewListCtrl manage column headers and sorting
     if (LayerPanel::Instance())


### PR DESCRIPTION
### Motivation
- Reloading the truss table rebuilds all rows and can transiently change the `wxDataView` selection, which should not push undo states or notify viewers.  
- Preventing transient selection events avoids spurious undo entries and unnecessary viewer updates during internal table reconstruction.  
- Keep code clarity by using the same `ConfigManager` reference for scene and selection reads during reload.  

### Description
- Capture the persisted selection at the start of `TrussTablePanel::ReloadData()` using `ConfigManager::GetSelectedTrusses()` and add a one-line comment above the function.  
- Block `wxEVT_DATAVIEW_SELECTION_CHANGED` for the duration of the destructive rebuild by creating a scoped `wxEventBlocker` and perform `DeleteAllItems`, cache clears, row append, and row-map rebuild inside that scope.  
- After rebuilding rows, restore the saved selection with `SelectByUuid(..., false)` and call `UpdateSelectionHighlight()` to update visuals without pushing undo or notifying viewers.  
- Use the local `cfg = guiConfigServices->LegacyConfigManager()` reference for scene access and update `docs/release-notes-draft.md` with an internal change note.  

### Testing
- Ran `git diff --check` and it reported no whitespace or diff-check issues.  
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both succeeded.  
- Attempted `cmake -S . -B build`, which failed in this environment due to missing `wxWidgets` libraries/includes and is not indicative of a logic regression in the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26dc401ee4832486ee26b2da312f96)