### PR TITLE
Make imported fixture category resolution idempotent

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -231,8 +231,22 @@ std::string ResolveGdtfPath(const MvrScene &scene,
   return (std::filesystem::path(scene.basePath) / specPath).string();
 }
 
+// Returns whether an imported fixture category is authoritative enough to keep.
+bool HasAuthoritativeImportCategory(const Fixture &fixture) {
+  if (fixture.category.empty())
+    return false;
+  return fixture.categorySource == GdtfFixtureCategory::kManualSource ||
+         fixture.categorySource == GdtfFixtureCategory::kAutoFallbackSource;
+}
+
 // Ensures imported fixtures always have a resolved category and source.
 void EnsureFixtureCategoryForImport(const MvrScene &scene, Fixture &fixture) {
+  if (HasAuthoritativeImportCategory(fixture)) {
+    if (fixture.categorySource == GdtfFixtureCategory::kManualSource)
+      fixture.categorySourceReason.clear();
+    return;
+  }
+
   auto containsWord = [](std::string value, const std::string &needle) {
     std::transform(value.begin(), value.end(), value.begin(),
                    [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
@@ -1552,6 +1566,11 @@ void ApplyImportedGdtfMetadata(Fixture &fixture,
       fixture.weightKg = metadata.weightKg;
     if (fixture.powerConsumptionW <= 0.0f)
       fixture.powerConsumptionW = metadata.powerConsumptionW;
+  }
+  if (fixture.category.empty() && !metadata.resolvedCategory.empty()) {
+    fixture.category = metadata.resolvedCategory;
+    fixture.categorySource = metadata.categorySource;
+    fixture.categorySourceReason = metadata.categoryReason;
   }
 }
 
@@ -3160,8 +3179,7 @@ bool RiderImporter::ImportText(const std::string &text,
   HoistWeightDistribution::ApplyForImportedSupports(
       scene, importedSupportUuids, roundedRiggingTotalsByPosition);
 
-  // Categories must be resolved before fixture distribution/positioning so any
-  // downstream placement strategy can rely on category values.
+  // Fill any missing fixture categories before placement so downstream distribution can rely on them.
   for (const std::string &uuid : importedFixtureUuids) {
     auto fixtureIt = scene.fixtures.find(uuid);
     if (fixtureIt == scene.fixtures.end())

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -48,7 +48,7 @@ Changes since `v1.3.0`.
 
 ## Internal changes
 
-- Improved rider imports by reusing parsed GDTF fixture metadata during fixture creation, reducing repeated GDTF lookups while preserving existing dictionary, category, weight, and power precedence.
+- Improved rider imports by reusing parsed GDTF fixture metadata during fixture creation and skipping repeated category inference once an imported fixture has an authoritative category, reducing repeated GDTF lookups while preserving existing dictionary, category, weight, and power precedence.
 - Added backward-cpp integration, generated build metadata, and release workflow symbol archives for Windows, Linux, macOS, and Arch Linux builds.
 - Improved truss table reload stability so rebuilding rows preserves existing truss selection without triggering transient selection side effects.
 - Added concise diagnostics for truss loading and 2D viewer picking to make validation and interaction issues easier to troubleshoot.


### PR DESCRIPTION
### Motivation
- Imported fixtures sometimes triggered repeated and expensive GDTF inference passes even when a dictionary/manual or cached auto-resolved category was already available, causing unnecessary work during rider imports. 
- The change aims to make category resolution idempotent and cheap while preserving dictionary and manual precedence and avoiding repeated GDTF file inspection.

### Description
- Added `HasAuthoritativeImportCategory(const Fixture&)` to detect when an imported fixture already has an authoritative category (`Manual` or `AutoFallback`) and return early from `EnsureFixtureCategoryForImport` when appropriate. 
- Updated `EnsureFixtureCategoryForImport(const MvrScene&, Fixture&)` to short-circuit when a fixture already has an authoritative category and to clear `categorySourceReason` for manual sources. 
- Modified `ApplyImportedGdtfMetadata` so cached GDTF metadata populates `category`, `categorySource`, and `categorySourceReason` only when the fixture currently has an empty category, preserving dictionary/manual precedence. 
- Clarified the final rider-import category pass comment to state it now only fills missing categories before placement rather than repeating inference. 
- Updated `docs/release-notes-draft.md` to reflect the rider-import performance and inference-skipping improvement.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded. 
- Ran `git diff --check` to validate whitespace/diff issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d36ae54bc8324860572b9ed163093)