### PR TITLE
Add Magnet snapping workflow (core service, 2D toolbar toggle, tests)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -30,6 +30,7 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/layoutviewpresets.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/logger.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/markdown.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/magnet_snap.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/patchmanager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/pdftext.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/print/PageSetup.cpp

--- a/core/magnet_snap.cpp
+++ b/core/magnet_snap.cpp
@@ -31,6 +31,18 @@ std::array<float, 3> Add(const std::array<float, 3> &a,
   return {a[0] + b[0], a[1] + b[1], a[2] + b[2]};
 }
 
+
+// Returns the dot product for two millimeter vectors.
+float Dot(const std::array<float, 3> &a, const std::array<float, 3> &b) {
+  return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+}
+
+// Returns the vector difference between two points.
+std::array<float, 3> Subtract(const std::array<float, 3> &a,
+                              const std::array<float, 3> &b) {
+  return {a[0] - b[0], a[1] - b[1], a[2] - b[2]};
+}
+
 // Returns the vector length in millimeters.
 float Length(const std::array<float, 3> &v) {
   return std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
@@ -91,6 +103,47 @@ std::vector<Face> BuildFaces(const Bounds &bounds, bool trussPrimaryFaces) {
                      Scale(basis[axis], -1.0f)});
   }
   return faces;
+}
+
+
+// Finds the nearest point on an oriented bounds surface to a world-space point.
+std::array<float, 3> ClosestPointOnSurface(const Bounds &bounds,
+                                           const std::array<float, 3> &point) {
+  const std::array<std::array<float, 3>, 3> basis = {
+      Normalize(bounds.transform.u), Normalize(bounds.transform.v),
+      Normalize(bounds.transform.w)};
+  const auto relative = Subtract(point, bounds.transform.o);
+  std::array<float, 3> local{};
+  std::array<float, 3> halfSize{};
+  bool inside = true;
+  for (int axis = 0; axis < 3; ++axis) {
+    halfSize[axis] = bounds.size[axis] * 0.5f;
+    local[axis] = Dot(relative, basis[axis]);
+    if (local[axis] < -halfSize[axis] || local[axis] > halfSize[axis])
+      inside = false;
+    local[axis] = std::clamp(local[axis], -halfSize[axis], halfSize[axis]);
+  }
+
+  if (inside) {
+    int nearestAxis = 0;
+    float nearestDistance = std::numeric_limits<float>::max();
+    for (int axis = 0; axis < 3; ++axis) {
+      const float positiveDistance = halfSize[axis] - local[axis];
+      const float negativeDistance = local[axis] + halfSize[axis];
+      const float axisDistance = std::min(positiveDistance, negativeDistance);
+      if (axisDistance < nearestDistance) {
+        nearestDistance = axisDistance;
+        nearestAxis = axis;
+      }
+    }
+    local[nearestAxis] = local[nearestAxis] >= 0.0f ? halfSize[nearestAxis]
+                                                    : -halfSize[nearestAxis];
+  }
+
+  std::array<float, 3> closest = bounds.transform.o;
+  for (int axis = 0; axis < 3; ++axis)
+    closest = Add(closest, Scale(basis[axis], local[axis]));
+  return closest;
 }
 
 // Returns the source object transform target.
@@ -165,16 +218,29 @@ std::optional<SnapResult> FindSnap(const MvrScene &scene,
   }
 
   if (source.type == ObjectType::Fixture) {
-    const Face insertion{sourceBounds->transform.o, {0.0f, 0.0f, 1.0f}};
+    const std::array<float, 3> insertion = sourceBounds->transform.o;
     for (const auto &[uuid, truss] : scene.trusses) {
       const Bounds targetBounds{truss.transform,
                                 {std::max(truss.lengthMm, 1.0f),
                                  std::max(truss.widthMm, 1.0f),
                                  std::max(truss.heightMm, 1.0f)}};
-      for (const auto &targetFace : BuildFaces(targetBounds, false))
-        ConsiderFacePair(source, ObjectType::Truss, uuid,
-                         SnapKind::FixtureToTruss, insertion, targetFace,
-                         settings.thresholdMm, bestDistance, best);
+      const std::array<float, 3> closest =
+          ClosestPointOnSurface(targetBounds, insertion);
+      const std::array<float, 3> delta = Subtract(closest, insertion);
+      const float distance = Length(delta);
+      if (distance > settings.thresholdMm || distance >= bestDistance)
+        continue;
+      bestDistance = distance;
+      SnapResult result;
+      result.snapped = true;
+      result.kind = SnapKind::FixtureToTruss;
+      result.sourceUuid = source.uuid;
+      result.targetUuid = uuid;
+      result.sourceType = source.type;
+      result.targetType = ObjectType::Truss;
+      result.translationDeltaMm = delta;
+      result.needsTrussGrouping = false;
+      best = result;
     }
     return best;
   }

--- a/core/magnet_snap.cpp
+++ b/core/magnet_snap.cpp
@@ -1,0 +1,238 @@
+#include "magnet_snap.h"
+
+#include "matrixutils.h"
+#include "scene_grouping.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace magnet_snap {
+namespace {
+
+struct Bounds {
+  Matrix transform{};
+  std::array<float, 3> size{0.0f, 0.0f, 0.0f};
+};
+
+struct Face {
+  std::array<float, 3> center{};
+  std::array<float, 3> normal{};
+};
+
+// Returns the vector scaled by a scalar factor.
+std::array<float, 3> Scale(const std::array<float, 3> &v, float s) {
+  return {v[0] * s, v[1] * s, v[2] * s};
+}
+
+// Returns the sum of two vectors.
+std::array<float, 3> Add(const std::array<float, 3> &a,
+                         const std::array<float, 3> &b) {
+  return {a[0] + b[0], a[1] + b[1], a[2] + b[2]};
+}
+
+// Returns the vector length in millimeters.
+float Length(const std::array<float, 3> &v) {
+  return std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
+}
+
+// Returns a normalized vector or a safe fallback.
+std::array<float, 3> Normalize(const std::array<float, 3> &v) {
+  const float len = Length(v);
+  if (len <= 1e-5f)
+    return {0.0f, 0.0f, 0.0f};
+  return {v[0] / len, v[1] / len, v[2] / len};
+}
+
+// Returns transformed bounds for objects with known dimensions.
+std::optional<Bounds> GetBounds(const MvrScene &scene, ObjectType type,
+                                const std::string &uuid) {
+  if (type == ObjectType::Truss) {
+    auto it = scene.trusses.find(uuid);
+    if (it == scene.trusses.end())
+      return std::nullopt;
+    const Truss &t = it->second;
+    return Bounds{t.transform, {std::max(t.lengthMm, 1.0f),
+                                std::max(t.widthMm, 1.0f),
+                                std::max(t.heightMm, 1.0f)}};
+  }
+  if (type == ObjectType::Fixture) {
+    auto it = scene.fixtures.find(uuid);
+    if (it == scene.fixtures.end())
+      return std::nullopt;
+    return Bounds{it->second.transform, {1.0f, 1.0f, 1.0f}};
+  }
+  auto it = scene.sceneObjects.find(uuid);
+  if (it == scene.sceneObjects.end())
+    return std::nullopt;
+  return Bounds{it->second.transform, {1000.0f, 1000.0f, 1000.0f}};
+}
+
+// Builds oriented box face centers from object transform axes.
+std::vector<Face> BuildFaces(const Bounds &bounds, bool trussPrimaryFaces) {
+  std::vector<int> axes{0, 1, 2};
+  if (trussPrimaryFaces) {
+    const auto maxIt = std::max_element(bounds.size.begin(), bounds.size.end());
+    const int longAxis = static_cast<int>(std::distance(bounds.size.begin(), maxIt));
+    const float minSize = *std::min_element(bounds.size.begin(), bounds.size.end());
+    const bool elongated = bounds.size[longAxis] >= minSize * 1.4f;
+    if (elongated)
+      axes = {longAxis};
+  }
+
+  const std::array<std::array<float, 3>, 3> basis = {
+      Normalize(bounds.transform.u), Normalize(bounds.transform.v),
+      Normalize(bounds.transform.w)};
+  std::vector<Face> faces;
+  for (int axis : axes) {
+    const auto offset = Scale(basis[axis], bounds.size[axis] * 0.5f);
+    faces.push_back({Add(bounds.transform.o, offset), basis[axis]});
+    faces.push_back({Add(bounds.transform.o, Scale(offset, -1.0f)),
+                     Scale(basis[axis], -1.0f)});
+  }
+  return faces;
+}
+
+// Returns the source object transform target.
+scene_grouping::SceneTransformTarget TargetFor(ObjectType type,
+                                               const std::string &uuid) {
+  switch (type) {
+  case ObjectType::Fixture:
+    return {MvrNodeType::Fixture, uuid};
+  case ObjectType::Truss:
+    return {MvrNodeType::Truss, uuid};
+  case ObjectType::SceneObject:
+    return {MvrNodeType::SceneObject, uuid};
+  }
+  return {MvrNodeType::SceneObject, uuid};
+}
+
+// Tests a source and target face pair and stores the closest snap result.
+void ConsiderFacePair(const SnapSource &source, ObjectType targetType,
+                      const std::string &targetUuid, SnapKind kind,
+                      const Face &sourceFace, const Face &targetFace,
+                      float thresholdMm, float &bestDistance,
+                      std::optional<SnapResult> &best) {
+  const std::array<float, 3> delta = {targetFace.center[0] - sourceFace.center[0],
+                                     targetFace.center[1] - sourceFace.center[1],
+                                     targetFace.center[2] - sourceFace.center[2]};
+  const float distance = Length(delta);
+  if (distance > thresholdMm || distance >= bestDistance)
+    return;
+  bestDistance = distance;
+  SnapResult result;
+  result.snapped = true;
+  result.kind = kind;
+  result.sourceUuid = source.uuid;
+  result.targetUuid = targetUuid;
+  result.sourceType = source.type;
+  result.targetType = targetType;
+  result.translationDeltaMm = delta;
+  result.needsTrussGrouping = kind == SnapKind::TrussToTruss;
+  best = result;
+}
+
+} // namespace
+
+// Finds the best non-destructive Magnet snap candidate for the source object.
+std::optional<SnapResult> FindSnap(const MvrScene &scene,
+                                   const SnapSource &source,
+                                   const SnapSettings &settings) {
+  const auto sourceBounds = GetBounds(scene, source.type, source.uuid);
+  if (!sourceBounds)
+    return std::nullopt;
+
+  float bestDistance = std::numeric_limits<float>::max();
+  std::optional<SnapResult> best;
+
+  if (source.type == ObjectType::Truss) {
+    const auto sourceFaces = BuildFaces(*sourceBounds, true);
+    for (const auto &[uuid, truss] : scene.trusses) {
+      if (uuid == source.uuid)
+        continue;
+      const Bounds targetBounds{truss.transform,
+                                {std::max(truss.lengthMm, 1.0f),
+                                 std::max(truss.widthMm, 1.0f),
+                                 std::max(truss.heightMm, 1.0f)}};
+      for (const auto &sourceFace : sourceFaces) {
+        for (const auto &targetFace : BuildFaces(targetBounds, true))
+          ConsiderFacePair(source, ObjectType::Truss, uuid,
+                           SnapKind::TrussToTruss, sourceFace, targetFace,
+                           settings.thresholdMm, bestDistance, best);
+      }
+    }
+    return best;
+  }
+
+  if (source.type == ObjectType::Fixture) {
+    const Face insertion{sourceBounds->transform.o, {0.0f, 0.0f, 1.0f}};
+    for (const auto &[uuid, truss] : scene.trusses) {
+      const Bounds targetBounds{truss.transform,
+                                {std::max(truss.lengthMm, 1.0f),
+                                 std::max(truss.widthMm, 1.0f),
+                                 std::max(truss.heightMm, 1.0f)}};
+      for (const auto &targetFace : BuildFaces(targetBounds, false))
+        ConsiderFacePair(source, ObjectType::Truss, uuid,
+                         SnapKind::FixtureToTruss, insertion, targetFace,
+                         settings.thresholdMm, bestDistance, best);
+    }
+    return best;
+  }
+
+  const auto sourceFaces = BuildFaces(*sourceBounds, false);
+  auto considerSceneTarget = [&](ObjectType targetType, const std::string &uuid,
+                                 const Bounds &bounds) {
+    if (targetType == source.type && uuid == source.uuid)
+      return;
+    for (const auto &sourceFace : sourceFaces) {
+      for (const auto &targetFace : BuildFaces(bounds, false))
+        ConsiderFacePair(source, targetType, uuid, SnapKind::SceneObjectToObject,
+                         sourceFace, targetFace, settings.thresholdMm,
+                         bestDistance, best);
+    }
+  };
+  for (const auto &[uuid, truss] : scene.trusses)
+    considerSceneTarget(ObjectType::Truss, uuid,
+                        {truss.transform, {std::max(truss.lengthMm, 1.0f),
+                                           std::max(truss.widthMm, 1.0f),
+                                           std::max(truss.heightMm, 1.0f)}});
+  for (const auto &[uuid, object] : scene.sceneObjects)
+    considerSceneTarget(ObjectType::SceneObject, uuid,
+                        {object.transform, {1000.0f, 1000.0f, 1000.0f}});
+  return best;
+}
+
+// Applies a translation-only snap result through scene_grouping transform helpers.
+bool ApplySnapTransform(MvrScene &scene, const SnapResult &result) {
+  if (!result.snapped)
+    return false;
+  auto target = TargetFor(result.sourceType, result.sourceUuid);
+  Matrix transform = scene_grouping::GetTargetWorldTransform(scene, target);
+  for (int axis = 0; axis < 3; ++axis)
+    transform.o[axis] += result.translationDeltaMm[axis];
+  scene_grouping::SetTargetWorldTransform(scene, target, transform);
+  return true;
+}
+
+// Creates or extends an official MVR GroupObject after a committed truss snap.
+bool ApplyCommittedTrussGrouping(MvrScene &scene, const SnapResult &result) {
+  if (!result.needsTrussGrouping || result.sourceType != ObjectType::Truss ||
+      result.targetType != ObjectType::Truss)
+    return false;
+  auto sourceIt = scene.trusses.find(result.sourceUuid);
+  auto targetIt = scene.trusses.find(result.targetUuid);
+  if (sourceIt == scene.trusses.end() || targetIt == scene.trusses.end())
+    return false;
+  scene_grouping::ObjectSelection selection;
+  selection.trusses = {result.targetUuid, result.sourceUuid};
+  if (!targetIt->second.parentGroupUuid.empty()) {
+    scene_grouping::ObjectSelection addSelection;
+    addSelection.trusses = {result.sourceUuid};
+    return scene_grouping::AddSelectionToGroup(
+               scene, addSelection, targetIt->second.parentGroupUuid)
+        .changed;
+  }
+  return scene_grouping::GroupSelection(scene, selection).changed;
+}
+
+} // namespace magnet_snap

--- a/core/magnet_snap.cpp
+++ b/core/magnet_snap.cpp
@@ -181,7 +181,7 @@ void ConsiderFacePair(const SnapSource &source, ObjectType targetType,
   result.sourceType = source.type;
   result.targetType = targetType;
   result.translationDeltaMm = delta;
-  result.needsTrussGrouping = kind == SnapKind::TrussToTruss;
+  result.needsGrouping = kind == SnapKind::TrussToTruss;
   best = result;
 }
 
@@ -239,7 +239,7 @@ std::optional<SnapResult> FindSnap(const MvrScene &scene,
       result.sourceType = source.type;
       result.targetType = ObjectType::Truss;
       result.translationDeltaMm = delta;
-      result.needsTrussGrouping = false;
+      result.needsGrouping = true;
       best = result;
     }
     return best;
@@ -280,25 +280,56 @@ bool ApplySnapTransform(MvrScene &scene, const SnapResult &result) {
   return true;
 }
 
-// Creates or extends an official MVR GroupObject after a committed truss snap.
-bool ApplyCommittedTrussGrouping(MvrScene &scene, const SnapResult &result) {
-  if (!result.needsTrussGrouping || result.sourceType != ObjectType::Truss ||
-      result.targetType != ObjectType::Truss)
+// Creates or extends official MVR GroupObjects after a committed snap.
+bool ApplyCommittedSnapGrouping(MvrScene &scene, const SnapResult &result) {
+  if (!result.needsGrouping)
     return false;
-  auto sourceIt = scene.trusses.find(result.sourceUuid);
-  auto targetIt = scene.trusses.find(result.targetUuid);
-  if (sourceIt == scene.trusses.end() || targetIt == scene.trusses.end())
-    return false;
-  scene_grouping::ObjectSelection selection;
-  selection.trusses = {result.targetUuid, result.sourceUuid};
-  if (!targetIt->second.parentGroupUuid.empty()) {
-    scene_grouping::ObjectSelection addSelection;
-    addSelection.trusses = {result.sourceUuid};
-    return scene_grouping::AddSelectionToGroup(
-               scene, addSelection, targetIt->second.parentGroupUuid)
-        .changed;
+  if (result.kind == SnapKind::TrussToTruss) {
+    auto sourceIt = scene.trusses.find(result.sourceUuid);
+    auto targetIt = scene.trusses.find(result.targetUuid);
+    if (sourceIt == scene.trusses.end() || targetIt == scene.trusses.end())
+      return false;
+    scene_grouping::ObjectSelection selection;
+    selection.trusses = {result.targetUuid, result.sourceUuid};
+    if (!targetIt->second.parentGroupUuid.empty()) {
+      scene_grouping::ObjectSelection addSelection;
+      addSelection.trusses = {result.sourceUuid};
+      return scene_grouping::AddSelectionToGroup(
+                 scene, addSelection, targetIt->second.parentGroupUuid)
+          .changed;
+    }
+    return scene_grouping::GroupSelection(scene, selection).changed;
   }
-  return scene_grouping::GroupSelection(scene, selection).changed;
+  if (result.kind == SnapKind::FixtureToTruss) {
+    auto fixtureIt = scene.fixtures.find(result.sourceUuid);
+    auto targetIt = scene.trusses.find(result.targetUuid);
+    if (fixtureIt == scene.fixtures.end() || targetIt == scene.trusses.end())
+      return false;
+    if (!targetIt->second.parentGroupUuid.empty()) {
+      scene_grouping::ObjectSelection addSelection;
+      addSelection.fixtures = {result.sourceUuid};
+      return scene_grouping::AddSelectionToGroup(
+                 scene, addSelection, targetIt->second.parentGroupUuid)
+          .changed;
+    }
+    scene_grouping::ObjectSelection selection;
+    selection.fixtures = {result.sourceUuid};
+    selection.trusses = {result.targetUuid};
+    return scene_grouping::GroupSelection(scene, selection).changed;
+  }
+  return false;
+}
+
+// Removes the snapped source from its direct GroupObject when it is detached.
+bool DetachSnapSourceFromGroup(MvrScene &scene, const SnapResult &result) {
+  scene_grouping::ObjectSelection selection;
+  if (result.sourceType == ObjectType::Truss)
+    selection.trusses = {result.sourceUuid};
+  else if (result.sourceType == ObjectType::Fixture)
+    selection.fixtures = {result.sourceUuid};
+  else
+    return false;
+  return scene_grouping::RemoveSelectionFromGroup(scene, selection).changed;
 }
 
 } // namespace magnet_snap

--- a/core/magnet_snap.h
+++ b/core/magnet_snap.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "mvrscene.h"
+
+#include <array>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace magnet_snap {
+
+constexpr float kDefaultSnapDistanceMm = 250.0f;
+constexpr const char *kMagnetEnabledConfigKey = "viewport_magnet_enabled";
+
+enum class ObjectType { Fixture, Truss, SceneObject };
+enum class SnapKind { None, TrussToTruss, FixtureToTruss, SceneObjectToObject };
+
+struct SnapSource {
+  ObjectType type = ObjectType::SceneObject;
+  std::string uuid;
+};
+
+struct SnapSettings {
+  float thresholdMm = kDefaultSnapDistanceMm;
+};
+
+struct SnapResult {
+  bool snapped = false;
+  SnapKind kind = SnapKind::None;
+  std::string sourceUuid;
+  std::string targetUuid;
+  ObjectType sourceType = ObjectType::SceneObject;
+  ObjectType targetType = ObjectType::SceneObject;
+  std::array<float, 3> translationDeltaMm{0.0f, 0.0f, 0.0f};
+  bool needsTrussGrouping = false;
+};
+
+// Finds the best non-destructive Magnet snap candidate for the source object.
+std::optional<SnapResult> FindSnap(const MvrScene &scene,
+                                   const SnapSource &source,
+                                   const SnapSettings &settings = {});
+
+// Applies a translation-only snap result through scene_grouping transform helpers.
+bool ApplySnapTransform(MvrScene &scene, const SnapResult &result);
+
+// Creates or extends an official MVR GroupObject after a committed truss snap.
+bool ApplyCommittedTrussGrouping(MvrScene &scene, const SnapResult &result);
+
+} // namespace magnet_snap

--- a/core/magnet_snap.h
+++ b/core/magnet_snap.h
@@ -10,6 +10,7 @@
 namespace magnet_snap {
 
 constexpr float kDefaultSnapDistanceMm = 250.0f;
+constexpr float kSnapRetainDistanceMm = 75.0f;
 constexpr const char *kMagnetEnabledConfigKey = "viewport_magnet_enabled";
 
 enum class ObjectType { Fixture, Truss, SceneObject };

--- a/core/magnet_snap.h
+++ b/core/magnet_snap.h
@@ -32,7 +32,7 @@ struct SnapResult {
   ObjectType sourceType = ObjectType::SceneObject;
   ObjectType targetType = ObjectType::SceneObject;
   std::array<float, 3> translationDeltaMm{0.0f, 0.0f, 0.0f};
-  bool needsTrussGrouping = false;
+  bool needsGrouping = false;
 };
 
 // Finds the best non-destructive Magnet snap candidate for the source object.
@@ -43,7 +43,10 @@ std::optional<SnapResult> FindSnap(const MvrScene &scene,
 // Applies a translation-only snap result through scene_grouping transform helpers.
 bool ApplySnapTransform(MvrScene &scene, const SnapResult &result);
 
-// Creates or extends an official MVR GroupObject after a committed truss snap.
-bool ApplyCommittedTrussGrouping(MvrScene &scene, const SnapResult &result);
+// Creates or extends official MVR GroupObjects after a committed snap.
+bool ApplyCommittedSnapGrouping(MvrScene &scene, const SnapResult &result);
+
+// Removes the snapped source from its direct GroupObject when it is detached.
+bool DetachSnapSourceFromGroup(MvrScene &scene, const SnapResult &result);
 
 } // namespace magnet_snap

--- a/core/magnet_snap.h
+++ b/core/magnet_snap.h
@@ -10,7 +10,6 @@
 namespace magnet_snap {
 
 constexpr float kDefaultSnapDistanceMm = 250.0f;
-constexpr float kSnapRetainDistanceMm = 75.0f;
 constexpr const char *kMagnetEnabledConfigKey = "viewport_magnet_enabled";
 
 enum class ObjectType { Fixture, Truss, SceneObject };

--- a/core/scene_grouping.cpp
+++ b/core/scene_grouping.cpp
@@ -631,6 +631,32 @@ OperationResult GroupSelection(MvrScene &scene,
   return result;
 }
 
+
+// Adds selected scene entities to an existing GroupObject while preserving world placement.
+OperationResult AddSelectionToGroup(MvrScene &scene,
+                                    const ObjectSelection &selection,
+                                    const std::string &groupUuid) {
+  OperationResult result;
+  auto groupIt = scene.groupObjects.find(groupUuid);
+  if (groupIt == scene.groupObjects.end())
+    return result;
+
+  std::vector<SelectedObjectRef> objects = CollectSelectedObjects(scene, selection);
+  for (const auto &object : objects) {
+    if (object.parentGroupUuid == groupUuid)
+      continue;
+    RemoveChildFromGroups(scene, object.type, object.uuid);
+    const Matrix localTransform = MatrixUtils::Multiply(
+        InverseMatrix(groupIt->second.transform), object.worldTransform);
+    ApplyParentAndLocalTransform(scene, object, groupUuid, localTransform);
+    groupIt->second.children.push_back({object.type, object.uuid});
+    AppendAffectedTarget(result, scene, object.type, object.uuid);
+    result.changed = true;
+  }
+  result.groupUuid = groupUuid;
+  return result;
+}
+
 // Removes selected effective groups and promotes their direct children.
 OperationResult UngroupSelection(MvrScene &scene,
                                  const ObjectSelection &selection) {

--- a/core/scene_grouping.cpp
+++ b/core/scene_grouping.cpp
@@ -301,6 +301,9 @@ std::string ParentGroupUuidForTarget(const MvrScene &scene,
 // Returns the highest group ancestor for a selected object when one exists.
 SceneTransformTarget ResolveTransformRoot(const MvrScene &scene,
                                           const SelectedObjectRef &object) {
+  if (object.type == MvrNodeType::Fixture)
+    return {object.type, object.uuid};
+
   std::string groupUuid = object.parentGroupUuid;
   if (groupUuid.empty())
     return {object.type, object.uuid};
@@ -654,6 +657,23 @@ OperationResult AddSelectionToGroup(MvrScene &scene,
     result.changed = true;
   }
   result.groupUuid = groupUuid;
+  return result;
+}
+
+
+// Removes selected scene entities from their direct GroupObject parents while preserving world placement.
+OperationResult RemoveSelectionFromGroup(MvrScene &scene,
+                                         const ObjectSelection &selection) {
+  OperationResult result;
+  std::vector<SelectedObjectRef> objects = CollectSelectedObjects(scene, selection);
+  for (const auto &object : objects) {
+    if (object.parentGroupUuid.empty())
+      continue;
+    RemoveChildFromGroups(scene, object.type, object.uuid);
+    ReparentChildPreservingWorld(scene, {object.type, object.uuid}, {});
+    AppendAffectedTarget(result, scene, object.type, object.uuid);
+    result.changed = true;
+  }
   return result;
 }
 

--- a/core/scene_grouping.h
+++ b/core/scene_grouping.h
@@ -55,6 +55,11 @@ OperationResult AddSelectionToGroup(MvrScene &scene,
                                     const ObjectSelection &selection,
                                     const std::string &groupUuid);
 
+// Removes selected scene entities from their direct parent groups without
+// deleting or flattening those groups.
+OperationResult RemoveSelectionFromGroup(MvrScene &scene,
+                                         const ObjectSelection &selection);
+
 // Removes selected scene entities from their direct parent groups.
 OperationResult UngroupSelection(MvrScene &scene,
                                  const ObjectSelection &selection);

--- a/core/scene_grouping.h
+++ b/core/scene_grouping.h
@@ -50,6 +50,11 @@ struct OperationResult {
 OperationResult GroupSelection(MvrScene &scene,
                                const ObjectSelection &selection);
 
+// Adds selected scene entities to an existing MVR-compatible GroupObject.
+OperationResult AddSelectionToGroup(MvrScene &scene,
+                                    const ObjectSelection &selection,
+                                    const std::string &groupUuid);
+
 // Removes selected scene entities from their direct parent groups.
 OperationResult UngroupSelection(MvrScene &scene,
                                  const ObjectSelection &selection);

--- a/docs/features.md
+++ b/docs/features.md
@@ -116,7 +116,7 @@ Additional safeguards include:
 
 - Top-down plan visualization with configurable grid and labels.
 - The shared viewport axis-lock toggle also controls 2D selection dragging: enabled keeps movement constrained to one screen axis, while disabled allows free movement across both axes in the active 2D plane.
-- The Magnet toolbar toggle is disabled by default and can be enabled to snap dragged trusses, fixtures, and scene objects to nearby compatible scene bounds. Truss-to-truss snaps can create or extend an official GroupObject when the mouse is released, while fixture and scene-object snaps only update transforms. Magnet does not modify Hang Position, does not merge geometry, and keeps exported MVR data standards-compliant.
+- The Magnet toolbar toggle is disabled by default and can be enabled to snap dragged trusses, fixtures, and scene objects to nearby compatible scene bounds in the 2D and 3D viewers. Fixture snaps use the nearest truss bounding-box surface or edge even when fixtures and trusses are managed from different tables. Truss-to-truss snaps can create or extend an official GroupObject when the mouse is released, while fixture and scene-object snaps only update transforms. Magnet does not modify Hang Position, does not merge geometry, and keeps exported MVR data standards-compliant.
 - Supports vector draw-command capture for downstream document/export workflows.
 
 ### Layout system

--- a/docs/features.md
+++ b/docs/features.md
@@ -116,6 +116,7 @@ Additional safeguards include:
 
 - Top-down plan visualization with configurable grid and labels.
 - The shared viewport axis-lock toggle also controls 2D selection dragging: enabled keeps movement constrained to one screen axis, while disabled allows free movement across both axes in the active 2D plane.
+- The Magnet toolbar toggle is disabled by default and can be enabled to snap dragged trusses, fixtures, and scene objects to nearby compatible scene bounds. Truss-to-truss snaps can create or extend an official GroupObject when the mouse is released, while fixture and scene-object snaps only update transforms. Magnet does not modify Hang Position, does not merge geometry, and keeps exported MVR data standards-compliant.
 - Supports vector draw-command capture for downstream document/export workflows.
 
 ### Layout system

--- a/docs/features.md
+++ b/docs/features.md
@@ -116,7 +116,7 @@ Additional safeguards include:
 
 - Top-down plan visualization with configurable grid and labels.
 - The shared viewport axis-lock toggle also controls 2D selection dragging: enabled keeps movement constrained to one screen axis, while disabled allows free movement across both axes in the active 2D plane.
-- The Magnet toolbar toggle is disabled by default and can be enabled to snap dragged trusses, fixtures, and scene objects to nearby compatible scene bounds in the 2D and 3D viewers. Fixture snaps use the nearest truss bounding-box surface or edge even when fixtures and trusses are managed from different tables. Truss-to-truss snaps can create or extend an official GroupObject when the mouse is released, while fixture and scene-object snaps only update transforms. Magnet does not modify Hang Position, does not merge geometry, and keeps exported MVR data standards-compliant.
+- The Magnet toolbar toggle is disabled by default and can be enabled to snap dragged trusses, fixtures, and scene objects to nearby compatible scene bounds in the 2D and 3D viewers. Fixture snaps use the nearest truss bounding-box surface or edge even when fixtures and trusses are managed from different tables. Truss-to-truss snaps can create or extend an official GroupObject when the mouse is released, and fixture-to-truss snaps add the fixture to the truss snap group so it can later be detached without flattening the rest of the group. Scene-object snaps only update transforms. Magnet does not modify Hang Position, does not merge geometry, and keeps exported MVR data standards-compliant.
 - Supports vector draw-command capture for downstream document/export workflows.
 
 ### Layout system

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -6,6 +6,7 @@ Changes since `v1.3.0`.
 
 ## New features
 
+- Added a disabled-by-default Magnet snapping toolbar mode for 2D dragging, with truss-to-truss grouping on committed snaps and transform-only fixture/object snaps that preserve Hang Position and MVR compatibility.
 - Added a project-persistent Axis Lock toolbar toggle for selection dragging, enabled by default for axis-constrained moves and allowing free 2D movement plus Blender-style view-plane movement in 3D when disabled.
 - Expanded basic primitive creation and editing for spheres, cubes, and cylinders with editable names, project-persistent default dimensions, default load/save buttons, and richer edit controls for position and rotation.
 - Added Edit menu Group and Ungroup commands with `Ctrl+G` and `Ctrl+U` shortcuts for cross-table scene selections, preserving object placement and hang-position assignments while using MVR-compatible GroupObject hierarchy.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -24,7 +24,7 @@ Changes since `v1.3.0`.
 
 ## Fixes
 
-- Improved Magnet fixture snapping so fixture insertion points detect nearby truss bounding-box surfaces and edges reliably across fixture and truss table selections.
+- Improved Magnet snapping so fixtures and trusses release from snapped targets more naturally as the mouse moves away, while fixture insertion points detect nearby truss bounding-box surfaces and edges reliably across fixture and truss table selections.
 - Fixed highlighted drag-coordinate feedback so the bottom X/Y/Z readout stays visible and reliably changes font color during 2D and 3D object moves.
 - Fixed scene object renaming so edited Data View names are preserved in the scene summary and MVR exports, supporting technical object-name workflows such as cable waypoints.
 - Kept the 2D and 3D viewer highlights pinned to the dragged scene element during mouse-drag moves so hover feedback no longer jumps to other elements mid-drag.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -15,6 +15,7 @@ Changes since `v1.3.0`.
 
 ## Improvements
 
+- Changed grouped fixture dragging so moving a selected fixture only moves that fixture, allowing fixtures to be repositioned along grouped trusses without moving the full group.
 - Added a 2D position gizmo while dragging scene elements so movement direction feedback follows the dragged insertion point and matches the 3D viewer.
 - Improved GroupObject handling so selecting a grouped member highlights and transforms the full root group, including nested groups, in 2D, 3D, and command-bar transform workflows.
 - Improved group hover feedback by using a more yellow primary highlight and a paler secondary group highlight across the 3D view and related fixture, truss, hoist, and scene object table rows, matching the table selection styling.
@@ -24,7 +25,7 @@ Changes since `v1.3.0`.
 
 ## Fixes
 
-- Improved Magnet snapping so fixtures and trusses release from snapped targets based on the raw mouse-following drag position, while fixture insertion points detect nearby truss bounding-box surfaces and edges reliably across fixture and truss table selections.
+- Improved Magnet snapping so fixtures and trusses release from snapped targets based on the raw mouse-following drag position, fixture-to-truss snaps join the fixture to the truss snap group, and detaching snapped fixtures or trusses preserves the rest of the group hierarchy.
 - Fixed highlighted drag-coordinate feedback so the bottom X/Y/Z readout stays visible and reliably changes font color during 2D and 3D object moves.
 - Fixed scene object renaming so edited Data View names are preserved in the scene summary and MVR exports, supporting technical object-name workflows such as cable waypoints.
 - Kept the 2D and 3D viewer highlights pinned to the dragged scene element during mouse-drag moves so hover feedback no longer jumps to other elements mid-drag.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -6,7 +6,7 @@ Changes since `v1.3.0`.
 
 ## New features
 
-- Added a disabled-by-default Magnet snapping toolbar mode for 2D dragging, with truss-to-truss grouping on committed snaps and transform-only fixture/object snaps that preserve Hang Position and MVR compatibility.
+- Added a disabled-by-default Magnet snapping toolbar mode for 2D and 3D dragging, with truss-to-truss grouping on committed snaps and transform-only fixture/object snaps that preserve Hang Position and MVR compatibility.
 - Added a project-persistent Axis Lock toolbar toggle for selection dragging, enabled by default for axis-constrained moves and allowing free 2D movement plus Blender-style view-plane movement in 3D when disabled.
 - Expanded basic primitive creation and editing for spheres, cubes, and cylinders with editable names, project-persistent default dimensions, default load/save buttons, and richer edit controls for position and rotation.
 - Added Edit menu Group and Ungroup commands with `Ctrl+G` and `Ctrl+U` shortcuts for cross-table scene selections, preserving object placement and hang-position assignments while using MVR-compatible GroupObject hierarchy.
@@ -24,6 +24,7 @@ Changes since `v1.3.0`.
 
 ## Fixes
 
+- Improved Magnet fixture snapping so fixture insertion points detect nearby truss bounding-box surfaces and edges reliably across fixture and truss table selections.
 - Fixed highlighted drag-coordinate feedback so the bottom X/Y/Z readout stays visible and reliably changes font color during 2D and 3D object moves.
 - Fixed scene object renaming so edited Data View names are preserved in the scene summary and MVR exports, supporting technical object-name workflows such as cable waypoints.
 - Kept the 2D and 3D viewer highlights pinned to the dragged scene element during mouse-drag moves so hover feedback no longer jumps to other elements mid-drag.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -24,7 +24,7 @@ Changes since `v1.3.0`.
 
 ## Fixes
 
-- Improved Magnet snapping so fixtures and trusses release from snapped targets more naturally as the mouse moves away, while fixture insertion points detect nearby truss bounding-box surfaces and edges reliably across fixture and truss table selections.
+- Improved Magnet snapping so fixtures and trusses release from snapped targets based on the raw mouse-following drag position, while fixture insertion points detect nearby truss bounding-box surfaces and edges reliably across fixture and truss table selections.
 - Fixed highlighted drag-coordinate feedback so the bottom X/Y/Z readout stays visible and reliably changes font color during 2D and 3D object moves.
 - Fixed scene object renaming so edited Data View names are preserved in the scene summary and MVR exports, supporting technical object-name workflows such as cable waypoints.
 - Kept the 2D and 3D viewer highlights pinned to the dragged scene element during mouse-drag moves so hover feedback no longer jumps to other elements mid-drag.

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -384,6 +384,7 @@ EVT_MENU(ID_View_Viewport_Side, MainWindow::OnViewportSideView)
 EVT_MENU(ID_View_Viewport_SelectTool, MainWindow::OnViewportSelectTool)
 EVT_MENU(ID_View_Viewport_MeasureTool, MainWindow::OnViewportMeasureTool)
 EVT_MENU(ID_View_Viewport_AxisConstraint, MainWindow::OnViewportAxisConstraint)
+EVT_MENU(ID_View_Viewport_Magnet, MainWindow::OnViewportMagnet)
 EVT_MENU(ID_View_Layout_2DView, MainWindow::OnLayoutAdd2DView)
 EVT_MENU(ID_View_Layout_Legend, MainWindow::OnLayoutAddLegend)
 EVT_MENU(ID_View_Layout_EventTable, MainWindow::OnLayoutAddEventTable)
@@ -1186,6 +1187,7 @@ void MainWindow::UpdateToolBarAvailability() {
     layoutViewsToolBar->EnableTool(ID_View_Viewport_SelectTool, enableViewportTools);
     layoutViewsToolBar->EnableTool(ID_View_Viewport_MeasureTool, enableViewportTools);
     layoutViewsToolBar->EnableTool(ID_View_Viewport_AxisConstraint, enableViewportTools);
+    layoutViewsToolBar->EnableTool(ID_View_Viewport_Magnet, enableViewportTools);
     layoutViewsToolBar->SetToolShortHelp(
         ID_View_Viewport_SelectTool,
         enableViewportTools ? "Switch to standard selection mode"
@@ -1197,6 +1199,10 @@ void MainWindow::UpdateToolBarAvailability() {
     layoutViewsToolBar->SetToolShortHelp(
         ID_View_Viewport_AxisConstraint,
         enableViewportTools ? "Toggle axis-constrained selection movement"
+                            : "Disabled while editing Layout views");
+    layoutViewsToolBar->SetToolShortHelp(
+        ID_View_Viewport_Magnet,
+        enableViewportTools ? "Toggle Magnet snapping while dragging"
                             : "Disabled while editing Layout views");
     layoutViewsToolBar->Refresh();
   }

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -214,6 +214,7 @@ private:
   void OnViewportSideView(wxCommandEvent &event);
   void OnViewportSelectTool(wxCommandEvent &event);
   void OnViewportMeasureTool(wxCommandEvent &event);
+  void OnViewportMagnet(wxCommandEvent &event);
   void OnViewportAxisConstraint(wxCommandEvent &event);
 
   void OnUndo(wxCommandEvent &event);           // Undo action placeholder

--- a/gui/mainwindow/ids/tools_ids.h
+++ b/gui/mainwindow/ids/tools_ids.h
@@ -2,7 +2,7 @@
 
 #include "view_ids.h"
 
-constexpr int ID_Tools_DownloadGdtf = ID_View_Viewport_AxisConstraint + 1;
+constexpr int ID_Tools_DownloadGdtf = ID_View_Viewport_Magnet + 1;
 constexpr int ID_Tools_EditDictionaries = ID_Tools_DownloadGdtf + 1;
 constexpr int ID_Tools_ImportRiderText = ID_Tools_EditDictionaries + 1;
 constexpr int ID_Tools_DistributeHoistWeights =

--- a/gui/mainwindow/ids/view_ids.h
+++ b/gui/mainwindow/ids/view_ids.h
@@ -25,3 +25,4 @@ constexpr int ID_View_Viewport_Side = ID_View_Viewport_Front + 1;
 constexpr int ID_View_Viewport_SelectTool = ID_View_Viewport_Side + 1;
 constexpr int ID_View_Viewport_MeasureTool = ID_View_Viewport_SelectTool + 1;
 constexpr int ID_View_Viewport_AxisConstraint = ID_View_Viewport_MeasureTool + 1;
+constexpr int ID_View_Viewport_Magnet = ID_View_Viewport_AxisConstraint + 1;

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -75,6 +75,7 @@
 #include "layoutviewerpanel.h"
 #include "loader_obj.h"
 #include "logger.h"
+#include "magnet_snap.h"
 #include "logindialog.h"
 #include "markdown.h"
 #include "preferencesdialog.h"
@@ -239,6 +240,11 @@ void MainWindow::CreateToolBars() {
                                               wxART_MISSING_IMAGE),
                               "Toggle axis-constrained selection movement",
                               wxITEM_CHECK);
+  layoutViewsToolBar->AddTool(ID_View_Viewport_Magnet, "Magnet",
+                              loadToolbarIcon("magnet",
+                                              wxART_MISSING_IMAGE),
+                              "Toggle Magnet snapping while dragging",
+                              wxITEM_CHECK);
   layoutViewsToolBar->ToggleTool(ID_View_Viewport_SelectTool, true);
   layoutViewsToolBar->ToggleTool(ID_View_Viewport_MeasureTool, false);
   layoutViewsToolBar->ToggleTool(
@@ -246,6 +252,10 @@ void MainWindow::CreateToolBars() {
       GetDefaultGuiConfigServices().Preferences().GetValue(
           selection_movement_settings::kAxisConstrainedMovementConfigKey) !=
           "0");
+  layoutViewsToolBar->ToggleTool(
+      ID_View_Viewport_Magnet,
+      GetDefaultGuiConfigServices().Preferences().GetValue(
+          magnet_snap::kMagnetEnabledConfigKey) == "1");
   layoutViewsToolBar->Realize();
   auiManager->AddPane(
       layoutViewsToolBar, wxAuiPaneInfo()

--- a/gui/mainwindow_view_shortcuts.cpp
+++ b/gui/mainwindow_view_shortcuts.cpp
@@ -140,9 +140,14 @@ void MainWindow::ApplyViewportShortcut(Viewer2DView view) {
 
 // Toggles Magnet snapping for 2D selection dragging and persists the preference.
 void MainWindow::OnViewportMagnet(wxCommandEvent &WXUNUSED(event)) {
-  const bool enabled = !(viewport2DPanel && viewport2DPanel->IsMagnetEnabled());
+  const bool currentEnabled =
+      (viewport2DPanel && viewport2DPanel->IsMagnetEnabled()) ||
+      (viewportPanel && viewportPanel->IsMagnetEnabled());
+  const bool enabled = !currentEnabled;
   if (viewport2DPanel)
     viewport2DPanel->SetMagnetEnabled(enabled);
+  if (viewportPanel)
+    viewportPanel->SetMagnetEnabled(enabled);
   if (layoutViewsToolBar) {
     layoutViewsToolBar->ToggleTool(ID_View_Viewport_Magnet, enabled);
     layoutViewsToolBar->Refresh();

--- a/gui/mainwindow_view_shortcuts.cpp
+++ b/gui/mainwindow_view_shortcuts.cpp
@@ -4,6 +4,7 @@
 #include "viewer3dpanel.h"
 #include "selection_movement_settings.h"
 #include "guiconfigservices.h"
+#include "magnet_snap.h"
 
 namespace {
 
@@ -47,6 +48,10 @@ void MainWindow::SyncViewportToolToggleState(bool measureEnabled) {
   layoutViewsToolBar->ToggleTool(ID_View_Viewport_SelectTool, !measureEnabled);
   layoutViewsToolBar->ToggleTool(ID_View_Viewport_MeasureTool, measureEnabled);
   SyncAxisConstraintToolToggleState();
+  layoutViewsToolBar->ToggleTool(
+      ID_View_Viewport_Magnet,
+      GetDefaultGuiConfigServices().Preferences().GetValue(
+          magnet_snap::kMagnetEnabledConfigKey) == "1");
   layoutViewsToolBar->Refresh();
 }
 
@@ -131,4 +136,15 @@ void MainWindow::ApplyViewportShortcut(Viewer2DView view) {
 
   if (viewportPanel)
     viewportPanel->SetStandardView(view);
+}
+
+// Toggles Magnet snapping for 2D selection dragging and persists the preference.
+void MainWindow::OnViewportMagnet(wxCommandEvent &WXUNUSED(event)) {
+  const bool enabled = !(viewport2DPanel && viewport2DPanel->IsMagnetEnabled());
+  if (viewport2DPanel)
+    viewport2DPanel->SetMagnetEnabled(enabled);
+  if (layoutViewsToolBar) {
+    layoutViewsToolBar->ToggleTool(ID_View_Viewport_Magnet, enabled);
+    layoutViewsToolBar->Refresh();
+  }
 }

--- a/resources/icons/outline/magnet.svg
+++ b/resources/icons/outline/magnet.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m12 15 4 4" />
+  <path d="M2.352 10.648a1.205 1.205 0 0 0 0 1.704l2.296 2.296a1.205 1.205 0 0 0 1.704 0l6.029-6.029a1 1 0 1 1 3 3l-6.029 6.029a1.205 1.205 0 0 0 0 1.704l2.296 2.296a1.205 1.205 0 0 0 1.704 0l6.365-6.367A1 1 0 0 0 8.716 4.282z" />
+  <path d="m5 8 4 4" />
+</svg>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -77,6 +77,15 @@ add_executable(scene_grouping_test scene_grouping_test.cpp
 target_include_directories(scene_grouping_test PRIVATE ../core ../models)
 add_test(NAME SceneGroupingPreservesTransforms COMMAND scene_grouping_test)
 
+add_executable(magnet_snap_test magnet_snap_test.cpp
+    ../core/magnet_snap.cpp
+    ../core/scene_grouping.cpp
+    ../core/uuidutils.cpp
+    ../models/mvrscene.cpp
+)
+target_include_directories(magnet_snap_test PRIVATE ../core ../models)
+add_test(NAME MagnetSnapCore COMMAND magnet_snap_test)
+
 add_executable(rdp_simplifier_test
                rdp_simplifier_test.cpp
                ../core/geometry/RdpSimplifier.cpp)

--- a/tests/magnet_snap_test.cpp
+++ b/tests/magnet_snap_test.cpp
@@ -1,0 +1,92 @@
+#include "magnet_snap.h"
+
+#include "matrixutils.h"
+#include "scene_grouping.h"
+
+#include <cassert>
+#include <cmath>
+
+namespace {
+
+// Builds a translated identity matrix.
+Matrix Translated(float x, float y, float z) {
+  Matrix matrix = MatrixUtils::Identity();
+  matrix.o = {x, y, z};
+  return matrix;
+}
+
+// Adds a truss with common test dimensions.
+void AddTruss(MvrScene &scene, const std::string &uuid, float x) {
+  Truss truss;
+  truss.uuid = uuid;
+  truss.layer = "No Layer";
+  truss.lengthMm = 3000.0f;
+  truss.widthMm = 300.0f;
+  truss.heightMm = 300.0f;
+  truss.position = "LX1";
+  truss.positionName = "LX1";
+  truss.transform = Translated(x, 0.0f, 0.0f);
+  scene.trusses[uuid] = truss;
+}
+
+} // namespace
+
+// Verifies Magnet snap candidates, metadata preservation, and committed grouping.
+int main() {
+  MvrScene scene;
+  AddTruss(scene, "target", 0.0f);
+  AddTruss(scene, "source", 3250.0f);
+
+  auto snap = magnet_snap::FindSnap(
+      scene, {magnet_snap::ObjectType::Truss, "source"});
+  assert(snap);
+  assert(snap->kind == magnet_snap::SnapKind::TrussToTruss);
+  assert(snap->needsTrussGrouping);
+  assert(std::fabs(snap->translationDeltaMm[0] + 250.0f) < 0.001f);
+
+  scene.trusses["source"].transform.o[0] = 4000.0f;
+  assert(!magnet_snap::FindSnap(
+      scene, {magnet_snap::ObjectType::Truss, "source"}));
+
+  scene.trusses["source"].transform.o[0] = 3250.0f;
+  snap = magnet_snap::FindSnap(scene,
+                               {magnet_snap::ObjectType::Truss, "source"});
+  assert(snap);
+  const std::string hang = scene.trusses["source"].positionName;
+  assert(magnet_snap::ApplySnapTransform(scene, *snap));
+  assert(scene.trusses["source"].positionName == hang);
+  assert(magnet_snap::ApplyCommittedTrussGrouping(scene, *snap));
+  assert(scene.groupObjects.size() == 1);
+  const std::string groupUuid = scene.trusses["target"].parentGroupUuid;
+  assert(!groupUuid.empty());
+
+  AddTruss(scene, "source-2", 6250.0f);
+  scene.trusses["source-2"].transform.o[0] = 3250.0f;
+  auto snap2 = magnet_snap::FindSnap(
+      scene, {magnet_snap::ObjectType::Truss, "source-2"});
+  assert(snap2);
+  assert(magnet_snap::ApplyCommittedTrussGrouping(scene, *snap2));
+  assert(scene.trusses["source-2"].parentGroupUuid == groupUuid);
+  assert(scene.groupObjects.size() == 1);
+
+  Fixture fixture;
+  fixture.uuid = "fixture";
+  fixture.transform = Translated(0.0f, 0.0f, 140.0f);
+  scene.fixtures[fixture.uuid] = fixture;
+  auto fixtureSnap = magnet_snap::FindSnap(
+      scene, {magnet_snap::ObjectType::Fixture, fixture.uuid});
+  assert(fixtureSnap);
+  assert(fixtureSnap->kind == magnet_snap::SnapKind::FixtureToTruss);
+  assert(!fixtureSnap->needsTrussGrouping);
+
+  SceneObject object;
+  object.uuid = "object";
+  object.transform = Translated(0.0f, 650.0f, 0.0f);
+  scene.sceneObjects[object.uuid] = object;
+  auto objectSnap = magnet_snap::FindSnap(
+      scene, {magnet_snap::ObjectType::SceneObject, object.uuid});
+  assert(objectSnap);
+  assert(objectSnap->kind == magnet_snap::SnapKind::SceneObjectToObject);
+
+  return 0;
+}

--- a/tests/magnet_snap_test.cpp
+++ b/tests/magnet_snap_test.cpp
@@ -71,13 +71,14 @@ int main() {
 
   Fixture fixture;
   fixture.uuid = "fixture";
-  fixture.transform = Translated(0.0f, 0.0f, 140.0f);
+  fixture.transform = Translated(1510.0f, 160.0f, 0.0f);
   scene.fixtures[fixture.uuid] = fixture;
   auto fixtureSnap = magnet_snap::FindSnap(
       scene, {magnet_snap::ObjectType::Fixture, fixture.uuid});
   assert(fixtureSnap);
   assert(fixtureSnap->kind == magnet_snap::SnapKind::FixtureToTruss);
   assert(!fixtureSnap->needsTrussGrouping);
+  assert(std::fabs(fixtureSnap->translationDeltaMm[1] + 10.0f) < 0.001f);
 
   SceneObject object;
   object.uuid = "object";

--- a/tests/magnet_snap_test.cpp
+++ b/tests/magnet_snap_test.cpp
@@ -41,7 +41,7 @@ int main() {
       scene, {magnet_snap::ObjectType::Truss, "source"});
   assert(snap);
   assert(snap->kind == magnet_snap::SnapKind::TrussToTruss);
-  assert(snap->needsTrussGrouping);
+  assert(snap->needsGrouping);
   assert(std::fabs(snap->translationDeltaMm[0] + 250.0f) < 0.001f);
 
   scene.trusses["source"].transform.o[0] = 4000.0f;
@@ -55,7 +55,7 @@ int main() {
   const std::string hang = scene.trusses["source"].positionName;
   assert(magnet_snap::ApplySnapTransform(scene, *snap));
   assert(scene.trusses["source"].positionName == hang);
-  assert(magnet_snap::ApplyCommittedTrussGrouping(scene, *snap));
+  assert(magnet_snap::ApplyCommittedSnapGrouping(scene, *snap));
   assert(scene.groupObjects.size() == 1);
   const std::string groupUuid = scene.trusses["target"].parentGroupUuid;
   assert(!groupUuid.empty());
@@ -65,7 +65,7 @@ int main() {
   auto snap2 = magnet_snap::FindSnap(
       scene, {magnet_snap::ObjectType::Truss, "source-2"});
   assert(snap2);
-  assert(magnet_snap::ApplyCommittedTrussGrouping(scene, *snap2));
+  assert(magnet_snap::ApplyCommittedSnapGrouping(scene, *snap2));
   assert(scene.trusses["source-2"].parentGroupUuid == groupUuid);
   assert(scene.groupObjects.size() == 1);
 
@@ -77,8 +77,13 @@ int main() {
       scene, {magnet_snap::ObjectType::Fixture, fixture.uuid});
   assert(fixtureSnap);
   assert(fixtureSnap->kind == magnet_snap::SnapKind::FixtureToTruss);
-  assert(!fixtureSnap->needsTrussGrouping);
+  assert(fixtureSnap->needsGrouping);
   assert(std::fabs(fixtureSnap->translationDeltaMm[1] + 10.0f) < 0.001f);
+  assert(magnet_snap::ApplyCommittedSnapGrouping(scene, *fixtureSnap));
+  assert(scene.fixtures[fixture.uuid].parentGroupUuid == groupUuid);
+  assert(magnet_snap::DetachSnapSourceFromGroup(scene, *fixtureSnap));
+  assert(scene.fixtures[fixture.uuid].parentGroupUuid.empty());
+  assert(scene.trusses["target"].parentGroupUuid == groupUuid);
 
   SceneObject object;
   object.uuid = "object";

--- a/tests/scene_grouping_test.cpp
+++ b/tests/scene_grouping_test.cpp
@@ -98,27 +98,26 @@ int main() {
   assert(scene_grouping::BuildTransformTargets(scene, childSelection).size() == 1);
   const auto nestedExpanded =
       scene_grouping::ExpandSelectionForGroupHighlights(scene, childSelection);
-  assert(nestedExpanded.size() == 3);
+  assert(nestedExpanded.size() == 1);
 
   scene_grouping::TranslateSelection(scene, childSelection,
                                      {1000.0f, 2000.0f, 0.0f});
   assert(NearlyEqual(scene.fixtures[fixture.uuid].transform.o[0], 2000.0f));
-  assert(NearlyEqual(scene.trusses[truss.uuid].transform.o[0], 4000.0f));
-  assert(NearlyEqual(scene.supports[support.uuid].transform.o[0], 6000.0f));
+  assert(NearlyEqual(scene.trusses[truss.uuid].transform.o[0], 3000.0f));
+  assert(NearlyEqual(scene.supports[support.uuid].transform.o[0], 5000.0f));
   assert(NearlyEqual(scene.fixtures[fixture.uuid].transform.o[1], 2000.0f));
-  assert(NearlyEqual(scene.trusses[truss.uuid].transform.o[1], 2000.0f));
-  assert(NearlyEqual(scene.supports[support.uuid].transform.o[1], 2000.0f));
+  assert(NearlyEqual(scene.trusses[truss.uuid].transform.o[1], 0.0f));
+  assert(NearlyEqual(scene.supports[support.uuid].transform.o[1], 0.0f));
 
-
-  const scene_grouping::OperationResult nestedUngroupResult =
-      scene_grouping::UngroupSelection(scene, childSelection);
-  assert(nestedUngroupResult.changed);
-  assert(scene.groupObjects.size() == 1);
-  assert(scene.supports[support.uuid].parentGroupUuid.empty());
-  assert(!scene.fixtures[fixture.uuid].parentGroupUuid.empty());
+  const scene_grouping::OperationResult fixtureDetachResult =
+      scene_grouping::RemoveSelectionFromGroup(scene, childSelection);
+  assert(fixtureDetachResult.changed);
+  assert(scene.groupObjects.size() == 2);
+  assert(scene.fixtures[fixture.uuid].parentGroupUuid.empty());
+  assert(!scene.trusses[truss.uuid].parentGroupUuid.empty());
   assert(NearlyEqual(scene.fixtures[fixture.uuid].transform.o[0], 2000.0f));
-  assert(NearlyEqual(scene.trusses[truss.uuid].transform.o[0], 4000.0f));
-  assert(NearlyEqual(scene.supports[support.uuid].transform.o[0], 6000.0f));
+  assert(NearlyEqual(scene.trusses[truss.uuid].transform.o[0], 3000.0f));
+  assert(NearlyEqual(scene.supports[support.uuid].transform.o[0], 5000.0f));
 
   return 0;
 }

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -1534,17 +1534,22 @@ std::optional<magnet_snap::SnapSource> Viewer2DPanel::BuildActiveMagnetSource() 
 }
 
 // Finds the current Magnet snap candidate for the active single-object drag.
-std::optional<magnet_snap::SnapResult> Viewer2DPanel::FindActiveMagnetSnap(
-    bool retainingExistingSnap) const {
+std::optional<magnet_snap::SnapResult> Viewer2DPanel::FindActiveMagnetSnap() const {
   auto source = BuildActiveMagnetSource();
   if (!source)
     return std::nullopt;
-  magnet_snap::SnapSettings settings;
-  settings.thresholdMm = retainingExistingSnap
-                             ? magnet_snap::kSnapRetainDistanceMm
-                             : magnet_snap::kDefaultSnapDistanceMm;
-  return magnet_snap::FindSnap(ConfigManager::Get().GetScene(), *source,
-                               settings);
+  return magnet_snap::FindSnap(ConfigManager::Get().GetScene(), *source);
+}
+
+// Restores the raw mouse-following transform before applying the next drag delta.
+void Viewer2DPanel::RestorePendingMagnetSnapPreview() {
+  if (!m_pendingMagnetSnap)
+    return;
+  magnet_snap::SnapResult inverse = *m_pendingMagnetSnap;
+  for (float &component : inverse.translationDeltaMm)
+    component = -component;
+  magnet_snap::ApplySnapTransform(ConfigManager::Get().GetScene(), inverse);
+  m_pendingMagnetSnap.reset();
 }
 
 // Commits deferred Magnet grouping after a successful truss snap.
@@ -1577,13 +1582,11 @@ void Viewer2DPanel::ApplySelectionDelta(
   selection.trusses = m_dragTrussUuids;
   selection.supports = m_dragSupportUuids;
   selection.sceneObjects = m_dragSceneObjectUuids;
+  RestorePendingMagnetSnapPreview();
   scene_grouping::TranslateSelection(cfg.GetScene(), selection, {dxMm, dyMm, dzMm});
-  const bool wasSnapped = m_pendingMagnetSnap.has_value();
-  if (auto snap = FindActiveMagnetSnap(wasSnapped)) {
+  if (auto snap = FindActiveMagnetSnap()) {
     magnet_snap::ApplySnapTransform(cfg.GetScene(), *snap);
     m_pendingMagnetSnap = snap;
-  } else {
-    m_pendingMagnetSnap.reset();
   }
   NotifyHighlightedWorldPosition(ComputeSelectionDragCenterMeters());
   ScheduleDragTableUpdate();

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -468,6 +468,8 @@ Viewer2DPanel::Viewer2DPanel(wxWindow *parent, bool allowOffscreenRender,
       m_enableSelection(enableSelection) {
   SetBackgroundStyle(wxBG_STYLE_CUSTOM);
   m_controller.SetSelectionOutlineEnabled(m_enableSelection);
+  m_magnetEnabled = ConfigManager::Get().GetValue(
+                        magnet_snap::kMagnetEnabledConfigKey) == "1";
   m_glContext = new wxGLContext(this);
   if (m_enableSelection) {
     StartDragTableUpdateWorker();
@@ -484,6 +486,7 @@ Viewer2DPanel::~Viewer2DPanel() {
   m_dragTarget = DragTarget::None;
   m_dragSelectionUuids.clear();
   m_dragSelectionMoved = false;
+  m_pendingMagnetSnap.reset();
   m_rectSelecting = false;
   m_interactionResumeTimer.Stop();
   m_hoverHitTestTimer.Stop();
@@ -723,6 +726,15 @@ void Viewer2DPanel::SetMeasureToolEnabled(bool enabled) {
     MainWindow::Instance()->SyncViewportToolToggleState(enabled);
   SetCursor(enabled ? wxCursor(wxCURSOR_CROSS) : wxCursor(wxCURSOR_ARROW));
   RequestRepaint();
+}
+
+// Enables or disables Magnet snapping for selection dragging.
+void Viewer2DPanel::SetMagnetEnabled(bool enabled) {
+  m_magnetEnabled = enabled;
+  m_pendingMagnetSnap.reset();
+  ConfigManager::Get().SetValue(magnet_snap::kMagnetEnabledConfigKey,
+                                enabled ? "1" : "0");
+  ConfigManager::Get().SaveUserConfig();
 }
 
 // Converts a mouse position in window coordinates into the current 2D world position.
@@ -1503,6 +1515,40 @@ void Viewer2DPanel::DrawSelectionDragGizmo(int width, int height) {
     glEnable(GL_DEPTH_TEST);
 }
 
+std::optional<magnet_snap::SnapSource> Viewer2DPanel::BuildActiveMagnetSource() const {
+  if (!m_magnetEnabled || m_measureToolState.enabled)
+    return std::nullopt;
+  if (m_dragTrussUuids.size() == 1 && m_dragFixtureUuids.empty() &&
+      m_dragSupportUuids.empty() && m_dragSceneObjectUuids.empty())
+    return magnet_snap::SnapSource{magnet_snap::ObjectType::Truss,
+                                   m_dragTrussUuids.front()};
+  if (m_dragFixtureUuids.size() == 1 && m_dragTrussUuids.empty() &&
+      m_dragSupportUuids.empty() && m_dragSceneObjectUuids.empty())
+    return magnet_snap::SnapSource{magnet_snap::ObjectType::Fixture,
+                                   m_dragFixtureUuids.front()};
+  if (m_dragSceneObjectUuids.size() == 1 && m_dragFixtureUuids.empty() &&
+      m_dragTrussUuids.empty() && m_dragSupportUuids.empty())
+    return magnet_snap::SnapSource{magnet_snap::ObjectType::SceneObject,
+                                   m_dragSceneObjectUuids.front()};
+  return std::nullopt;
+}
+
+// Finds the current Magnet snap candidate for the active single-object drag.
+std::optional<magnet_snap::SnapResult> Viewer2DPanel::FindActiveMagnetSnap() const {
+  auto source = BuildActiveMagnetSource();
+  if (!source)
+    return std::nullopt;
+  return magnet_snap::FindSnap(ConfigManager::Get().GetScene(), *source);
+}
+
+// Commits deferred Magnet grouping after a successful truss snap.
+void Viewer2DPanel::CommitActiveMagnetSnap() {
+  if (!m_pendingMagnetSnap || !m_pendingMagnetSnap->needsTrussGrouping)
+    return;
+  ConfigManager &cfg = ConfigManager::Get();
+  magnet_snap::ApplyCommittedTrussGrouping(cfg.GetScene(), *m_pendingMagnetSnap);
+}
+
 void Viewer2DPanel::ApplySelectionDelta(
     const std::array<float, 3> &deltaMeters) {
   if (m_dragSelectionUuids.empty())
@@ -1526,6 +1572,11 @@ void Viewer2DPanel::ApplySelectionDelta(
   selection.supports = m_dragSupportUuids;
   selection.sceneObjects = m_dragSceneObjectUuids;
   scene_grouping::TranslateSelection(cfg.GetScene(), selection, {dxMm, dyMm, dzMm});
+  m_pendingMagnetSnap.reset();
+  if (auto snap = FindActiveMagnetSnap()) {
+    magnet_snap::ApplySnapTransform(cfg.GetScene(), *snap);
+    m_pendingMagnetSnap = snap;
+  }
   NotifyHighlightedWorldPosition(ComputeSelectionDragCenterMeters());
   ScheduleDragTableUpdate();
 }
@@ -2641,8 +2692,11 @@ void Viewer2DPanel::OnMouseUp(wxMouseEvent &event) {
   if (event.LeftUp() && m_dragMode != DragMode::None) {
     if (HasCapture())
       ReleaseMouse();
-    if (m_dragMode == DragMode::Selection && m_dragSelectionMoved)
+    if (m_dragMode == DragMode::Selection && m_dragSelectionMoved) {
+      CommitActiveMagnetSnap();
       FinalizeSelectionDrag();
+    }
+    m_pendingMagnetSnap.reset();
     m_dragMode = DragMode::None;
     m_dragAxis = DragAxis::None;
     m_dragTarget = DragTarget::None;
@@ -3025,6 +3079,7 @@ void Viewer2DPanel::OnCaptureLost(wxMouseCaptureLostEvent &WXUNUSED(event)) {
   m_dragSupportUuids.clear();
   m_dragSceneObjectUuids.clear();
   m_dragSelectionMoved = false;
+  m_pendingMagnetSnap.reset();
   m_rectSelecting = false;
   m_rectSelectionAcrossAllTables = false;
   ClearCursorWorldPosition();

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -1534,11 +1534,17 @@ std::optional<magnet_snap::SnapSource> Viewer2DPanel::BuildActiveMagnetSource() 
 }
 
 // Finds the current Magnet snap candidate for the active single-object drag.
-std::optional<magnet_snap::SnapResult> Viewer2DPanel::FindActiveMagnetSnap() const {
+std::optional<magnet_snap::SnapResult> Viewer2DPanel::FindActiveMagnetSnap(
+    bool retainingExistingSnap) const {
   auto source = BuildActiveMagnetSource();
   if (!source)
     return std::nullopt;
-  return magnet_snap::FindSnap(ConfigManager::Get().GetScene(), *source);
+  magnet_snap::SnapSettings settings;
+  settings.thresholdMm = retainingExistingSnap
+                             ? magnet_snap::kSnapRetainDistanceMm
+                             : magnet_snap::kDefaultSnapDistanceMm;
+  return magnet_snap::FindSnap(ConfigManager::Get().GetScene(), *source,
+                               settings);
 }
 
 // Commits deferred Magnet grouping after a successful truss snap.
@@ -1572,10 +1578,12 @@ void Viewer2DPanel::ApplySelectionDelta(
   selection.supports = m_dragSupportUuids;
   selection.sceneObjects = m_dragSceneObjectUuids;
   scene_grouping::TranslateSelection(cfg.GetScene(), selection, {dxMm, dyMm, dzMm});
-  m_pendingMagnetSnap.reset();
-  if (auto snap = FindActiveMagnetSnap()) {
+  const bool wasSnapped = m_pendingMagnetSnap.has_value();
+  if (auto snap = FindActiveMagnetSnap(wasSnapped)) {
     magnet_snap::ApplySnapTransform(cfg.GetScene(), *snap);
     m_pendingMagnetSnap = snap;
+  } else {
+    m_pendingMagnetSnap.reset();
   }
   NotifyHighlightedWorldPosition(ComputeSelectionDragCenterMeters());
   ScheduleDragTableUpdate();

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -1542,22 +1542,25 @@ std::optional<magnet_snap::SnapResult> Viewer2DPanel::FindActiveMagnetSnap() con
 }
 
 // Restores the raw mouse-following transform before applying the next drag delta.
-void Viewer2DPanel::RestorePendingMagnetSnapPreview() {
+std::optional<magnet_snap::SnapResult>
+Viewer2DPanel::RestorePendingMagnetSnapPreview() {
   if (!m_pendingMagnetSnap)
-    return;
-  magnet_snap::SnapResult inverse = *m_pendingMagnetSnap;
+    return std::nullopt;
+  magnet_snap::SnapResult previous = *m_pendingMagnetSnap;
+  magnet_snap::SnapResult inverse = previous;
   for (float &component : inverse.translationDeltaMm)
     component = -component;
   magnet_snap::ApplySnapTransform(ConfigManager::Get().GetScene(), inverse);
   m_pendingMagnetSnap.reset();
+  return previous;
 }
 
 // Commits deferred Magnet grouping after a successful truss snap.
 void Viewer2DPanel::CommitActiveMagnetSnap() {
-  if (!m_pendingMagnetSnap || !m_pendingMagnetSnap->needsTrussGrouping)
+  if (!m_pendingMagnetSnap || !m_pendingMagnetSnap->needsGrouping)
     return;
   ConfigManager &cfg = ConfigManager::Get();
-  magnet_snap::ApplyCommittedTrussGrouping(cfg.GetScene(), *m_pendingMagnetSnap);
+  magnet_snap::ApplyCommittedSnapGrouping(cfg.GetScene(), *m_pendingMagnetSnap);
 }
 
 void Viewer2DPanel::ApplySelectionDelta(
@@ -1582,11 +1585,13 @@ void Viewer2DPanel::ApplySelectionDelta(
   selection.trusses = m_dragTrussUuids;
   selection.supports = m_dragSupportUuids;
   selection.sceneObjects = m_dragSceneObjectUuids;
-  RestorePendingMagnetSnapPreview();
+  const auto previousSnap = RestorePendingMagnetSnapPreview();
   scene_grouping::TranslateSelection(cfg.GetScene(), selection, {dxMm, dyMm, dzMm});
   if (auto snap = FindActiveMagnetSnap()) {
     magnet_snap::ApplySnapTransform(cfg.GetScene(), *snap);
     m_pendingMagnetSnap = snap;
+  } else if (previousSnap) {
+    magnet_snap::DetachSnapSourceFromGroup(cfg.GetScene(), *previousSnap);
   }
   NotifyHighlightedWorldPosition(ComputeSelectionDragCenterMeters());
   ScheduleDragTableUpdate();

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -203,7 +203,7 @@ private:
   void ApplySelectionDelta(const std::array<float, 3> &deltaMeters);
   std::optional<magnet_snap::SnapSource> BuildActiveMagnetSource() const;
   std::optional<magnet_snap::SnapResult> FindActiveMagnetSnap() const;
-  void RestorePendingMagnetSnapPreview();
+  std::optional<magnet_snap::SnapResult> RestorePendingMagnetSnapPreview();
   void CommitActiveMagnetSnap();
   void FinalizeSelectionDrag();
   void DrawSelectionDragGizmo(int width, int height);

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -27,6 +27,7 @@
 #include "canvas2d.h"
 #include "viewer3dcontroller.h"
 #include "viewer2d_measure_tool.h"
+#include "magnet_snap.h"
 #include <wx/glcanvas.h>
 #include <wx/wx.h>
 #include <array>
@@ -150,6 +151,8 @@ public:
       const std::optional<Viewer2DRenderOverrides> &overrides);
   void SetMeasureToolEnabled(bool enabled);
   bool IsMeasureToolEnabled() const { return m_measureToolState.enabled; }
+  void SetMagnetEnabled(bool enabled);
+  bool IsMagnetEnabled() const { return m_magnetEnabled; }
   std::optional<Viewer2DRenderOverrides> GetRenderOverrides() const {
     return m_renderOverrides;
   }
@@ -198,6 +201,9 @@ private:
       const std::optional<std::array<float, 3>> &positionMeters);
   void ClearCursorWorldPosition();
   void ApplySelectionDelta(const std::array<float, 3> &deltaMeters);
+  std::optional<magnet_snap::SnapSource> BuildActiveMagnetSource() const;
+  std::optional<magnet_snap::SnapResult> FindActiveMagnetSnap() const;
+  void CommitActiveMagnetSnap();
   void FinalizeSelectionDrag();
   void DrawSelectionDragGizmo(int width, int height);
   void ApplyRectangleSelection(const wxPoint &start, const wxPoint &end,
@@ -286,6 +292,8 @@ private:
   std::vector<std::string> m_dragSceneObjectUuids;
   bool m_dragSelectionMoved = false;
   bool m_dragSelectionPushedUndo = false;
+  bool m_magnetEnabled = false;
+  std::optional<magnet_snap::SnapResult> m_pendingMagnetSnap;
   bool m_draggedSincePress = false;
   wxLongLong m_dragPressTime = 0;
   bool m_rectSelecting = false;

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -202,7 +202,8 @@ private:
   void ClearCursorWorldPosition();
   void ApplySelectionDelta(const std::array<float, 3> &deltaMeters);
   std::optional<magnet_snap::SnapSource> BuildActiveMagnetSource() const;
-  std::optional<magnet_snap::SnapResult> FindActiveMagnetSnap() const;
+  std::optional<magnet_snap::SnapResult>
+  FindActiveMagnetSnap(bool retainingExistingSnap) const;
   void CommitActiveMagnetSnap();
   void FinalizeSelectionDrag();
   void DrawSelectionDragGizmo(int width, int height);

--- a/viewer2d/viewer2dpanel.h
+++ b/viewer2d/viewer2dpanel.h
@@ -202,8 +202,8 @@ private:
   void ClearCursorWorldPosition();
   void ApplySelectionDelta(const std::array<float, 3> &deltaMeters);
   std::optional<magnet_snap::SnapSource> BuildActiveMagnetSource() const;
-  std::optional<magnet_snap::SnapResult>
-  FindActiveMagnetSnap(bool retainingExistingSnap) const;
+  std::optional<magnet_snap::SnapResult> FindActiveMagnetSnap() const;
+  void RestorePendingMagnetSnapPreview();
   void CommitActiveMagnetSnap();
   void FinalizeSelectionDrag();
   void DrawSelectionDragGizmo(int width, int height);

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -2576,18 +2576,32 @@ std::optional<magnet_snap::SnapSource> Viewer3DPanel::BuildActiveMagnetSource() 
 }
 
 // Finds the current Magnet snap candidate for the active 3D drag.
-std::optional<magnet_snap::SnapResult> Viewer3DPanel::FindActiveMagnetSnap(
-    bool retainingExistingSnap) const
+std::optional<magnet_snap::SnapResult> Viewer3DPanel::FindActiveMagnetSnap() const
 {
     auto source = BuildActiveMagnetSource();
     if (!source)
         return std::nullopt;
     magnet_snap::SnapSettings settings;
-    settings.thresholdMm = retainingExistingSnap
-                               ? magnet_snap::kSnapRetainDistanceMm
+    settings.thresholdMm = source->type == magnet_snap::ObjectType::Fixture
+                               ? magnet_snap::kDefaultSnapDistanceMm * 2.0f
                                : magnet_snap::kDefaultSnapDistanceMm;
     return magnet_snap::FindSnap(ConfigManager::Get().GetScene(), *source,
                                  settings);
+}
+
+// Restores the raw mouse-following transform before applying the next 3D drag delta.
+void Viewer3DPanel::RestorePendingMagnetSnapPreview()
+{
+    if (!m_pendingMagnetSnap)
+        return;
+    magnet_snap::SnapResult inverse = *m_pendingMagnetSnap;
+    for (float& component : inverse.translationDeltaMm)
+        component = -component;
+    magnet_snap::ApplySnapTransform(ConfigManager::Get().GetScene(), inverse);
+    m_selectionDragAnchorMeters[0] += inverse.translationDeltaMm[0] / 1000.0f;
+    m_selectionDragAnchorMeters[1] += inverse.translationDeltaMm[1] / 1000.0f;
+    m_selectionDragAnchorMeters[2] += inverse.translationDeltaMm[2] / 1000.0f;
+    m_pendingMagnetSnap.reset();
 }
 
 // Commits deferred Magnet grouping after a successful 3D truss snap.
@@ -2626,16 +2640,14 @@ void Viewer3DPanel::ApplySelectionDragDelta(const std::array<float, 3>& deltaMet
     selection.fixtures = m_dragFixtureUuids;
     selection.trusses = m_dragTrussUuids;
     selection.sceneObjects = m_dragSceneObjectUuids;
+    RestorePendingMagnetSnapPreview();
     scene_grouping::TranslateSelection(cfg.GetScene(), selection, {dxMm, dyMm, dzMm});
-    const bool wasSnapped = m_pendingMagnetSnap.has_value();
-    if (auto snap = FindActiveMagnetSnap(wasSnapped)) {
+    if (auto snap = FindActiveMagnetSnap()) {
         magnet_snap::ApplySnapTransform(cfg.GetScene(), *snap);
         m_pendingMagnetSnap = snap;
         m_selectionDragAnchorMeters[0] += snap->translationDeltaMm[0] / 1000.0f;
         m_selectionDragAnchorMeters[1] += snap->translationDeltaMm[1] / 1000.0f;
         m_selectionDragAnchorMeters[2] += snap->translationDeltaMm[2] / 1000.0f;
-    } else {
-        m_pendingMagnetSnap.reset();
     }
     m_selectionDragAnchorMeters[0] += deltaMeters[0];
     m_selectionDragAnchorMeters[1] += deltaMeters[1];

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -2590,11 +2590,12 @@ std::optional<magnet_snap::SnapResult> Viewer3DPanel::FindActiveMagnetSnap() con
 }
 
 // Restores the raw mouse-following transform before applying the next 3D drag delta.
-void Viewer3DPanel::RestorePendingMagnetSnapPreview()
+std::optional<magnet_snap::SnapResult> Viewer3DPanel::RestorePendingMagnetSnapPreview()
 {
     if (!m_pendingMagnetSnap)
-        return;
-    magnet_snap::SnapResult inverse = *m_pendingMagnetSnap;
+        return std::nullopt;
+    magnet_snap::SnapResult previous = *m_pendingMagnetSnap;
+    magnet_snap::SnapResult inverse = previous;
     for (float& component : inverse.translationDeltaMm)
         component = -component;
     magnet_snap::ApplySnapTransform(ConfigManager::Get().GetScene(), inverse);
@@ -2602,15 +2603,16 @@ void Viewer3DPanel::RestorePendingMagnetSnapPreview()
     m_selectionDragAnchorMeters[1] += inverse.translationDeltaMm[1] / 1000.0f;
     m_selectionDragAnchorMeters[2] += inverse.translationDeltaMm[2] / 1000.0f;
     m_pendingMagnetSnap.reset();
+    return previous;
 }
 
 // Commits deferred Magnet grouping after a successful 3D truss snap.
 void Viewer3DPanel::CommitActiveMagnetSnap()
 {
-    if (!m_pendingMagnetSnap || !m_pendingMagnetSnap->needsTrussGrouping)
+    if (!m_pendingMagnetSnap || !m_pendingMagnetSnap->needsGrouping)
         return;
     ConfigManager& cfg = ConfigManager::Get();
-    magnet_snap::ApplyCommittedTrussGrouping(cfg.GetScene(), *m_pendingMagnetSnap);
+    magnet_snap::ApplyCommittedSnapGrouping(cfg.GetScene(), *m_pendingMagnetSnap);
 }
 
 // Applies a world-space delta to every object in the active selection drag.
@@ -2640,7 +2642,7 @@ void Viewer3DPanel::ApplySelectionDragDelta(const std::array<float, 3>& deltaMet
     selection.fixtures = m_dragFixtureUuids;
     selection.trusses = m_dragTrussUuids;
     selection.sceneObjects = m_dragSceneObjectUuids;
-    RestorePendingMagnetSnapPreview();
+    const auto previousSnap = RestorePendingMagnetSnapPreview();
     scene_grouping::TranslateSelection(cfg.GetScene(), selection, {dxMm, dyMm, dzMm});
     if (auto snap = FindActiveMagnetSnap()) {
         magnet_snap::ApplySnapTransform(cfg.GetScene(), *snap);
@@ -2648,6 +2650,8 @@ void Viewer3DPanel::ApplySelectionDragDelta(const std::array<float, 3>& deltaMet
         m_selectionDragAnchorMeters[0] += snap->translationDeltaMm[0] / 1000.0f;
         m_selectionDragAnchorMeters[1] += snap->translationDeltaMm[1] / 1000.0f;
         m_selectionDragAnchorMeters[2] += snap->translationDeltaMm[2] / 1000.0f;
+    } else if (previousSnap) {
+        magnet_snap::DetachSnapSourceFromGroup(cfg.GetScene(), *previousSnap);
     }
     m_selectionDragAnchorMeters[0] += deltaMeters[0];
     m_selectionDragAnchorMeters[1] += deltaMeters[1];

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -2576,12 +2576,18 @@ std::optional<magnet_snap::SnapSource> Viewer3DPanel::BuildActiveMagnetSource() 
 }
 
 // Finds the current Magnet snap candidate for the active 3D drag.
-std::optional<magnet_snap::SnapResult> Viewer3DPanel::FindActiveMagnetSnap() const
+std::optional<magnet_snap::SnapResult> Viewer3DPanel::FindActiveMagnetSnap(
+    bool retainingExistingSnap) const
 {
     auto source = BuildActiveMagnetSource();
     if (!source)
         return std::nullopt;
-    return magnet_snap::FindSnap(ConfigManager::Get().GetScene(), *source);
+    magnet_snap::SnapSettings settings;
+    settings.thresholdMm = retainingExistingSnap
+                               ? magnet_snap::kSnapRetainDistanceMm
+                               : magnet_snap::kDefaultSnapDistanceMm;
+    return magnet_snap::FindSnap(ConfigManager::Get().GetScene(), *source,
+                                 settings);
 }
 
 // Commits deferred Magnet grouping after a successful 3D truss snap.
@@ -2621,13 +2627,15 @@ void Viewer3DPanel::ApplySelectionDragDelta(const std::array<float, 3>& deltaMet
     selection.trusses = m_dragTrussUuids;
     selection.sceneObjects = m_dragSceneObjectUuids;
     scene_grouping::TranslateSelection(cfg.GetScene(), selection, {dxMm, dyMm, dzMm});
-    m_pendingMagnetSnap.reset();
-    if (auto snap = FindActiveMagnetSnap()) {
+    const bool wasSnapped = m_pendingMagnetSnap.has_value();
+    if (auto snap = FindActiveMagnetSnap(wasSnapped)) {
         magnet_snap::ApplySnapTransform(cfg.GetScene(), *snap);
         m_pendingMagnetSnap = snap;
         m_selectionDragAnchorMeters[0] += snap->translationDeltaMm[0] / 1000.0f;
         m_selectionDragAnchorMeters[1] += snap->translationDeltaMm[1] / 1000.0f;
         m_selectionDragAnchorMeters[2] += snap->translationDeltaMm[2] / 1000.0f;
+    } else {
+        m_pendingMagnetSnap.reset();
     }
     m_selectionDragAnchorMeters[0] += deltaMeters[0];
     m_selectionDragAnchorMeters[1] += deltaMeters[1];

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -51,6 +51,7 @@
 #include "../gui/selection_origin_token.h"
 #include "configmanager.h"
 #include "selection_movement_settings.h"
+#include "magnet_snap.h"
 #include "scene_grouping.h"
 #include "fixturepatchdialog.h"
 #include "viewer2dpanel.h"
@@ -836,6 +837,8 @@ Viewer3DPanel::Viewer3DPanel(wxWindow* parent)
                  wxFULL_REPAINT_ON_RESIZE | wxWANTS_CHARS),
     m_glContext(new wxGLContext(this))
 {
+    m_magnetEnabled = ConfigManager::Get().GetValue(
+                          magnet_snap::kMagnetEnabledConfigKey) == "1";
     SetBackgroundStyle(wxBG_STYLE_CUSTOM);
     Bind(wxEVT_THREAD, &Viewer3DPanel::OnThreadRefresh, this, wxEVT_VIEWER_REFRESH);
     m_zoomInteractionTimer.SetOwner(this);
@@ -1715,6 +1718,7 @@ void Viewer3DPanel::OnMouseUp(wxMouseEvent& event)
         if (HasCapture())
             ReleaseMouse();
         if (m_selectionDragMoved) {
+            CommitActiveMagnetSnap();
             FinalizeSelectionDrag();
             m_draggedSincePress = true;
         }
@@ -2099,6 +2103,17 @@ void Viewer3DPanel::OnRightUp(wxMouseEvent& event)
     }
 }
 
+
+// Enables or disables Magnet snapping for 3D selection dragging.
+void Viewer3DPanel::SetMagnetEnabled(bool enabled)
+{
+    m_magnetEnabled = enabled;
+    m_pendingMagnetSnap.reset();
+    ConfigManager::Get().SetValue(magnet_snap::kMagnetEnabledConfigKey,
+                                  enabled ? "1" : "0");
+    ConfigManager::Get().SaveUserConfig();
+}
+
 // Resets interaction state after wxWidgets reports lost mouse capture.
 void Viewer3DPanel::OnCaptureLost(wxMouseCaptureLostEvent& WXUNUSED(event))
 {
@@ -2287,6 +2302,7 @@ void Viewer3DPanel::ResetSelectionDragState()
     m_dragTrussUuids.clear();
     m_dragSceneObjectUuids.clear();
     m_selectionDragAxis = viewer3d::SelectionDragAxis::None;
+    m_pendingMagnetSnap.reset();
     if (MainWindow::Instance())
         MainWindow::Instance()->ClearHighlightedWorldPositionInStatusBar();
 }
@@ -2404,6 +2420,7 @@ bool Viewer3DPanel::PrepareSelectionDrag(const wxPoint& mousePos)
     SynchronizeHoverHighlight();
 
     m_selectionDragAxis = viewer3d::SelectionDragAxis::None;
+    m_pendingMagnetSnap.reset();
     m_selectionDragArmed = true;
     m_selectionDragMoved = false;
     m_selectionDragUndoPushed = false;
@@ -2537,6 +2554,45 @@ Viewer3DPanel::ProjectMouseToSelectionDragViewPlane(
         static_cast<float>(nearPoint[2] + rayDir[2] * t)};
 }
 
+
+// Builds a Magnet snap source for the active single-object 3D drag.
+std::optional<magnet_snap::SnapSource> Viewer3DPanel::BuildActiveMagnetSource() const
+{
+    if (!m_magnetEnabled || m_measureToolEnabled)
+        return std::nullopt;
+    if (m_dragTrussUuids.size() == 1 && m_dragFixtureUuids.empty() &&
+        m_dragSceneObjectUuids.empty())
+        return magnet_snap::SnapSource{magnet_snap::ObjectType::Truss,
+                                       m_dragTrussUuids.front()};
+    if (m_dragFixtureUuids.size() == 1 && m_dragTrussUuids.empty() &&
+        m_dragSceneObjectUuids.empty())
+        return magnet_snap::SnapSource{magnet_snap::ObjectType::Fixture,
+                                       m_dragFixtureUuids.front()};
+    if (m_dragSceneObjectUuids.size() == 1 && m_dragFixtureUuids.empty() &&
+        m_dragTrussUuids.empty())
+        return magnet_snap::SnapSource{magnet_snap::ObjectType::SceneObject,
+                                       m_dragSceneObjectUuids.front()};
+    return std::nullopt;
+}
+
+// Finds the current Magnet snap candidate for the active 3D drag.
+std::optional<magnet_snap::SnapResult> Viewer3DPanel::FindActiveMagnetSnap() const
+{
+    auto source = BuildActiveMagnetSource();
+    if (!source)
+        return std::nullopt;
+    return magnet_snap::FindSnap(ConfigManager::Get().GetScene(), *source);
+}
+
+// Commits deferred Magnet grouping after a successful 3D truss snap.
+void Viewer3DPanel::CommitActiveMagnetSnap()
+{
+    if (!m_pendingMagnetSnap || !m_pendingMagnetSnap->needsTrussGrouping)
+        return;
+    ConfigManager& cfg = ConfigManager::Get();
+    magnet_snap::ApplyCommittedTrussGrouping(cfg.GetScene(), *m_pendingMagnetSnap);
+}
+
 // Applies a world-space delta to every object in the active selection drag.
 void Viewer3DPanel::ApplySelectionDragDelta(const std::array<float, 3>& deltaMeters)
 {
@@ -2565,6 +2621,14 @@ void Viewer3DPanel::ApplySelectionDragDelta(const std::array<float, 3>& deltaMet
     selection.trusses = m_dragTrussUuids;
     selection.sceneObjects = m_dragSceneObjectUuids;
     scene_grouping::TranslateSelection(cfg.GetScene(), selection, {dxMm, dyMm, dzMm});
+    m_pendingMagnetSnap.reset();
+    if (auto snap = FindActiveMagnetSnap()) {
+        magnet_snap::ApplySnapTransform(cfg.GetScene(), *snap);
+        m_pendingMagnetSnap = snap;
+        m_selectionDragAnchorMeters[0] += snap->translationDeltaMm[0] / 1000.0f;
+        m_selectionDragAnchorMeters[1] += snap->translationDeltaMm[1] / 1000.0f;
+        m_selectionDragAnchorMeters[2] += snap->translationDeltaMm[2] / 1000.0f;
+    }
     m_selectionDragAnchorMeters[0] += deltaMeters[0];
     m_selectionDragAnchorMeters[1] += deltaMeters[1];
     m_selectionDragAnchorMeters[2] += deltaMeters[2];

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -167,8 +167,8 @@ private:
         const wxPoint& mousePos, const RenderSize& renderSize) const;
     void ApplySelectionDragDelta(const std::array<float, 3>& deltaMeters);
     std::optional<magnet_snap::SnapSource> BuildActiveMagnetSource() const;
-    std::optional<magnet_snap::SnapResult>
-    FindActiveMagnetSnap(bool retainingExistingSnap) const;
+    std::optional<magnet_snap::SnapResult> FindActiveMagnetSnap() const;
+    void RestorePendingMagnetSnapPreview();
     void CommitActiveMagnetSnap();
     void UpdateSelectionDragStatusPosition();
     void FinalizeSelectionDrag();

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -29,6 +29,7 @@
 #include "viewer3dcamera.h"
 #include "viewer3dcontroller.h"
 #include "ui_render_size.h"
+#include "magnet_snap.h"
 #include <array>
 #include <memory>
 #include <string>
@@ -81,6 +82,10 @@ public:
     void SetMeasureToolEnabled(bool enabled);
     // Returns whether the 3D measure tool is currently enabled.
     bool IsMeasureToolEnabled() const { return m_measureToolEnabled; }
+    // Enables or disables Magnet snapping for 3D selection dragging.
+    void SetMagnetEnabled(bool enabled);
+    // Returns whether Magnet snapping is currently enabled for 3D selection dragging.
+    bool IsMagnetEnabled() const { return m_magnetEnabled; }
 
     enum class HoverTargetTable { None, Fixtures, Trusses, SceneObjects };
 
@@ -100,6 +105,8 @@ private:
     bool m_selectionDragArmed = false;
     bool m_selectionDragMoved = false;
     bool m_selectionDragUndoPushed = false;
+    bool m_magnetEnabled = false;
+    std::optional<magnet_snap::SnapResult> m_pendingMagnetSnap;
     wxLongLong m_selectionDragPressTime = 0;
     HoverTargetTable m_selectionDragTarget = HoverTargetTable::None;
     std::vector<std::string> m_dragSelectionUuids;
@@ -159,6 +166,9 @@ private:
     std::optional<std::array<float, 3>> ProjectMouseToSelectionDragViewPlane(
         const wxPoint& mousePos, const RenderSize& renderSize) const;
     void ApplySelectionDragDelta(const std::array<float, 3>& deltaMeters);
+    std::optional<magnet_snap::SnapSource> BuildActiveMagnetSource() const;
+    std::optional<magnet_snap::SnapResult> FindActiveMagnetSnap() const;
+    void CommitActiveMagnetSnap();
     void UpdateSelectionDragStatusPosition();
     void FinalizeSelectionDrag();
     void DrawSelectionDragGizmo(const RenderSize& renderSize);

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -168,7 +168,7 @@ private:
     void ApplySelectionDragDelta(const std::array<float, 3>& deltaMeters);
     std::optional<magnet_snap::SnapSource> BuildActiveMagnetSource() const;
     std::optional<magnet_snap::SnapResult> FindActiveMagnetSnap() const;
-    void RestorePendingMagnetSnapPreview();
+    std::optional<magnet_snap::SnapResult> RestorePendingMagnetSnapPreview();
     void CommitActiveMagnetSnap();
     void UpdateSelectionDragStatusPosition();
     void FinalizeSelectionDrag();

--- a/viewer3d/viewer3dpanel.h
+++ b/viewer3d/viewer3dpanel.h
@@ -167,7 +167,8 @@ private:
         const wxPoint& mousePos, const RenderSize& renderSize) const;
     void ApplySelectionDragDelta(const std::array<float, 3>& deltaMeters);
     std::optional<magnet_snap::SnapSource> BuildActiveMagnetSource() const;
-    std::optional<magnet_snap::SnapResult> FindActiveMagnetSnap() const;
+    std::optional<magnet_snap::SnapResult>
+    FindActiveMagnetSnap(bool retainingExistingSnap) const;
     void CommitActiveMagnetSnap();
     void UpdateSelectionDragStatusPosition();
     void FinalizeSelectionDrag();


### PR DESCRIPTION
### Motivation
- Provide a first practical, non-destructive Magnet/Snap workflow so users can snap trusses, fixtures and scene objects while dragging in the 2D viewer without modifying Hang Position or MVR structure until commit. 
- Keep core snapping logic independent of GUI code and preserve existing GroupObject semantics (create/extend groups only on committed truss-to-truss snaps).

### Description
- Added a modular core snap service (`core/magnet_snap.h` and `core/magnet_snap.cpp`) implementing typed snap sources, candidates, results, a 250 mm default threshold, translation-only snap application, and a committed-truss grouping helper.
- Extended grouping helpers by adding `scene_grouping::AddSelectionToGroup(...)` so a truss snapped to a truss already in a group is added to the existing MVR GroupObject instead of creating nested groups.
- Integrated Magnet into the 2D drag workflow (`viewer2d/viewer2dpanel.{h,cpp}`) with temporary snap application during drag and deferred grouping on mouse release, plus a persisted toggle state using the existing preferences style.
- Added UI: Lucide official `magnet.svg` toolbar icon, new toolbar toggle wiring in `gui/mainwindow_menu.cpp`, MainWindow handlers and toggle sync in `gui/mainwindow_view_shortcuts.cpp` and `gui/mainwindow.cpp`, and the view id in `gui/mainwindow/ids/view_ids.h`.
- Project build integration: added `magnet_snap.cpp` to `core/CMakeLists.txt` and registered a focused unit test `tests/magnet_snap_test.cpp` in `tests/CMakeLists.txt`.
- Documentation: updated `docs/features.md` and `docs/release-notes-draft.md` to describe Magnet behavior and persistence.

### Testing
- Ran lightweight unit runs by compiling and executing the added core tests directly: `magnet_snap_test` and `scene_grouping_test` (built with `g++ -std=c++20` against project headers) and both tests succeeded (verified snap candidate detection, transform application, Hang Position preservation, and committed-group extension behavior).
- Ran repository checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and they passed.
- Attempted a full CMake configure of the test harness in this container, which failed due to missing system `wxWidgets` packages (environment limitation), not because of code changes; local CI/maintainer builds with wxWidgets should run normally.
- Added and registered the new core test `MagnetSnapCore` in the test CMake so it will run in CI once the environment has required GUI deps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ed289a0ac8324abde51efa6ec7b03)