### PR TITLE
Fix macOS GDTF filesystem path build

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -55,6 +55,7 @@ Changes since `v1.3.0`.
 
 ## Internal changes
 
+- Restored macOS installer build compatibility with Xcode 16.4 by avoiding deprecated filesystem path construction during GDTF model loading.
 - Improved installer build reliability by allowing the Windows packaging workflow to use the current Visual Studio generator when available, generating Windows Release symbol files for CI symbol archives, using a dynamic modern Windows installer wizard style, and keeping macOS command-bar float parsing portable across libc++ versions.
 - Improved GDTF loading efficiency by reusing cached archive content hashes when file metadata is unchanged, avoiding repeated full-file reads while preserving content-based cache invalidation.
 - Improved rider truss import efficiency by caching truss definition loads within each import, avoiding repeated retries for the same valid or invalid truss paths while preserving existing parsed truss data precedence.

--- a/viewer3d/gdtfloader.cpp
+++ b/viewer3d/gdtfloader.cpp
@@ -54,6 +54,16 @@ class wxZipStreamLink;
 namespace fs = std::filesystem;
 
 namespace {
+// Converts a UTF-8 string into a filesystem path without triggering macOS libc++ u8path deprecation warnings.
+static fs::path MakeUtf8Path(const std::string& text)
+{
+#if defined(__APPLE__)
+    return fs::path(text);
+#else
+    return fs::u8path(text);
+#endif
+}
+
 // Parses a trimmed float token and succeeds only when the whole token is numeric.
 bool TryParseFloat(const std::string& text, float& out)
 {
@@ -280,8 +290,6 @@ static void ApplyModelDimensions(Mesh& mesh, const GdtfModelInfo& modelInfo)
     }
 }
 
-// Locates a model file using spec-compliant preferred folders and cached recursive fallback lookups.
-
 // Builds a box primitive scaled from model dimensions using visible defaults for missing size components.
 static bool BuildDimensionFallbackMesh(const GdtfModelInfo& modelInfo, Mesh& mesh)
 {
@@ -299,14 +307,16 @@ static bool BuildDimensionFallbackMesh(const GdtfModelInfo& modelInfo, Mesh& mes
     ApplyModelDimensions(mesh, adjusted);
     return true;
 }
+
+// Locates a model file using spec-compliant preferred folders and cached recursive fallback lookups.
 static std::string FindModelFile(const std::string& baseDir,
                                  const std::string& fileName)
 {
-    const fs::path modelsDir = fs::u8path(baseDir) / "models";
+    const fs::path modelsDir = MakeUtf8Path(baseDir) / "models";
     if (!fs::exists(modelsDir))
         return {};
 
-    const fs::path requested = fs::u8path(fileName);
+    const fs::path requested = MakeUtf8Path(fileName);
     const std::string requestedName = requested.filename().string();
     const bool hasExtension = requested.has_extension();
 
@@ -1327,7 +1337,7 @@ static void ParseGeometry(tinyxml2::XMLElement* node,
                             bool loaded = false;
                             bool tried3ds = false;
                             bool triedGlb = false;
-                            const fs::path loadedPath = fs::u8path(path);
+                            const fs::path loadedPath = MakeUtf8Path(path);
                             std::string fallbackGlbPath;
 
                             if (HasExtension(loadedPath, ".3ds")) {
@@ -1336,7 +1346,7 @@ static void ParseGeometry(tinyxml2::XMLElement* node,
                                 loaded = Load3DS(path, mesh, false, &loadError3ds);
                                 if (!loaded) {
                                     fallbackGlbPath = FindModelFile(baseDir, loadedPath.stem().string());
-                                    if (!fallbackGlbPath.empty() && HasExtension(fs::u8path(fallbackGlbPath), ".glb")) {
+                                    if (!fallbackGlbPath.empty() && HasExtension(MakeUtf8Path(fallbackGlbPath), ".glb")) {
                                         triedGlb = true;
                                         std::string loadErrorGlbFallback;
                                         loaded = LoadGLB(fallbackGlbPath, mesh, &loadErrorGlbFallback);


### PR DESCRIPTION
### Motivation
- Xcode 16.4 / libc++ marks `std::filesystem::u8path` deprecated on macOS which caused a build failure when constructing filesystem paths in the GDTF loader.
- The intent is to restore macOS installer/build compatibility while keeping behavior unchanged on other platforms.
- Keep the change small and localized to GDTF filesystem path construction to avoid affecting other OS builds or logic.

### Description
- Added a small helper `MakeUtf8Path(const std::string&)` that uses `fs::path(text)` on macOS and `fs::u8path(text)` elsewhere to avoid the libc++ deprecation on Darwin.
- Replaced direct `fs::u8path(...)` calls in `FindModelFile`, model lookup, and GLB fallback checks with `MakeUtf8Path(...)` so path checks and extension tests remain correct across platforms.
- Added a concise release-note entry in `docs/release-notes-draft.md` documenting the macOS installer build compatibility fix.

### Testing
- Ran `git diff --check` and it succeeded with no whitespace or patch issues.
- Ran `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh` and both passed.
- Attempted `cmake --preset wsl-x64-release` for a configure smoke-check but configure failed due to the container lacking `wxWidgets` (expected environment limitation), not due to the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d85e9d7d083248ba71bc825f91b3b)