### PR TITLE
Fix truss height labels to respect selected units

### DIFF
--- a/core/units/unit_label_utils.cpp
+++ b/core/units/unit_label_utils.cpp
@@ -7,4 +7,11 @@ std::string LabelWithUnit(const std::string &label, const std::string &unitSuffi
   return label + " (" + unitSuffix + ")";
 }
 
+// Formats a distance value together with the active display unit suffix.
+std::string DistanceValueWithUnit(double valueMm, DistanceUnitSystem unitSystem,
+                                  ValueFormatContext context) {
+  return FormatDistanceFromMillimeters(valueMm, unitSystem, context) + " " +
+         DistanceUnitSuffix(unitSystem);
+}
+
 } // namespace Units

--- a/core/units/unit_label_utils.h
+++ b/core/units/unit_label_utils.h
@@ -1,9 +1,13 @@
 #pragma once
 
+#include "units.h"
+
 #include <string>
 
 namespace Units {
 
 std::string LabelWithUnit(const std::string &label, const std::string &unitSuffix);
+std::string DistanceValueWithUnit(double valueMm, DistanceUnitSystem unitSystem,
+                                  ValueFormatContext context);
 
 } // namespace Units

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -52,6 +52,7 @@ Changes since `v1.3.0`.
 - Improved fallback dimensions for direct truss model files so GLB and 3DS trusses remain visible and selectable even when model metadata or mesh loading is unavailable.
 - Fixed Add scene object so reusing an existing Perastage basic geometry object copies its primitive geometry data immediately instead of showing a default cube until the project is reopened.
 - Fixed basic geometry edit dialogs so position, screen size, and pipe length fields use the selected project distance units consistently.
+- Fixed 3D truss height labels so they show both the value and suffix in the selected project distance units.
 
 ## Stability and reliability
 

--- a/tests/ui_unit_utils_test.cpp
+++ b/tests/ui_unit_utils_test.cpp
@@ -82,8 +82,13 @@ void AssertWeightParsingWithSuffixes() {
   assert(std::abs(*pounds * 2.2046226218487757 - 220.0) < 1e-6);
 }
 
+// Verifies unit suffix helpers produce display-ready labels and values.
 void AssertLabelWithUnitHelper() {
   assert(Units::LabelWithUnit("Weight", "kg") == "Weight (kg)");
+  assert(Units::DistanceValueWithUnit(3000.0, Units::DistanceUnitSystem::Metric,
+                                      Units::ValueFormatContext::Label) == "3.00 m");
+  assert(Units::DistanceValueWithUnit(3048.0, Units::DistanceUnitSystem::Imperial,
+                                      Units::ValueFormatContext::Label) == "10.00 ft");
 }
 
 } // namespace

--- a/viewer3d/labels/label_render_system.cpp
+++ b/viewer3d/labels/label_render_system.cpp
@@ -22,6 +22,7 @@
 #include "logger.h"
 #include "scenedatamanager.h"
 #include "support.h"
+#include "units/unit_label_utils.h"
 #include "units/units.h"
 
 #include <algorithm>
@@ -478,14 +479,10 @@ ResolveAnchor(const ISelectionContext::BoundingBox *bounds,
   return {x, y, z};
 }
 
-std::string FormatMeters(float mm) {
-  std::ostringstream oss;
-  oss << std::fixed << std::setprecision(2) << mm / 1000.0f;
-  std::string s = oss.str();
-  s.erase(s.find_last_not_of('0') + 1, std::string::npos);
-  if (!s.empty() && s.back() == '.')
-    s.pop_back();
-  return s;
+// Formats a distance for rendered labels using the selected project units.
+std::string FormatDistanceLabel(float mm, Units::DistanceUnitSystem distanceUnit) {
+  return Units::DistanceValueWithUnit(mm, distanceUnit,
+                                      Units::ValueFormatContext::Label);
 }
 
 SupportLabelText BuildSupportLabelText(const Support &support,
@@ -1143,6 +1140,8 @@ void LabelRenderSystem::DrawAllFixtureLabels(int width, int height,
 // Draws visible truss labels in the 3D viewport.
 void LabelRenderSystem::DrawTrussLabels(int width, int height) {
   ConfigManager &cfg = ConfigManager::Get();
+  const auto distanceUnitSystem =
+      Units::ParseDistanceUnitSystem(cfg.GetValue("ui_distance_unit_system"));
   ProjectionContext projection;
   FillProjectionContext(width, height, projection);
 
@@ -1189,8 +1188,9 @@ void LabelRenderSystem::DrawTrussLabels(int width, int height) {
     wxString label = t.name.empty() ? wxString::FromUTF8(uuid)
                                     : wxString::FromUTF8(t.name);
     float baseHeight = t.transform.o[2] - t.heightMm * 0.5f;
-    const std::string heightText = FormatMeters(baseHeight);
-    label += "\nh = " + wxString::FromUTF8(heightText) + " m";
+    const std::string heightText =
+        FormatDistanceLabel(baseHeight, distanceUnitSystem);
+    label += "\nh = " + wxString::FromUTF8(heightText);
 
     auto utf8 = label.ToUTF8();
     DrawText2D(m_controller.GetNanoVGContext(), m_controller.GetLabelFont(),

--- a/viewer3d/picking/selectionsystem.cpp
+++ b/viewer3d/picking/selectionsystem.cpp
@@ -18,11 +18,12 @@
 
 #include "configmanager.h"
 #include "scenedatamanager.h"
+#include "units/unit_label_utils.h"
+#include "units/units.h"
 #include <algorithm>
 #include <array>
 #include <cfloat>
 #include <cmath>
-#include <cstdio>
 #include <cstring>
 #include <unordered_set>
 #include <wx/log.h>
@@ -269,11 +270,12 @@ bool ProjectBoundingBoxCenter(const ISelectionContext::BoundingBox &bb,
   return true;
 }
 
-std::string FormatMeters(float mm) {
-  const float meters = mm / 1000.0f;
-  char buffer[32];
-  std::snprintf(buffer, sizeof(buffer), "%.2f", meters);
-  return std::string(buffer);
+// Formats a distance for hover labels using the selected project units.
+std::string FormatDistanceLabel(float mm, const ConfigManager &cfg) {
+  const auto distanceUnit =
+      Units::ParseDistanceUnitSystem(cfg.GetValue("ui_distance_unit_system"));
+  return Units::DistanceValueWithUnit(mm, distanceUnit,
+                                      Units::ValueFormatContext::Label);
 }
 
 bool ProjectionMatchesCache(const ProjectionSnapshot &projection,
@@ -892,8 +894,8 @@ bool SelectionSystem::GetTrussLabelAt(int mouseX, int mouseY, int width,
       bestLabel = t.name.empty() ? wxString::FromUTF8(uuid)
                                  : wxString::FromUTF8(t.name);
       float baseHeight = t.transform.o[2] - t.heightMm * 0.5f;
-      const std::string hStr = FormatMeters(baseHeight);
-      bestLabel += "\nh = " + wxString::FromUTF8(hStr) + " m";
+      const std::string hStr = FormatDistanceLabel(baseHeight, cfg);
+      bestLabel += "\nh = " + wxString::FromUTF8(hStr);
       bestUuid = uuid;
       found = true;
     }


### PR DESCRIPTION
### Motivation
- Truss height labels in 3D and hover tooltips always displayed values as meters, ignoring the project `ui_distance_unit_system` preference. The intent is to show the value and the appropriate unit suffix according to the selected units.

### Description
- Added `Units::DistanceValueWithUnit(double valueMm, DistanceUnitSystem, ValueFormatContext)` to `core/units/unit_label_utils.{h,cpp}` to format a distance value together with the display suffix.
- Replaced hard-coded meter formatting in rendered truss labels in `viewer3d/labels/label_render_system.cpp` to use the new distance-with-unit formatter and read `ui_distance_unit_system` from `ConfigManager`.
- Replaced hard-coded meter formatting in 3D hover/truss pick labels in `viewer3d/picking/selectionsystem.cpp` to use the same formatter so hover tooltips match the selected units.
- Added unit-helper assertions to `tests/ui_unit_utils_test.cpp` and updated `docs/release-notes-draft.md` with the user-facing fix.

### Testing
- Ran project checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both returned OK. 
- Built and ran the unit helper test with `g++ -std=c++17 -Icore tests/ui_unit_utils_test.cpp core/units/units.cpp core/units/unit_label_utils.cpp -o /tmp/ui_unit_utils_test && /tmp/ui_unit_utils_test`, which printed success (`ui_unit_utils_test passed`).
- Ran `git diff --check` to ensure no whitespace/format issues; no errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a309220bb90832491adb691928ac648)