### PR TITLE
Add truss insertion options

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -85,6 +85,7 @@ Additional safeguards include:
 ### Data tables
 
 - Dedicated tables for fixtures, trusses, hoists, and objects.
+- Add Truss supports quantity, real-world insertion-point coordinates in the active distance units, automatic linear placement from the selected truss bounding-box length, and optional default grouping into one bridge.
 - Multi-row editing helpers include fills, ranges, interpolation, and relative expressions.
 - **Group** and **Ungroup** in the Edit menu create and remove MVR-compatible GroupObject hierarchy from the active cross-table selection across fixtures, trusses, hoists, and scene objects while preserving world placement and hang-position assignments; after grouping, clicking a member selects the full group across related tables, and the selection highlights and moves/rotates the full group, including nested groups, while hovering a grouped member uses a more yellow primary highlight and a paler related-green highlight on the other group members in the 3D view and related tables using the same row style as table selection.
 - CSV export is available through file/export workflows.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -10,6 +10,7 @@ Changes since `v1.3.0`.
 - Added a project-persistent Axis Lock toolbar toggle for selection dragging, enabled by default for axis-constrained moves and allowing free 2D movement plus Blender-style view-plane movement in 3D when disabled.
 - Expanded basic primitive creation and editing for spheres, cubes, and cylinders with editable names, project-persistent default dimensions, default load/save buttons, and richer edit controls for position and rotation.
 - Added Edit menu Group and Ungroup commands with `Ctrl+G` and `Ctrl+U` shortcuts for cross-table scene selections, preserving object placement and hang-position assignments while using MVR-compatible GroupObject hierarchy.
+- Expanded Add Truss with real-world X/Y/Z insertion coordinates in the active distance units, automatic multi-truss line placement, and default grouping into one bridge.
 - Added Help menu actions to open the local logs folder and export a manual diagnostic report for troubleshooting.
 - Added a startup update reminder checkbox so users can stop seeing repeated prompts for the same available version while keeping manual update checks available.
 

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -1,6 +1,7 @@
 target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/about_dialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/addfixturedialog.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/addtrussdialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/addressdialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/columnselectiondialog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/consolepanel.cpp

--- a/gui/addtrussdialog.cpp
+++ b/gui/addtrussdialog.cpp
@@ -1,0 +1,116 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "addtrussdialog.h"
+
+#include "configmanager.h"
+#include "guiconfigservices.h"
+#include "ui_unit_utils.h"
+#include "units/unit_label_utils.h"
+
+#include <string>
+
+#include <wx/button.h>
+#include <wx/checkbox.h>
+#include <wx/sizer.h>
+#include <wx/spinctrl.h>
+#include <wx/stattext.h>
+
+namespace {
+
+// Resolves the active project distance unit for add-truss coordinates.
+Units::DistanceUnitSystem ResolveDistanceUnitSystem() {
+  auto &cfg = GetDefaultGuiConfigServices().LegacyConfigManager();
+  return UiUnitUtils::ParseDistanceUnitSystem(
+      cfg.GetValue("ui_distance_unit_system"));
+}
+
+// Builds a coordinate label with the active distance unit suffix.
+wxString CoordinateLabel(const char *axis, Units::DistanceUnitSystem unitSystem) {
+  const std::string label = Units::LabelWithUnit(
+      std::string("Insertion point ") + axis,
+      UiUnitUtils::DistanceUnitSuffix(unitSystem));
+  return wxString::FromUTF8(label + ":");
+}
+
+// Adds a signed world-coordinate editor row to the dialog grid.
+wxSpinCtrlDouble *AddCoordinateRow(wxWindow *parent, wxFlexGridSizer *grid,
+                                   const char *axis,
+                                   Units::DistanceUnitSystem unitSystem) {
+  grid->Add(new wxStaticText(parent, wxID_ANY, CoordinateLabel(axis, unitSystem)),
+            0, wxALIGN_CENTER_VERTICAL);
+  auto *ctrl = new wxSpinCtrlDouble(parent, wxID_ANY);
+  ctrl->SetRange(
+      UiUnitUtils::DistanceMillimetersToDisplay(-1000000.0, unitSystem),
+      UiUnitUtils::DistanceMillimetersToDisplay(1000000.0, unitSystem));
+  ctrl->SetIncrement(0.1);
+  ctrl->SetDigits(2);
+  ctrl->SetValue(0.0);
+  grid->Add(ctrl, 1, wxEXPAND);
+  return ctrl;
+}
+
+} // namespace
+
+// Creates the add-truss options dialog.
+AddTrussDialog::AddTrussDialog(wxWindow *parent)
+    : wxDialog(parent, wxID_ANY, "Add Truss", wxDefaultPosition, wxDefaultSize,
+               wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER) {
+  const auto unitSystem = ResolveDistanceUnitSystem();
+
+  auto *root = new wxBoxSizer(wxVERTICAL);
+  auto *grid = new wxFlexGridSizer(5, 2, 8, 8);
+  grid->AddGrowableCol(1, 1);
+
+  grid->Add(new wxStaticText(this, wxID_ANY, "Quantity:"), 0,
+            wxALIGN_CENTER_VERTICAL);
+  quantityCtrl_ = new wxSpinCtrl(this, wxID_ANY);
+  quantityCtrl_->SetRange(1, 1000);
+  quantityCtrl_->SetValue(1);
+  grid->Add(quantityCtrl_, 1, wxEXPAND);
+
+  xCtrl_ = AddCoordinateRow(this, grid, "X", unitSystem);
+  yCtrl_ = AddCoordinateRow(this, grid, "Y", unitSystem);
+  zCtrl_ = AddCoordinateRow(this, grid, "Z", unitSystem);
+
+  grid->AddSpacer(1);
+  createGroupCtrl_ = new wxCheckBox(this, wxID_ANY, "Create group");
+  createGroupCtrl_->SetValue(true);
+  grid->Add(createGroupCtrl_, 1, wxEXPAND);
+
+  root->Add(grid, 1, wxALL | wxEXPAND, 12);
+  root->Add(CreateSeparatedButtonSizer(wxOK | wxCANCEL), 0,
+            wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND, 12);
+  SetSizerAndFit(root);
+  CentreOnParent();
+}
+
+// Returns the requested truss quantity, insertion point, and grouping mode.
+AddTrussRequest AddTrussDialog::GetRequest() const {
+  const auto unitSystem = ResolveDistanceUnitSystem();
+  AddTrussRequest request;
+  request.quantity = quantityCtrl_ ? quantityCtrl_->GetValue() : 1;
+  request.insertionPointMm = {
+      static_cast<float>(UiUnitUtils::DistanceDisplayToMillimeters(
+          xCtrl_ ? xCtrl_->GetValue() : 0.0, unitSystem)),
+      static_cast<float>(UiUnitUtils::DistanceDisplayToMillimeters(
+          yCtrl_ ? yCtrl_->GetValue() : 0.0, unitSystem)),
+      static_cast<float>(UiUnitUtils::DistanceDisplayToMillimeters(
+          zCtrl_ ? zCtrl_->GetValue() : 0.0, unitSystem))};
+  request.createGroup = createGroupCtrl_ ? createGroupCtrl_->GetValue() : true;
+  return request;
+}

--- a/gui/addtrussdialog.h
+++ b/gui/addtrussdialog.h
@@ -1,0 +1,46 @@
+/*
+ * This file is part of Perastage.
+ * Copyright (C) 2025 Luisma Peramato
+ *
+ * Perastage is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Perastage is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Perastage. If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <array>
+
+#include <wx/dialog.h>
+
+class wxCheckBox;
+class wxSpinCtrl;
+class wxSpinCtrlDouble;
+
+struct AddTrussRequest {
+  int quantity = 1;
+  std::array<float, 3> insertionPointMm{0.0f, 0.0f, 0.0f};
+  bool createGroup = true;
+};
+
+class AddTrussDialog final : public wxDialog {
+public:
+  explicit AddTrussDialog(wxWindow *parent);
+
+  AddTrussRequest GetRequest() const;
+
+private:
+  wxSpinCtrl *quantityCtrl_ = nullptr;
+  wxSpinCtrlDouble *xCtrl_ = nullptr;
+  wxSpinCtrlDouble *yCtrl_ = nullptr;
+  wxSpinCtrlDouble *zCtrl_ = nullptr;
+  wxCheckBox *createGroupCtrl_ = nullptr;
+};

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -51,6 +51,7 @@
 #include <wx/window.h>
 
 #include "addfixturedialog.h"
+#include "addtrussdialog.h"
 #include "autopatcher.h"
 #include "ui_feature_flags.h"
 #include "configmanager.h"
@@ -85,6 +86,7 @@
 #include "riggingpanel.h"
 #include "scene_object_primitive_dialogs.h"
 #include "scene_object_primitive_creation.h"
+#include "scene_grouping.h"
 #include "sceneobjecttablepanel.h"
 #include "selectfixturetypedialog.h"
 #include "selectnamedialog.h"
@@ -1380,8 +1382,11 @@ void MainWindow::OnAddTruss(wxCommandEvent &WXUNUSED(event)) {
   if (!baseTruss.name.empty())
     defaultName = baseTruss.name;
 
-  long qty = wxGetNumberFromUser("Enter truss quantity:", wxEmptyString,
-                                 "Add Truss", 1, 1, 1000, this);
+  AddTrussDialog addDialog(this);
+  if (addDialog.ShowModal() != wxID_OK)
+    return;
+  const AddTrussRequest addRequest = addDialog.GetRequest();
+  const long qty = addRequest.quantity;
   if (qty <= 0)
     return;
 
@@ -1411,6 +1416,10 @@ void MainWindow::OnAddTruss(wxCommandEvent &WXUNUSED(event)) {
     scene.layers[layer.uuid] = layer;
   }
 
+  std::vector<std::string> addedTrussUuids;
+  addedTrussUuids.reserve(static_cast<size_t>(qty));
+  const float trussSpacingMm =
+      baseTruss.lengthMm > 0.0f ? baseTruss.lengthMm : 0.0f;
   for (long i = 0; i < qty; ++i) {
     Truss t = baseTruss;
     t.uuid = wxString::Format("uuid_%lld", static_cast<long long>(baseId + i))
@@ -1420,7 +1429,20 @@ void MainWindow::OnAddTruss(wxCommandEvent &WXUNUSED(event)) {
     else
       t.name = defaultName;
     t.layer = layerName;
+    t.parentGroupUuid.clear();
+    t.hasLocalTransform = false;
+    t.transform.o = {addRequest.insertionPointMm[0] + trussSpacingMm * i,
+                     addRequest.insertionPointMm[1],
+                     addRequest.insertionPointMm[2]};
+    t.localTransform = t.transform;
     scene.trusses[t.uuid] = t;
+    addedTrussUuids.push_back(t.uuid);
+  }
+
+  if (addRequest.createGroup && addedTrussUuids.size() > 1) {
+    scene_grouping::ObjectSelection selection;
+    selection.trusses = addedTrussUuids;
+    scene_grouping::GroupSelection(scene, selection);
   }
 
   if (trussPanel)


### PR DESCRIPTION
### Motivation
- Replace the minimal single-number prompt for adding trusses with a dialog that allows specifying world `X/Y/Z` insertion coordinates in the active distance units, quantity, and a default-on grouping option. 
- Preserve existing placement behavior while enabling sensible multi-truss placement (first truss at the insertion point, following trusses spaced by the truss bounding-box length) and optional creation of a single MVR `GroupObject` for the run. 

### Description
- Added a new dialog `gui/addtrussdialog.h` / `gui/addtrussdialog.cpp` that captures `quantity`, world `insertionPointMm` (displayed in the active project distance units and converted to millimeters), and a `createGroup` checkbox defaulting to `true`. 
- Wired the new dialog into `MainWindow::OnAddTruss` (`gui/mainwindow_menu.cpp`) to replace the old `wxGetNumberFromUser` flow and to create `qty` trusses placed linearly starting at the requested insertion point using `baseTruss.lengthMm` as spacing. 
- Newly created trusses have `parentGroupUuid` cleared, `hasLocalTransform` set, and their `transform.o` and `localTransform` populated with the computed world positions; when `createGroup` is enabled and more than one truss was added the code calls `scene_grouping::GroupSelection(...)` to create an MVR-compatible group. 
- Added `gui/addtrussdialog.cpp` to the explicit GUI source list (`gui/CMakeLists.txt`) and updated `docs/features.md` and `docs/release-notes-draft.md` to document the new behavior. 

### Testing
- Ran `./tests/check_perastage_tree_modules.sh` which succeeded. 
- Ran `./tests/check_no_configmanager_get_in_gui.sh` which succeeded. 
- Ran `git diff --cached --check` which succeeded. 
- Attempted a local CMake configure (`cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`) but it failed in this environment due to missing `wxWidgets` (configuration blocked, not a code error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fdcc953048324a172d2374e44a36f)