### PR TITLE
Cache GDTF metadata during rider import

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -231,26 +231,7 @@ std::string ResolveGdtfPath(const MvrScene &scene,
   return (std::filesystem::path(scene.basePath) / specPath).string();
 }
 
-void ApplyFixturePhysicalPropertiesFromGdtf(const MvrScene &scene,
-                                            Fixture &fixture) {
-  if (fixture.gdtfSpec.empty())
-    return;
-
-  const std::string gdtfPath = ResolveGdtfPath(scene, fixture.gdtfSpec);
-  if (gdtfPath.empty())
-    return;
-
-  float gdtfWeightKg = 0.0f;
-  float gdtfPowerW = 0.0f;
-  if (!GetGdtfProperties(gdtfPath, gdtfWeightKg, gdtfPowerW))
-    return;
-
-  if (fixture.weightKg <= 0.0f)
-    fixture.weightKg = gdtfWeightKg;
-  if (fixture.powerConsumptionW <= 0.0f)
-    fixture.powerConsumptionW = gdtfPowerW;
-}
-
+// Ensures imported fixtures always have a resolved category and source.
 void EnsureFixtureCategoryForImport(const MvrScene &scene, Fixture &fixture) {
   auto containsWord = [](std::string value, const std::string &needle) {
     std::transform(value.begin(), value.end(), value.begin(),
@@ -1517,6 +1498,64 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
   return preview.str();
 }
 
+struct ImportedGdtfMetadata {
+  std::string parsedFixtureName;
+  bool hasProperties = false;
+  float weightKg = 0.0f;
+  float powerConsumptionW = 0.0f;
+  std::string resolvedCategory;
+  std::string categorySource;
+  std::string categoryReason;
+  bool hasChannelDerivedWashHint = false;
+};
+
+struct ImportedGdtfMetadataCache {
+  std::unordered_map<std::string, ImportedGdtfMetadata> entries;
+
+  // Returns parsed GDTF metadata cached by resolved path and mode.
+  const ImportedGdtfMetadata &Get(const MvrScene &scene,
+                                  const std::string &resolvedGdtfPath,
+                                  const std::string &modeName) {
+    const std::string key = resolvedGdtfPath + "\n" + modeName;
+    auto found = entries.find(key);
+    if (found != entries.end())
+      return found->second;
+
+    ImportedGdtfMetadata metadata;
+    metadata.parsedFixtureName = Trim(GetGdtfFixtureName(resolvedGdtfPath));
+    metadata.hasProperties =
+        GetGdtfProperties(resolvedGdtfPath, metadata.weightKg,
+                          metadata.powerConsumptionW);
+
+    Fixture categoryProbe;
+    categoryProbe.gdtfSpec = resolvedGdtfPath;
+    categoryProbe.gdtfMode = modeName;
+    EnsureFixtureCategoryForImport(scene, categoryProbe);
+    metadata.resolvedCategory = categoryProbe.category;
+    metadata.categorySource = categoryProbe.categorySource;
+    metadata.categoryReason = categoryProbe.categorySourceReason;
+    metadata.hasChannelDerivedWashHint =
+        metadata.categoryReason.find("channel hints") != std::string::npos;
+
+    auto [insertedIt, inserted] = entries.emplace(key, std::move(metadata));
+    return insertedIt->second;
+  }
+};
+
+// Applies cached GDTF metadata without overriding rider or dictionary choices.
+void ApplyImportedGdtfMetadata(Fixture &fixture,
+                               const ImportedGdtfMetadata &metadata) {
+  if (!metadata.parsedFixtureName.empty())
+    fixture.typeName = metadata.parsedFixtureName;
+  if (metadata.hasProperties) {
+    if (fixture.weightKg <= 0.0f)
+      fixture.weightKg = metadata.weightKg;
+    if (fixture.powerConsumptionW <= 0.0f)
+      fixture.powerConsumptionW = metadata.powerConsumptionW;
+  }
+}
+
+// Imports rider text into the current scene.
 bool RiderImporter::ImportText(const std::string &text,
                                ProgressCallback progressCallback) {
   if (text.empty())
@@ -1720,6 +1759,7 @@ bool RiderImporter::ImportText(const std::string &text,
   bool havePending = false;
   std::unordered_map<std::string, TrussCoordinateOverride>
       hangCoordinateOverrides;
+  ImportedGdtfMetadataCache importedGdtfMetadataCache;
   int parsedInputLineCount = 0;
 
   auto addFixtures = [&](int baseQuantity, const std::string &desc) {
@@ -1785,10 +1825,9 @@ bool RiderImporter::ImportText(const std::string &text,
             f.categorySourceReason.clear();
           }
           const std::string resolvedGdtfPath = ResolveGdtfPath(scene, f.gdtfSpec);
-          std::string parsed = Trim(GetGdtfFixtureName(resolvedGdtfPath));
-          if (!parsed.empty())
-            f.typeName = parsed;
-          ApplyFixturePhysicalPropertiesFromGdtf(scene, f);
+          const ImportedGdtfMetadata &metadata =
+              importedGdtfMetadataCache.Get(scene, resolvedGdtfPath, f.gdtfMode);
+          ApplyImportedGdtfMetadata(f, metadata);
         }
         EnsureFixtureCategoryForImport(scene, f);
         if (!seenTypes.count(f.typeName)) {

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -48,6 +48,7 @@ Changes since `v1.3.0`.
 
 ## Internal changes
 
+- Improved rider imports by reusing parsed GDTF fixture metadata during fixture creation, reducing repeated GDTF lookups while preserving existing dictionary, category, weight, and power precedence.
 - Added backward-cpp integration, generated build metadata, and release workflow symbol archives for Windows, Linux, macOS, and Arch Linux builds.
 - Improved truss table reload stability so rebuilding rows preserves existing truss selection without triggering transient selection side effects.
 - Added concise diagnostics for truss loading and 2D viewer picking to make validation and interaction issues easier to troubleshoot.


### PR DESCRIPTION
### Motivation
- Rider imports repeatedly parsed GDTF fixture names and physical properties per fixture which is wasteful and can slow large imports.
- The change adds a small import-local cache so GDTF parsing and property lookups are performed once per resolved GDTF path+mode pair.
- The implementation preserves existing precedence and behavior so dictionary choices and rider-provided values remain authoritative.

### Description
- Added an import-local `ImportedGdtfMetadata` struct and an `ImportedGdtfMetadataCache` keyed by resolved absolute GDTF path plus mode to cache parsed fixture name, weight, power, resolved category, category source/reason, and channel-derived hints.
- Added `ApplyImportedGdtfMetadata(Fixture&, const ImportedGdtfMetadata&)` to apply cached metadata while honoring existing rules: only replace `typeName` when parsed name is non-empty and only fill weight/power when current values are `<= 0.0f`.
- Replaced direct per-fixture calls to `GetGdtfFixtureName(...)` and `ApplyFixturePhysicalPropertiesFromGdtf(...)` inside the `addFixtures` lambda with a single cache lookup and `ApplyImportedGdtfMetadata(...)` invocation, and kept the existing category-resolution path (`EnsureFixtureCategoryForImport`) after dictionary handling.
- Added a concise one-line comment above `RiderImporter::ImportText()` and updated `docs/release-notes-draft.md` with an internal change entry describing the import optimization.

### Testing
- Ran `./tests/check_perastage_tree_modules.sh` which completed successfully.
- Ran `./tests/check_no_configmanager_get_in_gui.sh` which completed successfully.
- Ran `git diff --check` which reported no whitespace or conflict issues.
- Attempted `cmake --preset wsl-x64-debug` in the environment but configuration failed due to missing system wxWidgets packages (expected in this CI-less environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d342404a88324bb5150fc5e1dee3f)