### PR TITLE
Flatten MVR export resources to archive root and sanitize Perastage UserData

### DIFF
--- a/docs/release-notes-draft.md
+++ b/docs/release-notes-draft.md
@@ -39,6 +39,7 @@ Changes since `v1.3.0`.
 - Improved MVR compatibility by preserving Support objects during roundtrip export, preserving geometry-less Support nodes with empty Geometries and using small 10 cm placeholder geometry for otherwise empty SceneObject exports, and writing Truss children in schema-compatible order.
 - Fixed MVR Symbol/Symdef truss export so every Symbol keeps or receives a stable valid UUID and required Symdef reference, improving compatibility with strict MVR importers.
 - Improved MVR 1.6 truss export compatibility by writing canonical Truss UUIDs, moving Perastage truss metadata to root UserData, and preserving legacy truss metadata import.
+- Fixed MVR 1.6 exports so resource files are written at the archive root and Perastage truss metadata no longer exposes local filesystem paths.
 
 - Fixed GDTF persistence so automatic symbol generation and project-scoped fixture edits update project-owned copies or stable @Perastage library derivatives without filling the user fixture library with imported or generated project files.
 - Fixed Linux GTK layout warnings in the rich text toolbar by giving icon buttons enough themed padding while preserving the existing editing behavior.

--- a/mvr/mvrexporter.cpp
+++ b/mvr/mvrexporter.cpp
@@ -451,6 +451,10 @@ static std::string TruncateFileNamePreservingExtension(const std::string &fileNa
   return truncatedStem + extension;
 }
 
+// Sanitizes arbitrary input into a single portable archive filename.
+static std::string SanitizeArchiveFileName(const std::string &input,
+                                           const std::string &fallbackName);
+
 static std::string ResolveFallbackFixtureGdtfPath() {
   static const std::string resolvedPath = []() {
     const fs::path basePath = ProjectUtils::GetBaseLibraryPath("fixtures");
@@ -470,15 +474,26 @@ static std::string ResolveFallbackFixtureGdtfPath() {
   return resolvedPath;
 }
 
+// Returns true when an archive filename is already reserved case-insensitively.
+static bool ContainsArchiveFileNameCaseInsensitive(
+    const std::unordered_set<std::string> &usedPaths,
+    const std::string &candidate) {
+  const std::string candidateKey = ToLowerAscii(candidate);
+  return std::any_of(usedPaths.begin(), usedPaths.end(),
+                     [&](const std::string &used) {
+                       return ToLowerAscii(used) == candidateKey;
+                     });
+}
+
+// Creates a unique root-level MVR archive filename from any source-like path.
 static std::string EnsureUniqueArchivePath(const std::string &proposed,
                                            std::unordered_set<std::string> &usedPaths) {
   constexpr size_t kMaxArchiveEntryNameLength = 120;
-  fs::path path = fs::path(proposed).lexically_normal();
-  std::string normalized =
-      TruncateFileNamePreservingExtension(path.generic_string(), kMaxArchiveEntryNameLength);
-  if (normalized.empty())
+  std::string normalized = SanitizeArchiveFileName(proposed, "resource.bin");
+  normalized = TruncateFileNamePreservingExtension(normalized, kMaxArchiveEntryNameLength);
+  if (normalized.empty() || fs::path(normalized).stem().generic_string().empty())
     normalized = "resource.bin";
-  if (!usedPaths.contains(normalized)) {
+  if (!ContainsArchiveFileNameCaseInsensitive(usedPaths, normalized)) {
     usedPaths.insert(normalized);
     return normalized;
   }
@@ -486,7 +501,8 @@ static std::string EnsureUniqueArchivePath(const std::string &proposed,
   fs::path stemPath = fs::path(normalized);
   std::string ext = stemPath.extension().generic_string();
   std::string stem = stemPath.stem().generic_string();
-  fs::path parent = stemPath.parent_path();
+  if (stem.empty())
+    stem = "resource";
   int index = 1;
   while (true) {
     const std::string suffix = "_" + std::to_string(index + 1);
@@ -497,9 +513,10 @@ static std::string EnsureUniqueArchivePath(const std::string &proposed,
             : 0;
     if (adjustedStem.size() > candidateMaxStemLength)
       adjustedStem = adjustedStem.substr(0, candidateMaxStemLength);
-    std::string candidate =
-        (parent / (adjustedStem + suffix + ext)).generic_string();
-    if (!usedPaths.contains(candidate)) {
+    if (adjustedStem.empty())
+      adjustedStem = "resource";
+    std::string candidate = adjustedStem + suffix + ext;
+    if (!ContainsArchiveFileNameCaseInsensitive(usedPaths, candidate)) {
       usedPaths.insert(candidate);
       return candidate;
     }
@@ -507,6 +524,7 @@ static std::string EnsureUniqueArchivePath(const std::string &proposed,
   }
 }
 
+// Sanitizes arbitrary input into a single portable archive filename.
 static std::string SanitizeArchiveFileName(const std::string &input,
                                            const std::string &fallbackName) {
   constexpr size_t kMaxArchiveFileNameLength = 120;
@@ -542,6 +560,7 @@ static std::string SanitizeArchiveFileName(const std::string &input,
       sanitizeSingleFileName("", fallbackName), kMaxArchiveFileNameLength);
 }
 
+// Sanitizes arbitrary input into a relative archive path for legacy helpers.
 static std::string SanitizeArchiveRelativePath(const std::string &input,
                                                const std::string &fallbackName) {
   std::string candidate = TrimAscii(input);
@@ -567,6 +586,7 @@ static std::string SanitizeArchiveRelativePath(const std::string &input,
   return out.generic_string();
 }
 
+// Builds the preferred root-level GDTF archive filename for a truss.
 static std::string BuildTrussGdtfArchiveName(const Truss &truss) {
   std::string baseName = TrimAscii(truss.model);
   if (baseName.empty()) {
@@ -586,6 +606,7 @@ static std::string BuildTrussGdtfArchiveName(const Truss &truss) {
   return SanitizeArchiveFileName(baseName, "truss.gdtf");
 }
 
+// Builds the internal truss type key used for export-time resource reuse.
 static std::string BuildTrussTypeKey(const Truss &truss) {
   std::ostringstream key;
   key << TrimAscii(truss.gdtfSpec) << '|'
@@ -598,6 +619,27 @@ static std::string BuildTrussTypeKey(const Truss &truss) {
       << truss.heightMm << '|'
       << truss.weightKg;
   return key.str();
+}
+
+// Builds path-free Perastage truss type metadata for exported UserData.
+static std::string BuildExportTrussTypeKey(const Truss &truss,
+                                           const std::string &auxGdtfArchivePath) {
+  std::ostringstream key;
+  key << TrimAscii(truss.manufacturer) << '|'
+      << TrimAscii(truss.model) << '|'
+      << TrimAscii(truss.crossSection) << '|'
+      << truss.lengthMm << '|'
+      << truss.widthMm << '|'
+      << truss.heightMm << '|'
+      << truss.weightKg << '|'
+      << SanitizeArchiveFileName(auxGdtfArchivePath, "");
+  std::string value = key.str();
+  for (char &ch : value) {
+    const unsigned char uch = static_cast<unsigned char>(ch);
+    if (uch < 32 || ch == '/' || ch == '\\')
+      ch = '_';
+  }
+  return TrimAscii(value);
 }
 
 static const char *ToRepresentationText(Truss::GeometryRepresentation representation) {
@@ -615,19 +657,37 @@ static const char *ToRepresentationText(Truss::GeometryRepresentation representa
   }
 }
 
+// Returns true when a value is a root-level MVR FileName reference.
 static bool IsValidMvrFileName(const std::string &value) {
   if (value.empty())
     return false;
-  if (value.front() == '/' || value.find("..") != std::string::npos)
+  if (fs::path(value).stem().generic_string().empty())
     return false;
   for (unsigned char c : value) {
     if (c < 32)
       return false;
   }
-  return value.find(':') == std::string::npos && value.find('\\') == std::string::npos &&
+  return value.find('/') == std::string::npos &&
+         value.find('\\') == std::string::npos &&
+         value.find(':') == std::string::npos &&
          value.find('*') == std::string::npos && value.find('?') == std::string::npos &&
          value.find('"') == std::string::npos && value.find('<') == std::string::npos &&
-         value.find('>') == std::string::npos && value.find('|') == std::string::npos;
+         value.find('>') == std::string::npos && value.find('|') == std::string::npos &&
+         value != "." && value != "..";
+}
+
+// Returns true when exported metadata text looks like a local filesystem path.
+static bool LooksLikeLocalFilesystemPath(const std::string &value) {
+  const std::string trimmed = TrimAscii(value);
+  const std::string lower = ToLowerAscii(trimmed);
+  return trimmed.find('\\') != std::string::npos || trimmed.rfind("/", 0) == 0 ||
+         (trimmed.size() >= 3 && std::isalpha(static_cast<unsigned char>(trimmed[0])) &&
+          trimmed[1] == ':' && (trimmed[2] == '/' || trimmed[2] == '\\')) ||
+         lower.find("/users/") != std::string::npos ||
+         lower.find("/home/") != std::string::npos ||
+         lower.find("appdata") != std::string::npos ||
+         lower.find("/tmp/") != std::string::npos ||
+         lower.find("/temp/") != std::string::npos;
 }
 
 static bool IsCanonicalUuidString(const std::string &value) {
@@ -988,14 +1048,48 @@ static bool ValidateMvr16Export(
             wxLogError("MVR export validation failed: root TrussInfo references invalid exported Truss uuid '%s'", uuid);
             return false;
           }
+          for (const char *nodeName : {"ModelFile", "AuxGdtf", "TypeKey"}) {
+            if (tinyxml2::XMLElement *pathNode = info->FirstChildElement(nodeName)) {
+              const std::string value = TrimAscii(pathNode->GetText() ? pathNode->GetText() : "");
+              if (LooksLikeLocalFilesystemPath(value) || value.find('/') != std::string::npos ||
+                  value.find('\\') != std::string::npos) {
+                wxLogError("MVR export validation failed: Perastage UserData %s contains non-portable path text '%s'",
+                           nodeName, value);
+                return false;
+              }
+            }
+          }
         }
       }
       if (tinyxml2::XMLElement *manifest = data->FirstChildElement("TrussSidecarManifest")) {
+        for (tinyxml2::XMLElement *type = manifest->FirstChildElement("Type"); type;
+             type = type->NextSiblingElement("Type")) {
+          const std::string key = TrimAscii(type->Attribute("key") ? type->Attribute("key") : "");
+          const std::string gdtf = TrimAscii(type->Attribute("gdtf") ? type->Attribute("gdtf") : "");
+          if (LooksLikeLocalFilesystemPath(key) || key.find('/') != std::string::npos ||
+              key.find('\\') != std::string::npos) {
+            wxLogError("MVR export validation failed: Perastage UserData TrussSidecarManifest Type key contains non-portable path text '%s'",
+                       key);
+            return false;
+          }
+          if (!IsValidMvrFileName(gdtf)) {
+            wxLogError("MVR export validation failed: Perastage UserData TrussSidecarManifest Type gdtf '%s' is not a root-level MVR filename",
+                       gdtf);
+            return false;
+          }
+        }
         for (tinyxml2::XMLElement *inst = manifest->FirstChildElement("Instance"); inst;
              inst = inst->NextSiblingElement("Instance")) {
           const std::string uuid = TrimAscii(inst->Attribute("uuid") ? inst->Attribute("uuid") : "");
           if (!IsCanonicalUuidString(uuid) || !exportedTrussUuids.contains(uuid)) {
             wxLogError("MVR export validation failed: Truss sidecar manifest references invalid exported Truss uuid '%s'", uuid);
+            return false;
+          }
+          const std::string typeKey = TrimAscii(inst->Attribute("typeKey") ? inst->Attribute("typeKey") : "");
+          if (LooksLikeLocalFilesystemPath(typeKey) || typeKey.find('/') != std::string::npos ||
+              typeKey.find('\\') != std::string::npos) {
+            wxLogError("MVR export validation failed: Perastage UserData TrussSidecarManifest Instance typeKey contains non-portable path text '%s'",
+                       typeKey);
             return false;
           }
         }
@@ -1029,6 +1123,10 @@ static bool ValidateMvr16Export(
   }
 
   for (const auto &[archivePath, count] : archiveEntryCount) {
+    if (!IsValidMvrFileName(archivePath)) {
+      wxLogError("MVR export validation failed: ZIP entry '%s' is not a root-level MVR filename", archivePath);
+      return false;
+    }
     if (archivePath.empty()) {
       wxLogError("MVR export validation failed: found empty ZIP entry path");
       return false;
@@ -1405,12 +1503,14 @@ static void AppendTrussInfoMetadata(tinyxml2::XMLDocument &doc,
   addNum("Height", truss.heightMm, "mm");
   addNum("Weight", truss.weightKg, "kg");
   addTxt("CrossSection", truss.crossSection);
-  addTxt("ModelFile", truss.modelFile);
+  addTxt("ModelFile", SanitizeArchiveFileName(truss.modelFile, ""));
   addTxt("PositionName", truss.positionName);
   addTxt("HangPos", truss.positionName);
   addTxt("Representation", ToRepresentationText(truss.sourceRepresentation));
-  addTxt("TypeKey", trussTypeKey.empty() ? truss.perastageTypeKey : trussTypeKey);
-  addTxt("AuxGdtf", auxGdtfArchivePath.empty() ? truss.perastageAuxGdtfArchivePath : auxGdtfArchivePath);
+  addTxt("TypeKey", trussTypeKey.empty() ? SanitizeArchiveFileName(truss.perastageTypeKey, "") : trussTypeKey);
+  const std::string exportedAuxGdtf =
+      auxGdtfArchivePath.empty() ? truss.perastageAuxGdtfArchivePath : auxGdtfArchivePath;
+  addTxt("AuxGdtf", SanitizeArchiveFileName(exportedAuxGdtf, ""));
   trussInfoMap->InsertEndChild(info);
 }
 
@@ -1810,6 +1910,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
   std::unordered_map<std::string, std::string> gdtfArchiveByObjectUuid;
   std::unordered_map<std::string, GdtfOverrides> gdtfOverrides;
   std::unordered_map<std::string, std::string> trussArchiveByTypeKey;
+  std::unordered_map<std::string, std::string> trussExportTypeKeyByTypeKey;
   std::unordered_map<std::string, std::string> trussInstanceToTypeKey;
   std::unordered_map<std::string, std::string> primitiveSourceByToken;
   std::unordered_set<std::string> reservedArchivePaths;
@@ -1872,7 +1973,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
           continue;
 
         std::string preferredTextureName =
-            SanitizeArchiveRelativePath(textureRef, texturePath.filename().generic_string());
+            SanitizeArchiveFileName(textureRef, texturePath.filename().generic_string());
         registerResource(texturePath.generic_string(), preferredTextureName);
       }
       return;
@@ -1891,7 +1992,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
         if (!fs::exists(candidate))
           continue;
 
-        std::string preferredTextureName = SanitizeArchiveRelativePath(
+        std::string preferredTextureName = SanitizeArchiveFileName(
             trimmedRef, candidate.filename().generic_string());
         registerResource(candidate.generic_string(), preferredTextureName);
       }
@@ -2500,14 +2601,18 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
           trussSourceGdtf = tempPath.string();
       }
 
-      std::string trussPreferredName = "Perastage/truss_types/" + BuildTrussGdtfArchiveName(t);
+      std::string trussPreferredName = BuildTrussGdtfArchiveName(t);
       trussGdtfArchivePath =
           registerGdtfResource(exportedTrussUuid, trussSourceGdtf, trussPreferredName, true);
       if (!trussGdtfArchivePath.empty())
         trussArchiveByTypeKey[trussTypeKey] = trussGdtfArchivePath;
     }
-    if (!trussTypeKey.empty())
-      trussInstanceToTypeKey[exportedTrussUuid] = trussTypeKey;
+    const std::string exportTrussTypeKey =
+        BuildExportTrussTypeKey(t, trussGdtfArchivePath);
+    if (!trussTypeKey.empty()) {
+      trussExportTypeKeyByTypeKey[trussTypeKey] = exportTrussTypeKey;
+      trussInstanceToTypeKey[exportedTrussUuid] = exportTrussTypeKey;
+    }
 
     if (!trussGdtfArchivePath.empty()) {
       auto &ov = gdtfOverrides[trussGdtfArchivePath];
@@ -2676,7 +2781,7 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
     addInt("CustomIdType", t.customIdType);
 
     AppendTrussInfoMetadata(doc, trussInfoMap, t, exportedTrussUuid,
-                            trussTypeKey, trussGdtfArchivePath);
+                            exportTrussTypeKey, trussGdtfArchivePath);
 
     parent->InsertEndChild(te);
   };
@@ -3176,14 +3281,18 @@ bool MvrExporter::ExportToFile(const std::string &filePath, const MvrExportOptio
     tinyxml2::XMLElement *data = FindOrCreatePerastageDataNode(doc, root);
     tinyxml2::XMLElement *manifest = doc.NewElement("TrussSidecarManifest");
     for (const auto &[typeKey, archivePath] : trussArchiveByTypeKey) {
+      const auto exportTypeKeyIt = trussExportTypeKeyByTypeKey.find(typeKey);
+      const std::string exportTypeKey = exportTypeKeyIt != trussExportTypeKeyByTypeKey.end()
+                                           ? exportTypeKeyIt->second
+                                           : SanitizeArchiveFileName(typeKey, "truss_type");
       tinyxml2::XMLElement *typeNode = doc.NewElement("Type");
-      typeNode->SetAttribute("key", typeKey.c_str());
+      typeNode->SetAttribute("key", exportTypeKey.c_str());
       typeNode->SetAttribute("gdtf", archivePath.c_str());
       manifest->InsertEndChild(typeNode);
       Logger::Instance().Log(
           Logger::Level::Info,
           wxString::Format("MVR export generated truss sidecar GDTF typeKey=%s archive=%s",
-                           typeKey.c_str(), archivePath.c_str())
+                           exportTypeKey.c_str(), archivePath.c_str())
               .ToStdString());
     }
     for (const auto &[uuid, typeKey] : trussInstanceToTypeKey) {

--- a/tests/mvr_exporter_compliance_test.cpp
+++ b/tests/mvr_exporter_compliance_test.cpp
@@ -1,6 +1,7 @@
 /*
  * This file is part of Perastage.
  */
+#include <algorithm>
 #include <cassert>
 #include <filesystem>
 #include <fstream>
@@ -179,9 +180,14 @@ int main() {
   fs::create_directories(tempDir / "B");
   fs::create_directories(tempDir / "models");
   fs::create_directories(tempDir / "C");
+  fs::create_directories(tempDir / "case_a");
+  fs::create_directories(tempDir / "case_b");
 
   std::ofstream(tempDir / "A" / "Same.gdtf") << "A";
   std::ofstream(tempDir / "B" / "Same.gdtf") << "B";
+  std::ofstream(tempDir / "case_a" / "CaseOnly.gdtf") << "CASE A";
+  std::ofstream(tempDir / "case_b" / "caseonly.gdtf") << "CASE B";
+  std::ofstream(tempDir / "@PerastageFixture.gdtf") << "AT";
   std::ofstream(tempDir / "mesh.3ds") << "mesh";
   std::ofstream(tempDir / "models" / "truss_model.3ds") << "truss";
   std::ofstream(tempDir / "models" / "support_model.3ds") << "support";
@@ -245,6 +251,27 @@ int main() {
   fLongDup.gdtfSpec = duplicateLongNamedGdtf.generic_string();
   fLongDup.address = "8.1";
   scene.fixtures[fLongDup.uuid] = fLongDup;
+
+  Fixture fCaseA;
+  fCaseA.uuid = "fx-case-a";
+  fCaseA.instanceName = "Case A";
+  fCaseA.gdtfSpec = (tempDir / "case_a" / "CaseOnly.gdtf").generic_string();
+  fCaseA.address = "19.1";
+  scene.fixtures[fCaseA.uuid] = fCaseA;
+
+  Fixture fCaseB;
+  fCaseB.uuid = "fx-case-b";
+  fCaseB.instanceName = "Case B";
+  fCaseB.gdtfSpec = (tempDir / "case_b" / "caseonly.gdtf").generic_string();
+  fCaseB.address = "20.1";
+  scene.fixtures[fCaseB.uuid] = fCaseB;
+
+  Fixture fAt;
+  fAt.uuid = "fx-at";
+  fAt.instanceName = "At Fixture";
+  fAt.gdtfSpec = (tempDir / "@PerastageFixture.gdtf").generic_string();
+  fAt.address = "21.1";
+  scene.fixtures[fAt.uuid] = fAt;
 
   Fixture fEditedId;
   fEditedId.uuid = "fx-edited-id";
@@ -433,13 +460,31 @@ int main() {
 
   const auto mvrGeometryEntries = ReadArchiveTextEntries(mvrPath);
   std::unordered_set<std::string> entries;
-  for (const auto &[entryName, _] : mvrGeometryEntries)
+  for (const auto &[entryName, _] : mvrGeometryEntries) {
+    assert(entryName.find('/') == std::string::npos);
+    assert(entryName.find('\\') == std::string::npos);
+    assert(entryName.rfind("./", 0) != 0);
     entries.insert(entryName);
+  }
+  int caseOnlyEntryCount = 0;
+  for (const std::string &entryName : entries) {
+    std::string lowerEntry = entryName;
+    std::transform(lowerEntry.begin(), lowerEntry.end(), lowerEntry.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    if (lowerEntry == "caseonly.gdtf" || lowerEntry == "caseonly_2.gdtf")
+      ++caseOnlyEntryCount;
+  }
+  assert(caseOnlyEntryCount == 2);
+  assert(entries.count("@PerastageFixture.gdtf") == 1);
   auto xmlIt = mvrGeometryEntries.find("GeneralSceneDescription.xml");
   assert(xmlIt != mvrGeometryEntries.end());
   std::string xml = xmlIt->second;
 
   assert(!xml.empty());
+  assert(xml.find("Perastage/truss_types") == std::string::npos);
+  assert(xml.find("C:\\") == std::string::npos);
+  assert(xml.find('\\') == std::string::npos);
+  assert(xml.find(tempDir.generic_string()) == std::string::npos);
   tinyxml2::XMLDocument doc;
   assert(doc.Parse(xml.c_str()) == tinyxml2::XML_SUCCESS);
   tinyxml2::XMLElement *root = doc.FirstChildElement("GeneralSceneDescription");


### PR DESCRIPTION
### Motivation
- Ensure MVR 1.6 exports place every referenced resource at the ZIP archive root and never emit archive-relative paths or backslashes, complying with the MVR 1.6 spec. 
- Prevent embedding local filesystem paths in Perastage UserData (truss ModelFile/AuxGdtf/TypeKey) to keep exports portable and safe. 
- Make exported filenames deterministic, stable, and unique case-insensitively while preserving extensions and `@` characters. 
- Add targeted validation and tests to catch regressions and verify the new root-level naming behavior.

### Description
- Introduced `SanitizeArchiveFileName` and tightened `EnsureUniqueArchivePath` so every archive entry name is reduced to a single root-level filename and collisions are resolved with `_2/_3` suffixes in a case-insensitive way. 
- Replaced folder-prefixed truss GDTF registration (`Perastage/truss_types/...`) with root-level `BuildTrussGdtfArchiveName` usage and ensured `registerResource`/`registerGdtfResource` always record root filenames. 
- Replaced legacy relative-path sanitization for model/texture dependencies with root-file sanitization and updated `registerModelResource`/texture registration to produce root-level names. 
- Hardened MVR validation (`ValidateMvr16Export`) to reject any FileName or planned ZIP entry that contains '/', '\\', absolute drive prefixes, parent segments, or other reserved characters and added UserData scans that reject local filesystem-like strings for `ModelFile`, `AuxGdtf`, `TypeKey`, and sidecar manifest keys. 
- Sanitized Perastage truss UserData: `AppendTrussInfoMetadata` now writes path-free `ModelFile`/`AuxGdtf` and uses a new `BuildExportTrussTypeKey` to produce export-facing type keys that do not contain source paths; sidecar manifest keys are exported in sanitized form. 
- Kept resource-pruning, GDTF override patching, Geometry3D semantics, fixture IDs, and scene transforms unchanged except where necessary to satisfy root-level naming and validation rules. 
- Updated `tests/mvr_exporter_compliance_test.cpp` to add focused checks for: root-level ZIP entries (no slashes/backslashes), handling of same-named files differing by case (collision suffix), preservation of `@` filenames, and absence of folder prefixes and absolute/local paths in `GeneralSceneDescription.xml`. 
- Updated `docs/release-notes-draft.md` to document the export compatibility fix.

### Testing
- Ran repository checks `git diff --check` which reported no whitespace/path errors. 
- Ran mandatory project checks `tests/check_perastage_tree_modules.sh` and `tests/check_no_configmanager_get_in_gui.sh`, and both returned OK. 
- Updated `tests/mvr_exporter_compliance_test.cpp` to exercise archive-entry root-level assertions and collision/case tests, but building/running the full test binary was not possible in this container due to missing system `wxWidgets` development libraries during `cmake` configuration. 
- Performed local static validation and linters via the same scripts and observed no high-level failures; the modified exporter now enforces root-level naming and rejects non-portable UserData entries at validation time.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3268516e008324b325bf0410603c49)