### PR TITLE
Reuse rider filter cleanup regexes in BuildFixtureFilterPreview

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -127,6 +127,10 @@ static const std::regex kHangOnlyRe(
 static const std::regex kTrailingHangWithCoordinateRe(
     "(LX\\d+|lx\\s*sides?|screen|pantalla|proyecci[oó]n|led\\s*screen|backdrops?|tel[oó]n(?:es)?|puente\\s+de\\s+tel[oó]n(?:es)?|floor|efectos?|calle(?:s)?\\s+a\\s+suelo|ground\\s+lanes?|calle(?:s)?|side(?:s)?)(?:\\s*((?:\\([^\\)]*\\)|\\[[^\\]]*\\])))?\\s*$",
     std::regex::icase);
+static const std::regex kParenthesizedCleanupRe("\\([^\\)]*\\)");
+static const std::regex kBracketedCleanupRe("\\[[^\\]]*\\]");
+static const std::regex kHyphenSpacingCleanupRe("\\s*[-]\\s*");
+static const std::regex kWhitespaceCleanupRe("\\s+");
 std::string Trim(const std::string &s) {
   size_t start = s.find_first_not_of(" \t\r\n");
   if (start == std::string::npos)
@@ -1079,6 +1083,7 @@ bool RiderImporter::Import(const std::string &path,
   return ImportText(text, std::move(progressCallback));
 }
 
+// Builds a filtered rider preview containing fixtures and rigging context.
 std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
   if (text.empty())
     return {};
@@ -1107,9 +1112,9 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
 
   auto normalizeFixtureToken = [](const std::string &token) {
     std::string normalized = token;
-    normalized = std::regex_replace(normalized, std::regex("\\([^\\)]*\\)"), "");
-    normalized = std::regex_replace(normalized, std::regex("\\s*[-]\\s*"), "-");
-    normalized = std::regex_replace(normalized, std::regex("\\s+"), " ");
+    normalized = std::regex_replace(normalized, kParenthesizedCleanupRe, "");
+    normalized = std::regex_replace(normalized, kHyphenSpacingCleanupRe, "-");
+    normalized = std::regex_replace(normalized, kWhitespaceCleanupRe, " ");
     return Trim(normalized);
   };
 
@@ -1255,8 +1260,8 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
             marginSuffix.has_value()) {
           trussMarginSuffix = *marginSuffix;
         }
-        modelForHang = std::regex_replace(modelForHang, std::regex("\\([^\\)]*\\)"), "");
-        modelForHang = std::regex_replace(modelForHang, std::regex("\\[[^\\]]*\\]"), "");
+        modelForHang = std::regex_replace(modelForHang, kParenthesizedCleanupRe, "");
+        modelForHang = std::regex_replace(modelForHang, kBracketedCleanupRe, "");
         modelForHang = Trim(modelForHang);
         if (std::regex_match(modelForHang, kHangOnlyRe)) {
           hang = modelForHang;

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -49,6 +49,7 @@ Changes since `v1.3.0`.
 ## Internal changes
 
 - Improved rider imports by reusing parsed GDTF fixture metadata during fixture creation and skipping repeated category inference once an imported fixture has an authoritative category, reducing repeated GDTF lookups while preserving existing dictionary, category, weight, and power precedence.
+- Improved rider fixture filtering performance by reusing cleanup regular expressions in hot preview paths while preserving existing filtering behavior.
 - Improved text-to-scene creation so applying the rider text filter in the editor no longer repeats the same filtering work during import, while preserving existing import behavior for all other flows.
 - Added backward-cpp integration, generated build metadata, and release workflow symbol archives for Windows, Linux, macOS, and Arch Linux builds.
 - Improved truss table reload stability so rebuilding rows preserves existing truss selection without triggering transient selection side effects.


### PR DESCRIPTION
### Motivation
- Avoid constructing temporary `std::regex` objects inside the hot rider filtering/preview path to reduce repeated regex compilation cost while preserving existing behavior.
- Keep the change small and local to `BuildFixtureFilterPreview(...)` and adjacent cleanup logic so import behavior remains unchanged.

### Description
- Added four reused static regexes: `kParenthesizedCleanupRe`, `kBracketedCleanupRe`, `kHyphenSpacingCleanupRe`, and `kWhitespaceCleanupRe` next to the other precompiled regexes.
- Replaced temporary `std::regex` constructions inside the `normalizeFixtureToken` lambda with the new static regex objects and preserved the original replacement strings and patterns.
- Replaced the parenthesized/bracketed cleanup on `modelForHang` with the new `kParenthesizedCleanupRe` and `kBracketedCleanupRe` to avoid per-call regex construction.
- Added a concise one-line comment above `BuildFixtureFilterPreview(...)` and updated `docs/release-notes-draft.md` with a brief internal change entry describing the improvement.

### Testing
- Ran `tests/check_perastage_tree_modules.sh`, which succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d3ff1a4bc83248e608f55f97aa2f7)