### PR TITLE
Fix scene object name edits for MVR export

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -20,6 +20,7 @@ Changes since `v1.3.0`.
 
 ## Fixes
 
+- Fixed scene object renaming so edited Data View names are preserved in the scene summary and MVR exports, supporting technical object-name workflows such as cable waypoints.
 - Kept the 2D and 3D viewer highlights pinned to the dragged scene element during mouse-drag moves so hover feedback no longer jumps to other elements mid-drag.
 - Fixed quick-click fixture selection in the 3D view so hovered fixtures can still be selected when the precise release pick misses.
 - Fixed MVR fixture Color handling so visualization colors are no longer exported as gel/filter colors, while imported MVR Color values are preserved as fixture gel/filter data.

--- a/gui/sceneobjecttablepanel.cpp
+++ b/gui/sceneobjecttablepanel.cpp
@@ -797,7 +797,7 @@ void SceneObjectTablePanel::UpdateSceneData(bool logChanges)
         }
     };
 
-    // Persist row values only when layer or transform differs from scene data.
+    // Persist row values only when editable scene object data differs from scene data.
     for (size_t i = 0; i < count; ++i)
     {
         auto it = scene.sceneObjects.find(rowUuids[i]);
@@ -808,8 +808,11 @@ void SceneObjectTablePanel::UpdateSceneData(bool logChanges)
         SceneObject next = old;
         wxVariant v;
 
+        table->GetValue(v, i, 0);
+        next.name = std::string(v.GetString().ToUTF8());
+
         table->GetValue(v, i, 1);
-        std::string layerStr = std::string(v.GetString().mb_str());
+        std::string layerStr = std::string(v.GetString().ToUTF8());
         if (layerStr.empty())
             next.layer.clear();
         else
@@ -885,7 +888,8 @@ void SceneObjectTablePanel::UpdateSceneData(bool logChanges)
                  static_cast<float>(zMm)});
         }
 
-        const bool objectChanged = old.layer != next.layer ||
+        const bool objectChanged = old.name != next.name ||
+                                   old.layer != next.layer ||
                                    old.modelFile != next.modelFile ||
                                    transformChanged;
         if (!objectChanged)


### PR DESCRIPTION
### Motivation
- Fix a bug where renaming generic 3D objects in the Data View was not being persisted into the scene model, Summary panel, or exported MVR files causing external tools to still see generic names like "Cube 1".

### Description
- Read the Name column value into the scene model during table commit by updating `SceneObjectTablePanel::UpdateSceneData` so `SceneObject::name` is populated from the Data View (`gui/sceneobjecttablepanel.cpp`).
- Use UTF-8 value extraction for table strings and include `name` in the change-detection logic so name-only edits trigger undo/state updates, summary refresh, and viewport refresh (`gui/sceneobjecttablepanel.cpp`).
- Add a user-facing release-note entry describing the fix (`docs/release-notes-draft.md`).

### Testing
- Ran mandatory project checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both succeeded.
- Ran repository checks including `git diff --check`; no issues were reported and the changes were committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d635604348324b9a5adbca4ebe57d)