### PR TITLE
Cache rider truss definition imports

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -34,6 +34,7 @@
 #include <regex>
 #include <sstream>
 #include <string_view>
+#include <system_error>
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
@@ -1570,6 +1571,37 @@ struct ImportedGdtfMetadataCache {
   }
 };
 
+struct ImportedTrussDefinitionResult {
+  bool loaded = false;
+  Truss parsed;
+};
+
+struct ImportedTrussDefinitionCache {
+  std::unordered_map<std::string, ImportedTrussDefinitionResult> entries;
+
+  // Returns a stable cache key for a truss definition path.
+  std::string BuildKey(const std::string &path) const {
+    std::error_code ec;
+    std::filesystem::path normalized = std::filesystem::absolute(path, ec);
+    if (ec)
+      return path;
+    return normalized.lexically_normal().string();
+  }
+
+  // Loads and caches a truss definition for the current import.
+  const ImportedTrussDefinitionResult &Get(const std::string &path) {
+    const std::string key = BuildKey(path);
+    auto found = entries.find(key);
+    if (found != entries.end())
+      return found->second;
+
+    ImportedTrussDefinitionResult result;
+    result.loaded = LoadTrussDefinition(path, result.parsed);
+    auto [insertedIt, inserted] = entries.emplace(key, std::move(result));
+    return insertedIt->second;
+  }
+};
+
 // Applies cached GDTF metadata without overriding rider or dictionary choices.
 void ApplyImportedGdtfMetadata(Fixture &fixture,
                                const ImportedGdtfMetadata &metadata) {
@@ -1637,6 +1669,7 @@ bool RiderImporter::ImportText(const std::string &text,
   std::optional<float> lastBackdropReferencePosZ;
   std::optional<float> lastBackdropReferenceLengthMm;
   std::unordered_map<std::string, float> hangMarginOverridesMm;
+  ImportedTrussDefinitionCache trussDefinitionCache;
 
   auto getHangHeight = [&](const std::string &posName) {
     if (posName.rfind("LX", 0) == 0) {
@@ -2134,8 +2167,10 @@ bool RiderImporter::ImportText(const std::string &text,
             }
 
             if (dictPath) {
-              Truss parsed;
-              if (LoadTrussDefinition(*dictPath, parsed)) {
+              const ImportedTrussDefinitionResult &definition =
+                  trussDefinitionCache.Get(*dictPath);
+              if (definition.loaded) {
+                const Truss &parsed = definition.parsed;
                 if (!parsed.symbolFile.empty())
                   t.symbolFile = parsed.symbolFile;
                 t.modelFile = parsed.modelFile.empty() ? *dictPath : parsed.modelFile;
@@ -2461,8 +2496,10 @@ bool RiderImporter::ImportText(const std::string &text,
                 break;
             }
             if (dictPath) {
-              Truss parsed;
-              if (LoadTrussDefinition(*dictPath, parsed)) {
+              const ImportedTrussDefinitionResult &definition =
+                  trussDefinitionCache.Get(*dictPath);
+              if (definition.loaded) {
+                const Truss &parsed = definition.parsed;
                 if (!parsed.symbolFile.empty())
                   t.symbolFile = parsed.symbolFile;
                 t.modelFile = parsed.modelFile.empty() ? *dictPath : parsed.modelFile;
@@ -2633,8 +2670,10 @@ bool RiderImporter::ImportText(const std::string &text,
           }
 
           if (dictPath) {
-            Truss parsed;
-            if (LoadTrussDefinition(*dictPath, parsed)) {
+            const ImportedTrussDefinitionResult &definition =
+                trussDefinitionCache.Get(*dictPath);
+            if (definition.loaded) {
+              const Truss &parsed = definition.parsed;
               if (!parsed.symbolFile.empty())
                 t.symbolFile = parsed.symbolFile;
               t.modelFile = parsed.modelFile.empty() ? *dictPath : parsed.modelFile;
@@ -2716,12 +2755,20 @@ bool RiderImporter::ImportText(const std::string &text,
     bool dictionaryDefinitionFailed = false;
 
     if (!t.modelFile.empty()) {
-      resolved = LoadTrussDefinition(t.modelFile, parsed);
+      const ImportedTrussDefinitionResult &definition =
+          trussDefinitionCache.Get(t.modelFile);
+      resolved = definition.loaded;
+      if (resolved)
+        parsed = definition.parsed;
       if (!resolved)
         modelDefinitionFailed = true;
     }
     if (!resolved && !t.gdtfSpec.empty()) {
-      resolved = LoadTrussDefinition(t.gdtfSpec, parsed);
+      const ImportedTrussDefinitionResult &definition =
+          trussDefinitionCache.Get(t.gdtfSpec);
+      resolved = definition.loaded;
+      if (resolved)
+        parsed = definition.parsed;
       if (!resolved)
         gdtfDefinitionFailed = true;
     }
@@ -2732,7 +2779,11 @@ bool RiderImporter::ImportText(const std::string &text,
         auto dictPath = TrussDictionary::Get(lookupKey);
         if (!dictPath)
           continue;
-        resolved = LoadTrussDefinition(*dictPath, parsed);
+        const ImportedTrussDefinitionResult &definition =
+            trussDefinitionCache.Get(*dictPath);
+        resolved = definition.loaded;
+        if (resolved)
+          parsed = definition.parsed;
         if (!resolved)
           dictionaryDefinitionFailed = true;
         if (resolved && t.modelFile.empty())

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -48,6 +48,7 @@ Changes since `v1.3.0`.
 
 ## Internal changes
 
+- Improved rider truss import efficiency by caching truss definition loads within each import, avoiding repeated retries for the same valid or invalid truss paths while preserving existing parsed truss data precedence.
 - Improved rider imports by reusing parsed GDTF fixture metadata during fixture creation and skipping repeated category inference once an imported fixture has an authoritative category, reducing repeated GDTF lookups while preserving existing dictionary, category, weight, and power precedence.
 - Improved rider fixture filtering performance by reusing cleanup regular expressions and per-line section keyword normalization in hot preview paths while preserving existing filtering behavior.
 - Improved text-to-scene creation so applying the rider text filter in the editor no longer repeats the same filtering work during import, while preserving existing import behavior for all other flows.


### PR DESCRIPTION
### Motivation
- Reduce redundant truss-definition parsing and avoid repeated retries for the same path during a single rider import to improve import performance and reliability.
- Keep existing import behavior and precedence (dictionary vs model vs GDTF) while preventing extra filesystem/GDTF work for repeated invalid paths in the same import.
- Scope the cache to a single `ImportText()` invocation to avoid cross-import state while still reusing results across the multiple load sites inside the import.

### Description
- Added `ImportedTrussDefinitionResult` and `ImportedTrussDefinitionCache` types and a `trussDefinitionCache` instance inside `RiderImporter::ImportText()` to cache loads keyed by a stable normalized path key.
- The cache key uses `std::filesystem::absolute(path, ec).lexically_normal().string()` and falls back to the original path string when the filesystem normalization reports an error, preserving prior behavior on failures.
- Replaced direct `LoadTrussDefinition(...)` calls in truss creation and final rigging-resolution passes with `trussDefinitionCache.Get(...)`, and preserved all existing parsed-field copy logic and failure-tracking logic while caching both successful and failed loads.
- Updated `docs/release-notes-draft.md` with an internal-change entry describing the improvement.

### Testing
- `tests/check_perastage_tree_modules.sh` ran and returned OK.
- `tests/check_no_configmanager_get_in_gui.sh` ran and returned OK.
- `git diff --check` ran and returned OK (no whitespace/merge issues reported).
- `cmake --preset wsl-x64-debug` was attempted but configuration failed due to missing wxWidgets development libraries in the environment (expected for this CI-like environment and unrelated to the change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d437666e0832496b22e7d7da5f85d)