### PR TITLE
Fix Linux rich text toolbar GTK warnings

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -25,6 +25,7 @@ Changes since `v1.3.0`.
 
 ## Fixes
 
+- Fixed Linux GTK layout warnings in the rich text toolbar by giving icon buttons enough themed padding while preserving the existing editing behavior.
 - Fixed Magnet fixture-to-truss snapping so fixtures snap to the actual truss edge height, stay aligned when their snapped truss or full snapped group is moved, and only snap after an intentional drag starts.
 - Improved Magnet truss snapping so grouped truss runs can snap to loose trusses using the truss run bounds while ignoring attached fixtures.
 - Fixed reopening the last project from startup and loading its symbol cache metadata when the saved path contains accented or other non-ASCII characters.

--- a/gui/layouttextdialog.cpp
+++ b/gui/layouttextdialog.cpp
@@ -37,13 +37,16 @@
 
 namespace {
 constexpr int kToolbarIconSizePx = 16;
+constexpr int kToolbarButtonSizePx = 36;
 constexpr int kMinFontSize = 6;
 constexpr int kMaxFontSize = 72;
 
+// Returns the text colour used while editing rich text.
 wxColour GetEditorTextColour() {
   return *wxWHITE;
 }
 
+// Applies a consistent text colour to the whole rich text buffer.
 void NormalizeBufferTextColour(wxRichTextBuffer &buffer,
                                const wxColour &colour) {
   wxRichTextRange range = buffer.GetRange();
@@ -55,6 +58,7 @@ void NormalizeBufferTextColour(wxRichTextBuffer &buffer,
   buffer.SetStyle(range, attr);
 }
 
+// Initializes rich text handlers once before loading or saving rich text content.
 void EnsureRichTextHandlers() {
   static bool initialized = false;
   if (initialized)
@@ -67,6 +71,7 @@ void EnsureRichTextHandlers() {
 }
 } // namespace
 
+// Creates the rich text editing dialog and wires its toolbar controls.
 LayoutTextDialog::LayoutTextDialog(wxWindow *parent,
                                    const wxString &initialRichText,
                                    const wxString &fallbackText,
@@ -86,7 +91,8 @@ LayoutTextDialog::LayoutTextDialog(wxWindow *parent,
                                               kToolbarIconSizePx));
     wxBitmapButton *button = new wxBitmapButton(
         this, wxID_ANY, bitmap, wxDefaultPosition,
-        wxSize(kToolbarIconSizePx + 6, kToolbarIconSizePx + 6));
+        wxSize(kToolbarButtonSizePx, kToolbarButtonSizePx));
+    button->SetMinSize(wxSize(kToolbarButtonSizePx, kToolbarButtonSizePx));
     button->SetToolTip(tooltip);
     button->Bind(wxEVT_BUTTON, [handler](wxCommandEvent &) { handler(); });
     toolbarSizer->Add(button, 0, wxRIGHT, 4);
@@ -153,6 +159,7 @@ LayoutTextDialog::LayoutTextDialog(wxWindow *parent,
   Centre();
 }
 
+// Returns the edited content serialized as rich text XML.
 wxString LayoutTextDialog::GetRichText() const {
   if (!textCtrl)
     return wxEmptyString;
@@ -161,18 +168,22 @@ wxString LayoutTextDialog::GetRichText() const {
   return layouttext::SaveRichTextBufferToString(bufferCopy);
 }
 
+// Returns the edited content as plain text.
 wxString LayoutTextDialog::GetPlainText() const {
   return textCtrl ? textCtrl->GetBuffer().GetText() : wxString();
 }
 
+// Returns whether the text should use a solid background.
 bool LayoutTextDialog::GetSolidBackground() const {
   return solidBackgroundCtrl ? solidBackgroundCtrl->GetValue() : true;
 }
 
+// Returns whether the text frame should be drawn.
 bool LayoutTextDialog::GetDrawFrame() const {
   return drawFrameCtrl ? drawFrameCtrl->GetValue() : true;
 }
 
+// Loads a toolbar icon from project resources with an art-provider fallback.
 wxBitmapBundle LayoutTextDialog::LoadIcon(const std::string &name) const {
   auto svgPath = ProjectUtils::ResolveResourcePath(
       std::filesystem::path("icons") / "outline" / (name + ".svg"));
@@ -189,6 +200,7 @@ wxBitmapBundle LayoutTextDialog::LoadIcon(const std::string &name) const {
                                                kToolbarIconSizePx));
 }
 
+// Loads rich text content when possible and falls back to plain text.
 void LayoutTextDialog::LoadInitialContent(const wxString &initialRichText,
                                           const wxString &fallbackText) {
   if (!textCtrl)
@@ -202,6 +214,7 @@ void LayoutTextDialog::LoadInitialContent(const wxString &initialRichText,
   textCtrl->SetValue(fallbackText);
 }
 
+// Applies the default editor text style to current and future content.
 void LayoutTextDialog::ApplyDefaultFontStyle() {
   if (!textCtrl)
     return;
@@ -222,16 +235,19 @@ void LayoutTextDialog::ApplyDefaultFontStyle() {
   textCtrl->SetStyle(range, colourOnly);
 }
 
+// Toggles bold formatting for the current rich text selection.
 void LayoutTextDialog::ApplyBold() {
   if (textCtrl)
     textCtrl->ApplyBoldToSelection();
 }
 
+// Toggles italic formatting for the current rich text selection.
 void LayoutTextDialog::ApplyItalic() {
   if (textCtrl)
     textCtrl->ApplyItalicToSelection();
 }
 
+// Applies the selected font size to the current selection or document.
 void LayoutTextDialog::ApplyFontSize(int size) {
   if (!textCtrl)
     return;
@@ -252,6 +268,7 @@ void LayoutTextDialog::ApplyFontSize(int size) {
   }
 }
 
+// Adjusts the font size control by the requested delta and applies it.
 void LayoutTextDialog::AdjustFontSize(int delta) {
   if (!fontSizeCtrl)
     return;
@@ -261,6 +278,7 @@ void LayoutTextDialog::AdjustFontSize(int delta) {
   ApplyFontSize(size);
 }
 
+// Applies paragraph alignment to the current rich text selection.
 void LayoutTextDialog::ApplyAlignment(int alignment) {
   if (!textCtrl)
     return;


### PR DESCRIPTION
### Motivation

- GTK on Linux can emit `Negative content width` warnings when themed padding doesn't fit inside very small bitmap buttons, which did not appear on Windows due to a different native backend.
- The change gives the toolbar bitmap buttons enough allocation so themes stop producing negative-content-width warnings while preserving existing editor behavior and icon sizes.

### Description

- Added a new constant `kToolbarButtonSizePx = 36` and set each rich-text toolbar `wxBitmapButton` minimum/allocation to that size in `gui/layouttextdialog.cpp` while keeping the icon bitmap at `kToolbarIconSizePx = 16` so visual behavior is preserved.
- Set the button `SetMinSize` to ensure GTK layout has enough space for theme extents and avoid negative content width calculations.
- Added concise one-line English comments above the touched C++ function definitions in `gui/layouttextdialog.cpp` and updated `docs/release-notes-draft.md` with a short fix entry describing the GTK warning fix.

### Testing

- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.
- Ran `git diff --check` to validate no whitespace/patch issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fce285764832483762fca690f12a0)