### PR TITLE
Decouple GDTF geometry types into gdtf_geometry_types.h to fix GCC header-order build error

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -63,6 +63,7 @@ Changes since `v1.3.0`.
 
 ## Internal changes
 
+- Improved Linux GCC build reliability by separating lightweight GDTF geometry data types from loader declarations, reducing header-order coupling in the 3D resource and bounds systems.
 - Hardened the macOS installer workflow so restored vcpkg dependency caches are rebuilt when they contain stale Xcode SDK metadata, preventing old runner paths from breaking current macOS builds.
 - Improved macOS installer build diagnostics by saving full compiler logs, showing focused error context on failure, and uploading related CMake and vcpkg logs for maintainers.
 - Restored macOS installer build compatibility with newer Xcode toolchains by making GDTF metadata cache timestamp keys use an explicit portable duration representation.

--- a/viewer3d/gdtf_geometry_types.h
+++ b/viewer3d/gdtf_geometry_types.h
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "mesh.h"
+#include "types.h"
+
+struct GdtfObject {
+    Mesh mesh;
+    Matrix transform; // local transform relative to fixture
+    bool isLens = false;
+};
+
+enum class GdtfNodeType {
+    Geometry,
+    Axis,
+    Emitter
+};
+
+struct GdtfNode3D {
+    std::string stableName;
+    GdtfNodeType type = GdtfNodeType::Geometry;
+    int parentIndex = -1;
+    Matrix localTransform = Matrix{};
+    Matrix worldTransform = Matrix{};
+    bool isLens = false;
+    bool hasMesh = false;
+    Mesh mesh;
+};
+
+struct GdtfGeometryTree {
+    std::vector<GdtfNode3D> nodes;
+    std::vector<int> axisNodeIndices;
+    std::vector<int> emitterNodeIndices;
+};

--- a/viewer3d/gdtfloader.h
+++ b/viewer3d/gdtfloader.h
@@ -19,38 +19,8 @@
 
 #include <string>
 #include <vector>
-#include "mesh.h"
-// Use the Matrix definition shared by model code
-#include "types.h"
 
-struct GdtfObject {
-    Mesh mesh;
-    Matrix transform; // local transform relative to fixture
-    bool isLens = false;
-};
-
-enum class GdtfNodeType {
-    Geometry,
-    Axis,
-    Emitter
-};
-
-struct GdtfNode3D {
-    std::string stableName;
-    GdtfNodeType type = GdtfNodeType::Geometry;
-    int parentIndex = -1;
-    Matrix localTransform = Matrix{};
-    Matrix worldTransform = Matrix{};
-    bool isLens = false;
-    bool hasMesh = false;
-    Mesh mesh;
-};
-
-struct GdtfGeometryTree {
-    std::vector<GdtfNode3D> nodes;
-    std::vector<int> axisNodeIndices;
-    std::vector<int> emitterNodeIndices;
-};
+#include "gdtf_geometry_types.h"
 
 // Metadata for a GDTF model definition. Length/Width/Height correspond
 // to the desired bounding box dimensions in meters as specified in the

--- a/viewer3d/render/opaque_fixture_pass.cpp
+++ b/viewer3d/render/opaque_fixture_pass.cpp
@@ -28,7 +28,6 @@
 
 #include "configmanager.h"
 #include "fixture_mesh_color.h"
-#include "gdtfloader.h"
 #include "logger.h"
 #include "matrixutils.h"
 #include "mesh.h"

--- a/viewer3d/resources/mesh_processing.h
+++ b/viewer3d/resources/mesh_processing.h
@@ -3,7 +3,7 @@
 #include <string>
 #include <vector>
 
-#include "gdtfloader.h"
+#include "gdtf_geometry_types.h"
 #include "mesh.h"
 
 namespace viewer3d::resources {

--- a/viewer3d/resources/resource_sync_system.cpp
+++ b/viewer3d/resources/resource_sync_system.cpp
@@ -1,5 +1,6 @@
 #include "resource_sync_system.h"
 #include "filesystem_path_utils.h"
+#include "gdtfloader.h"
 #include "mesh_processing.h"
 #include "resource_path_search.h"
 

--- a/viewer3d/resources/resource_sync_system.h
+++ b/viewer3d/resources/resource_sync_system.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "mesh.h"
-#include "gdtfloader.h"
+#include "gdtf_geometry_types.h"
 #include "mesh_processing.h"
 #include "fixture.h"
 #include "sceneobject.h"


### PR DESCRIPTION
### Motivation
- Fix a Linux/GCC header-order build failure caused by `viewer3d/resources/resource_sync_system.h` including `gdtfloader.h` and exposing loader declarations where only lightweight data types are required.
- Reduce fragile coupling between culling/bounds code and the GDTF loader API by isolating pure data-type definitions into a minimal header.

### Description
- Added `viewer3d/gdtf_geometry_types.h` which contains `GdtfObject`, `GdtfNodeType`, `GdtfNode3D`, and `GdtfGeometryTree` and depends only on `string`, `vector`, `mesh.h`, and `types.h`.
- Updated `viewer3d/gdtfloader.h` to include the new type header and retain only loader/parsing declarations and metadata structs.
- Switched `viewer3d/resources/resource_sync_system.h` and `viewer3d/resources/mesh_processing.h` to include `gdtf_geometry_types.h` instead of `gdtfloader.h`, and added `gdtfloader.h` to `resource_sync_system.cpp` where loader functions are actually used.
- Removed an unnecessary `gdtfloader.h` include from `viewer3d/render/opaque_fixture_pass.cpp` to avoid pulling loader declarations into rendering headers.
- Added an internal release-note line to `docs/release-notes-draft.md` documenting the header-order / build reliability improvement.
- Preserved runtime behavior and public loader APIs; this is a header reorganization only.

### Testing
- Ran project checks: `tests/check_perastage_tree_modules.sh && tests/check_no_configmanager_get_in_gui.sh` and both succeeded.
- Attempted to configure/build with the `wsl-x64-debug` preset but CMake configuration failed in this environment due to missing `wxWidgets` development files (`wxWidgets_LIBRARIES` and `wxWidgets_INCLUDE_DIRS`), so `cmake --build build/wsl-x64-debug --parallel 8` and target builds (`mvr_sceneobject_symbol_identity_test`, `Perastage`) could not be executed here.
- Recommendation: verify full CMake configure and build on a Linux/WSL environment that has `wxWidgets` installed (or on CI) to confirm the header-order issue is resolved under GCC.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fa6fbefc88324b121e71b1cbbbec1)