### PR TITLE
Fix macOS build: remove deprecated std::filesystem::u8path and pin macOS runner

### DIFF
--- a/.github/workflows/macos-installer.yml
+++ b/.github/workflows/macos-installer.yml
@@ -23,7 +23,8 @@ on:
 
 jobs:
   build-macos-installer:
-    runs-on: macos-latest
+    # Use an explicit current-generation macOS runner to avoid unplanned macos-latest migrations.
+    runs-on: macos-26
 
     env:
       # Single source of truth for all vcpkg paths used across steps.
@@ -40,13 +41,23 @@ jobs:
         with:
           ref: ${{ inputs.source_ref != '' && inputs.source_ref || github.ref }}
 
-      # ── 2. Install macOS build tools ────────────────────────────────────────
+      # ── 2. Record macOS toolchain diagnostics ───────────────────────────────
+      - name: Record macOS toolchain diagnostics
+        run: |
+          sw_vers
+          uname -m
+          xcodebuild -version
+          clang++ --version
+          cmake --version
+          ninja --version || true
+
+      # ── 3. Install macOS build tools ────────────────────────────────────────
       - name: Install macOS build tools
         run: |
           brew update
           brew install autoconf autoconf-archive automake libtool ninja dylibbundler
 
-      # ── 3. Cache vcpkg installed tree + downloads ───────────────────────────
+      # ── 4. Cache vcpkg installed tree + downloads ───────────────────────────
       - name: Cache vcpkg
         uses: actions/cache@v4
         id: vcpkg-cache
@@ -55,12 +66,12 @@ jobs:
             .vcpkg-cache/downloads
             .vcpkg-cache/installed
             .vcpkg-cache/packages
-          key: ${{ runner.os }}-vcpkg-arm64-osx-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', '.github/workflows/macos-installer.yml') }}
+          key: ${{ runner.os }}-macos-26-vcpkg-arm64-osx-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', '.github/workflows/macos-installer.yml') }}
           restore-keys: |
-            ${{ runner.os }}-vcpkg-arm64-osx-
+            ${{ runner.os }}-macos-26-vcpkg-arm64-osx-
             ${{ runner.os }}-vcpkg-
 
-      # ── 4. Prepare vcpkg cache folders ──────────────────────────────────────
+      # ── 5. Prepare vcpkg cache folders ──────────────────────────────────────
       # These folders must exist before bootstrap because VCPKG_DOWNLOADS is
       # already visible to vcpkg during bootstrap.
       - name: Prepare vcpkg folders
@@ -69,7 +80,7 @@ jobs:
           mkdir -p "$VCPKG_INSTALLED"
           mkdir -p "$VCPKG_PACKAGES"
 
-      # ── 5. Bootstrap vcpkg ──────────────────────────────────────────────────
+      # ── 6. Bootstrap vcpkg ──────────────────────────────────────────────────
       - name: Bootstrap vcpkg
         run: |
           if [ -d "$VCPKG_ROOT/.git" ]; then
@@ -83,7 +94,7 @@ jobs:
 
           "$VCPKG_ROOT/bootstrap-vcpkg.sh" -disableMetrics
 
-      # ── 6. Install vcpkg packages ───────────────────────────────────────────
+      # ── 7. Install vcpkg packages ───────────────────────────────────────────
       - name: Install vcpkg packages
         run: |
           "$VCPKG_ROOT/vcpkg" install \
@@ -100,7 +111,7 @@ jobs:
             --x-packages-root="$VCPKG_PACKAGES" \
             --downloads-root="$VCPKG_DOWNLOADS"
 
-      # ── 7. Configure CMake ──────────────────────────────────────────────────
+      # ── 8. Configure CMake ──────────────────────────────────────────────────
       - name: Configure CMake
         run: |
           cmake -S . -B build \
@@ -110,12 +121,12 @@ jobs:
             -DVCPKG_TARGET_TRIPLET="$VCPKG_TRIPLET" \
             -DVCPKG_INSTALLED_DIR="$VCPKG_INSTALLED"
 
-      # ── 8. Build project ────────────────────────────────────────────────────
+      # ── 9. Build project ────────────────────────────────────────────────────
       - name: Build project
         run: |
           cmake --build build --config Release --parallel 2 --verbose
 
-      # ── 9. Stage distribution folder ────────────────────────────────────────
+      # ── 10. Stage distribution folder ────────────────────────────────────────
       - name: Stage distribution folder
         run: |
           cmake --build build --config Release --target perastage_stage
@@ -147,7 +158,7 @@ jobs:
           name: Perastage-macos-symbols
           path: out/Perastage-*-macOS-symbols.zip
 
-      # ── 10. Validate and prepare staged macOS app bundle ─────────────────────
+      # ── 11. Validate and prepare staged macOS app bundle ─────────────────────
       - name: Validate staged app bundle
         run: |
           test -d out/install/Release/Perastage.app
@@ -180,8 +191,8 @@ jobs:
             -x "$BIN_PATH" \
             -d "$FRAMEWORKS_PATH" \
             -p "@executable_path/../Frameworks/" \
-            -s "$VCPKG_INSTALLED/lib" \
-            -s "$VCPKG_INSTALLED/tools"
+            -s "$VCPKG_INSTALLED/$VCPKG_TRIPLET/lib" \
+            -s "$VCPKG_INSTALLED/$VCPKG_TRIPLET/tools"
 
           # Sign nested dynamic libraries and helper binaries before signing the bundle.
           while IFS= read -r file_path; do
@@ -217,14 +228,14 @@ jobs:
           done < <(otool -L "$BIN_PATH" | tail -n +2)
           test "$MISSING_DEPS" -eq 0
 
-      # ── 11. Upload staged build ─────────────────────────────────────────────
+      # ── 12. Upload staged build ─────────────────────────────────────────────
       - name: Upload staged distribution
         uses: actions/upload-artifact@v4
         with:
           name: Perastage-macos-staged
           path: out/install/Release
 
-      # ── 12. Build DMG package ───────────────────────────────────────────────
+      # ── 13. Build DMG package ───────────────────────────────────────────────
       - name: Build macOS DMG
         run: |
           APP_PATH="out/install/Release/Perastage.app"
@@ -247,7 +258,7 @@ jobs:
           rm -rf "$DMG_ROOT"
           find out/installer -name "*.dmg" -print
 
-      # ── 13. Validate generated DMG ───────────────────────────────────────────
+      # ── 14. Validate generated DMG ───────────────────────────────────────────
       - name: Validate generated DMG
         run: |
           DMG_FILE="$(find out/installer -name "*.dmg" -print -quit)"
@@ -273,7 +284,7 @@ jobs:
           plutil -lint "$MOUNT_DIR/Perastage.app/Contents/Info.plist"
           codesign --verify --deep --verbose=2 "$MOUNT_DIR/Perastage.app"
 
-      # ── 14. Collect DMG package ─────────────────────────────────────────────
+      # ── 15. Collect DMG package ─────────────────────────────────────────────
       - name: Collect macOS DMG
         run: |
           mkdir -p out/installer
@@ -286,7 +297,7 @@ jobs:
           xattr -c "$dmg_file" || true
           find out/installer -maxdepth 2 -name "*.dmg" -print
 
-      # ── 15. Upload DMG package ──────────────────────────────────────────────
+      # ── 16. Upload DMG package ──────────────────────────────────────────────
       - name: Upload macOS DMG
         uses: actions/upload-artifact@v4
         with:

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/dictionary_bundle.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dummyprofilelibrary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/file_import_utils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/filesystem_path_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtfdictionary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf_fixture_category.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gdtf_catalog_service.cpp

--- a/core/apppaths.cpp
+++ b/core/apppaths.cpp
@@ -1,4 +1,5 @@
 #include "apppaths.h"
+#include "filesystem_path_utils.h"
 
 #include <cstdlib>
 #include <system_error>
@@ -11,7 +12,7 @@ namespace {
 std::filesystem::path WxStringToPath(const wxString &value) {
   const wxScopedCharBuffer utf8 = value.ToUTF8();
   if (utf8)
-    return std::filesystem::u8path(std::string(utf8.data(), utf8.length()));
+    return PathUtils::PathFromUtf8(std::string(utf8.data(), utf8.length()));
   return std::filesystem::path(value.ToStdString());
 }
 
@@ -20,7 +21,7 @@ std::filesystem::path ResolvePreferredUserDataDir() {
 #ifdef _WIN32
   if (const char *localAppData = std::getenv("LOCALAPPDATA")) {
     if (*localAppData)
-      return std::filesystem::u8path(localAppData) / "Perastage";
+      return PathUtils::PathFromUtf8(localAppData) / "Perastage";
   }
 #endif
   const wxString userDataDir = wxStandardPaths::Get().GetUserDataDir();

--- a/core/configservices.cpp
+++ b/core/configservices.cpp
@@ -1,4 +1,5 @@
 #include "configservices.h"
+#include "filesystem_path_utils.h"
 #include "apppaths.h"
 
 #include "json.hpp"
@@ -30,10 +31,11 @@ std::string Utf8StringFromPath(const fs::path &path) {
   return std::string(utf8.begin(), utf8.end());
 }
 
+// Creates a filesystem path from UTF-8 configuration text.
 fs::path PathFromUtf8(const std::string &path) {
   if (path.empty())
     return {};
-  return fs::u8path(path);
+  return PathUtils::PathFromUtf8(path);
 }
 
 wxString WxStringFromPath(const fs::path &path) {

--- a/core/diagnostics/DiagnosticLogger.cpp
+++ b/core/diagnostics/DiagnosticLogger.cpp
@@ -1,4 +1,5 @@
 #include "diagnostics/DiagnosticLogger.h"
+#include "filesystem_path_utils.h"
 
 #include "diagnostics/DiagnosticPaths.h"
 #include "logger.h"
@@ -8,14 +9,6 @@
 namespace diagnostics {
 namespace {
 
-// Converts UTF-8 text into a filesystem path without deprecated helpers.
-std::filesystem::path PathFromUtf8(const std::string &text) {
-  std::u8string u8Text;
-  u8Text.reserve(text.size());
-  for (const char ch : text)
-    u8Text.push_back(static_cast<char8_t>(static_cast<unsigned char>(ch)));
-  return std::filesystem::path(u8Text);
-}
 
 } // namespace
 
@@ -64,7 +57,7 @@ std::filesystem::path DiagnosticLogger::CurrentLogFile() {
 std::string DiagnosticLogger::FileNameOnly(const std::string &pathText) {
   if (pathText.empty())
     return {};
-  std::filesystem::path path = PathFromUtf8(pathText);
+  std::filesystem::path path = PathUtils::PathFromUtf8(pathText);
   const std::u8string filenameU8 = path.filename().u8string();
   std::string filename(filenameU8.begin(), filenameU8.end());
   if (!filename.empty())

--- a/core/diagnostics/DiagnosticPaths.cpp
+++ b/core/diagnostics/DiagnosticPaths.cpp
@@ -1,4 +1,5 @@
 #include "diagnostics/DiagnosticPaths.h"
+#include "filesystem_path_utils.h"
 
 #include <chrono>
 #include <cstdlib>
@@ -31,31 +32,23 @@ std::string TimestampForFilename() {
   return stream.str();
 }
 
-// Converts UTF-8 text into a filesystem path without deprecated helpers.
-std::filesystem::path PathFromUtf8(const std::string &text) {
-  std::u8string u8Text;
-  u8Text.reserve(text.size());
-  for (const char ch : text)
-    u8Text.push_back(static_cast<char8_t>(static_cast<unsigned char>(ch)));
-  return std::filesystem::path(u8Text);
-}
 
 // Returns a home directory path from environment or platform user data.
 std::filesystem::path HomeDirectory() {
 #if defined(_WIN32)
   if (const char *userProfile = std::getenv("USERPROFILE")) {
     if (*userProfile)
-      return PathFromUtf8(userProfile);
+      return PathUtils::PathFromUtf8(userProfile);
   }
 #else
   if (const char *home = std::getenv("HOME")) {
     if (*home)
-      return PathFromUtf8(home);
+      return PathUtils::PathFromUtf8(home);
   }
 #ifdef __APPLE__
   if (const passwd *pw = getpwuid(getuid())) {
     if (pw->pw_dir && *pw->pw_dir)
-      return PathFromUtf8(pw->pw_dir);
+      return PathUtils::PathFromUtf8(pw->pw_dir);
   }
 #endif
 #endif
@@ -67,7 +60,7 @@ std::filesystem::path DiagnosticsBaseDirectory() {
 #if defined(_WIN32)
   if (const char *localAppData = std::getenv("LOCALAPPDATA")) {
     if (*localAppData)
-      return PathFromUtf8(localAppData) / "Perastage";
+      return PathUtils::PathFromUtf8(localAppData) / "Perastage";
   }
   return HomeDirectory() / "AppData" / "Local" / "Perastage";
 #elif defined(__APPLE__)
@@ -75,7 +68,7 @@ std::filesystem::path DiagnosticsBaseDirectory() {
 #else
   if (const char *xdgStateHome = std::getenv("XDG_STATE_HOME")) {
     if (*xdgStateHome)
-      return PathFromUtf8(xdgStateHome) / "perastage";
+      return PathUtils::PathFromUtf8(xdgStateHome) / "perastage";
   }
   return HomeDirectory() / ".local" / "state" / "perastage";
 #endif

--- a/core/dictionary_bundle.cpp
+++ b/core/dictionary_bundle.cpp
@@ -1,4 +1,5 @@
 #include "dictionary_bundle.h"
+#include "filesystem_path_utils.h"
 
 #include "dictionary_json_contract.h"
 #include "json.hpp"
@@ -174,7 +175,7 @@ nlohmann::json BuildFixturesEntriesJson(
 
     nlohmann::json outputEntry = nlohmann::json::object();
     if (!entry.path.empty()) {
-      const fs::path sourcePath = fs::u8path(entry.path);
+      const fs::path sourcePath = PathUtils::PathFromUtf8(entry.path);
       if (!fs::exists(sourcePath)) {
         error = "Missing fixture asset for entry '" + name + "': " + entry.path;
         return {};
@@ -235,7 +236,7 @@ nlohmann::json BuildTrussEntriesJson(
     if (source.empty())
       continue;
 
-    const fs::path sourcePath = fs::u8path(source);
+    const fs::path sourcePath = PathUtils::PathFromUtf8(source);
     if (!fs::exists(sourcePath)) {
       error = "Missing truss asset for entry '" + name + "': " + source;
       return {};
@@ -327,7 +328,7 @@ bool ExtractArchive(const fs::path &zipPath, const fs::path &destination,
     if (entry->IsDir())
       continue;
 
-    const fs::path outPath = destination / fs::u8path(entry->GetName().ToStdString());
+    const fs::path outPath = destination / PathUtils::PathFromUtf8(entry->GetName().ToStdString());
     std::error_code ec;
     fs::create_directories(outPath.parent_path(), ec);
 
@@ -409,7 +410,7 @@ bool ExportFixturesBundle(
   if (!error.empty())
     return false;
 
-  return WriteBundle(fs::u8path(outputZipPath), "fixtures", entries, assets, error);
+  return WriteBundle(PathUtils::PathFromUtf8(outputZipPath), "fixtures", entries, assets, error);
 }
 
 bool ExportTrussesBundle(
@@ -420,13 +421,13 @@ bool ExportTrussesBundle(
   if (!error.empty())
     return false;
 
-  return WriteBundle(fs::u8path(outputZipPath), "trusses", entries, assets, error);
+  return WriteBundle(PathUtils::PathFromUtf8(outputZipPath), "trusses", entries, assets, error);
 }
 
 PreparedImport PrepareBundleImport(const std::string &importPath, Type expectedType) {
   PreparedImport result;
 
-  const fs::path path = fs::u8path(importPath);
+  const fs::path path = PathUtils::PathFromUtf8(importPath);
   if (!fs::exists(path))
     return result;
 
@@ -497,7 +498,7 @@ PreparedImport PrepareBundleImport(const std::string &importPath, Type expectedT
     return result;
   }
 
-  const fs::path libraryDir = fs::u8path(ProjectUtils::GetWritableLibraryPath(expectedTypeText));
+  const fs::path libraryDir = PathUtils::PathFromUtf8(ProjectUtils::GetWritableLibraryPath(expectedTypeText));
   std::error_code ec;
   fs::create_directories(libraryDir, ec);
 
@@ -514,7 +515,7 @@ PreparedImport PrepareBundleImport(const std::string &importPath, Type expectedT
 
     const std::string archivePath = assetJson["path"].get<std::string>();
     const std::string expectedChecksum = assetJson["checksum"].get<std::string>();
-    const fs::path extractedPath = stagingDir / fs::u8path(archivePath);
+    const fs::path extractedPath = stagingDir / PathUtils::PathFromUtf8(archivePath);
     if (!fs::exists(extractedPath)) {
       result.errors.push_back("Bundle asset not found: " + archivePath);
       continue;

--- a/core/dummyprofilelibrary.cpp
+++ b/core/dummyprofilelibrary.cpp
@@ -1,4 +1,5 @@
 #include "dummyprofilelibrary.h"
+#include "filesystem_path_utils.h"
 
 #include "json.hpp"
 #include "projectutils.h"
@@ -33,7 +34,7 @@ std::vector<DummyHoistProfile> LoadProfiles() {
   if (baseDir.empty())
     return profiles;
 
-  const fs::path filePath = fs::u8path(baseDir) / "dummy_profiles.json";
+  const fs::path filePath = PathUtils::PathFromUtf8(baseDir) / "dummy_profiles.json";
   if (!fs::exists(filePath))
     return profiles;
 

--- a/core/filesystem_path_utils.cpp
+++ b/core/filesystem_path_utils.cpp
@@ -1,0 +1,66 @@
+#include "filesystem_path_utils.h"
+
+#include <stdexcept>
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#endif
+
+namespace PathUtils {
+
+// Creates a filesystem path from UTF-8 text using the native platform encoding.
+std::filesystem::path PathFromUtf8(const std::string &text) {
+  if (text.empty())
+    return {};
+
+#ifdef _WIN32
+  const int size = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS,
+                                       text.data(),
+                                       static_cast<int>(text.size()), nullptr, 0);
+  if (size <= 0)
+    throw std::runtime_error("Failed to convert UTF-8 path to a Windows path");
+
+  std::wstring wide(static_cast<std::size_t>(size), L'\0');
+  const int converted = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS,
+                                            text.data(),
+                                            static_cast<int>(text.size()),
+                                            wide.data(), size);
+  if (converted != size)
+    throw std::runtime_error("Failed to convert UTF-8 path to a Windows path");
+  return std::filesystem::path(wide);
+#else
+  return std::filesystem::path(text);
+#endif
+}
+
+// Converts a filesystem path to UTF-8 text for storage and cross-platform APIs.
+std::string PathToUtf8(const std::filesystem::path &path) {
+#ifdef _WIN32
+  const std::wstring wide = path.wstring();
+  if (wide.empty())
+    return {};
+
+  const int size = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS,
+                                       wide.data(),
+                                       static_cast<int>(wide.size()), nullptr, 0,
+                                       nullptr, nullptr);
+  if (size <= 0)
+    throw std::runtime_error("Failed to convert Windows path to UTF-8");
+
+  std::string text(static_cast<std::size_t>(size), '\0');
+  const int converted = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS,
+                                            wide.data(),
+                                            static_cast<int>(wide.size()),
+                                            text.data(), size, nullptr, nullptr);
+  if (converted != size)
+    throw std::runtime_error("Failed to convert Windows path to UTF-8");
+  return text;
+#else
+  return path.string();
+#endif
+}
+
+} // namespace PathUtils

--- a/core/filesystem_path_utils.h
+++ b/core/filesystem_path_utils.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+namespace PathUtils {
+
+std::filesystem::path PathFromUtf8(const std::string &text);
+std::string PathToUtf8(const std::filesystem::path &path);
+
+} // namespace PathUtils

--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "gdtfdictionary.h"
+#include "filesystem_path_utils.h"
 #include "configmanager.h"
 #include "dictionary_json_contract.h"
 #include "file_import_utils.h"
@@ -67,7 +68,7 @@ fs::path ResolveConfiguredDictionaryPath(const fs::path &defaultPath,
   if (trimmedPath.empty())
     return defaultPath;
 
-  fs::path configuredPath = fs::u8path(trimmedPath);
+  fs::path configuredPath = PathUtils::PathFromUtf8(trimmedPath);
   if (configuredPath.is_relative()) {
     configuredPath = defaultPath.parent_path() / configuredPath;
   }
@@ -108,8 +109,8 @@ bool PathsMatchForDictionaryEntries(const std::string &lhs,
                                     const std::string &rhs) {
   if (lhs.empty() || rhs.empty())
     return false;
-  const fs::path leftPath = fs::u8path(lhs).lexically_normal();
-  const fs::path rightPath = fs::u8path(rhs).lexically_normal();
+  const fs::path leftPath = PathUtils::PathFromUtf8(lhs).lexically_normal();
+  const fs::path rightPath = PathUtils::PathFromUtf8(rhs).lexically_normal();
   if (leftPath == rightPath)
     return true;
 
@@ -121,8 +122,8 @@ bool PathsMatchForDictionaryEntries(const std::string &lhs,
 bool PathsShareFileName(const std::string &lhs, const std::string &rhs) {
   if (lhs.empty() || rhs.empty())
     return false;
-  const fs::path leftPath = fs::u8path(lhs);
-  const fs::path rightPath = fs::u8path(rhs);
+  const fs::path leftPath = PathUtils::PathFromUtf8(lhs);
+  const fs::path rightPath = PathUtils::PathFromUtf8(rhs);
   if (leftPath.filename().empty() || rightPath.filename().empty())
     return false;
   return leftPath.filename() == rightPath.filename();
@@ -224,7 +225,7 @@ bool IsDummy1ChFallbackType(const std::string &type) {
 bool IsDummy1ChFallbackPath(const std::string &gdtfPath) {
   if (gdtfPath.empty())
     return false;
-  const std::string fileName = fs::u8path(gdtfPath).filename().string();
+  const std::string fileName = PathUtils::PathFromUtf8(gdtfPath).filename().string();
   return NormalizeAsciiKey(fileName) == "dummy1ch.gdtf";
 }
 
@@ -372,7 +373,7 @@ bool ApplyCategoryUpdateForFile(
 }
 
 fs::path GetUserDictFile() {
-  fs::path dir = fs::u8path(ProjectUtils::GetWritableLibraryPath("fixtures"));
+  fs::path dir = PathUtils::PathFromUtf8(ProjectUtils::GetWritableLibraryPath("fixtures"));
   if (dir.empty())
     return {};
   std::error_code ec;
@@ -435,7 +436,7 @@ bool MergeSeedEntriesIntoUserDictionary(
 
 fs::path ResolveImportedPath(const fs::path &jsonFile,
                              const std::string &rawPathText) {
-  const fs::path parsedPath = fs::u8path(rawPathText);
+  const fs::path parsedPath = PathUtils::PathFromUtf8(rawPathText);
   if (parsedPath.is_absolute())
     return parsedPath;
 
@@ -490,7 +491,7 @@ LoadFromFile(const fs::path &file, std::string &error) {
     if (value.is_string()) {
       const std::string rawPath = value.get<std::string>();
       fs::path p = ResolveImportedPath(file, rawPath);
-      if (!fs::u8path(rawPath).is_absolute() && !fs::exists(p)) {
+      if (!PathUtils::PathFromUtf8(rawPath).is_absolute() && !fs::exists(p)) {
         std::cerr << "Warning: fixtures dictionary entry '" << entryKey
                   << "' references missing relative path '" << rawPath
                   << "' resolved from '" << file.string() << "'." << std::endl;
@@ -512,7 +513,7 @@ LoadFromFile(const fs::path &file, std::string &error) {
 
     if (!fname.empty()) {
       fs::path p = ResolveImportedPath(file, fname);
-      if (!fs::u8path(fname).is_absolute() && !fs::exists(p)) {
+      if (!PathUtils::PathFromUtf8(fname).is_absolute() && !fs::exists(p)) {
         std::cerr << "Warning: fixtures dictionary entry '" << entryKey
                   << "' references missing relative path '" << fname
                   << "' resolved from '" << file.string() << "'." << std::endl;
@@ -596,7 +597,7 @@ DictionaryImportSummary MergeDictionaryEntries(
     if (value.path.empty())
       continue;
     std::error_code ec;
-    if (fs::exists(fs::u8path(value.path), ec))
+    if (fs::exists(PathUtils::PathFromUtf8(value.path), ec))
       continue;
     ++summary.missing_files_count;
     if (summary.missing_file_examples.size() < kMaxMissingExamples)
@@ -796,7 +797,7 @@ bool Save(const std::unordered_map<std::string, Entry> &dict,
       continue;
     nlohmann::json obj;
     if (!entry.path.empty()) {
-      fs::path p = fs::u8path(entry.path);
+      fs::path p = PathUtils::PathFromUtf8(entry.path);
       const std::string fileName = p.filename().string();
       if (!fileName.empty())
         obj["file"] = fileName;
@@ -904,7 +905,7 @@ void Update(const std::string &type, const std::string &gdtfPath, const std::str
     return;
   if (IsDummy1ChFallbackType(normalizedType) || IsDummy1ChFallbackPath(gdtfPath))
     return;
-  const fs::path src = fs::u8path(gdtfPath);
+  const fs::path src = PathUtils::PathFromUtf8(gdtfPath);
   if (!fs::exists(src))
     return;
   const fs::path file = GetConfiguredUserDictFile();
@@ -1051,7 +1052,7 @@ DictionaryImportSummary PreviewImportFromFile(const std::string &filePath,
   DictionaryImportSummary summary;
 
   std::string importError;
-  const fs::path importPath = fs::u8path(filePath);
+  const fs::path importPath = PathUtils::PathFromUtf8(filePath);
   auto importedOpt = LoadFromFile(importPath, importError);
   if (!importedOpt) {
     summary.errors.push_back("Failed to load import file: " + importError);
@@ -1074,7 +1075,7 @@ DictionaryImportSummary ApplyImportFromFile(const std::string &filePath,
   DictionaryImportSummary summary;
 
   std::string importError;
-  const fs::path importPath = fs::u8path(filePath);
+  const fs::path importPath = PathUtils::PathFromUtf8(filePath);
   auto importedOpt = LoadFromFile(importPath, importError);
   if (!importedOpt) {
     summary.errors.push_back("Failed to load import file: " + importError);

--- a/core/hoistpresetlibrary.cpp
+++ b/core/hoistpresetlibrary.cpp
@@ -1,4 +1,5 @@
 #include "hoistpresetlibrary.h"
+#include "filesystem_path_utils.h"
 
 #include "projectutils.h"
 #include "support.h"
@@ -33,7 +34,7 @@ std::vector<HoistPreset> LoadPresets() {
   if (baseDir.empty())
     return presets;
 
-  const fs::path filePath = fs::u8path(baseDir) / "hoist_presets.json";
+  const fs::path filePath = PathUtils::PathFromUtf8(baseDir) / "hoist_presets.json";
   if (!fs::exists(filePath))
     return presets;
 

--- a/core/layouts/LayoutDefaultsLoader.cpp
+++ b/core/layouts/LayoutDefaultsLoader.cpp
@@ -1,4 +1,5 @@
 #include "LayoutDefaultsLoader.h"
+#include "filesystem_path_utils.h"
 
 #include "LayoutTemplateSerializer.h"
 #include "json.hpp"
@@ -44,7 +45,7 @@ std::string ResolveImagePath(const std::string &rawPath,
   if (rawPath.empty())
     return rawPath;
 
-  fs::path parsedPath = fs::u8path(rawPath);
+  fs::path parsedPath = PathUtils::PathFromUtf8(rawPath);
   std::error_code ec;
   if (parsedPath.is_absolute()) {
     fs::path absolutePath = fs::absolute(parsedPath, ec);
@@ -77,7 +78,7 @@ std::string ResolveImagePath(const std::string &rawPath,
 
     const std::string strippedPath = StripResourcesPrefix(rawPath);
     if (strippedPath != rawPath) {
-      const fs::path strippedCandidate = resourceRoot / fs::u8path(strippedPath);
+      const fs::path strippedCandidate = resourceRoot / PathUtils::PathFromUtf8(strippedPath);
       if (std::string resolved = asAbsoluteIfExists(strippedCandidate);
           !resolved.empty()) {
         return resolved;
@@ -108,7 +109,7 @@ LayoutDefaultsLoadResult LoadLayoutDefaultsFromLibrary(
     return result;
 
   std::error_code ec;
-  const fs::path defaultsDir = fs::u8path(defaultsDirUtf8);
+  const fs::path defaultsDir = PathUtils::PathFromUtf8(defaultsDirUtf8);
   if (!fs::exists(defaultsDir, ec) || ec || !fs::is_directory(defaultsDir, ec) ||
       ec) {
     return result;

--- a/core/layouts/LayoutImageResourceRegistry.cpp
+++ b/core/layouts/LayoutImageResourceRegistry.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "LayoutImageResourceRegistry.h"
+#include "filesystem_path_utils.h"
 
 #include <algorithm>
 #include <filesystem>
@@ -37,7 +38,7 @@ std::string Utf8StringFromPath(const fs::path &path) {
 
 // Reads the complete image file into memory so projects do not depend on the source file later.
 bool ReadFileBytes(const std::string &path, std::vector<std::uint8_t> &out) {
-  std::ifstream in(fs::u8path(path), std::ios::binary);
+  std::ifstream in(PathUtils::PathFromUtf8(path), std::ios::binary);
   if (!in.is_open())
     return false;
   out.assign(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
@@ -46,7 +47,7 @@ bool ReadFileBytes(const std::string &path, std::vector<std::uint8_t> &out) {
 
 // Returns a lowercase extension while preserving common image format hints.
 std::string NormalizedExtension(const std::string &path) {
-  std::string ext = fs::u8path(path).extension().string();
+  std::string ext = PathUtils::PathFromUtf8(path).extension().string();
   std::transform(ext.begin(), ext.end(), ext.begin(), [](unsigned char ch) {
     return static_cast<char>(std::tolower(ch));
   });

--- a/core/projectutils.cpp
+++ b/core/projectutils.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "projectutils.h"
+#include "filesystem_path_utils.h"
 #include "apppaths.h"
 #include "library/library_bootstrap.h"
 #include "logger.h"
@@ -45,7 +46,7 @@ fs::path WxStringToPath(const wxString& value)
 {
     const wxScopedCharBuffer utf8 = value.ToUTF8();
     if (utf8)
-        return fs::u8path(std::string(utf8.data(), utf8.length()));
+        return PathUtils::PathFromUtf8(std::string(utf8.data(), utf8.length()));
 
     return fs::path(value.ToStdString());
 }
@@ -251,7 +252,7 @@ bool SaveLastProjectPath(const std::string& path)
         return true;
     }
     std::error_code ec;
-    fs::path resolved = fs::absolute(fs::u8path(path), ec);
+    fs::path resolved = fs::absolute(PathUtils::PathFromUtf8(path), ec);
     if (ec)
         out << path;
     else
@@ -273,7 +274,7 @@ std::optional<std::string> LoadLastProjectPath()
         return std::nullopt;
     fs::path candidate;
     try {
-        candidate = fs::u8path(rawPath);
+        candidate = PathUtils::PathFromUtf8(rawPath);
     } catch (...) {
         return std::nullopt;
     }
@@ -312,7 +313,7 @@ std::string GetWritableLibraryPath(const std::string& subdir)
 {
     if (const char* envPath = std::getenv("PERASTAGE_LIBRARY_PATH")) {
         if (*envPath != '\0') {
-            fs::path envRoot = fs::u8path(envPath);
+            fs::path envRoot = PathUtils::PathFromUtf8(envPath);
             std::error_code ec;
             const bool envRootExists = fs::exists(envRoot, ec);
             const bool envRootIsDir = !ec && fs::is_directory(envRoot, ec);
@@ -345,7 +346,7 @@ std::string GetWritableLibraryPath(const std::string& subdir)
 std::string GetDefaultLibraryPath(const std::string& subdir)
 {
     if (std::string installedPath = GetInstalledLibraryPath(subdir); !installedPath.empty()) {
-        const fs::path installed = fs::u8path(installedPath);
+        const fs::path installed = PathUtils::PathFromUtf8(installedPath);
         if (IsDirectoryWritable(installed))
             return installedPath;
     }

--- a/core/riderimporter.cpp
+++ b/core/riderimporter.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "riderimporter.h"
+#include "filesystem_path_utils.h"
 
 #include <algorithm>
 #include <array>
@@ -560,18 +561,18 @@ bool IsRenderableTrussGeometry(const std::string &path) {
 }
 
 std::filesystem::path ResolveTrussSymbolPath(const Truss &truss) {
-  std::filesystem::path symbolPath = std::filesystem::u8path(truss.symbolFile);
+  std::filesystem::path symbolPath = PathUtils::PathFromUtf8(truss.symbolFile);
   if (symbolPath.is_absolute())
     return symbolPath;
 
   if (!truss.modelFile.empty()) {
-    std::filesystem::path modelPath = std::filesystem::u8path(truss.modelFile);
+    std::filesystem::path modelPath = PathUtils::PathFromUtf8(truss.modelFile);
     if (modelPath.is_absolute())
       return modelPath.parent_path() / symbolPath;
   }
 
   if (!truss.gdtfSpec.empty()) {
-    std::filesystem::path gdtfPath = std::filesystem::u8path(truss.gdtfSpec);
+    std::filesystem::path gdtfPath = PathUtils::PathFromUtf8(truss.gdtfSpec);
     if (gdtfPath.is_absolute())
       return gdtfPath.parent_path() / symbolPath;
   }

--- a/core/truss_gdtf_builder.cpp
+++ b/core/truss_gdtf_builder.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "truss_gdtf_builder.h"
+#include "filesystem_path_utils.h"
 
 #include "json.hpp"
 #include "logger.h"
@@ -404,7 +405,7 @@ bool BuildTrussGdtfFromInstance(const Truss &truss, const fs::path &outGdtfPath,
   source.typeKey = truss.perastageTypeKey;
 
   auto pickGeometry = [&](const std::string &path) {
-    fs::path p = fs::u8path(path);
+    fs::path p = PathUtils::PathFromUtf8(path);
     std::string ext = p.extension().string();
     std::transform(ext.begin(), ext.end(), ext.begin(),
                    [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
@@ -423,7 +424,7 @@ bool BuildTrussGdtfFromInstance(const Truss &truss, const fs::path &outGdtfPath,
     pickGeometry(truss.modelFile);
 
   if (source.geometryPath.empty()) {
-    fs::path modelArchive = fs::u8path(truss.modelFile);
+    fs::path modelArchive = PathUtils::PathFromUtf8(truss.modelFile);
     std::string ext = modelArchive.extension().string();
     std::transform(ext.begin(), ext.end(), ext.begin(),
                    [](unsigned char c) { return static_cast<char>(std::tolower(c)); });

--- a/core/trussdictionary.cpp
+++ b/core/trussdictionary.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "trussdictionary.h"
+#include "filesystem_path_utils.h"
 
 #include "configmanager.h"
 #include "dictionary_json_contract.h"
@@ -86,7 +87,7 @@ static bool IsSupportedDictionaryFile(const fs::path &path) {
 }
 
 static fs::path GetUserDictFile() {
-  fs::path dir = fs::u8path(ProjectUtils::GetWritableLibraryPath("trusses"));
+  fs::path dir = PathUtils::PathFromUtf8(ProjectUtils::GetWritableLibraryPath("trusses"));
   if (dir.empty())
     return {};
   std::error_code ec;
@@ -105,7 +106,7 @@ static fs::path ResolveConfiguredDictionaryPath(
   if (trimmedPath.empty())
     return defaultPath;
 
-  fs::path configuredPath = fs::u8path(trimmedPath);
+  fs::path configuredPath = PathUtils::PathFromUtf8(trimmedPath);
   if (configuredPath.is_relative())
     configuredPath = defaultPath.parent_path() / configuredPath;
 
@@ -195,7 +196,7 @@ static bool MergeSeedEntriesIntoUserDictionary(
 
 static fs::path ResolveImportedPath(const fs::path &jsonFile,
                                     const std::string &rawPathText) {
-  const fs::path parsedPath = fs::u8path(rawPathText);
+  const fs::path parsedPath = PathUtils::PathFromUtf8(rawPathText);
   if (parsedPath.is_absolute())
     return parsedPath;
 
@@ -321,7 +322,7 @@ LoadFromFile(const fs::path &file, std::string &error) {
     }
 
     if (!fs::exists(path)) {
-      if (!fs::u8path(rawPath).is_absolute()) {
+      if (!PathUtils::PathFromUtf8(rawPath).is_absolute()) {
         std::cerr << "Warning: trusses dictionary " << sourceLabel
                   << " references missing relative path '" << rawPath
                   << "' resolved from '" << file.string() << "'."
@@ -382,7 +383,7 @@ DictionaryImportSummary MergeDictionaryEntries(
     if (value.empty())
       continue;
     std::error_code ec;
-    if (fs::exists(fs::u8path(value), ec))
+    if (fs::exists(PathUtils::PathFromUtf8(value), ec))
       continue;
     ++summary.missing_files_count;
     if (summary.missing_file_examples.size() < kMaxMissingExamples)
@@ -446,7 +447,7 @@ bool ImportTrussFile(const std::string &inputPath, std::string &storedPath,
                      std::string &error) {
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
   storedPath.clear();
-  fs::path src = fs::u8path(inputPath);
+  fs::path src = PathUtils::PathFromUtf8(inputPath);
   if (!fs::exists(src)) {
     error = "Truss file does not exist";
     return false;
@@ -634,7 +635,7 @@ bool Save(const std::unordered_map<std::string, std::string> &dict,
   std::sort(keys.begin(), keys.end());
 
   for (const auto &model : keys) {
-    fs::path p = fs::u8path(normalizedDict.at(model));
+    fs::path p = PathUtils::PathFromUtf8(normalizedDict.at(model));
     fs::path forced = p;
     if (forced.extension() != ".gdtf")
       forced.replace_extension(".gdtf");
@@ -687,7 +688,7 @@ std::optional<std::string> Get(const std::string &model) {
   if (it == dict.end())
     return std::nullopt;
 
-  if (!fs::exists(fs::u8path(it->second))) {
+  if (!fs::exists(PathUtils::PathFromUtf8(it->second))) {
     dict.erase(it);
     Save(dict);
     return std::nullopt;
@@ -722,7 +723,7 @@ DictionaryImportSummary PreviewImportFromFile(const std::string &filePath,
   DictionaryImportSummary summary;
 
   std::string importError;
-  const fs::path importPath = fs::u8path(filePath);
+  const fs::path importPath = PathUtils::PathFromUtf8(filePath);
   auto importedOpt = LoadFromFile(importPath, importError);
   if (!importedOpt) {
     summary.errors.push_back("Failed to load import file: " + importError);
@@ -745,7 +746,7 @@ DictionaryImportSummary ApplyImportFromFile(const std::string &filePath,
   DictionaryImportSummary summary;
 
   std::string importError;
-  const fs::path importPath = fs::u8path(filePath);
+  const fs::path importPath = PathUtils::PathFromUtf8(filePath);
   auto importedOpt = LoadFromFile(importPath, importError);
   if (!importedOpt) {
     summary.errors.push_back("Failed to load import file: " + importError);

--- a/core/trussloader.cpp
+++ b/core/trussloader.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "trussloader.h"
+#include "filesystem_path_utils.h"
 
 #include "truss_gdtf_builder.h"
 #include "logger.h"
@@ -53,7 +54,7 @@ static fs::path FromUtf8String(const std::string &text) {
   const char8_t *begin = reinterpret_cast<const char8_t *>(text.data());
   return fs::path(std::u8string(begin, begin + text.size()));
 #else
-  return fs::u8path(text);
+  return PathUtils::PathFromUtf8(text);
 #endif
 }
 

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -55,6 +55,7 @@ Changes since `v1.3.0`.
 
 ## Internal changes
 
+- Updated UTF-8 filesystem path handling across the codebase and pinned the macOS installer workflow to an explicit current-generation runner for more predictable CI builds.
 - Restored macOS installer build compatibility with Xcode 16.4 by avoiding deprecated filesystem path construction during GDTF model loading.
 - Improved installer build reliability by allowing the Windows packaging workflow to use the current Visual Studio generator when available, generating Windows Release symbol files for CI symbol archives, using a dynamic modern Windows installer wizard style, and keeping macOS command-bar float parsing portable across libc++ versions.
 - Improved GDTF loading efficiency by reusing cached archive content hashes when file metadata is unchanged, avoiding repeated full-file reads while preserving content-based cache invalidation.

--- a/gui/dictionaryeditdialog.cpp
+++ b/gui/dictionaryeditdialog.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "dictionaryeditdialog.h"
+#include "filesystem_path_utils.h"
 
 #include "columnutils.h"
 #include "colorfulrenderers.h"
@@ -98,8 +99,8 @@ bool FixturePathsMatchForColorFamily(const std::string &lhs,
                                      const std::string &rhs) {
   if (lhs.empty() || rhs.empty())
     return false;
-  const std::filesystem::path leftPath = std::filesystem::u8path(lhs).lexically_normal();
-  const std::filesystem::path rightPath = std::filesystem::u8path(rhs).lexically_normal();
+  const std::filesystem::path leftPath = PathUtils::PathFromUtf8(lhs).lexically_normal();
+  const std::filesystem::path rightPath = PathUtils::PathFromUtf8(rhs).lexically_normal();
   if (leftPath == rightPath)
     return true;
   if (!leftPath.filename().empty() && leftPath.filename() == rightPath.filename())
@@ -283,7 +284,7 @@ ExportPathStatusSummary AnalyzeFixtureExportPaths(
   constexpr size_t kMaxMissingExamples = 10;
   summary.total_entries = dict.size();
   for (const auto &[name, entry] : dict) {
-    if (HasExistingPath(std::filesystem::u8path(entry.path)))
+    if (HasExistingPath(PathUtils::PathFromUtf8(entry.path)))
       ++summary.found_entries;
     else {
       ++summary.missing_entries;
@@ -304,7 +305,7 @@ ExportPathStatusSummary AnalyzeTrussExportPaths(
   constexpr size_t kMaxMissingExamples = 10;
   summary.total_entries = dict.size();
   for (const auto &[name, path] : dict) {
-    if (HasExistingPath(std::filesystem::u8path(path)))
+    if (HasExistingPath(PathUtils::PathFromUtf8(path)))
       ++summary.found_entries;
     else {
       ++summary.missing_entries;
@@ -480,8 +481,8 @@ ImportPathValidationSummary ValidateFixtureImportPaths(const std::string &import
   if (!entriesOpt)
     return summary;
 
-  const std::filesystem::path importFilePath = std::filesystem::u8path(importPath);
-  const std::filesystem::path libraryDir = std::filesystem::u8path(
+  const std::filesystem::path importFilePath = PathUtils::PathFromUtf8(importPath);
+  const std::filesystem::path libraryDir = PathUtils::PathFromUtf8(
       ProjectUtils::GetWritableLibraryPath("fixtures"));
 
   auto checkEntry = [&](const std::string &entryName, const nlohmann::json &entryJson) {
@@ -496,7 +497,7 @@ ImportPathValidationSummary ValidateFixtureImportPaths(const std::string &import
       return;
 
     ++summary.checked_entries;
-    const std::filesystem::path sourcePath = std::filesystem::u8path(rawPath);
+    const std::filesystem::path sourcePath = PathUtils::PathFromUtf8(rawPath);
     const std::filesystem::path importRelativePath =
         ResolveImportRelativePath(importFilePath, sourcePath);
     const std::filesystem::path libraryRelativePath = libraryDir / sourcePath.filename();
@@ -539,9 +540,9 @@ ImportPathValidationSummary ValidateTrussImportPaths(const std::string &importPa
   if (!entriesOpt)
     return summary;
 
-  const std::filesystem::path importFilePath = std::filesystem::u8path(importPath);
+  const std::filesystem::path importFilePath = PathUtils::PathFromUtf8(importPath);
   const std::filesystem::path libraryDir =
-      std::filesystem::u8path(ProjectUtils::GetWritableLibraryPath("trusses"));
+      PathUtils::PathFromUtf8(ProjectUtils::GetWritableLibraryPath("trusses"));
 
   auto checkEntry = [&](const std::string &entryName, const nlohmann::json &entryJson) {
     if (!entryJson.is_object())
@@ -555,7 +556,7 @@ ImportPathValidationSummary ValidateTrussImportPaths(const std::string &importPa
       return;
 
     ++summary.checked_entries;
-    const std::filesystem::path sourcePath = std::filesystem::u8path(rawPath);
+    const std::filesystem::path sourcePath = PathUtils::PathFromUtf8(rawPath);
     const std::filesystem::path importRelativePath =
         ResolveImportRelativePath(importFilePath, sourcePath);
     const std::filesystem::path libraryRelativePath = libraryDir / sourcePath.filename();
@@ -638,12 +639,12 @@ CopyToLibrary(wxWindow *parent, const std::string &path, const char *libraryName
   if (path.empty())
     return std::nullopt;
 
-  const std::filesystem::path src = std::filesystem::u8path(path);
+  const std::filesystem::path src = PathUtils::PathFromUtf8(path);
   if (!std::filesystem::exists(src))
     return std::nullopt;
 
   const std::filesystem::path dir =
-      std::filesystem::u8path(ProjectUtils::GetWritableLibraryPath(libraryName));
+      PathUtils::PathFromUtf8(ProjectUtils::GetWritableLibraryPath(libraryName));
   if (dir.empty())
     return CopiedLibraryAsset{path, {}};
 
@@ -761,7 +762,7 @@ bool SaveFixturesSnapshotToFile(
     keys.push_back(name);
   std::sort(keys.begin(), keys.end());
 
-  const std::filesystem::path outputFsPath = std::filesystem::u8path(outputPath);
+  const std::filesystem::path outputFsPath = PathUtils::PathFromUtf8(outputPath);
   const std::filesystem::path targetAssetsDir = outputFsPath.parent_path();
   std::unordered_map<std::string, bool> useNewByFileName;
   if (copyReferencedAssets) {
@@ -771,7 +772,7 @@ bool SaveFixturesSnapshotToFile(
           paths.reserve(dict.size());
           for (const auto &[_, entry] : dict) {
             if (!entry.path.empty())
-              paths.push_back(std::filesystem::u8path(entry.path));
+              paths.push_back(PathUtils::PathFromUtf8(entry.path));
           }
           return paths;
         });
@@ -788,7 +789,7 @@ bool SaveFixturesSnapshotToFile(
       continue;
     nlohmann::json obj;
     if (!entry.path.empty()) {
-      const std::filesystem::path sourcePath = std::filesystem::u8path(entry.path);
+      const std::filesystem::path sourcePath = PathUtils::PathFromUtf8(entry.path);
       if (copyReferencedAssets) {
         const auto copiedRelativePath =
             CopySnapshotAsset(sourcePath, targetAssetsDir, useNewByFileName);
@@ -835,7 +836,7 @@ bool SaveTrussesSnapshotToFile(wxWindow *parent, const std::string &outputPath,
     keys.push_back(name);
   std::sort(keys.begin(), keys.end());
 
-  const std::filesystem::path outputFsPath = std::filesystem::u8path(outputPath);
+  const std::filesystem::path outputFsPath = PathUtils::PathFromUtf8(outputPath);
   const std::filesystem::path targetAssetsDir = outputFsPath.parent_path();
   std::unordered_map<std::string, bool> useNewByFileName;
   if (copyReferencedAssets) {
@@ -845,7 +846,7 @@ bool SaveTrussesSnapshotToFile(wxWindow *parent, const std::string &outputPath,
           paths.reserve(dict.size());
           for (const auto &[_, path] : dict) {
             if (!path.empty())
-              paths.push_back(std::filesystem::u8path(path));
+              paths.push_back(PathUtils::PathFromUtf8(path));
           }
           return paths;
         });
@@ -859,7 +860,7 @@ bool SaveTrussesSnapshotToFile(wxWindow *parent, const std::string &outputPath,
     const auto &path = dict.at(name);
     if (path.empty())
       continue;
-    const std::filesystem::path sourcePath = std::filesystem::u8path(path);
+    const std::filesystem::path sourcePath = PathUtils::PathFromUtf8(path);
     if (copyReferencedAssets) {
       const auto copiedRelativePath =
           CopySnapshotAsset(sourcePath, targetAssetsDir, useNewByFileName);
@@ -1273,9 +1274,9 @@ void DictionaryEditDialog::RefreshDictionarySelectionLabels() {
 void DictionaryEditDialog::OnSelectFixturesDictionary(
     wxCommandEvent &WXUNUSED(event)) {
   const std::filesystem::path currentPath =
-      std::filesystem::u8path(GdtfDictionary::GetActiveDictionaryFilePath());
+      PathUtils::PathFromUtf8(GdtfDictionary::GetActiveDictionaryFilePath());
   const wxString initialDir = wxString::FromUTF8(
-      (currentPath.empty() ? std::filesystem::u8path(
+      (currentPath.empty() ? PathUtils::PathFromUtf8(
                                  ProjectUtils::GetWritableLibraryPath("fixtures"))
                            : currentPath.parent_path())
           .string());
@@ -1290,7 +1291,7 @@ void DictionaryEditDialog::OnSelectFixturesDictionary(
 
   std::string error;
   std::filesystem::path selectedPath =
-      std::filesystem::u8path(std::string(dialog.GetPath().ToUTF8()));
+      PathUtils::PathFromUtf8(std::string(dialog.GetPath().ToUTF8()));
   if (!selectedPath.has_extension())
     selectedPath += ".json";
   const std::string selected = selectedPath.string();
@@ -1307,9 +1308,9 @@ void DictionaryEditDialog::OnSelectFixturesDictionary(
 void DictionaryEditDialog::OnSelectTrussesDictionary(
     wxCommandEvent &WXUNUSED(event)) {
   const std::filesystem::path currentPath =
-      std::filesystem::u8path(TrussDictionary::GetActiveDictionaryFilePath());
+      PathUtils::PathFromUtf8(TrussDictionary::GetActiveDictionaryFilePath());
   const wxString initialDir = wxString::FromUTF8(
-      (currentPath.empty() ? std::filesystem::u8path(
+      (currentPath.empty() ? PathUtils::PathFromUtf8(
                                  ProjectUtils::GetWritableLibraryPath("trusses"))
                            : currentPath.parent_path())
           .string());
@@ -1324,7 +1325,7 @@ void DictionaryEditDialog::OnSelectTrussesDictionary(
 
   std::string error;
   std::filesystem::path selectedPath =
-      std::filesystem::u8path(std::string(dialog.GetPath().ToUTF8()));
+      PathUtils::PathFromUtf8(std::string(dialog.GetPath().ToUTF8()));
   if (!selectedPath.has_extension())
     selectedPath += ".json";
   const std::string selected = selectedPath.string();
@@ -1392,7 +1393,7 @@ bool DictionaryEditDialog::SaveFixtures() {
     entry.importedAt = FileImportUtils::NowUtcIso8601();
     if (!row.sha256.empty())
       entry.sha256 = row.sha256;
-    else if (const auto hash = FileImportUtils::ComputeFileSha256(std::filesystem::u8path(row.path)))
+    else if (const auto hash = FileImportUtils::ComputeFileSha256(PathUtils::PathFromUtf8(row.path)))
       entry.sha256 = *hash;
     dict[row.name] = std::move(entry);
   }

--- a/gui/layout_view_cache_archive.cpp
+++ b/gui/layout_view_cache_archive.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "layout_view_cache_archive.h"
+#include "filesystem_path_utils.h"
 #include "layoutviewerpanel.h"
 
 #include <algorithm>
@@ -110,7 +111,7 @@ std::optional<fs::path> ResolveSourceAssetPath(const fs::path &root,
   if (reference.empty())
     return std::nullopt;
   std::error_code ec;
-  fs::path path = fs::u8path(reference);
+  fs::path path = PathUtils::PathFromUtf8(reference);
   if (!path.is_absolute())
     path = root / path;
   path = fs::weakly_canonical(path, ec);
@@ -169,7 +170,7 @@ std::optional<std::string> ComputeSourceAssetHash(const MvrScene &scene) {
   if (scene.basePath.empty())
     return std::nullopt;
   std::error_code ec;
-  const fs::path root = fs::weakly_canonical(fs::u8path(scene.basePath), ec);
+  const fs::path root = fs::weakly_canonical(PathUtils::PathFromUtf8(scene.basePath), ec);
   if (ec || !fs::is_directory(root, ec))
     return std::nullopt;
 

--- a/gui/layoutlegenditems.cpp
+++ b/gui/layoutlegenditems.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "layoutlegenditems.h"
+#include "filesystem_path_utils.h"
 
 #include <filesystem>
 #include <cctype>
@@ -78,9 +79,9 @@ std::vector<SharedLayoutLegendItem> BuildSharedLayoutLegendItems() {
     if (!fixture.gdtfSpec.empty()) {
       try {
         std::filesystem::path p =
-            basePath.empty() ? std::filesystem::u8path(fixture.gdtfSpec)
-                             : std::filesystem::u8path(basePath) /
-                                   std::filesystem::u8path(fixture.gdtfSpec);
+            basePath.empty() ? PathUtils::PathFromUtf8(fixture.gdtfSpec)
+                             : PathUtils::PathFromUtf8(basePath) /
+                                   PathUtils::PathFromUtf8(fixture.gdtfSpec);
         fullPath = p.string();
       } catch (const std::exception &) {
         fullPath.clear();

--- a/gui/layoutviewerpanel_image.cpp
+++ b/gui/layoutviewerpanel_image.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "layoutviewerpanel.h"
+#include "filesystem_path_utils.h"
 
 #include <algorithm>
 #include <cmath>
@@ -67,7 +68,7 @@ ImageSourceFileState GetImageSourceFileState(const std::string &imagePath) {
 
   std::error_code ec;
   try {
-    const std::filesystem::path path = std::filesystem::u8path(imagePath);
+    const std::filesystem::path path = PathUtils::PathFromUtf8(imagePath);
     if (!std::filesystem::exists(path, ec) || ec)
       return state;
 

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "mainwindow.h"
+#include "filesystem_path_utils.h"
 #include "diagnostics/DiagnosticLogger.h"
 
 #include <algorithm>
@@ -937,7 +938,7 @@ void MainWindow::LoadStartupProjectFromPath(const std::string &path) {
   namespace fs = std::filesystem;
 
   std::error_code ec;
-  const fs::path projectPath = fs::u8path(path);
+  const fs::path projectPath = PathUtils::PathFromUtf8(path);
   if (!fs::is_regular_file(projectPath, ec)) {
     ProjectUtils::SaveLastProjectPath("");
     ResetProject(true);

--- a/gui/mainwindow_fixture_add_flow.cpp
+++ b/gui/mainwindow_fixture_add_flow.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "mainwindow.h"
+#include "filesystem_path_utils.h"
 
 #include <chrono>
 #include <filesystem>
@@ -54,7 +55,7 @@ void MainWindow::AddFixtureFromGdtfPath(const std::string &gdtfPath,
   }
   const wxString gdtfPathWx = wxString::FromUTF8(gdtfPath);
 
-  if (!std::filesystem::exists(std::filesystem::u8path(gdtfPath))) {
+  if (!std::filesystem::exists(PathUtils::PathFromUtf8(gdtfPath))) {
     wxMessageBox("The selected GDTF file does not exist.", "Add fixture",
                  wxOK | wxICON_ERROR);
     if (consolePanel)

--- a/gui/mainwindow_io.cpp
+++ b/gui/mainwindow_io.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "mainwindow.h"
+#include "filesystem_path_utils.h"
 #include "mainwindow_io_controller.h"
 
 #include <algorithm>
@@ -77,7 +78,7 @@ std::string EnsureProjectFileExtension(const std::string &path) {
   if (path.empty())
     return path;
 
-  const std::filesystem::path candidate = std::filesystem::u8path(path);
+  const std::filesystem::path candidate = PathUtils::PathFromUtf8(path);
   const std::string ext = candidate.extension().string();
   const std::string requiredExt = ProjectUtils::PROJECT_EXTENSION;
   if (ext == requiredExt)

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "about_dialog.h"
+#include "filesystem_path_utils.h"
 #include "mainwindow.h"
 #include "mainwindow/controllers/mainwindow_io_controller.h"
 #include "mainwindow_view_controller.h"
@@ -569,7 +570,7 @@ void MainWindow::OnOpenUserLibraryFolder(wxCommandEvent &WXUNUSED(event)) {
   }
 
   const std::filesystem::path libraryRoot =
-      std::filesystem::u8path(fixturesPath).parent_path();
+      PathUtils::PathFromUtf8(fixturesPath).parent_path();
   const std::u8string folderPathUtf8 = libraryRoot.u8string();
   const std::string folderPathBytes(folderPathUtf8.begin(), folderPathUtf8.end());
   const wxString folderPath = wxString::FromUTF8(folderPathBytes.c_str());
@@ -1336,7 +1337,7 @@ void MainWindow::OnAddTruss(wxCommandEvent &WXUNUSED(event)) {
 
   Truss baseTruss;
   namespace fs = std::filesystem;
-  fs::path selectedTrussPath = fs::u8path(path);
+  fs::path selectedTrussPath = PathUtils::PathFromUtf8(path);
   std::string selectedExtension = selectedTrussPath.extension().string();
   std::transform(selectedExtension.begin(), selectedExtension.end(),
                  selectedExtension.begin(), [](unsigned char c) {
@@ -1427,7 +1428,7 @@ std::string NormalizeImportedObjectModelPathToGlb(const std::string &selectedPat
                                                   const std::string &sceneBasePath,
                                                   std::string &consoleError) {
   namespace fs = std::filesystem;
-  fs::path sourcePath = fs::u8path(selectedPath);
+  fs::path sourcePath = PathUtils::PathFromUtf8(selectedPath);
   std::string ext = sourcePath.extension().string();
   std::transform(ext.begin(), ext.end(), ext.begin(), [](unsigned char c) {
     return static_cast<char>(std::tolower(c));
@@ -1458,7 +1459,7 @@ std::string NormalizeImportedObjectModelPathToGlb(const std::string &selectedPat
 
   if (!sceneBasePath.empty()) {
     const fs::path absTarget = fs::weakly_canonical(targetPath, ec);
-    const fs::path absBase = fs::weakly_canonical(fs::u8path(sceneBasePath), ec);
+    const fs::path absBase = fs::weakly_canonical(PathUtils::PathFromUtf8(sceneBasePath), ec);
     if (!ec && !absTarget.empty() && !absBase.empty() &&
         absTarget.string().rfind(absBase.string(), 0) == 0) {
       return fs::relative(absTarget, absBase, ec).string();

--- a/gui/resource_path_utils.cpp
+++ b/gui/resource_path_utils.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "resource_path_utils.h"
+#include "filesystem_path_utils.h"
 
 #include "logger.h"
 
@@ -78,13 +79,13 @@ std::string MakeSceneRelativeResourcePathOrOriginal(
     return resourcePath;
 
   std::error_code ec;
-  const fs::path resource = NormalizedAbsolutePath(fs::u8path(resourcePath), ec);
+  const fs::path resource = NormalizedAbsolutePath(PathUtils::PathFromUtf8(resourcePath), ec);
   if (ec) {
     LogSceneRelativeConversionWarning(logContext, resourcePath, basePath, ec);
     return resourcePath;
   }
 
-  const fs::path base = NormalizedAbsolutePath(fs::u8path(basePath), ec);
+  const fs::path base = NormalizedAbsolutePath(PathUtils::PathFromUtf8(basePath), ec);
   if (ec) {
     LogSceneRelativeConversionWarning(logContext, resourcePath, basePath, ec);
     return resourcePath;

--- a/gui/resource_reference_sync.cpp
+++ b/gui/resource_reference_sync.cpp
@@ -1,4 +1,5 @@
 #include "resource_reference_sync.h"
+#include "filesystem_path_utils.h"
 
 #include <cctype>
 #include <filesystem>
@@ -29,9 +30,9 @@ bool IsPrimitiveReference(const std::string &value) {
 // Resolves scene-relative resource references against the current MVR base path.
 fs::path ResolveSceneResourcePath(const std::string &basePath,
                                   const std::string &pathRef) {
-  fs::path path = fs::u8path(pathRef);
+  fs::path path = PathUtils::PathFromUtf8(pathRef);
   if (!path.is_absolute() && !basePath.empty())
-    path = fs::u8path(basePath) / path;
+    path = PathUtils::PathFromUtf8(basePath) / path;
   return path.lexically_normal();
 }
 

--- a/gui/tools/fixture_category_assignment_tool.cpp
+++ b/gui/tools/fixture_category_assignment_tool.cpp
@@ -1,4 +1,5 @@
 #include "tools/fixture_category_assignment_tool.h"
+#include "filesystem_path_utils.h"
 
 #include <algorithm>
 #include <cctype>
@@ -36,12 +37,12 @@ std::string ResolveFixtureGdtfPath(const std::string &basePath,
   if (gdtfSpec.empty())
     return {};
 
-  const std::filesystem::path specPath = std::filesystem::u8path(gdtfSpec);
+  const std::filesystem::path specPath = PathUtils::PathFromUtf8(gdtfSpec);
   if (specPath.is_absolute() && std::filesystem::exists(specPath))
     return specPath.string();
 
   if (!basePath.empty()) {
-    const std::filesystem::path joined = std::filesystem::u8path(basePath) / specPath;
+    const std::filesystem::path joined = PathUtils::PathFromUtf8(basePath) / specPath;
     if (std::filesystem::exists(joined))
       return joined.string();
   }

--- a/main.cpp
+++ b/main.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "BuildInfo.h"
+#include "filesystem_path_utils.h"
 #include "app_version.h"
 #include "configmanager.h"
 #include "diagnostics/CrashHandler.h"
@@ -147,7 +148,7 @@ std::optional<std::string> GetStartupPathFromArgs(
   const fs::path launchWorkingDirectory =
       launchWorkingDirectoryUtf8.empty()
           ? fs::path()
-          : fs::u8path(launchWorkingDirectoryUtf8);
+          : PathUtils::PathFromUtf8(launchWorkingDirectoryUtf8);
 
   auto toUtf8 = [](const wxString &text) {
     wxCharBuffer utf8 = text.ToUTF8();
@@ -168,7 +169,7 @@ std::optional<std::string> GetStartupPathFromArgs(
       continue;
 
     const std::string normalizedRawPath = NormalizeExternalOpenPath(rawPath);
-    const fs::path candidate = fs::u8path(normalizedRawPath);
+    const fs::path candidate = PathUtils::PathFromUtf8(normalizedRawPath);
     const std::u8string extensionU8 = candidate.extension().u8string();
     const std::string extension(extensionU8.begin(), extensionU8.end());
     const std::string normalizedExtension = ToLowerAscii(extension);

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "mvrexporter.h"
+#include "filesystem_path_utils.h"
 #include "configmanager.h"
 #include "dummyprofilelibrary.h"
 #include "gdtf_mutation_audit.h"
@@ -254,7 +255,7 @@ static bool ResolveTextureDependencyPath(const fs::path &modelPath,
   if (normalizedRef.empty())
     return false;
 
-  const fs::path refPath = fs::u8path(normalizedRef);
+  const fs::path refPath = PathUtils::PathFromUtf8(normalizedRef);
   if (refPath.is_absolute() && fs::exists(refPath)) {
     resolvedPath = refPath;
     return true;
@@ -435,7 +436,7 @@ static std::string SanitizeArchiveRelativePath(const std::string &input,
   if (candidate.empty())
     return SanitizeArchiveFileName(candidate, fallbackName);
 
-  fs::path raw = fs::u8path(candidate);
+  fs::path raw = PathUtils::PathFromUtf8(candidate);
   std::vector<std::string> sanitizedParts;
   for (const auto &part : raw) {
     const std::string segment = TrimAscii(part.generic_string());
@@ -449,7 +450,7 @@ static std::string SanitizeArchiveRelativePath(const std::string &input,
 
   fs::path out;
   for (const std::string &segment : sanitizedParts)
-    out /= fs::u8path(segment);
+    out /= PathUtils::PathFromUtf8(segment);
   return out.generic_string();
 }
 
@@ -1519,7 +1520,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
         const std::string trimmedRef = TrimAscii(textureRef);
         if (trimmedRef.empty())
           continue;
-        const fs::path candidate = modelDir / fs::u8path(trimmedRef);
+        const fs::path candidate = modelDir / PathUtils::PathFromUtf8(trimmedRef);
         if (!fs::exists(candidate))
           continue;
 
@@ -1613,7 +1614,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
       const std::string tempFileName = wxString::Format(
           "primitive_%s_%zx.glb", primitiveLabel.c_str(), primitiveHash)
                                            .ToStdString();
-      fs::path outputPath = fs::u8path(primitiveTempDir) / fs::u8path(tempFileName);
+      fs::path outputPath = PathUtils::PathFromUtf8(primitiveTempDir) / PathUtils::PathFromUtf8(tempFileName);
       if (!mvr::WritePrimitiveModelForToken(primitiveKey, outputPath.generic_string()))
         return {};
       sourcePath = outputPath.generic_string();

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "mvrimporter.h"
+#include "filesystem_path_utils.h"
 #include "configmanager.h"
 #ifdef PERASTAGE_ENABLE_MVR_GDTF_DOWNLOAD_API
 #include "credentialstore.h"
@@ -196,7 +197,7 @@ static std::string NormalizeGdtfLookupKey(const std::string &value) {
   if (normalized.empty())
     return normalized;
 
-  fs::path path = fs::u8path(normalized);
+  fs::path path = PathUtils::PathFromUtf8(normalized);
   std::string stem = Trim(path.stem().string());
   std::string ext = ToLowerAscii(path.extension().string());
   if (ext.empty())
@@ -319,10 +320,10 @@ static bool IsRenderableTrussGeometry(const std::string &path) {
 
 static fs::path ResolveSceneRelativePath(const std::string &basePath,
                                          const std::string &pathText) {
-  fs::path path = fs::u8path(pathText);
+  fs::path path = PathUtils::PathFromUtf8(pathText);
   if (path.is_absolute() || basePath.empty())
     return path;
-  return fs::u8path(basePath) / path;
+  return PathUtils::PathFromUtf8(basePath) / path;
 }
 
 // Compares path components using platform filesystem case-sensitivity rules.
@@ -377,7 +378,7 @@ static std::string ToSceneRelativePathIfPossible(const std::string &basePath,
 
   std::error_code ec;
   const fs::path base =
-      NormalizedAbsolutePathForImport(fs::u8path(basePath), ec);
+      NormalizedAbsolutePathForImport(PathUtils::PathFromUtf8(basePath), ec);
   if (ec)
     return ToString(candidatePath.u8string());
 
@@ -418,8 +419,8 @@ static std::string ResolveGdtfPath(const std::string &baseDir,
     return {};
 
   fs::path candidate = baseDir.empty()
-                           ? fs::u8path(normalizedSpec)
-                           : fs::u8path(baseDir) / fs::u8path(normalizedSpec);
+                           ? PathUtils::PathFromUtf8(normalizedSpec)
+                           : PathUtils::PathFromUtf8(baseDir) / PathUtils::PathFromUtf8(normalizedSpec);
 
   std::error_code ec;
   const std::string candidateExt = ToLowerAscii(candidate.extension().string());
@@ -439,16 +440,16 @@ static std::string ResolveGdtfPath(const std::string &baseDir,
   // Restricts fallback directory scans to the extracted MVR base directory on Windows.
   if (baseDir.empty())
     return ToString(candidate.u8string());
-  fs::path lookupDir = fs::u8path(baseDir);
+  fs::path lookupDir = PathUtils::PathFromUtf8(baseDir);
 #else
   fs::path lookupDir =
-      baseDir.empty() ? fs::current_path(ec) : fs::u8path(baseDir);
+      baseDir.empty() ? fs::current_path(ec) : PathUtils::PathFromUtf8(baseDir);
 #endif
   if (ec || !fs::exists(lookupDir, ec) || ec)
     return ToString(candidate.u8string());
 
   const std::string expectedStem =
-      ToLowerAscii(Trim(fs::u8path(normalizedSpec).filename().stem().string()));
+      ToLowerAscii(Trim(PathUtils::PathFromUtf8(normalizedSpec).filename().stem().string()));
   const std::string normalizedSpecKey = NormalizeGdtfLookupKey(normalizedSpec);
   for (const auto &entry : fs::directory_iterator(lookupDir, ec)) {
     if (ec)
@@ -1040,7 +1041,7 @@ bool MvrImporter::ImportFromFileIntoResult(const std::string &filePath,
   fixtureUuidRemap.clear();
   importResult = MvrImportResult{};
   // Treat the incoming path as UTF-8 to preserve any non-ASCII characters
-  fs::path path = fs::u8path(filePath);
+  fs::path path = PathUtils::PathFromUtf8(filePath);
 
   std::string ext = path.extension().string();
   std::transform(ext.begin(), ext.end(), ext.begin(),
@@ -1154,7 +1155,7 @@ std::string MvrImporter::CreateTemporaryDirectory() {
     std::error_code ec;
     if (fs::create_directory(fullPath, ec) && !ec) {
       // Return the path encoded as UTF-8 so it can safely be converted back
-      // using fs::u8path or passed to wxWidgets APIs expecting UTF-8 strings.
+      // using PathUtils::PathFromUtf8 or passed to wxWidgets APIs expecting UTF-8 strings.
       return ToString(fullPath.u8string());
     }
   }
@@ -1180,7 +1181,7 @@ bool MvrImporter::ExtractMvrZip(const std::string &mvrPath,
   while ((entry.reset(zipStream.GetNextEntry())), entry) {
     // Extract entry names using UTF-8 to preserve special characters
     std::string entryName = entry->GetName().ToUTF8().data();
-    fs::path fullPath = fs::u8path(destDir) / fs::u8path(entryName);
+    fs::path fullPath = PathUtils::PathFromUtf8(destDir) / PathUtils::PathFromUtf8(entryName);
 
     if (entry->IsDir()) {
       std::string dirUtf8 = ToString(fullPath.u8string());
@@ -1206,8 +1207,8 @@ bool MvrImporter::ExtractMvrZip(const std::string &mvrPath,
       output = tryOpenOutput(fullPath);
 
     if (!output.is_open()) {
-      fs::path longDir = fs::u8path(destDir) / "_long";
-      std::string extension = fs::u8path(entryName).extension().string();
+      fs::path longDir = PathUtils::PathFromUtf8(destDir) / "_long";
+      std::string extension = PathUtils::PathFromUtf8(entryName).extension().string();
       std::string hashBase = std::to_string(std::hash<std::string>{}(normalizedEntryName));
       wxFileName::Mkdir(wxString::FromUTF8(ToString(longDir.u8string()).c_str()),
                         wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
@@ -1217,12 +1218,12 @@ bool MvrImporter::ExtractMvrZip(const std::string &mvrPath,
         if (suffix > 0)
           candidateName += "_" + std::to_string(suffix);
         candidateName += extension;
-        fs::path candidatePath = longDir / fs::u8path(candidateName);
+        fs::path candidatePath = longDir / PathUtils::PathFromUtf8(candidateName);
         output = tryOpenOutput(candidatePath);
         if (output.is_open()) {
           fullPath = candidatePath;
           pathRemap[normalizedEntryName] = ToString((fs::path("_long") /
-                                                     fs::u8path(candidateName))
+                                                     PathUtils::PathFromUtf8(candidateName))
                                                         .u8string());
           remapped = true;
         }
@@ -1307,7 +1308,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
 
   MvrScene &scene = importResult.scene;
   scene.Clear();
-  scene.basePath = ToString(fs::u8path(sceneXmlPath).parent_path().u8string());
+  scene.basePath = ToString(PathUtils::PathFromUtf8(sceneXmlPath).parent_path().u8string());
 
   root->QueryIntAttribute("verMajor", &scene.versionMajor);
   root->QueryIntAttribute("verMinor", &scene.versionMinor);
@@ -1571,7 +1572,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
     fileName = Trim(fileName);
     if (fileName.empty())
       return fileName;
-    return ToString(fs::u8path(fileName).u8string());
+    return ToString(PathUtils::PathFromUtf8(fileName).u8string());
   };
 
   auto normalizeAndResolveGeometryFileName = [&](std::string fileName) {
@@ -1584,7 +1585,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
     std::string remapped = RemapArchivePathIfNeeded(normalized);
     if (mvr::ResolvePrimitiveTokenFromModelRef(remapped, primitiveToken))
       return primitiveToken;
-    fs::path remappedPath = fs::u8path(remapped);
+    fs::path remappedPath = PathUtils::PathFromUtf8(remapped);
     fs::path resolved = ResolveSceneRelativePath(scene.basePath, remapped);
     if (!remappedPath.has_extension()) {
       const std::array<std::string, 3> extensions = {".gltf", ".glb", ".3ds"};
@@ -1629,7 +1630,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
     const std::string normalized = NormalizeArchivePathValue(spec);
     if (normalized.empty())
       return std::string{};
-    return ToSceneRelativePathIfPossible(scene.basePath, fs::u8path(resolveGdtfPathCached(normalized)));
+    return ToSceneRelativePathIfPossible(scene.basePath, PathUtils::PathFromUtf8(resolveGdtfPathCached(normalized)));
   };
 
   auto getGdtfModesCached = [&](const std::string &gdtfPath)
@@ -2270,8 +2271,8 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
           if (typeIt != perastageTypeToGdtfPath.end()) {
             truss.perastageAuxGdtfArchivePath = typeIt->second;
             fs::path auxPath = scene.basePath.empty()
-                                   ? fs::u8path(typeIt->second)
-                                   : fs::u8path(scene.basePath) / fs::u8path(typeIt->second);
+                                   ? PathUtils::PathFromUtf8(typeIt->second)
+                                   : PathUtils::PathFromUtf8(scene.basePath) / PathUtils::PathFromUtf8(typeIt->second);
             Truss sidecar;
             if (LoadTrussDefinition(ToString(auxPath.u8string()), sidecar)) {
               if (truss.manufacturer.empty())
@@ -2356,7 +2357,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                                                   ? support.gdtfSpec
                                                   : resolvedSupportGdtfPath;
           support.gdtfSpec = ToSceneRelativePathIfPossible(
-              scene.basePath, fs::u8path(supportGdtfPath));
+              scene.basePath, PathUtils::PathFromUtf8(supportGdtfPath));
         }
         support.gdtfMode = readText("GDTFMode");
         support.function = readText("Function");
@@ -3290,7 +3291,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
 #ifdef NDEBUG
                       ProjectUtils::GetWritableLibraryPath("fixtures");
 #else
-                      (fs::u8path(
+                      (PathUtils::PathFromUtf8(
                            wxStandardPaths::Get().GetExecutablePath().ToStdString())
                            .parent_path() /
                        "library" / "fixtures")
@@ -3475,7 +3476,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                 continue;
               f.gdtfSpec = selectedPathIt->second;
             f.gdtfSpec = ToSceneRelativePathIfPossible(
-                scene.basePath, fs::u8path(resolveFixtureGdtfPathForRead(f.gdtfSpec)));
+                scene.basePath, PathUtils::PathFromUtf8(resolveFixtureGdtfPathForRead(f.gdtfSpec)));
             std::string parsed =
                 Trim(GetGdtfFixtureName(resolveFixtureGdtfPathForRead(f.gdtfSpec)));
             if (!parsed.empty())
@@ -3519,7 +3520,7 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                     : -1;
             f.gdtfSpec = dictEntry->path;
             f.gdtfSpec = ToSceneRelativePathIfPossible(
-                scene.basePath, fs::u8path(resolveFixtureGdtfPathForRead(f.gdtfSpec)));
+                scene.basePath, PathUtils::PathFromUtf8(resolveFixtureGdtfPathForRead(f.gdtfSpec)));
             if (f.gdtfMode.empty())
               f.gdtfMode = dictEntry->mode;
             f.gdtfMode = resolveExistingGdtfModeCached(

--- a/mvr/primitive_model_resources.cpp
+++ b/mvr/primitive_model_resources.cpp
@@ -1,4 +1,5 @@
 #include "primitive_model_resources.h"
+#include "filesystem_path_utils.h"
 
 #include <algorithm>
 #include <cctype>
@@ -441,7 +442,7 @@ bool WriteGlb(const PrimitiveMeshData &mesh, const std::string &outputPath) {
   AppendBytes(glb, bin.data(), bin.size());
 
   std::error_code ec;
-  const fs::path output = fs::u8path(outputPath);
+  const fs::path output = PathUtils::PathFromUtf8(outputPath);
   if (output.has_parent_path())
     fs::create_directories(output.parent_path(), ec);
 

--- a/tests/dictionary_seed_merge_backup_test.cpp
+++ b/tests/dictionary_seed_merge_backup_test.cpp
@@ -2,6 +2,7 @@
  * This file is part of Perastage.
  */
 #include <cassert>
+#include "filesystem_path_utils.h"
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
@@ -124,7 +125,7 @@ int main() {
   assert(initializer.IsOk());
 
   const fs::path tempRoot = fs::temp_directory_path() /
-                            fs::u8path("perastage_dictionary_seed_merge_backup_test");
+                            PathUtils::PathFromUtf8("perastage_dictionary_seed_merge_backup_test");
   std::error_code ec;
   fs::remove_all(tempRoot, ec);
   fs::create_directories(tempRoot);

--- a/tests/gdtf_dictionary_color_mode_propagation_test.cpp
+++ b/tests/gdtf_dictionary_color_mode_propagation_test.cpp
@@ -2,6 +2,7 @@
  * This file is part of Perastage.
  */
 #include <cassert>
+#include "filesystem_path_utils.h"
 #include <filesystem>
 #include <fstream>
 #include <sstream>
@@ -37,7 +38,7 @@ int main() {
   assert(initializer.IsOk());
 
   const std::filesystem::path fixturesDir =
-      std::filesystem::u8path(ProjectUtils::GetDefaultLibraryPath("fixtures"));
+      PathUtils::PathFromUtf8(ProjectUtils::GetDefaultLibraryPath("fixtures"));
   std::filesystem::create_directories(fixturesDir);
   const std::filesystem::path dictPath = fixturesDir / "gdtf_dictionary.json";
   const bool hadOriginal = std::filesystem::exists(dictPath);

--- a/tests/gdtf_dictionary_color_roundtrip_test.cpp
+++ b/tests/gdtf_dictionary_color_roundtrip_test.cpp
@@ -2,6 +2,7 @@
  * This file is part of Perastage.
  */
 #include <cassert>
+#include "filesystem_path_utils.h"
 #include <filesystem>
 #include <fstream>
 #include <sstream>
@@ -37,7 +38,7 @@ int main() {
   assert(initializer.IsOk());
 
   const std::filesystem::path fixturesDir =
-      std::filesystem::u8path(ProjectUtils::GetDefaultLibraryPath("fixtures"));
+      PathUtils::PathFromUtf8(ProjectUtils::GetDefaultLibraryPath("fixtures"));
   std::filesystem::create_directories(fixturesDir);
   const std::filesystem::path dictPath = fixturesDir / "gdtf_dictionary.json";
 

--- a/tests/rider_truss_dictionary_normalization_test.cpp
+++ b/tests/rider_truss_dictionary_normalization_test.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include <cassert>
+#include "filesystem_path_utils.h"
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
@@ -88,7 +89,7 @@ void AssertTrussSymbolResolved(const std::string &textVariant) {
   assert(scene.trusses.size() == 1);
   const auto &truss = scene.trusses.begin()->second;
   assert(!truss.symbolFile.empty());
-  assert(fs::exists(fs::u8path(truss.symbolFile)));
+  assert(fs::exists(PathUtils::PathFromUtf8(truss.symbolFile)));
 }
 
 void AssertModelTokenDictionaryLookupWorks(const std::string &textVariant) {
@@ -102,7 +103,7 @@ void AssertModelTokenDictionaryLookupWorks(const std::string &textVariant) {
   assert(!truss.model.empty());
   assert(truss.model == TrussDictionary::NormalizeModelKey("FK40Q"));
   assert(!truss.symbolFile.empty());
-  assert(fs::exists(fs::u8path(truss.symbolFile)));
+  assert(fs::exists(PathUtils::PathFromUtf8(truss.symbolFile)));
 }
 
 } // namespace
@@ -112,15 +113,15 @@ int main() {
   assert(initializer.IsOk());
 
   const fs::path tempRoot =
-      fs::temp_directory_path() / fs::u8path("perastage_truss_model_normalization");
+      fs::temp_directory_path() / PathUtils::PathFromUtf8("perastage_truss_model_normalization");
   std::error_code ec;
   fs::remove_all(tempRoot, ec);
   fs::create_directories(tempRoot);
 
-  const fs::path libraryRoot = tempRoot / fs::u8path("library");
+  const fs::path libraryRoot = tempRoot / PathUtils::PathFromUtf8("library");
   SetLibraryPathEnv(ToUtf8String(libraryRoot));
 
-  const fs::path archivePath = tempRoot / fs::u8path("FK40Q.gdtf");
+  const fs::path archivePath = tempRoot / PathUtils::PathFromUtf8("FK40Q.gdtf");
   assert(WriteArchive(archivePath));
 
   TrussDictionary::Update("TRUSS 40X40 3M", ToUtf8String(archivePath));

--- a/tests/truss_path_encoding_regression_test.cpp
+++ b/tests/truss_path_encoding_regression_test.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include <cassert>
+#include "filesystem_path_utils.h"
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
@@ -81,7 +82,7 @@ bool WriteArchive(const fs::path &archivePath) {
 void RunPathCase(const fs::path &sourceDir, const std::string &modelName,
                  const std::string &fileName) {
   fs::create_directories(sourceDir);
-  const fs::path archivePath = sourceDir / fs::u8path(fileName);
+  const fs::path archivePath = sourceDir / PathUtils::PathFromUtf8(fileName);
   assert(WriteArchive(archivePath));
 
   TrussDictionary::Update(modelName, ToUtf8String(archivePath));
@@ -91,8 +92,8 @@ void RunPathCase(const fs::path &sourceDir, const std::string &modelName,
   Truss truss;
   assert(LoadTrussDefinition(*storedPath, truss));
   assert(!truss.symbolFile.empty());
-  assert(fs::exists(fs::u8path(truss.symbolFile)));
-  assert(fs::path(fs::u8path(truss.symbolFile)).filename() == "main.svg");
+  assert(fs::exists(PathUtils::PathFromUtf8(truss.symbolFile)));
+  assert(fs::path(PathUtils::PathFromUtf8(truss.symbolFile)).filename() == "main.svg");
   assert(truss.symbolFile != *storedPath);
 }
 
@@ -103,17 +104,17 @@ int main() {
   assert(initializer.IsOk());
 
   const fs::path tempRoot =
-      fs::temp_directory_path() / fs::u8path("perastage_truss_diccionario_ñ");
+      fs::temp_directory_path() / PathUtils::PathFromUtf8("perastage_truss_diccionario_ñ");
   std::error_code ec;
   fs::remove_all(tempRoot, ec);
   fs::create_directories(tempRoot);
 
-  const fs::path libraryRoot = tempRoot / fs::u8path("librería prueba");
+  const fs::path libraryRoot = tempRoot / PathUtils::PathFromUtf8("librería prueba");
   SetLibraryPathEnv(ToUtf8String(libraryRoot));
 
-  RunPathCase(tempRoot / fs::u8path("origen ñ"), "FK40Q-Unicode",
+  RunPathCase(tempRoot / PathUtils::PathFromUtf8("origen ñ"), "FK40Q-Unicode",
               "Tramo_áéíóú.gdtf");
-  RunPathCase(tempRoot / fs::u8path("source with spaces"), "FK40Q-Spaces",
+  RunPathCase(tempRoot / PathUtils::PathFromUtf8("source with spaces"), "FK40Q-Spaces",
               "FK40Q H-300.gdtf");
 
   TrussDictionary::Save({});

--- a/tests/trussloader_validation_test.cpp
+++ b/tests/trussloader_validation_test.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include <cassert>
+#include "filesystem_path_utils.h"
 #include <filesystem>
 #include <fstream>
 #include <map>
@@ -69,7 +70,7 @@ std::string MinimalGdtfDescription() {
 // Verifies truss loader extension validation and archive extraction safety.
 int main() {
   const fs::path tempRoot = fs::temp_directory_path() /
-                            fs::u8path("perastage_trussloader_validation_test");
+                            PathUtils::PathFromUtf8("perastage_trussloader_validation_test");
   std::error_code ec;
   fs::remove_all(tempRoot, ec);
   fs::create_directories(tempRoot);

--- a/viewer3d/gdtfloader.cpp
+++ b/viewer3d/gdtfloader.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "gdtfloader.h"
+#include "filesystem_path_utils.h"
 #include "gdtf_mutation_audit.h"
 #include "loader3ds.h"
 #include "loaderglb.h"
@@ -54,16 +55,6 @@ class wxZipStreamLink;
 namespace fs = std::filesystem;
 
 namespace {
-// Converts a UTF-8 string into a filesystem path without triggering macOS libc++ u8path deprecation warnings.
-static fs::path MakeUtf8Path(const std::string& text)
-{
-#if defined(__APPLE__)
-    return fs::path(text);
-#else
-    return fs::u8path(text);
-#endif
-}
-
 // Parses a trimmed float token and succeeds only when the whole token is numeric.
 bool TryParseFloat(const std::string& text, float& out)
 {
@@ -312,11 +303,11 @@ static bool BuildDimensionFallbackMesh(const GdtfModelInfo& modelInfo, Mesh& mes
 static std::string FindModelFile(const std::string& baseDir,
                                  const std::string& fileName)
 {
-    const fs::path modelsDir = MakeUtf8Path(baseDir) / "models";
+    const fs::path modelsDir = PathUtils::PathFromUtf8(baseDir) / "models";
     if (!fs::exists(modelsDir))
         return {};
 
-    const fs::path requested = MakeUtf8Path(fileName);
+    const fs::path requested = PathUtils::PathFromUtf8(fileName);
     const std::string requestedName = requested.filename().string();
     const bool hasExtension = requested.has_extension();
 
@@ -1337,7 +1328,7 @@ static void ParseGeometry(tinyxml2::XMLElement* node,
                             bool loaded = false;
                             bool tried3ds = false;
                             bool triedGlb = false;
-                            const fs::path loadedPath = MakeUtf8Path(path);
+                            const fs::path loadedPath = PathUtils::PathFromUtf8(path);
                             std::string fallbackGlbPath;
 
                             if (HasExtension(loadedPath, ".3ds")) {
@@ -1346,7 +1337,7 @@ static void ParseGeometry(tinyxml2::XMLElement* node,
                                 loaded = Load3DS(path, mesh, false, &loadError3ds);
                                 if (!loaded) {
                                     fallbackGlbPath = FindModelFile(baseDir, loadedPath.stem().string());
-                                    if (!fallbackGlbPath.empty() && HasExtension(MakeUtf8Path(fallbackGlbPath), ".glb")) {
+                                    if (!fallbackGlbPath.empty() && HasExtension(PathUtils::PathFromUtf8(fallbackGlbPath), ".glb")) {
                                         triedGlb = true;
                                         std::string loadErrorGlbFallback;
                                         loaded = LoadGLB(fallbackGlbPath, mesh, &loadErrorGlbFallback);

--- a/viewer3d/loader3ds.cpp
+++ b/viewer3d/loader3ds.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "loader3ds.h"
+#include "filesystem_path_utils.h"
 #include <fstream>
 #include <cstdint>
 #include <array>
@@ -142,7 +143,7 @@ static bool ResolveTexturePath(const fs::path& modelDir, const std::string& file
     if (filename.empty())
         return false;
 
-    fs::path texturePath = fs::u8path(filename);
+    fs::path texturePath = PathUtils::PathFromUtf8(filename);
     if (texturePath.is_absolute() && fs::exists(texturePath)) {
         outPath = texturePath;
         return true;
@@ -430,7 +431,7 @@ bool Load3DS(const std::string& path, Mesh& outMesh, bool applyObjectLocalTransf
     std::unordered_map<std::string, std::array<float, 3>> materials;
     FaceColorAccum colorAccum;
     std::string textureFilename;
-    const fs::path modelPath = fs::u8path(path);
+    const fs::path modelPath = PathUtils::PathFromUtf8(path);
     const fs::path modelDir = modelPath.has_parent_path() ? modelPath.parent_path() : fs::path();
 
     while(file.tellg() < rootEnd) {

--- a/viewer3d/loaderglb.cpp
+++ b/viewer3d/loaderglb.cpp
@@ -16,6 +16,7 @@
  * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
  */
 #include "loaderglb.h"
+#include "filesystem_path_utils.h"
 #include "consolepanel.h"
 #include "json.hpp"
 #include "matrixutils.h"
@@ -407,7 +408,7 @@ bool LoadGLB(const std::string& path, Mesh& outMesh, std::string* error)
                 if (!wxImg.LoadFile(stream, resolveBitmapType(image)))
                     return false;
             } else {
-                const fs::path uriPath = glbDir / fs::u8path(uri);
+                const fs::path uriPath = glbDir / PathUtils::PathFromUtf8(uri);
                 if (!wxImg.LoadFile(wxString::FromUTF8(uriPath.string())))
                     return false;
             }

--- a/viewer3d/resources/mesh_processing.cpp
+++ b/viewer3d/resources/mesh_processing.cpp
@@ -1,4 +1,5 @@
 #include "mesh_processing.h"
+#include "filesystem_path_utils.h"
 
 #include <algorithm>
 #include <cstdint>
@@ -70,7 +71,7 @@ std::string BuildCachePath(const std::string &sourcePath) {
 
 int64_t GetSourceTimestampNs(const std::string &sourcePath) {
   std::error_code ec;
-  const fs::file_time_type writeTime = fs::last_write_time(fs::u8path(sourcePath), ec);
+  const fs::file_time_type writeTime = fs::last_write_time(PathUtils::PathFromUtf8(sourcePath), ec);
   if (ec)
     return -1;
   return std::chrono::duration_cast<std::chrono::nanoseconds>(writeTime.time_since_epoch())

--- a/viewer3d/resources/resource_path_search.cpp
+++ b/viewer3d/resources/resource_path_search.cpp
@@ -1,4 +1,5 @@
 #include "resource_path_search.h"
+#include "filesystem_path_utils.h"
 
 #include "projectutils.h"
 
@@ -142,7 +143,7 @@ BoundedRecursiveSearchResult FindFileRecursiveBounded(
     return result;
   }
 
-  const fs::path root = fs::u8path(baseDir);
+  const fs::path root = PathUtils::PathFromUtf8(baseDir);
   if (IsSkippedRecursiveSearchRoot(root, &result.skipReason)) {
     result.skipped = true;
     return result;
@@ -215,12 +216,12 @@ BoundedRecursiveSearchResult FindFileRecursiveBounded(
 std::vector<fs::path> BuildRecursiveFallbackRoots(const std::string &base) {
   std::vector<fs::path> roots;
   if (!base.empty())
-    roots.push_back(fs::u8path(base));
+    roots.push_back(PathUtils::PathFromUtf8(base));
 
   const std::array<std::string, 3> librarySubdirs = {
       "fixtures", "trusses", "scene_objects"};
   for (const std::string &subdir : librarySubdirs) {
-    const fs::path root = fs::u8path(ProjectUtils::GetDefaultLibraryPath(subdir));
+    const fs::path root = PathUtils::PathFromUtf8(ProjectUtils::GetDefaultLibraryPath(subdir));
     if (!root.empty() && !ContainsPath(roots, root))
       roots.push_back(root);
   }

--- a/viewer3d/resources/resource_sync_system.cpp
+++ b/viewer3d/resources/resource_sync_system.cpp
@@ -1,4 +1,5 @@
 #include "resource_sync_system.h"
+#include "filesystem_path_utils.h"
 #include "mesh_processing.h"
 #include "resource_path_search.h"
 
@@ -48,7 +49,7 @@ PathExistenceResult CheckPathExistsNoThrow(const fs::path &path) {
 // Checks whether a UTF-8 filesystem path exists without throwing on malformed paths.
 PathExistenceResult CheckUtf8PathExistsNoThrow(const std::string &path) {
   try {
-    return CheckPathExistsNoThrow(fs::u8path(path));
+    return CheckPathExistsNoThrow(PathUtils::PathFromUtf8(path));
   } catch (const fs::filesystem_error &ex) {
     PathExistenceResult result;
     result.error = ex.code();
@@ -335,7 +336,7 @@ std::string ResolveFromLibrarySuffix(
   if (!installedLibraryRoot.empty() && !ContainsPath(roots, installedLibraryRoot))
     roots.push_back(installedLibraryRoot);
 
-  const fs::path writableLibraryRoot = fs::u8path(ProjectUtils::GetWritableLibraryPath(""));
+  const fs::path writableLibraryRoot = PathUtils::PathFromUtf8(ProjectUtils::GetWritableLibraryPath(""));
   if (!writableLibraryRoot.empty() && !ContainsPath(roots, writableLibraryRoot))
     roots.push_back(writableLibraryRoot);
 
@@ -366,7 +367,7 @@ std::string ResolveFromDefaultLibrary(
   const std::array<std::string, 3> librarySubdirs = {
       "fixtures", "trusses", "scene_objects"};
   for (const std::string &subdir : librarySubdirs) {
-    const fs::path root = fs::u8path(ProjectUtils::GetDefaultLibraryPath(subdir));
+    const fs::path root = PathUtils::PathFromUtf8(ProjectUtils::GetDefaultLibraryPath(subdir));
     const std::string directResolved =
         ResolveExistingPath(root / fileName, diagnostics);
     if (!directResolved.empty())
@@ -443,7 +444,7 @@ std::string ResolveGdtfPath(
     if (!relativeResolved.empty())
       return relativeResolved;
 
-    fs::path utf8AbsoluteCandidate = fs::u8path(variant);
+    fs::path utf8AbsoluteCandidate = PathUtils::PathFromUtf8(variant);
     if (utf8AbsoluteCandidate.is_absolute()) {
       const std::string utf8AbsoluteResolved =
           ResolveExistingPath(utf8AbsoluteCandidate, diagnostics);


### PR DESCRIPTION
### Motivation
- Xcode/libc++ deprecated `std::filesystem::u8path` in C++20 leading to macOS CI failures and warnings during the compile step; repository-wide uses must be migrated to avoid platform-specific deprecation issues. 
- The macOS installer workflow relied on the floating `macos-latest` label which can cause unplanned runner migrations; CI should explicitly target a current-generation runner and emit early diagnostics for easier triage. 
- Centralize UTF-8 ↔ filesystem path conversions to avoid duplicated logic and platform-specific conditionals scattered throughout the codebase.

### Description
- Added a small, cross-platform path helper `PathUtils::PathFromUtf8(...)` and `PathUtils::PathToUtf8(...)` in `core/filesystem_path_utils.h` / `core/filesystem_path_utils.cpp` and registered the `.cpp` in `core/CMakeLists.txt`. The helper preserves the prior behavior: uses narrow UTF-8 paths on POSIX and converts UTF-8→wide / wide→UTF-8 on Windows via Win32 APIs. 
- Replaced all active `std::filesystem::u8path` / `fs::u8path` usages across production code and tests with `PathUtils::PathFromUtf8(...)` (repository search shows no remaining active `u8path` occurrences). Total replaced occurrences: 160 (diff count). 
- Updated `viewer3d/gdtfloader.cpp` and other affected loading code to use the shared helper while preserving existing GLB/3DS fallback logic and all runtime behavior. No functional behavior, file formats, resource layout, or packaging semantics were changed. 
- Updated the macOS installer workflow `.github/workflows/macos-installer.yml` to use `runs-on: macos-26`, added an early toolchain diagnostics step (`sw_vers`, `uname -m`, `xcodebuild -version`, `clang++ --version`, `cmake --version`, `ninja --version || true`), made the vcpkg cache key runner-generation specific, and aligned `dylibbundler` search paths to `VCPKG_INSTALLED/$VCPKG_TRIPLET/{lib,tools}`. A short YAML comment explains the explicit runner label. 
- Updated `docs/release-notes-draft.md` with an Internal changes entry documenting the UTF-8 path handling and macOS CI pinning. 

### Testing
- Repository-wide search for `u8path`: `rg -n "u8path"` returned no active usages after the change (success). 
- Syntax check: `g++ -std=c++20 -Icore -fsyntax-only core/filesystem_path_utils.cpp` ran successfully (success). 
- Style/checks: `git diff --check` returned clean (success). 
- Mandatory AGENTS checks: `bash tests/check_perastage_tree_modules.sh && bash tests/check_no_configmanager_get_in_gui.sh` passed (success). 
- CMake configure: `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` was attempted locally but failed in this Linux environment due to missing wxWidgets (local configure blocked; unrelated to the u8path migration). 
- DMG/build validation: the macOS DMG build and codesign/otool validations were not possible locally because this environment is not macOS; the workflow still contains staged-app, symbols, DMG build, DMG validation, codesign verification, and otool dependency checks unchanged (DMG validation cannot be confirmed here). 

Notes: The pasted Actions fragment showed deprecation warnings referencing `u8path`; the full Actions log with the actual `error:` line was not available from this environment, so I performed a repository-wide migration of `u8path` usages rather than assuming a single-file fix. After the migration, no remaining `u8path` calls remain and CMake/configure ran until it hit a platform/tooling limitation (missing wxWidgets) locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d899dac408324ab393cbd2f2125df)