### PR TITLE
Fix Unicode last project path recovery

### DIFF
--- a/core/projectutils.cpp
+++ b/core/projectutils.cpp
@@ -225,6 +225,66 @@ fs::path ResolveResourcePath(const fs::path& relativePath)
     return {};
 }
 
+
+// Repairs legacy last-project paths that were saved after UTF-8 bytes were decoded as Latin-1 text.
+std::optional<std::string> RepairLegacyUtf8MojibakePath(const std::string& rawPath)
+{
+    wxString decodedAsUnicode = wxString::FromUTF8(rawPath.c_str(), rawPath.size());
+    if (decodedAsUnicode.empty())
+        return std::nullopt;
+
+    std::string originalUtf8Bytes;
+    originalUtf8Bytes.reserve(decodedAsUnicode.length());
+    for (size_t index = 0; index < decodedAsUnicode.length(); ++index) {
+        const unsigned int value = decodedAsUnicode[index].GetValue();
+        if (value > 0xFF)
+            return std::nullopt;
+        originalUtf8Bytes.push_back(static_cast<char>(value));
+    }
+
+    wxString repaired = wxString::FromUTF8(originalUtf8Bytes.c_str(),
+                                          originalUtf8Bytes.size());
+    if (repaired.empty() || repaired == decodedAsUnicode)
+        return std::nullopt;
+
+    const wxScopedCharBuffer repairedUtf8 = repaired.ToUTF8();
+    if (!repairedUtf8)
+        return std::nullopt;
+    return std::string(repairedUtf8.data(), repairedUtf8.length());
+}
+
+// Resolves a stored project path only when it points to an existing project file.
+std::optional<std::string> ResolveExistingProjectPath(const std::string& rawPath)
+{
+    fs::path candidate;
+    try {
+        candidate = PathUtils::PathFromUtf8(rawPath);
+    } catch (...) {
+        return std::nullopt;
+    }
+
+    auto isValidFile = [](const fs::path& path) {
+        std::error_code ec;
+        return fs::exists(path, ec) && fs::is_regular_file(path, ec);
+    };
+    if (candidate.is_absolute()) {
+        if (isValidFile(candidate))
+            return ToUtf8String(candidate);
+        return std::nullopt;
+    }
+    std::error_code ec;
+    fs::path currentCandidate = fs::absolute(candidate, ec);
+    if (!ec && isValidFile(currentCandidate))
+        return ToUtf8String(currentCandidate);
+    ec.clear();
+    wxFileName exe(wxStandardPaths::Get().GetExecutablePath());
+    fs::path exeBase = WxStringToPath(exe.GetPath());
+    fs::path exeCandidate = fs::absolute(exeBase / candidate, ec);
+    if (!ec && isValidFile(exeCandidate))
+        return ToUtf8String(exeCandidate);
+    return std::nullopt;
+}
+
 std::string GetLastProjectPathFile()
 {
     const auto dataDir = ResolveWritableUserDataDir();
@@ -272,31 +332,13 @@ std::optional<std::string> LoadLastProjectPath()
     std::getline(in, rawPath);
     if (rawPath.empty())
         return std::nullopt;
-    fs::path candidate;
-    try {
-        candidate = PathUtils::PathFromUtf8(rawPath);
-    } catch (...) {
-        return std::nullopt;
-    }
-    auto isValidFile = [](const fs::path& path) {
-        std::error_code ec;
-        return fs::exists(path, ec) && fs::is_regular_file(path, ec);
-    };
-    if (candidate.is_absolute()) {
-        if (isValidFile(candidate))
-            return ToUtf8String(candidate);
-        return std::nullopt;
-    }
-    std::error_code ec;
-    fs::path currentCandidate = fs::absolute(candidate, ec);
-    if (!ec && isValidFile(currentCandidate))
-        return ToUtf8String(currentCandidate);
-    ec.clear();
-    wxFileName exe(wxStandardPaths::Get().GetExecutablePath());
-    fs::path exeBase = WxStringToPath(exe.GetPath());
-    fs::path exeCandidate = fs::absolute(exeBase / candidate, ec);
-    if (!ec && isValidFile(exeCandidate))
-        return ToUtf8String(exeCandidate);
+
+    if (auto resolved = ResolveExistingProjectPath(rawPath))
+        return resolved;
+
+    if (auto repairedPath = RepairLegacyUtf8MojibakePath(rawPath))
+        return ResolveExistingProjectPath(*repairedPath);
+
     return std::nullopt;
 }
 

--- a/core/symbol_cache_manifest.cpp
+++ b/core/symbol_cache_manifest.cpp
@@ -1,9 +1,11 @@
 #include "symbol_cache_manifest.h"
+#include "filesystem_path_utils.h"
 
 #include <array>
 #include <chrono>
 #include <ctime>
 #include <exception>
+#include <filesystem>
 #include <fstream>
 #include <iomanip>
 #include <memory>
@@ -226,11 +228,21 @@ bool SymbolCacheManifest::SaveToJsonText(std::string &jsonText,
   return true;
 }
 
+// Converts a UTF-8 filesystem path into a wxString using the native platform representation.
+wxString WxStringFromUtf8Path(const std::string &path) {
+  const std::filesystem::path nativePath = PathUtils::PathFromUtf8(path);
+#ifdef _WIN32
+  return wxString(nativePath.wstring());
+#else
+  return wxString::FromUTF8(nativePath.string());
+#endif
+}
+
 // Loads the project-level manifest entry from a .pstg ZIP archive when present.
 bool SymbolCacheManifest::LoadFromProjectArchive(const std::string &projectPath,
                                                  std::string &errorMessage) {
   Clear();
-  wxFileInputStream input(projectPath);
+  wxFileInputStream input(WxStringFromUtf8Path(projectPath));
   if (!input.IsOk()) {
     errorMessage = "Could not open project archive for symbol cache manifest.";
     return false;

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -24,7 +24,7 @@ Changes since `v1.3.0`.
 - Improved 2D and 3D drag feedback so the bottom X/Y/Z status readout shows the dragged insertion-point position in a highlighted color while objects are being moved.
 
 ## Fixes
-- Fixed reopening the last project from startup when the saved path contains accented or other non-ASCII characters.
+- Fixed reopening the last project from startup and loading its symbol cache metadata when the saved path contains accented or other non-ASCII characters.
 
 - Improved Magnet snapping so fixtures and trusses release from snapped targets based on the raw mouse-following drag position, fixture-to-truss snaps join the fixture to the truss snap group, and detaching snapped fixtures or trusses preserves the rest of the group hierarchy.
 - Fixed highlighted drag-coordinate feedback so the bottom X/Y/Z readout stays visible and reliably changes font color during 2D and 3D object moves.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -24,6 +24,7 @@ Changes since `v1.3.0`.
 - Improved 2D and 3D drag feedback so the bottom X/Y/Z status readout shows the dragged insertion-point position in a highlighted color while objects are being moved.
 
 ## Fixes
+- Fixed reopening the last project from startup when the saved path contains accented or other non-ASCII characters.
 
 - Improved Magnet snapping so fixtures and trusses release from snapped targets based on the raw mouse-following drag position, fixture-to-truss snaps join the fixture to the truss snap group, and detaching snapped fixtures or trusses preserves the rest of the group hierarchy.
 - Fixed highlighted drag-coordinate feedback so the bottom X/Y/Z readout stays visible and reliably changes font color during 2D and 3D object moves.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -405,6 +405,8 @@ add_executable(truss_path_encoding_regression_test
                truss_path_encoding_regression_test.cpp
                configmanager_layoutmanager_stub.cpp
                ../core/projectutils.cpp
+               ../core/apppaths.cpp
+               ../core/filesystem_path_utils.cpp
                ../core/library/library_bootstrap.cpp
                ../core/trussdictionary.cpp
                ../core/trussloader.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1352,7 +1352,8 @@ target_include_directories(support_resolution_test PRIVATE ../models)
 add_test(NAME SupportResolution COMMAND support_resolution_test)
 
 add_executable(symbol_cache_manifest_test symbol_cache_manifest_test.cpp
-               ../core/symbol_cache_manifest.cpp)
+               ../core/symbol_cache_manifest.cpp
+               ../core/filesystem_path_utils.cpp)
 target_include_directories(symbol_cache_manifest_test PRIVATE
     ${CMAKE_SOURCE_DIR}/core
     ${CMAKE_SOURCE_DIR}/models

--- a/tests/symbol_cache_manifest_test.cpp
+++ b/tests/symbol_cache_manifest_test.cpp
@@ -1,11 +1,35 @@
 #include "symbol_cache_manifest.h"
 
 #include <cassert>
+#include <filesystem>
 #include <string>
 
+#include <wx/filename.h>
+#include <wx/init.h>
+#include <wx/wfstream.h>
+#include <wx/zipstrm.h>
+
+#include "filesystem_path_utils.h"
 #include "json.hpp"
 
 namespace {
+
+namespace fs = std::filesystem;
+
+// Converts a filesystem path to a wxString using the native platform representation.
+wxString WxStringFromPath(const fs::path &path) {
+#ifdef _WIN32
+  return wxString(path.wstring());
+#else
+  return wxString::FromUTF8(path.string());
+#endif
+}
+
+// Converts a filesystem path to UTF-8 for project APIs.
+std::string ToUtf8String(const fs::path &path) {
+  std::u8string utf8 = path.u8string();
+  return std::string(utf8.begin(), utf8.end());
+}
 
 // Builds a complete cache validation request used by manifest unit tests.
 symbol_cache::ValidationRequest BuildRequest(const std::string &hash = "hash-a") {
@@ -119,15 +143,63 @@ void TestFailedGenerationDoesNotMarkManifestValid() {
   assert(result.status == symbol_cache::ValidationStatus::MissingManifest);
 }
 
+// Writes a minimal project archive containing the symbol cache manifest entry.
+bool WriteProjectArchiveWithManifest(const fs::path &projectPath) {
+  wxFileName::Mkdir(WxStringFromPath(projectPath.parent_path()), wxS_DIR_DEFAULT,
+                    wxPATH_MKDIR_FULL);
+  wxFileOutputStream output(WxStringFromPath(projectPath));
+  if (!output.IsOk())
+    return false;
+
+  wxZipOutputStream zip(output);
+  if (!zip.IsOk())
+    return false;
+
+  const std::string manifestJson =
+      BuildManifestJson(symbol_cache::kCurrentManifestFormatVersion,
+                        symbol_cache::kCurrentPerastageSymbolFormatVersion)
+          .dump();
+  if (!zip.PutNextEntry(symbol_cache::kProjectArchiveEntryName))
+    return false;
+  zip.Write(manifestJson.data(), manifestJson.size());
+  zip.Close();
+  return output.IsOk();
+}
+
+// Verifies manifest loading from project archives whose paths contain non-ASCII characters.
+void TestProjectArchivePathUsesUtf8() {
+  const fs::path tempRoot =
+      fs::temp_directory_path() / PathUtils::PathFromUtf8("perastage_manifest_viña");
+  std::error_code ec;
+  fs::remove_all(tempRoot, ec);
+  fs::create_directories(tempRoot);
+
+  const fs::path projectPath =
+      tempRoot / PathUtils::PathFromUtf8("Escenaro_Metal_ViñaRock_1.pstg");
+  assert(WriteProjectArchiveWithManifest(projectPath));
+
+  symbol_cache::SymbolCacheManifest manifest;
+  std::string error;
+  assert(manifest.LoadFromProjectArchive(ToUtf8String(projectPath), error));
+  assert(error.empty());
+  assert(manifest.ValidateFixture(BuildRequest()).valid);
+
+  fs::remove_all(tempRoot, ec);
+}
+
 } // namespace
 
 // Runs symbol cache manifest validation and update-policy unit tests.
 int main() {
+  wxInitializer initializer;
+  assert(initializer.IsOk());
+
   TestValidManifestSkipsInspection();
   TestMissingManifestFallsBackToInspection();
   TestOutdatedManifestFallsBackToInspection();
   TestChangedGdtfHashFallsBackToInspection();
   TestSuccessfulGenerationUpdatesManifest();
   TestFailedGenerationDoesNotMarkManifestValid();
+  TestProjectArchivePathUsesUtf8();
   return 0;
 }

--- a/tests/truss_path_encoding_regression_test.cpp
+++ b/tests/truss_path_encoding_regression_test.cpp
@@ -28,6 +28,7 @@
 #include <wx/wfstream.h>
 #include <wx/zipstrm.h>
 
+#include "projectutils.h"
 #include "trussdictionary.h"
 #include "trussloader.h"
 
@@ -79,6 +80,48 @@ bool WriteArchive(const fs::path &archivePath) {
   return output.IsOk();
 }
 
+// Simulates legacy mojibake by treating UTF-8 bytes as Latin-1 text.
+std::string MangleUtf8AsLatin1(const std::string &text) {
+  wxString decodedAsUtf8 = wxString::FromUTF8(text.c_str(), text.size());
+  std::string latin1Bytes;
+  latin1Bytes.reserve(decodedAsUtf8.length());
+  for (size_t index = 0; index < decodedAsUtf8.length(); ++index) {
+    const unsigned int value = decodedAsUtf8[index].GetValue();
+    assert(value <= 0xFF);
+    latin1Bytes.push_back(static_cast<char>(value));
+  }
+  return latin1Bytes;
+}
+
+// Verifies last-project paths survive Unicode and legacy mojibake storage.
+void RunLastProjectPathCase(const fs::path &tempRoot) {
+  const fs::path projectPath =
+      tempRoot / PathUtils::PathFromUtf8("Escenaro_Metal_ViñaRock_1.pstg");
+  std::ofstream project(projectPath, std::ios::binary);
+  project << "placeholder";
+  project.close();
+
+  const std::string expectedPath = ToUtf8String(projectPath);
+  const std::string lastProjectPath = ProjectUtils::GetLastProjectPathFile();
+  std::string previousLastProject;
+  {
+    std::ifstream previousIn(lastProjectPath, std::ios::binary);
+    previousLastProject.assign(std::istreambuf_iterator<char>(previousIn),
+                               std::istreambuf_iterator<char>());
+  }
+
+  assert(ProjectUtils::SaveLastProjectPath(expectedPath));
+  assert(ProjectUtils::LoadLastProjectPath() == expectedPath);
+
+  std::ofstream legacyOut(lastProjectPath, std::ios::binary | std::ios::trunc);
+  legacyOut << MangleUtf8AsLatin1(expectedPath);
+  legacyOut.close();
+  assert(ProjectUtils::LoadLastProjectPath() == expectedPath);
+
+  std::ofstream restoreOut(lastProjectPath, std::ios::binary | std::ios::trunc);
+  restoreOut << previousLastProject;
+}
+
 void RunPathCase(const fs::path &sourceDir, const std::string &modelName,
                  const std::string &fileName) {
   fs::create_directories(sourceDir);
@@ -116,6 +159,7 @@ int main() {
               "Tramo_áéíóú.gdtf");
   RunPathCase(tempRoot / PathUtils::PathFromUtf8("source with spaces"), "FK40Q-Spaces",
               "FK40Q H-300.gdtf");
+  RunLastProjectPathCase(tempRoot);
 
   TrussDictionary::Save({});
   fs::remove_all(tempRoot, ec);


### PR DESCRIPTION
### Motivation
- Users reported startup failures when reopening the previously used project if the saved path contained accented or non-ASCII characters, caused by legacy mojibake or incorrect decoding of UTF-8 bytes.

### Description
- Added `RepairLegacyUtf8MojibakePath` and `ResolveExistingProjectPath` to `core/projectutils.cpp` and updated `LoadLastProjectPath` to first validate the stored UTF-8 path and then attempt to repair legacy UTF-8-as-Latin-1 mojibake before giving up.
- Added targeted regression coverage in `tests/truss_path_encoding_regression_test.cpp` to verify Unicode last-project persistence and legacy mojibake recovery using `RunLastProjectPathCase` and a `MangleUtf8AsLatin1` helper.
- Updated `tests/CMakeLists.txt` to include required path-utility sources for the new test cases and updated `docs/release-notes-draft.md` with a user-visible fix entry. 
- Added short, clarifying comments above the new helper functions and preserved project structure and module boundaries.

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed. 
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed. 
- Ran `git diff --check` and it reported no whitespace or trailing/merge errors. 
- Attempted `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug` but configuration failed in this environment due to missing system `wxWidgets` development files, so full build/test of the new unit was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fa1e99a8c83248f57f952d0792203)