### PR TITLE
Add Drag Move toolbar toggle (left-click selection dragging) and fix disabled toolbar icon colors

### DIFF
--- a/core/selection_movement_settings.h
+++ b/core/selection_movement_settings.h
@@ -6,6 +6,8 @@ namespace selection_movement_settings {
 
 constexpr const char *kAxisConstrainedMovementConfigKey =
     "selection_axis_constrained_movement";
+constexpr const char *kLeftDragSelectionMovementConfigKey =
+    "selection_left_drag_movement";
 
 // Returns whether selection dragging should stay constrained to axes.
 inline bool IsAxisConstrainedMovementEnabled(const ConfigManager &cfg) {
@@ -16,6 +18,17 @@ inline bool IsAxisConstrainedMovementEnabled(const ConfigManager &cfg) {
 // Persists whether selection dragging should stay constrained to axes.
 inline void SetAxisConstrainedMovementEnabled(ConfigManager &cfg, bool enabled) {
   cfg.SetValue(kAxisConstrainedMovementConfigKey, enabled ? "1" : "0");
+}
+
+// Returns whether left-click dragging may move selected scene elements.
+inline bool IsLeftDragSelectionMovementEnabled(const ConfigManager &cfg) {
+  const auto value = cfg.GetValue(kLeftDragSelectionMovementConfigKey);
+  return value && *value == "1";
+}
+
+// Persists whether left-click dragging may move selected scene elements.
+inline void SetLeftDragSelectionMovementEnabled(ConfigManager &cfg, bool enabled) {
+  cfg.SetValue(kLeftDragSelectionMovementConfigKey, enabled ? "1" : "0");
 }
 
 } // namespace selection_movement_settings

--- a/docs/features.md
+++ b/docs/features.md
@@ -103,6 +103,7 @@ Additional safeguards include:
 
 - OpenGL-based viewer with orbit, pan, zoom, and preset camera views.
 - Selection flows integrate with scene tables and command operations.
+- The viewport toolbar includes a Drag Move toggle for moving scene selections with a left-click drag. It is disabled by default to make viewport panning safer in dense scenes, and its state is stored with the project.
 - The viewport toolbar includes an axis-lock toggle for dragged scene selections. It is enabled by default for axis-constrained moves; disabling it stores the project setting and allows Blender-style free dragging on a plane parallel to the 3D camera view.
 - Context menu includes **Render style** with these options:
   - **Standard** for general-purpose scene reading.

--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -6,6 +6,8 @@ Changes since `v1.3.0`.
 
 ## New features
 
+- Added a project-persistent Drag Move toolbar toggle for enabling left-click selection dragging, disabled by default to reduce accidental object moves while panning dense 2D and 3D views.
+
 - Added MVR Import / Export preferences with a truss geometry export mode selector, defaulting to the standard MVR representation while offering a direct Geometry3D compatibility mode for truss symbols.
 - Added a disabled-by-default Magnet snapping toolbar mode for 2D and 3D dragging, with truss-to-truss grouping on committed snaps and transform-only fixture/object snaps that preserve Hang Position and MVR compatibility.
 - Added a project-persistent Axis Lock toolbar toggle for selection dragging, enabled by default for axis-constrained moves and allowing free 2D movement plus Blender-style view-plane movement in 3D when disabled.
@@ -26,6 +28,8 @@ Changes since `v1.3.0`.
 - Improved 2D and 3D drag feedback so the bottom X/Y/Z status readout shows the dragged insertion-point position in a highlighted color while objects are being moved.
 
 ## Fixes
+
+- Improved disabled toolbar icon colors for viewport selection, measurement, axis-lock, drag-move, and Magnet tools so disabled tools no longer look highlighted in dark mode.
 
 - Preserved embedded MVR GDTF fixture references when reopening `.pstg` projects so fixtures affected by GDTF dictionary conflicts do not silently downgrade to dummy geometry on the next save.
 - Improved MVR compatibility by preserving Support objects during roundtrip export, preserving geometry-less Support nodes with empty Geometries and using small 10 cm placeholder geometry for otherwise empty SceneObject exports, and writing Truss children in schema-compatible order.

--- a/docs/views.md
+++ b/docs/views.md
@@ -14,6 +14,7 @@ Typical checks:
 - Group selection while clicking scene items: clicking a grouped member selects its full group across related tables.
 - General scene structure before export.
 - Dragging feedback: while moving scene elements in 2D or with the 3D gizmo, the bottom X/Y/Z status readout shows the dragged insertion-point position with a highlighted font color until the mouse is released.
+- Drag Move: the **Drag Move** toolbar toggle, shown with the Move icon, enables moving scene selections by holding the left mouse button over an element and dragging. It is disabled by default so left-dragging pans the viewport in dense scenes unless the user enables selection dragging, and the setting is stored in the project.
 - Axis lock: the **Axis Lock** toolbar toggle, shown with the Move 3D icon, is enabled by default and stores its state in the project. When disabled, 3D selection dragging follows a plane parallel to the current camera view through the selection origin, similar to Blender free move.
 
 ## 2D view and layouts

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -76,6 +76,7 @@ using json = nlohmann::json;
 #include "autopatcher.h"
 #include "configmanager.h"
 #include "guiconfigservices.h"
+#include "magnet_snap.h"
 #include "highlight_status_bar.h"
 #include "consolepanel.h"
 #include "credentialstore.h"
@@ -384,6 +385,7 @@ EVT_MENU(ID_View_Viewport_Side, MainWindow::OnViewportSideView)
 EVT_MENU(ID_View_Viewport_SelectTool, MainWindow::OnViewportSelectTool)
 EVT_MENU(ID_View_Viewport_MeasureTool, MainWindow::OnViewportMeasureTool)
 EVT_MENU(ID_View_Viewport_AxisConstraint, MainWindow::OnViewportAxisConstraint)
+EVT_MENU(ID_View_Viewport_LeftDragMove, MainWindow::OnViewportLeftDragMove)
 EVT_MENU(ID_View_Viewport_Magnet, MainWindow::OnViewportMagnet)
 EVT_MENU(ID_View_Layout_2DView, MainWindow::OnLayoutAdd2DView)
 EVT_MENU(ID_View_Layout_Legend, MainWindow::OnLayoutAddLegend)
@@ -1189,6 +1191,7 @@ void MainWindow::UpdateToolBarAvailability() {
     layoutViewsToolBar->EnableTool(ID_View_Viewport_SelectTool, enableViewportTools);
     layoutViewsToolBar->EnableTool(ID_View_Viewport_MeasureTool, enableViewportTools);
     layoutViewsToolBar->EnableTool(ID_View_Viewport_AxisConstraint, enableViewportTools);
+    layoutViewsToolBar->EnableTool(ID_View_Viewport_LeftDragMove, enableViewportTools);
     layoutViewsToolBar->EnableTool(ID_View_Viewport_Magnet, enableViewportTools);
     layoutViewsToolBar->SetToolShortHelp(
         ID_View_Viewport_SelectTool,
@@ -1201,6 +1204,10 @@ void MainWindow::UpdateToolBarAvailability() {
     layoutViewsToolBar->SetToolShortHelp(
         ID_View_Viewport_AxisConstraint,
         enableViewportTools ? "Toggle axis-constrained selection movement"
+                            : "Disabled while editing Layout views");
+    layoutViewsToolBar->SetToolShortHelp(
+        ID_View_Viewport_LeftDragMove,
+        enableViewportTools ? "Toggle left-click selection dragging"
                             : "Disabled while editing Layout views");
     layoutViewsToolBar->SetToolShortHelp(
         ID_View_Viewport_Magnet,
@@ -1488,6 +1495,16 @@ void MainWindow::OnProjectLoaded(wxCommandEvent &event) {
     }
     if (viewport2DRenderPanel)
       viewport2DRenderPanel->ApplyConfig();
+    const bool magnetEnabled =
+        GetDefaultGuiConfigServices().Preferences().GetValue(
+            magnet_snap::kMagnetEnabledConfigKey) == "1";
+    if (viewportPanel)
+      viewportPanel->SetMagnetEnabled(magnetEnabled);
+    if (viewport2DPanel)
+      viewport2DPanel->SetMagnetEnabled(magnetEnabled);
+    SyncViewportToolToggleState(
+        (viewport2DPanel && viewport2DPanel->IsMeasureToolEnabled()) ||
+        (viewportPanel && viewportPanel->IsMeasureToolEnabled()));
     if (layerPanel)
       layerPanel->ReloadLayers();
     SplashScreen::SetMessage("Refreshing panels...");

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -86,6 +86,7 @@ public:
   bool ApplyShortcutDecision(const gui::ShortcutExecutionDecision &decision);
   void SyncViewportToolToggleState(bool measureEnabled);
   void SyncAxisConstraintToolToggleState();
+  void SyncLeftDragMoveToolToggleState();
   void Ensure2DViewportAvailable();
   Viewer2DPanel *GetLayoutCapturePanel() const;
   Viewer2DOffscreenRenderer *GetOffscreenRenderer();
@@ -215,6 +216,7 @@ private:
   void OnViewportSelectTool(wxCommandEvent &event);
   void OnViewportMeasureTool(wxCommandEvent &event);
   void OnViewportMagnet(wxCommandEvent &event);
+  void OnViewportLeftDragMove(wxCommandEvent &event);
   void OnViewportAxisConstraint(wxCommandEvent &event);
 
   void OnUndo(wxCommandEvent &event);           // Undo action placeholder

--- a/gui/mainwindow/ids/view_ids.h
+++ b/gui/mainwindow/ids/view_ids.h
@@ -25,4 +25,5 @@ constexpr int ID_View_Viewport_Side = ID_View_Viewport_Front + 1;
 constexpr int ID_View_Viewport_SelectTool = ID_View_Viewport_Side + 1;
 constexpr int ID_View_Viewport_MeasureTool = ID_View_Viewport_SelectTool + 1;
 constexpr int ID_View_Viewport_AxisConstraint = ID_View_Viewport_MeasureTool + 1;
-constexpr int ID_View_Viewport_Magnet = ID_View_Viewport_AxisConstraint + 1;
+constexpr int ID_View_Viewport_LeftDragMove = ID_View_Viewport_AxisConstraint + 1;
+constexpr int ID_View_Viewport_Magnet = ID_View_Viewport_LeftDragMove + 1;

--- a/gui/mainwindow_menu.cpp
+++ b/gui/mainwindow_menu.cpp
@@ -139,9 +139,10 @@ void MainWindow::CreateToolBars() {
   const auto addToolWithDisabledIcon =
       [&](wxAuiToolBar *toolbar, int id, const wxString &label,
           const std::string &iconName, const wxArtID &fallbackArtId,
-          const wxString &shortHelp) {
+          const wxString &shortHelp,
+          wxItemKind kind = wxITEM_NORMAL) {
         toolbar->AddTool(id, label, loadToolbarIcon(iconName, fallbackArtId),
-                         shortHelp);
+                         shortHelp, kind);
 
         wxAuiToolBarItem *toolItem = toolbar->FindTool(id);
         if (toolItem) {
@@ -227,26 +228,23 @@ void MainWindow::CreateToolBars() {
                                               wxART_MISSING_IMAGE),
                               "Apply side view to active viewport");
   layoutViewsToolBar->AddSeparator();
-  layoutViewsToolBar->AddTool(ID_View_Viewport_SelectTool, "Select Tool",
-                              loadToolbarIcon("mouse-pointer-2",
-                                              wxART_NORMAL_FILE),
-                              "Switch to standard selection mode",
-                              wxITEM_CHECK);
-  layoutViewsToolBar->AddTool(ID_View_Viewport_MeasureTool, "Measure Tool",
-                              loadToolbarIcon("ruler-dimension-line",
-                                              wxART_MISSING_IMAGE),
-                              "Toggle center-to-center measure tool",
-                              wxITEM_CHECK);
-  layoutViewsToolBar->AddTool(ID_View_Viewport_AxisConstraint, "Axis Lock",
-                              loadToolbarIcon("move-3d",
-                                              wxART_MISSING_IMAGE),
-                              "Toggle axis-constrained selection movement",
-                              wxITEM_CHECK);
-  layoutViewsToolBar->AddTool(ID_View_Viewport_Magnet, "Magnet",
-                              loadToolbarIcon("magnet",
-                                              wxART_MISSING_IMAGE),
-                              "Toggle Magnet snapping while dragging",
-                              wxITEM_CHECK);
+  addToolWithDisabledIcon(layoutViewsToolBar, ID_View_Viewport_SelectTool,
+                          "Select Tool", "mouse-pointer-2", wxART_NORMAL_FILE,
+                          "Switch to standard selection mode", wxITEM_CHECK);
+  addToolWithDisabledIcon(layoutViewsToolBar, ID_View_Viewport_MeasureTool,
+                          "Measure Tool", "ruler-dimension-line",
+                          wxART_MISSING_IMAGE,
+                          "Toggle center-to-center measure tool", wxITEM_CHECK);
+  addToolWithDisabledIcon(layoutViewsToolBar, ID_View_Viewport_AxisConstraint,
+                          "Axis Lock", "move-3d", wxART_MISSING_IMAGE,
+                          "Toggle axis-constrained selection movement",
+                          wxITEM_CHECK);
+  addToolWithDisabledIcon(layoutViewsToolBar, ID_View_Viewport_LeftDragMove,
+                          "Drag Move", "move", wxART_MISSING_IMAGE,
+                          "Toggle left-click selection dragging", wxITEM_CHECK);
+  addToolWithDisabledIcon(layoutViewsToolBar, ID_View_Viewport_Magnet, "Magnet",
+                          "magnet", wxART_MISSING_IMAGE,
+                          "Toggle Magnet snapping while dragging", wxITEM_CHECK);
   layoutViewsToolBar->ToggleTool(ID_View_Viewport_SelectTool, true);
   layoutViewsToolBar->ToggleTool(ID_View_Viewport_MeasureTool, false);
   layoutViewsToolBar->ToggleTool(
@@ -254,6 +252,11 @@ void MainWindow::CreateToolBars() {
       GetDefaultGuiConfigServices().Preferences().GetValue(
           selection_movement_settings::kAxisConstrainedMovementConfigKey) !=
           "0");
+  layoutViewsToolBar->ToggleTool(
+      ID_View_Viewport_LeftDragMove,
+      GetDefaultGuiConfigServices().Preferences().GetValue(
+          selection_movement_settings::kLeftDragSelectionMovementConfigKey) ==
+          "1");
   layoutViewsToolBar->ToggleTool(
       ID_View_Viewport_Magnet,
       GetDefaultGuiConfigServices().Preferences().GetValue(

--- a/gui/mainwindow_view_shortcuts.cpp
+++ b/gui/mainwindow_view_shortcuts.cpp
@@ -48,6 +48,7 @@ void MainWindow::SyncViewportToolToggleState(bool measureEnabled) {
   layoutViewsToolBar->ToggleTool(ID_View_Viewport_SelectTool, !measureEnabled);
   layoutViewsToolBar->ToggleTool(ID_View_Viewport_MeasureTool, measureEnabled);
   SyncAxisConstraintToolToggleState();
+  SyncLeftDragMoveToolToggleState();
   layoutViewsToolBar->ToggleTool(
       ID_View_Viewport_Magnet,
       GetDefaultGuiConfigServices().Preferences().GetValue(
@@ -64,6 +65,17 @@ void MainWindow::SyncAxisConstraintToolToggleState() {
       GetDefaultGuiConfigServices().Preferences().GetValue(
           selection_movement_settings::kAxisConstrainedMovementConfigKey) !=
           "0");
+}
+
+// Synchronizes the left-click selection dragging toolbar toggle with project settings.
+void MainWindow::SyncLeftDragMoveToolToggleState() {
+  if (!layoutViewsToolBar)
+    return;
+  layoutViewsToolBar->ToggleTool(
+      ID_View_Viewport_LeftDragMove,
+      GetDefaultGuiConfigServices().Preferences().GetValue(
+          selection_movement_settings::kLeftDragSelectionMovementConfigKey) ==
+          "1");
 }
 
 // Switches the viewport interaction back to standard selection mode.
@@ -99,6 +111,19 @@ void MainWindow::OnViewportAxisConstraint(wxCommandEvent &WXUNUSED(event)) {
       selection_movement_settings::kAxisConstrainedMovementConfigKey,
       axisConstraintEnabled ? "0" : "1");
   SyncAxisConstraintToolToggleState();
+}
+
+// Toggles project-level left-click selection dragging.
+void MainWindow::OnViewportLeftDragMove(wxCommandEvent &WXUNUSED(event)) {
+  auto &preferences = GetDefaultGuiConfigServices().Preferences();
+  const bool enabled =
+      preferences.GetValue(
+          selection_movement_settings::kLeftDragSelectionMovementConfigKey) ==
+      "1";
+  preferences.SetValue(
+      selection_movement_settings::kLeftDragSelectionMovementConfigKey,
+      enabled ? "0" : "1");
+  SyncLeftDragMoveToolToggleState();
 }
 
 bool MainWindow::ApplyFitShortcut() {

--- a/resources/icons/outline/magnet-disabled.svg
+++ b/resources/icons/outline/magnet-disabled.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#4A4A4A"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m12 15 4 4" />
+  <path d="M2.352 10.648a1.205 1.205 0 0 0 0 1.704l2.296 2.296a1.205 1.205 0 0 0 1.704 0l6.029-6.029a1 1 0 1 1 3 3l-6.029 6.029a1.205 1.205 0 0 0 0 1.704l2.296 2.296a1.205 1.205 0 0 0 1.704 0l6.365-6.367A1 1 0 0 0 8.716 4.282z" />
+  <path d="m5 8 4 4" />
+</svg>

--- a/resources/icons/outline/mouse-pointer-2-disabled.svg
+++ b/resources/icons/outline/mouse-pointer-2-disabled.svg
@@ -1,0 +1,4 @@
+<svg opacity="0.95" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#4A4A4A" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="m4 4 7 16 2.3-7.7L21 10z"/>
+  <path d="M13 13l6 6"/>
+</svg>

--- a/resources/icons/outline/move-3d-disabled.svg
+++ b/resources/icons/outline/move-3d-disabled.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#4A4A4A"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M5 3v16h16" />
+  <path d="m5 19 6-6" />
+  <path d="m2 6 3-3 3 3" />
+  <path d="m18 16 3 3-3 3" />
+</svg>

--- a/resources/icons/outline/move-disabled.svg
+++ b/resources/icons/outline/move-disabled.svg
@@ -1,0 +1,8 @@
+<svg opacity="0.95" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#4A4A4A" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 2v20"/>
+  <path d="m15 19-3 3-3-3"/>
+  <path d="m19 9 3 3-3 3"/>
+  <path d="M2 12h20"/>
+  <path d="m5 9-3 3 3 3"/>
+  <path d="m9 5 3-3 3 3"/>
+</svg>

--- a/resources/icons/outline/move.svg
+++ b/resources/icons/outline/move.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 2v20"/>
+  <path d="m15 19-3 3-3-3"/>
+  <path d="m19 9 3 3-3 3"/>
+  <path d="M2 12h20"/>
+  <path d="m5 9-3 3 3 3"/>
+  <path d="m9 5 3-3 3 3"/>
+</svg>

--- a/resources/icons/outline/ruler-dimension-line-disabled.svg
+++ b/resources/icons/outline/ruler-dimension-line-disabled.svg
@@ -1,0 +1,9 @@
+<svg opacity="0.95" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#4A4A4A" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 5v14"/>
+  <path d="M21 5v14"/>
+  <path d="M7 9h10"/>
+  <path d="m7 9 2-2"/>
+  <path d="m7 9 2 2"/>
+  <path d="m17 9-2-2"/>
+  <path d="m17 9-2 2"/>
+</svg>

--- a/viewer2d/viewer2dpanel.cpp
+++ b/viewer2d/viewer2dpanel.cpp
@@ -2514,6 +2514,10 @@ void Viewer2DPanel::OnMouseDown(wxMouseEvent &event) {
     if (!m_enableSelection || !IsShownOnScreen())
       return;
 
+    const bool leftDragSelectionMovement =
+        selection_movement_settings::IsLeftDragSelectionMovementEnabled(
+            ConfigManager::Get());
+
     if (event.ControlDown()) {
       m_dragMode = DragMode::RectSelection;
       m_rectSelecting = true;
@@ -2522,6 +2526,9 @@ void Viewer2DPanel::OnMouseDown(wxMouseEvent &event) {
       m_rectSelectEnd = m_lastMousePos;
       return;
     }
+
+    if (!leftDragSelectionMovement)
+      return;
 
     const RenderSize renderSize = ResolveRenderSize(this);
     const int w = renderSize.width;

--- a/viewer3d/viewer3dpanel.cpp
+++ b/viewer3d/viewer3dpanel.cpp
@@ -1664,7 +1664,9 @@ void Viewer3DPanel::OnMouseDown(wxMouseEvent& event)
         }
 
         if (event.LeftDown() && !event.ShiftDown() && !event.MiddleDown() &&
-            !event.RightDown()) {
+            !event.RightDown() &&
+            selection_movement_settings::IsLeftDragSelectionMovementEnabled(
+                ConfigManager::Get())) {
             if (PrepareSelectionDrag(event.GetPosition())) {
                 m_lastMousePos = event.GetPosition();
                 m_draggedSincePress = false;


### PR DESCRIPTION
### Motivation
- Avoid accidental object moves when panning dense 2D/3D views by making left-click selection-dragging opt-in via a toolbar toggle. 
- Ensure toolbar toggle states are synchronized and persist with the project, and fix disabled-icon coloring so disabled tools are visually distinct in dark mode.

### Description
- Added a project-persistent setting `selection_left_drag_movement` and helpers `IsLeftDragSelectionMovementEnabled` / `SetLeftDragSelectionMovementEnabled` in `core/selection_movement_settings.h` to control left-drag selection movement. 
- Added a new toolbar toggle `Drag Move` (ID `ID_View_Viewport_LeftDragMove`) to the Layout Views toolbar using the Lucide Move icon and wired it to the preferences so the button state is restored when a project is opened (`gui/mainwindow_menu.cpp`, `gui/mainwindow/ids/view_ids.h`).
- Synchronized the new toggle with existing viewport tool sync logic by adding `SyncLeftDragMoveToolToggleState()` and the `OnViewportLeftDragMove()` handler to toggle the preference (`gui/mainwindow_view_shortcuts.cpp`, `gui/mainwindow.h`, `gui/mainwindow.cpp`).
- Guarded 2D and 3D left-click selection drag flows so they only start when the new setting is enabled, preserving Ctrl+left-drag rectangle selection and normal pan/orbit behavior otherwise (`viewer2d/viewer2dpanel.cpp`, `viewer3d/viewer3dpanel.cpp`).
- Added disabled SVG variants and a new `move.svg` icon and updated `addToolWithDisabledIcon` usage so disabled toolbar icons use explicit disabled artwork and no longer look highlighted in dark mode (`resources/icons/outline/*`, `gui/mainwindow_menu.cpp`).
- Updated user-facing docs and release notes to describe the new `Drag Move` toggle and the disabled-icon color fix (`docs/features.md`, `docs/views.md`, `docs/release-notes-draft.md`).

### Testing
- Ran `tests/check_perastage_tree_modules.sh` and it passed.
- Ran `tests/check_no_configmanager_get_in_gui.sh` and it passed.
- Ran `git diff --check` (whitespace/checks) and it passed.
- Attempted a CMake configure `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug` but the build was blocked in the container due to missing wxWidgets development libraries (environment issue), so a full local build/test could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a310f9b06c883248d38e1e830ee569a)