### PR TITLE
Export canonical Truss UUIDs and move Perastage TrussInfo to root UserData

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -29,6 +29,7 @@ Changes since `v1.3.0`.
 - Preserved embedded MVR GDTF fixture references when reopening `.pstg` projects so fixtures affected by GDTF dictionary conflicts do not silently downgrade to dummy geometry on the next save.
 - Improved MVR compatibility by preserving Support objects during roundtrip export, preserving geometry-less Support nodes with empty Geometries and using small 10 cm placeholder geometry for otherwise empty SceneObject exports, and writing Truss children in schema-compatible order.
 - Fixed MVR Symbol/Symdef truss export so every Symbol keeps or receives a stable valid UUID and required Symdef reference, improving compatibility with strict MVR importers.
+- Improved MVR 1.6 truss export compatibility by writing canonical Truss UUIDs, moving Perastage truss metadata to root UserData, and preserving legacy truss metadata import.
 
 - Fixed GDTF persistence so automatic symbol generation and project-scoped fixture edits update project-owned copies or stable @Perastage library derivatives without filling the user fixture library with imported or generated project files.
 - Fixed Linux GTK layout warnings in the rich text toolbar by giving icon buttons enough themed padding while preserving the existing editing behavior.

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -116,6 +116,13 @@ static bool HasLayerAppearanceMetadata(const MvrScene &scene);
 static void AppendLayerAppearanceMetadata(tinyxml2::XMLDocument &doc,
                                           tinyxml2::XMLElement *perastageData,
                                           const MvrScene &scene);
+static bool HasTrussInfoMetadata(const Truss &truss);
+static void AppendTrussInfoMetadata(tinyxml2::XMLDocument &doc,
+                                    tinyxml2::XMLElement *trussInfoMap,
+                                    const Truss &truss,
+                                    const std::string &exportUuid,
+                                    const std::string &trussTypeKey,
+                                    const std::string &auxGdtfArchivePath);
 static void LogLegacyPositionUuidWarning(const std::string &message);
 
 static constexpr const char *kMvrProvider = "Perastage";
@@ -698,6 +705,7 @@ static bool ValidateMvr16Export(
   std::vector<std::string> referencedFiles;
   std::unordered_set<std::string> positionUuids;
   std::unordered_set<std::string> referencedPositionUuids;
+  std::unordered_set<std::string> exportedTrussUuids;
 
   if (tinyxml2::XMLElement *scene = root->FirstChildElement("Scene")) {
     if (tinyxml2::XMLElement *layers = scene->FirstChildElement("Layers")) {
@@ -751,6 +759,19 @@ static bool ValidateMvr16Export(
         if (symdefUuid.empty()) {
           wxLogError("MVR export validation failed: Symbol uuid '%s' in %s has no symdef",
                      symbolUuid, context);
+          return false;
+        }
+      }
+
+      if (std::string(cur->Name()) == "Truss") {
+        const std::string trussUuid = TrimAscii(cur->Attribute("uuid") ? cur->Attribute("uuid") : "");
+        if (!IsCanonicalUuidString(trussUuid)) {
+          wxLogError("MVR export validation failed: Truss uuid '%s' is missing or non-canonical", trussUuid);
+          return false;
+        }
+        exportedTrussUuids.insert(trussUuid);
+        if (cur->FirstChildElement("UserData")) {
+          wxLogError("MVR export validation failed: Truss uuid '%s' contains direct UserData", trussUuid);
           return false;
         }
       }
@@ -947,6 +968,36 @@ static bool ValidateMvr16Export(
         for (tinyxml2::XMLElement *child = cur->FirstChildElement(); child;
              child = child->NextSiblingElement())
           stack.push_back(child);
+      }
+    }
+  }
+
+  if (tinyxml2::XMLElement *rootUserData = root->FirstChildElement("UserData")) {
+    for (tinyxml2::XMLElement *data = rootUserData->FirstChildElement("Data"); data;
+         data = data->NextSiblingElement("Data")) {
+      const std::string provider = ToLowerAscii(TrimAscii(data->Attribute("provider") ? data->Attribute("provider") : ""));
+      if (provider != "perastage")
+        continue;
+      for (tinyxml2::XMLElement *map = data->FirstChildElement("TrussInfoMap"); map;
+           map = map->NextSiblingElement("TrussInfoMap")) {
+        for (tinyxml2::XMLElement *info = map->FirstChildElement("TrussInfo"); info;
+             info = info->NextSiblingElement("TrussInfo")) {
+          const std::string uuid = TrimAscii(info->Attribute("uuid") ? info->Attribute("uuid") : "");
+          if (!IsCanonicalUuidString(uuid) || !exportedTrussUuids.contains(uuid)) {
+            wxLogError("MVR export validation failed: root TrussInfo references invalid exported Truss uuid '%s'", uuid);
+            return false;
+          }
+        }
+      }
+      if (tinyxml2::XMLElement *manifest = data->FirstChildElement("TrussSidecarManifest")) {
+        for (tinyxml2::XMLElement *inst = manifest->FirstChildElement("Instance"); inst;
+             inst = inst->NextSiblingElement("Instance")) {
+          const std::string uuid = TrimAscii(inst->Attribute("uuid") ? inst->Attribute("uuid") : "");
+          if (!IsCanonicalUuidString(uuid) || !exportedTrussUuids.contains(uuid)) {
+            wxLogError("MVR export validation failed: Truss sidecar manifest references invalid exported Truss uuid '%s'", uuid);
+            return false;
+          }
+        }
       }
     }
   }
@@ -1286,6 +1337,61 @@ static void AppendLayerAppearanceMetadata(tinyxml2::XMLDocument &doc,
 
   if (map && !map->Parent())
     perastageData->InsertEndChild(map);
+}
+
+// Returns true when a truss carries Perastage-specific metadata for export.
+static bool HasTrussInfoMetadata(const Truss &truss) {
+  return !truss.manufacturer.empty() || !truss.model.empty() ||
+         truss.lengthMm != 0.0f || truss.widthMm != 0.0f ||
+         truss.heightMm != 0.0f || truss.weightKg != 0.0f ||
+         !truss.crossSection.empty() || !truss.modelFile.empty() ||
+         !truss.positionName.empty() ||
+         truss.sourceRepresentation != Truss::GeometryRepresentation::Unknown ||
+         !truss.perastageTypeKey.empty() || !truss.perastageAuxGdtfArchivePath.empty();
+}
+
+// Appends one root-level Perastage truss metadata entry keyed by exported UUID.
+static void AppendTrussInfoMetadata(tinyxml2::XMLDocument &doc,
+                                    tinyxml2::XMLElement *trussInfoMap,
+                                    const Truss &truss,
+                                    const std::string &exportUuid,
+                                    const std::string &trussTypeKey,
+                                    const std::string &auxGdtfArchivePath) {
+  if (!trussInfoMap || !HasTrussInfoMetadata(truss))
+    return;
+
+  tinyxml2::XMLElement *info = doc.NewElement("TrussInfo");
+  info->SetAttribute("uuid", exportUuid.c_str());
+  auto addTxt = [&](const char *name, const std::string &value) {
+    if (value.empty())
+      return;
+    tinyxml2::XMLElement *node = doc.NewElement(name);
+    node->SetText(value.c_str());
+    info->InsertEndChild(node);
+  };
+  auto addNum = [&](const char *name, float value, const char *unit) {
+    if (value == 0.0f)
+      return;
+    tinyxml2::XMLElement *node = doc.NewElement(name);
+    node->SetAttribute("unit", unit);
+    node->SetText(std::to_string(value).c_str());
+    info->InsertEndChild(node);
+  };
+
+  addTxt("Manufacturer", truss.manufacturer);
+  addTxt("Model", truss.model);
+  addNum("Length", truss.lengthMm, "mm");
+  addNum("Width", truss.widthMm, "mm");
+  addNum("Height", truss.heightMm, "mm");
+  addNum("Weight", truss.weightKg, "kg");
+  addTxt("CrossSection", truss.crossSection);
+  addTxt("ModelFile", truss.modelFile);
+  addTxt("PositionName", truss.positionName);
+  addTxt("HangPos", truss.positionName);
+  addTxt("Representation", ToRepresentationText(truss.sourceRepresentation));
+  addTxt("TypeKey", trussTypeKey.empty() ? truss.perastageTypeKey : trussTypeKey);
+  addTxt("AuxGdtf", auxGdtfArchivePath.empty() ? truss.perastageAuxGdtfArchivePath : auxGdtfArchivePath);
+  trussInfoMap->InsertEndChild(info);
 }
 
 // Appends Perastage support hoist metadata into the supplied Data element.
@@ -2038,6 +2144,53 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
   tinyxml2::XMLElement *layersNode = doc.NewElement("Layers");
 
   std::unordered_set<std::string> usedFixtureUuids;
+  std::unordered_set<std::string> usedObjectExportUuids;
+  for (const auto &[uuid, fixture] : scene.fixtures) {
+    const std::string exportUuid = CanonicalizeUuid(uuid);
+    if (!exportUuid.empty())
+      usedObjectExportUuids.insert(exportUuid);
+  }
+  for (const auto &[uuid, support] : scene.supports) {
+    const std::string exportUuid = CanonicalizeUuid(uuid);
+    if (!exportUuid.empty())
+      usedObjectExportUuids.insert(exportUuid);
+  }
+  for (const auto &[uuid, object] : scene.sceneObjects) {
+    const std::string exportUuid = CanonicalizeUuid(uuid);
+    if (!exportUuid.empty())
+      usedObjectExportUuids.insert(exportUuid);
+  }
+  for (const auto &[uuid, group] : scene.groupObjects) {
+    const std::string exportUuid = CanonicalizeUuid(uuid);
+    if (!exportUuid.empty())
+      usedObjectExportUuids.insert(exportUuid);
+  }
+  std::unordered_map<std::string, std::string> trussExportUuids;
+  for (const auto &[uuid, truss] : scene.trusses) {
+    std::string exportUuid = CanonicalizeUuid(truss.uuid);
+    const std::string seed = "mvr-export-truss:" + truss.uuid + ":" + truss.name + ":" +
+                             MatrixUtils::FormatMatrix(truss.transform);
+    const bool needsRepair = exportUuid.empty() || usedObjectExportUuids.contains(exportUuid);
+    if (needsRepair) {
+      Logger::Instance().Log(
+          Logger::Level::Warn,
+          wxString::Format(
+              "Truss '%s' has missing, non-canonical, or conflicting UUID '%s'. Applying deterministic fallback UUID for export.",
+              truss.name.c_str(), truss.uuid.c_str())
+              .ToStdString());
+      for (int suffix = 0;; ++suffix) {
+        const std::string candidate = DeriveDeterministicUuid(seed + "#" + std::to_string(suffix));
+        if (!candidate.empty() && !usedObjectExportUuids.contains(candidate)) {
+          exportUuid = candidate;
+          break;
+        }
+      }
+    }
+    usedObjectExportUuids.insert(exportUuid);
+    trussExportUuids[uuid] = exportUuid;
+  }
+  tinyxml2::XMLElement *trussInfoMap = doc.NewElement("TrussInfoMap");
+
   int exportedRealFixtureGdtfCount = 0;
   int exportedDummyFixtureGdtfCount = 0;
   int preservedOriginalFixtureGdtfRecoveries = 0;
@@ -2271,7 +2424,11 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
 
   auto exportTruss = [&](tinyxml2::XMLElement *parent, const Truss &t) {
     tinyxml2::XMLElement *te = doc.NewElement("Truss");
-    te->SetAttribute("uuid", t.uuid.c_str());
+    const auto exportUuidIt = trussExportUuids.find(t.uuid);
+    const std::string exportedTrussUuid = exportUuidIt != trussExportUuids.end()
+                                             ? exportUuidIt->second
+                                             : DeriveDeterministicUuid("mvr-export-truss:" + t.uuid + ":" + t.name);
+    te->SetAttribute("uuid", exportedTrussUuid.c_str());
     if (!t.name.empty())
       te->SetAttribute("name", t.name.c_str());
 
@@ -2300,8 +2457,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
     auto trussArchiveIt = trussArchiveByTypeKey.find(trussTypeKey);
     if (trussArchiveIt != trussArchiveByTypeKey.end()) {
       trussGdtfArchivePath = trussArchiveIt->second;
-      if (!t.uuid.empty())
-        gdtfArchiveByObjectUuid[t.uuid] = trussGdtfArchivePath;
+      if (!exportedTrussUuid.empty())
+        gdtfArchiveByObjectUuid[exportedTrussUuid] = trussGdtfArchivePath;
     } else {
       std::string trussSourceGdtf = t.gdtfSpec;
       if (trussSourceGdtf.empty() && fs::path(t.modelFile).extension() == ".gdtf")
@@ -2317,12 +2474,12 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
 
       std::string trussPreferredName = "Perastage/truss_types/" + BuildTrussGdtfArchiveName(t);
       trussGdtfArchivePath =
-          registerGdtfResource(t.uuid, trussSourceGdtf, trussPreferredName, true);
+          registerGdtfResource(exportedTrussUuid, trussSourceGdtf, trussPreferredName, true);
       if (!trussGdtfArchivePath.empty())
         trussArchiveByTypeKey[trussTypeKey] = trussGdtfArchivePath;
     }
     if (!trussTypeKey.empty())
-      trussInstanceToTypeKey[t.uuid] = trussTypeKey;
+      trussInstanceToTypeKey[exportedTrussUuid] = trussTypeKey;
 
     if (!trussGdtfArchivePath.empty()) {
       auto &ov = gdtfOverrides[trussGdtfArchivePath];
@@ -2426,50 +2583,8 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
     addInt("CustomId", t.customId);
     addInt("CustomIdType", t.customIdType);
 
-    bool hasMeta =
-                   (!t.manufacturer.empty() || !t.model.empty() ||
-                    t.lengthMm != 0.0f || t.widthMm != 0.0f ||
-                    t.heightMm != 0.0f || t.weightKg != 0.0f ||
-                    !t.crossSection.empty() || !t.modelFile.empty() ||
-                    !t.positionName.empty());
-    if (hasMeta) {
-      tinyxml2::XMLElement *ud = doc.NewElement("UserData");
-      tinyxml2::XMLElement *data = doc.NewElement("Data");
-      data->SetAttribute("provider", "Perastage");
-      data->SetAttribute("ver", "1.0");
-      tinyxml2::XMLElement *info = doc.NewElement("TrussInfo");
-      info->SetAttribute("uuid", t.uuid.c_str());
-      auto addTxt = [&](const char *n, const std::string &v) {
-        if (!v.empty()) {
-          tinyxml2::XMLElement *e = doc.NewElement(n);
-          e->SetText(v.c_str());
-          info->InsertEndChild(e);
-        }
-      };
-      auto addNum = [&](const char *n, float v, const char *unit) {
-        if (v != 0.0f) {
-          tinyxml2::XMLElement *e = doc.NewElement(n);
-          e->SetAttribute("unit", unit);
-          e->SetText(std::to_string(v).c_str());
-          info->InsertEndChild(e);
-        }
-      };
-      addTxt("Manufacturer", t.manufacturer);
-      addTxt("Model", t.model);
-      addNum("Length", t.lengthMm, "mm");
-      addNum("Width", t.widthMm, "mm");
-      addNum("Height", t.heightMm, "mm");
-      addNum("Weight", t.weightKg, "kg");
-      addTxt("CrossSection", t.crossSection);
-      addTxt("ModelFile", t.modelFile);
-      addTxt("HangPos", t.positionName);
-      addTxt("Representation", ToRepresentationText(t.sourceRepresentation));
-      addTxt("TypeKey", trussTypeKey);
-      addTxt("AuxGdtf", trussGdtfArchivePath);
-      data->InsertEndChild(info);
-      ud->InsertEndChild(data);
-      te->InsertEndChild(ud);
-    }
+    AppendTrussInfoMetadata(doc, trussInfoMap, t, exportedTrussUuid,
+                            trussTypeKey, trussGdtfArchivePath);
 
     parent->InsertEndChild(te);
   };
@@ -2954,6 +3069,13 @@ bool MvrExporter::ExportToFile(const std::string &filePath) {
       defaultLayerElem->SetAttribute("name", defaultLayerName.c_str());
     defaultLayerElem->InsertEndChild(rootChildList);
     layersNode->InsertEndChild(defaultLayerElem);
+  }
+
+  if (trussInfoMap->FirstChild()) {
+    tinyxml2::XMLElement *rootPerastageDataForTrusses = FindOrCreatePerastageDataNode(doc, root);
+    rootPerastageDataForTrusses->InsertEndChild(trussInfoMap);
+  } else {
+    doc.DeleteNode(trussInfoMap);
   }
 
   sceneNode->InsertEndChild(layersNode);

--- a/mvr/mvrimporter.cpp
+++ b/mvr/mvrimporter.cpp
@@ -1507,6 +1507,32 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
   };
   parseLayerAppearanceMap(root->FirstChildElement("UserData"));
 
+
+  std::unordered_map<std::string, tinyxml2::XMLElement *> rootTrussInfoByUuid;
+  // Collects root-level Perastage truss metadata by canonical exported UUID.
+  auto parseRootTrussInfoMap = [&](tinyxml2::XMLElement *userDataNode) {
+    if (!userDataNode)
+      return;
+    for (tinyxml2::XMLElement *data = userDataNode->FirstChildElement("Data"); data;
+         data = data->NextSiblingElement("Data")) {
+      const std::string provider = ToLowerCopy(
+          Trim(data->Attribute("provider") ? data->Attribute("provider") : ""));
+      if (provider != "perastage")
+        continue;
+      for (tinyxml2::XMLElement *map = data->FirstChildElement("TrussInfoMap"); map;
+           map = map->NextSiblingElement("TrussInfoMap")) {
+        for (tinyxml2::XMLElement *info = map->FirstChildElement("TrussInfo"); info;
+             info = info->NextSiblingElement("TrussInfo")) {
+          const std::string uuid = CanonicalizeUuid(
+              Trim(info->Attribute("uuid") ? info->Attribute("uuid") : ""));
+          if (!uuid.empty())
+            rootTrussInfoByUuid[uuid] = info;
+        }
+      }
+    }
+  };
+  parseRootTrussInfoMap(root->FirstChildElement("UserData"));
+
   // ---- Parse AUXData for Symdefs and Positions ----
   std::unordered_map<std::string, std::string> legacyPositionIdToCanonical;
   if (tinyxml2::XMLElement *auxNode = sceneNode->FirstChildElement("AUXData")) {
@@ -2188,6 +2214,71 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
         scene.fixtures[fixture.uuid] = fixture;
       };
 
+  // Applies Perastage TrussInfo metadata while preserving GDTF authority rules.
+  auto applyTrussInfo = [&](tinyxml2::XMLElement *info, Truss &truss,
+                              bool hasGdtfMetadataAuthority) {
+    if (!info)
+      return;
+    if (!hasGdtfMetadataAuthority) {
+      if (tinyxml2::XMLElement *m = info->FirstChildElement("Manufacturer"))
+        if (m->GetText())
+          truss.manufacturer = Trim(m->GetText());
+      if (tinyxml2::XMLElement *mo = info->FirstChildElement("Model"))
+        if (mo->GetText())
+          truss.model = Trim(mo->GetText());
+      if (tinyxml2::XMLElement *len = info->FirstChildElement("Length"))
+        if (len->GetText()) {
+          float parsed = 0.0f;
+          if (TryParseFloat(len->GetText(), parsed))
+            truss.lengthMm = parsed;
+        }
+      if (tinyxml2::XMLElement *wid = info->FirstChildElement("Width"))
+        if (wid->GetText()) {
+          float parsed = 0.0f;
+          if (TryParseFloat(wid->GetText(), parsed))
+            truss.widthMm = parsed;
+          else
+            truss.widthMm = 400.0f;
+        }
+      if (tinyxml2::XMLElement *hei = info->FirstChildElement("Height"))
+        if (hei->GetText()) {
+          float parsed = 0.0f;
+          if (TryParseFloat(hei->GetText(), parsed))
+            truss.heightMm = parsed;
+          else
+            truss.heightMm = 400.0f;
+        }
+      if (tinyxml2::XMLElement *wei = info->FirstChildElement("Weight"))
+        if (wei->GetText()) {
+          float parsed = 0.0f;
+          if (TryParseFloat(wei->GetText(), parsed))
+            truss.weightKg = parsed;
+        }
+      if (tinyxml2::XMLElement *cs = info->FirstChildElement("CrossSection"))
+        if (cs->GetText())
+          truss.crossSection = Trim(cs->GetText());
+    }
+    if (tinyxml2::XMLElement *mf = info->FirstChildElement("ModelFile"))
+      if (mf->GetText())
+        truss.modelFile = mf->GetText();
+    if (tinyxml2::XMLElement *hp = info->FirstChildElement("PositionName"))
+      if (hp->GetText())
+        truss.positionName = Trim(hp->GetText());
+    if (truss.positionName.empty())
+      if (tinyxml2::XMLElement *hp = info->FirstChildElement("HangPos"))
+        if (hp->GetText())
+          truss.positionName = Trim(hp->GetText());
+    if (tinyxml2::XMLElement *rep = info->FirstChildElement("Representation"))
+      if (rep->GetText())
+        truss.sourceRepresentation = ParseTrussRepresentation(rep->GetText());
+    if (tinyxml2::XMLElement *tk = info->FirstChildElement("TypeKey"))
+      if (tk->GetText())
+        truss.perastageTypeKey = Trim(tk->GetText());
+    if (tinyxml2::XMLElement *ag = info->FirstChildElement("AuxGdtf"))
+      if (ag->GetText())
+        truss.perastageAuxGdtfArchivePath = RemapArchivePathIfNeeded(Trim(ag->GetText()));
+  };
+
   std::function<void(tinyxml2::XMLElement *, const std::string &, const Matrix &, const Matrix &, const std::string &)> parseTruss =
       [&](tinyxml2::XMLElement *node, const std::string &layerName,
           const Matrix &nodeTransform, const Matrix &localTransform, const std::string &parentGroupUuid) {
@@ -2297,70 +2388,14 @@ bool MvrImporter::ParseSceneXml(const std::string &sceneXmlPath,
 
         const bool hasGdtfMetadataAuthority = !truss.gdtfSpec.empty() && !gdtfLoadFailed;
 
-        if (tinyxml2::XMLElement *ud = node->FirstChildElement("UserData")) {
+        auto rootTrussInfoIt = rootTrussInfoByUuid.find(truss.uuid);
+        if (rootTrussInfoIt != rootTrussInfoByUuid.end()) {
+          applyTrussInfo(rootTrussInfoIt->second, truss, hasGdtfMetadataAuthority);
+        } else if (tinyxml2::XMLElement *ud = node->FirstChildElement("UserData")) {
           for (tinyxml2::XMLElement *data = ud->FirstChildElement("Data"); data;
                data = data->NextSiblingElement("Data")) {
-            if (tinyxml2::XMLElement *info =
-                    data->FirstChildElement("TrussInfo")) {
-              // GDTF values are authoritative when available. TrussInfo is used
-              // only as fallback metadata if GDTF could not be loaded.
-              if (!hasGdtfMetadataAuthority) {
-                if (tinyxml2::XMLElement *m =
-                        info->FirstChildElement("Manufacturer"))
-                  if (m->GetText())
-                    truss.manufacturer = Trim(m->GetText());
-                if (tinyxml2::XMLElement *mo = info->FirstChildElement("Model"))
-                  if (mo->GetText())
-                    truss.model = Trim(mo->GetText());
-                if (tinyxml2::XMLElement *len = info->FirstChildElement("Length"))
-                  if (len->GetText()) {
-                    float parsed = 0.0f;
-                    if (TryParseFloat(len->GetText(), parsed))
-                      truss.lengthMm = parsed;
-                  }
-                if (tinyxml2::XMLElement *wid = info->FirstChildElement("Width"))
-                  if (wid->GetText()) {
-                    float parsed = 0.0f;
-                    if (TryParseFloat(wid->GetText(), parsed))
-                      truss.widthMm = parsed;
-                    else
-                      truss.widthMm = 400.0f;
-                  }
-                if (tinyxml2::XMLElement *hei = info->FirstChildElement("Height"))
-                  if (hei->GetText()) {
-                    float parsed = 0.0f;
-                    if (TryParseFloat(hei->GetText(), parsed))
-                      truss.heightMm = parsed;
-                    else
-                      truss.heightMm = 400.0f;
-                  }
-                if (tinyxml2::XMLElement *wei = info->FirstChildElement("Weight"))
-                  if (wei->GetText()) {
-                    float parsed = 0.0f;
-                    if (TryParseFloat(wei->GetText(), parsed))
-                      truss.weightKg = parsed;
-                  }
-                if (tinyxml2::XMLElement *cs =
-                        info->FirstChildElement("CrossSection"))
-                  if (cs->GetText())
-                    truss.crossSection = Trim(cs->GetText());
-              }
-              if (tinyxml2::XMLElement *mf =
-                      info->FirstChildElement("ModelFile"))
-                if (mf->GetText())
-                  truss.modelFile = mf->GetText();
-              if (tinyxml2::XMLElement *hp = info->FirstChildElement("HangPos"))
-                if (hp->GetText())
-                  truss.positionName = Trim(hp->GetText());
-              if (tinyxml2::XMLElement *rep = info->FirstChildElement("Representation"))
-                if (rep->GetText())
-                  truss.sourceRepresentation = ParseTrussRepresentation(rep->GetText());
-              if (tinyxml2::XMLElement *tk = info->FirstChildElement("TypeKey"))
-                if (tk->GetText())
-                  truss.perastageTypeKey = Trim(tk->GetText());
-              if (tinyxml2::XMLElement *ag = info->FirstChildElement("AuxGdtf"))
-                if (ag->GetText())
-                  truss.perastageAuxGdtfArchivePath = RemapArchivePathIfNeeded(Trim(ag->GetText()));
+            if (tinyxml2::XMLElement *info = data->FirstChildElement("TrussInfo")) {
+              applyTrussInfo(info, truss, hasGdtfMetadataAuthority);
               break;
             }
           }

--- a/tests/mvr_exporter_compliance_test.cpp
+++ b/tests/mvr_exporter_compliance_test.cpp
@@ -360,7 +360,14 @@ int main() {
   trDifferentType.uuid = "tr-3";
   trDifferentType.name = "TRUSS 3M";
   trDifferentType.lengthMm = 3000.0f;
-  scene.trusses[trDifferentType.uuid] = trDifferentType;
+  Truss trCanonical = trNonNumeric;
+  trCanonical.uuid = "12345678-1234-4234-9234-123456789ABC";
+  trCanonical.name = "Canonical Truss";
+  trCanonical.lengthMm = 4000.0f;
+  trCanonical.unitNumber = 12;
+  trCanonical.customId = 34;
+  trCanonical.customIdType = 56;
+  scene.trusses[trCanonical.uuid] = trCanonical;
 
   Support sup;
   sup.uuid = "sup-1";
@@ -483,6 +490,10 @@ int main() {
   bool sawFixtureVisualizationColorWithoutMvrColor = false;
   bool sawFixtureGelColor = false;
   bool sawNonNumericTrussNameFixtureIdConsistency = false;
+  bool sawCanonicalTrussUuidUnchanged = false;
+  bool sawInvalidTrussUuidRepaired = false;
+  bool sawCanonicalTrussStandardChildren = false;
+  std::string repairedInvalidTrussUuid;
   bool sawPrimitiveSphereWithIdentityGeometryMatrix = false;
   bool sawPrimitivePipeObjectMatrixUnbaked = false;
   bool sawPrimitivePipeGeometryMatrixNormalized = false;
@@ -612,7 +623,22 @@ int main() {
               ++mvrGeometryTrussesWithRenderableGdtf;
 
             const char *trussUuid = cur->Attribute("uuid");
-            if (trussUuid != nullptr && std::string(trussUuid) == trNonNumeric.uuid) {
+            assert(trussUuid != nullptr);
+            assert(CanonicalizeUuid(trussUuid) == std::string(trussUuid));
+            assert(cur->FirstChildElement("UserData") == nullptr);
+            if (std::string(trussUuid) == trCanonical.uuid) {
+              sawCanonicalTrussUuidUnchanged = true;
+              sawCanonicalTrussStandardChildren =
+                  cur->FirstChildElement("FixtureID") != nullptr &&
+                  cur->FirstChildElement("FixtureIDNumeric") != nullptr &&
+                  cur->FirstChildElement("UnitNumber") != nullptr &&
+                  cur->FirstChildElement("CustomId") != nullptr &&
+                  cur->FirstChildElement("CustomIdType") != nullptr;
+            }
+            const char *trussName = cur->Attribute("name");
+            if (trussName != nullptr && std::string(trussName) == trNonNumeric.name) {
+              sawInvalidTrussUuidRepaired = std::string(trussUuid) != trNonNumeric.uuid;
+              repairedInvalidTrussUuid = trussUuid;
               sawNonNumericTrussNameFixtureIdConsistency =
                   fixtureIdText == std::to_string(value);
             }
@@ -730,6 +756,10 @@ int main() {
   assert(sawFixtureVisualizationColorWithoutMvrColor);
   assert(sawFixtureGelColor);
   assert(sawNonNumericTrussNameFixtureIdConsistency);
+  assert(sawCanonicalTrussUuidUnchanged);
+  assert(sawInvalidTrussUuidRepaired);
+  assert(!repairedInvalidTrussUuid.empty());
+  assert(sawCanonicalTrussStandardChildren);
   assert(sawPrimitiveSphereWithIdentityGeometryMatrix);
   assert(sawPrimitivePipeObjectMatrixUnbaked);
   assert(sawPrimitivePipeGeometryMatrixNormalized);
@@ -778,6 +808,32 @@ int main() {
   assert(sawSphereInDefaultLayer);
   tinyxml2::XMLElement *rootUserData = root->FirstChildElement("UserData");
   assert(rootUserData != nullptr);
+  bool sawRootTrussInfoMap = false;
+  bool sawRepairedTrussInfo = false;
+  bool sawCanonicalTrussInfo = false;
+  for (tinyxml2::XMLElement *data = rootUserData->FirstChildElement("Data"); data;
+       data = data->NextSiblingElement("Data")) {
+    const char *provider = data->Attribute("provider");
+    if (provider == nullptr || std::string(provider) != "Perastage")
+      continue;
+    for (tinyxml2::XMLElement *map = data->FirstChildElement("TrussInfoMap"); map;
+         map = map->NextSiblingElement("TrussInfoMap")) {
+      sawRootTrussInfoMap = true;
+      for (tinyxml2::XMLElement *info = map->FirstChildElement("TrussInfo"); info;
+           info = info->NextSiblingElement("TrussInfo")) {
+        const char *uuid = info->Attribute("uuid");
+        assert(uuid != nullptr);
+        assert(CanonicalizeUuid(uuid) == std::string(uuid));
+        if (std::string(uuid) == repairedInvalidTrussUuid)
+          sawRepairedTrussInfo = true;
+        if (std::string(uuid) == trCanonical.uuid)
+          sawCanonicalTrussInfo = true;
+      }
+    }
+  }
+  assert(sawRootTrussInfoMap);
+  assert(sawRepairedTrussInfo);
+  assert(sawCanonicalTrussInfo);
 
   tinyxml2::XMLElement *auxNode = sceneNode->FirstChildElement("AUXData");
   assert(auxNode != nullptr);

--- a/tests/mvr_truss_roundtrip_structure_test.cpp
+++ b/tests/mvr_truss_roundtrip_structure_test.cpp
@@ -209,10 +209,18 @@ int main() {
   }
   assert(foundSymdef);
 
-  tinyxml2::XMLElement *sceneUserData = sceneNode->FirstChildElement("UserData");
-  assert(sceneUserData != nullptr);
-  tinyxml2::XMLElement *manifest = sceneUserData->FirstChildElement("Data")->FirstChildElement("TrussSidecarManifest");
+  assert(sceneNode->FirstChildElement("UserData") == nullptr);
+  tinyxml2::XMLElement *rootUserData = xml.FirstChildElement("GeneralSceneDescription")->FirstChildElement("UserData");
+  assert(rootUserData != nullptr);
+  tinyxml2::XMLElement *rootData = rootUserData->FirstChildElement("Data");
+  assert(rootData != nullptr);
+  tinyxml2::XMLElement *manifest = rootData->FirstChildElement("TrussSidecarManifest");
   assert(manifest != nullptr);
+  tinyxml2::XMLElement *trussInfoMap = rootData->FirstChildElement("TrussInfoMap");
+  assert(trussInfoMap != nullptr);
+  tinyxml2::XMLElement *trussInfo = trussInfoMap->FirstChildElement("TrussInfo");
+  assert(trussInfo != nullptr);
+  assert(std::string(trussInfo->Attribute("uuid")) == truss.uuid);
   tinyxml2::XMLElement *typeNode = manifest->FirstChildElement("Type");
   assert(typeNode != nullptr);
   assert(std::string(typeNode->Attribute("gdtf")).rfind("Perastage/truss_types/", 0) == 0);
@@ -229,6 +237,69 @@ int main() {
   assert(!importedTruss.perastageAuxGdtfArchivePath.empty());
   assert(importedTruss.manufacturer == "Perastage");
   assert(importedTruss.model == "Tower 40");
+
+  const fs::path legacyMvrPath = tempDir / "legacy-truss-userdata.mvr";
+  {
+    wxFileOutputStream legacyOut(legacyMvrPath.generic_string());
+    assert(legacyOut.IsOk());
+    wxZipOutputStream legacyZip(legacyOut);
+    const std::string legacyXml =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        "<GeneralSceneDescription verMajor=\"1\" verMinor=\"6\" provider=\"Perastage\" providerVersion=\"test\">"
+        "<Scene><Layers><Layer name=\"Default\"><ChildList>"
+        "<Truss uuid=\"uuid_17311332189900\" name=\"Legacy Truss\">"
+        "<Matrix>1,0,0,0,1,0,0,0,1,0,0,0</Matrix>"
+        "<FixtureID>1</FixtureID><FixtureIDNumeric>1</FixtureIDNumeric>"
+        "<UserData><Data provider=\"Perastage\" ver=\"1.0\"><TrussInfo uuid=\"uuid_17311332189900\">"
+        "<Manufacturer>Legacy Maker</Manufacturer><Model>Legacy Model</Model><Length unit=\"mm\">2500</Length>"
+        "<Width unit=\"mm\">400</Width><Height unit=\"mm\">400</Height><Weight unit=\"kg\">30</Weight>"
+        "<CrossSection>40x40</CrossSection><HangPos>Legacy Position</HangPos>"
+        "</TrussInfo></Data></UserData></Truss>"
+        "</ChildList></Layer></Layers></Scene></GeneralSceneDescription>";
+    assert(legacyZip.PutNextEntry("GeneralSceneDescription.xml"));
+    legacyZip.Write(legacyXml.data(), legacyXml.size());
+    legacyZip.Close();
+  }
+
+  cfg.Reset();
+  assert(importer.ImportFromFile(legacyMvrPath.string(), false, false));
+  MvrScene &legacyImportedScene = ConfigManager::Get().GetScene();
+  assert(legacyImportedScene.trusses.size() == 1);
+  const Truss &legacyImportedTruss = legacyImportedScene.trusses.begin()->second;
+  assert(CanonicalizeUuid(legacyImportedTruss.uuid) == legacyImportedTruss.uuid);
+  assert(legacyImportedTruss.manufacturer == "Legacy Maker");
+  assert(legacyImportedTruss.model == "Legacy Model");
+  assert(legacyImportedTruss.lengthMm == 2500.0f);
+  const fs::path migratedMvrPath = tempDir / "legacy-truss-migrated.mvr";
+  assert(exporter.ExportToFile(migratedMvrPath.string()));
+  const auto migratedEntries = ReadArchiveTextEntries(migratedMvrPath);
+  tinyxml2::XMLDocument migratedXml;
+  assert(migratedXml.Parse(migratedEntries.at("GeneralSceneDescription.xml").c_str()) ==
+         tinyxml2::XML_SUCCESS);
+  tinyxml2::XMLElement *migratedRoot = migratedXml.FirstChildElement("GeneralSceneDescription");
+  assert(migratedRoot != nullptr);
+  bool sawMigratedTrussInfo = false;
+  std::vector<tinyxml2::XMLElement *> migratedStack{migratedRoot};
+  while (!migratedStack.empty()) {
+    tinyxml2::XMLElement *node = migratedStack.back();
+    migratedStack.pop_back();
+    if (std::string(node->Name()) == "Truss") {
+      assert(node->FirstChildElement("UserData") == nullptr);
+      const char *uuid = node->Attribute("uuid");
+      assert(uuid != nullptr);
+      assert(CanonicalizeUuid(uuid) == std::string(uuid));
+    }
+    if (std::string(node->Name()) == "TrussInfo") {
+      const char *uuid = node->Attribute("uuid");
+      assert(uuid != nullptr);
+      assert(CanonicalizeUuid(uuid) == std::string(uuid));
+      sawMigratedTrussInfo = true;
+    }
+    for (tinyxml2::XMLElement *child = node->FirstChildElement(); child;
+         child = child->NextSiblingElement())
+      migratedStack.push_back(child);
+  }
+  assert(sawMigratedTrussInfo);
 
   cfg.Reset();
   MvrScene &generatedScene = cfg.GetScene();


### PR DESCRIPTION
### Motivation
- Fix MVR 1.6 incompatibilities where Perastage exported non-canonical Truss `uuid` values and inlined Perastage-specific `<UserData>` inside `<Truss>` which is invalid in the MVR 1.6 schema. 
- Preserve MVR-standard Truss children (including `FixtureID`, `FixtureIDNumeric`, `UnitNumber`, `CustomId`, `CustomIdType`) while moving Perastage metadata into a root-level, grouped provider block for portability and compatibility. 
- Keep backward-compatible import of legacy Perastage files that wrote `<Truss><UserData><Data provider="Perastage"><TrussInfo>...</TrussInfo></Data></UserData>`.

### Description
- Ensure exported `<Truss>` nodes always use canonical UUID strings by computing `trussExportUuids` and applying deterministic fallback canonical UUIDs for missing, non-canonical, or colliding Truss UUIDs at export time, and log a warning when repairs occur. 
- Replace per-Truss inline Perastage `UserData/TrussInfo` with a root-level `GeneralSceneDescription/UserData/Data provider="Perastage"` container named `TrussInfoMap`, and write one `TrussInfo uuid="<exported-canonical-uuid">...` entry per truss; keep all valid MVR Truss children inside `<Truss>`. 
- Propagate the repaired/exported UUID consistently to related maps and manifests by using the exported UUID when registering GDTF resources, populating `gdtfArchiveByObjectUuid`, and when filling the Truss sidecar `TrussSidecarManifest` `Instance` entries and `trussInstanceToTypeKey`. 
- Strengthen export validation in `ValidateMvr16Export` to reject missing/non-canonical Truss UUIDs, reject direct `<Truss><UserData>` children, and ensure root-level Perastage `TrussInfoMap` and `TrussSidecarManifest` reference valid exported canonical Truss UUIDs. 
- Extend importer parsing to prefer root-level `TrussInfoMap` entries via `parseRootTrussInfoMap(...)` and apply them (via `applyTrussInfo(...)`) while preserving legacy `<Truss><UserData>` fallback behavior when root-level metadata is absent. 
- Add focused helpers: `HasTrussInfoMetadata(...)` and `AppendTrussInfoMetadata(...)` to keep exporter logic modular. 
- Update tests to cover canonical UUID preservation, deterministic repair of invalid Truss UUIDs, absence of direct `<Truss><UserData>`, presence and correctness of root-level `TrussInfoMap` entries, and legacy-import-and-migrate roundtrip behavior. 
- Updated `docs/release-notes-draft.md` with a short entry describing the MVR truss export/import compatibility improvements.

### Testing
- Ran repository checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, both succeeded. 
- Ran `git diff --check` to ensure no whitespace/commit issues, which passed. 
- Attempted to configure and build the unit tests with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug && cmake --build build --target mvr_exporter_compliance_test mvr_truss_roundtrip_structure_test -j2` but the environment lacks `wxWidgets` development files so the CMake configure step failed and unit test binaries could not be executed here; the updated tests and new assertions are included in this change and should run in CI or a developer environment with `wxWidgets` available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3095619c2483249fe1967ee9de3787)