### PR TITLE
Fix 2D drag hover highlight

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -19,7 +19,7 @@ Changes since `v1.3.0`.
 
 ## Fixes
 
-- Kept the 2D viewer highlight pinned to the dragged scene element during mouse-drag moves so hover feedback no longer jumps to other elements mid-drag.
+- Kept the 2D and 3D viewer highlights pinned to the dragged scene element during mouse-drag moves so hover feedback no longer jumps to other elements mid-drag.
 - Fixed quick-click fixture selection in the 3D view so hovered fixtures can still be selected when the precise release pick misses.
 - Fixed MVR fixture Color handling so visualization colors are no longer exported as gel/filter colors, while imported MVR Color values are preserved as fixture gel/filter data.
 - Restored edge-safe fixture visibility and made fixture hover picking use actual fixture geometry so highlights and labels target the visible fixture instead of broad bounds.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -12,7 +12,7 @@ Changes since `v1.3.0`.
 
 ## Improvements
 
-- Added a 2D position gizmo while dragging scene elements so movement direction feedback matches the 3D viewer.
+- Added a 2D position gizmo while dragging scene elements so movement direction feedback follows the dragged insertion point and matches the 3D viewer.
 - Improved GroupObject handling so selecting a grouped member highlights and transforms the full root group, including nested groups, in 2D, 3D, and command-bar transform workflows.
 - Improved group hover feedback by using a more yellow primary highlight and a paler secondary group highlight across the 3D view and related fixture, truss, hoist, and scene object table rows, matching the table selection styling.
 - Improved 3D click selection for grouped scene items so a quick click selects the full group across fixture, truss, hoist, and scene object tables.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -19,6 +19,7 @@ Changes since `v1.3.0`.
 
 ## Fixes
 
+- Kept the 2D viewer highlight pinned to the dragged scene element during mouse-drag moves so hover feedback no longer jumps to other elements mid-drag.
 - Fixed quick-click fixture selection in the 3D view so hovered fixtures can still be selected when the precise release pick misses.
 - Fixed MVR fixture Color handling so visualization colors are no longer exported as gel/filter colors, while imported MVR Color values are preserved as fixture gel/filter data.
 - Restored edge-safe fixture visibility and made fixture hover picking use actual fixture geometry so highlights and labels target the visible fixture instead of broad bounds.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -12,6 +12,7 @@ Changes since `v1.3.0`.
 
 ## Improvements
 
+- Added a 2D position gizmo while dragging scene elements so movement direction feedback matches the 3D viewer.
 - Improved GroupObject handling so selecting a grouped member highlights and transforms the full root group, including nested groups, in 2D, 3D, and command-bar transform workflows.
 - Improved group hover feedback by using a more yellow primary highlight and a paler secondary group highlight across the 3D view and related fixture, truss, hoist, and scene object table rows, matching the table selection styling.
 - Improved 3D click selection for grouped scene items so a quick click selects the full group across fixture, truss, hoist, and scene object tables.

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -130,6 +130,22 @@ ResolveSceneElementCenterByUuid(const ConfigManager &cfg, const std::string &uui
   return std::nullopt;
 }
 
+
+// Draws a 2D triangular arrowhead in screen-space overlay coordinates.
+void DrawSelectionDragArrowhead2D(float baseX, float baseY, float dirX, float dirY,
+                                  float length, float radius) {
+  const float tipX = baseX + dirX * length;
+  const float tipY = baseY + dirY * length;
+  const float sideX = -dirY;
+  const float sideY = dirX;
+
+  glBegin(GL_TRIANGLES);
+  glVertex2f(tipX, tipY);
+  glVertex2f(baseX + sideX * radius, baseY + sideY * radius);
+  glVertex2f(baseX - sideX * radius, baseY - sideY * radius);
+  glEnd();
+}
+
 // Draws a CAD-like temporary dimension overlay with extension lines, arrows, and label.
 void DrawMeasureOverlay(Viewer3DController &controller,
                         const Viewer2DMeasureToolState &measureState,
@@ -1156,6 +1172,9 @@ void Viewer2DPanel::RenderInternal(bool swapBuffers) {
       viewer2d::EmitRulerToCanvas(rulerState, darkMode, *recordingCanvas);
   }
 
+  if (m_dragMode == DragMode::Selection)
+    DrawSelectionDragGizmo(w, h);
+
   if (m_measureToolState.enabled && m_measureToolState.hasAnchor) {
     std::optional<std::array<float, 3>> targetWorld;
     std::optional<std::array<float, 2>> targetScreenOverride;
@@ -1355,6 +1374,118 @@ std::array<float, 3> Viewer2DPanel::MapDragDelta(float dxMeters,
     return {0.0f, dxMeters, dyMeters};
   }
   return {dxMeters, dyMeters, 0.0f};
+}
+
+// Computes the current center point for the dragged 2D selection.
+std::optional<std::array<float, 3>>
+Viewer2DPanel::ComputeSelectionDragCenterMeters() const {
+  if (m_dragSelectionUuids.empty())
+    return std::nullopt;
+
+  const ConfigManager &cfg = ConfigManager::Get();
+  std::array<float, 3> center{0.0f, 0.0f, 0.0f};
+  size_t count = 0;
+  for (const std::string &uuid : m_dragSelectionUuids) {
+    const auto elementCenter = ResolveSceneElementCenterByUuid(cfg, uuid);
+    if (!elementCenter)
+      continue;
+    center[0] += (*elementCenter)[0];
+    center[1] += (*elementCenter)[1];
+    center[2] += (*elementCenter)[2];
+    ++count;
+  }
+
+  if (count == 0)
+    return std::nullopt;
+  center[0] /= static_cast<float>(count);
+  center[1] /= static_cast<float>(count);
+  center[2] /= static_cast<float>(count);
+  return center;
+}
+
+// Draws a position gizmo at the active 2D selection drag center.
+void Viewer2DPanel::DrawSelectionDragGizmo(int width, int height) {
+  if (m_dragMode != DragMode::Selection || m_dragSelectionUuids.empty() ||
+      width <= 0 || height <= 0)
+    return;
+
+  const auto centerWorld = ComputeSelectionDragCenterMeters();
+  if (!centerWorld)
+    return;
+
+  const auto centerScreen = Viewer2DMeasureWorldToScreen(
+      *centerWorld, m_view, width, height, m_zoom, m_offsetX, m_offsetY);
+  if (!centerScreen)
+    return;
+
+  const bool depthEnabled = glIsEnabled(GL_DEPTH_TEST);
+  if (depthEnabled)
+    glDisable(GL_DEPTH_TEST);
+
+  glMatrixMode(GL_PROJECTION);
+  glPushMatrix();
+  glLoadIdentity();
+  glOrtho(0.0f, static_cast<float>(width), 0.0f, static_cast<float>(height),
+          -1.0f, 1.0f);
+  glMatrixMode(GL_MODELVIEW);
+  glPushMatrix();
+  glLoadIdentity();
+
+  const float x = (*centerScreen)[0];
+  const float y = (*centerScreen)[1];
+  const float length = 58.0f;
+  const float arrowheadLength = 14.0f;
+  const float arrowheadRadius = 6.0f;
+  const float shaftLength = length - arrowheadLength;
+  const bool horizontalActive = m_dragAxis == DragAxis::Horizontal;
+  const bool verticalActive = m_dragAxis == DragAxis::Vertical;
+
+  std::array<float, 4> horizontalColor{};
+  std::array<float, 4> verticalColor{};
+  switch (m_view) {
+  case Viewer2DView::Top:
+  case Viewer2DView::Bottom:
+    horizontalColor = {horizontalActive ? 1.0f : 0.95f, 0.25f, 0.25f, 1.0f};
+    verticalColor = {0.25f, verticalActive ? 1.0f : 0.95f, 0.25f, 1.0f};
+    break;
+  case Viewer2DView::Front:
+    horizontalColor = {horizontalActive ? 1.0f : 0.95f, 0.25f, 0.25f, 1.0f};
+    verticalColor = {0.25f, 0.45f, verticalActive ? 1.0f : 0.95f, 1.0f};
+    break;
+  case Viewer2DView::Side:
+    horizontalColor = {0.25f, horizontalActive ? 1.0f : 0.95f, 0.25f, 1.0f};
+    verticalColor = {0.25f, 0.45f, verticalActive ? 1.0f : 0.95f, 1.0f};
+    break;
+  }
+
+  glLineWidth(2.5f);
+  glBegin(GL_LINES);
+  glColor4f(horizontalColor[0], horizontalColor[1], horizontalColor[2],
+            horizontalColor[3]);
+  glVertex2f(x, y);
+  glVertex2f(x + shaftLength, y);
+  glColor4f(verticalColor[0], verticalColor[1], verticalColor[2],
+            verticalColor[3]);
+  glVertex2f(x, y);
+  glVertex2f(x, y + shaftLength);
+  glEnd();
+
+  glColor4f(horizontalColor[0], horizontalColor[1], horizontalColor[2],
+            horizontalColor[3]);
+  DrawSelectionDragArrowhead2D(x + shaftLength, y, 1.0f, 0.0f,
+                               arrowheadLength, arrowheadRadius);
+  glColor4f(verticalColor[0], verticalColor[1], verticalColor[2],
+            verticalColor[3]);
+  DrawSelectionDragArrowhead2D(x, y + shaftLength, 0.0f, 1.0f,
+                               arrowheadLength, arrowheadRadius);
+
+  glPopMatrix();
+  glMatrixMode(GL_PROJECTION);
+  glPopMatrix();
+  glMatrixMode(GL_MODELVIEW);
+
+  if (depthEnabled)
+    glEnable(GL_DEPTH_TEST);
 }
 
 void Viewer2DPanel::ApplySelectionDelta(

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -2161,6 +2161,8 @@ void Viewer2DPanel::RunHoverHitTest(const wxPoint &screenPos) {
     return;
 
   m_hoverHitTestPending = false;
+  if (m_dragMode == DragMode::Selection)
+    return;
   m_lastHoverHitTestTime = std::chrono::steady_clock::now();
   m_lastHoverQueryScreenPos = screenPos;
   m_hoverQueryHasPos = true;
@@ -2387,6 +2389,7 @@ void Viewer2DPanel::OnMouseDown(wxMouseEvent &event) {
         }
       }
 
+      ApplyHoverUuid(uuid, true);
       m_dragMode = DragMode::Selection;
       m_dragTarget = target;
     }

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -1432,7 +1432,9 @@ void Viewer2DPanel::DrawSelectionDragGizmo(int width, int height) {
   glLoadIdentity();
 
   const float x = (*centerScreen)[0];
-  const float y = (*centerScreen)[1];
+  // Viewer2DMeasureWorldToScreen returns top-origin pixels; this overlay uses
+  // bottom-origin GL coordinates.
+  const float y = static_cast<float>(height) - (*centerScreen)[1];
   const float length = 58.0f;
   const float arrowheadLength = 14.0f;
   const float arrowheadRadius = 6.0f;

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -190,12 +190,14 @@ private:
   void TrackRefreshTelemetry();
 
   std::array<float, 3> MapDragDelta(float dxMeters, float dyMeters) const;
+  std::optional<std::array<float, 3>> ComputeSelectionDragCenterMeters() const;
   std::optional<std::array<float, 3>>
   ComputeWorldPositionFromScreen(const wxPoint &screenPos) const;
   void NotifyCursorWorldPosition(const wxPoint &screenPos);
   void ClearCursorWorldPosition();
   void ApplySelectionDelta(const std::array<float, 3> &deltaMeters);
   void FinalizeSelectionDrag();
+  void DrawSelectionDragGizmo(int width, int height);
   void ApplyRectangleSelection(const wxPoint &start, const wxPoint &end,
                                bool selectAcrossAllTables);
   void DrawSelectionRectangle(int width, int height, bool darkMode);

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -1110,12 +1110,12 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
     const auto nowForHover = std::chrono::steady_clock::now();
     const bool hoverCadenceDue = m_forceHoverQuery ||
         (nowForHover - m_lastHoverQueryTime) >= kHoverQueryInterval;
-    const bool hoverQueriesPausedForCamera =
-        m_cameraMoving || m_isInteracting || m_dragging;
-    if (hoverQueriesPausedForCamera && shouldUpdateHoverQuery)
-        viewer3d::diagnostics::Log("Hover picking paused during active camera navigation.");
+    const bool hoverQueriesPausedForInteraction =
+        m_cameraMoving || m_isInteracting || m_dragging || m_selectionDragArmed;
+    if (hoverQueriesPausedForInteraction && shouldUpdateHoverQuery)
+        viewer3d::diagnostics::Log("Hover picking paused during active interaction.");
     const bool shouldRunHoverQuery =
-        !hoverQueriesPausedForCamera &&
+        !hoverQueriesPausedForInteraction &&
         (!skipLabelWork || m_forceHoverQuery) &&
         shouldUpdateHoverQuery && hoverCadenceDue &&
         activeTable != HoverTargetTable::None &&
@@ -1183,46 +1183,7 @@ void Viewer3DPanel::OnPaint(wxPaintEvent& event)
     if (oldHoverUuid != m_hoverUuid || oldHasHover != m_hasHover) {
         const auto highlightUpdateStart = std::chrono::steady_clock::now();
         highlightChanged = true;
-        ++m_highlightRevision;
-        m_highlightRefreshPending = true;
-        if (m_basePassCache)
-            m_basePassCache->Invalidate();
-        m_controller.SetHighlightUuid(m_hoverUuid);
-        const MvrScene& scene = ConfigManager::Get().GetScene();
-        const HoverTableHighlights relatedHighlights =
-            BuildHoverTableHighlights(scene, m_hoverUuid);
-        if (FixtureTablePanel::Instance()) {
-            const std::string primaryUuid =
-                scene.fixtures.find(m_hoverUuid) != scene.fixtures.end()
-                    ? std::string(m_hoverUuid)
-                    : std::string();
-            FixtureTablePanel::Instance()->HighlightFixture(
-                primaryUuid, relatedHighlights.fixtures);
-        }
-        if (TrussTablePanel::Instance()) {
-            const std::string primaryUuid =
-                scene.trusses.find(m_hoverUuid) != scene.trusses.end()
-                    ? std::string(m_hoverUuid)
-                    : std::string();
-            TrussTablePanel::Instance()->HighlightTruss(
-                primaryUuid, relatedHighlights.trusses);
-        }
-        if (HoistTablePanel::Instance()) {
-            const std::string primaryUuid =
-                scene.supports.find(m_hoverUuid) != scene.supports.end()
-                    ? std::string(m_hoverUuid)
-                    : std::string();
-            HoistTablePanel::Instance()->HighlightHoist(
-                primaryUuid, relatedHighlights.supports);
-        }
-        if (SceneObjectTablePanel::Instance()) {
-            const std::string primaryUuid =
-                scene.sceneObjects.find(m_hoverUuid) != scene.sceneObjects.end()
-                    ? std::string(m_hoverUuid)
-                    : std::string();
-            SceneObjectTablePanel::Instance()->HighlightObject(
-                primaryUuid, relatedHighlights.sceneObjects);
-        }
+        SynchronizeHoverHighlight();
         const auto highlightUpdateElapsedMs =
             std::chrono::duration<double, std::milli>(
                 std::chrono::steady_clock::now() - highlightUpdateStart)
@@ -1854,6 +1815,53 @@ void Viewer3DPanel::OnMouseUp(wxMouseEvent& event)
 }
 
 
+// Synchronizes the current hover highlight with the 3D controller and tables.
+void Viewer3DPanel::SynchronizeHoverHighlight()
+{
+    ++m_highlightRevision;
+    m_highlightRefreshPending = true;
+    if (m_basePassCache)
+        m_basePassCache->Invalidate();
+    m_controller.SetHighlightUuid(m_hoverUuid);
+
+    const MvrScene& scene = ConfigManager::Get().GetScene();
+    const HoverTableHighlights relatedHighlights =
+        BuildHoverTableHighlights(scene, m_hoverUuid);
+    if (FixtureTablePanel::Instance()) {
+        const std::string primaryUuid =
+            scene.fixtures.find(m_hoverUuid) != scene.fixtures.end()
+                ? std::string(m_hoverUuid)
+                : std::string();
+        FixtureTablePanel::Instance()->HighlightFixture(
+            primaryUuid, relatedHighlights.fixtures);
+    }
+    if (TrussTablePanel::Instance()) {
+        const std::string primaryUuid =
+            scene.trusses.find(m_hoverUuid) != scene.trusses.end()
+                ? std::string(m_hoverUuid)
+                : std::string();
+        TrussTablePanel::Instance()->HighlightTruss(
+            primaryUuid, relatedHighlights.trusses);
+    }
+    if (HoistTablePanel::Instance()) {
+        const std::string primaryUuid =
+            scene.supports.find(m_hoverUuid) != scene.supports.end()
+                ? std::string(m_hoverUuid)
+                : std::string();
+        HoistTablePanel::Instance()->HighlightHoist(
+            primaryUuid, relatedHighlights.supports);
+    }
+    if (SceneObjectTablePanel::Instance()) {
+        const std::string primaryUuid =
+            scene.sceneObjects.find(m_hoverUuid) != scene.sceneObjects.end()
+                ? std::string(m_hoverUuid)
+                : std::string();
+        SceneObjectTablePanel::Instance()->HighlightObject(
+            primaryUuid, relatedHighlights.sceneObjects);
+    }
+}
+
+
 // Clears every object-selection store and synchronizes table and viewport highlights.
 void Viewer3DPanel::ClearAllObjectSelections(const char* undoLabel)
 {
@@ -2279,6 +2287,7 @@ void Viewer3DPanel::ResetSelectionDragState()
     m_selectionDragAxis = viewer3d::SelectionDragAxis::None;
 }
 
+// Computes the world-space center for the active selection drag target.
 std::array<float, 3> Viewer3DPanel::ComputeSelectionCenterMeters(
     const std::vector<std::string>& uuids, HoverTargetTable target) const
 {
@@ -2385,6 +2394,11 @@ bool Viewer3DPanel::PrepareSelectionDrag(const wxPoint& mousePos)
         for (float& component : m_selectionDragAnchorMeters)
             component /= static_cast<float>(dragTargets.size());
     }
+    m_hasHover = true;
+    m_hoverUuid = uuid;
+    m_hoverText.clear();
+    SynchronizeHoverHighlight();
+
     m_selectionDragAxis = viewer3d::SelectionDragAxis::None;
     m_selectionDragArmed = true;
     m_selectionDragMoved = false;

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -141,6 +141,8 @@ private:
 
     // Clear all selected scene object types and refresh related UI state.
     void ClearAllObjectSelections(const char* undoLabel);
+    // Synchronizes the current hover highlight with the 3D controller and tables.
+    void SynchronizeHoverHighlight();
     void OnCaptureLost(wxMouseCaptureLostEvent& event);
     void ApplyRectangleSelection(const wxPoint& start, const wxPoint& end);
     // Safely binds the GL context for interaction and picking paths.


### PR DESCRIPTION
### Motivation
- Prevent confusing hover feedback during mouse-driven selection drags by keeping the highlight pinned to the element where the drag started so it does not jump to other elements while dragging.

### Description
- Suppress hover hit-test processing while a selection drag is active by returning early in `Viewer2DPanel::RunHoverHitTest` when `m_dragMode == DragMode::Selection`.
- Pin the hover highlight when a selection drag begins by calling `ApplyHoverUuid(uuid, true)` at the start of the selection drag path in `Viewer2DPanel::OnMouseDown`.
- Updated `docs/release-notes-draft.md` with a user-visible fix entry describing the change.

### Testing
- `tests/check_perastage_tree_modules.sh` ran and reported OK.
- `tests/check_no_configmanager_get_in_gui.sh` ran and reported OK.
- Code checks (`git diff --check`) ran with no reported issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d5b6f125483248ed0ad363c6eb804)