### PR TITLE
Add project-persistent free selection movement toggle

### DIFF
--- a/core/selection_movement_settings.h
+++ b/core/selection_movement_settings.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "configmanager.h"
+
+namespace selection_movement_settings {
+
+constexpr const char *kAxisConstrainedMovementConfigKey =
+    "selection_axis_constrained_movement";
+
+// Returns whether selection dragging should stay constrained to axes.
+inline bool IsAxisConstrainedMovementEnabled(const ConfigManager &cfg) {
+  const auto value = cfg.GetValue(kAxisConstrainedMovementConfigKey);
+  return !value || *value != "0";
+}
+
+// Persists whether selection dragging should stay constrained to axes.
+inline void SetAxisConstrainedMovementEnabled(ConfigManager &cfg, bool enabled) {
+  cfg.SetValue(kAxisConstrainedMovementConfigKey, enabled ? "1" : "0");
+}
+
+} // namespace selection_movement_settings

--- a/docs/features.md
+++ b/docs/features.md
@@ -101,6 +101,7 @@ Additional safeguards include:
 
 - OpenGL-based viewer with orbit, pan, zoom, and preset camera views.
 - Selection flows integrate with scene tables and command operations.
+- The viewport toolbar includes an axis-lock toggle for dragged scene selections. It is enabled by default for axis-constrained moves; disabling it stores the project setting and allows Blender-style free dragging on a plane parallel to the 3D camera view.
 - Context menu includes **Render style** with these options:
   - **Standard** for general-purpose scene reading.
   - **Sketch mode** for high-readability geometry outlines.
@@ -114,6 +115,7 @@ Additional safeguards include:
 ### 2D Viewer
 
 - Top-down plan visualization with configurable grid and labels.
+- The shared viewport axis-lock toggle also controls 2D selection dragging: enabled keeps movement constrained to one screen axis, while disabled allows free movement across both axes in the active 2D plane.
 - Supports vector draw-command capture for downstream document/export workflows.
 
 ### Layout system

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -6,6 +6,7 @@ Changes since `v1.3.0`.
 
 ## New features
 
+- Added a project-persistent Axis Lock toolbar toggle for selection dragging, enabled by default for axis-constrained moves and allowing free 2D movement plus Blender-style view-plane movement in 3D when disabled.
 - Expanded basic primitive creation and editing for spheres, cubes, and cylinders with editable names, project-persistent default dimensions, default load/save buttons, and richer edit controls for position and rotation.
 - Added Edit menu Group and Ungroup commands with `Ctrl+G` and `Ctrl+U` shortcuts for cross-table scene selections, preserving object placement and hang-position assignments while using MVR-compatible GroupObject hierarchy.
 - Added Help menu actions to open the local logs folder and export a manual diagnostic report for troubleshooting.

--- a/docs/views.md
+++ b/docs/views.md
@@ -14,6 +14,7 @@ Typical checks:
 - Group selection while clicking scene items: clicking a grouped member selects its full group across related tables.
 - General scene structure before export.
 - Dragging feedback: while moving scene elements in 2D or with the 3D gizmo, the bottom X/Y/Z status readout shows the dragged insertion-point position with a highlighted font color until the mouse is released.
+- Axis lock: the **Axis Lock** toolbar toggle, shown with the Move 3D icon, is enabled by default and stores its state in the project. When disabled, 3D selection dragging follows a plane parallel to the current camera view through the selection origin, similar to Blender free move.
 
 ## 2D view and layouts
 
@@ -22,6 +23,7 @@ Use 2D when you need plan-oriented validation and output.
 Typical checks:
 
 - Top/plan readability.
+- Free 2D selection movement when **Axis Lock** is disabled; when enabled, dragged selections remain constrained to the dominant horizontal or vertical movement axis.
 - Layout alignment and coverage.
 - Print-ready preparation.
 

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -383,6 +383,7 @@ EVT_MENU(ID_View_Viewport_Front, MainWindow::OnViewportFrontView)
 EVT_MENU(ID_View_Viewport_Side, MainWindow::OnViewportSideView)
 EVT_MENU(ID_View_Viewport_SelectTool, MainWindow::OnViewportSelectTool)
 EVT_MENU(ID_View_Viewport_MeasureTool, MainWindow::OnViewportMeasureTool)
+EVT_MENU(ID_View_Viewport_AxisConstraint, MainWindow::OnViewportAxisConstraint)
 EVT_MENU(ID_View_Layout_2DView, MainWindow::OnLayoutAdd2DView)
 EVT_MENU(ID_View_Layout_Legend, MainWindow::OnLayoutAddLegend)
 EVT_MENU(ID_View_Layout_EventTable, MainWindow::OnLayoutAddEventTable)
@@ -1184,6 +1185,7 @@ void MainWindow::UpdateToolBarAvailability() {
   if (layoutViewsToolBar) {
     layoutViewsToolBar->EnableTool(ID_View_Viewport_SelectTool, enableViewportTools);
     layoutViewsToolBar->EnableTool(ID_View_Viewport_MeasureTool, enableViewportTools);
+    layoutViewsToolBar->EnableTool(ID_View_Viewport_AxisConstraint, enableViewportTools);
     layoutViewsToolBar->SetToolShortHelp(
         ID_View_Viewport_SelectTool,
         enableViewportTools ? "Switch to standard selection mode"
@@ -1191,6 +1193,10 @@ void MainWindow::UpdateToolBarAvailability() {
     layoutViewsToolBar->SetToolShortHelp(
         ID_View_Viewport_MeasureTool,
         enableViewportTools ? "Toggle center-to-center measure tool"
+                            : "Disabled while editing Layout views");
+    layoutViewsToolBar->SetToolShortHelp(
+        ID_View_Viewport_AxisConstraint,
+        enableViewportTools ? "Toggle axis-constrained selection movement"
                             : "Disabled while editing Layout views");
     layoutViewsToolBar->Refresh();
   }

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -85,6 +85,7 @@ public:
   void FocusConsoleForQuickCommand(const wxString &prefill);
   bool ApplyShortcutDecision(const gui::ShortcutExecutionDecision &decision);
   void SyncViewportToolToggleState(bool measureEnabled);
+  void SyncAxisConstraintToolToggleState();
   void Ensure2DViewportAvailable();
   Viewer2DPanel *GetLayoutCapturePanel() const;
   Viewer2DOffscreenRenderer *GetOffscreenRenderer();
@@ -213,6 +214,7 @@ private:
   void OnViewportSideView(wxCommandEvent &event);
   void OnViewportSelectTool(wxCommandEvent &event);
   void OnViewportMeasureTool(wxCommandEvent &event);
+  void OnViewportAxisConstraint(wxCommandEvent &event);
 
   void OnUndo(wxCommandEvent &event);           // Undo action placeholder
   void OnRedo(wxCommandEvent &event);           // Redo action placeholder

--- a/gui/mainwindow/ids/tools_ids.h
+++ b/gui/mainwindow/ids/tools_ids.h
@@ -2,7 +2,7 @@
 
 #include "view_ids.h"
 
-constexpr int ID_Tools_DownloadGdtf = ID_View_Viewport_MeasureTool + 1;
+constexpr int ID_Tools_DownloadGdtf = ID_View_Viewport_AxisConstraint + 1;
 constexpr int ID_Tools_EditDictionaries = ID_Tools_DownloadGdtf + 1;
 constexpr int ID_Tools_ImportRiderText = ID_Tools_EditDictionaries + 1;
 constexpr int ID_Tools_DistributeHoistWeights =

--- a/gui/mainwindow/ids/view_ids.h
+++ b/gui/mainwindow/ids/view_ids.h
@@ -24,3 +24,4 @@ constexpr int ID_View_Viewport_Front = ID_View_Viewport_Top + 1;
 constexpr int ID_View_Viewport_Side = ID_View_Viewport_Front + 1;
 constexpr int ID_View_Viewport_SelectTool = ID_View_Viewport_Side + 1;
 constexpr int ID_View_Viewport_MeasureTool = ID_View_Viewport_SelectTool + 1;
+constexpr int ID_View_Viewport_AxisConstraint = ID_View_Viewport_MeasureTool + 1;

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -97,6 +97,7 @@
 #include "update/update_notification_dialog.h"
 #include "viewer2dpanel.h"
 #include "viewer3dpanel.h"
+#include "selection_movement_settings.h"
 
 // Builds and registers the main application toolbars.
 void MainWindow::CreateToolBars() {
@@ -233,8 +234,18 @@ void MainWindow::CreateToolBars() {
                                               wxART_MISSING_IMAGE),
                               "Toggle center-to-center measure tool",
                               wxITEM_CHECK);
+  layoutViewsToolBar->AddTool(ID_View_Viewport_AxisConstraint, "Axis Lock",
+                              loadToolbarIcon("move-3d",
+                                              wxART_MISSING_IMAGE),
+                              "Toggle axis-constrained selection movement",
+                              wxITEM_CHECK);
   layoutViewsToolBar->ToggleTool(ID_View_Viewport_SelectTool, true);
   layoutViewsToolBar->ToggleTool(ID_View_Viewport_MeasureTool, false);
+  layoutViewsToolBar->ToggleTool(
+      ID_View_Viewport_AxisConstraint,
+      GetDefaultGuiConfigServices().Preferences().GetValue(
+          selection_movement_settings::kAxisConstrainedMovementConfigKey) !=
+          "0");
   layoutViewsToolBar->Realize();
   auiManager->AddPane(
       layoutViewsToolBar, wxAuiPaneInfo()

--- a/gui/mainwindow_view_shortcuts.cpp
+++ b/gui/mainwindow_view_shortcuts.cpp
@@ -2,6 +2,8 @@
 
 #include "viewer2drenderpanel.h"
 #include "viewer3dpanel.h"
+#include "selection_movement_settings.h"
+#include "guiconfigservices.h"
 
 namespace {
 
@@ -44,7 +46,19 @@ void MainWindow::SyncViewportToolToggleState(bool measureEnabled) {
     return;
   layoutViewsToolBar->ToggleTool(ID_View_Viewport_SelectTool, !measureEnabled);
   layoutViewsToolBar->ToggleTool(ID_View_Viewport_MeasureTool, measureEnabled);
+  SyncAxisConstraintToolToggleState();
   layoutViewsToolBar->Refresh();
+}
+
+// Synchronizes the axis-constrained movement toolbar toggle with project settings.
+void MainWindow::SyncAxisConstraintToolToggleState() {
+  if (!layoutViewsToolBar)
+    return;
+  layoutViewsToolBar->ToggleTool(
+      ID_View_Viewport_AxisConstraint,
+      GetDefaultGuiConfigServices().Preferences().GetValue(
+          selection_movement_settings::kAxisConstrainedMovementConfigKey) !=
+          "0");
 }
 
 // Switches the viewport interaction back to standard selection mode.
@@ -69,6 +83,18 @@ void MainWindow::OnViewportMeasureTool(wxCommandEvent &WXUNUSED(event)) {
   SyncViewportToolToggleState(enableMeasure);
 }
 
+// Toggles project-level axis-constrained selection movement.
+void MainWindow::OnViewportAxisConstraint(wxCommandEvent &WXUNUSED(event)) {
+  auto &preferences = GetDefaultGuiConfigServices().Preferences();
+  const bool axisConstraintEnabled =
+      preferences.GetValue(
+          selection_movement_settings::kAxisConstrainedMovementConfigKey) !=
+      "0";
+  preferences.SetValue(
+      selection_movement_settings::kAxisConstrainedMovementConfigKey,
+      axisConstraintEnabled ? "0" : "1");
+  SyncAxisConstraintToolToggleState();
+}
 
 bool MainWindow::ApplyFitShortcut() {
   const wxWindow *focusedWindow = wxWindow::FindFocus();

--- a/resources/icons/icons-usage.json
+++ b/resources/icons/icons-usage.json
@@ -55,6 +55,12 @@
       "group": "LayoutViewsToolbar"
     },
     {
+      "name": "Axis Lock",
+      "icon": "outline/move-3d.svg",
+      "description": "Toggles axis-constrained selection movement in the 2D and 3D viewports.",
+      "group": "LayoutViewsToolbar"
+    },
+    {
       "name": "Layout 2D View",
       "icon": "outline/panel-top-bottom-dashed.svg",
       "description": "Toggles or applies the 2D view layout.",

--- a/resources/icons/outline/move-3d.svg
+++ b/resources/icons/outline/move-3d.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M5 3v16h16" />
+  <path d="m5 19 6-6" />
+  <path d="m2 6 3-3 3 3" />
+  <path d="m18 16 3 3-3 3" />
+</svg>

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -44,6 +44,7 @@
 #include "mainwindow.h"
 #include "editable_focus_utils.h"
 #include "configmanager.h"
+#include "selection_movement_settings.h"
 #include "scene_grouping.h"
 #include "canvas2d.h"
 #include "fixturetablepanel.h"
@@ -3055,19 +3056,24 @@ void Viewer2DPanel::OnMouseMove(wxMouseEvent &event) {
     int dy = pos.y - m_lastMousePos.y;
 
     if (dx != 0 || dy != 0) {
-      if (m_dragAxis == DragAxis::None) {
-        int absDx = std::abs(dx);
-        int absDy = std::abs(dy);
-        if (absDx >= 3 || absDy >= 3) {
-          m_dragAxis =
-              absDx >= absDy ? DragAxis::Horizontal : DragAxis::Vertical;
+      const bool axisConstrainedMovement =
+          selection_movement_settings::IsAxisConstrainedMovementEnabled(
+              ConfigManager::Get());
+      if (axisConstrainedMovement) {
+        if (m_dragAxis == DragAxis::None) {
+          int absDx = std::abs(dx);
+          int absDy = std::abs(dy);
+          if (absDx >= 3 || absDy >= 3) {
+            m_dragAxis =
+                absDx >= absDy ? DragAxis::Horizontal : DragAxis::Vertical;
+          }
         }
-      }
 
-      if (m_dragAxis == DragAxis::Horizontal)
-        dy = 0;
-      else if (m_dragAxis == DragAxis::Vertical)
-        dx = 0;
+        if (m_dragAxis == DragAxis::Horizontal)
+          dy = 0;
+        else if (m_dragAxis == DragAxis::Vertical)
+          dx = 0;
+      }
 
       if (dx != 0 || dy != 0) {
         float ppm = PIXELS_PER_METER * m_zoom;

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -50,6 +50,7 @@
 #include "scene_object_primitive_editing.h"
 #include "../gui/selection_origin_token.h"
 #include "configmanager.h"
+#include "selection_movement_settings.h"
 #include "scene_grouping.h"
 #include "fixturepatchdialog.h"
 #include "viewer2dpanel.h"
@@ -75,6 +76,7 @@
 #include <set>
 #include <cstdint>
 #include <utility>
+#include <limits>
 
 wxDEFINE_EVENT(wxEVT_VIEWER_REFRESH, wxThreadEvent);
 wxBEGIN_EVENT_TABLE(Viewer3DPanel, wxGLCanvas)
@@ -2465,6 +2467,76 @@ Viewer3DPanel::BuildProjectedDragAxes(const RenderSize& renderSize) const
     return axes;
 }
 
+
+// Projects the mouse position onto the active selection drag view plane.
+std::optional<std::array<float, 3>>
+Viewer3DPanel::ProjectMouseToSelectionDragViewPlane(
+    const wxPoint& mousePos, const RenderSize& renderSize) const
+{
+    if (!renderSize.IsValid())
+        return std::nullopt;
+
+    GLdouble modelview[16] = {};
+    GLdouble projection[16] = {};
+    GLint viewport[4] = {0, 0, 0, 0};
+    glGetDoublev(GL_MODELVIEW_MATRIX, modelview);
+    glGetDoublev(GL_PROJECTION_MATRIX, projection);
+    glGetIntegerv(GL_VIEWPORT, viewport);
+
+    const wxPoint framebufferPos = ToFramebufferPoint(
+        const_cast<Viewer3DPanel*>(this), mousePos);
+    const double winX = static_cast<double>(framebufferPos.x);
+    const double winY = static_cast<double>(renderSize.height - framebufferPos.y);
+
+    auto unproject = [&](double x, double y, double z) {
+        std::array<double, 3> point{0.0, 0.0, 0.0};
+        if (gluUnProject(x, y, z, modelview, projection, viewport, &point[0],
+                         &point[1], &point[2]) != GL_TRUE) {
+            point = {std::numeric_limits<double>::quiet_NaN(),
+                     std::numeric_limits<double>::quiet_NaN(),
+                     std::numeric_limits<double>::quiet_NaN()};
+        }
+        return point;
+    };
+
+    const auto nearPoint = unproject(winX, winY, 0.0);
+    const auto farPoint = unproject(winX, winY, 1.0);
+    const auto centerNear = unproject(viewport[0] + viewport[2] * 0.5,
+                                      viewport[1] + viewport[3] * 0.5, 0.0);
+    const auto centerFar = unproject(viewport[0] + viewport[2] * 0.5,
+                                     viewport[1] + viewport[3] * 0.5, 1.0);
+    for (double value : {nearPoint[0], nearPoint[1], nearPoint[2], farPoint[0],
+                         farPoint[1], farPoint[2], centerNear[0], centerNear[1],
+                         centerNear[2], centerFar[0], centerFar[1], centerFar[2]}) {
+        if (!std::isfinite(value))
+            return std::nullopt;
+    }
+
+    const std::array<double, 3> rayDir{farPoint[0] - nearPoint[0],
+                                      farPoint[1] - nearPoint[1],
+                                      farPoint[2] - nearPoint[2]};
+    const std::array<double, 3> planeNormal{centerFar[0] - centerNear[0],
+                                           centerFar[1] - centerNear[1],
+                                           centerFar[2] - centerNear[2]};
+    const double denominator = rayDir[0] * planeNormal[0] +
+                               rayDir[1] * planeNormal[1] +
+                               rayDir[2] * planeNormal[2];
+    if (std::abs(denominator) <= 1e-12)
+        return std::nullopt;
+
+    const std::array<double, 3> planePoint{
+        m_selectionDragAnchorMeters[0], m_selectionDragAnchorMeters[1],
+        m_selectionDragAnchorMeters[2]};
+    const double t = ((planePoint[0] - nearPoint[0]) * planeNormal[0] +
+                      (planePoint[1] - nearPoint[1]) * planeNormal[1] +
+                      (planePoint[2] - nearPoint[2]) * planeNormal[2]) /
+                     denominator;
+    return std::array<float, 3>{
+        static_cast<float>(nearPoint[0] + rayDir[0] * t),
+        static_cast<float>(nearPoint[1] + rayDir[1] * t),
+        static_cast<float>(nearPoint[2] + rayDir[2] * t)};
+}
+
 // Applies a world-space delta to every object in the active selection drag.
 void Viewer3DPanel::ApplySelectionDragDelta(const std::array<float, 3>& deltaMeters)
 {
@@ -2648,24 +2720,42 @@ void Viewer3DPanel::OnMouseMove(wxMouseEvent& event)
             if (renderSize.IsValid() &&
                 TryBindGlContextForInteraction("OnMouseMove")) {
                 ApplyCameraMatrices(renderSize);
-                const auto projectedAxes = BuildProjectedDragAxes(renderSize);
-                if (m_selectionDragAxis == viewer3d::SelectionDragAxis::None) {
-                    m_selectionDragAxis = viewer3d::SelectDragAxisFromMouseDelta(
-                        dx, -dy, projectedAxes);
-                }
+                if (selection_movement_settings::IsAxisConstrainedMovementEnabled(
+                        ConfigManager::Get())) {
+                    const auto projectedAxes = BuildProjectedDragAxes(renderSize);
+                    if (m_selectionDragAxis == viewer3d::SelectionDragAxis::None) {
+                        m_selectionDragAxis = viewer3d::SelectDragAxisFromMouseDelta(
+                            dx, -dy, projectedAxes);
+                    }
 
-                const double axisDeltaMeters = viewer3d::ComputeDragMetersOnAxis(
-                    dx, -dy, m_selectionDragAxis, projectedAxes);
-                if (axisDeltaMeters != 0.0) {
-                    const auto axisVector =
-                        AxisVectorFromSelectionDragAxis(m_selectionDragAxis);
-                    const std::array<float, 3> worldDelta{
-                        axisVector[0] * static_cast<float>(axisDeltaMeters),
-                        axisVector[1] * static_cast<float>(axisDeltaMeters),
-                        axisVector[2] * static_cast<float>(axisDeltaMeters)};
-                    ApplySelectionDragDelta(worldDelta);
-                    m_selectionDragMoved = true;
-                    m_draggedSincePress = true;
+                    const double axisDeltaMeters = viewer3d::ComputeDragMetersOnAxis(
+                        dx, -dy, m_selectionDragAxis, projectedAxes);
+                    if (axisDeltaMeters != 0.0) {
+                        const auto axisVector =
+                            AxisVectorFromSelectionDragAxis(m_selectionDragAxis);
+                        const std::array<float, 3> worldDelta{
+                            axisVector[0] * static_cast<float>(axisDeltaMeters),
+                            axisVector[1] * static_cast<float>(axisDeltaMeters),
+                            axisVector[2] * static_cast<float>(axisDeltaMeters)};
+                        ApplySelectionDragDelta(worldDelta);
+                        m_selectionDragMoved = true;
+                        m_draggedSincePress = true;
+                    }
+                } else {
+                    const auto lastPoint = ProjectMouseToSelectionDragViewPlane(
+                        m_lastMousePos, renderSize);
+                    const auto currentPoint = ProjectMouseToSelectionDragViewPlane(
+                        pos, renderSize);
+                    if (lastPoint && currentPoint) {
+                        const std::array<float, 3> worldDelta{
+                            (*currentPoint)[0] - (*lastPoint)[0],
+                            (*currentPoint)[1] - (*lastPoint)[1],
+                            (*currentPoint)[2] - (*lastPoint)[2]};
+                        ApplySelectionDragDelta(worldDelta);
+                        m_selectionDragAxis = viewer3d::SelectionDragAxis::None;
+                        m_selectionDragMoved = true;
+                        m_draggedSincePress = true;
+                    }
                 }
             }
         }

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -156,6 +156,8 @@ private:
         const std::vector<std::string>& uuids, HoverTargetTable target) const;
     std::array<viewer3d::ProjectedAxis, 3> BuildProjectedDragAxes(
         const RenderSize& renderSize) const;
+    std::optional<std::array<float, 3>> ProjectMouseToSelectionDragViewPlane(
+        const wxPoint& mousePos, const RenderSize& renderSize) const;
     void ApplySelectionDragDelta(const std::array<float, 3>& deltaMeters);
     void UpdateSelectionDragStatusPosition();
     void FinalizeSelectionDrag();


### PR DESCRIPTION
### Motivation
- Allow users to choose between axis-constrained and free selection dragging in both 2D and 3D viewports, with the state persisted in the project and the toolbar exposing a toggle using the Lucide `move-3d` icon. 
- Keep the previous axis-locked behavior as the default while providing Blender-style view-plane dragging in 3D and free X/Y plane dragging in 2D when unlocked.

### Description
- Added a small project-level settings API in `core/selection_movement_settings.h` to read/write the `selection_axis_constrained_movement` key. 
- Introduced an Axis Lock toggle in the Layout Views toolbar using `resources/icons/outline/move-3d.svg` and wired the toolbar state via `GetDefaultGuiConfigServices().Preferences()` to avoid direct `ConfigManager::Get()` calls from `gui/` code. 
- 2D change: `viewer2dpanel.cpp` consults the new setting and preserves axis-constrained behavior when enabled, otherwise allows free two-axis dragging on the 2D plane. 
- 3D change: `viewer3dpanel` gains `ProjectMouseToSelectionDragViewPlane(...)` and logic to choose between existing axis-constrained movement and view-plane projection movement when the Axis Lock is disabled, applying the computed world delta to the dragged selection. 
- Updated IDs, toolbar creation, and shortcut syncing (`gui/mainwindow*`) and added the icon to `resources/icons/icons-usage.json`; documentation updated in `docs/features.md`, `docs/views.md`, and `docs/release-notes-draft.md`.

### Testing
- Ran `git diff --check` which produced no whitespace or patch issues and succeeded. 
- Ran `tests/check_perastage_tree_modules.sh` which succeeded. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` to ensure no direct `ConfigManager::Get()` calls in `gui/` and it succeeded. 
- Attempted a local CMake configure (`cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`) but it failed in this environment due to missing wxWidgets development packages, so a full build/test could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ed0624d948324b9a9585f60ab7b0b)