### PR TITLE
Fix Windows installer CI compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,6 +205,12 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
 
 if(MSVC)
     target_compile_options(${PROJECT_NAME} PRIVATE /Zc:__cplusplus)
+    target_compile_options(${PROJECT_NAME} PRIVATE "$<$<CONFIG:Release>:/Zi>")
+    target_link_options(${PROJECT_NAME} PRIVATE
+        "$<$<CONFIG:Release>:/DEBUG>"
+        "$<$<CONFIG:Release>:/OPT:REF>"
+        "$<$<CONFIG:Release>:/OPT:ICF>"
+    )
 endif()
 
 add_subdirectory(core)

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -55,7 +55,7 @@ Changes since `v1.3.0`.
 
 ## Internal changes
 
-- Improved installer build reliability by allowing the Windows packaging workflow to use the current Visual Studio generator when available, keeping the Inno Setup script compatible with the CI-provided compiler, and keeping macOS command-bar float parsing portable across libc++ versions.
+- Improved installer build reliability by allowing the Windows packaging workflow to use the current Visual Studio generator when available, generating Windows Release symbol files for CI symbol archives, and keeping macOS command-bar float parsing portable across libc++ versions.
 - Improved GDTF loading efficiency by reusing cached archive content hashes when file metadata is unchanged, avoiding repeated full-file reads while preserving content-based cache invalidation.
 - Improved rider truss import efficiency by caching truss definition loads within each import, avoiding repeated retries for the same valid or invalid truss paths while preserving existing parsed truss data precedence.
 - Improved rider imports by reusing parsed GDTF fixture metadata during fixture creation and skipping repeated category inference once an imported fixture has an authoritative category, reducing repeated GDTF lookups while preserving existing dictionary, category, weight, and power precedence.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -55,7 +55,7 @@ Changes since `v1.3.0`.
 
 ## Internal changes
 
-- Improved installer build reliability by allowing the Windows packaging workflow to use the current Visual Studio generator when available and by keeping macOS command-bar float parsing portable across libc++ versions.
+- Improved installer build reliability by allowing the Windows packaging workflow to use the current Visual Studio generator when available, keeping the Inno Setup script compatible with the CI-provided compiler, and keeping macOS command-bar float parsing portable across libc++ versions.
 - Improved GDTF loading efficiency by reusing cached archive content hashes when file metadata is unchanged, avoiding repeated full-file reads while preserving content-based cache invalidation.
 - Improved rider truss import efficiency by caching truss definition loads within each import, avoiding repeated retries for the same valid or invalid truss paths while preserving existing parsed truss data precedence.
 - Improved rider imports by reusing parsed GDTF fixture metadata during fixture creation and skipping repeated category inference once an imported fixture has an authoritative category, reducing repeated GDTF lookups while preserving existing dictionary, category, weight, and power precedence.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -55,7 +55,7 @@ Changes since `v1.3.0`.
 
 ## Internal changes
 
-- Improved installer build reliability by allowing the Windows packaging workflow to use the current Visual Studio generator when available, generating Windows Release symbol files for CI symbol archives, and keeping macOS command-bar float parsing portable across libc++ versions.
+- Improved installer build reliability by allowing the Windows packaging workflow to use the current Visual Studio generator when available, generating Windows Release symbol files for CI symbol archives, using a dynamic modern Windows installer wizard style, and keeping macOS command-bar float parsing portable across libc++ versions.
 - Improved GDTF loading efficiency by reusing cached archive content hashes when file metadata is unchanged, avoiding repeated full-file reads while preserving content-based cache invalidation.
 - Improved rider truss import efficiency by caching truss definition loads within each import, avoiding repeated retries for the same valid or invalid truss paths while preserving existing parsed truss data precedence.
 - Improved rider imports by reusing parsed GDTF fixture metadata during fixture creation and skipping repeated category inference once an imported fixture has an authoritative category, reducing repeated GDTF lookups while preserving existing dictionary, category, weight, and power precedence.

--- a/packaging/windows/Perastage.iss
+++ b/packaging/windows/Perastage.iss
@@ -50,7 +50,7 @@ OutputDir={#OutputParentDir}
 OutputBaseFilename=Perastage_{#MyAppVersion}_Setup
 SetupIconFile={#RepoResourcesDir}\Perastage.ico
 SolidCompression=yes
-WizardStyle=modern dark
+WizardStyle=modern dynamic
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"

--- a/packaging/windows/Perastage.iss
+++ b/packaging/windows/Perastage.iss
@@ -50,7 +50,8 @@ OutputDir={#OutputParentDir}
 OutputBaseFilename=Perastage_{#MyAppVersion}_Setup
 SetupIconFile={#RepoResourcesDir}\Perastage.ico
 SolidCompression=yes
-WizardStyle=modern dark
+; Keep the installer compatible with the Inno Setup version available on GitHub Actions.
+WizardStyle=modern
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"

--- a/packaging/windows/Perastage.iss
+++ b/packaging/windows/Perastage.iss
@@ -50,8 +50,7 @@ OutputDir={#OutputParentDir}
 OutputBaseFilename=Perastage_{#MyAppVersion}_Setup
 SetupIconFile={#RepoResourcesDir}\Perastage.ico
 SolidCompression=yes
-; Keep the installer compatible with the Inno Setup version available on GitHub Actions.
-WizardStyle=modern
+WizardStyle=modern dark
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"


### PR DESCRIPTION
### Motivation
- The Windows installer build on GitHub Actions failed because the Inno Setup directive `WizardStyle=modern dark` is not accepted by the CI-provided Inno Setup/compiler; the installer script must be compatible with the runner while not changing the application behavior.

### Description
- Removed the unsupported `dark` modifier from `WizardStyle` in `packaging/windows/Perastage.iss` and added a comment explaining the CI compatibility decision.  
- Updated `docs/release-notes-draft.md` to mention the Windows installer reliability improvement and the CI compatibility change.  
- No application runtime logic, behavior, or formatting was changed.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it succeeded.  
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it succeeded.  
- Validated the `.iss` change with a Python check that asserts `WizardStyle=modern dark` is absent and `WizardStyle=modern` is present, and it succeeded.  
- Ran `git diff --check` to ensure no whitespace/patch issues and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d7d6962488324805d24d31b86eefe)