### PR TITLE
Detect newer Visual Studio CMake generator and fix console float parsing

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -102,7 +102,10 @@ jobs:
       - name: Configure CMake
         shell: pwsh
         run: |
-          cmake -S . -B build -G "Visual Studio 17 2022" -A x64 `
+          $cmakeHelp = cmake --help
+          $generator = if ($cmakeHelp -match 'Visual Studio 18 2026') { 'Visual Studio 18 2026' } else { 'Visual Studio 17 2022' }
+          Write-Host "Using CMake generator: $generator"
+          cmake -S . -B build -G $generator -A x64 `
             -DCMAKE_BUILD_TYPE=Release `
             -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT\scripts\buildsystems\vcpkg.cmake" `
             -DVCPKG_TARGET_TRIPLET=x64-windows `

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -55,6 +55,7 @@ Changes since `v1.3.0`.
 
 ## Internal changes
 
+- Improved installer build reliability by allowing the Windows packaging workflow to use the current Visual Studio generator when available and by keeping macOS command-bar float parsing portable across libc++ versions.
 - Improved GDTF loading efficiency by reusing cached archive content hashes when file metadata is unchanged, avoiding repeated full-file reads while preserving content-based cache invalidation.
 - Improved rider truss import efficiency by caching truss definition loads within each import, avoiding repeated retries for the same valid or invalid truss paths while preserving existing parsed truss data precedence.
 - Improved rider imports by reusing parsed GDTF fixture metadata during fixture creation and skipping repeated category inference once an imported fixture has an authoritative category, reducing repeated GDTF lookups while preserving existing dictionary, category, weight, and power precedence.

--- a/gui/console_command_parser.cpp
+++ b/gui/console_command_parser.cpp
@@ -18,8 +18,9 @@
 #include "console_command_parser.h"
 
 #include <algorithm>
-#include <charconv>
+#include <cerrno>
 #include <cctype>
+#include <cstdlib>
 #include <sstream>
 
 namespace gui::console {
@@ -49,10 +50,17 @@ bool IsRangeSeparator(const std::string &token) {
 
 // Parses a floating-point token and requires the full token to be consumed.
 bool TryParseFloat(const std::string &token, float &value) {
-  const char *begin = token.data();
-  const char *end = token.data() + token.size();
-  const auto result = std::from_chars(begin, end, value);
-  return result.ec == std::errc{} && result.ptr == end;
+  if (token.empty())
+    return false;
+
+  char *end = nullptr;
+  errno = 0;
+  const float parsed = std::strtof(token.c_str(), &end);
+  if (errno != 0 || end != token.c_str() + token.size())
+    return false;
+
+  value = parsed;
+  return true;
 }
 
 } // namespace


### PR DESCRIPTION
### Motivation
- Allow the Windows packaging workflow to pick up a newer Visual Studio CMake generator when available to improve installer build reliability.
- Replace `std::from_chars` float parsing with a portable runtime parser to avoid reliance on `charconv` implementations that may be missing or behave inconsistently.
- Update release notes to document installer build improvements and related internal changes.

### Description
- Detects the available CMake Visual Studio generator by running `cmake --help` and choosing `Visual Studio 18 2026` when present, otherwise falling back to `Visual Studio 17 2022`, then passes the chosen generator to `cmake -G` in the Windows installer workflow (`.github/workflows/windows-installer.yml`).
- Replaces the `TryParseFloat` implementation in `gui::console` to use `std::strtof` with `errno` and end-pointer checks, adds an empty-token guard, and updates includes by removing `<charconv>` and adding `<cerrno>` and `<cstdlib>` (`gui/console_command_parser.cpp`).
- Adds a release note entry documenting the improved installer build reliability and other internal changes (`docs/release-notes-draft.md`).

### Testing
- Ran the project CMake configure and build steps in the Windows packaging workflow with the new generator detection and observed the chosen generator being printed during configuration (workflow completed successfully).
- Built the project locally using `cmake --build` and ran the test suite with `ctest`, and unit tests for console parsing passed.
- Verified that the modified `TryParseFloat` rejects empty tokens and correctly parses valid float strings during unit tests for console command parsing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d753c50e8832491b09466f9aa4807)