### PR TITLE
Use section flag instead of preview.str() in BuildFixtureFilterPreview

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -1515,7 +1515,7 @@ std::string RiderImporter::BuildFixtureFilterPreview(const std::string &text) {
       }
     }
 
-    if (!preview.str().empty())
+    if (!firstSection)
       preview << "\n\n";
     preview << "RIGGING";
     for (const std::string &hoistLine : hoistLines)

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -52,6 +52,7 @@ Changes since `v1.3.0`.
 - Improved rider truss import efficiency by caching truss definition loads within each import, avoiding repeated retries for the same valid or invalid truss paths while preserving existing parsed truss data precedence.
 - Improved rider imports by reusing parsed GDTF fixture metadata during fixture creation and skipping repeated category inference once an imported fixture has an authoritative category, reducing repeated GDTF lookups while preserving existing dictionary, category, weight, and power precedence.
 - Improved rider fixture filtering performance by reusing cleanup regular expressions and per-line section keyword normalization in hot preview paths while preserving existing filtering behavior.
+- Improved rider fixture filter preview construction by avoiding an extra string copy when appending rigging content, while preserving the existing preview layout.
 - Improved text-to-scene creation so applying the rider text filter in the editor no longer repeats the same filtering work during import, while preserving existing import behavior for all other flows.
 - Added backward-cpp integration, generated build metadata, and release workflow symbol archives for Windows, Linux, macOS, and Arch Linux builds.
 - Improved truss table reload stability so rebuilding rows preserves existing truss selection without triggering transient selection side effects.


### PR DESCRIPTION
### Motivation
- Avoid calling `preview.str()` during preview construction to prevent an extra string copy while preserving the exact blank-line spacing between fixture sections and the `RIGGING` section.

### Description
- Replaced the `if (!preview.str().empty())` check with the existing `firstSection` boolean in `RiderImporter::BuildFixtureFilterPreview(...)` and added a short internal entry to `docs/release-notes-draft.md` describing the preview-construction improvement.

### Testing
- Ran `rg -n "preview\.str\(\)|if \(!firstSection\)|BuildFixtureFilterPreview|Improved rider fixture filter preview construction" core/riderimporter.cpp docs/release-notes-draft.md`, `tests/check_perastage_tree_modules.sh`, `tests/check_no_configmanager_get_in_gui.sh`, and `git diff --check`, and all completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d4698817c832496874a084236923c)