### PR TITLE
Refine GDTF persistence policy to avoid auto-promoting project files to user library

### DIFF
--- a/core/gdtfdictionary.cpp
+++ b/core/gdtfdictionary.cpp
@@ -915,45 +915,53 @@ std::optional<std::string> GetDefaultColorForFixture(
   return matchedColor;
 }
 
-// Updates a fixture dictionary entry and applies deterministic GDTF copy/overwrite rules.
-void Update(const std::string &type, const std::string &gdtfPath, const std::string &mode, const std::string &category) {
+// Updates one dictionary entry without performing any fixture file copies.
+void UpdateDictionaryEntry(const std::string &type, const Entry &entry) {
   std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
   const std::string normalizedType = NormalizeTypeKey(type);
-  if (normalizedType.empty() || gdtfPath.empty())
-    return;
-  if (IsDummy1ChFallbackType(normalizedType) || IsDummy1ChFallbackPath(gdtfPath))
-    return;
-  const fs::path src = PathUtils::PathFromUtf8(gdtfPath);
-  if (!fs::exists(src))
-    return;
-  const fs::path file = GetConfiguredUserDictFile();
-  if (file.empty())
-    return;
-
-  const bool sourceIsPerastageNamed = IsPerastageNamedGdtfFile(src);
-  const fs::path defaultDest = file.parent_path() / src.filename();
-  const fs::path perastageDest =
-      file.parent_path() / BuildPerastageCanonicalGdtfFileName(src);
-  const fs::path dest = sourceIsPerastageNamed ? defaultDest : perastageDest;
-  const FileImportUtils::ConflictPolicy policy = sourceIsPerastageNamed
-                                                     ? FileImportUtils::ConflictPolicy::Overwrite
-                                                     : FileImportUtils::ConflictPolicy::Rename;
-  const auto copyResult = FileImportUtils::CopyWithConflictPolicy(src, dest, policy);
-  if (!copyResult.success)
+  if (normalizedType.empty())
     return;
 
   auto dictOpt = Load();
   if (!dictOpt)
-    return; // avoid overwriting existing dictionary on load failure
+    return;
   auto &dict = *dictOpt;
   std::string keyToUse = type;
   if (auto existingKey = FindEquivalentTypeKey(dict, normalizedType))
     keyToUse = *existingKey;
-  Entry e;
-  auto it = dict.find(keyToUse);
-  if (it != dict.end())
-    e = it->second;
+  dict[keyToUse] = entry;
+  Save(dict);
+}
 
+// Creates or refreshes a stable @Perastage derivative for a library-owned GDTF.
+std::optional<Entry> CreateOrUpdatePerastageLibraryDerivative(
+    const std::string &type, const std::string &gdtfPath, const std::string &mode,
+    const std::string &category) {
+  std::lock_guard<std::recursive_mutex> lock(StartupFileAccessGate::Mutex());
+  const std::string normalizedType = NormalizeTypeKey(type);
+  if (normalizedType.empty() || gdtfPath.empty())
+    return std::nullopt;
+  if (IsDummy1ChFallbackType(normalizedType) || IsDummy1ChFallbackPath(gdtfPath))
+    return std::nullopt;
+
+  const fs::path src = PathUtils::PathFromUtf8(gdtfPath);
+  if (!fs::exists(src))
+    return std::nullopt;
+  const fs::path file = GetConfiguredUserDictFile();
+  if (file.empty())
+    return std::nullopt;
+
+  const fs::path dest = IsPerastageNamedGdtfFile(src)
+                            ? file.parent_path() / src.filename()
+                            : file.parent_path() / BuildPerastageCanonicalGdtfFileName(src);
+  const auto copyResult = FileImportUtils::CopyWithConflictPolicy(
+      src, dest, FileImportUtils::ConflictPolicy::Overwrite);
+  if (!copyResult.success)
+    return std::nullopt;
+
+  Entry e;
+  if (auto existing = Get(type))
+    e = *existing;
   e.path = copyResult.finalPath.string();
   if (!mode.empty())
     e.mode = mode;
@@ -961,9 +969,13 @@ void Update(const std::string &type, const std::string &gdtfPath, const std::str
     e.category = category;
   e.importedAt = FileImportUtils::NowUtcIso8601();
   e.sha256 = copyResult.finalSha256;
+  UpdateDictionaryEntry(type, e);
+  return e;
+}
 
-  dict[keyToUse] = e;
-  Save(dict);
+// Registers an explicit user-library fixture import using deterministic @Perastage derivative rules.
+void Update(const std::string &type, const std::string &gdtfPath, const std::string &mode, const std::string &category) {
+  (void)CreateOrUpdatePerastageLibraryDerivative(type, gdtfPath, mode, category);
 }
 
 

--- a/core/gdtfdictionary.h
+++ b/core/gdtfdictionary.h
@@ -65,8 +65,14 @@ namespace GdtfDictionary {
     std::optional<std::string> GetDefaultColorForFixture(
         const std::string& type, const std::string& gdtfPath,
         const std::string& mode);
-    // Copies the gdtf file into the fixtures library and updates the dictionary
+    // Copies a user-selected GDTF into the fixtures library and updates the dictionary.
     void Update(const std::string& type, const std::string& gdtfPath, const std::string& mode = {}, const std::string& category = {});
+    // Creates or overwrites the stable @Perastage derivative for a library fixture and updates the dictionary.
+    std::optional<Entry> CreateOrUpdatePerastageLibraryDerivative(
+        const std::string& type, const std::string& gdtfPath,
+        const std::string& mode = {}, const std::string& category = {});
+    // Updates dictionary metadata without copying fixture files into the library.
+    void UpdateDictionaryEntry(const std::string& type, const Entry& entry);
     void UpdateCategory(const std::string& type, const std::string& category);
     void UpdateCategoryForFile(const std::string& type, const std::string& gdtfPath,
                                const std::string& category);

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -25,6 +25,7 @@ Changes since `v1.3.0`.
 
 ## Fixes
 
+- Fixed GDTF persistence so automatic symbol generation and project-scoped fixture edits update project-owned copies or stable @Perastage library derivatives without filling the user fixture library with imported or generated project files.
 - Fixed Linux GTK layout warnings in the rich text toolbar by giving icon buttons enough themed padding while preserving the existing editing behavior.
 - Fixed Magnet fixture-to-truss snapping so fixtures snap to the actual truss edge height, stay aligned when their snapped truss or full snapped group is moved, and only snap after an intentional drag starts.
 - Improved Magnet truss snapping so grouped truss runs can snap to loose trusses using the truss run bounds while ignoring attached fixtures.

--- a/gui/fixtureeditdialog.cpp
+++ b/gui/fixtureeditdialog.cpp
@@ -18,11 +18,11 @@
 #include "fixtureeditdialog.h"
 #include "fixturepreviewpanel.h"
 #include "fixturetablepanel.h"
+#include "filesystem_path_utils.h"
 #include "gdtfdictionary.h"
 #include "gdtfloader.h"
 #include "gdtf_mutation_audit.h"
 #include "projectutils.h"
-#include "gdtf_fixture_category.h"
 #include "symbolcache.h"
 #include "symbols/PerastageSvgSymbol.h"
 #include "viewer2dpanel.h"
@@ -43,8 +43,43 @@
 #include <memory>
 #include <algorithm>
 #include <initializer_list>
+#include <filesystem>
 
 namespace {
+
+// Checks whether a path resolves inside a candidate parent directory.
+bool IsPathInsideDirectory(const std::filesystem::path &path,
+                           const std::filesystem::path &directory) {
+  if (path.empty() || directory.empty())
+    return false;
+
+  std::error_code ec;
+  const std::filesystem::path canonicalPath =
+      std::filesystem::weakly_canonical(path, ec);
+  if (ec)
+    return false;
+  ec.clear();
+  const std::filesystem::path canonicalDirectory =
+      std::filesystem::weakly_canonical(directory, ec);
+  if (ec)
+    return false;
+
+  auto pathIt = canonicalPath.begin();
+  auto dirIt = canonicalDirectory.begin();
+  for (; dirIt != canonicalDirectory.end(); ++dirIt, ++pathIt) {
+    if (pathIt == canonicalPath.end() || *pathIt != *dirIt)
+      return false;
+  }
+  return true;
+}
+
+// Checks whether a GDTF path belongs to the writable user fixture library.
+bool IsUserFixtureLibraryPath(const std::string &path) {
+  const std::filesystem::path candidate = PathUtils::PathFromUtf8(path);
+  return IsPathInsideDirectory(
+      candidate,
+      PathUtils::PathFromUtf8(ProjectUtils::GetWritableLibraryPath("fixtures")));
+}
 
 bool ParseFloatOrDefault(const wxString &text, float &out) {
   double parsed = 0.0;
@@ -924,16 +959,33 @@ void FixtureEditDialog::ApplyChanges() {
       const bool gdtfPhysicalChanged =
           std::fabs(newPowerW - originalPowerW) > 0.01f ||
           std::fabs(newWeightKg - originalWeightKg) > 0.01f;
-      if (gdtfPhysicalCandidateChanged && gdtfPhysicalChanged &&
-          !SetGdtfProperties(std::string(gdtfPath.ToUTF8()), newWeightKg,
-                             newPowerW,
-                             GdtfMutationAudit::BuildPerastageModifiedBy())) {
-        wxMessageBox(
-            "Could not update GDTF physical properties (Weight/PowerConsumption).",
-            "GDTF update", wxOK | wxICON_WARNING, this);
-      } else if (gdtfPhysicalCandidateChanged && gdtfPhysicalChanged) {
-        originalPowerW = newPowerW;
-        originalWeightKg = newWeightKg;
+      if (gdtfPhysicalCandidateChanged && gdtfPhysicalChanged) {
+        std::string writableGdtfPath = std::string(gdtfPath.ToUTF8());
+        if (IsUserFixtureLibraryPath(writableGdtfPath)) {
+          auto derivative = GdtfDictionary::CreateOrUpdatePerastageLibraryDerivative(
+              std::string(originalType.ToUTF8()), writableGdtfPath);
+          if (derivative && !derivative->path.empty()) {
+            writableGdtfPath = derivative->path;
+            gdtfPath = wxString::FromUTF8(derivative->path);
+            if (modelCtrl)
+              modelCtrl->SetValue(gdtfPath);
+            if (panel && row >= 0) {
+              if (static_cast<size_t>(row) >= panel->gdtfPaths.size())
+                panel->gdtfPaths.resize(static_cast<size_t>(row) + 1);
+              panel->gdtfPaths[static_cast<size_t>(row)] = gdtfPath;
+              table->SetValue(wxVariant(wxFileName(gdtfPath).GetFullName()), row, 9);
+            }
+          }
+        }
+        if (!SetGdtfProperties(writableGdtfPath, newWeightKg, newPowerW,
+                               GdtfMutationAudit::BuildPerastageModifiedBy())) {
+          wxMessageBox(
+              "Could not update GDTF physical properties (Weight/PowerConsumption).",
+              "GDTF update", wxOK | wxICON_WARNING, this);
+        } else {
+          originalPowerW = newPowerW;
+          originalWeightKg = newWeightKg;
+        }
       }
     }
 
@@ -941,20 +993,7 @@ void FixtureEditDialog::ApplyChanges() {
       std::string mode =
           modeChoice ? std::string(modeChoice->GetStringSelection().ToUTF8())
                      : std::string();
-      wxVariant categoryVar;
-      table->GetValue(categoryVar, row, 18);
-      const std::string category = GdtfFixtureCategory::NormalizeCategory(
-          std::string(categoryVar.GetString().ToUTF8()));
-      const bool modeOnlyChange =
-          (modifiedColumns.size() > 7 && modifiedColumns[7]) &&
-          !(modifiedColumns.size() > 2 && modifiedColumns[2]) &&
-          !(modifiedColumns.size() > 9 && modifiedColumns[9]) &&
-          !(modifiedColumns.size() > 18 && modifiedColumns[18]);
-      if (!modeOnlyChange) {
-        // Keep dictionary default modes immutable outside dictionary editor.
-        GdtfDictionary::Update(std::string(originalType.ToUTF8()),
-                               std::string(gdtfPath.ToUTF8()), {}, category);
-      }
+      // Project fixture metadata edits stay project-scoped and do not promote files into the user library.
       panel->ApplyModeForGdtf(gdtfPath, wxString::FromUTF8(mode));
     }
   }

--- a/gui/fixturetablepanel.cpp
+++ b/gui/fixturetablepanel.cpp
@@ -557,14 +557,7 @@ void FixtureTablePanel::OnContextMenu(wxDataViewEvent &event) {
       if (changed)
         ApplyModeForGdtf(path, dictMode);
 
-      // Keep dictionary default modes immutable from project table edits.
-      for (size_t idx = 0; idx < selections.size(); ++idx) {
-        int r = table->ItemToRow(selections[idx]);
-        if (r == wxNOT_FOUND)
-          continue;
-        if (changed)
-          GdtfDictionary::Update(prevTypes[idx], pathUtf8);
-      }
+      // Project table GDTF changes stay project-scoped and do not promote files into the user library.
     }
     if (!changed)
       return;

--- a/gui/windows/symbol_fixture_applier.cpp
+++ b/gui/windows/symbol_fixture_applier.cpp
@@ -652,12 +652,29 @@ bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
   }
 
   if (options.updateSceneCopy && writableScenePath.empty() && !scene.basePath.empty() &&
-      !libraryPath.empty()) {
+      !libraryPath.empty() && !options.updateLibraryCopy) {
     if (!EnsureSceneLocalGdtfCopy(fs::path(libraryPath), fs::path(scene.basePath),
                                   fixtureIt->second, writableScenePath,
                                   errorMessage)) {
       return false;
     }
+  }
+
+  if (options.updateLibraryCopy && !libraryPath.empty() &&
+      !fixtureIt->second.typeName.empty()) {
+    auto derivative = GdtfDictionary::CreateOrUpdatePerastageLibraryDerivative(
+        fixtureIt->second.typeName, libraryPath, fixtureIt->second.gdtfMode,
+        fixtureIt->second.category);
+    if (!derivative || derivative->path.empty()) {
+      errorMessage = "Could not create the Perastage library fixture derivative.";
+      return false;
+    }
+    if (!RewriteGdtf(derivative->path, payloads, topSvgPath, sideSvgPath,
+                     frontSvgPath, bottomSvgPath, errorMessage)) {
+      return false;
+    }
+    fixtureIt->second.gdtfSpec = fs::path(derivative->path).filename().string();
+    return true;
   }
 
   if (options.updateSceneCopy && !writableScenePath.empty()) {
@@ -668,21 +685,9 @@ bool ApplySymbolsToFixtureGdtf(const std::vector<symbols::Symbol2D> &symbols,
     sceneUpdated = true;
   }
 
-  if (options.updateLibraryCopy && !libraryPath.empty()) {
-    const bool libraryEqualsScene =
-        !writableScenePath.empty() && libraryPath == writableScenePath;
-    if (!libraryEqualsScene &&
-        !RewriteGdtf(libraryPath, payloads, topSvgPath, sideSvgPath, frontSvgPath,
-                     bottomSvgPath, errorMessage)) {
-      if (!sceneUpdated)
-        return false;
-    }
-  }
-
-  if (libraryPath.empty() && !writableScenePath.empty() &&
-      !fixtureIt->second.typeName.empty()) {
-    // Keep dictionary default modes immutable outside dictionary editor.
-    GdtfDictionary::Update(fixtureIt->second.typeName, writableScenePath);
+  if (!sceneUpdated) {
+    errorMessage = "Could not resolve a project-owned fixture GDTF copy to update.";
+    return false;
   }
 
   return true;
@@ -793,6 +798,7 @@ bool InspectFixtureSymbolState(const Fixture &fixture,
   return true;
 }
 
+// Synchronizes only library-owned fixture changes back to a stable @Perastage derivative.
 bool SyncFixtureGdtfToLibrary(const Fixture &fixture,
                               const MvrScene &scene,
                               std::string &errorMessage) {
@@ -806,10 +812,13 @@ bool SyncFixtureGdtfToLibrary(const Fixture &fixture,
   if (scenePath.empty() || libraryPath.empty() || scenePath == libraryPath)
     return true;
 
-  std::error_code ec;
-  fs::copy_file(scenePath, libraryPath, fs::copy_options::overwrite_existing, ec);
-  if (ec) {
-    errorMessage = "Could not update fixture in the fixtures library.";
+  if (resolution.libraryPath.empty())
+    return true;
+
+  auto derivative = GdtfDictionary::CreateOrUpdatePerastageLibraryDerivative(
+      fixture.typeName, scenePath, fixture.gdtfMode, fixture.category);
+  if (!derivative) {
+    errorMessage = "Could not update the Perastage library fixture derivative.";
     return false;
   }
   return true;


### PR DESCRIPTION
### Motivation

- Prevent automatic or derived GDTF writes from polluting the user `library/fixtures` by making promotion to the user library explicit.
- Make dictionary updates and file-copy/derivative creation separate responsibilities so metadata changes do not implicitly create library files.
- Ensure project-owned GDTFs remain project-scoped and persistent when saved, and that Perastage-modified library fixtures use a stable `@Perastage` derivative that is overwritten on update.

### Description

- Split `GdtfDictionary::Update(...)` responsibilities into three explicit operations: `CreateOrUpdatePerastageLibraryDerivative(...)`, `UpdateDictionaryEntry(...)`, and kept `Update(...)` as the explicit user-library import path. (files: `core/gdtfdictionary.h`, `core/gdtfdictionary.cpp`)
- Route automatic symbol application to either a project/scene copy or a stable `@Perastage` derivative: `ApplySymbolsToFixtureGdtf(...)` now writes symbols to the resolved project file when project-owned, or creates/overwrites the stable `@Perastage` derivative for library-owned fixtures and updates the fixture spec to point to it. (file: `gui/windows/symbol_fixture_applier.cpp`)
- Stop silent promotion from project table and edit flows by removing automatic `GdtfDictionary::Update(...)` calls from project-scoped paths and making fixture edit physical-property edits create a derivative first for user-library fixtures before mutating content. (files: `gui/fixturetablepanel.cpp`, `gui/fixtureeditdialog.cpp`)
- Add a small helper to detect writable user library paths and keep the existing `@Perastage` naming convention and conflict policy consistent; update release notes to document the fix. (file: `gui/fixtureeditdialog.cpp`, `docs/release-notes-draft.md`)

### Testing

- `tests/check_perastage_tree_modules.sh` was run and passed.
- `tests/check_no_configmanager_get_in_gui.sh` was run and passed.
- `git diff --check` was run and reported no whitespace/patch errors.
- `cmake --preset wsl-x64-debug` was attempted and configuration failed in this environment because `wxWidgets` is not available (build attempt not completed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fd1d517ac8324bb1075831459de16)