### PR TITLE
Add group-hover highlights in 3D viewer

### DIFF
--- a/core/scene_grouping.cpp
+++ b/core/scene_grouping.cpp
@@ -44,7 +44,8 @@ float Determinant3x3(const Matrix &m) {
          m.w[0] * (m.u[1] * m.v[2] - m.v[1] * m.u[2]);
 }
 
-// Builds the inverse transform used to preserve world placement during reparenting.
+// Builds the inverse transform used to preserve world placement during
+// reparenting.
 Matrix InverseMatrix(const Matrix &m) {
   const float det = Determinant3x3(m);
   if (std::fabs(det) < 1e-8f)
@@ -56,19 +57,15 @@ Matrix InverseMatrix(const Matrix &m) {
   const float a20 = m.u[2], a21 = m.v[2], a22 = m.w[2];
 
   Matrix inv;
-  inv.u = { (a11 * a22 - a12 * a21) * invDet,
-            (a12 * a20 - a10 * a22) * invDet,
-            (a10 * a21 - a11 * a20) * invDet };
-  inv.v = { (a02 * a21 - a01 * a22) * invDet,
-            (a00 * a22 - a02 * a20) * invDet,
-            (a01 * a20 - a00 * a21) * invDet };
-  inv.w = { (a01 * a12 - a02 * a11) * invDet,
-            (a02 * a10 - a00 * a12) * invDet,
-            (a00 * a11 - a01 * a10) * invDet };
+  inv.u = {(a11 * a22 - a12 * a21) * invDet, (a12 * a20 - a10 * a22) * invDet,
+           (a10 * a21 - a11 * a20) * invDet};
+  inv.v = {(a02 * a21 - a01 * a22) * invDet, (a00 * a22 - a02 * a20) * invDet,
+           (a01 * a20 - a00 * a21) * invDet};
+  inv.w = {(a01 * a12 - a02 * a11) * invDet, (a02 * a10 - a00 * a12) * invDet,
+           (a00 * a11 - a01 * a10) * invDet};
 
   for (int i = 0; i < 3; ++i) {
-    inv.o[i] = -(inv.u[i] * m.o[0] + inv.v[i] * m.o[1] +
-                 inv.w[i] * m.o[2]);
+    inv.o[i] = -(inv.u[i] * m.o[0] + inv.v[i] * m.o[1] + inv.w[i] * m.o[2]);
   }
   return inv;
 }
@@ -118,19 +115,23 @@ std::string ParentGroupUuidFor(const MvrScene &scene, const MvrNodeType type,
   switch (type) {
   case MvrNodeType::Fixture: {
     auto it = scene.fixtures.find(uuid);
-    return it == scene.fixtures.end() ? std::string{} : it->second.parentGroupUuid;
+    return it == scene.fixtures.end() ? std::string{}
+                                      : it->second.parentGroupUuid;
   }
   case MvrNodeType::Truss: {
     auto it = scene.trusses.find(uuid);
-    return it == scene.trusses.end() ? std::string{} : it->second.parentGroupUuid;
+    return it == scene.trusses.end() ? std::string{}
+                                     : it->second.parentGroupUuid;
   }
   case MvrNodeType::Support: {
     auto it = scene.supports.find(uuid);
-    return it == scene.supports.end() ? std::string{} : it->second.parentGroupUuid;
+    return it == scene.supports.end() ? std::string{}
+                                      : it->second.parentGroupUuid;
   }
   case MvrNodeType::SceneObject: {
     auto it = scene.sceneObjects.find(uuid);
-    return it == scene.sceneObjects.end() ? std::string{} : it->second.parentGroupUuid;
+    return it == scene.sceneObjects.end() ? std::string{}
+                                          : it->second.parentGroupUuid;
   }
   case MvrNodeType::GroupObject:
     break;
@@ -139,8 +140,9 @@ std::string ParentGroupUuidFor(const MvrScene &scene, const MvrNodeType type,
 }
 
 // Adds existing selected objects to a normalized reference list.
-std::vector<SelectedObjectRef> CollectSelectedObjects(
-    const MvrScene &scene, const ObjectSelection &selection) {
+std::vector<SelectedObjectRef>
+CollectSelectedObjects(const MvrScene &scene,
+                       const ObjectSelection &selection) {
   std::vector<SelectedObjectRef> refs;
   std::set<std::pair<MvrNodeType, std::string>> seen;
 
@@ -150,8 +152,8 @@ std::vector<SelectedObjectRef> CollectSelectedObjects(
       auto it = table.find(uuid);
       if (it == table.end() || !seen.insert({type, uuid}).second)
         continue;
-      refs.push_back({type, uuid, it->second.layer,
-                      it->second.parentGroupUuid, it->second.transform});
+      refs.push_back({type, uuid, it->second.layer, it->second.parentGroupUuid,
+                      it->second.transform});
     }
   };
 
@@ -178,7 +180,8 @@ Matrix BuildGroupWorldTransform(const std::vector<SelectedObjectRef> &objects) {
 }
 
 // Returns a common direct parent if every selected object has the same one.
-std::string CommonParentGroupUuid(const std::vector<SelectedObjectRef> &objects) {
+std::string
+CommonParentGroupUuid(const std::vector<SelectedObjectRef> &objects) {
   if (objects.empty())
     return {};
   const std::string parent = objects.front().parentGroupUuid;
@@ -190,7 +193,8 @@ std::string CommonParentGroupUuid(const std::vector<SelectedObjectRef> &objects)
 }
 
 // Updates an object's parent group and local transform fields.
-void ApplyParentAndLocalTransform(MvrScene &scene, const SelectedObjectRef &object,
+void ApplyParentAndLocalTransform(MvrScene &scene,
+                                  const SelectedObjectRef &object,
                                   const std::string &parentGroupUuid,
                                   const Matrix &localTransform) {
   switch (object.type) {
@@ -241,12 +245,14 @@ void ApplyParentAndLocalTransform(MvrScene &scene, const SelectedObjectRef &obje
   }
 }
 
-// Adds an affected child UUID to the operation result for selection restoration.
+// Adds an affected child UUID to the operation result for selection
+// restoration.
 void AppendAffected(OperationResult &result, const MvrNodeType type,
                     const std::string &uuid) {
   switch (type) {
   case MvrNodeType::Fixture:
-    if (std::find(result.affectedFixtures.begin(), result.affectedFixtures.end(),
+    if (std::find(result.affectedFixtures.begin(),
+                  result.affectedFixtures.end(),
                   uuid) == result.affectedFixtures.end())
       result.affectedFixtures.push_back(uuid);
     break;
@@ -256,14 +262,15 @@ void AppendAffected(OperationResult &result, const MvrNodeType type,
       result.affectedTrusses.push_back(uuid);
     break;
   case MvrNodeType::Support:
-    if (std::find(result.affectedSupports.begin(), result.affectedSupports.end(),
+    if (std::find(result.affectedSupports.begin(),
+                  result.affectedSupports.end(),
                   uuid) == result.affectedSupports.end())
       result.affectedSupports.push_back(uuid);
     break;
   case MvrNodeType::SceneObject:
     if (std::find(result.affectedSceneObjects.begin(),
-                  result.affectedSceneObjects.end(), uuid) ==
-        result.affectedSceneObjects.end())
+                  result.affectedSceneObjects.end(),
+                  uuid) == result.affectedSceneObjects.end())
       result.affectedSceneObjects.push_back(uuid);
     break;
   case MvrNodeType::GroupObject:
@@ -271,8 +278,8 @@ void AppendAffected(OperationResult &result, const MvrNodeType type,
   }
 }
 
-
-// Multiplies a matrix point by the transform without applying translation scale changes.
+// Multiplies a matrix point by the transform without applying translation scale
+// changes.
 std::array<float, 3> TransformPoint(const Matrix &m,
                                     const std::array<float, 3> &point) {
   return {m.u[0] * point[0] + m.v[0] * point[1] + m.w[0] * point[2] + m.o[0],
@@ -285,7 +292,8 @@ std::string ParentGroupUuidForTarget(const MvrScene &scene,
                                      const SceneTransformTarget &target) {
   if (target.type == MvrNodeType::GroupObject) {
     auto it = scene.groupObjects.find(target.uuid);
-    return it == scene.groupObjects.end() ? std::string{} : it->second.parentGroupUuid;
+    return it == scene.groupObjects.end() ? std::string{}
+                                          : it->second.parentGroupUuid;
   }
   return ParentGroupUuidFor(scene, target.type, target.uuid);
 }
@@ -318,8 +326,8 @@ void UpdateLocalTransformForTarget(MvrScene &scene,
   if (!parentUuid.empty()) {
     auto parentIt = scene.groupObjects.find(parentUuid);
     if (parentIt != scene.groupObjects.end())
-      localTransform = MatrixUtils::Multiply(InverseMatrix(parentIt->second.transform),
-                                             worldTransform);
+      localTransform = MatrixUtils::Multiply(
+          InverseMatrix(parentIt->second.transform), worldTransform);
   }
 
   switch (target.type) {
@@ -378,46 +386,47 @@ void SynchronizeGroupChildrenWorldTransforms(MvrScene &scene,
       auto childIt = scene.groupObjects.find(child.uuid);
       if (childIt == scene.groupObjects.end())
         continue;
-      childIt->second.transform = MatrixUtils::Multiply(group.transform,
-                                                        childIt->second.localTransform);
+      childIt->second.transform = MatrixUtils::Multiply(
+          group.transform, childIt->second.localTransform);
       SynchronizeGroupChildrenWorldTransforms(scene, childIt->second);
     } else if (child.type == MvrNodeType::Fixture) {
       auto it = scene.fixtures.find(child.uuid);
       if (it != scene.fixtures.end())
-        it->second.transform = MatrixUtils::Multiply(group.transform,
-                                                     it->second.localTransform);
+        it->second.transform =
+            MatrixUtils::Multiply(group.transform, it->second.localTransform);
     } else if (child.type == MvrNodeType::Truss) {
       auto it = scene.trusses.find(child.uuid);
       if (it != scene.trusses.end())
-        it->second.transform = MatrixUtils::Multiply(group.transform,
-                                                     it->second.localTransform);
+        it->second.transform =
+            MatrixUtils::Multiply(group.transform, it->second.localTransform);
     } else if (child.type == MvrNodeType::Support) {
       auto it = scene.supports.find(child.uuid);
       if (it != scene.supports.end())
-        it->second.transform = MatrixUtils::Multiply(group.transform,
-                                                     it->second.localTransform);
+        it->second.transform =
+            MatrixUtils::Multiply(group.transform, it->second.localTransform);
     } else if (child.type == MvrNodeType::SceneObject) {
       auto it = scene.sceneObjects.find(child.uuid);
       if (it != scene.sceneObjects.end())
-        it->second.transform = MatrixUtils::Multiply(group.transform,
-                                                     it->second.localTransform);
+        it->second.transform =
+            MatrixUtils::Multiply(group.transform, it->second.localTransform);
     }
   }
 }
 
-// Rotates a target world transform around a pivot by applying a rotation matrix.
+// Rotates a target world transform around a pivot by applying a rotation
+// matrix.
 Matrix RotateTransformAroundPivot(const Matrix &source, const Matrix &rotation,
                                   const std::array<float, 3> &pivotMm) {
   Matrix rotated = MatrixUtils::Multiply(rotation, source);
   const std::array<float, 3> relative = {source.o[0] - pivotMm[0],
                                          source.o[1] - pivotMm[1],
                                          source.o[2] - pivotMm[2]};
-  const std::array<float, 3> rotatedPosition = TransformPoint(rotation, relative);
+  const std::array<float, 3> rotatedPosition =
+      TransformPoint(rotation, relative);
   rotated.o = {rotatedPosition[0] + pivotMm[0], rotatedPosition[1] + pivotMm[1],
                rotatedPosition[2] + pivotMm[2]};
   return rotated;
 }
-
 
 // Adds all descendant leaf UUIDs from a group to an operation result.
 void AppendAffectedGroupChildren(OperationResult &result, const MvrScene &scene,
@@ -443,41 +452,42 @@ void AppendAffectedTarget(OperationResult &result, const MvrScene &scene,
 }
 
 // Converts an effective transform target to a grouping child reference.
-SelectedObjectRef BuildSelectedObjectRefForTarget(const MvrScene &scene,
-                                                  const SceneTransformTarget &target) {
+SelectedObjectRef
+BuildSelectedObjectRefForTarget(const MvrScene &scene,
+                                const SceneTransformTarget &target) {
   if (target.type == MvrNodeType::GroupObject) {
     auto it = scene.groupObjects.find(target.uuid);
     if (it != scene.groupObjects.end())
-      return {target.type, target.uuid, it->second.layer, it->second.parentGroupUuid,
-              it->second.transform};
+      return {target.type, target.uuid, it->second.layer,
+              it->second.parentGroupUuid, it->second.transform};
   }
   switch (target.type) {
   case MvrNodeType::Fixture: {
     auto it = scene.fixtures.find(target.uuid);
     if (it != scene.fixtures.end())
-      return {target.type, target.uuid, it->second.layer, it->second.parentGroupUuid,
-              it->second.transform};
+      return {target.type, target.uuid, it->second.layer,
+              it->second.parentGroupUuid, it->second.transform};
     break;
   }
   case MvrNodeType::Truss: {
     auto it = scene.trusses.find(target.uuid);
     if (it != scene.trusses.end())
-      return {target.type, target.uuid, it->second.layer, it->second.parentGroupUuid,
-              it->second.transform};
+      return {target.type, target.uuid, it->second.layer,
+              it->second.parentGroupUuid, it->second.transform};
     break;
   }
   case MvrNodeType::Support: {
     auto it = scene.supports.find(target.uuid);
     if (it != scene.supports.end())
-      return {target.type, target.uuid, it->second.layer, it->second.parentGroupUuid,
-              it->second.transform};
+      return {target.type, target.uuid, it->second.layer,
+              it->second.parentGroupUuid, it->second.transform};
     break;
   }
   case MvrNodeType::SceneObject: {
     auto it = scene.sceneObjects.find(target.uuid);
     if (it != scene.sceneObjects.end())
-      return {target.type, target.uuid, it->second.layer, it->second.parentGroupUuid,
-              it->second.transform};
+      return {target.type, target.uuid, it->second.layer,
+              it->second.parentGroupUuid, it->second.transform};
     break;
   }
   case MvrNodeType::GroupObject:
@@ -504,9 +514,10 @@ void AppendGroupChildrenForHighlights(const MvrScene &scene,
 
 } // namespace
 
-
-// Reparents one child reference to a new parent group while preserving world placement.
-void ReparentChildPreservingWorld(MvrScene &scene, const GroupObjectChildRef &child,
+// Reparents one child reference to a new parent group while preserving world
+// placement.
+void ReparentChildPreservingWorld(MvrScene &scene,
+                                  const GroupObjectChildRef &child,
                                   const std::string &newParentUuid) {
   const SceneTransformTarget target{child.type, child.uuid};
   const Matrix worldTransform = GetTargetWorldTransform(scene, target);
@@ -514,22 +525,24 @@ void ReparentChildPreservingWorld(MvrScene &scene, const GroupObjectChildRef &ch
     auto childGroupIt = scene.groupObjects.find(child.uuid);
     if (childGroupIt != scene.groupObjects.end()) {
       childGroupIt->second.parentGroupUuid = newParentUuid;
-      childGroupIt->second.localTransform = newParentUuid.empty()
-                                               ? worldTransform
-                                               : MatrixUtils::Multiply(
-                                                     InverseMatrix(scene.groupObjects[newParentUuid].transform),
-                                                     worldTransform);
+      childGroupIt->second.localTransform =
+          newParentUuid.empty()
+              ? worldTransform
+              : MatrixUtils::Multiply(
+                    InverseMatrix(scene.groupObjects[newParentUuid].transform),
+                    worldTransform);
     }
     return;
   }
 
   SelectedObjectRef ref = BuildSelectedObjectRefForTarget(scene, target);
-  ApplyParentAndLocalTransform(scene, ref, newParentUuid,
-                               newParentUuid.empty()
-                                   ? worldTransform
-                                   : MatrixUtils::Multiply(
-                                         InverseMatrix(scene.groupObjects[newParentUuid].transform),
-                                         worldTransform));
+  ApplyParentAndLocalTransform(
+      scene, ref, newParentUuid,
+      newParentUuid.empty()
+          ? worldTransform
+          : MatrixUtils::Multiply(
+                InverseMatrix(scene.groupObjects[newParentUuid].transform),
+                worldTransform));
 }
 
 // Removes a group while promoting its direct children to the group's parent.
@@ -555,11 +568,13 @@ void UngroupRootTarget(MvrScene &scene, const std::string &groupUuid,
 }
 
 // Creates a new GroupObject and reparents the selected scene entities.
-OperationResult GroupSelection(MvrScene &scene, const ObjectSelection &selection) {
+OperationResult GroupSelection(MvrScene &scene,
+                               const ObjectSelection &selection) {
   OperationResult result;
-  std::vector<SelectedObjectRef> objects = CollectSelectedObjects(scene, selection);
-  const bool hasCommonDirectParent = objects.size() >= 2 &&
-                                     !CommonParentGroupUuid(objects).empty();
+  std::vector<SelectedObjectRef> objects =
+      CollectSelectedObjects(scene, selection);
+  const bool hasCommonDirectParent =
+      objects.size() >= 2 && !CommonParentGroupUuid(objects).empty();
   if (!hasCommonDirectParent) {
     const auto targets = BuildTransformTargets(scene, selection);
     objects.clear();
@@ -582,19 +597,20 @@ OperationResult GroupSelection(MvrScene &scene, const ObjectSelection &selection
   group.layer = objects.front().layer;
   group.parentGroupUuid = parentGroupUuid;
   group.transform = groupWorldTransform;
-  group.localTransform = parentGroupUuid.empty()
-                             ? groupWorldTransform
-                             : MatrixUtils::Multiply(
-                                   InverseMatrix(scene.groupObjects[parentGroupUuid].transform),
-                                   groupWorldTransform);
+  group.localTransform =
+      parentGroupUuid.empty()
+          ? groupWorldTransform
+          : MatrixUtils::Multiply(
+                InverseMatrix(scene.groupObjects[parentGroupUuid].transform),
+                groupWorldTransform);
 
   std::unordered_set<std::string> previousGroupsToCheck;
   for (const auto &object : objects) {
     if (!object.parentGroupUuid.empty())
       previousGroupsToCheck.insert(object.parentGroupUuid);
     RemoveChildFromGroups(scene, object.type, object.uuid);
-    const Matrix localTransform = MatrixUtils::Multiply(inverseGroupWorldTransform,
-                                                        object.worldTransform);
+    const Matrix localTransform = MatrixUtils::Multiply(
+        inverseGroupWorldTransform, object.worldTransform);
     ApplyParentAndLocalTransform(scene, object, group.uuid, localTransform);
     group.children.push_back({object.type, object.uuid});
     AppendAffectedTarget(result, scene, object.type, object.uuid);
@@ -616,7 +632,8 @@ OperationResult GroupSelection(MvrScene &scene, const ObjectSelection &selection
 }
 
 // Removes selected effective groups and promotes their direct children.
-OperationResult UngroupSelection(MvrScene &scene, const ObjectSelection &selection) {
+OperationResult UngroupSelection(MvrScene &scene,
+                                 const ObjectSelection &selection) {
   OperationResult result;
   const auto targets = BuildTransformTargets(scene, selection);
   for (const auto &target : targets) {
@@ -626,13 +643,13 @@ OperationResult UngroupSelection(MvrScene &scene, const ObjectSelection &selecti
   return result;
 }
 
-
 // Builds effective transform roots so group members move as one item.
-std::vector<SceneTransformTarget> BuildTransformTargets(
-    const MvrScene &scene, const ObjectSelection &selection) {
+std::vector<SceneTransformTarget>
+BuildTransformTargets(const MvrScene &scene, const ObjectSelection &selection) {
   std::vector<SceneTransformTarget> targets;
   std::set<std::pair<MvrNodeType, std::string>> seen;
-  const std::vector<SelectedObjectRef> objects = CollectSelectedObjects(scene, selection);
+  const std::vector<SelectedObjectRef> objects =
+      CollectSelectedObjects(scene, selection);
   for (const auto &object : objects) {
     SceneTransformTarget target = ResolveTransformRoot(scene, object);
     if (seen.insert({target.type, target.uuid}).second)
@@ -647,30 +664,37 @@ Matrix GetTargetWorldTransform(const MvrScene &scene,
   switch (target.type) {
   case MvrNodeType::Fixture: {
     auto it = scene.fixtures.find(target.uuid);
-    return it == scene.fixtures.end() ? MatrixUtils::Identity() : it->second.transform;
+    return it == scene.fixtures.end() ? MatrixUtils::Identity()
+                                      : it->second.transform;
   }
   case MvrNodeType::Truss: {
     auto it = scene.trusses.find(target.uuid);
-    return it == scene.trusses.end() ? MatrixUtils::Identity() : it->second.transform;
+    return it == scene.trusses.end() ? MatrixUtils::Identity()
+                                     : it->second.transform;
   }
   case MvrNodeType::Support: {
     auto it = scene.supports.find(target.uuid);
-    return it == scene.supports.end() ? MatrixUtils::Identity() : it->second.transform;
+    return it == scene.supports.end() ? MatrixUtils::Identity()
+                                      : it->second.transform;
   }
   case MvrNodeType::SceneObject: {
     auto it = scene.sceneObjects.find(target.uuid);
-    return it == scene.sceneObjects.end() ? MatrixUtils::Identity() : it->second.transform;
+    return it == scene.sceneObjects.end() ? MatrixUtils::Identity()
+                                          : it->second.transform;
   }
   case MvrNodeType::GroupObject: {
     auto it = scene.groupObjects.find(target.uuid);
-    return it == scene.groupObjects.end() ? MatrixUtils::Identity() : it->second.transform;
+    return it == scene.groupObjects.end() ? MatrixUtils::Identity()
+                                          : it->second.transform;
   }
   }
   return MatrixUtils::Identity();
 }
 
-// Applies a world transform to a target and recursively synchronizes group descendants.
-void SetTargetWorldTransform(MvrScene &scene, const SceneTransformTarget &target,
+// Applies a world transform to a target and recursively synchronizes group
+// descendants.
+void SetTargetWorldTransform(MvrScene &scene,
+                             const SceneTransformTarget &target,
                              const Matrix &worldTransform) {
   UpdateLocalTransformForTarget(scene, target, worldTransform);
   if (target.type != MvrNodeType::GroupObject)
@@ -693,8 +717,9 @@ void TranslateSelection(MvrScene &scene, const ObjectSelection &selection,
 }
 
 // Rotates selected effective targets around a shared millimeter pivot.
-void RotateSelectionAroundPivot(MvrScene &scene, const ObjectSelection &selection,
-                                int axis, float angleDeg,
+void RotateSelectionAroundPivot(MvrScene &scene,
+                                const ObjectSelection &selection, int axis,
+                                float angleDeg,
                                 const std::array<float, 3> &pivotMm) {
   Matrix rotation = MatrixUtils::Identity();
   if (axis == 0)
@@ -707,14 +732,17 @@ void RotateSelectionAroundPivot(MvrScene &scene, const ObjectSelection &selectio
   const auto targets = BuildTransformTargets(scene, selection);
   for (const auto &target : targets) {
     const Matrix transform = GetTargetWorldTransform(scene, target);
-    SetTargetWorldTransform(scene, target,
-                            RotateTransformAroundPivot(transform, rotation, pivotMm));
+    SetTargetWorldTransform(
+        scene, target,
+        RotateTransformAroundPivot(transform, rotation, pivotMm));
   }
 }
 
-// Returns selected UUIDs expanded with direct group siblings for viewport highlights.
-std::vector<std::string> ExpandSelectionForGroupHighlights(
-    const MvrScene &scene, const ObjectSelection &selection) {
+// Returns selected UUIDs expanded with direct group siblings for viewport
+// highlights.
+std::vector<std::string>
+ExpandSelectionForGroupHighlights(const MvrScene &scene,
+                                  const ObjectSelection &selection) {
   std::vector<std::string> expanded;
   std::unordered_set<std::string> seen;
   for (const auto &target : BuildTransformTargets(scene, selection)) {
@@ -724,6 +752,36 @@ std::vector<std::string> ExpandSelectionForGroupHighlights(
       AppendUnique(expanded, seen, target.uuid);
     }
   }
+  return expanded;
+}
+
+// Returns sibling UUIDs that share the hovered object's effective root group.
+std::vector<std::string>
+ExpandHoverForGroupHighlights(const MvrScene &scene, const std::string &uuid) {
+  std::vector<std::string> expanded;
+  if (uuid.empty())
+    return expanded;
+
+  ObjectSelection selection;
+  if (scene.fixtures.find(uuid) != scene.fixtures.end())
+    selection.fixtures.push_back(uuid);
+  else if (scene.trusses.find(uuid) != scene.trusses.end())
+    selection.trusses.push_back(uuid);
+  else if (scene.supports.find(uuid) != scene.supports.end())
+    selection.supports.push_back(uuid);
+  else if (scene.sceneObjects.find(uuid) != scene.sceneObjects.end())
+    selection.sceneObjects.push_back(uuid);
+  else
+    return expanded;
+
+  std::unordered_set<std::string> seen;
+  for (const auto &target : BuildTransformTargets(scene, selection)) {
+    if (target.type != MvrNodeType::GroupObject)
+      continue;
+    AppendGroupChildrenForHighlights(scene, target.uuid, expanded, seen);
+  }
+  expanded.erase(std::remove(expanded.begin(), expanded.end(), uuid),
+                 expanded.end());
   return expanded;
 }
 

--- a/core/scene_grouping.h
+++ b/core/scene_grouping.h
@@ -47,21 +47,25 @@ struct OperationResult {
 };
 
 // Creates one MVR-compatible GroupObject from the selected scene entities.
-OperationResult GroupSelection(MvrScene &scene, const ObjectSelection &selection);
+OperationResult GroupSelection(MvrScene &scene,
+                               const ObjectSelection &selection);
 
 // Removes selected scene entities from their direct parent groups.
-OperationResult UngroupSelection(MvrScene &scene, const ObjectSelection &selection);
+OperationResult UngroupSelection(MvrScene &scene,
+                                 const ObjectSelection &selection);
 
 // Builds effective transform roots so grouped objects behave as single units.
-std::vector<SceneTransformTarget> BuildTransformTargets(
-    const MvrScene &scene, const ObjectSelection &selection);
+std::vector<SceneTransformTarget>
+BuildTransformTargets(const MvrScene &scene, const ObjectSelection &selection);
 
 // Returns the current world transform for one transform target.
 Matrix GetTargetWorldTransform(const MvrScene &scene,
                                const SceneTransformTarget &target);
 
-// Applies a world transform to a target and recursively synchronizes group children.
-void SetTargetWorldTransform(MvrScene &scene, const SceneTransformTarget &target,
+// Applies a world transform to a target and recursively synchronizes group
+// children.
+void SetTargetWorldTransform(MvrScene &scene,
+                             const SceneTransformTarget &target,
                              const Matrix &worldTransform);
 
 // Translates effective selection targets by a millimeter delta.
@@ -69,12 +73,19 @@ void TranslateSelection(MvrScene &scene, const ObjectSelection &selection,
                         const std::array<float, 3> &deltaMm);
 
 // Rotates effective selection targets around a millimeter pivot.
-void RotateSelectionAroundPivot(MvrScene &scene, const ObjectSelection &selection,
-                                int axis, float angleDeg,
+void RotateSelectionAroundPivot(MvrScene &scene,
+                                const ObjectSelection &selection, int axis,
+                                float angleDeg,
                                 const std::array<float, 3> &pivotMm);
 
-// Expands UUID highlights so selecting one group member highlights its full root group.
-std::vector<std::string> ExpandSelectionForGroupHighlights(
-    const MvrScene &scene, const ObjectSelection &selection);
+// Expands UUID highlights so selecting one group member highlights its full
+// root group.
+std::vector<std::string>
+ExpandSelectionForGroupHighlights(const MvrScene &scene,
+                                  const ObjectSelection &selection);
+
+// Returns sibling UUIDs that share the hovered object's effective root group.
+std::vector<std::string> ExpandHoverForGroupHighlights(const MvrScene &scene,
+                                                       const std::string &uuid);
 
 } // namespace scene_grouping

--- a/docs/features.md
+++ b/docs/features.md
@@ -86,7 +86,7 @@ Additional safeguards include:
 
 - Dedicated tables for fixtures, trusses, hoists, and objects.
 - Multi-row editing helpers include fills, ranges, interpolation, and relative expressions.
-- **Group** and **Ungroup** in the Edit menu create and remove MVR-compatible GroupObject hierarchy from the active cross-table selection across fixtures, trusses, hoists, and scene objects while preserving world placement and hang-position assignments; after grouping, selecting a member highlights and moves/rotates the full group, including nested groups, while hovering a grouped member uses a more yellow primary highlight and a paler related-green highlight on the other group members in the 3D view and related tables.
+- **Group** and **Ungroup** in the Edit menu create and remove MVR-compatible GroupObject hierarchy from the active cross-table selection across fixtures, trusses, hoists, and scene objects while preserving world placement and hang-position assignments; after grouping, selecting a member highlights and moves/rotates the full group, including nested groups, while hovering a grouped member uses a more yellow primary highlight and a paler related-green highlight on the other group members in the 3D view and related tables using the same row style as table selection.
 - CSV export is available through file/export workflows.
 
 ### Conversion and type/color helpers

--- a/docs/features.md
+++ b/docs/features.md
@@ -86,7 +86,7 @@ Additional safeguards include:
 
 - Dedicated tables for fixtures, trusses, hoists, and objects.
 - Multi-row editing helpers include fills, ranges, interpolation, and relative expressions.
-- **Group** and **Ungroup** in the Edit menu create and remove MVR-compatible GroupObject hierarchy from the active cross-table selection across fixtures, trusses, hoists, and scene objects while preserving world placement and hang-position assignments; after grouping, selecting a member highlights and moves/rotates the full group, including nested groups, while hovering a grouped member uses a related green highlight on the other group members so the group relationship remains visible.
+- **Group** and **Ungroup** in the Edit menu create and remove MVR-compatible GroupObject hierarchy from the active cross-table selection across fixtures, trusses, hoists, and scene objects while preserving world placement and hang-position assignments; after grouping, selecting a member highlights and moves/rotates the full group, including nested groups, while hovering a grouped member uses a softer related-green highlight on the other group members so the group relationship remains visible.
 - CSV export is available through file/export workflows.
 
 ### Conversion and type/color helpers

--- a/docs/features.md
+++ b/docs/features.md
@@ -86,7 +86,7 @@ Additional safeguards include:
 
 - Dedicated tables for fixtures, trusses, hoists, and objects.
 - Multi-row editing helpers include fills, ranges, interpolation, and relative expressions.
-- **Group** and **Ungroup** in the Edit menu create and remove MVR-compatible GroupObject hierarchy from the active cross-table selection across fixtures, trusses, hoists, and scene objects while preserving world placement and hang-position assignments; after grouping, selecting a member highlights and moves/rotates the full group, including nested groups.
+- **Group** and **Ungroup** in the Edit menu create and remove MVR-compatible GroupObject hierarchy from the active cross-table selection across fixtures, trusses, hoists, and scene objects while preserving world placement and hang-position assignments; after grouping, selecting a member highlights and moves/rotates the full group, including nested groups, while hovering a grouped member uses a related green highlight on the other group members so the group relationship remains visible.
 - CSV export is available through file/export workflows.
 
 ### Conversion and type/color helpers

--- a/docs/features.md
+++ b/docs/features.md
@@ -86,7 +86,7 @@ Additional safeguards include:
 
 - Dedicated tables for fixtures, trusses, hoists, and objects.
 - Multi-row editing helpers include fills, ranges, interpolation, and relative expressions.
-- **Group** and **Ungroup** in the Edit menu create and remove MVR-compatible GroupObject hierarchy from the active cross-table selection across fixtures, trusses, hoists, and scene objects while preserving world placement and hang-position assignments; after grouping, selecting a member highlights and moves/rotates the full group, including nested groups, while hovering a grouped member uses a softer related-green highlight on the other group members so the group relationship remains visible.
+- **Group** and **Ungroup** in the Edit menu create and remove MVR-compatible GroupObject hierarchy from the active cross-table selection across fixtures, trusses, hoists, and scene objects while preserving world placement and hang-position assignments; after grouping, selecting a member highlights and moves/rotates the full group, including nested groups, while hovering a grouped member uses a more yellow primary highlight and a paler related-green highlight on the other group members in the 3D view and related tables.
 - CSV export is available through file/export workflows.
 
 ### Conversion and type/color helpers

--- a/docs/features.md
+++ b/docs/features.md
@@ -86,7 +86,7 @@ Additional safeguards include:
 
 - Dedicated tables for fixtures, trusses, hoists, and objects.
 - Multi-row editing helpers include fills, ranges, interpolation, and relative expressions.
-- **Group** and **Ungroup** in the Edit menu create and remove MVR-compatible GroupObject hierarchy from the active cross-table selection across fixtures, trusses, hoists, and scene objects while preserving world placement and hang-position assignments; after grouping, selecting a member highlights and moves/rotates the full group, including nested groups, while hovering a grouped member uses a more yellow primary highlight and a paler related-green highlight on the other group members in the 3D view and related tables using the same row style as table selection.
+- **Group** and **Ungroup** in the Edit menu create and remove MVR-compatible GroupObject hierarchy from the active cross-table selection across fixtures, trusses, hoists, and scene objects while preserving world placement and hang-position assignments; after grouping, clicking a member selects the full group across related tables, and the selection highlights and moves/rotates the full group, including nested groups, while hovering a grouped member uses a more yellow primary highlight and a paler related-green highlight on the other group members in the 3D view and related tables using the same row style as table selection.
 - CSV export is available through file/export workflows.
 
 ### Conversion and type/color helpers

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -13,7 +13,7 @@ Changes since `v1.3.0`.
 ## Improvements
 
 - Improved GroupObject handling so selecting a grouped member highlights and transforms the full root group, including nested groups, in 2D, 3D, and command-bar transform workflows.
-- Improved 3D hover feedback for grouped scene items by showing related group members with a distinct green highlight across fixtures, trusses, hoists, and scene objects.
+- Improved 3D hover feedback for grouped scene items by showing related group members with a softer related-green highlight across fixtures, trusses, hoists, and scene objects.
 
 ## Fixes
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -13,7 +13,7 @@ Changes since `v1.3.0`.
 ## Improvements
 
 - Improved GroupObject handling so selecting a grouped member highlights and transforms the full root group, including nested groups, in 2D, 3D, and command-bar transform workflows.
-- Improved 3D hover feedback for grouped scene items by showing related group members with a softer related-green highlight across fixtures, trusses, hoists, and scene objects.
+- Improved group hover feedback by using a more yellow primary highlight and a paler secondary group highlight across the 3D view and related fixture, truss, hoist, and scene object table rows.
 
 ## Fixes
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -13,7 +13,7 @@ Changes since `v1.3.0`.
 ## Improvements
 
 - Improved GroupObject handling so selecting a grouped member highlights and transforms the full root group, including nested groups, in 2D, 3D, and command-bar transform workflows.
-- Improved group hover feedback by using a more yellow primary highlight and a paler secondary group highlight across the 3D view and related fixture, truss, hoist, and scene object table rows.
+- Improved group hover feedback by using a more yellow primary highlight and a paler secondary group highlight across the 3D view and related fixture, truss, hoist, and scene object table rows, matching the table selection styling.
 
 ## Fixes
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -14,9 +14,11 @@ Changes since `v1.3.0`.
 
 - Improved GroupObject handling so selecting a grouped member highlights and transforms the full root group, including nested groups, in 2D, 3D, and command-bar transform workflows.
 - Improved group hover feedback by using a more yellow primary highlight and a paler secondary group highlight across the 3D view and related fixture, truss, hoist, and scene object table rows, matching the table selection styling.
+- Improved 3D click selection for grouped scene items so a quick click selects the full group across fixture, truss, hoist, and scene object tables.
 
 ## Fixes
 
+- Fixed quick-click fixture selection in the 3D view so hovered fixtures can still be selected when the precise release pick misses.
 - Fixed MVR fixture Color handling so visualization colors are no longer exported as gel/filter colors, while imported MVR Color values are preserved as fixture gel/filter data.
 - Restored edge-safe fixture visibility and made fixture hover picking use actual fixture geometry so highlights and labels target the visible fixture instead of broad bounds.
 - Fixed fixture ID edits so saved project files and exported MVR files keep the updated numeric fixture IDs instead of reverting to imported IDs.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -49,3 +49,4 @@ Changes since `v1.3.0`.
 - Added backward-cpp integration, generated build metadata, and release workflow symbol archives for Windows, Linux, macOS, and Arch Linux builds.
 - Improved truss table reload stability so rebuilding rows preserves existing truss selection without triggering transient selection side effects.
 - Added concise diagnostics for truss loading and 2D viewer picking to make validation and interaction issues easier to troubleshoot.
+- Improved grouped-hover rendering integration so symbol capture paths use the same highlight state as direct 3D drawing.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -13,6 +13,7 @@ Changes since `v1.3.0`.
 ## Improvements
 
 - Improved GroupObject handling so selecting a grouped member highlights and transforms the full root group, including nested groups, in 2D, 3D, and command-bar transform workflows.
+- Improved 3D hover feedback for grouped scene items by showing related group members with a distinct green highlight across fixtures, trusses, hoists, and scene objects.
 
 ## Fixes
 

--- a/docs/views.md
+++ b/docs/views.md
@@ -10,7 +10,7 @@ Typical checks:
 
 - Position and orientation.
 - Relationships between fixtures, trusses, hoists, and objects.
-- Group membership while hovering scene items: the hovered item uses the primary hover highlight, and other members of the same group use a paler related-green highlight in the 3D view and related tables.
+- Group membership while hovering scene items: the hovered item uses the primary hover highlight, and other members of the same group use a paler related-green highlight in the 3D view and related tables, with table rows styled like selected rows.
 - General scene structure before export.
 
 ## 2D view and layouts

--- a/docs/views.md
+++ b/docs/views.md
@@ -10,7 +10,7 @@ Typical checks:
 
 - Position and orientation.
 - Relationships between fixtures, trusses, hoists, and objects.
-- Group membership while hovering scene items: the hovered item keeps the normal highlight, and other members of the same group use a softer related-green highlight.
+- Group membership while hovering scene items: the hovered item uses the primary hover highlight, and other members of the same group use a paler related-green highlight in the 3D view and related tables.
 - General scene structure before export.
 
 ## 2D view and layouts

--- a/docs/views.md
+++ b/docs/views.md
@@ -11,6 +11,7 @@ Typical checks:
 - Position and orientation.
 - Relationships between fixtures, trusses, hoists, and objects.
 - Group membership while hovering scene items: the hovered item uses the primary hover highlight, and other members of the same group use a paler related-green highlight in the 3D view and related tables, with table rows styled like selected rows.
+- Group selection while clicking scene items: clicking a grouped member selects its full group across related tables.
 - General scene structure before export.
 
 ## 2D view and layouts

--- a/docs/views.md
+++ b/docs/views.md
@@ -10,6 +10,7 @@ Typical checks:
 
 - Position and orientation.
 - Relationships between fixtures, trusses, hoists, and objects.
+- Group membership while hovering scene items: the hovered item keeps the normal highlight, and other members of the same group use a related green highlight.
 - General scene structure before export.
 
 ## 2D view and layouts

--- a/docs/views.md
+++ b/docs/views.md
@@ -10,7 +10,7 @@ Typical checks:
 
 - Position and orientation.
 - Relationships between fixtures, trusses, hoists, and objects.
-- Group membership while hovering scene items: the hovered item keeps the normal highlight, and other members of the same group use a related green highlight.
+- Group membership while hovering scene items: the hovered item keeps the normal highlight, and other members of the same group use a softer related-green highlight.
 - General scene structure before export.
 
 ## 2D view and layouts

--- a/gui/colorstore.h
+++ b/gui/colorstore.h
@@ -25,10 +25,17 @@ public:
   std::vector<wxDataViewItemAttr> rowAttrs;
   std::vector<std::vector<wxDataViewItemAttr>> cellAttrs;
   std::vector<bool> selectionRows;
+  std::vector<bool> primaryHighlightRows;
+  std::vector<bool> secondaryHighlightRows;
   wxColour selectionBackground;
   wxColour selectionForeground;
+  wxColour primaryHighlightBackground;
+  wxColour secondaryHighlightBackground;
+  wxColour highlightForeground;
   bool selectionBackgroundEnabled = false;
   bool selectionForegroundEnabled = false;
+  bool highlightBackgroundEnabled = false;
+  bool highlightForegroundEnabled = false;
 
   bool GetAttrByRow(unsigned row, unsigned col,
                     wxDataViewItemAttr &attr) const override {
@@ -60,6 +67,24 @@ public:
       return true;
     }
 
+    const bool isPrimaryHighlight =
+        row < primaryHighlightRows.size() && primaryHighlightRows[row];
+    const bool isSecondaryHighlight =
+        row < secondaryHighlightRows.size() && secondaryHighlightRows[row];
+    if ((isPrimaryHighlight || isSecondaryHighlight) &&
+        (highlightBackgroundEnabled || highlightForegroundEnabled)) {
+      if (!hasAttr)
+        attr = wxDataViewItemAttr();
+      if (highlightBackgroundEnabled && !attr.HasBackgroundColour()) {
+        attr.SetBackgroundColour(isPrimaryHighlight
+                                     ? primaryHighlightBackground
+                                     : secondaryHighlightBackground);
+      }
+      if (highlightForegroundEnabled && !hasTextColour)
+        attr.SetColour(highlightForeground);
+      return true;
+    }
+
     return hasAttr;
   }
 
@@ -68,6 +93,8 @@ public:
     rowAttrs.emplace_back();
     cellAttrs.emplace_back();
     selectionRows.push_back(false);
+    primaryHighlightRows.push_back(false);
+    secondaryHighlightRows.push_back(false);
   }
 
   void PrependItem(const wxVector<wxVariant> &values, wxUIntPtr data = 0) {
@@ -75,6 +102,8 @@ public:
     rowAttrs.insert(rowAttrs.begin(), wxDataViewItemAttr());
     cellAttrs.insert(cellAttrs.begin(), std::vector<wxDataViewItemAttr>());
     selectionRows.insert(selectionRows.begin(), false);
+    primaryHighlightRows.insert(primaryHighlightRows.begin(), false);
+    secondaryHighlightRows.insert(secondaryHighlightRows.begin(), false);
   }
 
   void InsertItem(unsigned row, const wxVector<wxVariant> &values,
@@ -84,6 +113,8 @@ public:
     cellAttrs.insert(cellAttrs.begin() + row,
                      std::vector<wxDataViewItemAttr>());
     selectionRows.insert(selectionRows.begin() + row, false);
+    primaryHighlightRows.insert(primaryHighlightRows.begin() + row, false);
+    secondaryHighlightRows.insert(secondaryHighlightRows.begin() + row, false);
   }
 
   void DeleteItem(unsigned row) {
@@ -94,6 +125,10 @@ public:
       cellAttrs.erase(cellAttrs.begin() + row);
     if (row < selectionRows.size())
       selectionRows.erase(selectionRows.begin() + row);
+    if (row < primaryHighlightRows.size())
+      primaryHighlightRows.erase(primaryHighlightRows.begin() + row);
+    if (row < secondaryHighlightRows.size())
+      secondaryHighlightRows.erase(secondaryHighlightRows.begin() + row);
   }
 
   void DeleteAllItems() {
@@ -101,6 +136,8 @@ public:
     rowAttrs.clear();
     cellAttrs.clear();
     selectionRows.clear();
+    primaryHighlightRows.clear();
+    secondaryHighlightRows.clear();
   }
 
   void SetRowBackgroundColour(unsigned row, const wxColour &colour) {
@@ -188,6 +225,51 @@ public:
       bool oldVal = i < oldSize ? oldRows[i] : false;
       bool newVal = i < selectionRows.size() ? selectionRows[i] : false;
       if (oldVal != newVal)
+        RowChanged(i);
+    }
+  }
+
+  // Applies primary and secondary row highlights using selection-style colors.
+  void SetHighlightRows(const std::vector<bool> &primaryRows,
+                        const std::vector<bool> &secondaryRows,
+                        const wxColour &primaryBackground,
+                        const wxColour &secondaryBackground,
+                        const wxColour &foreground) {
+    std::vector<bool> oldPrimaryRows = primaryHighlightRows;
+    std::vector<bool> oldSecondaryRows = secondaryHighlightRows;
+    primaryHighlightRows.assign(primaryRows.begin(), primaryRows.end());
+    secondaryHighlightRows.assign(secondaryRows.begin(), secondaryRows.end());
+    size_t itemCount = GetItemCount();
+    if (itemCount > primaryHighlightRows.size())
+      primaryHighlightRows.resize(itemCount, false);
+    if (itemCount > secondaryHighlightRows.size())
+      secondaryHighlightRows.resize(itemCount, false);
+    if (primaryHighlightRows.size() > itemCount)
+      primaryHighlightRows.resize(itemCount);
+    if (secondaryHighlightRows.size() > itemCount)
+      secondaryHighlightRows.resize(itemCount);
+    primaryHighlightBackground = primaryBackground;
+    secondaryHighlightBackground = secondaryBackground;
+    highlightForeground = foreground;
+    highlightBackgroundEnabled = true;
+    highlightForegroundEnabled = true;
+
+    size_t notifyCount =
+        (std::min)((std::max)(oldPrimaryRows.size(), primaryHighlightRows.size()),
+                   itemCount);
+    notifyCount = (std::max)(notifyCount,
+                             (std::min)((std::max)(oldSecondaryRows.size(),
+                                                    secondaryHighlightRows.size()),
+                                        itemCount));
+    for (size_t i = 0; i < notifyCount; ++i) {
+      bool oldPrimary = i < oldPrimaryRows.size() ? oldPrimaryRows[i] : false;
+      bool newPrimary =
+          i < primaryHighlightRows.size() ? primaryHighlightRows[i] : false;
+      bool oldSecondary =
+          i < oldSecondaryRows.size() ? oldSecondaryRows[i] : false;
+      bool newSecondary =
+          i < secondaryHighlightRows.size() ? secondaryHighlightRows[i] : false;
+      if (oldPrimary != newPrimary || oldSecondary != newSecondary)
         RowChanged(i);
     }
   }

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -1115,23 +1115,18 @@ void FixtureTablePanel::HighlightFixture(
     return row;
   };
 
-  const int previousRow = findRow(highlightedUuid);
-  if (previousRow != wxNOT_FOUND)
-    store->ClearRowBackground(previousRow);
-  for (const auto &relatedUuid : highlightedRelatedUuids) {
-    const int relatedRow = findRow(relatedUuid);
-    if (relatedRow != wxNOT_FOUND)
-      store->ClearRowBackground(relatedRow);
-  }
-
+  std::vector<bool> primaryRows(table->GetItemCount(), false);
+  std::vector<bool> secondaryRows(table->GetItemCount(), false);
   const int currentRow = findRow(uuid);
   if (currentRow != wxNOT_FOUND)
-    store->SetRowBackgroundColour(currentRow, wxColour(170, 220, 0));
+    primaryRows[static_cast<size_t>(currentRow)] = true;
   for (const auto &relatedUuid : relatedUuids) {
     const int relatedRow = findRow(relatedUuid);
     if (relatedRow != wxNOT_FOUND && relatedRow != currentRow)
-      store->SetRowBackgroundColour(relatedRow, wxColour(110, 210, 150));
+      secondaryRows[static_cast<size_t>(relatedRow)] = true;
   }
+  store->SetHighlightRows(primaryRows, secondaryRows, wxColour(170, 220, 0),
+                          wxColour(110, 210, 150), wxColour(0, 0, 0));
 
   highlightedUuid = uuid;
   highlightedRelatedUuids = relatedUuids;

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -1092,9 +1092,15 @@ bool FixtureTablePanel::IsActivePage() const {
   return nb && nb->GetPage(nb->GetSelection()) == this;
 }
 
-// Selects and scrolls to the row matching a fixture UUID.
+// Applies a primary hover highlight to one fixture row.
 void FixtureTablePanel::HighlightFixture(const std::string &uuid) {
-  if (uuid == highlightedUuid)
+  HighlightFixture(uuid, {});
+}
+
+// Applies primary and related group-hover highlights to fixture rows.
+void FixtureTablePanel::HighlightFixture(
+    const std::string &uuid, const std::vector<std::string> &relatedUuids) {
+  if (uuid == highlightedUuid && relatedUuids == highlightedRelatedUuids)
     return;
 
   auto findRow = [&](const std::string &candidate) -> int {
@@ -1112,12 +1118,23 @@ void FixtureTablePanel::HighlightFixture(const std::string &uuid) {
   const int previousRow = findRow(highlightedUuid);
   if (previousRow != wxNOT_FOUND)
     store->ClearRowBackground(previousRow);
+  for (const auto &relatedUuid : highlightedRelatedUuids) {
+    const int relatedRow = findRow(relatedUuid);
+    if (relatedRow != wxNOT_FOUND)
+      store->ClearRowBackground(relatedRow);
+  }
 
   const int currentRow = findRow(uuid);
   if (currentRow != wxNOT_FOUND)
-    store->SetRowBackgroundColour(currentRow, wxColour(0, 200, 0));
+    store->SetRowBackgroundColour(currentRow, wxColour(170, 220, 0));
+  for (const auto &relatedUuid : relatedUuids) {
+    const int relatedRow = findRow(relatedUuid);
+    if (relatedRow != wxNOT_FOUND && relatedRow != currentRow)
+      store->SetRowBackgroundColour(relatedRow, wxColour(110, 210, 150));
+  }
 
   highlightedUuid = uuid;
+  highlightedRelatedUuids = relatedUuids;
   table->Refresh();
 }
 

--- a/gui/fixturetablepanel.h
+++ b/gui/fixturetablepanel.h
@@ -58,6 +58,8 @@ public:
     ~FixtureTablePanel();
     void ReloadData(); // Refresh content from ConfigManager
     void HighlightFixture(const std::string& uuid);
+    void HighlightFixture(const std::string& uuid,
+                          const std::vector<std::string>& relatedUuids);
     void ClearSelection();
     std::vector<std::string> GetSelectedUuids() const;
     void SelectByUuid(const std::vector<std::string>& uuids,
@@ -88,6 +90,7 @@ private:
     std::vector<wxString> columnLabels;
     std::vector<wxString> gdtfPaths; // Stores full GDTF paths per row
     std::vector<std::string> rowUuids;
+    std::vector<std::string> highlightedRelatedUuids;
     std::unordered_map<wxUIntPtr, std::string> rowUuidByKey;
     std::unordered_map<wxUIntPtr, wxString> gdtfPathByKey;
     wxUIntPtr nextRowKey = 1;

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -1177,12 +1177,22 @@ bool HoistTablePanel::IsActivePage() const {
   return nb->GetPage(static_cast<size_t>(selection)) == this;
 }
 
+// Applies a primary hover highlight to one hoist row.
 void HoistTablePanel::HighlightHoist(const std::string &uuid) {
+  HighlightHoist(uuid, {});
+}
+
+// Applies primary and related group-hover highlights to hoist rows.
+void HoistTablePanel::HighlightHoist(
+    const std::string &uuid, const std::vector<std::string> &relatedUuids) {
   size_t count =
       std::min(rowUuids.size(), static_cast<size_t>(table->GetItemCount()));
   for (size_t i = 0; i < count; ++i) {
     if (!uuid.empty() && rowUuids[i] == uuid)
-      store->SetRowBackgroundColour(i, wxColour(0, 200, 0));
+      store->SetRowBackgroundColour(i, wxColour(170, 220, 0));
+    else if (std::find(relatedUuids.begin(), relatedUuids.end(), rowUuids[i]) !=
+             relatedUuids.end())
+      store->SetRowBackgroundColour(i, wxColour(110, 210, 150));
     else
       store->ClearRowBackground(i);
   }

--- a/gui/hoisttablepanel.cpp
+++ b/gui/hoisttablepanel.cpp
@@ -1187,15 +1187,17 @@ void HoistTablePanel::HighlightHoist(
     const std::string &uuid, const std::vector<std::string> &relatedUuids) {
   size_t count =
       std::min(rowUuids.size(), static_cast<size_t>(table->GetItemCount()));
+  std::vector<bool> primaryRows(table->GetItemCount(), false);
+  std::vector<bool> secondaryRows(table->GetItemCount(), false);
   for (size_t i = 0; i < count; ++i) {
     if (!uuid.empty() && rowUuids[i] == uuid)
-      store->SetRowBackgroundColour(i, wxColour(170, 220, 0));
+      primaryRows[i] = true;
     else if (std::find(relatedUuids.begin(), relatedUuids.end(), rowUuids[i]) !=
              relatedUuids.end())
-      store->SetRowBackgroundColour(i, wxColour(110, 210, 150));
-    else
-      store->ClearRowBackground(i);
+      secondaryRows[i] = true;
   }
+  store->SetHighlightRows(primaryRows, secondaryRows, wxColour(170, 220, 0),
+                          wxColour(110, 210, 150), wxColour(0, 0, 0));
   table->Refresh();
 }
 

--- a/gui/hoisttablepanel.h
+++ b/gui/hoisttablepanel.h
@@ -35,6 +35,8 @@ public:
 
   void ReloadData();
   void HighlightHoist(const std::string &uuid);
+  void HighlightHoist(const std::string &uuid,
+                      const std::vector<std::string> &relatedUuids);
   void ClearSelection();
   std::vector<std::string> GetSelectedUuids() const;
   void SelectByUuid(const std::vector<std::string> &uuids,

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -922,9 +922,17 @@ bool SceneObjectTablePanel::IsActivePage() const
     return nb && nb->GetPage(nb->GetSelection()) == this;
 }
 
+// Applies a primary hover highlight to one scene object row.
 void SceneObjectTablePanel::HighlightObject(const std::string& uuid)
 {
-    if (uuid == highlightedUuid)
+    HighlightObject(uuid, {});
+}
+
+// Applies primary and related group-hover highlights to scene object rows.
+void SceneObjectTablePanel::HighlightObject(
+    const std::string& uuid, const std::vector<std::string>& relatedUuids)
+{
+    if (uuid == highlightedUuid && relatedUuids == highlightedRelatedUuids)
         return;
 
     auto findRow = [&](const std::string& candidate) -> int {
@@ -942,12 +950,23 @@ void SceneObjectTablePanel::HighlightObject(const std::string& uuid)
     const int previousRow = findRow(highlightedUuid);
     if (previousRow != wxNOT_FOUND)
         store->ClearRowBackground(previousRow);
+    for (const auto& relatedUuid : highlightedRelatedUuids) {
+        const int relatedRow = findRow(relatedUuid);
+        if (relatedRow != wxNOT_FOUND)
+            store->ClearRowBackground(relatedRow);
+    }
 
     const int currentRow = findRow(uuid);
     if (currentRow != wxNOT_FOUND)
-        store->SetRowBackgroundColour(currentRow, wxColour(0, 200, 0));
+        store->SetRowBackgroundColour(currentRow, wxColour(170, 220, 0));
+    for (const auto& relatedUuid : relatedUuids) {
+        const int relatedRow = findRow(relatedUuid);
+        if (relatedRow != wxNOT_FOUND && relatedRow != currentRow)
+            store->SetRowBackgroundColour(relatedRow, wxColour(110, 210, 150));
+    }
 
     highlightedUuid = uuid;
+    highlightedRelatedUuids = relatedUuids;
     table->Refresh();
 }
 

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -947,23 +947,18 @@ void SceneObjectTablePanel::HighlightObject(
         return row;
     };
 
-    const int previousRow = findRow(highlightedUuid);
-    if (previousRow != wxNOT_FOUND)
-        store->ClearRowBackground(previousRow);
-    for (const auto& relatedUuid : highlightedRelatedUuids) {
-        const int relatedRow = findRow(relatedUuid);
-        if (relatedRow != wxNOT_FOUND)
-            store->ClearRowBackground(relatedRow);
-    }
-
+    std::vector<bool> primaryRows(table->GetItemCount(), false);
+    std::vector<bool> secondaryRows(table->GetItemCount(), false);
     const int currentRow = findRow(uuid);
     if (currentRow != wxNOT_FOUND)
-        store->SetRowBackgroundColour(currentRow, wxColour(170, 220, 0));
+        primaryRows[static_cast<size_t>(currentRow)] = true;
     for (const auto& relatedUuid : relatedUuids) {
         const int relatedRow = findRow(relatedUuid);
         if (relatedRow != wxNOT_FOUND && relatedRow != currentRow)
-            store->SetRowBackgroundColour(relatedRow, wxColour(110, 210, 150));
+            secondaryRows[static_cast<size_t>(relatedRow)] = true;
     }
+    store->SetHighlightRows(primaryRows, secondaryRows, wxColour(170, 220, 0),
+                            wxColour(110, 210, 150), wxColour(0, 0, 0));
 
     highlightedUuid = uuid;
     highlightedRelatedUuids = relatedUuids;

--- a/gui/sceneobjecttablepanel.h
+++ b/gui/sceneobjecttablepanel.h
@@ -35,6 +35,8 @@ public:
     ~SceneObjectTablePanel();
     void ReloadData();
     void HighlightObject(const std::string& uuid);
+    void HighlightObject(const std::string& uuid,
+                         const std::vector<std::string>& relatedUuids);
     void ClearSelection();
     std::vector<std::string> GetSelectedUuids() const;
     void SelectByUuid(const std::vector<std::string>& uuids,
@@ -56,6 +58,7 @@ private:
     std::vector<wxString> columnLabels;
     std::vector<wxString> modelPaths;
     std::vector<std::string> rowUuids;
+    std::vector<std::string> highlightedRelatedUuids;
     std::unordered_map<wxUIntPtr, std::string> rowUuidByKey;
     std::unordered_map<wxUIntPtr, wxString> modelPathByKey;
     wxUIntPtr nextRowKey = 1;

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -1170,23 +1170,18 @@ void TrussTablePanel::HighlightTruss(
         return row;
     };
 
-    const int previousRow = findRow(highlightedUuid);
-    if (previousRow != wxNOT_FOUND)
-        store->ClearRowBackground(previousRow);
-    for (const auto& relatedUuid : highlightedRelatedUuids) {
-        const int relatedRow = findRow(relatedUuid);
-        if (relatedRow != wxNOT_FOUND)
-            store->ClearRowBackground(relatedRow);
-    }
-
+    std::vector<bool> primaryRows(table->GetItemCount(), false);
+    std::vector<bool> secondaryRows(table->GetItemCount(), false);
     const int currentRow = findRow(uuid);
     if (currentRow != wxNOT_FOUND)
-        store->SetRowBackgroundColour(currentRow, wxColour(170, 220, 0));
+        primaryRows[static_cast<size_t>(currentRow)] = true;
     for (const auto& relatedUuid : relatedUuids) {
         const int relatedRow = findRow(relatedUuid);
         if (relatedRow != wxNOT_FOUND && relatedRow != currentRow)
-            store->SetRowBackgroundColour(relatedRow, wxColour(110, 210, 150));
+            secondaryRows[static_cast<size_t>(relatedRow)] = true;
     }
+    store->SetHighlightRows(primaryRows, secondaryRows, wxColour(170, 220, 0),
+                            wxColour(110, 210, 150), wxColour(0, 0, 0));
 
     highlightedUuid = uuid;
     highlightedRelatedUuids = relatedUuids;

--- a/gui/trusstablepanel.cpp
+++ b/gui/trusstablepanel.cpp
@@ -1145,9 +1145,17 @@ bool TrussTablePanel::IsActivePage() const
     return nb && nb->GetPage(nb->GetSelection()) == this;
 }
 
+// Applies a primary hover highlight to one truss row.
 void TrussTablePanel::HighlightTruss(const std::string& uuid)
 {
-    if (uuid == highlightedUuid)
+    HighlightTruss(uuid, {});
+}
+
+// Applies primary and related group-hover highlights to truss rows.
+void TrussTablePanel::HighlightTruss(
+    const std::string& uuid, const std::vector<std::string>& relatedUuids)
+{
+    if (uuid == highlightedUuid && relatedUuids == highlightedRelatedUuids)
         return;
 
     auto findRow = [&](const std::string& candidate) -> int {
@@ -1165,12 +1173,23 @@ void TrussTablePanel::HighlightTruss(const std::string& uuid)
     const int previousRow = findRow(highlightedUuid);
     if (previousRow != wxNOT_FOUND)
         store->ClearRowBackground(previousRow);
+    for (const auto& relatedUuid : highlightedRelatedUuids) {
+        const int relatedRow = findRow(relatedUuid);
+        if (relatedRow != wxNOT_FOUND)
+            store->ClearRowBackground(relatedRow);
+    }
 
     const int currentRow = findRow(uuid);
     if (currentRow != wxNOT_FOUND)
-        store->SetRowBackgroundColour(currentRow, wxColour(0, 200, 0));
+        store->SetRowBackgroundColour(currentRow, wxColour(170, 220, 0));
+    for (const auto& relatedUuid : relatedUuids) {
+        const int relatedRow = findRow(relatedUuid);
+        if (relatedRow != wxNOT_FOUND && relatedRow != currentRow)
+            store->SetRowBackgroundColour(relatedRow, wxColour(110, 210, 150));
+    }
 
     highlightedUuid = uuid;
+    highlightedRelatedUuids = relatedUuids;
     table->Refresh();
 }
 

--- a/gui/trusstablepanel.h
+++ b/gui/trusstablepanel.h
@@ -35,6 +35,8 @@ public:
     ~TrussTablePanel();
     void ReloadData(); // Refresh from ConfigManager
     void HighlightTruss(const std::string& uuid);
+    void HighlightTruss(const std::string& uuid,
+                        const std::vector<std::string>& relatedUuids);
     void ClearSelection();
     std::vector<std::string> GetSelectedUuids() const;
     void SelectByUuid(const std::vector<std::string>& uuids,
@@ -55,6 +57,7 @@ private:
     wxDataViewListCtrl* table;
     std::vector<wxString> columnLabels;
     std::vector<std::string> rowUuids;
+    std::vector<std::string> highlightedRelatedUuids;
     std::unordered_map<wxUIntPtr, std::string> rowUuidByKey;
     std::unordered_map<wxUIntPtr, wxString> modelPathByKey;
     std::unordered_map<wxUIntPtr, wxString> symbolPathByKey;

--- a/viewer3d/interfaces/irendercontext.h
+++ b/viewer3d/interfaces/irendercontext.h
@@ -13,6 +13,7 @@ public:
   virtual bool SkipOutlinesForCurrentFrame() const = 0;
   virtual bool IsSelectionOutlineEnabled2D() const = 0;
   virtual bool IsUuidHighlighted(const std::string &uuid) const = 0;
+  virtual bool IsUuidGroupHighlighted(const std::string &uuid) const = 0;
   virtual bool IsUuidSelected(const std::string &uuid) const = 0;
   virtual bool IsCaptureOnly() const = 0;
   virtual ICanvas2D *GetCaptureCanvas() const = 0;

--- a/viewer3d/render/gl_primitive_renderer.cpp
+++ b/viewer3d/render/gl_primitive_renderer.cpp
@@ -18,10 +18,13 @@
 namespace GLPrimitiveRenderer {
 
 namespace {
+constexpr float kPrimaryHighlightR = 0.78f;
+constexpr float kPrimaryHighlightG = 1.0f;
+constexpr float kPrimaryHighlightB = 0.0f;
 
-constexpr float kGroupHighlightR = 0.62f;
-constexpr float kGroupHighlightG = 0.90f;
-constexpr float kGroupHighlightB = 0.58f;
+constexpr float kGroupHighlightR = 0.25f;
+constexpr float kGroupHighlightG = 0.78f;
+constexpr float kGroupHighlightB = 0.55f;
 
 void DrawBoxEdges(float x0, float x1, float y0, float y1, float z0, float z1) {
   glBegin(GL_LINES);
@@ -182,7 +185,7 @@ void DrawWireframeBox(float length, float height, float width, float r, float g,
         float glowWidth = lineWidth + 3.0f;
         glLineWidth(glowWidth);
         if (highlight)
-          setColor(0.0f, 1.0f, 0.0f);
+          setColor(kPrimaryHighlightR, kPrimaryHighlightG, kPrimaryHighlightB);
         else if (groupHighlight)
           setColor(kGroupHighlightR, kGroupHighlightG, kGroupHighlightB);
         else if (selected)
@@ -217,7 +220,7 @@ void DrawWireframeBox(float length, float height, float width, float r, float g,
     return;
   } else if (!captureOnly) {
     if (highlight)
-      setColor(0.0f, 1.0f, 0.0f);
+      setColor(kPrimaryHighlightR, kPrimaryHighlightG, kPrimaryHighlightB);
     else if (groupHighlight)
       setColor(kGroupHighlightR, kGroupHighlightG, kGroupHighlightB);
     else if (selected)
@@ -229,7 +232,7 @@ void DrawWireframeBox(float length, float height, float width, float r, float g,
   CanvasStroke stroke;
   stroke.width = 1.0f;
   if (highlight)
-    stroke.color = {0.0f, 1.0f, 0.0f, 1.0f};
+    stroke.color = {kPrimaryHighlightR, kPrimaryHighlightG, kPrimaryHighlightB, 1.0f};
   else if (groupHighlight)
     stroke.color = {kGroupHighlightR, kGroupHighlightG, kGroupHighlightB, 1.0f};
   else if (selected)
@@ -260,7 +263,8 @@ void DrawCubeWithOutline(
       if (!captureOnly && drawOutline) {
         float glowWidth = baseWidth + 3.0f;
         if (highlight)
-          DrawWireframeCube(size, 0.0f, 1.0f, 0.0f, mode, captureTransform,
+          DrawWireframeCube(size, kPrimaryHighlightR, kPrimaryHighlightG,
+                            kPrimaryHighlightB, mode, captureTransform,
                             lineWidth, glowWidth, false, captureOnly,
                             captureCanvas, setColor, recordLine);
         else if (groupHighlight)
@@ -284,9 +288,10 @@ void DrawCubeWithOutline(
     if (!captureOnly && drawOutline) {
       float glowWidth = baseWidth + 3.0f;
       if (highlight)
-        DrawWireframeCube(size, 0.0f, 1.0f, 0.0f, mode, captureTransform,
-                          lineWidth, glowWidth, false, captureOnly,
-                          captureCanvas, setColor, recordLine);
+        DrawWireframeCube(size, kPrimaryHighlightR, kPrimaryHighlightG,
+                          kPrimaryHighlightB, mode, captureTransform, lineWidth,
+                          glowWidth, false, captureOnly, captureCanvas,
+                          setColor, recordLine);
       else if (groupHighlight)
         DrawWireframeCube(size, kGroupHighlightR, kGroupHighlightG,
                           kGroupHighlightB, mode, captureTransform, lineWidth,
@@ -338,7 +343,8 @@ void DrawCubeWithOutline(
   }
 
   if (highlight)
-    DrawCube(size, 0.0f, 1.0f, 0.0f, captureOnly, setColor);
+    DrawCube(size, kPrimaryHighlightR, kPrimaryHighlightG, kPrimaryHighlightB,
+             captureOnly, setColor);
   else if (groupHighlight)
     DrawCube(size, kGroupHighlightR, kGroupHighlightG, kGroupHighlightB,
              captureOnly, setColor);

--- a/viewer3d/render/gl_primitive_renderer.cpp
+++ b/viewer3d/render/gl_primitive_renderer.cpp
@@ -19,6 +19,10 @@ namespace GLPrimitiveRenderer {
 
 namespace {
 
+constexpr float kGroupHighlightR = 0.62f;
+constexpr float kGroupHighlightG = 0.90f;
+constexpr float kGroupHighlightB = 0.58f;
+
 void DrawBoxEdges(float x0, float x1, float y0, float y1, float z0, float z1) {
   glBegin(GL_LINES);
   glVertex3f(x0, y0, z0);
@@ -180,7 +184,7 @@ void DrawWireframeBox(float length, float height, float width, float r, float g,
         if (highlight)
           setColor(0.0f, 1.0f, 0.0f);
         else if (groupHighlight)
-          setColor(0.45f, 1.0f, 0.35f);
+          setColor(kGroupHighlightR, kGroupHighlightG, kGroupHighlightB);
         else if (selected)
           setColor(0.0f, 1.0f, 1.0f);
         DrawBoxEdges(x0, x1, y0, y1, z0, z1);
@@ -215,7 +219,7 @@ void DrawWireframeBox(float length, float height, float width, float r, float g,
     if (highlight)
       setColor(0.0f, 1.0f, 0.0f);
     else if (groupHighlight)
-      setColor(0.45f, 1.0f, 0.35f);
+      setColor(kGroupHighlightR, kGroupHighlightG, kGroupHighlightB);
     else if (selected)
       setColor(0.0f, 1.0f, 1.0f);
     else
@@ -227,7 +231,7 @@ void DrawWireframeBox(float length, float height, float width, float r, float g,
   if (highlight)
     stroke.color = {0.0f, 1.0f, 0.0f, 1.0f};
   else if (groupHighlight)
-    stroke.color = {0.45f, 1.0f, 0.35f, 1.0f};
+    stroke.color = {kGroupHighlightR, kGroupHighlightG, kGroupHighlightB, 1.0f};
   else if (selected)
     stroke.color = {0.0f, 1.0f, 1.0f, 1.0f};
   else
@@ -260,9 +264,10 @@ void DrawCubeWithOutline(
                             lineWidth, glowWidth, false, captureOnly,
                             captureCanvas, setColor, recordLine);
         else if (groupHighlight)
-          DrawWireframeCube(size, 0.45f, 1.0f, 0.35f, mode, captureTransform,
-                            lineWidth, glowWidth, false, captureOnly,
-                            captureCanvas, setColor, recordLine);
+          DrawWireframeCube(size, kGroupHighlightR, kGroupHighlightG,
+                            kGroupHighlightB, mode, captureTransform, lineWidth,
+                            glowWidth, false, captureOnly, captureCanvas,
+                            setColor, recordLine);
         else if (selected)
           DrawWireframeCube(size, 0.0f, 1.0f, 1.0f, mode, captureTransform,
                             lineWidth, glowWidth, false, captureOnly,
@@ -283,9 +288,10 @@ void DrawCubeWithOutline(
                           lineWidth, glowWidth, false, captureOnly,
                           captureCanvas, setColor, recordLine);
       else if (groupHighlight)
-        DrawWireframeCube(size, 0.45f, 1.0f, 0.35f, mode, captureTransform,
-                          lineWidth, glowWidth, false, captureOnly,
-                          captureCanvas, setColor, recordLine);
+        DrawWireframeCube(size, kGroupHighlightR, kGroupHighlightG,
+                          kGroupHighlightB, mode, captureTransform, lineWidth,
+                          glowWidth, false, captureOnly, captureCanvas,
+                          setColor, recordLine);
       else if (selected)
         DrawWireframeCube(size, 0.0f, 1.0f, 1.0f, mode, captureTransform,
                           lineWidth, glowWidth, false, captureOnly,
@@ -334,7 +340,8 @@ void DrawCubeWithOutline(
   if (highlight)
     DrawCube(size, 0.0f, 1.0f, 0.0f, captureOnly, setColor);
   else if (groupHighlight)
-    DrawCube(size, 0.45f, 1.0f, 0.35f, captureOnly, setColor);
+    DrawCube(size, kGroupHighlightR, kGroupHighlightG, kGroupHighlightB,
+             captureOnly, setColor);
   else if (selected)
     DrawCube(size, 0.0f, 1.0f, 1.0f, captureOnly, setColor);
   else

--- a/viewer3d/render/gl_primitive_renderer.cpp
+++ b/viewer3d/render/gl_primitive_renderer.cpp
@@ -50,11 +50,11 @@ void DrawBoxEdges(float x0, float x1, float y0, float y1, float z0, float z1) {
 
 void RecordBoxEdges(float x0, float x1, float y0, float y1, float z0, float z1,
                     const CaptureTransform &captureTransform,
-                    const CanvasStroke &stroke, const RecordLineFn &recordLine) {
-  std::vector<std::array<float, 3>> verts = {{x0, y0, z0}, {x1, y0, z0},
-                                             {x0, y1, z0}, {x1, y1, z0},
-                                             {x0, y0, z1}, {x1, y0, z1},
-                                             {x0, y1, z1}, {x1, y1, z1}};
+                    const CanvasStroke &stroke,
+                    const RecordLineFn &recordLine) {
+  std::vector<std::array<float, 3>> verts = {
+      {x0, y0, z0}, {x1, y0, z0}, {x0, y1, z0}, {x1, y1, z0},
+      {x0, y0, z1}, {x1, y0, z1}, {x0, y1, z1}, {x1, y1, z1}};
   if (captureTransform) {
     for (auto &p : verts)
       p = captureTransform(p);
@@ -134,7 +134,8 @@ void DrawWireframeCube(float size, float r, float g, float b,
   stroke.color = {r, g, b, 1.0f};
   stroke.width = lineWidth;
   if (captureCanvas && recordCapture)
-    RecordBoxEdges(x0, x1, y0, y1, z0, z1, captureTransform, stroke, recordLine);
+    RecordBoxEdges(x0, x1, y0, y1, z0, z1, captureTransform, stroke,
+                   recordLine);
 
   glLineWidth(1.0f);
   if (mode != Viewer2DRenderMode::Wireframe) {
@@ -152,8 +153,8 @@ void DrawWireframeCube(float size, float r, float g, float b,
 }
 
 void DrawWireframeBox(float length, float height, float width, float r, float g,
-                      float b, bool highlight, bool selected, bool wireframe,
-                      Viewer2DRenderMode mode,
+                      float b, bool highlight, bool groupHighlight,
+                      bool selected, bool wireframe, Viewer2DRenderMode mode,
                       const CaptureTransform &captureTransform,
                       bool skipOutlinesForCurrentFrame,
                       bool showSelectionOutline2D, bool captureOnly,
@@ -170,13 +171,16 @@ void DrawWireframeBox(float length, float height, float width, float r, float g,
     const float strokeG = useWireframeModeColor ? g : 0.0f;
     const float strokeB = useWireframeModeColor ? b : 0.0f;
     const bool drawOutline = !skipOutlinesForCurrentFrame &&
-                             showSelectionOutline2D && (highlight || selected);
+                             showSelectionOutline2D &&
+                             (highlight || groupHighlight || selected);
     if (!captureOnly) {
       if (drawOutline) {
         float glowWidth = lineWidth + 3.0f;
         glLineWidth(glowWidth);
         if (highlight)
           setColor(0.0f, 1.0f, 0.0f);
+        else if (groupHighlight)
+          setColor(0.45f, 1.0f, 0.35f);
         else if (selected)
           setColor(0.0f, 1.0f, 1.0f);
         DrawBoxEdges(x0, x1, y0, y1, z0, z1);
@@ -210,6 +214,8 @@ void DrawWireframeBox(float length, float height, float width, float r, float g,
   } else if (!captureOnly) {
     if (highlight)
       setColor(0.0f, 1.0f, 0.0f);
+    else if (groupHighlight)
+      setColor(0.45f, 1.0f, 0.35f);
     else if (selected)
       setColor(0.0f, 1.0f, 1.0f);
     else
@@ -220,6 +226,8 @@ void DrawWireframeBox(float length, float height, float width, float r, float g,
   stroke.width = 1.0f;
   if (highlight)
     stroke.color = {0.0f, 1.0f, 0.0f, 1.0f};
+  else if (groupHighlight)
+    stroke.color = {0.45f, 1.0f, 0.35f, 1.0f};
   else if (selected)
     stroke.color = {0.0f, 1.0f, 1.0f, 1.0f};
   else
@@ -232,20 +240,18 @@ void DrawWireframeBox(float length, float height, float width, float r, float g,
                    recordLine);
 }
 
-void DrawCubeWithOutline(float size, float r, float g, float b, bool highlight,
-                         bool selected, bool wireframe,
-                         Viewer2DRenderMode mode,
-                         const CaptureTransform &captureTransform,
-                         bool skipOutlinesForCurrentFrame,
-                         bool showSelectionOutline2D, bool captureOnly,
-                         bool captureCanvas, float lineWidth,
-                         const SetColorFn &setColor,
-                         const RecordLineFn &recordLine,
-                         const RecordPolygonFn &recordPolygon) {
+void DrawCubeWithOutline(
+    float size, float r, float g, float b, bool highlight, bool groupHighlight,
+    bool selected, bool wireframe, Viewer2DRenderMode mode,
+    const CaptureTransform &captureTransform, bool skipOutlinesForCurrentFrame,
+    bool showSelectionOutline2D, bool captureOnly, bool captureCanvas,
+    float lineWidth, const SetColorFn &setColor, const RecordLineFn &recordLine,
+    const RecordPolygonFn &recordPolygon) {
   if (wireframe) {
     if (mode == Viewer2DRenderMode::Wireframe) {
       const bool drawOutline = !skipOutlinesForCurrentFrame &&
-                               showSelectionOutline2D && (highlight || selected);
+                               showSelectionOutline2D &&
+                               (highlight || groupHighlight || selected);
       float baseWidth = 1.0f;
       if (!captureOnly && drawOutline) {
         float glowWidth = baseWidth + 3.0f;
@@ -253,23 +259,31 @@ void DrawCubeWithOutline(float size, float r, float g, float b, bool highlight,
           DrawWireframeCube(size, 0.0f, 1.0f, 0.0f, mode, captureTransform,
                             lineWidth, glowWidth, false, captureOnly,
                             captureCanvas, setColor, recordLine);
+        else if (groupHighlight)
+          DrawWireframeCube(size, 0.45f, 1.0f, 0.35f, mode, captureTransform,
+                            lineWidth, glowWidth, false, captureOnly,
+                            captureCanvas, setColor, recordLine);
         else if (selected)
           DrawWireframeCube(size, 0.0f, 1.0f, 1.0f, mode, captureTransform,
                             lineWidth, glowWidth, false, captureOnly,
                             captureCanvas, setColor, recordLine);
       }
-      DrawWireframeCube(size, r, g, b, mode, captureTransform,
-                        lineWidth, -1.0f, true, captureOnly, captureCanvas,
-                        setColor, recordLine);
+      DrawWireframeCube(size, r, g, b, mode, captureTransform, lineWidth, -1.0f,
+                        true, captureOnly, captureCanvas, setColor, recordLine);
       return;
     }
     const bool drawOutline = !skipOutlinesForCurrentFrame &&
-                             showSelectionOutline2D && (highlight || selected);
+                             showSelectionOutline2D &&
+                             (highlight || groupHighlight || selected);
     float baseWidth = 2.0f;
     if (!captureOnly && drawOutline) {
       float glowWidth = baseWidth + 3.0f;
       if (highlight)
         DrawWireframeCube(size, 0.0f, 1.0f, 0.0f, mode, captureTransform,
+                          lineWidth, glowWidth, false, captureOnly,
+                          captureCanvas, setColor, recordLine);
+      else if (groupHighlight)
+        DrawWireframeCube(size, 0.45f, 1.0f, 0.35f, mode, captureTransform,
                           lineWidth, glowWidth, false, captureOnly,
                           captureCanvas, setColor, recordLine);
       else if (selected)
@@ -319,6 +333,8 @@ void DrawCubeWithOutline(float size, float r, float g, float b, bool highlight,
 
   if (highlight)
     DrawCube(size, 0.0f, 1.0f, 0.0f, captureOnly, setColor);
+  else if (groupHighlight)
+    DrawCube(size, 0.45f, 1.0f, 0.35f, captureOnly, setColor);
   else if (selected)
     DrawCube(size, 0.0f, 1.0f, 1.0f, captureOnly, setColor);
   else

--- a/viewer3d/render/gl_primitive_renderer.h
+++ b/viewer3d/render/gl_primitive_renderer.h
@@ -12,25 +12,27 @@ namespace GLPrimitiveRenderer {
 using CaptureTransform =
     std::function<std::array<float, 3>(const std::array<float, 3> &)>;
 using SetColorFn = std::function<void(float, float, float)>;
-using RecordLineFn = std::function<void(const std::array<float, 3> &,
-                                        const std::array<float, 3> &,
-                                        const CanvasStroke &)>;
-using RecordPolygonFn = std::function<void(
-    const std::vector<std::array<float, 3>> &, const CanvasStroke &,
-    const CanvasFill *)>;
+using RecordLineFn =
+    std::function<void(const std::array<float, 3> &,
+                       const std::array<float, 3> &, const CanvasStroke &)>;
+using RecordPolygonFn =
+    std::function<void(const std::vector<std::array<float, 3>> &,
+                       const CanvasStroke &, const CanvasFill *)>;
 
 void DrawCube(float size, float r, float g, float b, bool captureOnly,
               const SetColorFn &setColor);
 
 void DrawWireframeCube(float size, float r, float g, float b,
-                       Viewer2DRenderMode mode, const CaptureTransform &captureTransform,
+                       Viewer2DRenderMode mode,
+                       const CaptureTransform &captureTransform,
                        float lineWidth, float lineWidthOverride,
                        bool recordCapture, bool captureOnly, bool captureCanvas,
-                       const SetColorFn &setColor, const RecordLineFn &recordLine);
+                       const SetColorFn &setColor,
+                       const RecordLineFn &recordLine);
 
 void DrawWireframeBox(float length, float height, float width, float r, float g,
-                      float b, bool highlight, bool selected, bool wireframe,
-                      Viewer2DRenderMode mode,
+                      float b, bool highlight, bool groupHighlight,
+                      bool selected, bool wireframe, Viewer2DRenderMode mode,
                       const CaptureTransform &captureTransform,
                       bool skipOutlinesForCurrentFrame,
                       bool showSelectionOutline2D, bool captureOnly,
@@ -38,15 +40,12 @@ void DrawWireframeBox(float length, float height, float width, float r, float g,
                       const SetColorFn &setColor,
                       const RecordLineFn &recordLine);
 
-void DrawCubeWithOutline(float size, float r, float g, float b, bool highlight,
-                         bool selected, bool wireframe,
-                         Viewer2DRenderMode mode,
-                         const CaptureTransform &captureTransform,
-                         bool skipOutlinesForCurrentFrame,
-                         bool showSelectionOutline2D, bool captureOnly,
-                         bool captureCanvas, float lineWidth,
-                         const SetColorFn &setColor,
-                         const RecordLineFn &recordLine,
-                         const RecordPolygonFn &recordPolygon);
+void DrawCubeWithOutline(
+    float size, float r, float g, float b, bool highlight, bool groupHighlight,
+    bool selected, bool wireframe, Viewer2DRenderMode mode,
+    const CaptureTransform &captureTransform, bool skipOutlinesForCurrentFrame,
+    bool showSelectionOutline2D, bool captureOnly, bool captureCanvas,
+    float lineWidth, const SetColorFn &setColor, const RecordLineFn &recordLine,
+    const RecordPolygonFn &recordPolygon);
 
 } // namespace GLPrimitiveRenderer

--- a/viewer3d/render/hoist_symbol_renderer.cpp
+++ b/viewer3d/render/hoist_symbol_renderer.cpp
@@ -171,7 +171,8 @@ void DrawOutlineLoop(IRenderContext &renderContext,
   stroke.width = lineWidth;
   stroke.color = {color.r, color.g, color.b, 1.0f};
   for (size_t i = 0; i < points.size(); ++i)
-    renderContext.RecordLine(points[i], points[(i + 1) % points.size()], stroke);
+    renderContext.RecordLine(points[i], points[(i + 1) % points.size()],
+                             stroke);
 }
 
 void DrawSegment(IRenderContext &renderContext, const std::array<float, 3> &a,
@@ -251,10 +252,10 @@ void DrawCircleSymbol(IRenderContext &renderContext, float cx, float cy,
   std::vector<std::array<float, 3>> ring;
   ring.reserve(static_cast<size_t>(kSegments));
   for (int i = 0; i < kSegments; ++i) {
-    const float t = 2.0f * kPi *
-                    (static_cast<float>(i) / static_cast<float>(kSegments));
-    ring.push_back(
-        MakePoint(cx + std::cos(t) * kHalfSizeMeters, cy + std::sin(t) * kHalfSizeMeters, z));
+    const float t =
+        2.0f * kPi * (static_cast<float>(i) / static_cast<float>(kSegments));
+    ring.push_back(MakePoint(cx + std::cos(t) * kHalfSizeMeters,
+                             cy + std::sin(t) * kHalfSizeMeters, z));
   }
 
   constexpr int kQuarterSegments = 11;
@@ -262,8 +263,8 @@ void DrawCircleSymbol(IRenderContext &renderContext, float cx, float cy,
   topRight.reserve(static_cast<size_t>(kQuarterSegments + 2));
   topRight.push_back(MakePoint(cx, cy, z));
   for (int i = 0; i <= kQuarterSegments; ++i) {
-    const float t = static_cast<float>(i) / static_cast<float>(kQuarterSegments) *
-                    (kPi * 0.5f);
+    const float t = static_cast<float>(i) /
+                    static_cast<float>(kQuarterSegments) * (kPi * 0.5f);
     topRight.push_back(MakePoint(cx + std::cos(t) * kHalfSizeMeters,
                                  cy + std::sin(t) * kHalfSizeMeters, z));
   }
@@ -272,9 +273,9 @@ void DrawCircleSymbol(IRenderContext &renderContext, float cx, float cy,
   bottomLeft.reserve(static_cast<size_t>(kQuarterSegments + 2));
   bottomLeft.push_back(MakePoint(cx, cy, z));
   for (int i = 0; i <= kQuarterSegments; ++i) {
-    const float t = kPi +
-                    static_cast<float>(i) / static_cast<float>(kQuarterSegments) *
-                        (kPi * 0.5f);
+    const float t = kPi + static_cast<float>(i) /
+                              static_cast<float>(kQuarterSegments) *
+                              (kPi * 0.5f);
     bottomLeft.push_back(MakePoint(cx + std::cos(t) * kHalfSizeMeters,
                                    cy + std::sin(t) * kHalfSizeMeters, z));
   }
@@ -317,7 +318,8 @@ void DrawTriangleSymbol(IRenderContext &renderContext, float cx, float cy,
   DrawFillPolygon(renderContext, {top, rightCross, center}, color);
   DrawFillPolygon(renderContext, {leftCross, left, baseMid, center}, color);
 
-  DrawOutlineLoop(renderContext, {top, right, left}, outlineColor, outlineWidth);
+  DrawOutlineLoop(renderContext, {top, right, left}, outlineColor,
+                  outlineWidth);
   DrawSegment(renderContext, leftCross, rightCross, outlineColor, outlineWidth);
   DrawSegment(renderContext, top, baseMid, outlineColor, outlineWidth);
 }
@@ -326,8 +328,8 @@ void DrawPentagonSymbol(IRenderContext &renderContext, float cx, float cy,
                         float z, const RgbColor &color,
                         const RgbColor &outlineColor, float outlineWidth) {
   const auto top = MakePoint(cx, cy + kHalfSizeMeters, z);
-  const auto rightTop = MakePoint(cx + kHalfSizeMeters * 0.85f,
-                                  cy + kHalfSizeMeters * 0.25f, z);
+  const auto rightTop =
+      MakePoint(cx + kHalfSizeMeters * 0.85f, cy + kHalfSizeMeters * 0.25f, z);
   const auto rightBottom =
       MakePoint(cx + kHalfSizeMeters * 0.55f, cy - kHalfSizeMeters, z);
   const auto leftBottom =
@@ -335,9 +337,8 @@ void DrawPentagonSymbol(IRenderContext &renderContext, float cx, float cy,
   const auto leftTop =
       MakePoint(cx - kHalfSizeMeters * 0.85f, cy + kHalfSizeMeters * 0.25f, z);
   const auto center = MakePoint(cx, cy - kHalfSizeMeters * 0.15f, z);
-  const auto bottomMid =
-      MakePoint((leftBottom[0] + rightBottom[0]) * 0.5f,
-                (leftBottom[1] + rightBottom[1]) * 0.5f, z);
+  const auto bottomMid = MakePoint((leftBottom[0] + rightBottom[0]) * 0.5f,
+                                   (leftBottom[1] + rightBottom[1]) * 0.5f, z);
 
   const auto pointOnEdgeAtY = [z](const std::array<float, 3> &a,
                                   const std::array<float, 3> &b, float y) {
@@ -350,10 +351,12 @@ void DrawPentagonSymbol(IRenderContext &renderContext, float cx, float cy,
   const auto leftCross = pointOnEdgeAtY(leftTop, leftBottom, center[1]);
   const auto rightCross = pointOnEdgeAtY(rightTop, rightBottom, center[1]);
 
-  DrawFillPolygon(renderContext, {top, rightTop, rightBottom, leftBottom, leftTop},
+  DrawFillPolygon(renderContext,
+                  {top, rightTop, rightBottom, leftBottom, leftTop},
                   WhiteColor());
   DrawFillPolygon(renderContext, {top, rightTop, rightCross, center}, color);
-  DrawFillPolygon(renderContext, {leftCross, leftBottom, bottomMid, center}, color);
+  DrawFillPolygon(renderContext, {leftCross, leftBottom, bottomMid, center},
+                  color);
 
   DrawOutlineLoop(renderContext,
                   {top, rightTop, rightBottom, leftBottom, leftTop},
@@ -409,18 +412,19 @@ void Render(IRenderContext &renderContext, const RenderFrameContext &context) {
       continue;
 
     const RgbColor color = ResolveHoistLayerColor(scene, support);
-    const bool isHighlighted = renderContext.IsUuidHighlighted(uuid);
+    const bool isHighlighted = renderContext.IsUuidHighlighted(uuid) ||
+                               renderContext.IsUuidGroupHighlighted(uuid);
     const bool isSelected = renderContext.IsUuidSelected(uuid);
     const bool useOutlineColors =
         context.is2DViewer && renderContext.IsSelectionOutlineEnabled2D();
     const RgbColor outlineColor =
-        useOutlineColors ? (isHighlighted ? HighlightColor()
-                                          : (isSelected ? SelectedColor() : color))
-                         : color;
-    const float outlineWidth =
-        useOutlineColors && (isHighlighted || isSelected)
-            ? kSelectionLineWidth
-            : kLineWidth;
+        useOutlineColors
+            ? (isHighlighted ? HighlightColor()
+                             : (isSelected ? SelectedColor() : color))
+            : color;
+    const float outlineWidth = useOutlineColors && (isHighlighted || isSelected)
+                                   ? kSelectionLineWidth
+                                   : kLineWidth;
 
     DrawHoistSymbol(renderContext, support, color, outlineColor, outlineWidth);
   }

--- a/viewer3d/render/hoist_symbol_renderer.cpp
+++ b/viewer3d/render/hoist_symbol_renderer.cpp
@@ -127,6 +127,8 @@ std::array<float, 3> MakePoint(float x, float y, float z) { return {x, y, z}; }
 
 RgbColor WhiteColor() { return {1.0f, 1.0f, 1.0f}; }
 RgbColor HighlightColor() { return {0.0f, 1.0f, 0.0f}; }
+// Returns the softer highlight color used for grouped hover siblings.
+RgbColor GroupHighlightColor() { return {0.62f, 0.90f, 0.58f}; }
 RgbColor SelectedColor() { return {0.0f, 1.0f, 1.0f}; }
 
 void DrawFillPolygon(IRenderContext &renderContext,
@@ -412,19 +414,23 @@ void Render(IRenderContext &renderContext, const RenderFrameContext &context) {
       continue;
 
     const RgbColor color = ResolveHoistLayerColor(scene, support);
-    const bool isHighlighted = renderContext.IsUuidHighlighted(uuid) ||
-                               renderContext.IsUuidGroupHighlighted(uuid);
+    const bool isHighlighted = renderContext.IsUuidHighlighted(uuid);
+    const bool isGroupHighlighted = renderContext.IsUuidGroupHighlighted(uuid);
     const bool isSelected = renderContext.IsUuidSelected(uuid);
     const bool useOutlineColors =
         context.is2DViewer && renderContext.IsSelectionOutlineEnabled2D();
     const RgbColor outlineColor =
         useOutlineColors
-            ? (isHighlighted ? HighlightColor()
-                             : (isSelected ? SelectedColor() : color))
+            ? (isHighlighted
+                   ? HighlightColor()
+                   : (isGroupHighlighted
+                          ? GroupHighlightColor()
+                          : (isSelected ? SelectedColor() : color)))
             : color;
-    const float outlineWidth = useOutlineColors && (isHighlighted || isSelected)
-                                   ? kSelectionLineWidth
-                                   : kLineWidth;
+    const float outlineWidth =
+        useOutlineColors && (isHighlighted || isGroupHighlighted || isSelected)
+            ? kSelectionLineWidth
+            : kLineWidth;
 
     DrawHoistSymbol(renderContext, support, color, outlineColor, outlineWidth);
   }

--- a/viewer3d/render/hoist_symbol_renderer.cpp
+++ b/viewer3d/render/hoist_symbol_renderer.cpp
@@ -126,9 +126,9 @@ HoistShape ResolveHoistShape(float capacityKg) {
 std::array<float, 3> MakePoint(float x, float y, float z) { return {x, y, z}; }
 
 RgbColor WhiteColor() { return {1.0f, 1.0f, 1.0f}; }
-RgbColor HighlightColor() { return {0.0f, 1.0f, 0.0f}; }
+RgbColor HighlightColor() { return {0.78f, 1.0f, 0.0f}; }
 // Returns the softer highlight color used for grouped hover siblings.
-RgbColor GroupHighlightColor() { return {0.62f, 0.90f, 0.58f}; }
+RgbColor GroupHighlightColor() { return {0.25f, 0.78f, 0.55f}; }
 RgbColor SelectedColor() { return {0.0f, 1.0f, 1.0f}; }
 
 void DrawFillPolygon(IRenderContext &renderContext,

--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -26,18 +26,18 @@
 #include <unordered_map>
 #include <vector>
 
-#include "matrixutils.h"
 #include "configmanager.h"
+#include "fixture_mesh_color.h"
+#include "gdtfloader.h"
 #include "logger.h"
+#include "matrixutils.h"
 #include "mesh.h"
 #include "opaque_pass_utils.h"
-#include "universe_color.h"
 #include "perastage_svg_symbol_builder.h"
 #include "scenedatamanager.h"
 #include "symbols/PerastageSvgSymbol.h"
+#include "universe_color.h"
 #include "viewer3dcontroller.h"
-#include "gdtfloader.h"
-#include "fixture_mesh_color.h"
 #include <meshoptimizer.h>
 
 namespace {
@@ -120,7 +120,8 @@ uint32_t BuildFixtureSymbolStyleVersion(float r, float g, float b) {
   return 0x1000000u | (toByte(r) << 16) | (toByte(g) << 8) | toByte(b);
 }
 
-std::vector<SymbolViewKind> BuildSymbolViewCandidates(SymbolViewKind requested) {
+std::vector<SymbolViewKind>
+BuildSymbolViewCandidates(SymbolViewKind requested) {
   if (requested == SymbolViewKind::Top)
     return {SymbolViewKind::Top, SymbolViewKind::Bottom};
   if (requested == SymbolViewKind::Bottom)
@@ -177,29 +178,28 @@ const Mesh &ResolveMovingProxyMesh(const Mesh &source,
 
     const size_t indexCount = proxy.indices.size();
     const float proxyRatio = computeProxyRatio(sourceTriangleCount);
-    const size_t requestedTriangles =
-        static_cast<size_t>(static_cast<float>(sourceTriangleCount) * proxyRatio);
+    const size_t requestedTriangles = static_cast<size_t>(
+        static_cast<float>(sourceTriangleCount) * proxyRatio);
     const size_t targetTriangles = std::clamp(
-        requestedTriangles,
-        std::min(kProxyMinTriangles, sourceTriangleCount),
+        requestedTriangles, std::min(kProxyMinTriangles, sourceTriangleCount),
         std::min(kProxyMaxTriangles, sourceTriangleCount));
     const size_t targetIndexCount = std::max<size_t>(3, targetTriangles * 3);
 
     std::vector<uint32_t> simplified(indexCount);
-    size_t simplifiedCount = meshopt_simplify(
-        simplified.data(), proxy.indices.data(), indexCount, proxy.vertices.data(),
-        vertexCount, sizeof(float) * 3, targetIndexCount, kProxySimplifyError, 0,
-        nullptr);
-    const size_t acceptableUpperBound = std::max(
-        targetIndexCount + targetIndexCount / 4,
-        std::min(indexCount, indexCount * 4 / 5));
+    size_t simplifiedCount =
+        meshopt_simplify(simplified.data(), proxy.indices.data(), indexCount,
+                         proxy.vertices.data(), vertexCount, sizeof(float) * 3,
+                         targetIndexCount, kProxySimplifyError, 0, nullptr);
+    const size_t acceptableUpperBound =
+        std::max(targetIndexCount + targetIndexCount / 4,
+                 std::min(indexCount, indexCount * 4 / 5));
 
     // Some dense/non-manifold fixtures (often 32-bit/high-poly assets) can be
     // too constrained for a strict low-error pass. Escalate sloppy simplify
     // error in steps before using coarse subsampling to avoid odd artifacts.
     if (simplifiedCount < 3 || simplifiedCount > acceptableUpperBound) {
-      const std::vector<float> sloppyErrors = {kProxySimplifyError, 0.02f, 0.05f,
-                                               0.10f, 0.20f};
+      const std::vector<float> sloppyErrors = {kProxySimplifyError, 0.02f,
+                                               0.05f, 0.10f, 0.20f};
       std::vector<uint32_t> sloppyCandidate(indexCount);
       size_t bestCount = 0;
       std::vector<uint32_t> bestIndices;
@@ -235,8 +235,7 @@ const Mesh &ResolveMovingProxyMesh(const Mesh &source,
       // triangle subsample so every heavy fixture still gets a lighter proxy
       // while moving the camera.
       const size_t sourceTriangles = indexCount / 3;
-      const size_t targetTriangles =
-          std::max<size_t>(1, targetIndexCount / 3);
+      const size_t targetTriangles = std::max<size_t>(1, targetIndexCount / 3);
       simplified.clear();
       simplified.reserve(targetTriangles * 3);
       for (size_t t = 0; t < targetTriangles; ++t) {
@@ -294,8 +293,7 @@ void TessEndCallback(void *polygonData) {
 }
 
 void TessCombineCallback(GLdouble coords[3], void *vertexData[4],
-                                  GLfloat weight[4], void **outData,
-                                  void *polygonData) {
+                         GLfloat weight[4], void **outData, void *polygonData) {
   (void)vertexData;
   (void)weight;
   auto *context = static_cast<SvgTessellationContext *>(polygonData);
@@ -327,9 +325,8 @@ void AppendSvgContourVertices(std::vector<std::array<GLdouble, 3>> &storage,
 }
 
 void DrawSvgFilledPolygon(const PerastageSvgPolygon &polygon,
-                          const PerastageSvgSymbolData &svg,
-                          Viewer2DView view, double anchorX,
-                          double anchorY) {
+                          const PerastageSvgSymbolData &svg, Viewer2DView view,
+                          double anchorX, double anchorY) {
   if (polygon.points.size() < 3)
     return;
 
@@ -354,7 +351,8 @@ void DrawSvgFilledPolygon(const PerastageSvgPolygon &polygon,
   AppendSvgContourVertices(contourVertices, polygon.points, svg, view, anchorX,
                            anchorY);
   for (const auto &hole : polygon.holes)
-    AppendSvgContourVertices(contourVertices, hole, svg, view, anchorX, anchorY);
+    AppendSvgContourVertices(contourVertices, hole, svg, view, anchorX,
+                             anchorY);
 
   if (contourVertices.size() < polygon.points.size()) {
     gluDeleteTess(tess);
@@ -383,7 +381,8 @@ void DrawSvgFilledPolygon(const PerastageSvgPolygon &polygon,
   gluDeleteTess(tess);
 }
 
-std::array<float, 3> BuildSvgVertexForView(float x, float y, Viewer2DView view) {
+std::array<float, 3> BuildSvgVertexForView(float x, float y,
+                                           Viewer2DView view) {
   switch (view) {
   case Viewer2DView::Front:
     return {x, 0.0f, y};
@@ -470,10 +469,9 @@ bool DrawPerastageSvgInFixturePass(const PerastageSvgSymbolData &svg,
       continue;
     glBegin(GL_LINE_STRIP);
     for (const auto &point : line.points) {
-      const auto vertex =
-          BuildSvgVertexForView(static_cast<float>(point.x + svg.offsetXmm - anchorX),
-                                static_cast<float>(point.y + svg.offsetYmm - anchorY),
-                                view);
+      const auto vertex = BuildSvgVertexForView(
+          static_cast<float>(point.x + svg.offsetXmm - anchorX),
+          static_cast<float>(point.y + svg.offsetYmm - anchorY), view);
       glVertex3f(vertex[0], vertex[1], vertex[2]);
     }
     glEnd();
@@ -489,10 +487,22 @@ void CancelFixtureRotationForLayoutSvg(const Matrix &fixtureTransform,
     return;
 
   float inverseRotation[16] = {
-      fixtureTransform.u[0], fixtureTransform.v[0], fixtureTransform.w[0], 0.0f,
-      fixtureTransform.u[1], fixtureTransform.v[1], fixtureTransform.w[1], 0.0f,
-      fixtureTransform.u[2], fixtureTransform.v[2], fixtureTransform.w[2], 0.0f,
-      0.0f,                 0.0f,                 0.0f,                 1.0f,
+      fixtureTransform.u[0],
+      fixtureTransform.v[0],
+      fixtureTransform.w[0],
+      0.0f,
+      fixtureTransform.u[1],
+      fixtureTransform.v[1],
+      fixtureTransform.w[1],
+      0.0f,
+      fixtureTransform.u[2],
+      fixtureTransform.v[2],
+      fixtureTransform.w[2],
+      0.0f,
+      0.0f,
+      0.0f,
+      0.0f,
+      1.0f,
   };
   glMultMatrixf(inverseRotation);
 }
@@ -566,12 +576,14 @@ struct FixtureRenderMetrics {
   size_t fallbackDrawCalls = 0;
 };
 
-// Returns true only for fixture metric combinations that have not been logged before.
+// Returns true only for fixture metric combinations that have not been logged
+// before.
 bool ShouldLogFixtureRenderMetrics(const FixtureRenderMetrics &metrics) {
   using MetricsKey = std::array<size_t, 4>;
   static std::set<MetricsKey> loggedMetricKeys;
   const MetricsKey key = {metrics.instancedFixtures, metrics.fallbackFixtures,
-                          metrics.instancedDrawCalls, metrics.fallbackDrawCalls};
+                          metrics.instancedDrawCalls,
+                          metrics.fallbackDrawCalls};
   return loggedMetricKeys.insert(key).second;
 }
 
@@ -609,14 +621,18 @@ void AddFixtureInstancedDraw(FixtureInstancedBatches &batches, const Mesh &mesh,
 
 } // namespace
 
-// Renders visible fixtures using instanced paths when possible and fallback draws otherwise.
+// Renders visible fixtures using instanced paths when possible and fallback
+// draws otherwise.
 void OpaqueFixturePass::Render(
     Viewer3DController &controller, const RenderFrameContext &context,
     const Viewer3DVisibleSet &visibleSet,
-    const std::function<std::array<float, 3>(const std::string &, const std::string &)> &getTypeColor,
-    const std::function<std::array<float, 3>(const std::string &)> &getLayerColor,
+    const std::function<std::array<float, 3>(
+        const std::string &, const std::string &)> &getTypeColor,
+    const std::function<std::array<float, 3>(const std::string &)>
+        &getLayerColor,
     const std::function<SymbolViewKind(Viewer2DView)> &resolveSymbolView,
-    const std::function<std::array<float, 3>(const std::string &)> &getPickColor) {
+    const std::function<std::array<float, 3>(const std::string &)>
+        &getPickColor) {
   const auto &fixtures = SceneDataManager::Instance().GetFixtures();
   if (context.idOnlyPass) {
     glShadeModel(GL_FLAT);
@@ -638,7 +654,8 @@ void OpaqueFixturePass::Render(
       std::string gdtfPath;
       auto gdtfPathIt = controller.m_resourceSyncState.resolvedGdtfSpecs.find(
           ResolveCacheKey(fixture.gdtfSpec));
-      if (gdtfPathIt != controller.m_resourceSyncState.resolvedGdtfSpecs.end() &&
+      if (gdtfPathIt !=
+              controller.m_resourceSyncState.resolvedGdtfSpecs.end() &&
           gdtfPathIt->second.attempted)
         gdtfPath = gdtfPathIt->second.resolvedPath;
 
@@ -679,7 +696,8 @@ void OpaqueFixturePass::Render(
     forceBottomViewForTopFixtures =
         controller.GetForceBottomViewForTopFixturesOverride().value();
   }
-  const bool drawRealTopInTopView = isTopView2D && !forceBottomViewForTopFixtures;
+  const bool drawRealTopInTopView =
+      isTopView2D && !forceBottomViewForTopFixtures;
 
   glShadeModel((context.texturedStyle && !wireframe) ? GL_SMOOTH : GL_FLAT);
   // Keep 2D wireframe fixture overlays unchanged, but in the real 3D wireframe
@@ -709,8 +727,8 @@ void OpaqueFixturePass::Render(
             const float g = static_cast<float>((color >> 8) & 0xFFu) / 255.0f;
             const float b = static_cast<float>(color & 0xFFu) / 255.0f;
             controller.DrawMeshWithOutline(
-                *key.mesh, r, g, b, key.scale, false, false, draw.cx, draw.cy,
-                draw.cz, key.wireframe, key.mode,
+                *key.mesh, r, g, b, key.scale, false, false, false, draw.cx,
+                draw.cy, draw.cz, key.wireframe, key.mode,
                 [](const std::array<float, 3> &p) { return p; }, key.unlit,
                 draw.worldMatrix.data());
             glPopMatrix();
@@ -737,12 +755,15 @@ void OpaqueFixturePass::Render(
       controller.m_captureCanvas->SetSourceKey(fixtureCaptureKey);
     }
 
-    const bool highlight =
-        context.selectionOverlayPass && !controller.m_highlightUuid.empty() &&
-        uuid == controller.m_highlightUuid;
-    const bool selected = context.selectionOverlayPass &&
-                          controller.m_selectedUuids.find(uuid) !=
-                              controller.m_selectedUuids.end();
+    const bool highlight = context.selectionOverlayPass &&
+                           !controller.m_highlightUuid.empty() &&
+                           uuid == controller.m_highlightUuid;
+    const bool groupHighlight = context.selectionOverlayPass &&
+                                controller.m_groupHighlightUuids.find(uuid) !=
+                                    controller.m_groupHighlightUuids.end();
+    const bool selected =
+        context.selectionOverlayPass && controller.m_selectedUuids.find(uuid) !=
+                                            controller.m_selectedUuids.end();
 
     float matrix[16];
     MatrixToArray(f.transform, matrix);
@@ -807,9 +828,10 @@ void OpaqueFixturePass::Render(
     fixtureTransform.o[1] *= RENDER_SCALE;
     fixtureTransform.o[2] *= RENDER_SCALE;
 
-    auto applyFixtureCapture = [fixtureTransform](const std::array<float, 3> &p) {
-      return TransformPoint(fixtureTransform, p);
-    };
+    auto applyFixtureCapture =
+        [fixtureTransform](const std::array<float, 3> &p) {
+          return TransformPoint(fixtureTransform, p);
+        };
 
     const std::string normalizedGdtfPath = NormalizeModelKeyPath(gdtfPath);
     const std::string modelKey =
@@ -819,10 +841,11 @@ void OpaqueFixturePass::Render(
     auto itg = controller.m_resourceSyncState.loadedGdtf.find(gdtfPath);
 
     bool renderedPerastageSvg = false;
-    const bool captureRecordingActive = controller.m_captureCanvas && !skipCapture;
-    const bool preferLayoutSvg =
-        context.preferPerastageSvgSymbolsForLayouts && is2DViewer &&
-        !captureRecordingActive && mode != Viewer2DRenderMode::Wireframe;
+    const bool captureRecordingActive =
+        controller.m_captureCanvas && !skipCapture;
+    const bool preferLayoutSvg = context.preferPerastageSvgSymbolsForLayouts &&
+                                 is2DViewer && !captureRecordingActive &&
+                                 mode != Viewer2DRenderMode::Wireframe;
     if (preferLayoutSvg && !svgSourcePath.empty()) {
       const Viewer2DView fixtureView =
           isTopView2D && forceBottomViewForTopFixtures ? Viewer2DView::Bottom
@@ -838,7 +861,8 @@ void OpaqueFixturePass::Render(
           PerastageSvgSymbolData svg;
           if (LoadPerastageSvgSymbolFromGdtf(svgSourcePath, candidateView, svg))
             loaded = std::move(svg);
-          cacheIt = perastageSvgCache.emplace(cacheKey, std::move(loaded)).first;
+          cacheIt =
+              perastageSvgCache.emplace(cacheKey, std::move(loaded)).first;
         }
         if (!cacheIt->second.has_value())
           continue;
@@ -856,8 +880,8 @@ void OpaqueFixturePass::Render(
           controller.m_captureView == Viewer2DView::Top ||
           controller.m_captureView == Viewer2DView::Front ||
           controller.m_captureView == Viewer2DView::Side) &&
-         mode != Viewer2DRenderMode::Wireframe &&
-         !highlight && !selected);
+         mode != Viewer2DRenderMode::Wireframe && !highlight &&
+         !groupHighlight && !selected);
     bool placedSymbolInstance = false;
     if (useSymbolInstancing && controller.m_captureCanvas && !skipCapture) {
       if (!modelKey.empty()) {
@@ -871,16 +895,13 @@ void OpaqueFixturePass::Render(
         symbolKey.viewKind = resolveSymbolView(fixtureCaptureView);
         symbolKey.styleVersion = BuildFixtureSymbolStyleVersion(r, g, b);
 
-        const auto &symbol =
-            controller.m_bottomSymbolCache.GetOrCreate(symbolKey, [&](const SymbolKey &,
-                                                         uint32_t symbolId) {
+        const auto &symbol = controller.m_bottomSymbolCache.GetOrCreate(
+            symbolKey, [&](const SymbolKey &, uint32_t symbolId) {
               SymbolDefinition svgDefinition{};
               if (!svgSourcePath.empty() &&
-                  TryBuildPerastageSvgSymbolDefinition(svgSourcePath,
-                                                       symbolKey.viewKind,
-                                                       symbolId,
-                                                       {r, g, b},
-                                                       svgDefinition)) {
+                  TryBuildPerastageSvgSymbolDefinition(
+                      svgSourcePath, symbolKey.viewKind, symbolId, {r, g, b},
+                      svgDefinition)) {
                 return svgDefinition;
               }
 
@@ -926,18 +947,18 @@ void OpaqueFixturePass::Render(
                   }
                   controller.DrawMeshWithOutline(
                       obj.mesh, partR, partG, partB, RENDER_SCALE, false, false,
-                      0.0f, 0.0f, 0.0f, wireframe, mode, applyCapture, false);
+                      false, 0.0f, 0.0f, 0.0f, wireframe, mode, applyCapture,
+                      false);
                 }
               } else {
                 controller.m_captureCanvas->SetSourceKey(fixtureCaptureKey);
-                const bool fallbackWireframe =
-                    wireframe;
+                const bool fallbackWireframe = wireframe;
                 const bool fallbackUnlit =
                     context.whiteModelStyle &&
                     !controller.IsSketchRenderStyleEnabled();
                 controller.DrawMeshWithOutline(
                     FallbackFixtureCubeMesh(), r, g, b, 0.2f, false, false,
-                    0.0f, 0.0f, 0.0f, fallbackWireframe, mode,
+                    false, 0.0f, 0.0f, 0.0f, fallbackWireframe, mode,
                     [](const std::array<float, 3> &p) { return p; },
                     fallbackUnlit);
               }
@@ -984,15 +1005,15 @@ void OpaqueFixturePass::Render(
           float m2[16];
           MatrixToArray(obj.transform, m2);
           controller.ApplyTransform(m2, false);
-          Matrix worldMatrix = MatrixUtils::Multiply(f.transform, obj.transform);
+          Matrix worldMatrix =
+              MatrixUtils::Multiply(f.transform, obj.transform);
           float partMatrix[16];
           MatrixToArray(worldMatrix, partMatrix);
-          auto applyCapture =
-              [fixtureTransform, objTransform = obj.transform](
-                  const std::array<float, 3> &p) {
-                auto local = TransformPoint(objTransform, p);
-                return TransformPoint(fixtureTransform, local);
-              };
+          auto applyCapture = [fixtureTransform, objTransform = obj.transform](
+                                  const std::array<float, 3> &p) {
+            auto local = TransformPoint(objTransform, p);
+            return TransformPoint(fixtureTransform, local);
+          };
           float partR = r;
           float partG = g;
           float partB = b;
@@ -1004,25 +1025,22 @@ void OpaqueFixturePass::Render(
             partB = isWhiteRenderMode ? 1.0f : 0.35f;
           }
           const bool drawUnlit = !is2DViewer && obj.isLens;
-          controller.DrawMeshWithOutline(obj.mesh, partR, partG, partB,
-                                         RENDER_SCALE, highlight, selected, cx,
-                                         cy, cz, wireframe, mode, applyCapture,
-                                         drawUnlit, partMatrix);
+          controller.DrawMeshWithOutline(
+              obj.mesh, partR, partG, partB, RENDER_SCALE, highlight,
+              groupHighlight, selected, cx, cy, cz, wireframe, mode,
+              applyCapture, drawUnlit, partMatrix);
           ++drawCalls;
           glPopMatrix();
         }
       } else {
-        const bool fallbackWireframe =
-            wireframe;
-        const bool fallbackUnlit =
-            !highlight && !selected &&
-            context.whiteModelStyle &&
-            !controller.IsSketchRenderStyleEnabled();
-        controller.DrawMeshWithOutline(FallbackFixtureCubeMesh(), r, g, b, 0.2f,
-                                       highlight, selected, cx, cy, cz,
-                                       fallbackWireframe, mode,
-                                       applyFixtureCapture, fallbackUnlit,
-                                       matrix);
+        const bool fallbackWireframe = wireframe;
+        const bool fallbackUnlit = !highlight && !groupHighlight && !selected &&
+                                   context.whiteModelStyle &&
+                                   !controller.IsSketchRenderStyleEnabled();
+        controller.DrawMeshWithOutline(
+            FallbackFixtureCubeMesh(), r, g, b, 0.2f, highlight, groupHighlight,
+            selected, cx, cy, cz, fallbackWireframe, mode, applyFixtureCapture,
+            fallbackUnlit, matrix);
         ++drawCalls;
       }
       return drawCalls;
@@ -1036,9 +1054,10 @@ void OpaqueFixturePass::Render(
       continue;
     }
 
-    // Uses proxy/instanced fixture draws only for non-highlighted fast interaction frames.
-    if (context.skipOptionalWork && !highlight && !selected &&
-        !captureRecordingActive) {
+    // Uses proxy/instanced fixture draws only for non-highlighted fast
+    // interaction frames.
+    if (context.skipOptionalWork && !highlight && !groupHighlight &&
+        !selected && !captureRecordingActive) {
       ++frameMetrics.instancedFixtures;
       if (itg != controller.m_resourceSyncState.loadedGdtf.end()) {
         const auto &parts = itg->second;
@@ -1049,7 +1068,8 @@ void OpaqueFixturePass::Render(
           const auto &obj = parts[partIndex];
           float localMatrix[16];
           MatrixToArray(obj.transform, localMatrix);
-          Matrix worldMatrix = MatrixUtils::Multiply(f.transform, obj.transform);
+          Matrix worldMatrix =
+              MatrixUtils::Multiply(f.transform, obj.transform);
           float worldMatrixArray[16];
           MatrixToArray(worldMatrix, worldMatrixArray);
           float partR = r;
@@ -1064,14 +1084,15 @@ void OpaqueFixturePass::Render(
           }
           const bool drawUnlit = !is2DViewer && obj.isLens;
           const Mesh &proxyMesh = ResolveMovingProxyMesh(obj.mesh, controller);
-          AddFixtureInstancedDraw(fixtureInstancedBatches, proxyMesh, partR, partG,
-                                  partB, drawUnlit, wireframe, mode, RENDER_SCALE,
-                                  cx, cy, cz, matrix, localMatrix, worldMatrixArray);
+          AddFixtureInstancedDraw(fixtureInstancedBatches, proxyMesh, partR,
+                                  partG, partB, drawUnlit, wireframe, mode,
+                                  RENDER_SCALE, cx, cy, cz, matrix, localMatrix,
+                                  worldMatrixArray);
         }
       } else {
-        AddFixtureInstancedDraw(fixtureInstancedBatches, FallbackFixtureCubeMesh(),
-                                r, g, b, false, wireframe, mode, 0.2f, cx, cy,
-                                cz, matrix, nullptr, matrix);
+        AddFixtureInstancedDraw(
+            fixtureInstancedBatches, FallbackFixtureCubeMesh(), r, g, b, false,
+            wireframe, mode, 0.2f, cx, cy, cz, matrix, nullptr, matrix);
       }
       glPopMatrix();
       if (controller.m_captureCanvas && !skipCapture)
@@ -1083,8 +1104,8 @@ void OpaqueFixturePass::Render(
     // path while the camera is moving. When the camera is static we draw full
     // geometry directly to avoid persistent proxy rendering.
     const bool eligibleForFixtureInstancedBatch =
-        context.skipOptionalWork && !highlight && !selected &&
-        !captureRecordingActive;
+        context.skipOptionalWork && !highlight && !groupHighlight &&
+        !selected && !captureRecordingActive;
     if (eligibleForFixtureInstancedBatch) {
       ++frameMetrics.instancedFixtures;
       if (itg != controller.m_resourceSyncState.loadedGdtf.end()) {
@@ -1096,7 +1117,8 @@ void OpaqueFixturePass::Render(
           const auto &obj = parts[partIndex];
           float localMatrix[16];
           MatrixToArray(obj.transform, localMatrix);
-          Matrix worldMatrix = MatrixUtils::Multiply(f.transform, obj.transform);
+          Matrix worldMatrix =
+              MatrixUtils::Multiply(f.transform, obj.transform);
           float worldMatrixArray[16];
           MatrixToArray(worldMatrix, worldMatrixArray);
 
@@ -1117,9 +1139,9 @@ void OpaqueFixturePass::Render(
                                   worldMatrixArray);
         }
       } else {
-        AddFixtureInstancedDraw(fixtureInstancedBatches, FallbackFixtureCubeMesh(),
-                                r, g, b, false, wireframe, mode, 0.2f, cx, cy,
-                                cz, matrix, nullptr, matrix);
+        AddFixtureInstancedDraw(
+            fixtureInstancedBatches, FallbackFixtureCubeMesh(), r, g, b, false,
+            wireframe, mode, 0.2f, cx, cy, cz, matrix, nullptr, matrix);
       }
     } else {
       ++frameMetrics.fallbackFixtures;
@@ -1144,8 +1166,8 @@ void OpaqueFixturePass::Render(
   if (ShouldLogFixtureRenderMetrics(frameMetrics)) {
     Logger::Instance().Log(
         "fixture render metrics: instancedFixtures=" +
-        std::to_string(frameMetrics.instancedFixtures) + ", fallbackFixtures=" +
-        std::to_string(frameMetrics.fallbackFixtures) +
+        std::to_string(frameMetrics.instancedFixtures) +
+        ", fallbackFixtures=" + std::to_string(frameMetrics.fallbackFixtures) +
         ", instancedDrawCalls=" +
         std::to_string(frameMetrics.instancedDrawCalls) +
         ", fallbackDrawCalls=" +

--- a/viewer3d/render/opaque_object_pass.cpp
+++ b/viewer3d/render/opaque_object_pass.cpp
@@ -98,19 +98,17 @@ bool IsPipeSceneObject(const SceneObject &object) {
     return false;
 
   std::string upperName = object.name;
-  std::transform(upperName.begin(), upperName.end(), upperName.begin(),
-                 [](unsigned char c) {
-                   return static_cast<char>(std::toupper(c));
-                 });
+  std::transform(
+      upperName.begin(), upperName.end(), upperName.begin(),
+      [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
   return upperName.rfind("PIPE", 0) == 0;
 }
 
 bool IsScreenSceneObject(const SceneObject &object) {
   std::string lowerName = object.name;
-  std::transform(lowerName.begin(), lowerName.end(), lowerName.begin(),
-                 [](unsigned char c) {
-                   return static_cast<char>(std::tolower(c));
-                 });
+  std::transform(
+      lowerName.begin(), lowerName.end(), lowerName.begin(),
+      [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
   return lowerName.find("screen") != std::string::npos ||
          lowerName.find("pantalla") != std::string::npos;
 }
@@ -149,8 +147,7 @@ const Mesh *TryGetPrimitiveSceneObjectMesh(const std::string &modelRef) {
   Mesh mesh;
   if (!BuildPrimitiveMesh(primitiveType, mesh))
     return nullptr;
-  auto [insertedIt, inserted] =
-      cache.emplace(primitiveType, std::move(mesh));
+  auto [insertedIt, inserted] = cache.emplace(primitiveType, std::move(mesh));
   (void)inserted;
   return &insertedIt->second;
 }
@@ -209,9 +206,11 @@ std::string BuildSceneObjectSymbolSignature(
 void OpaqueObjectPass::Render(
     Viewer3DController &controller, const RenderFrameContext &context,
     const Viewer3DVisibleSet &visibleSet,
-    const std::function<std::array<float, 3>(const std::string &)> &getLayerColor,
+    const std::function<std::array<float, 3>(const std::string &)>
+        &getLayerColor,
     const std::function<SymbolViewKind(Viewer2DView)> &resolveSymbolView,
-    const std::function<std::array<float, 3>(const std::string &)> &getPickColor) {
+    const std::function<std::array<float, 3>(const std::string &)>
+        &getPickColor) {
   if (context.idOnlyPass) {
     glShadeModel(GL_FLAT);
     for (const auto &uuid : visibleSet.objectUuids) {
@@ -250,12 +249,15 @@ void OpaqueObjectPass::Render(
       controller.m_captureCanvas->SetSourceKey(objectCaptureKey);
     }
 
-    const bool highlight =
-        context.selectionOverlayPass && !controller.m_highlightUuid.empty() &&
-        uuid == controller.m_highlightUuid;
-    const bool selected = context.selectionOverlayPass &&
-                          controller.m_selectedUuids.find(uuid) !=
-                              controller.m_selectedUuids.end();
+    const bool highlight = context.selectionOverlayPass &&
+                           !controller.m_highlightUuid.empty() &&
+                           uuid == controller.m_highlightUuid;
+    const bool groupHighlight = context.selectionOverlayPass &&
+                                controller.m_groupHighlightUuids.find(uuid) !=
+                                    controller.m_groupHighlightUuids.end();
+    const bool selected =
+        context.selectionOverlayPass && controller.m_selectedUuids.find(uuid) !=
+                                            controller.m_selectedUuids.end();
 
     float matrix[16];
     MatrixToArray(m.transform, matrix);
@@ -354,7 +356,7 @@ void OpaqueObjectPass::Render(
     auto drawSceneObjectGeometry =
         [&](const std::function<std::array<float, 3>(
                 const std::array<float, 3> &)> &captureTransformFn,
-            bool isHighlighted, bool isSelected) {
+            bool isHighlighted, bool isGroupHighlighted, bool isSelected) {
           const bool disableDepthBiasForScreen =
               IsScreenSceneObject(m) && !isHighlighted && !isSelected;
           const bool disableDepthBias =
@@ -375,9 +377,10 @@ void OpaqueObjectPass::Render(
               partCaptureMatrix.o[0] *= RENDER_SCALE;
               partCaptureMatrix.o[1] *= RENDER_SCALE;
               partCaptureMatrix.o[2] *= RENDER_SCALE;
-              auto partCapture = [partCaptureMatrix](const std::array<float, 3> &p) {
-                return TransformPoint(partCaptureMatrix, p);
-              };
+              auto partCapture =
+                  [partCaptureMatrix](const std::array<float, 3> &p) {
+                    return TransformPoint(partCaptureMatrix, p);
+                  };
 
               Matrix localCaptureMatrix = part.localTransform;
               localCaptureMatrix.o[0] *= RENDER_SCALE;
@@ -398,12 +401,10 @@ void OpaqueObjectPass::Render(
               else
                 partCaptureTransform = localPartCapture;
 
-              controller.DrawMeshWithOutline(*part.mesh, r, g, b, RENDER_SCALE,
-                                             isHighlighted, isSelected, cx, cy,
-                                             cz, wireframe, mode,
-                                             partCaptureTransform, false,
-                                             partMatrix,
-                                             disableDepthBias);
+              controller.DrawMeshWithOutline(
+                  *part.mesh, r, g, b, RENDER_SCALE, isHighlighted,
+                  isGroupHighlighted, isSelected, cx, cy, cz, wireframe, mode,
+                  partCaptureTransform, false, partMatrix, disableDepthBias);
               glPopMatrix();
             }
           } else {
@@ -411,7 +412,7 @@ void OpaqueObjectPass::Render(
             // so every render style (white model, textured, by-layer, etc.)
             // stays visually consistent even when the object has no mesh file.
             const bool useUnlitFallbackFill =
-                !isHighlighted && !isSelected &&
+                !isHighlighted && !isGroupHighlighted && !isSelected &&
                 context.whiteModelStyle &&
                 !controller.IsSketchRenderStyleEnabled();
             const bool fallbackWireframe = wireframe;
@@ -419,9 +420,9 @@ void OpaqueObjectPass::Render(
                                            ? FallbackSceneObjectCylinderMesh()
                                            : FallbackSceneObjectCubeMesh();
             controller.DrawMeshWithOutline(
-                fallbackMesh, r, g, b, 0.3f, isHighlighted, isSelected, cx, cy,
-                cz, fallbackWireframe, mode, captureTransformFn,
-                useUnlitFallbackFill, matrix,
+                fallbackMesh, r, g, b, 0.3f, isHighlighted, isGroupHighlighted,
+                isSelected, cx, cy, cz, fallbackWireframe, mode,
+                captureTransformFn, useUnlitFallbackFill, matrix,
                 disableDepthBias);
           }
         };
@@ -434,7 +435,7 @@ void OpaqueObjectPass::Render(
           captureView == Viewer2DView::Side) &&
          mode != Viewer2DRenderMode::Wireframe &&
          CanUseAffineSymbolInstance(captureTransform, captureView) &&
-         !highlight && !selected);
+         !highlight && !groupHighlight && !selected);
     bool placedInstance = false;
     if (useSymbolInstancing && controller.m_captureCanvas && !skipCapture) {
       std::vector<SceneObjectSymbolPartSignature> symbolMeshParts;
@@ -451,9 +452,8 @@ void OpaqueObjectPass::Render(
         symbolKey.viewKind = resolveSymbolView(captureView);
         symbolKey.styleVersion = 1;
 
-        const auto &symbol =
-            controller.m_bottomSymbolCache.GetOrCreate(symbolKey, [&](const SymbolKey &,
-                                                           uint32_t symbolId) {
+        const auto &symbol = controller.m_bottomSymbolCache.GetOrCreate(
+            symbolKey, [&](const SymbolKey &, uint32_t symbolId) {
               SymbolDefinition definition{};
               definition.symbolId = symbolId;
               auto localCanvas =
@@ -475,8 +475,7 @@ void OpaqueObjectPass::Render(
                   objectCaptureKey.empty() ? "scene_object" : objectCaptureKey);
               drawSceneObjectGeometry({}, false, false);
               localCanvas->EndFrame();
-              definition.bounds =
-                  ComputeSymbolBounds(definition.localCommands);
+              definition.bounds = ComputeSymbolBounds(definition.localCommands);
 
               controller.m_captureCanvas = prevCanvas;
               controller.m_captureView = prevView;
@@ -498,11 +497,13 @@ void OpaqueObjectPass::Render(
       bool prevCaptureOnly = controller.m_captureOnly;
       controller.m_captureCanvas = nullptr;
       controller.m_captureOnly = false;
-      drawSceneObjectGeometry(applyCapture, highlight, selected);
+      drawSceneObjectGeometry(applyCapture, highlight, groupHighlight,
+                              selected);
       controller.m_captureCanvas = prevCanvas;
       controller.m_captureOnly = prevCaptureOnly;
     } else {
-      drawSceneObjectGeometry(applyCapture, highlight, selected);
+      drawSceneObjectGeometry(applyCapture, highlight, groupHighlight,
+                              selected);
     }
 
     glPopMatrix();

--- a/viewer3d/render/opaque_object_pass.cpp
+++ b/viewer3d/render/opaque_object_pass.cpp
@@ -473,7 +473,7 @@ void OpaqueObjectPass::Render(
 
               controller.m_captureCanvas->SetSourceKey(
                   objectCaptureKey.empty() ? "scene_object" : objectCaptureKey);
-              drawSceneObjectGeometry({}, false, false);
+              drawSceneObjectGeometry({}, false, false, false);
               localCanvas->EndFrame();
               definition.bounds = ComputeSymbolBounds(definition.localCommands);
 

--- a/viewer3d/render/opaque_truss_pass.cpp
+++ b/viewer3d/render/opaque_truss_pass.cpp
@@ -264,7 +264,7 @@ void OpaqueTrussPass::Render(
 
               controller.m_captureCanvas->SetSourceKey(
                   trussCaptureKey.empty() ? "truss" : trussCaptureKey);
-              drawTrussGeometry({}, false, false);
+              drawTrussGeometry({}, false, false, false);
               localCanvas->EndFrame();
               definition.bounds = ComputeSymbolBounds(definition.localCommands);
 

--- a/viewer3d/render/opaque_truss_pass.cpp
+++ b/viewer3d/render/opaque_truss_pass.cpp
@@ -79,9 +79,11 @@ void DrawBoundsSolid(const Viewer3DBoundingBox &bb) {
 void OpaqueTrussPass::Render(
     Viewer3DController &controller, const RenderFrameContext &context,
     const Viewer3DVisibleSet &visibleSet,
-    const std::function<std::array<float, 3>(const std::string &)> &getLayerColor,
+    const std::function<std::array<float, 3>(const std::string &)>
+        &getLayerColor,
     const std::function<SymbolViewKind(Viewer2DView)> &resolveSymbolView,
-    const std::function<std::array<float, 3>(const std::string &)> &getPickColor) {
+    const std::function<std::array<float, 3>(const std::string &)>
+        &getPickColor) {
   if (context.idOnlyPass) {
     glShadeModel(GL_FLAT);
     for (const auto &uuid : visibleSet.trussUuids) {
@@ -117,12 +119,15 @@ void OpaqueTrussPass::Render(
       controller.m_captureCanvas->SetSourceKey(trussCaptureKey);
     }
 
-    const bool highlight =
-        context.selectionOverlayPass && !controller.m_highlightUuid.empty() &&
-        uuid == controller.m_highlightUuid;
-    const bool selected = context.selectionOverlayPass &&
-                          controller.m_selectedUuids.find(uuid) !=
-                              controller.m_selectedUuids.end();
+    const bool highlight = context.selectionOverlayPass &&
+                           !controller.m_highlightUuid.empty() &&
+                           uuid == controller.m_highlightUuid;
+    const bool groupHighlight = context.selectionOverlayPass &&
+                                controller.m_groupHighlightUuids.find(uuid) !=
+                                    controller.m_groupHighlightUuids.end();
+    const bool selected =
+        context.selectionOverlayPass && controller.m_selectedUuids.find(uuid) !=
+                                            controller.m_selectedUuids.end();
 
     float matrix[16];
     MatrixToArray(t.transform, matrix);
@@ -166,7 +171,8 @@ void OpaqueTrussPass::Render(
     if (!t.symbolFile.empty()) {
       auto trussPathIt = controller.m_resourceSyncState.resolvedModelRefs.find(
           ResolveCacheKey(t.symbolFile));
-      if (trussPathIt != controller.m_resourceSyncState.resolvedModelRefs.end() &&
+      if (trussPathIt !=
+              controller.m_resourceSyncState.resolvedModelRefs.end() &&
           trussPathIt->second.attempted)
         trussPath = trussPathIt->second.resolvedPath;
       if (!trussPath.empty()) {
@@ -191,16 +197,17 @@ void OpaqueTrussPass::Render(
     auto drawTrussGeometry =
         [&](const std::function<std::array<float, 3>(
                 const std::array<float, 3> &)> &captureTransformFn,
-            bool isHighlighted, bool isSelected) {
+            bool isHighlighted, bool isGroupHighlighted, bool isSelected) {
           if (trussMesh) {
-            controller.DrawMeshWithOutline(*trussMesh, r, g, b, RENDER_SCALE,
-                                           isHighlighted, isSelected, cx, cy,
-                                           cz, wireframe, mode,
-                                           captureTransformFn, false, matrix);
+            controller.DrawMeshWithOutline(
+                *trussMesh, r, g, b, RENDER_SCALE, isHighlighted,
+                isGroupHighlighted, isSelected, cx, cy, cz, wireframe, mode,
+                captureTransformFn, false, matrix);
           } else {
             controller.DrawWireframeBox(trussLen, trussHei, trussWid, r, g, b,
-                                        isHighlighted, isSelected, wireframe,
-                                        mode, captureTransformFn);
+                                        isHighlighted, isGroupHighlighted,
+                                        isSelected, wireframe, mode,
+                                        captureTransformFn);
           }
         };
 
@@ -210,8 +217,8 @@ void OpaqueTrussPass::Render(
           captureView == Viewer2DView::Top ||
           captureView == Viewer2DView::Front ||
           captureView == Viewer2DView::Side) &&
-         mode != Viewer2DRenderMode::Wireframe &&
-         !highlight && !selected);
+         mode != Viewer2DRenderMode::Wireframe && !highlight &&
+         !groupHighlight && !selected);
     bool placedInstance = false;
     if (useSymbolInstancing && controller.m_captureCanvas && !skipCapture) {
       std::string modelKey;
@@ -222,8 +229,7 @@ void OpaqueTrussPass::Render(
       if (modelKey.empty() && !trussMesh) {
         std::ostringstream boxKey;
         boxKey << "box:" << trussWorldDimensionsMm[0] << "x"
-               << trussWorldDimensionsMm[2] << "x"
-               << trussWorldDimensionsMm[1];
+               << trussWorldDimensionsMm[2] << "x" << trussWorldDimensionsMm[1];
         modelKey = boxKey.str();
       }
       if (modelKey.empty() && !t.model.empty())
@@ -237,9 +243,8 @@ void OpaqueTrussPass::Render(
         symbolKey.viewKind = resolveSymbolView(captureView);
         symbolKey.styleVersion = 1;
 
-        const auto &symbol =
-            controller.m_bottomSymbolCache.GetOrCreate(symbolKey, [&](const SymbolKey &,
-                                                           uint32_t symbolId) {
+        const auto &symbol = controller.m_bottomSymbolCache.GetOrCreate(
+            symbolKey, [&](const SymbolKey &, uint32_t symbolId) {
               SymbolDefinition definition{};
               definition.symbolId = symbolId;
               auto localCanvas =
@@ -283,11 +288,11 @@ void OpaqueTrussPass::Render(
       bool prevCaptureOnly = controller.m_captureOnly;
       controller.m_captureCanvas = nullptr;
       controller.m_captureOnly = false;
-      drawTrussGeometry(applyCapture, highlight, selected);
+      drawTrussGeometry(applyCapture, highlight, groupHighlight, selected);
       controller.m_captureCanvas = prevCanvas;
       controller.m_captureOnly = prevCaptureOnly;
     } else {
-      drawTrussGeometry(applyCapture, highlight, selected);
+      drawTrussGeometry(applyCapture, highlight, groupHighlight, selected);
     }
 
     glPopMatrix();

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -14,10 +14,10 @@
 #include <GL/gl.h>
 #endif
 
+#include "configmanager.h"
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
-#include "configmanager.h"
 
 namespace {
 struct InkColor {
@@ -39,8 +39,8 @@ enum class SketchInteractionWireframeMode {
 };
 
 SketchInteractionWireframeMode ReadSketchInteractionWireframeMode() {
-  const float rawValue =
-      ConfigManager::Get().GetFloat("viewer3d_sketch_interaction_wireframe_mode");
+  const float rawValue = ConfigManager::Get().GetFloat(
+      "viewer3d_sketch_interaction_wireframe_mode");
   const int mode = static_cast<int>(std::lround(rawValue));
   switch (mode) {
   case 1:
@@ -55,8 +55,8 @@ SketchInteractionWireframeMode ReadSketchInteractionWireframeMode() {
 }
 
 int ReadSketchInteractionWireframeStep() {
-  const float rawStep =
-      ConfigManager::Get().GetFloat("viewer3d_sketch_interaction_wireframe_step");
+  const float rawStep = ConfigManager::Get().GetFloat(
+      "viewer3d_sketch_interaction_wireframe_step");
   const int step = static_cast<int>(std::lround(rawStep));
   return std::clamp(step, 1, 12);
 }
@@ -176,7 +176,8 @@ bool LinkProgram(GLuint program) {
   return linked == GL_TRUE;
 }
 
-// Creates the three-tone ink shader program and caches its attribute and uniform locations.
+// Creates the three-tone ink shader program and caches its attribute and
+// uniform locations.
 ThreeToneInkProgram CreateThreeToneInkProgram() {
   static constexpr const char *kVertexShader = R"glsl(
     #version 120
@@ -248,7 +249,8 @@ ThreeToneInkProgram CreateThreeToneInkProgram() {
   result.positionAttrib = glGetAttribLocation(result.program, "aPosition");
   result.normalAttrib = glGetAttribLocation(result.program, "aNormal");
   result.modelViewUniform = glGetUniformLocation(result.program, "uModelView");
-  result.projectionUniform = glGetUniformLocation(result.program, "uProjection");
+  result.projectionUniform =
+      glGetUniformLocation(result.program, "uProjection");
   result.normalMatrixUniform =
       glGetUniformLocation(result.program, "uNormalMatrix");
   result.lightDirUniform = glGetUniformLocation(result.program, "uLightDir");
@@ -270,7 +272,8 @@ const ThreeToneInkProgram &GetThreeToneInkProgram() {
   return program;
 }
 
-// Builds the inverse-transpose normal matrix from the current model-view matrix.
+// Builds the inverse-transpose normal matrix from the current model-view
+// matrix.
 void ComputeNormalMatrix3x3(const float *modelView, float *normalMatrix3x3) {
   const float m00 = modelView[0];
   const float m01 = modelView[4];
@@ -331,7 +334,8 @@ void RestoreFrontFace(GLint previousFrontFace) {
   glFrontFace(static_cast<GLenum>(previousFrontFace));
 }
 
-// Returns the supplied model matrix or reads the current OpenGL model-view matrix.
+// Returns the supplied model matrix or reads the current OpenGL model-view
+// matrix.
 const float *ResolveModelMatrixForMirroring(const float *modelMatrix,
                                             float fallbackModelMatrix[16]) {
   if (modelMatrix != nullptr)
@@ -349,10 +353,10 @@ bool DrawMeshThreeToneInkGpu(const Mesh &mesh, float scale,
   const bool flatGpuHandlesValid =
       glIsBuffer(mesh.vboFlatVertices) == GL_TRUE &&
       glIsBuffer(mesh.vboFlatNormals) == GL_TRUE;
-  const bool canUseGpuPath =
-      mesh.buffersReady && mesh.vao != 0 && mesh.vboVertices != 0 &&
-      mesh.vboNormals != 0 && mesh.eboTriangles != 0 && gpuHandlesValid &&
-      mesh.triangleIndexCount > 0;
+  const bool canUseGpuPath = mesh.buffersReady && mesh.vao != 0 &&
+                             mesh.vboVertices != 0 && mesh.vboNormals != 0 &&
+                             mesh.eboTriangles != 0 && gpuHandlesValid &&
+                             mesh.triangleIndexCount > 0;
   const bool canUseSketchFlatPath =
       sketchFill && mesh.buffersReady && mesh.vao != 0 &&
       mesh.vboFlatVertices != 0 && mesh.vboFlatNormals != 0 &&
@@ -408,8 +412,8 @@ bool DrawMeshThreeToneInkGpu(const Mesh &mesh, float scale,
   glBindBuffer(GL_ARRAY_BUFFER,
                canUseSketchFlatPath ? mesh.vboFlatVertices : mesh.vboVertices);
   glEnableVertexAttribArray(static_cast<GLuint>(program.positionAttrib));
-  glVertexAttribPointer(static_cast<GLuint>(program.positionAttrib), 3, GL_FLOAT,
-                        GL_FALSE, 0, nullptr);
+  glVertexAttribPointer(static_cast<GLuint>(program.positionAttrib), 3,
+                        GL_FLOAT, GL_FALSE, 0, nullptr);
 
   glBindBuffer(GL_ARRAY_BUFFER,
                canUseSketchFlatPath ? mesh.vboFlatNormals : mesh.vboNormals);
@@ -443,14 +447,15 @@ void DrawMeshThreeToneInkImmediate(const Mesh &mesh, float scale,
                                    const float *modelMatrix, bool sketchFill);
 
 // Draws a mesh using three-tone ink shading with GPU and immediate fallbacks.
-void DrawMeshThreeToneInk(const Mesh &mesh, float scale, const float *modelMatrix,
-                           bool sketchFill) {
+void DrawMeshThreeToneInk(const Mesh &mesh, float scale,
+                          const float *modelMatrix, bool sketchFill) {
   if (DrawMeshThreeToneInkGpu(mesh, scale, modelMatrix, sketchFill))
     return;
   DrawMeshThreeToneInkImmediate(mesh, scale, modelMatrix, sketchFill);
 }
 
-// Draws a mesh with CPU-side three-tone ink shading when GPU shaders are unavailable.
+// Draws a mesh with CPU-side three-tone ink shading when GPU shaders are
+// unavailable.
 void DrawMeshThreeToneInkImmediate(const Mesh &mesh, float scale,
                                    const float *modelMatrix, bool sketchFill) {
   std::array<float, 3> lightDir = NormalizeVector(0.35f, -0.55f, 1.0f);
@@ -470,7 +475,7 @@ void DrawMeshThreeToneInkImmediate(const Mesh &mesh, float scale,
   glBegin(GL_TRIANGLES);
   for (size_t i = 0; i + 2 < triangleIndices->size(); i += 3) {
     const uint32_t tri[3] = {(*triangleIndices)[i], (*triangleIndices)[i + 1],
-                                   (*triangleIndices)[i + 2]};
+                             (*triangleIndices)[i + 2]};
     const float v0x = mesh.vertices[tri[0] * 3];
     const float v0y = mesh.vertices[tri[0] * 3 + 1];
     const float v0z = mesh.vertices[tri[0] * 3 + 2];
@@ -556,19 +561,18 @@ void DrawMeshThreeToneInkImmediate(const Mesh &mesh, float scale,
 
 void SceneRenderer::DrawMeshWithOutline(
     const Mesh &mesh, float r, float g, float b, float scale, bool highlight,
-    bool selected, float cx, float cy, float cz, bool wireframe,
-    Viewer2DRenderMode mode,
-    const std::function<std::array<float, 3>(const std::array<float, 3> &)> &
-        captureTransform,
+    bool groupHighlight, bool selected, float cx, float cy, float cz,
+    bool wireframe, Viewer2DRenderMode mode,
+    const std::function<std::array<float, 3>(const std::array<float, 3> &)>
+        &captureTransform,
     bool unlit, const float *modelMatrix, bool disableDepthBias) {
   (void)cx;
   (void)cy;
   (void)cz;
-  const bool forceDisableTexture =
-      mode == Viewer2DRenderMode::Wireframe ||
-      mode == Viewer2DRenderMode::ByFixtureType ||
-      mode == Viewer2DRenderMode::ByLayer ||
-      mode == Viewer2DRenderMode::ByUniverse;
+  const bool forceDisableTexture = mode == Viewer2DRenderMode::Wireframe ||
+                                   mode == Viewer2DRenderMode::ByFixtureType ||
+                                   mode == Viewer2DRenderMode::ByLayer ||
+                                   mode == Viewer2DRenderMode::ByUniverse;
   const GLboolean texture2DWasEnabled = glIsEnabled(GL_TEXTURE_2D);
   if (forceDisableTexture && texture2DWasEnabled)
     glDisable(GL_TEXTURE_2D);
@@ -585,15 +589,15 @@ void SceneRenderer::DrawMeshWithOutline(
             .lineWidth;
     bool symbolCaptureRenderProfile =
         mode == Viewer2DRenderMode::ByFixtureType ||
-        ConfigManager::Get().GetFloat("viewer3d_symbol_capture_render_profile") >=
-            0.5f;
+        ConfigManager::Get().GetFloat(
+            "viewer3d_symbol_capture_render_profile") >= 0.5f;
     if (m_controller.GetSymbolCaptureRenderProfileOverride().has_value()) {
       symbolCaptureRenderProfile =
           m_controller.GetSymbolCaptureRenderProfileOverride().value();
     }
-    const bool drawOutline =
-        !m_controller.SkipOutlinesForCurrentFrame() &&
-        m_controller.IsSelectionOutlineEnabled2D() && (highlight || selected);
+    const bool drawOutline = !m_controller.SkipOutlinesForCurrentFrame() &&
+                             m_controller.IsSelectionOutlineEnabled2D() &&
+                             (highlight || groupHighlight || selected);
     const bool useWireframeModeColor = mode == Viewer2DRenderMode::Wireframe;
     const float strokeR = useWireframeModeColor ? r : 0.0f;
     const float strokeG = useWireframeModeColor ? g : 0.0f;
@@ -613,6 +617,8 @@ void SceneRenderer::DrawMeshWithOutline(
         glLineWidth(glowWidth);
         if (highlight)
           m_controller.SetGLColor(0.0f, 1.0f, 0.0f);
+        else if (groupHighlight)
+          m_controller.SetGLColor(0.45f, 1.0f, 0.35f);
         else if (selected)
           m_controller.SetGLColor(0.0f, 1.0f, 1.0f);
         DrawMeshWireframe(mesh, scale, captureTransform);
@@ -637,7 +643,8 @@ void SceneRenderer::DrawMeshWithOutline(
     }
     if (m_controller.IsCaptureOnly())
       DrawMeshWireframe(mesh, scale, captureTransform, &stroke);
-    if (m_controller.GetCaptureCanvas() && mode != Viewer2DRenderMode::Wireframe) {
+    if (m_controller.GetCaptureCanvas() &&
+        mode != Viewer2DRenderMode::Wireframe) {
       CanvasFill fill;
       fill.color = {r, g, b, 1.0f};
       for (size_t i = 0; i + 2 < mesh.indices.size(); i += 3) {
@@ -681,7 +688,8 @@ void SceneRenderer::DrawMeshWithOutline(
 
   if (!m_controller.IsCaptureOnly()) {
     if (m_controller.IsWhiteModelStyleEnabled()) {
-      const GLboolean texture2DWhiteModelWasEnabled = glIsEnabled(GL_TEXTURE_2D);
+      const GLboolean texture2DWhiteModelWasEnabled =
+          glIsEnabled(GL_TEXTURE_2D);
       if (texture2DWhiteModelWasEnabled)
         glDisable(GL_TEXTURE_2D);
       const bool useColorFillInWhiteStyle =
@@ -694,24 +702,26 @@ void SceneRenderer::DrawMeshWithOutline(
           m_controller.IsPureWhiteRenderStyleEnabled();
       // Keep 3D white-model aligned with the 2D viewer draw order:
       // stroke pass first, then polygon-offset fill pass.
-      const LineRenderProfile lineProfile =
-          GetLineRenderProfile(m_controller.IsInteracting(),
-                               mode == Viewer2DRenderMode::Wireframe,
-                               m_controller.UseAdaptiveLineProfile());
+      const LineRenderProfile lineProfile = GetLineRenderProfile(
+          m_controller.IsInteracting(), mode == Viewer2DRenderMode::Wireframe,
+          m_controller.UseAdaptiveLineProfile());
       const float lineWidth = lineProfile.lineWidth;
       auto setHighlightOrSelectionColor = [&]() {
         if (highlight)
           m_controller.SetGLColor(0.0f, 1.0f, 0.0f);
+        else if (groupHighlight)
+          m_controller.SetGLColor(0.45f, 1.0f, 0.35f);
         else if (selected)
           m_controller.SetGLColor(0.0f, 1.0f, 1.0f);
         else
           m_controller.SetGLColor(0.0f, 0.0f, 0.0f);
       };
-      const bool drawOutline =
-          !m_controller.SkipOutlinesForCurrentFrame() &&
-          m_controller.IsSelectionOutlineEnabled2D() && (highlight || selected);
+      const bool drawOutline = !m_controller.SkipOutlinesForCurrentFrame() &&
+                               m_controller.IsSelectionOutlineEnabled2D() &&
+                               (highlight || groupHighlight || selected);
       const bool interactiveSketchMode =
-          m_controller.IsSketchRenderStyleEnabled() && m_controller.IsInteracting();
+          m_controller.IsSketchRenderStyleEnabled() &&
+          m_controller.IsInteracting();
       const SketchInteractionWireframeMode interactionMode =
           interactiveSketchMode ? ReadSketchInteractionWireframeMode()
                                 : SketchInteractionWireframeMode::FullQuality;
@@ -720,11 +730,12 @@ void SceneRenderer::DrawMeshWithOutline(
       if (interactiveSketchMode) {
         if (interactionMode == SketchInteractionWireframeMode::Sparse) {
           wireframeTriangleStep = ReadSketchInteractionWireframeStep();
-        } else if (interactionMode == SketchInteractionWireframeMode::FillOnly) {
+        } else if (interactionMode ==
+                   SketchInteractionWireframeMode::FillOnly) {
           drawBaseWireframe = false;
         } else if (interactionMode ==
                    SketchInteractionWireframeMode::HighlightSelectedOnly) {
-          drawBaseWireframe = highlight || selected;
+          drawBaseWireframe = highlight || groupHighlight || selected;
         }
       }
 
@@ -750,7 +761,7 @@ void SceneRenderer::DrawMeshWithOutline(
         glEnable(GL_POLYGON_OFFSET_FILL);
         glPolygonOffset(-1.0f, -1.0f);
       }
-      if (highlight || selected) {
+      if (highlight || groupHighlight || selected) {
         setHighlightOrSelectionColor();
         if (!glIsEnabled(GL_LIGHTING))
           glEnable(GL_LIGHTING);
@@ -785,16 +796,18 @@ void SceneRenderer::DrawMeshWithOutline(
       if (texture2DWhiteModelWasEnabled)
         glEnable(GL_TEXTURE_2D);
     } else {
-      const bool useTexture = m_controller.IsTexturedRenderStyleEnabled() &&
-                              !highlight && !selected &&
-                              mesh.textureId != 0 &&
-                              mesh.texcoords.size() >= (mesh.vertices.size() / 3u) * 2u;
+      const bool useTexture =
+          m_controller.IsTexturedRenderStyleEnabled() && !highlight &&
+          !groupHighlight && !selected && mesh.textureId != 0 &&
+          mesh.texcoords.size() >= (mesh.vertices.size() / 3u) * 2u;
       const bool useMaterialColor =
-                                    m_controller.IsTexturedRenderStyleEnabled() &&
-                                    !highlight && !selected &&
-                                    !useTexture && mesh.hasMaterialBaseColor;
+          m_controller.IsTexturedRenderStyleEnabled() && !highlight &&
+          !groupHighlight && !selected && !useTexture &&
+          mesh.hasMaterialBaseColor;
       if (highlight)
         m_controller.SetGLColor(0.0f, 1.0f, 0.0f);
+      else if (groupHighlight)
+        m_controller.SetGLColor(0.45f, 1.0f, 0.35f);
       else if (selected)
         m_controller.SetGLColor(0.0f, 1.0f, 1.0f);
       else if (useMaterialColor)
@@ -842,18 +855,18 @@ void SceneRenderer::DrawMeshWithOutline(
 // Draws mesh edges as wireframe lines and records them for capture output.
 void SceneRenderer::DrawMeshWireframe(
     const Mesh &mesh, float scale,
-    const std::function<std::array<float, 3>(const std::array<float, 3> &)> &
-        captureTransform,
+    const std::function<std::array<float, 3>(const std::array<float, 3> &)>
+        &captureTransform,
     const CanvasStroke *captureStroke, int triangleStep) {
   const size_t triangleAdvance =
       static_cast<size_t>(std::max(1, triangleStep)) * 3u;
   const bool gpuHandlesValid = glIsBuffer(mesh.vboVertices) == GL_TRUE &&
                                glIsBuffer(mesh.eboLines) == GL_TRUE &&
                                glIsBuffer(mesh.eboTriangles) == GL_TRUE;
-  const bool canUseGpuWireframe =
-      mesh.buffersReady && mesh.vao != 0 && mesh.vboVertices != 0 &&
-      mesh.eboLines != 0 && mesh.eboTriangles != 0 && gpuHandlesValid &&
-      triangleAdvance == 3u;
+  const bool canUseGpuWireframe = mesh.buffersReady && mesh.vao != 0 &&
+                                  mesh.vboVertices != 0 && mesh.eboLines != 0 &&
+                                  mesh.eboTriangles != 0 && gpuHandlesValid &&
+                                  triangleAdvance == 3u;
 
   if (!m_controller.IsCaptureOnly() && canUseGpuWireframe) {
     glBindVertexArray(mesh.vao);
@@ -879,19 +892,25 @@ void SceneRenderer::DrawMeshWireframe(
       const uint32_t i1 = mesh.indices[i + 1];
       const uint32_t i2 = mesh.indices[i + 2];
 
-      glVertex3f(mesh.vertices[i0 * 3] * scale, mesh.vertices[i0 * 3 + 1] * scale,
+      glVertex3f(mesh.vertices[i0 * 3] * scale,
+                 mesh.vertices[i0 * 3 + 1] * scale,
                  mesh.vertices[i0 * 3 + 2] * scale);
-      glVertex3f(mesh.vertices[i1 * 3] * scale, mesh.vertices[i1 * 3 + 1] * scale,
+      glVertex3f(mesh.vertices[i1 * 3] * scale,
+                 mesh.vertices[i1 * 3 + 1] * scale,
                  mesh.vertices[i1 * 3 + 2] * scale);
 
-      glVertex3f(mesh.vertices[i1 * 3] * scale, mesh.vertices[i1 * 3 + 1] * scale,
+      glVertex3f(mesh.vertices[i1 * 3] * scale,
+                 mesh.vertices[i1 * 3 + 1] * scale,
                  mesh.vertices[i1 * 3 + 2] * scale);
-      glVertex3f(mesh.vertices[i2 * 3] * scale, mesh.vertices[i2 * 3 + 1] * scale,
+      glVertex3f(mesh.vertices[i2 * 3] * scale,
+                 mesh.vertices[i2 * 3 + 1] * scale,
                  mesh.vertices[i2 * 3 + 2] * scale);
 
-      glVertex3f(mesh.vertices[i2 * 3] * scale, mesh.vertices[i2 * 3 + 1] * scale,
+      glVertex3f(mesh.vertices[i2 * 3] * scale,
+                 mesh.vertices[i2 * 3 + 1] * scale,
                  mesh.vertices[i2 * 3 + 2] * scale);
-      glVertex3f(mesh.vertices[i0 * 3] * scale, mesh.vertices[i0 * 3 + 1] * scale,
+      glVertex3f(mesh.vertices[i0 * 3] * scale,
+                 mesh.vertices[i0 * 3 + 1] * scale,
                  mesh.vertices[i0 * 3 + 2] * scale);
     }
     glEnd();
@@ -928,9 +947,10 @@ void SceneRenderer::DrawMeshWireframe(
   }
 }
 
-// Draws a lit or textured mesh while preserving front-face orientation for mirrored transforms.
-void SceneRenderer::DrawMesh(const Mesh &mesh, float scale, const float *modelMatrix,
-                             bool useTexture) {
+// Draws a lit or textured mesh while preserving front-face orientation for
+// mirrored transforms.
+void SceneRenderer::DrawMesh(const Mesh &mesh, float scale,
+                             const float *modelMatrix, bool useTexture) {
   const GLboolean cullWasEnabled = glIsEnabled(GL_CULL_FACE);
   if (cullWasEnabled)
     glDisable(GL_CULL_FACE);
@@ -965,9 +985,8 @@ void SceneRenderer::DrawMesh(const Mesh &mesh, float scale, const float *modelMa
       mesh.vboFlatNormals != 0 && mesh.flatVertexCount > 0 &&
       flatGpuHandlesValid;
 
-  const bool allowGpuTriangles =
-      canUseGpuTriangles && !useTexture &&
-      (!useFaceNormals || !canUseGpuFlatTriangles);
+  const bool allowGpuTriangles = canUseGpuTriangles && !useTexture &&
+                                 (!useFaceNormals || !canUseGpuFlatTriangles);
   const bool allowGpuFlatTriangles = canUseGpuFlatTriangles && useFaceNormals;
 
   if (!m_controller.IsCaptureOnly() &&
@@ -980,8 +999,8 @@ void SceneRenderer::DrawMesh(const Mesh &mesh, float scale, const float *modelMa
     glPushMatrix();
     glScalef(scale, scale, scale);
 
-    glBindBuffer(GL_ARRAY_BUFFER,
-                 allowGpuFlatTriangles ? mesh.vboFlatVertices : mesh.vboVertices);
+    glBindBuffer(GL_ARRAY_BUFFER, allowGpuFlatTriangles ? mesh.vboFlatVertices
+                                                        : mesh.vboVertices);
     glEnableClientState(GL_VERTEX_ARRAY);
     glVertexPointer(3, GL_FLOAT, 0, nullptr);
 
@@ -1054,18 +1073,17 @@ void SceneRenderer::DrawMesh(const Mesh &mesh, float scale, const float *modelMa
           ny /= len;
           nz /= len;
           if (hasNormals) {
-            const float avgNx = ((*normalData)[i0 * 3] +
-                                 (*normalData)[i1 * 3] +
+            const float avgNx = ((*normalData)[i0 * 3] + (*normalData)[i1 * 3] +
                                  (*normalData)[i2 * 3]) /
                                 3.0f;
-            const float avgNy = ((*normalData)[i0 * 3 + 1] +
-                                 (*normalData)[i1 * 3 + 1] +
-                                 (*normalData)[i2 * 3 + 1]) /
-                                3.0f;
-            const float avgNz = ((*normalData)[i0 * 3 + 2] +
-                                 (*normalData)[i1 * 3 + 2] +
-                                 (*normalData)[i2 * 3 + 2]) /
-                                3.0f;
+            const float avgNy =
+                ((*normalData)[i0 * 3 + 1] + (*normalData)[i1 * 3 + 1] +
+                 (*normalData)[i2 * 3 + 1]) /
+                3.0f;
+            const float avgNz =
+                ((*normalData)[i0 * 3 + 2] + (*normalData)[i1 * 3 + 2] +
+                 (*normalData)[i2 * 3 + 2]) /
+                3.0f;
             const float alignment = nx * avgNx + ny * avgNy + nz * avgNz;
             if (alignment < 0.0f) {
               nx = -nx;
@@ -1086,30 +1104,26 @@ void SceneRenderer::DrawMesh(const Mesh &mesh, float scale, const float *modelMa
 
       if (hasNormals) {
         if (textureEnabled) {
-          float faceNx = (v1y - v0y) * (v2z - v0z) -
-                         (v1z - v0z) * (v2y - v0y);
-          float faceNy = (v1z - v0z) * (v2x - v0x) -
-                         (v1x - v0x) * (v2z - v0z);
-          float faceNz = (v1x - v0x) * (v2y - v0y) -
-                         (v1y - v0y) * (v2x - v0x);
+          float faceNx = (v1y - v0y) * (v2z - v0z) - (v1z - v0z) * (v2y - v0y);
+          float faceNy = (v1z - v0z) * (v2x - v0x) - (v1x - v0x) * (v2z - v0z);
+          float faceNz = (v1x - v0x) * (v2y - v0y) - (v1y - v0y) * (v2x - v0x);
           const float faceLen =
               std::sqrt(faceNx * faceNx + faceNy * faceNy + faceNz * faceNz);
           if (faceLen > 0.0f) {
             faceNx /= faceLen;
             faceNy /= faceLen;
             faceNz /= faceLen;
-            const float avgNx = ((*normalData)[i0 * 3] +
-                                 (*normalData)[i1 * 3] +
+            const float avgNx = ((*normalData)[i0 * 3] + (*normalData)[i1 * 3] +
                                  (*normalData)[i2 * 3]) /
                                 3.0f;
-            const float avgNy = ((*normalData)[i0 * 3 + 1] +
-                                 (*normalData)[i1 * 3 + 1] +
-                                 (*normalData)[i2 * 3 + 1]) /
-                                3.0f;
-            const float avgNz = ((*normalData)[i0 * 3 + 2] +
-                                 (*normalData)[i1 * 3 + 2] +
-                                 (*normalData)[i2 * 3 + 2]) /
-                                3.0f;
+            const float avgNy =
+                ((*normalData)[i0 * 3 + 1] + (*normalData)[i1 * 3 + 1] +
+                 (*normalData)[i2 * 3 + 1]) /
+                3.0f;
+            const float avgNz =
+                ((*normalData)[i0 * 3 + 2] + (*normalData)[i1 * 3 + 2] +
+                 (*normalData)[i2 * 3 + 2]) /
+                3.0f;
             const float alignment =
                 faceNx * avgNx + faceNy * avgNy + faceNz * avgNz;
             if (alignment < 0.0f) {
@@ -1180,10 +1194,12 @@ void SceneRenderer::DrawMesh(const Mesh &mesh, float scale, const float *modelMa
     glEnable(GL_CULL_FACE);
 }
 
-// Draw the 2D reference grid with configurable spacing and a moderate centered extent.
+// Draw the 2D reference grid with configurable spacing and a moderate centered
+// extent.
 void SceneRenderer::DrawGrid(int style, float r, float g, float b,
                              Viewer2DView view) {
-  const float step = std::max(0.01f, ConfigManager::Get().GetFloat("grid_spacing_m"));
+  const float step =
+      std::max(0.01f, ConfigManager::Get().GetFloat("grid_spacing_m"));
   const float halfCellCount = 40.0f;
   const float size = step * halfCellCount;
 
@@ -1215,7 +1231,8 @@ void SceneRenderer::DrawGrid(int style, float r, float g, float b,
         glVertex3f(i, size, 0.0f);
         glVertex3f(-size, i, 0.0f);
         glVertex3f(size, i, 0.0f);
-        if (m_controller.GetCaptureCanvas() && m_controller.CaptureIncludesGrid()) {
+        if (m_controller.GetCaptureCanvas() &&
+            m_controller.CaptureIncludesGrid()) {
           m_controller.RecordLine({i, -size, 0.0f}, {i, size, 0.0f}, stroke);
           m_controller.RecordLine({-size, i, 0.0f}, {size, i, 0.0f}, stroke);
         }
@@ -1225,7 +1242,8 @@ void SceneRenderer::DrawGrid(int style, float r, float g, float b,
         glVertex3f(i, 0.0f, size);
         glVertex3f(-size, 0.0f, i);
         glVertex3f(size, 0.0f, i);
-        if (m_controller.GetCaptureCanvas() && m_controller.CaptureIncludesGrid()) {
+        if (m_controller.GetCaptureCanvas() &&
+            m_controller.CaptureIncludesGrid()) {
           m_controller.RecordLine({i, 0.0f, -size}, {i, 0.0f, size}, stroke);
           m_controller.RecordLine({-size, 0.0f, i}, {size, 0.0f, i}, stroke);
         }
@@ -1235,7 +1253,8 @@ void SceneRenderer::DrawGrid(int style, float r, float g, float b,
         glVertex3f(0.0f, i, size);
         glVertex3f(0.0f, -size, i);
         glVertex3f(0.0f, size, i);
-        if (m_controller.GetCaptureCanvas() && m_controller.CaptureIncludesGrid()) {
+        if (m_controller.GetCaptureCanvas() &&
+            m_controller.CaptureIncludesGrid()) {
           m_controller.RecordLine({0.0f, i, -size}, {0.0f, i, size}, stroke);
           m_controller.RecordLine({0.0f, -size, i}, {0.0f, size, i}, stroke);
         }
@@ -1254,17 +1273,20 @@ void SceneRenderer::DrawGrid(int style, float r, float g, float b,
         case Viewer2DView::Top:
         case Viewer2DView::Bottom:
           glVertex3f(x, y, 0.0f);
-          if (m_controller.GetCaptureCanvas() && m_controller.CaptureIncludesGrid())
+          if (m_controller.GetCaptureCanvas() &&
+              m_controller.CaptureIncludesGrid())
             m_controller.RecordLine({x, y, 0.0f}, {x, y, 0.0f}, stroke);
           break;
         case Viewer2DView::Front:
           glVertex3f(x, 0.0f, y);
-          if (m_controller.GetCaptureCanvas() && m_controller.CaptureIncludesGrid())
+          if (m_controller.GetCaptureCanvas() &&
+              m_controller.CaptureIncludesGrid())
             m_controller.RecordLine({x, 0.0f, y}, {x, 0.0f, y}, stroke);
           break;
         case Viewer2DView::Side:
           glVertex3f(0.0f, x, y);
-          if (m_controller.GetCaptureCanvas() && m_controller.CaptureIncludesGrid())
+          if (m_controller.GetCaptureCanvas() &&
+              m_controller.CaptureIncludesGrid())
             m_controller.RecordLine({0.0f, x, y}, {0.0f, x, y}, stroke);
           break;
         }
@@ -1286,9 +1308,12 @@ void SceneRenderer::DrawGrid(int style, float r, float g, float b,
           glVertex3f(x + half, y, 0.0f);
           glVertex3f(x, y - half, 0.0f);
           glVertex3f(x, y + half, 0.0f);
-          if (m_controller.GetCaptureCanvas() && m_controller.CaptureIncludesGrid()) {
-            m_controller.RecordLine({x - half, y, 0.0f}, {x + half, y, 0.0f}, stroke);
-            m_controller.RecordLine({x, y - half, 0.0f}, {x, y + half, 0.0f}, stroke);
+          if (m_controller.GetCaptureCanvas() &&
+              m_controller.CaptureIncludesGrid()) {
+            m_controller.RecordLine({x - half, y, 0.0f}, {x + half, y, 0.0f},
+                                    stroke);
+            m_controller.RecordLine({x, y - half, 0.0f}, {x, y + half, 0.0f},
+                                    stroke);
           }
           break;
         case Viewer2DView::Front:
@@ -1296,9 +1321,12 @@ void SceneRenderer::DrawGrid(int style, float r, float g, float b,
           glVertex3f(x + half, 0.0f, y);
           glVertex3f(x, 0.0f, y - half);
           glVertex3f(x, 0.0f, y + half);
-          if (m_controller.GetCaptureCanvas() && m_controller.CaptureIncludesGrid()) {
-            m_controller.RecordLine({x - half, 0.0f, y}, {x + half, 0.0f, y}, stroke);
-            m_controller.RecordLine({x, 0.0f, y - half}, {x, 0.0f, y + half}, stroke);
+          if (m_controller.GetCaptureCanvas() &&
+              m_controller.CaptureIncludesGrid()) {
+            m_controller.RecordLine({x - half, 0.0f, y}, {x + half, 0.0f, y},
+                                    stroke);
+            m_controller.RecordLine({x, 0.0f, y - half}, {x, 0.0f, y + half},
+                                    stroke);
           }
           break;
         case Viewer2DView::Side:
@@ -1306,9 +1334,12 @@ void SceneRenderer::DrawGrid(int style, float r, float g, float b,
           glVertex3f(0.0f, x + half, y);
           glVertex3f(0.0f, x, y - half);
           glVertex3f(0.0f, x, y + half);
-          if (m_controller.GetCaptureCanvas() && m_controller.CaptureIncludesGrid()) {
-            m_controller.RecordLine({0.0f, x - half, y}, {0.0f, x + half, y}, stroke);
-            m_controller.RecordLine({0.0f, x, y - half}, {0.0f, x, y + half}, stroke);
+          if (m_controller.GetCaptureCanvas() &&
+              m_controller.CaptureIncludesGrid()) {
+            m_controller.RecordLine({0.0f, x - half, y}, {0.0f, x + half, y},
+                                    stroke);
+            m_controller.RecordLine({0.0f, x, y - half}, {0.0f, x, y + half},
+                                    stroke);
           }
           break;
         }

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -20,9 +20,12 @@
 #include <cstdint>
 
 namespace {
-constexpr float kGroupHighlightR = 0.62f;
-constexpr float kGroupHighlightG = 0.90f;
-constexpr float kGroupHighlightB = 0.58f;
+constexpr float kPrimaryHighlightR = 0.78f;
+constexpr float kPrimaryHighlightG = 1.0f;
+constexpr float kPrimaryHighlightB = 0.0f;
+constexpr float kGroupHighlightR = 0.25f;
+constexpr float kGroupHighlightG = 0.78f;
+constexpr float kGroupHighlightB = 0.55f;
 
 struct InkColor {
   float r = 1.0f;
@@ -620,7 +623,8 @@ void SceneRenderer::DrawMeshWithOutline(
         float glowWidth = lineWidth + 3.0f;
         glLineWidth(glowWidth);
         if (highlight)
-          m_controller.SetGLColor(0.0f, 1.0f, 0.0f);
+          m_controller.SetGLColor(kPrimaryHighlightR, kPrimaryHighlightG,
+                                  kPrimaryHighlightB);
         else if (groupHighlight)
           m_controller.SetGLColor(kGroupHighlightR, kGroupHighlightG,
                                   kGroupHighlightB);
@@ -713,7 +717,8 @@ void SceneRenderer::DrawMeshWithOutline(
       const float lineWidth = lineProfile.lineWidth;
       auto setHighlightOrSelectionColor = [&]() {
         if (highlight)
-          m_controller.SetGLColor(0.0f, 1.0f, 0.0f);
+          m_controller.SetGLColor(kPrimaryHighlightR, kPrimaryHighlightG,
+                                  kPrimaryHighlightB);
         else if (groupHighlight)
           m_controller.SetGLColor(kGroupHighlightR, kGroupHighlightG,
                                   kGroupHighlightB);
@@ -811,7 +816,8 @@ void SceneRenderer::DrawMeshWithOutline(
           !groupHighlight && !selected && !useTexture &&
           mesh.hasMaterialBaseColor;
       if (highlight)
-        m_controller.SetGLColor(0.0f, 1.0f, 0.0f);
+        m_controller.SetGLColor(kPrimaryHighlightR, kPrimaryHighlightG,
+                                kPrimaryHighlightB);
       else if (groupHighlight)
         m_controller.SetGLColor(kGroupHighlightR, kGroupHighlightG,
                                 kGroupHighlightB);

--- a/viewer3d/render/scenerenderer.cpp
+++ b/viewer3d/render/scenerenderer.cpp
@@ -20,6 +20,10 @@
 #include <cstdint>
 
 namespace {
+constexpr float kGroupHighlightR = 0.62f;
+constexpr float kGroupHighlightG = 0.90f;
+constexpr float kGroupHighlightB = 0.58f;
+
 struct InkColor {
   float r = 1.0f;
   float g = 1.0f;
@@ -618,7 +622,8 @@ void SceneRenderer::DrawMeshWithOutline(
         if (highlight)
           m_controller.SetGLColor(0.0f, 1.0f, 0.0f);
         else if (groupHighlight)
-          m_controller.SetGLColor(0.45f, 1.0f, 0.35f);
+          m_controller.SetGLColor(kGroupHighlightR, kGroupHighlightG,
+                                  kGroupHighlightB);
         else if (selected)
           m_controller.SetGLColor(0.0f, 1.0f, 1.0f);
         DrawMeshWireframe(mesh, scale, captureTransform);
@@ -710,7 +715,8 @@ void SceneRenderer::DrawMeshWithOutline(
         if (highlight)
           m_controller.SetGLColor(0.0f, 1.0f, 0.0f);
         else if (groupHighlight)
-          m_controller.SetGLColor(0.45f, 1.0f, 0.35f);
+          m_controller.SetGLColor(kGroupHighlightR, kGroupHighlightG,
+                                  kGroupHighlightB);
         else if (selected)
           m_controller.SetGLColor(0.0f, 1.0f, 1.0f);
         else
@@ -807,7 +813,8 @@ void SceneRenderer::DrawMeshWithOutline(
       if (highlight)
         m_controller.SetGLColor(0.0f, 1.0f, 0.0f);
       else if (groupHighlight)
-        m_controller.SetGLColor(0.45f, 1.0f, 0.35f);
+        m_controller.SetGLColor(kGroupHighlightR, kGroupHighlightG,
+                                kGroupHighlightB);
       else if (selected)
         m_controller.SetGLColor(0.0f, 1.0f, 1.0f);
       else if (useMaterialColor)

--- a/viewer3d/render/scenerenderer.h
+++ b/viewer3d/render/scenerenderer.h
@@ -7,20 +7,21 @@
 
 class SceneRenderer {
 public:
-  explicit SceneRenderer(IRenderContext &controller) : m_controller(controller) {}
+  explicit SceneRenderer(IRenderContext &controller)
+      : m_controller(controller) {}
 
   void DrawMeshWithOutline(
       const Mesh &mesh, float r, float g, float b, float scale, bool highlight,
-      bool selected, float cx, float cy, float cz, bool wireframe,
-      Viewer2DRenderMode mode,
-      const std::function<std::array<float, 3>(const std::array<float, 3> &)> &captureTransform,
-      bool unlit, const float *modelMatrix,
-      bool disableDepthBias = false);
+      bool groupHighlight, bool selected, float cx, float cy, float cz,
+      bool wireframe, Viewer2DRenderMode mode,
+      const std::function<std::array<float, 3>(const std::array<float, 3> &)>
+          &captureTransform,
+      bool unlit, const float *modelMatrix, bool disableDepthBias = false);
   void DrawMeshWireframe(
       const Mesh &mesh, float scale,
-      const std::function<std::array<float, 3>(const std::array<float, 3> &)> &captureTransform,
-      const CanvasStroke *captureStroke = nullptr,
-      int triangleStep = 1);
+      const std::function<std::array<float, 3>(const std::array<float, 3> &)>
+          &captureTransform,
+      const CanvasStroke *captureStroke = nullptr, int triangleStep = 1);
   void DrawMesh(const Mesh &mesh, float scale, const float *modelMatrix,
                 bool useTexture = false);
   void DrawGrid(int style, float r, float g, float b, Viewer2DView view);

--- a/viewer3d/render/selection_overlay_pass.cpp
+++ b/viewer3d/render/selection_overlay_pass.cpp
@@ -61,27 +61,32 @@ bool HexToRGB(const std::string &hex, float &r, float &g, float &b) {
   return true;
 }
 
-bool ContainsUuid(const std::vector<std::string> &uuids, const std::string &uuid) {
+bool ContainsUuid(const std::vector<std::string> &uuids,
+                  const std::string &uuid) {
   return std::find(uuids.begin(), uuids.end(), uuid) != uuids.end();
 }
 
-void AppendUuidIfRenderable(const std::string &uuid,
-                            const std::unordered_map<std::string, Fixture> &fixtures,
-                            const std::unordered_map<std::string, Truss> &trusses,
-                            const std::unordered_map<std::string, SceneObject> &objects,
-                            Viewer3DVisibleSet &overlaySet) {
+void AppendUuidIfRenderable(
+    const std::string &uuid,
+    const std::unordered_map<std::string, Fixture> &fixtures,
+    const std::unordered_map<std::string, Truss> &trusses,
+    const std::unordered_map<std::string, SceneObject> &objects,
+    Viewer3DVisibleSet &overlaySet) {
   if (uuid.empty())
     return;
 
-  if (fixtures.find(uuid) != fixtures.end() && !ContainsUuid(overlaySet.fixtureUuids, uuid)) {
+  if (fixtures.find(uuid) != fixtures.end() &&
+      !ContainsUuid(overlaySet.fixtureUuids, uuid)) {
     overlaySet.fixtureUuids.push_back(uuid);
     return;
   }
-  if (trusses.find(uuid) != trusses.end() && !ContainsUuid(overlaySet.trussUuids, uuid)) {
+  if (trusses.find(uuid) != trusses.end() &&
+      !ContainsUuid(overlaySet.trussUuids, uuid)) {
     overlaySet.trussUuids.push_back(uuid);
     return;
   }
-  if (objects.find(uuid) != objects.end() && !ContainsUuid(overlaySet.objectUuids, uuid)) {
+  if (objects.find(uuid) != objects.end() &&
+      !ContainsUuid(overlaySet.objectUuids, uuid)) {
     overlaySet.objectUuids.push_back(uuid);
     return;
   }
@@ -96,15 +101,19 @@ void SelectionOverlayPass::Render(Viewer3DController &controller,
   const auto &objects = SceneDataManager::Instance().GetSceneObjects();
 
   Viewer3DVisibleSet overlaySet;
-  const auto appendFromVisibility = [&](const std::vector<std::string> &sourceUuids,
-                                        std::vector<std::string> &targetUuids) {
-    for (const auto &uuid : sourceUuids) {
-      if (uuid == controller.m_highlightUuid ||
-          controller.m_selectedUuids.find(uuid) != controller.m_selectedUuids.end()) {
-        targetUuids.push_back(uuid);
-      }
-    }
-  };
+  const auto appendFromVisibility =
+      [&](const std::vector<std::string> &sourceUuids,
+          std::vector<std::string> &targetUuids) {
+        for (const auto &uuid : sourceUuids) {
+          if (uuid == controller.m_highlightUuid ||
+              controller.m_groupHighlightUuids.find(uuid) !=
+                  controller.m_groupHighlightUuids.end() ||
+              controller.m_selectedUuids.find(uuid) !=
+                  controller.m_selectedUuids.end()) {
+            targetUuids.push_back(uuid);
+          }
+        }
+      };
 
   appendFromVisibility(visibleSet.fixtureUuids, overlaySet.fixtureUuids);
   appendFromVisibility(visibleSet.trussUuids, overlaySet.trussUuids);
@@ -112,6 +121,9 @@ void SelectionOverlayPass::Render(Viewer3DController &controller,
 
   AppendUuidIfRenderable(controller.m_highlightUuid, fixtures, trusses, objects,
                          overlaySet);
+  for (const auto &uuid : controller.m_groupHighlightUuids) {
+    AppendUuidIfRenderable(uuid, fixtures, trusses, objects, overlaySet);
+  }
 
   for (const auto &uuid : controller.m_selectedUuids) {
     AppendUuidIfRenderable(uuid, fixtures, trusses, objects, overlaySet);
@@ -156,11 +168,12 @@ void SelectionOverlayPass::Render(Viewer3DController &controller,
   GLint previousDepthFunc = GL_LESS;
   glGetIntegerv(GL_DEPTH_FUNC, &previousDepthFunc);
   glDepthFunc(GL_LEQUAL);
-  OpaqueObjectPass::Render(controller, overlayContext, overlaySet, getLayerColor,
-                           resolveSymbolView, getPickColor);
+  OpaqueObjectPass::Render(controller, overlayContext, overlaySet,
+                           getLayerColor, resolveSymbolView, getPickColor);
   OpaqueTrussPass::Render(controller, overlayContext, overlaySet, getLayerColor,
                           resolveSymbolView, getPickColor);
-  OpaqueFixturePass::Render(controller, overlayContext, overlaySet, getTypeColor,
-                            getLayerColor, resolveSymbolView, getPickColor);
+  OpaqueFixturePass::Render(controller, overlayContext, overlaySet,
+                            getTypeColor, getLayerColor, resolveSymbolView,
+                            getPickColor);
   glDepthFunc(static_cast<GLenum>(previousDepthFunc));
 }

--- a/viewer3d/viewer3dcontroller.cpp
+++ b/viewer3d/viewer3dcontroller.cpp
@@ -39,56 +39,57 @@
 #include <GL/gl.h>
 #include <GL/glu.h>
 #endif
-#include <cstdlib>
 #include <algorithm>
+#include <cstdlib>
 #include <numeric>
 
 #include "configmanager.h"
 #include "loader3ds.h"
 #include "loaderglb.h"
-#include "scenedatamanager.h"
 #include "matrixutils.h"
+#include "scenedatamanager.h"
 #include "viewer3dcontroller.h"
 // Include shared Matrix type used throughout models
-#include "types.h"
+#include "bounds_cache_system.h"
 #include "consolepanel.h"
-#include "logger.h"
-#include "projectutils.h"
-#include "scenerenderer.h"
-#include "render_pipeline.h"
-#include "opaque_fixture_pass.h"
+#include "gl_primitive_renderer.h"
 #include "hoist_symbol_renderer.h"
+#include "id_pick_pass.h"
+#include "label_render_system.h"
+#include "lighting_profile.h"
+#include "logger.h"
+#include "opaque_fixture_pass.h"
 #include "opaque_object_pass.h"
 #include "opaque_truss_pass.h"
+#include "projectutils.h"
+#include "render_pipeline.h"
+#include "scene_grouping.h"
+#include "scenerenderer.h"
 #include "selection_overlay_pass.h"
-#include "bounds_cache_system.h"
-#include "visibilitysystem.h"
-#include "label_render_system.h"
 #include "selectionsystem.h"
-#include "id_pick_pass.h"
-#include "gl_primitive_renderer.h"
-#include "lighting_profile.h"
+#include "types.h"
 #include "viewer3d_render_style.h"
 #include "viewer3dcontroller_cache_helpers.h"
+#include "visibilitysystem.h"
 
 #include <wx/wx.h>
 #define NANOVG_GL2_IMPLEMENTATION
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cfloat>
 #include <cmath>
+#include <cstdint>
 #include <filesystem>
+#include <iomanip>
 #include <iostream>
 #include <nanovg.h>
 #include <nanovg_gl.h>
-#include <cstdint>
-#include <iomanip>
-#include <string_view>
 #include <sstream>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-#include <atomic>
 
 namespace fs = std::filesystem;
 
@@ -107,9 +108,11 @@ struct Viewer3DController::Impl {
   std::vector<const std::pair<const std::string, Fixture> *> sortedFixtures;
   std::vector<const std::pair<const std::string, Truss> *> sortedTrusses;
   std::vector<const std::pair<const std::string, SceneObject> *> sortedObjects;
-  std::vector<const std::pair<const std::string, Fixture> *> visibleSortedFixtures;
+  std::vector<const std::pair<const std::string, Fixture> *>
+      visibleSortedFixtures;
   std::vector<const std::pair<const std::string, Truss> *> visibleSortedTrusses;
-  std::vector<const std::pair<const std::string, SceneObject> *> visibleSortedObjects;
+  std::vector<const std::pair<const std::string, SceneObject> *>
+      visibleSortedObjects;
   std::unordered_set<std::string> lastHiddenLayers;
   std::unordered_set<std::string> lastHiddenFixtureTypes;
   size_t hiddenLayersVersion = 0;
@@ -120,6 +123,7 @@ struct Viewer3DController::Impl {
   std::unordered_map<std::string, std::array<float, 3>> typeColors;
   std::unordered_map<std::string, std::array<float, 3>> layerColors;
   std::string highlightUuid;
+  std::unordered_set<std::string> groupHighlightUuids;
   std::unordered_set<std::string> selectedUuids;
   NVGcontext *vg = nullptr;
   int font = -1;
@@ -150,7 +154,8 @@ struct Viewer3DController::Impl {
   mutable VisibleSet cachedLayerVisibleCandidates;
   mutable size_t layerVisibleCandidatesSceneVersion = static_cast<size_t>(-1);
   mutable std::unordered_set<std::string> layerVisibleCandidatesHiddenLayers;
-  mutable std::unordered_set<std::string> layerVisibleCandidatesHiddenFixtureTypes;
+  mutable std::unordered_set<std::string>
+      layerVisibleCandidatesHiddenFixtureTypes;
   mutable size_t layerVisibleCandidatesRevision = 0;
   mutable size_t visibleSetLayerCandidatesRevision = static_cast<size_t>(-1);
   mutable bool visibleSetFrustumCulling = false;
@@ -224,8 +229,7 @@ struct EdgeInfo {
 
 // Builds and returns face Normal.
 static std::array<float, 3> BuildFaceNormal(const std::vector<float> &vertices,
-                                            uint32_t i0,
-                                            uint32_t i1,
+                                            uint32_t i0, uint32_t i1,
                                             uint32_t i2) {
   const size_t p0 = static_cast<size_t>(i0) * 3u;
   const size_t p1 = static_cast<size_t>(i1) * 3u;
@@ -261,8 +265,7 @@ BuildWireframeIndices(const std::vector<float> &vertices,
                       bool includeCoplanarEdges) {
   static constexpr float kCreaseAngleDeg = 5.0f;
   static constexpr float kPi = 3.14159265358979323846f;
-  const float creaseDotThreshold =
-      std::cos(kCreaseAngleDeg * kPi / 180.0f);
+  const float creaseDotThreshold = std::cos(kCreaseAngleDeg * kPi / 180.0f);
 
   std::unordered_map<EdgeKey, EdgeInfo, EdgeKeyHash> edges;
   edges.reserve(triangleIndices.size());
@@ -282,7 +285,8 @@ BuildWireframeIndices(const std::vector<float> &vertices,
     const uint32_t i0 = triangleIndices[i];
     const uint32_t i1 = triangleIndices[i + 1];
     const uint32_t i2 = triangleIndices[i + 2];
-    const std::array<float, 3> faceNormal = BuildFaceNormal(vertices, i0, i1, i2);
+    const std::array<float, 3> faceNormal =
+        BuildFaceNormal(vertices, i0, i1, i2);
 
     registerEdge(i0, i1, faceNormal);
     registerEdge(i1, i2, faceNormal);
@@ -369,7 +373,6 @@ static std::array<float, 3> MakeDeterministicColor(std::string_view key) {
   float val = 0.7f + static_cast<float>((hash >> 16) & 0xFFu) / 255.0f * 0.25f;
   return HsvToRgb(hue, sat, val);
 }
-
 
 // Computes and returns symbol Bounds.
 static SymbolBounds ComputeSymbolBounds(const CommandBuffer &buffer) {
@@ -507,9 +510,9 @@ static std::array<float, 3> TransformPoint(const Matrix &m,
           m.u[2] * p[0] + m.v[2] * p[1] + m.w[2] * p[2] + m.o[2]};
 }
 
-
 // Builds and returns instance Transform2D.
-static Transform2D BuildInstanceTransform2D(const Matrix &m, Viewer2DView view) {
+static Transform2D BuildInstanceTransform2D(const Matrix &m,
+                                            Viewer2DView view) {
   Transform2D t{};
   switch (view) {
   case Viewer2DView::Top:
@@ -593,8 +596,8 @@ void Viewer3DController::RecordPolyline(
 
 // Records polygon.
 void Viewer3DController::RecordPolygon(
-    const std::vector<std::array<float, 3>> &points,
-    const CanvasStroke &stroke, const CanvasFill *fill) const {
+    const std::vector<std::array<float, 3>> &points, const CanvasStroke &stroke,
+    const CanvasFill *fill) const {
   if (!m_impl->captureCanvas || points.size() < 3)
     return;
   std::vector<float> flat;
@@ -630,9 +633,9 @@ Viewer3DController::Viewer3DController()
     : m_impl(std::make_unique<Impl>()),
       m_resourceSyncState(m_impl->resourceSyncState),
       m_fixtureBounds(m_impl->fixtureBounds),
-      m_trussBounds(m_impl->trussBounds),
-      m_objectBounds(m_impl->objectBounds),
+      m_trussBounds(m_impl->trussBounds), m_objectBounds(m_impl->objectBounds),
       m_highlightUuid(m_impl->highlightUuid),
+      m_groupHighlightUuids(m_impl->groupHighlightUuids),
       m_selectedUuids(m_impl->selectedUuids),
       m_captureCanvas(m_impl->captureCanvas),
       m_captureView(m_impl->captureView),
@@ -760,6 +763,11 @@ void Viewer3DController::SetSelectedUuids(
 // Applies highlight UUID.
 void Viewer3DController::ApplyHighlightUuid(const std::string &uuid) {
   m_impl->highlightUuid = uuid;
+  m_impl->groupHighlightUuids.clear();
+  for (const auto &groupUuid : scene_grouping::ExpandHoverForGroupHighlights(
+           ConfigManager::Get().GetScene(), uuid)) {
+    m_impl->groupHighlightUuids.insert(groupUuid);
+  }
 }
 
 // Replaces selected UUIDs.
@@ -791,19 +799,17 @@ Viewer3DController::FindObjectBounds(const std::string &uuid) const {
   return it == m_impl->objectBounds.end() ? nullptr : &it->second;
 }
 
-
 // Ensures bounds Computed is available.
 bool Viewer3DController::EnsureBoundsComputed(
     const std::string &uuid, ItemType type,
     const std::unordered_set<std::string> &hiddenLayers) {
-  return m_impl->visibilitySystem->EnsureBoundsComputed(uuid, type, hiddenLayers);
+  return m_impl->visibilitySystem->EnsureBoundsComputed(uuid, type,
+                                                        hiddenLayers);
 }
 
 // Loads meshes or GDTF models referenced by scene objects. Called when the
 // scene is updated.
-void Viewer3DController::Update() {
-  UpdateFrameStateLightweight();
-}
+void Viewer3DController::Update() { UpdateFrameStateLightweight(); }
 
 // Updates frame State Lightweight.
 void Viewer3DController::UpdateFrameStateLightweight() {
@@ -811,12 +817,14 @@ void Viewer3DController::UpdateFrameStateLightweight() {
   const auto hiddenLayers = ControllerSnapshotHiddenLayers(cfg);
   const auto hiddenFixtureTypes = cfg.GetHiddenFixtureTypes();
   if (hiddenLayers != m_impl->lastHiddenLayers) {
-    Logger::Instance().Log("visibility dirty reason: hidden layers changed vs last frame snapshot");
+    Logger::Instance().Log("visibility dirty reason: hidden layers changed vs "
+                           "last frame snapshot");
     m_impl->visibilityChangedDirty = true;
     MarkResourceSyncPending();
   }
   if (hiddenFixtureTypes != m_impl->lastHiddenFixtureTypes) {
-    Logger::Instance().Log("visibility dirty reason: hidden fixture types changed vs last frame snapshot");
+    Logger::Instance().Log("visibility dirty reason: hidden fixture types "
+                           "changed vs last frame snapshot");
     m_impl->visibilityChangedDirty = true;
     MarkResourceSyncPending();
   }
@@ -890,7 +898,9 @@ void Viewer3DController::UpdateResourcesIfDirty() {
 
   ResourceSyncCallbacks callbacks;
   callbacks.setupMeshBuffers = [this](Mesh &mesh) { SetupMeshBuffers(mesh); };
-  callbacks.releaseMeshBuffers = [this](Mesh &mesh) { ReleaseMeshBuffers(mesh); };
+  callbacks.releaseMeshBuffers = [this](Mesh &mesh) {
+    ReleaseMeshBuffers(mesh);
+  };
   callbacks.appendConsoleMessage = [](const std::string &msg) {
     if (ConsolePanel::Instance())
       ConsolePanel::Instance()->AppendMessage(wxString::FromUTF8(msg));
@@ -909,8 +919,9 @@ void Viewer3DController::UpdateResourcesIfDirty() {
       visibleObjects, visibleFixtures, m_impl->resourceSyncState, callbacks);
 
   if (syncResult.sceneChanged) {
-    Logger::Instance().Log("scene dirty reason: resource sync signature changed to " +
-                           std::to_string(syncResult.sceneSignature));
+    Logger::Instance().Log(
+        "scene dirty reason: resource sync signature changed to " +
+        std::to_string(syncResult.sceneSignature));
     ++m_impl->sceneVersion;
     m_impl->sceneChangedDirty = true;
     std::lock_guard<std::mutex> lock(m_impl->sortedListsMutex);
@@ -928,31 +939,31 @@ void Viewer3DController::UpdateResourcesIfDirty() {
   }
 
   BoundsCacheSystem::Context boundsContext{
-      m_impl->resourceSyncState, m_impl->modelBounds, m_impl->fixtureBounds,
-      m_impl->trussBounds,      m_impl->objectBounds, m_impl->boundsHiddenLayers,
-      m_impl->sceneVersion,     m_impl->cachedVersion, m_impl->sceneChangedDirty,
-      m_impl->assetsChangedDirty, m_impl->visibilityChangedDirty,
-      m_impl->sortedListsMutex, m_impl->sortedListsDirty};
+      m_impl->resourceSyncState,      m_impl->modelBounds,
+      m_impl->fixtureBounds,          m_impl->trussBounds,
+      m_impl->objectBounds,           m_impl->boundsHiddenLayers,
+      m_impl->sceneVersion,           m_impl->cachedVersion,
+      m_impl->sceneChangedDirty,      m_impl->assetsChangedDirty,
+      m_impl->visibilityChangedDirty, m_impl->sortedListsMutex,
+      m_impl->sortedListsDirty};
   BoundsCacheSystem::RebuildIfDirty(boundsContext, hiddenLayers, trusses,
                                     objects, fixtures);
   m_impl->lastHiddenLayers = hiddenLayers;
   m_impl->lastHiddenFixtureTypes = cfg.GetHiddenFixtureTypes();
 }
 
-
-
 // Attempts to build Layer Visible Candidates.
 bool Viewer3DController::TryBuildLayerVisibleCandidates(
     const std::unordered_set<std::string> &hiddenLayers,
     VisibleSet &out) const {
-  return m_impl->visibilitySystem->TryBuildLayerVisibleCandidates(hiddenLayers, out);
+  return m_impl->visibilitySystem->TryBuildLayerVisibleCandidates(hiddenLayers,
+                                                                  out);
 }
 
 // Attempts to build Visible Set.
 bool Viewer3DController::TryBuildVisibleSet(
-    const ViewFrustumSnapshot &frustum, bool useFrustumCulling,
-    float minPixels, const VisibleSet &layerVisibleCandidates,
-    VisibleSet &out) const {
+    const ViewFrustumSnapshot &frustum, bool useFrustumCulling, float minPixels,
+    const VisibleSet &layerVisibleCandidates, VisibleSet &out) const {
   return m_impl->visibilitySystem->TryBuildVisibleSet(
       frustum, useFrustumCulling, minPixels, layerVisibleCandidates, out);
 }
@@ -960,10 +971,10 @@ bool Viewer3DController::TryBuildVisibleSet(
 // Returns visible Set.
 const Viewer3DController::VisibleSet &Viewer3DController::GetVisibleSet(
     const ViewFrustumSnapshot &frustum,
-    const std::unordered_set<std::string> &hiddenLayers,
-    bool useFrustumCulling, float minPixels) const {
+    const std::unordered_set<std::string> &hiddenLayers, bool useFrustumCulling,
+    float minPixels) const {
   return m_impl->visibilitySystem->GetVisibleSet(frustum, hiddenLayers,
-                                           useFrustumCulling, minPixels);
+                                                 useFrustumCulling, minPixels);
 }
 
 // Rebuilds visible Set Cache.
@@ -1009,7 +1020,8 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
   // During camera movement we prioritize frame pacing: keep drawing the
   // scene and camera updates, but defer optional CPU/GPU work until the
   // interaction grace period ends in Viewer3DPanel::ShouldPauseHeavyTasks().
-  context.skipOptionalWork = m_impl->cameraMoving && context.fastInteractionMode;
+  context.skipOptionalWork =
+      m_impl->cameraMoving && context.fastInteractionMode;
   context.skipCapture = context.skipOptionalWork && skipCaptureWhenMoving;
   context.skipOutlinesForCurrentFrame =
       context.skipOptionalWork && skipOutlinesWhenMoving;
@@ -1034,14 +1046,12 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
   context.minCullingPixels =
       context.is2DViewer ? culling.minPixels2D : culling.minPixels3D;
 
-  const bool isWireframeMode =
-      context.mode == Viewer2DRenderMode::Wireframe;
+  const bool isWireframeMode = context.mode == Viewer2DRenderMode::Wireframe;
   const bool isWhiteMode = context.mode == Viewer2DRenderMode::White;
   const bool isByFixtureTypeMode =
       context.mode == Viewer2DRenderMode::ByFixtureType;
   const bool isByLayerMode = context.mode == Viewer2DRenderMode::ByLayer;
-  const bool isByUniverseMode =
-      context.mode == Viewer2DRenderMode::ByUniverse;
+  const bool isByUniverseMode = context.mode == Viewer2DRenderMode::ByUniverse;
 
   context.useLighting = !context.wireframe;
   context.useAmbientOcclusion =
@@ -1081,8 +1091,9 @@ void Viewer3DController::RenderScene(bool wireframe, Viewer2DRenderMode mode,
 }
 
 // Prepares and returns render Frame.
-const Viewer3DController::VisibleSet &Viewer3DController::PrepareRenderFrame(
-    const RenderFrameContext &context, ViewFrustumSnapshot &frustum) {
+const Viewer3DController::VisibleSet &
+Viewer3DController::PrepareRenderFrame(const RenderFrameContext &context,
+                                       ViewFrustumSnapshot &frustum) {
   m_impl->skipOutlinesForCurrentFrame = context.skipOutlinesForCurrentFrame;
 
   int viewport[4] = {0, 0, 0, 0};
@@ -1106,7 +1117,8 @@ const Viewer3DController::VisibleSet &Viewer3DController::PrepareRenderFrame(
         (context.is2DViewer && m_impl->sortedListsLastView != context.view);
     if ((m_impl->sortedListsDirty || viewSortChanged) &&
         !context.skipOptionalWork) {
-      // Computes the transform-origin depth used by fixtures, trusses, and fallback object sorting.
+      // Computes the transform-origin depth used by fixtures, trusses, and
+      // fallback object sorting.
       const auto sortDepthKey = [&](const Matrix &transform) {
         if (!context.is2DViewer)
           return transform.o[2];
@@ -1123,7 +1135,8 @@ const Viewer3DController::VisibleSet &Viewer3DController::PrepareRenderFrame(
           return transform.o[2];
         }
       };
-      // Computes scene-object 2D sort depth from cached world bounds when available.
+      // Computes scene-object 2D sort depth from cached world bounds when
+      // available.
       const auto sceneObjectSortDepthKey = [&](const auto *entry) {
         const auto &transform = entry->second.transform;
         if (!context.is2DViewer)
@@ -1158,7 +1171,8 @@ const Viewer3DController::VisibleSet &Viewer3DController::PrepareRenderFrame(
         sceneObjectSortDepthKeys.emplace(obj.first,
                                          sceneObjectSortDepthKey(&obj));
       }
-      // Returns the precomputed scene-object sort depth for a sorted-list entry.
+      // Returns the precomputed scene-object sort depth for a sorted-list
+      // entry.
       const auto sceneObjectSortDepth = [&](const auto *entry) {
         const auto keyIt = sceneObjectSortDepthKeys.find(entry->first);
         if (keyIt != sceneObjectSortDepthKeys.end())
@@ -1204,10 +1218,10 @@ const Viewer3DController::VisibleSet &Viewer3DController::PrepareRenderFrame(
       ControllerInvalidateVisibleSetLayerCandidateCacheOwnership(
           m_impl->layerVisibleCandidatesSceneVersion);
     }
-
   }
 
-  std::copy(std::begin(viewport), std::end(viewport), std::begin(frustum.viewport));
+  std::copy(std::begin(viewport), std::end(viewport),
+            std::begin(frustum.viewport));
   std::copy(std::begin(model), std::end(model), std::begin(frustum.model));
   std::copy(std::begin(proj), std::end(proj), std::begin(frustum.projection));
   frustum.is2DViewer = context.is2DViewer;
@@ -1226,8 +1240,8 @@ void Viewer3DController::RenderOpaqueFrame(const RenderFrameContext &context,
 
   if (context.useLighting)
     SetupBasicLighting(context.useAmbientOcclusion,
-                      context.ambientOcclusionStrength,
-                      context.whiteModelStyle);
+                       context.ambientOcclusionStrength,
+                       context.whiteModelStyle);
   else
     glDisable(GL_LIGHTING);
 
@@ -1305,9 +1319,10 @@ void Viewer3DController::FinalizeRenderFrame() {
     m_impl->captureCanvas->SetSourceKey("unknown");
 }
 
-
 // Sets dark Mode.
-void Viewer3DController::SetDarkMode(bool enabled) { m_impl->darkMode = enabled; }
+void Viewer3DController::SetDarkMode(bool enabled) {
+  m_impl->darkMode = enabled;
+}
 
 // Sets interacting.
 void Viewer3DController::SetInteracting(bool interacting) {
@@ -1315,7 +1330,9 @@ void Viewer3DController::SetInteracting(bool interacting) {
 }
 
 // Sets camera Moving.
-void Viewer3DController::SetCameraMoving(bool moving) { m_impl->cameraMoving = moving; }
+void Viewer3DController::SetCameraMoving(bool moving) {
+  m_impl->cameraMoving = moving;
+}
 
 // Sets selection Outline Enabled.
 void Viewer3DController::SetSelectionOutlineEnabled(bool enabled) {
@@ -1394,8 +1411,8 @@ bool Viewer3DController::IsSymbolCaptureRenderProfileEnabled(
     return m_impl->symbolCaptureRenderProfileOverride.value();
   if (mode == Viewer2DRenderMode::ByFixtureType)
     return true;
-  return ConfigManager::Get().GetFloat("viewer3d_symbol_capture_render_profile") >=
-         0.5f;
+  return ConfigManager::Get().GetFloat(
+             "viewer3d_symbol_capture_render_profile") >= 0.5f;
 }
 
 // Checks whether camera Moving.
@@ -1406,8 +1423,8 @@ std::array<float, 3> Viewer3DController::AdjustColor(float r, float g,
                                                      float b) const {
   if (!m_impl->darkMode)
     return {r, g, b};
-  if (m_impl->activeRenderMode == Viewer2DRenderMode::Wireframe &&
-      r == 0.0f && g == 0.0f && b == 0.0f)
+  if (m_impl->activeRenderMode == Viewer2DRenderMode::Wireframe && r == 0.0f &&
+      g == 0.0f && b == 0.0f)
     return {1.0f, 1.0f, 1.0f};
   return {r, g, b};
 }
@@ -1425,17 +1442,16 @@ void Viewer3DController::DrawCube(float size, float r, float g, float b) {
       [this](float cr, float cg, float cb) { SetGLColor(cr, cg, cb); });
 }
 
-
 // Draws a wireframe cube centered at origin with given size and color
 void Viewer3DController::DrawWireframeCube(
     float size, float r, float g, float b, Viewer2DRenderMode mode,
-    const std::function<std::array<float, 3>(const std::array<float, 3> &)> &
-        captureTransform,
+    const std::function<std::array<float, 3>(const std::array<float, 3> &)>
+        &captureTransform,
     float lineWidthOverride, bool recordCapture) {
-  float lineWidth =
-      GetLineRenderProfile(m_impl->isInteracting, mode == Viewer2DRenderMode::Wireframe,
-                           m_impl->useAdaptiveLineProfile)
-          .lineWidth;
+  float lineWidth = GetLineRenderProfile(m_impl->isInteracting,
+                                         mode == Viewer2DRenderMode::Wireframe,
+                                         m_impl->useAdaptiveLineProfile)
+                        .lineWidth;
   if (IsSymbolCaptureRenderProfileEnabled(mode))
     lineWidth = 2.0f;
   GLPrimitiveRenderer::DrawWireframeCube(
@@ -1446,60 +1462,60 @@ void Viewer3DController::DrawWireframeCube(
              const CanvasStroke &stroke) { RecordLine(a, b, stroke); });
 }
 
-
 // Draws a wireframe box whose origin sits at the left end of the span.
 // The box extends along +X for the given length and is centered in Y/Z.
 void Viewer3DController::DrawWireframeBox(
     float length, float height, float width, float r, float g, float b,
-    bool highlight, bool selected, bool wireframe, Viewer2DRenderMode mode,
-    const std::function<std::array<float, 3>(const std::array<float, 3> &)> &
-        captureTransform) {
-  float lineWidth =
-      GetLineRenderProfile(m_impl->isInteracting, mode == Viewer2DRenderMode::Wireframe,
-                           m_impl->useAdaptiveLineProfile)
-          .lineWidth;
+    bool highlight, bool groupHighlight, bool selected, bool wireframe,
+    Viewer2DRenderMode mode,
+    const std::function<std::array<float, 3>(const std::array<float, 3> &)>
+        &captureTransform) {
+  float lineWidth = GetLineRenderProfile(m_impl->isInteracting,
+                                         mode == Viewer2DRenderMode::Wireframe,
+                                         m_impl->useAdaptiveLineProfile)
+                        .lineWidth;
   if (IsSymbolCaptureRenderProfileEnabled(mode))
     lineWidth = 2.0f;
   GLPrimitiveRenderer::DrawWireframeBox(
-      length, height, width, r, g, b, highlight, selected, wireframe, mode,
-      captureTransform, m_impl->skipOutlinesForCurrentFrame, m_impl->showSelectionOutline2D,
-      m_impl->captureOnly, m_impl->captureCanvas, lineWidth,
+      length, height, width, r, g, b, highlight, groupHighlight, selected,
+      wireframe, mode, captureTransform, m_impl->skipOutlinesForCurrentFrame,
+      m_impl->showSelectionOutline2D, m_impl->captureOnly,
+      m_impl->captureCanvas, lineWidth,
       [this](float cr, float cg, float cb) { SetGLColor(cr, cg, cb); },
       [this](const std::array<float, 3> &a, const std::array<float, 3> &b,
              const CanvasStroke &stroke) { RecordLine(a, b, stroke); });
 }
 
-
 // Draws a colored cube. If selected or highlighted it is tinted
 // in cyan or green respectively instead of its original color.
 void Viewer3DController::DrawCubeWithOutline(
-    float size, float r, float g, float b, bool highlight, bool selected,
-    float cx, float cy, float cz, bool wireframe, Viewer2DRenderMode mode,
-    const std::function<std::array<float, 3>(const std::array<float, 3> &)> &
-        captureTransform) {
+    float size, float r, float g, float b, bool highlight, bool groupHighlight,
+    bool selected, float cx, float cy, float cz, bool wireframe,
+    Viewer2DRenderMode mode,
+    const std::function<std::array<float, 3>(const std::array<float, 3> &)>
+        &captureTransform) {
   (void)cx;
   (void)cy;
   (void)cz;
 
-  float lineWidth =
-      GetLineRenderProfile(m_impl->isInteracting, mode == Viewer2DRenderMode::Wireframe,
-                           m_impl->useAdaptiveLineProfile)
-          .lineWidth;
+  float lineWidth = GetLineRenderProfile(m_impl->isInteracting,
+                                         mode == Viewer2DRenderMode::Wireframe,
+                                         m_impl->useAdaptiveLineProfile)
+                        .lineWidth;
   if (IsSymbolCaptureRenderProfileEnabled(mode))
     lineWidth = 2.0f;
   GLPrimitiveRenderer::DrawCubeWithOutline(
-      size, r, g, b, highlight, selected, wireframe, mode, captureTransform,
-      m_impl->skipOutlinesForCurrentFrame, m_impl->showSelectionOutline2D, m_impl->captureOnly,
+      size, r, g, b, highlight, groupHighlight, selected, wireframe, mode,
+      captureTransform, m_impl->skipOutlinesForCurrentFrame,
+      m_impl->showSelectionOutline2D, m_impl->captureOnly,
       m_impl->captureCanvas, lineWidth,
       [this](float cr, float cg, float cb) { SetGLColor(cr, cg, cb); },
       [this](const std::array<float, 3> &a, const std::array<float, 3> &b,
              const CanvasStroke &stroke) { RecordLine(a, b, stroke); },
       [this](const std::vector<std::array<float, 3>> &points,
-             const CanvasStroke &stroke, const CanvasFill *fill) {
-        RecordPolygon(points, stroke, fill);
-      });
+             const CanvasStroke &stroke,
+             const CanvasFill *fill) { RecordPolygon(points, stroke, fill); });
 }
-
 
 // Configures mesh Buffers.
 void Viewer3DController::SetupMeshBuffers(Mesh &mesh) {
@@ -1507,10 +1523,11 @@ void Viewer3DController::SetupMeshBuffers(Mesh &mesh) {
     return;
 
   const bool hasVertexBufferSupport = GLEW_VERSION_1_5;
-  const bool hasVertexArraySupport = GLEW_VERSION_3_0 || GLEW_ARB_vertex_array_object;
+  const bool hasVertexArraySupport =
+      GLEW_VERSION_3_0 || GLEW_ARB_vertex_array_object;
   if (!hasVertexBufferSupport || !hasVertexArraySupport) {
-    Logger::Instance().Log(
-        "Viewer3DController: OpenGL buffer functions are unavailable; skipping mesh GPU buffer setup.");
+    Logger::Instance().Log("Viewer3DController: OpenGL buffer functions are "
+                           "unavailable; skipping mesh GPU buffer setup.");
     mesh.buffersReady = false;
     return;
   }
@@ -1568,14 +1585,12 @@ void Viewer3DController::SetupMeshBuffers(Mesh &mesh) {
 
   glGenBuffers(1, &mesh.eboTriangles);
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mesh.eboTriangles);
-  glBufferData(GL_ELEMENT_ARRAY_BUFFER,
-               mesh.indices.size() * sizeof(uint32_t),
+  glBufferData(GL_ELEMENT_ARRAY_BUFFER, mesh.indices.size() * sizeof(uint32_t),
                mesh.indices.data(), GL_STATIC_DRAW);
 
   glGenBuffers(1, &mesh.eboLines);
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mesh.eboLines);
-  glBufferData(GL_ELEMENT_ARRAY_BUFFER,
-               lineIndices.size() * sizeof(uint32_t),
+  glBufferData(GL_ELEMENT_ARRAY_BUFFER, lineIndices.size() * sizeof(uint32_t),
                lineIndices.data(), GL_STATIC_DRAW);
 
   // Restore the triangle index buffer while the VAO is bound so the VAO keeps
@@ -1590,8 +1605,10 @@ void Viewer3DController::SetupMeshBuffers(Mesh &mesh) {
       glIsBuffer(mesh.vboVertices) == GL_TRUE &&
       glIsBuffer(mesh.vboNormals) == GL_TRUE &&
       (mesh.vboTexCoords == 0 || glIsBuffer(mesh.vboTexCoords) == GL_TRUE) &&
-      (mesh.vboFlatVertices == 0 || glIsBuffer(mesh.vboFlatVertices) == GL_TRUE) &&
-      (mesh.vboFlatNormals == 0 || glIsBuffer(mesh.vboFlatNormals) == GL_TRUE) &&
+      (mesh.vboFlatVertices == 0 ||
+       glIsBuffer(mesh.vboFlatVertices) == GL_TRUE) &&
+      (mesh.vboFlatNormals == 0 ||
+       glIsBuffer(mesh.vboFlatNormals) == GL_TRUE) &&
       glIsBuffer(mesh.eboTriangles) == GL_TRUE &&
       glIsBuffer(mesh.eboLines) == GL_TRUE;
 
@@ -1623,8 +1640,9 @@ void Viewer3DController::SetupMeshBuffers(Mesh &mesh) {
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mesh.textureWidth, mesh.textureHeight,
-                 0, GL_RGBA, GL_UNSIGNED_BYTE, mesh.textureRgba.data());
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, mesh.textureWidth,
+                 mesh.textureHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+                 mesh.textureRgba.data());
     glBindTexture(GL_TEXTURE_2D, 0);
   }
 }
@@ -1683,8 +1701,8 @@ void Viewer3DController::ReleaseMeshBuffers(Mesh &mesh) {
 // Draws the reference grid on one of the principal planes
 // Draws the XYZ axes centered at origin
 void Viewer3DController::DrawAxes() {
-  const LineRenderProfile profile =
-      GetLineRenderProfile(m_impl->isInteracting, false, m_impl->useAdaptiveLineProfile);
+  const LineRenderProfile profile = GetLineRenderProfile(
+      m_impl->isInteracting, false, m_impl->useAdaptiveLineProfile);
   const GLboolean lineSmoothWasEnabled = glIsEnabled(GL_LINE_SMOOTH);
   if (profile.enableLineSmoothing)
     glEnable(GL_LINE_SMOOTH);
@@ -1863,22 +1881,21 @@ void Viewer3DController::ClearBottomSymbolCache() {
 // Draws mesh With Outline.
 void Viewer3DController::DrawMeshWithOutline(
     const Mesh &mesh, float r, float g, float b, float scale, bool highlight,
-    bool selected, float cx, float cy, float cz, bool wireframe,
-    Viewer2DRenderMode mode,
-    const std::function<std::array<float, 3>(const std::array<float, 3> &)> &
-        captureTransform,
+    bool groupHighlight, bool selected, float cx, float cy, float cz,
+    bool wireframe, Viewer2DRenderMode mode,
+    const std::function<std::array<float, 3>(const std::array<float, 3> &)>
+        &captureTransform,
     bool unlit, const float *modelMatrix, bool disableDepthBias) {
-  m_impl->sceneRenderer->DrawMeshWithOutline(mesh, r, g, b, scale, highlight,
-                                       selected, cx, cy, cz, wireframe, mode,
-                                       captureTransform, unlit, modelMatrix,
-                                       disableDepthBias);
+  m_impl->sceneRenderer->DrawMeshWithOutline(
+      mesh, r, g, b, scale, highlight, groupHighlight, selected, cx, cy, cz,
+      wireframe, mode, captureTransform, unlit, modelMatrix, disableDepthBias);
 }
 
 // Draws mesh Wireframe.
 void Viewer3DController::DrawMeshWireframe(
     const Mesh &mesh, float scale,
-    const std::function<std::array<float, 3>(const std::array<float, 3> &)> &
-        captureTransform) {
+    const std::function<std::array<float, 3>(const std::array<float, 3> &)>
+        &captureTransform) {
   m_impl->sceneRenderer->DrawMeshWireframe(mesh, scale, captureTransform);
 }
 
@@ -1905,32 +1922,25 @@ bool Viewer3DController::GetFixtureLabelAt(int mouseX, int mouseY, int width,
                                            wxPoint &outPos,
                                            std::string *outUuid,
                                            bool confirmDepth) {
-  return m_impl->selectionSystem->GetFixtureLabelAt(mouseX, mouseY, width, height,
-                                                     outLabel, outPos, outUuid,
-                                                     confirmDepth);
+  return m_impl->selectionSystem->GetFixtureLabelAt(
+      mouseX, mouseY, width, height, outLabel, outPos, outUuid, confirmDepth);
 }
 
 // Returns truss Label At.
 bool Viewer3DController::GetTrussLabelAt(int mouseX, int mouseY, int width,
                                          int height, wxString &outLabel,
-                                         wxPoint &outPos,
-                                         std::string *outUuid,
+                                         wxPoint &outPos, std::string *outUuid,
                                          bool confirmDepth) {
-  return m_impl->selectionSystem->GetTrussLabelAt(mouseX, mouseY, width, height,
-                                                   outLabel, outPos, outUuid,
-                                                   confirmDepth);
+  return m_impl->selectionSystem->GetTrussLabelAt(
+      mouseX, mouseY, width, height, outLabel, outPos, outUuid, confirmDepth);
 }
 
 // Returns scene Object Label At.
-bool Viewer3DController::GetSceneObjectLabelAt(int mouseX, int mouseY,
-                                                int width, int height,
-                                                wxString &outLabel,
-                                                wxPoint &outPos,
-                                                std::string *outUuid,
-                                                bool confirmDepth) {
-  return m_impl->selectionSystem->GetSceneObjectLabelAt(mouseX, mouseY, width,
-                                                         height, outLabel, outPos,
-                                                         outUuid, confirmDepth);
+bool Viewer3DController::GetSceneObjectLabelAt(
+    int mouseX, int mouseY, int width, int height, wxString &outLabel,
+    wxPoint &outPos, std::string *outUuid, bool confirmDepth) {
+  return m_impl->selectionSystem->GetSceneObjectLabelAt(
+      mouseX, mouseY, width, height, outLabel, outPos, outUuid, confirmDepth);
 }
 
 // Returns hover UUID At.
@@ -1951,9 +1961,8 @@ bool Viewer3DController::GetHoverUuidAt(int mouseX, int mouseY, int width,
     selectionTarget = SelectionSystem::HoverPickTarget::SceneObject;
     break;
   }
-  return m_impl->selectionSystem->GetHoverUuidAt(mouseX, mouseY, width, height,
-                                                  selectionTarget, outUuid,
-                                                  confirmDepth);
+  return m_impl->selectionSystem->GetHoverUuidAt(
+      mouseX, mouseY, width, height, selectionTarget, outUuid, confirmDepth);
 }
 
 // Returns pick UUID At.
@@ -1969,24 +1978,27 @@ size_t Viewer3DController::GetSceneVersionSnapshot() const {
 }
 
 // Returns fixtures In Screen Rect.
-std::vector<std::string> Viewer3DController::GetFixturesInScreenRect(
-    int x1, int y1, int x2, int y2, int width, int height) const {
+std::vector<std::string>
+Viewer3DController::GetFixturesInScreenRect(int x1, int y1, int x2, int y2,
+                                            int width, int height) const {
   return m_impl->selectionSystem->GetFixturesInScreenRect(x1, y1, x2, y2, width,
-                                                    height);
+                                                          height);
 }
 
 // Returns trusses In Screen Rect.
-std::vector<std::string> Viewer3DController::GetTrussesInScreenRect(
-    int x1, int y1, int x2, int y2, int width, int height) const {
+std::vector<std::string>
+Viewer3DController::GetTrussesInScreenRect(int x1, int y1, int x2, int y2,
+                                           int width, int height) const {
   return m_impl->selectionSystem->GetTrussesInScreenRect(x1, y1, x2, y2, width,
-                                                   height);
+                                                         height);
 }
 
 // Returns scene Objects In Screen Rect.
-std::vector<std::string> Viewer3DController::GetSceneObjectsInScreenRect(
-    int x1, int y1, int x2, int y2, int width, int height) const {
-  return m_impl->selectionSystem->GetSceneObjectsInScreenRect(x1, y1, x2, y2, width,
-                                                        height);
+std::vector<std::string>
+Viewer3DController::GetSceneObjectsInScreenRect(int x1, int y1, int x2, int y2,
+                                                int width, int height) const {
+  return m_impl->selectionSystem->GetSceneObjectsInScreenRect(x1, y1, x2, y2,
+                                                              width, height);
 }
 
 // Checks whether interacting.
@@ -2010,6 +2022,12 @@ bool Viewer3DController::IsSelectionOutlineEnabled2D() const {
 // Checks whether uUID Highlighted.
 bool Viewer3DController::IsUuidHighlighted(const std::string &uuid) const {
   return !uuid.empty() && m_impl->highlightUuid == uuid;
+}
+
+// Checks whether the UUID is highlighted as a hovered group sibling.
+bool Viewer3DController::IsUuidGroupHighlighted(const std::string &uuid) const {
+  return !uuid.empty() && m_impl->groupHighlightUuids.find(uuid) !=
+                              m_impl->groupHighlightUuids.end();
 }
 
 // Checks whether uUID Selected.
@@ -2122,7 +2140,9 @@ Viewer3DController::GetObjectBounds() {
 }
 
 // Returns scene Version.
-size_t Viewer3DController::GetSceneVersion() const { return m_impl->sceneVersion; }
+size_t Viewer3DController::GetSceneVersion() const {
+  return m_impl->sceneVersion;
+}
 
 const std::vector<const std::pair<const std::string, Fixture> *> &
 // Returns sorted Fixtures.
@@ -2148,7 +2168,8 @@ std::mutex &Viewer3DController::GetSortedListsMutex() const {
 }
 
 // Returns cached Visible Set.
-Viewer3DController::VisibleSet &Viewer3DController::GetCachedVisibleSet() const {
+Viewer3DController::VisibleSet &
+Viewer3DController::GetCachedVisibleSet() const {
   return m_impl->cachedVisibleSet;
 }
 

--- a/viewer3d/viewer3dcontroller.h
+++ b/viewer3d/viewer3dcontroller.h
@@ -24,11 +24,11 @@
 
 #pragma once
 
-#include "viewer3d_types.h"
 #include "irendercontext.h"
 #include "iselectioncontext.h"
 #include "ivisibilitycontext.h"
 #include "symbolcache.h"
+#include "viewer3d_types.h"
 #include <array>
 #include <functional>
 #include <memory>
@@ -92,13 +92,9 @@ public:
 
   void RenderScene(bool wireframe = false,
                    Viewer2DRenderMode mode = Viewer2DRenderMode::White,
-                   Viewer2DView view = Viewer2DView::Top,
-                   bool showGrid = true,
-                   int gridStyle = 0,
-                   float gridR = 0.35f,
-                   float gridG = 0.35f,
-                   float gridB = 0.35f,
-                   bool gridOnTop = false,
+                   Viewer2DView view = Viewer2DView::Top, bool showGrid = true,
+                   int gridStyle = 0, float gridR = 0.35f, float gridG = 0.35f,
+                   float gridB = 0.35f, bool gridOnTop = false,
                    bool is2DViewer = false,
                    bool preferPerastageSvgSymbolsForLayouts = false);
 
@@ -157,7 +153,8 @@ public:
                                                        int height) const;
 
   void SetLayerColor(const std::string &layer, const std::string &hex);
-  static std::string BuildFixtureTypeAutoColorHex(const std::string &fixtureTypeKey);
+  static std::string
+  BuildFixtureTypeAutoColorHex(const std::string &fixtureTypeKey);
   std::shared_ptr<const SymbolDefinitionSnapshot>
   GetBottomSymbolCacheSnapshot() const;
   void ClearBottomSymbolCache();
@@ -166,7 +163,8 @@ public:
                         bool includeGrid = true,
                         bool useSymbolInstancing = false);
   void EnsureMeshGpuBuffers(Mesh &mesh);
-  void SetForceBottomViewForTopFixturesOverride(const std::optional<bool> &value);
+  void
+  SetForceBottomViewForTopFixturesOverride(const std::optional<bool> &value);
   void SetSymbolCaptureRenderProfileOverride(const std::optional<bool> &value);
   void SetSymbolCaptureIncludeCoplanarEdgesOverride(
       const std::optional<bool> &value);
@@ -185,6 +183,7 @@ private:
   std::unordered_map<std::string, BoundingBox> &m_trussBounds;
   std::unordered_map<std::string, BoundingBox> &m_objectBounds;
   std::string &m_highlightUuid;
+  std::unordered_set<std::string> &m_groupHighlightUuids;
   std::unordered_set<std::string> &m_selectedUuids;
   ICanvas2D *&m_captureCanvas;
   Viewer2DView &m_captureView;
@@ -203,54 +202,47 @@ private:
 
   void DrawCube(float size = 0.2f, float r = 1.0f, float g = 1.0f,
                 float b = 1.0f);
-  void DrawWireframeCube(float size = 0.3f, float r = 1.0f, float g = 1.0f,
-                         float b = 0.0f,
-                         Viewer2DRenderMode mode = Viewer2DRenderMode::White,
-                         const std::function<std::array<float, 3>(
-                             const std::array<float, 3> &)> &captureTransform =
-                             {},
-                         float lineWidthOverride = -1.0f,
-                         bool recordCapture = true);
-  void DrawWireframeBox(float length, float height, float width,
-                        float r = 1.0f, float g = 1.0f, float b = 1.0f,
-                        bool highlight = false, bool selected = false,
-                        bool wireframe = false,
-                        Viewer2DRenderMode mode = Viewer2DRenderMode::White,
-                        const std::function<std::array<float, 3>(
-                            const std::array<float, 3> &)> &captureTransform =
-                            {});
-  void DrawMeshWithOutline(const Mesh &mesh, float r = 1.0f, float g = 1.0f,
-                           float b = 1.0f, float scale = RENDER_SCALE,
-                           bool highlight = false, bool selected = false,
-                           float cx = 0.0f, float cy = 0.0f, float cz = 0.0f,
-                           bool wireframe = false,
-                           Viewer2DRenderMode mode = Viewer2DRenderMode::White,
-                           const std::function<std::array<float, 3>(
-                               const std::array<float, 3> &)> &captureTransform =
-                               {},
-                           bool unlit = false,
-                           const float *modelMatrix = nullptr,
-                           bool disableDepthBias = false);
+  void DrawWireframeCube(
+      float size = 0.3f, float r = 1.0f, float g = 1.0f, float b = 0.0f,
+      Viewer2DRenderMode mode = Viewer2DRenderMode::White,
+      const std::function<std::array<float, 3>(const std::array<float, 3> &)>
+          &captureTransform = {},
+      float lineWidthOverride = -1.0f, bool recordCapture = true);
+  void DrawWireframeBox(
+      float length, float height, float width, float r = 1.0f, float g = 1.0f,
+      float b = 1.0f, bool highlight = false, bool groupHighlight = false,
+      bool selected = false, bool wireframe = false,
+      Viewer2DRenderMode mode = Viewer2DRenderMode::White,
+      const std::function<std::array<float, 3>(const std::array<float, 3> &)>
+          &captureTransform = {});
+  void DrawMeshWithOutline(
+      const Mesh &mesh, float r = 1.0f, float g = 1.0f, float b = 1.0f,
+      float scale = RENDER_SCALE, bool highlight = false,
+      bool groupHighlight = false, bool selected = false, float cx = 0.0f,
+      float cy = 0.0f, float cz = 0.0f, bool wireframe = false,
+      Viewer2DRenderMode mode = Viewer2DRenderMode::White,
+      const std::function<std::array<float, 3>(const std::array<float, 3> &)>
+          &captureTransform = {},
+      bool unlit = false, const float *modelMatrix = nullptr,
+      bool disableDepthBias = false);
   void DrawMeshWireframe(
       const Mesh &mesh, float scale = RENDER_SCALE,
-      const std::function<std::array<float, 3>(
-          const std::array<float, 3> &)> &captureTransform = {});
-  void DrawCubeWithOutline(float size = 0.2f, float r = 1.0f, float g = 1.0f,
-                           float b = 1.0f, bool highlight = false,
-                           bool selected = false, float cx = 0.0f,
-                           float cy = 0.0f, float cz = 0.0f,
-                           bool wireframe = false,
-                           Viewer2DRenderMode mode = Viewer2DRenderMode::White,
-                           const std::function<std::array<float, 3>(
-                               const std::array<float, 3> &)> &captureTransform =
-                               {});
+      const std::function<std::array<float, 3>(const std::array<float, 3> &)>
+          &captureTransform = {});
+  void DrawCubeWithOutline(
+      float size = 0.2f, float r = 1.0f, float g = 1.0f, float b = 1.0f,
+      bool highlight = false, bool groupHighlight = false,
+      bool selected = false, float cx = 0.0f, float cy = 0.0f, float cz = 0.0f,
+      bool wireframe = false,
+      Viewer2DRenderMode mode = Viewer2DRenderMode::White,
+      const std::function<std::array<float, 3>(const std::array<float, 3> &)>
+          &captureTransform = {});
   void ApplyTransform(const float matrix[16], bool scaleTranslation = true);
   void DrawGrid(int style, float r, float g, float b,
                 Viewer2DView view = Viewer2DView::Top);
   void DrawAxes();
   void SetupBasicLighting(bool ambientOcclusionEnabled,
-                          float ambientOcclusionStrength,
-                          bool whiteModelStyle);
+                          float ambientOcclusionStrength, bool whiteModelStyle);
   void SetupMaterialFromRGB(float r, float g, float b);
   void SetGLColor(float r, float g, float b) const override;
   std::array<float, 3> AdjustColor(float r, float g, float b) const;
@@ -279,8 +271,9 @@ private:
                           bool useFrustumCulling, float minPixels,
                           const VisibleSet &layerVisibleCandidates,
                           VisibleSet &out) const;
-  bool EnsureBoundsComputed(const std::string &uuid, ItemType type,
-                            const std::unordered_set<std::string> &hiddenLayers);
+  bool
+  EnsureBoundsComputed(const std::string &uuid, ItemType type,
+                       const std::unordered_set<std::string> &hiddenLayers);
   bool IsSymbolCaptureRenderProfileEnabled(Viewer2DRenderMode mode) const;
 
   bool IsInteracting() const override;
@@ -288,6 +281,7 @@ private:
   bool SkipOutlinesForCurrentFrame() const override;
   bool IsSelectionOutlineEnabled2D() const override;
   bool IsUuidHighlighted(const std::string &uuid) const override;
+  bool IsUuidGroupHighlighted(const std::string &uuid) const override;
   bool IsUuidSelected(const std::string &uuid) const override;
   bool IsCaptureOnly() const override;
   ICanvas2D *GetCaptureCanvas() const override;

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -148,6 +148,31 @@ bool Is2DDarkModeEnabled() {
     return ConfigManager::Get().GetFloat("view2d_dark_mode") >= 0.5f;
 }
 
+struct HoverTableHighlights {
+    std::vector<std::string> fixtures;
+    std::vector<std::string> trusses;
+    std::vector<std::string> supports;
+    std::vector<std::string> sceneObjects;
+};
+
+// Splits related hover UUIDs by table ownership for synchronized table highlights.
+HoverTableHighlights BuildHoverTableHighlights(const MvrScene& scene,
+                                               const std::string& hoverUuid) {
+    HoverTableHighlights highlights;
+    for (const auto& uuid :
+         scene_grouping::ExpandHoverForGroupHighlights(scene, hoverUuid)) {
+        if (scene.fixtures.find(uuid) != scene.fixtures.end())
+            highlights.fixtures.push_back(uuid);
+        else if (scene.trusses.find(uuid) != scene.trusses.end())
+            highlights.trusses.push_back(uuid);
+        else if (scene.supports.find(uuid) != scene.supports.end())
+            highlights.supports.push_back(uuid);
+        else if (scene.sceneObjects.find(uuid) != scene.sceneObjects.end())
+            highlights.sceneObjects.push_back(uuid);
+    }
+    return highlights;
+}
+
 template <typename T>
 void HashCombine(size_t& seed, const T& value) {
     seed ^= std::hash<T>{}(value) + 0x9e3779b97f4a7c15ULL + (seed << 6) + (seed >> 2);
@@ -988,23 +1013,40 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
         if (m_basePassCache)
             m_basePassCache->Invalidate();
         m_controller.SetHighlightUuid(m_hoverUuid);
+        const MvrScene& scene = ConfigManager::Get().GetScene();
+        const HoverTableHighlights relatedHighlights =
+            BuildHoverTableHighlights(scene, m_hoverUuid);
         if (FixtureTablePanel::Instance()) {
-            FixtureTablePanel::Instance()->HighlightFixture(
-                FixtureTablePanel::Instance()->IsActivePage()
+            const std::string primaryUuid =
+                scene.fixtures.find(m_hoverUuid) != scene.fixtures.end()
                     ? std::string(m_hoverUuid)
-                    : std::string());
+                    : std::string();
+            FixtureTablePanel::Instance()->HighlightFixture(
+                primaryUuid, relatedHighlights.fixtures);
         }
         if (TrussTablePanel::Instance()) {
-            TrussTablePanel::Instance()->HighlightTruss(
-                TrussTablePanel::Instance()->IsActivePage()
+            const std::string primaryUuid =
+                scene.trusses.find(m_hoverUuid) != scene.trusses.end()
                     ? std::string(m_hoverUuid)
-                    : std::string());
+                    : std::string();
+            TrussTablePanel::Instance()->HighlightTruss(
+                primaryUuid, relatedHighlights.trusses);
+        }
+        if (HoistTablePanel::Instance()) {
+            const std::string primaryUuid =
+                scene.supports.find(m_hoverUuid) != scene.supports.end()
+                    ? std::string(m_hoverUuid)
+                    : std::string();
+            HoistTablePanel::Instance()->HighlightHoist(
+                primaryUuid, relatedHighlights.supports);
         }
         if (SceneObjectTablePanel::Instance()) {
-            SceneObjectTablePanel::Instance()->HighlightObject(
-                SceneObjectTablePanel::Instance()->IsActivePage()
+            const std::string primaryUuid =
+                scene.sceneObjects.find(m_hoverUuid) != scene.sceneObjects.end()
                     ? std::string(m_hoverUuid)
-                    : std::string());
+                    : std::string();
+            SceneObjectTablePanel::Instance()->HighlightObject(
+                primaryUuid, relatedHighlights.sceneObjects);
         }
         const auto highlightUpdateElapsedMs =
             std::chrono::duration<double, std::milli>(
@@ -2766,6 +2808,8 @@ void Viewer3DPanel::OnMouseLeave(wxMouseEvent& event)
         FixtureTablePanel::Instance()->HighlightFixture(std::string());
     if (TrussTablePanel::Instance())
         TrussTablePanel::Instance()->HighlightTruss(std::string());
+    if (HoistTablePanel::Instance())
+        HoistTablePanel::Instance()->HighlightHoist(std::string());
     if (SceneObjectTablePanel::Instance())
         SceneObjectTablePanel::Instance()->HighlightObject(std::string());
     Refresh();

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -155,22 +155,85 @@ struct HoverTableHighlights {
     std::vector<std::string> sceneObjects;
 };
 
+// Appends a UUID to a sequence when it is not already present.
+void AppendUniqueUuid(std::vector<std::string>& uuids, const std::string& uuid) {
+    if (uuid.empty())
+        return;
+    if (std::find(uuids.begin(), uuids.end(), uuid) == uuids.end())
+        uuids.push_back(uuid);
+}
+
+// Splits one UUID into the table bucket that owns it.
+void AppendUuidToTableHighlights(const MvrScene& scene, const std::string& uuid,
+                                 HoverTableHighlights& highlights) {
+    if (scene.fixtures.find(uuid) != scene.fixtures.end())
+        AppendUniqueUuid(highlights.fixtures, uuid);
+    else if (scene.trusses.find(uuid) != scene.trusses.end())
+        AppendUniqueUuid(highlights.trusses, uuid);
+    else if (scene.supports.find(uuid) != scene.supports.end())
+        AppendUniqueUuid(highlights.supports, uuid);
+    else if (scene.sceneObjects.find(uuid) != scene.sceneObjects.end())
+        AppendUniqueUuid(highlights.sceneObjects, uuid);
+}
+
 // Splits related hover UUIDs by table ownership for synchronized table highlights.
 HoverTableHighlights BuildHoverTableHighlights(const MvrScene& scene,
                                                const std::string& hoverUuid) {
     HoverTableHighlights highlights;
     for (const auto& uuid :
          scene_grouping::ExpandHoverForGroupHighlights(scene, hoverUuid)) {
-        if (scene.fixtures.find(uuid) != scene.fixtures.end())
-            highlights.fixtures.push_back(uuid);
-        else if (scene.trusses.find(uuid) != scene.trusses.end())
-            highlights.trusses.push_back(uuid);
-        else if (scene.supports.find(uuid) != scene.supports.end())
-            highlights.supports.push_back(uuid);
-        else if (scene.sceneObjects.find(uuid) != scene.sceneObjects.end())
-            highlights.sceneObjects.push_back(uuid);
+        AppendUuidToTableHighlights(scene, uuid, highlights);
     }
     return highlights;
+}
+
+// Builds the cross-table selection represented by a clicked scene item.
+HoverTableHighlights BuildClickSelectionHighlights(
+    const MvrScene& scene, const std::string& uuid) {
+    HoverTableHighlights highlights;
+    AppendUuidToTableHighlights(scene, uuid, highlights);
+    for (const auto& relatedUuid :
+         scene_grouping::ExpandHoverForGroupHighlights(scene, uuid)) {
+        AppendUuidToTableHighlights(scene, relatedUuid, highlights);
+    }
+    return highlights;
+}
+
+// Returns true when every grouped click UUID is already selected.
+bool ContainsAllUuids(const std::vector<std::string>& selection,
+                      const std::vector<std::string>& clickedUuids) {
+    return std::all_of(clickedUuids.begin(), clickedUuids.end(),
+                       [&](const std::string& uuid) {
+                           return std::find(selection.begin(), selection.end(),
+                                            uuid) != selection.end();
+                       });
+}
+
+// Adds or removes grouped click UUIDs from an existing additive selection.
+std::vector<std::string> ToggleClickedUuids(std::vector<std::string> selection,
+                                            const std::vector<std::string>& clickedUuids) {
+    if (clickedUuids.empty())
+        return selection;
+    const bool removeClickedUuids = ContainsAllUuids(selection, clickedUuids);
+    for (const auto& uuid : clickedUuids) {
+        auto it = std::find(selection.begin(), selection.end(), uuid);
+        if (removeClickedUuids) {
+            if (it != selection.end())
+                selection.erase(it);
+        } else if (it == selection.end()) {
+            selection.push_back(uuid);
+        }
+    }
+    return selection;
+}
+
+// Updates one typed selection according to the additive click mode.
+std::vector<std::string> ResolveClickedSelection(
+    const std::vector<std::string>& currentSelection,
+    const std::vector<std::string>& clickedUuids, bool additive) {
+    if (!additive)
+        return clickedUuids;
+    return ToggleClickedUuids(currentSelection, clickedUuids);
 }
 
 template <typename T>
@@ -480,6 +543,46 @@ void ApplyFixtureSelectionToUi(const std::vector<std::string>& selection,
         else
             FixtureTablePanel::Instance()->SelectByUuid(selection, false);
     }
+}
+
+// Applies cross-table scene selections to config, viewport, and table panels.
+void ApplyObjectSelectionToUi(const HoverTableHighlights& selection,
+                              Viewer3DPanel* panel)
+{
+    ConfigManager& cfg = ConfigManager::Get();
+    const bool selectionChanged =
+        selection.fixtures != cfg.GetSelectedFixtures() ||
+        selection.trusses != cfg.GetSelectedTrusses() ||
+        selection.supports != cfg.GetSelectedSupports() ||
+        selection.sceneObjects != cfg.GetSelectedSceneObjects();
+    if (selectionChanged) {
+        cfg.PushUndoState("object selection");
+        cfg.SetSelectedFixtures(selection.fixtures);
+        cfg.SetSelectedTrusses(selection.trusses);
+        cfg.SetSelectedSupports(selection.supports);
+        cfg.SetSelectedSceneObjects(selection.sceneObjects);
+    }
+
+    std::set<std::string> mergedSelection;
+    mergedSelection.insert(selection.fixtures.begin(), selection.fixtures.end());
+    mergedSelection.insert(selection.trusses.begin(), selection.trusses.end());
+    mergedSelection.insert(selection.supports.begin(), selection.supports.end());
+    mergedSelection.insert(selection.sceneObjects.begin(), selection.sceneObjects.end());
+    if (panel) {
+        panel->SetSelectedFixtures(std::vector<std::string>(
+            mergedSelection.begin(), mergedSelection.end()));
+    }
+
+    selection::ScopedOrigin selectionOrigin(selection::Origin::Viewer3D);
+    if (FixtureTablePanel::Instance())
+        FixtureTablePanel::Instance()->SelectByUuid(selection.fixtures, false);
+    if (TrussTablePanel::Instance())
+        TrussTablePanel::Instance()->SelectByUuid(selection.trusses, false);
+    if (HoistTablePanel::Instance())
+        HoistTablePanel::Instance()->SelectByUuid(selection.supports, false);
+    if (SceneObjectTablePanel::Instance())
+        SceneObjectTablePanel::Instance()->SelectByUuid(selection.sceneObjects,
+                                                       false);
 }
 
 // Resolves which table should receive hover and pick queries.
@@ -1618,6 +1721,10 @@ void Viewer3DPanel::OnMouseUp(wxMouseEvent& event)
         const HoverTargetTable activeTable = ResolveActiveHoverTargetTable();
         bool found = QueryHoverUuid(m_controller, activeTable, pickPos.x,
                                     pickPos.y, w, h, uuid, true);
+        if (!found && !m_hoverUuid.empty()) {
+            uuid = m_hoverUuid;
+            found = true;
+        }
 
         ConfigManager& cfg = ConfigManager::Get();
         if (m_measureToolEnabled) {
@@ -1652,73 +1759,19 @@ void Viewer3DPanel::OnMouseUp(wxMouseEvent& event)
         if (found)
         {
             bool additive = event.ShiftDown() || event.ControlDown();
-            std::vector<std::string> selection;
-            if (activeTable == HoverTargetTable::Fixtures &&
-                FixtureTablePanel::Instance())
-            {
-                if (additive)
-                    selection = FixtureTablePanel::Instance()->GetSelectedUuids();
-                if (additive)
-                {
-                    auto it = std::find(selection.begin(), selection.end(), uuid);
-                    if (it != selection.end())
-                        selection.erase(it);
-                    else
-                        selection.push_back(uuid);
-                }
-                else
-                    selection = {uuid};
-                if (selection != cfg.GetSelectedFixtures()) {
-                    cfg.PushUndoState("fixture selection");
-                    cfg.SetSelectedFixtures(selection);
-                }
-                SetSelectedFixtures(selection);
-                FixtureTablePanel::Instance()->SelectByUuid(selection, false);
-            }
-            else if (activeTable == HoverTargetTable::Trusses &&
-                     TrussTablePanel::Instance())
-            {
-                if (additive)
-                    selection = TrussTablePanel::Instance()->GetSelectedUuids();
-                if (additive)
-                {
-                    auto it = std::find(selection.begin(), selection.end(), uuid);
-                    if (it != selection.end())
-                        selection.erase(it);
-                    else
-                        selection.push_back(uuid);
-                }
-                else
-                    selection = {uuid};
-                if (selection != cfg.GetSelectedTrusses()) {
-                    cfg.PushUndoState("truss selection");
-                    cfg.SetSelectedTrusses(selection);
-                }
-                SetSelectedFixtures(selection);
-                TrussTablePanel::Instance()->SelectByUuid(selection, false);
-            }
-            else if (activeTable == HoverTargetTable::SceneObjects &&
-                     SceneObjectTablePanel::Instance())
-            {
-                if (additive)
-                    selection = SceneObjectTablePanel::Instance()->GetSelectedUuids();
-                if (additive)
-                {
-                    auto it = std::find(selection.begin(), selection.end(), uuid);
-                    if (it != selection.end())
-                        selection.erase(it);
-                    else
-                        selection.push_back(uuid);
-                }
-                else
-                    selection = {uuid};
-                if (selection != cfg.GetSelectedSceneObjects()) {
-                    cfg.PushUndoState("scene object selection");
-                    cfg.SetSelectedSceneObjects(selection);
-                }
-                SetSelectedFixtures(selection);
-                SceneObjectTablePanel::Instance()->SelectByUuid(selection, false);
-            }
+            const HoverTableHighlights clickedSelection =
+                BuildClickSelectionHighlights(cfg.GetScene(), uuid);
+            HoverTableHighlights resolvedSelection;
+            resolvedSelection.fixtures = ResolveClickedSelection(
+                cfg.GetSelectedFixtures(), clickedSelection.fixtures, additive);
+            resolvedSelection.trusses = ResolveClickedSelection(
+                cfg.GetSelectedTrusses(), clickedSelection.trusses, additive);
+            resolvedSelection.supports = ResolveClickedSelection(
+                cfg.GetSelectedSupports(), clickedSelection.supports, additive);
+            resolvedSelection.sceneObjects = ResolveClickedSelection(
+                cfg.GetSelectedSceneObjects(), clickedSelection.sceneObjects,
+                additive);
+            ApplyObjectSelectionToUi(resolvedSelection, this);
         }
         else
         {


### PR DESCRIPTION
### Motivation
- Improve hover feedback when the hovered 3D element belongs to a GroupObject so other members of the same effective root group are visually indicated with a distinct related-green tone, making group membership obvious across fixtures, trusses, supports and scene objects.
- Make the group-hover behavior transversal to table/viewport workflows because groups can contain elements from multiple tables.

### Description
- Added `scene_grouping::ExpandHoverForGroupHighlights` to collect sibling UUIDs for a hovered element and exposed it via the grouping API used by the viewer.
- Added a `groupHighlight` path to rendering by storing per-frame `m_groupHighlightUuids` inside `Viewer3DController` (and exposing `IsUuidGroupHighlighted` via `IRenderContext`), and populate it in `Viewer3DController::ApplyHighlightUuid` using `ExpandHoverForGroupHighlights`.
- Wired the new group-highlight flag through rendering primitives and mesh draws (`GLPrimitiveRenderer`, `SceneRenderer::DrawMeshWithOutline`) and updated opaque render passes and overlay logic (`Opaque*Pass`, `SelectionOverlayPass`, `HoistSymbolRenderer`) so group siblings are drawn with a distinct green tone (approx `{0.45,1.0,0.35}`) without replacing the primary hover tint.
- Updated user-facing docs and release notes in `docs/features.md`, `docs/views.md`, and `docs/release-notes-draft.md` to describe the grouped-hover visual feedback.

### Testing
- `tests/check_perastage_tree_modules.sh` ran and returned `OK`.
- `tests/check_no_configmanager_get_in_gui.sh` ran and returned `OK`.
- `git diff --check` was run and reported no whitespace/format issues.
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug` could not be completed in the CI environment because the wxWidgets development libraries/headers are not installed, blocking a full build in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d235ba7c08324909571d36713ca48)