### PR TITLE
Store MVR layer colors in Perastage UserData

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -37,6 +37,7 @@ Perastage is designed for lighting designers, programmers, and technicians who n
 ### MVR export
 
 - Exports the current scene back to `.mvr` for interoperability.
+- Stores Perastage-specific layer appearance metadata, including layer colors, in a root-level MVR `UserData/Data` block instead of writing non-standard `Color` children inside `Layer` nodes.
 - Parametric objects exported as Fixture/Truss/Support receive stable non-empty `FixtureID` and globally unique `FixtureIDNumeric` values.
 
 ### GDTF integration and dictionary pipeline

--- a/docs/opening-mvr-files.md
+++ b/docs/opening-mvr-files.md
@@ -61,6 +61,8 @@ In addition to MVR exchange, Perastage supports project-based work so you can:
 
 ## Export MVR
 
+Perastage stores its own layer appearance metadata, including layer colors, in a root-level MVR `UserData/Data` block with `provider="Perastage"`. This keeps new exports standards-compliant while still allowing Perastage to recover layer colors from its own MVR files when the metadata is preserved. Older Perastage MVR files that used direct `Layer/Color` children are still accepted on import, but new exports do not write that legacy structure.
+
 When your changes are ready for exchange:
 
 1. Open **File → Export MVR...**.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -42,6 +42,7 @@ Changes since `v1.3.0`.
 - Kept the 2D and 3D viewer highlights pinned to the dragged scene element during mouse-drag moves so hover feedback no longer jumps to other elements mid-drag.
 - Fixed quick-click fixture selection in the 3D view so hovered fixtures can still be selected when the precise release pick misses.
 - Fixed MVR fixture Color handling so visualization colors are no longer exported as gel/filter colors, while imported MVR Color values are preserved as fixture gel/filter data.
+- Fixed MVR layer color persistence so Perastage now stores layer appearance metadata in a standards-compliant root UserData block, while still importing legacy Layer/Color data from older exports.
 - Fixed MVR fixture UnitNumber export so existing unit numbers are preserved and missing values are generated deterministically by fixture type and stage position.
 - Restored edge-safe fixture visibility and made fixture hover picking use actual fixture geometry so highlights and labels target the visible fixture instead of broad bounds.
 - Fixed fixture ID edits so saved project files and exported MVR files keep the updated numeric fixture IDs instead of reverting to imported IDs.

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -104,10 +104,18 @@ static bool ShouldExportSupportHoistInfo(const Support &support);
 static tinyxml2::XMLElement *FindFirstPerastageUserData(tinyxml2::XMLElement *node);
 static tinyxml2::XMLElement *FindOrCreatePerastageDataNode(tinyxml2::XMLDocument &doc,
                                                             tinyxml2::XMLElement *node);
+
 static void AppendSupportHoistInfoUserData(tinyxml2::XMLDocument &doc,
                                            tinyxml2::XMLElement *supportData,
                                            const Support &support);
 static bool IsCanonicalUuidString(const std::string &value);
+static std::string ExportLayerUuid(const std::string &layerUuid,
+                                   const std::string &layerName);
+static bool IsLayerColorMetadataValue(const std::string &color);
+static bool HasLayerAppearanceMetadata(const MvrScene &scene);
+static void AppendLayerAppearanceMetadata(tinyxml2::XMLDocument &doc,
+                                          tinyxml2::XMLElement *perastageData,
+                                          const MvrScene &scene);
 static void LogLegacyPositionUuidWarning(const std::string &message);
 
 static constexpr const char *kMvrProvider = "Perastage";
@@ -692,6 +700,15 @@ static bool ValidateMvr16Export(
   std::unordered_set<std::string> referencedPositionUuids;
 
   if (tinyxml2::XMLElement *scene = root->FirstChildElement("Scene")) {
+    if (tinyxml2::XMLElement *layers = scene->FirstChildElement("Layers")) {
+      for (tinyxml2::XMLElement *layer = layers->FirstChildElement("Layer"); layer;
+           layer = layer->NextSiblingElement("Layer")) {
+        if (layer->FirstChildElement("Color")) {
+          wxLogError("MVR export validation failed: Layer/Color is not valid in MVR 1.6");
+          return false;
+        }
+      }
+    }
     if (scene->FirstChildElement("UserData")) {
       wxLogError("MVR export validation failed: Scene/UserData is not valid in MVR 1.6");
       return false;
@@ -1168,6 +1185,7 @@ static bool ShouldExportSupportHoistInfo(const Support &support) {
          NormalizeHoistDataSource(support.hoistFunctionSource) != "Inherited";
 }
 
+// Finds the first UserData element that already contains Perastage-owned data.
 static tinyxml2::XMLElement *FindFirstPerastageUserData(tinyxml2::XMLElement *node) {
   if (!node)
     return nullptr;
@@ -1186,6 +1204,7 @@ static tinyxml2::XMLElement *FindFirstPerastageUserData(tinyxml2::XMLElement *no
   return nullptr;
 }
 
+// Finds or creates the Perastage Data element under a valid parent node.
 static tinyxml2::XMLElement *FindOrCreatePerastageDataNode(tinyxml2::XMLDocument &doc,
                                                             tinyxml2::XMLElement *node) {
   tinyxml2::XMLElement *ud = FindFirstPerastageUserData(node);
@@ -1209,6 +1228,67 @@ static tinyxml2::XMLElement *FindOrCreatePerastageDataNode(tinyxml2::XMLDocument
   return data;
 }
 
+// Resolves the canonical MVR layer UUID exported for a Perastage layer.
+static std::string ExportLayerUuid(const std::string &layerUuid,
+                                   const std::string &layerName) {
+  if (layerUuid.empty())
+    return {};
+  return IsCanonicalUuidString(layerUuid)
+             ? layerUuid
+             : DeriveDeterministicUuid("mvr:layer:" + layerName + ":" + layerUuid);
+}
+
+// Returns true when the color can be stored as Perastage #RRGGBB metadata.
+static bool IsLayerColorMetadataValue(const std::string &color) {
+  if (color.size() != 7 || color[0] != '#')
+    return false;
+  return std::all_of(color.begin() + 1, color.end(), [](unsigned char ch) {
+    return std::isxdigit(ch) != 0;
+  });
+}
+
+// Returns true when any layer has Perastage color metadata to export.
+static bool HasLayerAppearanceMetadata(const MvrScene &scene) {
+  return std::any_of(scene.layers.begin(), scene.layers.end(), [](const auto &entry) {
+    return IsLayerColorMetadataValue(entry.second.color);
+  });
+}
+
+// Appends the root-level Perastage layer appearance map when layers define colors.
+static void AppendLayerAppearanceMetadata(tinyxml2::XMLDocument &doc,
+                                          tinyxml2::XMLElement *perastageData,
+                                          const MvrScene &scene) {
+  if (!perastageData)
+    return;
+
+  tinyxml2::XMLElement *map = nullptr;
+  for (tinyxml2::XMLElement *existing = perastageData->FirstChildElement("LayerAppearanceMap");
+       existing; existing = existing->NextSiblingElement("LayerAppearanceMap")) {
+    map = existing;
+    break;
+  }
+
+  for (const auto &[layerUuid, layer] : scene.layers) {
+    if (!IsLayerColorMetadataValue(layer.color))
+      continue;
+    if (!map)
+      map = doc.NewElement("LayerAppearanceMap");
+
+    tinyxml2::XMLElement *entry = doc.NewElement("Layer");
+    const std::string exportUuid = ExportLayerUuid(layerUuid, layer.name);
+    if (!exportUuid.empty())
+      entry->SetAttribute("uuid", exportUuid.c_str());
+    if (!layer.name.empty())
+      entry->SetAttribute("name", layer.name.c_str());
+    entry->SetAttribute("color", layer.color.c_str());
+    map->InsertEndChild(entry);
+  }
+
+  if (map && !map->Parent())
+    perastageData->InsertEndChild(map);
+}
+
+// Appends Perastage support hoist metadata into the supplied Data element.
 static void AppendSupportHoistInfoUserData(tinyxml2::XMLDocument &doc,
                                            tinyxml2::XMLElement *supportData,
                                            const Support &support) {
@@ -1879,6 +1959,11 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
                      scene.providerVersion.empty() ? kMvrProviderVersion
                                                    : scene.providerVersion.c_str());
   doc.InsertEndChild(root);
+
+  if (HasLayerAppearanceMetadata(scene)) {
+    tinyxml2::XMLElement *rootPerastageData = FindOrCreatePerastageDataNode(doc, root);
+    AppendLayerAppearanceMetadata(doc, rootPerastageData, scene);
+  }
 
   tinyxml2::XMLElement *sceneNode = doc.NewElement("Scene");
   root->InsertEndChild(sceneNode);
@@ -2788,22 +2873,12 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
       continue;
     tinyxml2::XMLElement *layerElem = doc.NewElement("Layer");
     if (!layerUuid.empty()) {
-      const std::string exportLayerUuid =
-          IsCanonicalUuidString(layerUuid)
-              ? layerUuid
-              : DeriveDeterministicUuid("mvr:layer:" + layer.name + ":" + layerUuid);
+      const std::string exportLayerUuid = ExportLayerUuid(layerUuid, layer.name);
       layerElem->SetAttribute("uuid", exportLayerUuid.c_str());
     }
     if (!layer.name.empty())
       layerElem->SetAttribute("name", layer.name.c_str());
 
-    if (!layer.color.empty() && layer.color.size() == 7 &&
-        layer.color[0] == '#') {
-      std::string cie = HexToCie(layer.color);
-      tinyxml2::XMLElement *col = doc.NewElement("Color");
-      col->SetText(cie.c_str());
-      layerElem->InsertEndChild(col);
-    }
 
     tinyxml2::XMLElement *childList = doc.NewElement("ChildList");
 
@@ -2872,10 +2947,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
     tinyxml2::XMLElement *defaultLayerElem = doc.NewElement("Layer");
     if (!defaultLayerUuid.empty()) {
       const std::string exportDefaultLayerUuid =
-          IsCanonicalUuidString(defaultLayerUuid)
-              ? defaultLayerUuid
-              : DeriveDeterministicUuid("mvr:layer:" + defaultLayerName + ":" +
-                                        defaultLayerUuid);
+          ExportLayerUuid(defaultLayerUuid, defaultLayerName);
       defaultLayerElem->SetAttribute("uuid", exportDefaultLayerUuid.c_str());
     }
     if (!defaultLayerName.empty())
@@ -2887,10 +2959,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
   sceneNode->InsertEndChild(layersNode);
 
   if (!trussArchiveByTypeKey.empty()) {
-    tinyxml2::XMLElement *rootUserData = doc.NewElement("UserData");
-    tinyxml2::XMLElement *data = doc.NewElement("Data");
-    data->SetAttribute("provider", "Perastage");
-    data->SetAttribute("ver", "1.0");
+    tinyxml2::XMLElement *data = FindOrCreatePerastageDataNode(doc, root);
     tinyxml2::XMLElement *manifest = doc.NewElement("TrussSidecarManifest");
     for (const auto &[typeKey, archivePath] : trussArchiveByTypeKey) {
       tinyxml2::XMLElement *typeNode = doc.NewElement("Type");
@@ -2915,8 +2984,6 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
               .ToStdString());
     }
     data->InsertEndChild(manifest);
-    rootUserData->InsertEndChild(data);
-    root->InsertEndChild(rootUserData);
   }
 
   // Prunes non-referenced resources so deleted scene elements do not keep stale payload files.

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -1467,6 +1467,46 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
                "MVR import used legacy Scene/UserData fallback for Perastage sidecar manifest");
   }
 
+  std::unordered_map<std::string, std::string> layerColorByUuid;
+  std::unordered_map<std::string, std::string> layerColorByName;
+  auto isHexRgb = [](const std::string &color) {
+    if (color.size() != 7 || color[0] != '#')
+      return false;
+    return std::all_of(color.begin() + 1, color.end(), [](unsigned char ch) {
+      return std::isxdigit(ch) != 0;
+    });
+  };
+  auto parseLayerAppearanceMap = [&](tinyxml2::XMLElement *userDataNode) {
+    if (!userDataNode)
+      return;
+    for (tinyxml2::XMLElement *data = userDataNode->FirstChildElement("Data"); data;
+         data = data->NextSiblingElement("Data")) {
+      const std::string provider = ToLowerCopy(
+          Trim(data->Attribute("provider") ? data->Attribute("provider") : ""));
+      if (provider != "perastage")
+        continue;
+      for (tinyxml2::XMLElement *map = data->FirstChildElement("LayerAppearanceMap"); map;
+           map = map->NextSiblingElement("LayerAppearanceMap")) {
+        for (tinyxml2::XMLElement *entry = map->FirstChildElement("Layer"); entry;
+             entry = entry->NextSiblingElement("Layer")) {
+          const std::string color =
+              Trim(entry->Attribute("color") ? entry->Attribute("color") : "");
+          if (!isHexRgb(color))
+            continue;
+          const std::string uuid =
+              CanonicalizeUuid(Trim(entry->Attribute("uuid") ? entry->Attribute("uuid") : ""));
+          const std::string name =
+              Trim(entry->Attribute("name") ? entry->Attribute("name") : "");
+          if (!uuid.empty())
+            layerColorByUuid[uuid] = color;
+          if (!name.empty())
+            layerColorByName[name] = color;
+        }
+      }
+    }
+  };
+  parseLayerAppearanceMap(root->FirstChildElement("UserData"));
+
   // ---- Parse AUXData for Symdefs and Positions ----
   std::unordered_map<std::string, std::string> legacyPositionIdToCanonical;
   if (tinyxml2::XMLElement *auxNode = sceneNode->FirstChildElement("AUXData")) {
@@ -2833,10 +2873,20 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
       if (uuidAttr)
         l.uuid = uuidAttr;
       l.name = layerStr;
-      if (tinyxml2::XMLElement *colorNode =
-              layer->FirstChildElement("Color")) {
-        if (const char *txt = colorNode->GetText())
-          l.color = CieToHex(txt);
+      auto colorByUuid = layerColorByUuid.find(CanonicalizeUuid(l.uuid));
+      if (colorByUuid != layerColorByUuid.end()) {
+        l.color = colorByUuid->second;
+      } else {
+        auto colorByName = layerColorByName.find(l.name);
+        if (colorByName != layerColorByName.end()) {
+          l.color = colorByName->second;
+        } else if (tinyxml2::XMLElement *colorNode =
+                       layer->FirstChildElement("Color")) {
+          if (const char *txt = colorNode->GetText()) {
+            const std::string legacyColor = Trim(txt);
+            l.color = isHexRgb(legacyColor) ? legacyColor : CieToHex(legacyColor);
+          }
+        }
       }
       scene.layers[l.uuid] = l;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -556,6 +556,41 @@ add_test(NAME MvrSupportUserDataRoundtrip COMMAND mvr_support_userdata_roundtrip
 set_library_env(MvrSupportUserDataRoundtrip)
 
 
+add_executable(mvr_layer_appearance_userdata_test mvr_layer_appearance_userdata_test.cpp
+               ../core/configmanager.cpp
+               ../core/configservices.cpp
+               ../core/projectutils.cpp
+               ../core/library/library_bootstrap.cpp
+               ../core/gdtfdictionary.cpp
+               ../core/gdtf_fixture_category.cpp
+               ../core/trussdictionary.cpp
+               ../core/trussloader.cpp
+               ../core/truss_gdtf_builder.cpp
+               ../core/uuidutils.cpp
+               ../core/dummyprofilelibrary.cpp
+               ../mvr/mvrimporter.cpp
+               ../mvr/gdtf_catalog_matcher.cpp
+               ../viewer2d/fixture_label_overrides.cpp
+               ../mvr/mvrexporter.cpp
+               ../mvr/primitive_model_resources.cpp
+               ../core/gdtf_mutation_audit.cpp
+               ../core/logger.cpp
+               gdtfloader_stub.cpp
+               consolepanel_stub.cpp
+               ../models/mvrscene.cpp
+               ../models/fixture.cpp
+               ../models/truss.cpp
+               ../models/sceneobject.cpp
+               ../models/layer.cpp
+               ${LAYOUT_SOURCES})
+target_include_directories(mvr_layer_appearance_userdata_test PRIVATE
+                           . ../core ../models ../mvr ../gui ../third_party)
+target_link_libraries(mvr_layer_appearance_userdata_test PRIVATE
+                      ${wxWidgets_LIBRARIES} tinyxml2::tinyxml2)
+add_test(NAME MvrLayerAppearanceUserData COMMAND mvr_layer_appearance_userdata_test)
+set_library_env(MvrLayerAppearanceUserData)
+
+
 add_executable(mvr_fixture_category_roundtrip_test mvr_fixture_category_roundtrip_test.cpp
                ../core/configmanager.cpp
                ../core/configservices.cpp

--- a/tests/mvr_layer_appearance_userdata_test.cpp
+++ b/tests/mvr_layer_appearance_userdata_test.cpp
@@ -1,0 +1,170 @@
+/*
+ * This file is part of Perastage.
+ */
+#include <cassert>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <tinyxml2.h>
+#include <wx/init.h>
+#include <wx/wfstream.h>
+#include <wx/zipstrm.h>
+
+#include "configmanager.h"
+#include "layer.h"
+#include "mvrexporter.h"
+#include "mvrimporter.h"
+
+// Reads the current ZIP entry into a string.
+static std::string ReadCurrentZipEntry(wxZipInputStream &zip) {
+  std::string content;
+  char buffer[4096];
+  while (true) {
+    zip.Read(buffer, sizeof(buffer));
+    const size_t bytes = zip.LastRead();
+    if (bytes == 0)
+      break;
+    content.append(buffer, bytes);
+  }
+  return content;
+}
+
+// Reads GeneralSceneDescription.xml from an MVR ZIP archive.
+static std::string ReadSceneXml(const std::filesystem::path &archivePath) {
+  wxFileInputStream input(archivePath.generic_string());
+  assert(input.IsOk());
+  wxZipInputStream zip(input);
+  std::unique_ptr<wxZipEntry> entry;
+  while ((entry.reset(zip.GetNextEntry())), entry) {
+    if (entry->GetName().ToStdString() == "GeneralSceneDescription.xml")
+      return ReadCurrentZipEntry(zip);
+    ReadCurrentZipEntry(zip);
+  }
+  return {};
+}
+
+// Writes a minimal MVR archive containing the supplied scene XML.
+static void WriteMvrWithSceneXml(const std::filesystem::path &archivePath,
+                                 const std::string &xml) {
+  wxFileOutputStream output(archivePath.generic_string());
+  assert(output.IsOk());
+  wxZipOutputStream zip(output);
+  assert(zip.PutNextEntry("GeneralSceneDescription.xml"));
+  zip.Write(xml.data(), xml.size());
+  zip.CloseEntry();
+  zip.Close();
+}
+
+// Finds the first exported Perastage layer appearance entry for the requested layer name.
+static tinyxml2::XMLElement *FindLayerAppearance(tinyxml2::XMLDocument &doc,
+                                                 const char *layerName) {
+  tinyxml2::XMLElement *root = doc.FirstChildElement("GeneralSceneDescription");
+  assert(root != nullptr);
+  tinyxml2::XMLElement *userData = root->FirstChildElement("UserData");
+  assert(userData != nullptr);
+  tinyxml2::XMLElement *data = userData->FirstChildElement("Data");
+  assert(data != nullptr);
+  assert(std::string(data->Attribute("provider")) == "Perastage");
+  tinyxml2::XMLElement *map = data->FirstChildElement("LayerAppearanceMap");
+  assert(map != nullptr);
+  for (tinyxml2::XMLElement *layer = map->FirstChildElement("Layer"); layer;
+       layer = layer->NextSiblingElement("Layer")) {
+    const char *name = layer->Attribute("name");
+    if (name && std::string(name) == layerName)
+      return layer;
+  }
+  return nullptr;
+}
+
+// Verifies the exported scene XML stores layer colors only in root Perastage UserData.
+static void VerifyExportStructure(const std::filesystem::path &archivePath,
+                                  const char *layerName,
+                                  const char *expectedColor) {
+  const std::string xml = ReadSceneXml(archivePath);
+  assert(!xml.empty());
+
+  tinyxml2::XMLDocument doc;
+  assert(doc.Parse(xml.c_str()) == tinyxml2::XML_SUCCESS);
+  tinyxml2::XMLElement *root = doc.FirstChildElement("GeneralSceneDescription");
+  assert(root != nullptr);
+  tinyxml2::XMLElement *scene = root->FirstChildElement("Scene");
+  assert(scene != nullptr);
+  assert(scene->FirstChildElement("UserData") == nullptr);
+  tinyxml2::XMLElement *layers = scene->FirstChildElement("Layers");
+  assert(layers != nullptr);
+  for (tinyxml2::XMLElement *layer = layers->FirstChildElement("Layer"); layer;
+       layer = layer->NextSiblingElement("Layer")) {
+    assert(layer->FirstChildElement("Color") == nullptr);
+  }
+
+  tinyxml2::XMLElement *appearance = FindLayerAppearance(doc, layerName);
+  assert(appearance != nullptr);
+  assert(std::string(appearance->Attribute("color")) == expectedColor);
+}
+
+// Exports and imports a colored layer using the Perastage UserData appearance map.
+static void TestLayerAppearanceRoundtrip(const std::filesystem::path &tempDir) {
+  auto &cfg = ConfigManager::Get();
+  cfg.Reset();
+  MvrScene &scene = cfg.GetScene();
+
+  Layer layer;
+  layer.uuid = "11111111-1111-4111-8111-111111111111";
+  layer.name = "Color Layer";
+  layer.color = "#3366AA";
+  scene.layers[layer.uuid] = layer;
+
+  const std::filesystem::path archivePath = tempDir / "layer-appearance.mvr";
+  MvrExporter exporter;
+  assert(exporter.ExportToFile(archivePath.generic_string()));
+  VerifyExportStructure(archivePath, "Color Layer", "#3366AA");
+
+  MvrScene imported;
+  MvrImporter importer;
+  assert(importer.ImportSceneFromFile(archivePath.generic_string(), imported, false, false));
+  const auto importedLayer = imported.layers.find(layer.uuid);
+  assert(importedLayer != imported.layers.end());
+  assert(importedLayer->second.color == "#3366AA");
+}
+
+// Imports legacy Layer/Color data and reexports it using only Perastage UserData.
+static void TestLegacyLayerColorCompatibility(const std::filesystem::path &tempDir) {
+  const std::filesystem::path legacyPath = tempDir / "legacy-layer-color.mvr";
+  const std::string legacyXml =
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+      "<GeneralSceneDescription verMajor=\"1\" verMinor=\"6\" provider=\"Perastage\" providerVersion=\"test\">"
+      "<Scene><Layers><Layer uuid=\"22222222-2222-4222-8222-222222222222\" name=\"Legacy Layer\">"
+      "<Color>#445566</Color><ChildList/></Layer></Layers></Scene>"
+      "</GeneralSceneDescription>";
+  WriteMvrWithSceneXml(legacyPath, legacyXml);
+
+  MvrScene imported;
+  MvrImporter importer;
+  assert(importer.ImportSceneFromFile(legacyPath.generic_string(), imported, false, false));
+  const auto importedLayer = imported.layers.find("22222222-2222-4222-8222-222222222222");
+  assert(importedLayer != imported.layers.end());
+  assert(importedLayer->second.color == "#445566");
+
+  auto &cfg = ConfigManager::Get();
+  cfg.Reset();
+  cfg.GetScene() = imported;
+  const std::filesystem::path reexportPath = tempDir / "legacy-reexport.mvr";
+  MvrExporter exporter;
+  assert(exporter.ExportToFile(reexportPath.generic_string()));
+  VerifyExportStructure(reexportPath, "Legacy Layer", "#445566");
+}
+
+int main() {
+  wxInitializer initializer;
+  assert(initializer.IsOk());
+
+  const std::filesystem::path tempDir =
+      std::filesystem::temp_directory_path() / "mvr_layer_appearance_userdata_test";
+  std::filesystem::create_directories(tempDir);
+
+  TestLayerAppearanceRoundtrip(tempDir);
+  TestLegacyLayerColorCompatibility(tempDir);
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- Exporting layer color as a direct `<Layer>/<Color>` child is not compliant with MVR 1.6 and must be moved to a valid UserData block owned by Perastage.
- Keep Perastage layer color metadata recoverable on Perastage roundtrip imports while avoiding invalid MVR structure and allowing future Perastage metadata to live in the same provider block.

### Description
- Move layer color export into a root-level `UserData/Data provider="Perastage"/LayerAppearanceMap` with `<Layer uuid="..." name="..." color="#RRGGBB" />` entries and stop writing direct `Layer/Color` children (`mvr/mvrexporter.cpp`).
- Reuse or create a single Perastage `Data` element under an existing valid `UserData` parent beneath `GeneralSceneDescription` instead of emitting duplicate provider blocks, and append the `LayerAppearanceMap` there (`FindOrCreatePerastageDataNode`, `AppendLayerAppearanceMetadata`).
- Preserve stable identifiers by exporting canonical or deterministic layer UUIDs and always include the readable layer name as a fallback in the `LayerAppearanceMap` entries (`ExportLayerUuid`).
- Update import logic to prefer the new Perastage `LayerAppearanceMap` (match by UUID then by name) and keep the legacy `<Layer><Color>...</Color></Layer>` reading as a fallback; legacy colors are converted to `#RRGGBB` if necessary (`mvr/mvrimporter.cpp`).
- Add export validation to reject `Layer/Color` children in produced MVR 1.6 XML and ensure `Scene/UserData` is not created in invalid locations; reuse Perastage Data for existing truss sidecar metadata (`ValidateMvr16Export` and truss-sidecar export path). 
- Add a focused unit test `tests/mvr_layer_appearance_userdata_test.cpp` and register it in `tests/CMakeLists.txt` that checks roundtrip preservation, structural export (no `Layer/Color` children), and legacy-compat import/reexport behavior.
- Update user docs and release notes to explain the new standards-compliant storage location and legacy compatibility (`docs/features.md`, `docs/opening-mvr-files.md`, `docs/release-notes-draft.md`).

### Testing
- Ran repository checks: `git diff --check` succeeded and both project policy scripts `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh` passed.
- Added and committed the unit test; test is registered in `tests/CMakeLists.txt` but full test build could not be executed here because `cmake` configuration failed due to missing wxWidgets development libraries in this environment (configuration error while running `cmake -S . -B build -DBUILD_TESTING=ON`).
- Manual inspection and automated grep/rg scans confirm no new direct `Layer/Color` emission lines remain; import paths read the new `LayerAppearanceMap` first and fallback to legacy `Layer/Color` when present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a308effd26883249a810d30158df2c6)