### PR TITLE
Avoid duplicate rider text filtering

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -1576,7 +1576,8 @@ void ApplyImportedGdtfMetadata(Fixture &fixture,
 
 // Imports rider text into the current scene.
 bool RiderImporter::ImportText(const std::string &text,
-                               ProgressCallback progressCallback) {
+                               ProgressCallback progressCallback,
+                               bool skipFixtureFilterPreview) {
   if (text.empty())
     return false;
   auto reportProgress = [&](std::string stage, int completed = 0, int total = 0) {
@@ -1585,11 +1586,13 @@ bool RiderImporter::ImportText(const std::string &text,
     progressCallback(ProgressState{std::move(stage), completed, total});
   };
 
-  reportProgress("Filtering text...", 1, 6);
-  // Keep scene creation consistent with the dialog preview flow:
-  // import always consumes the same normalized text produced by the
-  // filter pass used by "Apply filter".
-  const std::string filteredText = BuildFixtureFilterPreview(text);
+  reportProgress(skipFixtureFilterPreview ? "Using filtered text..."
+                                          : "Filtering text...",
+                 1, 6);
+  // Keep scene creation consistent with the dialog preview flow while allowing
+  // callers that already hold preview text to avoid repeating the filter pass.
+  const std::string filteredText =
+      skipFixtureFilterPreview ? std::string{} : BuildFixtureFilterPreview(text);
   const std::string &textToImport = filteredText.empty() ? text : filteredText;
   reportProgress("Parsing lines...", 2, 6);
   const int totalInputLines = [&]() {

--- a/core/riderimporter.h
+++ b/core/riderimporter.h
@@ -43,5 +43,6 @@ public:
     static std::string BuildFixtureFilterPreview(const std::string& text);
     // Import from raw rider text. Returns true on success.
     static bool ImportText(const std::string& text,
-                           ProgressCallback progressCallback = {});
+                           ProgressCallback progressCallback = {},
+                           bool skipFixtureFilterPreview = false);
 };

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -49,6 +49,7 @@ Changes since `v1.3.0`.
 ## Internal changes
 
 - Improved rider imports by reusing parsed GDTF fixture metadata during fixture creation and skipping repeated category inference once an imported fixture has an authoritative category, reducing repeated GDTF lookups while preserving existing dictionary, category, weight, and power precedence.
+- Improved text-to-scene creation so applying the rider text filter in the editor no longer repeats the same filtering work during import, while preserving existing import behavior for all other flows.
 - Added backward-cpp integration, generated build metadata, and release workflow symbol archives for Windows, Linux, macOS, and Arch Linux builds.
 - Improved truss table reload stability so rebuilding rows preserves existing truss selection without triggering transient selection side effects.
 - Added concise diagnostics for truss loading and 2D viewer picking to make validation and interaction issues easier to troubleshoot.

--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -398,8 +398,10 @@ void MainWindow::OnImportRiderText(wxCommandEvent &WXUNUSED(event)) {
   std::unique_ptr<wxProgressDialog> createProgress;
   wxYieldIfNeeded();
 
+  const bool riderTextAlreadyFiltered = dlg.IsCurrentTextFilteredPreview();
   if (!RiderImporter::ImportText(
-          riderText, [&](const RiderImporter::ProgressState &progress) {
+          riderText,
+          [&](const RiderImporter::ProgressState &progress) {
             if (!GetStatusBar())
               return;
             const wxString stageText = wxString::FromUTF8(progress.stage);
@@ -426,7 +428,8 @@ void MainWindow::OnImportRiderText(wxCommandEvent &WXUNUSED(event)) {
               SetStatusText("Text import: " + stageText, 0);
             }
             GetStatusBar()->Update();
-          })) {
+          },
+          riderTextAlreadyFiltered)) {
     wxMessageBox("Failed to import rider text.", "Error", wxICON_ERROR);
     if (consolePanel)
       consolePanel->AppendMessage("[ERROR] Failed to import rider from text.");

--- a/gui/ridertextdialog.cpp
+++ b/gui/ridertextdialog.cpp
@@ -157,10 +157,17 @@ RiderTextDialog::RiderTextDialog(wxWindow *parent,
   CentreOnScreen();
 }
 
+// Returns the UTF-8 rider text selected for scene creation.
 const std::string &RiderTextDialog::GetRiderTextUtf8() const {
   return selectedRiderTextUtf8;
 }
 
+// Returns whether the current editor text already contains the filter preview.
+bool RiderTextDialog::IsCurrentTextFilteredPreview() const {
+  return currentTextIsFilteredPreview;
+}
+
+// Returns the title of the loaded source file when the dialog uses a file.
 wxString RiderTextDialog::GetLoadedFileTitle() const {
   if (!sourceLoadedFromFile)
     return wxEmptyString;
@@ -182,6 +189,7 @@ bool RiderTextDialog::TryGetCurrentText(std::string &outText) const {
   return true;
 }
 
+// Loads rider text from a selected TXT or PDF file into the editor.
 void RiderTextDialog::OnLoadFromFile(wxCommandEvent &WXUNUSED(event)) {
   wxString miscDir =
       wxString::FromUTF8(ProjectUtils::GetDefaultLibraryPath("misc"));
@@ -238,9 +246,11 @@ void RiderTextDialog::OnLoadFromFile(wxCommandEvent &WXUNUSED(event)) {
   if (sourceText)
     sourceText->SetLabel(wxString("Loaded: ") + sourceLabel);
   textCtrl->ChangeValue(loadedText);
+  currentTextIsFilteredPreview = false;
   autocompleteProvider.RefreshDynamicTerms();
 }
 
+// Loads the built-in rider example into the editor.
 void RiderTextDialog::OnLoadExample(wxCommandEvent &WXUNUSED(event)) {
   const wxString exampleText =
       "LX1 \n"
@@ -294,8 +304,10 @@ void RiderTextDialog::OnLoadExample(wxCommandEvent &WXUNUSED(event)) {
   if (sourceText)
     sourceText->SetLabel(wxString("Loaded: ") + sourceLabel);
   autocompleteProvider.RefreshDynamicTerms();
+  currentTextIsFilteredPreview = false;
 }
 
+// Replaces the editor content with the fixture filter preview.
 void RiderTextDialog::OnApplyFilter(wxCommandEvent &WXUNUSED(event)) {
   std::string text;
   if (!TryGetCurrentText(text) || text.empty()) {
@@ -320,6 +332,7 @@ void RiderTextDialog::OnApplyFilter(wxCommandEvent &WXUNUSED(event)) {
     return;
   }
   textCtrl->ChangeValue(filteredText);
+  currentTextIsFilteredPreview = true;
   autocompleteProvider.RefreshDynamicTerms();
 }
 
@@ -333,7 +346,9 @@ void RiderTextDialog::OnApply(wxCommandEvent &WXUNUSED(event)) {
   EndModal(wxID_OK);
 }
 
+// Handles manual text edits and schedules autocomplete updates.
 void RiderTextDialog::OnTextChanged(wxCommandEvent &event) {
+  currentTextIsFilteredPreview = false;
   if (!suppressAutocompleteTextEvent)
     autocompleteTimer.StartOnce(35);
   event.Skip();
@@ -490,6 +505,7 @@ bool RiderTextDialog::IsSuggestionPopupVisible() const {
   return suggestionPopup && suggestionPopup->IsShown();
 }
 
+// Replaces the token at the insertion point with an accepted suggestion.
 void RiderTextDialog::ReplaceCurrentToken(const std::string &replacement) {
   if (!textCtrl)
     return;
@@ -539,6 +555,7 @@ void RiderTextDialog::ReplaceCurrentToken(const std::string &replacement) {
   }
 
   suppressAutocompleteTextEvent = true;
+  currentTextIsFilteredPreview = false;
   textCtrl->Replace(tokenStart, tokenEnd, replacementText);
   textCtrl->SetInsertionPoint(tokenStart + replacementText.length());
   suppressAutocompleteTextEvent = false;

--- a/gui/ridertextdialog.h
+++ b/gui/ridertextdialog.h
@@ -38,6 +38,7 @@ public:
                            const wxString &initialSource = wxEmptyString);
   const std::string &GetRiderTextUtf8() const;
   wxString GetLoadedFileTitle() const;
+  bool IsCurrentTextFilteredPreview() const;
 
 private:
   bool TryGetCurrentText(std::string &outText) const;
@@ -69,6 +70,7 @@ private:
   std::vector<RiderTextAutocompleteProvider::Suggestion> currentSuggestions;
   wxTimer autocompleteTimer;
   bool suppressAutocompleteTextEvent = false;
+  bool currentTextIsFilteredPreview = false;
 
   wxDECLARE_EVENT_TABLE();
 };


### PR DESCRIPTION
### Motivation

- Reduce duplicated work when the editor has already applied the fixture filter preview so import does not run the same filter pass again while preserving existing behavior for other callers.

### Description

- Add a lightweight dialog state `currentTextIsFilteredPreview` and expose it via `RiderTextDialog::IsCurrentTextFilteredPreview()` so callers can detect when the editor text is already the filter preview.
- Set/reset that flag in `RiderTextDialog` when the user uses `Apply filter`, loads text/examples, manually edits text, or accepts autocomplete so automated detection stays in sync with user actions.
- Add an optional `skipFixtureFilterPreview` parameter to `RiderImporter::ImportText(...)` (default `false`) so callers that know the text is already filtered can skip `BuildFixtureFilterPreview(...)` without changing default behavior.
- Use the dialog flag in `MainWindow::OnImportRiderText()` to pass `skipFixtureFilterPreview` only when appropriate, keeping all other import flows unchanged.
- Add concise one-line comments for several `RiderTextDialog` functions and update `docs/release-notes-draft.md` with an internal change note about the optimization.

### Testing

- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both succeeded.
- Ran `git diff --check` and code style checks reported no issues.
- Attempted to configure and build the `rider_filter_preview_test` unit test, but CMake configuration failed because the environment is missing `wxWidgets`, so the unit test run could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d3abaa97c8324930c5b34867d5241)