### PR TITLE
Fix macOS GDTF timestamp cache key build and add macOS build diagnostics

### DIFF
--- a/.github/workflows/macos-installer.yml
+++ b/.github/workflows/macos-installer.yml
@@ -124,7 +124,36 @@ jobs:
       # ── 9. Build project ────────────────────────────────────────────────────
       - name: Build project
         run: |
-          cmake --build build --config Release --parallel 2 --verbose
+          set -o pipefail
+          mkdir -p build
+          cmake --build build --config Release --parallel 1 --verbose 2>&1 | tee build/macos-build.log
+          build_status=${PIPESTATUS[0]}
+          if [ "$build_status" -ne 0 ]; then
+            echo "::group::Focused compiler diagnostics"
+            first_error_line="$(grep -n -m 1 -E '(^|[:[:space:]])error:' build/macos-build.log | cut -d: -f1 || true)"
+            if [ -n "$first_error_line" ]; then
+              start_line=$(( first_error_line > 40 ? first_error_line - 40 : 1 ))
+              end_line=$(( first_error_line + 120 ))
+              sed -n "${start_line},${end_line}p" build/macos-build.log
+            else
+              echo "No compiler error marker was found in build/macos-build.log."
+              tail -n 200 build/macos-build.log
+            fi
+            echo "::endgroup::"
+            exit "$build_status"
+          fi
+
+      - name: Upload macOS build diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Perastage-macos-build-diagnostics
+          if-no-files-found: warn
+          path: |
+            build/macos-build.log
+            build/CMakeFiles/CMakeOutput.log
+            build/CMakeFiles/CMakeError.log
+            .vcpkg-cache/**/*.log
 
       # ── 10. Stage distribution folder ────────────────────────────────────────
       - name: Stage distribution folder

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -56,6 +56,8 @@ Changes since `v1.3.0`.
 
 ## Internal changes
 
+- Improved macOS installer build diagnostics by saving full compiler logs, showing focused error context on failure, and uploading related CMake and vcpkg logs for maintainers.
+- Restored macOS installer build compatibility with newer Xcode toolchains by making GDTF metadata cache timestamp keys use an explicit portable duration representation.
 - Updated UTF-8 filesystem path handling across the codebase and pinned the macOS installer workflow to an explicit current-generation runner for more predictable CI builds.
 - Restored macOS installer build compatibility with Xcode 16.4 by avoiding deprecated filesystem path construction during GDTF model loading.
 - Improved installer build reliability by allowing the Windows packaging workflow to use the current Visual Studio generator when available, generating Windows Release symbol files for CI symbol archives, using a dynamic modern Windows installer wizard style, and keeping macOS command-bar float parsing portable across libc++ versions.

--- a/viewer3d/gdtfloader.cpp
+++ b/viewer3d/gdtfloader.cpp
@@ -1069,14 +1069,23 @@ static std::string ParseModelColor(tinyxml2::XMLElement* ft)
     return os.str();
 }
 
+// Converts a filesystem timestamp to a portable nanosecond string for cache keys.
+static std::string FileTimestampToCacheKeyString(const fs::file_time_type& timestamp)
+{
+    const auto timestampNs = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        timestamp.time_since_epoch());
+    const auto timestampValue = static_cast<std::int64_t>(timestampNs.count());
+    return std::to_string(timestampValue);
+}
+
 // Builds the metadata key used to reuse hashes for unchanged GDTF archive files.
 static std::string BuildGdtfHashCacheKey(const fs::path& absPath,
                                          const fs::file_time_type& timestamp,
                                          uintmax_t fileSize)
 {
     std::ostringstream oss;
-    oss << absPath.string() << '|'
-        << timestamp.time_since_epoch().count() << '|'
+    oss << PathUtils::PathToUtf8(absPath) << '|'
+        << FileTimestampToCacheKeyString(timestamp) << '|'
         << fileSize;
     return oss.str();
 }


### PR DESCRIPTION
### Motivation
- CI macOS builds on Xcode 26 failed when compiling `viewer3d/gdtfloader.cpp` due to streaming a non-portable `time_since_epoch().count()` operand into an `ostringstream`, so a portable timestamp representation is required while preserving the existing metadata hash cache intent.
- Improve macOS workflow diagnostics so full compiler output is captured, focused error context is printed on failure, and maintainers can retrieve complete build/CMake/vcpkg logs for faster triage.

### Description
- Added a portable helper `FileTimestampToCacheKeyString(const fs::file_time_type&)` that normalizes `file_time_type` to `nanoseconds`, casts to `std::int64_t`, and returns a `std::string`, with a one-line comment above the function. (`viewer3d/gdtfloader.cpp`).
- Rewrote `BuildGdtfHashCacheKey(...)` to call `FileTimestampToCacheKeyString(...)` and to convert paths via `PathUtils::PathToUtf8(...)` instead of streaming `fs::path` or raw `count()` values, preserving the cache key composition of path + timestamp + size. (`viewer3d/gdtfloader.cpp`).
- Updated the macOS installer workflow to run the build serially (`--parallel 1`), capture the full build output with `tee` to `build/macos-build.log`, preserve and check the real exit code, print a focused compiler-error context around the first `error:` if the build fails, and upload build/CMake/vcpkg logs on failure as an artifact named `Perastage-macos-build-diagnostics` (failure-only). (`.github/workflows/macos-installer.yml`).
- Kept existing dylibbundler vcpkg search paths and the pinned `runs-on: macos-26` runner; updated `docs/release-notes-draft.md` with notes about the diagnostic and compatibility improvements. (`.github/workflows/macos-installer.yml`, `docs/release-notes-draft.md`).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` which returned `OK`. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` which returned `OK`.
- Confirmed with repository searches that no project source uses `u8path` and that `viewer3d/gdtfloader.cpp` no longer streams `timestamp.time_since_epoch().count()` (search/verification succeeded).
- Verified the workflow changes include `runs-on: macos-26`, `--parallel 1`, the `dylibbundler` vcpkg search paths, and the new `Perastage-macos-build-diagnostics` artifact configuration (search/verification succeeded).
- Attempted local CMake configure with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`, which exercised dependency discovery but could not complete due to missing `wxWidgets` in this environment (configure blocked, not a code regression).
- Ran `git diff --check` and repository checks after the edits with no whitespace or diff errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d9158dc2c8324abb6722a1d617e41)