### PR TITLE
Make filesystem timestamp cache keys portable and improve macOS build diagnostics

### DIFF
--- a/.github/workflows/macos-installer.yml
+++ b/.github/workflows/macos-installer.yml
@@ -124,20 +124,21 @@ jobs:
       # ── 9. Build project ────────────────────────────────────────────────────
       - name: Build project
         run: |
-          set -o pipefail
+          set -euo pipefail
+          BUILD_LOG="build/macos-build.log"
           mkdir -p build
-          cmake --build build --config Release --parallel 1 --verbose 2>&1 | tee build/macos-build.log
+          cmake --build build --config Release --parallel 1 --verbose 2>&1 | tee "$BUILD_LOG"
           build_status=${PIPESTATUS[0]}
           if [ "$build_status" -ne 0 ]; then
             echo "::group::Focused compiler diagnostics"
-            first_error_line="$(grep -n -m 1 -E '(^|[:[:space:]])error:' build/macos-build.log | cut -d: -f1 || true)"
+            first_error_line="$(grep -n -m 1 -E '(^|[:[:space:]])error:' "$BUILD_LOG" | cut -d: -f1 || true)"
             if [ -n "$first_error_line" ]; then
               start_line=$(( first_error_line > 40 ? first_error_line - 40 : 1 ))
               end_line=$(( first_error_line + 120 ))
-              sed -n "${start_line},${end_line}p" build/macos-build.log
+              sed -n "${start_line},${end_line}p" "$BUILD_LOG"
             else
-              echo "No compiler error marker was found in build/macos-build.log."
-              tail -n 200 build/macos-build.log
+              echo "No compiler error marker was found in $BUILD_LOG."
+              tail -n 200 "$BUILD_LOG"
             fi
             echo "::endgroup::"
             exit "$build_status"
@@ -154,6 +155,7 @@ jobs:
             build/CMakeFiles/CMakeOutput.log
             build/CMakeFiles/CMakeError.log
             .vcpkg-cache/**/*.log
+            vcpkg/buildtrees/**/*.log
 
       # ── 10. Stage distribution folder ────────────────────────────────────────
       - name: Stage distribution folder

--- a/core/trussloader.cpp
+++ b/core/trussloader.cpp
@@ -28,7 +28,9 @@
 #include <wx/zipstrm.h>
 
 #include <algorithm>
+#include <chrono>
 #include <cctype>
+#include <cstdint>
 #include <filesystem>
 #include <functional>
 #include <fstream>
@@ -46,6 +48,14 @@ constexpr const char *kSupportedTrussFileDialogWildcard =
 static std::string ToUtf8String(const fs::path &path) {
   std::u8string utf8 = path.u8string();
   return std::string(utf8.begin(), utf8.end());
+}
+
+// Converts a filesystem timestamp to a portable nanosecond string for cache keys.
+static std::string FileTimestampToCacheKeyString(const fs::file_time_type &timestamp) {
+  const auto timestampNs =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(timestamp.time_since_epoch());
+  const auto timestampValue = static_cast<std::int64_t>(timestampNs.count());
+  return std::to_string(timestampValue);
 }
 
 // Converts a UTF-8 string into a filesystem path without losing non-ASCII characters.
@@ -188,12 +198,11 @@ static fs::path BuildGdtfExtractionCacheDir(const fs::path &gdtfPath) {
   if (ec)
     normalized = gdtfPath;
 
-  std::string key = normalized.generic_string();
+  std::string key = PathUtils::PathToUtf8(normalized);
   std::error_code timeEc;
   const auto writeTime = fs::last_write_time(gdtfPath, timeEc);
   if (!timeEc)
-    key += "#" +
-           std::to_string(static_cast<long long>(writeTime.time_since_epoch().count()));
+    key += "#" + FileTimestampToCacheKeyString(writeTime);
 
   const std::size_t hashValue = std::hash<std::string>{}(key);
   fs::path cacheRoot = fs::temp_directory_path() / "perastage-truss-gdtf-cache";

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -57,7 +57,7 @@ Changes since `v1.3.0`.
 ## Internal changes
 
 - Improved macOS installer build diagnostics by saving full compiler logs, showing focused error context on failure, and uploading related CMake and vcpkg logs for maintainers.
-- Restored macOS installer build compatibility with newer Xcode toolchains by making GDTF metadata cache timestamp keys use an explicit portable duration representation.
+- Restored macOS installer build compatibility with newer Xcode toolchains by making filesystem timestamp cache keys use explicit portable duration representations.
 - Updated UTF-8 filesystem path handling across the codebase and pinned the macOS installer workflow to an explicit current-generation runner for more predictable CI builds.
 - Restored macOS installer build compatibility with Xcode 16.4 by avoiding deprecated filesystem path construction during GDTF model loading.
 - Improved installer build reliability by allowing the Windows packaging workflow to use the current Visual Studio generator when available, generating Windows Release symbol files for CI symbol archives, using a dynamic modern Windows installer wizard style, and keeping macOS command-bar float parsing portable across libc++ versions.


### PR DESCRIPTION
### Motivation
- Fix macOS Xcode 26 libc++ compile errors caused by streaming unstreamable `file_time_type::duration::count()` values into `std::ostringstream` while preserving the GDTF metadata hash cache behavior. 
- Improve GitHub Actions macOS installer diagnostics so full compiler logs are preserved and focused error context is shown when builds fail. 

### Description
- Replace direct streaming of `timestamp.time_since_epoch().count()` with a helper `FileTimestampToCacheKeyString(...)` that converts `fs::file_time_type` to `std::chrono::nanoseconds`, casts the count to a stable `int64_t`, and returns `std::to_string(...)` for use in cache keys; this is used in `viewer3d/gdtfloader.cpp` to build the GDTF metadata-keyed cache key without changing cache intent or behavior. 
- Apply the same portable timestamp conversion and use `PathUtils::PathToUtf8(...)` for normalized path text in `core/trussloader.cpp` for the GDTF extraction cache key. 
- Tighten `.github/workflows/macos-installer.yml` build step: enable `set -euo pipefail`, write the build output to a named log file via `tee`, keep `--parallel 1` to reduce interleaving, print a focused compiler error context around the first `error:` in the saved log on failure, and upload extra vcpkg build-tree logs (`vcpkg/buildtrees/**/*.log`) as diagnostics when the job fails. 
- Update `docs/release-notes-draft.md` to reflect the portability and diagnostics improvements. 
- Preserve all runtime behavior, the metadata-keyed GDTF hash cache, DMG naming, and staged artifact names/layout. 

### Testing
- Ran mandatory repository checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both succeeded. 
- Verified there are no remaining project source uses of `std::filesystem::u8path`, `fs::u8path`, or `u8path(...)` via repository search. 
- Verified `viewer3d/gdtfloader.cpp` no longer streams `timestamp.time_since_epoch().count()` and uses the portable helper instead. 
- Verified workflow changes: `runs-on: macos-26`, `dylibbundler` vcpkg `lib`/`tools` search paths, `--parallel 1`, and `build/macos-build.log` usage are present in `.github/workflows/macos-installer.yml`. 
- Ran `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` locally to validate configuration; configure failed in this environment due to missing system `wxWidgets` (local container lacks the system dependency), so full local build was not executed. 
- All automated search-and-check validations (grep checks) used in validation succeeded; changes were committed as a single logical update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dacc58bb0832489e20871828d846f)