### PR TITLE
Fix command-bar thru separators for transform values

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -13,6 +13,7 @@ Changes since `v1.3.0`.
 
 ## Fixes
 
+- Fixed command-bar position and rotation value parsing so `t` and `thru` separators distribute selected items the same way as two space-separated values.
 - Fixed MVR Eurotruss rendering in the 3D viewport by preserving native 3DS SceneObject mesh dimensions, keeping repeated SceneObject Symbol children distinct per parent object, and preserving correct truss fallback sizing for rotated trusses.
 - Improved truss file validation so unsupported model formats are rejected clearly, while direct GLB and 3DS truss models now load only when the selected file exists.
 - Improved fallback dimensions for direct truss model files so GLB and 3DS trusses remain visible and selectable even when model metadata or mesh loading is unavailable.

--- a/docs/shortcuts-and-command-bar.md
+++ b/docs/shortcuts-and-command-bar.md
@@ -91,7 +91,7 @@ Selection syntax examples:
 Notes:
 
 - One value applies to all selected items.
-- Two values distribute linearly from start to end across selection.
+- Two values distribute linearly from start to end across selection; `t` and `thru` are accepted as optional range separators, so `pos x -7 t 7`, `pos x -7 thru 7`, and `pos x -7 7` are equivalent.
 - Use `++` / `--` for relative offsets (for example `pos x ++ 1.5`).
 - Group rotation pivot defaults to selection bounding-box center.
 - You can override pivot with a trailing `x,y,z` triplet, for example `rot y ++45 --g -2.5,0,0`.

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/addressdialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/columnselectiondialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/consolepanel.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/console_command_parser.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ui_feature_flags.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dictionaryeditdialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dictionary_selection_controls.cpp

--- a/gui/console_command_parser.cpp
+++ b/gui/console_command_parser.cpp
@@ -1,0 +1,90 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "console_command_parser.h"
+
+#include <algorithm>
+#include <charconv>
+#include <cctype>
+#include <sstream>
+
+namespace gui::console {
+namespace {
+
+// Trims ASCII whitespace from both sides of a console token string.
+std::string Trim(const std::string &text) {
+  const size_t start = text.find_first_not_of(" \t\n\r");
+  const size_t end = text.find_last_not_of(" \t\n\r");
+  if (start == std::string::npos)
+    return std::string();
+  return text.substr(start, end - start + 1);
+}
+
+// Converts a token to lowercase for case-insensitive command parsing.
+std::string ToLower(std::string token) {
+  std::transform(token.begin(), token.end(), token.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+  return token;
+}
+
+// Returns true when the token is a range separator in transform value lists.
+bool IsRangeSeparator(const std::string &token) {
+  const std::string lower = ToLower(token);
+  return lower == "t" || lower == "thru";
+}
+
+// Parses a floating-point token and requires the full token to be consumed.
+bool TryParseFloat(const std::string &token, float &value) {
+  const char *begin = token.data();
+  const char *end = token.data() + token.size();
+  const auto result = std::from_chars(begin, end, value);
+  return result.ec == std::errc{} && result.ptr == end;
+}
+
+} // namespace
+
+// Parses console position and rotation value lists, including optional range separators.
+std::vector<float> ParseTransformValues(const std::string &text,
+                                        bool &relative) {
+  relative = false;
+  std::string remaining = Trim(text);
+  float sign = 1.0f;
+  if (remaining.rfind("++", 0) == 0) {
+    relative = true;
+    remaining = Trim(remaining.substr(2));
+  } else if (remaining.rfind("--", 0) == 0) {
+    relative = true;
+    sign = -1.0f;
+    remaining = Trim(remaining.substr(2));
+  }
+
+  std::stringstream stream(remaining);
+  std::vector<float> values;
+  std::string token;
+  while (stream >> token) {
+    if (IsRangeSeparator(token))
+      continue;
+
+    float value = 0.0f;
+    if (!TryParseFloat(token, value))
+      break;
+    values.push_back(sign * value);
+  }
+  return values;
+}
+
+} // namespace gui::console

--- a/gui/console_command_parser.h
+++ b/gui/console_command_parser.h
@@ -1,0 +1,29 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace gui::console {
+
+// Parses console position and rotation value lists, including optional range separators.
+std::vector<float> ParseTransformValues(const std::string &text,
+                                        bool &relative);
+
+} // namespace gui::console

--- a/gui/consolepanel.cpp
+++ b/gui/consolepanel.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "consolepanel.h"
+#include "console_command_parser.h"
 #include "configmanager.h"
 #include "guiconfigservices.h"
 #include "fixturetablepanel.h"
@@ -505,6 +506,7 @@ NormalizeRangeTokens(const std::vector<std::string> &tokens) {
   return out;
 }
 
+// Parses and applies command-bar actions to the current scene selection.
 void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
   std::string cmd = std::string(cmdWx.ToUTF8());
   cmd = trim(cmd);
@@ -876,24 +878,8 @@ void ConsolePanel::ProcessCommand(const wxString &cmdWx) {
       }
     };
 
-    auto parseVals = [&](const std::string &s, bool &relative) {
-      relative = false;
-      std::string str = trim(s);
-      float sign = 1.0f;
-      if (str.rfind("++", 0) == 0) {
-        relative = true;
-        str = trim(str.substr(2));
-      } else if (str.rfind("--", 0) == 0) {
-        relative = true;
-        sign = -1.0f;
-        str = trim(str.substr(2));
-      }
-      std::stringstream ss(str);
-      std::vector<float> vals;
-      float v;
-      while (ss >> v)
-        vals.push_back(sign * v);
-      return vals;
+    auto parseVals = [](const std::string &s, bool &relative) {
+      return gui::console::ParseTransformValues(s, relative);
     };
 
     auto refreshSelectionAfterTransform = [&]() {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -127,6 +127,12 @@ add_executable(mainwindow_cli_shortcut_router_test
 target_include_directories(mainwindow_cli_shortcut_router_test PRIVATE .. ../gui)
 add_test(NAME MainWindowCliShortcutRouter COMMAND mainwindow_cli_shortcut_router_test)
 
+add_executable(console_command_parser_test
+               console_command_parser_test.cpp
+               ../gui/console_command_parser.cpp)
+target_include_directories(console_command_parser_test PRIVATE .. ../gui)
+add_test(NAME ConsoleCommandParser COMMAND console_command_parser_test)
+
 add_executable(editable_focus_utils_test
                editable_focus_utils_test.cpp
                ../gui/editable_focus_utils.cpp)

--- a/tests/console_command_parser_test.cpp
+++ b/tests/console_command_parser_test.cpp
@@ -1,0 +1,47 @@
+#include "console_command_parser.h"
+
+#include <cassert>
+#include <cmath>
+#include <vector>
+
+namespace {
+
+// Compares two float vectors with a small tolerance for parser regression tests.
+bool EqualValues(const std::vector<float> &actual,
+                 const std::vector<float> &expected) {
+  if (actual.size() != expected.size())
+    return false;
+  for (size_t i = 0; i < actual.size(); ++i) {
+    if (std::fabs(actual[i] - expected[i]) > 0.0001f)
+      return false;
+  }
+  return true;
+}
+
+} // namespace
+
+// Verifies transform value parsing accepts whitespace and thru-style separators.
+int main() {
+  bool relative = false;
+  auto values = gui::console::ParseTransformValues("-7 7", relative);
+  assert(!relative);
+  assert(EqualValues(values, {-7.0f, 7.0f}));
+
+  values = gui::console::ParseTransformValues("-7 t 7", relative);
+  assert(!relative);
+  assert(EqualValues(values, {-7.0f, 7.0f}));
+
+  values = gui::console::ParseTransformValues("-7 thru 7", relative);
+  assert(!relative);
+  assert(EqualValues(values, {-7.0f, 7.0f}));
+
+  values = gui::console::ParseTransformValues("++ 1.5 t 3.5", relative);
+  assert(relative);
+  assert(EqualValues(values, {1.5f, 3.5f}));
+
+  values = gui::console::ParseTransformValues("-- 1.5 thru 3.5", relative);
+  assert(relative);
+  assert(EqualValues(values, {-1.5f, -3.5f}));
+
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- The console `pos`/`rot` transform commands treated `t`/`thru` differently than a plain space, causing inputs like `pos x -7 t 7` to place all elements at `-7` instead of distributing between `-7` and `7`.
- Provide a focused, robust parser for transform value lists so the same distribution behavior works for space-separated values and `t`/`thru` separators.

### Description
- Added a small parser module `gui/console_command_parser.{h,cpp}` that implements `gui::console::ParseTransformValues(...)` and accepts `t` and `thru` as optional range separators, preserves `++`/`--` relative prefixes, and requires full-token float parsing. 
- Wired `ConsolePanel::ProcessCommand` to call the shared parser (`ParseTransformValues`) instead of duplicating parsing logic, and added a one-line comment above `ProcessCommand` for clarity. 
- Registered the new source in `gui/CMakeLists.txt` and added a focused unit test `tests/console_command_parser_test.cpp` with a test target entry in `tests/CMakeLists.txt`. 
- Updated user documentation `docs/shortcuts-and-command-bar.md` to state that `t` and `thru` are accepted separators and added an entry to `docs/release-notes-draft.md` describing the user-visible fix.

### Testing
- Built and ran the focused parser unit test: `g++ -std=c++20 -Igui tests/console_command_parser_test.cpp gui/console_command_parser.cpp` and executed the binary; the test passed (regression checks for `-7 7`, `-7 t 7`, `-7 thru 7`, `++`/`--` behavior). 
- Ran repository checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both returned OK. 
- Attempted full CMake configure/build for tests but the environment lacked wxWidgets discovery (`wxWidgets_LIBRARIES` / `wxWidgets_INCLUDE_DIRS`), so a full CTest run could not be completed in this environment; this is an environment limitation and not a regression in the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27bb53459c83248f2c9740f79cde94)