### PR TITLE
Optimize rider fixture splitting

### DIFF
--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -588,15 +588,37 @@ std::string DescribeTrussForLog(const Truss &truss) {
   return oss.str();
 }
 
+// Returns a trimmed view over ASCII whitespace without copying.
+std::string_view TrimView(std::string_view s) {
+  const size_t start = s.find_first_not_of(" \t\r\n");
+  if (start == std::string_view::npos)
+    return {};
+  const size_t end = s.find_last_not_of(" \t\r\n");
+  return s.substr(start, end - start + 1);
+}
+
+// Visits each non-empty trimmed plus-separated segment without owning strings.
+template <typename Callback>
+void ForEachSplitPlusPart(std::string_view s, Callback callback) {
+  size_t start = 0;
+  while (start <= s.size()) {
+    const size_t plus = s.find('+', start);
+    const size_t end = plus == std::string_view::npos ? s.size() : plus;
+    const std::string_view part = TrimView(s.substr(start, end - start));
+    if (!part.empty())
+      callback(part);
+    if (plus == std::string_view::npos)
+      break;
+    start = plus + 1;
+  }
+}
+
+// Splits a plus-separated string into owned, trimmed, non-empty segments.
 std::vector<std::string> SplitPlus(const std::string &s) {
   std::vector<std::string> out;
-  std::istringstream ss(s);
-  std::string item;
-  while (std::getline(ss, item, '+')) {
-    item = Trim(item);
-    if (!item.empty())
-      out.push_back(item);
-  }
+  ForEachSplitPlusPart(s, [&](std::string_view item) {
+    out.emplace_back(item);
+  });
   return out;
 }
 
@@ -1133,9 +1155,9 @@ ParsedRiderImport ParseRiderImport(const std::string &text) {
 
   auto appendFixtureLines = [&](int baseQuantity, const std::string &descRaw) {
     const std::string hang = currentHang.empty() ? "UNASSIGNED" : currentHang;
-    auto parts = SplitPlus(descRaw);
-    for (const auto &partRaw : parts) {
+    ForEachSplitPlusPart(descRaw, [&](std::string_view partRawView) {
       std::smatch pm;
+      std::string partRaw(partRawView);
       std::string part = partRaw;
       int quantity = baseQuantity;
       if (std::regex_match(partRaw, pm, kFixtureLineRe)) {
@@ -1155,7 +1177,7 @@ ParsedRiderImport ParseRiderImport(const std::string &text) {
       parsed.fixtureRequests.push_back(hang + "\n" + fixtureRequest);
       if (NormalizeHangName(hang) == "SCREEN")
         parsed.screenRequests.push_back(fixtureRequest);
-    }
+    });
   };
 
   auto formatLengthM = [](float meters) {
@@ -1881,9 +1903,9 @@ bool RiderImporter::ImportText(const std::string &text,
   int parsedInputLineCount = 0;
 
   auto addFixtures = [&](int baseQuantity, const std::string &desc) {
-    auto parts = SplitPlus(desc);
-    for (const auto &partRaw : parts) {
+    ForEachSplitPlusPart(desc, [&](std::string_view partRawView) {
       std::smatch pm;
+      std::string partRaw(partRawView);
       std::string part = partRaw;
       int quantity = baseQuantity;
       if (std::regex_match(partRaw, pm, kFixtureLineRe)) {
@@ -1969,7 +1991,7 @@ bool RiderImporter::ImportText(const std::string &text,
         importedFixtureOrderByUuid[f.uuid] = nextImportedFixtureOrder++;
         addToLayer(f.layer, f.uuid);
       }
-    }
+    });
   };
   while (std::getline(iss, line)) {
     ++parsedInputLineCount;

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -1167,7 +1167,7 @@ ParsedRiderImport ParseRiderImport(const std::string &text) {
       }
       part = normalizeFixtureToken(part);
       if (part.empty())
-        continue;
+        return;
 
       auto &bucket = fixturesByHang[hang];
       if (bucket.empty())
@@ -1945,7 +1945,7 @@ bool RiderImporter::ImportText(const std::string &text,
                                                 : "pos " + currentHang;
           screenObjectRequests.push_back(std::move(request));
         }
-        continue;
+        return;
       }
       int &counter = nameCounters[part];
       for (int i = 0; i < quantity; ++i) {

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -52,6 +52,7 @@ Changes since `v1.3.0`.
 - Improved rider truss import efficiency by caching truss definition loads within each import, avoiding repeated retries for the same valid or invalid truss paths while preserving existing parsed truss data precedence.
 - Improved rider imports by reusing parsed GDTF fixture metadata during fixture creation and skipping repeated category inference once an imported fixture has an authoritative category, reducing repeated GDTF lookups while preserving existing dictionary, category, weight, and power precedence.
 - Improved rider fixture filtering performance by reusing cleanup regular expressions and per-line section keyword normalization in hot preview paths while preserving existing filtering behavior.
+- Improved rider fixture splitting performance during text import and fixture filter preview by avoiding intermediate string lists while preserving existing parsing behavior.
 - Improved rider fixture filter preview construction by avoiding an extra string copy when appending rigging content, while preserving the existing preview layout.
 - Improved rider text import internals by separating filtered rider requests into a parsed intermediate model, preserving preview output while reducing coupling between filtering and scene creation.
 - Improved text-to-scene creation so applying the rider text filter in the editor no longer repeats the same filtering work during import, while preserving existing import behavior for all other flows.


### PR DESCRIPTION
### Motivation
- Reduce allocation and copying overhead when splitting plus-separated fixture descriptions in rider import hot paths while preserving existing trimming and parsing semantics.
- Keep the existing owning `SplitPlus(...)` API available for callers that require owned strings.

### Description
- Added a non-owning view helper `TrimView(std::string_view)` and `ForEachSplitPlusPart(std::string_view, Callback)` to iterate trimmed, non-empty, plus-separated segments without allocating new strings.
- Reimplemented `SplitPlus(const std::string&)` to reuse the view-based iterator so its public behavior is unchanged.
- Replaced intermediate-vector usage with `ForEachSplitPlusPart(...)` in `appendFixtureLines(...)` (filter preview path) and the fixture creation path in `ImportText()` so both use the non-owning splitter while preserving existing quantity parsing, screen detection, and fixture creation behavior.
- Updated `docs/release-notes-draft.md` with an internal note about the performance improvement.

### Testing
- ✅ Ran mandatory checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh` which passed.
- ✅ Ran `git diff --check` to validate whitespace and patch cleanliness which passed.
- ⚠️ Attempted to configure/build and run CMake tests (targeting `rider_filter_preview_test`, `rider_import_linear_order_test`, `rider_import_order_test`) but full test execution was blocked during CMake configuration because wxWidgets development files are not installed in the CI/container environment, so those tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d4c8f66c88324bb4605343db9d4a6)