### PR TITLE
Fix adding primitive scene object templates

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -31,6 +31,7 @@ Changes since `v1.3.0`.
 - Fixed MVR Eurotruss rendering in the 3D viewport by preserving native 3DS SceneObject mesh dimensions, keeping repeated SceneObject Symbol children distinct per parent object, and preserving correct truss fallback sizing for rotated trusses.
 - Improved truss file validation so unsupported model formats are rejected clearly, while direct GLB and 3DS truss models now load only when the selected file exists.
 - Improved fallback dimensions for direct truss model files so GLB and 3DS trusses remain visible and selectable even when model metadata or mesh loading is unavailable.
+- Fixed Add scene object so reusing an existing Perastage basic geometry object copies its primitive geometry data immediately instead of showing a default cube until the project is reopened.
 
 ## Stability and reliability
 

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -1475,15 +1475,16 @@ void MainWindow::OnAddSceneObject(wxCommandEvent &WXUNUSED(event)) {
 
   std::string path;
   std::string defaultName;
+  const SceneObject *templateObject = nullptr;
 
   if (!scene.sceneObjects.empty()) {
-    std::map<std::string, std::string> nameToFile;
+    std::map<std::string, const SceneObject *> nameToObject;
     for (const auto &[uuid, o] : scene.sceneObjects)
-      if (!o.name.empty() && !o.modelFile.empty())
-        nameToFile.try_emplace(o.name, o.modelFile);
+      if (!o.name.empty() && !o.GetPrimaryModel().empty())
+        nameToObject.try_emplace(o.name, &o);
     std::vector<std::string> names;
-    names.reserve(nameToFile.size());
-    for (const auto &[n, _] : nameToFile)
+    names.reserve(nameToObject.size());
+    for (const auto &[n, _] : nameToObject)
       names.push_back(n);
 
     SelectNameDialog chooseDlg(this, names, "Select Scene Object",
@@ -1507,7 +1508,11 @@ void MainWindow::OnAddSceneObject(wxCommandEvent &WXUNUSED(event)) {
       if (sel < 0 || sel >= static_cast<int>(names.size()))
         return;
       defaultName = names[sel];
-      path = nameToFile[defaultName];
+      auto objectIt = nameToObject.find(defaultName);
+      if (objectIt == nameToObject.end() || objectIt->second == nullptr)
+        return;
+      templateObject = objectIt->second;
+      path = templateObject->GetPrimaryModel();
     }
   } else {
     wxString objDir = wxString::FromUTF8(
@@ -1530,15 +1535,19 @@ void MainWindow::OnAddSceneObject(wxCommandEvent &WXUNUSED(event)) {
   namespace fs = std::filesystem;
   cfg.PushUndoState("add scene object");
   std::string base = scene.basePath;
-  std::string conversionError;
-  path = NormalizeImportedObjectModelPathToGlb(path, base, conversionError);
-  if (!conversionError.empty() && ConsolePanel::Instance())
-    ConsolePanel::Instance()->AppendMessage(wxString::FromUTF8(conversionError));
-  if (!base.empty()) {
-    fs::path abs = fs::absolute(path);
-    fs::path b = fs::absolute(base);
-    if (abs.string().rfind(b.string(), 0) == 0)
-      path = fs::relative(abs, b).string();
+  const bool useTemplateGeometry =
+      templateObject != nullptr && !templateObject->geometries.empty();
+  if (!useTemplateGeometry) {
+    std::string conversionError;
+    path = NormalizeImportedObjectModelPathToGlb(path, base, conversionError);
+    if (!conversionError.empty() && ConsolePanel::Instance())
+      ConsolePanel::Instance()->AppendMessage(wxString::FromUTF8(conversionError));
+    if (!base.empty()) {
+      fs::path abs = fs::absolute(path);
+      fs::path b = fs::absolute(base);
+      if (abs.string().rfind(b.string(), 0) == 0)
+        path = fs::relative(abs, b).string();
+    }
   }
 
   auto baseId = std::chrono::steady_clock::now().time_since_epoch().count();
@@ -1566,7 +1575,12 @@ void MainWindow::OnAddSceneObject(wxCommandEvent &WXUNUSED(event)) {
       obj.name = defaultName + " " + std::to_string(i + 1);
     else
       obj.name = defaultName;
-    obj.modelFile = path;
+    if (useTemplateGeometry) {
+      obj.geometries = templateObject->geometries;
+      obj.modelFile = templateObject->modelFile;
+    } else {
+      obj.modelFile = path;
+    }
     obj.layer = layerName;
     scene.sceneObjects[obj.uuid] = obj;
   }


### PR DESCRIPTION
### Motivation
- Fix a bug where `Add scene object...` would insert a default cube when the chosen template was a Perastage/Peraviz basic-geometry scene object instead of copying its primitive geometry immediately.
- Ensure the add-object flow detects and preserves in-scene primitive geometry templates without changing existing external file import behavior.

### Description
- Replace the name->file lookup with a name->`SceneObject*` lookup so the add dialog can detect when the user selected an existing scene object as a template.
- When a template object with non-empty `geometries` is selected, skip external-model normalization and copy `geometries` and `modelFile` from the template into the new objects instead of setting `modelFile` to the import path.
- Preserve the existing import/normalization path for true external files by only skipping conversion when `useTemplateGeometry` is true.
- Update `docs/release-notes-draft.md` with a user-visible fix entry for this change.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both succeeded.
- Ran `git diff --check` to validate whitespace and diff issues, which returned no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d6f24c6a08324baf4618664f5160d)