### PR TITLE
Fix MVR fixture color semantics

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -16,6 +16,7 @@ Changes since `v1.3.0`.
 
 ## Fixes
 
+- Fixed MVR fixture Color handling so visualization colors are no longer exported as gel/filter colors, while imported MVR Color values are preserved as fixture gel/filter data.
 - Restored edge-safe fixture visibility and made fixture hover picking use actual fixture geometry so highlights and labels target the visible fixture instead of broad bounds.
 - Fixed fixture ID edits so saved project files and exported MVR files keep the updated numeric fixture IDs instead of reverting to imported IDs.
 - Fixed command-bar position and rotation value parsing so `t` and `thru` separators distribute selected items the same way as two space-separated values.

--- a/models/fixture.h
+++ b/models/fixture.h
@@ -41,7 +41,8 @@ struct Fixture {
     bool hasLocalTransform = false; // True when localTransform was explicitly assigned
     std::string parentGroupUuid;    // Parent GroupObject UUID when grouped
 
-    std::string color;            // Hex RGB color (e.g., "#RRGGBB")
+    std::string color;            // Hex RGB visualization color (e.g., "#RRGGBB")
+    std::string gelColor;         // Optional physical gel/filter color exported as MVR Color
 
     std::string fixtureIdText;    // FixtureID (free-form string identifier from XML)
     int fixtureId = 0;            // Numeric FixtureID fallback used internally
@@ -60,6 +61,6 @@ struct Fixture {
     std::string categorySource;   // Category source (Manual, AutoFallback, ...)
     std::string categorySourceReason; // Why category fallback was applied
 
-    // Convenience method to access translation as array
+    // Returns the fixture translation as an array.
     std::array<float,3> GetPosition() const { return transform.o; }
 };

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -1881,8 +1881,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
     addNum("PowerConsumption", f.powerConsumptionW, "W");
     addNum("Weight", f.weightKg, "kg");
 
-    if (!f.color.empty() && f.color.size() == 7 && f.color[0] == '#') {
-      std::string cie = HexToCie(f.color);
+    if (!f.gelColor.empty() && f.gelColor.size() == 7 && f.gelColor[0] == '#') {
+      std::string cie = HexToCie(f.gelColor);
       tinyxml2::XMLElement *col = doc.NewElement("Color");
       col->SetText(cie.c_str());
       fe->InsertEndChild(col);

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -1981,7 +1981,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         if (tinyxml2::XMLElement *colorNode =
                 node->FirstChildElement("Color")) {
           if (const char *txt = colorNode->GetText())
-            fixture.color = CieToHex(txt);
+            fixture.gelColor = CieToHex(txt);
         }
         if (tinyxml2::XMLElement *pcNode =
                 node->FirstChildElement("PowerConsumption")) {

--- a/tests/mvr_exporter_compliance_test.cpp
+++ b/tests/mvr_exporter_compliance_test.cpp
@@ -188,6 +188,7 @@ int main() {
   f2.fixtureIdNumeric = 0;
   f2.unitNumber = 0;
   f2.address = "3.1";
+  f2.color = "#445566";
   scene.fixtures[f2.uuid] = f2;
 
   Fixture f3;
@@ -195,6 +196,7 @@ int main() {
   f3.instanceName = "Floor Wash";
   f3.gdtfSpec = (tempDir / "A" / "Same.gdtf").generic_string();
   f3.address = "6.121";
+  f3.gelColor = "#00FF00";
   scene.fixtures[f3.uuid] = f3;
 
   Fixture fLong;
@@ -332,6 +334,8 @@ int main() {
   bool sawAddress3585 = false;
   bool sawAddress4097 = false;
   bool sawEditedFixtureId = false;
+  bool sawFixtureVisualizationColorWithoutMvrColor = false;
+  bool sawFixtureGelColor = false;
   bool sawNonNumericTrussNameFixtureIdConsistency = false;
   bool sawPrimitiveSphereWithIdentityGeometryMatrix = false;
   bool sawPrimitivePipeObjectMatrixUnbaked = false;
@@ -371,6 +375,18 @@ int main() {
             std::string fixtureUuid = uuidAttr;
             std::string fixtureNodeName = nameAttr;
             assert(fixtureNodeName == "Fixture_" + fixtureUuid);
+
+            auto *colorNode = cur->FirstChildElement("Color");
+            if (fixtureUuid == f2.uuid) {
+              assert(colorNode == nullptr);
+              sawFixtureVisualizationColorWithoutMvrColor = true;
+            }
+            if (fixtureUuid == f3.uuid) {
+              assert(colorNode != nullptr);
+              assert(colorNode->GetText() != nullptr);
+              assert(std::string(colorNode->GetText()) == "0.300000,0.600000,0.715200");
+              sawFixtureGelColor = true;
+            }
 
             if (fixtureUuid == fEditedId.uuid) {
               assert(fixtureIdText == "909");
@@ -567,6 +583,8 @@ int main() {
   assert(sawAddress3585);
   assert(sawAddress4097);
   assert(sawEditedFixtureId);
+  assert(sawFixtureVisualizationColorWithoutMvrColor);
+  assert(sawFixtureGelColor);
   assert(sawNonNumericTrussNameFixtureIdConsistency);
   assert(sawPrimitiveSphereWithIdentityGeometryMatrix);
   assert(sawPrimitivePipeObjectMatrixUnbaked);
@@ -777,6 +795,8 @@ int main() {
   assert(legacyFixture.position != "LX1");
   assert(CanonicalizeUuid(legacyFixture.position) == legacyFixture.position);
   assert(importedScene.positions.count(legacyFixture.position) == 1);
+  assert(legacyFixture.color.empty());
+  assert(!legacyFixture.gelColor.empty());
 
   fs::remove_all(tempDir);
   return 0;

--- a/viewer3d/render/fixture_mesh_color.h
+++ b/viewer3d/render/fixture_mesh_color.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <array>
+
+namespace viewer3d::render {
+
+// Internal rendering fallback for fixture meshes with no material or GDTF model color; never serialize this as MVR Fixture Color.
+inline constexpr std::array<float, 3> DEFAULT_MESH_COLOR{1.0f, 1.0f, 1.0f};
+
+} // namespace viewer3d::render

--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -37,6 +37,7 @@
 #include "symbols/PerastageSvgSymbol.h"
 #include "viewer3dcontroller.h"
 #include "gdtfloader.h"
+#include "fixture_mesh_color.h"
 #include <meshoptimizer.h>
 
 namespace {
@@ -765,7 +766,9 @@ void OpaqueFixturePass::Render(
         gdtfPathIt->second.attempted)
       gdtfPath = gdtfPathIt->second.resolvedPath;
 
-    float r = 1.0f, g = 1.0f, b = 1.0f;
+    float r = viewer3d::render::DEFAULT_MESH_COLOR[0];
+    float g = viewer3d::render::DEFAULT_MESH_COLOR[1];
+    float b = viewer3d::render::DEFAULT_MESH_COLOR[2];
     if (context.whiteModelStyle && !wireframe) {
       r = 0.95f;
       g = 0.95f;


### PR DESCRIPTION
### Motivation

- Prevent exporting Perastage internal 3D visualization colors as MVR `<Color>` gel/filter values to remain compatible with the MVR spec and grandMA3 semantics.
- Keep existing 3D visualization behavior (mesh tint fallback) but separate it from MVR serialization so exports/imports are semantically correct.
- Make the change small and focused around MVR import/export and the 3D rendering fallback, and update tests and release notes accordingly.

### Description

- Added an explicit optional per-fixture `gelColor` field in `Fixture` (`models/fixture.h`) and clarified `color` as the visualization color only.
- Export now writes the MVR `<Color>` node only when `gelColor` is set; exporter uses `gelColor` and no longer serializes the visualization `color` (`mvr/mvrexporter.cpp`).
- Import now reads MVR `<Color>` into `gelColor` and leaves the visualization `color` unchanged (`mvr/mvrimporter.cpp`).
- Centralized the internal mesh fallback visualization color as `viewer3d::render::DEFAULT_MESH_COLOR` in a single header (`viewer3d/render/fixture_mesh_color.h`) and wired the 3D renderer to use it (`viewer3d/render/opaque_fixture_pass.cpp`); this value is documented as rendering-only and must not be serialized.
- Extended `tests/mvr_exporter_compliance_test.cpp` to assert that fixtures with only visualization `color` do not produce a `<Color>` node, that `gelColor` exports to the expected CIE value, and that imported `<Color>` populates `gelColor` without modifying the visualization color.
- Updated `docs/release-notes-draft.md` with a concise note about the MVR color handling fix.
- Note: changes are localized and small, so extraction of new modules was not required for this PR; if a later split is desired, move MVR related helpers from `mvrexporter.cpp` into a dedicated `mvr/` helper file.

### Testing

- Ran `tests/check_perastage_tree_modules.sh` and it passed (OK).
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed (OK).
- Updated and added assertions in `tests/mvr_exporter_compliance_test.cpp` to cover the new import/export semantics, but building/running the test inside this container failed to configure due to missing wxWidgets development libraries when attempting `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug && cmake --build build --target mvr_exporter_compliance_test -j2` (wxWidgets not available in the environment).
- Performed quick static checks: `rg` search for `DEFAULT_MESH_COLOR` and `git diff --check` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2cf80a6f248324b759473b6ce73ebe)