### PR TITLE
Optimize fixture filter preview keyword scans

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -1158,22 +1158,31 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
       havePending = false;
       continue;
     }
-    if (ContainsCaseInsensitive(line, "sonido") ||
-        ContainsCaseInsensitive(line, "audio") ||
-        ContainsCaseInsensitive(line, "control de p.a.") ||
-        ContainsCaseInsensitive(line, "monitores") ||
-        ContainsCaseInsensitive(line, "microfon") ||
-        ContainsCaseInsensitive(line, "video") ||
-        ContainsCaseInsensitive(line, "realizacion") ||
-        ContainsCaseInsensitive(line, "control")) {
+    const std::string lowerLine = [&line]() {
+      std::string lowered = line;
+      std::transform(lowered.begin(), lowered.end(), lowered.begin(),
+                     [](unsigned char c) {
+                       return static_cast<char>(std::tolower(c));
+                     });
+      return lowered;
+    }();
+
+    if (lowerLine.find("sonido") != std::string::npos ||
+        lowerLine.find("audio") != std::string::npos ||
+        lowerLine.find("control de p.a.") != std::string::npos ||
+        lowerLine.find("monitores") != std::string::npos ||
+        lowerLine.find("microfon") != std::string::npos ||
+        lowerLine.find("video") != std::string::npos ||
+        lowerLine.find("realizacion") != std::string::npos ||
+        lowerLine.find("control") != std::string::npos) {
       seenSectionHeader = true;
       inFixtures = false;
       inRigging = false;
-      inControl = ContainsCaseInsensitive(line, "control");
+      inControl = lowerLine.find("control") != std::string::npos;
       havePending = false;
       continue;
     }
-    if (ContainsCaseInsensitive(line, "rigging")) {
+    if (lowerLine.find("rigging") != std::string::npos) {
       seenSectionHeader = true;
       inFixtures = false;
       inRigging = true;
@@ -1181,9 +1190,9 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
       havePending = false;
       continue;
     }
-    if (!inControl && (ContainsCaseInsensitive(line, "ilumin") ||
-                       ContainsCaseInsensitive(line, "robotica") ||
-                       ContainsCaseInsensitive(line, "convencion"))) {
+    if (!inControl && (lowerLine.find("ilumin") != std::string::npos ||
+                       lowerLine.find("robotica") != std::string::npos ||
+                       lowerLine.find("convencion") != std::string::npos)) {
       seenSectionHeader = true;
       inFixtures = true;
       inRigging = false;

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -49,7 +49,7 @@ Changes since `v1.3.0`.
 ## Internal changes
 
 - Improved rider imports by reusing parsed GDTF fixture metadata during fixture creation and skipping repeated category inference once an imported fixture has an authoritative category, reducing repeated GDTF lookups while preserving existing dictionary, category, weight, and power precedence.
-- Improved rider fixture filtering performance by reusing cleanup regular expressions in hot preview paths while preserving existing filtering behavior.
+- Improved rider fixture filtering performance by reusing cleanup regular expressions and per-line section keyword normalization in hot preview paths while preserving existing filtering behavior.
 - Improved text-to-scene creation so applying the rider text filter in the editor no longer repeats the same filtering work during import, while preserving existing import behavior for all other flows.
 - Added backward-cpp integration, generated build metadata, and release workflow symbol archives for Windows, Linux, macOS, and Arch Linux builds.
 - Improved truss table reload stability so rebuilding rows preserves existing truss selection without triggering transient selection side effects.


### PR DESCRIPTION
### Motivation
- Reduce repeated case-insensitive substring scans in the hot rider preview path to improve performance while keeping existing section-detection semantics intact.

### Description
- Lowercase each stripped preview line once in `RiderImporter::BuildFixtureFilterPreview` and reuse that normalized string for section-keyword detection in `core/riderimporter.cpp`.
- Replace repeated `ContainsCaseInsensitive(line, "...")` calls in the section-header block with `lowerLine.find("...")` checks, preserving Spanish and English keywords such as `sonido`, `realizacion`, `ilumin`, `robotica`, and `convencion`.
- Leave regex-based parsing and other helper behavior unchanged to avoid altering parsing semantics.
- Update `docs/release-notes-draft.md` to mention the internal rider filtering improvement.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which succeeded.
- Ran `tests/check_no_configmanager_get_in_gui.sh` which succeeded.
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d419c5d708324ba5435c6e1bba272)