### PR TITLE
Fix fixture ID persistence in MVR export

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -13,8 +13,10 @@ Changes since `v1.3.0`.
 ## Improvements
 
 - Improved GroupObject handling so selecting a grouped member highlights and transforms the full root group, including nested groups, in 2D, 3D, and command-bar transform workflows.
+
 ## Fixes
 
+- Fixed fixture ID edits so saved project files and exported MVR files keep the updated numeric fixture IDs instead of reverting to imported IDs.
 - Fixed command-bar position and rotation value parsing so `t` and `thru` separators distribute selected items the same way as two space-separated values.
 - Fixed MVR Eurotruss rendering in the 3D viewport by preserving native 3DS SceneObject mesh dimensions, keeping repeated SceneObject Symbol children distinct per parent object, and preserving correct truss fallback sizing for rotated trusses.
 - Improved truss file validation so unsupported model formats are rejected clearly, while direct GLB and 3DS truss models now load only when the selected file exists.

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -83,6 +83,11 @@ struct ThreeDsChunkHeader {
   uint32_t length = 0;
 };
 
+struct FixtureExportId {
+  std::string text;
+  int numeric = 0;
+};
+
 static bool TryParseInt(std::string_view text, int &out);
 static bool ParseMvrAddressNodeText(const std::string &text, int &universeOut,
                                     int &channelOut);
@@ -90,6 +95,7 @@ static bool TryComputeAbsoluteDmx(int universe1Based, int address1Based,
                                   int &absoluteOut);
 static std::string TrimAscii(std::string value);
 static std::string ToLowerAscii(std::string value);
+static FixtureExportId ResolveFixtureExportId(const Fixture &fixture);
 
 static bool ShouldExportSupportHoistInfo(const Support &support);
 static tinyxml2::XMLElement *FindFirstPerastageUserData(tinyxml2::XMLElement *node);
@@ -105,6 +111,22 @@ static constexpr const char *kMvrProvider = "Perastage";
 static constexpr const char *kMvrProviderVersion = "1.0";
 static constexpr const char *kDummyFallbackFixtureGdtfFileName = "Dummy 1ch.gdtf";
 static constexpr const char *kLegacyFallbackFixtureGdtfFileName = "Generic 1ch.gdtf";
+
+// Resolves the MVR FixtureID values from the current editable fixture ID.
+static FixtureExportId ResolveFixtureExportId(const Fixture &fixture) {
+  FixtureExportId id;
+  id.numeric = fixture.fixtureId > 0 ? fixture.fixtureId : fixture.fixtureIdNumeric;
+  if (id.numeric <= 0)
+    id.numeric = 0;
+
+  const bool importedNumericStillMatches =
+      fixture.fixtureIdNumeric > 0 && fixture.fixtureId == fixture.fixtureIdNumeric;
+  if (importedNumericStillMatches)
+    id.text = TrimAscii(fixture.fixtureIdText);
+  if (id.text.empty() && id.numeric > 0)
+    id.text = std::to_string(id.numeric);
+  return id;
+}
 
 static bool Read3dsChunkHeader(std::ifstream &file, ThreeDsChunkHeader &chunk) {
   if (!file.read(reinterpret_cast<char *>(&chunk.id), sizeof(chunk.id)))
@@ -1612,8 +1634,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
         usedIds.insert(candidate);
     };
     for (const auto &[uid, f] : scene.fixtures) {
-      int existing = f.fixtureIdNumeric > 0 ? f.fixtureIdNumeric : f.fixtureId;
-      reserveId(existing);
+      reserveId(ResolveFixtureExportId(f).numeric);
     }
 
     auto allocId = [&]() {
@@ -1625,14 +1646,12 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
 
     std::unordered_map<std::string, std::pair<std::string, int>> result;
     for (const auto &[uid, f] : scene.fixtures) {
-      int numeric = f.fixtureIdNumeric > 0 ? f.fixtureIdNumeric : f.fixtureId;
-      if (numeric <= 0) {
-        numeric = allocId();
+      FixtureExportId fixtureId = ResolveFixtureExportId(f);
+      if (fixtureId.numeric <= 0) {
+        fixtureId.numeric = allocId();
+        fixtureId.text = std::to_string(fixtureId.numeric);
       }
-      std::string stringId = TrimAscii(f.fixtureIdText);
-      if (stringId.empty())
-        stringId = std::to_string(numeric);
-      result[uid] = {stringId, numeric};
+      result[uid] = {fixtureId.text, fixtureId.numeric};
     }
 
     for (const auto &[uid, t] : scene.trusses) {
@@ -1808,17 +1827,18 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
     };
 
     auto idIt = assignedIds.find(f.uuid);
-    int fixtureNumericId = f.fixtureIdNumeric > 0 ? f.fixtureIdNumeric : f.fixtureId;
-    if (fixtureNumericId <= 0 && idIt != assignedIds.end())
-      fixtureNumericId = idIt->second.second;
-    if (fixtureNumericId <= 0)
-      fixtureNumericId = 1;
-    std::string fixtureId = TrimAscii(f.fixtureIdText);
-    if (fixtureId.empty())
-      fixtureId = std::to_string(fixtureNumericId);
-    addStr("FixtureID", fixtureId);
-    addInt("FixtureIDNumeric", fixtureNumericId);
-    if (f.unitNumber != 0 && f.unitNumber != fixtureNumericId)
+    FixtureExportId fixtureExportId = ResolveFixtureExportId(f);
+    if (fixtureExportId.numeric <= 0 && idIt != assignedIds.end())
+      fixtureExportId = {idIt->second.first, idIt->second.second};
+    if (fixtureExportId.numeric <= 0) {
+      fixtureExportId.numeric = 1;
+      fixtureExportId.text = "1";
+    }
+    if (fixtureExportId.text.empty())
+      fixtureExportId.text = std::to_string(fixtureExportId.numeric);
+    addStr("FixtureID", fixtureExportId.text);
+    addInt("FixtureIDNumeric", fixtureExportId.numeric);
+    if (f.unitNumber != 0 && f.unitNumber != fixtureExportId.numeric)
       addInt("UnitNumber", f.unitNumber);
     addInt("CustomId", f.customId);
     addInt("CustomIdType", f.customIdType);

--- a/tests/mvr_exporter_compliance_test.cpp
+++ b/tests/mvr_exporter_compliance_test.cpp
@@ -211,6 +211,16 @@ int main() {
   fLongDup.address = "8.1";
   scene.fixtures[fLongDup.uuid] = fLongDup;
 
+  Fixture fEditedId;
+  fEditedId.uuid = "fx-edited-id";
+  fEditedId.instanceName = "Edited ID Fixture";
+  fEditedId.gdtfSpec = (tempDir / "A" / "Same.gdtf").generic_string();
+  fEditedId.fixtureIdText = "Old imported ID";
+  fEditedId.fixtureIdNumeric = 12;
+  fEditedId.fixtureId = 909;
+  fEditedId.address = "9.1";
+  scene.fixtures[fEditedId.uuid] = fEditedId;
+
   Truss tr;
   tr.uuid = "tr-1";
   tr.name = "Main Truss";
@@ -320,6 +330,8 @@ int main() {
   bool sawAddress2681 = false;
   bool sawAddress3073 = false;
   bool sawAddress3585 = false;
+  bool sawAddress4097 = false;
+  bool sawEditedFixtureId = false;
   bool sawNonNumericTrussNameFixtureIdConsistency = false;
   bool sawPrimitiveSphereWithIdentityGeometryMatrix = false;
   bool sawPrimitivePipeObjectMatrixUnbaked = false;
@@ -359,6 +371,12 @@ int main() {
             std::string fixtureUuid = uuidAttr;
             std::string fixtureNodeName = nameAttr;
             assert(fixtureNodeName == "Fixture_" + fixtureUuid);
+
+            if (fixtureUuid == fEditedId.uuid) {
+              assert(fixtureIdText == "909");
+              assert(value == 909);
+              sawEditedFixtureId = true;
+            }
 
             auto *unitNode = cur->FirstChildElement("UnitNumber");
             if (unitNode) {
@@ -404,6 +422,8 @@ int main() {
               sawAddress3073 = true;
             if (absoluteAddress == ComputeAbsoluteDmx(8, 1))
               sawAddress3585 = true;
+            if (absoluteAddress == ComputeAbsoluteDmx(9, 1))
+              sawAddress4097 = true;
             ++fixtureAddressCount;
           }
 
@@ -539,12 +559,14 @@ int main() {
   }
 
   assert(gdtfCount.size() >= 2);
-  assert(fixtureAddressCount == 5);
+  assert(fixtureAddressCount == 6);
   assert(sawAddress1);
   assert(sawAddress1025);
   assert(sawAddress2681);
   assert(sawAddress3073);
   assert(sawAddress3585);
+  assert(sawAddress4097);
+  assert(sawEditedFixtureId);
   assert(sawNonNumericTrussNameFixtureIdConsistency);
   assert(sawPrimitiveSphereWithIdentityGeometryMatrix);
   assert(sawPrimitivePipeObjectMatrixUnbaked);

--- a/tests/save_load_roundtrip_test.cpp
+++ b/tests/save_load_roundtrip_test.cpp
@@ -92,6 +92,7 @@ int main() {
     Fixture f2; f2.uuid = "fx2"; f2.instanceName = "Fixture 2"; f2.layer = layer.name; f2.typeName = "FixtureType"; f2.gdtfSpec = "orig.gdtf"; f2.fixtureIdText = "S101B"; f2.fixtureIdNumeric = 101; f2.fixtureId = 101; scene.fixtures[f2.uuid] = f2;
     const std::string nonCanonicalFixtureUuid = "A0B1C2D3-E4F5-4678-9ABC-DEF012345678";
     Fixture f3; f3.uuid = nonCanonicalFixtureUuid; f3.instanceName = "Fixture 3"; f3.layer = layer.name; f3.typeName = "FixtureType"; f3.gdtfSpec = "orig.gdtf"; f3.fixtureIdText = "S101C"; f3.fixtureIdNumeric = 101; f3.fixtureId = 101; scene.fixtures[f3.uuid] = f3;
+    Fixture f4; f4.uuid = "fx-edited-id"; f4.instanceName = "Edited ID Fixture"; f4.layer = layer.name; f4.typeName = "FixtureType"; f4.gdtfSpec = "orig.gdtf"; f4.fixtureIdText = "Imported ID"; f4.fixtureIdNumeric = 44; f4.fixtureId = 707; scene.fixtures[f4.uuid] = f4;
     viewer2d::ApplyShowLabelNameOverride(cfg, {nonCanonicalFixtureUuid}, 0, true);
     Truss t; t.uuid = "tr1"; t.name = "Truss"; t.layer = layer.name; scene.trusses[t.uuid] = t;
     SceneObject o; o.uuid = "obj1"; o.name = "Object"; o.layer = layer.name; scene.sceneObjects[o.uuid] = o;
@@ -136,7 +137,7 @@ int main() {
     assert(cfg.LoadProject(temp.string()));
 
     const auto &scene2 = cfg.GetScene();
-    assert(scene2.fixtures.size() == 3);
+    assert(scene2.fixtures.size() == 4);
     assert(scene2.trusses.size() == 1);
     assert(scene2.sceneObjects.size() == 3);
     assert(scene2.supports.size() == 2);
@@ -157,6 +158,9 @@ int main() {
     assert(scene2.fixtures.at("fx1").fixtureIdNumeric == 101);
     assert(scene2.fixtures.at("fx2").fixtureIdText == "S101B");
     assert(scene2.fixtures.at("fx2").fixtureIdNumeric == 101);
+    assert(scene2.fixtures.at("fx-edited-id").fixtureId == 707);
+    assert(scene2.fixtures.at("fx-edited-id").fixtureIdNumeric == 707);
+    assert(scene2.fixtures.at("fx-edited-id").fixtureIdText == "707");
     const std::string canonicalFixtureUuid = CanonicalizeUuid(nonCanonicalFixtureUuid);
     assert(!canonicalFixtureUuid.empty());
     assert(scene2.fixtures.count(canonicalFixtureUuid) == 1);


### PR DESCRIPTION
### Motivation
- Edited fixture numeric IDs could be lost when saving projects or exporting MVR because the exporter preferred imported metadata instead of the current editable ID state.
- Ensure exported .mvr and saved project files reflect user edits to fixture IDs while preserving imported free-form FixtureID text only when it still matches the numeric ID.

### Description
- Added a small helper `FixtureExportId` and `ResolveFixtureExportId(const Fixture &)` to derive the authoritative `FixtureID`/`FixtureIDNumeric` from the current editable fixture state and imported metadata.
- Wired the resolver into the exporter ID reservation/allocation logic and per-fixture XML serialization so assigned/serialized IDs use the resolved values instead of blindly using imported fields.
- Updated two regression tests (`tests/mvr_exporter_compliance_test.cpp` and `tests/save_load_roundtrip_test.cpp`) to cover edited fixture-ID export and project save/load round-trips, and added a release-note entry in `docs/release-notes-draft.md`.

### Testing
- `tests/check_perastage_tree_modules.sh` — passed.
- `tests/check_no_configmanager_get_in_gui.sh` — passed.
- `git diff --check` — passed (no whitespace or diff-check issues).
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON` — configuration failed in this environment due to missing wxWidgets development files (`wxWidgets_LIBRARIES` / `wxWidgets_INCLUDE_DIRS`), so full test build/run was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ad6cb8cbc832486705071bd8bd0e6)